### PR TITLE
Add StartsWith and EndsWith

### DIFF
--- a/doc/ref/string.xml
+++ b/doc/ref/string.xml
@@ -497,7 +497,8 @@ gap> s;
 
 <#Include Label="JoinStringsWithSeparator">
 <#Include Label="Chomp">
-
+<#Include Label="StartsWith">
+        
 The following two functions convert basic strings to lists of numbers and
 vice versa. They are useful for examples of text encryption.
 <#Include Label="NumbersString">
@@ -709,4 +710,3 @@ functionality in this direction.
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <!-- %% -->
 <!-- %E -->
-

--- a/lib/string.gd
+++ b/lib/string.gd
@@ -613,7 +613,6 @@ DeclareGlobalFunction( "JoinStringsWithSeparator" );
 ##  <#GAPDoc Label="Chomp">
 ##  <ManSection>
 ##  <Func Name="Chomp" Arg='str'/>
-##
 ##  <Description>
 ##  Like the similarly named Perl function, <Ref Func="Chomp"/> removes a
 ##  trailing newline character (or carriage-return line-feed couplet) from a
@@ -657,6 +656,27 @@ DeclareGlobalFunction( "JoinStringsWithSeparator" );
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction( "Chomp" );
+
+#############################################################################
+##
+#F  StartsWith( <string>, <prefix> ) . . . does <string> start with <prefix>?
+#F  EndsWith( <string>, <suffix> ) . . . . . does <string> end with <suffix>?
+##
+##  <#GAPDoc Label="StartsWith">
+##  <ManSection>
+##  <Func Name="StartsWith" Arg='string, prefix'/>
+##  <Func Name="EndsWith" Arg='string, suffix'/>
+##
+##  <Description>
+##  <Index>Prefix</Index>
+##  <Index>Suffix</Index>
+##  Determines whether a string starts or ends with another string.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction( "StartsWith" );
+DeclareGlobalFunction( "EndsWith" );
 
 
 #############################################################################
@@ -747,4 +767,3 @@ BindGlobal("BHINT", "\>\<");
 #############################################################################
 ##
 #E
-

--- a/lib/string.gi
+++ b/lib/string.gi
@@ -734,6 +734,16 @@ InstallGlobalFunction(Chomp, function(str)
   fi;
 end);
 
+InstallGlobalFunction(StartsWith, function(string, prefix)
+  return Length(prefix) <= Length(string) and
+    string{[1..Length(prefix)]} = prefix;
+end);
+
+InstallGlobalFunction(EndsWith, function(string, suffix)
+  return Length(suffix) <= Length(string) and
+    string{[Length(string)-Length(suffix)+1..Length(string)]} = suffix;
+end);
+
 
 #############################################################################
 ##
@@ -1051,4 +1061,3 @@ end);
 #############################################################################
 ##
 #E
-

--- a/tst/teststandard/startendwith.tst
+++ b/tst/teststandard/startendwith.tst
@@ -1,0 +1,44 @@
+gap> START_TEST("startendwith.tst");
+gap> StartsWith("abc", "a");
+true
+gap> StartsWith("abc", "abc");
+true
+gap> StartsWith("", "");
+true
+gap> StartsWith("abc", "abcd");
+false
+gap> StartsWith("", "abc");
+false
+gap> StartsWith("abc", "ab");
+true
+gap> StartsWith("abc", "");
+true
+gap> StartsWith([1,2,3], [1,2]);
+true
+gap> StartsWith([1,2], [1,2,3]);
+false
+gap> StartsWith("abc", ['a', 'b']);
+true
+gap> StartsWith("abc", "bc");
+false
+gap> EndsWith("abc", "c");
+true
+gap> EndsWith("abc", "abc");
+true
+gap> EndsWith("", "");
+true
+gap> EndsWith("abc", "abcd");
+false
+gap> EndsWith("", "abc");
+false
+gap> EndsWith("abc", "bc");
+true
+gap> EndsWith("abc", "");
+true
+gap> EndsWith([1,2,3], [2,3]);
+true
+gap> EndsWith([1,2], [1,2,3]);
+false
+gap> EndsWith("abc", ['b', 'c']);
+true
+gap> STOP_TEST("startendwith.tst", 1);


### PR DESCRIPTION
This adds functions StartsWith and EndsWith, which let you check for prefixes and suffixes on strings (and arbitrary lists). These are back-ported for HPC-GAP, with documentation and tests.