### PR TITLE
Use -K option to restrict the amount of memory used in tests

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -77,8 +77,8 @@ endif
 GAPARCH=@GAPARCH@
 GAPARGS=
 
-TESTGAP = ./bin/gap-$(CONFIGNAME).sh -b -m 100m -o 1g -A -q -x 80 -r $(GAPARGS)
-TESTGAPauto = ./bin/gap-$(CONFIGNAME).sh -b -m 100m -o 1g -q -x 80 -r $(GAPARGS)
+TESTGAP = ./bin/gap-$(CONFIGNAME).sh -b -m 100m -o 1g -K 2g -A -q -x 80 -r $(GAPARGS)
+TESTGAPauto = ./bin/gap-$(CONFIGNAME).sh -b -m 100m -o 1g -K 2g -q -x 80 -r $(GAPARGS)
 
 PKG_BOOTSTRAP_URL="http://www.gap-system.org/pub/gap/gap4pkgs/"
 PKG_MINIMAL="bootstrap-pkg-minimal.tar.gz"

--- a/tst/testbugfix.g
+++ b/tst/testbugfix.g
@@ -11,7 +11,7 @@
 ##  gap> Read( Filename( DirectoriesLibrary( "tst" ), "testbugfix.g" ) );
 ##
 
-Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g'.\n",
+Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g -K 2g'.\n",
        "The more GAP4stones you get, the faster your system is.\n",
        "The runtime of the following tests (in general) increases.\n",
        "******************************************************************\n",

--- a/tst/testinstall.g
+++ b/tst/testinstall.g
@@ -26,7 +26,7 @@
 ##  <#/GAPDoc>
 ##
 
-Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g'.\n",
+Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g -K 2g'.\n",
        "The more GAP4stones you get, the faster your system is.\n",
        "The runtime of the following tests (in general) increases.\n",
        "You should expect the test to take about one minute and show about\n",

--- a/tst/testprofiling.g
+++ b/tst/testprofiling.g
@@ -24,7 +24,7 @@
 ##  <#/GAPDoc>
 ##
 
-Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g'.\n",
+Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g -K 2g'.\n",
        "The more GAP4stones you get, the faster your system is.\n",
        "The runtime of the following tests (in general) increases.\n",
        "******************************************************************\n",

--- a/tst/teststandard.g
+++ b/tst/teststandard.g
@@ -24,7 +24,7 @@
 ##  <#/GAPDoc>
 ##
 
-Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g'.\n",
+Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g -K 2g'.\n",
        "The more GAP4stones you get, the faster your system is.\n",
        "The runtime of the following tests (in general) increases.\n",
        "******************************************************************\n",

--- a/tst/testtravis.g
+++ b/tst/testtravis.g
@@ -13,7 +13,7 @@
 ##  gap> Read( Filename( DirectoriesLibrary( "tst" ), "testtravis.g" ) );
 ##
 
-Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g'.\n",
+Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g -K 2g'.\n",
        "The more GAP4stones you get, the faster your system is.\n",
        "The runtime of the following tests (in general) increases.\n",
        "******************************************************************\n",


### PR DESCRIPTION
At the moment, the default value of `-K` option, which limits the amount of memory available to GAP, is zero. This means that it is limited only by the operating system (more precisely, whether the build is 32 or 64-bit). 

Dealing with #896, I observed that this has the following effect on regression tests. The tests are started with `-o 1g` option, which specifies when to trigger the break loop with `Error, reached the pre-set memory limit (change it with the -o command line option)` message. When GAP continues to the next command, the workspace grows, and in a case of a test where this may happen several times, this becomes a problem which we observe on our Jenkins slaves (for example, running 4 tests concurrently on a slave with 12 GB RAM).

This pull requests will make use of `-K 2g` option in all tests invoked via `make test<something>`. This will be enough to not to interrupt the test completely when the limit of 1g is hit, but will prevent test workspaces from growing to giant sizes.
