### PR TITLE
Make it easier to skip tests that require a specific package

### DIFF
--- a/tst/teststandard/ctbl.tst
+++ b/tst/teststandard/ctbl.tst
@@ -42,20 +42,23 @@ gap> ClassPositionsOfCentre( TrivialCharacter( t ) );
 [ 1 ]
 gap> ClassPositionsOfKernel( TrivialCharacter( t ) );
 [ 1 ]
-gap> LoadPackage("ctbllib", "1", false);; 
 
 # `CharacterTableDirectProduct' in all four combinations.
-gap> t1:= CharacterTable( "Cyclic", 2 );
+gap> if LoadPackage("ctbllib", "1", false) <> fail then  # TestRequires: ctbllib, 1
+>      t1:= CharacterTable( "Cyclic", 2 );
+>      t2:= CharacterTable( "Cyclic", 3 );
+>      Print( t1 );
+>      Print( t2 );
+>      Print( t1 * t1 );
+>      Print( ( t1 mod 2 ) * ( t1 mod 2 ) );
+>      Print( ( t1 mod 2 ) * t2 );
+>      Print( t2 * ( t1 mod 2 ) );
+>    fi;
 CharacterTable( "C2" )
-gap> t2:= CharacterTable( "Cyclic", 3 );
 CharacterTable( "C3" )
-gap> t1 * t1;
 CharacterTable( "C2xC2" )
-gap> ( t1 mod 2 ) * ( t1 mod 2 );
 BrauerTable( "C2xC2", 2 )
-gap> ( t1 mod 2 ) * t2;
 BrauerTable( "C2xC3", 2 )
-gap> t2 * ( t1 mod 2 );
 BrauerTable( "C3xC2", 2 )
 gap> STOP_TEST( "ctbl.tst", 2970000);
 

--- a/tst/teststandard/ctbl.tst
+++ b/tst/teststandard/ctbl.tst
@@ -47,12 +47,12 @@ gap> ClassPositionsOfKernel( TrivialCharacter( t ) );
 gap> if LoadPackage("ctbllib", "1", false) <> fail then  # TestRequires: ctbllib, 1
 >      t1:= CharacterTable( "Cyclic", 2 );
 >      t2:= CharacterTable( "Cyclic", 3 );
->      Print( t1 );
->      Print( t2 );
->      Print( t1 * t1 );
->      Print( ( t1 mod 2 ) * ( t1 mod 2 ) );
->      Print( ( t1 mod 2 ) * t2 );
->      Print( t2 * ( t1 mod 2 ) );
+>      Print( t1, "\n" );
+>      Print( t2, "\n" );
+>      Print( t1 * t1, "\n" );
+>      Print( ( t1 mod 2 ) * ( t1 mod 2 ), "\n" );
+>      Print( ( t1 mod 2 ) * t2, "\n" );
+>      Print( t2 * ( t1 mod 2 ), "\n" );
 >    fi;
 CharacterTable( "C2" )
 CharacterTable( "C3" )


### PR DESCRIPTION
I recently built GAP for the first time, and tried running the test suite with:

```
$ bin/gap.sh -A -x 80 -r -m 100m -o 1g tst/teststandard.g
```

However, I had not installed the full suite of packages, which leads to a number of failures. For example:

```
testing: /home/iguananaut/src/gap/tst/teststandard/ctbl.tst
########> Diff in /home/iguananaut/src/gap/tst/teststandard/ctbl.tst:48
# Input is:
t1:= CharacterTable( "Cyclic", 2 );
# Expected output:
CharacterTable( "C2" )
# But found:
Error, sorry, the GAP Character Table Library is not loaded,
call `LoadPackage( "CTblLib" )' if you want to use it
########
########> Diff in /home/iguananaut/src/gap/tst/teststandard/ctbl.tst:50
# Input is:
t2:= CharacterTable( "Cyclic", 3 );
# Expected output:
CharacterTable( "C3" )
# But found:
Error, sorry, the GAP Character Table Library is not loaded,
call `LoadPackage( "CTblLib" )' if you want to use it
########
########> Diff in /home/iguananaut/src/gap/tst/teststandard/ctbl.tst:52
# Input is:
t1 * t1;
# Expected output:
CharacterTable( "C2xC2" )
# But found:
<mapping: Group( [ (1,2,3,4) ] ) -> Group( [ (1,2,3,4) ] ) >
########
########> Diff in /home/iguananaut/src/gap/tst/teststandard/ctbl.tst:54
# Input is:
( t1 mod 2 ) * ( t1 mod 2 );
# Expected output:
BrauerTable( "C2xC2", 2 )
# But found:
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 1st choice method found for `mod' on 2 arguments
########
########> Diff in /home/iguananaut/src/gap/tst/teststandard/ctbl.tst:56
# Input is:
( t1 mod 2 ) * t2;
# Expected output:
BrauerTable( "C2xC3", 2 )
# But found:
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 1st choice method found for `mod' on 2 arguments
########
########> Diff in /home/iguananaut/src/gap/tst/teststandard/ctbl.tst:58
# Input is:
t2 * ( t1 mod 2 );
# Expected output:
BrauerTable( "C3xC2", 2 )
# But found:
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 1st choice method found for `mod' on 2 arguments
########
ctbl.tst               23203            128   ( next ~1 sec )
```

It may be just as well to require that the full set of packages be installed before running this test suite, and that would be fine, though I didn't see that documented anywhere.  Nonetheless, I thought it would be worth fixing those tests to check for required packages first.  However, I found it a bit inconvenient to _skip_ a test if it can't be run.  The existing workaround was to just manually assert equality of results  and not take advantage of the generally more convenient "doctest" style test.

This patch is a proof of concept for an easier way to skip tests if a required package can't be satisfied, by adding a special comment at the end of a line that begins `# TestRequires:` followed by a package name and optional version (separated by a comma).  For example:

```
gap> LoadPackage("ctbllib", "1");  # TestRequires: ctbllib, 1
```

This test will be skipped outright if the requirement can't be satisfied.

I think the implementation is still a bit rough, but I wanted to put the general idea out there.
