### PR TITLE
Make DBG functions available separately.

### DIFF
--- a/etc/dbgmacro.py
+++ b/etc/dbgmacro.py
@@ -35,7 +35,6 @@ def emit_redef(return_type, name, arg_types):
   emit("")
   emit("#ifdef " + name)
   emit("")
-  emit("static inline")
   emit(return_type + "DBG_" + name + "(" + ", ".join(args) + ")")
   emit("{")
   if len(args):


### PR DESCRIPTION
dbgmacro.c contains auto-generated debug versions of macros. This patch
makes the DBG_ variant accessible even when inlining or the debugger
hides the function.