### PR TITLE
Fix kernel method for 'Remove' with one argument

### DIFF
--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -232,8 +232,10 @@ Obj            RemPlist (
     }
     removed = ELM_PLIST(list, pos);
     SET_ELM_PLIST(list, pos, (Obj)0L);
-    SET_LEN_PLIST(list, pos-1);
-    if ( pos == 1 ) {
+    pos--;
+    while ( 1 <= pos && ELM_PLIST( list, pos ) == 0 ) { pos--; }
+    SET_LEN_PLIST(list, pos);
+    if ( pos == 0 ) {
       RetypeBag(list, T_PLIST_EMPTY);
     }
     if (4*pos*sizeof(Obj) < 3*SIZE_BAG(list))

--- a/tst/teststandard/bugfix.tst
+++ b/tst/teststandard/bugfix.tst
@@ -3049,8 +3049,18 @@ gap> G:=Group((1,2,3,4));;Factorization(G,Elements(G)[1]);
 gap> l := [1,,,5];;
 gap> Remove(l);
 5
-gap> l;
-[ 1 ]
+gap> [l, Length(l)];
+[ [ 1 ], 1 ]
+gap> l := [,,,"x"];;
+gap> Remove(l);
+"x"
+gap> [l, Length(l)];
+[ [  ], 0 ]
+gap> l := [1,2,,[],"x"];;
+gap> Remove(l);
+"x"
+gap> [l, Length(l)];
+[ [ 1, 2,, [  ] ], 4 ]
 
 #############################################################################
 gap> STOP_TEST( "bugfix.tst", 831990000);

--- a/tst/teststandard/bugfix.tst
+++ b/tst/teststandard/bugfix.tst
@@ -3045,6 +3045,13 @@ gap> Size(Stabilizer(g, [ [1,2], [3,4] ], OnSetsSets));
 gap> G:=Group((1,2,3,4));;Factorization(G,Elements(G)[1]);
 <identity ...>
 
+#2016/04/27 (FL, bug reported on support list)
+gap> l := [1,,,5];;
+gap> Remove(l);
+5
+gap> l;
+[ 1 ]
+
 #############################################################################
 gap> STOP_TEST( "bugfix.tst", 831990000);
 


### PR DESCRIPTION
This fixes the following problem (reported to the support list):
gap> L:=[1,2,,,3];
[ 1, 2,,, 3 ]
gap> Remove(L);
3
gap> L;
[ 1, 2,, ]

that is, the length was not reduced to the position of the last bound entry.