### PR TITLE
Fix printing to background threads.

### DIFF
--- a/lib/consoleui.g
+++ b/lib/consoleui.g
@@ -132,7 +132,7 @@ BindGlobal("FindThread@", function(id)
 end);
 
 BindGlobal("SendControl@", function(type, data)
-  SendChannel(ControlChannel@, `[ type, ThreadID@(), data ] );
+  SendChannel(ControlChannel@, MakeReadOnly([ type, ThreadID@(), data ]) );
 end);
 
 BindGlobal("RegisterThread@", function()


### PR DESCRIPTION
Making control messages read-only rather than immutable corrects a
subtle error in commit #2757f992df2ad7b2fc2821c79abbaf611a5248eb.

This fixes `RunTask(Print, "123\n");`.