### PR TITLE
Remove test that loads package ctbllib

### DIFF
--- a/tst/teststandard/ctbl.tst
+++ b/tst/teststandard/ctbl.tst
@@ -42,21 +42,6 @@ gap> ClassPositionsOfCentre( TrivialCharacter( t ) );
 [ 1 ]
 gap> ClassPositionsOfKernel( TrivialCharacter( t ) );
 [ 1 ]
-gap> LoadPackage("ctbllib", "1", false);; 
-
-# `CharacterTableDirectProduct' in all four combinations.
-gap> t1:= CharacterTable( "Cyclic", 2 );
-CharacterTable( "C2" )
-gap> t2:= CharacterTable( "Cyclic", 3 );
-CharacterTable( "C3" )
-gap> t1 * t1;
-CharacterTable( "C2xC2" )
-gap> ( t1 mod 2 ) * ( t1 mod 2 );
-BrauerTable( "C2xC2", 2 )
-gap> ( t1 mod 2 ) * t2;
-BrauerTable( "C2xC3", 2 )
-gap> t2 * ( t1 mod 2 );
-BrauerTable( "C3xC2", 2 )
 gap> STOP_TEST( "ctbl.tst", 3370000);
 
 #############################################################################


### PR DESCRIPTION
The same test is provided as part of `ctbllib`.