### PR TITLE
Better error handling for stat syscall for IsDirectoryPathString

### DIFF
--- a/doc/ref/files.xml
+++ b/doc/ref/files.xml
@@ -341,8 +341,11 @@ true
 <Description>
 <Ref Func="IsDirectoryPath"/>
 returns <K>true</K> if the file with the filename <A>filename</A> exists
-<E>and</E> is a directory,
-and <K>false</K> otherwise.
+<E>and</E> is a directory, <K>false</K> if it exists and is not a file,
+and <K>fail</K> otherwise. If <Ref Func="IsDirectoryPath"/> returns <K>fail</K>,
+you can use <Ref Func="LastSystemError"/> to get more information about the
+nature of the failure.
+
 Note that this function does not check if the &GAP; process actually has
 write or execute permissions for the directory.
 You can use <Ref Func="IsWritableFile"/>,

--- a/src/streams.c
+++ b/src/streams.c
@@ -1411,7 +1411,16 @@ Obj FuncIsDirectoryPathString (
     
     /* call the system dependent function                                  */
     res = SyIsDirectoryPath( CSTR_STRING(filename) );
-    return res == -1 ? False : True;
+    switch(res) {
+    case 0:
+        return True;
+        break;
+    case -1:
+        return False;
+        break;
+    default:
+        return Fail;
+    }
 }
 
 

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -3755,7 +3755,7 @@ Int SyIsDirectoryPath ( const Char * name )
     SyClearErrorNo();
     if ( stat( name, &buf ) == -1 ) {
         SySetErrorNo();
-        return -1;
+        return -2;
     }
     return S_ISDIR(buf.st_mode) ? 0 : -1;
 }

--- a/tst/testinstall/dir.tst
+++ b/tst/testinstall/dir.tst
@@ -3,11 +3,12 @@ gap> base := Filename( DirectoriesLibrary( "tst" ), "example-dir");;
 gap> dirbase := Directory(base);;
 gap> badbase := Concatenation(base,"cheeseababababab");;
 gap> baddirbase := Directory(badbase);;
-gap> dirs := [base, dirbase, badbase, baddirbase];;
+gap> file := Filename( DirectoriesLibrary( "tst" ), "example.txt");;
+gap> dirs := [base, dirbase, badbase, baddirbase, file];;
 gap> List(dirs, IsDirectoryPath);
-[ true, true, false, false ]
+[ true, true, fail, fail, false ]
 gap> List(dirs, IsDirectory);
-[ false, true, false, true ]
+[ false, true, false, true, false ]
 gap> DirectoryHome() = Directory("~") or ARCH_IS_WINDOWS();
 true
 gap> ForAll([DirectoryHome, DirectoryDesktop,DirectoryCurrent],


### PR DESCRIPTION
* `SyIsDirectoryPath` returns `0` if the argument is an existing path *and* a directory,  `-1` if the argument is an existing path *and* not a directory, and `-2` if the syscall failed
* `SyIsDirectoryPath` in the case of failure updates the `LastSystemError()`, enabling GAP code to handle failures
* `IsDirectoryPathString` returns `true`, `false` or `fail` if `SyDirectoryPath` returned `0`, `-1` or `-2` respectively.
* The behaviour of `IsDirectoryPathString` is almost backwards compatible, except that cases where a user explicitly tests its return value for `false`.