### PR TITLE
Add .clang-format, .ctags and .editorconfig

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+#
+# Configure clang-format to a style that resembles a good subset
+# of the GAP kernel.
+#
+# For information on the settings in this file, please consult
+# <http://clang.llvm.org/docs/ClangFormatStyleOptions.html>
+# See also <https://clangformat.com/>
+
+AlignConsecutiveDeclarations: true
+AlignTrailingComments: true
+AllowShortBlocksOnASingleLine: true
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: true
+BinPackParameters: false
+BreakBeforeBraces: Stroustrup
+ColumnLimit: 78
+Cpp11BracedListStyle: false
+IndentCaseLabels: false
+IndentWidth: 4
+MaxEmptyLinesToKeep: 2
+PointerBindsToType: Middle
+SpacesBeforeTrailingComments: 4
+UseTab: Never

--- a/.ctags
+++ b/.ctags
@@ -1,0 +1,1 @@
+dev/ctags_for_gap

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# See http://EditorConfig.org
+
+# This is the top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file.
+# But do not trim trailing whitespaces -- while we
+# want that eventually, it just causes pain right now,
+# if it pollutes commits.
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = false
+indent_style = space
+indent_size = 4
+charset = utf-8
+
+# In Makefile one must use tab indentation
+[Makefile*]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,5 @@
 *.rej
 *.orig
 
-
+/tags
 /src/TAGS

--- a/Makefile.in
+++ b/Makefile.in
@@ -493,9 +493,13 @@ bootstrap-pkg-full:
         tar xzf ../$(PKG_FULL) ; \
     fi;
 
+# update ctags if requests
+tags:
+	ctags -R src lib grp
+
 .PHONY: clean clean_$(CLEANME) clean_gap clean_gap_$(CLEANME) clean_gmp clean_gmp_$(CLEANME) distclean
 .PHONY: compile config default extern manuals packages rebuild removewin setconfig static strip
 .PHONY: testinstall testinstall.g testmanuals testpackages testpackagesload testpackagesvars teststandard teststandardrenormalize
 .PHONY: cygwin removewin winbinp
 .PHONY: bootstrap-pkg-minimal bootstrap-pkg-full
-.PHONY: check
+.PHONY: check tags


### PR DESCRIPTION
This PR adds three files to the root directory:

1. `.ctags` is simply a copy of `dev/ctags_for_gap`. This makes it very easy to regenerate ctags. Indeed, I also added a `tags` target to the Makefile.

2. `.editorconfig` sets some default editor options, understood by various editors, see <http://editorconfig.org/>

3. `.clang-format` sets defaults for the `clang-format` C/C++ code formatter (see <https://clang.llvm.org/docs/ClangFormat.html>) which set a style similar to what is discussed on <https://github.com/gapdays/gap-sage-days2016/wiki/Code-formatting-recommendations> and which tries to be close to the "origina" GAP kernel code formatting (presumably due to Martin Schönert).

The goal of the latter two is to make it easier to apply consistent code formatting to GAP kernel sources *for those people who want that*. In particular, these files do not force anybody to accept any particular styling, nor are there plans to reformat the whole code base or anything.