### PR TITLE
Add nicer iterator printing functionality (WIP, do not merge yet)

### DIFF
--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -76,11 +76,23 @@ InstallMethod( PrintObj,
     "for an iterator",
     [ IsIterator ],
     function( iter )
-    if IsMutable( iter ) then
-      Print( "<iterator>" );
-    else
-      Print( "<iterator (immutable)>" );
+    local msg;
+    msg := "<iterator";
+    if not IsMutable( iter ) then
+      Append(msg, " (immutable)");
     fi;
+    if IsBound( iter!.description ) then
+      Append(msg, " ");
+      if IsFunction(iter!.description(iter)) then
+        Append(msg, iter!.description(iter));
+      elif IsString(iter!.description(iter)) then
+        Append(msg, iter!.description);
+      else
+        Error("Invalid description for iterator.");
+      fi;
+    fi;
+    Append(msg,">");
+    Print(msg);
     end );
 
 

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -83,7 +83,7 @@ InstallMethod( PrintObj,
     fi;
     if IsBound( iter!.description ) then
       Append(msg, " ");
-      if IsFunction(iter!.description(iter)) then
+      if IsFunction(iter!.description) then
         Append(msg, iter!.description(iter));
       elif IsString(iter!.description(iter)) then
         Append(msg, iter!.description);


### PR DESCRIPTION
I noticed that printing iterators gives a rather non-descriptive message. This is one way of making this nicer in a backwards-compatible way by providing callbacks that give additional information about an iterator.

What do people think?