### PR TITLE
Timerfix

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -1463,7 +1463,7 @@ void SyStopAlarm(UInt *seconds, UInt *nanoseconds) {
 
   timer_settime(syTimer, 0, &tv, &buf);
   SyAlarmRunning = 0;
-  signal(TIMER_SIGNAL, SIG_DFL);
+  signal(TIMER_SIGNAL, SIG_IGN);
 
   if (seconds)
     *seconds = (UInt)buf.it_value.tv_sec;
@@ -1529,7 +1529,7 @@ void SyInstallAlarm ( UInt seconds, UInt nanoseconds )
   SyAlarmRunning = 1;
   SyAlarmHasGoneOff = 0;
   if (setitimer(ITIMER_VIRTUAL, &tv, NULL)) {
-    signal(SIGVTALRM, SIG_DFL);
+    signal(SIGVTALRM, SIG_IGN);
     ErrorReturnVoid("Could not set interval timer", 0L, 0L, "you can return to ignore");
   }
   return;
@@ -1544,7 +1544,7 @@ void SyStopAlarm(UInt *seconds, UInt *nanoseconds) {
 
   setitimer(ITIMER_VIRTUAL, &tv, &buf);
   SyAlarmRunning = 0;
-  signal(SIGVTALRM, SIG_DFL);
+  signal(SIGVTALRM, SIG_IGN);
 
   if (seconds)
     *seconds = (UInt)buf.it_value.tv_sec;

--- a/tst/testinstall/timeout.tst
+++ b/tst/testinstall/timeout.tst
@@ -13,13 +13,13 @@ gap> spinFor(10,0);
 0
 gap> CallWithTimeout(50000,spinFor,1);
 [  ]
-gap> CallWithTimeout(5000,spinFor,10000);
+gap> CallWithTimeout(5000,spinFor,50000);
 fail
 gap> CallWithTimeout(50000,spinFor,1,1);
 [ 1 ]
 gap> CallWithTimeoutList(50000,spinFor,[1,1]);
 [ 1 ]
-gap> CallWithTimeoutList(5000,spinFor,[10000,1]);
+gap> CallWithTimeoutList(5000,spinFor,[50000,1]);
 fail
 gap> CallWithTimeoutList(50000,spinFor,[1]);
 [  ]


### PR DESCRIPTION
This is two tweaks needed for the timer code to pass in cygwin.

1) Cygwin will sometimes report timers after they are cancelled. When we set the signal handler to default, this caused GAP to exit. Change to ignore instead.

2) Extend test timeouts