### PR TITLE
Fix name of IsPositionLookupDictionary

### DIFF
--- a/lib/dict.gd
+++ b/lib/dict.gd
@@ -353,7 +353,7 @@ IsSortLookupDictionary:=NewRepresentation("IsSortLookupDictionary",
 ##
 IsPositionDictionary:=NewRepresentation("IsPositionDictionary",
   IsDictionaryDefaultRep,["domain","blist"] );
-IsPositionLookupDictionary:=NewRepresentation("IsPositionDictionary",
+IsPositionLookupDictionary:=NewRepresentation("IsPositionLookupDictionary",
   IsPositionDictionary and IsLookupDictionary,
   ["domain","blist","vals"] );
 
@@ -694,4 +694,3 @@ DeclareOperation( "SetHashEntry", [ IsHash and IsMutable, IsObject, IsObject ] )
 ##DeclareOperation( "AddHashEntryAtLastIndex", [ IsHash and IsMutable, IsObject ] );
 
 #E
-


### PR DESCRIPTION
Very boring patch, just confused me for a while (we have two representations called IsPositionDictionary)