### PR TITLE
Add missing methods for -infinity

### DIFF
--- a/lib/float.gi
+++ b/lib/float.gi
@@ -108,6 +108,10 @@ BindGlobal("INSTALLFLOATCONSTRUCTORS", function(arg)
     InstallMethod(NewFloat, [filter,IsInfinity], -1, function(filter,obj)
         return Inverse(NewFloat(filter,0));
     end);
+
+    InstallMethod(NewFloat, [filter,IsNegInfinity], -1, function(filter,obj)
+        return -Inverse(NewFloat(filter,0));
+    end);
     
     InstallMethod(NewFloat, [filter,IsList], -1, function(filter,mantexp)
         if mantexp[1]=0 then
@@ -131,6 +135,10 @@ BindGlobal("INSTALLFLOATCONSTRUCTORS", function(arg)
     
     InstallMethod(MakeFloat, [filter,IsInfinity], -1, function(filter,obj)
         return Inverse(MakeFloat(filter,0));
+    end);
+
+    InstallMethod(MakeFloat, [filter,IsNegInfinity], -1, function(filter,obj)
+        return -Inverse(MakeFloat(filter,0));
     end);
     
     InstallMethod(MakeFloat, [filter,IsList], -1, function(filter,mantexp)

--- a/tst/teststandard/float.tst
+++ b/tst/teststandard/float.tst
@@ -121,6 +121,30 @@ gap> Exp(last);
 0.948683
 gap> last^2;
 0.9
+gap> 1.0/0.0;
+inf
+gap> -1.0/0.0;
+-inf
+gap> -Float(infinity) = Float(-infinity);
+true
+gap> posinf := Float(infinity);
+inf
+gap> neginf := Float(-infinity);
+-inf
+gap> neginf < posinf;
+true
+gap> neginf <> posinf;
+true
+gap> neginf < 0.0;
+true
+gap> 0.0 < posinf;
+true
+gap> MakeFloat(1.0, infinity) = posinf;
+true
+gap> -MakeFloat(1.0, infinity) = neginf;
+true
+gap> MakeFloat(1.0, -infinity) = neginf;
+true
 gap> STOP_TEST( "float.tst", 280000);
 
 #############################################################################


### PR DESCRIPTION
Add missing methods to ensure that `-infinity` can be converted to a `Float`.