### PR TITLE
Remove need to pass library directory to GAP / gap.sh

### DIFF
--- a/doc/dev/updates.xml
+++ b/doc/dev/updates.xml
@@ -337,7 +337,7 @@ Version numbers must be adjusted in the following files:
 <C>NeedKernelVersion</C>
 </Item>
 <Item>
-<F>src/system.c</F>, see <C>SyKernelVersion</C> and <C>SyWindowsPath</C>
+<F>src/system.c</F>, see <C>SyKernelVersion</C>
 </Item>
 <Item>
 <F>doc/versiondata</F>, see <C>VERSIONNUMBER</C>,

--- a/src/gap.c
+++ b/src/gap.c
@@ -514,6 +514,8 @@ int realmain( int argc, char * argv[], char * environ[] )
   Obj                 func;                   /* function (compiler)     */
   Int4                crc;                    /* crc of file to compile  */
 
+  SetupGAPLocation(argc, argv);
+
   /* initialize everything and read init.g which runs the GAP session */
   InitializeGap( &argc, argv, environ );
   if (!STATE(UserHasQUIT)) {         /* maybe the user QUIT from the initial

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -3082,8 +3082,8 @@ Int SyIsExistingFile ( const Char * name )
 **
 *F  SyIsReadableFile( <name> )  . . . . . . . . . . . is file <name> readable
 **
-**  'SyIsReadableFile'   returns 1  if the   file  <name> is   readable and 0
-**  otherwise. <name> is a system dependent description of the file.
+**  'SyIsReadableFile'   returns 0  if the   file  <name> is   readable and
+**  -1 otherwise. <name> is a system dependent description of the file.
 */
 Int SyIsReadableFile ( const Char * name )
 {

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -82,6 +82,13 @@ typedef void       sig_handler_t ( int );
 
 #ifdef SYS_IS_CYGWIN32
 #include <process.h>
+#include <stdlib.h>
+#endif
+
+#include <limits.h>
+
+#ifdef SYS_IS_DARWIN
+#include <mach-o/dyld.h>
 #endif
 
 
@@ -439,6 +446,119 @@ Int SyLoadModule( const Char * name, InitInfoFunc * func )
 }
 
 #endif
+
+/****************************************************************************
+**
+*F * * * * * * * * * * finding location of executable * * * * * * * * * * * *
+*/
+
+/****************************************************************************
+** The function 'find_yourself' is based on code (C) 2015 Mark Whitis, under
+** the MIT License : http://stackoverflow.com/a/34271901/928031
+*/
+
+void find_yourself(const char * argv0, char * result, size_t size_of_result)
+{
+    char findyourself_save_path[LONG_PATH_SIZE] = { 0 };
+
+
+    strlcpy(findyourself_save_path, getenv("PATH"),
+            sizeof(findyourself_save_path));
+
+    // + 256 gives us (lots) of slack to put the program name on the end
+    char newpath[LONG_PATH_SIZE + 256];
+    char newpath2[LONG_PATH_SIZE + 256];
+
+    result[0] = 0;
+
+    if (argv0[0] == '/') {
+        char * ret = realpath(argv0, newpath);
+        if (ret && !access(newpath, F_OK)) {
+            strlcpy(result, newpath, size_of_result);
+        }
+    }
+    else if (strchr(argv0, '/')) {
+        char   findyourself_save_pwd[LONG_PATH_SIZE] = { 0 };
+        char * retcwd =
+            getcwd(findyourself_save_pwd, sizeof(findyourself_save_pwd));
+        if (!retcwd)
+            return;
+        strlcpy(newpath2, findyourself_save_pwd, sizeof(newpath2));
+        strlcat(newpath2, "/", sizeof(newpath2));
+        strlcat(newpath2, argv0, sizeof(newpath2));
+        char * retpath = realpath(newpath2, newpath);
+        if (retpath && !access(newpath, F_OK)) {
+            strlcpy(result, newpath, size_of_result);
+        }
+    }
+    else {
+        char * saveptr;
+        char * pathitem;
+        for (pathitem = strtok_r(findyourself_save_path, ":", &saveptr);
+             pathitem; pathitem = strtok_r(NULL, ":", &saveptr)) {
+            strlcpy(newpath2, pathitem, sizeof(newpath2));
+            strlcat(newpath2, "/", sizeof(newpath2));
+            strlcat(newpath2, argv0, sizeof(newpath2));
+            char * ret = realpath(newpath2, newpath);
+            if (ret && !access(newpath, F_OK)) {
+                strlcpy(result, newpath, size_of_result);
+            }
+        }
+    }
+}
+
+
+char GAPExecLocation[LONG_PATH_SIZE] = { 0 };
+
+void SetupGAPLocation(int argc, char ** argv)
+{
+    char locBuf[LONG_PATH_SIZE] = { 0 };
+    Int4 length = 0;
+
+// Note: We keep cleaning exePath[0], as some of these methods
+// do not promise to leave the buffer empty on a failed return.
+
+#ifdef SYS_IS_DARWIN
+    char     exePath[PATH_MAX];
+    uint32_t len = sizeof(locBuf);
+    if (_NSGetExecutablePath(locBuf, &len) != 0) {
+        exePath[0] = '\0';    // buffer too small (!)
+    }
+#endif
+
+    // Try some generic techniques for BSDs, Linux and Cygwin
+
+    if (locBuf[0] == 0) {
+        ssize_t ret = readlink("/proc/self/exe", locBuf, sizeof(locBuf));
+        // If error returned, clear first character of buffer
+        if (!ret)
+            locBuf[0] = 0;
+    }
+
+    if (locBuf[0] == 0) {
+        ssize_t ret = readlink("/proc/curproc/exe", locBuf, sizeof(locBuf));
+        // If error returned, clear first character of buffer
+        if (!ret)
+            locBuf[0] = 0;
+    }
+
+    // If we are still failing, go and search the path
+    if (locBuf[0] == 0) {
+        find_yourself(argv[0], locBuf, LONG_PATH_SIZE);
+    }
+
+    // Remove symlinks (if present)
+    char * ret = realpath(locBuf, GAPExecLocation);
+    if (!ret)
+        locBuf[0] = 0;
+
+    // Now strip the executable name off
+    length = strlen(GAPExecLocation);
+    while (length > 0 && GAPExecLocation[length] != '/') {
+        GAPExecLocation[length] = 0;
+        length--;
+    }
+}
 
 
 /****************************************************************************

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -451,8 +451,8 @@ extern Int SyIsExistingFile(
 **
 *F  SyIsReadableFile( <name> )  . . . . . . . . . . . is file <name> readable
 **
-**  'SyIsReadableFile'   returns 1  if the   file  <name> is   readable and 0
-**  otherwise. <name> is a system dependent description of the file.
+**  'SyIsReadableFile'   returns 0  if the   file  <name> is   readable and
+**  -1 otherwise. <name> is a system dependent description of the file.
 */
 extern Int SyIsReadableFile(
             const Char * name );

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -78,6 +78,35 @@ extern Int SyLoadModule( const Char * name, InitInfoFunc * func );
 
 /****************************************************************************
 **
+*F * * * * * * * * * * finding location of executable * * * * * * * * * * * *
+*/
+
+/* On some OSes PATH_MAX is unreliable, so we make our buffer longer.
+** No buffer size is perfect, but we need to use a hard-code size.
+** We need to make the buffer PATH_MAX (or larger) as POSIX functions
+** we pass the buffer to assume the buffer is at least this big.
+*/
+
+#ifdef PATH_MAX
+#define LONG_PATH_SIZE_1 (PATH_MAX < 4096 ? 4096 : PATH_MAX)
+#else
+#define LONG_PATH_SIZE_1 4096
+#endif
+
+#define LONG_PATH_SIZE                                                       \
+    (LONG_PATH_SIZE_1 < GAP_PATH_MAX ? GAP_PATH_MAX : LONG_PATH_SIZE_1)
+
+// Contains the directory containing the running GAP executable
+// or contains the empty string is it could not be detect.
+extern char GAPExecLocation[LONG_PATH_SIZE];
+
+// Fills in GAPExecLocation. Is called straight after 'main' starts.
+void SetupGAPLocation(int argc, char ** argv);
+
+
+/****************************************************************************
+**
+
 *F * * * * * * * * * * * * * * * window handler * * * * * * * * * * * * * * *
 */
 

--- a/src/system.c
+++ b/src/system.c
@@ -85,13 +85,6 @@ Int enableCodeCoverageAtStartup( Char **argv, void * dummy);
 const Char * SyKernelVersion = "4.dev";
 
 /****************************************************************************
- *V  SyWindowsPath  . . . . . . . . . . . . . . . . . default path for Windows
- ** do not edit the following line. Occurrences of `gap4dev'
- ** will be replaced by string matching by distribution wrapping scripts.
- */
-const Char * SyWindowsPath = "/cygdrive/c/gap4dev";
-
-/****************************************************************************
 **
 *F * * * * * * * * * * * command line settable options  * * * * * * * * * * *
 */
@@ -1895,9 +1888,7 @@ void InitSystem (
     
     SyInstallAnswerIntr();
 
-#ifdef SYS_IS_CYGWIN32
-    SySetGapRootPath(SyWindowsPath);
-#elif defined(SYS_DEFAULT_PATHS)
+#if defined(SYS_DEFAULT_PATHS)
     SySetGapRootPath( SYS_DEFAULT_PATHS );
 #else
     SySetInitialGapRootPaths();

--- a/src/system.c
+++ b/src/system.c
@@ -85,10 +85,10 @@ Int enableCodeCoverageAtStartup( Char **argv, void * dummy);
 const Char * SyKernelVersion = "4.dev";
 
 /****************************************************************************
-*V  SyWindowsPath  . . . . . . . . . . . . . . . . . default path for Windows
-** do not edit the following line. Occurrences of `gap4dev'
-** will be replaced by string matching by distribution wrapping scripts.
-*/
+ *V  SyWindowsPath  . . . . . . . . . . . . . . . . . default path for Windows
+ ** do not edit the following line. Occurrences of `gap4dev'
+ ** will be replaced by string matching by distribution wrapping scripts.
+ */
 const Char * SyWindowsPath = "/cygdrive/c/gap4dev";
 
 /****************************************************************************
@@ -1860,11 +1860,11 @@ void InitSystem (
     SyInstallAnswerIntr();
 
 #ifdef SYS_IS_CYGWIN32
-    SySetGapRootPath( SyWindowsPath );
+    SySetGapRootPath(SyWindowsPath);
 #elif defined(SYS_DEFAULT_PATHS)
     SySetGapRootPath( SYS_DEFAULT_PATHS );
 #else
-    SySetGapRootPath( "./" );
+    SySetGapRootPath("./");
 #endif
 
     /* save the original command line for export to GAP */


### PR DESCRIPTION
This patch adds a global variable, `GAPExecLocation`, which stores (hopefully) the full path of GAP's executable.

We then use that to look for GAP's library path. The new method of finding GAP's library is:

1) If we can find GAP's executable, look in it's directory for lib/init.g. If we don't find it, look 3 directory levels up (to deal with how GAP's executable is typically two levels deep).

2) Look in the environment variable GAPROOT. If it exists, use it to find path (if it doesn't contain any `;`, then it will wipe out (1), as usual)

3) Look at the '-l'/'--roots' command line option, which as normal can wipe out (1) and (2).

With this change, I can just symlink the GAP executable into a directory in my path and GAP runs. I can also copy an entire GAP installation and it works (as long as I don't use gap.sh). I haven't checked every package survives the copy.

I imagine the function to find GAP's location might need tuning on different OSes. We can work on this, but I wanted to see if people were generally in favour of this technique.

Long term, this should remove the need for gap.sh entirely (although of course people can still use it if they want!)
