### PR TITLE
[WIP] Add OBJ_MASTER_POINTER function

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -1245,6 +1245,25 @@ Obj IsIdenticalHandler (
 
 /****************************************************************************
 **
+
+*F  ObjMasterPointer( <self>, <obj> )  . . . . .  Returns the bag of an object
+**
+**  'ObjMasterPointer' implements the GAP-level function 'ObjMasterPointer'
+*/
+Obj ObjMasterPointer (
+    Obj                 self,
+    Obj                 obj )
+{
+    if(obj > (Obj)MptrBags && obj < (Obj)OldBags) {
+        return INTOBJ_INT(obj - (Obj)MptrBags);
+    }
+    else {
+        return Fail;
+    }
+}
+
+/****************************************************************************
+**
 *V  SaveObjFuncs (<type>) . . . . . . . . . . . . . functions to save objects
 **
 ** 'SaveObjFuncs' is the dispatch table that  contains, for every type
@@ -1606,6 +1625,9 @@ static StructGVarFunc GVarFuncs [] = {
 
     { "IS_IDENTICAL_OBJ", 2, "obj1, obj2", 
       IsIdenticalHandler, "src/objects.c:IS_IDENTICAL_OBJ" },
+
+    { "OBJ_MASTER_POINTER", 1, "obj",
+      ObjMasterPointer, "src/objects.c:OBJ_MASTER_POINTER" },
 
     { "IS_COMOBJ", 1, "obj",
       IS_COMOBJ_Handler, "src/objects.c:IS_COMOBJ" },


### PR DESCRIPTION
This adds a function which lets you get the bag number of a GAP object. it returns `Fail` for immediate objects (small integers and floats).

For those unfamiliar, the bag number of a GAP object is (basically) the memory location at which an object is stored. Basically, `OBJ_MASTER_POINTER(x) = OBJ_MASTER_POINTER(y)` if and only if `IsIdenticalObj(x,y)` and x and y are not small integers or floats.

The reason I want this function is that it allows users to efficiently check if any of a set of objects are equal (at the moment we only have IsIdenticalObj, which is inefficient for comparing a set of objects). I want this to copy StabChains at the GAP level (where items can be shared between levels).

Obviously currently missing documentation, but wanted to see if anyone was fundamentally opposed to the function, or design, before I did that.


One design decision I could take is to make the relationship `OBJ_MASTER_POINTER(x) = OBJ_MASTER_POINTER(y)` if and only if `IsIdenticalObj(x,y)` always true. This would basically mean giving a value for ints and floats instead of fail. This would make the function easier to explain, but not (I think) be more useful for the (rare) user who wants this kind of functionality.