### PR TITLE
Fix IsKernelFunction

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -1348,7 +1348,7 @@ void PrintFunction (
         }
 
         /* print the body                                                  */
-        if ( BODY_FUNC(func) == 0 || SIZE_OBJ(BODY_FUNC(func)) == NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) ) {
+        if (FuncIsKernelFunction(0L, func) == True) {
             outputtedfunc = 0;
             if ( BODY_FUNC(func) ) {
                 Obj body = BODY_FUNC(func);
@@ -1915,7 +1915,10 @@ Obj FuncUNPROFILE_FUNC(
 Obj FuncIsKernelFunction(Obj self, Obj func) {
   if (!IS_FUNC(func))
     return Fail;
-  else return (BODY_FUNC(func) == 0 || SIZE_OBJ(BODY_FUNC(func)) == 0) ? True : False;
+  else 
+    return ((BODY_FUNC(func) == 0) ||
+            (SIZE_OBJ(BODY_FUNC(func))
+             == NUMBER_HEADER_ITEMS_BODY*sizeof(Obj))) ? True : False;
 }
 
 Obj FuncHandlerCookieOfFunction(Obj self, Obj func)

--- a/src/calls.h
+++ b/src/calls.h
@@ -386,6 +386,18 @@ extern void PrintFunction (
 
 
 /****************************************************************************
+*
+*F  FuncIsKernelFunction( <self>, <func> ) . . . . . . . .  print a function
+**
+**  'FuncIsKernelFunction' returns Fail if <func> is not a function, True if
+**  <func> is a function, and is installed as a kernel function, and False
+**  otherwise.
+*/
+extern Obj FuncIsKernelFunction(
+                        Obj self,
+                        Obj func);
+
+/****************************************************************************
 **
 *F  FuncCALL_FUNC_LIST( <self>, <func>, <list> )  . . . . . . call a function
 **

--- a/tst/testinstall/function.tst
+++ b/tst/testinstall/function.tst
@@ -1,0 +1,10 @@
+gap> START_TEST("function.tst");
+gap> IsKernelFunction(IsKernelFunction);
+true
+gap> IsKernelFunction(function(x) return 1; end);
+false
+gap> IsKernelFunction(5);
+fail
+gap> IsKernelFunction(rec( a := function() return 0; end ));
+fail
+gap> STOP_TEST("function.tst", 1);


### PR DESCRIPTION
Previously this returned `False` for certain functions installed as kernel functions, and then crashed.