### PR TITLE
Fix caching of the degree of transformation

### DIFF
--- a/src/trans.c
+++ b/src/trans.c
@@ -302,15 +302,13 @@ Obj FuncDegreeOfTransformation(Obj self, Obj f){
   UInt    n, i, deg;
   UInt2   *ptf2;
   UInt4   *ptf4;
-  Obj     ext;
 
   if(TNUM_OBJ(f)==T_TRANS2){ 
-    ext=EXT_TRANS(f);
-    if(ext == NULL){ 
+    if (EXT_TRANS(f) == NULL) {
       n=DEG_TRANS2(f);
       ptf2=ADDR_TRANS2(f);
       if(ptf2[n-1]!=n-1){
-        ext=INTOBJ_INT(n);
+        EXT_TRANS(f) = INTOBJ_INT(n);
       } else {
         deg=0;
         for(i=0;i<n;i++){ 
@@ -319,18 +317,17 @@ Obj FuncDegreeOfTransformation(Obj self, Obj f){
           } else if(ptf2[i]<i&&i+1>deg){
             deg=i+1;
           }
-        }  
-        ext=INTOBJ_INT(deg);
+        }
+        EXT_TRANS(f) = INTOBJ_INT(deg);
       }
     }
-    return ext;
+    return EXT_TRANS(f);
   } else if (TNUM_OBJ(f)==T_TRANS4){
-    ext=EXT_TRANS(f);
-    if(ext == NULL){ 
+    if (EXT_TRANS(f) == NULL) {
       n=DEG_TRANS4(f);
       ptf4=ADDR_TRANS4(f);
       if(ptf4[n-1]!=n-1){
-        ext=INTOBJ_INT(n);
+        EXT_TRANS(f) = INTOBJ_INT(n);
       } else {
         deg=0;
         for(i=0;i<n;i++){ 
@@ -340,10 +337,10 @@ Obj FuncDegreeOfTransformation(Obj self, Obj f){
             deg=i+1;
           }
         }  
-        ext=INTOBJ_INT(deg);
+        EXT_TRANS(f) = INTOBJ_INT(deg);
       }
     }
-    return ext;
+    return EXT_TRANS(f);
   }
   ErrorQuit("usage: the argument should be a transformation,", 0L, 0L);
   return 0L;
@@ -1286,7 +1283,7 @@ Obj FuncHASH_FUNC_FOR_TRANS(Obj self, Obj f, Obj data){
   
   if(TNUM_OBJ(f)==T_TRANS4){
     if(deg<=65536){
-      FuncTRIM_TRANS(self, f, EXT_TRANS(f));
+      FuncTRIM_TRANS(self, f, INTOBJ_INT(deg));
     } else {
       return INTOBJ_INT((HASHKEY_BAG_NC(f, (UInt4) 255, 3*sizeof(Obj), 
               (int) 4*deg) % (INT_INTOBJ(data)))+1);

--- a/tst/testinstall/trans.tst
+++ b/tst/testinstall/trans.tst
@@ -1188,6 +1188,16 @@ true
 gap> ConstantTransformation(4,1)<IdentityTransformation;
 true
 
+# Test for the issue with caching the degree of a transformation in PR #384
+gap> x := Transformation([1,1]) ^ (1,2)(3,70000);
+Transformation( [ 2, 2 ] )
+gap> IsTrans4Rep(x);
+true
+gap> HASH_FUNC_FOR_TRANS(x, 101);
+41
+gap> x;
+Transformation( [ 2, 2 ] )
+
 #
 gap> SetUserPreference("TransformationDisplayLimit", display);;
 gap> SetUserPreference("NotationForTransformations", notation);;


### PR DESCRIPTION
This commit fixes the caching of the degree of a transformation.
Previously, although there was space reserved in a transformation for
caching the degree, it was in fact never cached. This caused a problem
in `HASH_FUNC_FOR_TRANS` where it was assumed that the degree was cached
after it was calculated. In particular, 4 bytes transformations were
trimmed using the (non-)cached value of the degree, which was 0, and
this resulted in non-identity transformations having their value changed
to the identity transformation when they were hashed.

For example, without this pull request:

    gap> x := Transformation([1,1]) ^ (1,2)(3,70000);
    Transformation( [ 2, 2 ] )
    gap> IsTrans4Rep(x);
    true
    gap> HASH_FUNC_FOR_TRANS(x, 101);
    22
    gap> x;
    IdentityTransformation

and with:

    gap> x := Transformation([1,1]) ^ (1,2)(3,70000);
    Transformation( [ 2, 2 ] )
    gap> IsTrans4Rep(x);
    true
    gap> HASH_FUNC_FOR_TRANS(x, 101);
    41
    gap> x;
    Transformation( [ 2, 2 ] )

