### PR TITLE
Move towards using Immutable StabChains where possible

### DIFF
--- a/lib/csetperm.gi
+++ b/lib/csetperm.gi
@@ -47,8 +47,8 @@ MAX_SIZE_TRANSVERSAL := 100000;
 BindGlobal( "RightTransversalPermGroupConstructor", function( filter, G, U )
   local GC, UC, noyet, orbs, domain, GCC, UCC, ac, nc, bpt, enum, i;
 
-    GC := CopyStabChain( StabChainMutable( G ) );
-    UC := CopyStabChain( StabChainMutable( U ) );
+    GC := CopyStabChain( StabChainImmutable( G ) );
+    UC := CopyStabChain( StabChainImmutable( U ) );
     noyet:=ValueOption("noascendingchain")<>true;
     if not IsTrivial( G )  then
         orbs := ShallowCopy( OrbitsDomain( U, MovedPoints( G ) ) );

--- a/lib/ghomperm.gi
+++ b/lib/ghomperm.gi
@@ -1587,7 +1587,7 @@ InstallGlobalFunction( ImageKernelBlocksHomomorphism, function( hom, H,par )
             i,  j;      # loop variables
     
     D := Enumerator( UnderlyingExternalSet( hom ) );
-    S := CopyStabChain( StabChainMutable( H ) );
+    S := CopyStabChain( StabChainImmutable( H ) );
     full := IsIdenticalObj( H, Source( hom ) );
     if full  then
         SetStabChainMutable( hom, S );
@@ -1755,7 +1755,7 @@ InstallGlobalFunction( PreImageSetStabBlocksHomomorphism, function( hom, I )
 
     # if <I> is trivial then preimage is the kernel of <hom>
     if IsEmpty( I.genlabels )  then
-        H := CopyStabChain( StabChainMutable(
+        H := CopyStabChain( StabChainImmutable(
                  KernelOfMultiplicativeGeneralMapping( hom ) ) );
 
     # else begin with the preimage $H_{block[i]}$ of the stabilizer  $I_{i}$,
@@ -2089,4 +2089,3 @@ end );
 #############################################################################
 ##
 #E
-

--- a/lib/pcgsperm.gi
+++ b/lib/pcgsperm.gi
@@ -674,7 +674,7 @@ end );
 InstallGlobalFunction( SolvableNormalClosurePermGroup, function( G, H )
     local   U,  oldlen,  series,  bound,  z,  S;
 
-    U := CopyStabChain( StabChainMutable( TrivialSubgroup( G ) ) );
+    U := CopyStabChain( StabChainImmutable( TrivialSubgroup( G ) ) );
     oldlen := Length( U.labels );
     
     # The `genlabels' at every level of $U$ must be sets.
@@ -822,7 +822,7 @@ InstallMethod( PcSeries, true, [ IsPcgs and IsPcgsPermGroupRep ], 0,
     local   series,  G,  N,  i;
 
     G := GroupOfPcgs( pcgs );
-    N := CopyStabChain( StabChainMutable( TrivialSubgroup( G ) ) );
+    N := CopyStabChain( StabChainImmutable( TrivialSubgroup( G ) ) );
     series := [ GroupStabChain( G, CopyStabChain( N ), true ) ];
     for i  in Reversed( [ 1 .. Length( pcgs ) ] )  do
         AddNormalizingElementPcgs( N, pcgs[ i ] );

--- a/lib/stbc.gd
+++ b/lib/stbc.gd
@@ -247,7 +247,7 @@ DeclareGlobalFunction( "StabChainBaseStrongGenerators" );
 ##  <Func Name="CopyStabChain" Arg='S'/>
 ##
 ##  <Description>
-##  This function returns a copy of the stabilizer chain <A>S</A>
+##  This function returns a mutable copy of the stabilizer chain <A>S</A>
 ##  that has no mutable object (list or record) in common with <A>S</A>.
 ##  The <C>labels</C> components of the result are possibly shared by several
 ##  levels, but superfluous labels are removed.
@@ -860,4 +860,3 @@ DeclareGlobalFunction( "ClosureRandomPermGroup" );
 #############################################################################
 ##
 #E
-

--- a/lib/stbc.gi
+++ b/lib/stbc.gi
@@ -212,11 +212,40 @@ end);
 ##  (iterated) `stabilizer' component of a bigger chain.
 ##
 InstallGlobalFunction(CopyStabChain,function( C1 )
-    local   C,Xlabels,  S,  len,  xlab,  need,  poss,  i;
+    local   C,Xlabels,  S,  len,  xlab,  need,  poss,  i, copyChain;
+
+    copyChain := function(C, labelorig, labelcpy)
+        local obj, r, objNum, objPos, l;
+        obj := rec();
+        # Need to do labels first
+        objNum := MASTER_POINTER_NUMBER(C.labels);
+        objPos := Position(labelorig, objNum);
+        if objPos <> fail then
+            obj.labels := labelcpy[objPos];
+        else
+            Add(labelorig, objNum);
+            l := List(C.labels);
+            Add(labelcpy, l);
+            obj.labels := l;
+        fi;
+
+        for r in RecNames(C) do
+            if r = "stabilizer" then
+                obj.(r) := copyChain(C.(r), labelorig, labelcpy);
+            elif r = "labels" then
+                ;# skip
+            elif IsList(C.(r)) then
+                obj.(r) := List(C.(r));
+            else
+                obj.(r) := C.(r);
+            fi;
+        od;
+        return obj;
+    end;
 
     # To begin with, make a deep copy.
-    C := StructuralCopy( C1 );
-    
+    C := copyChain( C1, [], [] );
+
     # First pass: Collect the necessary genlabels.
     Xlabels := [  ];
     S := C;
@@ -1813,4 +1842,3 @@ end);
 #############################################################################
 ##
 #E
-

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -829,7 +829,7 @@ InstallGlobalFunction( EmptyRBase, function( G, Omega, P )
         if IsIdenticalObj( G[ 1 ], G[ 2 ] )  then
             rbase.level2 := true;
         else
-            rbase.level2 := CopyStabChain( StabChainMutable( G[ 2 ] ) );
+            rbase.level2 := CopyStabChain( StabChainImmutable( G[ 2 ] ) );
             rbase.lev2   := [  ];
         fi;
         G := G[ 1 ];
@@ -841,7 +841,7 @@ InstallGlobalFunction( EmptyRBase, function( G, Omega, P )
 #        rbase.fix   := [  ];
 #        rbase.level := NrMovedPoints( G );
 #    else
-        rbase.chain := CopyStabChain( StabChainMutable( G ) );
+        rbase.chain := CopyStabChain( StabChainImmutable( G ) );
         rbase.level := rbase.chain;
 #    fi;
     
@@ -1547,8 +1547,8 @@ InstallGlobalFunction( PartitionBacktrack,
         
         # In   the representative case,   assign  to <L>  and <R>  stabilizer
         # chains.
-        L := ListStabChain( CopyStabChain( StabChainMutable( L ) ) );
-        R := ListStabChain( CopyStabChain( StabChainMutable( R ) ) );
+        L := ListStabChain( CopyStabChain( StabChainImmutable( L ) ) );
+        R := ListStabChain( CopyStabChain( StabChainImmutable( R ) ) );
 
     fi;
     


### PR DESCRIPTION
This patch makes `CopyStabChain` work correctly on Immutable StabChains, which then allows us to move several uses of `MutableStabChain` to `ImmutableStabChain`.

My long term plan here is to eliminate `MutableStabChain` from the standard library (although we will probably leave it for some time).  There are two good reasons to do this:

1) My experience in re-writing partition backtracking is `MutableStabChain` eads to subtle bugs and fragile code as different parts of the library alter it.

2) It's existence is a major blocker for HPC-GAP, as it isn't compatible with multi-threaded code.