### PR TITLE
Fix error message truncation

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -1621,7 +1621,7 @@ static Obj ErrorMessageToGAPString(
     Int                 arg1,
     Int                 arg2 )
 {
-  Char message[120];
+  Char message[1024];
   Obj Message;
   SPrTo(message, sizeof(message), msg, arg1, arg2);
   message[sizeof(message)-1] = '\0';

--- a/tst/testinstall/trans.tst
+++ b/tst/testinstall/trans.tst
@@ -789,13 +789,13 @@ gap> q = p ^ -1;
 true
 gap> PermLeftQuoTransformationNC((), IdentityTransformation);
 Error, PermLeftQuoTransformationNC: the arguments must both be transformations\
- (not permutation (small) and transformation (sm
+ (not permutation (small) and transformation (small))
 gap> PermLeftQuoTransformationNC(IdentityTransformation, ());
 Error, PermLeftQuoTransformationNC: the arguments must both be transformations\
- (not transformation (small) and permutation (sm
+ (not transformation (small) and permutation (small))
 gap> PermLeftQuoTransformationNC((), ());
 Error, PermLeftQuoTransformationNC: the arguments must both be transformations\
- (not permutation (small) and permutation (small
+ (not permutation (small) and permutation (small))
 gap> g := Transformation([3, 8, 1, 9, 9, 4, 10, 5, 10, 6]);;
 gap> f := (g ^ (2, 20)) * (1, 3, 8)(6, 9);;
 gap> PermLeftQuoTransformationNC(f, g);


### PR DESCRIPTION
Fix #785 , by increasing a buffer from 120 characters to 1024. Unfortunately we can't make this buffer variable sized, but this should hopefully be big enough for any error message we'll ever see.