### PR TITLE
Add file/line info to 'trying next' and vconstructors

### DIFF
--- a/lib/methsel.g
+++ b/lib/methsel.g
@@ -213,7 +213,15 @@ end;
 
 #F  # # # # # # # # # # #  verbose try next method  # # # # # # # # # # # # #
 ##
-
+NEXT_VMETHOD_PRINT_INFO := function ( methods, i, arity)
+    Print("#I Trying next: ", methods[(arity+4)*(i-1)+(arity+4)]);
+    if FILENAME_FUNC(methods[(arity+4)*(i-1)+(arity+2)]) <> fail then
+        Print(" at ",
+              FILENAME_FUNC(methods[(arity+4)*(i-1)+(arity+2)]), ":",
+              STARTLINE_FUNC(methods[(arity+4)*(i-1)+(arity+2)]));
+    fi;
+    Print("\n");
+end;
 
 
 #############################################################################
@@ -230,7 +238,7 @@ NEXT_VMETHOD_0ARGS := function ( operation, k )
         if methods[4*(i-1)+1]()
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[4*(i-1)+4], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 0);
                 return methods[4*(i-1)+2];
             else
                 j := j + 1;
@@ -255,7 +263,7 @@ NEXT_VMETHOD_1ARGS := function ( operation, k, type1 )
           and methods[5*(i-1)+1]( type1![1] )
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[5*(i-1)+5], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 1);
                 return methods[5*(i-1)+3];
             else
                 j := j + 1;
@@ -281,7 +289,7 @@ NEXT_VMETHOD_2ARGS := function ( operation, k, type1, type2 )
           and methods[6*(i-1)+1]( type1![1], type2![1] )
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[6*(i-1)+6], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 2);
                 return methods[6*(i-1)+4];
             else
                 j := j + 1;
@@ -308,7 +316,7 @@ NEXT_VMETHOD_3ARGS := function ( operation, k, type1, type2, type3 )
           and methods[7*(i-1)+1]( type1![1], type2![1], type3![1] )
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[7*(i-1)+7], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 3);
                 return methods[7*(i-1)+5];
             else
                 j := j + 1;
@@ -338,7 +346,7 @@ NEXT_VMETHOD_4ARGS := function ( operation, k, type1, type2, type3,
                                    type4![1] )
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[8*(i-1)+8], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 4);
                 return methods[8*(i-1)+6];
             else
                 j := j + 1;
@@ -369,7 +377,7 @@ NEXT_VMETHOD_5ARGS := function ( operation, k, type1, type2, type3,
                                    type4![1], type5![1] )
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[9*(i-1)+9], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 5);
                 return methods[9*(i-1)+7];
             else
                 j := j + 1;
@@ -401,7 +409,7 @@ NEXT_VMETHOD_6ARGS := function ( operation, k, type1, type2, type3,
                                    type4![1], type5![1], type6![1] )
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[10*(i-1)+10], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 6);
                 return methods[10*(i-1)+8];
             else
                 j := j + 1;
@@ -447,7 +455,7 @@ VCONSTRUCTOR_0ARGS := function ( operation )
     for i  in [1..LEN_LIST(methods)/4]  do
         if methods[4*(i-1)+1]()
         then
-            Print( "#I  ", methods[4*(i-1)+4], "\n" );
+            VMETHOD_PRINT_INFO(methods, i, 0);
             return methods[4*(i-1)+2];
         fi;
     od;
@@ -467,7 +475,7 @@ VCONSTRUCTOR_1ARGS := function ( operation, flags1 )
         if    IS_SUBSET_FLAGS( methods[5*(i-1)+2], flags1 )
           and methods[5*(i-1)+1]( flags1 )
         then
-            Print( "#I  ", methods[5*(i-1)+5], "\n" );
+            VMETHOD_PRINT_INFO(methods, i, 1);
             return methods[5*(i-1)+3];
         fi;
     od;
@@ -488,7 +496,7 @@ VCONSTRUCTOR_2ARGS := function ( operation, flags1, type2 )
           and IS_SUBSET_FLAGS( type2![2], methods[6*(i-1)+3] )
           and methods[6*(i-1)+1]( flags1, type2![1] )
         then
-            Print( "#I  ", methods[6*(i-1)+6], "\n" );
+            VMETHOD_PRINT_INFO(methods, i, 2);
             return methods[6*(i-1)+4];
         fi;
     od;
@@ -510,7 +518,7 @@ VCONSTRUCTOR_3ARGS := function ( operation, flags1, type2, type3 )
           and IS_SUBSET_FLAGS( type3![2], methods[7*(i-1)+4] )
           and methods[7*(i-1)+1]( flags1, type2![1], type3![1] )
         then
-            Print( "#I  ", methods[7*(i-1)+7], "\n" );
+            VMETHOD_PRINT_INFO(methods, i, 3);
             return methods[7*(i-1)+5];
         fi;
     od;
@@ -535,7 +543,7 @@ VCONSTRUCTOR_4ARGS := function ( operation, flags1, type2, type3,
           and  methods[8*(i-1)+1]( flags1, type2![1], type3![1],
                                    type4![1] )
         then
-            Print( "#I  ", methods[8*(i-1)+8], "\n" );
+            VMETHOD_PRINT_INFO(methods, i, 4);
             return methods[8*(i-1)+6];
         fi;
     od;
@@ -561,7 +569,7 @@ VCONSTRUCTOR_5ARGS := function ( operation, flags1, type2, type3,
           and  methods[9*(i-1)+1]( flags1, type2![1], type3![1],
                                    type4![1], type5![1] )
         then
-            Print( "#I  ", methods[9*(i-1)+9], "\n" );
+            VMETHOD_PRINT_INFO(methods, i, 5);
             return methods[9*(i-1)+7];
         fi;
     od;
@@ -588,7 +596,7 @@ VCONSTRUCTOR_6ARGS := function ( operation, flags1, type2, type3,
           and  methods[10*(i-1)+1]( flags1, type2![1], type3![1],
                                    type4![1], type5![1], type6![1] )
         then
-            Print( "#I  ", methods[10*(i-1)+10], "\n" );
+            VMETHOD_PRINT_INFO(methods, i, 6);
             return methods[10*(i-1)+8];
         fi;
     od;
@@ -627,7 +635,7 @@ NEXT_VCONSTRUCTOR_0ARGS := function ( operation, k )
         if methods[4*(i-1)+1]()
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[4*(i-1)+4], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 0);
                 return methods[4*(i-1)+2];
             else
                 j := j + 1;
@@ -652,7 +660,7 @@ NEXT_VCONSTRUCTOR_1ARGS := function ( operation, k, flags1 )
           and methods[5*(i-1)+1]( flags1 )
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[5*(i-1)+5], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 1);
                 return methods[5*(i-1)+3];
             else
                 j := j + 1;
@@ -678,7 +686,7 @@ NEXT_VCONSTRUCTOR_2ARGS := function ( operation, k, flags1, type2 )
           and methods[6*(i-1)+1]( flags1, type2![1] )
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[6*(i-1)+6], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 2);
                 return methods[6*(i-1)+4];
             else
                 j := j + 1;
@@ -705,7 +713,7 @@ NEXT_VCONSTRUCTOR_3ARGS := function ( operation, k, flags1, type2, type3 )
           and methods[7*(i-1)+1]( flags1, type2![1], type3![1] )
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[7*(i-1)+7], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 3);
                 return methods[7*(i-1)+5];
             else
                 j := j + 1;
@@ -735,7 +743,7 @@ NEXT_VCONSTRUCTOR_4ARGS := function ( operation, k, flags1, type2, type3,
                                    type4![1] )
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[8*(i-1)+8], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 4);
                 return methods[8*(i-1)+6];
             else
                 j := j + 1;
@@ -766,7 +774,7 @@ NEXT_VCONSTRUCTOR_5ARGS := function ( operation, k, flags1, type2, type3,
                                    type4![1], type5![1] )
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[9*(i-1)+9], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 5);
                 return methods[9*(i-1)+7];
             else
                 j := j + 1;
@@ -798,7 +806,7 @@ NEXT_VCONSTRUCTOR_6ARGS := function ( operation, k, flags1, type2, type3,
                                    type4![1], type5![1], type6![1] )
         then
             if k = j  then
-                Print( "#I  trying next: ", methods[10*(i-1)+10], "\n" );
+                NEXT_VMETHOD_PRINT_INFO(methods, i, 6);
                 return methods[10*(i-1)+8];
             else
                 j := j + 1;


### PR DESCRIPTION
Previously, line/file info was added to trace methods.

This info wasn't in 'trying next' lines, or constructors. Now it is.

First I show some new output, then the old output below. Notice more lines now have file:line info.

The remaining missing lines are:

* system getter : There is no line number :)
* =: for `infinity` and cyclotomic : This is just set to `ReturnFalse`, which is a system call. In general, these line numbers are the actual functions, not the location of the `InstallMethod`, which some users might want, but we can't sensibly store anyway.

I'd like to put this patch into 4.8 as well, but I'm happy if we decide it shouldn't be.

```
gap> TraceAllMethods();;
gap> Union(Rationals, Integers);;
#I  Size: system getter
#I  =: for `infinity' and cyclotomic
#I  Size: system getter
#I  =: for `infinity' and cyclotomic
#I  Union2: for two times the same ring (ResClasses) at /Users/caj/reps/gap/gap/pkg/resclasses/lib/resclass.gi:1716
#I  =: for certain cyclotomic semirings at /Users/caj/reps/gap/gap/lib/cyclotom.gi:2020
#I  CollectionsFamily: for a family at /Users/caj/reps/gap/gap/lib/coll.gi:22
#I  Setter(ElementsFamily): method to inherit `Characteristic' to collections families at /Users/caj/reps/gap/gap/lib/arith.gi:604
#I Trying next: Setter(ElementsFamily): system setter
#I  Setter(CollectionsFamily): system setter
#I  PositionProperty: for dense list and function at /Users/caj/reps/gap/gap/lib/list.gi:1546
#I  PositionProperty: for dense list and function at /Users/caj/reps/gap/gap/lib/list.gi:1546
#I Trying next: Union2: for two collections at /Users/caj/reps/gap/gap/lib/coll.gi:2554
#I Trying next: Union2: for two classes/lists/collections at /Users/caj/reps/gap/gap/pkg/crisp/lib/classes.gi:695
#I  InfoLevel at /Users/caj/reps/gap/gap/lib/info.gi:281
#I  InfoLevel at /Users/caj/reps/gap/gap/lib/info.gi:281
gap> NewFloat(FLOAT_DEFAULT_REP, 1.234);;
#I  NewFloat at /Users/caj/reps/gap/gap/lib/float.gi:124
gap>
```

```
gap> TraceAllMethods();;
gap> Union(Rationals, Integers);;
#I  Size: system getter
#I  =: for `infinity' and cyclotomic
#I  Size: system getter
#I  =: for `infinity' and cyclotomic
#I  Union2: for two times the same ring (ResClasses) at /Users/caj/reps/gap/gap-clean/pkg/resclasses/lib/resclass.gi:1281
#I  =: for certain cyclotomic semirings at /Users/caj/reps/gap/gap-clean/lib/cyclotom.gi:2020
#I  CollectionsFamily: for a family at /Users/caj/reps/gap/gap-clean/lib/coll.gi:22
#I  Setter(ElementsFamily): method to inherit `Characteristic' to collections families at /Users/caj/reps/gap/gap-clean/lib/arith.gi:604
#I  trying next: Setter(ElementsFamily): system setter
#I  Setter(CollectionsFamily): system setter
#I  PositionProperty: for dense list and function at /Users/caj/reps/gap/gap-clean/lib/list.gi:1546
#I  PositionProperty: for dense list and function at /Users/caj/reps/gap/gap-clean/lib/list.gi:1546
#I  trying next: Union2: for two collections
#I  trying next: Union2: for two classes/lists/collections
#I  InfoLevel at /Users/caj/reps/gap/gap-clean/lib/info.gi:281
#I  InfoLevel at /Users/caj/reps/gap/gap-clean/lib/info.gi:281
gap> NewFloat(FLOAT_DEFAULT_REP, 1.234);;
#I  NewFloat
```