### PR TITLE
Extra hint in "No Method Found" if one of the arguments is 'fail'

### DIFF
--- a/lib/methsel2.g
+++ b/lib/methsel2.g
@@ -44,7 +44,7 @@ ApplicableMethod := fail;
 ##
 HANDLE_METHOD_NOT_FOUND := function ( INF )
   local no_method_found, ShowArguments, ShowArgument, ShowDetails, ShowMethods, 
-             ShowOtherMethods;
+             ShowOtherMethods, i;
 
 
 #############################################################################
@@ -226,6 +226,12 @@ end;
 PRINT_TO( "*errout*",
         "Error, no method found! For debugging hints type ?Recovery from NoMethodFound\n" ); # should go to errout
   no_method_found:="no ";
+  for i in [ 1 .. LENGTH(INF.Arguments) ] do
+    if INF.Arguments[i] = fail then
+      PRINT_TO( "*errout*",
+                "The ", Ordinal(i), " argument is 'fail' which might point to an earlier problem\n" ); # should go to errout
+    fi;
+  od;
   APPEND_LIST(no_method_found,Ordinal(INF.Precedence+1));
   APPEND_LIST(no_method_found," choice method found for `");
   APPEND_LIST(no_method_found,NAME_FUNC(INF.Operation));


### PR DESCRIPTION
This PR is an alternative to PR #355 by @ChrisJefferson. 

It originates from issue #354 initiated by @cdwensley, and adds an extra hint in the "No Method Found" message in the case where one of the arguments is `fail`, as suggested by @stevelinton.

For example:
```
gap> Read(Filename(DirectoriesLibrary("tst"),"testall.g"));
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
The 1st argument is 'fail' which might point to an earlier problem
Error, no 1st choice method found for `Read' on 1 arguments called from
...
```
