### PR TITLE
Add string methods for inverse semigroups/monoids

### DIFF
--- a/lib/invsgp.gi
+++ b/lib/invsgp.gi
@@ -373,11 +373,19 @@ InstallMethod( PrintObj,
     end );
 
 InstallMethod( String,
-    "for a inverse semigroup with known generators",
+    "for a inverse semigroup with known generators as an inverse semigroup",
     [ IsInverseSemigroup and HasGeneratorsOfInverseSemigroup ],
     function( S )
     return STRINGIFY( "InverseSemigroup( ", 
      GeneratorsOfInverseSemigroup( S ), " )" );
+    end );
+
+InstallMethod( String,
+    "for a inverse semigroup with known generators as a semigroup",
+    [ IsInverseSemigroup and HasGeneratorsOfSemigroup ],
+    function( S )
+    return STRINGIFY( "Semigroup( ", 
+     GeneratorsOfSemigroup( S ), " )" );
     end );
 
 InstallMethod( PrintString,
@@ -426,12 +434,21 @@ InstallMethod( PrintObj,
     end );
 
 InstallMethod( String,
-    "for a inverse monoid with known generators",
+    "for a inverse monoid with known generators as a monoid",
+    [ IsInverseMonoid and HasGeneratorsOfMonoid ],
+    function( S )
+    return STRINGIFY( "Monoid( ", 
+     GeneratorsOfMonoid( S ), " )" );
+    end );
+
+InstallMethod( String,
+    "for a inverse monoid with known generators as an inverse monoid",
     [ IsInverseMonoid and HasGeneratorsOfInverseMonoid ],
     function( S )
     return STRINGIFY( "InverseMonoid( ", 
      GeneratorsOfInverseMonoid( S ), " )" );
     end );
+
 
 InstallMethod( PrintString,
     "for a inverse monoid with known generators",

--- a/tst/testinstall/invsgp.tst
+++ b/tst/testinstall/invsgp.tst
@@ -1,0 +1,60 @@
+#############################################################################
+##
+#W  invsgp.tst                 GAP library                  James D. Mitchell
+##
+##
+#Y  Copyright (C) 2016
+##
+
+gap> START_TEST("invsgp.tst");
+
+# Test String method for inverse semigroup with generators as a semigroup
+gap> S := Semigroup(Transformation([1, 2, 3, 4, 5, 6, 7, 7, 7]), 
+>                   Transformation([4, 6, 3, 6, 6, 6, 7, 7, 7]),
+>                   Transformation([4, 5, 6, 1, 6, 6, 7, 7, 7]), 
+>                   Transformation([6, 6, 3, 1, 6, 6, 7, 7, 7]), 
+>                   Transformation([4, 6, 6, 1, 2, 6, 7, 7, 7]));;
+gap> IsInverseSemigroup(S);
+true
+gap> String(S);
+"Semigroup( [ Transformation( [ 1, 2, 3, 4, 5, 6, 7, 7, 7 ] ), Transformation(\
+ [ 4, 6, 3, 6, 6, 6, 7, 7, 7 ] ), Transformation( [ 4, 5, 6, 1, 6, 6, 7, 7, 7 \
+] ), Transformation( [ 6, 6, 3, 1, 6, 6, 7, 7, 7 ] ), Transformation( [ 4, 6, \
+6, 1, 2, 6, 7, 7, 7 ] ) ] )"
+gap> S = EvalString(String(S));
+true
+
+# Test String method for inverse monoid with generators as a monoid
+gap> S := Monoid(Transformation([1, 2, 3, 4, 5, 6, 7, 7, 7]), 
+>                Transformation([4, 6, 3, 6, 6, 6, 7, 7, 7]),
+>                Transformation([4, 5, 6, 1, 6, 6, 7, 7, 7]), 
+>                Transformation([6, 6, 3, 1, 6, 6, 7, 7, 7]), 
+>                Transformation([4, 6, 6, 1, 2, 6, 7, 7, 7]));;
+gap> IsInverseMonoid(S);
+true
+gap> String(S);
+"Monoid( [ Transformation( [ 1, 2, 3, 4, 5, 6, 7, 7, 7 ] ), Transformation( [ \
+4, 6, 3, 6, 6, 6, 7, 7, 7 ] ), Transformation( [ 4, 5, 6, 1, 6, 6, 7, 7, 7 ] )\
+, Transformation( [ 6, 6, 3, 1, 6, 6, 7, 7, 7 ] ), Transformation( [ 4, 6, 6, \
+1, 2, 6, 7, 7, 7 ] ) ] )"
+gap> S = EvalString(String(S));
+true
+
+# Test string method for inverse monoid with inverse monoid generators
+gap> S := InverseMonoid(PartialPerm([1, 2, 3]), PartialPerm([1], [2]));;
+gap> String(S);
+"InverseMonoid( [ PartialPermNC( [ 1, 2, 3 ], [ 1, 2, 3 ] ), PartialPermNC( [ \
+1 ], [ 2 ] ) ] )"
+gap> S = EvalString(String(S));
+true
+
+# Test string method for inverse semigroup with inverse semigroup generators
+gap> S := InverseSemigroup(PartialPerm([1, 2, 3]), PartialPerm([1], [2]));;
+gap> String(S);
+"InverseMonoid( [ PartialPermNC( [ 1, 2, 3 ], [ 1, 2, 3 ] ), PartialPermNC( [ \
+1 ], [ 2 ] ) ] )"
+gap> S = EvalString(String(S));
+true
+
+#
+gap> STOP_TEST( "invsgp.tst", 1090000);


### PR DESCRIPTION
There were no specific methods for `String` installed for semigroups that happen to be inverse semigroups but which fail to have generators as an inverse semigroup. For example, previously:

    gap> S := Semigroup(Transformation([1, 2, 3, 4, 5, 6, 7, 7, 7]), 
    >                   Transformation([4, 6, 3, 6, 6, 6, 7, 7, 7]),
    >                   Transformation([4, 5, 6, 1, 6, 6, 7, 7, 7]), 
    >                   Transformation([6, 6, 3, 1, 6, 6, 7, 7, 7]), 
    >                   Transformation([4, 6, 6, 1, 2, 6, 7, 7, 7]));
    gap> IsInverseSemigroup(S);
    true
    gap> String(S);
    "InverseSemigroup( ... )"

After this pull request:

    gap> S := Semigroup(Transformation([1, 2, 3, 4, 5, 6, 7, 7, 7]), 
    >                   Transformation([4, 6, 3, 6, 6, 6, 7, 7, 7]),
    >                   Transformation([4, 5, 6, 1, 6, 6, 7, 7, 7]), 
    >                   Transformation([6, 6, 3, 1, 6, 6, 7, 7, 7]), 
    >                   Transformation([4, 6, 6, 1, 2, 6, 7, 7, 7]));;
    gap> IsInverseSemigroup(S);
    true
    gap> String(S);
    "Semigroup( [ Transformation( [ 1, 2, 3, 4, 5, 6, 7, 7, 7 ] ), Transformation(\
     [ 4, 6, 3, 6, 6, 6, 7, 7, 7 ] ), Transformation( [ 4, 5, 6, 1, 6, 6, 7, 7, 7 \
    ] ), Transformation( [ 6, 6, 3, 1, 6, 6, 7, 7, 7 ] ), Transformation( [ 4, 6, \
    6, 1, 2, 6, 7, 7, 7 ] ) ] )"

