### PR TITLE
Fix #397 (Segfault after quitting from a break loop)

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2726,20 +2726,20 @@ ExecStatus ReadEvalCommand ( Obj context, UInt *dualSemicolon )
         SyntaxError( "; expected");
     }
 
-    /* check for dual semicolon                                            */
-    if ( *TLS(In) == ';' ) {
-        GetSymbol();
-        if (dualSemicolon) *dualSemicolon = 1;
-    }
-    else {
-        if (dualSemicolon) *dualSemicolon = 0;
-    }
-
-    /* end the interpreter                                                 */
-    if ( ! READ_ERROR() ) {
+    /* Note that GetSymbol below potentially calls into the interpreter
+       again, and if an error occurred the interpreter is not in the correct
+       state to execute ReadLine on an input stream, leading to crashes */
+    if (!READ_ERROR()) {
         type = IntrEnd( 0UL );
-    }
-    else {
+
+        /* check for dual semicolon */
+        if ( *TLS(In) == ';' ) {
+            GetSymbol();
+            if (dualSemicolon) *dualSemicolon = 1;
+        } else {
+            if (dualSemicolon) *dualSemicolon = 0;
+        }
+    } else {
         IntrEnd( 1UL );
         type = STATUS_ERROR;
     }


### PR DESCRIPTION
If the interpreter runs into an error while reading from a stream and
tries to check for a dual semicolon at the end of the statement, the
call to GetSymbol() leads to a call to ReadLine on the input stream.

With  (IsInputTextStream and IsInputTextStringRep) the correct method
is selected and called. The crash happens inside the method when trying
to access the stream or local variables.

This might not be the correct fix yet, but it seems clear that the
interpreter state is not right at this point.

Maybe @stevelinton or @ChrisJefferson can have a look and comment.