### PR TITLE
Rename USER_HOME_EXPAND to UserHomeExpand and add documentation

### DIFF
--- a/doc/ref/files.xml
+++ b/doc/ref/files.xml
@@ -198,7 +198,6 @@ or into <F>/home/myhome/gap</F>, respectively.
 <#Include Label="DirectoryContents">
 <#Include Label="DirectoryDesktop">
 <#Include Label="DirectoryHome">
-
 </Section>
 
 
@@ -475,6 +474,7 @@ can be used to get information about the error.
 </Description>
 </ManSection>
 
+<#Include Label="UserHomeExpand">
 
 <#Include Label="Reread">
 
@@ -485,4 +485,3 @@ can be used to get information about the error.
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <!-- %% -->
 <!-- %E -->
-

--- a/lib/files.gd
+++ b/lib/files.gd
@@ -660,6 +660,25 @@ end );
 DeclareGlobalFunction( "Edit" );
 
 
+#############################################################################
+##
+#F  UserHomeExpand . . . . . . . . . . . . .  expand leading ~ in file name
+##
+##  <#GAPDoc Label="UserHomeExpand">
+##  <ManSection>
+##  <Func Name="UserHomeExpand" Arg='obj'/>
+##  <Description>
+##
+##  Replaces "~" at the start of <A>obj</A> with the users home directory
+##  (which is stored in `GAPInfo.UserHome`, if known) and returns the result.
+##  If <A>obj</A> does not start with "~", the filename is returned unchanged.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##  
+DeclareGlobalFunction("UserHomeExpand");
+
+
 # the character set definitions might be needed when processing files, thus
 # they must come earlier.
 BIND_GLOBAL("CHARS_DIGITS",Immutable(SSortedList("0123456789")));

--- a/lib/files.gi
+++ b/lib/files.gi
@@ -36,6 +36,18 @@ BindGlobal( "DirectoryType", NewType(
     DirectoriesFamily,
     IsDirectory and IsDirectoryRep ) );
 
+#############################################################################
+##
+#F  UserHomeExpand . . . . . . . . . . . . .  expand leading ~ in file name
+## 
+
+InstallGlobalFunction("UserHomeExpand", function(str)
+  if not IsString(str) then
+    ErrorMayQuit("Filenames must be a string");
+  fi;
+  return USER_HOME_EXPAND(str);
+end);
+
 
 
 #############################################################################

--- a/lib/streams.gd
+++ b/lib/streams.gd
@@ -1002,7 +1002,7 @@ DeclareOperation( "PrintFormattingStatus", [IsOutputStream] );
 BIND_GLOBAL( "AppendTo", function( arg )
     if IsString(arg[1])  then
         arg := ShallowCopy(arg);
-        arg[1] := USER_HOME_EXPAND(arg[1]);
+        arg[1] := UserHomeExpand(arg[1]);
         CallFuncList( APPEND_TO, arg );
     elif IsOutputStream(arg[1])  then
         # direct call to `WriteAll' if arg is one string and formatting
@@ -1037,7 +1037,7 @@ end );
 BIND_GLOBAL( "PrintTo", function( arg )    
     if IsString(arg[1])  then
         arg := ShallowCopy(arg);
-        arg[1] := USER_HOME_EXPAND(arg[1]);
+        arg[1] := UserHomeExpand(arg[1]);
         CallFuncList( PRINT_TO, arg );
     elif IsOutputStream(arg[1])  then
         # direct call to `WriteAll' if arg is one string and formatting
@@ -1350,4 +1350,3 @@ DeclareGlobalFunction( "InputFromUser" );
 #############################################################################
 ##
 #E
-

--- a/lib/string.g
+++ b/lib/string.g
@@ -325,20 +325,8 @@ InstallMethod( String,
 
     
 #############################################################################
+## Documented as UserHomeExpand in files.gi
 ##
-#F  USER_HOME_EXPAND . . . . . . . . . . . . .  expand leading ~ in file name
-##
-##  <ManSection>
-##  <Func Name="USER_HOME_EXPAND" Arg='obj'/>
-##  <Description>
-##
-##  
-##  If `GAPInfo.UserHome' has positive length then a leading '~' character in 
-##  string `str' is substituted by the content of `GAPInfo.UserHome'.
-##  Otherwise `str' itself is returned.
-##  </Description>
-##  </ManSection>
-##  
 BIND_GLOBAL("USER_HOME_EXPAND", function(str)
   if Length(str) > 0 and str[1] = '~' and IsString(GAPInfo.UserHome) and
      Length( GAPInfo.UserHome ) > 0 then
@@ -347,7 +335,6 @@ BIND_GLOBAL("USER_HOME_EXPAND", function(str)
     return str;
   fi;
 end);
-    
 
 #############################################################################
 ##


### PR DESCRIPTION
The function `USER_HOME_EXPAND` expands an initial `~` in a filename to the user's home directory. It is used in several places and it seems worth promoting to a documented function.

`USER_NAME_EXPAND` is left, because we need this function very early during startup, in particular before functions like `Error` exist, so we have `UserNameExpand` with nice input checking which calls `USER_NAME_EXPAND`.