### PR TITLE
Remove more StabChainMutable

### DIFF
--- a/doc/ref/grpperm.xml
+++ b/doc/ref/grpperm.xml
@@ -409,6 +409,7 @@ guaranteed correct output.
 <Heading>Construction of Stabilizer Chains</Heading>
 
 <#Include Label="StabChain">
+<#Include Label="SetStabChain">
 <#Include Label="StabChainOptions">
 <#Include Label="DefaultStabChainOptions">
 <#Include Label="StabChainBaseStrongGenerators">
@@ -692,4 +693,3 @@ is much faster than the first one and takes less memory.
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <!-- %% -->
 <!-- %E -->
-

--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -320,7 +320,7 @@ local clT,	# classes T
 
 #	  #force 'centralizers[j]' to have its base appropriate to the component
 #	  # (this will speed up preimages)
-#	  if not (HasStabChainMutable(cen) 
+#	  if not (HasStabChainImmutable(cen) 
 #	     and i<=Length(centralizers)
 #	     and BaseStabChain(StabChainMutable(cen))[1] in centralizers[i])
 #	    then

--- a/lib/factgrp.gi
+++ b/lib/factgrp.gi
@@ -789,7 +789,7 @@ local o, s, k, gut, erg, H, hom, b, ihom, improve, map, loop,
   # if the original group has no stabchain we probably do not want to keep
   # it (or a homomorphisms pool) there -- make a copy for working
   # intermediately with it.
-  if not HasStabChainMutable(G) then
+  if not HasStabChainImmutable(G) then
     H:= GroupWithGenerators( GeneratorsOfGroup( G ),One(G) );
     if HasSize(G) then
       SetSize(H,Size(G));
@@ -939,7 +939,7 @@ local gimg,img,dom,b,improve,bp,bb,i,k,bestdeg,subo,op,bc,bestblock,bdom,
 	      fi;
 
 	      op:=ActionHomomorphism(gimg,bb,OnSets,"surjective");
-	      if HasSize(gimg) and not HasStabChainMutable(gimg) then
+	      if HasSize(gimg) and not HasStabChainImmutable(gimg) then
 		sto:=StabChainOptions(Range(op));
 		sto.limit:=Size(gimg);
 		# try only with random (will exclude some chances, but is
@@ -993,7 +993,7 @@ local gimg,img,dom,b,improve,bp,bb,i,k,bestdeg,subo,op,bc,bestblock,bdom,
 	    b:=Set(List(b,i->Immutable(Union(bdom{i}))));
 	  fi;
 	  op:=ActionHomomorphism(gimg,b,OnSets,"surjective");
-	  if HasSize(gimg) and not HasStabChainMutable(gimg) then
+	  if HasSize(gimg) and not HasStabChainImmutable(gimg) then
 	    sto:=StabChainOptions(Range(op));
 	    sto.limit:=Size(gimg);
 	    # try only with random (will exclude some chances, but is

--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -80,7 +80,7 @@ local s, bas, sg, o, gi, l, p, rel, start, i;
   if IsFreeGroup(s) then
     return true;
   fi;
-  bas:=BaseStabChain(StabChainMutable(Range(hom)));
+  bas:=BaseStabChain(StabChainImmutable(Range(hom)));
   sg:=FreeGeneratorsOfFpGroup(s);
   o:=One(Range(hom));
   # take the images corresponding to the free gens in case of reordering or

--- a/lib/ghomperm.gi
+++ b/lib/ghomperm.gi
@@ -1058,7 +1058,7 @@ InstallMethod( CompositionMapping2, "group hom. with perm group hom.",
     S.idimage := One( Range( hom1 ) );
     prd := GroupHomomorphismByImagesNC( Source( hom2 ), Range( hom1 ),
                    stb.generators, stb.genimages );
-    SetStabChainMutable( prd, stb );
+    SetStabChain( prd, stb );
     return prd;
 end );
 
@@ -1433,7 +1433,7 @@ local   D,  I,G;
   else
     G:=SubgroupNC(Range(hom),
       List(GeneratorsOfGroup(H),i->Permutation(i,D)));
-    SetStabChainMutable(G,I);
+    SetStabChain(G,I);
     return G;
   fi;
 end );
@@ -1460,7 +1460,7 @@ local   D,H,I,G;
     return GroupStabChain( I );
   else
     G:=Group(List(GeneratorsOfGroup(H),i->Permutation(i,D)),());
-    SetStabChainMutable(G,I);
+    SetStabChain(G,I);
     return G;
   fi;
 end;

--- a/lib/ghomperm.gi
+++ b/lib/ghomperm.gi
@@ -1286,11 +1286,11 @@ end );
 ##
 InstallGlobalFunction( MakeStabChainLong,
     function( hom, stb, ran, c1, c2, cohom, cokername )
-    local   newlevs,  S,  idimage, i,  len,  rest,  trans;
+    local   newlevs,  S, baseS, idimage, i,  len,  rest,  trans;
     
     # Construct the stabilizer chain for <hom>.
     S := CopyStabChain( stb );
-    SetStabChainMutable( hom, S );
+    baseS := S;
     newlevs := [  ];
     idimage:= One( Range( hom ) );
 
@@ -1334,7 +1334,9 @@ InstallGlobalFunction( MakeStabChainLong,
     for S  in newlevs  do
         Unbind( S[ Length( S ) ] );
     od;
-    
+
+    SetStabChain( hom, baseS );
+
     # Construct the cokernel.
     if not IsEmpty( stb.genlabels )  then
         if not Tester( cokername )( cohom )  then
@@ -1347,7 +1349,6 @@ InstallGlobalFunction( MakeStabChainLong,
     else 
         Setter( cokername )( cohom, TrivialSubgroup( Range( hom ) ) );
     fi;
-    
 end );
 
 #############################################################################

--- a/lib/ghomperm.gi
+++ b/lib/ghomperm.gi
@@ -1271,7 +1271,7 @@ InstallGlobalFunction( StabChainPermGroupToPermGroupGeneralMappingByImages,
     
     if  NrMovedPoints(longgroup)<=10000 and
        (not HasInverseGeneralMapping( hom )
-       or not HasStabChainMutable( InverseGeneralMapping( hom ) )
+       or not HasStabChainImmutable( InverseGeneralMapping( hom ) )
        or not HasKernelOfMultiplicativeGeneralMapping( hom ) 
        )then
         MakeStabChainLong( InverseGeneralMapping( hom ),
@@ -1380,7 +1380,7 @@ InstallMethod( KernelOfMultiplicativeGeneralMapping,
           IsToPermGroupGeneralMappingByImages ], 0,
 function( hom )
 local ker;
-  if HasStabChainMutable( hom ) then TryNextMethod(); fi;
+  if HasStabChainImmutable( hom ) then TryNextMethod(); fi;
   StabChainPermGroupToPermGroupGeneralMappingByImages( hom );
   ker:=KernelOfMultiplicativeGeneralMapping( hom );
   if Size(ker)=1 then
@@ -1428,7 +1428,7 @@ end );
 InstallMethod( ImagesSet,"constituent homomorphism", CollFamSourceEqFamElms,
         # this method should *not* be applied if the group to be mapped has
         # no stabilizer chain (for example because it is very big).
-        [ IsConstituentHomomorphism, IsPermGroup and HasStabChainMutable], 0,
+        [ IsConstituentHomomorphism, IsPermGroup and HasStabChainImmutable], 0,
 function( hom, H )
 local   D,  I,G;
   
@@ -1457,7 +1457,7 @@ RanImgSrcSurjTraho:=function(hom)
 local   D,H,I,G;
   H:=Source(hom);
   # only worth if the source has a stab chain to utilize
-  if not HasStabChainMutable(H) then
+  if not HasStabChainImmutable(H) then
     TryNextMethod();
   fi;
   D := Enumerator( UnderlyingExternalSet( hom ) );
@@ -1492,7 +1492,7 @@ InstallMethod( PreImagesRepresentative,"constituent homomorphism",
   FamRangeEqFamElm,[IsConstituentHomomorphism,IsPerm], 0,
 function( hom, elm )
 local D,DP;
-  if not HasStabChainMutable(Source(hom)) then
+  if not HasStabChainImmutable(Source(hom)) then
     # do not enforce a stabchain if not neccessary -- it could be big
     TryNextMethod();
   fi;
@@ -1667,7 +1667,7 @@ end);
 RanImgSrcSurjBloho:=function(hom)
 local gens,imgs,ran,dom;
 # using stabchain info will produce just too many generators
-  if ValueOption("onlyimage")=fail and HasStabChainMutable(Source(hom)) 
+  if ValueOption("onlyimage")=fail and HasStabChainImmutable(Source(hom)) 
     and NrMovedPoints(Source(hom))<20000 then
     # transfer stabchain information if not too expensive
     ran:=ImageKernelBlocksHomomorphism(hom,Source(hom),false);

--- a/lib/ghomperm.gi
+++ b/lib/ghomperm.gi
@@ -1029,7 +1029,7 @@ InstallMethod( CompositionMapping2, "group hom. with perm group hom.",
     function( hom1, hom2 )
     local   prd,  stb,  levs,  S,t,i,oli;
 
-    stb := StructuralCopy( StabChainMutable( hom2 ) );
+    stb := CopyStabChain( StabChainImmutable( hom2 ) );
     levs := [  ];
     S := stb;
     while IsBound( S.stabilizer )  do
@@ -1694,7 +1694,7 @@ InstallMethod( PreImagesRepresentative, "blocks homomorphism",
             pos;        # position of point hit by preimage
     
     D := Enumerator( UnderlyingExternalSet( hom ) );
-    S := StabChainMutable( hom );
+    S := StabChainImmutable( hom );
     pre := One( Source( hom ) );
 
     # loop over the blocks and their iterated set stabilizers
@@ -1832,7 +1832,7 @@ local e1,e2,d1,d2,i,ac,act,hom,xset;
   MakeImmutable(d2);
   IsSSortedList(d2);
   xset:=ExternalSet(Source(map1),d2,act);
-  xset!.basePermImage:=BaseStabChain(StabChainMutable(ImagesSource(map2)));
+  xset!.basePermImage:=BaseStabChain(StabChainImmutable(ImagesSource(map2)));
   SetBaseOfGroup(xset,d2{xset!.basePermImage});
 
   if HasImagesSource(map1) and HasIsSurjective(map2) 
@@ -1998,8 +1998,8 @@ function( hom )
         for pnt  in dom  do
             sliced := [  ];
             while pnt <> bpt  do
-                Add( sliced, StabChainMutable( hom ).transimages[ pnt ] );
-                pnt := pnt ^ StabChainMutable( hom ).transversal[ pnt ];
+                Add( sliced, StabChainImmutable( hom ).transimages[ pnt ] );
+                pnt := pnt ^ StabChainImmutable( hom ).transversal[ pnt ];
             od;
             Add( idom, PreImageWord( fix, sliced ) );
         od;

--- a/lib/ghomperm.gi
+++ b/lib/ghomperm.gi
@@ -944,6 +944,9 @@ InstallOtherMethod( StabChainMutable, "perm mapping by images",  true,
 
     od;
     
+    if not HasStabChainImmutable(hom) then
+        SetStabChainImmutable(hom, Immutable(S));
+    fi;
     return S;
 end );
 
@@ -1358,7 +1361,14 @@ end );
 InstallMethod( StabChainMutable, "perm to perm mapping by images",true,
         [ IsPermGroupGeneralMappingByImages and
           IsToPermGroupGeneralMappingByImages ], 0,
-        StabChainPermGroupToPermGroupGeneralMappingByImages );
+        function(g)
+            local stab;
+            stab := StabChainPermGroupToPermGroupGeneralMappingByImages(g);
+            if not HasStabChainImmutable(g) then
+                SetStabChainImmutable(g, Immutable(stab));
+            fi;
+            return stab;
+        end);
 
 #############################################################################
 ##

--- a/lib/grpffmat.gi
+++ b/lib/grpffmat.gi
@@ -749,7 +749,7 @@ local G,PG,cl,c,i,r,s,sel,p,z,a,x,prop,fus,f,reps,repi,repo,zel,fcl,
   #act:=ActionHomomorphism(G,dom,OnLines,"surjective");
   PG:=Image(act); # this will be PSL etc.
 
-  StabChainMutable(PG);; # needed anyhow and will speed up images under act
+  StabChainImmutable(PG);; # needed anyhow and will speed up images under act
   z:=Size(Centre(G));
   zel:=Filtered(Elements(Centre(G)),x->Order(x)>1);
   cl:=ConjugacyClasses(G);
@@ -826,4 +826,3 @@ end);
 #############################################################################
 ##
 #E
-

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -48,7 +48,7 @@ InstallMethod( AsSubgroup,"perm groups",
     UseIsomorphismRelation( U, S );
     UseSubsetRelation( U, S );
     if HasStabChainMutable( U )  then
-        SetStabChainMutable( S, StabChainMutable( U ) );
+        SetStabChain( S, StabChainMutable( U ) );
     fi;
     return S;
 end );
@@ -745,7 +745,7 @@ BindGlobal("DoClosurePrmGp",function( G, gens, options )
     else
       if inpar  then  C := SubgroupNC(P,newgens);
 		else  C := Group( newgens,One(G) );           fi;
-      SetStabChainMutable(C,chain);
+      SetStabChain(C,chain);
     fi;
     SetStabChainOptions( C, rec( random := options.random ) );
 
@@ -819,7 +819,7 @@ BindGlobal("DoNormalClosurePermGroup",function ( G, U )
     N := SubgroupNC( G, GeneratorsOfGroup(U) );
     UseIsomorphismRelation(U,N);
     UseSubsetRelation(U,N);
-    SetStabChainMutable( N, StabChainMutable( U ) );
+    SetStabChain( N, StabChainMutable( U ) );
     options := ShallowCopy( StabChainOptions( U ) );
     if IsBound( options.random )  then  random := options.random;
                                   else  random := 1000;            fi;
@@ -897,7 +897,7 @@ BindGlobal("DoNormalClosurePermGroup",function ( G, U )
         fi;
         chain := SCRRestoredRecord( chain );
     fi;
-    SetStabChainMutable( N, chain );
+    SetStabChain( N, chain );
     if result <> chain.identity  then
         N := ClosureGroup( N, [ result ] );
     fi;
@@ -932,7 +932,7 @@ local   H,  S;
     if HasStabChainMutable(G) then
       S := EmptyStabChain( [  ], One( H ) );
       ConjugateStabChain( StabChainMutable( G ), S, g, g );
-      SetStabChainMutable( H, S );
+      SetStabChain( H, S );
     elif HasSize(G) then
       SetSize(H,Size(G));
     fi;
@@ -2174,4 +2174,3 @@ end);
 #############################################################################
 ##
 #E
-

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -47,7 +47,7 @@ InstallMethod( AsSubgroup,"perm groups",
     S:= SubgroupNC( G, GeneratorsOfGroup( U ) );
     UseIsomorphismRelation( U, S );
     UseSubsetRelation( U, S );
-    if HasStabChainMutable( U )  then
+    if HasStabChainImmutable( U )  then
         SetStabChain( S, StabChainMutable( U ) );
     fi;
     return S;
@@ -929,7 +929,7 @@ function( G, g )
 local   H,  S;
     
     H := GroupByGenerators( OnTuples( GeneratorsOfGroup( G ), g ), One( G ) );
-    if HasStabChainMutable(G) then
+    if HasStabChainImmutable(G) then
       S := EmptyStabChain( [  ], One( H ) );
       ConjugateStabChain( StabChainMutable( G ), S, g, g );
       SetStabChain( H, S );
@@ -1626,7 +1626,7 @@ InstallGlobalFunction( ApproximateSuborbitsStabilizerPermGroup,
           processStabGen, currPt,currGen, stgp, orblen, gens,Ggens;
 
     one:= One( G );
-  if HasStabChainMutable( G ) and punkt in StabChainMutable(G).orbit then
+  if HasStabChainImmutable( G ) and punkt in StabChainImmutable(G).orbit then
 # if we already have a stab chain and bother computing the proper
 # stabilizer, a trivial orbit algorithm seems best.
     return Concatenation([[punkt]],

--- a/lib/grpprmcs.gi
+++ b/lib/grpprmcs.gi
@@ -1649,7 +1649,7 @@ InstallMethod( RadicalGroup,
     # but not all subgroups in the comp.ser have their own stabchain.
     normals:=[];
     for i in [1..Length(list)-1] do
-      if HasStabChainMutable(list[i]) then
+      if HasStabChainImmutable(list[i]) then
         normals[i]:=ShallowCopy(StabChainMutable(list[i]).generators);
       else
         normals[i]:=ShallowCopy(GeneratorsOfGroup(list[i]));

--- a/lib/mapphomo.gi
+++ b/lib/mapphomo.gi
@@ -313,7 +313,7 @@ InstallMethod( ImagesSet,
     if     IsActionHomomorphism( map )
        and HasBaseOfGroup( UnderlyingExternalSet( map ) )
        and not HasBaseOfGroup( img )
-       and not HasStabChainMutable( img )  then
+       and not HasStabChainImmutable( img )  then
         if not IsBound( UnderlyingExternalSet( map )!.basePermImage )  then
             UnderlyingExternalSet( map )!.basePermImage :=
 	     List(BaseOfGroup(UnderlyingExternalSet(map)),

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -2968,7 +2968,7 @@ local   xset,he,gp,p,canfail,bas,fun;
   # can we compute the image cheaper using stabilizer chain methods?
   if not canfail and HasImagesSource(hom) then
     gp:=ImagesSource(hom);
-    if HasStabChainMutable(gp) or HasStabChainImmutable(gp) then
+    if HasStabChainImmutable(gp) then
       bas:=BaseStabChain(StabChain(gp));
       if Length(bas)*50<Length(he) then
 	p:=RepresentativeActionOp(gp,bas,
@@ -3074,7 +3074,7 @@ InstallMethod( ImagesSource,"actionHomomorphismByBase", true,
     
     xset := UnderlyingExternalSet( hom );
     img := ImagesSet( hom, Source( hom ) );
-    if not HasStabChainMutable( img )  and  not HasBaseOfGroup( img )  then
+    if not HasStabChainImmutable( img )  and  not HasBaseOfGroup( img )  then
         if not IsBound( xset!.basePermImage )  then
             D := HomeEnumerator( xset );
             xset!.basePermImage := List( BaseOfGroup( xset ),

--- a/lib/oprtglat.gi
+++ b/lib/oprtglat.gi
@@ -177,7 +177,7 @@ function(G,dom,all)
     n:=n-1;
     gp:=dom[p];
     t:=Length(GeneratorsOfGroup(gp));
-    if HasSize(gp) and not HasStabChainMutable(gp) and t>4 then
+    if HasSize(gp) and not HasStabChainImmutable(gp) and t>4 then
       sel:=GeneratorsOfGroup(gp);
       t:=Group(sel{Set(List([1,2],i->Random([1..t])))},One(gp));
       while Size(t)<Size(gp) do

--- a/lib/oprtperm.gi
+++ b/lib/oprtperm.gi
@@ -23,7 +23,7 @@ InstallOtherMethod( OrbitOp,
     if gens <> acts  or  act <> OnPoints  then
         TryNextMethod();
     fi;
-    if HasStabChainMutable( G )
+    if HasStabChainImmutable( G )
        and IsInBasicOrbit( StabChainMutable( G ), pnt ) then
         return Immutable(StabChainMutable( G ).orbit);
     else
@@ -1501,7 +1501,7 @@ PermGroupStabilizerOp:=function(arg)
 
     # enforce size computation (unless the stabilizer did not cause a
     # StabChain to be computed.
-    if HasStabChainMutable(K) then
+    if HasStabChainImmutable(K) then
       Size(K);
     fi;
 

--- a/lib/pcgsperm.gi
+++ b/lib/pcgsperm.gi
@@ -317,7 +317,7 @@ InstallGlobalFunction(TryPcgsPermGroup,function(arg)
     # Otherwise start  with stabilizer chain  of  <U> with identical `labels'
     # components on all levels.
     if IsGroup( U )  then                               
-        if IsTrivial( U )  and  not HasStabChainMutable( U )  then
+        if IsTrivial( U )  and  not HasStabChainImmutable( U )  then
             U := EmptyStabChain( [  ], One( U ) );
         else
 	    S:=U;

--- a/lib/stbc.gd
+++ b/lib/stbc.gd
@@ -174,6 +174,21 @@ DeclareOperation( "StabChainOp", [ IsGroup, IsRecord ] );
 DeclareAttribute( "StabChainMutable", IsObject, "mutable" );
 DeclareAttribute( "StabChainImmutable", IsObject );
 
+#############################################################################
+##
+##  <#GAPDoc Label="SetStabChain">
+##  <ManSection>
+##  <Func Name="SetStabChain" Arg='G, stabchain'
+##   Label="for a group and a stabilizer chain"/>
+##
+##  <Description>
+##  This function sets the <Ref Attr="StabChainImmutable"/> of <A>G</A> to
+##  <A>stabchain</A>. Further, if <A>stabchain</A> is mutable, it sets
+##  <Ref Attr="StabChainMutable"/> of <A>G</A>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+DeclareGlobalFunction( "SetStabChain" );
 
 #############################################################################
 ##

--- a/lib/stbc.gi
+++ b/lib/stbc.gi
@@ -34,7 +34,14 @@ InstallMethod( StabChainImmutable,"use StabChainMutable",
   true, [ IsObject ], 0, StabChainMutable );
 
 InstallMethod( StabChainMutable,"call StabChainOp", true, [ IsGroup ], 0,
-    G -> StabChainOp( G, rec(  ) ) );
+    function( G )
+        local stab;
+        stab := StabChainOp( G, rec(  ) );
+        if not HasStabChainImmutable(G) then
+            SetStabChainImmutable(G, stab);
+        fi;
+        return stab;
+    end);
 
 InstallOtherMethod( StabChainOp,"with base", true, [ IsPermGroup,
         IsList and IsCyclotomicCollection ], 0,

--- a/lib/stbc.gi
+++ b/lib/stbc.gi
@@ -21,6 +21,15 @@ InstallGlobalFunction( StabChain, function( arg )
     fi;
 end );
 
+InstallGlobalFunction( SetStabChain, function(G, chain)
+     if IsMutable(chain) then
+         SetStabChainMutable(G, chain);
+     fi;
+     if not HasStabChainImmutable(G) then
+         SetStabChainImmutable(G, Immutable(chain));
+     fi;
+ end );
+
 InstallMethod( StabChainImmutable,"use StabChainMutable",
   true, [ IsObject ], 0, StabChainMutable );
 
@@ -178,7 +187,7 @@ InstallMethod( StabChainOp,"group and option",
         StabChainOptions( G ).random := options.random;
     fi;
     
-    SetStabChainMutable( G, S );
+    SetStabChain( G, S );
     return S;
 end );
 
@@ -443,7 +452,7 @@ local   S,  G,  P,L;
             G := Subgroup( P, L );
         fi;
     fi;
-    SetStabChainMutable( G, S );
+    SetStabChain( G, S );
 
     return G;
 end);

--- a/lib/stbc.gi
+++ b/lib/stbc.gi
@@ -81,7 +81,7 @@ InstallMethod( StabChainOp,"group and option",
     local   S,  T,  degree,  pcgs;
     
     # If a stabilizer chain <S> is already known, modify it.
-    if HasStabChainMutable( G )  then
+    if HasStabChainImmutable( G )  then
         S := StructuralCopy( StabChainMutable( G ) );
         if IsBound( options.base )  then
             if not IsBound( options.reduced )  then
@@ -344,7 +344,7 @@ InstallGlobalFunction(CopyOptionsDefaults,function( G, options )
 
     # See whether we know a base for <G>.
     if not IsBound( options.knownBase )  then
-	if HasStabChainMutable(G) then
+	if HasStabChainImmutable(G) then
 	  options.knownBase := BaseStabChain(StabChainMutable(G));
         elif   HasBaseOfGroup( G )  then
 	  options.knownBase := BaseOfGroup( G );
@@ -354,7 +354,7 @@ InstallGlobalFunction(CopyOptionsDefaults,function( G, options )
 		and not IsIdenticalObj( P, Parent( P ) )  do
 	    P := Parent( P );
 	  od;
-	  if HasStabChainMutable(P) then
+	  if HasStabChainImmutable(P) then
 	    options.knownBase := BaseStabChain(StabChainMutable(P));
 	  elif HasBaseOfGroup( P )  then
 	    options.knownBase := BaseOfGroup( P );


### PR DESCRIPTION
This continues to remove references to StabChainMutable.

The big change here is making sure wherever we create a StabChainMutable, we also create a StabChainImmutable. This allows us to switch all uses of HasStabChainMutable to HasStabChainImmutable.

There is a helper function SetStabChain, which always sets StabChainImmutable, and sets StabChainMutable if the given chain is mutable.

In some places calls to SetStabChainMutable are moved. That is because we now never set the StabChain until we have finished building it.