### PR TITLE
Fix ViewString method for inverse monoids without generators as an inverse semigroup/monoid

### DIFF
--- a/lib/semigrp.gi
+++ b/lib/semigrp.gi
@@ -119,14 +119,18 @@ end);
 
 # ViewString
 
-InstallMethod(ViewString, "for a semigroup with generators",
+InstallMethod(ViewString, "for a semigroup with semigroup generators",
 [IsSemigroup and HasGeneratorsOfSemigroup], _ViewStringForSemigroups);
 
-InstallMethod(ViewString, "for a monoid with generators",
+InstallMethod(ViewString, "for a monoid with monoid generators",
 [IsMonoid and HasGeneratorsOfMonoid], _ViewStringForSemigroups);
 
 InstallMethod(ViewString, "for an inverse semigroup with semigroup generators",
 [IsInverseSemigroup and HasGeneratorsOfSemigroup],
+_ViewStringForSemigroups);
+
+InstallMethod(ViewString, "for an inverse monoid with semigroup generators",
+[IsInverseMonoid and HasGeneratorsOfSemigroup],
 _ViewStringForSemigroups);
 
 InstallMethod(ViewString, 
@@ -134,7 +138,8 @@ InstallMethod(ViewString,
 [IsInverseSemigroup and HasGeneratorsOfInverseSemigroup],
 _ViewStringForSemigroups);
 
-InstallMethod(ViewString, "for an inverse monoid with generators",
+InstallMethod(ViewString, 
+"for an inverse monoid with inverse monoid generators",
 [IsInverseMonoid and HasGeneratorsOfInverseMonoid],
 _ViewStringForSemigroups);
 

--- a/tst/testinstall/semigrp.tst
+++ b/tst/testinstall/semigrp.tst
@@ -444,6 +444,18 @@ gap> Size(S);
 gap> S;
 <inverse transformation semigroup of size 36, degree 5 with 3 generators>
 
+# Check correct view method is used for inverse monoids without
+# GeneratorsOfInverseSemigroup
+gap> S := Monoid(Transformation([1, 2, 3, 4, 5, 6, 7, 7, 7]), 
+>                Transformation([4, 6, 3, 6, 6, 6, 7, 7, 7]),
+>                Transformation([4, 5, 6, 1, 6, 6, 7, 7, 7]), 
+>                Transformation([6, 6, 3, 1, 6, 6, 7, 7, 7]), 
+>                Transformation([4, 6, 6, 1, 2, 6, 7, 7, 7]));;
+gap> IsInverseSemigroup(S);
+true
+gap> S;
+<inverse transformation monoid of size 18, degree 9 with 5 generators>
+
 #
 gap> STOP_TEST( "semigrp.tst", 1090000);
 


### PR DESCRIPTION
### Description of changes (for the release notes)

Previously for inverse monoids with `GeneratorsOfSemigroup` but not with `GeneratorsOfInverseSemigroup` the wrong method for `ViewString` was selected, i.e. the method for `ViewString` of an inverse monoid (with no generators) had higher priority than the intended method.

Before this commit:

    gap> S := Monoid(Transformation([1, 2, 3, 4, 5, 6, 7, 7, 7]),
    >                Transformation([4, 6, 3, 6, 6, 6, 7, 7, 7]),
    >                Transformation([4, 5, 6, 1, 6, 6, 7, 7, 7]),
    >                Transformation([6, 6, 3, 1, 6, 6, 7, 7, 7]),
    >                Transformation([4, 6, 6, 1, 2, 6, 7, 7, 7]));;
    gap> IsInverseSemigroup(S);
    true
    gap> S;
    <inverse monoid>

after:

    gap> S := Monoid(Transformation([1, 2, 3, 4, 5, 6, 7, 7, 7]), 
    >                Transformation([4, 6, 3, 6, 6, 6, 7, 7, 7]),
    >                Transformation([4, 5, 6, 1, 6, 6, 7, 7, 7]), 
    >                Transformation([6, 6, 3, 1, 6, 6, 7, 7, 7]), 
    >                Transformation([4, 6, 6, 1, 2, 6, 7, 7, 7]));;
    gap> IsInverseSemigroup(S);
    true
    gap> S;
    <inverse transformation monoid of size 18, degree 9 with 5 generators>


