### PR TITLE
Various speed improvements to polynomial factorization and the GAP meataxe

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -379,7 +379,7 @@ BindGlobal( "Matrix_OrderPolynomialInner", function( fld, mat, vec, vecs)
         p := ShallowCopy(zeroes);
         Add(p,one);
         ConvertToVectorRepNC(p,fld);
-        piv := PositionNot(w,zero,0);
+        piv := PositionNonZero(w,0);
 
         #
         # Strip as far as we can
@@ -391,7 +391,7 @@ BindGlobal( "Matrix_OrderPolynomialInner", function( fld, mat, vec, vecs)
                 AddCoeffs(p, pols[piv], x);
             fi;
             AddRowVector(w, vecs[piv],  x, piv, d);
-            piv := PositionNot(w,zero,piv);
+            piv := PositionNonZero(w,piv);
         od;
 
         #

--- a/lib/meataxe.gi
+++ b/lib/meataxe.gi
@@ -1109,7 +1109,7 @@ SMTX_IrreducibilityTest:=function ( module )
          newgenlist, coefflist, orig_ngens, zero, 
          N, NT, v, subbasis, fac, sfac, pol, orig_pol, q, dim, ndim, i,
          l, trying, deg, facno, bestfacno, F, count, R, rt0,idmat,
-         pfac1, pfac2, pfr, idemp, M2, mat2, mat3;
+         pfac1, pfac2, quotRem, pfr, idemp, M2, mat2, mat3;
 
    rt0:=Runtime ();
    Info(InfoMeatAxe,1,"Calling MeatAxe. All times will be in milliseconds");
@@ -1290,10 +1290,14 @@ SMTX_IrreducibilityTest:=function ( module )
                      Info(InfoMeatAxe,1,"Trying Ivanyos/Lux Method");
                      #first find the appropriate idempotent
                      pfac1:=sfac[facno];
-                     pfac2:= Quotient(R, orig_pol, sfac[facno]);
-                     while QuotRemLaurpols(pfac2, sfac[facno], 2) = Zero(R) do
+                     pfac2:=orig_pol;
+                     while true do
+                       quotRem := QuotRemLaurpols(pfac2, sfac[facno], 3);
+                       if quotRem[2] <> Zero(R) then
+                         break;
+                       fi;
+                       pfac2 := quotRem[1];
                        pfac1:=pfac1*sfac[facno];
-                       pfac2:= Quotient(R, pfac2, sfac[facno]);
                      od;
                      pfr:=GcdRepresentation(pfac1, pfac2);
                      idemp:=QuotRemLaurpols(pfr[2]*pfac2, orig_pol, 2);

--- a/lib/meataxe.gi
+++ b/lib/meataxe.gi
@@ -1286,7 +1286,7 @@ SMTX_IrreducibilityTest:=function ( module )
                         bestfacno:=facno;
                      fi;
                   fi;
-		  if trying and deg>1 and count>2 then
+                  if trying and deg>1 and count>2 then
                      Info(InfoMeatAxe,1,"Trying Ivanyos/Lux Method");
                      #first find the appropriate idempotent
                      pfac1:=sfac[facno];
@@ -1297,14 +1297,14 @@ SMTX_IrreducibilityTest:=function ( module )
                      od;
                      pfr:=GcdRepresentation(pfac1, pfac2);
                      idemp:=QuotRemLaurpols(pfr[2]*pfac2, orig_pol, 2);
-		     #Now another random element in the group algebra.
+                     #Now another random element in the group algebra.
                      #and a random vector in the module
                      g2:=Random (F);
                      if IsOne(g2) then
-                          M2:=matrices[1];
-                        else
-                          M2:=g2 * matrices[1];
-                        fi;
+                       M2:=matrices[1];
+                     else
+                       M2:=g2 * matrices[1];
+                     fi;
                      for g1 in [2..ngens] do
                         g2:=Random (F);
                         if IsOne(g2) then
@@ -1326,7 +1326,7 @@ SMTX_IrreducibilityTest:=function ( module )
                      subbasis:=SMTX.SpinnedBasis (v, matrices, F,orig_ngens);
                      Info(InfoMeatAxe,2,"Spun up vector. Dimension = ",
                        Length(subbasis),". Time = ",Runtime()-rt0,".");
-                    if Length(subbasis) < dim and Length(subbasis) <> 0  then
+                     if Length(subbasis) < dim and Length(subbasis) <> 0  then
                        # Proper submodule found 
                        trying:=false;
                        ans:=false;
@@ -1336,7 +1336,7 @@ SMTX_IrreducibilityTest:=function ( module )
                   facno:=facno + 1;
                od; # going through irreducible factors of fixed degree.
                # If trying is false at this stage, then we don't have 
-               #an answer yet, so we have to go onto factors of the next degree.
+               # an answer yet, so we have to go onto factors of the next degree.
                # Now divide p by the factors used if necessary
                if trying and deg < maxdeg then
                   for q in fac do

--- a/lib/meataxe.gi
+++ b/lib/meataxe.gi
@@ -293,17 +293,6 @@ SMTX.SetFGCentMatMinPoly:=SMTX.Setter("fieldGenCentMatMinPoly");
 
 SMTX.SetDegreeFieldExt:=SMTX.Setter("degreeFieldExt");
 
-LinearCombinationVecs:=function(v,c)
-local i,s;
-  s:=ShallowCopy(c[1]*v[1]);
-  for i in [2..Length(c)] do
-    if not IsZero(c[i]) then
-      AddRowVector(s,v[i],c[i]);
-    fi;
-  od;
-  return s;
-end;
-
 
 #############################################################################
 ##
@@ -3153,8 +3142,7 @@ mats:=m.generators;
       m:=List(Concatenation(m.smashMeataxe.denombasis,
 		      m.smashMeataxe.fakbasis{[1..SMTX.Dimension(m)]}),
 		      ShallowCopy);
-                 #List(m.smashMeataxe.csbasis,
-		 #     i->LinearCombinationVecs(m.smashMeataxe.fakbasis,i)));
+                 #List(m.smashMeataxe.csbasis, i->i*m.smashMeataxe.fakbasis));
       TriangulizeMat(m);
       m:=ImmutableMatrix(F,m);
 #      m:=Filtered(m,i->i<>Zero(i));
@@ -3176,8 +3164,7 @@ mats:=m.generators;
       s.smashMeataxe.denombasis:=m.smashMeataxe.denombasis;
 
       #s.smashMeataxe.csbasis:= IdentityMat(SMTX.Dimension(s), SMTX.Field(s) );
-      s.smashMeataxe.fakbasis:=
-        List(b,i->LinearCombinationVecs(m.smashMeataxe.fakbasis,i));
+      s.smashMeataxe.fakbasis:=b*m.smashMeataxe.fakbasis;
 
       q.smashMeataxe.denombasis:=Concatenation(
         #List(m.smashMeataxe.denombasis,ShallowCopy),
@@ -3185,8 +3172,8 @@ mats:=m.generators;
         #List(s.smashMeataxe.fakbasis{[1..s.dimension]},ShallowCopy));
         s.smashMeataxe.fakbasis{[1..s.dimension]});
       #q.smashMeataxe.csbasis:= IdentityMat(SMTX.Dimension(q), SMTX.Field(q) );
-      q.smashMeataxe.fakbasis:=List(b{[SMTX.Dimension(s)+1..Length(b)]},
-                       i->LinearCombinationVecs(m.smashMeataxe.fakbasis,i));
+      q.smashMeataxe.fakbasis:=List([SMTX.Dimension(s)+1..Length(b)],
+                       i->b[i] * m.smashMeataxe.fakbasis);    
       Add(queue,s);
       Add(queue,q);
     fi;
@@ -3222,7 +3209,7 @@ local cf,u,i,j,f,cl,min,neu,sq,sb,fb,k,nmin,F;
       Info(InfoMeatAxe,3,Length(nmin),"minimal submodules");
       for k in nmin do 
         sq:=Concatenation(List(sb,ShallowCopy), # don't destroy old basis
-	                  List(k,i->LinearCombinationVecs(fb,i)));
+	                  k*fb);
 	TriangulizeMat(sq);
 	sq:=ImmutableMatrix(F,sq);
 	Assert(2,SMTX.InducedAction(m,sq)<>fail);
@@ -3296,7 +3283,7 @@ local a,u,i,nb;
   nb:=a[2];
   nb:=nb{[Length(sub)+1..Length(nb)]}; # the new basis part
   nb:=List(u,i->Concatenation( List( sub, ShallowCopy ),
-                               List(i,j->LinearCombinationVecs(nb,j))));
+                               i*nb));
   u:=[];
   for i in nb do
     TriangulizeMat(i);

--- a/lib/meataxe.gi
+++ b/lib/meataxe.gi
@@ -3121,6 +3121,7 @@ mats:=m.generators;
   F:=SMTX.Field(m);
   one:=One(F);
   b:= IdentityMat(SMTX.Dimension(m),SMTX.Field(m) );
+  ConvertToMatrixRep(b);
   # denombasis: Basis des Kerns
   m.smashMeataxe.denombasis:=[];
   # csbasis: Basis des Moduls
@@ -3174,6 +3175,8 @@ mats:=m.generators;
       #q.smashMeataxe.csbasis:= IdentityMat(SMTX.Dimension(q), SMTX.Field(q) );
       q.smashMeataxe.fakbasis:=List([SMTX.Dimension(s)+1..Length(b)],
                        i->b[i] * m.smashMeataxe.fakbasis);    
+      ConvertToMatrixRep(q.smashMeataxe.fakbasis);
+
       Add(queue,s);
       Add(queue,q);
     fi;

--- a/lib/polyfinf.gi
+++ b/lib/polyfinf.gi
@@ -187,7 +187,8 @@ InstallMethod( Factors, "polynomial over a finite field",
 
 function(R,f)
 local   cr,  opt,  irf,  i,  ind,  v,  l,  g,  k,  d,  
-	facs,  h,  q,  char,  r;
+	facs,  h,  q,  char,  r,
+	gc, hc, fam, val;
 
   # parse the arguments
   cr := CoefficientsRing(R);
@@ -264,14 +265,64 @@ local   cr,  opt,  irf,  i,  ind,  v,  l,  g,  k,  d,
     fi;
 
     if DegreeOfLaurentPolynomial(g)>0 then
+      # Above w computed a square free factorization of k/g = k/k' in facs.
+      # Now determine how often each factor h in facs divides g, by repeatedly
+      # dividing g by h.
+      #
+      # The code for this is basically equivalent to the commented out code
+      # snippet below; however, it avoids converting coefficient lists to
+      # polynomials and back again during each loop iteration. This has a
+      # significant performance effect if the polynomial is divided by a
+      # larger power of a given divisor polynomial.
+      #
+      # for h in ShallowCopy(facs)  do
+      #   q := Quotient( g, h );
+      #   while q <> fail  do
+      #     Add( facs, h );
+      #     g := q;
+      #     q := Quotient( g, h );
+      #   od;
+      # od;
+
+      # convert g to coefficients list
+      fam := FamilyObj( g );
+      gc := CoefficientsOfLaurentPolynomial( g );
+      if gc[2] > 0 then
+        gc := ShiftedCoeffs(gc[1],gc[2]);
+      else
+        # the call to ShallowCopy below is necessary to ensure gc is mutable,
+        # so that QUOTREM_LAURPOLS_LISTS can modify it
+        gc := ShallowCopy(gc[1]);
+      fi;
+
+      # perform repeated divisions by the factors in facs
       for h in ShallowCopy(facs)  do
-	q := Quotient( g, h );
-	while q <> fail  do
-	  Add( facs, h );
-	  g := q;
-	  q := Quotient( g, h );
-	od;
+        # convert h to coefficients list
+        hc := CoefficientsOfLaurentPolynomial(h);
+        if hc[2] > 0 then
+          hc := ShiftedCoeffs(hc[1], hc[2]);
+        else
+          # calling ShallowCopy here is not necessary, but results in a
+          # considerable speed boost
+          hc := ShallowCopy(hc[1]);
+        fi;
+
+        # divide g by h as long as there is no remainder
+        while true do
+          # perform the actual division; since QUOTREM_LAURPOLS_LISTS modifies
+          # its first argument, we pass a copy of gc in; this is necessary to
+          # correctly handle the final iteration, in which division by h fails
+          q := QUOTREM_LAURPOLS_LISTS( ShallowCopy(gc), hc );
+          if not IsZero( q[2] ) then break; fi;
+          Add( facs, h );
+          gc := q[1];
+        od;
       od;
+
+      # convert coefficients list back into a polynomial
+      val := RemoveOuterCoeffs( gc, fam!.zeroCoefficient );
+      g := LaurentPolynomialByExtRepNC( fam, gc, val, ind );
+
     fi;
     if 0=DegreeOfLaurentPolynomial(g) then
       if not IsOne(g) then

--- a/lib/ratfun1.gi
+++ b/lib/ratfun1.gi
@@ -872,7 +872,7 @@ end;
 
 # This function is destructive on the first argument!
 QUOTREM_LAURPOLS_LISTS:=function(fc,gc)
-local q,m,n,i,c,k,f;
+local q,m,n,i,c,k,f,z;
   # try to divide
   q:=[];
   n:=Length(gc);
@@ -888,10 +888,14 @@ local q,m,n,i,c,k,f;
   else
     f:=0;
   fi;
+  z:=Zero(gc[n]);
   for i in [0..m] do
-    c:=fc[m-i+n]/gc[n];
-    k:=[1..n]+m-i;
-    fc{k}:=fc{k}-c*gc;
+    c := fc[m-i+n];
+    if c <> z then
+      c:=c/gc[n];
+      k:=[1+m-i..n+m-i];
+      fc{k}:=fc{k}-c*gc;
+    fi;
     q[m-i+1]:=c;
   od;
   if f>0 then


### PR DESCRIPTION
While investigating the recog package together with Alice Niemeyer and Frank Lübeck last week, I came up with some tweaks to GAP that improved the recognition speed for some examples considerably.

First example: The following went from about 5.5 seconds to about 2.1 seconds on my laptop:
```gap
mat := IdentityMat( 300, GF(2) );;
mat{[1,2]}{[1,2]} := [[0,1],[1,0]]*Z(2);;
ConvertToMatrixRep(mat);;
M:=GModuleByMats([mat],GF(2));;
MTX.BasesCompositionSeries(M);; time;
```

Second example: The following went from about 78 milliseconds to 10ms. Over larger fields, it is not quite as dramatic, but still noticable (e.g. over GF(3), it went from 55ms to 13ms, and over GF(17) from 62ms to 39ms).

There are more optimization opportunities in the meataxe code. For example, it compute characteristic polynomials, then factors them. But the code for computing characteristic polynomials actually does so by first computing factors, then multiplying them... The obvious idea then is to provide a function which directly returns those factors (they won't be irreducible in general, but certainly still easier to factorize than the full char poly). Indeed, I noticed that the cvec package defines a method for that: `FactorsOfCharacteristicPolynomial`. Perhaps something like this should be added to GAP itself?