### PR TITLE
Raised assertion level from 2 to 3 in two GHBINC methods

### DIFF
--- a/lib/ghom.gi
+++ b/lib/ghom.gi
@@ -445,7 +445,7 @@ local   hom;
     HasIsHandledByNiceMonomorphism(H)) 
     and ValueOption("noassert")<>true 
     and not IsSubgroupFpGroup(H) then
-    Assert( 2, IsMapping( hom ) );
+    Assert( 3, IsMapping( hom ) );
   fi;
   SetIsMapping( hom, true );
   return hom;
@@ -457,7 +457,7 @@ function( G, gens, imgs )
 local   hom;
   hom := GroupGeneralMappingByImagesNC( G, gens, imgs );
   if not HasIsHandledByNiceMonomorphism(G) and ValueOption("noassert")<>true then
-    Assert( 2, IsMapping( hom ) );
+    Assert( 3, IsMapping( hom ) );
   fi;
   SetIsMapping( hom, true );
   return hom;


### PR DESCRIPTION
This PR changes two lines and increments assertion level from 2 to 3 in two check added in PR #472. This should address the problem reported in #562 and permit us to proceed with GAP 4.8 because of going into the stable-4.8 branch. 

If I am not missing something, we're not actually removing any checks - those two assertions are new, and we actually intend to test them soon accordingly to #564 (they run OK in the core system tests, it's packages where the tests are being stuck).

@hulpke @fingolfin - you were involved in discussions in #472, could you please review my PR?