### PR TITLE
Give better error message if a helpfile is missing

### DIFF
--- a/lib/helpdef.gi
+++ b/lib/helpdef.gi
@@ -297,9 +297,14 @@ InstallGlobalFunction(HELP_CHAPTER_INFO, function( book, chapter )
 
         filename := Filename( info.directories, info.filenames[chapter] );
         if filename = fail  then
+            Error("help file ", info.filenames[chapter], " for help book '", book.bookname, "' not found");
             return fail;
         fi;
         stream := StringStreamInputTextFile(filename);
+        if stream = fail then
+            Error("help file ", filename, " does not exist or is not readable");
+            return fail;
+        fi;
         poss   := [];
         secnum := 0;
         repeat

--- a/lib/helpt2t.gi
+++ b/lib/helpt2t.gi
@@ -219,7 +219,7 @@ local   book, chapter, section, key, subkey, MatchKey, ssectypes,
   info := HELP_BOOK_INFO(book);
   chap := HELP_CHAPTER_INFO( book, chapter );
   if chap = fail  then
-      return;
+      return fail;
   fi;
 
   # store lines


### PR DESCRIPTION
A recent xgap release had a bug: it's old-style manual was missing a file (`gobject.tex`) in the release tarball (see https://github.com/gap-packages/xgap/issues/3). This lead to a rather unhelpful error message by the GAP help system:
```
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 1st choice method found for `PositionStream' on 1 arguments called from
PositionStream( stream 
 ) at /mnt/disk2/hudson-slave/workspace/GAP-update-release-test/GAPCOPTS/64bui\
ld/GAPGMP/gmp/GAPTARGET/standard/label/64bit/gap4r8/lib/helpdef.gi:306 called \
from
...
```
That was the error @alex-konovalov got, I actually saw a different one:
```
Error, Function Calls: <func> must return a value in
  return HELP_PRINT_SECTION_TEXT( info, chnr, secnr ); at /home/r/mhorn/gap/lib/helpdef.gi:669 called from
HELP_BOOK_HANDLER.(book.handler).HelpData( book, entrynr, type ) at /home/r/mhorn/gap/lib/helpbase.gi:783 called from
...
```
This PR improves on the situation, by inserting explicit error messages that at least give a hint as to what went wrong, making it easier to debug similar issues in the future.

I also fixed `HELP_PRINT_SECTION_TEXT` to always return a value (see also issue #464  and PR #466).
