### PR TITLE
List extensions: allow arbitrary objects as list "indices"

### DIFF
--- a/lib/list.gd
+++ b/lib/list.gd
@@ -164,7 +164,7 @@ DeclareAttributeKernel( "Length", IsList, LENGTH );
 ##  <#/GAPDoc>
 ##
 DeclareOperationKernel( "IsBound[]",
-    [ IsList, IS_INT ],
+    [ IsList, IsObject ],
     ISB_LIST );
 
 
@@ -173,7 +173,7 @@ DeclareOperationKernel( "IsBound[]",
 #o  <list>[<pos>] . . . . . . . . . . . . . . . select an element from a list
 ##
 DeclareOperationKernel( "[]",
-    [ IsList, IS_INT ],
+    [ IsList, IsObject ],
     ELM_LIST );
 
 
@@ -234,7 +234,7 @@ DeclareOperationKernel( "Elm0List",
 ##  <#/GAPDoc>
 ##
 DeclareOperationKernel( "Unbind[]",
-    [ IsList and IsMutable, IS_INT ],
+    [ IsList and IsMutable, IsObject ],
     UNB_LIST );
 
 

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -243,7 +243,7 @@ DeclareOperationKernel( "Unbind[]",
 #o  <list>[<pos>] := <obj>
 ##
 DeclareOperationKernel( "[]:=",
-    [ IsList and IsMutable, IS_INT, IsObject ],
+    [ IsList and IsMutable, IsObject, IsObject ],
     ASS_LIST );
 
 

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -116,10 +116,10 @@ typedef UInt    RNam;
  if ( ! IS_INTOBJ(obj) ) ErrorQuitIntSmall(obj);
 
 #define CHECK_INT_SMALL_POS(obj) \
- if ( ! IS_INTOBJ(obj) || INT_INTOBJ(obj) <= 0 ) ErrorQuitIntSmallPos(obj);
+ if ( ! IS_POS_INTOBJ(obj) ) ErrorQuitIntSmallPos(obj);
 
 #define CHECK_INT_POS(obj) \
- if ( TNUM_OBJ(obj) != T_INTPOS && (! IS_INTOBJ(obj) || INT_INTOBJ(obj) <= 0) ) ErrorQuitIntPos(obj);
+ if ( TNUM_OBJ(obj) != T_INTPOS && ( ! IS_POS_INTOBJ(obj)) ) ErrorQuitIntPos(obj);
 
 #define CHECK_BOOL(obj) \
  if ( obj != True && obj != False ) ErrorQuitBool(obj);
@@ -241,13 +241,13 @@ typedef UInt    RNam;
 
 
 #define C_ELM_LIST(elm,list,p) \
- elm = IS_INTOBJ(p) ? ELM_LIST( list, INT_INTOBJ(p) ) : ELMB_LIST(list, p);
+ elm = IS_POS_INTOBJ(p) ? ELM_LIST( list, INT_INTOBJ(p) ) : ELMB_LIST(list, p);
 
 #define C_ELM_LIST_NLE(elm,list,p) \
- elm = IS_INTOBJ(p) ? ELMW_LIST( list, INT_INTOBJ(p) ) : ELMB_LIST(list, p);
+ elm = IS_POS_INTOBJ(p) ? ELMW_LIST( list, INT_INTOBJ(p) ) : ELMB_LIST(list, p);
 
 #define C_ELM_LIST_FPL(elm,list,p) \
- if ( IS_INTOBJ(p) && IS_PLIST(list) ) { \
+ if ( IS_POS_INTOBJ(p) && IS_PLIST(list) ) { \
   if ( INT_INTOBJ(p) <= LEN_PLIST(list) ) { \
    elm = ELM_PLIST( list, INT_INTOBJ(p) ); \
    if ( elm == 0 ) elm = ELM_LIST( list, INT_INTOBJ(p) ); \
@@ -255,16 +255,16 @@ typedef UInt    RNam;
  } else C_ELM_LIST( elm, list, p )
 
 #define C_ELM_LIST_NLE_FPL(elm,list,p) \
- if ( IS_INTOBJ(p) && IS_PLIST(list) ) { \
+ if ( IS_POS_INTOBJ(p) && IS_PLIST(list) ) { \
   elm = ELM_PLIST( list, INT_INTOBJ(p) ); \
  } else C_ELM_LIST_NLE(elm, list, p)
 
 #define C_ASS_LIST(list,p,rhs) \
-  if (IS_INTOBJ(p)) ASS_LIST( list, INT_INTOBJ(p), rhs ); \
+  if (IS_POS_INTOBJ(p)) ASS_LIST( list, INT_INTOBJ(p), rhs ); \
   else ASSB_LIST(list, p, rhs);
 
 #define C_ASS_LIST_FPL(list,p,rhs) \
- if ( IS_INTOBJ(p) && TNUM_OBJ(list) == T_PLIST ) { \
+ if ( IS_POS_INTOBJ(p) && TNUM_OBJ(list) == T_PLIST ) { \
   if ( LEN_PLIST(list) < INT_INTOBJ(p) ) { \
    GROW_PLIST( list, (UInt)INT_INTOBJ(p) ); \
    SET_LEN_PLIST( list, INT_INTOBJ(p) ); \
@@ -277,7 +277,7 @@ typedef UInt    RNam;
  }
 
 #define C_ASS_LIST_FPL_INTOBJ(list,p,rhs) \
- if ( IS_INTOBJ(p) && TNUM_OBJ(list) == T_PLIST) { \
+ if ( IS_POS_INTOBJ(p) && TNUM_OBJ(list) == T_PLIST) { \
   if ( LEN_PLIST(list) < INT_INTOBJ(p) ) { \
    GROW_PLIST( list, (UInt)INT_INTOBJ(p) ); \
    SET_LEN_PLIST( list, INT_INTOBJ(p) ); \
@@ -289,10 +289,10 @@ typedef UInt    RNam;
  }
 
 #define C_ISB_LIST( list, pos) \
-  ((IS_INTOBJ(pos) ? ISB_LIST(list, INT_INTOBJ(pos)) : ISBB_LIST( list, pos)) ? True : False)
+  ((IS_POS_INTOBJ(pos) ? ISB_LIST(list, INT_INTOBJ(pos)) : ISBB_LIST( list, pos)) ? True : False)
 
 #define C_UNB_LIST( list, pos) \
-   if (IS_INTOBJ(pos)) UNB_LIST(list, INT_INTOBJ(pos)); else UNBB_LIST(list, pos);
+   if (IS_POS_INTOBJ(pos)) UNB_LIST(list, INT_INTOBJ(pos)); else UNBB_LIST(list, pos);
 
 extern  void            AddList (
             Obj                 list,

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -3165,7 +3165,6 @@ void            IntrAssList ( void )
 {
     Obj                 list;           /* list                            */
     Obj                 pos;            /* position                        */
-    Int                 p;              /* position, as a C integer        */
     Obj                 rhs;            /* right hand side                 */
 
     /* ignore or code                                                      */
@@ -3177,16 +3176,18 @@ void            IntrAssList ( void )
     /* get the right hand side                                             */
     rhs = PopObj();
 
-    /* get the position                                          */
+    /* get the position                                                    */
     pos = PopObj();
-    /* get the list (checking is done by 'ASS_LIST' or 'ASSB_LIST')         */
+
+    /* get the list (checking is done by 'ASS_LIST' or 'ASSB_LIST')        */
     list = PopObj();
 
-    if (IS_INTOBJ(pos) && (p = INT_INTOBJ(pos)) > 0) {
-        /* assign to the element of the list                                   */
-        ASS_LIST( list, p, rhs );
-    } else
+    /* assign to the element of the list                                   */
+    if (IS_POS_INTOBJ(pos)) {
+        ASS_LIST( list, INT_INTOBJ(pos), rhs );
+    } else {
         ASSB_LIST(list, pos, rhs);
+    }
 
     /* push the right hand side again                                      */
     PushObj( rhs );
@@ -3253,7 +3254,7 @@ void            IntrAssListLevel (
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0) ) {
+    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_POS_INTOBJ(pos)) ) {
         ErrorQuit(
          "List Assignment: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
@@ -3309,7 +3310,6 @@ void            IntrUnbList ( void )
 {
     Obj                 list;           /* list                            */
     Obj                 pos;            /* position                        */
-    Int                 p;              /* position, as a C integer        */
 
     /* ignore or code                                                      */
     if ( IntrReturning > 0 ) { return; }
@@ -3319,22 +3319,16 @@ void            IntrUnbList ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0) ) {
-        ErrorQuit(
-         "List Assignment: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
-    }
 
-    /* get the list (checking is done by 'UNB_LIST')                       */
+    /* get the list (checking is done by 'UNB_LIST' or 'UNBB_LIST')        */
     list = PopObj();
 
-    if (IS_INTOBJ(pos)) {
-        p = INT_INTOBJ(pos);
-
-        /* unbind the element                                                  */
-        UNB_LIST( list, p );
-    } else
+    /* unbind the element                                                  */
+    if (IS_POS_INTOBJ(pos)) {
+        UNB_LIST( list, INT_INTOBJ(pos) );
+    } else {
         UNBB_LIST(list, pos);
+    }
 
     /* push void                                                           */
     PushVoidObj();
@@ -3424,7 +3418,7 @@ void            IntrElmListLevel (
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 )) {
+    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_POS_INTOBJ(pos) )) {
         ErrorQuit(
             "List Element: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
@@ -3477,7 +3471,6 @@ void            IntrIsbList ( void )
     Obj                 isb;            /* isbound, result                 */
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, right operand         */
-    Int                 p;              /* position, as C integer          */
 
     /* ignore or code                                                      */
     if ( IntrReturning > 0 ) { return; }
@@ -3487,22 +3480,16 @@ void            IntrIsbList ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 )) {
-        ErrorQuit(
-            "List Element: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
-    }
 
-    /* get the list (checking is done by 'ISB_LIST')                       */
+    /* get the list (checking is done by 'ISB_LIST' or 'ISBB_LIST')        */
     list = PopObj();
 
-    if (IS_INTOBJ(pos)) {
-        p = INT_INTOBJ( pos );
-
-        /* get the result                                                      */
-        isb = (ISB_LIST( list, p ) ? True : False);
-    } else
-        isb = (ISBB_LIST( list, pos) ? True : False);
+    /* get the result                                                      */
+    if (IS_POS_INTOBJ(pos)) {
+        isb = ISB_LIST( list, INT_INTOBJ(pos) ) ? True : False;
+    } else {
+        isb = ISBB_LIST( list, pos) ? True : False;
+    }
 
     /* push the result                                                     */
     PushObj( isb );
@@ -3738,7 +3725,7 @@ void            IntrAssPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    if ( ! IS_POS_INTOBJ(pos) ) {
         ErrorQuit(
          "PosObj Assignment: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
@@ -3829,12 +3816,11 @@ void            IntrAssPosObjLevel (
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    if ( ! IS_POS_INTOBJ(pos) ) {
         ErrorQuit(
          "PosObj Assignment: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
     }
-
 
     /* assign the right hand sides to the elements of several lists        */
     ErrorQuit(
@@ -3891,7 +3877,7 @@ void            IntrUnbPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    if ( ! IS_POS_INTOBJ(pos) ) {
         ErrorQuit(
          "PosObj Assignment: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
@@ -3938,7 +3924,7 @@ void            IntrElmPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    if ( ! IS_POS_INTOBJ(pos) ) {
         ErrorQuit(
             "PosObj Element: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
@@ -4020,7 +4006,7 @@ void            IntrElmPosObjLevel (
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    if ( ! IS_POS_INTOBJ(pos) ) {
         ErrorQuit(
             "PosObj Element: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
@@ -4087,7 +4073,7 @@ void            IntrIsbPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    if ( ! IS_POS_INTOBJ(pos) ) {
         ErrorQuit(
             "PosObj Element: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -3177,20 +3177,12 @@ void            IntrAssList ( void )
     /* get the right hand side                                             */
     rhs = PopObj();
 
-    /* get and check the position                                          */
+    /* get the position                                          */
     pos = PopObj();
-    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0) ) {
-        ErrorQuit(
-         "List Assignment: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
-    }
-
     /* get the list (checking is done by 'ASS_LIST' or 'ASSB_LIST')         */
     list = PopObj();
 
-    if (IS_INTOBJ(pos)) {
-        p = INT_INTOBJ(pos);
-
+    if (IS_INTOBJ(pos) && (p = INT_INTOBJ(pos)) > 0) {
         /* assign to the element of the list                                   */
         ASS_LIST( list, p, rhs );
     } else

--- a/src/lists.c
+++ b/src/lists.c
@@ -535,23 +535,6 @@ Obj FuncELM0_LIST (
 */
 Obj (*ElmListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
-/****************************************************************************
-**
-*V  ElmbListFuncs[<type>]  . . . . . . . . . . .  table of selection functions
-**
-**  'ELMB_LIST' returns the element at the position  <pos> in the list <list>.
-**  An  error is signalled if  <list> is not a list,  if <pos> is larger than
-**  the length of <list>, or if <list>  has no assigned  object at <pos>.  It
-**  is the responsibility  of the caller to  ensure that <pos>  is a positive
-**  integer.
-**
-**  'ELMB_LIST' only calls the functions  pointed to by 'ElmbListFuncs[<type>]'
-**  passing <list> and <pos>  as arguments.  If  <type> is not  the type of a
-**  list, then 'ElmbListFuncs[<type>]' points to 'ElmbListError', which signals
-**  the error.
-*/
-Obj (*ElmbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos );
-
 
 /****************************************************************************
 **
@@ -617,67 +600,6 @@ Obj ElmListObject (
     return elm;
 }
 
-#if 0
-/****************************************************************************
-**
-*F  ElmbListError( <list>, <pos> ) . . . . . . . . . . . . . . . error message
-*/
-Obj ElmbListError (
-    Obj                 list,
-    Obj                 pos )
-{
-    list = ErrorReturnObj(
-        "List Element: <list> must be a list (not a %s)",
-        (Int)TNAM_OBJ(list), 0L,
-        "you can replace <list> via 'return <list>;'" );
-    return ELMB_LIST( list, pos );
-}
-
-/****************************************************************************
-**
-*F  ElmbListInternal( <list>, <pos> ) . . . . . . . . . . . . . error message
-*/
-Obj ElmbListInternal (
-    Obj                 list,
-    Obj                 pos )
-{
-  do {
-    pos = ErrorReturnObj(
-        "List Element: an internal list cannot have an element in such a position",
-        0L, 0L,
-        "you can supply a new position <pos> via 'return <pos>;'" );
-  } while (!IS_INTOBJ(pos) || INT_INTOBJ(pos) < 0);
-  return ELM_LIST( list, INT_INTOBJ(pos) );
-}
-
-
-/****************************************************************************
-**
-*F  ElmbListObject( <list>, <pos>  . . . . . . . select an element from a list
-**
-**  `ElmbListObject' is the `ELMB_LIST',  function
-**  for objects.   'ElmbListObjects' selects the  element at position <pos> of
-**  list  object <list>.   It is the  responsibility  of the caller to ensure
-**  that <pos> is a positive integer.  The methods have to signal an error if
-**  <pos> is larger than the length of <list> or if the entry is not bound.
-*/
-
-Obj ElmbListObject (
-    Obj                 list,
-    Obj                 pos )
-{
-    Obj                 elm;
-
-    elm = DoOperation2Args( ElmListOper, list, pos );
-    while ( elm == 0 ) {
-        elm = ErrorReturnObj(
-            "List access method must return a value", 0L, 0L,
-            "you can supply a value <val> via 'return <val>;'" );
-    }
-    return elm;
-}
-
-#endif
 
 Obj ELMB_LIST(Obj list, Obj pos)     {
    Obj                 elm;
@@ -1091,8 +1013,11 @@ Obj             FuncASS_LIST (
     Obj                 pos,
     Obj                 obj )
 {
+  if (IS_INTOBJ(pos)) 
     ASS_LIST( list, INT_INTOBJ(pos), obj );
-    return 0;
+  else
+    ASSB_LIST(list, pos, obj);
+  return 0;
 }
 
 void            AssListError (
@@ -1121,6 +1046,7 @@ void            AssListDefault (
 **
 *F  AssListObject( <list>, <pos>, <obj> ) . . . . . . . assign to list object
 */
+
 Obj AssListOper;
 
 void AssListObject (
@@ -1128,74 +1054,17 @@ void AssListObject (
     Int                 pos,
     Obj                 obj )
 {
-    DoOperation3Args( AssListOper, list, INTOBJ_INT(pos), obj );
-}
-/****************************************************************************
-**
-*F  ASSB_LIST(<list>,<pos>,<obj>)  . . . . . . . . assign an element to a list
-*V  AssbListFuncs[<type>]  . . . . . . . . . . . table of assignment functions
-*F  AssbListError(<list>,<pos>,<obj>)  . . . . . . . error assignment function
-**
-**  'ASSB_LIST' only calls the  function pointed to by 'AssbListFuncs[<type>]',
-**  passing <list>, <pos>, and <obj> as arguments.  If <type> is not the type
-**  of  a list, then 'AssbListFuncs[<type>]'  points to 'AssbListError',  which
-**  just signals an error.
-**
-**  'ASSB_LIST' is defined in the declaration part of this package as follows.
-**
-#define ASSB_LIST(list,pos,obj) \
-                        ((*AssbListFuncs[TNUM_OBJ(list)])(list,pos,obj))
-*/
-void            (*AssbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos, Obj obj );
-
-Obj             FuncASSB_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos,
-    Obj                 obj )
-{
-    ASSB_LIST( list, pos, obj );
-    return 0;
+  DoOperation3Args( AssListOper, list, INTOBJ_INT(pos), obj );
 }
 
-void            AssbListError (
-    Obj                 list,
-    Obj                 pos,
-    Obj                 obj )
-{
-    list = ErrorReturnObj(
-        "List Assignment: <list> must be a list (not a %s)",
-        (Int)TNAM_OBJ(list), 0L,
-        "you can replace <list> via 'return <list>;'" );
-    ASSB_LIST( list, pos, obj );
-}
-
-void            AssbListInternal (
-    Obj                 list,
-    Obj                 pos,
-    Obj                 obj )
-{
-  do {
-    pos = ErrorReturnObj( "List assignment: you cannot assign to such a large position in an internal list",
-                          0, 0, 
-                          "you can supply a new position <pos> via 'return <pos>;'" );
-  } while (!IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0);
-  ASS_LIST(list, INT_INTOBJ(pos), obj);
-}
-
-
-/****************************************************************************
-**
-*F  AssbListObject( <list>, <pos>, <obj> ) . . . . . . . assign to list object
-*/
-
-void AssbListObject (
+void ASSB_LIST (
     Obj                 list,
     Obj                 pos,
     Obj                 obj )
 {
     DoOperation3Args( AssListOper, list, pos, obj );
 }
+
 
 
 /****************************************************************************
@@ -2781,20 +2650,6 @@ static Int InitKernel (
     ElmvListFuncs[ T_SINGULAR ] = ElmListObject;
     ElmwListFuncs[ T_SINGULAR ] = ElmListObject;
 
-    /* make and install the 'ELMB_LIST' operation                           
-    for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        ElmbListFuncs[  type ] = ElmbListError;
-    }
-
-    for (type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
-      ElmbListFuncs[ type ] = ElmbListInternal;
-    }
-    
-    for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
-        ElmbListFuncs[  type ] = ElmbListObject;
-    }
-
-    */
 
     /* make and install the 'ELMS_LIST' operation                          */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
@@ -2848,19 +2703,6 @@ static Int InitKernel (
     AssListFuncs[ T_SINGULAR ] = AssListObject;
 
 
-    /* make and install the 'ASSB_LIST' operation                           */
-    for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        AssbListFuncs[  type ] = AssbListError;
-    }
-
-    for (type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
-      AssbListFuncs[ type ] = AssbListInternal;
-    }
-    
-    for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
-        AssbListFuncs[  type ] = AssbListObject;
-    }
-    AssbListFuncs[ T_SINGULAR ] = AssbListObject;
 
     /* make and install the 'ASSS_LIST' operation                          */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {

--- a/src/lists.c
+++ b/src/lists.c
@@ -48,6 +48,7 @@
 #include        "integer.h"             /* integers                        */
 
 
+
 /****************************************************************************
 **
 *F  IS_LIST(<obj>)  . . . . . . . . . . . . . . . . . . . is an object a list
@@ -332,12 +333,15 @@ Int             (*IsbvListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
 Obj             IsbListOper;
 
-Obj             IsbListHandler (
+Obj             FuncISB_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 pos )
 {
-    return (ISB_LIST( list, INT_INTOBJ(pos) ) ? True : False);
+    if (IS_POS_INTOBJ(pos))
+        return ISB_LIST( list, INT_INTOBJ(pos) ) ? True : False;
+    else
+        return ISBB_LIST( list, pos ) ? True : False;
 }
 
 Int             IsbListError (
@@ -355,64 +359,14 @@ Int             IsbListObject (
     Obj                 list,
     Int                 pos )
 {
-    return (DoOperation2Args( IsbListOper, list, INTOBJ_INT(pos) ) == True);
+    return DoOperation2Args( IsbListOper, list, INTOBJ_INT(pos) ) == True;
 }
 
-/****************************************************************************
-**
-*F  ISBB_LIST(<list>,<pos>,<obj>)  . . . . . isbound for an element to a list
-*V  IsbbListFuncs[<type>]  . . . . . . . . .  . table of isbound functions
-*F  IsbbListError(<list>,<pos>,<obj>)  . . . . . . . error isbound function
-**
-**  'ISBB_LIST' only calls the  function pointed to by 'IsbbListFuncs[<type>]',
-**  passing <list>, <pos>, and <obj> as arguments.  If <type> is not the type
-**  of  a list, then 'IsbbListFuncs[<type>]'  points to 'IsbbListError',  which
-**  just signals an error.
-**
-**  'ISBB_LIST' is defined in the declaration part of this package as follows.
-**
-#define ISBB_LIST(list,pos,obj) \
-                        ((*IsbbListFuncs[TNUM_OBJ(list)])(list,pos,obj))
-*/
-Int            (*IsbbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos);
-
-Obj             FuncISBB_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos)
-{
-    return ISBB_LIST( list, pos ) ? True: False;
-}
-
-Int            IsbbListError (
+Int             ISBB_LIST (
     Obj                 list,
     Obj                 pos )
 {
-    list = ErrorReturnObj(
-        "Isbound: <list> must be a list (not a %s)",
-        (Int)TNAM_OBJ(list), 0L,
-        "you can replace <list> via 'return <list>;'" );
-    return ISBB_LIST( list, pos );
-}
-
-Int            IsbbListInternal (
-    Obj                 list,
-    Obj                 pos)
-{
-  return 0;
-}
-
-
-/****************************************************************************
-**
-*F  IsbbListObject( <list>, <pos>, <obj> ) . . . . . . . assign to list object
-*/
-
-Int IsbbListObject (
-    Obj                 list,
-    Obj                 pos )
-{
-    return DoOperation2Args( IsbListOper, list, pos ) == True ? 1 : 0;
+    return DoOperation2Args( IsbListOper, list, pos ) == True;
 }
 
 
@@ -900,7 +854,10 @@ Obj             FuncUNB_LIST (
     Obj                 list,
     Obj                 pos )
 {
-    UNB_LIST( list, INT_INTOBJ(pos) );
+    if (IS_POS_INTOBJ(pos))
+        UNB_LIST( list, INT_INTOBJ(pos) );
+    else
+        UNBB_LIST( list, pos );
     return 0;
 }
 
@@ -930,59 +887,7 @@ void            UnbListObject (
     DoOperation2Args( UnbListOper, list, INTOBJ_INT(pos) );
 }
 
-/****************************************************************************
-**
-*F  UNBB_LIST(<list>,<pos>,<obj>)  . . . . . . . . unbind an element to a list
-*V  UnbbListFuncs[<type>]  . . . . . . . . . . .  table of unbinding functions
-*F  UnbbListError(<list>,<pos>,<obj>)  . . . . . . . .error unbinding function
-**
-**  'UNBB_LIST' only calls the  function pointed to by 'UnbbListFuncs[<type>]',
-**  passing <list>, <pos>, and <obj> as arguments.  If <type> is not the type
-**  of  a list, then 'UnbbListFuncs[<type>]'  points to 'UnbbListError',  which
-**  just signals an error.
-**
-**  'UNBB_LIST' is defined in the declaration part of this package as follows.
-**
-#define UNBB_LIST(list,pos,obj) \
-                        ((*UnbbListFuncs[TNUM_OBJ(list)])(list,pos,obj))
-*/
-void            (*UnbbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos );
-
-Obj             FuncUNBB_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos )
-{
-    UNBB_LIST( list, pos );
-    return 0;
-}
-
-void            UnbbListError (
-    Obj                 list,
-    Obj                 pos )
-{
-    list = ErrorReturnObj(
-        "List Unbindment: <list> must be a list (not a %s)",
-        (Int)TNAM_OBJ(list), 0L,
-        "you can replace <list> via 'return <list>;'" );
-    UNBB_LIST( list, pos );
-}
-
-void            UnbbListInternal (
-    Obj                 list,
-    Obj                 pos)
-{
-  /* large positions are already unbound */
-  return;
-}
-
-
-/****************************************************************************
-**
-*F  UnbbListObject( <list>, <pos>, <obj> ) . . . . . . . unbind  list object
-*/
-
-void UnbbListObject (
+void            UNBB_LIST (
     Obj                 list,
     Obj                 pos )
 {
@@ -1007,17 +912,19 @@ void UnbbListObject (
 */
 void            (*AssListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos, Obj obj );
 
+Obj AssListOper;
+
 Obj             FuncASS_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 pos,
     Obj                 obj )
 {
-  if (IS_INTOBJ(pos)) 
-    ASS_LIST( list, INT_INTOBJ(pos), obj );
-  else
-    ASSB_LIST(list, pos, obj);
-  return 0;
+    if (IS_INTOBJ(pos)) 
+        ASS_LIST( list, INT_INTOBJ(pos), obj );
+    else
+        ASSB_LIST(list, pos, obj);
+    return 0;
 }
 
 void            AssListError (
@@ -1047,14 +954,12 @@ void            AssListDefault (
 *F  AssListObject( <list>, <pos>, <obj> ) . . . . . . . assign to list object
 */
 
-Obj AssListOper;
-
 void AssListObject (
     Obj                 list,
     Int                 pos,
     Obj                 obj )
 {
-  DoOperation3Args( AssListOper, list, INTOBJ_INT(pos), obj );
+    DoOperation3Args( AssListOper, list, INTOBJ_INT(pos), obj );
 }
 
 void ASSB_LIST (
@@ -2461,7 +2366,7 @@ static StructGVarOper GVarOpers [] = {
       DoOperation0Args, "src/lists.c:POS_LIST" },
 
     { "ISB_LIST", 2, "list, pos", &IsbListOper,
-      IsbListHandler, "src/lists.c:ISB_LIST" },
+      FuncISB_LIST, "src/lists.c:ISB_LIST" },
 
     { "ELM0_LIST", 2, "list, pos", &Elm0ListOper,
       FuncELM0_LIST, "src/lists.c:ELM0_LIST" },
@@ -2608,19 +2513,6 @@ static Int InitKernel (
     IsbListFuncs[ T_SINGULAR ] = IsbListObject;
     IsbvListFuncs[ T_SINGULAR ] = IsbListObject;
 
-    /* make and install the 'ISBB_LIST' operation                           */
-    for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        IsbbListFuncs[  type ] = IsbbListError;
-    }
-
-    for (type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
-      IsbbListFuncs[ type ] = IsbbListInternal;
-    }
-    
-    for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
-        IsbbListFuncs[  type ] = IsbbListObject;
-    }
-    IsbbListFuncs[ T_SINGULAR ] = IsbbListObject;
 
     /* make and install the 'ELM0_LIST' operation                          */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
@@ -2676,19 +2568,6 @@ static Int InitKernel (
     }
     UnbListFuncs[ T_SINGULAR ] = UnbListObject;
 
-    /* make and install the 'UNBB_LIST' operation                           */
-    for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        UnbbListFuncs[  type ] = UnbbListError;
-    }
-
-    for (type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
-      UnbbListFuncs[ type ] = UnbbListInternal;
-    }
-    
-    for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
-        UnbbListFuncs[  type ] = UnbbListObject;
-    }
-    UnbbListFuncs[ T_SINGULAR ] = UnbbListObject;
 
     /* make and install the 'ASS_LIST' operation                           */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {

--- a/src/lists.h
+++ b/src/lists.h
@@ -232,24 +232,12 @@ extern Obj (*ElmListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 **  call them with arguments that have side effects.
 **
 **  The difference between ELM_LIST and ELMB_LIST is that ELMB_LIST accepts
-**  an object as the second argument (which should be a positive large integer.
+**  an object as the second argument
 **  It is intended as an interface for access to elements of large external
 **  lists, on the rare occasions when the kernel needs to do this.
 */
 #define ELM_LIST(list,pos)      ((*ElmListFuncs[TNUM_OBJ(list)])(list,pos))
 
-/****************************************************************************
-**
-*V  ElmbListFuncs[ <type> ]  . . . . . . . . . .  table of selection functions
-**
-**  A package implementing a  list  type <type> may  provide a  function for
-**  'ELMB_LIST' and install it  in 'ElmbListFuncs[<type>]'.  This function must
-**  signal an error if <pos> is larger than the length of <list> or if <list>
-**  has no assigned object at <pos>.
-
-extern Obj (*ElmbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos );
-
-*/
 
 /****************************************************************************
 **
@@ -265,7 +253,7 @@ extern Obj (*ElmbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos );
 **  call them with arguments that have side effects.
 **
 **  The difference between ELM_LIST and ELMB_LIST is that ELMB_LIST accepts
-**  an object as the second argument (which should be a positive large integer.
+**  an object as the second argument
 **  It is intended as an interface for access to elements of large external
 **  lists, on the rare occasions when the kernel needs to do this.
 */
@@ -465,10 +453,8 @@ extern  void            (*AssListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos, O
 **  <list> if <pos> is larger than the length of  <list> and must also change
 **  the representation of <list> to that of a plain list if necessary.
 */
-#define ASSB_LIST(list,pos,obj) \
-                        ((*AssbListFuncs[TNUM_OBJ(list)])(list,pos,obj))
 
-extern  void            (*AssbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos, Obj obj );
+extern void ASSB_LIST(Obj list, Obj pos, Obj obj);
 
 
 /****************************************************************************

--- a/src/lists.h
+++ b/src/lists.h
@@ -140,11 +140,7 @@ extern  Int             (*IsbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
 extern  Int             (*IsbvListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
-#define ISBB_LIST(list,pos) \
-                        ((*IsbbListFuncs[TNUM_OBJ(list)])(list,pos))
-
-extern  Int             (*IsbbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos );
-
+extern Int ISBB_LIST( Obj list, Obj pos );
 
 
 /****************************************************************************
@@ -221,6 +217,7 @@ extern Obj (*ElmListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 /****************************************************************************
 **
 *F  ELM_LIST( <list>, <pos> ) . . . . . . . . . select an element from a list
+*F  ELMB_LIST( <list>, <pos> ) . . . . . . . . . select an element from a list
 **
 **  'ELM_LIST' returns the element at the position  <pos> in the list <list>.
 **  An  error is signalled if  <list> is not a list,  if <pos> is larger than
@@ -238,29 +235,7 @@ extern Obj (*ElmListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 */
 #define ELM_LIST(list,pos)      ((*ElmListFuncs[TNUM_OBJ(list)])(list,pos))
 
-
-/****************************************************************************
-**
-*F  ELMB_LIST( <list>, <pos> ) . . . . . . . . . select an element from a list
-**
-**  'ELM_LIST' returns the element at the position  <pos> in the list <list>.
-**  An  error is signalled if  <list> is not a list,  if <pos> is larger than
-**  the length of <list>, or if <list>  has no assigned  object at <pos>.  It
-**  is the responsibility  of the caller to  ensure that <pos>  is a positive
-**  integer.
-**
-**  Note that 'ELM_LIST', 'ELMV_LIST', and  'ELMW_LIST' are macros, so do not
-**  call them with arguments that have side effects.
-**
-**  The difference between ELM_LIST and ELMB_LIST is that ELMB_LIST accepts
-**  an object as the second argument
-**  It is intended as an interface for access to elements of large external
-**  lists, on the rare occasions when the kernel needs to do this.
-*/
-extern Obj ELMB_LIST( Obj list, Obj pos);
-
-
-
+extern Obj ELMB_LIST( Obj list, Obj pos );
 
 
 /****************************************************************************
@@ -403,12 +378,10 @@ extern void ElmsListLevelCheck (
 
 extern void             (*UnbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
-#define UNBB_LIST(list,pos) \
-                        ((*UnbbListFuncs[TNUM_OBJ(list)])(list,pos))
+extern void UNBB_LIST( Obj list, Obj pos );
 
-extern void             (*UnbbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos );
+extern void UnbListDefault( Obj list, Int  pos );
 
-extern void  UnbListDefault ( Obj list, Int  pos );
 
 /****************************************************************************
 **
@@ -434,27 +407,7 @@ extern void  UnbListDefault ( Obj list, Int  pos );
 
 extern  void            (*AssListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos, Obj obj );
 
-/****************************************************************************
-**
-*F  ASSB_LIST(<list>,<pos>,<obj>)  . . . . . . . . assign an element to a list
-*V  AssbListFuncs[<type>]  . . . . . . . . . . . table of assignment functions
-**
-**  'ASSB_LIST' assigns the object <obj> to the list <list> at position <pos>.
-**  Note that  the assignment may change  the length or the representation of
-**  <list>.  An error   is signalled if  <list>  is not a  list.    It is the
-**  responsibility of the caller to ensure that <pos>  is a positive integer,
-**  and that <obj> is not 0.
-**
-**  Note that 'ASSB_LIST' is a macro,  so do not  call it with arguments  that
-**  have side effects.
-**
-**  A package  implementing a list type  <type> must provide  such a function
-**  and   install it in  'AssbListFuncs[<type>]'.   This  function must extend
-**  <list> if <pos> is larger than the length of  <list> and must also change
-**  the representation of <list> to that of a plain list if necessary.
-*/
-
-extern void ASSB_LIST(Obj list, Obj pos, Obj obj);
+extern void ASSB_LIST( Obj list, Obj pos, Obj obj );
 
 
 /****************************************************************************

--- a/src/vars.c
+++ b/src/vars.c
@@ -1138,21 +1138,15 @@ UInt            ExecAssList (
     SET_BRK_CURR_STAT( stat );
     list = EVAL_EXPR( ADDR_STAT(stat)[0] );
 
-    /* evaluate and check the position                                     */
+    /* evaluate  the position                                     */
     pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
-    while ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 )) {
-        pos = ErrorReturnObj(
-         "List Assignment: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L,
-            "you can replace <position> via 'return <position>;'" );
-    }
 
     /* evaluate the right hand side                                        */
     rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
 
-    if (IS_INTOBJ(pos))
+    if (IS_INTOBJ(pos) && (p = INT_INTOBJ(pos)) > 0)
         {
-          p = INT_INTOBJ(pos);
+
           
           /* special case for plain list                                         */
           if ( TNUM_OBJ(list) == T_PLIST ) {


### PR DESCRIPTION
The changes in this pull request make it possible to implement methods for [], []:=, etc. which take arbitrary objects as "index", not just positive integers. At the same time, it unifies some code and fixes a few places which should have only accepted positive integers, but actually accepted arbitrary integers.

The original motivation for this patch was to make it possible to implement matrix methods which take a pair of integers, like so:
```gap
   a[[i,j]] := 2;
```
to se the entry in row i, column j of the matrix a to 2. 
Internally, this would invokes the []:= method with the parameters  "a" and "[i,j]", and the method can then set the matrix entry. E.g. for IsMatrixObj objects, it could invoke SetMatElm.

There are other applications, however, e.g. for nicer interfaces to dictionaries: 
```gap
  dict["key"]  := value;
  if IsBound(dict["key"]) then
    ...
```

The biggest missing thing in this PR is a documentation update, and some review by somebody other than Steve and me. If the changes look sane, we could merge them now, and coument the changes later.


BTW, for the matrix application, it would be even nicer if we had a language extensions that would allow directly writing
```gap
   a[i,j] := 2;
```
i.e. without the double brackets. But this is apparently harder to achieve (?), and could still be done later, and I think the changes presented here are useful for other applications (such as dictionaries / maps).