### PR TITLE
Temporary provision for the PrimGrp package

### DIFF
--- a/lib/read.g
+++ b/lib/read.g
@@ -60,17 +60,23 @@ fi;
 ##
 #X  Read primitive groups library
 ##
-PRIM_AVAILABLE:=ReadPrim( "primitiv.gd","primitive groups" );
-PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "irredsol.gd","irreducible solvable groups" );
-PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "primitiv.grp",
-                                     "primitive groups" );
-PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "primitiv.gi",
-                                     "primitive groups" );
 
-PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "irredsol.grp","irreducible solvable groups" );
-PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "irredsol.gi","irreducible solvable groups" );
-PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "cohorts.grp","irreducible solvable groups" );
+# only load component if not available as package
+if TestPackageAvailability("primgrp")=fail then
+  PRIM_AVAILABLE:=ReadPrim( "primitiv.gd","primitive groups" );
+  PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "irredsol.gd","irreducible solvable groups" );
+  PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "primitiv.grp",
+                                       "primitive groups" );
+  PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "primitiv.gi",
+                                       "primitive groups" );
 
+  PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "irredsol.grp",
+                                       "irreducible solvable groups" );
+  PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "irredsol.gi",
+                                       "irreducible solvable groups" );
+  PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "cohorts.grp",
+                                       "irreducible solvable groups" );
+fi;
 
 #############################################################################
 ##


### PR DESCRIPTION
I have started to work on the `PrimGrp` package at https://github.com/gap-packages/primgrp. At the moment it has the first loadable version of the package, with files from `prim/grps` in its `data` directory and with `prim/*.g*` files in its `lib` directory. I have added `PackageInfo.g`, `init.g` and `read.g` file to ensure that it is loadable.

This pull request checks the availability of the `PrimGrp` package and loads the primitive groups library contained in the core system only if the package is not available. This is the same approach that @hulpke uses several lines above for the `TransGrp` package. As soon as `PrimGrp` package will be completed and picked up for the redistribution, the `prim` subdirectory of the core GAP system could be safely removed.
