### PR TITLE
Enhance MaximalNormalSubgroups for finite solvable groups

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -4232,6 +4232,15 @@ InstallMethod( MaximalNormalSubgroups,
 
 end);
 
+#############################################################################
+##
+#M  MaximalNormalSubgroups( <G> )
+##
+InstallMethod( MaximalNormalSubgroups, "for simple groups",
+              [ IsGroup and IsSimpleGroup ], SUM_FLAGS,
+              function(G) return [ TrivialSubgroup(G) ]; end);
+
+
 ##############################################################################
 ##
 #F  MinimalNormalSubgroups(<G>)

--- a/lib/grppcatr.gi
+++ b/lib/grppcatr.gi
@@ -466,6 +466,62 @@ end );
 
 #############################################################################
 ##
+#M  MaximalNormalSubgroups( <G> )
+##
+InstallMethod( MaximalNormalSubgroups, "for finite solvable groups",
+              [ IsGroup ],
+              RankFilter( IsGroup and CanComputeSize and IsFinite
+                          and IsSolvableGroup ) - RankFilter( IsGroup ),
+
+  function( G )
+    local GF,     # FactorGroup of G
+          MaxGF,  # MaximalNormalSubgroups of GF
+          max,    # MaximalNormalSubgroups of G
+          SS,     # SylowSystem of G
+          N,      # a maximal normal subgroup
+          i, j;   # loop variables
+
+    if not CanComputeSize(G) or not IsFinite(G) or not IsSolvableGroup(G)
+    then
+      # not a finite solvable group
+      TryNextMethod();
+    elif not IsAbelian(G) then
+      # every maximal normal subgroup is above the derived subgroup
+      GF := CommutatorFactorGroup(G);
+      MaxGF := MaximalNormalSubgroups(GF);
+      # currently MaximalNormalSubgroups returns a list, not a set
+      return List(MaxGF, N -> PreImage(NaturalHomomorphism(GF), N));
+    elif not IsPGroup(G) then
+      # maximal normal is maximal in one Sylow multiplied by the other Sylows
+      SS := SylowSystem(G);
+      max := [ ];
+      for i in [1..Length(SS)] do
+        for N in MaximalNormalSubgroups(SS[i]) do
+          for j in [1..Length(SS)] do
+            if j<>i then
+              N := ClosureSubgroupNC(N, SS[j]);
+            fi;
+          od;
+          Add(max, N);
+        od;
+      od;
+      return max;
+    elif not IsElementaryAbelian(G) then
+      # every maximal subgroup is normal, hence above the Frattini subgroup
+      GF := FactorGroup(G, FrattiniSubgroup(G));
+      MaxGF := MaximalNormalSubgroups(GF);
+      return List(MaxGF, N -> PreImage(NaturalHomomorphism(GF), N));
+    else
+      # for elementary abelian groups return all maximal subgroups
+      # NormalMaximalSubgroups seems to omit some unnecessary checks,
+      # hence faster than MaximalSubgroups
+      return NormalMaximalSubgroups(G);
+    fi;
+  end);
+
+
+#############################################################################
+##
 #F  ModifyMinGens( <pcgsG>, <pcgsS>, <pcgsL>, <min> )
 ##
 ModifyMinGens := function( pcgs, pcgsS, pcgsL, min )

--- a/lib/grppcatr.gi
+++ b/lib/grppcatr.gi
@@ -496,8 +496,8 @@ InstallMethod( MaximalNormalSubgroups, "for solvable groups",
       fi;
     elif IsSolvableGroup(G) then
       # every maximal normal subgroup is above the derived subgroup
-      Gf := CommutatorFactorGroup(G);
-      hom := NaturalHomomorphism(Gf);
+      hom := MaximalAbelianQuotient(G);
+      Gf := Image(hom);
       MaxGf := MaximalNormalSubgroups(Gf);
       return List(MaxGf, N -> PreImage(hom, N));
     else

--- a/lib/grppcatr.gi
+++ b/lib/grppcatr.gi
@@ -486,7 +486,7 @@ InstallMethod( MaximalNormalSubgroups, "for solvable groups",
         # convert it to an Abelian PcGroup with same invariants
         Gf := AbelianGroup(IsPcGroup, AbelianInvariants(G));
         hom := IsomorphismGroups(G, Gf);
-        MaxGf := MaximalNormalSubgroups(Gf);
+        MaxGf := NormalMaximalSubgroups(Gf);
         return List(MaxGf, N -> PreImage(hom, N));
       else
         # for abelian pc groups return all maximal subgroups

--- a/tst/testinstall/opers/MaximalNormalSubgroups.tst
+++ b/tst/testinstall/opers/MaximalNormalSubgroups.tst
@@ -10,12 +10,39 @@ gap> List(MaximalNormalSubgroups(G),N ->List(MinimalGeneratingSet(N),Order));
   [ 2, 20, 12600 ], [ 2, 20, 12600 ], [ 2, 20, 12600 ], [ 2, 60, 2520 ], 
   [ 2, 12, 12600 ], [ 2, 12, 12600 ], [ 2, 12, 12600 ], [ 2, 12, 12600 ], 
   [ 2, 12, 12600 ], [ 2, 60, 1800 ] ]
-gap> D := DihedralGroup(Factorial(10));;
-gap> List(MaximalNormalSubgroups(G), StructureDescription);
-[ "C6300 x C60 x C2", "C12600 x C30 x C2", "C12600 x C30 x C2", 
-  "C12600 x C60", "C12600 x C60", "C12600 x C60", "C12600 x C60", 
-  "C4200 x C60 x C2", "C12600 x C20 x C2", "C12600 x C20 x C2", 
-  "C12600 x C20 x C2", "C2520 x C60 x C2", "C12600 x C12 x C2", 
-  "C12600 x C12 x C2", "C12600 x C12 x C2", "C12600 x C12 x C2", 
-  "C12600 x C12 x C2", "C1800 x C60 x C2" ]
+gap> A := AbelianGroup(IsFpGroup, [2,4,8,3,9,5,25,7]);;
+gap> List(MaximalNormalSubgroups(A),N -> AbelianInvariants(N));
+[ [ 2, 3, 4, 4, 5, 7, 9, 25 ], [ 2, 2, 3, 5, 7, 8, 9, 25 ], 
+  [ 2, 2, 3, 5, 7, 8, 9, 25 ], [ 3, 4, 5, 7, 8, 9, 25 ], 
+  [ 3, 4, 5, 7, 8, 9, 25 ], [ 3, 4, 5, 7, 8, 9, 25 ], 
+  [ 3, 4, 5, 7, 8, 9, 25 ], [ 2, 3, 3, 4, 5, 7, 8, 25 ], 
+  [ 2, 4, 5, 7, 8, 9, 25 ], [ 2, 4, 5, 7, 8, 9, 25 ], 
+  [ 2, 4, 5, 7, 8, 9, 25 ], [ 2, 3, 4, 5, 5, 7, 8, 9 ], 
+  [ 2, 3, 4, 7, 8, 9, 25 ], [ 2, 3, 4, 7, 8, 9, 25 ], 
+  [ 2, 3, 4, 7, 8, 9, 25 ], [ 2, 3, 4, 7, 8, 9, 25 ], 
+  [ 2, 3, 4, 7, 8, 9, 25 ], [ 2, 3, 4, 5, 8, 9, 25 ] ]
+gap> ForAll(MaximalNormalSubgroups(A), N -> IsSubgroup(A, N) and IsNormal(A, N));
+true
+gap> D1 := DihedralGroup(Factorial(10));;
+gap> List(MaximalNormalSubgroups(D1), StructureDescription);
+[ "D1814400", "C1814400", "D1814400" ]
+gap> D2 := DihedralGroup(IsFpGroup, 360);;
+gap> List(MaximalNormalSubgroups(D2), StructureDescription);
+[ "C180", "D180", "D180" ]
+gap> ForAll(MaximalNormalSubgroups(D2), N -> IsSubgroup(D2, N) and IsNormal(D2, N));
+true
+
+# some infinite fp-groups
+#gap> F := FreeGroup("r", "s");; r := F.1;; s := F.2;;
+#gap> G := F/[r*s*r^(-1)*s^(-1), r^180, s^168];;
+#gap> Length(MaximalNormalSubgroups(G));
+#9
+#gap> G := F/[s^2, s*r*s*r];;
+
+# currently IsSolvable(G) would not run, will be remedied later
+#gap> IsAbelian(DerivedSubgroup(G));
+#true
+#gap> SetIsSolvableGroup(G, true);
+#gap> Length(MaximalNormalSubgroups(G));
+#3
 gap> STOP_TEST("MaximalNormalSubgroups.tst", 10000);

--- a/tst/testinstall/opers/MaximalNormalSubgroups.tst
+++ b/tst/testinstall/opers/MaximalNormalSubgroups.tst
@@ -3,6 +3,8 @@ gap> G := SymmetricGroup(4);; MaximalNormalSubgroups(G)=[DerivedSubgroup(G)];
 true
 gap> G := SymmetricGroup(5);; MaximalNormalSubgroups(G)=[DerivedSubgroup(G)];
 true
+gap> G := AlternatingGroup(5);; Size(MaximalNormalSubgroups(G))=1 and IsTrivial(MaximalNormalSubgroups(G)[1]);
+true
 gap> l := [2,4,8,3,9,5,25,7];; G := DirectProduct(List(l, CyclicGroup));;
 gap> List(MaximalNormalSubgroups(G),N ->List(MinimalGeneratingSet(N),Order));
 [ [ 2, 60, 6300 ], [ 2, 30, 12600 ], [ 2, 30, 12600 ], [ 60, 12600 ], 

--- a/tst/testinstall/opers/MaximalNormalSubgroups.tst
+++ b/tst/testinstall/opers/MaximalNormalSubgroups.tst
@@ -33,16 +33,16 @@ gap> ForAll(MaximalNormalSubgroups(D2), N -> IsSubgroup(D2, N) and IsNormal(D2, 
 true
 
 # some infinite fp-groups
-#gap> F := FreeGroup("r", "s");; r := F.1;; s := F.2;;
-#gap> G := F/[r*s*r^(-1)*s^(-1), r^180, s^168];;
-#gap> Length(MaximalNormalSubgroups(G));
-#9
-#gap> G := F/[s^2, s*r*s*r];;
+gap> F := FreeGroup("r", "s");; r := F.1;; s := F.2;;
+gap> G := F/[r^(-1)*s^(-1)*r*s, r^18, s^24];;
+gap> Length(MaximalNormalSubgroups(G));
+7
+gap> G := F/[s^2, s*r*s*r];;
 
 # currently IsSolvable(G) would not run, will be remedied later
-#gap> IsAbelian(DerivedSubgroup(G));
-#true
-#gap> SetIsSolvableGroup(G, true);
-#gap> Length(MaximalNormalSubgroups(G));
-#3
+gap> IsAbelian(DerivedSubgroup(G));
+true
+gap> SetIsSolvableGroup(G, true);
+gap> Length(MaximalNormalSubgroups(G));
+3
 gap> STOP_TEST("MaximalNormalSubgroups.tst", 10000);

--- a/tst/testinstall/opers/MaximalNormalSubgroups.tst
+++ b/tst/testinstall/opers/MaximalNormalSubgroups.tst
@@ -1,0 +1,21 @@
+gap> START_TEST("normal_hall_subgroups.tst");
+gap> G := SymmetricGroup(4);; MaximalNormalSubgroups(G)=[DerivedSubgroup(G)];
+true
+gap> G := SymmetricGroup(5);; MaximalNormalSubgroups(G)=[DerivedSubgroup(G)];
+true
+gap> l := [2,4,8,3,9,5,25,7];; G := DirectProduct(List(l, CyclicGroup));;
+gap> List(MaximalNormalSubgroups(G),N ->List(MinimalGeneratingSet(N),Order));
+[ [ 2, 60, 6300 ], [ 2, 30, 12600 ], [ 2, 30, 12600 ], [ 60, 12600 ], 
+  [ 60, 12600 ], [ 60, 12600 ], [ 60, 12600 ], [ 2, 60, 4200 ], 
+  [ 2, 20, 12600 ], [ 2, 20, 12600 ], [ 2, 20, 12600 ], [ 2, 60, 2520 ], 
+  [ 2, 12, 12600 ], [ 2, 12, 12600 ], [ 2, 12, 12600 ], [ 2, 12, 12600 ], 
+  [ 2, 12, 12600 ], [ 2, 60, 1800 ] ]
+gap> D := DihedralGroup(Factorial(10));;
+gap> List(MaximalNormalSubgroups(G), StructureDescription);
+[ "C6300 x C60 x C2", "C12600 x C30 x C2", "C12600 x C30 x C2", 
+  "C12600 x C60", "C12600 x C60", "C12600 x C60", "C12600 x C60", 
+  "C4200 x C60 x C2", "C12600 x C20 x C2", "C12600 x C20 x C2", 
+  "C12600 x C20 x C2", "C2520 x C60 x C2", "C12600 x C12 x C2", 
+  "C12600 x C12 x C2", "C12600 x C12 x C2", "C12600 x C12 x C2", 
+  "C12600 x C12 x C2", "C1800 x C60 x C2" ]
+gap> STOP_TEST("normal_hall_subgroups.tst", 10000);

--- a/tst/testinstall/opers/MaximalNormalSubgroups.tst
+++ b/tst/testinstall/opers/MaximalNormalSubgroups.tst
@@ -1,4 +1,4 @@
-gap> START_TEST("normal_hall_subgroups.tst");
+gap> START_TEST("MaximalNormalSubgroups.tst");
 gap> G := SymmetricGroup(4);; MaximalNormalSubgroups(G)=[DerivedSubgroup(G)];
 true
 gap> G := SymmetricGroup(5);; MaximalNormalSubgroups(G)=[DerivedSubgroup(G)];
@@ -18,4 +18,4 @@ gap> List(MaximalNormalSubgroups(G), StructureDescription);
   "C12600 x C20 x C2", "C2520 x C60 x C2", "C12600 x C12 x C2", 
   "C12600 x C12 x C2", "C12600 x C12 x C2", "C12600 x C12 x C2", 
   "C12600 x C12 x C2", "C1800 x C60 x C2" ]
-gap> STOP_TEST("normal_hall_subgroups.tst", 10000);
+gap> STOP_TEST("MaximalNormalSubgroups.tst", 10000);


### PR DESCRIPTION
For finite solvable groups every maximal normal subgroup contains G', thus we can factor out with this. 
For abelian groups, a maximal normal subgroup looks like a maximal normal subgroup in one Sylow multiplied by all other Sylows. 
For an abelian p-group maximal normal subgroups are the same as maximal subgroups, hence we can factor out by the Frattini subgroup. 
For elementary abelian groups one can use NormalMaximalSubgroups from grppcatr.gi. This was the main reason I put this method here rather than into grp.gi. 
MaximalSubgroups could also be used, but seems to do some extra checks which are unnecessary for elementary abelian groups. 

Rank of this method is raised to become RankFilter(CanComputeSize and IsFinite and IsSolvable).

Some parts probably can be generalized for polycyclic groups, but I did not check thoroughly. 

Added tests, profiling says that all relevant lines are run. 

Some more testing shows that for big abelian or dihedral groups the new method is significantly faster. These are not added to the tst file. In any case, for solvable groups we spare a NormalSubgroups computation.
