### PR TITLE
Dense FILTERS

### DIFF
--- a/lib/list.gd
+++ b/lib/list.gd
@@ -507,14 +507,14 @@ InstallTrueMethod( IsSortedList, IsSSortedList );
 InstallTrueMethod( IsSSortedList, IsList and IsEmpty );
 
 
-#T #############################################################################
-#T ##
-#T #p  IsNSortedList( <list> )
-#T ##
-#T ##  returns `true' if the list <list> is not sorted (see~"IsSortedList").
-#T ##
-#T DeclarePropertyKernel( "IsNSortedList", IsDenseList, IS_NSORT_LIST );
-#T (is currently not really supported)
+ #############################################################################
+ ##
+ #p  IsNSortedList( <list> )
+ ##
+ ##  returns `true' if the list <list> is not sorted (see~"IsSortedList").
+ ##
+ DeclarePropertyKernel( "IsNSortedList", IsDenseList, IS_NSORT_LIST );
+
 
 
 #############################################################################

--- a/lib/macfloat.g
+++ b/lib/macfloat.g
@@ -13,7 +13,9 @@
 ##
 
 #############################################################################
-DeclareRepresentation("IsIEEE754FloatRep", IsFloat and IsInternalRep and IS_MACFLOAT,[]);
+DeclareRepresentation("IsIEEE754FloatRep", IsFloat and IsInternalRep 
+        #and IS_MACFLOAT
+        ,[]);
 
 BIND_GLOBAL("IEEE754FloatsFamily", NewFamily("IEEE754FloatsFamily", IsIEEE754FloatRep));
 

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -483,8 +483,8 @@ Obj FuncFREXP_MACFLOAT( Obj self, Obj f)
 */
 static StructGVarFilt GVarFilts [] = {
 
-    { "IS_MACFLOAT", "obj", &IsMacfloatFilt,
-      IsMacfloatHandler, "src/macfloat.c:IS_MACFLOAT" },
+  /*    { "IS_MACFLOAT", "obj", &IsMacfloatFilt,
+	IsMacfloatHandler, "src/macfloat.c:IS_MACFLOAT" }, */
 
     { 0 }
 


### PR DESCRIPTION
The list FILTERS had a few holes which arose from filters declared in the kernel but never 
"ratified" by DeclareXXXXKernel calls. The PR fixes this by deleting IS_MACFLOAT (never used) and 
uncommented a DeclarePropertyKernel call for IsNSortedList (used in a few places).

