### PR TITLE
Rewrite DerivedSeriesOfGroup to check for abelian derived subgroups

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -778,16 +778,28 @@ InstallMethod( DerivedSeriesOfGroup,
     fi;
 
     # compute the series by repeated calling of `DerivedSubgroup'
-    S := [ G ];
-    Info( InfoGroup, 2, "DerivedSeriesOfGroup: step ", Length(S) );
-    D := DerivedSubgroup( G );
-    while D <> S[ Length(S) ]  do
-        Add( S, D );
-        Info( InfoGroup, 2, "DerivedSeriesOfGroup: step ", Length(S) );
-        D := DerivedSubgroup( D );
-    od;
+    S := [ ];
+    repeat
+        if S = [ ] then
+            D := G;
+        else
+            Info( InfoGroup, 2, "DerivedSeriesOfGroup: step ", Length(S) );
+            D := DerivedSubgroup( D );
+        fi;
+        Add(S, D);
+        if IsAbelian(D) then
+            if not IsTrivial(G) then
+                Info( InfoGroup, 2, "DerivedSeriesOfGroup: step ", Length(S) );
+                Add(S, TrivialSubgroup(G));
+            fi;
+            SetIsSolvableGroup(G, true);
+            return S;
+        fi;
+    until D = DerivedSubgroup(D);
 
     # return the series when it becomes stable
+    # this can only run if G was nonsolvable
+    SetIsSolvableGroup(G, false);
     return S;
     end );
 

--- a/tst/testinstall/opers/IsSolvableGroup.tst
+++ b/tst/testinstall/opers/IsSolvableGroup.tst
@@ -1,0 +1,33 @@
+gap> START_TEST("IsSolvableGroup.tst");
+gap> List(AllGroups(120), IsSolvableGroup);
+[ true, true, true, true, false, true, true, true, true, true, true, true, 
+  true, true, true, true, true, true, true, true, true, true, true, true, 
+  true, true, true, true, true, true, true, true, true, false, false, true, 
+  true, true, true, true, true, true, true, true, true, true, true ]
+gap> List(AllTransitiveGroups(DegreeAction, 8), IsSolvable);
+[ true, true, true, true, true, true, true, true, true, true, true, true, 
+  true, true, true, true, true, true, true, true, true, true, true, true, 
+  true, true, true, true, true, true, true, true, true, true, true, true, 
+  false, true, true, true, true, true, false, true, true, true, true, false, 
+  false, false ]
+gap> IsSolvable(DihedralGroup(24));
+true
+gap> IsSolvable(DihedralGroup(IsFpGroup,24));
+true
+gap> DerivedSeries(Group(()));
+[ Group(()) ]
+gap> IsSolvableGroup(AbelianGroup([2,3,4,5,6,7,8,9,10]));
+true
+gap> IsSolvableGroup(AbelianGroup(IsFpGroup,[2,3,4,5,6,7,8,9,10]));
+true
+gap> IsSolvableGroup(Group(()));
+true
+gap> A := AbelianGroup([3,3,3]);; H := AutomorphismGroup(A);;
+gap> B := SylowSubgroup(H, 13);; G := SemidirectProduct(B, A);;
+gap> HasIsSolvableGroup(G) and IsSolvable(G);
+true
+gap> F := FreeGroup("r", "s");; r := F.1;; s := F.2;;
+gap> G := F/[s^2, s*r*s*r];;
+gap> IsSolvable(G);
+true
+gap> STOP_TEST("IsSolvableGroup.tst", 10000);


### PR DESCRIPTION
DerivedSeriesOfGroup is rewritten to check for the derived subgroup being
abelian. In some cases this may terminate for fp-groups for which the old
method did not, in the expense of an extra IsAbelian check for each term.
Insted of while do, repeat until is used to decrease code repetition.

Test file is added.

This is supposed to fix #584, where some discussion is already started. 

This attribute is one of the most basic in GAP, so please, everybody, (try to) tear it apart as long as it is not perfect.