### PR TITLE
Don't delete downloaded package files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -441,22 +441,20 @@ bootstrap-pkg-minimal:
 	@if test -e pkg; then \
         echo "The pkg directory already exists. Please move or remove it to proceed."; \
     else \
+        wget -N $(PKG_BOOTSTRAP_URL)$(PKG_MINIMAL) ; \
         mkdir pkg ; \
         cd pkg ; \
-        wget $(PKG_BOOTSTRAP_URL)$(PKG_MINIMAL) ; \
-        tar xzf $(PKG_MINIMAL) ; \
-        rm $(PKG_MINIMAL) ; \
+        tar xzf ../$(PKG_MINIMAL) ; \
     fi;
 
 bootstrap-pkg-full:
 	@if test -e pkg; then \
         echo "The pkg directory already exists. Please move or remove it to proceed" ; \
     else \
+        wget -N $(PKG_BOOTSTRAP_URL)$(PKG_FULL) ; \
         mkdir pkg ; \
         cd pkg ; \
-        wget $(PKG_BOOTSTRAP_URL)$(PKG_FULL) ; \
-        tar xzf $(PKG_FULL) ; \
-        rm $(PKG_FULL) ; \
+        tar xzf ../$(PKG_FULL) ; \
     fi;
 
 .PHONY: clean clean_$(CLEANME) clean_gap clean_gap_$(CLEANME) clean_gmp clean_gmp_$(CLEANME) compile config cygwin default distclean extern manuals packages rebuild removewin setconfig static strip testinstall testinstall.g testmanuals testpackages testpackagesload testpackagesvars teststandard teststandardrenormalize winbinp


### PR DESCRIPTION
This just rearranges the recently added 'bootstrap-pkg-full' and 'bootstrap-pkg-minimal' Makefile options, so we:

* Don't delete the downloaded package archives
* Check if we already have an up-to-date file if they are run again (that's what wget -N does).

This does use a little more disc space (we keep a compressed copy of the package archive around), but saves bandwidth if packages are repeatedly downloaded (and if, for example, users want to check if their package archive is up to date).



