### PR TITLE
Add option to ignore user configuration options

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -660,7 +660,9 @@ DeclareUserPreference( rec(
   ) );
 
 CallAndInstallPostRestore( function()
-    READ_GAP_ROOT( "gap.ini" );
+    if not GAPInfo.CommandLineOptions.ignoreconfig then
+      READ_GAP_ROOT( "gap.ini" );
+    fi;
 end );
 
 
@@ -808,6 +810,9 @@ end );
 ##  then read the first `gaprc' file from the GAP root directories.
 ##
 CallAndInstallPostRestore( function()
+    if GAPInfo.CommandLineOptions.ignoreconfig then
+      return;
+    fi;
     if READ_GAP_ROOT( "gaprc" ) then
       GAPInfo.HasReadGAPRC:= true;
     elif not IsExistingFile(GAPInfo.UserGapRoot) then

--- a/lib/system.g
+++ b/lib/system.g
@@ -109,6 +109,8 @@ BIND_GLOBAL( "GAPInfo", rec(
            help := [ "Run ProfileLineByLine(<filename>) on GAP start"] ),
       rec( long := "cover", default := "", arg := "<file>",
            help := [ "Run CoverageLineByLine(<filename>) on GAP start"] ),
+      rec( long := "ignoreconfig", default := false,
+           help := [ "disable/enable reading user configuration files"] ),
           ],
     ) );
 


### PR DESCRIPTION
Implements #1086 . Basically, provides a command line option `--ignoreconfig`, which disables reading of both gap.ini and gaprc. This is useful for tests which don't want to be effected by user's preferences.