### PR TITLE
Fix One/Zero/MultiplicativeZero for partial perms

### DIFF
--- a/doc/ref/pperm.xml
+++ b/doc/ref/pperm.xml
@@ -130,7 +130,7 @@ The fundamental attributes of a partial permutation are:
   union of its domain and its image, and the <E>zero</E> of a partial
   permutation is just the empty partial permutation; see 
   <Ref Oper="One" Label="for a partial perm"/> and
-  <Ref Oper="Zero" Label="for a partial perm"/>.
+  <Ref Oper="MultiplicativeZero" Label="for a partial perm"/>.
   <P/>
 
   If <C>S</C> is an arbitrary inverse semigroup, the <E>natural partial
@@ -980,15 +980,15 @@ gap> One(f);
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 
 <ManSection>
-  <Meth Name="Zero" Arg="f" Label="for a partial perm"/>
+  <Meth Name="MultiplicativeZero" Arg="f" Label="for a partial perm"/>
   <Returns>The empty partial permutation.</Returns>
   <Description>
-    As described in <Ref Attr="ZeroImmutable" BookName="ref"/>,
+    As described in <Ref Attr="MultiplicativeZero" BookName="ref"/>,
     <C>Zero</C> returns the multiplicative zero element of the partial
     permutation <A>f</A>, which is the empty partial permutation. 
     <Example>
-gap> f:=PartialPerm([ 1, 2, 3, 4, 5, 7, 10 ], [ 3, 7, 9, 6, 1, 10, 2 ]);;
-gap> Zero(f);
+gap> f := PartialPerm([ 1, 2, 3, 4, 5, 7, 10 ], [ 3, 7, 9, 6, 1, 10, 2 ]);;
+gap> MultiplicativeZero(f);
 &lt;empty partial perm></Example>
   </Description>
 </ManSection>

--- a/lib/arith.gd
+++ b/lib/arith.gd
@@ -373,6 +373,32 @@ DeclareSynonym( "IsMultiplicativeElementWithOneList",
 DeclareSynonym( "IsMultiplicativeElementWithOneTable",
     IsMultiplicativeElementWithOneCollColl   and IsTable );
 
+##  <#GAPDoc Label="IsMultiplicativeElementWithZero">
+##  <ManSection>
+##  <Filt Name="IsMultiplicativeElementWithZero" Arg='elt' Type='Category'/>
+##  <Returns><K>true</K> or <K>false</K>.</Returns>
+##  <Description>
+##  This is the category of elements in a family which can be the operands of 
+##  <C>*</C> (multiplication) and the operation 
+##  <Ref Attr="MultiplicativeZero"/>.
+##  <Example><![CDATA[
+##  gap> S:=Semigroup(Transformation( [ 1, 1, 1 ] ));;
+##  gap> M:=MagmaWithZeroAdjoined(S);
+##  <<commutative transformation semigroup of degree 3 with 1 generator>
+##    with 0 adjoined>
+##  gap> x:=Representative(M);
+##  <semigroup with 0 adjoined elt: Transformation( [ 1, 1, 1 ] )>
+##  gap> IsMultiplicativeElementWithZero(x);
+##  true
+##  gap> MultiplicativeZeroOp(x);
+##  <semigroup with 0 adjoined elt: 0>
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+
+DeclareCategory("IsMultiplicativeElementWithZero",IsMultiplicativeElement);
+DeclareCategoryCollections("IsMultiplicativeElementWithZero");
 
 #############################################################################
 ##

--- a/lib/mgmadj.gd
+++ b/lib/mgmadj.gd
@@ -10,32 +10,8 @@
 ##  This file contains declarations for magmas with zero adjoined.
 ##
 
-##  <#GAPDoc Label="IsMultiplicativeElementWithZero">
-##  <ManSection>
-##  <Filt Name="IsMultiplicativeElementWithZero" Arg='elt' Type='Category'/>
-##  <Returns><K>true</K> or <K>false</K>.</Returns>
-##  <Description>
-##  This is the category of elements in a family which can be the operands of 
-##  <C>*</C> (multiplication) and the operation 
-##  <Ref Attr="MultiplicativeZero"/>.
-##  <Example><![CDATA[
-##  gap> S:=Semigroup(Transformation( [ 1, 1, 1 ] ));;
-##  gap> M:=MagmaWithZeroAdjoined(S);
-##  <<commutative transformation semigroup of degree 3 with 1 generator>
-##    with 0 adjoined>
-##  gap> x:=Representative(M);
-##  <semigroup with 0 adjoined elt: Transformation( [ 1, 1, 1 ] )>
-##  gap> IsMultiplicativeElementWithZero(x);
-##  true
-##  gap> MultiplicativeZeroOp(x);
-##  <semigroup with 0 adjoined elt: 0>
-##  ]]></Example>
-##  </Description>
-##  </ManSection>
-##  <#/GAPDoc>
-
-DeclareCategory("IsMultiplicativeElementWithZero",IsMultiplicativeElement);
-DeclareCategoryCollections("IsMultiplicativeElementWithZero");
+# IsMultiplicativeElementWithZero is defined in arith.gd so that it can be read
+# in read1.g, and used in the kernel.
 
 ##  <#GAPDoc Label="MultiplicativeZeroOp">
 ##  <ManSection>

--- a/lib/mgmadj.gi
+++ b/lib/mgmadj.gi
@@ -10,6 +10,12 @@
 ##  This file contains generic methods for magmas with zero adjoined.
 ##
 
+InstallMethod(MultiplicativeZero, "for a multiplicative element with zero",
+[IsMultiplicativeElementWithZero], 
+function(x)
+  return MultiplicativeZeroOp(x);
+end);
+
 InstallMethod( IsMultiplicativeZero,
 "for magma with multiplicative zero and multiplicative element",
 IsCollsElms,

--- a/lib/pperm.g
+++ b/lib/pperm.g
@@ -1,6 +1,6 @@
 
 DeclareCategoryKernel("IsPartialPerm", IsMultiplicativeElementWithInverse 
-and IsAssociativeElement, IS_PPERM);
+and IsMultiplicativeElementWithZero and IsAssociativeElement, IS_PPERM);
 
 DeclareCategoryCollections( "IsPartialPerm" );
 DeclareCategoryCollections( "IsPartialPermCollection" );

--- a/lib/pperm.gd
+++ b/lib/pperm.gd
@@ -84,4 +84,7 @@ DeclareAttribute("RankOfPartialPermCollection", IsPartialPermCollection);
 DeclareAttribute("DomainOfPartialPermCollection", IsPartialPermCollection);
 DeclareAttribute("ImageOfPartialPermCollection", IsPartialPermCollection);
 
+DeclareAttribute("OneImmutable", IsPartialPermCollection);
+DeclareOperation("OneMutable", [IsPartialPermCollection]);
+
 InstallTrueMethod(IsGeneratorsOfInverseSemigroup, IsPartialPermCollection);

--- a/lib/pperm.gi
+++ b/lib/pperm.gi
@@ -762,21 +762,14 @@ InstallMethod(SmallestImageOfMovedPoint, "for a partial perm collection",
 [IsPartialPermCollection], 
 coll-> Minimum(List(coll, SmallestImageOfMovedPoint)));
 
-InstallOtherMethod(One, "for a partial perm coll", 
+InstallMethod(OneImmutable, "for a partial perm coll", 
 [IsPartialPermCollection], 
 function(x)
-  return JoinOfIdempotentPartialPermsNC(List(x, One)); 
+  return JoinOfIdempotentPartialPermsNC(List(x, OneImmutable)); 
 end);
 
-InstallOtherMethod(OneMutable, "for a partial perm coll", 
-[IsPartialPermCollection], 
-function(x)
-  return JoinOfIdempotentPartialPermsNC(List(x, One)); 
-end);
+InstallMethod(OneMutable, "for a partial perm coll", 
+[IsPartialPermCollection], OneImmutable);
 
-#
-
-InstallOtherMethod(ZeroMutable, "for a partial perm coll",
-[IsPartialPermCollection], MeetOfPartialPerms);
-
-#EOF
+InstallMethod(MultiplicativeZeroOp, "for a partial perm",
+[IsPartialPerm], x -> PartialPerm([]));

--- a/lib/semipperm.gi
+++ b/lib/semipperm.gi
@@ -31,24 +31,35 @@ function(S)
                        "\<\< ");
 end);
 
-InstallMethod(One, "for a partial perm semigroup with generators",
-[IsPartialPermSemigroup and HasGeneratorsOfSemigroup],
+InstallMethod(OneMutable, "for a partial perm semigroup",
+[IsPartialPermSemigroup], OneImmutable);
+
+# The next method matches more than one declaration, hence the
+# InstallOtherMethod to avoid warnings on startup
+
+InstallOtherMethod(OneImmutable, "for a partial perm semigroup",
+[IsPartialPermSemigroup],
 function(S)
   local x;
+  if HasGeneratorsOfSemigroup(S) then 
+    x := OneImmutable(GeneratorsOfSemigroup(S));
+  else 
+    x := OneImmutable(AsList(S));
+  fi;
 
-  x := One(GeneratorsOfSemigroup(S));
   if x in S then
     return x;
   fi;
   return fail;
 end);
 
-#
+# The next method matches more than one declaration, hence the
+# InstallOtherMethod to avoid warnings on startup
 
-InstallMethod(One, "for a partial perm monoid with generators", 
-[IsPartialPermMonoid and HasGeneratorsOfSemigroup],
-function(s)
-  return One(GeneratorsOfSemigroup(s));
+InstallOtherMethod(OneImmutable, "for a partial perm monoid", 
+[IsPartialPermMonoid],
+function(S)
+  return One(GeneratorsOfSemigroup(S));
 end);
 
 #
@@ -136,32 +147,6 @@ InstallMethod(SmallestMovedPoint, "for a partial perm semigroup",
 InstallMethod(SmallestImageOfMovedPoint, "for a partial perm semigroup",
 [IsPartialPermSemigroup], 
 s-> SmallestImageOfMovedPoint(GeneratorsOfSemigroup(s)));
-
-#
-
-InstallOtherMethod(OneMutable, "for a partial perm semigroup",
-[IsPartialPermSemigroup],
-function(s)
-  local  one;
-  one := One(GeneratorsOfSemigroup(s));
-  if one in s then
-    return one;
-  fi;
-  return fail;
-end);
-
-#
-
-InstallOtherMethod(ZeroMutable, "for a partial perm semigroup",
-[IsPartialPermSemigroup],
-function(s)
-  local  zero;
-  zero := Zero(GeneratorsOfSemigroup(s));
-  if zero in s then
-    return zero;
-  fi;
-  return fail;
-end);
 
 #
 

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -2157,10 +2157,6 @@ Obj FuncHAS_IMG_PPERM( Obj self, Obj f ){
 
 /* GAP kernel functions */
 
-Obj ZeroPPerm(Obj f){
-  return EmptyPartialPerm;
-}
-
 // an idempotent partial perm on the union of the domain and image 
 Obj OnePPerm( Obj f){
   Obj     g, img, dom;
@@ -5932,12 +5928,6 @@ static Int InitKernel ( StructInitInfo *module )
     LQuoFuncs [ T_PPERM2  ][ T_PPERM4 ] = LQuoPPerm24;
     LQuoFuncs [ T_PPERM4  ][ T_PPERM2 ] = LQuoPPerm42;
     LQuoFuncs [ T_PPERM4  ][ T_PPERM4 ] = LQuoPPerm44;
-    
-    /* install the zero function for partial perms */
-    ZeroFuncs [T_PPERM2] = ZeroPPerm;
-    ZeroFuncs [T_PPERM4] = ZeroPPerm;
-    ZeroMutFuncs [T_PPERM2] = ZeroPPerm;
-    ZeroMutFuncs [T_PPERM4] = ZeroPPerm;
     
     /* install the one function for partial perms */
     OneFuncs [T_PPERM2] = OnePPerm;

--- a/tst/testinstall/pperm.tst
+++ b/tst/testinstall/pperm.tst
@@ -2407,6 +2407,16 @@ gap> x := PartialPerm([70000], [1]);
 gap> CodegreeOfPartialPerm(x / x);
 70000
 
+# Test Zero and MultiplicativeZeroOp
+gap> x := PartialPerm([1, 2, 4, 7, 9], [5, 3, 7, 4, 9]);;
+gap> Zero(x);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `ZeroMutable' on 1 arguments
+gap> MultiplicativeZeroOp(x);
+<empty partial perm>
+gap> MultiplicativeZero(x);
+<empty partial perm>
+
 #
 gap> SetUserPreference("PartialPermDisplayLimit", display);;
 gap> SetUserPreference("NotationForPartialPerm", notationpp);;

--- a/tst/testinstall/semipperm.tst
+++ b/tst/testinstall/semipperm.tst
@@ -5,7 +5,15 @@
 ##
 #############################################################################
 ##
+
+#
 gap> START_TEST("semipperm.tst");
+
+#
+gap> PPermDisplayLimit := UserPreference("PartialPermDisplayLimit");;
+gap> PPermNotation := UserPreference("NotationForPartialPerms");;
+gap> SetUserPreference("PartialPermDisplayLimit", 100);
+gap> SetUserPreference("NotationForPartialPerms", "component");
 
 # Test DisplayString
 gap> S := Semigroup(PartialPerm([1, 2, 3], [4, 5, 11]), 
@@ -37,5 +45,63 @@ gap> SmallestMovedPoint(S);
 gap> SmallestImageOfMovedPoint(S);
 1
 
+# Test  One for a partial perm semigroup without generators
+gap> S := SymmetricInverseMonoid(3);;
+gap> I := SemigroupIdealByGenerators(S, [S.3]);;
+gap> HasGeneratorsOfSemigroup(I);
+false
+gap> One(I);
+fail
+gap> I := SemigroupIdealByGenerators(S, [S.1]);;
+gap> HasGeneratorsOfSemigroup(I);
+false
+gap> One(I);
+<identity partial perm on [ 1, 2, 3 ]>
+
+# Test  One for a partial perm monoid with generators
+gap> S := SymmetricInverseMonoid(3);;
+gap> One(S);
+<identity partial perm on [ 1, 2, 3 ]>
+gap> S := Semigroup(S);;
+gap> One(S);
+<identity partial perm on [ 1, 2, 3 ]>
+
+# Test  One for a partial perm semigroup with generators
+gap> S := Semigroup(PartialPerm([1, 2, 3], [4, 5, 11]), 
+>                   PartialPerm([1], [3]));;
+gap> One(S);
+fail
+gap> S := Semigroup(PartialPerm([2, 1, 3]));;
+gap> One(S);
+<identity partial perm on [ 1, 2, 3 ]>
+
+# Test MultiplicativeZero for partial perm semigroups
+gap> x := PartialPerm([1, 2, 4, 7, 9], [5, 3, 7, 4, 9]);;
+gap> S := InverseSemigroup(x);
+<inverse partial perm semigroup of rank 7 with 1 generator>
+gap> Zero(S);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `ZeroMutable' on 1 arguments
+gap> MultiplicativeZero(S);
+fail
+
+# Test MultiplicativeZero 
+gap> S := SymmetricInverseMonoid(5);
+<symmetric inverse monoid of degree 5>
+gap> MultiplicativeZero(S);
+<empty partial perm>
+gap> S := Monoid(PartialPerm([1]));;
+gap> MultiplicativeZero(S);
+<identity partial perm on [ 1 ]>
+gap> MultiplicativeZero(S);
+<identity partial perm on [ 1 ]>
+gap> S := Monoid(PartialPerm([2, 1]));;
+gap> MultiplicativeZero(S);
+fail
+
 #
-gap> STOP_TEST( "semipperm.tst", 10000);
+gap> SetUserPreference("PartialPermDisplayLimit", PPermDisplayLimit);;
+gap> SetUserPreference("NotationForPartialPerm", PPermNotation);;
+
+#
+gap> STOP_TEST( "semipperm.tst", 42710000);


### PR DESCRIPTION
Please make sure that this pull request:

- [X] is submitted to the correct branch (the stable branch is only for bugfixes)
- [X] contains an accurate description of changes for the release notes below
- [X] provides new tests or relies on existing ones
- [ ] correctly refers to other issues and related pull requests

### Tick all what applies to this pull request

- [ ] Adds new features
- [X] Improves and extends functionality
- [ ] Fixes bugs that could lead to crashes
- [X] Fixes bugs that could lead to incorrect results
- [ ] Fixes bugs that could lead to break loops

### Write below the description of changes (for the release notes)
There were several issues here:

1. some declarations were missing

2. for a partial perm semigroup without generators the default method or
a `One` of a partial perm collection was used. This always returned an
answer, when it shouldn't have it if the `One` was not in the semigroup.

3. partial perms and semigroups of partial perms had methods for `Zero`,
which according to the manual "return the additive neutral element of
the additive element". Since partial perms are not additive these
methods were inappropriate. As such they are removed in this PR and
methods for `MultiplicativeZero` are introduced instead. Partial perms 
should have belonged to the category `IsMultiplicativeElementWithZero`, 
and so I added this to the definition of `IsPartialPerm` in `pperm.g`. 
This meant moving the declaration of `IsMultiplicativeElementWithZero` 
from `mgmadj.gd` to `arith.gd` so that it is available when `pperm.g` is 
read (from `read1.g`). There was no default method for the attribute 
`MultiplicativeZero` for an object in `IsMultipicativeElementWithZero`
so I added one of these too, it simply calls `MultiplicativeZeroOp`. 

This commit fixes these issues.