### PR TITLE
Better print routine for inaccessible objects

### DIFF
--- a/lib/stdtasks.g
+++ b/lib/stdtasks.g
@@ -351,7 +351,7 @@ BindGlobal("RunTask", function(arg)
   local task;
   task := TASKS.NewTask(arg[1], arg{[2..Length(arg)]});
   task.started := true;
-  ShareSpecialObj(task);
+  ShareSpecialObj(task, "task descriptor");
   TASKS.QueueTask(task);
   return task;
 end);

--- a/src/objects.c
+++ b/src/objects.c
@@ -925,8 +925,10 @@ void PrintInaccessibleObject(Obj obj)
   } else {
     sprintf(buffer, "%p", region);
     name = buffer;
+    Pr("<protected object in shared region %s (id: %d)>", (Int) name, (Int) obj);
+    return;
   }
-  Pr("<obj %d inaccessible in region: %s>", (Int) obj, (Int)name);
+  Pr("<protected '%s' object (id: %d)>", (Int) name, (Int) obj);
 }
      
 #define MARK(obj)     do {} while (0)


### PR DESCRIPTION
Objects that cannot be accessed for printing are now described
as "protected" to not generate the impression that an error
occurred.
