### PR TITLE
Fixed rec.!(expr).

### DIFF
--- a/src/vars.c
+++ b/src/vars.c
@@ -2563,8 +2563,9 @@ Obj             EvalElmComObjExpr (
         return ElmPRec( record, rnam );
       case T_ACOMOBJ:
         return ElmARecord( record, rnam );
+      default:
+        return ELM_REC( record, rnam);
     }
-    return 0;
 }
 
 


### PR DESCRIPTION
rec!.(expr) returned the null object if rec was not a component object
or atomic component object, but a plain record.