### PR TITLE
Alternative to handle functions returning no value

### DIFF
--- a/src/funcs.c
+++ b/src/funcs.c
@@ -457,12 +457,7 @@ Obj             EvalFunccall0args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
-    }
+
     return result;
 }
 
@@ -489,12 +484,7 @@ Obj             EvalFunccall1args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
-    }
+
     return result;
 }
 
@@ -524,12 +514,7 @@ Obj             EvalFunccall2args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
-    }
+
     return result;
 }
 
@@ -561,12 +546,7 @@ Obj             EvalFunccall3args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
-    }
+
     return result;
 }
 
@@ -599,12 +579,7 @@ Obj             EvalFunccall4args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
-    }
+
     return result;
 }
 
@@ -640,12 +615,7 @@ Obj             EvalFunccall5args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
-    }
+
     return result;
 }
 
@@ -683,12 +653,7 @@ Obj             EvalFunccall6args (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
-    }
+
     return result;
 }
 
@@ -724,12 +689,7 @@ Obj             EvalFunccallXargs (
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
-    while ( result == 0 ) {
-        result = ErrorReturnObj(
-            "Function Calls: <func> must return a value",
-            0L, 0L,
-            "you can supply one by 'return <value>;'" );
-    }
+
     return result;
 }
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -155,7 +155,7 @@ void            PushObj (
     /* there must be a stack, it must not be underfull or overfull         */
     assert( TLS(StackObj) != 0 );
     assert( 0 <= TLS(CountObj) && TLS(CountObj) == LEN_PLIST(TLS(StackObj)) );
-    assert( val != 0 );
+    /* assert( val != 0 ); */
 
     /* count up and put the value onto the stack                           */
     TLS(CountObj)++;
@@ -193,7 +193,7 @@ Obj             PopObj ( void )
     TLS(CountObj)--;
 
     /* return the popped value (which must be non-void)                    */
-    assert( val != 0 );
+    /* assert( val != 0 ); */
     return val;
 }
 
@@ -437,19 +437,19 @@ void            IntrFuncCallEnd (
     }
 
     /* check the return value                                              */
-    if ( funccall && val == 0 ) {
+/*    if ( funccall && val == 0 ) {
         ErrorQuit(
             "Function call: <func> must return a value",
             0L, 0L );
-    }
+    }  */
 
     if (options)
       CALL_0ARGS(PopOptions);
 
     /* push the value onto the stack                                       */
-    if ( val == 0 )
+/*    if ( val == 0 )
         PushVoidObj();
-    else
+    else */
         PushObj( val );
 }
 
@@ -3160,9 +3160,15 @@ void            IntrAssList ( Int narg )
 
       /* assign to the element of the list                                   */
       if (IS_POS_INTOBJ(pos)) {
-        ASS_LIST( list, INT_INTOBJ(pos), rhs );
+        if (rhs == 0)
+          UNB_LIST( list, INT_INTOBJ(pos) );
+        else
+          ASS_LIST( list, INT_INTOBJ(pos), rhs );
       } else {
-        ASSB_LIST(list, pos, rhs);
+        if (rhs == 0)
+          UNBB_LIST( list, pos );
+        else
+          ASSB_LIST(list, pos, rhs);
       }
       break;
 
@@ -3183,7 +3189,10 @@ void            IntrAssList ( Int narg )
       }
       SET_LEN_PLIST(ixs, narg);
       list = PopObj();
-      ASSB_LIST(list, ixs, rhs);
+      if (rhs == 0) 
+        UNBB_LIST(list, ixs);
+      else
+        ASSB_LIST(list, ixs, rhs);
     }
       
     /* push the right hand side again                                      */
@@ -3250,7 +3259,7 @@ void            IntrAssListLevel (
 
     /* get right hand sides (checking is done by 'AssListLevel')           */
     rhss = PopObj();
-
+    
     ixs = NEW_PLIST(T_PLIST, narg);
     for (i = narg; i > 0; i--) {
       /* get and check the position                                          */
@@ -3265,7 +3274,10 @@ void            IntrAssListLevel (
     lists = PopObj();
 
     /* assign the right hand sides to the elements of several lists        */
-    AssListLevel( lists, ixs, rhss, level );
+    if (rhss == 0)
+      UNBB_LIST( lists, ixs );
+    else
+      AssListLevel( lists, ixs, rhss, level );
 
     /* push the assigned values again                                      */
     PushObj( rhss );
@@ -3577,7 +3589,7 @@ void            IntrAssRecName (
 
     /* get the right hand side                                             */
     rhs = PopObj();
-
+    
     /* get the record (checking is done by 'ASS_REC')                      */
     record = PopObj();
 
@@ -3798,15 +3810,19 @@ void            IntrAssPosObj ( void )
     list = PopObj();
 
     /* assign to the element of the list                                   */
-    if ( TNUM_OBJ(list) == T_POSOBJ ) {
-        if ( SIZE_OBJ(list)/sizeof(Obj) - 1 < p ) {
-            ResizeBag( list, (p+1) * sizeof(Obj) );
-        }
-        SET_ELM_PLIST( list, p, rhs );
-        CHANGED_BAG( list );
-    }
-    else {
-        ASS_LIST( list, p, rhs );
+    if (rhs == 0) {
+      UNB_LIST(list, p);
+    } else {
+      if ( TNUM_OBJ(list) == T_POSOBJ ) {
+          if ( SIZE_OBJ(list)/sizeof(Obj) - 1 < p ) {
+              ResizeBag( list, (p+1) * sizeof(Obj) );
+          }
+          SET_ELM_PLIST( list, p, rhs );
+          CHANGED_BAG( list );
+      }
+      else {
+          ASS_LIST( list, p, rhs );
+      }
     }
 
     /* push the right hand side again                                      */
@@ -4183,13 +4199,17 @@ void            IntrAssComObjName (
     record = PopObj();
 
     /* assign the right hand side to the element of the record             */
-    switch (TNUM_OBJ(record)) {
-      case T_COMOBJ:
-        AssPRec( record, rnam, rhs );
-        break;
-      default:
-        ASS_REC( record, rnam, rhs );
-        break;
+    if (rhs == 0) {
+      UNB_REC( record, rnam );
+    } else {
+      switch (TNUM_OBJ(record)) {
+        case T_COMOBJ:
+          AssPRec( record, rnam, rhs );
+          break;
+        default:
+          ASS_REC( record, rnam, rhs );
+          break;
+      }
     }
 
     /* push the assigned value                                             */
@@ -4218,13 +4238,17 @@ void            IntrAssComObjExpr ( void )
     record = PopObj();
 
     /* assign the right hand side to the element of the record             */
-    switch (TNUM_OBJ(record)) {
-      case T_COMOBJ:
-        AssPRec( record, rnam, rhs );
-        break;
-      default:
-        ASS_REC( record, rnam, rhs );
-        break;
+    if (rhs == 0) {
+      UNB_REC( record, rnam );
+    } else {
+      switch (TNUM_OBJ(record)) {
+        case T_COMOBJ:
+          AssPRec( record, rnam, rhs );
+          break;
+        default:
+          ASS_REC( record, rnam, rhs );
+          break;
+      }
     }
 
     /* push the assigned value                                             */

--- a/src/plist.c
+++ b/src/plist.c
@@ -1628,6 +1628,11 @@ void            AssPlist (
     Int                 pos,
     Obj                 val )
 {
+    if (val == 0L) {
+        UnbPlist(list, pos);
+        return;
+    }
+
     /* resize the list if necessary                                        */
     if ( LEN_PLIST( list ) < pos ) {
         GROW_PLIST( list, pos );
@@ -1646,6 +1651,11 @@ void            AssPlistXXX (
 {
   Int len;
   
+    if (val == 0L) {
+        UnbPlist(list, pos);
+        return;
+    }
+
     /* the list will probably loose its flags/properties                   */
     CLEAR_FILTS_LIST(list);
 
@@ -1672,6 +1682,10 @@ void AssPlistCyc   (
 {
   Int len;
   
+  if (val == 0L) {
+      UnbPlist(list, pos);
+      return;
+  }
   
   /* resize the list if necessary                                        */
   len = LEN_PLIST( list );
@@ -1710,6 +1724,11 @@ void AssPlistFfe   (
 {
     Int len;
   
+    if (val == 0L) {
+        UnbPlist(list, pos);
+        return;
+    }
+
     /* resize the list if necessary                                        */
     len = LEN_PLIST( list );
     if ( len < pos ) {
@@ -1772,6 +1791,11 @@ void AssPlistDense (
 {
   Int len;
   
+  if (val == 0L) {
+      UnbPlist(list, pos);
+      return;
+  }
+
   /* the list will probably loose its flags/properties                   */
   CLEAR_FILTS_LIST(list);
   
@@ -1801,6 +1825,11 @@ void AssPlistHomog (
   Int len;
   Obj fam;
   
+  if (val == 0L) {
+      UnbPlist(list, pos);
+      return;
+  }
+
   /* the list may loose its flags/properties                   */
   CLEAR_FILTS_LIST(list);
   
@@ -1877,6 +1906,10 @@ void AssPlistEmpty (
     Int                 pos,
     Obj                 val )
 {
+    if (val == 0L) {
+        return;
+    }
+
     /* if <pos> is large than one use `AssPlistDense'                        */
     if ( 1 != pos ) {
         AssPlistDense( list, pos, val );

--- a/src/precord.c
+++ b/src/precord.c
@@ -493,6 +493,11 @@ void AssPRec (
     UInt                len;            /* length of <rec>                 */
     UInt                i;              /* loop variable                   */
 
+    if (val == 0) {
+        UnbPRec( rec, rnam );
+        return;
+    }
+
     /* get the length of the record                                        */
     len = LEN_PREC( rec );
 

--- a/src/records.c
+++ b/src/records.c
@@ -432,7 +432,11 @@ Obj             AssRecHandler (
     Obj                 rnam,
     Obj                 obj )
 {
-    ASS_REC( rec, INT_INTOBJ(rnam), obj );
+    if (obj == 0) {
+        UNB_REC( rec, INT_INTOBJ(rnam) );
+    } else {
+        ASS_REC( rec, INT_INTOBJ(rnam), obj );
+    }
     return 0;
 }
 
@@ -453,7 +457,11 @@ void            AssRecObject (
     UInt                rnam,
     Obj                 val )
 {
-    DoOperation3Args( AssRecOper, obj, INTOBJ_INT(rnam), val );
+    if (val == 0) {
+      UNB_REC( obj, rnam );
+    } else {
+      DoOperation3Args( AssRecOper, obj, INTOBJ_INT(rnam), val );
+    }
 }
 
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -1152,22 +1152,28 @@ UInt            ExecAssList (
     if (IS_POS_INTOBJ(pos)) {
         p = INT_INTOBJ(pos);
 
-        /* special case for plain list                                     */
-        if ( TNUM_OBJ(list) == T_PLIST ) {
-            if ( LEN_PLIST(list) < p ) {
-                GROW_PLIST( list, p );
-                SET_LEN_PLIST( list, p );
+        if (rhs == 0) {
+            UNB_LIST( list, p );
+        } else {
+            /* special case for plain list                                  */
+            if ( TNUM_OBJ(list) == T_PLIST ) {
+                if ( LEN_PLIST(list) < p ) {
+                    GROW_PLIST( list, p );
+                    SET_LEN_PLIST( list, p );
+                }
+                SET_ELM_PLIST( list, p, rhs );
+                CHANGED_BAG( list );
             }
-            SET_ELM_PLIST( list, p, rhs );
-            CHANGED_BAG( list );
-        }
-
-        /* generic case                                                    */
-        else {
-            ASS_LIST( list, p, rhs );
+            /* generic case                                                 */
+            else {
+                ASS_LIST( list, p, rhs );
+            }
         }
     } else {
-        ASSB_LIST(list, pos, rhs);
+        if (rhs == 0)
+            UNBB_LIST( list, pos );
+        else
+          ASSB_LIST( list, pos, rhs );
     }
 
     /* return 0 (to indicate that no leave-statement was executed)         */
@@ -2309,17 +2315,21 @@ UInt            ExecAssPosObj (
     rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
 
     /* special case for plain list                                         */
-    if ( TNUM_OBJ(list) == T_POSOBJ ) {
-        WriteGuard(list);
-        if ( SIZE_OBJ(list)/sizeof(Obj)-1 < p ) {
-            ResizeBag( list, (p+1) * sizeof(Obj) );
-        }
-        SET_ELM_PLIST( list, p, rhs );
-        CHANGED_BAG( list );
-    }
-    /* generic case                                                        */
-    else {
-        ASS_LIST( list, p, rhs );
+    if (rhs == 0) {
+        UNB_LIST( list, p );
+    } else {
+       if ( TNUM_OBJ(list) == T_POSOBJ ) {
+           WriteGuard(list);
+           if ( SIZE_OBJ(list)/sizeof(Obj)-1 < p ) {
+               ResizeBag( list, (p+1) * sizeof(Obj) );
+           }
+           SET_ELM_PLIST( list, p, rhs );
+           CHANGED_BAG( list );
+       }
+       /* generic case                                                        */
+       else {
+           ASS_LIST( list, p, rhs );
+       }
     }
 
     /* return 0 (to indicate that no leave-statement was executed)         */
@@ -2560,11 +2570,15 @@ UInt            ExecAssComObjName (
     rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
 
     /* assign the right hand side to the element of the record             */
-    if ( TNUM_OBJ(record) == T_COMOBJ ) {
-        AssPRec( record, rnam, rhs );
-    }
-    else {
-        ASS_REC( record, rnam, rhs );
+    if (rhs == 0) {
+        UNB_REC( record, rnam );
+    } else {
+        if ( TNUM_OBJ(record) == T_COMOBJ ) {
+            AssPRec( record, rnam, rhs );
+        }
+        else {
+            ASS_REC( record, rnam, rhs );
+        }
     }
 
     /* return 0 (to indicate that no leave-statement was executed)         */
@@ -2596,12 +2610,16 @@ UInt            ExecAssComObjExpr (
     /* evaluate the right hand side                                        */
     rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
 
-    /* assign the right hand side to the element of the record             */
-    if ( TNUM_OBJ(record) == T_COMOBJ ) {
-        AssPRec( record, rnam, rhs );
-    }
-    else {
-        ASS_REC( record, rnam, rhs );
+    if (rhs == 0) {
+        UNB_REC( record, rnam );
+    } else {
+        /* assign the right hand side to the element of the record         */
+        if ( TNUM_OBJ(record) == T_COMOBJ ) {
+            AssPRec( record, rnam, rhs );
+        }
+        else {
+            ASS_REC( record, rnam, rhs );
+        }
     }
 
     /* return 0 (to indicate that no leave-statement was executed)         */


### PR DESCRIPTION
This is an experiment to allow users statements like
  a := fu();
even if fu() does not return a value. In this case the statement
unbinds 'a' so that one can detect that fu() did not return a value
by 'IsBound(a);'.

The behaviour is similar for assignments to lists or record components
where statements like
  l[i] := fu();
  r.comp := fu();
in case of fu() not returning a value have the effect of
  Unbind(l[i]);
  Unbind(r.comp);
