### PR TITLE
Sync src/compiler.c between GAP and HPC-GAP

### DIFF
--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -297,6 +297,10 @@ static Obj  HdlrFunc4 (
  CHECK_BOUND( t_1, "name" )
  if ( TNUM_OBJ(a_obj) == T_COMOBJ ) {
   AssPRec( a_obj, RNamObj(t_1), a_val );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(a_obj) == T_ACOMOBJ ) {
+  AssARecord( a_obj, RNamObj(t_1), a_val );
+#endif
  }
  else {
   ASS_REC( a_obj, RNamObj(t_1), a_val );
@@ -525,6 +529,10 @@ static Obj  HdlrFunc5 (
  /* family!.NAME := name; */
  if ( TNUM_OBJ(l_family) == T_COMOBJ ) {
   AssPRec( l_family, R_NAME, a_name );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(l_family) == T_ACOMOBJ ) {
+  AssARecord( l_family, R_NAME, a_name );
+#endif
  }
  else {
   ASS_REC( l_family, R_NAME, a_name );
@@ -533,6 +541,10 @@ static Obj  HdlrFunc5 (
  /* family!.REQ_FLAGS := req_filter; */
  if ( TNUM_OBJ(l_family) == T_COMOBJ ) {
   AssPRec( l_family, R_REQ__FLAGS, a_req__filter );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(l_family) == T_ACOMOBJ ) {
+  AssARecord( l_family, R_REQ__FLAGS, a_req__filter );
+#endif
  }
  else {
   ASS_REC( l_family, R_REQ__FLAGS, a_req__filter );
@@ -541,6 +553,10 @@ static Obj  HdlrFunc5 (
  /* family!.IMP_FLAGS := imp_filter; */
  if ( TNUM_OBJ(l_family) == T_COMOBJ ) {
   AssPRec( l_family, R_IMP__FLAGS, a_imp__filter );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(l_family) == T_ACOMOBJ ) {
+  AssARecord( l_family, R_IMP__FLAGS, a_imp__filter );
+#endif
  }
  else {
   ASS_REC( l_family, R_IMP__FLAGS, a_imp__filter );
@@ -551,6 +567,10 @@ static Obj  HdlrFunc5 (
  SET_LEN_PLIST( t_1, 0 );
  if ( TNUM_OBJ(l_family) == T_COMOBJ ) {
   AssPRec( l_family, R_TYPES, t_1 );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(l_family) == T_ACOMOBJ ) {
+  AssARecord( l_family, R_TYPES, t_1 );
+#endif
  }
  else {
   ASS_REC( l_family, R_TYPES, t_1 );
@@ -559,6 +579,10 @@ static Obj  HdlrFunc5 (
  /* family!.nTYPES := 0; */
  if ( TNUM_OBJ(l_family) == T_COMOBJ ) {
   AssPRec( l_family, R_nTYPES, INTOBJ_INT(0) );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(l_family) == T_ACOMOBJ ) {
+  AssARecord( l_family, R_nTYPES, INTOBJ_INT(0) );
+#endif
  }
  else {
   ASS_REC( l_family, R_nTYPES, INTOBJ_INT(0) );
@@ -567,6 +591,10 @@ static Obj  HdlrFunc5 (
  /* family!.HASH_SIZE := 32; */
  if ( TNUM_OBJ(l_family) == T_COMOBJ ) {
   AssPRec( l_family, R_HASH__SIZE, INTOBJ_INT(32) );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(l_family) == T_ACOMOBJ ) {
+  AssARecord( l_family, R_HASH__SIZE, INTOBJ_INT(32) );
+#endif
  }
  else {
   ASS_REC( l_family, R_HASH__SIZE, INTOBJ_INT(32) );
@@ -577,6 +605,10 @@ static Obj  HdlrFunc5 (
  SET_LEN_PLIST( t_1, 0 );
  if ( TNUM_OBJ(l_family) == T_COMOBJ ) {
   AssPRec( l_family, R_TYPES__LIST__FAM, t_1 );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(l_family) == T_ACOMOBJ ) {
+  AssARecord( l_family, R_TYPES__LIST__FAM, t_1 );
+#endif
  }
  else {
   ASS_REC( l_family, R_TYPES__LIST__FAM, t_1 );
@@ -585,6 +617,10 @@ static Obj  HdlrFunc5 (
  /* family!.TYPES_LIST_FAM[27] := 0; */
  if ( TNUM_OBJ(l_family) == T_COMOBJ ) {
   t_1 = ElmPRec( l_family, R_TYPES__LIST__FAM );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(l_family) == T_ACOMOBJ) {
+  t_1 = ElmARecord( l_family, R_TYPES__LIST__FAM );
+#endif
  }
  else {
   t_1 = ELM_REC( l_family, R_TYPES__LIST__FAM );
@@ -932,6 +968,10 @@ static Obj  HdlrFunc11 (
  /* cache := family!.TYPES; */
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   t_1 = ElmPRec( a_family, R_TYPES );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(a_family) == T_ACOMOBJ) {
+  t_1 = ElmARecord( a_family, R_TYPES );
+#endif
  }
  else {
   t_1 = ELM_REC( a_family, R_TYPES );
@@ -944,6 +984,10 @@ static Obj  HdlrFunc11 (
  CHECK_FUNC_RESULT( t_3 )
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   t_4 = ElmPRec( a_family, R_HASH__SIZE );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(a_family) == T_ACOMOBJ) {
+  t_4 = ElmARecord( a_family, R_HASH__SIZE );
+#endif
  }
  else {
   t_4 = ELM_REC( a_family, R_HASH__SIZE );
@@ -1092,6 +1136,10 @@ static Obj  HdlrFunc11 (
  /* if 3 * family!.nTYPES > family!.HASH_SIZE then */
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   t_3 = ElmPRec( a_family, R_nTYPES );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(a_family) == T_ACOMOBJ) {
+  t_3 = ElmARecord( a_family, R_nTYPES );
+#endif
  }
  else {
   t_3 = ELM_REC( a_family, R_nTYPES );
@@ -1099,6 +1147,10 @@ static Obj  HdlrFunc11 (
  C_PROD_FIA( t_2, INTOBJ_INT(3), t_3 )
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   t_3 = ElmPRec( a_family, R_HASH__SIZE );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(a_family) == T_ACOMOBJ) {
+  t_3 = ElmARecord( a_family, R_HASH__SIZE );
+#endif
  }
  else {
   t_3 = ELM_REC( a_family, R_HASH__SIZE );
@@ -1114,6 +1166,10 @@ static Obj  HdlrFunc11 (
   /* ncl := 3 * family!.HASH_SIZE + 1; */
   if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
    t_3 = ElmPRec( a_family, R_HASH__SIZE );
+#ifdef HPCGAP
+  } else if ( TNUM_OBJ(a_family) == T_ACOMOBJ) {
+   t_3 = ElmARecord( a_family, R_HASH__SIZE );
+#endif
   }
   else {
    t_3 = ELM_REC( a_family, R_HASH__SIZE );
@@ -1161,6 +1217,10 @@ static Obj  HdlrFunc11 (
   /* family!.HASH_SIZE := ncl; */
   if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
    AssPRec( a_family, R_HASH__SIZE, l_ncl );
+#ifdef HPCGAP
+  } else if ( TNUM_OBJ(a_family) == T_ACOMOBJ ) {
+   AssARecord( a_family, R_HASH__SIZE, l_ncl );
+#endif
   }
   else {
    ASS_REC( a_family, R_HASH__SIZE, l_ncl );
@@ -1169,6 +1229,10 @@ static Obj  HdlrFunc11 (
   /* family!.TYPES := ncache; */
   if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
    AssPRec( a_family, R_TYPES, l_ncache );
+#ifdef HPCGAP
+  } else if ( TNUM_OBJ(a_family) == T_ACOMOBJ ) {
+   AssARecord( a_family, R_TYPES, l_ncache );
+#endif
   }
   else {
    ASS_REC( a_family, R_TYPES, l_ncache );
@@ -1197,6 +1261,10 @@ static Obj  HdlrFunc11 (
  /* family!.nTYPES := family!.nTYPES + 1; */
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   t_2 = ElmPRec( a_family, R_nTYPES );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(a_family) == T_ACOMOBJ) {
+  t_2 = ElmARecord( a_family, R_nTYPES );
+#endif
  }
  else {
   t_2 = ELM_REC( a_family, R_nTYPES );
@@ -1204,6 +1272,10 @@ static Obj  HdlrFunc11 (
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   AssPRec( a_family, R_nTYPES, t_1 );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(a_family) == T_ACOMOBJ ) {
+  AssARecord( a_family, R_nTYPES, t_1 );
+#endif
  }
  else {
   ASS_REC( a_family, R_nTYPES, t_1 );
@@ -1250,6 +1322,10 @@ static Obj  HdlrFunc12 (
  t_6 = GF_AND__FLAGS;
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   t_7 = ElmPRec( a_family, R_IMP__FLAGS );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(a_family) == T_ACOMOBJ) {
+  t_7 = ElmARecord( a_family, R_IMP__FLAGS );
+#endif
  }
  else {
   t_7 = ELM_REC( a_family, R_IMP__FLAGS );
@@ -1305,6 +1381,10 @@ static Obj  HdlrFunc13 (
  t_6 = GF_AND__FLAGS;
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   t_7 = ElmPRec( a_family, R_IMP__FLAGS );
+#ifdef HPCGAP
+ } else if ( TNUM_OBJ(a_family) == T_ACOMOBJ) {
+  t_7 = ElmARecord( a_family, R_IMP__FLAGS );
+#endif
  }
  else {
   t_7 = ELM_REC( a_family, R_IMP__FLAGS );
@@ -1498,6 +1578,10 @@ static Obj  HdlrFunc15 (
   if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
    t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
       && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
+#ifdef HPCGAP
+  } else if ( TNUM_OBJ(a_type) == T_APOSOBJ ) {
+   t_5 = Elm0AList(a_type,INT_INTOBJ(l_i)) != 0 ? True : False;
+#endif
   }
   else {
    t_5 = (ISB_LIST( a_type, INT_INTOBJ(l_i) ) ? True : False);
@@ -1591,6 +1675,10 @@ static Obj  HdlrFunc16 (
   if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
    t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
       && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
+#ifdef HPCGAP
+  } else if ( TNUM_OBJ(a_type) == T_APOSOBJ ) {
+   t_5 = Elm0AList(a_type,INT_INTOBJ(l_i)) != 0 ? True : False;
+#endif
   }
   else {
    t_5 = (ISB_LIST( a_type, INT_INTOBJ(l_i) ) ? True : False);
@@ -1765,6 +1853,10 @@ static Obj  HdlrFunc18 (
   if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
    t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
       && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
+#ifdef HPCGAP
+  } else if ( TNUM_OBJ(a_type) == T_APOSOBJ ) {
+   t_5 = Elm0AList(a_type,INT_INTOBJ(l_i)) != 0 ? True : False;
+#endif
   }
   else {
    t_5 = (ISB_LIST( a_type, INT_INTOBJ(l_i) ) ? True : False);
@@ -1853,6 +1945,10 @@ static Obj  HdlrFunc19 (
   if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
    t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
       && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
+#ifdef HPCGAP
+  } else if ( TNUM_OBJ(a_type) == T_APOSOBJ ) {
+   t_5 = Elm0AList(a_type,INT_INTOBJ(l_i)) != 0 ? True : False;
+#endif
   }
   else {
    t_5 = (ISB_LIST( a_type, INT_INTOBJ(l_i) ) ? True : False);
@@ -3123,6 +3219,10 @@ static Obj  HdlrFunc34 (
      CHECK_FUNC_RESULT( t_6 )
      if ( TNUM_OBJ(l_obj) == T_COMOBJ ) {
       AssPRec( l_obj, RNamObj(t_5), t_6 );
+#ifdef HPCGAP
+     } else if ( TNUM_OBJ(l_obj) == T_ACOMOBJ ) {
+      AssARecord( l_obj, RNamObj(t_5), t_6 );
+#endif
      }
      else {
       ASS_REC( l_obj, RNamObj(t_5), t_6 );

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -758,9 +758,11 @@ void            Emit (
     va_start( ap, fmt );
     for ( p = fmt; *p != '\0'; p++ ) {
 
-        /* print an indent                                                 */
-        if ( 0 < EmitIndent2 && *p == '}' ) EmitIndent2--;
-        while ( 0 < EmitIndent2-- )  Pr( " ", 0L, 0L );
+        /* print an indent, except for preprocessor commands               */
+        if ( *fmt != '#' ) {
+            if ( 0 < EmitIndent2 && *p == '}' ) EmitIndent2--;
+            while ( 0 < EmitIndent2-- )  Pr( " ", 0L, 0L );
+        }
 
         /* format an argument                                              */
         if ( *p == '%' ) {
@@ -3592,6 +3594,10 @@ CVar CompIsbPosObj (
     Emit( "if ( TNUM_OBJ(%c) == T_POSOBJ ) {\n", list );
     Emit( "%c = (%i <= SIZE_OBJ(%c)/sizeof(Obj)-1\n", isb, pos, list );
     Emit( "   && ELM_PLIST(%c,%i) != 0 ? True : False);\n", list, pos );
+    Emit( "#ifdef HPCGAP\n" );
+    Emit( "} else if ( TNUM_OBJ(%c) == T_APOSOBJ ) {\n", list );
+    Emit( "%c = Elm0AList(%c,%i) != 0 ? True : False;\n", isb, list, pos );
+    Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
     Emit( "%c = (ISB_LIST( %c, %i ) ? True : False);\n", isb, list, pos );
     Emit( "}\n" );
@@ -3632,6 +3638,10 @@ CVar CompElmComObjName (
     /* emit the code to select the element of the record                   */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
     Emit( "%c = ElmPRec( %c, R_%n );\n", elm, record, NAME_RNAM(rnam) );
+    Emit( "#ifdef HPCGAP\n" );
+    Emit( "} else if ( TNUM_OBJ(%c) == T_ACOMOBJ) {\n", record );
+    Emit( "%c = ElmARecord( %c, R_%n );\n", elm, record, NAME_RNAM(rnam) );
+    Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
     Emit( "%c = ELM_REC( %c, R_%n );\n", elm, record, NAME_RNAM(rnam) );
     Emit( "}\n" );
@@ -3671,6 +3681,10 @@ CVar CompElmComObjExpr (
     /* emit the code to select the element of the record                   */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
     Emit( "%c = ElmPRec( %c, RNamObj(%c) );\n", elm, record, rnam );
+    Emit( "#ifdef HPCGAP\n" );
+    Emit( "} else if ( TNUM_OBJ(%c) == T_ACOMOBJ ) {\n", record );
+    Emit( "%c = ElmARecord( %c, RNamObj(%c) );\n", elm, record, rnam );
+    Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
     Emit( "%c = ELM_REC( %c, RNamObj(%c) );\n", elm, record, rnam );
     Emit( "}\n" );
@@ -3712,6 +3726,11 @@ CVar CompIsbComObjName (
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
     Emit( "%c = (IsbPRec( %c, R_%n ) ? True : False);\n",
           isb, record, NAME_RNAM(rnam) );
+    Emit( "#ifdef HPCGAP\n" );
+    Emit( "} else if ( TNUM_OBJ(%c) == T_ACOMOBJ ) {\n", record );
+    Emit( "%c = (IsbARecord( %c, R_%n ) ? True : False);\n",
+                isb, record, NAME_RNAM(rnam) );
+    Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
     Emit( "%c = (ISB_REC( %c, R_%n ) ? True : False);\n",
           isb, record, NAME_RNAM(rnam) );
@@ -3752,6 +3771,11 @@ CVar CompIsbComObjExpr (
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
     Emit( "%c = (IsbPRec( %c, RNamObj(%c) ) ? True : False);\n",
           isb, record, rnam );
+    Emit( "#ifdef HPCGAP\n" );
+    Emit( "} else if ( TNUM_OBJ(%c) == T_ACOMOBJ ) {\n", record );
+    Emit( "%c = (IsbARecord( %c, RNamObj(%c) ) ? True : False);\n",
+                isb, record, rnam );
+    Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
     Emit( "%c = (ISB_REC( %c, RNamObj(%c) ) ? True : False);\n",
           isb, record, rnam );
@@ -5197,6 +5221,10 @@ void CompAssComObjName (
     /* emit the code for the assignment                                    */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
     Emit( "AssPRec( %c, R_%n, %c );\n", record, NAME_RNAM(rnam), rhs );
+    Emit( "#ifdef HPCGAP\n" );
+    Emit( "} else if ( TNUM_OBJ(%c) == T_ACOMOBJ ) {\n", record );
+    Emit( "AssARecord( %c, R_%n, %c );\n", record, NAME_RNAM(rnam), rhs );
+    Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
     Emit( "ASS_REC( %c, R_%n, %c );\n", record, NAME_RNAM(rnam), rhs );
     Emit( "}\n" );
@@ -5235,6 +5263,10 @@ void CompAssComObjExpr (
     /* emit the code for the assignment                                    */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
     Emit( "AssPRec( %c, RNamObj(%c), %c );\n", record, rnam, rhs );
+    Emit( "#ifdef HPCGAP\n" );
+    Emit( "} else if ( TNUM_OBJ(%c) == T_ACOMOBJ ) {\n", record );
+    Emit( "AssARecord( %c, RNamObj(%c), %c );\n", record, rnam, rhs );
+    Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
     Emit( "ASS_REC( %c, RNamObj(%c), %c );\n", record, rnam, rhs );
     Emit( "}\n" );
@@ -5271,6 +5303,10 @@ void CompUnbComObjName (
     /* emit the code for the assignment                                    */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
     Emit( "UnbPRec( %c, R_%n );\n", record, NAME_RNAM(rnam) );
+    Emit( "#ifdef HPCGAP\n" );
+    Emit( "} else if ( TNUM_OBJ(%c) == T_ACOMOBJ ) {\n", record );
+    Emit( "UnbARecord( %c, R_%n );\n", record, NAME_RNAM(rnam) );
+    Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
     Emit( "UNB_REC( %c, R_%n );\n", record, NAME_RNAM(rnam) );
     Emit( "}\n" );
@@ -5305,6 +5341,10 @@ void CompUnbComObjExpr (
     /* emit the code for the assignment                                    */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
     Emit( "UnbPRec( %c, RNamObj(%c) );\n", record, rnam );
+    Emit( "#ifdef HPCGAP\n" );
+    Emit( "} else if ( TNUM_OBJ(%c) == T_ACOMOBJ ) {\n", record );
+    Emit( "UnbARecord( %c, RNamObj(%c) );\n", record, rnam );
+    Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
     Emit( "UNB_REC( %c, RNamObj(%c) );\n", record, rnam );
     Emit( "}\n" );


### PR DESCRIPTION
Some HPC-GAP specific emits were changed to surround the
emitted code by #ifdef HPCGAP / #endif