### PR TITLE
Info messages when loading package fails

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1485,6 +1485,12 @@ InstallGlobalFunction( LoadPackage, function( arg )
       else
         LogPackageLoadingMessage( PACKAGE_DEBUG,
             "return from LoadPackage, package is not available", Name );
+        if banner then
+          if InfoLevel(InfoPackageLoading) < 4 then
+            Info(InfoWarning,1, Name, " package is not available. To see further details, enter");
+            Info(InfoWarning,1, "SetInfoLevel(InfoPackageLoading,4); and try to load the package again.");
+          fi;
+        fi;
       fi;
       GAPInfo.LoadPackageLevel:= GAPInfo.LoadPackageLevel - 1;
       return path;

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1422,6 +1422,10 @@ InstallGlobalFunction( LoadPackage, function( arg )
     if not IsBound( GAPInfo.PackagesInfo.( name ) ) then
       LogPackageLoadingMessage( PACKAGE_DEBUG,
           "no package with this name is installed, return 'fail'", name );
+      if InfoLevel(InfoPackageLoading) < 4 then
+        Info(InfoWarning,1, name, " package is not available. Check that the name is correct");
+        Info(InfoWarning,1, "and it is present in one of the GAP root directories (see '??RootPaths')");
+      fi;
       return fail;
     fi;
 

--- a/tst/teststandard/bugfix.tst
+++ b/tst/teststandard/bugfix.tst
@@ -2855,7 +2855,7 @@ gap> if LoadPackage("tomlib", false) <> fail then
 # Tests requiring CTblLib
 
 # 2005/08/29 (TB)
-gap> LoadPackage("ctbllib", "=0.0");
+gap> LoadPackage("ctbllib", "=0.0",false);
 fail
 
 ##  Bug 18 for fix 4


### PR DESCRIPTION
This PR attempts to address #480 by suggesting to increase InfoPackageLoading and retry to load the package. This happens only if `banner=true` when the package is loaded. 

For example,

```
gap> LoadPackage("openmath");
#I  OpenMath package is not available. To see further details, enter
#I  SetInfoLevel(InfoPackageLoading,4); and try to load the package again.
fail
gap> SetInfoLevel(InfoPackageLoading,4); 
gap> LoadPackage("openmath");
#I  OpenMath: entering LoadPackage 
#I  OpenMath: PackageAvailabilityInfo for version 11.3.1
#I  OpenMath: PackageAvailabilityInfo: the AvailabilityTest function returned 'true'
#I  OpenMath: PackageAvailabilityInfo: check needed packages
#I            GapDoc (>= 1.3)
#I            IO (>= 3.0)
#I  IO: PackageAvailabilityInfo for version 4.4.4
#I      (required: >= 3.0)
#I  IO: PackageAvailabilityInfo: the AvailabilityTest function returned fail
#I  IO: PackageAvailabilityInfo: no installed version fits
#I  OpenMath: PackageAvailabilityInfo: dependency 'io' is not satisfied
#I  OpenMath: PackageAvailabilityInfo: check of needed packages done
#I  OpenMath: PackageAvailabilityInfo: no installed version fits
#I  OpenMath: return from LoadPackage, package is not available
fail
gap> 
```