### PR TITLE
Add version and type information to line-by-line profile output

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -475,10 +475,22 @@ Obj ProfileEvalBoolPassthrough(Expr stat)
   return RealEvalBoolFuncs[TNUM_STAT(stat)](stat);
 }
 
+
+
 /****************************************************************************
 **
 ** Activating and deacivating profiling, either at startup or by user request
 */
+
+void outputVersionInfo()
+{
+    fprintf(profileState.Stream, 
+            "{ \"Type\": \"_\", \"Version\":1, \"IsCover\": %s, "
+            "  \"TimeType\": \"%s\"}\n", 
+            profileState.OutputRepeats?"false":"true",
+            profileState.useGetTimeOfDay?"Wall":"CPU");
+  
+}
 
 void enableAtStartup(char* filename, Int repeats)
 {
@@ -521,7 +533,7 @@ void enableAtStartup(char* filename, Int repeats)
 #endif
 #endif
 
-
+    outputVersionInfo();
 }
 
 // This function is for when GAP is started with -c, and
@@ -650,6 +662,7 @@ Obj FuncACTIVATE_PROFILING (
 #endif
     }
 
+    outputVersionInfo();
     HashUnlock(&profileState);
 
     return True;

--- a/src/profile.c
+++ b/src/profile.c
@@ -323,11 +323,14 @@ void InstallPrintExprFunc(Int pos, void(*expr)(Expr)) {
 static inline UInt getFilenameId(Stat stat)
 {
   UInt id = FILENAMEID_STAT(stat);
-  if(LEN_PLIST(OutputtedFilenameList) < id || !ELM_PLIST(OutputtedFilenameList,id))
+  if(LEN_PLIST(OutputtedFilenameList) < id || ELM_PLIST(OutputtedFilenameList,id) != True)
   {
-    GROW_PLIST(OutputtedFilenameList, id);
-    SET_LEN_PLIST(OutputtedFilenameList, id);
+    if(LEN_PLIST(OutputtedFilenameList) < id) {
+      GROW_PLIST(OutputtedFilenameList, id);
+      SET_LEN_PLIST(OutputtedFilenameList, id);
+    }
     SET_ELM_PLIST(OutputtedFilenameList, id, True);
+    CHANGED_BAG(OutputtedFilenameList);
     fprintf(profileState.Stream, "{\"Type\":\"S\",\"File\":\"%s\",\"FileId\":%d}\n",
                                   CSTR_STRING(FILENAME_STAT(stat)), (int)id);
   }


### PR DESCRIPTION
This is just a minor profiling tweak, which adds some information about how the profile was generated, mainly so the 'profiling' package can then produce more useful feedback and errors.