### PR TITLE
Add methods for Intersection2 with empty list as parameter

### DIFF
--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -2368,6 +2368,16 @@ InstallOtherMethod( Intersection2,
     [ IsList, IsList ],
     IntersectionSet );
 
+InstallOtherMethod( Intersection2,
+    "for two lists or collections, the second being empty",
+    [ IsListOrCollection, IsListOrCollection and IsEmpty ],
+    function(C1, C2) return []; end);
+
+InstallOtherMethod( Intersection2,
+    "for two lists or collections, the first being empty",
+    [ IsListOrCollection and IsEmpty, IsListOrCollection ],
+    function(C1, C2) return []; end);
+
 InstallMethod( Intersection2,
     "for two collections in the same family, both lists",
     IsIdenticalObj,

--- a/tst/teststandard/bugfix.tst
+++ b/tst/teststandard/bugfix.tst
@@ -3043,6 +3043,14 @@ gap> Size(Stabilizer(g, [ [1,2], [3,4] ], OnSetsSets));
 gap> G:=Group((1,2,3,4));;Factorization(G,Elements(G)[1]);
 <identity ...>
 
+#2016/5/2 (MP)
+gap> S := FullTransformationMonoid(2);;
+gap> D := GreensDClassOfElement(S, IdentityTransformation);;
+gap> Intersection(D, []);
+[  ]
+gap> Intersection([], D);
+[  ]
+
 #############################################################################
 gap> STOP_TEST( "bugfix.tst", 831990000);
 


### PR DESCRIPTION
This is a fix for #773.