### PR TITLE
Updated documentation and incremented version for primitive groups library

### DIFF
--- a/doc/manualbib.xml
+++ b/doc/manualbib.xml
@@ -1470,6 +1470,30 @@
   <other type="pages">xx+1028</other>
 </book></entry>
 
+<entry id="CRDQ11"><article>
+  <author>
+    <name><first>Hannah J.</first><last>Coutts</last></name>
+  </author>
+  <author>
+    <name><first>Colva M.</first><last>Roney-Dougal</last></name>
+  </author>
+  <author>
+    <name><first>Martyn</first><last>Quick</last></name>
+  </author>
+  <title>The primitive permutation groups of degree less than 4096</title>
+  <journal><value key="comma2"/></journal>
+  <year>2011</year>
+  <volume>39</volume>
+  <number>10</number>
+  <pages>3526&ndash;3546</pages>
+  <issn>0092-7872</issn>
+  <mrnumber>2845584</mrnumber>
+  <mrclass>20B15</mrclass>
+  <mrreviewer>Thomas Michael Keller</mrreviewer>
+  <other type="coden">COALDM</other>
+  <other type="fjournal">Communications in Algebra</other>
+</article></entry>
+
 <entry id="coxlittleoshea"><book>
   <author>
     <name><first>David</first><last>Cox</last></name>

--- a/doc/ref/grplib.xml
+++ b/doc/ref/grplib.xml
@@ -702,7 +702,7 @@ together with a serial number if this is necessary to make it unique.
 
 <Description>
 In <Cite Key="DixonMortimer88"/> the primitive groups are sorted in
-<Q>cohorts</Q> according to their socle. For each degree, the variable
+<Q>cohorts</Q> according to their socle. For each degree less than 2500, the variable
 <Ref Var="COHORTS_PRIMITIVE_GROUPS"/> contains a list of the cohorts
 for the primitive groups of this degree. Each cohort is represented by a
 list of length 2, the first entry specifies the socle type (see

--- a/prim/primitiv.gd
+++ b/prim/primitiv.gd
@@ -13,8 +13,8 @@
 ##  &GAP; contains a library of primitive permutation groups which includes,
 ##  up to permutation isomorphism (i.e., up to conjugacy in the corresponding
 ##  symmetric group),
-##  all  primitive  permutation groups of  degree <M>&lt;&nbsp;2500</M>,
-##  calculated in <Cite Key="RoneyDougal05"/>,
+##  all  primitive  permutation groups of  degree <M>&lt;&nbsp;4096</M>,
+##  calculated in <Cite Key="RoneyDougal05"/> and <Cite Key="CRDQ11"/>,
 ##  in particular,
 ##  <List>
 ##  <Item>
@@ -99,7 +99,8 @@ DeclareComponent("prim","3.0");
 ##  returns the primitive permutation  group of degree <A>deg</A> with number <A>nr</A>
 ##  from the list. 
 ##  <P/>
-##  The arrangement of the groups differs from the arrangement of primitive
+##  The arrangement of the groups of degrees not greater than 50
+##  differs from the arrangement of primitive
 ##  groups in the list of C.&nbsp;Sims, which was used in &GAP;&nbsp;3. See
 ##  <Ref Func="SimsNo"/>.
 ##  </Description>

--- a/prim/primitiv.gd
+++ b/prim/primitiv.gd
@@ -84,7 +84,7 @@
 ##
 ## tell GAP about the component
 ##
-DeclareComponent("prim","2.1");
+DeclareComponent("prim","3.0");
 
 
 #############################################################################

--- a/prim/primitiv.gd
+++ b/prim/primitiv.gd
@@ -214,9 +214,10 @@ DeclareGlobalFunction( "OnePrimitiveGroup" );
 ##  <Attr Name="SimsNo" Arg='G'/>
 ##
 ##  <Description>
-##  If <A>G</A> is a primitive group obtained by <Ref Func="PrimitiveGroup"/>
-##  (respectively one of the selection functions) this attribute contains the
-##  number of the isomorphic group in the original list of C.&nbsp;Sims.
+##  If <A>G</A> is a primitive group of degree not greater than 50,
+##  obtained by <Ref Func="PrimitiveGroup"/>
+##  (respectively one of the selection functions), then this attribute contains
+##  the number of the isomorphic group in the original list of C.&nbsp;Sims.
 ##  (This is the arrangement as it was used in &GAP;&nbsp;3.)
 ##  <P/>
 ##  <Example><![CDATA[

--- a/prim/primitiv.gi
+++ b/prim/primitiv.gi
@@ -505,7 +505,7 @@ local arglis,i,j,a,b,l,p,deg,gut,g,grp,nr,f,RFL,ind,it;
   od;
 
   if f then
-    Print( "#W  AllPrimitiveGroups: Degree restricted to [ 1 .. ",
+    Print( "#W  AllPrimitiveGroups: Degree restricted to [ 2 .. ",
            PRIMRANGE[ Length( PRIMRANGE ) ], " ]\n" );
   fi;
 

--- a/prim/primitiv.gi
+++ b/prim/primitiv.gi
@@ -356,6 +356,9 @@ InstallMethod(SimsNo,"via `PrimitiveIdentification'",true,[IsPermGroup],0,
 function(grp)
 local dom;
   dom:=MovedPoints(grp);
+  if NrMovedPoints(grp) > 50 then
+    Error("SimsNo is defined only for primitive groups of degree <= 50");
+  fi;
   if not IsTransitive(grp,dom) and IsPrimitive(grp,dom) then
     Error("Group must operate primitively");
   fi;


### PR DESCRIPTION
This is a follow-up of PR #818 which:
- increments the version of the `prim` component from 2.1 to 3.0
- fixes #832 and #833 
- updates documentation to reflect that now it covers degrees < 4096.

When this PR will be merged, it should be possible to work on organising the Primitive Groups Library into a GAP package in https://github.com/gap-packages/primgrp

A related issue #834 could be pursued separately. It might be that its cause hides in `ONanScottType`: for groups of degree up to 2499, O'Nan-Scott types 4a, 4b and 5 cannot occur, and we need to check if this assumption is used in the code. 


