### PR TITLE
Only read the component small if smallgrp package is not available

### DIFF
--- a/lib/read.g
+++ b/lib/read.g
@@ -36,7 +36,9 @@ ReadLib("galois.gi");
 #X  Read library of groups of small order
 #X  Read identification routine
 ##
-ReadSmall( "readsml.g","small groups" );
+if TestPackageAvailability("smallgrp")=fail then
+  ReadSmall( "readsml.g","small groups" );
+fi;
 
 #############################################################################
 ##


### PR DESCRIPTION
This is pretty much the same as #859, but for the small groups library.

The git repository for `smallgrp` can be found [here](https://github.com/gap-packages/smallgrp)