### PR TITLE
Add 'make install' support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -70,6 +70,17 @@ endif
 GAPARCH=@GAPARCH@
 GAPARGS=
 
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+datarootdir=@datarootdir@
+GAPROOT=@datadir@/gap
+GAPROOTARCH=@libdir@/gap
+GAPINST=$(DESTDIR)$(GAPROOT)
+GAPINSTARCH=$(DESTDIR)$(GAPROOTARCH)
+GAPINSTBIN=$(DESTDIR)@bindir@
+DIRINST=etc grp lib tst prim small trans doc
+DIRINSTARCH=bin extern
+
 TESTGAP = ./bin/gap-$(CONFIGNAME).sh -b -m 100m -o 750m -A -q -x 80 -r $(GAPARGS)
 TESTGAPauto = ./bin/gap-$(CONFIGNAME).sh -b -m 100m -o 750m -q -x 80 -r $(GAPARGS)
 
@@ -179,7 +190,7 @@ clean_gap_$(CLEANME): rebuild
 	    echo "changing config to "$$nextconf; \
 	    $(MAKE) setconfig CONFIGNAME=$$nextconf; \
 	  else \
-	    rm -f Makefile sysinfo.gap bin/gap.sh; \
+	    rm -f Makefile sysinfo.gap bin/gap.sh bin/gapinst.sh; \
 	  fi; \
 	fi)
 	rm -f Makefile-$(CONFIGNAME)
@@ -197,6 +208,17 @@ clean_gmp_$(CLEANME):
 
 distclean:
 	while test -e Makefile; do $(MAKE) clean; done
+
+install:
+	mkdir -p $(GAPINST)     && cp -pr $(DIRINST) $(GAPINST)
+	mkdir -p $(GAPINSTARCH) && cp -pr $(DIRINSTARCH) $(GAPINSTARCH)
+	cp -p sysinfo.gap-$(CONFIGNAME) $(GAPINSTARCH)
+	ln -s sysinfo.gap-$(CONFIGNAME) $(GAPINSTARCH)/sysinfo.gap
+	mkdir -p $(GAPINSTBIN)  && \
+	sed -e "s@\$${prefix}@${prefix}@g;" \
+	    -e "s@\$${exec_prefix}@${exec_prefix}@g;" \
+	    -e "s@\$${datarootdir}@${datarootdir}@g;" \
+	     < bin/gapinst.sh > $(GAPINSTBIN)/gap && chmod +x $(GAPINSTBIN)/gap
 
 manuals:
 	( echo 'SaveWorkspace( "doc/wsp.g" );' | $(TESTGAPauto) )

--- a/configure
+++ b/configure
@@ -4234,7 +4234,7 @@ fi
 
 
 mkdir -p bin
-ac_config_files="$ac_config_files Makefile-${CONFIGNAME}:Makefile.in sysinfo.gap-${CONFIGNAME}:sysinfo.in bin/gap-${CONFIGNAME}.sh:gap.shi"
+ac_config_files="$ac_config_files Makefile-${CONFIGNAME}:Makefile.in sysinfo.gap-${CONFIGNAME}:sysinfo.in bin/gap-${CONFIGNAME}.sh:gap.shi bin/gapinst.sh:gapinst.shi"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -4944,6 +4944,7 @@ do
     "Makefile-${CONFIGNAME}") CONFIG_FILES="$CONFIG_FILES Makefile-${CONFIGNAME}:Makefile.in" ;;
     "sysinfo.gap-${CONFIGNAME}") CONFIG_FILES="$CONFIG_FILES sysinfo.gap-${CONFIGNAME}:sysinfo.in" ;;
     "bin/gap-${CONFIGNAME}.sh") CONFIG_FILES="$CONFIG_FILES bin/gap-${CONFIGNAME}.sh:gap.shi" ;;
+    "bin/gapinst.sh") CONFIG_FILES="$CONFIG_FILES bin/gapinst.sh:gapinst.shi" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.in
+++ b/configure.in
@@ -157,7 +157,7 @@ AC_SUBST(USE_GMP)
 AC_SUBST(GMP_VER)
 
 mkdir -p bin
-AC_OUTPUT(Makefile-${CONFIGNAME}:Makefile.in sysinfo.gap-${CONFIGNAME}:sysinfo.in bin/gap-${CONFIGNAME}.sh:gap.shi)
+AC_OUTPUT(Makefile-${CONFIGNAME}:Makefile.in sysinfo.gap-${CONFIGNAME}:sysinfo.in bin/gap-${CONFIGNAME}.sh:gap.shi bin/gapinst.sh:gapinst.shi)
 ln -sf gap-${CONFIGNAME}.sh bin/gap.sh
 ln -sf Makefile-${CONFIGNAME} Makefile
 ln -sf sysinfo.gap-${CONFIGNAME} sysinfo.gap

--- a/gapinst.shi
+++ b/gapinst.shi
@@ -1,0 +1,75 @@
+#!/bin/sh
+#############################################################################
+##
+##  gap.sh                      GAP                          Martin Schoenert
+##
+##  This is a shell script for the  UNIX  operating system  that starts  GAP.
+##  This is the place  where  you  make  all  the  necessary  customizations.
+##  Then copy this file to a  directory in your  search path,  e.g., '~/bin'.
+##  If you later move GAP to another location you must only change this file.
+##
+
+
+#############################################################################
+##
+##  GAP_DIR . . . . . . . . . . . . . . . . . . . . directory where GAP lives
+##
+##  Set 'GAP_DIR' to the name of the directory where you have installed  GAP,
+##  i.e., the directory with the subdirectories  'lib',  'grp',  'doc',  etc.
+##  You won't have to change this unless you move the installation.
+##
+if [ "x$GAP_DIR" = "x" ];  then
+GAP_DIR="@libdir@/gap"
+fi
+
+#############################################################################
+##
+##  GAP_LIBS . . . . . . . . . . . . . . . . . . . . . extra GAP directories
+##
+##  Set 'GAP_LIBS' to the name of extra directories where GAP should look
+##  for a GAP installation, separated by semicolons.
+##  You won't have to change this unless you want to add more directory.
+##
+if [ "x$GAP_LIBS" = "x" ];  then
+GAP_LIBS="$GAP_DIR;@datadir@/gap"
+fi
+## this should be removed in a few year: @datarootdir@
+
+#############################################################################
+##
+##  GAP_MEM . . . . . . . . . . . . . . . . . . . amount of initial workspace
+##
+##  Set 'GAP_MEM' to the amount of memory GAP shall use as initial workspace.
+##  The default depends on whether GAP is compiled with in 32-bit or 64-bit
+##  mode. You have to uncomment and change the following if you want GAP
+##  to use a larger initial workspace. If you are not going to run GAP
+##  in parallel with other programs you may want to set this value close
+##  to the amount of memory your computer has.
+##
+#if [ "x$GAP_MEM" = "x" ];  then
+#GAP_MEM="-m 256m"
+#fi
+
+
+#############################################################################
+##
+##  GAP_PRG . . . . . . . . . . . . . . . . .  name of the executable program
+##
+##  Set 'GAP_PRG' to the  name of the executable  program of the  GAP kernel.
+##  The default is  '<target>/XX-bit/gap'  where  <target>  is the target you
+##  have selected during compilation and  XX  is 32 or 64 - set automatically
+##  according to your  system  architecture,  unless specified by  you at the 
+##  './configure' stage.
+##
+if [ "x$GAP_PRG" = "x" ];  then
+GAP_PRG=@GAPARCH@/gap@EXEEXT@
+fi
+
+
+#############################################################################
+##
+##  GAP . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . run GAP
+##
+##  You  probably should  not change  this line,  which  finally starts  GAP.
+##
+exec "$GAP_DIR/bin/$GAP_PRG" $GAP_MEM -l "$GAP_LIBS" "$@"


### PR DESCRIPTION
Following the discussion on this topic in GAP support, I've created this pull request from the branch `bill-install-target` in a clone of the GAP Git repository hosted by Bill, so we may be able to test it and discuss the necessity of this change here.

Comments by Bill:
Half of this patch (including the sed command) is to support autoconf `${prefix} ${exec_prefix} ${datarootdir}` semantic.

Makefile.in: add install target
gapinst.shi: variant of gap.sh script for global installation

Installed in datadir/gap: etc grp lib tst prim small trans doc
installed in libdir/gap: bin extern sysinfo.gap
