### PR TITLE
Library: Fix iterator printing

### DIFF
--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -1254,7 +1254,6 @@ DeclareOperation( "NextIterator", [ IsIterator and IsMutable ] );
 ##
 DeclareGlobalFunction( "TrivialIterator" );
 
-
 #############################################################################
 ##
 #F  IteratorByFunctions( <record> )
@@ -1291,6 +1290,13 @@ DeclareGlobalFunction( "TrivialIterator" );
 ##      can be called in order to create a new iterator that is independent
 ##      of <A>iter</A> but behaves like <A>iter</A> w.r.t. the operations
 ##      <Ref Func="NextIterator"/> and <Ref Func="IsDoneIterator"/>.
+##  </Item>
+##  <Mark><C>ViewIterator</C></Mark>
+##  <Item>
+##      either a function in one argument <A>iter</A> returning a string describing
+##      the iterator, or a string a describing the iterator. This is used for
+##      PrintObj. This can be left unbound in which case PrintObj called on the
+##      iterator will just print &lt;iterator&gt;.
 ##  </Item>
 ##  </List>
 ##  Further (data) components may be contained in <A>record</A> which can be

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -956,7 +956,7 @@ InstallOtherMethod( NextIterator,
 #F  IteratorByFunctions( <record> )
 ##
 DeclareRepresentation( "IsIteratorByFunctionsRep", IsComponentObjectRep,
-    [ "NextIterator", "IsDoneIterator", "ShallowCopy", "DescIterator" ] );
+    [ "NextIterator", "IsDoneIterator", "ShallowCopy", "ViewIterator" ] );
 
 DeclareSynonym( "IsIteratorByFunctions",
     IsIteratorByFunctionsRep and IsIterator );
@@ -994,7 +994,7 @@ InstallMethod( ShallowCopy,
     new.NextIterator   := iter!.NextIterator;
     new.IsDoneIterator := iter!.IsDoneIterator;
     new.ShallowCopy    := iter!.ShallowCopy;
-    new.DescIterator   := iter!.DescIterator;
+    new.ViewIterator   := iter!.ViewIterator;
     return IteratorByFunctions( new );
     end );
 
@@ -1007,12 +1007,12 @@ InstallMethod( PrintObj,
     if not IsMutable( iter ) then
       Append(msg, " (immutable)");
     fi;
-    if IsBound( iter!.DescIterator ) then
+    if IsBound( iter!.ViewIterator ) then
       Append(msg, " ");
-      if IsFunction(iter!.DescIterator) then
-        Append(msg, iter!.DescIterator(iter));
-      elif IsString(iter!.DescIterator) then
-        Append(msg, iter!.DescIterator);
+      if IsFunction(iter!.ViewIterator) then
+        Append(msg, iter!.ViewIterator(iter));
+      elif IsString(iter!.ViewIterator) then
+        Append(msg, iter!.ViewIterator);
       else
         Error("Invalid description for iterator.");
       fi;

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -956,7 +956,7 @@ InstallOtherMethod( NextIterator,
 #F  IteratorByFunctions( <record> )
 ##
 DeclareRepresentation( "IsIteratorByFunctionsRep", IsComponentObjectRep,
-    [ "NextIterator", "IsDoneIterator", "ShallowCopy" ] );
+    [ "NextIterator", "IsDoneIterator", "ShallowCopy", "DescIterator" ] );
 
 DeclareSynonym( "IsIteratorByFunctions",
     IsIteratorByFunctionsRep and IsIterator );
@@ -994,6 +994,7 @@ InstallMethod( ShallowCopy,
     new.NextIterator   := iter!.NextIterator;
     new.IsDoneIterator := iter!.IsDoneIterator;
     new.ShallowCopy    := iter!.ShallowCopy;
+    new.DescIterator   := iter!.DescIterator;
     return IteratorByFunctions( new );
     end );
 
@@ -1006,12 +1007,12 @@ InstallMethod( PrintObj,
     if not IsMutable( iter ) then
       Append(msg, " (immutable)");
     fi;
-    if IsBound( iter!.description ) then
+    if IsBound( iter!.DescIterator ) then
       Append(msg, " ");
-      if IsFunction(iter!.description) then
-        Append(msg, iter!.description(iter));
-      elif IsString(iter!.description(iter)) then
-        Append(msg, iter!.description);
+      if IsFunction(iter!.DescIterator) then
+        Append(msg, iter!.DescIterator(iter));
+      elif IsString(iter!.DescIterator) then
+        Append(msg, iter!.DescIterator);
       else
         Error("Invalid description for iterator.");
       fi;

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -76,25 +76,12 @@ InstallMethod( PrintObj,
     "for an iterator",
     [ IsIterator ],
     function( iter )
-    local msg;
-    msg := "<iterator";
-    if not IsMutable( iter ) then
-      Append(msg, " (immutable)");
+    if IsMutable( iter ) then
+      Print( "<iterator>" );
+    else
+      Print( "<iterator (immutable)>" );
     fi;
-    if IsBound( iter!.description ) then
-      Append(msg, " ");
-      if IsFunction(iter!.description) then
-        Append(msg, iter!.description(iter));
-      elif IsString(iter!.description(iter)) then
-        Append(msg, iter!.description);
-      else
-        Error("Invalid description for iterator.");
-      fi;
-    fi;
-    Append(msg,">");
-    Print(msg);
-    end );
-
+end );
 
 #############################################################################
 ##
@@ -1010,6 +997,28 @@ InstallMethod( ShallowCopy,
     return IteratorByFunctions( new );
     end );
 
+InstallMethod( PrintObj,
+    "for an iterator",
+    [ IsIteratorByFunctions ],
+    function( iter )
+    local msg;
+    msg := "<iterator";
+    if not IsMutable( iter ) then
+      Append(msg, " (immutable)");
+    fi;
+    if IsBound( iter!.description ) then
+      Append(msg, " ");
+      if IsFunction(iter!.description) then
+        Append(msg, iter!.description(iter));
+      elif IsString(iter!.description(iter)) then
+        Append(msg, iter!.description);
+      else
+        Error("Invalid description for iterator.");
+      fi;
+    fi;
+    Append(msg,">");
+    Print(msg);
+    end );
 
 #############################################################################
 ##

--- a/lib/integer.gi
+++ b/lib/integer.gi
@@ -1593,7 +1593,16 @@ InstallMethod( Iterator,
             end,
         IsDoneIterator := ReturnFalse,
         ShallowCopy := iter -> rec( counter:= iter!.counter ),
-
+        DescIterator := function( iter )
+            local msg;
+            msg := "of Integers at ";
+            if iter!.counter mod 2 = 0 then
+              Append(msg, String(iter!.counter / 2));
+            else
+              Append(msg, String((1 - iter!.counter) / 2));
+            fi;
+            return msg;
+          end,
         counter := 0 ) ) );
 
         

--- a/lib/integer.gi
+++ b/lib/integer.gi
@@ -1593,7 +1593,7 @@ InstallMethod( Iterator,
             end,
         IsDoneIterator := ReturnFalse,
         ShallowCopy := iter -> rec( counter:= iter!.counter ),
-        DescIterator := function( iter )
+        ViewIterator := function( iter )
             local msg;
             msg := "of Integers at ";
             if iter!.counter mod 2 = 0 then


### PR DESCRIPTION
* The description function should only be used if the iterator is
  in IsIteratorByFunctions
* As pointed out by @stevelinton in his comments on #114 for
  IsIterator it is not possible to know whether the iterator is
  even a component object