### PR TITLE
kernel: add optimized versions of PROD_INTOBJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+autom4te.cache
 Makefile
 Makefile-*
 config.log

--- a/cnf/config.hin
+++ b/cnf/config.hin
@@ -376,6 +376,18 @@
 /* Define to 1 if you have the `_setjmp' function. */
 #undef HAVE__SETJMP
 
+/* Define to 1 if the system has the `__builtin_smulll_overflow' built-in
+   function */
+#undef HAVE___BUILTIN_SMULLL_OVERFLOW
+
+/* Define to 1 if the system has the `__builtin_smull_overflow' built-in
+   function */
+#undef HAVE___BUILTIN_SMULL_OVERFLOW
+
+/* Define to 1 if the system has the `__builtin_smul_overflow' built-in
+   function */
+#undef HAVE___BUILTIN_SMUL_OVERFLOW
+
 /* define as 1 on Itanium architecture to flush and mark register stack */
 #undef ITANIUM
 
@@ -396,6 +408,15 @@
 
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
+
+/* The size of `int', as computed by sizeof. */
+#undef SIZEOF_INT
+
+/* The size of `long', as computed by sizeof. */
+#undef SIZEOF_LONG
+
+/* The size of `long long', as computed by sizeof. */
+#undef SIZEOF_LONG_LONG
 
 /* The size of `void *', as computed by sizeof. */
 #undef SIZEOF_VOID_P

--- a/cnf/configure.in
+++ b/cnf/configure.in
@@ -48,11 +48,36 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
   [CXX=;])
 AC_LANG_POP([C++])
 
+AC_DEFUN([CHECK_COMPILER_BUILTIN],
+[AC_MSG_CHECKING([for $1])
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM(
+            [[]],
+            [$1[($2)];
+            ]
+        )],
+        [AS_VAR_SET([[have_]$1], [yes])],
+        [AS_VAR_SET([[have_]$1], [no])]
+        )
+    AC_MSG_RESULT(AS_VAR_GET([[have_]$1]))
+    AS_IF([test yes = AS_VAR_GET([[have_]$1])],
+        [AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_]$1), 1,
+            [Define to 1 if the system has the `]$1[' built-in function])], []
+        )])
+
+CHECK_COMPILER_BUILTIN([__builtin_smul_overflow],[0,0,0]);
+CHECK_COMPILER_BUILTIN([__builtin_smull_overflow],[0,0,0]);
+CHECK_COMPILER_BUILTIN([__builtin_smulll_overflow],[0,0,0]);
+
+
 #
 # Assume that cross-compiling is for 32 bit systems 
 # (alpha/NT will have to wait)
 #
 AC_CHECK_SIZEOF([void *])
+AC_CHECK_SIZEOF([int])
+AC_CHECK_SIZEOF([long])
+AC_CHECK_SIZEOF([long long])
 GP_C_UNDERSCORE_SYMBOLS
 
 

--- a/cnf/configure.out
+++ b/cnf/configure.out
@@ -1802,6 +1802,52 @@ fi
 
 } # ac_fn_cxx_try_compile
 
+# ac_fn_c_try_link LINENO
+# -----------------------
+# Try to link conftest.$ac_ext, and return whether this succeeded.
+ac_fn_c_try_link ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  rm -f conftest.$ac_objext conftest$ac_exeext
+  if { { ac_try="$ac_link"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_link") 2>conftest.err
+  ac_status=$?
+  if test -s conftest.err; then
+    grep -v '^ *+' conftest.err >conftest.er1
+    cat conftest.er1 >&5
+    mv -f conftest.er1 conftest.err
+  fi
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; } && {
+	 test -z "$ac_c_werror_flag" ||
+	 test ! -s conftest.err
+       } && test -s conftest$ac_exeext && {
+	 test "$cross_compiling" = yes ||
+	 test -x conftest$ac_exeext
+       }; then :
+  ac_retval=0
+else
+  $as_echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+	ac_retval=1
+fi
+  # Delete the IPA/IPO (Inter Procedural Analysis/Optimization) information
+  # created by the PGI compiler (conftest_ipa8_conftest.oo), as it would
+  # interfere with the next link command; also delete a directory that is
+  # left behind by Apple's compiler.  We do this before executing the actions.
+  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+  as_fn_set_status $ac_retval
+
+} # ac_fn_c_try_link
+
 # ac_fn_c_check_header_mongrel LINENO HEADER VAR INCLUDES
 # -------------------------------------------------------
 # Tests whether HEADER exists, giving a warning if it cannot be compiled using
@@ -2076,52 +2122,6 @@ $as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_find_uintX_t
-
-# ac_fn_c_try_link LINENO
-# -----------------------
-# Try to link conftest.$ac_ext, and return whether this succeeded.
-ac_fn_c_try_link ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  rm -f conftest.$ac_objext conftest$ac_exeext
-  if { { ac_try="$ac_link"
-case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-$as_echo "$ac_try_echo"; } >&5
-  (eval "$ac_link") 2>conftest.err
-  ac_status=$?
-  if test -s conftest.err; then
-    grep -v '^ *+' conftest.err >conftest.er1
-    cat conftest.er1 >&5
-    mv -f conftest.er1 conftest.err
-  fi
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; } && {
-	 test -z "$ac_c_werror_flag" ||
-	 test ! -s conftest.err
-       } && test -s conftest$ac_exeext && {
-	 test "$cross_compiling" = yes ||
-	 test -x conftest$ac_exeext
-       }; then :
-  ac_retval=0
-else
-  $as_echo "$as_me: failed program was:" >&5
-sed 's/^/| /' conftest.$ac_ext >&5
-
-	ac_retval=1
-fi
-  # Delete the IPA/IPO (Inter Procedural Analysis/Optimization) information
-  # created by the PGI compiler (conftest_ipa8_conftest.oo), as it would
-  # interfere with the next link command; also delete a directory that is
-  # left behind by Apple's compiler.  We do this before executing the actions.
-  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-  as_fn_set_status $ac_retval
-
-} # ac_fn_c_try_link
 
 # ac_fn_c_check_func LINENO FUNC VAR
 # ----------------------------------
@@ -4424,6 +4424,106 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for __builtin_smul_overflow" >&5
+$as_echo_n "checking for __builtin_smul_overflow... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+__builtin_smul_overflow(0,0,0);
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  have___builtin_smul_overflow=yes
+else
+  have___builtin_smul_overflow=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have___builtin_smul_overflow" >&5
+$as_echo "$have___builtin_smul_overflow" >&6; }
+    if test yes = $have___builtin_smul_overflow; then :
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE___BUILTIN_SMUL_OVERFLOW 1
+_ACEOF
+
+fi;
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for __builtin_smull_overflow" >&5
+$as_echo_n "checking for __builtin_smull_overflow... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+__builtin_smull_overflow(0,0,0);
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  have___builtin_smull_overflow=yes
+else
+  have___builtin_smull_overflow=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have___builtin_smull_overflow" >&5
+$as_echo "$have___builtin_smull_overflow" >&6; }
+    if test yes = $have___builtin_smull_overflow; then :
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE___BUILTIN_SMULL_OVERFLOW 1
+_ACEOF
+
+fi;
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for __builtin_smulll_overflow" >&5
+$as_echo_n "checking for __builtin_smulll_overflow... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+__builtin_smulll_overflow(0,0,0);
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  have___builtin_smulll_overflow=yes
+else
+  have___builtin_smulll_overflow=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have___builtin_smulll_overflow" >&5
+$as_echo "$have___builtin_smulll_overflow" >&6; }
+    if test yes = $have___builtin_smulll_overflow; then :
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE___BUILTIN_SMULLL_OVERFLOW 1
+_ACEOF
+
+fi;
+
+
 #
 # Assume that cross-compiling is for 32 bit systems
 # (alpha/NT will have to wait)
@@ -4458,6 +4558,105 @@ $as_echo "$ac_cv_sizeof_void_p" >&6; }
 
 cat >>confdefs.h <<_ACEOF
 #define SIZEOF_VOID_P $ac_cv_sizeof_void_p
+_ACEOF
+
+
+# The cast to long int works around a bug in the HP C Compiler
+# version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+# declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+# This bug is HP SR number 8606223364.
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of int" >&5
+$as_echo_n "checking size of int... " >&6; }
+if ${ac_cv_sizeof_int+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if ac_fn_c_compute_int "$LINENO" "(long int) (sizeof (int))" "ac_cv_sizeof_int"        "$ac_includes_default"; then :
+
+else
+  if test "$ac_cv_type_int" = yes; then
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error 77 "cannot compute sizeof (int)
+See \`config.log' for more details" "$LINENO" 5; }
+   else
+     ac_cv_sizeof_int=0
+   fi
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_int" >&5
+$as_echo "$ac_cv_sizeof_int" >&6; }
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define SIZEOF_INT $ac_cv_sizeof_int
+_ACEOF
+
+
+# The cast to long int works around a bug in the HP C Compiler
+# version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+# declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+# This bug is HP SR number 8606223364.
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of long" >&5
+$as_echo_n "checking size of long... " >&6; }
+if ${ac_cv_sizeof_long+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if ac_fn_c_compute_int "$LINENO" "(long int) (sizeof (long))" "ac_cv_sizeof_long"        "$ac_includes_default"; then :
+
+else
+  if test "$ac_cv_type_long" = yes; then
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error 77 "cannot compute sizeof (long)
+See \`config.log' for more details" "$LINENO" 5; }
+   else
+     ac_cv_sizeof_long=0
+   fi
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_long" >&5
+$as_echo "$ac_cv_sizeof_long" >&6; }
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define SIZEOF_LONG $ac_cv_sizeof_long
+_ACEOF
+
+
+# The cast to long int works around a bug in the HP C Compiler
+# version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+# declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+# This bug is HP SR number 8606223364.
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of long long" >&5
+$as_echo_n "checking size of long long... " >&6; }
+if ${ac_cv_sizeof_long_long+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if ac_fn_c_compute_int "$LINENO" "(long int) (sizeof (long long))" "ac_cv_sizeof_long_long"        "$ac_includes_default"; then :
+
+else
+  if test "$ac_cv_type_long_long" = yes; then
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error 77 "cannot compute sizeof (long long)
+See \`config.log' for more details" "$LINENO" 5; }
+   else
+     ac_cv_sizeof_long_long=0
+   fi
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_long_long" >&5
+$as_echo "$ac_cv_sizeof_long_long" >&6; }
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define SIZEOF_LONG_LONG $ac_cv_sizeof_long_long
 _ACEOF
 
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -152,6 +152,33 @@
 **  The product itself is stored in <o>.
 */
 
+
+#if SIZEOF_VOID_P == SIZEOF_INT && HAVE___BUILTIN_SMUL_OVERFLOW && HAVE_ARITHRIGHTSHIFT
+static inline Obj prod_intobjs(int l, int r)
+{
+  int prod;
+  if (__builtin_smul_overflow(l >> 1, r ^ 1, &prod))
+    return (Obj) 0;
+  return (Obj) ((prod >> 1) ^ 1);
+}
+#elif SIZEOF_VOID_P == SIZEOF_LONG && HAVE___BUILTIN_SMULL_OVERFLOW && HAVE_ARITHRIGHTSHIFT
+static inline Obj prod_intobjs(long l, long r)
+{
+  long prod;
+  if (__builtin_smull_overflow(l >> 1, r ^ 1, &prod))
+    return (Obj) 0;
+  return (Obj) ((prod >> 1) ^ 1);
+}
+#elif SIZEOF_VOID_P == SIZEOF_LONG_LONG && HAVE___BUILTIN_SMULLL_OVERFLOW && HAVE_ARITHRIGHTSHIFT
+static inline Obj prod_intobjs(long long l, long long r)
+{
+  long long prod;
+  if (__builtin_smulll_overflow(l >> 1, r ^ 1, &prod))
+    return (Obj) 0;
+  return (Obj) ((prod >> 1) ^ 1);
+}
+#else
+
 #ifdef SYS_IS_64_BIT
 #define HALF_A_WORD 32
 #else
@@ -186,6 +213,7 @@ static inline Obj prod_intobjs(Int l, Int r)
 
   return (Obj) 0;
 }
+#endif
 
 #define PROD_INTOBJS( o, l, r) ((o) = prod_intobjs((Int)(l),(Int)(r)), \
                                   (o) != (Obj) 0)


### PR DESCRIPTION
Add three variants of PROD_INTOBJS using portable GCC extensions such as
__builtin_smul_overflow (supported by GCC >= 5.0 and clang >= 3.4)

I took great care to verify via test programs written in that the new
implementations yields identical results to PROD_INTOBJS, at least on
64bit systems (and I see no reason why 32bit should be different).

Regarding performance: in a C micro benchmark, the new code outperforms
the old by a factor of 2 on my laptop. In GAP, the gain is not as
impressive, probably because other things add a lot of overhead. Still,
there is a gain of about 10%-15% with this micro benchmark:

foo:=function(b)
  local r,i,j,x;
  r:=[-b..b];;
  for i in r do
    for j in r do
      x:=i*j;
    od;
  od;
  return x;
end;

Old code:
gap> foo(2^12);;time;
1480
gap> foo(2^13);;time;
5559

New code:
gap> foo(2^12);;time;
1186
gap> foo(2^13);;time;
4849

For comparison, the C mini benchmark does something very similar, but is
faster by a factor 18 (for inputs 2^12, 2^13) to 40 (for input 2^14).

Disassembling the code generated by GCC and clang for the new
implementation shows that it is very close what I'd write by hand, while
the old code is a very complicated, and requires divisions in some cases
(= slow).

Please make sure that this pull request:

- [x] is submitted to the correct branch (the stable branch is only for bugfixes)
- [x] contains an accurate description of changes for the release notes below
- [ ] provides new tests or relies on existing ones
- [ ] correctly refers to other issues and related pull requests

### Tick all what applies to this pull request

- [ ] Adds new features
- [x] Improves and extends functionality
- [ ] Fixes bugs that could lead to crashes
- [ ] Fixes bugs that could lead to incorrect results
- [ ] Fixes bugs that could lead to break loops

### Write below the description of changes (for the release notes)
