### PR TITLE
Make BuildPackages.sh to accept packages as arguments, log into file and color the output

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -117,18 +117,35 @@ build_carat() {
 # It is not possible to move around compiled binaries because these have the
 # path to some data files burned in.
 zcat carat-2.1b1.tgz | tar pxf -
-ln -s carat-2.1b1/bin bin
+# If the symbolic link does not exist then create it.
+# Does not check if bin exists already with some content or as a file, etc.
+# Thus this code is unstable, but should be corrected by package author
+# and not by this script.
+if [[ ! -L ./bin ]]
+then
+  ln -s ./carat-2.1b1/bin ./bin
+fi
 cd carat-2.1b1
 make TOPDIR="$(pwd)"
 chmod -R a+rX .
 cd bin
-aa=$(./config.guess)
-# TODO dangerous to parse output of ls, use find instead
-# or better yet, use 'shopt -s nullglob' as with the packages
-for x in "$(ls -d1 $GAPDIR/bin/${aa}*)"
-do
-  ln -s "$aa" "$(basename $x)"
-done
+# This sets GAParch as it should be.
+# Alternatively, one could check $GAPDIR/bin for all directories instead.
+source "$GAPDIR/sysinfo.gap"
+# If the symbolic link does not exist then create it.
+if [[ ! -L ./"$GAParch" ]]
+then
+  shopt -s nullglob
+  # We assume that there is only one appropriate directory....
+  for archdir in *
+  do
+    if [[ -d "$archdir" ]] && [[ ! -L "$archdir" ]]
+    then
+      ln -s ./"$archdir" ./"$GAParch"
+    fi
+  done
+  shopt -u nullglob
+fi
 )
 }
 

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -153,7 +153,7 @@ buildpackage() {
   cd "$dir"
   case "$dir" in
     anupq*)
-      ./configure CFLAGS=-m32 LDFLAGS=-m32 --with-gaproot=$GAPDIR &&
+      ./configure "CFLAGS=-m32 LDFLAGS=-m32 --with-gaproot=$GAPDIR"
       "$MAKE" CFLAGS=-m32 LOPTS=-m32
     ;;
 
@@ -170,31 +170,31 @@ buildpackage() {
     ;;
 
     fplsa*)
-      ./configure "$GAPDIR" &&
+      ./configure "$GAPDIR"
       "$MAKE" CC="gcc -O2 "
     ;;
 
     kbmag*)
-      ./configure "$GAPDIR" &&
+      ./configure "$GAPDIR"
       "$MAKE" COPTS="-O2 -g"
     ;;
 
     NormalizInterface*)
-      ./build-normaliz.sh "$GAPDIR" &&
+      ./build-normaliz.sh "$GAPDIR"
       run_configure_and_make
     ;;
 
     pargap*)
-      ./configure "$GAPDIR" &&
-      "$MAKE" &&
-      cp bin/pargap.sh "$GAPDIR/bin" &&
+      ./configure "$GAPDIR"
+      "$MAKE"
+      cp bin/pargap.sh "$GAPDIR/bin"
       rm -f ALLPKG
     ;;
 
     xgap*)
-      ./configure --with-gaproot="$GAPDIR" &&
-      "$MAKE" &&
-      rm -f "$GAPDIR/bin/xgap.sh" &&
+      ./configure --with-gaproot="$GAPDIR"
+      "$MAKE"
+      rm -f "$GAPDIR/bin/xgap.sh"
       cp bin/xgap.sh "$GAPDIR/bin"
     ;;
 

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -83,7 +83,7 @@ then
   exit 1
 fi
 
-if (grep 'ABI_CFLAGS=-m32' $GAPDIR/Makefile > /dev/null)
+if [[ "$(grep -c 'ABI_CFLAGS=-m32' $GAPDIR/Makefile)" -ge 1 ]]
 then
   echo "Building with 32-bit ABI"
   ABI32=YES
@@ -253,7 +253,7 @@ do
     fi
 
     # remove log files if package needed no compilation
-    if [[ $(grep -c 'No building required for' "$LOGDIR/$PKG.log") -ge 1 ]]
+    if [[ "$(grep -c 'No building required for' $LOGDIR/$PKG.log)" -ge 1 ]]
     then
       rm -f "$LOGDIR/$PKG.err"
       rm -f "$LOGDIR/$PKG.out"

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -8,6 +8,22 @@ mkdir -p "$LOGDIR"
 LOGFILE=buildpackages
 FAILPKGFILE=fail
 
+# print notices in green
+notice() {
+    printf "\033[32m%s\033[0m\n" "$@"
+}
+
+# print warnings in yellow
+warning() {
+    printf "\033[33mWARNING: %s\033[0m\n" "$@"
+}
+
+# print error in red and exit
+error() {
+    printf "\033[31mERROR: %s\033[0m\n" "$@"
+    exit 1
+}
+
 build_packages() {
 
 # This script attempts to build all GAP packages contained in the current
@@ -32,9 +48,8 @@ build_packages() {
 # Is someone trying to run us from inside the 'bin' directory?
 if [[ -f gapicon.bmp ]]
 then
-  echo "This script must be run from inside the pkg directory"
-  echo "Type: cd ../pkg; ../bin/BuildPackages.sh"
-  exit 1
+  error "This script must be run from inside the pkg directory" \
+        "Type: cd ../pkg; ../bin/BuildPackages.sh"
 fi
 
 # CURDIR
@@ -60,7 +75,7 @@ else
   GAPDIR="$(pwd)"
   cd "$CURDIR"
 fi
-echo "Using GAP location: $GAPDIR"
+notice "Using GAP location: $GAPDIR"
 
 # pakcages to build
 if [[ "$#" -ge 1 ]]
@@ -77,15 +92,14 @@ fi
 # We need to test if $GAPDIR is right
 if ! [[ -f "$GAPDIR/sysinfo.gap" ]]
 then
-  echo "$GAPDIR is not the root of a gap installation (no sysinfo.gap)"
-  echo "Please provide the absolute path of your GAP root directory as"
-  echo "first argument to this script."
-  exit 1
+  error "$GAPDIR is not the root of a gap installation (no sysinfo.gap)" \
+        "Please provide the absolute path of your GAP root directory as" \
+        "first argument to this script."
 fi
 
 if [[ "$(grep -c 'ABI_CFLAGS=-m32' $GAPDIR/Makefile)" -ge 1 ]]
 then
-  echo "Building with 32-bit ABI"
+  notice "Building with 32-bit ABI"
   ABI32=YES
   CONFIGFLAGS="CFLAGS=-m32 LDFLAGS=-m32 LOPTS=-m32 CXXFLAGS=-m32"
 fi
@@ -100,14 +114,13 @@ else
   MAKE=make
 fi
 
-cat <<EOF
-Attempting to build GAP packages.
-Note that many GAP packages require extra programs to be installed,
-and some are quite difficult to build. Please read the documentation for
-packages which fail to build correctly, and only worry about packages
-you require!
-Logging into ./$LOGDIR/$LOGFILE.log
-EOF
+notice \
+"Attempting to build GAP packages." \
+"Note that many GAP packages require extra programs to be installed," \
+"and some are quite difficult to build. Please read the documentation for" \
+"packages which fail to build correctly, and only worry about packages" \
+"you require!" \
+"Logging into ./$LOGDIR/$LOGFILE.log"
 
 build_carat() {
 (
@@ -161,7 +174,7 @@ cd ../..
 
 build_fail() {
   echo ""
-  echo "=* Failed to build $PKG"
+  warning "Failed to build $PKG"
   echo "$PKG" >> "$LOGDIR/$FAILPKGFILE.log"
 }
 
@@ -182,7 +195,7 @@ run_configure_and_make() {
     fi
     "$MAKE"
   else
-    echo "No building required for $PKG"
+    notice "No building required for $PKG"
   fi
 }
 
@@ -192,7 +205,7 @@ build_one_package() {
   echo ""
   date
   echo ""
-  echo "==== Checking $PKG"
+  notice "==== Checking $PKG"
   (  # start subshell
   set -e
   cd "$CURDIR/$PKG"
@@ -281,8 +294,8 @@ done
 
 echo "" >> "$LOGDIR/$FAILPKGFILE.log"
 echo ""
-echo "Output logged into ./$LOGDIR/$LOGFILE.log"
-echo "Packages failed to build are in ./$LOGDIR/$FAILPKGFILE.log"
+notice "Output logged into ./$LOGDIR/$LOGFILE.log"
+notice "Packages failed to build are in ./$LOGDIR/$FAILPKGFILE.log"
 # end of build_all_packages
 }
 

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-LOGDIR="log"
+LOGDIR=log
 mkdir -p "$LOGDIR"
 
-LOGFILE="buildpackages"
-FAILPKGFILE="fail"
+LOGFILE=buildpackages
+FAILPKGFILE=fail
 
 build_all_packages() {
 
@@ -39,7 +39,7 @@ else
 fi
 
 # Is someone trying to run us from inside the 'bin' directory?
-if [[ -f "gapicon.bmp" ]]
+if [[ -f gapicon.bmp ]]
 then
   echo "This script must be run from inside the pkg directory"
   echo "Type: cd ../pkg; ../bin/BuildPackages.sh"
@@ -59,7 +59,7 @@ fi
 if (cd "$SUBDIR" && grep 'ABI_CFLAGS=-m32' $GAPDIR/Makefile > /dev/null)
 then
   echo "Building with 32-bit ABI"
-  ABI32="YES"
+  ABI32=YES
   CONFIGFLAGS="CFLAGS=-m32 LDFLAGS=-m32 LOPTS=-m32 CXXFLAGS=-m32"
 fi
 
@@ -68,9 +68,9 @@ fi
 # is BSD make, not GNU make.
 if ! [[ "x$(which gmake)" = "x" ]]
 then
-  MAKE="gmake"
+  MAKE=gmake
 else
-  MAKE="make"
+  MAKE=make
 fi
 
 cat <<EOF

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -224,8 +224,6 @@ do
       rm -f "$LOGDIR/$PKG.err"
       rm -f "$LOGDIR/$PKG.out"
     fi
-  else
-    echo "$PKG is not a GAP package -- no PackageInfo.g"
   fi
 done
 

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -224,6 +224,14 @@ do
       rm -f "$LOGDIR/$PKG.err"
       rm -f "$LOGDIR/$PKG.out"
     fi
+
+    # remove log files if package needed no compilation
+    if [[ $(grep -c 'No building required for' "$LOGDIR/$PKG.log") -ge 1 ]]
+    then
+      rm -f "$LOGDIR/$PKG.err"
+      rm -f "$LOGDIR/$PKG.out"
+      rm -f "$LOGDIR/$PKG.log"
+    fi
   fi
 done
 


### PR DESCRIPTION
Log every package to different file with Buildpackages.sh fixing #1014, and handle packages given as arguments

The first argument should give the gaproot directory with ````--with-gaproot=````. All further arguments are considered package directories (their names have to be complete!). If first argument does not start with ````--with-gaproot=````, then it is also considered a package to be built. If no packages are given as arguments, then everything is built.

For better readability, added an extra empty line before checking a new package, 
and also before reporting that a package is failed to compile. This latter line is colored by yellow and preceded by ````WARNING````. Errors are red, text written by the script is green. 

Packages failed to build are logged to ````pkg/log/fail.log````, together with a
date of when they failed.

Every package ````PKG```` build output is logged to a file in ````pkg/log/$PKG.log````.
The whole output is written into ````pkg/log/buildpackages.log````.

If there is ````stderr```` output, it is written to ````.err```` files, then the ````stdout````
output is written to ````.out```` files. The ````.log```` files contain the whole output
in sequence. Every file contains the _colored_ text, ie. ````cat```` understands it and will print to the screen in a colored way. 

Every ````.log````, ````.out````, ````.err```` file is overwritten at every rerun of
````buildpackages.sh````, ***except*** for ````fail.log````, which is always appended
together with the date of the run.

Also, ````date```` is run and logged into every package log file to keep some track of when happened whatever happened.

Relative paths are replaced by absolute paths. 

Output of ````ls```` is dangerous to parse, replaced by ````shopt -s nullglob```` where appropriate.

Building carat is fixed.