### PR TITLE
Increased -o option value for tests from 750m to 1g.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -70,8 +70,8 @@ endif
 GAPARCH=@GAPARCH@
 GAPARGS=
 
-TESTGAP = ./bin/gap-$(CONFIGNAME).sh -b -m 100m -o 750m -A -q -x 80 -r $(GAPARGS)
-TESTGAPauto = ./bin/gap-$(CONFIGNAME).sh -b -m 100m -o 750m -q -x 80 -r $(GAPARGS)
+TESTGAP = ./bin/gap-$(CONFIGNAME).sh -b -m 100m -o 1g -A -q -x 80 -r $(GAPARGS)
+TESTGAPauto = ./bin/gap-$(CONFIGNAME).sh -b -m 100m -o 1g -q -x 80 -r $(GAPARGS)
 
 PKG_BOOTSTRAP_URL="http://www.gap-system.org/pub/gap/gap4pkgs/"
 PKG_MINIMAL="bootstrap-pkg-minimal.tar.gz"

--- a/tst/testbugfix.g
+++ b/tst/testbugfix.g
@@ -28,7 +28,7 @@
 ##  <#/GAPDoc>
 ##
 
-Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 750m'.\n",
+Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g'.\n",
        "The more GAP4stones you get, the faster your system is.\n",
        "The runtime of the following tests (in general) increases.\n",
        "******************************************************************\n",

--- a/tst/testinstall.g
+++ b/tst/testinstall.g
@@ -21,14 +21,14 @@
 ##  gap> Read( Filename( DirectoriesLibrary( "tst" ), "testinstall.g" ) );
 ##  ]]></Log>
 ##  <P/>
-##  The test requires about 750MB of memory and runs about one 
+##  The test requires up to 1 GB of memory and runs about one
 ##  minute on an Intel Core 2 Duo / 2.53 GHz machine.
 ##  You will get a large number of lines with output about the progress
 ##  of the tests.
 ##  <#/GAPDoc>
 ##
 
-Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 750m'.\n",
+Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g'.\n",
        "The more GAP4stones you get, the faster your system is.\n",
        "The runtime of the following tests (in general) increases.\n",
        "You should expect the test to take about one minute and show about\n",

--- a/tst/teststandard.g
+++ b/tst/teststandard.g
@@ -19,13 +19,13 @@
 ##  gap> Read( Filename( DirectoriesLibrary( "tst" ), "teststandard.g" ) );
 ##  ]]></Log>
 ##  <P/>
-##  The test requires about 750MB of memory and runs about one hour on an 
+##  The test requires up to 1 GB of memory and runs about one hour on an
 ##  Intel Core 2 Duo / 2.53 GHz machine, and produces an output similar 
 ##  to the <File>testinstall.g</File> test.
 ##  <#/GAPDoc>
 ##
 
-Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 750m'.\n",
+Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g'.\n",
        "The more GAP4stones you get, the faster your system is.\n",
        "The runtime of the following tests (in general) increases.\n",
        "******************************************************************\n",

--- a/tst/testtravis.g
+++ b/tst/testtravis.g
@@ -28,7 +28,7 @@
 ##  <#/GAPDoc>
 ##
 
-Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 750m'.\n",
+Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g'.\n",
        "The more GAP4stones you get, the faster your system is.\n",
        "The runtime of the following tests (in general) increases.\n",
        "******************************************************************\n",


### PR DESCRIPTION
This is a follow-up of #256. It increases the value used for `-o` command line option in GAP test suite (`make testinstall/teststandard/etc`) from 750m to 1g. This fixes a problem mentioned in #256 when `hash2.tst` runs out of memory just because the order in which tests are performed had been changed. We would like to run renormalisation more often and perform tests in the order of increased duration, not relying on the particular order of the tests.

1g is still more conservative then the default `-o` value which is 2g. This hopefully may help to catch some inefficiency problems which may be not noticed otherwise.