### PR TITLE
src: remove SyStr* functions

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -2789,10 +2789,10 @@ Obj FuncKERNEL_INFO(Obj self) {
         str = NEW_STRING(lenstr2);
     else
         str = NEW_STRING(lenstr);
-    SyStrncat(CSTR_STRING(str),sysenviron[i],lenstr2);
+    strncat(CSTR_STRING(str),sysenviron[i],lenstr2);
     r = RNamName(CSTR_STRING(str));
     *(CSTR_STRING(str)) = 0;
-    SyStrncat(CSTR_STRING(str),p, lenstr);
+    strncat(CSTR_STRING(str),p, lenstr);
     SET_LEN_STRING(str, lenstr);
     SHRINK_STRING(str);
     AssPRec(tmp,r , str);

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -532,12 +532,12 @@ void InitSweepFuncBags (
 
     if ( TabSweepFuncBags[type] != 0 ) {
         str[0] = 0;
-        SyStrncat( str, "warning: sweep function for type ", 33 );
+        strncat( str, "warning: sweep function for type ", 33 );
         str[33] = '0' + ((type/100) % 10);
         str[34] = '0' + ((type/ 10) % 10);
         str[35] = '0' + ((type/  1) % 10);
         str[36] = 0;
-        SyStrncat( str, " already installed\n", 19 );
+        strncat( str, " already installed\n", 19 );
         SyFputs( str, 0 );
     }
 #endif
@@ -590,12 +590,12 @@ void InitMarkFuncBags (
 
     if ( TabMarkFuncBags[type] != MarkAllSubBagsDefault ) {
         str[0] = 0;
-        SyStrncat( str, "warning: mark function for type ", 32 );
+        strncat( str, "warning: mark function for type ", 32 );
         str[32] = '0' + ((type/100) % 10);
         str[33] = '0' + ((type/ 10) % 10);
         str[34] = '0' + ((type/  1) % 10);
         str[35] = 0;
-        SyStrncat( str, " already installed\n", 19 );
+        strncat( str, " already installed\n", 19 );
         SyFputs( str, 0 );
     }
 #endif

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1251,7 +1251,7 @@ Char GetLine ( void )
 
             /* there may be one line waiting                               */
             if ( TLS(TestLine)[0] != '\0' ) {
-                SyStrncat( TLS(In), TLS(TestLine), sizeof(TLS(Input)->line) );
+                strncat( TLS(In), TLS(TestLine), sizeof(TLS(Input)->line) );
                 TLS(TestLine)[0] = '\0';
             }
 

--- a/src/system.c
+++ b/src/system.c
@@ -604,58 +604,9 @@ UInt SyTimeChildrenSys ( void )
 
 /****************************************************************************
 **
-*F  SyStrlen( <str> ) . . . . . . . . . . . . . . . . . .  length of a string
-**
-**  'SyStrlen' returns the length of the string <str>, i.e.,  the  number  of
-**  characters in <str> that precede the terminating null character.
-*/
-UInt SyStrlen (
-    const Char *         str )
-{
-    return strlen( str );
-}
-
-
-/****************************************************************************
-**
-*F  SyStrcmp( <str1>, <str2> )  . . . . . . . . . . . . . compare two strings
-**
-**  'SyStrcmp' returns an integer greater than, equal to, or less  than  zero
-**  according to whether <str1> is greater  than,  equal  to,  or  less  than
-**  <str2> lexicographically.
-*/
-Int SyStrcmp (
-    const Char *        str1,
-    const Char *        str2 )
-{
-    return strcmp( str1, str2 );
-}
-
-
-/****************************************************************************
-**
-*F  SyStrncmp( <str1>, <str2>, <len> )  . . . . . . . . . compare two strings
-**
-**  'SyStrncmp' returns an integer greater than, equal to,  or less than zero
-**  according  to whether  <str1>  is greater than,  equal  to,  or less than
-**  <str2> lexicographically.  'SyStrncmp' compares at most <len> characters.
-*/
-Int SyStrncmp (
-    const Char *        str1,
-    const Char *        str2,
-    UInt                len )
-{
-    return strncmp( str1, str2, len );
-}
-
-/****************************************************************************
-**
 *F  SyIntString( <string> ) . . . . . . . . extract a C integer from a string
 **
 */
-
-
-
 
 #if HAVE_ATOL
 Int SyIntString( const Char *string) {
@@ -684,27 +635,7 @@ Int SyIntString( const Char *string) {
   return sign*x;
 }
 
-
 #endif
-
-
-
-/****************************************************************************
-**
-*F  SyStrncat( <dst>, <src>, <len> )  . . . . .  append one string to another
-**
-**  'SyStrncat'  appends characters from the  <src>  to <dst>  until either a
-**  null character  is  encoutered  or  <len>  characters have   been copied.
-**  <dst> becomes the concatenation of <dst> and <src>.  The resulting string
-**  is always null terminated.  'SyStrncat' returns a pointer to <dst>.
-*/
-Char * SyStrncat (
-    Char *              dst,
-    const Char *        src,
-    UInt                len )
-{
-    return strncat( dst, src, len );
-}
 
 
 #ifndef HAVE_STRLCPY

--- a/src/system.h
+++ b/src/system.h
@@ -642,65 +642,11 @@ extern UInt SyTimeChildrenSys ( void );
 
 /****************************************************************************
 **
-*F  SyStrlen( <str> ) . . . . . . . . . . . . . . . . . .  length of a string
-**
-**  'SyStrlen' returns the length of the string <str>, i.e.,  the  number  of
-**  characters in <str> that precede the terminating null character.
-*/
-extern UInt SyStrlen (
-            const Char *     str );
-
-
-/****************************************************************************
-**
-*F  SyStrcmp( <str1>, <str2> )  . . . . . . . . . . . . . compare two strings
-**
-**  'SyStrcmp' returns an integer greater than, equal to, or less  than  zero
-**  according to whether <str1> is greater  than,  equal  to,  or  less  than
-**  <str2> lexicographically.
-*/
-extern Int SyStrcmp (
-            const Char *    str1,
-            const Char *    str2 );
-
-
-/****************************************************************************
-**
-*F  SyStrncmp( <str1>, <str2>, <len> )  . . . . . . . . . compare two strings
-**
-**  'SyStrncmp' returns an integer greater than, equal to,  or less than zero
-**  according  to whether  <str1>  is greater than,  equal  to,  or less than
-**  <str2> lexicographically.  'SyStrncmp' compares at most <len> characters.
-*/
-extern Int SyStrncmp (
-            const Char *    str1,
-            const Char *    str2,
-            UInt            len );
-
-/****************************************************************************
-**
 *F  SyIntString( <string> ) . . . . . . . . extract a C integer from a string
 **
 */
 
 extern Int SyIntString( const Char *string );
-
-
-
-/****************************************************************************
-**
-*F  SyStrncat( <dst>, <src>, <len> )  . . . . .  append one string to another
-**
-**  'SyStrncat'  appends characters from the  <src>  to <dst>  until either a
-**  null character  is  encoutered  or  <len>  characters have   been copied.
-**  <dst> becomes the concatenation of <dst> and <src>.  The resulting string
-**  is always null terminated.  'SyStrncat' returns a pointer to <dst>.
-*/
-extern Char * SyStrncat (
-            Char *              dst,
-            const Char *        src,
-            UInt                len );
-
 
 
 /****************************************************************************


### PR DESCRIPTION
These functions are not anymore used by any packages (seems I managed to convince every user to abandon them over the past couple years ;-).

They are still used in HPC-GAP. So I think this PR should NOT be merged before PR #239 in order to avoid conflicts. Once #239 is merged, I can rebase this PR suitably.