### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/objects.h
+++ b/src/objects.h
@@ -71,7 +71,7 @@
 **  'INTOBJ_INT' converts the C integer <i> to an (immediate) integer object.
 */
 #define INTOBJ_INT(i) \
-    ((Obj)(((Int)(i) << 2) + 0x01))
+    ((Obj)(((UInt)(Int)(i) << 2) + 0x01))
 
 
 /****************************************************************************


### PR DESCRIPTION
This patch fixes two compiler warning in the stable branch. One of them is #924, the other one is about bit-shifting unsigned integers.

This patch doesn't change any functionality, just makes the code changes necessary to get rid of the warnings. In one case, this required slightly re-writing a function.