### PR TITLE
Reject bad floating-point numbers like .n

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1677,6 +1677,8 @@ void GetNumber ( UInt StartingStatus )
     if (wasEscaped || (IsIdent(c)  && c != 'e' && c != 'E' && c != 'D' && c != 'q' &&
                        c != 'd' && c != 'Q')) {
 
+      if (!seenADigit)
+        SyntaxError("Badly formed number, need a digit before or after the decimal point");
       /* We allow one letter on the end of the numbers -- could be an i,
        C99 style */
       if (!wasEscaped) {

--- a/tst/testinstall/longnumber.tst
+++ b/tst/testinstall/longnumber.tst
@@ -164,6 +164,33 @@ gap> 1111111111111111111111111111111111111.1;
 1.11111e+36
 gap> 1.11111111111111111111111111111111111111;
 1.11111
+gap> .;
+Syntax error: Badly formed number, need a digit before or after the decimal po\
+int in stream line 1
+.;
+^
+gap> .n;
+Syntax error: Badly formed number, need a digit before or after the decimal po\
+int in stream line 1
+.n;
+^
+gap> .q;
+Syntax error: Badly formed number, need a digit before or after the decimal po\
+int in stream line 1
+.q;
+^
+gap> .0n;
+fail
+gap> .0q;
+Syntax error: Badly Formed Number, need at least one digit in the exponent in \
+stream line 1
+.0q;
+  ^
+gap> .0qn;
+Syntax error: Badly Formed Number, need at least one digit in the exponent in \
+stream line 1
+.0qn;
+  ^
 gap> Unbind(x);
 gap> STOP_TEST( "longnumber.tst", 270000);
 


### PR DESCRIPTION
At the moment we will parse `.n` (and in general a `.` followed by most characters) as a float, and then transform it into `fail` later. This makes the parser simply reject it.