### PR TITLE
Fix PrintPPerm4 on big endian machines

### DIFF
--- a/src/pperm.c
+++ b/src/pperm.c
@@ -2248,7 +2248,7 @@ Obj PrintPPerm4(Obj self, Obj f){
   
   deg=DEG_PPERM4(f);
   if(deg==0) Pr("<empty partial perm>", 0L, 0L);
-  n=MAX(deg, CODEG_PPERM2(f));
+  n=MAX(deg, CODEG_PPERM4(f));
   ResizeTmpPPerm(n);
   ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
   for(i=0;i<n;i++) ptseen[i]=0; 


### PR DESCRIPTION
The Fedora PowerPC64 team tried to build gap 4.8.3 but hit a test failure in pperm.tst.  The QuoPPerm22 part of the bug was fixed in git in mid-April.  This fixes the only other case of the codegree being accessed with the wrong bit width, which accidentally works on little endian architectures like the x86 if the codegree is < 65536, but doesn't work on big endian machines.