### PR TITLE
QuoPPerm fix

### DIFF
--- a/src/pperm.c
+++ b/src/pperm.c
@@ -4437,7 +4437,7 @@ Obj QuoPPerm22(Obj f, Obj g){
     rank=RANK_PPERM2(f);
     for(i=1;i<=rank;i++){
       j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]<=deginv){ 
+      if(j<deg && ptf[j]<=deginv){
         ptquo[j]=pttmp[ptf[j]-1];
         if(ptquo[j]>codeg) codeg=ptquo[j];
       }
@@ -4508,7 +4508,7 @@ Obj QuoPPerm24(Obj f, Obj g){
     rank=RANK_PPERM2(f);
     for(i=1;i<=rank;i++){
       j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]<=deginv){ 
+      if(j<deg && ptf[j]<=deginv){
         ptquo[j]=pttmp[ptf[j]-1];
         if(ptquo[j]>codeg) codeg=ptquo[j];
       }
@@ -4579,7 +4579,7 @@ Obj QuoPPerm42(Obj f, Obj g){
     rank=RANK_PPERM4(f);
     for(i=1;i<=rank;i++){
       j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]<=deginv){ 
+      if(j<deg && ptf[j]<=deginv){
         ptquo[j]=pttmp[ptf[j]-1];
         if(ptquo[j]>codeg) codeg=ptquo[j];
       }
@@ -4644,7 +4644,7 @@ Obj QuoPPerm44(Obj f, Obj g){
     rank=RANK_PPERM4(f);
     for(i=1;i<=rank;i++){
       j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]<=deginv){ 
+      if(j<deg && ptf[j]<=deginv){
         ptquo[j]=pttmp[ptf[j]-1];
         if(ptquo[j]>codeg) codeg=ptquo[j];
       }

--- a/src/trans.c
+++ b/src/trans.c
@@ -2016,13 +2016,12 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
   rank=1;
   
   if(TNUM_OBJ(f)==T_TRANS2){
-    deg=DEG_TRANS2(f);
+    deg=INT_INTOBJ(FuncDegreeOfTransformation(self,f));
     if(len>=deg){
-      pttmp=ResizeInitTmpTrans(len);
-      ptf2=ADDR_TRANS2(f);
       out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, len);
       SET_LEN_PLIST(out, len);
-    
+      pttmp=ResizeInitTmpTrans(len);
+      ptf2=ADDR_TRANS2(f);
       for(i=0;i<deg;i++){ //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf2[i]+1))-1; // f first!
         if(pttmp[j]==0) pttmp[j]=rank++;
@@ -2035,10 +2034,10 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
         SET_ELM_PLIST(out, i, INTOBJ_INT(pttmp[j]));
       }
     } else {//len<deg
-      pttmp=ResizeInitTmpTrans(deg);
-      ptf2=ADDR_TRANS2(f);
       out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, deg);
       SET_LEN_PLIST(out, deg);
+      pttmp=ResizeInitTmpTrans(deg);
+      ptf2=ADDR_TRANS2(f);
       for(i=0;i<len;i++){  //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf2[i]+1))-1; // f first!
         if(pttmp[j]==0) pttmp[j]=rank++;
@@ -2056,13 +2055,12 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
       }
     }
   } else { 
-    deg=DEG_TRANS4(f);
+    deg=INT_INTOBJ(FuncDegreeOfTransformation(self,f));
     if(len>=deg){
-      pttmp=ResizeInitTmpTrans(len);
-      ptf4=ADDR_TRANS4(f);
       out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, len);
       SET_LEN_PLIST(out, len);
-    
+      pttmp=ResizeInitTmpTrans(len);
+      ptf4=ADDR_TRANS4(f);
       for(i=0;i<deg;i++){ //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf4[i]+1))-1; // f first!
         if(pttmp[j]==0) pttmp[j]=rank++;
@@ -2075,10 +2073,10 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
         SET_ELM_PLIST(out, i, INTOBJ_INT(pttmp[j]));
       }
     } else {//len<deg
-      pttmp=ResizeInitTmpTrans(deg);
-      ptf4=ADDR_TRANS4(f);
       out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, deg);
       SET_LEN_PLIST(out, deg);
+      pttmp=ResizeInitTmpTrans(deg);
+      ptf4=ADDR_TRANS4(f);
       for(i=0;i<len;i++){  //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf4[i]+1))-1; // f first!
         if(pttmp[j]==0) pttmp[j]=rank++;

--- a/src/trans.c
+++ b/src/trans.c
@@ -2012,8 +2012,6 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
   }
 
   len=LEN_LIST(ker);
-  out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, len);
-  SET_LEN_PLIST(out, len);
   
   rank=1;
   
@@ -2022,6 +2020,8 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
     if(len>=deg){
       pttmp=ResizeInitTmpTrans(len);
       ptf2=ADDR_TRANS2(f);
+      out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, len);
+      SET_LEN_PLIST(out, len);
     
       for(i=0;i<deg;i++){ //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf2[i]+1))-1; // f first!
@@ -2037,14 +2037,22 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
     } else {//len<deg
       pttmp=ResizeInitTmpTrans(deg);
       ptf2=ADDR_TRANS2(f);
+      out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, deg);
+      SET_LEN_PLIST(out, deg);
       for(i=0;i<len;i++){  //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf2[i]+1))-1; // f first!
         if(pttmp[j]==0) pttmp[j]=rank++;
         SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[j]));
       }
-      for(;i<deg;i++){     //just <f>
-        if(pttmp[ptf2[i]]==0) pttmp[ptf2[i]]=rank++;
-        SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[ptf2[i]]));
+      for(;i<deg;i++){//assume g acts as identity on i
+	if(ptf2[i]+1<=len) {  //refers to a class in ker
+	  j=INT_INTOBJ(ELM_LIST(ker, ptf2[i]+1))-1;
+	  if(pttmp[j]==0) pttmp[j]=rank++;
+	  SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[j]));
+	} else {  //refers to a class outside ker
+	  if(pttmp[ptf2[i]]==0) pttmp[ptf2[i]]=rank++;
+	  SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[ptf2[i]]));
+	}
       }
     }
   } else { 
@@ -2052,6 +2060,8 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
     if(len>=deg){
       pttmp=ResizeInitTmpTrans(len);
       ptf4=ADDR_TRANS4(f);
+      out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, len);
+      SET_LEN_PLIST(out, len);
     
       for(i=0;i<deg;i++){ //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf4[i]+1))-1; // f first!
@@ -2067,14 +2077,22 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n){
     } else {//len<deg
       pttmp=ResizeInitTmpTrans(deg);
       ptf4=ADDR_TRANS4(f);
+      out=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, deg);
+      SET_LEN_PLIST(out, deg);
       for(i=0;i<len;i++){  //<f> then <g> with ker(<g>)=<ker>
         j=INT_INTOBJ(ELM_LIST(ker, ptf4[i]+1))-1; // f first!
         if(pttmp[j]==0) pttmp[j]=rank++;
         SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[j]));
       }
       for(;i<deg;i++){     //just <f>
-        if(pttmp[ptf4[i]]==0) pttmp[ptf4[i]]=rank++;
-        SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[ptf4[i]]));
+	if(ptf4[i]+1<=len) {
+	  j=INT_INTOBJ(ELM_LIST(ker, ptf4[i]+1))-1;
+	  if(pttmp[j]==0) pttmp[j]=rank++;
+	  SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[j]));
+	} else {
+	  if(pttmp[ptf4[i]]==0) pttmp[ptf4[i]]=rank++;
+	  SET_ELM_PLIST(out, i+1, INTOBJ_INT(pttmp[ptf4[i]]));
+	}
       }
     }
   }


### PR DESCRIPTION
`QuoPPerm22` and its allies were writing beyond the end of a list.

We first calculate the degree `deg` of `fg^-1`.  When we compose `f` with `g^-1`, there may be a case where `(j)f <= deginv` but `j > deg` (where `deginv` is the degree of `g^-1`).  In this case, since `j > deg` we must have `(j)(fg^-1) = 0`, but in this case we still write a zero to the `j`th location in `ptquo`, which cannot exist since `ptquo` has length `deg`.

We add a quick check that `j < deg` (changing from `<=` to `<` to account for the points being 0-indexed) and this makes sure that we never write to anywhere illegal.