### PR TITLE
Disable do od functions

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1529,7 +1529,9 @@ void ReadLiteral (
     /* <Function>                                                          */
     case S_FUNCTION:
     case S_ATOMIC:
+#ifdef HPCGAP
     case S_DO:
+#endif
         ReadFuncExpr( follow, mode );
         break;
 
@@ -1583,8 +1585,11 @@ void ReadAtom (
     }
     /* otherwise read a literal expression                                 */
     else if (IS_IN(TLS(Symbol),S_INT|S_TRUE|S_FALSE|S_CHAR|S_STRING|S_LBRACK|
-                          S_REC|S_FUNCTION|S_DO|S_ATOMIC| S_FLOAT | S_DOT |
-                         S_MAPTO))
+                          S_REC|S_FUNCTION|
+#ifdef HPCGAP
+                          S_DO|
+#endif
+                          S_ATOMIC|S_FLOAT|S_DOT|S_MAPTO))
     {
         ReadLiteral( follow, mode );
     }


### PR DESCRIPTION
During the HPC-GAP merge, at some point we pulled in 'do od' functions, a little-known HPC-GAP function.

These allows a function which takes no arguments to be written as 'do ... od'. For example:

```
gap> y := 0;
gap> x := do y := y + 1; return y; od;
gap> x();
1
gap> x();
2
```

I'm personally not convinced by this feature, but it certainly shouldn't sneak into GAP accidentally!

This patch removes the code from stable-4.8, where it hopefully hasn't been in the wild long enough for anyone to use it.