### PR TITLE
Speeding up loops over iterators

### DIFF
--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -1031,6 +1031,7 @@ end );
 ##  <#GAPDoc Label="Iterator">
 ##  <ManSection>
 ##  <Oper Name="Iterator" Arg='listorcoll'/>
+##  <Filt Name="IsStandardIterator" Arg='listorcoll'/>
 ##
 ##  <Description>
 ##  Iterators provide a possibility to loop over the elements of a
@@ -1098,6 +1099,11 @@ end );
 ##  from <M>C</M>, which provides a (partial) mapping from <M>C</M> to the
 ##  positive integers.
 ##  <P/>
+##  The filter <Ref Filt="IsStandardIterator"/> means that the iterator is
+##  implemented as a component object and has components <C>IsDoneIterator</C>
+##  and <C>NextIterator</C> which are bound to the methods of the operations of
+##  the same name for this iterator. 
+##  <!-- (This is used to avoid overhead when looping over such iterators.) -->
 ##  <!--  We wanted to admit an iterator as first argument of <C>Filtered</C>,-->
 ##  <!--  <C>First</C>, <C>ForAll</C>, <C>ForAny</C>, <C>Number</C>.-->
 ##  <!--  This is not yet implemented.-->
@@ -1123,6 +1129,7 @@ end );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+DeclareFilter("IsStandardIterator");
 DeclareOperation( "Iterator", [ IsListOrCollection ] );
 
 
@@ -1307,6 +1314,9 @@ DeclareGlobalFunction( "TrivialIterator" );
 ##  <Ref Func="IteratorByFunctions"/> does <E>not</E> make a shallow copy of
 ##  <A>record</A>, this record is changed in place
 ##  (see Section &nbsp;<Ref Sect="Creating Objects"/>).
+##  <P/>
+##  Iterators constructed with <Ref Func="IteratorByFunctions"/> are in the
+##  filter <Ref Filt="IsStandardIterator"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -976,7 +976,7 @@ InstallGlobalFunction( IteratorByFunctions, function( record )
       Error( "<record> must be a record with components `NextIterator',\n",
              "`IsDoneIterator', and `ShallowCopy'" );
     fi;
-    filter:= IsIteratorByFunctions and IsMutable;
+    filter:= IsIteratorByFunctions and IsStandardIterator and IsMutable;
 
     return Objectify( NewType( IteratorsFamily, filter ), record );
 end );

--- a/src/stats.c
+++ b/src/stats.c
@@ -423,6 +423,8 @@ Obj             IS_DONE_ITER;
 
 Obj             NEXT_ITER;
 
+Obj             STD_ITER;
+
 UInt            ExecFor (
     Stat                stat )
 {
@@ -433,6 +435,8 @@ UInt            ExecFor (
     Obj                 elm;            /* one element of the list         */
     Stat                body;           /* body of loop                    */
     UInt                i;              /* loop variable                   */
+    Obj                 nfun, dfun;     /* functions for NextIterator and
+                                           IsDoneIterator                  */  
 
     /* get the variable (initialize them first to please 'lint')           */
     if ( IS_REFLVAR( ADDR_STAT(stat)[0] ) ) {
@@ -499,11 +503,20 @@ UInt            ExecFor (
         /* get the iterator                                                */
         list = CALL_1ARGS( ITERATOR, list );
 
+        if ( CALL_1ARGS( STD_ITER, list ) == True ) {
+            /* this can avoid method selection overhead on iterator        */
+            dfun = ElmPRec( list, RNamName("IsDoneIterator") );
+            nfun = ElmPRec( list, RNamName("NextIterator") );
+        } else {
+            dfun = IS_DONE_ITER;
+            nfun = NEXT_ITER;
+        }
+
         /* loop over the iterator                                          */
-        while ( CALL_1ARGS( IS_DONE_ITER, list ) == False ) {
+        while ( CALL_1ARGS( dfun, list ) == False ) {
 
             /* get the element and assign it to the variable               */
-            elm = CALL_1ARGS( NEXT_ITER, list );
+            elm = CALL_1ARGS( nfun, list );
             if      ( vart == 'l' )  ASS_LVAR( var, elm );
             else if ( vart == 'h' )  ASS_HVAR( var, elm );
             else if ( vart == 'g' )  AssGVar(  var, elm );
@@ -541,6 +554,8 @@ UInt            ExecFor2 (
     Stat                body1;          /* first  stat. of body of loop    */
     Stat                body2;          /* second stat. of body of loop    */
     UInt                i;              /* loop variable                   */
+    Obj                 nfun, dfun;     /* functions for NextIterator and
+                                           IsDoneIterator                  */  
 
     /* get the variable (initialize them first to please 'lint')           */
     if ( IS_REFLVAR( ADDR_STAT(stat)[0] ) ) {
@@ -613,11 +628,20 @@ UInt            ExecFor2 (
         /* get the iterator                                                */
         list = CALL_1ARGS( ITERATOR, list );
 
+        if ( CALL_1ARGS( STD_ITER, list ) == True ) {
+            /* this can avoid method selection overhead on iterator        */
+            dfun = ElmPRec( list, RNamName("IsDoneIterator") );
+            nfun = ElmPRec( list, RNamName("NextIterator") );
+        } else {
+            dfun = IS_DONE_ITER;
+            nfun = NEXT_ITER;
+        }
+
         /* loop over the iterator                                          */
-        while ( CALL_1ARGS( IS_DONE_ITER, list ) == False ) {
+        while ( CALL_1ARGS( dfun, list ) == False ) {
 
             /* get the element and assign it to the variable               */
-            elm = CALL_1ARGS( NEXT_ITER, list );
+            elm = CALL_1ARGS( nfun, list );
             if      ( vart == 'l' )  ASS_LVAR( var, elm );
             else if ( vart == 'h' )  ASS_HVAR( var, elm );
             else if ( vart == 'g' )  AssGVar(  var, elm );
@@ -661,6 +685,8 @@ UInt            ExecFor3 (
     Stat                body2;          /* second stat. of body of loop    */
     Stat                body3;          /* third  stat. of body of loop    */
     UInt                i;              /* loop variable                   */
+    Obj                 nfun, dfun;     /* functions for NextIterator and
+                                           IsDoneIterator                  */  
 
     /* get the variable (initialize them first to please 'lint')           */
     if ( IS_REFLVAR( ADDR_STAT(stat)[0] ) ) {
@@ -740,11 +766,20 @@ UInt            ExecFor3 (
         /* get the iterator                                                */
         list = CALL_1ARGS( ITERATOR, list );
 
+        if ( CALL_1ARGS( STD_ITER, list ) == True ) {
+            /* this can avoid method selection overhead on iterator        */
+            dfun = ElmPRec( list, RNamName("IsDoneIterator") );
+            nfun = ElmPRec( list, RNamName("NextIterator") );
+        } else {
+            dfun = IS_DONE_ITER;
+            nfun = NEXT_ITER;
+        }
+
         /* loop over the iterator                                          */
-        while ( CALL_1ARGS( IS_DONE_ITER, list ) == False ) {
+        while ( CALL_1ARGS( dfun, list ) == False ) {
 
             /* get the element and assign it to the variable               */
-            elm = CALL_1ARGS( NEXT_ITER, list );
+            elm = CALL_1ARGS( nfun, list );
             if      ( vart == 'l' )  ASS_LVAR( var, elm );
             else if ( vart == 'h' )  ASS_HVAR( var, elm );
             else if ( vart == 'g' )  AssGVar(  var, elm );
@@ -2149,6 +2184,7 @@ static Int InitKernel (
     ImportFuncFromLibrary( "Iterator",       &ITERATOR );
     ImportFuncFromLibrary( "IsDoneIterator", &IS_DONE_ITER );
     ImportFuncFromLibrary( "NextIterator",   &NEXT_ITER );
+    ImportFuncFromLibrary( "IsStandardIterator",   &STD_ITER );
 
     /* install executors for non-statements                                */
     for ( i = 0; i < sizeof(ExecStatFuncs)/sizeof(ExecStatFuncs[0]); i++ ) {


### PR DESCRIPTION
In loops over iterators which are not lists the method selection for
IsDoneIterator and NextIterator can lead to considerable overhead.

This patch introduces a filter `IsStandardIterator` which means that
the iterator is a component object with components .IsDoneIterator
and .NextIterator which provide the methods with the same name.

In the kernel we use these functions directly instead of the generic
operations for iterators in `IsStandardIterator`.

Documentation for `IsStandardIterator` is included. All iterators
constructed by `IteratorByFunctions` are in `IsStandardIterator`.

Examples: Looping over GF(1000003) becomes 25% faster, looping over
SymmetricGroup(11) about 15% faster on my system. Of course, the
advantage is bigger if NextIterator is cheaper.