### PR TITLE
Fix CopyToVectorRepNC to handle the case of plain lists of

### DIFF
--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1514,8 +1514,12 @@ InstallGlobalFunction(CopyToVectorRepNC,function( v, q )
     # Calling COMMON_FIELD_VECFFE may force a full inspection of the list.
     common := COMMON_FIELD_VECFFE(v);
     if common = fail then
-        Error("ConvertToVectorRepNC: Vector cannot be written over GF(",q,").\n",
-              "You may try to use ConvertToVectorRep instead\n");
+        common := SMALLEST_FIELD_VECFFE(v);
+        if common = fail then
+            Error("CopyToVectorRepNC: Vector cannot be written over GF(",q,").\n",
+                  "You may try to use CopyToVectorRep instead\n");
+        fi;
+        
     fi;
     
     if q = 2 then


### PR DESCRIPTION
FFEs which actually all lie in a common field but are not written over it.

Fixes a bug in CopyToVectorRep when given a vector that consists of elements that actually lie in a common field but are not all written over it. Showed up in testing the manual for Suzuki Group (Replaces #110 )