### PR TITLE
Key dependent operation

### DIFF
--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -607,6 +607,42 @@ InstallAttributeFunction(
             DO_NOTHING_SETTER );
     end );
 
+#############################################################################
+##
+#F  PositionSortedOddPositions( <list>, <elm> )
+##
+##  works like PositionSorted, but only looks at odd positions
+##  compared with the original algorithm, this translates
+##  indices i -> 2*i - 1
+##
+##  keep function here so it will be compiled
+##
+BIND_GLOBAL ("PositionSortedOddPositions",
+function (list, elm)
+
+    local i, j, k;
+
+    k := LEN_LIST( list ) + 1;
+    if k mod 2 = 0 then
+        k := k + 1;
+    fi;
+
+    i := -1;
+
+    while i + 2 < k do
+
+        # (i < 0 or list[i] < elm) and (k > Length( list ) or list[k] >= elm)
+
+        j := 2 * QUO_INT( i+k+2, 4 ) - 1;
+        if list[j] < elm then
+            i := j;
+        else
+            k := j;
+        fi;
+    od;
+
+    return k;
+end);
 
 #############################################################################
 ##
@@ -774,25 +810,22 @@ BIND_GLOBAL( "KeyDependentOperation",
 
         keytest( key );
         known:= attr( D );
-        i:= 1;
-        while i < LEN_LIST( known ) and known[i] < key do
-          i:= i + 2;
-        od;
 
-	# Start storing only after the result has been computed.
-        # This avoids errors if a calculation had been interrupted.
+        i:= PositionSortedOddPositions( known, key );
 
         if LEN_LIST( known ) < i or known[i] <> key then
-	  erg := oper( D, key );
-          while i < LEN_LIST( known ) and known[i] < key do
-            i:= i + 2;
-          od;
-          if LEN_LIST( known ) < i or known[i] <> key then
-            known{ [ i + 2 .. LEN_LIST( known ) + 2 ] }:=
-              known{ [ i .. LEN_LIST( known ) ] };
-            known[  i  ]:= key;
-            known[ i+1 ]:= erg;
-          fi;
+            erg := oper( D, key );
+
+            # re-compute position, just in case the call to oper added to known
+            # including the possibility that the result is already stored
+            # don't use setter because erg isn't necessarily equal to the stored result
+            i:= PositionSortedOddPositions( known, key );
+            if LEN_LIST( known ) < i or known[i] <> key then
+                known{ [ i + 2 .. LEN_LIST( known ) + 2 ] }:=
+                    known{ [ i .. LEN_LIST( known ) ] };
+                known[  i  ]:= key;
+                known[ i+1 ]:= erg;
+            fi;
         fi;
         return known[ i+1 ];
         end );
@@ -811,10 +844,7 @@ BIND_GLOBAL( "KeyDependentOperation",
 
             keytest( key );
             known:= attr( D );
-            i:= 1;
-            while i < LEN_LIST( known ) and known[i] < key do
-                i:= i + 2;
-            od;
+            i:= PositionSortedOddPositions( known, key );
             return i <= LEN_LIST( known ) and known[i] = key;
         end );
     # define tester function
@@ -831,10 +861,7 @@ BIND_GLOBAL( "KeyDependentOperation",
 
             keytest( key );
             known:= attr( D );
-            i:= 1;
-            while i < LEN_LIST( known ) and known[i] < key do
-                i:= i + 2;
-            od;
+            i:= PositionSortedOddPositions( known, key );
             if LEN_LIST( known ) < i or known[i] <> key then
                 known{ [ i + 2 .. LEN_LIST( known ) + 2 ] }:=
                 known{ [ i .. LEN_LIST( known ) ] };

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -659,7 +659,9 @@ InstallAttributeFunction(
 ##  <Ref Func="KeyDependentOperation"/> declares the two operations and the
 ##  attribute as described above,
 ##  with names <A>name</A>, <A>name</A><C>Op</C>,
-##  and <C>Computed</C><A>name</A><C>s</C>.
+##  and <C>Computed</C><A>name</A><C>s</C>, as well as tester and setter operations
+##  <C>Has</C><A>name</A> and <C>Set</C><A>name</A>, respectively. Note, however,
+##  that the tester is not a filter.
 ##  <A>dom-req</A> and <A>key-req</A> specify the required filters for the
 ##  first and second argument of the operation <A>name</A><C>Op</C>,
 ##  which are needed to create this operation with
@@ -688,10 +690,14 @@ InstallAttributeFunction(
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> s4 := Group((1,2,3,4),(1,2));;
-##  gap> SylowSubgroup( s4, 5 );;  ComputedSylowSubgroups( s4 );
-##  [ 5, Group(()) ]
+##  gap> SylowSubgroup( s4, 7 );;  ComputedSylowSubgroups( s4 );
+##  [ 7, Group(()) ]
 ##  gap> SylowSubgroup( s4, 2 );;  ComputedSylowSubgroups( s4 );
-##  [ 2, Group([ (3,4), (1,4)(2,3), (1,3)(2,4) ]), 5, Group(()) ]
+##  [ 2, Group([ (3,4), (1,4)(2,3), (1,3)(2,4) ]), 7, Group(()) ]
+##  gap> HasSylowSubgroup( s4, 5 );
+##  false
+##  gap> SetSylowSubgroup( s4, 5, Group(()));; ComputedSylowSubgroups( s4 );
+##  [ 2, Group([ (3,4), (1,4)(2,3), (1,3)(2,4) ]), 5, Group(()), 7, Group(()) ]
 ##  ]]></Example>
 ##  <P/>
 ##  <Log><![CDATA[
@@ -789,6 +795,52 @@ BIND_GLOBAL( "KeyDependentOperation",
           fi;
         fi;
         return known[ i+1 ];
+        end );
+
+    # define tester function
+    str:= "Has";
+    APPEND_LIST_INTR( str, name );
+    DeclareOperation( str, [ domreq, keyreq ] );
+    InstallOtherMethod( VALUE_GLOBAL( str ),
+        "default method",
+        true,
+        [ domreq, keyreq ], 0,
+        function( D, key )
+
+            local known, i;
+
+            keytest( key );
+            known:= attr( D );
+            i:= 1;
+            while i < LEN_LIST( known ) and known[i] < key do
+                i:= i + 2;
+            od;
+            return i <= LEN_LIST( known ) and known[i] = key;
+        end );
+    # define tester function
+    str:= "Set";
+    APPEND_LIST_INTR( str, name );
+    DeclareOperation( str, [ domreq, keyreq, IS_OBJECT ] );
+    InstallOtherMethod( VALUE_GLOBAL( str ),
+        "default method",
+        true,
+        [ domreq, keyreq, IS_OBJECT ], 0,
+        function( D, key, obj )
+
+            local known, i;
+
+            keytest( key );
+            known:= attr( D );
+            i:= 1;
+            while i < LEN_LIST( known ) and known[i] < key do
+                i:= i + 2;
+            od;
+            if LEN_LIST( known ) < i or known[i] <> key then
+                known{ [ i + 2 .. LEN_LIST( known ) + 2 ] }:=
+                known{ [ i .. LEN_LIST( known ) ] };
+                known[  i  ]:= key;
+                known[ i+1 ]:= obj;
+            fi;
         end );
 end );
 

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -778,10 +778,15 @@ BIND_GLOBAL( "KeyDependentOperation",
 
         if LEN_LIST( known ) < i or known[i] <> key then
 	  erg := oper( D, key );
-          known{ [ i + 2 .. LEN_LIST( known ) + 2 ] }:=
-            known{ [ i .. LEN_LIST( known ) ] };
-          known[  i  ]:= key;
-          known[ i+1 ]:= erg;
+          while i < LEN_LIST( known ) and known[i] < key do
+            i:= i + 2;
+          od;
+          if LEN_LIST( known ) < i or known[i] <> key then
+            known{ [ i + 2 .. LEN_LIST( known ) + 2 ] }:=
+              known{ [ i .. LEN_LIST( known ) ] };
+            known[  i  ]:= key;
+            known[ i+1 ]:= erg;
+          fi;
         fi;
         return known[ i+1 ];
         end );

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -150,9 +150,9 @@ static Obj  GF_CallFuncList;
 static RNam R_MaxNrArgsMethod;
 
 /* information for the functions */
-static Obj  NameFunc[16];
-static Obj  NamsFunc[16];
-static Int  NargFunc[16];
+static Obj  NameFunc[18];
+static Obj  NamsFunc[18];
+static Int  NargFunc[18];
 static Obj  DefaultName;
 static Obj FileName;
 
@@ -2734,6 +2734,209 @@ static Obj  HdlrFunc13 (
  return 0;
 }
 
+/* handler for function 14 */
+static Obj  HdlrFunc14 (
+ Obj  self,
+ Obj  a_D,
+ Obj  a_key )
+{
+ Obj l_known = 0;
+ Obj l_i = 0;
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Obj t_4 = 0;
+ Obj t_5 = 0;
+ Bag oldFrame;
+ OLD_BRK_CURR_STAT
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ REM_BRK_CURR_STAT();
+ SET_BRK_CURR_STAT(0);
+ 
+ /* keytest( key ); */
+ t_1 = OBJ_LVAR_1UP( 2 );
+ CHECK_BOUND( t_1, "keytest" )
+ CHECK_FUNC( t_1 )
+ CALL_1ARGS( t_1, a_key );
+ 
+ /* known := attr( D ); */
+ t_2 = OBJ_LVAR_1UP( 4 );
+ CHECK_BOUND( t_2, "attr" )
+ CHECK_FUNC( t_2 )
+ t_1 = CALL_1ARGS( t_2, a_D );
+ CHECK_FUNC_RESULT( t_1 )
+ l_known = t_1;
+ 
+ /* i := 1; */
+ l_i = INTOBJ_INT(1);
+ 
+ /* while i < LEN_LIST( known ) and known[i] < key od */
+ while ( 1 ) {
+  t_4 = GF_LEN__LIST;
+  t_3 = CALL_1ARGS( t_4, l_known );
+  CHECK_FUNC_RESULT( t_3 )
+  t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
+  t_1 = t_2;
+  if ( t_1 ) {
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_4, l_known, l_i )
+   t_3 = (Obj)(UInt)(LT( t_4, a_key ));
+   t_1 = t_3;
+  }
+  if ( ! t_1 ) break;
+  
+  /* i := i + 2; */
+  C_SUM_FIA( t_1, l_i, INTOBJ_INT(2) )
+  l_i = t_1;
+  
+ }
+ /* od */
+ 
+ /* return i <= LEN_LIST( known ) and known[i] = key; */
+ t_4 = GF_LEN__LIST;
+ t_3 = CALL_1ARGS( t_4, l_known );
+ CHECK_FUNC_RESULT( t_3 )
+ t_2 = (LT( t_3, l_i ) ?  False : True);
+ if ( t_2 == False ) {
+  t_1 = t_2;
+ }
+ else if ( t_2 == True ) {
+  CHECK_INT_POS( l_i )
+  C_ELM_LIST_FPL( t_4, l_known, l_i )
+  t_3 = (EQ( t_4, a_key ) ? True : False);
+  t_1 = t_3;
+ }
+ else {
+  CHECK_FUNC( t_2 )
+  C_ELM_LIST_FPL( t_5, l_known, l_i )
+  t_4 = (EQ( t_5, a_key ) ? True : False);
+  CHECK_FUNC( t_4 )
+  t_1 = NewAndFilter( t_2, t_4 );
+ }
+ RES_BRK_CURR_STAT();
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return t_1;
+ 
+ /* return; */
+ RES_BRK_CURR_STAT();
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 15 */
+static Obj  HdlrFunc15 (
+ Obj  self,
+ Obj  a_D,
+ Obj  a_key,
+ Obj  a_obj )
+{
+ Obj l_known = 0;
+ Obj l_i = 0;
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Obj t_4 = 0;
+ Obj t_5 = 0;
+ Bag oldFrame;
+ OLD_BRK_CURR_STAT
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ REM_BRK_CURR_STAT();
+ SET_BRK_CURR_STAT(0);
+ 
+ /* keytest( key ); */
+ t_1 = OBJ_LVAR_1UP( 2 );
+ CHECK_BOUND( t_1, "keytest" )
+ CHECK_FUNC( t_1 )
+ CALL_1ARGS( t_1, a_key );
+ 
+ /* known := attr( D ); */
+ t_2 = OBJ_LVAR_1UP( 4 );
+ CHECK_BOUND( t_2, "attr" )
+ CHECK_FUNC( t_2 )
+ t_1 = CALL_1ARGS( t_2, a_D );
+ CHECK_FUNC_RESULT( t_1 )
+ l_known = t_1;
+ 
+ /* i := 1; */
+ l_i = INTOBJ_INT(1);
+ 
+ /* while i < LEN_LIST( known ) and known[i] < key od */
+ while ( 1 ) {
+  t_4 = GF_LEN__LIST;
+  t_3 = CALL_1ARGS( t_4, l_known );
+  CHECK_FUNC_RESULT( t_3 )
+  t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
+  t_1 = t_2;
+  if ( t_1 ) {
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_4, l_known, l_i )
+   t_3 = (Obj)(UInt)(LT( t_4, a_key ));
+   t_1 = t_3;
+  }
+  if ( ! t_1 ) break;
+  
+  /* i := i + 2; */
+  C_SUM_FIA( t_1, l_i, INTOBJ_INT(2) )
+  l_i = t_1;
+  
+ }
+ /* od */
+ 
+ /* if LEN_LIST( known ) < i or known[i] <> key then */
+ t_4 = GF_LEN__LIST;
+ t_3 = CALL_1ARGS( t_4, l_known );
+ CHECK_FUNC_RESULT( t_3 )
+ t_2 = (Obj)(UInt)(LT( t_3, l_i ));
+ t_1 = t_2;
+ if ( ! t_1 ) {
+  CHECK_INT_POS( l_i )
+  C_ELM_LIST_FPL( t_4, l_known, l_i )
+  t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
+  t_1 = t_3;
+ }
+ if ( t_1 ) {
+  
+  /* known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]}; */
+  C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
+  t_5 = GF_LEN__LIST;
+  t_4 = CALL_1ARGS( t_5, l_known );
+  CHECK_FUNC_RESULT( t_4 )
+  C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
+  t_1 = Range2Check( t_2, t_3 );
+  t_5 = GF_LEN__LIST;
+  t_4 = CALL_1ARGS( t_5, l_known );
+  CHECK_FUNC_RESULT( t_4 )
+  t_3 = Range2Check( l_i, t_4 );
+  t_2 = ElmsListCheck( l_known, t_3 );
+  AsssListCheck( l_known, t_1, t_2 );
+  
+  /* known[i] := key; */
+  CHECK_INT_POS( l_i )
+  C_ASS_LIST_FPL( l_known, l_i, a_key )
+  
+  /* known[i + 1] := obj; */
+  C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_1 )
+  C_ASS_LIST_FPL( l_known, t_1, a_obj )
+  
+ }
+ /* fi */
+ 
+ /* return; */
+ RES_BRK_CURR_STAT();
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ RES_BRK_CURR_STAT();
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
 /* handler for function 10 */
 static Obj  HdlrFunc10 (
  Obj  self,
@@ -2776,8 +2979,8 @@ static Obj  HdlrFunc10 (
   t_1 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
   ENVI_FUNC( t_1 ) = TLS(CurrLVars);
   t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
-  STARTLINE_BODY(t_2) = INTOBJ_INT(732);
-  ENDLINE_BODY(t_2) = INTOBJ_INT(736);
+  STARTLINE_BODY(t_2) = INTOBJ_INT(738);
+  ENDLINE_BODY(t_2) = INTOBJ_INT(742);
   FILENAME_BODY(t_2) = FileName;
   BODY_FUNC(t_1) = t_2;
   CHANGED_BAG( TLS(CurrLVars) );
@@ -2856,8 +3059,8 @@ static Obj  HdlrFunc10 (
  t_6 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
  ENVI_FUNC( t_6 ) = TLS(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_7) = INTOBJ_INT(753);
- ENDLINE_BODY(t_7) = INTOBJ_INT(753);
+ STARTLINE_BODY(t_7) = INTOBJ_INT(759);
+ ENDLINE_BODY(t_7) = INTOBJ_INT(759);
  FILENAME_BODY(t_7) = FileName;
  BODY_FUNC(t_6) = t_7;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -2924,8 +3127,125 @@ static Obj  HdlrFunc10 (
  t_6 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
  ENVI_FUNC( t_6 ) = TLS(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_7) = INTOBJ_INT(766);
- ENDLINE_BODY(t_7) = INTOBJ_INT(792);
+ STARTLINE_BODY(t_7) = INTOBJ_INT(772);
+ ENDLINE_BODY(t_7) = INTOBJ_INT(798);
+ FILENAME_BODY(t_7) = FileName;
+ BODY_FUNC(t_6) = t_7;
+ CHANGED_BAG( TLS(CurrLVars) );
+ CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ 
+ /* str := "Has"; */
+ C_NEW_STRING( t_1, 3, "Has" );
+ l_str = t_1;
+ 
+ /* APPEND_LIST_INTR( str, name ); */
+ t_1 = GF_APPEND__LIST__INTR;
+ t_2 = OBJ_LVAR( 1 );
+ CHECK_BOUND( t_2, "name" )
+ CALL_2ARGS( t_1, l_str, t_2 );
+ 
+ /* DeclareOperation( str, [ domreq, keyreq ] ); */
+ t_1 = GF_DeclareOperation;
+ t_2 = NEW_PLIST( T_PLIST, 2 );
+ SET_LEN_PLIST( t_2, 2 );
+ SET_ELM_PLIST( t_2, 1, a_domreq );
+ CHANGED_BAG( t_2 );
+ SET_ELM_PLIST( t_2, 2, a_keyreq );
+ CHANGED_BAG( t_2 );
+ CALL_2ARGS( t_1, l_str, t_2 );
+ 
+ /* InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
+      local  known, i;
+      keytest( key );
+      known := attr( D );
+      i := 1;
+      while i < LEN_LIST( known ) and known[i] < key  do
+          i := i + 2;
+      od;
+      return i <= LEN_LIST( known ) and known[i] = key;
+  end ); */
+ t_1 = GF_InstallOtherMethod;
+ t_3 = GF_VALUE__GLOBAL;
+ t_2 = CALL_1ARGS( t_3, l_str );
+ CHECK_FUNC_RESULT( t_2 )
+ C_NEW_STRING( t_3, 14, "default method" );
+ t_4 = True;
+ t_5 = NEW_PLIST( T_PLIST, 2 );
+ SET_LEN_PLIST( t_5, 2 );
+ SET_ELM_PLIST( t_5, 1, a_domreq );
+ CHANGED_BAG( t_5 );
+ SET_ELM_PLIST( t_5, 2, a_keyreq );
+ CHANGED_BAG( t_5 );
+ t_6 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
+ ENVI_FUNC( t_6 ) = TLS(CurrLVars);
+ t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
+ STARTLINE_BODY(t_7) = INTOBJ_INT(808);
+ ENDLINE_BODY(t_7) = INTOBJ_INT(819);
+ FILENAME_BODY(t_7) = FileName;
+ BODY_FUNC(t_6) = t_7;
+ CHANGED_BAG( TLS(CurrLVars) );
+ CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ 
+ /* str := "Set"; */
+ C_NEW_STRING( t_1, 3, "Set" );
+ l_str = t_1;
+ 
+ /* APPEND_LIST_INTR( str, name ); */
+ t_1 = GF_APPEND__LIST__INTR;
+ t_2 = OBJ_LVAR( 1 );
+ CHECK_BOUND( t_2, "name" )
+ CALL_2ARGS( t_1, l_str, t_2 );
+ 
+ /* DeclareOperation( str, [ domreq, keyreq, IS_OBJECT ] ); */
+ t_1 = GF_DeclareOperation;
+ t_2 = NEW_PLIST( T_PLIST, 3 );
+ SET_LEN_PLIST( t_2, 3 );
+ SET_ELM_PLIST( t_2, 1, a_domreq );
+ CHANGED_BAG( t_2 );
+ SET_ELM_PLIST( t_2, 2, a_keyreq );
+ CHANGED_BAG( t_2 );
+ t_3 = GC_IS__OBJECT;
+ CHECK_BOUND( t_3, "IS_OBJECT" )
+ SET_ELM_PLIST( t_2, 3, t_3 );
+ CHANGED_BAG( t_2 );
+ CALL_2ARGS( t_1, l_str, t_2 );
+ 
+ /* InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq, IS_OBJECT ], 0, function ( D, key, obj )
+      local  known, i;
+      keytest( key );
+      known := attr( D );
+      i := 1;
+      while i < LEN_LIST( known ) and known[i] < key  do
+          i := i + 2;
+      od;
+      if LEN_LIST( known ) < i or known[i] <> key  then
+          known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
+          known[i] := key;
+          known[i + 1] := obj;
+      fi;
+      return;
+  end ); */
+ t_1 = GF_InstallOtherMethod;
+ t_3 = GF_VALUE__GLOBAL;
+ t_2 = CALL_1ARGS( t_3, l_str );
+ CHECK_FUNC_RESULT( t_2 )
+ C_NEW_STRING( t_3, 14, "default method" );
+ t_4 = True;
+ t_5 = NEW_PLIST( T_PLIST, 3 );
+ SET_LEN_PLIST( t_5, 3 );
+ SET_ELM_PLIST( t_5, 1, a_domreq );
+ CHANGED_BAG( t_5 );
+ SET_ELM_PLIST( t_5, 2, a_keyreq );
+ CHANGED_BAG( t_5 );
+ t_6 = GC_IS__OBJECT;
+ CHECK_BOUND( t_6, "IS_OBJECT" )
+ SET_ELM_PLIST( t_5, 3, t_6 );
+ CHANGED_BAG( t_5 );
+ t_6 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
+ ENVI_FUNC( t_6 ) = TLS(CurrLVars);
+ t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
+ STARTLINE_BODY(t_7) = INTOBJ_INT(828);
+ ENDLINE_BODY(t_7) = INTOBJ_INT(844);
  FILENAME_BODY(t_7) = FileName;
  BODY_FUNC(t_6) = t_7;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -2942,8 +3262,8 @@ static Obj  HdlrFunc10 (
  return 0;
 }
 
-/* handler for function 15 */
-static Obj  HdlrFunc15 (
+/* handler for function 17 */
+static Obj  HdlrFunc17 (
  Obj  self,
  Obj  a_arg )
 {
@@ -3133,8 +3453,8 @@ static Obj  HdlrFunc15 (
  return 0;
 }
 
-/* handler for function 14 */
-static Obj  HdlrFunc14 (
+/* handler for function 16 */
+static Obj  HdlrFunc16 (
  Obj  self,
  Obj  a_arg )
 {
@@ -3302,11 +3622,11 @@ static Obj  HdlrFunc14 (
  CHECK_BOUND( l_fampred, "fampred" )
  t_3 = OBJ_LVAR( 2 );
  CHECK_BOUND( t_3, "reqs" )
- t_4 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
+ t_4 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
  ENVI_FUNC( t_4 ) = TLS(CurrLVars);
  t_5 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_5) = INTOBJ_INT(860);
- ENDLINE_BODY(t_5) = INTOBJ_INT(876);
+ STARTLINE_BODY(t_5) = INTOBJ_INT(912);
+ ENDLINE_BODY(t_5) = INTOBJ_INT(928);
  FILENAME_BODY(t_5) = FileName;
  BODY_FUNC(t_4) = t_5;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -3813,6 +4133,37 @@ static Obj  HdlrFunc1 (
             fi;
             return known[i + 1];
         end );
+      str := "Has";
+      APPEND_LIST_INTR( str, name );
+      DeclareOperation( str, [ domreq, keyreq ] );
+      InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
+            local  known, i;
+            keytest( key );
+            known := attr( D );
+            i := 1;
+            while i < LEN_LIST( known ) and known[i] < key  do
+                i := i + 2;
+            od;
+            return i <= LEN_LIST( known ) and known[i] = key;
+        end );
+      str := "Set";
+      APPEND_LIST_INTR( str, name );
+      DeclareOperation( str, [ domreq, keyreq, IS_OBJECT ] );
+      InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq, IS_OBJECT ], 0, function ( D, key, obj )
+            local  known, i;
+            keytest( key );
+            known := attr( D );
+            i := 1;
+            while i < LEN_LIST( known ) and known[i] < key  do
+                i := i + 2;
+            od;
+            if LEN_LIST( known ) < i or known[i] <> key  then
+                known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
+                known[i] := key;
+                known[i + 1] := obj;
+            fi;
+            return;
+        end );
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
@@ -3820,8 +4171,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(728);
- ENDLINE_BODY(t_4) = INTOBJ_INT(793);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(734);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(845);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -3869,11 +4220,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "RedispatchOnCondition" );
- t_3 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
+ t_3 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(828);
- ENDLINE_BODY(t_4) = INTOBJ_INT(877);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(880);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(929);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -3984,38 +4335,42 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "CallFuncList", &GF_CallFuncList );
  
  /* information for the functions */
- InitGlobalBag( &DefaultName, "GAPROOT/lib/oper1.g:DefaultName(-61697988)" );
- InitGlobalBag( &FileName, "GAPROOT/lib/oper1.g:FileName(-61697988)" );
- InitHandlerFunc( HdlrFunc1, "GAPROOT/lib/oper1.g:HdlrFunc1(-61697988)" );
- InitGlobalBag( &(NameFunc[1]), "GAPROOT/lib/oper1.g:NameFunc[1](-61697988)" );
- InitHandlerFunc( HdlrFunc2, "GAPROOT/lib/oper1.g:HdlrFunc2(-61697988)" );
- InitGlobalBag( &(NameFunc[2]), "GAPROOT/lib/oper1.g:NameFunc[2](-61697988)" );
- InitHandlerFunc( HdlrFunc3, "GAPROOT/lib/oper1.g:HdlrFunc3(-61697988)" );
- InitGlobalBag( &(NameFunc[3]), "GAPROOT/lib/oper1.g:NameFunc[3](-61697988)" );
- InitHandlerFunc( HdlrFunc4, "GAPROOT/lib/oper1.g:HdlrFunc4(-61697988)" );
- InitGlobalBag( &(NameFunc[4]), "GAPROOT/lib/oper1.g:NameFunc[4](-61697988)" );
- InitHandlerFunc( HdlrFunc5, "GAPROOT/lib/oper1.g:HdlrFunc5(-61697988)" );
- InitGlobalBag( &(NameFunc[5]), "GAPROOT/lib/oper1.g:NameFunc[5](-61697988)" );
- InitHandlerFunc( HdlrFunc6, "GAPROOT/lib/oper1.g:HdlrFunc6(-61697988)" );
- InitGlobalBag( &(NameFunc[6]), "GAPROOT/lib/oper1.g:NameFunc[6](-61697988)" );
- InitHandlerFunc( HdlrFunc7, "GAPROOT/lib/oper1.g:HdlrFunc7(-61697988)" );
- InitGlobalBag( &(NameFunc[7]), "GAPROOT/lib/oper1.g:NameFunc[7](-61697988)" );
- InitHandlerFunc( HdlrFunc8, "GAPROOT/lib/oper1.g:HdlrFunc8(-61697988)" );
- InitGlobalBag( &(NameFunc[8]), "GAPROOT/lib/oper1.g:NameFunc[8](-61697988)" );
- InitHandlerFunc( HdlrFunc9, "GAPROOT/lib/oper1.g:HdlrFunc9(-61697988)" );
- InitGlobalBag( &(NameFunc[9]), "GAPROOT/lib/oper1.g:NameFunc[9](-61697988)" );
- InitHandlerFunc( HdlrFunc10, "GAPROOT/lib/oper1.g:HdlrFunc10(-61697988)" );
- InitGlobalBag( &(NameFunc[10]), "GAPROOT/lib/oper1.g:NameFunc[10](-61697988)" );
- InitHandlerFunc( HdlrFunc11, "GAPROOT/lib/oper1.g:HdlrFunc11(-61697988)" );
- InitGlobalBag( &(NameFunc[11]), "GAPROOT/lib/oper1.g:NameFunc[11](-61697988)" );
- InitHandlerFunc( HdlrFunc12, "GAPROOT/lib/oper1.g:HdlrFunc12(-61697988)" );
- InitGlobalBag( &(NameFunc[12]), "GAPROOT/lib/oper1.g:NameFunc[12](-61697988)" );
- InitHandlerFunc( HdlrFunc13, "GAPROOT/lib/oper1.g:HdlrFunc13(-61697988)" );
- InitGlobalBag( &(NameFunc[13]), "GAPROOT/lib/oper1.g:NameFunc[13](-61697988)" );
- InitHandlerFunc( HdlrFunc14, "GAPROOT/lib/oper1.g:HdlrFunc14(-61697988)" );
- InitGlobalBag( &(NameFunc[14]), "GAPROOT/lib/oper1.g:NameFunc[14](-61697988)" );
- InitHandlerFunc( HdlrFunc15, "GAPROOT/lib/oper1.g:HdlrFunc15(-61697988)" );
- InitGlobalBag( &(NameFunc[15]), "GAPROOT/lib/oper1.g:NameFunc[15](-61697988)" );
+ InitGlobalBag( &DefaultName, "GAPROOT/lib/oper1.g:DefaultName(-108220442)" );
+ InitGlobalBag( &FileName, "GAPROOT/lib/oper1.g:FileName(-108220442)" );
+ InitHandlerFunc( HdlrFunc1, "GAPROOT/lib/oper1.g:HdlrFunc1(-108220442)" );
+ InitGlobalBag( &(NameFunc[1]), "GAPROOT/lib/oper1.g:NameFunc[1](-108220442)" );
+ InitHandlerFunc( HdlrFunc2, "GAPROOT/lib/oper1.g:HdlrFunc2(-108220442)" );
+ InitGlobalBag( &(NameFunc[2]), "GAPROOT/lib/oper1.g:NameFunc[2](-108220442)" );
+ InitHandlerFunc( HdlrFunc3, "GAPROOT/lib/oper1.g:HdlrFunc3(-108220442)" );
+ InitGlobalBag( &(NameFunc[3]), "GAPROOT/lib/oper1.g:NameFunc[3](-108220442)" );
+ InitHandlerFunc( HdlrFunc4, "GAPROOT/lib/oper1.g:HdlrFunc4(-108220442)" );
+ InitGlobalBag( &(NameFunc[4]), "GAPROOT/lib/oper1.g:NameFunc[4](-108220442)" );
+ InitHandlerFunc( HdlrFunc5, "GAPROOT/lib/oper1.g:HdlrFunc5(-108220442)" );
+ InitGlobalBag( &(NameFunc[5]), "GAPROOT/lib/oper1.g:NameFunc[5](-108220442)" );
+ InitHandlerFunc( HdlrFunc6, "GAPROOT/lib/oper1.g:HdlrFunc6(-108220442)" );
+ InitGlobalBag( &(NameFunc[6]), "GAPROOT/lib/oper1.g:NameFunc[6](-108220442)" );
+ InitHandlerFunc( HdlrFunc7, "GAPROOT/lib/oper1.g:HdlrFunc7(-108220442)" );
+ InitGlobalBag( &(NameFunc[7]), "GAPROOT/lib/oper1.g:NameFunc[7](-108220442)" );
+ InitHandlerFunc( HdlrFunc8, "GAPROOT/lib/oper1.g:HdlrFunc8(-108220442)" );
+ InitGlobalBag( &(NameFunc[8]), "GAPROOT/lib/oper1.g:NameFunc[8](-108220442)" );
+ InitHandlerFunc( HdlrFunc9, "GAPROOT/lib/oper1.g:HdlrFunc9(-108220442)" );
+ InitGlobalBag( &(NameFunc[9]), "GAPROOT/lib/oper1.g:NameFunc[9](-108220442)" );
+ InitHandlerFunc( HdlrFunc10, "GAPROOT/lib/oper1.g:HdlrFunc10(-108220442)" );
+ InitGlobalBag( &(NameFunc[10]), "GAPROOT/lib/oper1.g:NameFunc[10](-108220442)" );
+ InitHandlerFunc( HdlrFunc11, "GAPROOT/lib/oper1.g:HdlrFunc11(-108220442)" );
+ InitGlobalBag( &(NameFunc[11]), "GAPROOT/lib/oper1.g:NameFunc[11](-108220442)" );
+ InitHandlerFunc( HdlrFunc12, "GAPROOT/lib/oper1.g:HdlrFunc12(-108220442)" );
+ InitGlobalBag( &(NameFunc[12]), "GAPROOT/lib/oper1.g:NameFunc[12](-108220442)" );
+ InitHandlerFunc( HdlrFunc13, "GAPROOT/lib/oper1.g:HdlrFunc13(-108220442)" );
+ InitGlobalBag( &(NameFunc[13]), "GAPROOT/lib/oper1.g:NameFunc[13](-108220442)" );
+ InitHandlerFunc( HdlrFunc14, "GAPROOT/lib/oper1.g:HdlrFunc14(-108220442)" );
+ InitGlobalBag( &(NameFunc[14]), "GAPROOT/lib/oper1.g:NameFunc[14](-108220442)" );
+ InitHandlerFunc( HdlrFunc15, "GAPROOT/lib/oper1.g:HdlrFunc15(-108220442)" );
+ InitGlobalBag( &(NameFunc[15]), "GAPROOT/lib/oper1.g:NameFunc[15](-108220442)" );
+ InitHandlerFunc( HdlrFunc16, "GAPROOT/lib/oper1.g:HdlrFunc16(-108220442)" );
+ InitGlobalBag( &(NameFunc[16]), "GAPROOT/lib/oper1.g:NameFunc[16](-108220442)" );
+ InitHandlerFunc( HdlrFunc17, "GAPROOT/lib/oper1.g:HdlrFunc17(-108220442)" );
+ InitGlobalBag( &(NameFunc[17]), "GAPROOT/lib/oper1.g:NameFunc[17](-108220442)" );
  
  /* return success */
  return 0;
@@ -4151,10 +4506,16 @@ static Int InitLibrary ( StructInitInfo * module )
  NargFunc[13] = 2;
  NameFunc[14] = DefaultName;
  NamsFunc[14] = 0;
- NargFunc[14] = -1;
+ NargFunc[14] = 2;
  NameFunc[15] = DefaultName;
  NamsFunc[15] = 0;
- NargFunc[15] = -1;
+ NargFunc[15] = 3;
+ NameFunc[16] = DefaultName;
+ NamsFunc[16] = 0;
+ NargFunc[16] = -1;
+ NameFunc[17] = DefaultName;
+ NamsFunc[17] = 0;
+ NargFunc[17] = -1;
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
@@ -4292,10 +4653,16 @@ static Int PostRestore ( StructInitInfo * module )
  NargFunc[13] = 2;
  NameFunc[14] = DefaultName;
  NamsFunc[14] = 0;
- NargFunc[14] = -1;
+ NargFunc[14] = 2;
  NameFunc[15] = DefaultName;
  NamsFunc[15] = 0;
- NargFunc[15] = -1;
+ NargFunc[15] = 3;
+ NameFunc[16] = DefaultName;
+ NamsFunc[16] = 0;
+ NargFunc[16] = -1;
+ NameFunc[17] = DefaultName;
+ NamsFunc[17] = 0;
+ NargFunc[17] = -1;
  
  /* return success */
  return 0;
@@ -4310,7 +4677,7 @@ static StructInitInfo module = {
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,
  /* version     = */ 0,
- /* crc         = */ -61697988,
+ /* crc         = */ -108220442,
  /* initKernel  = */ InitKernel,
  /* initLibrary = */ InitLibrary,
  /* checkInit   = */ 0,

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -2655,28 +2655,67 @@ static Obj  HdlrFunc13 (
   CHECK_FUNC_RESULT( t_1 )
   l_erg = t_1;
   
-  /* known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]}; */
-  C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
-  t_5 = GF_LEN__LIST;
-  t_4 = CALL_1ARGS( t_5, l_known );
-  CHECK_FUNC_RESULT( t_4 )
-  C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
-  t_1 = Range2Check( t_2, t_3 );
-  t_5 = GF_LEN__LIST;
-  t_4 = CALL_1ARGS( t_5, l_known );
-  CHECK_FUNC_RESULT( t_4 )
-  t_3 = Range2Check( l_i, t_4 );
-  t_2 = ElmsListCheck( l_known, t_3 );
-  AsssListCheck( l_known, t_1, t_2 );
+  /* while i < LEN_LIST( known ) and known[i] < key od */
+  while ( 1 ) {
+   t_4 = GF_LEN__LIST;
+   t_3 = CALL_1ARGS( t_4, l_known );
+   CHECK_FUNC_RESULT( t_3 )
+   t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
+   t_1 = t_2;
+   if ( t_1 ) {
+    CHECK_INT_POS( l_i )
+    C_ELM_LIST_FPL( t_4, l_known, l_i )
+    t_3 = (Obj)(UInt)(LT( t_4, a_key ));
+    t_1 = t_3;
+   }
+   if ( ! t_1 ) break;
+   
+   /* i := i + 2; */
+   C_SUM_FIA( t_1, l_i, INTOBJ_INT(2) )
+   l_i = t_1;
+   
+  }
+  /* od */
   
-  /* known[i] := key; */
-  CHECK_INT_POS( l_i )
-  C_ASS_LIST_FPL( l_known, l_i, a_key )
-  
-  /* known[i + 1] := erg; */
-  C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_1 )
-  C_ASS_LIST_FPL( l_known, t_1, l_erg )
+  /* if LEN_LIST( known ) < i or known[i] <> key then */
+  t_4 = GF_LEN__LIST;
+  t_3 = CALL_1ARGS( t_4, l_known );
+  CHECK_FUNC_RESULT( t_3 )
+  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
+  t_1 = t_2;
+  if ( ! t_1 ) {
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_4, l_known, l_i )
+   t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
+   t_1 = t_3;
+  }
+  if ( t_1 ) {
+   
+   /* known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]}; */
+   C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
+   t_5 = GF_LEN__LIST;
+   t_4 = CALL_1ARGS( t_5, l_known );
+   CHECK_FUNC_RESULT( t_4 )
+   C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
+   t_1 = Range2Check( t_2, t_3 );
+   t_5 = GF_LEN__LIST;
+   t_4 = CALL_1ARGS( t_5, l_known );
+   CHECK_FUNC_RESULT( t_4 )
+   t_3 = Range2Check( l_i, t_4 );
+   t_2 = ElmsListCheck( l_known, t_3 );
+   AsssListCheck( l_known, t_1, t_2 );
+   
+   /* known[i] := key; */
+   CHECK_INT_POS( l_i )
+   C_ASS_LIST_FPL( l_known, l_i, a_key )
+   
+   /* known[i + 1] := erg; */
+   C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_1 )
+   C_ASS_LIST_FPL( l_known, t_1, l_erg )
+   
+  }
+  /* fi */
   
  }
  /* fi */
@@ -2857,9 +2896,14 @@ static Obj  HdlrFunc10 (
       od;
       if LEN_LIST( known ) < i or known[i] <> key  then
           erg := oper( D, key );
-          known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
-          known[i] := key;
-          known[i + 1] := erg;
+          while i < LEN_LIST( known ) and known[i] < key  do
+              i := i + 2;
+          od;
+          if LEN_LIST( known ) < i or known[i] <> key  then
+              known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
+              known[i] := key;
+              known[i + 1] := erg;
+          fi;
       fi;
       return known[i + 1];
   end ); */
@@ -2881,7 +2925,7 @@ static Obj  HdlrFunc10 (
  ENVI_FUNC( t_6 ) = TLS(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_7) = INTOBJ_INT(766);
- ENDLINE_BODY(t_7) = INTOBJ_INT(787);
+ ENDLINE_BODY(t_7) = INTOBJ_INT(792);
  FILENAME_BODY(t_7) = FileName;
  BODY_FUNC(t_6) = t_7;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -3261,8 +3305,8 @@ static Obj  HdlrFunc14 (
  t_4 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
  ENVI_FUNC( t_4 ) = TLS(CurrLVars);
  t_5 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_5) = INTOBJ_INT(855);
- ENDLINE_BODY(t_5) = INTOBJ_INT(871);
+ STARTLINE_BODY(t_5) = INTOBJ_INT(860);
+ ENDLINE_BODY(t_5) = INTOBJ_INT(876);
  FILENAME_BODY(t_5) = FileName;
  BODY_FUNC(t_4) = t_5;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -3758,9 +3802,14 @@ static Obj  HdlrFunc1 (
             od;
             if LEN_LIST( known ) < i or known[i] <> key  then
                 erg := oper( D, key );
-                known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
-                known[i] := key;
-                known[i + 1] := erg;
+                while i < LEN_LIST( known ) and known[i] < key  do
+                    i := i + 2;
+                od;
+                if LEN_LIST( known ) < i or known[i] <> key  then
+                    known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
+                    known[i] := key;
+                    known[i + 1] := erg;
+                fi;
             fi;
             return known[i + 1];
         end );
@@ -3772,7 +3821,7 @@ static Obj  HdlrFunc1 (
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  STARTLINE_BODY(t_4) = INTOBJ_INT(728);
- ENDLINE_BODY(t_4) = INTOBJ_INT(788);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(793);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -3823,8 +3872,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(823);
- ENDLINE_BODY(t_4) = INTOBJ_INT(872);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(828);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(877);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -3935,38 +3984,38 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "CallFuncList", &GF_CallFuncList );
  
  /* information for the functions */
- InitGlobalBag( &DefaultName, "GAPROOT/lib/oper1.g:DefaultName(-28903883)" );
- InitGlobalBag( &FileName, "GAPROOT/lib/oper1.g:FileName(-28903883)" );
- InitHandlerFunc( HdlrFunc1, "GAPROOT/lib/oper1.g:HdlrFunc1(-28903883)" );
- InitGlobalBag( &(NameFunc[1]), "GAPROOT/lib/oper1.g:NameFunc[1](-28903883)" );
- InitHandlerFunc( HdlrFunc2, "GAPROOT/lib/oper1.g:HdlrFunc2(-28903883)" );
- InitGlobalBag( &(NameFunc[2]), "GAPROOT/lib/oper1.g:NameFunc[2](-28903883)" );
- InitHandlerFunc( HdlrFunc3, "GAPROOT/lib/oper1.g:HdlrFunc3(-28903883)" );
- InitGlobalBag( &(NameFunc[3]), "GAPROOT/lib/oper1.g:NameFunc[3](-28903883)" );
- InitHandlerFunc( HdlrFunc4, "GAPROOT/lib/oper1.g:HdlrFunc4(-28903883)" );
- InitGlobalBag( &(NameFunc[4]), "GAPROOT/lib/oper1.g:NameFunc[4](-28903883)" );
- InitHandlerFunc( HdlrFunc5, "GAPROOT/lib/oper1.g:HdlrFunc5(-28903883)" );
- InitGlobalBag( &(NameFunc[5]), "GAPROOT/lib/oper1.g:NameFunc[5](-28903883)" );
- InitHandlerFunc( HdlrFunc6, "GAPROOT/lib/oper1.g:HdlrFunc6(-28903883)" );
- InitGlobalBag( &(NameFunc[6]), "GAPROOT/lib/oper1.g:NameFunc[6](-28903883)" );
- InitHandlerFunc( HdlrFunc7, "GAPROOT/lib/oper1.g:HdlrFunc7(-28903883)" );
- InitGlobalBag( &(NameFunc[7]), "GAPROOT/lib/oper1.g:NameFunc[7](-28903883)" );
- InitHandlerFunc( HdlrFunc8, "GAPROOT/lib/oper1.g:HdlrFunc8(-28903883)" );
- InitGlobalBag( &(NameFunc[8]), "GAPROOT/lib/oper1.g:NameFunc[8](-28903883)" );
- InitHandlerFunc( HdlrFunc9, "GAPROOT/lib/oper1.g:HdlrFunc9(-28903883)" );
- InitGlobalBag( &(NameFunc[9]), "GAPROOT/lib/oper1.g:NameFunc[9](-28903883)" );
- InitHandlerFunc( HdlrFunc10, "GAPROOT/lib/oper1.g:HdlrFunc10(-28903883)" );
- InitGlobalBag( &(NameFunc[10]), "GAPROOT/lib/oper1.g:NameFunc[10](-28903883)" );
- InitHandlerFunc( HdlrFunc11, "GAPROOT/lib/oper1.g:HdlrFunc11(-28903883)" );
- InitGlobalBag( &(NameFunc[11]), "GAPROOT/lib/oper1.g:NameFunc[11](-28903883)" );
- InitHandlerFunc( HdlrFunc12, "GAPROOT/lib/oper1.g:HdlrFunc12(-28903883)" );
- InitGlobalBag( &(NameFunc[12]), "GAPROOT/lib/oper1.g:NameFunc[12](-28903883)" );
- InitHandlerFunc( HdlrFunc13, "GAPROOT/lib/oper1.g:HdlrFunc13(-28903883)" );
- InitGlobalBag( &(NameFunc[13]), "GAPROOT/lib/oper1.g:NameFunc[13](-28903883)" );
- InitHandlerFunc( HdlrFunc14, "GAPROOT/lib/oper1.g:HdlrFunc14(-28903883)" );
- InitGlobalBag( &(NameFunc[14]), "GAPROOT/lib/oper1.g:NameFunc[14](-28903883)" );
- InitHandlerFunc( HdlrFunc15, "GAPROOT/lib/oper1.g:HdlrFunc15(-28903883)" );
- InitGlobalBag( &(NameFunc[15]), "GAPROOT/lib/oper1.g:NameFunc[15](-28903883)" );
+ InitGlobalBag( &DefaultName, "GAPROOT/lib/oper1.g:DefaultName(-61697988)" );
+ InitGlobalBag( &FileName, "GAPROOT/lib/oper1.g:FileName(-61697988)" );
+ InitHandlerFunc( HdlrFunc1, "GAPROOT/lib/oper1.g:HdlrFunc1(-61697988)" );
+ InitGlobalBag( &(NameFunc[1]), "GAPROOT/lib/oper1.g:NameFunc[1](-61697988)" );
+ InitHandlerFunc( HdlrFunc2, "GAPROOT/lib/oper1.g:HdlrFunc2(-61697988)" );
+ InitGlobalBag( &(NameFunc[2]), "GAPROOT/lib/oper1.g:NameFunc[2](-61697988)" );
+ InitHandlerFunc( HdlrFunc3, "GAPROOT/lib/oper1.g:HdlrFunc3(-61697988)" );
+ InitGlobalBag( &(NameFunc[3]), "GAPROOT/lib/oper1.g:NameFunc[3](-61697988)" );
+ InitHandlerFunc( HdlrFunc4, "GAPROOT/lib/oper1.g:HdlrFunc4(-61697988)" );
+ InitGlobalBag( &(NameFunc[4]), "GAPROOT/lib/oper1.g:NameFunc[4](-61697988)" );
+ InitHandlerFunc( HdlrFunc5, "GAPROOT/lib/oper1.g:HdlrFunc5(-61697988)" );
+ InitGlobalBag( &(NameFunc[5]), "GAPROOT/lib/oper1.g:NameFunc[5](-61697988)" );
+ InitHandlerFunc( HdlrFunc6, "GAPROOT/lib/oper1.g:HdlrFunc6(-61697988)" );
+ InitGlobalBag( &(NameFunc[6]), "GAPROOT/lib/oper1.g:NameFunc[6](-61697988)" );
+ InitHandlerFunc( HdlrFunc7, "GAPROOT/lib/oper1.g:HdlrFunc7(-61697988)" );
+ InitGlobalBag( &(NameFunc[7]), "GAPROOT/lib/oper1.g:NameFunc[7](-61697988)" );
+ InitHandlerFunc( HdlrFunc8, "GAPROOT/lib/oper1.g:HdlrFunc8(-61697988)" );
+ InitGlobalBag( &(NameFunc[8]), "GAPROOT/lib/oper1.g:NameFunc[8](-61697988)" );
+ InitHandlerFunc( HdlrFunc9, "GAPROOT/lib/oper1.g:HdlrFunc9(-61697988)" );
+ InitGlobalBag( &(NameFunc[9]), "GAPROOT/lib/oper1.g:NameFunc[9](-61697988)" );
+ InitHandlerFunc( HdlrFunc10, "GAPROOT/lib/oper1.g:HdlrFunc10(-61697988)" );
+ InitGlobalBag( &(NameFunc[10]), "GAPROOT/lib/oper1.g:NameFunc[10](-61697988)" );
+ InitHandlerFunc( HdlrFunc11, "GAPROOT/lib/oper1.g:HdlrFunc11(-61697988)" );
+ InitGlobalBag( &(NameFunc[11]), "GAPROOT/lib/oper1.g:NameFunc[11](-61697988)" );
+ InitHandlerFunc( HdlrFunc12, "GAPROOT/lib/oper1.g:HdlrFunc12(-61697988)" );
+ InitGlobalBag( &(NameFunc[12]), "GAPROOT/lib/oper1.g:NameFunc[12](-61697988)" );
+ InitHandlerFunc( HdlrFunc13, "GAPROOT/lib/oper1.g:HdlrFunc13(-61697988)" );
+ InitGlobalBag( &(NameFunc[13]), "GAPROOT/lib/oper1.g:NameFunc[13](-61697988)" );
+ InitHandlerFunc( HdlrFunc14, "GAPROOT/lib/oper1.g:HdlrFunc14(-61697988)" );
+ InitGlobalBag( &(NameFunc[14]), "GAPROOT/lib/oper1.g:NameFunc[14](-61697988)" );
+ InitHandlerFunc( HdlrFunc15, "GAPROOT/lib/oper1.g:HdlrFunc15(-61697988)" );
+ InitGlobalBag( &(NameFunc[15]), "GAPROOT/lib/oper1.g:NameFunc[15](-61697988)" );
  
  /* return success */
  return 0;
@@ -4261,7 +4310,7 @@ static StructInitInfo module = {
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,
  /* version     = */ 0,
- /* crc         = */ -28903883,
+ /* crc         = */ -61697988,
  /* initKernel  = */ InitKernel,
  /* initLibrary = */ InitLibrary,
  /* checkInit   = */ 0,

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -65,6 +65,8 @@ static GVar G_CHANGED__METHODS__OPERATION;
 static Obj  GF_CHANGED__METHODS__OPERATION;
 static GVar G_DO__NOTHING__SETTER;
 static Obj  GC_DO__NOTHING__SETTER;
+static GVar G_QUO__INT;
+static Obj  GF_QUO__INT;
 static GVar G_RETURN__TRUE;
 static Obj  GC_RETURN__TRUE;
 static GVar G_RETURN__FALSE;
@@ -143,6 +145,8 @@ static GVar G_DeclareAttribute;
 static Obj  GF_DeclareAttribute;
 static GVar G_InstallMethod;
 static Obj  GF_InstallMethod;
+static GVar G_PositionSortedOddPositions;
+static Obj  GF_PositionSortedOddPositions;
 static GVar G_CallFuncList;
 static Obj  GF_CallFuncList;
 
@@ -150,9 +154,9 @@ static Obj  GF_CallFuncList;
 static RNam R_MaxNrArgsMethod;
 
 /* information for the functions */
-static Obj  NameFunc[18];
-static Obj  NamsFunc[18];
-static Int  NargFunc[18];
+static Obj  NameFunc[19];
+static Obj  NamsFunc[19];
+static Int  NargFunc[19];
 static Obj  DefaultName;
 static Obj FileName;
 
@@ -2498,8 +2502,103 @@ static Obj  HdlrFunc9 (
  return 0;
 }
 
-/* handler for function 11 */
-static Obj  HdlrFunc11 (
+/* handler for function 10 */
+static Obj  HdlrFunc10 (
+ Obj  self,
+ Obj  a_list,
+ Obj  a_elm )
+{
+ Obj l_i = 0;
+ Obj l_j = 0;
+ Obj l_k = 0;
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Obj t_4 = 0;
+ Obj t_5 = 0;
+ Obj t_6 = 0;
+ Bag oldFrame;
+ OLD_BRK_CURR_STAT
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ REM_BRK_CURR_STAT();
+ SET_BRK_CURR_STAT(0);
+ 
+ /* k := LEN_LIST( list ) + 1; */
+ t_3 = GF_LEN__LIST;
+ t_2 = CALL_1ARGS( t_3, a_list );
+ CHECK_FUNC_RESULT( t_2 )
+ C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
+ l_k = t_1;
+ 
+ /* if k mod 2 = 0 then */
+ t_2 = MOD( l_k, INTOBJ_INT(2) );
+ t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(0) ));
+ if ( t_1 ) {
+  
+  /* k := k + 1; */
+  C_SUM_FIA( t_1, l_k, INTOBJ_INT(1) )
+  l_k = t_1;
+  
+ }
+ /* fi */
+ 
+ /* i := -1; */
+ l_i = INTOBJ_INT(-1);
+ 
+ /* while i + 2 < k od */
+ while ( 1 ) {
+  C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
+  t_1 = (Obj)(UInt)(LT( t_2, l_k ));
+  if ( ! t_1 ) break;
+  
+  /* j := 2 * QUO_INT( (i + k + 2), 4 ) - 1; */
+  t_4 = GF_QUO__INT;
+  C_SUM_FIA( t_6, l_i, l_k )
+  C_SUM_FIA( t_5, t_6, INTOBJ_INT(2) )
+  t_3 = CALL_2ARGS( t_4, t_5, INTOBJ_INT(4) );
+  CHECK_FUNC_RESULT( t_3 )
+  C_PROD_FIA( t_2, INTOBJ_INT(2), t_3 )
+  C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
+  l_j = t_1;
+  
+  /* if list[j] < elm then */
+  CHECK_INT_POS( l_j )
+  C_ELM_LIST_FPL( t_2, a_list, l_j )
+  t_1 = (Obj)(UInt)(LT( t_2, a_elm ));
+  if ( t_1 ) {
+   
+   /* i := j; */
+   l_i = l_j;
+   
+  }
+  
+  /* else */
+  else {
+   
+   /* k := j; */
+   l_k = l_j;
+   
+  }
+  /* fi */
+  
+ }
+ /* od */
+ 
+ /* return k; */
+ RES_BRK_CURR_STAT();
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return l_k;
+ 
+ /* return; */
+ RES_BRK_CURR_STAT();
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 12 */
+static Obj  HdlrFunc12 (
  Obj  self,
  Obj  a_key )
 {
@@ -2545,8 +2644,8 @@ static Obj  HdlrFunc11 (
  return 0;
 }
 
-/* handler for function 12 */
-static Obj  HdlrFunc12 (
+/* handler for function 13 */
+static Obj  HdlrFunc13 (
  Obj  self,
  Obj  a_D )
 {
@@ -2572,8 +2671,8 @@ static Obj  HdlrFunc12 (
  return 0;
 }
 
-/* handler for function 13 */
-static Obj  HdlrFunc13 (
+/* handler for function 14 */
+static Obj  HdlrFunc14 (
  Obj  self,
  Obj  a_D,
  Obj  a_key )
@@ -2608,30 +2707,11 @@ static Obj  HdlrFunc13 (
  CHECK_FUNC_RESULT( t_1 )
  l_known = t_1;
  
- /* i := 1; */
- l_i = INTOBJ_INT(1);
- 
- /* while i < LEN_LIST( known ) and known[i] < key od */
- while ( 1 ) {
-  t_4 = GF_LEN__LIST;
-  t_3 = CALL_1ARGS( t_4, l_known );
-  CHECK_FUNC_RESULT( t_3 )
-  t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
-  t_1 = t_2;
-  if ( t_1 ) {
-   CHECK_INT_POS( l_i )
-   C_ELM_LIST_FPL( t_4, l_known, l_i )
-   t_3 = (Obj)(UInt)(LT( t_4, a_key ));
-   t_1 = t_3;
-  }
-  if ( ! t_1 ) break;
-  
-  /* i := i + 2; */
-  C_SUM_FIA( t_1, l_i, INTOBJ_INT(2) )
-  l_i = t_1;
-  
- }
- /* od */
+ /* i := PositionSortedOddPositions( known, key ); */
+ t_2 = GF_PositionSortedOddPositions;
+ t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ CHECK_FUNC_RESULT( t_1 )
+ l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
@@ -2655,27 +2735,11 @@ static Obj  HdlrFunc13 (
   CHECK_FUNC_RESULT( t_1 )
   l_erg = t_1;
   
-  /* while i < LEN_LIST( known ) and known[i] < key od */
-  while ( 1 ) {
-   t_4 = GF_LEN__LIST;
-   t_3 = CALL_1ARGS( t_4, l_known );
-   CHECK_FUNC_RESULT( t_3 )
-   t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
-   t_1 = t_2;
-   if ( t_1 ) {
-    CHECK_INT_POS( l_i )
-    C_ELM_LIST_FPL( t_4, l_known, l_i )
-    t_3 = (Obj)(UInt)(LT( t_4, a_key ));
-    t_1 = t_3;
-   }
-   if ( ! t_1 ) break;
-   
-   /* i := i + 2; */
-   C_SUM_FIA( t_1, l_i, INTOBJ_INT(2) )
-   l_i = t_1;
-   
-  }
-  /* od */
+  /* i := PositionSortedOddPositions( known, key ); */
+  t_2 = GF_PositionSortedOddPositions;
+  t_1 = CALL_2ARGS( t_2, l_known, a_key );
+  CHECK_FUNC_RESULT( t_1 )
+  l_i = t_1;
   
   /* if LEN_LIST( known ) < i or known[i] <> key then */
   t_4 = GF_LEN__LIST;
@@ -2734,8 +2798,8 @@ static Obj  HdlrFunc13 (
  return 0;
 }
 
-/* handler for function 14 */
-static Obj  HdlrFunc14 (
+/* handler for function 15 */
+static Obj  HdlrFunc15 (
  Obj  self,
  Obj  a_D,
  Obj  a_key )
@@ -2769,30 +2833,11 @@ static Obj  HdlrFunc14 (
  CHECK_FUNC_RESULT( t_1 )
  l_known = t_1;
  
- /* i := 1; */
- l_i = INTOBJ_INT(1);
- 
- /* while i < LEN_LIST( known ) and known[i] < key od */
- while ( 1 ) {
-  t_4 = GF_LEN__LIST;
-  t_3 = CALL_1ARGS( t_4, l_known );
-  CHECK_FUNC_RESULT( t_3 )
-  t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
-  t_1 = t_2;
-  if ( t_1 ) {
-   CHECK_INT_POS( l_i )
-   C_ELM_LIST_FPL( t_4, l_known, l_i )
-   t_3 = (Obj)(UInt)(LT( t_4, a_key ));
-   t_1 = t_3;
-  }
-  if ( ! t_1 ) break;
-  
-  /* i := i + 2; */
-  C_SUM_FIA( t_1, l_i, INTOBJ_INT(2) )
-  l_i = t_1;
-  
- }
- /* od */
+ /* i := PositionSortedOddPositions( known, key ); */
+ t_2 = GF_PositionSortedOddPositions;
+ t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ CHECK_FUNC_RESULT( t_1 )
+ l_i = t_1;
  
  /* return i <= LEN_LIST( known ) and known[i] = key; */
  t_4 = GF_LEN__LIST;
@@ -2825,8 +2870,8 @@ static Obj  HdlrFunc14 (
  return 0;
 }
 
-/* handler for function 15 */
-static Obj  HdlrFunc15 (
+/* handler for function 16 */
+static Obj  HdlrFunc16 (
  Obj  self,
  Obj  a_D,
  Obj  a_key,
@@ -2861,30 +2906,11 @@ static Obj  HdlrFunc15 (
  CHECK_FUNC_RESULT( t_1 )
  l_known = t_1;
  
- /* i := 1; */
- l_i = INTOBJ_INT(1);
- 
- /* while i < LEN_LIST( known ) and known[i] < key od */
- while ( 1 ) {
-  t_4 = GF_LEN__LIST;
-  t_3 = CALL_1ARGS( t_4, l_known );
-  CHECK_FUNC_RESULT( t_3 )
-  t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
-  t_1 = t_2;
-  if ( t_1 ) {
-   CHECK_INT_POS( l_i )
-   C_ELM_LIST_FPL( t_4, l_known, l_i )
-   t_3 = (Obj)(UInt)(LT( t_4, a_key ));
-   t_1 = t_3;
-  }
-  if ( ! t_1 ) break;
-  
-  /* i := i + 2; */
-  C_SUM_FIA( t_1, l_i, INTOBJ_INT(2) )
-  l_i = t_1;
-  
- }
- /* od */
+ /* i := PositionSortedOddPositions( known, key ); */
+ t_2 = GF_PositionSortedOddPositions;
+ t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ CHECK_FUNC_RESULT( t_1 )
+ l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
@@ -2937,8 +2963,8 @@ static Obj  HdlrFunc15 (
  return 0;
 }
 
-/* handler for function 10 */
-static Obj  HdlrFunc10 (
+/* handler for function 11 */
+static Obj  HdlrFunc11 (
  Obj  self,
  Obj  a_name,
  Obj  a_domreq,
@@ -2976,11 +3002,11 @@ static Obj  HdlrFunc10 (
       fi;
       return;
   end; */
-  t_1 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
+  t_1 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
   ENVI_FUNC( t_1 ) = TLS(CurrLVars);
   t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
-  STARTLINE_BODY(t_2) = INTOBJ_INT(738);
-  ENDLINE_BODY(t_2) = INTOBJ_INT(742);
+  STARTLINE_BODY(t_2) = INTOBJ_INT(774);
+  ENDLINE_BODY(t_2) = INTOBJ_INT(778);
   FILENAME_BODY(t_2) = FileName;
   BODY_FUNC(t_1) = t_2;
   CHANGED_BAG( TLS(CurrLVars) );
@@ -3056,11 +3082,11 @@ static Obj  HdlrFunc10 (
  SET_LEN_PLIST( t_5, 1 );
  SET_ELM_PLIST( t_5, 1, a_domreq );
  CHANGED_BAG( t_5 );
- t_6 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
+ t_6 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
  ENVI_FUNC( t_6 ) = TLS(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_7) = INTOBJ_INT(759);
- ENDLINE_BODY(t_7) = INTOBJ_INT(759);
+ STARTLINE_BODY(t_7) = INTOBJ_INT(795);
+ ENDLINE_BODY(t_7) = INTOBJ_INT(795);
  FILENAME_BODY(t_7) = FileName;
  BODY_FUNC(t_6) = t_7;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -3093,15 +3119,10 @@ static Obj  HdlrFunc10 (
       local  known, i, erg;
       keytest( key );
       known := attr( D );
-      i := 1;
-      while i < LEN_LIST( known ) and known[i] < key  do
-          i := i + 2;
-      od;
+      i := PositionSortedOddPositions( known, key );
       if LEN_LIST( known ) < i or known[i] <> key  then
           erg := oper( D, key );
-          while i < LEN_LIST( known ) and known[i] < key  do
-              i := i + 2;
-          od;
+          i := PositionSortedOddPositions( known, key );
           if LEN_LIST( known ) < i or known[i] <> key  then
               known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
               known[i] := key;
@@ -3124,11 +3145,11 @@ static Obj  HdlrFunc10 (
  CHANGED_BAG( t_5 );
  SET_ELM_PLIST( t_5, 2, a_keyreq );
  CHANGED_BAG( t_5 );
- t_6 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
+ t_6 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
  ENVI_FUNC( t_6 ) = TLS(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_7) = INTOBJ_INT(772);
- ENDLINE_BODY(t_7) = INTOBJ_INT(798);
+ STARTLINE_BODY(t_7) = INTOBJ_INT(808);
+ ENDLINE_BODY(t_7) = INTOBJ_INT(831);
  FILENAME_BODY(t_7) = FileName;
  BODY_FUNC(t_6) = t_7;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -3158,10 +3179,7 @@ static Obj  HdlrFunc10 (
       local  known, i;
       keytest( key );
       known := attr( D );
-      i := 1;
-      while i < LEN_LIST( known ) and known[i] < key  do
-          i := i + 2;
-      od;
+      i := PositionSortedOddPositions( known, key );
       return i <= LEN_LIST( known ) and known[i] = key;
   end ); */
  t_1 = GF_InstallOtherMethod;
@@ -3176,11 +3194,11 @@ static Obj  HdlrFunc10 (
  CHANGED_BAG( t_5 );
  SET_ELM_PLIST( t_5, 2, a_keyreq );
  CHANGED_BAG( t_5 );
- t_6 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
+ t_6 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
  ENVI_FUNC( t_6 ) = TLS(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_7) = INTOBJ_INT(808);
- ENDLINE_BODY(t_7) = INTOBJ_INT(819);
+ STARTLINE_BODY(t_7) = INTOBJ_INT(841);
+ ENDLINE_BODY(t_7) = INTOBJ_INT(849);
  FILENAME_BODY(t_7) = FileName;
  BODY_FUNC(t_6) = t_7;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -3214,10 +3232,7 @@ static Obj  HdlrFunc10 (
       local  known, i;
       keytest( key );
       known := attr( D );
-      i := 1;
-      while i < LEN_LIST( known ) and known[i] < key  do
-          i := i + 2;
-      od;
+      i := PositionSortedOddPositions( known, key );
       if LEN_LIST( known ) < i or known[i] <> key  then
           known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
           known[i] := key;
@@ -3241,11 +3256,11 @@ static Obj  HdlrFunc10 (
  CHECK_BOUND( t_6, "IS_OBJECT" )
  SET_ELM_PLIST( t_5, 3, t_6 );
  CHANGED_BAG( t_5 );
- t_6 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
+ t_6 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
  ENVI_FUNC( t_6 ) = TLS(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_7) = INTOBJ_INT(828);
- ENDLINE_BODY(t_7) = INTOBJ_INT(844);
+ STARTLINE_BODY(t_7) = INTOBJ_INT(858);
+ ENDLINE_BODY(t_7) = INTOBJ_INT(871);
  FILENAME_BODY(t_7) = FileName;
  BODY_FUNC(t_6) = t_7;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -3262,8 +3277,8 @@ static Obj  HdlrFunc10 (
  return 0;
 }
 
-/* handler for function 17 */
-static Obj  HdlrFunc17 (
+/* handler for function 18 */
+static Obj  HdlrFunc18 (
  Obj  self,
  Obj  a_arg )
 {
@@ -3453,8 +3468,8 @@ static Obj  HdlrFunc17 (
  return 0;
 }
 
-/* handler for function 16 */
-static Obj  HdlrFunc16 (
+/* handler for function 17 */
+static Obj  HdlrFunc17 (
  Obj  self,
  Obj  a_arg )
 {
@@ -3622,11 +3637,11 @@ static Obj  HdlrFunc16 (
  CHECK_BOUND( l_fampred, "fampred" )
  t_3 = OBJ_LVAR( 2 );
  CHECK_BOUND( t_3, "reqs" )
- t_4 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
+ t_4 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
  ENVI_FUNC( t_4 ) = TLS(CurrLVars);
  t_5 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_5) = INTOBJ_INT(912);
- ENDLINE_BODY(t_5) = INTOBJ_INT(928);
+ STARTLINE_BODY(t_5) = INTOBJ_INT(939);
+ ENDLINE_BODY(t_5) = INTOBJ_INT(955);
  FILENAME_BODY(t_5) = FileName;
  BODY_FUNC(t_4) = t_5;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -4084,6 +4099,35 @@ static Obj  HdlrFunc1 (
  CHANGED_BAG( TLS(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
+ /* BIND_GLOBAL( "PositionSortedOddPositions", function ( list, elm )
+      local  i, j, k;
+      k := LEN_LIST( list ) + 1;
+      if k mod 2 = 0  then
+          k := k + 1;
+      fi;
+      i := -1;
+      while i + 2 < k  do
+          j := 2 * QUO_INT( (i + k + 2), 4 ) - 1;
+          if list[j] < elm  then
+              i := j;
+          else
+              k := j;
+          fi;
+      od;
+      return k;
+  end ); */
+ t_1 = GF_BIND__GLOBAL;
+ C_NEW_STRING( t_2, 26, "PositionSortedOddPositions" );
+ t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
+ ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
+ STARTLINE_BODY(t_4) = INTOBJ_INT(621);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(645);
+ FILENAME_BODY(t_4) = FileName;
+ BODY_FUNC(t_3) = t_4;
+ CHANGED_BAG( TLS(CurrLVars) );
+ CALL_2ARGS( t_1, t_2, t_3 );
+ 
  /* IsPrimeInt := "2b defined"; */
  C_NEW_STRING( t_1, 10, "2b defined" );
  AssGVar( G_IsPrimeInt, t_1 );
@@ -4116,15 +4160,10 @@ static Obj  HdlrFunc1 (
             local  known, i, erg;
             keytest( key );
             known := attr( D );
-            i := 1;
-            while i < LEN_LIST( known ) and known[i] < key  do
-                i := i + 2;
-            od;
+            i := PositionSortedOddPositions( known, key );
             if LEN_LIST( known ) < i or known[i] <> key  then
                 erg := oper( D, key );
-                while i < LEN_LIST( known ) and known[i] < key  do
-                    i := i + 2;
-                od;
+                i := PositionSortedOddPositions( known, key );
                 if LEN_LIST( known ) < i or known[i] <> key  then
                     known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
                     known[i] := key;
@@ -4140,10 +4179,7 @@ static Obj  HdlrFunc1 (
             local  known, i;
             keytest( key );
             known := attr( D );
-            i := 1;
-            while i < LEN_LIST( known ) and known[i] < key  do
-                i := i + 2;
-            od;
+            i := PositionSortedOddPositions( known, key );
             return i <= LEN_LIST( known ) and known[i] = key;
         end );
       str := "Set";
@@ -4153,10 +4189,7 @@ static Obj  HdlrFunc1 (
             local  known, i;
             keytest( key );
             known := attr( D );
-            i := 1;
-            while i < LEN_LIST( known ) and known[i] < key  do
-                i := i + 2;
-            od;
+            i := PositionSortedOddPositions( known, key );
             if LEN_LIST( known ) < i or known[i] <> key  then
                 known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
                 known[i] := key;
@@ -4168,11 +4201,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "KeyDependentOperation" );
- t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
+ t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(734);
- ENDLINE_BODY(t_4) = INTOBJ_INT(845);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(770);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(872);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -4220,11 +4253,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "RedispatchOnCondition" );
- t_3 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
+ t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
  ENVI_FUNC( t_3 ) = TLS(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
- STARTLINE_BODY(t_4) = INTOBJ_INT(880);
- ENDLINE_BODY(t_4) = INTOBJ_INT(929);
+ STARTLINE_BODY(t_4) = INTOBJ_INT(907);
+ ENDLINE_BODY(t_4) = INTOBJ_INT(956);
  FILENAME_BODY(t_4) = FileName;
  BODY_FUNC(t_3) = t_4;
  CHANGED_BAG( TLS(CurrLVars) );
@@ -4293,6 +4326,7 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "METHODS_OPERATION", &GF_METHODS__OPERATION );
  InitFopyGVar( "CHANGED_METHODS_OPERATION", &GF_CHANGED__METHODS__OPERATION );
  InitCopyGVar( "DO_NOTHING_SETTER", &GC_DO__NOTHING__SETTER );
+ InitFopyGVar( "QUO_INT", &GF_QUO__INT );
  InitCopyGVar( "RETURN_TRUE", &GC_RETURN__TRUE );
  InitCopyGVar( "RETURN_FALSE", &GC_RETURN__FALSE );
  InitFopyGVar( "LEN_LIST", &GF_LEN__LIST );
@@ -4332,45 +4366,48 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "VALUE_GLOBAL", &GF_VALUE__GLOBAL );
  InitFopyGVar( "DeclareAttribute", &GF_DeclareAttribute );
  InitFopyGVar( "InstallMethod", &GF_InstallMethod );
+ InitFopyGVar( "PositionSortedOddPositions", &GF_PositionSortedOddPositions );
  InitFopyGVar( "CallFuncList", &GF_CallFuncList );
  
  /* information for the functions */
- InitGlobalBag( &DefaultName, "GAPROOT/lib/oper1.g:DefaultName(-108220442)" );
- InitGlobalBag( &FileName, "GAPROOT/lib/oper1.g:FileName(-108220442)" );
- InitHandlerFunc( HdlrFunc1, "GAPROOT/lib/oper1.g:HdlrFunc1(-108220442)" );
- InitGlobalBag( &(NameFunc[1]), "GAPROOT/lib/oper1.g:NameFunc[1](-108220442)" );
- InitHandlerFunc( HdlrFunc2, "GAPROOT/lib/oper1.g:HdlrFunc2(-108220442)" );
- InitGlobalBag( &(NameFunc[2]), "GAPROOT/lib/oper1.g:NameFunc[2](-108220442)" );
- InitHandlerFunc( HdlrFunc3, "GAPROOT/lib/oper1.g:HdlrFunc3(-108220442)" );
- InitGlobalBag( &(NameFunc[3]), "GAPROOT/lib/oper1.g:NameFunc[3](-108220442)" );
- InitHandlerFunc( HdlrFunc4, "GAPROOT/lib/oper1.g:HdlrFunc4(-108220442)" );
- InitGlobalBag( &(NameFunc[4]), "GAPROOT/lib/oper1.g:NameFunc[4](-108220442)" );
- InitHandlerFunc( HdlrFunc5, "GAPROOT/lib/oper1.g:HdlrFunc5(-108220442)" );
- InitGlobalBag( &(NameFunc[5]), "GAPROOT/lib/oper1.g:NameFunc[5](-108220442)" );
- InitHandlerFunc( HdlrFunc6, "GAPROOT/lib/oper1.g:HdlrFunc6(-108220442)" );
- InitGlobalBag( &(NameFunc[6]), "GAPROOT/lib/oper1.g:NameFunc[6](-108220442)" );
- InitHandlerFunc( HdlrFunc7, "GAPROOT/lib/oper1.g:HdlrFunc7(-108220442)" );
- InitGlobalBag( &(NameFunc[7]), "GAPROOT/lib/oper1.g:NameFunc[7](-108220442)" );
- InitHandlerFunc( HdlrFunc8, "GAPROOT/lib/oper1.g:HdlrFunc8(-108220442)" );
- InitGlobalBag( &(NameFunc[8]), "GAPROOT/lib/oper1.g:NameFunc[8](-108220442)" );
- InitHandlerFunc( HdlrFunc9, "GAPROOT/lib/oper1.g:HdlrFunc9(-108220442)" );
- InitGlobalBag( &(NameFunc[9]), "GAPROOT/lib/oper1.g:NameFunc[9](-108220442)" );
- InitHandlerFunc( HdlrFunc10, "GAPROOT/lib/oper1.g:HdlrFunc10(-108220442)" );
- InitGlobalBag( &(NameFunc[10]), "GAPROOT/lib/oper1.g:NameFunc[10](-108220442)" );
- InitHandlerFunc( HdlrFunc11, "GAPROOT/lib/oper1.g:HdlrFunc11(-108220442)" );
- InitGlobalBag( &(NameFunc[11]), "GAPROOT/lib/oper1.g:NameFunc[11](-108220442)" );
- InitHandlerFunc( HdlrFunc12, "GAPROOT/lib/oper1.g:HdlrFunc12(-108220442)" );
- InitGlobalBag( &(NameFunc[12]), "GAPROOT/lib/oper1.g:NameFunc[12](-108220442)" );
- InitHandlerFunc( HdlrFunc13, "GAPROOT/lib/oper1.g:HdlrFunc13(-108220442)" );
- InitGlobalBag( &(NameFunc[13]), "GAPROOT/lib/oper1.g:NameFunc[13](-108220442)" );
- InitHandlerFunc( HdlrFunc14, "GAPROOT/lib/oper1.g:HdlrFunc14(-108220442)" );
- InitGlobalBag( &(NameFunc[14]), "GAPROOT/lib/oper1.g:NameFunc[14](-108220442)" );
- InitHandlerFunc( HdlrFunc15, "GAPROOT/lib/oper1.g:HdlrFunc15(-108220442)" );
- InitGlobalBag( &(NameFunc[15]), "GAPROOT/lib/oper1.g:NameFunc[15](-108220442)" );
- InitHandlerFunc( HdlrFunc16, "GAPROOT/lib/oper1.g:HdlrFunc16(-108220442)" );
- InitGlobalBag( &(NameFunc[16]), "GAPROOT/lib/oper1.g:NameFunc[16](-108220442)" );
- InitHandlerFunc( HdlrFunc17, "GAPROOT/lib/oper1.g:HdlrFunc17(-108220442)" );
- InitGlobalBag( &(NameFunc[17]), "GAPROOT/lib/oper1.g:NameFunc[17](-108220442)" );
+ InitGlobalBag( &DefaultName, "GAPROOT/lib/oper1.g:DefaultName(52080042)" );
+ InitGlobalBag( &FileName, "GAPROOT/lib/oper1.g:FileName(52080042)" );
+ InitHandlerFunc( HdlrFunc1, "GAPROOT/lib/oper1.g:HdlrFunc1(52080042)" );
+ InitGlobalBag( &(NameFunc[1]), "GAPROOT/lib/oper1.g:NameFunc[1](52080042)" );
+ InitHandlerFunc( HdlrFunc2, "GAPROOT/lib/oper1.g:HdlrFunc2(52080042)" );
+ InitGlobalBag( &(NameFunc[2]), "GAPROOT/lib/oper1.g:NameFunc[2](52080042)" );
+ InitHandlerFunc( HdlrFunc3, "GAPROOT/lib/oper1.g:HdlrFunc3(52080042)" );
+ InitGlobalBag( &(NameFunc[3]), "GAPROOT/lib/oper1.g:NameFunc[3](52080042)" );
+ InitHandlerFunc( HdlrFunc4, "GAPROOT/lib/oper1.g:HdlrFunc4(52080042)" );
+ InitGlobalBag( &(NameFunc[4]), "GAPROOT/lib/oper1.g:NameFunc[4](52080042)" );
+ InitHandlerFunc( HdlrFunc5, "GAPROOT/lib/oper1.g:HdlrFunc5(52080042)" );
+ InitGlobalBag( &(NameFunc[5]), "GAPROOT/lib/oper1.g:NameFunc[5](52080042)" );
+ InitHandlerFunc( HdlrFunc6, "GAPROOT/lib/oper1.g:HdlrFunc6(52080042)" );
+ InitGlobalBag( &(NameFunc[6]), "GAPROOT/lib/oper1.g:NameFunc[6](52080042)" );
+ InitHandlerFunc( HdlrFunc7, "GAPROOT/lib/oper1.g:HdlrFunc7(52080042)" );
+ InitGlobalBag( &(NameFunc[7]), "GAPROOT/lib/oper1.g:NameFunc[7](52080042)" );
+ InitHandlerFunc( HdlrFunc8, "GAPROOT/lib/oper1.g:HdlrFunc8(52080042)" );
+ InitGlobalBag( &(NameFunc[8]), "GAPROOT/lib/oper1.g:NameFunc[8](52080042)" );
+ InitHandlerFunc( HdlrFunc9, "GAPROOT/lib/oper1.g:HdlrFunc9(52080042)" );
+ InitGlobalBag( &(NameFunc[9]), "GAPROOT/lib/oper1.g:NameFunc[9](52080042)" );
+ InitHandlerFunc( HdlrFunc10, "GAPROOT/lib/oper1.g:HdlrFunc10(52080042)" );
+ InitGlobalBag( &(NameFunc[10]), "GAPROOT/lib/oper1.g:NameFunc[10](52080042)" );
+ InitHandlerFunc( HdlrFunc11, "GAPROOT/lib/oper1.g:HdlrFunc11(52080042)" );
+ InitGlobalBag( &(NameFunc[11]), "GAPROOT/lib/oper1.g:NameFunc[11](52080042)" );
+ InitHandlerFunc( HdlrFunc12, "GAPROOT/lib/oper1.g:HdlrFunc12(52080042)" );
+ InitGlobalBag( &(NameFunc[12]), "GAPROOT/lib/oper1.g:NameFunc[12](52080042)" );
+ InitHandlerFunc( HdlrFunc13, "GAPROOT/lib/oper1.g:HdlrFunc13(52080042)" );
+ InitGlobalBag( &(NameFunc[13]), "GAPROOT/lib/oper1.g:NameFunc[13](52080042)" );
+ InitHandlerFunc( HdlrFunc14, "GAPROOT/lib/oper1.g:HdlrFunc14(52080042)" );
+ InitGlobalBag( &(NameFunc[14]), "GAPROOT/lib/oper1.g:NameFunc[14](52080042)" );
+ InitHandlerFunc( HdlrFunc15, "GAPROOT/lib/oper1.g:HdlrFunc15(52080042)" );
+ InitGlobalBag( &(NameFunc[15]), "GAPROOT/lib/oper1.g:NameFunc[15](52080042)" );
+ InitHandlerFunc( HdlrFunc16, "GAPROOT/lib/oper1.g:HdlrFunc16(52080042)" );
+ InitGlobalBag( &(NameFunc[16]), "GAPROOT/lib/oper1.g:NameFunc[16](52080042)" );
+ InitHandlerFunc( HdlrFunc17, "GAPROOT/lib/oper1.g:HdlrFunc17(52080042)" );
+ InitGlobalBag( &(NameFunc[17]), "GAPROOT/lib/oper1.g:NameFunc[17](52080042)" );
+ InitHandlerFunc( HdlrFunc18, "GAPROOT/lib/oper1.g:HdlrFunc18(52080042)" );
+ InitGlobalBag( &(NameFunc[18]), "GAPROOT/lib/oper1.g:NameFunc[18](52080042)" );
  
  /* return success */
  return 0;
@@ -4418,6 +4455,7 @@ static Int InitLibrary ( StructInitInfo * module )
  G_METHODS__OPERATION = GVarName( "METHODS_OPERATION" );
  G_CHANGED__METHODS__OPERATION = GVarName( "CHANGED_METHODS_OPERATION" );
  G_DO__NOTHING__SETTER = GVarName( "DO_NOTHING_SETTER" );
+ G_QUO__INT = GVarName( "QUO_INT" );
  G_RETURN__TRUE = GVarName( "RETURN_TRUE" );
  G_RETURN__FALSE = GVarName( "RETURN_FALSE" );
  G_LEN__LIST = GVarName( "LEN_LIST" );
@@ -4457,6 +4495,7 @@ static Int InitLibrary ( StructInitInfo * module )
  G_VALUE__GLOBAL = GVarName( "VALUE_GLOBAL" );
  G_DeclareAttribute = GVarName( "DeclareAttribute" );
  G_InstallMethod = GVarName( "InstallMethod" );
+ G_PositionSortedOddPositions = GVarName( "PositionSortedOddPositions" );
  G_CallFuncList = GVarName( "CallFuncList" );
  
  /* record names used in handlers */
@@ -4494,28 +4533,31 @@ static Int InitLibrary ( StructInitInfo * module )
  NargFunc[9] = 6;
  NameFunc[10] = DefaultName;
  NamsFunc[10] = 0;
- NargFunc[10] = 4;
+ NargFunc[10] = 2;
  NameFunc[11] = DefaultName;
  NamsFunc[11] = 0;
- NargFunc[11] = 1;
+ NargFunc[11] = 4;
  NameFunc[12] = DefaultName;
  NamsFunc[12] = 0;
  NargFunc[12] = 1;
  NameFunc[13] = DefaultName;
  NamsFunc[13] = 0;
- NargFunc[13] = 2;
+ NargFunc[13] = 1;
  NameFunc[14] = DefaultName;
  NamsFunc[14] = 0;
  NargFunc[14] = 2;
  NameFunc[15] = DefaultName;
  NamsFunc[15] = 0;
- NargFunc[15] = 3;
+ NargFunc[15] = 2;
  NameFunc[16] = DefaultName;
  NamsFunc[16] = 0;
- NargFunc[16] = -1;
+ NargFunc[16] = 3;
  NameFunc[17] = DefaultName;
  NamsFunc[17] = 0;
  NargFunc[17] = -1;
+ NameFunc[18] = DefaultName;
+ NamsFunc[18] = 0;
+ NargFunc[18] = -1;
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
@@ -4567,6 +4609,7 @@ static Int PostRestore ( StructInitInfo * module )
  G_METHODS__OPERATION = GVarName( "METHODS_OPERATION" );
  G_CHANGED__METHODS__OPERATION = GVarName( "CHANGED_METHODS_OPERATION" );
  G_DO__NOTHING__SETTER = GVarName( "DO_NOTHING_SETTER" );
+ G_QUO__INT = GVarName( "QUO_INT" );
  G_RETURN__TRUE = GVarName( "RETURN_TRUE" );
  G_RETURN__FALSE = GVarName( "RETURN_FALSE" );
  G_LEN__LIST = GVarName( "LEN_LIST" );
@@ -4606,6 +4649,7 @@ static Int PostRestore ( StructInitInfo * module )
  G_VALUE__GLOBAL = GVarName( "VALUE_GLOBAL" );
  G_DeclareAttribute = GVarName( "DeclareAttribute" );
  G_InstallMethod = GVarName( "InstallMethod" );
+ G_PositionSortedOddPositions = GVarName( "PositionSortedOddPositions" );
  G_CallFuncList = GVarName( "CallFuncList" );
  
  /* record names used in handlers */
@@ -4641,28 +4685,31 @@ static Int PostRestore ( StructInitInfo * module )
  NargFunc[9] = 6;
  NameFunc[10] = DefaultName;
  NamsFunc[10] = 0;
- NargFunc[10] = 4;
+ NargFunc[10] = 2;
  NameFunc[11] = DefaultName;
  NamsFunc[11] = 0;
- NargFunc[11] = 1;
+ NargFunc[11] = 4;
  NameFunc[12] = DefaultName;
  NamsFunc[12] = 0;
  NargFunc[12] = 1;
  NameFunc[13] = DefaultName;
  NamsFunc[13] = 0;
- NargFunc[13] = 2;
+ NargFunc[13] = 1;
  NameFunc[14] = DefaultName;
  NamsFunc[14] = 0;
  NargFunc[14] = 2;
  NameFunc[15] = DefaultName;
  NamsFunc[15] = 0;
- NargFunc[15] = 3;
+ NargFunc[15] = 2;
  NameFunc[16] = DefaultName;
  NamsFunc[16] = 0;
- NargFunc[16] = -1;
+ NargFunc[16] = 3;
  NameFunc[17] = DefaultName;
  NamsFunc[17] = 0;
  NargFunc[17] = -1;
+ NameFunc[18] = DefaultName;
+ NamsFunc[18] = 0;
+ NargFunc[18] = -1;
  
  /* return success */
  return 0;
@@ -4677,7 +4724,7 @@ static StructInitInfo module = {
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,
  /* version     = */ 0,
- /* crc         = */ -108220442,
+ /* crc         = */ 52080042,
  /* initKernel  = */ InitKernel,
  /* initLibrary = */ InitLibrary,
  /* checkInit   = */ 0,


### PR DESCRIPTION
add setter and tester operations for KeyDependentOperations

This should make it easier to handle the problems raised in #412 and #511. 

In the long run, it might be a good idea to "undocument" the Computed… attribute itself, and maybe replace it by a dictionary object.

This PR also fixes a potential problem when computing a value, the Computed… attribute gets changed (because the called method computed other attribute values on the way, etc).


