### PR TITLE
Split FuncREAD_STRING_FILE into system dependent bits

### DIFF
--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -630,6 +630,15 @@ extern void syWinPut (
     const Char *        cmd,
     const Char *        str );
 
+/***************************************************************************
+ **
+ *F SyReadFileString( <fid> )
+ **   - read file given by <fid> file into a string
+ */
+
+extern Obj SyReadStringFile (
+    Int fid );
+
 
      
 /****************************************************************************

--- a/tst/testinstall/read.tst
+++ b/tst/testinstall/read.tst
@@ -71,4 +71,13 @@ gap> SeekPositionStream(x, 3);
 true
 gap> ReadAll(x);
 "lo\ngoodbye\ni like pies\n"
+gap> StringFile(Filename( DirectoriesLibrary("tst"), "example.txt" ));
+"hello\ngoodbye\ni like pies\n"
+gap> dir := DirectoryTemporary();;
+gap> FileString( Filename(dir, "tmp1"), "Hello, world!");
+13
+gap> StringFile( Filename(dir, "tmp2"));
+fail
+gap> StringFile( Filename(dir, "tmp1"));
+"Hello, world!"
 gap> STOP_TEST( "read.tst", 220000);


### PR DESCRIPTION
The #ifdefs within the function made the function less readable,
so FuncREAD_STRING_FILE now calls SyReadStringFile which is implemented
as two separate functions in sysfiles.c