### PR TITLE
Travis: add explicit 'make config' and use parallel build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ matrix:
 
 script:
   - ./configure --with-gmp=system
-  - make
+  - make config
+  - make -j4
   - make bootstrap-pkg-full
   - bash etc/ci.sh


### PR DESCRIPTION
This PR adjusts the travis config in two ways:

1. We explicitly invoke `make config` before `make`. The only reason for this is that it makes it possible measure the time `configure` takes on travis separately from the actual compile time
2. We pass -j4 to `make` in order to potentially speed up the build time.

Now, I am not yet sure the latter has a noticable effect, the Travis docs are a bit fuzzy there, but I figured it's worth a shot :)