### PR TITLE
fix in ShortestVectors for issue #838

### DIFF
--- a/lib/zlattice.gi
+++ b/lib/zlattice.gi
@@ -1377,7 +1377,7 @@ InstallGlobalFunction( ShortestVectors, function( arg )
     anz := 0;
     con := true;
     srt( n, 0 );
-
+    c.vectors := c.vectors{[1..Length(c.norms)]};
     Info( InfoZLattice, 2,
           "ShortestVectors: ", Length( c.vectors ), " vectors found" );
     return c;


### PR DESCRIPTION
See https://github.com/gap-system/gap/issues/838 for details and an example to check.

This is needed if "positive" is set in a call to `OrthogonalEmbeddings` and the last vector `c.vectors[anz]` produced by the function `ShortestVectors` happens to be not non-negative. Then the lines rejecting it:

```
if checkpositiv and neg then
       c.vectors[anz] := [];
       anz := anz - 1;
```

leave an uncleared `[]`last entry in `c.vectors`, resulting in the error mentioned in the issue at hand.
