### PR TITLE
Make HasSolvableFactorGroup slightly more efficient

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -5070,8 +5070,11 @@ end);
 #M  HasSolvableFactorGroup(<G>,<N>)   test whether G/N is solvable
 ##
 InstallGlobalFunction(HasSolvableFactorGroup,function(G,N)
+local s,l;
   Assert(2,IsNormal(G,N) and IsSubgroup(G,N));
-  return ForAny(DerivedSeriesOfGroup(G),x->IsSubset(N,x));
+  s := DerivedSeriesOfGroup(G);
+  l := Length(s);
+  return IsSubgroup(N,s[l]);
 end);
 
 #############################################################################


### PR DESCRIPTION
Old method checked if any element of ````DerivedSeries```` is in ````N````. Now it only checks for the last element. 