### PR TITLE
Stablizer chain computation speedup

### DIFF
--- a/lib/stbc.gi
+++ b/lib/stbc.gi
@@ -487,70 +487,84 @@ InstallGlobalFunction( AddGeneratorsExtendSchreierTree, function( S, new )
     od;
                           
     # Extend the orbit and the transversal with the new labels.
-    len := Length( S.orbit );
-    i := 1;
+#    len := Length( S.orbit );
+ #   i := 1;
+    
+    
+    
+    # move tests outside loops as much as possible
+    newlabs := Filtered(S.genlabels, j->not old[j]);
+    
+    #
+    # New kernel functions take over from the GAP code in comments here.
+    # the speedup is considerable. 
+    #
     
     # move tests outside loops as much as possible
     newlabs := Filtered(S.genlabels, j->not old[j]);
     if IsBound( S.cycles )  then
-        for i in [1..len] do
-            for j in newlabs do
-                img := S.orbit[ i ] / S.labels[ j ];
-                if IsBound( S.translabels[ img ] )  then
-                    S.cycles[i] := true;
-                else
-                    S.translabels[ img ] := j;
-                    S.transversal[ img ] := S.labels[ j ];
-                    Add( S.orbit, img );
-                    Add( S.cycles, false);
+        AGESTC(S.orbit, newlabs, S.cycles, S.labels, S.translabels, S.transversal, S.genlabels);
+        
+        # for i in [1..len] do
+        #     for j in newlabs do
+        #         img := S.orbit[ i ] / S.labels[ j ];
+        #         if IsBound( S.translabels[ img ] )  then
+        #             S.cycles[i] := true;
+        #         else
+        #             S.translabels[ img ] := j;
+        #             S.transversal[ img ] := S.labels[ j ];
+        #             Add( S.orbit, img );
+        #             Add( S.cycles, false);
                     
-                fi;
-            od;
-        od;
+        #         fi;
+        #     od;
+        # od;
         
                 
-        while i <= Length( S.orbit )  do
-            for j  in S.genlabels  do
-                img := S.orbit[ i ] / S.labels[ j ];
-                if  IsBound( S.translabels[ img ] )  then
-                    S.cycles[i] := true;
-                else
-                    S.translabels[ img ] := j;
-                    S.transversal[ img ] := S.labels[ j ];
-                    Add( S.orbit, img );
-                    Add( S.cycles, false);
+        # while i <= Length( S.orbit )  do
+        #     for j  in S.genlabels  do
+        #         img := S.orbit[ i ] / S.labels[ j ];
+        #         if  IsBound( S.translabels[ img ] )  then
+        #             S.cycles[i] := true;
+        #         else
+        #             S.translabels[ img ] := j;
+        #             S.transversal[ img ] := S.labels[ j ];
+        #             Add( S.orbit, img );
+        #             Add( S.cycles, false);
                     
-                fi;
-            od;
-            i := i + 1;
-        od;
+        #         fi;
+        #     od;
+        #     i := i + 1;
+        # od;
         
     else
 
+        AGEST(S.orbit, newlabs,  S.labels, S.translabels, S.transversal, S.genlabels);
         
-        for i in [1..len] do
-            for j in newlabs do
-                img := S.orbit[ i ] / S.labels[ j ];
-                if not IsBound( S.translabels[ img ] )  then
-                    S.translabels[ img ] := j;
-                    S.transversal[ img ] := S.labels[ j ];
-                    Add( S.orbit, img );
-                fi;
-            od;
-        od;
+        # for i in [1..len] do
+        #     for j in newlabs do
+        #         img := S.orbit[ i ] / S.labels[ j ];
+        #         if not IsBound( S.translabels[ img ] )  then
+        #             S.translabels[ img ] := j;
+        #             S.transversal[ img ] := S.labels[ j ];
+        #             Add( S.orbit, img );
+        #         fi;
+        #     od;
+        # od;
         
                 
-        while i <= Length( S.orbit )  do
-            for j  in S.genlabels  do
-                img := S.orbit[ i ] / S.labels[ j ];
-                    if not IsBound( S.translabels[ img ] )  then
-                        S.translabels[ img ] := j;
-                        S.transversal[ img ] := S.labels[ j ];
-                        Add( S.orbit, img );
-                    fi;
-                od;
-            i := i + 1;
-        od;
+        # while i <= Length( S.orbit )  do
+        #     for j  in S.genlabels  do
+        #         img := S.orbit[ i ] / S.labels[ j ];
+        #             if not IsBound( S.translabels[ img ] )  then
+        #                 S.translabels[ img ] := j;
+        #                 S.transversal[ img ] := S.labels[ j ];
+        #                 Add( S.orbit, img );
+        #             fi;
+        #         od;
+        #     i := i + 1;
+        # od;
+
     fi;
 end );
 

--- a/lib/stbc.gi
+++ b/lib/stbc.gi
@@ -463,6 +463,7 @@ InstallGlobalFunction( AddGeneratorsExtendSchreierTree, function( S, new )
             old,  ald,  # genlabels before extension
             len,        # initial length of the orbit of <S>
             img,        # image during orbit algorithm
+            newlabs,    # selected labels
             i,  j;      # loop variable
 
     # Put in the new labels.
@@ -489,42 +490,65 @@ InstallGlobalFunction( AddGeneratorsExtendSchreierTree, function( S, new )
     len := Length( S.orbit );
     i := 1;
     
+    # move tests outside loops as much as possible
+    newlabs := Filtered(S.genlabels, j->not old[j]);
     if IsBound( S.cycles )  then
+        for i in [1..len] do
+            for j in newlabs do
+                img := S.orbit[ i ] / S.labels[ j ];
+                if IsBound( S.translabels[ img ] )  then
+                    S.cycles[i] := true;
+                else
+                    S.translabels[ img ] := j;
+                    S.transversal[ img ] := S.labels[ j ];
+                    Add( S.orbit, img );
+                    Add( S.cycles, false);
+                    
+                fi;
+            od;
+        od;
+        
+                
         while i <= Length( S.orbit )  do
             for j  in S.genlabels  do
-                
-                # Use new labels for old points, all labels for new points.
-                if i > len  or  not old[ j ]  then
-                    img := S.orbit[ i ] / S.labels[ j ];
-                    if IsBound( S.translabels[ img ] )  then
-                        S.cycles[ i ] := true;
-                    else
-                        S.translabels[ img ] := j;
-                        S.transversal[ img ] := S.labels[ j ];
-                        Add( S.orbit, img );
-                        Add( S.cycles, false );
-                    fi;
+                img := S.orbit[ i ] / S.labels[ j ];
+                if  IsBound( S.translabels[ img ] )  then
+                    S.cycles[i] := true;
+                else
+                    S.translabels[ img ] := j;
+                    S.transversal[ img ] := S.labels[ j ];
+                    Add( S.orbit, img );
+                    Add( S.cycles, false);
+                    
                 fi;
-                
             od;
             i := i + 1;
         od;
         
     else
+
+        
+        for i in [1..len] do
+            for j in newlabs do
+                img := S.orbit[ i ] / S.labels[ j ];
+                if not IsBound( S.translabels[ img ] )  then
+                    S.translabels[ img ] := j;
+                    S.transversal[ img ] := S.labels[ j ];
+                    Add( S.orbit, img );
+                fi;
+            od;
+        od;
+        
+                
         while i <= Length( S.orbit )  do
             for j  in S.genlabels  do
-                
-                # Use new labels for old points, all labels for new points.
-                if i > len  or  not old[ j ]  then
-                    img := S.orbit[ i ] / S.labels[ j ];
+                img := S.orbit[ i ] / S.labels[ j ];
                     if not IsBound( S.translabels[ img ] )  then
                         S.translabels[ img ] := j;
                         S.transversal[ img ] := S.labels[ j ];
                         Add( S.orbit, img );
                     fi;
-                fi;
-                
-            od;
+                od;
             i := i + 1;
         od;
     fi;

--- a/lib/stbc.gi
+++ b/lib/stbc.gi
@@ -470,6 +470,7 @@ InstallGlobalFunction( AddGeneratorsExtendSchreierTree, function( S, new )
     old := BlistList( [ 1 .. Length( S.labels ) ], S.genlabels );
     old[ 1 ] := true;
     ald := StructuralCopy( old );
+    newlabs := [];
     for gen  in new  do
         pos := Position( S.labels, gen );
         if pos = fail  then
@@ -477,8 +478,10 @@ InstallGlobalFunction( AddGeneratorsExtendSchreierTree, function( S, new )
             Add( old, false );
             Add( ald, true );
             Add( S.genlabels, Length( S.labels ) );
+            Add( newlabs, Length(S.labels));            
         elif not ald[ pos ]  then
             Add( S.genlabels, pos );
+            Add( newlabs, pos);            
         fi;
         if     IsBound( S.generators )
            and pos <> 1 and not gen in S.generators  then
@@ -492,16 +495,14 @@ InstallGlobalFunction( AddGeneratorsExtendSchreierTree, function( S, new )
     
     
     
-    # move tests outside loops as much as possible
-    newlabs := Filtered(S.genlabels, j->not old[j]);
-    
     #
     # New kernel functions take over from the GAP code in comments here.
     # the speedup is considerable. 
     #
     
     # move tests outside loops as much as possible
-    newlabs := Filtered(S.genlabels, j->not old[j]);
+    Assert(1,newlabs = Filtered(S.genlabels, j->not old[j]));
+    
     if IsBound( S.cycles )  then
         AGESTC(S.orbit, newlabs, S.cycles, S.labels, S.translabels, S.transversal, S.genlabels);
         

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -4596,6 +4596,15 @@ Obj Array2Perm (
     return perm;
 }
 
+static inline Int myquo( Obj pt, Obj perm) {
+  if (TNUM_OBJ(perm) == T_PERM2)
+    return INT_INTOBJ(QuoIntPerm2(pt, perm));
+  else if (TNUM_OBJ(perm) == T_PERM4)
+    return INT_INTOBJ(QuoIntPerm4(pt, perm));
+  else
+    return INT_INTOBJ(QUO(pt,perm ));
+}
+  
 
 /* Stabilizer chain helper implements AddGeneratorsExtendSchreierTree Inner loop */
 Obj FuncAGESTC( Obj self, Obj args)
@@ -4621,7 +4630,7 @@ Obj FuncAGESTC( Obj self, Obj args)
     for (j = 1; j <= lenn; j++) {
       oj = ELM_PLIST(newlabs,j);
       lj = ELM_PLIST(labels, INT_INTOBJ(oj));
-      img = INT_INTOBJ(QUO(pt,lj ));
+      img = myquo(pt, lj);
       if (img <= LEN_PLIST(translabels) && (Obj)0 != ELM_PLIST(translabels,img)) 
 	ASS_LIST(cycles, i, True);
       else {
@@ -4637,7 +4646,7 @@ Obj FuncAGESTC( Obj self, Obj args)
     for (j = 1; j <= lenl; j++) {
       oj = ELM_PLIST(genlabels, j);
       lj = ELM_PLIST(labels, INT_INTOBJ(oj));
-      img = INT_INTOBJ(QUO(pt,lj ));
+      img = myquo(pt, lj);
       if (img <= LEN_PLIST(translabels) && (Obj)0 != ELM_PLIST(translabels,img)) 
 	ASS_LIST(cycles, i, True);
       else {
@@ -4668,7 +4677,7 @@ Obj FuncAGEST( Obj self, Obj orbit, Obj newlabs,  Obj labels, Obj translabels, O
     for (j = 1; j <= lenn; j++) {
       oj = ELM_PLIST(newlabs,j);
       lj = ELM_PLIST(labels, INT_INTOBJ(oj));
-      img = INT_INTOBJ(QUO(pt,lj ));
+      img = myquo(pt,lj);
       if (img > LEN_PLIST(translabels) || (Obj)0 == ELM_PLIST(translabels,img)) {
 	ASS_LIST(translabels, img, oj);
 	ASS_LIST(transversal, img, lj);
@@ -4681,7 +4690,7 @@ Obj FuncAGEST( Obj self, Obj orbit, Obj newlabs,  Obj labels, Obj translabels, O
     for (j = 1; j <= lenl; j++) {
       oj = ELM_PLIST(genlabels, j);
       lj = ELM_PLIST(labels, INT_INTOBJ(oj));
-	img = INT_INTOBJ(QUO(pt,lj ));
+      img = myquo(pt, lj);
 	if (img > LEN_PLIST(translabels) || (Obj)0 == ELM_PLIST(translabels,img)) {
 	  ASS_LIST(translabels, img, oj);
 	  ASS_LIST(transversal, img, lj);

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -4597,6 +4597,102 @@ Obj Array2Perm (
 }
 
 
+/* Stabilizer chain helper implements AddGeneratorsExtendSchreierTree Inner loop */
+Obj FuncAGESTC( Obj self, Obj args)
+
+{
+  Int i,j;
+  Obj pt;
+  Obj oj, lj;
+  Int img;
+  Obj orbit = ELM_PLIST(args,1);
+  Obj newlabs = ELM_PLIST(args,2);
+  Obj cycles = ELM_PLIST(args,3);
+  Obj labels = ELM_PLIST(args,4);
+  Obj translabels = ELM_PLIST(args,5);
+  Obj transversal = ELM_PLIST(args, 6);
+  Obj genlabels = ELM_PLIST(args,7);
+  Int len = LEN_PLIST(orbit);
+  Int len2 = len;
+  Int lenn = LEN_PLIST(newlabs);
+  Int lenl = LEN_PLIST(genlabels);
+  for (i = 1; i<= len; i++) {
+    pt = ELM_PLIST(orbit, i);
+    for (j = 1; j <= lenn; j++) {
+      oj = ELM_PLIST(newlabs,j);
+      lj = ELM_PLIST(labels, INT_INTOBJ(oj));
+      img = INT_INTOBJ(QUO(pt,lj ));
+      if (img <= LEN_PLIST(translabels) && (Obj)0 != ELM_PLIST(translabels,img)) 
+	ASS_LIST(cycles, i, True);
+      else {
+	ASS_LIST(translabels, img, oj);
+	ASS_LIST(transversal, img, lj);
+	ASS_LIST(orbit, ++len2, INTOBJ_INT(img));
+	ASS_LIST(cycles, len2, False);
+      }
+    }
+  }
+  while (i <= len2) {
+    pt = ELM_PLIST(orbit, i);
+    for (j = 1; j <= lenl; j++) {
+      oj = ELM_PLIST(genlabels, j);
+      lj = ELM_PLIST(labels, INT_INTOBJ(oj));
+      img = INT_INTOBJ(QUO(pt,lj ));
+      if (img <= LEN_PLIST(translabels) && (Obj)0 != ELM_PLIST(translabels,img)) 
+	ASS_LIST(cycles, i, True);
+      else {
+	ASS_LIST(translabels, img, oj);
+	ASS_LIST(transversal, img, lj);
+	ASS_LIST(orbit, ++len2, INTOBJ_INT(img));
+	ASS_LIST(cycles, len2, False);
+      }
+    }
+    i++;
+  }
+  return (Obj) 0;
+}
+
+/* Stabilizer chain helper implements AddGeneratorsExtendSchreierTree Inner loop */
+Obj FuncAGEST( Obj self, Obj orbit, Obj newlabs,  Obj labels, Obj translabels, Obj transversal, Obj genlabels)
+{
+  Int i,j;
+  Int len = LEN_PLIST(orbit);
+  Int len2 = len;
+  Int lenn = LEN_PLIST(newlabs);
+  Int lenl = LEN_PLIST(genlabels);
+  Obj pt;
+  Obj oj,lj;
+  Int img;
+  for (i = 1; i<= len; i++) {
+    pt = ELM_PLIST(orbit, i);
+    for (j = 1; j <= lenn; j++) {
+      oj = ELM_PLIST(newlabs,j);
+      lj = ELM_PLIST(labels, INT_INTOBJ(oj));
+      img = INT_INTOBJ(QUO(pt,lj ));
+      if (img > LEN_PLIST(translabels) || (Obj)0 == ELM_PLIST(translabels,img)) {
+	ASS_LIST(translabels, img, oj);
+	ASS_LIST(transversal, img, lj);
+	ASS_LIST(orbit, ++len2, INTOBJ_INT(img));
+      }
+    }
+  }
+  while (i <= len2) {
+    pt = ELM_PLIST(orbit, i);
+    for (j = 1; j <= lenl; j++) {
+      oj = ELM_PLIST(genlabels, j);
+      lj = ELM_PLIST(labels, INT_INTOBJ(oj));
+	img = INT_INTOBJ(QUO(pt,lj ));
+	if (img > LEN_PLIST(translabels) || (Obj)0 == ELM_PLIST(translabels,img)) {
+	  ASS_LIST(translabels, img, oj);
+	  ASS_LIST(transversal, img, lj);
+	  ASS_LIST(orbit, ++len2, INTOBJ_INT(img));
+	}
+    }
+    i++;
+  }
+  return (Obj) 0;
+}
+
 
 /****************************************************************************
 **
@@ -4679,7 +4775,12 @@ static StructGVarFunc GVarFuncs [] = {
     { "DISTANCE_PERMS", 2, "perm1, perm2",
       FuncDistancePerms, "src/permutat.c:DISTANCE_PERMS" },
     
-
+    { "AGEST", 6, "orbit, newlabels, labels, translabels, transversal,genblabels",
+      FuncAGEST, "src/permutat.c:AGEST" },
+    
+    { "AGESTC", -1, "orbit, newlabels, cycles, labels, translabels, transversal, genlabels",
+      FuncAGESTC, "src/permutat.c:AGESTC" },
+    
 
     { 0 }
 


### PR DESCRIPTION
Almost all computations that construct or change stabilizer chains make heavy use of a function called
AddGeneratorsExtendSchreierTree. Profiling grpperm.tst in particular revealed a lot of time spent in this code.  

This PR moves the critical parts of this function into the kernel. It seems to give a 10% speedup in grpperm.tst with current GAP4. 

This is also a test which has a big discrepancy between gap4 and single-threaded hpcgap. It will be interesting to see if this change makes the discrepancy bigger or smaller.