### PR TITLE
Protect global variable names from accidental changes

### DIFF
--- a/src/gvars.c
+++ b/src/gvars.c
@@ -684,10 +684,14 @@ Obj FuncIDENTS_GVAR (
     /*QQ extern Obj          NameGVars;   */
     Obj                 copy;
     UInt                i;
+    Obj                 strcopy;
 
     copy = NEW_PLIST( T_PLIST+IMMUTABLE, LEN_PLIST(NameGVars) );
     for ( i = 1;  i <= LEN_PLIST(NameGVars);  i++ ) {
-        SET_ELM_PLIST( copy, i, ELM_PLIST( NameGVars, i ) );
+        /* Copy the string here, because we do not want members of NameGVars
+         * accessable to users, as these strings must not be changed */
+        strcopy = CopyToStringRep( ELM_PLIST( NameGVars, i ) );
+        SET_ELM_PLIST( copy, i, strcopy );
     }
     SET_LEN_PLIST( copy, LEN_PLIST(NameGVars) );
     return copy;
@@ -699,11 +703,16 @@ Obj FuncIDENTS_BOUND_GVARS (
     /*QQ extern Obj          NameGVars;   */
     Obj                 copy;
     UInt                i, j;
+    Obj                 strcopy;
 
     copy = NEW_PLIST( T_PLIST+IMMUTABLE, LEN_PLIST(NameGVars) );
     for ( i = 1, j = 1;  i <= LEN_PLIST(NameGVars);  i++ ) {
         if ( VAL_GVAR( i ) || ELM_PLIST( ExprGVars, i )) {
-           SET_ELM_PLIST( copy, j, ELM_PLIST( NameGVars, i ) );
+           /* Copy the string here, because we do not want members of
+            * NameGVars accessable to users, as these strings must not be
+            * changed */
+           strcopy = CopyToStringRep( ELM_PLIST( NameGVars, i ) );
+           SET_ELM_PLIST( copy, j, strcopy );
            j++;
         }
     }

--- a/tst/teststandard/varnames.tst
+++ b/tst/teststandard/varnames.tst
@@ -10,7 +10,9 @@ gap> Filtered( NamesSystemGVars(), x -> not x in ALL_KEYWORDS() and
 >            ( Length(x)=1 or (IsLowerAlphaChar(x[1]) and Length(x) < 12) ) );
 [ "*", "+", "-", ".", "/", "<", "=", "E", "X", "Z", "^", "fail", "infinity", 
   "last", "last2", "last3", "time" ]
-gap> # Filtered(NamesSystemGVars(),name->IsSubset(LETTERS,name));;  
+gap> Filtered(NamesSystemGVars(),name->IsSubset(LETTERS,name));;
+gap> IsSubset(IDENTS_GVAR(), IDENTS_BOUND_GVARS() );
+true
 gap> E;
 <Operation "E">
 gap> X;


### PR DESCRIPTION
Protect global variable names from accidental changes, by making a copy.