### PR TITLE
Change syntax errors/warnings to use FILE:LINE format

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -329,8 +329,12 @@ InstallGlobalFunction("Test", function(arg)
              if d[1] <> '-' then
                d := Concatenation("+", d);
              fi;
-             Print("########> Time diff in ",
-                   fnam,", line ",line,":\n");
+             Print("########> Time diff in ");
+             if IsStream(fnam) then
+               Print("test stream, line ",line,"\n");
+             else
+               Print(fnam,":",line,"\n");
+             fi;
              Print("# Input:\n", inp);
              Print("# Old time: ", oldt,"   New time: ", newt,
              "    (", d, "%)\n");
@@ -338,11 +342,12 @@ InstallGlobalFunction("Test", function(arg)
            rewriteToFile := false,
            breakOnError := false,
            reportDiff := function(inp, expout, found, fnam, line, time)
+             Print("########> Diff in ");
              if IsStream(fnam) then
-               fnam := "test stream";
+               Print("test stream, line ",line,"\n");
+             else
+               Print(fnam,":",line,"\n");
              fi;
-             Print("########> Diff in ",
-                   fnam,", line ",line,":\n");
              Print("# Input is:\n", inp);
              Print("# Expected output:\n", expout);
              Print("# But found:\n", found);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -147,7 +147,7 @@ void            SyntaxError (
         /* print the message and the filename, unless it is '*stdin*'          */
         Pr( "Syntax error: %s", (Int)msg, 0L );
         if ( strcmp( "*stdin*", TLS(Input)->name ) != 0 )
-          Pr( " in %s line %d", (Int)TLS(Input)->name, (Int)TLS(Input)->number );
+          Pr( " in %s:%d", (Int)TLS(Input)->name, (Int)TLS(Input)->number );
         Pr( "\n", 0L, 0L );
 
         /* print the current line                                              */
@@ -188,7 +188,7 @@ void            SyntaxWarning (
         /* print the message and the filename, unless it is '*stdin*'          */
         Pr( "Syntax warning: %s", (Int)msg, 0L );
         if ( strcmp( "*stdin*", TLS(Input)->name ) != 0 )
-          Pr( " in %s line %d", (Int)TLS(Input)->name, (Int)TLS(Input)->number );
+          Pr( " in %s:%d", (Int)TLS(Input)->name, (Int)TLS(Input)->number );
         Pr( "\n", 0L, 0L );
 
         /* print the current line                                              */


### PR DESCRIPTION
This changes syntax errors and warnings to print slightly differently. Before:
```
gap> Read("test.g");
Syntax error: expression expected in test.g line 1
*1;
^
```

After:
```
gap> Read("test.g");
Syntax error: expression expected in test.g:1
*1;
^
gap>
```

The primary reason I'd like to see that is selfish: Such strings are recognized by my terminal, and I can Cmd-click them to open an editor for that file, at the correct line.

This format also matches the output of gcc and clang when it comes to errors:
```
~/Projekte/GAP/gap.github (git:mh/syntax-error-lines)$ clang test.c
test.c:1:2: error: expected identifier or '('
*1;
 ^
1 error generated.
~/Projekte/GAP/gap.github (git:mh/syntax-error-lines)$ gcc-5 test.c
test.c:1:2: error: expected identifier or ‘(’ before numeric constant
 *1;
  ^
```
I realize that might be a somewhat bizarre reason, but I thought I could at least try to convince you this is useful ;-).

Of course, there is a the potential drawback that end users may not understand the new output.