### PR TITLE
allow repeated use of same DeclareSynonym call

### DIFF
--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -337,18 +337,24 @@ end );
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL( "DeclareSynonym", function( name, value )
-    BIND_GLOBAL( name, value );
+    if ISBOUND_GLOBAL(name) and IS_IDENTICAL_OBJ(VALUE_GLOBAL(name), value) then
+        if not REREADING then
+            INFO_DEBUG( 1, "multiple declarations for synonym `", name, "'\n" );
+        fi;
+    else
+        BIND_GLOBAL( name, value );
+    fi;
 end );
 
 BIND_GLOBAL( "DeclareSynonymAttr", function( name, value )
     local nname;
-    BIND_GLOBAL( name, value );
+    DeclareSynonym( name, value );
     nname:= "Set";
     APPEND_LIST_INTR( nname, name );
-    BIND_GLOBAL( nname, Setter( value ) );
+    DeclareSynonym( nname, Setter( value ) );
     nname:= "Has";
     APPEND_LIST_INTR( nname, name );
-    BIND_GLOBAL( nname, Tester( value ) );
+    DeclareSynonym( nname, Tester( value ) );
 end );
 
 


### PR DESCRIPTION
### Description of changes (for the release notes)

This allows the same synonym to be declared in different places, e.g., different packages, similar to DeclareOperation. This might be useful to remove package dependencies.

For example, this would allow an alternative resolution of the dependencies between the upcoming PrimitiveGroups package and IRREDSOL discussed in #791 (by making the same declarations in both packages).

BTW., I don't think that coll.gd is a good place for this code, should it be moved elsewhere (oper.g or variable.g)?

I don't think that this needs test code.
