### PR TITLE
Fix version header dependency.

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -33,7 +33,9 @@
 
 #include        "system.h"              /* system dependent part           */
 
+#ifndef WARD_ENABLED
 #include        "gap_version.h"         /* SCM information                 */
+#endif
 
 #include        "gap.h"                 /* get UserHasQUIT                 */
 


### PR DESCRIPTION
This fixes an issue with the version header not being generated in
time for Ward to read it. Since Ward does not need the contents of
the header file, we simply skip it for that stage.