### PR TITLE
Added suggestion to call ?cite to the GAP startup screen

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -1082,7 +1082,7 @@ BindGlobal( "ShowPackageInformation", function()
                     "\n" );
       fi;
 
-      Print( " Try '?help' for help. See also  '?copyright' and  '?authors'",
+      Print( " Try '??help' for help. See also '?copyright', '?cite' and '?authors'",
              "\n" );
     fi;
 end );


### PR DESCRIPTION
This pull request should promote good software citation practices, suggesting to look for the `Cite` function that will generate sample citation for the version being used, in several formats.
