### PR TITLE
Use QUIT_GAP instead of FORCE_QUIT_GAP in testing

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -656,7 +656,7 @@ TestDirectory := function(arg)
     if not(testResult) and opts.earlyStop then
       STOP_TEST := STOP_TEST_CPY;
       if opts.exitGAP then
-        FORCE_QUIT_GAP(1);
+        QUIT_GAP(1);
       fi;
       return false;
     fi;
@@ -696,7 +696,7 @@ TestDirectory := function(arg)
          String( totalTime, 15 ), "\n\n" );
          
   if opts.exitGAP then
-    FORCE_QUIT_GAP(testTotal = 0);
+    QUIT_GAP(testTotal = 0);
   fi;
   
   return testTotal;


### PR DESCRIPTION
This is a small internal testing change.

It should stop the behaviour which occasionally comes up in GAP, and often in HPC-GAP, where the end of output of tests is lost (the tests get run, but FORCE_QUIT_GAP leads to the buffer contents being lost).