### PR TITLE
Fix Issue #411 - Uniform Syntax Error Format

### DIFF
--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -81,7 +81,7 @@ error message of the following form
 <P/>
 <Log><![CDATA[
 gap> 1 * ;
-Syntax error: expression expected
+Syntax error: Expression expected
 1 * ;
     ^
 ]]></Log>

--- a/src/code.c
+++ b/src/code.c
@@ -1309,7 +1309,7 @@ void            CodeBreak ( void )
     Stat                stat;           /* break-statement, result         */
 
     if (!TLS(LoopNesting))
-      SyntaxError("break statement not enclosed in a loop");
+      SyntaxError("Break statement not enclosed in a loop");
     
     /* allocate the break-statement                                        */
     stat = NewStat( T_BREAK, 0 * sizeof(Expr) );
@@ -1330,7 +1330,7 @@ void            CodeContinue ( void )
     Stat                stat;           /* continue-statement, result         */
 
     if (!TLS(LoopNesting))
-      SyntaxError("continue statement not enclosed in a loop");
+      SyntaxError("Continue statement not enclosed in a loop");
 
     /* allocate the continue-statement                                        */
     stat = NewStat( T_CONTINUE, 0 * sizeof(Expr) );

--- a/src/read.c
+++ b/src/read.c
@@ -216,7 +216,7 @@ void ReadFuncCallOption( TypSymbolSet follow )
     if ( ! READ_ERROR() ) { IntrFuncCallOptionsBeginElmExpr(); }
   }
   else {
-    SyntaxError("identifier expected");
+    SyntaxError("Identifier expected");
   }
   if ( TLS(Symbol) == S_ASSIGN )
     {
@@ -273,7 +273,7 @@ void ReadCallVarAss (
 
     /* all variables must begin with an identifier                         */
     if ( TLS(Symbol) != S_IDENT ) {
-        SyntaxError( "identifier expected" );
+        SyntaxError( "Identifier expected" );
         return;
     }
 
@@ -366,7 +366,7 @@ void ReadCallVarAss (
 	  return;
 	}
       else
-	SyntaxError("function literal in impossible context");
+	SyntaxError("Function literal in impossible context");
     }
 
     /* check whether this is an unbound global variable                    */
@@ -386,7 +386,7 @@ void ReadCallVarAss (
              ELM_REC(GAPInfo,WarnOnUnboundGlobalsRNam) != False )
       && ! SyCompilePlease )
     {
-        SyntaxWarning("unbound global variable");
+        SyntaxWarning("Unbound global variable");
     }
 
     /* check whether this is a reference to the global variable '~'        */
@@ -469,7 +469,7 @@ void ReadCallVarAss (
                 type = ':';
             }
             else {
-                SyntaxError("record component name expected");
+                SyntaxError("Record component name expected");
             }
             level = 0;
         }
@@ -489,7 +489,7 @@ void ReadCallVarAss (
                 type = '|';
             }
             else {
-                SyntaxError("record component name expected");
+                SyntaxError("Record component name expected");
             }
             level = 0;
         }
@@ -598,7 +598,7 @@ void ReadCallVarAss (
         else if ( type == ':' ) { IntrUnbRecExpr();               }
         else if ( type == '!' ) { IntrUnbComObjName( rnam );      }
         else if ( type == '|' ) { IntrUnbComObjExpr();            }
-        else { SyntaxError("illegal operand for 'Unbind'");       }
+        else { SyntaxError("Illegal operand for 'Unbind'");       }
     }
 
 
@@ -615,7 +615,7 @@ void ReadCallVarAss (
         else if ( type == ':' ) { IntrIsbRecExpr();               }
         else if ( type == '!' ) { IntrIsbComObjName( rnam );      }
         else if ( type == '|' ) { IntrIsbComObjExpr();            }
-        else { SyntaxError("illegal operand for 'IsBound'");      }
+        else { SyntaxError("Illegal operand for 'IsBound'");      }
     }
 
 }
@@ -994,16 +994,16 @@ void ReadListExpr (
 
     /* incorrect place for three dots                                      */
     if (TLS(Symbol) == S_DOTDOTDOT) {
-            SyntaxError("only two dots in a range");
+            SyntaxError("Only two dots in a range");
     }
 
     /* '..' <Expr> ']'                                                     */
     if ( TLS(Symbol) == S_DOTDOT ) {
         if ( pos != nr ) {
-            SyntaxError("must have no unbound entries in range");
+            SyntaxError("Must have no unbound entries in range");
         }
         if ( 2 < nr ) {
-            SyntaxError("must have at most 2 entries before '..'");
+            SyntaxError("Must have at most 2 entries before '..'");
         }
         range = 1;
         Match( S_DOTDOT, "..", follow );
@@ -1013,7 +1013,7 @@ void ReadListExpr (
         if ( ! READ_ERROR() ) { IntrListExprEndElm(); }
         nr++;
         if ( TLS(ReadTop) == 1 && TLS(ReadTilde) == 1 ) {
-            SyntaxError("sorry, '~' not allowed in range");
+            SyntaxError("Sorry, '~' not allowed in range");
         }
     }
 
@@ -1073,7 +1073,7 @@ void ReadRecExpr (
 	  if ( ! READ_ERROR() ) { IntrRecExprBeginElmExpr(); }
         }
         else {
-	  SyntaxError("identifier expected");
+	  SyntaxError("Identifier expected");
         }
         Match( S_ASSIGN, ":=", follow );
         ReadExpr( S_RPAREN|follow, 'r' );
@@ -1224,7 +1224,7 @@ void ReadFuncExpr (
 
 	    for ( i = 1; i <= narg; i++ ) {
 		if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
-		    SyntaxError("name used for two arguments");
+		    SyntaxError("Name used for two arguments");
 		}
 	    }
         C_NEW_STRING_DYN( name, TLS(Value) );
@@ -1245,7 +1245,7 @@ void ReadFuncExpr (
         Match( S_LOCAL, "local", follow );
         for ( i = 1; i <= narg; i++ ) {
             if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
-                SyntaxError("name used for argument and local");
+                SyntaxError("Name used for argument and local");
             }
         }
         C_NEW_STRING_DYN( name, TLS(Value) );
@@ -1258,12 +1258,12 @@ void ReadFuncExpr (
             Match( S_COMMA, ",", follow );
             for ( i = 1; i <= narg; i++ ) {
                 if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
-                    SyntaxError("name used for argument and local");
+                    SyntaxError("Name used for argument and local");
                 }
             }
             for ( i = narg+1; i <= narg+nloc; i++ ) {
                 if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
-                    SyntaxError("name used for two locals");
+                    SyntaxError("Name used for two locals");
                 }
             }
             C_NEW_STRING_DYN( name, TLS(Value) );
@@ -2690,7 +2690,7 @@ UInt ReadEvalFile ( void )
             Match( S_COMMA, ",", 0L );
             for ( i = 1; i <= nloc; i++ ) {
                 if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
-                    SyntaxError("name used for two locals");
+                    SyntaxError("Name used for two locals");
                 }
             }
             C_NEW_STRING_DYN( name, TLS(Value) );

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1678,7 +1678,7 @@ void GetNumber ( UInt StartingStatus )
                        c != 'd' && c != 'Q')) {
 
       if (!seenADigit)
-        SyntaxError("Badly formed number, need a digit before or after the decimal point");
+        SyntaxError("Badly formed number: need a digit before or after the decimal point");
       /* We allow one letter on the end of the numbers -- could be an i,
        C99 style */
       if (!wasEscaped) {
@@ -1711,7 +1711,7 @@ void GetNumber ( UInt StartingStatus )
        left the previous loop because of overflow */
     if (IsAlpha(c)) {
         if (!seenADigit)
-          SyntaxError("Badly formed number, need a digit before or after the decimal point");
+          SyntaxError("Badly formed number: need a digit before or after the decimal point");
         seenExp = 1;
         TLS(Value)[i++] = c;
         c = GetCleanedChar(&wasEscaped);
@@ -1733,7 +1733,7 @@ void GetNumber ( UInt StartingStatus )
        deal with the end of token case */
     if (!seenExp) {
       if (!seenADigit)
-        SyntaxError("Badly formed number, need a digit before or after the decimal point");
+        SyntaxError("Badly formed number: need a digit before or after the decimal point");
       /* Might be a conversion marker */
       if (!wasEscaped) {
         if (IsAlpha(c) && c != 'e' && c != 'E' && c != 'd' && c != 'D' && c != 'q' && c != 'Q') {
@@ -1803,7 +1803,7 @@ void GetNumber ( UInt StartingStatus )
 
   /* Otherwise this is the end of the token */
   if (!seenExpDigit)
-    SyntaxError("Badly Formed Number, need at least one digit in the exponent");
+    SyntaxError("Badly Formed Number: need at least one digit in the exponent");
   TLS(Symbol) = S_FLOAT;
   TLS(Value)[i] = '\0';
   return;
@@ -1872,7 +1872,7 @@ void GetStr ( void )
       else if ( IsDigit( *TLS(In) ) ) {
         a = *TLS(In); GET_CHAR(); b = *TLS(In); GET_CHAR(); c = *TLS(In);
         if (!( IsDigit(b) && IsDigit(c) )){
-          SyntaxError("expecting three octal digits after \\ in string");
+          SyntaxError("Expecting three octal digits after \\ in string");
         }
         TLS(Value)[i] = (a-'0') * 64 + (b-'0') * 8 + c-'0';
       }
@@ -1896,9 +1896,9 @@ void GetStr ( void )
 
   /* check for error conditions                                          */
   if ( *TLS(In) == '\n'  )
-    SyntaxError("string must not include <newline>");
+    SyntaxError("String must not include <newline>");
   if ( *TLS(In) == '\377' )
-    SyntaxError("string must end with \" before end of file");
+    SyntaxError("String must end with \" before end of file");
 
   /* set length of string, set 'Symbol' and skip trailing '"'            */
   TLS(ValueLen) = i;
@@ -1975,7 +1975,7 @@ void GetTripStr ( void )
 
   /* check for error conditions                                          */
   if ( *TLS(In) == '\377' )
-    SyntaxError("string must end with \" before end of file");
+    SyntaxError("String must end with \" before end of file");
 
   /* set length of string, set 'Symbol' and skip trailing '"'            */
   TLS(ValueLen) = i;
@@ -2059,18 +2059,18 @@ void GetChar ( void )
       c = 64 * (*TLS(In) - '0');
       GET_CHAR();
       if ( *TLS(In) < '0' || *TLS(In) > '7' )
-        SyntaxError("expecting octal digit in character constant");
+        SyntaxError("Expecting octal digit in character constant");
       c = c + 8 * (*TLS(In) - '0');
       GET_CHAR();
       if ( *TLS(In) < '0' || *TLS(In) > '7' )
-        SyntaxError("expecting 3 octal digits in character constant");
+        SyntaxError("Expecting 3 octal digits in character constant");
       c = c + (*TLS(In) - '0');
       TLS(Value)[0] = c;
     }
     else                     TLS(Value)[0] = *TLS(In);
   }
   else if ( *TLS(In) == '\n' ) {
-    SyntaxError("newline not allowed in character literal");
+    SyntaxError("Newline not allowed in character literal");
   }
   /* put normal chars into 'TLS(Value)'                                       */
   else {
@@ -2083,7 +2083,7 @@ void GetChar ( void )
   
   /* check for terminating single quote                                  */
   if ( *TLS(In) != '\'' )
-    SyntaxError("missing single quote in character constant");
+    SyntaxError("Missing single quote in character constant");
 
   /* skip the closing quote                                              */
   TLS(Symbol) = S_CHAR;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -168,7 +168,7 @@ void            SyntaxError (
 
 /****************************************************************************
 **
-*F  SyntaxWarning( <msg> )  . . . . . . . . . . . . . . .  raise a syntax error
+*F  SyntaxWarning( <msg> )  . . . . . . . . . . . . . . raise a syntax warning
 **
 */
 void            SyntaxWarning (

--- a/tst/testinstall/break.tst
+++ b/tst/testinstall/break.tst
@@ -4,11 +4,11 @@ Error, A break statement can only appear inside a loop
 gap> continue;
 Error, A continue statement can only appear inside a loop
 gap> f := function() break; end;
-Syntax error: break statement not enclosed in a loop in stream line 1
+Syntax error: Break statement not enclosed in a loop in stream line 1
 f := function() break; end;
                      ^
 gap> f := function() continue; end;
-Syntax error: continue statement not enclosed in a loop in stream line 1
+Syntax error: Continue statement not enclosed in a loop in stream line 1
 f := function() continue; end;
                         ^
 gap> f := function() local i; for i in [1..5] do continue; od; end;;
@@ -24,15 +24,15 @@ gap> f();
 gap> f := function() local i; i := 1; repeat i := i + 1; break; until i in [1..5]; end;;
 gap> f();
 gap> for i in [1..5] do List([1..5], function(x) continue; return 1; end); od;
-Syntax error: continue statement not enclosed in a loop in stream line 1
+Syntax error: Continue statement not enclosed in a loop in stream line 1
 for i in [1..5] do List([1..5], function(x) continue; return 1; end); od;
                                                     ^
 gap> for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
-Syntax error: break statement not enclosed in a loop in stream line 1
+Syntax error: Break statement not enclosed in a loop in stream line 1
 for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
                                                  ^
 gap> for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
-Syntax error: break statement not enclosed in a loop in stream line 1
+Syntax error: Break statement not enclosed in a loop in stream line 1
 for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
                                                  ^
 gap> STOP_TEST("break.tst", 1);

--- a/tst/testinstall/longnumber.tst
+++ b/tst/testinstall/longnumber.tst
@@ -165,29 +165,29 @@ gap> 1111111111111111111111111111111111111.1;
 gap> 1.11111111111111111111111111111111111111;
 1.11111
 gap> .;
-Syntax error: Badly formed number, need a digit before or after the decimal po\
+Syntax error: Badly formed number: need a digit before or after the decimal po\
 int in stream line 1
 .;
 ^
 gap> .n;
-Syntax error: Badly formed number, need a digit before or after the decimal po\
+Syntax error: Badly formed number: need a digit before or after the decimal po\
 int in stream line 1
 .n;
 ^
 gap> .q;
-Syntax error: Badly formed number, need a digit before or after the decimal po\
+Syntax error: Badly formed number: need a digit before or after the decimal po\
 int in stream line 1
 .q;
 ^
 gap> .0n;
 fail
 gap> .0q;
-Syntax error: Badly Formed Number, need at least one digit in the exponent in \
+Syntax error: Badly Formed Number: need at least one digit in the exponent in \
 stream line 1
 .0q;
   ^
 gap> .0qn;
-Syntax error: Badly Formed Number, need at least one digit in the exponent in \
+Syntax error: Badly Formed Number: need at least one digit in the exponent in \
 stream line 1
 .0qn;
   ^

--- a/tst/testinstall/varargs.tst
+++ b/tst/testinstall/varargs.tst
@@ -84,7 +84,7 @@ end
 gap> [1..2];
 [ 1, 2 ]
 gap> [1...2];
-Syntax error: only two dots in a range in stream line 1
+Syntax error: Only two dots in a range in stream line 1
 [1...2];
     ^
 gap> f := function(a,arg) return [a,arg]; end;

--- a/tst/teststandard/bugfix.tst
+++ b/tst/teststandard/bugfix.tst
@@ -2607,7 +2607,7 @@ gap> PositionSublist("xyz", "");
 
 # 2013/08/21 (MH)
 gap> . . . .
-Syntax error: Badly formed number, need a digit before or after the decimal po\
+Syntax error: Badly formed number: need a digit before or after the decimal po\
 int in stream line 1
 . . . .
 ^


### PR DESCRIPTION
This PR fixes issue #411 by ensuring all SyntaxError/SyntaxWarning messages have a consistent format.