### PR TITLE
Revert gasman to non-HPC gap version

### DIFF
--- a/src/gasman.c
+++ b/src/gasman.c
@@ -111,41 +111,15 @@
 **  already dead.
 */
 #include        <string.h>
-#include        <stdlib.h>
-#include        <stdio.h>
 #include        "system.h"              /* Ints, UInts                     */
 
 
 
 #include        "gasman.h"              /* garbage collector               */
 
-#ifdef BOEHM_GC
-
-#define LARGE_GC_SIZE (8192 * sizeof(UInt))
-#define TL_GC_SIZE (256 * sizeof(UInt))
-
-#ifndef DISABLE_GC
-#include <gc/gc.h>
-#include <gc/gc_inline.h>
-#include <gc/gc_typed.h>
-#include <gc/gc_mark.h>
-#else
-#include <stdlib.h>
-#endif
-#endif
-
-
 #include        "objects.h"             /* objects                         */
 #include        "scanner.h"             /* scanner                         */
 
-#include	"code.h"		/* coder                           */
-#include	"hpc/thread.h"		/* threads			   */
-#include	"hpc/tls.h"			/* thread-local storage		   */
-#ifdef TRACK_CREATOR
-/* Need CURR_FUNC and NAME_FUNC() */
-#include        "calls.h"               /* calls                           */
-#include        "vars.h"                /* variables                       */
-#endif
 
 
 
@@ -236,6 +210,21 @@
 /* This could be 65536, but would waste memory in various tables */
 
 #define NTYPES 256
+
+
+/* These variables are here so they can be accessed by
+ * hpc_boehm_gc.h
+ */
+
+TNumMarkFuncBags TabMarkFuncBags [ NTYPES ];
+
+
+/* Several functions in this file are guarded by #ifndef BOEHM_GC.
+ * hpc_boehm_gc.h contains replacements of those functions for when
+ * gasman is not in use */
+#ifdef BOEHM_GC
+#include       "hpc_boehm_gc.h"         /* boehm-specific code             */
+#endif
 
 /****************************************************************************
 **
@@ -478,6 +467,7 @@ UInt                    NrDeadBags;
 UInt                    SizeDeadBags;
 UInt                    NrHalfDeadBags;
 
+
 /****************************************************************************
 **
 *V  InfoBags[<type>]  . . . . . . . . . . . . . . . . .  information for bags
@@ -503,14 +493,13 @@ static inline UInt IS_BAG (
 **  'InitMsgsFuncBags'  simply  stores  the  printing  function  in a  global
 **  variable.
 */
+#ifndef BOEHM_GC
 TNumMsgsFuncBags        MsgsFuncBags;
 
 void            InitMsgsFuncBags (
     TNumMsgsFuncBags    msgs_func )
 {
-#ifndef BOEHM_GC
     MsgsFuncBags = msgs_func;
-#endif
 }
 
 
@@ -526,7 +515,6 @@ void InitSweepFuncBags (
     UInt                type,
     TNumSweepFuncBags    sweep_func )
 {
-#ifndef BOEHM_GC
 #ifdef CHECK_FOR_CLASH_IN_INIT_SWEEP_FUNC
     char                str[256];
 
@@ -542,8 +530,10 @@ void InitSweepFuncBags (
     }
 #endif
     TabSweepFuncBags[type] = sweep_func;
-#endif
 }
+
+#endif
+
 
 #if ITANIUM
 extern void * ItaniumRegisterStackTop();
@@ -572,19 +562,13 @@ static void ItaniumSpecialMarkingInit() {
 **  'MarkAllSubBagsDefault' is the same  as 'MarkAllSubBags' but is only used
 **  by GASMAN as default.  This will allow to catch type clashes.
 */
-TNumMarkFuncBags TabMarkFuncBags [ NTYPES ];
-#ifdef BOEHM_GC
-int TabMarkTypeBags [ NTYPES ];
-#endif
 
 
+#ifndef BOEHM_GC
 void InitMarkFuncBags (
     UInt                type,
     TNumMarkFuncBags    mark_func )
 {
-#ifdef BOEHM_GC
-    int mark_type;
-#endif
 #ifdef CHECK_FOR_CLASH_IN_INIT_MARK_FUNC
     char                str[256];
 
@@ -600,25 +584,8 @@ void InitMarkFuncBags (
     }
 #endif
     TabMarkFuncBags[type] = mark_func;
-#ifdef BOEHM_GC
-    if (mark_func == MarkNoSubBags)
-      mark_type = 0;
-    else if (mark_func == MarkAllSubBags)
-      mark_type = -1;
-    else if (mark_func == MarkOneSubBags)
-      mark_type = 1;
-    else if (mark_func == MarkTwoSubBags)
-      mark_type = 2;
-    else if (mark_func == MarkThreeSubBags)
-      mark_type = 3;
-    else if (mark_func == MarkFourSubBags)
-      mark_type = 4;
-    else
-      mark_type = -1;
-    TabMarkTypeBags[type] = mark_type;
-#endif
 }
-
+#endif
 
 void MarkNoSubBags (
     Bag                 bag )
@@ -718,13 +685,6 @@ void MarkBagWeakly(
 }
 
 
-#ifdef BOEHM_GC
-static GC_descr GCDesc[MAX_GC_PREFIX_DESC+1];
-static unsigned GCKind[MAX_GC_PREFIX_DESC+1];
-static GC_descr GCMDesc[MAX_GC_PREFIX_DESC+1];
-static unsigned GCMKind[MAX_GC_PREFIX_DESC+1];
-#endif
-
 
 /****************************************************************************
 **
@@ -734,19 +694,18 @@ static unsigned GCMKind[MAX_GC_PREFIX_DESC+1];
 **  walking the masterpointer area. Not terribly safe.
 **
 */
-
+#ifndef BOEHM_GC
 void CallbackForAllBags(
      void (*func)(Bag) )
 {
-#ifndef BOEHM_GC
   Bag ptr;
   for (ptr = (Bag)MptrBags; ptr < (Bag)OldBags; ptr ++)
     if (*ptr != 0 && !IS_WEAK_DEAD_BAG(ptr) && (Bag)(*ptr) >= (Bag)OldBags)
       {
         (*func)(ptr);
       }
-#endif
 }
+#endif
 
 
 /****************************************************************************
@@ -783,13 +742,12 @@ void ClearGlobalBags ( void )
   WarnInitGlobalBag = 0;
   return;
 }
-#endif
 
 void InitGlobalBag (
     Bag *               addr,
     const Char *        cookie )
 {
-#ifndef BOEHM_GC
+
     if ( GlobalBags.nr == NR_GLOBAL_BAGS ) {
         (*AbortFuncBags)(
             "Panic: Gasman cannot handle so many global variables" );
@@ -813,12 +771,10 @@ void InitGlobalBag (
     GlobalBags.cookie[GlobalBags.nr] = cookie;
     GlobalBags.nr++;
     GlobalSortingStatus = 0;
-#endif
 }
 
 
 
-#ifndef BOEHM_GC
 static Int IsLessGlobal (
     const Char *        cookie1,
     const Char *        cookie2,
@@ -836,13 +792,11 @@ static Int IsLessGlobal (
     return 1;
   return strcmp(cookie1, cookie2) < 0;
 }
-#endif
 
 
 
 void SortGlobals( UInt byWhat )
 {
-#ifndef BOEHM_GC
   const Char *tmpcookie;
   Bag * tmpaddr;
   UInt len, h, i, k;
@@ -876,7 +830,6 @@ void SortGlobals( UInt byWhat )
   }
   GlobalSortingStatus = byWhat;
   return;
-#endif
 }
 
 
@@ -884,7 +837,6 @@ void SortGlobals( UInt byWhat )
 Bag * GlobalByCookie(
        const Char * cookie )
 {
-#ifndef BOEHM_GC
   UInt i,top,bottom,middle;
   Int res;
   if (cookie == 0L)
@@ -917,9 +869,6 @@ Bag * GlobalByCookie(
       }
       return (Bag *)0L;
     }
-#else
-    return (Bag *) 0;
-#endif /* !BOEHM_GC */
 }
 
 
@@ -928,7 +877,6 @@ extern TNumAllocFuncBags       AllocFuncBags;
 
 void StartRestoringBags( UInt nBags, UInt maxSize)
 {
-#ifndef BOEHM_GC
   UInt target;
   Bag *newmem;
 /*Bag *ptr; */
@@ -954,12 +902,10 @@ void StartRestoringBags( UInt nBags, UInt maxSize)
   SizeAllBags = 0;
   NrAllBags = 0;
   return;
-#endif
 }
 
 Bag NextBagRestoring( UInt size, UInt type)
 {
-#ifndef BOEHM_GC
   Bag bag;
   UInt i;
   *(Bag **)NextMptrRestoring = (AllocBags+HEADER_SIZE);
@@ -995,14 +941,10 @@ Bag NextBagRestoring( UInt size, UInt type)
   SizeAllBags += size;
   NrAllBags ++;
   return bag;
-#else
-  return 0;
-#endif
 }
 
 void FinishedRestoringBags( void )
 {
-#ifndef BOEHM_GC
   Bag p;
 /*  Bag *ptr; */
   YoungBags = AllocBags;
@@ -1020,11 +962,9 @@ void FinishedRestoringBags( void )
   NrHalfDeadBags = 0;
   ChangedBags = 0;
   return;
-#endif
 }
 
 
-#ifndef BOEHM_GC
 /****************************************************************************
 **
 *F  InitFreeFuncBag(<type>,<free-func>) . . . . . .  install freeing function
@@ -1047,7 +987,6 @@ void            InitFreeFuncBag (
     }
     TabFreeFuncBags[type] = free_func;
 }
-#endif
 
 
 /****************************************************************************
@@ -1064,10 +1003,8 @@ void            InitCollectFuncBags (
     TNumCollectFuncBags before_func,
     TNumCollectFuncBags after_func )
 {
-#ifndef BOEHM_GC
     BeforeCollectFuncBags = before_func;
     AfterCollectFuncBags  = after_func;
-#endif
 }
 
 
@@ -1081,10 +1018,8 @@ void            InitCollectFuncBags (
 
 void FinishBags( void )
 {
-#ifndef BOEHM_GC
   (*AllocFuncBags)(-(sizeof(Bag)*SizeWorkspace/1024),2);
   return;
-#endif
 }
 
 /****************************************************************************
@@ -1110,53 +1045,6 @@ UInt                    DirtyBags;
 
 TNumAbortFuncBags       AbortFuncBags;
 
-#ifdef BOEHM_GC
-
-/*
- * Build memory layout information for Boehm GC.
- *
- * Bitmapped type descriptors have a bit set if the word at the
- * corresponding offset may contain a reference. This is done
- * by first creating a bitmap and then using GC_make_descriptor()
- * to build a descriptor from the bitmap. Memory for a specific
- * type layout can be allocated with GC_malloc_explicitly_typed()
- * and GC_malloc_explicitly_typed_ignore_off_page().
- *
- * We also create a new 'kind' for each collector. Kinds have their
- * own associated free lists and do not require to have type information
- * stored in each bag, thus potentially saving some memory. Allocating
- * memory of a specific kind is done with GC_generic_malloc(). There
- * is no public _ignore_off_page() version for this call, so we use
- * GC_malloc_explicitly_typed_ignore_off_page() instead, given that
- * the overhead is negligible for large objects.
- */
-
-void BuildPrefixGCDescriptor(unsigned prefix_len) {
-
-  if (prefix_len) {
-    GC_word bits[1] = {0};
-    unsigned i;
-    for (i=0; i<prefix_len; i++)
-      GC_set_bit(bits, (i + HEADER_SIZE));
-    GCDesc[prefix_len] = GC_make_descriptor(bits, prefix_len + HEADER_SIZE);
-    GC_set_bit(bits, 0);
-    GCMDesc[prefix_len] = GC_make_descriptor(bits, prefix_len + HEADER_SIZE);
-  } else {
-    GCDesc[prefix_len] = GC_DS_LENGTH;
-    GCMDesc[prefix_len] = GC_DS_LENGTH | sizeof(void *);
-  }
-  GCKind[prefix_len] = GC_new_kind(GC_new_free_list(), GCDesc[prefix_len],
-    0, 1);
-  GCMKind[prefix_len] = GC_new_kind(GC_new_free_list(), GCMDesc[prefix_len],
-    0, 0);
-}
-
-#endif
-
-#ifdef BOEHM_GC
-static void TLAllocatorInit(void);
-#endif
-
 void            InitBags (
     TNumAllocFuncBags   alloc_func,
     UInt                initial_size,
@@ -1167,9 +1055,8 @@ void            InitBags (
     UInt                dirty,
     TNumAbortFuncBags   abort_func )
 {
-    UInt                i;              /* loop variable                   */
-#ifndef BOEHM_GC
     Bag *               p;              /* loop variable                   */
+    UInt                i;              /* loop variable                   */
 
     ClearGlobalBags();
     WarnInitGlobalBag = 0;
@@ -1223,140 +1110,12 @@ void            InitBags (
     DirtyBags = dirty;
 
     /* install the marking functions                                       */
-    for ( i = 0; i < 255; i++ ) {
+    for ( i = 0; i < 255; i++ )
         TabMarkFuncBags[i] = MarkAllSubBagsDefault;
-    }
 
     /* Set ChangedBags to a proper initial value */
     ChangedBags = 0;
-#else /* BOEHM_GC */
-    /* install the marking functions                                       */
-    for ( i = 0; i < 255; i++ ) {
-        TabMarkFuncBags[i] = MarkAllSubBagsDefault;
-	TabMarkTypeBags[i] = -1;
-    }
-#ifndef DISABLE_GC
-    if (!getenv("GC_MARKERS")) {
-      /* The Boehm GC does not have an API to set the number of
-       * markers for the parallel mark and sweep implementation,
-       * so we use the documented environment variable GC_MARKERS
-       * instead. However, we do not override it if it's already
-       * set.
-       */
-      static char marker_env_str[32];
-      unsigned num_markers = 2;
-      extern UInt SyNumProcessors;
-      extern UInt SyNumGCThreads;
-      if (!SyNumGCThreads)
-        SyNumGCThreads = SyNumProcessors;
-      if (SyNumGCThreads) {
-        if (SyNumGCThreads <= MAX_GC_THREADS)
-	  num_markers = (unsigned) SyNumProcessors;
-	else
-	  num_markers = MAX_GC_THREADS;
-      }
-      sprintf(marker_env_str, "GC_MARKERS=%u", num_markers);
-      putenv(marker_env_str);
-    }
-    GC_set_all_interior_pointers(0);
-    GC_init();
-    TLAllocatorInit();
-    GC_register_displacement(0);
-    GC_register_displacement(HEADER_SIZE*sizeof(Bag));
-    initial_size *= 1024;
-    if (GC_get_heap_size() < initial_size)
-      GC_expand_hp(initial_size - GC_get_heap_size());
-    if (SyStorKill)
-      GC_set_max_heap_size(SyStorKill * 1024);
-    AddGCRoots();
-    CreateMainRegion();
-    for (i=0; i<=MAX_GC_PREFIX_DESC; i++) {
-      BuildPrefixGCDescriptor(i);
-      /* This is necessary to initialize some internal structures
-       * in the garbage collector: */
-      GC_generic_malloc((HEADER_SIZE + i) * sizeof(UInt), GCMKind[i]);
-    }
-#endif /* DISABLE_GC */
-#endif /* BOEHM_GC */
-}
 
-#ifdef BOEHM_GC
-
-#define GRANULE_SIZE (2 * sizeof(UInt))
-
-static unsigned char TLAllocatorSeg[TL_GC_SIZE / GRANULE_SIZE + 1];
-static unsigned TLAllocatorSize[TL_GC_SIZE / GRANULE_SIZE];
-static UInt TLAllocatorMaxSeg;
-
-static void TLAllocatorInit(void) {
-  unsigned stage = 16;
-  unsigned inc = 1;
-  unsigned i = 0;
-  unsigned k = 0;
-  unsigned j;
-  unsigned max = TL_GC_SIZE / GRANULE_SIZE;
-  while (i <= max) {
-    if (i == stage) {
-      stage *= 2;
-      inc *= 2;
-    }
-    TLAllocatorSize[k] = i * GRANULE_SIZE;
-    TLAllocatorSeg[i] = k;
-    for (j=1; j<inc; j++) {
-      if (i + j <= max)
-        TLAllocatorSeg[i+j] = k+1;
-    }
-    i += inc;
-    k ++;
-  }
-  TLAllocatorMaxSeg = k;
-  if (MAX_GC_PREFIX_DESC * sizeof(void *) > sizeof(TLS(FreeList)))
-    abort();
-}
-
-/****************************************************************************
-**
-*F  AllocateBagMemory( <gc_type>, <type>, <size> )
-**
-**  Allocate memory for a new bag.
-**
-**  'AllocateBagMemory' is an auxiliary routine for the Boehm GC that
-**  allocates memory from the appropriate pool. 'gc_type' is -1 if all words
-**  in the bag can refer to other bags, 0 if the bag will not contain any
-**  references to other bags, and > 0 to indicate a specific memory layout
-**  descriptor.
-**/
-void *AllocateBagMemory(int gc_type, int type, UInt size)
-{
-    void *result = NULL;
-    if (size <= TL_GC_SIZE) {
-      UInt alloc_seg, alloc_size;
-      alloc_size = (size + GRANULE_SIZE - 1 ) / GRANULE_SIZE;
-      alloc_seg = TLAllocatorSeg[alloc_size];
-      alloc_size = TLAllocatorSize[alloc_seg];
-      if (!TLS(FreeList)[gc_type+1])
-        TLS(FreeList)[gc_type+1] =
-	  GC_malloc(sizeof(void *) * TLAllocatorMaxSeg);
-      if (!(result = TLS(FreeList)[gc_type+1][alloc_seg])) {
-        if (gc_type < 0)
-	  TLS(FreeList)[0][alloc_seg] = GC_malloc_many(alloc_size);
-	else
-	  GC_generic_malloc_many(alloc_size, GCMKind[gc_type],
-	    &TLS(FreeList)[gc_type+1][alloc_seg]);
-	result = TLS(FreeList)[gc_type+1][alloc_seg];
-      }
-      TLS(FreeList)[gc_type+1][alloc_seg] = *(void **)result;
-      memset(result, 0, alloc_size);
-    } else {
-      if (gc_type >= 0)
-        result = GC_generic_malloc(size, GCKind[gc_type]);
-      else
-        result = GC_malloc(size);
-    }
-    if (TabFinalizerFuncBags[type])
-      GC_register_finalizer_no_order(result, StandardFinalizer,
-	NULL, NULL, NULL);
-    return result;
 }
 #endif
 
@@ -1399,17 +1158,14 @@ void *AllocateBagMemory(int gc_type, int type, UInt size)
 **  local  variables  of the function.  To  enable  statistics only {\Gasman}
 **  needs to be recompiled.
 */
+#ifndef BOEHM_GC
 Bag NewBag (
     UInt                type,
     UInt                size )
 {
     Bag                 bag;            /* identifier of the new bag       */
     Bag *               dst;            /* destination of the new bag      */
-#ifdef BOEHM_GC
-    UInt		alloc_size;
-#endif
 
-#ifndef BOEHM_GC
 #ifdef TREMBLE_HEAP
     CollectBags(0,0);
 #endif
@@ -1439,60 +1195,6 @@ Bag NewBag (
     dst       = AllocBags;
     AllocBags = dst + HEADER_SIZE + WORDS_BAG(size);
     ADD_CANARY();
-#else /* BOEHM_GC */
-    alloc_size = HEADER_SIZE*sizeof(Bag) + size;
-#ifndef DISABLE_GC
-#ifndef TRACK_CREATOR
-    bag = GC_malloc(2*sizeof(Bag *));
-#else
-    bag = GC_malloc(4*sizeof(Bag *));
-    if (TLS(PtrLVars)) {
-      bag[2] = (void *)(CURR_FUNC);
-      if (TLS(CurrLVars) != TLS(BottomLVars)) {
-        Obj plvars = ADDR_OBJ(TLS(CurrLVars))[2];
-	bag[3] = (void *) (ADDR_OBJ(plvars)[0]);
-      }
-    }
-#endif
-    /* If the size of an object is zero (such as an empty permutation),
-     * and the header size is a multiple of twice the word size of the
-     * architecture, then the master pointer will actually point past
-     * the allocated area. Because this would result in the object
-     * being freed prematurely, we will allocate at least one extra
-     * byte so that the master pointer actually points to within an
-     * allocated memory area.
-     */
-    if (size == 0)
-      alloc_size++;
-    /* While we use the Boehm GC without the "all interior pointers"
-     * option, stack references to the interior of an object will
-     * still be valid from any reference on the stack. This can lead,
-     * for example, to a 1GB string never being freed if there's an
-     * integer on the stack that happens to also be a reference to
-     * any character inside that string. The garbage collector does
-     * this because after compiler optimizations (especially reduction
-     * in strength) references to the beginning of an object may be
-     * lost.
-     *
-     * However, this is not generally a risk with GAP objects, because
-     * master pointers on the heap will always retain a reference to
-     * the start of the object (or, more precisely, to the first byte
-     * past the header area). Hence, compiler optimizations pose no
-     * actual risk unless the master pointer is destroyed also.
-     *
-     * To avoid the scenario where large objects do not get deallocated,
-     * we therefore use the _ignore_off_page() calls. One caveat here
-     * is that these calls do not use thread-local allocation, making
-     * them somewhat slower. Hence, we only use them for sufficiently
-     * large objects.
-     */
-    dst = AllocateBagMemory(TabMarkTypeBags[type], type, alloc_size);
-#else
-    bag = malloc(2*sizeof(Bag *));
-    dst = malloc(alloc_size);
-    memset(dst, 0, alloc_size);
-#endif /* DISABLE_GC */
-#endif /* BOEHM_GC */
 
     /* enter size-type words                                               */
 #ifdef USE_NEWSHAPE
@@ -1555,37 +1257,17 @@ void            RetypeBag (
           InfoBags[old_type].sizeAll  -= size;
           InfoBags[new_type].sizeAll  += size;
     }
-#else
-#ifdef BOEHM_GC
-    UInt old_type = TNUM_BAG(bag);
-#endif
 #endif
 
     /* change the size-type word                                           */
 #ifdef USE_NEWSHAPE
-    *(*bag-HEADER_SIZE) &= 0xFFFFFFFFFFFF0000L;
+    *(*bag-HEADER_SIZE) &= 0xFFFFFFFFFFFFFF00L;
     *(*bag-HEADER_SIZE) |= new_type;
 #else
     *(*bag-HEADER_SIZE) = new_type;
 #endif
-#ifdef BOEHM_GC
-    {
-      int old_gctype, new_gctype;
-      UInt size;
-      void *new_mem, *old_mem;
-      old_gctype = TabMarkTypeBags[old_type];
-      new_gctype = TabMarkTypeBags[new_type];
-      if (old_gctype != new_gctype) {
-        size = SIZE_BAG(bag) + HEADER_SIZE * sizeof(Bag);
-	new_mem = AllocateBagMemory(new_gctype, new_type, size);
-	old_mem = PTR_BAG(bag);
-	old_mem = ((char *) old_mem) - HEADER_SIZE * sizeof(Bag);
-	memcpy(new_mem, old_mem, size);
-	PTR_BAG(bag) = (void *)(((char *)new_mem) + HEADER_SIZE * sizeof(Bag));
-      }
-    }
-#endif
 }
+#endif
 
 
 /****************************************************************************
@@ -1661,7 +1343,7 @@ void            RetypeBag (
 **  If {\Gasman}  was compiled with the  option 'COUNT_BAGS' then 'ResizeBag'
 **  also updates the information in 'InfoBags' (see "InfoBags").
 */
-
+#ifndef BOEHM_GC
    UInt ResizeBag (
     Bag                 bag,
     UInt                new_size )
@@ -1670,11 +1352,7 @@ void            RetypeBag (
     UInt                old_size;       /* old size of the bag             */
     Bag *               dst;            /* destination in copying          */
     Bag *               src;            /* source in copying               */
-#ifndef BOEHM_GC
     Bag *               end;            /* end in copying                  */
-#else
-    UInt                alloc_size;
-#endif
 
     /* check the size                                                      */
 
@@ -1694,30 +1372,7 @@ void            RetypeBag (
     SizeAllBags             += new_size - old_size;
 
     /* if the real size of the bag doesn't change                          */
-#ifndef BOEHM_GC
     if ( WORDS_BAG(new_size) == WORDS_BAG(old_size) ) {
-#else
-#ifndef DISABLE_GC
-    alloc_size = GC_size(PTR_BAG(bag)-HEADER_SIZE);
-    /* An alternative implementation would be to compare
-     * new_size <= alloc_size in the following test in order
-     * to avoid reallocations for alternating contractions
-     * and expansions. However, typed allocation in the Boehm
-     * GC stores layout information in the last word of a memory
-     * block and we may accidentally overwrite this information,
-     * because GC_size() includes that extraneous word when
-     * returning the size of a memory block.
-     *
-     * This is technically a bug in GC_size(), but until and
-     * unless there is an upstream fix, we'll do it the safe
-     * way.
-     */
-    if ( new_size <= old_size
-         && HEADER_SIZE*sizeof(Bag) + new_size >= alloc_size * 3/4) {
-#else
-    if (new_size <= old_size) {
-#endif /* DISABLE_GC */
-#endif
 
         /* change the size word                                            */
 #ifdef USE_NEWSHAPE
@@ -1730,7 +1385,6 @@ void            RetypeBag (
     /* if the bag is shrunk                                                */
     /* we must not shrink the last bag by moving 'AllocBags',              */
     /* since the remainder may not be zero filled                          */
-#ifndef BOEHM_GC
     else if ( WORDS_BAG(new_size) < WORDS_BAG(old_size) ) {
 
       /* leave magic size-type word for the sweeper, type must be 255    */
@@ -1780,11 +1434,10 @@ void            RetypeBag (
       *(*bag-2) = new_size;
 #endif
     }
-#endif /* !BOEHM_GC */
+
     /* if the bag is enlarged                                              */
     else {
 
-#ifndef BOEHM_GC
         /* check that enough storage for the new bag is available          */
         if ( SizeAllocationArea <  HEADER_SIZE+WORDS_BAG(new_size)
           && CollectBags( new_size, 0 ) == 0 ) {
@@ -1795,29 +1448,13 @@ void            RetypeBag (
         dst       = AllocBags;
         AllocBags = dst + HEADER_SIZE + WORDS_BAG(new_size);
         ADD_CANARY();
-#else
-        alloc_size = HEADER_SIZE*sizeof(Bag) + new_size;
-        if (new_size == 0)
-            alloc_size++;
-#ifndef DISABLE_GC
-        dst = AllocateBagMemory(TabMarkTypeBags[type], type, alloc_size);
-#else
-        dst       = malloc( alloc_size );
-        memset(dst, 0, alloc_size);
-#endif
-#endif
-
         /* leave magic size-type word  for the sweeper, type must be 255   */
 #ifdef USE_NEWSHAPE
-#ifndef BOEHM_GC
         *(*bag-2) = (((WORDS_BAG(old_size)+1) * sizeof(Bag))) << 16 | 255;
-#endif
         *dst++ = (Bag)(new_size << 16 | type);
 #else
-#ifndef BOEHM_GC
         *(*bag-3) = 255;
         *(*bag-2) = (((WORDS_BAG(old_size)+2) * sizeof(Bag)));
-#endif
 
         /* enter the new size-type word                                    */
 
@@ -1825,13 +1462,12 @@ void            RetypeBag (
         *dst++ = (Bag)new_size;
 #endif
 
-
-#ifndef BOEHM_GC
         CANARY_DISABLE_VALGRIND();
         /* if the bag is already on the changed bags list, keep it there   */
         if ( PTR_BAG(bag)[-1] != bag ) {
             *dst++ = PTR_BAG(bag)[-1];
         }
+
 
         /* if the bag is old, put it onto the changed bags list            */
         else if ( PTR_BAG(bag) <= YoungBags ) {
@@ -1843,27 +1479,15 @@ void            RetypeBag (
             *dst++ = bag;
         }
 	    CANARY_ENABLE_VALGRIND();
-#else
-        *dst++ = bag;
-#endif
+
         /* set the masterpointer                                           */
         src = PTR_BAG(bag);
-#ifndef BOEHM_GC
         end = src + WORDS_BAG(old_size);
-#endif
         PTR_BAG(bag) = dst;
 
-#ifndef BOEHM_GC
         /* copy the contents of the bag                                    */
         while ( src < end )
             *dst++ = *src++;
-#else
-        if (dst != src) {
-            memcpy( dst, src, old_size < new_size ? old_size : new_size );
-        } else if (new_size < old_size) {
-            memset(dst+new_size, 0, old_size - new_size);
-        }
-#endif
 
     }
 
@@ -2073,7 +1697,6 @@ void            RetypeBag (
 **  the sweep functions have done their work then no  references to these bag
 **  identifiers can exist, and so 'CollectBags' frees these masterpointers.
 */
-#ifndef BOEHM_GC
 
 syJmp_buf RegsBags;
 
@@ -2134,15 +1757,12 @@ not look like valid pointers, and should be congruent to 1 mod sizeof(Bag) */
 Bag * NewWeakDeadBagMarker = (Bag *)(1000*sizeof(Bag) + 1L);
 Bag * OldWeakDeadBagMarker = (Bag *)(1001*sizeof(Bag) + 1L);
 
-#endif /* !BOEHM_GC */
-
 
 
 UInt CollectBags (
     UInt                size,
     UInt                full )
 {
-#ifndef BOEHM_GC
     Bag                 first;          /* first bag on a linked list      */
     Bag *               p;              /* loop variable                   */
     Bag *               dst;            /* destination in sweeping         */
@@ -2733,12 +2353,6 @@ again:
 
     /* return success                                                      */
     return 1;
-#else
-#ifndef DISABLE_GC
-    GC_gcollect();
-#endif
-    return 1;
-#endif
 }
 
 
@@ -2748,7 +2362,6 @@ again:
 **
 */
 
-#ifndef BOEHM_GC
 void CheckMasterPointers( void )
 {
   Bag *ptr;


### PR DESCRIPTION
This patch looks very big, but if you diff with an earlier commit (picking an example, b58f57695100d2803beeac5a2782b8da99b5bed3 ), then you will find this just backs out an earlier HPC-GAP gasman merge.

The only addition now is some functions are surrounded by `#ifndef BOEHM_GC`, and if that macro is defined an extra header is included which pulls in replacements for these functions (this file isn't in GAP yet, only HPC-GAP).

This allows us to cleanly separate the HPCGAP and gasman garbage collectors.