### PR TITLE
Analysis of NewType usage -- DO NOT MERGE

### DIFF
--- a/lib/addcoset.gi
+++ b/lib/addcoset.gi
@@ -37,7 +37,7 @@ InstallMethod( AdditiveCoset,
     IsCollsElms,
     [ IsAdditiveGroup, IsAdditiveElement ], 0,
     function( A, a )
-    return Objectify( NewType( FamilyObj( A ),
+    return Objectify( NewType3( TypeOfTypes, FamilyObj( A ),
                                    IsAdditiveCoset
                                and IsAdditiveCosetDefaultRep ),
                       [ A, a ] );

--- a/lib/addgphom.gi
+++ b/lib/addgphom.gi
@@ -25,7 +25,7 @@ local map;
 
       # make the general mapping
       map:= Objectify(
-        NewType(GeneralMappingsFamily(ElementsFamily(FamilyObj(arg[1])),
+        NewType3( TypeOfTypes,GeneralMappingsFamily(ElementsFamily(FamilyObj(arg[1])),
         ElementsFamily(FamilyObj(arg[2]))),
                                IsSPMappingByFunctionRep
                            and IsSingleValued
@@ -38,7 +38,7 @@ local map;
 
       # make the mapping
       map:= Objectify(
-        NewType(GeneralMappingsFamily(ElementsFamily(FamilyObj(arg[1])),
+        NewType3( TypeOfTypes,GeneralMappingsFamily(ElementsFamily(FamilyObj(arg[1])),
         ElementsFamily(FamilyObj(arg[2]))),
                                IsSPMappingByFunctionWithInverseRep
                            and IsBijective

--- a/lib/addmagma.gi
+++ b/lib/addmagma.gi
@@ -173,7 +173,7 @@ InstallGlobalFunction( SubadditiveMagmaNC, function( M, gens )
     local K, S;
 
     if IsEmpty( gens ) then
-      K:= NewType( FamilyObj(M),
+      K:= NewType3( TypeOfTypes, FamilyObj(M),
                        IsAdditiveMagma
                    and IsTrivial
                    and IsAttributeStoringRep );
@@ -251,7 +251,7 @@ InstallGlobalFunction( SubadditiveMagmaWithZeroNC, function( M, gens )
     local K, S;
 
     if IsEmpty( gens ) then
-      K:= NewType( FamilyObj(M),
+      K:= NewType3( TypeOfTypes, FamilyObj(M),
                        IsAdditiveGroup
                    and IsTrivial
                    and IsAttributeStoringRep );
@@ -323,7 +323,7 @@ InstallGlobalFunction( SubadditiveGroupNC, function( M, gens )
     local K, S;
 
     if IsEmpty( gens ) then
-      K:= NewType( FamilyObj(M),
+      K:= NewType3( TypeOfTypes, FamilyObj(M),
                        IsAdditiveGroup
                    and IsTrivial
                    and IsAttributeStoringRep );
@@ -356,7 +356,7 @@ InstallMethod( AdditiveMagmaByGenerators,
     [ IsCollection ],
     function( gens )
     local M;
-    M:= Objectify( NewType( FamilyObj( gens ),
+    M:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsAdditiveMagma and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfAdditiveMagma( M, AsList( gens ) );
@@ -376,7 +376,7 @@ InstallOtherMethod( AdditiveMagmaByGenerators,
     if not ( IsEmpty(gens) or IsIdenticalObj( FamilyObj(gens), family ) ) then
       Error( "<family> and family of <gens> do not match" );
     fi;
-    M:= Objectify( NewType( family,
+    M:= Objectify( NewType3( TypeOfTypes, family,
                             IsAdditiveMagma and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfAdditiveMagma( M, AsList( gens ) );
@@ -393,7 +393,7 @@ InstallMethod( AdditiveMagmaWithZeroByGenerators,
     [ IsCollection ],
     function( gens )
     local M;
-    M:= Objectify( NewType( FamilyObj( gens ),
+    M:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                        IsAdditiveMagmaWithZero and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfAdditiveMagmaWithZero( M, AsList( gens ) );
@@ -413,7 +413,7 @@ InstallOtherMethod( AdditiveMagmaWithZeroByGenerators,
     if not ( IsEmpty(gens) or IsIdenticalObj( FamilyObj(gens), family ) ) then
       Error( "<family> and family of <gens> do not match" );
     fi;
-    M:= Objectify( NewType( family,
+    M:= Objectify( NewType3( TypeOfTypes, family,
                        IsAdditiveMagmaWithZero and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfAdditiveMagmaWithZero( M, AsList( gens ) );
@@ -430,7 +430,7 @@ InstallMethod( AdditiveGroupByGenerators,
     [ IsCollection ],
     function( gens )
     local M;
-    M:= Objectify( NewType( FamilyObj( gens ),
+    M:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                      IsAdditiveGroup and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfAdditiveGroup( M, AsList( gens ) );
@@ -450,7 +450,7 @@ InstallOtherMethod( AdditiveGroupByGenerators,
     if not ( IsEmpty(gens) or IsIdenticalObj( FamilyObj(gens), family ) ) then
       Error( "<family> and family of <gens> do not match" );
     fi;
-    M:= Objectify( NewType( family,
+    M:= Objectify( NewType3( TypeOfTypes, family,
                      IsAdditiveGroup and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfAdditiveGroup( M, AsList( gens ) );

--- a/lib/adjoin.gi
+++ b/lib/adjoin.gi
@@ -27,7 +27,7 @@ end);
 
 InstallMethod(AdjoinedIdentityDefaultType, [IsFamily],
         function(fam) 
-    return NewType(fam, IsMonoidByAdjoiningIdentityEltRep and 
+    return NewType3( TypeOfTypes,fam, IsMonoidByAdjoiningIdentityEltRep and 
                    IsMonoidByAdjoiningIdentityElt);
 end);
 

--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -42,7 +42,7 @@ InstallMethod( FLMLORByGenerators,
     [ IsRing, IsCollection ],
     function( R, gens )
     local A;
-    A:= Objectify( NewType( FamilyObj( gens ),
+    A:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsFLMLOR and IsAttributeStoringRep ),
                    rec() );
     SetLeftActingDomain( A, R );
@@ -57,7 +57,7 @@ InstallOtherMethod( FLMLORByGenerators,
     [ IsRing, IsHomogeneousList, IsRingElement ],
     function( R, gens, zero )
     local A;
-    A:= Objectify( NewType( CollectionsFamily( FamilyObj( zero ) ),
+    A:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( zero ) ),
                             IsFLMLOR and IsAttributeStoringRep ),
                    rec() );
     SetLeftActingDomain( A, R );
@@ -84,7 +84,7 @@ InstallMethod( FLMLORWithOneByGenerators,
     [ IsRing, IsCollection ],
     function( R, gens )
     local A;
-    A:= Objectify( NewType( FamilyObj( gens ),
+    A:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsFLMLORWithOne and IsAttributeStoringRep ),
                    rec() );
     SetLeftActingDomain( A, R );
@@ -99,7 +99,7 @@ InstallOtherMethod( FLMLORWithOneByGenerators,
     [ IsRing, IsHomogeneousList, IsRingElement ],
     function( R, gens, zero )
     local A;
-    A:= Objectify( NewType( CollectionsFamily( FamilyObj( zero ) ),
+    A:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( zero ) ),
                             IsFLMLORWithOne and IsAttributeStoringRep ),
                    rec() );
     SetLeftActingDomain( A, R );
@@ -195,7 +195,7 @@ end );
 InstallGlobalFunction( SubFLMLORNC, function( arg )
     local S;
     if IsEmpty( arg[2] ) then
-      S:= Objectify( NewType( FamilyObj( arg[1] ),
+      S:= Objectify( NewType3( TypeOfTypes, FamilyObj( arg[1] ),
                                   IsFLMLOR
                               and IsTrivial
                               and IsTwoSidedIdealInParent
@@ -3103,7 +3103,7 @@ InstallOtherMethod( DirectSumOfAlgebras,
                         CanonicalBasis(L){[1..Dimension(A1)]} );
            f2:= LeftModuleGeneralMappingByImages( A2, L, CanonicalBasis(A2),
                         CanonicalBasis(L){[Dimension(A1)+1..Dimension(L)]} );
-           R:= Objectify( NewType( NewFamily( "RootSystemFam", IsObject ),
+           R:= Objectify( NewType3( TypeOfTypes, NewFamily( "RootSystemFam", IsObject ),
                        IsAttributeStoringRep and IsRootSystemFromLieAlgebra ),
                        rec() );
            RV:= List( PositiveRootVectors( R1 ), x -> Image( f1, x ) );

--- a/lib/algfld.gi
+++ b/lib/algfld.gi
@@ -85,8 +85,8 @@ local fam,i,cof,red,rchar,impattr,deg;
 	 IsAlgebraicElementFamily and CanEasilySortElements);
 
   # The two types
-  fam!.baseType := NewType(fam,IsAlgBFRep);
-  fam!.extType := NewType(fam,IsKroneckerConstRep);
+  fam!.baseType := NewType3( TypeOfTypes,fam,IsAlgBFRep);
+  fam!.extType := NewType3( TypeOfTypes,fam,IsKroneckerConstRep);
 
   # Important trivia
   fam!.baseField:=f;
@@ -171,7 +171,7 @@ local f,p,nam,e,fam,colf;
   SetCharacteristic(fam,Characteristic(f));
   fam!.indeterminateName:=nam;
   colf:=CollectionsFamily(fam);
-  e:=Objectify(NewType(colf,IsAlgebraicExtensionDefaultRep),
+  e:=Objectify(NewType3( TypeOfTypes,colf,IsAlgebraicExtensionDefaultRep),
                rec());
 
   fam!.wholeField:=e;
@@ -947,7 +947,7 @@ InstallMethod( CanonicalBasis,
     [ IsAlgebraicExtension ], 0,
     function( F )
     local B;
-    B:= Objectify( NewType( FamilyObj( F ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( F ),
                             IsCanonicalBasisAlgebraicExtension ),
                    rec() );
     SetUnderlyingLeftModule( B, F );

--- a/lib/algfp.gi
+++ b/lib/algfp.gi
@@ -269,7 +269,7 @@ InstallGlobalFunction( FactorFreeAlgebraByRelators, function( F, rels )
     fam := NewFamily( "FamilyElementsFpAlgebra", IsElementOfFpAlgebra );
 
     # Create the default type for the elements.
-    fam!.defaultType := NewType( fam,
+    fam!.defaultType := NewType3( TypeOfTypes, fam,
                        IsElementOfFpAlgebra and IsPackedElementDefaultRep );
 
     fam!.freeAlgebra := F;
@@ -283,7 +283,7 @@ InstallGlobalFunction( FactorFreeAlgebraByRelators, function( F, rels )
     if IsAlgebraWithOne( F ) then
 
       A := Objectify(
-          NewType( CollectionsFamily( fam ),
+          NewType3( TypeOfTypes, CollectionsFamily( fam ),
                        IsSubalgebraFpAlgebra
                    and IsAlgebraWithOne
                    and IsWholeFamily
@@ -298,7 +298,7 @@ InstallGlobalFunction( FactorFreeAlgebraByRelators, function( F, rels )
     else
 
       A := Objectify(
-          NewType( CollectionsFamily( fam ),
+          NewType3( TypeOfTypes, CollectionsFamily( fam ),
                        IsSubalgebraFpAlgebra
                    and IsWholeFamily
                    and IsAttributeStoringRep ),

--- a/lib/alghom.gi
+++ b/lib/alghom.gi
@@ -1088,7 +1088,7 @@ InstallMethod( OperationAlgebraHomomorphism,
     local ophom, image;
 
     # Make the general mapping.
-    ophom:= Objectify( NewType( GeneralMappingsFamily(
+    ophom:= Objectify( NewType3( TypeOfTypes, GeneralMappingsFamily(
                                   ElementsFamily( FamilyObj( A ) ),
                                   CollectionsFamily( FamilyObj(
                                       LeftActingDomain( A ) ) ) ),
@@ -1531,7 +1531,7 @@ InstallMethod( IsomorphismMatrixFLMLOR,
       UseIsomorphismRelation( A, I );
 
       # Make an operation algebra homomorphism.
-      map:= Objectify( NewType( GeneralMappingsFamily(
+      map:= Objectify( NewType3( TypeOfTypes, GeneralMappingsFamily(
                                     ElementsFamily( FamilyObj( A ) ),
                                     ElementsFamily( FamilyObj( imgs ) ) ),
                                   IsSPGeneralMapping
@@ -1709,7 +1709,7 @@ InstallMethod( IsomorphismFpFLMLOR,
 
     # Set the info to compute with a basis of the f.p. algebra.
     SetNiceAlgebraMonomorphism( Fp,
-        Objectify( NewType( GeneralMappingsFamily(
+        Objectify( NewType3( TypeOfTypes, GeneralMappingsFamily(
                               ElementsFamily( FamilyObj( Fp ) ),
                               ElementsFamily( FamilyObj( A ) ) ),
                                 IsSPGeneralMapping

--- a/lib/alglie.gi
+++ b/lib/alglie.gi
@@ -3067,7 +3067,7 @@ InstallMethod( RootSystem,
     # ,\alpha(h_l)], where the h_i form the `Cartan' part of the canonical
     # generators.
     
-    R:= Objectify( NewType( NewFamily( "RootSystemFam", IsObject ),
+    R:= Objectify( NewType3( TypeOfTypes, NewFamily( "RootSystemFam", IsObject ),
                 IsAttributeStoringRep and IsRootSystemFromLieAlgebra ), 
                 rec() );
     SetCanonicalGenerators( R, [ x, y, h ] );
@@ -3478,7 +3478,7 @@ InstallOtherMethod( UniversalEnvelopingAlgebra,
 
     # Enter data to handle elements.
     Fam:= ElementsFamily( FamilyObj( U ) );
-    Fam!.normalizedType:= NewType( Fam,
+    Fam!.normalizedType:= NewType3( TypeOfTypes, Fam,
                                        IsElementOfFpAlgebra
                                    and IsPackedElementDefaultRep
                                    and IsNormalForm );
@@ -3699,7 +3699,7 @@ InstallGlobalFunction( FreeLieAlgebra, function( arg )
     one:= One( R );
     zero:= Zero( R );
 
-    F!.defaultType := NewType( F, IsMagmaRingObjDefaultRep );
+    F!.defaultType := NewType3( TypeOfTypes, F, IsMagmaRingObjDefaultRep );
     F!.familyRing  := FamilyObj( R );
     F!.familyMagma := FamilyObj( M );
     F!.zeroRing    := zero;
@@ -3713,7 +3713,7 @@ InstallGlobalFunction( FreeLieAlgebra, function( arg )
 
 
     # Make the magma ring object.
-    L:= Objectify( NewType( CollectionsFamily( F ),
+    L:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( F ),
                                 IsMagmaRingModuloRelations
                             and IsAttributeStoringRep ),
                    rec() );

--- a/lib/algliess.gi
+++ b/lib/algliess.gi
@@ -614,7 +614,7 @@ SimpleLieAlgebraTypeA_G:= function( type, n, F )
         
     fi;
         
-    R:= Objectify( NewType( NewFamily( "RootSystemFam", IsObject ),
+    R:= Objectify( NewType3( TypeOfTypes, NewFamily( "RootSystemFam", IsObject ),
                 IsAttributeStoringRep and IsRootSystemFromLieAlgebra ), 
                 rec() );
     SetUnderlyingLieAlgebra( R, L );

--- a/lib/algmat.gi
+++ b/lib/algmat.gi
@@ -182,13 +182,13 @@ InstallMethod( FLMLORByGenerators,
     fi;
 
     if ForAll( mats, mat -> ForAll( mat, row -> IsSubset( F, row ) ) ) then
-      A:= Objectify( NewType( FamilyObj( mats ),
+      A:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsFLMLOR
                               and IsGaussianMatrixSpace
                               and IsAttributeStoringRep ),
                      rec() );
     else
-      A:= Objectify( NewType( FamilyObj( mats ),
+      A:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsFLMLOR
                               and IsVectorSpace
                               and IsNonGaussianMatrixSpace
@@ -224,7 +224,7 @@ InstallOtherMethod( FLMLORByGenerators,
       Error( "<zero> must be a square matrix" );
     fi;
 
-    A:= Objectify( NewType( CollectionsFamily( FamilyObj( zero ) ),
+    A:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( zero ) ),
                                 IsFLMLOR
                             and IsGaussianMatrixSpace
                             and IsTrivial
@@ -260,13 +260,13 @@ InstallOtherMethod( FLMLORByGenerators,
     fi;
 
     if ForAll( mats, mat -> ForAll( mat, row -> IsSubset( F, row ) ) ) then
-      A:= Objectify( NewType( FamilyObj( mats ),
+      A:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsFLMLOR
                               and IsGaussianMatrixSpace
                               and IsAttributeStoringRep ),
                      rec() );
     else
-      A:= Objectify( NewType( FamilyObj( mats ),
+      A:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsFLMLOR
                               and IsVectorSpace
                               and IsNonGaussianMatrixSpace
@@ -314,13 +314,13 @@ InstallMethod( FLMLORByGenerators,
     fi;
 
     if ForAll( mats, mat -> ForAll( mat, row -> IsSubset( F, row ) ) ) then
-      A:= Objectify( NewType( FamilyObj( mats ),
+      A:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsFLMLOR
                               and IsGaussianMatrixSpace
                               and IsAttributeStoringRep ),
                      rec() );
     else
-      A:= Objectify( NewType( FamilyObj( mats ),
+      A:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsFLMLOR
                               and IsVectorSpace
                               and IsNonGaussianMatrixSpace
@@ -354,7 +354,7 @@ InstallOtherMethod( FLMLORByGenerators,
       Error( "<zero> must be a square matrix" );
     fi;
 
-    A:= Objectify( NewType( CollectionsFamily( FamilyObj( zero ) ),
+    A:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( zero ) ),
                                 IsFLMLOR
                             and IsGaussianMatrixSpace
                             and IsTrivial
@@ -391,13 +391,13 @@ InstallOtherMethod( FLMLORByGenerators,
     fi;
 
     if ForAll( mats, mat -> ForAll( mat, row -> IsSubset( F, row ) ) ) then
-      A:= Objectify( NewType( FamilyObj( mats ),
+      A:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsFLMLOR
                               and IsGaussianMatrixSpace
                               and IsAttributeStoringRep ),
                      rec() );
     else
-      A:= Objectify( NewType( FamilyObj( mats ),
+      A:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsFLMLOR
                               and IsVectorSpace
                               and IsNonGaussianMatrixSpace
@@ -443,13 +443,13 @@ InstallMethod( FLMLORWithOneByGenerators,
     fi;
 
     if ForAll( mats, mat -> ForAll( mat, row -> IsSubset( F, row ) ) ) then
-      A:= Objectify( NewType( FamilyObj( mats ),
+      A:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsFLMLORWithOne
                               and IsGaussianMatrixSpace
                               and IsAttributeStoringRep ),
                      rec() );
     else
-      A:= Objectify( NewType( FamilyObj( mats ),
+      A:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsFLMLORWithOne
                               and IsVectorSpace
                               and IsNonGaussianMatrixSpace
@@ -484,7 +484,7 @@ InstallOtherMethod( FLMLORWithOneByGenerators,
       Error( "<zero> must be a square matrix" );
     fi;
 
-    A:= Objectify( NewType( CollectionsFamily( FamilyObj( zero ) ),
+    A:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( zero ) ),
                                 IsFLMLORWithOne
                             and IsGaussianMatrixSpace
                             and IsAssociative
@@ -521,13 +521,13 @@ InstallOtherMethod( FLMLORWithOneByGenerators,
     fi;
 
     if ForAll( mats, mat -> ForAll( mat, row -> IsSubset( F, row ) ) ) then
-      A:= Objectify( NewType( FamilyObj( mats ),
+      A:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsFLMLORWithOne
                               and IsGaussianMatrixSpace
                               and IsAttributeStoringRep ),
                      rec() );
     else
-      A:= Objectify( NewType( FamilyObj( mats ),
+      A:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsFLMLORWithOne
                               and IsVectorSpace
                               and IsNonGaussianMatrixSpace
@@ -569,7 +569,7 @@ InstallMethod( TwoSidedIdealByGenerators,
       Error( "entries of <mats> do not have the right dimension" );
     fi;
 
-    I:= Objectify( NewType( FamilyObj( mats ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                 IsFLMLOR
                             and IsGaussianMatrixSpace
                             and IsAttributeStoringRep ),
@@ -601,7 +601,7 @@ InstallMethod( TwoSidedIdealByGenerators,
       Error( "entries of <mats> do not have the right dimension" );
     fi;
 
-    I:= Objectify( NewType( FamilyObj( mats ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                 IsFLMLOR
                             and IsVectorSpace
                             and IsNonGaussianMatrixSpace
@@ -626,7 +626,7 @@ InstallMethod( TwoSidedIdealByGenerators,
     function( A, mats )
     local I;
 
-    I:= Objectify( NewType( FamilyObj( mats ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                 IsFLMLOR
                             and IsGaussianMatrixSpace
                             and IsTrivial
@@ -665,7 +665,7 @@ InstallMethod( LeftIdealByGenerators,
       Error( "entries of <mats> do not have the right dimension" );
     fi;
 
-    I:= Objectify( NewType( FamilyObj( mats ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                 IsFLMLOR
                             and IsGaussianMatrixSpace
                             and IsAttributeStoringRep ),
@@ -696,7 +696,7 @@ InstallMethod( LeftIdealByGenerators,
       Error( "entries of <mats> do not have the right dimension" );
     fi;
 
-    I:= Objectify( NewType( FamilyObj( mats ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                 IsFLMLOR
                             and IsVectorSpace
                             and IsNonGaussianMatrixSpace
@@ -720,7 +720,7 @@ InstallMethod( LeftIdealByGenerators,
     function( A, mats )
     local I;
 
-    I:= Objectify( NewType( FamilyObj( mats ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                 IsFLMLOR
                             and IsGaussianMatrixSpace
                             and IsTrivial
@@ -758,7 +758,7 @@ InstallMethod( RightIdealByGenerators,
       Error( "entries of <mats> do not have the right dimension" );
     fi;
 
-    I:= Objectify( NewType( FamilyObj( mats ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                 IsFLMLOR
                             and IsGaussianMatrixSpace
                             and IsAttributeStoringRep ),
@@ -789,7 +789,7 @@ InstallMethod( RightIdealByGenerators,
       Error( "entries of <mats> do not have the right dimension" );
     fi;
 
-    I:= Objectify( NewType( FamilyObj( mats ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                 IsFLMLOR
                             and IsVectorSpace
                             and IsNonGaussianMatrixSpace
@@ -813,7 +813,7 @@ InstallMethod( RightIdealByGenerators,
     function( A, mats )
     local I;
 
-    I:= Objectify( NewType( FamilyObj( mats ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                 IsFLMLOR
                             and IsGaussianMatrixSpace
                             and IsTrivial
@@ -1469,7 +1469,7 @@ InstallGlobalFunction( EmptyMatrix, function( char )
     fi;
 
     # Construct the matrix.
-    mat:= Objectify( NewType( Fam,
+    mat:= Objectify( NewType3( TypeOfTypes, Fam,
                                   IsList
                               and IsEmpty
                               and IsOrdinaryMatrix

--- a/lib/algrep.gi
+++ b/lib/algrep.gi
@@ -118,7 +118,7 @@ BindGlobal( "BasisOfAlgebraModule",
     function( V, vectors )
     local B, delmod, vecs;
     
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                             IsFiniteBasisDefault and
                             IsBasisOfAlgebraModuleElementSpace and
                             IsAttributeStoringRep ),
@@ -299,7 +299,7 @@ InstallMethod( LeftAlgebraModule,
       local F,type,g,W,gens,B;
 
       F:= LeftActingDomain( A );
-      type:= NewType( NewFamily( "AlgModElementsFam",
+      type:= NewType3( TypeOfTypes, NewFamily( "AlgModElementsFam",
                                     IsLeftAlgebraModuleElement ),
                      IsPackedElementDefaultRep );
       gens:= GeneratorsOfLeftModule( V );
@@ -310,7 +310,7 @@ InstallMethod( LeftAlgebraModule,
           g:= [ Objectify( type, [ Zero(V) ] ) ];
       fi;
       
-      W:= Objectify( NewType( FamilyObj( g ),
+      W:= Objectify( NewType3( TypeOfTypes, FamilyObj( g ),
                             IsLeftModule and IsAttributeStoringRep ),
                    rec() );
       SetLeftActingDomain( W, F );
@@ -326,7 +326,7 @@ InstallMethod( LeftAlgebraModule,
       SetUnderlyingLeftModule( W, V );
       
       if HasBasis( V ) then
-          B:= Objectify( NewType( FamilyObj( W ),
+          B:= Objectify( NewType3( TypeOfTypes, FamilyObj( W ),
                       IsFiniteBasisDefault and
                       IsBasisOfAlgebraModuleElementSpace and
                       IsAttributeStoringRep ),
@@ -360,7 +360,7 @@ InstallMethod( RightAlgebraModule,
       local F,type,g,W,gens,B;
 
       F:= LeftActingDomain( A );
-      type:= NewType( NewFamily( "AlgModElementsFam",
+      type:= NewType3( TypeOfTypes, NewFamily( "AlgModElementsFam",
                                     IsRightAlgebraModuleElement ),
                      IsPackedElementDefaultRep );
       gens:= GeneratorsOfLeftModule( V );
@@ -371,7 +371,7 @@ InstallMethod( RightAlgebraModule,
           g:= [ Objectify( type, [ Zero(V) ] ) ];
       fi;
       
-      W:= Objectify( NewType( FamilyObj( g ),
+      W:= Objectify( NewType3( TypeOfTypes, FamilyObj( g ),
                             IsLeftModule and IsAttributeStoringRep ),
                    rec() );
       SetLeftActingDomain( W, F );
@@ -387,7 +387,7 @@ InstallMethod( RightAlgebraModule,
       SetUnderlyingLeftModule( W, V );
 
       if HasBasis( V ) then
-          B:= Objectify( NewType( FamilyObj( W ),
+          B:= Objectify( NewType3( TypeOfTypes, FamilyObj( W ),
                       IsFiniteBasisDefault and
                       IsBasisOfAlgebraModuleElementSpace and
                       IsAttributeStoringRep ),
@@ -422,7 +422,7 @@ InstallMethod( BiAlgebraModule,
       local   F,  type,  g,  W, Ba, gens;
 
       F:= LeftActingDomain( A );
-      type:= NewType( NewFamily( "AlgModElementsFam",
+      type:= NewType3( TypeOfTypes, NewFamily( "AlgModElementsFam",
                           IsLeftAlgebraModuleElement and
                           IsRightAlgebraModuleElement ),
                        IsPackedElementDefaultRep );
@@ -434,7 +434,7 @@ InstallMethod( BiAlgebraModule,
           g:= [ Objectify( type, [ Zero(V) ] ) ];
       fi;
       
-      W:= Objectify( NewType( FamilyObj( g ),
+      W:= Objectify( NewType3( TypeOfTypes, FamilyObj( g ),
                             IsLeftModule and IsAttributeStoringRep ),
                    rec() );
       SetLeftActingDomain( W, F );
@@ -453,7 +453,7 @@ InstallMethod( BiAlgebraModule,
       SetUnderlyingLeftModule( W, V );
       
       if HasBasis( V ) then
-          Ba:= Objectify( NewType( FamilyObj( W ),
+          Ba:= Objectify( NewType3( TypeOfTypes, FamilyObj( W ),
                       IsFiniteBasisDefault and
                       IsBasisOfAlgebraModuleElementSpace and
                       IsAttributeStoringRep ),
@@ -503,7 +503,7 @@ InstallMethod( MutableBasis,
                                         List( vectors, ExtRepOfObj ) )
             );
 
-    return Objectify( NewType( FamilyObj( vectors ),
+    return Objectify( NewType3( TypeOfTypes, FamilyObj( vectors ),
                                  IsMutableBasis
                              and IsMutable
                              and IsMutableBasisViaUnderlyingMutableBasisRep ),
@@ -524,7 +524,7 @@ InstallOtherMethod( MutableBasis,
                                         ExtRepOfObj( zero ) )
             );
 
-    return Objectify( NewType( CollectionsFamily( FamilyObj( zero ) ),
+    return Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( zero ) ),
                                    IsMutableBasis
                                and IsMutable
                                and IsMutableBasisViaUnderlyingMutableBasisRep ),
@@ -935,7 +935,7 @@ InstallMethod( SubAlgebraModule,
 
       local sub;
 
-      sub:= Objectify( NewType( FamilyObj( V ),
+      sub:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                     IsLeftModule and IsAttributeStoringRep ), rec() );
       SetIsAlgebraModule( sub, true );
       SetLeftActingDomain( sub, LeftActingDomain( V ) );
@@ -971,7 +971,7 @@ InstallOtherMethod( SubAlgebraModule,
          Error( "Usage: SubAlgebraModule( <V>, <gens>, <str>) where the last argument is string \"basis\"" );
       fi;
 
-      sub:= Objectify( NewType( FamilyObj( V ),
+      sub:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                        IsLeftModule and IsAttributeStoringRep ), rec() );
       SetIsAlgebraModule( sub, true );
       SetLeftActingDomain( sub, LeftActingDomain( V ) );
@@ -1610,7 +1610,7 @@ BindGlobal( "BasisOfMonomialSpace",
     function( V, vectors )
     local B;
 
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                             IsFiniteBasisDefault and
                             IsBasisOfMonomialSpaceRep and
                             IsAttributeStoringRep ),
@@ -1929,7 +1929,7 @@ InstallMethod( TensorProductOp,
     fi;
     
     fam:= NewFamily( "TensorElementsFam", IsTensorElement );
-    type:= NewType( fam, IsMonomialElementRep );
+    type:= NewType3( TypeOfTypes, fam, IsMonomialElementRep );
     fam!.monomialElementDefaultType:= type;
     fam!.zeroCoefficient:= Zero( F );
     fam!.constituentBases:= List( list, Basis );
@@ -2335,7 +2335,7 @@ InstallMethod( ExteriorPower,
 
     F:= LeftActingDomain( V );
     fam:= NewFamily( "WedgeElementsFam", IsWedgeElement );
-    type:= NewType( fam, IsMonomialElementRep );
+    type:= NewType3( TypeOfTypes, fam, IsMonomialElementRep );
     fam!.monomialElementDefaultType:= type;
     fam!.zeroCoefficient:= Zero( F );
     fam!.constituentBasis:= Basis( V );
@@ -2659,7 +2659,7 @@ InstallMethod( SymmetricPower,
 
     F:= LeftActingDomain( V );
     fam:= NewFamily( "SymmetricElementsFam", IsSymmetricPowerElement );
-    type:= NewType( fam, IsMonomialElementRep );
+    type:= NewType3( TypeOfTypes, fam, IsMonomialElementRep );
     fam!.monomialElementDefaultType:= type;
     fam!.zeroCoefficient:= Zero( F );
     fam!.constituentBasis:= Basis( V );
@@ -3067,7 +3067,7 @@ BindGlobal( "BasisOfSparseRowSpace",
 
     # Finally we construct the basis.
 
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                 IsBasisOfSparseRowSpaceRep and
                 IsFiniteBasisDefault and
                 IsAttributeStoringRep ),
@@ -3191,12 +3191,12 @@ InstallMethod( FullSparseRowSpace,
 
     fam:= NewFamily( "FamilyOfSparseRowSpaceElements",
                   IsSparseRowSpaceElement );
-    fam!.sparseRowSpaceElementDefaultType:= NewType( fam,
+    fam!.sparseRowSpaceElementDefaultType:= NewType3( TypeOfTypes, fam,
                                                IsPackedElementDefaultRep );
     fam!.zeroCoefficient:= Zero( F );
     bV:= List( [1..n], x -> ObjByExtRep( fam, [ x, One(F) ] ) );
     V:= VectorSpace( F, bV );
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                 IsBasisOfSparseRowSpaceRep and
                 IsFiniteBasisDefault and
                 IsAttributeStoringRep ),
@@ -3419,7 +3419,7 @@ InstallMethod( DirectSumOfAlgebraModules,
 
     F:= LeftActingDomain( list[1] );
     fam:= NewFamily( "DirectSumElementsFam", IsDirectSumElement );
-    type:= NewType( fam, IsPackedElementDefaultRep );
+    type:= NewType3( TypeOfTypes, fam, IsPackedElementDefaultRep );
     fam!.directSumElementDefaultType:= type;
     fam!.zeroCoefficient:= Zero( F );
     fam!.constituentModules:= list;
@@ -3509,13 +3509,13 @@ InstallMethod( DirectSumOfAlgebraModules,
 
     W:= VectorSpace( F, gens, "basis" );
     SetNiceFreeLeftModule( W, niceMod );
-    B:= Objectify( NewType( FamilyObj( V ), IsFiniteBasisDefault and
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ), IsFiniteBasisDefault and
                  IsBasisOfAlgebraModuleElementSpace and
                  IsAttributeStoringRep ), rec() );
     SetUnderlyingLeftModule( B, V );
     SetBasisVectors( B, GeneratorsOfAlgebraModule(V) );
 
-    BW:= Objectify( NewType( FamilyObj( W ), IsBasisByNiceBasis and
+    BW:= Objectify( NewType3( TypeOfTypes, FamilyObj( W ), IsBasisByNiceBasis and
                                             IsAttributeStoringRep ), rec() );
     SetUnderlyingLeftModule( BW, W );
     SetBasisVectors( BW, gens );

--- a/lib/algsc.gi
+++ b/lib/algsc.gi
@@ -601,7 +601,7 @@ BindGlobal( "AlgebraByStructureConstantsArg", function( arglist, filter )
 
     # Construct the default type of the family.
     Fam!.defaultTypeDenseCoeffVectorRep :=
-        NewType( Fam, IsSCAlgebraObj and IsDenseCoeffVectorRep );
+        NewType3( TypeOfTypes, Fam, IsSCAlgebraObj and IsDenseCoeffVectorRep );
 
     SetCharacteristic( Fam, Characteristic( R ) );
     SetCoefficientsFamily( Fam, ElementsFamily( FamilyObj( R ) ) );
@@ -1042,7 +1042,7 @@ InstallMethod( CanonicalBasis,
     [ IsFreeLeftModule and IsSCAlgebraObjCollection and IsFullSCAlgebra ],
     function( A )
     local B;
-    B:= Objectify( NewType( FamilyObj( A ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( A ),
                                 IsCanonicalBasisFullSCAlgebra
                             and IsAttributeStoringRep
                             and IsFiniteBasisDefault

--- a/lib/arith.gi
+++ b/lib/arith.gi
@@ -692,12 +692,12 @@ function(fam)
 local nfam;
   nfam:=NewFamily("AdditiveElementsAsMultiplicativeElementsFamily(...)");
   nfam!.underlyingFamily:=fam;
-  nfam!.defaultType:=NewType(nfam,IsAdditiveElementAsMultiplicativeElementRep);
+  nfam!.defaultType:=NewType3( TypeOfTypes,nfam,IsAdditiveElementAsMultiplicativeElementRep);
   nfam!.defaultTypeOne:=
-    NewType(nfam,IsAdditiveElementAsMultiplicativeElementRep and
+    NewType3( TypeOfTypes,nfam,IsAdditiveElementAsMultiplicativeElementRep and
     IsMultiplicativeElementWithOne);
   nfam!.defaultTypeInverse:=
-    NewType(nfam,IsAdditiveElementAsMultiplicativeElementRep and
+    NewType3( TypeOfTypes,nfam,IsAdditiveElementAsMultiplicativeElementRep and
     IsMultiplicativeElementWithInverse);
   return nfam;
 end);

--- a/lib/basicim.gi
+++ b/lib/basicim.gi
@@ -153,7 +153,7 @@ InstallMethod( BasicImageGroupElement, "for basic image group elt", true,
     [ IsWordWithInverse, IsList, IsList, IsList, IsGroupHomomorphism ], 0, 
     function( word, base, baseImage, orbitGenerators, homFromFree )
         local Type, Rec;
-	Type := NewType( BasicImageEltRepFamily, IsBasicImageEltRep );
+	Type := NewType3( TypeOfTypes, BasicImageEltRepFamily, IsBasicImageEltRep );
 	Rec := rec( Word := word, Base := base, BaseImage := baseImage,
 		    OrbitGenerators := orbitGenerators, HomFromFree := homFromFree );
 	return Objectify( Type, Rec );
@@ -187,7 +187,7 @@ InstallMethod( BasicImageGroupElement, "for basic image group elt", true,
 	base := BaseOfGroup( siftGroup );
 	baseImage := List( base, b -> b^g );
 
-	Type := NewType( BasicImageEltRepFamily, IsBasicImageEltRep );
+	Type := NewType3( TypeOfTypes, BasicImageEltRepFamily, IsBasicImageEltRep );
 	Rec := rec( Word := word, Base := base, BaseImage := baseImage,
 		    OrbitGenerators := orbitGens, HomFromFree := homFromFree );
 	return Objectify( Type, Rec );

--- a/lib/basis.gi
+++ b/lib/basis.gi
@@ -149,7 +149,7 @@ InstallMethod( RelativeBasis,
     fi;
 
     # Construct the relative basis.
-    R:= Objectify( NewType( FamilyObj( vectors ),
+    R:= Objectify( NewType3( TypeOfTypes, FamilyObj( vectors ),
                                 IsFiniteBasisDefault
                             and IsRelativeBasisDefaultRep ),
                    rec() );
@@ -185,7 +185,7 @@ InstallMethod( RelativeBasisNC,
     fi;
 
     # Construct the relative basis.
-    R:= Objectify( NewType( FamilyObj( vectors ),
+    R:= Objectify( NewType3( TypeOfTypes, FamilyObj( vectors ),
                                 IsFiniteBasisDefault
                             and IsRelativeBasisDefaultRep ),
                    rec() );
@@ -1062,7 +1062,7 @@ InstallMethod( IsCanonicalBasis,
 ##
 BasisForFreeModuleByNiceBasis:= function( V )
     local B;
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsBasisByNiceBasis
                             and IsAttributeStoringRep ),
@@ -1090,7 +1090,7 @@ InstallMethod( Basis,
     local B;
 
     # Create the basis object.
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsBasisByNiceBasis
                             and IsAttributeStoringRep ),
@@ -1118,7 +1118,7 @@ InstallMethod( BasisNC,
     local B;
 
     # Create the basis object.
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsBasisByNiceBasis
                             and IsAttributeStoringRep ),
@@ -1277,7 +1277,7 @@ InstallMethod( Basis,
     [ IsFreeLeftModule and IsTrivial ],
     function( V )
     local B;
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsEmpty
                             and IsAttributeStoringRep ),
@@ -1297,7 +1297,7 @@ InstallMethod( Basis,
     fi;
 
     # Construct an empty basis.
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsEmpty
                             and IsAttributeStoringRep ),
@@ -1316,7 +1316,7 @@ InstallMethod( BasisNC,
     local B;
 
     # Construct an empty basis.
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsEmpty
                             and IsAttributeStoringRep ),
@@ -1339,7 +1339,7 @@ InstallMethod( SemiEchelonBasis,
     fi;
 
     # Construct an empty basis.
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsEmpty
                             and IsSemiEchelonized
@@ -1359,7 +1359,7 @@ InstallMethod( SemiEchelonBasisNC,
     local B;
 
     # Construct an empty basis.
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsEmpty
                             and IsSemiEchelonized
@@ -1420,7 +1420,7 @@ DeclareRepresentation( "IsBasisWithReplacedLeftModuleRep",
 InstallGlobalFunction( BasisWithReplacedLeftModule, function( B, V )
     local new;
 
-    new:= Objectify( NewType( FamilyObj( B ),
+    new:= Objectify( NewType3( TypeOfTypes, FamilyObj( B ),
                                   IsFiniteBasisDefault
                               and IsBasisWithReplacedLeftModuleRep ),
                      rec() );

--- a/lib/basismut.gi
+++ b/lib/basismut.gi
@@ -113,7 +113,7 @@ InstallMethod( MutableBasis,
              leftActingDomain := R
             );
 
-    return Objectify( NewType( FamilyObj( vectors ),
+    return Objectify( NewType3( TypeOfTypes, FamilyObj( vectors ),
                                    IsMutableBasis
                                and IsMutable
                                and IsMutableBasisByImmutableBasisRep ),
@@ -134,7 +134,7 @@ InstallOtherMethod( MutableBasis,
              leftActingDomain := R
             );
 
-    return Objectify( NewType( CollectionsFamily( FamilyObj( zero ) ),
+    return Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( zero ) ),
                                    IsMutableBasis
                                and IsMutable
                                and IsMutableBasisByImmutableBasisRep ),
@@ -270,7 +270,7 @@ InstallGlobalFunction( MutableBasisViaNiceMutableBasisMethod2,
              leftModule := M
             );
 
-    return Objectify( NewType( FamilyObj( vectors ),
+    return Objectify( NewType3( TypeOfTypes, FamilyObj( vectors ),
                                    IsMutableBasis
                                and IsMutable
                                and IsMutableBasisViaNiceMutableBasisRep ),
@@ -307,7 +307,7 @@ InstallGlobalFunction( MutableBasisViaNiceMutableBasisMethod3,
       Error( "<M> is not handled via nice bases" );
     fi;
 
-    return Objectify( NewType( CollectionsFamily( FamilyObj( zero ) ),
+    return Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( zero ) ),
                                    IsMutableBasis
                                and IsMutable
                                and IsMutableBasisViaNiceMutableBasisRep ),

--- a/lib/boolean.g
+++ b/lib/boolean.g
@@ -62,7 +62,7 @@ BIND_GLOBAL( "BooleanFamily",
 ##  </ManSection>
 ##
 BIND_GLOBAL( "TYPE_BOOL",
-    NewType( BooleanFamily, IS_BOOL and IsInternalRep ) );
+    NewType3( TypeOfTypes, BooleanFamily, IS_BOOL and IsInternalRep ) );
 
 
 #############################################################################

--- a/lib/clas.gi
+++ b/lib/clas.gi
@@ -115,7 +115,7 @@ local fam,  filter,  cl;
       fi;
       filter:=filter and HasActingDomain and HasRepresentative and
 	      HasFunctionAction;
-      fam!.defaultClassType:=NewType( FamilyObj( G ), filter );
+      fam!.defaultClassType:=NewType3( TypeOfTypes, FamilyObj( G ), filter );
     fi;
 
     cl:=rec( start := [ g ] );
@@ -140,7 +140,7 @@ local fam,  filter,  cl;
       fi;
       filter:=filter and HasActingDomain and HasRepresentative and
 	      HasFunctionAction and HasStabilizerOfExternalSet;
-      fam!.defaultClassCentType:=NewType( FamilyObj( G ), filter );
+      fam!.defaultClassCentType:=NewType3( TypeOfTypes, FamilyObj( G ), filter );
     fi;
 
     cl:=rec( start := [ g ]);

--- a/lib/clas.gi
+++ b/lib/clas.gi
@@ -460,17 +460,17 @@ end );
 ##
 InstallMethod( RationalClass, IsCollsElms, [ IsGroup, IsObject ],
     function( G, g )
-    local   cl;
-
-    cl := Objectify( NewType( FamilyObj( G ) ), rec(  ) );
+    local   filter, cl;
     if IsPermGroup( G )  then
-        SetFilterObj( cl, IsRationalClassPermGroupRep );
+        filter := IsRationalClassPermGroupRep;
     else
-        SetFilterObj( cl, IsRationalClassGroupRep );
+        filter := IsRationalClassGroupRep;
     fi;
-    SetActingDomain( cl, G );
-    SetRepresentative( cl, g );
-    SetFunctionAction( cl, OnPoints );
+    cl := rec(  );
+    ObjectifyWithAttributes( cl, NewType( FamilyObj( G ), filter ),
+	    ActingDomain, G,
+	    Representative, g,
+	    FunctionAction, OnPoints );
     return cl;
 end );
 

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -425,7 +425,7 @@ InstallGlobalFunction( EnumeratorByFunctions, function( D, record )
       Error( "<D> must be a record or a family" );
     fi;
 
-    enum:= Objectify( NewType( Fam, filter ), record );
+    enum:= Objectify( NewType3( TypeOfTypes, Fam, filter ), record );
 
     if IsDomain( D ) then
       SetUnderlyingCollection( enum, D );
@@ -985,7 +985,7 @@ InstallGlobalFunction( IteratorByFunctions, function( record )
     fi;
     filter:= IsIteratorByFunctions and IsMutable;
 
-    return Objectify( NewType( IteratorsFamily, filter ), record );
+    return Objectify( NewType3( TypeOfTypes, IteratorsFamily, filter ), record );
 end );
 
 InstallMethod( IsDoneIterator,

--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -223,7 +223,7 @@ function(U,g,V)
 local d,fam;
   fam:=FamilyObj(U);
   if not IsBound(fam!.doubleCosetsDefaultType) then
-    fam!.doubleCosetsDefaultType:=NewType(fam,IsDoubleCosetDefaultRep
+    fam!.doubleCosetsDefaultType:=NewType3( TypeOfTypes,fam,IsDoubleCosetDefaultRep
           and HasLeftActingGroup and HasRightActingGroup
 	  and HasRepresentative);
   fi;
@@ -240,7 +240,7 @@ function(U,g,V,sz)
 local d,fam;
   fam:=FamilyObj(U);
   if not IsBound(fam!.doubleCosetsDefaultSizeType) then
-    fam!.doubleCosetsDefaultSizeType:=NewType(fam,IsDoubleCosetDefaultRep
+    fam!.doubleCosetsDefaultSizeType:=NewType3( TypeOfTypes,fam,IsDoubleCosetDefaultRep
 	  and HasSize and HasIsFinite and IsFinite
           and HasLeftActingGroup and HasRightActingGroup
 	  and HasRepresentative);
@@ -367,7 +367,7 @@ local d,fam;
 
   fam:=FamilyObj(U);
   if not IsBound(fam!.rightCosetsDefaultType) then
-    fam!.rightCosetsDefaultType:=NewType(fam,IsRightCosetDefaultRep and
+    fam!.rightCosetsDefaultType:=NewType3( TypeOfTypes,fam,IsRightCosetDefaultRep and
           HasActingDomain and HasFunctionAction and HasRepresentative and
 	  HasCanonicalRepresentativeDeterminatorOfExternalSet);
   fi;
@@ -388,7 +388,7 @@ local d,fam;
 
   fam:=FamilyObj(U);
   if not IsBound(fam!.rightCosetsDefaultSizeType) then
-    fam!.rightCosetsDefaultSizeType:=NewType(fam,IsRightCosetDefaultRep and
+    fam!.rightCosetsDefaultSizeType:=NewType3( TypeOfTypes,fam,IsRightCosetDefaultRep and
           HasActingDomain and HasFunctionAction and HasRepresentative and
 	  HasSize and HasCanonicalRepresentativeDeterminatorOfExternalSet);
   fi;
@@ -1080,7 +1080,7 @@ DeclareRepresentation( "IsRightTransversalViaCosetsRep",
 InstallMethod(RightTransversalOp, "generic, use RightCosets",
   IsIdenticalObj,[IsGroup,IsGroup],0,
 function(G,U)
-  return Objectify( NewType( FamilyObj( G ),
+  return Objectify( NewType3( TypeOfTypes, FamilyObj( G ),
 		    IsRightTransversalViaCosetsRep and IsList and 
 		    IsDuplicateFreeList and IsAttributeStoringRep ),
           rec( group := G,
@@ -1177,7 +1177,7 @@ local trans,m,i;
     Add(m,m[Length(m)]*Length(t[i]));
   od;
   m:=Reversed(m);
-  trans:=Objectify(NewType(FamilyObj(G),
+  trans:=Objectify(NewType3( TypeOfTypes,FamilyObj(G),
 			IsFactoredTransversalRep and IsList 
 			and IsDuplicateFreeList and IsAttributeStoringRep),
           rec(group:=G,

--- a/lib/csetpc.gi
+++ b/lib/csetpc.gi
@@ -241,7 +241,7 @@ DeclareRepresentation( "IsRightTransversalPcGroupRep", IsRightTransversalRep,
 DoRightTransversalPc:=function( G, U )
 local elements, g, u, e, i,t,depths,gens,p;
 
-  t := Objectify( NewType( FamilyObj( G ),
+  t := Objectify( NewType3( TypeOfTypes, FamilyObj( G ),
                                IsList and IsDuplicateFreeList
                            and IsRightTransversalPcGroupRep ),
           rec( group :=G,

--- a/lib/csetperm.gi
+++ b/lib/csetperm.gi
@@ -98,7 +98,7 @@ BindGlobal( "RightTransversalPermGroupConstructor", function( filter, G, U )
     AddCosetInfoStabChain(GC,UC,LargestMovedPoint(G));
     MinimizeExplicitTransversal(UC,LargestMovedPoint(G));
 
-    enum := Objectify( NewType( FamilyObj( G ),
+    enum := Objectify( NewType3( TypeOfTypes, FamilyObj( G ),
                            filter and IsList and IsDuplicateFreeList
                            and IsAttributeStoringRep ),
           rec( group := G,

--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -1064,7 +1064,7 @@ InstallMethod( OrdinaryCharacterTable,
     local tbl, ccl, idpos, bijection;
 
     # Make the object.
-    tbl:= Objectify( NewType( NearlyCharacterTablesFamily,
+    tbl:= Objectify( NewType3( TypeOfTypes, NearlyCharacterTablesFamily,
                               IsOrdinaryTable and IsAttributeStoringRep ),
                      rec() );
 
@@ -4315,11 +4315,11 @@ InstallGlobalFunction( ConvertToCharacterTableNC, function( record )
     if not IsBound( record.UnderlyingCharacteristic ) then
       Error( "<record> needs component `UnderlyingCharacteristic'" );
     elif record.UnderlyingCharacteristic = 0 then
-      Objectify( NewType( NearlyCharacterTablesFamily,
+      Objectify( NewType3( TypeOfTypes, NearlyCharacterTablesFamily,
                           IsOrdinaryTable and IsAttributeStoringRep ),
                  record );
     else
-      Objectify( NewType( NearlyCharacterTablesFamily,
+      Objectify( NewType3( TypeOfTypes, NearlyCharacterTablesFamily,
                           IsBrauerTable and IsAttributeStoringRep ),
                  record );
     fi;
@@ -4382,7 +4382,7 @@ InstallGlobalFunction( ConvertToLibraryCharacterTableNC, function( record )
 
     # Make the object.
     if IsBound( record.isGenericTable ) and record.isGenericTable then
-      Objectify( NewType( NearlyCharacterTablesFamily,
+      Objectify( NewType3( TypeOfTypes, NearlyCharacterTablesFamily,
                           IsGenericCharacterTableRep ),
                  record );
     else

--- a/lib/ctblfuns.gi
+++ b/lib/ctblfuns.gi
@@ -1193,7 +1193,7 @@ InstallMethod( ClassFunction,
     fi;
 
     # Create the object.
-    chi:= Objectify( NewType( FamilyObj( values ),
+    chi:= Objectify( NewType3( TypeOfTypes, FamilyObj( values ),
                                   IsClassFunction
                               and IsAttributeStoringRep ),
                      rec() );
@@ -4794,7 +4794,7 @@ InstallOtherMethod( GroupWithGenerators,
     fi;
 
     # Construct the group.
-    G:= Objectify( NewType( FamilyObj( gens ), filter ), rec() );
+    G:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ), filter ), rec() );
     SetGeneratorsOfMagmaWithInverses( G, AsList( gens ) );
     return G;
     end );
@@ -4822,7 +4822,7 @@ InstallOtherMethod( GroupWithGenerators,
     fi;
 
     # Construct the group.
-    G:= Objectify( NewType( FamilyObj( gens ), filter), rec() );
+    G:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ), filter), rec() );
     SetGeneratorsOfMagmaWithInverses( G, AsList( gens ) );
     SetOne( G, id );
     return G;
@@ -4839,7 +4839,7 @@ InstallOtherMethod( GroupWithGenerators,
     fi;
 
     # Construct the group.
-    G:= Objectify( NewType( CollectionsFamily( FamilyObj( id ) ),
+    G:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( id ) ),
                             IsGroup and IsAttributeStoringRep and
 			    IsFinitelyGeneratedGroup and IsTrivial ),
 

--- a/lib/cyclotom.g
+++ b/lib/cyclotom.g
@@ -249,7 +249,7 @@ DeclareRepresentation( "IsSmallIntRep", IsInternalRep, [] );
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_INT_SMALL_ZERO", NewType( CyclotomicsFamily,
+BIND_GLOBAL( "TYPE_INT_SMALL_ZERO", NewType3( TypeOfTypes, CyclotomicsFamily,
                             IsInt and IsZeroCyc and IsSmallIntRep ) );
 
 
@@ -264,7 +264,7 @@ BIND_GLOBAL( "TYPE_INT_SMALL_ZERO", NewType( CyclotomicsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_INT_SMALL_NEG", NewType( CyclotomicsFamily,
+BIND_GLOBAL( "TYPE_INT_SMALL_NEG", NewType3( TypeOfTypes, CyclotomicsFamily,
                             IsInt and IsNegRat and IsSmallIntRep ) );
 
 
@@ -279,7 +279,7 @@ BIND_GLOBAL( "TYPE_INT_SMALL_NEG", NewType( CyclotomicsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_INT_SMALL_POS", NewType( CyclotomicsFamily,
+BIND_GLOBAL( "TYPE_INT_SMALL_POS", NewType3( TypeOfTypes, CyclotomicsFamily,
                             IsPosInt and IsSmallIntRep ) );
 
 
@@ -294,7 +294,7 @@ BIND_GLOBAL( "TYPE_INT_SMALL_POS", NewType( CyclotomicsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_INT_LARGE_NEG", NewType( CyclotomicsFamily,
+BIND_GLOBAL( "TYPE_INT_LARGE_NEG", NewType3( TypeOfTypes, CyclotomicsFamily,
                             IsInt and IsNegRat and IsInternalRep ) );
 
 
@@ -309,7 +309,7 @@ BIND_GLOBAL( "TYPE_INT_LARGE_NEG", NewType( CyclotomicsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_INT_LARGE_POS", NewType( CyclotomicsFamily,
+BIND_GLOBAL( "TYPE_INT_LARGE_POS", NewType3( TypeOfTypes, CyclotomicsFamily,
                             IsPosInt and IsInternalRep ) );
 
 
@@ -324,7 +324,7 @@ BIND_GLOBAL( "TYPE_INT_LARGE_POS", NewType( CyclotomicsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_RAT_NEG", NewType( CyclotomicsFamily,
+BIND_GLOBAL( "TYPE_RAT_NEG", NewType3( TypeOfTypes, CyclotomicsFamily,
                             IsRat and IsNegRat and IsInternalRep ) );
 
 
@@ -339,7 +339,7 @@ BIND_GLOBAL( "TYPE_RAT_NEG", NewType( CyclotomicsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_RAT_POS", NewType( CyclotomicsFamily,
+BIND_GLOBAL( "TYPE_RAT_POS", NewType3( TypeOfTypes, CyclotomicsFamily,
                             IsRat and IsPosRat and IsInternalRep ) );
 
 #############################################################################
@@ -354,7 +354,7 @@ BIND_GLOBAL( "TYPE_RAT_POS", NewType( CyclotomicsFamily,
 ##  </ManSection>
 ##
 BIND_GLOBAL( "TYPE_CYC",
-    NewType( CyclotomicsFamily, IsCyc and IsInternalRep ) );
+    NewType3( TypeOfTypes, CyclotomicsFamily, IsCyc and IsInternalRep ) );
 
 
 #############################################################################
@@ -471,7 +471,7 @@ DeclareCategory( "IsInfinity", IsCyclotomic );
 
 UNBIND_GLOBAL( "infinity" );
 BIND_GLOBAL( "infinity",
-    Objectify( NewType( CyclotomicsFamily, IsInfinity
+    Objectify( NewType3( TypeOfTypes, CyclotomicsFamily, IsInfinity
                         and IsPositionalObjectRep ), [] ) );
 
 InstallMethod( PrintObj,
@@ -506,7 +506,7 @@ InstallMethod( \<,
 DeclareCategory( "IsNegInfinity", IsCyclotomic );
 
 BIND_GLOBAL( "Ninfinity",
-    Objectify( NewType( CyclotomicsFamily, IsNegInfinity
+    Objectify( NewType3( TypeOfTypes, CyclotomicsFamily, IsNegInfinity
                         and IsPositionalObjectRep ), [] ) );
 
 InstallMethod( PrintObj,

--- a/lib/dict.gd
+++ b/lib/dict.gd
@@ -478,10 +478,10 @@ DeclareRepresentation( "IsSparseHashRep",
      "NumberKeys"] );
 
 BindGlobal("DefaultSparseHashRepType",
-  NewType( DictionariesFamily, IsSparseHashRep and IsMutable and IsCopyable ));
+  NewType3( TypeOfTypes, DictionariesFamily, IsSparseHashRep and IsMutable and IsCopyable ));
 
 BindGlobal("DefaultSparseHashWithIKRepType",
-        NewType( DictionariesFamily, IsSparseHashRep and TableHasIntKeyFun 
+        NewType3( TypeOfTypes, DictionariesFamily, IsSparseHashRep and TableHasIntKeyFun 
                 and IsMutable and IsCopyable));
 
 #############################################################################

--- a/lib/dict.gi
+++ b/lib/dict.gi
@@ -27,7 +27,7 @@ local d,rep;
     rep:=IsListDictionary;
     d.list:=[];
   fi;
-  Objectify(NewType(DictionariesFamily,rep and IsMutable and IsCopyable),d);
+  Objectify(NewType3( TypeOfTypes,DictionariesFamily,rep and IsMutable and IsCopyable),d);
   return d;
 end);
 
@@ -42,7 +42,7 @@ local d,rep;
     rep:=IsSortDictionary;
     d.list:=[];
   fi;
-  Objectify(NewType(DictionariesFamily,rep and IsMutable and IsCopyable),d);
+  Objectify(NewType3( TypeOfTypes,DictionariesFamily,rep and IsMutable and IsCopyable),d);
   return d;
 end);
 
@@ -56,28 +56,28 @@ InstallMethod(ShallowCopy, [IsListLookupDictionary and IsCopyable],
         function(dict)
     local   c;
     c := rec( entries := ShallowCopy(dict!.entries) );
-    return Objectify( NewType(DictionariesFamily, IsListLookupDictionary and IsMutable), c);
+    return Objectify( NewType3( TypeOfTypes,DictionariesFamily, IsListLookupDictionary and IsMutable), c);
 end);
 
 InstallMethod(ShallowCopy, [IsListDictionary and IsCopyable],
         function(dict)
     local   c;
     c := rec( list := ShallowCopy(dict!.list) );
-    return Objectify( NewType(DictionariesFamily, IsListDictionary and IsMutable), c);
+    return Objectify( NewType3( TypeOfTypes,DictionariesFamily, IsListDictionary and IsMutable), c);
 end);
 
 InstallMethod(ShallowCopy, [IsSortLookupDictionary and IsCopyable],
         function(dict)
     local   c;
     c := rec( entries := ShallowCopy(dict!.entries) );
-    return Objectify( NewType(DictionariesFamily, IsSortLookupDictionary and IsMutable), c);
+    return Objectify( NewType3( TypeOfTypes,DictionariesFamily, IsSortLookupDictionary and IsMutable), c);
 end);
 
 InstallMethod(ShallowCopy, [IsSortDictionary and IsCopyable],
         function(dict)
     local   c;
     c := rec( list := ShallowCopy(dict!.list) );
-    return Objectify( NewType(DictionariesFamily, IsSortDictionary and IsMutable), c);
+    return Objectify( NewType3( TypeOfTypes,DictionariesFamily, IsSortDictionary and IsMutable), c);
 end);
 
 
@@ -205,7 +205,7 @@ local d,rep;
   else
     rep:=IsPositionDictionary;
   fi;
-  Objectify(NewType(DictionariesFamily,rep and IsMutable and IsCopyable),d);
+  Objectify(NewType3( TypeOfTypes,DictionariesFamily,rep and IsMutable and IsCopyable),d);
   return d;
 end);
 
@@ -214,7 +214,7 @@ InstallMethod(ShallowCopy, [IsPositionDictionary and IsCopyable],
     local   r;
     r := rec( domain := d!.domain,
               blist := ShallowCopy(d!.blist));
-    Objectify(NewType(DictionariesFamily,IsPositionDictionary and IsMutable and IsCopyable),r);
+    Objectify(NewType3( TypeOfTypes,DictionariesFamily,IsPositionDictionary and IsMutable and IsCopyable),r);
     return r;
 end);
         
@@ -224,7 +224,7 @@ InstallMethod(ShallowCopy, [IsPositionLookupDictionary and IsCopyable],
     r := rec( domain := d!.domain,
               blist := ShallowCopy(d!.blist),
               vals := ShallowCopy(d!.vals));
-    Objectify(NewType(DictionariesFamily,IsPositionLookupDictionary and IsMutable and IsCopyable),r);
+    Objectify(NewType3( TypeOfTypes,DictionariesFamily,IsPositionLookupDictionary and IsMutable and IsCopyable),r);
     return r;
 end);
         
@@ -385,7 +385,7 @@ InstallGlobalFunction( DenseHashTable,
     function( )
         local Type, Rec;
 
-        Type := NewType( DictionariesFamily, IsDenseHashRep and IsMutable );
+        Type := NewType3( TypeOfTypes, DictionariesFamily, IsDenseHashRep and IsMutable );
         Rec := rec( KeyArray := [], ValueArray := [] );
         return Objectify( Type, Rec );
     end );

--- a/lib/domain.gi
+++ b/lib/domain.gi
@@ -125,7 +125,7 @@ InstallMethod( DomainByGenerators,
     [ IsFamily, IsList and IsEmpty ],
     function ( F, generators )
     local   D;
-    D := Objectify( NewType( CollectionsFamily( F ),
+    D := Objectify( NewType3( TypeOfTypes, CollectionsFamily( F ),
                              IsDomain and IsAttributeStoringRep ),
                     rec() );
     SetGeneratorsOfDomain( D, AsList( generators ) );
@@ -145,7 +145,7 @@ InstallMethod( DomainByGenerators,
     if IsNotIdenticalObj( CollectionsFamily(F), FamilyObj(generators) ) then
         Error( "each element in <generators> must lie in <F>" );
     fi;
-    D := Objectify( NewType( FamilyObj( generators ),
+    D := Objectify( NewType3( TypeOfTypes, FamilyObj( generators ),
                              IsDomain and IsAttributeStoringRep ),
                     rec() );
     SetGeneratorsOfDomain( D, AsList( generators ) );
@@ -162,7 +162,7 @@ InstallOtherMethod( DomainByGenerators,
     [ IsCollection ],
     function ( generators )
     local   D;
-    D := Objectify( NewType( FamilyObj( generators ),
+    D := Objectify( NewType3( TypeOfTypes, FamilyObj( generators ),
                              IsDomain and IsAttributeStoringRep ),
                     rec() );
     SetGeneratorsOfDomain( D, AsList( generators ) );

--- a/lib/factgrp.gi
+++ b/lib/factgrp.gi
@@ -1371,7 +1371,7 @@ local   map,  pcgs, A, filter,p,i;
   map.sourcePcgsImages := GeneratorsOfGroup( A );
 
   ObjectifyWithAttributes( map,
-  NewType( GeneralMappingsFamily
+  NewType3( TypeOfTypes, GeneralMappingsFamily
 	  ( ElementsFamily( FamilyObj( G ) ),
 	    ElementsFamily( FamilyObj( A ) ) ), filter ), 
 	    Source,G,

--- a/lib/fastendo.gi
+++ b/lib/fastendo.gi
@@ -67,7 +67,7 @@ function(m)
 
 	# create the type if necessary
 	if not IsBound(FamilyObj(m)!.transtype) then
-		FamilyObj(m)!.transtype := NewType(FamilyObj(m), 
+		FamilyObj(m)!.transtype := NewType3( TypeOfTypes,FamilyObj(m), 
 			IsEndoMapping and IsNonSPGeneralMapping 
 			and IsTransformationRepOfEndo);
 	fi;

--- a/lib/ffe.g
+++ b/lib/ffe.g
@@ -57,7 +57,7 @@ BIND_GLOBAL( "TYPE_FFE", function ( p )
     IS_FFE,CanEasilySortElements,CanEasilySortElements );
     SetIsUFDFamily( fam, true );
     SetCharacteristic( fam, p );
-    type:= NewType( fam, IS_FFE and IsInternalRep and HasDegreeFFE);
+    type:= NewType3( TypeOfTypes, fam, IS_FFE and IsInternalRep and HasDegreeFFE);
     TYPES_FFE[p]:= type;
 #T     SetElmWPObj( TYPES_FFE, p, type );
     return type;
@@ -82,7 +82,7 @@ BIND_GLOBAL( "TYPE_FFE0", function ( p )
 #T       fi;
 #T     fi;
     fam:= FamilyType(TYPE_FFE(p));
-    type:= NewType( fam, IS_FFE and IsInternalRep and IsZero and HasIsZero 
+    type:= NewType3( TypeOfTypes, fam, IS_FFE and IsInternalRep and IsZero and HasIsZero 
                    and HasDegreeFFE );
     TYPES_FFE0[p]:= type;
 #T     SetElmWPObj( TYPES_FFE, p, type );

--- a/lib/ffe.gi
+++ b/lib/ffe.gi
@@ -196,7 +196,7 @@ InstallGlobalFunction( FFEFamily, function( p )
 
         # Store the type for the representation of prime field elements
         # via residues.
-        F!.typeOfZmodnZObj:= NewType( F, IsZmodpZObjLarge 
+        F!.typeOfZmodnZObj:= NewType3( TypeOfTypes, F, IsZmodpZObjLarge 
 	  and IsModulusRep and IsZDFRE);
         SetDataType( F!.typeOfZmodnZObj, p );
         F!.typeOfZmodnZObj![ ZNZ_PURE_TYPE ]:= F!.typeOfZmodnZObj;
@@ -969,7 +969,7 @@ InstallMethod( FieldOverItselfByGenerators,
 
     local F, d, q;
 
-    F:= Objectify( NewType( FamilyObj( elms ),
+    F:= Objectify( NewType3( TypeOfTypes, FamilyObj( elms ),
                             IsField and IsAttributeStoringRep ),
                    rec() );
     d:= DegreeFFE( elms );
@@ -1004,7 +1004,7 @@ InstallMethod( FieldByGenerators,
 
     local F, d, subd, q, z;
 
-    F := Objectify( NewType( FamilyObj( gens ),
+    F := Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                              IsField and IsAttributeStoringRep ),
                     rec() );
 

--- a/lib/ffeconway.gi
+++ b/lib/ffeconway.gi
@@ -123,7 +123,7 @@ FFECONWAY.ZNC := function(p,d)
     zc := fam!.ZCache;
     if not IsBound(zc[d]) then
         if not IsBound(fam!.ConwayFldEltDefaultType) then
-            fam!.ConwayFldEltDefaultType := NewType(fam, IsCoeffsModConwayPolRep and IsLexOrderedFFE);
+            fam!.ConwayFldEltDefaultType := NewType3( TypeOfTypes,fam, IsCoeffsModConwayPolRep and IsLexOrderedFFE);
         fi;
         FFECONWAY.SetUpConwayStuff(p,d);
         #

--- a/lib/field.gi
+++ b/lib/field.gi
@@ -29,7 +29,7 @@ InstallMethod( DivisionRingByGenerators,
     [ IsDivisionRing, IsCollection ],
     function( F, gens )
     local D;
-    D:= Objectify( NewType( FamilyObj( gens ),
+    D:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsField and IsAttributeStoringRep ),
                    rec() );
     SetLeftActingDomain( D, F );
@@ -50,7 +50,7 @@ InstallMethod( FieldOverItselfByGenerators,
     if IsEmpty( gens ) then
       Error( "need at least one element" );
     fi;
-    F:= Objectify( NewType( FamilyObj( gens ),
+    F:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsField and IsAttributeStoringRep ),
                    rec() );
     SetLeftActingDomain( F, F );
@@ -151,7 +151,7 @@ end );
 InstallGlobalFunction( SubfieldNC, function( F, gens )
     local S;
     if IsEmpty( gens ) then
-      S:= Objectify( NewType( FamilyObj( F ),
+      S:= Objectify( NewType3( TypeOfTypes, FamilyObj( F ),
                               IsDivisionRing and IsAttributeStoringRep ),
                      rec() );
       SetLeftActingDomain( S, F );

--- a/lib/fieldfin.gi
+++ b/lib/fieldfin.gi
@@ -415,7 +415,7 @@ InstallMethod( Basis,
           k;
 
     # Set up the basis object.
-    B:= Objectify( NewType( FamilyObj( gens ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                                 IsFiniteBasisDefault
                             and IsBasisFiniteFieldRep ),
                    rec() );
@@ -480,7 +480,7 @@ InstallMethod( BasisNC,
           k;
 
     # Set up the basis object.
-    B:= Objectify( NewType( FamilyObj( gens ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                                 IsFiniteBasisDefault
                             and IsBasisFiniteFieldRep ),
                    rec() );

--- a/lib/files.gi
+++ b/lib/files.gi
@@ -26,7 +26,7 @@ DeclareRepresentation(
 ##
 #V  DirectoryType . . . . . . . . . . . . . . . . default type of a directory
 ##
-BindGlobal( "DirectoryType", NewType(
+BindGlobal( "DirectoryType", NewType3( TypeOfTypes,
     DirectoriesFamily,
     IsDirectory and IsDirectoryRep ) );
 

--- a/lib/flag.g
+++ b/lib/flag.g
@@ -25,7 +25,7 @@ BIND_GLOBAL( "FlagsFamily", NewFamily( "FlagsFamily", IsObject ) );
 ##
 #V  TYPE_FLAGS  . . . . . . . . . . . . . . . . . . . . . . . . type of flags
 ##
-BIND_GLOBAL( "TYPE_FLAGS", NewType( FlagsFamily,  IsInternalRep ) );
+BIND_GLOBAL( "TYPE_FLAGS", NewType3( TypeOfTypes, FlagsFamily,  IsInternalRep ) );
 
 
 #############################################################################

--- a/lib/fldabnum.gi
+++ b/lib/fldabnum.gi
@@ -33,7 +33,7 @@ BindGlobal( "AbelianNumberFieldByReducedGaloisStabilizerInfo",
 
     local D, d;
 
-    D:= Objectify( NewType( CollectionsFamily( CyclotomicsFamily ),
+    D:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( CyclotomicsFamily ),
                                 IsField
                             and IsFiniteDimensional
                             and IsAbelianNumberField
@@ -1221,7 +1221,7 @@ InstallMethod( CanonicalBasis,
           l;
 
     # Make the basis object.
-    B:= Objectify( NewType( FamilyObj( F ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( F ),
                                 IsFiniteBasisDefault
                             and IsCanonicalBasis
                             and IsCanonicalBasisAbelianNumberFieldRep ),
@@ -1498,7 +1498,7 @@ InstallMethod( CanonicalBasis,
 
     n:= Conductor( F );
 
-    B:= Objectify( NewType( FamilyObj( F ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( F ),
                                 IsFiniteBasisDefault
                             and IsCanonicalBasis
                             and IsCanonicalBasisCyclotomicFieldRep ),
@@ -1740,7 +1740,7 @@ InstallMethod( Coefficients,
 ##
 #V  Cyclotomics . . . . . . . . . . . . . . . . . .  field of all cyclotomics
 ##
-InstallValue( Cyclotomics, Objectify( NewType(
+InstallValue( Cyclotomics, Objectify( NewType3( TypeOfTypes,
     CollectionsFamily( CyclotomicsFamily ),
     IsField and IsAttributeStoringRep ),
     rec() ) );

--- a/lib/float.gi
+++ b/lib/float.gi
@@ -679,38 +679,38 @@ InstallOtherMethod(RationalFunctionsFamily, "floats pseudofield",
           IsRationalFunctionsFamily);
 
   # default type for polynomials
-  fam!.defaultPolynomialType := NewType( fam,
+  fam!.defaultPolynomialType := NewType3( TypeOfTypes, fam,
 	  IsPolynomial and IsPolynomialDefaultRep and
 	  HasExtRepPolynomialRatFun);
 
   # default type for univariate laurent polynomials
   fam!.threeLaurentPolynomialTypes := 
-    [ NewType( fam,
+    [ NewType3( TypeOfTypes, fam,
 	  IsLaurentPolynomial
 	  and IsLaurentPolynomialDefaultRep and
 	  HasIndeterminateNumberOfLaurentPolynomial and
 	  HasCoefficientsOfLaurentPolynomial), 
 
-	  NewType( fam,
+	  NewType3( TypeOfTypes, fam,
 	    IsLaurentPolynomial
 	    and IsLaurentPolynomialDefaultRep and
 	    HasIndeterminateNumberOfLaurentPolynomial and
 	    HasCoefficientsOfLaurentPolynomial and
 	    IsConstantRationalFunction and IsUnivariatePolynomial),
 
-	  NewType( fam,
+	  NewType3( TypeOfTypes, fam,
 	    IsLaurentPolynomial and IsLaurentPolynomialDefaultRep and
 	    HasIndeterminateNumberOfLaurentPolynomial and
 	    HasCoefficientsOfLaurentPolynomial and
 	    IsUnivariatePolynomial)];
 	      
   # default type for univariate rational functions
-  fam!.univariateRatfunType := NewType( fam,
+  fam!.univariateRatfunType := NewType3( TypeOfTypes, fam,
 	  IsUnivariateRationalFunctionDefaultRep  and
 	  HasIndeterminateNumberOfLaurentPolynomial and
 	  HasCoefficientsOfUnivariateRationalFunction);
 	      
-  fam!.defaultRatFunType := NewType( fam,
+  fam!.defaultRatFunType := NewType3( TypeOfTypes, fam,
           IsRationalFunctionDefaultRep and
 	  HasExtRepNumeratorRatFun and HasExtRepDenominatorRatFun);
 
@@ -837,7 +837,7 @@ function( r, n )
                      #and IsAlgebraWithOne; # done above already
     fi;
     
-    prng := Objectify( NewType( CollectionsFamily(rfun), type ), rec() );
+    prng := Objectify( NewType3( TypeOfTypes, CollectionsFamily(rfun), type ), rec() );
 
     # set the left acting domain
     SetLeftActingDomain( prng, r );

--- a/lib/fpmon.gi
+++ b/lib/fpmon.gi
@@ -190,12 +190,12 @@ function( F, rels )
     fam!.freeMonoid:= F;
     fam!.relations := Immutable( rels );
 
-    fam!.defaultType := NewType( fam, IsElementOfFpMonoid
+    fam!.defaultType := NewType3( TypeOfTypes, fam, IsElementOfFpMonoid
       and IsPackedElementDefaultRep );
 
     # Create the monoid
     s := Objectify(
-        NewType( CollectionsFamily( fam ),
+        NewType3( TypeOfTypes, CollectionsFamily( fam ),
         IsMonoid and IsFpMonoid and IsAttributeStoringRep),
         rec() );
 

--- a/lib/fpsemi.gi
+++ b/lib/fpsemi.gi
@@ -161,12 +161,12 @@ function( F, rels )
     fam!.freeSemigroup := F;
     fam!.relations := Immutable( rels );
 
-    fam!.defaultType := NewType( fam, IsElementOfFpSemigroup 
+    fam!.defaultType := NewType3( TypeOfTypes, fam, IsElementOfFpSemigroup 
 			and IsPackedElementDefaultRep );
 
     # Create the semigroup.
     S := Objectify(
-        NewType( CollectionsFamily( fam ),
+        NewType3( TypeOfTypes, CollectionsFamily( fam ),
         IsSemigroup and IsFpSemigroup and IsAttributeStoringRep),
         rec() );
 

--- a/lib/function.g
+++ b/lib/function.g
@@ -103,7 +103,7 @@ BIND_GLOBAL( "FunctionsFamily", NewFamily( "FunctionsFamily", IsFunction ) );
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_FUNCTION", NewType( FunctionsFamily,
+BIND_GLOBAL( "TYPE_FUNCTION", NewType3( TypeOfTypes, FunctionsFamily,
                           IsFunction and IsInternalRep ) );
 
 
@@ -119,7 +119,7 @@ BIND_GLOBAL( "TYPE_FUNCTION", NewType( FunctionsFamily,
 ##  </ManSection>
 ##
 BIND_GLOBAL( "TYPE_OPERATION",
-    NewType( FunctionsFamily,
+    NewType3( TypeOfTypes, FunctionsFamily,
              IsFunction and IsOperation and IsInternalRep ) );
 
 

--- a/lib/gaussian.gi
+++ b/lib/gaussian.gi
@@ -60,7 +60,7 @@ InstallMethod( CanonicalBasis,
     function( GaussianIntegers )
     local B;
 
-    B:= Objectify( NewType( FamilyObj( GaussianIntegers ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( GaussianIntegers ),
                                 IsFiniteBasisDefault
                             and IsCanonicalBasis
                             and IsCanonicalBasisGaussianIntegersRep ),

--- a/lib/ghom.gi
+++ b/lib/ghom.gi
@@ -391,7 +391,7 @@ local   filter,  hom,pcgs,imgso,mapi,l,obj_args,p;
   fi;
 
   obj_args[2] := 
-    NewType( GeneralMappingsFamily( ElementsFamily( FamilyObj( G ) ),
+    NewType3( TypeOfTypes, GeneralMappingsFamily( ElementsFamily( FamilyObj( G ) ),
                                     ElementsFamily( FamilyObj( H ) ) ),
              filter );
 
@@ -953,7 +953,7 @@ InstallMethod( ConjugatorIsomorphism,
     local fam, hom;
 
     fam:= ElementsFamily( FamilyObj( G ) );
-    hom:= Objectify( NewType( GeneralMappingsFamily( fam, fam ),
+    hom:= Objectify( NewType3( TypeOfTypes, GeneralMappingsFamily( fam, fam ),
                                   IsConjugatorIsomorphism
                               and IsSPGeneralMapping
                               and IsAttributeStoringRep ),
@@ -977,7 +977,7 @@ InstallMethod( ConjugatorAutomorphismNC,
     local fam, hom;
 
     fam:= ElementsFamily( FamilyObj( G ) );
-    hom:= Objectify( NewType( GeneralMappingsFamily( fam, fam ),
+    hom:= Objectify( NewType3( TypeOfTypes, GeneralMappingsFamily( fam, fam ),
                                   IsConjugatorAutomorphism
                               and IsSPGeneralMapping
                               and IsAttributeStoringRep ),
@@ -1533,7 +1533,7 @@ local map,type,prefun;
 
       # make the general mapping
       map:= Objectify(
-        NewType(GeneralMappingsFamily(ElementsFamily(FamilyObj(arg[1])),
+        NewType3( TypeOfTypes,GeneralMappingsFamily(ElementsFamily(FamilyObj(arg[1])),
         ElementsFamily(FamilyObj(arg[2]))),type),
                        rec( fun:= arg[3] ) );
       if prefun<>fail then
@@ -1545,7 +1545,7 @@ local map,type,prefun;
 
       # make the mapping
       map:= Objectify(
-        NewType(GeneralMappingsFamily(ElementsFamily(FamilyObj(arg[1])),
+        NewType3( TypeOfTypes,GeneralMappingsFamily(ElementsFamily(FamilyObj(arg[1])),
         ElementsFamily(FamilyObj(arg[2]))),
                                IsSPMappingByFunctionWithInverseRep
                            and IsBijective

--- a/lib/ghompcgs.gi
+++ b/lib/ghompcgs.gi
@@ -61,7 +61,7 @@ local hom, pcgs, pcgsimgs, H, filter, G;
               sourcePcgsImages := pcgsimgs);
 
     ObjectifyWithAttributes(hom,
-              NewType( 
+              NewType3( TypeOfTypes, 
                 GeneralMappingsFamily( ElementsFamily( FamilyObj( G ) ),
                                        ElementsFamily( FamilyObj( H ) ) ),
                 filter ),
@@ -96,7 +96,7 @@ local fam,hom, pcgs, pcgsimgs, G;
 
   fam:=FamilyObj(hom1);
   if not IsBound(fam!.defaultAutomorphismType) then
-    fam!.defaultAutomorphismType:=NewType(fam,
+    fam!.defaultAutomorphismType:=NewType3( TypeOfTypes,fam,
       IsPcGroupHomomorphismByImages and IsToPcGroupHomomorphismByImages and
       IsTotal and IsInjective and IsSurjective and
       HasSource and HasRange and HasImagesSource and HasPreImagesRange);
@@ -536,7 +536,7 @@ InstallMethod( NaturalHomomorphismByNormalSubgroupOp, IsIdenticalObj,
     pF:=Pcgs(F);
     imgs:=List(pcgsG,i->PcElementByExponents(pF,
               ExponentsOfPcElement(pcgsF,i)));
-    hom:=Objectify( NewType( GeneralMappingsFamily
+    hom:=Objectify( NewType3( TypeOfTypes, GeneralMappingsFamily
                   ( ElementsFamily( FamilyObj( G ) ),
                     ElementsFamily( FamilyObj( F ) ) ),
                   IsPcgsToPcgsHomomorphism ),

--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -819,7 +819,7 @@ local I,n,fam,typ,gens,hgens,id,i,e,info,W,p,dom;
   fi;
 
   fam:=NewFamily("WreathProductElemFamily",IsWreathProductElement);
-  typ:=NewType(fam,IsWreathProductElementDefaultRep);
+  typ:=NewType3( TypeOfTypes,fam,IsWreathProductElementDefaultRep);
   fam!.defaultType:=typ;
   info:=rec(groups:=[G,H],
 	    family:=fam,

--- a/lib/gprdperm.gi
+++ b/lib/gprdperm.gi
@@ -124,7 +124,7 @@ InstallMethod( Embedding,"perm direct product", true,
     info := DirectProductInfo( D );
     if IsBound( info.embeddings[i] ) then return info.embeddings[i]; fi;
     
-    emb := Objectify( NewType( GeneralMappingsFamily( PermutationsFamily,
+    emb := Objectify( NewType3( TypeOfTypes, GeneralMappingsFamily( PermutationsFamily,
                                                       PermutationsFamily ),
                    IsEmbeddingDirectProductPermGroup ),
                    rec( component := i ) );
@@ -245,7 +245,7 @@ InstallMethod( Projection,"perm direct product", true,
     info := DirectProductInfo( D );
     if IsBound( info.projections[i] ) then return info.projections[i]; fi;
     
-    prj := Objectify( NewType( GeneralMappingsFamily( PermutationsFamily,
+    prj := Objectify( NewType3( TypeOfTypes, GeneralMappingsFamily( PermutationsFamily,
                                                       PermutationsFamily ),
                    IsProjectionDirectProductPermGroup ),
                    rec( component := i ) );
@@ -418,7 +418,7 @@ InstallMethod( Projection,"perm subdirect product",true,
     info := SubdirectProductInfo( S );
     if IsBound( info.projections[i] ) then return info.projections[i]; fi;
     
-    prj := Objectify( NewType( GeneralMappingsFamily( PermutationsFamily,
+    prj := Objectify( NewType3( TypeOfTypes, GeneralMappingsFamily( PermutationsFamily,
                                                       PermutationsFamily ),
                    IsProjectionSubdirectProductPermGroup ),
                    rec( component := i ) );
@@ -655,7 +655,7 @@ local	G,H,	    # factors
       degI   := degI,
       hgens  := hgens,
       components := components,
-      embeddingType := NewType(
+      embeddingType := NewType3( TypeOfTypes,
                  GeneralMappingsFamily(PermutationsFamily,PermutationsFamily),
 		 IsEmbeddingImprimitiveWreathProductPermGroup),
       embeddings := [],
@@ -898,7 +898,7 @@ InstallGlobalFunction( WreathProductProductAction, function( G, H )
       basegens := basegens,
       base   := SubgroupNC(W,Flat(basegens)),
       hgens  := hgens,
-      embeddingType := NewType(
+      embeddingType := NewType3( TypeOfTypes,
                  GeneralMappingsFamily(PermutationsFamily,PermutationsFamily),
 		 IsEmbeddingProductActionWreathProductPermGroup),
       embeddings := []);

--- a/lib/gptransv.gi
+++ b/lib/gptransv.gi
@@ -86,7 +86,7 @@ InstallGlobalFunction( SchreierTransversal,
 	fi;
 	AddHashEntry( hashTable, basePoint, "at base point" );
         AddHashEntry( hashDepth, basePoint, 0 );
-	Type := NewType( TransvBySchreierTreeFamily,
+	Type := NewType3( TypeOfTypes, TransvBySchreierTreeFamily,
                          IsRightTransversal and IsTransvBySchreierTree );
 	Rec := rec( OrbitGenerators := [],
                     StrongGenerators := strongGens,
@@ -627,7 +627,7 @@ InstallGlobalFunction( HomTransversal,
     function( h )
     local quo, Type, Rec, obj;
     quo := QuotientGroupByHomomorphism( h );
-    Type := NewType( TransvByHomomorphismFamily, IsRightTransversal 
+    Type := NewType3( TypeOfTypes, TransvByHomomorphismFamily, IsRightTransversal 
                     and IsTransvByHomomorphism );
     Rec := rec( Homomorphism := h,
                 NumberSifted := 0 );
@@ -757,7 +757,7 @@ function( proj, inj )
     if Source( proj ) <> Range( inj ) or Range( proj ) <> Source( inj ) then
 	Error("incorrect proj and inj");
     fi;
-    Type := NewType( TransvByDirProdFamily, IsRightTransversal 
+    Type := NewType3( TypeOfTypes, TransvByDirProdFamily, IsRightTransversal 
                     and IsTransvByDirProd );
     Rec := rec( Projection := proj,
                 Injection := inj,
@@ -874,7 +874,7 @@ function( G )
 #    if not HasSize(G) then Print("WARNING:  creating transversal by",
 #        " trivial group\n  without knowing size of original group\n");
 #    fi;
-    Type := NewType( TransvByTrivSubgrpFamily, IsRightTransversal 
+    Type := NewType3( TypeOfTypes, TransvByTrivSubgrpFamily, IsRightTransversal 
                     and IsTransvByTrivSubgrp );
     Rec := rec( Group := G, NumberSifted := 0 );
     return Objectify( Type, Rec );
@@ -968,7 +968,7 @@ InstallMethod( SiftOneLevel, "for transversal by trivial subgroup", true,
 InstallGlobalFunction( TransversalBySiftFunction,
 function( supergroup, subgroup, sift )
     local Type, Rec;
-    Type := NewType( TransvBySiftFunctFamily, IsRightTransversal 
+    Type := NewType3( TypeOfTypes, TransvBySiftFunctFamily, IsRightTransversal 
                     and IsTransvBySiftFunct );
     Rec := rec( Sift := sift, ParentGroup := supergroup,
                 Subgroup := subgroup, NumberSifted := 0 );

--- a/lib/groebner.gi
+++ b/lib/groebner.gi
@@ -19,7 +19,7 @@ end);
 
 BindGlobal("MakeMonomialOrdering",function(name,ercomp)
 local obj;
-  obj:=Objectify(NewType(MonomialOrderingsFamily,IsMonomialOrderingDefaultRep),
+  obj:=Objectify(NewType3( TypeOfTypes,MonomialOrderingsFamily,IsMonomialOrderingDefaultRep),
                  rec());
   SetName(obj,name);
   SetMonomialExtrepComparisonFun(obj,ercomp);

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -3730,7 +3730,7 @@ InstallMethod( GroupWithGenerators,
     if IsFinite(gens) then
       if not IsBound(fam!.defaultFinitelyGeneratedGroupType) then
         fam!.defaultFinitelyGeneratedGroupType:=
-          NewType(fam,IsGroup and IsAttributeStoringRep
+          NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep
                       and HasGeneratorsOfMagmaWithInverses
                       and IsFinitelyGeneratedGroup);
       fi;
@@ -3738,7 +3738,7 @@ InstallMethod( GroupWithGenerators,
     else
       if not IsBound(fam!.defaultGroupType) then
         fam!.defaultGroupType:=
-          NewType(fam,IsGroup and IsAttributeStoringRep
+          NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep
                       and HasGeneratorsOfMagmaWithInverses);
       fi;
       typ:=fam!.defaultGroupType;
@@ -3760,7 +3760,7 @@ InstallMethod( GroupWithGenerators,
     if IsFinite(gens) then
       if not IsBound(fam!.defaultFinitelyGeneratedGroupWithOneType) then
         fam!.defaultFinitelyGeneratedGroupWithOneType:=
-          NewType(fam,IsGroup and IsAttributeStoringRep
+          NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep
                       and HasGeneratorsOfMagmaWithInverses
                       and IsFinitelyGeneratedGroup and HasOne);
       fi;
@@ -3768,7 +3768,7 @@ InstallMethod( GroupWithGenerators,
     else
       if not IsBound(fam!.defaultGroupWithOneType) then
         fam!.defaultGroupWithOneType:=
-          NewType(fam,IsGroup and IsAttributeStoringRep
+          NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep
                       and HasGeneratorsOfMagmaWithInverses and HasOne);
       fi;
       typ:=fam!.defaultGroupWithOneType;
@@ -3790,7 +3790,7 @@ InstallMethod( GroupWithGenerators,
     fam:= CollectionsFamily( FamilyObj( id ) );
     if not IsBound( fam!.defaultFinitelyGeneratedGroupWithOneType ) then
       fam!.defaultFinitelyGeneratedGroupWithOneType:=
-        NewType( fam, IsGroup and IsAttributeStoringRep
+        NewType3( TypeOfTypes, fam, IsGroup and IsAttributeStoringRep
                       and HasGeneratorsOfMagmaWithInverses
                       and IsFinitelyGeneratedGroup and HasOne );
     fi;
@@ -3942,7 +3942,7 @@ InstallMethod(\in,
 InstallGlobalFunction( SubgroupByProperty, function( G, prop )
 local K, S;
 
-  K:= NewType( FamilyObj(G), IsMagmaWithInverses
+  K:= NewType3( TypeOfTypes, FamilyObj(G), IsMagmaWithInverses
                   and IsAttributeStoringRep 
                   and HasElementTestFunction);
   S:=rec();
@@ -3985,7 +3985,7 @@ end );
 InstallGlobalFunction( SubgroupShell, function( G )
 local K, S;
 
-  K:= NewType( FamilyObj(G), IsMagmaWithInverses
+  K:= NewType3( TypeOfTypes, FamilyObj(G), IsMagmaWithInverses
                   and IsAttributeStoringRep);
   S:=rec();
   Objectify(K,S);

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -399,7 +399,7 @@ end);
 ##
 InstallGlobalFunction(SubgroupOfWholeGroupByCosetTable,function(fam,tab)
 local S;
-  S := Objectify(NewType(fam,IsGroup and IsAttributeStoringRep ),
+  S := Objectify(NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep ),
         rec() ); 
   SetParent(S,fam!.wholeGroup);
   SetCosetTableInWholeGroup(S,tab);
@@ -423,7 +423,7 @@ local S;
 #    return S;
 #  fi;
 
-  S := Objectify(NewType(fam, IsGroup and
+  S := Objectify(NewType3( TypeOfTypes,fam, IsGroup and
     IsSubgroupOfWholeGroupByQuotientRep and IsAttributeStoringRep ),
         rec(quot:=Q,sub:=U) ); 
   SetParent(S,fam!.wholeGroup);
@@ -1528,14 +1528,14 @@ BindGlobal( "FactorFreeGroupByRelators", function( F, rels )
     fam := NewFamily( "FamilyElementsFpGroup", IsElementOfFpGroup );
 
     # Create the default type for the elements.
-    fam!.defaultType := NewType( fam, IsPackedElementDefaultRep );
+    fam!.defaultType := NewType3( TypeOfTypes, fam, IsPackedElementDefaultRep );
 
     fam!.freeGroup := F;
     fam!.relators := Immutable( rels );
 
     # Create the group.
     G := Objectify(
-        NewType( CollectionsFamily( fam ),
+        NewType3( TypeOfTypes, CollectionsFamily( fam ),
             IsSubgroupFpGroup and IsWholeFamily and IsAttributeStoringRep ),
         rec() );
 
@@ -5124,7 +5124,7 @@ local G,T,gens,g,reps,ng,index,i,j,ndef,n,iso;
 
   if index=1 then
     # trivial case
-    return Objectify( NewType( FamilyObj( OG ),
+    return Objectify( NewType3( TypeOfTypes, FamilyObj( OG ),
 		      IsRightTransversalFpGroupRep and IsList and 
 		      IsDuplicateFreeList and IsAttributeStoringRep ),
       rec( group := OG,
@@ -5144,7 +5144,7 @@ local G,T,gens,g,reps,ng,index,i,j,ndef,n,iso;
         #this is true because T is 'standardized' 
         ndef := ndef+1;
 	if ndef=index then 
-	  return Objectify( NewType( FamilyObj( OG ),
+	  return Objectify( NewType3( TypeOfTypes, FamilyObj( OG ),
 			    IsRightTransversalFpGroupRep and IsList and 
 			    IsDuplicateFreeList and IsAttributeStoringRep ),
 	    rec( group := OG,

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -87,7 +87,7 @@ local filter,cl;
     else
       filter:=IsConjugacyClassSubgroupsRep;
     fi;
-    cl:=Objectify(NewType(CollectionsFamily(FamilyObj(G)),
+    cl:=Objectify(NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(G)),
       filter),rec());
     SetActingDomain(cl,G);
     SetRepresentative(cl,U);
@@ -219,7 +219,7 @@ local lattice;
 	end);
 
   # create the lattice
-  lattice:=Objectify(NewType(FamilyObj(classes),IsLatticeSubgroupsRep),
+  lattice:=Objectify(NewType3( TypeOfTypes,FamilyObj(classes),IsLatticeSubgroupsRep),
     rec(conjugacyClassesSubgroups:=classes,
         group:=G));
 

--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -817,7 +817,7 @@ InstallMethod( GroupWithGenerators,
     if IsFinite(gens) then
       if not IsBound(fam!.defaultFinitelyGeneratedGroupType) then
 	fam!.defaultFinitelyGeneratedGroupType:=
-	  NewType(fam,IsGroup and IsAttributeStoringRep
+	  NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep
 		      and HasGeneratorsOfMagmaWithInverses
 		      and IsFinitelyGeneratedGroup);
       fi;
@@ -846,7 +846,7 @@ local G,fam,typ,f;
     if IsFinite(gens) then
       if not IsBound(fam!.defaultFinitelyGeneratedGroupWithOneType) then
 	fam!.defaultFinitelyGeneratedGroupWithOneType:=
-	  NewType(fam,IsGroup and IsAttributeStoringRep
+	  NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep
 		      and HasGeneratorsOfMagmaWithInverses
 		      and IsFinitelyGeneratedGroup and HasOne);
       fi;
@@ -1074,7 +1074,7 @@ InstallGlobalFunction( "BlowUpIsomorphism", function( matgrp, B )
 
     iso:= rec();
     ObjectifyWithAttributes( iso,
-        NewType( GeneralMappingsFamily( FamilyObj( preimgs[1] ),
+        NewType3( TypeOfTypes, GeneralMappingsFamily( FamilyObj( preimgs[1] ),
                                         FamilyObj( imgs[1] ) ),
                      IsBlowUpIsomorphism
                  and IsGroupGeneralMapping

--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -103,7 +103,7 @@ function( nice, grp )
     local   fam,  pre;
 
     fam := FamilyObj( Source(nice) );
-    pre := Objectify(NewType(fam,IsGroup and IsAttributeStoringRep), rec());
+    pre := Objectify(NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep), rec());
     SetIsHandledByNiceMonomorphism( pre, true );
     SetNiceMonomorphism( pre, nice );
     SetNiceObject( pre, grp );
@@ -1021,7 +1021,7 @@ InstallMethod( Enumerator,"use nice monomorphism",true,
         [ IsGroup and IsHandledByNiceMonomorphism and IsFinite ], 0,
 function( G )
     return Objectify(
-        NewType( FamilyObj(G), IsList and IsEnumeratorByNiceomorphismRep ),
+        NewType3( TypeOfTypes, FamilyObj(G), IsList and IsEnumeratorByNiceomorphismRep ),
         rec( group:=G,
 	     morphism:=NiceMonomorphism(G),
 	     niceEnumerator:=Enumerator(NiceObject(G))));

--- a/lib/grppc.gi
+++ b/lib/grppc.gi
@@ -348,7 +348,7 @@ InstallMethod( GroupWithGenerators,
     if IsFinite(gens) then
       if not IsBound(fam!.defaultFinitelyGeneratedGroupType) then
 	fam!.defaultFinitelyGeneratedGroupType:=
-	  NewType(fam,IsGroup and IsAttributeStoringRep 
+	  NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep 
 		      and HasGeneratorsOfMagmaWithInverses
 		      and IsFinitelyGeneratedGroup
 		      and HasFamilyPcgs and HasHomePcgs);
@@ -357,7 +357,7 @@ InstallMethod( GroupWithGenerators,
     else
       if not IsBound(fam!.defaultGroupType) then
         fam!.defaultGroupType:=
-	  NewType(fam,IsGroup and IsAttributeStoringRep 
+	  NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep 
 		      and HasGeneratorsOfMagmaWithInverses
 		      and HasFamilyPcgs and HasHomePcgs);
       fi;
@@ -386,7 +386,7 @@ InstallOtherMethod( GroupWithGenerators,
     if IsFinite(gens) then
       if not IsBound(fam!.defaultFinitelyGeneratedGroupWithOneType) then
 	fam!.defaultFinitelyGeneratedGroupWithOneType:=
-	  NewType(fam,IsGroup and IsAttributeStoringRep 
+	  NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep 
 		      and HasGeneratorsOfMagmaWithInverses
 		      and IsFinitelyGeneratedGroup and HasOne
 		      and HasFamilyPcgs and HasHomePcgs);
@@ -395,7 +395,7 @@ InstallOtherMethod( GroupWithGenerators,
     else
       if not IsBound(fam!.defaultGroupWithOneType) then
         fam!.defaultGroupWithOneType:=
-	  NewType(fam,IsGroup and IsAttributeStoringRep 
+	  NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep 
 		      and HasGeneratorsOfMagmaWithInverses and HasOne
 		      and HasFamilyPcgs and HasHomePcgs);
       fi;
@@ -423,7 +423,7 @@ InstallOtherMethod( GroupWithGenerators,
     fam:= CollectionsFamily( FamilyObj( id ) );
     if not IsBound(fam!.defaultFinitelyGeneratedGroupWithOneType) then
       fam!.defaultFinitelyGeneratedGroupWithOneType:=
-	NewType(fam,IsGroup and IsAttributeStoringRep 
+	NewType3( TypeOfTypes,fam,IsGroup and IsAttributeStoringRep 
 		    and HasGeneratorsOfMagmaWithInverses
 		    and IsFinitelyGeneratedGroup and HasOne
 		    and HasFamilyPcgs and HasHomePcgs);
@@ -2142,7 +2142,7 @@ InstallMethod(ConjugacyClassSubgroups,IsIdenticalObj,[IsPcGroup,IsPcGroup],0,
 function(G,U)
 local cl;
 
-    cl:=Objectify(NewType(CollectionsFamily(FamilyObj(G)),
+    cl:=Objectify(NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(G)),
       IsConjugacyClassSubgroupsByStabilizerRep),rec());
     SetActingDomain(cl,G);
     SetRepresentative(cl,U);

--- a/lib/grppclat.gi
+++ b/lib/grppclat.gi
@@ -1231,7 +1231,7 @@ local s,i,c,classes, lattice,map,GI;
 	       end);
 
   # create the lattice
-  lattice:=Objectify(NewType(FamilyObj(classes),IsLatticeSubgroupsRep),
+  lattice:=Objectify(NewType3( TypeOfTypes,FamilyObj(classes),IsLatticeSubgroupsRep),
 		     rec());
   lattice!.conjugacyClassesSubgroups:=classes;
   lattice!.group     :=G;

--- a/lib/grptbl.gi
+++ b/lib/grptbl.gi
@@ -217,7 +217,7 @@ function( A, domconst, filts )
   F!.n:=n;
   SetMultiplicationTable( F, A );
   elms:= Immutable( List( [1..n],
-             i -> Objectify( NewType( F, filts), [ i ] ) ) );
+             i -> Objectify( NewType3( TypeOfTypes, F, filts), [ i ] ) ) );
   SetIsSSortedList( elms, true );
   F!.set:= elms;
   F!.inverse:= [];

--- a/lib/hash.gi
+++ b/lib/hash.gi
@@ -226,7 +226,7 @@ InstallMethod(ShrinkableHashTable,
     rangefam := ElementsFamily(FamilyObj(source));
     Info(InfoHashTables, 1, "Creating a list hash table");
     Info(InfoHashTables, 2, "Source: ", source, " Range: ",range);
-    return Objectify(NewType(GeneralMappingsFamily(sourcefam, rangefam), 
+    return Objectify(NewType3( TypeOfTypes,GeneralMappingsFamily(sourcefam, rangefam), 
                    IsFlexibleGeneralMapping and IsListHashTable and
                    HasSource and HasRange and IsMutable),
                    rec(
@@ -531,7 +531,7 @@ InstallMethod( ShallowCopy, true, [ IsListHashTable ], 0,
     end;
     Info(InfoHashTables,2,"Copying list hash table ",ht!.entries," entries");
 
-    return Objectify(NewType(FamilyObj(ht),
+    return Objectify(NewType3( TypeOfTypes,FamilyObj(ht),
                    IsFlexibleGeneralMapping and IsListHashTable and
                    HasSource and HasRange and IsMutable),
                    rec(
@@ -606,7 +606,7 @@ InstallMethod(SingleValuedHashTable, true, [IsCollection, IsCollection, IsFuncti
     Info(InfoHashTables, 2, "Source: ", source, " Range: ",range);
     sourcefam := ElementsFamily(FamilyObj(source));
     rangefam := ElementsFamily(FamilyObj(range));
-    obj := Objectify(NewType(GeneralMappingsFamily(sourcefam, rangefam), 
+    obj := Objectify(NewType3( TypeOfTypes,GeneralMappingsFamily(sourcefam, rangefam), 
                    IsExtensiblePartialMapping and IsFlatHashTable and
                    HasSource and HasRange and IsMutable),
                    rec(
@@ -858,7 +858,7 @@ end);
 InstallMethod(ShallowCopy, true, [IsFlatHashTable and IsSingleValued], 0,
         function(ht)
     
-    return Objectify(NewType(FamilyObj(ht),
+    return Objectify(NewType3( TypeOfTypes,FamilyObj(ht),
                    IsExtensiblePartialMapping and IsFlatHashTable and
                    HasSource and HasRange and IsMutable),
                    rec(

--- a/lib/ideal.gi
+++ b/lib/ideal.gi
@@ -56,7 +56,7 @@ InstallGlobalFunction( TwoSidedIdealNC, function( arg )
       if IsFLMLOR( arg[1] ) then
         I:= SubFLMLORNC( arg[1], arg[2] );
       else
-        I:= Objectify( NewType( FamilyObj( arg[1] ),
+        I:= Objectify( NewType3( TypeOfTypes, FamilyObj( arg[1] ),
                                     IsRing
                                 and IsTrivial
                                 and IsAttributeStoringRep ),
@@ -197,7 +197,7 @@ InstallMethod( TwoSidedIdealByGenerators,
     [ IsRing, IsCollection ], 0,
     function( R, gens )
     local I;
-    I:= Objectify( NewType( FamilyObj( R ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( R ),
                                 IsRing
                             and IsAttributeStoringRep ),
                    rec() );
@@ -218,7 +218,7 @@ InstallMethod( LeftIdealByGenerators,
     [ IsRing, IsCollection ], 0,
     function( R, gens )
     local I;
-    I:= Objectify( NewType( FamilyObj( R ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( R ),
                                 IsRing
                             and IsAttributeStoringRep ),
                    rec() );
@@ -238,7 +238,7 @@ InstallMethod( RightIdealByGenerators,
     [ IsRing, IsCollection ], 0,
     function( R, gens )
     local I;
-    I:= Objectify( NewType( FamilyObj( R ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( R ),
                                 IsRing
                             and IsAttributeStoringRep ),
                    rec() );

--- a/lib/idealalg.gi
+++ b/lib/idealalg.gi
@@ -210,7 +210,7 @@ InstallMethod( TwoSidedIdealByGenerators,
     [ IsFLMLOR, IsCollection ], 0,
     function( A, gens )
     local I, lad;
-    I:= Objectify( NewType( FamilyObj( A ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( A ),
                                 IsFLMLOR
                             and IsAttributeStoringRep ),
                    rec() );
@@ -230,7 +230,7 @@ InstallMethod( LeftIdealByGenerators,
     [ IsFLMLOR, IsCollection ], 0,
     function( A, gens )
     local I, lad;
-    I:= Objectify( NewType( FamilyObj( A ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( A ),
                                 IsFLMLOR
                             and IsAttributeStoringRep ),
                    rec() );
@@ -249,7 +249,7 @@ InstallMethod( RightIdealByGenerators,
     [ IsFLMLOR, IsCollection ], 0,
     function( A, gens )
     local I, lad;
-    I:= Objectify( NewType( FamilyObj( A ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( A ),
                                 IsFLMLOR
                             and IsAttributeStoringRep ),
                    rec() );
@@ -269,7 +269,7 @@ InstallMethod( TwoSidedIdealByGenerators,
     [ IsFLMLOR, IsList and IsEmpty ], 0,
     function( A, gens )
     local I, lad;
-    I:= Objectify( NewType( FamilyObj( A ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( A ),
                                 IsFLMLOR
                             and IsTrivial
                             and IsAttributeStoringRep ),
@@ -291,7 +291,7 @@ InstallMethod( LeftIdealByGenerators,
     [ IsFLMLOR, IsList and IsEmpty ], 0,
     function( A, gens )
     local I, lad;
-    I:= Objectify( NewType( FamilyObj( A ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( A ),
                                 IsFLMLOR
                             and IsTrivial
                             and IsAttributeStoringRep ),
@@ -312,7 +312,7 @@ InstallMethod( RightIdealByGenerators,
     [ IsFLMLOR, IsList and IsEmpty ], 0,
     function( A, gens )
     local I, lad;
-    I:= Objectify( NewType( FamilyObj( A ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( A ),
                                 IsFLMLOR
                             and IsTrivial
                             and IsAttributeStoringRep ),

--- a/lib/ieee754.g
+++ b/lib/ieee754.g
@@ -121,7 +121,7 @@ InstallMethod( ComplexConjugate, "for macfloats", [ IsIEEE754FloatRep ], x->x);
 
 DeclareCategory("IsIEEE754PseudoField", IsFloatPseudoField);
 BindGlobal("IEEE754_PSEUDOFIELD",
-        Objectify(NewType(CollectionsFamily(IEEE754FloatsFamily),
+        Objectify(NewType3( TypeOfTypes,CollectionsFamily(IEEE754FloatsFamily),
                 IsIEEE754PseudoField and IsAttributeStoringRep),rec()));
 SetName(IEEE754_PSEUDOFIELD, "IEEE754_PSEUDOFIELD");
 

--- a/lib/info.gi
+++ b/lib/info.gi
@@ -114,7 +114,7 @@ InfoData.InfoClass :=  function(num)
     if num < 1 or num > Length(InfoData.CurrentLevels) then
         Error("Bad info class number -- this is a bug");
     fi;
-    return Objectify(NewType(InfoClassFamily,IsInfoClassListRep),
+    return Objectify(NewType3( TypeOfTypes,InfoClassFamily,IsInfoClassListRep),
                    [num]);
 end;
 

--- a/lib/integer.gi
+++ b/lib/integer.gi
@@ -19,7 +19,7 @@
 ##
 #V  Integers  . . . . . . . . . . . . . . . . . . . . .  ring of the integers
 ##
-InstallValue( Integers, Objectify( NewType(
+InstallValue( Integers, Objectify( NewType3( TypeOfTypes,
     CollectionsFamily( CyclotomicsFamily ),
     IsIntegers and IsAttributeStoringRep ),
     rec() ) );
@@ -40,7 +40,7 @@ SetIsWholeFamily( Integers, false );
 ##
 #V  NonnegativeIntegers . . . . . . . . . .  semiring of nonnegative integers
 ##
-InstallValue( NonnegativeIntegers, Objectify( NewType(
+InstallValue( NonnegativeIntegers, Objectify( NewType3( TypeOfTypes,
     CollectionsFamily( CyclotomicsFamily ),
     IsNonnegativeIntegers and IsAttributeStoringRep ),
     rec() ) );
@@ -57,7 +57,7 @@ SetIsWholeFamily( NonnegativeIntegers, false );
 ##
 #V  PositiveIntegers  . . . . . . . . . . . . . semiring of positive integers
 ##
-InstallValue( PositiveIntegers, Objectify( NewType(
+InstallValue( PositiveIntegers, Objectify( NewType3( TypeOfTypes,
     CollectionsFamily( CyclotomicsFamily ),
     IsPositiveIntegers and IsAttributeStoringRep ),
     rec() ) );
@@ -74,7 +74,7 @@ SetIsWholeFamily( PositiveIntegers, false );
 ##
 #V  GaussianIntegers  . . . . . . . . . . . . . . . ring of Gaussian integers
 ##
-InstallValue( GaussianIntegers, Objectify( NewType(
+InstallValue( GaussianIntegers, Objectify( NewType3( TypeOfTypes,
     CollectionsFamily(CyclotomicsFamily),
     IsGaussianIntegers and IsAttributeStoringRep ),
     rec() ) );
@@ -122,7 +122,7 @@ InstallMethod( CanonicalBasis,
     [ IsIntegers ], 0,
     function( Integers )
     local B;
-    B:= Objectify( NewType( FamilyObj( Integers ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( Integers ),
                                 IsFiniteBasisDefault
                             and IsCanonicalBasis
                             and IsCanonicalBasisIntegersRep ),

--- a/lib/invsgp.gi
+++ b/lib/invsgp.gi
@@ -188,7 +188,7 @@ InstallMethod(InverseMonoidByGenerators,
 function(gens)
   local s, one, pos;
 
-  s:=Objectify( NewType (FamilyObj( gens ), IsMagmaWithOne and
+  s:=Objectify( NewType3( TypeOfTypes,FamilyObj( gens ), IsMagmaWithOne and
    IsInverseSemigroup and IsAttributeStoringRep), rec());
   
   one:=One(gens);
@@ -218,7 +218,7 @@ InstallMethod(InverseSemigroupByGenerators,
 function(gens)
   local s, pos;
 
-  s:=Objectify( NewType (FamilyObj( gens ), IsMagma and
+  s:=Objectify( NewType3( TypeOfTypes,FamilyObj( gens ), IsMagma and
    IsInverseSemigroup and IsAttributeStoringRep), rec());
   SetGeneratorsOfInverseSemigroup(s, AsList(gens));
   

--- a/lib/kbsemi.gi
+++ b/lib/kbsemi.gi
@@ -106,7 +106,7 @@ local r,kbrws,rwsfam,relations_with_correct_order,CantorList,relwco,
 
   relwco:=relations_with_correct_order(r,wordord);
 
-  kbrws := Objectify(NewType(rwsfam, 
+  kbrws := Objectify(NewType3( TypeOfTypes,rwsfam, 
     IsMutable and IsKnuthBendixRewritingSystem and 
     IsKnuthBendixRewritingSystemRep), 
     rec(family:= fam,

--- a/lib/liefam.gi
+++ b/lib/liefam.gi
@@ -56,7 +56,7 @@ InstallMethod( LieFamily,
 #T maintain other req/imp properties as implied properties of `F'?
 
     # Enter the type of objects in the image.
-    F!.packedType:= NewType( F, filt and IsPackedElementDefaultRep );
+    F!.packedType:= NewType3( TypeOfTypes, F, filt and IsPackedElementDefaultRep );
 
     # Return the Lie family.
     return F;
@@ -86,7 +86,7 @@ InstallMethod( LieFamily,
 #T maintain other req/imp properties as implied properties of `F'?
 
     # Enter the type of objects in the image.
-    F!.packedType:= NewType( F, filt
+    F!.packedType:= NewType3( TypeOfTypes, F, filt
                                 and IsPackedElementDefaultRep
                                 and IsLieMatrix );
 
@@ -549,7 +549,7 @@ InstallHandlingByNiceBasis( "IsLieObjectsModule", rec(
 IdealByGeneratorsForLieAlgebra := function( L, elms )
     local I, lad;
 
-    I:= Objectify( NewType( FamilyObj( L ),
+    I:= Objectify( NewType3( TypeOfTypes, FamilyObj( L ),
                                 IsFLMLOR
                             and IsAttributeStoringRep
                             and IsLieAlgebra ),

--- a/lib/lierep.gi
+++ b/lib/lierep.gi
@@ -57,7 +57,7 @@ InstallMethod( Cochain,
              fam:= NewFamily( "CochainFamily", IsCochain );
              fam!.order:= s;
              fam!.module:= V;
-             type:= NewType( fam, IsZeroCochainRep );
+             type:= NewType3( TypeOfTypes, fam, IsZeroCochainRep );
              V!.zeroCochainType:= type;
            else
              type:= V!.zeroCochainType;
@@ -69,7 +69,7 @@ InstallMethod( Cochain,
             fam:= NewFamily( "CochainFamily", IsCochain );
             fam!.order:= s;
             fam!.module:= V;
-            type:= NewType( fam, IsPackedElementDefaultRep );
+            type:= NewType3( TypeOfTypes, fam, IsPackedElementDefaultRep );
             V!.cochainTypes[s]:= type;
          else
             type:= V!.cochainTypes[s];
@@ -556,7 +556,7 @@ InstallGlobalFunction( LieCoboundaryOperator,
           fam!.order:= s+1;
           fam!.module:= V;
           fam!.tuples:= tups;
-          type:= NewType( fam, IsPackedElementDefaultRep );
+          type:= NewType3( TypeOfTypes, fam, IsPackedElementDefaultRep );
           V!.cochainTypes[s+1]:= type;
        fi;
 
@@ -2420,7 +2420,7 @@ InstallGlobalFunction( VectorSearchTable,
         fi;
 
         fam := NewFamily("VectorSearchTableFam", IsVectorSearchTable);
-        T := Objectify( NewType(fam, 
+        T := Objectify( NewType3( TypeOfTypes,fam, 
                                 IsVectorSearchTableDefaultRep and IsMutable),
                         rec( top := 0) );
 
@@ -2526,7 +2526,7 @@ InstallMethod( LatticeGeneratorsInUEA,
 
     fam:= NewFamily( "UEALatticeEltFam", IsUEALatticeElement );
     fam!.packedUEALatticeElementDefaultType:=
-                            NewType( fam, IsPackedElementDefaultRep );
+                            NewType3( TypeOfTypes, fam, IsPackedElementDefaultRep );
     fam!.roots:= roots;
     fam!.rootVecs:= Rvecs;
 
@@ -3032,7 +3032,7 @@ BindGlobal( "BasisOfWeightRepSpace",
     function( V, vectors )
     local B;
 
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                             IsFiniteBasisDefault and
                             IsBasisOfWeightRepElementSpace and
                             IsAttributeStoringRep ),
@@ -3751,7 +3751,7 @@ InstallMethod( HighestWeightModule,
     wvecs:= [ ];
     no:= 0;
     fam:= NewFamily( "WeightRepElementsFamily", IsWeightRepElement );
-    fam!.weightRepElementDefaultType:= NewType( fam,
+    fam!.weightRepElementDefaultType:= NewType3( TypeOfTypes, fam,
                                                IsPackedElementDefaultRep );
 
     for k in [1..Length(weights)] do
@@ -3771,7 +3771,7 @@ InstallMethod( HighestWeightModule,
     V:= LeftAlgebraModuleByGenerators( L, \^, wvecs );
     SetGeneratorsOfLeftModule( V, GeneratorsOfAlgebraModule( V ) );
 
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                             IsFiniteBasisDefault and
                             IsBasisOfAlgebraModuleElementSpace and
                             IsAttributeStoringRep ),

--- a/lib/list.g
+++ b/lib/list.g
@@ -256,27 +256,27 @@ BIND_GLOBAL( "TYPE_BLIST_IMM",
     IsCopyable and IsInternalRep and IsDenseList and IsHomogeneousList and 
     IS_BLIST_REP ) );
 BIND_GLOBAL( "TYPE_BLIST_NSORT_MUT", 
-  NewType( CollectionsFamily(BooleanFamily),
+  NewType3( TypeOfTypes, CollectionsFamily(BooleanFamily),
     IsMutable and IsInternalRep and IsDenseList and IsHomogeneousList and 
     IS_BLIST_REP and Tester(IsSSortedList) ) );
 BIND_GLOBAL( "TYPE_BLIST_NSORT_IMM", 
-  NewType( CollectionsFamily(BooleanFamily),
+  NewType3( TypeOfTypes, CollectionsFamily(BooleanFamily),
     IsCopyable and IsInternalRep and IsDenseList and IsHomogeneousList and 
     IS_BLIST_REP and Tester(IsSSortedList) ) );
 BIND_GLOBAL( "TYPE_BLIST_SSORT_MUT", 
-  NewType( CollectionsFamily(BooleanFamily),
+  NewType3( TypeOfTypes, CollectionsFamily(BooleanFamily),
     IsMutable and IsInternalRep and IsDenseList and IsHomogeneousList and 
     IS_BLIST_REP and Tester(IsSSortedList) and IsSSortedList ) );
 BIND_GLOBAL( "TYPE_BLIST_SSORT_IMM", 
-  NewType( CollectionsFamily(BooleanFamily),
+  NewType3( TypeOfTypes, CollectionsFamily(BooleanFamily),
     IsCopyable and IsInternalRep and IsDenseList and IsHomogeneousList and 
     IS_BLIST_REP and Tester(IsSSortedList) and IsSSortedList ) );
 BIND_GLOBAL( "TYPE_BLIST_EMPTY_MUT",
-  NewType( CollectionsFamily(BooleanFamily),
+  NewType3( TypeOfTypes, CollectionsFamily(BooleanFamily),
     IsMutable and IsInternalRep and IsDenseList and IsHomogeneousList and 
     IS_BLIST_REP and IsEmpty and Tester(IsEmpty) ) );
 BIND_GLOBAL( "TYPE_BLIST_EMPTY_IMM", 
-  NewType( CollectionsFamily(BooleanFamily),
+  NewType3( TypeOfTypes, CollectionsFamily(BooleanFamily),
     IsCopyable and IsInternalRep and IsDenseList and IsHomogeneousList and 
     IS_BLIST_REP and IsEmpty and Tester(IsEmpty) ) );
 
@@ -353,7 +353,7 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_HOM_NSORT
     elif knr = 3  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsMutable and IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         Tester(IsSSortedList) and
@@ -361,7 +361,7 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_HOM_NSORT + IMMUTABLE
     elif knr = 4  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         Tester(IsSSortedList) and
@@ -369,7 +369,7 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_HOM_SSORT
     elif knr = 5  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsMutable and IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         Tester(IsSSortedList) and
@@ -378,7 +378,7 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_HOM_SSORT + IMMUTABLE
     elif knr = 6  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         Tester(IsSSortedList) and
@@ -401,7 +401,7 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_TAB_NSORT
     elif knr = 9  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsMutable and IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         Tester(IsSSortedList) and IsTable
@@ -409,7 +409,7 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_TAB_NSORT + IMMUTABLE
     elif knr = 10  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         Tester(IsSSortedList) and IsTable
@@ -417,7 +417,7 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_TAB_SSORT
     elif knr = 11  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsMutable and IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         Tester(IsSSortedList) and
@@ -425,7 +425,7 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_TAB_SSORT + IMMUTABLE
     elif knr = 12  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsList and IsDenseList and IsHomogeneousList
                         and Tester(IsSSortedList)
                         and IsCollection and IsSSortedList and IsTable
@@ -447,7 +447,7 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_TAB_RECT_NSORT
     elif knr = 15  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsMutable and IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         Tester(IsSSortedList) and IsTable and HasIsRectangularTable and IsRectangularTable
@@ -455,7 +455,7 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_TAB_RECT_NSORT + IMMUTABLE
     elif knr = 16  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         Tester(IsSSortedList) and IsTable and HasIsRectangularTable and IsRectangularTable
@@ -463,7 +463,7 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_TAB_RECT_SSORT
     elif knr = 17  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsMutable and IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         Tester(IsSSortedList) and
@@ -471,7 +471,7 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_TAB_RECT_SSORT + IMMUTABLE
     elif knr = 18  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsList and IsDenseList and IsHomogeneousList
                         and Tester(IsSSortedList)
                        and IsCollection and IsSSortedList and IsTable and HasIsRectangularTable 
@@ -629,7 +629,7 @@ end );
 ##  </ManSection>
 ##
 BIND_GLOBAL( "TYPE_RANGE_SSORT_MUTABLE", 
-        NewType(CollectionsFamily(CyclotomicsFamily), 
+        NewType3( TypeOfTypes,CollectionsFamily(CyclotomicsFamily), 
                 IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                 Tester(IsSSortedList) and IsRange and IsMutable and
@@ -649,7 +649,7 @@ BIND_GLOBAL( "TYPE_RANGE_SSORT_MUTABLE",
 ##  </ManSection>
 ##
 BIND_GLOBAL( "TYPE_RANGE_NSORT_MUTABLE", 
-        NewType(CollectionsFamily(CyclotomicsFamily), 
+        NewType3( TypeOfTypes,CollectionsFamily(CyclotomicsFamily), 
                 IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                 Tester(IsSSortedList) and IsRange and IsMutable
@@ -669,7 +669,7 @@ BIND_GLOBAL( "TYPE_RANGE_NSORT_MUTABLE",
 ##  </ManSection>
 ##
 BIND_GLOBAL( "TYPE_RANGE_SSORT_IMMUTABLE", 
-        NewType(CollectionsFamily(CyclotomicsFamily), 
+        NewType3( TypeOfTypes,CollectionsFamily(CyclotomicsFamily), 
                 IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                 Tester(IsSSortedList) and IsRange and
@@ -689,7 +689,7 @@ BIND_GLOBAL( "TYPE_RANGE_SSORT_IMMUTABLE",
 ##  </ManSection>
 ##
 BIND_GLOBAL( "TYPE_RANGE_NSORT_IMMUTABLE", 
-        NewType(CollectionsFamily(CyclotomicsFamily), 
+        NewType3( TypeOfTypes,CollectionsFamily(CyclotomicsFamily), 
                 IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                 Tester(IsSSortedList) and IsRange 

--- a/lib/list.g
+++ b/lib/list.g
@@ -99,7 +99,7 @@ InstallTrueMethod( IsTable, IsRectangularTable );
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_LIST_NDENSE_MUTABLE", NewType( ListsFamily,
+BIND_GLOBAL( "TYPE_LIST_NDENSE_MUTABLE", NewType3( TypeOfTypes, ListsFamily,
     IsMutable and IsList and IsPlistRep ) );
 
 
@@ -114,7 +114,7 @@ BIND_GLOBAL( "TYPE_LIST_NDENSE_MUTABLE", NewType( ListsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_LIST_NDENSE_IMMUTABLE", NewType( ListsFamily,
+BIND_GLOBAL( "TYPE_LIST_NDENSE_IMMUTABLE", NewType3( TypeOfTypes, ListsFamily,
     IsList and IsPlistRep ) );
 
 
@@ -129,7 +129,7 @@ BIND_GLOBAL( "TYPE_LIST_NDENSE_IMMUTABLE", NewType( ListsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_MUTABLE", NewType( ListsFamily,
+BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_MUTABLE", NewType3( TypeOfTypes, ListsFamily,
     IsMutable and IsList and IsDenseList and IsPlistRep ) );
 
 
@@ -144,7 +144,7 @@ BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_MUTABLE", NewType( ListsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_IMMUTABLE", NewType( ListsFamily,
+BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_IMMUTABLE", NewType3( TypeOfTypes, ListsFamily,
         IsList and IsDenseList and IsPlistRep ) );
 
 #############################################################################
@@ -158,7 +158,7 @@ BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_IMMUTABLE", NewType( ListsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_SSORT_MUTABLE", NewType( ListsFamily,
+BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_SSORT_MUTABLE", NewType3( TypeOfTypes, ListsFamily,
     IsMutable and IsList and IsDenseList and IsPlistRep and IsSSortedList ) );
 
 #############################################################################
@@ -172,7 +172,7 @@ BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_SSORT_MUTABLE", NewType( ListsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_NSORT_MUTABLE", NewType( ListsFamily,
+BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_NSORT_MUTABLE", NewType3( TypeOfTypes, ListsFamily,
     IsMutable and IsList and IsDenseList and IsPlistRep ) );
 
 
@@ -187,7 +187,7 @@ BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_NSORT_MUTABLE", NewType( ListsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_SSORT_IMMUTABLE", NewType( ListsFamily,
+BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_SSORT_IMMUTABLE", NewType3( TypeOfTypes, ListsFamily,
         IsList and IsDenseList and IsPlistRep and IsSSortedList ) );
 
 #############################################################################
@@ -201,7 +201,7 @@ BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_SSORT_IMMUTABLE", NewType( ListsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_NSORT_IMMUTABLE", NewType( ListsFamily,
+BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_NSORT_IMMUTABLE", NewType3( TypeOfTypes, ListsFamily,
         IsList and IsDenseList and IsPlistRep ) );
 
 #############################################################################
@@ -215,7 +215,7 @@ BIND_GLOBAL( "TYPE_LIST_DENSE_NHOM_NSORT_IMMUTABLE", NewType( ListsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_LIST_EMPTY_MUTABLE", NewType( ListsFamily,
+BIND_GLOBAL( "TYPE_LIST_EMPTY_MUTABLE", NewType3( TypeOfTypes, ListsFamily,
     IsMutable and IsList and IsDenseList and IsHomogeneousList
     and IsEmpty and IsString and IsPlistRep ) );
 
@@ -231,7 +231,7 @@ BIND_GLOBAL( "TYPE_LIST_EMPTY_MUTABLE", NewType( ListsFamily,
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_LIST_EMPTY_IMMUTABLE", NewType( ListsFamily,
+BIND_GLOBAL( "TYPE_LIST_EMPTY_IMMUTABLE", NewType3( TypeOfTypes, ListsFamily,
     IsList and IsDenseList and IsHomogeneousList
     and IsEmpty and IsString and IsPlistRep ) );
 
@@ -248,11 +248,11 @@ BIND_GLOBAL( "TYPE_LIST_EMPTY_IMMUTABLE", NewType( ListsFamily,
 ##  </ManSection>
 ##
 BIND_GLOBAL( "TYPE_BLIST_MUT", 
-  NewType( CollectionsFamily(BooleanFamily),
+  NewType3( TypeOfTypes, CollectionsFamily(BooleanFamily),
     IsMutable and IsInternalRep and IsDenseList and IsHomogeneousList and 
     IS_BLIST_REP ) );
 BIND_GLOBAL( "TYPE_BLIST_IMM", 
-  NewType( CollectionsFamily(BooleanFamily),
+  NewType3( TypeOfTypes, CollectionsFamily(BooleanFamily),
     IsCopyable and IsInternalRep and IsDenseList and IsHomogeneousList and 
     IS_BLIST_REP ) );
 BIND_GLOBAL( "TYPE_BLIST_NSORT_MUT", 
@@ -339,14 +339,14 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_HOM
     if   knr = 1  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsMutable and IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         IsPlistRep );
 
     # T_PLIST_HOM + IMMUTABLE
     elif knr = 2  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         IsPlistRep );
@@ -387,14 +387,14 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_TAB
     elif knr = 7  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsMutable and IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         IsTable and IsPlistRep );
 
     # T_PLIST_TAB + IMMUTABLE
     elif knr = 8  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         IsTable and IsPlistRep );
@@ -433,14 +433,14 @@ BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
 
     # T_PLIST_TAB_RECT
     elif knr = 13  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsMutable and IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         IsTable and HasIsRectangularTable and IsRectangularTable and IsPlistRep );
 
     # T_PLIST_TAB_RECT + IMMUTABLE
     elif knr = 14  then
-        return NewType( colls,
+        return NewType3( TypeOfTypes, colls,
                         IsList and IsDenseList and
                         IsHomogeneousList and IsCollection and
                         IsTable and HasIsRectangularTable and IsRectangularTable and IsPlistRep );

--- a/lib/listcoef.gi
+++ b/lib/listcoef.gi
@@ -1601,7 +1601,7 @@ InstallMethod( AddToListEntries, "fast kernel method", true,
 # data types for low index memory blocks. Created here to avoid having to
 # read the fp group stuff early
 InstallValue(TYPE_LOWINDEX_DATA,
-  NewType(NewFamily("LowIndexDataFamily",IsObject),
+  NewType3( TypeOfTypes,NewFamily("LowIndexDataFamily",IsObject),
     IsObject and IsDataObjectRep));
 
 #############################################################################

--- a/lib/macfloat.g
+++ b/lib/macfloat.g
@@ -17,7 +17,7 @@ DeclareRepresentation("IsIEEE754FloatRep", IsFloat and IsInternalRep and IS_MACF
 
 BIND_GLOBAL("IEEE754FloatsFamily", NewFamily("IEEE754FloatsFamily", IsIEEE754FloatRep));
 
-BIND_GLOBAL( "TYPE_MACFLOAT", NewType(IEEE754FloatsFamily, IsIEEE754FloatRep));
+BIND_GLOBAL( "TYPE_MACFLOAT", NewType3( TypeOfTypes,IEEE754FloatsFamily, IsIEEE754FloatRep));
 
 #############################################################################
 ##

--- a/lib/magma.gi
+++ b/lib/magma.gi
@@ -392,7 +392,7 @@ InstallGlobalFunction( SubmagmaNC, function( M, gens )
     local K, S;
 
     if IsEmpty( gens ) then
-      K:= NewType( FamilyObj(M),
+      K:= NewType3( TypeOfTypes, FamilyObj(M),
                        IsMagma
                    and IsTrivial
                    and IsAttributeStoringRep );
@@ -467,7 +467,7 @@ InstallGlobalFunction( SubmagmaWithOneNC, function( M, gens )
     local K, S;
 
     if IsEmpty( gens ) then
-      K:= NewType( FamilyObj(M),
+      K:= NewType3( TypeOfTypes, FamilyObj(M),
                        IsMagmaWithInverses
                    and IsTrivial
                    and IsAttributeStoringRep );
@@ -521,7 +521,7 @@ local M,gens,S;
         Error( "<M> must be a magma-with-inverses" );
     fi;
     if Length(arg)=1 then
-      S:=Objectify(NewType( FamilyObj(M),
+      S:=Objectify(NewType3( TypeOfTypes, FamilyObj(M),
                             IsMagmaWithInverses
                             and IsAttributeStoringRep), rec() );
       SetParent(S,M);
@@ -554,7 +554,7 @@ InstallGlobalFunction( SubmagmaWithInversesNC, function( M, gens )
     local K, S;
 
     if IsEmpty( gens ) then
-      K:= NewType( FamilyObj(M),
+      K:= NewType3( TypeOfTypes, FamilyObj(M),
                        IsMagmaWithInverses
                    and IsTrivial
                    and IsAttributeStoringRep
@@ -579,7 +579,7 @@ InstallMethod( MagmaByGenerators,
     [ IsCollection ] , 0,
     function( gens )
     local M;
-    M:= Objectify( NewType( FamilyObj( gens ),
+    M:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsMagma and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfMagma( M, AsList( gens ) );
@@ -600,7 +600,7 @@ InstallOtherMethod( MagmaByGenerators,
     if not ( IsEmpty(gens) or IsIdenticalObj( FamilyObj(gens), family ) ) then
       Error( "<family> and family of <gens> do not match" );
     fi;
-    M:= Objectify( NewType( family,
+    M:= Objectify( NewType3( TypeOfTypes, family,
                             IsMagma and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfMagma( M, AsList( gens ) );
@@ -618,7 +618,7 @@ InstallMethod( MagmaWithOneByGenerators,
     [ IsCollection ] , 0,
     function( gens )
     local M;
-    M:= Objectify( NewType( FamilyObj( gens ),
+    M:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsMagmaWithOne and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfMagmaWithOne( M, AsList( gens ) );
@@ -639,7 +639,7 @@ InstallOtherMethod( MagmaWithOneByGenerators,
     if not ( IsEmpty(gens) or IsIdenticalObj( FamilyObj(gens), family ) ) then
       Error( "<family> and family of <gens> do not match" );
     fi;
-    M:= Objectify( NewType( family,
+    M:= Objectify( NewType3( TypeOfTypes, family,
                             IsMagmaWithOne and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfMagmaWithOne( M, AsList( gens ) );
@@ -655,7 +655,7 @@ MakeMagmaWithInversesByFiniteGenerators:=function(family,gens)
 local M;
   if not IsBound(family!.defaultMagmaWithInversesByGeneratorsType) then
     family!.defaultMagmaWithInversesByGeneratorsType :=
-      NewType( FamilyObj( gens ),
+      NewType3( TypeOfTypes, FamilyObj( gens ),
                 IsMagmaWithInverses and IsAttributeStoringRep 
                 and HasGeneratorsOfMagmaWithInverses 
                 and IsFinitelyGeneratedGroup);

--- a/lib/mapping.gi
+++ b/lib/mapping.gi
@@ -1272,7 +1272,7 @@ InstallMethod( UnderlyingRelation,
     [ IsGeneralMapping ], 0,
     function( map )
     local rel;
-    rel:= Objectify( NewType( CollectionsFamily(
+    rel:= Objectify( NewType3( TypeOfTypes, CollectionsFamily(
           DirectProductElementsFamily( [ ElementsFamily( FamilyObj( Source( map ) ) ),
                           ElementsFamily( FamilyObj( Range( map  ) ) ) ] ) ),
                               IsDomain and IsAttributeStoringRep ),

--- a/lib/mapprep.gi
+++ b/lib/mapprep.gi
@@ -57,7 +57,7 @@ InstallGlobalFunction( TypeOfDefaultGeneralMapping,
     fi;
 
     # Construct the type.
-    Type:= NewType( GeneralMappingsFamily(
+    Type:= NewType3( TypeOfTypes, GeneralMappingsFamily(
                           ElementsFamily( FamilyObj( source ) ),
                           ElementsFamily( FamilyObj( range  ) ) ),
                     IsDefaultGeneralMappingRep and filter );

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -49,7 +49,7 @@ InstallGlobalFunction(TYPE_MAT8BIT,
                  IsRingElementTable and IsNoImmediateMethodsObject and 
                  HasIsRectangularTable and IsRectangularTable;
         if mut then filts := filts and IsMutable; fi;
-        TYPES_MAT8BIT[col][q] := NewType(CollectionsFamily(FamilyObj(GF(q))),filts);
+        TYPES_MAT8BIT[col][q] := NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(GF(q))),filts);
     fi;
     return TYPES_MAT8BIT[col][q];
 end);

--- a/lib/matblock.gi
+++ b/lib/matblock.gi
@@ -112,7 +112,7 @@ InstallGlobalFunction( BlockMatrix, function( arg )
     od;
 
     # Construct and return the block matrix.
-    return Objectify( NewType( CollectionsFamily( CollectionsFamily(
+    return Objectify( NewType3( TypeOfTypes, CollectionsFamily( CollectionsFamily(
                                    FamilyObj( zero ) ) ),
                                    IsOrdinaryMatrix
                                and IsMultiplicativeGeneralizedRowVector

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -22,13 +22,13 @@ InstallGlobalFunction( MakePlistVectorType,
         filter2 := filter and IsMutable and CanEasilyCompareElements;
     fi;
     if IsIdenticalObj(basedomain,Integers) then
-        T := NewType(FamilyObj(basedomain),
+        T := NewType3( TypeOfTypes,FamilyObj(basedomain),
                        filter2 and IsIntVector);
     elif IsFinite(basedomain) and IsField(basedomain) then
-        T := NewType(FamilyObj(basedomain),
+        T := NewType3( TypeOfTypes,FamilyObj(basedomain),
                        filter2 and IsFFEVector);
     else
-        T := NewType(FamilyObj(basedomain),
+        T := NewType3( TypeOfTypes,FamilyObj(basedomain),
                        filter2);
     fi;
     return T;
@@ -79,7 +79,7 @@ InstallMethod( NewMatrix,
        CanEasilyCompareElements(Representative(basedomain)) then
         filter2 := filter2 and CanEasilyCompareElements;
     fi;
-    Objectify( NewType(CollectionsFamily(FamilyObj(basedomain)),
+    Objectify( NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(basedomain)),
                        filter2), m );
     return m;
   end );
@@ -100,7 +100,7 @@ InstallMethod( NewZeroMatrix,
         m[i] := ZeroVector( cols, e );
     od;
     m := [basedomain,e,cols,m];
-    Objectify( NewType(CollectionsFamily(FamilyObj(basedomain)),
+    Objectify( NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(basedomain)),
                        filter and IsMutable), m );
     return m;
   end );
@@ -122,7 +122,7 @@ InstallMethod( NewIdentityMatrix,
         m[i][i] := One(basedomain);
     od;
     m := [basedomain,e,rows,m];
-    Objectify( NewType(CollectionsFamily(FamilyObj(basedomain)),
+    Objectify( NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(basedomain)),
                        filter and IsMutable), m );
     return m;
   end );

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -240,7 +240,7 @@ end );
 DeclareRepresentation( "IsNullMapMatrix", IsMatrix, [  ] );
 
 BindGlobal( "NullMapMatrix",
-    Objectify( NewType( ListsFamily, IsNullMapMatrix ), [  ] ) );
+    Objectify( NewType3( TypeOfTypes, ListsFamily, IsNullMapMatrix ), [  ] ) );
 
 InstallMethod( Length,
     "for null map matrix",

--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -12,7 +12,7 @@
 
 InstallMethod(TypeOfObjWithMemory,"generic",true,[IsFamily],0,
 function(fam)
-  return NewType(fam,IsObjWithMemory);
+  return NewType3( TypeOfTypes,fam,IsObjWithMemory);
 end);
 
 InstallGlobalFunction( GeneratorsWithMemory, 

--- a/lib/mgmadj.gi
+++ b/lib/mgmadj.gi
@@ -127,7 +127,7 @@ function(m)
   fi;
 
   fam:=NewFamily( "FamilyOfElementOfMagmaWithZeroAdjoined", filts);
-  type:=NewType(fam, filts and IsMagmaWithZeroAdjoinedElementRep);
+  type:=NewType3( TypeOfTypes,fam, filts and IsMagmaWithZeroAdjoinedElementRep);
   
   #the injection
   inj:=function(elt)
@@ -154,7 +154,7 @@ function(m)
 
   zero := Objectify(type, rec(elt:=fail));;
   gens:=Concatenation(List(GeneratorsOfMagma(m), g-> inj(g)), [zero]);
-  out:=Objectify( NewType( FamilyObj( gens ), filts), rec());
+  out:=Objectify( NewType3( TypeOfTypes, FamilyObj( gens ), filts), rec());
 
   # store the magma in the family so that it can be recovered from an element
   fam!.MagmaWithZeroAdjoined:=out;

--- a/lib/mgmcong.gi
+++ b/lib/mgmcong.gi
@@ -171,7 +171,7 @@ function(F, gens, category )
                ElementsFamily(FamilyObj(F)) );
     
     # Create the default type for the elements.
-    cong := Objectify(NewType(fam, 
+    cong := Objectify(NewType3( TypeOfTypes,fam, 
                 category and IsEquivalenceRelationDefaultRep), rec());
     SetSource(cong, F);
     SetRange(cong, F);
@@ -222,7 +222,7 @@ function(F, part, cat)
                 ElementsFamily(FamilyObj(F)) );
     
     # Create the default type for the elements.
-    cong :=  Objectify(NewType(fam, 
+    cong :=  Objectify(NewType3( TypeOfTypes,fam, 
                  cat and IsEquivalenceRelationDefaultRep), rec());
     SetSource(cong, F);
     SetRange(cong, F);
@@ -983,7 +983,7 @@ function(rel, rep)
     filts:=filts and IsAssociativeElement;
   fi;
 
-  new:= Objectify(NewType(CollectionsFamily(FamilyObj(rep)), filts), rec());
+  new:= Objectify(NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(rep)), filts), rec());
 
   SetEquivalenceClassRelation(new, rel);
   SetRepresentative(new, rep);
@@ -998,11 +998,11 @@ function(rel, rep)
     local new;
 
     if IsMultiplicativeElementWithOne(rep) then
-         new:= Objectify(NewType(CollectionsFamily(FamilyObj(rep)),
+         new:= Objectify(NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(rep)),
                    IsCongruenceClass and IsEquivalenceClassDefaultRep 
                    and IsMultiplicativeElementWithOne), rec());
     else
-         new:= Objectify(NewType(CollectionsFamily(FamilyObj(rep)),
+         new:= Objectify(NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(rep)),
                    IsCongruenceClass and IsEquivalenceClassDefaultRep 
                    and IsMultiplicativeElement), rec());
     fi;
@@ -1020,11 +1020,11 @@ InstallMethod(EquivalenceClassOfElementNC,
         local new;
 
         if IsMultiplicativeElementWithOne(rep) then
-             new:= Objectify(NewType(CollectionsFamily(FamilyObj(rep)),
+             new:= Objectify(NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(rep)),
                        IsCongruenceClass and IsEquivalenceClassDefaultRep 
                        and IsMultiplicativeElementWithOne), rec());
         else
-             new:= Objectify(NewType(CollectionsFamily(FamilyObj(rep)),
+             new:= Objectify(NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(rep)),
                        IsCongruenceClass and IsEquivalenceClassDefaultRep 
                        and IsMultiplicativeElement), rec());
         fi;

--- a/lib/mgmfree.gi
+++ b/lib/mgmfree.gi
@@ -321,7 +321,7 @@ InstallGlobalFunction( FreeMagma,
 
     # Store the names and the default type.
     F!.names:= names;
-    F!.defaultType:= NewType( F, IsNonassocWord and IsBracketRep );
+    F!.defaultType:= NewType3( TypeOfTypes, F, IsNonassocWord and IsBracketRep );
 
     # Make the magma.
     if IsFinite( names ) then
@@ -386,7 +386,7 @@ InstallGlobalFunction( FreeMagmaWithOne,
 
     # Store the names and the default type.
     F!.names:= names;
-    F!.defaultType:= NewType( F, IsNonassocWordWithOne and IsBracketRep );
+    F!.defaultType:= NewType3( TypeOfTypes, F, IsNonassocWordWithOne and IsBracketRep );
 
     # Make the magma.
     if IsFinite( names ) then

--- a/lib/mgmideal.gi
+++ b/lib/mgmideal.gi
@@ -154,7 +154,7 @@ InstallMethod( LeftMagmaIdealByGenerators,
     function( M, gens )
     local S;
 
-		S:= Objectify( NewType( FamilyObj( gens ),
+		S:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsLeftMagmaIdeal and IsAttributeStoringRep ),
                    rec() );
 
@@ -178,7 +178,7 @@ InstallMethod( RightMagmaIdealByGenerators,
     function( M, gens )
     local S;
 
-    S:= Objectify( NewType( FamilyObj( gens ),
+    S:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsRightMagmaIdeal and IsAttributeStoringRep ),
                    rec() );
 
@@ -204,7 +204,7 @@ InstallMethod( MagmaIdealByGenerators,
     function( M, gens )
     local S;
 
-    S:= Objectify( NewType( FamilyObj( gens ),
+    S:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsMagmaIdeal and IsAttributeStoringRep ),
                    rec() );
 

--- a/lib/mgmring.gi
+++ b/lib/mgmring.gi
@@ -717,7 +717,7 @@ InstallGlobalFunction( FreeMagmaRing, function( R, M )
     one:= One( R );
     zero:= Zero( R );
 
-    F!.defaultType := NewType( F, IsMagmaRingObjDefaultRep );
+    F!.defaultType := NewType3( TypeOfTypes, F, IsMagmaRingObjDefaultRep );
     F!.familyRing  := FamilyObj( R );
     F!.familyMagma := FamilyObj( M );
     F!.zeroRing    := zero;
@@ -743,12 +743,12 @@ InstallGlobalFunction( FreeMagmaRing, function( R, M )
 
     # Make the magma ring object.
     if IsMagmaWithOne( M ) then
-      RM:= Objectify( NewType( CollectionsFamily( F ),
+      RM:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( F ),
                                    IsFreeMagmaRingWithOne
                                and IsAttributeStoringRep ),
                       rec() );
     else
-      RM:= Objectify( NewType( CollectionsFamily( F ),
+      RM:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( F ),
                                    IsFreeMagmaRing
                                and IsAttributeStoringRep ),
                       rec() );
@@ -903,7 +903,7 @@ InstallMethod( CanonicalBasis,
     one  := One(  LeftActingDomain( RM ) );
     zero := Zero( LeftActingDomain( RM ) );
 
-    B:= Objectify( NewType( FamilyObj( RM ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( RM ),
                                 IsFiniteBasisDefault
                             and IsCanonicalBasisFreeMagmaRingRep ),
                    rec() );
@@ -1508,7 +1508,7 @@ InstallGlobalFunction( MagmaRingModuloSpanOfZero, function( R, M, z )
     one:= One( R );
     zero:= Zero( R );
 
-    F!.defaultType := NewType( F, IsMagmaRingObjDefaultRep );
+    F!.defaultType := NewType3( TypeOfTypes, F, IsMagmaRingObjDefaultRep );
     F!.familyRing  := FamilyObj( R );
     F!.familyMagma := FamilyObj( M );
     F!.zeroRing    := zero;
@@ -1519,7 +1519,7 @@ InstallGlobalFunction( MagmaRingModuloSpanOfZero, function( R, M, z )
     # 0-dimensional and the characteristic would then be 0.
 
     # Make the magma ring object.
-    RM:= Objectify( NewType( CollectionsFamily( F ),
+    RM:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( F ),
                                  IsMagmaRingModuloSpanOfZero
                              and IsAttributeStoringRep ),
                     rec() );

--- a/lib/module.gi
+++ b/lib/module.gi
@@ -24,7 +24,7 @@ InstallMethod( LeftModuleByGenerators,
     [ IsRing, IsCollection ],
     function( R, gens )
     local V;
-    V:= Objectify( NewType( FamilyObj( gens ),
+    V:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsLeftModule and IsAttributeStoringRep ),
                    rec() );
     SetLeftActingDomain( V, R );
@@ -40,7 +40,7 @@ InstallMethod( LeftModuleByGenerators,
     function( R, gens, zero )
     local V;
 
-    V:= Objectify( NewType( CollectionsFamily( FamilyObj( zero ) ),
+    V:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( zero ) ),
                             IsLeftModule and IsAttributeStoringRep ),
                    rec() );
     SetLeftActingDomain( V, R );
@@ -338,7 +338,7 @@ end );
 InstallGlobalFunction( SubmoduleNC, function( arg )
     local S;
     if IsEmpty( arg[2] ) then
-      S:= Objectify( NewType( FamilyObj( arg[1] ),
+      S:= Objectify( NewType3( TypeOfTypes, FamilyObj( arg[1] ),
                                   IsFreeLeftModule
                               and IsTrivial
                               and IsAttributeStoringRep ),

--- a/lib/modulmat.gi
+++ b/lib/modulmat.gi
@@ -43,7 +43,7 @@ InstallGlobalFunction( FullMatrixModule, function( R, m, n )
     fi;
 
     if IsDivisionRing( R ) then
-      M:= Objectify( NewType( CollectionsFamily( CollectionsFamily(
+      M:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( CollectionsFamily(
                                                      FamilyObj( R ) ) ),
                                   IsFreeLeftModule
                               and IsGaussianSpace
@@ -51,7 +51,7 @@ InstallGlobalFunction( FullMatrixModule, function( R, m, n )
                               and IsAttributeStoringRep ),
                      rec() );
     else
-      M:= Objectify( NewType( CollectionsFamily( CollectionsFamily(
+      M:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( CollectionsFamily(
                                                      FamilyObj( R ) ) ),
                                   IsFreeLeftModule
                               and IsFullMatrixModule
@@ -282,7 +282,7 @@ InstallMethod( CanonicalBasis,
     [ IsFreeLeftModule and IsFullMatrixModule ],
     function( V )
     local B;
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsCanonicalBasis
                             and IsCanonicalBasisFullMatrixModule

--- a/lib/modulrow.gi
+++ b/lib/modulrow.gi
@@ -28,14 +28,14 @@ InstallGlobalFunction( FullRowModule, function( R, n )
     fi;
 
     if IsDivisionRing( R ) then
-      M:= Objectify( NewType( CollectionsFamily( FamilyObj( R ) ),
+      M:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( R ) ),
                                   IsFreeLeftModule
                               and IsGaussianSpace
                               and IsFullRowModule
                               and IsAttributeStoringRep ),
                      rec() );
     else
-      M:= Objectify( NewType( CollectionsFamily( FamilyObj( R ) ),
+      M:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( R ) ),
                                   IsFreeLeftModule
                               and IsFullRowModule
                               and IsAttributeStoringRep ),
@@ -226,7 +226,7 @@ InstallMethod( CanonicalBasis,
     [ IsFreeLeftModule and IsFullRowModule ],
     function( V )
     local B;
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsCanonicalBasis
                             and IsCanonicalBasisFullRowModule

--- a/lib/monoid.gi
+++ b/lib/monoid.gi
@@ -87,7 +87,7 @@ InstallOtherMethod( MonoidByGenerators,
     [ IsCollection ] , 0,
     function( gens )
     local M;
-    M:= Objectify( NewType( FamilyObj( gens ),
+    M:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsMonoid and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfMagmaWithOne( M, AsList( gens ) );
@@ -100,7 +100,7 @@ InstallOtherMethod( MonoidByGenerators,
     [ IsCollection, IsMultiplicativeElementWithOne ], 0,
     function( gens, id )
     local M;
-    M:= Objectify( NewType( FamilyObj( gens ),
+    M:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsMonoid and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfMagmaWithOne( M, AsList( gens ) );
@@ -114,7 +114,7 @@ InstallOtherMethod( MonoidByGenerators,
     [ IsEmpty, IsMultiplicativeElementWithOne ], 0,
     function( gens, id )
     local M;
-    M:= Objectify( NewType( CollectionsFamily( FamilyObj( id ) ),
+    M:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( id ) ),
                                 IsMonoid
                             and IsTrivial
                             and IsAttributeStoringRep ),

--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -502,7 +502,7 @@ local xset,fam,hom;
   fam := GeneralMappingsFamily( ElementsFamily( FamilyObj( aut ) ),
 				PermutationsFamily );
   hom := rec(  );
-  hom:=Objectify(NewType(fam,
+  hom:=Objectify(NewType3( TypeOfTypes,fam,
 		IsActionHomomorphismAutomGroup and IsSurjective ),hom);
   SetIsInjective(hom,true);
   SetUnderlyingExternalSet( hom, xset );

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -46,7 +46,7 @@ InstallGlobalFunction( ExternalSetByFilterConstructor,
       D:= EmptyRowVector( CyclotomicsFamily );
     fi;
 
-    Objectify( NewType( FamilyObj( D ), filter ), xset );
+    Objectify( NewType3( TypeOfTypes, FamilyObj( D ), filter ), xset );
     SetActingDomain  ( xset, G );
     SetHomeEnumerator( xset, D );
     if not IsExternalSetByActorsRep( xset )  then
@@ -713,7 +713,7 @@ local   xset,surj,G,  D,  act,  fam,  filter,  hom,  i;
     if surj  then
         filter := filter and IsSurjective;
     fi;
-    Objectify( NewType( fam, filter ), hom );
+    Objectify( NewType3( TypeOfTypes, fam, filter ), hom );
     SetUnderlyingExternalSet( hom, xset );
     return hom;
 end );

--- a/lib/orders.gi
+++ b/lib/orders.gi
@@ -60,7 +60,7 @@ function( fam, fun, list)
     fi;
     
     ord := Objectify( 
-            NewType( OrderingsFamily( fam ), 
+            NewType3( TypeOfTypes, OrderingsFamily( fam ), 
             IsAttributeStoringRep),rec());
 
     SetFamilyForOrdering(ord, fam);
@@ -92,7 +92,7 @@ function( fam, fun, list)
     fi;
    
     ord := Objectify(
-            NewType( OrderingsFamily( fam ),
+            NewType3( TypeOfTypes, OrderingsFamily( fam ),
             IsAttributeStoringRep),rec());
 
     SetFamilyForOrdering(ord, fam);

--- a/lib/padics.gi
+++ b/lib/padics.gi
@@ -394,7 +394,7 @@ InstallGlobalFunction( PurePadicNumberFamily, function( p, precision )
         fam!.precision:= precision;
         fam!.modulus:= p^precision;
         fam!.printPadicSeries:= true;
-        fam!.defaultType := NewType( fam, IsPurePadicNumber );
+        fam!.defaultType := NewType3( TypeOfTypes, fam, IsPurePadicNumber );
         PADICS_FAMILIES[p][precision] := fam;
     fi;
     return PADICS_FAMILIES[p][precision];
@@ -759,7 +759,7 @@ InstallGlobalFunction( PadicExtensionNumberFamily,
     Append( str, String(precision) );
     Append( str, ",...)" );
     fam := NewFamily( str, IsPadicExtensionNumber );
-    fam!.defaultType := NewType( fam, IsPadicExtensionNumber );
+    fam!.defaultType := NewType3( TypeOfTypes, fam, IsPadicExtensionNumber );
     fam!.prime       := p;
     fam!.precision   := precision;
     fam!.modulus     := p^precision;

--- a/lib/pcgs.gi
+++ b/lib/pcgs.gi
@@ -200,10 +200,10 @@ function( filter, imp, efam, pcs,attl )
       one:=fail;
     fi;
     if one<>fail then
-      attl:=Concatenation([pcgs, NewType( fam, imp and HasOneOfPcgs),
+      attl:=Concatenation([pcgs, NewType3( TypeOfTypes, fam, imp and HasOneOfPcgs),
 			  Length,Length(pcs),OneOfPcgs,one],attl);
     else
-      attl:=Concatenation([pcgs, NewType( fam, imp ),
+      attl:=Concatenation([pcgs, NewType3( TypeOfTypes, fam, imp ),
 			  Length,Length(pcs)],attl);
     fi;
 
@@ -1260,7 +1260,7 @@ DeclareRepresentation( "IsEnumeratorByPcgsRep",
 InstallMethod( EnumeratorByPcgs,"pcgs", true, [ IsPcgs ], 0,
 function( pcgs )
     return Objectify(
-        NewType( FamilyObj(pcgs), IsList and IsEnumeratorByPcgsRep ),
+        NewType3( TypeOfTypes, FamilyObj(pcgs), IsList and IsEnumeratorByPcgsRep ),
         rec( pcgs := pcgs, sublist := [ 1 .. Length(pcgs) ],
              relativeOrders := RelativeOrders(pcgs),
              complementList := [] ) );
@@ -1274,7 +1274,7 @@ end );
 InstallOtherMethod( EnumeratorByPcgs,"pcgs, sublist",true,[IsPcgs,IsList],0,
 function( pcgs, sublist )
     return Objectify(
-        NewType( FamilyObj(pcgs), IsList and IsEnumeratorByPcgsRep ),
+        NewType3( TypeOfTypes, FamilyObj(pcgs), IsList and IsEnumeratorByPcgsRep ),
         rec( pcgs := pcgs, sublist := sublist,
              relativeOrders := RelativeOrders(pcgs),
              complementList := Difference([1..Length(pcgs)],sublist) ) );

--- a/lib/permutat.g
+++ b/lib/permutat.g
@@ -384,7 +384,7 @@ BIND_GLOBAL( "PermutationsFamily",
 ##  </ManSection>
 ##
 BIND_GLOBAL( "TYPE_PERM2",
-    NewType( PermutationsFamily, IsPerm and IsPerm2Rep ) );
+    NewType3( TypeOfTypes, PermutationsFamily, IsPerm and IsPerm2Rep ) );
 
 
 #############################################################################
@@ -399,7 +399,7 @@ BIND_GLOBAL( "TYPE_PERM2",
 ##  </ManSection>
 ##
 BIND_GLOBAL( "TYPE_PERM4",
-    NewType( PermutationsFamily, IsPerm and IsPerm4Rep ) );
+    NewType3( TypeOfTypes, PermutationsFamily, IsPerm and IsPerm4Rep ) );
 
 
 #############################################################################

--- a/lib/pperm.g
+++ b/lib/pperm.g
@@ -11,10 +11,10 @@ BIND_GLOBAL("PartialPermFamily", NewFamily("PartialPermFamily",
 DeclareRepresentation( "IsPPerm2Rep", IsInternalRep, [] );
 DeclareRepresentation( "IsPPerm4Rep", IsInternalRep, [] );
 
-BIND_GLOBAL("TYPE_PPERM2", NewType(PartialPermFamily,
+BIND_GLOBAL("TYPE_PPERM2", NewType3( TypeOfTypes,PartialPermFamily,
  IsPartialPerm and IsPPerm2Rep));
 
-BIND_GLOBAL("TYPE_PPERM4", NewType(PartialPermFamily,
+BIND_GLOBAL("TYPE_PPERM4", NewType3( TypeOfTypes,PartialPermFamily,
  IsPartialPerm and IsPPerm4Rep));
 
 

--- a/lib/pquot.gi
+++ b/lib/pquot.gi
@@ -1186,7 +1186,7 @@ function( G, p, n, collector )
     
     ##  Now turn this into a new object.
     fam  := NewFamily( "QuotientSystem", IsQuotientSystem );
-    type := NewType( fam, IsPQuotientSystem and IsMutable );
+    type := NewType3( TypeOfTypes, fam, IsPQuotientSystem and IsMutable );
     Objectify( type, qs );
 
     return qs;

--- a/lib/proto.gi
+++ b/lib/proto.gi
@@ -87,7 +87,7 @@ function(spec)
     cat);
   
   # create the type
-  eType := NewType(eFam, allfilters);
+  eType := NewType3( TypeOfTypes,eFam, allfilters);
 
   # the creation function
   makeelt := x->Objectify(eType, rec(data := x));

--- a/lib/quogphom.gi
+++ b/lib/quogphom.gi
@@ -55,7 +55,7 @@ local fam,filt;
 
   fam:=NewFamily("HomCosetFamily",filt);
   fam!.homomorphism:=hom;
-  fam!.defaultType:=NewType(fam,filt);
+  fam!.defaultType:=NewType3( TypeOfTypes,fam,filt);
   return fam;
 
 end);

--- a/lib/random.gi
+++ b/lib/random.gi
@@ -17,7 +17,7 @@
 # right type and then calls 'Init'.
 InstallMethod(RandomSource, [IsOperation, IsObject], function(rep, seed)
   local res;
-  res := Objectify(NewType(RandomSourcesFamily, rep), rec());
+  res := Objectify(NewType3( TypeOfTypes,RandomSourcesFamily, rep), rec());
   return Init (res, seed);
 end);
 InstallMethod(RandomSource, [IsOperation], function(rep)
@@ -68,7 +68,7 @@ end);
 ############################################################################
 ##  We provide the "classical" GAP random generator via a random source.
 ##  
-InstallValue(GlobalRandomSource, Objectify(NewType(RandomSourcesFamily,
+InstallValue(GlobalRandomSource, Objectify(NewType3( TypeOfTypes,RandomSourcesFamily,
                                                   IsGlobalRandomSource),rec()));
 InstallMethod(Init, [IsGlobalRandomSource, IsObject], function(rs, seed)
   if IsInt(seed) then

--- a/lib/ratfun.gi
+++ b/lib/ratfun.gi
@@ -732,40 +732,40 @@ function( efam )
     elmfilt, CanEasilySortElements,filt);
 
   # default type for polynomials
-  fam!.defaultPolynomialType := NewType( fam,
+  fam!.defaultPolynomialType := NewType3( TypeOfTypes, fam,
 	  IsPolynomial and IsPolynomialDefaultRep and
 	  HasExtRepPolynomialRatFun);
 
   # default type for univariate laurent polynomials
   fam!.threeLaurentPolynomialTypes := 
-    [ NewType( fam,
+    [ NewType3( TypeOfTypes, fam,
 	  IsLaurentPolynomial
 	  and IsLaurentPolynomialDefaultRep and
 	  HasIndeterminateNumberOfLaurentPolynomial and
 	  HasCoefficientsOfLaurentPolynomial), 
 
-	  NewType( fam,
+	  NewType3( TypeOfTypes, fam,
 	    IsLaurentPolynomial
 	    and IsLaurentPolynomialDefaultRep and
 	    HasIndeterminateNumberOfLaurentPolynomial and
 	    HasCoefficientsOfLaurentPolynomial and
 	    IsConstantRationalFunction and IsUnivariatePolynomial),
 
-	  NewType( fam,
+	  NewType3( TypeOfTypes, fam,
 	    IsLaurentPolynomial and IsLaurentPolynomialDefaultRep and
 	    HasIndeterminateNumberOfLaurentPolynomial and
 	    HasCoefficientsOfLaurentPolynomial and
 	    IsUnivariatePolynomial)];
 	      
   # default type for univariate rational functions
-  fam!.univariateRatfunType := NewType( fam,
+  fam!.univariateRatfunType := NewType3( TypeOfTypes, fam,
 	  IsUnivariateRationalFunctionDefaultRep  and
 	  HasIndeterminateNumberOfLaurentPolynomial and
 	  HasCoefficientsOfUnivariateRationalFunction);
 	      
   if IsUFDFamily(efam) then
     # default type for rational functions
-    fam!.defaultRatFunType := NewType( fam,
+    fam!.defaultRatFunType := NewType3( TypeOfTypes, fam,
 	    IsRationalFunctionDefaultRep and
 	    HasExtRepNumeratorRatFun and HasExtRepDenominatorRatFun);
   fi;

--- a/lib/rational.gi
+++ b/lib/rational.gi
@@ -15,7 +15,7 @@
 ##
 #V  Rationals . . . . . . . . . . . . . . . . . . . . . .  field of rationals
 ##
-InstallValue( Rationals, Objectify( NewType(
+InstallValue( Rationals, Objectify( NewType3( TypeOfTypes,
     CollectionsFamily( CyclotomicsFamily ),
     IsRationals and IsAttributeStoringRep ), rec() ) );
 SetName( Rationals, "Rationals" );
@@ -32,7 +32,7 @@ SetIsWholeFamily( Rationals, false );
 ##
 #V  GaussianRationals . . . . . . . . . . . . . . field of Gaussian rationals
 ##
-InstallValue( GaussianRationals, Objectify( NewType(
+InstallValue( GaussianRationals, Objectify( NewType3( TypeOfTypes,
     CollectionsFamily( CyclotomicsFamily ),
     IsGaussianRationals and IsAttributeStoringRep ), rec() ) );
 SetName( GaussianRationals, "GaussianRationals" );
@@ -104,7 +104,7 @@ InstallMethod( CanonicalBasis,
     [ IsRationals ],
     function( Rationals )
     local B;
-    B:= Objectify( NewType( FamilyObj( Rationals ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( Rationals ),
                                 IsFiniteBasisDefault
                             and IsCanonicalBasis
                             and IsCanonicalBasisRationals ),

--- a/lib/record.g
+++ b/lib/record.g
@@ -78,7 +78,7 @@ BIND_GLOBAL( "RecordsFamily", NewFamily( "RecordsFamily", IS_REC ) );
 ##  </ManSection>
 ##
 BIND_GLOBAL( "TYPE_PREC_MUTABLE",
-    NewType( RecordsFamily, IS_MUTABLE_OBJ and IS_REC and IsInternalRep ) );
+    NewType3( TypeOfTypes, RecordsFamily, IS_MUTABLE_OBJ and IS_REC and IsInternalRep ) );
 
 
 #############################################################################
@@ -93,7 +93,7 @@ BIND_GLOBAL( "TYPE_PREC_MUTABLE",
 ##  </ManSection>
 ##
 BIND_GLOBAL( "TYPE_PREC_IMMUTABLE",
-    NewType( RecordsFamily, IS_REC and IsInternalRep ) );
+    NewType3( TypeOfTypes, RecordsFamily, IS_REC and IsInternalRep ) );
 
 
 #############################################################################

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -243,11 +243,11 @@ function(S, mat)
           IsReesMatrixSemigroupElement);
 
   # create the Rees matrix semigroup
-  R := Objectify( NewType( CollectionsFamily( fam ), IsWholeFamily and
+  R := Objectify( NewType3( TypeOfTypes, CollectionsFamily( fam ), IsWholeFamily and
    IsReesMatrixSubsemigroup and IsAttributeStoringRep ), rec() );
 
   # store the type of the elements in the semigroup
-  type:=NewType(fam, IsReesMatrixSemigroupElement);
+  type:=NewType3( TypeOfTypes,fam, IsReesMatrixSemigroupElement);
   
   fam!.type:=type;
   SetTypeReesMatrixSemigroupElements(R, type); 
@@ -292,11 +292,11 @@ function(S, mat)
           IsReesZeroMatrixSemigroupElement);
 
   # create the Rees matrix semigroup
-  R := Objectify( NewType( CollectionsFamily( fam ), IsWholeFamily and
+  R := Objectify( NewType3( TypeOfTypes, CollectionsFamily( fam ), IsWholeFamily and
    IsReesZeroMatrixSubsemigroup and IsAttributeStoringRep ), rec() );
 
   # store the type of the elements in the semigroup
-  type:=NewType(fam, IsReesZeroMatrixSemigroupElement);
+  type:=NewType3( TypeOfTypes,fam, IsReesZeroMatrixSemigroupElement);
   
   fam!.type:=type;
   SetTypeReesMatrixSemigroupElements(R, type); 
@@ -1186,7 +1186,7 @@ function(R, I, U, J)
   local S;
 
   if U=UnderlyingSemigroup(R) and ForAny(Matrix(R){J}{I}, x-> 0 in x) then 
-    S:=Objectify( NewType( FamilyObj(R),
+    S:=Objectify( NewType3( TypeOfTypes, FamilyObj(R),
      IsReesZeroMatrixSubsemigroup and IsAttributeStoringRep ), rec() );
     SetTypeReesMatrixSemigroupElements(S, TypeReesMatrixSemigroupElements(R));
 
@@ -1237,7 +1237,7 @@ function(R, I, U, J)
   local S;
     
   if U=UnderlyingSemigroup(R) then 
-    S:=Objectify( NewType( FamilyObj(R),
+    S:=Objectify( NewType3( TypeOfTypes, FamilyObj(R),
       IsReesMatrixSubsemigroup and IsAttributeStoringRep ), rec() );
     SetTypeReesMatrixSemigroupElements(S, TypeReesMatrixSemigroupElements(R));
 

--- a/lib/relation.gi
+++ b/lib/relation.gi
@@ -884,7 +884,7 @@ InstallGlobalFunction(BinaryRelationOnPointsNC,
 
         d:= Length(lst);
         fam:= GeneralMappingsFamily(FamilyObj(1), FamilyObj(1));
-        rel:= Objectify(NewType(fam, IsBinaryRelation and 
+        rel:= Objectify(NewType3( TypeOfTypes,fam, IsBinaryRelation and 
                   IsBinaryRelationOnPointsRep and
                       IsNonSPGeneralMapping), rec());
 
@@ -1435,7 +1435,7 @@ InstallGlobalFunction(EquivalenceRelationByPartition,
         subsX := Filtered(subsX, i->Length(i)>1);
 
 	# Create the default type for the elements.
-        rel :=  Objectify(NewType(fam, 
+        rel :=  Objectify(NewType3( TypeOfTypes,fam, 
 		IsEquivalenceRelation and IsEquivalenceRelationDefaultRep), rec());
 	SetEquivalenceRelationPartition(rel, subsX);
 	SetSource(rel, X);
@@ -1459,7 +1459,7 @@ InstallGlobalFunction(EquivalenceRelationByPartitionNC,
 		ElementsFamily(FamilyObj(X)) );
 
 	# Create the default type for the elements.
-        rel :=  Objectify(NewType(fam, 
+        rel :=  Objectify(NewType3( TypeOfTypes,fam, 
 		IsEquivalenceRelation and IsEquivalenceRelationDefaultRep), rec());
 
         ## The only assurance is singletons and empty blocks are removed
@@ -1524,7 +1524,7 @@ InstallGlobalFunction(EquivalenceRelationByProperty,
         ElementsFamily(FamilyObj(X)) );
 
         # Create the default type for the elements.
-        rel :=  Objectify(NewType(fam, IsEquivalenceRelation 
+        rel :=  Objectify(NewType3( TypeOfTypes,fam, IsEquivalenceRelation 
             and IsEquivalenceRelationDefaultRep and IsNonSPGeneralMapping), rec());
         SetSource(rel, X);
         SetRange(rel, X);
@@ -2054,7 +2054,7 @@ InstallMethod(EquivalenceClassOfElementNC, "no check", true,
  
        local new;
 
-       new:= Objectify(NewType(CollectionsFamily(FamilyObj(rep)),
+       new:= Objectify(NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(rep)),
                  IsEquivalenceClass and IsEquivalenceClassDefaultRep), rec());
 
        SetEquivalenceClassRelation(new, rel);

--- a/lib/ring.gi
+++ b/lib/ring.gi
@@ -332,7 +332,7 @@ InstallMethod( RingByGenerators,
     [ IsCollection ], 0,
     function( gens )
     local R;
-    R:= Objectify( NewType( FamilyObj( gens ),
+    R:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsRing and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfRing( R, gens );
@@ -458,7 +458,7 @@ end );
 InstallGlobalFunction( SubringWithOneNC, function( R, gens )
     local S;
     if IsEmpty( gens ) then
-      S:= Objectify( NewType( FamilyObj( R ),
+      S:= Objectify( NewType3( TypeOfTypes, FamilyObj( R ),
                               IsRingWithOne and IsAttributeStoringRep ),
                      rec() );
       SetGeneratorsOfRingWithOne( S, AsList( gens ) );
@@ -480,7 +480,7 @@ InstallMethod( RingWithOneByGenerators,
     [ IsCollection ], 0,
     function( gens )
     local R;
-    R:= Objectify( NewType( FamilyObj( gens ),
+    R:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsRingWithOne and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfRingWithOne( R, gens );

--- a/lib/ringpoly.gi
+++ b/lib/ringpoly.gi
@@ -183,7 +183,7 @@ function( r, n )
           type:= type and IsAlgebraicExtensionPolynomialRing;
         fi;
     fi;
-    prng := Objectify( NewType( CollectionsFamily(rfun), type ), rec() );
+    prng := Objectify( NewType3( TypeOfTypes, CollectionsFamily(rfun), type ), rec() );
 
     # set the left acting domain
     SetLeftActingDomain( prng, r );
@@ -672,7 +672,7 @@ function(r,n)
     type:= type and IsField;
   fi;
 
-  fcfl := Objectify(NewType(CollectionsFamily(rfun),type),rec());;
+  fcfl := Objectify(NewType3( TypeOfTypes,CollectionsFamily(rfun),type),rec());;
 
   # The function field is commutative if and only if the coefficient ring is.
   if HasIsCommutative(r) then

--- a/lib/ringsc.gi
+++ b/lib/ringsc.gi
@@ -398,7 +398,7 @@ InstallGlobalFunction( RingByStructureConstants, function( arg )
 
     # Construct the default type of the family.
     Fam!.defaultTypeDenseCoeffVectorRep :=
-        NewType( Fam, IsSCRingObj and IsDenseCoeffVectorRep );
+        NewType3( TypeOfTypes, Fam, IsSCRingObj and IsDenseCoeffVectorRep );
 
     SetCoefficientsFamily( Fam, ElementsFamily( FamilyObj( Integers ) ) );
     # temporary

--- a/lib/rvecempt.gi
+++ b/lib/rvecempt.gi
@@ -27,7 +27,7 @@ InstallMethod( EmptyRowVector,
     true,
     [ IsFamily ], 0,
     function( F )
-    return Objectify( NewType( CollectionsFamily( F ),
+    return Objectify( NewType3( TypeOfTypes, CollectionsFamily( F ),
                                    IsRowVector
                                and IsEmpty
                                and IsEmptyRowVectorRep ),

--- a/lib/rws.gd
+++ b/lib/rws.gd
@@ -70,7 +70,7 @@
 ##  rewriting system (in the file <F>lib/kbsemi.gi</F>) uses
 ##  <P/>
 ##  <Log><![CDATA[
-##  kbrws := Objectify(NewType(rwsfam, 
+##  kbrws := Objectify(NewType3( TypeOfTypes,rwsfam, 
 ##    IsMutable and IsKnuthBendixRewritingSystem and 
 ##    IsKnuthBendixRewritingSystemRep), 
 ##    rec(family:= fam,

--- a/lib/rwsdt.gi
+++ b/lib/rwsdt.gi
@@ -125,7 +125,7 @@ function( efam, gens, orders )
     dt[ PC_CONJUGATES ] := List( gens, g -> [] );
 
     # convert into a positional object
-    type := NewType( fam, IsDeepThoughtCollectorRep and IsMutable );
+    type := NewType3( TypeOfTypes, fam, IsDeepThoughtCollectorRep and IsMutable );
     Objectify( type, dt );
 
     # underlying family vermutlich nicht n"otig

--- a/lib/rwsgrp.gi
+++ b/lib/rwsgrp.gi
@@ -301,7 +301,7 @@ function( rws )
     fam!.rewritingSystem := Immutable(rws);
 
     # create the default type for the elements
-    fam!.defaultType := NewType( fam, IsPackedElementDefaultRep );
+    fam!.defaultType := NewType3( TypeOfTypes, fam, IsPackedElementDefaultRep );
 
     # that's it
     return fam;

--- a/lib/rwspcgrp.gi
+++ b/lib/rwspcgrp.gi
@@ -143,7 +143,7 @@ function( rws )
       IsElementsFamilyByRws and CanEasilySortElements );
 
     # create the default type for the elements
-    fam!.defaultType := NewType( fam, IsPackedElementDefaultRep );
+    fam!.defaultType := NewType3( TypeOfTypes, fam, IsPackedElementDefaultRep );
 
     # store the identity
     SetOne( fam, ElementByRws( fam, ReducedOne(rws) ) );
@@ -382,7 +382,7 @@ function( sc )
     fi;
 
     # create a new family in the category <IsElementsFamilyByRws>
-    fam := NewFamily5( NewType( FamilyOfFamilies,
+    fam := NewFamily5( NewType3( TypeOfTypes, FamilyOfFamilies,
                            IsFamily and IsFamilyDefaultRep
                            and IsElementsFamilyBy8BitsSingleCollector ),
       "MultiplicativeElementsWithInversesFamilyBy8BitsSingleCollector(...)",
@@ -395,10 +395,10 @@ function( sc )
     fam!.rewritingSystem := Immutable(sc);
 
     # create the default type for the elements
-    fam!.defaultType := NewType( fam, IsPackedElementDefaultRep );
+    fam!.defaultType := NewType3( TypeOfTypes, fam, IsPackedElementDefaultRep );
 
     # create the special 8 bits type
-    fam!.8BitsType := NewType( fam, Is8BitsPcWordRep );
+    fam!.8BitsType := NewType3( TypeOfTypes, fam, Is8BitsPcWordRep );
 
     # copy the assoc word type
     for i  in [ AWP_FIRST_ENTRY .. AWP_FIRST_FREE-1 ]  do
@@ -554,7 +554,7 @@ function( sc )
     fi;
 
     # create a new family in the category <IsElementsFamilyByRws>
-    fam := NewFamily5( NewType( FamilyOfFamilies,
+    fam := NewFamily5( NewType3( TypeOfTypes, FamilyOfFamilies,
                            IsFamily and IsFamilyDefaultRep
                            and IsElementsFamilyBy16BitsSingleCollector ),
       "MultiplicativeElementsWithInversesFamilyBy16BitsSingleCollector(...)",
@@ -567,10 +567,10 @@ function( sc )
     fam!.rewritingSystem := Immutable(sc);
 
     # create the default type for the elements
-    fam!.defaultType := NewType( fam, IsPackedElementDefaultRep );
+    fam!.defaultType := NewType3( TypeOfTypes, fam, IsPackedElementDefaultRep );
 
     # create the special 16 bits type
-    fam!.16BitsType := NewType( fam, Is16BitsPcWordRep );
+    fam!.16BitsType := NewType3( TypeOfTypes, fam, Is16BitsPcWordRep );
 
     # copy the assoc word type
     for i  in [ AWP_FIRST_ENTRY .. AWP_FIRST_FREE-1 ]  do
@@ -725,7 +725,7 @@ function( sc )
     fi;
 
     # create a new family in the category <IsElementsFamilyByRws>
-    fam := NewFamily5( NewType( FamilyOfFamilies,
+    fam := NewFamily5( NewType3( TypeOfTypes, FamilyOfFamilies,
                            IsFamily and IsFamilyDefaultRep
                            and IsElementsFamilyBy32BitsSingleCollector ),
       "MultiplicativeElementsWithInversesFamilyBy32BitsSingleCollector(...)",
@@ -738,10 +738,10 @@ function( sc )
     fam!.rewritingSystem := Immutable(sc);
 
     # create the default type for the elements
-    fam!.defaultType := NewType( fam, IsPackedElementDefaultRep );
+    fam!.defaultType := NewType3( TypeOfTypes, fam, IsPackedElementDefaultRep );
 
     # create the special 32 bits type
-    fam!.32BitsType := NewType( fam, Is32BitsPcWordRep );
+    fam!.32BitsType := NewType3( TypeOfTypes, fam, Is32BitsPcWordRep );
 
     # copy the assoc word type
     for i  in [ AWP_FIRST_ENTRY .. AWP_FIRST_FREE-1 ]  do

--- a/lib/rwspcsng.gi
+++ b/lib/rwspcsng.gi
@@ -1033,7 +1033,7 @@ function( efam, gens, orders )
     sc[SCP_CONJUGATES] := List( sc[SCP_RWS_GENERATORS], x -> [] );
 
     # convert into a list object and set number of bits
-    type := NewType( fam, IsSingleCollectorRep and bits and IsFinite
+    type := NewType3( TypeOfTypes, fam, IsSingleCollectorRep and bits and IsFinite
                           and IsMutable );
     Objectify( type, sc );
     SetFeatureObj( sc, HasUnderlyingFamily,      true );

--- a/lib/rwssmg.gi
+++ b/lib/rwssmg.gi
@@ -25,7 +25,7 @@ function(kbrws)
 
   fam := NewFamily("Family of reduced confluent rewriting systems",
           IsReducedConfluentRewritingSystem);
-  rws:= Objectify(NewType(fam,IsAttributeStoringRep and
+  rws:= Objectify(NewType3( TypeOfTypes,fam,IsAttributeStoringRep and
           IsReducedConfluentRewritingSystem), rec());
   SetRules(rws,StructuralCopy(Rules(kbrws)));
   rws!.tzrules:=StructuralCopy(kbrws!.tzrules);

--- a/lib/semigrp.gi
+++ b/lib/semigrp.gi
@@ -283,7 +283,7 @@ InstallMethod( SemigroupByGenerators,
     function( gens )
       local S, pos;
 
-    S:= Objectify( NewType( FamilyObj( gens ),
+    S:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                             IsSemigroup and IsAttributeStoringRep ),
                    rec() );
     SetGeneratorsOfMagma( S, AsList( gens ) );

--- a/lib/semiquo.gi
+++ b/lib/semiquo.gi
@@ -38,7 +38,7 @@ function(cong)
     filters := filters and IsFinite;
   fi;
 
-  Q:=Objectify(NewType( CollectionsFamily( efam ), filters), rec() );
+  Q:=Objectify(NewType3( TypeOfTypes, CollectionsFamily( efam ), filters), rec() );
 
   SetRepresentative(Q, Qrep);
   SetQuotientSemigroupPreimage(Q, S);

--- a/lib/semirel.gi
+++ b/lib/semirel.gi
@@ -33,7 +33,7 @@ function(X)
 	     ElementsFamily(FamilyObj(X)) );
 
     # Create the default type for the elements.
-    rel :=  Objectify(NewType(fam,
+    rel :=  Objectify(NewType3( TypeOfTypes,fam,
 	       IsEquivalenceRelation and IsEquivalenceRelationDefaultRep
 	       and IsGreensRRelation), rec());
 
@@ -56,7 +56,7 @@ function(X)
 	    ElementsFamily(FamilyObj(X)) );
 
     # Create the default type for the elements.
-    rel :=  Objectify(NewType(fam,
+    rel :=  Objectify(NewType3( TypeOfTypes,fam,
 	    IsEquivalenceRelation and IsEquivalenceRelationDefaultRep
 	    and IsGreensLRelation), rec());
 
@@ -78,7 +78,7 @@ function(X)
 	    ElementsFamily(FamilyObj(X)) );
 
     # Create the default type for the elements.
-    rel :=  Objectify(NewType(fam,
+    rel :=  Objectify(NewType3( TypeOfTypes,fam,
 	    IsEquivalenceRelation and IsEquivalenceRelationDefaultRep
 	    and IsGreensJRelation), rec());
 
@@ -99,7 +99,7 @@ function(X)
 	    ElementsFamily(FamilyObj(X)) );
 
     # Create the default type for the elements.
-    rel :=  Objectify(NewType(fam,
+    rel :=  Objectify(NewType3( TypeOfTypes,fam,
 	    IsEquivalenceRelation and IsEquivalenceRelationDefaultRep
 	    and IsGreensDRelation), rec());
 
@@ -121,7 +121,7 @@ function(X)
 	    ElementsFamily(FamilyObj(X)) );
 
     # Create the default type for the elements.
-    rel :=  Objectify(NewType(fam,
+    rel :=  Objectify(NewType3( TypeOfTypes,fam,
 	    IsEquivalenceRelation and IsEquivalenceRelationDefaultRep
 	    and IsGreensHRelation), rec());
 
@@ -395,7 +395,7 @@ function(rel, rep)
     filts:=filts and IsGreensJClass;
   fi;
   
-  new:= Objectify(NewType(CollectionsFamily(FamilyObj(rep)), filts), rec());
+  new:= Objectify(NewType3( TypeOfTypes,CollectionsFamily(FamilyObj(rep)), filts), rec());
 
   SetEquivalenceClassRelation(new, rel);
   SetRepresentative(new, rep);
@@ -1203,7 +1203,7 @@ local hom, filter;
 	#SetAsSSortedList(imgslist, imgslist);
   hom:=rec(imgslist:=imgslist);
 
-Objectify(NewType( GeneralMappingsFamily
+Objectify(NewType3( TypeOfTypes, GeneralMappingsFamily
     ( ElementsFamily( FamilyObj( S ) ),
       ElementsFamily( FamilyObj( T ) ) ), IsSemigroupHomomorphism
       and IsSemigroupHomomorphismByImagesRep), hom);

--- a/lib/sgpres.gi
+++ b/lib/sgpres.gi
@@ -2437,7 +2437,7 @@ InstallGlobalFunction( PresentationAugmentedCosetTable,
     numgens := Length( gens );
 
     # create the Tietze object.
-    T := Objectify( NewType( PresentationsFamily,
+    T := Objectify( NewType3( TypeOfTypes, PresentationsFamily,
                                  IsPresentationDefaultRep
                              and IsPresentation
                              and IsMutable ),

--- a/lib/sparselistsorted.gi
+++ b/lib/sparselistsorted.gi
@@ -103,7 +103,7 @@ InstallGlobalFunction(SparseListBySortedListNC, function(poss, vals, length, def
         filt := filt and IsTable;
     fi;
     fam := CollectionsFamily(FamilyObj(default));
-    type :=  NewType( fam, filt);
+    type :=  NewType3( TypeOfTypes, fam, filt);
     l := [];
     l[SL_LENGTH]  := length;
     l[SL_DEFAULT] := default;

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -1519,7 +1519,7 @@ InstallGlobalFunction( PartitionBacktrack,
 #    else
         if IsList( Pr )  then
             image.perm := Objectify
-                ( NewType( PermutationsFamily, IsSlicedPerm ),
+                ( NewType3( TypeOfTypes, PermutationsFamily, IsSlicedPerm ),
                   rec( length := 0, word := [  ] ) );
             image.perm!.lftObj := Pr[ 1 ];
 #            image.perm!.rgtObj := Pr[ 2 ];
@@ -1595,7 +1595,7 @@ function( rbase, image, Q, strat )
                              else  t := image.perm2;  fi;
     if IsSlicedPerm( t )  then
         t := ShallowCopy( t );
-        SET_TYPE_COMOBJ( t, NewType( PermutationsFamily, IsSlicedPermInv ) );
+        SET_TYPE_COMOBJ( t, NewType3( TypeOfTypes, PermutationsFamily, IsSlicedPermInv ) );
     else
         t := t ^ -1;
     fi;

--- a/lib/straight.gi
+++ b/lib/straight.gi
@@ -31,7 +31,7 @@ BindGlobal( "StraightLineProgramsFamily",
     NewFamily( "StraightLineProgramsFamily", IsStraightLineProgram ) );
 
 BindGlobal( "StraightLineProgramsDefaultType",
-    NewType( StraightLineProgramsFamily,
+    NewType3( TypeOfTypes, StraightLineProgramsFamily,
              IsStraightLineProgram and IsAttributeStoringRep
                                    and HasLinesOfStraightLineProgram ) );
 
@@ -950,7 +950,7 @@ InstallGlobalFunction( "IntegratedStraightLineProgram",
 ##
 InstallMethod(StraightLineProgElmType,"generic",true,[IsFamily],0,
 function(fam)
-  return NewType(fam,IsStraightLineProgElm);
+  return NewType3( TypeOfTypes,fam,IsStraightLineProgElm);
 end);
 
 #############################################################################

--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -23,7 +23,7 @@
 
 #V  ClosedStreamType  . . . . . . . . . . . . . . . . type of a closed stream
 ##
-ClosedStreamType := NewType(
+ClosedStreamType := NewType3( TypeOfTypes,
     StreamsFamily,
     IsClosedStream );
 
@@ -446,7 +446,7 @@ end );
 ##
 #V  InputTextStringType
 ##
-InputTextStringType := NewType(
+InputTextStringType := NewType3( TypeOfTypes,
     StreamsFamily,
     IsInputTextStream and IsInputTextStringRep );
 
@@ -635,7 +635,7 @@ DeclareRepresentation(
 ##
 #V  InputTextFileType . . . . . . . . . . .  type of a input text file stream
 ##
-InputTextFileType := NewType(
+InputTextFileType := NewType3( TypeOfTypes,
     StreamsFamily,
     IsInputTextStream and IsInputTextFileRep );
 
@@ -811,7 +811,7 @@ DeclareRepresentation(
 ##
 #V  InputTextNoneType	. . . . . . . . . . . type of dummy input text stream
 ##
-InputTextNoneType := NewType(
+InputTextNoneType := NewType3( TypeOfTypes,
     StreamsFamily,
     IsInputTextNone and IsInputTextNoneRep );
 
@@ -947,7 +947,7 @@ DeclareRepresentation(
 ##
 #V  OutputTextStringType
 ##
-OutputTextStringType := NewType(
+OutputTextStringType := NewType3( TypeOfTypes,
     StreamsFamily,
     IsOutputTextStream and IsOutputTextStringRep );
 
@@ -1072,7 +1072,7 @@ DeclareRepresentation(
 ##
 #V  OutputTextFileType
 ##
-OutputTextFileType := NewType(
+OutputTextFileType := NewType3( TypeOfTypes,
     StreamsFamily,
     IsOutputTextStream and IsOutputTextFileRep );
 
@@ -1247,7 +1247,7 @@ DeclareRepresentation(
 ##
 #V  OutputTextNoneType  . . . . . . . . . .  type of dummy output text stream
 ##
-OutputTextNoneType := NewType(
+OutputTextNoneType := NewType3( TypeOfTypes,
     StreamsFamily,
     IsOutputTextNone and IsOutputTextNoneRep );
 
@@ -1390,7 +1390,7 @@ DeclareRepresentation("IsInputOutputStreamByPtyRep", IsPositionalObjectRep,
         []);
 
 InputOutputStreamByPtyDefaultType :=
-  NewType(StreamsFamily, IsInputOutputStreamByPtyRep and IsInputOutputStream);
+  NewType3( TypeOfTypes,StreamsFamily, IsInputOutputStreamByPtyRep and IsInputOutputStream);
 
 #############################################################################
 ##

--- a/lib/string.g
+++ b/lib/string.g
@@ -229,11 +229,11 @@ BIND_GLOBAL( "TYPES_STRING",
           
           ~[2], # T_STRING_NSORT + IMMUTABLE
           
-          NewType (StringFamily, IsString and IsStringRep and
+          NewType3( TypeOfTypes,StringFamily, IsString and IsStringRep and
                   IsSSortedList and IsMutable ),
           # T_STRING_SSORT 
           
-          NewType (StringFamily, IsString and IsStringRep and
+          NewType3( TypeOfTypes,StringFamily, IsString and IsStringRep and
                   IsSSortedList )
           # T_STRING_SSORT +IMMUTABLE
           ]);

--- a/lib/string.g
+++ b/lib/string.g
@@ -202,7 +202,7 @@ BIND_GLOBAL( "CharsFamily", NewFamily( "CharsFamily", IsChar ) );
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_CHAR", NewType( CharsFamily, IsChar and IsInternalRep ) );
+BIND_GLOBAL( "TYPE_CHAR", NewType3( TypeOfTypes, CharsFamily, IsChar and IsInternalRep ) );
 
 
 #############################################################################
@@ -219,10 +219,10 @@ BIND_GLOBAL( "TYPE_CHAR", NewType( CharsFamily, IsChar and IsInternalRep ) );
 BIND_GLOBAL( "StringFamily", NewFamily( "StringsFamily", IsCharCollection ) );
 
 BIND_GLOBAL( "TYPES_STRING", 
-        [ NewType( StringFamily, IsString and IsStringRep and
+        [ NewType3( TypeOfTypes, StringFamily, IsString and IsStringRep and
                 IsMutable ), # T_STRING
           
-          NewType( StringFamily, IsString and IsStringRep ), 
+          NewType3( TypeOfTypes, StringFamily, IsString and IsStringRep ), 
           # T_STRING + IMMUTABLE
           
           ~[1], # T_STRING_NSORT

--- a/lib/tietze.gi
+++ b/lib/tietze.gi
@@ -300,7 +300,7 @@ InstallGlobalFunction( PresentationFpGroup, function ( arg )
     fi;
 
     # Create the Presentation.
-    T := Objectify( NewType( PresentationsFamily, 
+    T := Objectify( NewType3( TypeOfTypes, PresentationsFamily, 
                                  IsPresentationDefaultRep
                              and IsPresentation                            
                              and IsMutable ),

--- a/lib/tom.gi
+++ b/lib/tom.gi
@@ -965,7 +965,7 @@ InstallGlobalFunction( LatticeSubgroupsByTom, function( G )
     od;
 
     # Create the lattice.
-    lattice:=Objectify(NewType(FamilyObj(classes),IsLatticeSubgroupsRep),
+    lattice:=Objectify(NewType3( TypeOfTypes,FamilyObj(classes),IsLatticeSubgroupsRep),
                        rec());
     lattice!.conjugacyClassesSubgroups:=classes;
     lattice!.group     :=G;
@@ -1207,7 +1207,7 @@ InstallGlobalFunction( ConvertToTableOfMarks, function( record )
     names:= RecNames( record );
 
     # Make the object.
-    Objectify( NewType( TableOfMarksFamily,
+    Objectify( NewType3( TypeOfTypes, TableOfMarksFamily,
                         IsTableOfMarks and IsAttributeStoringRep ),
                record );
 

--- a/lib/trans.g
+++ b/lib/trans.g
@@ -12,9 +12,9 @@ BIND_GLOBAL("TransformationFamily", NewFamily("TransformationFamily",
 DeclareRepresentation( "IsTrans2Rep", IsInternalRep, [] );
 DeclareRepresentation( "IsTrans4Rep", IsInternalRep, [] );
 
-BIND_GLOBAL("TYPE_TRANS2", NewType(TransformationFamily,
+BIND_GLOBAL("TYPE_TRANS2", NewType3( TypeOfTypes,TransformationFamily,
  IsTransformation and IsTrans2Rep));
 
-BIND_GLOBAL("TYPE_TRANS4", NewType(TransformationFamily,
+BIND_GLOBAL("TYPE_TRANS4", NewType3( TypeOfTypes,TransformationFamily,
  IsTransformation and IsTrans4Rep));
 

--- a/lib/tuples.gi
+++ b/lib/tuples.gi
@@ -16,7 +16,7 @@
 #V  DIRECT_PRODUCT_ELEMENT_FAMILIES . . . list of all direct product elements
 #V                                                                   families
 ##
-EmptyDirectProductElementsFamily!.defaultTupleType:= NewType(
+EmptyDirectProductElementsFamily!.defaultTupleType:= NewType3( TypeOfTypes,
     EmptyDirectProductElementsFamily, IsDefaultDirectProductElementRep );
 
 SetComponentsOfDirectProductElementsFamily( EmptyDirectProductElementsFamily,
@@ -85,7 +85,7 @@ InstallMethod( DirectProductElementsFamily,
       SetComponentsOfDirectProductElementsFamily( tuplesfam,
           Immutable( famlist ) );
       SetElmWPObj( tupfams, freepos, tuplesfam );
-      tuplesfam!.defaultTupleType:= NewType( tuplesfam,
+      tuplesfam!.defaultTupleType:= NewType3( TypeOfTypes, tuplesfam,
                                         IsDefaultDirectProductElementRep );
     fi;
 

--- a/lib/type.g
+++ b/lib/type.g
@@ -565,7 +565,7 @@ function ( type )
     family := type![1];
     flags  := type![2];
     data   := type![ POS_DATA_TYPE ];
-    Print( "NewType( ", family );
+    Print( "NewType3( TypeOfTypes, ", family );
     if flags <> [] or data <> false then
         Print( ", " );
         Print( TRUES_FLAGS( flags ) );

--- a/lib/unknown.gi
+++ b/lib/unknown.gi
@@ -38,7 +38,7 @@ DeclareRepresentation( "IsUnknownDefaultRep",
 ##
 #V  UnknownsType
 ##
-BindGlobal( "UnknownsType", NewType( CyclotomicsFamily,
+BindGlobal( "UnknownsType", NewType3( TypeOfTypes, CyclotomicsFamily,
     IsUnknown and IsUnknownDefaultRep ) );
 
 

--- a/lib/variable.g
+++ b/lib/variable.g
@@ -36,7 +36,7 @@ BIND_GLOBAL( "ToBeDefinedObjFamily",
 ##
 #V  ToBeDefinedObjType  . . . . . . . . . . . type of "to be defined" objects
 ##
-BIND_GLOBAL( "ToBeDefinedObjType", NewType(
+BIND_GLOBAL( "ToBeDefinedObjType", NewType3( TypeOfTypes,
     ToBeDefinedObjFamily, IsPositionalObjectRep ) );
 
 
@@ -230,7 +230,7 @@ BIND_GLOBAL( "Assert", 0 );
 
 DeclareCategory("IsLVarsBag", IsObject);
 BIND_GLOBAL( "LVARS_FAMILY", NewFamily(IsLVarsBag, IsLVarsBag));
-BIND_GLOBAL( "TYPE_LVARS", NewType(LVARS_FAMILY, IsLVarsBag));
+BIND_GLOBAL( "TYPE_LVARS", NewType3( TypeOfTypes,LVARS_FAMILY, IsLVarsBag));
 
 #############################################################################
 #

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -49,7 +49,7 @@ InstallGlobalFunction(TYPE_VEC8BIT,
                  IsNoImmediateMethodsObject and
                  IsRingElementList and HasLength;
         if mut then filts := filts and IsMutable; fi;
-        TYPES_VEC8BIT[col][q] := NewType(FamilyObj(GF(q)),filts);
+        TYPES_VEC8BIT[col][q] := NewType3( TypeOfTypes,FamilyObj(GF(q)),filts);
     fi;
     return TYPES_VEC8BIT[col][q];
 end);
@@ -65,7 +65,7 @@ InstallGlobalFunction(TYPE_VEC8BIT_LOCKED,
                  IsLockedRepresentationVector and
                  IsRingElementList and HasLength;
         if mut then filts := filts and IsMutable; fi;
-        TYPES_VEC8BIT[col][q] := NewType(FamilyObj(GF(q)),filts);
+        TYPES_VEC8BIT[col][q] := NewType3( TypeOfTypes,FamilyObj(GF(q)),filts);
     fi;
     return TYPES_VEC8BIT[col][q];
 end);
@@ -79,7 +79,7 @@ end);
 ##
 
 InstallValue( TYPE_FIELDINFO_8BIT,
-  NewType(NewFamily("FieldInfo8BitFamily", IsObject),
+  NewType3( TypeOfTypes,NewFamily("FieldInfo8BitFamily", IsObject),
           IsObject and IsDataObjectRep));
 
 #############################################################################

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -24,7 +24,7 @@ DeclareFilter( "IsLockedRepresentationVector" );
 #V  TYPE_LIST_GF2VEC  . . . . . . . . . . . . . . type of mutable GF2 vectors
 ##
 InstallValue( TYPE_LIST_GF2VEC,
-  NewType( CollectionsFamily( FFEFamily(2) ),
+  NewType3( TypeOfTypes, CollectionsFamily( FFEFamily(2) ),
            IsHomogeneousList and IsListDefault and IsNoImmediateMethodsObject
            and IsMutable and IsCopyable and IsGF2VectorRep )
 );
@@ -35,7 +35,7 @@ InstallValue( TYPE_LIST_GF2VEC,
 #V  TYPE_LIST_GF2VEC_IMM  . . . . . . . . . . . type of immutable GF2 vectors
 ##
 InstallValue( TYPE_LIST_GF2VEC_IMM,
-  NewType( CollectionsFamily( FFEFamily(2) ),
+  NewType3( TypeOfTypes, CollectionsFamily( FFEFamily(2) ),
           IsHomogeneousList and IsListDefault and IsNoImmediateMethodsObject 
            and IsCopyable and IsGF2VectorRep )
 );
@@ -45,7 +45,7 @@ InstallValue( TYPE_LIST_GF2VEC_IMM,
 #V  TYPE_LIST_GF2VEC_IMM_LOCKED  . . . . type of immutable locked GF2 vectors
 ##
 InstallValue( TYPE_LIST_GF2VEC_IMM_LOCKED,
-  NewType( CollectionsFamily( FFEFamily(2) ),
+  NewType3( TypeOfTypes, CollectionsFamily( FFEFamily(2) ),
           IsHomogeneousList and IsListDefault and IsNoImmediateMethodsObject 
            and IsCopyable and IsGF2VectorRep and IsLockedRepresentationVector)
 );
@@ -55,7 +55,7 @@ InstallValue( TYPE_LIST_GF2VEC_IMM_LOCKED,
 #V  TYPE_LIST_GF2VEC_LOCKED  . . . . type of mutable locked GF2 vectors
 ##
 InstallValue( TYPE_LIST_GF2VEC_LOCKED,
-  NewType( CollectionsFamily( FFEFamily(2) ),
+  NewType3( TypeOfTypes, CollectionsFamily( FFEFamily(2) ),
           IsHomogeneousList and IsListDefault and IsNoImmediateMethodsObject 
            and IsCopyable and IsGF2VectorRep and
           IsLockedRepresentationVector and IsMutable)
@@ -67,7 +67,7 @@ InstallValue( TYPE_LIST_GF2VEC_LOCKED,
 #V  TYPE_LIST_GF2MAT  . . . . . . . . . . . . .  type of mutable GF2 matrices
 ##
 InstallValue( TYPE_LIST_GF2MAT,
-  NewType( CollectionsFamily(CollectionsFamily(FFEFamily(2))),
+  NewType3( TypeOfTypes, CollectionsFamily(CollectionsFamily(FFEFamily(2))),
            IsMatrix and IsListDefault and IsSmallList and
           IsFFECollColl and IsNoImmediateMethodsObject
            and IsMutable and IsCopyable and IsGF2MatrixRep and
@@ -80,7 +80,7 @@ InstallValue( TYPE_LIST_GF2MAT,
 #V  TYPE_LIST_GF2MAT_IMM  . . . . . . . . . .  type of immutable GF2 matrices
 ##
 InstallValue( TYPE_LIST_GF2MAT_IMM,
-  NewType( CollectionsFamily(CollectionsFamily(FFEFamily(2))),
+  NewType3( TypeOfTypes, CollectionsFamily(CollectionsFamily(FFEFamily(2))),
           IsMatrix and IsListDefault and IsCopyable and IsGF2MatrixRep
           and IsNoImmediateMethodsObject 
           and IsSmallList and IsFFECollColl and

--- a/lib/vspc.gi
+++ b/lib/vspc.gi
@@ -578,7 +578,7 @@ InstallMethod( Subspaces,
     [ IsVectorSpace, IsInt ],
     function( V, dim )
     if IsFinite( V ) then
-      return Objectify( NewType( CollectionsFamily( FamilyObj( V ) ),
+      return Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( V ) ),
                                      IsSubspacesVectorSpace
                                  and IsSubspacesVectorSpaceDefaultRep ),
                         rec(
@@ -601,7 +601,7 @@ InstallMethod( Subspaces,
     [ IsVectorSpace ],
     function( V )
     if IsFinite( V ) then
-      return Objectify( NewType( CollectionsFamily( FamilyObj( V ) ),
+      return Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( V ) ),
                                      IsSubspacesVectorSpace
                                  and IsSubspacesVectorSpaceDefaultRep ),
                         rec(

--- a/lib/vspchom.gi
+++ b/lib/vspchom.gi
@@ -2128,7 +2128,7 @@ InstallMethod( Basis,
     [ IsFreeLeftModule and IsFullHomModule ], 100,
     function( V )
     local B;
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsPseudoCanonicalBasisFullHomModule
                             and IsAttributeStoringRep ),
@@ -2164,7 +2164,7 @@ InstallMethod( Hom,
       W:= AsLeftModule( F, W );
     fi;
 
-    M:= Objectify( NewType( CollectionsFamily( GeneralMappingsFamily(
+    M:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( GeneralMappingsFamily(
                                 ElementsFamily( FamilyObj( V ) ),
                                 ElementsFamily( FamilyObj( W ) ) ) ),
                                 IsFreeLeftModule

--- a/lib/vspcmat.gi
+++ b/lib/vspcmat.gi
@@ -443,7 +443,7 @@ InstallMethod( Basis,
     fi;
 
     # Construct a semi-echelonized basis.
-    B:= Objectify( NewType( FamilyObj( gens ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianMatrixSpaceRep ),
@@ -483,7 +483,7 @@ InstallMethod( BasisNC,
     fi;
 
     # Construct a semi-echelonized basis.
-    B:= Objectify( NewType( FamilyObj( gens ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianMatrixSpaceRep ),
@@ -515,7 +515,7 @@ InstallMethod( SemiEchelonBasis,
     [ IsGaussianMatrixSpace ],
     function( V )
     local B;
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianMatrixSpaceRep ),
@@ -541,7 +541,7 @@ InstallMethod( SemiEchelonBasis,
     fi;
 
     # Construct the basis.
-    B:= Objectify( NewType( FamilyObj( gens ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianMatrixSpaceRep ),
@@ -572,7 +572,7 @@ InstallMethod( SemiEchelonBasisNC,
 
     local B;  # the basis, result
 
-    B:= Objectify( NewType( FamilyObj( gens ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianMatrixSpaceRep ),
@@ -713,7 +713,7 @@ InstallMethod( CanonicalBasis,
     fi;
 
     # Make the basis.
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianMatrixSpaceRep
@@ -784,7 +784,7 @@ InstallMethod( CanonicalBasis,
     [ IsFullMatrixModule ],
     function( V )
     local B, dims, m, n;
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsCanonicalBasis
                             and IsSemiEchelonized
@@ -847,7 +847,7 @@ InstallMethod( MutableBasis,
       # Note that `mats' is not empty.
       newmats:= SemiEchelonMats( mats );
 
-      B:= Objectify( NewType( FamilyObj( mats ),
+      B:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsMutableBasis
                               and IsMutable
                               and IsMutableBasisOfGaussianMatrixSpaceRep ),
@@ -886,7 +886,7 @@ InstallMethod( MutableBasis,
       # Note that `mats' is not empty.
       newmats:= SemiEchelonMats( mats );
 
-      B:= Objectify( NewType( FamilyObj( mats ),
+      B:= Objectify( NewType3( TypeOfTypes, FamilyObj( mats ),
                                   IsMutableBasis
                               and IsMutable
                               and IsMutableBasisOfGaussianMatrixSpaceRep ),
@@ -925,7 +925,7 @@ InstallOtherMethod( MutableBasis,
 
     else
 
-      B:= Objectify( NewType( CollectionsFamily( FamilyObj( zero ) ),
+      B:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( zero ) ),
                                   IsMutableBasis
                               and IsMutable
                               and IsMutableBasisOfGaussianMatrixSpaceRep ),

--- a/lib/vspcrow.gi
+++ b/lib/vspcrow.gi
@@ -57,12 +57,12 @@ InstallMethod( LeftModuleByGenerators,
     local V;
 
     if ForAll( mat, row -> IsSubset( F, row ) ) then
-      V:= Objectify( NewType( FamilyObj( mat ),
+      V:= Objectify( NewType3( TypeOfTypes, FamilyObj( mat ),
                                   IsGaussianRowSpace
                               and IsAttributeStoringRep ),
                      rec() );
     else
-      V:= Objectify( NewType( FamilyObj( mat ),
+      V:= Objectify( NewType3( TypeOfTypes, FamilyObj( mat ),
                                   IsVectorSpace
                               and IsNonGaussianRowSpace
                               and IsRowModule
@@ -89,7 +89,7 @@ InstallMethod( LeftModuleByGenerators,
     fi;
 #T explicit 2nd argument above!
 
-    V:= Objectify( NewType( CollectionsFamily( FamilyObj( F ) ),
+    V:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( F ) ),
                                 IsGaussianRowSpace
                             and IsAttributeStoringRep ),
                    rec() );
@@ -114,12 +114,12 @@ InstallMethod( LeftModuleByGenerators,
 #T explicit 2nd argument above!
 
     if ForAll( mat, row -> IsSubset( F, row ) ) then
-      V:= Objectify( NewType( FamilyObj( mat ),
+      V:= Objectify( NewType3( TypeOfTypes, FamilyObj( mat ),
                                   IsGaussianRowSpace
                               and IsAttributeStoringRep ),
                      rec() );
     else
-      V:= Objectify( NewType( FamilyObj( mat ),
+      V:= Objectify( NewType3( TypeOfTypes, FamilyObj( mat ),
                                   IsVectorSpace
                               and IsNonGaussianRowSpace
                               and IsRowModule
@@ -525,7 +525,7 @@ InstallMethod( Basis,
     fi;
 
     # Construct the basis.
-    B:= Objectify( NewType( FamilyObj( gens ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianRowSpaceRep ),
@@ -568,7 +568,7 @@ InstallMethod( BasisNC,
     fi;
 
     # Construct the basis.
-    B:= Objectify( NewType( FamilyObj( gens ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianRowSpaceRep ),
@@ -604,7 +604,7 @@ InstallMethod( SemiEchelonBasis,
     function( V )
     local B, gens;
 
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianRowSpaceRep ),
@@ -638,7 +638,7 @@ InstallMethod( SemiEchelonBasis,
     fi;
 
     # Construct the basis.
-    B:= Objectify( NewType( FamilyObj( gens ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianRowSpaceRep ),
@@ -674,7 +674,7 @@ InstallMethod( SemiEchelonBasisNC,
     function( V, gens )
     local B,  # the basis, result
           gensi; # immutable copy
-    B:= Objectify( NewType( FamilyObj( gens ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( gens ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianRowSpaceRep ),
@@ -1011,7 +1011,7 @@ InstallMethod( CanonicalBasis,
       fi;
     od;
 
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianRowSpaceRep
@@ -1068,7 +1068,7 @@ InstallMethod( CanonicalBasis,
 
     fi;
 
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsSemiEchelonized
                             and IsSemiEchelonBasisOfGaussianRowSpaceRep
@@ -1142,7 +1142,7 @@ InstallMethod( CanonicalBasis,
     [ IsFullRowModule and IsVectorSpace ],
     function( V )
     local B;
-    B:= Objectify( NewType( FamilyObj( V ),
+    B:= Objectify( NewType3( TypeOfTypes, FamilyObj( V ),
                                 IsFiniteBasisDefault
                             and IsCanonicalBasis
                             and IsSemiEchelonized
@@ -1336,7 +1336,7 @@ InstallMethod( Subspaces,
     "for (Gaussian) full row space",
     [ IsFullRowModule and IsVectorSpace, IsInt ],
     function( V, dim )
-    return Objectify( NewType( CollectionsFamily( FamilyObj( V ) ),
+    return Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( V ) ),
                                    IsSubspacesVectorSpace
                                and IsSubspacesFullRowSpaceDefaultRep ),
                       rec(
@@ -1360,7 +1360,7 @@ InstallOtherMethod( Subspaces,
 ##
 InstallMethod( Subspaces,
     [ IsFullRowModule and IsVectorSpace ],
-    V -> Objectify( NewType( CollectionsFamily( FamilyObj( V ) ),
+    V -> Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( V ) ),
                                  IsSubspacesVectorSpace
                              and IsSubspacesFullRowSpaceDefaultRep ),
                     rec(
@@ -1412,7 +1412,7 @@ InstallMethod( MutableBasis,
       # Note that `vectors' is not empty.
       newvectors:= SemiEchelonMat( vectors );
 
-      B:= Objectify( NewType( FamilyObj( vectors ),
+      B:= Objectify( NewType3( TypeOfTypes, FamilyObj( vectors ),
                                   IsMutableBasis
                               and IsMutable
                               and IsMutableBasisOfGaussianRowSpaceRep ),
@@ -1443,7 +1443,7 @@ InstallOtherMethod( MutableBasis,
 
     else
 
-      B:= Objectify( NewType( CollectionsFamily( FamilyObj( zero ) ),
+      B:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( zero ) ),
                                   IsMutableBasis
                               and IsMutable
                               and IsMutableBasisOfGaussianRowSpaceRep ),

--- a/lib/wordrep.gi
+++ b/lib/wordrep.gi
@@ -977,7 +977,7 @@ InstallGlobalFunction( StoreInfoFreeMagma, function( F, names, req )
 			infinity          ];
 
     # Store the internal types.
-    K:= NewType( F, Is8BitsAssocWord and req );
+    K:= NewType3( TypeOfTypes, F, Is8BitsAssocWord and req );
     K![ AWP_PURE_TYPE    ]      := K;
     K![ AWP_NR_BITS_EXP  ]      := F!.expBits[1];
     K![ AWP_NR_GENS      ]      := rank;
@@ -986,7 +986,7 @@ InstallGlobalFunction( StoreInfoFreeMagma, function( F, names, req )
     K![ AWP_FUN_ASSOC_WORD    ] := 8Bits_AssocWord;
     F!.types[1]:= K;
 
-    K:= NewType( F, Is16BitsAssocWord and req );
+    K:= NewType3( TypeOfTypes, F, Is16BitsAssocWord and req );
     K![ AWP_PURE_TYPE    ]      := K;
     K![ AWP_NR_BITS_EXP  ]      := F!.expBits[2];
     K![ AWP_NR_GENS      ]      := rank;
@@ -995,7 +995,7 @@ InstallGlobalFunction( StoreInfoFreeMagma, function( F, names, req )
     K![ AWP_FUN_ASSOC_WORD    ] := 16Bits_AssocWord;
     F!.types[2]:= K;
 
-    K:= NewType( F, Is32BitsAssocWord and req );
+    K:= NewType3( TypeOfTypes, F, Is32BitsAssocWord and req );
     K![ AWP_PURE_TYPE    ]      := K;
     K![ AWP_NR_BITS_EXP  ]      := F!.expBits[3];
     K![ AWP_NR_GENS      ]      := rank;
@@ -1006,7 +1006,7 @@ InstallGlobalFunction( StoreInfoFreeMagma, function( F, names, req )
 
   fi;
 
-  K:= NewType( F, IsInfBitsAssocWord and req );
+  K:= NewType3( TypeOfTypes, F, IsInfBitsAssocWord and req );
   K![ AWP_PURE_TYPE    ]      := K;
   K![ AWP_NR_BITS_EXP  ]      := infinity;
   K![ AWP_NR_GENS      ]      := Length( names );
@@ -1016,9 +1016,9 @@ InstallGlobalFunction( StoreInfoFreeMagma, function( F, names, req )
   F!.types[4]:= K;
 
   if IsBLetterWordsFamily(F) then
-    K:= NewType( F, IsBLetterAssocWordRep and req );
+    K:= NewType3( TypeOfTypes, F, IsBLetterAssocWordRep and req );
   else
-    K:= NewType( F, IsWLetterAssocWordRep and req );
+    K:= NewType3( TypeOfTypes, F, IsWLetterAssocWordRep and req );
   fi;
   F!.letterWordType:=K;
 
@@ -1134,7 +1134,7 @@ InstallGlobalFunction( InfiniteListOfNames, function( arg )
       Error( "usage: InfiniteListOfNames( <string>[, <init>] )" );
     fi;
 
-    list:= Objectify( NewType( CollectionsFamily( FamilyObj( string ) ),
+    list:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( FamilyObj( string ) ),
                                    IsList
                                and IsDenseList
                                and IsConstantTimeAccessList
@@ -1269,7 +1269,7 @@ InstallGlobalFunction( InfiniteListOfGenerators, function( arg )
       init := Immutable( arg[2] );
     fi;
 
-    list:= Objectify( NewType( CollectionsFamily( F ),
+    list:= Objectify( NewType3( TypeOfTypes, CollectionsFamily( F ),
                                    IsList
                                and IsDenseList
                                and IsConstantTimeAccessList

--- a/lib/wpobj.g
+++ b/lib/wpobj.g
@@ -15,7 +15,7 @@
 ##
 #V  TYPE_WPOBJ  . . . . . . . . . . . . . . . . . . . . type of all wp object
 ##
-TYPE_WPOBJ := NewType( ListsFamily,
+TYPE_WPOBJ := NewType3( TypeOfTypes, ListsFamily,
     IsWeakPointerObject and IsInternalRep and IsSmallList and IsMutable );
 
 

--- a/lib/zmodnz.gi
+++ b/lib/zmodnz.gi
@@ -80,7 +80,7 @@ InstallOtherMethod( ZmodnZObj,
 
       # Store the type for the representation of prime field elements
       # via residues.
-      Fam!.typeOfZmodnZObj:= NewType( Fam,
+      Fam!.typeOfZmodnZObj:= NewType3( TypeOfTypes, Fam,
                                  IsZmodpZObjSmall and IsModulusRep );
       SetDataType( Fam!.typeOfZmodnZObj, p );
       Fam!.typeOfZmodnZObj![ ZNZ_PURE_TYPE ]:= Fam!.typeOfZmodnZObj;
@@ -1048,7 +1048,7 @@ InstallGlobalFunction( ZmodnZ, function( n )
       SetCharacteristic(F,n);
 
       # Store the objects type.
-      F!.typeOfZmodnZObj:= NewType( F,     IsZmodnZObjNonprime
+      F!.typeOfZmodnZObj:= NewType3( TypeOfTypes, F,     IsZmodnZObjNonprime
                                        and IsModulusRep );
       SetDataType( F!.typeOfZmodnZObj, n );
       F!.typeOfZmodnZObj![ ZNZ_PURE_TYPE ]:= F!.typeOfZmodnZObj;

--- a/lib/zmodnze.gi
+++ b/lib/zmodnze.gi
@@ -59,7 +59,7 @@ function( Fam, celt )
   # now we reduce coefficients modulo n
   coeffs := List(coeffs, x -> x mod n);
   elt := coeffs * List( [1..m], j -> E(m)^(j-1) );
-  return Objectify( NewType( Fam, IsZmodnZepsObj and IsZmodnZepsRep ),
+  return Objectify( NewType3( TypeOfTypes, Fam, IsZmodnZepsObj and IsZmodnZepsRep ),
                     [ elt ] );
 end );
 

--- a/prim/primitiv.gi
+++ b/prim/primitiv.gi
@@ -521,7 +521,7 @@ local arglis,i,j,a,b,l,p,deg,gut,g,grp,nr,f,RFL,ind,it;
     fi;
   od;
 
-  it:=Objectify(NewType(IteratorsFamily,
+  it:=Objectify(NewType3(TypeOfTypes,IteratorsFamily,
                         IsIterator and IsPrimGrpIterRep and IsMutable),rec());
 
   it!.deg:=deg;

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -2182,7 +2182,7 @@ false
 gap> if IsBound(IsXYZ) then MakeReadWriteGlobal("IsXYZ"); Unbind(IsXYZ); fi;
 gap> fam := NewFamily("XYZsFamily");;
 gap> DeclareCategory("IsXYZ",IsObject);
-gap> type := NewType(fam,IsXYZ and IsPositionalObjectRep);;
+gap> type := NewType3( TypeOfTypes,fam,IsXYZ and IsPositionalObjectRep);;
 gap> o := Objectify(type,[]);;
 gap> InstallMethod(String,[IsXYZ],function(o) return "XYZ"; end);
 gap> o;


### PR DESCRIPTION
This PR is not for merging, but rather for analysis (potentially useful for e.g. HPC-GAP). Specifically, I wrote a regex pattern to find all calls to `NewType` with exactly two parameters, and replaced those with corresponding calls to `NewType3`. One can grep through the resulting code base to discover all places where NewType is used with a different number of arguments.

To my surprise, there is exactly *one* such spot: In lib/clas.gi:465, the single parameter version is used:
```gap
InstallMethod( RationalClass, IsCollsElms, [ IsGroup, IsObject ],
    function( G, g )
    local   cl;

    cl := Objectify( NewType( FamilyObj( G ) ), rec(  ) );
    if IsPermGroup( G )  then
        SetFilterObj( cl, IsRationalClassPermGroupRep );
    else
        SetFilterObj( cl, IsRationalClassGroupRep );
    fi;
    SetActingDomain( cl, G );
    SetRepresentative( cl, g );
    SetFunctionAction( cl, OnPoints );
    return cl;
end );
```
Quite clearly, one could easily replace that with the two parameter version, too.

I also did the same thing for the package distro I use (slightly oudated: gap4r7p5_2014_05_24-20_02). There only one exceptional usage here, too, using the three parameter version. Specifically, `cvec` has this in `cvec.gi`, global function `CVEC_NewCVecClass`:
```gap
  ty := NewType(CollectionsFamily(scafam),filts and IsMutable,cl);
```
Indeed, `cvec` makes heavy use of `DataType` (and is the only package using it).


Thus, it seems quite feasible to get rid of all `NewType` variants except for the one with two parameters, should we desire to. At the very least, it means that only that variant needs to be optimized.