### PR TITLE
[WIP] Add basic InstPackages.sh

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+# You need 'gzip', GNU 'tar', a C compiler, sed, pdftex to run this.
+# Run this script from the 'pkg' subdirectory of your GAP installation.
+
+# Contact support@gap-system.org for questions and complaints.
+
+# Note, that this isn't and is not intended to be a sophisticated script.
+# Even if it doesn't work completely automatically for you, you may get
+# an idea what to do for a complete installation of GAP.
+
+# Package-specific info:
+
+# == Linboxing
+#  Easy, if prerequisites are installed. You may get GNU GMP
+#  (http://gmplib.org/) and BLAS (http://www.netlib.org/blas/)
+#  via packages in your Linux distribution. But you probably need to
+#  install LinBox (http://www.linalg.org/download.html) yourself.
+
+if [ $# -eq 0 ]
+  then
+    echo "Assuming default GAP location: ../.."
+    GAPDIR=../..
+  else
+    echo "Using GAP location: $1"
+    GAPDIR="$1"
+fi
+
+# Is someone trying to run us from inside the 'bin' directory?
+if [ -f gapicon.bmp ]
+  then
+    echo "This script must be run from inside the pkg directory"
+    echo "Type: cd ../pkg; ../bin/BuildPackages.sh"
+    exit 1
+fi
+
+# We need any subdirectory, to test if $GAPDIR is right
+SUBDIR=`ls -d */ | head -n 1`
+if ! (cd $SUBDIR && [ -f $GAPDIR/sysinfo.gap ])
+  then
+    echo "$GAPDIR is not the root of a gap installation (no sysinfo.gap)"
+    exit 1
+fi
+
+
+echo Attempting to build GAP packages.
+echo Note that many GAP packages require extra programs to be installed,
+echo and some are quite difficult to build. Please read the documentation for
+echo packages which fail to build correctly, and only worry about packages
+echo you require!
+
+build_carat() {
+(
+# TODO: FIX Carat
+# Installation of Carat produces a lot of data, maybe you want to leave
+# this out until a user complains.
+# It is not possible to move around compiled binaries because these have the
+# path to some data files burned in.
+cd carat
+tar xzpf carat-2.1b1.tgz
+rm -f bin
+ln -s carat-2.1b1/bin bin
+cd carat-2.1b1/functions
+# Install the include Gmp first.
+# (If you have already Gmp on your system, you can delete the file
+# gmp-*.tar.gz and delete the target 'Gmp' from the target 'ALL' in
+# carat-2.1b1/Makefile.)
+tar xzpf gmp-*.tar.gz
+cd ..
+make TOPDIR=`pwd` Links
+# Note that Gmp may use processor specific code, so this step may not be ok
+# for a network installation if you want to use the package on older computers
+# as well.
+make TOPDIR=`pwd` Gmp
+# And now the actual Carat programs.
+make TOPDIR=`pwd` CFLAGS='-O2'
+)
+}
+
+build_cohomolo() {
+(
+cd cohomolo
+./configure $GAPDIR
+cd standalone/progs.d
+cp makefile.orig makefile
+cd ../..
+make
+)
+}
+
+build_fail() {
+  echo = Failed to build $dir
+}
+
+run_configure_and_make() {
+  # We want to know if this is an autoconf configure script
+  # or not, without actually executing it!
+  if [ -f autogen.sh ] && ! [ -f configure ] then
+    ./autogen.sh
+  fi;
+  if [ -f configure ]; then
+    if grep Autoconf ./configure > /dev/null; then
+      ./configure $CONFIGFLAGS --with-gaproot=$GAPDIR && make
+    else
+      ./configure $GAPDIR && make
+    fi;
+  fi;
+}
+
+if grep 'ABI_CFLAGS=-m32' $GAPDIR/Makefile > /dev/null ; then
+  echo Building with 32-bit ABI
+  ABI32=YES
+  CONFIGFLAGS="CFLAGS=-m32 LDFLAGS=-m32 LOPTS=-m32 CXXFLAGS=-m32"
+fi;
+
+for dir in `ls -d */`
+do
+    if [ -e $dir/PackageInfo.g ]; then
+      echo ==== Building $dir
+      case $dir in
+        anupq*)
+          (cd $dir && ./configure $CONFIGFLAGS && make $CONFIGFLAGS) || build_fail
+        ;;
+
+        atlasrep*)
+          (cd $dir && chmod 1777 datagens dataword) || build_fail
+        ;;
+
+        carat*)
+          build_carat || build_fail
+        ;;
+
+        cohomolo*)
+          build_cohomolo || build_fail
+        ;;
+
+        fplsa*)
+          (cd $dir && ./configure $GAPDIR && make CC="gcc -O2 ") || build_fail
+        ;;
+
+        kbmag*)
+          (cd $dir && ./configure $GAPDIR && make COPTS="-O2 -g") || build_fail
+        ;;
+
+        pargap*)
+          (cd $dir && ./configure $GAPDIR && make && cp bin/pargap.sh $GAPDIR/bin && rm -f ALLPKG) || build_fail
+        ;;
+
+        xgap*)
+          (cd $dir && ./configure && make && rm -f $GAPDIR/bin/xgap.sh && cp bin/xgap.sh $GAPDIR/bin) || build_fail
+        ;;
+
+        simpcomp*)
+        ;;
+        
+        *)
+          (cd $dir && run_configure_and_make) || build_fail
+        ;;
+      esac;
+    else
+      echo "$dir is not a GAP package -- no PackageInfo.g"
+    fi;
+done;


### PR DESCRIPTION
This adds to the repository a cleaned up copy of `InstPackages.sh`, the script which tries to build GAP packages. While this isn't perfect, it is I believe better than what we have had before (go and find the script). Of course, on almost all computers you won't be able to build every package (has anyone ever had every package built at once?)

There are many ways this could be improved -- the major obvious issue is that at present we assume that we are in the 'pkg' directory of GAP's source tree.

The main simplification is that I try to build as many packages as possible with one simple(ish) rule. That rule is:

* If there is a `configure` file, run `./configure && make`

32-bit builds on 64-bit OSes add one wrinkle: If the configure script was generated by `autoconf`, then add `CFLAGS=-m32 LDFLAGS=-m32 LOPTS=-m32 CXXFLAGS=-m32 && make`.

This lets us build the vast majority of packages. A few packages remain, most of which will be easy to fix (if updates are released).

There are a few issues I hit, just for people's information:

* It's not generally safe to run 'make clean' or 'make distclean', as this will then force us to rebuild documentation which seems to fail for some packages.

* It's also not safe to run makefiles where there is no configure, as that also often seems to end up failing for documentation related reasons.

