### PR TITLE
lib/basis.gi: Handle some cases involving zero space and zero vector (WIP)

### DIFF
--- a/lib/basis.gi
+++ b/lib/basis.gi
@@ -1157,7 +1157,7 @@ InstallMethod( NiceFreeLeftModule,
     local gens;
 
     gens:= GeneratorsOfLeftModule( V );
-    if IsEmpty( gens ) then
+    if IsEmpty( gens ) or ForAll( gens, IsZero ) then
       return LeftModuleByGenerators( LeftActingDomain( V ), [],
                           NiceVector( V, Zero( V ) ) );
     else
@@ -1252,6 +1252,8 @@ InstallMethod( \in,
     a:= NiceVector( V, v );
     if a = fail then
       return false;
+    elif IsZero(a) then
+      return true;
     else
       return a in W and v = UglyVector( V, a );
     fi;
@@ -1479,4 +1481,3 @@ InstallMethod( IsCanonicalBasis,
 #############################################################################
 ##
 #E
-


### PR DESCRIPTION
This is an attempt at fixing an issue reported by Chris Wensley on GAP Support on the
30th of June. The code that exhibits the problem is the following

```
gap> F := Rationals;;
gap> m := [ [0,1,2], [0,0,3], [0,0,0] ];;
gap> A := Algebra( F, [m] );;
gap> basA := Basis(A);;
gap> vecA := BasisVectors(basA);;
gap> dimA := Dimension(A);;

gap> ## now replace m^2 with m^3, the zero matrix:
gap> S := Subalgebra( A, [m^3] );
<algebra over Rationals, with 1 generators>
gap> basS := Basis(S);;
gap> vecS := BasisVectors(basS);;
gap> dimS := Dimension(S);
0
gap> homS := AlgebraGeneralMappingByImages( S, S, vecS, vecS );
[  ] -> [  ]
gap> B := Algebra( F, [homS] );
<algebra over Rationals, with 1 generators>
gap> map := AlgebraGeneralMappingByImages( A, B, vecA, [homS,homS] );
```

And the problem is caused by not handling the zero mapping/zero matrix in
NiceFreeLeftModule and the element test \in for vector spaces handled by
a nice basis.