### PR TITLE
GHBI: verify that image of a map is contained in its range (version AH)

### DIFF
--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -2337,8 +2337,8 @@ local r,	#radical
       else
 	new:=LiftClassesEANonsolvGeneral(G,mpcgs,i,hom,pcisom,solvtriv,fran);
       fi;
-      Assert(3,ForAll(new,x->x[6]
-        =Size(Group(Concatenation(x[2],DenominatorOfModuloPcgs(mpcgs))))));
+      #Assert(3,ForAll(new,x->x[6]
+      #  =Size(Group(Concatenation(x[2],DenominatorOfModuloPcgs(mpcgs))))));
 
 #if ForAny(new,x->x[2]<>TFMakeInducedPcgsModulo(pcgs,x[2],nran)) then Error("HUH6");fi;
 #Print(List(new,x->List(x[2],y->DepthOfPcElement(pcgs,y))),"\n");

--- a/lib/ghom.gd
+++ b/lib/ghom.gd
@@ -53,17 +53,15 @@
 ##  <#/GAPDoc>
 ##
 
-# for future use:
-#DeclareOperation( "GroupGeneralMappingByImages",
-#    [ IsGroup, IsGroup, IsList, IsList ] );
-#DeclareOperation( "GroupGeneralMappingByImages",
-#    [ IsGroup, IsList, IsList ] );
+DeclareOperation( "GroupGeneralMappingByImages",
+    [ IsGroup, IsGroup, IsList, IsList ] );
+DeclareOperation( "GroupGeneralMappingByImages",
+    [ IsGroup, IsList, IsList ] );
 
 DeclareOperation( "GroupGeneralMappingByImagesNC",
     [ IsGroup, IsGroup, IsList, IsList ] );
 DeclareOperation( "GroupGeneralMappingByImagesNC",
     [ IsGroup, IsList, IsList ] );
-DeclareSynonym("GroupGeneralMappingByImages",GroupGeneralMappingByImagesNC);
 
 
 #############################################################################

--- a/lib/ghom.gi
+++ b/lib/ghom.gi
@@ -306,8 +306,12 @@ local   filter,  hom,pcgs,imgso,mapi,l,obj_args,p;
     Error("<gens> and <imgs> must be lists of same length");
   fi;
 
-  Assert( 2, ForAll( gens, x -> x in G ) );
-  Assert( 2, ForAll( imgs, x -> x in H ) );
+  if not HasIsHandledByNiceMonomorphism(G) and ValueOption("noassert")<>true then
+    Assert( 2, ForAll( gens, x -> x in G ) );
+  fi;
+  if not HasIsHandledByNiceMonomorphism(H) and ValueOption("noassert")<>true then
+    Assert( 2, ForAll( imgs, x -> x in H ) );
+  fi;
 
   mapi:=[Immutable(gens),Immutable(imgs)];
   filter := IsGroupGeneralMappingByImages and HasSource and HasRange 
@@ -437,7 +441,11 @@ InstallMethod( GroupHomomorphismByImagesNC, "for group, group, list, list",
 function( G, H, gens, imgs )
 local   hom;
   hom := GroupGeneralMappingByImagesNC( G, H, gens, imgs );
-  Assert( 2, IsMapping( hom ) );
+  if not (HasIsHandledByNiceMonomorphism(G) or
+    HasIsHandledByNiceMonomorphism(H)) 
+    and ValueOption("noassert")<>true then
+    Assert( 2, IsMapping( hom ) );
+  fi;
   SetIsMapping( hom, true );
   return hom;
 end );
@@ -447,7 +455,9 @@ InstallMethod( GroupHomomorphismByImagesNC, "for group, list, list",
 function( G, gens, imgs )
 local   hom;
   hom := GroupGeneralMappingByImagesNC( G, gens, imgs );
-  Assert( 2, IsMapping( hom ) );
+  if not HasIsHandledByNiceMonomorphism(G) and ValueOption("noassert")<>true then
+    Assert( 2, IsMapping( hom ) );
+  fi;
   SetIsMapping( hom, true );
   return hom;
 end );
@@ -678,7 +688,7 @@ function( hom )
 local mapi;
   mapi:=MappingGeneratorsImages(hom);
   mapi:=GroupHomomorphismByImagesNC( Range( hom ),   Source( hom ),
-                                      mapi[2], mapi[1] );
+                                      mapi[2], mapi[1]);
   SetIsBijective( mapi, true );
   return mapi;
 end );

--- a/lib/ghom.gi
+++ b/lib/ghom.gi
@@ -456,25 +456,15 @@ InstallOtherMethod( GroupHomomorphismByImagesNC, "for group, group, list",
                     true, [ IsGroup, IsGroup, IsList ], 0,
 
   function( G, H, imgs )
-
-    local  hom;
-
-    hom := GroupGeneralMappingByImagesNC( G, H, GeneratorsOfGroup(G), imgs );
-    SetIsMapping( hom, true );
-    return hom;
+    return GroupHomomorphismByImagesNC( G, H, GeneratorsOfGroup(G), imgs );
   end );
 
 InstallOtherMethod( GroupHomomorphismByImagesNC, "for group, group",
                     true, [ IsGroup, IsGroup ], 0,
 
   function( G, H )
-
-    local  hom;
-
-    hom := GroupGeneralMappingByImagesNC( G, H, GeneratorsOfGroup(G),
+    return GroupHomomorphismByImagesNC( G, H, GeneratorsOfGroup(G),
                                               GeneratorsOfGroup(H) );
-    SetIsMapping( hom, true );
-    return hom;
   end );
 
 #############################################################################

--- a/lib/ghom.gi
+++ b/lib/ghom.gi
@@ -409,27 +409,25 @@ function( G, gens, imgs )
     return GroupGeneralMappingByImagesNC(G,GroupWithGenerators(imgs),gens,imgs);
 end);
 
-# temporarily disabled until we separate GroupGeneralMappingByImages from
-# its NC version.
-#InstallMethod( GroupGeneralMappingByImages, "for group, group, list, list",
-#    true, [ IsGroup, IsGroup, IsList, IsList ], 0,
-#function( G, H, gens, imgs )
-#    if not ForAll(gens,x->x in G) then
-#      Error("generators must lie in source group");
-#    elif not ForAll(imgs,x->x in H) then
-#      Error("images must lie in range group");
-#    fi;
-#    return GroupGeneralMappingByImagesNC(G,H,gens,imgs);
-#end);
-#
-#InstallMethod( GroupGeneralMappingByImages, "make onto",
-#    true, [ IsGroup, IsList, IsList ], 0, 
-#function( G, gens, imgs )
-#    if not ForAll(gens,x->x in G) then
-#      Error("generators must lie in source group");
-#    fi;
-#    return GroupGeneralMappingByImagesNC(G,gens,imgs);
-#end);
+InstallMethod( GroupGeneralMappingByImages, "for group, group, list, list",
+    true, [ IsGroup, IsGroup, IsList, IsList ], 0,
+function( G, H, gens, imgs )
+    if not ForAll(gens,x->x in G) then
+      Error("generators must lie in source group");
+    elif not ForAll(imgs,x->x in H) then
+      Error("images must lie in range group");
+    fi;
+    return GroupGeneralMappingByImagesNC(G,H,gens,imgs);
+end);
+
+InstallMethod( GroupGeneralMappingByImages, "make onto",
+    true, [ IsGroup, IsList, IsList ], 0,
+function( G, gens, imgs )
+    if not ForAll(gens,x->x in G) then
+      Error("generators must lie in source group");
+    fi;
+    return GroupGeneralMappingByImagesNC(G,gens,imgs);
+end);
 
 InstallMethod( GroupHomomorphismByImagesNC, "for group, group, list, list",
     true, [ IsGroup, IsGroup, IsList, IsList ], 0,

--- a/lib/ghom.gi
+++ b/lib/ghom.gi
@@ -443,7 +443,8 @@ local   hom;
   hom := GroupGeneralMappingByImagesNC( G, H, gens, imgs );
   if not (HasIsHandledByNiceMonomorphism(G) or
     HasIsHandledByNiceMonomorphism(H)) 
-    and ValueOption("noassert")<>true then
+    and ValueOption("noassert")<>true 
+    and not IsSubgroupFpGroup(H) then
     Assert( 2, IsMapping( hom ) );
   fi;
   SetIsMapping( hom, true );

--- a/lib/ghom.gi
+++ b/lib/ghom.gi
@@ -306,6 +306,9 @@ local   filter,  hom,pcgs,imgso,mapi,l,obj_args,p;
     Error("<gens> and <imgs> must be lists of same length");
   fi;
 
+  Assert( 2, ForAll( gens, x -> x in G ) );
+  Assert( 2, ForAll( imgs, x -> x in H ) );
+
   mapi:=[Immutable(gens),Immutable(imgs)];
   filter := IsGroupGeneralMappingByImages and HasSource and HasRange 
             and HasMappingGeneratorsImages;
@@ -434,6 +437,7 @@ InstallMethod( GroupHomomorphismByImagesNC, "for group, group, list, list",
 function( G, H, gens, imgs )
 local   hom;
   hom := GroupGeneralMappingByImagesNC( G, H, gens, imgs );
+  Assert( 2, IsMapping( hom ) );
   SetIsMapping( hom, true );
   return hom;
 end );
@@ -443,6 +447,7 @@ InstallMethod( GroupHomomorphismByImagesNC, "for group, list, list",
 function( G, gens, imgs )
 local   hom;
   hom := GroupGeneralMappingByImagesNC( G, gens, imgs );
+  Assert( 2, IsMapping( hom ) );
   SetIsMapping( hom, true );
   return hom;
 end );

--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -854,7 +854,7 @@ local aug,w,p,pres,f,fam;
   aug.primaryImages:=GeneratorsOfGroup(f);
   SecondaryImagesAugmentedCosetTable(aug);
 
-  f:=GroupHomomorphismByImagesNC(u,f,gens,GeneratorsOfGroup(f));
+  f:=GroupHomomorphismByImagesNC(u,f,gens,GeneratorsOfGroup(f):noassert);
 
   # tell f, that `aug' can be used as its coset table
   SetCosetTableFpHom(f,aug);

--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -802,7 +802,9 @@ local aug,w,p,pres,f,fam,opt;
 
   # write the homomorphism in terms of the image's free generators
   # (so preimages are cheap)
-  f:=GroupHomomorphismByImagesNC(u,f,w,GeneratorsOfGroup(f));
+  # this object cannot test whether is is a proper mapping, so skip
+  # safety assertions that could be triggered by the construction process
+  f:=GroupHomomorphismByImagesNC(u,f,w,GeneratorsOfGroup(f):noassert);
   # but give it `aug' as coset table, so we will use rewriting for images
   SetCosetTableFpHom(f,aug);
 

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -234,11 +234,12 @@ function(g,str,N)
   local ser, ab, homs, gens, idx, start, pcgs, hom, f, fgens, auts, sf, orb, tra, j, a, ad, lad, n, fg, free, rels, fp, vals, dec, still, lgens, ngens, nrels, nvals, p, dodecomp, decomp, hogens, di, i, k, l, m;
   if Size(g)=1 then
     # often occurs in induction base base
-    return GroupHomomorphismByFunction(g,TRIVIAL_FP_GROUP,x->One(TRIVIAL_FP_GROUP),x->One(g));
+    return
+    GroupHomomorphismByFunction(g,TRIVIAL_FP_GROUP,x->One(TRIVIAL_FP_GROUP),x->One(g):noassert);
   elif g=N then
     # often occurs in induction base base
     return GroupHomomorphismByImagesNC(g,TRIVIAL_FP_GROUP,GeneratorsOfGroup(g),
-             List(GeneratorsOfGroup(g),x->One(TRIVIAL_FP_GROUP)));
+             List(GeneratorsOfGroup(g),x->One(TRIVIAL_FP_GROUP)):noassert);
   elif IsTrivial(N) then
     ser:=ChiefSeries(g);
   else
@@ -262,7 +263,7 @@ function(g,str,N)
       Append(gens,pcgs);
     else
       ab[i-1]:=false;
-      hom:=NaturalHomomorphismByNormalSubgroup(ser[i-1],ser[i]);
+      hom:=NaturalHomomorphismByNormalSubgroup(ser[i-1],ser[i]:noassert);
       IsOne(hom);
       f:=Image(hom);
       # knowing simplicity makes it easy to test whether a map is faithful
@@ -281,7 +282,7 @@ function(g,str,N)
       fgens:=GeneratorsOfGroup(f);
       auts:=List(GeneratorsOfGroup(g),i->
 	     GroupHomomorphismByImagesNC(f,f,fgens,
-	       List(fgens,j->Image(hom,PreImagesRepresentative(hom,j)^i))));
+	       List(fgens,j->Image(hom,PreImagesRepresentative(hom,j)^i)):noassert));
       for j in auts do
 	SetIsBijective(j,true);
       od;
@@ -305,7 +306,7 @@ function(g,str,N)
       # we know sf is simple
       SetIsSimpleGroup(sf,true);
       IsNaturalAlternatingGroup(sf);
-      a:=IsomorphismFpGroup(sf);
+      a:=IsomorphismFpGroup(sf:noassert);
       ad:=List(GeneratorsOfGroup(Range(a)),i->PreImagesRepresentative(a,i));
       lad:=Length(ad);
 
@@ -332,7 +333,7 @@ function(g,str,N)
       od;
 
       fp:=fg/rels;
-      a:=GroupHomomorphismByImagesNC(f,fp,fgens,GeneratorsOfGroup(fp));
+      a:=GroupHomomorphismByImagesNC(f,fp,fgens,GeneratorsOfGroup(fp):noassert);
       Append(gens,List(fgens,i->PreImagesRepresentative(hom,i)));
 
       # here we really want a composed homomorphism, to avoid extra work for 
@@ -426,13 +427,13 @@ function(g,str,N)
   fp:=f/rels;
   di:=rec(gens:=gens,fp:=fp,idx:=idx,dec:=dec,source:=g);
   if IsTrivial(N) then
-    hom:=GroupHomomorphismByImagesNC(g,fp,gens,GeneratorsOfGroup(fp));
+    hom:=GroupHomomorphismByImagesNC(g,fp,gens,GeneratorsOfGroup(fp):noassert);
     SetIsBijective(hom,true);
   else
     hom:=GroupHomomorphismByImagesNC(g,fp,
 	  Concatenation(gens,GeneratorsOfGroup(N)),
 	  Concatenation(GeneratorsOfGroup(fp),
-	    List(GeneratorsOfGroup(N),i->One(fp))));
+	    List(GeneratorsOfGroup(N),i->One(fp))):noassert);
     SetIsSurjective(hom,true);
     SetKernelOfMultiplicativeGeneralMapping(hom,N);
   fi;
@@ -563,7 +564,7 @@ local fpq, qgens, qreps, fpqg, rels, pcgs, p, f, qimg, idx, nimg, decomp,
   hom2:=GroupHomomorphismByImagesNC(G,fp,
 	 Concatenation(Concatenation(qreps,pcgs),GeneratorsOfGroup(N)),
 	 Concatenation(GeneratorsOfGroup(fp),
-	 List(GeneratorsOfGroup(N),x->One(fp))));
+	 List(GeneratorsOfGroup(N),x->One(fp))):noassert);
 
   # build decompositioninfo
   di:=rec(gens:=Concatenation(qreps,pcgs),fp:=fp,source:=G);

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -604,7 +604,9 @@ local di, hom;
     if di.gens=ggens or cgens=ggens then
       di.gens:=cgens;
       di.source:=k;
-      hom:=GroupHomomorphismByImagesNC(k,di.fp,cgens,GeneratorsOfGroup(di.fp));
+      # this homomorphism is just to store decomposition information and is
+      # not declared total, so an assertion test will fail
+      hom:=GroupHomomorphismByImagesNC(k,di.fp,cgens,GeneratorsOfGroup(di.fp):noassert);
       hom!.decompinfo:=`di;
       if HasIsSurjective(h) and IsSurjective(h) 
 	and HasKernelOfMultiplicativeGeneralMapping(h)

--- a/lib/maxsub.gi
+++ b/lib/maxsub.gi
@@ -225,7 +225,7 @@ BindGlobal("MaximalSubgroupClassesSol",function(G)
             pcgsM := InducedPcgsByPcSequenceNC( spec, spec{[homliftlevel+1..f-1]} );
 	    RUN_IN_GGMBI:=true;
 	    fphom:=LiftFactorFpHom(fphom,G,Group(spec),
-	      Group(spec{[homliftlevel+1..f-1]}),pcgsM);
+	      Group(spec{[f..Length(spec)]}),pcgsM);
 	    RUN_IN_GGMBI:=false;
 	    # translate words
 	    L:=FreeGeneratorsOfFpGroup(Range(fphom)){[1..Length(wordgens)]};

--- a/lib/maxsub.gi
+++ b/lib/maxsub.gi
@@ -204,8 +204,10 @@ BindGlobal("MaximalSubgroupClassesSol",function(G)
     wordpre:=List(wordfpgens,x->PreImagesRepresentative(ff.factorhom,
 	      PreImagesRepresentative(fphom,x)));
     fphom:=ff.factorhom*fphom;
-    f:=GroupHomomorphismByImagesNC(Range(fphom),Source(fphom),
-	wordfpgens,wordpre);
+    # no assertion as this is not a proper homomorphism, but an inverse
+    # multiplicative map
+    f:=GroupGeneralMappingByImagesNC(Range(fphom),Source(fphom),
+	wordfpgens,wordpre:noassert);
     SetInverseGeneralMapping(fphom,f);
 
     homliftlevel:=0;

--- a/lib/permdeco.gi
+++ b/lib/permdeco.gi
@@ -27,7 +27,7 @@ local   pcgs,r,hom,A,iso,p,i;
 
   A:=CreateIsomorphicPcGroup(pcgs,true,false);
 
-  iso := GroupHomomorphismByImagesNC( G, A, pcgs, GeneratorsOfGroup( A ));
+  iso := GroupHomomorphismByImagesNC( r, A, pcgs, GeneratorsOfGroup( A ));
   SetIsBijective( iso, true );
   return rec(pcgs:=pcgs,
              depths:=IndicesEANormalSteps(pcgs),

--- a/tst/teststandard/mapphomo.tst
+++ b/tst/teststandard/mapphomo.tst
@@ -63,6 +63,16 @@ false
 gap> HasIsSurjective(hom); IsSurjective(hom);
 true
 true
+gap> G := Group((1,2));;
+gap> H := Group((1,2,3));;
+gap> GroupHomomorphismByImages(G, H, [(1,2)], [(1,2)]);
+Error, images must lie in range group
+gap> GroupHomomorphismByImages(G, H, [(2,3)], [(2,3)]);
+Error, generators must lie in source group
+gap> GroupHomomorphismByImages(G, H, [(1,2)], [(1,2,3)]);
+fail
+gap> GroupHomomorphismByImages(G, H, [], []);
+fail
 gap> STOP_TEST( "mapphomo.tst", 2040000);
 
 #############################################################################


### PR DESCRIPTION
This is a pull request, based on stable-4.8 that contains #401 and adds commands that make testinstall.g run on assertion level 2 without infinite recursion problems.

The same changes also need to go into master, though this is probably beyond my skills