### PR TITLE
Add check for IsObject to IsFilter

### DIFF
--- a/lib/filter.g
+++ b/lib/filter.g
@@ -302,9 +302,12 @@ end );
 ##
 ##  function to test whether <x> is a filter.
 ##  (This is *not* a filter itself!.)
+##  We handle IsObject as a special case, as it is equal to ReturnTrue,
+##  as all objects satisfy IsObject!
 ##
 BIND_GLOBAL( "IsFilter",
-    x -> IS_OPERATION( x ) and ( FLAG1_FILTER( x ) <> 0 or x in FILTERS ) );
+    x -> IS_IDENTICAL_OBJ(x, IS_OBJECT) or
+         ( IS_OPERATION( x ) and ( FLAG1_FILTER( x ) <> 0 or x in FILTERS ) ) ) ;
 
 
 ## Global Rank declarations

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -148,7 +148,7 @@ local oper,l,obj,skip,verbos,fams,flags,i,j,methods,flag,flag2,
   flags:=[];
   fams:=[];
   for i in obj do
-    if IsFilter(i) or IsIdenticalObj( i, IsObject ) then
+    if IsFilter(i) then
       Add(flags,FLAGS_FILTER(i));
       Add(fams,fail);
     elif IsType(i) then

--- a/tst/teststandard/bugfix.tst
+++ b/tst/teststandard/bugfix.tst
@@ -3110,6 +3110,10 @@ gap> SCRSift(sc, (1,2));
 gap> Intersection([]);
 [  ]
 
+# 2016/07/20 (CJ, github issue #861)
+gap> IsFilter(IsObject);
+true
+
 #############################################################################
 gap> STOP_TEST( "bugfix.tst", 831990000);
 


### PR DESCRIPTION
Fixes `IsFilter(IsObject)` returning false (fixes #861 )

### Description of changes (for the release notes)

Ensure that `IsFilter(IsObject)` returns true.