### PR TITLE
Add CallWithTimeout and related.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -128,8 +128,10 @@ extern: config
 		MAKE_GMP='$(MAKE_GMP)' \
 		CONFIGNAME='$(CONFIGNAME)' )
 
-compile: extern
+bin/$(GAPARCH)/gap_version.h:
 	cnf/mkversionheader.sh bin/$(GAPARCH)/gap_version.h
+
+compile: extern bin/$(GAPARCH)/gap_version.h
 	( cd bin/$(GAPARCH); \
 		$(MAKE) \
 		ABI='$(ABI)' \

--- a/cnf/Makefile
+++ b/cnf/Makefile
@@ -110,7 +110,7 @@ Makegap.in: Makegap.top Makefile Makegap.bottom
 	@echo >> Makegap.in
 	@echo '# compile and link GAP' >> Makegap.in
 	@echo 'gap: $$(OBJECTS) $$(ITANIUMOBJ) $$(EXTOBJS)' >> Makegap.in
-	@echo '	$$(CC) $$(LDFLAGS) -o gap $$(OBJECTS) $$(ITANIUMOBJ) -lm $$(MPILIBS) $$(EXTOBJS) $$(GMP_LIBS) $$(CONFLIBS)' >> Makegap.in
+	@echo '	$$(CC) $$(LDFLAGS) -o gap $$(OBJECTS) $$(ITANIUMOBJ) -lm -lrt $$(MPILIBS) $$(EXTOBJS) $$(GMP_LIBS) $$(CONFLIBS)' >> Makegap.in
 	@echo >> Makegap.in
 	@echo '# compile and link gap.dll on cygwin' >> Makegap.in
 	@echo 'gapdll: $$(OBJECTS) $$(ITANIUMOBJ) $$(EXTOBJS)' >> Makegap.in

--- a/cnf/Makegap.in
+++ b/cnf/Makegap.in
@@ -37,7 +37,7 @@ OBJECTS=ariths.o blister.o bool.o c_filt1.o c_meths1.o c_oper1.o c_random.o c_ty
 
 # compile and link GAP
 gap: $(OBJECTS) $(ITANIUMOBJ) $(EXTOBJS)
-	$(CC) $(LDFLAGS) -o gap $(OBJECTS) $(ITANIUMOBJ) -lm $(MPILIBS) $(EXTOBJS) $(GMP_LIBS) $(CONFLIBS)
+	$(CC) $(LDFLAGS) -o gap $(OBJECTS) $(ITANIUMOBJ) -lm  $(MPILIBS) $(EXTOBJS) $(GMP_LIBS) $(CONFLIBS)
 
 # compile and link gap.dll on cygwin
 gapdll: $(OBJECTS) $(ITANIUMOBJ) $(EXTOBJS)
@@ -262,7 +262,8 @@ gap.o: ../../Makefile @srcdir@/gap.c @srcdir@/system.h config.h @srcdir@/gasman.
 	$(CC) $(CPPFLAGS) $(GMP_CFLAGS) $(CFLAGS) -o gap.o -c @srcdir@/gap.c
 
 gasman.o: ../../Makefile @srcdir@/gasman.c @srcdir@/system.h config.h @srcdir@/gasman.h \
-  @srcdir@/atomic.h @srcdir@/objects.h @srcdir@/scanner.h
+  @srcdir@/atomic.h @srcdir@/objects.h @srcdir@/scanner.h @srcdir@/code.h \
+  @srcdir@/thread.h @srcdir@/tls.h
 	$(CC) $(CPPFLAGS) $(GMP_CFLAGS) $(CFLAGS) -o gasman.o -c @srcdir@/gasman.c
 
 gmpints.o: ../../Makefile @srcdir@/gmpints.c @srcdir@/system.h config.h @srcdir@/gasman.h \

--- a/cnf/config.hin
+++ b/cnf/config.hin
@@ -77,6 +77,9 @@
 /* Define to 1 if you have the `fstat' function. */
 #undef HAVE_FSTAT
 
+/* Define to 1 if you have the `getitimer' function. */
+#undef HAVE_GETITIMER
+
 /* Define to 1 if you have the `getpseudotty' function. */
 #undef HAVE_GETPSEUDOTTY
 
@@ -100,6 +103,9 @@
 
 /* Define to 1 if you have the `readline' library (-lreadline). */
 #undef HAVE_LIBREADLINE
+
+/* Define to 1 if you have the `rt' library (-lrt). */
+#undef HAVE_LIBRT
 
 /* Define to 1 if you have the <libutil.h> header file. */
 #undef HAVE_LIBUTIL_H
@@ -194,11 +200,17 @@
 /* Define to 1 if you have the `send' function. */
 #undef HAVE_SEND
 
+/* Define to 1 if you have the `setitimer' function. */
+#undef HAVE_SETITIMER
+
 /* Define to 1 if you have the `setpgid' function. */
 #undef HAVE_SETPGID
 
 /* Define to 1 if you have the <sgtty.h> header file. */
 #undef HAVE_SGTTY_H
+
+/* Define to 1 if you have the `sigaction' function. */
+#undef HAVE_SIGACTION
 
 /* Define to 1 if you have the `signal' function. */
 #undef HAVE_SIGNAL
@@ -265,6 +277,15 @@
 /* Define to 1 if you have the <sys/sysmacros.h> header file. */
 #undef HAVE_SYS_SYSMACROS_H
 
+/* Define to 1 if you have the `sys_timer_create' function. */
+#undef HAVE_SYS_TIMER_CREATE
+
+/* Define to 1 if you have the `sys_timer_gettime' function. */
+#undef HAVE_SYS_TIMER_GETTIME
+
+/* Define to 1 if you have the `sys_timer_settime' function. */
+#undef HAVE_SYS_TIMER_SETTIME
+
 /* Define to 1 if you have the <sys/times.h> header file. */
 #undef HAVE_SYS_TIMES_H
 
@@ -283,8 +304,20 @@
 /* Define to 1 if you have the <termio.h> header file. */
 #undef HAVE_TERMIO_H
 
+/* Define to 1 if you have the `timer_create' function. */
+#undef HAVE_TIMER_CREATE
+
+/* Define to 1 if you have the `timer_gettime' function. */
+#undef HAVE_TIMER_GETTIME
+
+/* Define to 1 if you have the `timer_settime' function. */
+#undef HAVE_TIMER_SETTIME
+
 /* Define to 1 if you have the `times' function. */
 #undef HAVE_TIMES
+
+/* Define to 1 if you have the <time.h> header file. */
+#undef HAVE_TIME_H
 
 /* Define to 1 if you have the `trunc' function. */
 #undef HAVE_TRUNC

--- a/cnf/config.hin
+++ b/cnf/config.hin
@@ -221,6 +221,9 @@
 /* Define to 1 if you have the `sigsetjmp' function. */
 #undef HAVE_SIGSETJMP
 
+/* Check for sig_atomic_t */
+#undef HAVE_SIG_ATOMIC_T
+
 /* Define to 1 if you have the `socket' function. */
 #undef HAVE_SOCKET
 

--- a/cnf/configure.in
+++ b/cnf/configure.in
@@ -70,6 +70,7 @@ AC_HEADER_STDC
 
 AC_CHECK_HEADERS( assert.h errno.h math.h stdio.h stdlib.h string.h )
 AC_CHECK_HEADERS( termios.h termio.h sgtty.h signal.h unistd.h sys/stat.h )
+AC_CHECK_TYPE( sig_atomic_t, [], [ AC_DEFINE([HAVE_SIG_ATOMIC_T],[],[Check for sig_atomic_t]) ],[#include <signal.h>])
 AC_CHECK_HEADERS( fcntl.h sys/ioctl.h time.h sys/time.h sys/types.h sys/sysmacros.h sys/resource.h )
 
 dnl #########################################################################

--- a/cnf/configure.in
+++ b/cnf/configure.in
@@ -70,7 +70,7 @@ AC_HEADER_STDC
 
 AC_CHECK_HEADERS( assert.h errno.h math.h stdio.h stdlib.h string.h )
 AC_CHECK_HEADERS( termios.h termio.h sgtty.h signal.h unistd.h sys/stat.h )
-AC_CHECK_HEADERS( fcntl.h sys/ioctl.h sys/time.h sys/types.h sys/sysmacros.h sys/resource.h )
+AC_CHECK_HEADERS( fcntl.h sys/ioctl.h time.h sys/time.h sys/types.h sys/sysmacros.h sys/resource.h )
 
 dnl #########################################################################
 dnl ##
@@ -143,8 +143,14 @@ dnl ##
 dnl ## check for timing functions
 dnl ##
 
-AC_CHECK_HEADERS( sys/times.h sys/param.h )
+AC_CHECK_HEADERS( time.h sys/times.h sys/param.h )
 AC_CHECK_FUNCS( times getrusage gettimeofday )
+AC_CHECK_FUNCS( setitimer getitimer)
+AC_CHECK_LIB( [rt], [timer_create])
+AC_CHECK_FUNCS( timer_settime timer_gettime timer_create )
+AC_CHECK_FUNCS( sys_timer_settime sys_timer_gettime sys_timer_create )
+
+
 
 
 dnl #########################################################################
@@ -194,7 +200,7 @@ dnl ##
 dnl ## check for signal handling
 dnl ##
 
-AC_CHECK_FUNCS( signal )
+AC_CHECK_FUNCS( signal sigaction)
 
 
 dnl #########################################################################

--- a/cnf/configure.out
+++ b/cnf/configure.out
@@ -1840,6 +1840,60 @@ fi
 
 } # ac_fn_c_check_header_mongrel
 
+# ac_fn_c_check_type LINENO TYPE VAR INCLUDES
+# -------------------------------------------
+# Tests whether TYPE exists after having included INCLUDES, setting cache
+# variable VAR accordingly.
+ac_fn_c_check_type ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+$as_echo_n "checking for $2... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  eval "$3=no"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+int
+main ()
+{
+if (sizeof ($2))
+	 return 0;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+int
+main ()
+{
+if (sizeof (($2)))
+	    return 0;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+else
+  eval "$3=yes"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+eval ac_res=\$$3
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_type
+
 # ac_fn_c_find_intX_t LINENO BITS VAR
 # -----------------------------------
 # Finds a signed integer type with width BITS, setting cache variable VAR
@@ -2082,60 +2136,6 @@ $as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_func
-
-# ac_fn_c_check_type LINENO TYPE VAR INCLUDES
-# -------------------------------------------
-# Tests whether TYPE exists after having included INCLUDES, setting cache
-# variable VAR accordingly.
-ac_fn_c_check_type ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
-$as_echo_n "checking for $2... " >&6; }
-if eval \${$3+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  eval "$3=no"
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-$4
-int
-main ()
-{
-if (sizeof ($2))
-	 return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-$4
-int
-main ()
-{
-if (sizeof (($2)))
-	    return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-else
-  eval "$3=yes"
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-eval ac_res=\$$3
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-
-} # ac_fn_c_check_type
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -4706,6 +4706,16 @@ _ACEOF
 fi
 
 done
+
+ac_fn_c_check_type "$LINENO" "sig_atomic_t" "ac_cv_type_sig_atomic_t" "#include <signal.h>
+"
+if test "x$ac_cv_type_sig_atomic_t" = xyes; then :
+
+else
+
+$as_echo "#define HAVE_SIG_ATOMIC_T /**/" >>confdefs.h
+
+fi
 
 for ac_header in fcntl.h sys/ioctl.h time.h sys/time.h sys/types.h sys/sysmacros.h sys/resource.h
 do :

--- a/cnf/configure.out
+++ b/cnf/configure.out
@@ -4707,7 +4707,7 @@ fi
 
 done
 
-for ac_header in fcntl.h sys/ioctl.h sys/time.h sys/types.h sys/sysmacros.h sys/resource.h
+for ac_header in fcntl.h sys/ioctl.h time.h sys/time.h sys/types.h sys/sysmacros.h sys/resource.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -5058,7 +5058,7 @@ esac;
 
 
 
-for ac_header in sys/times.h sys/param.h
+for ac_header in time.h sys/times.h sys/param.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -5082,6 +5082,89 @@ _ACEOF
 
 fi
 done
+
+for ac_func in setitimer getitimer
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
+
+fi
+done
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for timer_create in -lrt" >&5
+$as_echo_n "checking for timer_create in -lrt... " >&6; }
+if ${ac_cv_lib_rt_timer_create+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lrt  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char timer_create ();
+int
+main ()
+{
+return timer_create ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_rt_timer_create=yes
+else
+  ac_cv_lib_rt_timer_create=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_rt_timer_create" >&5
+$as_echo "$ac_cv_lib_rt_timer_create" >&6; }
+if test "x$ac_cv_lib_rt_timer_create" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBRT 1
+_ACEOF
+
+  LIBS="-lrt $LIBS"
+
+fi
+
+for ac_func in timer_settime timer_gettime timer_create
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
+
+fi
+done
+
+for ac_func in sys_timer_settime sys_timer_gettime sys_timer_create
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
+
+fi
+done
+
+
 
 
 
@@ -5441,7 +5524,7 @@ $as_echo "$gp_cv_c_union_wait" >&6; }
 
 
 
-for ac_func in signal
+for ac_func in signal sigaction
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/dev/Updates/timeout
+++ b/dev/Updates/timeout
@@ -1,0 +1,22 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Format 'yyyy/mm/dd'
+!! Date
+2015/11/16
+!! Changed by
+SL
+! Reported by
+
+!! Type of Change
+New: new functionality
+
+!! Description
+Add CallWithTimeout and CallWithTimeoutList to provide for time limited function calls.
+Details are in the documentation. A test file is provided.
+
+! Test Code
+
+! Prefetch
+
+!! Changeset
+
+!! End

--- a/doc/ref/function.xml
+++ b/doc/ref/function.xml
@@ -42,6 +42,17 @@ several arguments</Heading>
 
 </Section>
 
+<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
+<Section Label="Calling a function with a time limit">
+<Heading>Calling a function with a time limit</Heading>
+
+
+<#Include Label="CallWithTimeout">
+<#Include Label="GAPInfo.TimeoutsSupported">
+</Section>
+
+
+
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <Section Label="Functions that do nothing">

--- a/doc/ref/makedocreldata.g
+++ b/doc/ref/makedocreldata.g
@@ -64,6 +64,7 @@ GAPInfo.ManualDataRef:= rec(
     "../../lib/fpmon.gd",
     "../../lib/fpsemi.gd",
     "../../lib/function.g",
+    "../../lib/function.gd",
     "../../lib/galois.gd",
     "../../lib/gasman.gd",
     "../../lib/ghom.gd",

--- a/lib/error.g
+++ b/lib/error.g
@@ -113,8 +113,9 @@ Unbind(ErrorInner);
 BIND_GLOBAL("ErrorInner",
         function( arg )
     local   context, mayReturnVoid,  mayReturnObj,  lateMessage,  earlyMessage,  
-            x,  prompt,  res, errorLVars, justQuit, printThisStatement;
+            x,  prompt,  res, errorLVars, justQuit, printThisStatement, timeout;
 
+    timeout := STOP_TIMEOUT();
 	context := arg[1].context;
     if not IsLVarsBag(context) then
         PrintTo("*errout*", "ErrorInner:   option context must be a local variables bag\n");
@@ -247,6 +248,9 @@ BIND_GLOBAL("ErrorInner",
             SetUserHasQuit(1);	
         fi;
         JUMP_TO_CATCH(3);
+    fi;
+    if timeout <> fail then
+       RESUME_TIMEOUT(timeout);
     fi;
     if Length(res) > 0 then
         return res[1];

--- a/lib/function.gd
+++ b/lib/function.gd
@@ -43,7 +43,9 @@
 ##  <C>CallWithTimeout[List]</C> is an empty list.<P/>
 ##
 ##  If the call does not complete within the timeout, the result of <C>CallWithTimeout[List]</C>
-##  is <K>fail</K>.<P/>
+##  is <K>fail</K>. In this case, just as if you had <C>quit</C> from a break loop, there is some
+##  risk that internal data structures in &GAP; may have been left in an inconsistent state, and you 
+##  should proceed with caution.<P/>
 ##
 ##  The timer is suspended during execution of a break loop and abandoned when you quit from a break loop.<P/>
 ##

--- a/lib/function.gd
+++ b/lib/function.gd
@@ -65,7 +65,8 @@
 ##
 ##  The precision of the timeouts is not guaranteed, and there is a system dependent upper limit on the timeout 
 ##  which is typically about 8 years on 32 bit systems and about 30 billion years on 64 bit systems. Timeouts longer
-##  than this will be reduced to this limit.<P/>
+##  than this will be reduced to this limit. On Windows systems, timing is based on elapsed time, not CPU time
+##  because the necessary POSIX CPU timing API is not supported.<P/>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/function.gd
+++ b/lib/function.gd
@@ -1,0 +1,62 @@
+
+#############################################################################
+##
+#W  function.gd                GAP library                     Steve Linton
+##
+##
+#Y  Copyright (C) 2015 The GAP Group
+##
+##  This file contains the declarations of the functions and operations
+##  relating to functions and function-calling which are not so basic
+##  that they need to be in function.g
+##
+
+
+#############################################################################
+##
+#F  CallWithTimeout( <timeout>, <func>[, <arg1>[, <arg2>....]] )  
+##         . . call a function with a time limit
+#F  CallWithTimeoutList( <timeout>, <func>, <arglist> )  
+##
+##  <#GAPDoc Label="CallWithTimeout">
+##  <ManSection>
+##  <Func Name="CallWithTimeout" Arg='timeout, func, .....'/>
+##  <Func Name="CallWithTimeoutList" Arg='timeout, func, args'/>
+##
+##  <Description>
+##    CallWithTimeout and CallWithTimeoutList support calling a function
+##  with a limit on the CPU time it can consume. 
+##
+##  If the call completes within the allotted time and returns a value, the result of 
+##  CallWithTimeout[List] is a length 1 list containing that value. 
+##  
+##  If the call completes within the allotted time and returns no value, the result of 
+##  CallWithTimeout[List] is an empty list.
+##
+##  If the call does not complete within the timeout, the result of CallWithTimeout[List]
+## is fail.
+##
+##  The timer is suspended during execution of a break loop and abandoned when you quit from a break loop.
+##
+## CallWithTimeout is variadic. 
+##  Its third and subsequent arguments if any are the arguments if any passed to <func>
+##  CallWithTimeoutList in contract takes exactly three arguments, of which the third is a list
+##  (possibly empty) or arguments to pass to <func>. 
+## 
+##  The limit <timeout> is specified as a record. At present the following components are recognised
+##  nanoseconds, microseconds, milliseconds, seconds, minutes, hours, days and weeks. Any of these 
+##  components which is present should be bound to a positive integer, rational or float and the times
+##  represented are totalled.
+##
+##  Further components are permitted and ignored, to allow for future functionality.
+##
+##  As a shorthand, a single positive integers may be supplied, and is taken as a number of microseconds
+##
+##  The precision of the timeouts is not guaranteed, and there is a system dependent upper limit on the timeout 
+##  which is typically about 8 years on 32 bit systems and about 30 billion years on 64 bit systems. Timeouts longer
+##  than this will be silently ignored. 
+##
+
+DeclareGlobalFunction("CallWithTimeout");
+DeclareGlobalFunction("CallWithTimeoutList");
+

--- a/lib/function.gd
+++ b/lib/function.gd
@@ -19,43 +19,54 @@
 #F  CallWithTimeoutList( <timeout>, <func>, <arglist> )  
 ##
 ##  <#GAPDoc Label="CallWithTimeout">
+##  <Index>Timeouts</Index>
 ##  <ManSection>
 ##  <Func Name="CallWithTimeout" Arg='timeout, func, .....'/>
-##  <Func Name="CallWithTimeoutList" Arg='timeout, func, args'/>
+##  <Func Name="CallWithTimeoutList" Arg='timeout, func, arglist'/>
 ##
 ##  <Description>
-##    CallWithTimeout and CallWithTimeoutList support calling a function
-##  with a limit on the CPU time it can consume. 
+##    <C>CallWithTimeout</C> and <C>CallWithTimeoutList</C> support calling a function
+##  with a limit on the CPU time it can consume. <P/>
+##
+##  This functionality may not be available on all systems and you should check 
+##  <Ref Var="GAPInfo.TimeoutsSupported"/> before using this functionality.<P/>
+##
+##  <C>CallWithTimeout</C> is variadic. 
+##  Its third and subsequent arguments, if any, are the arguments passed to <A>func</A>.
+##  <C>CallWithTimeoutList</C> in contrast takes exactly three arguments, of which the third is a list
+##  (possibly empty) or arguments to pass to <A>func</A>. <P/>
 ##
 ##  If the call completes within the allotted time and returns a value, the result of 
-##  CallWithTimeout[List] is a length 1 list containing that value. 
+##  <C>CallWithTimeout[List]</C> is a length 1 list containing that value. <P/>
 ##  
 ##  If the call completes within the allotted time and returns no value, the result of 
-##  CallWithTimeout[List] is an empty list.
+##  <C>CallWithTimeout[List]</C> is an empty list.<P/>
 ##
-##  If the call does not complete within the timeout, the result of CallWithTimeout[List]
-## is fail.
+##  If the call does not complete within the timeout, the result of <C>CallWithTimeout[List]</C>
+##  is <K>fail</K>.<P/>
 ##
-##  The timer is suspended during execution of a break loop and abandoned when you quit from a break loop.
+##  The timer is suspended during execution of a break loop and abandoned when you quit from a break loop.<P/>
 ##
-## CallWithTimeout is variadic. 
-##  Its third and subsequent arguments if any are the arguments if any passed to <func>
-##  CallWithTimeoutList in contract takes exactly three arguments, of which the third is a list
-##  (possibly empty) or arguments to pass to <func>. 
-## 
-##  The limit <timeout> is specified as a record. At present the following components are recognised
-##  nanoseconds, microseconds, milliseconds, seconds, minutes, hours, days and weeks. Any of these 
+##  Timeouts may not be nested. That is, during execution of <C>CallWithTimeout(<A>timeout</A>,<A>func</A>,...)</C>,
+##  <A>func</A> (or functions it calls) may not call <C>CallWithTimeout</C> or <C>CallWithTimeoutList</C>. 
+##  This restriction may be lifted on at least some systems in future releases. It is 
+##  permitted to use <C>CallWithTimeout</C> or <C>CallWithTimeoutList</C> from within a break loop, even if a
+##  suspended timeout exists, although there is limit on the depth of such nesting.<P/>
+##
+##  The limit <A>timeout</A> is specified as a record. At present the following components are recognised
+##  <C>nanoseconds</C>, <C>microseconds</C>, <C>milliseconds</C>, <C>seconds</C>, 
+##  <C>minutes</C>, <C>hours</C>, <C>days</C> and <C>weeks</C>. Any of these 
 ##  components which is present should be bound to a positive integer, rational or float and the times
-##  represented are totalled.
-##
-##  Further components are permitted and ignored, to allow for future functionality.
-##
-##  As a shorthand, a single positive integers may be supplied, and is taken as a number of microseconds
+##  represented are totalled to give the actual timeout. As a shorthand, a single positive 
+##  integers may be supplied, and is taken as a number of microseconds.
+##  Further components are permitted and ignored, to allow for future functionality.<P/>
 ##
 ##  The precision of the timeouts is not guaranteed, and there is a system dependent upper limit on the timeout 
 ##  which is typically about 8 years on 32 bit systems and about 30 billion years on 64 bit systems. Timeouts longer
-##  than this will be silently ignored. 
-##
+##  than this will be reduced to this limit.<P/>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 
 DeclareGlobalFunction("CallWithTimeout");
 DeclareGlobalFunction("CallWithTimeoutList");

--- a/lib/function.gi
+++ b/lib/function.gi
@@ -1,0 +1,86 @@
+#############################################################################
+##
+#W  function.gi                GAP library                     Steve Linton
+##
+##
+#Y  Copyright (C) 2015 The GAP Group
+##
+ ##  This file contains the implementations of the functions and operations
+##  relating to functions and function-calling which are not so basic
+##  that they need to be in function.g
+##
+
+
+#############################################################################
+##
+#F  CallWithTimeout( <timeout>, <func>[, <arg1>[, <arg2>....]] )  
+##         . . call a function with a time limit
+#F  CallWithTimeoutList( <timeout>, <func>, <arglist> )  
+##
+##
+
+InstallGlobalFunction(CallWithTimeout, 
+        function( timeout, func, arg )
+    return CallWithTimeoutList(timeout, func, arg);
+end );
+
+InstallGlobalFunction("CallWithTimeoutList",
+        function(timeout, func, arglist )
+    local  process, nano, seconds, microseconds;
+    process := function(name, scale)
+        local  val;
+        if IsBound(timeout.(name)) then
+            val := timeout.(name);
+            if IsRat(val) or IsFloat(val) then
+                nano := nano + Int(val*scale);
+            else
+                Error("CallWithTimeout[List]: can't understand period of ",val," ",name,". Ignoring.");
+            fi;
+        fi;
+    end;
+    if not GAPInfo.TimeoutsSupported then
+        Error("Calling with time limits not supported in this GAP installation");
+        return fail;
+    fi;
+    if IsInt(timeout) then
+        nano := 1000*timeout;
+    else
+        if not IsRecord(timeout) then
+            Error("CallWithTimeout[List]: timeout must be an integer or record");
+            return fail;
+        fi;
+        nano := 0;
+        process("nanoseconds",1);
+        process("microseconds",1000);
+        process("milliseconds",1000000);
+        process("seconds",10^9);
+        process("minutes",60*10^9);
+        process("hours",3600*10^9);
+        process("days",24*3600*10^9);
+        process("weeks",7*24*3600*10^9);
+    fi;
+    if nano < 0 then
+        Error("Negative timeout is not permitted");
+        return fail;
+    fi;
+    seconds := QuoInt(nano, 10^9);
+    microseconds := QuoInt(nano mod 10^9, 1000);
+    if seconds = 0 and microseconds = 0 then
+        # zero or tiny timeout. just simulate timeout now
+        return fail;
+    fi;
+    # make sure it's a small int. Cap timeouts at about 8 years on
+    # 32 bit systems
+    seconds := Minimum(seconds,2^(8*GAPInfo.BytesPerVariable-4)-1);
+    return CALL_WITH_TIMEOUT(seconds, microseconds, func, arglist);
+end);
+
+    
+        
+        
+        
+        
+                
+       
+                  
+

--- a/lib/read3.g
+++ b/lib/read3.g
@@ -250,5 +250,8 @@ ReadLib("other.gd");
 
 ReadLib("gasman.gd");
 
+# files dealing with function calling
+ReadLib("function.gd");
+
 # random sources
 ReadLib("random.gi");

--- a/lib/read5.g
+++ b/lib/read5.g
@@ -251,6 +251,9 @@ ReadLib( "other.gi");
 
 ReadLib( "gasman.gi");
 
+ReadLib( "function.gi");
+
+
 # floateans, now really install all handlers
 ReadLib( "float.gi" );
 ReadLib( "ieee754.g" );

--- a/lib/system.g
+++ b/lib/system.g
@@ -523,7 +523,7 @@ end);
 ##
 ## <Description>
 ##  tests whether this installation of &GAP; supports the timeout functionality
-## of <C>CallWithTimeout</C> and related functions. 
+## of <Ref Func="CallWithTimeout"/> and related functions. 
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/system.g
+++ b/lib/system.g
@@ -513,6 +513,22 @@ BIND_GLOBAL("ARCH_IS_UNIX",function()
   return not ARCH_IS_WINDOWS();
 end);
 
+#############################################################################
+##
+#V  GAPInfo.TimeoutsSupported
+##
+##  <#GAPDoc Label="GAPInfo.TimeoutsSupported">
+##  <ManSection>
+##  <Var Name="GAPInfo.TimeoutsSupported"/>
+##
+## <Description>
+##  tests whether this installation of &GAP; supports the timeout functionality
+## of <C>CallWithTimeout</C> and related functions. 
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+
+GAPInfo.TimeoutsSupported := TIMEOUTS_SUPPORTED();
 
 #############################################################################
 ##

--- a/src/gap.c
+++ b/src/gap.c
@@ -1362,6 +1362,139 @@ Obj FuncSetUserHasQuit( Obj Self, Obj value)
   return 0;
 }
 
+
+ #define MAX_TIMEOUT_NESTING_DEPTH 1024
+ 
+ syJmp_buf AlarmJumpBuffers[MAX_TIMEOUT_NESTING_DEPTH];
+ UInt NumAlarmJumpBuffers = 0;
+
+ Obj FuncTIMEOUTS_SUPPORTED(Obj self) {
+   return SyHaveAlarms ? True: False;
+ }
+   
+ Obj FuncCALL_WITH_TIMEOUT( Obj self, Obj seconds, Obj microseconds, Obj func, Obj args )
+{
+  Obj plain_args;
+    Obj res;
+    Obj currLVars;
+    Obj result;
+    Int recursionDepth;
+    Stat currStat;
+    if (!SyHaveAlarms)
+      ErrorMayQuit("CALL_WITH_TIMEOUT: timeouts not supported on this system", 0L, 0L);
+    if (!IS_INTOBJ(seconds) || 0 > INT_INTOBJ(seconds))
+      ErrorMayQuit("CALL_WITH_TIMEOUT(<seconds>, <microseconds>, <func>,<args>): <seconds> must be a non-negative small integer",0,0);
+    if (!IS_INTOBJ(microseconds) || 0 > INT_INTOBJ(microseconds) || 999999999 < INT_INTOBJ(microseconds))
+      ErrorMayQuit("CALL_WITH_TIMEOUT(<seconds>, <microseconds>, <func>,<args>): <microseconds> must be a non-negative small integer less than 10^9",0,0);
+    if (!IS_FUNC(func))
+      ErrorMayQuit("CALL_WITH_TIMEOUT(<seconds>, <microseconds>, <func>,<args>): <func> must be a function",0,0);
+    if (!IS_LIST(args))
+      ErrorMayQuit("CALL_WITH_TIMEOUT(<seconds>, <microseconds>, <func>,<args>): <args> must be a list",0,0);
+    if (!IS_PLIST(args))
+      {
+        plain_args = SHALLOW_COPY_OBJ(args);
+        PLAIN_LIST(plain_args);
+      }
+    else 
+      plain_args = args;
+    if (SyAlarmRunning)
+      ErrorMayQuit("CALL_WITH_TIMEOUT cannot currently be nested except via break loops."
+		   " There is already a timeout running", 0, 0);
+    if (NumAlarmJumpBuffers++ >= MAX_TIMEOUT_NESTING_DEPTH)
+      ErrorMayQuit("Nesting depth of timeouts via break loops limited to %i", MAX_TIMEOUT_NESTING_DEPTH, 0L);
+    currLVars = TLS(CurrLVars);
+    currStat = TLS(CurrStat);
+    recursionDepth = TLS(RecursionDepth);
+    if (sySetjmp(AlarmJumpBuffers[NumAlarmJumpBuffers])) {
+      /* Timeout happened */
+      TLS(CurrLVars) = currLVars;
+      TLS(PtrLVars) = PTR_BAG(TLS(CurrLVars));
+      TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+      TLS(CurrStat) = currStat;
+      TLS(RecursionDepth) = recursionDepth;
+      res = Fail;
+    } else {
+      SyInstallAlarm( INT_INTOBJ(seconds), 1000*INT_INTOBJ(microseconds));
+      switch (LEN_PLIST(plain_args)) {
+      case 0: result = CALL_0ARGS(func);
+        break;
+      case 1: result = CALL_1ARGS(func, ELM_PLIST(plain_args,1));
+        break;
+      case 2: result = CALL_2ARGS(func, ELM_PLIST(plain_args,1),
+                                  ELM_PLIST(plain_args,2));
+        break;
+      case 3: result = CALL_3ARGS(func, ELM_PLIST(plain_args,1),
+                                  ELM_PLIST(plain_args,2), ELM_PLIST(plain_args,3));
+        break;
+      case 4: result = CALL_4ARGS(func, ELM_PLIST(plain_args,1),
+                                  ELM_PLIST(plain_args,2), ELM_PLIST(plain_args,3),
+                                  ELM_PLIST(plain_args,4));
+        break;
+      case 5: result = CALL_5ARGS(func, ELM_PLIST(plain_args,1),
+                                  ELM_PLIST(plain_args,2), ELM_PLIST(plain_args,3),
+                                  ELM_PLIST(plain_args,4), ELM_PLIST(plain_args,5));
+        break;
+      case 6: result = CALL_6ARGS(func, ELM_PLIST(plain_args,1),
+                                  ELM_PLIST(plain_args,2), ELM_PLIST(plain_args,3),
+                                  ELM_PLIST(plain_args,4), ELM_PLIST(plain_args,5),
+                                  ELM_PLIST(plain_args,6));
+        break;
+      default: result = CALL_XARGS(func, plain_args);
+      }
+      /* make sure the alarm is not still running */
+      SyStopAlarm( NULL, NULL);
+      res = NEW_PLIST(T_PLIST_DENSE+IMMUTABLE, 1);
+      if (result)
+        {
+          SET_LEN_PLIST(res,1);
+          SET_ELM_PLIST(res,1,result);
+          CHANGED_BAG(res);
+        }
+      else {
+	RetypeBag(res, T_PLIST_EMPTY+IMMUTABLE);
+        SET_LEN_PLIST(res,0);
+      }
+    }
+    assert(NumAlarmJumpBuffers);
+    NumAlarmJumpBuffers--;
+    return res;
+}
+
+Obj FuncSTOP_TIMEOUT( Obj self ) {
+  UInt seconds, nanoseconds;
+  if (!SyHaveAlarms || !SyAlarmRunning) 
+    return Fail;
+  SyStopAlarm(&seconds, &nanoseconds);
+  Obj state = NEW_PLIST(T_PLIST_CYC+IMMUTABLE, 3);
+  SET_ELM_PLIST(state,1,INTOBJ_INT(seconds));
+  SET_ELM_PLIST(state,2,INTOBJ_INT(nanoseconds/1000));
+  SET_ELM_PLIST(state,3,INTOBJ_INT(NumAlarmJumpBuffers));
+  SET_LEN_PLIST(state,3);
+  return state;
+}
+
+Obj FuncRESUME_TIMEOUT( Obj self, Obj state ) {
+  if (!SyHaveAlarms || SyAlarmRunning) 
+    return Fail;
+  if (!IS_PLIST(state) || LEN_PLIST(state) < 2)
+    return Fail;
+  if (!IS_INTOBJ(ELM_PLIST(state,1)) ||
+      !IS_INTOBJ(ELM_PLIST(state,2)))
+    return Fail;
+  Int s = INT_INTOBJ(ELM_PLIST(state,1));
+  Int us = INT_INTOBJ(ELM_PLIST(state,2));
+  if (s < 0 || us < 0 || us > 999999)
+    return Fail;
+  Int depth = INT_INTOBJ(ELM_PLIST(state,3));
+  if (depth < 0 || depth >= MAX_TIMEOUT_NESTING_DEPTH)
+    return Fail;
+  NumAlarmJumpBuffers = depth;
+  SyInstallAlarm(s, 1000*us);
+  return True;
+}
+
+ 
+ 
 /****************************************************************************
 **
 *F  ErrorQuit( <msg>, <arg1>, <arg2> )  . . . . . . . . . . .  print and quit
@@ -1404,7 +1537,8 @@ Obj CallErrorInner (
   SET_ELM_PLIST(l,1,EarlyMsg);
   SET_LEN_PLIST(l,1);
   SET_BRK_CALL_TO(TLS(CurrStat));
-  return CALL_2ARGS(ErrorInner,r,l);  
+  Obj res =  CALL_2ARGS(ErrorInner,r,l);
+  return res;
 }
 
 void ErrorQuit (
@@ -1581,7 +1715,7 @@ void ErrorMayQuit (
 Obj Error;
 Obj ErrorInner;
 
-
+ 
 /****************************************************************************
 **
 
@@ -2916,6 +3050,18 @@ static StructGVarFunc GVarFuncs [] = {
 
     { "CALL_WITH_CATCH", 2, "func, args",
       FuncCALL_WITH_CATCH, "src/gap.c:CALL_WITH_CATCH" },
+
+    { "TIMEOUTS_SUPPORTED", 0, "",
+      FuncTIMEOUTS_SUPPORTED, "src/gap.c:TIMEOUTS_SUPPORTED" },
+
+    { "CALL_WITH_TIMEOUT", 4, "seconds, microseconds, func, args",
+      FuncCALL_WITH_TIMEOUT, "src/gap.c:CALL_WITH_TIMEOUT" },
+
+    {"STOP_TIMEOUT", 0, "",
+     FuncSTOP_TIMEOUT, "src/gap.c:FuncSTOP_TIMEOUT" },
+
+    {"RESUME_TIMEOUT", 1, "state",
+     FuncRESUME_TIMEOUT, "src/gap.c:FuncRESUME_TIMEOUT" },
 
     { "JUMP_TO_CATCH", 1, "payload",
       FuncJUMP_TO_CATCH, "src/gap.c:JUMP_TO_CATCH" },

--- a/src/gap.h
+++ b/src/gap.h
@@ -49,6 +49,16 @@ extern UInt Last3;
 */
 extern UInt Time;
 
+/****************************************************************************
+**
+*V  AlarmJumpBuffer . . . . . .long jump buffer used for timeouts 
+**
+**  Needs to be visible to code in read.c that stores away execution state 
+*/
+
+
+extern syJmp_buf AlarmJumpBuffers[];
+extern UInt NumAlarmJumpBuffers;
 
 
 /****************************************************************************

--- a/src/stats.c
+++ b/src/stats.c
@@ -1679,9 +1679,15 @@ UInt ExecIntrStat (
     }
     HaveInterrupt();
 
+
+    /* One reason we might be here is a timeout. If so longjump out to the 
+       CallWithTimeLimit where we started */
+    
+    if ( SyAlarmHasGoneOff ) 
+      syLongjmp(AlarmJumpBuffers[NumAlarmJumpBuffers],1);
+      
     /* and now for something completely different                          */
     SET_BRK_CURR_STAT( stat );
-
     if ( SyStorOverrun != 0 ) {
       SyStorOverrun = 0; /* reset */
       ErrorReturnVoid(

--- a/src/stats.h
+++ b/src/stats.h
@@ -110,6 +110,7 @@ extern UInt TakeInterrupt();
 **  those systems the executors test 'SyIsIntr' at regular intervals.
 */
 extern  void            InterruptExecStat ( );
+extern  void            UnInterruptExecStat ( );
 
 
 /****************************************************************************

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -1278,6 +1278,7 @@ void syStopraw (
 #endif /* HAVE_SGTTY_H || HAVE_TERMIO_H || HAVE_TERMIOS_H */
 
 
+
 /****************************************************************************
 **
 
@@ -1297,7 +1298,7 @@ void syStopraw (
 **  For  UNIX  we  install 'syAnswerIntr' to  answer interrupt 'SIGINT'. If
 **  two interrupts  occur within 1 second 'syAnswerIntr' exits GAP.
 */
-#if HAVE_SIGNAL
+#if HAVE_SIGNAL 
 
 
 UInt            syLastIntr;             /* time of the last interrupt      */
@@ -1358,6 +1359,214 @@ UInt SyIsIntr ( void )
     return isIntr;
 }
 
+
+/* Code for Timeouts */
+
+volatile int SyAlarmRunning = 0;
+volatile int SyAlarmHasGoneOff = 0;
+
+#endif
+
+#if HAVE_TIMER_CREATE && HAVE_SIGACTION
+
+/* Could live without sigaction but it seems to be pretty universal */
+
+/* This uses the POSIX 2001 API
+   which allows per-thread timing and minimises risk of
+   interference with other code using timers.
+
+   Sadly it's not always available, so we have an alternative implementation
+   below using the odler setitimer interface */
+
+/* Handler for the Alarm signal */
+
+const int SyHaveAlarms = 1;
+
+/* This API lets us pick wich signal to use */
+#define TIMER_SIGNAL SIGVTALRM
+
+
+/* For now anyway we create one timer at initialisation and use it */
+static timer_t syTimer = 0;
+
+static void SyInitAlarm( void ) {
+/* Create the CPU timer used for timeouts */
+  struct sigevent se;
+  se.sigev_notify = SIGEV_SIGNAL;
+  se.sigev_signo = TIMER_SIGNAL;
+  se.sigev_value.sival_int = 0x12345678;  
+  timer_create( CLOCK_THREAD_CPUTIME_ID, &se, &syTimer);
+}
+
+static void syAnswerAlarm ( int signr, siginfo_t * si, void *context)
+{
+    /* interrupt the executor                                             
+       Later we might want to do something cleverer with throwing an 
+       exception or dealing better if this isn't our timer     */
+  assert( signr == TIMER_SIGNAL);
+  assert( si->si_signo == TIMER_SIGNAL);
+  assert( si->si_code == SI_TIMER);
+  assert( si->si_value.sival_int == 0x12345678 );
+  SyAlarmRunning = 0;
+  SyAlarmHasGoneOff = 1;
+  InterruptExecStat();
+}
+
+ 
+void SyInstallAlarm ( UInt seconds, UInt nanoseconds )
+{
+  struct sigaction sa;
+  
+  sa.sa_handler = NULL;
+  sa.sa_sigaction = syAnswerAlarm;
+  sigemptyset(&(sa.sa_mask));
+  sa.sa_flags = SA_RESETHAND | SA_SIGINFO;
+  
+  /* First install the handler */
+  if (sigaction( TIMER_SIGNAL, &sa, NULL ))
+    {
+      ErrorReturnVoid("Could not set handler for alarm signal",0L,0L,"you can return to ignore");
+      return;
+    }
+
+  
+  struct itimerspec tv;
+  tv.it_value.tv_sec = (time_t)seconds;
+  tv.it_value.tv_nsec = (long)nanoseconds;
+  tv.it_interval.tv_sec = (time_t)0;
+  tv.it_interval.tv_nsec = 0L;
+  
+  SyAlarmRunning = 1;
+  SyAlarmHasGoneOff = 0;
+  if (timer_settime(syTimer, 0, &tv, NULL)) {
+    signal(TIMER_SIGNAL, SIG_DFL);
+    ErrorReturnVoid("Could not set interval timer", 0L, 0L, "you can return to ignore");
+  }
+  return;
+}
+
+void SyStopAlarm(UInt *seconds, UInt *nanoseconds) {
+  struct itimerspec tv, buf;
+  tv.it_value.tv_sec = (time_t)0;
+  tv.it_value.tv_nsec = 0L;
+  tv.it_interval.tv_sec = (time_t)0;
+  tv.it_interval.tv_nsec = 0L;
+
+  timer_settime(syTimer, 0, &tv, &buf);
+  SyAlarmRunning = 0;
+  signal(TIMER_SIGNAL, SIG_DFL);
+
+  if (seconds)
+    *seconds = (UInt)buf.it_value.tv_sec;
+  if (nanoseconds)
+    *nanoseconds = (UInt)buf.it_value.tv_nsec;
+  return;
+}
+
+#else
+#if HAVE_SETITIMER && HAVE_SIGACTION
+
+/* Using setitimer and getitimer from sys/time.h */
+/* again sigaction could be replaced by signal if that was useful
+ sigaction is just a bit more robust */
+
+/* Handler for the Alarm signal */
+
+const int SyHaveAlarms = 1;
+
+
+static void SyInitAlarm( void ) {
+  /* No initialisation in this case */
+  return; 
+}
+
+static void syAnswerAlarm ( int signr, siginfo_t * si, void *context)
+{
+    /* interrupt the executor                                             
+       Later we might want to do something cleverer with throwing an 
+       exception or dealing better if this isn't our timer     */
+  assert( signr == SIGVTALRM);
+  assert( si->si_signo == SIGVTALRM);
+  SyAlarmRunning = 0;
+  SyAlarmHasGoneOff = 1;
+  InterruptExecStat();
+}
+
+ 
+void SyInstallAlarm ( UInt seconds, UInt nanoseconds )
+{
+  struct sigaction sa;
+  
+  sa.sa_handler = NULL;
+  sa.sa_sigaction = syAnswerAlarm;
+  sigemptyset(&(sa.sa_mask));
+  sa.sa_flags = SA_RESETHAND | SA_SIGINFO;
+
+  
+  /* First install the handler */
+  if (sigaction( SIGVTALRM, &sa, NULL ))
+    {
+      ErrorReturnVoid("Could not set handler for alarm signal",0L,0L,"you can return to ignore");
+      return;
+    }
+
+  
+  struct itimerval tv;
+  tv.it_value.tv_sec = (time_t)seconds;
+  tv.it_value.tv_usec = (suseconds_t)(nanoseconds/1000);
+  tv.it_interval.tv_sec = (time_t)0;
+  tv.it_interval.tv_usec = (suseconds_t)0L;
+  
+  SyAlarmRunning = 1;
+  SyAlarmHasGoneOff = 0;
+  if (setitimer(ITIMER_VIRTUAL, &tv, NULL)) {
+    signal(SIGVTALRM, SIG_DFL);
+    ErrorReturnVoid("Could not set interval timer", 0L, 0L, "you can return to ignore");
+  }
+  return;
+}
+
+void SyStopAlarm(UInt *seconds, UInt *nanoseconds) {
+  struct itimerval tv, buf;
+  tv.it_value.tv_sec = (time_t)0;
+  tv.it_value.tv_usec = (suseconds_t)0L;
+  tv.it_interval.tv_sec = (time_t)0;
+  tv.it_interval.tv_usec = (suseconds_t)0L;
+
+  setitimer(ITIMER_VIRTUAL, &tv, &buf);
+  SyAlarmRunning = 0;
+  signal(SIGVTALRM, SIG_DFL);
+
+  if (seconds)
+    *seconds = (UInt)buf.it_value.tv_sec;
+  if (nanoseconds)
+    *nanoseconds = 1000*(UInt)buf.it_value.tv_usec;
+  return;
+}
+
+#else
+const int SyHaveAlarms = 0;
+
+/* stub implementations */
+
+static void SyInitAlarm( void ) {
+  /* No initialisation in this case */
+  return; 
+}
+
+ 
+void SyInstallAlarm ( UInt seconds, UInt nanoseconds )
+{
+  assert(0);
+  return;
+}
+
+void SyStopAlarm(UInt *seconds, UInt *nanoseconds) {
+  assert(0);
+  return;
+}
+
+#endif
 #endif
 
 
@@ -3834,6 +4043,8 @@ static StructGVarFunc GVarFuncs [] = {
        FuncREADLINEINITLINE, "src/sysfiles.c:FuncREADLINEINITLINE" },
 #endif
 
+
+
     { 0 } };
 
 
@@ -3866,6 +4077,8 @@ static Int postRestore (
 static Int InitKernel(
       StructInitInfo * module )
 {
+  SyInitAlarm();
+  
   /* init filters and functions                                          */
   InitHdlrFuncsFromTable( GVarFuncs );
 

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -1389,13 +1389,19 @@ int SyHaveAlarms = 1;
 /* For now anyway we create one timer at initialisation and use it */
 static timer_t syTimer = 0;
 
+#if SYS_IS_CYGWIN32
+#define MY_CLOCK CLOCK_REALTIME
+#else
+#define MY_CLOCK CLOCK_THREAD_CPUTIME_ID
+#endif
+
 static void SyInitAlarm( void ) {
 /* Create the CPU timer used for timeouts */
   struct sigevent se;
   se.sigev_notify = SIGEV_SIGNAL;
   se.sigev_signo = TIMER_SIGNAL;
-  se.sigev_value.sival_int = 0x12345678;  
-  if (timer_create( CLOCK_THREAD_CPUTIME_ID, &se, &syTimer)) {
+  se.sigev_value.sival_int = 0x12345678;
+  if (timer_create( MY_CLOCK, &se, &syTimer)) {
     Pr("#E  Could not create interval timer. Timeouts will not be supported\n",0L,0L);
     SyHaveAlarms = 0;
   }

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -1380,7 +1380,7 @@ volatile int SyAlarmHasGoneOff = 0;
 
 /* Handler for the Alarm signal */
 
-const int SyHaveAlarms = 1;
+int SyHaveAlarms = 1;
 
 /* This API lets us pick wich signal to use */
 #define TIMER_SIGNAL SIGVTALRM
@@ -1395,7 +1395,10 @@ static void SyInitAlarm( void ) {
   se.sigev_notify = SIGEV_SIGNAL;
   se.sigev_signo = TIMER_SIGNAL;
   se.sigev_value.sival_int = 0x12345678;  
-  timer_create( CLOCK_THREAD_CPUTIME_ID, &se, &syTimer);
+  if (timer_create( CLOCK_THREAD_CPUTIME_ID, &se, &syTimer)) {
+    Pr("#E  Could not create interval timer. Timeouts will not be supported\n",0L,0L);
+    SyHaveAlarms = 0;
+  }
 }
 
 static void syAnswerAlarm ( int signr, siginfo_t * si, void *context)
@@ -1420,7 +1423,7 @@ void SyInstallAlarm ( UInt seconds, UInt nanoseconds )
   sa.sa_handler = NULL;
   sa.sa_sigaction = syAnswerAlarm;
   sigemptyset(&(sa.sa_mask));
-  sa.sa_flags = SA_RESETHAND | SA_SIGINFO;
+  sa.sa_flags = SA_RESETHAND | SA_SIGINFO | SA_RESTART;
   
   /* First install the handler */
   if (sigaction( TIMER_SIGNAL, &sa, NULL ))
@@ -1472,7 +1475,7 @@ void SyStopAlarm(UInt *seconds, UInt *nanoseconds) {
 
 /* Handler for the Alarm signal */
 
-const int SyHaveAlarms = 1;
+int SyHaveAlarms = 1;
 
 
 static void SyInitAlarm( void ) {
@@ -1500,7 +1503,7 @@ void SyInstallAlarm ( UInt seconds, UInt nanoseconds )
   sa.sa_handler = NULL;
   sa.sa_sigaction = syAnswerAlarm;
   sigemptyset(&(sa.sa_mask));
-  sa.sa_flags = SA_RESETHAND | SA_SIGINFO;
+  sa.sa_flags = SA_RESETHAND | SA_SIGINFO | SA_RESTART;
 
   
   /* First install the handler */
@@ -4042,7 +4045,6 @@ static StructGVarFunc GVarFuncs [] = {
     { "READLINEINITLINE", 1, "line",
        FuncREADLINEINITLINE, "src/sysfiles.c:FuncREADLINEINITLINE" },
 #endif
-
 
 
     { 0 } };

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -307,9 +307,17 @@ extern void SyFputs (
 **
 **  'SyIsIntr' returns 1 if the user typed '<ctr>-C' and 0 otherwise.
 */
+
 extern void SyInstallAnswerIntr ( void );
 
 extern UInt SyIsIntr ( void );
+
+extern const int SyHaveAlarms;
+extern volatile int SyAlarmRunning;
+extern volatile int SyAlarmHasGoneOff;
+
+extern void SyInstallAlarm( UInt seconds, UInt nanoseconds);
+extern void SyStopAlarm( UInt *seconds, UInt *nanoseconds);
 
 
 /****************************************************************************

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -312,7 +312,7 @@ extern void SyInstallAnswerIntr ( void );
 
 extern UInt SyIsIntr ( void );
 
-extern const int SyHaveAlarms;
+extern int SyHaveAlarms;
 extern volatile int SyAlarmRunning;
 extern volatile int SyAlarmHasGoneOff;
 

--- a/src/system.h
+++ b/src/system.h
@@ -1053,6 +1053,8 @@ extern Char *getOptionArg(Char key, UInt which);
 #endif
 #endif
 
+extern syJmp_buf AlarmJumpBuffer;
+
 
 
 /****************************************************************************

--- a/tst/testinstall/timeout.tst
+++ b/tst/testinstall/timeout.tst
@@ -1,10 +1,12 @@
 gap> START_TEST("timeout.tst");
-gap> spinFor := function(ms, arg) local t; t := Runtime();
-Syntax warning: New syntax used -- intentional? in stream line 1
-spinFor := function(ms, arg) local t; t := Runtime();
-                                      ^
-> while Runtime() < t + ms do od; if Length(arg) >= 1
+gap> spinFor := function(ms, arg) local t;
+> t := Runtimes().user_time + Runtimes().system_time;
+> while Runtimes().user_time + Runtimes().system_time < t + ms do od;
+> if Length(arg) >= 1
 > then return arg[1]; else return; fi; end;
+Syntax warning: New syntax used -- intentional? in stream line 2
+t := Runtimes().user_time + Runtimes().system_time;
+^
 function( ms, arg ) ... end
 gap> spinFor(10);
 gap> spinFor(10,0);

--- a/tst/testinstall/timeout.tst
+++ b/tst/testinstall/timeout.tst
@@ -1,0 +1,24 @@
+gap> START_TEST("timeout.tst");
+gap> spinFor := function(ms, arg) local t; t := Runtime();
+Syntax warning: New syntax used -- intentional? in stream line 1
+spinFor := function(ms, arg) local t; t := Runtime();
+                                      ^
+> while Runtime() < t + ms do od; if Length(arg) >= 1
+> then return arg[1]; else return; fi; end;
+function( ms, arg ) ... end
+gap> spinFor(10);
+gap> spinFor(10,0);
+0
+gap> CallWithTimeout(5000,spinFor,1);
+[  ]
+gap> CallWithTimeout(5000,spinFor,10000);
+fail
+gap> CallWithTimeout(5000,spinFor,1,1);
+[ 1 ]
+gap> CallWithTimeoutList(5000,spinFor,[1,1]);
+[ 1 ]
+gap> CallWithTimeoutList(5000,spinFor,[10000,1]);
+fail
+gap> CallWithTimeoutList(5000,spinFor,[1]);
+[  ]
+gap> STOP_TEST( "timeout.tst", 330000);


### PR DESCRIPTION
This PR adds a GAP level function 

`CALL_WITH_TIMEOUT( <seconds>, <useconds>, <fn>, <args> )`

`<seconds>` and `<useconds>` must be small ints

The return value is 

    fail -- ran out of time
    [] -- returned within the timeout, no result
    [ <result> ] -- returned a result within the timeout

The timer is paused during a break loop (and might even by nestable) and reset on quitting from a break.
There are some support functions:

TIMEOUTS_SUPPORTED(); -- returns true if timeouts could be compiled in this system and false otherwise

`STOP_TIMEOUT();` -- stops the timer and returns a length 2 list `[<seconds>, <useconds>]`
`RESUME_TIMEOUT( <state> );` -- takes such a list and sets the timer to it and starts it.

these are used in the break loop handling.

This is all intended to be wrapped up at GAP level into something a little bit nicer. There are two implementations behind the scenes, depending on your OS -- one using setitimer and a nicer one using the newer POSIX interface  -- `timer-create()` etc. The second of these could be made to work sensibly in HPC-GAP, I think, but is not available on a Mac.

I'd welcome testing.
