### PR TITLE
Remove special cases in list and record parsing

### DIFF
--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1176,29 +1176,9 @@ void ListExpr2 (
                 SET_FILT_LIST(list, FN_IS_NDENSE);
                 posshole = 2;
               }
-
-            /* special case if subexpression is a list expression              */
-            if ( TNUM_EXPR( ADDR_EXPR(expr)[i-1] ) == T_LIST_EXPR ) {
-              sub = ListExpr1( ADDR_EXPR(expr)[i-1] );
-              SET_ELM_PLIST( list, i, sub );
-              CHANGED_BAG( list );
-              ListExpr2( sub, ADDR_EXPR(expr)[i-1] );
-            }
-            
-            /* special case if subexpression is a record expression            */
-            else if ( TNUM_EXPR( ADDR_EXPR(expr)[i-1] ) == T_REC_EXPR ) {
-              sub = RecExpr1( ADDR_EXPR(expr)[i-1] );
-              SET_ELM_PLIST( list, i, sub );
-              CHANGED_BAG( list );
-              RecExpr2( sub, ADDR_EXPR(expr)[i-1] );
-            }
-            
-            /* general case                                                    */
-            else {
-              sub = EVAL_EXPR( ADDR_EXPR(expr)[i-1] );
-              SET_ELM_PLIST( list, i, sub );
-              CHANGED_BAG( list );
-            }
+            sub = EVAL_EXPR( ADDR_EXPR(expr)[i-1] );
+            SET_ELM_PLIST( list, i, sub );
+            CHANGED_BAG( list );
           }
 
     }
@@ -1539,26 +1519,8 @@ void            RecExpr2 (
         if ( tmp == 0 ) {
             continue;
         }
-
-        /* special case if subexpression is a list expression             */
-        else if ( TNUM_EXPR( tmp ) == T_LIST_EXPR ) {
-            sub = ListExpr1( tmp );
-            AssPRec(rec,rnam,sub);
-            ListExpr2( sub, tmp );
-        }
-
-        /* special case if subexpression is a record expression            */
-        else if ( TNUM_EXPR( tmp ) == T_REC_EXPR ) {
-            sub = RecExpr1( tmp );
-            AssPRec(rec,rnam,sub);
-            RecExpr2( sub, tmp );
-        }
-
-        /* general case                                                    */
-        else {
-            sub = EVAL_EXPR( tmp );
-            AssPRec(rec,rnam,sub);
-        }
+        sub = EVAL_EXPR( tmp );
+        AssPRec(rec,rnam,sub);
     }
     SortPRecRNam(rec,0);
 


### PR DESCRIPTION
This removes some special cases from handling records in lists, and lists in records.

I've carefully inspected this code, and it's only purpose seems to be optimisation. I've then build some big tests with nested lists and records, and convinced myself that it doesn't speed up (in fact, I think it might slightly slow things down).

The reason to get rid of this code now is that it causes the profiler to miss the lines, because it skips the normal execution loop, so this is the easiest way to fix the profiler.

For the curious, I wondered if this was necessary for statements like

```rec( a := [ 3, ~.a ], y := 2 )```

to work. However, while you can make GAP print that, it could never parse it back in (in master, 4.7.9, or with this patch).

```
gap> x := [3,~];
gap> rec( a := x, y := 2);
rec( a := [ 3, ~.a ], y := 2 )
gap> rec( a := [ 3, ~.a ], y := 2 );
Error, Record: '<rec>.a' must have an assigned value
not in any function at *stdin*:9
you can 'return;' after assigning a value
```