### PR TITLE
Add faster log2int, function just for C code, and a new log2int test

### DIFF
--- a/src/gmpints.c
+++ b/src/gmpints.c
@@ -611,6 +611,25 @@ Obj FuncIntHexString( Obj self,  Obj str )
   }
 }
 
+/****************************************************************************
+**  
+**  Implementation of Log2Int for C integers.
+*/
+
+Int CLog2Int(Int a)
+{
+  Int res, mask;
+  if (a < 0) a = -a;
+  if (a < 1) return -1;
+  if (a < 65536) {
+    for(mask = 2, res = 0; ;mask *= 2, res += 1) {
+      if(a < mask) return res;
+    }
+  }
+  for(mask = 65536, res = 15; ;mask *= 2, res += 1) {
+    if(a < mask) return res;
+  }
+}
 
 /****************************************************************************
 **
@@ -620,20 +639,13 @@ Obj FuncIntHexString( Obj self,  Obj str )
 */
 Obj FuncLog2Int( Obj self, Obj integer)
 {
-  Int res, d;
+  Int d;
   Int a, len;
-  Int mask;
   TypLimb dmask;
   
   /* case of small ints                                                    */
   if (IS_INTOBJ(integer)) {
-    a = INT_INTOBJ(integer);
-    if (a < 0) a = -a;
-    res = NR_SMALL_INT_BITS;
-    for(res = NR_SMALL_INT_BITS, mask = (Int)1 << NR_SMALL_INT_BITS;
-        (mask & a) == 0 && mask != (Int)0;
-        mask = mask >> 1, res--);
-    return INTOBJ_INT(res);
+    return INTOBJ_INT(CLog2Int(INT_INTOBJ(integer)));
   }
 
   /* case of long ints                                                     */

--- a/src/gmpints.h
+++ b/src/gmpints.h
@@ -245,6 +245,7 @@ extern  Obj             GcdInt (
                                 Obj                 opR );
 
 
+extern Int CLog2Int(Int intnum);
 extern Obj FuncLog2Int( Obj self, Obj intnum);
 
 extern Obj AInvInt ( Obj gmp );

--- a/src/integer.c
+++ b/src/integer.c
@@ -513,6 +513,26 @@ void            PrintInt (
 }
 
 /****************************************************************************
+**  
+**  Implementation of Log2Int for C integers.
+*/
+
+Int CLog2Int(Int a)
+{
+  Int res, mask;
+  if (a < 0) a = -a;
+  if (a < 1) return -1;
+  if (a < 65536) {
+    for(mask = 2, res = 0; ;mask *= 2, res += 1) {
+      if(a < mask) return res;
+    }
+  }
+  for(mask = 65536, res = 15; ;mask *= 2, res += 1) {
+    if(a < mask) return res;
+  }
+}
+
+/****************************************************************************
 **
 *F  FuncLog2Int( <self>, <int> ) . . . . . . . . . nr of bits of integer - 1
 **
@@ -520,20 +540,13 @@ void            PrintInt (
 */
 Obj FuncLog2Int( Obj self, Obj integer)
 {
-  Int res, d;
+  Int d;
   Int a, len;
-  Int mask;
   TypDigit dmask;
 
   /* case of small ints */
   if (IS_INTOBJ(integer)) {
-    a = INT_INTOBJ(integer);
-    if (a < 0) a = -a;
-    res = NR_SMALL_INT_BITS;
-    for(res = NR_SMALL_INT_BITS, mask = (Int)1 << NR_SMALL_INT_BITS;
-        (mask & a) == 0 && mask != (Int)0;
-        mask = mask >> 1, res--);
-    return INTOBJ_INT(res);
+    return INTOBJ_INT(CLog2Int(INT_INTOBJ(integer)));
   }
 
   /* case of long ints */

--- a/src/integer.h
+++ b/src/integer.h
@@ -223,6 +223,7 @@ extern  Obj             GcdInt (
             Obj                 opR );
 
 
+extern Int CLog2Int(Int a);
 extern Obj FuncLog2Int( Obj self, Obj intnum);
 
 /****************************************************************************

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -221,7 +221,7 @@ Obj FuncRandomListMT(Obj self, Obj mtstr, Obj list)
   len = LEN_LIST(list);
   if (len == 0) return Fail;
   mt = (UInt4*) CHARS_STRING(mtstr);
-  lg = 31 - INT_INTOBJ(FuncLog2Int((Obj)0, INTOBJ_INT(len)));
+  lg = 31 - CLog2Int(len);
   for (a = nextrandMT_int32(mt) >> lg;
        a >= len;
        a = nextrandMT_int32(mt) >> lg

--- a/tst/testinstall/log2.tst
+++ b/tst/testinstall/log2.tst
@@ -1,0 +1,12 @@
+gap> START_TEST("log2.tst");
+gap> List([-5..5], Log2Int);
+[ 2, 2, 1, 1, 0, -1, 0, 1, 1, 2, 2 ]
+gap> ForAll([2..100], x -> Log2Int(2^x) = x and
+>                         Log2Int(2^x-1) = x-1 and
+>                         Log2Int(2^x+1) = x);
+true
+gap> ForAll([2..100], x -> Log2Int(-(2^x)) = x and
+>                         Log2Int(-(2^x)-1) = x and
+>                         Log2Int(-(2^x)+1) = x-1);
+true
+gap> STOP_TEST( "log2.tst", 100 );


### PR DESCRIPTION
This adds a faster log2int. This actually appear fairly high up in profiles of the test-suite.

There are hundreds of different ways of doing log2int, if anyone wants to investigate them all feel free! This one is twice as fast on the cases we run in the testsuite, and (in particular) is designed to be faster for logging smaller values (which we do much more than larger values).

Also, add a decent test (it was this test which originally uncovered the bug in log2int that @markuspf just submitted a fix for).