### PR TITLE
Check for profiling too many files / files with too many lines

### DIFF
--- a/doc/changes/changes48.xml
+++ b/doc/changes/changes48.xml
@@ -273,6 +273,95 @@ modules and Cat1-algebras and morphisms of these structures.
 
 </Section>
 
+
+<Section Label="gap483">
+<Heading>&GAP; 4.8.3 (March 2016)</Heading>
+
+<Subsection Label="Changes in the core GAP system introduced in GAP 4.8.3">
+<Heading>Changes in the core &GAP; system introduced in &GAP; 4.8.3</Heading>
+
+New features:
+<List>
+<Item>
+<!-- #647 -->
+New function <Ref Func="TestPackage" BookName="ref"/> to run standard tests
+(if available) for a single package in the current &GAP; session (also callable
+via <C>make testpackage PKGNAME=pkgname</C> to run package tests in the same
+settings that are used for testing &GAP; releases).
+</Item>
+</List>
+
+Improved and extended functionality:
+<List>
+<Item>
+<!-- #670 -->
+<Ref Func="TestDirectory" BookName="ref"/> now prints a special status message
+to indicate the outcome of the test (this is convenient for automated testing).
+If necessary, this message may be suppressed by using the option
+<C>suppressStatusMessage</C>
+</Item>
+<Item>
+<!-- [#655] -->
+Improved output of tracing methods (which may be invoked, for example, with
+<Ref Func="TraceAllMethods" BookName="ref"/>) by displaying filename and line
+number in some more cases.
+</Item>
+</List>
+
+Changed functionality:
+<List>
+<Item>
+<!-- #615 -->
+Fixed some inconsistencies in the usage of
+<Ref Prop="IsGeneratorsOfSemigroup" BookName="ref"/>.
+</Item>
+</List>
+
+Fixed bugs that could lead to incorrect results:
+<List>
+<Item>
+<!-- #626 -->
+Fallback methods for conjugacy classes, that were never intended for infinite
+groups, now use <Ref Prop="IsFinite" BookName="ref"/> filter to prevent them
+being called for infinite groups. [Reported by Gabor Horvath]
+</Item>
+</List>
+
+Fixed bugs that could lead to break loops:
+<List>
+<Item>
+<!-- #665 -->
+Calculating stabiliser for the alternating group caused a break loop in the
+case when it defers to the corresponding symmetric group.
+</Item>
+<Item>
+<!-- #663 -->
+It was not possible to use <Ref Func="DotFileLatticeSubgroups" BookName="ref"/>
+for a trivial group. [Reported by Sergio Siccha]
+</Item>
+<Item>
+<!-- #648 -->
+A break loop while computing <Ref Attr="AutomorphismGroup" BookName="ref"/> for
+<C>TransitiveGroup(12,269)</C>. [Reported by Ignat Soroko]
+</Item>
+<Item>
+<!-- #622 -->
+A break loop while computing conjugacy classes of <C>PSL(6,4)</C>.
+[Reported by Martin Macaj]
+</Item>
+</List>
+
+Other fixed bugs:
+<List>
+<Item>
+<!-- #654 -->
+Fix for using Firefox as a default help viewer with
+<Ref Func="SetHelpViewer" BookName="ref"/>. [Reported by Tom McDonough]
+</Item>
+</List>
+</Subsection>
+</Section>
+
 </Chapter>
 
 

--- a/src/profile.h
+++ b/src/profile.h
@@ -28,7 +28,8 @@
 StructInitInfo * InitInfoProfile ( void );
 
 void RegisterStatWithProfiling(Stat);
-
+void RegisterProfilingLineOverflowOccured();
+void RegisterProfilingFileOverflowOccured();
 
 void InstallEvalBoolFunc( Int, Obj(*)(Expr));
 void InstallEvalExprFunc( Int, Obj(*)(Expr));

--- a/tst/teststandard/prof.tst
+++ b/tst/teststandard/prof.tst
@@ -1,0 +1,71 @@
+# This test would badly break if we run it while profiling is active
+# So in that case we just make sure we don't break anything
+gap> START_TEST("prof.tst");
+gap> tempdir := DirectoryTemporary();;
+gap> prof := IsLineByLineProfileActive();;
+gap> if prof then Print("prof.tst will produce failures if run with profiling"); fi;
+gap> CLEAR_PROFILE_OVERFLOW_CHECKS();
+gap> longFile := function(l)
+>      return Concatenation( [ ListWithIdenticalEntries(l - 1, '\n'),
+>                              "f := function(x) return x + ", String(l), "; end;\n" ] );
+>    end;;
+gap> FileString(Filename(tempdir, "line-65535.g"), longFile(65535));;
+gap> FileString(Filename(tempdir, "line-65536.g"), longFile(65536));;
+gap> FileString(Filename(tempdir, "line-65537.g"), longFile(65537));;
+gap> Read(Filename(tempdir, "line-65535.g"));;
+gap> f(0);
+65535
+gap> Read(Filename(tempdir, "line-65536.g"));;
+gap> f(0);
+65536
+gap> Read(Filename(tempdir, "line-65537.g"));;
+gap> f(0);
+65537
+gap> IsLineByLineProfileActive();
+false
+gap> if not prof then ProfileLineByLine(Filename(tempdir, "profout.gz")); fi;
+#I Profiling only works on the first 65,535 lines of each file
+#I (this warning will only appear once).
+gap> IsLineByLineProfileActive();
+true
+gap> UnprofileLineByLine();
+true
+gap> IsLineByLineProfileActive();
+false
+gap> CLEAR_PROFILE_OVERFLOW_CHECKS();
+gap> if not prof then ProfileLineByLine(Filename(tempdir, "profout.gz")); fi;
+gap> IsLineByLineProfileActive();
+true
+gap> Read(Filename(tempdir, "line-65535.g"));;
+gap> f(0);
+65535
+gap> Read(Filename(tempdir, "line-65536.g"));;
+#I Profiling only works on the first 65,535 lines of each file
+#I (this warning will only appear once).
+gap> f(0);
+65536
+gap> Read(Filename(tempdir, "line-65536.g"));;
+gap> f(0);
+65536
+gap> Read(Filename(tempdir, "line-65537.g"));;
+gap> f(0);
+65537
+gap> if prof then lim := 10; else lim := 66000; fi;
+gap> for i in [1..lim] do
+> f := fail;
+> Read(Filename(tempdir, "line-65536.g"));
+> if f(0) <> 65536 then Print("bad"); fi;
+> od;
+#I Profiling only works for the first 65,535 read files
+#I (this warning will only appear once).
+gap> f(0);
+65536
+gap> for i in [1..10] do
+> f := fail;
+> Read(Filename(tempdir, "line-65536.g"));
+> if f(0) <> 65536 then Print("bad"); fi;
+> od;
+gap> if not prof then UnprofileLineByLine(); fi;
+gap> IsLineByLineProfileActive();
+false
+gap> STOP_TEST("prof.tst", 1);


### PR DESCRIPTION
The current profiling stuff can break with files > 65,535 lines, or if GAP reads more than 65,535 files in the same session, even if profiling is not used (it doesn't break GAP, just gives bad profiles).

This patch catches this case, and produces an error in this situation. The patch ended up being bigger than I would like.

The test is designed so if you are running tests with coverage, they won't break that test coverage gathering (but the test will still fail).