### PR TITLE
Warning if some components of the core system are missing.

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -1008,7 +1008,7 @@ end );
 
 BindGlobal( "ShowPackageInformation", function()
   local linelen, indent, btop, vert, bbot, print_info,
-        libs, cmpdist, ld, f;
+        libs, cmpdist, ld, ms, f;
 
     linelen:= SizeScreen()[1] - 2;
     print_info:= function( prefix, values, suffix )
@@ -1057,7 +1057,13 @@ BindGlobal( "ShowPackageInformation", function()
                    small11:="0.1",small2:="2.0",small3:="2.0",small4:="1.0",
                    small5:="1.0",small6:="1.0",small7:="1.0",small8:="1.0",
                    small9:="1.0");
+        ms := ShallowCopy(cmpdist); ms.prim:="2.1"; ms.trans:="1.0";
         ld := ShallowCopy(GAPInfo.LoadedComponents);
+        for f in RecNames(ld) do
+          if ld.(f) = ms.(f) then
+            Unbind(ms.(f));
+          fi;
+        od;
         if ForAll(RecNames(cmpdist), f-> IsBound(ld.(f))
                                           and ld.(f) = cmpdist.(f)) then
           for f in RecNames(cmpdist) do
@@ -1070,6 +1076,19 @@ BindGlobal( "ShowPackageInformation", function()
                     List( RecNames( ld ), name -> Concatenation( name, " ",
                                       ld.( name ) ) ),
                     "\n");
+        if ms <> rec() then
+        print_info(
+          " WARNING: Some functionality is not available because of missing components:",
+                    List( RecNames( ms ), name -> Concatenation( name, " ",
+                                      ms.( name ) ) ),
+          "\n");
+        fi;
+      else # if no components are present at all
+        print_info(
+          " WARNING: Some functionality is not available because of missing ",
+          ["Small Groups", "Transitive Permutation Groups",
+           "and Primitive Permutation Groups"],
+           "libraries \n");
       fi;
 
       # For each loaded package, print name and version number.


### PR DESCRIPTION
This checks for components that may be missing if the distribution on core system has been rearranged.

For example, if some parts of the small groups library (and also `trans` and `prim`) are missing, the banner will contain a warning:

```
 Libs used:  gmp, readline
 Loading the library and packages ...
 Components: small 2.1, small2 2.0, small3 2.0, small4 1.0, small5 1.0, 
             small6 1.0, small7 1.0, small8 1.0, id2 3.0, id3 2.1, id4 1.0, 
             id5 1.0, id6 1.0
 WARNING: Some functionality is not available because of missing components:
             id10 0.1, id9 1.0, small10 0.2, small11 0.1, small9 1.0, prim 2.1, 
             trans 1.0
 Packages:   GAPDoc 1.5.1
 Try '??help' for help. See also '?copyright', '?cite' and '?authors'
gap>
```
(in this case I have removed `small/small9`, but that affected other components because of their interdependencies).

In case of all three group libraries missing, the warning will look like this:
```
Libs used:  gmp, readline
 Loading the library and packages ...
 WARNING: Some functionality is not available because of missing Small Groups, 
             Transitive Permutation Groups, and Primitive Permutation Groups
             libraries 
 Packages:   GAPDoc 1.5.1
 Try '??help' for help. See also '?copyright', '?cite' and '?authors' 
``` 

I also learned during this implementation that missing `trans` causes errors while loading Browse package, and missing `prim` - errors for CTblLib and IRREDSOL (not surprising, since package authors of course assume that these are parts of the core system).