### PR TITLE
 Fix: Isomorphisms of trivial groups are bijective

### DIFF
--- a/lib/ghom.gi
+++ b/lib/ghom.gi
@@ -1402,7 +1402,9 @@ BindGlobal( "IsomorphismAbelianGroupViaIndependentGenerators", function ( filter
 
   if IsTrivial( G ) then
     K := TrivialGroup( filter );
-    return GroupHomomorphismByImagesNC( G, K, [], [] );
+    nice := GroupHomomorphismByImagesNC( G, K, [], [] );
+    SetIsBijective( nice, true );
+    return nice;
   fi;
 
   gens := IndependentGeneratorsOfAbelianGroup( G );

--- a/tst/testinstall/triviso.tst
+++ b/tst/testinstall/triviso.tst
@@ -13,4 +13,8 @@ gap> phi := IsomorphismPermGroup(G);
 [  ] -> [  ]
 gap> HasIsBijective(phi);
 true
+gap> inv := InverseGeneralMapping(phi);
+[  ] -> [  ]
+gap> HasIsMapping(inv);
+true
 gap> STOP_TEST( "triviso.tst", 10000);

--- a/tst/testinstall/triviso.tst
+++ b/tst/testinstall/triviso.tst
@@ -1,0 +1,16 @@
+#############################################################################
+##
+#W  triviso.tst
+#Y  Bernhard Reinke
+##
+#############################################################################
+##
+
+gap> START_TEST("triviso.tst");
+gap> G := Group(());
+Group(())
+gap> phi := IsomorphismPermGroup(G);
+[  ] -> [  ]
+gap> HasIsBijective(phi);
+true
+gap> STOP_TEST( "triviso.tst", 10000);


### PR DESCRIPTION
The group homomorphism returned by
IsomorphismAbelianGroupViaIndependentGenerators should always have
IsBijective set. This was not the case when the given group was trivial.

### Tick all what applies to this pull request

- [ ] Adds new features
- [ ] Improves and extends functionality
- [ ] Fixes bugs that could lead to crashes
- [ ] Fixes bugs that could lead to incorrect results
- [x] Fixes bugs that could lead to break loops

### Write below the description of changes (for the release notes)

The group homomorphism returned by IsomorphismAbelianGroupViaIndependentGenerators has also IsBijective set if the given group was trivial.