### PR TITLE
Sl/last thread local

### DIFF
--- a/lib/thread1.g
+++ b/lib/thread1.g
@@ -273,5 +273,10 @@ BIND_GLOBAL("THREAD_INIT", function()
 end);
 
 MakeThreadLocal("~");
+MakeThreadLocal("last");
+MakeThreadLocal("last2");
+MakeThreadLocal("last3");
+MakeThreadLocal("time");
+
 
 HaveMultiThreadedUI := false;

--- a/src/gap.c
+++ b/src/gap.c
@@ -322,9 +322,9 @@ Obj Shell ( Obj context,
 
       /* remember the value in 'last'    */
       if (lastDepth >= 3)
-        AssGVar( Last3, ValGVar( Last2 ) );
+        AssGVar( Last3, ValGVarTL( Last2 ) );
       if (lastDepth >= 2)
-        AssGVar( Last2, ValGVar( Last  ) );
+        AssGVar( Last2, ValGVarTL( Last  ) );
       if (lastDepth >= 1)
         AssGVar( Last,  TLS->readEvalResult   );
 

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -404,6 +404,20 @@ Obj             ValGVarTL (
     return val;
 }
 
+Obj FuncIsThreadLocalGvar( Obj self, Obj name) {
+  UInt gvar, gvar_bucket, gvar_index;
+  if (!IsStringConv(name))
+    ErrorMayQuit("IsThreadLocalGVar: argument must be a string (not a %s)",
+		 (Int)TNAM_OBJ(name), 0L);
+
+  gvar = GVarName(CSTR_STRING(name));
+  gvar_bucket = GVAR_BUCKET(gvar);
+  gvar_index = GVAR_INDEX(gvar);
+  return (VAL_GVAR(gvar) == 0 && IS_INTOBJ(ELM_PLIST(ExprGVars[gvar_bucket], gvar_index))) ?
+    True: False;
+}
+  
+
 
 /****************************************************************************
 **
@@ -1378,6 +1392,9 @@ static StructGVarFunc GVarFuncs [] = {
 
     { "GET_NAMESPACE", 0L, "",
       FuncGET_NAMESPACE, "src/gvars.c:GET_NAMESPACE" },
+
+    { "IsThreadLocalGVar", 1L, "name",
+      FuncIsThreadLocalGvar, "src/gvars.c:IsThreadLocalGvar"},
 
     { 0 }
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -277,8 +277,8 @@ static void READ_TEST_OR_LOOP(void)
         if ( type == 0 && TLS->readEvalResult != 0 ) {
 
             /* remember the value in 'last' and the time in 'time'         */
-            AssGVar( Last3, ValGVar( Last2 ) );
-            AssGVar( Last2, ValGVar( Last  ) );
+            AssGVar( Last3, ValGVarTL( Last2 ) );
+            AssGVar( Last2, ValGVarTL( Last  ) );
             AssGVar( Last,  TLS->readEvalResult   );
 
             /* print the result                                            */


### PR DESCRIPTION
This patch makes last, last2 and last3 and time thread-local and adds IsThreadLocalGVar so
that thread-local variables like these can be skipped when checking for thread-local objects in global variables.