### PR TITLE
Backported to stable-4.7 earlier patches by @dimpase.

### DIFF
--- a/dev/Updates/mtxchar0
+++ b/dev/Updates/mtxchar0
@@ -1,0 +1,29 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Format 'yyyy/mm/dd'
+!! 2015/02/11
+!! Changed by
+DP, AH
+!! Type of Change
+Fix: usability issue
+New: improved documentation
+!! Description
+Removed unnecessary tests for the finiteness of the field from GModule and 
+related functions (the ones that do not need meataxe, but just linear algebra).
+Thus the correponding functions will work in char 0 case, or for other infinite
+fields, too.
+! Test Code
+gap> a:=AlternatingGroup(5);;
+gap> irr:=IrreducibleRepresentations(a);;
+gap> m:=GModuleByMats(GeneratorsOfGroup(Image(irr[3])),CyclotomicField(10));;
+gap> mm:=TensorProductGModule(m,m);;
+gap> smm:=MTX.SubGModule(mm,[[1,1,1,1,1,1,1,1,1]]);;
+gap> Size(Group(MTX.InducedActionSubmodule(mm,smm).generators));
+60
+gap> im:=InducedGModule(AlternatingGroup(6),a,m);;
+gap> im.dimension;
+18
+gap> MTX.CompositionFactors(m);
+Error, Argument of IsIrreducible is not over a finite field.
+!! Changeset
+47c566add2e58ce4395385cb916363660d2dfb74
+!! End

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -1061,8 +1061,13 @@ local proveIndecomposability, addnilpotent, n, F, zero, basis, enddim,
     return true;
   end;
 
+  if not M.IsOverFiniteField then
+    return Error ("Argument of ProperModuleDecomp is not over a finite field.");
+  fi;
+
   n:=M.dimension;
   F:=M.field;
+
   zero:=Zero(F);
   Info(InfoMtxHom,2,"ProperModuleDecomp for module of dimension ", n);
 

--- a/lib/meataxe.gd
+++ b/lib/meataxe.gd
@@ -22,7 +22,7 @@ DeclareGlobalFunction("GModuleByMats");
 ##
 #F  TrivialGModule ( g, F ) . . . trivial G-module
 ##
-##  g is a finite group, F a finite field, trivial smash G-module computed.
+##  g is a finite group, F a field, trivial smash G-module computed.
 DeclareGlobalFunction("TrivialGModule");
 
 #############################################################################
@@ -38,7 +38,7 @@ DeclareGlobalFunction("InducedGModule");
 ##
 #F PermutationGModule ( g, F) . permutation module
 ##
-## g is a permutation group, F a finite field.
+## g is a permutation group, F a field.
 ## The corresponding permutation module is output.
 DeclareGlobalFunction("PermutationGModule");
 


### PR DESCRIPTION
Removed unnecessary tests for the finiteness of the field from GModule and
related functions (the ones that do not need meataxe, but just linear algebra).
Thus the correponding functions will work in char 0 case, or for other infinite
fields, too.

This is already implemented in the master branch.