### PR TITLE
Introduce NAME_OBJ_RNAM, and use to avoid GC issues with C strings

### DIFF
--- a/src/precord.c
+++ b/src/precord.c
@@ -722,7 +722,7 @@ Obj InnerRecNames( Obj rec )
     UInt                rnam;           /* one name of record              */
     Obj                 string;         /* one name as string              */
     UInt                i;
-
+    Obj                 name;
     SortPRecRNam(rec,0);   /* Make sure rnams are sorted and thus negative */
 
     /* allocate the list                                                   */
@@ -733,7 +733,8 @@ Obj InnerRecNames( Obj rec )
     for ( i = 1; i <= LEN_PREC(rec); i++ ) {
         rnam = -(Int)(GET_RNAM_PREC( rec, i ));
         /* could have been moved by garbage collection */
-        C_NEW_STRING_DYN( string, NAME_RNAM(rnam) );
+        name = NAME_OBJ_RNAM( rnam );
+        string = CopyToStringRep( name );
         SET_ELM_PLIST( list, i, string );
         CHANGED_BAG( list );
     }
@@ -1083,6 +1084,3 @@ StructInitInfo * InitInfoPRecord ( void )
 
 *E  precord.c . . . . . . . . . . . . . . . . . . . . . . . . . . . ends here
 */
-
-
-

--- a/src/records.c
+++ b/src/records.c
@@ -249,7 +249,7 @@ Obj             NameRNamHandler (
     Obj                 rnam )
 {
     Obj                 name;
-    Char                *cname;
+    Obj                 oname;
     while ( ! IS_INTOBJ(rnam)
          || INT_INTOBJ(rnam) <= 0
         || CountRNam < INT_INTOBJ(rnam) ) {
@@ -258,8 +258,8 @@ Obj             NameRNamHandler (
             (Int)TNAM_OBJ(rnam), 0L,
             "you can replace <rnam> via 'return <rnam>;'" );
     }
-    cname = NAME_RNAM( INT_INTOBJ(rnam) );
-    C_NEW_STRING_DYN( name, cname);
+    oname = NAME_OBJ_RNAM( INT_INTOBJ(rnam) );
+    name = CopyToStringRep(oname);
     return name;
 }
 
@@ -558,12 +558,12 @@ Obj FuncALL_RNAMES (
 {
     Obj                 copy, s;
     UInt                i;
-    Char*               name;
+    Obj                 name;
 
     copy = NEW_PLIST( T_PLIST+IMMUTABLE, CountRNam );
     for ( i = 1;  i <= CountRNam;  i++ ) {
-        name = NAME_RNAM( i );
-        C_NEW_STRING_DYN(s, name);
+        name = NAME_OBJ_RNAM( i );
+        s = CopyToStringRep(name);
         SET_ELM_PLIST( copy, i, s );
     }
     SET_LEN_PLIST( copy, CountRNam );
@@ -784,4 +784,3 @@ StructInitInfo * InitInfoRecords ( void )
 
 *E  records.c . . . . . . . . . . . . . . . . . . . . . . . . . . . ends here
 */
-

--- a/src/records.h
+++ b/src/records.h
@@ -19,15 +19,17 @@
 
 /****************************************************************************
 **
-
-*F  NAME_RNAM(<rnam>) . . . . . . . . . . . . . . . .  name for a record name
+*F  NAME_RNAM(<rnam>) . . . . . . . . . . .name for a record name as C string
+*F  NAME_OBJ_RNAM(<rnam>) . . . . . . . . .name for a record name as an Obj
 **
 **  'NAME_RNAM' returns the name (as a C string) for the record name <rnam>.
+**  'NAME_OBJ_RNAM' returns the name (as an Obj) for the record name <rnam>.
 **
-**  Note that 'NAME_RNAM' is a  macro, so do not call  it with arguments that
-**  have side effects.
+**  Note that 'NAME_RNAM' and 'NAME_OBJ_RNAM' are macros, so do not call them
+**  with arguments that have side effects.
 */
 #define NAME_RNAM(rnam) CSTR_STRING( ELM_PLIST( NamesRNam, rnam ) )
+#define NAME_OBJ_RNAM(rnam) ELM_PLIST( NamesRNam, rnam )
 
 extern  Obj             NamesRNam;
 

--- a/src/string.c
+++ b/src/string.c
@@ -1440,6 +1440,8 @@ Obj CopyToStringRep(
     return (copy);
 }
 
+
+
 /****************************************************************************
 **
 *F  ConvString( <string> )  . . convert a string to the string representation


### PR DESCRIPTION
The macro `NAME_RNAM` returns a `char*` from inside a `Bag`, so it can't be used safely in situations where GC can occur.

This introduces `NAME_OBJ_RNAM`, which returns the `Bag` containing the string instead of a `char*`, and then uses that wherever approriate. Mostly changing copies of `C_NEW_STRING_DYN` (which makes a new bag which copies a `char*`) to `CopyToStringRep` (which copies a Bag containing a string). 