### PR TITLE
Help Random methods to use RandomSource

### DIFF
--- a/doc/ref/methsel.xml
+++ b/doc/ref/methsel.xml
@@ -85,6 +85,7 @@ For declaring that a filter is implied by other filters there is
 
 <#Include Label="InstallMethod">
 <#Include Label="InstallOtherMethod">
+<#Include Label="InstallMethodWithRandomSource">
 
 </Section>
 

--- a/lib/integer.gi
+++ b/lib/integer.gi
@@ -1741,12 +1741,12 @@ NrBitsInt := function ( n )
     return nr;
 end;
 
-InstallMethod( Random,
-    "for `Integers'",
-    true,
-    [ IsIntegers ], 0,
-    function( Integers )
-    return NrBitsInt( Random( [0..2^20-1] ) ) - 10;
+InstallMethodWithRandomSource(Random,
+    "for a random source and `Integers'", true,
+    [IsRandomSource, IsIntegers],
+    0,
+    function( rg, Integers )
+    return NrBitsInt( Random( rg, [0..2^20-1] ) ) - 10;
     end );
 
 

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -454,12 +454,12 @@ InstallOtherMethod(
 ##
 #M  Random( <list> )  . . . . . . . . . . . . . . . .  for a dense small list
 ##
-InstallOtherMethod( Random,
+InstallMethod( Random,
     "for a dense small list",
     [ IsList and IsDenseList and IsSmallList ],
     RandomList );
 
-InstallOtherMethod( Random,
+InstallMethod( Random,
     "for a dense (small) list",
     [ IsList and IsDenseList ],
     function( list )

--- a/lib/padics.gi
+++ b/lib/padics.gi
@@ -480,17 +480,17 @@ end );
 ##  may get two pure p-adic  numbers that have no  "digit"  in common, so  by
 ##  adding them, one of the two vanishes.
 ##
-InstallOtherMethod( Random,
+InstallOtherMethodWithRandomSource( Random, "for a random source and a pure p-adic family",
     true,
-    [ IsPurePadicNumberFamily ],
+    [ IsRandomSource, IsPurePadicNumberFamily ],
     0,
 
-function ( fam )
+function ( rg, fam )
     local c;
 
     c := [];
-    c[1] := Random( -fam!.precision, fam!.precision );
-    c[2] := Random( 0, fam!.modulus-1 );
+    c[1] := Random( rg, -fam!.precision, fam!.precision );
+    c[2] := Random( rg, 0, fam!.modulus-1 );
     while c[2] mod fam!.prime = 0  do
         c[1] := c[1] + 1;
         c[2] := c[2] / fam!.prime;
@@ -903,19 +903,19 @@ end );
 ##  Again this is just something that returns an extended p-adic number.  The
 ##  p-part is not totally covered (just ranges from -precision to precision).
 ##
-InstallOtherMethod( Random,
+InstallOtherMethodWithRandomSource( Random, "for a random source and p-adic extension family",
     true,
-    [ IsPadicExtensionNumberFamily ],
+    [ IsRandomSource, IsPadicExtensionNumberFamily ],
     0,
 
-function ( fam )
+function ( rg, fam )
     local   c,  l;
 
     c := [];
-    c[1] := Random( -fam!.precision, fam!.precision );
+    c[1] := Random( rg, -fam!.precision, fam!.precision );
     c[2] := [];
     for l  in [ 1 .. fam!.n ] do
-        c[2][l] := Random( 0, fam!.modulus-1 );
+        c[2][l] := Random( rg, 0, fam!.modulus-1 );
     od;
     while ForAll( c[2], x-> x mod fam!.prime = 0 ) do
         c[1] := c[1] + 1;

--- a/lib/random.gd
+++ b/lib/random.gd
@@ -69,8 +69,108 @@ DeclareCategory( "IsRandomSource", IsComponentObjectRep );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "Random", [IsRandomSource, IsList] );
+DeclareOperation( "Random", [IsRandomSource, IsListOrCollection] );
 DeclareOperation( "Random", [IsRandomSource, IsInt, IsInt] );
+
+##############################################################################
+##
+##  <#GAPDoc Label="InstallMethodWithRandomSource">
+##  <ManSection>
+##  <Func Name="InstallMethodWithRandomSource"
+##   Arg="opr,info[,famp],args-filts[,val],method"/>
+##  <Func Name="InstallOtherMethodWithRandomSource"
+##   Arg="opr,info[,famp],args-filts[,val],method"/>
+##
+##  <Description>
+##  These functions are designed to simplify adding new methods for
+##  <Ref Oper="Random" Label="for a list or collection"/> and
+##  <Ref Oper="PseudoRandom"/> to GAP which can
+##  be called both with, and without, a random source.
+##  <P/>
+##  They accept the same arguments as <Ref Func="InstallMethod"/> and
+##  <Ref Func="InstallOtherMethod"/>, with
+##  the extra requirement that the first member of <A>args-filts</A> must
+##  be <Ref Filt="IsRandomSource"/>, and the <A>info</A> argument
+##  is compulsory and must begin 'for a random source and'.
+##  <P/>
+##  This function then installs two methods: first it calls
+##  <Ref Func="InstallMethod"/> (or <Ref Func="InstallOtherMethod"/>)
+##  with unchanged arguments.
+##  Then it calls <Ref Func="InstallMethod"/>
+##  (or <Ref Func="InstallOtherMethod"/>) a second time to install
+##  another method which lacks the initial random source argument; this
+##  additional method simply invokes the original method, with
+##  <Ref Var="GlobalRandomSource"/> added as first argument.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+(function()
+    local func;
+    func := function(installType)
+        return function(args...)
+            local str, filterpos, filtercopy, argscopy, i, func, info;
+
+            # Check we understand arguments
+            # Second value must be an info string
+            if not IsString(args[2]) then
+                ErrorNoReturn("Second argument must be an info string");
+            fi;
+
+            # Info strings always tend to begin 'for ', and here we want
+            # to be able to edit it, so we check.
+            if args[2]{[1..23]} <> "for a random source and" then
+                ErrorNoReturn("Info string must begin 'for a random source and'");
+            fi;
+
+            # Filters must start with 'IsRandomSource'
+            for i in [1..Length(args)] do
+                if IsList(args[i]) and args[i][1] = IsRandomSource then
+                    filterpos := i;
+                fi;
+            od;
+
+            if not IsBound(filterpos) then
+                ErrorNoReturn("Must use a list of filters beginning 'IsRandomSource'");
+            fi;
+
+            # Last argument must be the actual method
+            if not IsFunction(args[Length(args)]) then
+                ErrorNoReturn("Argument list must end with the method");
+            fi;
+
+            # Install 
+            CallFuncList(installType, args);
+
+            # Install random, wrapping random source argument
+            argscopy := List(args);
+
+            # Remove 'IsRandomSource' from the filter list
+            argscopy[filterpos] := argscopy[filterpos]{[2..Length(argscopy[filterpos])]};
+
+            # Correct info string by removing 'a random source and'
+            info := "for";
+            APPEND_LIST(info, argscopy[2]{[24..Length(argscopy[2])]});
+            argscopy[2] := info;
+
+            func := argscopy[Length(argscopy)];
+            if Length(argscopy[filterpos]) = 1 then
+                argscopy[Length(argscopy)] := x -> func(GlobalMersenneTwister,x);
+            elif Length(argscopy[filterpos]) = 2 then
+                argscopy[Length(argscopy)] :=
+                    function(x,y)
+                        return func(GlobalMersenneTwister,x,y);
+                    end;
+            else
+                Error("Only 2 or 3 argument methods supported");
+            fi;
+
+            CallFuncList(installType, argscopy);
+        end;
+    end;
+    BIND_GLOBAL("InstallMethodWithRandomSource", func(InstallMethod));
+    BIND_GLOBAL("InstallOtherMethodWithRandomSource", func(InstallOtherMethod));
+end)();
 
 #############################################################################
 ##  

--- a/tst/testinstall/random.tst
+++ b/tst/testinstall/random.tst
@@ -3,4 +3,6 @@ gap> Read( Filename( DirectoriesLibrary( "tst" ), "testrandom.g" ) );
 gap> randomTest(Integers, Random);
 gap> randomTest([1..10], Random);
 gap> randomTest([1,-6,"cheese", Group(())], Random);
+gap> randomTest(PadicExtensionNumberFamily(3, 5, [1,1,1], [1,1]), Random, function(x,y) return IsPadicExtensionNumber(x); end);
+gap> randomTest(PurePadicNumberFamily(2,20), Random, function(x,y) return IsPurePadicNumber(x); end);
 gap> STOP_TEST("random.tst", 1);

--- a/tst/testinstall/random.tst
+++ b/tst/testinstall/random.tst
@@ -1,0 +1,6 @@
+gap> START_TEST("random.tst");
+gap> Read( Filename( DirectoriesLibrary( "tst" ), "testrandom.g" ) );
+gap> randomTest(Integers, Random);
+gap> randomTest([1..10], Random);
+gap> randomTest([1,-6,"cheese", Group(())], Random);
+gap> STOP_TEST("random.tst", 1);

--- a/tst/testrandom.g
+++ b/tst/testrandom.g
@@ -1,0 +1,89 @@
+randomTest := function(collection, method, checkin...)
+    local test1, test2, test3, test4, test5, test6, localgen, checkmethod;
+    if Length(checkin) = 0 then
+        checkmethod := \in;
+    else
+        checkmethod := checkin[1];
+    fi;
+
+    # Firstly, we will generate a base list
+    Init(GlobalMersenneTwister, 6);
+    test1 := List([1..1000], x -> method(collection));
+    # test2 should = test1
+    Init(GlobalMersenneTwister, 6);
+    test2 := List([1..1000], x -> method(collection));
+    # test3 should also = test1
+    Init(GlobalMersenneTwister, 6);
+    test3 := List([1..1000], x -> method(GlobalMersenneTwister, collection));
+    # test4 should be different (as it came from a different seed)
+    Init(GlobalMersenneTwister, 8);
+    test4 := List([1..1000], x -> method(collection));
+    # test5 should be the same as test4, as it is made from seed 8
+    # test6 should be the same as test1. Also, it checks that making test5
+    # did not touch the global source at all.
+    Init(GlobalMersenneTwister, 8);
+    localgen :=  RandomSource(IsMersenneTwister, 6);
+    test5 := List([1..1000], x -> method(localgen, collection));
+    test6 := List([1..1000], x -> method(collection));
+    if ForAny(Concatenation(test1, test2, test3, test4, test5, test6), x -> not (checkmethod(x, collection)) ) then
+        Print("Random member outside collection: ", collection,"\n");
+    fi;
+    if test1 <> test2 then
+        Print("Random not repeatable: ", collection, "\n");
+    fi;
+    if test2 <> test3 then
+        Print("Random 2-arg vs 1-arg broken: ", collection, "\n");
+    fi;
+    if test1 = test4 then
+        Print("Random not changing with random seed: ", collection, "\n");
+    fi;
+    if test1 <> test5 then
+        Print("Alt gen broken: ", collection, "\n");
+    fi;
+    if test4 <> test6 then
+        Print("Random with a passed in seed affected the global generator: ", collection, "\n");
+    fi;
+end;;
+
+# A special test for collections of size 1
+randomTestForSizeOneCollection := function(collection, method)
+    local i, val, localgen, intlist1, intlist2;
+    if Size(collection) <> 1 then
+        Print("randomTestForSizeOneCollection is only for collections of size 1");
+        return;
+    fi;
+
+    val := Representative(collection);
+
+    Init(GlobalMersenneTwister, 6);
+    intlist1 := List([1..1000], x -> Random([1..10]));
+
+    for i in [1..1000] do
+        if method(collection) <> val then
+            Print("Random returned something outside collection :", collection, ":", val);
+        fi;
+    od;
+
+    for i in [1..1000] do
+        if method(GlobalMersenneTwister, collection) <> val then
+            Print("Random returned something outside collection :", collection, ":", val);
+        fi;
+    od;
+
+    localgen := RandomSource(IsMersenneTwister, 6);
+
+    Init(GlobalMersenneTwister, 6);
+    for i in [1..1000] do
+        if method(localgen, collection) <> val then
+            Print("Random returned something outside collection :", collection, ":", val);
+        fi;
+    od;
+
+    # The previous loop should not have affected GlobalMersenneTwister,
+    # so this should be the same as intlist1
+    intlist2 := List([1..1000], x -> Random([1..10]));
+
+    if intlist1 <> intlist2 then
+        Print("Random read from local gen affected global gen: ", collection);
+    fi;
+end;;


### PR DESCRIPTION
The idea behind this patch is that we want (long term) for all implementations of `Random` to take an optional `RandomSource`.

Given an implementation of `Random` which takes a `RandomSource`, it's easy to wrap it and make a version which doesn't take a random source. This is what `InstallRandomMethod` does.

I show an example of using this on `Integers`. If this is happily accepted, then hopefully I (or other people!) will convert all `InstallMethod` for `Random` to use `InstallRandomMethod`. This will allow users to control random numbers better, and avoid code duplication.
