### PR TITLE
Library: Fix iterator printing 2

### DIFF
--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -1292,6 +1292,14 @@ DeclareGlobalFunction( "TrivialIterator" );
 ##      of <A>iter</A> but behaves like <A>iter</A> w.r.t. the operations
 ##      <Ref Func="NextIterator"/> and <Ref Func="IsDoneIterator"/>.
 ##  </Item>
+##  <Mark><C>ViewObj</C> and <C>PrintObj</C></Mark>
+##  <Item>
+##      two functions that print what one wants to be printed when
+##      <C>View( <A>iter</A> )</C> or <C>Print( <A>item</A> )</C> is called
+##      (see&nbsp;<Ref Sect="View and Print"/>),
+##      if the <C>ViewObj</C> component is missing then the <C>PrintObj</C>
+##      method is used as a default.
+##  </Item>
 ##  </List>
 ##  Further (data) components may be contained in <A>record</A> which can be
 ##  used by these function.

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -81,16 +81,6 @@ InstallMethod( PrintObj,
     if not IsMutable( iter ) then
       Append(msg, " (immutable)");
     fi;
-    if IsBound( iter!.description ) then
-      Append(msg, " ");
-      if IsFunction(iter!.description) then
-        Append(msg, iter!.description(iter));
-      elif IsString(iter!.description(iter)) then
-        Append(msg, iter!.description);
-      else
-        Error("Invalid description for iterator.");
-      fi;
-    fi;
     Append(msg,">");
     Print(msg);
     end );
@@ -969,7 +959,8 @@ InstallOtherMethod( NextIterator,
 #F  IteratorByFunctions( <record> )
 ##
 DeclareRepresentation( "IsIteratorByFunctionsRep", IsComponentObjectRep,
-    [ "NextIterator", "IsDoneIterator", "ShallowCopy" ] );
+    [ "NextIterator", "IsDoneIterator", "ShallowCopy",
+    , "ViewObj", "PrintObj"] );
 
 DeclareSynonym( "IsIteratorByFunctions",
     IsIteratorByFunctionsRep and IsIterator );
@@ -1007,9 +998,40 @@ InstallMethod( ShallowCopy,
     new.NextIterator   := iter!.NextIterator;
     new.IsDoneIterator := iter!.IsDoneIterator;
     new.ShallowCopy    := iter!.ShallowCopy;
+    new.ViewObj        := iter!.ViewObj;
+    new.PrintObj       := iter!.ViewObj;
     return IteratorByFunctions( new );
     end );
 
+InstallMethod( ViewObj,
+    "for an iterator that perhaps has its own `ViewObj' function",
+    [ IsIteratorByFunctions ], 20,
+function( iter )
+    if IsBound( iter!.ViewObj ) then
+        iter!.ViewObj( iter );
+    elif IsBound( iter!.PrintObj ) then
+        iter!.PrintObj( iter );
+    elif HasUnderlyingCollection( iter ) then
+        Print( "<iterator of " );
+        View( UnderlyingCollection( iter ) );
+        Print( ">" );
+    else
+        Print( "<iterator>" );
+    fi;
+end );
+
+InstallMethod( PrintObj,
+    "for an iterator that perhaps has its own `PrintObj' function",
+    [ IsIteratorByFunctions ],
+function( iter )
+    if IsBound( iter!.PrintObj ) then
+       iter!.PrintObj( iter );
+    elif HasUnderlyingCollection( iter ) then
+       Print( "<iterator of ", UnderlyingCollection( iter ), ">" );
+    else
+       Print( "<iterator>" );
+    fi;
+end );
 
 #############################################################################
 ##

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -998,8 +998,12 @@ InstallMethod( ShallowCopy,
     new.NextIterator   := iter!.NextIterator;
     new.IsDoneIterator := iter!.IsDoneIterator;
     new.ShallowCopy    := iter!.ShallowCopy;
-    new.ViewObj        := iter!.ViewObj;
-    new.PrintObj       := iter!.ViewObj;
+    if IsBound(iter!.ViewObj) then
+        new.ViewObj    := iter!.ViewObj;
+    fi;
+    if IsBound(iter!.PrintObj) then
+        new.PrintObj   := iter!.PrintObj;
+    fi;
     return IteratorByFunctions( new );
     end );
 

--- a/lib/integer.gi
+++ b/lib/integer.gi
@@ -1593,7 +1593,17 @@ InstallMethod( Iterator,
             end,
         IsDoneIterator := ReturnFalse,
         ShallowCopy := iter -> rec( counter:= iter!.counter ),
-
+	PrintObj := function(iter)
+            local msg;
+            msg := "<iterator of Integers at ";
+            if iter!.counter mod 2 = 0 then
+              Append(msg, String(iter!.counter / 2));
+            else
+              Append(msg, String((1 - iter!.counter) / 2));
+            fi;
+            Append(msg,">");
+            Print(msg);
+          end,
         counter := 0 ) ) );
 
         


### PR DESCRIPTION
This supercedes #137. 

* IteratorByFunctions now works in the same way as EnumeratorByFunctions.
* I removed the slightly hacky printing for general iterators
* I added iterator printing for Integers. Of course going over the library and adding more descriptive PrintObj functions is desirable.