### PR TITLE
Library: Fix pperm.c issue with zero length lists

### DIFF
--- a/src/pperm.c
+++ b/src/pperm.c
@@ -5403,6 +5403,10 @@ Obj OnSetsPPerm (Obj set, Obj f){
   }
   //maybe a problem here if the result <res> has length 0, this certainly
   //caused a problem in OnPosIntSetsPPerm...
+  if (len == 0) { 
+    RetypeBag(res, IS_MUTABLE_PLIST(set)?T_PLIST_EMPTY:T_PLIST_EMPTY+IMMUTABLE);
+    return res;
+  }
   ResizeBag(res, (len+1)*sizeof(Obj));
   SET_LEN_PLIST(res, len);
 


### PR DESCRIPTION
This was suggested by @james-d-mitchell in [issue #10 for orb](https://github.com/gap-system/orb/issues/10) 