### PR TITLE
Add default filter in the manual of PerfectGroup

### DIFF
--- a/grp/perf.gd
+++ b/grp/perf.gd
@@ -166,10 +166,11 @@ DeclareSynonym("NrPerfectLibraryGroups",NumberPerfectLibraryGroups);
 ##  <M><A>n</A> = 1</M>.
 ##  The optional argument <A>filt</A> defines the filter in which the group is
 ##  returned.
-##  Possible filters so far are <Ref Func="IsPermGroup"/> and
-##  <Ref Func="IsSubgroupFpGroup"/>.
+##  Possible filters so far are <Ref Filt="IsPermGroup"/> and
+##  <Ref Filt="IsSubgroupFpGroup"/>.
 ##  In the latter case, the  generators and relators used coincide with those
 ##  given in&nbsp;<Cite Key="HP89"/>.
+##  The default filter is <Ref Filt="IsSubgroupFpGroup"/>.
 ##  <Example><![CDATA[
 ##  gap> G := PerfectGroup(IsPermGroup,6048,1);
 ##  U3(3)


### PR DESCRIPTION
This PR extends the manual by a sentence for ````PerfectGroup```` to make it clear that the default presentation is ````IsSubgroupFpGroup````

Should this go into stable, as well? If so, then do I need a separate PR for that, or can this be cherry-picked there?