### PR TITLE
Fix IsBound(r!.val), and some further IsBound tests

### DIFF
--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -4411,7 +4411,7 @@ void            IntrIsbComObjName (
     /* get the result                                                      */
     switch (TNUM_OBJ(record)) {
       case T_COMOBJ:
-        isb = ElmPRec( record, rnam ) ? True : False;
+        isb = IsbPRec( record, rnam ) ? True : False;
         break;
       default:
         isb = ISB_REC( record, rnam ) ? True : False;

--- a/tst/testinstall/bound.tst
+++ b/tst/testinstall/bound.tst
@@ -1,0 +1,24 @@
+gap> START_TEST("bound.tst");
+gap> S := SymmetricGroup(2);;
+gap> IsBound(S!.cheese);
+false
+gap> IsBound(S!.Size);
+true
+gap> f := ( -> IsBound(S!.cheese) );; f();
+false
+gap> f := ( -> IsBound(S!.Size) );; f();
+true
+gap> r := rec(a := 2, b := fail);;
+gap> IsBound(r.a);
+true
+gap> IsBound(r.b);
+true
+gap> IsBound(r.c);
+false
+gap> f := ( -> IsBound(r.a) );; f();
+true
+gap> f := ( -> IsBound(r.b) );; f();
+true
+gap> f := ( -> IsBound(r.c) );; f();
+false
+gap> STOP_TEST("bound.tst", 1);


### PR DESCRIPTION
This fixes the bug reported by @sebasguts in #389 .

During some earlier code cleanup by @fingolfin , there was a little cut+paste error (and is as common in GAP, no tests).