### PR TITLE
Quit evaluator if first symbol had syntax error 

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2679,6 +2679,11 @@ ExecStatus ReadEvalCommand ( Obj context, UInt *dualSemicolon )
     /* get the first symbol from the input                                 */
     Match( TLS(Symbol), "", 0UL );
 
+    /* using READ_ERROR sets the jump buffer and mucks up the interpreter */
+    if (TLS(NrError)) {
+        return STATUS_ERROR;
+    }
+
     /* if we have hit <end-of-file>, then give up                          */
     if ( TLS(Symbol) == S_EOF )  { return STATUS_EOF; }
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2126,32 +2126,32 @@ void GetChar ( void )
   /* skip '\''                                                           */
   GET_CHAR();
 
-  /* handle escape equences                                              */
-  if ( *TLS(In) == '\\' ) {
-    GET_CHAR();
-    TLS(Value)[0] = GetEscapedChar();
-  }
-  else if ( *TLS(In) == '\n' ) {
-    SyntaxError("Newline not allowed in character literal");
-  }
-  /* put normal chars into 'TLS(Value)'                                  */
-  else {
-    TLS(Value)[0] = *TLS(In);
-  }
-
-  /* read the next character                                             */
-  GET_CHAR();
-
-  /* check for terminating single quote                                  */
-  if ( *TLS(In) != '\'' )
-    SyntaxError("Missing single quote in character constant");
-
-  /* skip the closing quote                                              */
+  /* Make sure symbol is set */
   TLS(Symbol) = S_CHAR;
-  if ( *TLS(In) == '\'' )  GET_CHAR();
 
+  /* handle escape equences                                              */
+  if ( *TLS(In) == '\n' ) {
+    SyntaxError("Character literal must not include <newline>");
+  } else {
+    if ( *TLS(In) == '\\' ) {
+      GET_CHAR();
+      TLS(Value)[0] = GetEscapedChar();
+    } else {
+      /* put normal chars into 'TLS(Value)' */
+      TLS(Value)[0] = *TLS(In);
+    }
+
+    /* read the next character */
+    GET_CHAR();
+
+    /* check for terminating single quote, and skip */
+    if ( *TLS(In) == '\'' ) {
+      GET_CHAR();
+    } else {
+      SyntaxError("Missing single quote in character constant");
+    }
+  }
 }
-
 
 /****************************************************************************
  **

--- a/tst/testinstall/strings.tst
+++ b/tst/testinstall/strings.tst
@@ -67,10 +67,16 @@ gap> '\0x1bc';
 Syntax error: Missing single quote in character constant in stream:1
 '\0x1bc';
      ^
-Syntax error: ; expected in stream:2
-^
 gap> "\0x1bc";
 "\033c"
+gap> '
+Syntax error: Character literal must not include <newline> in stream:1
+'
+^
+gap> "
+Syntax error: String must not include <newline> in stream:1
+"
+^
 
 # Empty string
 gap> x:="";


### PR DESCRIPTION
Please make sure that this pull request:

- [x] is submitted to the correct branch (the stable branch is only for bugfixes)
- [x] contains an accurate description of changes for the release notes below
- [x] provides new tests or relies on existing ones
- [x] correctly refers to other issues and related pull requests

### Tick all what applies to this pull request

- [ ] Adds new features
- [ ] Improves and extends functionality
- [x] Fixes bugs that could lead to crashes
- [ ] Fixes bugs that could lead to incorrect results
- [ ] Fixes bugs that could lead to break loops

### Write below the description of changes (for the release notes)

This PR addresses #995.

If the parser encountered a syntax error in the first symbol it read, it did not abandon the expression it was trying to parse early enough. This lead to inconsistent state with the prompt `gap>` being printed, even though the interpreter is still waiting for the expression to finish parsing. 

