### PR TITLE
src/gmpints.c: remove call to mp_set_memory_functions

### DIFF
--- a/src/gmpints.c
+++ b/src/gmpints.c
@@ -12,7 +12,6 @@
 **  This file implements the  functions  handling  GMP integers.
 **
 */
-#include        <sys/mman.h>
 #include        "system.h"              /* Ints, UInts                     */
 
 #include        "gasman.h"              /* garbage collector               */
@@ -2538,23 +2537,6 @@ static StructGVarFunc GVarFuncs [] = {
 **
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
 */
-
-static void *allocForGmp(size_t size) {
-  return mmap((void *)0, size, PROT_READ| PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
-}
-
-static void *reallocForGmp (void *old, size_t old_size, size_t new_size) {
-  void * newptr = allocForGmp(new_size);
-  size_t common_size = (new_size < old_size) ? new_size:old_size;
-  memcpy(newptr, old, common_size);
-  munmap(old, old_size);
-  return newptr;
-}
-
-static  void freeForGmp (void *ptr, size_t size) {
-  munmap(ptr, size);
-}
-
 static Int InitKernel ( StructInitInfo * module )
 {
   UInt                t1,  t2;
@@ -2563,8 +2545,6 @@ static Int InitKernel ( StructInitInfo * module )
     FPUTS_TO_STDERR("Panic, GMP limb size mismatch\n");
     SyExit( 1 ); 
   }
-
-   mp_set_memory_functions( allocForGmp, reallocForGmp, freeForGmp); 
 
   /* init filters and functions                                            */
   InitHdlrFiltsFromTable( GVarFilts );


### PR DESCRIPTION
In Nov 2010, we added code which set GMP to use custom code for memory
allocations, which made it use mmap/munmap. However, we do not need that at
all, as we exclusively use low level GMP interfaces, which do not make any
memory allocations.

Presumably, this change was done to allow us to call high-level GMP APIs, but
we never ended up actually doing that.

Despite this, the change has a noticeable impact, but sadly a negative one: If
one actually does use the high-level APIs, operations become much, much
slower. For example, running Normaliz via NormalizInterface from inside GAP, a
computation that usually takes a dozen seconds or so, did not finish after
several minutes.

If we want to do something like this, I fear we need to implement a proper
full-blown memory manager. But for now, I don't see a reason to do so. Esp. on
64bit machines, were it (empirically) seems relatively safe to use malloc
inside GAP kernel code...