### PR TITLE
WIP  -- Trying to deal with in-place conversions to compressed vector and matrix reps

### DIFF
--- a/lib/ffeconway.gi
+++ b/lib/ffeconway.gi
@@ -1506,14 +1506,16 @@ InstallMethod(Coefficients,
         IsCollsElms,
         [IsCanonicalBasis and IsBasisFiniteFieldRep, IsFFE and IsCoeffsModConwayPolRep],
         function(cb,x)
+    local  y;
     if not IsPrimeField(LeftActingDomain(UnderlyingLeftModule(cb))) then
         TryNextMethod();
     fi;
     if DegreeOverPrimeField(UnderlyingLeftModule(cb)) <> x![2] then
         TryNextMethod();
     fi;
-    PadCoeffs(x![1],x![2]);
-    return Immutable(x![1]);
+    y := ShallowCopy(x![1]);
+    PadCoeffs(y,x![2]);
+    return Immutable(y);
 end);
 
 #############################################################################

--- a/lib/ffeconway.gi
+++ b/lib/ffeconway.gi
@@ -58,7 +58,8 @@ BindGlobal("FFECONWAY", rec());
 ## 'fam!.ConwayFldEltReducers[d]' contains a function which will take a mutable 
 ##                               vector of FFEs in compressed format (if appropriate)
 ##                               reduce it modulo the Conway polynomial and fix its 
-##                               length to be exactly 'd'
+##                               length to be exactly 'd'. Returns the adjusted vector, which
+##                               may sometimes be a copy of the original
 ## 'fam!.ZCache[d]'            contains 'Z(p,d)' once it has been computed.
 ##
 
@@ -87,8 +88,12 @@ FFECONWAY.SetUpConwayStuff := function(p,d)
     #
     if p = 2 then
         reducer := function(v)
+            if not IsGF2VectorRep(v) then
+                v := CopyToVectorRep(v,2);
+            fi;
             REDUCE_COEFFS_GF2VEC(v,Length(v),cp,d+1);
             RESIZE_GF2VEC(v,d);
+            return v;
         end;
     elif p <= 256 then
         #
@@ -96,8 +101,12 @@ FFECONWAY.SetUpConwayStuff := function(p,d)
         #
         cps := MAKE_SHIFTED_COEFFS_VEC8BIT(cp,d+1);
         reducer := function(v)
+            if not Is8BitVectorRep(v) then
+                v := CopyToVectorRep(v,p);
+            fi;
             REDUCE_COEFFS_VEC8BIT(v,Length(v),cps);
             RESIZE_VEC8BIT(v,d);
+            return v;
         end;
     else
         #
@@ -112,12 +121,13 @@ FFECONWAY.SetUpConwayStuff := function(p,d)
                     Unbind(v[i]);
                 od;
             fi;
+            return v;
         end;
     fi;
 
     atomic readwrite fam!.ConwayPolCoeffs do    
       if not IsBound(fam!.ConwayPolCoeffs[d]) then
-        fam!.ConwayPolCoeffs[d] := MakeReadOnly(cp);
+        fam!.ConwayPolCoeffs[d] := MakeImmutable(cp);
         fam!.ConwayFldEltReducers[d] := reducer;
       fi;  
     od;
@@ -147,11 +157,12 @@ FFECONWAY.ZNC := function(p,d)
     if p<=256 then
         v := CopyToVectorRep(v,p);
     fi;
+    MakeImmutable(v);    
     # put 'false' in the third component because we know it is irreducible
     zpd := Objectify(fam!.ConwayFldEltDefaultType, [v,d,false] );
     
     if not IsBound(fam!.ZCache[d]) then
-        fam!.ZCache[d] := MakeReadOnly(zpd);
+        fam!.ZCache[d] := MakeImmutable(zpd);
     fi;
     return fam!.ZCache[d];
     
@@ -386,13 +397,13 @@ FFECONWAY.FiniteFieldEmbeddingRecord := function(p, d1,d2)
             x := CopyToVectorRep(x,p);
         fi;  
         z1 := PowerModCoeffs(x,n,c);
-        fam!.ConwayFldEltReducers[d2](z1);
+        z1 := fam!.ConwayFldEltReducers[d2](z1);
         m := [ZeroMutable(z1),z1];
         m[1][1] := Z(p)^0;
         z := z1;
         for i in [2..d1-1] do
             z := ProductCoeffs(z,z1);
-            fam!.ConwayFldEltReducers[d2](z);
+            z := fam!.ConwayFldEltReducers[d2](z);
             Add(m,z);
         od;
         ConvertToMatrixRep(m,p);
@@ -407,7 +418,7 @@ FFECONWAY.FiniteFieldEmbeddingRecord := function(p, d1,d2)
             fi;
         od;
         Assert(2,d1 = 1 or res.relations = []);
-        MakeReadOnly(r);
+        MakeImmutable(r);
         fam!.embeddingRecords[d2][d1] := r;
     fi;
     return fam!.embeddingRecords[d2][d1];
@@ -433,7 +444,7 @@ FFECONWAY.WriteOverLargerField := function(x,d2)
         if d1 = d2 then
             return x;
         fi;
-        v := Coefficients(CanonicalBasis(AsField(GF(p,1),GF(p,d1))),x);
+        v := Coefficients(CanonicalBasis(AsField(GF(p,1),GF(p,d1))),x);        
     else
         d1 := x![2];
         if d1 = d2 then
@@ -450,7 +461,7 @@ FFECONWAY.WriteOverLargerField := function(x,d2)
     else
         y := fail;
     fi;
-    return Objectify(fam!.ConwayFldEltDefaultType, [v*f!.mat,d2,y]);
+    return Objectify(fam!.ConwayFldEltDefaultType, [`(v*f!.mat),d2,y]);
 end;
 
 #############################################################################
@@ -519,7 +530,7 @@ FFECONWAY.TryToWriteInSmallerField := function(x,d1)
         oversmalld :=  Sum([1..smalld], i-> z^(i-1)*v2[i]);
         
     else
-        oversmalld :=  Objectify(fam!.ConwayFldEltDefaultType,[v2,d1,fail]);
+        oversmalld :=  Objectify(fam!.ConwayFldEltDefaultType,[`v2,d1,fail]);
     fi;
     if smalld < d1 then
         return FFECONWAY.WriteOverLargerField(oversmalld, d1);
@@ -706,7 +717,7 @@ FFECONWAY.SumConwayOtherFFEs := function(x1,x2)
     fam := FamilyObj(x1);
     cc := FFECONWAY.CoeffsOverCommonField(x1,x2);
     v := cc[1]+cc[2];
-       return Objectify(fam!.ConwayFldEltDefaultType, [v,cc[3],fail]);
+       return Objectify(fam!.ConwayFldEltDefaultType, [`v,cc[3],fail]);
 end;
 
 #############################################################################
@@ -732,7 +743,7 @@ InstallMethod(\+,
     fi;
     fam := FamilyObj(x1);
     return Objectify(fam!.ConwayFldEltDefaultType, 
-                   [v,d,fail]);
+                   [`v,d,fail]);
 end);
 
 InstallMethod(\+,
@@ -777,7 +788,7 @@ FFECONWAY.DiffConwayOtherFFEs := function(x1,x2)
     fam := FamilyObj(x1);
     cc := FFECONWAY.CoeffsOverCommonField(x1,x2);
     v := cc[1]-cc[2];
-       return Objectify(fam!.ConwayFldEltDefaultType, [v,cc[3],fail]);
+       return Objectify(fam!.ConwayFldEltDefaultType, [`v,cc[3],fail]);
 end;
 
 #############################################################################
@@ -803,7 +814,7 @@ InstallMethod(\-,
     fi;
     fam := FamilyObj(x1);
     return Objectify(fam!.ConwayFldEltDefaultType, 
-                   [v,d,fail]);
+                   [`v,d,fail]);
 end);
 
 InstallMethod(\-,
@@ -840,8 +851,8 @@ FFECONWAY.ProdConwayOtherFFEs := function(x1,x2)
     fam := FamilyObj(x1);
     cc := FFECONWAY.CoeffsOverCommonField(x1,x2);
     v := ProductCoeffs(cc[1],cc[2]);
-    fam!.ConwayFldEltReducers[cc[3]](v);
-    return Objectify(fam!.ConwayFldEltDefaultType, [v,cc[3], fail]);
+    v := fam!.ConwayFldEltReducers[cc[3]](v);
+    return Objectify(fam!.ConwayFldEltDefaultType, [`v,cc[3], fail]);
 end;
 
 #############################################################################
@@ -863,9 +874,9 @@ InstallMethod(\*,
         d := cc[3];
     fi;
     fam := FamilyObj(x1);
-    fam!.ConwayFldEltReducers[d](v);
+    v := fam!.ConwayFldEltReducers[d](v);
     return Objectify(fam!.ConwayFldEltDefaultType, 
-                   [v,d,fail]);
+                   [`v,d,fail]);
     end
 
 );
@@ -910,7 +921,7 @@ InstallMethod(AdditiveInverseOp,
     else
         y := -x![3];
     fi;
-    return Objectify(fam!.ConwayFldEltDefaultType, [AdditiveInverseMutable(x![1]),x![2],y]);
+    return Objectify(fam!.ConwayFldEltDefaultType, [AdditiveInverse(x![1]),x![2],y]);
 end);
 
 #############################################################################
@@ -953,18 +964,18 @@ InstallMethod(InverseOp,
     MultRowVector(r,Inverse(a[1]));
     if AssertionLevel() >= 2 then
         t := ProductCoeffs(x![1],r);
-        fam!.ConwayFldEltReducers[d](t);
+        t := fam!.ConwayFldEltReducers[d](t);
         if not IsOne(t[1]) or ForAny([2..Length(t)], i->not IsZero(t[i])) then
             Error("Inverse has failed");
         fi;
     fi;
-    fam!.ConwayFldEltReducers[d](r);
+    r := fam!.ConwayFldEltReducers[d](r);
     if IsBool(x![3]) then
         y := x![3];
     else
         y := Inverse(x![3]);
     fi;
-    return MakeReadOnly( Objectify(fam!.ConwayFldEltDefaultType,[r,d,y]) );
+    return MakeReadOnly( Objectify(fam!.ConwayFldEltDefaultType,[`r,d,y]) );
 end);
 
 InstallMethod(QUO_FFE_LARGE,
@@ -1021,7 +1032,7 @@ FFECONWAY.Zero := function(x)
     fi;
     d := x![2];
     if not IsBound(fam!.ZeroConwayFFEs[d]) then
-        fam!.ZeroConwayFFEs[d] := MakeReadOnly(Objectify(fam!.ConwayFldEltDefaultType,[ZeroMutable(x![1]),d, 
+        fam!.ZeroConwayFFEs[d] := MakeReadOnly(Objectify(fam!.ConwayFldEltDefaultType,[Zero(x![1]),d, 
                                           0*Z(fam!.Characteristic)]));
     fi;
     return fam!.ZeroConwayFFEs[d];
@@ -1053,7 +1064,7 @@ FFECONWAY.One := function(x)
     if not IsBound(fam!.OneConwayFFEs[d]) then
         v := ZeroMutable(x![1]);
         v[1] := Z(fam!.Characteristic)^0;
-        fam!.OneConwayFFEs[d] := MakeReadOnly(Objectify(fam!.ConwayFldEltDefaultType,[v,d, 
+        fam!.OneConwayFFEs[d] := MakeReadOnly(Objectify(fam!.ConwayFldEltDefaultType,[`v,d, 
                                          Z(fam!.Characteristic)^0]));
     fi;
     return fam!.OneConwayFFEs[d];
@@ -1525,7 +1536,7 @@ InstallMethod(Enumerator,
     e := Enumerator(RowSpace(GF(p,1),d));
     return EnumeratorByFunctions(f, rec(
                    ElementNumber := function(en,n)
-        return Objectify(fam!.ConwayFldEltDefaultType, [ e[n], d, fail]);
+        return Objectify(fam!.ConwayFldEltDefaultType, [ `e[n], d, fail]);
         end,
                    NumberElement := function(en,x)
         x := FFECONWAY.WriteOverLargerField(x,d);
@@ -1576,7 +1587,7 @@ InstallMethod(Random,
     p := Characteristic(f);
     v := Random(RowSpace(GF(p,1),d));
     fam := FFEFamily(Characteristic(f));
-    return Objectify(fam!.ConwayFldEltDefaultType, [v,d,fail]);
+    return Objectify(fam!.ConwayFldEltDefaultType, [`v,d,fail]);
 end);
 
 #############################################################################
@@ -1603,7 +1614,7 @@ InstallMethod(MinimalPolynomial,
     m := [o,y];
     for i in [2..d] do
         y := ProductCoeffs(y,x);
-        fam!.ConwayFldEltReducers[dd](y);
+        y := fam!.ConwayFldEltReducers[dd](y);
         Add(m,y);
     od;
     ConvertToMatrixRep(m,p);

--- a/lib/ffeconway.gi
+++ b/lib/ffeconway.gi
@@ -31,7 +31,7 @@
 ##  
 
 BindGlobal("IsCoeffsModConwayPolRep", 
-        NewRepresentation( "IsCoeffsModConwayPolRep", IsPositionalObjectRep,3));
+        NewRepresentation( "IsCoeffsModConwayPolRep", IsAtomicPositionalObjectRep,3));
 
 #############################################################################
 ##

--- a/lib/grppclat.gi
+++ b/lib/grppclat.gi
@@ -152,7 +152,7 @@ local g,op,a,pcgs,ma,mat,d,f,i,j,new,newmat,id,p,dodim,compldim,compl,dims,nm;
     fi;
     if d>2 then
       nm:=TriangulizedNullspaceMat(TransposedMat(id{[1]}));
-      ConvertToMatrixRep(nm,f);
+      nm := CopyToMatrixRep(nm,f);
       Add(compl,nm);
     fi;
     for i in [2..d] do

--- a/lib/listcoef.gi
+++ b/lib/listcoef.gi
@@ -1287,7 +1287,7 @@ AClosestVectorDriver := function(mat,f,vec,cnt,stop,coords)
     fi;
     
     mat := CopyToMatrixRepNC(mat,Size(f));
-    vec := CopyToVectorRepNC(vec,f);
+    vec := CopyToVectorRepNC(vec,Size(f));
     
     # build the data structures
     f:=AsSSortedList(f);
@@ -1534,23 +1534,15 @@ InstallMethod(CosetLeadersMatFFE,"generic",IsCollsElms,
     if 2 <= q and q < 256 then
         
         # 8 bit case, need to get all vectors over the right field
-        ok8 := true;
-        if q <> ConvertToVectorRepNC(v,q) then
-            v := PlainListCopy(v);
-            ok8 := ok8 and q = ConvertToVectorRepNC(v,q);
-        fi;
-        if ok8 and q <> ConvertToVectorRepNC(w,q) then
-            w := PlainListCopy(w);
-            ok8 := ok8 and q = ConvertToVectorRepNC(w,q);
-        fi;
+        v := CopyToVectorRepNC(v,q);
+        w := CopyToVectorRepNC(w,q);
         for x in vl{[1..n]} do
             for i in [1..q+1] do
-                if ok8 and q <> ConvertToVectorRepNC(x[i],q) then
-                    x[i] := PlainListCopy(x[i]);
-                    ok8 := ok8 and q = ConvertToVectorRepNC(x[i],q);
-                fi;
+                x[i] := CopyToVectorRepNC(x[i],q);
             od;
         od;
+        ok8 := true;
+        
     else
         ok8 := false;
     fi;

--- a/lib/listcoef.gi
+++ b/lib/listcoef.gi
@@ -1090,15 +1090,16 @@ InstallMethod(DistanceVecFFE,"gf2 vectors",
 InstallMethod(DistancesDistributionVecFFEsVecFFE,"generic",IsCollsElms,
   [IsList, IsList],0,
 function(vecs,vec)
-local d,i;
-  ConvertToMatrixRep(vecs);
-  ConvertToVectorRep(vec);
-  d:=ListWithIdenticalEntries(Length(vec)+1,0);
-  for i in vecs do
-    i:=DistanceVecFFE(i,vec);
-    d[i+1]:=d[i+1]+1;
-  od;
-  return d;
+    local d,i,q;
+    q := DefaultField(vecs);
+    vecs := CopyToMatrixRep(vecs,q);
+    vec := CopyToVectorRep(vec,q);
+    d:=ListWithIdenticalEntries(Length(vec)+1,0);
+    for i in vecs do
+        i:=DistanceVecFFE(i,vec);
+        d[i+1]:=d[i+1]+1;
+    od;
+    return d;
 end);
 
 
@@ -1125,8 +1126,8 @@ InstallMethod(DistancesDistributionMatFFEVecFFE,"generic",IsCollsElmsElms,
         [IsMatrix,IsFFECollection and IsField, IsList],0,
         function(mat,f,vec)
     local d,fdi,i,j,veclis,mult,mults,fdip,q, ok8;
-    ConvertToMatrixRepNC(mat,f);
-    ConvertToVectorRepNC(vec,f);
+    mat := CopyToMatrixRepNC(mat,f);
+    vec := CopyToVectorRepNC(vec,f);
     # build the data structures
     f:=AsSSortedList(f);
     Assert(1,f[1]=Zero(f[1]));
@@ -1285,8 +1286,8 @@ AClosestVectorDriver := function(mat,f,vec,cnt,stop,coords)
       Error("First list needs at least ", cnt, " vectors . . .\n");
     fi;
     
-    ConvertToMatrixRepNC(mat,Size(f));
-    ConvertToVectorRepNC(vec,f);
+    mat := CopyToMatrixRepNC(mat,Size(f));
+    vec := CopyToVectorRepNC(vec,f);
     
     # build the data structures
     f:=AsSSortedList(f);

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -456,7 +456,6 @@ InstallGlobalFunction(CopyToMatrixRep,
             q := Size(q);
         else
 	    return fail ; # not a field -- exit
-
         fi;
     fi;
     

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -456,6 +456,7 @@ InstallGlobalFunction(CopyToMatrixRep,
             q := Size(q);
         else
 	    return fail ; # not a field -- exit
+
         fi;
     fi;
     

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -455,7 +455,7 @@ InstallGlobalFunction(CopyToMatrixRep,
             fi;
             q := Size(q);
         else
-	    return; # not a field -- exit
+	    return fail ; # not a field -- exit
         fi;
     fi;
     
@@ -766,6 +766,7 @@ InstallMethod( OneSameMutability, "8 bit matrix", true,
         w[i] := one;
         Add(o,w);
     od;
+    ConvertToMatrixRepNC(o, Q_VEC8BIT(v));
     if not IsMutable(m![2]) then
         for i in [1..m![1]] do
             MakeImmutable(o[i]);
@@ -774,7 +775,7 @@ InstallMethod( OneSameMutability, "8 bit matrix", true,
     if not IsMutable(m) then
         MakeImmutable(o);
     fi;
-    ConvertToMatrixRepNC(o, Q_VEC8BIT(v));
+
     return o;
 end);
 

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -1112,6 +1112,7 @@ InstallMethod(PostMakeImmutable, [Is8BitMatrixRep],
     for i in [2..m![1]] do
         MakeImmutable(m![i]);
     od;
+    MakeReadOnly(m);
 end);
 
 

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -436,6 +436,69 @@ end);
 
 #############################################################################
 ##
+#M  CopyToMatrixRepNC( <list>, <fieldsize )
+#M  CopyToMatrixRep( <list>[, <fieldsize> | <field>])
+##
+
+
+InstallGlobalFunction(CopyToMatrixRep,
+        function( m,q )
+    local  newm;
+
+    
+    
+    
+    if not IsInt(q) then
+        if IsField(q) then
+            if Characteristic(q) = 0 then
+                return fail;
+            fi;
+            q := Size(q);
+        else
+	    return; # not a field -- exit
+        fi;
+    fi;
+    
+    if Length(m) = 0 then
+        return [];
+    fi;
+    
+    #
+    # If we are already compressed, then our rows are certainly
+    #  locked, so we will not be able to change representation
+    #
+    
+    newm := List(m, v->CopyToVectorRep(v,q));
+    
+    ConvertToMatrixRepNC(newm,q);
+    
+    return newm;
+    
+end);    
+
+
+InstallGlobalFunction(CopyToMatrixRepNC, function(m , q )    
+    local  newm;
+    
+    
+    if Length(m) = 0 then
+        return [];
+    fi;
+    
+    #
+    # If we are already compressed, then our rows are certainly
+    #  locked, so we will not be able to change representation
+    #
+    
+    newm := List(m, v->CopyToVectorRepNC(v,q));
+    
+    ConvertToMatrixRepNC(newm,q);
+    
+    return newm;
+end);
+
+#############################################################################
+##
 #M <vec> * <mat>
 ##
 

--- a/lib/ratfun1.gi
+++ b/lib/ratfun1.gi
@@ -46,10 +46,9 @@ local f,typ,lc,q;
   if IS_PLIST_REP(coeff) and IsFFECollection(coeff) then
       q := COMMON_FIELD_VECFFE(coeff);
       if q = fail then
-          q := SMALLEST_FIELD_VECFFE(coeff);
-          
+          q := SMALLEST_FIELD_VECFFE(coeff);          
       fi;
-      if q <= 256 then
+      if q <> fail and q <= 256 then
           coeff := `CopyToVectorRep(coeff,q);
       fi;
       Assert(1, coeff <> fail);

--- a/lib/ratfun1.gi
+++ b/lib/ratfun1.gi
@@ -46,9 +46,10 @@ local f,typ,lc,q;
   if IS_PLIST_REP(coeff) and IsFFECollection(coeff) then
       q := COMMON_FIELD_VECFFE(coeff);
       if q = fail then
-          q := SMALLEST_FIELD_VECFFE(coeff);          
+          q := SMALLEST_FIELD_VECFFE(coeff);
+          
       fi;
-      if q <> fail and q <= 256 then
+      if q <= 256 then
           coeff := `CopyToVectorRep(coeff,q);
       fi;
       Assert(1, coeff <> fail);

--- a/lib/ratfun1.gi
+++ b/lib/ratfun1.gi
@@ -18,7 +18,7 @@
 # Functions to create objects 
 
 LAUR_POL_BY_EXTREP:=function(rfam,coeff,val,inum)
-local f,typ,lc;
+local f,typ,lc,q;
 
 # trap code for unreduced coeffs.
 # if Length(coeffs[1])>0 
@@ -43,15 +43,29 @@ local f,typ,lc;
   fi;
   
   # slightly better to do this after the Length has been determined 
-  if IS_PLIST_REP(coeff) then
-    if IsFFECollection(coeff) then
-      ConvertToVectorRep(coeff);
-      if IS_DATOBJ(coeff) then
-	coeff := ShallowCopy(coeff);
-	MakeReadOnly(coeff);
+  if IS_PLIST_REP(coeff) and IsFFECollection(coeff) then
+      q := COMMON_FIELD_VECFFE(coeff);
+      if q = fail then
+          q := SMALLEST_FIELD_VECFFE(coeff);
+          
       fi;
-    fi;
+      if q <= 256 then
+          coeff := `CopyToVectorRep(coeff,q);
+      fi;
+      Assert(1, coeff <> fail);
+      
   fi;
+  
+  
+  # if IS_PLIST_REP(coeff) then
+  #   if IsFFECollection(coeff) then
+  #     ConvertToVectorRep(coeff);
+  #     if IS_DATOBJ(coeff) then
+  #       coeff := ShallowCopy(coeff);
+  #       MakeReadOnly(coeff);
+  #     fi;
+  #   fi;
+  # fi;
 
   
   # objectify. We have to be *fast*. Thus we don't even call

--- a/lib/vecmat.gd
+++ b/lib/vecmat.gd
@@ -210,6 +210,18 @@ DeclareSynonym( "ConvertToVectorRep",ConvertToVectorRepNC);
 DeclareGlobalFunction( "CopyToVectorRep");
 DeclareGlobalFunction( "CopyToVectorRepNC");
 
+
+#############################################################################
+##
+#F  CopyToMatrixRep( <list>, <field> )
+#F  CopyToMatrixRep( <list>, <fieldsize> )
+#F  CopyToMatrixRepNC( <list>, <fieldsize> )
+##
+
+DeclareGlobalFunction( "CopyToMatrixRepNC" );
+DeclareGlobalFunction( "CopyToMatrixRep" );
+
+
 #############################################################################
 ##
 #F  ConvertToMatrixRep( <list>[, <field>] )

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2309,6 +2309,7 @@ InstallMethod(PostMakeImmutable, [IsGF2MatrixRep],
     for i in [2..m![1]] do
         MakeImmutable(m![i]);
     od;
+    MakeReadOnly(m);
 end);
 
 #############################################################################

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1588,94 +1588,99 @@ end);
 ##
 #F  ImmutableMatrix( <field>, <matrix> [,<change>] ) 
 ##
-DoImmutableMatrix:=function(field,matrix,change)
-local sf, rep, ind, ind2, row, i,big,l;
-  if not (IsPlistRep(matrix) or IsGF2MatrixRep(matrix) or
-    Is8BitMatrixRep(matrix)) then
-    # if empty of not list based, simply return `Immutable'.
-    return Immutable(matrix);
-  fi;
-  if IsInt(field) then
-    sf:=field;
-  else
-    if not IsField(field) then
-      # not a field
-      return matrix;
-    fi;
-    sf:=Size(field);
-  fi;
-
-  big:=sf>256 or sf=0;
-
-  # the representation we want the rows to be in
-  if sf=2 then
-    rep:=IsGF2VectorRep;
-  elif not big then
-    rep:=function(v) return Is8BitVectorRep(v) and Q_VEC8BIT(v) = sf; end;
-  else
-    rep:=IsPlistRep;
-  fi;
-
-  # get the indices of the rows that need changing the representation.
-  ind:=[]; # rows to convert
-  ind2:=[]; # rows to rebuild 
-  for i in [1..Length(matrix)] do
-    if not rep(matrix[i]) then
-      if big or IsLockedRepresentationVector(matrix[i]) 
-	or (IsMutable(matrix[i]) and not change) then
-        Add(ind2,i);
-      else
-	# wrong rep, but can be converted
-	Add(ind,i);
-      fi;
-    elif (IsMutable(matrix[i]) and not change) then
-      # right rep but wrong mutability
-      Add(ind2,i);
-    fi;
-  od;
-
-  # do we need to rebuild outer matrix layer?
-  if not IsMutable(matrix) # matrix was immutable
-    or (IsMutable(matrix) and not change) # matrix was mutable
-    or (Length(ind2)>0 and   # we want to change rows
-      not IsMutable(matrix)) #but cannot change entries
-    or (Is8BitMatrixRep(matrix) # matrix is be compact rep
-       and (Length(ind)>0 or Length(ind2)>0) ) # and we change rows
-       then
-    l:=matrix;
-    matrix:=[];
-    for i in l do
-      Add(matrix,i);
-    od;
-  fi;
-
-  # rebuild some rows
-  if big then
-    for i in ind2 do
-      matrix[i]:=List(matrix[i],j->j); # plist conversion
-    od;
-  else
-    for i in ind2 do
-      row := CopyToVectorRep(matrix[i], sf);
-      if row <> fail then
-        matrix[i] := row;
-      fi;
-    od;
-  fi;
-
-  # this can only happen if not big
-  for i in ind do
-    matrix[i]:=CopyToVectorRep(matrix[i],sf);
-  od;
-
-  MakeImmutable(matrix);
-  if sf=2 and not IsGF2MatrixRep(matrix) then
-    CONV_GF2MAT(matrix);
-  elif sf>2 and sf<=256 and not Is8BitMatrixRep(matrix) then
-    CONV_MAT8BIT(matrix,sf);
-  fi;
-  return matrix;
+DoImmutableMatrix := function(field,matrix,change)
+    return `CopyToMatrixRep(matrix, field);
 end;
+
+
+# DoImmutableMatrix:=function(field,matrix,change)
+# local sf, rep, ind, ind2, row, i,big,l;
+#   if not (IsPlistRep(matrix) or IsGF2MatrixRep(matrix) or
+#     Is8BitMatrixRep(matrix)) then
+#     # if empty of not list based, simply return `Immutable'.
+#     return Immutable(matrix);
+#   fi;
+#   if IsInt(field) then
+#     sf:=field;
+#   else
+#     if not IsField(field) then
+#       # not a field
+#       return matrix;
+#     fi;
+#     sf:=Size(field);
+#   fi;
+
+#   big:=sf>256 or sf=0;
+
+#   # the representation we want the rows to be in
+#   if sf=2 then
+#     rep:=IsGF2VectorRep;
+#   elif not big then
+#     rep:=function(v) return Is8BitVectorRep(v) and Q_VEC8BIT(v) = sf; end;
+#   else
+#     rep:=IsPlistRep;
+#   fi;
+
+#   # get the indices of the rows that need changing the representation.
+#   ind:=[]; # rows to convert
+#   ind2:=[]; # rows to rebuild 
+#   for i in [1..Length(matrix)] do
+#     if not rep(matrix[i]) then
+#       if big or IsLockedRepresentationVector(matrix[i]) 
+# 	or (IsMutable(matrix[i]) and not change) then
+#         Add(ind2,i);
+#       else
+# 	# wrong rep, but can be converted
+# 	Add(ind,i);
+#       fi;
+#     elif (IsMutable(matrix[i]) and not change) then
+#       # right rep but wrong mutability
+#       Add(ind2,i);
+#     fi;
+#   od;
+
+#   # do we need to rebuild outer matrix layer?
+#   if not IsMutable(matrix) # matrix was immutable
+#     or (IsMutable(matrix) and not change) # matrix was mutable
+#     or (Length(ind2)>0 and   # we want to change rows
+#       not IsMutable(matrix)) #but cannot change entries
+#     or (Is8BitMatrixRep(matrix) # matrix is be compact rep
+#        and (Length(ind)>0 or Length(ind2)>0) ) # and we change rows
+#        then
+#     l:=matrix;
+#     matrix:=[];
+#     for i in l do
+#       Add(matrix,i);
+#     od;
+#   fi;
+
+#   # rebuild some rows
+#   if big then
+#     for i in ind2 do
+#       matrix[i]:=List(matrix[i],j->j); # plist conversion
+#     od;
+#   else
+#     for i in ind2 do
+#       row := CopyToVectorRep(matrix[i], sf);
+#       if row <> fail then
+#         matrix[i] := row;
+#       fi;
+#     od;
+#   fi;
+
+#   # this can only happen if not big
+#   for i in ind do
+#     matrix[i]:=CopyToVectorRep(matrix[i],sf);
+#   od;
+
+#   MakeImmutable(matrix);
+#   if sf=2 and not IsGF2MatrixRep(matrix) then
+#     CONV_GF2MAT(matrix);
+#   elif sf>2 and sf<=256 and not Is8BitMatrixRep(matrix) then
+#     CONV_MAT8BIT(matrix,sf);
+#   fi;
+#   return matrix;
+# end;
 
 InstallMethod( ImmutableMatrix,"general,2",[IsObject,IsMatrix],0,
 function(f,m)

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1589,7 +1589,13 @@ end);
 #F  ImmutableMatrix( <field>, <matrix> [,<change>] ) 
 ##
 DoImmutableMatrix := function(field,matrix,change)
-    return `CopyToMatrixRep(matrix, field);
+    if not IsField(field) or Size(field) > 256 then
+        return Immutable(matrix);
+    else
+        
+        return `CopyToMatrixRep(matrix, field);
+    fi;
+    
 end;
 
 

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1386,93 +1386,122 @@ end);
 #F  CopyToVectorRep( <v>, <q> )
 ##
 InstallGlobalFunction(CopyToVectorRep,function( v, q )
-    local vc, common, field, res;
-
-    # Handle fast, certain cases where there is no work. Microseconds count here
+    local  primeAndDegree, pd, p, d, q1, pd1, p1, d1;
+    
+    primeAndDegree := function(q)
+        local  f;
+        f := FactorsInt(q);
+        return [f[1],Length(f)];
+    end;
+    
+    pd := primeAndDegree(q);
+    p := pd[1];
+    d := pd[2];
+    
     
     if Length(v) = 0 then
-        return v;
+        return ShallowCopy(v);
     fi;    
     
-    if IsGF2VectorRep(v) and q=2 then
-        if IsMutable(v) then
-          return(ShallowCopy(v));
+    if IsGF2VectorRep(v) then
+        if q = 2 then
+            return ShallowCopy(v);
+        elif q mod 2 = 0 then
+            if q <= 256 then
+                v := ShallowCopy(v);
+                CONV_VEC8BIT(v,q);
+                return v;
+            else
+                return PlainListCopy(v);
+            fi;
         else
-          return v;
-        fi;  
+            return fail;
+        fi;
     fi;
     
     if Is8BitVectorRep(v) then
-        if q = Q_VEC8BIT(v) then
-            if IsMutable(v) then
-                return(ShallowCopy(v));
-            else
-                return v;
-            fi; 
+        q1 := Q_VEC8BIT(v);
+        
+        if q = q1 then
+            return ShallowCopy(v);
         fi;
+        
+        pd1 := primeAndDegree(q1);
+        p1 := pd1[1];
+        d1 := pd1[2];
+        
+        if p <> p1 then
+            return fail;
+        fi;
+        if d mod d1 <> 0 and ForAny(v, x-> d mod DegreeFFE(x) <> 0) then
+            return fail;
+        fi;
+        
+        if q > 256 then
+            return PlainListCopy(v);
+        fi;
+        v := ShallowCopy(v);
+        if q = 2 then
+            CONV_GF2VEC(v);
+        else
+            CONV_VEC8BIT(v,q);
+        fi;
+        return v;
     fi;
     
-    # Ask the kernel to check the list for us.
-    # We have to do this, even in an NC version because the list might contain
-    # elements of large finite fields.
-    # Calling IS_VECFFE may force a full inspection of the list.
-        
-    if not IS_VECFFE(v) then
-        # TODO: no need of the next 'if' block in the NC-version
+    #
+    # So now we're left with the possibility that v is a plain list.
+    #
+    
+    #
+    # If it isn't a list of small finite field elements already then we 
+    # will need to see if we can write it as one.
+    #
+
+    v := ShallowCopy(v);
+    if  IS_VECFFE(v) then
+        q1 := COMMON_FIELD_VECFFE(v);
+        pd1 := primeAndDegree(q1);
+        p1 := pd1[1];
+        d1 := pd1[2];
+        if p1 <> p then
+            return fail;
+        fi;
+        if d mod d1 <> 0 and ForAny(v, x-> d mod DegreeFFE(x) <> 0) then
+            return fail;
+        fi;
+    else        
         if IsFFECollection(v) then
-            # Now we might have some elements in a large field representation
-            # or possibly a totally bad list. We will examine the shallow copy 
-            # of v to avoid side effects when CopyToVectorRep modifies v and 
-            # then returns fail 
-            vc := ShallowCopy(v);
-            common := FFECONWAY.WriteOverSmallestCommonField(vc);
+            #
+            # It contains some Conway field elements
+            #
+            q1 := FFECONWAY.WriteOverSmallestCommonField(v);
             #
             # FFECONWAY.WriteOverSmallestCommonField returns an integer or fail.
-            # When it resturns an integer, it may modify individual entries of vc
+            # When it resturns an integer, it may modify individual entries of v
             #
-            if common = fail or common  > 256 then
-                #
-                # vector needs a field > 256, so can't be compressed
-                # or vector contains non-ffes or no common characteristic
-                #
-                return fail; # v can not be written over GF(q)
+            if q1 = fail  then
+                return fail; # v can not be written over any finite field
             fi;
-            # CLONE_OBJ(v,vc); # commented out the hack used in in-place conversion
         else
-            return fail; # v can not be written over GF(q)
+            return fail; # v can not be written over any finite field
         fi;
-    else
-        common := COMMON_FIELD_VECFFE(v);
-        vc := v;
+        pd1 := primeAndDegree(q1);
+        p1 := pd1[1];
+        d1 := pd1[2];
+        if p <> p1 or d mod d1 <> 0 then
+            return fail;
+        fi;
     fi;
-    
     if q = 2 then
-        Assert(2, ForAll(vc, elm -> elm in GF(2)));
-        if common > 2 and common mod 2 = 0 then
-            common := SMALLEST_FIELD_VECFFE(vc);
-        fi;
-        if common <> 2 then
-            Error("CopyToVectorRep: Vector cannot be written over GF(2)");
-        fi;
-        res := COPY_GF2VEC(vc);
-        if not IsMutable(v) then MakeImmutable(res); fi;
-        return res;
+        CONV_GF2VEC(v);
     elif q <= 256 then
-        if common <> q then 
-            Assert(2, ForAll(vc, elm -> elm in GF(q)));
-            if IsPlistRep(vc) and  GcdInt(common,q) > 1  then
-                common := SMALLEST_FIELD_VECFFE(vc);
-            fi;
-            if common ^ LogInt(q, common) <> q then
-                Error("CopyToVectorRep: Vector cannot be written over GF(",q,")");
-            fi;
-        fi;
-        res := COPY_VEC8BIT(vc,q);
-        if not IsMutable(v) then MakeImmutable(res); fi;
-        return res;
-    else    
-        return fail; # vector can not be written over GF(q)
+        CONV_VEC8BIT(v,q);
+    elif not IsPlistRep(v) then
+        v := PlainListCopy(v);
     fi;
+
+    return v;
 end);
 
 
@@ -1485,71 +1514,62 @@ end);
 ##  finite field, and all elements of v lie in this field. 
 ##
 InstallGlobalFunction(CopyToVectorRepNC,function( v, q )
-    local common, field, res;
-
-    # Handle fast, certain cases where there is no work. Microseconds count here
+    local q1;
+    
+    Assert(1, q <= 256);
+    Assert(2, ForAll(v, x-> x in GF(q)));
+    
     
     if Length(v) = 0 then
+        return ShallowCopy(v);
+    fi;    
+    
+    if IsGF2VectorRep(v) then
+        v := ShallowCopy(v);
+        if q > 2 then
+            CONV_VEC8BIT(v,q);
+        fi;
+        return v;
+    fi;
+        
+    if Is8BitVectorRep(v) then
+        q1 := Q_VEC8BIT(v);
+        v := ShallowCopy(v);
+        if q = 2 then
+            CONV_GF2VEC(v);
+        elif q <> q1 then
+            CONV_VEC8BIT(v,q);
+        fi;
         return v;
     fi;
     
-    if IsGF2VectorRep(v) and q=2 then
-        if IsMutable(v) then
-          return(ShallowCopy(v));
-        else
-          return v;
-        fi;  
-    fi;
+    #
+    # So now we're left with the possibility that v is a plain list.
+    #
     
-    if Is8BitVectorRep(v) then
-        if q = Q_VEC8BIT(v) then
-            if IsMutable(v) then
-                return(ShallowCopy(v));
-            else
-                return v;
-            fi; 
-        fi;
+    #
+    # If it isn't a list of small finite field elements already then we 
+    # will need to  write it as one.
+    #
+
+    v := ShallowCopy(v);
+    if not IS_VECFFE(v) then
+        #
+        # It contains some Conway field elements
+        #
+        FFECONWAY.WriteOverSmallestCommonField(v);
     fi;
-    
-    # Calling COMMON_FIELD_VECFFE may force a full inspection of the list.
-    common := COMMON_FIELD_VECFFE(v);
-    if common = fail then
-        common := SMALLEST_FIELD_VECFFE(v);
-        if common = fail then
-            Error("CopyToVectorRepNC: Vector cannot be written over GF(",q,").\n",
-                  "You may try to use CopyToVectorRep instead\n");
-        fi;
-        
-    fi;
-    
+    Assert(2, IS_VECFFE(v));
     if q = 2 then
-        Assert(2, ForAll(v, elm -> elm in GF(2)));
-        if common > 2 and common mod 2 = 0 then
-            common := SMALLEST_FIELD_VECFFE(v);
-        fi;
-        if common <> 2 then
-            Error("ConvertToVectorRepNC: Vector cannot be written over GF(2)");
-        fi;
-        res := COPY_GF2VEC(v);
-        if not IsMutable(v) then MakeImmutable(res); fi;
-        return res;
+        CONV_GF2VEC(v);
     elif q <= 256 then
-        if common <> q then 
-            Assert(2, ForAll(v, elm -> elm in GF(q)));
-            if IsPlistRep(v) and  GcdInt(common,q) > 1  then
-                common := SMALLEST_FIELD_VECFFE(v);
-            fi;
-            if common ^ LogInt(q, common) <> q then
-                Error("ConvertToVectorRepNC: Vector cannot be written over GF(",q,")");
-            fi;
-        fi;
-        res :=COPY_VEC8BIT(v,q);
-        if not IsMutable(v) then MakeImmutable(res); fi;
-        return res;
-    else    
-        Error("ConvertToVectorRepNC: Vector cannot be written over GF(",q,")");
+        CONV_VEC8BIT(v,q);
+    elif not IsPlistRep(v) then
+        v := PlainListCopy(v);
     fi;
+    return v;
 end);
+
 
 
 #############################################################################

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1589,13 +1589,7 @@ end);
 #F  ImmutableMatrix( <field>, <matrix> [,<change>] ) 
 ##
 DoImmutableMatrix := function(field,matrix,change)
-    if not IsField(field) or Size(field) > 256 then
-        return Immutable(matrix);
-    else
-        
-        return `CopyToMatrixRep(matrix, field);
-    fi;
-    
+    return `CopyToMatrixRep(matrix, field);
 end;
 
 

--- a/lib/vspcrow.gi
+++ b/lib/vspcrow.gi
@@ -649,8 +649,9 @@ InstallMethod( SemiEchelonBasis,
       SetIsRectangularTable( B, true );
     fi;
     SetUnderlyingLeftModule( B, V );
-    gensi := Immutable(gens);
-    ConvertToMatrixRep(gensi, LeftActingDomain(V));
+    gensi := CopyToMatrixRep(gens, LeftActingDomain(V));
+    MakeImmutable(gensi);
+    
     SetBasisVectors( B, gensi );
 
     B!.heads:= heads;
@@ -685,8 +686,8 @@ InstallMethod( SemiEchelonBasisNC,
       SetIsRectangularTable( B, true );
     fi;
     SetUnderlyingLeftModule( B, V );
-    gensi := Immutable(gens);
-    ConvertToMatrixRep(gensi, LeftActingDomain(V));
+    gensi := CopyToMatrixRep(gens, LeftActingDomain(V));
+    MakeImmutable(gensi);
     SetBasisVectors( B, gens );
 
     # Provide the `heads' information.

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -797,6 +797,9 @@ void ConvVec8Bit (
     /* already in the correct representation                               */
     if (IS_VEC8BIT_REP(list) && FIELD_VEC8BIT(list) == q) 
             return;
+
+    if (REGION(list) == 0)
+      ErrorMayQuit("CONV_VEC8BIT: In-place conversion of object in the public region",0L,0L);
     
     if (IS_VEC8BIT_REP(list) && FIELD_VEC8BIT(list) < q) {
       RewriteVec8Bit(list, q);
@@ -1538,7 +1541,8 @@ Obj FuncPROD_VEC8BIT_FFE( Obj self, Obj vec, Obj ffe)
 	  CALL_1ARGS(ConvertToVectorRep, prod);
 	else {
 	  q = ChooseFieldVecFFE(prod);
-	  if (q && q <= 256) {
+
+	  if (q) {
 	    prod = CALL_2ARGS(CopyToVectorRep,prod,INTOBJ_INT(q));
 	    MakeImmutable(prod);
 	  }

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -797,9 +797,6 @@ void ConvVec8Bit (
     /* already in the correct representation                               */
     if (IS_VEC8BIT_REP(list) && FIELD_VEC8BIT(list) == q) 
             return;
-
-    if (REGION(list) == 0)
-      ErrorMayQuit("CONV_VEC8BIT: In-place conversion of object in the public region",0L,0L);
     
     if (IS_VEC8BIT_REP(list) && FIELD_VEC8BIT(list) < q) {
       RewriteVec8Bit(list, q);
@@ -1541,8 +1538,7 @@ Obj FuncPROD_VEC8BIT_FFE( Obj self, Obj vec, Obj ffe)
 	  CALL_1ARGS(ConvertToVectorRep, prod);
 	else {
 	  q = ChooseFieldVecFFE(prod);
-
-	  if (q) {
+	  if (q && q <= 256) {
 	    prod = CALL_2ARGS(CopyToVectorRep,prod,INTOBJ_INT(q));
 	    MakeImmutable(prod);
 	  }

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -1122,7 +1122,7 @@ UInt ChooseFieldVecFFE(Obj vec) {
 Obj FuncSMALLEST_FIELD_VECFFE( Obj self, Obj vec)
 {
   UInt smallest = SmallestFieldVecFFE(vec);
-  return smallest ? INTOBJ_INT(smallest) : 0;
+  return smallest ? INTOBJ_INT(smallest) : Fail;
 }
 
 /****************************************************************************

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -1070,32 +1070,38 @@ Obj FuncIS_VECFFE( Obj self, Obj vec)
     return IsVecFFE(vec) ? True : False;
 }
 
-Obj FuncCOMMON_FIELD_VECFFE( Obj self, Obj vec)
-{
+
+UInt CommonFieldVecFFE(Obj vec) {
     Obj elm;
     if (!IsVecFFE(vec))
-        return Fail;
+        return 0;
     elm = ELM_PLIST(vec, 1);
-    return INTOBJ_INT(SIZE_FF(FLD_FFE(elm)));
+    return SIZE_FF(FLD_FFE(elm));
 }
 
-Obj FuncSMALLEST_FIELD_VECFFE( Obj self, Obj vec)
+
+Obj FuncCOMMON_FIELD_VECFFE( Obj self, Obj vec)
 {
+  UInt common = CommonFieldVecFFE(vec);
+  return common ? INTOBJ_INT(common) : Fail;
+}
+
+UInt SmallestFieldVecFFE(Obj vec) {
     Obj elm;
     UInt deg, deg1, deg2, i, len, p, q;
     UInt isVecFFE = IsVecFFE(vec);
     len  = LEN_PLIST(vec);
     if (len == 0)
-        return Fail;
+        return 0;
     elm = ELM_PLIST(vec, 1);
     if (!isVecFFE && !IS_FFE(elm))
-        return Fail;
+        return 0;
     deg = DegreeFFE(elm);
     p = CharFFE(elm);
     for (i = 2; i <= len; i++) {
         elm = ELM_PLIST(vec, i);
         if (!isVecFFE && (!IS_FFE(elm) || CharFFE(elm) != p))
-            return Fail;
+            return 0;
         deg2 =  DegreeFFE(elm);
         deg1 = deg;
         while (deg % deg2 != 0)
@@ -1104,7 +1110,19 @@ Obj FuncSMALLEST_FIELD_VECFFE( Obj self, Obj vec)
     q = p;
     for (i = 2; i <= deg; i++)
         q *= p;
-    return INTOBJ_INT(q);
+    return q;
+}
+
+UInt ChooseFieldVecFFE(Obj vec) {
+  UInt common = CommonFieldVecFFE(vec);
+  return common ? common : SmallestFieldVecFFE(vec);
+}
+  
+
+Obj FuncSMALLEST_FIELD_VECFFE( Obj self, Obj vec)
+{
+  UInt smallest = SmallestFieldVecFFE(vec);
+  return smallest ? INTOBJ_INT(smallest) : 0;
 }
 
 /****************************************************************************

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1608,6 +1608,15 @@ void ConvGF2Vec (
         return;
     }
 
+    /* fail now if the object is in the public region. If it's shared
+       and we don't have write access, or it's readonly we will fail
+       later anyway, but any obect in the public region is a
+       problem here */
+
+    if (REGION(list) == 0) 
+      ErrorMayQuit("In place format conversion on object in the public region",0L,0L);
+    
+    
     /* Otherwise make it a plain list so that we will know where it keeps
        its data -- could do much better in the case of GF(2^n) vectors that actually
        lie over GF(2) */
@@ -1782,6 +1791,8 @@ Obj FuncCONV_GF2MAT( Obj self, Obj list)
   len = LEN_LIST(list);
   if (len == 0)
     return (Obj)0;
+  if (!REGION(list))
+    ErrorMayQuit("CONV_GF2MAT: in-place conversion of object in the public region",0L,0L);
   
   PLAIN_LIST(list);
   GROW_PLIST(list, len+1);

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1616,6 +1616,15 @@ void ConvGF2Vec (
         return;
     }
 
+    /* fail now if the object is in the public region. If it's shared
+       and we don't have write access, or it's readonly we will fail
+       later anyway, but any obect in the public region is a
+       problem here */
+
+    if (REGION(list) == 0) 
+      ErrorMayQuit("In place format conversion on object in the public region",0L,0L);
+    
+    
     /* Otherwise make it a plain list so that we will know where it keeps
        its data -- could do much better in the case of GF(2^n) vectors that actually
        lie over GF(2) */

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1603,20 +1603,19 @@ void ConvGF2Vec (
     UInt                bit;            /* one bit of a block              */
     Obj                 x;
         
-    /* already in the correct representation                               */
-    if ( IS_GF2VEC_REP(list) ) {
-        return;
-    }
-
     /* fail now if the object is in the public region. If it's shared
        and we don't have write access, or it's readonly we will fail
        later anyway, but any obect in the public region is a
        problem here */
 
     if (REGION(list) == 0) 
-      ErrorMayQuit("In place format conversion on object in the public region",0L,0L);
-    
-    
+      ErrorMayQuit("CONV_GF2VEC: In place format conversion on object in the public region",0L,0L);
+
+    /* already in the correct representation                               */
+    if ( IS_GF2VEC_REP(list) ) {
+        return;
+    }
+
     /* Otherwise make it a plain list so that we will know where it keeps
        its data -- could do much better in the case of GF(2^n) vectors that actually
        lie over GF(2) */

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1616,15 +1616,6 @@ void ConvGF2Vec (
         return;
     }
 
-    /* fail now if the object is in the public region. If it's shared
-       and we don't have write access, or it's readonly we will fail
-       later anyway, but any obect in the public region is a
-       problem here */
-
-    if (REGION(list) == 0) 
-      ErrorMayQuit("In place format conversion on object in the public region",0L,0L);
-    
-    
     /* Otherwise make it a plain list so that we will know where it keeps
        its data -- could do much better in the case of GF(2^n) vectors that actually
        lie over GF(2) */


### PR DESCRIPTION
This PR is based on having the kernel ban in-place compressed matrix and vector conversions on objects in the atomic region. Quite a lot of library changes were needed to cope with this, as well as one change to autpgrp. Mainly code like

MakeImmutable(m);
ConvertToMatrixRep(m);

simply needs the two lines swapped. 

In the process I made a number of cleanups to the ffeconway code (using atomic positional objects) and also add a PostMakeImmutable for compressed matrices so that immutable compressed matrices are readonly (they are non-atomic positional objects).