### PR TITLE
Fix speed regression in pc collectors (HPC-GAP)

### DIFF
--- a/lib/rwspcsng.gi
+++ b/lib/rwspcsng.gi
@@ -16,16 +16,6 @@
 ##
 
 
-BindThreadLocalConstructor("SCOBJ_NW_STACK", ->[]);
-BindThreadLocalConstructor("SCOBJ_LW_STACK", ->[]);
-BindThreadLocalConstructor("SCOBJ_PW_STACK", ->[]);
-BindThreadLocalConstructor("SCOBJ_EW_STACK", ->[]);
-BindThreadLocalConstructor("SCOBJ_GE_STACK", ->[]);
-BindThreadLocalConstructor("SCOBJ_CW_VECTOR", ->"");
-BindThreadLocalConstructor("SCOBJ_CW2_VECTOR", ->"");
-BindThreadLocalConstructor("SCOBJ_MAX_STACK_SIZE", ->256);
-
-
 #############################################################################
 ##
 #R  IsSingleCollectorRep( <obj> )

--- a/src/objccoll-impl.h
+++ b/src/objccoll-impl.h
@@ -16,7 +16,7 @@
 */
 #define SC_PUSH_WORD( word, exp ) \
     if ( ++sp == max ) { \
-        SC_SET_MAX_STACK_SIZE( sc, 2 * SC_MAX_STACK_SIZE(sc) ); \
+        TLS->SC_MAX_STACK_SIZE *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(word); \
@@ -27,7 +27,7 @@
 
 #define SC_PUSH_GEN( gen, exp ) \
     if ( ++sp == max ) { \
-        SC_SET_MAX_STACK_SIZE( sc, 2 * SC_MAX_STACK_SIZE(sc) ); \
+        TLS->SC_MAX_STACK_SIZE *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(gen); \
@@ -186,22 +186,22 @@ Int CombiCollectWord ( Obj sc, Obj vv, Obj w )
     exps = 1UL << (ebits-1);
 
     /* <nw> contains the stack of words to insert                          */
-    vnw = SC_NW_STACK(sc);
+    vnw = TLS->SC_NW_STACK;
 
     /* <lw> contains the word end of the word in <nw>                      */
-    vlw = SC_LW_STACK(sc);
+    vlw = TLS->SC_LW_STACK;
 
     /* <pw> contains the position of the word in <nw> to look at           */
-    vpw = SC_PW_STACK(sc);
+    vpw = TLS->SC_PW_STACK;
 
     /* <ew> contains the unprocessed exponents at position <pw>            */
-    vew = SC_EW_STACK(sc);
+    vew = TLS->SC_EW_STACK;
 
     /* <ge> contains the global exponent of the word                       */
-    vge = SC_GE_STACK(sc);
+    vge = TLS->SC_GE_STACK;
 
     /* get the maximal stack size                                          */
-    max = SC_MAX_STACK_SIZE(sc);
+    max = TLS->SC_MAX_STACK_SIZE;
 
     /* ensure that the stacks are large enough                             */
     if ( SIZE_OBJ(vnw)/sizeof(Obj) < max+1 ) {

--- a/src/objscoll-impl.h
+++ b/src/objscoll-impl.h
@@ -120,7 +120,7 @@ Int VectorWord ( Obj vv, Obj v, Int num )
 */
 #define SC_PUSH_WORD( word, exp ) \
     if ( ++sp == max ) { \
-        SC_SET_MAX_STACK_SIZE( sc, 2 * SC_MAX_STACK_SIZE(sc) ); \
+        TLS->SC_MAX_STACK_SIZE *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(word); \
@@ -257,22 +257,22 @@ Int SingleCollectWord ( Obj sc, Obj vv, Obj w )
     exps = 1UL << (ebits-1);
 
     /* <nw> contains the stack of words to insert                          */
-    vnw = SC_NW_STACK(sc);
+    vnw = TLS->SC_NW_STACK;
 
     /* <lw> contains the word end of the word in <nw>                      */
-    vlw = SC_LW_STACK(sc);
+    vlw = TLS->SC_LW_STACK;
 
     /* <pw> contains the position of the word in <nw> to look at           */
-    vpw = SC_PW_STACK(sc);
+    vpw = TLS->SC_PW_STACK;
 
     /* <ew> contains the unprocessed exponents at position <pw>            */
-    vew = SC_EW_STACK(sc);
+    vew = TLS->SC_EW_STACK;
 
     /* <ge> contains the global exponent of the word                       */
-    vge = SC_GE_STACK(sc);
+    vge = TLS->SC_GE_STACK;
 
     /* get the maximal stack size                                          */
-    max = SC_MAX_STACK_SIZE(sc);
+    max = TLS->SC_MAX_STACK_SIZE;
 
     /* ensure that the stacks are large enough                             */
     if ( SIZE_OBJ(vnw)/sizeof(Obj) < max+1 ) {

--- a/src/objscoll.c
+++ b/src/objscoll.c
@@ -278,7 +278,7 @@ Obj ReducedComm (
     Int *               qtr;        /* pointer into the collect vector     */
 
     /* use 'cwVector' to collect word <u>*<w> to                           */
-    vcw = SC_CW_VECTOR(sc);
+    vcw = TLS->SC_CW_VECTOR;
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     /* check that it has the correct length, unpack <u> into it            */
@@ -296,7 +296,7 @@ Obj ReducedComm (
     }
 
     /* use 'cw2Vector' to collect word <w>*<u> to                          */
-    vc2 = SC_CW2_VECTOR(sc);
+    vc2 = TLS->SC_CW2_VECTOR;
 
     /* check that it has the correct length, unpack <w> into it            */
     if ( fc->vectorWord( vc2, w, num ) == -1 ) {
@@ -348,7 +348,7 @@ Obj ReducedForm (
     Int *               qtr;    /* pointer into the collect vector         */
 
     /* use 'cwVector' to collect word <w> to                               */
-    vcw = SC_CW_VECTOR(sc);
+    vcw = TLS->SC_CW_VECTOR;
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     /* check that it has the correct length                                */
@@ -388,7 +388,7 @@ Obj ReducedLeftQuotient (
     Int *               qtr;        /* pointer into the collect vector     */
 
     /* use 'cwVector' to collect word <w> to                               */
-    vcw = SC_CW_VECTOR(sc);
+    vcw = TLS->SC_CW_VECTOR;
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     /* check that it has the correct length, unpack <w> into it            */
@@ -399,7 +399,7 @@ Obj ReducedLeftQuotient (
     }
 
     /* use 'cw2Vector' to collect word <u> to                              */
-    vc2 = SC_CW2_VECTOR(sc);
+    vc2 = TLS->SC_CW2_VECTOR;
 
     /* check that it has the correct length, unpack <u> into it            */
     if ( fc->vectorWord( vc2, u, num ) == -1 ) {
@@ -443,7 +443,7 @@ Obj ReducedProduct (
     Int *               qtr;        /* pointer into the collect vector     */
 
     /* use 'cwVector' to collect word <w> to                               */
-    vcw = SC_CW_VECTOR(sc);
+    vcw = TLS->SC_CW_VECTOR;
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     /* check that it has the correct length, unpack <w> into it            */
@@ -489,8 +489,8 @@ Obj ReducedPowerSmallInt (
     pow = INT_INTOBJ(vpow);
 
     /* use 'cwVector' and 'cw2Vector to collect words to                   */
-    vcw  = SC_CW_VECTOR(sc);
-    vc2  = SC_CW2_VECTOR(sc);
+    vcw  = TLS->SC_CW_VECTOR;
+    vc2  = TLS->SC_CW2_VECTOR;
     num  = SC_NUMBER_RWS_GENERATORS(sc);
     type = SC_DEFAULT_TYPE(sc);
 
@@ -587,8 +587,8 @@ Obj ReducedQuotient (
     Int *               qtr;        /* pointer into the collect vector     */
 
     /* use 'cwVector' to collect word <w> to                               */
-    vcw  = SC_CW_VECTOR(sc);
-    vc2  = SC_CW2_VECTOR(sc);
+    vcw  = TLS->SC_CW_VECTOR;
+    vc2  = TLS->SC_CW2_VECTOR;
     num  = SC_NUMBER_RWS_GENERATORS(sc);
     type = SC_DEFAULT_TYPE(sc);
 
@@ -707,6 +707,22 @@ Obj FuncFinPowConjCol_ReducedQuotient ( Obj self, Obj sc, Obj w, Obj u )
 }
 
 
+/****************************************************************************
+**
+*F  SET_SCOBJ_MAX_STACK_SIZE( <self>, <size> )
+*/
+Obj FuncSET_SCOBJ_MAX_STACK_SIZE ( Obj self, Obj size )
+{
+    if (IS_INTOBJ(size) && INT_INTOBJ(size) > 0)
+        TLS->SC_MAX_STACK_SIZE = INT_INTOBJ(size);
+    else
+        ErrorQuit( "collect vector must be a positive small integer not a %s",
+                   (Int)TNAM_OBJ(size), 0L );
+
+    return 0;
+}
+
+
 
 
 /****************************************************************************
@@ -749,14 +765,46 @@ static StructGVarFunc GVarFuncs [] = {
       FuncFinPowConjCol_ReducedQuotient,
       "src/objscoll.c:FinPowConjCol_ReducedQuotient" },
 
+    { "SET_SCOBJ_MAX_STACK_SIZE", 1, "size",
+      FuncSET_SCOBJ_MAX_STACK_SIZE,
+      "src/objscoll.c:SET_SCOBJ_MAX_STACK_SIZE" },
+
     { 0 }
 
 };
 
 
+/*
+ * Allocate a Plist of the given length, pre-allocating
+ * the number of entries given by 'reserved'.
+ */
+static inline Obj NewPlist( UInt tnum, UInt len, UInt reserved )
+{
+    Obj obj;
+    obj = NEW_PLIST( tnum, reserved );
+    SET_LEN_PLIST( obj, len );
+    return obj;
+}
+
+/*
+ * Setup the collector stacks etc.
+ */
+static void SetupCollectorStacks()
+{
+    const UInt maxStackSize = 256;
+    TLS->SC_NW_STACK = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    TLS->SC_LW_STACK = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    TLS->SC_PW_STACK = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    TLS->SC_EW_STACK = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    TLS->SC_GE_STACK = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    TLS->SC_CW_VECTOR = NEW_STRING( 0 );
+    TLS->SC_CW2_VECTOR = NEW_STRING( 0 );
+    TLS->SC_MAX_STACK_SIZE = maxStackSize;
+}
+
+
 /****************************************************************************
 **
-
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
 */
 static Int InitKernel (
@@ -764,6 +812,8 @@ static Int InitKernel (
 {
     /* init filters and functions                                          */
     InitHdlrFuncsFromTable( GVarFuncs );
+
+    InstallTLSHandler(SetupCollectorStacks, NULL);
 
     /* return success                                                      */
     return 0;
@@ -806,15 +856,6 @@ static Int InitLibrary (
              INTOBJ_INT(SCP_CLASS) );
     AssGVar( GVarName( "SCP_AVECTOR2" ),
              INTOBJ_INT(SCP_AVECTOR2) );
-
-    SCOBJ_NW_STACK_GVAR = GVarName( "SCOBJ_NW_STACK" );
-    SCOBJ_LW_STACK_GVAR = GVarName( "SCOBJ_LW_STACK" );
-    SCOBJ_PW_STACK_GVAR = GVarName( "SCOBJ_PW_STACK" );
-    SCOBJ_EW_STACK_GVAR = GVarName( "SCOBJ_EW_STACK" );
-    SCOBJ_GE_STACK_GVAR = GVarName( "SCOBJ_GE_STACK" );
-    SCOBJ_CW_VECTOR_GVAR = GVarName( "SCOBJ_CW_VECTOR" );
-    SCOBJ_CW2_VECTOR_GVAR = GVarName( "SCOBJ_CW2_VECTOR" );
-    SCOBJ_MAX_STACK_SIZE_GVAR = GVarName( "SCOBJ_MAX_STACK_SIZE" );
 
     /* export collector number                                             */
     AssGVar( GVarName( "8Bits_SingleCollector" ),

--- a/src/objscoll.h
+++ b/src/objscoll.h
@@ -46,59 +46,23 @@
 #define SC_CONJUGATES(sc) \
     (ADDR_OBJ(sc)[SCP_CONJUGATES])
 
-#define SC_CW_VECTOR(sc) \
-    ValGVarTL( SCOBJ_CW_VECTOR_GVAR )
-
-#define SC_CW2_VECTOR(sc) \
-    ValGVarTL( SCOBJ_CW2_VECTOR_GVAR )
-
 #define SC_DEFAULT_TYPE(sc) \
     (ADDR_OBJ(sc)[SCP_DEFAULT_TYPE])
-
-#define SC_EW_STACK(sc) \
-    ValGVarTL( SCOBJ_EW_STACK_GVAR )
-
-#define SC_GE_STACK(sc) \
-    ValGVarTL( SCOBJ_GE_STACK_GVAR )
 
 #define SC_INVERSES(sc) \
     (ADDR_OBJ(sc)[SCP_INVERSES])
 
-#define SC_LW_STACK(sc) \
-    ValGVarTL( SCOBJ_LW_STACK_GVAR )
-
-#define SC_MAX_STACK_SIZE(sc) \
-    INT_INTOBJ(ValGVarTL( SCOBJ_MAX_STACK_SIZE_GVAR ) )
-
-#define SC_SET_MAX_STACK_SIZE(sc,obj) \
-    AssGVar( SCOBJ_MAX_STACK_SIZE_GVAR, INTOBJ_INT(obj) )
-
 #define SC_NUMBER_RWS_GENERATORS(sc) \
     (INT_INTOBJ((ADDR_OBJ(sc)[SCP_NUMBER_RWS_GENERATORS])))
 
-#define SC_NW_STACK(sc) \
-    ValGVarTL( SCOBJ_NW_STACK_GVAR )
-
 #define SC_POWERS(sc) \
     (ADDR_OBJ(sc)[SCP_POWERS])
-
-#define SC_PW_STACK(sc) \
-    ValGVarTL( SCOBJ_PW_STACK_GVAR )
 
 #define SC_RELATIVE_ORDERS(sc) \
     (ADDR_OBJ(sc)[SCP_RELATIVE_ORDERS])
 
 #define SC_RWS_GENERATORS(sc) \
     (ADDR_OBJ(sc)[SCP_RWS_GENERATORS])
-
-UInt SCOBJ_NW_STACK_GVAR;
-UInt SCOBJ_LW_STACK_GVAR;
-UInt SCOBJ_PW_STACK_GVAR;
-UInt SCOBJ_EW_STACK_GVAR;
-UInt SCOBJ_GE_STACK_GVAR;
-UInt SCOBJ_CW_VECTOR_GVAR;
-UInt SCOBJ_CW2_VECTOR_GVAR;
-UInt SCOBJ_MAX_STACK_SIZE_GVAR;
 
 /****************************************************************************
 **

--- a/src/tls.h
+++ b/src/tls.h
@@ -162,6 +162,16 @@ typedef struct ThreadLocalStorage
   Obj SerializationRegistry;
   Obj SerializationStack;
 
+  /* For objscoll*, objccoll* */
+  Obj SC_NW_STACK;
+  Obj SC_LW_STACK;
+  Obj SC_PW_STACK;
+  Obj SC_EW_STACK;
+  Obj SC_GE_STACK;
+  Obj SC_CW_VECTOR;
+  Obj SC_CW2_VECTOR;
+  UInt SC_MAX_STACK_SIZE;
+
   /* Profiling */
   UInt CountActive;
   UInt LocksAcquired;

--- a/tst/rwspcsng.tst
+++ b/tst/rwspcsng.tst
@@ -62,10 +62,10 @@ gap> rws;
 <<up-to-date single collector, 8 Bits>>
 
 # force stack overflow
-gap> SCOBJ_MAX_STACK_SIZE := 1;;
+gap> SET_SCOBJ_MAX_STACK_SIZE(1);
 gap> IsConfluent(rws);
 true
-gap> SCOBJ_MAX_STACK_SIZE := 1;;
+gap> SET_SCOBJ_MAX_STACK_SIZE(1);
 
 # construct the maximal word
 gap> l := [1..11]*0;;
@@ -416,10 +416,10 @@ gap> Print(List( rws![SCP_INVERSES], ExtRepOfObj ),"\n");
   [ 56, 30 ], [ 57, 1, 58, 1 ], [ 58, 1 ], [ 59, 4 ], [ 60, 4 ], [ 61, 4 ] ]
 
 # force stack overflow
-gap> SCOBJ_MAX_STACK_SIZE := 1;;
+gap> SET_SCOBJ_MAX_STACK_SIZE(1);
 gap> IsConfluent(rws);
 true
-gap> SCOBJ_MAX_STACK_SIZE := 1;;
+gap> SET_SCOBJ_MAX_STACK_SIZE(1);
 
 # construct the maximal word
 gap> l := [1..61]*0;;
@@ -797,10 +797,10 @@ gap> Print(List( rws![SCP_INVERSES], ExtRepOfObj ),"\n");
   [ 56, 30 ], [ 57, 1, 58, 1 ], [ 58, 1 ], [ 59, 4 ], [ 60, 4 ], [ 61, 4 ] ]
 
 # force stack overflow
-gap> SCOBJ_MAX_STACK_SIZE := 1;;
+gap> SET_SCOBJ_MAX_STACK_SIZE(1);
 gap> IsConfluent(rws);
 true
-gap> SCOBJ_MAX_STACK_SIZE := 1;;
+gap> SET_SCOBJ_MAX_STACK_SIZE(1);
 
 # construct the maximal word
 gap> l := [1..61]*0;;


### PR DESCRIPTION
My recent changes to the pc collector code made things slower than they need to be. This commit addresses this.

Below is the full commit message of the single commit in this PR:


We were looking up the collector stacks by quering GAP variables in tight
loops in the C code using VAL_GVAR. Instead of that, we now use InitGlobalBag
to setup C variables to directly reference those stack objects.

As an added side benefit, those stacks are now hidden from the user, and
can thus not be messed with. This also means that the user cannot
manually shrink them. To compensate, a new function SET_SCOBJ_MAX_STACK_SIZE
was provided to allow a force-reset of the stacks.