### PR TITLE
Some small enhancements on Sylow and Hall subgroup computations

### DIFF
--- a/grp/basicmat.gi
+++ b/grp/basicmat.gi
@@ -538,6 +538,7 @@ SylowSubgroupOfNaturalGL := function( gl, p )
   SetSize( syl, p^PadicValuation( Size(gl), p ) );
   SetIsPGroup( syl, true );
   SetPrimePGroup( syl, p );
+  SetHallSubgroup(gl, [p], syl);
   Assert( 2, Size( Group( GeneratorsOfGroup( syl ) ) ) = Size( syl ) );
   return syl;
 end;

--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -212,6 +212,7 @@ function ( G, p )
     if Size( S ) > 1 then
         SetIsPGroup( S, true );
         SetPrimePGroup( S, p );
+        SetHallSubgroup(G, [p], S);
     fi;
 
     # return the Sylow subgroup
@@ -1574,6 +1575,7 @@ local   S,          # <p>-Sylow subgroup of <G>, result
     if Size( S ) > 1 then
         SetIsPGroup( S, true );
         SetPrimePGroup( S, p );
+        SetHallSubgroup(G, [p], S);
     fi;
 
     # return the Sylow subgroup

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -2649,6 +2649,13 @@ end);
 ##  <p> subgroup of <G>.  This is the core of the <p> Sylow subgroups.
 ##
 InstallMethod( PCoreOp,
+    "generic method for nilpotent group and prime",
+    [ IsGroup and IsNilpotentGroup, IsPosInt ],
+    function ( G, p )
+    return SylowSubgroup( G, p );
+    end );
+
+InstallMethod( PCoreOp,
     "generic method for group and prime",
     [ IsGroup, IsPosInt ],
     function ( G, p )

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -2820,6 +2820,27 @@ InstallMethod (HallSubgroupOp, "test trivial cases", true,
     end);
 
 
+#############################################################################
+##
+#M  HallSubgroupOp( <G>, <p> ) . . . . . . . . . . . . for a nilpotent group
+##
+InstallMethod( HallSubgroupOp,
+    "method for a nilpotent group",
+    [ IsGroup and IsNilpotentGroup, IsList ],
+    function( G, pi )
+    local p, smallpi, S;
+
+    S := TrivialSubgroup(G);
+    smallpi := [];
+    for p in pi do
+      AddSet(smallpi, p);
+      S := ClosureSubgroupNC(S, SylowSubgroup(G, p));
+      SetHallSubgroup(G, smallpi, S);
+    od;
+    return S;
+    end );
+
+
 ############################################################################
 ##
 #M  SylowComplementOp (<grp>, <p>)

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -2656,7 +2656,7 @@ end);
 ##
 InstallMethod( PCoreOp,
     "generic method for nilpotent group and prime",
-    [ IsGroup and IsNilpotentGroup, IsPosInt ],
+    [ IsGroup and IsNilpotentGroup and IsFinite, IsPosInt ],
     function ( G, p )
     return SylowSubgroup( G, p );
     end );
@@ -2770,7 +2770,7 @@ InstallMethod( SylowSubgroupOp,
 ##
 InstallMethod( SylowSubgroupOp,
     "method for a nilpotent group, and a prime",
-    [ IsGroup and IsNilpotentGroup, IsPosInt ],
+    [ IsGroup and IsNilpotentGroup and IsFinite, IsPosInt ],
     function( G, p )
     local gens, g, ord, S;
 
@@ -2834,7 +2834,7 @@ InstallMethod (HallSubgroupOp, "test trivial cases", true,
 ##
 InstallMethod( HallSubgroupOp,
     "method for a nilpotent group",
-    [ IsGroup and IsNilpotentGroup, IsList ],
+    [ IsGroup and IsNilpotentGroup and IsFinite, IsList ],
     function( G, pi )
     local p, smallpi, S;
 

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -2830,7 +2830,7 @@ InstallMethod (HallSubgroupOp, "test trivial cases", true,
 
 #############################################################################
 ##
-#M  HallSubgroupOp( <G>, <p> ) . . . . . . . . . . . . for a nilpotent group
+#M  HallSubgroupOp( <G>, <pi> ) . . . . . . . . . . . . for a nilpotent group
 ##
 InstallMethod( HallSubgroupOp,
     "method for a nilpotent group",

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1587,6 +1587,8 @@ function( G )
         comp[i] := SubgroupByPcgs( G, sub );
         SetIsPGroup( comp[i], true );
         SetPrimePGroup( comp[i], primes[i] );
+        SetSylowSubgroup(G, primes[i], comp[i]);
+        SetHallSubgroup(G, [primes[i]], comp[i]);
     od;
     return comp;
 end );
@@ -1614,6 +1616,10 @@ function( G )
                            x -> weights[x][3] in pis[i] )};
         sub  := InducedPcgsByPcSequenceNC( spec, gens );
         comp[i] := SubgroupByPcgs( G, sub );
+        SetHallSubgroup(G, pis[i], comp[i]);
+        if Length(pis[i])=1 then
+            SetSylowSubgroup(G, pis[i][1], comp[i]);
+        fi;
     od;
     return comp;
 end );
@@ -2783,6 +2789,8 @@ InstallMethod( SylowSubgroupOp,
     if Size(S) > 1 then
         SetIsPGroup( S, true );
         SetPrimePGroup( S, p );
+        SetHallSubgroup(G, [p], S);
+        SetPCore(G, p, S);
     fi;
     return S;
     end );

--- a/lib/grppcatr.gi
+++ b/lib/grppcatr.gi
@@ -270,7 +270,7 @@ function( G, p )
     for i in [1..Length(spec)] do
         if weights[i][3] <> p then
             Add( gens, spec[i] );
-            Add( pi, weights[i][3] );
+            AddSet( pi, weights[i][3] );
         fi;
     od;
     gens := InducedPcgsByPcSequenceNC( spec, gens );

--- a/lib/grppcatr.gi
+++ b/lib/grppcatr.gi
@@ -261,16 +261,24 @@ InstallMethod( SylowComplementOp,
     80,
 
 function( G, p )
-    local   spec,  weights,  gens,  i,  S;
+    local   spec,  weights,  gens,  i,  S,  pi;
 
     spec := SpecialPcgs( G );
     weights := LGWeights( spec );
     gens := [];
+    pi := [];
     for i in [1..Length(spec)] do
-        if weights[i][3] <> p then Add( gens, spec[i] ); fi;
+        if weights[i][3] <> p then
+            Add( gens, spec[i] );
+            Add( pi, weights[i][3] );
+        fi;
     od;
     gens := InducedPcgsByPcSequenceNC( spec, gens );
     S := SubgroupByPcgs( G, gens );
+    SetHallSubgroup( G, pi, S );
+    if Length( pi ) = 1 then
+        SetSylowSubgroup( G, pi[1], S );
+    fi;
     return S;
 end );
 
@@ -306,6 +314,7 @@ function( G, p )
     if Size(S) > 1 then
         SetIsPGroup( S, true );
         SetPrimePGroup( S, p );
+        SetHallSubgroup(G, [p], S);
     fi;
     return S;
 end );

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -1420,6 +1420,7 @@ local   S;
   if Size(S) > 1 then
     SetIsPGroup( S, true );
     SetPrimePGroup( S, p );
+    SetHallSubgroup(G, [p], S);
   fi;
   return S;
 end );

--- a/lib/grpprmcs.gi
+++ b/lib/grpprmcs.gi
@@ -1366,7 +1366,7 @@ InstallMethod( PCoreOp,
             factorsize, # the sizes of factor groups in composition series
             index,      # loop variable running through the indices of
                         # subgroups in the composition series
-            pri,primes, # list of primes in the factorization of numbers
+            primes,     # list of primes in the factorization of numbers
             ppart,      # p-part of Size(G)
             homlist,    # list of homomorphisms applied to workgroup
             lenhomlist, # length of homlist
@@ -1390,8 +1390,7 @@ InstallMethod( PCoreOp,
             pgenlist;   # list of generators for the p-core
 
     # handle trivial cases
-    pri := FactorsInt(p);
-    if Length(pri) > 1  then
+    if not IsPrime(p)  then
         return TrivialSubgroup(workgroup);
     fi;
     if IsTrivial(workgroup)  then

--- a/lib/grpprmcs.gi
+++ b/lib/grpprmcs.gi
@@ -1415,6 +1415,8 @@ InstallMethod( PCoreOp,
            if ppart > 1 then
                SetIsPGroup( D, true );
                SetPrimePGroup( D, p );
+               SetSylowSubgroup( workgroup, p, D );
+               SetHallSubgroup( workgroup, [p], D );
            fi;
            return D;
     fi;

--- a/tst/testinstall/sylowhall.tst
+++ b/tst/testinstall/sylowhall.tst
@@ -1,0 +1,97 @@
+gap> START_TEST("sylowhall.tst");
+gap> G := GL(3,4);; PrimeDivisors(Size(G));
+[ 2, 3, 5, 7 ]
+gap> IdGroup(SylowSubgroup(G, 2));
+[ 64, 242 ]
+gap> IdGroup(SylowSubgroup(G, 3));
+[ 81, 7 ]
+gap> IdGroup(SylowSubgroup(G, 5));
+[ 5, 1 ]
+gap> IdGroup(SylowSubgroup(G, 7));
+[ 7, 1 ]
+gap> SylowSystem(G);
+fail
+gap> HallSystem(G);
+fail
+gap> fine := true;; for p in PrimeDivisors(Size(G)) do fine := fine and HasHallSubgroup(G, [p]); od; fine;
+true
+gap> G := GL(4,3);; PrimeDivisors(Size(G));
+[ 2, 3, 5, 13 ]
+gap> HallSubgroup(G, [2, 3, 5, 13]) = G;
+true
+gap> fine := true;; for p in PrimeDivisors(Size(G)) do fine := fine and HallSubgroup(G, [p]) = SylowSubgroup(G, p); od; fine;
+true
+gap> IsTrivial(HallSubgroup(G, [7, 11, 17]));
+true
+gap> D := DihedralGroup(24);;
+gap> IdGroup(SylowSubgroup(D,2));
+[ 8, 3 ]
+gap> PCore(D, 2)=D;
+false
+gap> IdGroup(PCore(D, 2));
+[ 4, 1 ]
+gap> HasHallSubgroup(D,[2]) and HallSubgroup(D,[2]) = SylowSubgroup(D,2);
+true
+gap> SylowComplement(D,2)=HallSubgroup(D,[3]);
+true
+gap> SylowComplement(D,2)=SylowSubgroup(D,3);
+true
+gap> SylowComplement(D,5)=D;
+true
+gap> A := AlternatingGroup(4);;
+gap> SylowComplement(A, 3)=Group((1,2)(3,4), (1,3)(2,4));
+true
+gap> G := SmallGroup(8,4);; SylowComplement(G,5)=G;
+true
+gap> IsTrivial(SylowComplement(G,2));
+true
+gap> G := SmallGroup(1080, 248);;
+gap> List(SylowSystem(G), Size);
+[ 8, 27, 5 ]
+gap> fine := true;; for p in PrimeDivisors(Size(G)) do fine := fine and HasSylowSubgroup(G, p); od; fine;
+true
+gap> HasHallSubgroup(G,[2]) and HasHallSubgroup(G,[2]) and HasHallSubgroup(G,[5]);
+true
+gap> HasHallSubgroup(G, [2, 5]);
+false
+gap> IdGroup(HallSubgroup(G, [2,5]));
+[ 40, 10 ]
+gap> PCore(G,2) = SylowSubgroup(G,2);
+true
+gap> G := SmallGroup(1080, 248);; IsNilpotentGroup(G);
+true
+gap> PCore(G,2) = SylowSubgroup(G,2);
+true
+gap> G := SmallGroup(1080, 248);;
+gap> List(HallSystem(G), Size);
+[ 1, 8, 216, 1080, 40, 27, 135, 5 ]
+gap> fine := true;; for pi in Combinations(PrimeDivisors(Size(G))) do fine := fine and HasHallSubgroup(G, pi); od; fine;
+true
+gap> HasSylowComplement(G, 2);
+false
+gap> SylowComplement(G, 2)=HallSubgroup(G, [3,5]);
+true
+gap> IdGroup(HallSubgroup(AlternatingGroup(5), [2,3]));
+[ 12, 3 ]
+gap> IdGroup(SylowSubgroup(Group((1,2),(1,2,3,4,5)), 2));
+[ 8, 3 ]
+gap> IdGroup(PCore(Group(()), 2));
+[ 1, 1 ]
+gap> PCore(Group((1,2),(1,2,3,4,5)), 2) = PCore(Group((1,2),(1,2,3,4,5)), 7);
+true
+gap> G := Group((1,3),(1,2,3,4), (5,6,7));;
+gap> PCore(G, 2) = Group((1,3),(1,2,3,4));
+true
+gap> F := FreeGroup("x", "y");; x := F.1;; y := F.2;;
+gap> G := F/[x*y*x^(-1)*y^(-1), x^30, (x*y)^70];;
+gap> IdGroup(SylowSubgroup(G, 2));
+[ 4, 2 ]
+gap> IdGroup(HallSubgroup(G, [2,3]));
+[ 12, 5 ]
+gap> IsAbelian(G);
+true
+gap> IdGroup(SylowSubgroup(G, 5));
+[ 25, 2 ]
+gap> IdGroup(HallSubgroup(G, [5,7]));
+[ 175, 2 ]
+gap> STOP_TEST("sylowhall.tst", 10000);


### PR DESCRIPTION
This PR is supposed to address #412 and #511

Added PCore and HallSubgroup methods for nilpotent groups. 

Used SetHallSubgroup and SetSylowSubgroup to store computed Hall subgroups and Sylow subgroups. 

About the nilpotent group method, I am rather unsatisfied at the moment, because the pcgs methods are currently ranked higher. If the method would be installed for finite nilpotent groups, then it would rank higher. Should an extra method for finite nilpotent groups be added, or maybe should the nilpotent method be artificially ranked higher? 