### PR TITLE
Fix NanosecondsSinceEpoch

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -917,7 +917,7 @@ Obj FuncNanosecondsSinceEpoch(Obj self)
   if (gettimeofday(&tv, NULL) == 0) {
     res = ObjInt_Int(tv.tv_sec);
     res = ProdInt(res, ObjInt_Int(1000000L));
-    res = SumInt(res, ObjInt_Int(tv.tv_used));
+    res = SumInt(res, ObjInt_Int(tv.tv_usec));
     res = ProdInt(res, ObjInt_Int(1000L));
   } else {
     res = Fail;

--- a/src/gap.c
+++ b/src/gap.c
@@ -899,16 +899,15 @@ Obj FuncRUNTIMES( Obj     self)
 */
 Obj FuncNanosecondsSinceEpoch(Obj self)
 {
-  Obj res, sec, usec;
+  Obj res;
 
 #if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
   struct timespec ts;
 
   if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
-    usec = INTOBJ_INT(ts.tv_nsec);
-    sec = INTOBJ_INT(ts.tv_sec);
-    C_PROD(res, sec, INTOBJ_INT(1000000000L));
-    C_SUM_INTOBJS(res, res, usec);
+    res = ObjInt_Int(ts.tv_sec);
+    res = ProdInt(res, ObjInt_Int(1000000000L));
+    res = SumInt(res, ObjInt_Int(ts.tv_nsec));
   } else {
     res = Fail;
   }
@@ -916,11 +915,10 @@ Obj FuncNanosecondsSinceEpoch(Obj self)
   struct timeval tv;
 
   if (gettimeofday(&tv, NULL) == 0) {
-    usec = INTOBJ_INT(tv.tv_usec);
-    C_PROD(usec,usec,INTOBJ_INT(1000));
-    sec = INTOBJ_INT(tv.tv_sec);
-    C_PROD(res, sec, INTOBJ_INT(1000000L));
-    C_SUM_INTOBJS(res, res, usec);
+    res = ObjInt_Int(tv.tv_sec);
+    res = ProdInt(res, ObjInt_Int(1000000L));
+    res = SumInt(res, ObjInt_Int(tv.tv_used));
+    res = ProdInt(res, ObjInt_Int(1000L));
   } else {
     res = Fail;
   };

--- a/tst/testinstall/nanoseconds.tst
+++ b/tst/testinstall/nanoseconds.tst
@@ -1,0 +1,13 @@
+gap> START_TEST( "nanoseconds.tst" );
+gap> t := NanosecondsSinceEpoch();;
+gap> f := function(t)
+> local t2;
+> if t <> fail then
+> t2 := NanosecondsSinceEpoch();
+> return IsPosInt(t2 - t);
+> fi;
+> end;;
+gap> f(t);
+true
+gap> STOP_TEST( "nanoseconds.tst", 10 );
+


### PR DESCRIPTION
Turns out that on 32bit compiles `NanosecondsSinceEpoch` overflows GAP's (small) integers which crashes GAP. That's obviously not good, hence I now use `ObjInt_Int` and `ProdInt` and `SumInt` to compute the final nanoseconds value.

I also added a test that runs `NanosecondsSinceEpoch` just so that it crashes right away if such an issue crops up again, and doesn't make an unrelated test crash in rather unhelpful ways.