### PR TITLE
Add support for using gettimeofday for profiling time

### DIFF
--- a/cnf/config.hin
+++ b/cnf/config.hin
@@ -86,6 +86,9 @@
 /* Define to 1 if you have the `getrusage' function. */
 #undef HAVE_GETRUSAGE
 
+/* Define to 1 if you have the `gettimeofday' function. */
+#undef HAVE_GETTIMEOFDAY
+
 /* Define to 1 if you have the `grantpt' function. */
 #undef HAVE_GRANTPT
 

--- a/cnf/configure.in
+++ b/cnf/configure.in
@@ -144,7 +144,7 @@ dnl ## check for timing functions
 dnl ##
 
 AC_CHECK_HEADERS( sys/times.h sys/param.h )
-AC_CHECK_FUNCS( times getrusage )
+AC_CHECK_FUNCS( times getrusage gettimeofday )
 
 
 dnl #########################################################################

--- a/cnf/configure.out
+++ b/cnf/configure.out
@@ -5071,7 +5071,7 @@ fi
 
 done
 
-for ac_func in times getrusage
+for ac_func in times getrusage gettimeofday
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"


### PR DESCRIPTION
As in description, this lets the profiling use either getrusage or gettimeofday (faster) to get the times taken in profiling GAP.