### PR TITLE
ErrorQuit instead of ErrorMayQuit if input or output can't be opened

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -255,12 +255,12 @@ Obj Shell ( Obj context,
   
   /* read-eval-print loop                                                */
   if (!OpenOutput(outFile))
-    ErrorMayQuit("SHELL: can't open outfile %s",(Int)outFile,0);
+      ErrorQuit("SHELL: can't open outfile %s",(Int)outFile,0);
 
   if(!OpenInput(inFile))
     {
       CloseOutput();
-      ErrorMayQuit("SHELL: can't open infile %s",(Int)inFile,0);
+      ErrorQuit("SHELL: can't open infile %s",(Int)inFile,0);
     }
   
   oldPrintDepth = TLS(PrintObjDepth);


### PR DESCRIPTION
This resolves the infinite looping problem reported by me in #318. Note that I am not sure that this is the *correct* fix for this problem.