### PR TITLE
Improve how readline history deals with multiline input

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -290,8 +290,16 @@ Obj Shell ( Obj context,
         }
     }
 
-    /* now  read and evaluate and view one command  */
+    /* now read and evaluate and view one command  */
     status = ReadEvalCommand(ShellContext, &dualSemicolon);
+#if HAVE_LIBREADLINE
+    if (SyUseReadline) {
+      /* (maybe) add all entered lines to history; we use key 1 for this function */
+      extern int GAP_rl_func(int count, int key);
+      GAP_rl_func(0, 1);
+    }
+#endif
+
     if (UserHasQUIT)
       break;
 

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -2384,8 +2384,10 @@ Char * readlineFgets (
       return (Char*)0;
     }
   }
-  /* maybe add to history, we use key 0 for this function */
+  /* (maybe) queue last line for addition to history; we use key 0 for this function.
+     The actual addition is triggered in gap.c, function Shell(). */
   GAP_rl_func(0, 0);
+
   len = strlen(rlres);
   strncpy(line, rlres, len);
   free(rlres);


### PR DESCRIPTION
This tweaks the way GAP deals with multiline input (at least when using readline -- I did not (yet?) test what happens if readline is disabled). Previously, when you e.g. pasted a function like this:

```
f := function(x)
  return x+1;
end;
```

then afterwards pressing arrow-up showed you three individual lines of input.

With this patch, arrow up gives

```
gap> f := function(x) return x+1; end;
```
