### PR TITLE
Merge gap and hpcgap exit handling

### DIFF
--- a/src/gap.h
+++ b/src/gap.h
@@ -229,7 +229,7 @@ typedef UInt ExecStatus;
 
 extern UInt UserHasQuit;
 extern UInt UserHasQUIT;
-extern UInt UserHasQUITReturnValue;
+extern UInt SystemErrorCode;
 
 #if 0
 /****************************************************************************

--- a/src/system.c
+++ b/src/system.c
@@ -1477,7 +1477,7 @@ void SySleep ( UInt secs )
 **
 **  If the user calls 'QUIT_GAP' with a value, then the global variable
 **  'UserHasQUIT' will be set, and their requested return value will be
-**  in 'UserHasQUITReturnValue'. If the return value would be 0, we check
+**  in 'SystemErrorCode'. If the return value would be 0, we check
 **  this calue and use it instead.
 */
 void SyExit (
@@ -1493,12 +1493,7 @@ void SyExit (
   }
 
 #endif
-    if(ret == 0) {
-        exit(UserHasQUITReturnValue);
-    }
-    else {
         exit( (int)ret );
-    }
 }
 
 /****************************************************************************


### PR DESCRIPTION
This code aims to take the (in my opinion) best parts of gap and hpcgap's exit handling. The aim is to make sure that errors are always correctly reported and remove all need for 'grep'ing to see if tests passed/failed.

The new recommended flow is as follows:

* At any time call `GAP_EXIT_CODE` to set the return value GAP will exit with (defaults to 0). This will be used whenever GAP doesn't decide to internally return a non-0 value (which is caused by serious internal issues). The main use of this is to catch cases where tests cause GAP to exit (they cause an `Error` for example).
* `QUIT_GAP` and `FORCE_QUIT_GAP` both exit GAP. If they are given a value it is used as the return value, else the value from `GAP_EXIT_CODE` is used. The difference between `QUIT_GAP` and `FORCE_QUIT_GAP` is that `QUIT_GAP` tries to exit "nicely", while `FORCE_QUIT_GAP` exits straight away. `FORCE_QUIT_GAP` is more useful in HPC-GAP, where exiting nicely is much harder.

My suggested flow for tests (the main application of this) is as follows:
```
GAP_EXIT_CODE(1) # If we fail due to a GAP error, we want to report failure.
# We could save these up if we want to carry on trying to run tests.
if not(testfunction()) then FORCE_QUIT_GAP(); fi;
...
# When we get to the end, we return with 0 if all our tests worked.
FORCE_QUIT_GAP(0);
```

If this patch is considered acceptable I will merge it into hpc-gap (which already mostly works this way).