### PR TITLE
Fix for using firefox as a help viewer

### DIFF
--- a/lib/helpview.gi
+++ b/lib/helpview.gi
@@ -218,7 +218,7 @@ else # UNIX but not Mac OS X
   HELP_VIEWER_INFO.firefox := rec(
   type := "url",
   show := function(url)
-    Exec(Concatenation("firefox -remote \"openURL(file:", url, ")\""));
+    Exec(Concatenation("firefox \"file://", url,"\" >/dev/null 2>1 &"));
   end
   );
 


### PR DESCRIPTION
The problem report and the suggested fix were sent by Tom McDonough to GAP Support