### PR TITLE
Move pausing on exit on Cygwin out of GAP, and into the bat scripts which run GAP

### DIFF
--- a/cnf/gap.bai
+++ b/cnf/gap.bai
@@ -5,4 +5,5 @@ set HOME=%HOMEDRIVE%%HOMEPATH%
 set PATH=@wincygbin@;%PATH%
 cd %HOME%
 start "GAP" @wincygbin@\mintty.exe -s 120,40 @gapdir@/bin/@GAPARCH@/gap.exe -l @gapdir@ %*
+if NOT ["%errorlevel%"]==["0"] timeout 15
 exit

--- a/cnf/gapcmd.bai
+++ b/cnf/gapcmd.bai
@@ -5,4 +5,5 @@ set HOME=%HOMEDRIVE%%HOMEPATH%
 set PATH=@wincygbin@;%PATH%
 cd %HOME%
 @wingapdir@\bin\@GAPARCH@\gap.exe -l @gapdir@ %*
+if NOT ["%errorlevel%"]==["0"] timeout 15
 exit

--- a/cnf/gaprxvt.bai
+++ b/cnf/gaprxvt.bai
@@ -5,4 +5,5 @@ set HOME=%HOMEDRIVE%%HOMEPATH%
 set PATH=@wincygbin@;%PATH%
 cd %HOME%
 start "GAP" @wincygbin@\rxvt.exe -fn fixedsys -sl 1000 - e@gapdir@/bin/@GAPARCH@/gap.exe -l @gapdir@ %*
+if NOT ["%errorlevel%"]==["0"] timeout 15
 exit

--- a/src/system.c
+++ b/src/system.c
@@ -1429,16 +1429,6 @@ void SySleep ( UInt secs )
 void SyExit (
     UInt                ret )
 {
-#if SYS_IS_CYGWIN32
-  if (ret!=0) {
-    Int c;
-    fputs("gap: Press <Enter> to end program\n",stderr);
-    do {
-      c=SyGetch(1);   /* wait for the user to type <return> */
-    } while (c!='\n' && c!=' ');
-  }
-
-#endif
         exit( (int)ret );
 }
 


### PR DESCRIPTION
As in description, this stops GAP on windows prompting "press any key to continue on exit", moving this functionality to gap.bat and friends.

This is to make the 'gap.sh' experience closer to linux.