### PR TITLE
Fix for using default browser to view help on Windows

### DIFF
--- a/lib/helpview.gi
+++ b/lib/helpview.gi
@@ -69,19 +69,18 @@ if ARCH_IS_WINDOWS() then
   HELP_VIEWER_INFO.browser := rec(
   type := "url",
   show := function( filename )
-    local pos;
+    local pos, winfilename;
     if not filename{[1..9]}="/cygdrive" then
-      Error( "corrupted name of the help file ", filename );
+      Error( "the name of the help file ", filename , " must start with /cygdrive" );
+    else
+      winfilename:=MakeExternalFilename( SplitString( filename, "#" )[1] );
     fi;
-    Print( "Opening help page in default windows browser ... \c" );
-    Process( DirectoryCurrent(),
-             Filename( DirectoriesLibrary( "bin" ), "cygstart.exe" ),
-             InputTextNone(),
-             OutputTextNone(),
-             [ SplitString( filename, "#" )[1] ] );
+    Print( "Opening help page ", winfilename, " in default windows browser ... \c" );
+    Exec( Concatenation("start ", winfilename ) );
     Print( "done! \n" );         
   end
   );
+
 
 elif ARCH_IS_MAC_OS_X() then
   # html version using Mac OS X default browser


### PR DESCRIPTION
This fixes #361. Now Windows users are able to call
```
SetHelpViewer("browser");
```
and use their default browser to view GAP help pages. 

The same limitation applies as before: this will navigate to the beginning of the corresponding help file, and not to the exact location in the manual.

