### PR TITLE
Do not profile the 'return' statements inserted into the end of functions

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -222,14 +222,16 @@ Stat fillFilenameLine(Int fileid, Int line, Int size, Int type)
 **  'NewStat'   allocates a new   statement memory block  of  type <type> and
 **  <size> bytes.  'NewStat' returns the identifier of the new statement.
 **
-**  NewStat( <type>, <size>, <line> ) allows the line number of the statement
-**  to also be specified (else the current line when NewStat is called is
-**  used).
+**  NewStatWithProf( <type>, <size>, <line>, <file> ) allows the line number
+**  and fileid of the statement to also be specified, else the current line
+**  and file when NewStat was called is used. line=0, file=0 is used
+**  to denote a statement which should not be tracked.
 */
-Stat NewStatWithLine (
+static Stat NewStatWithProf (
     UInt                type,
     UInt                size,
-    UInt                line)
+    UInt                line,
+    UInt                file)
 {
     Stat                stat;           /* result                          */
 
@@ -248,10 +250,9 @@ Stat NewStatWithLine (
         ResizeBag( BODY_FUNC(CURR_FUNC), 2*SIZE_BAG(BODY_FUNC(CURR_FUNC)) );
         TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
-    setup_gapname(TLS(Input));
     
     /* enter type and size                                                 */
-    ADDR_STAT(stat)[-1] = fillFilenameLine(TLS(Input)->gapnameid, line, size, type);
+    ADDR_STAT(stat)[-1] = fillFilenameLine(file, line, size, type);
     RegisterStatWithProfiling(stat);
     /* return the new statement                                            */
     return stat;
@@ -261,8 +262,11 @@ Stat NewStat (
     UInt                type,
     UInt                size)
 {
-    return NewStatWithLine(type, size, TLS(Input)->number);
+    setup_gapname(TLS(Input));
+
+    return NewStatWithProf(type, size, TLS(Input)->number, TLS(Input)->gapnameid);
 }
+
 
 
 /****************************************************************************
@@ -835,7 +839,7 @@ void CodeFuncExprEnd (
         if ( TNUM_STAT(stat1) != T_RETURN_VOID
           && TNUM_STAT(stat1) != T_RETURN_OBJ )
         {
-            CodeReturnVoid();
+            CodeReturnVoidWhichIsNotProfiled();
             nr++;
         }
     }
@@ -1448,6 +1452,10 @@ void CodeReturnObj ( void )
 **
 **  'CodeReturnVoid' is the action  to  code a return-void-statement.   It is
 **  called when the reader encounters a 'return;'.
+**
+**  'CodeReturnVoidWhichIsNotProfiled' creates a return which will not
+**  be tracked by profiling. This is used for the implicit return put
+**  at the end of functions.
 */
 void CodeReturnVoid ( void )
 {
@@ -1455,6 +1463,18 @@ void CodeReturnVoid ( void )
 
     /* allocate the return-statement                                       */
     stat = NewStat( T_RETURN_VOID, 0 * sizeof(Expr) );
+
+    /* push the return-statement                                           */
+    PushStat( stat );
+}
+
+void CodeReturnVoidWhichIsNotProfiled ( void )
+{
+    Stat                stat;           /* return-statement, result        */
+
+    /* allocate the return-statement, without profile information          */
+
+    stat = NewStatWithProf( T_RETURN_VOID, 0 * sizeof(Expr), 0, 0 );
 
     /* push the return-statement                                           */
     PushStat( stat );

--- a/src/code.h
+++ b/src/code.h
@@ -867,9 +867,13 @@ extern  void            CodeReturnObj ( void );
 **
 **  'CodeReturnVoid' is the action  to  code a return-void-statement.   It is
 **  called when the reader encounters a 'return;'.
+**
+**  'CodeReturnVoidWhichIsNotProfiled' creates a return which will not
+**  be tracked by profiling. This is used for the implicit return put
+**  at the end of functions.
 */
 extern  void            CodeReturnVoid ( void );
-
+extern  void            CodeReturnVoidWhichIsNotProfiled ( void );
 
 /****************************************************************************
 **

--- a/src/profile.c
+++ b/src/profile.c
@@ -343,6 +343,10 @@ void InstallPrintExprFunc(Int pos, void(*expr)(Expr)) {
 static inline UInt getFilenameId(Stat stat)
 {
   UInt id = FILENAMEID_STAT(stat);
+  if(id == 0)
+  {
+    return 0;
+  }
   if(LEN_PLIST(OutputtedFilenameList) < id || ELM_PLIST(OutputtedFilenameList,id) != True)
   {
     if(LEN_PLIST(OutputtedFilenameList) < id) {
@@ -396,6 +400,14 @@ static inline void outputStat(Stat stat, int exec, int visited)
   }
 
   nameid = getFilenameId(stat);
+
+  // Statement not attached to a file
+  if(nameid == 0)
+  {
+    HashUnlock(&profileState);
+    return;
+  }
+
   line = LINE_STAT(stat);
   if(profileState.lastOutputted.line != line ||
      profileState.lastOutputted.fileID != nameid ||


### PR DESCRIPTION
This stops us marking the 'end' statements of functions as not executed in profiling, which is really us marking the 'return;' statement which is transparently inserted by the GAP parser at the end of functions.

There is a test for this in the `profiling` package. (we can't really test it in GAP itself, except of course by looking at the profiling output and seeing the ends hopefully no longer marked unexecuted!)