### PR TITLE
Improve profile coverage of else and for-range statements

### DIFF
--- a/src/profile.h
+++ b/src/profile.h
@@ -23,12 +23,14 @@
 
 /****************************************************************************
 **
-
 *F  InitInfoStats() . . . . . . . . . . . . . . . . . table of init functions
 */
 StructInitInfo * InitInfoProfile ( void );
 
 void RegisterStatWithProfiling(Stat);
+
+
+
 
 void InstallEvalBoolFunc( Int, Obj(*)(Expr));
 void InstallEvalExprFunc( Int, Obj(*)(Expr));
@@ -46,6 +48,23 @@ void ProfileLineByLineOutFunction(Obj o);
 #define PROF_IN_FUNCTION(x)
 #define PROF_OUT_FUNCTION(x)
 #endif
+
+/****************************************************************************
+**
+** We need this to be in the header, so it can be inlined away. The only
+** functionality here which should be publicly used is 'VisitStatIfProfiling'
+*/
+
+extern UInt profileState_Active;
+
+void visitStat(Stat stat);
+
+static inline void VisitStatIfProfiling(Stat stat)
+{
+  if(profileState_Active)
+    visitStat(stat);
+}
+
 
 #endif // GAP_STATS_H
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -54,6 +54,8 @@
 
 #include        "vars.h"                /* variables                       */
 
+#include        "profile.h"             /* visit statements for profiling  */
+
 /****************************************************************************
 **
 
@@ -857,6 +859,7 @@ UInt            ExecForRange (
 
     /* evaluate the range                                                  */
     SET_BRK_CURR_STAT( stat );
+    VisitStatIfProfiling(ADDR_STAT(stat)[1]);
     elm = EVAL_EXPR( ADDR_EXPR( ADDR_STAT(stat)[1] )[0] );
     while ( ! IS_INTOBJ(elm) ) {
         elm = ErrorReturnObj(
@@ -921,6 +924,7 @@ UInt            ExecForRange2 (
 
     /* evaluate the range                                                  */
     SET_BRK_CURR_STAT( stat );
+    VisitStatIfProfiling(ADDR_STAT(stat)[1]);
     elm = EVAL_EXPR( ADDR_EXPR( ADDR_STAT(stat)[1] )[0] );
     while ( ! IS_INTOBJ(elm) ) {
         elm = ErrorReturnObj(
@@ -992,6 +996,7 @@ UInt            ExecForRange3 (
 
     /* evaluate the range                                                  */
     SET_BRK_CURR_STAT( stat );
+    VisitStatIfProfiling(ADDR_STAT(stat)[1]);
     elm = EVAL_EXPR( ADDR_EXPR( ADDR_STAT(stat)[1] )[0] );
     while ( ! IS_INTOBJ(elm) ) {
         elm = ErrorReturnObj(


### PR DESCRIPTION
This improves the line-by-line profiling so it correctly handles else statements, and for loops with ranges (e.g. `for i in [1..n]`). Previously such code would be (incorrectly) marked as not executed.

This does cause an extra (very small) function to be invoked whenever we consider a for-range statement, checking if we are currently profiling, but the cost is very small, and this is the only place where profiling has any cost when not being used.