### PR TITLE
TestPackage function and 'testpackage' make target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -274,6 +274,33 @@ testpackages:
 	( chmod 777 testpackages.in; ./testpackages.in; rm testpackages.in )
 	( rm wsp.g )
 
+testpackage:
+	mkdir -p dev/log
+	( echo 'SetAssertionLevel( 2 ); ReadGapRoot( "tst/testutil.g" ); \
+            SaveWorkspace( "wsp.g" );' | $(TESTGAP) )
+	( echo 'CreatePackageTestsInput( "testpackage.in", \
+            "dev/log/testpackage1", \
+            "$(TESTGAP) -L wsp.g", "false", "$(PKGNAME)" );'\
+            | $(TESTGAP) -L wsp.g > /dev/null )
+	( chmod 777 testpackage.in; ./testpackage.in; rm testpackage.in )
+	( rm wsp.g )
+	( echo 'SetAssertionLevel( 2 ); ReadGapRoot( "tst/testutil.g" ); \
+            SaveWorkspace( "wsp.g" );' | $(TESTGAPauto) )
+	( echo 'CreatePackageTestsInput( "testpackage.in", \
+            "dev/log/testpackageA", \
+            "$(TESTGAPauto) -L wsp.g", "auto", "$(PKGNAME)" );'\
+            | $(TESTGAPauto) -L wsp.g > /dev/null )
+	( chmod 777 testpackage.in; ./testpackage.in; rm testpackage.in )
+	( rm wsp.g )
+	( echo 'SetAssertionLevel( 2 ); ReadGapRoot( "tst/testutil.g" ); \
+            SaveWorkspace( "wsp.g" );' | $(TESTGAP) )
+	( echo 'CreatePackageTestsInput( "testpackage.in", \
+            "dev/log/testpackage2", \
+            "$(TESTGAP) -L wsp.g", "true", "$(PKGNAME)" );'\
+            | $(TESTGAP) -L wsp.g > /dev/null )
+	( chmod 777 testpackage.in; ./testpackage.in; rm testpackage.in )
+	( rm wsp.g )
+
 testpackagesload:
 	mkdir -p dev/log
 	( echo 'ReadGapRoot( "tst/testutil.g" ); \

--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -769,6 +769,9 @@ gaussian.tst               0             10
 
 <#Include Label="Test">
 <#Include Label="TestDirectory">
+
+See also <Ref Func="TestPackage"/> for the information on running standard
+tests for &GAP; packages.
 </Section>
 
 

--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -95,6 +95,7 @@ package and not by users of a package.
 
 <#Include Label="ReadPackage">
 <#Include Label="TestPackageAvailability">
+<#Include Label="TestPackage">
 <#Include Label="InstalledPackageVersion">
 <#Include Label="DirectoriesPackageLibrary">
 <#Include Label="DirectoriesPackagePrograms">

--- a/lib/test.gd
+++ b/lib/test.gd
@@ -12,4 +12,5 @@ DeclareGlobalFunction("ParseTestFile");
 DeclareGlobalFunction("RunTests");
 DeclareGlobalFunction("Test");
 DeclareGlobalFunction("TestDirectory");
+DeclareGlobalFunction("TestPackage");
 

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -761,7 +761,42 @@ InstallGlobalFunction( "TestDirectory", function(arg)
   return testTotal;
 end);
 
-
+#############################################################################
+##
+## TestPackage( <pkgname> )
+##
+##  <#GAPDoc Label="TestPackage">
+##  <ManSection>
+##  <Func Name="TestPackage" Arg='pkgname'/>
+##  <Description>
+##  It is recommended that a &GAP; package specifies a standard test in its
+##  <F>PackageInfo.g</F> file. If <A>pkgname</A> is a string with the name of
+##  a &GAP; package, then <C>TestDirectory(pkgname)</C> will check if this
+##  package is loadable and has the standard test, and will run this test in
+##  the current &GAP; session.<P/>
+##
+##  The output of the test depends on the particular package, and it also
+##  may depend on the current &GAP; session (loaded packages, state of the
+##  random sources, defined global variables etc.). If you would like to
+##  run the test for the same package in the same setting that is used
+##  for the testing of &GAP; releases, you have to call
+##
+##  <Log><![CDATA[
+##  make testpackage PKGNAME=pkgname
+##  ]]></Log>
+##
+##  in the UNIX shell (without quotes around <A>pkgname</A>). This will run
+##  the standard test for the package <A>pkgname</A> three times in different
+##  settings, and will write test output to three files in the <F>dev/log</F>
+##  directory. These output files will be named in the format
+##  <F>testpackageX_timestamp.pkgname</F>, where <C>X=A</C> for the test
+##  with packages loaded by default, <C>X=1</C> for the test without other
+##  packages (i.e. when &GAP; is started with <C>-A</C> command line option),
+##  and <C>X=2</C> when the test is run with all packages loaded.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
 InstallGlobalFunction( "TestPackage", function(pkgname)
 local testfile, str;
 if not IsBound( GAPInfo.PackagesInfo.(pkgname) ) then

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -760,3 +760,42 @@ InstallGlobalFunction( "TestDirectory", function(arg)
   
   return testTotal;
 end);
+
+
+InstallGlobalFunction( "TestPackage", function(pkgname)
+local testfile, str;
+if not IsBound( GAPInfo.PackagesInfo.(pkgname) ) then
+    Print("#I  No package with the name ", pkgname, " is available\n");
+    return;
+elif LoadPackage( pkgname ) = fail then
+    Print( "#I ", pkgname, " package can not be loaded\n" );
+    return;
+elif not IsBound( GAPInfo.PackagesInfo.(pkgname)[1].TestFile ) then
+    Print("#I No standard tests specified in ", pkgname, " package, version ",
+          GAPInfo.PackagesInfo.(pkgname)[1].Version,  "\n");
+    return;
+else
+    testfile := Filename( DirectoriesPackageLibrary( pkgname, "" ), 
+                          GAPInfo.PackagesInfo.(pkgname)[1].TestFile );
+    str:= StringFile( testfile );
+    if not IsString( str ) then
+        Print( "#I Test file `", testfile, "' for package `", pkgname, 
+        " version ", GAPInfo.PackagesInfo.(pkgname)[1].Version, " is not readable\n" );
+        return;
+    fi;
+    if EndsWith(testfile,".tst") then
+        if Test( testfile, rec(compareFunction := "uptowhitespace") ) then
+            Print( "#I  No errors detected while testing package ", pkgname,
+                   " version ", GAPInfo.PackagesInfo.(pkgname)[1].Version, 
+                   "\n#I  using the test file `", testfile, "'\n");
+        else
+            Print( "#I  Errors detected while testing package ", pkgname, 
+                   " version ", GAPInfo.PackagesInfo.(pkgname)[1].Version, 
+                   "\n#I  using the test file `", testfile, "'\n");
+        fi;
+    elif not READ( testfile ) then
+        Print( "#I Test file `", testfile, "' for package `", pkgname,
+        " version ", GAPInfo.PackagesInfo.(pkgname)[1].Version, " is not readable\n" );
+    fi;
+fi;
+end);

--- a/tst/testutil.g
+++ b/tst/testutil.g
@@ -76,8 +76,8 @@ end;
 ##  is actually managed in the Makefile, and is passed to this function 
 ##  just to be printed in the information messages.
 ##
-BindGlobal( "CreatePackageTestsInput", function( scriptfile, outfile, gap, other )
-    local result, name, entry, pair, testfile;
+BindGlobal( "CreatePackageTestsInput", function( scriptfile, outfile, gap, other, pkgname... )
+    local result, name, entry, pair, testfile, packages;
 
     SizeScreen( [ 1000 ] );
     InitializePackagesInfoRecords( false );
@@ -85,7 +85,19 @@ BindGlobal( "CreatePackageTestsInput", function( scriptfile, outfile, gap, other
     
     Append( result, "TIMESTAMP=`date -u +_%Y-%m-%d-%H-%M`\n" );
 
-    for name in SortedList(ShallowCopy(RecNames(GAPInfo.PackagesInfo))) do 
+    if Length(pkgname)=0 then
+      packages := SortedList(ShallowCopy(RecNames(GAPInfo.PackagesInfo)));
+    else
+      packages := pkgname;
+      if Length(packages) <> 1 or Length(packages[1]) = 0 then
+         Error("Usage: make testpackage PKGNAME=pkgname");
+      fi;
+      if not pkgname[1] in RecNames(GAPInfo.PackagesInfo) then
+         Error("There is no package with the name ", pkgname[1], " installed\n");
+      fi;
+    fi;
+
+    for name in packages do
       for entry in GAPInfo.PackagesInfo.( name ) do
         if IsBound( entry.InstallationPath ) and IsBound( entry.TestFile ) then
           testfile := Filename( DirectoriesPackageLibrary( name, "" ), entry.TestFile );


### PR DESCRIPTION
This is in response to the issue #637 by @ChrisJefferson.

This PR adds two ways of testing a GAP package.

The first is called from the shell using
```
make testpackage PKGNAME=packagename
``` 

This is as maximally close to the setting in which we run regression tests as possible - the difference is of course in the local version of GAP and the selection of package. Otherwise, it will run the test three times, each in a new GAP session (without/default/all packages), with assertion level 2, and will produce three log files in the dev/log directory.

The second may be called from the GAP prompt via
```
TestPackage("pkgname");
```
In this case assertion level will not be changed, and the test will run only once in the current GAP session. 

I've labeled this "DO NOT MERGE" since I should also document this before merging, but I'm submitting the code to get some feedback.

