### PR TITLE
Changed  inequality to strict in documentation of Jennings series

### DIFF
--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1653,7 +1653,7 @@ DeclareAttribute( "InvariantForm", IsGroup );
 ##  This series is defined by setting
 ##  <M>G_1 = <A>G</A></M> and for <M>i \geq 0</M>,
 ##  <M>G_{{i+1}} = [G_i,<A>G</A>] G_j^p</M>,
-##  where <M>j</M> is the smallest integer <M>\geq i/p</M>.
+##  where <M>j</M> is the smallest integer <M>> i/p</M>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/tst/testinstall/pgroups.tst
+++ b/tst/testinstall/pgroups.tst
@@ -168,4 +168,7 @@ gap> ForAll(PrimeDivisors(s), p -> HasPrimePGroup(SylowSubgroup(G, p)));
 true
 gap> ForAll(PrimeDivisors(s), p -> p=PrimePGroup(SylowSubgroup(G, p)));
 true
+gap> JenningsSeries(CyclicGroup(4));
+[ <pc group of size 4 with 2 generators>, Group([ f2 ]), 
+  Group([ <identity> of ... ]) ]
 gap> STOP_TEST("pgroups.tst", 10000);


### PR DESCRIPTION
Please make sure that this pull request:

- [ ] is submitted to the correct branch (the stable branch is only for bugfixes)

- [ ] contains an accurate description of changes for the release notes below

- [ ] provides new tests or relies on existing ones

- [ ] correctly refers to other issues and related pull requests

### Description of changes (for the release notes)
Fixed the issue raised by Benjamin Sambale about the documentation of the Jennings Series. The documentation had incorrectly used `\geq` and this has now been changed to a strict inequality, `>`.
