### PR TITLE
Add RegisterTNUM functionality (wip)

### DIFF
--- a/src/lists.c
+++ b/src/lists.c
@@ -2537,7 +2537,6 @@ static Int InitKernel (
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         LenListFuncs[ type ] = LenListObject;
     }
-    LenListFuncs[ T_SINGULAR ] = LenListObject;
 
     /* make and install the 'LENGTH' function                            */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
@@ -2549,7 +2548,6 @@ static Int InitKernel (
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
         LengthFuncs[ type ] = LengthInternal;
     }
-    LengthFuncs[ T_SINGULAR ] = LengthObject;
 
 
     /* make and install the 'ISB_LIST' operation                           */
@@ -2561,9 +2559,6 @@ static Int InitKernel (
         IsbListFuncs[  type ] = IsbListObject;
         IsbvListFuncs[ type ] = IsbListObject;
     }
-    IsbListFuncs[ T_SINGULAR ] = IsbListObject;
-    IsbvListFuncs[ T_SINGULAR ] = IsbListObject;
-
 
     /* make and install the 'ELM0_LIST' operation                          */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
@@ -2574,8 +2569,6 @@ static Int InitKernel (
         Elm0ListFuncs[  type ] = Elm0ListObject;
         Elm0vListFuncs[ type ] = Elm0ListObject;
     }
-    Elm0ListFuncs[ T_SINGULAR ] = Elm0ListObject;
-    Elm0vListFuncs[ T_SINGULAR ] = Elm0ListObject;
 
 
     /* make and install the 'ELM_LIST' operation                           */
@@ -2589,9 +2582,6 @@ static Int InitKernel (
         ElmvListFuncs[ type ] = ElmListObject;
         ElmwListFuncs[ type ] = ElmListObject;
     }
-    ElmListFuncs[  T_SINGULAR ] = ElmListObject;
-    ElmvListFuncs[ T_SINGULAR ] = ElmListObject;
-    ElmwListFuncs[ T_SINGULAR ] = ElmListObject;
 
 
     /* make and install the 'ELMS_LIST' operation                          */
@@ -2604,7 +2594,6 @@ static Int InitKernel (
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         ElmsListFuncs[ type ] = ElmsListObject;
     }
-    ElmsListFuncs[ T_SINGULAR ] = ElmsListObject;
 
 
     /* make and install the 'UNB_LIST' operation                           */
@@ -2617,7 +2606,6 @@ static Int InitKernel (
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         UnbListFuncs[ type ] = UnbListObject;
     }
-    UnbListFuncs[ T_SINGULAR ] = UnbListObject;
 
 
     /* make and install the 'ASS_LIST' operation                           */
@@ -2630,7 +2618,6 @@ static Int InitKernel (
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         AssListFuncs[ type ] = AssListObject;
     }
-    AssListFuncs[ T_SINGULAR ] = AssListObject;
 
 
 
@@ -2644,7 +2631,6 @@ static Int InitKernel (
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         AsssListFuncs[ type ] = AsssListObject;
     }
-    AsssListFuncs[ T_SINGULAR ] = AsssListObject;
     
 
     /* make and install the 'IS_DENSE_LIST' filter                         */
@@ -2657,7 +2643,6 @@ static Int InitKernel (
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         IsDenseListFuncs[ type ] = IsDenseListObject;
     }
-    IsDenseListFuncs[ T_SINGULAR ] = IsDenseListObject;
 
 
     /* make and install the 'IS_HOMOG_LIST' filter                         */
@@ -2670,7 +2655,6 @@ static Int InitKernel (
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         IsHomogListFuncs[ type ] = IsHomogListObject;
     }
-    IsHomogListFuncs[ T_SINGULAR ] = IsHomogListObject;
 
 
     /* make and install the 'IS_TABLE_LIST' filter                         */
@@ -2683,7 +2667,6 @@ static Int InitKernel (
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         IsTableListFuncs[ type ] = IsTableListObject;
     }
-    IsTableListFuncs[ T_SINGULAR ] = IsTableListObject;
 
 
     /* make and install the 'IS_SSORT_LIST' property                       */
@@ -2696,7 +2679,6 @@ static Int InitKernel (
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         IsSSortListFuncs[ type ] = IsSSortListObject;
     }
-    IsSSortListFuncs[ T_SINGULAR ] = IsSSortListObject;
 
 
     /* make and install the 'IS_POSS_LIST' property                        */
@@ -2709,7 +2691,6 @@ static Int InitKernel (
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         IsPossListFuncs[ type ] = IsPossListObject;
     }
-    IsPossListFuncs[ T_SINGULAR ] = IsPossListObject;
 
 
     /* make and install the 'POS_LIST' operation                           */
@@ -2722,7 +2703,6 @@ static Int InitKernel (
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         PosListFuncs[ type ] = PosListObject;
     }
-    PosListFuncs[ T_SINGULAR ] = PosListObject;
 
 
     /* install the error functions into the other tables                   */

--- a/src/objects.c
+++ b/src/objects.c
@@ -39,6 +39,33 @@
 #include        "saveload.h"            /* saving and loading              */
 
 
+static Int lastFreePackageTNUM = FIRST_PACKAGE_TNUM;
+
+/****************************************************************************
+**
+*F  RegisterPackageTNUM( <name>, <typeObjFunc> )
+**
+**  Allocates a TNUM for use by a package. The parameters <name> and
+**  <typeObjFunc> are used to initialize the relevant entries in the
+**  InfoBags and TypeObjFuncs arrays.
+**
+**  If allocation fails (e.g. because no more TNUMs are available),
+**  a negative value is returned.
+*/
+Int RegisterPackageTNUM( const char *name, Obj (*typeObjFunc)(Obj obj) )
+{
+    if (lastFreePackageTNUM > LAST_PACKAGE_TNUM)
+        return -1;
+
+    Int tnum = lastFreePackageTNUM++;
+
+    InfoBags[tnum].name = name;
+    TypeObjFuncs[tnum] = typeObjFunc;
+
+    return tnum;
+}
+
+
 /****************************************************************************
 **
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -220,6 +220,20 @@ static inline Obj prod_intobjs(Int l, Int r)
 
 /****************************************************************************
 **
+*F  RegisterPackageTNUM( <name>, <typeObjFunc> )
+**
+**  Allocates a TNUM for use by a package. The parameters <name> and
+**  <typeObjFunc> are used to initialize the relevant entries in the
+**  InfoBags and TypeObjFuncs arrays.
+**
+**  If allocation fails (e.g. because no more TNUMs are available),
+**  a negative value is returned.
+*/
+Int RegisterPackageTNUM( const char *name, Obj (*typeObjFunc)(Obj obj) );
+
+
+/****************************************************************************
+**
 
 *S  T_<name>  . . . . . . . . . . . . . . . . symbolic names for object types
 *S  FIRST_CONSTANT_TNUM, LAST_CONSTANT_TNUM . . . . range of constant   types
@@ -338,7 +352,11 @@ static inline Obj prod_intobjs(Int l, Int r)
 #define T_WPOBJ                 (FIRST_EXTERNAL_TNUM+ 3)
      /* #define T_DUMMYOBJ              (FIRST_EXTERNAL_TNUM+ 4)
         remove to get parity right */
-#define LAST_EXTERNAL_TNUM      T_WPOBJ
+
+#define FIRST_PACKAGE_TNUM      T_WPOBJ
+#define LAST_PACKAGE_TNUM       (FIRST_PACKAGE_TNUM+49)
+
+#define LAST_EXTERNAL_TNUM      LAST_PACKAGE_TNUM
 #define LAST_REAL_TNUM          LAST_EXTERNAL_TNUM
 #define LAST_VIRTUAL_TNUM LAST_EXTERNAL_TNUM
 
@@ -371,7 +389,6 @@ static inline Obj prod_intobjs(Int l, Int r)
 
 /****************************************************************************
 **
-
 *F  TNUM_OBJ( <obj> ) . . . . . . . . . . . . . . . . . . . type of an object
 **
 **  'TNUM_OBJ' returns the type of the object <obj>.

--- a/src/objects.h
+++ b/src/objects.h
@@ -262,7 +262,7 @@ static inline Obj prod_intobjs(Int l, Int r)
 */
 #define FIRST_REAL_TNUM         0
 
-#define FIRST_CONSTANT_TNUM     ((UInt)0)
+#define FIRST_CONSTANT_TNUM     (0UL)
 #define T_INT                   (FIRST_CONSTANT_TNUM+ 0)    /* immediate */
 #define T_INTPOS                (FIRST_CONSTANT_TNUM+ 1)
 #define T_INTNEG                (FIRST_CONSTANT_TNUM+ 2)
@@ -351,6 +351,10 @@ static inline Obj prod_intobjs(Int l, Int r)
 #define TESTING                 COPYING
 #define LAST_TESTING_TNUM       LAST_COPYING_TNUM
 
+#if LAST_COPYING_TNUM > 254
+#error LAST_COPYING_TNUM out of range
+#endif
+
 
 /****************************************************************************
 **
@@ -358,7 +362,11 @@ static inline Obj prod_intobjs(Int l, Int r)
 **
 **  'T_BODY' is the type of the function body bags.
 */
-#define T_BODY                  175
+#define T_BODY                  254
+
+#if T_BODY <= LAST_COPYING_TNUM
+#error T_BODY out of range
+#endif
 
 
 /****************************************************************************


### PR DESCRIPTION
See issue #15 for details (perhaps the details should be added here, too, and that issue be closed? Whatever).

This is WIP and should not quite yet be merged:

* RegisterTNUM should be documented somewhere (perhaps we should first merge the developer manual back into the repository? indeed, perhaps we should have done this when this repository was created, merging the two histories back together?)
* The last commit removes the special treatment of T_SINGULAR. This is not at all necessary for adding RegisterTNUM, but I had it on my local branch, as I did that to test whether RegisterTNUM works well for SingularInterface (it does). That patch should either be dropped; or actually T_SINGULAR be removed. This would break the current version of SingularInterface, but that's nothing I'd worry about: I'd quickly fix it by adding an autoconf test that checks whether T_SINGULAR resp. RegisterTNUM is defined, and switches behavior accordingly (so it would be possible to compile it against old and new GAP versions). Since SingularInterface is pretty much in "alpha" stage anyway, I think this is OK (even though it would mean that one has to recompile SingularInterface when updating GAP...)
