### PR TITLE
Add FrattiniSubgroup for nilpotent groups

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1013,6 +1013,32 @@ RedispatchOnCondition( FittingSubgroup, true, [IsGroup], [IsFinite], 0);
 ##
 #M  FrattiniSubgroup( <G> ) . . . . . . . . . .  Frattini subgroup of a group
 ##
+InstallMethod( FrattiniSubgroup, "generic method for nilpotent groups",
+            [ IsGroup ],
+            RankFilter( IsGroup and IsNilpotentGroup )
+            - RankFilter( IsGroup ),
+function(G)
+local i, p, q, gen, Gf;
+    if IsTrivial(G) then
+      return G;
+    elif IsAbelian(G) then
+        gen := [ ];
+        for i in [1..Length(AbelianInvariants(G))] do
+            q := AbelianInvariants(G)[i];
+            if q<>0 and not IsPrime(q) then
+                p := SmallestRootInt(q);
+                Add(gen, IndependentGeneratorsOfAbelianGroup(G)[i]^p);
+            fi;
+        od;
+        return SubgroupNC(G, gen);
+    elif IsNilpotentGroup(G) then
+        Gf := CommutatorFactorGroup(G);
+        return PreImage(NaturalHomomorphism(Gf), FrattiniSubgroup(Gf));
+    else
+        TryNextMethod();
+    fi;
+end);
+
 InstallMethod( FrattiniSubgroup, "generic method for groups", [ IsGroup ],0,
 function(G)
 local m;

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1018,16 +1018,18 @@ InstallMethod( FrattiniSubgroup, "generic method for nilpotent groups",
             RankFilter( IsGroup and IsNilpotentGroup )
             - RankFilter( IsGroup ),
 function(G)
-local i, p, q, gen, Gf;
+local i, abinv, indgen, p, q, gen, Gf;
     if IsTrivial(G) then
       return G;
     elif IsAbelian(G) then
         gen := [ ];
-        for i in [1..Length(AbelianInvariants(G))] do
-            q := AbelianInvariants(G)[i];
+        abinv := AbelianInvariants(G);
+        indgen := IndependentGeneratorsOfAbelianGroup(G);
+        for i in [1..Length(abinv)] do
+            q := abinv[i];
             if q<>0 and not IsPrime(q) then
                 p := SmallestRootInt(q);
-                Add(gen, IndependentGeneratorsOfAbelianGroup(G)[i]^p);
+                Add(gen, indgen[i]^p);
             fi;
         od;
         return SubgroupNC(G, gen);

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1018,7 +1018,7 @@ InstallMethod( FrattiniSubgroup, "generic method for nilpotent groups",
             RankFilter( IsGroup and IsNilpotentGroup )
             - RankFilter( IsGroup ),
 function(G)
-local i, abinv, indgen, p, q, gen, Gf;
+local i, abinv, indgen, p, q, gen, hom, Gf;
     if IsTrivial(G) then
       return G;
     elif IsAbelian(G) then
@@ -1034,8 +1034,10 @@ local i, abinv, indgen, p, q, gen, Gf;
         od;
         return SubgroupNC(G, gen);
     elif IsNilpotentGroup(G) then
-        Gf := CommutatorFactorGroup(G);
-        return PreImage(NaturalHomomorphism(Gf), FrattiniSubgroup(Gf));
+        hom := MaximalAbelianQuotient(G);
+        Gf := Image(hom);
+        SetIsAbelian(Gf, true);
+        return PreImage(hom, FrattiniSubgroup(Gf));
     else
         TryNextMethod();
     fi;

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -1593,15 +1593,14 @@ end );
 ##
 InstallMethod( FrattiniSubgroup,"for permgrp", true, [ IsPermGroup ], 0,
     function( G )
-    local   fac,  p,  l,  k,  i,  j;
+    local   p,  l,  k,  i,  j;
 
-    fac := Set( FactorsInt( Size( G ) ) );
-    if Length( fac ) > 1  then
+    if not IsPGroup( G ) then
         TryNextMethod();
-    elif fac[1]=1 then
+    elif IsTrivial( G ) then
       return G;
     fi;
-    p := fac[ 1 ];
+    p := PrimePGroup( G );
     l := GeneratorsOfGroup( G );
     k := [ l[1]^p ];
     for i  in [ 2 .. Length(l) ]  do

--- a/tst/testinstall/opers/FrattiniSubgroup.tst
+++ b/tst/testinstall/opers/FrattiniSubgroup.tst
@@ -1,6 +1,26 @@
 gap> START_TEST("FrattiniSubgroup.tst");
 
 #
+gap> FrattiniSubgroup(Group(()));
+Group(())
+gap> FrattiniSubgroup(Group((1,3),(1,2,3,4)));
+Group([ (1,3)(2,4) ])
+gap> D := DihedralGroup(IsFpGroup,8);;
+gap> FrattiniSubgroup(D)=Group([ D.1^2 ]);
+true
+gap> F := FreeGroup("x", "y", "z");; x := F.1;; y := F.2;; z := F.3;;
+gap> G := F/[x^(-1)*y^(-1)*x*y, x^(-1)*z^(-1)*x*z, z^(-1)*y^(-1)*z*y, x^180, y^168];;
+gap> HasIsAbelian(FrattiniSubgroup(G));
+true
+gap> GeneratorsOfGroup(FrattiniSubgroup(G));
+[ (x^-195*y^196)^6, (x^-1*y)^630, (x^-1*y)^840 ]
+gap> F := FrattiniSubgroup(DirectProduct(DihedralGroup(IsFpGroup,8), SmallGroup(27,4)));;
+gap> IdGroup(F);
+[ 6, 2 ]
+gap> HasIsNilpotentGroup(F);
+true
+
+#
 gap> FrattiniSubgroup(SymmetricGroup(3));
 Group(())
 gap> FrattiniSubgroup(SymmetricGroup(4));


### PR DESCRIPTION
General FrattiniSubgroup method is added for nilpotent groups. Now this
works for fp-groups, as well, see test examples.
Further, the nilpotent permutation p-group case is enhanced (no factorization is needed, only checking if a group is a p-group). I am not entirely sure if this permgroup method here is really needed, though, because this new general method for any nilpotent group should really cover it. 

Tests are added.

The test file may conflict with #400 after that has been merged. Further, currently ````IsNilpotent```` is not really good with nilpotent fp-groups, because in computing ````LowerCentralSeries```` checking if two groups are equal might not terminate.
