### PR TITLE
build: improve cnf/mkversionheader.sh

### DIFF
--- a/cnf/mkversionheader.sh
+++ b/cnf/mkversionheader.sh
@@ -1,19 +1,27 @@
-#!/bin/sh
+#!/bin/sh -ex
 
-GAP_BUILD_VERSION=`git describe --tags --dirty`
+TMP="$1".tmp
+DST="$1"
+
+# Determine build version and date
+GAP_BUILD_VERSION=`git describe --tags --dirty || echo`
 GAP_BUILD_DATE=`date +"%Y-%m-%d %H:%M:%S (%Z)"`
-if test x"${GAP_BUILD_VERSION}" != x ; then
-cat > $1 <<EOF
+if test x"${GAP_BUILD_VERSION}" = x ; then
+  GAP_BUILD_VERSION=unknown
+fi
+
+# Generate the file
+cat > "$TMP" <<EOF
 #ifndef GAP_BUILD_VERSION
 #define GAP_BUILD_VERSION  "$GAP_BUILD_VERSION"
 #define GAP_BUILD_DATETIME "$GAP_BUILD_DATE"
 #endif
 EOF
-else
-cat > $1 <<EOF
-#ifndef GAP_BUILD_VERSION
-#define GAP_BUILD_VERSION  "none"
-#define GAP_BUILD_DATETIME "$GAP_BUILD_DATE"
-#endif
-EOF
-fi
+
+# Only copy the header over if there were any changes, to
+# avoid pointless recompiles.
+if ! cmp -s $TMP $DST ; then
+  cp "$TMP" "$DST"
+fi;
+
+rm $TMP


### PR DESCRIPTION
* Specify -e flag, to ensure errors cause the script to exit
* Only modify gap_version.h if its contents changed, to avoid
  pointless recompiles
* Attempt to safely deal with paths including spaces
* Refactor code so that the code for generating the header is
  not duplicated

In addition, perhaps instead of "none" we should print "4.dev" to stay closer to the former behavior? Alternatively, use "unknown", which results in "GAP, Version unknown" instead of the current "GAP, Version none"