### PR TITLE
Fix bug in OnSetsPerm

### DIFF
--- a/src/permutat.c
+++ b/src/permutat.c
@@ -4335,7 +4335,7 @@ Obj             OnSetsPerm (
             }
             if ( k < len ) {
                 ResizeBag( res, (k+1)*sizeof(Obj) );
-                ADDR_OBJ(res)[0] = INTOBJ_INT(k);
+                SET_LEN_PLIST(res, k);
             }
         }
 


### PR DESCRIPTION
Before this change, I get: 

    gap> InstallOtherMethod(POW, "for a character and perm",
    > [IsChar, IsPerm],
    > function(char, p)
    >   return 1;
    > end);
    gap>
    gap> OnSets("abc", (1,2));
    [ 1, 131135, 1, 393219, <lvars bag> ]
    gap>

Because the length of the output list is not properly set in the function `OnSetsPerm` in `permutat.c`. This PR fixes this issue. I haven't added a test because I wouldn't want to install the method for `POW` given above. 

