### PR TITLE
Ensure ErrorNoReturn is defined at the same time as Error

### DIFF
--- a/lib/error.g
+++ b/lib/error.g
@@ -274,6 +274,8 @@ BIND_GLOBAL("Error",
                                arg);
 end);
 
+Unbind(ErrorNoReturn);
+
 BIND_GLOBAL("ErrorNoReturn",
        function ( arg )
     ErrorInner( rec(

--- a/lib/init.g
+++ b/lib/init.g
@@ -67,6 +67,8 @@ Error := function( arg )
     JUMP_TO_CATCH("early error");
 end;
 
+ErrorNoReturn := Error;
+
 ErrorInner := function(arg)
     local x;
     Print("Error before error-handling is initialized: ");


### PR DESCRIPTION
As in title -- this just makes sure `ErrorNoReturn` as defined at the same time as `Error`, in the same way, so it can be used anywhere in the library `Error` can be.