### PR TITLE
Add ComplementClassesRepresentatives for all groups

### DIFF
--- a/lib/grppccom.gd
+++ b/lib/grppccom.gd
@@ -188,5 +188,23 @@ DeclareOperation("ComplementClassesRepresentatives",[IsGroup,IsGroup]);
 
 #############################################################################
 ##
+#O  ComplementClassesRepresentativesKD( <G>, <N> ) . . . . complement classes
+##
+##  <ManSection>
+##  <Oper Name="ComplementClassesRepresentativesKD" Arg="G, N"/>
+##
+##  <Description>
+##  This is the same operation as ComplementClassesRepresentatives, except
+##  that this stores the complements for the normal subgroups as a
+##  keydependent operation.
+##  </Description>
+##  </ManSection>
+##
+KeyDependentOperation( "ComplementClassesRepresentativesKD", IsGroup,
+                                                      IsGroup, ReturnTrue );
+
+
+#############################################################################
+##
 #E
 

--- a/lib/grppccom.gd
+++ b/lib/grppccom.gd
@@ -188,23 +188,5 @@ DeclareOperation("ComplementClassesRepresentatives",[IsGroup,IsGroup]);
 
 #############################################################################
 ##
-#O  ComplementClassesRepresentativesKD( <G>, <N> ) . . . . complement classes
-##
-##  <ManSection>
-##  <Oper Name="ComplementClassesRepresentativesKD" Arg="G, N"/>
-##
-##  <Description>
-##  This is the same operation as ComplementClassesRepresentatives, except
-##  that this stores the complements for the normal subgroups as a
-##  keydependent operation.
-##  </Description>
-##  </ManSection>
-##
-KeyDependentOperation( "ComplementClassesRepresentativesKD", IsGroup,
-                                                      IsGroup, ReturnTrue );
-
-
-#############################################################################
-##
 #E
 

--- a/lib/grppccom.gi
+++ b/lib/grppccom.gi
@@ -1242,22 +1242,6 @@ end);
 
 #############################################################################
 ##
-#M  ComplementClassesRepresentativesKD( <G> ) . . . . . . . . generic method
-##
-##
-##  This is the same operation as ComplementClassesRepresentatives, except
-##  that this stores the complements for the normal subgroups.
-##
-InstallMethod( ComplementClassesRepresentativesKDOp,
-               "generic method", [ IsGroup,  IsGroup ], 0,
-
-  function( G, N )
-    return ComplementClassesRepresentatives(G, N);
-  end);
-
-
-#############################################################################
-##
 #E  grppccom.gi . . . . . . . . . . . . . . . . . . . . . . . . . . ends here
 ##
 

--- a/lib/grppccom.gi
+++ b/lib/grppccom.gi
@@ -1230,9 +1230,9 @@ function( G, N )
   C := [ ];
   for Hc in ConjugacyClassesSubgroups(G) do
     H := Representative(Hc);
-    if not IsTrivial(H) and G<>H and IsTrivial(Intersection(N, H)) and
-      (( CanComputeSize(G) and CanComputeSize(N) and CanComputeSize(H) and
-        Size(G) = Size(N)*Size(H) ) or G = ClosureGroup(N, H) ) then
+    if (( CanComputeSize(G) and CanComputeSize(N) and CanComputeSize(H) and
+        Size(G) = Size(N)*Size(H) ) or G = ClosureGroup(N, H) )
+	and IsTrivial(Intersection(N, H)) then
       Add(C, H);
     fi;
   od;

--- a/lib/grppccom.gi
+++ b/lib/grppccom.gi
@@ -1213,7 +1213,7 @@ function( G, N )
   if IsSolvableGroup(N) or HasSolvableFactorGroup(G, N) then
     TryNextMethod();
   fi;
-  Error("Cannot compute complements if both N and G/N are nonsolvable");
+  Error("cannot compute complements if both N and G/N are nonsolvable");
 end);
 
 

--- a/lib/grppccom.gi
+++ b/lib/grppccom.gi
@@ -1204,17 +1204,57 @@ end);
 
 #############################################################################
 ##
-#M  ComplementcClassesRepresentatives( <G>, <N> )
+#M  ComplementcClassesRepresentatives( <G>, <N> ) . . . . . . generic method
 ##
 InstallMethod( ComplementClassesRepresentatives,
-  "tell that the normal subgroup must be solvable",IsIdenticalObj,
-  [IsGroup,IsGroup],-2*RankFilter(IsGroup),
+  "by computing all subgroups", IsIdenticalObj, [ IsGroup, IsGroup ],
+  -2*RankFilter(IsGroup),
+
 function( G, N )
-  if IsSolvableGroup(N) then
+
+  local C, Hc, H;
+
+  # if <N> is trivial the only complement is <G>
+  if IsTrivial(N) then
+      C := [ G ];
+  # if <G> and <N> are equal the only complement is trivial
+  elif G = N  then
+      C := [ TrivialSubgroup(G) ];
+  elif not IsNormal(G, N) then
+    Error("N must be normal in G");
+  elif IsSolvableGroup(N) or HasSolvableFactorGroup(G, N) then
     TryNextMethod();
   fi;
-  Error("Cannot compute complement classes for nonsolvable normal subgroups");
+
+  Info(InfoWarning,1,"N and G/N are not solvable, computing all subgroups!");
+  C := [ ];
+  for Hc in ConjugacyClassesSubgroups(G) do
+    H := Representative(Hc);
+    if not IsTrivial(H) and G<>H and IsTrivial(Intersection(N, H)) and
+      (( CanComputeSize(G) and CanComputeSize(N) and CanComputeSize(H) and
+        Size(G) = Size(N)*Size(H) ) or G = ClosureGroup(N, H) ) then
+      Add(C, H);
+    fi;
+  od;
+  return C;
 end);
+
+
+#############################################################################
+##
+#M  ComplementClassesRepresentativesKD( <G> ) . . . . . . . . generic method
+##
+##
+##  This is the same operation as ComplementClassesRepresentatives, except
+##  that this stores the complements for the normal subgroups.
+##
+InstallMethod( ComplementClassesRepresentativesKDOp,
+               "generic method", [ IsGroup,  IsGroup ], 0,
+
+  function( G, N )
+    return ComplementClassesRepresentatives(G, N);
+  end);
+
 
 #############################################################################
 ##

--- a/lib/grppccom.gi
+++ b/lib/grppccom.gi
@@ -1204,11 +1204,26 @@ end);
 
 #############################################################################
 ##
-#M  ComplementcClassesRepresentatives( <G>, <N> ) . . . . . . generic method
+#M  ComplementcClassesRepresentatives( <G>, <N> )
 ##
 InstallMethod( ComplementClassesRepresentatives,
-  "by computing all subgroups", IsIdenticalObj, [ IsGroup, IsGroup ],
-  -2*RankFilter(IsGroup),
+  "tell that the normal subgroup or factor must be solvable", IsIdenticalObj,
+  [ IsGroup, IsGroup ], -2*RankFilter(IsGroup),
+function( G, N )
+  if IsSolvableGroup(N) or HasSolvableFactorGroup(G, N) then
+    TryNextMethod();
+  fi;
+  Error("Cannot compute complements if both N and G/N are nonsolvable");
+end);
+
+
+#############################################################################
+##
+#M  ComplementcClassesRepresentatives( <G>, <N> ) . from conj. cl. subgroups
+##
+InstallMethod( ComplementClassesRepresentatives,
+  "using conjugacy classes of subgroups", IsIdenticalObj,
+  [ IsGroup and HasConjugacyClassesSubgroups, IsGroup ], 0,
 
 function( G, N )
 
@@ -1222,20 +1237,17 @@ function( G, N )
       C := [ TrivialSubgroup(G) ];
   elif not IsNormal(G, N) then
     Error("N must be normal in G");
-  elif IsSolvableGroup(N) or HasSolvableFactorGroup(G, N) then
-    TryNextMethod();
+  else
+    C := [ ];
+    for Hc in ConjugacyClassesSubgroups(G) do
+      H := Representative(Hc);
+      if (( CanComputeSize(G) and CanComputeSize(N) and CanComputeSize(H) and
+	  Size(G) = Size(N)*Size(H) ) or G = ClosureGroup(N, H) )
+	  and IsTrivial(Intersection(N, H)) then
+	Add(C, H);
+      fi;
+    od;
   fi;
-
-  Info(InfoWarning,1,"N and G/N are not solvable, computing all subgroups!");
-  C := [ ];
-  for Hc in ConjugacyClassesSubgroups(G) do
-    H := Representative(Hc);
-    if (( CanComputeSize(G) and CanComputeSize(N) and CanComputeSize(H) and
-        Size(G) = Size(N)*Size(H) ) or G = ClosureGroup(N, H) )
-	and IsTrivial(Intersection(N, H)) then
-      Add(C, H);
-    fi;
-  od;
   return C;
 end);
 

--- a/tst/testinstall/opers/ComplementClassesRepresentatives.tst
+++ b/tst/testinstall/opers/ComplementClassesRepresentatives.tst
@@ -1,17 +1,21 @@
 gap> START_TEST("ComplementClassesRepresentatives.tst");
 gap> n := 0;; for G in AllGroups(60) do for N in NormalSubgroups(G) do if ComplementClassesRepresentatives(G, N)<>fail then n := n+1; fi; od; od; n;
 133
-gap> G := Group([ (4,8)(6,10), (4,6,10,8,12), (2,4,12)(6,10,8), (3,9)(4,6,10,8,12)(7,11), (3,5)(4,6,10,8,12)(9,11), (1,3,11,9,5)(4,6,10,8,12) ]);;
-gap> N := NormalSubgroups(G)[2];;
-gap> ComplementClassesRepresentatives(G, N);
-#I  N and G/N are not solvable, computing all subgroups!
-[ Group([ (2,10)(4,12), (2,4,12)(6,10,8) ]), Group([ (1,9)(2,10)(3,11)
-  (4,12), (1,3,11)(2,4,12)(5,9,7)(6,10,8) ]), Group([ (2,10)(3,11)(4,12)
-  (5,7), (1,9,5)(2,4,12)(3,7,11)(6,10,8) ]) ]
+gap> G := SymmetricGroup(4);; N := DerivedSubgroup(AlternatingGroup(4));;
+gap> Set(ComplementClassesRepresentatives(G, N), H -> H^G)=Set([ Group([ (3,4), (2,4,3) ])^G ]);
+true
+gap> G := SymmetricGroup(4);; N := DerivedSubgroup(AlternatingGroup(4));;
+gap> ConjugacyClassesSubgroups(G);;
+gap> Set(ComplementClassesRepresentatives(G, N), H -> H^G)=Set([ Group([ (3,4), (2,4,3) ])^G ]);
+true
+gap> G := Group([ (6,7,8,9,10), (8,9,10), (1,2)(6,7), (1,2,3,4,5)(6,7,8,9,10) ]);;
+gap> N := Group((6,7,8),(6,7,8,9,10));; ConjugacyClassesSubgroups(G);;
+gap> Set(ComplementClassesRepresentatives(G, N), H -> H^G)=Set([ Group([ (1,2,5)(3,4)(6,7), (1,4)(2,5,3)(6,7) ])^G, Group([ (2,5)(7,8), (1,3,5,4)(6,10,9,7) ])^G, Group([ (2,3,4)(6,8,10), (1,2)(3,5,4)(6,10,7)(8,9) ])^G ]);
+true
 gap> G := SymmetricGroup(5);; N := AlternatingGroup(5);;
-gap> List(ComplementClassesRepresentatives(G, N), IdGroup);
-[ [ 2, 1 ] ]
+gap> Set(ComplementClassesRepresentatives(G, N), H -> H^G)=Set([ Group([ (1,2) ])^G ]);
+true
 gap> G := SymmetricGroup(6);; N := AlternatingGroup(6);;
-gap> List(ComplementClassesRepresentatives(G, N), IdGroup);
-[ [ 2, 1 ], [ 2, 1 ] ]
+gap> Set(ComplementClassesRepresentatives(G, N), H -> H^G)=Set([ Group([ (1,2) ])^G, Group([ (1,2)(3,4)(5,6) ])^G ]);
+true
 gap> STOP_TEST("ComplementClassesRepresentatives.tst", 10000);

--- a/tst/testinstall/opers/ComplementClassesRepresentatives.tst
+++ b/tst/testinstall/opers/ComplementClassesRepresentatives.tst
@@ -3,13 +3,11 @@ gap> n := 0;; for G in AllGroups(60) do for N in NormalSubgroups(G) do if Comple
 133
 gap> G := Group([ (4,8)(6,10), (4,6,10,8,12), (2,4,12)(6,10,8), (3,9)(4,6,10,8,12)(7,11), (3,5)(4,6,10,8,12)(9,11), (1,3,11,9,5)(4,6,10,8,12) ]);;
 gap> N := NormalSubgroups(G)[2];;
-gap> ComplementClassesRepresentativesKD(G, N);
+gap> ComplementClassesRepresentatives(G, N);
 #I  N and G/N are not solvable, computing all subgroups!
 [ Group([ (2,10)(4,12), (2,4,12)(6,10,8) ]), Group([ (1,9)(2,10)(3,11)
   (4,12), (1,3,11)(2,4,12)(5,9,7)(6,10,8) ]), Group([ (2,10)(3,11)(4,12)
   (5,7), (1,9,5)(2,4,12)(3,7,11)(6,10,8) ]) ]
-gap> N in ComputedComplementClassesRepresentativesKDs(G);
-true
 gap> G := SymmetricGroup(5);; N := AlternatingGroup(5);;
 gap> List(ComplementClassesRepresentatives(G, N), IdGroup);
 [ [ 2, 1 ] ]

--- a/tst/testinstall/opers/ComplementClassesRepresentatives.tst
+++ b/tst/testinstall/opers/ComplementClassesRepresentatives.tst
@@ -6,8 +6,20 @@ gap> Set(ComplementClassesRepresentatives(G, N), H -> H^G)=Set([ Group([ (3,4), 
 true
 gap> G := SymmetricGroup(4);; N := DerivedSubgroup(AlternatingGroup(4));;
 gap> ConjugacyClassesSubgroups(G);;
+gap> IsTrivial(ComplementClassesRepresentatives(G, G));
+true
+gap> ComplementClassesRepresentatives(G, Group((1,2)));
+Error, N must be normal in G
 gap> Set(ComplementClassesRepresentatives(G, N), H -> H^G)=Set([ Group([ (3,4), (2,4,3) ])^G ]);
 true
+gap> G := Group((1,2),(1,2,3,4));;
+gap> N := DerivedSubgroup(Group((1,2,3),(2,3,4)));;
+gap> Set(ComplementClassesRepresentatives(G, N), H -> H^G)=Set([ Group([ (3,4), (2,4,3) ])^G ]);
+true
+gap> G := Group([ (6,7,8,9,10), (8,9,10), (1,2)(6,7), (1,2,3,4,5)(6,7,8,9,10) ]);;
+gap> N := Group((6,7,8),(6,7,8,9,10));;
+gap> ComplementClassesRepresentatives(G, N);
+Error, cannot compute complements if both N and G/N are nonsolvable
 gap> G := Group([ (6,7,8,9,10), (8,9,10), (1,2)(6,7), (1,2,3,4,5)(6,7,8,9,10) ]);;
 gap> N := Group((6,7,8),(6,7,8,9,10));; ConjugacyClassesSubgroups(G);;
 gap> Set(ComplementClassesRepresentatives(G, N), H -> H^G)=Set([ Group([ (1,2,5)(3,4)(6,7), (1,4)(2,5,3)(6,7) ])^G, Group([ (2,5)(7,8), (1,3,5,4)(6,10,9,7) ])^G, Group([ (2,3,4)(6,8,10), (1,2)(3,5,4)(6,10,7)(8,9) ])^G ]);

--- a/tst/testinstall/opers/ComplementClassesRepresentatives.tst
+++ b/tst/testinstall/opers/ComplementClassesRepresentatives.tst
@@ -1,0 +1,19 @@
+gap> START_TEST("ComplementClassesRepresentatives.tst");
+gap> n := 0;; for G in AllGroups(60) do for N in NormalSubgroups(G) do if ComplementClassesRepresentatives(G, N)<>fail then n := n+1; fi; od; od; n;
+133
+gap> G := Group([ (4,8)(6,10), (4,6,10,8,12), (2,4,12)(6,10,8), (3,9)(4,6,10,8,12)(7,11), (3,5)(4,6,10,8,12)(9,11), (1,3,11,9,5)(4,6,10,8,12) ]);;
+gap> N := NormalSubgroups(G)[2];;
+gap> ComplementClassesRepresentativesKD(G, N);
+#I  N and G/N are not solvable, computing all subgroups!
+[ Group([ (2,10)(4,12), (2,4,12)(6,10,8) ]), Group([ (1,9)(2,10)(3,11)
+  (4,12), (1,3,11)(2,4,12)(5,9,7)(6,10,8) ]), Group([ (2,10)(3,11)(4,12)
+  (5,7), (1,9,5)(2,4,12)(3,7,11)(6,10,8) ]) ]
+gap> N in ComputedComplementClassesRepresentativesKDs(G);
+true
+gap> G := SymmetricGroup(5);; N := AlternatingGroup(5);;
+gap> List(ComplementClassesRepresentatives(G, N), IdGroup);
+[ [ 2, 1 ] ]
+gap> G := SymmetricGroup(6);; N := AlternatingGroup(6);;
+gap> List(ComplementClassesRepresentatives(G, N), IdGroup);
+[ [ 2, 1 ], [ 2, 1 ] ]
+gap> STOP_TEST("ComplementClassesRepresentatives.tst", 10000);


### PR DESCRIPTION
This is the third installment in the series of enhancing
StructureDescription. (The first being DirectFactorsOfGroup, the second is
NormalHallSubgroups.)

This commit adds a method to ComplementClassesRepresentatives by
computing all conjugacy classes of subgroups, and then checking them
one-by-one for a suitable complement. It has a very low rank, and (just in
case) checks first whether some faster method cannot be used. Further, it
warns the user that all subgroups are computed, because this method can be
really inefficient.

In the fourth installment, SemidirectDecompositions will be written to use
ComplementClassesRepresentatives to determine whether or not a group can
be factored as a semidirect product.

Moreover, added a new KeyDependentOperation named
ComplementClassesRepresentativeKD, which calls
ComplementClassesRepresentative, but stores the result as a usual
KeyDependentOperation does. I believe this can be useful, and it should go
to the manual, but I would need help with that.

Added test file, which at least runs through the new code, and parts of
the old code, as well.
