### PR TITLE
Maximal normal subgroups fixes

### DIFF
--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1759,10 +1759,21 @@ DeclareAttribute( "NilpotencyClassOfGroup", IsGroup );
 ##
 ##  <Description>
 ##  is a list containing those proper normal subgroups of the group <A>G</A>
-##  that are maximal among the proper normal subgroups.
+##  that are maximal among the proper normal subgroups. Gives error if there
+##  are infinitely many maximal normal subgroups.
+##
+##  Note, that the maximal normal subgroups of a group <A>G</A> can be
+##  computed more efficiently if the character table of <A>G</A> is known or
+##  if <A>G</A> is known to be abelian or solvable (even if infinite). So if
+##  the character table is needed, anyhow, or <A>G</A> is suspected to be
+##  abelian or solvable, then these should be computed before computing the
+##  maximal normal subgroups.
 ##  <Example><![CDATA[
 ##  gap> MaximalNormalSubgroups( g );
 ##  [ Group([ (1,2,3), (2,3,4) ]) ]
+##  gap> f := FreeGroup("x", "y");; x := f.1;; y := f.2;;
+##  gap> List(MaximalNormalSubgroups(f/[x^2, y^2]), GeneratorsOfGroup);
+##  [ [ x, y*x*y^-1 ], [ y, x*y*x^-1 ], [ y*x^-1 ] ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1759,8 +1759,9 @@ DeclareAttribute( "NilpotencyClassOfGroup", IsGroup );
 ##
 ##  <Description>
 ##  is a list containing those proper normal subgroups of the group <A>G</A>
-##  that are maximal among the proper normal subgroups. Gives error if there
-##  are infinitely many maximal normal subgroups.
+##  that are maximal among the proper normal subgroups. Gives error if
+##  <A>G</A>/<A>G'</A> is infinite, yielding infinitely many maximal normal
+##  subgroups.
 ##
 ##  Note, that the maximal normal subgroups of a group <A>G</A> can be
 ##  computed more efficiently if the character table of <A>G</A> is known or

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -4582,9 +4582,14 @@ end);
 ##  anyhow,you should compute it before computing the maximal normal
 ##  subgroups.
 ##
+##  *Note* that for abelian and solvable groups the maximal normal subgroups
+##  can be computed very quickly. Thus if you suspect your group to be
+##  abelian or solvable, then check it before computing the maximal normal
+##  subgroups.
+##
 InstallMethod( MaximalNormalSubgroups,
     "generic search",
-    [ IsGroup ],
+    [ IsGroup and IsFinite ],
     function(G)
     local
           maximal, # list of maximal normal subgroups,result
@@ -4611,6 +4616,10 @@ InstallMethod( MaximalNormalSubgroups,
 
 end);
 
+RedispatchOnCondition( MaximalNormalSubgroups, true,
+    [ IsGroup ],
+    [ IsFinite ], 0);
+
 #############################################################################
 ##
 #M  MaximalNormalSubgroups( <G> )
@@ -4618,6 +4627,23 @@ end);
 InstallMethod( MaximalNormalSubgroups, "for simple groups",
               [ IsGroup and IsSimpleGroup ], SUM_FLAGS,
               function(G) return [ TrivialSubgroup(G) ]; end);
+
+
+#############################################################################
+##
+#M  MaximalNormalSubgroups( <G> )
+##
+InstallMethod( MaximalNormalSubgroups, "general method selection",
+              [ IsGroup ],
+    function(G)
+
+    if 0 in AbelianInvariants(G) then
+      # (p) is a maximal normal subgroup in Z for every prime p
+      Error("number of maximal normal subgroups is infinity");
+    else
+      TryNextMethod();
+    fi;
+end);
 
 
 ##############################################################################
@@ -4723,8 +4749,8 @@ InstallMethod( MinimalNormalSubgroups, "for nilpotent groups",
   # IsGroup and IsFinite ranks higher than IsGroup and IsNilpotentGroup
   # so we have to increase the rank, otherwise the method for computation
   # by conjugacy classes above is selected.
-  RankFilter(IsGroup and IsFinite)
-  - RankFilter(IsGroup and IsNilpotentGroup),
+  RankFilter( IsGroup and IsFinite and IsNilpotentGroup )
+  - RankFilter( IsGroup and IsNilpotentGroup ),
   function(G)
     local soc, i, p, primes, gen, min, MinimalSubgroupsOfPGroupByGenerators;
 

--- a/lib/grppcatr.gi
+++ b/lib/grppcatr.gi
@@ -482,30 +482,33 @@ end );
 ##
 InstallMethod( MaximalNormalSubgroups, "for abelian groups",
                [ IsGroup and IsAbelian ],
-               # IsGroup and IsFinite ranks higher than
-               # IsGroup and IsAbelian, so we have to increase the
-               # rank, otherwise the method for normal subgroup computation
-               # is selected.
+               # IsGroup and IsFinite ranks higher than IsGroup and IsAbelian,
+               # so we have to increase the rank, otherwise the method for
+               # normal subgroup computation is selected.
                RankFilter( IsGroup and IsFinite and IsAbelian )
                - RankFilter( IsGroup and IsAbelian ),
 function( G )
     local Gf,     # FactorGroup of G
           hom,    # homomorphism from G to Gf
           MaxGf,  # MaximalNormalSubgroups of Gf
-          AbInv;  # Abelian invariants of G
+          AbInv;  # abelian invariants of G
     if not IsPcGroup(G) then
         AbInv := AbelianInvariants(G);
         if 0 in AbInv then
             # (p) is a maximal normal subgroup in Z for every prime p
             Error("number of maximal normal subgroups is infinity");
         else
-            # convert it to an Abelian PcGroup with same invariants
+            # convert it to an abelian PcGroup with same invariants
             Gf := AbelianGroup(IsPcGroup, AbInv);
             hom := IsomorphismGroups(G, Gf);
+            # for abelian groups all maximal normal subgroup are also
+            # normal maximal subgroups and vice-versa
             MaxGf := NormalMaximalSubgroups(Gf);
             return List(MaxGf, N -> PreImage(hom, N));
         fi;
     else
+        # for abelian groups all maximal normal subgroup are also
+        # normal maximal subgroups and vice-versa
         # for abelian pc groups return all maximal subgroups
         # NormalMaximalSubgroups seems to omit some unnecessary checks,
         # hence faster than MaximalSubgroups

--- a/lib/grppcatr.gi
+++ b/lib/grppcatr.gi
@@ -499,8 +499,8 @@ function( G )
             Error("number of maximal normal subgroups is infinity");
         else
             # convert it to an abelian PcGroup with same invariants
-            Gf := AbelianGroup(IsPcGroup, AbInv);
-            hom := IsomorphismGroups(G, Gf);
+            hom := IsomorphismPcGroup(G);
+            Gf := Image(hom);
             # for abelian groups all maximal normal subgroup are also
             # normal maximal subgroups and vice-versa
             MaxGf := NormalMaximalSubgroups(Gf);

--- a/lib/grppcatr.gi
+++ b/lib/grppcatr.gi
@@ -480,18 +480,31 @@ end );
 ##
 #M  MaximalNormalSubgroups( <G> )
 ##
-InstallMethod( MaximalNormalSubgroups, "for solvable groups",
+InstallMethod( MaximalNormalSubgroups, "for abelian groups",
                [ IsGroup and IsAbelian ],
+               # IsGroup and IsFinite ranks higher than
+               # IsGroup and IsAbelian, so we have to increase the
+               # rank, otherwise the method for normal subgroup computation
+               # is selected.
+               RankFilter( IsGroup and IsFinite and IsAbelian )
+               - RankFilter( IsGroup and IsAbelian ),
 function( G )
     local Gf,     # FactorGroup of G
           hom,    # homomorphism from G to Gf
-          MaxGf;  # MaximalNormalSubgroups of Gf
+          MaxGf,  # MaximalNormalSubgroups of Gf
+          AbInv;  # Abelian invariants of G
     if not IsPcGroup(G) then
-        # convert it to an Abelian PcGroup with same invariants
-        Gf := AbelianGroup(IsPcGroup, AbelianInvariants(G));
-        hom := IsomorphismGroups(G, Gf);
-        MaxGf := NormalMaximalSubgroups(Gf);
-        return List(MaxGf, N -> PreImage(hom, N));
+        AbInv := AbelianInvariants(G);
+        if 0 in AbInv then
+            # (p) is a maximal normal subgroup in Z for every prime p
+            Error("number of maximal normal subgroups is infinity");
+        else
+            # convert it to an Abelian PcGroup with same invariants
+            Gf := AbelianGroup(IsPcGroup, AbInv);
+            hom := IsomorphismGroups(G, Gf);
+            MaxGf := NormalMaximalSubgroups(Gf);
+            return List(MaxGf, N -> PreImage(hom, N));
+        fi;
     else
         # for abelian pc groups return all maximal subgroups
         # NormalMaximalSubgroups seems to omit some unnecessary checks,
@@ -502,6 +515,12 @@ end);
 
 InstallMethod( MaximalNormalSubgroups, "for solvable groups",
               [ IsGroup and IsSolvableGroup ],
+               # IsGroup and IsFinite ranks higher than
+               # IsGroup and IsSolvableGroup, so we have to increase the
+               # rank, otherwise the method for normal subgroup computation
+               # is selected.
+               RankFilter( IsGroup and IsFinite and IsSolvableGroup )
+               - RankFilter( IsGroup and IsSolvableGroup ),
 function( G )
     local Gf,     # FactorGroup of G
           hom,    # homomorphism from G to Gf
@@ -514,6 +533,10 @@ function( G )
     MaxGf := MaximalNormalSubgroups(Gf);
     return List(MaxGf, N -> PreImage(hom, N));
 end);
+
+RedispatchOnCondition( MaximalNormalSubgroups, true,
+    [ IsGroup ],
+    [ IsSolvableGroup ], 0);
 
 
 #############################################################################

--- a/tst/testinstall/opers/MaximalNormalSubgroups.tst
+++ b/tst/testinstall/opers/MaximalNormalSubgroups.tst
@@ -42,6 +42,14 @@ gap> Length(MaximalNormalSubgroups(G));
 gap> G := F/[s^2, s*r*s*r];;
 gap> Length(MaximalNormalSubgroups(G));
 3
+gap> G := F/[s^2];;
+gap> MaximalNormalSubgroups(G);
+Error, number of maximal normal subgroups is infinity
+gap> G := F/[s^2, r*s*r^(-1)*s^(-1)];;
+gap> MaximalNormalSubgroups(G);
+Error, number of maximal normal subgroups is infinity
+gap> MaximalNormalSubgroups( AbelianGroup( [ 0 ] ) );
+Error, number of maximal normal subgroups is infinity
 
 # a finite fp-group
 gap> G := F/[r^12, s^2, r*s*r^(-1)*s^(-1)];;

--- a/tst/testinstall/opers/MaximalNormalSubgroups.tst
+++ b/tst/testinstall/opers/MaximalNormalSubgroups.tst
@@ -28,9 +28,9 @@ true
 gap> D1 := DihedralGroup(Factorial(10));;
 gap> SortedList(List(MaximalNormalSubgroups(D1), StructureDescription));
 [ "C1814400", "D1814400", "D1814400" ]
-gap> D2 := DihedralGroup(IsFpGroup, 360);;
+gap> D2 := DihedralGroup(IsFpGroup, 36);;
 gap> SortedList(List(MaximalNormalSubgroups(D2), StructureDescription));
-[ "C180", "D180", "D180" ]
+[ "C18", "D18", "D18" ]
 gap> ForAll(MaximalNormalSubgroups(D2), N -> IsSubgroup(D2, N) and IsNormal(D2, N));
 true
 

--- a/tst/testinstall/opers/MaximalNormalSubgroups.tst
+++ b/tst/testinstall/opers/MaximalNormalSubgroups.tst
@@ -6,23 +6,23 @@ true
 gap> G := AlternatingGroup(5);; Size(MaximalNormalSubgroups(G))=1 and IsTrivial(MaximalNormalSubgroups(G)[1]);
 true
 gap> l := [2,4,8,3,9,5,25,7];; G := DirectProduct(List(l, CyclicGroup));;
-gap> List(MaximalNormalSubgroups(G),N ->List(MinimalGeneratingSet(N),Order));
-[ [ 2, 60, 6300 ], [ 2, 30, 12600 ], [ 2, 30, 12600 ], [ 60, 12600 ], 
-  [ 60, 12600 ], [ 60, 12600 ], [ 60, 12600 ], [ 2, 60, 4200 ], 
-  [ 2, 20, 12600 ], [ 2, 20, 12600 ], [ 2, 20, 12600 ], [ 2, 60, 2520 ], 
-  [ 2, 12, 12600 ], [ 2, 12, 12600 ], [ 2, 12, 12600 ], [ 2, 12, 12600 ], 
-  [ 2, 12, 12600 ], [ 2, 60, 1800 ] ]
+gap> SortedList(List(MaximalNormalSubgroups(G),N ->List(MinimalGeneratingSet(N),Order)));
+[ [ 2, 12, 12600 ], [ 2, 12, 12600 ], [ 2, 12, 12600 ], [ 2, 12, 12600 ], 
+  [ 2, 12, 12600 ], [ 2, 20, 12600 ], [ 2, 20, 12600 ], [ 2, 20, 12600 ], 
+  [ 2, 30, 12600 ], [ 2, 30, 12600 ], [ 2, 60, 1800 ], [ 2, 60, 2520 ], 
+  [ 2, 60, 4200 ], [ 2, 60, 6300 ], [ 60, 12600 ], [ 60, 12600 ], 
+  [ 60, 12600 ], [ 60, 12600 ] ]
 gap> A := AbelianGroup(IsFpGroup, [2,4,8,3,9,5,25,7]);;
-gap> List(MaximalNormalSubgroups(A),N -> AbelianInvariants(N));
-[ [ 2, 3, 4, 4, 5, 7, 9, 25 ], [ 2, 2, 3, 5, 7, 8, 9, 25 ], 
-  [ 2, 2, 3, 5, 7, 8, 9, 25 ], [ 3, 4, 5, 7, 8, 9, 25 ], 
-  [ 3, 4, 5, 7, 8, 9, 25 ], [ 3, 4, 5, 7, 8, 9, 25 ], 
-  [ 3, 4, 5, 7, 8, 9, 25 ], [ 2, 3, 3, 4, 5, 7, 8, 25 ], 
+gap> SortedList(List(MaximalNormalSubgroups(A),N -> AbelianInvariants(N)));
+[ [ 2, 2, 3, 5, 7, 8, 9, 25 ], [ 2, 2, 3, 5, 7, 8, 9, 25 ], 
+  [ 2, 3, 3, 4, 5, 7, 8, 25 ], [ 2, 3, 4, 4, 5, 7, 9, 25 ], 
+  [ 2, 3, 4, 5, 5, 7, 8, 9 ], [ 2, 3, 4, 5, 8, 9, 25 ], 
+  [ 2, 3, 4, 7, 8, 9, 25 ], [ 2, 3, 4, 7, 8, 9, 25 ], 
+  [ 2, 3, 4, 7, 8, 9, 25 ], [ 2, 3, 4, 7, 8, 9, 25 ], 
+  [ 2, 3, 4, 7, 8, 9, 25 ], [ 2, 4, 5, 7, 8, 9, 25 ], 
   [ 2, 4, 5, 7, 8, 9, 25 ], [ 2, 4, 5, 7, 8, 9, 25 ], 
-  [ 2, 4, 5, 7, 8, 9, 25 ], [ 2, 3, 4, 5, 5, 7, 8, 9 ], 
-  [ 2, 3, 4, 7, 8, 9, 25 ], [ 2, 3, 4, 7, 8, 9, 25 ], 
-  [ 2, 3, 4, 7, 8, 9, 25 ], [ 2, 3, 4, 7, 8, 9, 25 ], 
-  [ 2, 3, 4, 7, 8, 9, 25 ], [ 2, 3, 4, 5, 8, 9, 25 ] ]
+  [ 3, 4, 5, 7, 8, 9, 25 ], [ 3, 4, 5, 7, 8, 9, 25 ], 
+  [ 3, 4, 5, 7, 8, 9, 25 ], [ 3, 4, 5, 7, 8, 9, 25 ] ]
 gap> ForAll(MaximalNormalSubgroups(A), N -> IsSubgroup(A, N) and IsNormal(A, N));
 true
 gap> D1 := DihedralGroup(Factorial(10));;
@@ -37,15 +37,14 @@ true
 # some infinite fp-groups
 gap> F := FreeGroup("r", "s");; r := F.1;; s := F.2;;
 gap> G := F/[r^(-1)*s^(-1)*r*s, r^18, s^24];;
-gap> IsNilpotentGroup(G);;
 gap> Length(MaximalNormalSubgroups(G));
 7
 gap> G := F/[s^2, s*r*s*r];;
-
-# currently IsSolvable(G) would not run, will be remedied later
-gap> IsAbelian(DerivedSubgroup(G));
-true
-gap> SetIsSolvableGroup(G, true);
 gap> Length(MaximalNormalSubgroups(G));
 3
+
+# a finite fp-group
+gap> G := F/[r^12, s^2, r*s*r^(-1)*s^(-1)];;
+gap> SortedList(List(MaximalNormalSubgroups(G), AbelianInvariants));
+[ [ 2, 2, 3 ], [ 2, 4 ], [ 3, 4 ], [ 3, 4 ] ]
 gap> STOP_TEST("MaximalNormalSubgroups.tst", 10000);


### PR DESCRIPTION
Fix some issues with MaximalNormalSubgroups introduced from #692 after merging #552. 

- NormalSubgroup computation method is only called for finite groups.
- Redispatch is added for two methods (finite, solvable). (Not added for abelian, because abelian
  groups should be recognized by the IsSolvabe test.)
- New generic method added checking if AbelianInvariants has 0.
- Abelian method checks if AbelianInvariants has 0 (for non pc-groups).
- If GAP finds that there are infinitely many maximal normal subgroups, then
  it returns fail instead of erroring out (e.g. if 0 is in AbelianInvariants).
- Manual is changed to reflect this new behaviour, an example is added, as well.
- Lists are replaced by sorted lists in test file and some more tests are added.

I tried to heed to the guidelines set in #692. I believe there can be two possibilities for concern here. One is the obvious behaviour change if 0 is in AbelianInvariants meaning there are infinitely many maximal normal subgroups, then earlier `MaximalNormalSubgroups` would simply error with no method found, and now it returns `fail`. The other is that earlier the method calling `NormalSubgroups` first and then checking for maximal ones in that list is now only called for finite groups in `grp.gi:4464`. I do not know if any method for `NormalSubgroups` for infinite groups exists, but if there are some then it should be discussed how to reintroduce the _computing `NormalSubgroups` first_ method for `MaximalNormalSubgroups` for such groups. 

Test should run with -A -m 100m -o 1g, but instead of 1.8 seconds it runs for 75.5 seconds on my machine with these parameters. I am not sure if anything should be done about this.
