### PR TITLE
Add tests for Backtraces

### DIFF
--- a/tst/test-error/bad-add.g
+++ b/tst/test-error/bad-add.g
@@ -1,0 +1,4 @@
+f := function()
+    return 1 + "abc";
+end;
+f();

--- a/tst/test-error/bad-add.g.out
+++ b/tst/test-error/bad-add.g.out
@@ -1,0 +1,8 @@
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `+' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+1 + "abc" at bad-add.g:2 called from
+<function "f">( <arguments> )
+ called from read-eval loop at bad-add.g:4
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 

--- a/tst/test-error/bad-array-double-1.g
+++ b/tst/test-error/bad-array-double-1.g
@@ -1,0 +1,4 @@
+f := function()
+    return "abc"[1,1];
+end;
+f();

--- a/tst/test-error/bad-array-double-1.g.out
+++ b/tst/test-error/bad-array-double-1.g.out
@@ -1,0 +1,8 @@
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `[]' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+<compiled or corrupted statement>  called from
+<function "f">( <arguments> )
+ called from read-eval loop at bad-array-double-1.g:4
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 

--- a/tst/test-error/bad-array-int-0.g
+++ b/tst/test-error/bad-array-int-0.g
@@ -1,0 +1,6 @@
+f := function()
+    local l;
+    l := [];
+    return l[0];
+end;
+f();

--- a/tst/test-error/bad-array-int-0.g.out
+++ b/tst/test-error/bad-array-int-0.g.out
@@ -1,0 +1,8 @@
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `[]' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l[0] at bad-array-int-0.g:4 called from
+<function "f">( <arguments> )
+ called from read-eval loop at bad-array-int-0.g:6
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 

--- a/tst/test-error/bad-array-int-1.g
+++ b/tst/test-error/bad-array-int-1.g
@@ -1,0 +1,4 @@
+f := function()
+    return 1[1];
+end;
+f();

--- a/tst/test-error/bad-array-int-1.g.out
+++ b/tst/test-error/bad-array-int-1.g.out
@@ -1,0 +1,6 @@
+Error, List Element: <list> must be a list (not a integer) in
+  return 1[1]; at bad-array-int-1.g:2 called from 
+<function "f">( <arguments> )
+ called from read-eval loop at bad-array-int-1.g:4
+you can replace <list> via 'return <list>;'
+brk> 

--- a/tst/test-error/bad-array-int-2.g.out
+++ b/tst/test-error/bad-array-int-2.g.out
@@ -1,0 +1,8 @@
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `[]' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+1["abc"] at bad-array-int-2.g:2 called from
+<function "f">( <arguments> )
+ called from read-eval loop at bad-array-int-2.g:4
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 

--- a/tst/test-error/bad-array-string.g
+++ b/tst/test-error/bad-array-string.g
@@ -1,0 +1,4 @@
+f := function()
+    return 1["abc"];
+end;
+f();

--- a/tst/test-error/bad-array-string.g.out
+++ b/tst/test-error/bad-array-string.g.out
@@ -1,0 +1,8 @@
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `[]' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+1["abc"] at bad-array-string.g:2 called from
+<function "f">( <arguments> )
+ called from read-eval loop at bad-array-string.g:4
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 

--- a/tst/test-error/bad-array-undef-0.g
+++ b/tst/test-error/bad-array-undef-0.g
@@ -1,0 +1,5 @@
+f := function()
+    local l;
+    return l[1];
+end;
+f();

--- a/tst/test-error/bad-array-undef-0.g.out
+++ b/tst/test-error/bad-array-undef-0.g.out
@@ -1,0 +1,6 @@
+Error, Variable: 'l' must have an assigned value in
+  return l[1]; at bad-array-undef-0.g:3 called from 
+<function "f">( <arguments> )
+ called from read-eval loop at bad-array-undef-0.g:5
+you can 'return;' after assigning a value
+brk> 

--- a/tst/test-error/bad-array-undef-1.g
+++ b/tst/test-error/bad-array-undef-1.g
@@ -1,0 +1,6 @@
+f := function()
+    local l,m;
+    l := [];
+    return l[m];
+end;
+f();

--- a/tst/test-error/bad-array-undef-1.g.out
+++ b/tst/test-error/bad-array-undef-1.g.out
@@ -1,0 +1,6 @@
+Error, Variable: 'm' must have an assigned value in
+  return l[m]; at bad-array-undef-1.g:4 called from 
+<function "f">( <arguments> )
+ called from read-eval loop at bad-array-undef-1.g:6
+you can 'return;' after assigning a value
+brk> 

--- a/tst/test-error/bad-minus.g
+++ b/tst/test-error/bad-minus.g
@@ -1,0 +1,4 @@
+f := function()
+    return 1 - "abc";
+end;
+f();

--- a/tst/test-error/bad-minus.g.out
+++ b/tst/test-error/bad-minus.g.out
@@ -1,0 +1,11 @@
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `AdditiveInverseMutable' on 1 arguments at GAPROOT/lib/methsel2.g:241 called from
+AINV_MUT( elm ) at GAPROOT/lib/arith.gi:200 called from
+AdditiveInverseAttr( elm 
+ ) at GAPROOT/lib/arith.gi:213 called from
+1 - "abc" at bad-minus.g:2 called from
+<function "f">( <arguments> )
+ called from read-eval loop at bad-minus.g:4
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 

--- a/tst/test-error/regenerate_error_tests.sh
+++ b/tst/test-error/regenerate_error_tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+for gfile in *.g; do
+    ./run_gap.sh ../../bin/gap.sh "${gfile}" > "${gfile}.out"
+done
+

--- a/tst/test-error/run_error_tests.sh
+++ b/tst/test-error/run_error_tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+retvalue=0
+for gfile in *.g; do
+    if ! diff "${gfile}.out" <(./run_gap.sh ../../bin/gap.sh "${gfile}"); then
+        echo "${gfile}" failed
+        retvalue=1
+    fi;
+done;
+exit ${retvalue}
+

--- a/tst/test-error/run_gap.sh
+++ b/tst/test-error/run_gap.sh
@@ -1,0 +1,11 @@
+#/usr/bin/env bash
+
+# This script should be run as ./run_gap.sh gap gapfile.g
+# It provides the following features:
+# 1) Stop GAP from attaching to the terminal (which it will
+#    use in the break loop)
+# 2) Combine stderr and stdout
+# 3) Rewrite the root of gap with the string GAPROOT,
+#    so the output is usable on other machines
+GAPROOT=$(cd ../..; pwd)
+echo 'Read("'$2'");\n' | $1 -q -b 2>&1 | sed "s:${GAPROOT//:/\\:}:GAPROOT:g"


### PR DESCRIPTION
Please make sure that this pull request:

- [X] is submitted to the correct branch (the stable branch is only for bugfixes)
- [X] contains an accurate description of changes for the release notes below
- [X] provides new tests or relies on existing ones
- [X] correctly refers to other issues and related pull requests

### Tick all what applies to this pull request

- [X] Adds new features

### Write below the description of changes (for the release notes)

This adds a new type of test, which allows testing the exact output of GAP. This is useful for testing GAP's break loop and backtraces in particular.

Run `run_error_tests.sh` to run all tests. They are not (yet) linked into being run all the time.

This is a necessary part of my planned improvements to GAP's reporting on what line caused problems when entering the break loop.