### PR TITLE
Change START_TEST to set assertion level to *at least* 2

### DIFF
--- a/lib/profile.g
+++ b/lib/profile.g
@@ -1037,7 +1037,7 @@ end);
 ##  <Ref Func="START_TEST"/> reinitialize the caches and the global
 ##  random number generator, in order to be independent of the reading
 ##  order of several test files. Furthermore, the assertion level
-##  (see&nbsp;<Ref Func="Assert"/>) is set to <M>2</M> by
+##  (see&nbsp;<Ref Func="Assert"/>) is set to <M>2</M> (if it was lower before) by
 ##  <Ref Func="START_TEST"/> and set back to the previous value in the
 ##  subsequent <Ref Func="STOP_TEST"/> call.
 ##  <P/>
@@ -1077,7 +1077,9 @@ START_TEST := function( name )
     GAPInfo.TestData.START_TIME := Runtime();
     GAPInfo.TestData.START_NAME := name;
     GAPInfo.TestData.AssertionLevel:= AssertionLevel();
-    SetAssertionLevel( 2 );
+    if GAPInfo.TestData.AssertionLevel < 2 then
+        SetAssertionLevel( 2 );
+    fi;
 end;
 
 STOP_TEST := function( file, fac )


### PR DESCRIPTION
Thus if the assertion level is higher than 2 before the tests start, they stay at this higher level.

This allows to run the test suite at higher assertion levels. Certain issues may only become apparent at such a higher level (see e.g. #420)