### PR TITLE
Permutations from Random Sources

### DIFF
--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -748,12 +748,12 @@ InstallMethod( Size,
     [ IsNaturalSymmetricGroup ], 0,
     sym -> Factorial( NrMovedPoints(sym) ) );
 
-BindGlobal("FLOYDS_ALGORITHM", function(deg, even)
+BindGlobal("FLOYDS_ALGORITHM", function(rs,deg, even)
     local  rnd, sgn, i, k, tmp;
     rnd := [1..deg];
     sgn := 1;
     for i  in [1..deg-1] do
-        k := Random( [ i .. deg] );
+        k := Random( rs, [ i .. deg] );
         if k <> i then
             tmp := rnd[i];
             rnd[i] := rnd[k];
@@ -774,9 +774,9 @@ end);
 InstallMethod( Random,
     "symmetric group: floyd's algorithm",
     true,
-    [ IsNaturalSymmetricGroup ],
+    [ IsRandomSource, IsNaturalSymmetricGroup ],
     10, # override perm. gp. method
-function ( G )
+function ( rs, G )
     local   rnd,        # random permutation, result
 	    deg,
 	    mov;
@@ -791,7 +791,7 @@ function ( G )
     # use Floyd\'s algorithm
     mov:=MovedPoints(G);
     deg:=Length(mov);
-    rnd := FLOYDS_ALGORITHM(deg,false);
+    rnd := FLOYDS_ALGORITHM(rs,deg,false);
     # return the permutation
     return PermList( rnd )^MappingPermListList([1..deg],mov);
 end);
@@ -800,15 +800,13 @@ end);
 InstallMethod( Random,
     "alternating group: floyd's algorithm",
     true,
-    [ IsNaturalAlternatingGroup ],
+    [ IsRandomSource, IsNaturalAlternatingGroup ],
     10, # override perm gp. method
-function ( G )
+function ( rs, G )
     local   rnd,        # random permutation, result
-            sgn,        # sign of the permutation so far
-            tmp,        # temporary variable for swapping
 	    deg,
-	    mov,
-            i,  k;      # loop variables
+	    mov;
+    
 
     # test for internal rep
     if HasGeneratorsOfGroup(G) and 
@@ -818,11 +816,25 @@ function ( G )
     # use Floyd\'s algorithm
     mov:=MovedPoints(G);
     deg:=Length(mov);
-    rnd := FLOYDS_ALGORITHM(deg, true);
+    rnd := FLOYDS_ALGORITHM(rs, deg, true);
 
     # return the permutation
     return PermList( rnd )^MappingPermListList([1..deg],mov);
 end);
+
+InstallMethod( Random,
+        "symmetric group: use default random source",
+        true,
+        [IsNaturalSymmetricGroup],
+        10,
+        G->Random(GlobalRandomSource, G));
+
+InstallMethod( Random,
+        "alternating group: use default random source",
+        true,
+        [IsNaturalAlternatingGroup],
+        10,
+        G->Random(GlobalRandomSource, G));
 
 
 #############################################################################

--- a/lib/random.gd
+++ b/lib/random.gd
@@ -70,6 +70,7 @@ DeclareCategory( "IsRandomSource", IsComponentObjectRep );
 ##  <#/GAPDoc>
 ##
 DeclareOperation( "Random", [IsRandomSource, IsList] );
+DeclareOperation( "Random", [IsRandomSource, IsCollection and IsFinite] );
 DeclareOperation( "Random", [IsRandomSource, IsInt, IsInt] );
 
 #############################################################################


### PR DESCRIPTION
Allows `Random( <random-source>, SymmetricGroup(<n>))` and the like.
Breaks pperm and trans tests due to changes to number of calls to the global random source, or something. The best solution would be RandomPartialPerm and similar to accept a Random Source and then use one in testing.
