### PR TITLE
Add `Undefined` object

### DIFF
--- a/src/bool.c
+++ b/src/bool.c
@@ -36,9 +36,9 @@
 #include        "lists.h"               /* generic lists                   */
 #include        "string.h"              /* strings                         */
 
-#include "code.h"		/* coder                           */
-#include "hpc/thread.h"		/* threads			   */
-#include "hpc/tls.h"			/* thread-local storage		   */
+#include	"code.h"		/* coder                           */
+#include	"hpc/thread.h"		/* threads			   */
+#include	"hpc/tls.h"		/* thread-local storage		   */
 
 
 /****************************************************************************
@@ -77,6 +77,18 @@ Obj Fail;
 **  a file line-by-line via a library function (demo.g)
 */
 Obj SFail;
+
+/****************************************************************************
+**
+*V  Undefined  . . . . . . . . . . . . . . . . . . . . . . . undefined value
+**
+**  'Undefined' is a special object that is used in lieu of (Obj) 0 in places
+**  where the kernel cannot handle a null reference easily. This object is
+**  never exposed to GAP code and only used within the kernel.
+*/
+Obj Undefined;
+
+
 
 
 /****************************************************************************
@@ -117,6 +129,9 @@ void PrintBool (
     }
     else if ( bool == SFail ) {
         Pr( "SuPeRfail", 0L, 0L );
+    }
+    else if ( bool == Undefined ) {
+        Pr( "Undefined", 0L, 0L );
     }
     else {
         Pr( "<<very strange boolean value>>", 0L, 0L );
@@ -403,6 +418,7 @@ static Int InitKernel (
     InitGlobalBag( &False, "src/bool.c:FALSE" );
     InitGlobalBag( &Fail,  "src/bool.c:FAIL"  );
     InitGlobalBag( &SFail,  "src/bool.c:SFAIL"  );
+    InitGlobalBag( &Undefined,  "src/bool.c:UNDEFINED"  );
 
     /* install the saving functions                                       */
     SaveObjFuncs[ T_BOOL ] = SaveBool;
@@ -417,6 +433,7 @@ static Int InitKernel (
     EqFuncs[ T_BOOL ][ T_BOOL ] = EqBool;
     LtFuncs[ T_BOOL ][ T_BOOL ] = LtBool;
 
+    MakeBagTypePublic(T_BOOL);
     /* return success                                                      */
     return 0;
 }
@@ -450,6 +467,9 @@ static Int InitLibrary (
     gvar = GVarName( "SuPeRfail" );
     AssGVar( gvar, SFail );
     MakeReadOnlyGVar(gvar);
+
+    /* Undefined is an internal value */
+    Undefined = NewBag( T_BOOL, 0 );
 
     /* make and install the 'RETURN_TRUE' function                         */
     tmp = NewFunctionC( "RETURN_TRUE", -1L, "arg", ReturnTrue1 );

--- a/src/bool.h
+++ b/src/bool.h
@@ -51,6 +51,16 @@ extern Obj Fail;
 */
 extern Obj SFail;
 
+/****************************************************************************
+**
+*V  Undefined  . . . . . . . . . . . . . . . . . . . . . . . undefined value
+**
+**  'Undefined' is a special object that is used in lieu of (Obj) 0 in places
+**  where the kernel cannot handle a null reference easily. This object is
+**  never exposed to GAP code and only used within the kernel.
+*/
+extern Obj Undefined;
+
 
 /****************************************************************************
 **


### PR DESCRIPTION
This adds the `Undefined` object from HPC-GAP. This should never be exposed
to GAP-Level code.

This introduces a call to `MakeBagTypePublic` into `bool.c`. Do we want this to happen, and rename these things to use a HPC prefix later?