### PR TITLE
Let mkversionheader.sh detect presence of git and git repos

### DIFF
--- a/cnf/mkversionheader.sh
+++ b/cnf/mkversionheader.sh
@@ -4,11 +4,13 @@ TMP="$1".tmp
 DST="$1"
 
 # Determine build version and date
-GAP_BUILD_VERSION=`git describe --tags --dirty || echo`
-GAP_BUILD_DATE=`date +"%Y-%m-%d %H:%M:%S (%Z)"`
-if test x"${GAP_BUILD_VERSION}" = x ; then
-  GAP_BUILD_VERSION=unknown
+GAP_BUILD_VERSION=unknown
+if command -v git >/dev/null 2>&1 ; then
+  if test -d .git ; then
+    GAP_BUILD_VERSION=`git describe --tags --dirty || echo`
+  fi
 fi
+GAP_BUILD_DATE=`date +"%Y-%m-%d %H:%M:%S (%Z)"`
 
 # Generate the file
 cat > "$TMP" <<EOF


### PR DESCRIPTION
This is an alternative to PR #492 (which was already merged into master). Without it, GAP 4.8.3 will print incorrect versions when compiled inside a surrounding git repository. E.g. if you extract GAP in your home directory, but your homedirectory is a git repository. Or if you build GAP inside sage. Or if you build GAP using my "GAP for Mac OS X" tool chain. Etc.

This is different from PR #492 because the change there was actually slightly incorrect (as a result, GAP on the master branch is back to printing "unknown" as its version).

This PR targets stable-4.8 because I actually think it would be quite desirable to have this in 4.8.3, and it has a low-risk: the worst that can happen is that a wrong version of GAP is printed; but the point of this patch is to *fix* such issues in various instances. On the upside, it is used only in a very specific and isolated way, so testing it is fairly easy.