### PR TITLE
Change formatting of name/line of statements in backtraces

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -1245,12 +1245,12 @@ Obj FuncPrintExecutingStatement(Obj self, Obj context)
      else if ( TNUM_STAT(call)  <= LAST_STAT_TNUM ) {
 #endif
       PrintStat( call );
-      Pr(" on line %d of file %s",LINE_STAT(call),(UInt)CSTR_STRING(FILENAME_STAT(call)));
+      Pr(" at %s:%d",(UInt)CSTR_STRING(FILENAME_STAT(call)),LINE_STAT(call));
     }
     else if ( FIRST_EXPR_TNUM <= TNUM_EXPR(call)
               && TNUM_EXPR(call)  <= LAST_EXPR_TNUM ) {
       PrintExpr( call );
-      Pr(" on line %d of file %s",LINE_STAT(call),(UInt)CSTR_STRING(FILENAME_STAT(call)));
+      Pr(" at %s:%d",(UInt)CSTR_STRING(FILENAME_STAT(call)),LINE_STAT(call));
     }
     SWITCH_TO_OLD_LVARS( currLVars );
     return (Obj) 0;


### PR DESCRIPTION
This alters how GAP prints file and linenumber in backtraces, from:

```Intersection2( I, D ) on line 2479 of file /Users/caj/reps/gap/gap/lib/coll.gi```

to:

```Intersection2( I, D ) at /Users/caj/reps/gap/gap/lib/coll.gi:2479```

This second format is a little shorter, and also a more standard way of presenting file/line numbers. Obviously we could use either, I have a slight preference for this one.