### PR TITLE
Remove uses of SuPeRfail in the library

### DIFF
--- a/lib/demo.g
+++ b/lib/demo.g
@@ -41,13 +41,13 @@ BindGlobal( "Demonstration", function( file )
     Print( "demo> \c" );
     while CHAR_INT( ReadByte( keyboard ) ) <> 'q' do
         storedtime := Runtime();
-        result:=READ_COMMAND( input, true ); # Executing the command.
+        result:=READ_COMMAND_REAL( input, true ); # Executing the command.
         time := Runtime()-storedtime;
-        if result <> SuPeRfail then
+        if Length(result) = 2 then
             last3 := last2;
             last2 := last;
-            last := result;
-            View( result);
+            last := result[2];
+            View( result[2] );
             Print("\n" );
         fi;
 
@@ -86,16 +86,16 @@ local   input,command,exec,result,blank,semic,hash,process,l,view,estream;
         fi;
         estream:=InputTextString( exec );
         storedtime := Runtime();
-        result:=READ_COMMAND( estream, true ); # Executing the command.
+        result:=READ_COMMAND_REAL( estream, true ); # Executing the command.
         time := Runtime()-storedtime;
         CloseStream(estream);
-        if result<>SuPeRfail then
+        if Length(result) = 2 then
             last3 := last2;
             last2 := last;
-            last := result;
+            last := result[2];
             if view then
-               View(result);
-                Print("\n");
+               View(result[2]);
+               Print("\n");
             fi;
         fi;
         exec:="";

--- a/src/bool.c
+++ b/src/bool.c
@@ -70,13 +70,13 @@ Obj Fail;
 
 /****************************************************************************
 **
-*V  SFail  . . . . . . . . . . . . . . . . . . . . . . . . . . superfail value
+*V  SuPeRfail  . . . . . . . . . . . . . . . . . . . . . . .  superfail value
 **
-**  'SFail' is an ``superfail'' object which is used to indicate failure if
+**  'SuPeRfail' is an ``superfail'' object which is used to indicate failure if
 **  `fail' itself is a sensible response. This is used when having GAP read
 **  a file line-by-line via a library function (demo.g)
 */
-Obj SFail;
+Obj SuPeRfail;
 
 
 /****************************************************************************
@@ -115,7 +115,7 @@ void PrintBool (
     else if ( bool == Fail ) {
         Pr( "fail", 0L, 0L );
     }
-    else if ( bool == SFail ) {
+    else if ( bool == SuPeRfail ) {
         Pr( "SuPeRfail", 0L, 0L );
     }
     else {
@@ -402,7 +402,7 @@ static Int InitKernel (
     InitGlobalBag( &True,  "src/bool.c:TRUE"  );
     InitGlobalBag( &False, "src/bool.c:FALSE" );
     InitGlobalBag( &Fail,  "src/bool.c:FAIL"  );
-    InitGlobalBag( &SFail,  "src/bool.c:SFAIL"  );
+    InitGlobalBag( &SuPeRfail,  "src/bool.c:SUPERFAIL"  );
 
     /* install the saving functions                                       */
     SaveObjFuncs[ T_BOOL ] = SaveBool;
@@ -446,9 +446,9 @@ static Int InitLibrary (
     MakeReadOnlyGVar(gvar);
 
     /* `SuPeRfail' ditto                       */
-    SFail  = NewBag( T_BOOL, 0L );
+    SuPeRfail  = NewBag( T_BOOL, 0L );
     gvar = GVarName( "SuPeRfail" );
-    AssGVar( gvar, SFail );
+    AssGVar( gvar, SuPeRfail );
     MakeReadOnlyGVar(gvar);
 
     /* make and install the 'RETURN_TRUE' function                         */

--- a/src/bool.h
+++ b/src/bool.h
@@ -43,13 +43,13 @@ extern Obj Fail;
 
 /****************************************************************************
 **
-*V  SFail  . . . . . . . . . . . . . . . . . . . . . . . . . . superfail value
+*V  SuPeRfail  . . . . . . . . . . . . . . . . . . . . . . .  superfail value
 **
-**  'SFail' is an ``superfail'' object which is used to indicate failure if
+**  'SuPeRfail' is an ``superfail'' object which is used to indicate failure if
 **  `fail' itself is a sensible response. This is used when having GAP read
 **  a file line-by-line via a library function (demo.g)
 */
-extern Obj SFail;
+extern Obj SuPeRfail;
 
 
 /****************************************************************************

--- a/src/streams.c
+++ b/src/streams.c
@@ -104,7 +104,7 @@ Obj FuncREAD_COMMAND ( Obj self, Obj stream, Obj echo )
 
     /* try to open the file                                                */
     if ( ! OpenInputStream(stream) ) {
-        return SFail;
+        return SuPeRfail;
     }
 
     if (echo == True)
@@ -116,18 +116,18 @@ Obj FuncREAD_COMMAND ( Obj self, Obj stream, Obj echo )
     
     CloseInput();
 
-    if( status == 0 ) return SFail;
+    if( status == 0 ) return SuPeRfail;
 
     if (TLS(UserHasQUIT)) {
       TLS(UserHasQUIT) = 0;
-      return SFail;
+      return SuPeRfail;
     }
 
     if (TLS(UserHasQuit)) {
       TLS(UserHasQuit) = 0;
     }
     
-    return TLS(ReadEvalResult) ? TLS(ReadEvalResult) : SFail;
+    return TLS(ReadEvalResult) ? TLS(ReadEvalResult) : SuPeRfail;
     
 }
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -98,13 +98,25 @@ Int READ_COMMAND ( void )
     return 1;
 }
 
-Obj FuncREAD_COMMAND ( Obj self, Obj stream, Obj echo )
+/*
+ Returns a list with one or two entries. The first
+ entry is set to "false" if there was any error
+ executing the command, and "true" otherwise.
+ The second entry, if present, is the return value of
+ the command. If it not present, the command returned nothing.
+*/
+Obj FuncREAD_COMMAND_REAL ( Obj self, Obj stream, Obj echo )
 {
     Int status;
+    Obj result;
+
+    result = NEW_PLIST( T_PLIST, 2 );
+    SET_LEN_PLIST(result, 1);
+    SET_ELM_PLIST(result, 1, False);
 
     /* try to open the file                                                */
     if ( ! OpenInputStream(stream) ) {
-        return SuPeRfail;
+        return result;
     }
 
     if (echo == True)
@@ -116,19 +128,34 @@ Obj FuncREAD_COMMAND ( Obj self, Obj stream, Obj echo )
     
     CloseInput();
 
-    if( status == 0 ) return SuPeRfail;
+    if( status == 0 ) return result;
 
     if (TLS(UserHasQUIT)) {
       TLS(UserHasQUIT) = 0;
-      return SuPeRfail;
+      return result;
     }
 
     if (TLS(UserHasQuit)) {
       TLS(UserHasQuit) = 0;
     }
     
-    return TLS(ReadEvalResult) ? TLS(ReadEvalResult) : SuPeRfail;
-    
+    SET_ELM_PLIST(result, 1, True);
+    if (TLS(ReadEvalResult)) {
+        SET_LEN_PLIST(result, 2);
+        SET_ELM_PLIST(result, 2, TLS(ReadEvalResult));
+    }
+    return result;
+}
+
+/*
+ Deprecated alternative to READ_COMMAND_REAL, kept for now to maintain
+ compatibility with the few packages that use it.
+ */
+Obj FuncREAD_COMMAND ( Obj self, Obj stream, Obj echo )
+{
+    Obj result;
+    result = FuncREAD_COMMAND_REAL(self, stream, echo);
+    return (LEN_PLIST(result) == 2) ? ELM_PLIST(result, 2) : SuPeRfail;
 }
 
 /****************************************************************************
@@ -2233,6 +2260,9 @@ static StructGVarFunc GVarFuncs [] = {
 
     { "READ_NORECOVERY", 1L, "filename",
       FuncREAD_NORECOVERY, "src/streams.c:READ_NORECOVERY" },
+
+    { "READ_COMMAND_REAL", 2L, "stream, echo",
+      FuncREAD_COMMAND_REAL, "src/streams.c:READ_COMMAND_REAL" },
 
     { "READ_COMMAND", 2L, "stream, echo", 
       FuncREAD_COMMAND, "src/streams.c:READ_COMMAND" },


### PR DESCRIPTION
This PR removes usage of `SuPeRfail` in the library, specifically in `lib/demo.g`. This is achieved by adding `READ_COMMAND_REAL` to the kernel, an alternative to `READ_COMMAND` (in fact, `READ_COMMAND` is now just a thin wrapper around `READ_COMMAND_REAL`).

I am not great on naming things, so if you have a better idea than `READ_COMMAND_REAL`, please let me know

My hope is that we can eventually get rid of `SuPeRfail` completely with this.

For now, I am aware of these packages using `SuPeRfail` in some way:
* io -- knows how to (un)pickle it it -- we can probably just remove that code, can't we? or are there legitimate reasons to serialize `SuPeRfail`?
* scscp -- has a modified copy of the demo code, could be easily adapted to use `READ_COMMAND_REAL`
* rcwa -- has a modified copy of the demo code, could be easily adapted to use `READ_COMMAND_REAL`
* openmath -- just occurs in a test, but that is so because openmath uses `READ_COMMAND`; my guess is that it should be changed to use `READ_COMMAND_REAL`
* sgpviz -- could be easily adapted to use `READ_COMMAND_REAL`
* ToolsForHomalg, CAP: code could be refactored, e.g. in a similar way to how `READ_COMMAND_REAL` does it (see also homalg-project/homalg_project#151)
* fr -- does not use `SuPeRfail`, but does use `READ_COMMAND`. I don't really understand what it uses it for, though, but I hope it could also us `READ_COMMAND_REAL`.

If we could this into GAP soon (perhaps even backport it to GAP 4.8?), then packages could start removing uses of `SuPeRfail`. And once that is compete, we can get rid of `SuPeRfail` (e.g. in GAP 4.9)