### PR TITLE
lib: rename ErrorMayQuit to ErrorNoReturn

### DIFF
--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -915,17 +915,17 @@ were called with these arguments.
 Then a break loop (see&nbsp;<Ref Sect="Break Loops"/>) is
 entered, unless the standard error output is not connected to a terminal.
 You can leave this break loop with <C>return;</C> to continue execution with
-the statement following the call to <Ref Func="Error"/>. <Ref Func="ErrorMayQuit"/>
+the statement following the call to <Ref Func="Error"/>. <Ref Func="ErrorNoReturn"/>
 operates identically to <Ref Func="Error"/>, except it does not allow using
 <C>return;</C> to continue execution.
 </Description>
 </ManSection>
 
 <ManSection>
-<Func Name="ErrorMayQuit" Arg='messages ...'/>
+<Func Name="ErrorNoReturn" Arg='messages ...'/>
 
 <Description>
-<Ref Func="ErrorMayQuit"/> signals an error from within a function.
+<Ref Func="ErrorNoReturn"/> signals an error from within a function.
 First the messages <A>messages</A> are printed,
 this is done exactly as if <Ref Func="Print"/>
 (see&nbsp;<Ref Sect="View and Print"/>)

--- a/lib/error.g
+++ b/lib/error.g
@@ -279,3 +279,5 @@ BIND_GLOBAL("ErrorNoReturn",
          printThisStatement := false), arg);
 end);
  
+# HACK: remove this before final GAP 4.8 release
+BIND_GLOBAL("ErrorMayQuit", ErrorNoReturn);

--- a/lib/error.g
+++ b/lib/error.g
@@ -270,7 +270,7 @@ BIND_GLOBAL("Error",
                                arg);
 end);
 
-BIND_GLOBAL("ErrorMayQuit",
+BIND_GLOBAL("ErrorNoReturn",
        function ( arg )
     ErrorInner( rec(
          context := ParentLVars( GetCurrentLVars(  ) ),

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -1362,7 +1362,7 @@ InstallMethod(IsomorphismReesMatrixSemigroup, "for a D-class",
 [IsGreensDClass],
 function(D)
   if Number(D, IsIdempotent) <> Length(GreensHClasses(D)) then
-    ErrorMayQuit("IsomorphismReesMatrixSemigroup: usage,\n",
+    ErrorNoReturn("IsomorphismReesMatrixSemigroup: usage,\n",
                  "the D-class is not a subsemigroup,");
   fi;
   return _InjectionPrincipalFactor(D, ReesMatrixSemigroup);


### PR DESCRIPTION
See issue #470 

Note that if this merged, it should be merged both into stable-4.8 and master. And in master, one additional change will be needed, as it also uses `ErrorMayQuit` in `lib/files.gi:46`