### PR TITLE
Make 'And-Filter' store the 'and'ed terms

### DIFF
--- a/src/opers.c
+++ b/src/opers.c
@@ -1212,10 +1212,25 @@ Obj NewAndFilter (
     Obj                 getter;
     Obj                 flags;
 
+    Int                 str_len;
+    Obj                 str;
+    char*               s;
+
     if ( oper1 == ReturnTrueFilter && oper2 == ReturnTrueFilter )
         return ReturnTrueFilter;
 
-    getter = NewFunctionT( T_FUNCTION, SIZE_OPER, StringAndFilter, 1,
+    str_len = GET_LEN_STRING(NAME_FUNC(oper1)) + GET_LEN_STRING(NAME_FUNC(oper2)) + 8;
+    str = NEW_STRING(str_len);
+    s = CSTR_STRING(str);
+    s[0] = '(';
+    s[1] = 0;
+    strlcat(s, CSTR_STRING(NAME_FUNC(oper1)), str_len);
+    strlcat(s, " and ", str_len);
+    strlcat(s, CSTR_STRING(NAME_FUNC(oper2)), str_len);
+    strlcat(s, ")", str_len);
+    SET_LEN_STRING(str, str_len - 1);
+
+    getter = NewFunctionT( T_FUNCTION, SIZE_OPER, str, 1,
                            ArglistObj, DoAndFilter );
     FLAG1_FILT(getter)  = oper1;
     FLAG2_FILT(getter)  = oper2;


### PR DESCRIPTION
This makes and-filters store which filters they were created from. This is most easily described with an example!

Current GAP:

```
gap> Print(IsPermGroup);
<Filter <<and-filter>> >
```

This patch:

```
gap> Print(IsPermGroup);
<Filter "((IsMagmaWithInverses and IsAssociative) and CategoryCollections(IsPerm))">
```