### PR TITLE
WIP: Enhanced list indexing

### DIFF
--- a/dev/Updates/multi-index
+++ b/dev/Updates/multi-index
@@ -1,0 +1,29 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Format 'yyyy/mm/dd'
+!! Date
+2015/03/18
+!! Changed by
+SL
+! Reported by
+
+!! Type of Change
+New: extended functionality
+
+!! Description
+
+Kernel support for accessing lists using multiple indices.
+This doesn't do anything by itself but allows library or packages
+to install methods supporting expressions like
+m[1,2];
+m[1,2,3] := x;
+IsBound(m["a","b",Z(7)]);
+Unbind(m[1][2,3])
+
+
+! Test Code
+
+! Prefetch
+
+!! Changeset
+
+!! End

--- a/doc/ref/lists.xml
+++ b/doc/ref/lists.xml
@@ -83,15 +83,15 @@ position (see&nbsp;<Ref Sect="IsBound and Unbind for Lists"/>).
 <P/>
 The term basic operation means that each other list operation can be
 formulated in terms of the basic operations.
-(But note that usually a more efficient method than this one is implemented.)
+(But note that often a more efficient method than this one is implemented.)
 <P/>
 Any &GAP; object <A>list</A> in the category <Ref Func="IsList"/> is regarded
 as a list, and if methods for the basic list operations are installed for
 <A>list</A> then <A>list</A> can be used also for the other list operations.
 <P/>
 For internally represented lists, kernel methods are provided for the basic
-list operations.
-For other lists, it is possible to install appropriate methods for these
+list operations with positive integer indices.
+For other lists or other indices, it is possible to install appropriate methods for these
 operations.
 This permits the implementation of lists that do not need to store all list
 elements (see also&nbsp;<Ref Sect="Enumerators"/>);
@@ -105,15 +105,14 @@ may have to be paid (see&nbsp;<Ref Func="ConstantTimeAccessList"/>).
 <Index Subkey="operation">list assignment</Index>
 <Index Subkey="operation">list unbind</Index>
 <ManSection>
-<Oper Name="\[\]" Arg='list, pos'/>
-<Oper Name="IsBound\[\]" Arg='list, pos'/>
-<Oper Name="\[\]\:\=" Arg='list, pos, val'/>
-<Oper Name="Unbind\[\]" Arg='list, pos'/>
+<Oper Name="\[\]" Arg='list, ix'/>
+<Oper Name="IsBound\[\]" Arg='list, ix'/>
+<Oper Name="\[\]\:\=" Arg='list, pos, ix'/>
+<Oper Name="Unbind\[\]" Arg='list, ix'/>
 
 <Description>
 These operations implement element access, test for element boundedness,
-list element assignment, and removal of the element at position <A>pos</A>.
-In all cases, the index <A>pos</A> must be a positive integer.
+list element assignment, and removal of the element with index  <A>ix</A>.
 <P/>
 Note that the special characters <C>[</C>, <C>]</C>, <C>:</C>,
 and <C>=</C> must be escaped with a backslash <C>\</C>
@@ -123,12 +122,20 @@ whereas <C>[]</C> denotes an empty list.
 (Maybe the variable names involving special characters look strange,
 but nevertheless they are quite suggestive.)
 <P/>
-<C>\[\]( <A>list</A>, <A>pos</A> )</C> is equivalent to
-<C><A>list</A>[ <A>pos</A> ]</C>,
+<C>\[\]( <A>list</A>, <A>ix</A> )</C> is equivalent to
+<C><A>list</A>[ <A>ix</A> ]</C>,
 which clearly will usually be preferred;
 the former is useful mainly if one wants to access the operation itself,
 for example if one wants to install a method for element access in a
 special kind of lists.
+<P/>
+The syntax <C><A>list</A>[ <A>ix1</A>, <A>ix2</A>,.... <A>ixn</A>
+]</C>, with two or more indices is treated as a shorthand for
+<C><A>list</A>[[ <A>ix1</A>, <A>ix2</A>,.... <A>ixn</A>]]</C>
+
+This is intended to provide a nicer syntax for accessing elements of
+matrices and tensors.
+
 <P/>
 Similarly,
 <Ref Oper="IsBound\[\]"/> is used explicitly mainly in method installations.
@@ -152,23 +159,28 @@ and <Ref Oper="Unbind\[\]"/>.
 
 <Index Subkey="list elements">accessing</Index>
 <Index Subkey="access">list element</Index>
-<C><A>list</A>[ <A>pos</A> ]</C>
+<C><A>list</A>[ <A>ix</A> ]</C>
 <P/>
-The above construct evaluates to the <A>pos</A>-th element of the list
-<A>list</A>,
-where <A>pos</A> must be a positive integer.
-List indexing is done with origin 1,
-i.e., the first element of the list is the element at position 1.
+The above construct evaluates to the element of the list
+<A>list</A> with index <A>ix</A>.
+For built-in list types and collections, indexing is done with origin 1,
+i.e., the first element of the list is the element with index 1.
 <Example><![CDATA[
 gap> l := [ 2, 3, 5, 7, 11, 13 ];;  l[1];  l[2];  l[6];
 2
 3
 13
 ]]></Example>
-If <A>list</A> is not a list, or <A>pos</A> does not evaluate to a
-positive integer,
-or <C><A>list</A>[<A>pos</A>]</C> is unbound an error is signalled.
+If <A>list</A> is not a built-in list, or <A>ix</A> does not evaluate to a
+positive integer, method selection is invoked to try and find a way of
+indexing <A>list</A> with index <A>ix</A>. If this fails, or the
+selected method finds that
+<C><A>list</A>[<A>ix</A>]</C> is unbound, an error is signalled.
 <P/>
+<Index>multiple indices</Index>
+<C><A>list</A>[ <A>ix1</A>,<A>ix2</A>,...]</C> <P/> is a short-hand for <C><A>list</A>[[<A>ix1</A>,<A>ix2</A>,...]]</C>
+<P/>
+
 <Index>sublist</Index>
 <Index Subkey="access">sublist</Index>
 <C><A>list</A>{ <A>poss</A> }</C>
@@ -176,7 +188,6 @@ or <C><A>list</A>[<A>pos</A>]</C> is unbound an error is signalled.
 The above construct evaluates to a new list <A>new</A> whose first element is
 <C><A>list</A>[<A>poss</A>[1]]</C>,
 whose second element is <C><A>list</A>[<A>poss</A>[2]]</C>, and so on.
-<A>poss</A> must be a dense list of positive integers.
 However, it does not need to be sorted and may contain duplicate elements.
 If for any <M>i</M>,
 <C><A>list</A>[ <A>poss</A>[</C><M>i</M><C>] ]</C> is unbound,
@@ -271,14 +282,13 @@ cf.&nbsp;<Ref Sect="Basic Operations for Lists"/>.)
 
 <Index Subkey="to a list">assignment</Index>
 <Index Subkey="assignment">list element</Index>
-<C><A>list</A>[ <A>pos</A> ] := <A>object</A>;</C>
+<C><A>list</A>[ <A>ix</A> ] := <A>object</A>;</C>
 <P/>
 The list element assignment assigns the object <A>object</A>,
-which can be of any type, to the list entry at the position <A>pos</A>,
-which must be a positive integer,
+which can be of any type, to the list with index <A>ix</A>,
 in the mutable (see&nbsp;<Ref Sect="Mutability and Copyability"/>) list
 <A>list</A>.
-That means that accessing the <A>pos</A>-th element of the list <A>list</A>
+That means that accessing the <A>ix</A>-th element of the list <A>list</A>
 will return <A>object</A> after this assignment.
 <P/>
 <Example><![CDATA[
@@ -291,7 +301,7 @@ gap> l[ l[1] ] := 10;; l;       # <index> may be an expression
 [ 3, [ 4, 5, 6 ], 10 ]
 ]]></Example>
 <P/>
-If the index <A>pos</A> is larger than the length of the list <A>list</A>
+If the index <A>ix</A> is an integer larger than the length of the list <A>list</A>
 (see <Ref Func="Length"/>),
 the list is automatically enlarged to make room for the new element.
 Note that it is possible to generate lists with holes that way.
@@ -315,6 +325,10 @@ If <A>list</A> does not evaluate to a list, <A>pos</A> does not evaluate to a
 positive integer or <A>object</A> is a call to a function which does not
 return a value (for example <C>Print</C>) an error is signalled.
 <P/>
+<Index Subkey="assignment">multiple indices</Index>
+<C><A>list</A>[ <A>ix1</A>,<A>ix2</A>,...] := <A>obj</A></C>
+<P/> is a short-hand for <C><A>list</A>[[<A>ix1</A>,<A>ix2</A>,...]]
+:= <A>obj</A></C>.<P/>
 <Index Subkey="assignment">sublist</Index>
 <C><A>list</A>{ <A>poss</A> } := <A>objects</A>;</C>
 <P/>

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -164,7 +164,7 @@ DeclareAttributeKernel( "Length", IsList, LENGTH );
 ##  <#/GAPDoc>
 ##
 DeclareOperationKernel( "IsBound[]",
-    [ IsList, IS_INT ],
+    [ IsList, IsObject ],
     ISB_LIST );
 
 
@@ -173,7 +173,7 @@ DeclareOperationKernel( "IsBound[]",
 #o  <list>[<pos>] . . . . . . . . . . . . . . . select an element from a list
 ##
 DeclareOperationKernel( "[]",
-    [ IsList, IS_INT ],
+    [ IsList, IsObject ],
     ELM_LIST );
 
 
@@ -234,7 +234,7 @@ DeclareOperationKernel( "Elm0List",
 ##  <#/GAPDoc>
 ##
 DeclareOperationKernel( "Unbind[]",
-    [ IsList and IsMutable, IS_INT ],
+    [ IsList and IsMutable, IsObject ],
     UNB_LIST );
 
 

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -139,14 +139,16 @@ DeclareAttributeKernel( "Length", IsList, LENGTH );
 #############################################################################
 ##
 #O  IsBound( <list>[<pos>] )  . . . . . . . . test for an element from a list
+#O  IsBound( <list>[<ix1>,<ix2>,...] )  . . . . . . . . test for an element from a list
 ##
 ##  <#GAPDoc Label="IsBound_list">
 ##  <ManSection>
-##  <Oper Name="IsBound" Arg='list[n]' Label="for a list position"/>
+##  <Oper Name="IsBound" Arg='list[n]' Label="for a list index"/>
+##  <Oper Name="IsBound" Arg='list[ix1,ix2,...]' Label="for multiple indices"/>
 ##
 ##  <Description>
-##  <Ref Func="IsBound" Label="for a list position"/> returns <K>true</K>
-##  if the list <A>list</A> has a element at the position <A>n</A>,
+##  <Ref Func="IsBound" Label="for a list index"/> returns <K>true</K>
+##  if the list <A>list</A> has a element at index <A>n</A>,
 ##  and <K>false</K> otherwise.
 ##  <A>list</A> must evaluate to a list, otherwise an error is signalled.
 ##  <P/>
@@ -159,6 +161,9 @@ DeclareAttributeKernel( "Length", IsList, LENGTH );
 ##  gap> IsBound( l[101] );
 ##  false
 ##  ]]></Example>
+##
+##  <C>IsBound(<A>list</A>[<A>ix1</A>,<A>ix2</A>,...]</C> is a short-hand for  
+##  <C>IsBound(<A>list</A>[[<A>ix1</A>,<A>ix2</A>,...]]</C>   
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -202,15 +207,16 @@ DeclareOperationKernel( "Elm0List",
 ##  <#GAPDoc Label="Unbind_list">
 ##  <ManSection>
 ##  <Oper Name="Unbind" Arg='list[n]' Label="unbind a list entry"/>
+##  <Oper Name="Unbind" Arg='list[ix1,ix2,...]' Label="for multiple indices"/>
 ##
 ##  <Description>
-##  <Ref Func="Unbind" Label="unbind a list entry"/> deletes the element at
-##  the position <A>n</A> in the mutable list <A>list</A>.  That is, after
+##  <Ref Func="Unbind" Label="unbind a list entry"/> deletes the element with index
+##  <A>n</A> in the mutable list <A>list</A>.  That is, after
 ##  execution of <Ref Func="Unbind" Label="unbind a list entry"/>,
-##  <A>list</A> no longer has an assigned value at the position <A>n</A>.
+##  <A>list</A> no longer has an assigned value with index <A>n</A>.
 ##  Thus <Ref Func="Unbind" Label="unbind a list entry"/> can be used to
 ##  produce holes in a list.
-##  Note that it is not an error to unbind a nonexisting list element.
+##  Note that it is not an error to unbind a nonexistant list element.
 ##  <A>list</A> must evaluate to a list, otherwise an error is signalled.
 ##  <P/>
 ##  <Example><![CDATA[
@@ -229,6 +235,8 @@ DeclareOperationKernel( "Elm0List",
 ##  and there would be no way to tell
 ##  <Ref Func="Unbind" Label="unbind a list entry"/>
 ##  which component to remove.
+##  <C>Unbind(<A>list</A>[<A>ix1</A>,<A>ix2</A>,...]</C> is a short-hand for  
+##  <C>Unbind(<A>list</A>[[<A>ix1</A>,<A>ix2</A>,...]]</C>   
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -243,7 +243,7 @@ DeclareOperationKernel( "Unbind[]",
 #o  <list>[<pos>] := <obj>
 ##
 DeclareOperationKernel( "[]:=",
-    [ IsList and IsMutable, IS_INT, IsObject ],
+    [ IsList and IsMutable, IsObject, IsObject ],
     ASS_LIST );
 
 

--- a/src/code.c
+++ b/src/code.c
@@ -2353,20 +2353,24 @@ void CodeIsbGVar (
 *F  CodeAssListLevel( <level> ) . . . . . .  code assignment to several lists
 *F  CodeAsssListLevel( <level> )  . code multiple assignment to several lists
 */
-void CodeAssListUniv (
-    Stat                ass )
+void CodeAssListUniv ( 
+		      Stat                ass,
+		       Int narg)
 {
     Expr                list;           /* list expression                 */
     Expr                pos;            /* position expression             */
     Expr                rhsx;           /* right hand side expression      */
+    Int i;
 
     /* enter the right hand side expression                                */
     rhsx = PopExpr();
-    ADDR_STAT(ass)[2] = (Stat)rhsx;
+    ADDR_STAT(ass)[narg+1] = (Stat)rhsx;
 
     /* enter the position expression                                       */
-    pos = PopExpr();
-    ADDR_STAT(ass)[1] = (Stat)pos;
+    for (i = narg; i > 0; i--) {
+      pos = PopExpr();
+      ADDR_STAT(ass)[i] = (Stat)pos;
+    }
 
     /* enter the list expression                                           */
     list = PopExpr();
@@ -2376,15 +2380,25 @@ void CodeAssListUniv (
     PushStat( ass );
 }
 
-void CodeAssList ( void )
+void CodeAssList ( Int narg )
 {
     Stat                ass;            /* assignment, result              */
 
     /* allocate the assignment                                             */
-    ass = NewStat( T_ASS_LIST, 3 * sizeof(Stat) );
+    switch (narg) {
+    case 1:
+      ass = NewStat( T_ASS_LIST, 3 * sizeof(Stat) );
+      break;
+
+    case 2:
+      ass = NewStat(T_ASS2_LIST, 4* sizeof(Stat));
+      break;
+    default:
+      ass  = NewStat(T_ASSX_LIST, (narg + 2)*sizeof(Stat));
+    }
 
     /* let 'CodeAssListUniv' do the rest                                   */
-    CodeAssListUniv( ass );
+    CodeAssListUniv( ass, narg );
 }
 
 void CodeAsssList ( void )
@@ -2395,10 +2409,10 @@ void CodeAsssList ( void )
     ass = NewStat( T_ASSS_LIST, 3 * sizeof(Stat) );
 
     /* let 'CodeAssListUniv' do the rest                                   */
-    CodeAssListUniv( ass );
+    CodeAssListUniv( ass, 1 );
 }
 
-void CodeAssListLevel (
+void CodeAssListLevel ( Int narg,
     UInt                level )
 {
     Stat                ass;            /* assignment, result              */
@@ -2408,7 +2422,7 @@ void CodeAssListLevel (
     ADDR_STAT(ass)[3] = (Stat)level;
 
     /* let 'CodeAssListUniv' do the rest                                   */
-    CodeAssListUniv( ass );
+    CodeAssListUniv( ass, narg );
 }
 
 void CodeAsssListLevel (
@@ -2421,7 +2435,7 @@ void CodeAsssListLevel (
     ADDR_STAT(ass)[3] = (Stat)level;
 
     /* let 'CodeAssListUniv' do the rest                                   */
-    CodeAssListUniv( ass );
+    CodeAssListUniv( ass, 1 );
 }
 
 
@@ -2429,18 +2443,21 @@ void CodeAsssListLevel (
 **
 *F  CodeUnbList() . . . . . . . . . . . . . . .  code unbind of list position
 */
-void CodeUnbList ( void )
+void CodeUnbList ( Int narg )
 {
     Expr                list;           /* list expression                 */
     Expr                pos;            /* position expression             */
     Stat                ass;            /* unbind, result                  */
+    Int i;
 
     /* allocate the unbind                                                 */
-    ass = NewStat( T_UNB_LIST, 2 * sizeof(Stat) );
+    ass = NewStat( T_UNB_LIST, (narg+1) * sizeof(Stat) );
 
-    /* enter the position expression                                       */
-    pos = PopExpr();
-    ADDR_STAT(ass)[1] = (Stat)pos;
+    /* enter the position expressions                                       */
+    for (i = narg; i > 0; i--) {
+      pos = PopExpr();
+      ADDR_STAT(ass)[i] = (Stat)pos;
+    }
 
     /* enter the list expression                                           */
     list = PopExpr();
@@ -2540,18 +2557,21 @@ void CodeElmsListLevel (
 **
 *F  CodeIsbList() . . . . . . . . . . . . . .  code bound list position check
 */
-void CodeIsbList ( void )
+void CodeIsbList ( Int narg )
 {
     Expr                ref;            /* isbound, result                 */
     Expr                list;           /* list expression                 */
     Expr                pos;            /* position expression             */
+    Int i;
 
     /* allocate the isbound                                                */
-    ref = NewExpr( T_ISB_LIST, 2 * sizeof(Expr) );
+    ref = NewExpr( T_ISB_LIST, (narg + 1) * sizeof(Expr) );
 
     /* enter the position expression                                       */
-    pos = PopExpr();
-    ADDR_EXPR(ref)[1] = pos;
+    for (i = narg; i > 0; i--) {
+      pos = PopExpr();
+      ADDR_EXPR(ref)[i] = pos;
+    }
 
     /* enter the list expression                                           */
     list = PopExpr();

--- a/src/code.c
+++ b/src/code.c
@@ -2418,8 +2418,8 @@ void CodeAssListLevel ( Int narg,
     Stat                ass;            /* assignment, result              */
 
     /* allocate the assignment and enter the level                         */
-    ass = NewStat( T_ASS_LIST_LEV, 4 * sizeof(Stat) );
-    ADDR_STAT(ass)[3] = (Stat)level;
+    ass = NewStat( T_ASS_LIST_LEV, (narg +3) * sizeof(Stat) );
+    ADDR_STAT(ass)[narg+2] = (Stat)level;
 
     /* let 'CodeAssListUniv' do the rest                                   */
     CodeAssListUniv( ass, narg );

--- a/src/code.c
+++ b/src/code.c
@@ -2514,14 +2514,12 @@ void CodeElmListLevel ( Int narg,
 {
     Expr                ref;            /* reference, result               */
 
-    /* allocate the reference and enter the level                          */
-    if (narg != 1)
-      SyntaxError("Not supported");
-    ref = NewExpr( T_ELM_LIST_LEV, 3 * sizeof(Expr) );
-    ADDR_EXPR(ref)[2] = (Stat)level;
+    ref = NewExpr( T_ELM_LIST_LEV, (narg+2)*sizeof(Expr));
+    ADDR_EXPR(ref)[narg+1] = (Stat)level;
+      
 
     /* let 'CodeElmListUniv' do the rest                                   */
-    CodeElmListUniv( ref, 1 );
+    CodeElmListUniv( ref, narg );
 }
 
 void CodeElmsListLevel (

--- a/src/code.c
+++ b/src/code.c
@@ -2459,14 +2459,19 @@ void CodeUnbList ( void )
 *F  CodeElmsListLevel( <level> )  .  code multiple selection of several lists
 */
 void CodeElmListUniv (
-    Expr                ref )
+		      Expr                ref,
+		      Int narg)
 {
     Expr                list;           /* list expression                 */
     Expr                pos;            /* position expression             */
+    Int                i;
 
     /* enter the position expression                                       */
-    pos = PopExpr();
-    ADDR_EXPR(ref)[1] = pos;
+
+    for (i = narg; i > 0; i--) {
+      pos = PopExpr();
+      ADDR_EXPR(ref)[i] = pos;
+    }
 
     /* enter the list expression                                           */
     list = PopExpr();
@@ -2476,15 +2481,21 @@ void CodeElmListUniv (
     PushExpr( ref );
 }
 
-void CodeElmList ( void )
+void CodeElmList ( Int narg )
 {
     Expr                ref;            /* reference, result               */
 
-    /* allocate the reference                                              */
-    ref = NewExpr( T_ELM_LIST, 2 * sizeof(Expr) );
-
-    /* let 'CodeElmListUniv' to the rest                                   */
-    CodeElmListUniv( ref );
+      /* allocate the reference                                              */
+    if (narg == 1)
+      ref = NewExpr( T_ELM_LIST, 2 * sizeof(Expr) );
+    else if (narg == 2)
+      ref = NewExpr( T_ELM2_LIST, 3 * sizeof(Expr) );
+    else
+      ref = NewExpr( T_ELMX_LIST, (narg + 1) *sizeof(Expr));
+      
+      /* let 'CodeElmListUniv' to the rest                                   */
+    CodeElmListUniv( ref, narg );
+      
 }
 
 void CodeElmsList ( void )
@@ -2495,20 +2506,22 @@ void CodeElmsList ( void )
     ref = NewExpr( T_ELMS_LIST, 2 * sizeof(Expr) );
 
     /* let 'CodeElmListUniv' to the rest                                   */
-    CodeElmListUniv( ref );
+    CodeElmListUniv( ref, 1 );
 }
 
-void CodeElmListLevel (
+void CodeElmListLevel ( Int narg,
     UInt                level )
 {
     Expr                ref;            /* reference, result               */
 
     /* allocate the reference and enter the level                          */
+    if (narg != 1)
+      SyntaxError("Not supported");
     ref = NewExpr( T_ELM_LIST_LEV, 3 * sizeof(Expr) );
     ADDR_EXPR(ref)[2] = (Stat)level;
 
     /* let 'CodeElmListUniv' do the rest                                   */
-    CodeElmListUniv( ref );
+    CodeElmListUniv( ref, 1 );
 }
 
 void CodeElmsListLevel (
@@ -2521,7 +2534,7 @@ void CodeElmsListLevel (
     ADDR_EXPR(ref)[2] = (Stat)level;
 
     /* let 'CodeElmListUniv' do the rest                                   */
-    CodeElmListUniv( ref );
+    CodeElmListUniv( ref, 1 );
 }
 
 

--- a/src/code.h
+++ b/src/code.h
@@ -389,8 +389,10 @@ Obj FILENAME_STAT(Stat stat);
 
 #define T_ELM2_LIST             (FIRST_EXPR_TNUM+84)
 #define T_ELMX_LIST             (FIRST_EXPR_TNUM+85)
+#define T_ASS2_LIST             (FIRST_EXPR_TNUM+86)
+#define T_ASSX_LIST             (FIRST_EXPR_TNUM+87)
 
-#define LAST_EXPR_TNUM          T_ELMX_LIST
+#define LAST_EXPR_TNUM          T_ASSX_LIST
 
 
 /****************************************************************************
@@ -1156,17 +1158,17 @@ extern  void            CodeIsbGVar (
 *F  CodeAssListLevel(<level>) . . . . . . .  code assignment to several lists
 *F  CodeAsssListLevel(<level>)  . . code multiple assignment to several lists
 */
-extern  void            CodeAssList ( void );
+extern  void            CodeAssList ( Int narg );
 
 extern  void            CodeAsssList ( void );
 
-extern  void            CodeAssListLevel (
+extern  void            CodeAssListLevel ( Int narg,
             UInt                level );
 
 extern  void            CodeAsssListLevel (
             UInt                level );
 
-extern  void            CodeUnbList ( void );
+extern  void            CodeUnbList ( Int narg );
 
 
 /****************************************************************************
@@ -1187,7 +1189,7 @@ extern  void            CodeElmListLevel (
 extern  void            CodeElmsListLevel (
             UInt                level );
 
-extern  void            CodeIsbList ( void );
+extern  void            CodeIsbList ( Int narg );
 
 
 /****************************************************************************

--- a/src/code.h
+++ b/src/code.h
@@ -387,7 +387,10 @@ Obj FILENAME_STAT(Stat stat);
 #define T_FLOAT_EXPR_EAGER      (FIRST_EXPR_TNUM+82)
 #define T_FLOAT_EXPR_LAZY       (FIRST_EXPR_TNUM+83)
 
-#define LAST_EXPR_TNUM          T_FLOAT_EXPR_LAZY
+#define T_ELM2_LIST             (FIRST_EXPR_TNUM+84)
+#define T_ELMX_LIST             (FIRST_EXPR_TNUM+85)
+
+#define LAST_EXPR_TNUM          T_ELMX_LIST
 
 
 /****************************************************************************
@@ -1173,12 +1176,13 @@ extern  void            CodeUnbList ( void );
 *F  CodeElmListLevel(<level>) . . . . . . . . code selection of several lists
 *F  CodeElmsListLevel(<level>)  . .  code multiple selection of several lists
 */
-extern  void            CodeElmList ( void );
+extern  void            CodeElmList ( Int narg );
 
 extern  void            CodeElmsList ( void );
 
 extern  void            CodeElmListLevel (
-            UInt                level );
+					  Int narg,
+					  UInt level);
 
 extern  void            CodeElmsListLevel (
             UInt                level );

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -116,10 +116,10 @@ typedef UInt    RNam;
  if ( ! IS_INTOBJ(obj) ) ErrorQuitIntSmall(obj);
 
 #define CHECK_INT_SMALL_POS(obj) \
- if ( ! IS_INTOBJ(obj) || INT_INTOBJ(obj) <= 0 ) ErrorQuitIntSmallPos(obj);
+ if ( ! IS_POS_INTOBJ(obj) ) ErrorQuitIntSmallPos(obj);
 
 #define CHECK_INT_POS(obj) \
- if ( TNUM_OBJ(obj) != T_INTPOS && (! IS_INTOBJ(obj) || INT_INTOBJ(obj) <= 0) ) ErrorQuitIntPos(obj);
+ if ( TNUM_OBJ(obj) != T_INTPOS && ( ! IS_POS_INTOBJ(obj)) ) ErrorQuitIntPos(obj);
 
 #define CHECK_BOOL(obj) \
  if ( obj != True && obj != False ) ErrorQuitBool(obj);
@@ -241,13 +241,13 @@ typedef UInt    RNam;
 
 
 #define C_ELM_LIST(elm,list,p) \
- elm = IS_INTOBJ(p) ? ELM_LIST( list, INT_INTOBJ(p) ) : ELMB_LIST(list, p);
+ elm = IS_POS_INTOBJ(p) ? ELM_LIST( list, INT_INTOBJ(p) ) : ELMB_LIST(list, p);
 
 #define C_ELM_LIST_NLE(elm,list,p) \
- elm = IS_INTOBJ(p) ? ELMW_LIST( list, INT_INTOBJ(p) ) : ELMB_LIST(list, p);
+ elm = IS_POS_INTOBJ(p) ? ELMW_LIST( list, INT_INTOBJ(p) ) : ELMB_LIST(list, p);
 
 #define C_ELM_LIST_FPL(elm,list,p) \
- if ( IS_INTOBJ(p) && IS_PLIST(list) ) { \
+ if ( IS_POS_INTOBJ(p) && IS_PLIST(list) ) { \
   if ( INT_INTOBJ(p) <= LEN_PLIST(list) ) { \
    elm = ELM_PLIST( list, INT_INTOBJ(p) ); \
    if ( elm == 0 ) elm = ELM_LIST( list, INT_INTOBJ(p) ); \
@@ -255,16 +255,16 @@ typedef UInt    RNam;
  } else C_ELM_LIST( elm, list, p )
 
 #define C_ELM_LIST_NLE_FPL(elm,list,p) \
- if ( IS_INTOBJ(p) && IS_PLIST(list) ) { \
+ if ( IS_POS_INTOBJ(p) && IS_PLIST(list) ) { \
   elm = ELM_PLIST( list, INT_INTOBJ(p) ); \
  } else C_ELM_LIST_NLE(elm, list, p)
 
 #define C_ASS_LIST(list,p,rhs) \
-  if (IS_INTOBJ(p)) ASS_LIST( list, INT_INTOBJ(p), rhs ); \
+  if (IS_POS_INTOBJ(p)) ASS_LIST( list, INT_INTOBJ(p), rhs ); \
   else ASSB_LIST(list, p, rhs);
 
 #define C_ASS_LIST_FPL(list,p,rhs) \
- if ( IS_INTOBJ(p) && TNUM_OBJ(list) == T_PLIST ) { \
+ if ( IS_POS_INTOBJ(p) && TNUM_OBJ(list) == T_PLIST ) { \
   if ( LEN_PLIST(list) < INT_INTOBJ(p) ) { \
    GROW_PLIST( list, (UInt)INT_INTOBJ(p) ); \
    SET_LEN_PLIST( list, INT_INTOBJ(p) ); \
@@ -277,7 +277,7 @@ typedef UInt    RNam;
  }
 
 #define C_ASS_LIST_FPL_INTOBJ(list,p,rhs) \
- if ( IS_INTOBJ(p) && TNUM_OBJ(list) == T_PLIST) { \
+ if ( IS_POS_INTOBJ(p) && TNUM_OBJ(list) == T_PLIST) { \
   if ( LEN_PLIST(list) < INT_INTOBJ(p) ) { \
    GROW_PLIST( list, (UInt)INT_INTOBJ(p) ); \
    SET_LEN_PLIST( list, INT_INTOBJ(p) ); \
@@ -289,10 +289,10 @@ typedef UInt    RNam;
  }
 
 #define C_ISB_LIST( list, pos) \
-  ((IS_INTOBJ(pos) ? ISB_LIST(list, INT_INTOBJ(pos)) : ISBB_LIST( list, pos)) ? True : False)
+  ((IS_POS_INTOBJ(pos) ? ISB_LIST(list, INT_INTOBJ(pos)) : ISBB_LIST( list, pos)) ? True : False)
 
 #define C_UNB_LIST( list, pos) \
-   if (IS_INTOBJ(pos)) UNB_LIST(list, INT_INTOBJ(pos)); else UNBB_LIST(list, pos);
+   if (IS_POS_INTOBJ(pos)) UNB_LIST(list, INT_INTOBJ(pos)); else UNBB_LIST(list, pos);
 
 extern  void            AddList (
             Obj                 list,

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -3165,7 +3165,6 @@ void            IntrAssList ( void )
 {
     Obj                 list;           /* list                            */
     Obj                 pos;            /* position                        */
-    Int                 p;              /* position, as a C integer        */
     Obj                 rhs;            /* right hand side                 */
 
     /* ignore or code                                                      */
@@ -3177,16 +3176,18 @@ void            IntrAssList ( void )
     /* get the right hand side                                             */
     rhs = PopObj();
 
-    /* get the position                                          */
+    /* get the position                                                    */
     pos = PopObj();
-    /* get the list (checking is done by 'ASS_LIST' or 'ASSB_LIST')         */
+
+    /* get the list (checking is done by 'ASS_LIST' or 'ASSB_LIST')        */
     list = PopObj();
 
-    if (IS_INTOBJ(pos) && (p = INT_INTOBJ(pos)) > 0) {
-        /* assign to the element of the list                                   */
-        ASS_LIST( list, p, rhs );
-    } else
+    /* assign to the element of the list                                   */
+    if (IS_POS_INTOBJ(pos)) {
+        ASS_LIST( list, INT_INTOBJ(pos), rhs );
+    } else {
         ASSB_LIST(list, pos, rhs);
+    }
 
     /* push the right hand side again                                      */
     PushObj( rhs );
@@ -3253,7 +3254,7 @@ void            IntrAssListLevel (
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0) ) {
+    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_POS_INTOBJ(pos)) ) {
         ErrorQuit(
          "List Assignment: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
@@ -3309,7 +3310,6 @@ void            IntrUnbList ( void )
 {
     Obj                 list;           /* list                            */
     Obj                 pos;            /* position                        */
-    Int                 p;              /* position, as a C integer        */
 
     /* ignore or code                                                      */
     if ( IntrReturning > 0 ) { return; }
@@ -3319,22 +3319,16 @@ void            IntrUnbList ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0) ) {
-        ErrorQuit(
-         "List Assignment: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
-    }
 
-    /* get the list (checking is done by 'UNB_LIST')                       */
+    /* get the list (checking is done by 'UNB_LIST' or 'UNBB_LIST')        */
     list = PopObj();
 
-    if (IS_INTOBJ(pos)) {
-        p = INT_INTOBJ(pos);
-
-        /* unbind the element                                                  */
-        UNB_LIST( list, p );
-    } else
+    /* unbind the element                                                  */
+    if (IS_POS_INTOBJ(pos)) {
+        UNB_LIST( list, INT_INTOBJ(pos) );
+    } else {
         UNBB_LIST(list, pos);
+    }
 
     /* push void                                                           */
     PushVoidObj();
@@ -3424,7 +3418,7 @@ void            IntrElmListLevel (
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 )) {
+    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_POS_INTOBJ(pos) )) {
         ErrorQuit(
             "List Element: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
@@ -3477,7 +3471,6 @@ void            IntrIsbList ( void )
     Obj                 isb;            /* isbound, result                 */
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, right operand         */
-    Int                 p;              /* position, as C integer          */
 
     /* ignore or code                                                      */
     if ( IntrReturning > 0 ) { return; }
@@ -3487,22 +3480,16 @@ void            IntrIsbList ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 )) {
-        ErrorQuit(
-            "List Element: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
-    }
 
-    /* get the list (checking is done by 'ISB_LIST')                       */
+    /* get the list (checking is done by 'ISB_LIST' or 'ISBB_LIST')        */
     list = PopObj();
 
-    if (IS_INTOBJ(pos)) {
-        p = INT_INTOBJ( pos );
-
-        /* get the result                                                      */
-        isb = (ISB_LIST( list, p ) ? True : False);
-    } else
-        isb = (ISBB_LIST( list, pos) ? True : False);
+    /* get the result                                                      */
+    if (IS_POS_INTOBJ(pos)) {
+        isb = ISB_LIST( list, INT_INTOBJ(pos) ) ? True : False;
+    } else {
+        isb = ISBB_LIST( list, pos) ? True : False;
+    }
 
     /* push the result                                                     */
     PushObj( isb );
@@ -3738,7 +3725,7 @@ void            IntrAssPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    if ( ! IS_POS_INTOBJ(pos) ) {
         ErrorQuit(
          "PosObj Assignment: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
@@ -3829,12 +3816,11 @@ void            IntrAssPosObjLevel (
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    if ( ! IS_POS_INTOBJ(pos) ) {
         ErrorQuit(
          "PosObj Assignment: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
     }
-
 
     /* assign the right hand sides to the elements of several lists        */
     ErrorQuit(
@@ -3891,7 +3877,7 @@ void            IntrUnbPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    if ( ! IS_POS_INTOBJ(pos) ) {
         ErrorQuit(
          "PosObj Assignment: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
@@ -3938,7 +3924,7 @@ void            IntrElmPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    if ( ! IS_POS_INTOBJ(pos) ) {
         ErrorQuit(
             "PosObj Element: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
@@ -4020,7 +4006,7 @@ void            IntrElmPosObjLevel (
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    if ( ! IS_POS_INTOBJ(pos) ) {
         ErrorQuit(
             "PosObj Element: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );
@@ -4087,7 +4073,7 @@ void            IntrIsbPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    if ( ! IS_POS_INTOBJ(pos) ) {
         ErrorQuit(
             "PosObj Element: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L );

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -3177,20 +3177,12 @@ void            IntrAssList ( void )
     /* get the right hand side                                             */
     rhs = PopObj();
 
-    /* get and check the position                                          */
+    /* get the position                                          */
     pos = PopObj();
-    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0) ) {
-        ErrorQuit(
-         "List Assignment: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
-    }
-
     /* get the list (checking is done by 'ASS_LIST' or 'ASSB_LIST')         */
     list = PopObj();
 
-    if (IS_INTOBJ(pos)) {
-        p = INT_INTOBJ(pos);
-
+    if (IS_INTOBJ(pos) && (p = INT_INTOBJ(pos)) > 0) {
         /* assign to the element of the list                                   */
         ASS_LIST( list, p, rhs );
     } else

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -3434,6 +3434,8 @@ void            IntrElmListLevel ( Int narg,
 {
     Obj                 lists;          /* lists, left operand             */
     Obj                 pos;            /* position, right operand         */
+    Obj ixs;
+    Int i;
 
     /* ignore or code                                                      */
     if ( IntrReturning > 0 ) { return; }
@@ -3441,20 +3443,29 @@ void            IntrElmListLevel ( Int narg,
     if ( IntrCoding    > 0 ) { CodeElmListLevel( narg, level ); return; }
 
 
-    /* get and check the position                                          */
-    pos = PopObj();
-    if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_POS_INTOBJ(pos) )) {
-        ErrorQuit(
-            "List Element: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
+    /* get the positions */
+    ixs = NEW_PLIST(T_PLIST, narg);
+    for (i = narg; i > 0; i--) {
+      pos = PopObj();
+      SET_ELM_PLIST(ixs,i,pos);
+      CHANGED_BAG(ixs);
     }
+    SET_LEN_PLIST(ixs, narg);
+      
+    /* /\* get and check the position                                          *\/ */
+    /* pos = PopObj(); */
+    /* if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_POS_INTOBJ(pos) )) { */
+    /*     ErrorQuit( */
+    /*         "List Element: <position> must be a positive integer (not a %s)", */
+    /*         (Int)TNAM_OBJ(pos), 0L ); */
+    /* } */
 
     /* get lists (if this works, then <lists> is nested <level> deep,      */
     /* checking it is nested <level>+1 deep is done by 'ElmListLevel')     */
     lists = PopObj();
 
     /* select the elements from several lists (store them in <lists>)      */
-    ElmListLevel( lists, pos, level );
+    ElmListLevel( lists, ixs, level );
 
     /* push the elements                                                   */
     PushObj( lists );

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -753,17 +753,17 @@ extern  void            IntrIsbGVar (
 *F  IntrAssListLevel(<level>) . . . . . interpret assignment to several lists
 *F  IntrAsssListLevel(<level>)  . . intr multiple assignment to several lists
 */
-extern  void            IntrAssList ( void );
+extern  void            IntrAssList ( Int narg );
 
 extern  void            IntrAsssList ( void );
 
-extern  void            IntrAssListLevel (
+extern  void            IntrAssListLevel ( Int narg,
             UInt                level );
 
 extern  void            IntrAsssListLevel (
             UInt                level );
 
-extern  void            IntrUnbList ( void );
+extern  void            IntrUnbList (Int narg );
 
 
 /****************************************************************************
@@ -783,7 +783,7 @@ extern  void            IntrElmListLevel ( Int narg,
 extern  void            IntrElmsListLevel (
             UInt                level );
 
-extern  void            IntrIsbList ( void );
+extern  void            IntrIsbList ( Int narg );
 
 
 /****************************************************************************

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -773,11 +773,11 @@ extern  void            IntrUnbList ( void );
 *F  IntrElmListLevel(<level>) . . . . .  interpret selection of several lists
 *F  IntrElmsListLevel(<level>)  . .  intr multiple selection of several lists
 */
-extern  void            IntrElmList ( void );
+extern  void            IntrElmList ( Int narg);
 
 extern  void            IntrElmsList ( void );
 
-extern  void            IntrElmListLevel (
+extern  void            IntrElmListLevel ( Int narg,
             UInt                level );
 
 extern  void            IntrElmsListLevel (

--- a/src/lists.c
+++ b/src/lists.c
@@ -535,23 +535,6 @@ Obj FuncELM0_LIST (
 */
 Obj (*ElmListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
-/****************************************************************************
-**
-*V  ElmbListFuncs[<type>]  . . . . . . . . . . .  table of selection functions
-**
-**  'ELMB_LIST' returns the element at the position  <pos> in the list <list>.
-**  An  error is signalled if  <list> is not a list,  if <pos> is larger than
-**  the length of <list>, or if <list>  has no assigned  object at <pos>.  It
-**  is the responsibility  of the caller to  ensure that <pos>  is a positive
-**  integer.
-**
-**  'ELMB_LIST' only calls the functions  pointed to by 'ElmbListFuncs[<type>]'
-**  passing <list> and <pos>  as arguments.  If  <type> is not  the type of a
-**  list, then 'ElmbListFuncs[<type>]' points to 'ElmbListError', which signals
-**  the error.
-*/
-Obj (*ElmbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos );
-
 
 /****************************************************************************
 **
@@ -617,67 +600,6 @@ Obj ElmListObject (
     return elm;
 }
 
-#if 0
-/****************************************************************************
-**
-*F  ElmbListError( <list>, <pos> ) . . . . . . . . . . . . . . . error message
-*/
-Obj ElmbListError (
-    Obj                 list,
-    Obj                 pos )
-{
-    list = ErrorReturnObj(
-        "List Element: <list> must be a list (not a %s)",
-        (Int)TNAM_OBJ(list), 0L,
-        "you can replace <list> via 'return <list>;'" );
-    return ELMB_LIST( list, pos );
-}
-
-/****************************************************************************
-**
-*F  ElmbListInternal( <list>, <pos> ) . . . . . . . . . . . . . error message
-*/
-Obj ElmbListInternal (
-    Obj                 list,
-    Obj                 pos )
-{
-  do {
-    pos = ErrorReturnObj(
-        "List Element: an internal list cannot have an element in such a position",
-        0L, 0L,
-        "you can supply a new position <pos> via 'return <pos>;'" );
-  } while (!IS_INTOBJ(pos) || INT_INTOBJ(pos) < 0);
-  return ELM_LIST( list, INT_INTOBJ(pos) );
-}
-
-
-/****************************************************************************
-**
-*F  ElmbListObject( <list>, <pos>  . . . . . . . select an element from a list
-**
-**  `ElmbListObject' is the `ELMB_LIST',  function
-**  for objects.   'ElmbListObjects' selects the  element at position <pos> of
-**  list  object <list>.   It is the  responsibility  of the caller to ensure
-**  that <pos> is a positive integer.  The methods have to signal an error if
-**  <pos> is larger than the length of <list> or if the entry is not bound.
-*/
-
-Obj ElmbListObject (
-    Obj                 list,
-    Obj                 pos )
-{
-    Obj                 elm;
-
-    elm = DoOperation2Args( ElmListOper, list, pos );
-    while ( elm == 0 ) {
-        elm = ErrorReturnObj(
-            "List access method must return a value", 0L, 0L,
-            "you can supply a value <val> via 'return <val>;'" );
-    }
-    return elm;
-}
-
-#endif
 
 Obj ELMB_LIST(Obj list, Obj pos)     {
    Obj                 elm;
@@ -1091,8 +1013,11 @@ Obj             FuncASS_LIST (
     Obj                 pos,
     Obj                 obj )
 {
+  if (IS_INTOBJ(pos)) 
     ASS_LIST( list, INT_INTOBJ(pos), obj );
-    return 0;
+  else
+    ASSB_LIST(list, pos, obj);
+  return 0;
 }
 
 void            AssListError (
@@ -1121,6 +1046,7 @@ void            AssListDefault (
 **
 *F  AssListObject( <list>, <pos>, <obj> ) . . . . . . . assign to list object
 */
+
 Obj AssListOper;
 
 void AssListObject (
@@ -1128,74 +1054,17 @@ void AssListObject (
     Int                 pos,
     Obj                 obj )
 {
-    DoOperation3Args( AssListOper, list, INTOBJ_INT(pos), obj );
-}
-/****************************************************************************
-**
-*F  ASSB_LIST(<list>,<pos>,<obj>)  . . . . . . . . assign an element to a list
-*V  AssbListFuncs[<type>]  . . . . . . . . . . . table of assignment functions
-*F  AssbListError(<list>,<pos>,<obj>)  . . . . . . . error assignment function
-**
-**  'ASSB_LIST' only calls the  function pointed to by 'AssbListFuncs[<type>]',
-**  passing <list>, <pos>, and <obj> as arguments.  If <type> is not the type
-**  of  a list, then 'AssbListFuncs[<type>]'  points to 'AssbListError',  which
-**  just signals an error.
-**
-**  'ASSB_LIST' is defined in the declaration part of this package as follows.
-**
-#define ASSB_LIST(list,pos,obj) \
-                        ((*AssbListFuncs[TNUM_OBJ(list)])(list,pos,obj))
-*/
-void            (*AssbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos, Obj obj );
-
-Obj             FuncASSB_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos,
-    Obj                 obj )
-{
-    ASSB_LIST( list, pos, obj );
-    return 0;
+  DoOperation3Args( AssListOper, list, INTOBJ_INT(pos), obj );
 }
 
-void            AssbListError (
-    Obj                 list,
-    Obj                 pos,
-    Obj                 obj )
-{
-    list = ErrorReturnObj(
-        "List Assignment: <list> must be a list (not a %s)",
-        (Int)TNAM_OBJ(list), 0L,
-        "you can replace <list> via 'return <list>;'" );
-    ASSB_LIST( list, pos, obj );
-}
-
-void            AssbListInternal (
-    Obj                 list,
-    Obj                 pos,
-    Obj                 obj )
-{
-  do {
-    pos = ErrorReturnObj( "List assignment: you cannot assign to such a large position in an internal list",
-                          0, 0, 
-                          "you can supply a new position <pos> via 'return <pos>;'" );
-  } while (!IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0);
-  ASS_LIST(list, INT_INTOBJ(pos), obj);
-}
-
-
-/****************************************************************************
-**
-*F  AssbListObject( <list>, <pos>, <obj> ) . . . . . . . assign to list object
-*/
-
-void AssbListObject (
+void ASSB_LIST (
     Obj                 list,
     Obj                 pos,
     Obj                 obj )
 {
     DoOperation3Args( AssListOper, list, pos, obj );
 }
+
 
 
 /****************************************************************************
@@ -2781,20 +2650,6 @@ static Int InitKernel (
     ElmvListFuncs[ T_SINGULAR ] = ElmListObject;
     ElmwListFuncs[ T_SINGULAR ] = ElmListObject;
 
-    /* make and install the 'ELMB_LIST' operation                           
-    for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        ElmbListFuncs[  type ] = ElmbListError;
-    }
-
-    for (type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
-      ElmbListFuncs[ type ] = ElmbListInternal;
-    }
-    
-    for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
-        ElmbListFuncs[  type ] = ElmbListObject;
-    }
-
-    */
 
     /* make and install the 'ELMS_LIST' operation                          */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
@@ -2848,19 +2703,6 @@ static Int InitKernel (
     AssListFuncs[ T_SINGULAR ] = AssListObject;
 
 
-    /* make and install the 'ASSB_LIST' operation                           */
-    for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        AssbListFuncs[  type ] = AssbListError;
-    }
-
-    for (type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
-      AssbListFuncs[ type ] = AssbListInternal;
-    }
-    
-    for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
-        AssbListFuncs[  type ] = AssbListObject;
-    }
-    AssbListFuncs[ T_SINGULAR ] = AssbListObject;
 
     /* make and install the 'ASSS_LIST' operation                          */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {

--- a/src/lists.c
+++ b/src/lists.c
@@ -1661,13 +1661,17 @@ Obj FuncPOS_LIST_DEFAULT (
 */
 void            ElmListLevel (
     Obj                 lists,
-    Obj                 pos,
+    Obj                 ixs,
     Int                 level )
 {
     Int                 len;            /* length of <lists>               */
     Obj                 list;           /* one list from <lists>           */
     Obj                 elm;            /* selected element from <list>    */
     Int                 i;              /* loop variable                   */
+    Obj pos;
+    Obj pos1;
+    Obj pos2;
+      
 
     /* if <level> is one, perform the replacements                         */
     if ( level == 1 ) {
@@ -1680,10 +1684,25 @@ void            ElmListLevel (
             list = ELM_PLIST( lists, i );
 
             /* select the element                                          */
-            if (IS_INTOBJ(pos))
-              elm = ELM_LIST( list, INT_INTOBJ(pos) );
-            else
-              elm = ELMB_LIST(list, pos);
+	    switch(LEN_PLIST(ixs)) {
+	    case 1:
+	      pos = ELM_PLIST(ixs,1);
+	      if (IS_INTOBJ(pos))
+		elm = ELM_LIST( list, INT_INTOBJ(pos) );
+	      else
+		elm = ELMB_LIST(list, pos);
+	      break;
+	      
+	    case 2:
+	      pos1 = ELM_PLIST(ixs,1);
+	      pos2 = ELM_PLIST(ixs,2);
+	      elm = ELM2_LIST(list, pos1, pos2);
+	      break;
+
+	    default:
+	      elm = ELMB_LIST(list, ixs);
+	      
+	    }
 
             /* replace the list with the element                           */
             SET_ELM_PLIST( lists, i, elm );
@@ -1707,7 +1726,7 @@ void            ElmListLevel (
             list = ELM_PLIST( lists, i );
 
             /* recurse                                                     */
-            ElmListLevel( list, pos, level-1 );
+            ElmListLevel( list, ixs, level-1 );
 
         }
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -99,6 +99,14 @@ Obj Elm2List(Obj list, Obj pos1, Obj pos2) {
   return ELMB_LIST(list, ixs);
 }
 
+void Ass2List(Obj list, Obj pos1, Obj pos2, Obj obj) {
+  Obj ixs = NEW_PLIST(T_PLIST,2);
+  SET_ELM_PLIST(ixs,1,pos1);
+  SET_ELM_PLIST(ixs,2,pos2);
+  SET_LEN_PLIST(ixs,2);
+  ASSB_LIST(list, ixs, obj);
+}
+
 /****************************************************************************
 **
 *F  IS_SMALL_LIST(<obj>)  . . . . . . . . . . . . . . . . . . . is an object a list
@@ -1819,7 +1827,7 @@ void            ElmsListLevel (
 */
 void            AssListLevel (
     Obj                 lists,
-    Obj                 pos,
+    Obj                 ixs,
     Obj                 objs,
     Int                 level )
 {
@@ -1827,6 +1835,7 @@ void            AssListLevel (
     Obj                 list;           /* one list of <lists>             */
     Obj                 obj;            /* one value from <objs>           */
     Int                 i;              /* loop variable                   */
+    Obj pos,pos1,pos2;
 
     /* check <objs>                                                        */
     while ( ! IS_DENSE_LIST(objs) || LEN_LIST(lists) != LEN_LIST(objs) ) {
@@ -1857,11 +1866,25 @@ void            AssListLevel (
             /* select the element to assign                                */
             obj = ELMW_LIST( objs, i );
 
-            /* assign the element                                          */
-            if (IS_INTOBJ(pos))
-              ASS_LIST( list, INT_INTOBJ(pos), obj );
-            else
-              ASSB_LIST(list, pos, obj);
+	    switch(LEN_PLIST(ixs)) {
+	    case 1:
+	      /* assign the element                                          */
+	      pos = ELM_PLIST(ixs,1);
+	      if (IS_INTOBJ(pos))
+		ASS_LIST( list, INT_INTOBJ(pos), obj );
+	      else
+		ASSB_LIST(list, pos, obj);
+	      break;
+	      
+	    case 2:
+	      pos1 = ELM_PLIST(ixs,1);
+	      pos2 = ELM_PLIST(ixs,2);
+	      ASS2_LIST(list, pos1, pos2, obj);
+	      break;
+
+	    default:
+	      ASSB_LIST(list, ixs, obj);
+	    }
 
         }
 
@@ -1881,7 +1904,7 @@ void            AssListLevel (
             obj = ELMW_LIST( objs, i );
 
             /* recurse                                                     */
-            AssListLevel( list, pos, obj, level-1 );
+            AssListLevel( list, ixs, obj, level-1 );
 
         }
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -90,6 +90,15 @@ Int             IsListObject (
     return (DoFilter( IsListFilt, obj ) == True);
 }
 
+
+Obj Elm2List(Obj list, Obj pos1, Obj pos2) {
+  Obj ixs = NEW_PLIST(T_PLIST,2);
+  SET_ELM_PLIST(ixs,1,pos1);
+  SET_ELM_PLIST(ixs,2,pos2);
+  SET_LEN_PLIST(ixs,2);
+  return ELMB_LIST(list, ixs);
+}
+
 /****************************************************************************
 **
 *F  IS_SMALL_LIST(<obj>)  . . . . . . . . . . . . . . . . . . . is an object a list

--- a/src/lists.c
+++ b/src/lists.c
@@ -48,6 +48,7 @@
 #include        "integer.h"             /* integers                        */
 
 
+
 /****************************************************************************
 **
 *F  IS_LIST(<obj>)  . . . . . . . . . . . . . . . . . . . is an object a list
@@ -332,12 +333,15 @@ Int             (*IsbvListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
 Obj             IsbListOper;
 
-Obj             IsbListHandler (
+Obj             FuncISB_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 pos )
 {
-    return (ISB_LIST( list, INT_INTOBJ(pos) ) ? True : False);
+    if (IS_POS_INTOBJ(pos))
+        return ISB_LIST( list, INT_INTOBJ(pos) ) ? True : False;
+    else
+        return ISBB_LIST( list, pos ) ? True : False;
 }
 
 Int             IsbListError (
@@ -355,64 +359,14 @@ Int             IsbListObject (
     Obj                 list,
     Int                 pos )
 {
-    return (DoOperation2Args( IsbListOper, list, INTOBJ_INT(pos) ) == True);
+    return DoOperation2Args( IsbListOper, list, INTOBJ_INT(pos) ) == True;
 }
 
-/****************************************************************************
-**
-*F  ISBB_LIST(<list>,<pos>,<obj>)  . . . . . isbound for an element to a list
-*V  IsbbListFuncs[<type>]  . . . . . . . . .  . table of isbound functions
-*F  IsbbListError(<list>,<pos>,<obj>)  . . . . . . . error isbound function
-**
-**  'ISBB_LIST' only calls the  function pointed to by 'IsbbListFuncs[<type>]',
-**  passing <list>, <pos>, and <obj> as arguments.  If <type> is not the type
-**  of  a list, then 'IsbbListFuncs[<type>]'  points to 'IsbbListError',  which
-**  just signals an error.
-**
-**  'ISBB_LIST' is defined in the declaration part of this package as follows.
-**
-#define ISBB_LIST(list,pos,obj) \
-                        ((*IsbbListFuncs[TNUM_OBJ(list)])(list,pos,obj))
-*/
-Int            (*IsbbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos);
-
-Obj             FuncISBB_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos)
-{
-    return ISBB_LIST( list, pos ) ? True: False;
-}
-
-Int            IsbbListError (
+Int             ISBB_LIST (
     Obj                 list,
     Obj                 pos )
 {
-    list = ErrorReturnObj(
-        "Isbound: <list> must be a list (not a %s)",
-        (Int)TNAM_OBJ(list), 0L,
-        "you can replace <list> via 'return <list>;'" );
-    return ISBB_LIST( list, pos );
-}
-
-Int            IsbbListInternal (
-    Obj                 list,
-    Obj                 pos)
-{
-  return 0;
-}
-
-
-/****************************************************************************
-**
-*F  IsbbListObject( <list>, <pos>, <obj> ) . . . . . . . assign to list object
-*/
-
-Int IsbbListObject (
-    Obj                 list,
-    Obj                 pos )
-{
-    return DoOperation2Args( IsbListOper, list, pos ) == True ? 1 : 0;
+    return DoOperation2Args( IsbListOper, list, pos ) == True;
 }
 
 
@@ -900,7 +854,10 @@ Obj             FuncUNB_LIST (
     Obj                 list,
     Obj                 pos )
 {
-    UNB_LIST( list, INT_INTOBJ(pos) );
+    if (IS_POS_INTOBJ(pos))
+        UNB_LIST( list, INT_INTOBJ(pos) );
+    else
+        UNBB_LIST( list, pos );
     return 0;
 }
 
@@ -930,59 +887,7 @@ void            UnbListObject (
     DoOperation2Args( UnbListOper, list, INTOBJ_INT(pos) );
 }
 
-/****************************************************************************
-**
-*F  UNBB_LIST(<list>,<pos>,<obj>)  . . . . . . . . unbind an element to a list
-*V  UnbbListFuncs[<type>]  . . . . . . . . . . .  table of unbinding functions
-*F  UnbbListError(<list>,<pos>,<obj>)  . . . . . . . .error unbinding function
-**
-**  'UNBB_LIST' only calls the  function pointed to by 'UnbbListFuncs[<type>]',
-**  passing <list>, <pos>, and <obj> as arguments.  If <type> is not the type
-**  of  a list, then 'UnbbListFuncs[<type>]'  points to 'UnbbListError',  which
-**  just signals an error.
-**
-**  'UNBB_LIST' is defined in the declaration part of this package as follows.
-**
-#define UNBB_LIST(list,pos,obj) \
-                        ((*UnbbListFuncs[TNUM_OBJ(list)])(list,pos,obj))
-*/
-void            (*UnbbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos );
-
-Obj             FuncUNBB_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos )
-{
-    UNBB_LIST( list, pos );
-    return 0;
-}
-
-void            UnbbListError (
-    Obj                 list,
-    Obj                 pos )
-{
-    list = ErrorReturnObj(
-        "List Unbindment: <list> must be a list (not a %s)",
-        (Int)TNAM_OBJ(list), 0L,
-        "you can replace <list> via 'return <list>;'" );
-    UNBB_LIST( list, pos );
-}
-
-void            UnbbListInternal (
-    Obj                 list,
-    Obj                 pos)
-{
-  /* large positions are already unbound */
-  return;
-}
-
-
-/****************************************************************************
-**
-*F  UnbbListObject( <list>, <pos>, <obj> ) . . . . . . . unbind  list object
-*/
-
-void UnbbListObject (
+void            UNBB_LIST (
     Obj                 list,
     Obj                 pos )
 {
@@ -1007,17 +912,19 @@ void UnbbListObject (
 */
 void            (*AssListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos, Obj obj );
 
+Obj AssListOper;
+
 Obj             FuncASS_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 pos,
     Obj                 obj )
 {
-  if (IS_INTOBJ(pos)) 
-    ASS_LIST( list, INT_INTOBJ(pos), obj );
-  else
-    ASSB_LIST(list, pos, obj);
-  return 0;
+    if (IS_INTOBJ(pos)) 
+        ASS_LIST( list, INT_INTOBJ(pos), obj );
+    else
+        ASSB_LIST(list, pos, obj);
+    return 0;
 }
 
 void            AssListError (
@@ -1047,14 +954,12 @@ void            AssListDefault (
 *F  AssListObject( <list>, <pos>, <obj> ) . . . . . . . assign to list object
 */
 
-Obj AssListOper;
-
 void AssListObject (
     Obj                 list,
     Int                 pos,
     Obj                 obj )
 {
-  DoOperation3Args( AssListOper, list, INTOBJ_INT(pos), obj );
+    DoOperation3Args( AssListOper, list, INTOBJ_INT(pos), obj );
 }
 
 void ASSB_LIST (
@@ -2461,7 +2366,7 @@ static StructGVarOper GVarOpers [] = {
       DoOperation0Args, "src/lists.c:POS_LIST" },
 
     { "ISB_LIST", 2, "list, pos", &IsbListOper,
-      IsbListHandler, "src/lists.c:ISB_LIST" },
+      FuncISB_LIST, "src/lists.c:ISB_LIST" },
 
     { "ELM0_LIST", 2, "list, pos", &Elm0ListOper,
       FuncELM0_LIST, "src/lists.c:ELM0_LIST" },
@@ -2608,19 +2513,6 @@ static Int InitKernel (
     IsbListFuncs[ T_SINGULAR ] = IsbListObject;
     IsbvListFuncs[ T_SINGULAR ] = IsbListObject;
 
-    /* make and install the 'ISBB_LIST' operation                           */
-    for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        IsbbListFuncs[  type ] = IsbbListError;
-    }
-
-    for (type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
-      IsbbListFuncs[ type ] = IsbbListInternal;
-    }
-    
-    for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
-        IsbbListFuncs[  type ] = IsbbListObject;
-    }
-    IsbbListFuncs[ T_SINGULAR ] = IsbbListObject;
 
     /* make and install the 'ELM0_LIST' operation                          */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
@@ -2676,19 +2568,6 @@ static Int InitKernel (
     }
     UnbListFuncs[ T_SINGULAR ] = UnbListObject;
 
-    /* make and install the 'UNBB_LIST' operation                           */
-    for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        UnbbListFuncs[  type ] = UnbbListError;
-    }
-
-    for (type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
-      UnbbListFuncs[ type ] = UnbbListInternal;
-    }
-    
-    for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
-        UnbbListFuncs[  type ] = UnbbListObject;
-    }
-    UnbbListFuncs[ T_SINGULAR ] = UnbbListObject;
 
     /* make and install the 'ASS_LIST' operation                           */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {

--- a/src/lists.c
+++ b/src/lists.c
@@ -1819,7 +1819,7 @@ void            ElmsListLevel (
 
 /****************************************************************************
 **
-*F  AssListLevel(<lists>,<pos>,<objs>,<level>)  . . . . . . . . . . . . . . .
+*F  AssListLevel(<lists>,<ixs>,<objs>,<level>)  . . . . . . . . . . . . . . .
 *F  . . . . . . . . . . . . .  assign an element to several lists in parallel
 **
 **  'AssListLevel'  either assigns an  element  to all  lists in parallel  if

--- a/src/lists.h
+++ b/src/lists.h
@@ -246,6 +246,9 @@ extern Obj Elm2List(Obj list, Obj pos1, Obj pos2);
 
 #define ELM2_LIST(list, pos1, pos2) Elm2List(list, pos1, pos2)
 
+extern void Ass2List(Obj list, Obj pos1, Obj pos2, Obj obj);
+
+#define ASS2_LIST(list, pos1, pos2, obj) Ass2List(list, pos1, pos2, obj)
 
 
 /****************************************************************************

--- a/src/lists.h
+++ b/src/lists.h
@@ -237,6 +237,16 @@ extern Obj (*ElmListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
 extern Obj ELMB_LIST( Obj list, Obj pos );
 
+/****************************************************************************
+**
+*F  ELM2_LIST( <list>, <pos1>, <pos2> ) . . . . select an element from a list
+*/
+
+extern Obj Elm2List(Obj list, Obj pos1, Obj pos2);
+
+#define ELM2_LIST(list, pos1, pos2) Elm2List(list, pos1, pos2)
+
+
 
 /****************************************************************************
 **

--- a/src/lists.h
+++ b/src/lists.h
@@ -232,24 +232,12 @@ extern Obj (*ElmListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 **  call them with arguments that have side effects.
 **
 **  The difference between ELM_LIST and ELMB_LIST is that ELMB_LIST accepts
-**  an object as the second argument (which should be a positive large integer.
+**  an object as the second argument
 **  It is intended as an interface for access to elements of large external
 **  lists, on the rare occasions when the kernel needs to do this.
 */
 #define ELM_LIST(list,pos)      ((*ElmListFuncs[TNUM_OBJ(list)])(list,pos))
 
-/****************************************************************************
-**
-*V  ElmbListFuncs[ <type> ]  . . . . . . . . . .  table of selection functions
-**
-**  A package implementing a  list  type <type> may  provide a  function for
-**  'ELMB_LIST' and install it  in 'ElmbListFuncs[<type>]'.  This function must
-**  signal an error if <pos> is larger than the length of <list> or if <list>
-**  has no assigned object at <pos>.
-
-extern Obj (*ElmbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos );
-
-*/
 
 /****************************************************************************
 **
@@ -265,7 +253,7 @@ extern Obj (*ElmbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos );
 **  call them with arguments that have side effects.
 **
 **  The difference between ELM_LIST and ELMB_LIST is that ELMB_LIST accepts
-**  an object as the second argument (which should be a positive large integer.
+**  an object as the second argument
 **  It is intended as an interface for access to elements of large external
 **  lists, on the rare occasions when the kernel needs to do this.
 */
@@ -465,10 +453,8 @@ extern  void            (*AssListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos, O
 **  <list> if <pos> is larger than the length of  <list> and must also change
 **  the representation of <list> to that of a plain list if necessary.
 */
-#define ASSB_LIST(list,pos,obj) \
-                        ((*AssbListFuncs[TNUM_OBJ(list)])(list,pos,obj))
 
-extern  void            (*AssbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos, Obj obj );
+extern void ASSB_LIST(Obj list, Obj pos, Obj obj);
 
 
 /****************************************************************************

--- a/src/lists.h
+++ b/src/lists.h
@@ -140,11 +140,7 @@ extern  Int             (*IsbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
 extern  Int             (*IsbvListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
-#define ISBB_LIST(list,pos) \
-                        ((*IsbbListFuncs[TNUM_OBJ(list)])(list,pos))
-
-extern  Int             (*IsbbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos );
-
+extern Int ISBB_LIST( Obj list, Obj pos );
 
 
 /****************************************************************************
@@ -221,6 +217,7 @@ extern Obj (*ElmListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 /****************************************************************************
 **
 *F  ELM_LIST( <list>, <pos> ) . . . . . . . . . select an element from a list
+*F  ELMB_LIST( <list>, <pos> ) . . . . . . . . . select an element from a list
 **
 **  'ELM_LIST' returns the element at the position  <pos> in the list <list>.
 **  An  error is signalled if  <list> is not a list,  if <pos> is larger than
@@ -238,29 +235,7 @@ extern Obj (*ElmListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 */
 #define ELM_LIST(list,pos)      ((*ElmListFuncs[TNUM_OBJ(list)])(list,pos))
 
-
-/****************************************************************************
-**
-*F  ELMB_LIST( <list>, <pos> ) . . . . . . . . . select an element from a list
-**
-**  'ELM_LIST' returns the element at the position  <pos> in the list <list>.
-**  An  error is signalled if  <list> is not a list,  if <pos> is larger than
-**  the length of <list>, or if <list>  has no assigned  object at <pos>.  It
-**  is the responsibility  of the caller to  ensure that <pos>  is a positive
-**  integer.
-**
-**  Note that 'ELM_LIST', 'ELMV_LIST', and  'ELMW_LIST' are macros, so do not
-**  call them with arguments that have side effects.
-**
-**  The difference between ELM_LIST and ELMB_LIST is that ELMB_LIST accepts
-**  an object as the second argument
-**  It is intended as an interface for access to elements of large external
-**  lists, on the rare occasions when the kernel needs to do this.
-*/
-extern Obj ELMB_LIST( Obj list, Obj pos);
-
-
-
+extern Obj ELMB_LIST( Obj list, Obj pos );
 
 
 /****************************************************************************
@@ -403,12 +378,10 @@ extern void ElmsListLevelCheck (
 
 extern void             (*UnbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
-#define UNBB_LIST(list,pos) \
-                        ((*UnbbListFuncs[TNUM_OBJ(list)])(list,pos))
+extern void UNBB_LIST( Obj list, Obj pos );
 
-extern void             (*UnbbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj pos );
+extern void UnbListDefault( Obj list, Int  pos );
 
-extern void  UnbListDefault ( Obj list, Int  pos );
 
 /****************************************************************************
 **
@@ -434,27 +407,7 @@ extern void  UnbListDefault ( Obj list, Int  pos );
 
 extern  void            (*AssListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos, Obj obj );
 
-/****************************************************************************
-**
-*F  ASSB_LIST(<list>,<pos>,<obj>)  . . . . . . . . assign an element to a list
-*V  AssbListFuncs[<type>]  . . . . . . . . . . . table of assignment functions
-**
-**  'ASSB_LIST' assigns the object <obj> to the list <list> at position <pos>.
-**  Note that  the assignment may change  the length or the representation of
-**  <list>.  An error   is signalled if  <list>  is not a  list.    It is the
-**  responsibility of the caller to ensure that <pos>  is a positive integer,
-**  and that <obj> is not 0.
-**
-**  Note that 'ASSB_LIST' is a macro,  so do not  call it with arguments  that
-**  have side effects.
-**
-**  A package  implementing a list type  <type> must provide  such a function
-**  and   install it in  'AssbListFuncs[<type>]'.   This  function must extend
-**  <list> if <pos> is larger than the length of  <list> and must also change
-**  the representation of <list> to that of a plain list if necessary.
-*/
-
-extern void ASSB_LIST(Obj list, Obj pos, Obj obj);
+extern void ASSB_LIST( Obj list, Obj pos, Obj obj );
 
 
 /****************************************************************************

--- a/src/read.c
+++ b/src/read.c
@@ -563,8 +563,8 @@ void ReadCallVarAss (
         else if ( type == 'h' ) { IntrAssHVar( var );             }
         else if ( type == 'd' ) { IntrAssDVar( var, nest0 - 1 );  }
         else if ( type == 'g' ) { IntrAssGVar( var );             }
-        else if ( type == '[' ) { IntrAssList();                  }
-        else if ( type == ']' ) { IntrAssListLevel( level );      }
+        else if ( type == '[' ) { IntrAssList( narg );                  }
+        else if ( type == ']' ) { IntrAssListLevel( narg, level );      }
         else if ( type == '{' ) { IntrAsssList();                 }
         else if ( type == '}' ) { IntrAsssListLevel( level );     }
         else if ( type == '<' ) { IntrAssPosObj();                }
@@ -589,7 +589,7 @@ void ReadCallVarAss (
         else if ( type == 'h' ) { IntrUnbHVar( var );             }
         else if ( type == 'd' ) { IntrUnbDVar( var, nest0 - 1 );  }
         else if ( type == 'g' ) { IntrUnbGVar( var );             }
-        else if ( type == '[' ) { IntrUnbList();                  }
+        else if ( type == '[' ) { IntrUnbList( narg );            }
         else if ( type == '<' ) { IntrUnbPosObj();                }
         else if ( type == '.' ) { IntrUnbRecName( rnam );         }
         else if ( type == ':' ) { IntrUnbRecExpr();               }
@@ -606,7 +606,7 @@ void ReadCallVarAss (
         else if ( type == 'h' ) { IntrIsbHVar( var );             }
         else if ( type == 'd' ) { IntrIsbDVar( var, nest0 - 1 );  }
         else if ( type == 'g' ) { IntrIsbGVar( var );             }
-        else if ( type == '[' ) { IntrIsbList();                  }
+        else if ( type == '[' ) { IntrIsbList( narg );            }
         else if ( type == '<' ) { IntrIsbPosObj();                }
         else if ( type == '.' ) { IntrIsbRecName( rnam );         }
         else if ( type == ':' ) { IntrIsbRecExpr();               }

--- a/src/read.c
+++ b/src/read.c
@@ -180,7 +180,7 @@ UInt GlobalComesFromEnclosingForLoop (UInt var)
 **  <Ident> :=  a|b|..|z|A|B|..|Z { a|b|..|z|A|B|..|Z|0|..|9|_ }
 **
 **  <Var> := <Ident>
-**        |  <Var> '[' <Expr> ]'
+**        |  <Var> '[' <Expr> [,<Expr>]* ']'
 **        |  <Var> '{' <Expr> '}'
 **        |  <Var> '.' <Ident>
 **        |  <Var> '(' [ <Expr> { ',' <Expr> } ] [':' [ <options> ]] ')'
@@ -397,8 +397,8 @@ void ReadCallVarAss (
         else if ( type == 'h' ) { IntrRefHVar( var );           level=0; }
         else if ( type == 'd' ) { IntrRefDVar( var, nest0 - 1 );           level=0; }
         else if ( type == 'g' ) { IntrRefGVar( var );           level=0; }
-        else if ( type == '[' ) { IntrElmList();                         }
-        else if ( type == ']' ) { IntrElmListLevel( level );             }
+        else if ( type == '[' ) { IntrElmList(narg);                    }
+        else if ( type == ']' ) { IntrElmListLevel( level, narg );       }
         else if ( type == '{' ) { IntrElmsList();               level++; }
         else if ( type == '}' ) { IntrElmsListLevel( level );   level++; }
         else if ( type == '<' ) { IntrElmPosObj();                       }
@@ -414,8 +414,15 @@ void ReadCallVarAss (
 
         /* <Var> '[' <Expr> ']'  list selector                             */
         if ( Symbol == S_LBRACK ) {
+	    
             Match( S_LBRACK, "[", follow );
-            ReadExpr( S_RBRACK|follow, 'r' );
+	    ReadExpr( S_COMMA|S_RBRACK|follow, 'r' );
+	    narg = 1;
+	    while (Symbol == S_COMMA) {
+	      Match(S_COMMA,",", follow|S_RBRACK);
+	      ReadExpr(S_COMMA|S_RBRACK|follow, 'r' );
+	      narg++;
+	    }
             Match( S_RBRACK, "]", follow );
             type = (level == 0 ? '[' : ']');
         }
@@ -519,8 +526,8 @@ void ReadCallVarAss (
         else if ( type == 'h' ) { IntrRefHVar( var );           }
         else if ( type == 'd' ) { IntrRefDVar( var, nest0 - 1 );           }
         else if ( type == 'g' ) { IntrRefGVar( var );           }
-        else if ( type == '[' ) { IntrElmList();                }
-        else if ( type == ']' ) { IntrElmListLevel( level );    }
+        else if ( type == '[' ) { IntrElmList(narg);                }
+        else if ( type == ']' ) { IntrElmListLevel( narg, level );    }
         else if ( type == '{' ) { IntrElmsList();               }
         else if ( type == '}' ) { IntrElmsListLevel( level );   }
         else if ( type == '<' ) { IntrElmPosObj();                }

--- a/src/read.c
+++ b/src/read.c
@@ -398,7 +398,7 @@ void ReadCallVarAss (
         else if ( type == 'd' ) { IntrRefDVar( var, nest0 - 1 );           level=0; }
         else if ( type == 'g' ) { IntrRefGVar( var );           level=0; }
         else if ( type == '[' ) { IntrElmList(narg);                    }
-        else if ( type == ']' ) { IntrElmListLevel( level, narg );       }
+        else if ( type == ']' ) { IntrElmListLevel( narg, level );       }
         else if ( type == '{' ) { IntrElmsList();               level++; }
         else if ( type == '}' ) { IntrElmsListLevel( level );   level++; }
         else if ( type == '<' ) { IntrElmPosObj();                       }

--- a/src/vars.c
+++ b/src/vars.c
@@ -1548,6 +1548,7 @@ Obj             EvalElmListLevel (
     return lists;
 }
 
+
 /****************************************************************************
 **
 *F  EvalElmsListLevel(<expr>) . . .  select several elements of several lists
@@ -1713,6 +1714,22 @@ void PrintElmXList (
 {
   Int i;
   Int narg = SIZE_EXPR(expr)/sizeof(Expr) -1 ;
+    Pr("%2>",0L,0L);
+    PrintExpr( ADDR_EXPR(expr)[0] );
+    Pr("%<[",0L,0L);
+    PrintExpr( ADDR_EXPR(expr)[1] );
+    for (i = 2; i <= narg; i++) {
+      Pr("%<, %<",0L,0L);
+      PrintExpr( ADDR_EXPR(expr)[2] );
+    }
+    Pr("%<]",0L,0L);
+}
+
+void PrintElmListLevel (
+		     Expr expr )
+{
+  Int i;
+  Int narg = SIZE_EXPR(expr)/sizeof(Expr) -2 ;
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(expr)[0] );
     Pr("%<[",0L,0L);
@@ -3056,7 +3073,7 @@ static Int InitKernel (
     InstallPrintStatFunc( T_UNB_LIST       , PrintUnbList);
     InstallPrintExprFunc( T_ELM_LIST       , PrintElmList);
     InstallPrintExprFunc( T_ELMS_LIST      , PrintElmsList);
-    InstallPrintExprFunc( T_ELM_LIST_LEV   , PrintElmList);
+    InstallPrintExprFunc( T_ELM_LIST_LEV   , PrintElmListLevel);
     InstallPrintExprFunc( T_ELMS_LIST_LEV  , PrintElmsList);
     InstallPrintExprFunc( T_ISB_LIST       , PrintIsbList);
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -1138,21 +1138,15 @@ UInt            ExecAssList (
     SET_BRK_CURR_STAT( stat );
     list = EVAL_EXPR( ADDR_STAT(stat)[0] );
 
-    /* evaluate and check the position                                     */
+    /* evaluate  the position                                     */
     pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
-    while ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 )) {
-        pos = ErrorReturnObj(
-         "List Assignment: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L,
-            "you can replace <position> via 'return <position>;'" );
-    }
 
     /* evaluate the right hand side                                        */
     rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
 
-    if (IS_INTOBJ(pos))
+    if (IS_INTOBJ(pos) && (p = INT_INTOBJ(pos)) > 0)
         {
-          p = INT_INTOBJ(pos);
+
           
           /* special case for plain list                                         */
           if ( TNUM_OBJ(list) == T_PLIST ) {

--- a/src/vars.c
+++ b/src/vars.c
@@ -1403,6 +1403,72 @@ Obj             EvalElmList (
     return elm;
 }
 
+/****************************************************************************
+**
+*F  EvalElm2List(<expr>) . . . . . . . . . . . . select an element of a list
+**
+**  'EvalElm2List' evaluates the list  element expression  <expr> of the  form
+**  '<list>[<pos1>,<pos2>]'.
+*/
+Obj             EvalElm2List (
+    Expr                expr )
+{
+    Obj                 elm;            /* element, result                 */
+    Obj                 list;           /* list, left operand              */
+    Obj                 pos1;            /* position, right operand         */
+    Obj                 pos2;            /* position, right operand         */
+
+    /* evaluate the list (checking is done by 'ELM2_LIST')                  */
+    list = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+
+    /* evaluate and check the positions                                     */
+    pos1 = EVAL_EXPR( ADDR_EXPR(expr)[1] ); 
+    pos2 = EVAL_EXPR( ADDR_EXPR(expr)[2] ); 
+   
+    elm = ELM2_LIST(list, pos1, pos2);
+
+
+    /* return the element                                                  */
+    return elm;
+}
+
+/****************************************************************************
+**
+*F  EvalElm2List(<expr>) . . . . . . . . . . . . select an element of a list
+**
+**  'EvalElm2List' evaluates the list  element expression  <expr> of the  form
+**  '<list>[<pos1>,<pos2>,<pos3>,....]'.
+*/
+Obj             EvalElmXList (
+    Expr                expr )
+{
+    Obj                 elm;            /* element, result                 */
+    Obj                 list;           /* list, left operand              */
+    Obj                 pos;            /* position, right operand         */
+    Obj ixs;
+    Int narg;
+    Int i;
+     
+
+    /* evaluate the list (checking is done by 'ELM2_LIST')                  */
+    list = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+
+    /* evaluate and check the positions                                     */
+    narg = SIZE_EXPR(expr)/sizeof(Expr) -1;
+    ixs = NEW_PLIST(T_PLIST,narg);
+    for (i = 1; i <= narg; i++) {
+      pos = EVAL_EXPR( ADDR_EXPR(expr)[i] );
+      SET_ELM_PLIST(ixs,i,pos);
+      CHANGED_BAG(ixs);
+    }
+    SET_LEN_PLIST(ixs,narg);
+   
+    elm = ELMB_LIST(list,ixs);
+
+    /* return the element                                                  */
+    return elm;
+}
+
 
 /****************************************************************************
 **
@@ -2948,6 +3014,9 @@ static Int InitKernel (
     InstallEvalExprFunc( T_ELM_LIST_LEV   , EvalElmListLevel);
     InstallEvalExprFunc( T_ELMS_LIST_LEV  , EvalElmsListLevel);
     InstallEvalExprFunc( T_ISB_LIST       , EvalIsbList);
+    InstallEvalExprFunc( T_ELM2_LIST      , EvalElm2List);
+    InstallEvalExprFunc( T_ELMX_LIST      , EvalElmXList);
+    
     InstallPrintStatFunc( T_ASS_LIST       , PrintAssList);
     InstallPrintStatFunc( T_ASSS_LIST      , PrintAsssList);
     InstallPrintStatFunc( T_ASS_LIST_LEV   , PrintAssList);
@@ -2958,6 +3027,7 @@ static Int InitKernel (
     InstallPrintExprFunc( T_ELM_LIST_LEV   , PrintElmList);
     InstallPrintExprFunc( T_ELMS_LIST_LEV  , PrintElmsList);
     InstallPrintExprFunc( T_ISB_LIST       , PrintIsbList);
+
 
     /* install executors, evaluators, and printers for record elements     */
     InstallExecStatFunc( T_ASS_REC_NAME   , ExecAssRecName);

--- a/src/vars.c
+++ b/src/vars.c
@@ -1138,35 +1138,32 @@ UInt            ExecAssList (
     SET_BRK_CURR_STAT( stat );
     list = EVAL_EXPR( ADDR_STAT(stat)[0] );
 
-    /* evaluate  the position                                     */
+    /* evaluate the position                                               */
     pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
 
     /* evaluate the right hand side                                        */
     rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
 
-    if (IS_INTOBJ(pos) && (p = INT_INTOBJ(pos)) > 0)
-        {
+    if (IS_POS_INTOBJ(pos)) {
+        p = INT_INTOBJ(pos);
 
-          
-          /* special case for plain list                                         */
-          if ( TNUM_OBJ(list) == T_PLIST ) {
+        /* special case for plain list                                     */
+        if ( TNUM_OBJ(list) == T_PLIST ) {
             if ( LEN_PLIST(list) < p ) {
-              GROW_PLIST( list, p );
-              SET_LEN_PLIST( list, p );
+                GROW_PLIST( list, p );
+                SET_LEN_PLIST( list, p );
             }
             SET_ELM_PLIST( list, p, rhs );
             CHANGED_BAG( list );
-          }
-          
-          /* generic case                                                        */
-          else
-            {
-              ASS_LIST( list, p, rhs );
-            }
         }
-    else
-      ASSB_LIST(list, pos, rhs);
-          
+
+        /* generic case                                                    */
+        else {
+            ASS_LIST( list, p, rhs );
+        }
+    } else {
+        ASSB_LIST(list, pos, rhs);
+    }
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -1255,7 +1252,7 @@ UInt            ExecAssListLevel (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
-    while ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0) ) {
+    while ( TNUM_OBJ(pos) != T_INTPOS && (! IS_POS_INTOBJ(pos)) ) {
         pos = ErrorReturnObj(
          "List Assignment: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L,
@@ -1338,24 +1335,20 @@ UInt            ExecUnbList (
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, left operand          */
-    Int                 p;              /* position, as a C integer        */
 
     /* evaluate the list (checking is done by 'LEN_LIST')                  */
     SET_BRK_CURR_STAT( stat );
     list = EVAL_EXPR( ADDR_STAT(stat)[0] );
 
-    /* evaluate and check the position                                     */
+    /* evaluate the position                                               */
     pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
-    while ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
-        pos = ErrorReturnObj(
-         "List Assignment: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L,
-            "you can replace <position> via 'return <position>;'" );
-    }
-    p = INT_INTOBJ(pos);
 
     /* unbind the element                                                  */
-    UNB_LIST( list, p );
+    if (IS_POS_INTOBJ(pos)) {
+        UNB_LIST( list, INT_INTOBJ(pos) );
+    } else {
+        UNBB_LIST( list, pos );
+    }
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -1382,31 +1375,30 @@ Obj             EvalElmList (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR( ADDR_EXPR(expr)[1] );
-    
+
     SET_BRK_CALL_TO(expr);     /* Note possible call for FuncWhere */
 
-    if (IS_INTOBJ(pos) && (p = INT_INTOBJ( pos )) > 0)
-      {
-        
-        /* special case for plain lists (use generic code to signal errors)    */
-        if ( IS_PLIST( list ) )
-          {
+    if (IS_POS_INTOBJ(pos)) {
+        p = INT_INTOBJ( pos );
+
+        /* special case for plain lists (use generic code to signal errors) */
+        if ( IS_PLIST( list ) ) {
             if ( LEN_PLIST(list) < p ) {
-              return ELM_LIST( list, p );
+                return ELM_LIST( list, p );
             }
             elm = ELM_PLIST( list, p );
             if ( elm == 0 ) {
-              return ELM_LIST( list, p );
+                return ELM_LIST( list, p );
             }
-          }
-        /* generic case                                                        */
-        else
-          {
+        }
+        /* generic case                                                    */
+        else {
             elm = ELM_LIST( list, p );
-          }
-      }
-    else
-      elm = ELMB_LIST(list, pos);
+        }
+    } else {
+        elm = ELMB_LIST(list, pos);
+    }
+
     /* return the element                                                  */
     return elm;
 }
@@ -1472,7 +1464,7 @@ Obj             EvalElmListLevel (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR( ADDR_EXPR(expr)[1] );
-    while ( TNUM_OBJ(pos) != T_INTPOS && (! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 )) {
+    while ( TNUM_OBJ(pos) != T_INTPOS && (! IS_POS_INTOBJ(pos) )) {
         pos = ErrorReturnObj(
             "List Element: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L,
@@ -1480,7 +1472,7 @@ Obj             EvalElmListLevel (
     }
     /* get the level                                                       */
     level = (Int)(ADDR_EXPR(expr)[2]);
-    
+
     /* select the elements from several lists (store them in <lists>)      */
     ElmListLevel( lists, pos, level );
 
@@ -1546,20 +1538,17 @@ Obj             EvalIsbList (
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, right operand         */
-    Int                 p;              /* position, as C integer          */
 
     /* evaluate the list (checking is done by 'ISB_LIST')                  */
     list = EVAL_EXPR( ADDR_EXPR(expr)[0] );
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR( ADDR_EXPR(expr)[1] );
-    if (IS_INTOBJ(pos))
-      {
-        p = INT_INTOBJ( pos );
-        return (ISB_LIST( list, p ) ? True : False);
-      }
+
+    if (IS_POS_INTOBJ(pos))
+        return ISB_LIST( list, INT_INTOBJ(pos) ) ? True : False;
     else
-      return ISBB_LIST(list, pos) ? True : False;
+        return ISBB_LIST(list, pos) ? True : False;
 }
 
 
@@ -2044,7 +2033,7 @@ UInt            ExecAssPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
-    while ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    while ( ! IS_POS_INTOBJ(pos) ) {
         pos = ErrorReturnObj(
          "PosObj Assignment: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L,
@@ -2094,7 +2083,7 @@ UInt            ExecUnbPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
-    while ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    while ( ! IS_POS_INTOBJ(pos) ) {
         pos = ErrorReturnObj(
          "PosObj Assignment: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L,
@@ -2137,7 +2126,7 @@ Obj             EvalElmPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR( ADDR_EXPR(expr)[1] );
-    while ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    while ( ! IS_POS_INTOBJ(pos) ) {
         pos = ErrorReturnObj(
             "PosObj Element: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L,
@@ -2192,7 +2181,7 @@ Obj             EvalIsbPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR( ADDR_EXPR(expr)[1] );
-    while ( ! IS_INTOBJ(pos) || INT_INTOBJ(pos) <= 0 ) {
+    while ( ! IS_POS_INTOBJ(pos) ) {
         pos = ErrorReturnObj(
             "PosObj Element: <position> must be a positive integer (not a %s)",
             (Int)TNAM_OBJ(pos), 0L,
@@ -2686,8 +2675,8 @@ void            PrintIsbComObjExpr (
 *F  FuncParentLVars
 *F  FuncContentsLVars
 **
-**  Provide access to local variable bags at GAP level. Mainly for use in 
-**  error handling. 
+**  Provide access to local variable bags at GAP level. Mainly for use in
+**  error handling.
 **
 */
 
@@ -2718,7 +2707,7 @@ Obj FuncContentsLVars (Obj self, Obj lvars )
   Obj values = NEW_PLIST(T_PLIST+IMMUTABLE, len);
   if (lvars == BottomLVars)
     return False;
-  AssPRec(contents, RNamName("func"), func);  
+  AssPRec(contents, RNamName("func"), func);
   AssPRec(contents,RNamName("names"), nams);
   memcpy((void *)(1+ADDR_OBJ(values)), (void *)(3+ADDR_OBJ(lvars)), len*sizeof(Obj));
   while (ELM_PLIST(values, len) == 0)
@@ -2727,7 +2716,7 @@ Obj FuncContentsLVars (Obj self, Obj lvars )
   AssPRec(contents, RNamName("values"), values);
   if (ENVI_FUNC(func) != BottomLVars)
     AssPRec(contents, RNamName("higher"), ENVI_FUNC(func));
-  return contents;  
+  return contents;
 }
 
 /****************************************************************************
@@ -2850,7 +2839,7 @@ static Int InitKernel (
 {
     UInt                i;              /* loop variable                   */
     CurrLVars = (Bag) 0;
-    
+
     /* make 'CurrLVars' known to Gasman                                    */
     InitGlobalBag( &CurrLVars,   "src/vars.c:CurrLVars"   );
     InitGlobalBag( &BottomLVars, "src/vars.c:BottomLVars" );
@@ -2873,7 +2862,7 @@ static Int InitKernel (
         EqFuncs[T_LVARS][i] = EqLVarsX;
         EqFuncs[i][T_LVARS] = EqLVarsX;
       }
-   
+
 
     /* install executors, evaluators, and printers for local variables     */
     InstallExecStatFunc( T_ASS_LVAR       , ExecAssLVar);

--- a/src/vars.c
+++ b/src/vars.c
@@ -1168,6 +1168,77 @@ UInt            ExecAssList (
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
 }
+/****************************************************************************
+**
+*F  ExecAss2List(<ass>)  . . . . . . . . . . .  assign to an element of a list
+**
+**  'ExexAss2List'  executes the list  assignment statement <stat> of the form
+**  '<list>[<position>,<position>] := <rhs>;'.
+*/
+UInt            ExecAss2List (
+    Expr                stat )
+{
+    Obj                 list;           /* list, left operand              */
+    Obj                 pos1;            /* position, left operand          */
+    Obj                 pos2;            /* position, left operand          */
+    Obj                 rhs;            /* right hand side, right operand  */
+
+    /* evaluate the list (checking is done by 'ASS_LIST')                  */
+    SET_BRK_CURR_STAT( stat );
+    list = EVAL_EXPR( ADDR_STAT(stat)[0] );
+
+    /* evaluate the position                                               */
+    pos1 = EVAL_EXPR( ADDR_STAT(stat)[1] );
+    pos2 = EVAL_EXPR( ADDR_STAT(stat)[2] );
+
+    /* evaluate the right hand side                                        */
+    rhs = EVAL_EXPR( ADDR_STAT(stat)[3] );
+
+    ASS2_LIST( list, pos1, pos2, rhs );
+
+    /* return 0 (to indicate that no leave-statement was executed)         */
+    return 0;
+}
+/****************************************************************************
+**
+*F  ExecAssXList(<ass>)  . . . . . . . . . . .  assign to an element of a list
+**
+**  'ExexAssXList'  executes the list  assignment statement <stat> of the form
+**  '<list>[<position>,<position>,<position>[,<position>]*] := <rhs>;'.
+*/
+UInt            ExecAssXList (
+    Expr                stat )
+{
+    Obj                 list;           /* list, left operand              */
+    Obj                 pos;            /* position, left operand          */
+    Obj                 rhs;            /* right hand side, right operand  */
+    Obj ixs;
+    Int i;
+    Int narg;
+
+    /* evaluate the list (checking is done by 'ASS_LIST')                  */
+    SET_BRK_CURR_STAT( stat );
+    list = EVAL_EXPR( ADDR_STAT(stat)[0] );
+
+    narg = SIZE_STAT(stat)/sizeof(Stat) - 2;
+    ixs = NEW_PLIST(T_PLIST,narg);
+
+    for (i = 1; i <= narg; i++) {
+      /* evaluate the position                                               */
+      pos = EVAL_EXPR( ADDR_STAT(stat)[i] );
+      SET_ELM_PLIST(ixs,i,pos);
+      CHANGED_BAG(ixs);
+    }
+    SET_LEN_PLIST(ixs,narg);
+
+    /* evaluate the right hand side                                        */
+    rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
+
+    ASSB_LIST(list, ixs, rhs);
+
+    /* return 0 (to indicate that no leave-statement was executed)         */
+    return 0;
+}
 
 
 /****************************************************************************
@@ -1244,29 +1315,30 @@ UInt            ExecAssListLevel (
     Obj                 pos;            /* position, left operand          */
     Obj                 rhss;           /* right hand sides, right operand */
     Int                 level;          /* level                           */
+    Int narg,i;
+    Obj ixs;
 
     /* evaluate lists (if this works, then <lists> is nested <level> deep, */
     /* checking it is nested <level>+1 deep is done by 'AssListLevel')     */
     SET_BRK_CURR_STAT( stat );
     lists = EVAL_EXPR( ADDR_STAT(stat)[0] );
-
-    /* evaluate and check the position                                     */
-    pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
-    while ( TNUM_OBJ(pos) != T_INTPOS && (! IS_POS_INTOBJ(pos)) ) {
-        pos = ErrorReturnObj(
-         "List Assignment: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L,
-            "you can replace <position> via 'return <position>;'" );
+    narg = SIZE_STAT(stat)/sizeof(Stat) -3;
+    ixs = NEW_PLIST(T_PLIST, narg);
+    for (i = 1; i <= narg; i++) {
+      pos = EVAL_EXPR(ADDR_STAT(stat)[i]);
+      SET_ELM_PLIST(ixs,i,pos);
+      CHANGED_BAG(ixs);
     }
+    SET_LEN_PLIST(ixs, narg);
 
     /* evaluate right hand sides (checking is done by 'AssListLevel')      */
-    rhss = EVAL_EXPR( ADDR_STAT(stat)[2] );
-
+    rhss = EVAL_EXPR( ADDR_STAT(stat)[narg+1] );
+      
     /* get the level                                                       */
-    level = (Int)(ADDR_STAT(stat)[3]);
+    level = (Int)(ADDR_STAT(stat)[narg+2]);
 
     /* assign the right hand sides to the elements of several lists        */
-    AssListLevel( lists, pos, rhss, level );
+    AssListLevel( lists, ixs, rhss, level );
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -1335,20 +1407,34 @@ UInt            ExecUnbList (
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, left operand          */
+    Obj ixs;
+    Int narg;
+    Int i;
 
     /* evaluate the list (checking is done by 'LEN_LIST')                  */
     SET_BRK_CURR_STAT( stat );
     list = EVAL_EXPR( ADDR_STAT(stat)[0] );
-
-    /* evaluate the position                                               */
-    pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
-
-    /* unbind the element                                                  */
-    if (IS_POS_INTOBJ(pos)) {
+    narg = SIZE_STAT(stat)/sizeof(Stat) - 1;
+    if (narg == 1) {
+      pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
+      /* unbind the element                                                  */
+      if (IS_POS_INTOBJ(pos)) {
         UNB_LIST( list, INT_INTOBJ(pos) );
-    } else {
+      } else {
         UNBB_LIST( list, pos );
+      }
+    } else {
+      ixs = NEW_PLIST(T_PLIST, narg);
+      for (i = 1; i <= narg; i++) {
+	/* evaluate the position                                               */
+	pos = EVAL_EXPR( ADDR_STAT(stat)[i] );
+	SET_ELM_PLIST(ixs,i,pos);
+	CHANGED_BAG(ixs);
+      }
+      SET_LEN_PLIST(ixs, narg);
+      UNBB_LIST(list, ixs);
     }
+    
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -1606,17 +1692,31 @@ Obj             EvalIsbList (
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, right operand         */
+    Obj ixs;
+    Int narg, i;
 
     /* evaluate the list (checking is done by 'ISB_LIST')                  */
     list = EVAL_EXPR( ADDR_EXPR(expr)[0] );
-
-    /* evaluate and check the position                                     */
-    pos = EVAL_EXPR( ADDR_EXPR(expr)[1] );
-
-    if (IS_POS_INTOBJ(pos))
+    narg = SIZE_EXPR(expr)/sizeof(Expr) -1;
+    if (narg == 1) {
+      /* evaluate and check the position                                     */
+      pos = EVAL_EXPR( ADDR_EXPR(expr)[1] );
+      
+      if (IS_POS_INTOBJ(pos))
         return ISB_LIST( list, INT_INTOBJ(pos) ) ? True : False;
-    else
+      else
         return ISBB_LIST(list, pos) ? True : False;
+    } else {
+      ixs = NEW_PLIST(T_PLIST, narg);
+      for (i = 1; i <= narg; i++) {
+	pos = EVAL_EXPR( ADDR_EXPR(expr)[i] );
+	SET_ELM_PLIST(ixs,i,pos);
+	CHANGED_BAG(ixs);
+      }
+      SET_LEN_PLIST(ixs, narg);
+      return ISBB_LIST(list, ixs) ? True : False;
+    }
+	
 }
 
 
@@ -1642,14 +1742,54 @@ void            PrintAssList (
     Pr("%2<;",0L,0L);
 }
 
+void            PrintAss2List (
+    Stat                stat )
+{
+    Pr("%4>",0L,0L);
+    PrintExpr( ADDR_STAT(stat)[0] );
+    Pr("%<[",0L,0L);
+    PrintExpr( ADDR_STAT(stat)[1] );
+    Pr("%<, %>",0L,0L);
+    PrintExpr( ADDR_STAT(stat)[2] );
+    Pr("%<]",0L,0L);
+    Pr("%< %>:= ",0L,0L);
+    PrintExpr( ADDR_STAT(stat)[3] );
+    Pr("%2<;",0L,0L);
+}
+
+void            PrintAssXList (
+    Stat                stat )
+{
+  Int narg = SIZE_STAT(stat)/sizeof(stat) - 2;
+  Int i;
+    Pr("%4>",0L,0L);
+    PrintExpr( ADDR_STAT(stat)[0] );
+    Pr("%<[",0L,0L);
+    PrintExpr( ADDR_STAT(stat)[1] );
+    for (i = 2; i <= narg; i++) {
+      Pr("%<, %>",0L,0L);
+      PrintExpr( ADDR_STAT(stat)[i] );
+    }
+    Pr("%<]",0L,0L);
+    Pr("%< %>:= ",0L,0L);
+    PrintExpr( ADDR_STAT(stat)[narg + 1] );
+    Pr("%2<;",0L,0L);
+}
+
 void            PrintUnbList (
     Stat                stat )
 {
+  Int narg = SIZE_STAT(stat)/sizeof(Stat) -1;
+  Int i;
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_STAT(stat)[0] );
     Pr("%<[",0L,0L);
     PrintExpr( ADDR_STAT(stat)[1] );
+    for (i = 2; i <= narg; i++) {
+      Pr("%<, %>",0L,0L);
+      PrintExpr(ADDR_STAT(stat)[i]);
+    }
     Pr("%<]",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -1745,11 +1885,17 @@ void PrintElmListLevel (
 void            PrintIsbList (
     Expr                expr )
 {
+  Int narg = SIZE_EXPR(expr)/sizeof(Expr) - 1;
+  Int i;
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(expr)[0] );
     Pr("%<[",0L,0L);
     PrintExpr( ADDR_EXPR(expr)[1] );
+    for (i = 2; i <= narg; i++) {
+      Pr("%<, %>", 0L, 0L);
+      PrintExpr(ADDR_EXPR(expr)[i] );
+    }
     Pr("%<]",0L,0L);
     Pr( " )", 0L, 0L );
 }
@@ -3055,6 +3201,11 @@ static Int InitKernel (
     InstallExecStatFunc( T_ASSS_LIST      , ExecAsssList);
     InstallExecStatFunc( T_ASS_LIST_LEV   , ExecAssListLevel);
     InstallExecStatFunc( T_ASSS_LIST_LEV  , ExecAsssListLevel);
+    InstallExecStatFunc( T_ASS2_LIST  , ExecAss2List);
+    InstallExecStatFunc( T_ASSX_LIST  , ExecAssXList);
+    InstallPrintStatFunc( T_ASS2_LIST  , PrintAss2List);
+    InstallPrintStatFunc( T_ASSX_LIST  , PrintAssXList);
+    
     InstallExecStatFunc( T_UNB_LIST       , ExecUnbList);
     InstallEvalExprFunc( T_ELM_LIST       , EvalElmList);
     InstallEvalExprFunc( T_ELMS_LIST      , EvalElmsList);

--- a/src/vars.c
+++ b/src/vars.c
@@ -1522,30 +1522,31 @@ Obj             EvalElmListLevel (
 {
     Obj                 lists;          /* lists, left operand             */
     Obj                 pos;            /* position, right operand         */
+    Obj                 ixs;
     Int                 level;          /* level                           */
+    Int narg;
+    Int i;
 
     /* evaluate lists (if this works, then <lists> is nested <level> deep, */
     /* checking it is nested <level>+1 deep is done by 'ElmListLevel')     */
     lists = EVAL_EXPR( ADDR_EXPR(expr)[0] );
-
-    /* evaluate and check the position                                     */
-    pos = EVAL_EXPR( ADDR_EXPR(expr)[1] );
-    while ( TNUM_OBJ(pos) != T_INTPOS && (! IS_POS_INTOBJ(pos) )) {
-        pos = ErrorReturnObj(
-            "List Element: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L,
-            "you can replace <position> via 'return <position>;'" );
+    narg = SIZE_EXPR(expr)/sizeof(Expr) -2;
+    ixs = NEW_PLIST(T_PLIST, narg);
+    for (i = 1; i <= narg; i++) {
+      pos = EVAL_EXPR( ADDR_EXPR(expr)[i]);
+      SET_ELM_PLIST(ixs, i, pos);
+      CHANGED_BAG(ixs);
     }
+    SET_LEN_PLIST(ixs, narg);
     /* get the level                                                       */
-    level = (Int)(ADDR_EXPR(expr)[2]);
-
+    level = (Int)(ADDR_EXPR(expr)[narg+1]);
+    
     /* select the elements from several lists (store them in <lists>)      */
-    ElmListLevel( lists, pos, level );
+    ElmListLevel( lists, ixs, level );
 
     /* return the elements                                                 */
     return lists;
 }
-
 
 /****************************************************************************
 **

--- a/src/vars.c
+++ b/src/vars.c
@@ -1695,6 +1695,35 @@ void            PrintElmList (
     Pr("%<]",0L,0L);
 }
 
+void PrintElm2List (
+		     Expr expr )
+{
+    Pr("%2>",0L,0L);
+    PrintExpr( ADDR_EXPR(expr)[0] );
+    Pr("%<[",0L,0L);
+    PrintExpr( ADDR_EXPR(expr)[1] );
+    Pr("%<, %<",0L,0L);
+    PrintExpr( ADDR_EXPR(expr)[2] );
+    Pr("%<]",0L,0L);
+}
+
+void PrintElmXList (
+		     Expr expr )
+{
+  Int i;
+  Int narg = SIZE_EXPR(expr)/sizeof(Expr) -1 ;
+    Pr("%2>",0L,0L);
+    PrintExpr( ADDR_EXPR(expr)[0] );
+    Pr("%<[",0L,0L);
+    PrintExpr( ADDR_EXPR(expr)[1] );
+    for (i = 2; i <= narg; i++) {
+      Pr("%<, %<",0L,0L);
+      PrintExpr( ADDR_EXPR(expr)[2] );
+    }
+    Pr("%<]",0L,0L);
+}
+
+
 void            PrintIsbList (
     Expr                expr )
 {
@@ -3016,6 +3045,8 @@ static Int InitKernel (
     InstallEvalExprFunc( T_ISB_LIST       , EvalIsbList);
     InstallEvalExprFunc( T_ELM2_LIST      , EvalElm2List);
     InstallEvalExprFunc( T_ELMX_LIST      , EvalElmXList);
+    InstallPrintExprFunc( T_ELM2_LIST     , PrintElm2List);
+    InstallPrintExprFunc( T_ELMX_LIST     , PrintElmXList);
     
     InstallPrintStatFunc( T_ASS_LIST       , PrintAssList);
     InstallPrintStatFunc( T_ASSS_LIST      , PrintAsssList);

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -1,0 +1,121 @@
+#############################################################################
+##
+#A  listindex.tst               GAP 4.0 library                   Steve Linton
+##
+##
+##
+##
+gap> START_TEST("listindex.tst");
+gap> r := NewCategory("ListTestObject",IsList and HasLength and HasIsFinite);
+<Category "ListTestObject">
+gap> InstallMethod(\[\],[r,IsObject],function(l,ix) 
+>     return ix;
+> end);
+gap> InstallMethod(\[\]\:\=,[r and IsMutable,IsObject, IsObject],function(l,ix,x) 
+>     Print ("Assign ",ix," ",x,"\n");
+> end);
+gap> InstallMethod(Unbind\[\],[r and IsMutable,IsObject],function(l,ix) 
+>     Print ("Unbind ",ix,"\n");
+> end);
+gap> InstallMethod(IsBound\[\],[r and IsMutable,IsObject],function(l,ix) 
+>     Print ("IsBound ",ix,"\n");
+>     return false;
+> end);
+gap> InstallMethod(Length,[r],l->infinity);
+gap> InstallMethod(IsFinite,[r],ReturnFalse);
+gap> t := NewType(ListsFamily, r and IsMutable and IsPositionalObjectRep);;
+gap> o := Objectify(t,[]);;
+gap> o[1];
+1
+gap> o[-17];
+-17
+gap> o[Z(3)];
+Z(3)
+gap> o[[1,2]];
+[ 1, 2 ]
+gap> o[3,4];
+[ 3, 4 ]
+gap> o[3,4,5];
+[ 3, 4, 5 ]
+gap> o["abc"];
+"abc"
+gap> o[2] := 3;
+Assign 2 3
+3
+gap> o[2^200] := fail;
+Assign 1606938044258990275541962092341162602522202993782792835301376 fail
+fail
+gap> o[E(4)] := "i";
+Assign E(4) i
+"i"
+gap> o[[12,34,56]] := 99;
+Assign [ 12, 34, 56 ] 99
+99
+gap> o[-1,"e"] := 1.0;
+Assign [ -1, "e" ] 1
+1.
+gap> o[2.0,3.0,4.5] := infinity;
+Assign [ 2, 3, 4.5 ] infinity
+infinity
+gap> Unbind(o[1]);
+Unbind 1
+gap> Unbind(o[-17]);
+Unbind -17
+gap> Unbind(o[Z(3)]);
+Unbind Z(3)
+gap> Unbind(o[[1,2]]);
+Unbind [ 1, 2 ]
+gap> Unbind(o[3,4]);
+Unbind [ 3, 4 ]
+gap> Unbind(o[3,4,5]);
+Unbind [ 3, 4, 5 ]
+gap> Unbind(o["abc"]);
+Unbind abc
+gap> IsBound(o[1]);
+IsBound 1
+false
+gap> IsBound(o[-17]);
+IsBound -17
+false
+gap> IsBound(o[Z(3)]);
+IsBound Z(3)
+false
+gap> IsBound(o[[1,2]]);
+IsBound [ 1, 2 ]
+false
+gap> IsBound(o[3,4]);
+IsBound [ 3, 4 ]
+false
+gap> IsBound(o[3,4,5]);
+IsBound [ 3, 4, 5 ]
+false
+gap> IsBound(o["abc"]);
+IsBound abc
+false
+gap> foo := function(a)
+>     return[ a[1,2,3],
+>             a[4,5],
+>             o[1,2,3],
+>             o[4,5],
+>             function()
+>         return [a[6,7], a[5,6,7]];
+>     end];
+> end;
+function( a ) ... end
+gap> Print(foo,"\n");
+function ( a )
+    return [ a[1, 2, 2], a[4, 5], o[1, 2, 2], o[4, 5], function (  )
+  return [ a[6, 7], a[5, 6, 6] ];
+end ];
+end
+gap> res := foo(o);
+[ [ 1, 2, 3 ], [ 4, 5 ], [ 1, 2, 3 ], [ 4, 5 ], function(  ) ... end ]
+gap> res[5]();
+[ [ 6, 7 ], [ 5, 6, 7 ] ]
+
+# that's all, folks
+gap> STOP_TEST( "listgen.tst", 1000000 );
+
+#############################################################################
+##
+#E


### PR DESCRIPTION
This is a cleaned up and rebased version of two old pull requests #83 and #28 (Thanks to @fingolfin and @markuspf for fixing the mess I'd made). It extends support for indexing into lists using indexes other than positive small integers. All such indexing ends up with GAP-level methods. It also adds the syntax l[i1,i2,....] which is mapped to l[[i1,i2,...]]. There is infrastructure in the kernel to allow for fast methods for the case of two indices (without creating the length 2 list) but this is currently not exported to GAP level. 

Tests and documentation are still needed.