### PR TITLE
trans: fix NrTransitiveGroups regression; better error handling

### DIFF
--- a/lib/grpperm.gd
+++ b/lib/grpperm.gd
@@ -300,9 +300,9 @@ DeclareGlobalFunction( "TransitiveGroupsAvailable" );
 
 # dummy declarations to satisfy library references to transitive groups
 # library
-DeclareGlobalFunction("NrTransitiveGroups","placeholder for transgrp package");
-DeclareGlobalFunction("TransitiveGroup","placeholder for transgrp package");
-DeclareGlobalFunction("TRANSProperties","placeholder for transgrp package");
+DeclareGlobalFunction( "NrTransitiveGroups", "placeholder for transgrp package" );
+DeclareGlobalFunction( "TransitiveGroup", "placeholder for transgrp package" );
+DeclareGlobalFunction( "TRANSProperties", "placeholder for transgrp package" );
 DeclareGlobalVariable( "TRANSSHAPEFREQS", "placeholder for transgrp package" );
 
 #############################################################################

--- a/trans/trans.grp
+++ b/trans/trans.grp
@@ -292,6 +292,9 @@ local Tbak,Fbak,flg,sel,i,fname;
 end);
 
 InstallGlobalFunction(TransitiveGroupsAvailable,function(deg)
+  if not IsPosInt(deg) then
+    Error("degree must be a positive integer");
+  fi;
   if deg>TRANSDEGREES then
     return false;
   fi;
@@ -342,8 +345,11 @@ InstallGlobalFunction(NrTransitiveGroups, function(deg)
   if deg=1 then
     return 0;
   fi;
+  if not IsPosInt(deg) then
+    Error("degree must be a positive integer");
+  fi;
   if not TransitiveGroupsAvailable(deg) then
-    return 0;
+    return fail;
   fi;
   return TRANSLENGTHS[deg];
 end);


### PR DESCRIPTION
This fixes a regression introduced in PR #825:

NrTransitiveGroups is documented to return fail for degrees which are not covered by the transitive groups library, but since that PR, it returned 0 instead.

Moreover, passing a non-positive degree lead to errors deeper in the code; instead of that, we now print a suitable error message.

