### PR TITLE
Prevent a diff in trans.tst caused when GAP is 32-bit

### DIFF
--- a/tst/testinstall/trans.tst
+++ b/tst/testinstall/trans.tst
@@ -1193,8 +1193,7 @@ gap> x := Transformation([1,1]) ^ (1,2)(3,70000);
 Transformation( [ 2, 2 ] )
 gap> IsTrans4Rep(x);
 true
-gap> HASH_FUNC_FOR_TRANS(x, 101);
-41
+gap> HASH_FUNC_FOR_TRANS(x, 101);;
 gap> x;
 Transformation( [ 2, 2 ] )
 


### PR DESCRIPTION
The function HASH_FUNC_FOR_TRANS uses HASHKEY_BAG which uses a different
method depending on whether GAP is built as 32-bit or 64-bit. In other
words, the hash value of a transformation can be different in 32-bit
than in 64-bit, so the actual value shouldn't be displayed in the test.

The test causing this diff was added in PR #418.