### PR TITLE
Missing extern in header file.

### DIFF
--- a/src/bool.h
+++ b/src/bool.h
@@ -59,7 +59,7 @@ extern Obj SFail;
 **  where the kernel cannot handle a null reference easily. This object is
 **  never exposed to GAP code and only used within the kernel.
 */
-Obj Undefined;
+extern Obj Undefined;
 
 
 /****************************************************************************


### PR DESCRIPTION
The "Obj Undefined" declaration in bool.h missed an "extern" keyword.