### PR TITLE
Fix bug in FixedPoints for a partial perm coll

### DIFF
--- a/lib/pperm.gi
+++ b/lib/pperm.gi
@@ -740,7 +740,7 @@ InstallMethod(MovedPoints, "for a partial perm coll",
 [IsPartialPermCollection], coll-> Union(List(coll, MovedPoints)));
 
 InstallMethod(NrFixedPoints, "for a partial perm coll",
-[IsPartialPermCollection], coll-> Length(MovedPoints(coll)));
+[IsPartialPermCollection], coll-> Length(FixedPointsOfPartialPerm(coll)));
 
 InstallMethod(NrMovedPoints, "for a partial perm coll",
 [IsPartialPermCollection], coll-> Length(MovedPoints(coll)));

--- a/lib/semipperm.gi
+++ b/lib/semipperm.gi
@@ -109,7 +109,7 @@ s-> ImageOfPartialPermCollection(GeneratorsOfSemigroup(s)));
 
 InstallMethod(FixedPointsOfPartialPerm, "for a partial perm semigroup",
 [IsPartialPermSemigroup],
-s-> MovedPoints(GeneratorsOfSemigroup(s)));
+s-> FixedPointsOfPartialPerm(GeneratorsOfSemigroup(s)));
 
 InstallMethod(MovedPoints, "for a partial perm semigroup",
 [IsPartialPermSemigroup],

--- a/tst/testinstall/semipperm.tst
+++ b/tst/testinstall/semipperm.tst
@@ -1,0 +1,41 @@
+#############################################################################
+##
+#W  semipperm.tst
+#Y  James D. Mitchell
+##
+#############################################################################
+##
+gap> START_TEST("semipperm.tst");
+
+# Test DisplayString
+gap> S := Semigroup(PartialPerm([1, 2, 3], [4, 5, 11]), 
+>                   PartialPerm([1], [3]));;
+gap> DisplayString(S);
+"\><\>partial perm\< \>semigroup\< \>of\< \>rank \>3\<\< \>with\< \>2\< \>gene\
+rators\<>\<"
+
+# Test Fixed/moved points etc
+gap> S := Semigroup(PartialPerm([1, 2, 3, 4, 6, 7, 10], [10, 8, 4, 6, 5, 3, 2]),
+>              PartialPerm([1, 2, 4, 5, 6, 9, 10], [3, 5, 8, 4, 1, 9, 7]),
+>              PartialPerm([1, 2, 4, 7, 9], [5, 3, 7, 4, 9]),
+>              PartialPerm([1, 2, 3, 4, 6, 8], [5, 1, 10, 7, 8, 9]));
+<partial perm semigroup of rank 10 with 4 generators>
+gap> FixedPointsOfPartialPerm(S);
+[ 9 ]
+gap> MovedPoints(S);
+[ 1, 2, 3, 4, 5, 6, 7, 8, 10 ]
+gap> NrFixedPoints(S);
+1
+gap> NrMovedPoints(S);
+9
+gap> LargestMovedPoint(S);
+10
+gap> LargestImageOfMovedPoint(S);
+10
+gap> SmallestMovedPoint(S);
+1
+gap> SmallestImageOfMovedPoint(S);
+1
+
+#
+gap> STOP_TEST( "semipperm.tst", 10000);


### PR DESCRIPTION

Please make sure that this pull request:

- [X] is submitted to the correct branch (the stable branch is only for bugfixes)
- [X] contains an accurate description of changes for the release notes below
- [X] provides new tests or relies on existing ones
- [X] correctly refers to other issues and related pull requests

### Tick all what applies to this pull request

- [ ] Adds new features
- [ ] Improves and extends functionality
- [ ] Fixes bugs that could lead to crashes
- [X] Fixes bugs that could lead to incorrect results
- [ ] Fixes bugs that could lead to break loops

### Write below the description of changes (for the release notes)
Previously `NrFixedPoints` and `FixedPointsOfPartialPerm`  for a partial perm and a partial perm semigroup, respectively, returned the moved points instead. Also some tests are added.
