### PR TITLE
Rewrite RationalClass constructor to have less overhead

### DIFF
--- a/lib/clas.gi
+++ b/lib/clas.gi
@@ -460,17 +460,17 @@ end );
 ##
 InstallMethod( RationalClass, IsCollsElms, [ IsGroup, IsObject ],
     function( G, g )
-    local   cl;
-
-    cl := Objectify( NewType( FamilyObj( G ) ), rec(  ) );
+    local   filter, cl;
     if IsPermGroup( G )  then
-        SetFilterObj( cl, IsRationalClassPermGroupRep );
+        filter := IsRationalClassPermGroupRep;
     else
-        SetFilterObj( cl, IsRationalClassGroupRep );
+        filter := IsRationalClassGroupRep;
     fi;
-    SetActingDomain( cl, G );
-    SetRepresentative( cl, g );
-    SetFunctionAction( cl, OnPoints );
+    cl := rec(  );
+    ObjectifyWithAttributes( cl, NewType( FamilyObj( G ), filter ),
+	    ActingDomain, G,
+	    Representative, g,
+	    FunctionAction, OnPoints );
     return cl;
 end );
 


### PR DESCRIPTION
It now uses ObjectifyWithAttributes, and the two-parameter version of NewType,
which should help to avoid many pointless intermediate type objects.

This change has been cherry-picked from PR #157 