### PR TITLE
Make FittingSubgroup method immediate for nilpotent groups

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -989,8 +989,8 @@ InstallMethod( Exponent,
 ##
 #M  FittingSubgroup( <G> )  . . . . . . . . . . . Fitting subgroup of a group
 ##
-InstallMethod( FittingSubgroup, "for nilpotent group",
-    [ IsGroup and IsNilpotentGroup ], SUM_FLAGS, IdFunc );
+InstallImmediateMethod( FittingSubgroup,
+    IsGroup and IsNilpotentGroup, SUM_FLAGS, IdFunc );
 
 InstallMethod( FittingSubgroup,
     "generic method for groups",

--- a/tst/testinstall/opers/FittingSubgroup.tst
+++ b/tst/testinstall/opers/FittingSubgroup.tst
@@ -18,7 +18,7 @@ true
 #
 gap> List(AllSmallGroups(60), g -> Size(FittingSubgroup(g)));
 [ 30, 30, 30, 60, 1, 15, 15, 15, 20, 30, 30, 30, 60 ]
-gap> ForAll(AllSmallGroups(60), g -> IsNormal(g, FrattiniSubgroup(g)));
+gap> ForAll(AllSmallGroups(60), g -> IsNormal(g, FittingSubgroup(g)));
 true
 
 #
@@ -39,9 +39,9 @@ gap> f := FittingSubgroup(g);;
 gap> HasIsNilpotentGroup(f);
 true
 gap> p := SylowSubgroup(g, 2);;
-gap> HasIsNilpotentGroup(p);
+gap> HasIsNilpotentGroup(p) and IsNilpotentGroup(p);
 true
-gap> HasIsNilpotentGroup(FittingSubgroup(p));
+gap> HasFittingSubgroup(p) and HasIsNilpotentGroup(FittingSubgroup(p)) and FittingSubgroup(p)=p;
 true
 
 #


### PR DESCRIPTION
This is a continuation of #400 to make FittingSubgroup method immediate for nilpotent groups. 
Further, FrattiniSubgroup is rewritten to FittingSubgroup in the tst file,
and the immediatemethod is checked, as well.
