### PR TITLE
Always build anupq in 32-bit mode

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -139,6 +139,11 @@ do
       set -e
       cd $dir
       case $dir in
+        anupq*)
+          ./configure CFLAGS=-m32 LDFLAGS=-m32 &&
+          $MAKE CFLAGS=-m32 LOPTS=-m32
+        ;;
+
         atlasrep*)
           chmod 1777 datagens dataword
         ;;


### PR DESCRIPTION
(Hopefully) fixes the issues with building anupq in `BuildPackages.sh`, by forcing it to always build in 32-bit mode.