### PR TITLE
Move SCRSift into the kernel

### DIFF
--- a/lib/stbcrand.gi
+++ b/lib/stbcrand.gi
@@ -659,26 +659,40 @@ end );
 ##
 ##  tries to factor g as product of cosetreps in S; returns remainder
 ##
-InstallGlobalFunction( SCRSift, function ( S, g )
-    local stb,   # the stabilizer of S we currently work with
-          bpt;   # first point of stb.orbit
+ SCRSiftOld :=  function ( S, g )
+     local stb,   # the stabilizer of S we currently work with
+           bpt;   # first point of stb.orbit
 
-    stb := S;
-    while IsBound( stb.stabilizer ) do
-        bpt := stb.orbit[1];
-        if IsBound( stb.transversal[bpt^g] ) then
-            while bpt <> bpt^g do
-                g := g*stb.transversal[bpt^g];
-            od;
-            stb := stb.stabilizer;
-        else
-            #current g witnesses that input was not in S
-            return g;
-        fi;
-    od;
+     stb := S;
+     while IsBound( stb.stabilizer ) do
+         bpt := stb.orbit[1];
+         if IsBound( stb.transversal[bpt^g] ) then
+             while bpt <> bpt^g do
+                 g := g*stb.transversal[bpt^g];
+             od;
+             stb := stb.stabilizer;
+         else
+             #current g witnesses that input was not in S
+             return g;
+         fi;
+     od;
 
-    return g;
-end );
+     return g;
+ end;
+ 
+ 
+ 
+ InstallGlobalFunction( SCRSift, function(S,g)
+     local result;
+     
+#     return SCRSiftOld(S, g);
+     
+     result :=  SCR_SIFT_HELPER(S, g, Maximum(LargestMovedPoint(g),LargestMovedPoint(S!.generators)));
+     
+#     Assert(2,result = SCRSiftOld(S, g));
+     return result;
+end);
+
 
 
 #############################################################################

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -4750,6 +4750,7 @@ Obj FuncSCR_SIFT_HELPER(Obj self, Obj S, Obj g, Obj n)
   Obj result;
   Obj t;
   Obj trans;
+  int i;
 
   /* Setup the result, sort out which rep we are going to work in  */
   if (nn > 65535) {
@@ -4775,26 +4776,26 @@ Obj FuncSCR_SIFT_HELPER(Obj self, Obj S, Obj g, Obj n)
   if (IS_PERM2(g) && useP2) {
     UInt2 * ptR = ADDR_PERM2(result);
     memmove(ptR,ADDR_PERM2(g),2*dg);
-    for (int i = dg; i < nn; i++)
+    for ( i = dg; i < nn; i++)
       ptR[i] = (UInt2)i;
   } else if (IS_PERM4(g) && !useP2) {
     UInt4 *ptR = ADDR_PERM4(result);
     memmove(ptR,ADDR_PERM4(g),4*dg);    
-    for (int i = dg; i <nn; i++)
+    for ( i = dg; i <nn; i++)
       ptR[i] = (UInt4)i;
   } else if (IS_PERM2(g) && !useP2) {
     UInt4 *ptR = ADDR_PERM4(result);
     UInt2 *ptG = ADDR_PERM2(g);
-    for (int i = 0; i < dg; i++)
+    for ( i = 0; i < dg; i++)
       ptR[i] = (UInt4)ptG[i];
-    for (int i = dg; i < nn; i++)
+    for (i = dg; i < nn; i++)
       ptR[i] = (UInt4)i;
   } else {
     UInt2 *ptR = ADDR_PERM2(result);
     UInt4 *ptG = ADDR_PERM4(g);
-    for (int i = 0; i < dg; i++)
+    for ( i = 0; i < dg; i++)
       ptR[i] = (UInt2)ptG[i];
-    for (int i = dg; i < nn; i++)
+    for (i = dg; i < nn; i++)
       ptR[i] = (UInt2)i;
   }    
     
@@ -4826,20 +4827,20 @@ Obj FuncSCR_SIFT_HELPER(Obj self, Obj S, Obj g, Obj n)
 	    UInt2 *ptT = ADDR_PERM2(t);
 	    UInt dt = DEG_PERM2(t);
 	    if (dt >= nn)
-	      for (int i = 0; i < nn; i++) 
+	      for (i = 0; i < nn; i++) 
 		ptR[i] = ptT[ptR[i]];
 	    else
-	      for (int i = 0; i < nn; i++)
+	      for ( i = 0; i < nn; i++)
 		ptR[i] = IMAGE(ptR[i], ptT, dt);
 	  }
 	  else {
 	    UInt4 *ptT = ADDR_PERM4(t);
 	    UInt dt = DEG_PERM4(t);
 	    if (dt >= nn)
-	      for (int i = 0; i < nn; i++)
+	      for ( i = 0; i < nn; i++)
 		ptR[i] = (UInt2) ptT[ptR[i]];
 	    else
-	      for (int i = 0; i < nn; i++)
+	      for ( i = 0; i < nn; i++)
 		ptR[i] = (UInt2)IMAGE(ptR[i], ptT, dt);
 	  }
 	  im = (Int)ptR[bpt];
@@ -4849,20 +4850,20 @@ Obj FuncSCR_SIFT_HELPER(Obj self, Obj S, Obj g, Obj n)
 	    UInt2 *ptT = ADDR_PERM2(t);
 	    UInt dt = DEG_PERM2(t);
 	    if (dt >= nn)
-	      for (int i = 0; i < nn; i++)
+	      for ( i = 0; i < nn; i++)
 		ptR[i] = (UInt4)ptT[ptR[i]];
 	    else
-	      for (int i = 0; i < nn; i++)
+	      for ( i = 0; i < nn; i++)
 		ptR[i] = (UInt4)IMAGE(ptR[i], ptT, dt);
 	  }
 	  else {
 	    UInt4 *ptT = ADDR_PERM4(t);
 	    UInt dt = DEG_PERM4(t);
 	    if (dt >= nn)
-	      for (int i = 0; i < nn; i++)
+	      for ( i = 0; i < nn; i++)
 		ptR[i] = ptT[ptR[i]];
 	    else
-	      for (int i = 0; i < nn; i++)
+	      for ( i = 0; i < nn; i++)
 		ptR[i] = IMAGE(ptR[i], ptT, dt);
 	  }
 	  im = (Int)ptR[bpt];

--- a/src/permutat.h
+++ b/src/permutat.h
@@ -32,6 +32,9 @@
 
 #define IMAGE(i,pt,dg)  (((i) < (dg)) ? (pt)[(i)] : (i))
 
+#define IS_PERM2(perm)  (TNUM_OBJ(perm) == T_PERM2)
+#define IS_PERM4(perm)  (TNUM_OBJ(perm) == T_PERM4)
+
 /****************************************************************************
 **
 *V  IdentityPerm  . . . . . . . . . . . . . . . . . . .  identity permutation

--- a/tst/teststandard/stabchain.tst
+++ b/tst/teststandard/stabchain.tst
@@ -4,6 +4,8 @@
 ##
 ##
 ##  Test orbit algorithms, which use hashing
+##  Also a few direct tests of SCRSift, since I have been working on it.
+##     SL
 ##  Exclude from testinstall.g: why?
 ##
 gap> START_TEST("stabchain.tst");
@@ -27,6 +29,20 @@ gap> while not IsDoneIterator(it) do NextIterator(it); od;;
 gap> l := List(it2);;
 gap> Length(l);
 3628795
+gap> SCRSift(S,(1,2));
+()
+gap> SCRSift(S,(1,11));
+(1,11)
+gap> SCRSift(S,(1,10));
+()
+gap> m := MathieuGroup(24);;
+gap> S := StabChain(m,[1..24]);
+<stabilizer chain record, Base [ 1, 2, 3, 4, 5, 6, 7 ], Orbit length 
+24, Size: 244823040>
+gap> SCRSift(S,(1,2));
+(8,11)(9,21)(12,23)(14,16)(17,22)(18,24)(19,20)
+gap> SCRSift(S,GeneratorsOfGroup(m)[1]);
+()
 gap> STOP_TEST( "stabchain.tst", 130120000);
 
 #############################################################################


### PR DESCRIPTION
Gains about 30% in time but massively reduces the amount of memory allocated, with consequent reduction of garbage collection time

