### PR TITLE
kernel: remove OpenAppendStream

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -929,7 +929,7 @@ UInt OpenOutput (
 **
 *F  OpenOutputStream( <stream> )  . . . . . . open a stream as current output
 **
-**  The same as 'OpenOutput' but for streams.
+**  The same as 'OpenOutput' (and also 'OpenAppend') but for streams.
 */
 
 Obj PrintFormattingStatus;
@@ -1047,19 +1047,6 @@ UInt OpenAppend (
 
     /* indicate success                                                    */
     return 1;
-}
-
-
-/****************************************************************************
-**
-*F  OpenAppendStream( <stream> )  . . . . . . open a stream as current output
-**
-**  The same as 'OpenAppend' but for streams.
-*/
-UInt OpenAppendStream (
-    Obj                 stream )
-{
-    return OpenOutputStream(stream);
 }
 
 

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -743,7 +743,7 @@ extern UInt OpenOutput (
 **
 *F  OpenOutputStream( <stream> )  . . . . . . open a stream as current output
 **
-**  The same as 'OpenOutput' but for streams.
+**  The same as 'OpenOutput' (and also 'OpenAppend') but for streams.
 */
 extern UInt OpenOutputStream (
     Obj                 stream );
@@ -782,16 +782,6 @@ extern UInt CloseOutput ( void );
 */
 extern UInt OpenAppend (
     const Char *        filename );
-
-
-/****************************************************************************
-**
-*F  OpenAppendStream( <stream> )  . . . . . . open a stream as current output
-**
-**  The same as 'OpenAppend' but for streams.
-*/
-extern UInt OpenAppendStream (
-    Obj                 stream );
 
 
 /****************************************************************************

--- a/src/streams.c
+++ b/src/streams.c
@@ -809,8 +809,7 @@ static Obj PRINT_OR_APPEND_TO_STREAM(Obj args, int append)
     stream = ELM_LIST(args,1);
 
     /* try to open the file for output                                     */
-    i = append ? OpenAppendStream(stream)
-               : OpenOutputStream(stream);
+    i = OpenOutputStream(stream);
     if ( ! i ) {
         ErrorQuit( "%s: cannot open stream for output", (Int)funcname, 0L );
         return 0;
@@ -875,6 +874,9 @@ Obj FuncPRINT_TO_STREAM (
     Obj                 self,
     Obj                 args )
 {
+    /* Note that FuncPRINT_TO_STREAM and FuncAPPEND_TO_STREAM do exactly the
+       same, they only differ in the function name they print as part
+       of their error messages. */
     return PRINT_OR_APPEND_TO_STREAM(args, 0);
 }
 
@@ -899,6 +901,9 @@ Obj FuncAPPEND_TO_STREAM (
     Obj                 self,
     Obj                 args )
 {
+    /* Note that FuncPRINT_TO_STREAM and FuncAPPEND_TO_STREAM do exactly the
+       same, they only differ in the function name they print as part
+       of their error messages. */
     return PRINT_OR_APPEND_TO_STREAM(args, 1);
 }
 
@@ -925,18 +930,14 @@ Obj FuncSET_OUTPUT (
           }
         }
     } else {  /* an open stream */
-        if ( append != False ) {
-          if ( ! OpenAppendStream( file ) ) {
+        if ( ! OpenOutputStream( file ) ) {
+          if ( append != False ) {
              ErrorQuit( "SET_OUTPUT: cannot open stream for appending", 0L, 0L );
           } else {
-             return 0;
+             ErrorQuit( "SET_OUTPUT: cannot open stream for output", 0L, 0L );
           }
         } else {
-          if ( ! OpenOutputStream( file ) ) {
-             ErrorQuit( "SET_OUTPUT: cannot open stream for output", 0L, 0L );
-          } else {
-            return 0;
-          }
+          return 0;
         }
     }
     return 0;

--- a/tst/testinstall/streams.tst
+++ b/tst/testinstall/streams.tst
@@ -1,0 +1,37 @@
+gap> START_TEST("streams.tst");
+
+#
+gap> tmpdir := DirectoryTemporary();;
+gap> fname := Filename(tmpdir, "data");;
+
+# write initial data
+gap> stream := OutputTextFile( fname, false );;
+gap> PrintTo( stream, "1");
+gap> AppendTo( stream, "2");
+gap> PrintTo( stream, "3");
+gap> CloseStream(stream);
+
+# verify it
+gap> StringFile(fname);
+"123"
+
+# append to initial data
+gap> stream := OutputTextFile( fname, true );;
+gap> PrintTo( stream, "4");
+gap> CloseStream(stream);
+
+# verify it
+gap> StringFile(fname);
+"1234"
+
+# overwrite initial data
+gap> stream := OutputTextFile( fname, false );;
+gap> PrintTo( stream, "new content");
+gap> CloseStream(stream);
+
+# verify it
+gap> StringFile(fname);
+"new content"
+
+#
+gap> STOP_TEST( "streams.tst", 10000);


### PR DESCRIPTION
It was simply a wrapper around OpenOutputStream and was confusing
in that it obfuscated the fact that printing and appending to
a stream do the same thing.
