### PR TITLE
Merge First with FirstOp, Filtered with FilteredOp, etc.

### DIFF
--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -2559,23 +2559,7 @@ DeclareOperation( "ProductOp", [ IsListOrCollection ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "Filtered" );
-
-
-#############################################################################
-##
-#O  FilteredOp( <C>, <func> )
-##
-##  <ManSection>
-##  <Oper Name="FilteredOp" Arg='C, func'/>
-##
-##  <Description>
-##  <C>FilteredOp</C> is the operation called by <C>Filtered</C>
-##  if <A>C</A> is not an internal list.
-##  </Description>
-##  </ManSection>
-##
-DeclareOperation( "FilteredOp", [ IsListOrCollection, IsFunction ] );
+DeclareOperation( "Filtered", [ IsListOrCollection, IsFunction ] );
 
 
 #############################################################################
@@ -2630,23 +2614,7 @@ DeclareOperation( "FilteredOp", [ IsListOrCollection, IsFunction ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "Number" );
-
-
-#############################################################################
-##
-#O  NumberOp( <C>, <func> )
-##
-##  <ManSection>
-##  <Oper Name="NumberOp" Arg='C, func'/>
-##
-##  <Description>
-##  <C>NumberOp</C> is the operation called by <C>Number</C>
-##  if <A>C</A> is not an internal list.
-##  </Description>
-##  </ManSection>
-##
-DeclareOperation( "NumberOp", [ IsListOrCollection, IsFunction ] );
+DeclareOperation( "Number", [ IsListOrCollection, IsFunction ] );
 
 
 #############################################################################
@@ -2676,23 +2644,7 @@ DeclareOperation( "NumberOp", [ IsListOrCollection, IsFunction ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "ForAll" );
-
-
-#############################################################################
-##
-#O  ForAllOp( <C>, <func> )
-##
-##  <ManSection>
-##  <Oper Name="ForAllOp" Arg='C, func'/>
-##
-##  <Description>
-##  <C>ForAllOp</C> is the operation called by <C>ForAll</C>
-##  if <A>C</A> is not an internal list.
-##  </Description>
-##  </ManSection>
-##
-DeclareOperation( "ForAllOp", [ IsListOrCollection, IsFunction ] );
+DeclareOperation( "ForAll", [ IsListOrCollection, IsFunction ] );
 
 
 #############################################################################
@@ -2724,23 +2676,7 @@ DeclareOperation( "ForAllOp", [ IsListOrCollection, IsFunction ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "ForAny" );
-
-
-#############################################################################
-##
-#O  ForAnyOp( <C>, <func> )
-##
-##  <ManSection>
-##  <Oper Name="ForAnyOp" Arg='C, func'/>
-##
-##  <Description>
-##  <C>ForAnyOp</C> is the operation called by <C>ForAny</C>
-##  if <A>C</A> is not an internal list.
-##  </Description>
-##  </ManSection>
-##
-DeclareOperation( "ForAnyOp", [ IsListOrCollection, IsFunction ] );
+DeclareOperation( "ForAny", [ IsListOrCollection, IsFunction ] );
 
 
 #############################################################################

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -813,7 +813,7 @@ InstallMethod( ListOp,
 
 InstallMethod( ListOp,
     "for a dense list, and a function",
-    [ IsDenseList, IsFunction ],
+    [ IsDenseList and IsFinite, IsFunction ],
     function ( C, func )
     local   res, elm;
     res := EmptyPlist(Length(C));
@@ -1432,7 +1432,7 @@ InstallMethod( Filtered,
     end );
 InstallMethod( Filtered,
     "for a dense list, and a function",
-    [ IsDenseList, IsFunction ],
+    [ IsDenseList and IsFinite, IsFunction ],
     function ( C, func )
     local res, elm, ob;
     res := [];

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -1399,34 +1399,25 @@ end;
 
 #############################################################################
 ##
-#F  Filtered( <coll>, <func> )
+#M  Filtered( <C>, <func> ) . . . . . . extract elements that have a property
 ##
-InstallGlobalFunction( Filtered,
-    function( C, func )
-    local tnum, res, i, elm;
-    tnum:= TNUM_OBJ_INT( C );
-    if FIRST_LIST_TNUM <= tnum and tnum <= LAST_LIST_TNUM then
-      # start with empty list of same representation
-      res := C{[]};
-      i   := 0;
-      for elm in C do
+InstallMethod( Filtered,
+    "for an internal list, and a function",
+    [ IsList and IsInternalRep, IsFunction ],
+    function ( C, func )
+    local res, i, elm;
+    # start with empty list of same representation
+    res := C{[]};
+    i   := 0;
+    for elm in C do
         if func( elm ) then
-          i:= i+1;
-          res[i]:= elm;
+            i:= i+1;
+            res[i]:= elm;
         fi;
-      od;
-      return res;
-    else
-      return FilteredOp( C, func );
-    fi;
-end );
-
-
-#############################################################################
-##
-#M  FilteredOp( <C>, <func> ) . . . . . extract elements that have a property
-##
-InstallMethod( FilteredOp,
+    od;
+    return res;
+    end );
+InstallMethod( Filtered,
     "for a list/collection, and a function",
     [ IsListOrCollection, IsFunction ],
     function ( C, func )
@@ -1439,23 +1430,7 @@ InstallMethod( FilteredOp,
     od;
     return res;
     end );
-InstallMethod( FilteredOp,
-    "for a list, and a function",
-    [ IsList, IsFunction ],
-    function ( C, func )
-    local res, elm, ob;
-    res := [];
-    for elm in [1..Length(C)] do
-        if IsBound(C[elm]) then
-            ob := C[elm];
-            if func( ob ) then
-                Add( res, ob );
-            fi;
-        fi;
-    od;
-    return res;
-    end );
-InstallMethod( FilteredOp,
+InstallMethod( Filtered,
     "for a dense list, and a function",
     [ IsDenseList, IsFunction ],
     function ( C, func )
@@ -1471,7 +1446,7 @@ InstallMethod( FilteredOp,
     end );
 
 #T Is this useful compared to the previous method? (FL)
-InstallMethod( FilteredOp,
+InstallMethod( Filtered,
     "for an empty list/collection, and a function",
     [ IsEmpty, IsFunction ], 
     SUM_FLAGS, # there is nothing to do
@@ -1482,46 +1457,22 @@ InstallMethod( FilteredOp,
 
 #############################################################################
 ##
-#F  Number( <coll> )
-#F  Number( <coll>, <func> )
+#M  Number( <C>, <func> ) . . . . . . . . count elements that have a property
 ##
-InstallGlobalFunction( Number,
-    function( arg )
-    local tnum, C, func, nr, elm,l;
-    l := Length( arg );
-    if l = 0 then
-      Error( "usage: Number( <C>[, <func>] )" );
-    fi;
-    tnum:= TNUM_OBJ_INT( arg[1] );
-    if FIRST_LIST_TNUM <= tnum and tnum <= LAST_LIST_TNUM then
-      C:= arg[1];
-      if l = 1 then
-        nr := 0;
-        for elm in C do
-            nr := nr + 1;
-        od;
-        return nr;
-      else
-        func:= arg[2];
-        nr := 0;
-        for elm in C do
-            if func( elm ) then
-                nr:= nr + 1;
-            fi;
-        od;
-        return nr;
-      fi;
-    else
-      return CallFuncList( NumberOp, arg );
-    fi;
-end );
-
-
-#############################################################################
-##
-#M  NumberOp( <C>, <func> ) . . . . . . . count elements that have a property
-##
-InstallMethod( NumberOp,
+InstallMethod( Number,
+    "for an internal list, and a function",
+    [ IsList and IsInternalRep, IsFunction ],
+    function ( C, func )
+    local nr, elm;
+    nr := 0;
+    for elm in C do
+        if func( elm ) then
+            nr:= nr + 1;
+        fi;
+    od;
+    return nr;
+    end );
+InstallMethod( Number,
     "for a list/collection, and a function",
     [ IsListOrCollection, IsFunction ],
     function ( C, func )
@@ -1534,24 +1485,9 @@ InstallMethod( NumberOp,
     od;
     return nr;
     end );
-InstallMethod( NumberOp,
-    "for a list, and a function",
-    [ IsList, IsFunction ],
-    function ( C, func )
-    local nr, elm;
-    nr := 0;
-    for elm in [1..Length(C)] do
-        if IsBound(C[elm]) then
-            if func( C[elm] ) then
-                nr:= nr + 1;
-            fi;
-        fi;
-    od;
-    return nr;
-    end );
-InstallMethod( NumberOp,
+InstallMethod( Number,
     "for a dense list, and a function",
-    [ IsDenseList, IsFunction ],
+    [ IsDenseList and IsFinite, IsFunction ],
     function ( C, func )
     local nr, elm;
     nr := 0;
@@ -1566,9 +1502,9 @@ InstallMethod( NumberOp,
 
 #############################################################################
 ##
-#M  NumberOp( <C> ) . . . . . . . . . . . count elements that have a property
+#M  Number( <C> ) . . . . . . . . . . . . count elements that have a property
 ##
-InstallOtherMethod( NumberOp,
+InstallOtherMethod( Number,
     "for a list/collection",
     [ IsListOrCollection ],
     function ( C )
@@ -1579,50 +1515,29 @@ InstallOtherMethod( NumberOp,
     od;
     return nr;
     end );
-InstallOtherMethod( NumberOp,
-    "for a list",
-    [ IsList ],
-    function ( C )
-    local nr, elm;
-    nr := 0;
-    for elm in [1..Length(C)] do
-        if IsBound(C[elm]) then
-            nr := nr + 1;
-        fi;
-    od;
-    return nr;
-    end );
-InstallOtherMethod( NumberOp,
+
+InstallOtherMethod( Number,
     "for a dense list",
     [ IsDenseList ], Length );
 
 
 #############################################################################
 ##
-#F  ForAll( <coll>, <func> )
+#M  ForAll( <C>, <func> ) . . . .  test a property for all elements of a list
 ##
-InstallGlobalFunction( ForAll,
-    function( C, func )
-    local tnum, elm;
-    tnum:= TNUM_OBJ_INT( C );
-    if FIRST_LIST_TNUM <= tnum and tnum <= LAST_LIST_TNUM then
-      for elm in C do
-          if not func( elm ) then
-              return false;
-          fi;
-      od;
-      return true;
-    else
-      return ForAllOp( C, func );
-    fi;
-end );
-
-
-#############################################################################
-##
-#M  ForAllOp( <C>, <func> ) . . .  test a property for all elements of a list
-##
-InstallMethod( ForAllOp,
+InstallMethod( ForAll,
+    "for an internal list, and a function",
+    [ IsList and IsInternalRep, IsFunction ],
+    function ( C, func )
+    local elm;
+    for elm in C do
+        if not func( elm ) then
+            return false;
+        fi;
+    od;
+    return true;
+    end );
+InstallMethod( ForAll,
     "for a list/collection, and a function",
     [ IsListOrCollection, IsFunction ],
     function ( C, func )
@@ -1634,21 +1549,7 @@ InstallMethod( ForAllOp,
     od;
     return true;
     end );
-InstallMethod( ForAllOp,
-    "for a list, and a function",
-    [ IsList and IsFinite, IsFunction ],
-    function ( C, func )
-    local elm;
-    for elm in [1..Length(C)] do
-        if IsBound(C[elm]) then
-            if not func( C[elm] ) then
-                return false;
-            fi;
-        fi;
-    od;
-    return true;
-    end );
-InstallMethod( ForAllOp,
+InstallMethod( ForAll,
     "for a dense list, and a function",
     [ IsDenseList and IsFinite, IsFunction ],
     function ( C, func )
@@ -1661,7 +1562,7 @@ InstallMethod( ForAllOp,
     return true;
     end );
 
-InstallOtherMethod( ForAllOp,
+InstallOtherMethod( ForAll,
     "for an empty list/collection, and a function",
     [ IsEmpty, IsFunction ], 
     SUM_FLAGS, # there is nothing to do
@@ -1670,30 +1571,21 @@ InstallOtherMethod( ForAllOp,
 
 #############################################################################
 ##
-#F  ForAny( <coll>, <func> )
+#M  ForAny( <C>, <func> ) . . . . . test a property for any element of a list
 ##
-InstallGlobalFunction( ForAny,
-    function( C, func )
-    local tnum, elm;
-    tnum:= TNUM_OBJ_INT( C );
-    if FIRST_LIST_TNUM <= tnum and tnum <= LAST_LIST_TNUM then
-      for elm in C do
-          if func( elm ) then
-              return true;
-          fi;
-      od;
-      return false;
-    else
-      return ForAnyOp( C, func );
-    fi;
+InstallMethod( ForAny,
+    "for an internal list, and a function",
+    [ IsList and IsInternalRep, IsFunction ],
+    function ( C, func )
+    local elm;
+    for elm in C do
+        if func( elm ) then
+            return true;
+        fi;
+    od;
+    return false;
 end );
-
-
-#############################################################################
-##
-#M  ForAnyOp( <C>, <func> ) . . . . test a property for any element of a list
-##
-InstallMethod( ForAnyOp,
+InstallMethod( ForAny,
     "for a list/collection, and a function",
     [ IsListOrCollection, IsFunction ],
     function ( C, func )
@@ -1705,22 +1597,7 @@ InstallMethod( ForAnyOp,
     od;
     return false;
 end );
-
-InstallMethod( ForAnyOp,
-    "for a list, and a function",
-    [ IsList and IsFinite, IsFunction ],
-    function ( C, func )
-    local elm;
-    for elm in [1..Length(C)] do
-        if IsBound(C[elm]) then
-            if func( C[elm] ) then
-                return true;
-            fi;
-        fi;
-    od;
-    return false;
-    end );
-InstallMethod( ForAnyOp,
+InstallMethod( ForAny,
     "for a dense list, and a function",
     [ IsDenseList and IsFinite, IsFunction ],
     function ( C, func )
@@ -1733,7 +1610,7 @@ InstallMethod( ForAnyOp,
     return false;
     end );
 
-InstallOtherMethod( ForAnyOp,
+InstallOtherMethod( ForAny,
     "for an empty list/collection, and a function",
     [ IsEmpty, IsFunction ],
     SUM_FLAGS, # there is nothing to do

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -1445,10 +1445,10 @@ InstallMethod( Filtered,
     return res;
     end );
 
-#T Is this useful compared to the previous method? (FL)
+# Optimization for empty lists gives a tiny but noticeable speedup
 InstallMethod( Filtered,
     "for an empty list/collection, and a function",
-    [ IsEmpty, IsFunction ], 
+    [ IsEmpty and IsListOrCollection, IsFunction ], 
     SUM_FLAGS, # there is nothing to do
     function( list, func )
     return [];
@@ -1562,9 +1562,10 @@ InstallMethod( ForAll,
     return true;
     end );
 
-InstallOtherMethod( ForAll,
+# Optimization for empty lists gives a tiny but noticeable speedup
+InstallMethod( ForAll,
     "for an empty list/collection, and a function",
-    [ IsEmpty, IsFunction ], 
+    [ IsEmpty and IsListOrCollection, IsFunction ], 
     SUM_FLAGS, # there is nothing to do
     ReturnTrue );
 
@@ -1610,9 +1611,10 @@ InstallMethod( ForAny,
     return false;
     end );
 
-InstallOtherMethod( ForAny,
+# Optimization for empty lists gives a tiny but noticeable speedup
+InstallMethod( ForAny,
     "for an empty list/collection, and a function",
-    [ IsEmpty, IsFunction ],
+    [ IsEmpty and IsListOrCollection, IsFunction ],
     SUM_FLAGS, # there is nothing to do
     ReturnFalse );
 

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -1899,7 +1899,7 @@ DeclareGlobalFunction( "IteratorList" );
 ##
 ##  <#GAPDoc Label="First">
 ##  <ManSection>
-##  <Func Name="First" Arg='list, func'/>
+##  <Oper Name="First" Arg='list, func'/>
 ##
 ##  <Description>
 ##  <Ref Func="First"/> returns the first element of the list <A>list</A>
@@ -1929,23 +1929,7 @@ DeclareGlobalFunction( "IteratorList" );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "First" );
-
-
-#############################################################################
-##
-#O  FirstOp( <list>, <func> )
-##
-##  <ManSection>
-##  <Oper Name="FirstOp" Arg='list, func'/>
-##
-##  <Description>
-##  <Ref Oper="FirstOp"/> is the operation called by <Ref Func="First"/>
-##  if <A>list</A> is not an internally represented list.
-##  </Description>
-##  </ManSection>
-##
-DeclareOperation( "FirstOp", [ IsListOrCollection, IsFunction ] );
+DeclareOperation( "First", [ IsListOrCollection, IsFunction ] );
 
 
 #############################################################################

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -3622,7 +3622,7 @@ end);
 ##  This is intended for use in certain rare situations, such as before
 ##  Objectifying. Normally, ConstantAccessTimeList should be enough
 ##
-##  This function guarantees that the reult will be a plain list, distinct
+##  This function guarantees that the result will be a plain list, distinct
 ##  from the input object.
 ##
 InstallGlobalFunction(PlainListCopy, function( list )

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -2619,28 +2619,7 @@ InstallMethod( Permuted,
 ##
 #F  First( <C>, <func> )  . . .  find first element in a list with a property
 ##
-InstallGlobalFunction( First,
-    function ( C, func )
-    local tnum, elm;
-    tnum:= TNUM_OBJ_INT( C );
-    if FIRST_LIST_TNUM <= tnum and tnum <= LAST_LIST_TNUM then
-      for elm in C do
-          if func( elm ) then
-              return elm;
-          fi;
-      od;
-      return fail;
-    else
-      return FirstOp( C, func );
-    fi;
-end );
-
-
-#############################################################################
-##
-#M  FirstOp( <C>, <func> )  . .  find first element in a list with a property
-##
-InstallMethod( FirstOp,
+InstallMethod( First,
     "for a list or collection and a function",
     [ IsListOrCollection, IsFunction ],
     function ( C, func )

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -505,5 +505,26 @@ DeclareOperation("PositionFirstComponent",[IsList,IsObject]);
 
 #############################################################################
 ##
+#O  FirstOp( <list>, <func> )
+#O  NumberOp( <C>, <func> )
+#O  ForAllOp( <C>, <func> )
+#O  ForAnyOp( <C>, <func> )
+#O  FilteredOp( <C>, <func> )
+##
+## Removed due to being unnecessary. Instead, First was turned into an
+## operation. If you are installing methods for this, install them for
+## First instead.
+##
+## Deprecated in GAP >= 4.9
+##
+DeclareSynonym( "FirstOp", First );
+DeclareSynonym( "NumberOp", Number );
+DeclareSynonym( "ForAllOp", ForAll );
+DeclareSynonym( "ForAnyOp", ForAny );
+DeclareSynonym( "FilteredOp", Filtered );
+
+
+#############################################################################
+##
 #E
 

--- a/lib/sparselistgen.gi
+++ b/lib/sparselistgen.gi
@@ -198,11 +198,11 @@ end);
 
 #############################################################################
 ##
-#M  NumberOp( <sl>, <func> )
+#M  Number( <sl>, <func> )
 ##
 
 
-InstallMethod(NumberOp, "sparse list", [IsSparseList, IsFunction],
+InstallMethod(Number, "sparse list", [IsSparseList, IsFunction],
         function(sl, func)
     local   ss,  n;
     ss := SparseStructureOfList(sl);
@@ -218,14 +218,14 @@ end);
 
 #############################################################################
 ##
-#M  ForAllOp( <sl>, <func> )
+#M  ForAll( <sl>, <func> )
 ##
 ##  This is a little more complicated than you might think, because the
 ##  default value may not actually appear anywhere in the list
 ##
 
 
-InstallMethod(ForAllOp, 
+InstallMethod(ForAll, 
         "sparse list", [IsSparseList, IsFunction],
         function(sl, func)
     local   ss;
@@ -236,13 +236,13 @@ end);
 
 #############################################################################
 ##
-#M  ForAnyOp( <sl>, <func> )
+#M  ForAny( <sl>, <func> )
 ##
 ##  This is a little more complicated than you might think, because the
 ##  default value may not actually appear anywhere in the list
 ##
 
-InstallMethod(ForAnyOp, 
+InstallMethod(ForAny, 
         "sparse list", [IsSparseList, IsFunction],
         function(sl, func)
     local   ss;

--- a/lib/sparselistsorted.gi
+++ b/lib/sparselistsorted.gi
@@ -351,7 +351,7 @@ InstallMethod(Permuted, "sparse list", [IsSparseListBySortedListRep
     return SparseListBySortedListNC( poss, vals, sl![SL_LENGTH], sl![SL_DEFAULT]);
 end);
 
-InstallMethod( FilteredOp, "sparse list", [IsSparseListBySortedListRep 
+InstallMethod( Filtered, "sparse list", [IsSparseListBySortedListRep 
         and IsSparseList, IsFunction],
         function(sl, filt)
     local   skipped,  iposs,  oposs,  ivals,  ovals,  i,  newlen;


### PR DESCRIPTION
This pull request deals with `First`, `Number`, `ForAll`, `ForAny`, `Filtered` and their undocumented "Op" variants `FirstOp` and so on. To keep things simple, I'll just refer to `First` from now on.

Previously, `First` was a global function, which checked if its first argument had the TNUM of an internal list, and if yes, applied certain code to it; if not, it delegated to the `FirstOp` operation. This setup was introduced by Thomas Breuer in March 1998 (the commit also dealt with `Sum`, `Product`, and `List`, but I do not). No reason was given, but I assume it was to speed up things.

Fast forward today. For the datastructure package, we'd like to use `First` in a single-argument version, so I looked into turning `First` into an operation. This lead to me discovering the situation I just described. Curious, I tested what happend if I merged `First` and `FirstOp`. I wanted to know how much slower it really made things.

To my surprise, the change made no difference. Moreover, when I applied a similar change to `Number`, things actually got _faster_, at least in the micro benchmark I used! This lead to a lot more research and testing... I discovered the following:
- the method dispatch creates no measurable overhead. Or perhaps it is measurable with a far more elaborate setup, but for me it was basically drowned out in the noise generated by garbage collection and other outside factors
- the following two loops seemingly do the same thing, but in reality, they (a) do not and (b) perform quite differently, depending on the input:

```
# Loop 1
for x in C do
  ...
od;
# Loop 2
for i in [1..Length(C)] do
  x := C[i];
  ...
od;
```

But these are not at all equivalent. For starters, loop 2 only works correctly for dense lists, but let's ignore that for the moment. But in reality, the first loop actually corresponds more closely to this (as is explained in the manual entry for the `for` loop):

```
# Loop 3
i := 1;
while i <= Length(C) do
  x := C[i];
  i := i + 1;
  ...
od;
```

Now, for internal lists (such as plists, blists, ranges, strings), loop 1 is always the fastest. But for non-internal lists (such as 8-bit compressed vectors), the second loop is faster -- because it does not constantly recompute the list length. While doing that is fast, if you have millions of iterations, the overhead adds up. (The explicit loop 3 is always slowest, by the way).

On the other hand, for non-dense loops, loop 1 is always fastest, since adding calls to `IsBound` to loop 2 slows it down tremendously. This leads to the bizarre situation that for optimal performance, one wants to use loop 1 for the generic case, but not for dense lists, _except_ those dense lists also are internal... :). This PR does just that, which means that despite the simpler structure of the code, it actually is a little bit faster in many cases. I performed quite some benchmarking, and will attach some results as well as my benchmark code (yay, to GitHub for introducing that feature today :-). The test took varous short (ca 5 element) and longer (ca 5*1024 elements) lists, and applied the relevant functions / operations, once with `ReturnFalse` and once with `ReturnTrue`. Well, not just once, many times; then repeated this, and compute the avarages of the runs (it even prints the standard deviation ;-). All times are in milliseconds.
- Before: [filtered-bench-res-master.txt](https://github.com/gap-system/gap/files/3010/filtered-bench-res-master.txt)
- After: [filtered-bench-res-first-last.txt](https://github.com/gap-system/gap/files/3011/filtered-bench-res-first-last.txt)
- Here is the code to generate those numbers: [filtered-bench.g.txt](https://github.com/gap-system/gap/files/3012/filtered-bench.g.txt)

To ensure backwards compatibility, I made `FirstOp` a synonym of `First`, etc. This ensures that the packages `cvec`, `fr` and `resclasses` keep working, as they install some methods for the "Op" variants (these were the only packages I could find doing so).

Finally, the fact that loop 1 corresponds to loop 3, but not to loop 2, means that strictly speaking the different methods have slightly different semantics. Consider this code snippet:

```
list := ... some list, internal or external ...;
Number( list,  function(x)  Add(list, x); return true; end);
```

If `list` is a dense non-internal list, or if it is empty, this returns the length of `list`; otherwise, it runs into an endless loop.

But this is existing behavior, so I don't feel bad about it. And anyway, if a user does something like this, it's their own fault... ;-). But perhaps we should document that `First` and friends assume that the list is not modified while they run.
