### PR TITLE
Fix bug in initialisation of TmpPPerm

### DIFF
--- a/src/pperm.c
+++ b/src/pperm.c
@@ -54,10 +54,11 @@ Obj   EmptyPartialPerm;
 #define  TmpPPerm TLS(TmpPPerm)
 
 static inline void ResizeTmpPPerm( UInt len ){
-  if (TmpPPerm == (Obj)0) 
-    TmpPPerm = NewBag(T_PPERM4, len*sizeof(UInt4));
-  else if (SIZE_BAG(TmpPPerm) < len*sizeof(UInt4))
-    ResizeBag(TmpPPerm,len*sizeof(UInt4));
+  if (TmpPPerm == (Obj)0) {
+    TmpPPerm = NewBag(T_PPERM4, (len + 1) * sizeof(UInt4) + 2 * sizeof(Obj));
+  } else if (SIZE_OBJ(TmpPPerm) < (len + 1) * sizeof(UInt4) + 2 * sizeof(Obj)) {
+    ResizeBag(TmpPPerm,(len + 1) * sizeof(UInt4) + 2 * sizeof(Obj));
+  }
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Please make sure that this pull request:

- [X] is submitted to the correct branch (the stable branch is only for bugfixes)
- [X] contains an accurate description of changes for the release notes below
- [ ] provides new tests or relies on existing ones
- [ ] correctly refers to other issues and related pull requests

### Tick all what applies to this pull request

- [ ] Adds new features
- [ ] Improves and extends functionality
- [X] Fixes bugs that could lead to crashes
- [ ] Fixes bugs that could lead to incorrect results
- [ ] Fixes bugs that could lead to break loops

### Write below the description of changes (for the release notes)

The function `ResizeTmpPPerm` did not correctly initialise `TmpPPerm`, the
bag was too small. A similar fix was made relatively recently by CAJ to
`ResizeTmpTrans`. I can't provide an example where this causes a problem, 
but it was causing a seg fault in the tests for the Semigroups package.