### PR TITLE
Remove XSET_ type-caching optimisations

### DIFF
--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -89,11 +89,6 @@ DeclareRepresentation( "IsExternalOrbit",
     IsExternalSubset, [ "start" ] );
 DeclareCategory( "IsExternalSetByPcgs", IsExternalSet );
 
-# The following two integer variables give position in which the `Type' of an
-# external set can  store the `Type' of its  external subsets resp.  external
-# orbits (to avoid repeated calls of `NewType').
-BindGlobal( "XSET_XSSETTYPE", 4 );
-BindGlobal( "XSET_XORBTYPE", 5 );
 
 
 #############################################################################
@@ -2623,4 +2618,3 @@ DeclareOperation("DomainForAction",[IsObject,IsListOrCollection,IsFunction]);
 #############################################################################
 ##
 #E
-

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -205,17 +205,9 @@ InstallOtherMethod( ExternalSubsetOp,
 
     type := TypeObj( xset );
 
-    # The type of an external set can store the type of its external subsets,
-    # to avoid repeated calls of `NewType'.
-    if not IsBound( type![XSET_XSSETTYPE] )  then
-        xsset := ExternalSetByFilterConstructor( IsExternalSubset,
-                         G, HomeEnumerator( xset ), gens, acts, act );
-        type![XSET_XSSETTYPE] := TypeObj( xsset );
-    else
-        xsset := ExternalSetByTypeConstructor( type![XSET_XSSETTYPE],
-                         G, HomeEnumerator( xset ), gens, acts, act );
-    fi;
-    
+    xsset := ExternalSetByFilterConstructor( IsExternalSubset,
+                     G, HomeEnumerator( xset ), gens, acts, act );
+
     xsset!.start := Immutable( start );
     return xsset;
 end );
@@ -339,18 +331,10 @@ InstallOtherMethod( ExternalOrbitOp,
     local   type,  xorb;
 
     type := TypeObj( xset );
-    
-    # The type of  an external set  can store the type  of external orbits of
-    # its points, to avoid repeated calls of `NewType'.
-    if not IsBound( type![XSET_XORBTYPE] )  then
-        xorb := ExternalSetByFilterConstructor( IsExternalOrbit,
-                        G, HomeEnumerator( xset ), gens, acts, act );
-        type![XSET_XORBTYPE] := TypeObj( xorb );
-    else
-        xorb := ExternalSetByTypeConstructor( type![XSET_XORBTYPE],
-                        G, HomeEnumerator( xset ), gens, acts, act );
-    fi;
-    
+
+    xorb := ExternalSetByFilterConstructor( IsExternalOrbit,
+                    G, HomeEnumerator( xset ), gens, acts, act );
+
     SetRepresentative( xorb, pnt );
     xorb!.start := Immutable( [ pnt ] );
     return xorb;
@@ -3413,4 +3397,3 @@ InstallMethod( IsInjective, "for a linear action homomorphism",
 #############################################################################
 ##
 #E
-

--- a/tst/teststandard/bugfix.tst
+++ b/tst/teststandard/bugfix.tst
@@ -2825,6 +2825,19 @@ gap> -w+w;
 
 #############################################################################
 #
+#  Changes 4.7.8 -> 4.7.9
+
+#2015/10/20 (Chris Jefferson)
+gap> extS := ExternalSet(SymmetricGroup(4), [1..4],
+>                   GeneratorsOfGroup(SymmetricGroup(4)),
+>                   GeneratorsOfGroup(SymmetricGroup(4)),
+>                   OnRight);
+<xset:[ 1 .. 4 ]>
+gap> ExternalSubset(extS);
+[  ]^G
+
+#############################################################################
+#
 # Tests requiring loading some packages must be performed at the end.
 # Do not put tests that do not need any packages below this line.
 #


### PR DESCRIPTION
This removes XSET_XSETTYPE and XSET_XORBTYPE, which are used to cache things in types in oprt.gd. One is broken and the other might break in some cases, and NewType has got faster in recent years.