### PR TITLE
Remove colors from log files created by BuildPackages.sh

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -29,6 +29,13 @@ std_error() {
     printf "\033[31mERROR: %s\033[0m\n" "$@"
 }
 
+nocolor(){
+    sed -e 's|\x1b\[31mERROR: ||g' \
+        -e 's|\x1b\[32m||g' \
+        -e 's|\x1b\[33mWARNING: ||g' \
+        -e 's|\x1b\[0m||g'
+}
+
 build_packages() {
 
 # This script attempts to build all GAP packages contained in the current
@@ -291,14 +298,16 @@ do
   if [[ -e "$CURDIR/$PKG/PackageInfo.g" ]]
   then
     (build_one_package "$PKG" \
-     > >(tee "$LOGDIR/$PKG.out") \
+     > >(tee >( nocolor > "$LOGDIR/$PKG.out" ) ) \
     2> >(while read line
          do \
            std_error "$line"
          done \
-         > >(tee "$LOGDIR/$PKG.err" >&2) \
+         > >(tee >( nocolor > "$LOGDIR/$PKG.err" ) >&2 ) \
          ) \
-    )> >(tee "$LOGDIR/$PKG.log" ) 2>&1
+    )> >(tee >( nocolor > "$LOGDIR/$PKG.log" ) ) 2>&1
+
+sleep 1
 
     # remove superfluous log files if there was no error message
     if [[ ! -s "$LOGDIR/$PKG.err" ]]
@@ -326,14 +335,16 @@ notice "Packages failed to build are in ./$LOGDIR/$FAILPKGFILE.log"
 
 # Log error to .err, output to .out, everything to .log
 ( build_packages "$@" \
- > >(tee "$LOGDIR/$LOGFILE.out") \
+ > >(tee >( nocolor > "$LOGDIR/$LOGFILE.out" ) ) \
 2> >(while read line
      do \
        std_error "$line"
      done \
-     > >(tee "$LOGDIR/$LOGFILE.err" >&2) \
+     > >(tee >( nocolor > "$LOGDIR/$LOGFILE.err" ) >&2 ) \
     ) \
-)> >( tee "$LOGDIR/$LOGFILE.log" ) 2>&1
+)> >( tee >( nocolor > "$LOGDIR/$LOGFILE.log" ) ) 2>&1
+
+sleep 1
 
 # remove superfluous buildpackages log files if there was no error message
 if [[ ! -s "$LOGDIR/$LOGFILE.err" ]]


### PR DESCRIPTION
This is another attempt to fix #1120 (the alternative is in #1121). 
The colors still appear on terminal but are removed before writing to the log files. Tested and seems to work as intended.

HELP needed: I added two lines with ````sleep 1```` (lines 310 and 347), because for some reason the ````$PKG.err```` files are created with some delay. Without the sleep, the script does not find the ````$PKG.err```` file, hence removes both ````$PKG.err```` and ````$PKG.out```` (in lines 312-317). Anyone has any idea why this is happening and how it could be circumvented? I managed to identify that the cause of this error is line 306.