### PR TITLE
Reverting nested alarms in the stable-4.8 branch

### DIFF
--- a/tst/testinstall/timeout.tst
+++ b/tst/testinstall/timeout.tst
@@ -20,17 +20,4 @@ gap> CallWithTimeoutList(5000,spinFor,[50000,1]);
 [ false ]
 gap> CallWithTimeoutList(50000,spinFor,[1]);
 [ true ]
-gap> spin2 := function(use, timeout) return CallWithTimeout(timeout, spinFor, use); end;
-function( use, timeout ) ... end
-gap> CallWithTimeout(100000, spin2,2000,50000);
-[ true, [ false ] ]
-gap> CallWithTimeout(100000, spin2,50,200000);
-[ true, [ true ] ]
-gap> CallWithTimeout(1000000, spin2,50,200000);
-[ true, [ true ] ]
-gap> CallWithTimeout(10000, spin2,500,200000);
-[ false ]
-gap> ct := 0;; CallWithTimeout(1000000, function() while true do spin2(500,500000); ct := ct+1; od; end);; 2 <= ct; ct <= 10;
-true
-true
 gap> STOP_TEST( "timeout.tst", 330000);


### PR DESCRIPTION
This reverts the following commits:
53e0a18c662c4189edbc4e8dd53894342da6ffe8
b8f10919355305e9f76456ba06a8495ecc8234a4
96c7532d8db5b576bfe52a99ea87941d909a60de
ce694b2ba66451673434c721db5034d73ebbb945

since this code is not yet ready for the release.