### PR TITLE
Improve performance of EqPerm22 and EqPerm44

### DIFF
--- a/src/permutat.c
+++ b/src/permutat.c
@@ -278,6 +278,7 @@ void            PrintPermQ (
 **
 **  Two permutations may be equal, even if the two sequences do not have  the
 **  same length, if  the  larger  permutation  fixes  the  exceeding  points.
+**
 */
 Int             EqPerm22 (
     Obj                 opL,
@@ -285,8 +286,10 @@ Int             EqPerm22 (
 {
     UInt                degL;           /* degree of the left operand      */
     UInt2 *             ptL;            /* pointer to the left operand     */
+    UInt2 *             ptLstart;       /* pointer to left operand start   */
     UInt                degR;           /* degree of the right operand     */
     UInt2 *             ptR;            /* pointer to the right operand    */
+    UInt2 *             ptRstart;       /* pointer to right operand start  */
     UInt                p;              /* loop variable                   */
 
     /* get the degrees                                                     */
@@ -294,25 +297,40 @@ Int             EqPerm22 (
     degR = DEG_PERM2(opR);
 
     /* set up the pointers                                                 */
-    ptL = ADDR_PERM2(opL);
-    ptR = ADDR_PERM2(opR);
+    ptLstart = ADDR_PERM2(opL);
+    ptRstart = ADDR_PERM2(opR);
 
+    /* if permutations are different sizes, check final element as
+     * early check                                                         */
+
+    if ( degL != degR ) {
+      if ( degL < degR ) {
+        if ( *(ptRstart + degR - 1) != (degR - 1) )
+          return 0L;
+      }
+      else {
+        if ( *(ptLstart + degL - 1) != (degL - 1) )
+          return 0L;
+      }
+    }
+    
     /* search for a difference and return False if you find one          */
     if ( degL <= degR ) {
-        for ( p = 0; p < degL; p++ )
-            if ( *(ptL++) != *(ptR++) )
-                return 0L;
-        for ( p = degL; p < degR; p++ )
-            if (        p != *(ptR++) )
-                return 0L;
+      ptR = ptRstart + degL;
+      for ( p = degL; p < degR; p++ )
+          if ( *(ptR++) !=        p )
+              return 0L;
+        
+        if(memcmp(ptLstart, ptRstart, degL * sizeof(UInt2)) != 0)
+            return 0L;
     }
     else {
-        for ( p = 0; p < degR; p++ )
-            if ( *(ptL++) != *(ptR++) )
-                return 0L;
+        ptL = ptLstart + degR;
         for ( p = degR; p < degL; p++ )
             if ( *(ptL++) !=        p )
                 return 0L;
+        if(memcmp(ptLstart, ptRstart, degR * sizeof(UInt2)) != 0)
+          return 0L;
     }
 
     /* otherwise they must be equal                                        */
@@ -405,8 +423,10 @@ Int             EqPerm44 (
 {
     UInt                degL;           /* degree of the left operand      */
     UInt4 *             ptL;            /* pointer to the left operand     */
+    UInt4 *             ptLstart;       /* pointer to left operand start   */
     UInt                degR;           /* degree of the right operand     */
     UInt4 *             ptR;            /* pointer to the right operand    */
+    UInt4 *             ptRstart;       /* pointer to right operand start  */
     UInt                p;              /* loop variable                   */
 
     /* get the degrees                                                     */
@@ -414,25 +434,40 @@ Int             EqPerm44 (
     degR = DEG_PERM4(opR);
 
     /* set up the pointers                                                 */
-    ptL = ADDR_PERM4(opL);
-    ptR = ADDR_PERM4(opR);
+    ptLstart = ADDR_PERM4(opL);
+    ptRstart = ADDR_PERM4(opR);
 
+    /* if permutations are different sizes, check final element as
+     * early check                                                         */
+
+    if ( degL != degR ) {
+      if ( degL < degR ) {
+        if ( *(ptRstart + degR - 1) != (degR - 1) )
+          return 0L;
+      }
+      else {
+        if ( *(ptLstart + degL - 1) != (degL - 1) )
+          return 0L;
+      }
+    }
+    
     /* search for a difference and return False if you find one          */
     if ( degL <= degR ) {
-        for ( p = 0; p < degL; p++ )
-            if ( *(ptL++) != *(ptR++) )
-                return 0L;
-        for ( p = degL; p < degR; p++ )
-            if (        p != *(ptR++) )
-                return 0L;
+      ptR = ptRstart + degL;
+      for ( p = degL; p < degR; p++ )
+          if ( *(ptR++) !=        p )
+              return 0L;
+        
+        if(memcmp(ptLstart, ptRstart, degL * sizeof(UInt4)) != 0)
+            return 0L;
     }
     else {
-        for ( p = 0; p < degR; p++ )
-            if ( *(ptL++) != *(ptR++) )
-                return 0L;
+        ptL = ptLstart + degR;
         for ( p = degR; p < degL; p++ )
             if ( *(ptL++) !=        p )
                 return 0L;
+        if(memcmp(ptLstart, ptRstart, degR * sizeof(UInt4)) != 0)
+          return 0L;
     }
 
     /* otherwise they must be equal                                        */
@@ -468,6 +503,7 @@ Int             LtPerm22 (
 
     /* search for a difference and return if you find one                  */
     if ( degL <= degR ) {
+      
         for ( p = 0; p < degL; p++ )
             if ( *(ptL++) != *(ptR++) ) {
                 if ( *(--ptL) < *(--ptR) )  return 1L ;

--- a/tst/testinstall/perm.tst
+++ b/tst/testinstall/perm.tst
@@ -1,0 +1,27 @@
+gap> START_TEST("perm.tst");
+gap> () = ();
+true
+gap> () = (1,2,3);
+false
+gap> (1,2,3) = ();
+false
+gap> (1,2,3) = (1,2,3);
+true
+gap> PermList([1,2,3]) = ();
+true
+gap> () = PermList([1,2,3]);
+true
+gap> (1,2) = PermList([2,1,3]);
+true
+gap> PermList([2,1,3]) = (1,2);
+true
+gap> checklens := Concatenation([1..20], [2^15-10..2^15+10],
+>                               [2^16-10..2^16+10], [2^17-10..2^17+10]);;
+gap> ForAll(checklens, n -> PermList(Concatenation([1..n-1], [n+1,n])) =
+>                           PermList(Concatenation([1..n-1],[n+1,n,n+2])));
+true
+gap> ForAll(checklens, n -> not(
+>  PermList(Concatenation([1..n-1], [n+1,n,n+2,n+4,n+3])) =
+>  PermList(Concatenation([1..n-1], [n+1,n+2,n,n+4,n+3]))));
+true
+gap> STOP_TEST("perm.tst", 10);


### PR DESCRIPTION
This provides 3 improvements to permutation equality. Together they provide a speed-up of 5 times on average, and much larger in some special cases.

The improvements are:

* Use memcmp when comparing two blocks of memory, which is usually optimised by the compiler.
* Switch to first comparing the area of the permutation where one is longer than the other, in the hope we have kept our permutations trims so this won't just be the identity.
* Add a further special check, when we have permutations of unequal length, if the very last member is different. This will make properly trimmed permutations of equal length return almost immediately.

As a practical example, this speeds up the following GAP code by about 12% on my machine:
````
p := (1,39,45,82,28,37,23,36,31,83,77,93,29,58,87,91,63,71,70,56,89,74,3,9,
16,54,97,60,96,26,84,40,79,13,73,48,86,72,34,22,35,57,2,10,65,59,66)(4,
92,81,12,21,64,42,25,88,85,33,100,49,24,20,76,8)(5,94,27,18,14,38)(6,53,
98,51,67,99,17,78,68,19,11,52,32,75,47,41,7,95,46,62,43,50,44,55)(15,69,
30,61,90);
g := DirectProduct(List([1..10], x -> AlternatingGroup(10)));
h := g^p;
Intersection(g,h);
````

If this patch is accepted, there are several other places memcmp could be used (unfortunately not in LeqPerm, because memcmp doesn't tell us where the mismatch occurred).