### PR TITLE
Syntax error on a break outside any loop

### DIFF
--- a/dev/Updates/break-outside-loop
+++ b/dev/Updates/break-outside-loop
@@ -1,0 +1,27 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Format 'yyyy/mm/dd'
+!! 2015/10/27
+
+!! Changed by SL
+
+! Reported by James Mitchell
+
+!! Type of Change
+Fix: inappropriate error message
+
+!! Description
+
+Including a break or continue statement in a function body
+but not in a loop now gives a syntax error. Previously it failed
+untidily at run time.
+
+! Test Code
+gap> function() break; end;
+Syntax error: break statement not enclosed in a loop
+function() break; end;
+                ^
+! Prefetch
+
+!! Changeset
+
+!! End

--- a/src/read.c
+++ b/src/read.c
@@ -1251,6 +1251,7 @@ void ReadFuncExpr (
     /* 'function( ... arg )' takes a variable number of arguments              */
     if (narg >= 1 && ! strcmp( "arg", CSTR_STRING( ELM_LIST(nams, narg) ) ) )
       {
+	/* TODO: remove this before the next non-beta release */
 	if (narg > 1)
 	  SyntaxWarning("New syntax used -- intentional?");
 	narg = -narg;

--- a/tst/testinstall/break.tst
+++ b/tst/testinstall/break.tst
@@ -1,0 +1,38 @@
+gap> START_TEST("break.tst");
+gap> break;
+Error, A break statement can only appear inside a loop
+gap> continue;
+Error, A continue statement can only appear inside a loop
+gap> f := function() break; end;
+Syntax error: break statement not enclosed in a loop in stream line 1
+f := function() break; end;
+                     ^
+gap> f := function() continue; end;
+Syntax error: continue statement not enclosed in a loop in stream line 1
+f := function() continue; end;
+                        ^
+gap> f := function() local i; for i in [1..5] do continue; od; end;;
+gap> f();
+gap> f := function() local i; for i in [1..5] do break; od; end;;
+gap> f();
+gap> f := function() local i; i := 1; while i in [1..5] do i := i + 1; continue; od; end;;
+gap> f();
+gap> f := function() local i; i := 1; while i in [1..5] do break; od; end;;
+gap> f();
+gap> f := function() local i; i := 1; repeat i := i + 1; continue; until i in [1..5]; end;;
+gap> f();
+gap> f := function() local i; i := 1; repeat i := i + 1; break; until i in [1..5]; end;;
+gap> f();
+gap> for i in [1..5] do List([1..5], function(x) continue; return 1; end); od;
+Syntax error: continue statement not enclosed in a loop in stream line 1
+for i in [1..5] do List([1..5], function(x) continue; return 1; end); od;
+                                                    ^
+gap> for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
+Syntax error: break statement not enclosed in a loop in stream line 1
+for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
+                                                 ^
+gap> for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
+Syntax error: break statement not enclosed in a loop in stream line 1
+for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
+                                                 ^
+gap> STOP_TEST("break.tst", 1);


### PR DESCRIPTION
This PR adds code to detect when a break or continue statement is being parsed (technically coded) and is not contained in a loop within the current function body. 