### PR TITLE
Put CI script into shell script 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,4 @@ script:
   - ./configure --with-gmp=system
   - make
   - make bootstrap-pkg-full
-  - if [[ x"$ABI" != "x32" ]] ; then cd pkg/io* ; ./configure ; make ; cd ../.. ; cd pkg/profiling* ; ./configure ; make ; cd ../.. ; fi
-  - if [[ $TEST_SUITE = 'makemanuals' && $TRAVIS_OS_NAME = 'linux' ]]; then make manuals ; cat doc/*/make_manuals.out ; if [ `cat doc/*/make_manuals.out | grep -c "manual.lab written"` != '3' ]; then echo "Build failed"; exit 1; fi; fi
-  - if [[ $TEST_SUITE != 'makemanuals' && x"$ABI" != "x32" ]]; then echo "Read(\"tst/${TEST_SUITE}.g\"); quit;" | sh bin/gap.sh --cover coverage | tee testlog.txt | grep --colour=always -E "########> Diff|$" ; echo "CoverToJson(\"coverage\", \"coverage.json\"); quit;" | sh bin/gap.sh etc/cover2json.g ; cd bin/x86* ; gcov -o . ../../src/* ; cd ../.. ; cat testlog.txt | tail -n 2 | grep "total"; ( ! grep "########> Diff" testlog.txt ) ; fi
-  - if [[ $TEST_SUITE != 'makemanuals' && x"$ABI" = "x32" ]]; then echo "Read(\"tst/${TEST_SUITE}.g\"); quit;" | sh bin/gap.sh | tee testlog.txt | grep --colour=always -E "########> Diff|$" ; cat testlog.txt | tail -n 2 | grep "total"; ( ! grep "########> Diff" testlog.txt ) ; fi
-  
-
+  - bash etc/ci.sh

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Continous integration testing script
 
@@ -22,13 +22,13 @@ else
         cd pkg/io*
         ./configure
         make
-        cd ../.
+        cd ../..
         cd pkg/profiling*
         ./configure
         make
         cd ../..
         echo "Read(\"tst/${TEST_SUITE}.g\"); quit;" |\
-            sh bin/gap.sh --cover cover |\
+            sh bin/gap.sh --cover coverage |\
             tee testlog.txt |\
             grep --colour=always -E "########> Diff|$"
         echo "CoverToJson(\"coverage\", \"coverage.json\"); quit;" |\

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Continous integration testing script
+
+if [[ $TEST_SUITE = 'makemanuals' && $TRAVIS_OS_NAME = 'linux' ]]
+then
+    make manuals
+    cat doc/*/make_manuals.out
+    if [ `cat doc/*/make_manuals.out | grep -c "manual.lab written"` != '3' ]
+    then
+        echo "Build failed"
+        exit 1
+    fi
+else
+    if [[ x"$ABI" == "x32" ]]
+    then
+        echo "Read(\"tst/${TEST_SUITE}.g\"); quit;" |\
+           sh bin/gap.sh |\
+           tee testlog.txt |\
+           grep --colour=always -E "########> Diff|$"
+    else
+        cd pkg/io*
+        ./configure
+        make
+        cd ../.
+        cd pkg/profiling*
+        ./configure
+        make
+        cd ../..
+        echo "Read(\"tst/${TEST_SUITE}.g\"); quit;" |\
+            sh bin/gap.sh --cover cover |\
+            tee testlog.txt |\
+            grep --colour=always -E "########> Diff|$"
+        echo "CoverToJson(\"coverage\", \"coverage.json\"); quit;" |\
+            sh bin/gap.sh etc/cover2json.g
+        cd bin/x86* ; gcov -o . ../../src/*
+        cd ../..
+    fi;
+    cat testlog.txt | tail -n 2 |\
+        grep "total"; ( ! grep "########> Diff" testlog.txt )
+fi;


### PR DESCRIPTION
This PR puts the code run for CI into a script rather than the travis config file. 

* scripting in the travis YAML file is ugly, error prone, and a pain to debug,
* we can now use this script for AppVeyor as well
* with sufficient tweaking this can be run locally to test whether it works before pushing to travis and having to wait for results to come back.