### PR TITLE
[WIP] New variadic arguments implementation

### DIFF
--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -782,10 +782,11 @@ If it is not, &GAP; signals an error.
 Next &GAP; checks that the number of actual arguments <A>arg-expr</A>s agrees
 with the number of <E>formal arguments</E> as given in the function definition.
 If they do not agree &GAP; signals an error.
-An exception is the case when the last formal argument
-has the name <C>arg</C>. In this case there must be at least as many
+An exception is the case when the function has a variable length argument list,
+which is denoted by adding <C>...</C> after the final argument.
+In this case there must be at least as many
 actual arguments as there are formal arguments <E>before the
-<C>arg</C></E> and can be any larger number
+final argument</E> and can be any larger number
 (see&nbsp;<Ref Sect="Function"/> for examples).
 <P/>
 Now &GAP; allocates for each formal argument and for each <E>formal local</E>
@@ -1735,15 +1736,14 @@ only needs about <C>Log(<A>n</A>)</C> steps.
 <Index Subkey="with a variable number of arguments">functions</Index>
 <Index Key="arg" Subkey="special function argument"><C>arg</C></Index>
 As noted in Section&nbsp;<Ref Sect="Function Calls"/>,
-the case where a functions last formal argument has the name
-<C>arg</C>, is special.
+the case where a function's last argument is followed by <C>...</C> is special.
 It provides a way of defining  a  function  with  a  variable  number  of
 arguments. The values of the actual arguments are computed and the
 first ones are assigned to the new variables corresponding to the
-formal arguments before the <C>arg</C> if any. The values of all the
+formal arguments before the last argument, if any. The values of all the
 remaining actual arguments are stored  in  a  list
-and this list is assigned to the new variable corresponding to the formal
-argument <C>arg</C>. There are  two  typical  scenarios  for  wanting  such  a
+and this list is assigned to the new variable corresponding to the final formal
+argument. There are  two  typical  scenarios  for  wanting  such  a
 possibility:  having  optional  arguments  and  having  any   number   of
 arguments.
 <P/>
@@ -1752,7 +1752,7 @@ The  following  example  shows  one  way  that  the  function
 <Q>optional argument</Q> scenario.
 <P/>
 <Example><![CDATA[
-gap> position := function ( list, obj, arg )    
+gap> position := function ( list, obj, arg... )    
 >     local pos;
 >     if 0 = Length(arg) then
 >       pos := 0;
@@ -1767,10 +1767,7 @@ gap> position := function ( list, obj, arg )
 >     until list[pos] = obj;
 >     return pos;
 >    end;
-Syntax warning: New syntax used -- intentional? in stream line 3
-    if 0 = Length(arg) then
-     ^
-function( list, obj, arg ) ... end
+function( list, obj, arg... ) ... end
 gap> position([1, 4, 2], 4);
 2
 gap> position([1, 4, 2], 3);
@@ -1783,15 +1780,15 @@ The following  example  demonstrates  the  <Q>any  number  of  arguments</Q>
 scenario.
 <P/>
 <Example><![CDATA[
-gap> sum := function ( arg )
+gap> sum := function ( l... )
 >     local total, x;
 >     total := 0;
->     for x in arg do
+>     for x in l do
 >       total := total + x;
 >     od;
 >     return total;
 >    end;
-function( arg ) ... end
+function( l... ) ... end
 gap> sum(1, 2, 3);
 6
 gap> sum(1, 2, 3, 4);
@@ -1804,14 +1801,18 @@ The user should compare the above with the  &GAP; function <Ref Func="Sum"/>
 which, for example, may take a list argument and optionally
 an initial element (which zero should the sum of an empty list return?).
 <P/>
-Note that if a function <A>f</A> is defined as above with its last formal
-argument <C>arg</C> then <C>NumberArgumentsFunction(<A>f</A>)</C> returns
-minus the number of formal arguments (including the <C>arg</C>
+GAP will also special case a function with a single argument with the name
+<C>arg</C> as function with a variable length list of arguments, as if the
+user had written <C>arg...</C>.
+<P/>
+Note that if a function <A>f</A> is defined as above
+then <C>NumberArgumentsFunction(<A>f</A>)</C> returns
+minus the number of formal arguments (including the final argument)
 (see&nbsp;<Ref Func="NumberArgumentsFunction"/>).
 <P/>
-The argument <C>arg</C> when used as the single argument name of some function
-<A>f</A> tells &GAP; that when it encounters <A>f</A> that it should form  a  list
-out of the arguments of <A>f</A>.
+Using the <C>...</C> notation on a function <A>f</A> with only a single
+named argument tells &GAP; that when it encounters <A>f</A> that it should
+form a list out of the arguments of <A>f</A>.
 What if one wishes to do the <Q>opposite</Q>:
 tell &GAP; that a list should be <Q>unwrapped</Q> and passed as several
 arguments to a function.
@@ -2268,4 +2269,3 @@ the part may occur arbitrarily often, or possibly be missing.
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <!-- %% -->
 <!-- %E -->
-

--- a/lib/function.g
+++ b/lib/function.g
@@ -191,8 +191,8 @@ DeclareOperationKernel( "SetNameFunction", [IS_OBJECT, IS_STRING], SET_NAME_FUNC
 ##  <Description>
 ##  returns the number of arguments the function <A>func</A> accepts.
 ##  -1 is returned for all operations.
-##  For functions that use <C>arg</C> to take a variable number of arguments,
-##  the number returned is - the total number of parameters including the <C>arg</C>.
+##  For functions that use <C>...</C> or <C>arg</C> to take a variable number of
+##  arguments, the number returned is -1 times the total number of parameters.
 ##  For attributes, 1 is returned.
 ##  <P/>
 ##  <Example><![CDATA[
@@ -204,10 +204,7 @@ DeclareOperationKernel( "SetNameFunction", [IS_OBJECT, IS_STRING], SET_NAME_FUNC
 ##  3
 ##  gap> NumberArgumentsFunction(Sum);
 ##  -1
-##  gap> NumberArgumentsFunction(function(a,arg) return 1; end);
-##  Syntax warning: New syntax used -- intentional? in stream line 1
-##  NumberArgumentsFunction(function(a,arg) return 1; end);
-##                                               ^
+##  gap> NumberArgumentsFunction(function(a, x...) return 1; end);
 ##  -2
 ##  ]]></Example>
 ##  </Description>
@@ -557,7 +554,8 @@ BIND_GLOBAL( "IdFunc", ID_FUNC );
 ##
 InstallMethod( ViewObj, "for a function", true, [IsFunction], 0,
         function ( func )
-    local  locks, nams, narg, i;
+    local  locks, nams, narg, i, isvarg;
+    isvarg := false;
     locks := LOCKS_FUNC(func);
     if locks <> fail then
         Print("atomic ");
@@ -566,7 +564,11 @@ InstallMethod( ViewObj, "for a function", true, [IsFunction], 0,
     nams := NAMS_FUNC(func);
     narg := NARG_FUNC(func);
     if narg < 0 then
+        isvarg := true;
         narg := -narg;
+    fi;
+    if narg = 1 and nams <> fail and nams[1] = "arg" then
+        isvarg := true;
     fi;
     if narg <> 0 then
         if nams = fail then
@@ -590,6 +592,9 @@ InstallMethod( ViewObj, "for a function", true, [IsFunction], 0,
                 fi;
                 Print(", ",nams[i]);
             od;
+        fi;
+        if isvarg then
+            Print("...");
         fi;
     fi;    
     Print(" ) ... end");

--- a/lib/function.gi
+++ b/lib/function.gi
@@ -20,7 +20,7 @@
 ##
 
 InstallGlobalFunction(CallWithTimeout, 
-        function( timeout, func, arg )
+        function( timeout, func, arg... )
     return CallWithTimeoutList(timeout, func, arg);
 end );
 
@@ -83,4 +83,3 @@ end);
                 
        
                   
-

--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -910,7 +910,7 @@ end);
 ##
 #M  StabilizerOp( <nat-sym-grp>, ...... )
 ##
-SYMGP_STABILIZER := function(sym, arg)
+SYMGP_STABILIZER := function(sym, arg...)
     local  k, act, pt, mov, stab, nat, diff, int, bls, mov1, parts, 
            part, bl, i, gens, size;
     k := Length(arg);
@@ -1012,7 +1012,7 @@ InstallOtherMethod( StabilizerOp,"alternating group", true,
   # the objects might be a group element: rank up	
         RankFilter(IsMultiplicativeElementWithInverse) + 
         RankFilter(IsSolvableGroup),
-        function(g, arg) 
+        function(g, arg...) 
     return AlternatingSubgroup(CallFuncList(Stabilizer, Concatenation([SymmetricParentGroup(g)], arg)));
 end);
 
@@ -1022,7 +1022,7 @@ InstallOtherMethod( StabilizerOp,"alternating group", true,
   # the objects might be a group element: rank up	
         RankFilter(IsMultiplicativeElementWithInverse) + 
         RankFilter(IsSolvableGroup),
-        function(g, arg) 
+        function(g, arg...)
     return AlternatingSubgroup(CallFuncList(Stabilizer, Concatenation([SymmetricParentGroup(g)], arg)));
 end);
 

--- a/src/calls.c
+++ b/src/calls.c
@@ -1299,7 +1299,9 @@ void PrintFunction (
     Int                 nloc;           /* number of locals                */
     Obj                 oldLVars;       /* terrible hack                   */
     UInt                i;              /* loop variable                   */
+    UInt                isvarg;         /* does function have varargs?     */
 
+    isvarg = 0;
 
     if ( IS_OPERATION(func) ) {
       CALL_1ARGS( PrintOperation, func );
@@ -1311,13 +1313,19 @@ void PrintFunction (
 
     /* print the arguments                                                 */
     narg = NARG_FUNC(func);
-    if (narg < 0)
+    if (narg < 0) {
+      isvarg = 1;
       narg = -narg;
+    }
+    
     for ( i = 1; i <= narg; i++ ) {
         if ( NAMS_FUNC(func) != 0 )
             Pr( "%I", (Int)NAMI_FUNC( func, (Int)i ), 0L );
         else
             Pr( "<<arg-%d>>", (Int)i, 0L );
+        if(isvarg && i == narg) {
+            Pr("...", 0L, 0L);
+        }
         if ( i != narg )  Pr("%<, %>",0L,0L);
     }
     Pr(" %<)",0L,0L);

--- a/src/read.c
+++ b/src/read.c
@@ -1114,7 +1114,7 @@ void ReadFuncExpr (
 {
     volatile Obj        nams;           /* list of local variables names   */
     volatile Obj        name;           /* one local variable name         */
-    volatile UInt       narg;           /* number of arguments             */
+    volatile Int        narg;           /* number of arguments             */
     volatile UInt       isvarg = 0;     /* does function have varargs?     */
     volatile UInt       nloc;           /* number of locals                */
     volatile UInt       nr;             /* number of statements            */
@@ -1278,12 +1278,9 @@ void ReadFuncExpr (
     /* Also, we special case function(arg)                                   */
     if (isvarg || ( narg == 1 && ! strcmp( "arg", CSTR_STRING( ELM_LIST(nams, narg) ) )) )
       {
-	/* TODO: remove this before the next non-beta release */
-	if (narg > 1 && ! strcmp( "arg", CSTR_STRING( ELM_LIST(nams, narg) ) ) )
-	  SyntaxWarning("New syntax used -- intentional?");
 	narg = -narg;
       }
-	
+      
     /*     if ( narg == 1 && ! strcmp( "arg", CSTR_STRING( ELM_LIST(nams,1) ) ) )
 	   narg = -1; */
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2165,7 +2165,12 @@ void GetSymbol ( void )
   case '.':   TLS(Symbol) = S_DOT;                         GET_CHAR();
     /*            if ( *TLS(In) == '\\' ) { GET_CHAR();
             if ( *TLS(In) == '\n' ) { GET_CHAR(); } }   */
-    if ( *TLS(In) == '.' ) { TLS(Symbol) = S_DOTDOT;  GET_CHAR();  break; }
+    if ( *TLS(In) == '.' ) { 
+            TLS(Symbol) = S_DOTDOT; GET_CHAR();
+            if ( *TLS(In) == '.') {
+                    TLS(Symbol) = S_DOTDOTDOT; GET_CHAR();
+            }
+    }
     break;
 
   case '!':   TLS(Symbol) = S_ILLEGAL;                     GET_CHAR();

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -64,6 +64,7 @@
 #define S_COLON         ((1UL<< 9)+2)
 #define S_READWRITE     ((1UL<< 9)+3)
 #define S_READONLY      ((1UL<< 9)+4)
+#define S_DOTDOTDOT     ((1UL<< 9)+5)
 
 #define S_PARTIALINT    ((1UL<<10)+0) /* Some digits */
 #define S_INT           ((1UL<<10)+1)

--- a/tst/testinstall/timeout.tst
+++ b/tst/testinstall/timeout.tst
@@ -1,13 +1,10 @@
 gap> START_TEST("timeout.tst");
-gap> spinFor := function(ms, arg) local t;
+gap> spinFor := function(ms, arg...) local t;
 > t := Runtimes().user_time + Runtimes().system_time;
 > while Runtimes().user_time + Runtimes().system_time < t + ms do od;
 > if Length(arg) >= 1
 > then return arg[1]; else return; fi; end;
-Syntax warning: New syntax used -- intentional? in stream line 2
-t := Runtimes().user_time + Runtimes().system_time;
-^
-function( ms, arg ) ... end
+function( ms, arg... ) ... end
 gap> spinFor(10);
 gap> spinFor(10,0);
 0

--- a/tst/testinstall/varargs.tst
+++ b/tst/testinstall/varargs.tst
@@ -1,0 +1,94 @@
+gap> START_TEST("varargs.tst");
+gap> f := function(a,b...) return [a,b]; end;
+function( a, b... ) ... end
+gap> Display(f);
+function ( a, b... )
+    return [ a, b ];
+end
+gap> f(1);
+[ 1, [  ] ]
+gap> f(1,2);
+[ 1, [ 2 ] ]
+gap> f(1,2,3);
+[ 1, [ 2, 3 ] ]
+gap> f := function(arg) return arg; end;
+function( arg... ) ... end
+gap> Display(f);
+function ( arg... )
+    return arg;
+end
+gap> f();
+[  ]
+gap> f(1);
+[ 1 ]
+gap> f(1,2);
+[ 1, 2 ]
+gap> f(1,2,3);
+[ 1, 2, 3 ]
+gap> f := function(arg...) return arg; end;
+function( arg... ) ... end
+gap> Display(f);
+function ( arg... )
+    return arg;
+end
+gap> f();
+[  ]
+gap> f(1);
+[ 1 ]
+gap> f(1,2);
+[ 1, 2 ]
+gap> f(1,2,3);
+[ 1, 2, 3 ]
+gap> f := function(a...) return a; end;
+function( a... ) ... end
+gap> Display(f);
+function ( a... )
+    return a;
+end
+gap> f();
+[  ]
+gap> f(1);
+[ 1 ]
+gap> f(1,2);
+[ 1, 2 ]
+gap> f(1,2,3);
+[ 1, 2, 3 ]
+gap> function(a,b..) end;
+Syntax error: Three dots required for variadic argument list in stream line 1
+function(a,b..) end;
+             ^
+gap> function(a...,b) end;
+Syntax error: Only final argument can be variadic in stream line 1
+function(a...,b) end;
+             ^
+gap> function(a..,b) end;
+Syntax error: Three dots required for variadic argument list in stream line 1
+function(a..,b) end;
+           ^
+gap> function(a....,b) end;
+Syntax error: ) expected in stream line 1
+function(a....,b) end;
+             ^
+gap> function(a,b....) end;
+Syntax error: ) expected in stream line 1
+function(a,b....) end;
+               ^
+gap> f := function(a,b..) end;
+Syntax error: Three dots required for variadic argument list in stream line 1
+f := function(a,b..) end;
+                  ^
+gap> Display(RETURN_FIRST);
+function ( object... )
+    <<kernel or compiled code>>
+end
+gap> [1..2];
+[ 1, 2 ]
+gap> [1...2];
+Syntax error: only two dots in a range in stream line 1
+[1...2];
+    ^
+gap> f := function(a,arg) return [a,arg]; end;
+function( a, arg ) ... end
+gap> f(1,2);
+[ 1, 2 ]
+gap> STOP_TEST("varargs.tst", 1);


### PR DESCRIPTION
Changes the notation for variadic argument lists from `(a,b,arg)` (where arg is a special name) to `(a,b, ...p)` (where `p` can be any identifier, including `arg`). This doesn't change functionality at all, it just means that we don't break any code which was using `arg` as an argument name.

This patch leaves the older (new) notation in for now, if we like this I'll remove it and fix the standard library.

For the curious, after all this stuff is finished, all GAP 4.7 code will behave identically, this will only add new notation.