### PR TITLE
Add reference for usage of filters in Basic Groups doc

### DIFF
--- a/grp/basic.gd
+++ b/grp/basic.gd
@@ -60,6 +60,8 @@ DeclareConstructor( "TrivialGroupCons", [ IsGroup ] );
 ##  constructs a trivial group in the category given by the filter
 ##  <A>filter</A>.
 ##  If <A>filter</A> is not given it defaults to <Ref Func="IsPcGroup"/>.
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> TrivialGroup();
@@ -114,6 +116,8 @@ DeclareConstructor( "AbelianGroupCons", [ IsGroup, IsList ] );
 ##  If <A>filt</A> is not given it defaults to <Ref Func="IsPcGroup"/>.
 ##  The generators of the group returned are the elements corresponding to
 ##  the integers in <A>ints</A>.
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> AbelianGroup([1,2,3]);
@@ -173,6 +177,8 @@ DeclareConstructor( "AlternatingGroupCons", [ IsGroup, IsInt ] );
 ##  constructs the alternating group of degree <A>deg</A> in the category given
 ##  by the filter <A>filt</A>.
 ##  If <A>filt</A> is not given it defaults to <Ref Prop="IsPermGroup"/>.
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  In the second version, the function constructs the alternating group on
 ##  the points given in the set <A>dom</A> which must be a set of positive
 ##  integers.
@@ -225,6 +231,8 @@ DeclareConstructor( "CyclicGroupCons", [ IsGroup, IsInt ] );
 ##  constructs the cyclic group of size <A>n</A> in the category given by the
 ##  filter <A>filt</A>.
 ##  If <A>filt</A> is not given it defaults to <Ref Func="IsPcGroup"/>.
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> CyclicGroup(12);
@@ -291,10 +299,14 @@ DeclareConstructor( "DihedralGroupCons", [ IsGroup, IsInt ] );
 ##  constructs the dihedral group of size <A>n</A> in the category given by the
 ##  filter <A>filt</A>.
 ##  If <A>filt</A> is not given it defaults to <Ref Func="IsPcGroup"/>.
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  <P/>
 ##  <Example><![CDATA[
-##  gap> DihedralGroup(10);
-##  <pc group of size 10 with 2 generators>
+##  gap> DihedralGroup(8);
+##  <pc group of size 8 with 3 generators>
+##  gap> DihedralGroup( IsPermGroup, 8 );
+##  Group([ (1,2,3,4), (2,4) ])
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
@@ -345,6 +357,8 @@ DeclareConstructor( "QuaternionGroupCons", [ IsGroup, IsInt ] );
 ##  <A>n</A> in the category given by the filter <A>filt</A>.  Here, <A>n</A>
 ##  is a multiple of 4.
 ##  If <A>filt</A> is not given it defaults to <Ref Func="IsPcGroup"/>.
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  Methods are also available for permutation and matrix groups (of minimal
 ##  degree and minimal dimension in coprime characteristic).
 ##  <P/>
@@ -404,6 +418,8 @@ DeclareConstructor( "ElementaryAbelianGroupCons", [ IsGroup, IsInt ] );
 ##  constructs the elementary abelian group of size <A>n</A> in the category
 ##  given by the filter <A>filt</A>.
 ##  If <A>filt</A> is not given it defaults to <Ref Func="IsPcGroup"/>.
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> ElementaryAbelianGroup(8192);
@@ -457,6 +473,8 @@ DeclareConstructor( "FreeAbelianGroupCons", [ IsGroup, IsInt ] );
 ##  constructs the free abelian group of rank <A>n</A> in the category
 ##  given by the filter <A>filt</A>.
 ##  If <A>filt</A> is not given it defaults to <Ref Func="IsFpGroup"/>.
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> FreeAbelianGroup(4);
@@ -519,6 +537,8 @@ DeclareConstructor( "ExtraspecialGroupCons", [ IsGroup, IsInt, IsObject ] );
 ##  For <M>p = 2</M>, only the above plus or minus signs are admissible.
 ##  <P/>
 ##  If <A>filt</A> is not given it defaults to <Ref Func="IsPcGroup"/>.
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> ExtraspecialGroup( 27, 3 );
@@ -577,6 +597,8 @@ DeclareConstructor( "MathieuGroupCons", [ IsGroup, IsInt ] );
 ##  given by the filter <A>filt</A>, where <A>degree</A> must be in the set
 ##  <M>\{ 9, 10, 11, 12, 21, 22, 23, 24 \}</M>.
 ##  If <A>filt</A> is not given it defaults to <Ref Prop="IsPermGroup"/>.
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> MathieuGroup( 11 );
@@ -633,6 +655,8 @@ DeclareConstructor( "SymmetricGroupCons", [ IsGroup, IsInt ] );
 ##  constructs the symmetric group of degree <A>deg</A> in the category
 ##  given by the filter <A>filt</A>.
 ##  If <A>filt</A> is not given it defaults to <Ref Prop="IsPermGroup"/>.
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  In the second version, the function constructs the symmetric group on
 ##  the points given in the set <A>dom</A> which must be a set of positive
 ##  integers.

--- a/grp/ree.gd
+++ b/grp/ree.gd
@@ -36,6 +36,8 @@ DeclareConstructor( "ReeGroupCons", [ IsGroup, IsInt ] );
 ##  If <A>filt</A> is not given it defaults to <Ref Func="IsMatrixGroup"/>
 ##  and the generating matrices are based on&nbsp;<Cite Key="KLM01"/>.
 ##  (No particular choice of a generating set is guaranteed.)
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> ReeGroup( 27 );

--- a/grp/suzuki.gd
+++ b/grp/suzuki.gd
@@ -37,6 +37,8 @@ DeclareConstructor( "SuzukiGroupCons", [ IsGroup, IsInt ] );
 ##  <P/>
 ##  If <A>filt</A> is not given it defaults to <Ref Func="IsMatrixGroup"/>,
 ##  and the returned group is the Suzuki group itself.
+##  For more information on possible values of <A>filt</A> see section
+##  (<Ref Sect="Basic Groups"/>).
 ##  <Example><![CDATA[
 ##  gap> SuzukiGroup( 32 );
 ##  Sz(32)


### PR DESCRIPTION
Please make sure that this pull request:

- [ ] is submitted to the correct branch (the stable branch is only for bugfixes)
- [ ] contains an accurate description of changes for the release notes below
- [ ] provides new tests or relies on existing ones
- [ ] correctly refers to other issues and related pull requests

### Tick all what applies to this pull request

- [ ] Adds new features
- [ ] Improves and extends functionality
- [ ] Fixes bugs that could lead to crashes
- [ ] Fixes bugs that could lead to incorrect results
- [ ] Fixes bugs that could lead to break loops

### Write below the description of changes (for the release notes)
Adds references about how to use the filter argument to the documentation of the Basic Groups library. Also adds an example to DihedralGroup using the IsPermGroup filter.
