### PR TITLE
Tilde fix

### DIFF
--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -1822,23 +1822,55 @@ Also see Chapter&nbsp;<Ref Chap="Functions"/>.
 <P/>
 <Index Subkey="definition by arrow notation">functions</Index>
 <Index>arrow notation for functions</Index>
-<C><A>arg-ident</A> -> <A>expr</A></C>
+<C>{ <A>arg-list</A> } -> <A>expr</A></C>
 <P/>
 This is a shorthand for
 <P/>
-<C>function ( <A>arg-ident</A> ) return <A>expr</A>; end.</C>
+<C>function ( <A>arg-list</A> ) return <A>expr</A>; end.</C>
 <P/>
-<A>arg-ident</A> must be a single identifier, i.e., it is not possible to
-write functions of several arguments this way. Also <C>arg</C> is not treated
-specially, so it is also impossible to write functions that take a
-variable number of arguments this way.
+<A>arg-list</A> is a (possibly empty) argument list. Any arguments list
+which would be valid for a normal GAP function is also valid here (including
+variadic arguments).
 <P/>
-The following is an example of a typical use of such a function
+The following gives a couple of examples of a typical use of such a function
 <P/>
 <Example><![CDATA[
+gap> Sum( List( [1..100], {x} -> x^2 ) );
+338350
+gap> list := [3, 5, 2, 1, 3];;
+gap> Sort(list, {x,y} -> x > y);
+gap> list;
+[ 5, 3, 3, 2, 1 ]
+gap> f := {x,y...} -> y;;
+gap> f(1,2,3,4);
+[ 2, 3, 4 ]
+]]></Example>
+<P/>
+The <C>{</C> and <C>}</C> may be omitted for
+functions with one and zero arguments:
+<Example><![CDATA[
+gap> Sum( List( [1..100], {x} -> x^2 ) );
+338350
 gap> Sum( List( [1..100], x -> x^2 ) );
 338350
+gap> f := {} -> 2;
+function(  ) ... end
+gap> Print(f);
+function (  )
+    return 2;
+end
+gap> f();
+2
+gap> g := -> 2;
+function(  ) ... end
+gap> Print(g);
+function (  )
+    return 2;
+end
+gap> g();
+2
 ]]></Example>
+
 <P/>
 When the definition of a function <A>fun1</A> is evaluated inside another
 function <A>fun2</A>,

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2610,13 +2610,13 @@ CVar CompListTildeExpr (
     list = CompListExpr1( expr );
 
     /* assign the list to '~'                                              */
-    Emit( "AssGVar( Tilde, %c );\n", list );
+    Emit( "AssGVarUnsafe( Tilde, %c );\n", list );
 
     /* evaluate the subexpressions into the list value                     */
     CompListExpr2( list, expr );
 
     /* restore old value of '~'                                            */
-    Emit( "AssGVar( Tilde, %c );\n", tilde );
+    Emit( "AssGVarUnsafe( Tilde, %c );\n", tilde );
     if ( IS_TEMP_CVAR( tilde ) )  FreeTemp( TEMP_CVAR( tilde ) );
 
     /* return the list value                                               */
@@ -2828,13 +2828,13 @@ CVar CompRecTildeExpr (
     rec = CompRecExpr1( expr );
 
     /* assign the record value to the variable '~'                         */
-    Emit( "AssGVar( Tilde, %c );\n", rec );
+    Emit( "AssGVarUnsafe( Tilde, %c );\n", rec );
 
     /* evaluate the subexpressions into the record value                   */
     CompRecExpr2( rec, expr );
 
     /* restore the old value of '~'                                        */
-    Emit( "AssGVar( Tilde, %c );\n", tilde );
+    Emit( "AssGVarUnsafe( Tilde, %c );\n", tilde );
     if ( IS_TEMP_CVAR( tilde ) )  FreeTemp( TEMP_CVAR( tilde ) );
 
     /* return the record value                                             */

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1087,13 +1087,13 @@ Obj             EvalListTildeExpr (
     list = ListExpr1( expr );
 
     /* assign the list to '~'                                              */
-    AssGVar( Tilde, list );
+    AssGVarUnsafe( Tilde, list );
 
     /* evaluate the subexpressions into the list value                     */
     ListExpr2( list, expr );
 
     /* restore old value of '~'                                            */
-    AssGVar( Tilde, tilde );
+    AssGVarUnsafe( Tilde, tilde );
 
     /* return the list value                                               */
     return list;
@@ -1441,13 +1441,13 @@ Obj             EvalRecTildeExpr (
     rec = RecExpr1( expr );
 
     /* assign the record value to the variable '~'                         */
-    AssGVar( Tilde, rec );
+    AssGVarUnsafe( Tilde, rec );
 
     /* evaluate the subexpressions into the record value                   */
     RecExpr2( rec, expr );
 
     /* restore the old value of '~'                                        */
-    AssGVar( Tilde, tilde );
+    AssGVarUnsafe( Tilde, tilde );
 
     /* return the record value                                             */
     return rec;

--- a/src/gap.c
+++ b/src/gap.c
@@ -1344,6 +1344,7 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
     Obj res;
     Obj currLVars;
     Obj result;
+    Obj tilde;
     Int recursionDepth;
     Stat currStat;
     if (!IS_FUNC(func))
@@ -1354,6 +1355,7 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
     currLVars = TLS(CurrLVars);
     currStat = TLS(CurrStat);
     recursionDepth = TLS(RecursionDepth);
+    tilde = VAL_GVAR(Tilde);
     res = NEW_PLIST(T_PLIST_DENSE+IMMUTABLE,2);
     if (sySetjmp(TLS(ReadJmpError))) {
       SET_LEN_PLIST(res,2);
@@ -1366,6 +1368,7 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
       TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
       TLS(CurrStat) = currStat;
       TLS(RecursionDepth) = recursionDepth;
+      AssGVarUnsafe(Tilde, tilde);
     } else {
       result = CallFuncList(func, args);
       SET_ELM_PLIST(res,1,True);

--- a/src/gvars.h
+++ b/src/gvars.h
@@ -98,6 +98,17 @@ extern  void            AssGVar (
 
 /****************************************************************************
 **
+*F  AssGVarUnsafe(<gvar>,<val>) . . assign to a global variable with checks
+**
+**  'AssGVarUnsafe' assigns the value <val> to the global variable <gvar>
+**  without readonly checks or copie/fopie checking.
+*/
+extern  void            AssGVarUnsafe (
+            UInt                gvar,
+            Obj                 val );
+
+/****************************************************************************
+**
 *F  ValAutoGVar(<gvar>) . . . . . . . .  value of a automatic global variable
 **
 **  'ValAutoGVar' returns the value of the global variable <gvar>.  This will

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2325,7 +2325,7 @@ void            IntrListExprBegin (
         old = VAL_GVAR( Tilde );
         if ( old != 0 ) { PushObj( old ); }
         else            { PushVoidObj();  }
-        AssGVar( Tilde, list );
+        AssGVarUnsafe( Tilde, list );
     }
 
     /* push the list                                                       */
@@ -2398,7 +2398,7 @@ void            IntrListExprEnd (
     if ( top ) {
         list = PopObj();
         old = PopVoidObj();
-        AssGVar( Tilde, old );
+        AssGVarUnsafe( Tilde, old );
         PushObj( list );
     }
 
@@ -2538,7 +2538,7 @@ void            IntrRecExprBegin (
         old = VAL_GVAR( Tilde );
         if ( old != 0 ) { PushObj( old ); }
         else            { PushVoidObj();  }
-        AssGVar( Tilde, record );
+        AssGVarUnsafe( Tilde, record );
     }
 
     /* push the record                                                     */
@@ -2621,7 +2621,7 @@ void            IntrRecExprEnd (
     if ( top ) {
         record = PopObj();
         old = PopVoidObj();
-        AssGVar( Tilde, old );
+        AssGVarUnsafe( Tilde, old );
         PushObj( record );
     }
 }

--- a/src/read.c
+++ b/src/read.c
@@ -1240,6 +1240,151 @@ void ReadRecExpr (
     TLS(ReadTop)--;
 }
 
+/****************************************************************************
+**
+**  ArgList representes the return value of ReadFuncArgList
+*/
+struct ArgList
+{
+    Int        narg;           /* number of arguments             */
+    Obj        nams;           /* list of local variables names   */
+    UInt       isvarg;         /* does function have varargs?     */
+};
+
+
+/****************************************************************************
+**
+*F  ReadFuncArgList(<follow>, <is_atomic>, <is_block>, <symbol>, <symbolstr>)
+**  . . . . . . . . . .  read a function argument list.
+**
+**  'ReadFuncArgList' reads the argument list of a function. In case of an
+**  error it skips all symbols up to one contained in <follow>.
+**
+**  <ArgList> :=    ('readwrite'|'readonly') <Ident>
+**                   {',' ('readwrite'|'readonly') <Ident> } ( '...' )
+**
+**  is_atomic: Is this an atomic function?
+**  symbol: The end symbol of the arglist (usually S_RBRACK, but S_RBRACE
+**          for lambda functions).
+**  symbolstr: symbol as an ascii string
+**
+**  This function assumes the opening bracket is already read, and is
+**  responsible for reading the closing bracket.
+*/
+
+struct ArgList ReadFuncArgList(
+    TypSymbolSet        follow,
+    Int is_atomic,
+    UInt symbol,
+    const Char * symbolstr)
+{
+    Obj        name;           /* one local variable name         */
+    Int        narg;           /* number of arguments             */
+    int        lockmode;       /* type of lock for current argument */
+    Obj        nams;           /* list of local variables names   */
+    Bag        locks = 0;      /* locks of the function */
+    UInt       isvarg = 0;     /* does function have varargs?     */
+
+    UInt       i;              /* loop variable */
+    if (is_atomic)
+        locks = NEW_STRING(4);
+
+    /* make and push the new local variables list (args and locals)        */
+    narg = 0;
+    nams = NEW_PLIST( T_PLIST, narg );
+    SET_LEN_PLIST( nams, narg );
+    TLS(CountNams) += 1;
+    ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
+    if ( TLS(Symbol) != symbol ) {
+        lockmode = 0;
+        switch (TLS(Symbol)) {
+            case S_READWRITE:
+            if (!is_atomic) {
+                SyntaxError("'readwrite' argument of non-atomic function");
+                GetSymbol();
+                break;
+            }
+            lockmode++;
+            case S_READONLY:
+            if (!is_atomic) {
+                SyntaxError("'readonly' argument of non-atomic function");
+                GetSymbol();
+                break;
+            }
+            lockmode++;
+            CHARS_STRING(locks)[0] = lockmode;
+            SET_LEN_STRING(locks, 1);
+            GetSymbol();
+        }
+        C_NEW_STRING_DYN( name, TLS(Value) );
+        narg += 1;
+        ASS_LIST( nams, narg, name );
+        Match(S_IDENT,"identifier",symbol|S_LOCAL|STATBEGIN|S_END|follow);
+    }
+
+    if(TLS(Symbol) == S_DOTDOT) {
+        SyntaxError("Three dots required for variadic argument list");
+    }
+    if(TLS(Symbol) == S_DOTDOTDOT) {
+        isvarg = 1;
+        GetSymbol();
+    }
+
+    while ( TLS(Symbol) == S_COMMA ) {
+        if (isvarg) {
+            SyntaxError("Only final argument can be variadic");
+        }
+
+        Match( S_COMMA, ",", follow );
+        lockmode = 0;
+        switch (TLS(Symbol)) {
+            case S_READWRITE:
+            if (!is_atomic) {
+                SyntaxError("'readwrite' argument of non-atomic function");
+                GetSymbol();
+                break;
+            }
+            lockmode++;
+            case S_READONLY:
+            if (!is_atomic) {
+                SyntaxError("'readonly' argument of non-atomic function");
+                GetSymbol();
+                break;
+            }
+            lockmode++;
+            GrowString(locks, narg+1);
+            SET_LEN_STRING(locks, narg+1);
+            CHARS_STRING(locks)[narg] = lockmode;
+            GetSymbol();
+        }
+
+        if(TLS(Symbol) != S_IDENT) {
+            SyntaxError("Expect identifier");
+        }
+
+        for (i = 1; i <= narg; i++ ) {
+            if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
+                SyntaxError("Name used for two arguments");
+            }
+        }
+        C_NEW_STRING_DYN( name, TLS(Value) );
+        narg += 1;
+        ASS_LIST( nams, narg, name );
+        Match(S_IDENT,"identifier",symbol|S_LOCAL|STATBEGIN|S_END|follow);
+        if(TLS(Symbol) == S_DOTDOT) {
+            SyntaxError("Three dots required for variadic argument list");
+        }
+        if(TLS(Symbol) == S_DOTDOTDOT) {
+            isvarg = 1;
+            GetSymbol();
+        }
+    }
+    Match( symbol, symbolstr, S_LOCAL|STATBEGIN|S_END|follow );
+
+    struct ArgList ret = {narg, nams, isvarg};
+    return ret;
+}
+
 
 /****************************************************************************
 **
@@ -1248,22 +1393,16 @@ void ReadRecExpr (
 **  'ReadFuncExpr' reads a function literal expression.  In  case of an error
 **  it skips all symbols up to one contained in <follow>.
 **
-**  <Function> := 'function (' [ <Ident> {',' <Ident>} ] ')'
+**  <Function> := 'function (' <ArgList> ')'
 **                             [ 'local'  <Ident> {',' <Ident>} ';' ]
 **                             <Statments>
 **                'end'
 */
-
-
 void ReadFuncExpr (
     TypSymbolSet        follow,
     Char mode)
 {
-    volatile Obj        nams;           /* list of local variables names   */
     volatile Obj        name;           /* one local variable name         */
-    volatile Int        narg;           /* number of arguments             */
-    volatile UInt       isvarg = 0;     /* does function have varargs?     */
-    volatile UInt       nloc;           /* number of locals                */
     volatile UInt       nr;             /* number of statements            */
     volatile UInt       i;              /* loop variable                   */
     volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
@@ -1271,123 +1410,41 @@ void ReadFuncExpr (
     volatile Int        startLine;      /* line number of function keyword */
     volatile int        is_block = 0;   /* is this a do ... od block?      */
     volatile int        is_atomic = 0;  /* is this an atomic function?      */
-    volatile int        lockmode;       /* type of lock for current argument */
-    volatile Bag        locks = 0;      /* locks of the function */
+    volatile Int        narg;           /* number of arguments             */
+    volatile Obj        nams;           /* list of local variables names   */
+    volatile UInt       nloc;           /* number of locals                */
+    UInt                isvarg = 0;     /* is this function variadic?      */
+    nloc = 0;
 
     /* begin the function               */
     startLine = TLS(Input)->number;
     if (TLS(Symbol) == S_DO) {
 	Match( S_DO, "do", follow );
         is_block = 1;
+        /* make and push the new local variables list (args and locals)        */
+        narg = 0;
+        nams = NEW_PLIST( T_PLIST, narg );
+        SET_LEN_PLIST( nams, narg );
+        TLS(CountNams) += 1;
+        ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
     } else {
-	if (TLS(Symbol) == S_ATOMIC) {
-	    Match(S_ATOMIC, "atomic", follow);
-	    is_atomic = 1;
-	} else if (mode == 'a') { /* in this case the atomic keyword
-                                 was matched away by ReadAtomic before
-                                 we realised we were reading an atomic function */
-        is_atomic = 1;
-    }
-    if (is_atomic)
-        locks = NEW_STRING(4);
-
-    Match( S_FUNCTION, "function", follow );
-    Match( S_LPAREN, "(", S_IDENT|S_RPAREN|S_LOCAL|STATBEGIN|S_END|follow );
-    }
-
-    /* make and push the new local variables list (args and locals)        */
-    narg = nloc = 0;
-    nams = NEW_PLIST( T_PLIST, narg+nloc );
-    SET_LEN_PLIST( nams, narg+nloc );
-    TLS(CountNams) += 1;
-    ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
-    if (!is_block) {
-	if ( TLS(Symbol) != S_RPAREN ) {
-	    lockmode = 0;
-	    switch (TLS(Symbol)) {
-	      case S_READWRITE:
-	        if (!is_atomic) {
-		  SyntaxError("'readwrite' argument of non-atomic function");
-                  GetSymbol();
-                  break;
-                }
-	        lockmode++;
-	      case S_READONLY:
-	        if (!is_atomic) {
-		  SyntaxError("'readonly' argument of non-atomic function");
-                  GetSymbol();
-                  break;
-                }
-	        lockmode++;
-		CHARS_STRING(locks)[0] = lockmode;
-		SET_LEN_STRING(locks, 1);
-                GetSymbol();
-	    }
-        C_NEW_STRING_DYN( name, TLS(Value) );
-	    narg += 1;
-	    ASS_LIST( nams, narg+nloc, name );
-	    Match(S_IDENT,"identifier",S_RPAREN|S_LOCAL|STATBEGIN|S_END|follow);
-	}
-
-	if(TLS(Symbol) == S_DOTDOT) {
-	    SyntaxError("Three dots required for variadic argument list");
-	}
-	if(TLS(Symbol) == S_DOTDOTDOT) {
-	    isvarg = 1;
-	    GetSymbol();
+        if (TLS(Symbol) == S_ATOMIC) {
+            Match(S_ATOMIC, "atomic", follow);
+            is_atomic = 1;
+        } else if (mode == 'a') { /* in this case the atomic keyword
+                                     was matched away by ReadAtomic before
+                                     we realised we were reading an atomic function */
+            is_atomic = 1;
+        }
+        Match( S_FUNCTION, "function", follow );
+        Match( S_LPAREN, "(", S_IDENT|S_RPAREN|S_LOCAL|STATBEGIN|S_END|follow );
+        struct ArgList args = ReadFuncArgList(follow, is_atomic, S_RPAREN, ")");
+        narg = args.narg;
+        nams = args.nams;
+        isvarg = args.isvarg;
     }
 
-	while ( TLS(Symbol) == S_COMMA ) {
-	    if (isvarg) {
-	        SyntaxError("Only final argument can be variadic");
-	    }
 
-	    Match( S_COMMA, ",", follow );
-	    lockmode = 0;
-	    switch (TLS(Symbol)) {
-	      case S_READWRITE:
-	        if (!is_atomic) {
-		  SyntaxError("'readwrite' argument of non-atomic function");
-                  GetSymbol();
-                  break;
-                }
-	        lockmode++;
-	      case S_READONLY:
-	        if (!is_atomic) {
-		  SyntaxError("'readonly' argument of non-atomic function");
-                  GetSymbol();
-                  break;
-                }
-	        lockmode++;
-		GrowString(locks, narg+1);
-		SET_LEN_STRING(locks, narg+1);
-		CHARS_STRING(locks)[narg] = lockmode;
-	        GetSymbol();
-	    }
-
-	    if(TLS(Symbol) != S_IDENT) {
-	        SyntaxError("Expect identifier");
-	    }
-
-	    for ( i = 1; i <= narg; i++ ) {
-		if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
-		    SyntaxError("Name used for two arguments");
-		}
-	    }
-        C_NEW_STRING_DYN( name, TLS(Value) );
-	    narg += 1;
-	    ASS_LIST( nams, narg+nloc, name );
-	    Match(S_IDENT,"identifier",S_RPAREN|S_LOCAL|STATBEGIN|S_END|follow);
-	    if(TLS(Symbol) == S_DOTDOT) {
-	        SyntaxError("Three dots required for variadic argument list");
-	    }
-	    if(TLS(Symbol) == S_DOTDOTDOT) {
-	        isvarg = 1;
-	        GetSymbol();
-	    }
-	}
-        Match( S_RPAREN, ")", S_LOCAL|STATBEGIN|S_END|follow );
-    }
     if ( TLS(Symbol) == S_LOCAL ) {
         Match( S_LOCAL, "local", follow );
         for ( i = 1; i <= narg; i++ ) {
@@ -1469,28 +1526,21 @@ void ReadFuncExpr (
 
 /****************************************************************************
 **
-*F  ReadFuncExpr1(<follow>) . . . . . . . . . . .  read a function expression
+*F  ReadFuncExprBody(<follow>) . . . . . . read the body function expression
 **
-**  'ReadFuncExpr1' reads  an abbreviated  function literal   expression.  In
-**  case of an error it skips all symbols up to one contained in <follow>.
+**  'ReadFuncExprBody reads an abbreviated  function literal expression after
+**  the variable declaration. In case of an error it skips all symbols up to
+**  one contained in <follow>.
 **
-**      <Function>      := <Var> '->' <Expr>
+**      <FunctionBody>      := '->' <Expr>
 */
-void ReadFuncExpr1 (
-    TypSymbolSet        follow )
+void ReadFuncExprBody (
+    TypSymbolSet        follow,
+    Obj nams,
+    UInt narg)
 {
-    volatile Obj        nams;           /* list of local variables names   */
-    volatile Obj        name;           /* one local variable name         */
     volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>             */
-
-    /* make and push the new local variables list                          */
-    nams = NEW_PLIST( T_PLIST, 1 );
-    SET_LEN_PLIST( nams, 0 );
-    TLS(CountNams)++;
-    ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
-    C_NEW_STRING_DYN( name, TLS(Value) );
-    ASS_LIST( nams, 1, name );
+    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>        */
 
     /* match away the '->'                                                 */
     Match( S_MAPTO, "->", follow );
@@ -1500,7 +1550,9 @@ void ReadFuncExpr1 (
     nrError   = TLS(NrError);
 
     /* begin interpreting the function expression (with 1 argument)        */
-    if ( ! READ_ERROR() ) { IntrFuncExprBegin( 1L, 0L, nams, TLS(Input)->number ); }
+    if ( ! READ_ERROR() ) {
+        IntrFuncExprBegin( narg, 0L, nams, TLS(Input)->number );
+    }
 
     /* read the expression and turn it into a return-statement             */
     ReadExpr( follow, 'r' );
@@ -1527,6 +1579,62 @@ void ReadFuncExpr1 (
 
 /****************************************************************************
 **
+*F  ReadFuncExprLong(<follow>) . . . . . read a multi-arg function expression
+**
+**  'ReadFuncExprLong' reads  an abbreviated  function literal expression.  In
+**  case of an error it skips all symbols up to one contained in <follow>.
+**
+**      <Function>      := '{' <ArgList> '}' '->' <Expr>
+*/
+void ReadFuncExprLong (
+    TypSymbolSet        follow )
+{
+    volatile Int        narg;           /* number of arguments             */
+    volatile Obj        nams;           /* list of local variables names   */
+
+    Match( S_LBRACE, "{", follow );
+
+    struct ArgList args = ReadFuncArgList(follow, 0, S_RBRACE, ")");
+    narg = args.narg;
+    nams = args.nams;
+
+    /* 'function( a,b, p... )' takes a variable number of arguments           */
+    /* Also, we special case function(arg)                                   */
+    if (args.isvarg) {
+      narg = -narg;
+    }
+
+    ReadFuncExprBody(follow, nams, narg);
+}
+
+/****************************************************************************
+**
+*F  ReadFuncExpr1(<follow>) . . . . . . . . . . .  read a function expression
+**
+**  'ReadFuncExpr1' reads  an abbreviated  function literal   expression.  In
+**  case of an error it skips all symbols up to one contained in <follow>.
+**
+**      <Function>      := <Var> '->' <Expr>
+*/
+void ReadFuncExpr1 (
+    TypSymbolSet        follow )
+{
+    volatile Obj        nams;           /* list of local variables names   */
+    volatile Obj        name;           /* one local variable name         */
+
+    /* make and push the new local variables list                          */
+    nams = NEW_PLIST( T_PLIST, 1 );
+    SET_LEN_PLIST( nams, 0 );
+    TLS(CountNams)++;
+    ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
+    C_NEW_STRING_DYN( name, TLS(Value) );
+    ASS_LIST( nams, 1, name );
+
+    ReadFuncExprBody(follow, nams, 1);
+}
+
+/****************************************************************************
+**
 *F  ReadFuncExpr0(<follow>) . . . . . . . . . . .  read a function expression
 **
 **  'ReadFuncExpr0' reads  an abbreviated  function literal   expression.  In
@@ -1535,11 +1643,9 @@ void ReadFuncExpr1 (
 **      <Function>      := '->' <Expr>
 */
 void ReadFuncExpr0 (
-    TypSymbolSet        follow )
+    TypSymbolSet        follow)
 {
     volatile Obj        nams;           /* list of local variables names   */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>             */
 
     /* make and push the new local variables list                          */
     nams = NEW_PLIST( T_PLIST, 0 );
@@ -1547,36 +1653,7 @@ void ReadFuncExpr0 (
     TLS(CountNams)++;
     ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
 
-    /* match away the '->'                                                 */
-    Match( S_MAPTO, "->", follow );
-
-    /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
-
-    /* begin interpreting the function expression (with 1 argument)        */
-    if ( ! READ_ERROR() ) { IntrFuncExprBegin( 0L, 0L, nams, TLS(Input)->number ); }
-
-    /* read the expression and turn it into a return-statement             */
-    ReadExpr( follow, 'r' );
-    if ( ! READ_ERROR() ) { IntrReturnObj(); }
-
-    /* end interpreting the function expression (with 1 statement)         */
-    if ( ! READ_ERROR() ) {
-        IntrFuncExprEnd( 1UL, 1UL );
-    }
-
-    /* an error has occured *after* the 'IntrFuncExprEnd'                  */
-    else if ( nrError == 0  && TLS(IntrCoding) ) {
-        CodeEnd(1);
-        TLS(IntrCoding)--;
-        TLS(CurrLVars) = currLVars;
-        TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-        TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
-    }
-
-    /* pop the new local variables list                                    */
-    TLS(CountNams)--;
+    ReadFuncExprBody(follow, nams, 0);
 }
 
 /****************************************************************************
@@ -1696,6 +1773,10 @@ void ReadLiteral (
 
     case S_MAPTO:
         ReadFuncExpr0( follow );
+        break;
+
+    case S_LBRACE:
+        ReadFuncExprLong( follow );
         break;
 
     /* signal an error, we want to see a literal                           */

--- a/src/read.c
+++ b/src/read.c
@@ -1316,6 +1316,9 @@ struct ArgList ReadFuncArgList(
             SET_LEN_STRING(locks, 1);
             GetSymbol();
         }
+        if ( strcmp("~", TLS(Value)) == 0 ) {
+                SyntaxError("~ is not a valid name for an argument");
+        }
         C_NEW_STRING_DYN( name, TLS(Value) );
         narg += 1;
         ASS_LIST( nams, narg, name );
@@ -1366,6 +1369,9 @@ struct ArgList ReadFuncArgList(
             if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
                 SyntaxError("Name used for two arguments");
             }
+        }
+        if ( strcmp("~", TLS(Value)) == 0 ) {
+                SyntaxError("~ is not a valid name for an argument");
         }
         C_NEW_STRING_DYN( name, TLS(Value) );
         narg += 1;
@@ -1452,6 +1458,9 @@ void ReadFuncExpr (
                 SyntaxError("Name used for argument and local");
             }
         }
+        if ( strcmp("~", TLS(Value)) == 0 ) {
+                SyntaxError("~ is not a valid name for a local identifier");
+        }
         C_NEW_STRING_DYN( name, TLS(Value) );
         nloc += 1;
         ASS_LIST( nams, narg+nloc, name );
@@ -1469,6 +1478,9 @@ void ReadFuncExpr (
                 if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
                     SyntaxError("Name used for two locals");
                 }
+            }
+            if ( strcmp("~", TLS(Value)) == 0 ) {
+                SyntaxError("~ is not a valid name for a local identifier");
             }
             C_NEW_STRING_DYN( name, TLS(Value) );
             nloc += 1;

--- a/src/stats.c
+++ b/src/stats.c
@@ -1798,8 +1798,9 @@ void ClearError ( void )
         }
     }
 
-    /* reset <TLS(NrError)>                                                     */
+    /* reset <TLS(NrError)> and Tilde                                      */
     TLS(NrError) = 0;
+    AssGVarUnsafe(Tilde, 0);
 }
 
 /****************************************************************************

--- a/tst/testinstall/atomic_basic.tst
+++ b/tst/testinstall/atomic_basic.tst
@@ -76,4 +76,32 @@ gap> h5 := function(readonly x, readonly y, z) end;;
 Syntax error: 'readonly' argument of non-atomic function in stream:1
 h5 := function(readonly x, readonly y, z) end;;
                       ^
+gap> h5 := {readonly x} -> x;
+Syntax error: 'readonly' argument of non-atomic function in stream:1
+h5 := {readonly x} -> x;
+              ^
+gap> h5 := {readonly x} -> x;
+Syntax error: 'readonly' argument of non-atomic function in stream:1
+h5 := {readonly x} -> x;
+              ^
+gap> h5 := {x, readonly y} -> x;
+Syntax error: 'readonly' argument of non-atomic function in stream:1
+h5 := {x, readonly y} -> x;
+                 ^
+gap> h5 := {readwrite x, y} -> x;
+Syntax error: 'readwrite' argument of non-atomic function in stream:1
+h5 := {readwrite x, y} -> x;
+               ^
+gap> h5 := {x, readwrite y} -> x;
+Syntax error: 'readwrite' argument of non-atomic function in stream:1
+h5 := {x, readwrite y} -> x;
+                  ^
+gap> h5 := {readwrite} -> x;
+Syntax error: 'readwrite' argument of non-atomic function in stream:1
+h5 := {readwrite} -> x;
+               ^
+gap> h5 := {readwrite readonly x} -> x;
+Syntax error: 'readwrite' argument of non-atomic function in stream:1
+h5 := {readwrite readonly x} -> x;
+               ^
 gap> STOP_TEST("atomic_basic.tst", 260000);

--- a/tst/testinstall/function.tst
+++ b/tst/testinstall/function.tst
@@ -156,4 +156,24 @@ gap> f := ({x,y...} -> [x,y]);
 function( x, y... ) ... end
 gap> f(2,3);
 [ 2, [ 3 ] ]
+gap> function(a,a) end;
+Syntax error: Name used for two arguments in stream:1
+function(a,a) end;
+           ^
+gap> function(a,b,a) end;
+Syntax error: Name used for two arguments in stream:1
+function(a,b,a) end;
+             ^
+gap> function(a,b) local c,c; end;
+Syntax error: Name used for two locals in stream:1
+function(a,b) local c,c; end;
+                      ^
+gap> function(a,b) local c,b,c; end;
+Syntax error: Name used for argument and local in stream:1
+function(a,b) local c,b,c; end;
+                      ^
+gap> function(a,b) local b,c,b,c; end;
+Syntax error: Name used for argument and local in stream:1
+function(a,b) local b,c,b,c; end;
+                    ^
 gap> STOP_TEST("function.tst", 1);

--- a/tst/testinstall/function.tst
+++ b/tst/testinstall/function.tst
@@ -98,4 +98,62 @@ gap> (function() return 2; end)();
 gap> (function() return function() end; end)()();
 gap> (function() return function() return 3; end; end)()();
 3
+gap> x -> x;
+function( x ) ... end
+gap> (x->x)("abc");
+"abc"
+gap> (x -> 2*x)(4);
+8
+gap> Print(x->x, "\n");
+function ( x )
+    return x;
+end
+gap> ->1;
+function(  ) ... end
+gap> (->1)();
+1
+gap> {}->1;
+function(  ) ... end
+gap> ({}->1)();
+1
+gap> Print(->1, "\n");
+function (  )
+    return 1;
+end
+gap> Print({}->1, "\n");
+function (  )
+    return 1;
+end
+gap> x -> y -> x+y;
+function( x ) ... end
+gap> Print(x -> y -> x+y, "\n");
+function ( x )
+    return function ( y )
+          return x + y;
+      end;
+end
+gap> f := x -> y -> x+y;
+function( x ) ... end
+gap> f(1)(2);
+3
+gap> Print({x} -> x, "\n");
+function ( x )
+    return x;
+end
+gap> Print({x,y} -> x + y, "\n");
+function ( x, y )
+    return x + y;
+end
+gap> f := ({x,y} -> x + y);
+function( x, y ) ... end
+gap> f(2,3);
+5
+gap> f := ({x,y..} -> [x,y]);
+Syntax error: Three dots required for variadic argument list in stream:1
+f := ({x,y..} -> [x,y]);
+           ^
+gap> f := ({x,y...} -> [x,y]);
+function( x, y... ) ... end
+gap> f(2,3);
+[ 2, [ 3 ] ]
 gap> STOP_TEST("function.tst", 1);

--- a/tst/testinstall/tilde.tst
+++ b/tst/testinstall/tilde.tst
@@ -25,4 +25,32 @@ gap> r.x;
 rec( x := ~, y := [ 1, 2, ~ ] )
 gap> r.y[3];
 rec( x := ~, y := [ 1, 2, ~ ] )
+gap> f := function(~) local a; end;
+Syntax error: ~ is not a valid name for an argument in stream:1
+f := function(~) local a; end;
+              ^
+gap> f := function(a,~) local a; end;
+Syntax error: ~ is not a valid name for an argument in stream:1
+f := function(a,~) local a; end;
+                ^
+gap> f := function(a,b) local ~; end;
+Syntax error: ~ is not a valid name for a local identifier in stream:1
+f := function(a,b) local ~; end;
+                         ^
+gap> f := function(a,b) local x,~; end;
+Syntax error: ~ is not a valid name for a local identifier in stream:1
+f := function(a,b) local x,~; end;
+                           ^
+gap> {~} -> ~;
+Syntax error: ~ is not a valid name for an argument in stream:1
+{~} -> ~;
+ ^
+gap> {~,~} -> 2;
+Syntax error: ~ is not a valid name for an argument in stream:1
+{~,~} -> 2;
+ ^
+gap> ({} -> ~);
+function(  ) ... end
+gap> ({} -> ~)();
+Error, Variable: '~' must have an assigned value
 gap> STOP_TEST( "tilde.tst", 1);

--- a/tst/testinstall/tilde.tst
+++ b/tst/testinstall/tilde.tst
@@ -1,0 +1,28 @@
+gap> START_TEST("tilde.tst");
+gap> aqq~ := 1;
+Error, Variable: 'aqq' must have a value
+Syntax error: ; expected in stream:1
+aqq~ := 1;
+   ^
+gap> ~a := 1;
+Error, Variable: '~' must have a value
+Syntax error: ; expected in stream:1
+~a := 1;
+ ^
+gap> ~ := 1;
+Error, '~' cannot be assigned
+gap> l := [2, ~];
+[ 2, ~ ]
+gap> l = l[2];
+true
+gap> r := rec(x := ~, y := [1,2,~]);
+rec( x := ~, y := [ 1, 2, ~ ] )
+gap> r.x;
+rec( x := ~, y := [ 1, 2, ~ ] )
+gap> r.y;
+[ 1, 2, rec( x := ~[3], y := ~ ) ]
+gap> r.x;
+rec( x := ~, y := [ 1, 2, ~ ] )
+gap> r.y[3];
+rec( x := ~, y := [ 1, 2, ~ ] )
+gap> STOP_TEST( "tilde.tst", 1);


### PR DESCRIPTION
Fixes #1049 (users can assign `~`).

This is built on top of #490, so that should be merged first (if that gets rejected, or edited, I will adjust this as appropriate).