### PR TITLE
Made LARGEST_IDENTIFIER_NUMBER a fixed atomic list.

### DIFF
--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -1644,7 +1644,7 @@ DeclareAttributeSuppCT( "Identifier", IsNearlyCharacterTable, [] );
 DeclareGlobalVariable( "LARGEST_IDENTIFIER_NUMBER",
     "list containing the largest identifier of an ordinary character table\
  in the current session" );
-InstallFlushableValue( LARGEST_IDENTIFIER_NUMBER, [ 0 ] );
+InstallValue( LARGEST_IDENTIFIER_NUMBER, FixedAtomicList([ 0 ]) );
 
 
 #############################################################################

--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -2515,8 +2515,7 @@ InstallMethod( Identifier,
     function( tbl )
 
     # Construct an identifier that is unique in the current session.
-    LARGEST_IDENTIFIER_NUMBER[1]:= LARGEST_IDENTIFIER_NUMBER[1] + 1;
-    tbl:= Concatenation( "CT", String( LARGEST_IDENTIFIER_NUMBER[1] ) );
+    tbl:= Concatenation( "CT", String( ATOMIC_ADDITION( LARGEST_IDENTIFIER_NUMBER, 1, 1 ) ) );
     ConvertToStringRep( tbl );
     return tbl;
     end );


### PR DESCRIPTION
This fixes ctblmono.tst run in the background thread.