### PR TITLE
Add NormalHallSubgroups

### DIFF
--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -3289,6 +3289,45 @@ KeyDependentOperation( "HallSubgroup", IsGroup, IsList, ReturnTrue );
 
 #############################################################################
 ##
+#F  NormalHallSubgroupsFromSylows( <G>[, <method>] )
+##
+##  <ManSection>
+##  <Func Name="NormalHallSubgroupsFromSylows" Arg="G[, method]"/>
+##
+##  <Description>
+##    Computes all normal Hall subgroups, that is all normal subgroups
+##    <A>N</A> for which the size of <A>N</A> is relatively prime to the
+##    index of <A>N</A> in <A>G</A>.
+##
+##    Sometimes it is not desirable to compute all normal Hall subgroups. The
+##    user can express such a wish by using the <A>method</A> <Q>"any"</Q>.
+##    Then NormalHallSubgroupsFromSylows returns a nontrivial normal Hall
+##    subgroup, if there is one, and returns fail, otherwise.
+##  </Description>
+##  </ManSection>
+##
+DeclareGlobalFunction( "NormalHallSubgroupsFromSylows", [ IsGroup ] );
+
+
+#############################################################################
+##
+#A  NormalHallSubgroups( <G> )
+##
+##  <ManSection>
+##  <Attr Name="NormalHallSubgroups" Arg="G"/>
+##
+##  <Description>
+##    Returns a list of all normal Hall subgroups, that is of all normal
+##    subgroups <A>N</A> for which the size of <A>N</A> is relatively prime
+##    to the index of <A>N</A> in <A>G</A>.
+##  </Description>
+##  </ManSection>
+##
+DeclareAttribute( "NormalHallSubgroups", IsGroup );
+
+
+#############################################################################
+##
 #O  NrConjugacyClassesInSupergroup( <U>, <G> )
 ##
 ##  <ManSection>

--- a/tst/testinstall/opers/NormalHallSubgroups.tst
+++ b/tst/testinstall/opers/NormalHallSubgroups.tst
@@ -1,0 +1,78 @@
+gap> START_TEST("NormalHallSubgroups.tst");
+gap> for G in AllGroups(60) do Print(List(NormalHallSubgroups(G), IdGroup), "\n"); od;
+[ [ 1, 1 ], [ 5, 1 ], [ 3, 1 ], [ 15, 1 ], [ 12, 1 ], [ 60, 1 ] ]
+[ [ 1, 1 ], [ 3, 1 ], [ 5, 1 ], [ 15, 1 ], [ 20, 1 ], [ 60, 2 ] ]
+[ [ 1, 1 ], [ 3, 1 ], [ 5, 1 ], [ 15, 1 ], [ 60, 3 ] ]
+[ [ 1, 1 ], [ 3, 1 ], [ 5, 1 ], [ 15, 1 ], [ 4, 1 ], [ 12, 2 ], [ 20, 2 ], 
+  [ 60, 4 ] ]
+[ [ 1, 1 ], [ 60, 5 ] ]
+[ [ 1, 1 ], [ 3, 1 ], [ 5, 1 ], [ 15, 1 ], [ 20, 3 ], [ 60, 6 ] ]
+[ [ 1, 1 ], [ 3, 1 ], [ 5, 1 ], [ 15, 1 ], [ 60, 7 ] ]
+[ [ 1, 1 ], [ 3, 1 ], [ 5, 1 ], [ 15, 1 ], [ 60, 8 ] ]
+[ [ 1, 1 ], [ 5, 1 ], [ 4, 2 ], [ 12, 3 ], [ 20, 5 ], [ 60, 9 ] ]
+[ [ 1, 1 ], [ 3, 1 ], [ 5, 1 ], [ 20, 4 ], [ 15, 1 ], [ 60, 10 ] ]
+[ [ 1, 1 ], [ 5, 1 ], [ 3, 1 ], [ 12, 4 ], [ 15, 1 ], [ 60, 11 ] ]
+[ [ 1, 1 ], [ 3, 1 ], [ 5, 1 ], [ 15, 1 ], [ 60, 12 ] ]
+[ [ 1, 1 ], [ 4, 2 ], [ 3, 1 ], [ 12, 5 ], [ 5, 1 ], [ 20, 5 ], [ 15, 1 ], 
+  [ 60, 13 ] ]
+gap> for G in AllGroups(60) do primes := PrimeDivisors(Size(G)); l := []; for pi in IteratorOfCombinations(primes) do N := HallSubgroup(G, pi); if N<>fail and IsGroup(N) and IsNormal(G, N) then AddSet(l, N); fi; od; if l <> NormalHallSubgroups(G) then Print(IdGroup(G), "\n"); fi; od;
+gap> List(AllSmallGroups(168), G -> List(NormalHallSubgroups(G), Size));
+[ [ 1, 7, 21, 56, 168 ], [ 1, 8, 7, 21, 56, 168 ], [ 1, 7, 3, 21, 24, 168 ], 
+  [ 1, 3, 7, 21, 56, 168 ], [ 1, 3, 7, 21, 168 ], 
+  [ 1, 3, 7, 21, 8, 24, 56, 168 ], [ 1, 7, 21, 56, 168 ], 
+  [ 1, 7, 21, 56, 168 ], [ 1, 7, 21, 56, 168 ], [ 1, 7, 21, 56, 168 ], 
+  [ 1, 7, 21, 56, 168 ], [ 1, 3, 7, 21, 168 ], [ 1, 3, 7, 21, 168 ], 
+  [ 1, 3, 7, 21, 168 ], [ 1, 3, 7, 21, 168 ], [ 1, 3, 7, 21, 168 ], 
+  [ 1, 3, 7, 21, 168 ], [ 1, 3, 7, 21, 168 ], [ 1, 8, 7, 21, 56, 168 ], 
+  [ 1, 8, 7, 21, 56, 168 ], [ 1, 8, 7, 21, 56, 168 ], 
+  [ 1, 7, 8, 24, 56, 168 ], [ 1, 7, 8, 56, 168 ], [ 1, 3, 7, 21, 56, 168 ], 
+  [ 1, 3, 7, 21, 56, 168 ], [ 1, 3, 7, 21, 56, 168 ], 
+  [ 1, 3, 7, 21, 56, 168 ], [ 1, 3, 7, 21, 56, 168 ], 
+  [ 1, 7, 3, 21, 24, 168 ], [ 1, 7, 3, 21, 24, 168 ], 
+  [ 1, 7, 3, 21, 24, 168 ], [ 1, 7, 3, 21, 24, 168 ], 
+  [ 1, 7, 3, 21, 24, 168 ], [ 1, 3, 7, 21, 168 ], [ 1, 3, 7, 21, 168 ], 
+  [ 1, 3, 7, 21, 168 ], [ 1, 3, 7, 21, 168 ], [ 1, 3, 7, 21, 168 ], 
+  [ 1, 3, 7, 21, 8, 24, 56, 168 ], [ 1, 3, 7, 21, 8, 24, 56, 168 ], 
+  [ 1, 3, 7, 21, 8, 24, 56, 168 ], [ 1, 168 ], [ 1, 8, 56, 168 ], 
+  [ 1, 3, 8, 24, 56, 168 ], [ 1, 7, 24, 168 ], [ 1, 7, 168 ], 
+  [ 1, 7, 56, 21, 168 ], [ 1, 7, 56, 168 ], [ 1, 7, 56, 168 ], 
+  [ 1, 3, 7, 21, 168 ], [ 1, 8, 7, 56, 21, 168 ], [ 1, 7, 8, 24, 56, 168 ], 
+  [ 1, 8, 7, 56, 168 ], [ 1, 3, 7, 56, 21, 168 ], [ 1, 7, 3, 24, 21, 168 ], 
+  [ 1, 3, 7, 21, 168 ], [ 1, 8, 3, 24, 7, 56, 21, 168 ] ]
+gap> for G in AllGroups(168) do primes := PrimeDivisors(Size(G)); l := []; for pi in IteratorOfCombinations(primes) do N := HallSubgroup(G, pi); if N<>fail and IsGroup(N) and IsNormal(G, N) then AddSet(l, N); fi; od; if l <> NormalHallSubgroups(G) then Print(IdGroup(G), "\n"); fi; od;
+gap> List(AllPrimitiveGroups(DegreeAction, 8), G -> List(NormalHallSubgroups(G), Size));
+[ [ 1, 56, 8 ], [ 1, 168, 56, 8 ], [ 1, 1344 ], [ 1, 168 ], [ 1, 336 ], 
+  [ 1, 20160 ], [ 1, 40320 ] ]
+gap> List(NormalHallSubgroups(PrimitiveGroup(8,2)), Size);
+[ 1, 168, 56, 8 ]
+gap> Positions(List(AllTransitiveGroups(DegreeAction, 6), G -> NormalHallSubgroupsFromSylows(G, "any")), fail);
+[ 7, 8, 11, 12, 14, 15, 16 ]
+gap> N := PSL(2,32);; aut := SylowSubgroup(AutomorphismGroup(N),5);;
+gap> G := SemidirectProduct(aut, N);;
+gap> Size(NormalHallSubgroupsFromSylows(G, "any"));
+32736
+gap> A4 := AlternatingGroup(4);;
+gap> HallSubgroup(A4, [2])=Group((1,2)(3,4),(1,3)(2,4));
+true
+gap> HallSubgroup(A4, [3]);; Length(ComputedHallSubgroups(A4));
+4
+gap> NormalHallSubgroupsFromSylows(A4, "any")=Group((1,2)(3,4),(1,3)(2,4));
+true
+gap> D := DihedralGroup(8);; NormalHallSubgroupsFromSylows(D, "any");
+fail
+gap> HasNormalHallSubgroups(D);
+true
+gap> NormalHallSubgroupsFromSylows(D)=[TrivialSubgroup(D), D];
+true
+gap> NormalHallSubgroupsFromSylows(D, "any");
+fail
+gap> D := DihedralGroup(12);; 
+gap> List(NormalHallSubgroups(D), Size);
+[ 1, 3, 12 ]
+gap> Size(NormalHallSubgroupsFromSylows(D, "any"));
+3
+gap> NormalHallSubgroupsFromSylows(Group(()), "any");
+fail
+gap> Length(NormalHallSubgroups(Group(())));
+1
+gap> STOP_TEST("NormalHallSubgroups.tst", 10000);


### PR DESCRIPTION
This is the second installment in the series of enhancing
StructureDescription. (The first being DirectFactorsOfGroup.)

A new global function NormalHalSubgroupFromSylows is introduced, which
computes normal Hall subgroups by computing normal closures of all Sylows.
An optional second argument "any" is recognized, in which case the function
returns the first nontrivial normal Hall subgroup, if exists, and returns
fail, otherwise. This will be used for computing semidirect decompositions,
because in this situation the Schur-Zassenhaus theorem guarantees a
complement.

NormalHallSubgroups is a new attribute, which consists of a list of all
normal Hall subgroups of a group. This is currently defined only for groups
which can compute size for all their subgroups. This check might not be
needed, e.g. the function works for DihedralGroup(IsFpGroup, 60), as well.

A test file is added.