### PR TITLE
Fix `FileString~ for string > 2G (#862 for stable-4.8)

### DIFF
--- a/lib/string.gi
+++ b/lib/string.gi
@@ -781,6 +781,11 @@ InstallGlobalFunction(StringFile, function(name)
     return fail;
   fi;
   str := READ_STRING_FILE(f![1]);
+  if str = fail then
+    CloseStream(f);
+    Error("in StringFile: ", LastSystemError().message, "\n");
+    return fail;
+  fi;
   CloseStream(f);
   return str;
 end);
@@ -806,6 +811,7 @@ InstallGlobalFunction(FileString, function(arg)
   if WRITE_STRING_FILE_NC(out![1], str) = fail then
     CloseStream(out);
     Error("in FileString: ", LastSystemError().message, "\n");
+    return fail;
   fi;
   CloseStream(out);
   return Length(str);

--- a/lib/string.gi
+++ b/lib/string.gi
@@ -803,7 +803,10 @@ InstallGlobalFunction(FileString, function(arg)
     return fail;
   fi;
   IS_STRING_CONV(str);
-  WRITE_STRING_FILE_NC(out![1], str);
+  if WRITE_STRING_FILE_NC(out![1], str) = fail then
+    CloseStream(out);
+    Error("in FileString: ", LastSystemError().message, "\n");
+  fi;
   CloseStream(out);
   return Length(str);
 end);

--- a/src/streams.c
+++ b/src/streams.c
@@ -1972,10 +1972,11 @@ Obj FuncREAD_STRING_FILE (
     Obj             self,
     Obj             fid )
 {
-    Char            buf[20001];
-    Int             ret, len;
+    Char            buf[32769];
+    Int             ret, len, l;
     UInt            lstr;
     Obj             str;
+    char            *ptr;
 
     /* check the argument                                                  */
     while ( ! IS_INTOBJ(fid) ) {
@@ -2001,23 +2002,32 @@ Obj FuncREAD_STRING_FILE (
             }
             len = (Int) fstatbuf.st_size;
             str = NEW_STRING( len );
-            ret = read( syBuf[INT_INTOBJ(fid)].fp, 
-                        CHARS_STRING(str), len);
-            CHARS_STRING(str)[ret] = '\0';
-            SET_LEN_STRING(str, ret);
-            if ( (off_t) ret == fstatbuf.st_size ) {
-                 return str;
+            CHARS_STRING(str)[len] = '\0';
+            SET_LEN_STRING(str, len);
+            ptr = CSTR_STRING(str);
+            while (len > 0) {
+              l = (len > 1048576) ? 1048576 : len;
+              ret = read( syBuf[INT_INTOBJ(fid)].fp, ptr, l);
+              if (ret == -1) {
+                SySetErrorNo();
+                return Fail;
+              }
+              len -= ret;
+              ptr += ret;
             }
+            return str;
         }
     }
 #endif
 #endif
-    /* read <fid> until we see  eof   (in 20kB pieces)                     */
+    /* read <fid> until we see  eof   (in 32kB pieces)                     */
     str = NEW_STRING(0);
     len = 0;
     while (1) {
-        if ( (ret = read( syBuf[INT_INTOBJ(fid)].fp , buf, 20000)) <= 0 )
-            break;
+        if ( (ret = read( syBuf[INT_INTOBJ(fid)].fp , buf, 32768)) <= 0 ) {
+            SySetErrorNo();
+            return Fail;
+        }
         len += ret;
         GROW_STRING( str, len );
 	lstr = GET_LEN_STRING(str);

--- a/src/streams.c
+++ b/src/streams.c
@@ -1947,13 +1947,24 @@ Obj FuncWRITE_STRING_FILE_NC (
     Obj             fid,
     Obj             str )
 {
-    Int             len = 0, ret;
+    Int             len = 0, l, ret;
+    char            *ptr;
 
     /* don't check the argument                                            */
     
     len = GET_LEN_STRING(str);
-    ret = write( syBuf[INT_INTOBJ(fid)].echo, CHARS_STRING(str), len);
-    return (ret == len)?True : Fail;
+    ptr = CSTR_STRING(str);
+    while (len > 0) {
+      l = (len > 1048576) ? 1048576 : len;
+      ret = write( syBuf[INT_INTOBJ(fid)].echo, CHARS_STRING(str), l);
+      if (ret == -1) {
+        SySetErrorNo();
+        return Fail;
+      }
+      len -= ret;
+      ptr += ret;
+    }
+    return True;
 }
 
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -1956,7 +1956,7 @@ Obj FuncWRITE_STRING_FILE_NC (
     ptr = CSTR_STRING(str);
     while (len > 0) {
       l = (len > 1048576) ? 1048576 : len;
-      ret = write( syBuf[INT_INTOBJ(fid)].echo, CHARS_STRING(str), l);
+      ret = write( syBuf[INT_INTOBJ(fid)].echo, ptr, l);
       if (ret == -1) {
         SySetErrorNo();
         return Fail;


### PR DESCRIPTION
This was submitted as #862 on the master branch.

# Description of changes (for the release notes)

So far, FileString only wrote files < 2G and did not indicate
an error in case of larger strings.

With this fix strings of any length can be written and in case of a failure
the corresponding system error is shown.
