### PR TITLE
Fixed locking problem for Task arguments.

### DIFF
--- a/lib/tasks.g
+++ b/lib/tasks.g
@@ -341,7 +341,7 @@ WaitTask := function(arg)
     od;
   od;
   for task in arg do
-    p := WRITE_LOCK(false, task);
+    p := LOCK(false, task);
     if IsIdenticalObj (p, fail) then
       Error("Could not obtain lock in WaitTask\n");
     fi;


### PR DESCRIPTION
Due to a search and replace operation, a `LOCK()` call had
erroneously become a `WRITE_LOCK()` call in lib/tasks.g.

Note that this does not affect lib/stdtasks.g, which is the normally active tasks implementation; it's still a good idea to have this work.