### PR TITLE
Turn off warning for partial variadic functions. Turn warning for arg…

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1178,7 +1178,7 @@ void ReadFuncExpr (
 	while ( TLS(Symbol) == S_COMMA ) {
 	    if (narg > 0 && !strcmp(CSTR_STRING(ELM_LIST(nams,narg)),"arg"))
 	      {
-		SyntaxWarning("arg used not as the last argument");
+		SyntaxError("arg used not as the last argument");
 	      }
 
 	    Match( S_COMMA, ",", follow );
@@ -1251,9 +1251,6 @@ void ReadFuncExpr (
     /* 'function( ... arg )' takes a variable number of arguments              */
     if (narg >= 1 && ! strcmp( "arg", CSTR_STRING( ELM_LIST(nams, narg) ) ) )
       {
-	/* TODO: remove this before the next non-beta release */
-	if (narg > 1)
-	  SyntaxWarning("New syntax used -- intentional?");
 	narg = -narg;
       }
 	

--- a/tst/testinstall/timeout.tst
+++ b/tst/testinstall/timeout.tst
@@ -4,9 +4,6 @@ gap> spinFor := function(ms, arg) local t;
 > while Runtimes().user_time + Runtimes().system_time < t + ms do od;
 > if Length(arg) >= 1
 > then return arg[1]; else return; fi; end;
-Syntax warning: New syntax used -- intentional? in stream line 2
-t := Runtimes().user_time + Runtimes().system_time;
-^
 function( ms, arg ) ... end
 gap> spinFor(10);
 gap> spinFor(10,0);


### PR DESCRIPTION
… not in last place into error.

This is intended to be merged in the first non-beta release of 4.8