### PR TITLE
Some improvements for LatticeByCyclicExtension

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -62,6 +62,27 @@ InstallMethod( IsCyclic,
     fi;
     end );
 
+InstallMethod( Size,
+    "for a cyclic group",
+    [ IsGroup and IsCyclic and HasGeneratorsOfGroup ],
+    -RankFilter(HasGeneratorsOfGroup),
+function(G)
+  local gens;
+  if HasMinimalGeneratingSet(G) then
+    gens:=MinimalGeneratingSet(G);
+  else
+    gens:=GeneratorsOfGroup(G);
+  fi;
+  if Length(gens) = 1 and gens[1] <> One(G) then
+    SetMinimalGeneratingSet(G,gens);
+    return Order(gens[1]);
+  elif Length(gens) <= 1 then
+    SetMinimalGeneratingSet(G,[]);
+    return 1;
+  fi;
+  TryNextMethod();
+end);
+
 InstallMethod( MinimalGeneratingSet,"cyclic groups",true,
     [ IsGroup and IsCyclic and IsFinite ],
     RankFilter(IsFinite and IsPcGroup),

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -88,7 +88,7 @@ InstallMethod( MinimalGeneratingSet,"cyclic groups",true,
     RankFilter(IsFinite and IsPcGroup),
 function ( G )
 local g;
-  if Size(G)=1 then return [];fi;
+  if IsTrivial(G) then return []; fi;
   g:=Product(IndependentGeneratorsOfAbelianGroup(G),One(G));
   Assert( 1, Index(G,Subgroup(G,[g])) = 1 );
   return [g];
@@ -408,9 +408,9 @@ InstallMethod( IsNilpotentGroup,
 #M  IsPerfectGroup( <G> ) . . . . . . . . . . . .  test if a group is perfect
 ##
 InstallImmediateMethod( IsPerfectGroup,
-    IsGroup and IsSolvableGroup and HasSize,
+    IsSolvableGroup and HasIsTrivial,
     0,
-    grp -> Size( grp ) = 1 );
+    IsTrivial );
 
 InstallMethod( IsPerfectGroup,
     "method for finite groups",

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -51,16 +51,22 @@ function (G,func)
 local   zuppos,            # set of zuppos,result
 	c,                 # a representative of a class of elements
 	o,                 # its order
+	h,                 # the subgroup < c > of G
 	N,                 # normalizer of < c >
 	t;                 # loop variable
+
+  if HasZuppos(G) then
+    return Filtered(Zuppos(G), c -> func(Subgroup(G,[c])));
+  fi;
 
   # compute the zuppos
   zuppos:=[One(G)];
   for c in List(ConjugacyClasses(G),Representative)  do
     o:=Order(c);
-    if func(Group(c)) and IsPrimePowerInt(o)  then
+    h:=Subgroup(G,[c]);
+    if IsPrimePowerInt(o) and func(h)  then
       if ForAll([2..o],i -> Gcd(o,i) <> 1 or not c^i in zuppos) then
-	N:=Normalizer(G,Subgroup(G,[c]));
+	N:=Normalizer(G,h);
 	for t in RightTransversal(G,N)  do
 	  Add(zuppos,c^t);
 	od;

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -290,7 +290,7 @@ local   G,		   # group
     G:=arg[1];
     noperf:=false;
     zuppofunc:=false;
-    if Length(arg)>1 and IsFunction(arg[2]) then
+    if Length(arg)>1 and (IsFunction(arg[2]) or IsList(arg[2])) then
       func:=arg[2];
       Info(InfoLattice,1,"lattice discarding function active!");
       if IsList(func) then

--- a/tst/testinstall/opers/LatticeByCyclicExtension.tst
+++ b/tst/testinstall/opers/LatticeByCyclicExtension.tst
@@ -1,0 +1,20 @@
+gap> START_TEST("LatticeByCyclicExtension.tst");
+
+#
+gap> G:=SmallGroup(625,1);
+<pc group of size 625 with 4 generators>
+gap> A:=AutomorphismGroup(G);
+<group of size 500 with 7 generators>
+gap> fun:=g->IsInt(4/Size(g));;
+gap> LatticeByCyclicExtension(A);
+<subgroup lattice of <group of size 500 with 7 generators>, 12 classes, 
+12 subgroups>
+gap> LatticeByCyclicExtension(A, fun);
+<subgroup lattice of <group of size 500 with 7 generators>, 3 classes, 
+3 subgroups, restricted under further condition l!.func>
+gap> LatticeByCyclicExtension(A, [fun,fun]);
+<subgroup lattice of <group of size 500 with 7 generators>, 3 classes, 
+3 subgroups, restricted under further condition l!.func>
+
+#
+gap> STOP_TEST("LatticeByCyclicExtension.tst", 1);


### PR DESCRIPTION
According to the documentation of LatticeByCyclicExtension, the optional
second argument can be either a function, or a list of two functions.
The latter did not actually work, which is now fixed

I guess @hulpke is the person best qualified to evaluate this change.