### PR TITLE
ViewString for function

### DIFF
--- a/lib/function.g
+++ b/lib/function.g
@@ -548,59 +548,6 @@ BIND_GLOBAL( "ReturnFirst", RETURN_FIRST );
 BIND_GLOBAL( "IdFunc", ID_FUNC );
 
 
-#############################################################################
-##
-#M  ViewObj( <func> ) . . . . . . . . . . . . . . . . . . . . . . view method
-##
-InstallMethod( ViewObj, "for a function", true, [IsFunction], 0,
-        function ( func )
-    local  locks, nams, narg, i, isvarg;
-    isvarg := false;
-    locks := LOCKS_FUNC(func);
-    if locks <> fail then
-        Print("atomic ");
-    fi;
-    Print("function( ");
-    nams := NAMS_FUNC(func);
-    narg := NARG_FUNC(func);
-    if narg < 0 then
-        isvarg := true;
-        narg := -narg;
-    fi;
-    if narg = 1 and nams <> fail and nams[1] = "arg" then
-        isvarg := true;
-    fi;
-    if narg <> 0 then
-        if nams = fail then
-            Print( "<",narg," unnamed arguments>" );
-        else
-            if locks <> fail then
-                if locks[1] = '\001' then
-                    Print("readonly ");
-                elif locks[1] = '\002' then
-                    Print("readwrite ");
-                fi;
-            fi;
-            Print(nams[1]);
-            for i in [2..narg] do
-                if locks <> fail then
-                    if locks[i] = '\001' then
-                        Print("readonly ");
-                    elif locks[i] = '\002' then
-                        Print("readwrite ");
-                    fi;
-                fi;
-                Print(", ",nams[i]);
-            od;
-        fi;
-        if isvarg then
-            Print("...");
-        fi;
-    fi;    
-    Print(" ) ... end");
-end);
-
-    
 BIND_GLOBAL( "PRINT_OPERATION",    function ( op )
     local   class,  flags,  types,  catok,  repok,  propok,  seenprop,  
             t;

--- a/lib/function.gi
+++ b/lib/function.gi
@@ -75,11 +75,52 @@ InstallGlobalFunction("CallWithTimeoutList",
     return CALL_WITH_TIMEOUT(seconds, microseconds, func, arglist);
 end);
 
-    
-        
-        
-        
-        
-                
-       
-                  
+InstallMethod( ViewString, "for a function", true, [IsFunction], 0,
+function(func)
+    local  locks, nams, narg, i, isvarg, result;
+    result := "";
+    isvarg := false;
+    locks := LOCKS_FUNC(func);
+    if locks <> fail then
+        Append(result, "atomic ");
+    fi;
+    Append(result, "function( ");
+    nams := NAMS_FUNC(func);
+    narg := NARG_FUNC(func);
+    if narg < 0 then
+        isvarg := true;
+        narg := -narg;
+    fi;
+    if narg = 1 and nams <> fail and nams[1] = "arg" then
+        isvarg := true;
+    fi;
+    if narg <> 0 then
+        if nams = fail then
+            Append(result, STRINGIFY("<",narg," unnamed arguments>"));
+        else
+            if locks <> fail then
+                if locks[1] = '\001' then
+                    Append(result, "readonly ");
+                elif locks[1] = '\002' then
+                    Append(result, "readwrite ");
+                fi;
+            fi;
+            Append(result, nams[1]);
+            for i in [2..narg] do
+                if locks <> fail then
+                    if locks[i] = '\001' then
+                        Append(result, "readonly ");
+                    elif locks[i] = '\002' then
+                        Append(result, "readwrite ");
+                    fi;
+                fi;
+                Append(result, STRINGIFY(", ",nams[i]));
+            od;
+        fi;
+        if isvarg then
+            Append(result, "...");
+        fi;
+    fi;
+    Append(result, " ) ... end");
+    return result;
+end);


### PR DESCRIPTION
This installs a method for `ViewString` for functions, and removes the `ViewObj` method for functions.

I don't know whether there was a reason to install `ViewObj` in `function.g`, it would have installed this method earlier in the loading process, but tests pass here with the change.

I noticed that there is no `ViewString` for functions because I use ViewString in the Jupyter kernel.