### PR TITLE
Fix bug in HasAvailableBytes not considering '0' a valid value for bufno

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -2332,7 +2332,7 @@ Int HasAvailableBytes( UInt fid )
       syBuf[fid].fp == -1)
     return -1;
 
-  if (syBuf[fid].bufno > 0)
+  if (syBuf[fid].bufno >= 0)
     {
       bufno = syBuf[fid].bufno;
       if (syBuffers[bufno].bufstart < syBuffers[bufno].buflen)


### PR DESCRIPTION
Fixes #1016.

Unfortunately there is no test included, as this can't be tested with a `.tst` file, and in any GAP test format we have, the test file is open!

However, I hope it is fairly obvious there is a bug here -- `bufno` is set to a value `>= 0` when in use, not `> 0` (which can be seen in various other places). It also fixes the reported problem.