### PR TITLE
Fix IsomorphismReesZeroMatrixSemigroup

### DIFF
--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -1355,8 +1355,8 @@ function(D, constructor)
   rms := constructor(G, mat);
 
   iso := function(x)
-    i := PositionProperty(R, y -> y in GreensRClassOfElement(D, x));
-    j := PositionProperty(L, y -> y in GreensLClassOfElement(D, x));
+    i := PositionProperty(R, y -> y in GreensRClassOfElement(Parent(D), x));
+    j := PositionProperty(L, y -> y in GreensLClassOfElement(Parent(D), x));
 
     if i = fail or j = fail then
       return fail;
@@ -1409,7 +1409,7 @@ end);
 InstallMethod(IsomorphismReesZeroMatrixSemigroup,
 "for a finite 0-simple", [IsSemigroup],
 function(S)
-  local D, inj;
+  local D, map, inj, inv;
 
   if not (IsZeroSimpleSemigroup(S) and IsFinite(S)) then
     Error("usage: the semigroup must be a finite 0-simple semigroup,");
@@ -1419,11 +1419,27 @@ function(S)
   D := First(GreensDClasses(S),
              x -> not IsMultiplicativeZero(S, Representative(x)));
 
-  inj := _InjectionPrincipalFactor(D, ReesZeroMatrixSemigroup);
+  map := _InjectionPrincipalFactor(D, ReesZeroMatrixSemigroup);
 
-  return MagmaIsomorphismByFunctionsNC(S, Range(inj),
-                                       x -> x ^ inj,
-                                       x -> x ^ InverseGeneralMapping(inj));
+  # the below is necessary since map is not defined on the zero of S 
+  inj := function(x)
+    if x = MultiplicativeZero(S) then
+      return MultiplicativeZero(Range(map));
+    fi;
+    return x ^ map;
+  end;
+  
+  inv := function(x)
+    if x = MultiplicativeZero(Range(map)) then
+      return MultiplicativeZero(S);
+    fi;
+    return x ^ InverseGeneralMapping(map);
+  end;
+
+  return MagmaIsomorphismByFunctionsNC(S, 
+                                       Range(map),
+                                       inj,
+                                       inv);
 end);
 
 #

--- a/tst/teststandard/reesmat.tst
+++ b/tst/teststandard/reesmat.tst
@@ -1101,6 +1101,38 @@ false
 gap> S := FreeSemigroup(1);;
 gap> R := ReesZeroMatrixSemigroup(S, [[S.1]]);;
 
+# Test IsomorphismReesZeroMatrixSemigroup 
+gap> BruteForceIsoCheck := function(iso)
+>   local x, y;
+>   if not IsInjective(iso) or not IsSurjective(iso) then
+>     return false;
+>   fi;
+>   for x in GeneratorsOfSemigroup(Source(iso)) do
+>     for y in GeneratorsOfSemigroup(Source(iso)) do
+>       if x ^ iso * y ^ iso <> (x * y) ^ iso then
+>         return false;
+>       fi;
+>     od;
+>   od;
+>   return true;
+> end;;
+gap> BruteForceInverseCheck := function(map)
+> local inv;
+>   inv := InverseGeneralMapping(map);
+>   return ForAll(Source(map), x -> x = (x ^ map) ^ inv)
+>     and ForAll(Range(map), x -> x = (x ^ inv) ^ map);
+> end;;
+gap> S := Semigroup(Transformation([1, 2, 1, 4, 1, 2]),
+>                   Transformation([1, 3, 1, 5, 1, 3]), 
+>                   Transformation([1, 1, 2, 1, 4, 4]));;
+gap> IsZeroSimpleSemigroup(S);
+true
+gap> map := IsomorphismReesZeroMatrixSemigroup(S);;
+gap> BruteForceIsoCheck(map);
+true
+gap> BruteForceInverseCheck(map);
+true
+
 #
 gap> STOP_TEST( "reesmat.tst", 54100000);
 


### PR DESCRIPTION
Please make sure that this pull request:

- [X] is submitted to the correct branch (the stable branch is only for bugfixes)
- [X] contains an accurate description of changes for the release notes below
- [X] provides new tests or relies on existing ones
- [ ] correctly refers to other issues and related pull requests

### Tick all what applies to this pull request

- [ ] Adds new features
- [ ] Improves and extends functionality
- [ ] Fixes bugs that could lead to crashes
- [X] Fixes bugs that could lead to incorrect results
- [X] Fixes bugs that could lead to break loops

### Write below the description of changes (for the release notes)
For a finite 0-simple semigroup, previously the isomorphism returned by `IsomorphismReesZeroMatrixSemigroup` was not defined on the zero of its domain or range.