### PR TITLE
Remove some left-over calls to SyStr* functions

### DIFF
--- a/src/gvars.c
+++ b/src/gvars.c
@@ -305,7 +305,7 @@ void            AssGVar (
 	if ( val != 0 && TNUM_OBJ(val) == T_FUNCTION && NAME_FUNC(val) == 0 ) {
 	    name = NameGVar(gvar);
 	    /*CCC        onam = NEW_STRING(strlen(name));
-	      SyStrncat( CSTR_STRING(onam), name, strlen(name) ); CCC*/
+	      strncat( CSTR_STRING(onam), name, strlen(name) ); CCC*/
 	    len = strlen(name);
 	    C_NEW_STRING_DYN(onam, name);
 	    RESET_FILT_LIST( onam, FN_IS_MUTABLE );

--- a/src/hpc/gapmpi.c
+++ b/src/hpc/gapmpi.c
@@ -93,8 +93,8 @@ Obj UNIX_Hostname( Obj self )
   if (res == -1) {
     perror("UNIX_Hostname: ");
     sprintf( buf, "<unknown name>"); }
-  host = NEW_STRING( SyStrlen(buf) ); /* NEW_STRING() allows for extra '\0' */
-  SyStrncat( CSTR_STRING(host), buf, SyStrlen(buf) );
+  host = NEW_STRING( strlen(buf) ); /* NEW_STRING() allows for extra '\0' */
+  strncat( CSTR_STRING(host), buf, strlen(buf) );
   return host;
 }
 
@@ -434,7 +434,7 @@ Obj MPIsend( Obj self, Obj args )
   tag = ( LEN_LIST(args) > 2 ? ELM_LIST( args, 3 ) : 0 );
   ConvString( buf );
   MPI_Send( ((char*)CSTR_STRING(buf)),
-			SyStrlen((const Char*)CSTR_STRING(buf)), /* don't incl. \0 */
+			strlen((const Char*)CSTR_STRING(buf)), /* don't incl. \0 */
 			MPIdatatype_infer(buf), INT_INTOBJ(dest), INT_INTOBJ(tag),
 			MPI_COMM_WORLD);
   return 0;
@@ -469,7 +469,7 @@ Obj MPIrecv2( Obj self, Obj args )
   buf = NEW_STRING( count);
   ConvString( buf );
   /* Note GET_LEN_STRING() returns GAP string length
-     and SyStrlen(CSTR_STRING()) returns C string length (up to '\0') */
+     and strlen(CSTR_STRING()) returns C string length (up to '\0') */
   MPI_Recv( CSTR_STRING(buf), GET_LEN_STRING(buf),
             MPI_CHAR,
             INT_INTOBJ(source), INT_INTOBJ(tag), MPI_COMM_WORLD, &last_status);
@@ -492,7 +492,7 @@ Obj MPIrecv( Obj self, Obj args )
       ErrorQuit("MPI_Recv():  received a buffer that is not a string", 0L, 0L);
   ConvString( buf );
   /* Note GET_LEN_STRING() returns GAP string length
-	 and SyStrlen(CSTR_STRING()) returns C string length (up to '\0') */
+	 and strlen(CSTR_STRING()) returns C string length (up to '\0') */
   if ( ! MPI_READ_ERROR() )
     MPI_Recv( CSTR_STRING(buf), GET_LEN_STRING(buf),
 	     last_datatype=MPIdatatype_infer(buf),


### PR DESCRIPTION
Apparently, gapmpi.c is never even compiled in our test setup, or else this should have produced compiler errors. Makes me wonder if we should add another Jenkins builds, which builds HPC-GAP with mpi enabled?
