### PR TITLE
Fixed memory bug in FuncON_KERNEL_ANTI_ACTION

### DIFF
--- a/src/trans.c
+++ b/src/trans.c
@@ -2016,13 +2016,12 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
   rank=1;
   
   if(TNUM_OBJ(f)==T_TRANS2){
-    deg=DEG_TRANS2(f);
+    deg=INT_INTOBJ(FuncDegreeOfTransformation(self,f));
     if(len>=deg){
-      pttmp=ResizeInitTmpTrans(len);
-      ptf2=ADDR_TRANS2(f);
       out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, len);
       SET_LEN_PLIST(out, len);
-    
+      pttmp=ResizeInitTmpTrans(len);
+      ptf2=ADDR_TRANS2(f);
       for(i=0;i<deg;i++){ //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf2[i]+1))-1; // f first!
         if(pttmp[j]==0) pttmp[j]=rank++;
@@ -2035,10 +2034,10 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
         SET_ELM_PLIST(out, i, INTOBJ_INT(pttmp[j]));
       }
     } else {//len<deg
-      pttmp=ResizeInitTmpTrans(deg);
-      ptf2=ADDR_TRANS2(f);
       out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, deg);
       SET_LEN_PLIST(out, deg);
+      pttmp=ResizeInitTmpTrans(deg);
+      ptf2=ADDR_TRANS2(f);
       for(i=0;i<len;i++){  //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf2[i]+1))-1; // f first!
         if(pttmp[j]==0) pttmp[j]=rank++;
@@ -2056,13 +2055,12 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
       }
     }
   } else { 
-    deg=DEG_TRANS4(f);
+    deg=INT_INTOBJ(FuncDegreeOfTransformation(self,f));
     if(len>=deg){
-      pttmp=ResizeInitTmpTrans(len);
-      ptf4=ADDR_TRANS4(f);
       out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, len);
       SET_LEN_PLIST(out, len);
-    
+      pttmp=ResizeInitTmpTrans(len);
+      ptf4=ADDR_TRANS4(f);
       for(i=0;i<deg;i++){ //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf4[i]+1))-1; // f first!
         if(pttmp[j]==0) pttmp[j]=rank++;
@@ -2075,10 +2073,10 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
         SET_ELM_PLIST(out, i, INTOBJ_INT(pttmp[j]));
       }
     } else {//len<deg
-      pttmp=ResizeInitTmpTrans(deg);
-      ptf4=ADDR_TRANS4(f);
       out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, deg);
       SET_LEN_PLIST(out, deg);
+      pttmp=ResizeInitTmpTrans(deg);
+      ptf4=ADDR_TRANS4(f);
       for(i=0;i<len;i++){  //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf4[i]+1))-1; // f first!
         if(pttmp[j]==0) pttmp[j]=rank++;

--- a/src/trans.c
+++ b/src/trans.c
@@ -2012,8 +2012,6 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
   }
 
   len=LEN_LIST(ker);
-  out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, len);
-  SET_LEN_PLIST(out, len);
   
   rank=1;
   
@@ -2022,6 +2020,8 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
     if(len>=deg){
       pttmp=ResizeInitTmpTrans(len);
       ptf2=ADDR_TRANS2(f);
+      out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, len);
+      SET_LEN_PLIST(out, len);
     
       for(i=0;i<deg;i++){ //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf2[i]+1))-1; // f first!
@@ -2037,14 +2037,22 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
     } else {//len<deg
       pttmp=ResizeInitTmpTrans(deg);
       ptf2=ADDR_TRANS2(f);
+      out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, deg);
+      SET_LEN_PLIST(out, deg);
       for(i=0;i<len;i++){  //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf2[i]+1))-1; // f first!
         if(pttmp[j]==0) pttmp[j]=rank++;
         SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[j]));
       }
-      for(;i<deg;i++){     //just <f>
-        if(pttmp[ptf2[i]]==0) pttmp[ptf2[i]]=rank++;
-        SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[ptf2[i]]));
+      for(;i<deg;i++){//assume g acts as identity on i
+	if(ptf2[i]+1<=len) {  //refers to a class in ker
+	  j=INT_INTOBJ(ELM_LIST(ker, ptf2[i]+1))-1;
+	  if(pttmp[j]==0) pttmp[j]=rank++;
+	  SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[j]));
+	} else {  //refers to a class outside ker
+	  if(pttmp[ptf2[i]]==0) pttmp[ptf2[i]]=rank++;
+	  SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[ptf2[i]]));
+	}
       }
     }
   } else { 
@@ -2052,6 +2060,8 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
     if(len>=deg){
       pttmp=ResizeInitTmpTrans(len);
       ptf4=ADDR_TRANS4(f);
+      out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, len);
+      SET_LEN_PLIST(out, len);
     
       for(i=0;i<deg;i++){ //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf4[i]+1))-1; // f first!
@@ -2067,14 +2077,22 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
     } else {//len<deg
       pttmp=ResizeInitTmpTrans(deg);
       ptf4=ADDR_TRANS4(f);
+      out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, deg);
+      SET_LEN_PLIST(out, deg);
       for(i=0;i<len;i++){  //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf4[i]+1))-1; // f first!
         if(pttmp[j]==0) pttmp[j]=rank++;
         SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[j]));
       }
       for(;i<deg;i++){     //just <f>
-        if(pttmp[ptf4[i]]==0) pttmp[ptf4[i]]=rank++;
-        SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[ptf4[i]]));
+	if(ptf4[i]+1<=len) {
+	  j=INT_INTOBJ(ELM_LIST(ker, ptf4[i]+1))-1;
+	  if(pttmp[j]==0) pttmp[j]=rank++;
+	  SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[j]));
+	} else {
+	  if(pttmp[ptf4[i]]==0) pttmp[ptf4[i]]=rank++;
+	  SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[ptf4[i]]));
+	}
       }
     }
   }


### PR DESCRIPTION
OnKernelAntiAction was writing to a position in the output `out` which was higher than the size of the list.  If `deg`, the degree of `f`, is greater than the length of `ker`, we need to make `out` long enough to store all the information being written.

We also added a check in the `deg > len` case, for when a point `i` above `len` was mapped to a point in a class of `ker`.

Correct behaviour is demonstrated by comparing the results of the following test:
```gap
gap> f := Transformation([3,2,2,4,4,7,7,5]);
Transformation( [ 3, 2, 2, 4, 4, 7, 7, 5 ] )
gap> ker := [1,2,1,3,3];
[ 1, 2, 1, 3, 3 ]
gap> OnKernelAntiAction(ker,f);
[ 1, 2, 2, 3, 3, 4, 4, 3 ]
```
which used to return the list `[ 1, 2, 2, 3, 3 ]`, writing the last three elements into a forbidden space.