### PR TITLE
Improve install instructions, fix C++ compiler dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,22 @@
 # Contributing to GAP
 
-We invite everyone to contribute by submitting patches,
-pull requests, and bug reports. We would like to make the contributing
-process as easy as possible.
+We invite everyone to contribute by submitting patches, pull requests, and
+bug reports. We would like to make the contributing process as easy as
+possible.
 
 ## Packages versus contributions to the "core" system
 
-One way of contributing to GAP is to write a GAP [package](http://www.gap-system.org/Packages/packages.html) and 
-send it to us to consider for redistribution with GAP.  This is appropriate if your contribution adds 
-a body of functionality for some area of mathematics (or some coherent batch of system functionality). 
-A package is also appropriate if you plan to continue to develop your code in the future. You will retain control
-of your code and be recorded as author and maintainer of it.
+One way of contributing to GAP is to write a GAP package (see
+<http://www.gap-system.org/Packages/packages.html>) and send it to us to
+consider for redistribution with GAP.  This is appropriate if your
+contribution adds a body of functionality for some area of mathematics (or
+some coherent batch of system functionality). A package is also appropriate
+if you plan to continue to develop your code in the future. You will retain
+control of your code and be recorded as author and maintainer of it.
 
-Packages are not an appropriate way to release fixes or extremely small changes, or to impose your own preferences for,
-for instance, how things should be printed.
+Packages are not an appropriate way to release fixes or extremely small
+changes, or to impose your own preferences for, for instance, how things
+should be printed.
 
 ## Issue reporting and code contributions
 
@@ -41,49 +44,55 @@ for instance, how things should be printed.
 
 ## Making Changes
 
-GAP development follows a straightforward branching model. We prefer using the GitHub
-infrastructure. If you would like to contribute, but do not want to create a GitHub
-account, see below for an alternative.
+GAP development follows a straightforward branching model. We prefer using
+the GitHub infrastructure. If you would like to contribute, but do not want
+to create a GitHub account, see below for an alternative.
 
- * Make sure you are familiar with [Git](http://git-scm.com/book) - see the [Atlassian Git Tutorials](https://www.atlassian.com/git/tutorials/) for an excellent introduction to Git.
- * Make sure you have a [GitHub account](https://github.com/signup/free).
- * Make sure you are familiar with [GAP](http://www.gap-system.org/).
- * Fork our [main development repository](https://github.com/gap-system/gap) on github
- * Clone your fork to a chosen directory on your local machine using HTTPS:
-```
-$ git clone https://github.com/<your github user name>/gap.git
-```
-This will create a folder called `gap` (in the location where you ran `git clone`) containing the source files, folders and the Git repository.  The clone automatically sets up a remote alias named `origin` pointing to your fork on GitHub, which you can verify with:
-```
-$ git remote -v
-```
- * Add `gap-system/gap` as a remote upstream
-```
-$ git remote add upstream https://github.com/gap-system/gap.git
-```
- * Ensure your existing clone is up-to-date with current `HEAD` e.g.
-```
-$ git fetch upstream
-$ git merge upstream/master
-```
- * Create and checkout onto a topic (or feature) branch on which to base your work.
-   * This is typically done from the local `master` branch.
-   * For your own sanity, please avoid working on the local `master` branch.
- ```
- $ git branch fix/master/my_contrib master
- $ git checkout fix/master/my_contrib
- ```
-  A shorter way of doing the above is
- ```
- $ git checkout -b fix/master/my_contrib master
- ```
- which creates the topic branch and checks out that branch immediately after.
- * Make commits of logical units.
- * Check for unnecessary whitespace with
-```
-$ git diff --check
-```
- * Make sure your commit messages are along the lines of:
+* Make sure you are familiar with [Git](http://git-scm.com/book)
+  * see for example the [Atlassian Git Tutorials](https://www.atlassian.com/git/tutorials/)
+    for an excellent introduction to Git.
+* Make sure you have a [GitHub account](https://github.com/signup/free).
+* Make sure you are familiar with [GAP](http://www.gap-system.org/).
+* Fork our [main development repository](https://github.com/gap-system/gap) on github
+* Clone your fork to a chosen directory on your local machine using HTTPS:
+
+        $ git clone https://github.com/<your github user name>/gap.git
+
+* This will create a folder called `gap` (in the location where you ran `git
+  clone`) containing the source files, folders and the Git repository.  The
+  clone automatically sets up a remote alias named `origin` pointing to your
+  fork on GitHub, which you can verify with:
+
+        $ git remote -v
+
+* Add `gap-system/gap` as a remote upstream
+
+        $ git remote add upstream https://github.com/gap-system/gap.git
+
+* Ensure your existing clone is up-to-date with current `HEAD` e.g.
+
+        $ git fetch upstream
+        $ git merge upstream/master
+
+* Create and checkout onto a topic (or feature) branch on which to base your work.
+  * This is typically done from the local `master` branch.
+  * For your own sanity, please avoid working on the local `master` branch.
+    Instead, create a new branch for your work:
+
+        $ git branch fix/master/my_contrib master
+        $ git checkout fix/master/my_contrib
+
+    A shorter way of doing the above is
+
+        $ git checkout -b fix/master/my_contrib master
+
+    which creates the topic branch and checks out that branch immediately after.
+* Make commits of logical units.
+* Check for unnecessary whitespace with
+
+        $ git diff --check
+
+* Make sure your commit messages are along the lines of:
 
         Short (50 chars or less) summary of changes
 
@@ -101,31 +110,36 @@ $ git diff --check
         - Typically a hyphen or asterisk is used for the bullet, preceded by a
           single space, with blank lines in between, but conventions vary here
 
- * Make sure you have added any necessary tests for your changes.
- * Run all the tests to assure nothing else was accidentally broken.
-```
-$ make testinstall
-$ make teststandard
-```
+* Make sure you have added any necessary tests for your changes.
+* Run all the tests to assure nothing else was accidentally broken.
+
+        $ make testinstall
+        $ make teststandard
+
  * Push your changes to a topic branch in your fork of the repository.
-```
-$ git push origin fix/master/my_contrib
-```
+
+        $ git push origin fix/master/my_contrib
+
  * Go to GitHub and submit a pull request to GAP.
 
-From there you will have to wait on one of the GAP committers to respond to the request.
-This response might be an accept or some changes/improvements/alternatives will be suggested.  We do not guarantee that all requests will be accepted.
+From there you will have to wait on one of the GAP committers to respond to
+the request. This response might be an accept or some
+changes/improvements/alternatives will be suggested.  We do not guarantee
+that all requests will be accepted.
 
 ## Making changes without Github account
 
-If you do not want to open a GitHub account you can still clone the GAP repository
-like so:
-```
-git clone https://github.com/gap-system/gap.git
-```
+If you do not want to open a GitHub account you can still clone the GAP
+repository like so:
 
-Make your changes and commits, create a patch containing the commits you want to send, and use git's [`send-email` feature](http://git-scm.com/docs/git-send-email) to email the patch to
-gap@gap-system.org.  You can refer to [this tutorial](https://burzalodowa.wordpress.com/2013/10/05/how-to-send-patches-with-git-send-email/) on how to do this.
+    git clone https://github.com/gap-system/gap.git
+
+
+Make your changes and commits, create a patch containing the commits you
+want to send, and use git's [`send-email` feature](http://git-scm.com/docs/git-send-email)
+to email the patch to <gap@gap-system.org>.  You can refer to
+[this tutorial](https://burzalodowa.wordpress.com/2013/10/05/how-to-send-patches-with-git-send-email/)
+on how to do this.
 
 ## Additional Resources
 
@@ -137,6 +151,7 @@ gap@gap-system.org.  You can refer to [this tutorial](https://burzalodowa.wordpr
 * [Using Pull Requests](https://help.github.com/articles/using-pull-requests)
 * [General GitHub Documentation](https://help.github.com/)
 
-Heavily adapted from the contributing files from the [Puppet project](https://github.com/puppetlabs/puppet),
+Heavily adapted from the contributing files from the
+[Puppet project](https://github.com/puppetlabs/puppet),
 [Factory Girl Rails](https://github.com/thoughtbot/factory_girl_rails/blob/master/CONTRIBUTING.md),
-and [Idris](https://github.com/idris-lang/Idris-dev)
+and [Idris](https://github.com/idris-lang/Idris-dev).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,17 @@ We invite everyone to contribute by submitting patches,
 pull requests, and bug reports. We would like to make the contributing
 process as easy as possible.
 
+## Packages versus contributions to the "core" system
+
+One way of contributing to GAP is to write a GAP [package](http://www.gap-system.org/Packages/packages.html) and 
+send it to us to consider for redistribution with GAP.  This is appropriate if your contribution adds 
+a body of functionality for some area of mathematics (or some coherent batch of system functionality). 
+A package is also appropriate if you plan to continue to develop your code in the future. You will retain control
+of your code and be recorded as author and maintainer of it.
+
+Packages are not an appropriate way to release fixes or extremely small changes, or to impose your own preferences for,
+for instance, how things should be printed.
+
 ## Issue reporting and code contributions
 
 * Before you report an issue, or wish to add functionality, please try
@@ -94,7 +105,7 @@ $ git diff --check
  * Run all the tests to assure nothing else was accidentally broken.
 ```
 $ make testinstall
-$ make testall
+$ make teststandard
 ```
  * Push your changes to a topic branch in your fork of the repository.
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,7 +30,7 @@ mostly by offering precompiled binaries are:
 
 Note, however, that these are updated independently and may not yet provide
 the latest GAP release. Further details are available on the GAP website
-here: http://www.gap-system.org/Download/alternatives.html.
+here: <http://www.gap-system.org/Download/alternatives.html>.
 
 
 1 Installation Overview
@@ -50,7 +50,7 @@ To get maximum benefit from GAP and from various packages, we recommend
 that in addition a C++ compiler is available, and it may be useful
 to install a number of other free software libraries (and their associated
 development tools) although they are not required for basic operation. See
-http://www.gap-system.org/Download/tools.html for more details.
+<http://www.gap-system.org/Download/tools.html> for more details.
 
 The installation consists of 5 easy steps:
 
@@ -77,7 +77,7 @@ common problems with the installation.
 =====================
 
 You can get archives for the GAP distribution from the GAP website
-http://www.gap-system.org. You need to download one of the archives
+<http://www.gap-system.org>. You need to download one of the archives
 named in the format
 
 	gap4rXpY_<timestamp>.<archive_type>
@@ -172,7 +172,7 @@ description of each is also available via
 -----
 
 By default, GAP uses the external library GMP (see
-http://www.gmplib.org) for large integer arithmetic, replacing the built-in
+<http://www.gmplib.org>) for large integer arithmetic, replacing the built-in
 code used in previous versions and achieving a significant speed-up in
 related computations. There is a version of GMP included with the GAP
 archive you downloaded and this will be used unless otherwise requested.
@@ -195,8 +195,8 @@ is equivalent to `--with-gmp=no`.
 * Readline
 ----------
 
-GAP now also uses the external library Readline (see
-http://www.gnu.org/software/readline) for better command line
+GAP optionally also uses the external library Readline (see
+<http://www.gnu.org/software/readline>) for better command line
 editing. GAP will use this library by default if it is available on
 your system. You can configure Readline use as follows:
 
@@ -399,7 +399,7 @@ file provided with the corresponding package.
 If you have problems with package installations please contact the package
 authors as listed in the packages README file. Many GAP packages have their
 own development repositories and issue trackers, details of which could be
-found at https://gap-packages.github.io/.
+found at <https://gap-packages.github.io/>.
 
 
 8 Finish Installation and Cleanup
@@ -408,7 +408,7 @@ found at https://gap-packages.github.io/.
 Congratulations, your installation is finished.
 
 Once the installation is complete, we would like to ask you to send us a
-short note to support@gap-system.org, telling us about the installation.
+short note to <support@gap-system.org>, telling us about the installation.
 (This is just a courtesy; we like to know how many people are using GAP and
 get feedback regarding difficulties (hopefully none) that users may have
 had with installation.)
@@ -417,7 +417,7 @@ We also suggest that you subscribe to our GAP Forum mailing list; see the
 GAP web pages for details. Whenever there is a bug fix or new release of
 GAP this is where it is announced. The GAP Forum also deals with user
 questions of a general nature; bug reports and other problems you have
-while installing and/or using GAP should be sent to support@gap-system.org.
+while installing and/or using GAP should be sent to <support@gap-system.org>.
 
 If you are new to GAP, you might want to read through the following two
 sections for information about the documentation.
@@ -447,8 +447,8 @@ files are included in the directory `gap4rX/doc` in the subdirectories
 
 If you want to use these manual files with the help system from your GAP
 session you may check (or make sure) that your system provides some
-additional software like xpdf (http://www.foolabs.com/xpdf/) or acroread
-(http://www.adobe.com/products/acrobat/readstep.html).
+additional software like [xpdf](http://www.foolabs.com/xpdf/) or
+[acroread](http://www.adobe.com/products/acrobat/readstep.html).
 
 To complete beginners, we suggest you read (parts of) the tutorial first
 for an introduction to GAP 4. Then start to use the system with extensive
@@ -467,7 +467,7 @@ the help system which provides useful search features.
 
 This section lists a few common problems when installing or running GAP and
 their remedies. Also see the FAQ list on the GAP web pages at
-http://www.gap-system.org/Faq/faq.html
+<http://www.gap-system.org/Faq/faq.html>.
 
 * GAP starts with a warning `hmm, I cannot find lib/init.g`
 
@@ -548,7 +548,7 @@ can type POW(a,b) for a^b.)
 
 You might want to try different shells, starting each of the three .bat
 files in the `bin` directory: `gap.bat`. `gaprxvt.bat` and `gapcmd.bat`.
-Also, http://www.gap-system.org/Faq/faq.html#4 might give a remedy.
+Also, <http://www.gap-system.org/Faq/faq.html#4> might give a remedy.
 
 * GAP does not work in the remote desktop
 
@@ -563,7 +563,7 @@ version installed (use "Find"), delete the older one (and probably copy the
 newer one in both places).
 
 If all these remedies fail or you encountered a bug please send a mail to
-support@gap-system.org. Please give:
+<support@gap-system.org>. Please give:
 * a (short, if possible) self-contained excerpt of a GAP session containing
   both input and output that illustrates your problem (including comments
   of why you think it is a bug); and
@@ -620,7 +620,7 @@ If you do wish to use another compiler, you should run the command `make
 clean` in the GAP root directory, set the environment variable `CC` to
 the name of your preferred compiler and then rerun configure and make.
 You may have to experiment to determine the best values for `CFLAGS`
-and/or `COPTS` as described above. Please let us (support@gap-system.org)
+and/or `COPTS` as described above. Please let us (<support@gap-system.org>)
 know the results of your experiments.
 
 We also recommend that you install a C++ compiler before compiling GAP;
@@ -705,7 +705,7 @@ the actual path to the GAP root directory in the Windows format. Please avoid
 introducing new line breaks when editing (i.e. do not use a text editor which
 automatically wraps long lines).
 
-Please contact support@gap-system.org if you need further information.
+Please contact <support@gap-system.org> if you need further information.
 
 
 Wishing you fun and success using GAP,

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -215,15 +215,20 @@ pasting text very slow. If you have that version of the readline library,
 this delay be avoided by pressing a key (e.g. space) during the paste, or
 you may prefer to build GAP without readline to avoid this issue entirely.
 
-Build mode
-----------
+Build 32-bit vs. 64-bit binaries
+--------------------------------
 
 GAP will attempt to build in 32-bit mode on 32-bit machines and in 64-bit
 mode on 64-bit machines. On a 64-bit machine, you can tell GAP to build in
 32-bit instead, if you wish. In that case, GMP will also be built in 32-bit
 mode. You can configure the build mode as follows:
 
-    ./configure ABI=32|64
+    ./configure ABI=32
+
+or
+
+    ./configure ABI=64
+
 
 The value of the argument determines the build mode GAP will attempt to
 use. Note that building in 64-bit mode on a 32-bit architecture is not

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -377,29 +377,19 @@ You can skip this compilation now and do it later -- GAP will work fine,
 but the capabilities of the affected packages won't be available.
 
 In general, each package contains a `README` file that contains information
-about the package and the necessary installation. Typically the
-installation for a package consists of changing to the packages directory
-and issuing the commands `./configure ; make` (or, for some older packages
-`./configure ../.. ; make` in the packages directory. This has to be done
-separately for every package, and their `README` files should tell exactly
-which commands to use.
+about the package and the necessary installation. Typically, for a package
+that requires compilation, the installation steps consist of changing to
+the packages directory and issuing the commands `./configure && make` in
+the packages directory. This has to be done separately for every package,
+and their `README` files should tell exactly which commands to use.
 
-To help with this tedious process, we provide a shell script that will
-compile most of the packages that require compilation on UNIX systems
-(including Linux and OS X) with sufficiently many libraries, headers
-and tools available. To use it, download and run in the `pkg` directory
-one of the shell scripts
+To help with this tedious process, we ship a shell script called
+`bin/BuildPackages.sh` that will compile most of the packages that require
+compilation on Unix systems (including Linux and OS X) with sufficiently
+many libraries, headers and tools available. To use it, change to the
+`gap4rX/pkg` directory and execute the script like this:
 
-    http://www.gap-system.org/Download/InstPackages.sh
-
-for the 64-bit GAP installation or
-
-    http://www.gap-system.org/Download/InstPackages32.sh
-
-for the 32-bit GAP installation (you will need to call `chmod u+x` to make
-it executable first). You may also copy and paste it into the shell line by
-line. If something doesn't work on your system, please, refer to the `README`
-file provided with the corresponding package.
+    ../bin/BuildPackages.sh
 
 If you have problems with package installations please contact the package
 authors as listed in the packages README file. Many GAP packages have their

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ GAP INSTALLATION INSTRUCTIONS
 14. Expert Windows Installation
 
 These are the installation instructions for the GAP source distribution
-on UNIX (which covers Linux and OS X), and for the GAP binary distribution
+on Unix (which covers Linux and OS X), and for the GAP binary distribution
 for Windows.
 
 Alternative installation methods which aim to simplify the installation
@@ -61,7 +61,7 @@ The installation consists of five easy steps:
 3. Compile the kernel (unless a binary has been provided already)
 4. Test the installation
 5. Compile the packages that require it.
-   (some of them will only work under Unix and OS X).
+   (some of them will only work under Unix).
 
 Installation will always install the new version of GAP. If you are
 worried about losing the old version, you can keep an existing installation
@@ -85,9 +85,9 @@ named in the format
 for GAP 4.X.Y. The `<timestamp>` is updated whenever there is a change
 to the GAP system or any package.
 
-If you use Unix or OS X, you can use the `.tar.gz`, `.tar.bz2` or `.zip`
-archives containing the GAP source distribution. Such archive will unpack
-to the directory named `gap4rX`.
+If you use Unix (including OS X), you can use the `.tar.gz`, `.tar.bz2` or
+`.zip` archives containing the GAP source distribution. Such archive will
+unpack to the directory named `gap4rX`.
 
 If you use Windows, then use the `.exe` installer which contains binaries
 for GAP and some packages and provides the standard installation procedure.
@@ -99,13 +99,13 @@ for GAP and some packages and provides the standard installation procedure.
 The exact method of unpacking will vary dependently on the operating system
 and the type of archive used.
 
-* Unix, OS X
-------------
+* Unix (including OS X)
+-----------------------
 
-Under Unix or OS X unpack the archive `gap4rXpY_<timestamp>`
-in whatever place you want GAP to reside.
+Under Unix style operating systems (such as Linux and OS X), unpack the
+archive `gap4rXpY_<timestamp>` in whatever place you want GAP to reside.
 
-(If you unpack the archive as root user under UNIX, make sure that you
+(If you unpack the archive as root user under Unix, make sure that you
 issue the command `umask 022` before, to ensure that users will have
 permissions to read the files.)
 
@@ -127,9 +127,9 @@ it in a directory named like `C:\Users\alice\My Documents\gap4rX` or
 =============
 
 For the Windows version the unpacking process will already have put
-binaries in place. Under Unix and OS X you will have to compile such a
-binary yourself. (OS X users: please see section "GAP for OS X"
-below for information about compilation)
+binaries in place. Under Unix you will have to compile such a binary
+yourself. (OS X users: please see section "GAP for OS X" below for
+additional information about compilation)
 
 Change to the directory `gap4rX` (which you just created by unpacking).
 To get started quickly you may simply build GAP with default settings
@@ -267,8 +267,8 @@ The configure options just described may be combined as you like or omitted.
 6 Testing the installation
 ==========================
 
-You are now at a point where you can start GAP for the first time. Unix and
-OS X users should type
+You are now at a point where you can start GAP for the first time. Unix
+users (including those on OS X) should type
 
     ./bin/gap.sh
 
@@ -590,7 +590,7 @@ that might affect the compilation (in particular `CC`, `LD`, `CFLAGS`,
 12 Optimization and Compiler Options
 ====================================
 
-Because of the large variety of different versions of UNIX and different
+Because of the large variety of different versions of Unix and different
 compilers it is possible that the configure process will not chose best
 possible optimisation level, but you might need to tell make about it.
 
@@ -700,7 +700,7 @@ say `E:`, the easiest way would be just to use `E:\gap4rX`.
 
 If you need to edit a `*.bat` file to specify the path to your GAP installation
 manually, you will have to replace substrings `/c/gap4rX/` by the actual path
-to the GAP root directory in the UNIX format, and substrings `C:\gap4rX\` by
+to the GAP root directory in the Unix format, and substrings `C:\gap4rX\` by
 the actual path to the GAP root directory in the Windows format. Please avoid
 introducing new line breaks when editing (i.e. do not use a text editor which
 automatically wraps long lines).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -634,12 +634,11 @@ require a C++ compiler.
 13 GAP for OS X
 ===================
 
-We hope that a binary distribution for some recent version(s) of OS X
-will be available shortly. In the meantime, since OS X is built on top
-of a variant of Unix, you should follow the Unix installations to compile
-GAP; then you will be able to use all features of GAP as well as all
-packages. However for installation you might need a basic knowledge of
-Unix.
+Currently we provide no precompiler binary distribution for OS X. However,
+since OS X is an operating system in the Unix family, you can follow the
+Unix installation guidelines to compile GAP; then you will be able to use
+all features of GAP as well as all packages. However for installation you
+might need a basic knowledge of Unix.
 
 The following are a couple of notes and remarks about this:
 
@@ -648,12 +647,10 @@ First, note that you should get the Unix type GAP archives, i.e. one of
 (you won't be able to compile the program as given in the `-win.zip` archive).
 
 Next, you will need a compiler and build tools like `make`. These tools are
-included in the "XCode" app(lication) which is generally not installed by
-default on a new Mac. You may be able to install this application by
-running an installer package already on your system (look at the Installer
-folder under Applications) but if not you can get it from Apple by
-registering as a developer (see http://developer.apple.com), or by
-downloading it from the App Store.
+included in the "Xcode" application which is not installed by default on a
+new Mac. On all recent versions of OS X, you can install it for free via
+the App Store. For older versions for OS X, you may need to register with
+Apple as a developer and download it from <http://developer.apple.com>.
 
 To compile and run GAP you will have to open the Terminal application and
 type the necessary Unix commands into its window. The Terminal application

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,5 @@
 GAP INSTALLATION INSTRUCTIONS
-----------------------------------------------------
+=============================
 
 1. Installation Overview
 2. Getting the Archive
@@ -99,8 +99,8 @@ for GAP and some packages and provides the standard installation procedure.
 The exact method of unpacking will vary dependently on the operating system
 and the type of archive used.
 
-* Unix (including OS X)
------------------------
+Unix (including OS X)
+---------------------
 
 Under Unix style operating systems (such as Linux and OS X), unpack the
 archive `gap4rXpY_<timestamp>` in whatever place you want GAP to reside.
@@ -109,8 +109,8 @@ archive `gap4rXpY_<timestamp>` in whatever place you want GAP to reside.
 issue the command `umask 022` before, to ensure that users will have
 permissions to read the files.)
 
-* Windows
----------
+Windows
+-------
 
 If you are using the `.exe` installer, simply download and run it. It will
 offer a standard installation procedure, during which you will be able to
@@ -168,8 +168,8 @@ description of each is also available via
 
     ./configure --help
 
-* GMP
------
+GMP
+---
 
 By default, GAP uses the external library GMP (see
 <http://www.gmplib.org>) for large integer arithmetic, replacing the built-in
@@ -192,8 +192,8 @@ will be used instead of GMP.
 Note that `--with-gmp` is equivalent to `--with-gmp=yes` and `--without-gmp`
 is equivalent to `--with-gmp=no`.
 
-* Readline
-----------
+Readline
+--------
 
 GAP optionally also uses the external library Readline (see
 <http://www.gnu.org/software/readline>) for better command line
@@ -215,8 +215,8 @@ pasting text very slow. If you have that version of the readline library,
 this delay be avoided by pressing a key (e.g. space) during the paste, or
 you may prefer to build GAP without readline to avoid this issue entirely.
 
-* Build mode
-------------
+Build mode
+----------
 
 GAP will attempt to build in 32-bit mode on 32-bit machines and in 64-bit
 mode on 64-bit machines. On a 64-bit machine, you can tell GAP to build in
@@ -246,8 +246,8 @@ these can be called directly to choose the version you want. The link
 The configure step creates the `Makefile`, needed for the make command. You
 should not need to provide any arguments to `make` in order to build GAP.
 
-* Configuration name
---------------------
+Configuration name
+------------------
 
 In order to facilitate having several builds of GAP side-by-side, perhaps
 in the case that you have both 32 and 64-bit builds or for other different
@@ -469,7 +469,7 @@ This section lists a few common problems when installing or running GAP and
 their remedies. Also see the FAQ list on the GAP web pages at
 <http://www.gap-system.org/Faq/faq.html>.
 
-* GAP starts with a warning `hmm, I cannot find lib/init.g`
+### GAP starts with a warning `hmm, I cannot find lib/init.g`
 
 You either started only the binary or did not edit the shell script/batch
 file to give the correct library path. You must start the binary with the
@@ -480,13 +480,13 @@ command line option
 where `<path>` is the path to the GAP home directory (see Section "Command
 Line Options" of the GAP Reference manual).
 
-* When starting, GAP produces error messages about undefined variables.
+### When starting, GAP produces error messages about undefined variables.
 
 You might have a `.gaprc` file in your home directory that was used by
 GAP 4.4 but is not compatible with later releases. See section "The gap.ini
 and gaprc files" in Section "Running GAP" of the GAP Reference manual.
 
-* GAP stops with an error message `exceeded the permitted memory`.
+### GAP stops with an error message `exceeded the permitted memory`.
 
 Your job required more memory than is permitted by default (this is a
 safety feature to avoid single jobs wrecking a multi-user system.) You can
@@ -494,7 +494,7 @@ type `return;` to continue, if the error message happens repeatedly it might
 be better to start the job anew and use the command line option `-o` to set a
 higher memory limit.
 
-* GAP stops with an error message: `cannot extend the workspace any more`.
+### GAP stops with an error message: `cannot extend the workspace any more`.
 
 Your calculation exceeded the available memory. Most likely you asked GAP
 to do something which required more memory than you have (as listing all
@@ -504,7 +504,7 @@ much memory GAP uses. If this is below what your machine has available
 extending the workspace is impossible. Start GAP with more memory or use
 the `-a` option to pre-allocate initially a large piece of workspace.
 
-* GAP is not able to allocate memory above a certain limit
+### GAP is not able to allocate memory above a certain limit
 
 In a 32-bit mode GAP is unable to use over 4 GB of memory. In fact, since
 some address space is needed for system purposes, it is likely that GAP
@@ -516,14 +516,14 @@ collisions with system libraries located by default at an address within
 the workspace. (Under Linux for example, 1 GB is a typical limit.) You can
 compile a static binary using make static.
 
-* Recompilation fails or the new binary crashes.
+### Recompilation fails or the new binary crashes.
 
 Call make clean and restart the configure / make process completely from
 scratch. (It is possible that the operating system and/or compiler got
 upgraded in the meantime and so the existing .o files cannot be used any
 longer.
 
-* A calculation runs into an error `no method found`.
+### A calculation runs into an error `no method found`.
 
 GAP is not able to execute a certain operation with the given arguments.
 Besides the possibility of bugs in the library this means two things:
@@ -537,43 +537,46 @@ manual.
 
 Problems specific to Windows
 
-* The ^-key or "-key cannot be entered.
+### The ^-key or "-key cannot be entered.
 
 This is a problem if you are running a keyboard driver for some non-english
 languages. These drivers catch the ^ character to produce the French
 circumflex accent and do not pass it properly to GAP. No fix is known. (One
 can type POW(a,b) for a^b.)
 
-* Cut and Paste does not work
+### Cut and Paste does not work
 
 You might want to try different shells, starting each of the three .bat
 files in the `bin` directory: `gap.bat`. `gaprxvt.bat` and `gapcmd.bat`.
 Also, <http://www.gap-system.org/Faq/faq.html#4> might give a remedy.
 
-* GAP does not work in the remote desktop
+### GAP does not work in the remote desktop
 
 GAP can not be started in the Windows Command Prompt shell (via `gapcmd.bat`)
 in the remote desktop. To start GAP in the remote desktop, use scripts
 `gap.bat` or `gaprxvt.bat` which should work in such setting.
 
-* You get an error message about the `cygwin1.dll`
+### You get an error message about the `cygwin1.dll`
 
 GAP comes with a version of this dynamic library. If you have another
 version installed (use "Find"), delete the older one (and probably copy the
 newer one in both places).
 
+### Something else went wrong
+
 If all these remedies fail or you encountered a bug please send a mail to
 <support@gap-system.org>. Please give:
+
 * a (short, if possible) self-contained excerpt of a GAP session containing
   both input and output that illustrates your problem (including comments
   of why you think it is a bug); and
-* state the type of machine, operating system, (compiler used, if
-  UNIX/Linux) and version of GAP you are using (the line from the GAP
+* state the type of machine, the operating system, which compiler you used
+  (if any), and the version of GAP you are using (the line from the GAP
   banner starting with
 
-    GAP, Version 4.X.Y...
+        GAP, Version 4.X.Y...
 
-when GAP starts up, supplies the information required).
+  when GAP starts up, supplies the information required).
 
 
 11 Known Problems of the Configure Process

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,7 +46,8 @@ program.
 Installing the GAP distribution with all the packages and full data
 libraries takes about 1.6 GB of disk space and (except on Windows) will
 require a C compiler (gcc is recommended) to be installed on your system.
-To get maximum benefit from GAP and from various packages it may be useful
+To get maximum benefit from GAP and from various packages, we recommend
+that in addition a C++ compiler is available, and it may be useful
 to install a number of other free software libraries (and their associated
 development tools) although they are not required for basic operation. See
 http://www.gap-system.org/Download/tools.html for more details.
@@ -59,7 +60,7 @@ The installation consists of 5 easy steps:
   probably already done this.
 * Compile the kernel (unless a binary has been provided already)
 * Test the installation
-* Compile the packages that include C code
+* Compile the packages that require it.
   (some of them will only work under Unix and OS X).
 
 Installation will always install the new version of GAP. If you are
@@ -621,6 +622,10 @@ the name of your preferred compiler and then rerun configure and make.
 You may have to experiment to determine the best values for `CFLAGS`
 and/or `COPTS` as described above. Please let us (support@gap-system.org)
 know the results of your experiments.
+
+We also recommend that you install a C++ compiler before compiling GAP;
+while GAP itself does not need it, there are GAP packages which do
+require a C++ compiler.
 
 
 13 GAP for OS X

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,16 +52,16 @@ to install a number of other free software libraries (and their associated
 development tools) although they are not required for basic operation. See
 <http://www.gap-system.org/Download/tools.html> for more details.
 
-The installation consists of 5 easy steps:
+The installation consists of five easy steps:
 
-* Get the archive suitable for your system
-* Unpack the archive in the directory where you wish to install GAP
-  If you are reading this file as part of a GAP installation, you have
-  probably already done this.
-* Compile the kernel (unless a binary has been provided already)
-* Test the installation
-* Compile the packages that require it.
-  (some of them will only work under Unix and OS X).
+1. Get the archive suitable for your system
+2. Unpack the archive in the directory where you wish to install GAP
+   If you are reading this file as part of a GAP installation, you have
+   probably already done this.
+3. Compile the kernel (unless a binary has been provided already)
+4. Test the installation
+5. Compile the packages that require it.
+   (some of them will only work under Unix and OS X).
 
 Installation will always install the new version of GAP. If you are
 worried about losing the old version, you can keep an existing installation

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -122,10 +122,6 @@ do
     if [ -e $dir/PackageInfo.g ]; then
       echo "==== Building $dir"
       case $dir in
-        anupq*)
-          (cd $dir && ./configure $CONFIGFLAGS && $MAKE $CONFIGFLAGS) || build_fail
-        ;;
-
         atlasrep*)
           (cd $dir && chmod 1777 datagens dataword) || build_fail
         ;;

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -2,9 +2,17 @@
 
 set -e
 
+# This script attempts to build all GAP packages contained in the current
+# directory. Normally, you should run this script from the 'pkg'
+# subdirectory of your GAP installation.
+
+# You can also run it from other locations, but then you need to tell the
+# script where your GAP root directory is, by passing it as first argument
+# to the script. By default, the script assumes that the parent of the
+# current working directory is the GAP root directory.
+
 # You need at least 'gzip', GNU 'tar', a C compiler, sed, pdftex to run this.
 # Some packages also need a C++ compiler.
-# Run this script from the 'pkg' subdirectory of your GAP installation.
 
 # Contact support@gap-system.org for questions and complaints.
 
@@ -42,6 +50,8 @@ SUBDIR=`ls -d */ | head -n 1`
 if ! (cd $SUBDIR && [ -f $GAPDIR/sysinfo.gap ])
   then
     echo "$GAPDIR is not the root of a gap installation (no sysinfo.gap)"
+    echo "Please provide the absolute path of your GAP root directory as"
+    echo "first argument to this script."
     exit 1
 fi
 

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -146,6 +146,10 @@ do
           (cd $dir && ./configure $GAPDIR && $MAKE COPTS="-O2 -g") || build_fail
         ;;
 
+        NormalizInterface*)
+          (cd $dir && ./build-normaliz.sh $GAPDIR && run_configure_and_make) || build_fail
+        ;;
+
         pargap*)
           (cd $dir && ./configure $GAPDIR && $MAKE && cp bin/pargap.sh $GAPDIR/bin && rm -f ALLPKG) || build_fail
         ;;

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -20,13 +20,6 @@ set -e
 # Even if it doesn't work completely automatically for you, you may get
 # an idea what to do for a complete installation of GAP.
 
-if ! [ x`which gmake` = "x" ] ; then
-  MAKE=gmake
-else
-  MAKE=make
-fi
-
-# Package-specific info:
 
 if [ $# -eq 0 ]
   then
@@ -60,6 +53,15 @@ if (cd $SUBDIR && grep 'ABI_CFLAGS=-m32' $GAPDIR/Makefile > /dev/null) ; then
   ABI32=YES
   CONFIGFLAGS="CFLAGS=-m32 LDFLAGS=-m32 LOPTS=-m32 CXXFLAGS=-m32"
 fi;
+
+# Many package require GNU make. So use gmake if available,
+# for improved compatibility with *BSD systems where "make"
+# is BSD make, not GNU make.
+if ! [ x`which gmake` = "x" ] ; then
+  MAKE=gmake
+else
+  MAKE=make
+fi
 
 cat <<EOF
 Attempting to build GAP packages.

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -110,10 +110,11 @@ run_configure_and_make() {
   fi;
   if [ -f configure ]; then
     if grep Autoconf ./configure > /dev/null; then
-      ./configure $CONFIGFLAGS --with-gaproot=$GAPDIR && $MAKE
+      ./configure $CONFIGFLAGS --with-gaproot=$GAPDIR
     else
-      ./configure $GAPDIR && $MAKE
+      ./configure $GAPDIR
     fi;
+    $MAKE
   else
     echo "No building required for ${dir%/}"
   fi;

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-# You need 'gzip', GNU 'tar', a C compiler, sed, pdftex to run this.
+# You need at least 'gzip', GNU 'tar', a C compiler, sed, pdftex to run this.
+# Some packages also need a C++ compiler.
 # Run this script from the 'pkg' subdirectory of your GAP installation.
 
 # Contact support@gap-system.org for questions and complaints.
@@ -18,12 +19,6 @@ else
 fi
 
 # Package-specific info:
-
-# == Linboxing
-#  Easy, if prerequisites are installed. You may get GNU GMP
-#  (http://gmplib.org/) and BLAS (http://www.netlib.org/blas/)
-#  via packages in your Linux distribution. But you probably need to
-#  install LinBox (http://www.linalg.org/download.html) yourself.
 
 if [ $# -eq 0 ]
   then
@@ -51,16 +46,18 @@ if ! (cd $SUBDIR && [ -f $GAPDIR/sysinfo.gap ])
 fi
 
 if (cd $SUBDIR && grep 'ABI_CFLAGS=-m32' $GAPDIR/Makefile > /dev/null) ; then
-  echo Building with 32-bit ABI
+  echo "Building with 32-bit ABI"
   ABI32=YES
   CONFIGFLAGS="CFLAGS=-m32 LDFLAGS=-m32 LOPTS=-m32 CXXFLAGS=-m32"
 fi;
 
-echo Attempting to build GAP packages.
-echo Note that many GAP packages require extra programs to be installed,
-echo and some are quite difficult to build. Please read the documentation for
-echo packages which fail to build correctly, and only worry about packages
-echo you require!
+cat <<EOF
+Attempting to build GAP packages.
+Note that many GAP packages require extra programs to be installed,
+and some are quite difficult to build. Please read the documentation for
+packages which fail to build correctly, and only worry about packages
+you require!
+EOF
 
 build_carat() {
 (
@@ -102,7 +99,7 @@ $MAKE
 }
 
 build_fail() {
-  echo = Failed to build $dir
+  echo "= Failed to build $dir"
 }
 
 run_configure_and_make() {
@@ -123,7 +120,7 @@ run_configure_and_make() {
 for dir in `ls -d */`
 do
     if [ -e $dir/PackageInfo.g ]; then
-      echo ==== Building $dir
+      echo "==== Building $dir"
       case $dir in
         anupq*)
           (cd $dir && ./configure $CONFIGFLAGS && $MAKE $CONFIGFLAGS) || build_fail

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -89,7 +89,7 @@ $MAKE TOPDIR=`pwd` CFLAGS='-O2'
 
 build_cohomolo() {
 (
-cd cohomolo
+cd $dir
 ./configure $GAPDIR
 cd standalone/progs.d
 cp makefile.orig makefile

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -66,7 +66,6 @@ build_carat() {
 # this out until a user complains.
 # It is not possible to move around compiled binaries because these have the
 # path to some data files burned in.
-cd carat
 tar xzpf carat-2.1b1.tgz
 rm -f bin
 ln -s carat-2.1b1/bin bin
@@ -89,7 +88,6 @@ $MAKE TOPDIR=`pwd` CFLAGS='-O2'
 
 build_cohomolo() {
 (
-cd $dir
 ./configure $GAPDIR
 cd standalone/progs.d
 cp makefile.orig makefile
@@ -125,46 +123,60 @@ do
     if [ -e $dir/PackageInfo.g ]; then
       dir="${dir%/}"
       echo "==== Checking $dir"
+      (  # start subshell
+      set -e
+      cd $dir
       case $dir in
         atlasrep*)
-          (cd $dir && chmod 1777 datagens dataword) || build_fail
+          chmod 1777 datagens dataword
         ;;
 
         carat*)
-          build_carat || build_fail
+          build_carat
         ;;
 
         cohomolo*)
-          build_cohomolo || build_fail
+          build_cohomolo
         ;;
 
         fplsa*)
-          (cd $dir && ./configure $GAPDIR && $MAKE CC="gcc -O2 ") || build_fail
+          ./configure $GAPDIR &&
+          $MAKE CC="gcc -O2 "
         ;;
 
         kbmag*)
-          (cd $dir && ./configure $GAPDIR && $MAKE COPTS="-O2 -g") || build_fail
+          ./configure $GAPDIR &&
+          $MAKE COPTS="-O2 -g"
         ;;
 
         NormalizInterface*)
-          (cd $dir && ./build-normaliz.sh $GAPDIR && run_configure_and_make) || build_fail
+          ./build-normaliz.sh $GAPDIR &&
+          run_configure_and_make
         ;;
 
         pargap*)
-          (cd $dir && ./configure $GAPDIR && $MAKE && cp bin/pargap.sh $GAPDIR/bin && rm -f ALLPKG) || build_fail
+          ./configure $GAPDIR &&
+          $MAKE &&
+          cp bin/pargap.sh $GAPDIR/bin &&
+          rm -f ALLPKG
         ;;
 
         xgap*)
-          (cd $dir && ./configure && $MAKE && rm -f $GAPDIR/bin/xgap.sh && cp bin/xgap.sh $GAPDIR/bin) || build_fail
+          ./configure &&
+          $MAKE &&
+          rm -f $GAPDIR/bin/xgap.sh &&
+          cp bin/xgap.sh $GAPDIR/bin
         ;;
 
         simpcomp*)
         ;;
         
         *)
-          (cd $dir && run_configure_and_make) || build_fail
+          run_configure_and_make
         ;;
       esac;
+      ) || build_fail
+      # end subshell
     else
       echo "$dir is not a GAP package -- no PackageInfo.g"
     fi;

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -116,14 +116,15 @@ run_configure_and_make() {
     fi;
     $MAKE
   else
-    echo "No building required for ${dir%/}"
+    echo "No building required for $dir"
   fi;
 }
 
 for dir in `ls -d */`
 do
     if [ -e $dir/PackageInfo.g ]; then
-      echo "==== Checking ${dir%/}"
+      dir="${dir%/}"
+      echo "==== Checking $dir"
       case $dir in
         atlasrep*)
           (cd $dir && chmod 1777 datagens dataword) || build_fail

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -114,13 +114,15 @@ run_configure_and_make() {
     else
       ./configure $GAPDIR && $MAKE
     fi;
+  else
+    echo "No building required for ${dir%/}"
   fi;
 }
 
 for dir in `ls -d */`
 do
     if [ -e $dir/PackageInfo.g ]; then
-      echo "==== Building $dir"
+      echo "==== Checking ${dir%/}"
       case $dir in
         atlasrep*)
           (cd $dir && chmod 1777 datagens dataword) || build_fail

--- a/cnf/configure.in
+++ b/cnf/configure.in
@@ -37,6 +37,17 @@ fi
 AC_DEFINE_UNQUOTED([HAVE_ARITHRIGHTSHIFT],[$HAVE_ARITHRIGHTSHIFT],
   [define as 1 if >> for long int behaves like an arithmetic right shift for negative numbers])
 
+# autoconf may set CXX to g++ even if there is no working C++ compiler.
+# So verify that CXX really is able to compile C++ code.
+AC_LANG_PUSH([C++])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+  [[#include <iostream>
+    #ifndef __cplusplus
+    #error "broken C++"
+    #endif]])],,
+  [CXX=;])
+AC_LANG_POP([C++])
+
 #
 # Assume that cross-compiling is for 32 bit systems 
 # (alpha/NT will have to wait)
@@ -370,6 +381,7 @@ dnl ## generate a makefile
 dnl ##
 
 AC_SUBST(CC)
+AC_SUBST(CXX)
 AC_SUBST(CFLAGS)
 AC_SUBST(CPPFLAGS)
 AC_SUBST(LDFLAGS)

--- a/cnf/configure.out
+++ b/cnf/configure.out
@@ -645,6 +645,9 @@ build_vendor
 build_cpu
 build
 NM
+ac_ct_CXX
+CXXFLAGS
+CXX
 EGREP
 GREP
 CPP
@@ -709,7 +712,10 @@ CFLAGS
 LDFLAGS
 LIBS
 CPPFLAGS
-CPP'
+CPP
+CXX
+CXXFLAGS
+CCC'
 
 
 # Initialize some variables set by options.
@@ -1336,6 +1342,8 @@ Some influential environment variables:
   CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
               you have headers in a nonstandard directory <include dir>
   CPP         C preprocessor
+  CXX         C++ compiler command
+  CXXFLAGS    C++ compiler flags
 
 Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.
@@ -1748,6 +1756,44 @@ rm -f conftest.val
   as_fn_set_status $ac_retval
 
 } # ac_fn_c_compute_int
+
+# ac_fn_cxx_try_compile LINENO
+# ----------------------------
+# Try to compile conftest.$ac_ext, and return whether this succeeded.
+ac_fn_cxx_try_compile ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  rm -f conftest.$ac_objext
+  if { { ac_try="$ac_compile"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_compile") 2>conftest.err
+  ac_status=$?
+  if test -s conftest.err; then
+    grep -v '^ *+' conftest.err >conftest.er1
+    cat conftest.er1 >&5
+    mv -f conftest.er1 conftest.err
+  fi
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; } && {
+	 test -z "$ac_cxx_werror_flag" ||
+	 test ! -s conftest.err
+       } && test -s conftest.$ac_objext; then :
+  ac_retval=0
+else
+  $as_echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+	ac_retval=1
+fi
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+  as_fn_set_status $ac_retval
+
+} # ac_fn_cxx_try_compile
 
 # ac_fn_c_check_header_mongrel LINENO HEADER VAR INCLUDES
 # -------------------------------------------------------
@@ -4078,6 +4124,299 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
+# autoconf may set CXX to g++ even if there is no working C++ compiler.
+# So verify that CXX really is able to compile C++ code.
+ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+if test -z "$CXX"; then
+  if test -n "$CCC"; then
+    CXX=$CCC
+  else
+    if test -n "$ac_tool_prefix"; then
+  for ac_prog in g++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC
+  do
+    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
+set dummy $ac_tool_prefix$ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CXX+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$CXX"; then
+  ac_cv_prog_CXX="$CXX" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_CXX="$ac_tool_prefix$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+CXX=$ac_cv_prog_CXX
+if test -n "$CXX"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CXX" >&5
+$as_echo "$CXX" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+    test -n "$CXX" && break
+  done
+fi
+if test -z "$CXX"; then
+  ac_ct_CXX=$CXX
+  for ac_prog in g++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_CXX+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$ac_ct_CXX"; then
+  ac_cv_prog_ac_ct_CXX="$ac_ct_CXX" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_CXX="$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_CXX=$ac_cv_prog_ac_ct_CXX
+if test -n "$ac_ct_CXX"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CXX" >&5
+$as_echo "$ac_ct_CXX" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$ac_ct_CXX" && break
+done
+
+  if test "x$ac_ct_CXX" = x; then
+    CXX="g++"
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    CXX=$ac_ct_CXX
+  fi
+fi
+
+  fi
+fi
+# Provide some information about the compiler.
+$as_echo "$as_me:${as_lineno-$LINENO}: checking for C++ compiler version" >&5
+set X $ac_compile
+ac_compiler=$2
+for ac_option in --version -v -V -qversion; do
+  { { ac_try="$ac_compiler $ac_option >&5"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_compiler $ac_option >&5") 2>conftest.err
+  ac_status=$?
+  if test -s conftest.err; then
+    sed '10a\
+... rest of stderr output deleted ...
+         10q' conftest.err >conftest.er1
+    cat conftest.er1 >&5
+  fi
+  rm -f conftest.er1 conftest.err
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }
+done
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are using the GNU C++ compiler" >&5
+$as_echo_n "checking whether we are using the GNU C++ compiler... " >&6; }
+if ${ac_cv_cxx_compiler_gnu+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+#ifndef __GNUC__
+       choke me
+#endif
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ac_compiler_gnu=yes
+else
+  ac_compiler_gnu=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_cv_cxx_compiler_gnu=$ac_compiler_gnu
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_compiler_gnu" >&5
+$as_echo "$ac_cv_cxx_compiler_gnu" >&6; }
+if test $ac_compiler_gnu = yes; then
+  GXX=yes
+else
+  GXX=
+fi
+ac_test_CXXFLAGS=${CXXFLAGS+set}
+ac_save_CXXFLAGS=$CXXFLAGS
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CXX accepts -g" >&5
+$as_echo_n "checking whether $CXX accepts -g... " >&6; }
+if ${ac_cv_prog_cxx_g+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_save_cxx_werror_flag=$ac_cxx_werror_flag
+   ac_cxx_werror_flag=yes
+   ac_cv_prog_cxx_g=no
+   CXXFLAGS="-g"
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ac_cv_prog_cxx_g=yes
+else
+  CXXFLAGS=""
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+else
+  ac_cxx_werror_flag=$ac_save_cxx_werror_flag
+	 CXXFLAGS="-g"
+	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ac_cv_prog_cxx_g=yes
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+   ac_cxx_werror_flag=$ac_save_cxx_werror_flag
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cxx_g" >&5
+$as_echo "$ac_cv_prog_cxx_g" >&6; }
+if test "$ac_test_CXXFLAGS" = set; then
+  CXXFLAGS=$ac_save_CXXFLAGS
+elif test $ac_cv_prog_cxx_g = yes; then
+  if test "$GXX" = yes; then
+    CXXFLAGS="-g -O2"
+  else
+    CXXFLAGS="-g"
+  fi
+else
+  if test "$GXX" = yes; then
+    CXXFLAGS="-O2"
+  else
+    CXXFLAGS=
+  fi
+fi
+ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <iostream>
+    #ifndef __cplusplus
+    #error "broken C++"
+    #endif
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+else
+  CXX=;
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
 #
 # Assume that cross-compiling is for 32 bit systems
 # (alpha/NT will have to wait)
@@ -6108,6 +6447,7 @@ esac
 
 
 gp_configure_options=$ac_configure_args
+
 
 
 

--- a/extern/Makefile.in
+++ b/extern/Makefile.in
@@ -4,8 +4,14 @@ endif
 CFLAGS=@CFLAGS@ @ABI_CFLAGS@ $(COPTS)
 LDFLAGS=@LDFLAGS@ $(LOPTS)
 CC=@CC@
+CXX=@CXX@
 GAPARCH=@GAPARCH@
 MPFRVER=2.3.1
+ifdef CXX
+GMP_EXTRA_FLAGS=--enable-cxx
+else
+GMP_EXTRA_FLAGS=
+endif
 
 all: $(MAKE_GMP)
 
@@ -33,7 +39,7 @@ gmp_config: ../../../extern/gmp-$(GMP_VER)
 	    echo ""; \
 	    echo "Configuring GMP. Logging to bin/$(GAPARCH)/extern/gmp-$(GMP_VER)/build_log. Please wait... "; \
 	    echo ""; \
-	    ./configure --prefix=`pwd`/../../bin/$(GAPARCH)/extern/gmp-$(GMP_VER) --enable-cxx ABI=$(ABI) \
+	    ./configure --prefix=`pwd`/../../bin/$(GAPARCH)/extern/gmp-$(GMP_VER) $(GMP_EXTRA_FLAGS) ABI=$(ABI) \
 	     > ../../bin/$(GAPARCH)/extern/gmp-$(GMP_VER)/build_log 2>&1; \
 	    rm -f LASTBUILD*; \
 	    touch LASTBUILD.$(GAPARCH); \


### PR DESCRIPTION
This PR for the stable-4.8 branch
- fixes build failures on systems without C++ compiler (see also PR #728),
- improves INSTALL.md
- improves CONTRIBUTING,md
- improves bin/BuildPackages.sh

The latter script is meant to replace `InstPackages.sh`. 

Before this merged, a few things need to happen (probably by adding commits to this PR):
- [x] improve BuildPackages.sh a bit more (see issue #737)
- [x] somebody needs to verify that the removal of the special case for anupq really did not break anything (it didn't for me, but then I don't know why it was added in the first place)

