### PR TITLE
Cleanup of command line options

### DIFF
--- a/lib/system.g
+++ b/lib/system.g
@@ -66,6 +66,7 @@ BIND_GLOBAL( "GAPInfo", rec(
       [ "o", "2g", "<mem>", "set hint for maximal workspace size (GAP may allocate more)" ],
       [ "K", "0", "<mem>", "set maximal workspace size (GAP never allocates more)" ],
       [ "c", "0", "<mem>", "set the cache size value" ],
+      [ "s", "4g", "<mem>", "set the initially mapped virtual memory" ],
       [ "a", "0", "<mem>", "set amount to pre-malloc-ate",
              "postfix 'k' = *1024, 'm' = *1024*1024, 'g' = *1024*1024*1024" ],
       ,
@@ -87,11 +88,9 @@ BIND_GLOBAL( "GAPInfo", rec(
       [ "p", false, "enable/disable package output mode" ],
       [ "E", false ],
       [ "U", "" ],     # -C -U undocumented options to the compiler
-      [ "s", "4g" ],
       [ "z", "20" ],
       [ "-prof", "", "<file>", "Run ProfileLineByLine(<filename>,\"w\", true) on GAP start" ],
       [ "-cover", "", "<file>", "Run ProfileLineByLine(<filename>,\"w\", false) on GAP start" ],
-      [ "p", false, "enable/disable package output mode" ],
       
           ],
     ) );

--- a/src/system.c
+++ b/src/system.c
@@ -372,7 +372,7 @@ Int SyStorOverrun;
 *V  SyStorKill . . . . . . . . . . . . . . . . . . maximal size of workspace
 **
 **  'SyStorKill' is really the maximal size of the workspace allocated by 
-**  Gasman. GAP exists before trying to allocate more than this amount
+**  Gasman in kB. GAP exits before trying to allocate more than this amount
 **  of memory.
 **
 **  This is per default disabled (i.e. = 0).
@@ -1963,6 +1963,11 @@ void InitSystem (
         SyStorMax = SyStorMin;
     }
 
+    /* fix pool size if larger than SyStorKill */
+    if ( SyStorKill != 0 && SyAllocPool != 0 &&
+                            SyAllocPool > 1024 * SyStorKill ) {
+        SyAllocPool = SyStorKill * 1024;
+    }
     /* fix pool size if it is given and lower than SyStorMax */
     if ( SyAllocPool != 0 && SyAllocPool < SyStorMax * 1024) {
         SyAllocPool = SyStorMax * 1024;


### PR DESCRIPTION
1. when -K is given and -s is larger then reduce -s option, it is useless
   to pre-map memory which we never want to use.

2. fixed the output of 'gap -h': '-p' was mentioned twice and '-s' was
   not mentioned at all.