### PR TITLE
Add a generic 'no return' value to GAP

### DIFF
--- a/lib/boolean.g
+++ b/lib/boolean.g
@@ -80,6 +80,8 @@ InstallMethod( String,
       return "false";
     elif bool = fail  then
       return "fail";
+    elif bool = NoReturn then
+      return "<no return value>";
     else
       Error( "unknown boolean <bool>" );
     fi;

--- a/src/bool.c
+++ b/src/bool.c
@@ -77,6 +77,8 @@ Obj Fail;
 */
 Obj SuPeRfail;
 
+Obj NoReturn;
+
 /****************************************************************************
 **
 *V  Undefined  . . . . . . . . . . . . . . . . . . . . . . . undefined value
@@ -127,6 +129,9 @@ void PrintBool (
     }
     else if ( bool == SuPeRfail ) {
         Pr( "SuPeRfail", 0L, 0L );
+    }
+    else if ( bool == NoReturn ) {
+        Pr( "<no return value>", 0L, 0L );
     }
     else if ( bool == Undefined ) {
         Pr( "Undefined", 0L, 0L );
@@ -416,6 +421,7 @@ static Int InitKernel (
     InitGlobalBag( &False, "src/bool.c:FALSE" );
     InitGlobalBag( &Fail,  "src/bool.c:FAIL"  );
     InitGlobalBag( &SuPeRfail,  "src/bool.c:SUPERFAIL"  );
+    InitGlobalBag( &NoReturn,  "src/bool.c:NORETURN"  );
     InitGlobalBag( &Undefined,  "src/bool.c:UNDEFINED"  );
 
     /* install the saving functions                                       */
@@ -464,6 +470,12 @@ static Int InitLibrary (
     SuPeRfail  = NewBag( T_BOOL, 0L );
     gvar = GVarName( "SuPeRfail" );
     AssGVar( gvar, SuPeRfail );
+    MakeReadOnlyGVar(gvar);
+
+    /* `NoReturn' ditto                       */
+    NoReturn  = NewBag( T_BOOL, 0L );
+    gvar = GVarName( "NoReturn" );
+    AssGVar( gvar, NoReturn );
     MakeReadOnlyGVar(gvar);
 
     /* Undefined is an internal value */

--- a/src/bool.h
+++ b/src/bool.h
@@ -53,6 +53,15 @@ extern Obj SuPeRfail;
 
 /****************************************************************************
 **
+*V   NoReturn  . . . . . . . . . . . . . . . . . . . . . . .  superfail value
+**
+**  'NoReturn' is a special value returned by functions which would otherwise
+**  return no value.
+*/
+extern Obj NoReturn;
+
+/****************************************************************************
+**
 *V  Undefined  . . . . . . . . . . . . . . . . . . . . . . . undefined value
 **
 **  'Undefined' is a special object that is used in lieu of (Obj) 0 in places

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -457,11 +457,8 @@ Obj             EvalFunccall0args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
+    if ( result == 0 ) {
+            result = NoReturn;
     }
     return result;
 }
@@ -489,11 +486,8 @@ Obj             EvalFunccall1args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
+    if ( result == 0 ) {
+            result = NoReturn;
     }
     return result;
 }
@@ -524,11 +518,8 @@ Obj             EvalFunccall2args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
+    if ( result == 0 ) {
+            result = NoReturn;
     }
     return result;
 }
@@ -561,11 +552,8 @@ Obj             EvalFunccall3args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
+    if ( result == 0 ) {
+            result = NoReturn;
     }
     return result;
 }
@@ -599,11 +587,8 @@ Obj             EvalFunccall4args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
+    if ( result == 0 ) {
+            result = NoReturn;
     }
     return result;
 }
@@ -640,11 +625,8 @@ Obj             EvalFunccall5args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
+    if ( result == 0 ) {
+            result = NoReturn;
     }
     return result;
 }
@@ -683,11 +665,8 @@ Obj             EvalFunccall6args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
+    if ( result == 0 ) {
+            result = NoReturn;
     }
     return result;
 }
@@ -724,11 +703,8 @@ Obj             EvalFunccallXargs (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
+    if ( result == 0 ) {
+            result = NoReturn;
     }
     return result;
 }

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -438,9 +438,7 @@ void            IntrFuncCallEnd (
 
     /* check the return value                                              */
     if ( funccall && val == 0 ) {
-        ErrorQuit(
-            "Function call: <func> must return a value",
-            0L, 0L );
+        val = NoReturn;
     }
 
     if (options)


### PR DESCRIPTION
This pull request is an experiment in adding a generic, "no return" value to GAP. This adds a new (currently boolean) value 'NoReturn', and any function which appears to have no return value in fact returns 'NoReturn'.

Here are some examples:

```
gap> f := function() end;
function(  ) ... end
gap> f();
gap> f() = NoReturn;
true
gap> x := f();
<no return value>
gap> x;
<no return value>
gap> Print(x);
<no return value>
gap> f() = NoReturn
```

This should make no change to any working GAP code, either run interactively or not. The only difference is if you try to assign the result of a function to a variable when the function doesn't return, previously that was an error, now that variable is assigned `NoReturn`.
