### PR TITLE
kernel: rewrite (C)Log2Int using compiler builtins

### DIFF
--- a/cnf/config.hin
+++ b/cnf/config.hin
@@ -376,6 +376,15 @@
 /* Define to 1 if you have the `_setjmp' function. */
 #undef HAVE__SETJMP
 
+/* Define to 1 if the system has the `__builtin_clz' built-in function */
+#undef HAVE___BUILTIN_CLZ
+
+/* Define to 1 if the system has the `__builtin_clzl' built-in function */
+#undef HAVE___BUILTIN_CLZL
+
+/* Define to 1 if the system has the `__builtin_clzll' built-in function */
+#undef HAVE___BUILTIN_CLZLL
+
 /* Define to 1 if the system has the `__builtin_smulll_overflow' built-in
    function */
 #undef HAVE___BUILTIN_SMULLL_OVERFLOW

--- a/cnf/configure.in
+++ b/cnf/configure.in
@@ -68,6 +68,9 @@ AC_DEFUN([CHECK_COMPILER_BUILTIN],
 CHECK_COMPILER_BUILTIN([__builtin_smul_overflow],[0,0,0]);
 CHECK_COMPILER_BUILTIN([__builtin_smull_overflow],[0,0,0]);
 CHECK_COMPILER_BUILTIN([__builtin_smulll_overflow],[0,0,0]);
+CHECK_COMPILER_BUILTIN([__builtin_clz],[0]);
+CHECK_COMPILER_BUILTIN([__builtin_clzl],[0]);
+CHECK_COMPILER_BUILTIN([__builtin_clzll],[0]);
 
 
 #

--- a/cnf/configure.out
+++ b/cnf/configure.out
@@ -4522,6 +4522,102 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 fi;
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for __builtin_clz" >&5
+$as_echo_n "checking for __builtin_clz... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+__builtin_clz(0);
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  have___builtin_clz=yes
+else
+  have___builtin_clz=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have___builtin_clz" >&5
+$as_echo "$have___builtin_clz" >&6; }
+    if test yes = $have___builtin_clz; then :
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE___BUILTIN_CLZ 1
+_ACEOF
+
+fi;
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for __builtin_clzl" >&5
+$as_echo_n "checking for __builtin_clzl... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+__builtin_clzl(0);
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  have___builtin_clzl=yes
+else
+  have___builtin_clzl=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have___builtin_clzl" >&5
+$as_echo "$have___builtin_clzl" >&6; }
+    if test yes = $have___builtin_clzl; then :
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE___BUILTIN_CLZL 1
+_ACEOF
+
+fi;
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for __builtin_clzll" >&5
+$as_echo_n "checking for __builtin_clzll... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+__builtin_clzll(0);
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  have___builtin_clzll=yes
+else
+  have___builtin_clzll=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have___builtin_clzll" >&5
+$as_echo "$have___builtin_clzll" >&6; }
+    if test yes = $have___builtin_clzll; then :
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE___BUILTIN_CLZLL 1
+_ACEOF
+
+fi;
 
 
 #


### PR DESCRIPTION
Compared to the old CLog2Int code, on my machine the new code using
compiler builtins is between 5 and 10 times faster, and the new generic
code is still 1.2 to 4 times faster.

The new FuncLog2Int calls CLog2Int (or rather, the new static inline
function CLog2UInt which expects an unsigned argument), and thus
benefits from the optimizations as well (though not by as much).

Some micro benchmarks, using the old code:

gap> x:=2^0;; for a in [0..2^25] do Log2Int(x); od; time;
998
gap> x:=2^50;; for a in [0..2^25] do Log2Int(x); od; time;
1916
gap> x:=2^60;; for a in [0..2^25] do Log2Int(x); od; time;
1312
gap> x:=2^80;; for a in [0..2^25] do Log2Int(x); od; time;
2773
gap> x:=2^180;; for a in [0..2^25] do Log2Int(x); od; time;
1504

New code:

gap> x:=2^0;; for a in [0..2^25] do Log2Int(x); od; time;
955
gap> x:=2^50;; for a in [0..2^25] do Log2Int(x); od; time;
970
gap> x:=2^60;; for a in [0..2^25] do Log2Int(x); od; time;
1045
gap> x:=2^80;; for a in [0..2^25] do Log2Int(x); od; time;
1020
gap> x:=2^180;; for a in [0..2^25] do Log2Int(x); od; time;
1007
