### PR TITLE
StructureDescriptions fix

### DIFF
--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -74,6 +74,22 @@ DeclareGlobalFunction( "UnionIfCanEasilySortElements", IsList );
 
 #############################################################################
 ##
+#F  AddSetIfCanEasilySortElements( <list>, <object> ) . . . . generic method
+##
+##  <ManSection>
+##  <Func Name="AddSetIfCanEasilySortElements" Arg="list, obj"/>
+##
+##  <Description>
+##    Adds the <A>obj</A> to the list <A>list</A>. If CanEasilySortElements
+##    is true for <A>list</A> and <A>list</A> is a set, then AddSet is used
+##    instead of Add. Does not return anything, but changes <list>.
+##  </Description>
+##  </ManSection>
+##
+DeclareGlobalFunction( "AddSetIfCanEasilySortElements", IsList );
+
+#############################################################################
+##
 #O  NormalComplement( <G>, <N> ) . . . . . . . . . . . generic method
 ##
 ##  <#GAPDoc Label="NormalComplement">

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -98,10 +98,10 @@ DeclareGlobalFunction( "AddSetIfCanEasilySortElements", IsList );
 ##
 ##  <Description>
 ##    Gives a normal complement to the normal subgroup <A>N</A> in <A>G</A>
-##    if exists, fail otherwise.
+##    if exists, <C>fail</C> otherwise.
 ##    In theory it finds the normal complement for infinite <A>G</A>,
-##    but can have an infinite loop if <A>G/N</A> is abelian and <A>N</A> is
-##    infinite.
+##    but can have an infinite loop if <A>G</A>/<A>N</A> is abelian and
+##    <A>N</A> is infinite.
 ##    NormalComplementsNC does not check if <A>N</A> is a normal
 ##    subgroup of <A>G</A>.
 ##  </Description>
@@ -126,8 +126,8 @@ DeclareOperation( "NormalComplementNC", [IsGroup, IsGroup]);
 ##  <Attr Name="DirectFactorsOfGroup" Arg="G"/>
 ##
 ##  <Description>
-##    A (sorted if possible) list of factors [<A>G1</A>, .., <A>Gr</A>] such
-##    that <A>G</A> = <A>G1</A> x .. x <A>Gr</A> and none of the <A>Gi</A>
+##    A (sorted if possible) list of factors [<M>G_1</M>, .., <M>G_r</M>] such
+##    that <A>G</A> = <M>G_1</M> x .. x <M>G_r</M> and none of the <M>G_i</M>
 ##    is a direct product.
 ##    If <A>G</A> is an infinite abelian group, then it returns an unsorted
 ##    list of the factors. DirectFactorsOfGroup currently cannot compute the
@@ -157,8 +157,8 @@ DeclareAttribute( "DirectFactorsOfGroup", IsGroup );
 ##
 ##  <Description>
 ##    For a finite group this function returns a list 
-##    of characteristic subgroups [<A>G1</A>, .., <A>Gr</A>] such
-##    that <A>G</A> = <A>G1</A> x .. x <A>Gr</A> and none of the <A>Gi</A>
+##    of characteristic subgroups [<M>G_1</M>, .., <M>G_r</M>] such
+##    that <A>G</A> = <M>G_1</M> x .. x <M>G_r</M> and none of the <M>G_i</M>
 ##    is a direct product of characteristic subgroups.
 ##  </Description>
 ##  </ManSection>
@@ -174,9 +174,9 @@ DeclareAttribute( "CharacteristicFactorsOfGroup", IsGroup );
 ##  <Func Name="DirectFactorsOfGroup" Arg="G, Ns, MinNs"/>
 ##
 ##  <Description>
-##    A (sorted if possible) list of factors [<A>G1</A>, .., <A>Gr</A>] such
-##    that <A>G</A> = <A>G1</A> x .. x <A>Gr</A> and none of the <A>Gi</A>
-##    is a direct product, and all the factors <A>Gi</A> are from the list
+##    A (sorted if possible) list of factors [<M>G_1</M>, .., <M>G_r</M>] such
+##    that <A>G</A> = <M>G_1</M> x .. x <M>G_r</M> and none of the <M>G_i</M>
+##    is a direct product, and all the factors <M>G_i</M> are from the list
 ##    <A>Ns</A>. The list <A>MinNs</A> is supposed to be a list such that the
 ##    intersection of any two groups from <A>Ns</A> is either trivial or
 ##    contains a group from <A>MinNs</A>.
@@ -282,14 +282,14 @@ DeclareGlobalFunction( "DirectFactorsOfGroupFromList",
 
 #############################################################################
 ##
-#A  DirectFactorsOfGroupKN( <G> ) . . . . decomposition into a direct product
+#F  DirectFactorsOfGroupKN( <G> ) . . . . decomposition into a direct product
 ##
 ##  <ManSection>
 ##  <Func Name="DirectFactorsOfGroupKN" Arg="G"/>
 ##
 ##  <Description>
-##    A (sorted if possible) list of factors [<A>G1</A>, .., <A>Gr</A>] such
-##    that <A>G</A> = <A>G1</A> x .. x <A>Gr</A> and none of the <A>Gi</A>
+##    A (sorted if possible) list of factors [<M>G_1</M>, .., <M>G_r</M>] such
+##    that <M>G</M> = <M>G_1</M> x .. x <M>G_r</M> and none of the <M>G_i</M>
 ##    is a direct product.
 ##    This is the implementation of the algorithm described in
 ##    Neeraj Kayal and Timur Nezhmetdinov, Factoring Groups Efficiently,
@@ -320,22 +320,23 @@ DeclareGlobalFunction( "DirectFactorsOfGroupKN", IsGroup );
 ##    With the <A>method</A> <Q<"all"</Q>,
 ##    SemidirectDecompositionsOfFiniteGroup computes all conjugacy classes
 ##    of complement subgroups to all normal subgroups in <A>L</A>, and
-##    returns a list [[<A>N1</A>, <A>H1</A>], .., [<A>Nr</A>, <A>Hr</A>]] of
-##    all direct or semidirect decompositions, where <A>Ni</A> are from
+##    returns a list [[<M>N1</M>, <M>H1</M>], .., [<M>Nr</M>, <M>Hr</M>]] of
+##    all direct or semidirect decompositions, where <M>Ni</M> are from
 ##    <A>L</A>.
 ##
 ##    If <A>method</A> <Q>"any"</Q> is used, then
-##    SemidirectDecompositionsOfFiniteGroup returns [ <A>N</A>, <A>H</A> ]
-##    for some nontrivial <A>N</A> in <A>L</A> if exists, and returns fail
-##    otherwise. In particular, it first looks if $<A>G</A> is defined as a
-##    nontrivial semidirect product, and if yes, then it returns the two
-##    factors. Second, it looks for a nontrivial normal Hall subgroup, and
-##    if finds any, then will compute a complement to it. Otherwise it goes
-##    through the list <A>L</A>.
+##    SemidirectDecompositionsOfFiniteGroup returns [ <M>N</M>, <M>H</M> ]
+##    for some nontrivial <M>N</M> in <A>L</A> if exists, and returns
+##    <C>fail</C> otherwise. In particular, it first looks if $<A>G</A> is
+##    defined as a nontrivial semidirect product, and if yes, then it
+##    returns the two factors. Second, it looks for a nontrivial normal
+##    Hall subgroup, and if finds any, then will compute a complement to
+##    it. Otherwise it goes through the list <A>L</A>.
 ##
 ##    The <A>method</A> <Q>"str"</Q> differs from the <A>method</A>
 ##    <Q>"any</Q> by not computing normal complement to a normal Hall
-##    subgroup <A>N</A>, and in this case returns [ <A>N</A>, <A>G/N</A> ].
+##    subgroup <M>N</M>, and in this case returns
+##    [ <M>N</M>, <A>G</A>/<M>N</M> ].
 ##  </Description>
 ##  </ManSection>
 ##
@@ -349,9 +350,9 @@ DeclareGlobalFunction( "SemidirectDecompositionsOfFiniteGroup", IsGroup );
 ##  <Attr Name="SemidirectDecompositions" Arg="G"/>
 ##
 ##  <Description>
-##    A list [[<A>N1</A>, <A>H1</A>], .., [<A>Nr</A>, <A>Hr</A>]] of all
+##    A list [[<M>N_1</M>, <M>H_1</M>], .., [<M>N_r</M>, <M>H_r</M>]] of all
 ##    direct or semidirect decompositions up to conjugacy classes of
-##    <A>Hi</A>. Note that this function also recognizes direct products,
+##    <M>H_i</M>. Note that this function also recognizes direct products,
 ##    and it may take a very long time to run for particular groups.
 ##  </Description>
 ##  </ManSection>
@@ -644,7 +645,7 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##  <Attr Name="StructureDescription" Arg="G"/>
 ##
 ##  <Description>
-##  The method for <Ref Func="StructureDescription"/> exhibits a structure
+##  The method for <Ref Attr="StructureDescription"/> exhibits a structure
 ##  of the given group <A>G</A> to some extent, using the strategy outlined
 ##    below. The idea is to return a possibly short string which gives some
 ##    insight in the structure of the considered group. It is intended
@@ -654,12 +655,12 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##  chief factors is not described -- often not the most useful way to describe
 ##  a group.<P/>
 ##
-##  The string returned by <Ref Func="StructureDescription"/> is
+##  The string returned by <Ref Attr="StructureDescription"/> is
 ##  <B>not</B> an isomorphism invariant: non-isomorphic groups can have the
 ##  same string value, and two isomorphic groups in different representations
 ##  can produce different strings.
 ##
-##  The value returned by <Ref Func="StructureDescription"/> is a string of
+##  The value returned by <Ref Attr="StructureDescription"/> is a string of
 ##  the following form: <P/>
 ##  <Listing><![CDATA[
 ##    StructureDescription(<G>) ::=
@@ -701,20 +702,20 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##                                          ; Frattini factor group
 ##  ]]></Listing>
 ##  <P/>
-##  Note that the <Ref Func="StructureDescription"/> is only <E>one</E>
+##  Note that the <Ref Attr="StructureDescription"/> is only <E>one</E>
 ##  possible way of building up the given group from smaller pieces. <P/>
 ##
 ##  The option <Q>short</Q> is recognized - if this option is set, an
 ##  abbreviated output format is used (e.g. <C>"6x3"</C> instead of
 ##  <C>"C6 x C3"</C>). <P/>
 ##
-##  If the <Ref Func="Name"/> attribute is not bound, but
-##  <Ref Func="StructureDescription"/> is, <Ref Func="View"/> prints the
-##  value of the attribute <Ref Func="StructureDescription"/>.
+##  If the <Ref Attr="Name"/> attribute is not bound, but
+##  <Ref Attr="StructureDescription"/> is, <Ref Func="View"/> prints the
+##  value of the attribute <Ref Attr="StructureDescription"/>.
 ##  The <Ref Func="Print"/>ed representation of a group is not affected
-##  by computing a <Ref Func="StructureDescription"/>. <P/>
+##  by computing a <Ref Attr="StructureDescription"/>. <P/>
 ##
-##  The strategy used to compute a <Ref Func="StructureDescription"/> is
+##  The strategy used to compute a <Ref Attr="StructureDescription"/> is
 ##  as follows:
 ##  <P/>
 ##  <List>
@@ -756,7 +757,7 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##    <Item>
 ##      if <A>G</A> is solvable, then select a solvable normal Hall subgroup
 ##      <M>N</M>, if exists, and consider the semidirect decomposition of
-##      <M>N</M> and <M>G/N</M>,
+##      <M>N</M> and <A>G</A>/<M>N</M>,
 ##    </Item>
 ##    <Mark>3.</Mark>
 ##    <Item>
@@ -766,7 +767,9 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##    </List>
 ##    The option <Q>nice</Q> is recognized. If this option is set, then all
 ##    semidirect products are computed in order to find a possibly nicer
-##    presentation. Note, that this may take a long time.
+##    presentation. Note, that this may take a very long time if <A>G</A> has
+##    many normal subgroups, e.g. if <A>G</A>/<A>G</A>' has many cyclic
+##    factors.
 ##    If the option <Q>nice</Q> is set, then GAP would select a pair
 ##    <M>N</M>, <M>H</M> with the following preferences:
 ##    <List>
@@ -814,7 +817,7 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##    situation.
 ##  </Item>
 ##  </List>
-##  Note that <Ref Func="StructureDescription"/> is <E>not</E> intended
+##  Note that <Ref Attr="StructureDescription"/> is <E>not</E> intended
 ##  to be a research tool, but rather an educational tool. The reasons for
 ##  this are as follows:
 ##  <List>
@@ -829,7 +832,7 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##    <Mark>2.</Mark>
 ##    <Item>
 ##      In particular many <M>p</M>-groups have very <Q>similar</Q>
-##      structure, and <Ref Func="StructureDescription"/> can only
+##      structure, and <Ref Attr="StructureDescription"/> can only
 ##      exhibit a little of it. Changing this would likely make the
 ##      output not essentially easier to read than a pc presentation.
 ##    </Item>

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -24,8 +24,8 @@
 ##
 ##  <Description>
 ##    For normal subgroups <A>U</A> and <A>V</A> of <A>G</A>,
-##    IsTrivialNormalIntersection returns
-##    true if <A>U</A> and <A>V</A> intersect trivially, and false otherwise.
+##    <Ref Oper="IsTrivialNormalIntersection"/> returns <K>true</K> if
+##    <A>U</A> and <A>V</A> intersect trivially, and <K>false</K> otherwise.
 ##    The result is undefined if either <A>U</A> or <A>V</A> is not a normal
 ##    subgroup of G.
 ##  </Description>
@@ -42,15 +42,17 @@ DeclareOperation( "IsTrivialNormalIntersection",
 ##  <Func Name="IsTrivialNormalIntersectionInList" Arg="MinNs, U, V"/>
 ##
 ##  <Description>
-##    For groups <A>U</A> and <A>V</A>, IsTrivialNormalIntersection returns
-##    false if for any group H in list <A>MinNs</A> both <A>U</A> and
-##    <A>V</A> contains the first nontrivial generator of H. Otherwise, the
-##    result is true.
-##    This operation is useful if it is already known that the intersection
+##    For groups <A>U</A> and <A>V</A>,
+##    <Ref Func="IsTrivialNormalIntersectionInList"/> returns <K>false</K>
+##    if for any group <M>H</M> in list <A>MinNs</A> both <A>U</A> and
+##    <A>V</A> contains the first nontrivial generator of <M>H</M>.
+##    Otherwise, the result is <K>true</K>.
+##    This function is useful if it is already known that the intersection
 ##    of <A>U</A> and <A>V</A> is either trivial, or contains at least one
 ##    group from <A>MinNs</A>.
 ##    For example if <A>U</A> and <A>V</A> are normal subgroups of a group
-##    G and <A>MinNs</A>=MinimalNormalSubgroups(G).
+##    <M>G</M> and
+##    <A>MinNs</A>=<Ref Attr="MinimalNormalSubgroups"/>(<M>G</M>).
 ##  </Description>
 ##  </ManSection>
 ##
@@ -65,8 +67,10 @@ DeclareGlobalFunction( "IsTrivialNormalIntersectionInList",
 ##  <Func Name="UnionIfCanEasilySortElements" Arg="L1[, L2, ... ]"/>
 ##
 ##  <Description>
-##    Return the union of <A>Li</A> if CanEasilySortElements is true for all
-##    elements of all <A>Li</A>, and the concatenation of them, otherwise.
+##    Returns the <Ref Func="Union"/> of <A>Li</A> if
+##    <Ref Prop="CanEasilySortElements"/> is <K>true</K> for all elements
+##    of all <A>Li</A>, and the <Ref Func="Concatenation"/> of them,
+##    otherwise.
 ##  </Description>
 ##  </ManSection>
 ##
@@ -80,9 +84,11 @@ DeclareGlobalFunction( "UnionIfCanEasilySortElements", IsList );
 ##  <Func Name="AddSetIfCanEasilySortElements" Arg="list, obj"/>
 ##
 ##  <Description>
-##    Adds the <A>obj</A> to the list <A>list</A>. If CanEasilySortElements
-##    is true for <A>list</A> and <A>list</A> is a set, then AddSet is used
-##    instead of Add. Does not return anything, but changes <list>.
+##    Adds the <A>obj</A> to the list <A>list</A>. If
+##    <Ref Prop="CanEasilySortElements"/> is <K>true</K> for <A>list</A>
+##    and <A>list</A> is a set, then <Ref Oper="AddSet"/> is used instead
+##    of <Ref Oper="Add"/>. Does not return anything, but changes
+##    <A>list</A>.
 ##  </Description>
 ##  </ManSection>
 ##
@@ -98,11 +104,11 @@ DeclareGlobalFunction( "AddSetIfCanEasilySortElements", IsList );
 ##
 ##  <Description>
 ##    Gives a normal complement to the normal subgroup <A>N</A> in <A>G</A>
-##    if exists, <C>fail</C> otherwise.
+##    if exists, <K>fail</K> otherwise.
 ##    In theory it finds the normal complement for infinite <A>G</A>,
 ##    but can have an infinite loop if <A>G</A>/<A>N</A> is abelian and
 ##    <A>N</A> is infinite.
-##    NormalComplementsNC does not check if <A>N</A> is a normal
+##    <C>NormalComplementsNC</C> does not check if <A>N</A> is a normal
 ##    subgroup of <A>G</A>.
 ##  </Description>
 ##  </ManSection>
@@ -282,7 +288,7 @@ DeclareGlobalFunction( "DirectFactorsOfGroupFromList",
 
 #############################################################################
 ##
-#F  DirectFactorsOfGroupKN( <G> ) . . . . decomposition into a direct product
+#F  DirectFactorsOfGroupByKN( <G> ) . . . decomposition into a direct product
 ##
 ##  <ManSection>
 ##  <Func Name="DirectFactorsOfGroupKN" Arg="G"/>
@@ -299,7 +305,7 @@ DeclareGlobalFunction( "DirectFactorsOfGroupFromList",
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalFunction( "DirectFactorsOfGroupKN", IsGroup );
+DeclareGlobalFunction( "DirectFactorsOfGroupByKN", IsGroup );
 
 #############################################################################
 ##
@@ -327,7 +333,7 @@ DeclareGlobalFunction( "DirectFactorsOfGroupKN", IsGroup );
 ##    If <A>method</A> <Q>"any"</Q> is used, then
 ##    SemidirectDecompositionsOfFiniteGroup returns [ <M>N</M>, <M>H</M> ]
 ##    for some nontrivial <M>N</M> in <A>L</A> if exists, and returns
-##    <C>fail</C> otherwise. In particular, it first looks if $<A>G</A> is
+##    <K>fail</K> otherwise. In particular, it first looks if $<A>G</A> is
 ##    defined as a nontrivial semidirect product, and if yes, then it
 ##    returns the two factors. Second, it looks for a nontrivial normal
 ##    Hall subgroup, and if finds any, then will compute a complement to
@@ -336,7 +342,7 @@ DeclareGlobalFunction( "DirectFactorsOfGroupKN", IsGroup );
 ##    The <A>method</A> <Q>"str"</Q> differs from the <A>method</A>
 ##    <Q>"any</Q> by not computing normal complement to a normal Hall
 ##    subgroup <M>N</M>, and in this case returns
-##    [ <M>N</M>, <A>G</A>/<M>N</M> ].
+##    [ <M>N</M>, <M><A>G</A>/N</M> ].
 ##  </Description>
 ##  </ManSection>
 ##
@@ -757,7 +763,7 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##    <Item>
 ##      if <A>G</A> is solvable, then select a solvable normal Hall subgroup
 ##      <M>N</M>, if exists, and consider the semidirect decomposition of
-##      <M>N</M> and <A>G</A>/<M>N</M>,
+##      <M>N</M> and <M><A>G</A>/N</M>,
 ##    </Item>
 ##    <Mark>3.</Mark>
 ##    <Item>
@@ -768,7 +774,7 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##    The option <Q>nice</Q> is recognized. If this option is set, then all
 ##    semidirect products are computed in order to find a possibly nicer
 ##    presentation. Note, that this may take a very long time if <A>G</A> has
-##    many normal subgroups, e.g. if <A>G</A>/<A>G</A>' has many cyclic
+##    many normal subgroups, e.g. if <M><A>G</A>/<A>G</A>'</M> has many cyclic
 ##    factors.
 ##    If the option <Q>nice</Q> is set, then GAP would select a pair
 ##    <M>N</M>, <M>H</M> with the following preferences:
@@ -804,8 +810,8 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##  <Item>
 ##    Fall back to non-splitting extensions:
 ##    If the centre or the commutator factor group is non-trivial,
-##    write <A>G</A> as Z(<A>G</A>).<A>G</A>/Z(<A>G</A>) or
-##    <A>G</A>'.<A>G</A>/<A>G</A>', respectively.
+##    write <A>G</A> as <M>Z(<A>G</A>)</M>.<M><A>G</A>/Z(<A>G</A>)</M> or
+##    <M><A>G</A>'</M>.<M><A>G</A>/<A>G</A>'</M>, respectively.
 ##    Otherwise if the Frattini subgroup is non-trivial, write <A>G</A>
 ##    as <M>\Phi</M>(<A>G</A>).<A>G</A>/<M>\Phi</M>(<A>G</A>).
 ##  </Item>

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -862,6 +862,10 @@ InstallMethod( SemidirectDecompositions,
     return SemidirectDecompositionsOfFiniteGroup(G);
   end );
 
+RedispatchOnCondition( SemidirectDecompositions, true,
+    [ IsGroup ],
+    [ IsFinite ], 0);
+
 #############################################################################
 ##
 #M  DecompositionTypesOfGroup( <G> ) . . . . . . . . . . . . . generic method

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -1967,18 +1967,6 @@ RedispatchOnCondition( StructureDescription, true,
 
 #############################################################################
 ##
-#M  StructureDescription( <G> ) . . . . . . . . . . .  for group by nice mono
-##
-InstallMethod( StructureDescription,
-               "for groups handled by nice monomorphism", true, 
-			   [ IsGroup and IsHandledByNiceMonomorphism], 0,
-	function ( G )
-		return StructureDescription ( NiceObject ( G ) );
-	end );
-	
-
-#############################################################################
-##
 #M  ViewObj( <G> ) . . . . . . . . for group with known structure description
 ##
 InstallMethod( ViewObj,

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -377,7 +377,7 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
 
     # the KN method performs slower in practice, only called if forced
     if ValueOption("useKN") = true then
-      return DirectFactorsOfGroupKN(G);
+      return DirectFactorsOfGroupByKN(G);
     fi;
 
     # nilpotent groups are direct products of Sylow subgroups
@@ -568,7 +568,7 @@ InstallGlobalFunction( DirectFactorsOfGroupFromList,
     return [ G ];
   end );
 
-InstallGlobalFunction(DirectFactorsOfGroupKN,
+InstallGlobalFunction(DirectFactorsOfGroupByKN,
 
   function(G)
 
@@ -702,7 +702,7 @@ InstallGlobalFunction(DirectFactorsOfGroupKN,
         Z1 := Centralizer(G, prodK);
         # Z1 is nonabelian <==> contains a nonabelian factor
         if not IsAbelian(Z1) then
-          N := First(DirectFactorsOfGroupKN(Z1), x-> not IsAbelian(x));
+          N := First(DirectFactorsOfGroupByKN(Z1), x-> not IsAbelian(x));
           # not sure if IsNormal(G, N) should be checked
 
           # this certainly can be done better,
@@ -712,7 +712,7 @@ InstallGlobalFunction(DirectFactorsOfGroupKN,
           if B <> fail then
             # N is direct indecomposable by construction
             return UnionIfCanEasilySortElements([N],
-                                                  DirectFactorsOfGroupKN(B));
+                                                  DirectFactorsOfGroupByKN(B));
           fi;
         fi;
       fi;

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -95,6 +95,21 @@ InstallGlobalFunction( UnionIfCanEasilySortElements,
 
 #############################################################################
 ##
+#M  AddSetIfCanEasilySortElements( <list>[, <obj> ) . . . . . generic method
+##
+InstallGlobalFunction( AddSetIfCanEasilySortElements,
+
+  function( list, obj )
+
+    if CanEasilySortElements( list ) and IsSet( list ) then
+      AddSet( list, obj );
+    else
+      Add( list, obj );
+    fi;
+  end);
+
+#############################################################################
+##
 #M  NormalComplement( <G>, <N> ) . . . . . . . . . . . generic method
 ##
 InstallMethod( NormalComplement,
@@ -260,7 +275,7 @@ InstallMethod(DirectFactorsOfGroup,
         for N in DfMinNs do
           g := First(GeneratorsOfGroup(N), g -> g<>One(N));
           if g <> fail then
-            AddSet(gs, g);
+            AddSetIfCanEasilySortElements(gs, g);
           fi;
         od;
         # normal subgroup containing all minimal subgroups cannot have complement in H
@@ -323,7 +338,7 @@ InstallMethod(DirectFactorsOfGroup, "if normal subgroups are computed", true,
     for N in MinNs do
       g := First(GeneratorsOfGroup(N), g -> g<>One(N));
       if g <> fail then
-        AddSet(gs, g);
+        AddSetIfCanEasilySortElements(gs, g);
       fi;
     od;
     # normal subgroup containing all minimal subgroups cannot have complement
@@ -450,7 +465,7 @@ InstallMethod(DirectFactorsOfGroup, "generic method", true,
     for N in MinNs do
       g := First(GeneratorsOfGroup(N), g -> g<>One(N));
       if g <> fail then
-        AddSet(gs, g);
+        AddSetIfCanEasilySortElements(gs, g);
       fi;
     od;
     # normal subgroup containing all minimal subgroups cannot have complement
@@ -489,7 +504,7 @@ local Ns,MinNs,sel,a,sz,j,gs,g,N;
   for N in MinNs do
     g := First(GeneratorsOfGroup(N), g -> g<>One(N));
     if g <> fail then
-      AddSet(gs, g);
+      AddSetIfCanEasilySortElements(gs, g);
     fi;
   od;
   # normal subgroup containing all minimal subgroups cannot have complement
@@ -515,7 +530,7 @@ InstallGlobalFunction( DirectFactorsOfGroupFromList,
     for N in MinNs do
       g := First(GeneratorsOfGroup(N), g -> g<>One(N));
       if g <> fail then
-        AddSet(gs, g);
+        AddSetIfCanEasilySortElements(gs, g);
       fi;
     od;
     # normal subgroup containing all minimal subgroups cannot have complement
@@ -629,10 +644,10 @@ InstallGlobalFunction(DirectFactorsOfGroupKN,
               g := a*b;
               if g<>b*a then
                 com := false;
-                AddSet(preedges, [c1, c2]);
+                AddSetIfCanEasilySortElements(preedges, [c1, c2]);
                 break;
               else
-                AddSet(prod, g);
+                AddSetIfCanEasilySortElements(prod, g);
               fi;
             od;
             if not com then
@@ -644,7 +659,7 @@ InstallGlobalFunction(DirectFactorsOfGroupKN,
             b := Representative(c2);
             c3 := ConjugacyClass(G, a*b);
             if Size(c3)=Size(prod) then
-              AddSet(RedCl, c3);
+              AddSetIfCanEasilySortElements(RedCl, c3);
             fi;
           fi;
         fi;
@@ -755,7 +770,7 @@ InstallGlobalFunction(SemidirectDecompositionsOfFiniteGroup, function( arg )
         return [ N, H ];
       elif method="all" and
         ( not IsBound(Ns) or N in Ns ) then
-        AddSet(NHs, [ N, H ]);
+        AddSetIfCanEasilySortElements(NHs, [ N, H ]);
       fi;
     od;
     if method in [ "any", "str" ] then
@@ -820,7 +835,7 @@ InstallGlobalFunction(SemidirectDecompositionsOfFiniteGroup, function( arg )
         return [ N, H[1] ];
       else
         for i in [1..Length(H)] do
-          AddSet( NHs, [ N, H[i] ] );
+          AddSetIfCanEasilySortElements( NHs, [ N, H[i] ] );
         od;
       fi;
     fi;
@@ -1808,9 +1823,9 @@ InstallMethod( StructureDescription,
       fi;
     else
       NHs := [ ];
-      for NH in SemidirectDecompositionsOfFiniteGroup( G, "all" ) do
+      for NH in SemidirectDecompositions( G ) do
         if not IsTrivial( NH[1] ) and not IsTrivial( NH[2] ) then
-          AddSet(NHs, [ NH[1], NH[2] ]);
+          AddSetIfCanEasilySortElements(NHs, [ NH[1], NH[2] ]);
         fi;
       od;
       if Length(NHs) > 0 then

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -1931,9 +1931,9 @@ BindGlobal( "StructureDescriptionForFiniteGroups", # for finite groups
     then return SD_insertsep([StructureDescription(FrattiniSubgroup(G)),
                               StructureDescription(G/FrattiniSubgroup(G))],
                              " . ","x:.");
-    # this does not happen for Size(G)<645120
     elif     IsPosInt(NrPerfectGroups(Size(G)))
          and not Size(G) in [ 86016, 368640, 737280 ]
+    # this does not happen for Size(G)<10^6
     then
          id := PerfectIdentification(G);
          return Concatenation("PerfectGroup(",String(id[1]),",",

--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -839,6 +839,14 @@ AttributeMethodByNiceMonomorphism( Size,
 
 #############################################################################
 ##
+#M  StructureDescription( <G> )
+##
+AttributeMethodByNiceMonomorphism( StructureDescription,
+    [ IsGroup ] );
+
+
+#############################################################################
+##
 #M  SubnormalSeries( <G>, <U> ) . subnormal series from a group to a subgroup
 ##
 GroupSeriesMethodByNiceMonomorphismCollColl( SubnormalSeriesOp,

--- a/tst/testinstall/direct_factors.tst
+++ b/tst/testinstall/direct_factors.tst
@@ -51,7 +51,7 @@ gap> List(DirectFactorsOfGroup(G), IdGroup);
 [ [ 8, 3 ], [ 8, 3 ] ]
 gap> List(DirectFactorsOfGroup(SmallGroup(64,226):useKN), IdGroup);
 [ [ 8, 3 ], [ 8, 3 ] ]
-gap> List(DirectFactorsOfGroupKN(SmallGroup(8,5)), IdGroup);
+gap> List(DirectFactorsOfGroupByKN(SmallGroup(8,5)), IdGroup);
 [ [ 2, 1 ], [ 2, 1 ], [ 2, 1 ] ]
 gap> D := DihedralGroup(12);; NormalSubgroups(D);;
 gap> List(DirectFactorsOfGroup(D), IdGroup);
@@ -64,7 +64,7 @@ gap> List(DirectFactorsOfGroup(G), IdGroup);
 [ [ 48, 1 ] ]
 gap> DirectFactorsOfGroup(Group(()));
 [ Group(()) ]
-gap> DirectFactorsOfGroupKN(Group(()));
+gap> DirectFactorsOfGroupByKN(Group(()));
 [ Group(()) ]
 gap> F := FreeGroup("x","y");; x := F.1;; y := F.2;;
 gap> DirectFactorsOfGroup(F/[x*y*x^(-1)*y^(-1)]);

--- a/tst/testinstall/direct_factors.tst
+++ b/tst/testinstall/direct_factors.tst
@@ -5,6 +5,8 @@ true
 gap> U := Df[1];; V := Df[2];;
 gap> NormalComplement(D, U)=V;
 true
+gap> NormalComplement(Group((1,2),(1,2,3)), Group((1,2)));
+Error, N must be a normal subgroup of G
 gap> IsTrivialNormalIntersection(D, U, V);
 true
 gap> U := Center(D);; V := Centralizer(D, DerivedSubgroup(D));;
@@ -49,6 +51,8 @@ gap> List(DirectFactorsOfGroup(G), IdGroup);
 [ [ 8, 3 ], [ 8, 3 ] ]
 gap> List(DirectFactorsOfGroup(SmallGroup(64,226):useKN), IdGroup);
 [ [ 8, 3 ], [ 8, 3 ] ]
+gap> List(DirectFactorsOfGroupKN(SmallGroup(8,5)), IdGroup);
+[ [ 2, 1 ], [ 2, 1 ], [ 2, 1 ] ]
 gap> D := DihedralGroup(12);; NormalSubgroups(D);;
 gap> List(DirectFactorsOfGroup(D), IdGroup);
 [ [ 6, 1 ], [ 2, 1 ] ]
@@ -59,6 +63,8 @@ gap> G := SmallGroup(48, 1);; NormalSubgroups(G);;
 gap> List(DirectFactorsOfGroup(G), IdGroup);
 [ [ 48, 1 ] ]
 gap> DirectFactorsOfGroup(Group(()));
+[ Group(()) ]
+gap> DirectFactorsOfGroupKN(Group(()));
 [ Group(()) ]
 gap> F := FreeGroup("x","y");; x := F.1;; y := F.2;;
 gap> DirectFactorsOfGroup(F/[x*y*x^(-1)*y^(-1)]);

--- a/tst/testinstall/opers/SemidirectDecompositions.tst
+++ b/tst/testinstall/opers/SemidirectDecompositions.tst
@@ -77,4 +77,8 @@ Error, usage: SemidirectDecompositionsOfFiniteGroup(<G> [, <Ns>] [, <mthd>])
 gap> G := Group([ (4,8)(6,10), (4,6,10,8,12), (2,4,12)(6,10,8), (3,9)(4,6,10,8,12)(7,11), (3,5)(4,6,10,8,12)(9,11), (1,3,11,9,5)(4,6,10,8,12) ]);;
 gap> Length(SemidirectDecompositions(G));
 8
+gap> F := FreeGroup("r", "s");; r := F.1;; s := F.2;;
+gap> G := F/[s^2, r^3, s*r*s*r];;
+gap> Length(SemidirectDecompositions(G));
+3
 gap> STOP_TEST("Semidirectdecompositions.tst", 10000);

--- a/tst/testinstall/opers/StructureDescription.tst
+++ b/tst/testinstall/opers/StructureDescription.tst
@@ -72,6 +72,20 @@ gap> List(AllSmallNonabelianSimpleGroups([1..1000000]), StructureDescription);
   "PSL(2,89)", "PSL(3,5)", "M22", "PSL(2,97)", "PSL(2,101)", "PSL(2,103)", 
   "HJ", "PSL(2,107)", "PSL(2,109)", "PSL(2,113)", "PSL(2,121)", "PSL(2,125)", 
   "O(5,4)" ]
+gap> G := FactorGroup(Sp(6,3), Center(Sp(6,3)));;
+gap> StructureDescription(G);
+"PSp(6,3)"
+gap> StructureDescription(Omega(1,8,2));
+"O+(8,2)"
+gap> StructureDescription(Omega(-1,8,2));
+"O-(8,2)"
+gap> List(AllPrimitiveGroups(DegreeAction, 819, Size, 211341312, IsSimple, true), StructureDescription);
+[ "3D(4,2)" ]
+gap> G := Ree(27);;
+gap> HasIsFinite(G) and IsFinite(G) and HasIsSimpleGroup(G) and IsSimple(G);
+true
+gap> StructureDescriptionForFiniteSimpleGroups(Ree(27));
+"Ree(27)"
 gap> StructureDescription(AbelianGroup([0,0,0,2,3,4,5,6,7,8,9,10]));
 "C0 x C0 x C0 x C2520 x C60 x C6 x C2 x C2"
 gap> StructureDescription(AbelianGroup([0,0,0,2,3,4,5,6,7,8,9,10]):short);
@@ -86,4 +100,11 @@ gap> StructureDescription(SmallGroup(64,17):recompute,nice);
 #I  [ [ "C4 x C2", "C8" ], [ "C8 x C2", "C4" ] ]
 "(C4 x C2) : C8"
 gap> SetInfoLevel(InfoWarning,infolevel);
+gap> F := FreeGroup("r", "s");; r := F.1;; s := F.2;;
+gap> G := F/[s^2, r^3, s*r*s*r];;
+gap> StructureDescription(G);
+"S3"
+gap> G := F/[s*r*s^(-1)*r^(-1)];;
+gap> StructureDescription(G);
+"C0 x C0"
 gap> STOP_TEST("StructureDescription.tst", 10000);

--- a/tst/teststandard/bugfix.tst
+++ b/tst/teststandard/bugfix.tst
@@ -1078,12 +1078,12 @@ gap> testG :=
 >               [ [     -1,        0 ], [     0,      -1 ] ]];
 >       return (Group(M1));
 >    end;;
-gap> StructureDescription(testG(8,2));
-"((C8 x C2) : C2) : C2"
+gap> StructureDescription(testG(8,2):nice);
+"(C8 x C4) : C2"
 gap> StructureDescription(testG(8,3));
 "C3 x QD16"
-gap> StructureDescription(testG(8,4));
-"((C16 x C2) : C2) : C2"
+gap> StructureDescription(testG(8,4):nice);
+"(C16 x C4) : C2"
 
 # 2006/02/27 (AH)
 gap> RepresentativeAction(Group(()), [1], [2], OnSets);;

--- a/tst/teststandard/opers/StructureDescription.tst
+++ b/tst/teststandard/opers/StructureDescription.tst
@@ -2,4 +2,8 @@ gap> START_TEST("StructureDescription.tst");
 gap> G := Group([ (6,7,8,9,10), (8,9,10), (1,2)(6,7), (1,2,3,4,5)(6,7,8,9,10) ]);;
 gap> StructureDescription(G);
 "A5 : S5"
+
+## this currently takes a veeeeeery long time (about 20 minutes)
+#gap> StructureDescription(Ree(27));
+#"Ree(27)"
 gap> STOP_TEST("StructureDescription.tst", 10000);

--- a/tst/teststandard/opers/StructureDescription.tst
+++ b/tst/teststandard/opers/StructureDescription.tst
@@ -2,8 +2,4 @@ gap> START_TEST("StructureDescription.tst");
 gap> G := Group([ (6,7,8,9,10), (8,9,10), (1,2)(6,7), (1,2,3,4,5)(6,7,8,9,10) ]);;
 gap> StructureDescription(G);
 "A5 : S5"
-
-## this currently takes a veeeeeery long time (about 20 minutes)
-#gap> StructureDescription(Ree(27));
-#"Ree(27)"
 gap> STOP_TEST("StructureDescription.tst", 10000);


### PR DESCRIPTION
This splits the current general ````StructureDescription```` code for an abelian for a finite and for a finite simple method, with redispatches. 

Further, it adds nice monomorphism in the proper way (into ````grpnice.gi````), while removes it from ````grpnames.gi````. 

Corrects problematic tests, and fixes the ````StructureDescription```` part of #973.

Added some more tests to increase the code coverage of ````grpnames.gi```` . Now all lines (except for the ones for which I have no idea if an example even exists for) are covered for ````StructureDescription````, ````DirectFactors```` and ````SemidirectDecompositions````.

Manual entries are cleaned up in these three functions and in some of the functions they use in ````grpnames.gd```` (for easier future documentation).