### PR TITLE
Make data stored in CanonicalBasis of abelian number field immutable

### DIFF
--- a/lib/fldabnum.gi
+++ b/lib/fldabnum.gi
@@ -1271,8 +1271,8 @@ InstallMethod( CanonicalBasis,
       # Fill in additional components.
       SetBasisVectors( B, List( lenst,
                                 x -> Sum( List( x, y -> E(N)^y ) ) ) );
-      B!.coeffslist  := List( lenst, x -> x[1] + 1 );
-      B!.lenstrabase := lenst;
+      B!.coeffslist  := `List( lenst, x -> x[1] + 1 );
+      B!.lenstrabase := `lenst;
       B!.conductor   := N;
 #T better compute basis vectors only if necessary
 #T (in the case of a normal basis the vectors are of course known ...)


### PR DESCRIPTION
This supersedes PR #84 and fixes the problem reported by Claus Fieker about an access error occurring after calling
```
Test("tst/fldabnum.tst",rec(compareFunction:="uptowhitespace"));
```
in one thread and then repeating this call in another thread. The problem comes from storing additional data in the canonical basis as `B!.coeffslist` and `B!.lenstrabase` and is fixed by making them immutable.
