### PR TITLE
Better error handling for tasks.

### DIFF
--- a/lib/error.g
+++ b/lib/error.g
@@ -43,9 +43,6 @@ end);
 
 ErrorLVars := fail;
 
-
-
-
 BIND_GLOBAL("WHERE", function( context, depth, outercontext)
     local   bottom,  lastcontext,  f;
     if depth <= 0 then
@@ -191,11 +188,18 @@ BIND_GLOBAL("ErrorInner",
     errorLVars := ErrorLVars;
     ErrorLVars := context;
     if QUITTING or not BreakOnError then
-        PrintTo("*errout*","Error, ");
-        for x in earlyMessage do
-            PrintTo("*errout*",x);
-        od;
-        PrintTo("*errout*","\n");
+        if not SilentErrors then
+	  PrintTo("*errout*","Error, ");
+	  for x in earlyMessage do
+	      PrintTo("*errout*",x);
+	  od;
+	  PrintTo("*errout*","\n");
+	fi;
+	LastErrorMessage := "";
+	for x in earlyMessage do
+	  Append(LastErrorMessage, x);
+	od;
+	MakeImmutable(LastErrorMessage);
         ErrorLevel := ErrorLevel-1;
         ErrorLVars := errorLVars;
         if ErrorLevel = 0 then LEAVE_ALL_NAMESPACES(); fi;

--- a/lib/init.g
+++ b/lib/init.g
@@ -248,7 +248,10 @@ CallAndInstallPostRestore( function()
     UNBIND_GLOBAL( "TEACHING_MODE" );
     BIND_GLOBAL( "TEACHING_MODE", GAPInfo.CommandLineOptions.T );
     BindThreadLocal( "BreakOnError", not GAPInfo.CommandLineOptions.T );
+    BindThreadLocal( "SilentErrors", false );
+    BindThreadLocal( "LastErrorMessage", "" );
 end);
+
 
 
 #############################################################################


### PR DESCRIPTION
HPC-GAP now supports suppression of error message output (via the
thread-local variable SilentErrors, to be used in conjunction with
BreakOnErrors) and recovery of the last error message in that case with
the thread-local variable LastErrorMessage.

This is used by the standard task library to learn whether the task
succeeded or failed and why (via TaskSuccess() and TaskError()).
Likewise, task errors will now not drop the user into a break loop
anymore, though we may want to make this a configurable option.