### PR TITLE
Fix MakeExternalFilename handling 'fail' when in Cygwin correctly

### DIFF
--- a/lib/files.gi
+++ b/lib/files.gi
@@ -142,7 +142,7 @@ end );
 BindGlobal("MakeExternalFilename",
   function(name)
     local path, prefix;
-    if ARCH_IS_WINDOWS() then
+    if ARCH_IS_WINDOWS() and name <> fail then
         prefix := First( [ "/proc/cygdrive/", "/cygdrive/" ], s -> StartsWith( name, s ) );
         if prefix <> fail then
             path := Concatenation("C:",name{[Length(prefix)+2..Length(name)]});

--- a/tst/testinstall/dir.tst
+++ b/tst/testinstall/dir.tst
@@ -18,4 +18,16 @@ gap> SortedList(DirectoryContents(dirTest));
 [ ".", "..", "A", "B", "C", "D" ]
 gap> SortedList(DirectoryContents(Directory(dirTest)));
 [ ".", "..", "A", "B", "C", "D" ]
+gap> if ARCH_IS_WINDOWS() then
+> Print(ExternalFilename(Directory("/illegal"), "filename") = "\\illegal\\filename",
+>       ExternalFilename([Directory("/illegal")], "filename") = fail,
+>       ExternalFilename(Directory("/proc/cygdrive/C/"), "filename") = "C:\\filename",
+>       ExternalFilename(Directory("/cygdrive/Q/"), "filename") = "Q:\\filename","\n");
+> else
+> Print(ExternalFilename(Directory("/illegal"), "filename") = "/illegal/filename",
+>       ExternalFilename([Directory("/illegal")], "filename") = fail,
+>       ExternalFilename(Directory("/proc/cygdrive/C/"), "filename") = "/proc/cygdrive/C/filename",
+>       ExternalFilename(Directory("/cygdrive/Q/"), "filename") = "/cygdrive/Q/filename","\n");
+> fi;
+truetruetruetrue
 gap> STOP_TEST("dir.tst", 270000);


### PR DESCRIPTION
This is a tiny fix to handle an inconsistency in `ExternalFilename`, which returns `fail` for invalid filenames on linux/mac, but crashes on windows.

This fixes loading GRAPE on windows without having dreadnaut built.

This function isn't documented.. and I can't be bothered to write any right now. I did write a little test.