### PR TITLE
Fix rankings for Socle and MinimalNormalSubgroups

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -4678,7 +4678,7 @@ InstallMethod( MinimalNormalSubgroups,
     # should have and IsSolvable check, as well,
     # but methods for solvable groups are only in CRISP
     # which aggeressively checks for solvability, anyway
-    if IsNilpotentGroup(G) then
+    if (not HasIsNilpotentGroup(G) and IsNilpotentGroup(G)) then
       return MinimalNormalSubgroups( G );
     fi;
 

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1816,7 +1816,8 @@ InstallMethod( Socle, "for elementary abelian groups",
 ##
 InstallMethod( Socle, "for nilpotent groups",
               [ IsGroup and IsNilpotentGroup ],
-              SUM_FLAGS,
+              RankFilter( IsGroup and IsFinite and IsNilpotentGroup )
+              - RankFilter( IsGroup and IsNilpotentGroup ),
   function(G)
     local P, C, size, gen, abinv, indgen, i, p, q, soc;
 
@@ -4673,6 +4674,14 @@ InstallMethod( MinimalNormalSubgroups,
     function( G )
     local nt, c, r, U;
 
+    # force an IsNilpotent check
+    # should have and IsSolvable check, as well,
+    # but methods for solvable groups are only in CRISP
+    # which aggeressively checks for solvability, anyway
+    if IsNilpotentGroup(G) then
+      return MinimalNormalSubgroups( G );
+    fi;
+
     nt:= [];
     for c in ConjugacyClasses( G ) do
       r:= Representative( c );
@@ -4686,6 +4695,10 @@ InstallMethod( MinimalNormalSubgroups,
     od;
     return nt;
     end );
+
+RedispatchOnCondition(MinimalNormalSubgroups, true,
+    [IsGroup],
+    [IsFinite], 0);
 
 
 #############################################################################
@@ -4723,8 +4736,8 @@ InstallMethod( MinimalNormalSubgroups, "for nilpotent groups",
   # IsGroup and IsFinite ranks higher than IsGroup and IsNilpotentGroup
   # so we have to increase the rank, otherwise the method for computation
   # by conjugacy classes above is selected.
-  RankFilter(IsGroup and IsFinite)
-  - RankFilter(IsGroup and IsNilpotentGroup),
+  RankFilter( IsGroup and IsNilpotentGroup and IsFinite )
+  - RankFilter( IsGroup and IsNilpotentGroup ),
   function(G)
     local soc, i, p, primes, gen, min, MinimalSubgroupsOfPGroupByGenerators;
 

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -2238,11 +2238,20 @@ InstallMethod(NormalSubgroups,"homomorphism principle perm groups",true,
 ##
 #M  Socle(<G>)
 ##
-InstallMethod(Socle,"from normal subgroups",true,[IsGroup],0,
+InstallMethod(Socle,"from normal subgroups",true,[IsGroup and IsFinite],0,
 function(G)
 local n,i,s;
   if Size(G)=1 then return G;fi;
-  # deal with lareg EA socle factor for fitting free
+
+  # force an IsNilpotent check
+  # should have and IsSolvable check, as well,
+  # but methods for solvable groups are only in CRISP
+  # which aggeressively checks for solvability, anyway
+  if IsNilpotentGroup(G) then
+    return Socle(G);
+  fi;
+
+  # deal with large EA socle factor for fitting free
 
   # this could be a bit shorter.
   if Size(RadicalGroup(G))=1 then

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -2247,7 +2247,7 @@ local n,i,s;
   # should have and IsSolvable check, as well,
   # but methods for solvable groups are only in CRISP
   # which aggeressively checks for solvability, anyway
-  if IsNilpotentGroup(G) then
+  if (not HasIsNilpotentGroup(G) and IsNilpotentGroup(G)) then
     return Socle(G);
   fi;
 

--- a/tst/testinstall/opers/MinimalNormalSubgroups.tst
+++ b/tst/testinstall/opers/MinimalNormalSubgroups.tst
@@ -65,6 +65,10 @@ gap> x := F.1;; y := F.2;; z := F.3;;
 gap> G := F/[x^(-1)*y^(-1)*x*y, x^(-1)*z^(-1)*x*z, z^(-1)*y^(-1)*z*y, (x*y)^180, (x*y^5)^168];; IsAbelian(G);;
 gap> Size(MinimalNormalSubgroups(G));
 9
+gap> G := F/[x^2, y^2, x^(-1)*y^(-1)*x*y, z];;
+gap> IsFinite(G);;
+gap> Size(MinimalNormalSubgroups(G));
+3
 gap> for G in AllGroups(60) do NormalSubgroups(G);; Print(Collected(List(Set(MinimalNormalSubgroups(G)), IdGroup)), "\n"); od;
 [ [ [ 2, 1 ], 1 ], [ [ 3, 1 ], 1 ], [ [ 5, 1 ], 1 ] ]
 [ [ [ 2, 1 ], 1 ], [ [ 3, 1 ], 1 ], [ [ 5, 1 ], 1 ] ]

--- a/tst/testinstall/opers/MinimalNormalSubgroups.tst
+++ b/tst/testinstall/opers/MinimalNormalSubgroups.tst
@@ -43,6 +43,9 @@ true
 gap> k := 5;; P := SylowSubgroup(SymmetricGroup(4*k), 2);; A := Group((4*k+1, 4*k+2, 4*k+3));; G := ClosureGroup(P, A);; IsNilpotentGroup(G);;
 gap> Set(MinimalNormalSubgroups(G)) = Set([ Group([ (1,2)(3,4)(5,6)(7,8)(9,10)(11,12)(13,14)(15,16) ]), Group([ (17,18)(19,20) ]), Group([ (1,2)(3,4)(5,6)(7,8)(9,10)(11,12)(13,14)(15,16)(17,18)(19,20) ]), Group([ (21,22,23) ]) ]);
 true
+gap> G := SmallGroup(24,12);;
+gap> SortedList(List(MinimalNormalSubgroups(G), IdGroup));
+[ [ 4, 2 ] ]
 gap> A := DihedralGroup(16);;
 gap> B := SmallGroup(27, 3);;
 gap> C := SmallGroup(125, 4);;

--- a/tst/testinstall/opers/Socle.tst
+++ b/tst/testinstall/opers/Socle.tst
@@ -85,4 +85,8 @@ gap> G := F/[x^(-1)*y^(-1)*x*y, x^(-1)*z^(-1)*x*z, z^(-1)*y^(-1)*z*y, (x*y)^180,
 gap> IsAbelian(G);;
 gap> Size(Socle(G));
 1260
+gap> G := F/[x^2, y^2, x^(-1)*y^(-1)*x*y, z];;
+gap> IsFinite(G);;
+gap> Size(Socle(G));
+4
 gap> STOP_TEST("Socle.tst", 10000);

--- a/tst/testinstall/opers/Socle.tst
+++ b/tst/testinstall/opers/Socle.tst
@@ -57,9 +57,14 @@ true
 gap> Socle(PrimitiveGroup(8,3)) = Group([ (1,7)(2,8)(3,5)(4,6), (1,3)(2,4)(5,7)(6,8), (1,2)(3,4)(5,6)(7,8) ]);
 true
 gap> k := 5;; P := SylowSubgroup(SymmetricGroup(4*k), 2);; A := Group((4*k+1, 4*k+2, 4*k+3));; G := ClosureGroup(P, A);;
-gap> IsNilpotentGroup(G);;
 gap> Socle(G) = Group([ (21,22,23), (1,2)(3,4)(5,6)(7,8)(9,10)(11,12)(13,14)(15,16), (17,18)(19,20) ]);
 true
+gap> G := Group([ (1,2,3,5,4), (1,3)(2,4)(6,7) ]);;
+gap> Socle(G) = Group((1,2,3),(3,4,5),(6,7));
+true
+gap> G := SmallGroup(24,12);;
+gap> IdGroup(Socle(G));
+[ 4, 2 ]
 gap> A := DihedralGroup(16);;
 gap> B := SmallGroup(27, 3);;
 gap> C := SmallGroup(125, 4);;


### PR DESCRIPTION
Fixed the rankings of `Socle` and `MinimalNormalSubgroups` methods for nilpotent groups.

Some old methods for `Socle` or for `MinimalNormalSubgroups` were called for arbitrary groups, but they seem to only work for finite groups, and thus their filters have been changed. Further, for two methods I put in a forced `IsNilpotent` check, because for such groups the nilpotent method seems to be much more faster. 

Added some new tests. All tests run without packages, as well. Interestingly, they are much faster without packages (408ms vs 644ms for `Socle.tst`, 1884ms vs 2332ms for `MinimalNormalSubgroups.tst`). The reason is that CRISP is rather aggressively checks for solvability and finiteness (in fact, there is a `CRISP_RedispatchOnCondition` command, which I guess does redispatch even if there were other applicable methods with lower ranks. And solvable methods are slower than nilpotent methods, thus the speed difference.

Note that there are no explicit methods for solvable groups without CRISP, thus I never forced an `IsSolvableGroup` check in the low ranked methods.
