### PR TITLE
Enhance DirectFactorsOfGroup for faster StructureDescription

### DIFF
--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -16,6 +16,26 @@
 
 #############################################################################
 ##
+#O  IsTrivialNormalIntersection( <G>, <U>, <V> ) . . . . . . . generic method
+##
+##  <ManSection>
+##  <Oper Name="IsTrivialNormalIntersection" Arg="G, U, V"/>
+##
+##  <Description>
+##    For normal subgroups U and V of G, IsTrivialNormalIntersection returns
+##    true if U and V intersect trivially, and false otherwise.
+##    If U and V are not normal subgroups of G, then it may return true
+##    even if they have a nontrivial intersection.
+##  </Description>
+##  </ManSection>
+##
+DeclareOperation( "IsTrivialNormalIntersection",[IsGroup, IsGroup, IsGroup]);
+# checks if arg2 and arg3 both contain the first generator of any element in
+# the given list arg1 of (minimal) normal subgroups
+DeclareOperation( "IsTrivialNormalIntersectionInList",[IsList, IsGroup, IsGroup]);
+
+#############################################################################
+##
 #A  DirectFactorsOfGroup( <G> ) . . . . . decomposition into a direct product
 ##
 ##  <ManSection>
@@ -122,6 +142,21 @@
 ##   and where it is in the b-sequence if any. The the
 ##   linear algorithm above may be used.
 ##
+
+## The Kayal-Nezhmetdinov algorithm is described in
+## Neeraj Kayal and Timur Nezhmetdinov, Factoring Groups Efficiently, in
+## International Colloquium on Automata, Languages and Programming (ICALP) ,
+## Springer Verlag, 2009.
+# Gives a normal complement to the second argument if exists, fail otherwise.
+# In theory it finds the normal complement for infinite groups, as well,
+# but has an infinite loop if g/N is Abelian for infinite N.
+DeclareOperation( "ComplementNormalSubgroup", [IsGroup, IsGroup]);
+DeclareOperation( "ComplementNormalSubgroupNC", [IsGroup, IsGroup]);
+# Kayal-Nezhmetdinov algorithm with only a few tweaks
+DeclareAttribute( "DirectFactorsOfGroupKN", IsGroup );
+# checks if there are factors from first list
+# trivial intersection is checked if both contain anyone from second list
+DeclareGlobalFunction( "DirectFactorsOfGroupFromList", [IsGroup, IsList, IsList]);
 DeclareAttribute( "DirectFactorsOfGroup", IsGroup );
 
 #############################################################################

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -115,6 +115,15 @@ DeclareOperation( "ComplementNormalSubgroupNC", [IsGroup, IsGroup]);
 ##    If <A>G</A> is an infinite abelian group, then it returns an unsorted
 ##    list of the factors. DirectFactorsOfGroup currently cannot compute the
 ##    direct factors of a nonabelian infinite group.
+##
+##    The option <Q>useKN</Q> forces to use the function
+##    DirectFactorsOfGroupKN based on
+##    Neeraj Kayal and Timur Nezhmetdinov, Factoring Groups Efficiently,
+##    in International Colloquium on Automata, Languages and Programming
+##    (ICALP), Lecture Notes in Computer Science 5555, 585-596,
+##    Springer Verlag, Berlin Heidelberg 2009.
+##    This algorithm never computes normal subgroups, and performs slower in
+##    practice than the default method.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -240,7 +249,7 @@ DeclareGlobalFunction( "DirectFactorsOfGroupFromList",
 #A  DirectFactorsOfGroupKN( <G> ) . . . . decomposition into a direct product
 ##
 ##  <ManSection>
-##  <Attr Name="DirectFactorsOfGroupKN" Arg="G"/>
+##  <Func Name="DirectFactorsOfGroupKN" Arg="G"/>
 ##
 ##  <Description>
 ##    A (sorted if possible) list of factors [<A>G1</A>, .., <A>Gr</A>] such
@@ -254,7 +263,7 @@ DeclareGlobalFunction( "DirectFactorsOfGroupFromList",
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareAttribute( "DirectFactorsOfGroupKN", IsGroup );
+DeclareGlobalFunction( "DirectFactorsOfGroupKN", IsGroup );
 
 #############################################################################
 ##

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -58,6 +58,21 @@ DeclareGlobalFunction( "IsTrivialNormalIntersectionInList",
 
 #############################################################################
 ##
+#F  UnionIfCanEasilySortElements( <L1>[, <L2>, ... ] ) . . . . generic method
+##
+##  <ManSection>
+##  <Func Name="UnionIfCanEasilySortElements" Arg="L1[, L2, ... ]"/>
+##
+##  <Description>
+##    Return the union of <A>Li</A> if CanEasilySortElements is true for all
+##    elements of all <A>Li</A>, and the concatenation of them, otherwise.
+##  </Description>
+##  </ManSection>
+##
+DeclareGlobalFunction( "UnionIfCanEasilySortElements", IsList );
+
+#############################################################################
+##
 #O  ComplementNormalSubgroup( <G>, <N> ) . . . . . . . . . . . generic method
 ##
 ##  <#GAPDoc Label="ComplementNormalSubgroup">
@@ -94,8 +109,8 @@ DeclareOperation( "ComplementNormalSubgroupNC", [IsGroup, IsGroup]);
 ##  <Attr Name="DirectFactorsOfGroup" Arg="G"/>
 ##
 ##  <Description>
-##    A sorted list of factors [<A>G1</A>, .., <A>Gr</A>] such that
-##    <A>G</A> = <A>G1</A> x .. x <A>Gr</A> and none of the <A>Gi</A>
+##    A (sorted if possible) list of factors [<A>G1</A>, .., <A>Gr</A>] such
+##    that <A>G</A> = <A>G1</A> x .. x <A>Gr</A> and none of the <A>Gi</A>
 ##    is a direct product.
 ##    If <A>G</A> is an infinite abelian group, then it returns an unsorted
 ##    list of the factors. DirectFactorsOfGroup currently cannot compute the
@@ -114,8 +129,8 @@ DeclareAttribute( "DirectFactorsOfGroup", IsGroup );
 ##  <Func Name="DirectFactorsOfGroup" Arg="G, Ns, MinNs"/>
 ##
 ##  <Description>
-##    A sorted list of factors [<A>G1</A>, .., <A>Gr</A>] such that
-##    <A>G</A> = <A>G1</A> x .. x <A>Gr</A>, none of the <A>Gi</A>
+##    A (sorted if possible) list of factors [<A>G1</A>, .., <A>Gr</A>] such
+##    that <A>G</A> = <A>G1</A> x .. x <A>Gr</A> and none of the <A>Gi</A>
 ##    is a direct product, and all the factors <A>Gi</A> are from the list
 ##    <A>Ns</A>. The list <A>MinNs</A> is supposed to be a list such that the
 ##    intersection of any two groups from <A>Ns</A> is either trivial or
@@ -228,8 +243,8 @@ DeclareGlobalFunction( "DirectFactorsOfGroupFromList",
 ##  <Attr Name="DirectFactorsOfGroupKN" Arg="G"/>
 ##
 ##  <Description>
-##    A sorted list of factors [<A>G1</A>, .., <A>Gr</A>] such that
-##    <A>G</A> = <A>G1</A> x .. x <A>Gr</A> and none of the <A>Gi</A>
+##    A (sorted if possible) list of factors [<A>G1</A>, .., <A>Gr</A>] such
+##    that <A>G</A> = <A>G1</A> x .. x <A>Gr</A> and none of the <A>Gi</A>
 ##    is a direct product.
 ##    This is the implementation of the algorithm described in
 ##    Neeraj Kayal and Timur Nezhmetdinov, Factoring Groups Efficiently,

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -35,10 +35,10 @@ DeclareOperation( "IsTrivialNormalIntersection",
 
 #############################################################################
 ##
-#O  IsTrivialNormalIntersectionInList( <MinNs>, <U>, <V> ) . . generic method
+#F  IsTrivialNormalIntersectionInList( <MinNs>, <U>, <V> ) . . generic method
 ##
 ##  <ManSection>
-##  <Oper Name="IsTrivialNormalIntersectionInList" Arg="MinNs, U, V"/>
+##  <Func Name="IsTrivialNormalIntersectionInList" Arg="MinNs, U, V"/>
 ##
 ##  <Description>
 ##    For groups <A>U</A> and <A>V</A>, IsTrivialNormalIntersection returns

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -22,22 +22,74 @@
 ##  <Oper Name="IsTrivialNormalIntersection" Arg="G, U, V"/>
 ##
 ##  <Description>
-##    For normal subgroups U and V of G, IsTrivialNormalIntersection returns
-##    true if U and V intersect trivially, and false otherwise.
-##    If U and V are not normal subgroups of G, then it may return true
-##    even if they have a nontrivial intersection.
+##    For normal subgroups <A>U</A> and <A>V</A> of <A>G</A>,
+##    IsTrivialNormalIntersection returns
+##    true if <A>U</A> and <A>V</A> intersect trivially, and false otherwise.
+##    The result is undefined if either <A>U</A> or <A>V</A> is not a normal
+##    subgroup of G.
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareOperation( "IsTrivialNormalIntersection",[IsGroup, IsGroup, IsGroup]);
-# checks if arg2 and arg3 both contain the first generator of any element in
-# the given list arg1 of (minimal) normal subgroups
-DeclareOperation( "IsTrivialNormalIntersectionInList",[IsList, IsGroup, IsGroup]);
+DeclareOperation( "IsTrivialNormalIntersection",
+                  [ IsGroup, IsGroup, IsGroup ] );
+
+#############################################################################
+##
+#O  IsTrivialNormalIntersectionInList( <MinNs>, <U>, <V> ) . . generic method
+##
+##  <ManSection>
+##  <Oper Name="IsTrivialNormalIntersectionInList" Arg="MinNs, U, V"/>
+##
+##  <Description>
+##    For groups <A>U</A> and <A>V</A>, IsTrivialNormalIntersection returns
+##    false if for any group H in list <A>MinNs</A> both <A>U</A> and
+##    <A>V</A> contains the first nontrivial generator of H. Otherwise, the
+##    result is true.
+##    This operation is useful if it is already known that the intersection
+##    of <A>U</A> and <A>V</A> is either trivial, or contains at least one
+##    group from <A>MinNs</A>.
+##    For example if </A>U</A> and </A>V</A> are normal subgroups of a group
+##    G and <A>MinNs</A>=MinimalNormalSubgroups(G).
+##  </Description>
+##  </ManSection>
+##
+DeclareOperation( "IsTrivialNormalIntersectionInList",
+                  [ IsList, IsGroup, IsGroup ] );
+
+#############################################################################
+##
+#O  ComplementNormalSubgroup( <G>, <N> ) . . . . . . . . . . . generic method
+##
+##  <#GAPDoc Label="ComplementNormalSubgroup">
+##  <ManSection>
+##  <Oper Name="ComplementNormalSubgroup" Arg="G, N"/>
+##
+##  <Description>
+##    Gives a normal complement to the normal subgroup <A>N</A> in <A>G</A>
+##    if exists, fail otherwise.
+##    In theory it finds the normal complement for infinite <A>G</A>,
+##    but can have an infinite loop if <A>G/N</A> is abelian and <A>N</A> is
+##    infinite.
+##    ComplementNormalSubgroupsNC does not check if <A>N</A> is a normal
+##    subgroup of <A>G</A>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+##    This is the implementation of the algorithm described in
+##    Neeraj Kayal and Timur Nezhmetdinov, Factoring Groups Efficiently,
+##    in International Colloquium on Automata, Languages and Programming
+##    (ICALP), Lecture Notes in Computer Science 5555, 585-596,
+##    Springer Verlag, Berlin Heidelberg 2009.
+##
+DeclareOperation( "ComplementNormalSubgroup", [IsGroup, IsGroup]);
+DeclareOperation( "ComplementNormalSubgroupNC", [IsGroup, IsGroup]);
 
 #############################################################################
 ##
 #A  DirectFactorsOfGroup( <G> ) . . . . . decomposition into a direct product
 ##
+##  <#GAPDoc Label="DirectFactorsOfGroup">
 ##  <ManSection>
 ##  <Attr Name="DirectFactorsOfGroup" Arg="G"/>
 ##
@@ -45,6 +97,29 @@ DeclareOperation( "IsTrivialNormalIntersectionInList",[IsList, IsGroup, IsGroup]
 ##    A sorted list of factors [<A>G1</A>, .., <A>Gr</A>] such that
 ##    <A>G</A> = <A>G1</A> x .. x <A>Gr</A> and none of the <A>Gi</A>
 ##    is a direct product.
+##    If <A>G</A> is an infinite abelian group, then it returns an unsorted
+##    list of the factors. DirectFactorsOfGroup currently cannot compute the
+##    direct factors of a nonabelian infinite group.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareAttribute( "DirectFactorsOfGroup", IsGroup );
+
+#############################################################################
+##
+#F  DirectFactorsOfGroupFromList( <G>, <Ns>, <MinNs> )
+##
+##  <ManSection>
+##  <Func Name="DirectFactorsOfGroup" Arg="G, Ns, MinNs"/>
+##
+##  <Description>
+##    A sorted list of factors [<A>G1</A>, .., <A>Gr</A>] such that
+##    <A>G</A> = <A>G1</A> x .. x <A>Gr</A>, none of the <A>Gi</A>
+##    is a direct product, and all the factors <A>Gi</A> are from the list
+##    <A>Ns</A>. The list <A>MinNs</A> is supposed to be a list such that the
+##    intersection of any two groups from <A>Ns</A> is either trivial or
+##    contains a group from <A>MinNs</A>.
 ##  </Description>
 ##  </ManSection>
 ##
@@ -139,25 +214,32 @@ DeclareOperation( "IsTrivialNormalIntersectionInList",[IsList, IsGroup, IsGroup]
 ##      This is done by merging the two sequences into
 ##   a single increasing sequence of pairs <c_i, which_i>
 ##   where which_i indicates where c_i is in the a-sequence
-##   and where it is in the b-sequence if any. The the
+##   and where it is in the b-sequence if any. Then the
 ##   linear algorithm above may be used.
 ##
+DeclareGlobalFunction( "DirectFactorsOfGroupFromList",
+                        [ IsGroup, IsList, IsList ] );
 
-## The Kayal-Nezhmetdinov algorithm is described in
-## Neeraj Kayal and Timur Nezhmetdinov, Factoring Groups Efficiently, in
-## International Colloquium on Automata, Languages and Programming (ICALP) ,
-## Springer Verlag, 2009.
-# Gives a normal complement to the second argument if exists, fail otherwise.
-# In theory it finds the normal complement for infinite groups, as well,
-# but has an infinite loop if g/N is Abelian for infinite N.
-DeclareOperation( "ComplementNormalSubgroup", [IsGroup, IsGroup]);
-DeclareOperation( "ComplementNormalSubgroupNC", [IsGroup, IsGroup]);
-# Kayal-Nezhmetdinov algorithm with only a few tweaks
+#############################################################################
+##
+#A  DirectFactorsOfGroupKN( <G> ) . . . . decomposition into a direct product
+##
+##  <ManSection>
+##  <Attr Name="DirectFactorsOfGroupKN" Arg="G"/>
+##
+##  <Description>
+##    A sorted list of factors [<A>G1</A>, .., <A>Gr</A>] such that
+##    <A>G</A> = <A>G1</A> x .. x <A>Gr</A> and none of the <A>Gi</A>
+##    is a direct product.
+##    This is the implementation of the algorithm described in
+##    Neeraj Kayal and Timur Nezhmetdinov, Factoring Groups Efficiently,
+##    in International Colloquium on Automata, Languages and Programming
+##    (ICALP), Lecture Notes in Computer Science 5555, 585-596,
+##    Springer Verlag, Berlin Heidelberg 2009.
+##  </Description>
+##  </ManSection>
+##
 DeclareAttribute( "DirectFactorsOfGroupKN", IsGroup );
-# checks if there are factors from first list
-# trivial intersection is checked if both contain anyone from second list
-DeclareGlobalFunction( "DirectFactorsOfGroupFromList", [IsGroup, IsList, IsList]);
-DeclareAttribute( "DirectFactorsOfGroup", IsGroup );
 
 #############################################################################
 ##

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -73,11 +73,11 @@ DeclareGlobalFunction( "UnionIfCanEasilySortElements", IsList );
 
 #############################################################################
 ##
-#O  ComplementNormalSubgroup( <G>, <N> ) . . . . . . . . . . . generic method
+#O  NormalComplement( <G>, <N> ) . . . . . . . . . . . generic method
 ##
-##  <#GAPDoc Label="ComplementNormalSubgroup">
+##  <#GAPDoc Label="NormalComplement">
 ##  <ManSection>
-##  <Oper Name="ComplementNormalSubgroup" Arg="G, N"/>
+##  <Oper Name="NormalComplement" Arg="G, N"/>
 ##
 ##  <Description>
 ##    Gives a normal complement to the normal subgroup <A>N</A> in <A>G</A>
@@ -85,7 +85,7 @@ DeclareGlobalFunction( "UnionIfCanEasilySortElements", IsList );
 ##    In theory it finds the normal complement for infinite <A>G</A>,
 ##    but can have an infinite loop if <A>G/N</A> is abelian and <A>N</A> is
 ##    infinite.
-##    ComplementNormalSubgroupsNC does not check if <A>N</A> is a normal
+##    NormalComplementsNC does not check if <A>N</A> is a normal
 ##    subgroup of <A>G</A>.
 ##  </Description>
 ##  </ManSection>
@@ -97,8 +97,8 @@ DeclareGlobalFunction( "UnionIfCanEasilySortElements", IsList );
 ##    (ICALP), Lecture Notes in Computer Science 5555, 585-596,
 ##    Springer Verlag, Berlin Heidelberg 2009.
 ##
-DeclareOperation( "ComplementNormalSubgroup", [IsGroup, IsGroup]);
-DeclareOperation( "ComplementNormalSubgroupNC", [IsGroup, IsGroup]);
+DeclareOperation( "NormalComplement", [IsGroup, IsGroup]);
+DeclareOperation( "NormalComplementNC", [IsGroup, IsGroup]);
 
 #############################################################################
 ##

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -48,7 +48,7 @@ DeclareOperation( "IsTrivialNormalIntersection",
 ##    This operation is useful if it is already known that the intersection
 ##    of <A>U</A> and <A>V</A> is either trivial, or contains at least one
 ##    group from <A>MinNs</A>.
-##    For example if </A>U</A> and </A>V</A> are normal subgroups of a group
+##    For example if <A>U</A> and <A>V</A> are normal subgroups of a group
 ##    G and <A>MinNs</A>=MinimalNormalSubgroups(G).
 ##  </Description>
 ##  </ManSection>

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -53,7 +53,7 @@ DeclareOperation( "IsTrivialNormalIntersection",
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareOperation( "IsTrivialNormalIntersectionInList",
+DeclareGlobalFunction( "IsTrivialNormalIntersectionInList",
                   [ IsList, IsGroup, IsGroup ] );
 
 #############################################################################

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -315,6 +315,11 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
 
     if not CanComputeSize(G) or not IsFinite(G) then TryNextMethod(); fi;
 
+    # the KN method performs slower in practice, only called if forced
+    if ValueOption("useKN") = true then
+      return DirectFactorsOfGroupKN(G);
+    fi;
+
     # nilpotent groups are direct products of Sylow subgroups
     if IsNilpotentGroup(G) then
       if not IsPGroup(G) then
@@ -466,8 +471,8 @@ InstallGlobalFunction( DirectFactorsOfGroupFromList,
     return [ G ];
   end );
 
-InstallMethod(DirectFactorsOfGroupKN, "Kayal-Nezhmetdinov method", true,
-                        [ IsGroup ], 0,
+InstallGlobalFunction(DirectFactorsOfGroupKN,
+
   function(G)
 
     local Ns,       # list of some direct components

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -89,7 +89,7 @@ InstallMethod( IsTrivialNormalIntersection,
 #M  ComplementNormalSubgroup( <G>, <N> ) . . . . . . . . . . . generic method
 ##
 InstallMethod( ComplementNormalSubgroup,
-               "generic method", [ IsGroup,  IsGroup ],
+               "generic method", IsIdenticalObj, [ IsGroup,  IsGroup ],
 
   function( G, N )
 
@@ -110,7 +110,7 @@ InstallMethod( ComplementNormalSubgroup,
   end);
 
 InstallMethod( ComplementNormalSubgroupNC,
-               "generic method", [ IsGroup,  IsGroup ],
+               "generic method", IsIdenticalObj, [ IsGroup,  IsGroup ],
 
   function( G, N )
 
@@ -119,12 +119,12 @@ InstallMethod( ComplementNormalSubgroupNC,
           gF,   # element of F=G/N
           i,    # running index
           l,    # list for storing stuff
-          b,    # elements of Abelian complement
+          b,    # elements of abelian complement
           B,    # complement to N
           T,    # = [C_G(N), G] = 1 x B'
           Gf,   # = G/T = N x B/B'
           Nf,   # = NT/T
-          Bf,   # Abelian complement to Nf in Gf ( = B/B')
+          Bf,   # abelian complement to Nf in Gf ( = B/B')
           BfF;  # Direct factors of Bf
 
     # if <N> is trivial then the only complement is <G>
@@ -135,7 +135,7 @@ InstallMethod( ComplementNormalSubgroupNC,
     elif G = N  then
       return TrivialSubgroup(G);
 
-    # if G/N is Abelian
+    # if G/N is abelian
     elif HasAbelianFactorGroup(G, N) then
       F := FactorGroupNC(G, N);
       b := [];
@@ -154,7 +154,7 @@ InstallMethod( ComplementNormalSubgroupNC,
       B := SubgroupNC(G, b);
       return B;
 
-    # if G/N is not Abelian
+    # if G/N is not abelian
     else
       T := CommutatorSubgroup(Centralizer(G, N), G);
       if not IsTrivial(T) and IsTrivialNormalIntersection(G, T, N) then
@@ -274,14 +274,15 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
           N,        # (possible) component of G, containing g
           B;        # (possible) complement of G in N
 
-    # for Abelian groups return the canonical decomposition
+    # for abelian groups return the canonical decomposition
     if IsTrivial(G) then
       return [G];
     elif IsAbelian(G) then
       Ns := List(IndependentGeneratorsOfAbelianGroup(G),
                                                   g -> SubgroupNC(G, [g]));
-      # for infinite groups Set may be very inefficient
-      # might cause problems because for finite groups we return a set
+      # for infinite groups Set may be very inefficient or might not even
+      # terminate
+      # this might cause problems because for finite groups we return a set
       if not IsFinite(G) then
         return Ns;
       else
@@ -291,7 +292,7 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
 
     if not IsFinite(G) then TryNextMethod(); fi;
 
-    # Nilpotent groups are direct product of Sylow subgroups
+    # nilpotent groups are direct product of Sylow subgroups
     if IsNilpotentGroup(G) then
       if not IsPGroup(G) then
         Ns := [ ];
@@ -315,9 +316,9 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
       fi;
     fi;
 
-    # look for Abelian cyclic component from the center
+    # look for abelian cyclic component from the center
     C := Center(G);
-    # (these components cannot lie in the commutator)
+    # abelian cyclic components cannot lie in the commutator
     Gd := DerivedSubgroup(G);
     avoid := [];
     for g in C do
@@ -334,19 +335,19 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
       fi;
     od;
 
-    # all components are non-Abelian
+    # all components are nonabelian
     if IsCyclic(Gd) and IsPrimePowerInt(Size(Gd)) then
-      # if A and B are two non-Abelian components, then
+      # if A and B are two nonabelian components, then
       # A' and B' must be nontrivial
-      # this can only help for some meta-Abelian groups
+      # this can only help for some metabelian groups
       return [ G ];
     fi;
 
     if not IsTrivial(C) then
       GC := G/C;
       if IsAbelian(GC) and Length(DirectFactorsOfGroup(GC)) < 4 then
-        # if A and B are two non-Abelian components,
-        # where A/Center(A) and B/Center(B) are Abelian, then
+        # if A and B are two nonabelian components,
+        # where A/Center(A) and B/Center(B) are abelian, then
         # A/Center(A) and B/Center(B) must have at least two components each
         return [ G ];
       fi;
@@ -459,10 +460,10 @@ InstallMethod(DirectFactorsOfGroupKN, "Kayal-Nezhmetdinov method", true,
           edges,    # final edges of the non-commuting graph
           e,        # one edge of the non-commuting graph
           comp,     # components of the non-commuting graph
-          DfZ1,     # non-Abelian direct factors of Z1
+          DfZ1,     # nonabelian direct factors of Z1
           S1;       # index set corresponding to first component
 
-    # for Abelian groups return the canonical decomposition
+    # for abelian groups return the canonical decomposition
     if IsTrivial(G) then
       return [G];
     elif IsAbelian(G) then
@@ -479,7 +480,7 @@ InstallMethod(DirectFactorsOfGroupKN, "Kayal-Nezhmetdinov method", true,
 
     if not IsFinite(G) then TryNextMethod(); fi;
 
-    # look for Abelian cyclic component from the center
+    # look for abelian cyclic component from the center
     C := Center(G);
     # (these components cannot lie in the commutator)
     Gd := DerivedSubgroup(G);
@@ -498,7 +499,7 @@ InstallMethod(DirectFactorsOfGroupKN, "Kayal-Nezhmetdinov method", true,
       fi;
     od;
 
-    # all components are non-Abelian
+    # all components are nonabelian
     # !!! this can (and should) be made more efficient later !!!
     # instead of conjugacy classes we should calculate by normal subgroups
     # generated by 1 element
@@ -568,7 +569,7 @@ InstallMethod(DirectFactorsOfGroupKN, "Kayal-Nezhmetdinov method", true,
         prodK := ClosureGroup(prodK, K);
       od;
       Z1 := Centralizer(G, prodK);
-      # Z1 is non-Abelian <==> contains a non-Abelian factor
+      # Z1 is nonabelian <==> contains a nonabelian factor
       if not IsAbelian(Z1) then
         N := First(DirectFactorsOfGroupKN(Z1), x-> not IsAbelian(x));
         # not sure if IsNormal(G, N) should be checked

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -217,7 +217,7 @@ InstallMethod(DirectFactorsOfGroup, "if normal subgroups are computed", true,
                       [ IsGroup and HasNormalSubgroups ], 10,
 
   function(G)
-    local Ns, MinNs, GGd, gs;
+    local Ns, MinNs, GGd, g, N, gs;
 
     Ns := NormalSubgroups(G);
     MinNs := MinimalNormalSubgroups(G);
@@ -239,7 +239,13 @@ InstallMethod(DirectFactorsOfGroup, "if normal subgroups are computed", true,
       return [ G ];
     fi;
 
-    gs := Set(MinNs, N -> GeneratorsOfGroup(N)[1]);
+    gs := [ ];
+    for N in MinNs do
+      g := First(GeneratorsOfGroup(N), g -> g<>One(N));
+      if g <> fail then
+        AddSet(gs, g);
+      fi;
+    od;
     # normal subgroup containing all minimal subgroups cannot have complement
     Ns := Filtered(Ns, N -> not IsSubset(N, gs));
 
@@ -362,7 +368,13 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
       return [ G ];
     fi;
 
-    gs := Set(MinNs, N -> GeneratorsOfGroup(N)[1]);
+    gs := [ ];
+    for N in MinNs do
+      g := First(GeneratorsOfGroup(N), g -> g<>One(N));
+      if g <> fail then
+        AddSet(gs, g);
+      fi;
+    od;
     # normal subgroup containing all minimal subgroups cannot have complement
     Ns := Filtered(Ns, N -> not IsSubset(N, gs));
 
@@ -373,7 +385,7 @@ InstallGlobalFunction( DirectFactorsOfGroupFromList,
 
   function ( G, NList, MinList )
 
-    local  gs, Ns, MinNs, NNs, MinNNs, facts, sizes, i, j, s1, s2;
+    local g, N, gs, Ns, MinNs, NNs, MinNNs, facts, sizes, i, j, s1, s2;
 
     if Length(MinList)=1 then
       # size of MinList is an upper bound to the number of components
@@ -384,8 +396,13 @@ InstallGlobalFunction( DirectFactorsOfGroupFromList,
 
     Ns := ShallowCopy(NList);
     MinNs := ShallowCopy(MinList);
-    gs:= List(Filtered(MinNs, N -> not IsTrivial(N)),
-                                               N -> GeneratorsOfGroup(N)[1]);
+    gs := [ ];
+    for N in MinNs do
+      g := First(GeneratorsOfGroup(N), g -> g<>One(N));
+      if g <> fail then
+        AddSet(gs, g);
+      fi;
+    od;
     # normal subgroup containing all minimal subgroups cannot have complement
     Ns := Filtered(Ns, N -> not IsSubset(N, gs));
     sizes := List(Ns,Size);

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -295,9 +295,8 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
           return [ G ];
         fi;
       fi;
-    fi;
-
-    if IsSolvableGroup(G) then
+    # nonabelian p-groups cannot have a unique maximal subgroup
+    elif IsSolvableGroup(G) then
       GGd := CommutatorFactorGroup(G);
       if IsCyclic(GGd) and IsPrimePowerInt(Size(GGd)) then
         # G is direct indecomposable, because has a unique maximal subgroup

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -593,27 +593,30 @@ InstallMethod(DirectFactorsOfGroupKN, "Kayal-Nezhmetdinov method", true,
 
     # look for the possible direct components from Ns
     # partition to two sets, consider both
-    for S1 in PartitionsSet(Ns,2) do for i in [1..2] do
-      prodK := TrivialSubgroup(G);
-      for K in S1[i] do
-        prodK := ClosureGroup(prodK, K);
-      od;
-      Z1 := Centralizer(G, prodK);
-      # Z1 is nonabelian <==> contains a nonabelian factor
-      if not IsAbelian(Z1) then
-        N := First(DirectFactorsOfGroupKN(Z1), x-> not IsAbelian(x));
-        # not sure if IsNormal(G, N) should be checked
+    for S1 in IteratorOfCombinations(Ns) do
+      if S1 <> [] and S1<>Ns then
+        prodK := TrivialSubgroup(G);
+        for K in S1 do
+          prodK := ClosureGroup(prodK, K);
+        od;
+        Z1 := Centralizer(G, prodK);
+        # Z1 is nonabelian <==> contains a nonabelian factor
+        if not IsAbelian(Z1) then
+          N := First(DirectFactorsOfGroupKN(Z1), x-> not IsAbelian(x));
+          # not sure if IsNormal(G, N) should be checked
 
-        # this certainly can be done better,
-        # because we basically know all possible normal subgroups
-        # but it suffices for now
-        B := ComplementNormalSubgroup(G, N);
-        if B <> fail then
-          # N is direct indecomposable by construction
-          return UnionIfCanEasilySortElements([N],DirectFactorsOfGroupKN(B));
+          # this certainly can be done better,
+          # because we basically know all possible normal subgroups
+          # but it suffices for now
+          B := ComplementNormalSubgroup(G, N);
+          if B <> fail then
+            # N is direct indecomposable by construction
+            return UnionIfCanEasilySortElements([N],
+                                                  DirectFactorsOfGroupKN(B));
+          fi;
         fi;
       fi;
-    od; od;
+    od;
 
     # if no direct component is found
     return [ G ];

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -239,10 +239,16 @@ InstallMethod(DirectFactorsOfGroup, "if normal subgroups are computed", true,
         # G is direct indecomposable, because has a unique maximal subgroup
         return [ G ];
       fi;
-    elif Length(MaximalNormalSubgroups(G))= 1 then
-      # size of MaximalNormalSubgroups is an upper bound to the number of
-      # components
-      return [ G ];
+    else
+      GGd := CommutatorFactorGroup(G);
+      # if GGd is not cyclic of prime power size then there are at least two
+      # maximal subgroups
+      if IsTrivial(GGd) or (IsCyclic(GGd) and IsPrimePowerInt(Size(GGd)))
+        and Length(MaximalNormalSubgroups(G))= 1 then
+        # size of MaximalNormalSubgroups is an upper bound to the number of
+        # components
+        return [ G ];
+      fi;
     fi;
 
     gs := [ ];
@@ -368,10 +374,16 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
       return [ G ];
     fi;
 
-    if not IsSolvableGroup(G) and Length(MaximalNormalSubgroups(G))= 1 then
-      # size of MaximalNormalSubgroups is an upper bound to the number of
-      # components
-      return [ G ];
+    if not IsSolvableGroup(G) then
+      GGd := CommutatorFactorGroup(G);
+      # if GGd is not cyclic of prime power size then there are at least two
+      # maximal subgroups
+      if IsTrivial(GGd) or (IsCyclic(GGd) and IsPrimePowerInt(Size(GGd)))
+        and Length(MaximalNormalSubgroups(G))= 1 then
+        # size of MaximalNormalSubgroups is an upper bound to the number of
+        # components
+        return [ G ];
+      fi;
     fi;
 
     gs := [ ];

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -25,16 +25,18 @@
 ##
 #M  IsTrivialNormalIntersectionInList( <L>, <U>, <V> ) . . . . generic method
 ##
-InstallMethod( IsTrivialNormalIntersectionInList,
-               "if minimal normal subgroups are computed",
-               [ IsList, IsGroup, IsGroup ],
+InstallGlobalFunction( IsTrivialNormalIntersectionInList,
 
-  function( L, U, V )
-    local gs;
+  function( MinNs, U, V )
+    local N, g;
 
-    gs:= List(Filtered(L, N -> not IsTrivial(N)),
-                                               N -> GeneratorsOfGroup(N)[1]);
-    return ForAll(gs, g -> not g in U or not g in V);
+    for N in MinNs do
+      g := First(GeneratorsOfGroup(N), g -> g<>One(N));
+      if g <> fail and g in U and g in V then
+        return false;
+      fi;
+    od;
+    return true;
   end);
 
 #############################################################################
@@ -43,41 +45,28 @@ InstallMethod( IsTrivialNormalIntersectionInList,
 ##
 
 InstallMethod( IsTrivialNormalIntersection,
-               "if minimal normal subgroups are computed",
+               "if minimal normal subgroups are computed", IsFamFamFam,
                [ IsGroup and HasMinimalNormalSubgroups, IsGroup, IsGroup ],
 
   function( G, U, V )
-    local gs;
+    local N, g;
 
-    gs := List(MinimalNormalSubgroups(G), N -> GeneratorsOfGroup(N)[1]);
-    return ForAll(gs, g -> not g in U or not g in V);
+    for N in MinimalNormalSubgroups(G) do
+      g := First(GeneratorsOfGroup(N), g -> g<>One(N));
+      if g <> fail and g in U and g in V then
+        # found a nontrivial common element
+        return false;
+      fi;
+    od;
+    # if U and V intersect nontrivially, then their intersection must contain
+    # a minimal normal subgroup, and therefore both U and V contains any of
+    # its generators
+    return true;
   end);
 
 InstallMethod( IsTrivialNormalIntersection,
-               "if socle is computed",
-               [ IsGroup and HasSocle, IsGroup, IsGroup ],
-
-  function( G, U, V )
-    local gs;
-
-    gs := GeneratorsOfGroup(Socle(G));
-    return ForAll(gs, g -> not g in U or not g in V);
-  end);
-
-InstallMethod( IsTrivialNormalIntersection,
-               "for nilpotent groups",
-               [ IsGroup and IsNilpotentGroup, IsGroup, IsGroup ],
-
-  function( G, U, V )
-    local gs;
-
-    gs := List(MinimalNormalSubgroups(Center(G)),
-                                              N -> GeneratorsOfGroup(N)[1]);
-    return ForAll(gs, g -> not g in U or not g in V);
-  end);
-
-InstallMethod( IsTrivialNormalIntersection,
-               "generic method", [ IsGroup, IsGroup, IsGroup ],
+               "generic method", IsFamFamFam,
+               [ IsGroup, IsGroup, IsGroup ],
 
   function( G, U, V )
 

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -313,7 +313,7 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
       return Ns;
     fi;
 
-    if not IsFinite(G) then TryNextMethod(); fi;
+    if not CanComputeSize(G) or not IsFinite(G) then TryNextMethod(); fi;
 
     # nilpotent groups are direct products of Sylow subgroups
     if IsNilpotentGroup(G) then

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -342,7 +342,7 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
     Gd := DerivedSubgroup(G);
     D := Intersection(C, Gd);
     for g in RationalClasses(C) do
-      N := Subgroup(C, Set(g));
+      N := Subgroup(C, [Representative(g)]);
       if not IsTrivial(N) and IsTrivialNormalIntersection(C, D, N) then
         B := ComplementNormalSubgroupNC(G, N);
         # if B is a complement to N
@@ -515,7 +515,7 @@ InstallMethod(DirectFactorsOfGroupKN, "Kayal-Nezhmetdinov method", true,
     Gd := DerivedSubgroup(G);
     D := Intersection(C, Gd);
     for g in RationalClasses(C) do
-      N := Subgroup(C, Set(g));
+      N := Subgroup(C, [Representative(g)]);
       if not IsTrivial(N) and IsTrivialNormalIntersection(C, D, N) then
         B := ComplementNormalSubgroupNC(G, N);
         # if B is a complement to N

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -194,7 +194,7 @@ InstallMethod( ComplementNormalSubgroupNC,
 ##
 InstallMethod(DirectFactorsOfGroup,
             "for direct products if normal subgroups are computed", true,
-            [ IsGroup and HasDirectProductInfo and HasNormalSubgroups ], 10,
+            [ IsGroup and HasDirectProductInfo and HasNormalSubgroups ], 0,
 
   function(G)
     local i, info, Ns, MinNs, H, Df, DfNs, DfMinNs, N, g, gs;
@@ -228,7 +228,7 @@ InstallMethod(DirectFactorsOfGroup,
   end);
 
 InstallMethod(DirectFactorsOfGroup, "for direct products", true,
-                      [ IsGroup and HasDirectProductInfo ], 10,
+                      [ IsGroup and HasDirectProductInfo ], 0,
 
   function(G)
     local i, info, Ns;
@@ -243,7 +243,7 @@ InstallMethod(DirectFactorsOfGroup, "for direct products", true,
   end);
 
 InstallMethod(DirectFactorsOfGroup, "if normal subgroups are computed", true,
-                      [ IsGroup and HasNormalSubgroups ], 10,
+                      [ IsGroup and HasNormalSubgroups ], 0,
 
   function(G)
     local Ns, MinNs, GGd, g, N, gs;
@@ -467,7 +467,7 @@ InstallGlobalFunction( DirectFactorsOfGroupFromList,
   end );
 
 InstallMethod(DirectFactorsOfGroupKN, "Kayal-Nezhmetdinov method", true,
-                        [ IsGroup ], 10,
+                        [ IsGroup ], 0,
   function(G)
 
     local Ns,       # list of some direct components

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -315,7 +315,7 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
 
     if not IsFinite(G) then TryNextMethod(); fi;
 
-    # nilpotent groups are direct product of Sylow subgroups
+    # nilpotent groups are direct products of Sylow subgroups
     if IsNilpotentGroup(G) then
       if not IsPGroup(G) then
         Ns := [ ];
@@ -323,11 +323,9 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
           Ns := UnionIfCanEasilySortElements(Ns, DirectFactorsOfGroup(N));
         od;
         return Ns;
-      else
-        if IsCyclic(Center(G)) then
-          # G is direct indecomposable, because has a unique minimal subgroup
-          return [ G ];
-        fi;
+      elif IsCyclic(Center(G)) then
+        # G is direct indecomposable, because has a unique minimal subgroup
+        return [ G ];
       fi;
     # nonabelian p-groups cannot have a unique maximal subgroup
     elif IsSolvableGroup(G) then

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -294,7 +294,6 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
           GGd,      # G/G'
           C,        # Center(G)
           D,        # Intersection(C, Gd)
-          GC,       # G/C
           Ns,       # list of normal subgroups
           MinNs,    # list of minimal normal subgroups
           gs,       # list containing one generator for each MinNs
@@ -364,14 +363,12 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
       return [ G ];
     fi;
 
-    if not IsTrivial(C) then
-      GC := G/C;
-      if IsAbelian(GC) and Length(DirectFactorsOfGroup(GC)) < 4 then
-        # if A and B are two nonabelian components,
-        # where A/Center(A) and B/Center(B) are abelian, then
-        # A/Center(A) and B/Center(B) must have at least two components each
-        return [ G ];
-      fi;
+    if not IsTrivial(C) and HasAbelianFactorGroup(G, C)
+      and Length(DirectFactorsOfGroup(G/C)) < 4 then
+      # if A and B are two nonabelian components,
+      # where A/Center(A) and B/Center(B) are abelian, then
+      # A/Center(A) and B/Center(B) must have at least two components each
+      return [ G ];
     fi;
 
     # if everything else fails, compute all normal subgroups

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -176,7 +176,7 @@ InstallMethod(DirectFactorsOfGroup,
             [ IsGroup and HasDirectProductInfo and HasNormalSubgroups ], 10,
 
   function(G)
-    local i, info, Ns, MinNs, H, Df, DfNs, DfMinNs, gs;
+    local i, info, Ns, MinNs, H, Df, DfNs, DfMinNs, N, g, gs;
 
     Ns := NormalSubgroups(G);
     MinNs := MinimalNormalSubgroups(G);
@@ -190,7 +190,13 @@ InstallMethod(DirectFactorsOfGroup,
         UniteSet(Df, H);
       else
         DfNs := Filtered(Ns, N ->IsSubset(H, N));
-        gs := Set(DfMinNs, N -> GeneratorsOfGroup(N)[1]);
+        gs := [ ];
+        for N in DfMinNs do
+          g := First(GeneratorsOfGroup(N), g -> g<>One(N));
+          if g <> fail then
+            AddSet(gs, g);
+          fi;
+        od;
         # normal subgroup containing all minimal subgroups cannot have complement in H
         DfNs := Filtered(DfNs, N -> not IsSubset(N, gs));
         UniteSet(Df, DirectFactorsOfGroupFromList(H, DfNs, DfMinNs));

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -272,8 +272,8 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
           Gd,       # G'
           GGd,      # G/G'
           C,        # Center(G)
+          D,        # Intersection(C, Gd)
           GC,       # G/C
-          avoid,    # set of elements or indices to avoid
           Ns,       # list of normal subgroups
           MinNs,    # list of minimal normal subgroups
           gs,       # list containing one generator for each MinNs
@@ -324,19 +324,16 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
 
     # look for abelian cyclic component from the center
     C := Center(G);
-    # abelian cyclic components cannot lie in the commutator
+    # abelian cyclic components have trivial intersection with the commutator
     Gd := DerivedSubgroup(G);
-    avoid := [];
-    for g in C do
-      if not g in Gd and ForAll(avoid,h -> not g in RationalClass(G, h)) then
-        N := Subgroup(G, [g]);
+    D := Intersection(C, Gd);
+    for g in RationalClasses(C) do
+      N := Subgroup(C, Set(g));
+      if not IsTrivial(N) and IsTrivialNormalIntersection(C, D, N) then
         B := ComplementNormalSubgroupNC(G, N);
         # if B is a complement to N
         if B <> fail then
           return Union(DirectFactorsOfGroup(N), DirectFactorsOfGroup(B));
-        # if there is no complement to N then discard the generators of N
-        else
-          AddSet(avoid, g);
         fi;
       fi;
     od;
@@ -470,8 +467,8 @@ InstallMethod(DirectFactorsOfGroupKN, "Kayal-Nezhmetdinov method", true,
           prodK,    # product of normal subgroups
           Z1,       # contains a (unique) component with trivial center
           g,a,b,    # elements of G
-          avoid,    # set of elements or indices to avoid
           C,        # Center(G)
+          D,        # Intersection(C, Gd)
           Cl,       # all conjugacy classes of G
           Clf,      # filtered list of conjugacy classes of G
           c1,c2,c3, # conjugacy class of G
@@ -505,19 +502,16 @@ InstallMethod(DirectFactorsOfGroupKN, "Kayal-Nezhmetdinov method", true,
 
     # look for abelian cyclic component from the center
     C := Center(G);
-    # (these components cannot lie in the commutator)
+    # abelian cyclic components have trivial intersection with the commutator
     Gd := DerivedSubgroup(G);
-    avoid := [];
-    for g in C do
-      if not g in Gd and ForAll(avoid,h -> not g in RationalClass(G, h)) then
-        N := Subgroup(G, [g]);
+    D := Intersection(C, Gd);
+    for g in RationalClasses(C) do
+      N := Subgroup(C, Set(g));
+      if not IsTrivial(N) and IsTrivialNormalIntersection(C, D, N) then
         B := ComplementNormalSubgroupNC(G, N);
         # if B is a complement to N
         if B <> fail then
-          return Union(DirectFactorsOfGroupKN(N), DirectFactorsOfGroupKN(B));
-        # if there is no complement to N then discard the generators of N
-        else
-          AddSet(avoid, g);
+          return Union(DirectFactorsOfGroup(N), DirectFactorsOfGroup(B));
         fi;
       fi;
     od;

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -94,9 +94,9 @@ InstallGlobalFunction( UnionIfCanEasilySortElements,
 
 #############################################################################
 ##
-#M  ComplementNormalSubgroup( <G>, <N> ) . . . . . . . . . . . generic method
+#M  NormalComplement( <G>, <N> ) . . . . . . . . . . . generic method
 ##
-InstallMethod( ComplementNormalSubgroup,
+InstallMethod( NormalComplement,
                "generic method", IsIdenticalObj, [ IsGroup,  IsGroup ],
 
   function( G, N )
@@ -113,11 +113,11 @@ InstallMethod( ComplementNormalSubgroup,
       Error("N must be a normal subgroup of G");
 
     else
-      return ComplementNormalSubgroupNC(G, N);
+      return NormalComplementNC(G, N);
     fi;
   end);
 
-InstallMethod( ComplementNormalSubgroupNC,
+InstallMethod( NormalComplementNC,
                "generic method", IsIdenticalObj, [ IsGroup,  IsGroup ],
 
   function( G, N )
@@ -161,7 +161,7 @@ InstallMethod( ComplementNormalSubgroupNC,
         g := PreImagesRepresentative(NaturalHomomorphism(F), gF);
         R := RightCoset(N, g);
         # DirectFactorsOfGroup already computed Center and RationalClasses
-        # when calling ComplementNormalSubgroup
+        # when calling NormalComplement
         if HasCenter(G) and HasRationalClasses(Center(G)) then
           l := [];
           C := Center(G);
@@ -216,7 +216,7 @@ InstallMethod( ComplementNormalSubgroupNC,
         Nf := Image(NaturalHomomorphism(Gf), N);
         # not quite sure if this check is needed
         if HasAbelianFactorGroup(Gf, Nf) then
-          Bf := ComplementNormalSubgroupNC(Gf, Nf);
+          Bf := NormalComplementNC(Gf, Nf);
           if Bf = fail then
             return fail;
           else
@@ -393,7 +393,7 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
     for g in RationalClasses(C) do
       N := Subgroup(C, [Representative(g)]);
       if not IsTrivial(N) and IsTrivialNormalIntersection(C, D, N) then
-        B := ComplementNormalSubgroupNC(G, N);
+        B := NormalComplementNC(G, N);
         # if B is a complement to N
         if B <> fail then
           return UnionIfCanEasilySortElements( DirectFactorsOfGroup(N),
@@ -562,7 +562,7 @@ InstallGlobalFunction(DirectFactorsOfGroupKN,
     for g in RationalClasses(C) do
       N := Subgroup(C, [Representative(g)]);
       if not IsTrivial(N) and IsTrivialNormalIntersection(C, D, N) then
-        B := ComplementNormalSubgroupNC(G, N);
+        B := NormalComplementNC(G, N);
         # if B is a complement to N
         if B <> fail then
           return UnionIfCanEasilySortElements( DirectFactorsOfGroup(N),
@@ -653,7 +653,7 @@ InstallGlobalFunction(DirectFactorsOfGroupKN,
           # this certainly can be done better,
           # because we basically know all possible normal subgroups
           # but it suffices for now
-          B := ComplementNormalSubgroup(G, N);
+          B := NormalComplement(G, N);
           if B <> fail then
             # N is direct indecomposable by construction
             return UnionIfCanEasilySortElements([N],

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -425,8 +425,6 @@ InstallGlobalFunction( DirectFactorsOfGroupFromList,
       return [ G ];
     fi;
 
-    if not IsFinite(G) then TryNextMethod(); fi;
-
     Ns := ShallowCopy(NList);
     MinNs := ShallowCopy(MinList);
     gs := [ ];
@@ -511,8 +509,6 @@ InstallGlobalFunction(DirectFactorsOfGroupKN,
       od;
       return Ns;
     fi;
-
-    if not IsFinite(G) then TryNextMethod(); fi;
 
     # look for abelian cyclic component from the center
     C := Center(G);

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -291,8 +291,7 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
                         [ IsGroup ], 0,
   function(G)
 
-    local p,        # prime
-          Gd,       # G'
+    local Gd,       # G'
           GGd,      # G/G'
           C,        # Center(G)
           D,        # Intersection(C, Gd)
@@ -320,9 +319,8 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
     if IsNilpotentGroup(G) then
       if not IsPGroup(G) then
         Ns := [ ];
-        for p in PrimeDivisors(Size(G)) do
-          Ns := UnionIfCanEasilySortElements(Ns,
-                                  DirectFactorsOfGroup(SylowSubgroup(G, p)));
+        for N in SylowSystem(G) do
+          Ns := UnionIfCanEasilySortElements(Ns, DirectFactorsOfGroup(N));
         od;
         return Ns;
       else

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -531,16 +531,18 @@ InstallMethod(DirectFactorsOfGroupKN, "Kayal-Nezhmetdinov method", true,
         if c1 <> c2 then
           for a in c1 do
             for b in c2 do
-              if com then
-                g := a*b;
-                if g<>b*a then
-                  com := false;
-                  AddSet(preedges, [c1, c2]);
-                else
-                  AddSet(prod, g);
-                fi;
+              g := a*b;
+              if g<>b*a then
+                com := false;
+                AddSet(preedges, [c1, c2]);
+                break;
+              else
+                AddSet(prod, g);
               fi;
             od;
+            if not com then
+              break;
+            fi;
           od;
           if com and Size(prod) = Size(c1)*Size(c2) then
             a := Representative(c1);

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -125,6 +125,7 @@ InstallMethod( ComplementNormalSubgroupNC,
     local F,    # G/N
           DfF,  # Direct factors of F=G/N
           gF,   # element of F=G/N
+          g,    # element of G corresponding to gF
           i,    # running index
           l,    # list for storing stuff
           b,    # elements of abelian complement
@@ -151,8 +152,9 @@ InstallMethod( ComplementNormalSubgroupNC,
       i:=0;
       for gF in IndependentGeneratorsOfAbelianGroup(F) do
         i := i+1;
-        l := First(PreImage(NaturalHomomorphism(F), [gF]),
-              x -> IsCentral(G, SubgroupNC(G,[x])) and Order(x) = Order(gF));
+        g := PreImagesRepresentative(NaturalHomomorphism(F), gF);
+        l := First(RightCoset(N, g),
+              x -> Order(x) = Order(gF) and IsCentral(G, SubgroupNC(G,[x])));
         if l <> fail then
           b[i] := l;
         else

--- a/tst/testinstall/direct_factors.tst
+++ b/tst/testinstall/direct_factors.tst
@@ -3,7 +3,7 @@ gap> D := DihedralGroup(12);; Df := DirectFactorsOfGroup(D);; IsSet(Df); List(Df
 true
 [ [ 6, 1 ], [ 2, 1 ] ]
 gap> U := Df[1];; V := Df[2];;
-gap> ComplementNormalSubgroup(D, U)=V;
+gap> NormalComplement(D, U)=V;
 true
 gap> IsTrivialNormalIntersection(D, U, V);
 true
@@ -17,15 +17,26 @@ true
 gap> U := Center(D);; V := Centralizer(D, DerivedSubgroup(D));;
 gap> IsTrivialNormalIntersection(D, U, V);
 false
-gap> ComplementNormalSubgroup(D, D);
+gap> NormalComplement(SymmetricGroup(10), AlternatingGroup(10));
+fail
+gap> G := SymmetricGroup(10);; N := AlternatingGroup(10);; Center(G);;
+gap> NormalComplement(G, N);
+fail
+gap> G := SmallGroup(64,3);;N:=First(NormalSubgroups(G),N -> Size(N)=4);;
+gap> Center(G);;
+gap> NormalComplement(G, N);
+fail
+gap> n := 0;; for G in AllGroups(16) do for N in NormalSubgroups(G) do C := NormalComplement(G, N); if C<>fail then n := n+1; fi; od; od; n;
+135
+gap> NormalComplement(D, D);
 Group([  ])
-gap> ComplementNormalSubgroup(D, DerivedSubgroup(Center(D)))=D;
+gap> NormalComplement(D, DerivedSubgroup(Center(D)))=D;
 true
-gap> ComplementNormalSubgroupNC(D, D);
+gap> NormalComplementNC(D, D);
 Group([  ])
-gap> ComplementNormalSubgroupNC(D, DerivedSubgroup(Center(D)))=D;
+gap> NormalComplementNC(D, DerivedSubgroup(Center(D)))=D;
 true
-gap> G:=SmallGroup(16,7);; C := Center(G);; ComplementNormalSubgroup(G,C);
+gap> G:=SmallGroup(16,7);; C := Center(G);; NormalComplement(G,C);
 fail
 gap> G := DirectProduct(D, D, D);;
 gap> List(DirectFactorsOfGroup(G), IdGroup);

--- a/tst/testinstall/direct_factors.tst
+++ b/tst/testinstall/direct_factors.tst
@@ -1,0 +1,101 @@
+gap> START_TEST("direct_factors.tst");
+gap> D := DihedralGroup(12);; Df := DirectFactorsOfGroup(D);; IsSet(Df); List(Df, IdGroup); 
+true
+[ [ 6, 1 ], [ 2, 1 ] ]
+gap> U := Df[1];; V := Df[2];;
+gap> ComplementNormalSubgroup(D, U)=V;
+true
+gap> IsTrivialNormalIntersection(D, U, V);
+true
+gap> U := Center(D);; V := Centralizer(D, DerivedSubgroup(D));;
+gap> IsTrivialNormalIntersection(D, U, V);
+false
+gap> MinimalNormalSubgroups(D);;
+gap> U := Df[1];; V := Df[2];;
+gap> IsTrivialNormalIntersection(D, U, V);
+true
+gap> U := Center(D);; V := Centralizer(D, DerivedSubgroup(D));;
+gap> IsTrivialNormalIntersection(D, U, V);
+false
+gap> ComplementNormalSubgroup(D, D);
+Group([  ])
+gap> ComplementNormalSubgroup(D, DerivedSubgroup(Center(D)))=D;
+true
+gap> ComplementNormalSubgroupNC(D, D);
+Group([  ])
+gap> ComplementNormalSubgroupNC(D, DerivedSubgroup(Center(D)))=D;
+true
+gap> G:=SmallGroup(16,7);; C := Center(G);; ComplementNormalSubgroup(G,C);
+fail
+gap> G := DirectProduct(D, D, D);;
+gap> List(DirectFactorsOfGroup(G), IdGroup);
+[ [ 6, 1 ], [ 6, 1 ], [ 6, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ] ]
+gap> G := DirectProduct(D, D);; NormalSubgroups(G);;
+gap> List(DirectFactorsOfGroup(G), IdGroup);
+[ [ 6, 1 ], [ 6, 1 ], [ 2, 1 ], [ 2, 1 ] ]
+gap> D := DihedralGroup(8);; G := DirectProduct(D, D);; NormalSubgroups(G);;
+gap> List(DirectFactorsOfGroup(G), IdGroup);
+[ [ 8, 3 ], [ 8, 3 ] ]
+gap> List(DirectFactorsOfGroup(SmallGroup(64,226):useKN), IdGroup);
+[ [ 8, 3 ], [ 8, 3 ] ]
+gap> D := DihedralGroup(12);; NormalSubgroups(D);;
+gap> List(DirectFactorsOfGroup(D), IdGroup);
+[ [ 6, 1 ], [ 2, 1 ] ]
+gap> Q := QuaternionGroup(8);; NormalSubgroups(Q);;
+gap> List(DirectFactorsOfGroup(Q), IdGroup);
+[ [ 8, 4 ] ]
+gap> G := SmallGroup(48, 1);; NormalSubgroups(G);;
+gap> List(DirectFactorsOfGroup(G), IdGroup);
+[ [ 48, 1 ] ]
+gap> DirectFactorsOfGroup(Group(()));
+[ Group(()) ]
+gap> F := FreeGroup("x","y");; x := F.1;; y := F.2;;
+gap> DirectFactorsOfGroup(F/[x*y*x^(-1)*y^(-1)]);
+[ Group([ x ]), Group([ y ]) ]
+gap> IsList(DirectFactorsOfGroup(F/[x*y*x^(-1)*y^(-1)]));
+true
+gap> DirectFactorsOfGroup(F/[(x*y)^30,x*y*x^(-1)*y^(-1)]);
+[ Group([ x ]), Group([ (x*y)^15 ]), Group([ (x*y)^10 ]), Group([ (x*y)^6 ]) ]
+gap> List(DirectFactorsOfGroup(F/[(x*y)^30,(x*y^7)^11,x*y*x^(-1)*y^(-1)]),IdGroup);
+[ [ 4, 1 ], [ 5, 1 ], [ 9, 1 ], [ 11, 1 ] ]
+gap> List(DirectFactorsOfGroup(SmallGroup(256, 56091)), IdGroup);
+[ [ 256, 56091 ] ]
+gap> for G in AllGroups(16) do Print(List(DirectFactorsOfGroup(G), IdGroup),"\n"); od;
+[ [ 16, 1 ] ]
+[ [ 4, 1 ], [ 4, 1 ] ]
+[ [ 16, 3 ] ]
+[ [ 16, 4 ] ]
+[ [ 8, 1 ], [ 2, 1 ] ]
+[ [ 16, 6 ] ]
+[ [ 16, 7 ] ]
+[ [ 16, 8 ] ]
+[ [ 16, 9 ] ]
+[ [ 2, 1 ], [ 2, 1 ], [ 4, 1 ] ]
+[ [ 2, 1 ], [ 8, 3 ] ]
+[ [ 2, 1 ], [ 8, 4 ] ]
+[ [ 16, 13 ] ]
+[ [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ] ]
+gap> List(DirectFactorsOfGroup(SmallGroup(1728,31093)), IdGroup);
+[ [ 64, 266 ], [ 27, 3 ] ]
+gap> List(DirectFactorsOfGroup(SmallGroup(120,29)), IdGroup);
+[ [ 2, 1 ], [ 60, 3 ] ]
+gap> List(DirectFactorsOfGroup(SmallGroup(240,112)), IdGroup);
+[ [ 3, 1 ], [ 80, 29 ] ]
+gap> List(DirectFactorsOfGroup(SmallGroup(64,214)), IdGroup);
+[ [ 64, 214 ] ]
+gap> List(DirectFactorsOfGroup(SmallGroup(64,215)), IdGroup);
+[ [ 64, 215 ] ]
+gap> List(DirectFactorsOfGroup(SmallGroup(64,226):useKN), IdGroup);
+[ [ 8, 3 ], [ 8, 3 ] ]
+gap> DirectFactorsOfGroup(SymmetricGroup(4));
+[ Sym( [ 1 .. 4 ] ) ]
+gap> DirectFactorsOfGroup(SymmetricGroup(5));
+[ Sym( [ 1 .. 5 ] ) ]
+gap> G := Group([ (4,8)(6,10), (4,6,10,8,12), (2,4,12)(6,10,8), (3,9)(4,6,10,8,12)(7,11), (3,5)(4,6,10,8,12)(9,11), (1,3,11,9,5)(4,6,10,8,12) ]);;
+gap> DirectFactorsOfGroup(G)=[G];
+true
+gap> G := Group([ (4,8)(6,10), (4,6,10,8,12), (2,4,12)(6,10,8), (3,9)(4,6,10,8,12)(7,11), (3,5)(4,6,10,8,12)(9,11), (1,3,11,9,5)(4,6,10,8,12) ]);;
+gap> NormalSubgroups(G);;
+gap> DirectFactorsOfGroup(G)=[G];
+true
+gap> STOP_TEST("direct_factors.tst", 10000);


### PR DESCRIPTION
The default DirectFactorsOfGroup attribute has undergone a serious
enhancement, without having proper documentation, yet.

- The Kayal-Nezhmetdinov algorithm is implemented with some tweaks under the
  attribute DirectFactorsOfGroupKN. From now on, it is referred to as the
  KN method.
  Some parts of the code is reused in the main DirectFactorsOfGroup
  attribute, but there are no direct calls to DirectFactorsOfGroupKN.
- The KN method has an algorithm for computing a direct complement to a
  normal subgroup. This is implemented in the operation
  ComplementNormalSubgroup. This particular operation (in theory) should
  work for infinite groups, as well.
- The main DirectFactorsOfGroup algorithm works as follows:
  - for Abelian groups computes the decomposition to cyclic groups of
    prime-power order,
    (for infinite Abelian groups the output is only a list of the direct
    factors instead of a set, because calling Set on the factors might
    not finish running in reasonable time;
    infinite non-Abelian groups are not handled, at all)
  - for nilpotent groups it calls itself on the Sylow subgroups,
  - checks several sufficient conditions for the group being direct
    indecomposable,
  - looks for Abelian cyclic components from the center of the group,
  - checks for more sufficient conditions for the group being direct
    indecomposable,
  - computes the normal subgroups and the minimal normal subgroups, and
    calls DirectFactorsOfGroupFromList.
- DirectFactorsOfGroupFromList is a more efficient version of the old
  factorization method. It essentially searches through the normal subgroups
  (2nd argument, which is a list) by size and looks for a complement from
  the same list. If it finds a complement then the first factor is direct
  indecomposable, the second is decomposed further using the same list
  filtered from the clearly noncomplemented normal subgroups.
  Trivial intersection is checked by IsTrivialNormalIntersectionInList,
  which checks if any of the minimal subgroups (3rd argument, which is a
  list) is contained in both normal subgroups. This is faster than computing
  the normal intersection and checking if that is trivial.
- IsTrivialNormalIntersection is implemented in cases where one knows more
  about the structure of the group.
- Cases where the group is already a direct product or already has
  NormalSubgroups computed are handled in separate methods.
- Some lines contained a space at their end, these spaces are all removed
  automatically by the text editor.

Tested on SmallGroups of order different than 512, 768, 1024, 1280, 1536,
1792, and on a couple hundred test permutation groups.

More times than not the new method was significantly (>200ms, >10%) faster
than the old method, in many cases because it immediately found the group
is direct indecomposable, rather than spending much time computing the
normal subgroups. In particular, the groups specifically mentioned in 
issue #160 are factored almost instantly now. 

The KN method seems to be drastically slower if the direct factors are
non-Abelian. Computing normal subgrups in such cases is much faster.
However, the implementation is kept for possible future enhancements.