### PR TITLE
Initialise GAPInfo.LoadPackageLevel

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -172,6 +172,7 @@ InstallGlobalFunction( InitializePackagesInfoRecords, function( arg )
       return;
     fi;
 
+    GAPInfo.LoadPackageLevel:= 0;
     GAPInfo.PackagesInfo:= [];
     GAPInfo.PackagesInfoRefuseLoad:= [];
 


### PR DESCRIPTION
This is not properly initialised if one does not have any needed packages