### PR TITLE
Add a git mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,10 @@
+Alexander Konovalov <alexk@mcs.st-andrews.ac.uk> <alex-konovalov@users.noreply.github.com>
+Chris Jefferson <caj21@st-andrews.ac.uk>
+Markus Pfeiffer <markus.pfeiffer@st-andrews.ac.uk> <markus.pfeiffer@morphism.de>
+Markus Pfeiffer <markus.pfeiffer@st-andrews.ac.uk> <markuspf@users.noreply.github.com>
+James Mitchell <jdm3@st-and.ac.uk> <jdm3@st-andrews.ac.uk>
+James Mitchell <jdm3@st-and.ac.uk> <james-d-mitchell@users.noreply.github.com>
+Steve Linton <steve.linton@st-andrews.ac.uk>
+Steve Linton <steve.linton@st-andrews.ac.uk> <sal@cs.st-andrews.ac.uk>
+Steve Linton <steve.linton@st-andrews.ac.uk> <ab8e9259@opayq.com>
+


### PR DESCRIPTION
This adds a git mailmap which ensures that `git shortlog -sne` gives more meaningful output. See also <https://www.kernel.org/pub/software/scm/git/docs/git-shortlog.html>