### PR TITLE
travis: enable coverage reporting for 32bit builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       after_success:
           - bash <(curl -s https://codecov.io/bash)
     - os: linux
-      env: TEST_SUITE=testbugfix  CFLAGS="-fprofile-arcs -ftest-coverage" LDFLAGS="-fprofile-arcs"
+      env: TEST_SUITE=testbugfix CFLAGS="-fprofile-arcs -ftest-coverage" LDFLAGS="-fprofile-arcs"
       compiler: gcc
       addons:
         apt_packages:
@@ -46,12 +46,13 @@ matrix:
          - texlive-fonts-recommended
          - texlive-fonts-extra
     - os: linux
-      env: TEST_SUITE=testtravis ABI=32
+      env: TEST_SUITE=testtravis ABI=32 CFLAGS="-fprofile-arcs -ftest-coverage -m32" LDFLAGS="-fprofile-arcs"
       compiler: gcc
       addons: 
         apt_packages:
           - libgmp-dev:i386
           - gcc-multilib
+          - g++-multilib
       after_success:
           - bash <(curl -s https://codecov.io/bash)
 

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -8,6 +8,11 @@
 
 set -ex
 
+if [[ x"$ABI" == "x32" ]]
+then
+  CONFIGFLAGS="CFLAGS=-m32 LDFLAGS=-m32 LOPTS=-m32 CXXFLAGS=-m32"
+fi
+
 if [[ $TEST_SUITE = 'makemanuals' && $TRAVIS_OS_NAME = 'linux' ]]
 then
     make manuals
@@ -24,16 +29,16 @@ else
         exit 1
     fi
 
-    if [[ x"$ABI" == "x32" ]]
+    if [[ x"$COVERAGE" == "xno" ]]
     then
         sh bin/gap.sh tst/${TEST_SUITE}.g
     else
         cd pkg/io*
-        ./configure
+        ./configure $CONFIGFLAGS
         make
         cd ../..
         cd pkg/profiling*
-        ./configure
+        ./configure $CONFIGFLAGS
         make
         cd ../..
 


### PR DESCRIPTION
This is currently blocked by gap-packages/profiling#34

Also, I vaguely recall that profiling may only be available in 64bit build, but I couldn't find anything about that in the manual - perhaps @ChrisJefferson can comment? In that case I would modify this to only collect gcov results.