### PR TITLE
WIP: Avoid the use of NEW_TYPE_READONLY

### DIFF
--- a/etc/dbgmacro.py
+++ b/etc/dbgmacro.py
@@ -35,7 +35,6 @@ def emit_redef(return_type, name, arg_types):
   emit("")
   emit("#ifdef " + name)
   emit("")
-  emit("static inline")
   emit(return_type + "DBG_" + name + "(" + ", ".join(args) + ")")
   emit("{")
   if len(args):

--- a/lib/type1.g
+++ b/lib/type1.g
@@ -1089,7 +1089,7 @@ BIND_GLOBAL( "ObjectifyWithAttributes", function (arg)
             Objectify( NEW_TYPE(TypeOfTypes, 
                     FamilyType(type), 
                     flags , 
-                    DataType(type)), obj, fail);
+                    DataType(type), fail), obj);
         else
             Objectify( type, obj );
         fi;

--- a/lib/type1.g
+++ b/lib/type1.g
@@ -211,14 +211,14 @@ ASS_GVAR(_NEW_TYPE_READONLY, true);
 MakeThreadLocal(_NEW_TYPE_READONLY);
 
 
-BIND_GLOBAL("ConstructExtendedType", function(body)
-    local type, save_flag;
-    save_flag := VAL_GVAR(_NEW_TYPE_READONLY);
-    ASS_GVAR(_NEW_TYPE_READONLY, false);
-    type := body();
-    ASS_GVAR(_NEW_TYPE_READONLY, save_flag);
-    return MakeReadOnlyObj(type);
-end);
+# BIND_GLOBAL("ConstructExtendedType", function(body)
+#     local type, save_flag;
+#     save_flag := VAL_GVAR(_NEW_TYPE_READONLY);
+#     ASS_GVAR(_NEW_TYPE_READONLY, false);
+#     type := body();
+#     ASS_GVAR(_NEW_TYPE_READONLY, save_flag);
+#     return MakeReadOnlyObj(type);
+# end);
 
 BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data, parent)
     local   lock, hash,  cache,  cached,  type, ncache, ncl, t,i;
@@ -258,7 +258,7 @@ BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data, parent)
     type[POS_DATA_TYPE] := MakeReadOnly(data);
     type[POS_NUMB_TYPE] := NEW_TYPE_NEXT_ID;
     
-    if IS_IDENTICAL_OBJ(parent,fail) then
+    if not IS_IDENTICAL_OBJ(parent,fail) then
         for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ] do
             if IsBound( parent![i] ) and not IsBound(type[i]) then
                 type[i] := parent![i];

--- a/lib/type1.g
+++ b/lib/type1.g
@@ -220,8 +220,8 @@ BIND_GLOBAL("ConstructExtendedType", function(body)
     return MakeReadOnlyObj(type);
 end);
 
-BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data )
-    local   lock, hash,  cache,  cached,  type, ncache, ncl, t;
+BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data, parent)
+    local   lock, hash,  cache,  cached,  type, ncache, ncl, t,i;
 
     # maybe it is in the type cache
     lock := WRITE_LOCK(DS_TYPE_CACHE);
@@ -257,6 +257,17 @@ BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data )
     type := [ family, flags ];
     type[POS_DATA_TYPE] := MakeReadOnly(data);
     type[POS_NUMB_TYPE] := NEW_TYPE_NEXT_ID;
+    
+    if IS_IDENTICAL_OBJ(parent,fail) then
+        for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ] do
+            if IsBound( parent![i] ) and not IsBound(type[i]) then
+                type[i] := parent![i];
+            fi;
+        od;
+    fi;
+    
+            
+
 
     SET_TYPE_POSOBJ( type, typeOfTypes );
     
@@ -288,7 +299,7 @@ BIND_GLOBAL( "NewType2", function ( typeOfTypes, family )
     return NEW_TYPE( typeOfTypes,
                      family,
                      family!.IMP_FLAGS,
-                     fail );
+                     fail, fail );
 end );
 
 
@@ -298,7 +309,7 @@ BIND_GLOBAL( "NewType3", function ( typeOfTypes, family, filter )
                      WITH_IMPS_FLAGS( AND_FLAGS(
                         family!.IMP_FLAGS,
                         FLAGS_FILTER(filter) ) ),
-                     fail );
+                     fail, fail );
 end );
 
 
@@ -308,20 +319,25 @@ BIND_GLOBAL( "NewType4", function ( typeOfTypes, family, filter, data )
                      WITH_IMPS_FLAGS( AND_FLAGS(
                         family!.IMP_FLAGS,
                         FLAGS_FILTER(filter) ) ),
-                     data );
+                     data, fail );
 end );
 
 
 BIND_GLOBAL( "NewType5",
     function ( typeOfTypes, family, filter, data, stuff )
-    local   type;
+    local   type, temp;
+    #
+    # temp is a fake type
+    #
+    temp := [];
+    temp[POS_FIRST_FREE_TYPE] := stuff;
     type := NEW_TYPE( typeOfTypes,
                       family,
                       WITH_IMPS_FLAGS( AND_FLAGS(
                          family!.IMP_FLAGS,
                          FLAGS_FILTER(filter) ) ),
-                      data );
-    type![ POS_FIRST_FREE_TYPE ] := stuff;
+                      data, temp );
+#    type![ POS_FIRST_FREE_TYPE ] := stuff;
 #T really ??
     return type;
 end );
@@ -374,42 +390,43 @@ end );
 ##
 BIND_GLOBAL( "Subtype2", function ( type, filter )
     local   new, i, save_flag;
-    save_flag := VAL_GVAR(_NEW_TYPE_READONLY);
-    ASS_GVAR(_NEW_TYPE_READONLY, false);
+#    save_flag := VAL_GVAR(_NEW_TYPE_READONLY);
+#    ASS_GVAR(_NEW_TYPE_READONLY, false);
     new := NEW_TYPE( TypeOfTypes,
                      type![1],
                      WITH_IMPS_FLAGS( AND_FLAGS(
                         type![2],
                         FLAGS_FILTER( filter ) ) ),
-                     type![ POS_DATA_TYPE ] );
-    for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do
-        if IsBound( type![i] ) and not IsBound(new![i]) then
-            new![i] := type![i];
-        fi;
-    od;
-    MakeReadOnlyObj(new);
-    ASS_GVAR(_NEW_TYPE_READONLY, save_flag);
+                     type![ POS_DATA_TYPE ], type );
+    # for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do
+    #     if IsBound( type![i] ) and not IsBound(new![i]) then
+    #         new![i] := type![i];
+    #     fi;
+    # od;
+    # MakeReadOnlyObj(new);
+    # ASS_GVAR(_NEW_TYPE_READONLY, save_flag);
     return new;
 end );
 
 
 BIND_GLOBAL( "Subtype3", function ( type, filter, data )
     local   new, i, save_flag;
-    save_flag := VAL_GVAR(_NEW_TYPE_READONLY);
-    ASS_GVAR(_NEW_TYPE_READONLY, false);
+
+#    save_flag := VAL_GVAR(_NEW_TYPE_READONLY);
+#    ASS_GVAR(_NEW_TYPE_READONLY, false);
     new := NEW_TYPE( TypeOfTypes,
                      type![1],
                      WITH_IMPS_FLAGS( AND_FLAGS(
                         type![2],
                         FLAGS_FILTER( filter ) ) ),
-                     data );
-    for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do
-        if IsBound( type![i] ) and not IsBound(new![i]) then
-            new![i] := type![i];
-        fi;
-    od;
-    MakeReadOnlyObj(new);
-    ASS_GVAR(_NEW_TYPE_READONLY, save_flag);
+                     data , type);
+    # for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do
+    #     if IsBound( type![i] ) and not IsBound(new![i]) then
+    #         new![i] := type![i];
+    #     fi;
+    # od;
+    # MakeReadOnlyObj(new);
+    # ASS_GVAR(_NEW_TYPE_READONLY, save_flag);
     return new;
 end );
 
@@ -451,12 +468,12 @@ BIND_GLOBAL( "SupType2", function ( type, filter )
                      SUB_FLAGS(
                         type![2],
                         FLAGS_FILTER( filter ) ),
-                     type![ POS_DATA_TYPE ] );
-    for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do
-        if IsBound( type![i] ) then
-            new![i] := type![i];
-        fi;
-    od;
+                     type![ POS_DATA_TYPE ], type );
+    # for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do
+    #     if IsBound( type![i] ) then
+    #         new![i] := type![i];
+    #     fi;
+    # od;
     return new;
 end );
 
@@ -468,12 +485,12 @@ BIND_GLOBAL( "SupType3", function ( type, filter, data )
                      SUB_FLAGS(
                         type![2],
                         FLAGS_FILTER( filter ) ),
-                     data );
-    for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do
-        if IsBound( type![i] ) then
-            new![i] := type![i];
-        fi;
-    od;
+                     data, type );
+    # for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do
+    #     if IsBound( type![i] ) then
+    #         new![i] := type![i];
+    #     fi;
+    # od;
     return new;
 end );
 
@@ -1072,7 +1089,7 @@ BIND_GLOBAL( "ObjectifyWithAttributes", function (arg)
             Objectify( NEW_TYPE(TypeOfTypes, 
                     FamilyType(type), 
                     flags , 
-                    DataType(type)), obj);
+                    DataType(type)), obj, fail);
         else
             Objectify( type, obj );
         fi;

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -174,10 +174,10 @@ static GVar G_FLUSH__ALL__METHOD__CACHES;
 static Obj  GF_FLUSH__ALL__METHOD__CACHES;
 static GVar G_POS__NUMB__TYPE;
 static Obj  GC_POS__NUMB__TYPE;
-static GVar G_NEW__TYPE;
-static Obj  GF_NEW__TYPE;
 static GVar G_POS__FIRST__FREE__TYPE;
 static Obj  GC_POS__FIRST__FREE__TYPE;
+static GVar G_NEW__TYPE;
+static Obj  GF_NEW__TYPE;
 static GVar G_IsFamily;
 static Obj  GF_IsFamily;
 static GVar G_NewType2;
@@ -258,9 +258,9 @@ static RNam R_nTYPES;
 static RNam R_HASH__SIZE;
 
 /* information for the functions */
-static Obj  NameFunc[40];
-static Obj  NamsFunc[40];
-static Int  NargFunc[40];
+static Obj  NameFunc[39];
+static Obj  NamsFunc[39];
+static Int  NargFunc[39];
 static Obj  DefaultName;
 static Obj FileName;
 
@@ -997,69 +997,11 @@ static Obj  HdlrFunc10 (
 /* handler for function 11 */
 static Obj  HdlrFunc11 (
  Obj  self,
- Obj  a_body )
-{
- Obj l_type = 0;
- Obj l_save__flag = 0;
- Obj t_1 = 0;
- Obj t_2 = 0;
- Obj t_3 = 0;
- Bag oldFrame;
- OLD_BRK_CURR_STAT
- 
- /* allocate new stack frame */
- SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
- 
- /* save_flag := VAL_GVAR( _NEW_TYPE_READONLY ); */
- t_2 = GF_VAL__GVAR;
- t_3 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_3, "_NEW_TYPE_READONLY" )
- t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
- l_save__flag = t_1;
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, false ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- t_3 = False;
- CALL_2ARGS( t_1, t_2, t_3 );
- 
- /* type := body(  ); */
- CHECK_FUNC( a_body )
- t_1 = CALL_0ARGS( a_body );
- CHECK_FUNC_RESULT( t_1 )
- l_type = t_1;
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, save_flag ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- CALL_2ARGS( t_1, t_2, l_save__flag );
- 
- /* return MakeReadOnlyObj( type ); */
- t_2 = GF_MakeReadOnlyObj;
- t_1 = CALL_1ARGS( t_2, l_type );
- CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
- SWITCH_TO_OLD_FRAME(oldFrame);
- return t_1;
- 
- /* return; */
- RES_BRK_CURR_STAT();
- SWITCH_TO_OLD_FRAME(oldFrame);
- return 0;
-}
-
-/* handler for function 12 */
-static Obj  HdlrFunc12 (
- Obj  self,
  Obj  a_typeOfTypes,
  Obj  a_family,
  Obj  a_flags,
- Obj  a_data )
+ Obj  a_data,
+ Obj  a_parent )
 {
  Obj l_lock = 0;
  Obj l_hash = 0;
@@ -1069,6 +1011,7 @@ static Obj  HdlrFunc12 (
  Obj l_ncache = 0;
  Obj l_ncl = 0;
  Obj l_t = 0;
+ Obj l_i = 0;
  Obj t_1 = 0;
  Obj t_2 = 0;
  Obj t_3 = 0;
@@ -1272,6 +1215,64 @@ static Obj  HdlrFunc12 (
  CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
  C_ASS_LIST_FPL( l_type, t_1, t_2 )
  
+ /* if not IS_IDENTICAL_OBJ( parent, fail ) then */
+ t_4 = GF_IS__IDENTICAL__OBJ;
+ t_5 = GC_fail;
+ CHECK_BOUND( t_5, "fail" )
+ t_3 = CALL_2ARGS( t_4, a_parent, t_5 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
+ t_2 = (Obj)(UInt)(t_3 != False);
+ t_1 = (Obj)(UInt)( ! ((Int)t_2) );
+ if ( t_1 ) {
+  
+  /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ] do */
+  t_2 = GC_POS__FIRST__FREE__TYPE;
+  CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
+  CHECK_INT_SMALL( t_2 )
+  t_4 = GF_LEN__POSOBJ;
+  t_3 = CALL_1ARGS( t_4, a_parent );
+  CHECK_FUNC_RESULT( t_3 )
+  CHECK_INT_SMALL( t_3 )
+  for ( t_1 = t_2;
+        ((Int)t_1) <= ((Int)t_3);
+        t_1 = (Obj)(((UInt)t_1)+4) ) {
+   l_i = t_1;
+   
+   /* if IsBound( parent![i]) and not IsBound( type[i] ) then */
+   CHECK_INT_SMALL_POS( l_i )
+   if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
+    t_6 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
+       && ELM_PLIST(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False);
+   } else if ( TNUM_OBJ(a_parent) == T_APOSOBJ ) {
+    t_6 = Elm0AList(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False;
+   }
+   else {
+    t_6 = (ISB_LIST( a_parent, INT_INTOBJ(l_i) ) ? True : False);
+   }
+   t_5 = (Obj)(UInt)(t_6 != False);
+   t_4 = t_5;
+   if ( t_4 ) {
+    t_8 = C_ISB_LIST( l_type, l_i );
+    t_7 = (Obj)(UInt)(t_8 != False);
+    t_6 = (Obj)(UInt)( ! ((Int)t_7) );
+    t_4 = t_6;
+   }
+   if ( t_4 ) {
+    
+    /* type[i] := parent![i]; */
+    C_ELM_POSOBJ_NLE( t_4, a_parent, INT_INTOBJ(l_i) );
+    C_ASS_LIST_FPL( l_type, l_i, t_4 )
+    
+   }
+   /* fi */
+   
+  }
+  /* od */
+  
+ }
+ /* fi */
+ 
  /* SET_TYPE_POSOBJ( type, typeOfTypes ); */
  t_1 = GF_SET__TYPE__POSOBJ;
  CALL_2ARGS( t_1, l_type, a_typeOfTypes );
@@ -1447,8 +1448,8 @@ static Obj  HdlrFunc12 (
  return 0;
 }
 
-/* handler for function 13 */
-static Obj  HdlrFunc13 (
+/* handler for function 12 */
+static Obj  HdlrFunc12 (
  Obj  self,
  Obj  a_typeOfTypes,
  Obj  a_family )
@@ -1457,6 +1458,7 @@ static Obj  HdlrFunc13 (
  Obj t_2 = 0;
  Obj t_3 = 0;
  Obj t_4 = 0;
+ Obj t_5 = 0;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
  
@@ -1465,7 +1467,7 @@ static Obj  HdlrFunc13 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* return NEW_TYPE( typeOfTypes, family, family!.IMP_FLAGS, fail ); */
+ /* return NEW_TYPE( typeOfTypes, family, family!.IMP_FLAGS, fail, fail ); */
  t_2 = GF_NEW__TYPE;
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   t_3 = ElmPRec( a_family, R_IMP__FLAGS );
@@ -1477,7 +1479,9 @@ static Obj  HdlrFunc13 (
  }
  t_4 = GC_fail;
  CHECK_BOUND( t_4, "fail" )
- t_1 = CALL_4ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4 );
+ t_5 = GC_fail;
+ CHECK_BOUND( t_5, "fail" )
+ t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
  CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1489,8 +1493,8 @@ static Obj  HdlrFunc13 (
  return 0;
 }
 
-/* handler for function 14 */
-static Obj  HdlrFunc14 (
+/* handler for function 13 */
+static Obj  HdlrFunc13 (
  Obj  self,
  Obj  a_typeOfTypes,
  Obj  a_family,
@@ -1513,7 +1517,7 @@ static Obj  HdlrFunc14 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail ); */
+ /* return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail, fail ); */
  t_2 = GF_NEW__TYPE;
  t_4 = GF_WITH__IMPS__FLAGS;
  t_6 = GF_AND__FLAGS;
@@ -1534,7 +1538,9 @@ static Obj  HdlrFunc14 (
  CHECK_FUNC_RESULT( t_3 )
  t_4 = GC_fail;
  CHECK_BOUND( t_4, "fail" )
- t_1 = CALL_4ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4 );
+ t_5 = GC_fail;
+ CHECK_BOUND( t_5, "fail" )
+ t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
  CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1546,8 +1552,8 @@ static Obj  HdlrFunc14 (
  return 0;
 }
 
-/* handler for function 15 */
-static Obj  HdlrFunc15 (
+/* handler for function 14 */
+static Obj  HdlrFunc14 (
  Obj  self,
  Obj  a_typeOfTypes,
  Obj  a_family,
@@ -1571,7 +1577,7 @@ static Obj  HdlrFunc15 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data ); */
+ /* return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, fail ); */
  t_2 = GF_NEW__TYPE;
  t_4 = GF_WITH__IMPS__FLAGS;
  t_6 = GF_AND__FLAGS;
@@ -1590,7 +1596,9 @@ static Obj  HdlrFunc15 (
  CHECK_FUNC_RESULT( t_5 )
  t_3 = CALL_1ARGS( t_4, t_5 );
  CHECK_FUNC_RESULT( t_3 )
- t_1 = CALL_4ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data );
+ t_4 = GC_fail;
+ CHECK_BOUND( t_4, "fail" )
+ t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, t_4 );
  CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1602,8 +1610,8 @@ static Obj  HdlrFunc15 (
  return 0;
 }
 
-/* handler for function 16 */
-static Obj  HdlrFunc16 (
+/* handler for function 15 */
+static Obj  HdlrFunc15 (
  Obj  self,
  Obj  a_typeOfTypes,
  Obj  a_family,
@@ -1612,6 +1620,7 @@ static Obj  HdlrFunc16 (
  Obj  a_stuff )
 {
  Obj l_type = 0;
+ Obj l_temp = 0;
  Obj t_1 = 0;
  Obj t_2 = 0;
  Obj t_3 = 0;
@@ -1629,7 +1638,18 @@ static Obj  HdlrFunc16 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* type := NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data ); */
+ /* temp := [  ]; */
+ t_1 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_1, 0 );
+ l_temp = t_1;
+ 
+ /* temp[POS_FIRST_FREE_TYPE] := stuff; */
+ t_1 = GC_POS__FIRST__FREE__TYPE;
+ CHECK_BOUND( t_1, "POS_FIRST_FREE_TYPE" )
+ CHECK_INT_POS( t_1 )
+ C_ASS_LIST_FPL( l_temp, t_1, a_stuff )
+ 
+ /* type := NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, temp ); */
  t_2 = GF_NEW__TYPE;
  t_4 = GF_WITH__IMPS__FLAGS;
  t_6 = GF_AND__FLAGS;
@@ -1648,15 +1668,9 @@ static Obj  HdlrFunc16 (
  CHECK_FUNC_RESULT( t_5 )
  t_3 = CALL_1ARGS( t_4, t_5 );
  CHECK_FUNC_RESULT( t_3 )
- t_1 = CALL_4ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data );
+ t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, l_temp );
  CHECK_FUNC_RESULT( t_1 )
  l_type = t_1;
- 
- /* type![POS_FIRST_FREE_TYPE] := stuff; */
- t_1 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_1, "POS_FIRST_FREE_TYPE" )
- CHECK_INT_SMALL_POS( t_1 )
- C_ASS_POSOBJ( l_type, INT_INTOBJ(t_1), a_stuff )
  
  /* return type; */
  RES_BRK_CURR_STAT();
@@ -1669,8 +1683,8 @@ static Obj  HdlrFunc16 (
  return 0;
 }
 
-/* handler for function 17 */
-static Obj  HdlrFunc17 (
+/* handler for function 16 */
+static Obj  HdlrFunc16 (
  Obj  self,
  Obj  a_arg )
 {
@@ -1815,8 +1829,8 @@ static Obj  HdlrFunc17 (
  return 0;
 }
 
-/* handler for function 18 */
-static Obj  HdlrFunc18 (
+/* handler for function 17 */
+static Obj  HdlrFunc17 (
  Obj  self,
  Obj  a_type,
  Obj  a_filter )
@@ -1843,22 +1857,7 @@ static Obj  HdlrFunc18 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* save_flag := VAL_GVAR( _NEW_TYPE_READONLY ); */
- t_2 = GF_VAL__GVAR;
- t_3 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_3, "_NEW_TYPE_READONLY" )
- t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
- l_save__flag = t_1;
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, false ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- t_3 = False;
- CALL_2ARGS( t_1, t_2, t_3 );
- 
- /* new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![POS_DATA_TYPE] ); */
+ /* new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![POS_DATA_TYPE], type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
@@ -1877,71 +1876,9 @@ static Obj  HdlrFunc18 (
  CHECK_BOUND( t_7, "POS_DATA_TYPE" )
  CHECK_INT_SMALL_POS( t_7 )
  C_ELM_POSOBJ_NLE( t_6, a_type, INT_INTOBJ(t_7) );
- t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
+ t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
  CHECK_FUNC_RESULT( t_1 )
  l_new = t_1;
- 
- /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do */
- t_2 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
- CHECK_INT_SMALL( t_2 )
- t_4 = GF_LEN__POSOBJ;
- t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_INT_SMALL( t_3 )
- for ( t_1 = t_2;
-       ((Int)t_1) <= ((Int)t_3);
-       t_1 = (Obj)(((UInt)t_1)+4) ) {
-  l_i = t_1;
-  
-  /* if IsBound( type![i]) and not IsBound( new![i]) then */
-  CHECK_INT_SMALL_POS( l_i )
-  if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
-   t_6 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
-      && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
-  } else if ( TNUM_OBJ(a_type) == T_APOSOBJ ) {
-   t_6 = Elm0AList(a_type,INT_INTOBJ(l_i)) != 0 ? True : False;
-  }
-  else {
-   t_6 = (ISB_LIST( a_type, INT_INTOBJ(l_i) ) ? True : False);
-  }
-  t_5 = (Obj)(UInt)(t_6 != False);
-  t_4 = t_5;
-  if ( t_4 ) {
-   if ( TNUM_OBJ(l_new) == T_POSOBJ ) {
-    t_8 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_new)/sizeof(Obj)-1
-       && ELM_PLIST(l_new,INT_INTOBJ(l_i)) != 0 ? True : False);
-   } else if ( TNUM_OBJ(l_new) == T_APOSOBJ ) {
-    t_8 = Elm0AList(l_new,INT_INTOBJ(l_i)) != 0 ? True : False;
-   }
-   else {
-    t_8 = (ISB_LIST( l_new, INT_INTOBJ(l_i) ) ? True : False);
-   }
-   t_7 = (Obj)(UInt)(t_8 != False);
-   t_6 = (Obj)(UInt)( ! ((Int)t_7) );
-   t_4 = t_6;
-  }
-  if ( t_4 ) {
-   
-   /* new![i] := type![i]; */
-   C_ELM_POSOBJ_NLE( t_4, a_type, INT_INTOBJ(l_i) );
-   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 )
-   
-  }
-  /* fi */
-  
- }
- /* od */
- 
- /* MakeReadOnlyObj( new ); */
- t_1 = GF_MakeReadOnlyObj;
- CALL_1ARGS( t_1, l_new );
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, save_flag ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- CALL_2ARGS( t_1, t_2, l_save__flag );
  
  /* return new; */
  RES_BRK_CURR_STAT();
@@ -1954,8 +1891,8 @@ static Obj  HdlrFunc18 (
  return 0;
 }
 
-/* handler for function 19 */
-static Obj  HdlrFunc19 (
+/* handler for function 18 */
+static Obj  HdlrFunc18 (
  Obj  self,
  Obj  a_type,
  Obj  a_filter,
@@ -1983,22 +1920,7 @@ static Obj  HdlrFunc19 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* save_flag := VAL_GVAR( _NEW_TYPE_READONLY ); */
- t_2 = GF_VAL__GVAR;
- t_3 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_3, "_NEW_TYPE_READONLY" )
- t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
- l_save__flag = t_1;
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, false ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- t_3 = False;
- CALL_2ARGS( t_1, t_2, t_3 );
- 
- /* new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data ); */
+ /* new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
@@ -2013,71 +1935,9 @@ static Obj  HdlrFunc19 (
  CHECK_FUNC_RESULT( t_7 )
  t_5 = CALL_1ARGS( t_6, t_7 );
  CHECK_FUNC_RESULT( t_5 )
- t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, a_data );
+ t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
  CHECK_FUNC_RESULT( t_1 )
  l_new = t_1;
- 
- /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do */
- t_2 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
- CHECK_INT_SMALL( t_2 )
- t_4 = GF_LEN__POSOBJ;
- t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_INT_SMALL( t_3 )
- for ( t_1 = t_2;
-       ((Int)t_1) <= ((Int)t_3);
-       t_1 = (Obj)(((UInt)t_1)+4) ) {
-  l_i = t_1;
-  
-  /* if IsBound( type![i]) and not IsBound( new![i]) then */
-  CHECK_INT_SMALL_POS( l_i )
-  if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
-   t_6 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
-      && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
-  } else if ( TNUM_OBJ(a_type) == T_APOSOBJ ) {
-   t_6 = Elm0AList(a_type,INT_INTOBJ(l_i)) != 0 ? True : False;
-  }
-  else {
-   t_6 = (ISB_LIST( a_type, INT_INTOBJ(l_i) ) ? True : False);
-  }
-  t_5 = (Obj)(UInt)(t_6 != False);
-  t_4 = t_5;
-  if ( t_4 ) {
-   if ( TNUM_OBJ(l_new) == T_POSOBJ ) {
-    t_8 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_new)/sizeof(Obj)-1
-       && ELM_PLIST(l_new,INT_INTOBJ(l_i)) != 0 ? True : False);
-   } else if ( TNUM_OBJ(l_new) == T_APOSOBJ ) {
-    t_8 = Elm0AList(l_new,INT_INTOBJ(l_i)) != 0 ? True : False;
-   }
-   else {
-    t_8 = (ISB_LIST( l_new, INT_INTOBJ(l_i) ) ? True : False);
-   }
-   t_7 = (Obj)(UInt)(t_8 != False);
-   t_6 = (Obj)(UInt)( ! ((Int)t_7) );
-   t_4 = t_6;
-  }
-  if ( t_4 ) {
-   
-   /* new![i] := type![i]; */
-   C_ELM_POSOBJ_NLE( t_4, a_type, INT_INTOBJ(l_i) );
-   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 )
-   
-  }
-  /* fi */
-  
- }
- /* od */
- 
- /* MakeReadOnlyObj( new ); */
- t_1 = GF_MakeReadOnlyObj;
- CALL_1ARGS( t_1, l_new );
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, save_flag ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- CALL_2ARGS( t_1, t_2, l_save__flag );
  
  /* return new; */
  RES_BRK_CURR_STAT();
@@ -2090,8 +1950,8 @@ static Obj  HdlrFunc19 (
  return 0;
 }
 
-/* handler for function 20 */
-static Obj  HdlrFunc20 (
+/* handler for function 19 */
+static Obj  HdlrFunc19 (
  Obj  self,
  Obj  a_arg )
 {
@@ -2184,8 +2044,8 @@ static Obj  HdlrFunc20 (
  return 0;
 }
 
-/* handler for function 21 */
-static Obj  HdlrFunc21 (
+/* handler for function 20 */
+static Obj  HdlrFunc20 (
  Obj  self,
  Obj  a_type,
  Obj  a_filter )
@@ -2209,7 +2069,7 @@ static Obj  HdlrFunc21 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![POS_DATA_TYPE] ); */
+ /* new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![POS_DATA_TYPE], type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
@@ -2225,46 +2085,9 @@ static Obj  HdlrFunc21 (
  CHECK_BOUND( t_7, "POS_DATA_TYPE" )
  CHECK_INT_SMALL_POS( t_7 )
  C_ELM_POSOBJ_NLE( t_6, a_type, INT_INTOBJ(t_7) );
- t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
+ t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
  CHECK_FUNC_RESULT( t_1 )
  l_new = t_1;
- 
- /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do */
- t_2 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
- CHECK_INT_SMALL( t_2 )
- t_4 = GF_LEN__POSOBJ;
- t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_INT_SMALL( t_3 )
- for ( t_1 = t_2;
-       ((Int)t_1) <= ((Int)t_3);
-       t_1 = (Obj)(((UInt)t_1)+4) ) {
-  l_i = t_1;
-  
-  /* if IsBound( type![i]) then */
-  CHECK_INT_SMALL_POS( l_i )
-  if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
-   t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
-      && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
-  } else if ( TNUM_OBJ(a_type) == T_APOSOBJ ) {
-   t_5 = Elm0AList(a_type,INT_INTOBJ(l_i)) != 0 ? True : False;
-  }
-  else {
-   t_5 = (ISB_LIST( a_type, INT_INTOBJ(l_i) ) ? True : False);
-  }
-  t_4 = (Obj)(UInt)(t_5 != False);
-  if ( t_4 ) {
-   
-   /* new![i] := type![i]; */
-   C_ELM_POSOBJ_NLE( t_4, a_type, INT_INTOBJ(l_i) );
-   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 )
-   
-  }
-  /* fi */
-  
- }
- /* od */
  
  /* return new; */
  RES_BRK_CURR_STAT();
@@ -2277,8 +2100,8 @@ static Obj  HdlrFunc21 (
  return 0;
 }
 
-/* handler for function 22 */
-static Obj  HdlrFunc22 (
+/* handler for function 21 */
+static Obj  HdlrFunc21 (
  Obj  self,
  Obj  a_type,
  Obj  a_filter,
@@ -2303,7 +2126,7 @@ static Obj  HdlrFunc22 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data ); */
+ /* new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
@@ -2315,46 +2138,9 @@ static Obj  HdlrFunc22 (
  CHECK_FUNC_RESULT( t_8 )
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
  CHECK_FUNC_RESULT( t_5 )
- t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, a_data );
+ t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
  CHECK_FUNC_RESULT( t_1 )
  l_new = t_1;
- 
- /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do */
- t_2 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
- CHECK_INT_SMALL( t_2 )
- t_4 = GF_LEN__POSOBJ;
- t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_INT_SMALL( t_3 )
- for ( t_1 = t_2;
-       ((Int)t_1) <= ((Int)t_3);
-       t_1 = (Obj)(((UInt)t_1)+4) ) {
-  l_i = t_1;
-  
-  /* if IsBound( type![i]) then */
-  CHECK_INT_SMALL_POS( l_i )
-  if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
-   t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
-      && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
-  } else if ( TNUM_OBJ(a_type) == T_APOSOBJ ) {
-   t_5 = Elm0AList(a_type,INT_INTOBJ(l_i)) != 0 ? True : False;
-  }
-  else {
-   t_5 = (ISB_LIST( a_type, INT_INTOBJ(l_i) ) ? True : False);
-  }
-  t_4 = (Obj)(UInt)(t_5 != False);
-  if ( t_4 ) {
-   
-   /* new![i] := type![i]; */
-   C_ELM_POSOBJ_NLE( t_4, a_type, INT_INTOBJ(l_i) );
-   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 )
-   
-  }
-  /* fi */
-  
- }
- /* od */
  
  /* return new; */
  RES_BRK_CURR_STAT();
@@ -2367,8 +2153,8 @@ static Obj  HdlrFunc22 (
  return 0;
 }
 
-/* handler for function 23 */
-static Obj  HdlrFunc23 (
+/* handler for function 22 */
+static Obj  HdlrFunc22 (
  Obj  self,
  Obj  a_arg )
 {
@@ -2450,8 +2236,8 @@ static Obj  HdlrFunc23 (
  return 0;
 }
 
-/* handler for function 24 */
-static Obj  HdlrFunc24 (
+/* handler for function 23 */
+static Obj  HdlrFunc23 (
  Obj  self,
  Obj  a_K )
 {
@@ -2476,8 +2262,8 @@ static Obj  HdlrFunc24 (
  return 0;
 }
 
-/* handler for function 25 */
-static Obj  HdlrFunc25 (
+/* handler for function 24 */
+static Obj  HdlrFunc24 (
  Obj  self,
  Obj  a_K )
 {
@@ -2502,8 +2288,8 @@ static Obj  HdlrFunc25 (
  return 0;
 }
 
-/* handler for function 26 */
-static Obj  HdlrFunc26 (
+/* handler for function 25 */
+static Obj  HdlrFunc25 (
  Obj  self,
  Obj  a_K )
 {
@@ -2532,8 +2318,8 @@ static Obj  HdlrFunc26 (
  return 0;
 }
 
-/* handler for function 27 */
-static Obj  HdlrFunc27 (
+/* handler for function 26 */
+static Obj  HdlrFunc26 (
  Obj  self,
  Obj  a_K,
  Obj  a_data )
@@ -2570,8 +2356,8 @@ static Obj  HdlrFunc27 (
  return 0;
 }
 
-/* handler for function 28 */
-static Obj  HdlrFunc28 (
+/* handler for function 27 */
+static Obj  HdlrFunc27 (
  Obj  self,
  Obj  a_K )
 {
@@ -2600,8 +2386,8 @@ static Obj  HdlrFunc28 (
  return 0;
 }
 
-/* handler for function 29 */
-static Obj  HdlrFunc29 (
+/* handler for function 28 */
+static Obj  HdlrFunc28 (
  Obj  self,
  Obj  a_obj )
 {
@@ -2634,8 +2420,8 @@ static Obj  HdlrFunc29 (
  return 0;
 }
 
-/* handler for function 30 */
-static Obj  HdlrFunc30 (
+/* handler for function 29 */
+static Obj  HdlrFunc29 (
  Obj  self,
  Obj  a_obj )
 {
@@ -2668,8 +2454,8 @@ static Obj  HdlrFunc30 (
  return 0;
 }
 
-/* handler for function 31 */
-static Obj  HdlrFunc31 (
+/* handler for function 30 */
+static Obj  HdlrFunc30 (
  Obj  self,
  Obj  a_obj )
 {
@@ -2702,8 +2488,8 @@ static Obj  HdlrFunc31 (
  return 0;
 }
 
-/* handler for function 32 */
-static Obj  HdlrFunc32 (
+/* handler for function 31 */
+static Obj  HdlrFunc31 (
  Obj  self,
  Obj  a_type,
  Obj  a_obj )
@@ -2796,8 +2582,8 @@ static Obj  HdlrFunc32 (
  return 0;
 }
 
-/* handler for function 33 */
-static Obj  HdlrFunc33 (
+/* handler for function 32 */
+static Obj  HdlrFunc32 (
  Obj  self,
  Obj  a_type,
  Obj  a_obj )
@@ -2986,8 +2772,8 @@ static Obj  HdlrFunc33 (
  return 0;
 }
 
-/* handler for function 34 */
-static Obj  HdlrFunc34 (
+/* handler for function 33 */
+static Obj  HdlrFunc33 (
  Obj  self,
  Obj  a_type,
  Obj  a_obj )
@@ -3096,8 +2882,8 @@ static Obj  HdlrFunc34 (
  return 0;
 }
 
-/* handler for function 35 */
-static Obj  HdlrFunc35 (
+/* handler for function 34 */
+static Obj  HdlrFunc34 (
  Obj  self,
  Obj  a_obj,
  Obj  a_filter )
@@ -3373,8 +3159,8 @@ static Obj  HdlrFunc35 (
  return 0;
 }
 
-/* handler for function 36 */
-static Obj  HdlrFunc36 (
+/* handler for function 35 */
+static Obj  HdlrFunc35 (
  Obj  self,
  Obj  a_obj,
  Obj  a_filter )
@@ -3558,8 +3344,8 @@ static Obj  HdlrFunc36 (
  return 0;
 }
 
-/* handler for function 37 */
-static Obj  HdlrFunc37 (
+/* handler for function 36 */
+static Obj  HdlrFunc36 (
  Obj  self,
  Obj  a_obj,
  Obj  a_filter,
@@ -3606,8 +3392,8 @@ static Obj  HdlrFunc37 (
  return 0;
 }
 
-/* handler for function 38 */
-static Obj  HdlrFunc38 (
+/* handler for function 37 */
+static Obj  HdlrFunc37 (
  Obj  self,
  Obj  a_arg )
 {
@@ -3986,8 +3772,8 @@ static Obj  HdlrFunc38 (
  return 0;
 }
 
-/* handler for function 39 */
-static Obj  HdlrFunc39 (
+/* handler for function 38 */
+static Obj  HdlrFunc38 (
  Obj  self,
  Obj  a_arg )
 {
@@ -4232,7 +4018,7 @@ static Obj  HdlrFunc39 (
    CHECK_FUNC_RESULT( t_1 )
    l_flags = t_1;
    
-   /* Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ) ), obj ); */
+   /* Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ), fail ), obj ); */
    t_1 = GF_Objectify;
    t_3 = GF_NEW__TYPE;
    t_4 = GC_TypeOfTypes;
@@ -4243,7 +4029,9 @@ static Obj  HdlrFunc39 (
    t_7 = GF_DataType;
    t_6 = CALL_1ARGS( t_7, l_type );
    CHECK_FUNC_RESULT( t_6 )
-   t_2 = CALL_4ARGS( t_3, t_4, t_5, l_flags, t_6 );
+   t_7 = GC_fail;
+   CHECK_BOUND( t_7, "fail" )
+   t_2 = CALL_5ARGS( t_3, t_4, t_5, l_flags, t_6, t_7 );
    CHECK_FUNC_RESULT( t_2 )
    CALL_2ARGS( t_1, t_2, l_obj );
    
@@ -4568,28 +4356,8 @@ static Obj  HdlrFunc1 (
  CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
  CALL_1ARGS( t_1, t_2 );
  
- /* BIND_GLOBAL( "ConstructExtendedType", function ( body )
-      local  type, save_flag;
-      save_flag := VAL_GVAR( _NEW_TYPE_READONLY );
-      ASS_GVAR( _NEW_TYPE_READONLY, false );
-      type := body(  );
-      ASS_GVAR( _NEW_TYPE_READONLY, save_flag );
-      return MakeReadOnlyObj( type );
-  end ); */
- t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 21, "ConstructExtendedType" );
- t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
- ENVI_FUNC( t_3 ) = TLS->currLVars;
- t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(214);
- ENDLINE_BODY(t_4) = INTOBJ_INT(221);
- FILENAME_BODY(t_4) = FileName;
- BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS->currLVars );
- CALL_2ARGS( t_1, t_2, t_3 );
- 
- /* BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data )
-      local  lock, hash, cache, cached, type, ncache, ncl, t;
+ /* BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data, parent )
+      local  lock, hash, cache, cached, type, ncache, ncl, t, i;
       lock := WRITE_LOCK( DS_TYPE_CACHE );
       cache := family!.TYPES;
       hash := HASH_FLAGS( flags ) mod family!.HASH_SIZE + 1;
@@ -4615,6 +4383,13 @@ static Obj  HdlrFunc1 (
       type := [ family, flags ];
       type[POS_DATA_TYPE] := MakeReadOnly( data );
       type[POS_NUMB_TYPE] := NEW_TYPE_NEXT_ID;
+      if not IS_IDENTICAL_OBJ( parent, fail )  then
+          for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ]  do
+              if IsBound( parent![i]) and not IsBound( type[i] )  then
+                  type[i] := parent![i];
+              fi;
+          od;
+      fi;
       SET_TYPE_POSOBJ( type, typeOfTypes );
       if 3 * family!.nTYPES > family!.HASH_SIZE  then
           ncache := MIGRATE_RAW( [  ], DS_TYPE_CACHE );
@@ -4637,74 +4412,75 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NEW_TYPE" );
- t_3 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
+ t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(223);
- ENDLINE_BODY(t_4) = INTOBJ_INT(284);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(295);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType2", function ( typeOfTypes, family )
-      return NEW_TYPE( typeOfTypes, family, family!.IMP_FLAGS, fail );
+      return NEW_TYPE( typeOfTypes, family, family!.IMP_FLAGS, fail, fail );
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType2" );
- t_3 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
+ t_3 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(287);
- ENDLINE_BODY(t_4) = INTOBJ_INT(292);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(298);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(303);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType3", function ( typeOfTypes, family, filter )
-      return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail );
+      return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail, fail );
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType3" );
- t_3 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
+ t_3 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(295);
- ENDLINE_BODY(t_4) = INTOBJ_INT(302);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(306);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(313);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType4", function ( typeOfTypes, family, filter, data )
-      return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data );
+      return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, fail );
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType4" );
- t_3 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
+ t_3 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(305);
- ENDLINE_BODY(t_4) = INTOBJ_INT(312);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(316);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(323);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType5", function ( typeOfTypes, family, filter, data, stuff )
-      local  type;
-      type := NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data );
-      type![POS_FIRST_FREE_TYPE] := stuff;
+      local  type, temp;
+      temp := [  ];
+      temp[POS_FIRST_FREE_TYPE] := stuff;
+      type := NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, temp );
       return type;
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType5" );
- t_3 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
+ t_3 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(316);
- ENDLINE_BODY(t_4) = INTOBJ_INT(327);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(327);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(343);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4730,11 +4506,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "NewType" );
- t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
+ t_3 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(330);
- ENDLINE_BODY(t_4) = INTOBJ_INT(362);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(346);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(378);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4742,25 +4518,16 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "Subtype2", function ( type, filter )
       local  new, i, save_flag;
-      save_flag := VAL_GVAR( _NEW_TYPE_READONLY );
-      ASS_GVAR( _NEW_TYPE_READONLY, false );
-      new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![POS_DATA_TYPE] );
-      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ]  do
-          if IsBound( type![i]) and not IsBound( new![i])  then
-              new![i] := type![i];
-          fi;
-      od;
-      MakeReadOnlyObj( new );
-      ASS_GVAR( _NEW_TYPE_READONLY, save_flag );
+      new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![POS_DATA_TYPE], type );
       return new;
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "Subtype2" );
- t_3 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
+ t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(375);
- ENDLINE_BODY(t_4) = INTOBJ_INT(393);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(391);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(409);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4768,25 +4535,16 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "Subtype3", function ( type, filter, data )
       local  new, i, save_flag;
-      save_flag := VAL_GVAR( _NEW_TYPE_READONLY );
-      ASS_GVAR( _NEW_TYPE_READONLY, false );
-      new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data );
-      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ]  do
-          if IsBound( type![i]) and not IsBound( new![i])  then
-              new![i] := type![i];
-          fi;
-      od;
-      MakeReadOnlyObj( new );
-      ASS_GVAR( _NEW_TYPE_READONLY, save_flag );
+      new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type );
       return new;
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "Subtype3" );
- t_3 = NewFunction( NameFunc[19], NargFunc[19], NamsFunc[19], HdlrFunc19 );
+ t_3 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(396);
- ENDLINE_BODY(t_4) = INTOBJ_INT(414);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(412);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(431);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4811,11 +4569,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "Subtype" );
- t_3 = NewFunction( NameFunc[20], NargFunc[20], NamsFunc[20], HdlrFunc20 );
+ t_3 = NewFunction( NameFunc[19], NargFunc[19], NamsFunc[19], HdlrFunc19 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(418);
- ENDLINE_BODY(t_4) = INTOBJ_INT(433);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(435);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(450);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4823,21 +4581,16 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "SupType2", function ( type, filter )
       local  new, i;
-      new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![POS_DATA_TYPE] );
-      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ]  do
-          if IsBound( type![i])  then
-              new![i] := type![i];
-          fi;
-      od;
+      new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![POS_DATA_TYPE], type );
       return new;
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "SupType2" );
- t_3 = NewFunction( NameFunc[21], NargFunc[21], NamsFunc[21], HdlrFunc21 );
+ t_3 = NewFunction( NameFunc[20], NargFunc[20], NamsFunc[20], HdlrFunc20 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(447);
- ENDLINE_BODY(t_4) = INTOBJ_INT(461);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(464);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(478);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4845,21 +4598,16 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "SupType3", function ( type, filter, data )
       local  new, i;
-      new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data );
-      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ]  do
-          if IsBound( type![i])  then
-              new![i] := type![i];
-          fi;
-      od;
+      new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type );
       return new;
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "SupType3" );
- t_3 = NewFunction( NameFunc[22], NargFunc[22], NamsFunc[22], HdlrFunc22 );
+ t_3 = NewFunction( NameFunc[21], NargFunc[21], NamsFunc[21], HdlrFunc21 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(464);
- ENDLINE_BODY(t_4) = INTOBJ_INT(478);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(481);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(495);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4878,11 +4626,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "SupType" );
- t_3 = NewFunction( NameFunc[23], NargFunc[23], NamsFunc[23], HdlrFunc23 );
+ t_3 = NewFunction( NameFunc[22], NargFunc[22], NamsFunc[22], HdlrFunc22 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(481);
- ENDLINE_BODY(t_4) = INTOBJ_INT(495);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(498);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(512);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4893,11 +4641,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "FamilyType" );
- t_3 = NewFunction( NameFunc[24], NargFunc[24], NamsFunc[24], HdlrFunc24 );
+ t_3 = NewFunction( NameFunc[23], NargFunc[23], NamsFunc[23], HdlrFunc23 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(509);
- ENDLINE_BODY(t_4) = INTOBJ_INT(509);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(526);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(526);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4908,11 +4656,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "FlagsType" );
- t_3 = NewFunction( NameFunc[25], NargFunc[25], NamsFunc[25], HdlrFunc25 );
+ t_3 = NewFunction( NameFunc[24], NargFunc[24], NamsFunc[24], HdlrFunc24 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(523);
- ENDLINE_BODY(t_4) = INTOBJ_INT(523);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(540);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(540);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4923,11 +4671,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "DataType" );
- t_3 = NewFunction( NameFunc[26], NargFunc[26], NamsFunc[26], HdlrFunc26 );
+ t_3 = NewFunction( NameFunc[25], NargFunc[25], NamsFunc[25], HdlrFunc25 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(539);
- ENDLINE_BODY(t_4) = INTOBJ_INT(539);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(556);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(556);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4939,11 +4687,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 11, "SetDataType" );
- t_3 = NewFunction( NameFunc[27], NargFunc[27], NamsFunc[27], HdlrFunc27 );
+ t_3 = NewFunction( NameFunc[26], NargFunc[26], NamsFunc[26], HdlrFunc26 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(541);
- ENDLINE_BODY(t_4) = INTOBJ_INT(543);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(558);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(560);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4954,11 +4702,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "SharedType" );
- t_3 = NewFunction( NameFunc[28], NargFunc[28], NamsFunc[28], HdlrFunc28 );
+ t_3 = NewFunction( NameFunc[27], NargFunc[27], NamsFunc[27], HdlrFunc27 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(557);
- ENDLINE_BODY(t_4) = INTOBJ_INT(557);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(574);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(574);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4983,11 +4731,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "FlagsObj" );
- t_3 = NewFunction( NameFunc[29], NargFunc[29], NamsFunc[29], HdlrFunc29 );
+ t_3 = NewFunction( NameFunc[28], NargFunc[28], NamsFunc[28], HdlrFunc28 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(656);
- ENDLINE_BODY(t_4) = INTOBJ_INT(656);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(673);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(673);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -4998,11 +4746,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "DataObj" );
- t_3 = NewFunction( NameFunc[30], NargFunc[30], NamsFunc[30], HdlrFunc30 );
+ t_3 = NewFunction( NameFunc[29], NargFunc[29], NamsFunc[29], HdlrFunc29 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(670);
- ENDLINE_BODY(t_4) = INTOBJ_INT(670);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(687);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(687);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -5013,11 +4761,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "SharedObj" );
- t_3 = NewFunction( NameFunc[31], NargFunc[31], NamsFunc[31], HdlrFunc31 );
+ t_3 = NewFunction( NameFunc[30], NargFunc[30], NamsFunc[30], HdlrFunc30 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(684);
- ENDLINE_BODY(t_4) = INTOBJ_INT(684);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(701);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(701);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -5039,11 +4787,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "SetTypeObj" );
- t_3 = NewFunction( NameFunc[32], NargFunc[32], NamsFunc[32], HdlrFunc32 );
+ t_3 = NewFunction( NameFunc[31], NargFunc[31], NamsFunc[31], HdlrFunc31 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(698);
- ENDLINE_BODY(t_4) = INTOBJ_INT(711);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(715);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(728);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -5110,11 +4858,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "Objectify" );
- t_3 = NewFunction( NameFunc[33], NargFunc[33], NamsFunc[33], HdlrFunc33 );
+ t_3 = NewFunction( NameFunc[32], NargFunc[32], NamsFunc[32], HdlrFunc32 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(721);
- ENDLINE_BODY(t_4) = INTOBJ_INT(750);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(738);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(767);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -5138,11 +4886,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "ChangeTypeObj" );
- t_3 = NewFunction( NameFunc[34], NargFunc[34], NamsFunc[34], HdlrFunc34 );
+ t_3 = NewFunction( NameFunc[33], NargFunc[33], NamsFunc[33], HdlrFunc33 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(764);
- ENDLINE_BODY(t_4) = INTOBJ_INT(779);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(781);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(796);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -5196,11 +4944,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 12, "SetFilterObj" );
- t_3 = NewFunction( NameFunc[35], NargFunc[35], NamsFunc[35], HdlrFunc35 );
+ t_3 = NewFunction( NameFunc[34], NargFunc[34], NamsFunc[34], HdlrFunc34 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(803);
- ENDLINE_BODY(t_4) = INTOBJ_INT(841);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(820);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(858);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -5238,11 +4986,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 14, "ResetFilterObj" );
- t_3 = NewFunction( NameFunc[36], NargFunc[36], NamsFunc[36], HdlrFunc36 );
+ t_3 = NewFunction( NameFunc[35], NargFunc[35], NamsFunc[35], HdlrFunc35 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(863);
- ENDLINE_BODY(t_4) = INTOBJ_INT(885);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(880);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(902);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -5265,11 +5013,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "SetFeatureObj" );
- t_3 = NewFunction( NameFunc[37], NargFunc[37], NamsFunc[37], HdlrFunc37 );
+ t_3 = NewFunction( NameFunc[36], NargFunc[36], NamsFunc[36], HdlrFunc36 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(901);
- ENDLINE_BODY(t_4) = INTOBJ_INT(907);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(918);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(924);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -5318,11 +5066,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "SetMultipleAttributes" );
- t_3 = NewFunction( NameFunc[38], NargFunc[38], NamsFunc[38], HdlrFunc38 );
+ t_3 = NewFunction( NameFunc[37], NargFunc[37], NamsFunc[37], HdlrFunc37 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(928);
- ENDLINE_BODY(t_4) = INTOBJ_INT(980);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(945);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(997);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -5381,7 +5129,7 @@ static Obj  HdlrFunc1 (
           od;
           if not IS_SUBSET_FLAGS( flags, nflags )  then
               flags := WITH_IMPS_FLAGS( AND_FLAGS( flags, nflags ) );
-              Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ) ), obj );
+              Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ), fail ), obj );
           else
               Objectify( type, obj );
           fi;
@@ -5397,11 +5145,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 23, "ObjectifyWithAttributes" );
- t_3 = NewFunction( NameFunc[39], NargFunc[39], NamsFunc[39], HdlrFunc39 );
+ t_3 = NewFunction( NameFunc[38], NargFunc[38], NamsFunc[38], HdlrFunc38 );
  ENVI_FUNC( t_3 ) = TLS->currLVars;
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(1027);
- ENDLINE_BODY(t_4) = INTOBJ_INT(1092);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(1044);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(1109);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS->currLVars );
@@ -5510,8 +5258,8 @@ static Int InitKernel ( StructInitInfo * module )
  InitCopyGVar( "NEW_TYPE_ID_LIMIT", &GC_NEW__TYPE__ID__LIMIT );
  InitFopyGVar( "FLUSH_ALL_METHOD_CACHES", &GF_FLUSH__ALL__METHOD__CACHES );
  InitCopyGVar( "POS_NUMB_TYPE", &GC_POS__NUMB__TYPE );
- InitFopyGVar( "NEW_TYPE", &GF_NEW__TYPE );
  InitCopyGVar( "POS_FIRST_FREE_TYPE", &GC_POS__FIRST__FREE__TYPE );
+ InitFopyGVar( "NEW_TYPE", &GF_NEW__TYPE );
  InitFopyGVar( "IsFamily", &GF_IsFamily );
  InitFopyGVar( "NewType2", &GF_NewType2 );
  InitCopyGVar( "TypeOfTypes", &GC_TypeOfTypes );
@@ -5550,86 +5298,84 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "Objectify", &GF_Objectify );
  
  /* information for the functions */
- InitGlobalBag( &DefaultName, "GAPROOT/lib/type1.g:DefaultName(41572953)" );
- InitGlobalBag( &FileName, "GAPROOT/lib/type1.g:FileName(41572953)" );
- InitHandlerFunc( HdlrFunc1, "GAPROOT/lib/type1.g:HdlrFunc1(41572953)" );
- InitGlobalBag( &(NameFunc[1]), "GAPROOT/lib/type1.g:NameFunc[1](41572953)" );
- InitHandlerFunc( HdlrFunc2, "GAPROOT/lib/type1.g:HdlrFunc2(41572953)" );
- InitGlobalBag( &(NameFunc[2]), "GAPROOT/lib/type1.g:NameFunc[2](41572953)" );
- InitHandlerFunc( HdlrFunc3, "GAPROOT/lib/type1.g:HdlrFunc3(41572953)" );
- InitGlobalBag( &(NameFunc[3]), "GAPROOT/lib/type1.g:NameFunc[3](41572953)" );
- InitHandlerFunc( HdlrFunc4, "GAPROOT/lib/type1.g:HdlrFunc4(41572953)" );
- InitGlobalBag( &(NameFunc[4]), "GAPROOT/lib/type1.g:NameFunc[4](41572953)" );
- InitHandlerFunc( HdlrFunc5, "GAPROOT/lib/type1.g:HdlrFunc5(41572953)" );
- InitGlobalBag( &(NameFunc[5]), "GAPROOT/lib/type1.g:NameFunc[5](41572953)" );
- InitHandlerFunc( HdlrFunc6, "GAPROOT/lib/type1.g:HdlrFunc6(41572953)" );
- InitGlobalBag( &(NameFunc[6]), "GAPROOT/lib/type1.g:NameFunc[6](41572953)" );
- InitHandlerFunc( HdlrFunc7, "GAPROOT/lib/type1.g:HdlrFunc7(41572953)" );
- InitGlobalBag( &(NameFunc[7]), "GAPROOT/lib/type1.g:NameFunc[7](41572953)" );
- InitHandlerFunc( HdlrFunc8, "GAPROOT/lib/type1.g:HdlrFunc8(41572953)" );
- InitGlobalBag( &(NameFunc[8]), "GAPROOT/lib/type1.g:NameFunc[8](41572953)" );
- InitHandlerFunc( HdlrFunc9, "GAPROOT/lib/type1.g:HdlrFunc9(41572953)" );
- InitGlobalBag( &(NameFunc[9]), "GAPROOT/lib/type1.g:NameFunc[9](41572953)" );
- InitHandlerFunc( HdlrFunc10, "GAPROOT/lib/type1.g:HdlrFunc10(41572953)" );
- InitGlobalBag( &(NameFunc[10]), "GAPROOT/lib/type1.g:NameFunc[10](41572953)" );
- InitHandlerFunc( HdlrFunc11, "GAPROOT/lib/type1.g:HdlrFunc11(41572953)" );
- InitGlobalBag( &(NameFunc[11]), "GAPROOT/lib/type1.g:NameFunc[11](41572953)" );
- InitHandlerFunc( HdlrFunc12, "GAPROOT/lib/type1.g:HdlrFunc12(41572953)" );
- InitGlobalBag( &(NameFunc[12]), "GAPROOT/lib/type1.g:NameFunc[12](41572953)" );
- InitHandlerFunc( HdlrFunc13, "GAPROOT/lib/type1.g:HdlrFunc13(41572953)" );
- InitGlobalBag( &(NameFunc[13]), "GAPROOT/lib/type1.g:NameFunc[13](41572953)" );
- InitHandlerFunc( HdlrFunc14, "GAPROOT/lib/type1.g:HdlrFunc14(41572953)" );
- InitGlobalBag( &(NameFunc[14]), "GAPROOT/lib/type1.g:NameFunc[14](41572953)" );
- InitHandlerFunc( HdlrFunc15, "GAPROOT/lib/type1.g:HdlrFunc15(41572953)" );
- InitGlobalBag( &(NameFunc[15]), "GAPROOT/lib/type1.g:NameFunc[15](41572953)" );
- InitHandlerFunc( HdlrFunc16, "GAPROOT/lib/type1.g:HdlrFunc16(41572953)" );
- InitGlobalBag( &(NameFunc[16]), "GAPROOT/lib/type1.g:NameFunc[16](41572953)" );
- InitHandlerFunc( HdlrFunc17, "GAPROOT/lib/type1.g:HdlrFunc17(41572953)" );
- InitGlobalBag( &(NameFunc[17]), "GAPROOT/lib/type1.g:NameFunc[17](41572953)" );
- InitHandlerFunc( HdlrFunc18, "GAPROOT/lib/type1.g:HdlrFunc18(41572953)" );
- InitGlobalBag( &(NameFunc[18]), "GAPROOT/lib/type1.g:NameFunc[18](41572953)" );
- InitHandlerFunc( HdlrFunc19, "GAPROOT/lib/type1.g:HdlrFunc19(41572953)" );
- InitGlobalBag( &(NameFunc[19]), "GAPROOT/lib/type1.g:NameFunc[19](41572953)" );
- InitHandlerFunc( HdlrFunc20, "GAPROOT/lib/type1.g:HdlrFunc20(41572953)" );
- InitGlobalBag( &(NameFunc[20]), "GAPROOT/lib/type1.g:NameFunc[20](41572953)" );
- InitHandlerFunc( HdlrFunc21, "GAPROOT/lib/type1.g:HdlrFunc21(41572953)" );
- InitGlobalBag( &(NameFunc[21]), "GAPROOT/lib/type1.g:NameFunc[21](41572953)" );
- InitHandlerFunc( HdlrFunc22, "GAPROOT/lib/type1.g:HdlrFunc22(41572953)" );
- InitGlobalBag( &(NameFunc[22]), "GAPROOT/lib/type1.g:NameFunc[22](41572953)" );
- InitHandlerFunc( HdlrFunc23, "GAPROOT/lib/type1.g:HdlrFunc23(41572953)" );
- InitGlobalBag( &(NameFunc[23]), "GAPROOT/lib/type1.g:NameFunc[23](41572953)" );
- InitHandlerFunc( HdlrFunc24, "GAPROOT/lib/type1.g:HdlrFunc24(41572953)" );
- InitGlobalBag( &(NameFunc[24]), "GAPROOT/lib/type1.g:NameFunc[24](41572953)" );
- InitHandlerFunc( HdlrFunc25, "GAPROOT/lib/type1.g:HdlrFunc25(41572953)" );
- InitGlobalBag( &(NameFunc[25]), "GAPROOT/lib/type1.g:NameFunc[25](41572953)" );
- InitHandlerFunc( HdlrFunc26, "GAPROOT/lib/type1.g:HdlrFunc26(41572953)" );
- InitGlobalBag( &(NameFunc[26]), "GAPROOT/lib/type1.g:NameFunc[26](41572953)" );
- InitHandlerFunc( HdlrFunc27, "GAPROOT/lib/type1.g:HdlrFunc27(41572953)" );
- InitGlobalBag( &(NameFunc[27]), "GAPROOT/lib/type1.g:NameFunc[27](41572953)" );
- InitHandlerFunc( HdlrFunc28, "GAPROOT/lib/type1.g:HdlrFunc28(41572953)" );
- InitGlobalBag( &(NameFunc[28]), "GAPROOT/lib/type1.g:NameFunc[28](41572953)" );
- InitHandlerFunc( HdlrFunc29, "GAPROOT/lib/type1.g:HdlrFunc29(41572953)" );
- InitGlobalBag( &(NameFunc[29]), "GAPROOT/lib/type1.g:NameFunc[29](41572953)" );
- InitHandlerFunc( HdlrFunc30, "GAPROOT/lib/type1.g:HdlrFunc30(41572953)" );
- InitGlobalBag( &(NameFunc[30]), "GAPROOT/lib/type1.g:NameFunc[30](41572953)" );
- InitHandlerFunc( HdlrFunc31, "GAPROOT/lib/type1.g:HdlrFunc31(41572953)" );
- InitGlobalBag( &(NameFunc[31]), "GAPROOT/lib/type1.g:NameFunc[31](41572953)" );
- InitHandlerFunc( HdlrFunc32, "GAPROOT/lib/type1.g:HdlrFunc32(41572953)" );
- InitGlobalBag( &(NameFunc[32]), "GAPROOT/lib/type1.g:NameFunc[32](41572953)" );
- InitHandlerFunc( HdlrFunc33, "GAPROOT/lib/type1.g:HdlrFunc33(41572953)" );
- InitGlobalBag( &(NameFunc[33]), "GAPROOT/lib/type1.g:NameFunc[33](41572953)" );
- InitHandlerFunc( HdlrFunc34, "GAPROOT/lib/type1.g:HdlrFunc34(41572953)" );
- InitGlobalBag( &(NameFunc[34]), "GAPROOT/lib/type1.g:NameFunc[34](41572953)" );
- InitHandlerFunc( HdlrFunc35, "GAPROOT/lib/type1.g:HdlrFunc35(41572953)" );
- InitGlobalBag( &(NameFunc[35]), "GAPROOT/lib/type1.g:NameFunc[35](41572953)" );
- InitHandlerFunc( HdlrFunc36, "GAPROOT/lib/type1.g:HdlrFunc36(41572953)" );
- InitGlobalBag( &(NameFunc[36]), "GAPROOT/lib/type1.g:NameFunc[36](41572953)" );
- InitHandlerFunc( HdlrFunc37, "GAPROOT/lib/type1.g:HdlrFunc37(41572953)" );
- InitGlobalBag( &(NameFunc[37]), "GAPROOT/lib/type1.g:NameFunc[37](41572953)" );
- InitHandlerFunc( HdlrFunc38, "GAPROOT/lib/type1.g:HdlrFunc38(41572953)" );
- InitGlobalBag( &(NameFunc[38]), "GAPROOT/lib/type1.g:NameFunc[38](41572953)" );
- InitHandlerFunc( HdlrFunc39, "GAPROOT/lib/type1.g:HdlrFunc39(41572953)" );
- InitGlobalBag( &(NameFunc[39]), "GAPROOT/lib/type1.g:NameFunc[39](41572953)" );
+ InitGlobalBag( &DefaultName, "GAPROOT/lib/type1.g:DefaultName(-28108360)" );
+ InitGlobalBag( &FileName, "GAPROOT/lib/type1.g:FileName(-28108360)" );
+ InitHandlerFunc( HdlrFunc1, "GAPROOT/lib/type1.g:HdlrFunc1(-28108360)" );
+ InitGlobalBag( &(NameFunc[1]), "GAPROOT/lib/type1.g:NameFunc[1](-28108360)" );
+ InitHandlerFunc( HdlrFunc2, "GAPROOT/lib/type1.g:HdlrFunc2(-28108360)" );
+ InitGlobalBag( &(NameFunc[2]), "GAPROOT/lib/type1.g:NameFunc[2](-28108360)" );
+ InitHandlerFunc( HdlrFunc3, "GAPROOT/lib/type1.g:HdlrFunc3(-28108360)" );
+ InitGlobalBag( &(NameFunc[3]), "GAPROOT/lib/type1.g:NameFunc[3](-28108360)" );
+ InitHandlerFunc( HdlrFunc4, "GAPROOT/lib/type1.g:HdlrFunc4(-28108360)" );
+ InitGlobalBag( &(NameFunc[4]), "GAPROOT/lib/type1.g:NameFunc[4](-28108360)" );
+ InitHandlerFunc( HdlrFunc5, "GAPROOT/lib/type1.g:HdlrFunc5(-28108360)" );
+ InitGlobalBag( &(NameFunc[5]), "GAPROOT/lib/type1.g:NameFunc[5](-28108360)" );
+ InitHandlerFunc( HdlrFunc6, "GAPROOT/lib/type1.g:HdlrFunc6(-28108360)" );
+ InitGlobalBag( &(NameFunc[6]), "GAPROOT/lib/type1.g:NameFunc[6](-28108360)" );
+ InitHandlerFunc( HdlrFunc7, "GAPROOT/lib/type1.g:HdlrFunc7(-28108360)" );
+ InitGlobalBag( &(NameFunc[7]), "GAPROOT/lib/type1.g:NameFunc[7](-28108360)" );
+ InitHandlerFunc( HdlrFunc8, "GAPROOT/lib/type1.g:HdlrFunc8(-28108360)" );
+ InitGlobalBag( &(NameFunc[8]), "GAPROOT/lib/type1.g:NameFunc[8](-28108360)" );
+ InitHandlerFunc( HdlrFunc9, "GAPROOT/lib/type1.g:HdlrFunc9(-28108360)" );
+ InitGlobalBag( &(NameFunc[9]), "GAPROOT/lib/type1.g:NameFunc[9](-28108360)" );
+ InitHandlerFunc( HdlrFunc10, "GAPROOT/lib/type1.g:HdlrFunc10(-28108360)" );
+ InitGlobalBag( &(NameFunc[10]), "GAPROOT/lib/type1.g:NameFunc[10](-28108360)" );
+ InitHandlerFunc( HdlrFunc11, "GAPROOT/lib/type1.g:HdlrFunc11(-28108360)" );
+ InitGlobalBag( &(NameFunc[11]), "GAPROOT/lib/type1.g:NameFunc[11](-28108360)" );
+ InitHandlerFunc( HdlrFunc12, "GAPROOT/lib/type1.g:HdlrFunc12(-28108360)" );
+ InitGlobalBag( &(NameFunc[12]), "GAPROOT/lib/type1.g:NameFunc[12](-28108360)" );
+ InitHandlerFunc( HdlrFunc13, "GAPROOT/lib/type1.g:HdlrFunc13(-28108360)" );
+ InitGlobalBag( &(NameFunc[13]), "GAPROOT/lib/type1.g:NameFunc[13](-28108360)" );
+ InitHandlerFunc( HdlrFunc14, "GAPROOT/lib/type1.g:HdlrFunc14(-28108360)" );
+ InitGlobalBag( &(NameFunc[14]), "GAPROOT/lib/type1.g:NameFunc[14](-28108360)" );
+ InitHandlerFunc( HdlrFunc15, "GAPROOT/lib/type1.g:HdlrFunc15(-28108360)" );
+ InitGlobalBag( &(NameFunc[15]), "GAPROOT/lib/type1.g:NameFunc[15](-28108360)" );
+ InitHandlerFunc( HdlrFunc16, "GAPROOT/lib/type1.g:HdlrFunc16(-28108360)" );
+ InitGlobalBag( &(NameFunc[16]), "GAPROOT/lib/type1.g:NameFunc[16](-28108360)" );
+ InitHandlerFunc( HdlrFunc17, "GAPROOT/lib/type1.g:HdlrFunc17(-28108360)" );
+ InitGlobalBag( &(NameFunc[17]), "GAPROOT/lib/type1.g:NameFunc[17](-28108360)" );
+ InitHandlerFunc( HdlrFunc18, "GAPROOT/lib/type1.g:HdlrFunc18(-28108360)" );
+ InitGlobalBag( &(NameFunc[18]), "GAPROOT/lib/type1.g:NameFunc[18](-28108360)" );
+ InitHandlerFunc( HdlrFunc19, "GAPROOT/lib/type1.g:HdlrFunc19(-28108360)" );
+ InitGlobalBag( &(NameFunc[19]), "GAPROOT/lib/type1.g:NameFunc[19](-28108360)" );
+ InitHandlerFunc( HdlrFunc20, "GAPROOT/lib/type1.g:HdlrFunc20(-28108360)" );
+ InitGlobalBag( &(NameFunc[20]), "GAPROOT/lib/type1.g:NameFunc[20](-28108360)" );
+ InitHandlerFunc( HdlrFunc21, "GAPROOT/lib/type1.g:HdlrFunc21(-28108360)" );
+ InitGlobalBag( &(NameFunc[21]), "GAPROOT/lib/type1.g:NameFunc[21](-28108360)" );
+ InitHandlerFunc( HdlrFunc22, "GAPROOT/lib/type1.g:HdlrFunc22(-28108360)" );
+ InitGlobalBag( &(NameFunc[22]), "GAPROOT/lib/type1.g:NameFunc[22](-28108360)" );
+ InitHandlerFunc( HdlrFunc23, "GAPROOT/lib/type1.g:HdlrFunc23(-28108360)" );
+ InitGlobalBag( &(NameFunc[23]), "GAPROOT/lib/type1.g:NameFunc[23](-28108360)" );
+ InitHandlerFunc( HdlrFunc24, "GAPROOT/lib/type1.g:HdlrFunc24(-28108360)" );
+ InitGlobalBag( &(NameFunc[24]), "GAPROOT/lib/type1.g:NameFunc[24](-28108360)" );
+ InitHandlerFunc( HdlrFunc25, "GAPROOT/lib/type1.g:HdlrFunc25(-28108360)" );
+ InitGlobalBag( &(NameFunc[25]), "GAPROOT/lib/type1.g:NameFunc[25](-28108360)" );
+ InitHandlerFunc( HdlrFunc26, "GAPROOT/lib/type1.g:HdlrFunc26(-28108360)" );
+ InitGlobalBag( &(NameFunc[26]), "GAPROOT/lib/type1.g:NameFunc[26](-28108360)" );
+ InitHandlerFunc( HdlrFunc27, "GAPROOT/lib/type1.g:HdlrFunc27(-28108360)" );
+ InitGlobalBag( &(NameFunc[27]), "GAPROOT/lib/type1.g:NameFunc[27](-28108360)" );
+ InitHandlerFunc( HdlrFunc28, "GAPROOT/lib/type1.g:HdlrFunc28(-28108360)" );
+ InitGlobalBag( &(NameFunc[28]), "GAPROOT/lib/type1.g:NameFunc[28](-28108360)" );
+ InitHandlerFunc( HdlrFunc29, "GAPROOT/lib/type1.g:HdlrFunc29(-28108360)" );
+ InitGlobalBag( &(NameFunc[29]), "GAPROOT/lib/type1.g:NameFunc[29](-28108360)" );
+ InitHandlerFunc( HdlrFunc30, "GAPROOT/lib/type1.g:HdlrFunc30(-28108360)" );
+ InitGlobalBag( &(NameFunc[30]), "GAPROOT/lib/type1.g:NameFunc[30](-28108360)" );
+ InitHandlerFunc( HdlrFunc31, "GAPROOT/lib/type1.g:HdlrFunc31(-28108360)" );
+ InitGlobalBag( &(NameFunc[31]), "GAPROOT/lib/type1.g:NameFunc[31](-28108360)" );
+ InitHandlerFunc( HdlrFunc32, "GAPROOT/lib/type1.g:HdlrFunc32(-28108360)" );
+ InitGlobalBag( &(NameFunc[32]), "GAPROOT/lib/type1.g:NameFunc[32](-28108360)" );
+ InitHandlerFunc( HdlrFunc33, "GAPROOT/lib/type1.g:HdlrFunc33(-28108360)" );
+ InitGlobalBag( &(NameFunc[33]), "GAPROOT/lib/type1.g:NameFunc[33](-28108360)" );
+ InitHandlerFunc( HdlrFunc34, "GAPROOT/lib/type1.g:HdlrFunc34(-28108360)" );
+ InitGlobalBag( &(NameFunc[34]), "GAPROOT/lib/type1.g:NameFunc[34](-28108360)" );
+ InitHandlerFunc( HdlrFunc35, "GAPROOT/lib/type1.g:HdlrFunc35(-28108360)" );
+ InitGlobalBag( &(NameFunc[35]), "GAPROOT/lib/type1.g:NameFunc[35](-28108360)" );
+ InitHandlerFunc( HdlrFunc36, "GAPROOT/lib/type1.g:HdlrFunc36(-28108360)" );
+ InitGlobalBag( &(NameFunc[36]), "GAPROOT/lib/type1.g:NameFunc[36](-28108360)" );
+ InitHandlerFunc( HdlrFunc37, "GAPROOT/lib/type1.g:HdlrFunc37(-28108360)" );
+ InitGlobalBag( &(NameFunc[37]), "GAPROOT/lib/type1.g:NameFunc[37](-28108360)" );
+ InitHandlerFunc( HdlrFunc38, "GAPROOT/lib/type1.g:HdlrFunc38(-28108360)" );
+ InitGlobalBag( &(NameFunc[38]), "GAPROOT/lib/type1.g:NameFunc[38](-28108360)" );
  
  /* return success */
  return 0;
@@ -5730,8 +5476,8 @@ static Int InitLibrary ( StructInitInfo * module )
  G_NEW__TYPE__ID__LIMIT = GVarName( "NEW_TYPE_ID_LIMIT" );
  G_FLUSH__ALL__METHOD__CACHES = GVarName( "FLUSH_ALL_METHOD_CACHES" );
  G_POS__NUMB__TYPE = GVarName( "POS_NUMB_TYPE" );
- G_NEW__TYPE = GVarName( "NEW_TYPE" );
  G_POS__FIRST__FREE__TYPE = GVarName( "POS_FIRST_FREE_TYPE" );
+ G_NEW__TYPE = GVarName( "NEW_TYPE" );
  G_IsFamily = GVarName( "IsFamily" );
  G_NewType2 = GVarName( "NewType2" );
  G_TypeOfTypes = GVarName( "TypeOfTypes" );
@@ -5810,43 +5556,43 @@ static Int InitLibrary ( StructInitInfo * module )
  NargFunc[10] = -1;
  NameFunc[11] = DefaultName;
  NamsFunc[11] = 0;
- NargFunc[11] = 1;
+ NargFunc[11] = 5;
  NameFunc[12] = DefaultName;
  NamsFunc[12] = 0;
- NargFunc[12] = 4;
+ NargFunc[12] = 2;
  NameFunc[13] = DefaultName;
  NamsFunc[13] = 0;
- NargFunc[13] = 2;
+ NargFunc[13] = 3;
  NameFunc[14] = DefaultName;
  NamsFunc[14] = 0;
- NargFunc[14] = 3;
+ NargFunc[14] = 4;
  NameFunc[15] = DefaultName;
  NamsFunc[15] = 0;
- NargFunc[15] = 4;
+ NargFunc[15] = 5;
  NameFunc[16] = DefaultName;
  NamsFunc[16] = 0;
- NargFunc[16] = 5;
+ NargFunc[16] = -1;
  NameFunc[17] = DefaultName;
  NamsFunc[17] = 0;
- NargFunc[17] = -1;
+ NargFunc[17] = 2;
  NameFunc[18] = DefaultName;
  NamsFunc[18] = 0;
- NargFunc[18] = 2;
+ NargFunc[18] = 3;
  NameFunc[19] = DefaultName;
  NamsFunc[19] = 0;
- NargFunc[19] = 3;
+ NargFunc[19] = -1;
  NameFunc[20] = DefaultName;
  NamsFunc[20] = 0;
- NargFunc[20] = -1;
+ NargFunc[20] = 2;
  NameFunc[21] = DefaultName;
  NamsFunc[21] = 0;
- NargFunc[21] = 2;
+ NargFunc[21] = 3;
  NameFunc[22] = DefaultName;
  NamsFunc[22] = 0;
- NargFunc[22] = 3;
+ NargFunc[22] = -1;
  NameFunc[23] = DefaultName;
  NamsFunc[23] = 0;
- NargFunc[23] = -1;
+ NargFunc[23] = 1;
  NameFunc[24] = DefaultName;
  NamsFunc[24] = 0;
  NargFunc[24] = 1;
@@ -5855,10 +5601,10 @@ static Int InitLibrary ( StructInitInfo * module )
  NargFunc[25] = 1;
  NameFunc[26] = DefaultName;
  NamsFunc[26] = 0;
- NargFunc[26] = 1;
+ NargFunc[26] = 2;
  NameFunc[27] = DefaultName;
  NamsFunc[27] = 0;
- NargFunc[27] = 2;
+ NargFunc[27] = 1;
  NameFunc[28] = DefaultName;
  NamsFunc[28] = 0;
  NargFunc[28] = 1;
@@ -5870,7 +5616,7 @@ static Int InitLibrary ( StructInitInfo * module )
  NargFunc[30] = 1;
  NameFunc[31] = DefaultName;
  NamsFunc[31] = 0;
- NargFunc[31] = 1;
+ NargFunc[31] = 2;
  NameFunc[32] = DefaultName;
  NamsFunc[32] = 0;
  NargFunc[32] = 2;
@@ -5885,16 +5631,13 @@ static Int InitLibrary ( StructInitInfo * module )
  NargFunc[35] = 2;
  NameFunc[36] = DefaultName;
  NamsFunc[36] = 0;
- NargFunc[36] = 2;
+ NargFunc[36] = 3;
  NameFunc[37] = DefaultName;
  NamsFunc[37] = 0;
- NargFunc[37] = 3;
+ NargFunc[37] = -1;
  NameFunc[38] = DefaultName;
  NamsFunc[38] = 0;
  NargFunc[38] = -1;
- NameFunc[39] = DefaultName;
- NamsFunc[39] = 0;
- NargFunc[39] = -1;
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
@@ -5999,8 +5742,8 @@ static Int PostRestore ( StructInitInfo * module )
  G_NEW__TYPE__ID__LIMIT = GVarName( "NEW_TYPE_ID_LIMIT" );
  G_FLUSH__ALL__METHOD__CACHES = GVarName( "FLUSH_ALL_METHOD_CACHES" );
  G_POS__NUMB__TYPE = GVarName( "POS_NUMB_TYPE" );
- G_NEW__TYPE = GVarName( "NEW_TYPE" );
  G_POS__FIRST__FREE__TYPE = GVarName( "POS_FIRST_FREE_TYPE" );
+ G_NEW__TYPE = GVarName( "NEW_TYPE" );
  G_IsFamily = GVarName( "IsFamily" );
  G_NewType2 = GVarName( "NewType2" );
  G_TypeOfTypes = GVarName( "TypeOfTypes" );
@@ -6077,43 +5820,43 @@ static Int PostRestore ( StructInitInfo * module )
  NargFunc[10] = -1;
  NameFunc[11] = DefaultName;
  NamsFunc[11] = 0;
- NargFunc[11] = 1;
+ NargFunc[11] = 5;
  NameFunc[12] = DefaultName;
  NamsFunc[12] = 0;
- NargFunc[12] = 4;
+ NargFunc[12] = 2;
  NameFunc[13] = DefaultName;
  NamsFunc[13] = 0;
- NargFunc[13] = 2;
+ NargFunc[13] = 3;
  NameFunc[14] = DefaultName;
  NamsFunc[14] = 0;
- NargFunc[14] = 3;
+ NargFunc[14] = 4;
  NameFunc[15] = DefaultName;
  NamsFunc[15] = 0;
- NargFunc[15] = 4;
+ NargFunc[15] = 5;
  NameFunc[16] = DefaultName;
  NamsFunc[16] = 0;
- NargFunc[16] = 5;
+ NargFunc[16] = -1;
  NameFunc[17] = DefaultName;
  NamsFunc[17] = 0;
- NargFunc[17] = -1;
+ NargFunc[17] = 2;
  NameFunc[18] = DefaultName;
  NamsFunc[18] = 0;
- NargFunc[18] = 2;
+ NargFunc[18] = 3;
  NameFunc[19] = DefaultName;
  NamsFunc[19] = 0;
- NargFunc[19] = 3;
+ NargFunc[19] = -1;
  NameFunc[20] = DefaultName;
  NamsFunc[20] = 0;
- NargFunc[20] = -1;
+ NargFunc[20] = 2;
  NameFunc[21] = DefaultName;
  NamsFunc[21] = 0;
- NargFunc[21] = 2;
+ NargFunc[21] = 3;
  NameFunc[22] = DefaultName;
  NamsFunc[22] = 0;
- NargFunc[22] = 3;
+ NargFunc[22] = -1;
  NameFunc[23] = DefaultName;
  NamsFunc[23] = 0;
- NargFunc[23] = -1;
+ NargFunc[23] = 1;
  NameFunc[24] = DefaultName;
  NamsFunc[24] = 0;
  NargFunc[24] = 1;
@@ -6122,10 +5865,10 @@ static Int PostRestore ( StructInitInfo * module )
  NargFunc[25] = 1;
  NameFunc[26] = DefaultName;
  NamsFunc[26] = 0;
- NargFunc[26] = 1;
+ NargFunc[26] = 2;
  NameFunc[27] = DefaultName;
  NamsFunc[27] = 0;
- NargFunc[27] = 2;
+ NargFunc[27] = 1;
  NameFunc[28] = DefaultName;
  NamsFunc[28] = 0;
  NargFunc[28] = 1;
@@ -6137,7 +5880,7 @@ static Int PostRestore ( StructInitInfo * module )
  NargFunc[30] = 1;
  NameFunc[31] = DefaultName;
  NamsFunc[31] = 0;
- NargFunc[31] = 1;
+ NargFunc[31] = 2;
  NameFunc[32] = DefaultName;
  NamsFunc[32] = 0;
  NargFunc[32] = 2;
@@ -6152,16 +5895,13 @@ static Int PostRestore ( StructInitInfo * module )
  NargFunc[35] = 2;
  NameFunc[36] = DefaultName;
  NamsFunc[36] = 0;
- NargFunc[36] = 2;
+ NargFunc[36] = 3;
  NameFunc[37] = DefaultName;
  NamsFunc[37] = 0;
- NargFunc[37] = 3;
+ NargFunc[37] = -1;
  NameFunc[38] = DefaultName;
  NamsFunc[38] = 0;
  NargFunc[38] = -1;
- NameFunc[39] = DefaultName;
- NamsFunc[39] = 0;
- NargFunc[39] = -1;
  
  /* return success */
  return 0;
@@ -6176,7 +5916,7 @@ static StructInitInfo module = {
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,
  /* version     = */ 0,
- /* crc         = */ 41572953,
+ /* crc         = */ -28108360,
  /* initKernel  = */ InitKernel,
  /* initLibrary = */ InitLibrary,
  /* checkInit   = */ 0,


### PR DESCRIPTION
This PR is just one commit, which tries to improve usage of the type cache by avoiding setting NEW_TYPE_READONLY to true. Instead we pass one more argument to NEW_TYPE.