### PR TITLE
Fix speed regression in pc collectors

### DIFF
--- a/lib/rwspcsng.gi
+++ b/lib/rwspcsng.gi
@@ -16,16 +16,6 @@
 ##
 
 
-SCOBJ_NW_STACK := [];
-SCOBJ_LW_STACK := [];
-SCOBJ_PW_STACK := [];
-SCOBJ_EW_STACK := [];
-SCOBJ_GE_STACK := [];
-SCOBJ_CW_VECTOR := "";
-SCOBJ_CW2_VECTOR := "";
-SCOBJ_MAX_STACK_SIZE := 256;
-
-
 #############################################################################
 ##
 #R  IsSingleCollectorRep( <obj> )

--- a/src/objccoll-impl.h
+++ b/src/objccoll-impl.h
@@ -16,7 +16,7 @@
 */
 #define SC_PUSH_WORD( word, exp ) \
     if ( ++sp == max ) { \
-        SC_SET_MAX_STACK_SIZE( sc, 2 * SC_MAX_STACK_SIZE(sc) ); \
+        SC_MAX_STACK_SIZE *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(word); \
@@ -27,7 +27,7 @@
 
 #define SC_PUSH_GEN( gen, exp ) \
     if ( ++sp == max ) { \
-        SC_SET_MAX_STACK_SIZE( sc, 2 * SC_MAX_STACK_SIZE(sc) ); \
+        SC_MAX_STACK_SIZE *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(gen); \
@@ -186,22 +186,22 @@ Int CombiCollectWord ( Obj sc, Obj vv, Obj w )
     exps = 1UL << (ebits-1);
 
     /* <nw> contains the stack of words to insert                          */
-    vnw = SC_NW_STACK(sc);
+    vnw = SC_NW_STACK;
 
     /* <lw> contains the word end of the word in <nw>                      */
-    vlw = SC_LW_STACK(sc);
+    vlw = SC_LW_STACK;
 
     /* <pw> contains the position of the word in <nw> to look at           */
-    vpw = SC_PW_STACK(sc);
+    vpw = SC_PW_STACK;
 
     /* <ew> contains the unprocessed exponents at position <pw>            */
-    vew = SC_EW_STACK(sc);
+    vew = SC_EW_STACK;
 
     /* <ge> contains the global exponent of the word                       */
-    vge = SC_GE_STACK(sc);
+    vge = SC_GE_STACK;
 
     /* get the maximal stack size                                          */
-    max = SC_MAX_STACK_SIZE(sc);
+    max = SC_MAX_STACK_SIZE;
 
     /* ensure that the stacks are large enough                             */
     if ( SIZE_OBJ(vnw)/sizeof(Obj) < max+1 ) {

--- a/src/objscoll-impl.h
+++ b/src/objscoll-impl.h
@@ -116,7 +116,7 @@ Int VectorWord ( Obj vv, Obj v, Int num )
 */
 #define SC_PUSH_WORD( word, exp ) \
     if ( ++sp == max ) { \
-        SC_SET_MAX_STACK_SIZE( sc, 2 * SC_MAX_STACK_SIZE(sc) ); \
+        SC_MAX_STACK_SIZE *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(word); \
@@ -253,22 +253,22 @@ Int SingleCollectWord ( Obj sc, Obj vv, Obj w )
     exps = 1UL << (ebits-1);
 
     /* <nw> contains the stack of words to insert                          */
-    vnw = SC_NW_STACK(sc);
+    vnw = SC_NW_STACK;
 
     /* <lw> contains the word end of the word in <nw>                      */
-    vlw = SC_LW_STACK(sc);
+    vlw = SC_LW_STACK;
 
     /* <pw> contains the position of the word in <nw> to look at           */
-    vpw = SC_PW_STACK(sc);
+    vpw = SC_PW_STACK;
 
     /* <ew> contains the unprocessed exponents at position <pw>            */
-    vew = SC_EW_STACK(sc);
+    vew = SC_EW_STACK;
 
     /* <ge> contains the global exponent of the word                       */
-    vge = SC_GE_STACK(sc);
+    vge = SC_GE_STACK;
 
     /* get the maximal stack size                                          */
-    max = SC_MAX_STACK_SIZE(sc);
+    max = SC_MAX_STACK_SIZE;
 
     /* ensure that the stacks are large enough                             */
     if ( SIZE_OBJ(vnw)/sizeof(Obj) < max+1 ) {

--- a/src/objscoll.h
+++ b/src/objscoll.h
@@ -46,44 +46,17 @@
 #define SC_CONJUGATES(sc) \
     (ADDR_OBJ(sc)[SCP_CONJUGATES])
 
-#define SC_CW_VECTOR(sc) \
-    VAL_GVAR( SCOBJ_CW_VECTOR_GVAR )
-
-#define SC_CW2_VECTOR(sc) \
-    VAL_GVAR( SCOBJ_CW2_VECTOR_GVAR )
-
 #define SC_DEFAULT_TYPE(sc) \
     (ADDR_OBJ(sc)[SCP_DEFAULT_TYPE])
-
-#define SC_EW_STACK(sc) \
-    VAL_GVAR( SCOBJ_EW_STACK_GVAR )
-
-#define SC_GE_STACK(sc) \
-    VAL_GVAR( SCOBJ_GE_STACK_GVAR )
 
 #define SC_INVERSES(sc) \
     (ADDR_OBJ(sc)[SCP_INVERSES])
 
-#define SC_LW_STACK(sc) \
-    VAL_GVAR( SCOBJ_LW_STACK_GVAR )
-
-#define SC_MAX_STACK_SIZE(sc) \
-    INT_INTOBJ(VAL_GVAR( SCOBJ_MAX_STACK_SIZE_GVAR ) )
-
-#define SC_SET_MAX_STACK_SIZE(sc,obj) \
-    AssGVar( SCOBJ_MAX_STACK_SIZE_GVAR, INTOBJ_INT(obj) )
-
 #define SC_NUMBER_RWS_GENERATORS(sc) \
     (INT_INTOBJ((ADDR_OBJ(sc)[SCP_NUMBER_RWS_GENERATORS])))
 
-#define SC_NW_STACK(sc) \
-    VAL_GVAR( SCOBJ_NW_STACK_GVAR )
-
 #define SC_POWERS(sc) \
     (ADDR_OBJ(sc)[SCP_POWERS])
-
-#define SC_PW_STACK(sc) \
-    VAL_GVAR( SCOBJ_PW_STACK_GVAR )
 
 #define SC_RELATIVE_ORDERS(sc) \
     (ADDR_OBJ(sc)[SCP_RELATIVE_ORDERS])
@@ -91,14 +64,14 @@
 #define SC_RWS_GENERATORS(sc) \
     (ADDR_OBJ(sc)[SCP_RWS_GENERATORS])
 
-UInt SCOBJ_NW_STACK_GVAR;
-UInt SCOBJ_LW_STACK_GVAR;
-UInt SCOBJ_PW_STACK_GVAR;
-UInt SCOBJ_EW_STACK_GVAR;
-UInt SCOBJ_GE_STACK_GVAR;
-UInt SCOBJ_CW_VECTOR_GVAR;
-UInt SCOBJ_CW2_VECTOR_GVAR;
-UInt SCOBJ_MAX_STACK_SIZE_GVAR;
+extern Obj SC_NW_STACK;
+extern Obj SC_LW_STACK;
+extern Obj SC_PW_STACK;
+extern Obj SC_EW_STACK;
+extern Obj SC_GE_STACK;
+extern Obj SC_CW_VECTOR;
+extern Obj SC_CW2_VECTOR;
+extern UInt SC_MAX_STACK_SIZE;
 
 /****************************************************************************
 **

--- a/tst/rwspcsng.tst
+++ b/tst/rwspcsng.tst
@@ -62,10 +62,10 @@ gap> rws;
 <<up-to-date single collector, 8 Bits>>
 
 # force stack overflow
-gap> SCOBJ_MAX_STACK_SIZE := 1;;
+gap> SET_SCOBJ_MAX_STACK_SIZE(1);
 gap> IsConfluent(rws);
 true
-gap> SCOBJ_MAX_STACK_SIZE := 1;;
+gap> SET_SCOBJ_MAX_STACK_SIZE(1);
 
 # construct the maximal word
 gap> l := [1..11]*0;;
@@ -416,10 +416,10 @@ gap> Print(List( rws![SCP_INVERSES], ExtRepOfObj ),"\n");
   [ 56, 30 ], [ 57, 1, 58, 1 ], [ 58, 1 ], [ 59, 4 ], [ 60, 4 ], [ 61, 4 ] ]
 
 # force stack overflow
-gap> SCOBJ_MAX_STACK_SIZE := 1;;
+gap> SET_SCOBJ_MAX_STACK_SIZE(1);
 gap> IsConfluent(rws);
 true
-gap> SCOBJ_MAX_STACK_SIZE := 1;;
+gap> SET_SCOBJ_MAX_STACK_SIZE(1);
 
 # construct the maximal word
 gap> l := [1..61]*0;;
@@ -797,10 +797,10 @@ gap> Print(List( rws![SCP_INVERSES], ExtRepOfObj ),"\n");
   [ 56, 30 ], [ 57, 1, 58, 1 ], [ 58, 1 ], [ 59, 4 ], [ 60, 4 ], [ 61, 4 ] ]
 
 # force stack overflow
-gap> SCOBJ_MAX_STACK_SIZE := 1;;
+gap> SET_SCOBJ_MAX_STACK_SIZE(1);
 gap> IsConfluent(rws);
 true
-gap> SCOBJ_MAX_STACK_SIZE := 1;;
+gap> SET_SCOBJ_MAX_STACK_SIZE(1);
 
 # construct the maximal word
 gap> l := [1..61]*0;;


### PR DESCRIPTION
This is a sibling of PR #144, ported to classic GAP. There, this does not seem to be strictly necessary, but it ensures the code is similar to that HPC-GAP, which should simplify code merges in the future.

One caveat: This gets rid of the recently added `PostRestore` function (see PR #127). Strictly speaking, it shouldn't be necessary, as we re-initialize everything in the C code now anyway. This assumes that one does not save the workspace in the middle of an ongoing collection process... I *think* this is not possible anyway, but am not 100% certain... Anyway, this seems to be a highly improbable and silly thing to do anyway, so I am not overly concerned...