### PR TITLE
FIX: Remove immediate methods to transfer mapping information.

### DIFF
--- a/lib/mapping.gi
+++ b/lib/mapping.gi
@@ -516,57 +516,63 @@ InstallGlobalFunction( CompositionMapping, function ( arg )
 end );
 
 
-#############################################################################
-##
-#M  IsInjective( <map> )  . . . . . for gen. mapp. with known inv. gen. mapp.
-#M  IsSingleValued( <map> ) . . . . for gen. mapp. with known inv. gen. mapp.
-#M  IsSurjective( <map> ) . . . . . for gen. mapp. with known inv. gen. mapp.
-#M  IsTotal( <map> )  . . . . . . . for gen. mapp. with known inv. gen. mapp.
-##
-InstallImmediateMethod( IsInjective,
-    IsGeneralMapping and HasInverseGeneralMapping, 0,
-    function( map )
-    map:= InverseGeneralMapping( map );
-    if HasIsSingleValued( map ) then
-      return IsSingleValued( map );
-    else
-      TryNextMethod();
-    fi;
-    end );
-
-InstallImmediateMethod( IsSingleValued,
-    IsGeneralMapping and HasInverseGeneralMapping, 0,
-    function( map )
-    map:= InverseGeneralMapping( map );
-    if HasIsInjective( map ) then
-      return IsInjective( map );
-    else
-      TryNextMethod();
-    fi;
-    end );
-
-InstallImmediateMethod( IsSurjective,
-    IsGeneralMapping and HasInverseGeneralMapping, 0,
-    function( map )
-    map:= InverseGeneralMapping( map );
-    if HasIsTotal( map ) then
-      return IsTotal( map );
-    else
-      TryNextMethod();
-    fi;
-    end );
-
-InstallImmediateMethod( IsTotal,
-    IsGeneralMapping and HasInverseGeneralMapping, 0,
-    function( map )
-    map:= InverseGeneralMapping( map );
-    if HasIsSurjective( map ) then
-      return IsSurjective( map );
-    else
-      TryNextMethod();
-    fi;
-    end );
-
+# Temporarily disabled -- See #569
+# Currently some group homomrophisms construct inverse maps that are really
+# restricted inverses (i.e. defined only on the image). Together with these
+# immediate methods this can cause wrong indications of IsSurjective etc.
+# for these maps. While this needs to be fixed in the future properly, the
+# immediate methods are temporarily disabled to avoid this error having
+# further effects.
+# #############################################################################
+# ##
+# #M  IsInjective( <map> )  . . . . . for gen. mapp. with known inv. gen. mapp.
+# #M  IsSingleValued( <map> ) . . . . for gen. mapp. with known inv. gen. mapp.
+# #M  IsSurjective( <map> ) . . . . . for gen. mapp. with known inv. gen. mapp.
+# #M  IsTotal( <map> )  . . . . . . . for gen. mapp. with known inv. gen. mapp.
+# ##
+# InstallImmediateMethod( IsInjective,
+#     IsGeneralMapping and HasInverseGeneralMapping, 0,
+#     function( map )
+#     map:= InverseGeneralMapping( map );
+#     if HasIsSingleValued( map ) then
+#       return IsSingleValued( map );
+#     else
+#       TryNextMethod();
+#     fi;
+#     end );
+# 
+# InstallImmediateMethod( IsSingleValued,
+#     IsGeneralMapping and HasInverseGeneralMapping, 0,
+#     function( map )
+#     map:= InverseGeneralMapping( map );
+#     if HasIsInjective( map ) then
+#       return IsInjective( map );
+#     else
+#       TryNextMethod();
+#     fi;
+#     end );
+# 
+# InstallImmediateMethod( IsSurjective,
+#     IsGeneralMapping and HasInverseGeneralMapping, 0,
+#     function( map )
+#     map:= InverseGeneralMapping( map );
+#     if HasIsTotal( map ) then
+#       return IsTotal( map );
+#     else
+#       TryNextMethod();
+#     fi;
+#     end );
+# 
+# InstallImmediateMethod( IsTotal,
+#     IsGeneralMapping and HasInverseGeneralMapping, 0,
+#     function( map )
+#     map:= InverseGeneralMapping( map );
+#     if HasIsSurjective( map ) then
+#       return IsSurjective( map );
+#     else
+#       TryNextMethod();
+#     fi;
+#     end );
 
 #############################################################################
 ##

--- a/tst/teststandard/bugfix.tst
+++ b/tst/teststandard/bugfix.tst
@@ -2982,6 +2982,12 @@ gap> p := 227;; x := X(GF(p), "x");; f := x^(7^2) - x;;
 gap> PowerMod(x, p, f);
 x^35
 
+#2016/2/4 (AH)
+gap> N := AlternatingGroup(6);; H := AutomorphismGroup(N);;
+gap> G := SemidirectProduct(H, N);;
+gap> Size(Image(Embedding(G, 1)))=Size(H);
+true
+
 #############################################################################
 gap> STOP_TEST( "bugfix.tst", 781280000);
 


### PR DESCRIPTION
These immediate methods try to transfer information from an inverse general
mapping to the original. However these inverses may not be defined on the
range (but only on the image), so doing so is invalid.

This fixes #565.