### PR TITLE
Fix crash when using non-positive index in Add (and CopyListEntries)

### DIFF
--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -148,7 +148,7 @@ Obj FuncADD_LIST3 (
   Int ipos;
   if (pos == (Obj)0)
     ipos = -1;
-  else if (IS_INTOBJ(pos))
+  else if (IS_INTOBJ(pos) && INT_INTOBJ(pos) > 0)
     ipos = INT_INTOBJ(pos);
   else {
     DoOperation3Args( self, list,  obj, pos);

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1676,11 +1676,10 @@ static inline Int GetIntObj( Obj list, UInt pos)
       Pr("panic: internal inconsistency", 0L, 0L);
       SyExit(1);
     }
-  while (!IS_INTOBJ(entry))
+  if (!IS_INTOBJ(entry))
     {
-      entry = ErrorReturnObj("COPY_LIST_ENTRIES: argument %d  must be a small integer, not a %s",
-                             (Int)pos, (Int)InfoBags[TNUM_OBJ(entry)].name,
-                             "you can return a small integer to continue");
+      ErrorMayQuit("COPY_LIST_ENTRIES: argument %d  must be a small integer, not a %s",
+                   (Int)pos, (Int)InfoBags[TNUM_OBJ(entry)].name);
     }
   return INT_INTOBJ(entry);
 }
@@ -1688,10 +1687,10 @@ static inline Int GetIntObj( Obj list, UInt pos)
 Obj FuncCOPY_LIST_ENTRIES( Obj self, Obj args )
 {  
   Obj srclist;
-  UInt srcstart;
+  Int srcstart;
   Int srcinc;
   Obj dstlist;
-  UInt dststart;
+  Int dststart;
   Int dstinc;
   UInt number;
   UInt srcmax;
@@ -1715,14 +1714,13 @@ Obj FuncCOPY_LIST_ENTRIES( Obj self, Obj args )
       Pr("panic: internal inconsistency", 0L, 0L);
       SyExit(1);
     }
-  while (!IS_PLIST(srclist))
+  if (!IS_PLIST(srclist))
     {
-      srclist = ErrorReturnObj("COPY_LIST_ENTRIES: source must be a plain list not a %s",
-                               (Int)InfoBags[TNUM_OBJ(srclist)].name, 0L,
-                               "you can return a plain list to continue");
+      ErrorMayQuit("COPY_LIST_ENTRIES: source must be a plain list not a %s",
+                   (Int)InfoBags[TNUM_OBJ(srclist)].name, 0L);
     }
 
-  srcstart = (UInt)GetIntObj(args,2);
+  srcstart = GetIntObj(args,2);
   srcinc = GetIntObj(args,3);
   dstlist = ELM_PLIST(args,4);
   if (!dstlist)
@@ -1732,17 +1730,22 @@ Obj FuncCOPY_LIST_ENTRIES( Obj self, Obj args )
     }
   while (!IS_PLIST(dstlist) || !IS_MUTABLE_OBJ(dstlist))
     {
-      dstlist = ErrorReturnObj("COPY_LIST_ENTRIES: destination must be a mutable plain list not a %s",
-                               (Int)InfoBags[TNUM_OBJ(dstlist)].name, 0L,
-                               "you can return a plain list to continue");
+      ErrorMayQuit("COPY_LIST_ENTRIES: destination must be a mutable plain list not a %s",
+                   (Int)InfoBags[TNUM_OBJ(dstlist)].name, 0L);
     }
-  dststart = (UInt)GetIntObj(args,5);
+  dststart = GetIntObj(args,5);
   dstinc = GetIntObj(args,6);
   number = GetIntObj(args,7);
   
   if (number == 0)
     return (Obj) 0;
   
+  if ( srcstart <= 0 || dststart <= 0 ||
+       srcstart + (number-1)*srcinc <= 0 || dststart + (number-1)*dstinc <= 0)
+    {
+      ErrorMayQuit("COPY_LIST_ENTRIES: list indices must be positive integers",0L,0L);
+    }
+
   srcmax = (srcinc > 0) ? srcstart + (number-1)*srcinc : srcstart;
   dstmax = (dstinc > 0) ? dststart + (number-1)*dstinc : dststart;
   

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -112,6 +112,28 @@ gap> res := foo(o);
 [ [ 1, 2, 3 ], [ 4, 5 ], [ 1, 2, 3 ], [ 4, 5 ], function(  ) ... end ]
 gap> res[5]();
 [ [ 6, 7 ], [ 5, 6, 7 ] ]
+gap> s := [];; Add(s, 1); s;
+[ 1 ]
+gap> Add(s, 4); s;
+[ 1, 4 ]
+gap> s := [];; Add(s,1,3); s;
+[ ,, 1 ]
+gap> s := [];; Add(s,1,1); s;
+[ 1 ]
+gap> s := [];; Add(s, ' ',1); s;
+" "
+gap> s := [];; Add(s, ' ',2); s;
+[ , ' ' ]
+gap> s := [];; Add(s, 0, 0);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `Add' on 3 arguments
+gap> s;
+[  ]
+gap> s := [];; Add(s, 0, -1);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `Add' on 3 arguments
+gap> s;
+[  ]
 
 # that's all, folks
 gap> STOP_TEST( "listgen.tst", 320000);

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -134,6 +134,50 @@ Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Add' on 3 arguments
 gap> s;
 [  ]
+gap> s := [1,2,3];; l := [4,5,6];;
+gap> CopyListEntries(s,1,1,l,1,1,1); l;
+[ 1, 5, 6 ]
+gap> CopyListEntries(s,2,2,l,2,2,1); l;
+[ 1, 2, 6 ]
+gap> CopyListEntries(s,8,2,l,1,1,2); l;
+[ ,, 6 ]
+gap> CopyListEntries(s,3,-1,l,1,1,2); l;
+[ 3, 2, 6 ]
+gap> CopyListEntries(s,3,-1,l,6,-1,2); l;
+[ 3, 2, 6,, 2, 3 ]
+gap> CopyListEntries(s,3,-1,l,4,-3,2); l;
+[ 2, 2, 6, 3, 2, 3 ]
+gap> CopyListEntries("abc",3,-1,l,4,-3,2);
+Error, COPY_LIST_ENTRIES: source must be a plain list not a list (string)
+gap> CopyListEntries(s,3,-1,"abc",4,-3,2);
+Error, COPY_LIST_ENTRIES: destination must be a mutable plain list not a list \
+(string)
+gap> CopyListEntries(s,3,-1,Immutable([1,2,3]),4,-3,2);
+Error, COPY_LIST_ENTRIES: destination must be a mutable plain list not a list \
+(plain,cyc,imm)
+gap> CopyListEntries(s, "cheese", 1, l, 1, 1, 2);
+Error, COPY_LIST_ENTRIES: argument 2  must be a small integer, not a list (str\
+ing)
+gap> CopyListEntries(s, 1, "cheese", l, 1, 1, 2);
+Error, COPY_LIST_ENTRIES: argument 3  must be a small integer, not a list (str\
+ing)
+gap> CopyListEntries(s, 1, 1, l, "cheese", 1, 2);
+Error, COPY_LIST_ENTRIES: argument 5  must be a small integer, not a list (str\
+ing)
+gap> CopyListEntries(s, 1, 1, l, 1, "cheese", 2);
+Error, COPY_LIST_ENTRIES: argument 6  must be a small integer, not a list (str\
+ing)
+gap> CopyListEntries(s, 1, 1, l, 1, 1, "cheese");
+Error, COPY_LIST_ENTRIES: argument 7  must be a small integer, not a list (str\
+ing)
+gap> CopyListEntries(s,0,1,l,1,1,2);
+Error, COPY_LIST_ENTRIES: list indices must be positive integers
+gap> CopyListEntries(s,1,-1,l,1,1,2);
+Error, COPY_LIST_ENTRIES: list indices must be positive integers
+gap> CopyListEntries(s,1,1,l,1,-1,2);
+Error, COPY_LIST_ENTRIES: list indices must be positive integers
+gap> CopyListEntries(s,1,1,l,0,1,2);
+Error, COPY_LIST_ENTRIES: list indices must be positive integers
 
 # that's all, folks
 gap> STOP_TEST( "listgen.tst", 320000);


### PR DESCRIPTION
This fixes `Add(l,b,0)` (or any negative integer as final argument) segfaulting. This was (I think) introduced during allowing non-positive integers as list indices.

I had a quick check to see if any other list functions had similar issues, and found `CopyListEntries` has similar issues, but they go back to it's introduction. This are also fixed here (I changed some `ErrorReturnObj` to `ErrorMayQuit`, because I couldn't be bothered making the new logic fix `ErrorReturnObj`).