### PR TITLE
Globalstate fixes

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -222,10 +222,10 @@ char *original_argv0;
 static char **sysargv;
 static char **sysenviron;
 
-/* TL:
-Obj ShellContext = 0;
-Obj BaseShellContext = 0;
-UInt ShellContextDepth;
+/*
+TL: Obj ShellContext = 0;
+TL: Obj BaseShellContext = 0;
+TL: UInt ShellContextDepth;
 */
 
 Obj Shell ( Obj context, 
@@ -1203,13 +1203,13 @@ Obj FuncWindowCmd (
 *F  FuncDownEnv( <self>, <level> )  . . . . . . . . .  change the environment
 */
 
-/* TL:
-Obj  ErrorLVars0;    
-Obj  ErrorLVars;
-Int  ErrorLLevel;
+/*
+TL: Obj  ErrorLVars0;
+TL: Obj  ErrorLVars;
+TL: Int  ErrorLLevel;
 */
 
-// extern Obj BottomLVars;
+// TL: extern Obj BottomLVars;
 
 
 void DownEnvInner( Int depth )

--- a/src/gap.c
+++ b/src/gap.c
@@ -1202,9 +1202,11 @@ Obj FuncWindowCmd (
 *F  FuncDownEnv( <self>, <level> )  . . . . . . . . .  change the environment
 */
 
+/* TL:
 Obj  ErrorLVars0;    
 Obj  ErrorLVars;
 Int  ErrorLLevel;
+*/
 
 // extern Obj BottomLVars;
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -222,10 +222,11 @@ char *original_argv0;
 static char **sysargv;
 static char **sysenviron;
 
+/* TL:
 Obj ShellContext = 0;
 Obj BaseShellContext = 0;
 UInt ShellContextDepth;
-
+*/
 
 Obj Shell ( Obj context, 
             UInt canReturnVoid,

--- a/src/globalstate.h
+++ b/src/globalstate.h
@@ -29,7 +29,9 @@ typedef struct GlobalState
   Obj IntrState;
   Obj StackObj;
   Int CountObj;
+#if defined(HPCGAP)
   UInt PeriodicCheckCount;
+#endif
 
   /* From gvar.c */
   Obj CurrNamespace;
@@ -38,7 +40,9 @@ typedef struct GlobalState
   Bag BottomLVars;
   Bag CurrLVars;
   Obj *PtrLVars;
+#if defined(HPCGAP)
   Bag LVarsPool[16];
+#endif
 
   /* From read.c */
   syJmp_buf ReadJmpError;
@@ -74,7 +78,7 @@ typedef struct GlobalState
   TypInputFile *  TestInput;
   TypOutputFile * TestOutput;
   TypOutputFile * IgnoreStdoutErrout;
-#ifdef HPCGAP
+#if defined(HPCGAP)
   Obj		  DefaultOutput;
   Obj		  DefaultInput;
 #endif
@@ -156,15 +160,17 @@ typedef struct GlobalState
   Int PrintObjFull;
   // HPC-GAP Obj PrintObjThissObj;
   Obj PrintObjThiss[MAXPRINTDEPTH];
-  // HPG-GAP Obj PrintObjIndicesObj;
+  // HPC-GAP Obj PrintObjIndicesObj;
   Int PrintObjIndices[MAXPRINTDEPTH];
 
+#if defined(HPCGAP)
   /* For serializer.c */
   Obj SerializationObj;
   UInt SerializationIndex;
   void *SerializationDispatcher;
   Obj SerializationRegistry;
   Obj SerializationStack;
+#endif
 
   /* For objscoll*, objccoll* */
   Obj SC_NW_STACK;
@@ -176,10 +182,12 @@ typedef struct GlobalState
   Obj SC_CW2_VECTOR;
   UInt SC_MAX_STACK_SIZE;
 
+#if defined(HPCGAP)
   /* Profiling */
   UInt CountActive;
   UInt LocksAcquired;
   UInt LocksContended;
+#endif
 
   /* Allocation */
 #ifdef BOEHM_GC


### PR DESCRIPTION
Make sure that there are no global variables shadowing state held in `GlobalState`, this should address #935.

I followed the procedure in #935, but the semiautomation is a hack of emacs lisp and grep, so not for public consumption. 