### PR TITLE
Fix isomorphisms from fp monoid to fp semigroup

### DIFF
--- a/lib/fpmon.gd
+++ b/lib/fpmon.gd
@@ -213,7 +213,8 @@ DeclareAttribute("RelationsOfFpMonoid",IsFpMonoid);
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareAttribute("IsomorphismFpMonoid",IsMonoid);
+
+DeclareAttribute("IsomorphismFpMonoid",IsSemigroup);
 
 ############################################################################
 ##

--- a/lib/fpmon.gi
+++ b/lib/fpmon.gi
@@ -18,38 +18,38 @@
 #M  ElementOfFpMonoid( <fam>, <elm> )
 ##
 InstallMethod( ElementOfFpMonoid,
-	"for a family of f.p. monoid elements, and an assoc. word",
-	true,
-	[ IsElementOfFpMonoidFamily, IsAssocWordWithOne ],
-	0,
-	function( fam, elm )
-		return Objectify( fam!.defaultType, [ Immutable( elm ) ] );
-	end );
+        "for a family of f.p. monoid elements, and an assoc. word",
+        true,
+        [ IsElementOfFpMonoidFamily, IsAssocWordWithOne ],
+        0,
+        function( fam, elm )
+                return Objectify( fam!.defaultType, [ Immutable( elm ) ] );
+        end );
 
 #############################################################################
 ##
 #M  UnderlyingElement( <elm> )  . . . . . . for element of fp monoid 
 ##
 InstallMethod( UnderlyingElement,
-	"for an element of an fp monoid (default repres.)",
-	true,
-	[ IsElementOfFpMonoid and IsPackedElementDefaultRep ],
-	0,
-	obj -> obj![1] );
+        "for an element of an fp monoid (default repres.)",
+        true,
+        [ IsElementOfFpMonoid and IsPackedElementDefaultRep ],
+        0,
+        obj -> obj![1] );
 
 #############################################################################
 ##
 #M  \*( <x1>, <x2> )
 ##
 InstallMethod( \*,
-	"for two elements of a fp monoid",
-	IsIdenticalObj,
-	[ IsElementOfFpMonoid, IsElementOfFpMonoid],
-	0,
-	function( x1, x2 )
-		return ElementOfFpMonoid(FamilyObj(x1),
-						UnderlyingElement(x1)*UnderlyingElement(x2));
-	end );
+        "for two elements of a fp monoid",
+        IsIdenticalObj,
+        [ IsElementOfFpMonoid, IsElementOfFpMonoid],
+        0,
+        function( x1, x2 )
+                return ElementOfFpMonoid(FamilyObj(x1),
+                                                UnderlyingElement(x1)*UnderlyingElement(x2));
+        end );
 
 #############################################################################
 ##
@@ -82,11 +82,11 @@ InstallMethod( \=,
     [ IsElementOfFpMonoid, IsElementOfFpMonoid],
     0,
     function( x1, x2 )
-			local m,rws;
+                        local m,rws;
 
-			m := CollectionsFamily(FamilyObj(x1))!.wholeMonoid;
+                        m := CollectionsFamily(FamilyObj(x1))!.wholeMonoid;
       rws:= ReducedConfluentRewritingSystem(m);
-	
+        
       return ReducedForm(rws, UnderlyingElement(x1)) =
           ReducedForm(rws, UnderlyingElement(x2));
 
@@ -140,16 +140,16 @@ end );
 #M  FpMonoidOfElementOfFpMonoid( <elm> )
 ##
 InstallMethod( FpMonoidOfElementOfFpMonoid,
-	"for an fp monoid element", true,
-	[IsElementOfFpMonoid], 0,
-	elm -> CollectionsFamily(FamilyObj(elm))!.wholeMonoid);
+        "for an fp monoid element", true,
+        [IsElementOfFpMonoid], 0,
+        elm -> CollectionsFamily(FamilyObj(elm))!.wholeMonoid);
 
 #############################################################################
 ##
 #M  FpGrpMonSmgOfFpGrpMonSmgElement( <elm> )
 ##
-##	for an fp monoid element <elm> returns the fp monoid to which
-##	<elm> belongs to 
+##      for an fp monoid element <elm> returns the fp monoid to which
+##      <elm> belongs to 
 ##
 InstallMethod(FpGrpMonSmgOfFpGrpMonSmgElement,
   "for an element of an fp monoid", true,
@@ -210,7 +210,7 @@ function( F, rels )
     if Length(gens) > Length(rels) then
       SetIsFinite(s, false);
     fi;
-	
+        
     return s;
 end);
 

--- a/tst/testinstall/fpmon.tst
+++ b/tst/testinstall/fpmon.tst
@@ -1,0 +1,24 @@
+#############################################################################
+##
+#W  fpmon.tst
+#Y  James D. Mitchell
+##
+#############################################################################
+##
+
+gap> START_TEST("fpmon.tst");
+
+# Test that the inverse of an isomorphism from an fp monoid to an fp semigroup
+# is really the inverse.
+gap> F := FreeMonoid(2);; 
+gap> rels := [ [ F.1^2, F.1 ], [ F.2^2, F.2 ], [ F.1*F.2*F.1, F.1*F.2 ], 
+> [ F.2*F.1*F.2, F.1*F.2 ] ];;
+gap> S := F / rels;
+<fp monoid on the generators [ m1, m2 ]>
+gap> map := IsomorphismFpSemigroup(S);;
+gap> inv := InverseGeneralMapping(map);;
+gap> ForAll(S, x -> (x ^ map) ^ inv = x);
+true
+
+#
+gap> STOP_TEST( "fpmon.tst", 10000);


### PR DESCRIPTION
Please make sure that this pull request:

- [X] is submitted to the correct branch (the stable branch is only for bugfixes)
- [X] contains an accurate description of changes for the release notes below
- [X] provides new tests or relies on existing ones
- [ ] correctly refers to other issues and related pull requests

### Tick all what applies to this pull request

- [X] Adds new features
- [ ] Improves and extends functionality
- [ ] Fixes bugs that could lead to crashes
- [ ] Fixes bugs that could lead to incorrect results
- [X] Fixes bugs that could lead to break loops

### Write below the description of changes (for the release notes)
There are two main changes in this PR:

1. Fix a bug in the method for `IsomorphismFpSemigroup` for a finitely presented monoid. Previously the inverse of the returned isomorphism was not properly defined (and not the inverse of the isomorphism)

2. Change the declaration of `IsomorphismFpMonoid` so that it can be applied to objects in `IsSemigroup` rather than only `IsMonoid`. A semigroup can be isomorphic to a monoid, while not being a monoid in the technical GAP sense. For example, the semigroup generated by
Transformation([1, 2, 3, 3, 3]) is not a monoid in the GAP sense but is mathematically. With this change we could now install methods for `IsomorphismFpMonoid` for such a semigroup.