### PR TITLE
Changing references from testall.g to teststandard.g

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ $ git diff --check
  * Run all the tests to assure nothing else was accidentally broken.
 ```
 $ make testinstall
-$ make testall
+$ make teststandard
 ```
  * Push your changes to a topic branch in your fork of the repository.
 ```

--- a/INSTALL
+++ b/INSTALL
@@ -346,10 +346,10 @@ gaussian.tst               0             10
 [ further lines deleted ]
 
 If you want to run a more advanced check (this is not required and may take
-up to an hour), you can read testall.g which is an extended test script
+up to an hour), you can read teststandard.g which is an extended test script
 performing all tests from the tst directory.
 
-gap> Read( Filename( DirectoriesLibrary( "tst" ), "testall.g" ) );
+gap> Read( Filename( DirectoriesLibrary( "tst" ), "teststandard.g" ) );
 
 The test requires about 512 MB of memory and runs about one hour on an
 Intel Core 2 Duo / 2.53 GHz machine, and produces an output similar to the

--- a/tst/teststandard.g
+++ b/tst/teststandard.g
@@ -1,6 +1,6 @@
 #############################################################################
 ##
-#W  testall.g                   GAP library                      Frank Celler
+#W  teststandard.g                   GAP library                      Frank Celler
 ##
 ##
 #Y  Copyright (C)  1997,  Lehrstuhl D für Mathematik,  RWTH Aachen,  Germany


### PR DESCRIPTION
testall was replaced with teststandard in commit
64cf0c3b8e92f16e3dcbe834f4122dfadd2f0202