### PR TITLE
Replaced ReadTest by Test with comparison up to whitespaces.

### DIFF
--- a/doc/changes/changes44.xml
+++ b/doc/changes/changes44.xml
@@ -878,7 +878,7 @@ that reflects exactly the required filters.
 </Item>
 
 <Item>
-In test files that are read with <Ref BookName="ref" Func="ReadTest"/>,
+In test files that are read with <C>ReadTest</C>,
 the assertion level is set to 2 between <C>START_TEST</C>
 and <C>STOP_TEST</C>.
 This may result in runtimes for the tests that are substantially longer
@@ -980,7 +980,7 @@ New Conway polynomials provided by John Bray and Kate Minola have been added.
 </Item>
 
 <Item>
-The <Ref BookName="ref" Func="ReadTest"/>
+The <C>ReadTest</C>
  methods for strings (filenames) and streams now automatically set
 the screen width (see <Ref BookName="ref" Func="SizeScreen"/>) to 80 before the tests,
 and reset it afterwards.

--- a/doc/changes/changes45.xml
+++ b/doc/changes/changes45.xml
@@ -221,7 +221,7 @@ printed and to the output stream, see <Ref Sect="Info Functions" BookName="ref"/
 </Item>
 <Item>
 New function <Ref Func="Test" BookName="ref"/>  which is a more flexible and
-informative substitute of <Ref Func="ReadTest" BookName="ref"/> operation.
+informative substitute of <C>ReadTest</C> operation.
 </Item>
 <Item>
 <C>ConnectGroupAndCharacterTable</C> is replaced by more robust 

--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -692,7 +692,6 @@ Test files are used to check that &GAP; produces correct results in
 certain computations. A selection of test files for the library can be
 found in the <F>tst</F> directory of the &GAP; distribution.
 
-<#Include Label="ReadTest">
 <#Include Label="StartStopTest">
 
 <#Include Label="[1]{testinstall.g}">

--- a/doc/ref/streams.xml
+++ b/doc/ref/streams.xml
@@ -78,9 +78,8 @@ during compilation of &GAP;.
 <Section Label="Operations for Input Streams">
 <Heading>Operations for Input Streams</Heading>
 
-Three operations normally used to read files: <Ref Oper="Read"/>, 
-<Ref Oper="ReadAsFunction"/> and <Ref Oper="ReadTest"/>
-can also be used to read &GAP; input from a
+Two operations normally used to read files: <Ref Oper="Read"/> and
+<Ref Oper="ReadAsFunction"/> can also be used to read &GAP; input from a
 stream. The input is immediately parsed and executed. When reading
 from a stream <A>str</A>, the &GAP; kernel generates calls to
 <C>ReadLine(<A>str</A>)</C> to supply text to the parser. 
@@ -126,16 +125,6 @@ gap> Read(i);
 gap> a;
 10
 ]]></Example>
-</Description>
-</ManSection>
-
-
-<ManSection>
-<Oper Name="ReadTest" Arg='input-text-stream' Label="for streams"/>
-
-<Description>
-reads the input-text-stream as  test input until <C>end-of-stream</C> occurs.
-See <Ref Sect="File Operations"/> for details.
 </Description>
 </ManSection>
 

--- a/lib/files.gd
+++ b/lib/files.gd
@@ -246,39 +246,6 @@ DeclareOperation( "Read", [ IsString ] );
 
 #############################################################################
 ##
-#O  ReadTest( <string> )  . . . . . . . . . . . . . . . . .  read a test file
-##
-##  <#GAPDoc Label="ReadTest">
-##  <ManSection>
-##  <Oper Name="ReadTest" Arg='string'/>
-##  
-##  <Description>
-##  reads the test file with name <A>string</A>.
-##  The test file should contain lines of &GAP; input and corresponding output.
-##  The input lines start with the <C>gap> </C> prompt
-##  (or with the <C>> </C> prompt if commands exceed one line).
-##  The output is exactly as would result from typing
-##  in the input interactively to a &GAP; session
-##  (on a screen with 80 characters per line).
-##  <P/>
-##  Optionally, <Ref Func="START_TEST"/> and <Ref Func="STOP_TEST"/> 
-##  may be used in the beginning and end of test files 
-##  to reinitialize the caches and the global 
-##  random number generator in order to be independent of the reading order 
-##  of several test files. 
-##  Furthermore, <Ref Func="START_TEST"/> increases the assertion level 
-##  for the time of the test, and <Ref Func="STOP_TEST"/> sets the 
-##  proportionality factor that is used to output a <Q>&GAP;stone</Q> 
-##  speed ranking after the file has been completely processed.
-##  </Description>
-##  </ManSection>
-##  <#/GAPDoc>
-##
-DeclareOperation( "ReadTest", [ IsString ] );
-
-
-#############################################################################
-##
 #O  ReadAsFunction( <filename> ) . . . . . . . . . . read a file as function
 ##
 ##  <#GAPDoc Label="ReadAsFunction">

--- a/lib/files.gi
+++ b/lib/files.gi
@@ -217,26 +217,6 @@ end );
 
 #############################################################################
 ##
-#M  ReadTest( <filename> )  . . . . . . . . . . . . . . . .  read a test file
-##
-InstallMethod( ReadTest,
-    "string",
-    [ IsString ],
-    function( name )
-    local oldvalue, result, breakOnError;
-	breakOnError := BreakOnError;
-	BreakOnError := false;
-    oldvalue:= SizeScreen();
-    SizeScreen( [ 80 ] );
-    result:= READ_TEST( USER_HOME_EXPAND( name ) );  
-    SizeScreen( oldvalue );
-    BreakOnError := breakOnError;
-    return result;
-    end );
-
-
-#############################################################################
-##
 #M  ReadAsFunction( <filename> )  . . . . . . . . . . read a file as function
 ##
 InstallMethod( ReadAsFunction,

--- a/lib/helpdef.gi
+++ b/lib/helpdef.gi
@@ -18,66 +18,6 @@
   
 ################ ???????????????????????????? ###############################
 
-# this doesn't seem to do something sensible, outdated? (FL)
-#############################################################################
-##
-#F  HELP_TEST_EXAMPLES( <book>, <chapter> ) . . . . . . . . test the examples
-##
-HELP_TEST_EXAMPLES\?\?\? := function( book, chapter )
-    local   info,  chap,  filename,  stream,  examples,  test,  line,
-            size;
-
-    # get the chapter info
-    info := HELP_BOOK_INFO(book);
-    chap := HELP_CHAPTER_INFO( book, chapter );
-    if chap = fail  then
-        return;
-    fi;
-
-    # open the stream and read in the help
-    filename := Filename( info.directories, info.filenames[chapter] );
-    stream := InputTextFile(filename);
-
-    # search for examples
-    examples := false;
-    test := "";
-    repeat
-        line := ReadLine(stream);
-        if line <> fail  then
-
-            # example environment
-            if MATCH_BEGIN(line,"\\beginexample")  then
-                examples := true;
-            elif MATCH_BEGIN(line,"\\endexample")  then
-                examples := false;
-            fi;
-
-            # store the lines
-            if examples and not MATCH_BEGIN(line,"\\beginexample")  then
-                if Length(line) < 5  then
-                    Print( "* ", line );
-                elif line[5] <> '#'  then
-                    line := line{[5..Length(line)]};
-                    Append( test, line );
-                fi;
-            fi;
-        fi;
-    until IsEndOfStream(stream);
-    CloseStream(stream);
-
-    # now do the test
-    stream := InputTextString( test );
-
-    size := SizeScreen();
-    SizeScreen( [ 72, ] );
-    RANDOM_SEED(1);
-
-    ReadTest(stream);
-
-    SizeScreen(size);
-
-end;
-################ ?????????????end???????????? ###############################
 
 #############################################################################
 ##  

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -502,6 +502,20 @@ end);
 ##
 DeclareOperation("PositionFirstComponent",[IsList,IsObject]);
 
+#############################################################################
+##
+#O  ReadTest 
+##
+##  `ReadTest' is superseded by more robust and flexible `Test'. Since the
+##  former is still used in some packages, for backwards compatibility we
+##  replace it by the call of `Test' with comparison up to whitespaces.
+##
+BindGlobal( "ReadTest", function( fn )
+  Print("#I  ReadTest is no longer supported. Please use more robust and flexible\n",
+        "#I  Test. For backwards compatibility, ReadTest(<filename>) is replaced\n",
+        "#I  by Test( <filename>, rec( compareFunction := \"uptowhitespace\" ))\n");
+  Test( fn, rec( compareFunction := "uptowhitespace" ));
+end);
 
 #############################################################################
 ##

--- a/lib/profile.g
+++ b/lib/profile.g
@@ -1033,7 +1033,7 @@ end);
 ##
 ##  <Description>
 ##  <Ref Func="START_TEST"/> and <Ref Func="STOP_TEST"/> may be optionally
-##  used in files that are read via <Ref Func="ReadTest"/>. If used,
+##  used in files that are read via <Ref Func="Test"/>. If used,
 ##  <Ref Func="START_TEST"/> reinitialize the caches and the global
 ##  random number generator, in order to be independent of the reading
 ##  order of several test files. Furthermore, the assertion level
@@ -1064,7 +1064,7 @@ end);
 ##  <F>tst/combinat.tst</F>.
 ##  <P/>
 ##  Note that the functions in <F>tst/testutil.g</F> temporarily replace
-##  <Ref Func="STOP_TEST"/> before they call <Ref Func="ReadTest"/>.
+##  <Ref Func="STOP_TEST"/> before they call <Ref Func="Test"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -237,26 +237,6 @@ end );
 
 #############################################################################
 ##
-#M  ReadTest( <input-stream> ) . . . . . . . . read stream as TEST input
-##
-InstallOtherMethod( ReadTest,
-    "input stream",
-    [ IsInputStream ],
-    function( stream )
-    local oldvalue, result, breakOnError;
-	breakOnError := BreakOnError;
-	BreakOnError := false;
-    oldvalue:= SizeScreen();
-    SizeScreen( [ 80 ] );
-    result:= READ_TEST_STREAM( stream );
-    SizeScreen( oldvalue );
- 	BreakOnError := breakOnError;
-    return result;
-    end );
-
-
-#############################################################################
-##
 #M  ReadAsFunction( <input-stream> ) . . . . . . read stream as function
 ##
 InstallOtherMethod( ReadAsFunction,

--- a/lib/system.g
+++ b/lib/system.g
@@ -445,7 +445,7 @@ end );
 ##  <Var Name="GAPInfo.TestData"/>
 ##
 ##  <Description>
-##  This is a mutable record used in files that are read via <C>ReadTest</C>.
+##  This is a mutable record used in files that are read via <C>Test</C>.
 ##  These files contain the commands <C>START_TEST</C> and <C>STOP_TEST</C>,
 ##  which set, read, and unbind the components <C>START_TIME</C> and <C>START_NAME</C>.
 ##  The function <C>RunStandardTests</C> also uses a component <C>results</C>.

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -5,7 +5,6 @@
 #Y  Copyright (C) 2011 The GAP Group
 ##
 ##  This file contains functions for test files.
-##  These can substitute the READ_TEST functionality in the GAP kernel.
 ##
 
 ##  FirstDiff := function(a, b)

--- a/src/streams.c
+++ b/src/streams.c
@@ -304,24 +304,6 @@ static void READ_TEST_OR_LOOP(void)
     }
 }
 
-/****************************************************************************
-**
-*F  READ_TEST() . . . . . . . . . . . . . . . . .  read current input as test
-**
-**  Read the current input as test and close the input stream.
-*/
-static void READ_TEST ( void )
-{
-    READ_TEST_OR_LOOP();
-
-    /* close the input file again, and return 'true'                       */
-    if ( ! CloseTest() ) {
-        ErrorQuit(
-            "Panic: ReadTest cannot close input, this should not happen",
-            0L, 0L );
-    }
-    ClearError();
-}
 
 /****************************************************************************
 **
@@ -1049,52 +1031,6 @@ Obj FuncREAD_STREAM_LOOP (
     /* read the test file                                                  */
     READ_LOOP();
     TLS(IgnoreStdoutErrout) = NULL;
-    return True;
-}
-
-
-/****************************************************************************
-**
-*F  FuncREAD_TEST( <self>, <filename> ) . . . . . . . . . .  read a test file
-*/
-Obj FuncREAD_TEST (
-    Obj                 self,
-    Obj                 filename )
-{
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "ReadTest: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
-
-    /* try to open the file                                                */
-    if ( ! OpenTest( CSTR_STRING(filename) ) ) {
-        return False;
-    }
-
-    /* read the test file                                                  */
-    READ_TEST();
-    return True;
-}
-
-
-/****************************************************************************
-**
-*F  FuncREAD_TEST_STREAM( <self>, <stream> )  . . . . . .  read a test stream
-*/
-Obj FuncREAD_TEST_STREAM (
-    Obj                 self,
-    Obj                 stream )
-{
-    /* try to open the file                                                */
-    if ( ! OpenTestStream(stream) ) {
-        return False;
-    }
-
-    /* read the test file                                                  */
-    READ_TEST();
     return True;
 }
 
@@ -2306,12 +2242,6 @@ static StructGVarFunc GVarFuncs [] = {
 
     { "READ_STREAM_LOOP", 2L, "stream, catchstderrout",
       FuncREAD_STREAM_LOOP, "src/streams.c:READ_STREAM_LOOP" },
-
-    { "READ_TEST", 1L, "filename", 
-      FuncREAD_TEST, "src/streams.c:READ_TEST" },
-
-    { "READ_TEST_STREAM", 1L, "stream",
-      FuncREAD_TEST_STREAM, "src/streams.c:READ_TEST_STREAM" },
 
     { "READ_AS_FUNC", 1L, "filename",
       FuncREAD_AS_FUNC, "src/streams.c:READ_AS_FUNC" },

--- a/tst/teststandard/arithlst.tst
+++ b/tst/teststandard/arithlst.tst
@@ -12,7 +12,7 @@ gap> START_TEST("arithlst.tst");
 #############################################################################
 ##
 ##  Parametrize the output; if `error' has the value `Error' then only the
-##  first error in each call is printed in the `ReadTest' run,
+##  first error in each call is printed in the `Test' run,
 ##  if the value is `Print' then all errors are printed.
 ##
 gap> error:= Print;;

--- a/tst/testutil.g
+++ b/tst/testutil.g
@@ -356,8 +356,8 @@ BindGlobal( "CreatePackageTestsInput", function( scriptfile, outfile, gap, other
 ##  and reads the file <testfile> (a path relative to the package directory).
 ##  If <other> is `true' then all other available packages are also loaded.
 ##
-##  The file <testfile> can either be a file that contains `ReadTest'
-##  or `Test' statements and therefore must be read with `Read',
+##  The file <testfile> can either be a file that contains 
+##  `Test' statements and therefore must be read with `Read',
 ##  or it can be a file that itself must be read with `Test';
 ##  the latter is detected from the occurrence of a substring
 ##  `"START_TEST"' in the file.


### PR DESCRIPTION
This implements the idea from issue #172 to make `ReadTest` obsolete and replace it by a call to `test` with comparison up to whitespaces. I've tested it on those packages which are still using `ReadTests` and it works fine - the tests now produce the new output, and nothing is broken. 

Probably the kernel function `READ_TEST_OR_LOOP` could be also renamed to `READ_LOOP`. 