### PR TITLE
SmallGroups: Fix ShallowCopy for SimpleGroupsIterator

### DIFF
--- a/grp/simple.gi
+++ b/grp/simple.gi
@@ -726,7 +726,7 @@ InstallGlobalFunction(SimpleGroupsIterator,function(arg)
     NextIterator:=NextIterator_SimGp,
     ShallowCopy:=iter -> rec( a:=iter!.a,
       b:=iter!.b, ende:=iter!.ende,
-      stack:=iter!.stack, pos:=iter!.pos,
+      stack:=ShallowCopy(iter!.stack), pos:=iter!.pos,
       nopsl2:=iter!.nopsl2,
       done:=iter!.done),
     a:=a,


### PR DESCRIPTION
As pointed out by Alexander Hulpke in #113, the stack has to be
ShallowCopied as well.