### PR TITLE
lib: fix regression in meataxe code that broke grpauto.tst

### DIFF
--- a/lib/meataxe.gi
+++ b/lib/meataxe.gi
@@ -2980,7 +2980,7 @@ local cf,dim,b,den,sub,i,s,q,found,qb;
             qb:=b{[den+1..Length(b)]}; # basis
             qb:=List(s,x->x*qb);
             qb:=Concatenation(b{[1..den]},qb);
-            TriangulizeMat(qb);
+            qb:=TriangulizedMat(qb);
             Add(sub,qb);
             s:=SMTX.InducedAction(q,s,3);
             b:=Concatenation(b{[1..den]},s[3]*b{[den+1..Length(b)]});

--- a/tst/testinstall/meataxe.tst
+++ b/tst/testinstall/meataxe.tst
@@ -155,4 +155,37 @@ gap> MTX.IsIrreducible(randM);
 true
 
 #
+# Tests for individual Smash meataxe functions
+#
+
+#
+gap> m:=RegularModule(SymmetricGroup(3), GF(2));
+[ [ (1,2,3), (1,2) ], 
+  rec( IsOverFiniteField := true, dimension := 6, field := GF(2), 
+      generators := [ <an immutable 6x6 matrix over GF2>, 
+          <an immutable 6x6 matrix over GF2> ], isMTXModule := true ) ]
+gap> res:=SMTX.BasesCSSmallDimUp(m[2]);
+[ [  ], [ <a GF2 vector of length 6> ], 
+  [ <a GF2 vector of length 6>, <a GF2 vector of length 6> ], 
+  [ <a GF2 vector of length 6>, <a GF2 vector of length 6>, 
+      <a GF2 vector of length 6>, <a GF2 vector of length 6> ], 
+  [ <a GF2 vector of length 6>, <a GF2 vector of length 6>, 
+      <a GF2 vector of length 6>, <a GF2 vector of length 6>, 
+      <a GF2 vector of length 6>, <a GF2 vector of length 6> ] ]
+gap> Display(Concatenation(res));
+ 1 1 1 1 1 1
+ 1 . . 1 1 .
+ . 1 1 . . 1
+ 1 . . . 1 1
+ . 1 . . 1 .
+ . . 1 . 1 1
+ . . . 1 . 1
+ 1 . . . . .
+ . 1 . . . .
+ . . 1 . . .
+ . . . 1 . .
+ . . . . 1 .
+ . . . . . 1
+
+#
 gap> STOP_TEST("meataxe.tst", 10000);


### PR DESCRIPTION
Note: I have not yet tested whether this fixes *all* problems.

Also: I would like to create a faster test case for reproducing the issue, which can be added to testinstall. But not tonight :)