### PR TITLE
Remove line that was duplicated in adding TLS macro

### DIFF
--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2933,7 +2933,6 @@ void            IntrAssDVar (
     /* assign the right hand side                                          */
     currLVars = TLS(CurrLVars);
     SWITCH_TO_OLD_LVARS( TLS(ErrorLVars) );
-    SWITCH_TO_OLD_LVARS( TLS(ErrorLVars) );
     while (depth--)
       SWITCH_TO_OLD_LVARS( PTR_BAG(TLS(CurrLVars)) [2] );
     ASS_HVAR( dvar, rhs );


### PR DESCRIPTION
I believe this is a bug that was introduced by @fingolfin in 1952c4d1