### PR TITLE
Make Permanent an attribute

### DIFF
--- a/lib/combinat.gd
+++ b/lib/combinat.gd
@@ -1487,7 +1487,7 @@ DeclareGlobalFunction("Bernoulli");
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction("Permanent");
+DeclareAttribute("Permanent", IsMatrix);
 
 
 #############################################################################

--- a/lib/combinat.gi
+++ b/lib/combinat.gi
@@ -1344,7 +1344,10 @@ Permanent2 := function ( mat, m, n, r, v, i, sum )
 end;
 MakeReadOnlyGlobal( "Permanent2" );
 
-InstallGlobalFunction(Permanent,function ( mat )
+InstallMethod(Permanent,
+   "for matrices",
+   [ IsMatrix ],
+function ( mat )
     local m, n;
 
     m := Length(mat);


### PR DESCRIPTION
I would liketo use permanents in other contexts (with other matrix objects), hence I'd like to make `Permanent` an attribute. If method selection is a concern we can go the `PermanentOp` route if necessary.