### PR TITLE
Installflushfunction

### DIFF
--- a/tst/testinstall/flush.tst
+++ b/tst/testinstall/flush.tst
@@ -1,0 +1,24 @@
+gap> START_TEST("flush.tst");
+gap> DeclareGlobalVariable("cheesefun");
+gap> DeclareGlobalVariable("cheeseval");
+gap> cheesefun;
+<< cheesefun to be defined>>
+gap> cheeseval;
+<< cheeseval to be defined>>
+gap> InstallFlushableValueFromFunction(cheesefun, -> [1] );
+gap> InstallFlushableValueFromFunction(cheeseval, -> [2] );
+gap> cheesefun;
+[ 1 ]
+gap> cheeseval;
+[ 2 ]
+gap> cheesefun[2] := 6;;
+gap> cheeseval[2] := 5;;
+gap> cheesefun;
+[ 1, 6 ]
+gap> cheeseval;
+[ 2, 5 ]
+gap> FlushCaches();
+gap> cheesefun;
+[ 1 ]
+gap> cheeseval;
+[ 2 ]


### PR DESCRIPTION
This adds a function ```InstallFlushableValueFromFunction```, which is like ```InstallFlushableValue```, but takes a function which is called instead. This is more useful in HPC-GAP, where it makes it easier to handle which region objects end up in, but I am adding it here so it ends up in both systems.