### PR TITLE
Added a small info message to display before TestDirectory finishes.

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -693,6 +693,8 @@ InstallGlobalFunction( "TestDirectory", function(arg)
     if not(testResult) and opts.earlyStop then
       STOP_TEST := STOP_TEST_CPY;
       if opts.exitGAP then
+        # Do not change the next line - it is needed for testing scrips
+        Print( "#I  Errors detected while testing\n\n" );
         QUIT_GAP(1);
       fi;
       return false;
@@ -746,8 +748,12 @@ InstallGlobalFunction( "TestDirectory", function(arg)
   
   if opts.exitGAP then
     if testTotal then
+      # Do not change the next line - it is needed for testing scrips
+      Print( "#I  No errors detected while testing\n\n" );
       QUIT_GAP(0);
     else
+      # Do not change the next line - it is needed for testing scrips
+      Print( "#I  Errors detected while testing\n\n" );
       QUIT_GAP(1);
     fi;
   fi;


### PR DESCRIPTION
This PR adds a message 
```
#I  Errors detected while testing
```
or 
```
#I  Errors detected while testing
```
which will be printed before `TestDirectory` finishes. 
It will be useful e.g. if someone uses tail to look at the end of a long test file, and it will help to detect failures in standard tests of GAP packages, since the same message is already used for these purposes by some other packages.


