### PR TITLE
Implement NanosecondsSinceEpoch

### DIFF
--- a/cnf/config.hin
+++ b/cnf/config.hin
@@ -37,6 +37,12 @@
 /* Define to 1 if you have the `chmod' function. */
 #undef HAVE_CHMOD
 
+/* Define to 1 if you have the `clock_getres' function. */
+#undef HAVE_CLOCK_GETRES
+
+/* Define to 1 if you have the `clock_gettime' function. */
+#undef HAVE_CLOCK_GETTIME
+
 /* Define to 1 if you have the `closedir' function. */
 #undef HAVE_CLOSEDIR
 

--- a/cnf/configure.in
+++ b/cnf/configure.in
@@ -145,7 +145,7 @@ dnl ## check for timing functions
 dnl ##
 
 AC_CHECK_HEADERS( time.h sys/times.h sys/param.h )
-AC_CHECK_FUNCS( times getrusage gettimeofday )
+AC_CHECK_FUNCS( times getrusage gettimeofday clock_gettime clock_getres )
 AC_CHECK_FUNCS( setitimer getitimer)
 AC_CHECK_LIB( [rt], [timer_create])
 AC_CHECK_FUNCS( timer_settime timer_gettime timer_create )

--- a/cnf/configure.out
+++ b/cnf/configure.out
@@ -5081,7 +5081,7 @@ fi
 
 done
 
-for ac_func in times getrusage gettimeofday
+for ac_func in times getrusage gettimeofday clock_gettime clock_getres
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -382,6 +382,17 @@ hour/minute format.
 </Description>
 </ManSection>
 
+<ManSection>
+<Func Name="NanosecondsSinceEpoch" Arg=''/>
+<Description>
+<Ref Func="NanosecondsSinceEpoch"/> returns the time in nanoseconds
+that has passed since some fixed, but unspecified time in the past.
+
+This function is appropriate for doing wallclock time measurements.
+
+The actual resolution depends on the system that &GAP; is run on.
+</Description>
+</ManSection>
 
 <ManSection>
 <Var Name="time"/>


### PR DESCRIPTION
This is a helper function to measure wallclock time passed. There
is also an addition in the manual to describe this function.