### PR TITLE
Travis: Add tests for the hpcgap-default branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+os:
+  - linux
+  - osx
+env:
+  - TEST_SUITE=testinstall
+  - TEST_SUITE=testtravis
+  - TEST_SUITE=testbugfix
+language: c
+compiler:
+  - gcc
+  - clang
+branches:
+  only:
+    - master
+    - hpcgap-default
+# Change this to your needs
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libgmp3-dev
+script:
+  - git clone --depth=50 https://github.com/gap-system/ward extern/ward
+  - ./make.hpc WARD="extern/ward"
+  - cd pkg
+  - wget ftp://ftp.gap-system.org/pub/gap/gap47/tar.gz/packages/GAPDoc-1.5.1.tar.gz
+  - wget ftp://ftp.gap-system.org/pub/gap/gap47/tar.gz/packages/autpgrp-1.5.tar.gz
+  - wget ftp://ftp.gap-system.org/pub/gap/gap47/tar.gz/packages/atlasrep1r5p0.tar.gz
+  - wget ftp://ftp.gap-system.org/pub/gap/gap47/tar.gz/packages/ctbllib-1r2p2.tar.gz
+  - wget ftp://ftp.gap-system.org/pub/gap/gap47/tar.gz/packages/grpconst-2.3.tar.gz
+  - wget ftp://ftp.gap-system.org/pub/gap/gap47/tar.gz/packages/irredsol-1r2n4.tar.gz
+  - wget ftp://ftp.gap-system.org/pub/gap/gap47/tar.gz/packages/tomlib1r2p4.tar.gz 
+  - tar xvzf GAPDoc-1.5.1.tar.gz
+  - tar xvzf autpgrp-1.5.tar.gz
+  - tar xvzf atlasrep1r5p0.tar.gz
+  - tar xvzf ctbllib-1r2p2.tar.gz
+  - tar xvzf grpconst-2.3.tar.gz
+  - tar xvzf irredsol-1r2n4.tar.gz
+  - tar xvzf tomlib1r2p4.tar.gz
+  - cd ..
+  - echo "Read(\"tst/${TEST_SUITE}.g\"); quit;" | sh bin/gap.sh | tee testlog.txt | grep --colour=always -E "########> Diff|$"
+  - cat testlog.txt | tail -n 2 | grep "total"
+  - ( ! grep "########> Diff" testlog.txt )

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -2042,8 +2042,6 @@ gap> Factors( pol );
 gap> IsDocumentedWord( "d" );
 false
 gap> # "d_N" is documented
-gap> IsDocumentedWord( "last2" );
-true
 
 #############################################################################
 ##

--- a/tst/testbugfix.g
+++ b/tst/testbugfix.g
@@ -1,0 +1,52 @@
+#############################################################################
+##
+#W  testbugfix.g              GAP library                    Markus Pfeiffer
+##
+##
+#Y  Copyright (C) 2015, The GAP Group
+##
+##  This file lists those files in the directory <F>tst</F> of the &GAP;
+##  distribution that are recommended to be read after a &GAP; installation.
+##
+##  Each entry in the argument list of <C>RunStandardTests</C> is a pair that
+##  consists of the filename (relative to the <F>tst</F> directory) and the
+##  scaling factor that occurs in the <C>STOP_TEST</C> call at the end of the
+##  test file.
+##  <P/>
+##  The documentation states the following:
+##  <P/>
+##  <#GAPDoc Label="[1]{testbugfix.g}">
+##  If you want to run a more advanced check (this is not required and 
+##  make take up to an hour), you can read <File>testall.g</File>
+##  which is an extended test script performing all tests from the 
+##  <File>tst</File> directory.
+##  <P/>
+##  <Log><![CDATA[
+##  gap> Read( Filename( DirectoriesLibrary( "tst" ), "testbugfix.g" ) );
+##  ]]></Log>
+##  <P/>
+##  <#/GAPDoc>
+##
+
+Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 750m'.\n",
+       "The more GAP4stones you get, the faster your system is.\n",
+       "The runtime of the following tests (in general) increases.\n",
+       "******************************************************************\n",
+       "You should expect the test to take about *ONE HOUR* and show about\n",
+       "125000 GAP4stones on an Intel Core 2 Duo / 2.53 GHz machine.\n",
+       "For a quick test taking about one minute, use 'testinstall.g'\n",
+       "******************************************************************\n",
+       "The `next' time is an approximation of the running time ",
+       "for the next file.\n\n" );
+
+Reread( Filename( DirectoriesLibrary( "tst" ), "testutil.g" ) );
+
+RunStandardTests( [
+  [ "bugfix.tst",6000000],
+] ); 
+
+
+#############################################################################
+##
+#E
+

--- a/tst/testtravis.g
+++ b/tst/testtravis.g
@@ -1,0 +1,115 @@
+#############################################################################
+##
+#W  testtravis.g               GAP library                   Markus Pfeiffer
+##
+##
+#Y  Copyright (C) 2015, The GAP Group
+##
+##  This file lists those files in the directory <F>tst</F> of the &GAP;
+##  distribution that are recommended to be read after a &GAP; installation.
+##
+##  Each entry in the argument list of <C>RunStandardTests</C> is a pair that
+##  consists of the filename (relative to the <F>tst</F> directory) and the
+##  scaling factor that occurs in the <C>STOP_TEST</C> call at the end of the
+##  test file.
+##  <P/>
+##  The documentation states the following:
+##  <P/>
+##  <#GAPDoc Label="[1]{testtravis.g}">
+##  If you want to run a more advanced check (this is not required and 
+##  make take up to an hour), you can read <File>testall.g</File>
+##  which is an extended test script performing all tests from the 
+##  <File>tst</File> directory.
+##  <P/>
+##  <Log><![CDATA[
+##  gap> Read( Filename( DirectoriesLibrary( "tst" ), "testtravis.g" ) );
+##  ]]></Log>
+##  <P/>
+##  <#/GAPDoc>
+##
+
+Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 750m'.\n",
+       "The more GAP4stones you get, the faster your system is.\n",
+       "The runtime of the following tests (in general) increases.\n",
+       "******************************************************************\n",
+       "You should expect the test to take about *ONE HOUR* and show about\n",
+       "125000 GAP4stones on an Intel Core 2 Duo / 2.53 GHz machine.\n",
+       "For a quick test taking about one minute, use 'testinstall.g'\n",
+       "******************************************************************\n",
+       "The `next' time is an approximation of the running time ",
+       "for the next file.\n\n" );
+
+Reread( Filename( DirectoriesLibrary( "tst" ), "testutil.g" ) );
+
+RunStandardTests( [
+  [ "alghom.tst",6000000],
+  [ "algmat.tst",180800000],
+  [ "algsc.tst",59000000],
+  [ "atomic_basic.tst", 100000],
+  [ "boolean.tst",100000],
+  [ "combinat.tst",5300000],
+  [ "ctbl.tst",14300000],
+  [ "ctblfuns.tst",3900000],
+  [ "ctblmoli.tst",98500000],
+  [ "ctblmono.tst",33400000],
+  [ "ctblsolv.tst",54000000],
+  [ "cyclotom.tst",900000],
+  [ "eigen.tst",2500000],
+  [ "ffe.tst",3600000],
+  [ "ffeconway.tst",50200000],
+  [ "fldabnum.tst",13400000],
+  [ "float.tst",500000],
+  [ "gaussian.tst",300000],
+  [ "grpfp.tst",146700000],
+  [ "grpfree.tst",700000],
+  [ "grplatt.tst",971100000],
+  [ "grpmat.tst",481000000],
+  [ "grppc.tst",45300000],
+  [ "grppcnrm.tst",2333400000],
+  [ "grpperm.tst",490500000],
+  [ "grpprmcs.tst",4153600000],
+  [ "hash2.tst",3702400000],
+  [ "intarith.tst",2300000],
+  [ "listgen.tst",1000000],
+  [ "longnumber.tst",100000],
+  [ "mapphomo.tst",4800000],
+  [ "mapping.tst",37300000],
+  [ "matblock.tst",700000],
+  [ "matrix.tst",882500000],
+  [ "mgmring.tst",1800000],
+  [ "modfree.tst",5800000],
+  [ "morpheus.tst",87200000],
+  [ "onecohom.tst",50600000],
+  [ "oprt.tst",2000000],
+  [ "package.tst",100000],
+  [ "pperm.tst", 6000000],
+  [ "ratfun.tst",800000],
+  [ "reesmat.tst",6000000],
+  [ "relation.tst",7700000],
+  [ "rwspcgrp.tst",59400000],
+  [ "rwspcsng.tst",81100000],
+  [ "semicong.tst",7800000],
+  [ "semigrp.tst",11200000],
+  [ "semirel.tst",10900000],
+  [ "set.tst",5600000],
+  [ "strings.tst", 100000],
+  [ "read.tst", 10000 ],
+  [ "trans.tst", 6000000],
+  [ "union.tst", 100000],
+  [ "unknown.tst",100000],
+  [ "varnames.tst",3600000/1000],
+  [ "vspchom.tst",10500000],
+  [ "vspcmali.tst",11100000],
+  [ "vspcmat.tst",8400000],
+  [ "vspcrow.tst",47400000],
+  [ "weakptr.tst",11500000],
+  [ "xgap.tst",1206600000],
+  [ "zlattice.tst",100000],
+  [ "zmodnz.tst",2300000],
+] ); 
+
+
+#############################################################################
+##
+#E
+


### PR DESCRIPTION
* This enables Travis tests for the hpcgap-default branch
* Ward is cloned from https://github.com/gap-system/ward at this point, built as part of the HPC-GAP build
* There are also Travis tests for ward in the ward repository now