### PR TITLE
Do not shift negative integers

### DIFF
--- a/src/objects.h
+++ b/src/objects.h
@@ -71,7 +71,7 @@
 **  'INTOBJ_INT' converts the C integer <i> to an (immediate) integer object.
 */
 #define INTOBJ_INT(i) \
-    ((Obj)(((Int)(i) << 2) + 0x01))
+    ((Obj)(((UInt)(i) << 2) + 0x01))
 
 
 /****************************************************************************


### PR DESCRIPTION
This should result in no changes to how GAP operates, but clang has started optimising based on shifting negative integers (which you technically aren't allowed to do).