### PR TITLE
Fix DefaultInfoHandler

### DIFF
--- a/lib/info.gi
+++ b/lib/info.gi
@@ -78,7 +78,7 @@ InstallGlobalFunction( "DefaultInfoHandler", function( infoclass, level, list )
   if out = "*Print*" then
     if IsBoundGlobal( "PrintFormattedString" ) then
       fun := function(s)
-        if (IsString(s) and Length(s) > 0) or IsStringRep(s) and
+        if (IsString(s) and Length(s) > 0 or IsStringRep(s)) and
           #XXX this is a temporary hack, we would need a
           # IsInstalledGlobal instead of IsBoundGlobal here
                  NARG_FUNC(ValueGlobal("PrintFormattedString")) <> -1 then


### PR DESCRIPTION
This fixes a problem reported to the GAP Forum on 22 Jul 2016,
namely GAP runs into a breakloop on startup when setting:
  SetUserPreference( "InfoPackageLoadingLevel", 4 );

(The bug was introduced with commit 3c06dbd8.)