### PR TITLE
Add another ViewString method for inverse semigroups

### DIFF
--- a/lib/semigrp.gi
+++ b/lib/semigrp.gi
@@ -113,7 +113,12 @@ InstallMethod(ViewString, "for a semigroup with generators",
 InstallMethod(ViewString, "for a monoid with generators",
 [IsMonoid and HasGeneratorsOfMonoid], _ViewStringForSemigroups);
 
-InstallMethod(ViewString, "for an inverse semigroup with generators",
+InstallMethod(ViewString, "for an inverse semigroup with semigroup generators",
+[IsInverseSemigroup and HasGeneratorsOfSemigroup],
+_ViewStringForSemigroups);
+
+InstallMethod(ViewString, 
+"for an inverse semigroup with inverse semigroup generators",
 [IsInverseSemigroup and HasGeneratorsOfInverseSemigroup],
 _ViewStringForSemigroups);
 

--- a/tst/testinstall/semigrp.tst
+++ b/tst/testinstall/semigrp.tst
@@ -431,6 +431,19 @@ false
 gap> IsEmpty(T);
 true
 
+# Check for correct ViewString method for IsInverseSemigroup and
+# HasGeneratorsOfSemigroup
+gap> S := Semigroup(Transformation([4, 3, 5, 5, 5]),
+>                   Transformation([4, 1, 5, 2, 5]), 
+>                   Transformation([5, 5, 2, 1, 5]));
+<transformation semigroup of degree 5 with 3 generators>
+gap> IsInverseSemigroup(S);
+true
+gap> Size(S);
+36
+gap> S;
+<inverse transformation semigroup of size 36, degree 5 with 3 generators>
+
 #
 gap> STOP_TEST( "semigrp.tst", 1060000);
 


### PR DESCRIPTION
This commit introduces a method for `ViewString` for semigroups satisfying
`IsInverseSemigroup and HasGeneratorsOfSemigroup`.  The rank of the filter
`IsSemigroup and HasGeneratorsOfSemigroup` is 14, whereas the rank of
`IsInverseSemigroup` is 21. Previously, if a semigroup learned that it was
inverse but did not have `GeneratorsOfInverseSemigroup`, then the default
`ViewString` method for `IsInverseSemigroup` was used. With this commit the
more elaborate `_ViewStringForSemigroups` is used instead.

For example, before the change:

    gap> S := Semigroup(Transformation([4, 3, 5, 5, 5]),
    >                   Transformation([4, 1, 5, 2, 5]), 
    >                   Transformation([5, 5, 2, 1, 5]));
    <transformation semigroup of degree 5 with 3 generators>
    gap> IsInverseSemigroup(S);
    true
    gap> S;
    <inverse semigroup>

After the change:

    gap> S := Semigroup(Transformation([4, 3, 5, 5, 5]),
    >                   Transformation([4, 1, 5, 2, 5]), 
    >                   Transformation([5, 5, 2, 1, 5]));
    <transformation semigroup of degree 5 with 3 generators>
    gap> IsInverseSemigroup(S);
    true
    gap> S;
    <inverse transformation semigroup of degree 5 with 3 generators>
