### PR TITLE
Add darwin implementation of NanosecondsSinceEpoch

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -881,52 +881,21 @@ Obj FuncRUNTIMES( Obj     self)
 **
 *F  FuncNanosecondsSinceEpoch( <self> )
 **
-**  'FuncNanosecondsSinceEpoch' returns an integer which represents the 
-**  number of nanoseconds since some unspecified starting point. This means
-**  that the number returned by this function is not in itself meaningful,
-**  but the difference between the values returned by two consecutive calls
-**  can be used to measure wallclock time.
-**
-**  The accuracy of this is system dependent. For systems that implement
-**  clock_getres, we could get the promised accuracy.
-**
-**  Note that gettimeofday has been marked obsolete in the POSIX standard.
-**  We are using it because it is implemented in most systems still.
-**
-**  If we are using gettimeofday we cannot guarantee the values that
-**  are returned by NanosecondsSinceEpoch to be monotonic.
+**  'FuncNanosecondsSinceEpoch' returns an integer which represents the
+**  number of nanoseconds since some unspecified starting point. This
+**  function wraps SyNanosecondsSinceEpoch.
 **
 */
 Obj FuncNanosecondsSinceEpoch(Obj self)
 {
-  Obj res;
+  Int8 val = SyNanosecondsSinceEpoch();
 
-#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
-  struct timespec ts;
-
-  if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
-    res = ObjInt_Int(ts.tv_sec);
-    res = ProdInt(res, ObjInt_Int(1000000000L));
-    res = SumInt(res, ObjInt_Int(ts.tv_nsec));
-  } else {
-    res = Fail;
+  if(val == -1) {
+    return Fail;
   }
-#elif defined(HAVE_GETTIMEOFDAY)
-  struct timeval tv;
-
-  if (gettimeofday(&tv, NULL) == 0) {
-    res = ObjInt_Int(tv.tv_sec);
-    res = ProdInt(res, ObjInt_Int(1000000L));
-    res = SumInt(res, ObjInt_Int(tv.tv_usec));
-    res = ProdInt(res, ObjInt_Int(1000L));
-  } else {
-    res = Fail;
-  };
-#else
-  res = Fail
-#endif
-
-  return res;
+  else {
+    return ObjInt_Int8(val);
+  }
 }
 
 /****************************************************************************

--- a/src/gmpints.c
+++ b/src/gmpints.c
@@ -375,6 +375,31 @@ Obj ObjInt_UInt( UInt i )
   }
 }
 
+Obj ObjInt_Int8( Int8 i )
+{
+  int neg = 0;
+  if(i < 0) {
+    neg = 1;
+    i = -i;
+  }
+  UInt lower = (UInt8)i;
+  UInt upper = ((UInt8)i) >> sizeof(UInt)*8;
+  Obj total = ObjInt_UInt(lower);
+    
+  if(upper != 0) {
+    Obj upper_obj = ObjInt_UInt(upper);
+    Obj mult_obj = ProdInt(INTOBJ_INT(65536), INTOBJ_INT(65536));
+    upper_obj = ProdInt(upper_obj, mult_obj);
+    total = SumInt(total, upper_obj);
+  }
+  
+  if(neg) {
+    total = AInvInt(total);
+  }
+  
+  return total;
+}
+
 
 /****************************************************************************
 **

--- a/src/gmpints.h
+++ b/src/gmpints.h
@@ -73,7 +73,7 @@ typedef mp_size_t   TypGMPSize;
 
 
 /**************************************************************************
-** The following two functions convert a C Int or UInt respectively into
+** The following two functions convert Int, UInt or Int8 respectively into
 ** a GAP integer, either an immediate, small integer if possible or 
 ** otherwise a new GAP bag with TNUM T_INTPOS or T_INTNEG.
 **
@@ -84,6 +84,7 @@ typedef mp_size_t   TypGMPSize;
 
 Obj ObjInt_Int(Int i);
 Obj ObjInt_UInt(UInt i);
+Obj ObjInt_Int8(Int8 i);
 
 /****************************************************************************
 **

--- a/src/system.c
+++ b/src/system.c
@@ -1462,7 +1462,16 @@ Int8 SyNanosecondsSinceEpoch()
 {
   Int8 res;
 
-#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
+#if defined(SYS_IS_DARWIN)
+  static mach_timebase_info_data_t timeinfo;
+  if ( timeinfo.denom == 0 ) {
+    (void) mach_timebase_info(&timeinfo);
+  }
+  res = mach_absolute_time();
+
+  res *= timeinfo.numer;
+  res /= timeinfo.denom;
+#elif defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
   struct timespec ts;
 
   if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {

--- a/src/system.h
+++ b/src/system.h
@@ -1008,6 +1008,31 @@ typedef struct {
 extern void SyExit (
     UInt                ret );
 
+
+/****************************************************************************
+**
+*F  SyNanosecondsSinceEpoch()
+**
+**  'SyNanosecondsSinceEpoch' returns a 64-bit integer which represents the
+**  number of nanoseconds since some unspecified starting point. This means
+**  that the number returned by this function is not in itself meaningful,
+**  but the difference between the values returned by two consecutive calls
+**  can be used to measure wallclock time.
+**
+**  The accuracy of this is system dependent. For systems that implement
+**  clock_getres, we could get the promised accuracy.
+**
+**  Note that gettimeofday has been marked obsolete in the POSIX standard.
+**  We are using it because it is implemented in most systems still.
+**
+**  If we are using gettimeofday we cannot guarantee the values that
+**  are returned by SyNanosecondsSinceEpoch to be monotonic.
+**
+**  Returns -1 to represent failure
+**
+*/
+Int8 SyNanosecondsSinceEpoch();
+
 /****************************************************************************
 **
 *F  SySleep( <secs> ) . . . . . . . . . . . . Try to sleep for <secs> seconds


### PR DESCRIPTION
This extracts SyNanosecondsSinceEpoch to system.c, and adds a darwin implementation. Fixes #750, is a requirement for #749.