### PR TITLE
Fix AsPartialPerm method for transformations

### DIFF
--- a/doc/ref/pperm.xml
+++ b/doc/ref/pperm.xml
@@ -1068,7 +1068,6 @@ gap> AsPartialPerm(f, [ 1, 2, 3 ] );
       set of positive integer"/> 
     <Meth Name="AsPartialPerm" Arg="f, n" Label="for a transformation and a
       positive integer"/> 
-    <Meth Name="AsPartialPerm" Arg="f" Label="for a transformation"/>
   <Returns>A partial permutation or <K>fail</K>.</Returns>
   <Description>
     A transformation <A>f</A> defines a partial permutation when it is
@@ -1095,33 +1094,19 @@ gap> AsPartialPerm(f, [ 1, 2, 3 ] );
         integer and this set satisfies the
         conditions given above.
       </Item>
-      <Mark>for a transformation</Mark>
-      <Item> 
-        Let <C>n</C> denote the degree of <A>f</A>. If 
-        <C>n^<A>f</A>=n</C> and <A>f</A> is injective on those <C>i</C> such
-        that <C>i^<A>f</A>&lt;>n</C>, then <C>AsPartialPerm</C> returns
-        the partial permutation obtained by restricting <A>f</A> to those
-        <C>i</C> such that <C>i^<A>f</A>&lt;>n</C>.
-      </Item>
     </List>
-
-    <C>AsPartialPerm</C> returns <K>fail</K> if the arguments do not describe a
-    partial permutation.<P/>
 
     The operation <Ref Oper="PartialPermOp"/> can also be used to convert
     transformations into partial permutations.
 
   <Example>
 gap> f:=Transformation( [ 8, 3, 5, 9, 6, 2, 9, 7, 9 ] );;
-gap> AsPartialPerm(f);
-[1,8,7](2,3,5,6)
+gap> AsPartialPerm(f, [1, 2, 3, 5, 8]);
+[1,8,7][2,3,5,6]
 gap> AsPartialPerm(f, 3);
 [1,8][2,3,5]
 gap> AsPartialPerm(f, [ 2 .. 4 ] );
-[2,3,5][4,9]
-gap> f:=Transformation( [ 2, 10, 2, 4, 4, 7, 6, 9, 10, 1 ] );;
-gap> AsPartialPerm(f);
-fail</Example>
+[2,3,5][4,9]</Example>
   </Description>
 </ManSection>
 </Section>

--- a/lib/pperm.gi
+++ b/lib/pperm.gi
@@ -229,14 +229,12 @@ InstallMethod(AsPartialPerm, "for a transformation and list",
 [IsTransformation, IsList], 
 function(f, list)
   
-  if not IsSSortedList(list) or not ForAll(list, IsPosInt) 
-    or not ForAll(list, i-> i<=DegreeOfTransformation(f)) then 
-    Error("usage: the second argument must be a set of positive integers ", 
-    "not greater than the degree of the first argument,");
-    return;
+  if not IsSSortedList(list) or not ForAll(list, IsPosInt) then 
+    ErrorNoReturn("usage: the second argument must be a set of positive ",
+                  "integers,"); 
   elif not IsInjectiveListTrans(list, f) then 
-    Error("usage: the first argument must be injective on the second,");
-    return fail;
+    ErrorNoReturn("usage: the first argument must be injective on the ",
+                  "second,");
   fi;
   return PartialPermNC(list, OnTuples(list, f)); 
 end);
@@ -247,27 +245,6 @@ InstallMethod(AsPartialPerm, "for a transformation and positive int",
 [IsTransformation, IsPosInt], 
 function(f, n)
   return AsPartialPerm(f, [1..n]);
-end);
-
-# c method? JDM
-
-InstallMethod(AsPartialPerm, "for a transformation", 
-[IsTransformation],
-function(f)
-  local img, n;
-  n:=DegreeOfTransformation(f);
-  if not n^f=n then 
-    return fail; 
-  fi;
-  return PartialPerm(List([1..n], function(i) 
-    local j;
-    j:=i^f;
-    if j=n then 
-      return 0; 
-    else 
-      return j; 
-    fi;
-  end));
 end);
 
 # n is image of undefined points 

--- a/tst/testinstall/pperm.tst
+++ b/tst/testinstall/pperm.tst
@@ -2286,8 +2286,6 @@ gap> AsTransformation(f);
 <transformation: 6,2,5,10,4,7,8,9,10>
 gap> AsTransformation(f, 12);
 <transformation: 6,2,5,12,4,7,8,9,12,10,12>
-gap> AsPartialPerm(last);
-[1,6,7,8,9][3,5,4](2)(10)
 gap> f;
 [1,6,7,8,9][3,5,4](2)(10)
 gap> f:=PartialPermNC([ 1, 3, 4, 5, 6, 9 ], [ 9, 10, 5, 7, 2, 8 ]);;
@@ -2295,8 +2293,6 @@ gap> AsTransformation(f);
 <transformation: 9,11,10,5,7,2,11,11,8,11>
 gap> AsTransformation(f);
 <transformation: 9,11,10,5,7,2,11,11,8,11>
-gap> AsPartialPerm(last)=f;
-true
 gap> OnTuples([1..DegreeOfPartialPerm(f)], f);
 [ 9, 10, 5, 7, 2, 8 ]
 gap> g:=PartialPermNC([ 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 19 ],


### PR DESCRIPTION
Please make sure that this pull request:

- [X] is submitted to the correct branch (the stable branch is only for bugfixes)
- [X] contains an accurate description of changes for the release notes below
- [X] provides new tests or relies on existing ones
- [X] correctly refers to other issues and related pull requests

### Tick all what applies to this pull request

- [ ] Adds new features
- [X] Improves and extends functionality
- [ ] Fixes bugs that could lead to crashes
- [ ] Fixes bugs that could lead to incorrect results
- [ ] Fixes bugs that could lead to break loops

### Write below the description of changes (for the release notes)
The previous method was written when transformations had a fixed degree,
and was incorrect when applied to a degree-less transformation (i.e. all
transformations in GAP since GAP 4.7).

The method, related tests and doc, for AsPartialPerm of a transformation
(and no further args) were removed. It is not very clear what such a
method should do.