### PR TITLE
make type-data readonly.

### DIFF
--- a/lib/type1.g
+++ b/lib/type1.g
@@ -534,7 +534,7 @@ BIND_GLOBAL( "FlagsType", K -> K![2] );
 BIND_GLOBAL( "DataType", K -> K![ POS_DATA_TYPE ] );
 
 BIND_GLOBAL( "SetDataType", function ( K, data )
-    StrictBindOnce(K, POS_DATA_TYPE, data);
+    StrictBindOnce(K, POS_DATA_TYPE, `data);
 end );
 
 


### PR DESCRIPTION
Fixes a problem in algmat.tst visible after
 running it at least once in the main thread
 then running it in a different thread