### PR TITLE
Increase initial size of global variables and record names tables

### DIFF
--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1188,7 +1188,7 @@ static Int InitLibrary (
     SET_LEN_PLIST( FopiesGVars, 0 );
 
     /* make the list of global variables                                   */
-    SizeGVars  = 997;
+    SizeGVars  = 14033;
     TableGVars = NEW_PLIST( T_PLIST, SizeGVars );
     SET_LEN_PLIST( TableGVars, SizeGVars );
 

--- a/src/records.c
+++ b/src/records.c
@@ -739,7 +739,7 @@ static Int InitLibrary (
     SET_LEN_PLIST( NamesRNam, 0 );
 
     /* make the hash list of record names                                  */
-    SizeRNam = 997;
+    SizeRNam = 14033;
     HashRNam = NEW_PLIST( T_PLIST, SizeRNam );
     MakeBagPublic(HashRNam);
     SET_LEN_PLIST( HashRNam, SizeRNam );


### PR DESCRIPTION
This just increases some old constants (the number of global variables, and the number of record names). I have just moved them to approximately what they are when I run `gap -A`, so GAP doesn't thrash starting up increasing the sizes of these tables.

This speeds GAP's startup very slightly (~2% on my machine), and doesn't use any extra memory, as these tables get to this size anyway.