### PR TITLE
free groups: remove bad method, tweak DerivedSubgroup

### DIFF
--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -928,6 +928,10 @@ local hom,u;
   fi;
   u:=PreImage(hom,TrivialSubgroup(Range(hom)));
   SetIndexInWholeGroup(u,Size(Range(hom)));
+  if IsFreeGroup(G) and not IsAbelian(G) then
+    SetIsFinite(u,false);
+    SetIsFinitelyGeneratedGroup(u,false);
+  fi;
   return u;
 end);
 

--- a/lib/grpfree.gi
+++ b/lib/grpfree.gi
@@ -363,6 +363,7 @@ InstallMethod( IsCommutative,
 InstallMethod( IsSolvableGroup,
     "for a free group",
     [ IsFreeGroup ],
+    10, # rank it higher than the method in the fr package
     G -> IsAbelian( G ) );
 
 

--- a/lib/grpfree.gi
+++ b/lib/grpfree.gi
@@ -363,16 +363,7 @@ InstallMethod( IsCommutative,
 InstallMethod( IsSolvableGroup,
     "for a free group",
     [ IsFreeGroup ],
-    G -> IsFinitelyGeneratedGroup( G ) and IsAbelian( G ) );
-
-
-#############################################################################
-##
-#M  IsFinitelyGeneratedGroup( <G> ) . . . . . . . . . . . .  for a free group
-##
-InstallImmediateMethod( IsFinitelyGeneratedGroup,
-    IsFreeGroup and HasIndexInWholeGroup, 0,
-    G -> IndexInWholeGroup(G) < infinity );
+    G -> IsAbelian( G ) );
 
 
 #############################################################################


### PR DESCRIPTION
The IsFinitelyGeneratedGroup which I added in #625 is totally bogus. E.g. the subgroup `<F.1>` of F:=FreeGroup(2) has infinite index, but is still finitely generated. So is the derived sugbroup of a free group of rank 1.

Removed the bogus method completely. Since I couldn't think of a good "correct" alternative within GAP, I instead modified the DerivedSubgroup method for fp groups to handle free groups specially. This also achieves the goal, of making `IsSolvableGroup(DerivedSubgroup(FreeGroup(2)))` terminate in finite time.

Of course `fga` should be used for more complex computations with free groups, but I wanted to have this work even in plain GAP, as part of my program to fix all annoyances my students run into during my GAP based classes :-).

Thanks to @chsievers for pointing this embarassing mistake out to me!