### PR TITLE
Fix line and file in backtraces

### DIFF
--- a/lib/error.g
+++ b/lib/error.g
@@ -113,7 +113,8 @@ Unbind(ErrorInner);
 BIND_GLOBAL("ErrorInner",
         function( arg )
     local   context, mayReturnVoid,  mayReturnObj,  lateMessage,  earlyMessage,  
-            x,  prompt,  res, errorLVars, justQuit, printThisStatement, timeout;
+            x,  prompt,  res, errorLVars, justQuit, printThisStatement, timeout,
+            location;
 
     timeout := STOP_TIMEOUT();
 	context := arg[1].context;
@@ -214,6 +215,9 @@ BIND_GLOBAL("ErrorInner",
             PrintTo("*errout*","\c\n");
         fi;
     else
+        location := CURRENT_STATEMENT_LOCATION(context);
+        if location <> fail then          PrintTo("*errout*", " at ", location[1], ":", location[2]);
+        fi;
         PrintTo("*errout*"," called from\c\n");
     fi;
     if IsBound(OnBreak) and IsFunction(OnBreak) then

--- a/lib/error.g
+++ b/lib/error.g
@@ -82,7 +82,7 @@ BIND_GLOBAL("Where", function(arg)
     else
         WHERE(ParentLVars(ErrorLVars),depth, ErrorLVars);
     fi;
-    Print("at line ",INPUT_LINENUMBER()," of ",INPUT_FILENAME(),"\n");
+    Print("at ",INPUT_FILENAME(),":",INPUT_LINENUMBER(),"\n");
 end);
 
 OnBreak := Where;

--- a/src/gap.c
+++ b/src/gap.c
@@ -1234,6 +1234,38 @@ Obj FuncUpEnv (
   return 0;
 }
 
+Obj FuncExecutingStatementLocation(Obj self, Obj context)
+{
+  Obj currLVars = TLS(CurrLVars);
+  Expr call;
+  Int line;
+  Obj filename;
+  Obj retlist;
+  retlist = Fail;
+  if (context == TLS(BottomLVars))
+    return (Obj) 0;
+  SWITCH_TO_OLD_LVARS(context);
+  call = BRK_CALL_TO();
+  if (
+#if T_PROCCALL_0ARGS
+        ( FIRST_STAT_TNUM <= TNUM_STAT(call)
+                && TNUM_STAT(call)  <= LAST_STAT_TNUM ) ||
+#else
+        ( TNUM_STAT(call)  <= LAST_STAT_TNUM ) ||
+#endif
+        ( FIRST_EXPR_TNUM <= TNUM_EXPR(call)
+              && TNUM_EXPR(call)  <= LAST_EXPR_TNUM ) ) {
+    line = LINE_STAT(call);
+    filename = FILENAME_STAT(call);
+    retlist = NEW_PLIST(T_PLIST, 2);
+    SET_LEN_PLIST(retlist, 2);
+    SET_ELM_PLIST(retlist, 1, filename);
+    SET_ELM_PLIST(retlist, 2, INTOBJ_INT(line));
+    CHANGED_BAG(retlist);
+  }
+  SWITCH_TO_OLD_LVARS( currLVars );
+  return retlist;
+}
 
 Obj FuncPrintExecutingStatement(Obj self, Obj context)
 {
@@ -3113,7 +3145,10 @@ static StructGVarFunc GVarFuncs [] = {
     { "PRINT_CURRENT_STATEMENT", 1, "context",
       FuncPrintExecutingStatement, "src/gap.c:PRINT_CURRENT_STATEMENT" },
 
-  
+    { "CURRENT_STATEMENT_LOCATION", 1, "context",
+      FuncExecutingStatementLocation,
+      "src/gap.c:CURRENT_STATEMENT_LOCATION" },
+
     { 0 }
 
 };


### PR DESCRIPTION
This patch performs two improvements to backtraces.

1) Errors now show which file and line they were contained in ( fixes #599 )
2) The last line of tracebacks is now in 'filename:linenumber' format, like everything else.

At the moment only planning on applying this to master, as I imagine it might break some packages tests / manual examples here and there which are using the old notation.

This (I believe) puts filename:line information everywhere we can, and removes the last of the old 'line X of Y' notation. If anyone finds anywhere else, let me know!

For example:
```
Error, Q called from
CallError(  ); at /Users/caj/temp/t.g:6 called from
f(  ); at /Users/caj/temp/t.g:10 called from
<function "g">( <arguments> )
 called from read-eval loop at line 2 of *stdin*
you can 'quit;' to quit to outer loop, or
you can 'return;' to continue
```
becomes:

```
gap> Read("~/temp/t.g");
gap> g();
Error, Q at /Users/caj/temp/t.g:2 called from
CallError(  ); at /Users/caj/temp/t.g:6 called from
f(  ); at /Users/caj/temp/t.g:10 called from
<function "g">( <arguments> )
 called from read-eval loop at *stdin*:2
you can 'quit;' to quit to outer loop, or
you can 'return;' to continue
brk>
```