### PR TITLE
Fix Z(6,3) segfaulting, and incorrect spelling of "finfield.c"

### DIFF
--- a/src/finfield.c
+++ b/src/finfield.c
@@ -1953,7 +1953,7 @@ Obj FuncZ2 ( Obj self, Obj p, Obj d)
 static StructGVarFilt GVarFilts [] = {
 
     { "IS_FFE", "obj", &IsFFEFilt,
-      FuncIS_FFE, "src/finifield.c:IS_FFE" },
+      FuncIS_FFE, "src/finfield.c:IS_FFE" },
 
     { 0 }
 
@@ -1967,19 +1967,19 @@ static StructGVarFilt GVarFilts [] = {
 static StructGVarFunc GVarFuncs [] = {
 
     { "CHAR_FFE_DEFAULT", 1, "z",
-      FuncCHAR_FFE_DEFAULT, "src/finifield.c:CHAR_FFE_DEFAULT" },
+      FuncCHAR_FFE_DEFAULT, "src/finfield.c:CHAR_FFE_DEFAULT" },
 
     { "DEGREE_FFE_DEFAULT", 1, "z",
-      FunDEGREE_FFE_DEFAULT, "src/finifield.c:DEGREE_FFE_DEFAULT" },
+      FunDEGREE_FFE_DEFAULT, "src/finfield.c:DEGREE_FFE_DEFAULT" },
 
     { "LOG_FFE_DEFAULT", 2, "z, root",
-      FuncLOG_FFE_DEFAULT, "src/finifield.c:LOG_FFE_DEFAULT" },
+      FuncLOG_FFE_DEFAULT, "src/finfield.c:LOG_FFE_DEFAULT" },
 
     { "INT_FFE_DEFAULT", 1, "z",
-      FuncINT_FFE_DEFAULT, "src/finifield.c:INT_FFE_DEFAULT" },
+      FuncINT_FFE_DEFAULT, "src/finfield.c:INT_FFE_DEFAULT" },
 
     { "Z", 1, "q",
-      FuncZ, "src/finifield.c:Z" },
+      FuncZ, "src/finfield.c:Z" },
 
     { 0 }
 
@@ -2008,7 +2008,7 @@ static Int InitKernel (
     InitGlobalBag( &SuccFF, "src/finfield.c:SuccFF" );
     InitGlobalBag( &TypeFF, "src/finfield.c:TypeFF" );
     InitGlobalBag( &TypeFF0, "src/finfield.c:TypeFF0" );
-    InitGlobalBag( &IntFF, "src/finifield.c:IntFF" );
+    InitGlobalBag( &IntFF, "src/finfield.c:IntFF" );
 
     /* install the functions that handle overflow                          */
     ImportFuncFromLibrary( "SUM_FFE_LARGE",  &SUM_FFE_LARGE  );

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -1928,7 +1928,10 @@ Obj FuncZ2 ( Obj self, Obj p, Obj d)
             {
               /* get the finite field                                                */
               ff = FiniteField( ip, id );
-              
+
+              if (ff == 0)
+                ErrorMayQuit("Z: <q> must be a positive prime power", 0, 0);
+
               /* make the root                                                       */
               return NEW_FFE( ff, (ip == 2 && id == 1 ? 1 : 2) );
             }

--- a/tst/teststandard/bugfix.tst
+++ b/tst/teststandard/bugfix.tst
@@ -3152,6 +3152,10 @@ gap> Length(oe.vectors); Length(oe.solutions);
 159
 0
 
+# 2016/12/20 (MH)
+gap> Z(6,3);
+Error, Z: <q> must be a positive prime power
+
 #############################################################################
 gap> STOP_TEST( "bugfix.tst", 831990000);
 


### PR DESCRIPTION
The crash occurred because upon calling Z(q,d), the kernel function `FuncZ2` simply computes `q^d`, and only checks whether it is less or equal 65536, but does not verify that it is a prime power. This is not so bad, as it next calls `FiniteField`, which actually catches this -- and return 0. But then `FuncZ2` blindly passes that value to `NEW_FFE`, which returned an invalid FFE object. The segfault then happens once GAP tries to do anything with that object, e.g. print it to the user...

The other commit replaces `finifield.c` by `finfield.c` inside `GVarFilts[]`, `GVarFuncs[]` and `InitKernel()`. These strings are printed if you do e.g. `Display(Z)` in GAP, and having a correct filename helps with quickly locating the source code... :)