### PR TITLE
Switch to new travis way of installing packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ branches:
     - master
     - hpcgap-default
 # Change this to your needs
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libgmp3-dev
+addons:
+  apt_packages:
+  - libgmp3-dev
 script:
   - ./configure --with-gmp=system
   - make 


### PR DESCRIPTION
This switches to the new travis way of installing packages. The advantage is that (according to travis) by making sure we never use 'sudo', our builds should be faster!