### PR TITLE
Build GMP with C++ support enabled

### DIFF
--- a/extern/Makefile.in
+++ b/extern/Makefile.in
@@ -33,7 +33,7 @@ gmp_config: ../../../extern/gmp-$(GMP_VER)
 	    echo ""; \
 	    echo "Configuring GMP. Logging to bin/$(GAPARCH)/extern/gmp-$(GMP_VER)/build_log. Please wait... "; \
 	    echo ""; \
-	    ./configure --prefix=`pwd`/../../bin/$(GAPARCH)/extern/gmp-$(GMP_VER) ABI=$(ABI) \
+	    ./configure --prefix=`pwd`/../../bin/$(GAPARCH)/extern/gmp-$(GMP_VER) --enable-cxx ABI=$(ABI) \
 	     > ../../bin/$(GAPARCH)/extern/gmp-$(GMP_VER)/build_log 2>&1; \
 	    rm -f LASTBUILD*; \
 	    touch LASTBUILD.$(GAPARCH); \


### PR DESCRIPTION
This experimental pull requests changes the way we build GMP. Notably, it enables compilation of the GMP C++ interface.

While this is currently useless for GAP itself right now, it would be helpful for certain packages. Notably, the `NormalizInterface` package needs to build a version of `Normaliz` against the exact GMP library that GAP was linked against. But `Normaliz` needs the GMP C++ interface. Hence, right now one is forced to compile both GAP and Normaliz (and NormalizInterface) against an external version of GMP. While this is my personally preferred mode of compilation anyway, it complicates the setup process for NormalizInterface for regular GAP users.

This patch would simplify that problem, as now one can compile GAP "normally", and then use the GMP in it for Normaliz and NormalizInterface.

That said, I realize this change might be controversial. Still, I thought I should at least offer the idea.

Also note: *If* we merge this, it would be nice if it could also make it into GAP 4.8.0; we would like to ship NormalizInterface with that version of GAP, and then could immediately make use of the simplified setup process.