### PR TITLE
IsHandledByNiceMonomorphism implies CanComputeSizeAnySubgroup

### DIFF
--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -233,6 +233,14 @@ end );
 ##
 InstallTrueMethod(CanEasilyTestMembership,IsHandledByNiceMonomorphism);
 
+
+#############################################################################
+##
+#M  CanComputeSizeAnySubgroup( <permgroup> )
+##
+InstallTrueMethod(CanComputeSizeAnySubgroup,IsHandledByNiceMonomorphism);
+
+
 #############################################################################
 ##
 #M  AbelianInvariants( <G> )  . . . . . . . . . abelian invariants of a group


### PR DESCRIPTION
This enables GAP to pick a better OrbitStabilizerAlgorithm method,
e.g. for matrix groups. Quite noticeable if all you want is a stabilizer,
but not the full orbit.

I discussed this with @hulpke who agreed it was the correct thing to do.