### PR TITLE
Fixed or made more robust examples failing in the stable-4.8 branch

### DIFF
--- a/doc/ref/grplib.xml
+++ b/doc/ref/grplib.xml
@@ -1370,38 +1370,18 @@ gap> # Perform the computations in an isomorphic permutation group.
 gap> phi := IsomorphismPermGroup( G );;
 gap> P := Image( phi );
 Group([ (1,7,6)(2,9)(4,5,10), (2,3,4,5)(6,9,8,7) ])
-gap> D := DerivedSubgroup( P );
-Group([ (1,2,10,9)(3,8)(4,5)(6,7), (1,6)(2,7,9,4)(3,8)(5,10), (1,2)
-(4,5)(6,7)(9,10), (1,9)(2,10)(3,6,8,5)(4,7) ])
+gap> D := DerivedSubgroup( P );;
 gap> Size( D );
 960
 gap> IsPerfectGroup( D );
 true
 gap> # We have found the solvable residuum of P,
 gap> # now move the results back to the matrix group G.
-gap> R := PreImage( phi, D );
-<matrix group of size 960 with 4 generators>
-gap> for m in GeneratorsOfGroup( R ) do PrintArray( m ); od;
-[ [  -1,  -1,  -1,  -1,   2 ],
-  [   0,  -1,   0,   0,   0 ],
-  [   0,   0,   0,   1,   0 ],
-  [   0,   0,   1,   0,   0 ],
-  [  -1,  -1,   0,   0,   1 ] ]
-[ [   0,   0,  -1,   0,   0 ],
-  [   0,  -1,   0,   0,   0 ],
-  [   1,   0,   0,   0,   0 ],
-  [  -1,  -1,  -1,  -1,   2 ],
-  [   0,  -1,  -1,   0,   1 ] ]
-[ [   1,   1,   1,   1,  -2 ],
-  [   0,   1,   0,   0,   0 ],
-  [   0,   0,   0,   1,   0 ],
-  [   0,   0,   1,   0,   0 ],
-  [   0,   1,   1,   1,  -1 ] ]
-[ [  -1,  -1,  -1,  -1,   2 ],
-  [   0,   0,   0,  -1,   0 ],
-  [   0,   0,  -1,   0,   0 ],
-  [   0,   1,   0,   0,   0 ],
-  [   0,   0,  -1,  -1,   1 ] ]
+gap> R := PreImage( phi, D );;
+gap> StructureDescription(R);
+"(C2 x C2 x C2 x C2) : A5"
+gap> IdGroup(D)=IdGroup(R);
+true
 ]]></Example>
 </Description>
 </ManSection>

--- a/doc/tut/group.xml
+++ b/doc/tut/group.xml
@@ -921,14 +921,14 @@ Group([ (1,4)(2,3), (1,3)(2,4) ])
 gap> Image( hom, (1,2,3) );
 (1,2,3)
 gap> Image( hom, DerivedSubgroup(s4) );
-Group([ (1,3,2), (1,2,3) ])
+Group([ (1,3,2), (1,3,2) ])
 ]]></Example>
 <P/>
 <Log><![CDATA[
 gap> PreImage( hom, (1,2,3) );
 Error, <map> must be an inj. and surj. mapping called from
-<function>( <arguments> ) called from read-eval-loop
-Entering break read-eval-print loop ...
+<function "PreImage">( <arguments> )
+ called from read-eval loop at line 4 of *stdin*
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> quit;
@@ -976,13 +976,13 @@ But note that horrible things can happen if
 <Ref Func="GroupHomomorphismByImagesNC" BookName="ref"/>
 is used when the input does not describe a homomorphism.
 <P/>
-<Example><![CDATA[
+<Log><![CDATA[
 gap> hom2 := GroupHomomorphismByImagesNC( s4, s3,
 >            GeneratorsOfGroup(s4), [(1,2,3),(2,3)] );
 [ (1,2,3,4), (1,2) ] -> [ (1,2,3), (2,3) ]
 gap> Size( Kernel(hom2) );
 24
-]]></Example>
+]]></Log>
 <P/>
 In other words, &GAP; claims that the kernel is the full <C>s4</C>,
 yet <C>hom2</C> obviously has some non-trivial images!
@@ -993,10 +993,10 @@ to an element of order&nbsp;3 (namely, (1,2,3)).
 <Ref Func="GroupHomomorphismByImagesNC" BookName="ref"/>,
 &GAP; trusts you.</E>
 <P/>
-<Example><![CDATA[
+<Log><![CDATA[
 gap> IsGroupHomomorphism( hom2 );
 true
-]]></Example>
+]]></Log>
 <P/>
 And then it produces serious nonsense if the thing is not a homomorphism,
 as seen above!
@@ -1178,7 +1178,7 @@ gap> niceaut := NiceObject( aut );
 Group([ (1,4,2,3), (1,5,4)(2,6,3), (1,2)(3,4), (3,4)(5,6) ])
 gap> IsomorphismGroups( niceaut, SymmetricGroup( 4 ) );
 [ (1,4,2,3), (1,5,4)(2,6,3), (1,2)(3,4), (3,4)(5,6) ] -> 
-[ (1,2,3,4), (2,3,4), (1,3)(2,4), (1,2)(3,4) ]
+[ (1,2,3,4), (1,2,4), (1,3)(2,4), (1,2)(3,4) ]
 ]]></Example>
 <P/>
 The range of  a nice monomorphism is  in most cases a permutation  group,

--- a/lib/gprd.gd
+++ b/lib/gprd.gd
@@ -221,7 +221,7 @@ DeclareGlobalFunction("SubdirectDiagonalPerms");
 ##  gap> p:=SemidirectProduct(g,apci,n);
 ##  <pc group of size 24 with 4 generators>
 ##  gap> IsomorphismGroups(p,Group((1,2,3,4),(1,2)));
-##  [ f1, f2, f3, f4 ] -> [ (3,4), (1,4,3), (1,2)(3,4), (1,3)(2,4) ]
+##  [ f1, f2, f3, f4 ] -> [ (2,3), (1,2,3), (1,4)(2,3), (1,3)(2,4) ]
 ##  gap> SemidirectProduct(SU(3,3),GF(9)^3);
 ##  <matrix group of size 4408992 with 3 generators>
 ##  gap> SemidirectProduct(Group((1,2,3),(2,3,4)),GF(5)^4);

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1222,14 +1222,11 @@ DeclareAttribute( "PerfectResiduum", IsGroup );
 ##  <Example><![CDATA[
 ##  gap> m11:=TransitiveGroup(11,6);
 ##  M(11)
-##  gap> r:=RepresentativesPerfectSubgroups(m11);
-##  [ Group([ (3,4,10)(5,11,6)(7,9,8), (1,7)(3,6)(4,8)(9,11) ]), 
-##    Group([ (2,3,7)(4,11,9)(5,8,10), (1,7)(3,6)(4,8)(9,11) ]), 
-##    Group([ (3,4,11,5)(6,8,10,7), (1,7)(3,6)(4,8)(9,11) ]), 
-##    Group([ (2,3,5)(4,10,9)(6,7,11), (1,7)(3,6)(4,8)(9,11) ]), M(11), 
-##    Group(()) ]
+##  gap> r:=RepresentativesPerfectSubgroups(m11);;
 ##  gap> List(r,Size);
 ##  [ 60, 60, 360, 660, 7920, 1 ]
+##  gap> List(r,StructureDescription);
+##  [ "A5", "A5", "A6", "PSL(2,11)", "M11", "1" ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
@@ -1251,15 +1248,11 @@ DeclareAttribute( "RepresentativesSimpleSubgroups", IsGroup );
 ##  returns a list of the conjugacy classes of perfect subgroups of <A>G</A>.
 ##  (see <Ref Func="RepresentativesPerfectSubgroups"/>.)
 ##  <Example><![CDATA[
-##  gap> ConjugacyClassesPerfectSubgroups(m11);
-##  [ Group( [ ( 3, 4,10)( 5,11, 6)( 7, 9, 8), 
-##        ( 1, 7)( 3, 6)( 4, 8)( 9,11) ] )^G, 
-##    Group( [ ( 2, 3, 7)( 4,11, 9)( 5, 8,10), 
-##        ( 1, 7)( 3, 6)( 4, 8)( 9,11) ] )^G, 
-##    Group( [ ( 3, 4,11, 5)( 6, 8,10, 7), ( 1, 7)( 3, 6)( 4, 8)( 9,11) 
-##       ] )^G, 
-##    Group( [ ( 2, 3, 5)( 4,10, 9)( 6, 7,11), 
-##        ( 1, 7)( 3, 6)( 4, 8)( 9,11) ] )^G, M(11)^G, Group( () )^G ]
+##  gap> r := ConjugacyClassesPerfectSubgroups(m11);;
+##  gap> List(r, x -> StructureDescription(Representative(x)));
+##  [ "A5", "A5", "A6", "PSL(2,11)", "M11", "1" ]
+##  gap> SortedList( List(r,Size) );
+##  [ 1, 1, 11, 12, 66, 132 ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
@@ -3279,10 +3272,10 @@ KeyDependentOperation( "SylowComplement", IsGroup, IsPosInt, "prime" );
 ##  gap> HallSubgroup(h,[2,3]);  
 ##  [ <permutation group of size 96 with 6 generators>, 
 ##    <permutation group of size 96 with 6 generators> ]
-##  gap> HallSubgroup(h,[3,31]);
-##  Group([ (2,29,7)(3,30,11)(4,28,8)(5,27,9)(6,31,10)(12,24,21)(13,25,20)
-##  (14,23,17)(15,22,19)(16,26,18), (1,20,31,23,11,25,29,3,21,24,6,19,5,
-##  17,12,14,4,18,8,10,30,27,16,26,22,13,7,15,28,9,2) ])
+##  gap> u := HallSubgroup(h,[3,31]);;
+##  gap> Size(u); StructureDescription(u);
+##  93
+##  "C31 : C3"
 ##  gap> HallSubgroup(h,[5,31]);
 ##  fail
 ##  ]]></Example>
@@ -4132,7 +4125,7 @@ DeclareAttribute( "IsomorphismFpGroup", IsGroup );
 ##  #I  the image group has 3 gens and 11 rels of total length 92
 ##  gap> iso := IsomorphismFpGroupByGenerators( M12, gens : 
 ##  >                                           method := "fast" );;
-##  #I  the image group has 3 gens and 150 rels of total length 3336
+##  #I  the image group has 3 gens and 178 rels of total length 4001
 ##  ]]></Example>
 ##  <P/>
 ##  Though the option <C>method := "regular"</C> is only checked in the case
@@ -4154,7 +4147,7 @@ DeclareAttribute( "IsomorphismFpGroup", IsGroup );
 ##    [ [ 0, 1, 0, 0, 0 ], [ 0, 0, 1, 0, 0 ], [ 0, 0, 0, 1, 0 ], 
 ##        [ 1, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 1 ] ] ]
 ##  gap> iso := IsomorphismFpGroupByGenerators( G, gens );;
-##  #I  the image group has 2 gens and 10 rels of total length 126
+##  #I  the image group has 2 gens and 9 rels of total length 112
 ##  gap> iso := IsomorphismFpGroupByGenerators( G, gens : 
 ##  >                                           method := "regular");;
 ##  #I  the image group has 2 gens and 6 rels of total length 56

--- a/lib/teaching.g
+++ b/lib/teaching.g
@@ -194,9 +194,9 @@ DeclareGlobalFunction("CosetDecomposition");
 ##  <A>H</A>-conjugacy.
 ##  <Example><![CDATA[
 ##  gap> AllHomomorphismClasses(SymmetricGroup(4),SymmetricGroup(3)); 
-##  [ [ (1,3,4,2), (1,2,4) ] -> [ (), () ], 
-##    [ (1,3,4,2), (1,2,4) ] -> [ (1,2), () ], 
-##    [ (1,3,4,2), (1,2,4) ] -> [ (2,3), (1,2,3) ] ]
+##  [ [ (2,3,4), (1,4,3,2) ] -> [ (), () ], 
+##    [ (2,3,4), (1,4,3,2) ] -> [ (), (1,2) ], 
+##    [ (2,3,4), (1,4,3,2) ] -> [ (1,2,3), (1,2) ] ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>


### PR DESCRIPTION
This PR fixes examples that fail in the stable-4.8 branch in the test with default packages.

At the same time, I have tried to make some examples more robust by demonstrating the properties of the output rather then the exact output.

An example of using `GroupHomomorphismByImagesNC` became `<Log>` to be excluded from the automated tests, because they use assertion level 2 and this example triggers an assertion error.

I will merge this in a couple of days unless there will be any suggestions to change these examples further.