### PR TITLE
ENHANCE: Option `NoPrecomputedData` to avoid use of data libraries

### DIFF
--- a/doc/ref/grplib.xml
+++ b/doc/ref/grplib.xml
@@ -61,7 +61,19 @@ incarnations.
 Note that a system administrator may choose to install all, or
 only a  few,  or even  none of the  libraries.  So some  of the libraries
 mentioned below may not be available on your installation.
+<P/>
+&GAP; might use data libraries that are available to speed up calculations,
+for example in using a classification to determine that groups must be
+isomorphic, based on agreement of properties; or to determine maximal
+subgroups or subgroup maximality. This will be indicated by an info message
+of level 2 in the info class
+<Ref Func="InfoPerformance"/>.
 
+If the calculation is to be independent of such data library use, for
+example if it is used to verify the data library, functions can be called
+with the option <C>NoPrecomputedData</C>, to turn these features off. Doing
+so might cause significantly longer calculations, or even failure of certain
+calculations.
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <Section Label="Basic Groups">

--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -797,8 +797,12 @@ local d,a,map,possibly,cG,cH,nG,nH,i,j,sel,u,v,asAutomorphism,K,L,conj,e1,e2,
     if AbelianInvariants(a)<>AbelianInvariants(b) then
       return false;
     fi;
-    if Size(a)<1000 and Size(a)<>512 and IdGroup(a)<>IdGroup(b) then
-      return false;
+    if Size(a)<1000 and Size(a)<>512
+     and ValueOption(NO_PRECOMPUTED_DATA_OPTION)<>true then
+      Info(InfoPerformance,2,"Using Small Groups Library");
+      if IdGroup(a)<>IdGroup(b) then
+	return false;
+      fi;
     fi;
     return true;
   end;

--- a/lib/galois.gi
+++ b/lib/galois.gi
@@ -541,6 +541,7 @@ end);
 InstallGlobalFunction(ProbabilityShapes,function(arg)
 local f,n,i,sh,fu,ps,pps,ind,keineu,ba,bk,j,k,a,anz,pm,
       cnt,cand,d,alt,p,g,weg,fac;
+  Info(InfoPerformance,2,"Using Transitive Groups Library");
   f:=arg[1];
   f:=f/LeadingCoefficient(f);
   if not(IsIrreducible(f)) then
@@ -703,6 +704,7 @@ local f,n,sh,p,ind,cand,noca,alt,d,df,co,dco,res,resf,pat,pps,i,j,k,
       GrabCodedLengths,UnParOrbits,cnt,polring,basring,indet,indnum,
       extring,lpos;
 
+  Info(InfoPerformance,2,"Using Transitive Groups Library");
   GetProperty := function(l,prop)
   local i;
     for i in l{[9..Length(l)]} do

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -68,7 +68,9 @@ local l,iso,fp,stbc,gens;
   # use the perfect groups library
   PerfGrpLoad(Size(G));
   if Size(G)<10^6 and IsRecord(PERFRec) and
+     ValueOption(NO_PRECOMPUTED_DATA_OPTION)<>true and
      not Size(G) in Union(PERFRec.notAvailable,PERFRec.notKnown) then
+    Info(InfoPerformance,2,"Using Perfect Groups Library");
     # loop over the groups
     for l in List([1..NrPerfectGroups(Size(G))],
                   i->PerfectGroup(IsPermGroup,Size(G),i)) do

--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -1223,7 +1223,8 @@ syll, act, typ, sel, bas, wdom, comp, lperm, other, away, i, j,b0,opg;
       return NormalizerParentSA(s,b);
     fi;
     # nonabelian socle
-    if PrimitiveGroupsAvailable(Length(dom)) then
+    if PrimitiveGroupsAvailable(Length(dom)) 
+      and ValueOption(NO_PRECOMPUTED_DATA_OPTION)<>true then
       Info(InfoPerformance,2,"Using Primitive Groups Library");
       # use library
       beta:=Factorial(Length(dom))/2;
@@ -2136,7 +2137,7 @@ local G,max,dom,n,A,S,issn,p,i,j,m,k,powdec,pd,gps,v,invol,sel,mf,l,prim;
   fi;
   dom:=Set(MovedPoints(G));
   n:=Length(dom);
-  if  #ValueOption(NO_PRECOMPUTED_DATA_OPTION)=true or
+  if  ValueOption(NO_PRECOMPUTED_DATA_OPTION)=true or
    not PrimitiveGroupsAvailable(n) then
     return fail;
   fi;

--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -1130,17 +1130,22 @@ local b, bl,prop;
   # what properties can we find easily
   prop:=function(s)
   local p;
-  s:=Set(dom{s});
+
+    s:=Set(dom{s});
     p:=[Length(s)];
 
-    # type of action on blocks
-    if TransitiveGroupsAvailable(Length(dom)/Length(s)) then
-      Add(p,TransitiveIdentification(Action(G,Orbit(G,s,OnSets),OnSets)));
-    fi;
+    if  ValueOption(NO_PRECOMPUTED_DATA_OPTION)<>true then
+      Info(InfoPerformance,2,"Using Transitive Groups Library");
 
-    # type of action on blocks
-    if TransitiveGroupsAvailable(Length(s)) then
-      Add(p,TransitiveIdentification(Action(Stabilizer(G,s,OnSets),s)));
+      # type of action on blocks
+      if TransitiveGroupsAvailable(Length(dom)/Length(s)) then
+	Add(p,TransitiveIdentification(Action(G,Orbit(G,s,OnSets),OnSets)));
+      fi;
+
+      # type of action on blocks
+      if TransitiveGroupsAvailable(Length(s)) then
+	Add(p,TransitiveIdentification(Action(Stabilizer(G,s,OnSets),s)));
+      fi;
     fi;
 
     if Length(p)=1 then
@@ -1302,7 +1307,9 @@ syll, act, typ, sel, bas, wdom, comp, lperm, other, away, i, j,b0,opg;
 
       syll:=SymmetricGroup(ll);
       # if the degrees are small enough, even get local types
-      if ll>1 and TransitiveGroupsAvailable(ll) then
+      if ll>1 and TransitiveGroupsAvailable(ll) 
+        and ValueOption(NO_PRECOMPUTED_DATA_OPTION)<>true then
+	Info(InfoPerformance,2,"Using Transitive Groups Library");
 	Info(InfoGroup,1,"Length ",ll," sort by types");
 	act:=[];
 	typ:=[];

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -1367,9 +1367,16 @@ local badsizes,n,un,cl,r,i,l,u,bw,cnt,gens,go,imgs,bg,bi,emb,nu,k,j,
       Error(
         "failed due to incomplete information in the Holt/Plesken library");
     fi;
+
     cl:=Filtered(ConjugacyClasses(G),i->Representative(i) in D);
     Info(InfoLattice,2,Length(cl)," classes of ",
          Length(ConjugacyClasses(G))," to consider");
+
+    if Length(un)>0 and ValueOption(NO_PRECOMPUTED_DATA_OPTION)=true then
+      Error("Cannot get perfect subgroups without data library!");
+    elif Length(un)>0 then
+      Info(InfoPerformance,2,"Using Perfect Groups Library");
+    fi;
 
     r:=[];
     for i in un do

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -2755,7 +2755,9 @@ InstallGlobalFunction("SubgroupsTrivialFitting",function(G)
 	if tom<>fail then
 	  go:=ImagesSource(tom[1]);
 	  tom:=tom[2];
-	  if tom<>fail then
+	  if tom<>fail and
+	   ValueOption(NO_PRECOMPUTED_DATA_OPTION)<>true then
+	    Info(InfoPerformance,2,"Using Table of Marks Library");
 	    Info(InfoLattice,1, "Fetching subgroups of simple ",
 	      Identifier(tom)," from table of marks");
 	    len:=LengthsTom(tom);
@@ -2827,9 +2829,11 @@ local dom,n,t,map;
     map:=ConjugatorIsomorphism(G,map);
   fi;
 
-  if IsPackageMarkedForLoading("tomlib","")<>true then
+  if IsPackageMarkedForLoading("tomlib","")<>true or
+          ValueOption(NO_PRECOMPUTED_DATA_OPTION)=true then
     return fail; # no tomlib available
   fi;
+  Info(InfoPerformance,2,"Using Table of Marks Library");
   t:=TableOfMarks(Concatenation("A",String(n)));
   if t=fail then
     return fail;
@@ -2875,9 +2879,11 @@ local T,t,hom,inf,nam,i,aut;
   # missing?
   if inf=fail then return fail;fi;
 
-  if IsPackageMarkedForLoading("tomlib","")<>true then # force tomlib load
+  if IsPackageMarkedForLoading("tomlib","")<>true or # force tomlib load
+          ValueOption(NO_PRECOMPUTED_DATA_OPTION)=true then
     return fail; # no tomlib available
   fi;
+  Info(InfoPerformance,2,"Using Table of Marks Library");
 
   nam:=inf.tomName;
 
@@ -2918,7 +2924,9 @@ end);
 InstallGlobalFunction(TomDataMaxesAlmostSimple,function(G)
 local recog,m;
   recog:=TomDataAlmostSimpleRecognition(G);
-  if recog=fail then return fail; fi;
+  if recog=fail then
+    return fail;
+  fi;
   m:=List(MaximalSubgroupsTom(recog[2])[1],i->RepresentativeTom(recog[2],i));
   Info(InfoLattice,1,"Recognition found ",Length(m)," classes");
   m:=List(m,i->PreImage(recog[1],i));
@@ -2928,7 +2936,9 @@ end);
 InstallGlobalFunction(TomDataSubgroupsAlmostSimple,function(G)
 local recog,m,len;
   recog:=TomDataAlmostSimpleRecognition(G);
-  if recog=fail then return fail; fi;
+  if recog=fail then
+    return fail;
+  fi;
   len:=LengthsTom(recog[2]);
   m:=List([1..Length(len)],i->RepresentativeTom(recog[2],i));
   Info(InfoLattice,1,"Recognition found ",Length(m)," classes");

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -2605,13 +2605,18 @@ end);
 
 InstallGlobalFunction("SubdirectSubgroups",function(D)
 local fgi,inducedfactorautos,projs,psubs,info,n,l,nl,proj,emb,u,pos,
-      subs,s,t,i,j,k,myid,myfgi,iso,dc,f,no,ind,g,hom;
+      subs,s,t,i,j,k,myid,myfgi,iso,dc,f,no,ind,g,hom,uselib;
+
+  uselib:=ValueOption(NO_PRECOMPUTED_DATA_OPTION)<>true;
+  if uselib then
+    Info(InfoPerformance,2,"Using Small Groups Library");
+  fi;
 
   fgi:=function(gp,nor)
   local idx,hom,l,f;
     idx:=Index(gp,nor);
     hom:=NaturalHomomorphismByNormalSubgroup(gp,nor);
-    if idx>1000 or idx=512 then
+    if idx>1000 or idx=512 or not uselib then
       l:=[idx,fail];
     else
       l:=ShallowCopy(IdGroup(gp/nor));
@@ -2685,7 +2690,7 @@ local fgi,inducedfactorautos,projs,psubs,info,n,l,nl,proj,emb,u,pos,
 	for k in no do
 	  hom:=NaturalHomomorphismByNormalSubgroup(j[1],k.representative);
 	  f:=Image(hom);
-	  if Size(f)<1000 and Size(f)<>512 then
+	  if Size(f)<1000 and Size(f)<>512 and uselib then
 	    myid:=ShallowCopy(IdGroup(f));
 	  else
 	    myid:=[Size(f),fail];

--- a/lib/grppcaut.gi
+++ b/lib/grppcaut.gi
@@ -508,6 +508,7 @@ end;
 if not IsBound( MyFingerprint ) then MyFingerprint := false; fi;
 
 FingerprintSmall := function( G, U )
+    Info(InfoPerformance,2,"Using Small Groups Library");
     return [IdGroup( U ), Size( CommutatorSubgroup(G,U) )];
 end;
 
@@ -536,7 +537,8 @@ Fingerprint := function ( G, U )
     if not IsBool( MyFingerprint ) then
         return MyFingerprint( G, U );
     fi;
-    if ID_AVAILABLE( Size( U ) ) <> fail then 
+    if ID_AVAILABLE( Size( U ) ) <> fail and
+      ValueOption(NO_PRECOMPUTED_DATA_OPTION)<>true then
         return FingerprintSmall( G, U );
     elif Size( U ) <= 1000 then
         return FingerprintMedium( G, U );

--- a/lib/init.g
+++ b/lib/init.g
@@ -559,6 +559,13 @@ CallAndInstallPostRestore( function()
        ShowKernelInformation();
      fi;
      end );
+
+#############################################################################
+##
+##  Name of option to avoid precomputed data libraries -- made a variable so
+##  it can still be changed easily
+##
+BindGlobal("NO_PRECOMPUTED_DATA_OPTION","NoPrecomputedData");
         
      
 if not ( GAPInfo.CommandLineOptions.q or GAPInfo.CommandLineOptions.b ) then

--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -2038,7 +2038,9 @@ local m;
 
   if Size(G)<>Size(H) then
     return fail;
-  elif ID_AVAILABLE(Size(G)) <> fail then
+  elif ID_AVAILABLE(Size(G)) <> fail
+    and ValueOption(NO_PRECOMPUTED_DATA_OPTION)<>true then
+    Info(InfoPerformance,2,"Using Small Groups Library");
     if IdGroup(G)<>IdGroup(H) then
       return fail;
     elif ValueOption("hard")=fail 

--- a/tst/teststandard/grplatt.tst
+++ b/tst/teststandard/grplatt.tst
@@ -187,6 +187,10 @@ gap> g:=Group(
 >     31)(19,41)(20,28)(21,24) ]);;
 gap> Length(MaximalSubgroupClassReps(g));
 6
+gap> Length(ConjugacyClassesSubgroups(SymmetricGroup(7)));
+96
+gap> Length(ConjugacyClassesSubgroups(SymmetricGroup(7):NoPrecomputedData));
+96
 
 # thats all, folks
 gap> STOP_TEST( "grplatt.tst", 364210000);

--- a/tst/teststandard/grpperm.tst
+++ b/tst/teststandard/grpperm.tst
@@ -177,6 +177,15 @@ gap> g:=TransitiveGroup(12,250);;
 gap> hom:=IsomorphismPcGroup(g);;
 gap> Length(ConjugacyClassesByHomomorphicImage(g,hom));
 65
+
+# test of data library use
+gap> SetInfoLevel(InfoPerformance,2);
+gap> Size(Normalizer(SymmetricGroup(12),PrimitiveGroup(12,2)));
+#I  Using Primitive Groups Library
+95040
+gap> Size(Normalizer(SymmetricGroup(12),
+> PrimitiveGroup(12,2):NoPrecomputedData));
+95040
 gap> STOP_TEST( "grpperm.tst", 1814420000);
 
 #############################################################################


### PR DESCRIPTION
### Tick all what applies to this pull request

- [x] Adds new features
- [x] Improves and extends functionality

### Write below the description of changes (for the release notes)
Add the function option `NoPrecomputedData` to turn off reliance on data libraries. This applies for all uses of Small groups/Tom/Prim/Trans data libraries in the main GAP library.

Added deocumentation in section on data libraries.
