### PR TITLE
Fix handling of includes in SConstruct.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -528,15 +528,20 @@ GAP.Command("src/dbgmacro.c", "etc/dbgmacro.py",
 # generating matching files in the gen/ directory and make them
 # the actual source files instead.
 gen = []
+includes = glob.glob("src/*.h")
 if preprocess:
   import os, stat
   try: os.mkdir("gen")
   except: pass
-  pregen = source + glob.glob("src/*.h")
+  pregen = source + includes
+  includes = map(lambda s: "gen/"+s[4:], includes)
   gen = map(lambda s: "gen/"+s[4:], pregen)
   for i in range(len(pregen)):
     GAP.Command(gen[i], pregen[i],
         preprocess + " $SOURCE >$TARGET")
+    if gen[i].endswith(".c"):
+      obj = "build/obj/" + gen[i][4:-2] + ".o"
+      GAP.Depends(obj, includes)
   source = map(lambda s: "gen/"+s[4:], source)
 
 # Cygwin needs to be explicitly told to include libstdc++ when linking


### PR DESCRIPTION
When the "preprocess" or "ward" options were specified, include file
dependencies were not properly parsed. This patch fixes this issue
by creating the necessary dependencies.

Note: This is currently less than perfect, as any change to an include
file will trigger a recompilation of every generated .c file. However,
since most C files already depend on most include files and include file
changes are relatively uncommon, this is currently less of an issue.

Proper dependency handling should be done as a separate step.

This also uses "addguards2c", the JIT-compiled version of the Ward tool
instead of "addguards2", the interpreted version. This makes builds
considerably faster and because "addguards2c" already falls back to the
interpreter version when the JIT compiler cannot be built, this should
not cause any regressions on platforms that don't support LuaJIT.