### PR TITLE
Library: Remove RecNames for IsAtomicRecord

### DIFF
--- a/lib/thread.g
+++ b/lib/thread.g
@@ -81,12 +81,6 @@ BindGlobal("NewInterruptID", function()
   od;
 end);
 
-DeclareAttribute( "RecNames", IsAtomicRecord);
-InstallMethod( RecNames,
-    "for an atomic record in internal representation",
-    [ IsAtomicRecord and IsInternalRep],
-    REC_NAMES );
-
 if IsBound(ZmqSocket) then
   ReadLib("zmq.g");
 fi;


### PR DESCRIPTION
* This lead to a warning after the change in #43 that made
  IsAtomicRecord a subcategory of IsRecord
* The implementation is the same so this should not break anything