### PR TITLE
Fix of three bugs in RandomPrimitivePolynomial

### DIFF
--- a/lib/polyconw.gi
+++ b/lib/polyconw.gi
@@ -524,12 +524,10 @@ InstallGlobalFunction( IsCheapConwayPolynomial, function( p, n )
 end );
 
 # arg: F, n[, i]
-InstallGlobalFunction( RandomPrimitivePolynomial, function(arg)
-  local F, n, i, pol, FF, one, fac, a;
-  F := arg[1];
-  n := arg[2];
-  if Length(arg) > 2 then
-    i := arg[3];
+InstallGlobalFunction( RandomPrimitivePolynomial, function(F, n, varnum...)
+  local i, pol, FF, one, fac, a, zero;
+  if Length(varnum) > 0 then
+    i := varnum[1];
   else
     i := 1;
   fi;
@@ -539,16 +537,20 @@ InstallGlobalFunction( RandomPrimitivePolynomial, function(arg)
   if IsInt(F) then
     F := GF(F);
   fi;
-  repeat pol := RandomPol(F, n, i);
+  if n=1 and Size(F)=2 then
+    return Indeterminate(F, i) + One(F);
+  fi;
+  repeat pol := RandomPol(F, n);
   until IsIrreducibleRingElement(PolynomialRing(F), pol);
   FF := AlgebraicExtension(F, pol);
   one := One(FF);
+  zero := Zero(FF);
   fac:=List(Set(Factors(Size(FF)-1)), p-> (Size(FF)-1)/p);
   repeat 
     a := Random(FF);
-  until ForAll(fac, d-> a^d <> one);
-  return MinimalPolynomial(F, a);
-end );
+  until a <> zero and ForAll(fac, d-> a^d <> one);
+  return MinimalPolynomial(F, a, i);
+end);
 
 ##  # utility to write new data files in case of extensions
 ##  printConwayData := function(f)

--- a/tst/teststandard/bugfix.tst
+++ b/tst/teststandard/bugfix.tst
@@ -3062,6 +3062,20 @@ gap> Remove(l);
 gap> [l, Length(l)];
 [ [ 1, 2,, [  ] ], 4 ]
 
+#2016/04/29 (FL, bug reported on support list)
+gap> Collected(List([1..200], i-> RandomPrimitivePolynomial(2,2)));
+[ [ x_1^2+x_1+Z(2)^0, 200 ] ]
+
+#another bug, detected when fixing the previous one (FL)
+gap> RandomPrimitivePolynomial(2,2,100);
+x_100^2+x_100+Z(2)^0
+
+#and a third bug (FL)
+gap> RandomPrimitivePolynomial(2,1);
+x_1+Z(2)^0
+gap> RandomPrimitivePolynomial(2,1,13);
+x_13+Z(2)^0
+
 #############################################################################
 gap> STOP_TEST( "bugfix.tst", 831990000);
 


### PR DESCRIPTION
- bug 1 was reported to the support list: zero was not excluded when
  searching a primitive element
- bug 2: the optional parameter (number of variable) was ignored
- bug 3: the case GF(2) and n=1 (q^n-1 = 1) must be handled as special case

On this occasion: the handling of the optional argument is now implemented
with the new var...  syntax.