### PR TITLE
Copy filename before calling function which can GC

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -1116,6 +1116,8 @@ Obj FuncREAD_GAP_ROOT (
     Obj                 self,
     Obj                 filename )
 {
+    Char filenamecpy[4096];
+
     /* check the argument                                                  */
     while ( ! IsStringConv( filename ) ) {
         filename = ErrorReturnObj(
@@ -1124,8 +1126,10 @@ Obj FuncREAD_GAP_ROOT (
             "you can replace <filename> via 'return <filename>;'" );
     }
 
+    /* Copy to avoid garbage collection moving string                      */
+    strlcpy(filenamecpy, CSTR_STRING(filename), 4096);
     /* try to open the file                                                */
-    return READ_GAP_ROOT(CSTR_STRING(filename)) ? True : False;
+    return READ_GAP_ROOT(filenamecpy) ? True : False;
 }
 
 


### PR DESCRIPTION
This function stops is passing a C pointer to a string in a bag to `READ_GAP_ROOT`.

There is one unpleasantness - We allocate a big (4096 character) buffer to store the copy in. This should be big enough for any filename! I thought about trying to get `PATH_MAX`, but (a) it is often set to 4096 it seems, and (b) sometimes it isn't defined.