### PR TITLE
restore doc/manualindex for gapmacro.tex

### DIFF
--- a/doc/manualindex
+++ b/doc/manualindex
@@ -1,0 +1,43 @@
+#!/bin/sh
+# lowercase all lines without an @ symbol
+awk '$0 !~ /@/ {$0=tolower($0)} {print}' $1.idx >$1.idl
+
+# call makeindex to sort indexentries and produce an index
+# ... this *needs* manual.mst to be in place, otherwise we'll end
+# up with a LaTeX style index with \begin{index} .. \end{index}
+makeindex -l $1.idl
+
+# put hyphenation help into long commands
+echo "Hyphenating long index entries"
+echo '{a=index($0,"`");\
+    if (a==0) {print $0;}\
+    else {\
+      b=index($0,"'"'"'");\
+      if (b-a>40) {\
+	anf=substr($0,1,a);\
+	mid=substr($0,a+1,b-a-1);\
+	end=substr($0,b);\
+	b=length(mid);\
+	i=1;\
+	cap=1;\
+	mid2=substr(mid,1,i-1);\
+	while (i<=length(mid)) {\
+	  c=substr(mid,i,1);\
+	  if (c!=tolower(c)){\
+	    if (cap==0) mid2 = mid2 "\\-";\
+	    cap=1;\
+	  }\
+	  else cap=0;\
+	  mid2=mid2 c;\
+	  i=i+1;\
+	}\
+	print anf mid2 end;\
+      }\
+      else print $0;\
+    }
+  }' >mh.awk
+cp $1.ind $1.idl
+awk -f mh.awk $1.idl >$1.ind
+
+# clean up
+rm $1.idl mh.awk

--- a/doc/manualindex
+++ b/doc/manualindex
@@ -24,7 +24,7 @@ echo '{a=index($0,"`");\
 	while (i<=length(mid)) {\
 	  c=substr(mid,i,1);\
 	  if (c!=tolower(c)){\
-	    if (cap==0) mid2 = mid2 "\\-";\
+	    if (cap==0) mid2 = mid2 "\\\-";\
 	    cap=1;\
 	  }\
 	  else cap=0;\


### PR DESCRIPTION
This addresses Issue #640.

My version of awk seems to need an extra backslash charater. How about others' versions?