### PR TITLE
fix bug in NewmanInfinityCriterion 

### DIFF
--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -5242,7 +5242,7 @@ local GO,q,d,e,b,r,val,agemo,ngens;
     q:=PQuotient(G,p,2,ngens);
   until q<>fail;
   q:=Image(EpimorphismQuotientSystem(q));
-  q:=PCentralSeries(q,p);
+  q:=ShallowCopy(PCentralSeries(q,p));
   if Length(q)=1 then
     Error("Trivial <p> quotient");
   fi;


### PR DESCRIPTION
A method for NewmanInfinityCriterion modifies the value cached by PCentralSeries – this may cause wrong results later. The bug has been revealed by making the cached value immutable in #714. 
