### PR TITLE
Add ErrorMayQuit function, and documentation

### DIFF
--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -915,10 +915,27 @@ were called with these arguments.
 Then a break loop (see&nbsp;<Ref Sect="Break Loops"/>) is
 entered, unless the standard error output is not connected to a terminal.
 You can leave this break loop with <C>return;</C> to continue execution with
-the statement following the call to <Ref Func="Error"/>.
+the statement following the call to <Ref Func="Error"/>. <Ref Func="ErrorMayQuit"/>
+operates identically to <Ref Func="Error"/>, except it does not allow using
+<C>return;</C> to continue execution.
 </Description>
 </ManSection>
 
+<ManSection>
+<Func Name="ErrorMayQuit" Arg='messages ...'/>
+
+<Description>
+<Ref Func="ErrorMayQuit"/> signals an error from within a function.
+First the messages <A>messages</A> are printed,
+this is done exactly as if <Ref Func="Print"/>
+(see&nbsp;<Ref Sect="View and Print"/>)
+were called with these arguments.
+Then a break loop (see&nbsp;<Ref Sect="Break Loops"/>) is
+entered, unless the standard error output is not connected to a terminal.
+This break loop can only be exited with <C>quit;</C>. The function differs from
+<Ref Func="Error"/> by not allowing execution to continue.
+</Description>
+</ManSection>
 
 <ManSection>
 <Func Name="ErrorCount" Arg=''/>

--- a/lib/error.g
+++ b/lib/error.g
@@ -266,3 +266,12 @@ BIND_GLOBAL("Error",
                                arg);
 end);
 
+BIND_GLOBAL("ErrorMayQuit",
+       function ( arg )
+    ErrorInner( rec(
+         context := ParentLVars( GetCurrentLVars(  ) ),
+         mayReturnVoid := false, mayReturnObj := false,
+         lateMessage := "type 'quit;' to quit to outer loop",
+         printThisStatement := false), arg);
+end);
+ 


### PR DESCRIPTION
This adds the 'ErrorMayQuit' function, which is like 'Error' but does not allow returning.

This was discussed at Gap Days, but it seems it was never made into a pull request!