### PR TITLE
travis: abort ci.sh as soon as there is an error

### DIFF
--- a/etc/cover2json.g
+++ b/etc/cover2json.g
@@ -3,50 +3,5 @@ if LoadPackage("profiling") <> true then
     FORCE_QUIT_GAP(1);
 fi;
 
-# CoverToJson is only here temporarily until its functionality has been
-# published as part of the profiling package.
-if not IsBound(CoverToJson) then
-CoverToJson := function(data, outfile)
-    local outstream, lineinfo, prev, file, lines;
-
-    outfile := USER_HOME_EXPAND(outfile);
-    outstream := IO_File(outfile, "w");
-
-    if not(IsRecord(data)) then
-      data := ReadLineByLineProfile(data);
-    fi;
-
-    lineinfo := function(lineno, stat)
-        if stat[1] > 0 then
-            if stat[2] > 0 then
-                return STRINGIFY("\"", lineno, "\": \"1\"");
-            else
-                return STRINGIFY("\"", lineno, "\": \"0\"");
-            fi;
-        fi;
-        return "";
-    end;
-
-    IO_Write(outstream, "{ \"coverage\": {\n");
-    prev := false;
-
-    for file in data.line_info do
-        if file[1] <> "stream" then
-            if prev then
-                IO_Write(outstream, ",\n");
-            fi;
-            IO_Write(outstream, Concatenation("\"", file[1], "\": {\n" ));
-            lines := List([1..Length(file[2])], n -> lineinfo(n, file[2][n]));
-            lines := Filtered(lines, l -> Length(l) > 0);
-            IO_Write(outstream, JoinStringsWithSeparator(lines, ",\n"));
-            IO_Write(outstream, "}\n");
-            prev := true;
-        fi;
-    od;
-    IO_Write(outstream, "} }");
-    IO_Close(outstream);
-end;
-fi;
-
-CoverToJson("coverage", "coverage.json");
+OutputJsonCoverage("coverage", "coverage.json");
 QUIT_GAP(0);

--- a/etc/cover2json.g
+++ b/etc/cover2json.g
@@ -1,9 +1,11 @@
-# This file is only here temporarily until
-# its functionality has been published as part
-# of the profiling package.
+if LoadPackage("profiling") <> true then
+    Print("ERROR: could not load profiling package");
+    FORCE_QUIT_GAP(1);
+fi;
 
-LoadPackage("profiling");
-
+# CoverToJson is only here temporarily until its functionality has been
+# published as part of the profiling package.
+if not IsBound(CoverToJson) then
 CoverToJson := function(data, outfile)
     local outstream, lineinfo, prev, file, lines;
 
@@ -44,4 +46,7 @@ CoverToJson := function(data, outfile)
     IO_Write(outstream, "} }");
     IO_Close(outstream);
 end;
+fi;
 
+CoverToJson("coverage", "coverage.json");
+QUIT_GAP(0);


### PR DESCRIPTION
This PR sets the `-e` flag for `etc/ci.sh`, causing the script to abort as soon as any command in it fails. This way, if a build is broken due to outside circumstances (e.g. because gap-system.org it failed to download bootstrap packages), it doesn't blindly plunge ahead, but rather stops immediately.

This just affected me: Travis failed to download stuff from St Andrews:
```
The command "make -j4" exited with 0.
$ make bootstrap-pkg-full
--2016-12-21 16:23:55--  http://www.gap-system.org/pub/gap/gap4pkgs/bootstrap-pkg-full.tar.gz
Resolving www.gap-system.org (www.gap-system.org)... 138.251.206.223
Connecting to www.gap-system.org (www.gap-system.org)|138.251.206.223|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://palain.cs.st-andrews.ac.uk/pub/gap/gap4pkgs/bootstrap-pkg-full.tar.gz [following]
--2016-12-21 16:23:56--  https://palain.cs.st-andrews.ac.uk/pub/gap/gap4pkgs/bootstrap-pkg-full.tar.gz
Resolving palain.cs.st-andrews.ac.uk (palain.cs.st-andrews.ac.uk)... 138.251.206.223
Connecting to palain.cs.st-andrews.ac.uk (palain.cs.st-andrews.ac.uk)|138.251.206.223|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2016-12-21 16:23:57 ERROR 404: Not Found.
tar (child): ../bootstrap-pkg-full.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
make: *** [bootstrap-pkg-full] Error 2
The command "make bootstrap-pkg-full" exited with 2.

318.73s$ bash etc/ci.sh
```
At this point, I would have expected Travis to stop anyway, but apparently it doesn't (see also https://github.com/travis-ci/travis-ci/issues/1066 ), and just plows ahead:
```
etc/ci.sh: line 22: cd: pkg/io*: No such file or directory
checking for gcc... gcc
checking whether the C compiler works... yes
...
```
At this point, you can see that a `cd` command in `etc/ci.sh` fails, but it goes on anyway. With this PR, it would have aborted at that point. The great advantage of that is that it becomes easier to figure out what went wrong -- in the current setup lots and lots of additional error messages follow, and if you start reading the log at the bottom, you have to wade through irrelevant errors.