### PR TITLE
Warnings when too many temporary directories are created.

### DIFF
--- a/lib/files.gd
+++ b/lib/files.gd
@@ -464,10 +464,20 @@ end );
 ##  <K>fail</K> is returned.
 ##  In this case <Ref Func="LastSystemError"/> can be used to get information
 ##  about the error.
+##  <P/>
+##  A warning message is given if more than 1000 temporary directories are 
+##  created in any &GAP; session.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+DIRECTORY_TEMPORARY_COUNT := 0;
+DIRECTORY_TEMPORART_LIMIT := 1000;
+InfoTempDirectories := fail;
+
+
+
+
 BIND_GLOBAL( "DirectoryTemporary", function( arg )
     local   dir,drive,a;
 
@@ -493,7 +503,13 @@ BIND_GLOBAL( "DirectoryTemporary", function( arg )
 
   # remember directory name
   Add( GAPInfo.DirectoriesTemporary, dir );
-
+  
+  DIRECTORY_TEMPORARY_COUNT := DIRECTORY_TEMPORARY_COUNT + 1;
+  if DIRECTORY_TEMPORARY_COUNT = DIRECTORY_TEMPORART_LIMIT then
+      Info(InfoTempDirectories,1, DIRECTORY_TEMPORART_LIMIT, " temporary directories made in this session");
+      DIRECTORY_TEMPORART_LIMIT := DIRECTORY_TEMPORART_LIMIT*10;
+  fi;
+  
   return Directory(dir);
 end );
 

--- a/lib/files.gi
+++ b/lib/files.gi
@@ -10,6 +10,12 @@
 ##  This file contains the methods for files and directories.
 ##
 
+Unbind(InfoTempDirectories);
+
+DeclareInfoClass("InfoTempDirectories");
+SetInfoLevel(InfoTempDirectories,1);
+
+
 
 #############################################################################
 ##


### PR DESCRIPTION
Adds a warning after 1000, 10000, 100000 etc temporary directories are created in a GAP session.
Controlled by InfoTempDirectories, so you can shut it off if you know what you are doing.
Note that it doesn't check if the directories still exist, so may give unwanted warnings for some code.