### PR TITLE
Fix quitting

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -696,7 +696,11 @@ TestDirectory := function(arg)
          String( totalTime, 15 ), "\n\n" );
          
   if opts.exitGAP then
-    QUIT_GAP(testTotal = 0);
+    if testTotal then
+      QUIT_GAP(0);
+    else
+      QUIT_GAP(1);
+    fi;
   fi;
   
   return testTotal;

--- a/src/gap.c
+++ b/src/gap.c
@@ -2679,7 +2679,7 @@ Obj FuncFORCE_QUIT_GAP( Obj self, Obj args )
     ErrorQuit( "usage: FORCE_QUIT_GAP( [ <return value> ] )", 0L, 0L );
     return 0;
   }
-  SyExit(0);
+  SyExit(SystemErrorCode);
   return (Obj) 0; /* should never get here */
 }
 
@@ -3390,9 +3390,3 @@ void InitializeGap (
 
 *E  gap.c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ends here
 */
-
-
-
-
-
-


### PR DESCRIPTION
This fixes two bugs in GAP quitting -- one in FORCE_QUIT_GAP ignoring it's argument, and one with TestDirectory returning the wrong value to the OS.