### PR TITLE
Remove CanComputeSize check in DirectFactorsOfGroup

### DIFF
--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -357,7 +357,7 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
       return Ns;
     fi;
 
-    if not CanComputeSize(G) or not IsFinite(G) then TryNextMethod(); fi;
+    if not IsFinite(G) then TryNextMethod(); fi;
 
     # the KN method performs slower in practice, only called if forced
     if ValueOption("useKN") = true then

--- a/tst/testinstall/direct_factors.tst
+++ b/tst/testinstall/direct_factors.tst
@@ -112,4 +112,7 @@ true
 gap> G := Group([ (4,8)(6,10), (4,6,10,8,12), (2,4,12)(6,10,8), (3,9)(4,6,10,8,12)(7,11), (3,5)(4,6,10,8,12)(9,11), (1,3,11,9,5)(4,6,10,8,12) ]);;
 gap> DirectFactorsOfGroup(G)=[ Group([ (4,8)(6,10), (4,6)(10,12), (2,12,8)(4,6,10) ]), Group([ (1,7,9)(3,5,11), (3,9)(7,11), (3,11)(5,7) ]) ];
 true
+gap> G := DirectProduct(DihedralGroup(12), SymmetricGroup(4));;
+gap> SortedList(List(DirectFactorsOfGroup(G),IdGroup));
+[ [ 2, 1 ], [ 6, 1 ], [ 24, 12 ] ]
 gap> STOP_TEST("direct_factors.tst", 10000);


### PR DESCRIPTION
Fixes issue #712 

Test is added.

While we are at it, I would like the opinion of people. Here there are basically two methods. One for abelian groups and another for finite groups. Currently there is only one method installed which forces the abelian and finite checks. 

What would be the preference? To have an ````IsFinite```` and an ````IsAbelian```` method with properly ordered redispatches, or have it the way it is now? Currently it is in the way previously existed. 

I somehow had the feeling that it is not entirely clear which version is preferred, so that is why I am asking.