### PR TITLE
Don't change assertion level in START_TEST and STOP_TEST.

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -465,7 +465,8 @@ BindGlobal( "Matrix_CharacteristicPolynomialSameField",
             vec[i] := zero;
         fi;
     od;
-    Assert(3, IsZero(Value(cp,imat)));
+    #    Assert(3, IsZero(Value(cp,imat))); We can't do this because Value involves powering
+    #    which uses the CharacteristicPolynomial
     Assert(2, Length(CoefficientsOfUnivariatePolynomial(cp)) = n+1);
     Info(InfoMatrix,1,"Characteristic Polynomial returns ", cp);
     return cp;

--- a/lib/profile.g
+++ b/lib/profile.g
@@ -1076,10 +1076,6 @@ START_TEST := function( name )
     GASMAN( "collect" );
     GAPInfo.TestData.START_TIME := Runtime();
     GAPInfo.TestData.START_NAME := name;
-    GAPInfo.TestData.AssertionLevel:= AssertionLevel();
-    if GAPInfo.TestData.AssertionLevel < 2 then
-        SetAssertionLevel( 2 );
-    fi;
 end;
 
 STOP_TEST := function( file, fac )
@@ -1096,8 +1092,6 @@ STOP_TEST := function( file, fac )
     else
       Print( "GAP4stones: infinity\n" );
     fi;
-    SetAssertionLevel( GAPInfo.TestData.AssertionLevel );
-    Unbind( GAPInfo.TestData.AssertionLevel );
     Unbind( GAPInfo.TestData.START_TIME );
     Unbind( GAPInfo.TestData.START_NAME );
 end;


### PR DESCRIPTION
As discussed in #527 simply don't set assertion levels in the standard START_TEST and STOP_TEST.
Anyone who really wants to do this can call SetAssertionLevel before starting tests, or patch START_TEST and STOP_TEST when the need to.
