### PR TITLE
Further iteration to document UserHomeExpand

### DIFF
--- a/lib/cmdledit.g
+++ b/lib/cmdledit.g
@@ -673,7 +673,7 @@ BindGlobal("SaveCommandLineHistory", function(arg)
     if IsExistingFile(GAPInfo.UserGapRoot) then
       fnam := Concatenation(GAPInfo.UserGapRoot, "/history");
     else
-      fnam := USER_HOME_EXPAND("~/.gap_hist");
+      fnam := UserHomeExpand("~/.gap_hist");
     fi;
   fi;
   if true in arg then
@@ -707,7 +707,7 @@ BindGlobal("ReadCommandLineHistory", function(arg)
     if IsExistingFile(GAPInfo.UserGapRoot) then
       fnam := Concatenation(GAPInfo.UserGapRoot, "/history");
     else
-      fnam := USER_HOME_EXPAND("~/.gap_hist");
+      fnam := UserHomeExpand("~/.gap_hist");
     fi;
   fi;
   s := StringFile(fnam);

--- a/lib/files.gd
+++ b/lib/files.gd
@@ -659,26 +659,6 @@ end );
 ##
 DeclareGlobalFunction( "Edit" );
 
-
-#############################################################################
-##
-#F  UserHomeExpand . . . . . . . . . . . . .  expand leading ~ in file name
-##
-##  <#GAPDoc Label="UserHomeExpand">
-##  <ManSection>
-##  <Func Name="UserHomeExpand" Arg='obj'/>
-##  <Description>
-##
-##  Replaces "~" at the start of <A>obj</A> with the users home directory
-##  (which is stored in `GAPInfo.UserHome`, if known) and returns the result.
-##  If <A>obj</A> does not start with "~", the filename is returned unchanged.
-##  </Description>
-##  </ManSection>
-##  <#/GAPDoc>
-##  
-DeclareGlobalFunction("UserHomeExpand");
-
-
 # the character set definitions might be needed when processing files, thus
 # they must come earlier.
 BIND_GLOBAL("CHARS_DIGITS",Immutable(SSortedList("0123456789")));

--- a/lib/files.gi
+++ b/lib/files.gi
@@ -38,27 +38,13 @@ BindGlobal( "DirectoryType", NewType(
 
 #############################################################################
 ##
-#F  UserHomeExpand . . . . . . . . . . . . .  expand leading ~ in file name
-## 
-
-InstallGlobalFunction("UserHomeExpand", function(str)
-  if not IsString(str) then
-    ErrorMayQuit("Filenames must be a string");
-  fi;
-  return USER_HOME_EXPAND(str);
-end);
-
-
-
-#############################################################################
-##
 #M  Directory( <str> )  . . . . . . . . . . .  create a new directpory object
 ##
 InstallMethod( Directory,
     "string",
     [ IsString ],
 function( str )
-    str := USER_HOME_EXPAND(str);
+    str := UserHomeExpand(str);
     #
     # ':' or '\\' probably are untranslated MSDOS or MaxOS path
     # separators, but ':' in position 2 may be OK
@@ -188,7 +174,7 @@ InstallGlobalFunction(DirectoryContents, function(dirname)
     dirname := dirname![1];
   else
     # to make ~/mydir work
-    dirname := USER_HOME_EXPAND(dirname);
+    dirname := UserHomeExpand(dirname);
   fi;
   str := STRING_LIST_DIR(dirname);
   if str = fail then
@@ -211,7 +197,7 @@ InstallMethod( Read,
 function ( name )
     local   readIndent,  found;
 
-    name := USER_HOME_EXPAND(name);
+    name := UserHomeExpand(name);
 
     readIndent := SHALLOW_COPY_OBJ( READ_INDENT );
     APPEND_LIST_INTR( READ_INDENT, "  " );
@@ -234,7 +220,7 @@ end );
 InstallMethod( ReadAsFunction,
     "string",
     [ IsString ],
-    name -> READ_AS_FUNC( USER_HOME_EXPAND( name ) ) );  
+    name -> READ_AS_FUNC( UserHomeExpand( name ) ) );  
 
 
 #############################################################################
@@ -272,7 +258,7 @@ leave the 'Editor' and 'EditorOptions' preferences empty."
 InstallGlobalFunction( Edit, function( name )
     local   editor,  ret;
 
-    name := USER_HOME_EXPAND(name);
+    name := UserHomeExpand(name);
     editor := Filename( DirectoriesSystemPrograms(), UserPreference("Editor") );
     if editor = fail  then
         Error( "cannot locate editor `", UserPreference("Editor"),

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -543,5 +543,12 @@ end);
 
 #############################################################################
 ##
+#F  USER_HOME_EXPAND
+##
+##  This got a nicer name before is became documented.
+DeclareGlobalFunction( "USER_HOME_EXPAND" );
+
+#############################################################################
+##
 #E
 

--- a/lib/obsolete.gi
+++ b/lib/obsolete.gi
@@ -877,6 +877,17 @@ local lo,up,s;
 #  fi;
 end );
 
+#############################################################################
+##
+#F  USER_HOME_EXPAND
+##
+##  This got a nicer name before is became documented.
+InstallGlobalFunction( USER_HOME_EXPAND, function(str)
+  Info( InfoObsolete, 1,
+        "use the documented 'UserHomeExpand' instead of the obsolete ",
+        "'USER_HOME_EXPAND'" );
+  return UserHomeExpand(str);
+end);
 
 #############################################################################
 ##

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1556,7 +1556,7 @@ fi;
         # This is the first attempt to read stuff for this package.
         # So we handle the case of a `PreloadFile' entry.
         if IsBound( info.PreloadFile ) then
-          filename:= USER_HOME_EXPAND( info.PreloadFile );
+          filename:= UserHomeExpand( info.PreloadFile );
           if filename[1] = '/' then
             read:= READ( filename );
           else

--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -295,7 +295,7 @@ function(name)
     Print("#I  Already logging to ",IN_LOGGING_MODE,"\n");
     return;
   fi;
-  expandname := USER_HOME_EXPAND( name );
+  expandname := UserHomeExpand( name );
   LOG_TO( expandname );
   IN_LOGGING_MODE := name;
 end ); # ignore return value
@@ -333,7 +333,7 @@ InstallMethod( InputLogTo,
 InstallOtherMethod( InputLogTo,
     "for output file",
     [ IsString ],
-    function(name) name := USER_HOME_EXPAND(name); INPUT_LOG_TO(name); end );
+    function(name) name := UserHomeExpand(name); INPUT_LOG_TO(name); end );
     # ignore return value
 
 
@@ -364,7 +364,7 @@ InstallMethod( OutputLogTo,
 InstallOtherMethod( OutputLogTo,
     "for output file",
     [ IsString ],
-    function(name) name := USER_HOME_EXPAND(name); OUTPUT_LOG_TO(name); end );
+    function(name) name := UserHomeExpand(name); OUTPUT_LOG_TO(name); end );
     # ignore return value
 
 
@@ -636,7 +636,7 @@ InstallMethod( InputTextFile,
     [ IsString ],
 function( str )
     local   fid;
-    str := USER_HOME_EXPAND(str);
+    str := UserHomeExpand(str);
 
     fid := INPUT_TEXT_FILE(str);
     if fid = fail  then
@@ -1074,7 +1074,7 @@ InstallMethod( OutputTextFile,
       IsBool ],
 function( str, append )
     local   fid;
-    str := USER_HOME_EXPAND(str);
+    str := UserHomeExpand(str);
 
     fid := OUTPUT_TEXT_FILE( str, append );
     if fid = fail  then

--- a/lib/string.g
+++ b/lib/string.g
@@ -325,11 +325,26 @@ InstallMethod( String,
 
     
 #############################################################################
-## Documented as UserHomeExpand in files.gi
 ##
-BIND_GLOBAL("USER_HOME_EXPAND", function(str)
-  if Length(str) > 0 and str[1] = '~' and IsString(GAPInfo.UserHome) and
-     Length( GAPInfo.UserHome ) > 0 then
+#F  UserHomeExpand( <str> ) . . . . . . . . . . . . expand leading ~ in str
+##
+##  <#GAPDoc Label="UserHomeExpand">
+##  <ManSection>
+##  <Func Name="UserHomeExpand" Arg='str'/>
+##  <Description>
+##
+##  If the string <A>str</A> starts with a <C>'~'</C> character this
+##  function returns a new string with the leading <C>'~'</C> substituted by
+##  the users home directory as stored in <C>GAPInfo.UserHome</C>.
+##  
+##  Otherwise <A>str</A> is returned unchanged.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+BIND_GLOBAL("UserHomeExpand", function(str)
+  if IsString(str) and Length(str) > 0 and str[1] = '~' 
+        and IsString(GAPInfo.UserHome) and Length( GAPInfo.UserHome ) > 0 then
     return Concatenation( GAPInfo.UserHome, str{[2..Length(str)]});
   else
     return str;

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -1031,7 +1031,7 @@ static Int InitKernel (
     /* init filters and functions                                          */
     InitHdlrFuncsFromTable( GVarFuncs );
     /* allow ~/... expansion in SaveWorkspace                              */ 
-    ImportFuncFromLibrary("USER_HOME_EXPAND", &userHomeExpand);
+    ImportFuncFromLibrary("UserHomeExpand", &userHomeExpand);
 
     /* return success                                                      */
     return 0;


### PR DESCRIPTION
- gets almost rid of the old 'USER_HOME_EXPAND', except for an entry
  in lib/obsolete.* for backward compatibility (some packages use it,
  although it was not documented). In particular, the new code in
  lib/files.* is not needed.

- changes the documentation (e.g., `obj` is not a nice name for a string
  argument, and `"~"` is never at the start of a string, use proper GAPDoc
  syntax)