### PR TITLE
Fix segfaults in pperm.c

### DIFF
--- a/src/pperm.c
+++ b/src/pperm.c
@@ -267,6 +267,8 @@ Obj FuncSparsePartialPermNC( Obj self, Obj dom, Obj img ){
   UInt2 *ptf2;
   UInt4 *ptf4;
 
+  if(LEN_LIST(dom)==0) return EmptyPartialPerm;
+
   rank=LEN_LIST(dom);
   deg=INT_INTOBJ(ELM_LIST(dom, rank));
   
@@ -551,6 +553,13 @@ Obj FuncCOMPONENT_REPS_PPERM(Obj self, Obj f){
   Obj     dom, img, out;
  
   n=MAX(DEG_PPERM(f), CODEG_PPERM(f));
+
+  if (n == 0) {
+    out = NEW_PLIST(T_PLIST_EMPTY, 0);
+    SET_LEN_PLIST(out, 0);
+    return out;
+  }
+
   ResizeTmpPPerm(n);
   ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
   for(i=0;i<n;i++) ptseen[i]=0; 
@@ -696,8 +705,15 @@ Obj FuncCOMPONENTS_PPERM(Obj self, Obj f){
   UInt4   *ptseen;
   Obj     dom, img, out;
 
-  // init the buffer
   n=MAX(DEG_PPERM(f), CODEG_PPERM(f));
+
+  if (n == 0) {
+    out = NEW_PLIST(T_PLIST_EMPTY, 0);
+    SET_LEN_PLIST(out, 0);
+    return out;
+  }
+
+  // init the buffer
   ResizeTmpPPerm(n);
   ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
   for(i=0;i<n;i++) ptseen[i]=0; 

--- a/tst/testinstall/pperm.tst
+++ b/tst/testinstall/pperm.tst
@@ -93,6 +93,12 @@ true
 gap> f:=PartialPermNC([1..100000]);;
 gap> IsIdempotent(f);
 true
+gap> f := PartialPerm([], []);
+<empty partial perm>
+gap> IndexPeriodOfPartialPerm(f);
+[ 1, 1 ]
+gap> SmallestIdempotentPower(f);
+1
 
 # ComponentsOfPartialPerm, NrComponentsOfPartialPerm, 
 # ComponentRepsOfPartialPerm and ComponentPartialPermInt
@@ -114,6 +120,14 @@ true
 gap> List(ComponentRepsOfPartialPerm(f), i-> ComponentPartialPermInt(f, i))
 > =ComponentsOfPartialPerm(f);
 true
+gap> f := PartialPerm([], []);
+<empty partial perm>
+gap> ComponentsOfPartialPerm(f);
+[  ]
+gap> ComponentRepsOfPartialPerm(f);
+[  ]
+gap> NrComponentsOfPartialPerm(f);
+0
 
 # FixedPointsOfPartialPerm, MovedPoints, 
 # NrFixedPoints, NrMovedPoints


### PR DESCRIPTION
I have identified and resolved issues in the file `pperm.c` related
to the empty partial perm.

The functions `ComponentsOfPartialPerm` and `ComponentRepsOfPartialPerm`
returned malformed empty lists when given the empty partial perm.
The functions directly call `COMPONENTS_PPERM` or `COMPONENT_REPS_PPERM`,
respectively. When given the empty partial perm, these functions
return bad empty lists. A segfault would be called when, for example,
these lists were viewed. These lists are now correctly created as
empty lists when appropriate.

A partial perm can be created from lists by using either a 'dense'
or a 'sparse' method. If the empty partial perm has been created
using the sparse method - i.e. by calling `PartialPerm([], [])` -
then, calling any of `IndexPeriodOfPartialPerm`,
`SmallestIdempotentPower`, or `NrComponentsOfPartialPerm` (which directly
call corresponding C functions) on this partial perm would reliably 
lead to a segfault when `SemigroupsTestInstall` from the Semigroups 
package was run.

I have adjusted the partial perm creation function (when given two
sparse lists) to identify and directly return the `EmptyPartialPerm`
object when necessary, as the other creation already does. This
avoids the issues.