### PR TITLE
Do not make PrimeResiduesCache and DivisorsIntCache immutable

### DIFF
--- a/lib/integer.gi
+++ b/lib/integer.gi
@@ -464,8 +464,7 @@ end);
 #F  DivisorsInt( <n> )  . . . . . . . . . . . . . . .  divisors of an integer
 ##
 BindGlobal("DivisorsIntCache",
-        List([[1],[1,2],[1,3],[1,2,4],[1,5],[1,2,3,6],[1,7]], Immutable));
-MakeImmutable(DivisorsIntCache);
+        AtomicList(List([[1],[1,2],[1,3],[1,2,4],[1,5],[1,2,3,6],[1,7]], Immutable)));
 
 InstallGlobalFunction(DivisorsInt,function ( n )
     local  divisors, factors, divs;

--- a/lib/numtheor.gi
+++ b/lib/numtheor.gi
@@ -16,9 +16,7 @@
 #F  PrimeResidues( <m> )  . . . . . . . integers relative prime to an integer
 ##
 BindGlobal( "PrimeResiduesCache",
-        List( [[],[0],[1],[1,2],[1,3],[1,2,3,4],[1,5],[1,2,3,4,5,6]], Immutable ));
-
-MakeImmutable(PrimeResiduesCache);
+        AtomicList(List( [[],[0],[1],[1,2],[1,3],[1,2,3,4],[1,5],[1,2,3,4,5,6]], Immutable )));
 
 InstallGlobalFunction( PrimeResidues, function ( m )
     local  residues, p, i;


### PR DESCRIPTION
For the compatibility with HPC-GAP, they are made into AtomicLists.

This is an alternative to #651 (which suggest to revert #249).