### PR TITLE
Fix nice monomorphism dispatch for HallSubgroup

### DIFF
--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -444,7 +444,15 @@ function(g,l)
 local mon,h;
    mon:=NiceMonomorphism(g);
    h:=HallSubgroup(ImagesSet(mon,g),l);
-   return PreImage(mon,h);
+   if h = fail then
+       return fail;
+   elif IsList(h) then
+       return List(h, k -> PreImage(mon, k));
+   elif IsGroup(h) then
+       return PreImage(mon,h);
+   else
+       Error("Unexpected return value from HallSubgroup");
+   fi;
 end);
 
 #############################################################################

--- a/tst/testinstall/opers/HallSubgroup.tst
+++ b/tst/testinstall/opers/HallSubgroup.tst
@@ -1,0 +1,19 @@
+gap> START_TEST("HallSubgroup.tst");
+gap> G := GL(3,4);;
+gap> HallSubgroup(G, [2,3]);
+fail
+gap> G := PSL(4,2);;
+gap> IdGroup(HallSubgroup(G, [2,3]));
+[ 576, 8654 ]
+gap> G := PSp(4,5);;
+gap> IdGroup(HallSubgroup(G,[2,3]));
+[ 576, 8277 ]
+gap> G := Group([ [ [ Z(2)^0, 0*Z(2), 0*Z(2) ],
+> [ 0*Z(2), Z(2)^0, 0*Z(2) ],
+> [ 0*Z(2), Z(2)^0, Z(2)^0 ] ], 
+> [ [ 0*Z(2), Z(2)^0, 0*Z(2) ],
+> [ 0*Z(2), 0*Z(2), Z(2)^0 ],
+> [ Z(2)^0, 0*Z(2), 0*Z(2) ] ] ]);;
+gap> List(HallSubgroup(G, [2,3]), IdGroup);
+[ [ 24, 12 ], [ 24, 12 ] ]
+gap> STOP_TEST("HallSubgroup.tst", 10000);


### PR DESCRIPTION
Fixes issue #557 

Will this work when `HallSubgroup` returns a list of groups?

Also I will add some tests.