### PR TITLE
Fix a typo in testtravis.g

### DIFF
--- a/tst/testtravis.g
+++ b/tst/testtravis.g
@@ -44,7 +44,7 @@ Reread( Filename( DirectoriesLibrary( "tst" ), "testutil.g" ) );
 TestDirectory( [
   Filename( DirectoriesLibrary( "tst" ), "teststandard" ),
   Filename( DirectoriesLibrary( "tst" ), "testinstall" )],
-  rec(exitGAP := true, stonesLimit = 18080000) );
+  rec(exitGAP := true, stonesLimit := 18080000) );
   
 # Should never get here
 FORCE_QUIT_GAP(1);


### PR DESCRIPTION
This made testtravis just succeed. We have to be really careful when we change tests so that they actually *fail* when we want them to.