### PR TITLE
Fix bug in MeetOfPartialPerms

### DIFF
--- a/lib/pperm.gi
+++ b/lib/pperm.gi
@@ -167,20 +167,23 @@ end);
 
 InstallGlobalFunction(MeetOfPartialPerms, 
 function(arg)
-  local meet, i;
-
-  if IsPartialPermCollection(arg[1]) then 
+  local meet, i, empty;
+  
+  if Length(arg) = 1 and IsPartialPermCollection(arg[1]) then 
     return CallFuncList(MeetOfPartialPerms, AsList(arg[1]));
   elif not IsPartialPermCollection(arg) then 
-    Error("usage: the argument should be a collection of partial perms,");
+    Error("usage: the argument should be a collection of partial perms, ");
     return;
   fi;
 
-  meet:=arg[1]; i:=1;
-  repeat
-    i:=i+1;
-    meet:=MEET_PPERMS(meet, arg[i]);
-  until i=Length(arg) or meet=EmptyPartialPerm();
+  meet := arg[1]; 
+  i := 1;
+  empty := EmptyPartialPerm();
+
+  while i < Length(arg) and meet <> empty do
+    i := i + 1;
+    meet := MEET_PPERMS(meet, arg[i]);
+  od;
     
   return meet;
 end);

--- a/tst/testinstall/pperm.tst
+++ b/tst/testinstall/pperm.tst
@@ -670,6 +670,18 @@ gap> g:=PartialPermNC([100001,2,3,4,5]);
 [1,100001](2)(3)(4)(5)
 gap> MeetOfPartialPerms(f,g);
 <identity partial perm on [ 2, 3, 4, 5 ]>
+gap> MeetOfPartialPerms(PartialPerm([1]));
+<identity partial perm on [ 1 ]>
+gap> MeetOfPartialPerms(PartialPerm([1]), PartialPerm([2]));
+<empty partial perm>
+gap> MeetOfPartialPerms(PartialPerm([1]), PartialPerm([1, 2]));
+<identity partial perm on [ 1 ]>
+gap> MeetOfPartialPerms([]);
+Error, usage: the argument should be a collection of partial perms, 
+gap> MeetOfPartialPerms([PartialPerm([1]), PartialPerm([1, 2])]);
+<identity partial perm on [ 1 ]>
+gap> MeetOfPartialPerms(SymmetricInverseMonoid(3));
+<empty partial perm>
 
 # RestrictedPartialPerm
 gap> f:=PartialPermNC([100000,2,3,4,5]);


### PR DESCRIPTION
Please make sure that this pull request:

- [X] is submitted to the correct branch (the stable branch is only for bugfixes)
- [X] contains an accurate description of changes for the release notes below
- [X] provides new tests or relies on existing ones
- [X] correctly refers to other issues and related pull requests

### Tick all what applies to this pull request

- [ ] Adds new features
- [ ] Improves and extends functionality
- [ ] Fixes bugs that could lead to crashes
- [ ] Fixes bugs that could lead to incorrect results
- [X] Fixes bugs that could lead to break loops

### Write below the description of changes (for the release notes)
Previously if the argument was empty or of length 1, then this function
would error by trying to access unbound list entries. This commit fixes this, and adds tests.