### PR TITLE
Enhance some nilpotent and p-group attributes

### DIFF
--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -209,7 +209,7 @@ end );
 #M  IsNilpotentGroup( <D> )
 ##
 InstallMethod( IsNilpotentGroup, "for direct products",
-               [IsGroup and HasDirectProductInfo],
+               [IsGroup and HasDirectProductInfo], 30,
 function( D )
     return ForAll( DirectProductInfo( D ).groups, IsNilpotentGroup );
 end );

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -314,6 +314,24 @@ RedispatchOnCondition (PrimePGroup, true,
 #T for example one that checks only small integers?)
 
 InstallMethod( IsNilpotentGroup,
+    "if group size can be computed and is a prime power",
+    [ IsGroup and CanComputeSize ], 25,
+    function ( G )
+    local s;
+
+    s := Size ( G );
+    if IsInt( s ) and IsPrimePowerInt( s ) then
+        SetIsPGroup( G, true );
+        SetPrimePGroup( G, Factors( s )[1] );
+        return true;
+    else
+        SetIsPGroup( G, false );
+    fi;
+    TryNextMethod();
+    end );
+
+
+InstallMethod( IsNilpotentGroup,
     "generic method for groups",
     [ IsGroup ],
     function ( G )

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -258,6 +258,23 @@ InstallMethod( IsPGroup,
 #M  PrimePGroup . . . . . . . . . . . . . . . . . . . . .  prime of a p-group
 ##
 InstallMethod( PrimePGroup,
+    "generic method, check the order of a nontrivial generator",
+    [ IsPGroup and HasGeneratorsOfGroup ],
+function( G )
+local gen, s;
+  if IsTrivial( G ) then
+    return fail;
+  fi;
+  for gen in GeneratorsOfGroup( G ) do
+    s := Order( gen );
+    if s <> 1 then
+      break;
+    fi;
+  od;
+  return Factors( s )[1];
+end );
+
+InstallMethod( PrimePGroup,
     "generic method, check the group order",
     [ IsPGroup ],
 function( G )
@@ -271,8 +288,12 @@ local s;
   if s = 1 then
     return fail;
   fi;
-  return Set( Factors( s ) )[1];
+  return Factors( s )[1];
 end );
+
+RedispatchOnCondition (PrimePGroup, true,
+    [IsGroup],
+    [IsPGroup], 0);
 
 
 #############################################################################

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -176,9 +176,13 @@ InstallMethod( IsPGroup,
         if ord = infinity then
           return false;
         elif 1 < ord then
-          UniteSet( s, Factors( ord ) );
-          if 1 < Length( s ) then
+          if not IsPrimePowerInt( ord ) then
             return false;
+          else
+            AddSet( s, Factors( ord )[1] );
+            if 1 < Length( s ) then
+              return false;
+            fi;
           fi;
         fi;
       od;
@@ -193,10 +197,10 @@ InstallMethod( IsPGroup,
         return true;
       elif s = infinity then
         return false;
-      fi;
-      s:= Set( Factors( s ) );
-      if 1 < Length( s ) then
+      elif not IsPrimePowerInt( s ) then
         return false;
+      else
+        s:= Factors( s );
       fi;
 
     fi;
@@ -217,10 +221,10 @@ InstallMethod( IsPGroup,
         return true;
       elif s = infinity then
         return false;
-      fi;
-      s:= Set( Factors( s ) );
-      if 1 < Length( s ) then
+      elif not IsPrimePowerInt( s ) then
         return false;
+      else
+        s:= Factors( s );
       fi;
     else
       s:= [];
@@ -229,9 +233,13 @@ InstallMethod( IsPGroup,
         if ord = infinity then
           return false;
         elif 1 < ord then
-          UniteSet( s, Factors( ord ) );
-          if 1 < Length( s ) then
+          if not IsPrimePowerInt( ord ) then
             return false;
+          else
+            AddSet( s, Factors( ord )[1] );
+            if 1 < Length( s ) then
+              return false;
+            fi;
           fi;
         fi;
       od;

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -156,8 +156,57 @@ InstallMethod( IsElementaryAbelian,
 ##
 #M  IsPGroup( <G> ) . . . . . . . . . . . . . . . . .  is a group a p-group ?
 ##
+BindGlobal( "IS_PGROUP_FOR_NILPOTENT",
+
+    function( G )
+    local s, gen, ord;
+
+    s:= [];
+    for gen in GeneratorsOfGroup( G ) do
+      ord:= Order( gen );
+      if ord = infinity then
+        return false;
+      elif 1 < ord then
+        if not IsPrimePowerInt( ord ) then
+          return false;
+        else
+          AddSet( s, Factors( ord )[1] );
+          if 1 < Length( s ) then
+            return false;
+          fi;
+        fi;
+      fi;
+    od;
+    if IsEmpty( s ) then
+      return true;
+    fi;
+
+    SetPrimePGroup( G, s[1] );
+    return true;
+    end);
+
+BindGlobal( "IS_PGROUP_FROM_SIZE",
+
+    function( G )
+    local s;
+
+    s:= Size( G );
+    if s = 1 then
+      return true;
+    elif s = infinity then
+      return false;
+    elif not IsPrimePowerInt( s ) then
+      return false;
+    else
+      s:= Factors( s );
+    fi;
+
+    SetPrimePGroup( G, s[1] );
+    return true;
+    end);
+
 InstallMethod( IsPGroup,
-    "generic method (check order of the group or of generators)",
+    "generic method (check order of the group or of generators if nilpotent)",
     [ IsGroup ],
     function( G )
     local s, gen, ord;
@@ -169,44 +218,10 @@ InstallMethod( IsPGroup,
     if     ( not HasSize( G ) )
        and (    ( HasIsNilpotentGroup( G ) and IsNilpotentGroup( G ) )
              or IsAbelian( G ) ) then
-
-      s:= [];
-      for gen in GeneratorsOfGroup( G ) do
-        ord:= Order( gen );
-        if ord = infinity then
-          return false;
-        elif 1 < ord then
-          if not IsPrimePowerInt( ord ) then
-            return false;
-          else
-            AddSet( s, Factors( ord )[1] );
-            if 1 < Length( s ) then
-              return false;
-            fi;
-          fi;
-        fi;
-      od;
-      if IsEmpty( s ) then
-        return true;
-      fi;
-
+      return IS_PGROUP_FOR_NILPOTENT( G );
     else
-
-      s:= Size( G );
-      if s = 1 then
-        return true;
-      elif s = infinity then
-        return false;
-      elif not IsPrimePowerInt( s ) then
-        return false;
-      else
-        s:= Factors( s );
-      fi;
-
+      return IS_PGROUP_FROM_SIZE( G );
     fi;
-
-    SetPrimePGroup( G, s[1] );
-    return true;
     end );
 
 InstallMethod( IsPGroup,
@@ -216,40 +231,10 @@ InstallMethod( IsPGroup,
     local s, gen, ord;
 
     if HasSize( G ) then
-      s:= Size( G );
-      if s = 1 then
-        return true;
-      elif s = infinity then
-        return false;
-      elif not IsPrimePowerInt( s ) then
-        return false;
-      else
-        s:= Factors( s );
-      fi;
+      return IS_PGROUP_FROM_SIZE( G );
     else
-      s:= [];
-      for gen in GeneratorsOfGroup( G ) do
-        ord:= Order( gen );
-        if ord = infinity then
-          return false;
-        elif 1 < ord then
-          if not IsPrimePowerInt( ord ) then
-            return false;
-          else
-            AddSet( s, Factors( ord )[1] );
-            if 1 < Length( s ) then
-              return false;
-            fi;
-          fi;
-        fi;
-      od;
-      if IsEmpty( s ) then
-        return true;
-      fi;
+      return IS_PGROUP_FOR_NILPOTENT( G );
     fi;
-
-    SetPrimePGroup( G, s[1] );
-    return true;
     end );
 
 

--- a/tst/testinstall/pgroups.tst
+++ b/tst/testinstall/pgroups.tst
@@ -1,0 +1,171 @@
+gap> START_TEST("pgroups.tst");
+gap> A := Group((1,2),(3,4),(5,6));
+Group([ (1,2), (3,4), (5,6) ])
+gap> G := DirectProduct(A, A);
+Group([ (1,2), (3,4), (5,6), (7,8), (9,10), (11,12) ])
+gap> IsPGroup(G); 
+true
+gap> HasPrimePGroup(A) and HasPrimePGroup(G);
+true
+gap> PrimePGroup(A);
+2
+gap> PrimePGroup(G);
+2
+gap> B := Group((1,2,3),(4,5,6));
+Group([ (1,2,3), (4,5,6) ])
+gap> IsAbelian(B);
+true
+gap> G := DirectProduct(B, B);
+Group([ (1,2,3), (4,5,6), (7,8,9), (10,11,12) ])
+gap> IsPGroup(G); 
+true
+gap> HasPrimePGroup(G);
+true
+gap> PrimePGroup(G);
+3
+gap> C := Group((1,2,3,4),(5,6,7,8));
+Group([ (1,2,3,4), (5,6,7,8) ])
+gap> IsAbelian(C);
+true
+gap> G := DirectProduct(C, C);
+Group([ (1,2,3,4), (5,6,7,8), (9,10,11,12), (13,14,15,16) ])
+gap> Size(G);
+256
+gap> IsPGroup(G);
+true
+gap> HasPrimePGroup(G);
+true
+gap> PrimePGroup(G);
+2
+gap> D := Group((1,3),(1,2,3,4));
+Group([ (1,3), (1,2,3,4) ])
+gap> G := DirectProduct(D, D);
+Group([ (1,3), (1,2,3,4), (5,7), (5,6,7,8) ])
+gap> IsPGroup(G);
+true
+gap> HasPrimePGroup(D) and HasPrimePGroup(G);
+true
+gap> PrimePGroup(D);
+2
+gap> PrimePGroup(G);
+2
+gap> Q := Group( (1,2,3,8)(4,5,6,7), (1,7,3,5)(2,6,8,4) );
+Group([ (1,2,3,8)(4,5,6,7), (1,7,3,5)(2,6,8,4) ])
+gap> SetIsPGroup(Q,true); 
+gap> PrimePGroup(Q);
+2
+gap> G := DihedralGroup(IsFpGroup, 8);
+<fp group of size 8 on the generators [ r, s ]>
+gap> IsPGroup(G);
+true
+gap> H := CyclicGroup(IsFpGroup, 2);
+<fp group of size 2 on the generators [ a ]>
+gap> hom := GroupHomomorphismByImages(G, H, [G.1, G.2], [H.1, One(H)]);
+[ r, s ] -> [ a, <identity ...> ]
+gap> K := Kernel(hom);
+Group(<fp, no generators known>)
+gap> SetIsPGroup(K, true);
+gap> PrimePGroup(K);
+2
+gap> IsPGroup(TrivialGroup());
+true
+gap> PrimePGroup(TrivialGroup());
+fail
+gap> IsPGroup(AbelianGroup([2, 4, 8, 16]));
+true
+gap> IsPGroup(AbelianGroup([2, 4, 8, 18]));
+false
+gap> H1 := Group((1,2)(3,4),(1,2,3));
+Group([ (1,2)(3,4), (1,2,3) ])
+gap> IsPGroup(H1); 
+false
+gap> H2 := Group((1,2),(3,4,5));
+Group([ (1,2), (3,4,5) ])
+gap> IsPGroup(H2);
+false
+gap> H3 := Group((1,2),(3,4,5));
+Group([ (1,2), (3,4,5) ])
+gap> IsAbelian(H3);
+true
+gap> IsPGroup(H3);
+false
+gap> H4 := Group((1,2),(3,4,5));
+Group([ (1,2), (3,4,5) ])
+gap> IsAbelian(H4);
+true
+gap> Size(H4);
+6
+gap> IsPGroup(H4);
+false
+gap> K := Group((1,3),(1,2,3,4),(5,6,7));
+Group([ (1,3), (1,2,3,4), (5,6,7) ])
+gap> IsNilpotentGroup(K);
+true
+gap> HasIsPGroup(K);
+true
+gap> IsPGroup(K);
+false
+gap> L := Group((2,4), (1,2,3,4));
+Group([ (2,4), (1,2,3,4) ])
+gap> IsNilpotentGroup(L);
+true
+gap> HasIsPGroup(L) and HasPrimePGroup(L);
+true
+gap> IsPGroup(L);
+true
+gap> PrimePGroup(L);
+2
+gap> F := FreeGroup("r","s");
+<free group on the generators [ r, s ]>
+gap> r := F.1; s := F.2;
+r
+s
+gap> G := F/[ r^4, s^2, s*r*s*r ];
+<fp group on the generators [ r, s ]>
+gap> IsNilpotentGroup(G);
+true
+gap> G := F/[ r^3, s^2, r*s*r*s ];
+<fp group on the generators [ r, s ]>
+gap> IsNilpotentGroup(G);
+false
+gap> ForAll(List([1..11], i -> TransitiveGroup(8,i)), IsPGroup);
+true
+gap> IsPGroup(TransitiveGroup(8, 12));
+false
+gap> IsNilpotentGroup(TransitiveGroup(8, 12));
+false
+gap> IsPGroup(AlternatingGroup(3));
+true
+gap> IsPGroup(AlternatingGroup(4));
+false
+gap> IsPGroup(SymmetricGroup(3));
+false
+gap> G := SymmetricGroup(8);
+Sym( [ 1 .. 8 ] )
+gap> s := Size(G);
+40320
+gap> IsPGroup(G);
+false
+gap> IsNilpotentGroup(G);
+false
+gap> ForAll(PrimeDivisors(s), p -> HasIsPGroup(SylowSubgroup(G, p)));
+true
+gap> ForAll(PrimeDivisors(s), p -> HasPrimePGroup(SylowSubgroup(G, p)));
+true
+gap> ForAll(PrimeDivisors(s), p -> p=PrimePGroup(SylowSubgroup(G, p)));
+true
+gap> G := DihedralGroup(Factorial(8));
+<pc group of size 40320 with 11 generators>
+gap> IsPGroup(G);
+false
+gap> IsNilpotentGroup(G);
+false
+gap> s := Size(G);
+40320
+gap> ForAll(PrimeDivisors(s), p -> HasIsPGroup(SylowSubgroup(G, p)));
+true
+gap> ForAll(PrimeDivisors(s), p -> HasPrimePGroup(SylowSubgroup(G, p)));
+true
+gap> ForAll(PrimeDivisors(s), p -> p=PrimePGroup(SylowSubgroup(G, p)));
+true
+gap> STOP_TEST("pgroups.tst", 10000);


### PR DESCRIPTION
This pull request enhances IsNilpotentGroup, IsPGroup, PrimePGroup: 

    - Added method for groups where the size can be computed. The method uses
      the fast IsPrimePowerInt, and needs no factorization of integers.
    - Increased rank when the group is known to be a direct product.

    - RedispathcOnCondition if group is not yet known to be a p-group.
    - Added method if p-group has generators.
    - For a p-group Set(Factors(Size(G)))[1]=Factors(Size(G))[1], thus no need
      to call for Set.

    - Replaced Factors by first checking for IsPrimePowerInt, and then calling
      Factors.

The rank numbers are chosen so that these will be higher ranked than the currently highest method for permgroups in lib/grpperm.gi:1259. However, these ranks should be open to discussion. 

I personally do not like the code for IsPGroup. First, it contains almost 100% the same code twice, one for the nilpotent groups and one for without. Currently it works like the following: if size is known, then it is checked to be a prime power. Otherwise, if the group is nilpotent, then the orders of the generators are checked to be all prime powers for the same prime. If neither the size, nor nilpotency is known, then IsAbelian check is forced and if successful, then used the same way as for the nilpotent case. Finally, a Size computation is forced. I am sure that this can be written much better by using the filters and RedispatchOnCondition, so the whole code would actually be readable. I did not write it that way in order to make reviewing easier, but I am happy to do it if people agree.

Finally, the cases where the group is a direct product are not handled well, because knowing that the group is a direct product is a low ranked filter. It would be nice to increase these ranks in a uniform manner, rather than setting them one by one for IsNilpotentGroup, IsPGroup, etc. 
