### PR TITLE
syAnswerAlarm: remove assert on the siginfo_t argument.

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -1413,9 +1413,6 @@ static void syAnswerAlarm ( int signr, siginfo_t * si, void *context)
        Later we might want to do something cleverer with throwing an 
        exception or dealing better if this isn't our timer     */
   assert( signr == TIMER_SIGNAL);
-  assert( si->si_signo == TIMER_SIGNAL);
-  assert( si->si_code == SI_TIMER);
-  assert( si->si_value.sival_int == 0x12345678 );
   SyAlarmRunning = 0;
   SyAlarmHasGoneOff = 1;
   InterruptExecStat();


### PR DESCRIPTION
Please make sure that this pull request:

- [x] is submitted to the correct branch (the stable branch is only for bugfixes)

- [x] contains an accurate description of changes for the release notes below

- [x] provides new tests or relies on existing ones

- [x] correctly refers to other issues and related pull requests

### Description of changes (for the release notes)

The singinfo_t argument is not used by GAP and not well supported on BSD systems. As a result the assert fails even while the timer actually works.
