### PR TITLE
Fix regression in group constructors for matrix groups

### DIFF
--- a/grp/basic.gd
+++ b/grp/basic.gd
@@ -135,7 +135,6 @@ BindGlobal( "AbelianGroup", function ( arg )
     fi;
     return AbelianGroupCons( IsPcGroup, arg[1] );
   elif IsOperation(arg[1]) then
-
     if Length(arg) = 2  then
       return AbelianGroupCons( arg[1], arg[2] );
     fi;
@@ -257,9 +256,11 @@ BindGlobal( "CyclicGroup", function ( arg )
     fi;
     return CyclicGroupCons( IsPcGroup, arg[1] );
   elif IsOperation(arg[1]) then
-
     if Length(arg) = 2  then
       return CyclicGroupCons( arg[1], arg[2] );
+    elif Length(arg) = 3  then
+      # some filters require extra arguments, e.g. IsMatrixGroup + field
+      return CyclicGroupCons( arg[1], arg[2], arg[3] );
     fi;
   fi;
   Error( "usage: CyclicGroup( [<filter>, ]<size> )" );
@@ -311,7 +312,6 @@ BindGlobal( "DihedralGroup", function ( arg )
   if Length(arg) = 1  then
     return DihedralGroupCons( IsPcGroup, arg[1] );
   elif IsOperation(arg[1]) then
-
     if Length(arg) = 2  then
       return DihedralGroupCons( arg[1], arg[2] );
     fi;
@@ -368,9 +368,11 @@ BindGlobal( "QuaternionGroup", function ( arg )
   if Length(arg) = 1  then
     return QuaternionGroupCons( IsPcGroup, arg[1] );
   elif IsOperation(arg[1]) then
-
     if Length(arg) = 2  then
       return QuaternionGroupCons( arg[1], arg[2] );
+    elif Length(arg) = 3  then
+      # some filters require extra arguments, e.g. IsMatrixGroup + field
+      return QuaternionGroupCons( arg[1], arg[2], arg[3] );
     fi;
   fi;
   Error( "usage: QuaternionGroup( [<filter>, ]<size> )" );
@@ -422,7 +424,6 @@ BindGlobal( "ElementaryAbelianGroup", function ( arg )
   if Length(arg) = 1  then
     return ElementaryAbelianGroupCons( IsPcGroup, arg[1] );
   elif IsOperation(arg[1]) then
-
     if Length(arg) = 2  then
       return ElementaryAbelianGroupCons( arg[1], arg[2] );
     fi;
@@ -474,7 +475,6 @@ BindGlobal( "FreeAbelianGroup", function ( arg )
   if Length(arg) = 1  then
     return FreeAbelianGroupCons( IsFpGroup, arg[1] );
   elif IsOperation(arg[1]) then
-
     if Length(arg) = 2  then
       return FreeAbelianGroupCons( arg[1], arg[2] );
     fi;
@@ -539,7 +539,6 @@ BindGlobal( "ExtraspecialGroup", function ( arg )
   if Length(arg) = 2  then
     return ExtraspecialGroupCons( IsPcGroup, arg[1], arg[2] );
   elif IsOperation(arg[1]) then
-
     if Length(arg) = 3  then
       return ExtraspecialGroupCons( arg[1], arg[2], arg[3] );
     fi;
@@ -592,7 +591,6 @@ BindGlobal( "MathieuGroup", function( arg )
   if Length( arg ) = 1 then
     return MathieuGroupCons( IsPermGroup, arg[1] );
   elif IsOperation( arg[1] ) then
-
     if Length( arg ) = 2 then
       return MathieuGroupCons( arg[1], arg[2] );
     fi;

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -74,6 +74,11 @@ gap> CyclicGroup(IsPermGroup,4);
 Group([ (1,2,3,4) ])
 gap> CyclicGroup(IsFpGroup,4);
 <fp group of size 4 on the generators [ a ]>
+gap> G:=CyclicGroup(IsMatrixGroup, GF(2), 12);
+<matrix group of size 12 with 1 generators>
+gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
+GF(2)
+12
 
 #
 gap> CyclicGroup(2,3);
@@ -112,6 +117,11 @@ gap> QuaternionGroup(IsPermGroup,8);
 Group([ (1,5,3,7)(2,8,4,6), (1,2,3,4)(5,6,7,8) ])
 gap> QuaternionGroup(IsFpGroup,8);
 <fp group of size 8 on the generators [ r, s ]>
+gap> G:=QuaternionGroup(IsMatrixGroup, GF(3), 8);
+<matrix group of size 8 with 2 generators>
+gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
+GF(3)
+4
 
 #
 gap> QuaternionGroup(2,3);


### PR DESCRIPTION
This fixes the regression reported by @alex-konovalov 

(The fact that the manual examples uncovered this motivated me to submit issue #1076).

I still find these constructors a bit weird and arbitrary. Section 50.1 says that you can spcecify a ground field for matrix groups. Fine, but there in realit only methods for cyclic groups and quaternion groups, but not for all the others (abelian, extraspecial, elementary abelian, free abelian, Mathieu group). Also you can specify a dimension (and even if you could, then in general that would of course not define a unique representation).

Anyway, those are not excuses for breaking something :-).