### PR TITLE
Fix timer_create based timeouts

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -1457,6 +1457,10 @@ Obj FuncSetUserHasQuit( Obj Self, Obj value)
      }
    }
 
+   /* The next timeout was too close, this is a bit of a hack, just as below */
+   if ((iseconds==0) && (imicroseconds==0)) {
+      imicroseconds = 1;
+   }
    /* Here we actually call the function */
    SyInstallAlarm( iseconds, 1000*imicroseconds);
    result = CallFuncList(func, args);


### PR DESCRIPTION
This was caused by newer posix functions returning time remaining
on a timeout in nanoseconds. If there was less than 1000 nanoseconds
remaining, we reset the timer to a zero timeout, hence disabling it.

This is fixed by clamping the timeout to a minimum of 1000 nanoseconds.