### PR TITLE
Make sure 'time' has a value when gaprc is read

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -3094,6 +3094,7 @@ static Int PostRestore (
     Last2             = GVarName( "last2" );
     Last3             = GVarName( "last3" );
     Time              = GVarName( "time"  );
+    AssGVar(Time, INTOBJ_INT(0));
     QUITTINGGVar      = GVarName( "QUITTING" );
     
     /* return success                                                      */


### PR DESCRIPTION
The documentation for `ColorPrompt` has an example which uses `time`. However, this doesn't work, because when the prompt is run for the first time, `time` doesn't have a value yet. It didn't work in 4.7.8 either.

This provides a simple fix, by making sure when we first set up `time`, we give it a value (of 0, which seems most sensible).