### PR TITLE
Apply a fix for inverse semigroups

### DIFF
--- a/lib/invsgp.gd
+++ b/lib/invsgp.gd
@@ -38,5 +38,5 @@ DeclareAttribute("AsInverseMonoid", IsCollection);
 DeclareOperation("AsInverseSubsemigroup", [IsDomain, IsCollection]);
 DeclareOperation("AsInverseSubmonoid", [IsDomain, IsCollection]);
 
-DeclareAttribute("ReverseNaturalPartialOrder", IsInverseSemigroup);
-DeclareAttribute("NaturalPartialOrder", IsInverseSemigroup);
+DeclareAttribute("ReverseNaturalPartialOrder", IsSemigroup);
+DeclareAttribute("NaturalPartialOrder", IsSemigroup);


### PR DESCRIPTION
The attributes ReverseNaturalPartialOrder and NaturalPartialOrder apply
to IsSemigroup instead of IsInverseSemigroup