### PR TITLE
Library: Make GENERAL_MAPPING_REGION internal

### DIFF
--- a/lib/mapping.gd
+++ b/lib/mapping.gd
@@ -204,8 +204,11 @@
 ##
 
 ## Shared region for storing results of FamiliesOfGeneralMappingsAndRanges
+## This has to have higher precedence than TRANSREGION, because
+## while doing TransitiveIdentification we hold a lock on TRANSREGION
+## and want a lock for GENERAL_MAPPING_REGION
 BindGlobal("GENERAL_MAPPING_REGION",
-        NewLibraryRegion("FamiliesOfGeneralMappingsAndRanges region"));
+        NewInternalRegion("FamiliesOfGeneralMappingsAndRanges region"));
 
 #############################################################################
 ##


### PR DESCRIPTION
There is a locking conflict between TRANSREGION and GENERAL_MAPPING_REGION
which we resolve by giving GENERAL_MAPPING_REGION higher precedence.