### PR TITLE
ReadPackage error

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1192,6 +1192,9 @@ InstallGlobalFunction( ReadPackage, function( arg )
     if   Length( arg ) = 1 then
       # Guess the package name.
       pos:= Position( arg[1], '/' );
+      if pos = fail then
+        ErrorNoReturn(arg[1], " is not a filename in the form 'package/filepath'");
+      fi;
       relpath:= arg[1]{ [ pos+1 .. Length( arg[1] ) ] };
       pkgname:= LowercaseString( arg[1]{ [ 1 .. pos-1 ] } );
       namespace := GAPInfo.PackagesInfo.(pkgname)[1].PackageName;

--- a/tst/teststandard/package.tst
+++ b/tst/teststandard/package.tst
@@ -44,6 +44,8 @@ gap> for entry in Set( Concatenation( Concatenation( [ sml, equ ] ) ) ) do
 >     Error( "wrong result for ", [ entry, entry ], " and \"equal\"" );
 >   fi;
 > od;
+gap> ReadPackage("packagename");
+Error, packagename is not a filename in the form 'package/filepath'
 gap> STOP_TEST( "package.tst", 300000);
 
 #############################################################################


### PR DESCRIPTION
Improve error message when using `ReadPackage` to try and load a package, instead of `LoadPackage` (which I do at least once a week).

I briefly debated making `ReadPackage` just load the package, but decided that was a bit hacky.
