### PR TITLE
Improve HPC-GAP's NEW_TYPE

### DIFF
--- a/lib/type.g
+++ b/lib/type.g
@@ -398,11 +398,11 @@ DeclareRepresentation( "IsTypeDefaultRep",
 BIND_GLOBAL( "FamilyOfFamilies", AtomicRecord( rec() ) );
 
 NEW_TYPE_NEXT_ID := NEW_TYPE_NEXT_ID+1;
-BIND_GLOBAL( "TypeOfFamilies", AtomicList( [
+BIND_GLOBAL( "TypeOfFamilies", [
     FamilyOfFamilies,
     WITH_IMPS_FLAGS( FLAGS_FILTER( IsFamily and IsFamilyDefaultRep ) ),
     false,
-    NEW_TYPE_NEXT_ID ] ) );
+    NEW_TYPE_NEXT_ID ] );
 
 FamilyOfFamilies!.NAME          := "FamilyOfFamilies";
 FamilyOfFamilies!.REQ_FLAGS     := FLAGS_FILTER( IsFamily );
@@ -434,6 +434,7 @@ BIND_GLOBAL( "TypeOfTypes", [
     WITH_IMPS_FLAGS( FLAGS_FILTER( IsType and IsTypeDefaultRep ) ),
     false,
     NEW_TYPE_NEXT_ID ] );
+MakeReadOnly(TypeOfTypes);
 
 
 FamilyOfTypes!.NAME             := "FamilyOfTypes";
@@ -458,6 +459,7 @@ MakeReadOnly(TypeOfFamilyOfTypes);
 
 SET_TYPE_COMOBJ( FamilyOfFamilies, TypeOfFamilyOfFamilies );
 SET_TYPE_POSOBJ( TypeOfFamilies,   TypeOfTypes            );
+MakeReadOnly(TypeOfFamilies);
 
 SET_TYPE_COMOBJ( FamilyOfTypes,    TypeOfFamilyOfTypes    );
 SET_TYPE_POSOBJ( TypeOfTypes,      TypeOfTypes            );

--- a/lib/type1.g
+++ b/lib/type1.g
@@ -204,12 +204,6 @@ end );
 NEW_TYPE_CACHE_MISS  := 0;
 NEW_TYPE_CACHE_HIT   := 0;
 
-# We must access this through ASS_GVAR / VAL_GVAR as the compiler does not understand
-# thread local variables
-BIND_GLOBAL("_NEW_TYPE_READONLY", `"NEW_TYPE_READONLY");
-ASS_GVAR(_NEW_TYPE_READONLY, true);
-MakeThreadLocal(_NEW_TYPE_READONLY);
-
 BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data, parent )
     local   lock, hash,  cache,  cached,  type, ncache, ncl, t, i;
 
@@ -217,7 +211,7 @@ BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data, parent )
     lock := WRITE_LOCK(DS_TYPE_CACHE);
     cache := family!.TYPES;
     hash  := HASH_FLAGS(flags) mod family!.HASH_SIZE + 1;
-    if IsBound( cache[hash] ) and VAL_GVAR(_NEW_TYPE_READONLY) then
+    if IsBound( cache[hash] ) then
         cached := cache[hash];
         if IS_EQUAL_FLAGS( flags, cached![2] )  then
             if    IS_IDENTICAL_OBJ(  data,  cached![ POS_DATA_TYPE ] )
@@ -272,9 +266,7 @@ BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data, parent )
         cache[hash] := type;
     fi;
     family!.nTYPES := family!.nTYPES + 1;
-    if VAL_GVAR(_NEW_TYPE_READONLY) then
-        MakeReadOnlyObj(type);
-    fi;
+    MakeReadOnlyObj(type);
     UNLOCK(lock);
 
     # return the type

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -23,10 +23,6 @@ static GVar G_IS__STRING__REP;
 static Obj  GF_IS__STRING__REP;
 static GVar G_Error;
 static Obj  GF_Error;
-static GVar G_ASS__GVAR;
-static Obj  GF_ASS__GVAR;
-static GVar G_VAL__GVAR;
-static Obj  GF_VAL__GVAR;
 static GVar G_TYPE__OBJ;
 static Obj  GC_TYPE__OBJ;
 static Obj  GF_TYPE__OBJ;
@@ -98,8 +94,6 @@ static GVar G_UNLOCK;
 static Obj  GF_UNLOCK;
 static GVar G_MIGRATE__RAW;
 static Obj  GF_MIGRATE__RAW;
-static GVar G_MakeThreadLocal;
-static Obj  GF_MakeThreadLocal;
 static GVar G_MakeReadOnly;
 static Obj  GF_MakeReadOnly;
 static GVar G_MakeReadOnlyObj;
@@ -162,12 +156,10 @@ static GVar G_NEW__TYPE__CACHE__MISS;
 static Obj  GC_NEW__TYPE__CACHE__MISS;
 static GVar G_NEW__TYPE__CACHE__HIT;
 static Obj  GC_NEW__TYPE__CACHE__HIT;
-static GVar G_MakeLiteral;
-static Obj  GF_MakeLiteral;
-static GVar G___NEW__TYPE__READONLY;
-static Obj  GC___NEW__TYPE__READONLY;
 static GVar G_POS__DATA__TYPE;
 static Obj  GC_POS__DATA__TYPE;
+static GVar G_POS__FIRST__FREE__TYPE;
+static Obj  GC_POS__FIRST__FREE__TYPE;
 static GVar G_NEW__TYPE__NEXT__ID;
 static Obj  GC_NEW__TYPE__NEXT__ID;
 static GVar G_NEW__TYPE__ID__LIMIT;
@@ -178,8 +170,6 @@ static GVar G_POS__NUMB__TYPE;
 static Obj  GC_POS__NUMB__TYPE;
 static GVar G_NEW__TYPE;
 static Obj  GF_NEW__TYPE;
-static GVar G_POS__FIRST__FREE__TYPE;
-static Obj  GC_POS__FIRST__FREE__TYPE;
 static GVar G_IsFamily;
 static Obj  GF_IsFamily;
 static GVar G_NewType2;
@@ -200,6 +190,8 @@ static GVar G_SupType2;
 static Obj  GF_SupType2;
 static GVar G_SupType3;
 static Obj  GF_SupType3;
+static GVar G_MakeLiteral;
+static Obj  GF_MakeLiteral;
 static GVar G_FlagsType;
 static Obj  GF_FlagsType;
 static GVar G_TypeObj;
@@ -258,9 +250,9 @@ static RNam R_nTYPES;
 static RNam R_HASH__SIZE;
 
 /* information for the functions */
-static Obj  NameFunc[40];
-static Obj  NamsFunc[40];
-static Int  NargFunc[40];
+static Obj  NameFunc[39];
+static Obj  NamsFunc[39];
+static Int  NargFunc[39];
 static Obj  DefaultName;
 static Obj FileName;
 
@@ -997,69 +989,11 @@ static Obj  HdlrFunc10 (
 /* handler for function 11 */
 static Obj  HdlrFunc11 (
  Obj  self,
- Obj  a_body )
-{
- Obj l_type = 0;
- Obj l_save__flag = 0;
- Obj t_1 = 0;
- Obj t_2 = 0;
- Obj t_3 = 0;
- Bag oldFrame;
- OLD_BRK_CURR_STAT
- 
- /* allocate new stack frame */
- SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
- 
- /* save_flag := VAL_GVAR( _NEW_TYPE_READONLY ); */
- t_2 = GF_VAL__GVAR;
- t_3 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_3, "_NEW_TYPE_READONLY" )
- t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
- l_save__flag = t_1;
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, false ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- t_3 = False;
- CALL_2ARGS( t_1, t_2, t_3 );
- 
- /* type := body(  ); */
- CHECK_FUNC( a_body )
- t_1 = CALL_0ARGS( a_body );
- CHECK_FUNC_RESULT( t_1 )
- l_type = t_1;
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, save_flag ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- CALL_2ARGS( t_1, t_2, l_save__flag );
- 
- /* return MakeReadOnlyObj( type ); */
- t_2 = GF_MakeReadOnlyObj;
- t_1 = CALL_1ARGS( t_2, l_type );
- CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
- SWITCH_TO_OLD_FRAME(oldFrame);
- return t_1;
- 
- /* return; */
- RES_BRK_CURR_STAT();
- SWITCH_TO_OLD_FRAME(oldFrame);
- return 0;
-}
-
-/* handler for function 12 */
-static Obj  HdlrFunc12 (
- Obj  self,
  Obj  a_typeOfTypes,
  Obj  a_family,
  Obj  a_flags,
- Obj  a_data )
+ Obj  a_data,
+ Obj  a_parent )
 {
  Obj l_lock = 0;
  Obj l_hash = 0;
@@ -1069,6 +1003,8 @@ static Obj  HdlrFunc12 (
  Obj l_ncache = 0;
  Obj l_ncl = 0;
  Obj l_t = 0;
+ Obj l_i = 0;
+ Obj l_match = 0;
  Obj t_1 = 0;
  Obj t_2 = 0;
  Obj t_3 = 0;
@@ -1078,6 +1014,8 @@ static Obj  HdlrFunc12 (
  Obj t_7 = 0;
  Obj t_8 = 0;
  Obj t_9 = 0;
+ Obj t_10 = 0;
+ Obj t_11 = 0;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
  
@@ -1121,21 +1059,10 @@ static Obj  HdlrFunc12 (
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_hash = t_1;
  
- /* if IsBound( cache[hash] ) and VAL_GVAR( _NEW_TYPE_READONLY ) then */
+ /* if IsBound( cache[hash] ) then */
  CHECK_INT_POS( l_hash )
- t_3 = C_ISB_LIST( l_cache, l_hash );
- t_2 = (Obj)(UInt)(t_3 != False);
- t_1 = t_2;
- if ( t_1 ) {
-  t_5 = GF_VAL__GVAR;
-  t_6 = GC___NEW__TYPE__READONLY;
-  CHECK_BOUND( t_6, "_NEW_TYPE_READONLY" )
-  t_4 = CALL_1ARGS( t_5, t_6 );
-  CHECK_FUNC_RESULT( t_4 )
-  CHECK_BOOL( t_4 )
-  t_3 = (Obj)(UInt)(t_4 != False);
-  t_1 = t_3;
- }
+ t_2 = C_ISB_LIST( l_cache, l_hash );
+ t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* cached := cache[hash]; */
@@ -1150,6 +1077,10 @@ static Obj  HdlrFunc12 (
   CHECK_BOOL( t_2 )
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
+   
+   /* flags := cached![2]; */
+   C_ELM_POSOBJ_NLE( t_1, l_cached, 2 );
+   a_flags = t_1;
    
    /* if IS_IDENTICAL_OBJ( data, cached![POS_DATA_TYPE] ) and IS_IDENTICAL_OBJ( typeOfTypes, TYPE_OBJ( cached ) ) then */
    t_4 = GF_IS__IDENTICAL__OBJ;
@@ -1175,29 +1106,181 @@ static Obj  HdlrFunc12 (
    }
    if ( t_1 ) {
     
-    /* NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1; */
-    t_2 = GC_NEW__TYPE__CACHE__HIT;
-    CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" )
-    C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
-    AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
+    /* if IS_IDENTICAL_OBJ( parent, fail ) and LEN_POSOBJ( cached ) = POS_FIRST_FREE_TYPE - 1 then */
+    t_4 = GF_IS__IDENTICAL__OBJ;
+    t_5 = GC_fail;
+    CHECK_BOUND( t_5, "fail" )
+    t_3 = CALL_2ARGS( t_4, a_parent, t_5 );
+    CHECK_FUNC_RESULT( t_3 )
+    CHECK_BOOL( t_3 )
+    t_2 = (Obj)(UInt)(t_3 != False);
+    t_1 = t_2;
+    if ( t_1 ) {
+     t_5 = GF_LEN__POSOBJ;
+     t_4 = CALL_1ARGS( t_5, l_cached );
+     CHECK_FUNC_RESULT( t_4 )
+     t_6 = GC_POS__FIRST__FREE__TYPE;
+     CHECK_BOUND( t_6, "POS_FIRST_FREE_TYPE" )
+     C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
+     t_3 = (Obj)(UInt)(EQ( t_4, t_5 ));
+     t_1 = t_3;
+    }
+    if ( t_1 ) {
+     
+     /* NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1; */
+     t_2 = GC_NEW__TYPE__CACHE__HIT;
+     CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" )
+     C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
+     AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
+     
+     /* UNLOCK( lock ); */
+     t_1 = GF_UNLOCK;
+     CALL_1ARGS( t_1, l_lock );
+     
+     /* return cached; */
+     RES_BRK_CURR_STAT();
+     SWITCH_TO_OLD_FRAME(oldFrame);
+     return l_cached;
+     
+    }
+    /* fi */
     
-    /* UNLOCK( lock ); */
-    t_1 = GF_UNLOCK;
-    CALL_1ARGS( t_1, l_lock );
-    
-    /* return cached; */
-    RES_BRK_CURR_STAT();
-    SWITCH_TO_OLD_FRAME(oldFrame);
-    return l_cached;
-    
-   }
-   
-   /* else */
-   else {
-    
-    /* flags := cached![2]; */
-    C_ELM_POSOBJ_NLE( t_1, l_cached, 2 );
-    a_flags = t_1;
+    /* if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached ) then */
+    t_3 = GF_LEN__POSOBJ;
+    t_2 = CALL_1ARGS( t_3, a_parent );
+    CHECK_FUNC_RESULT( t_2 )
+    t_4 = GF_LEN__POSOBJ;
+    t_3 = CALL_1ARGS( t_4, l_cached );
+    CHECK_FUNC_RESULT( t_3 )
+    t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
+    if ( t_1 ) {
+     
+     /* match := true; */
+     t_1 = True;
+     l_match = t_1;
+     
+     /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ] do */
+     t_2 = GC_POS__FIRST__FREE__TYPE;
+     CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
+     CHECK_INT_SMALL( t_2 )
+     t_4 = GF_LEN__POSOBJ;
+     t_3 = CALL_1ARGS( t_4, a_parent );
+     CHECK_FUNC_RESULT( t_3 )
+     CHECK_INT_SMALL( t_3 )
+     for ( t_1 = t_2;
+           ((Int)t_1) <= ((Int)t_3);
+           t_1 = (Obj)(((UInt)t_1)+4) ) {
+      l_i = t_1;
+      
+      /* if IsBound( parent![i]) <> IsBound( cached![i]) then */
+      CHECK_INT_SMALL_POS( l_i )
+      if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
+       t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
+          && ELM_PLIST(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False);
+      } else if ( TNUM_OBJ(a_parent) == T_APOSOBJ ) {
+       t_5 = Elm0AList(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False;
+      }
+      else {
+       t_5 = (ISB_LIST( a_parent, INT_INTOBJ(l_i) ) ? True : False);
+      }
+      if ( TNUM_OBJ(l_cached) == T_POSOBJ ) {
+       t_6 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_cached)/sizeof(Obj)-1
+          && ELM_PLIST(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False);
+      } else if ( TNUM_OBJ(l_cached) == T_APOSOBJ ) {
+       t_6 = Elm0AList(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False;
+      }
+      else {
+       t_6 = (ISB_LIST( l_cached, INT_INTOBJ(l_i) ) ? True : False);
+      }
+      t_4 = (Obj)(UInt)( ! EQ( t_5, t_6 ));
+      if ( t_4 ) {
+       
+       /* match := false; */
+       t_4 = False;
+       l_match = t_4;
+       
+       /* break; */
+       break;
+       
+      }
+      /* fi */
+      
+      /* if IsBound( parent![i]) and IsBound( cached![i]) and not IS_IDENTICAL_OBJ( parent![i], cached![i] ) then */
+      if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
+       t_7 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
+          && ELM_PLIST(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False);
+      } else if ( TNUM_OBJ(a_parent) == T_APOSOBJ ) {
+       t_7 = Elm0AList(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False;
+      }
+      else {
+       t_7 = (ISB_LIST( a_parent, INT_INTOBJ(l_i) ) ? True : False);
+      }
+      t_6 = (Obj)(UInt)(t_7 != False);
+      t_5 = t_6;
+      if ( t_5 ) {
+       if ( TNUM_OBJ(l_cached) == T_POSOBJ ) {
+        t_8 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_cached)/sizeof(Obj)-1
+           && ELM_PLIST(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False);
+       } else if ( TNUM_OBJ(l_cached) == T_APOSOBJ ) {
+        t_8 = Elm0AList(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False;
+       }
+       else {
+        t_8 = (ISB_LIST( l_cached, INT_INTOBJ(l_i) ) ? True : False);
+       }
+       t_7 = (Obj)(UInt)(t_8 != False);
+       t_5 = t_7;
+      }
+      t_4 = t_5;
+      if ( t_4 ) {
+       t_9 = GF_IS__IDENTICAL__OBJ;
+       C_ELM_POSOBJ_NLE( t_10, a_parent, INT_INTOBJ(l_i) );
+       C_ELM_POSOBJ_NLE( t_11, l_cached, INT_INTOBJ(l_i) );
+       t_8 = CALL_2ARGS( t_9, t_10, t_11 );
+       CHECK_FUNC_RESULT( t_8 )
+       CHECK_BOOL( t_8 )
+       t_7 = (Obj)(UInt)(t_8 != False);
+       t_6 = (Obj)(UInt)( ! ((Int)t_7) );
+       t_4 = t_6;
+      }
+      if ( t_4 ) {
+       
+       /* match := false; */
+       t_4 = False;
+       l_match = t_4;
+       
+       /* break; */
+       break;
+       
+      }
+      /* fi */
+      
+     }
+     /* od */
+     
+     /* if match then */
+     t_1 = (Obj)(UInt)(l_match != False);
+     if ( t_1 ) {
+      
+      /* NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1; */
+      t_2 = GC_NEW__TYPE__CACHE__HIT;
+      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" )
+      C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
+      AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
+      
+      /* UNLOCK( lock ); */
+      t_1 = GF_UNLOCK;
+      CALL_1ARGS( t_1, l_lock );
+      
+      /* return cached; */
+      RES_BRK_CURR_STAT();
+      SWITCH_TO_OLD_FRAME(oldFrame);
+      return l_cached;
+      
+     }
+     /* fi */
+     
+    }
+    /* fi */
     
    }
    /* fi */
@@ -1271,6 +1354,64 @@ static Obj  HdlrFunc12 (
  t_2 = GC_NEW__TYPE__NEXT__ID;
  CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
  C_ASS_LIST_FPL( l_type, t_1, t_2 )
+ 
+ /* if not IS_IDENTICAL_OBJ( parent, fail ) then */
+ t_4 = GF_IS__IDENTICAL__OBJ;
+ t_5 = GC_fail;
+ CHECK_BOUND( t_5, "fail" )
+ t_3 = CALL_2ARGS( t_4, a_parent, t_5 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
+ t_2 = (Obj)(UInt)(t_3 != False);
+ t_1 = (Obj)(UInt)( ! ((Int)t_2) );
+ if ( t_1 ) {
+  
+  /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ] do */
+  t_2 = GC_POS__FIRST__FREE__TYPE;
+  CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
+  CHECK_INT_SMALL( t_2 )
+  t_4 = GF_LEN__POSOBJ;
+  t_3 = CALL_1ARGS( t_4, a_parent );
+  CHECK_FUNC_RESULT( t_3 )
+  CHECK_INT_SMALL( t_3 )
+  for ( t_1 = t_2;
+        ((Int)t_1) <= ((Int)t_3);
+        t_1 = (Obj)(((UInt)t_1)+4) ) {
+   l_i = t_1;
+   
+   /* if IsBound( parent![i]) and not IsBound( type[i] ) then */
+   CHECK_INT_SMALL_POS( l_i )
+   if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
+    t_6 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
+       && ELM_PLIST(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False);
+   } else if ( TNUM_OBJ(a_parent) == T_APOSOBJ ) {
+    t_6 = Elm0AList(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False;
+   }
+   else {
+    t_6 = (ISB_LIST( a_parent, INT_INTOBJ(l_i) ) ? True : False);
+   }
+   t_5 = (Obj)(UInt)(t_6 != False);
+   t_4 = t_5;
+   if ( t_4 ) {
+    t_8 = C_ISB_LIST( l_type, l_i );
+    t_7 = (Obj)(UInt)(t_8 != False);
+    t_6 = (Obj)(UInt)( ! ((Int)t_7) );
+    t_4 = t_6;
+   }
+   if ( t_4 ) {
+    
+    /* type[i] := parent![i]; */
+    C_ELM_POSOBJ_NLE( t_4, a_parent, INT_INTOBJ(l_i) );
+    C_ASS_LIST_FPL( l_type, l_i, t_4 )
+    
+   }
+   /* fi */
+   
+  }
+  /* od */
+  
+ }
+ /* fi */
  
  /* SET_TYPE_POSOBJ( type, typeOfTypes ); */
  t_1 = GF_SET__TYPE__POSOBJ;
@@ -1415,22 +1556,9 @@ static Obj  HdlrFunc12 (
   ASS_REC( a_family, R_nTYPES, t_1 );
  }
  
- /* if VAL_GVAR( _NEW_TYPE_READONLY ) then */
- t_3 = GF_VAL__GVAR;
- t_4 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_4, "_NEW_TYPE_READONLY" )
- t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
- t_1 = (Obj)(UInt)(t_2 != False);
- if ( t_1 ) {
-  
-  /* MakeReadOnlyObj( type ); */
-  t_1 = GF_MakeReadOnlyObj;
-  CALL_1ARGS( t_1, l_type );
-  
- }
- /* fi */
+ /* MakeReadOnlyObj( type ); */
+ t_1 = GF_MakeReadOnlyObj;
+ CALL_1ARGS( t_1, l_type );
  
  /* UNLOCK( lock ); */
  t_1 = GF_UNLOCK;
@@ -1447,8 +1575,8 @@ static Obj  HdlrFunc12 (
  return 0;
 }
 
-/* handler for function 13 */
-static Obj  HdlrFunc13 (
+/* handler for function 12 */
+static Obj  HdlrFunc12 (
  Obj  self,
  Obj  a_typeOfTypes,
  Obj  a_family )
@@ -1457,6 +1585,7 @@ static Obj  HdlrFunc13 (
  Obj t_2 = 0;
  Obj t_3 = 0;
  Obj t_4 = 0;
+ Obj t_5 = 0;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
  
@@ -1465,7 +1594,7 @@ static Obj  HdlrFunc13 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* return NEW_TYPE( typeOfTypes, family, family!.IMP_FLAGS, fail ); */
+ /* return NEW_TYPE( typeOfTypes, family, family!.IMP_FLAGS, fail, fail ); */
  t_2 = GF_NEW__TYPE;
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   t_3 = ElmPRec( a_family, R_IMP__FLAGS );
@@ -1477,7 +1606,9 @@ static Obj  HdlrFunc13 (
  }
  t_4 = GC_fail;
  CHECK_BOUND( t_4, "fail" )
- t_1 = CALL_4ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4 );
+ t_5 = GC_fail;
+ CHECK_BOUND( t_5, "fail" )
+ t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
  CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1489,8 +1620,8 @@ static Obj  HdlrFunc13 (
  return 0;
 }
 
-/* handler for function 14 */
-static Obj  HdlrFunc14 (
+/* handler for function 13 */
+static Obj  HdlrFunc13 (
  Obj  self,
  Obj  a_typeOfTypes,
  Obj  a_family,
@@ -1513,7 +1644,7 @@ static Obj  HdlrFunc14 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail ); */
+ /* return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail, fail ); */
  t_2 = GF_NEW__TYPE;
  t_4 = GF_WITH__IMPS__FLAGS;
  t_6 = GF_AND__FLAGS;
@@ -1534,7 +1665,9 @@ static Obj  HdlrFunc14 (
  CHECK_FUNC_RESULT( t_3 )
  t_4 = GC_fail;
  CHECK_BOUND( t_4, "fail" )
- t_1 = CALL_4ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4 );
+ t_5 = GC_fail;
+ CHECK_BOUND( t_5, "fail" )
+ t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
  CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1546,8 +1679,8 @@ static Obj  HdlrFunc14 (
  return 0;
 }
 
-/* handler for function 15 */
-static Obj  HdlrFunc15 (
+/* handler for function 14 */
+static Obj  HdlrFunc14 (
  Obj  self,
  Obj  a_typeOfTypes,
  Obj  a_family,
@@ -1571,7 +1704,7 @@ static Obj  HdlrFunc15 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data ); */
+ /* return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, fail ); */
  t_2 = GF_NEW__TYPE;
  t_4 = GF_WITH__IMPS__FLAGS;
  t_6 = GF_AND__FLAGS;
@@ -1590,7 +1723,9 @@ static Obj  HdlrFunc15 (
  CHECK_FUNC_RESULT( t_5 )
  t_3 = CALL_1ARGS( t_4, t_5 );
  CHECK_FUNC_RESULT( t_3 )
- t_1 = CALL_4ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data );
+ t_4 = GC_fail;
+ CHECK_BOUND( t_4, "fail" )
+ t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, t_4 );
  CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1602,8 +1737,8 @@ static Obj  HdlrFunc15 (
  return 0;
 }
 
-/* handler for function 16 */
-static Obj  HdlrFunc16 (
+/* handler for function 15 */
+static Obj  HdlrFunc15 (
  Obj  self,
  Obj  a_typeOfTypes,
  Obj  a_family,
@@ -1612,6 +1747,7 @@ static Obj  HdlrFunc16 (
  Obj  a_stuff )
 {
  Obj l_type = 0;
+ Obj l_temp = 0;
  Obj t_1 = 0;
  Obj t_2 = 0;
  Obj t_3 = 0;
@@ -1629,7 +1765,18 @@ static Obj  HdlrFunc16 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* type := NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data ); */
+ /* temp := [  ]; */
+ t_1 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_1, 0 );
+ l_temp = t_1;
+ 
+ /* temp[POS_FIRST_FREE_TYPE] := stuff; */
+ t_1 = GC_POS__FIRST__FREE__TYPE;
+ CHECK_BOUND( t_1, "POS_FIRST_FREE_TYPE" )
+ CHECK_INT_POS( t_1 )
+ C_ASS_LIST_FPL( l_temp, t_1, a_stuff )
+ 
+ /* type := NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, temp ); */
  t_2 = GF_NEW__TYPE;
  t_4 = GF_WITH__IMPS__FLAGS;
  t_6 = GF_AND__FLAGS;
@@ -1648,15 +1795,9 @@ static Obj  HdlrFunc16 (
  CHECK_FUNC_RESULT( t_5 )
  t_3 = CALL_1ARGS( t_4, t_5 );
  CHECK_FUNC_RESULT( t_3 )
- t_1 = CALL_4ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data );
+ t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, l_temp );
  CHECK_FUNC_RESULT( t_1 )
  l_type = t_1;
- 
- /* type![POS_FIRST_FREE_TYPE] := stuff; */
- t_1 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_1, "POS_FIRST_FREE_TYPE" )
- CHECK_INT_SMALL_POS( t_1 )
- C_ASS_POSOBJ( l_type, INT_INTOBJ(t_1), a_stuff )
  
  /* return type; */
  RES_BRK_CURR_STAT();
@@ -1669,8 +1810,8 @@ static Obj  HdlrFunc16 (
  return 0;
 }
 
-/* handler for function 17 */
-static Obj  HdlrFunc17 (
+/* handler for function 16 */
+static Obj  HdlrFunc16 (
  Obj  self,
  Obj  a_arg )
 {
@@ -1815,15 +1956,12 @@ static Obj  HdlrFunc17 (
  return 0;
 }
 
-/* handler for function 18 */
-static Obj  HdlrFunc18 (
+/* handler for function 17 */
+static Obj  HdlrFunc17 (
  Obj  self,
  Obj  a_type,
  Obj  a_filter )
 {
- Obj l_new = 0;
- Obj l_i = 0;
- Obj l_save__flag = 0;
  Obj t_1 = 0;
  Obj t_2 = 0;
  Obj t_3 = 0;
@@ -1843,22 +1981,7 @@ static Obj  HdlrFunc18 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* save_flag := VAL_GVAR( _NEW_TYPE_READONLY ); */
- t_2 = GF_VAL__GVAR;
- t_3 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_3, "_NEW_TYPE_READONLY" )
- t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
- l_save__flag = t_1;
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, false ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- t_3 = False;
- CALL_2ARGS( t_1, t_2, t_3 );
- 
- /* new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![POS_DATA_TYPE] ); */
+ /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![POS_DATA_TYPE], type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
@@ -1877,76 +2000,11 @@ static Obj  HdlrFunc18 (
  CHECK_BOUND( t_7, "POS_DATA_TYPE" )
  CHECK_INT_SMALL_POS( t_7 )
  C_ELM_POSOBJ_NLE( t_6, a_type, INT_INTOBJ(t_7) );
- t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
+ t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
  CHECK_FUNC_RESULT( t_1 )
- l_new = t_1;
- 
- /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do */
- t_2 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
- CHECK_INT_SMALL( t_2 )
- t_4 = GF_LEN__POSOBJ;
- t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_INT_SMALL( t_3 )
- for ( t_1 = t_2;
-       ((Int)t_1) <= ((Int)t_3);
-       t_1 = (Obj)(((UInt)t_1)+4) ) {
-  l_i = t_1;
-  
-  /* if IsBound( type![i]) and not IsBound( new![i]) then */
-  CHECK_INT_SMALL_POS( l_i )
-  if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
-   t_6 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
-      && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
-  } else if ( TNUM_OBJ(a_type) == T_APOSOBJ ) {
-   t_6 = Elm0AList(a_type,INT_INTOBJ(l_i)) != 0 ? True : False;
-  }
-  else {
-   t_6 = (ISB_LIST( a_type, INT_INTOBJ(l_i) ) ? True : False);
-  }
-  t_5 = (Obj)(UInt)(t_6 != False);
-  t_4 = t_5;
-  if ( t_4 ) {
-   if ( TNUM_OBJ(l_new) == T_POSOBJ ) {
-    t_8 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_new)/sizeof(Obj)-1
-       && ELM_PLIST(l_new,INT_INTOBJ(l_i)) != 0 ? True : False);
-   } else if ( TNUM_OBJ(l_new) == T_APOSOBJ ) {
-    t_8 = Elm0AList(l_new,INT_INTOBJ(l_i)) != 0 ? True : False;
-   }
-   else {
-    t_8 = (ISB_LIST( l_new, INT_INTOBJ(l_i) ) ? True : False);
-   }
-   t_7 = (Obj)(UInt)(t_8 != False);
-   t_6 = (Obj)(UInt)( ! ((Int)t_7) );
-   t_4 = t_6;
-  }
-  if ( t_4 ) {
-   
-   /* new![i] := type![i]; */
-   C_ELM_POSOBJ_NLE( t_4, a_type, INT_INTOBJ(l_i) );
-   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 )
-   
-  }
-  /* fi */
-  
- }
- /* od */
- 
- /* MakeReadOnlyObj( new ); */
- t_1 = GF_MakeReadOnlyObj;
- CALL_1ARGS( t_1, l_new );
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, save_flag ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- CALL_2ARGS( t_1, t_2, l_save__flag );
- 
- /* return new; */
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
- return l_new;
+ return t_1;
  
  /* return; */
  RES_BRK_CURR_STAT();
@@ -1954,16 +2012,13 @@ static Obj  HdlrFunc18 (
  return 0;
 }
 
-/* handler for function 19 */
-static Obj  HdlrFunc19 (
+/* handler for function 18 */
+static Obj  HdlrFunc18 (
  Obj  self,
  Obj  a_type,
  Obj  a_filter,
  Obj  a_data )
 {
- Obj l_new = 0;
- Obj l_i = 0;
- Obj l_save__flag = 0;
  Obj t_1 = 0;
  Obj t_2 = 0;
  Obj t_3 = 0;
@@ -1983,22 +2038,7 @@ static Obj  HdlrFunc19 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* save_flag := VAL_GVAR( _NEW_TYPE_READONLY ); */
- t_2 = GF_VAL__GVAR;
- t_3 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_3, "_NEW_TYPE_READONLY" )
- t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
- l_save__flag = t_1;
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, false ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- t_3 = False;
- CALL_2ARGS( t_1, t_2, t_3 );
- 
- /* new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data ); */
+ /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
@@ -2013,76 +2053,11 @@ static Obj  HdlrFunc19 (
  CHECK_FUNC_RESULT( t_7 )
  t_5 = CALL_1ARGS( t_6, t_7 );
  CHECK_FUNC_RESULT( t_5 )
- t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, a_data );
+ t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
  CHECK_FUNC_RESULT( t_1 )
- l_new = t_1;
- 
- /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do */
- t_2 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
- CHECK_INT_SMALL( t_2 )
- t_4 = GF_LEN__POSOBJ;
- t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_INT_SMALL( t_3 )
- for ( t_1 = t_2;
-       ((Int)t_1) <= ((Int)t_3);
-       t_1 = (Obj)(((UInt)t_1)+4) ) {
-  l_i = t_1;
-  
-  /* if IsBound( type![i]) and not IsBound( new![i]) then */
-  CHECK_INT_SMALL_POS( l_i )
-  if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
-   t_6 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
-      && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
-  } else if ( TNUM_OBJ(a_type) == T_APOSOBJ ) {
-   t_6 = Elm0AList(a_type,INT_INTOBJ(l_i)) != 0 ? True : False;
-  }
-  else {
-   t_6 = (ISB_LIST( a_type, INT_INTOBJ(l_i) ) ? True : False);
-  }
-  t_5 = (Obj)(UInt)(t_6 != False);
-  t_4 = t_5;
-  if ( t_4 ) {
-   if ( TNUM_OBJ(l_new) == T_POSOBJ ) {
-    t_8 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_new)/sizeof(Obj)-1
-       && ELM_PLIST(l_new,INT_INTOBJ(l_i)) != 0 ? True : False);
-   } else if ( TNUM_OBJ(l_new) == T_APOSOBJ ) {
-    t_8 = Elm0AList(l_new,INT_INTOBJ(l_i)) != 0 ? True : False;
-   }
-   else {
-    t_8 = (ISB_LIST( l_new, INT_INTOBJ(l_i) ) ? True : False);
-   }
-   t_7 = (Obj)(UInt)(t_8 != False);
-   t_6 = (Obj)(UInt)( ! ((Int)t_7) );
-   t_4 = t_6;
-  }
-  if ( t_4 ) {
-   
-   /* new![i] := type![i]; */
-   C_ELM_POSOBJ_NLE( t_4, a_type, INT_INTOBJ(l_i) );
-   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 )
-   
-  }
-  /* fi */
-  
- }
- /* od */
- 
- /* MakeReadOnlyObj( new ); */
- t_1 = GF_MakeReadOnlyObj;
- CALL_1ARGS( t_1, l_new );
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, save_flag ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- CALL_2ARGS( t_1, t_2, l_save__flag );
- 
- /* return new; */
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
- return l_new;
+ return t_1;
  
  /* return; */
  RES_BRK_CURR_STAT();
@@ -2090,8 +2065,8 @@ static Obj  HdlrFunc19 (
  return 0;
 }
 
-/* handler for function 20 */
-static Obj  HdlrFunc20 (
+/* handler for function 19 */
+static Obj  HdlrFunc19 (
  Obj  self,
  Obj  a_arg )
 {
@@ -2184,14 +2159,12 @@ static Obj  HdlrFunc20 (
  return 0;
 }
 
-/* handler for function 21 */
-static Obj  HdlrFunc21 (
+/* handler for function 20 */
+static Obj  HdlrFunc20 (
  Obj  self,
  Obj  a_type,
  Obj  a_filter )
 {
- Obj l_new = 0;
- Obj l_i = 0;
  Obj t_1 = 0;
  Obj t_2 = 0;
  Obj t_3 = 0;
@@ -2209,7 +2182,7 @@ static Obj  HdlrFunc21 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![POS_DATA_TYPE] ); */
+ /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![POS_DATA_TYPE], type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
@@ -2225,51 +2198,11 @@ static Obj  HdlrFunc21 (
  CHECK_BOUND( t_7, "POS_DATA_TYPE" )
  CHECK_INT_SMALL_POS( t_7 )
  C_ELM_POSOBJ_NLE( t_6, a_type, INT_INTOBJ(t_7) );
- t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
+ t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
  CHECK_FUNC_RESULT( t_1 )
- l_new = t_1;
- 
- /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do */
- t_2 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
- CHECK_INT_SMALL( t_2 )
- t_4 = GF_LEN__POSOBJ;
- t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_INT_SMALL( t_3 )
- for ( t_1 = t_2;
-       ((Int)t_1) <= ((Int)t_3);
-       t_1 = (Obj)(((UInt)t_1)+4) ) {
-  l_i = t_1;
-  
-  /* if IsBound( type![i]) then */
-  CHECK_INT_SMALL_POS( l_i )
-  if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
-   t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
-      && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
-  } else if ( TNUM_OBJ(a_type) == T_APOSOBJ ) {
-   t_5 = Elm0AList(a_type,INT_INTOBJ(l_i)) != 0 ? True : False;
-  }
-  else {
-   t_5 = (ISB_LIST( a_type, INT_INTOBJ(l_i) ) ? True : False);
-  }
-  t_4 = (Obj)(UInt)(t_5 != False);
-  if ( t_4 ) {
-   
-   /* new![i] := type![i]; */
-   C_ELM_POSOBJ_NLE( t_4, a_type, INT_INTOBJ(l_i) );
-   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 )
-   
-  }
-  /* fi */
-  
- }
- /* od */
- 
- /* return new; */
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
- return l_new;
+ return t_1;
  
  /* return; */
  RES_BRK_CURR_STAT();
@@ -2277,15 +2210,13 @@ static Obj  HdlrFunc21 (
  return 0;
 }
 
-/* handler for function 22 */
-static Obj  HdlrFunc22 (
+/* handler for function 21 */
+static Obj  HdlrFunc21 (
  Obj  self,
  Obj  a_type,
  Obj  a_filter,
  Obj  a_data )
 {
- Obj l_new = 0;
- Obj l_i = 0;
  Obj t_1 = 0;
  Obj t_2 = 0;
  Obj t_3 = 0;
@@ -2303,7 +2234,7 @@ static Obj  HdlrFunc22 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data ); */
+ /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
@@ -2315,51 +2246,11 @@ static Obj  HdlrFunc22 (
  CHECK_FUNC_RESULT( t_8 )
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
  CHECK_FUNC_RESULT( t_5 )
- t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, a_data );
+ t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
  CHECK_FUNC_RESULT( t_1 )
- l_new = t_1;
- 
- /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do */
- t_2 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
- CHECK_INT_SMALL( t_2 )
- t_4 = GF_LEN__POSOBJ;
- t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_INT_SMALL( t_3 )
- for ( t_1 = t_2;
-       ((Int)t_1) <= ((Int)t_3);
-       t_1 = (Obj)(((UInt)t_1)+4) ) {
-  l_i = t_1;
-  
-  /* if IsBound( type![i]) then */
-  CHECK_INT_SMALL_POS( l_i )
-  if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
-   t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
-      && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
-  } else if ( TNUM_OBJ(a_type) == T_APOSOBJ ) {
-   t_5 = Elm0AList(a_type,INT_INTOBJ(l_i)) != 0 ? True : False;
-  }
-  else {
-   t_5 = (ISB_LIST( a_type, INT_INTOBJ(l_i) ) ? True : False);
-  }
-  t_4 = (Obj)(UInt)(t_5 != False);
-  if ( t_4 ) {
-   
-   /* new![i] := type![i]; */
-   C_ELM_POSOBJ_NLE( t_4, a_type, INT_INTOBJ(l_i) );
-   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 )
-   
-  }
-  /* fi */
-  
- }
- /* od */
- 
- /* return new; */
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
- return l_new;
+ return t_1;
  
  /* return; */
  RES_BRK_CURR_STAT();
@@ -2367,8 +2258,8 @@ static Obj  HdlrFunc22 (
  return 0;
 }
 
-/* handler for function 23 */
-static Obj  HdlrFunc23 (
+/* handler for function 22 */
+static Obj  HdlrFunc22 (
  Obj  self,
  Obj  a_arg )
 {
@@ -2450,8 +2341,8 @@ static Obj  HdlrFunc23 (
  return 0;
 }
 
-/* handler for function 24 */
-static Obj  HdlrFunc24 (
+/* handler for function 23 */
+static Obj  HdlrFunc23 (
  Obj  self,
  Obj  a_K )
 {
@@ -2476,8 +2367,8 @@ static Obj  HdlrFunc24 (
  return 0;
 }
 
-/* handler for function 25 */
-static Obj  HdlrFunc25 (
+/* handler for function 24 */
+static Obj  HdlrFunc24 (
  Obj  self,
  Obj  a_K )
 {
@@ -2502,8 +2393,8 @@ static Obj  HdlrFunc25 (
  return 0;
 }
 
-/* handler for function 26 */
-static Obj  HdlrFunc26 (
+/* handler for function 25 */
+static Obj  HdlrFunc25 (
  Obj  self,
  Obj  a_K )
 {
@@ -2532,8 +2423,8 @@ static Obj  HdlrFunc26 (
  return 0;
 }
 
-/* handler for function 27 */
-static Obj  HdlrFunc27 (
+/* handler for function 26 */
+static Obj  HdlrFunc26 (
  Obj  self,
  Obj  a_K,
  Obj  a_data )
@@ -2570,8 +2461,8 @@ static Obj  HdlrFunc27 (
  return 0;
 }
 
-/* handler for function 28 */
-static Obj  HdlrFunc28 (
+/* handler for function 27 */
+static Obj  HdlrFunc27 (
  Obj  self,
  Obj  a_K )
 {
@@ -2600,8 +2491,8 @@ static Obj  HdlrFunc28 (
  return 0;
 }
 
-/* handler for function 29 */
-static Obj  HdlrFunc29 (
+/* handler for function 28 */
+static Obj  HdlrFunc28 (
  Obj  self,
  Obj  a_obj )
 {
@@ -2634,8 +2525,8 @@ static Obj  HdlrFunc29 (
  return 0;
 }
 
-/* handler for function 30 */
-static Obj  HdlrFunc30 (
+/* handler for function 29 */
+static Obj  HdlrFunc29 (
  Obj  self,
  Obj  a_obj )
 {
@@ -2668,8 +2559,8 @@ static Obj  HdlrFunc30 (
  return 0;
 }
 
-/* handler for function 31 */
-static Obj  HdlrFunc31 (
+/* handler for function 30 */
+static Obj  HdlrFunc30 (
  Obj  self,
  Obj  a_obj )
 {
@@ -2702,8 +2593,8 @@ static Obj  HdlrFunc31 (
  return 0;
 }
 
-/* handler for function 32 */
-static Obj  HdlrFunc32 (
+/* handler for function 31 */
+static Obj  HdlrFunc31 (
  Obj  self,
  Obj  a_type,
  Obj  a_obj )
@@ -2796,8 +2687,8 @@ static Obj  HdlrFunc32 (
  return 0;
 }
 
-/* handler for function 33 */
-static Obj  HdlrFunc33 (
+/* handler for function 32 */
+static Obj  HdlrFunc32 (
  Obj  self,
  Obj  a_type,
  Obj  a_obj )
@@ -2986,8 +2877,8 @@ static Obj  HdlrFunc33 (
  return 0;
 }
 
-/* handler for function 34 */
-static Obj  HdlrFunc34 (
+/* handler for function 33 */
+static Obj  HdlrFunc33 (
  Obj  self,
  Obj  a_type,
  Obj  a_obj )
@@ -3096,8 +2987,8 @@ static Obj  HdlrFunc34 (
  return 0;
 }
 
-/* handler for function 35 */
-static Obj  HdlrFunc35 (
+/* handler for function 34 */
+static Obj  HdlrFunc34 (
  Obj  self,
  Obj  a_obj,
  Obj  a_filter )
@@ -3373,8 +3264,8 @@ static Obj  HdlrFunc35 (
  return 0;
 }
 
-/* handler for function 36 */
-static Obj  HdlrFunc36 (
+/* handler for function 35 */
+static Obj  HdlrFunc35 (
  Obj  self,
  Obj  a_obj,
  Obj  a_filter )
@@ -3558,8 +3449,8 @@ static Obj  HdlrFunc36 (
  return 0;
 }
 
-/* handler for function 37 */
-static Obj  HdlrFunc37 (
+/* handler for function 36 */
+static Obj  HdlrFunc36 (
  Obj  self,
  Obj  a_obj,
  Obj  a_filter,
@@ -3606,8 +3497,8 @@ static Obj  HdlrFunc37 (
  return 0;
 }
 
-/* handler for function 38 */
-static Obj  HdlrFunc38 (
+/* handler for function 37 */
+static Obj  HdlrFunc37 (
  Obj  self,
  Obj  a_arg )
 {
@@ -3986,8 +3877,8 @@ static Obj  HdlrFunc38 (
  return 0;
 }
 
-/* handler for function 39 */
-static Obj  HdlrFunc39 (
+/* handler for function 38 */
+static Obj  HdlrFunc38 (
  Obj  self,
  Obj  a_arg )
 {
@@ -4232,7 +4123,7 @@ static Obj  HdlrFunc39 (
    CHECK_FUNC_RESULT( t_1 )
    l_flags = t_1;
    
-   /* Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ) ), obj ); */
+   /* Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ), fail ), obj ); */
    t_1 = GF_Objectify;
    t_3 = GF_NEW__TYPE;
    t_4 = GC_TypeOfTypes;
@@ -4243,7 +4134,9 @@ static Obj  HdlrFunc39 (
    t_7 = GF_DataType;
    t_6 = CALL_1ARGS( t_7, l_type );
    CHECK_FUNC_RESULT( t_6 )
-   t_2 = CALL_4ARGS( t_3, t_4, t_5, l_flags, t_6 );
+   t_7 = GC_fail;
+   CHECK_BOUND( t_7, "fail" )
+   t_2 = CALL_5ARGS( t_3, t_4, t_5, l_flags, t_6, t_7 );
    CHECK_FUNC_RESULT( t_2 )
    CALL_2ARGS( t_1, t_2, l_obj );
    
@@ -4549,62 +4442,39 @@ static Obj  HdlrFunc1 (
  /* NEW_TYPE_CACHE_HIT := 0; */
  AssGVar( G_NEW__TYPE__CACHE__HIT, INTOBJ_INT(0) );
  
- /* BIND_GLOBAL( "_NEW_TYPE_READONLY", MakeLiteral( "NEW_TYPE_READONLY" ) ); */
- t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 18, "_NEW_TYPE_READONLY" );
- t_4 = GF_MakeLiteral;
- C_NEW_STRING( t_5, 17, "NEW_TYPE_READONLY" );
- t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CALL_2ARGS( t_1, t_2, t_3 );
- 
- /* ASS_GVAR( _NEW_TYPE_READONLY, true ); */
- t_1 = GF_ASS__GVAR;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- t_3 = True;
- CALL_2ARGS( t_1, t_2, t_3 );
- 
- /* MakeThreadLocal( _NEW_TYPE_READONLY ); */
- t_1 = GF_MakeThreadLocal;
- t_2 = GC___NEW__TYPE__READONLY;
- CHECK_BOUND( t_2, "_NEW_TYPE_READONLY" )
- CALL_1ARGS( t_1, t_2 );
- 
- /* BIND_GLOBAL( "ConstructExtendedType", function ( body )
-      local  type, save_flag;
-      save_flag := VAL_GVAR( _NEW_TYPE_READONLY );
-      ASS_GVAR( _NEW_TYPE_READONLY, false );
-      type := body(  );
-      ASS_GVAR( _NEW_TYPE_READONLY, save_flag );
-      return MakeReadOnlyObj( type );
-  end ); */
- t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 21, "ConstructExtendedType" );
- t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
- t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(214);
- ENDLINE_BODY(t_4) = INTOBJ_INT(221);
- FILENAME_BODY(t_4) = FileName;
- BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
- CALL_2ARGS( t_1, t_2, t_3 );
- 
- /* BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data )
-      local  lock, hash, cache, cached, type, ncache, ncl, t;
+ /* BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data, parent )
+      local  lock, hash, cache, cached, type, ncache, ncl, t, i, match;
       lock := WRITE_LOCK( DS_TYPE_CACHE );
       cache := family!.TYPES;
       hash := HASH_FLAGS( flags ) mod family!.HASH_SIZE + 1;
-      if IsBound( cache[hash] ) and VAL_GVAR( _NEW_TYPE_READONLY )  then
+      if IsBound( cache[hash] )  then
           cached := cache[hash];
           if IS_EQUAL_FLAGS( flags, cached![2] )  then
+              flags := cached![2];
               if IS_IDENTICAL_OBJ( data, cached![POS_DATA_TYPE] ) and IS_IDENTICAL_OBJ( typeOfTypes, TYPE_OBJ( cached ) )  then
-                  NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1;
-                  UNLOCK( lock );
-                  return cached;
-              else
-                  flags := cached![2];
+                  if IS_IDENTICAL_OBJ( parent, fail ) and LEN_POSOBJ( cached ) = POS_FIRST_FREE_TYPE - 1  then
+                      NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1;
+                      UNLOCK( lock );
+                      return cached;
+                  fi;
+                  if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached )  then
+                      match := true;
+                      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ]  do
+                          if IsBound( parent![i]) <> IsBound( cached![i])  then
+                              match := false;
+                              break;
+                          fi;
+                          if IsBound( parent![i]) and IsBound( cached![i]) and not IS_IDENTICAL_OBJ( parent![i], cached![i] )  then
+                              match := false;
+                              break;
+                          fi;
+                      od;
+                      if match  then
+                          NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1;
+                          UNLOCK( lock );
+                          return cached;
+                      fi;
+                  fi;
               fi;
           fi;
           NEW_TYPE_CACHE_MISS := NEW_TYPE_CACHE_MISS + 1;
@@ -4618,6 +4488,13 @@ static Obj  HdlrFunc1 (
       type := [ family, flags ];
       type[POS_DATA_TYPE] := MakeReadOnly( data );
       type[POS_NUMB_TYPE] := NEW_TYPE_NEXT_ID;
+      if not IS_IDENTICAL_OBJ( parent, fail )  then
+          for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ]  do
+              if IsBound( parent![i]) and not IsBound( type[i] )  then
+                  type[i] := parent![i];
+              fi;
+          od;
+      fi;
       SET_TYPE_POSOBJ( type, typeOfTypes );
       if 3 * family!.nTYPES > family!.HASH_SIZE  then
           ncache := MIGRATE_RAW( [  ], DS_TYPE_CACHE );
@@ -4632,82 +4509,81 @@ static Obj  HdlrFunc1 (
           cache[hash] := type;
       fi;
       family!.nTYPES := family!.nTYPES + 1;
-      if VAL_GVAR( _NEW_TYPE_READONLY )  then
-          MakeReadOnlyObj( type );
-      fi;
+      MakeReadOnlyObj( type );
       UNLOCK( lock );
       return type;
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NEW_TYPE" );
- t_3 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
+ t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(223);
- ENDLINE_BODY(t_4) = INTOBJ_INT(284);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(207);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(296);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType2", function ( typeOfTypes, family )
-      return NEW_TYPE( typeOfTypes, family, family!.IMP_FLAGS, fail );
+      return NEW_TYPE( typeOfTypes, family, family!.IMP_FLAGS, fail, fail );
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType2" );
- t_3 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
+ t_3 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(287);
- ENDLINE_BODY(t_4) = INTOBJ_INT(292);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(299);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(304);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType3", function ( typeOfTypes, family, filter )
-      return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail );
+      return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail, fail );
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType3" );
- t_3 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
+ t_3 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(295);
- ENDLINE_BODY(t_4) = INTOBJ_INT(302);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(307);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(314);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType4", function ( typeOfTypes, family, filter, data )
-      return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data );
+      return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, fail );
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType4" );
- t_3 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
+ t_3 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(305);
- ENDLINE_BODY(t_4) = INTOBJ_INT(312);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(317);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(324);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType5", function ( typeOfTypes, family, filter, data, stuff )
-      local  type;
-      type := NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data );
-      type![POS_FIRST_FREE_TYPE] := stuff;
+      local  type, temp;
+      temp := [  ];
+      temp[POS_FIRST_FREE_TYPE] := stuff;
+      type := NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, temp );
       return type;
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType5" );
- t_3 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
+ t_3 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(316);
- ENDLINE_BODY(t_4) = INTOBJ_INT(327);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(328);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(339);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -4733,63 +4609,41 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "NewType" );
- t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
+ t_3 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(330);
- ENDLINE_BODY(t_4) = INTOBJ_INT(362);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(342);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(374);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Subtype2", function ( type, filter )
-      local  new, i, save_flag;
-      save_flag := VAL_GVAR( _NEW_TYPE_READONLY );
-      ASS_GVAR( _NEW_TYPE_READONLY, false );
-      new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![POS_DATA_TYPE] );
-      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ]  do
-          if IsBound( type![i]) and not IsBound( new![i])  then
-              new![i] := type![i];
-          fi;
-      od;
-      MakeReadOnlyObj( new );
-      ASS_GVAR( _NEW_TYPE_READONLY, save_flag );
-      return new;
+      return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![POS_DATA_TYPE], type );
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "Subtype2" );
- t_3 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
+ t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(375);
- ENDLINE_BODY(t_4) = INTOBJ_INT(393);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(387);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(394);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Subtype3", function ( type, filter, data )
-      local  new, i, save_flag;
-      save_flag := VAL_GVAR( _NEW_TYPE_READONLY );
-      ASS_GVAR( _NEW_TYPE_READONLY, false );
-      new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data );
-      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ]  do
-          if IsBound( type![i]) and not IsBound( new![i])  then
-              new![i] := type![i];
-          fi;
-      od;
-      MakeReadOnlyObj( new );
-      ASS_GVAR( _NEW_TYPE_READONLY, save_flag );
-      return new;
+      return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type );
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "Subtype3" );
- t_3 = NewFunction( NameFunc[19], NargFunc[19], NamsFunc[19], HdlrFunc19 );
+ t_3 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(396);
- ENDLINE_BODY(t_4) = INTOBJ_INT(414);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(397);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(404);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -4814,55 +4668,41 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "Subtype" );
- t_3 = NewFunction( NameFunc[20], NargFunc[20], NamsFunc[20], HdlrFunc20 );
+ t_3 = NewFunction( NameFunc[19], NargFunc[19], NamsFunc[19], HdlrFunc19 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(418);
- ENDLINE_BODY(t_4) = INTOBJ_INT(433);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(408);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(423);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType2", function ( type, filter )
-      local  new, i;
-      new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![POS_DATA_TYPE] );
-      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ]  do
-          if IsBound( type![i])  then
-              new![i] := type![i];
-          fi;
-      od;
-      return new;
+      return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![POS_DATA_TYPE], type );
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "SupType2" );
- t_3 = NewFunction( NameFunc[21], NargFunc[21], NamsFunc[21], HdlrFunc21 );
+ t_3 = NewFunction( NameFunc[20], NargFunc[20], NamsFunc[20], HdlrFunc20 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(447);
- ENDLINE_BODY(t_4) = INTOBJ_INT(461);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(437);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(444);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType3", function ( type, filter, data )
-      local  new, i;
-      new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data );
-      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ]  do
-          if IsBound( type![i])  then
-              new![i] := type![i];
-          fi;
-      od;
-      return new;
+      return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type );
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "SupType3" );
- t_3 = NewFunction( NameFunc[22], NargFunc[22], NamsFunc[22], HdlrFunc22 );
+ t_3 = NewFunction( NameFunc[21], NargFunc[21], NamsFunc[21], HdlrFunc21 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(464);
- ENDLINE_BODY(t_4) = INTOBJ_INT(478);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(447);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(454);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -4881,11 +4721,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "SupType" );
- t_3 = NewFunction( NameFunc[23], NargFunc[23], NamsFunc[23], HdlrFunc23 );
+ t_3 = NewFunction( NameFunc[22], NargFunc[22], NamsFunc[22], HdlrFunc22 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(481);
- ENDLINE_BODY(t_4) = INTOBJ_INT(495);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(457);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(471);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -4896,11 +4736,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "FamilyType" );
- t_3 = NewFunction( NameFunc[24], NargFunc[24], NamsFunc[24], HdlrFunc24 );
+ t_3 = NewFunction( NameFunc[23], NargFunc[23], NamsFunc[23], HdlrFunc23 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(509);
- ENDLINE_BODY(t_4) = INTOBJ_INT(509);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(485);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(485);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -4911,11 +4751,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "FlagsType" );
- t_3 = NewFunction( NameFunc[25], NargFunc[25], NamsFunc[25], HdlrFunc25 );
+ t_3 = NewFunction( NameFunc[24], NargFunc[24], NamsFunc[24], HdlrFunc24 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(523);
- ENDLINE_BODY(t_4) = INTOBJ_INT(523);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(499);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(499);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -4926,11 +4766,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "DataType" );
- t_3 = NewFunction( NameFunc[26], NargFunc[26], NamsFunc[26], HdlrFunc26 );
+ t_3 = NewFunction( NameFunc[25], NargFunc[25], NamsFunc[25], HdlrFunc25 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(539);
- ENDLINE_BODY(t_4) = INTOBJ_INT(539);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(515);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(515);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -4942,11 +4782,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 11, "SetDataType" );
- t_3 = NewFunction( NameFunc[27], NargFunc[27], NamsFunc[27], HdlrFunc27 );
+ t_3 = NewFunction( NameFunc[26], NargFunc[26], NamsFunc[26], HdlrFunc26 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(541);
- ENDLINE_BODY(t_4) = INTOBJ_INT(543);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(517);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(519);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -4957,11 +4797,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "SharedType" );
- t_3 = NewFunction( NameFunc[28], NargFunc[28], NamsFunc[28], HdlrFunc28 );
+ t_3 = NewFunction( NameFunc[27], NargFunc[27], NamsFunc[27], HdlrFunc27 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(557);
- ENDLINE_BODY(t_4) = INTOBJ_INT(557);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(533);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(533);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -4986,11 +4826,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "FlagsObj" );
- t_3 = NewFunction( NameFunc[29], NargFunc[29], NamsFunc[29], HdlrFunc29 );
+ t_3 = NewFunction( NameFunc[28], NargFunc[28], NamsFunc[28], HdlrFunc28 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(656);
- ENDLINE_BODY(t_4) = INTOBJ_INT(656);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(632);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(632);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -5001,11 +4841,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "DataObj" );
- t_3 = NewFunction( NameFunc[30], NargFunc[30], NamsFunc[30], HdlrFunc30 );
+ t_3 = NewFunction( NameFunc[29], NargFunc[29], NamsFunc[29], HdlrFunc29 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(670);
- ENDLINE_BODY(t_4) = INTOBJ_INT(670);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(646);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(646);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -5016,11 +4856,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "SharedObj" );
- t_3 = NewFunction( NameFunc[31], NargFunc[31], NamsFunc[31], HdlrFunc31 );
+ t_3 = NewFunction( NameFunc[30], NargFunc[30], NamsFunc[30], HdlrFunc30 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(684);
- ENDLINE_BODY(t_4) = INTOBJ_INT(684);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(660);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(660);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -5042,11 +4882,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "SetTypeObj" );
- t_3 = NewFunction( NameFunc[32], NargFunc[32], NamsFunc[32], HdlrFunc32 );
+ t_3 = NewFunction( NameFunc[31], NargFunc[31], NamsFunc[31], HdlrFunc31 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(698);
- ENDLINE_BODY(t_4) = INTOBJ_INT(711);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(674);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(687);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -5113,11 +4953,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "Objectify" );
- t_3 = NewFunction( NameFunc[33], NargFunc[33], NamsFunc[33], HdlrFunc33 );
+ t_3 = NewFunction( NameFunc[32], NargFunc[32], NamsFunc[32], HdlrFunc32 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(721);
- ENDLINE_BODY(t_4) = INTOBJ_INT(750);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(697);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(726);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -5141,11 +4981,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "ChangeTypeObj" );
- t_3 = NewFunction( NameFunc[34], NargFunc[34], NamsFunc[34], HdlrFunc34 );
+ t_3 = NewFunction( NameFunc[33], NargFunc[33], NamsFunc[33], HdlrFunc33 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(764);
- ENDLINE_BODY(t_4) = INTOBJ_INT(779);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(740);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(755);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -5199,11 +5039,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 12, "SetFilterObj" );
- t_3 = NewFunction( NameFunc[35], NargFunc[35], NamsFunc[35], HdlrFunc35 );
+ t_3 = NewFunction( NameFunc[34], NargFunc[34], NamsFunc[34], HdlrFunc34 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(803);
- ENDLINE_BODY(t_4) = INTOBJ_INT(841);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(779);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(817);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -5241,11 +5081,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 14, "ResetFilterObj" );
- t_3 = NewFunction( NameFunc[36], NargFunc[36], NamsFunc[36], HdlrFunc36 );
+ t_3 = NewFunction( NameFunc[35], NargFunc[35], NamsFunc[35], HdlrFunc35 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(863);
- ENDLINE_BODY(t_4) = INTOBJ_INT(885);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(839);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(861);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -5268,11 +5108,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "SetFeatureObj" );
- t_3 = NewFunction( NameFunc[37], NargFunc[37], NamsFunc[37], HdlrFunc37 );
+ t_3 = NewFunction( NameFunc[36], NargFunc[36], NamsFunc[36], HdlrFunc36 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(901);
- ENDLINE_BODY(t_4) = INTOBJ_INT(907);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(877);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(883);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -5321,11 +5161,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "SetMultipleAttributes" );
- t_3 = NewFunction( NameFunc[38], NargFunc[38], NamsFunc[38], HdlrFunc38 );
+ t_3 = NewFunction( NameFunc[37], NargFunc[37], NamsFunc[37], HdlrFunc37 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(928);
- ENDLINE_BODY(t_4) = INTOBJ_INT(980);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(904);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(956);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -5384,7 +5224,7 @@ static Obj  HdlrFunc1 (
           od;
           if not IS_SUBSET_FLAGS( flags, nflags )  then
               flags := WITH_IMPS_FLAGS( AND_FLAGS( flags, nflags ) );
-              Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ) ), obj );
+              Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ), fail ), obj );
           else
               Objectify( type, obj );
           fi;
@@ -5400,11 +5240,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 23, "ObjectifyWithAttributes" );
- t_3 = NewFunction( NameFunc[39], NargFunc[39], NamsFunc[39], HdlrFunc39 );
+ t_3 = NewFunction( NameFunc[38], NargFunc[38], NamsFunc[38], HdlrFunc38 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(1027);
- ENDLINE_BODY(t_4) = INTOBJ_INT(1092);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(1003);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(1068);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -5436,8 +5276,6 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "IS_RANGE", &GF_IS__RANGE );
  InitFopyGVar( "IS_STRING_REP", &GF_IS__STRING__REP );
  InitFopyGVar( "Error", &GF_Error );
- InitFopyGVar( "ASS_GVAR", &GF_ASS__GVAR );
- InitFopyGVar( "VAL_GVAR", &GF_VAL__GVAR );
  InitCopyGVar( "TYPE_OBJ", &GC_TYPE__OBJ );
  InitFopyGVar( "TYPE_OBJ", &GF_TYPE__OBJ );
  InitCopyGVar( "FAMILY_OBJ", &GC_FAMILY__OBJ );
@@ -5474,7 +5312,6 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "READ_LOCK", &GF_READ__LOCK );
  InitFopyGVar( "UNLOCK", &GF_UNLOCK );
  InitFopyGVar( "MIGRATE_RAW", &GF_MIGRATE__RAW );
- InitFopyGVar( "MakeThreadLocal", &GF_MakeThreadLocal );
  InitFopyGVar( "MakeReadOnly", &GF_MakeReadOnly );
  InitFopyGVar( "MakeReadOnlyObj", &GF_MakeReadOnlyObj );
  InitFopyGVar( "AtomicList", &GF_AtomicList );
@@ -5507,15 +5344,13 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "NewFamily5", &GF_NewFamily5 );
  InitCopyGVar( "NEW_TYPE_CACHE_MISS", &GC_NEW__TYPE__CACHE__MISS );
  InitCopyGVar( "NEW_TYPE_CACHE_HIT", &GC_NEW__TYPE__CACHE__HIT );
- InitFopyGVar( "MakeLiteral", &GF_MakeLiteral );
- InitCopyGVar( "_NEW_TYPE_READONLY", &GC___NEW__TYPE__READONLY );
  InitCopyGVar( "POS_DATA_TYPE", &GC_POS__DATA__TYPE );
+ InitCopyGVar( "POS_FIRST_FREE_TYPE", &GC_POS__FIRST__FREE__TYPE );
  InitCopyGVar( "NEW_TYPE_NEXT_ID", &GC_NEW__TYPE__NEXT__ID );
  InitCopyGVar( "NEW_TYPE_ID_LIMIT", &GC_NEW__TYPE__ID__LIMIT );
  InitFopyGVar( "FLUSH_ALL_METHOD_CACHES", &GF_FLUSH__ALL__METHOD__CACHES );
  InitCopyGVar( "POS_NUMB_TYPE", &GC_POS__NUMB__TYPE );
  InitFopyGVar( "NEW_TYPE", &GF_NEW__TYPE );
- InitCopyGVar( "POS_FIRST_FREE_TYPE", &GC_POS__FIRST__FREE__TYPE );
  InitFopyGVar( "IsFamily", &GF_IsFamily );
  InitFopyGVar( "NewType2", &GF_NewType2 );
  InitCopyGVar( "TypeOfTypes", &GC_TypeOfTypes );
@@ -5526,6 +5361,7 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "Subtype3", &GF_Subtype3 );
  InitFopyGVar( "SupType2", &GF_SupType2 );
  InitFopyGVar( "SupType3", &GF_SupType3 );
+ InitFopyGVar( "MakeLiteral", &GF_MakeLiteral );
  InitFopyGVar( "FlagsType", &GF_FlagsType );
  InitFopyGVar( "TypeObj", &GF_TypeObj );
  InitFopyGVar( "DataType", &GF_DataType );
@@ -5553,86 +5389,84 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "Objectify", &GF_Objectify );
  
  /* information for the functions */
- InitGlobalBag( &DefaultName, "GAPROOT/lib/type1.g:DefaultName(100336508)" );
- InitGlobalBag( &FileName, "GAPROOT/lib/type1.g:FileName(100336508)" );
- InitHandlerFunc( HdlrFunc1, "GAPROOT/lib/type1.g:HdlrFunc1(100336508)" );
- InitGlobalBag( &(NameFunc[1]), "GAPROOT/lib/type1.g:NameFunc[1](100336508)" );
- InitHandlerFunc( HdlrFunc2, "GAPROOT/lib/type1.g:HdlrFunc2(100336508)" );
- InitGlobalBag( &(NameFunc[2]), "GAPROOT/lib/type1.g:NameFunc[2](100336508)" );
- InitHandlerFunc( HdlrFunc3, "GAPROOT/lib/type1.g:HdlrFunc3(100336508)" );
- InitGlobalBag( &(NameFunc[3]), "GAPROOT/lib/type1.g:NameFunc[3](100336508)" );
- InitHandlerFunc( HdlrFunc4, "GAPROOT/lib/type1.g:HdlrFunc4(100336508)" );
- InitGlobalBag( &(NameFunc[4]), "GAPROOT/lib/type1.g:NameFunc[4](100336508)" );
- InitHandlerFunc( HdlrFunc5, "GAPROOT/lib/type1.g:HdlrFunc5(100336508)" );
- InitGlobalBag( &(NameFunc[5]), "GAPROOT/lib/type1.g:NameFunc[5](100336508)" );
- InitHandlerFunc( HdlrFunc6, "GAPROOT/lib/type1.g:HdlrFunc6(100336508)" );
- InitGlobalBag( &(NameFunc[6]), "GAPROOT/lib/type1.g:NameFunc[6](100336508)" );
- InitHandlerFunc( HdlrFunc7, "GAPROOT/lib/type1.g:HdlrFunc7(100336508)" );
- InitGlobalBag( &(NameFunc[7]), "GAPROOT/lib/type1.g:NameFunc[7](100336508)" );
- InitHandlerFunc( HdlrFunc8, "GAPROOT/lib/type1.g:HdlrFunc8(100336508)" );
- InitGlobalBag( &(NameFunc[8]), "GAPROOT/lib/type1.g:NameFunc[8](100336508)" );
- InitHandlerFunc( HdlrFunc9, "GAPROOT/lib/type1.g:HdlrFunc9(100336508)" );
- InitGlobalBag( &(NameFunc[9]), "GAPROOT/lib/type1.g:NameFunc[9](100336508)" );
- InitHandlerFunc( HdlrFunc10, "GAPROOT/lib/type1.g:HdlrFunc10(100336508)" );
- InitGlobalBag( &(NameFunc[10]), "GAPROOT/lib/type1.g:NameFunc[10](100336508)" );
- InitHandlerFunc( HdlrFunc11, "GAPROOT/lib/type1.g:HdlrFunc11(100336508)" );
- InitGlobalBag( &(NameFunc[11]), "GAPROOT/lib/type1.g:NameFunc[11](100336508)" );
- InitHandlerFunc( HdlrFunc12, "GAPROOT/lib/type1.g:HdlrFunc12(100336508)" );
- InitGlobalBag( &(NameFunc[12]), "GAPROOT/lib/type1.g:NameFunc[12](100336508)" );
- InitHandlerFunc( HdlrFunc13, "GAPROOT/lib/type1.g:HdlrFunc13(100336508)" );
- InitGlobalBag( &(NameFunc[13]), "GAPROOT/lib/type1.g:NameFunc[13](100336508)" );
- InitHandlerFunc( HdlrFunc14, "GAPROOT/lib/type1.g:HdlrFunc14(100336508)" );
- InitGlobalBag( &(NameFunc[14]), "GAPROOT/lib/type1.g:NameFunc[14](100336508)" );
- InitHandlerFunc( HdlrFunc15, "GAPROOT/lib/type1.g:HdlrFunc15(100336508)" );
- InitGlobalBag( &(NameFunc[15]), "GAPROOT/lib/type1.g:NameFunc[15](100336508)" );
- InitHandlerFunc( HdlrFunc16, "GAPROOT/lib/type1.g:HdlrFunc16(100336508)" );
- InitGlobalBag( &(NameFunc[16]), "GAPROOT/lib/type1.g:NameFunc[16](100336508)" );
- InitHandlerFunc( HdlrFunc17, "GAPROOT/lib/type1.g:HdlrFunc17(100336508)" );
- InitGlobalBag( &(NameFunc[17]), "GAPROOT/lib/type1.g:NameFunc[17](100336508)" );
- InitHandlerFunc( HdlrFunc18, "GAPROOT/lib/type1.g:HdlrFunc18(100336508)" );
- InitGlobalBag( &(NameFunc[18]), "GAPROOT/lib/type1.g:NameFunc[18](100336508)" );
- InitHandlerFunc( HdlrFunc19, "GAPROOT/lib/type1.g:HdlrFunc19(100336508)" );
- InitGlobalBag( &(NameFunc[19]), "GAPROOT/lib/type1.g:NameFunc[19](100336508)" );
- InitHandlerFunc( HdlrFunc20, "GAPROOT/lib/type1.g:HdlrFunc20(100336508)" );
- InitGlobalBag( &(NameFunc[20]), "GAPROOT/lib/type1.g:NameFunc[20](100336508)" );
- InitHandlerFunc( HdlrFunc21, "GAPROOT/lib/type1.g:HdlrFunc21(100336508)" );
- InitGlobalBag( &(NameFunc[21]), "GAPROOT/lib/type1.g:NameFunc[21](100336508)" );
- InitHandlerFunc( HdlrFunc22, "GAPROOT/lib/type1.g:HdlrFunc22(100336508)" );
- InitGlobalBag( &(NameFunc[22]), "GAPROOT/lib/type1.g:NameFunc[22](100336508)" );
- InitHandlerFunc( HdlrFunc23, "GAPROOT/lib/type1.g:HdlrFunc23(100336508)" );
- InitGlobalBag( &(NameFunc[23]), "GAPROOT/lib/type1.g:NameFunc[23](100336508)" );
- InitHandlerFunc( HdlrFunc24, "GAPROOT/lib/type1.g:HdlrFunc24(100336508)" );
- InitGlobalBag( &(NameFunc[24]), "GAPROOT/lib/type1.g:NameFunc[24](100336508)" );
- InitHandlerFunc( HdlrFunc25, "GAPROOT/lib/type1.g:HdlrFunc25(100336508)" );
- InitGlobalBag( &(NameFunc[25]), "GAPROOT/lib/type1.g:NameFunc[25](100336508)" );
- InitHandlerFunc( HdlrFunc26, "GAPROOT/lib/type1.g:HdlrFunc26(100336508)" );
- InitGlobalBag( &(NameFunc[26]), "GAPROOT/lib/type1.g:NameFunc[26](100336508)" );
- InitHandlerFunc( HdlrFunc27, "GAPROOT/lib/type1.g:HdlrFunc27(100336508)" );
- InitGlobalBag( &(NameFunc[27]), "GAPROOT/lib/type1.g:NameFunc[27](100336508)" );
- InitHandlerFunc( HdlrFunc28, "GAPROOT/lib/type1.g:HdlrFunc28(100336508)" );
- InitGlobalBag( &(NameFunc[28]), "GAPROOT/lib/type1.g:NameFunc[28](100336508)" );
- InitHandlerFunc( HdlrFunc29, "GAPROOT/lib/type1.g:HdlrFunc29(100336508)" );
- InitGlobalBag( &(NameFunc[29]), "GAPROOT/lib/type1.g:NameFunc[29](100336508)" );
- InitHandlerFunc( HdlrFunc30, "GAPROOT/lib/type1.g:HdlrFunc30(100336508)" );
- InitGlobalBag( &(NameFunc[30]), "GAPROOT/lib/type1.g:NameFunc[30](100336508)" );
- InitHandlerFunc( HdlrFunc31, "GAPROOT/lib/type1.g:HdlrFunc31(100336508)" );
- InitGlobalBag( &(NameFunc[31]), "GAPROOT/lib/type1.g:NameFunc[31](100336508)" );
- InitHandlerFunc( HdlrFunc32, "GAPROOT/lib/type1.g:HdlrFunc32(100336508)" );
- InitGlobalBag( &(NameFunc[32]), "GAPROOT/lib/type1.g:NameFunc[32](100336508)" );
- InitHandlerFunc( HdlrFunc33, "GAPROOT/lib/type1.g:HdlrFunc33(100336508)" );
- InitGlobalBag( &(NameFunc[33]), "GAPROOT/lib/type1.g:NameFunc[33](100336508)" );
- InitHandlerFunc( HdlrFunc34, "GAPROOT/lib/type1.g:HdlrFunc34(100336508)" );
- InitGlobalBag( &(NameFunc[34]), "GAPROOT/lib/type1.g:NameFunc[34](100336508)" );
- InitHandlerFunc( HdlrFunc35, "GAPROOT/lib/type1.g:HdlrFunc35(100336508)" );
- InitGlobalBag( &(NameFunc[35]), "GAPROOT/lib/type1.g:NameFunc[35](100336508)" );
- InitHandlerFunc( HdlrFunc36, "GAPROOT/lib/type1.g:HdlrFunc36(100336508)" );
- InitGlobalBag( &(NameFunc[36]), "GAPROOT/lib/type1.g:NameFunc[36](100336508)" );
- InitHandlerFunc( HdlrFunc37, "GAPROOT/lib/type1.g:HdlrFunc37(100336508)" );
- InitGlobalBag( &(NameFunc[37]), "GAPROOT/lib/type1.g:NameFunc[37](100336508)" );
- InitHandlerFunc( HdlrFunc38, "GAPROOT/lib/type1.g:HdlrFunc38(100336508)" );
- InitGlobalBag( &(NameFunc[38]), "GAPROOT/lib/type1.g:NameFunc[38](100336508)" );
- InitHandlerFunc( HdlrFunc39, "GAPROOT/lib/type1.g:HdlrFunc39(100336508)" );
- InitGlobalBag( &(NameFunc[39]), "GAPROOT/lib/type1.g:NameFunc[39](100336508)" );
+ InitGlobalBag( &DefaultName, "GAPROOT/lib/type1.g:DefaultName(-65342784)" );
+ InitGlobalBag( &FileName, "GAPROOT/lib/type1.g:FileName(-65342784)" );
+ InitHandlerFunc( HdlrFunc1, "GAPROOT/lib/type1.g:HdlrFunc1(-65342784)" );
+ InitGlobalBag( &(NameFunc[1]), "GAPROOT/lib/type1.g:NameFunc[1](-65342784)" );
+ InitHandlerFunc( HdlrFunc2, "GAPROOT/lib/type1.g:HdlrFunc2(-65342784)" );
+ InitGlobalBag( &(NameFunc[2]), "GAPROOT/lib/type1.g:NameFunc[2](-65342784)" );
+ InitHandlerFunc( HdlrFunc3, "GAPROOT/lib/type1.g:HdlrFunc3(-65342784)" );
+ InitGlobalBag( &(NameFunc[3]), "GAPROOT/lib/type1.g:NameFunc[3](-65342784)" );
+ InitHandlerFunc( HdlrFunc4, "GAPROOT/lib/type1.g:HdlrFunc4(-65342784)" );
+ InitGlobalBag( &(NameFunc[4]), "GAPROOT/lib/type1.g:NameFunc[4](-65342784)" );
+ InitHandlerFunc( HdlrFunc5, "GAPROOT/lib/type1.g:HdlrFunc5(-65342784)" );
+ InitGlobalBag( &(NameFunc[5]), "GAPROOT/lib/type1.g:NameFunc[5](-65342784)" );
+ InitHandlerFunc( HdlrFunc6, "GAPROOT/lib/type1.g:HdlrFunc6(-65342784)" );
+ InitGlobalBag( &(NameFunc[6]), "GAPROOT/lib/type1.g:NameFunc[6](-65342784)" );
+ InitHandlerFunc( HdlrFunc7, "GAPROOT/lib/type1.g:HdlrFunc7(-65342784)" );
+ InitGlobalBag( &(NameFunc[7]), "GAPROOT/lib/type1.g:NameFunc[7](-65342784)" );
+ InitHandlerFunc( HdlrFunc8, "GAPROOT/lib/type1.g:HdlrFunc8(-65342784)" );
+ InitGlobalBag( &(NameFunc[8]), "GAPROOT/lib/type1.g:NameFunc[8](-65342784)" );
+ InitHandlerFunc( HdlrFunc9, "GAPROOT/lib/type1.g:HdlrFunc9(-65342784)" );
+ InitGlobalBag( &(NameFunc[9]), "GAPROOT/lib/type1.g:NameFunc[9](-65342784)" );
+ InitHandlerFunc( HdlrFunc10, "GAPROOT/lib/type1.g:HdlrFunc10(-65342784)" );
+ InitGlobalBag( &(NameFunc[10]), "GAPROOT/lib/type1.g:NameFunc[10](-65342784)" );
+ InitHandlerFunc( HdlrFunc11, "GAPROOT/lib/type1.g:HdlrFunc11(-65342784)" );
+ InitGlobalBag( &(NameFunc[11]), "GAPROOT/lib/type1.g:NameFunc[11](-65342784)" );
+ InitHandlerFunc( HdlrFunc12, "GAPROOT/lib/type1.g:HdlrFunc12(-65342784)" );
+ InitGlobalBag( &(NameFunc[12]), "GAPROOT/lib/type1.g:NameFunc[12](-65342784)" );
+ InitHandlerFunc( HdlrFunc13, "GAPROOT/lib/type1.g:HdlrFunc13(-65342784)" );
+ InitGlobalBag( &(NameFunc[13]), "GAPROOT/lib/type1.g:NameFunc[13](-65342784)" );
+ InitHandlerFunc( HdlrFunc14, "GAPROOT/lib/type1.g:HdlrFunc14(-65342784)" );
+ InitGlobalBag( &(NameFunc[14]), "GAPROOT/lib/type1.g:NameFunc[14](-65342784)" );
+ InitHandlerFunc( HdlrFunc15, "GAPROOT/lib/type1.g:HdlrFunc15(-65342784)" );
+ InitGlobalBag( &(NameFunc[15]), "GAPROOT/lib/type1.g:NameFunc[15](-65342784)" );
+ InitHandlerFunc( HdlrFunc16, "GAPROOT/lib/type1.g:HdlrFunc16(-65342784)" );
+ InitGlobalBag( &(NameFunc[16]), "GAPROOT/lib/type1.g:NameFunc[16](-65342784)" );
+ InitHandlerFunc( HdlrFunc17, "GAPROOT/lib/type1.g:HdlrFunc17(-65342784)" );
+ InitGlobalBag( &(NameFunc[17]), "GAPROOT/lib/type1.g:NameFunc[17](-65342784)" );
+ InitHandlerFunc( HdlrFunc18, "GAPROOT/lib/type1.g:HdlrFunc18(-65342784)" );
+ InitGlobalBag( &(NameFunc[18]), "GAPROOT/lib/type1.g:NameFunc[18](-65342784)" );
+ InitHandlerFunc( HdlrFunc19, "GAPROOT/lib/type1.g:HdlrFunc19(-65342784)" );
+ InitGlobalBag( &(NameFunc[19]), "GAPROOT/lib/type1.g:NameFunc[19](-65342784)" );
+ InitHandlerFunc( HdlrFunc20, "GAPROOT/lib/type1.g:HdlrFunc20(-65342784)" );
+ InitGlobalBag( &(NameFunc[20]), "GAPROOT/lib/type1.g:NameFunc[20](-65342784)" );
+ InitHandlerFunc( HdlrFunc21, "GAPROOT/lib/type1.g:HdlrFunc21(-65342784)" );
+ InitGlobalBag( &(NameFunc[21]), "GAPROOT/lib/type1.g:NameFunc[21](-65342784)" );
+ InitHandlerFunc( HdlrFunc22, "GAPROOT/lib/type1.g:HdlrFunc22(-65342784)" );
+ InitGlobalBag( &(NameFunc[22]), "GAPROOT/lib/type1.g:NameFunc[22](-65342784)" );
+ InitHandlerFunc( HdlrFunc23, "GAPROOT/lib/type1.g:HdlrFunc23(-65342784)" );
+ InitGlobalBag( &(NameFunc[23]), "GAPROOT/lib/type1.g:NameFunc[23](-65342784)" );
+ InitHandlerFunc( HdlrFunc24, "GAPROOT/lib/type1.g:HdlrFunc24(-65342784)" );
+ InitGlobalBag( &(NameFunc[24]), "GAPROOT/lib/type1.g:NameFunc[24](-65342784)" );
+ InitHandlerFunc( HdlrFunc25, "GAPROOT/lib/type1.g:HdlrFunc25(-65342784)" );
+ InitGlobalBag( &(NameFunc[25]), "GAPROOT/lib/type1.g:NameFunc[25](-65342784)" );
+ InitHandlerFunc( HdlrFunc26, "GAPROOT/lib/type1.g:HdlrFunc26(-65342784)" );
+ InitGlobalBag( &(NameFunc[26]), "GAPROOT/lib/type1.g:NameFunc[26](-65342784)" );
+ InitHandlerFunc( HdlrFunc27, "GAPROOT/lib/type1.g:HdlrFunc27(-65342784)" );
+ InitGlobalBag( &(NameFunc[27]), "GAPROOT/lib/type1.g:NameFunc[27](-65342784)" );
+ InitHandlerFunc( HdlrFunc28, "GAPROOT/lib/type1.g:HdlrFunc28(-65342784)" );
+ InitGlobalBag( &(NameFunc[28]), "GAPROOT/lib/type1.g:NameFunc[28](-65342784)" );
+ InitHandlerFunc( HdlrFunc29, "GAPROOT/lib/type1.g:HdlrFunc29(-65342784)" );
+ InitGlobalBag( &(NameFunc[29]), "GAPROOT/lib/type1.g:NameFunc[29](-65342784)" );
+ InitHandlerFunc( HdlrFunc30, "GAPROOT/lib/type1.g:HdlrFunc30(-65342784)" );
+ InitGlobalBag( &(NameFunc[30]), "GAPROOT/lib/type1.g:NameFunc[30](-65342784)" );
+ InitHandlerFunc( HdlrFunc31, "GAPROOT/lib/type1.g:HdlrFunc31(-65342784)" );
+ InitGlobalBag( &(NameFunc[31]), "GAPROOT/lib/type1.g:NameFunc[31](-65342784)" );
+ InitHandlerFunc( HdlrFunc32, "GAPROOT/lib/type1.g:HdlrFunc32(-65342784)" );
+ InitGlobalBag( &(NameFunc[32]), "GAPROOT/lib/type1.g:NameFunc[32](-65342784)" );
+ InitHandlerFunc( HdlrFunc33, "GAPROOT/lib/type1.g:HdlrFunc33(-65342784)" );
+ InitGlobalBag( &(NameFunc[33]), "GAPROOT/lib/type1.g:NameFunc[33](-65342784)" );
+ InitHandlerFunc( HdlrFunc34, "GAPROOT/lib/type1.g:HdlrFunc34(-65342784)" );
+ InitGlobalBag( &(NameFunc[34]), "GAPROOT/lib/type1.g:NameFunc[34](-65342784)" );
+ InitHandlerFunc( HdlrFunc35, "GAPROOT/lib/type1.g:HdlrFunc35(-65342784)" );
+ InitGlobalBag( &(NameFunc[35]), "GAPROOT/lib/type1.g:NameFunc[35](-65342784)" );
+ InitHandlerFunc( HdlrFunc36, "GAPROOT/lib/type1.g:HdlrFunc36(-65342784)" );
+ InitGlobalBag( &(NameFunc[36]), "GAPROOT/lib/type1.g:NameFunc[36](-65342784)" );
+ InitHandlerFunc( HdlrFunc37, "GAPROOT/lib/type1.g:HdlrFunc37(-65342784)" );
+ InitGlobalBag( &(NameFunc[37]), "GAPROOT/lib/type1.g:NameFunc[37](-65342784)" );
+ InitHandlerFunc( HdlrFunc38, "GAPROOT/lib/type1.g:HdlrFunc38(-65342784)" );
+ InitGlobalBag( &(NameFunc[38]), "GAPROOT/lib/type1.g:NameFunc[38](-65342784)" );
  
  /* return success */
  return 0;
@@ -5659,8 +5493,6 @@ static Int InitLibrary ( StructInitInfo * module )
  G_IS__RANGE = GVarName( "IS_RANGE" );
  G_IS__STRING__REP = GVarName( "IS_STRING_REP" );
  G_Error = GVarName( "Error" );
- G_ASS__GVAR = GVarName( "ASS_GVAR" );
- G_VAL__GVAR = GVarName( "VAL_GVAR" );
  G_TYPE__OBJ = GVarName( "TYPE_OBJ" );
  G_FAMILY__OBJ = GVarName( "FAMILY_OBJ" );
  G_IMMUTABLE__COPY__OBJ = GVarName( "IMMUTABLE_COPY_OBJ" );
@@ -5696,7 +5528,6 @@ static Int InitLibrary ( StructInitInfo * module )
  G_READ__LOCK = GVarName( "READ_LOCK" );
  G_UNLOCK = GVarName( "UNLOCK" );
  G_MIGRATE__RAW = GVarName( "MIGRATE_RAW" );
- G_MakeThreadLocal = GVarName( "MakeThreadLocal" );
  G_MakeReadOnly = GVarName( "MakeReadOnly" );
  G_MakeReadOnlyObj = GVarName( "MakeReadOnlyObj" );
  G_AtomicList = GVarName( "AtomicList" );
@@ -5727,15 +5558,13 @@ static Int InitLibrary ( StructInitInfo * module )
  G_NewFamily5 = GVarName( "NewFamily5" );
  G_NEW__TYPE__CACHE__MISS = GVarName( "NEW_TYPE_CACHE_MISS" );
  G_NEW__TYPE__CACHE__HIT = GVarName( "NEW_TYPE_CACHE_HIT" );
- G_MakeLiteral = GVarName( "MakeLiteral" );
- G___NEW__TYPE__READONLY = GVarName( "_NEW_TYPE_READONLY" );
  G_POS__DATA__TYPE = GVarName( "POS_DATA_TYPE" );
+ G_POS__FIRST__FREE__TYPE = GVarName( "POS_FIRST_FREE_TYPE" );
  G_NEW__TYPE__NEXT__ID = GVarName( "NEW_TYPE_NEXT_ID" );
  G_NEW__TYPE__ID__LIMIT = GVarName( "NEW_TYPE_ID_LIMIT" );
  G_FLUSH__ALL__METHOD__CACHES = GVarName( "FLUSH_ALL_METHOD_CACHES" );
  G_POS__NUMB__TYPE = GVarName( "POS_NUMB_TYPE" );
  G_NEW__TYPE = GVarName( "NEW_TYPE" );
- G_POS__FIRST__FREE__TYPE = GVarName( "POS_FIRST_FREE_TYPE" );
  G_IsFamily = GVarName( "IsFamily" );
  G_NewType2 = GVarName( "NewType2" );
  G_TypeOfTypes = GVarName( "TypeOfTypes" );
@@ -5746,6 +5575,7 @@ static Int InitLibrary ( StructInitInfo * module )
  G_Subtype3 = GVarName( "Subtype3" );
  G_SupType2 = GVarName( "SupType2" );
  G_SupType3 = GVarName( "SupType3" );
+ G_MakeLiteral = GVarName( "MakeLiteral" );
  G_FlagsType = GVarName( "FlagsType" );
  G_TypeObj = GVarName( "TypeObj" );
  G_DataType = GVarName( "DataType" );
@@ -5813,43 +5643,43 @@ static Int InitLibrary ( StructInitInfo * module )
  NargFunc[10] = -1;
  NameFunc[11] = DefaultName;
  NamsFunc[11] = 0;
- NargFunc[11] = 1;
+ NargFunc[11] = 5;
  NameFunc[12] = DefaultName;
  NamsFunc[12] = 0;
- NargFunc[12] = 4;
+ NargFunc[12] = 2;
  NameFunc[13] = DefaultName;
  NamsFunc[13] = 0;
- NargFunc[13] = 2;
+ NargFunc[13] = 3;
  NameFunc[14] = DefaultName;
  NamsFunc[14] = 0;
- NargFunc[14] = 3;
+ NargFunc[14] = 4;
  NameFunc[15] = DefaultName;
  NamsFunc[15] = 0;
- NargFunc[15] = 4;
+ NargFunc[15] = 5;
  NameFunc[16] = DefaultName;
  NamsFunc[16] = 0;
- NargFunc[16] = 5;
+ NargFunc[16] = -1;
  NameFunc[17] = DefaultName;
  NamsFunc[17] = 0;
- NargFunc[17] = -1;
+ NargFunc[17] = 2;
  NameFunc[18] = DefaultName;
  NamsFunc[18] = 0;
- NargFunc[18] = 2;
+ NargFunc[18] = 3;
  NameFunc[19] = DefaultName;
  NamsFunc[19] = 0;
- NargFunc[19] = 3;
+ NargFunc[19] = -1;
  NameFunc[20] = DefaultName;
  NamsFunc[20] = 0;
- NargFunc[20] = -1;
+ NargFunc[20] = 2;
  NameFunc[21] = DefaultName;
  NamsFunc[21] = 0;
- NargFunc[21] = 2;
+ NargFunc[21] = 3;
  NameFunc[22] = DefaultName;
  NamsFunc[22] = 0;
- NargFunc[22] = 3;
+ NargFunc[22] = -1;
  NameFunc[23] = DefaultName;
  NamsFunc[23] = 0;
- NargFunc[23] = -1;
+ NargFunc[23] = 1;
  NameFunc[24] = DefaultName;
  NamsFunc[24] = 0;
  NargFunc[24] = 1;
@@ -5858,10 +5688,10 @@ static Int InitLibrary ( StructInitInfo * module )
  NargFunc[25] = 1;
  NameFunc[26] = DefaultName;
  NamsFunc[26] = 0;
- NargFunc[26] = 1;
+ NargFunc[26] = 2;
  NameFunc[27] = DefaultName;
  NamsFunc[27] = 0;
- NargFunc[27] = 2;
+ NargFunc[27] = 1;
  NameFunc[28] = DefaultName;
  NamsFunc[28] = 0;
  NargFunc[28] = 1;
@@ -5873,7 +5703,7 @@ static Int InitLibrary ( StructInitInfo * module )
  NargFunc[30] = 1;
  NameFunc[31] = DefaultName;
  NamsFunc[31] = 0;
- NargFunc[31] = 1;
+ NargFunc[31] = 2;
  NameFunc[32] = DefaultName;
  NamsFunc[32] = 0;
  NargFunc[32] = 2;
@@ -5888,16 +5718,13 @@ static Int InitLibrary ( StructInitInfo * module )
  NargFunc[35] = 2;
  NameFunc[36] = DefaultName;
  NamsFunc[36] = 0;
- NargFunc[36] = 2;
+ NargFunc[36] = 3;
  NameFunc[37] = DefaultName;
  NamsFunc[37] = 0;
- NargFunc[37] = 3;
+ NargFunc[37] = -1;
  NameFunc[38] = DefaultName;
  NamsFunc[38] = 0;
  NargFunc[38] = -1;
- NameFunc[39] = DefaultName;
- NamsFunc[39] = 0;
- NargFunc[39] = -1;
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
@@ -5928,8 +5755,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_IS__RANGE = GVarName( "IS_RANGE" );
  G_IS__STRING__REP = GVarName( "IS_STRING_REP" );
  G_Error = GVarName( "Error" );
- G_ASS__GVAR = GVarName( "ASS_GVAR" );
- G_VAL__GVAR = GVarName( "VAL_GVAR" );
  G_TYPE__OBJ = GVarName( "TYPE_OBJ" );
  G_FAMILY__OBJ = GVarName( "FAMILY_OBJ" );
  G_IMMUTABLE__COPY__OBJ = GVarName( "IMMUTABLE_COPY_OBJ" );
@@ -5965,7 +5790,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_READ__LOCK = GVarName( "READ_LOCK" );
  G_UNLOCK = GVarName( "UNLOCK" );
  G_MIGRATE__RAW = GVarName( "MIGRATE_RAW" );
- G_MakeThreadLocal = GVarName( "MakeThreadLocal" );
  G_MakeReadOnly = GVarName( "MakeReadOnly" );
  G_MakeReadOnlyObj = GVarName( "MakeReadOnlyObj" );
  G_AtomicList = GVarName( "AtomicList" );
@@ -5996,15 +5820,13 @@ static Int PostRestore ( StructInitInfo * module )
  G_NewFamily5 = GVarName( "NewFamily5" );
  G_NEW__TYPE__CACHE__MISS = GVarName( "NEW_TYPE_CACHE_MISS" );
  G_NEW__TYPE__CACHE__HIT = GVarName( "NEW_TYPE_CACHE_HIT" );
- G_MakeLiteral = GVarName( "MakeLiteral" );
- G___NEW__TYPE__READONLY = GVarName( "_NEW_TYPE_READONLY" );
  G_POS__DATA__TYPE = GVarName( "POS_DATA_TYPE" );
+ G_POS__FIRST__FREE__TYPE = GVarName( "POS_FIRST_FREE_TYPE" );
  G_NEW__TYPE__NEXT__ID = GVarName( "NEW_TYPE_NEXT_ID" );
  G_NEW__TYPE__ID__LIMIT = GVarName( "NEW_TYPE_ID_LIMIT" );
  G_FLUSH__ALL__METHOD__CACHES = GVarName( "FLUSH_ALL_METHOD_CACHES" );
  G_POS__NUMB__TYPE = GVarName( "POS_NUMB_TYPE" );
  G_NEW__TYPE = GVarName( "NEW_TYPE" );
- G_POS__FIRST__FREE__TYPE = GVarName( "POS_FIRST_FREE_TYPE" );
  G_IsFamily = GVarName( "IsFamily" );
  G_NewType2 = GVarName( "NewType2" );
  G_TypeOfTypes = GVarName( "TypeOfTypes" );
@@ -6015,6 +5837,7 @@ static Int PostRestore ( StructInitInfo * module )
  G_Subtype3 = GVarName( "Subtype3" );
  G_SupType2 = GVarName( "SupType2" );
  G_SupType3 = GVarName( "SupType3" );
+ G_MakeLiteral = GVarName( "MakeLiteral" );
  G_FlagsType = GVarName( "FlagsType" );
  G_TypeObj = GVarName( "TypeObj" );
  G_DataType = GVarName( "DataType" );
@@ -6080,43 +5903,43 @@ static Int PostRestore ( StructInitInfo * module )
  NargFunc[10] = -1;
  NameFunc[11] = DefaultName;
  NamsFunc[11] = 0;
- NargFunc[11] = 1;
+ NargFunc[11] = 5;
  NameFunc[12] = DefaultName;
  NamsFunc[12] = 0;
- NargFunc[12] = 4;
+ NargFunc[12] = 2;
  NameFunc[13] = DefaultName;
  NamsFunc[13] = 0;
- NargFunc[13] = 2;
+ NargFunc[13] = 3;
  NameFunc[14] = DefaultName;
  NamsFunc[14] = 0;
- NargFunc[14] = 3;
+ NargFunc[14] = 4;
  NameFunc[15] = DefaultName;
  NamsFunc[15] = 0;
- NargFunc[15] = 4;
+ NargFunc[15] = 5;
  NameFunc[16] = DefaultName;
  NamsFunc[16] = 0;
- NargFunc[16] = 5;
+ NargFunc[16] = -1;
  NameFunc[17] = DefaultName;
  NamsFunc[17] = 0;
- NargFunc[17] = -1;
+ NargFunc[17] = 2;
  NameFunc[18] = DefaultName;
  NamsFunc[18] = 0;
- NargFunc[18] = 2;
+ NargFunc[18] = 3;
  NameFunc[19] = DefaultName;
  NamsFunc[19] = 0;
- NargFunc[19] = 3;
+ NargFunc[19] = -1;
  NameFunc[20] = DefaultName;
  NamsFunc[20] = 0;
- NargFunc[20] = -1;
+ NargFunc[20] = 2;
  NameFunc[21] = DefaultName;
  NamsFunc[21] = 0;
- NargFunc[21] = 2;
+ NargFunc[21] = 3;
  NameFunc[22] = DefaultName;
  NamsFunc[22] = 0;
- NargFunc[22] = 3;
+ NargFunc[22] = -1;
  NameFunc[23] = DefaultName;
  NamsFunc[23] = 0;
- NargFunc[23] = -1;
+ NargFunc[23] = 1;
  NameFunc[24] = DefaultName;
  NamsFunc[24] = 0;
  NargFunc[24] = 1;
@@ -6125,10 +5948,10 @@ static Int PostRestore ( StructInitInfo * module )
  NargFunc[25] = 1;
  NameFunc[26] = DefaultName;
  NamsFunc[26] = 0;
- NargFunc[26] = 1;
+ NargFunc[26] = 2;
  NameFunc[27] = DefaultName;
  NamsFunc[27] = 0;
- NargFunc[27] = 2;
+ NargFunc[27] = 1;
  NameFunc[28] = DefaultName;
  NamsFunc[28] = 0;
  NargFunc[28] = 1;
@@ -6140,7 +5963,7 @@ static Int PostRestore ( StructInitInfo * module )
  NargFunc[30] = 1;
  NameFunc[31] = DefaultName;
  NamsFunc[31] = 0;
- NargFunc[31] = 1;
+ NargFunc[31] = 2;
  NameFunc[32] = DefaultName;
  NamsFunc[32] = 0;
  NargFunc[32] = 2;
@@ -6155,16 +5978,13 @@ static Int PostRestore ( StructInitInfo * module )
  NargFunc[35] = 2;
  NameFunc[36] = DefaultName;
  NamsFunc[36] = 0;
- NargFunc[36] = 2;
+ NargFunc[36] = 3;
  NameFunc[37] = DefaultName;
  NamsFunc[37] = 0;
- NargFunc[37] = 3;
+ NargFunc[37] = -1;
  NameFunc[38] = DefaultName;
  NamsFunc[38] = 0;
  NargFunc[38] = -1;
- NameFunc[39] = DefaultName;
- NamsFunc[39] = 0;
- NargFunc[39] = -1;
  
  /* return success */
  return 0;
@@ -6179,7 +5999,7 @@ static StructInitInfo module = {
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,
  /* version     = */ 0,
- /* crc         = */ 100336508,
+ /* crc         = */ -65342784,
  /* initKernel  = */ InitKernel,
  /* initLibrary = */ InitLibrary,
  /* checkInit   = */ 0,


### PR DESCRIPTION
This PR is yet another attempt to tweak `NEW_TYPE` in HPC-GAP, see #291 and  #295. It builds on both of these, but also gets rid of the last traces of `_NEW_TYPE_READONLY`, and implements another approach towards handling data from parent objects when using cached types.

However, I suspect the last part, may not be necessary at all; i.e. with this patch, I believe all library types will have at most 5 members set, and in particular, none in position `POS_FIRST_FREE_TYPE` and beyond.

I actually tried to verify that, but it turns out there are various types for which `LEN_POSOBJ` returns 6 or 16. Those of length 16 seem traced back to `TypeOfFamilies` -- its length was reported as 16 because it is created as an AtomicList. I changed it to use `MakeReadOnly` instead, and also called that on `TypeOfTypes`, making the code in `type.g` a bit more uniform. However, I am not completely whether this breaks anything. At least `make testinstall` does still pass, but that doesn't mean much...

Anyway: This leaves types of length 6; but really, of those only 4 seem to be bound. I am not sure where that comes from. Any suggestions?

Overall, I still hope that all type objects have at most 4 bound members -- then we could get rid of the whole `parent` feature. I guess we need to carefully check packages for this, though, they might be using this. But if they do, they are doing it badly, by not using `POS_FIRST_FREE_TYPE`.