### PR TITLE
Fixed an issue where QuoPPerm writes zeroes beyond the end of a list

### DIFF
--- a/src/pperm.c
+++ b/src/pperm.c
@@ -4437,7 +4437,7 @@ Obj QuoPPerm22(Obj f, Obj g){
     rank=RANK_PPERM2(f);
     for(i=1;i<=rank;i++){
       j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]<=deginv){ 
+      if(j<deg && ptf[j]<=deginv){
         ptquo[j]=pttmp[ptf[j]-1];
         if(ptquo[j]>codeg) codeg=ptquo[j];
       }
@@ -4508,7 +4508,7 @@ Obj QuoPPerm24(Obj f, Obj g){
     rank=RANK_PPERM2(f);
     for(i=1;i<=rank;i++){
       j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]<=deginv){ 
+      if(j<deg && ptf[j]<=deginv){
         ptquo[j]=pttmp[ptf[j]-1];
         if(ptquo[j]>codeg) codeg=ptquo[j];
       }
@@ -4579,7 +4579,7 @@ Obj QuoPPerm42(Obj f, Obj g){
     rank=RANK_PPERM4(f);
     for(i=1;i<=rank;i++){
       j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]<=deginv){ 
+      if(j<deg && ptf[j]<=deginv){
         ptquo[j]=pttmp[ptf[j]-1];
         if(ptquo[j]>codeg) codeg=ptquo[j];
       }
@@ -4644,7 +4644,7 @@ Obj QuoPPerm44(Obj f, Obj g){
     rank=RANK_PPERM4(f);
     for(i=1;i<=rank;i++){
       j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]<=deginv){ 
+      if(j<deg && ptf[j]<=deginv){
         ptquo[j]=pttmp[ptf[j]-1];
         if(ptquo[j]>codeg) codeg=ptquo[j];
       }


### PR DESCRIPTION
`QuoPPerm22` and its allies were writing beyond the end of a list.

We first calculate the degree `deg` of `fg^-1`.  When we compose `f` with `g^-1`, there may be a case where `(j)f <= deginv` but `j > deg` (where `deginv` is the degree of `g^-1`).  In this case, since `j > deg` we must have `(j)(fg^-1) = 0`, but in this case we still write a zero to the `j`th location in `ptquo`, which cannot exist since `ptquo` has length `deg`.

We add a quick check that `j < deg` (changing from `<=` to `<` to account for the points being 0-indexed) and this makes sure that we never write to anywhere illegal.