### PR TITLE
Backport TLS changes from HPC-GAP

### DIFF
--- a/src/c_filt1.c
+++ b/src/c_filt1.c
@@ -986,13 +986,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 22, "CLEAR_HIDDEN_IMP_CACHE" );
  t_3 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(26);
  ENDLINE_BODY(t_4) = INTOBJ_INT(38);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "WITH_HIDDEN_IMPS_FLAGS", function ( flags )
@@ -1023,13 +1023,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 22, "WITH_HIDDEN_IMPS_FLAGS" );
  t_3 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(41);
  ENDLINE_BODY(t_4) = INTOBJ_INT(71);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* IMPLICATIONS := [  ]; */
@@ -1061,13 +1061,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 15, "CLEAR_IMP_CACHE" );
  t_3 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(86);
  ENDLINE_BODY(t_4) = INTOBJ_INT(88);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "WITH_IMPS_FLAGS", function ( flags )
@@ -1108,13 +1108,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 15, "WITH_IMPS_FLAGS" );
  t_3 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(91);
  ENDLINE_BODY(t_4) = INTOBJ_INT(130);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* UNBIND_GLOBAL( "RANK_FILTER" ); */
@@ -1142,13 +1142,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 11, "RANK_FILTER" );
  t_3 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(144);
  ENDLINE_BODY(t_4) = INTOBJ_INT(161);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* RankFilter := RANK_FILTER; */
@@ -1177,13 +1177,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 17, "RANK_FILTER_STORE" );
  t_3 = NewFunction( NameFunc[7], NargFunc[7], NamsFunc[7], HdlrFunc7 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(166);
  ENDLINE_BODY(t_4) = INTOBJ_INT(180);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* UNBIND_GLOBAL( "RANK_FILTER_COMPLETION" ); */
@@ -1208,13 +1208,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 22, "RANK_FILTER_COMPLETION" );
  t_3 = NewFunction( NameFunc[8], NargFunc[8], NamsFunc[8], HdlrFunc8 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(183);
  ENDLINE_BODY(t_4) = INTOBJ_INT(198);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
@@ -1361,8 +1361,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = CurrLVars;
- CHANGED_BAG( CurrLVars );
+ ENVI_FUNC( func1 ) = TLS(CurrLVars);
+ CHANGED_BAG( TLS(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/src/c_meths1.c
+++ b/src/c_meths1.c
@@ -4655,13 +4655,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(19);
  ENDLINE_BODY(t_2) = INTOBJ_INT(30);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_METHOD__0ARGS, t_1 );
  
  /* METHOD_1ARGS := function ( operation, type1 )
@@ -4675,13 +4675,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(37);
  ENDLINE_BODY(t_2) = INTOBJ_INT(49);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_METHOD__1ARGS, t_1 );
  
  /* METHOD_2ARGS := function ( operation, type1, type2 )
@@ -4695,13 +4695,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(56);
  ENDLINE_BODY(t_2) = INTOBJ_INT(69);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_METHOD__2ARGS, t_1 );
  
  /* METHOD_3ARGS := function ( operation, type1, type2, type3 )
@@ -4715,13 +4715,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(76);
  ENDLINE_BODY(t_2) = INTOBJ_INT(90);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_METHOD__3ARGS, t_1 );
  
  /* METHOD_4ARGS := function ( operation, type1, type2, type3, type4 )
@@ -4736,13 +4736,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(97);
  ENDLINE_BODY(t_2) = INTOBJ_INT(114);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_METHOD__4ARGS, t_1 );
  
  /* METHOD_5ARGS := function ( operation, type1, type2, type3, type4, type5 )
@@ -4757,13 +4757,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[7], NargFunc[7], NamsFunc[7], HdlrFunc7 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(121);
  ENDLINE_BODY(t_2) = INTOBJ_INT(139);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_METHOD__5ARGS, t_1 );
  
  /* METHOD_6ARGS := function ( operation, type1, type2, type3, type4, type5, type6 )
@@ -4778,13 +4778,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[8], NargFunc[8], NamsFunc[8], HdlrFunc8 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(146);
  ENDLINE_BODY(t_2) = INTOBJ_INT(165);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_METHOD__6ARGS, t_1 );
  
  /* METHOD_XARGS := function ( arg )
@@ -4792,13 +4792,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[9], NargFunc[9], NamsFunc[9], HdlrFunc9 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(172);
  ENDLINE_BODY(t_2) = INTOBJ_INT(174);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_METHOD__XARGS, t_1 );
  
  /* NEXT_METHOD_0ARGS := function ( operation, k )
@@ -4817,13 +4817,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(189);
  ENDLINE_BODY(t_2) = INTOBJ_INT(205);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__METHOD__0ARGS, t_1 );
  
  /* NEXT_METHOD_1ARGS := function ( operation, k, type1 )
@@ -4842,13 +4842,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(212);
  ENDLINE_BODY(t_2) = INTOBJ_INT(229);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__METHOD__1ARGS, t_1 );
  
  /* NEXT_METHOD_2ARGS := function ( operation, k, type1, type2 )
@@ -4867,13 +4867,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(236);
  ENDLINE_BODY(t_2) = INTOBJ_INT(254);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__METHOD__2ARGS, t_1 );
  
  /* NEXT_METHOD_3ARGS := function ( operation, k, type1, type2, type3 )
@@ -4893,13 +4893,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(261);
  ENDLINE_BODY(t_2) = INTOBJ_INT(280);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__METHOD__3ARGS, t_1 );
  
  /* NEXT_METHOD_4ARGS := function ( operation, k, type1, type2, type3, type4 )
@@ -4919,13 +4919,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(287);
  ENDLINE_BODY(t_2) = INTOBJ_INT(309);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__METHOD__4ARGS, t_1 );
  
  /* NEXT_METHOD_5ARGS := function ( operation, k, type1, type2, type3, type4, type5 )
@@ -4945,13 +4945,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(316);
  ENDLINE_BODY(t_2) = INTOBJ_INT(339);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__METHOD__5ARGS, t_1 );
  
  /* NEXT_METHOD_6ARGS := function ( operation, k, type1, type2, type3, type4, type5, type6 )
@@ -4971,13 +4971,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(346);
  ENDLINE_BODY(t_2) = INTOBJ_INT(370);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__METHOD__6ARGS, t_1 );
  
  /* NEXT_METHOD_XARGS := function ( arg )
@@ -4985,13 +4985,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(377);
  ENDLINE_BODY(t_2) = INTOBJ_INT(379);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__METHOD__XARGS, t_1 );
  
  /* AttributeValueNotSet := function ( attr, obj )
@@ -5017,13 +5017,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(385);
  ENDLINE_BODY(t_2) = INTOBJ_INT(406);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_AttributeValueNotSet, t_1 );
  
  /* CONSTRUCTOR_0ARGS := function ( operation )
@@ -5037,13 +5037,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[19], NargFunc[19], NamsFunc[19], HdlrFunc19 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(419);
  ENDLINE_BODY(t_2) = INTOBJ_INT(430);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__0ARGS, t_1 );
  
  /* CONSTRUCTOR_1ARGS := function ( operation, flags1 )
@@ -5057,13 +5057,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[20], NargFunc[20], NamsFunc[20], HdlrFunc20 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(437);
  ENDLINE_BODY(t_2) = INTOBJ_INT(449);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__1ARGS, t_1 );
  
  /* CONSTRUCTOR_2ARGS := function ( operation, flags1, type2 )
@@ -5077,13 +5077,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[21], NargFunc[21], NamsFunc[21], HdlrFunc21 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(456);
  ENDLINE_BODY(t_2) = INTOBJ_INT(469);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__2ARGS, t_1 );
  
  /* CONSTRUCTOR_3ARGS := function ( operation, flags1, type2, type3 )
@@ -5097,13 +5097,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[22], NargFunc[22], NamsFunc[22], HdlrFunc22 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(476);
  ENDLINE_BODY(t_2) = INTOBJ_INT(490);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__3ARGS, t_1 );
  
  /* CONSTRUCTOR_4ARGS := function ( operation, flags1, type2, type3, type4 )
@@ -5118,13 +5118,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[23], NargFunc[23], NamsFunc[23], HdlrFunc23 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(497);
  ENDLINE_BODY(t_2) = INTOBJ_INT(514);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__4ARGS, t_1 );
  
  /* CONSTRUCTOR_5ARGS := function ( operation, flags1, type2, type3, type4, type5 )
@@ -5139,13 +5139,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[24], NargFunc[24], NamsFunc[24], HdlrFunc24 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(521);
  ENDLINE_BODY(t_2) = INTOBJ_INT(539);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__5ARGS, t_1 );
  
  /* CONSTRUCTOR_6ARGS := function ( operation, flags1, type2, type3, type4, type5, type6 )
@@ -5160,13 +5160,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[25], NargFunc[25], NamsFunc[25], HdlrFunc25 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(546);
  ENDLINE_BODY(t_2) = INTOBJ_INT(565);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__6ARGS, t_1 );
  
  /* CONSTRUCTOR_XARGS := function ( arg )
@@ -5174,13 +5174,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[26], NargFunc[26], NamsFunc[26], HdlrFunc26 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(572);
  ENDLINE_BODY(t_2) = INTOBJ_INT(574);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__XARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_0ARGS := function ( operation, k )
@@ -5199,13 +5199,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[27], NargFunc[27], NamsFunc[27], HdlrFunc27 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(589);
  ENDLINE_BODY(t_2) = INTOBJ_INT(605);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__0ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_1ARGS := function ( operation, k, flags1 )
@@ -5224,13 +5224,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[28], NargFunc[28], NamsFunc[28], HdlrFunc28 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(612);
  ENDLINE_BODY(t_2) = INTOBJ_INT(629);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__1ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_2ARGS := function ( operation, k, flags1, type2 )
@@ -5249,13 +5249,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[29], NargFunc[29], NamsFunc[29], HdlrFunc29 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(636);
  ENDLINE_BODY(t_2) = INTOBJ_INT(654);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__2ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_3ARGS := function ( operation, k, flags1, type2, type3 )
@@ -5274,13 +5274,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[30], NargFunc[30], NamsFunc[30], HdlrFunc30 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(661);
  ENDLINE_BODY(t_2) = INTOBJ_INT(680);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__3ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_4ARGS := function ( operation, k, flags1, type2, type3, type4 )
@@ -5300,13 +5300,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[31], NargFunc[31], NamsFunc[31], HdlrFunc31 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(687);
  ENDLINE_BODY(t_2) = INTOBJ_INT(709);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__4ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_5ARGS := function ( operation, k, flags1, type2, type3, type4, type5 )
@@ -5326,13 +5326,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[32], NargFunc[32], NamsFunc[32], HdlrFunc32 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(716);
  ENDLINE_BODY(t_2) = INTOBJ_INT(739);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__5ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_6ARGS := function ( operation, k, flags1, type2, type3, type4, type5, type6 )
@@ -5352,13 +5352,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[33], NargFunc[33], NamsFunc[33], HdlrFunc33 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(746);
  ENDLINE_BODY(t_2) = INTOBJ_INT(770);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__6ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_XARGS := function ( arg )
@@ -5366,13 +5366,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[34], NargFunc[34], NamsFunc[34], HdlrFunc34 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(777);
  ENDLINE_BODY(t_2) = INTOBJ_INT(779);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__XARGS, t_1 );
  
  /* return; */
@@ -5641,8 +5641,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = CurrLVars;
- CHANGED_BAG( CurrLVars );
+ ENVI_FUNC( func1 ) = TLS(CurrLVars);
+ CHANGED_BAG( TLS(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -2408,13 +2408,13 @@ static Obj  HdlrFunc7 (
    SET_ELM_PLIST( t_5, 1, l_cats );
    CHANGED_BAG( t_5 );
    t_6 = NewFunction( NameFunc[8], NargFunc[8], NamsFunc[8], HdlrFunc8 );
-   ENVI_FUNC( t_6 ) = CurrLVars;
+   ENVI_FUNC( t_6 ) = TLS(CurrLVars);
    t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
    STARTLINE_BODY(t_7) = INTOBJ_INT(577);
    ENDLINE_BODY(t_7) = INTOBJ_INT(595);
    FILENAME_BODY(t_7) = FileName;
    BODY_FUNC(t_6) = t_7;
-   CHANGED_BAG( CurrLVars );
+   CHANGED_BAG( TLS(CurrLVars) );
    CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, l_rank, t_6 );
    
   }
@@ -2723,13 +2723,13 @@ static Obj  HdlrFunc10 (
       return;
   end; */
   t_1 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
-  ENVI_FUNC( t_1 ) = CurrLVars;
+  ENVI_FUNC( t_1 ) = TLS(CurrLVars);
   t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
   STARTLINE_BODY(t_2) = INTOBJ_INT(732);
   ENDLINE_BODY(t_2) = INTOBJ_INT(736);
   FILENAME_BODY(t_2) = FileName;
   BODY_FUNC(t_1) = t_2;
-  CHANGED_BAG( CurrLVars );
+  CHANGED_BAG( TLS(CurrLVars) );
   ASS_LVAR( 2, t_1 );
   
  }
@@ -2803,13 +2803,13 @@ static Obj  HdlrFunc10 (
  SET_ELM_PLIST( t_5, 1, a_domreq );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
- ENVI_FUNC( t_6 ) = CurrLVars;
+ ENVI_FUNC( t_6 ) = TLS(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_7) = INTOBJ_INT(753);
  ENDLINE_BODY(t_7) = INTOBJ_INT(753);
  FILENAME_BODY(t_7) = FileName;
  BODY_FUNC(t_6) = t_7;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* DeclareOperation( name, [ domreq, keyreq ] ); */
@@ -2866,13 +2866,13 @@ static Obj  HdlrFunc10 (
  SET_ELM_PLIST( t_5, 2, a_keyreq );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
- ENVI_FUNC( t_6 ) = CurrLVars;
+ ENVI_FUNC( t_6 ) = TLS(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_7) = INTOBJ_INT(766);
  ENDLINE_BODY(t_7) = INTOBJ_INT(787);
  FILENAME_BODY(t_7) = FileName;
  BODY_FUNC(t_6) = t_7;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* return; */
@@ -3170,13 +3170,13 @@ static Obj  HdlrFunc14 (
  t_4 = OBJ_LVAR( 2 );
  CHECK_BOUND( t_4, "reqs" )
  t_5 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
- ENVI_FUNC( t_5 ) = CurrLVars;
+ ENVI_FUNC( t_5 ) = TLS(CurrLVars);
  t_6 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_6) = INTOBJ_INT(835);
  ENDLINE_BODY(t_6) = INTOBJ_INT(851);
  FILENAME_BODY(t_6) = FileName;
  BODY_FUNC(t_5) = t_6;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_6ARGS( t_1, t_2, t_3, a_fampred, t_4, a_val, t_5 );
  
  /* return; */
@@ -3264,13 +3264,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 19, "RunImmediateMethods" );
  t_3 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(26);
  ENDLINE_BODY(t_4) = INTOBJ_INT(117);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "INSTALL_METHOD_FLAGS", function ( opr, info, rel, flags, rank, method )
@@ -3361,13 +3361,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 20, "INSTALL_METHOD_FLAGS" );
  t_3 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(124);
  ENDLINE_BODY(t_4) = INTOBJ_INT(235);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "InstallMethod", function ( arg )
@@ -3377,13 +3377,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "InstallMethod" );
  t_3 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(282);
  ENDLINE_BODY(t_4) = INTOBJ_INT(284);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "InstallOtherMethod", function ( arg )
@@ -3393,13 +3393,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 18, "InstallOtherMethod" );
  t_3 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(309);
  ENDLINE_BODY(t_4) = INTOBJ_INT(311);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* DeclareGlobalFunction( "EvalString" ); */
@@ -3550,13 +3550,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 14, "INSTALL_METHOD" );
  t_3 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(322);
  ENDLINE_BODY(t_4) = INTOBJ_INT(526);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + 6; */
@@ -3607,13 +3607,13 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_InstallAttributeFunction;
  t_2 = NewFunction( NameFunc[7], NargFunc[7], NamsFunc[7], HdlrFunc7 );
- ENVI_FUNC( t_2 ) = CurrLVars;
+ ENVI_FUNC( t_2 ) = TLS(CurrLVars);
  t_3 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_3) = INTOBJ_INT(545);
  ENDLINE_BODY(t_3) = INTOBJ_INT(599);
  FILENAME_BODY(t_3) = FileName;
  BODY_FUNC(t_2) = t_3;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
@@ -3622,13 +3622,13 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_InstallAttributeFunction;
  t_2 = NewFunction( NameFunc[9], NargFunc[9], NamsFunc[9], HdlrFunc9 );
- ENVI_FUNC( t_2 ) = CurrLVars;
+ ENVI_FUNC( t_2 ) = TLS(CurrLVars);
  t_3 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_3) = INTOBJ_INT(602);
  ENDLINE_BODY(t_3) = INTOBJ_INT(608);
  FILENAME_BODY(t_3) = FileName;
  BODY_FUNC(t_2) = t_3;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
  /* IsPrimeInt := "2b defined"; */
@@ -3680,13 +3680,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "KeyDependentOperation" );
  t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(728);
  ENDLINE_BODY(t_4) = INTOBJ_INT(788);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* CallFuncList := "2b defined"; */
@@ -3715,13 +3715,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "RedispatchOnCondition" );
  t_3 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(821);
  ENDLINE_BODY(t_4) = INTOBJ_INT(852);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* InstallMethod( ViewObj, "default method using `PrintObj'", true, [ IS_OBJECT ], 0, PRINT_OBJ ); */
@@ -4003,8 +4003,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = CurrLVars;
- CHANGED_BAG( CurrLVars );
+ ENVI_FUNC( func1 ) = TLS(CurrLVars);
+ CHANGED_BAG( TLS(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/src/c_random.c
+++ b/src/c_random.c
@@ -263,13 +263,13 @@ static Obj  HdlrFunc1 (
       return list[QUO_INT( R_X[R_N] * LEN_LIST( list ), R_228 ) + 1];
   end; */
  t_1 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(23);
  ENDLINE_BODY(t_2) = INTOBJ_INT(27);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_RANDOM__LIST, t_1 );
  
  /* RANDOM_SEED := function ( n )
@@ -286,13 +286,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_1 ) = CurrLVars;
+ ENVI_FUNC( t_1 ) = TLS(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_2) = INTOBJ_INT(29);
  ENDLINE_BODY(t_2) = INTOBJ_INT(39);
  FILENAME_BODY(t_2) = FileName;
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  AssGVar( G_RANDOM__SEED, t_1 );
  
  /* if R_X = [  ] then */
@@ -383,8 +383,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = CurrLVars;
- CHANGED_BAG( CurrLVars );
+ ENVI_FUNC( func1 ) = TLS(CurrLVars);
+ CHANGED_BAG( TLS(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -375,13 +375,13 @@ static Obj  HdlrFunc3 (
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
-  ENVI_FUNC( t_5 ) = CurrLVars;
+  ENVI_FUNC( t_5 ) = TLS(CurrLVars);
   t_6 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
   STARTLINE_BODY(t_6) = INTOBJ_INT(39);
   ENDLINE_BODY(t_6) = INTOBJ_INT(42);
   FILENAME_BODY(t_6) = FileName;
   BODY_FUNC(t_5) = t_6;
-  CHANGED_BAG( CurrLVars );
+  CHANGED_BAG( TLS(CurrLVars) );
   CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
   
  }
@@ -3839,13 +3839,13 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_InstallAttributeFunction;
  t_2 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_2 ) = CurrLVars;
+ ENVI_FUNC( t_2 ) = TLS(CurrLVars);
  t_3 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_3) = INTOBJ_INT(19);
  ENDLINE_BODY(t_3) = INTOBJ_INT(26);
  FILENAME_BODY(t_3) = FileName;
  BODY_FUNC(t_2) = t_3;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + 6; */
@@ -3868,13 +3868,13 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_InstallAttributeFunction;
  t_2 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_2 ) = CurrLVars;
+ ENVI_FUNC( t_2 ) = TLS(CurrLVars);
  t_3 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_3) = INTOBJ_INT(31);
  ENDLINE_BODY(t_3) = INTOBJ_INT(52);
  FILENAME_BODY(t_3) = FileName;
  BODY_FUNC(t_2) = t_3;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
  /* Subtype := "defined below"; */
@@ -3906,13 +3906,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NEW_FAMILY" );
  t_3 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(89);
  ENDLINE_BODY(t_4) = INTOBJ_INT(117);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily2", function ( typeOfFamilies, name )
@@ -3921,13 +3921,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NewFamily2" );
  t_3 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(120);
  ENDLINE_BODY(t_4) = INTOBJ_INT(125);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily3", function ( typeOfFamilies, name, req )
@@ -3936,13 +3936,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NewFamily3" );
  t_3 = NewFunction( NameFunc[7], NargFunc[7], NamsFunc[7], HdlrFunc7 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(128);
  ENDLINE_BODY(t_4) = INTOBJ_INT(133);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily4", function ( typeOfFamilies, name, req, imp )
@@ -3951,13 +3951,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NewFamily4" );
  t_3 = NewFunction( NameFunc[8], NargFunc[8], NamsFunc[8], HdlrFunc8 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(136);
  ENDLINE_BODY(t_4) = INTOBJ_INT(141);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily5", function ( typeOfFamilies, name, req, imp, filter )
@@ -3966,13 +3966,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NewFamily5" );
  t_3 = NewFunction( NameFunc[9], NargFunc[9], NamsFunc[9], HdlrFunc9 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(145);
  ENDLINE_BODY(t_4) = INTOBJ_INT(150);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily", function ( arg )
@@ -3992,13 +3992,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "NewFamily" );
  t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(153);
  ENDLINE_BODY(t_4) = INTOBJ_INT(176);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* NEW_TYPE_CACHE_MISS := 0; */
@@ -4051,13 +4051,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NEW_TYPE" );
  t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(204);
  ENDLINE_BODY(t_4) = INTOBJ_INT(259);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType2", function ( typeOfTypes, family )
@@ -4066,13 +4066,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType2" );
  t_3 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(263);
  ENDLINE_BODY(t_4) = INTOBJ_INT(268);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType3", function ( typeOfTypes, family, filter )
@@ -4081,13 +4081,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType3" );
  t_3 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(271);
  ENDLINE_BODY(t_4) = INTOBJ_INT(278);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType4", function ( typeOfTypes, family, filter, data )
@@ -4096,13 +4096,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType4" );
  t_3 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(281);
  ENDLINE_BODY(t_4) = INTOBJ_INT(288);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType5", function ( typeOfTypes, family, filter, data, stuff )
@@ -4114,13 +4114,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType5" );
  t_3 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(292);
  ENDLINE_BODY(t_4) = INTOBJ_INT(303);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType", function ( arg )
@@ -4144,13 +4144,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "NewType" );
  t_3 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(306);
  ENDLINE_BODY(t_4) = INTOBJ_INT(338);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Subtype2", function ( type, filter )
@@ -4166,13 +4166,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "Subtype2" );
  t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(351);
  ENDLINE_BODY(t_4) = INTOBJ_INT(365);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Subtype3", function ( type, filter, data )
@@ -4188,13 +4188,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "Subtype3" );
  t_3 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(368);
  ENDLINE_BODY(t_4) = INTOBJ_INT(382);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Unbind( Subtype ); */
@@ -4214,13 +4214,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "Subtype" );
  t_3 = NewFunction( NameFunc[19], NargFunc[19], NamsFunc[19], HdlrFunc19 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(386);
  ENDLINE_BODY(t_4) = INTOBJ_INT(400);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType2", function ( type, filter )
@@ -4236,13 +4236,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "SupType2" );
  t_3 = NewFunction( NameFunc[20], NargFunc[20], NamsFunc[20], HdlrFunc20 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(414);
  ENDLINE_BODY(t_4) = INTOBJ_INT(428);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType3", function ( type, filter, data )
@@ -4258,13 +4258,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "SupType3" );
  t_3 = NewFunction( NameFunc[21], NargFunc[21], NamsFunc[21], HdlrFunc21 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(431);
  ENDLINE_BODY(t_4) = INTOBJ_INT(445);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType", function ( arg )
@@ -4281,13 +4281,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "SupType" );
  t_3 = NewFunction( NameFunc[22], NargFunc[22], NamsFunc[22], HdlrFunc22 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(448);
  ENDLINE_BODY(t_4) = INTOBJ_INT(462);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FamilyType", function ( K )
@@ -4296,13 +4296,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "FamilyType" );
  t_3 = NewFunction( NameFunc[23], NargFunc[23], NamsFunc[23], HdlrFunc23 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(476);
  ENDLINE_BODY(t_4) = INTOBJ_INT(476);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FlagsType", function ( K )
@@ -4311,13 +4311,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "FlagsType" );
  t_3 = NewFunction( NameFunc[24], NargFunc[24], NamsFunc[24], HdlrFunc24 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(490);
  ENDLINE_BODY(t_4) = INTOBJ_INT(490);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "DataType", function ( K )
@@ -4326,13 +4326,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "DataType" );
  t_3 = NewFunction( NameFunc[25], NargFunc[25], NamsFunc[25], HdlrFunc25 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(506);
  ENDLINE_BODY(t_4) = INTOBJ_INT(506);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetDataType", function ( K, data )
@@ -4342,13 +4342,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 11, "SetDataType" );
  t_3 = NewFunction( NameFunc[26], NargFunc[26], NamsFunc[26], HdlrFunc26 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(508);
  ENDLINE_BODY(t_4) = INTOBJ_INT(510);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SharedType", function ( K )
@@ -4357,13 +4357,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "SharedType" );
  t_3 = NewFunction( NameFunc[27], NargFunc[27], NamsFunc[27], HdlrFunc27 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(524);
  ENDLINE_BODY(t_4) = INTOBJ_INT(524);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "TypeObj", TYPE_OBJ ); */
@@ -4386,13 +4386,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "FlagsObj" );
  t_3 = NewFunction( NameFunc[28], NargFunc[28], NamsFunc[28], HdlrFunc28 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(623);
  ENDLINE_BODY(t_4) = INTOBJ_INT(623);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "DataObj", function ( obj )
@@ -4401,13 +4401,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "DataObj" );
  t_3 = NewFunction( NameFunc[29], NargFunc[29], NamsFunc[29], HdlrFunc29 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(637);
  ENDLINE_BODY(t_4) = INTOBJ_INT(637);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SharedObj", function ( obj )
@@ -4416,13 +4416,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "SharedObj" );
  t_3 = NewFunction( NameFunc[30], NargFunc[30], NamsFunc[30], HdlrFunc30 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(651);
  ENDLINE_BODY(t_4) = INTOBJ_INT(651);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetTypeObj", function ( type, obj )
@@ -4442,13 +4442,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "SetTypeObj" );
  t_3 = NewFunction( NameFunc[31], NargFunc[31], NamsFunc[31], HdlrFunc31 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(665);
  ENDLINE_BODY(t_4) = INTOBJ_INT(678);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsNonAtomicComponentObjectRepFlags", FLAGS_FILTER( IsNonAtomicComponentObjectRep ) ); */
@@ -4507,13 +4507,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "ChangeTypeObj" );
  t_3 = NewFunction( NameFunc[32], NargFunc[32], NamsFunc[32], HdlrFunc32 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(702);
  ENDLINE_BODY(t_4) = INTOBJ_INT(717);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ReObjectify", ChangeTypeObj ); */
@@ -4565,13 +4565,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 12, "SetFilterObj" );
  t_3 = NewFunction( NameFunc[33], NargFunc[33], NamsFunc[33], HdlrFunc33 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(741);
  ENDLINE_BODY(t_4) = INTOBJ_INT(779);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SET_FILTER_OBJ", SetFilterObj ); */
@@ -4607,13 +4607,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 14, "ResetFilterObj" );
  t_3 = NewFunction( NameFunc[34], NargFunc[34], NamsFunc[34], HdlrFunc34 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(801);
  ENDLINE_BODY(t_4) = INTOBJ_INT(823);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "RESET_FILTER_OBJ", ResetFilterObj ); */
@@ -4634,13 +4634,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "SetFeatureObj" );
  t_3 = NewFunction( NameFunc[35], NargFunc[35], NamsFunc[35], HdlrFunc35 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(839);
  ENDLINE_BODY(t_4) = INTOBJ_INT(845);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetMultipleAttributes", function ( arg )
@@ -4687,13 +4687,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "SetMultipleAttributes" );
  t_3 = NewFunction( NameFunc[36], NargFunc[36], NamsFunc[36], HdlrFunc36 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(866);
  ENDLINE_BODY(t_4) = INTOBJ_INT(918);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
@@ -4766,13 +4766,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 23, "ObjectifyWithAttributes" );
  t_3 = NewFunction( NameFunc[37], NargFunc[37], NamsFunc[37], HdlrFunc37 );
- ENVI_FUNC( t_3 ) = CurrLVars;
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(965);
  ENDLINE_BODY(t_4) = INTOBJ_INT(1030);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( CurrLVars );
+ CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
@@ -5207,8 +5207,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = CurrLVars;
- CHANGED_BAG( CurrLVars );
+ ENVI_FUNC( func1 ) = TLS(CurrLVars);
+ CHANGED_BAG( TLS(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/src/calls.c
+++ b/src/calls.c
@@ -60,11 +60,13 @@
 #include        "string.h"              /* strings                         */
 
 #include        "code.h"                /* coder                           */
-#include        "vars.h"                /* variables                       */
 
 #include        "stats.h"               /* statements                      */
 
 #include        "saveload.h"            /* saving and loading              */
+#include        "tls.h"                 /* thread-local storage            */
+
+#include        "vars.h"                /* variables                       */
 
 #include <assert.h>
 

--- a/src/code.c
+++ b/src/code.c
@@ -133,24 +133,24 @@ Stat NewStatWithLine (
     Stat                stat;           /* result                          */
 
     /* this is where the new statement goes                                */
-    stat = OffsBody + FIRST_STAT_CURR_FUNC;
+    stat = TLS(OffsBody) + FIRST_STAT_CURR_FUNC;
 
     /* increase the offset                                                 */
-    OffsBody = stat + ((size+sizeof(Stat)-1) / sizeof(Stat)) * sizeof(Stat);
+    TLS(OffsBody) = stat + ((size+sizeof(Stat)-1) / sizeof(Stat)) * sizeof(Stat);
 
     /* make certain that the current body bag is large enough              */
     if ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) == 0 ) {
-      ResizeBag( BODY_FUNC(CURR_FUNC), OffsBody + NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
-        PtrBody = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
+      ResizeBag( BODY_FUNC(CURR_FUNC), TLS(OffsBody) + NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
+        TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
-    while ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) < OffsBody + NUMBER_HEADER_ITEMS_BODY*sizeof(Obj)  ) {
+    while ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) < TLS(OffsBody) + NUMBER_HEADER_ITEMS_BODY*sizeof(Obj)  ) {
         ResizeBag( BODY_FUNC(CURR_FUNC), 2*SIZE_BAG(BODY_FUNC(CURR_FUNC)) );
-        PtrBody = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
+        TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
-    setup_gapname(Input);
+    setup_gapname(TLS(Input));
     
     /* enter type and size                                                 */
-    ADDR_STAT(stat)[-1] = ((Stat)Input->gapnameid << 48) + ((Stat)line << 32) +
+    ADDR_STAT(stat)[-1] = ((Stat)TLS(Input)->gapnameid << 48) + ((Stat)line << 32) +
                           ((Stat)size << 8) + (Stat)type;
     RegisterStatWithProfiling(stat);
     /* return the new statement                                            */
@@ -161,7 +161,7 @@ Stat NewStat (
     UInt                type,
     UInt                size)
 {
-    return NewStatWithLine(type, size, Input->number);
+    return NewStatWithLine(type, size, TLS(Input)->number);
 }
 
 
@@ -179,24 +179,24 @@ Expr            NewExpr (
     Expr                expr;           /* result                          */
 
     /* this is where the new expression goes                               */
-    expr = OffsBody + FIRST_STAT_CURR_FUNC;
+    expr = TLS(OffsBody) + FIRST_STAT_CURR_FUNC;
 
     /* increase the offset                                                 */
-    OffsBody = expr + ((size+sizeof(Expr)-1) / sizeof(Expr)) * sizeof(Expr);
+    TLS(OffsBody) = expr + ((size+sizeof(Expr)-1) / sizeof(Expr)) * sizeof(Expr);
 
     /* make certain that the current body bag is large enough              */
     if ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) == 0 ) {
-        ResizeBag( BODY_FUNC(CURR_FUNC), OffsBody );
-        PtrBody = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
+        ResizeBag( BODY_FUNC(CURR_FUNC), TLS(OffsBody) );
+        TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
-    while ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) < OffsBody ) {
+    while ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) < TLS(OffsBody) ) {
         ResizeBag( BODY_FUNC(CURR_FUNC), 2*SIZE_BAG(BODY_FUNC(CURR_FUNC)) );
-        PtrBody = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
+        TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
 
     /* enter type and size                                                 */
-    ADDR_EXPR(expr)[-1] = ((Stat)Input->gapnameid << 48) +
-                          ((Stat)Input->number << 32) +
+    ADDR_EXPR(expr)[-1] = ((Stat)TLS(Input)->gapnameid << 48) +
+                          ((Stat)TLS(Input)->number << 32) +
                           ((Stat)size << 8) + type;
     RegisterStatWithProfiling(expr);
     /* return the new expression                                           */
@@ -240,17 +240,17 @@ void PushStat (
     Stat                stat )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( StackStat != 0 );
-    assert( 0 <= CountStat );
-    assert( CountStat <= SIZE_BAG(StackStat)/sizeof(Stat) );
+    assert( TLS(StackStat) != 0 );
+    assert( 0 <= TLS(CountStat) );
+    assert( TLS(CountStat) <= SIZE_BAG(TLS(StackStat))/sizeof(Stat) );
     assert( stat != 0 );
 
     /* count up and put the statement onto the stack                       */
-    if ( CountStat == SIZE_BAG(StackStat)/sizeof(Stat) ) {
-        ResizeBag( StackStat, 2*CountStat*sizeof(Stat) );
+    if ( TLS(CountStat) == SIZE_BAG(TLS(StackStat))/sizeof(Stat) ) {
+        ResizeBag( TLS(StackStat), 2*TLS(CountStat)*sizeof(Stat) );
     }
-    ((Stat*)PTR_BAG(StackStat))[CountStat] = stat;
-    CountStat++;
+    ((Stat*)PTR_BAG(TLS(StackStat)))[TLS(CountStat)] = stat;
+    TLS(CountStat)++;
 }
 
 Stat PopStat ( void )
@@ -258,13 +258,13 @@ Stat PopStat ( void )
     Stat                stat;
 
     /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( StackStat != 0 );
-    assert( 1 <= CountStat );
-    assert( CountStat <= SIZE_BAG(StackStat)/sizeof(Stat) );
+    assert( TLS(StackStat) != 0 );
+    assert( 1 <= TLS(CountStat) );
+    assert( TLS(CountStat) <= SIZE_BAG(TLS(StackStat))/sizeof(Stat) );
 
     /* get the top statement from the stack, and count down                */
-    CountStat--;
-    stat = ((Stat*)PTR_BAG(StackStat))[CountStat];
+    TLS(CountStat)--;
+    stat = ((Stat*)PTR_BAG(TLS(StackStat)))[TLS(CountStat)];
 
     /* return the popped statement                                         */
     return stat;
@@ -334,17 +334,17 @@ void PushExpr (
     Expr                expr )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( StackExpr != 0 );
-    assert( 0 <= CountExpr );
-    assert( CountExpr <= SIZE_BAG(StackExpr)/sizeof(Expr) );
+    assert( TLS(StackExpr) != 0 );
+    assert( 0 <= TLS(CountExpr) );
+    assert( TLS(CountExpr) <= SIZE_BAG(TLS(StackExpr))/sizeof(Expr) );
     assert( expr != 0 );
 
     /* count up and put the expression onto the stack                      */
-    if ( CountExpr == SIZE_BAG(StackExpr)/sizeof(Expr) ) {
-        ResizeBag( StackExpr, 2*CountExpr*sizeof(Expr) );
+    if ( TLS(CountExpr) == SIZE_BAG(TLS(StackExpr))/sizeof(Expr) ) {
+        ResizeBag( TLS(StackExpr), 2*TLS(CountExpr)*sizeof(Expr) );
     }
-    ((Expr*)PTR_BAG(StackExpr))[CountExpr] = expr;
-    CountExpr++;
+    ((Expr*)PTR_BAG(TLS(StackExpr)))[TLS(CountExpr)] = expr;
+    TLS(CountExpr)++;
 }
 
 Expr PopExpr ( void )
@@ -352,13 +352,13 @@ Expr PopExpr ( void )
     Expr                expr;
 
     /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( StackExpr != 0 );
-    assert( 1 <= CountExpr );
-    assert( CountExpr <= SIZE_BAG(StackExpr)/sizeof(Expr) );
+    assert( TLS(StackExpr) != 0 );
+    assert( 1 <= TLS(CountExpr) );
+    assert( TLS(CountExpr) <= SIZE_BAG(TLS(StackExpr))/sizeof(Expr) );
 
     /* get the top expression from the stack, and count down               */
-    CountExpr--;
-    expr = ((Expr*)PTR_BAG(StackExpr))[CountExpr];
+    TLS(CountExpr)--;
+    expr = ((Expr*)PTR_BAG(TLS(StackExpr)))[TLS(CountExpr)];
 
     /* return the popped expression                                        */
     return expr;
@@ -513,14 +513,14 @@ Bag CodeLVars;
 void CodeBegin ( void )
 {
     /* the stacks must be empty                                            */
-    assert( CountStat == 0 );
-    assert( CountExpr == 0 );
+    assert( TLS(CountStat) == 0 );
+    assert( TLS(CountExpr) == 0 );
 
     /* remember the current frame                                          */
-    CodeLVars = CurrLVars;
+    TLS(CodeLVars) = TLS(CurrLVars);
 
     /* clear the code result bag                                           */
-    CodeResult = 0;
+    TLS(CodeResult) = 0;
 }
 
 UInt CodeEnd (
@@ -530,24 +530,24 @@ UInt CodeEnd (
     if ( ! error ) {
 
         /* the stacks must be empty                                        */
-        assert( CountStat == 0 );
-        assert( CountExpr == 0 );
+        assert( TLS(CountStat) == 0 );
+        assert( TLS(CountExpr) == 0 );
 
-        /* we must be back to 'CurrLVars'                                  */
-        assert( CurrLVars == CodeLVars );
+        /* we must be back to 'TLS(CurrLVars)'                                  */
+        assert( TLS(CurrLVars) == TLS(CodeLVars) );
 
-        /* 'CodeFuncExprEnd' left the function already in 'CodeResult'     */
+        /* 'CodeFuncExprEnd' left the function already in 'TLS(CodeResult)'     */
     }
 
     /* otherwise clean up the mess                                         */
     else {
 
         /* empty the stacks                                                */
-        CountStat = 0;
-        CountExpr = 0;
+        TLS(CountStat) = 0;
+        TLS(CountExpr) = 0;
 
         /* go back to the correct frame                                    */
-        SWITCH_TO_OLD_LVARS( CodeLVars );
+        SWITCH_TO_OLD_LVARS( TLS(CodeLVars) );
     }
 
     /* return value is ignored                                             */
@@ -693,7 +693,7 @@ void CodeFuncExprBegin (
     OffsBody = 0;
 
     /* give it an environment                                              */
-    ENVI_FUNC( fexp ) = CurrLVars;
+    ENVI_FUNC( fexp ) = TLS(CurrLVars);
     CHANGED_BAG( fexp );
 
     /* switch to this function                                             */
@@ -768,7 +768,7 @@ void CodeFuncExprEnd (
 
     /* if this was inside another function definition, make the expression */
     /* and store it in the function expression list of the outer function  */
-    if ( CurrLVars != CodeLVars ) {
+    if ( TLS(CurrLVars) != CodeLVars ) {
         fexs = FEXS_FUNC( CURR_FUNC );
         len = LEN_PLIST( fexs );
         GROW_PLIST(      fexs, len+1 );
@@ -780,9 +780,9 @@ void CodeFuncExprEnd (
         PushExpr( expr );
     }
 
-    /* otherwise, make the function and store it in 'CodeResult'           */
+    /* otherwise, make the function and store it in 'TLS(CodeResult)'           */
     else {
-        CodeResult = MakeFunction( fexp );
+        TLS(CodeResult) = MakeFunction( fexp );
     }
 
 }
@@ -3353,8 +3353,8 @@ static Int InitKernel (
     InitGlobalBag( &FilenameCache, "FilenameCache" );
 
     /* allocate the statements and expressions stacks                      */
-    InitGlobalBag( &StackStat, "StackStat" );
-    InitGlobalBag( &StackExpr, "StackExpr" );
+    InitGlobalBag( &TLS(StackStat), "TLS(StackStat)" );
+    InitGlobalBag( &TLS(StackExpr), "TLS(StackExpr)" );
 
     /* some functions and globals needed for float conversion */
     InitCopyGVar( "EAGER_FLOAT_LITERAL_CACHE", &EAGER_FLOAT_LITERAL_CACHE);
@@ -3413,17 +3413,17 @@ static Int PreSave (
   UInt i;
 
   /* Can't save in mid-parsing */
-  if (CountExpr || CountStat)
+  if (TLS(CountExpr) || TLS(CountStat))
     return 1;
 
   /* push the FP cache index out into a GAP Variable */
   AssGVar(GVAR_SAVED_FLOAT_INDEX, INTOBJ_INT(NextFloatExprNumber));
 
   /* clean any old data out of the statement and expression stacks */
-  for (i = 0; i < SIZE_BAG(StackStat)/sizeof(UInt); i++)
-    ADDR_OBJ(StackStat)[i] = (Obj)0;
-  for (i = 0; i < SIZE_BAG(StackExpr)/sizeof(UInt); i++)
-    ADDR_OBJ(StackExpr)[i] = (Obj)0;
+  for (i = 0; i < SIZE_BAG(TLS(StackStat))/sizeof(UInt); i++)
+    ADDR_OBJ(TLS(StackStat))[i] = (Obj)0;
+  for (i = 0; i < SIZE_BAG(TLS(StackExpr))/sizeof(UInt); i++)
+    ADDR_OBJ(TLS(StackExpr))[i] = (Obj)0;
   /* return success                                                      */
   return 0;
 }

--- a/src/code.h
+++ b/src/code.h
@@ -219,7 +219,7 @@ Obj FILENAME_STAT(Stat stat);
 **  'ADDR_STAT' returns   the  absolute address of the    memory block of the
 **  statement <stat>.
 */
-#define ADDR_STAT(stat) ((Stat*)(((char*)PtrBody)+(stat)))
+#define ADDR_STAT(stat) ((Stat*)(((char*)TLS(PtrBody))+(stat)))
 
 
 /****************************************************************************

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -136,7 +136,7 @@ typedef UInt    RNam;
 #define SWITCH_TO_NEW_FRAME     SWITCH_TO_NEW_LVARS
 #define SWITCH_TO_OLD_FRAME     SWITCH_TO_OLD_LVARS
 
-#define CURR_FRAME              CurrLVars
+#define CURR_FRAME              TLS(CurrLVars)
 #define CURR_FRAME_1UP          ENVI_FUNC( PTR_BAG( CURR_FRAME     )[0] )
 #define CURR_FRAME_2UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_1UP )[0] )
 #define CURR_FRAME_3UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_2UP )[0] )
@@ -145,7 +145,7 @@ typedef UInt    RNam;
 #define CURR_FRAME_6UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_5UP )[0] )
 #define CURR_FRAME_7UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_6UP )[0] )
 
-/* #define OBJ_LVAR(lvar)  PtrLVars[(lvar)+2] */
+/* #define OBJ_LVAR(lvar)  TLS(PtrLVars)[(lvar)+2] */
 #define OBJ_LVAR_0UP(lvar) \
     OBJ_LVAR(lvar)
 #define OBJ_LVAR_1UP(lvar) \
@@ -165,7 +165,7 @@ typedef UInt    RNam;
 #define OBJ_LVAR_8UP(lvar) \
     PTR_BAG(CURR_FRAME_8UP)[(lvar)+2]
 
-/* #define ASS_LVAR(lvar,obj) do { PtrLVars[(lvar)+2] = (obj); } while ( 0 ) */
+/* #define ASS_LVAR(lvar,obj) do { TLS(PtrLVars)[(lvar)+2] = (obj); } while ( 0 ) */
 #define ASS_LVAR_0UP(lvar,obj) \
     ASS_LVAR(lvar,obj)
 #define ASS_LVAR_1UP(lvar,obj) \

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1268,7 +1268,7 @@ CVar CompFuncExpr (
     Emit( ", HdlrFunc%d );\n", nr );
 
     /* this should probably be done by 'NewFunction'                       */
-    Emit( "ENVI_FUNC( %c ) = CurrLVars;\n", func );
+    Emit( "ENVI_FUNC( %c ) = TLS(CurrLVars);\n", func );
     tmp = CVAR_TEMP( NewTemp( "body" ) );
     Emit( "%c = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );\n", tmp );
     Emit( "STARTLINE_BODY(%c) = INTOBJ_INT(%d);\n", tmp, INT_INTOBJ(STARTLINE_BODY(BODY_FUNC(fexp))));
@@ -1277,7 +1277,7 @@ CVar CompFuncExpr (
     Emit( "BODY_FUNC(%c) = %c;\n", func, tmp );
     FreeTemp( TEMP_CVAR( tmp ) );
 
-    Emit( "CHANGED_BAG( CurrLVars );\n" );
+    Emit( "CHANGED_BAG( TLS(CurrLVars) );\n" );
 
     /* we know that the result is a function                               */
     SetInfoCVar( func, W_FUNC );
@@ -5558,7 +5558,7 @@ void CompFunc (
     }
     else {
         Emit( "\n/* restoring old stack frame */\n" );
-        Emit( "oldFrame = CurrLVars;\n" );
+        Emit( "oldFrame = TLS(CurrLVars);\n" );
         Emit( "SWITCH_TO_OLD_FRAME(ENVI_FUNC(self));\n" );
     }
 
@@ -5743,8 +5743,8 @@ Int CompileFunc (
     }
     Emit( "\n/* create all the functions defined in this module */\n" );
     Emit( "func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);\n" );
-    Emit( "ENVI_FUNC( func1 ) = CurrLVars;\n" );
-    Emit( "CHANGED_BAG( CurrLVars );\n" );
+    Emit( "ENVI_FUNC( func1 ) = TLS(CurrLVars);\n" );
+    Emit( "CHANGED_BAG( TLS(CurrLVars) );\n" );
     Emit( "body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));\n" );
     Emit( "BODY_FUNC( func1 ) = body1;\n" );
     Emit( "CHANGED_BAG( func1 );\n");

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -380,19 +380,19 @@ Int             LtCycNot (
 **
 *F  ConvertToBase(<n>)  . . . . . . convert a cyclotomic into the base, local
 **
-**  'ConvertToBase'  converts the cyclotomic  'ResultCyc' from the cyclotomic
+**  'ConvertToBase'  converts the cyclotomic  'TLS(ResultCyc)' from the cyclotomic
 **  field  of <n>th roots of  unity, into the base  form.  This means that it
 **  replaces every root $e_n^i$ that does not belong to the  base by a sum of
 **  other roots that do.
 **
-**  Suppose that $c*e_n^i$ appears in 'ResultCyc' but $e_n^i$ does not lie in
+**  Suppose that $c*e_n^i$ appears in 'TLS(ResultCyc)' but $e_n^i$ does not lie in
 **  the base.  This happens  because, for some  prime $p$ dividing $n$,  with
 **  maximal power $q$, $i \in (n/q)*[-(q/p-1)/2..(q/p-1)/2]$ mod $q$.
 **
 **  We take the identity  $1+e_p+e_p^2+..+e_p^{p-1}=0$, write it  using $n$th
 **  roots of unity, $0=1+e_n^{n/p}+e_n^{2n/p}+..+e_n^{(p-1)n/p}$ and multiply
 **  it  by $e_n^i$,   $0=e_n^i+e_n^{n/p+i}+e_n^{2n/p+i}+..+e_n^{(p-1)n/p+i}$.
-**  Now we subtract $c$ times the left hand side from 'ResultCyc'.
+**  Now we subtract $c$ times the left hand side from 'TLS(ResultCyc)'.
 **
 **  If $p^2$  does not divide  $n$ then the roots  that are  not in the  base
 **  because of $p$ are those  whose exponent is divisable  by $p$.  But $n/p$
@@ -409,10 +409,10 @@ Int             LtCycNot (
 **  which remove the roots that are not in the base because of larger primes,
 **  will not add new roots that do not lie in the base because of $p$ again.
 **
-**  For an example, suppose 'ResultCyc' is $e_{45}+e_{45}^5 =: e+e^5$.  $e^5$
+**  For an example, suppose 'TLS(ResultCyc)' is $e_{45}+e_{45}^5 =: e+e^5$.  $e^5$
 **  does  not lie in the  base  because $5  \in 5*[-1,0,1]$  mod $9$ and also
 **  because it is  divisable  by 5.  After  subtracting  $e^5*(1+e_3+e_3^2) =
-**  e^5+e^{20}+e^{35}$ from  'ResultCyc' we get $e-e^{20}-e^{35}$.  Those two
+**  e^5+e^{20}+e^{35}$ from  'TLS(ResultCyc)' we get $e-e^{20}-e^{35}$.  Those two
 **  roots are  still not  in the  base because of  5.  But  after subtracting
 **  $-e^{20}*(1+e_5+e_5^2+e_5^3+e_5^4)=-e^{20}-e^{29}-e^{38}-e^2-e^{11}$  and
 **  $-e^{35}*(1+e_5+e_5^2+e_5^3+e_5^4)=-e^{35}-e^{44}-e^8-e^{17}-e^{26}$   we
@@ -442,7 +442,7 @@ void            ConvertToBase (
     Obj                 sum;            /* sum of two coefficients         */
 
     /* get a pointer to the cyclotomic and a copy of n to factor           */
-    res = &(ELM_PLIST( ResultCyc, 1 ));
+    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
     nn  = n;
 
     /* first handle 2                                                      */
@@ -459,9 +459,9 @@ void            ConvertToBase (
                     l = (k + n/2) % n;
                     if ( ! ARE_INTOBJS( res[l], res[k] )
                       || ! DIFF_INTOBJS( sum, res[l], res[k] ) ) {
-                        CHANGED_BAG( ResultCyc );
+                        CHANGED_BAG( TLS(ResultCyc) );
                         sum = DIFF( res[l], res[k] );
-                        res = &(ELM_PLIST( ResultCyc, 1 ));
+                        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
                     }
                     res[l] = sum;
                     res[k] = INTOBJ_INT(0);
@@ -474,9 +474,9 @@ void            ConvertToBase (
                     l = (k + n/2) % n;
                     if ( ! ARE_INTOBJS( res[l], res[k] )
                       || ! DIFF_INTOBJS( sum, res[l], res[k] ) ) {
-                        CHANGED_BAG( ResultCyc );
+                        CHANGED_BAG( TLS(ResultCyc) );
                         sum = DIFF( res[l], res[k] );
-                        res = &(ELM_PLIST( ResultCyc, 1 ));
+                        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
                     }
                     res[l] = sum;
                     res[k] = INTOBJ_INT(0);
@@ -506,9 +506,9 @@ void            ConvertToBase (
                     for ( l = k+n/p; l < k+n; l += n/p ) {
                         if ( ! ARE_INTOBJS( res[l%n], res[k] )
                           || ! DIFF_INTOBJS( sum, res[l%n], res[k] ) ) {
-                            CHANGED_BAG( ResultCyc );
+                            CHANGED_BAG( TLS(ResultCyc) );
                             sum = DIFF( res[l%n], res[k] );
-                            res = &(ELM_PLIST( ResultCyc, 1 ));
+                            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
                         }
                         res[l%n] = sum;
                     }
@@ -522,9 +522,9 @@ void            ConvertToBase (
                     for ( l = k+n/p; l < k+n; l += n/p ) {
                         if ( ! ARE_INTOBJS( res[l%n], res[k] )
                           || ! DIFF_INTOBJS( sum, res[l%n], res[k] ) ) {
-                            CHANGED_BAG( ResultCyc );
+                            CHANGED_BAG( TLS(ResultCyc) );
                             sum = DIFF( res[l%n], res[k] );
-                            res = &(ELM_PLIST( ResultCyc, 1 ));
+                            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
                         }
                         res[l%n] = sum;
                     }
@@ -535,7 +535,7 @@ void            ConvertToBase (
     }
 
     /* notify Gasman                                                       */
-    CHANGED_BAG( ResultCyc );
+    CHANGED_BAG( TLS(ResultCyc) );
 }
 
 
@@ -543,10 +543,10 @@ void            ConvertToBase (
 **
 *F  Cyclotomic(<n>,<m>) . . . . . . . . . . create a packed cyclotomic, local
 **
-**  'Cyclotomic'    reduces  the cyclotomic   'ResultCyc'   into the smallest
+**  'Cyclotomic'    reduces  the cyclotomic   'TLS(ResultCyc)'   into the smallest
 **  possible cyclotomic subfield and returns it in packed form.
 **
-**  'ResultCyc'  must   also    be already converted      into  the base   by
+**  'TLS(ResultCyc)'  must   also    be already converted      into  the base   by
 **  'ConvertToBase'.   <n> must be  the order of the  primitive root in which
 **  written.
 **
@@ -560,7 +560,7 @@ void            ConvertToBase (
 **  rational.  If this is the case 'Cyclotomic' reduces it into the rationals
 **  and returns it as a rational.
 **
-**  After 'Cyclotomic' has  done its work it clears  the 'ResultCyc'  bag, so
+**  After 'Cyclotomic' has  done its work it clears  the 'TLS(ResultCyc)'  bag, so
 **  that it only contains 'INTOBJ_INT(0)'.  Thus the arithmetic functions can
 **  use this buffer without clearing it first.
 **
@@ -592,7 +592,7 @@ Obj             Cyclotomic (
     static UInt         nrp;            /* number of its prime factors     */
 
     /* get a pointer to the cyclotomic and a copy of n to factor           */
-    res = &(ELM_PLIST( ResultCyc, 1 ));
+    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
 
     /* count the terms and compute the gcd of the exponents with n         */
     len = 0;
@@ -646,12 +646,12 @@ Obj             Cyclotomic (
         if ( nrp % 2 == 0 )
             res[0] = cof;
         else {
-            CHANGED_BAG( ResultCyc );
+            CHANGED_BAG( TLS(ResultCyc) );
             res[0] = DIFF( INTOBJ_INT(0), cof );
         }
         n = 1;
     }
-    CHANGED_BAG( ResultCyc );
+    CHANGED_BAG( TLS(ResultCyc) );
 
     /* for all primes $p$ try to reduce from $Q(e_n)$ into $Q(e_{n/p})$    */
     gcd = phi; s = len; while ( s != 0 ) { t = s; s = gcd % s; gcd = t; }
@@ -684,16 +684,16 @@ Obj             Cyclotomic (
                     res[i] = INTOBJ_INT( - INT_INTOBJ(cof) );
                     if ( ! IS_INTOBJ(cof)
                       || (cof == INTOBJ_INT(-(1L<<NR_SMALL_INT_BITS))) ) {
-                        CHANGED_BAG( ResultCyc );
+                        CHANGED_BAG( TLS(ResultCyc) );
                         cof = DIFF( INTOBJ_INT(0), cof );
-                        res = &(ELM_PLIST( ResultCyc, 1 ));
+                        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
                         res[i] = cof;
                     }
                     for ( k = i+n/p; k < i+n && eql; k += n/p )
                         res[k%n] = INTOBJ_INT(0);
                 }
                 len = len / (p-1);
-                CHANGED_BAG( ResultCyc );
+                CHANGED_BAG( TLS(ResultCyc) );
 
                 /* now replace $e_n^{i*p}$ by $e_{n/p}^{i}$                */
                 for ( i = 1; i < n/p; i++ ) {
@@ -714,7 +714,7 @@ Obj             Cyclotomic (
         res[0] = INTOBJ_INT(0);
     }
 
-    /* otherwise copy terms into a new 'T_CYC' bag and clear 'ResultCyc'   */
+    /* otherwise copy terms into a new 'T_CYC' bag and clear 'TLS(ResultCyc)'   */
     else {
         cyc = NewBag( T_CYC, (len+1)*(sizeof(Obj)+sizeof(UInt4)) );
         cfs = COEFS_CYC(cyc);
@@ -722,7 +722,7 @@ Obj             Cyclotomic (
         cfs[0] = INTOBJ_INT(n);
         exs[0] = 0;
         k = 1;
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         for ( i = 0; i < n; i++ ) {
             if ( res[i] != INTOBJ_INT(0) ) {
                 cfs[k] = res[i];
@@ -787,10 +787,10 @@ static UInt FindCommonField(UInt nl, UInt nr, UInt *ml, UInt *mr)
   *mr = n/nr;
 
   /* make sure that the result bag is large enough                      */
-  if ( LEN_PLIST(ResultCyc) < n ) {
-    GROW_PLIST( ResultCyc, n );
-    SET_LEN_PLIST( ResultCyc, n );
-    res = &(ELM_PLIST( ResultCyc, 1 ));
+  if ( LEN_PLIST(TLS(ResultCyc)) < n ) {
+    GROW_PLIST( TLS(ResultCyc), n );
+    SET_LEN_PLIST( TLS(ResultCyc), n );
+    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
     for ( i = 0; i < n; i++ ) { res[i] = INTOBJ_INT(0); }
   }
   return n;
@@ -871,15 +871,15 @@ Obj             SumCyc (
  
     /* Copy the left operand into the result                               */
     if ( TNUM_OBJ(opL) != T_CYC ) {
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         res[0] = opL;
-        CHANGED_BAG( ResultCyc );
+        CHANGED_BAG( TLS(ResultCyc) );
     }
     else {
         len = SIZE_CYC(opL);
         cfs = COEFS_CYC(opL);
         exs = EXPOS_CYC(opL,len);
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         if ( ml == 1 ) {
             for ( i = 1; i < len; i++ )
                 res[exs[i]] = cfs[i];
@@ -888,34 +888,34 @@ Obj             SumCyc (
             for ( i = 1; i < len; i++ )
                 res[exs[i]*ml] = cfs[i];
         }
-        CHANGED_BAG( ResultCyc );
+        CHANGED_BAG( TLS(ResultCyc) );
     }
 
     /* add the right operand to the result                                 */
     if ( TNUM_OBJ(opR) != T_CYC ) {
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         sum = SUM( res[0], opR );
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         res[0] = sum;
-        CHANGED_BAG( ResultCyc );
+        CHANGED_BAG( TLS(ResultCyc) );
     }
     else {
         len = SIZE_CYC(opR);
         cfs = COEFS_CYC(opR);
         exs = EXPOS_CYC(opR,len);
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         for ( i = 1; i < len; i++ ) {
             if ( ! ARE_INTOBJS( res[exs[i]*mr], cfs[i] )
               || ! SUM_INTOBJS( sum, res[exs[i]*mr], cfs[i] ) ) {
-                CHANGED_BAG( ResultCyc );
+                CHANGED_BAG( TLS(ResultCyc) );
                 sum = SUM( res[exs[i]*mr], cfs[i] );
                 cfs = COEFS_CYC(opR);
                 exs = EXPOS_CYC(opR,len);
-                res = &(ELM_PLIST( ResultCyc, 1 ));
+                res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
             }
             res[exs[i]*mr] = sum;
         }
-        CHANGED_BAG( ResultCyc );
+        CHANGED_BAG( TLS(ResultCyc) );
     }
 
     /* return the base reduced packed cyclotomic                           */
@@ -1015,15 +1015,15 @@ Obj             DiffCyc (
 
     /* copy the left operand into the result                               */
     if ( TNUM_OBJ(opL) != T_CYC ) {
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         res[0] = opL;
-        CHANGED_BAG( ResultCyc );
+        CHANGED_BAG( TLS(ResultCyc) );
     }
     else {
         len = SIZE_CYC(opL);
         cfs = COEFS_CYC(opL);
         exs = EXPOS_CYC(opL,len);
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         if ( ml == 1 ) {
             for ( i = 1; i < len; i++ )
                 res[exs[i]] = cfs[i];
@@ -1032,34 +1032,34 @@ Obj             DiffCyc (
             for ( i = 1; i < len; i++ )
                 res[exs[i]*ml] = cfs[i];
         }
-        CHANGED_BAG( ResultCyc );
+        CHANGED_BAG( TLS(ResultCyc) );
     }
 
     /* subtract the right operand from the result                          */
     if ( TNUM_OBJ(opR) != T_CYC ) {
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         sum = DIFF( res[0], opR );
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         res[0] = sum;
-        CHANGED_BAG( ResultCyc );
+        CHANGED_BAG( TLS(ResultCyc) );
     }
     else {
         len = SIZE_CYC(opR);
         cfs = COEFS_CYC(opR);
         exs = EXPOS_CYC(opR,len);
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         for ( i = 1; i < len; i++ ) {
             if ( ! ARE_INTOBJS( res[exs[i]*mr], cfs[i] )
               || ! DIFF_INTOBJS( sum, res[exs[i]*mr], cfs[i] ) ) {
-                CHANGED_BAG( ResultCyc );
+                CHANGED_BAG( TLS(ResultCyc) );
                 sum = DIFF( res[exs[i]*mr], cfs[i] );
                 cfs = COEFS_CYC(opR);
                 exs = EXPOS_CYC(opR,len);
-                res = &(ELM_PLIST( ResultCyc, 1 ));
+                res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
             }
             res[exs[i]*mr] = sum;
         }
-        CHANGED_BAG( ResultCyc );
+        CHANGED_BAG( TLS(ResultCyc) );
     }
 
     /* return the base reduced packed cyclotomic                           */
@@ -1221,19 +1221,19 @@ Obj             ProdCyc (
             len = SIZE_CYC(opL);
             cfs = COEFS_CYC(opL);
             exs = EXPOS_CYC(opL,len);
-            res = &(ELM_PLIST( ResultCyc, 1 ));
+            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
             for ( i = 1; i < len; i++ ) {
                 if ( ! ARE_INTOBJS( res[(e+exs[i]*ml)%n], cfs[i] )
                   || ! SUM_INTOBJS( sum, res[(e+exs[i]*ml)%n], cfs[i] ) ) {
-                    CHANGED_BAG( ResultCyc );
+                    CHANGED_BAG( TLS(ResultCyc) );
                     sum = SUM( res[(e+exs[i]*ml)%n], cfs[i] );
                     cfs = COEFS_CYC(opL);
                     exs = EXPOS_CYC(opL,len);
-                    res = &(ELM_PLIST( ResultCyc, 1 ));
+                    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
                 }
                 res[(e+exs[i]*ml)%n] = sum;
             }
-            CHANGED_BAG( ResultCyc );
+            CHANGED_BAG( TLS(ResultCyc) );
         }
 
         /* if the coefficient is -1 just subtract                          */
@@ -1241,19 +1241,19 @@ Obj             ProdCyc (
             len = SIZE_CYC(opL);
             cfs = COEFS_CYC(opL);
             exs = EXPOS_CYC(opL,len);
-            res = &(ELM_PLIST( ResultCyc, 1 ));
+            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
             for ( i = 1; i < len; i++ ) {
                 if ( ! ARE_INTOBJS( res[(e+exs[i]*ml)%n], cfs[i] )
                   || ! DIFF_INTOBJS( sum, res[(e+exs[i]*ml)%n], cfs[i] ) ) {
-                    CHANGED_BAG( ResultCyc );
+                    CHANGED_BAG( TLS(ResultCyc) );
                     sum = DIFF( res[(e+exs[i]*ml)%n], cfs[i] );
                     cfs = COEFS_CYC(opL);
                     exs = EXPOS_CYC(opL,len);
-                    res = &(ELM_PLIST( ResultCyc, 1 ));
+                    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
                 }
                 res[(e+exs[i]*ml)%n] = sum;
             }
-            CHANGED_BAG( ResultCyc );
+            CHANGED_BAG( TLS(ResultCyc) );
         }
 
         /* if the coefficient is a small integer use immediate operations  */
@@ -1261,40 +1261,40 @@ Obj             ProdCyc (
             len = SIZE_CYC(opL);
             cfs = COEFS_CYC(opL);
             exs = EXPOS_CYC(opL,len);
-            res = &(ELM_PLIST( ResultCyc, 1 ));
+            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
             for ( i = 1; i < len; i++ ) {
                 if ( ! ARE_INTOBJS( cfs[i], res[(e+exs[i]*ml)%n] )
                   || ! PROD_INTOBJS( prd, cfs[i], c )
                   || ! SUM_INTOBJS( sum, res[(e+exs[i]*ml)%n], prd ) ) {
-                    CHANGED_BAG( ResultCyc );
+                    CHANGED_BAG( TLS(ResultCyc) );
                     prd = PROD( cfs[i], c );
                     exs = EXPOS_CYC(opL,len);
-                    res = &(ELM_PLIST( ResultCyc, 1 ));
+                    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
                     sum = SUM( res[(e+exs[i]*ml)%n], prd );
                     cfs = COEFS_CYC(opL);
                     exs = EXPOS_CYC(opL,len);
-                    res = &(ELM_PLIST( ResultCyc, 1 ));
+                    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
                 }
                 res[(e+exs[i]*ml)%n] = sum;
             }
-            CHANGED_BAG( ResultCyc );
+            CHANGED_BAG( TLS(ResultCyc) );
         }
 
         /* otherwise do it the normal way                                  */
         else {
             len = SIZE_CYC(opL);
             for ( i = 1; i < len; i++ ) {
-                CHANGED_BAG( ResultCyc );
+                CHANGED_BAG( TLS(ResultCyc) );
                 cfs = COEFS_CYC(opL);
                 prd = PROD( cfs[i], c );
                 exs = EXPOS_CYC(opL,len);
-                res = &(ELM_PLIST( ResultCyc, 1 ));
+                res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
                 sum = SUM( res[(e+exs[i]*ml)%n], prd );
                 exs = EXPOS_CYC(opL,len);
-                res = &(ELM_PLIST( ResultCyc, 1 ));
+                res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
                 res[(e+exs[i]*ml)%n] = sum;
             }
-            CHANGED_BAG( ResultCyc );
+            CHANGED_BAG( TLS(ResultCyc) );
         }
 
     }
@@ -1363,10 +1363,10 @@ Obj             InvCyc (
             /* permute the terms                                           */
             cfs = COEFS_CYC(op);
             exs = EXPOS_CYC(op,len);
-            res = &(ELM_PLIST( ResultCyc, 1 ));
+            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
             for ( k = 1; k < len; k++ )
                 res[(i*exs[k])%n] = cfs[k];
-            CHANGED_BAG( ResultCyc );
+            CHANGED_BAG( TLS(ResultCyc) );
 
             /* if n is squarefree conversion and reduction are unnecessary */
             if ( n < sqr*sqr ) {
@@ -1418,12 +1418,12 @@ Obj             PowCyc (
     }
 
     /* for $e_n^exp$ just put a 1 at the <exp>th position and convert      */
-    else if ( opL == LastECyc ) {
-        exp = (exp % LastNCyc + LastNCyc) % LastNCyc;
-        SET_ELM_PLIST( ResultCyc, exp, INTOBJ_INT(1) );
-        CHANGED_BAG( ResultCyc );
-        ConvertToBase( LastNCyc );
-        pow = Cyclotomic( LastNCyc, 1 );
+    else if ( opL == TLS(LastECyc) ) {
+        exp = (exp % TLS(LastNCyc) + TLS(LastNCyc)) % TLS(LastNCyc);
+        SET_ELM_PLIST( TLS(ResultCyc), exp, INTOBJ_INT(1) );
+        CHANGED_BAG( TLS(ResultCyc) );
+        ConvertToBase( TLS(LastNCyc) );
+        pow = Cyclotomic( TLS(LastNCyc), 1 );
     }
 
     /* for $(c*e_n^i)^exp$ if $e_n^i$ belongs to the base put 1 at $i*exp$ */
@@ -1431,9 +1431,9 @@ Obj             PowCyc (
         n = INT_INTOBJ( NOF_CYC(opL) );
         pow = POW( COEFS_CYC(opL)[1], opR );
         i = EXPOS_CYC(opL,2)[1];
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         res[((exp*i)%n+n)%n] = pow;
-        CHANGED_BAG( ResultCyc );
+        CHANGED_BAG( TLS(ResultCyc) );
         ConvertToBase( n );
         pow = Cyclotomic( n, 1 );
     }
@@ -1880,11 +1880,11 @@ Obj FuncGALOIS_CYC (
         len = SIZE_CYC(cyc);
         cfs = COEFS_CYC(cyc);
         exs = EXPOS_CYC(cyc,len);
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         for ( i = 1; i < len; i++ ) {
             res[(UInt8)exs[i]*(UInt8)o%(UInt8)n] = cfs[i];
         }
-        CHANGED_BAG( ResultCyc );
+        CHANGED_BAG( TLS(ResultCyc) );
 
         /* if n is squarefree conversion and reduction are unnecessary     */
         if ( n < sqr*sqr || (o == n-1 && n % 2 != 0) ) {
@@ -1904,19 +1904,19 @@ Obj FuncGALOIS_CYC (
         len = SIZE_CYC(cyc);
         cfs = COEFS_CYC(cyc);
         exs = EXPOS_CYC(cyc,len);
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         for ( i = 1; i < len; i++ ) {
             if ( ! ARE_INTOBJS( res[(UInt8)exs[i]*(UInt8)o%(UInt8)n], cfs[i] )
               || ! SUM_INTOBJS( sum, res[(UInt8)exs[i]*(UInt8)o%(UInt8)n], cfs[i] ) ) {
-                CHANGED_BAG( ResultCyc );
+                CHANGED_BAG( TLS(ResultCyc) );
                 sum = SUM( res[(UInt8)exs[i]*(UInt8)o%(UInt8)n], cfs[i] );
                 cfs = COEFS_CYC(cyc);
                 exs = EXPOS_CYC(cyc,len);
-                res = &(ELM_PLIST( ResultCyc, 1 ));
+                res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
             }
             res[exs[i]*o%n] = sum;
         }
-        CHANGED_BAG( ResultCyc );
+        CHANGED_BAG( TLS(ResultCyc) );
 
         /* if n is squarefree conversion and reduction are unnecessary     */
         if ( n < sqr*sqr ) {
@@ -1977,7 +1977,7 @@ Obj FuncCycList (
     }
 
     /* transfer the coefficients into the buffer                           */
-    res = &(ELM_PLIST( ResultCyc, 1 ));
+    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
     for ( i = 0; i < n; i++ ) {
         val = ELM_PLIST( list, i+1 );
         if ( ! ( TNUM_OBJ(val) == T_INT ||
@@ -1991,7 +1991,7 @@ Obj FuncCycList (
     }
 
     /* return the base reduced packed cyclotomic                           */
-    CHANGED_BAG( ResultCyc );
+    CHANGED_BAG( TLS(ResultCyc) );
     ConvertToBase( n );
     return Cyclotomic( n, 1 );
 }

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -1502,23 +1502,23 @@ Obj FuncE (
         return INTOBJ_INT(-1);
 
     /* if the root is not known already construct it                       */
-    if ( LastNCyc != INT_INTOBJ(n) ) {
-        LastNCyc = INT_INTOBJ(n);
-        if ( LEN_PLIST(ResultCyc) < LastNCyc ) {
-            GROW_PLIST( ResultCyc, LastNCyc );
-            SET_LEN_PLIST( ResultCyc, LastNCyc );
-            res = &(ELM_PLIST( ResultCyc, 1 ));
-            for ( i = 0; i < LastNCyc; i++ ) { res[i] = INTOBJ_INT(0); }
+    if ( TLS(LastNCyc) != INT_INTOBJ(n) ) {
+        TLS(LastNCyc) = INT_INTOBJ(n);
+        if ( LEN_PLIST(TLS(ResultCyc)) < TLS(LastNCyc) ) {
+            GROW_PLIST( TLS(ResultCyc), TLS(LastNCyc) );
+            SET_LEN_PLIST( TLS(ResultCyc), TLS(LastNCyc) );
+            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+            for ( i = 0; i < TLS(LastNCyc); i++ ) { res[i] = INTOBJ_INT(0); }
         }
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         res[1] = INTOBJ_INT(1);
-        CHANGED_BAG( ResultCyc );
-        ConvertToBase( LastNCyc );
-        LastECyc = Cyclotomic( LastNCyc, 1 );
+        CHANGED_BAG( TLS(ResultCyc) );
+        ConvertToBase( TLS(LastNCyc) );
+        TLS(LastECyc) = Cyclotomic( TLS(LastNCyc), 1 );
     }
 
     /* return the root                                                     */
-    return LastECyc;
+    return TLS(LastECyc);
 }
 
 
@@ -1969,10 +1969,10 @@ Obj FuncCycList (
 
     /* enlarge the buffer if necessary                                     */
     n = LEN_PLIST( list );
-    if ( LEN_PLIST(ResultCyc) < n ) {
-        GROW_PLIST( ResultCyc, n );
-        SET_LEN_PLIST( ResultCyc, n );
-        res = &(ELM_PLIST( ResultCyc, 1 ));
+    if ( LEN_PLIST(TLS(ResultCyc)) < n ) {
+        GROW_PLIST( TLS(ResultCyc), n );
+        SET_LEN_PLIST( TLS(ResultCyc), n );
+        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
         for ( i = 0; i < n; i++ ) { res[i] = INTOBJ_INT(0); }
     }
 
@@ -2150,8 +2150,8 @@ static StructGVarFunc GVarFuncs [] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
-  LastECyc = (Obj)0;
-  LastNCyc = 0;
+    TLS(LastECyc) = (Obj)0;
+    TLS(LastNCyc) = 0;
   
     /* install the marking function                                        */
     InfoBags[ T_CYC ].name = "cyclotomic";
@@ -2247,9 +2247,9 @@ static Int InitLibrary (
     UInt                i;              /* loop variable                   */
 
     /* create the result buffer                                            */
-    ResultCyc = NEW_PLIST( T_PLIST, 1024 );
-    SET_LEN_PLIST( ResultCyc, 1024 );
-    res = &(ELM_PLIST( ResultCyc, 1 ));
+    TLS(ResultCyc) = NEW_PLIST( T_PLIST, 1024 );
+    SET_LEN_PLIST( TLS(ResultCyc), 1024 );
+    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
     for ( i = 0; i < 1024; i++ ) { res[i] = INTOBJ_INT(0); }
 
     /* init filters and functions                                          */

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -68,8 +68,8 @@
 #endif
 #ifndef NO_LVAR_CHECKS
 #define OBJ_REFLVAR(expr)       \
-                        (*(Obj*)(((char*)PtrLVars)+(expr)+5) != 0 ? \
-                         *(Obj*)(((char*)PtrLVars)+(expr)+5) : \
+                        (*(Obj*)(((char*)TLS(PtrLVars))+(expr)+5) != 0 ? \
+                         *(Obj*)(((char*)TLS(PtrLVars))+(expr)+5) : \
                          ObjLVar( LVAR_REFLVAR( expr ) ) )
 #endif
 */

--- a/src/exprs.h
+++ b/src/exprs.h
@@ -37,8 +37,8 @@
 #endif
 
 #define OBJ_REFLVAR(expr)       \
-                        (*(Obj*)(((char*)PtrLVars)+OFFSET_REFLVAR(expr)) != 0 ? \
-                         *(Obj*)(((char*)PtrLVars)+OFFSET_REFLVAR(expr)) : \
+                        (*(Obj*)(((char*)TLS(PtrLVars))+OFFSET_REFLVAR(expr)) != 0 ? \
+                         *(Obj*)(((char*)TLS(PtrLVars))+OFFSET_REFLVAR(expr)) : \
                          ObjLVar( LVAR_REFLVAR( expr ) ) )
 #endif
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -795,7 +795,7 @@ static inline void CheckRecursionBefore( void )
 #define CHECK_RECURSION_BEFORE CheckRecursionBefore(); PROF_IN_FUNCTION(func);
 
 
-#define CHECK_RECURSION_AFTER     RecursionDepth--; PROF_OUT_FUNCTION(func);   
+#define CHECK_RECURSION_AFTER     TLS(RecursionDepth)--; PROF_OUT_FUNCTION(func);   
 
 
 Obj DoExecFunc0args (
@@ -906,8 +906,8 @@ Obj             DoExecFunc2args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = ReturnObjStat;
-        ReturnObjStat = (Obj)0;
+        returnObjStat = TLS(ReturnObjStat);
+        TLS(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -141,7 +141,7 @@ UInt            ExecProccall0args (
     else {
       CALL_0ARGS( func );
     }
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -169,7 +169,7 @@ UInt            ExecProccall1args (
       SET_BRK_CALL_TO( call );
       CALL_1ARGS( func, arg1 );
     } 
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -199,7 +199,7 @@ UInt            ExecProccall2args (
       SET_BRK_CALL_TO( call );
       CALL_2ARGS( func, arg1, arg2 );
     }
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -231,7 +231,7 @@ UInt            ExecProccall3args (
       SET_BRK_CALL_TO( call );
       CALL_3ARGS( func, arg1, arg2, arg3 );
     }
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -265,7 +265,7 @@ UInt            ExecProccall4args (
       SET_BRK_CALL_TO( call );
       CALL_4ARGS( func, arg1, arg2, arg3, arg4 );
     }
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -307,7 +307,7 @@ UInt            ExecProccall5args (
       SET_BRK_CALL_TO( call );
       CALL_5ARGS( func, arg1, arg2, arg3, arg4, arg5 );
     }
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -345,7 +345,7 @@ UInt            ExecProccall6args (
       SET_BRK_CALL_TO( call );
       CALL_6ARGS( func, arg1, arg2, arg3, arg4, arg5, arg6 );
     }
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -383,7 +383,7 @@ UInt            ExecProccallXargs (
       CALL_XARGS( func, args );
     }
 
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -449,7 +449,7 @@ Obj             EvalFunccall0args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_0ARGS( func );
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -481,7 +481,7 @@ Obj             EvalFunccall1args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_1ARGS( func, arg1 );
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -516,7 +516,7 @@ Obj             EvalFunccall2args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_2ARGS( func, arg1, arg2 );
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -553,7 +553,7 @@ Obj             EvalFunccall3args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_3ARGS( func, arg1, arg2, arg3 );
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -591,7 +591,7 @@ Obj             EvalFunccall4args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_4ARGS( func, arg1, arg2, arg3, arg4 );
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -632,7 +632,7 @@ Obj             EvalFunccall5args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_5ARGS( func, arg1, arg2, arg3, arg4, arg5 );
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -675,7 +675,7 @@ Obj             EvalFunccall6args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_6ARGS( func, arg1, arg2, arg3, arg4, arg5, arg6 );
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -716,7 +716,7 @@ Obj             EvalFunccallXargs (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_XARGS( func, args );
-    if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -752,7 +752,7 @@ Obj             EvalFunccallXargs (
 **  'DoExecFunc<i>args' first switches  to a new  values bag.  Then it enters
 **  the arguments <arg1>, <arg2>, and so on in this new  values bag.  Then it
 **  executes  the function body.   After  that it  switches back  to  the old
-**  values bag.  Finally it returns the result from 'ReturnObjStat'.
+**  values bag.  Finally it returns the result from 'TLS(ReturnObjStat)'.
 **
 **  Note that these functions are never called directly, they are only called
 **  through the function call mechanism.
@@ -771,21 +771,21 @@ static void RecursionDepthTrap( void )
      * when quit-ting a higher level brk-loop to a lower level one.
      * Therefore we don't do anything if  RecursionDepth <= 0
     */
-    if (RecursionDepth > 0) {
-        recursionDepth = RecursionDepth;
-        RecursionDepth = 0;
+    if (TLS(RecursionDepth) > 0) {
+        recursionDepth = TLS(RecursionDepth);
+        TLS(RecursionDepth) = 0;
         ErrorReturnVoid( "recursion depth trap (%d)\n",         
                          (Int)recursionDepth, 0L,               
                          "you may 'return;'" );
-        RecursionDepth = recursionDepth;
+        TLS(RecursionDepth) = recursionDepth;
     }
 }
      
 static inline void CheckRecursionBefore( void )
 {
-    RecursionDepth++;                                           
+    TLS(RecursionDepth)++;                                           
     if ( RecursionTrapInterval &&                                
-         0 == (RecursionDepth % RecursionTrapInterval) )
+         0 == (TLS(RecursionDepth) % RecursionTrapInterval) )
       RecursionDepthTrap();
 }
 
@@ -828,8 +828,8 @@ Obj DoExecFunc0args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = ReturnObjStat;
-        ReturnObjStat = (Obj)0;
+        returnObjStat = TLS(ReturnObjStat);
+        TLS(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -866,8 +866,8 @@ Obj             DoExecFunc1args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = ReturnObjStat;
-        ReturnObjStat = (Obj)0;
+        returnObjStat = TLS(ReturnObjStat);
+        TLS(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -948,8 +948,8 @@ Obj             DoExecFunc3args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = ReturnObjStat;
-        ReturnObjStat = (Obj)0;
+        returnObjStat = TLS(ReturnObjStat);
+        TLS(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -992,8 +992,8 @@ Obj             DoExecFunc4args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = ReturnObjStat;
-        ReturnObjStat = (Obj)0;
+        returnObjStat = TLS(ReturnObjStat);
+        TLS(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1038,8 +1038,8 @@ Obj             DoExecFunc5args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = ReturnObjStat;
-        ReturnObjStat = (Obj)0;
+        returnObjStat = TLS(ReturnObjStat);
+        TLS(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1086,8 +1086,8 @@ Obj             DoExecFunc6args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = ReturnObjStat;
-        ReturnObjStat = (Obj)0;
+        returnObjStat = TLS(ReturnObjStat);
+        TLS(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1138,8 +1138,8 @@ Obj             DoExecFuncXargs (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = ReturnObjStat;
-        ReturnObjStat = (Obj)0;
+        returnObjStat = TLS(ReturnObjStat);
+        TLS(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1192,8 +1192,8 @@ Obj DoPartialUnWrapFunc(Obj func, Obj args) {
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = ReturnObjStat;
-        ReturnObjStat = (Obj)0;
+        returnObjStat = TLS(ReturnObjStat);
+        TLS(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }  
 }
@@ -1231,9 +1231,9 @@ Obj             MakeFunction (
     /* install the things an interpreted function needs                    */
     NLOC_FUNC( func ) = NLOC_FUNC( fexp );
     BODY_FUNC( func ) = BODY_FUNC( fexp );
-    ENVI_FUNC( func ) = CurrLVars;
-    /* the 'CHANGED_BAG(CurrLVars)' is needed because it is delayed        */
-    CHANGED_BAG( CurrLVars );
+    ENVI_FUNC( func ) = TLS(CurrLVars);
+    /* the 'CHANGED_BAG(TLS(CurrLVars))' is needed because it is delayed        */
+    CHANGED_BAG( TLS(CurrLVars) );
     FEXS_FUNC( func ) = FEXS_FUNC( fexp );
 
     /* return the function                                                 */
@@ -1374,12 +1374,12 @@ void            ExecBegin ( Obj frame )
     /* remember the old execution state                                    */
     execState = NewBag( T_PLIST, 4*sizeof(Obj) );
     ADDR_OBJ(execState)[0] = (Obj)3;
-    ADDR_OBJ(execState)[1] = ExecState;
-    ADDR_OBJ(execState)[2] = CurrLVars;
-    /* the 'CHANGED_BAG(CurrLVars)' is needed because it is delayed        */
-    CHANGED_BAG( CurrLVars );
-    ADDR_OBJ(execState)[3] = INTOBJ_INT((Int)CurrStat);
-    ExecState = execState;
+    ADDR_OBJ(execState)[1] = TLS(ExecState);
+    ADDR_OBJ(execState)[2] = TLS(CurrLVars);
+    /* the 'CHANGED_BAG(TLS(CurrLVars))' is needed because it is delayed        */
+    CHANGED_BAG( TLS(CurrLVars) );
+    ADDR_OBJ(execState)[3] = INTOBJ_INT((Int)TLS(CurrStat));
+    TLS(ExecState) = execState;
 
     /* set up new state                                                    */
     SWITCH_TO_OLD_LVARS( frame );
@@ -1393,12 +1393,12 @@ void            ExecEnd (
     if ( ! error ) {
 
         /* the state must be primal again                                  */
-        assert( CurrStat  == 0 );
+        assert( TLS(CurrStat)  == 0 );
 
         /* switch back to the old state                                    */
-        SET_BRK_CURR_STAT( (Stat)INT_INTOBJ((ADDR_OBJ(ExecState)[3]) ));
-        SWITCH_TO_OLD_LVARS( ADDR_OBJ(ExecState)[2] );
-        ExecState = ADDR_OBJ(ExecState)[1];
+        SET_BRK_CURR_STAT( (Stat)INT_INTOBJ((ADDR_OBJ(TLS(ExecState))[3]) ));
+        SWITCH_TO_OLD_LVARS( ADDR_OBJ(TLS(ExecState))[2] );
+        TLS(ExecState) = ADDR_OBJ(TLS(ExecState))[1];
 
     }
 
@@ -1406,9 +1406,9 @@ void            ExecEnd (
     else {
 
         /* switch back to the old state                                    */
-        SET_BRK_CURR_STAT( (Stat)INT_INTOBJ((ADDR_OBJ(ExecState)[3]) ));
-        SWITCH_TO_OLD_LVARS( ADDR_OBJ(ExecState)[2] );
-        ExecState = ADDR_OBJ(ExecState)[1];
+        SET_BRK_CURR_STAT( (Stat)INT_INTOBJ((ADDR_OBJ(TLS(ExecState))[3]) ));
+        SWITCH_TO_OLD_LVARS( ADDR_OBJ(TLS(ExecState))[2] );
+        TLS(ExecState) = ADDR_OBJ(TLS(ExecState))[1];
 
     }
 }

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -32,7 +32,7 @@ extern  Obj             MakeFunction (
 /****************************************************************************
 **
 *F  ExecBegin( <frame> ) . . . . . . . . .begin an execution in context frame
-**  if in doubt, pass BottomLVars as <frame>
+**  if in doubt, pass TLS(BottomLVars) as <frame>
 **
 *F  ExecEnd(<error>)  . . . . . . . . . . . . . . . . . . .  end an execution
 */

--- a/src/gap.c
+++ b/src/gap.c
@@ -763,13 +763,13 @@ int main (
        ErrorCount = 0; */
   NrImportedGVars = 0;
   NrImportedFuncs = 0;
-  UserHasQUIT = 0;
+  TLS(UserHasQUIT) = 0;
   SystemErrorCode = 0;
-  UserHasQuit = 0;
+  TLS(UserHasQuit) = 0;
     
   /* initialize everything and read init.g which runs the GAP session */
   InitializeGap( &argc, argv );
-  if (!UserHasQUIT) {           /* maybe the user QUIT from the initial
+  if (!TLS(UserHasQUIT)) {           /* maybe the user QUIT from the initial
                                    read of init.g  somehow*/
     /* maybe compile in which case init.g got skipped */
     if ( SyCompilePlease ) {
@@ -1261,22 +1261,22 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
       }
     else 
       plain_args = args;
-    memcpy((void *)&readJmpError, (void *)&ReadJmpError, sizeof(syJmp_buf));
+    memcpy((void *)&readJmpError, (void *)&TLS(ReadJmpError), sizeof(syJmp_buf));
     currLVars = TLS(CurrLVars);
-    currStat = CurrStat;
-    recursionDepth = RecursionDepth;
+    currStat = TLS(CurrStat);
+    recursionDepth = TLS(RecursionDepth);
     res = NEW_PLIST(T_PLIST_DENSE+IMMUTABLE,2);
-    if (sySetjmp(ReadJmpError)) {
+    if (sySetjmp(TLS(ReadJmpError))) {
       SET_LEN_PLIST(res,2);
       SET_ELM_PLIST(res,1,False);
-      SET_ELM_PLIST(res,2,ThrownObject);
+      SET_ELM_PLIST(res,2,TLS(ThrownObject));
       CHANGED_BAG(res);
-      ThrownObject = 0;
+      TLS(ThrownObject) = 0;
       TLS(CurrLVars) = currLVars;
-      PtrLVars = PTR_BAG(TLS(CurrLVars));
-      PtrBody = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
-      CurrStat = currStat;
-      RecursionDepth = recursionDepth;
+      TLS(PtrLVars) = PTR_BAG(TLS(CurrLVars));
+      TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+      TLS(CurrStat) = currStat;
+      TLS(RecursionDepth) = recursionDepth;
     } else {
       switch (LEN_PLIST(plain_args)) {
       case 0: result = CALL_0ARGS(func);
@@ -1379,7 +1379,7 @@ Obj CallErrorInner (
   l = NEW_PLIST(T_PLIST_HOM+IMMUTABLE, 1);
   SET_ELM_PLIST(l,1,EarlyMsg);
   SET_LEN_PLIST(l,1);
-  SET_BRK_CALL_TO(CurrStat);
+  SET_BRK_CALL_TO(TLS(CurrStat));
   return CALL_2ARGS(ErrorInner,r,l);  
 }
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -169,7 +169,7 @@ void ViewObjHandler ( Obj obj )
   cfunc = ValAutoGVar(CustomViewGVar);
 
   /* if non-zero use this function, otherwise use `PrintObj'             */
-  memcpy( readJmpError, ReadJmpError, sizeof(syJmp_buf) );
+  memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
   if ( ! READ_ERROR() ) {
     if ( cfunc != 0 && TNUM_OBJ(cfunc) == T_FUNCTION ) {
       CALL_1ARGS(cfunc, obj);
@@ -181,10 +181,10 @@ void ViewObjHandler ( Obj obj )
       PrintObj( obj );
     }
     Pr( "\n", 0L, 0L );
-    memcpy( ReadJmpError, readJmpError, sizeof(syJmp_buf) );
+    memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
   }
   else {
-    memcpy( ReadJmpError, readJmpError, sizeof(syJmp_buf) );
+    memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
   }
 }
 
@@ -240,12 +240,12 @@ Obj Shell ( Obj context,
   Obj oldShellContext;
   Obj oldBaseShellContext;
   Int oldRecursionDepth;
-  oldShellContext = ShellContext;
-  ShellContext = context;
-  oldBaseShellContext = BaseShellContext;
-  BaseShellContext = context;
-  ShellContextDepth = 0;
-  oldRecursionDepth = RecursionDepth;
+  oldShellContext = TLS(ShellContext);
+  TLS(ShellContext) = context;
+  oldBaseShellContext = TLS(BaseShellContext);
+  TLS(BaseShellContext) = context;
+  TLS(ShellContextDepth) = 0;
+  oldRecursionDepth = TLS(RecursionDepth);
   
   /* read-eval-print loop                                                */
   if (!OpenOutput(outFile))
@@ -257,10 +257,10 @@ Obj Shell ( Obj context,
       ErrorMayQuit("SHELL: can't open infile %s",(Int)inFile,0);
     }
   
-  oldPrintDepth = PrintObjDepth;
-  PrintObjDepth = 0;
-  oldindent = Output->indent;
-  Output->indent = 0;
+  oldPrintDepth = TLS(PrintObjDepth);
+  TLS(PrintObjDepth) = 0;
+  oldindent = TLS(Output)->indent;
+  TLS(Output)->indent = 0;
 
   while ( 1 ) {
 
@@ -269,11 +269,11 @@ Obj Shell ( Obj context,
       time = SyTime();
 
     /* read and evaluate one command                                   */
-    Prompt = prompt;
+    TLS(Prompt) = prompt;
     ClearError();
-    PrintObjDepth = 0;
-    Output->indent = 0;
-    RecursionDepth = 0;
+    TLS(PrintObjDepth) = 0;
+    TLS(Output)->indent = 0;
+    TLS(RecursionDepth) = 0;
       
     /* here is a hook: */
     if (preCommandHook) {
@@ -285,19 +285,19 @@ Obj Shell ( Obj context,
         {
           Call0ArgsInNewReader(preCommandHook);
           /* Recover from a potential break loop: */
-          Prompt = prompt;
+          TLS(Prompt) = prompt;
           ClearError();
         }
     }
 
     /* now  read and evaluate and view one command  */
-    status = ReadEvalCommand(ShellContext, &dualSemicolon);
-    if (UserHasQUIT)
+    status = ReadEvalCommand(TLS(ShellContext), &dualSemicolon);
+    if (TLS(UserHasQUIT))
       break;
 
 
     /* handle ordinary command                                         */
-    if ( status == STATUS_END && ReadEvalResult != 0 ) {
+    if ( status == STATUS_END && TLS(ReadEvalResult) != 0 ) {
 
       /* remember the value in 'last'    */
       if (lastDepth >= 3)
@@ -305,11 +305,11 @@ Obj Shell ( Obj context,
       if (lastDepth >= 2)
         AssGVar( Last2, VAL_GVAR( Last  ) );
       if (lastDepth >= 1)
-        AssGVar( Last,  ReadEvalResult   );
+        AssGVar( Last,  TLS(ReadEvalResult)   );
 
       /* print the result                                            */
       if ( ! dualSemicolon ) {
-        ViewObjHandler( ReadEvalResult );
+        ViewObjHandler( TLS(ReadEvalResult) );
       }
             
     }
@@ -331,14 +331,14 @@ Obj Shell ( Obj context,
     
     /* handle quit command or <end-of-file>                            */
     else if ( status & (STATUS_EOF | STATUS_QUIT ) ) {
-      RecursionDepth = 0;
-      UserHasQuit = 1;
+      TLS(RecursionDepth) = 0;
+      TLS(UserHasQuit) = 1;
       break;
     }
         
     /* handle QUIT */
     else if (status & (STATUS_QQUIT)) {
-      UserHasQUIT = 1;
+      TLS(UserHasQUIT) = 1;
       break;
     }
         
@@ -346,26 +346,26 @@ Obj Shell ( Obj context,
     if (setTime)
       AssGVar( Time, INTOBJ_INT( SyTime() - time ) );
 
-    if (UserHasQuit)
+    if (TLS(UserHasQuit))
       {
         FlushRestOfInputLine();
-        UserHasQuit = 0;        /* quit has done its job if we are here */
+        TLS(UserHasQuit) = 0;        /* quit has done its job if we are here */
       }
 
   }
   
-  PrintObjDepth = oldPrintDepth;
-  Output->indent = oldindent;
+  TLS(PrintObjDepth) = oldPrintDepth;
+  TLS(Output)->indent = oldindent;
   CloseInput();
   CloseOutput();
-  BaseShellContext = oldBaseShellContext;
-  ShellContext = oldShellContext;
-  RecursionDepth = oldRecursionDepth;
-  if (UserHasQUIT)
+  TLS(BaseShellContext) = oldBaseShellContext;
+  TLS(ShellContext) = oldShellContext;
+  TLS(RecursionDepth) = oldRecursionDepth;
+  if (TLS(UserHasQUIT))
     {
       if (catchQUIT)
         {
-          UserHasQUIT = 0;
+          TLS(UserHasQUIT) = 0;
           MakeReadWriteGVar(QUITTINGGVar);
           AssGVar(QUITTINGGVar, True);
           MakeReadOnlyGVar(QUITTINGGVar);
@@ -389,7 +389,7 @@ Obj Shell ( Obj context,
     {
       res = NEW_PLIST(T_PLIST_HOM,1);
       SET_LEN_PLIST(res,1);
-      SET_ELM_PLIST(res,1,ReadEvalResult);
+      SET_ELM_PLIST(res,1,TLS(ReadEvalResult));
       return res;
     }
   assert(0); 
@@ -489,7 +489,7 @@ Obj FuncSHELL (Obj self, Obj args)
   res =  Shell(context, canReturnVoid, canReturnObj, lastDepth, setTime, promptBuffer, preCommandHook, catchQUIT,
                CSTR_STRING(infile), CSTR_STRING(outfile));
 
-  UserHasQuit = 0;
+  TLS(UserHasQuit) = 0;
   return res;
 }
 #ifdef HAVE_REALPATH
@@ -1124,29 +1124,29 @@ extern Obj BottomLVars;
 void DownEnvInner( Int depth )
 {
   /* if we really want to go up                                          */
-  if ( depth < 0 && -ErrorLLevel <= -depth ) {
+  if ( depth < 0 && -TLS(ErrorLLevel) <= -depth ) {
     depth = 0;
-    ErrorLVars = ErrorLVars0;
-    ErrorLLevel = 0;
-    ShellContextDepth = 0;
-    ShellContext = BaseShellContext;
+    TLS(ErrorLVars) = TLS(ErrorLVars0);
+    TLS(ErrorLLevel) = 0;
+    TLS(ShellContextDepth) = 0;
+    TLS(ShellContext) = TLS(BaseShellContext);
   }
   else if ( depth < 0 ) {
-    depth = -ErrorLLevel + depth;
-    ErrorLVars = ErrorLVars0;
-    ErrorLLevel = 0;
-    ShellContextDepth = 0;
-    ShellContext = BaseShellContext;
+    depth = -TLS(ErrorLLevel) + depth;
+    TLS(ErrorLVars) = TLS(ErrorLVars0);
+    TLS(ErrorLLevel) = 0;
+    TLS(ShellContextDepth) = 0;
+    TLS(ShellContext) = TLS(BaseShellContext);
   }
   
   /* now go down                                                         */
   while ( 0 < depth
-          && ErrorLVars != BottomLVars
-          && PTR_BAG(ErrorLVars)[2] != BottomLVars ) {
-    ErrorLVars = PTR_BAG(ErrorLVars)[2];
-    ErrorLLevel--;
-    ShellContext = PTR_BAG(ShellContext)[2];
-    ShellContextDepth--;
+          && TLS(ErrorLVars) != TLS(BottomLVars)
+          && PTR_BAG(TLS(ErrorLVars))[2] != TLS(BottomLVars) ) {
+    TLS(ErrorLVars) = PTR_BAG(TLS(ErrorLVars))[2];
+    TLS(ErrorLLevel)--;
+    TLS(ShellContext) = PTR_BAG(TLS(ShellContext))[2];
+    TLS(ShellContextDepth)--;
     depth--;
   }
 }
@@ -1167,7 +1167,7 @@ Obj FuncDownEnv (
     ErrorQuit( "usage: DownEnv( [ <depth> ] )", 0L, 0L );
     return 0;
   }
-  if ( ErrorLVars == 0 ) {
+  if ( TLS(ErrorLVars) == 0 ) {
     Pr( "not in any function\n", 0L, 0L );
     return 0;
   }
@@ -1193,7 +1193,7 @@ Obj FuncUpEnv (
     ErrorQuit( "usage: UpEnv( [ <depth> ] )", 0L, 0L );
     return 0;
   }
-  if ( ErrorLVars == 0 ) {
+  if ( TLS(ErrorLVars) == 0 ) {
     Pr( "not in any function\n", 0L, 0L );
     return 0;
   }
@@ -1205,9 +1205,9 @@ Obj FuncUpEnv (
 
 Obj FuncPrintExecutingStatement(Obj self, Obj context)
 {
-  Obj currLVars = CurrLVars;
+  Obj currLVars = TLS(CurrLVars);
   Expr call;
-  if (context == BottomLVars)
+  if (context == TLS(BottomLVars))
     return (Obj) 0;
   SWITCH_TO_OLD_LVARS(context);
   call = BRK_CALL_TO();
@@ -1262,7 +1262,7 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
     else 
       plain_args = args;
     memcpy((void *)&readJmpError, (void *)&ReadJmpError, sizeof(syJmp_buf));
-    currLVars = CurrLVars;
+    currLVars = TLS(CurrLVars);
     currStat = CurrStat;
     recursionDepth = RecursionDepth;
     res = NEW_PLIST(T_PLIST_DENSE+IMMUTABLE,2);
@@ -1272,8 +1272,8 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
       SET_ELM_PLIST(res,2,ThrownObject);
       CHANGED_BAG(res);
       ThrownObject = 0;
-      CurrLVars = currLVars;
-      PtrLVars = PTR_BAG(CurrLVars);
+      TLS(CurrLVars) = currLVars;
+      PtrLVars = PTR_BAG(TLS(CurrLVars));
       PtrBody = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
       CurrStat = currStat;
       RecursionDepth = recursionDepth;
@@ -1314,14 +1314,14 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
       else
         SET_LEN_PLIST(res,1);
     }
-    memcpy((void *)&ReadJmpError, (void *)&readJmpError, sizeof(syJmp_buf));
+    memcpy((void *)&TLS(ReadJmpError), (void *)&readJmpError, sizeof(syJmp_buf));
     return res;
 }
 
 Obj FuncJUMP_TO_CATCH( Obj self, Obj payload)
 {
-  ThrownObject = payload;
-  syLongjmp(ReadJmpError, 1);
+  TLS(ThrownObject) = payload;
+  syLongjmp(TLS(ReadJmpError), 1);
   return 0;
 }
   
@@ -1332,9 +1332,9 @@ UInt SystemErrorCode;
 
 Obj FuncSetUserHasQuit( Obj Self, Obj value)
 {
-  UserHasQuit = INT_INTOBJ(value);
-  if (UserHasQuit)
-    RecursionDepth = 0;
+  TLS(UserHasQuit) = INT_INTOBJ(value);
+  if (TLS(UserHasQuit))
+    TLS(RecursionDepth) = 0;
   return 0;
 }
 
@@ -1370,7 +1370,7 @@ Obj CallErrorInner (
   Obj r = NEW_PREC(0);
   Obj l;
   EarlyMsg = ErrorMessageToGAPString(msg, arg1, arg2);
-  AssPRec(r, RNamName("context"), CurrLVars);
+  AssPRec(r, RNamName("context"), TLS(CurrLVars));
   AssPRec(r, RNamName("justQuit"), justQuit? True : False);
   AssPRec(r, RNamName("mayReturnObj"), mayReturnObj? True : False);
   AssPRec(r, RNamName("mayReturnVoid"), mayReturnVoid? True : False);
@@ -1668,7 +1668,7 @@ Obj FuncLOAD_DYN (
 
     /* Start a new executor to run the outer function of the module
        in global context */
-    ExecBegin( BottomLVars );
+    ExecBegin( TLS(BottomLVars) );
     res = res || (info->initLibrary)(info);
     ExecEnd(res ? STATUS_ERROR : STATUS_END);
     if ( res ) {
@@ -1747,7 +1747,7 @@ Obj FuncLOAD_STAT (
     UpdateCopyFopyInfo();
     /* Start a new executor to run the outer function of the module
        in global context */
-    ExecBegin( BottomLVars );
+    ExecBegin( TLS(BottomLVars) );
     res = res || (info->initLibrary)(info);
     ExecEnd(res ? STATUS_ERROR : STATUS_END);
     if ( res ) {
@@ -2657,7 +2657,7 @@ Obj FuncQUIT_GAP( Obj self, Obj args )
     ErrorQuit( "usage: QUIT_GAP( [ <return value> ] )", 0L, 0L );
     return 0;
   }
-  UserHasQUIT = 1;
+  TLS(UserHasQUIT) = 1;
   ReadEvalError();
   return (Obj)0; 
 }

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -301,13 +301,13 @@ Obj CurrNamespace = 0;
 
 Obj FuncSET_NAMESPACE(Obj self, Obj str)
 {
-    CurrNamespace = str;
+    TLS(CurrNamespace) = str;
     return 0;
 }
 
 Obj FuncGET_NAMESPACE(Obj self)
 {
-    return CurrNamespace;
+    return TLS(CurrNamespace);
 }
 
 /****************************************************************************

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -332,7 +332,7 @@ UInt GVarName (
     Int                 len;            /* length of name                  */
 
     /* First see whether it could be namespace-local: */
-    cns = CSTR_STRING(CurrNamespace);
+    cns = CSTR_STRING(TLS(CurrNamespace));
     if (*cns) {   /* only if a namespace is set */
         len = strlen(name);
         if (name[len-1] == NSCHAR) {
@@ -1191,8 +1191,8 @@ static Int InitLibrary (
     SET_LEN_PLIST( TableGVars, SizeGVars );
 
     /* Create the current namespace: */
-    CurrNamespace = NEW_STRING(0);
-    SET_LEN_STRING(CurrNamespace,0);
+    TLS(CurrNamespace) = NEW_STRING(0);
+    SET_LEN_STRING(TLS(CurrNamespace),0);
     
     /* fix C vars                                                          */
     PostRestore( module );

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -424,7 +424,7 @@ void            IntrFuncCallEnd (
       else if ( 6 == nr ) { val = CALL_6ARGS( func, a1, a2, a3, a4, a5, a6 ); }
       else                { val = CALL_XARGS( func, args ); }
 
-      if (UserHasQuit || UserHasQUIT) /* the procedure must have called
+      if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
                                          READ() and the user quit from a break
                                          loop inside it */
         ReadEvalError();
@@ -2960,8 +2960,8 @@ void            IntrAssDVar (
 
     /* assign the right hand side                                          */
     currLVars = TLS(CurrLVars);
-    SWITCH_TO_OLD_LVARS( ErrorLVars );
-    SWITCH_TO_OLD_LVARS( ErrorLVars );
+    SWITCH_TO_OLD_LVARS( TLS(ErrorLVars) );
+    SWITCH_TO_OLD_LVARS( TLS(ErrorLVars) );
     while (depth--)
       SWITCH_TO_OLD_LVARS( PTR_BAG(TLS(CurrLVars)) [2] );
     ASS_HVAR( dvar, rhs );

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -72,7 +72,7 @@ extern UInt IntrReturning;
 *F  IntrEnd(<error>)  . . . . . . . . . . . . . . . . . . stop an interpreter
 **
 **  'IntrBegin( <frame> )' starts a new interpreter in context <frame>
-**  if in doubt, pass BottomLVars as <frame>
+**  if in doubt, pass TLS(BottomLVars) as <frame>
 **
 **  'IntrEnd(<error>)' stops the current interpreter.
 **

--- a/src/lists.c
+++ b/src/lists.c
@@ -2106,14 +2106,14 @@ void            PrintListDefault (
     }
 
     Pr("%2>[ %2>",0L,0L);
-    for ( PrintObjIndex=1; PrintObjIndex<=LEN_LIST(list); PrintObjIndex++ ) {
-        elm = ELMV0_LIST( list, PrintObjIndex );
+    for ( TLS(PrintObjIndex)=1; TLS(PrintObjIndex)<=LEN_LIST(list); TLS(PrintObjIndex)++ ) {
+        elm = ELMV0_LIST( list, TLS(PrintObjIndex) );
         if ( elm != 0 ) {
-            if ( 1 < PrintObjIndex )  Pr( "%<,%< %2>", 0L, 0L );
+            if ( 1 < TLS(PrintObjIndex) )  Pr( "%<,%< %2>", 0L, 0L );
             PrintObj( elm );
         }
         else {
-            if ( 1 < PrintObjIndex )  Pr( "%2<,%2>", 0L, 0L );
+            if ( 1 < TLS(PrintObjIndex) )  Pr( "%2<,%2>", 0L, 0L );
         }
     }
     Pr(" %4<]",0L,0L);

--- a/src/objccoll-impl.h
+++ b/src/objccoll-impl.h
@@ -16,7 +16,7 @@
 */
 #define SC_PUSH_WORD( word, exp ) \
     if ( ++sp == max ) { \
-        SC_MAX_STACK_SIZE *= 2; \
+        TLS(SC_MAX_STACK_SIZE) *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(word); \
@@ -27,7 +27,7 @@
 
 #define SC_PUSH_GEN( gen, exp ) \
     if ( ++sp == max ) { \
-        SC_MAX_STACK_SIZE *= 2; \
+        TLS(SC_MAX_STACK_SIZE) *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(gen); \
@@ -186,22 +186,22 @@ Int CombiCollectWord ( Obj sc, Obj vv, Obj w )
     exps = 1UL << (ebits-1);
 
     /* <nw> contains the stack of words to insert                          */
-    vnw = SC_NW_STACK;
+    vnw = TLS(SC_NW_STACK);
 
     /* <lw> contains the word end of the word in <nw>                      */
-    vlw = SC_LW_STACK;
+    vlw = TLS(SC_LW_STACK);
 
     /* <pw> contains the position of the word in <nw> to look at           */
-    vpw = SC_PW_STACK;
+    vpw = TLS(SC_PW_STACK);
 
     /* <ew> contains the unprocessed exponents at position <pw>            */
-    vew = SC_EW_STACK;
+    vew = TLS(SC_EW_STACK);
 
     /* <ge> contains the global exponent of the word                       */
-    vge = SC_GE_STACK;
+    vge = TLS(SC_GE_STACK);
 
     /* get the maximal stack size                                          */
-    max = SC_MAX_STACK_SIZE;
+    max = TLS(SC_MAX_STACK_SIZE);
 
     /* ensure that the stacks are large enough                             */
     if ( SIZE_OBJ(vnw)/sizeof(Obj) < max+1 ) {

--- a/src/objects.c
+++ b/src/objects.c
@@ -854,29 +854,29 @@ void            PrintObj (
 
     lastPV = LastPV;
     LastPV = 1;
-    fromview = (lastPV == 2) && (obj == PrintObjThis);
+    fromview = (lastPV == 2) && (obj == TLS(PrintObjThis));
     
     /* if <obj> is a subobject, then mark and remember the superobject
        unless ViewObj has done that job already */
     
-    if ( !fromview  && 0 < PrintObjDepth ) {
-        if ( IS_MARKABLE(PrintObjThis) )  MARK( PrintObjThis );
-        PrintObjThiss[PrintObjDepth-1]   = PrintObjThis;
-        PrintObjIndices[PrintObjDepth-1] = PrintObjIndex;
+    if ( !fromview  && 0 < TLS(PrintObjDepth) ) {
+        if ( IS_MARKABLE(TLS(PrintObjThis)) )  MARK( TLS(PrintObjThis) );
+        TLS(PrintObjThiss)[TLS(PrintObjDepth)-1]   = TLS(PrintObjThis);
+        TLS(PrintObjIndices)[TLS(PrintObjDepth)-1] = TLS(PrintObjIndex);
     }
 
     /* handle the <obj>                                                    */
     if (!fromview)
       {
-	PrintObjDepth += 1;
-	PrintObjThis   = obj;
-	PrintObjIndex  = 0;
+	TLS(PrintObjDepth) += 1;
+	TLS(PrintObjThis)   = obj;
+	TLS(PrintObjIndex)  = 0;
       }
 
     /* dispatch to the appropriate printing function                       */
-    if ( (! IS_MARKED( PrintObjThis )) ) {
-      if (PrintObjDepth < MAXPRINTDEPTH) {
-        (*PrintObjFuncs[ TNUM_OBJ(PrintObjThis) ])( PrintObjThis );
+    if ( (! IS_MARKED( TLS(PrintObjThis) )) ) {
+      if (TLS(PrintObjDepth) < MAXPRINTDEPTH) {
+        (*PrintObjFuncs[ TNUM_OBJ(TLS(PrintObjThis)) ])( TLS(PrintObjThis) );
       }
       else {
         /* don't recurse if depth too high */
@@ -980,21 +980,21 @@ void            ViewObj (
     LastPV = 2;
     
     /* if <obj> is a subobject, then mark and remember the superobject     */
-    if ( 0 < PrintObjDepth ) {
-        if ( IS_MARKABLE(PrintObjThis) )  MARK( PrintObjThis );
-        PrintObjThiss[PrintObjDepth-1]   = PrintObjThis;
-        PrintObjIndices[PrintObjDepth-1] =  PrintObjIndex;
+    if ( 0 < TLS(PrintObjDepth) ) {
+        if ( IS_MARKABLE(TLS(PrintObjThis)) )  MARK( TLS(PrintObjThis) );
+        TLS(PrintObjThiss)[TLS(PrintObjDepth)-1]   = TLS(PrintObjThis);
+        TLS(PrintObjIndices)[TLS(PrintObjDepth)-1] =  TLS(PrintObjIndex);
     }
 
     /* handle the <obj>                                                    */
-    PrintObjDepth += 1;
-    PrintObjThis   = obj;
-    PrintObjIndex  = 0;
+    TLS(PrintObjDepth) += 1;
+    TLS(PrintObjThis)   = obj;
+    TLS(PrintObjIndex)  = 0;
 
     /* dispatch to the appropriate viewing function                       */
 
-    if ( ! IS_MARKED( PrintObjThis ) ) {
-      if (PrintObjDepth < MAXPRINTDEPTH) {
+    if ( ! IS_MARKED( TLS(PrintObjThis) ) ) {
+      if (TLS(PrintObjDepth) < MAXPRINTDEPTH) {
         DoOperation1Args( ViewObjOper, obj );
       }
       else {

--- a/src/objects.c
+++ b/src/objects.c
@@ -812,8 +812,8 @@ static inline UInt IS_MARKED( Obj obj )
   UInt i;
   if (!IS_MARKABLE(obj))
     return 0;
-  for (i = 0; i < PrintObjDepth-1; i++)
-    if (PrintObjThiss[i] == obj)
+  for (i = 0; i < TLS(PrintObjDepth)-1; i++)
+    if (TLS(PrintObjThiss)[i] == obj)
       return 1;
   return 0;
 }
@@ -840,13 +840,13 @@ void            PrintObj (
 
     /* check for interrupts                                                */
     if ( SyIsIntr() ) {
-        i = PrintObjDepth;
+        i = TLS(PrintObjDepth);
         Pr( "%c%c", (Int)'\03', (Int)'\04' );
         ErrorReturnVoid(
             "user interrupt while printing",
             0L, 0L,
             "you can 'return;'" );
-        PrintObjDepth = i;
+        TLS(PrintObjDepth) = i;
     }
 
     /* First check if <obj> is actually the current object being Viewed
@@ -887,9 +887,9 @@ void            PrintObj (
     /* or print the path                                                   */
     else {
         Pr( "~", 0L, 0L );
-        for ( i = 0; PrintObjThis != PrintObjThiss[i]; i++ ) {
-            (*PrintPathFuncs[ TNUM_OBJ(PrintObjThiss[i])])
-                ( PrintObjThiss[i], PrintObjIndices[i] );
+        for ( i = 0; TLS(PrintObjThis) != TLS(PrintObjThiss)[i]; i++ ) {
+            (*PrintPathFuncs[ TNUM_OBJ(TLS(PrintObjThiss)[i])])
+                ( TLS(PrintObjThiss)[i], TLS(PrintObjIndices)[i] );
         }
     }
 
@@ -897,13 +897,13 @@ void            PrintObj (
     /* done with <obj>                                                     */
     if (!fromview)
       {
-	PrintObjDepth -= 1;
+	TLS(PrintObjDepth) -= 1;
 	
 	/* if <obj> is a subobject, then restore and unmark the superobject    */
-	if ( 0 < PrintObjDepth ) {
-	  PrintObjThis  = PrintObjThiss[PrintObjDepth-1];
-	  PrintObjIndex = PrintObjIndices[PrintObjDepth-1];
-	  if ( IS_MARKED(PrintObjThis) )  UNMARK( PrintObjThis );
+	if ( 0 < TLS(PrintObjDepth) ) {
+	  TLS(PrintObjThis)  = TLS(PrintObjThiss)[TLS(PrintObjDepth)-1];
+	  TLS(PrintObjIndex) = TLS(PrintObjIndices)[TLS(PrintObjDepth)-1];
+	  if ( IS_MARKED(TLS(PrintObjThis)) )  UNMARK( TLS(PrintObjThis) );
 	}
       }
     LastPV = lastPV;
@@ -953,7 +953,7 @@ Obj PrintObjHandler (
 Obj FuncSET_PRINT_OBJ_INDEX (Obj self, Obj ind)
 {
   if (IS_INTOBJ(ind))
-    PrintObjIndex = INT_INTOBJ(ind);
+    TLS(PrintObjIndex) = INT_INTOBJ(ind);
   return 0;
 }
 
@@ -1006,20 +1006,20 @@ void            ViewObj (
     /* or view the path                                                   */
     else {
         Pr( "~", 0L, 0L );
-        for ( i = 0; PrintObjThis != PrintObjThiss[i]; i++ ) {
-            (*PrintPathFuncs[ TNUM_OBJ(PrintObjThiss[i]) ])
-                ( PrintObjThiss[i], PrintObjIndices[i] );
+        for ( i = 0; TLS(PrintObjThis) != TLS(PrintObjThiss)[i]; i++ ) {
+            (*PrintPathFuncs[ TNUM_OBJ(TLS(PrintObjThiss)[i]) ])
+                ( TLS(PrintObjThiss)[i], TLS(PrintObjIndices)[i] );
         }
     }
 
     /* done with <obj>                                                     */
-    PrintObjDepth -= 1;
+    TLS(PrintObjDepth) -= 1;
 
     /* if <obj> is a subobject, then restore and unmark the superobject    */
-    if ( 0 < PrintObjDepth ) {
-        PrintObjThis  = PrintObjThiss[PrintObjDepth-1];
-        PrintObjIndex = PrintObjIndices[PrintObjDepth-1];
-        if ( IS_MARKED(PrintObjThis) )  UNMARK( PrintObjThis );
+    if ( 0 < TLS(PrintObjDepth) ) {
+        TLS(PrintObjThis)  = TLS(PrintObjThiss)[TLS(PrintObjDepth)-1];
+        TLS(PrintObjIndex) = TLS(PrintObjIndices)[TLS(PrintObjDepth)-1];
+        if ( IS_MARKED(TLS(PrintObjThis)) )  UNMARK( TLS(PrintObjThis) );
     }
 
     LastPV = lastPV;

--- a/src/objscoll-impl.h
+++ b/src/objscoll-impl.h
@@ -116,7 +116,7 @@ Int VectorWord ( Obj vv, Obj v, Int num )
 */
 #define SC_PUSH_WORD( word, exp ) \
     if ( ++sp == max ) { \
-        SC_MAX_STACK_SIZE *= 2; \
+        TLS(SC_MAX_STACK_SIZE) *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(word); \
@@ -253,22 +253,22 @@ Int SingleCollectWord ( Obj sc, Obj vv, Obj w )
     exps = 1UL << (ebits-1);
 
     /* <nw> contains the stack of words to insert                          */
-    vnw = SC_NW_STACK;
+    vnw = TLS(SC_NW_STACK);
 
     /* <lw> contains the word end of the word in <nw>                      */
-    vlw = SC_LW_STACK;
+    vlw = TLS(SC_LW_STACK);
 
     /* <pw> contains the position of the word in <nw> to look at           */
-    vpw = SC_PW_STACK;
+    vpw = TLS(SC_PW_STACK);
 
     /* <ew> contains the unprocessed exponents at position <pw>            */
-    vew = SC_EW_STACK;
+    vew = TLS(SC_EW_STACK);
 
     /* <ge> contains the global exponent of the word                       */
-    vge = SC_GE_STACK;
+    vge = TLS(SC_GE_STACK);
 
     /* get the maximal stack size                                          */
-    max = SC_MAX_STACK_SIZE;
+    max = TLS(SC_MAX_STACK_SIZE);
 
     /* ensure that the stacks are large enough                             */
     if ( SIZE_OBJ(vnw)/sizeof(Obj) < max+1 ) {

--- a/src/objscoll.c
+++ b/src/objscoll.c
@@ -286,7 +286,7 @@ Obj ReducedComm (
     Int *               qtr;        /* pointer into the collect vector     */
 
     /* use 'cwVector' to collect word <u>*<w> to                           */
-    vcw = SC_CW_VECTOR;
+    vcw = TLS(SC_CW_VECTOR);
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     /* check that it has the correct length, unpack <u> into it            */
@@ -304,7 +304,7 @@ Obj ReducedComm (
     }
 
     /* use 'cw2Vector' to collect word <w>*<u> to                          */
-    vc2 = SC_CW2_VECTOR;
+    vc2 = TLS(SC_CW2_VECTOR);
 
     /* check that it has the correct length, unpack <w> into it            */
     if ( fc->vectorWord( vc2, w, num ) == -1 ) {
@@ -356,7 +356,7 @@ Obj ReducedForm (
     Int *               qtr;    /* pointer into the collect vector         */
 
     /* use 'cwVector' to collect word <w> to                               */
-    vcw = SC_CW_VECTOR;
+    vcw = TLS(SC_CW_VECTOR);
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     /* check that it has the correct length                                */
@@ -396,7 +396,7 @@ Obj ReducedLeftQuotient (
     Int *               qtr;        /* pointer into the collect vector     */
 
     /* use 'cwVector' to collect word <w> to                               */
-    vcw = SC_CW_VECTOR;
+    vcw = TLS(SC_CW_VECTOR);
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     /* check that it has the correct length, unpack <w> into it            */
@@ -407,7 +407,7 @@ Obj ReducedLeftQuotient (
     }
 
     /* use 'cw2Vector' to collect word <u> to                              */
-    vc2 = SC_CW2_VECTOR;
+    vc2 = TLS(SC_CW2_VECTOR);
 
     /* check that it has the correct length, unpack <u> into it            */
     if ( fc->vectorWord( vc2, u, num ) == -1 ) {
@@ -451,7 +451,7 @@ Obj ReducedProduct (
     Int *               qtr;        /* pointer into the collect vector     */
 
     /* use 'cwVector' to collect word <w> to                               */
-    vcw = SC_CW_VECTOR;
+    vcw = TLS(SC_CW_VECTOR);
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     /* check that it has the correct length, unpack <w> into it            */
@@ -497,8 +497,8 @@ Obj ReducedPowerSmallInt (
     pow = INT_INTOBJ(vpow);
 
     /* use 'cwVector' and 'cw2Vector to collect words to                   */
-    vcw  = SC_CW_VECTOR;
-    vc2  = SC_CW2_VECTOR;
+    vcw  = TLS(SC_CW_VECTOR);
+    vc2  = TLS(SC_CW2_VECTOR);
     num  = SC_NUMBER_RWS_GENERATORS(sc);
     type = SC_DEFAULT_TYPE(sc);
 
@@ -595,8 +595,8 @@ Obj ReducedQuotient (
     Int *               qtr;        /* pointer into the collect vector     */
 
     /* use 'cwVector' to collect word <w> to                               */
-    vcw  = SC_CW_VECTOR;
-    vc2  = SC_CW2_VECTOR;
+    vcw  = TLS(SC_CW_VECTOR);
+    vc2  = TLS(SC_CW2_VECTOR);
     num  = SC_NUMBER_RWS_GENERATORS(sc);
     type = SC_DEFAULT_TYPE(sc);
 
@@ -722,7 +722,7 @@ Obj FuncFinPowConjCol_ReducedQuotient ( Obj self, Obj sc, Obj w, Obj u )
 Obj FuncSET_SCOBJ_MAX_STACK_SIZE ( Obj self, Obj size )
 {
     if (IS_INTOBJ(size) && INT_INTOBJ(size) > 0)
-        SC_MAX_STACK_SIZE = INT_INTOBJ(size);
+        TLS(SC_MAX_STACK_SIZE) = INT_INTOBJ(size);
     else
         ErrorQuit( "collect vector must be a positive small integer not a %s",
                    (Int)TNAM_OBJ(size), 0L );
@@ -800,14 +800,14 @@ static inline Obj NewPlist( UInt tnum, UInt len, UInt reserved )
 static void SetupCollectorStacks()
 {
     const UInt maxStackSize = 256;
-    SC_NW_STACK = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    SC_LW_STACK = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    SC_PW_STACK = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    SC_EW_STACK = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    SC_GE_STACK = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    SC_CW_VECTOR = NEW_STRING( 0 );
-    SC_CW2_VECTOR = NEW_STRING( 0 );
-    SC_MAX_STACK_SIZE = maxStackSize;
+    TLS(SC_NW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    TLS(SC_LW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    TLS(SC_PW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    TLS(SC_EW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    TLS(SC_GE_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    TLS(SC_CW_VECTOR) = NEW_STRING( 0 );
+    TLS(SC_CW2_VECTOR) = NEW_STRING( 0 );
+    TLS(SC_MAX_STACK_SIZE) = maxStackSize;
 }
 
 

--- a/src/opers.c
+++ b/src/opers.c
@@ -1623,9 +1623,9 @@ Obj DoOperation0Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 0 ) );
-              cache[2*CacheIndex] = method;
-              cache[2*CacheIndex+1] = prec;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[2*TLS(CacheIndex)] = method;
+              cache[2*TLS(CacheIndex)+1] = prec;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,0));
             }
 #ifdef COUNT_OPERS
@@ -1709,10 +1709,10 @@ Obj DoOperation1Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 1 ) );
-              cache[3*CacheIndex] = method;
-              cache[3*CacheIndex+1] = prec;
-              cache[3*CacheIndex+2] = id1;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[3*TLS(CacheIndex)] = method;
+              cache[3*TLS(CacheIndex)+1] = prec;
+              cache[3*TLS(CacheIndex)+2] = id1;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,1));
             }
 #ifdef COUNT_OPERS
@@ -1803,11 +1803,11 @@ Obj DoOperation2Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 2 ) );
-              cache[4*CacheIndex] = method;
-              cache[4*CacheIndex+1] = prec;
-              cache[4*CacheIndex+2] = id1;
-              cache[4*CacheIndex+3] = id2;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[4*TLS(CacheIndex)] = method;
+              cache[4*TLS(CacheIndex)+1] = prec;
+              cache[4*TLS(CacheIndex)+2] = id1;
+              cache[4*TLS(CacheIndex)+3] = id2;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,2));
             }
 #ifdef COUNT_OPERS
@@ -1903,12 +1903,12 @@ Obj DoOperation3Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 3 ) );
-              cache[5*CacheIndex] = method;
-              cache[5*CacheIndex+1] = prec;
-              cache[5*CacheIndex+2] = id1;
-              cache[5*CacheIndex+3] = id2;
-              cache[5*CacheIndex+4] = id3;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[5*TLS(CacheIndex)] = method;
+              cache[5*TLS(CacheIndex)+1] = prec;
+              cache[5*TLS(CacheIndex)+2] = id1;
+              cache[5*TLS(CacheIndex)+3] = id2;
+              cache[5*TLS(CacheIndex)+4] = id3;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,3));
             }
 #ifdef COUNT_OPERS
@@ -2011,13 +2011,13 @@ Obj DoOperation4Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 4 ) );
-              cache[6*CacheIndex] = method;
-              cache[6*CacheIndex+1] = prec;
-              cache[6*CacheIndex+2] = id1;
-              cache[6*CacheIndex+3] = id2;
-              cache[6*CacheIndex+4] = id3;
-              cache[6*CacheIndex+5] = id4;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[6*TLS(CacheIndex)] = method;
+              cache[6*TLS(CacheIndex)+1] = prec;
+              cache[6*TLS(CacheIndex)+2] = id1;
+              cache[6*TLS(CacheIndex)+3] = id2;
+              cache[6*TLS(CacheIndex)+4] = id3;
+              cache[6*TLS(CacheIndex)+5] = id4;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,4));
             }
 #ifdef COUNT_OPERS
@@ -2139,14 +2139,14 @@ Obj DoOperation5Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 5 ) );
-              cache[7*CacheIndex] = method;
-              cache[7*CacheIndex+1] = prec;
-              cache[7*CacheIndex+2] = id1;
-              cache[7*CacheIndex+3] = id2;
-              cache[7*CacheIndex+4] = id3;
-              cache[7*CacheIndex+5] = id4;
-              cache[7*CacheIndex+6] = id5;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[7*TLS(CacheIndex)] = method;
+              cache[7*TLS(CacheIndex)+1] = prec;
+              cache[7*TLS(CacheIndex)+2] = id1;
+              cache[7*TLS(CacheIndex)+3] = id2;
+              cache[7*TLS(CacheIndex)+4] = id3;
+              cache[7*TLS(CacheIndex)+5] = id4;
+              cache[7*TLS(CacheIndex)+6] = id5;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,5));
             }
 #ifdef COUNT_OPERS
@@ -2287,15 +2287,15 @@ Obj DoOperation6Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 6 ) );
-              cache[8*CacheIndex] = method;
-              cache[8*CacheIndex+1] = prec;
-              cache[8*CacheIndex+2] = id1;
-              cache[8*CacheIndex+3] = id2;
-              cache[8*CacheIndex+4] = id3;
-              cache[8*CacheIndex+5] = id4;
-              cache[8*CacheIndex+6] = id5;
-              cache[8*CacheIndex+7] = id6;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[8*TLS(CacheIndex)] = method;
+              cache[8*TLS(CacheIndex)+1] = prec;
+              cache[8*TLS(CacheIndex)+2] = id1;
+              cache[8*TLS(CacheIndex)+3] = id2;
+              cache[8*TLS(CacheIndex)+4] = id3;
+              cache[8*TLS(CacheIndex)+5] = id4;
+              cache[8*TLS(CacheIndex)+6] = id5;
+              cache[8*TLS(CacheIndex)+7] = id6;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,6));
             }
 #ifdef COUNT_OPERS
@@ -2900,7 +2900,7 @@ Obj NewOperation (
 
 *F  DoConstructor( <name> ) . . . . . . . . . . . . .  make a new constructor
 */
-UInt CacheIndex;
+UInt TLS(CacheIndex);
 
 Obj Constructor0Args;
 Obj NextConstructor0Args;
@@ -2990,9 +2990,9 @@ Obj DoConstructor0Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 0 ) );
-              cache[2*CacheIndex] = method;
-              cache[2*CacheIndex+1] = prec;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[2*TLS(CacheIndex)] = method;
+              cache[2*TLS(CacheIndex)+1] = prec;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,0));
             }
 #ifdef COUNT_OPERS
@@ -3081,10 +3081,10 @@ Obj DoConstructor1Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 1 ) );
-              cache[3*CacheIndex] = method;
-              cache[3*CacheIndex+1] = prec;
-              cache[3*CacheIndex+2] = type1;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[3*TLS(CacheIndex)] = method;
+              cache[3*TLS(CacheIndex)+1] = prec;
+              cache[3*TLS(CacheIndex)+2] = type1;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,1));
             }
 #ifdef COUNT_OPERS
@@ -3178,11 +3178,11 @@ Obj DoConstructor2Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 2 ) );
-              cache[4*CacheIndex] = method;
-              cache[4*CacheIndex+1] = prec;
-              cache[4*CacheIndex+2] = type1;
-              cache[4*CacheIndex+3] = id2;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[4*TLS(CacheIndex)] = method;
+              cache[4*TLS(CacheIndex)+1] = prec;
+              cache[4*TLS(CacheIndex)+2] = type1;
+              cache[4*TLS(CacheIndex)+3] = id2;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,2));
             }
 #ifdef COUNT_OPERS
@@ -3282,12 +3282,12 @@ Obj DoConstructor3Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 3 ) );
-              cache[5*CacheIndex] = method;
-              cache[5*CacheIndex+1] = prec;
-              cache[5*CacheIndex+2] = type1;
-              cache[5*CacheIndex+3] = id2;
-              cache[5*CacheIndex+4] = id3;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[5*TLS(CacheIndex)] = method;
+              cache[5*TLS(CacheIndex)+1] = prec;
+              cache[5*TLS(CacheIndex)+2] = type1;
+              cache[5*TLS(CacheIndex)+3] = id2;
+              cache[5*TLS(CacheIndex)+4] = id3;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,3));
             }
 #ifdef COUNT_OPERS
@@ -3393,13 +3393,13 @@ Obj DoConstructor4Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 4 ) );
-              cache[6*CacheIndex] = method;
-              cache[6*CacheIndex+1] = prec;
-              cache[6*CacheIndex+2] = type1;
-              cache[6*CacheIndex+3] = id2;
-              cache[6*CacheIndex+4] = id3;
-              cache[6*CacheIndex+5] = id4;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[6*TLS(CacheIndex)] = method;
+              cache[6*TLS(CacheIndex)+1] = prec;
+              cache[6*TLS(CacheIndex)+2] = type1;
+              cache[6*TLS(CacheIndex)+3] = id2;
+              cache[6*TLS(CacheIndex)+4] = id3;
+              cache[6*TLS(CacheIndex)+5] = id4;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,4));
             }
 #ifdef COUNT_OPERS
@@ -3523,14 +3523,14 @@ Obj DoConstructor5Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 5 ) );
-              cache[7*CacheIndex] = method;
-              cache[7*CacheIndex+1] = prec;
-              cache[7*CacheIndex+2] = type1;
-              cache[7*CacheIndex+3] = id2;
-              cache[7*CacheIndex+4] = id3;
-              cache[7*CacheIndex+5] = id4;
-              cache[7*CacheIndex+6] = id5;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[7*TLS(CacheIndex)] = method;
+              cache[7*TLS(CacheIndex)+1] = prec;
+              cache[7*TLS(CacheIndex)+2] = type1;
+              cache[7*TLS(CacheIndex)+3] = id2;
+              cache[7*TLS(CacheIndex)+4] = id3;
+              cache[7*TLS(CacheIndex)+5] = id4;
+              cache[7*TLS(CacheIndex)+6] = id5;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,5));
             }
 #ifdef COUNT_OPERS
@@ -3673,15 +3673,15 @@ Obj DoConstructor6Args (
           if (method && prec < INTOBJ_INT(CACHE_SIZE))
             {
               cache = 1+ADDR_OBJ( CACHE_OPER( oper, 6 ) );
-              cache[8*CacheIndex] = method;
-              cache[8*CacheIndex+1] = prec;
-              cache[8*CacheIndex+2] = type1;
-              cache[8*CacheIndex+3] = id2;
-              cache[8*CacheIndex+4] = id3;
-              cache[8*CacheIndex+5] = id4;
-              cache[8*CacheIndex+6] = id5;
-              cache[8*CacheIndex+7] = id6;
-              CacheIndex = (CacheIndex + 1) % CACHE_SIZE;
+              cache[8*TLS(CacheIndex)] = method;
+              cache[8*TLS(CacheIndex)+1] = prec;
+              cache[8*TLS(CacheIndex)+2] = type1;
+              cache[8*TLS(CacheIndex)+3] = id2;
+              cache[8*TLS(CacheIndex)+4] = id3;
+              cache[8*TLS(CacheIndex)+5] = id4;
+              cache[8*TLS(CacheIndex)+6] = id5;
+              cache[8*TLS(CacheIndex)+7] = id6;
+              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG(CACHE_OPER(oper,6));
             }
 #ifdef COUNT_OPERS

--- a/src/read.h
+++ b/src/read.h
@@ -27,15 +27,15 @@ extern syJmp_buf ReadJmpError;
 
 #ifndef DEBUG_READ_ERROR
 
-#define READ_ERROR()    (NrError || (NrError+=sySetjmp(ReadJmpError)))
+#define READ_ERROR()    (TLS(NrError) || (TLS(NrError)+=sySetjmp(TLS(ReadJmpError))))
 
 #else
 
 #define READ_ERROR()                                                     \
-    ( NrError ||                                                         \
-      ( ( NrError += setjmp(ReadJmpError) ) ?                            \
+    ( TLS(NrError) ||                                                         \
+      ( ( TLS(NrError) += setjmp(TLS(ReadJmpError)) ) ?                            \
         Pr( "READ_ERROR( %s, %d )\n", (Int)__FILE__, __LINE__ ),0 : 0 ), \
-      NrError )
+      TLS(NrError) )
 
 #endif
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -877,7 +877,7 @@ UInt OpenOutput (
     Int                 file;
 
     /* do nothing for stdout and errout if catched */
-    if ( TLS(Output) != NULL && IgnoreStdoutErrout == TLS(Output) &&
+    if ( TLS(Output) != NULL && TLS(IgnoreStdoutErrout) == TLS(Output) &&
           ( strcmp( filename, "*errout*" ) == 0
            || strcmp( filename, "*stdout*" ) == 0 ) ) {
         return 1;
@@ -975,7 +975,7 @@ UInt CloseOutput ( void )
     if ( TLS(Output) == TLS(TestOutput) )
         return 1;
     /* and similarly */
-    if ( IgnoreStdoutErrout == TLS(Output) )
+    if ( TLS(IgnoreStdoutErrout) == TLS(Output) )
         return 1;
 
     /* refuse to close the initial output file '*stdout*'                  */

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -277,7 +277,6 @@ void Match (
 
 /****************************************************************************
 **
-
 *F  OpenInput( <filename> ) . . . . . . . . . .  open a file as current input
 **
 **  'OpenInput' opens  the file with  the name <filename>  as  current input.
@@ -315,11 +314,11 @@ UInt OpenInput (
     Int                 file;
 
     /* fail if we can not handle another open input file                   */
-    if ( Input+1 == InputFiles+(sizeof(InputFiles)/sizeof(InputFiles[0])) )
+    if ( TLS(Input)+1 == TLS(InputFiles)+(sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0])) )
         return 0;
 
     /* in test mode keep reading from test input file for break loop input */
-    if ( TestInput != 0 && ! strcmp( filename, "*errin*" ) )
+    if ( TLS(TestInput) != 0 && ! strcmp( filename, "*errin*" ) )
         return 1;
 
     /* try to open the input file                                          */
@@ -328,27 +327,27 @@ UInt OpenInput (
         return 0;
 
     /* remember the current position in the current file                   */
-    if ( Input+1 != InputFiles ) {
-        Input->ptr    = In;
-        Input->symbol = Symbol;
+    if ( TLS(Input)+1 != TLS(InputFiles) ) {
+        TLS(Input)->ptr    = TLS(In);
+        TLS(Input)->symbol = TLS(Symbol);
     }
 
     /* enter the file identifier and the file name                         */
-    Input++;
-    Input->isstream = 0;
-    Input->file = file;
+    TLS(Input)++;
+    TLS(Input)->isstream = 0;
+    TLS(Input)->file = file;
     if (strcmp("*errin*", filename) && strcmp("*stdin*", filename))
-      Input->echo = 0;
+      TLS(Input)->echo = 0;
     else
-      Input->echo = 1;
-    strlcpy( Input->name, filename, sizeof(Input->name) );
-    Input->gapname = (Obj) 0;
+      TLS(Input)->echo = 1;
+    strlcpy( TLS(Input)->name, filename, sizeof(TLS(Input)->name) );
+    TLS(Input)->gapname = (Obj) 0;
 
     /* start with an empty line and no symbol                              */
-    In = Input->line;
-    In[0] = In[1] = '\0';
-    Symbol = S_ILLEGAL;
-    Input->number = 1;
+    TLS(In) = TLS(Input)->line;
+    TLS(In)[0] = TLS(In)[1] = '\0';
+    TLS(Symbol) = S_ILLEGAL;
+    TLS(Input)->number = 1;
 
     /* indicate success                                                    */
     return 1;
@@ -367,36 +366,36 @@ UInt OpenInputStream (
     Obj                 stream )
 {
     /* fail if we can not handle another open input file                   */
-    if ( Input+1 == InputFiles+(sizeof(InputFiles)/sizeof(InputFiles[0])) )
+    if ( TLS(Input)+1 == TLS(InputFiles)+(sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0])) )
         return 0;
 
     /* remember the current position in the current file                   */
-    if ( Input+1 != InputFiles ) {
-        Input->ptr    = In;
-        Input->symbol = Symbol;
+    if ( TLS(Input)+1 != TLS(InputFiles) ) {
+        TLS(Input)->ptr    = TLS(In);
+        TLS(Input)->symbol = TLS(Symbol);
     }
 
     /* enter the file identifier and the file name                         */
-    Input++;
-    Input->isstream = 1;
-    Input->stream = stream;
-    Input->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
-    if (Input->isstringstream) {
-        Input->sline = ADDR_OBJ(stream)[2];
-        Input->spos = INT_INTOBJ(ADDR_OBJ(stream)[1]);
+    TLS(Input)++;
+    TLS(Input)->isstream = 1;
+    TLS(Input)->stream = stream;
+    TLS(Input)->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
+    if (TLS(Input)->isstringstream) {
+        TLS(Input)->sline = ADDR_OBJ(stream)[2];
+        TLS(Input)->spos = INT_INTOBJ(ADDR_OBJ(stream)[1]);
     }
     else {
-        Input->sline = 0;
+        TLS(Input)->sline = 0;
     }
-    Input->file = -1;
-    Input->echo = 0;
-    strlcpy( Input->name, "stream", sizeof(Input->name) );
+    TLS(Input)->file = -1;
+    TLS(Input)->echo = 0;
+    strlcpy( TLS(Input)->name, "stream", sizeof(TLS(Input)->name) );
 
     /* start with an empty line and no symbol                              */
-    In = Input->line;
-    In[0] = In[1] = '\0';
-    Symbol = S_ILLEGAL;
-    Input->number = 1;
+    TLS(In) = TLS(Input)->line;
+    TLS(In)[0] = TLS(In)[1] = '\0';
+    TLS(Symbol) = S_ILLEGAL;
+    TLS(Input)->number = 1;
 
     /* indicate success                                                    */
     return 1;
@@ -421,26 +420,26 @@ UInt OpenInputStream (
 UInt CloseInput ( void )
 {
     /* refuse to close the initial input file                              */
-    if ( Input == InputFiles )
+    if ( TLS(Input) == TLS(InputFiles) )
         return 0;
 
     /* refuse to close the test input file                                 */
-    if ( Input == TestInput )
+    if ( TLS(Input) == TLS(TestInput) )
         return 0;
 
     /* close the input file                                                */
-    if ( ! Input->isstream ) {
-        SyFclose( Input->file );
+    if ( ! TLS(Input)->isstream ) {
+        SyFclose( TLS(Input)->file );
     }
 
     /* don't keep GAP objects alive unnecessarily */
-    Input->gapname = 0;
-    Input->sline = 0;
+    TLS(Input)->gapname = 0;
+    TLS(Input)->sline = 0;
 
     /* revert to last file                                                 */
-    Input--;
-    In     = Input->ptr;
-    Symbol = Input->symbol;
+    TLS(Input)--;
+    TLS(In)     = TLS(Input)->ptr;
+    TLS(Symbol) = TLS(Input)->symbol;
 
     /* indicate success                                                    */
     return 1;
@@ -454,9 +453,9 @@ UInt CloseInput ( void )
 
 void FlushRestOfInputLine( void )
 {
-  In[0] = In[1] = '\0';
-  /*   Input->number = 1; */
-  Symbol = S_ILLEGAL;
+  TLS(In)[0] = TLS(In)[1] = '\0';
+  /* TLS(Input)->number = 1; */
+  TLS(Symbol) = S_ILLEGAL;
 }
 
 
@@ -521,27 +520,27 @@ UInt OpenTestStream (
 UInt CloseTest ( void )
 {
     /* refuse to a non test file                                           */
-    if ( TestInput != Input )
+    if ( TLS(TestInput) != TLS(Input) )
         return 0;
 
     /* close the input file                                                */
-    if ( ! Input->isstream ) {
-        SyFclose( Input->file );
+    if ( ! TLS(Input)->isstream ) {
+        SyFclose( TLS(Input)->file );
     }
 
     /* don't keep GAP objects alive unnecessarily */
-    Input->gapname = 0;
-    Input->sline = 0;
+    TLS(Input)->gapname = 0;
+    TLS(Input)->sline = 0;
 
     /* revert to last file                                                 */
-    Input--;
-    In     = Input->ptr;
-    Symbol = Input->symbol;
+    TLS(Input)--;
+    TLS(In)     = TLS(Input)->ptr;
+    TLS(Symbol) = TLS(Input)->symbol;
 
     /* we are no longer in test mode                                       */
-    TestInput   = 0;
-    TestOutput  = 0;
-    TestLine[0] = '\0';
+    TLS(TestInput)   = 0;
+    TLS(TestOutput)  = 0;
+    TLS(TestLine)[0] = '\0';
 
     /* indicate success                                                    */
     return 1;
@@ -564,24 +563,24 @@ UInt CloseTest ( void )
 **  many   are too   many, but  16   files should  work everywhere.   Finally
 **  'OpenLog' will fail if there is already a current logfile.
 */
-static TypOutputFile logFile;
+static TypOutputFile LogFile;
 
 UInt OpenLog (
     const Char *        filename )
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( InputLog != 0 || OutputLog != 0 )
+    if ( TLS(InputLog) != 0 || TLS(OutputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    logFile.file = SyFopen( filename, "w" );
-    logFile.isstream = 0;
-    if ( logFile.file == -1 )
+    TLS(LogFile).file = SyFopen( filename, "w" );
+    TLS(LogFile).isstream = 0;
+    if ( TLS(LogFile).file == -1 )
         return 0;
 
-    InputLog  = &logFile;
-    OutputLog = &logFile;
+    TLS(InputLog)  = &TLS(LogFile);
+    TLS(OutputLog) = &TLS(LogFile);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -594,23 +593,23 @@ UInt OpenLog (
 **
 **  The same as 'OpenLog' but for streams.
 */
-static TypOutputFile logStream;
+static TypOutputFile LogStream;
 
 UInt OpenLogStream (
     Obj             stream )
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( InputLog != 0 || OutputLog != 0 )
+    if ( TLS(InputLog) != 0 || TLS(OutputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    logStream.isstream = 1;
-    logStream.stream = stream;
-    logStream.file = -1;
+    TLS(LogStream).isstream = 1;
+    TLS(LogStream).stream = stream;
+    TLS(LogStream).file = -1;
 
-    InputLog  = &logStream;
-    OutputLog = &logStream;
+    TLS(InputLog)  = &TLS(LogStream);
+    TLS(OutputLog) = &TLS(LogStream);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -661,23 +660,23 @@ UInt CloseLog ( void )
 **  dependent  how many are too many,  but 16 files  should work  everywhere.
 **  Finally 'OpenInputLog' will fail if there is already a current logfile.
 */
-static TypOutputFile inputLogFile;
+static TypOutputFile InputLogFile;
 
 UInt OpenInputLog (
     const Char *        filename )
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( InputLog != 0 )
+    if ( TLS(InputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    inputLogFile.file = SyFopen( filename, "w" );
-    inputLogFile.isstream = 0;
-    if ( inputLogFile.file == -1 )
+    TLS(InputLogFile).file = SyFopen( filename, "w" );
+    TLS(InputLogFile).isstream = 0;
+    if ( TLS(InputLogFile).file == -1 )
         return 0;
 
-    InputLog = &inputLogFile;
+    TLS(InputLog) = &TLS(InputLogFile);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -690,22 +689,22 @@ UInt OpenInputLog (
 **
 **  The same as 'OpenInputLog' but for streams.
 */
-static TypOutputFile inputLogStream;
+static TypOutputFile InputLogStream;
 
 UInt OpenInputLogStream (
     Obj                 stream )
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( InputLog != 0 )
+    if ( TLS(InputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    inputLogStream.isstream = 1;
-    inputLogStream.stream = stream;
-    inputLogStream.file = -1;
+    TLS(InputLogStream).isstream = 1;
+    TLS(InputLogStream).stream = stream;
+    TLS(InputLogStream).file = -1;
 
-    InputLog = &inputLogStream;
+    TLS(InputLog) = &TLS(InputLogStream);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -760,23 +759,23 @@ UInt CloseInputLog ( void )
 **  dependent how many are  too many,  but  16 files should  work everywhere.
 **  Finally 'OpenOutputLog' will fail if there is already a current logfile.
 */
-static TypOutputFile outputLogFile;
+static TypOutputFile OutputLogFile;
 
 UInt OpenOutputLog (
     const Char *        filename )
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( OutputLog != 0 )
+    if ( TLS(OutputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    outputLogFile.file = SyFopen( filename, "w" );
-    outputLogFile.isstream = 0;
-    if ( outputLogFile.file == -1 )
+    TLS(OutputLogFile).file = SyFopen( filename, "w" );
+    TLS(OutputLogFile).isstream = 0;
+    if ( TLS(OutputLogFile).file == -1 )
         return 0;
 
-    OutputLog = &outputLogFile;
+    TLS(OutputLog) = &TLS(OutputLogFile);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -789,22 +788,22 @@ UInt OpenOutputLog (
 **
 **  The same as 'OpenOutputLog' but for streams.
 */
-static TypOutputFile outputLogStream;
+static TypOutputFile OutputLogStream;
 
 UInt OpenOutputLogStream (
     Obj                 stream )
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( OutputLog != 0 )
+    if ( TLS(OutputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    outputLogStream.isstream = 1;
-    outputLogStream.stream = stream;
-    outputLogStream.file = -1;
+    TLS(OutputLogStream).isstream = 1;
+    TLS(OutputLogStream).stream = stream;
+    TLS(OutputLogStream).file = -1;
 
-    OutputLog = &outputLogStream;
+    TLS(OutputLog) = &TLS(OutputLogStream);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -878,18 +877,18 @@ UInt OpenOutput (
     Int                 file;
 
     /* do nothing for stdout and errout if catched */
-    if ( Output != NULL && IgnoreStdoutErrout == Output &&
+    if ( TLS(Output) != NULL && IgnoreStdoutErrout == TLS(Output) &&
           ( strcmp( filename, "*errout*" ) == 0
            || strcmp( filename, "*stdout*" ) == 0 ) ) {
         return 1;
     }
 
     /* fail if we can not handle another open output file                  */
-    if ( Output+1==OutputFiles+(sizeof(OutputFiles)/sizeof(OutputFiles[0])) )
+    if ( TLS(Output)+1==TLS(OutputFiles)+(sizeof(TLS(OutputFiles))/sizeof(TLS(OutputFiles)[0])) )
         return 0;
 
     /* in test mode keep printing to test output file for breakloop output */
-    if ( TestInput != 0 && ! strcmp( filename, "*errout*" ) )
+    if ( TLS(TestInput) != 0 && ! strcmp( filename, "*errout*" ) )
         return 1;
 
     /* try to open the file                                                */
@@ -898,19 +897,19 @@ UInt OpenOutput (
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
-    if (Output == 0L)
-      Output = OutputFiles;
+    if (TLS(Output) == 0L)
+      TLS(Output) = TLS(OutputFiles);
     else
-      Output++;
-    Output->file     = file;
-    Output->line[0]  = '\0';
-    Output->pos      = 0;
-    Output->indent   = 0;
-    Output->isstream = 0;
-    Output->format   = 1;
+      TLS(Output)++;
+    TLS(Output)->file     = file;
+    TLS(Output)->line[0]  = '\0';
+    TLS(Output)->pos      = 0;
+    TLS(Output)->indent   = 0;
+    TLS(Output)->isstream = 0;
+    TLS(Output)->format   = 1;
 
     /* variables related to line splitting, very bad place to split        */
-    Output->hints[0] = -1;
+    TLS(Output)->hints[0] = -1;
 
     /* indicate success                                                    */
     return 1;
@@ -930,21 +929,21 @@ UInt OpenOutputStream (
     Obj                 stream )
 {
     /* fail if we can not handle another open output file                  */
-    if ( Output+1==OutputFiles+(sizeof(OutputFiles)/sizeof(OutputFiles[0])) )
+    if ( TLS(Output)+1==TLS(OutputFiles)+(sizeof(TLS(OutputFiles))/sizeof(TLS(OutputFiles)[0])) )
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
-    Output++;
-    Output->stream   = stream;
-    Output->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
-    Output->format   = (CALL_1ARGS(PrintFormattingStatus, stream) == True);
-    Output->line[0]  = '\0';
-    Output->pos      = 0;
-    Output->indent   = 0;
-    Output->isstream = 1;
+    TLS(Output)++;
+    TLS(Output)->stream   = stream;
+    TLS(Output)->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
+    TLS(Output)->format   = (CALL_1ARGS(PrintFormattingStatus, stream) == True);
+    TLS(Output)->line[0]  = '\0';
+    TLS(Output)->pos      = 0;
+    TLS(Output)->indent   = 0;
+    TLS(Output)->isstream = 1;
 
     /* variables related to line splitting, very bad place to split        */
-    Output->hints[0] = -1;
+    TLS(Output)->hints[0] = -1;
 
     /* indicate success                                                    */
     return 1;
@@ -973,24 +972,24 @@ UInt CloseOutput ( void )
     /* silently refuse to close the test output file this is probably
          an attempt to close *errout* which is silently not opened, so
          lets silently not close it  */
-    if ( Output == TestOutput )
+    if ( TLS(Output) == TLS(TestOutput) )
         return 1;
     /* and similarly */
-    if ( IgnoreStdoutErrout == Output )
+    if ( IgnoreStdoutErrout == TLS(Output) )
         return 1;
 
     /* refuse to close the initial output file '*stdout*'                  */
-    if ( Output == OutputFiles )
+    if ( TLS(Output) == TLS(OutputFiles) )
         return 0;
 
     /* flush output and close the file                                     */
     Pr( "%c", (Int)'\03', 0L );
-    if ( ! Output->isstream ) {
-        SyFclose( Output->file );
+    if ( ! TLS(Output)->isstream ) {
+        SyFclose( TLS(Output)->file );
     }
 
     /* revert to previous output file and indicate success                 */
-    Output--;
+    TLS(Output)--;
     return 1;
 }
 
@@ -1012,11 +1011,11 @@ UInt OpenAppend (
     Int                 file;
 
     /* fail if we can not handle another open output file                  */
-    if ( Output+1==OutputFiles+(sizeof(OutputFiles)/sizeof(OutputFiles[0])) )
+    if ( TLS(Output)+1==TLS(OutputFiles)+(sizeof(TLS(OutputFiles))/sizeof(TLS(OutputFiles)[0])) )
         return 0;
 
     /* in test mode keep printing to test output file for breakloop output */
-    if ( TestInput != 0 && ! strcmp( filename, "*errout*" ) )
+    if ( TLS(TestInput) != 0 && ! strcmp( filename, "*errout*" ) )
         return 1;
 
     /* try to open the file                                                */
@@ -1025,15 +1024,15 @@ UInt OpenAppend (
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
-    Output++;
-    Output->file     = file;
-    Output->line[0]  = '\0';
-    Output->pos      = 0;
-    Output->indent   = 0;
-    Output->isstream = 0;
+    TLS(Output)++;
+    TLS(Output)->file     = file;
+    TLS(Output)->line[0]  = '\0';
+    TLS(Output)->pos      = 0;
+    TLS(Output)->indent   = 0;
+    TLS(Output)->isstream = 0;
 
     /* variables related to line splitting, very bad place to split        */
-    Output->hints[0] = -1;
+    TLS(Output)->hints[0] = -1;
 
     /* indicate success                                                    */
     return 1;
@@ -1206,10 +1205,10 @@ Char GetLine ( void )
            (if not inside reading long string which may have line
            or chunk from GetLine starting with '?')                        */
 
-        if ( In[0] == '?' && HELPSubsOn == 1) {
-            strlcpy( buf, In+1, sizeof(buf) );
-            strcpy( In, "HELP(\"" );
-            for ( p = In+6,  q = buf;  *q;  q++ ) {
+        if ( TLS(In)[0] == '?' && TLS(HELPSubsOn) == 1) {
+            strlcpy( buf, TLS(In)+1, sizeof(buf) );
+            strcpy( TLS(In), "HELP(\"" );
+            for ( p = TLS(In)+6,  q = buf;  *q;  q++ ) {
                 if ( *q != '"' && *q != '\n' ) {
                     *p++ = *q;
                 }
@@ -1616,35 +1615,35 @@ void GetNumber ( UInt StartingStatus )
          look for a float.
 
       This is a bit fragile  */
-      if (Symbol == S_DOT || Symbol == S_BDOT) {
-        Value[i]  = '\0';
-        Symbol = S_INT;
+      if (TLS(Symbol) == S_DOT || TLS(Symbol) == S_BDOT) {
+        TLS(Value)[i]  = '\0';
+        TLS(Symbol) = S_INT;
         return;
       }
       
       /* peek ahead to decide which */
       GET_CHAR();
-      if (*In == '.') {
+      if (*TLS(In) == '.') {
         /* It was .. */
-        UNGET_CHAR(*In);
-        Symbol = S_INT;
-        Value[i] = '\0';
+        UNGET_CHAR(*TLS(In));
+        TLS(Symbol) = S_INT;
+        TLS(Value)[i] = '\0';
         return;
       }
 
 
       /* Not .. Put back the character we peeked at */
-      UNGET_CHAR(*In);
+      UNGET_CHAR(*TLS(In));
       /* Now the . must be part of our number
          store it and move on */
-      Value[i++] = c;
+      TLS(Value)[i++] = c;
       c = GetCleanedChar(&wasEscaped);
     }
 
     else {
       /* Anything else we see tells us that the token is done */
-      Value[i]  = '\0';
-      Symbol = S_INT;
+      TLS(Value)[i]  = '\0';
+      TLS(Symbol) = S_INT;
       return;
     }
   }
@@ -1829,52 +1828,52 @@ void GetStr ( void )
   Char                a, b, c;
 
   /* Avoid substitution of '?' in beginning of GetLine chunks */
-  HELPSubsOn = 0;
+  TLS(HELPSubsOn) = 0;
 
   /* read all characters into 'Value'                                    */
-  for ( i = 0; i < SAFE_VALUE_SIZE-1 && *In != '"'
-           && *In != '\n' && *In != '\377'; i++ ) {
+  for ( i = 0; i < SAFE_VALUE_SIZE-1 && *TLS(In) != '"'
+           && *TLS(In) != '\n' && *TLS(In) != '\377'; i++ ) {
 
     fetch = 1;
     /* handle escape sequences                                         */
-    if ( *In == '\\' ) {
+    if ( *TLS(In) == '\\' ) {
       GET_CHAR();
       /* if next is another '\\' followed by '\n' it must be ignored */
-      while ( *In == '\\' ) {
+      while ( *TLS(In) == '\\' ) {
         GET_CHAR();
-        if ( *In == '\n' )
+        if ( *TLS(In) == '\n' )
           GET_CHAR();
         else {
           UNGET_CHAR( '\\' );
           break;
         }
       }
-      if      ( *In == '\n' )  i--;
-      else if ( *In == '\r' )  {
+      if      ( *TLS(In) == '\n' )  i--;
+      else if ( *TLS(In) == '\r' )  {
         GET_CHAR();
-        if  ( *In == '\n' )  i--;
-        else  {Value[i] = '\r'; fetch = 0;}
+        if  ( *TLS(In) == '\n' )  i--;
+        else  {TLS(Value)[i] = '\r'; fetch = 0;}
       }
-      else if ( *In == 'n'  )  Value[i] = '\n';
-      else if ( *In == 't'  )  Value[i] = '\t';
-      else if ( *In == 'r'  )  Value[i] = '\r';
-      else if ( *In == 'b'  )  Value[i] = '\b';
-      else if ( *In == '>'  )  Value[i] = '\01';
-      else if ( *In == '<'  )  Value[i] = '\02';
-      else if ( *In == 'c'  )  Value[i] = '\03';
-      else if ( IsDigit( *In ) ) {
-        a = *In; GET_CHAR(); b = *In; GET_CHAR(); c = *In;
+      else if ( *TLS(In) == 'n'  )  TLS(Value)[i] = '\n';
+      else if ( *TLS(In) == 't'  )  TLS(Value)[i] = '\t';
+      else if ( *TLS(In) == 'r'  )  TLS(Value)[i] = '\r';
+      else if ( *TLS(In) == 'b'  )  TLS(Value)[i] = '\b';
+      else if ( *TLS(In) == '>'  )  TLS(Value)[i] = '\01';
+      else if ( *TLS(In) == '<'  )  TLS(Value)[i] = '\02';
+      else if ( *TLS(In) == 'c'  )  TLS(Value)[i] = '\03';
+      else if ( IsDigit( *TLS(In) ) ) {
+        a = *TLS(In); GET_CHAR(); b = *TLS(In); GET_CHAR(); c = *TLS(In);
         if (!( IsDigit(b) && IsDigit(c) )){
           SyntaxError("expecting three octal digits after \\ in string");
         }
-        Value[i] = (a-'0') * 64 + (b-'0') * 8 + c-'0';
+        TLS(Value)[i] = (a-'0') * 64 + (b-'0') * 8 + c-'0';
       }
-      else  Value[i] = *In;
+      else  TLS(Value)[i] = *TLS(In);
     }
 
     /* put normal chars into 'Value' but only if there is room         */
     else {
-      Value[i] = *In;
+      TLS(Value)[i] = *TLS(In);
     }
 
     /* read the next character                                         */
@@ -1885,25 +1884,25 @@ void GetStr ( void )
   /* XXX although we have ValueLen we need trailing \000 here,
      in gap.c, function FuncMAKE_INIT this is still used as C-string
      and long integers and strings are not yet supported!    */
-  Value[i] = '\0';
+  TLS(Value)[i] = '\0';
 
   /* check for error conditions                                          */
-  if ( *In == '\n'  )
+  if ( *TLS(In) == '\n'  )
     SyntaxError("string must not include <newline>");
-  if ( *In == '\377' )
+  if ( *TLS(In) == '\377' )
     SyntaxError("string must end with \" before end of file");
 
   /* set length of string, set 'Symbol' and skip trailing '"'            */
-  ValueLen = i;
+  TLS(ValueLen) = i;
   if ( i < SAFE_VALUE_SIZE-1 )  {
-    Symbol = S_STRING;
-    if ( *In == '"' )  GET_CHAR();
+    TLS(Symbol) = S_STRING;
+    if ( *TLS(In) == '"' )  GET_CHAR();
   }
   else
-    Symbol = S_PARTIALSTRING;
+    TLS(Symbol) = S_PARTIALSTRING;
 
   /* switching on substitution of '?' */
-  HELPSubsOn = 1;
+  TLS(HELPSubsOn) = 1;
 }
 
 /****************************************************************************
@@ -1929,7 +1928,7 @@ void GetTripStr ( void )
   Int                 i = 0;
 
   /* Avoid substitution of '?' in beginning of GetLine chunks */
-  HELPSubsOn = 0;
+  TLS(HELPSubsOn) = 0;
   
   /* print only a partial prompt while reading a triple string           */
   if ( !SyQuiet )
@@ -1938,23 +1937,23 @@ void GetTripStr ( void )
     TLS(Prompt) = "";
   
   /* read all characters into 'Value'                                    */
-  for ( i = 0; i < SAFE_VALUE_SIZE-1 && *In != '\377'; i++ ) {
+  for ( i = 0; i < SAFE_VALUE_SIZE-1 && *TLS(In) != '\377'; i++ ) {
     // Only thing to check for is a triple quote.
     
-    if ( *In == '"') {
+    if ( *TLS(In) == '"') {
         GET_CHAR();
-        if (*In == '"') {
+        if (*TLS(In) == '"') {
             GET_CHAR();
-            if(*In == '"' ) {
+            if(*TLS(In) == '"' ) {
                 break;
             }
-            Value[i] = '"';
+            TLS(Value)[i] = '"';
             i++;
         }
-        Value[i] = '"';
+        TLS(Value)[i] = '"';
         i++;
     }
-    Value[i] = *In;
+    TLS(Value)[i] = *TLS(In);
 
 
     /* read the next character                                         */
@@ -1964,23 +1963,23 @@ void GetTripStr ( void )
   /* XXX although we have ValueLen we need trailing \000 here,
      in gap.c, function FuncMAKE_INIT this is still used as C-string
      and long integers and strings are not yet supported!    */
-  Value[i] = '\0';
+  TLS(Value)[i] = '\0';
 
   /* check for error conditions                                          */
-  if ( *In == '\377' )
+  if ( *TLS(In) == '\377' )
     SyntaxError("string must end with \" before end of file");
 
   /* set length of string, set 'Symbol' and skip trailing '"'            */
-  ValueLen = i;
+  TLS(ValueLen) = i;
   if ( i < SAFE_VALUE_SIZE-1 )  {
-    Symbol = S_STRING;
-    if ( *In == '"' )  GET_CHAR();
+    TLS(Symbol) = S_STRING;
+    if ( *TLS(In) == '"' )  GET_CHAR();
   }
   else
-    Symbol = S_PARTIALTRIPSTRING;
+    TLS(Symbol) = S_PARTIALTRIPSTRING;
 
   /* switching on substitution of '?' */
-  HELPSubsOn = 1;
+  TLS(HELPSubsOn) = 1;
 }
 
 /****************************************************************************
@@ -1994,21 +1993,21 @@ void GetTripStr ( void )
 void GetMaybeTripStr ( void )
 {
     /* Avoid substitution of '?' in beginning of GetLine chunks */
-    HELPSubsOn = 0;
+    TLS(HELPSubsOn) = 0;
     
     /* This is just a normal string! */
-    if ( *In != '"' ) {
+    if ( *TLS(In) != '"' ) {
         GetStr();
         return;
     }
     
     GET_CHAR();
     /* This was just an empty string! */
-    if ( *In != '"' ) {
-        Value[0] = '\0';
-        ValueLen = 0;
-        Symbol = S_STRING;
-        HELPSubsOn = 1;
+    if ( *TLS(In) != '"' ) {
+        TLS(Value)[0] = '\0';
+        TLS(ValueLen) = 0;
+        TLS(Symbol) = S_STRING;
+        TLS(HELPSubsOn) = 1;
         return;
     }
     
@@ -2100,136 +2099,136 @@ void GetChar ( void )
 void GetSymbol ( void )
 {
   /* special case if reading of a long token is not finished */
-  if (Symbol == S_PARTIALSTRING) {
+  if (TLS(Symbol) == S_PARTIALSTRING) {
     GetStr();
     return;
   }
   
-  if (Symbol == S_PARTIALTRIPSTRING) {
+  if (TLS(Symbol) == S_PARTIALTRIPSTRING) {
       GetTripStr();
       return;
   }
   
-  if (Symbol == S_PARTIALINT) {
-    if (Value[0] == '\0')
+  if (TLS(Symbol) == S_PARTIALINT) {
+    if (TLS(Value)[0] == '\0')
       GetNumber(0);
     else
       GetNumber(1);
     return;
   }
-  if (Symbol == S_PARTIALFLOAT1) {
+  if (TLS(Symbol) == S_PARTIALFLOAT1) {
     GetNumber(2);
     return;
   }
 
-  if (Symbol == S_PARTIALFLOAT2) {
+  if (TLS(Symbol) == S_PARTIALFLOAT2) {
     GetNumber(3);
     return;
   }
-  if (Symbol == S_PARTIALFLOAT3) {
+  if (TLS(Symbol) == S_PARTIALFLOAT3) {
     GetNumber(4);
     return;
   }
 
-  if (Symbol == S_PARTIALFLOAT4) {
+  if (TLS(Symbol) == S_PARTIALFLOAT4) {
     GetNumber(5);
     return;
   }
 
 
   /* if no character is available then get one                           */
-  if ( *In == '\0' )
-    { In--;
+  if ( *TLS(In) == '\0' )
+    { TLS(In)--;
       GET_CHAR();
     }
 
   /* skip over <spaces>, <tabs>, <newlines> and comments                 */
-  while (*In==' '||*In=='\t'||*In=='\n'||*In=='\r'||*In=='\f'||*In=='#') {
-    if ( *In == '#' ) {
-      while ( *In != '\n' && *In != '\r' && *In != '\377' )
+  while (*TLS(In)==' '||*TLS(In)=='\t'||*TLS(In)=='\n'||*TLS(In)=='\r'||*TLS(In)=='\f'||*TLS(In)=='#') {
+    if ( *TLS(In) == '#' ) {
+      while ( *TLS(In) != '\n' && *TLS(In) != '\r' && *TLS(In) != '\377' )
         GET_CHAR();
     }
     GET_CHAR();
   }
 
   /* switch according to the character                                   */
-  switch ( *In ) {
+  switch ( *TLS(In) ) {
 
-  case '.':   Symbol = S_DOT;                         GET_CHAR();
-    /*            if ( *In == '\\' ) { GET_CHAR();
-            if ( *In == '\n' ) { GET_CHAR(); } }   */
-    if ( *In == '.' ) { Symbol = S_DOTDOT;  GET_CHAR();  break; }
+  case '.':   TLS(Symbol) = S_DOT;                         GET_CHAR();
+    /*            if ( *TLS(In) == '\\' ) { GET_CHAR();
+            if ( *TLS(In) == '\n' ) { GET_CHAR(); } }   */
+    if ( *TLS(In) == '.' ) { TLS(Symbol) = S_DOTDOT;  GET_CHAR();  break; }
     break;
 
-  case '!':   Symbol = S_ILLEGAL;                     GET_CHAR();
-    if ( *In == '\\' ) { GET_CHAR();
-      if ( *In == '\n' ) { GET_CHAR(); } }
-    if ( *In == '.' ) { Symbol = S_BDOT;    GET_CHAR();  break; }
-    if ( *In == '[' ) { Symbol = S_BLBRACK; GET_CHAR();  break; }
-    if ( *In == '{' ) { Symbol = S_BLBRACE; GET_CHAR();  break; }
+  case '!':   TLS(Symbol) = S_ILLEGAL;                     GET_CHAR();
+    if ( *TLS(In) == '\\' ) { GET_CHAR();
+      if ( *TLS(In) == '\n' ) { GET_CHAR(); } }
+    if ( *TLS(In) == '.' ) { TLS(Symbol) = S_BDOT;    GET_CHAR();  break; }
+    if ( *TLS(In) == '[' ) { TLS(Symbol) = S_BLBRACK; GET_CHAR();  break; }
+    if ( *TLS(In) == '{' ) { TLS(Symbol) = S_BLBRACE; GET_CHAR();  break; }
     break;
-  case '[':   Symbol = S_LBRACK;                      GET_CHAR();  break;
-  case ']':   Symbol = S_RBRACK;                      GET_CHAR();  break;
-  case '{':   Symbol = S_LBRACE;                      GET_CHAR();  break;
-  case '}':   Symbol = S_RBRACE;                      GET_CHAR();  break;
-  case '(':   Symbol = S_LPAREN;                      GET_CHAR();  break;
-  case ')':   Symbol = S_RPAREN;                      GET_CHAR();  break;
-  case ',':   Symbol = S_COMMA;                       GET_CHAR();  break;
+  case '[':   TLS(Symbol) = S_LBRACK;                      GET_CHAR();  break;
+  case ']':   TLS(Symbol) = S_RBRACK;                      GET_CHAR();  break;
+  case '{':   TLS(Symbol) = S_LBRACE;                      GET_CHAR();  break;
+  case '}':   TLS(Symbol) = S_RBRACE;                      GET_CHAR();  break;
+  case '(':   TLS(Symbol) = S_LPAREN;                      GET_CHAR();  break;
+  case ')':   TLS(Symbol) = S_RPAREN;                      GET_CHAR();  break;
+  case ',':   TLS(Symbol) = S_COMMA;                       GET_CHAR();  break;
 
-  case ':':   Symbol = S_COLON;                       GET_CHAR();
-    if ( *In == '\\' ) {
+  case ':':   TLS(Symbol) = S_COLON;                       GET_CHAR();
+    if ( *TLS(In) == '\\' ) {
       GET_CHAR();
-      if ( *In == '\n' )
+      if ( *TLS(In) == '\n' )
         { GET_CHAR(); }
     }
-    if ( *In == '=' ) { Symbol = S_ASSIGN;  GET_CHAR(); break; }
-    if ( In[0] == ':' && In[1] == '=') {
-      Symbol = S_INCORPORATE; GET_CHAR(); GET_CHAR(); break;
+    if ( *TLS(In) == '=' ) { TLS(Symbol) = S_ASSIGN;  GET_CHAR(); break; }
+    if ( TLS(In)[0] == ':' && TLS(In)[1] == '=') {
+      TLS(Symbol) = S_INCORPORATE; GET_CHAR(); GET_CHAR(); break;
     }
     break;
 
-  case ';':   Symbol = S_SEMICOLON;                   GET_CHAR();  break;
+  case ';':   TLS(Symbol) = S_SEMICOLON;                   GET_CHAR();  break;
 
-  case '=':   Symbol = S_EQ;                          GET_CHAR();  break;
-  case '<':   Symbol = S_LT;                          GET_CHAR();
-    if ( *In == '\\' ) { GET_CHAR();
-      if ( *In == '\n' ) { GET_CHAR(); } }
-    if ( *In == '=' ) { Symbol = S_LE;      GET_CHAR();  break; }
-    if ( *In == '>' ) { Symbol = S_NE;      GET_CHAR();  break; }
+  case '=':   TLS(Symbol) = S_EQ;                          GET_CHAR();  break;
+  case '<':   TLS(Symbol) = S_LT;                          GET_CHAR();
+    if ( *TLS(In) == '\\' ) { GET_CHAR();
+      if ( *TLS(In) == '\n' ) { GET_CHAR(); } }
+    if ( *TLS(In) == '=' ) { TLS(Symbol) = S_LE;      GET_CHAR();  break; }
+    if ( *TLS(In) == '>' ) { TLS(Symbol) = S_NE;      GET_CHAR();  break; }
     break;
-  case '>':   Symbol = S_GT;                          GET_CHAR();
-    if ( *In == '\\' ) { GET_CHAR();
-      if ( *In == '\n' ) { GET_CHAR(); } }
-    if ( *In == '=' ) { Symbol = S_GE;      GET_CHAR();  break; }
+  case '>':   TLS(Symbol) = S_GT;                          GET_CHAR();
+    if ( *TLS(In) == '\\' ) { GET_CHAR();
+      if ( *TLS(In) == '\n' ) { GET_CHAR(); } }
+    if ( *TLS(In) == '=' ) { TLS(Symbol) = S_GE;      GET_CHAR();  break; }
     break;
 
-  case '+':   Symbol = S_PLUS;                        GET_CHAR();  break;
-  case '-':   Symbol = S_MINUS;                       GET_CHAR();
-    if ( *In == '\\' ) { GET_CHAR();
-      if ( *In == '\n' ) { GET_CHAR(); } }
-    if ( *In == '>' ) { Symbol=S_MAPTO;     GET_CHAR();  break; }
+  case '+':   TLS(Symbol) = S_PLUS;                        GET_CHAR();  break;
+  case '-':   TLS(Symbol) = S_MINUS;                       GET_CHAR();
+    if ( *TLS(In) == '\\' ) { GET_CHAR();
+      if ( *TLS(In) == '\n' ) { GET_CHAR(); } }
+    if ( *TLS(In) == '>' ) { TLS(Symbol)=S_MAPTO;     GET_CHAR();  break; }
     break;
-  case '*':   Symbol = S_MULT;                        GET_CHAR();  break;
-  case '/':   Symbol = S_DIV;                         GET_CHAR();  break;
-  case '^':   Symbol = S_POW;                         GET_CHAR();  break;
-  case '`':   Symbol = S_BACKQUOTE;              GET_CHAR();  break;
+  case '*':   TLS(Symbol) = S_MULT;                        GET_CHAR();  break;
+  case '/':   TLS(Symbol) = S_DIV;                         GET_CHAR();  break;
+  case '^':   TLS(Symbol) = S_POW;                         GET_CHAR();  break;
+  case '`':   TLS(Symbol) = S_BACKQUOTE;                   GET_CHAR();  break;
 
   case '"':                        GET_CHAR(); GetMaybeTripStr();  break;
   case '\'':                                          GetChar();   break;
   case '\\':                                          GetIdent();  break;
   case '_':                                           GetIdent();  break;
   case '@':                                           GetIdent();  break;
-  case '~':   Value[0] = '~';  Value[1] = '\0';
-    Symbol = S_IDENT;                       GET_CHAR();  break;
+  case '~':   TLS(Value)[0] = '~';  TLS(Value)[1] = '\0';
+    TLS(Symbol) = S_IDENT;                       GET_CHAR();  break;
 
   case '0': case '1': case '2': case '3': case '4':
   case '5': case '6': case '7': case '8': case '9':
     GetNumber(0);    break;
 
-  case '\377': Symbol = S_EOF;                        *In = '\0';  break;
+  case '\377': TLS(Symbol) = S_EOF;                        *TLS(In) = '\0';  break;
 
-  default :   if ( IsAlpha(*In) )                   { GetIdent();  break; }
-    Symbol = S_ILLEGAL;                     GET_CHAR();  break;
+  default :   if ( IsAlpha(*TLS(In)) )                   { GetIdent();  break; }
+    TLS(Symbol) = S_ILLEGAL;                     GET_CHAR();  break;
   }
 }
 
@@ -2443,7 +2442,6 @@ void PutChrTo (
   Char                str [MAXLENOUTPUTLINE];
 
 
-
   /* '\01', increment indentation level                                  */
   if ( ch == '\01' ) {
 
@@ -2505,7 +2503,7 @@ void PutChrTo (
   }
 
   /* normal character, room on the current line                          */
-  else if ( stream->pos < SyNrCols-2-NoSplitLine ) {
+  else if ( stream->pos < SyNrCols-2-TLS(NoSplitLine) ) {
 
     /* put the character on this line                                  */
     stream->line[ stream->pos++ ] = ch;
@@ -2621,6 +2619,7 @@ Obj FuncCPROMPT( Obj self)
  **  (important is the flush character without resetting the cursor column)
  */
 Char promptBuf[81];
+
 Obj FuncPRINT_CPROMPT( Obj self, Obj prompt )
 {
   if (IS_STRING_REP(prompt)) {
@@ -2921,10 +2920,10 @@ void FormatOutput(void (*put_a_char)(Char c), const Char *format, Int arg1, Int 
 }
 
 
-static KOutputStream theStream;
+static KOutputStream TheStream;
 
 static void putToTheStream( Char c) {
-  PutChrTo(theStream, c);
+  PutChrTo(TLS(TheStream), c);
 }
 
 void PrTo (
@@ -2933,10 +2932,10 @@ void PrTo (
            Int                 arg1,
            Int                 arg2 )
 {
-  KOutputStream savedStream = theStream;
-  theStream = stream;
+  KOutputStream savedStream = TLS(TheStream);
+  TLS(TheStream) = stream;
   FormatOutput( putToTheStream, format, arg1, arg2);
-  theStream = savedStream;
+  TLS(TheStream) = savedStream;
 }
 
 void Pr (
@@ -2944,43 +2943,43 @@ void Pr (
          Int                 arg1,
          Int                 arg2 )
 {
-  PrTo(Output, format, arg1, arg2);
+  PrTo(TLS(Output), format, arg1, arg2);
 }
 
-static Char *theBuffer;
-static UInt theCount;
-static UInt theLimit;
+static Char *TheBuffer;
+static UInt TheCount;
+static UInt TheLimit;
 
 static void putToTheBuffer( Char c)
 {
-  if (theCount < theLimit)
-    theBuffer[theCount++] = c;
+  if (TLS(TheCount) < TLS(TheLimit))
+    TLS(TheBuffer)[TLS(TheCount)++] = c;
 }
 
 void SPrTo(Char *buffer, UInt maxlen, const Char *format, Int arg1, Int arg2)
 {
-  Char *savedBuffer = theBuffer;
-  UInt savedCount = theCount;
-  UInt savedLimit = theLimit;
-  theBuffer = buffer;
-  theCount = 0;
-  theLimit = maxlen;
+  Char *savedBuffer = TLS(TheBuffer);
+  UInt savedCount = TLS(TheCount);
+  UInt savedLimit = TLS(TheLimit);
+  TLS(TheBuffer) = buffer;
+  TLS(TheCount) = 0;
+  TLS(TheLimit) = maxlen;
   FormatOutput(putToTheBuffer, format, arg1, arg2);
   putToTheBuffer('\0');
-  theBuffer = savedBuffer;
-  theCount = savedCount;
-  theLimit = savedLimit;
+  TLS(TheBuffer) = savedBuffer;
+  TLS(TheCount) = savedCount;
+  TLS(TheLimit) = savedLimit;
 }
 
 
 Obj FuncINPUT_FILENAME( Obj self) {
   Obj s;
-  C_NEW_STRING_DYN( s, Input->name );
+  C_NEW_STRING_DYN( s, TLS(Input)->name );
   return s;
 }
 
 Obj FuncINPUT_LINENUMBER( Obj self) {
-  return INTOBJ_INT(Input->number);
+  return INTOBJ_INT(TLS(Input)->number);
 }
 
 Obj FuncALL_KEYWORDS(Obj self) {
@@ -3000,9 +2999,9 @@ Obj FuncALL_KEYWORDS(Obj self) {
 
 Obj FuncSET_PRINT_FORMATTING_STDOUT(Obj self, Obj val) {
   if (val == False)
-    (OutputFiles+1)->format = 0;
+    (TLS(OutputFiles)+1)->format = 0;
   else
-    (OutputFiles+1)->format = 1;
+    (TLS(OutputFiles)+1)->format = 1;
   return val;
 }
 
@@ -3063,53 +3062,53 @@ static Int InitLibrary (
  **
  *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
  */
-static Char Cookie[sizeof(InputFiles)/sizeof(InputFiles[0])][9];
-static Char MoreCookie[sizeof(InputFiles)/sizeof(InputFiles[0])][9];
-static Char StillMoreCookie[sizeof(InputFiles)/sizeof(InputFiles[0])][9];
+static Char Cookie[sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0])][9];
+static Char MoreCookie[sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0])][9];
+static Char StillMoreCookie[sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0])][9];
 
 static Int InitKernel (
     StructInitInfo *    module )
 {
     Int                 i;
 
-    Input = InputFiles;
-    Input--;
+    TLS(Input) = TLS(InputFiles);
+    TLS(Input)--;
     (void)OpenInput(  "*stdin*"  );
-    Input->echo = 1; /* echo stdin */
-    Output = 0L;
+    TLS(Input)->echo = 1; /* echo stdin */
+    TLS(Output) = 0L;
     (void)OpenOutput( "*stdout*" );
 
-    InputLog  = 0;  OutputLog  = 0;
-    TestInput = 0;  TestOutput = 0;
+    TLS(InputLog)  = 0;  TLS(OutputLog)  = 0;
+    TLS(TestInput) = 0;  TLS(TestOutput) = 0;
 
     /* initialize cookies for streams                                      */
     /* also initialize the cookies for the GAP strings which hold the
        latest lines read from the streams  and the name of the current input file*/
-    for ( i = 0;  i < sizeof(InputFiles)/sizeof(InputFiles[0]);  i++ ) {
+    for ( i = 0;  i < sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0]);  i++ ) {
       Cookie[i][0] = 's';  Cookie[i][1] = 't';  Cookie[i][2] = 'r';
       Cookie[i][3] = 'e';  Cookie[i][4] = 'a';  Cookie[i][5] = 'm';
       Cookie[i][6] = ' ';  Cookie[i][7] = '0'+i;
       Cookie[i][8] = '\0';
-      InitGlobalBag(&(InputFiles[i].stream), &(Cookie[i][0]));
+      InitGlobalBag(&(TLS(InputFiles)[i].stream), &(Cookie[i][0]));
 
       MoreCookie[i][0] = 's';  MoreCookie[i][1] = 'l';  MoreCookie[i][2] = 'i';
       MoreCookie[i][3] = 'n';  MoreCookie[i][4] = 'e';  MoreCookie[i][5] = ' ';
       MoreCookie[i][6] = ' ';  MoreCookie[i][7] = '0'+i;
       MoreCookie[i][8] = '\0';
-      InitGlobalBag(&(InputFiles[i].sline), &(MoreCookie[i][0]));
+      InitGlobalBag(&(TLS(InputFiles)[i].sline), &(MoreCookie[i][0]));
 
       StillMoreCookie[i][0] = 'g';  StillMoreCookie[i][1] = 'a';  StillMoreCookie[i][2] = 'p';
       StillMoreCookie[i][3] = 'n';  StillMoreCookie[i][4] = 'a';  StillMoreCookie[i][5] = 'm';
       StillMoreCookie[i][6] = 'e';  StillMoreCookie[i][7] = '0'+i;
       StillMoreCookie[i][8] = '\0';
-      InitGlobalBag(&(InputFiles[i].gapname), &(StillMoreCookie[i][0]));
+      InitGlobalBag(&(TLS(InputFiles)[i].gapname), &(StillMoreCookie[i][0]));
     }
 
     /* tell GASMAN about the global bags                                   */
-    InitGlobalBag(&(logFile.stream),        "src/scanner.c:logFile"        );
-    InitGlobalBag(&(logStream.stream),      "src/scanner.c:logStream"      );
-    InitGlobalBag(&(inputLogStream.stream), "src/scanner.c:inputLogStream" );
-    InitGlobalBag(&(outputLogStream.stream),"src/scanner.c:outputLogStream");
+    InitGlobalBag(&(LogFile.stream),        "src/scanner.c:LogFile"        );
+    InitGlobalBag(&(LogStream.stream),      "src/scanner.c:LogStream"      );
+    InitGlobalBag(&(InputLogStream.stream), "src/scanner.c:InputLogStream" );
+    InitGlobalBag(&(OutputLogStream.stream),"src/scanner.c:OutputLogStream");
 
 
     /* import functions from the library                                   */
@@ -3153,6 +3152,5 @@ StructInitInfo * InitInfoScanner ( void )
 
 /****************************************************************************
  **
-
  *E  scanner.c . . . . . . . . . . . . . . . . . . . . . . . . . . . ends here
  */

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -128,36 +128,36 @@ void            SyntaxError (
 
     /* open error output                                                   */
     OpenOutput( "*errout*" );
-    assert(Output);
+    assert(TLS(Output));
 
     /* one more error                                                      */
-    NrError++;
-    NrErrLine++;
+    TLS(NrError)++;
+    TLS(NrErrLine)++;
 
     /* do not print a message if we found one already on the current line  */
-    if ( NrErrLine == 1 )
+    if ( TLS(NrErrLine) == 1 )
 
       {
         /* print the message and the filename, unless it is '*stdin*'          */
         Pr( "Syntax error: %s", (Int)msg, 0L );
-        if ( strcmp( "*stdin*", Input->name ) != 0 )
-          Pr( " in %s line %d", (Int)Input->name, (Int)Input->number );
+        if ( strcmp( "*stdin*", TLS(Input)->name ) != 0 )
+          Pr( " in %s line %d", (Int)TLS(Input)->name, (Int)TLS(Input)->number );
         Pr( "\n", 0L, 0L );
 
         /* print the current line                                              */
-        Pr( "%s", (Int)Input->line, 0L );
+        Pr( "%s", (Int)TLS(Input)->line, 0L );
 
         /* print a '^' pointing to the current position                        */
-        for ( i = 0; i < In - Input->line - 1; i++ ) {
-          if ( Input->line[i] == '\t' )  Pr("\t",0L,0L);
+        for ( i = 0; i < TLS(In) - TLS(Input)->line - 1; i++ ) {
+          if ( TLS(Input)->line[i] == '\t' )  Pr("\t",0L,0L);
           else  Pr(" ",0L,0L);
         }
         Pr( "^\n", 0L, 0L );
       }
     /* close error output                                                  */
-    assert(Output);
+    assert(TLS(Output));
     CloseOutput();
-    assert(Output);
+    assert(TLS(Output));
 }
 
 /****************************************************************************
@@ -172,33 +172,33 @@ void            SyntaxWarning (
 
     /* open error output                                                   */
     OpenOutput( "*errout*" );
-    assert(Output);
+    assert(TLS(Output));
 
 
     /* do not print a message if we found one already on the current line  */
-    if ( NrErrLine == 0 )
+    if ( TLS(NrErrLine) == 0 )
 
       {
         /* print the message and the filename, unless it is '*stdin*'          */
         Pr( "Syntax warning: %s", (Int)msg, 0L );
-        if ( strcmp( "*stdin*", Input->name ) != 0 )
-          Pr( " in %s line %d", (Int)Input->name, (Int)Input->number );
+        if ( strcmp( "*stdin*", TLS(Input)->name ) != 0 )
+          Pr( " in %s line %d", (Int)TLS(Input)->name, (Int)TLS(Input)->number );
         Pr( "\n", 0L, 0L );
 
         /* print the current line                                              */
-        Pr( "%s", (Int)Input->line, 0L );
+        Pr( "%s", (Int)TLS(Input)->line, 0L );
 
         /* print a '^' pointing to the current position                        */
-        for ( i = 0; i < In - Input->line - 1; i++ ) {
-          if ( Input->line[i] == '\t' )  Pr("\t",0L,0L);
+        for ( i = 0; i < TLS(In) - TLS(Input)->line - 1; i++ ) {
+          if ( TLS(Input)->line[i] == '\t' )  Pr("\t",0L,0L);
           else  Pr(" ",0L,0L);
         }
         Pr( "^\n", 0L, 0L );
       }
     /* close error output                                                  */
-    assert(Output);
+    assert(TLS(Output));
     CloseOutput();
-    assert(Output);
+    assert(TLS(Output));
 }
 
 
@@ -252,8 +252,8 @@ void Match (
 {
     Char                errmsg [256];
 
-    /* if 'Symbol' is the expected symbol match it away                    */
-    if ( symbol == Symbol ) {
+    /* if 'TLS(Symbol)' is the expected symbol match it away                    */
+    if ( symbol == TLS(Symbol) ) {
         GetSymbol();
     }
 
@@ -262,7 +262,7 @@ void Match (
         strlcpy( errmsg, msg, sizeof(errmsg) );
         strlcat( errmsg, " expected", sizeof(errmsg) );
         SyntaxError( errmsg );
-        while ( ! IS_IN( Symbol, skipto ) )
+        while ( ! IS_IN( TLS(Symbol), skipto ) )
             GetSymbol();
     }
 }
@@ -470,7 +470,7 @@ UInt OpenTest (
     const Char *        filename )
 {
     /* do not allow to nest test files                                     */
-    if ( TestInput != 0 )
+    if ( TLS(TestInput) != 0 )
         return 0;
 
     /* try to open the file as input file                                  */
@@ -478,9 +478,9 @@ UInt OpenTest (
         return 0;
 
     /* remember this is a test input                                       */
-    TestInput   = Input;
-    TestOutput  = Output;
-    TestLine[0] = '\0';
+    TLS(TestInput)   = TLS(Input);
+    TLS(TestOutput)  = TLS(Output);
+    TLS(TestLine)[0] = '\0';
 
     /* indicate success                                                    */
     return 1;
@@ -496,7 +496,7 @@ UInt OpenTestStream (
     Obj                 stream )
 {
     /* do not allow to nest test files                                     */
-    if ( TestInput != 0 )
+    if ( TLS(TestInput) != 0 )
         return 0;
 
     /* try to open the file as input file                                  */
@@ -504,9 +504,9 @@ UInt OpenTestStream (
         return 0;
 
     /* remember this is a test input                                       */
-    TestInput   = Input;
-    TestOutput  = Output;
-    TestLine[0] = '\0';
+    TLS(TestInput)   = TLS(Input);
+    TLS(TestOutput)  = TLS(Output);
+    TLS(TestLine)[0] = '\0';
 
     /* indicate success                                                    */
     return 1;
@@ -631,15 +631,15 @@ UInt OpenLogStream (
 UInt CloseLog ( void )
 {
     /* refuse to close a non existent logfile                              */
-    if ( InputLog == 0 || OutputLog == 0 || InputLog != OutputLog )
+    if ( TLS(InputLog) == 0 || TLS(OutputLog) == 0 || TLS(InputLog) != TLS(OutputLog) )
         return 0;
 
     /* close the logfile                                                   */
-    if ( ! InputLog->isstream ) {
-        SyFclose( InputLog->file );
+    if ( ! TLS(InputLog)->isstream ) {
+        SyFclose( TLS(InputLog)->file );
     }
-    InputLog  = 0;
-    OutputLog = 0;
+    TLS(InputLog)  = 0;
+    TLS(OutputLog) = 0;
 
     /* indicate success                                                    */
     return 1;
@@ -726,19 +726,19 @@ UInt OpenInputLogStream (
 UInt CloseInputLog ( void )
 {
     /* refuse to close a non existent logfile                              */
-    if ( InputLog == 0 )
+    if ( TLS(InputLog) == 0 )
         return 0;
 
     /* refuse to close a log opened with LogTo */
-    if (InputLog == OutputLog)
+    if (TLS(InputLog) == TLS(OutputLog))
       return 0;
     
     /* close the logfile                                                   */
-    if ( ! InputLog->isstream ) {
-        SyFclose( InputLog->file );
+    if ( ! TLS(InputLog)->isstream ) {
+        SyFclose( TLS(InputLog)->file );
     }
 
-    InputLog = 0;
+    TLS(InputLog) = 0;
 
     /* indicate success                                                    */
     return 1;
@@ -825,19 +825,19 @@ UInt OpenOutputLogStream (
 UInt CloseOutputLog ( void )
 {
     /* refuse to close a non existent logfile                              */
-    if ( OutputLog == 0 )
+    if ( TLS(OutputLog) == 0 )
         return 0;
 
     /* refuse to close a log opened with LogTo */
-    if (OutputLog == InputLog)
+    if (TLS(OutputLog) == TLS(InputLog))
       return 0;
 
     /* close the logfile                                                   */
-    if ( ! OutputLog->isstream ) {
-        SyFclose( OutputLog->file );
+    if ( ! TLS(OutputLog)->isstream ) {
+        SyFclose( TLS(OutputLog)->file );
     }
 
-    OutputLog = 0;
+    TLS(OutputLog) = 0;
 
     /* indicate success                                                    */
     return 1;
@@ -1162,43 +1162,43 @@ Char GetLine ( void )
     /* if file is '*stdin*' or '*errin*' print the prompt and flush it     */
     /* if the GAP function `PrintPromptHook' is defined then it is called  */
     /* for printing the prompt, see also `EndLineHook'                     */
-    if ( ! Input->isstream ) {
-       if ( Input->file == 0 ) {
+    if ( ! TLS(Input)->isstream ) {
+       if ( TLS(Input)->file == 0 ) {
             if ( ! SyQuiet ) {
-                if (Output->pos > 0)
+                if (TLS(Output)->pos > 0)
                     Pr("\n", 0L, 0L);
                 if ( PrintPromptHook )
                      Call0ArgsInNewReader( PrintPromptHook );
                 else
-                     Pr( "%s%c", (Int)Prompt, (Int)'\03' );
+                     Pr( "%s%c", (Int)TLS(Prompt), (Int)'\03' );
             } else
                 Pr( "%c", (Int)'\03', 0L );
         }
-        else if ( Input->file == 2 ) {
-            if (Output->pos > 0)
+        else if ( TLS(Input)->file == 2 ) {
+            if (TLS(Output)->pos > 0)
                 Pr("\n", 0L, 0L);
             if ( PrintPromptHook )
                  Call0ArgsInNewReader( PrintPromptHook );
             else
-                 Pr( "%s%c", (Int)Prompt, (Int)'\03' );
+                 Pr( "%s%c", (Int)TLS(Prompt), (Int)'\03' );
         }
     }
 
     /* bump the line number                                                */
-    if ( Input->line < In && (*(In-1) == '\n' || *(In-1) == '\r') ) {
-        Input->number++;
+    if ( TLS(Input)->line < TLS(In) && (*(TLS(In)-1) == '\n' || *(TLS(In)-1) == '\r') ) {
+        TLS(Input)->number++;
     }
 
-    /* initialize 'In', no errors on this line so far                      */
-    In = Input->line;  In[0] = '\0';
-    NrErrLine = 0;
+    /* initialize 'TLS(In)', no errors on this line so far                      */
+    TLS(In) = TLS(Input)->line;  TLS(In)[0] = '\0';
+    TLS(NrErrLine) = 0;
 
     /* read a line from an ordinary input file                             */
-    if ( TestInput != Input ) {
+    if ( TLS(TestInput) != TLS(Input) ) {
 
         /* try to read a line                                              */
-        if ( ! GetLine2( Input, Input->line, sizeof(Input->line) ) ) {
-            In[0] = '\377';  In[1] = '\0';
+        if ( ! GetLine2( TLS(Input), TLS(Input)->line, sizeof(TLS(Input)->line) ) ) {
+            TLS(In)[0] = '\377';  TLS(In)[1] = '\0';
         }
 
 
@@ -1220,18 +1220,18 @@ Char GetLine ( void )
             }
             *p = '\0';
             /* FIXME: We should do bounds checking, but don't know what 'In' points to */
-            strcat( In, "\");\n" );
+            strcat( TLS(In), "\");\n" );
         }
 
         /* if necessary echo the line to the logfile                      */
-        if( InputLog != 0 && Input->echo == 1)
-            if ( !(In[0] == '\377' && In[1] == '\0') )
-            PutLine2( InputLog, In, strlen(In) );
+        if( TLS(InputLog) != 0 && TLS(Input)->echo == 1)
+            if ( !(TLS(In)[0] == '\377' && TLS(In)[1] == '\0') )
+            PutLine2( TLS(InputLog), TLS(In), strlen(TLS(In)) );
 
-                /*      if ( ! Input->isstream ) {
-          if ( InputLog != 0 && ! Input->isstream ) {
-            if ( Input->file == 0 || Input->file == 2 ) {
-              PutLine2( InputLog, In );
+                /*      if ( ! TLS(Input)->isstream ) {
+          if ( TLS(InputLog) != 0 && ! TLS(Input)->isstream ) {
+            if ( TLS(Input)->file == 0 || TLS(Input)->file == 2 ) {
+              PutLine2( TLS(InputLog), TLS(In) );
             }
             }
             } */
@@ -1242,40 +1242,40 @@ Char GetLine ( void )
     else {
 
         /* continue until we got an input line                             */
-        while ( In[0] == '\0' ) {
+        while ( TLS(In)[0] == '\0' ) {
 
             /* there may be one line waiting                               */
-            if ( TestLine[0] != '\0' ) {
-                SyStrncat( In, TestLine, sizeof(Input->line) );
-                TestLine[0] = '\0';
+            if ( TLS(TestLine)[0] != '\0' ) {
+                SyStrncat( TLS(In), TLS(TestLine), sizeof(TLS(Input)->line) );
+                TLS(TestLine)[0] = '\0';
             }
 
             /* otherwise try to read a line                                */
             else {
-                if ( ! GetLine2(Input, Input->line, sizeof(Input->line)) ) {
-                    In[0] = '\377';  In[1] = '\0';
+                if ( ! GetLine2(TLS(Input), TLS(Input)->line, sizeof(TLS(Input)->line)) ) {
+                    TLS(In)[0] = '\377';  TLS(In)[1] = '\0';
                 }
             }
 
             /* if the line starts with a prompt its an input line          */
-            if      ( In[0] == 'g' && In[1] == 'a' && In[2] == 'p'
-                   && In[3] == '>' && In[4] == ' ' ) {
-                In = In + 5;
+            if      ( TLS(In)[0] == 'g' && TLS(In)[1] == 'a' && TLS(In)[2] == 'p'
+                   && TLS(In)[3] == '>' && TLS(In)[4] == ' ' ) {
+                TLS(In) = TLS(In) + 5;
             }
-            else if ( In[0] == '>' && In[1] == ' ' ) {
-                In = In + 2;
+            else if ( TLS(In)[0] == '>' && TLS(In)[1] == ' ' ) {
+                TLS(In) = TLS(In) + 2;
             }
 
             /* if the line is not empty or a comment, print it             */
-            else if ( In[0] != '\n' && In[0] != '#' && In[0] != '\377' ) {
+            else if ( TLS(In)[0] != '\n' && TLS(In)[0] != '#' && TLS(In)[0] != '\377' ) {
                 /* Commented out by AK
                 char obuf[8];
-                snprintf(obuf, sizeof(obuf), "-%5i:\n- ", (int)TestInput->number++);
-                PutLine2( TestOutput, obuf, 7 );
+                snprintf(obuf, sizeof(obuf), "-%5i:\n- ", (int)TLS(TestInput)->number++);
+                PutLine2( TLS(TestOutput), obuf, 7 );
                 */
-                PutLine2( TestOutput, "- ", 2 );
-                PutLine2( TestOutput, In, strlen(In) );
-                In[0] = '\0';
+                PutLine2( TLS(TestOutput), "- ", 2 );
+                PutLine2( TLS(TestOutput), TLS(In), strlen(TLS(In)) );
+                TLS(In)[0] = '\0';
             }
 
         }
@@ -1283,7 +1283,7 @@ Char GetLine ( void )
     }
 
     /* return the current character                                        */
-    return *In;
+    return *TLS(In);
 }
 
 
@@ -1304,19 +1304,19 @@ static Char Pushback = '\0';
 static Char *RealIn;
 
 static inline void GET_CHAR( void ) {
-  if (In == &Pushback) {
-      In = RealIn;
+  if (TLS(In) == &Pushback) {
+      TLS(In) = RealIn;
   } else
-    In++;
-  if (!*In)
+    TLS(In)++;
+  if (!*TLS(In))
     GetLine();
 }
 
 static inline void UNGET_CHAR( Char c ) {
-  assert(In != &Pushback);
+  assert(TLS(In) != &Pushback);
   Pushback = c;
-  RealIn = In;
-  In = &Pushback;
+  RealIn = TLS(In);
+  TLS(In) = &Pushback;
 }
 
 
@@ -1325,10 +1325,10 @@ static inline void UNGET_CHAR( Char c ) {
 *F  GetIdent()  . . . . . . . . . . . . . get an identifier or keyword, local
 **
 **  'GetIdent' reads   an identifier from  the current  input  file  into the
-**  variable 'Value' and sets 'Symbol' to 'S_IDENT'.   The first character of
+**  variable 'TLS(Value)' and sets 'Symbol' to 'S_IDENT'.   The first character of
 **  the   identifier  is  the current character  pointed to  by 'In'.  If the
 **  characters make  up   a  keyword 'GetIdent'  will  set   'Symbol'  to the
-**  corresponding value.  The parser will ignore 'Value' in this case.
+**  corresponding value.  The parser will ignore 'TLS(Value)' in this case.
 **
 **  An  identifier consists of a letter  followed by more letters, digits and
 **  underscores '_'.  An identifier is terminated by the first  character not
@@ -1337,19 +1337,19 @@ static inline void UNGET_CHAR( Char c ) {
 **  '\' can be used  to include special characters like  '('  in identifiers.
 **  For example 'G\(2\,5\)' is an identifier not a call to a function 'G'.
 **
-**  The size  of 'Value' limits the  number  of significant characters  in an
+**  The size  of 'TLS(Value)' limits the  number  of significant characters  in an
 **  identifier.   If  an  identifier   has more characters    'GetIdent' will
 **  silently truncate it.
 **
 **  After reading the identifier 'GetIdent'  looks at the  first and the last
-**  character  of  'Value' to see if  it  could possibly  be  a keyword.  For
+**  character  of  'TLS(Value)' to see if  it  could possibly  be  a keyword.  For
 **  example 'test'  could  not be  a  keyword  because there  is  no  keyword
 **  starting and ending with a 't'.  After that  test either 'GetIdent' knows
-**  that 'Value' is not a keyword, or there is a unique possible keyword that
+**  that 'TLS(Value)' is not a keyword, or there is a unique possible keyword that
 **  could match, because   no two  keywords  have  identical  first and  last
-**  characters.  For example if 'Value' starts with 'f' and ends with 'n' the
+**  characters.  For example if 'TLS(Value)' starts with 'f' and ends with 'n' the
 **  only possible keyword  is 'function'.   Thus in this case  'GetIdent' can
-**  decide with one string comparison if 'Value' holds a keyword or not.
+**  decide with one string comparison if 'TLS(Value)' holds a keyword or not.
 */
 extern void GetSymbol ( void );
 
@@ -1405,39 +1405,39 @@ void GetIdent ( void )
     /* initially it could be a keyword                                     */
     isQuoted = 0;
 
-    /* read all characters into 'Value'                                    */
-    for ( i=0; IsIdent(*In) || IsDigit(*In) || *In=='\\'; i++ ) {
+    /* read all characters into 'TLS(Value)'                                    */
+    for ( i=0; IsIdent(*TLS(In)) || IsDigit(*TLS(In)) || *TLS(In)=='\\'; i++ ) {
 
         fetch = 1;
         /* handle escape sequences                                         */
         /* we ignore '\ newline' by decrementing i, except at the
            very start of the identifier, when we cannot do that
            so we recurse instead                                           */
-        if ( *In == '\\' ) {
+        if ( *TLS(In) == '\\' ) {
             GET_CHAR();
-            if      ( *In == '\n' && i == 0 )  { GetSymbol();  return; }
-            else if ( *In == '\r' )  {
+            if      ( *TLS(In) == '\n' && i == 0 )  { GetSymbol();  return; }
+            else if ( *TLS(In) == '\r' )  {
                 GET_CHAR();
-                if  ( *In == '\n' )  {
+                if  ( *TLS(In) == '\n' )  {
                      if (i == 0) { GetSymbol();  return; }
                      else i--;
                 }
-                else  {Value[i] = '\r'; fetch = 0;}
+                else  {TLS(Value)[i] = '\r'; fetch = 0;}
             }
-            else if ( *In == '\n' && i < SAFE_VALUE_SIZE-1 )  i--;
-            else if ( *In == 'n'  && i < SAFE_VALUE_SIZE-1 )  Value[i] = '\n';
-            else if ( *In == 't'  && i < SAFE_VALUE_SIZE-1 )  Value[i] = '\t';
-            else if ( *In == 'r'  && i < SAFE_VALUE_SIZE-1 )  Value[i] = '\r';
-            else if ( *In == 'b'  && i < SAFE_VALUE_SIZE-1 )  Value[i] = '\b';
+            else if ( *TLS(In) == '\n' && i < SAFE_VALUE_SIZE-1 )  i--;
+            else if ( *TLS(In) == 'n'  && i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = '\n';
+            else if ( *TLS(In) == 't'  && i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = '\t';
+            else if ( *TLS(In) == 'r'  && i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = '\r';
+            else if ( *TLS(In) == 'b'  && i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = '\b';
             else if ( i < SAFE_VALUE_SIZE-1 )  {
-                Value[i] = *In;
+                TLS(Value)[i] = *TLS(In);
                 isQuoted = 1;
             }
         }
 
-        /* put normal chars into 'Value' but only if there is room         */
+        /* put normal chars into 'TLS(Value)' but only if there is room         */
         else {
-            if ( i < SAFE_VALUE_SIZE-1 )  Value[i] = *In;
+            if ( i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = *TLS(In);
         }
 
         /* read the next character                                         */
@@ -1447,59 +1447,59 @@ void GetIdent ( void )
 
     /* terminate the identifier and lets assume that it is not a keyword   */
     if ( i < SAFE_VALUE_SIZE-1 )
-        Value[i] = '\0';
+        TLS(Value)[i] = '\0';
     else {
         SyntaxError("Identifiers in GAP must consist of less than 1023 characters.");
         i =  SAFE_VALUE_SIZE-1;
-        Value[i] = '\0';
+        TLS(Value)[i] = '\0';
     }
-    Symbol = S_IDENT;
+    TLS(Symbol) = S_IDENT;
 
-    /* now check if 'Value' holds a keyword                                */
-    switch ( 256*Value[0]+Value[i-1] ) {
-    case 256*'a'+'d': if(!strcmp(Value,"and"))     Symbol=S_AND;     break;
-    case 256*'a'+'c': if(!strcmp(Value,"atomic"))  Symbol=S_ATOMIC;  break;
-    case 256*'b'+'k': if(!strcmp(Value,"break"))   Symbol=S_BREAK;   break;
-    case 256*'c'+'e': if(!strcmp(Value,"continue"))   Symbol=S_CONTINUE;   break;
-    case 256*'d'+'o': if(!strcmp(Value,"do"))      Symbol=S_DO;      break;
-    case 256*'e'+'f': if(!strcmp(Value,"elif"))    Symbol=S_ELIF;    break;
-    case 256*'e'+'e': if(!strcmp(Value,"else"))    Symbol=S_ELSE;    break;
-    case 256*'e'+'d': if(!strcmp(Value,"end"))     Symbol=S_END;     break;
-    case 256*'f'+'e': if(!strcmp(Value,"false"))   Symbol=S_FALSE;   break;
-    case 256*'f'+'i': if(!strcmp(Value,"fi"))      Symbol=S_FI;      break;
-    case 256*'f'+'r': if(!strcmp(Value,"for"))     Symbol=S_FOR;     break;
-    case 256*'f'+'n': if(!strcmp(Value,"function"))Symbol=S_FUNCTION;break;
-    case 256*'i'+'f': if(!strcmp(Value,"if"))      Symbol=S_IF;      break;
-    case 256*'i'+'n': if(!strcmp(Value,"in"))      Symbol=S_IN;      break;
-    case 256*'l'+'l': if(!strcmp(Value,"local"))   Symbol=S_LOCAL;   break;
-    case 256*'m'+'d': if(!strcmp(Value,"mod"))     Symbol=S_MOD;     break;
-    case 256*'n'+'t': if(!strcmp(Value,"not"))     Symbol=S_NOT;     break;
-    case 256*'o'+'d': if(!strcmp(Value,"od"))      Symbol=S_OD;      break;
-    case 256*'o'+'r': if(!strcmp(Value,"or"))      Symbol=S_OR;      break;
-    case 256*'r'+'e': if(!strcmp(Value,"readwrite")) Symbol=S_READWRITE;     break;
-    case 256*'r'+'y': if(!strcmp(Value,"readonly"))  Symbol=S_READONLY;     break;
-    case 256*'r'+'c': if(!strcmp(Value,"rec"))     Symbol=S_REC;     break;
-    case 256*'r'+'t': if(!strcmp(Value,"repeat"))  Symbol=S_REPEAT;  break;
-    case 256*'r'+'n': if(!strcmp(Value,"return"))  Symbol=S_RETURN;  break;
-    case 256*'t'+'n': if(!strcmp(Value,"then"))    Symbol=S_THEN;    break;
-    case 256*'t'+'e': if(!strcmp(Value,"true"))    Symbol=S_TRUE;    break;
-    case 256*'u'+'l': if(!strcmp(Value,"until"))   Symbol=S_UNTIL;   break;
-    case 256*'w'+'e': if(!strcmp(Value,"while"))   Symbol=S_WHILE;   break;
-    case 256*'q'+'t': if(!strcmp(Value,"quit"))    Symbol=S_QUIT;    break;
-    case 256*'Q'+'T': if(!strcmp(Value,"QUIT"))    Symbol=S_QQUIT;   break;
+    /* now check if 'TLS(Value)' holds a keyword                                */
+    switch ( 256*TLS(Value)[0]+TLS(Value)[i-1] ) {
+    case 256*'a'+'d': if(!strcmp(TLS(Value),"and"))     TLS(Symbol)=S_AND;     break;
+    case 256*'a'+'c': if(!strcmp(TLS(Value),"atomic"))  TLS(Symbol)=S_ATOMIC;  break;
+    case 256*'b'+'k': if(!strcmp(TLS(Value),"break"))   TLS(Symbol)=S_BREAK;   break;
+    case 256*'c'+'e': if(!strcmp(TLS(Value),"continue"))   TLS(Symbol)=S_CONTINUE;   break;
+    case 256*'d'+'o': if(!strcmp(TLS(Value),"do"))      TLS(Symbol)=S_DO;      break;
+    case 256*'e'+'f': if(!strcmp(TLS(Value),"elif"))    TLS(Symbol)=S_ELIF;    break;
+    case 256*'e'+'e': if(!strcmp(TLS(Value),"else"))    TLS(Symbol)=S_ELSE;    break;
+    case 256*'e'+'d': if(!strcmp(TLS(Value),"end"))     TLS(Symbol)=S_END;     break;
+    case 256*'f'+'e': if(!strcmp(TLS(Value),"false"))   TLS(Symbol)=S_FALSE;   break;
+    case 256*'f'+'i': if(!strcmp(TLS(Value),"fi"))      TLS(Symbol)=S_FI;      break;
+    case 256*'f'+'r': if(!strcmp(TLS(Value),"for"))     TLS(Symbol)=S_FOR;     break;
+    case 256*'f'+'n': if(!strcmp(TLS(Value),"function"))TLS(Symbol)=S_FUNCTION;break;
+    case 256*'i'+'f': if(!strcmp(TLS(Value),"if"))      TLS(Symbol)=S_IF;      break;
+    case 256*'i'+'n': if(!strcmp(TLS(Value),"in"))      TLS(Symbol)=S_IN;      break;
+    case 256*'l'+'l': if(!strcmp(TLS(Value),"local"))   TLS(Symbol)=S_LOCAL;   break;
+    case 256*'m'+'d': if(!strcmp(TLS(Value),"mod"))     TLS(Symbol)=S_MOD;     break;
+    case 256*'n'+'t': if(!strcmp(TLS(Value),"not"))     TLS(Symbol)=S_NOT;     break;
+    case 256*'o'+'d': if(!strcmp(TLS(Value),"od"))      TLS(Symbol)=S_OD;      break;
+    case 256*'o'+'r': if(!strcmp(TLS(Value),"or"))      TLS(Symbol)=S_OR;      break;
+    case 256*'r'+'e': if(!strcmp(TLS(Value),"readwrite")) TLS(Symbol)=S_READWRITE;     break;
+    case 256*'r'+'y': if(!strcmp(TLS(Value),"readonly"))  TLS(Symbol)=S_READONLY;     break;
+    case 256*'r'+'c': if(!strcmp(TLS(Value),"rec"))     TLS(Symbol)=S_REC;     break;
+    case 256*'r'+'t': if(!strcmp(TLS(Value),"repeat"))  TLS(Symbol)=S_REPEAT;  break;
+    case 256*'r'+'n': if(!strcmp(TLS(Value),"return"))  TLS(Symbol)=S_RETURN;  break;
+    case 256*'t'+'n': if(!strcmp(TLS(Value),"then"))    TLS(Symbol)=S_THEN;    break;
+    case 256*'t'+'e': if(!strcmp(TLS(Value),"true"))    TLS(Symbol)=S_TRUE;    break;
+    case 256*'u'+'l': if(!strcmp(TLS(Value),"until"))   TLS(Symbol)=S_UNTIL;   break;
+    case 256*'w'+'e': if(!strcmp(TLS(Value),"while"))   TLS(Symbol)=S_WHILE;   break;
+    case 256*'q'+'t': if(!strcmp(TLS(Value),"quit"))    TLS(Symbol)=S_QUIT;    break;
+    case 256*'Q'+'T': if(!strcmp(TLS(Value),"QUIT"))    TLS(Symbol)=S_QQUIT;   break;
 
-    case 256*'I'+'d': if(!strcmp(Value,"IsBound")) Symbol=S_ISBOUND; break;
-    case 256*'U'+'d': if(!strcmp(Value,"Unbind"))  Symbol=S_UNBIND;  break;
-    case 256*'T'+'d': if(!strcmp(Value,"TryNextMethod"))
-                                                     Symbol=S_TRYNEXT; break;
-    case 256*'I'+'o': if(!strcmp(Value,"Info"))    Symbol=S_INFO;    break;
-    case 256*'A'+'t': if(!strcmp(Value,"Assert"))  Symbol=S_ASSERT;  break;
+    case 256*'I'+'d': if(!strcmp(TLS(Value),"IsBound")) TLS(Symbol)=S_ISBOUND; break;
+    case 256*'U'+'d': if(!strcmp(TLS(Value),"Unbind"))  TLS(Symbol)=S_UNBIND;  break;
+    case 256*'T'+'d': if(!strcmp(TLS(Value),"TryNextMethod"))
+                                                     TLS(Symbol)=S_TRYNEXT; break;
+    case 256*'I'+'o': if(!strcmp(TLS(Value),"Info"))    TLS(Symbol)=S_INFO;    break;
+    case 256*'A'+'t': if(!strcmp(TLS(Value),"Assert"))  TLS(Symbol)=S_ASSERT;  break;
 
     default: ;
     }
 
     /* if it is quoted it is an identifier                                 */
-    if ( isQuoted )  Symbol = S_IDENT;
+    if ( isQuoted )  TLS(Symbol) = S_IDENT;
 
 
 }
@@ -1509,7 +1509,7 @@ void GetIdent ( void )
 *F  GetNumber()  . . . . . . . . . . . . . .  get an integer or float literal
 **
 **  'GetNumber' reads  a number from  the  current  input file into the
-**  variable  'Value' and sets  'Symbol' to 'S_INT', 'S_PARTIALINT',
+**  variable  'TLS(Value)' and sets  'Symbol' to 'S_INT', 'S_PARTIALINT',
 **  'S_FLOAT' or 'S_PARTIALFLOAT'.   The first character of
 **  the number is the current character pointed to by 'In'.
 **
@@ -1520,7 +1520,7 @@ void GetIdent ( void )
 **  As we read, we keep track of whether we have seen a . or exponent notation
 **  and so whether we will return S_[PARTIAL]INT or S_[PARTIAL]FLOAT.
 **
-**  When Value is  completely filled we have to check  if the reading of
+**  When TLS(Value) is  completely filled we have to check  if the reading of
 **  the number  is complete  or not to  decide whether to return a PARTIAL type.
 **
 **  The argument reflects how far we are through reading a possibly very long number
@@ -1534,32 +1534,32 @@ void GetIdent ( void )
 static Char GetCleanedChar( UInt *wasEscaped ) {
   GET_CHAR();
   *wasEscaped = 0;
-  if (*In == '\\') {
+  if (*TLS(In) == '\\') {
     GET_CHAR();
-    if      ( *In == '\n')
+    if      ( *TLS(In) == '\n')
       return GetCleanedChar(wasEscaped);
-    else if ( *In == '\r' )  {
+    else if ( *TLS(In) == '\r' )  {
       GET_CHAR();
-      if  ( *In == '\n' )
+      if  ( *TLS(In) == '\n' )
         return GetCleanedChar(wasEscaped);
       else {
-        UNGET_CHAR(*In);
+        UNGET_CHAR(*TLS(In));
         *wasEscaped = 1;
         return '\r';
       }
     }
     else {
       *wasEscaped = 1;
-      if ( *In == 'n')  return '\n';
-      else if ( *In == 't')  return '\t';
-      else if ( *In == 'r')  return '\r';
-      else if ( *In == 'b')  return '\b';
-      else if ( *In == '>')  return '\01';
-      else if ( *In == '<')  return '\02';
-      else if ( *In == 'c')  return '\03';
+      if ( *TLS(In) == 'n')  return '\n';
+      else if ( *TLS(In) == 't')  return '\t';
+      else if ( *TLS(In) == 'r')  return '\r';
+      else if ( *TLS(In) == 'b')  return '\b';
+      else if ( *TLS(In) == '>')  return '\01';
+      else if ( *TLS(In) == '<')  return '\02';
+      else if ( *TLS(In) == 'c')  return '\03';
     }
   }
-  return *In;
+  return *TLS(In);
 }
 
 
@@ -1572,11 +1572,11 @@ void GetNumber ( UInt StartingStatus )
   UInt seenADigit = (StartingStatus != 0 && StartingStatus != 2);
   UInt seenExpDigit = (StartingStatus ==5);
 
-  c = *In;
+  c = *TLS(In);
   if (StartingStatus  <  2) {
     /* read initial sequence of digits into 'Value'             */
     for (i = 0; !wasEscaped && IsDigit(c) && i < SAFE_VALUE_SIZE-1; i++) {
-      Value[i] = c;
+      TLS(Value)[i] = c;
       seenADigit = 1;
       c = GetCleanedChar(&wasEscaped);
     }
@@ -1585,26 +1585,26 @@ void GetNumber ( UInt StartingStatus )
     /* maybe we saw an identifier character and realised that this is an identifier we are reading */
     if (wasEscaped || IsIdent(c)) {
       /* Now we know we have an identifier read the rest of it */
-      Value[i++] = c;
+      TLS(Value)[i++] = c;
       c = GetCleanedChar(&wasEscaped);
       for (; wasEscaped || IsIdent(c) || IsDigit(c); i++) {
         if (i < SAFE_VALUE_SIZE -1)
-          Value[i] = c;
+          TLS(Value)[i] = c;
         c = GetCleanedChar(&wasEscaped);
       }
       if (i < SAFE_VALUE_SIZE -1)
-        Value[i] = '\0';
+        TLS(Value)[i] = '\0';
       else
-        Value[SAFE_VALUE_SIZE-1] = '\0';
-      Symbol = S_IDENT;
+        TLS(Value)[SAFE_VALUE_SIZE-1] = '\0';
+      TLS(Symbol) = S_IDENT;
       return;
     }
 
     /* Or maybe we just ran out of space */
     if (IsDigit(c)) {
       assert(i >= SAFE_VALUE_SIZE-1);
-      Symbol = S_PARTIALINT;
-      Value[SAFE_VALUE_SIZE-1] = '\0';
+      TLS(Symbol) = S_PARTIALINT;
+      TLS(Value)[SAFE_VALUE_SIZE-1] = '\0';
       return;
     }
 
@@ -1663,7 +1663,7 @@ void GetNumber ( UInt StartingStatus )
 
     /* read digits */
     for (; !wasEscaped && IsDigit(c) && i < SAFE_VALUE_SIZE-1; i++) {
-      Value[i] = c;
+      TLS(Value)[i] = c;
       seenADigit = 1;
       c = GetCleanedChar(&wasEscaped);
     }
@@ -1676,24 +1676,24 @@ void GetNumber ( UInt StartingStatus )
        C99 style */
       if (!wasEscaped) {
         if (IsAlpha(c)) {
-          Value[i++] = c;
+          TLS(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
         }
         /* independently of that, we allow an _ signalling immediate conversion */
         if (c == '_') {
-          Value[i++] = c;
+          TLS(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
           /* After which there may be one character signifying the conversion style */
           if (IsAlpha(c)) {
-            Value[i++] = c;
+            TLS(Value)[i++] = c;
             c = GetCleanedChar(&wasEscaped);
           }
         }
         /* Now if the next character is alphanumerical, or an identifier type symbol then we
            really do have an error, otherwise we return a result */
         if (!IsIdent(c) && !IsDigit(c)) {
-          Value[i] = '\0';
-          Symbol = S_FLOAT;
+          TLS(Value)[i] = '\0';
+          TLS(Symbol) = S_FLOAT;
           return;
         }
       }
@@ -1706,19 +1706,19 @@ void GetNumber ( UInt StartingStatus )
         if (!seenADigit)
           SyntaxError("Badly formed number, need a digit before or after the decimal point");
         seenExp = 1;
-        Value[i++] = c;
+        TLS(Value)[i++] = c;
         c = GetCleanedChar(&wasEscaped);
         if (!wasEscaped && (c == '+' || c == '-'))
           {
-            Value[i++] = c;
+            TLS(Value)[i++] = c;
             c = GetCleanedChar(&wasEscaped);
           }
       }
 
     /* Now deal with full buffer case */
     if (i >= SAFE_VALUE_SIZE -1) {
-      Symbol = seenExp ? S_PARTIALFLOAT3 : S_PARTIALFLOAT2;
-      Value[i] = '\0';
+      TLS(Symbol) = seenExp ? S_PARTIALFLOAT3 : S_PARTIALFLOAT2;
+      TLS(Value)[i] = '\0';
       return;
     }
 
@@ -1730,23 +1730,23 @@ void GetNumber ( UInt StartingStatus )
       /* Might be a conversion marker */
       if (!wasEscaped) {
         if (IsAlpha(c) && c != 'e' && c != 'E' && c != 'd' && c != 'D' && c != 'q' && c != 'Q') {
-          Value[i++] = c;
+          TLS(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
         }
         /* independently of that, we allow an _ signalling immediate conversion */
         if (c == '_') {
-          Value[i++] = c;
+          TLS(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
           /* After which there may be one character signifying the conversion style */
           if (IsAlpha(c))
-            Value[i++] = c;
+            TLS(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
         }
         /* Now if the next character is alphanumerical, or an identifier type symbol then we
            really do have an error, otherwise we return a result */
         if (!IsIdent(c) && !IsDigit(c)) {
-          Value[i] = '\0';
-          Symbol = S_FLOAT;
+          TLS(Value)[i] = '\0';
+          TLS(Symbol) = S_FLOAT;
           return;
         }
       }
@@ -1758,7 +1758,7 @@ void GetNumber ( UInt StartingStatus )
   /* Here we are into the unsigned exponent of a number
      in scientific notation, so we just read digits */
   for (; !wasEscaped && IsDigit(c) && i < SAFE_VALUE_SIZE-1; i++) {
-    Value[i] = c;
+    TLS(Value)[i] = c;
     seenExpDigit = 1;
     c = GetCleanedChar(&wasEscaped);
   }
@@ -1767,38 +1767,38 @@ void GetNumber ( UInt StartingStatus )
      which could be a conversion marker */
   if (seenExpDigit) {
     if (IsAlpha(c)) {
-      Value[i] = c;
+      TLS(Value)[i] = c;
       c = GetCleanedChar(&wasEscaped);
-      Value[i+1] = '\0';
-      Symbol = S_FLOAT;
+      TLS(Value)[i+1] = '\0';
+      TLS(Symbol) = S_FLOAT;
       return;
     }
     if (c == '_') {
-      Value[i++] = c;
+      TLS(Value)[i++] = c;
       c = GetCleanedChar(&wasEscaped);
       /* After which there may be one character signifying the conversion style */
       if (IsAlpha(c)) {
-        Value[i++] = c;
+        TLS(Value)[i++] = c;
         c = GetCleanedChar(&wasEscaped);
       }
-      Value[i] = '\0';
-      Symbol = S_FLOAT;
+      TLS(Value)[i] = '\0';
+      TLS(Symbol) = S_FLOAT;
       return;
     }
   }
 
   /* If we ran off the end */
   if (i >= SAFE_VALUE_SIZE -1) {
-    Symbol = seenExpDigit ? S_PARTIALFLOAT4 : S_PARTIALFLOAT3;
-    Value[i] = '\0';
+    TLS(Symbol) = seenExpDigit ? S_PARTIALFLOAT4 : S_PARTIALFLOAT3;
+    TLS(Value)[i] = '\0';
     return;
   }
 
   /* Otherwise this is the end of the token */
   if (!seenExpDigit)
     SyntaxError("Badly Formed Number, need at least one digit in the exponent");
-  Symbol = S_FLOAT;
-  Value[i] = '\0';
+  TLS(Symbol) = S_FLOAT;
+  TLS(Value)[i] = '\0';
   return;
 }
 
@@ -1808,7 +1808,7 @@ void GetNumber ( UInt StartingStatus )
  *F  GetStr()  . . . . . . . . . . . . . . . . . . . . . . get a string, local
  **
  **  'GetStr' reads  a  string from the  current input file into  the variable
- **  'Value' and sets 'Symbol'   to  'S_STRING'.  The opening double quote '"'
+ **  'TLS(Value)' and sets 'Symbol'   to  'S_STRING'.  The opening double quote '"'
  **  of the string is the current character pointed to by 'In'.
  **
  **  A string is a sequence of characters delimited  by double quotes '"'.  It
@@ -1819,7 +1819,7 @@ void GetNumber ( UInt StartingStatus )
  **  An error is raised if the string includes a <newline> character or if the
  **  file ends before the closing '"'.
  **
- **  When Value is  completely filled we have to check  if the reading of
+ **  When TLS(Value) is  completely filled we have to check  if the reading of
  **  the string is  complete or not to decide  between Symbol=S_STRING or
  **  S_PARTIALSTRING.
  */
@@ -2023,7 +2023,7 @@ void GetMaybeTripStr ( void )
  *F  GetChar() . . . . . . . . . . . . . . . . . get a single character, local
  **
  **  'GetChar' reads the next  character from the current input file  into the
- **  variable 'Value' and sets 'Symbol' to 'S_CHAR'.  The opening single quote
+ **  variable 'TLS(Value)' and sets 'Symbol' to 'S_CHAR'.  The opening single quote
  **  '\'' of the character is the current character pointed to by 'In'.
  **
  **  A  character is  a  single character delimited by single quotes '\''.  It
@@ -2038,36 +2038,36 @@ void GetChar ( void )
   GET_CHAR();
 
   /* handle escape equences                                              */
-  if ( *In == '\\' ) {
+  if ( *TLS(In) == '\\' ) {
     GET_CHAR();
-    if ( *In == 'n'  )       Value[0] = '\n';
-    else if ( *In == 't'  )  Value[0] = '\t';
-    else if ( *In == 'r'  )  Value[0] = '\r';
-    else if ( *In == 'b'  )  Value[0] = '\b';
-    else if ( *In == '>'  )  Value[0] = '\01';
-    else if ( *In == '<'  )  Value[0] = '\02';
-    else if ( *In == 'c'  )  Value[0] = '\03';
-    else if ( *In >= '0' && *In <= '7' ) {
+    if ( *TLS(In) == 'n'  )       TLS(Value)[0] = '\n';
+    else if ( *TLS(In) == 't'  )  TLS(Value)[0] = '\t';
+    else if ( *TLS(In) == 'r'  )  TLS(Value)[0] = '\r';
+    else if ( *TLS(In) == 'b'  )  TLS(Value)[0] = '\b';
+    else if ( *TLS(In) == '>'  )  TLS(Value)[0] = '\01';
+    else if ( *TLS(In) == '<'  )  TLS(Value)[0] = '\02';
+    else if ( *TLS(In) == 'c'  )  TLS(Value)[0] = '\03';
+    else if ( *TLS(In) >= '0' && *TLS(In) <= '7' ) {
       /* escaped three digit octal numbers are allowed in input */
-      c = 64 * (*In - '0');
+      c = 64 * (*TLS(In) - '0');
       GET_CHAR();
-      if ( *In < '0' || *In > '7' )
+      if ( *TLS(In) < '0' || *TLS(In) > '7' )
         SyntaxError("expecting octal digit in character constant");
-      c = c + 8 * (*In - '0');
+      c = c + 8 * (*TLS(In) - '0');
       GET_CHAR();
-      if ( *In < '0' || *In > '7' )
+      if ( *TLS(In) < '0' || *TLS(In) > '7' )
         SyntaxError("expecting 3 octal digits in character constant");
-      c = c + (*In - '0');
-      Value[0] = c;
+      c = c + (*TLS(In) - '0');
+      TLS(Value)[0] = c;
     }
-    else                     Value[0] = *In;
+    else                     TLS(Value)[0] = *TLS(In);
   }
-  else if ( *In == '\n' ) {
+  else if ( *TLS(In) == '\n' ) {
     SyntaxError("newline not allowed in character literal");
   }
-  /* put normal chars into 'Value'                                       */
+  /* put normal chars into 'TLS(Value)'                                       */
   else {
-    Value[0] = *In;
+    TLS(Value)[0] = *TLS(In);
   }
 
   /* read the next character                                             */
@@ -2075,12 +2075,12 @@ void GetChar ( void )
 
   
   /* check for terminating single quote                                  */
-  if ( *In != '\'' )
+  if ( *TLS(In) != '\'' )
     SyntaxError("missing single quote in character constant");
 
   /* skip the closing quote                                              */
-  Symbol = S_CHAR;
-  if ( *In == '\'' )  GET_CHAR();
+  TLS(Symbol) = S_CHAR;
+  if ( *TLS(In) == '\'' )  GET_CHAR();
 
 }
 
@@ -2091,7 +2091,7 @@ void GetChar ( void )
  **
  **  'GetSymbol' reads  the  next symbol from   the  input,  storing it in the
  **  variable 'Symbol'.  If 'Symbol' is  'S_IDENT', 'S_INT' or 'S_STRING'  the
- **  value of the symbol is stored in the variable 'Value'.  'GetSymbol' first
+ **  value of the symbol is stored in the variable 'TLS(Value)'.  'GetSymbol' first
  **  skips all <space>, <tab> and <newline> characters and comments.
  **
  **  After reading  a  symbol the current  character   is the first  character
@@ -2316,20 +2316,20 @@ void PutLineTo ( KOutputStream stream, UInt len )
   UInt lt,ls;     /* These are supposed to hold string lengths */
 
   /* if in test mode and the next input line matches print nothing       */
-  if ( TestInput != 0 && TestOutput == stream ) {
-    if ( TestLine[0] == '\0' ) {
-      if ( ! GetLine2( TestInput, TestLine, sizeof(TestLine) ) ) {
-        TestLine[0] = '\0';
+  if ( TLS(TestInput) != 0 && TLS(TestOutput) == stream ) {
+    if ( TLS(TestLine)[0] == '\0' ) {
+      if ( ! GetLine2( TLS(TestInput), TLS(TestLine), sizeof(TLS(TestLine)) ) ) {
+        TLS(TestLine)[0] = '\0';
       }
-      TestInput->number++;
+      TLS(TestInput)->number++;
     }
 
-    /* Note that TestLine is ended by a \n, but stream->line need not! */
+    /* Note that TLS(TestLine) is ended by a \n, but stream->line need not! */
 
-    lt = strlen(TestLine);   /* this counts including the newline! */
-    p = TestLine + (lt-2);
+    lt = strlen(TLS(TestLine));   /* this counts including the newline! */
+    p = TLS(TestLine) + (lt-2);
     /* this now points to the last char before \n in the line! */
-    while ( TestLine <= p && ( *p == ' ' || *p == '\t' ) ) {
+    while ( TLS(TestLine) <= p && ( *p == ' ' || *p == '\t' ) ) {
       p[1] = '\0';  p[0] = '\n';  p--; lt--;
     }
     /* lt is still the correct string length including \n */
@@ -2343,18 +2343,18 @@ void PutLineTo ( KOutputStream stream, UInt len )
       }
     }
     /* ls is still the correct string length including a possible \n */
-    if ( ! strncmp( TestLine, stream->line, ls ) ) {
+    if ( ! strncmp( TLS(TestLine), stream->line, ls ) ) {
       if (ls < lt)
-        memmove(TestLine,TestLine + ls,lt-ls+1);
+        memmove(TLS(TestLine),TLS(TestLine) + ls,lt-ls+1);
       else
-        TestLine[0] = '\0';
+        TLS(TestLine)[0] = '\0';
     }
     else {
       char obuf[80];
-      /* snprintf(obuf, sizeof(obuf), "+ 5%i bad example:\n+ ", (int)TestInput->number); */
-      snprintf(obuf, sizeof(obuf), "Line %i : \n+ ", (int)TestInput->number);
+      /* snprintf(obuf, sizeof(obuf), "+ 5%i bad example:\n+ ", (int)TLS(TestInput)->number); */
+      snprintf(obuf, sizeof(obuf), "Line %i : \n+ ", (int)TLS(TestInput)->number);
       PutLine2( stream, obuf, strlen(obuf) );
-      PutLine2( stream, Output->line, strlen(Output->line) );
+      PutLine2( stream, TLS(Output)->line, strlen(TLS(Output)->line) );
     }
   }
 
@@ -2364,9 +2364,9 @@ void PutLineTo ( KOutputStream stream, UInt len )
   }
 
   /* if neccessary echo it to the logfile                                */
-  if ( OutputLog != 0 && ! stream->isstream ) {
+  if ( TLS(OutputLog) != 0 && ! stream->isstream ) {
     if ( stream->file == 1 || stream->file == 3 ) {
-      PutLine2( OutputLog, stream->line, len );
+      PutLine2( TLS(OutputLog), stream->line, len );
     }
   }
 }
@@ -2595,7 +2595,7 @@ void PutChrTo (
 
 Obj FuncToggleEcho( Obj self)
 {
-  Input->echo = 1 - Input->echo;
+  TLS(Input)->echo = 1 - TLS(Input)->echo;
   return (Obj)0;
 }
 
@@ -2608,7 +2608,7 @@ Obj FuncToggleEcho( Obj self)
 Obj FuncCPROMPT( Obj self)
 {
   Obj p;
-  C_NEW_STRING_DYN( p, Prompt );
+  C_NEW_STRING_DYN( p, TLS(Prompt) );
   return p;
 }
 
@@ -2627,9 +2627,9 @@ Obj FuncPRINT_CPROMPT( Obj self, Obj prompt )
     /* by assigning to Prompt we also tell readline (if used) what the
        current prompt is  */
     strlcpy(promptBuf, CSTR_STRING(prompt), sizeof(promptBuf));
-    Prompt = promptBuf;
+    TLS(Prompt) = promptBuf;
   }
-  Pr("%s%c", (Int)Prompt, (Int)'\03' );
+  Pr("%s%c", (Int)TLS(Prompt), (Int)'\03' );
   return (Obj) 0;
 }
 
@@ -2748,14 +2748,14 @@ void FormatOutput(void (*put_a_char)(Char c), const Char *format, Int arg1, Int 
       /* must be careful that line breaks don't go inside
          escaped sequences \n or \123 or similar */
       for ( q = (Char*)arg1; *q != '\0'; q++ ) {
-        if (*q == '\\' && NoSplitLine == 0) {
+        if (*q == '\\' && TLS(NoSplitLine) == 0) {
           if (*(q+1) < '8' && *(q+1) >= '0')
-            NoSplitLine = 3;
+            TLS(NoSplitLine) = 3;
           else
-            NoSplitLine = 1;
+            TLS(NoSplitLine) = 1;
         }
-        else if (NoSplitLine > 0)
-          NoSplitLine--;
+        else if (TLS(NoSplitLine) > 0)
+          TLS(NoSplitLine)--;
         put_a_char( *q );
       }
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1933,9 +1933,9 @@ void GetTripStr ( void )
   
   /* print only a partial prompt while reading a triple string           */
   if ( !SyQuiet )
-    Prompt = "> ";
+    TLS(Prompt) = "> ";
   else
-    Prompt = "";
+    TLS(Prompt) = "";
   
   /* read all characters into 'Value'                                    */
   for ( i = 0; i < SAFE_VALUE_SIZE-1 && *In != '\377'; i++ ) {

--- a/src/stats.c
+++ b/src/stats.c
@@ -1534,7 +1534,7 @@ UInt            ExecReturnObj (
 
     /* evaluate the expression                                             */
     SET_BRK_CURR_STAT( stat );
-    ReturnObjStat = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    TLS(ReturnObjStat) = EVAL_EXPR( ADDR_STAT(stat)[0] );
 
     /* return up to function interpreter                                   */
     return 1;
@@ -1564,8 +1564,8 @@ UInt            ExecReturnVoid (
     }
 #endif
 
-    /* set 'ReturnObjStat' to void                                         */
-    ReturnObjStat = 0;
+    /* set 'TLS(ReturnObjStat)' to void                                         */
+    TLS(ReturnObjStat) = 0;
 
     /* return up to function interpreter                                   */
     return 2;
@@ -1718,8 +1718,8 @@ void ClearError ( void )
         }
     }
 
-    /* reset <NrError>                                                     */
-    NrError = 0;
+    /* reset <TLS(NrError)>                                                     */
+    TLS(NrError) = 0;
 }
 
 /****************************************************************************

--- a/src/stats.h
+++ b/src/stats.h
@@ -74,10 +74,10 @@ extern  Stat            CurrStat;
 *F  RES_BRK_CURR_STAT() . . . . . . . . restore currently executing statement
 */
 #ifndef NO_BRK_CURR_STAT
-#define SET_BRK_CURR_STAT(stat) (CurrStat = (stat))
+#define SET_BRK_CURR_STAT(stat) (TLS(CurrStat) = (stat))
 #define OLD_BRK_CURR_STAT       Stat oldStat;
-#define REM_BRK_CURR_STAT()     (oldStat = CurrStat)
-#define RES_BRK_CURR_STAT()     (CurrStat = oldStat)
+#define REM_BRK_CURR_STAT()     (oldStat = TLS(CurrStat))
+#define RES_BRK_CURR_STAT()     (TLS(CurrStat) = oldStat)
 #endif
 #ifdef  NO_BRK_CURR_STAT
 #define SET_BRK_CURR_STAT(stat) /* do nothing */

--- a/src/streams.c
+++ b/src/streams.c
@@ -1037,14 +1037,14 @@ Obj FuncREAD_STREAM_LOOP (
         return False;
     }
     if ( catcherrstdout == True )
-      IgnoreStdoutErrout = TLS(Output);
+      TLS(IgnoreStdoutErrout) = TLS(Output);
     else
-      IgnoreStdoutErrout = NULL;
+      TLS(IgnoreStdoutErrout) = NULL;
 
 
     /* read the test file                                                  */
     READ_LOOP();
-    IgnoreStdoutErrout = NULL;
+    TLS(IgnoreStdoutErrout) = NULL;
     return True;
 }
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -141,15 +141,15 @@ static Int READ_INNER ( UInt UseUHQ )
 {
     ExecStatus                status;
 
-    if (UserHasQuit)
+    if (TLS(UserHasQuit))
       {
         Pr("Warning: Entering READ with UserHasQuit set, this should never happen, resetting",0,0);
-        UserHasQuit = 0;
+        TLS(UserHasQuit) = 0;
       }
-    if (UserHasQUIT)
+    if (TLS(UserHasQUIT))
       {
         Pr("Warning: Entering READ with UserHasQUIT set, this should never happen, resetting",0,0);
-        UserHasQUIT = 0;
+        TLS(UserHasQUIT) = 0;
       }
     MakeReadWriteGVar(LastReadValueGVar);
     AssGVar( LastReadValueGVar, 0);
@@ -171,18 +171,18 @@ static Int READ_INNER ( UInt UseUHQ )
         else if ( status  & (STATUS_ERROR | STATUS_EOF)) 
           break;
         else if (status == STATUS_QUIT) {
-          RecursionDepth = 0;
-          UserHasQuit = 1;
+          TLS(RecursionDepth) = 0;
+          TLS(UserHasQuit) = 1;
           break;
         }
         else if (status == STATUS_QQUIT) {
-          UserHasQUIT = 1;
+          TLS(UserHasQUIT) = 1;
           break;
         }
-        if (ReadEvalResult)
+        if (TLS(ReadEvalResult))
           {
             MakeReadWriteGVar(LastReadValueGVar);
-            AssGVar( LastReadValueGVar, ReadEvalResult);
+            AssGVar( LastReadValueGVar, TLS(ReadEvalResult));
             MakeReadOnlyGVar(LastReadValueGVar);
           }
         
@@ -270,17 +270,17 @@ static void READ_TEST_OR_LOOP(void)
         AssGVar( Time, INTOBJ_INT( SyTime() - oldtime ) );
 
         /* handle ordinary command                                         */
-        if ( type == 0 && ReadEvalResult != 0 ) {
+        if ( type == 0 && TLS(ReadEvalResult) != 0 ) {
 
             /* remember the value in 'last' and the time in 'time'         */
             AssGVar( Last3, VAL_GVAR( Last2 ) );
             AssGVar( Last2, VAL_GVAR( Last  ) );
-            AssGVar( Last,  ReadEvalResult   );
+            AssGVar( Last,  TLS(ReadEvalResult)   );
 
             /* print the result                                            */
             if ( ! dualSemicolon ) {
                 Bag currLVars = TLS(CurrLVars); /* in case view runs into error */
-                ViewObjHandler( ReadEvalResult );
+                ViewObjHandler( TLS(ReadEvalResult) );
                 SWITCH_TO_OLD_LVARS(currLVars);
             }
         }
@@ -427,11 +427,11 @@ Int READ_GAP_ROOT ( Char * filename )
                 (Int)filename, 0L );
         }
         if ( OpenInput(result.pathname) ) {
-          SySetBuffering(Input->file);
+          SySetBuffering(TLS(Input)->file);
             while ( 1 ) {
                 ClearError();
                 type = ReadEvalCommand(TLS(BottomLVars), 0);
-                if (UserHasQuit || UserHasQUIT)
+                if (TLS(UserHasQuit) || TLS(UserHasQUIT))
                   break;
                 if ( type & (STATUS_RETURN_VAL | STATUS_RETURN_VOID) ) {
                     Pr( "'return' must not be used in file", 0L, 0L );
@@ -1037,7 +1037,7 @@ Obj FuncREAD_STREAM_LOOP (
         return False;
     }
     if ( catcherrstdout == True )
-      IgnoreStdoutErrout = Output;
+      IgnoreStdoutErrout = TLS(Output);
     else
       IgnoreStdoutErrout = NULL;
 

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -2370,13 +2370,13 @@ Char * readlineFgets (
   rl_event_hook = (OnCharReadHookActive != (Obj) 0) ? charreadhook_rl : 0;
   /* now do the real work */
   doingReadline = 1;
-  rlres = readline(Prompt);
+  rlres = readline(TLS(Prompt));
   doingReadline = 0;
   /* we get a NULL pointer on EOF, say by pressing Ctr-d  */
   if (!rlres) {
     if (!SyCTRD) {
       while (!rlres)
-        rlres = readline(Prompt);
+        rlres = readline(TLS(Prompt));
     }
     else {
       printf("\n");fflush(stdout);

--- a/src/system.h
+++ b/src/system.h
@@ -1125,6 +1125,11 @@ extern void InitSystem (
             Char *              argv [] );
 
 
+// FIXME: The TLS macro is for compatibility with the HPC-GAP branch, and helps
+// to keep the diffs between it and master branch small(er).
+#define TLS(x) x
+
+
 #endif // GAP_SYSTEM_H
 
 /****************************************************************************

--- a/src/tls.h
+++ b/src/tls.h
@@ -1,3 +1,7 @@
+#ifndef GAP_TLS_H
+#define GAP_TLS_H
+
 #define ReadGuard(bag) NOOP
 #define WriteGuard(bag) NOOP
 
+#endif

--- a/src/vars.c
+++ b/src/vars.c
@@ -2993,8 +2993,8 @@ void VarsAfterCollectBags ( void )
 {
   if (TLS(CurrLVars))
     {
-      PtrLVars = PTR_BAG( TLS(CurrLVars) );
-      PtrBody  = (Stat*)PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+      TLS(PtrLVars) = PTR_BAG( TLS(CurrLVars) );
+      TLS(PtrBody)  = (Stat*)PTR_BAG( BODY_FUNC( CURR_FUNC ) );
     }
   if (ValGVars)
     PtrGVars = PTR_BAG( ValGVars );

--- a/src/vars.h
+++ b/src/vars.h
@@ -160,7 +160,7 @@ static inline Obj SwitchToNewLvars(Obj func, UInt narg, UInt nloc
                       sizeof(Obj)*(3+narg+nloc) );
   PtrLVars  = PTR_BAG( TLS(CurrLVars) );
   CURR_FUNC = func;
-  PtrBody = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+  TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
   SET_BRK_CALL_FROM( old );
 #ifdef TRACEFRAMES
   if (STEVES_TRACING == True) {

--- a/src/vars.h
+++ b/src/vars.h
@@ -82,7 +82,7 @@ extern  Obj *           PtrLVars;
 **  This  is  in this package,  because  it is stored   along  with the local
 **  variables in the local variables bag.
 */
-#define CURR_FUNC       (PtrLVars[0])
+#define CURR_FUNC       (TLS(PtrLVars)[0])
 
 
 /****************************************************************************
@@ -100,17 +100,17 @@ extern Obj True;
 static inline void SetBrkCallTo( Expr expr, char * file, int line ) {
   if (STEVES_TRACING == True) {
     fprintf(stderr,"SBCT: %i %x %s %i\n",
-            (int)expr, (int)CurrLVars, file, line);
+            (int)expr, (int)TLS(CurrLVars), file, line);
   }
-  (PtrLVars[1] = (Obj)(Int)(expr));
+  (TLS(PtrLVars)[1] = (Obj)(Int)(expr));
 }
 
 #else
-#define SetBrkCallTo(expr, file, line)  (PtrLVars[1] = (Obj)(Int)(expr))
+#define SetBrkCallTo(expr, file, line)  (TLS(PtrLVars)[1] = (Obj)(Int)(expr))
 #endif
 
 #ifndef NO_BRK_CALLS
-#define BRK_CALL_TO()                   ((Expr)(Int)(PtrLVars[1]))
+#define BRK_CALL_TO()                   ((Expr)(Int)(TLS(PtrLVars)[1]))
 #define SET_BRK_CALL_TO(expr)           SetBrkCallTo(expr, __FILE__, __LINE__)
 #endif
 #ifdef  NO_BRK_CALLS
@@ -125,8 +125,8 @@ static inline void SetBrkCallTo( Expr expr, char * file, int line ) {
 *F  SET_BRK_CALL_FROM(lvars)  . .  set frame from which this frame was called
 */
 #ifndef NO_BRK_CALLS
-#define BRK_CALL_FROM()                 (PtrLVars[2])
-#define SET_BRK_CALL_FROM(lvars)        (PtrLVars[2] = (lvars))
+#define BRK_CALL_FROM()                 (TLS(PtrLVars)[2])
+#define SET_BRK_CALL_FROM(lvars)        (TLS(PtrLVars)[2] = (lvars))
 #endif
 #ifdef  NO_BRK_CALLS
 #define BRK_CALL_FROM()                 /* do nothing */
@@ -154,11 +154,11 @@ static inline Obj SwitchToNewLvars(Obj func, UInt narg, UInt nloc
 #endif
 )
 {
-  Obj old = CurrLVars;
+  Obj old = TLS(CurrLVars);
   CHANGED_BAG( old );
-  CurrLVars = NewBag( T_LVARS,
+  TLS(CurrLVars) = NewBag( T_LVARS,
                       sizeof(Obj)*(3+narg+nloc) );
-  PtrLVars  = PTR_BAG( CurrLVars );
+  PtrLVars  = PTR_BAG( TLS(CurrLVars) );
   CURR_FUNC = func;
   PtrBody = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
   SET_BRK_CALL_FROM( old );
@@ -167,7 +167,7 @@ static inline Obj SwitchToNewLvars(Obj func, UInt narg, UInt nloc
     Obj n = NAME_FUNC(func);
     Char *s = ((UInt)n) ? (Char *)CHARS_STRING(n) : (Char *)"nameless";
     fprintf(stderr,"STNL: %s %i\n   func %lx narg %i nloc %i function name %s\n     old lvars %lx new lvars %lx\n",
-            file, line, (UInt) func, (int)narg, (int)nloc,s,(UInt)old, (UInt)CurrLVars);
+            file, line, (UInt) func, (int)narg, (int)nloc,s,(UInt)old, (UInt)TLS(CurrLVars));
   }
 #endif
   return old;
@@ -196,13 +196,13 @@ static inline void SwitchToOldLVars( Obj old
 #ifdef TRACEFRAMES
   if (STEVES_TRACING == True) {
     fprintf(stderr,"STOL:  %s %i old lvars %lx new lvars %lx\n",
-           file, line, (UInt)CurrLVars,(UInt)old);
+           file, line, (UInt)TLS(CurrLVars),(UInt)old);
   }
 #endif
-  CHANGED_BAG( CurrLVars );
-  CurrLVars = (old);
-  PtrLVars  = PTR_BAG( CurrLVars );
-  PtrBody = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+  CHANGED_BAG( TLS(CurrLVars) );
+  TLS(CurrLVars) = (old);
+  TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
+  TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
 }
 
 #ifdef TRACEFRAMES
@@ -218,7 +218,7 @@ static inline void SwitchToOldLVars( Obj old
 **
 **  'ASS_LVAR' assigns the value <val> to the local variable <lvar>.
 */
-#define ASS_LVAR(lvar,val)      (PtrLVars[(lvar)+2] = (val))
+#define ASS_LVAR(lvar,val)      (TLS(PtrLVars)[(lvar)+2] = (val))
 
 
 /****************************************************************************
@@ -227,7 +227,7 @@ static inline void SwitchToOldLVars( Obj old
 **
 **  'OBJ_LVAR' returns the value of the local variable <lvar>.
 */
-#define OBJ_LVAR(lvar)          (PtrLVars[(lvar)+2])
+#define OBJ_LVAR(lvar)          (TLS(PtrLVars)[(lvar)+2])
 
 
 /****************************************************************************


### PR DESCRIPTION
This commit series adds a no-op C macro `#define TLS(x) x`  to the GAP C kernel, and wraps access to most global variables with it. This reduces the diff beween the `master` and `hpcgap-`default branches, and is a step towards a "soft" merge of the two branches.

Background: As discussed on two previous GAP Days meetings, and again during the current GAP Days in Trondheim, we cannot maintain two major GAP branches. We also cannot just switch to HPC-GAP, because even in single-threaded mode it still suffers from regressions compared to "classic" GAP (e.g. it is slower). We also do not want to abandon HPC-GAP. To resolve this, we instead want to incrementally reduce the diffs between the two branches, and eventually have them converge to a single branch, which can be compiled either as "classic" GAP (with all HPC stuff disabled), or as a full HPC-GAP (and possible some intermediate version, too). 

We plan to give a more detailed description of our proposal, with a concrete step-by-step plan, late on. But the basic idea was discussed and agreed upon on several meetings, so we are now proceeding with it.

Some diff stats on the `src` dir to give an impression (given as changes from `hpcgap: Before this begun:
```
 120 files changed, 27449 insertions(+), 6885 deletions(-)
```
After the `hpcgap-default` changes made today:
```
 119 files changed, 24521 insertions(+), 4746 deletions(-)
```
With the work in this PR:
```
 116 files changed, 22255 insertions(+), 2498 deletions(-)
```
More changes are coming soon.