### PR TITLE
Remove unused 'Randomizer'

### DIFF
--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -3249,13 +3249,6 @@ DeclareFilter( "CanComputeSize" );
 
 InstallTrueMethod( CanComputeSize, HasSize );
 
-
-DeclareOperation( "Randomizer", [IsCollection] );
-DeclareOperation( "CheapRandomizer", [IsCollection] );
-
-DeclareAttribute( "RandomizerAttr", IsCollection );
-DeclareAttribute( "CheapRandomizerAttr", IsCollection );
-
 # to allow for recusive calls
 DeclareGlobalFunction("JoinRanges");
 


### PR DESCRIPTION
This just removes `Randomizer` and `CheapRandomizer`. They have been in the code for a long time, but no method is installed in the library, or any package, and there is no mention of them in the docs.