### PR TITLE
Do not interpret empty lists as strings when Info prints - fixes #199

### DIFF
--- a/lib/info.gi
+++ b/lib/info.gi
@@ -78,11 +78,11 @@ InstallGlobalFunction( "DefaultInfoHandler", function( infoclass, level, list )
   if out = "*Print*" then
     if IsBoundGlobal( "PrintFormattedString" ) then
       fun := function(s)
-        if IsString(s) and 
-          #XXX this is a temporary hack, we would need a 
+        if (IsString(s) and Length(s) > 0) or IsStringRep(s) and
+          #XXX this is a temporary hack, we would need a
           # IsInstalledGlobal instead of IsBoundGlobal here
                  NARG_FUNC(ValueGlobal("PrintFormattedString")) <> -1 then
-          ValueGlobal( "PrintFormattedString" )(s); 
+          ValueGlobal( "PrintFormattedString" )(s);
         else
           Print(s);
         fi;

--- a/tst/teststandard/info.tst
+++ b/tst/teststandard/info.tst
@@ -1,0 +1,32 @@
+#############################################################################
+##
+#W  info.tst
+##
+##
+#Y  Copyright (C)  2015
+##
+##
+gap> START_TEST("info.tst");
+gap> InfoTest1 := NewInfoClass("InfoTest1");;
+gap> InfoLevel(InfoTest1);
+0
+gap> Info(InfoTest1, 1, "No");
+gap> Info(InfoTest1, 200, "No");
+gap> SetInfoLevel(InfoTest1, 1);
+gap> Info(InfoTest1, 1, "Yes");
+#I  Yes
+gap> Info(InfoTest1, 2, "No");
+gap> Info(InfoTest1, 200, "No");
+gap> Info(InfoTest1, 1, []);
+#I  [  ]
+gap> Info(InfoTest1, 1, [[]], [], 6);
+#I  [ [  ] ][  ]6
+gap> Info(InfoTest1, 1, (1,2)(3,4));
+#I  (1,2)(3,4)
+gap> Info(InfoTest1, 1, ['a', 'b', 'c']);
+#I  abc
+gap> STOP_TEST("info.tst", 1);
+
+#############################################################################
+##
+#E


### PR DESCRIPTION
This makes sure 'Info' does not interpret [] as a string (and therefore prints nothing, as it is the empty string.