### PR TITLE
Library: Use atomic readwrite for access to mapping region

### DIFF
--- a/lib/pcgsperm.gi
+++ b/lib/pcgsperm.gi
@@ -1089,7 +1089,10 @@ local r,i,p,A,f,a;
   # is the group in the mappings families cache?
   f:=FamiliesOfGeneralMappingsAndRanges(FamilyObj(OneOfPcgs(pcgs)));
   i:=1;
-  atomic readonly GENERAL_MAPPING_REGION do
+  # This needs to be atomic readwrite because the method
+  # for Length prunes entries off the end of weak pointer
+  # list.
+  atomic readwrite GENERAL_MAPPING_REGION do
     while i<=Length(f) do
       a:=ElmWPObj(f,i);
       if a<>fail and IsBound(a!.DefiningPcgs) 


### PR DESCRIPTION
* Calling Length on a weak pointer object can change the length of the
  weak pointer object, because it garbage collects unused entries
  at the end of the list.
* Hence even though we only read, we acquire a readwrite lock
* Thanks to Chris Jefferson <caj21@st-andrews.ac.uk> for spotting this.