### PR TITLE
Add READ_ALL_COMMANDS

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -98,6 +98,70 @@ Int READ_COMMAND ( void )
     return 1;
 }
 
+
+/*
+ * This function reads all code from the stream and returns either `fail` if the stream
+ * cannot be opened, or a list of lists of length at most two, where the first entry is
+ * either `true` or `false` depending on whether the statement was successfuly executed
+ * and the second entry is the result of the statement if there was one.
+ *
+ * This function is curently used in interactive tools such as the GAP Jupyter kernel to
+ * execute cells and is likely to be replaced by a function that can read a single command
+ * from a stream without losing the rest of its content.
+ */
+Obj FuncREAD_ALL_COMMANDS( Obj self, Obj stream, Obj echo )
+{
+    ExecStatus status;
+    Int resultCount, resultCapacity;
+    Obj result, resultList;
+
+    /* try to open the stream */
+    if (!OpenInputStream(stream) ) {
+      return Fail;
+    }
+
+    resultCount = 0;
+    resultCapacity = 16;
+    resultList = NEW_PLIST( T_PLIST, resultCapacity );
+    SET_LEN_PLIST(resultList, resultCount);
+
+    if (echo == True) {
+        TLS(Input)->echo = 1;
+    } else {
+        TLS(Input)->echo = 0;
+    }
+
+    do {
+        ClearError();
+        status = ReadEvalCommand(TLS(BottomLVars), 0);
+
+        if(!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT))) {
+            resultCount++;
+            if (resultCount > resultCapacity) {
+                resultCapacity += 16;
+                GROW_PLIST(resultList, resultCapacity);
+            }
+            result = NEW_PLIST( T_PLIST, 2 );
+            SET_LEN_PLIST(result, 1);
+            SET_ELM_PLIST(result, 1, False);
+            SET_ELM_PLIST(resultList, resultCount, result );
+            SET_LEN_PLIST(resultList, resultCount );
+
+            if(!(status & STATUS_ERROR)) {
+                SET_ELM_PLIST(result, 1, True);
+                if (TLS(ReadEvalResult)) {
+                    SET_LEN_PLIST(result, 2);
+                    SET_ELM_PLIST(result, 2, TLS(ReadEvalResult));
+                }
+            }
+        }
+    } while(!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT)));
+    CloseInput();
+    ClearError();
+
+    return resultList;
+}
+
 /*
  Returns a list with one or two entries. The first
  entry is set to "false" if there was any error
@@ -2220,6 +2284,9 @@ static StructGVarFunc GVarFuncs [] = {
 
     { "READ_NORECOVERY", 1L, "filename",
       FuncREAD_NORECOVERY, "src/streams.c:READ_NORECOVERY" },
+
+    { "READ_ALL_COMMANDS", 2L, "stream, echo",
+      FuncREAD_ALL_COMMANDS, "src/streams.c:READ_ALL_COMMANDS" },
 
     { "READ_COMMAND_REAL", 2L, "stream, echo",
       FuncREAD_COMMAND_REAL, "src/streams.c:READ_COMMAND_REAL" },

--- a/tst/testinstall/read.tst
+++ b/tst/testinstall/read.tst
@@ -85,4 +85,17 @@ gap> FileString( Filename(dir, "test.g.gz"), "\037\213\b\b0,\362W\000\ctest.g\00
 32
 gap> StringFile( Filename(dir, "test.g") ) = "1+1;\n" or ARCH_IS_WINDOWS(); # works only when Cygwin installed with gzip
 true
+gap> READ_ALL_COMMANDS(InputTextString(""), false);
+[  ]
+gap> READ_ALL_COMMANDS(InputTextString("a := (3,7,1); y := a^(-1);"), false);
+[ [ true, (1,3,7) ], [ true, (1,7,3) ] ]
+gap> READ_ALL_COMMANDS(InputTextString("Unbind(x); z := x;"), false);
+Error, Variable: 'x' must have a value
+[ [ true ], [ false ] ]
+gap> p := READ_ALL_COMMANDS(InputTextString("1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16;17;18;"), false);;
+gap> p;
+[ [ true, 1 ], [ true, 2 ], [ true, 3 ], [ true, 4 ], [ true, 5 ], 
+  [ true, 6 ], [ true, 7 ], [ true, 8 ], [ true, 9 ], [ true, 10 ], 
+  [ true, 11 ], [ true, 12 ], [ true, 13 ], [ true, 14 ], [ true, 15 ], 
+  [ true, 16 ], [ true, 17 ], [ true, 18 ] ]
 gap> STOP_TEST( "read.tst", 220000);


### PR DESCRIPTION
This function allows to interpret all statements from a
InputTextStream until EOF is reached.

The result is either `fail` or a list of lists of up to two entries, one for
each statement:
 * If the stream cannot be opened the result is `fail`
 * If the execution of the statement was successful, then the
   first entry of the list is true. If the statement had a value
   then the second entry is this value
 * If the execution of a statement failed, then the first entry
   of the list is false.
