### PR TITLE
Adjusted the GC_free_space_divisor parameter.

### DIFF
--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1331,6 +1331,7 @@ void            InitBags (
     }
     GC_set_all_interior_pointers(0);
     GC_init();
+    GC_set_free_space_divisor(1);
     TLAllocatorInit();
     GC_register_displacement(0);
     GC_register_displacement(HEADER_SIZE*sizeof(Bag));


### PR DESCRIPTION
Changed GC_free_space_divisor to 1 from its default of 3. This
makes garbage collection considerably faster at the cost of
requiring approximately 50% more memory.