### PR TITLE
Set package search paths independently from GAP roots

### DIFF
--- a/doc/ref/files.xml
+++ b/doc/ref/files.xml
@@ -101,6 +101,16 @@ for more information how to do this.
 
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
+<Section Label="GAP Package Directories">
+<Heading>GAP Package Directories</Heading>
+<Index Key="GAPInfo.PackagePaths"><C>GAPInfo.PackagePaths</C></Index>
+
+TODO
+
+</Section>
+
+
+<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <Section Label="Directories">
 <Heading>Directories</Heading>
 

--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -96,6 +96,7 @@ that is they will be loaded automatically when &GAP; starts
 
 <#Include Label="SetPackagePath">
 <#Include Label="ExtendRootDirectories">
+<#Include Label="ExtendPackageDirectories">
 <#Include Label="DisplayPackageLoadingLog">
 
 </Section>

--- a/lib/package.gd
+++ b/lib/package.gd
@@ -839,7 +839,8 @@ DeclareGlobalFunction( "LoadPackage" );
 ##  <P/>
 ##  See <Ref Func="SetPackagePath"/> for a way to force the loading of a
 ##  prescribed package version.
-##  See also <Ref Func="ExtendRootDirectories"/> for a method of adding
+##  See also <Ref Func="ExtendRootDirectories"/> and
+##  <Ref Func="ExtendPackageDirectories"/> for methods of adding
 ##  directories containing packages <E>after</E> &GAP; has been started.
 ##  </Subsection>
 ##  <#/GAPDoc>
@@ -926,6 +927,29 @@ DeclareGlobalFunction( "SetPackagePath" );
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction( "ExtendRootDirectories" );
+
+
+#############################################################################
+##
+#F  ExtendPackageDirectories( <paths> )
+##
+##  <#GAPDoc Label="ExtendPackageDirectories">
+##  <ManSection>
+##  <Func Name="ExtendPackageDirectories" Arg='paths'/>
+##
+##  <Description>
+##  Let <A>paths</A> be a list of strings that denote paths to intended
+##  &GAP; package directories (see <Ref Sect="GAP Package Directories"/>).
+##  The function <Ref Func="ExtendPackageDirectories"/> adds these paths to
+##  the global list <C>GAPInfo.PackagePaths</C> and calls the initialization of
+##  available &GAP; packages,
+##  such that later calls to <Ref Func="LoadPackage"/> will find the &GAP;
+##  packages that are contained in the directories given by <A>paths</A>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction( "ExtendPackageDirectories" );
 
 #############################################################################
 ##

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -300,8 +300,17 @@ InstallGlobalFunction( InitializePackagesInfoRecords, function( arg )
 
     LogPackageLoadingMessage( PACKAGE_DEBUG,
         "entering InitializePackagesInfoRecords", "GAP" );
+
+    # add any new pkg directories to the list
     pkgdirs:= DirectoriesLibrary( "pkg" );
-    if pkgdirs = fail then
+    if pkgdirs <> fail then
+        pkgdirs:= Filtered( pkgdirs, dir -> not dir in GAPInfo.PackageDirectories );
+        if not IsEmpty(pkgdirs) then
+            APPEND_LIST_INTR( GAPInfo.PackageDirectories, pkgdirs );
+        fi;
+    fi;
+
+    if IsEmpty(GAPInfo.PackageDirectories) then
       LogPackageLoadingMessage( PACKAGE_DEBUG,
           "exit InitializePackagesInfoRecords (no pkg directories found)",
           "GAP" );
@@ -327,7 +336,7 @@ InstallGlobalFunction( InitializePackagesInfoRecords, function( arg )
     # Loop over the package directories,
     # remove the packages listed in `NOAUTO' files from GAP's suggested
     # packages, and unite the information for the directories.
-    for pkgdir in pkgdirs do
+    for pkgdir in GAPInfo.PackageDirectories do
 
       if IsBound( GAPInfo.ExcludeFromAutoload ) then
         UniteSet( GAPInfo.ExcludeFromAutoload,
@@ -1816,6 +1825,7 @@ InstallGlobalFunction( ExtendRootDirectories, function( rootpaths )
     local i;
 
     rootpaths:= Filtered( rootpaths, path -> not path in GAPInfo.RootPaths );
+    # TODO: validate the paths???
     if not IsEmpty( rootpaths ) then
       # 'DirectoriesLibrary' concatenates root paths with directory names.
       for i in [ 1 .. Length( rootpaths ) ] do
@@ -1828,6 +1838,35 @@ InstallGlobalFunction( ExtendRootDirectories, function( rootpaths )
           rootpaths ) );
       # Clear the cache.
       GAPInfo.DirectoriesLibrary:= AtomicRecord( rec() );
+      # Reread the package information.
+      if IsBound( GAPInfo.PackagesInfoInitialized ) and
+         GAPInfo.PackagesInfoInitialized = true then
+        GAPInfo.PackagesInfoInitialized:= false;
+        InitializePackagesInfoRecords();
+      fi;
+    fi;
+    end );
+
+
+#############################################################################
+##
+#F  ExtendPackageDirectories( <paths_or_dirs> )
+##
+InstallGlobalFunction( ExtendPackageDirectories, function( paths_or_dirs )
+    local p, changed;
+    changed:= false;
+    for p in paths_or_dirs do
+      if IsString( p ) then
+        p:= Directory( p );
+      elif not IsDirectory( p ) then
+        Error("input must be a list of path strings or directory objects");
+      fi;
+      if not p in GAPInfo.PackageDirectories then
+        Add( GAPInfo.PackageDirectories, p );
+        changed:= true;
+      fi;
+    od;
+    if changed then
       # Reread the package information.
       if IsBound( GAPInfo.PackagesInfoInitialized ) and
          GAPInfo.PackagesInfoInitialized = true then

--- a/lib/system.g
+++ b/lib/system.g
@@ -302,6 +302,7 @@ CallAndInstallPostRestore( function()
 
     # paths
     GAPInfo.RootPaths:= GAPInfo.KernelInfo.GAP_ROOT_PATHS;
+    GAPInfo.PackageDirectories := [];
     if  IsBound(GAPInfo.SystemEnvironment.HOME) then
       GAPInfo.UserHome := GAPInfo.SystemEnvironment.HOME;
     else


### PR DESCRIPTION
This is work-in-progress code which I started in February, but then got sidetracked, and never completed.

Before I invest more effort into it, I thought I should ask what people think about this...

This PR is about changing GAP to tracker "package search directories" separately from "GAP roots"

The idea is that I would like to be able to tell GAP to load packages from a specific dir, and not just from a "foo/pkg/my-actual-package", where "foo" must be a GAP root, and "pkg" is fixed (GAP insists on it). Instead, I'd like to be able to just point GAP at a directory "foo", and it automaticaly picks up any packages in there -- regardless of whether "foo" itself is the directory of a package, or "foo" contains packages (such as "foo/cvec", "foo/orb", ...).

Of course one can still specify GAP roots; internally, when you specify a GAP root "foo", then GAP simply adds "foo/pkg" to the list of package search directories. But in addition, users should be able to specify package search directories which are not within a GAP root. Either by calling the GAP function `ExtendPackageDirectories()`, or by specifying a command line flag (the latter has not yet been implemented).

Of course if anybody is interested in this, feel free to help work on it... or just give feedback... :)

