### PR TITLE
Fix typo in trans.c to remove warning (doesn't change code behaviour)

### DIFF
--- a/src/trans.c
+++ b/src/trans.c
@@ -421,7 +421,7 @@ Obj FuncRANK_TRANS_LIST(Obj self, Obj f, Obj list){
     rank=0; 
     for(i=1;i<=len;i++){
       pt=ELM_LIST(list, i);
-      if(!TNUM_OBJ(pt)==T_INT||INT_INTOBJ(pt)<1){
+      if(TNUM_OBJ(pt)!=T_INT||INT_INTOBJ(pt)<1){
         ErrorQuit("usage: the second argument <list> must be a list of positive\n integers (not a %s)", (Int)TNAM_OBJ(pt), 0L);
       }
       j=INT_INTOBJ(pt)-1;
@@ -439,7 +439,7 @@ Obj FuncRANK_TRANS_LIST(Obj self, Obj f, Obj list){
     rank=0; 
     for(i=1;i<=len;i++){
       pt=ELM_LIST(list, i);
-      if(!TNUM_OBJ(pt)==T_INT||INT_INTOBJ(pt)<1){
+      if(TNUM_OBJ(pt)!=T_INT||INT_INTOBJ(pt)<1){
         ErrorQuit("usage: the second argument <list> must be a list of positive\n integers (not a %s)", (Int)TNAM_OBJ(pt), 0L);
       }
       j=INT_INTOBJ(pt)-1;


### PR DESCRIPTION
This is a tiny fix which was thrown up by a compiler warning.

Actually in this case it doesn't change behaviour, because T_INT is 0, and `(!x)==0` is the same as `!(x==0)`, but it is "wrong", and producing compiler warnings.

