### PR TITLE
BuildPackages.sh: pass gaproot to anupq and xgap

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -133,7 +133,7 @@ do
       cd $dir
       case $dir in
         anupq*)
-          ./configure CFLAGS=-m32 LDFLAGS=-m32 &&
+          ./configure CFLAGS=-m32 LDFLAGS=-m32 --with-gaproot=$GAPDIR &&
           $MAKE CFLAGS=-m32 LOPTS=-m32
         ;;
 
@@ -172,7 +172,7 @@ do
         ;;
 
         xgap*)
-          ./configure &&
+          ./configure --with-gaproot=$GAPDIR &&
           $MAKE &&
           rm -f $GAPDIR/bin/xgap.sh &&
           cp bin/xgap.sh $GAPDIR/bin


### PR DESCRIPTION
Without this, neither package builds correctly if one uses `BuildPackages.sh` to compile packages in an external location.