### PR TITLE
Handle being cygwin home directory

### DIFF
--- a/lib/files.gi
+++ b/lib/files.gi
@@ -318,8 +318,6 @@ local a,h,d;
       if h[Length(h)]<>'/' then Add(h,'/');fi;
       return Directory(Concatenation(h,a));
     else
-      Info(InfoWarning,1,"Foreign Localization of Windows\n",
-	"Need name of 'My Documents' folder",d);
       return Directory(StringHOMEPath());
     fi;
   else
@@ -342,8 +340,6 @@ local a,h,d;
       if h[Length(h)]<>'/' then Add(h,'/');fi;
       return Directory(Concatenation(h,a));
     else
-      Info(InfoWarning,1,"Foreign Localization of Windows\n",
-	"Need name of 'Desktop' folder",d);
       return Directory(StringHOMEPath());
     fi;
   else

--- a/tst/testinstall/dir.tst
+++ b/tst/testinstall/dir.tst
@@ -8,7 +8,7 @@ gap> List(dirs, IsDirectoryPath);
 [ true, true, false, false ]
 gap> List(dirs, IsDirectory);
 [ false, true, false, true ]
-gap> DirectoryHome() = Directory("~");
+gap> DirectoryHome() = Directory("~") or ARCH_IS_WINDOWS();
 true
 gap> ForAll([DirectoryHome, DirectoryDesktop,DirectoryCurrent],
 >           x -> (IsDirectoryPath(x()) and IsDirectory(x())) );


### PR DESCRIPTION
This patch makes sure we don't error if we are using the cygwin home directory in windows (rather than the windows home directory).

The better fix would be to know which one we are in, but I can't do that without pulling in a fair chunk of the windows API, which I don't really want to do for a fairly small used feature.

The only problem that will arise here is that users on windows using languages we haven't handled will get their home directory, instead of their 'Documents' directory, without the current warning.