### PR TITLE
add two tests for trivial cases which cause errors when nilmat is loaded

### DIFF
--- a/tst/testinstall/opers/Socle.tst
+++ b/tst/testinstall/opers/Socle.tst
@@ -89,4 +89,7 @@ gap> G := F/[x^2, y^2, x^(-1)*y^(-1)*x*y, z];;
 gap> IsFinite(G);;
 gap> Size(Socle(G));
 4
+gap> G := Group([], IdentityMat (4, GF(2)));;
+gap> IsTrivial(Socle(G));
+true
 gap> STOP_TEST("Socle.tst", 1);

--- a/tst/testinstall/opers/SylowSystem.tst
+++ b/tst/testinstall/opers/SylowSystem.tst
@@ -1,0 +1,5 @@
+gap> START_TEST("SylowSystem.tst");
+gap> G := Group([], IdentityMat (4, GF(2)));;
+gap> IsEmpty(SylowSystem(G));
+true
+gap> STOP_TEST("SylowSystem.tst", 10000);


### PR DESCRIPTION
When nilmat (v. 1.2) is loaded, the two added tests cause `Error`s. Do not merge before nilmat gets updated. The same error is also triggerred by CRISP automatic tests when nilmat is loaded.

This resolves #631. 
