### PR TITLE
Optimize ObjInt_Int8, and fix bug in ObjInt_Int

### DIFF
--- a/src/gmpints.c
+++ b/src/gmpints.c
@@ -345,9 +345,10 @@ Obj GMPorINTOBJ_INT( Int i )
   if ( (-(1L<<NR_SMALL_INT_BITS) <= i) && (i < 1L<<NR_SMALL_INT_BITS )) {
     return INTOBJ_INT(i);
   }
-    else if (i < 0 ) {
+  else if (i < 0 ) {
     gmp = NewBag( T_INTNEG, sizeof(TypLimb) );
-    }
+    i = -i;
+  }
   else {
     gmp = NewBag( T_INTPOS, sizeof(TypLimb) );
   }


### PR DESCRIPTION
The old implementation created multiple temporary GASMAN objects, which this implementation avoids. I also carefully verified that it is correct in various corner cases, via a test procedure on the C level.

Doing so, I discovered a bug in ObjInt_Int, which I also fixed.

BTW, It would be kind of nice if we had a good uniform to include C level test cases. Then I could have taken my test code, which I used to verify correctness of this implementation, and added it to the test suite.

Another note: The only way to correctly test this code is to make a 32bit build.