### PR TITLE
Powerful p-Groups Feature

### DIFF
--- a/doc/ref/groups.xml
+++ b/doc/ref/groups.xml
@@ -349,11 +349,13 @@ as they depend on a parameter.
 <#Include Label="IsFinitelyGeneratedGroup">
 <#Include Label="IsSubsetLocallyFiniteGroup">
 <#Include Label="IsPGroup">
+<#Include Label="IsPowerfulPGroup">
 <#Include Label="PrimePGroup">
 <#Include Label="PClassPGroup">
 <#Include Label="RankPGroup">
 <#Include Label="IsPSolvable">
 <#Include Label="IsPNilpotent">
+
 
 </Section>
 

--- a/doc/ref/groups.xml
+++ b/doc/ref/groups.xml
@@ -356,7 +356,6 @@ as they depend on a parameter.
 <#Include Label="IsPSolvable">
 <#Include Label="IsPNilpotent">
 
-
 </Section>
 
 

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -434,6 +434,32 @@ InstallFactorMaintenance( IsPGroup,
 
 InstallTrueMethod( IsPGroup, IsGroup and IsTrivial );
 InstallTrueMethod( IsPGroup, IsGroup and IsElementaryAbelian );
+#############################################################################
+##
+#P  IsPowerfulPGroup( <G> ) . . . . . . . . . . is a group a powerful p-group ?
+##
+##  <#GAPDoc Label="IsPowerfulPGroup">
+##  <ManSection>
+##  <Prop Name="IsPowerfulPGroup" Arg='G'/>
+##
+##  <Description>
+##  <Index Key="powerful p-group"><M>powerful p</M>-group</Index>
+##  A <E> powerful <M>p</M>-group</E> is a finite group whose order
+##  (see&nbsp;<Ref Func="Size"/>) is of ...blahblahblah the form <M>p^n</M> for a prime
+##  integer <M>p</M> and a nonnegative integer <M>n</M>.
+##  <Ref Prop="IsPGroup"/> returns <K>true</K> if <A>G</A> is a
+##  <M>p</M>-group, and <K>false</K> otherwise.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareProperty( "IsPowerfulPGroup", IsGroup );
+
+#Quotients of powerful of powerful p groups are powerful
+InstallFactorMaintenance( IsPowerfulPGroup,
+    IsPowerfulPGroup, IsGroup, IsGroup );
+#abelian p-groups are powerful
+InstallTrueMethod( IsPowerfulPGroup, IsPGroup and IsAbelian );
 
 
 #############################################################################

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -436,19 +436,24 @@ InstallTrueMethod( IsPGroup, IsGroup and IsTrivial );
 InstallTrueMethod( IsPGroup, IsGroup and IsElementaryAbelian );
 #############################################################################
 ##
-#P  IsPowerfulPGroup( <G> ) . . . . . . . . . . is a group a powerful p-group ?
+#P  IsPowerfulPGroup( <G> ) . . . . . . . . . is a group a powerful p-group ?
 ##
 ##  <#GAPDoc Label="IsPowerfulPGroup">
 ##  <ManSection>
 ##  <Prop Name="IsPowerfulPGroup" Arg='G'/>
 ##
 ##  <Description>
-##  <Index Key="powerful p-group"><M>powerful p</M>-group</Index>
-##  A <E> powerful <M>p</M>-group</E> is a finite group whose order
-##  (see&nbsp;<Ref Func="Size"/>) is of ...blahblahblah the form <M>p^n</M> for a prime
-##  integer <M>p</M> and a nonnegative integer <M>n</M>.
-##  <Ref Prop="IsPGroup"/> returns <K>true</K> if <A>G</A> is a
-##  <M>p</M>-group, and <K>false</K> otherwise.
+##  <Index Key="PowerfulPGroup">Powerful <M> p</M>-group</Index>
+##  A finite p-group <A>G</A> is said to be a Powerful <M>p</M>-group if the 
+##  commutator subgroup <M>[<A>G</A>,<A>G</A>]</M> is contained in
+##  <M><A>G</A>^{p}</M> if the prime <M>p</M> is odd, or if
+##  <M>[<A>G</A>,<A>G</A>]</M> is contained in <M><A>G</A>^{4}</M> 
+##  if<M> p = 2</M>. The subgroup <M><A>G</A>^{p}</M> is called the first 
+##  Agemo subgroup, (see&nbsp;<Ref Func="Agemo"/>).
+##  <Ref Prop="IsPowerfulPGroup"/> returns <K>true</K> if <A>G</A> is a 
+##  powerful <M>p</M>-group, and <K>false</K> otherwise. 
+##  <E>Note: </E>This function returns <K>true</K> if <A>G</A> is the trivial 
+##  group.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -460,8 +465,6 @@ InstallFactorMaintenance( IsPowerfulPGroup,
     IsPowerfulPGroup, IsGroup, IsGroup );
 #abelian p-groups are powerful
 InstallTrueMethod( IsPowerfulPGroup, IsPGroup and IsAbelian );
-
-
 #############################################################################
 ##
 #A  PrimePGroup( <G> )

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -240,6 +240,29 @@ InstallMethod( IsPGroup,
 ##
 #M  IsPowerfulPGroup( <G> ) . . . . . . . . . . is a group a powerful p-group ?
 ##
+InstallMethod( IsPowerfulPGroup,
+    "use characterisation of ",
+    [ IsGroup and HasRankPGroup and HasComputedOmegas ],
+     function( G )
+    local p;
+    if (IsTrivial(G)) then
+	return true;
+    else
+	p:=PrimePGroup(G);
+	if (p>3) then
+		if (RankPGroup(G)=Log(Order(Omega(G,p)),p)) then
+			return true;
+		else
+			return false;
+		fi;
+	else
+	TryNextMethod();
+	fi;
+    fi;
+
+
+      
+    end);
      
   
 InstallMethod( IsPowerfulPGroup,
@@ -248,11 +271,15 @@ InstallMethod( IsPowerfulPGroup,
      function( G )
     local p;
     if IsPGroup( G ) = false then
-      return false;
+      ErrorNoReturn( "<G> must be a p-group" );
+    elif IsTrivial(G) then
+      return true;
+	
     else
-      p:=Factors(Size( G ))[1];
+    
+      p:=PrimePGroup(G);
       if p = 2 then 
-        return IsSubgroup(Agemo(G,4),DerivedSubgroup( G ));
+        return IsSubgroup(Agemo(G,2,2),DerivedSubgroup( G ));
       else 
         return IsSubgroup(Agemo(G,p), DerivedSubgroup( G ));
       fi; 
@@ -1063,6 +1090,17 @@ function(G)
         fi;
     od;
     return SubgroupNC(G, gen);
+end);
+
+InstallMethod( FrattiniSubgroup, "for powerful p-groups",
+            [ IsPGroup and IsPowerfulPGroup and HasComputedAgemos ],100,
+function(G)
+    local p;
+#If the group is powerful and has computed agemos, then no work needs
+#to be done, since FrattiniSubgroup(G)=Agemo(G,p) in this case
+#by properties of powerful p-groups.
+	p:=PrimePGroup(G);
+	return Agemo(G,p);
 end);
 
 InstallMethod( FrattiniSubgroup, "for nilpotent groups",

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -274,7 +274,7 @@ InstallMethod( IsPowerfulPGroup,
      function( G )
     local p;
     if IsPGroup( G ) = false then
-      ErrorNoReturn( "<G> must be a p-group" );
+      return false;
     elif IsTrivial(G) then
       return true;
 	

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -236,6 +236,28 @@ InstallMethod( IsPGroup,
       return IS_PGROUP_FOR_NILPOTENT( G );
     fi;
     end );
+#############################################################################
+##
+#M  IsPowerfulPGroup( <G> ) . . . . . . . . . . is a group a powerful p-group ?
+##
+     
+  
+InstallMethod( IsPowerfulPGroup,
+    "generic method checks inclusion of commutator subgroup in agemo subgroup",
+    [ IsGroup ],
+     function( G )
+    local p;
+    if IsPGroup( G ) = false then
+      return false;
+    else
+      p:=Factors(Size( G ))[1];
+      if p = 2 then 
+        return IsSubgroup(Agemo(G,4),DerivedSubgroup( G ));
+      else 
+        return IsSubgroup(Agemo(G,p), DerivedSubgroup( G ));
+      fi; 
+    fi;
+    end);                                              
 
 
 #############################################################################

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -241,7 +241,7 @@ InstallMethod( IsPGroup,
 #M  IsPowerfulPGroup( <G> ) . . . . . . . . . . is a group a powerful p-group ?
 ##
 InstallMethod( IsPowerfulPGroup,
-    "use characterisation of ",
+    "use characterisation of powerful p-groups based on rank ",
     [ IsGroup and HasRankPGroup and HasComputedOmegas ],
      function( G )
     local p;
@@ -249,6 +249,9 @@ InstallMethod( IsPowerfulPGroup,
 	return true;
     else
 	p:=PrimePGroup(G);
+	#We use the less known characterisation of powerful p groups
+	# for p>3 by Jon Gonzalez-Sanchez, Amaia Zugadi-Reizabal
+	# can be found in 'A characterization of powerful p-groups'
 	if (p>3) then
 		if (RankPGroup(G)=Log(Order(Omega(G,p)),p)) then
 			return true;

--- a/tst/testinstall/pgroups.tst
+++ b/tst/testinstall/pgroups.tst
@@ -168,4 +168,36 @@ gap> ForAll(PrimeDivisors(s), p -> HasPrimePGroup(SylowSubgroup(G, p)));
 true
 gap> ForAll(PrimeDivisors(s), p -> p=PrimePGroup(SylowSubgroup(G, p)));
 true
+gap> G:=CyclicGroup(9);;
+gap> HasIsPowerfulPGroup(G);
+true
+gap> IsPowerfulPGroup(G);
+true
+gap> G:=CyclicGroup(10);;
+gap> IsPowerfulPGroup(G);
+Error, <G> must be a p-group
+gap> G:=SmallGroup(243,11);;
+gap> HasIsPowerfulPGroup(G);
+false
+gap> IsPowerfulPGroup(G);
+true
+gap> N:=NormalSubgroups(G)[3];;
+gap> H:=FactorGroup(G,N);;
+gap> HasIsPowerfulPGroup(H);
+true
+gap> IsPowerfulPGroup(H);
+true
+gap> myList:=AllSmallGroups(5^4);;
+gap> Length(Filtered(myList,g->IsPowerfulPGroup(g)));
+9
+gap> newList:=AllSmallGroups(5^4);;
+gap> for g in newList do
+> RankPGroup(g);
+> Agemo(g,5);
+> od;
+gap> Length(Filtered(newList,g->IsPowerfulPGroup(g)));
+9
+gap> myList:=AllSmallGroups(2^4);;
+gap> Length(Filtered(myList,g->IsPowerfulPGroup(g)));
+6
 gap> STOP_TEST("pgroups.tst", 10000);

--- a/tst/testinstall/pgroups.tst
+++ b/tst/testinstall/pgroups.tst
@@ -175,7 +175,7 @@ gap> IsPowerfulPGroup(G);
 true
 gap> G:=CyclicGroup(10);;
 gap> IsPowerfulPGroup(G);
-Error, <G> must be a p-group
+false
 gap> G:=SmallGroup(243,11);;
 gap> HasIsPowerfulPGroup(G);
 false


### PR DESCRIPTION
Please make sure that this pull request:

- [x] is submitted to the correct branch (the stable branch is only for bugfixes)

- [x] contains an accurate description of changes for the release notes below

- [x] provides new tests or relies on existing ones

- [ ] correctly refers to other issues and related pull requests

### Description of changes (for the release notes)
This feature adds the property`IsPowerfulPGroup` for groups, and the method `IsPowerfulPGroup(G)` . 
A finite p-group G is said to be a Powerful p-group if the commutator subgroup [G,G] is contained in
G^{p} if the prime p is odd, or if [G,G] is contained in G^{4} if p=2.
In the case a p- group is powerful, then FrattiniSubgroup(G)=G^{p} . Therefore, if GAP knows a group is powerful and has the computed Agemos (which is most likely the case if it has tested if G is powerful), then using this feature it can quickly return the FrattiniSubgroup without doing any extra work.


This is my first time uploading a GAP feature, I hope everything seems okay.

(Note: For more details on Powerful p-Groups, see:
Powerful p-groups. I. Finite groups, Alexander Lubotzky, Avinoam Mann )
