### PR TITLE
Fix bug with iterating over non-reduced stab chains

### DIFF
--- a/lib/stbc.gi
+++ b/lib/stbc.gi
@@ -1806,6 +1806,9 @@ function(S)
 
     lstack := ListStabChain(S);
     Remove(lstack);
+    while Length(lstack) > 0 and Length(lstack[Length(lstack)].orbit) = 1 do
+        Remove(lstack);
+    od;
     r := rec (
           stack := lstack
         , pos := List(lstack, x -> 1)

--- a/tst/testinstall/stabchain.tst
+++ b/tst/testinstall/stabchain.tst
@@ -1,0 +1,22 @@
+gap> START_TEST("stabchain.tst");
+gap> TestGens := function(g)
+> local m;
+> m := SortedList(List(g));
+> if Size(m) <> Size(g) or Size(Set(m)) <> Size(m) or
+>    Group(m) <> g then Print("0"); fi;
+> ChangeStabChain(StabChainMutable(g), [1..10], false);
+> if m <> SortedList(List(g)) then Print("1"); fi;
+> if m <> SortedList(List(g, x -> x)) then Print("2"); fi;
+> ChangeStabChain(StabChainMutable(g), [10,9..1], false);
+> if m <> SortedList(List(g)) then Print("3"); fi;
+> if m <> SortedList(List(g, x -> x)) then Print("3"); fi;
+> ChangeStabChain(StabChainMutable(g), [1,10,11,12,13,14,15,2,3,4,5,6,7,8], false);
+> if m <> SortedList(List(g)) then Print("5"); fi;
+> if m <> SortedList(List(g, x -> x)) then Print("4"); fi;
+> return true;
+> end;;
+gap> TestGens(Group(()));;
+gap> List([2..7],
+>       x -> List([1..NrTransitiveGroups(x)],
+>         y -> TestGens(TransitiveGroup(x,y))));;
+gap> STOP_TEST("stabchain.tst", 1);


### PR DESCRIPTION
The `Iterator` for permutation groups was broken when the `StabChainMutable` of the group was not reduced (which can reasonably happen as the result of various algorithms). I decided the easiest way to fix the algorithm was to just throw away any trivial elements from the end of the stab chain, as they are the ones causing trouble (ones in the middle / start may slightly increase work, but don't cause a bug).

@markuspf might want to take a glance at this, as this is his code I'm tweaking.