### PR TITLE
GroupHomomorphismByImages for groups with pcgs: performance problem

### DIFF
--- a/doc/tut/group.xml
+++ b/doc/tut/group.xml
@@ -920,8 +920,8 @@ gap> Kernel( hom );
 Group([ (1,4)(2,3), (1,3)(2,4) ])
 gap> Image( hom, (1,2,3) );
 (1,2,3)
-gap> Image( hom, DerivedSubgroup(s4) );
-Group([ (1,3,2), (1,3,2) ])
+gap> Size( Image( hom, DerivedSubgroup(s4) ) );
+3
 ]]></Example>
 <P/>
 <Log><![CDATA[
@@ -1178,7 +1178,7 @@ gap> niceaut := NiceObject( aut );
 Group([ (1,4,2,3), (1,5,4)(2,6,3), (1,2)(3,4), (3,4)(5,6) ])
 gap> IsomorphismGroups( niceaut, SymmetricGroup( 4 ) );
 [ (1,4,2,3), (1,5,4)(2,6,3), (1,2)(3,4), (3,4)(5,6) ] -> 
-[ (1,2,3,4), (1,2,4), (1,3)(2,4), (1,2)(3,4) ]
+[ (1,2,3,4), (2,3,4), (1,3)(2,4), (1,2)(3,4) ]
 ]]></Example>
 <P/>
 The range of  a nice monomorphism is  in most cases a permutation  group,

--- a/lib/error.g
+++ b/lib/error.g
@@ -278,6 +278,3 @@ BIND_GLOBAL("ErrorNoReturn",
          lateMessage := "type 'quit;' to quit to outer loop",
          printThisStatement := false), arg);
 end);
- 
-# HACK: remove this before final GAP 4.8 release
-BIND_GLOBAL("ErrorMayQuit", ErrorNoReturn);

--- a/lib/ghompcgs.gi
+++ b/lib/ghompcgs.gi
@@ -16,7 +16,14 @@ local p,q;
     p:=hom!.sourcePcgs;
     q:=hom!.sourcePcgsImages;
     hom!.sourcePcgsImagesPowers := List([1..Length(p)],
-      i->List([1..RelativeOrders(p)[i]-1], j->q[i]^j));
+      function (i)
+        local pow, j;
+        pow := [q[i]];
+        for j in [2..RelativeOrders(p)[i]-1] do
+            pow[j] := pow[j-1]*q[i];
+        od;
+        return pow;
+      end);
   fi;
   return hom!.sourcePcgsImagesPowers;
 end);

--- a/lib/gprd.gd
+++ b/lib/gprd.gd
@@ -220,8 +220,8 @@ DeclareGlobalFunction("SubdirectDiagonalPerms");
 ##  true
 ##  gap> p:=SemidirectProduct(g,apci,n);
 ##  <pc group of size 24 with 4 generators>
-##  gap> IsomorphismGroups(p,Group((1,2,3,4),(1,2)));
-##  [ f1, f2, f3, f4 ] -> [ (2,3), (1,2,3), (1,4)(2,3), (1,3)(2,4) ]
+##  gap> IsomorphismGroups(p,Group((1,2,3,4),(1,2))) <> fail;
+##  true
 ##  gap> SemidirectProduct(SU(3,3),GF(9)^3);
 ##  <matrix group of size 4408992 with 3 generators>
 ##  gap> SemidirectProduct(Group((1,2,3),(2,3,4)),GF(5)^4);

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -4126,7 +4126,7 @@ DeclareAttribute( "IsomorphismFpGroup", IsGroup );
 ##  #I  the image group has 3 gens and 11 rels of total length 92
 ##  gap> iso := IsomorphismFpGroupByGenerators( M12, gens : 
 ##  >                                           method := "fast" );;
-##  #I  the image group has 3 gens and 178 rels of total length 4001
+##  #I  the image group has 3 gens and 150 rels of total length 3336
 ##  ]]></Example>
 ##  <P/>
 ##  Though the option <C>method := "regular"</C> is only checked in the case
@@ -4148,7 +4148,7 @@ DeclareAttribute( "IsomorphismFpGroup", IsGroup );
 ##    [ [ 0, 1, 0, 0, 0 ], [ 0, 0, 1, 0, 0 ], [ 0, 0, 0, 1, 0 ], 
 ##        [ 1, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 1 ] ] ]
 ##  gap> iso := IsomorphismFpGroupByGenerators( G, gens );;
-##  #I  the image group has 2 gens and 9 rels of total length 112
+##  #I  the image group has 2 gens and 10 rels of total length 126
 ##  gap> iso := IsomorphismFpGroupByGenerators( G, gens : 
 ##  >                                           method := "regular");;
 ##  #I  the image group has 2 gens and 6 rels of total length 56

--- a/lib/teaching.g
+++ b/lib/teaching.g
@@ -194,9 +194,9 @@ DeclareGlobalFunction("CosetDecomposition");
 ##  <A>H</A>-conjugacy.
 ##  <Example><![CDATA[
 ##  gap> AllHomomorphismClasses(SymmetricGroup(4),SymmetricGroup(3)); 
-##  [ [ (2,3,4), (1,4,3,2) ] -> [ (), () ], 
-##    [ (2,3,4), (1,4,3,2) ] -> [ (), (1,2) ], 
-##    [ (2,3,4), (1,4,3,2) ] -> [ (1,2,3), (1,2) ] ]
+##  [ [ (1,3,4,2), (1,2,4) ] -> [ (), () ], 
+##    [ (1,3,4,2), (1,2,4) ] -> [ (1,2), () ], 
+##    [ (1,3,4,2), (1,2,4) ] -> [ (2,3), (1,2,3) ] ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/tst/testinstall/mapping.tst
+++ b/tst/testinstall/mapping.tst
@@ -287,6 +287,17 @@ gap> IsGroupHomomorphism(res);
 true
 gap> IsInjective(res);        
 true
+
+# The following test verifies we handle pcgs with large primes in them efficiently.
+# See also GitHub pull request #576
+gap> V := AsVectorSpace (GF(2), GF(2^17));;
+gap> h := BlownUpMat(Basis(V), [[Z(2^17)]]);;
+gap> ConvertToMatrixRep(h);;
+gap> G := CyclicGroup (2^17-1);;
+gap> H := Group (h);;
+gap> hom := GroupHomomorphismByImagesNC (G, H, [G.1], [h]);;
+gap> ImagesRepresentative(hom, G.1^2) = h^2;
+true
 gap> STOP_TEST( "mapping.tst", 5520000);
 
 #############################################################################


### PR DESCRIPTION
This is a partial fix for a performance problem with GroupHomomorphismByImages for groups with pcgs when at least one of the relative orders of the pcgs is a large prime. 
```
V := AsVectorSpace (GF(2), GF(2^17));
h := BlownUpMat(Basis(V), [[Z(2^17)]]);
ConvertToMatrixRep(h);
G := CyclicGroup (2^17-1);;
H := Group (h);;
hom := GroupHomomorphismByImagesNC (G, H, [G.1], [h]);;
ImagesRepresentative(hom, G.1^2);
```
The last command takes around 90 seconds on my machine. This is caused by the code precomputing all powers of the pcgs images, in this case ≈ 130000 powers of a 17x17 matrix. 

The present fix replaces powering by repeated multiplication, which reduces the image calculation to approx. 1.5 seconds. 

Not an ideal solution imo, but at least an improvement which shouldn't cause any harm.
