### PR TITLE
Fixed bug and added comments in FuncFLAT_KERNEL_TRANS_INT

### DIFF
--- a/src/trans.c
+++ b/src/trans.c
@@ -699,8 +699,10 @@ Obj FuncFLAT_KERNEL_TRANS_INT (Obj self, Obj f, Obj n){
         for(i=0;i<m;i++)      *ptnew++=*ptker++;
       } else { //m>deg
         for(i=0;i<deg;i++)    *ptnew++=*ptker++;
-        //add new points
-        for(i=RANK_TRANS2(f)+1;i<=m;i++) *ptnew++=INTOBJ_INT(i);
+        //we must now add another (m-deg) points,
+        //starting with the class number (rank+1)
+        for(i=RANK_TRANS2(f)+1; i<=m-deg+RANK_TRANS2(f); i++)
+          *ptnew++=INTOBJ_INT(i);
       }
       return new;
     }
@@ -725,8 +727,10 @@ Obj FuncFLAT_KERNEL_TRANS_INT (Obj self, Obj f, Obj n){
         for(i=0;i<m;i++)      *ptnew++=*ptker++;
       } else { //m>deg
         for(i=0;i<deg;i++)    *ptnew++=*ptker++;
-        //add new points
-        for(i=RANK_TRANS4(f)+1;i<=m;i++) *ptnew++=INTOBJ_INT(i);
+        //we must now add another (m-deg) points,
+        //starting with the class number (rank+1)
+        for(i=RANK_TRANS4(f)+1; i<=m-deg+RANK_TRANS4(f); i++)
+          *ptnew++=INTOBJ_INT(i);
       }
       return new;
     }


### PR DESCRIPTION
In `FuncFLAT_KERNEL_TRANS_INT`, the wrong number of additional points were being added in the case that `m > deg`.  Incrementing `i` until it reached `m` didn't make any sense.  In fact we want to add another `m - deg` points, so we need to increment `i` until it reaches `m - deg + RANK`.