### PR TITLE
Fix some bugs in the Rees (0)-matrix semigroups code

### DIFF
--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -38,16 +38,30 @@ function(R)
   TryNextMethod();
 end);
 
+InstallImmediateMethod(IsFinite, IsReesMatrixSubsemigroup, 0,
+function(R)
+  if IsBound(ElementsFamily(FamilyObj(R))!.IsFinite) then
+    return ElementsFamily(FamilyObj(R))!.IsFinite;
+  fi;
+  TryNextMethod();
+end);
+
 InstallMethod(IsFinite, "for a Rees matrix subsemigroup",
 [IsReesMatrixSubsemigroup], 
 function(R)
-  return IsFinite(ParentAttr(R));
+  if (not IsIdenticalObj(R, ParentAttr(R))) and HasIsFinite(ParentAttr(R)) then 
+    return IsFinite(ParentAttr(R));
+  fi;
+  TryNextMethod();
 end);
 
 InstallMethod(IsFinite, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup], 
 function(R)
-  return IsFinite(ParentAttr(R));
+  if (not IsIdenticalObj(R, ParentAttr(R))) and HasIsFinite(ParentAttr(R)) then 
+    return IsFinite(ParentAttr(R));
+  fi;
+  TryNextMethod();
 end);
 
 #
@@ -239,6 +253,10 @@ function(S, mat)
 
   fam := NewFamily( "ReesMatrixSemigroupElementsFamily",
           IsReesMatrixSemigroupElement);
+
+  if HasIsFinite(S) then
+    fam!.IsFinite := IsFinite(S);
+  fi;
 
   # create the Rees matrix semigroup
   R := Objectify( NewType( CollectionsFamily( fam ), IsWholeFamily and

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -334,8 +334,9 @@ function(S, mat)
   # cannot set IsZeroSimpleSemigroup to be <true> here since the matrix may
   # contain a row or column consisting entirely of 0s!
   # WW Also S might not be a simple semigroup (which is necessary)!
-
-  GeneratorsOfSemigroup(R);
+  if IsGroup(S) or (HasIsFinite(S) and IsFinite(S)) then 
+    GeneratorsOfSemigroup(R);
+  fi;
   SetIsSimpleSemigroup(R, false);
   return R;
 end);

--- a/tst/teststandard/reesmat.tst
+++ b/tst/teststandard/reesmat.tst
@@ -1085,6 +1085,15 @@ true
 gap> IsFinite(S);
 true
 
+# Test bug in IsFinite for RMS or RZMS created over a free group
+gap> S := FreeGroup(1);;
+gap> R := ReesMatrixSemigroup(S, [[S.1]]);;
+gap> IsFinite(R);
+false
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1]]);;
+gap> IsFinite(R);
+false
+
 #
 gap> STOP_TEST( "reesmat.tst", 54100000);
 

--- a/tst/teststandard/reesmat.tst
+++ b/tst/teststandard/reesmat.tst
@@ -609,8 +609,11 @@ gap> Length(GreensDClasses(UUU));
 4
 gap> Size(V);
 33
-gap> Vt:=Range(IsomorphismTransformationSemigroup(V));
-<transformation semigroup of degree 34 with 5 generators>
+gap> Vt:=Range(IsomorphismTransformationSemigroup(V));;
+gap> Length(GeneratorsOfSemigroup(Vt));
+5
+gap> DegreeOfTransformationSemigroup(Vt);
+34
 gap> Size(Vt);
 33
 gap> Representative(R);
@@ -1093,6 +1096,10 @@ false
 gap> R := ReesZeroMatrixSemigroup(S, [[S.1]]);;
 gap> IsFinite(R);
 false
+
+# Test bug in creation of RZMS over a free semigroup
+gap> S := FreeSemigroup(1);;
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1]]);;
 
 #
 gap> STOP_TEST( "reesmat.tst", 54100000);


### PR DESCRIPTION
This pull request fixes some bugs in the Rees (0-) matrix semigroup code related to creating such semigroups over infinite groups or semigroups. 

Tests are added which test cases that previously failed, these were pointed out by Wilf Wilson. 