### PR TITLE
Add extra argument to CallListFunc, to wrap return value.

### DIFF
--- a/lib/function.g
+++ b/lib/function.g
@@ -322,6 +322,7 @@ BIND_GLOBAL( "EndlineFunc", ENDLINE_FUNC );
 ##  <#GAPDoc Label="CallFuncList">
 ##  <ManSection>
 ##  <Oper Name="CallFuncList" Arg='func, args'/>
+##  <Oper Name="CallFuncListWrap" Arg='func, args'/>
 ##
 ##  <Description>
 ##  returns the result, when calling function <A>func</A> with the arguments
@@ -374,6 +375,17 @@ BIND_GLOBAL( "EndlineFunc", ENDLINE_FUNC );
 ##  gap> PrintDigits( 1, 9, 7, 3, 2 );
 ##  [ 1, 9, 7, 3, 2 ]
 ##  ]]></Example>
+##  <Ref Oper="CallFuncListWrap"/> differs only in that the result is a list.
+##  This returned list is empty if the called function returned no value,
+##  else it contains the returned value as it's single member. This allows
+##  wrapping functions which may, or may not return a value.
+##
+##  <Example><![CDATA[
+##  gap> CallFuncListWrap( x -> x, [1] );
+##  [ 1 ]
+##  gap> CallFuncListWrap( function(x) end, [1] );
+##  [ ]
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -382,6 +394,7 @@ BIND_GLOBAL( "EndlineFunc", ENDLINE_FUNC );
 ##
 UNBIND_GLOBAL("CallFuncList"); # was declared 2b defined
 DeclareOperationKernel( "CallFuncList", [IS_OBJECT, IS_LIST], CALL_FUNC_LIST );
+DeclareOperationKernel( "CallFuncListWrap", [IS_OBJECT, IS_LIST], CALL_FUNC_LIST_WRAP );
 
 
 #############################################################################

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -164,8 +164,8 @@ InstallTrueMethod(HasLength,IsPlistRep);
 ##  false
 ##  ]]></Example>
 ##
-##  <C>IsBound(<A>list</A>[<A>ix1</A>,<A>ix2</A>,...]</C> is a short-hand for  
-##  <C>IsBound(<A>list</A>[[<A>ix1</A>,<A>ix2</A>,...]]</C>   
+##  <C>IsBound(<A>list</A>[<A>ix1</A>,<A>ix2</A>,...])</C> is a short-hand for
+##  <C>IsBound(<A>list</A>[[<A>ix1</A>,<A>ix2</A>,...]])</C>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -237,8 +237,8 @@ DeclareOperationKernel( "Elm0List",
 ##  and there would be no way to tell
 ##  <Ref Func="Unbind" Label="unbind a list entry"/>
 ##  which component to remove.
-##  <C>Unbind(<A>list</A>[<A>ix1</A>,<A>ix2</A>,...]</C> is a short-hand for  
-##  <C>Unbind(<A>list</A>[[<A>ix1</A>,<A>ix2</A>,...]]</C>   
+##  <C>Unbind(<A>list</A>[<A>ix1</A>,<A>ix2</A>,...])</C> is a short-hand for
+##  <C>Unbind(<A>list</A>[[<A>ix1</A>,<A>ix2</A>,...]])</C>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/src/calls.c
+++ b/src/calls.c
@@ -1513,6 +1513,7 @@ Obj FuncCALL_FUNC (
 **  i.e., it is equivalent to '<func>( <list>[1], <list>[2]... )'.
 */
 Obj CallFuncListOper;
+Obj CallFuncListWrapOper;
 
 Obj CallFuncList ( Obj func, Obj list )
 {
@@ -1574,14 +1575,37 @@ Obj FuncCALL_FUNC_LIST (
     Obj                 func,
     Obj                 list )
 {
-  /* check that the second argument is a list                            */
-    while ( ! IS_SMALL_LIST( list ) ) {
-        list = ErrorReturnObj(
-            "CallFuncList: <list> must be a small list",
-            0L, 0L,
-            "you can replace <list> via 'return <list>;'" );
+    /* check that the second argument is a list                            */
+    if ( ! IS_SMALL_LIST( list ) ) {
+       ErrorMayQuit("CallFuncList: <list> must be a small list", 0L, 0L);
     }
     return CallFuncList(func, list);
+}
+
+Obj FuncCALL_FUNC_LIST_WRAP (
+    Obj                 self,
+    Obj                 func,
+    Obj                 list )
+{
+    Obj retval, retlist;
+    /* check that the second argument is a list                            */
+    if ( ! IS_SMALL_LIST( list ) ) {
+       ErrorMayQuit("CallFuncListWrap: <list> must be a small list", 0L, 0L);
+    }
+    retval = CallFuncList(func, list);
+
+    if (retval == 0)
+    {
+        retlist = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+    }
+    else
+    {
+        retlist = NEW_PLIST(T_PLIST, 1);
+        SET_LEN_PLIST(retlist, 1);
+        SET_ELM_PLIST(retlist, 1, retval);
+        CHANGED_BAG(retlist);
+    }
+    return retlist;
 }
 
 /****************************************************************************
@@ -2017,6 +2041,9 @@ static StructGVarOper GVarOpers [] = {
     { "CALL_FUNC_LIST", 2, "func, list", &CallFuncListOper,
       FuncCALL_FUNC_LIST, "src/calls.c:CALL_FUNC_LIST" },
 
+    { "CALL_FUNC_LIST_WRAP", 2, "func, list", &CallFuncListWrapOper,
+      FuncCALL_FUNC_LIST_WRAP, "src/calls.c:CALL_FUNC_LIST_WRAP" },
+
     { "NAME_FUNC", 1, "func", &NAME_FUNC_Oper,
       FuncNAME_FUNC, "src/calls.c:NAME_FUNC" },
 
@@ -2073,6 +2100,7 @@ static StructGVarFunc GVarFuncs [] = {
 
     { "ENDLINE_FUNC", 1, "func", 
       FuncENDLINE_FUNC, "src/calls.c:ENDLINE_FUNC" },
+
     { 0 }
 
 };

--- a/tst/testinstall/callfunc.tst
+++ b/tst/testinstall/callfunc.tst
@@ -1,0 +1,24 @@
+gap> START_TEST("callfunc.tst");
+
+# Union([1]) = 1 :(
+gap> ForAll([0,2..100], x -> [1..x] = CallFuncList(Union, List([1..x], y -> [y]) ) );
+true
+gap> CallFuncList(Group, [ (1,2) ]) = Group((1,2));
+true
+gap> ForAll([0,2..100], x -> [[1..x]] = CallFuncListWrap(Union, List([1..x], y -> [y]) ) );
+true
+gap> CallFuncListWrap(Group, [ (1,2) ]) = [ Group((1,2)) ];
+true
+gap> CallFuncList(Group, [ (1,2) ]) =  Group((1,2)) ;
+true
+gap> CallFuncList(Group, [ (1,2) ]) = Group((1,2)) ;
+true
+gap> l := [];;
+gap> CallFuncList(Add, [ l, 2 ] );
+gap> CallFuncList(Add, [ l, 3, 4] );
+gap> l = [2,,,3];
+true
+gap> swallow := function(x...) end;;
+gap> ForAll([0..100], x -> CallFuncListWrap(swallow, List([1..x], y -> [y]) ) = [] );
+true
+gap> STOP_TEST( "callfunc.tst", 1);


### PR DESCRIPTION
This has been previously requested by @fingolfin and myself.

Basically, CallListFunc (and GAP in general) doesn't provide a generic way of calling a function and capturing the return value of a function if one exists, but not breaking if there is not.

This adds `CallListFuncWrap` which is exactly the same as `CallListFunc`, except it returns a list of size 0 if the function returns nothing, and size 1 if there is a return value (containing that return value).
### Description of changes (for the release notes)

Add CallListFuncWrap, an extension to CallListFunc which allows generic code to handle functions which may or may not return a value.
