### PR TITLE
Made res.directories a list for nicer error for broken manuals

### DIFF
--- a/lib/helpdef.gi
+++ b/lib/helpdef.gi
@@ -272,7 +272,7 @@ HELP_BOOK_HANDLER.default.ReadSix := function(stream)
       Add(res.formats, "pdf");
     fi;
   fi;
-  res.directories := Directory(fname{[1..Length(fname)-10]});  
+  res.directories := [ Directory(fname{[1..Length(fname)-10]}) ];
   return res;
 end;
 


### PR DESCRIPTION
This addresses @frankluebeck's suggestion in #443 and should help to figure out problems in `helpsys.tst` happening when manuals are broken.