### PR TITLE
Better match list for `?Random`

### DIFF
--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -1587,7 +1587,9 @@ DeclareAttribute( "RepresentativeSmallest", IsListOrCollection );
 ##  <Oper Name="Random" Arg='from, to' Label="for lower and upper bound"/>
 ##
 ##  <Description>
-##  <Index Subkey="of a list or collection">random element</Index>
+##  <!-- to get this on top of results for ?Random -->
+##  <Index Key="Random"><Ref Func="Random" 
+##                           Label="for a list or collection"/></Index> 
 ##  <Ref Oper="Random" Label="for a list or collection"/> returns a
 ##  (pseudo-)random element of the list or collection <A>listorcoll</A>.
 ##  <P/>
@@ -1599,7 +1601,7 @@ DeclareAttribute( "RepresentativeSmallest", IsListOrCollection );
 ##  The distribution of elements returned by
 ##  <Ref Oper="Random" Label="for a list or collection"/> depends
 ##  on the argument.
-##  For a list, all elements are equally likely.
+##  For a list the distribution is uniform (all elements are equally likely).
 ##  The same holds usually for finite collections that are
 ##  not lists.
 ##  For infinite collections some reasonable distribution is used.
@@ -1608,19 +1610,24 @@ DeclareAttribute( "RepresentativeSmallest", IsListOrCollection );
 ##  which distribution is being used.
 ##  <P/>
 ##  For some collections ensuring a reasonable distribution can be
-##  difficult and require substantial runtime.
-##  If speed at the cost of equal distribution is desired,
+##  difficult and require substantial runtime (for example for large
+##  finite groups). If speed is more important than a guaranteed
+##  distribution, 
 ##  the operation <Ref Func="PseudoRandom"/> should be used instead.
 ##  <P/>
 ##  Note that <Ref Oper="Random" Label="for a list or collection"/>
 ##  is of course <E>not</E> an attribute.
 ##  <P/>
 ##  <Example><![CDATA[
-##  gap> Random(Rationals);
-##  4
+##  gap> Random([1..6]);
+##  6
+##  gap> Random(1, 2^100);
+##  216763054510766614871671341272
 ##  gap> g:= Group( (1,2,3) );;  Random( g );  Random( g );
-##  (1,3,2)
 ##  ()
+##  (1,3,2)
+##  gap> Random(Rationals);
+##  -4
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/random.gd
+++ b/lib/random.gd
@@ -49,15 +49,22 @@ DeclareCategory( "IsRandomSource", IsComponentObjectRep );
 ##
 ##  <#GAPDoc Label="Random">
 ##  <ManSection>
-##  <Oper Name="Random" Arg='rs, list' Label="for a list"/>
-##  <Oper Name="Random" Arg='rs, low, high' Label="for a range of integers"/>
+##  <Oper Name="Random" Arg='rs, list' Label="for random source and list"/>
+##  <Oper Name="Random" Arg='rs, low, high' 
+##                      Label="for random source and two integers"/>
 ##
 ##  <Description>
 ##  This operation returns a random element from list <A>list</A>, or an integer 
 ##  in the range from the given (possibly large) integers <A>low</A> to <A>high</A>,
 ##  respectively. 
+##  <P/>
 ##  The choice should only depend on the random source <A>rs</A> and have no 
 ##  effect on other random sources.
+##  <Example>
+##  gap> mysource := RandomSource(IsMersenneTwister, 42);;
+##  gap> Random(mysource, 1, 10^60);
+##  474943581767832038339909502952186501785153672757525589711853
+##  </Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>


### PR DESCRIPTION
- removed unnecessary index entry "random element of .."
- added a new index entry in the general documentation of
  `Random` which only consists of the text "Random" and so
  will be the first match when a user types `?Random`
- in last mentioned section: changed wording about `PseudoRandom`
  and improved examples
- corrected labels and added an example in ManSection on
  `Random` with a random source argument

This addresses issue " Merge documentation entries for 'Random'" #116 