### PR TITLE
Do not allow returning from break loop in GASMAN

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -1978,11 +1978,10 @@ Obj FuncGASMAN (
     Char                buf[41];
 
     /* check the argument                                                  */
-    while ( ! IS_SMALL_LIST(args) || LEN_LIST(args) == 0 ) {
-        args = ErrorReturnObj(
+    if ( ! IS_SMALL_LIST(args) || LEN_LIST(args) == 0 ) {
+        ErrorMayQuit(
             "usage: GASMAN( \"display\"|\"displayshort\"|\"clear\"|\"collect\"|\"message\"|\"partial\" )",
-            0L, 0L,
-            "you can replace the argument list <args> via 'return <args>;'" );
+            0L, 0L);
     }
 
     /* loop over the arguments                                             */


### PR DESCRIPTION
Fixes #580, (crash when returning from break loop), by just not allowing a return value.