### PR TITLE
Add --no-color option to BuildPackages.sh

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -184,23 +184,6 @@ std_error() {
   fi
 }
 
-### The main function to be run, its output is going to be logged.
-build_packages() {
-
-notice "Using GAP location: $GAPDIR"
-echo ""
-
-set_packages
-set_build_flags_for_32_bit
-set_make
-
-notice \
-"Attempting to build GAP packages." \
-"Note that many GAP packages require extra programs to be installed," \
-"and some are quite difficult to build. Please read the documentation for" \
-"packages which fail to build correctly, and only worry about packages" \
-"you require!" \
-"Logging into ./$LOGDIR/$LOGFILE.log"
 
 build_carat() {
 (
@@ -279,6 +262,7 @@ run_configure_and_make() {
   fi
 }
 
+
 build_one_package() {
   # requires one argument which is the package directory
   PKG="$1"
@@ -347,6 +331,25 @@ build_one_package() {
   esac
   ) || build_fail
 }
+
+
+### The main function to be run, its output is going to be logged.
+build_packages() {
+
+notice "Using GAP location: $GAPDIR"
+echo ""
+
+set_packages
+set_build_flags_for_32_bit
+set_make
+
+notice \
+"Attempting to build GAP packages." \
+"Note that many GAP packages require extra programs to be installed," \
+"and some are quite difficult to build. Please read the documentation for" \
+"packages which fail to build correctly, and only worry about packages" \
+"you require!" \
+"Logging into ./$LOGDIR/$LOGFILE.log"
 
 date >> "$LOGDIR/$FAILPKGFILE.log"
 for PKG in "${PACKAGES[@]}"

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -5,13 +5,24 @@
 # subdirectory of your GAP installation.
 
 # You can also run it from other locations, but then you need to tell the
-# script where your GAP root directory is, by passing it as _first_ argument
+# script where your GAP root directory is, by passing it as an argument
 # to the script with '--with-gaproot='. By default, the script assumes that
 # the parent of the current working directory is the GAP root directory.
 
 # By default the script colors its output, even in the log files. One can
-# turn it off by adding the argument --no-color _after_ --with-gaproot= (if
-# added) but _before_ all further arguments.
+# turn it off by adding the argument '--no-color'.
+
+# By default the logs are created into the './log' directory. This directory
+# can be changed by the argument '--with-logdir='.
+
+# By default the name of the main log file is 'buildpackages'. This filename
+# can be changed by the argument '--with-logfile='. Three files are created:
+# - one with .out extension containing the stdout output,
+# - one with .err extension containing the stderr output,
+# - one with .log extension containing the stdout and stderr together.
+
+# By default the packages failed to build are collected into the file named
+# 'fail'. This filename can be changed by the argument '--with-failpkgfile='.
 
 # If further arguments are added, then they are considered packages. In that
 # case only these packages will be built, and all others are ignored.
@@ -73,6 +84,39 @@ do
     --with-gaproot)
       shift
       GAPDIR="$1"
+      shift
+    ;;
+
+    --with-logdir=*)
+      LOGDIR=$(sed 's|--with-logdir=||' <<< "$1")
+      shift
+    ;;
+
+    --with-logdir)
+      shift
+      LOGDIR="$1"
+      shift
+    ;;
+
+    --with-logfile=*)
+      LOGFILE=$(sed 's|--with-logfile=||' <<< "$1")
+      shift
+    ;;
+
+    --with-logfile)
+      shift
+      LOGFILE="$1"
+      shift
+    ;;
+
+    --with-failpkgfile=*)
+      FAILPKGFILE=$(sed 's|--with-failpkgfile=||' <<< "$1")
+      shift
+    ;;
+
+    --with-failpkgfile)
+      shift
+      FAILPKGFILE="$1"
       shift
     ;;
 

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -11,13 +11,29 @@ then
 fi
 }
 
-LOGDIR=log
-mkdir -p "$LOGDIR"
+# set default parameters
+set_default_parameters() {
 
-LOGFILE=buildpackages
-FAILPKGFILE=fail
+# CURDIR
+CURDIR="$(pwd)"
 
+# default GAPDIR
+pushd .. >/dev/null
+GAPDIR="$(pwd)"
+popd >/dev/null
+
+# default COLOR
 COLOR=1
+
+# default LOGDIR
+LOGDIR=log
+
+# default LOGFILE
+LOGFILE=buildpackages
+
+# default FAILPKGFILE
+FAILPKGFILE=fail
+}
 
 # print notices in green
 notice() {
@@ -89,9 +105,6 @@ build_packages() {
 # an idea what to do for a complete installation of GAP.
 
 
-# CURDIR
-CURDIR="$(pwd)"
-
 # GAPDIR
 GAPDIR=""
 if [[ "$#" -ge 1 ]]
@@ -108,12 +121,6 @@ then
       cd "$CURDIR"
     ;;
   esac
-fi
-if [[ -z "$GAPDIR" ]]
-then
-  pushd ..
-  GAPDIR="$(pwd)"
-  popd
 fi
 
 # check if coloring should be turned off
@@ -371,7 +378,11 @@ notice "Packages failed to build are in ./$LOGDIR/$FAILPKGFILE.log"
 
 
 ### The main body of the script.
+set_default_parameters
 run_from_bin
+
+# Create LOGDIR
+mkdir -p "$LOGDIR"
 
 # Log error to .err, output to .out, everything to .log
 ( build_packages "$@" \

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -54,9 +54,7 @@ set_default_parameters() {
 CURDIR="$(pwd)"
 
 # default GAPDIR
-pushd .. >/dev/null
-GAPDIR="$(pwd)"
-popd >/dev/null
+GAPDIR="$(cd .. && pwd)"
 
 # default COLOR
 if [[ -t 1 ]]

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -108,6 +108,16 @@ then
 fi
 }
 
+# set build flags for 32 bit
+set_build_flags_for_32_bit(){
+if [[ "$(grep -c 'ABI_CFLAGS=-m32' $GAPDIR/Makefile)" -ge 1 ]]
+then
+  notice "Building with 32-bit ABI"
+  ABI32=YES
+  CONFIGFLAGS="CFLAGS=-m32 LDFLAGS=-m32 LOPTS=-m32 CXXFLAGS=-m32"
+fi
+}
+
 # packages to build
 set_packages(){
 if [[ "${PACKAGES[0]}" = "" ]]
@@ -168,14 +178,7 @@ notice "Using GAP location: $GAPDIR"
 echo ""
 
 set_packages
-
-if [[ "$(grep -c 'ABI_CFLAGS=-m32' $GAPDIR/Makefile)" -ge 1 ]]
-then
-  notice "Building with 32-bit ABI"
-  ABI32=YES
-  CONFIGFLAGS="CFLAGS=-m32 LDFLAGS=-m32 LOPTS=-m32 CXXFLAGS=-m32"
-fi
-
+set_build_flags_for_32_bit
 
 # Many package require GNU make. So use gmake if available,
 # for improved compatibility with *BSD systems where "make"

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -98,6 +98,16 @@ do
 done
 }
 
+# We need to test if $GAPDIR is right
+test_GAPDIR(){
+if ! [[ -f "$GAPDIR/sysinfo.gap" ]]
+then
+  error "$GAPDIR is not the root of a gap installation (no sysinfo.gap)" \
+        "Please provide the absolute path of your GAP root directory as" \
+        "first argument with '--with-gaproot=' to this script."
+fi
+}
+
 # packages to build
 set_packages(){
 if [[ "${PACKAGES[0]}" = "" ]]
@@ -158,14 +168,6 @@ notice "Using GAP location: $GAPDIR"
 echo ""
 
 set_packages
-
-# We need to test if $GAPDIR is right
-if ! [[ -f "$GAPDIR/sysinfo.gap" ]]
-then
-  error "$GAPDIR is not the root of a gap installation (no sysinfo.gap)" \
-        "Please provide the absolute path of your GAP root directory as" \
-        "first argument with '--with-gaproot=' to this script."
-fi
 
 if [[ "$(grep -c 'ABI_CFLAGS=-m32' $GAPDIR/Makefile)" -ge 1 ]]
 then
@@ -389,6 +391,7 @@ notice "Packages failed to build are in ./$LOGDIR/$FAILPKGFILE.log"
 set_default_parameters
 run_from_bin
 collect_arguments "$@"
+test_GAPDIR
 
 # Create LOGDIR
 mkdir -p "$LOGDIR"

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -1,5 +1,30 @@
 #!/usr/bin/env bash
 
+# This script attempts to build all GAP packages contained in the current
+# directory. Normally, you should run this script from the 'pkg'
+# subdirectory of your GAP installation.
+
+# You can also run it from other locations, but then you need to tell the
+# script where your GAP root directory is, by passing it as _first_ argument
+# to the script with '--with-gaproot='. By default, the script assumes that
+# the parent of the current working directory is the GAP root directory.
+
+# By default the script colors its output, even in the log files. One can
+# turn it off by adding the argument --no-color _after_ --with-gaproot= (if
+# added) but _before_ all further arguments.
+
+# If further arguments are added, then they are considered packages. In that
+# case only these packages will be built, and all others are ignored.
+
+# You need at least 'gzip', GNU 'tar', a C compiler, sed, pdftex to run this.
+# Some packages also need a C++ compiler.
+
+# Contact support@gap-system.org for questions and complaints.
+
+# Note, that this isn't and is not intended to be a sophisticated script.
+# Even if it doesn't work completely automatically for you, you may get
+# an idea what to do for a complete installation of GAP.
+
 set -e
 
 # Is someone trying to run us from inside the 'bin' directory?
@@ -128,34 +153,6 @@ std_error() {
 
 ### The main function to be run, its output is going to be logged.
 build_packages() {
-
-# This script attempts to build all GAP packages contained in the current
-# directory. Normally, you should run this script from the 'pkg'
-# subdirectory of your GAP installation.
-
-# You can also run it from other locations, but then you need to tell the
-# script where your GAP root directory is, by passing it as _first_ argument
-# to the script with '--with-gaproot='. By default, the script assumes that
-# the parent of the current working directory is the GAP root directory.
-
-# By default the script colors its output, even in the log files. One can
-# turn it off by adding the argument --no-color _after_ --with-gaproot= (if
-# added) but _before_ all further arguments.
-
-# If further arguments are added, then they are considered packages. In that
-# case only these packages will be built, and all others are ignored.
-
-# You need at least 'gzip', GNU 'tar', a C compiler, sed, pdftex to run this.
-# Some packages also need a C++ compiler.
-
-# Contact support@gap-system.org for questions and complaints.
-
-# Note, that this isn't and is not intended to be a sophisticated script.
-# Even if it doesn't work completely automatically for you, you may get
-# an idea what to do for a complete installation of GAP.
-
-
-# after colors are turned on or off we continue the script
 
 notice "Using GAP location: $GAPDIR"
 echo ""
@@ -384,7 +381,7 @@ echo "" >> "$LOGDIR/$FAILPKGFILE.log"
 echo ""
 notice "Output logged into ./$LOGDIR/$LOGFILE.log"
 notice "Packages failed to build are in ./$LOGDIR/$FAILPKGFILE.log"
-# end of build_all_packages
+# end of build_packages
 }
 
 

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -82,7 +82,7 @@ while [[ "$#" -ge 1 ]]
 do
   case "$1" in
     --with-gaproot=*)
-      GAPDIR=$(sed 's|--with-gaproot=||' <<< "$1")
+      GAPDIR=${$1#--with-gaproot=}
       shift
     ;;
 
@@ -93,7 +93,7 @@ do
     ;;
 
     --with-logdir=*)
-      LOGDIR=$(sed 's|--with-logdir=||' <<< "$1")
+      LOGDIR=${$1#--with-logdir=}
       shift
     ;;
 
@@ -104,7 +104,7 @@ do
     ;;
 
     --with-logfile=*)
-      LOGFILE=$(sed 's|--with-logfile=||' <<< "$1")
+      LOGFILE=${$1#--with-logfile=}
       shift
     ;;
 
@@ -115,7 +115,7 @@ do
     ;;
 
     --with-failpkgfile=*)
-      FAILPKGFILE=$(sed 's|--with-failpkgfile=||' <<< "$1")
+      FAILPKGFILE=${$1#--with-failpkgfile=}
       shift
     ;;
 

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -130,6 +130,19 @@ then
 fi
 }
 
+# Many package require GNU make. So use gmake if available,
+# for improved compatibility with *BSD systems where "make"
+# is BSD make, not GNU make.
+set_make(){
+if ! [[ "x$(which gmake)" = "x" ]]
+then
+  MAKE=gmake
+else
+  MAKE=make
+fi
+}
+
+
 # print notices in green
 notice() {
   if [[ "$COLOR" = "1" ]]
@@ -179,16 +192,7 @@ echo ""
 
 set_packages
 set_build_flags_for_32_bit
-
-# Many package require GNU make. So use gmake if available,
-# for improved compatibility with *BSD systems where "make"
-# is BSD make, not GNU make.
-if ! [[ "x$(which gmake)" = "x" ]]
-then
-  MAKE=gmake
-else
-  MAKE=make
-fi
+set_make
 
 notice \
 "Attempting to build GAP packages." \

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -59,9 +59,9 @@ GAPDIR="$(cd .. && pwd)"
 # default COLOR
 if [[ -t 1 ]]
 then
-  COLOR=1
+  COLOR=YES
 else
-  COLOR=0
+  COLOR=NO
 fi
 
 # default LOGDIR
@@ -125,7 +125,7 @@ do
 
     --no-color|--no-colors|--no-colour|--no-colours|\
     --nocolor|--nocolors|--nocolour|--nocolours)
-      COLOR=0
+      COLOR=NO
       shift
     ;;
 
@@ -192,7 +192,7 @@ fi
 
 # print notices in green
 notice() {
-  if [[ "$COLOR" = "1" ]]
+  if [[ "$COLOR" = "YES" ]]
   then
     printf "\033[32m%s\033[0m\n" "$@"
   else
@@ -202,7 +202,7 @@ notice() {
 
 # print warnings in yellow
 warning() {
-  if [[ "$COLOR" = "1" ]]
+  if [[ "$COLOR" = "YES" ]]
   then
     printf "\033[33mWARNING: %s\033[0m\n" "$@"
   else
@@ -212,7 +212,7 @@ warning() {
 
 # print error in red and exit
 error() {
-  if [[ "$COLOR" = "1" ]]
+  if [[ "$COLOR" = "YES" ]]
   then
     printf "\033[31mERROR: %s\033[0m\n" "$@"
   else
@@ -223,7 +223,7 @@ error() {
 
 # print stderr error in red but do not exit
 std_error() {
-  if [[ "$COLOR" = "1" ]]
+  if [[ "$COLOR" = "YES" ]]
   then
     printf "\033[31mERROR: %s\033[0m\n" "$@"
   else

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+# Is someone trying to run us from inside the 'bin' directory?
+run_from_bin(){
+if [[ -f gapicon.bmp ]]
+then
+  error "This script must be run from inside the pkg directory" \
+        "Type: cd ../pkg; ../bin/BuildPackages.sh"
+fi
+}
+
 LOGDIR=log
 mkdir -p "$LOGDIR"
 
@@ -51,6 +60,7 @@ std_error() {
   fi
 }
 
+### The main function to be run, its output is going to be logged.
 build_packages() {
 
 # This script attempts to build all GAP packages contained in the current
@@ -119,13 +129,6 @@ then
 fi
 
 # after colors are turned on or off we continue the script
-
-# Is someone trying to run us from inside the 'bin' directory?
-if [[ -f gapicon.bmp ]]
-then
-  error "This script must be run from inside the pkg directory" \
-        "Type: cd ../pkg; ../bin/BuildPackages.sh"
-fi
 
 notice "Using GAP location: $GAPDIR"
 
@@ -365,6 +368,10 @@ notice "Output logged into ./$LOGDIR/$LOGFILE.log"
 notice "Packages failed to build are in ./$LOGDIR/$FAILPKGFILE.log"
 # end of build_all_packages
 }
+
+
+### The main body of the script.
+run_from_bin
 
 # Log error to .err, output to .out, everything to .log
 ( build_packages "$@" \

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -59,7 +59,12 @@ GAPDIR="$(pwd)"
 popd >/dev/null
 
 # default COLOR
-COLOR=1
+if [[ -t 1 ]]
+then
+  COLOR=1
+else
+  COLOR=0
+fi
 
 # default LOGDIR
 LOGDIR=log

--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -8,25 +8,47 @@ mkdir -p "$LOGDIR"
 LOGFILE=buildpackages
 FAILPKGFILE=fail
 
+COLOR=1
+
 # print notices in green
 notice() {
+  if [[ "$COLOR" = "1" ]]
+  then
     printf "\033[32m%s\033[0m\n" "$@"
+  else
+    printf "%s\n" "$@"
+  fi
 }
 
 # print warnings in yellow
 warning() {
+  if [[ "$COLOR" = "1" ]]
+  then
     printf "\033[33mWARNING: %s\033[0m\n" "$@"
+  else
+    printf "%s\n" "$@"
+  fi
 }
 
 # print error in red and exit
 error() {
+  if [[ "$COLOR" = "1" ]]
+  then
     printf "\033[31mERROR: %s\033[0m\n" "$@"
-    exit 1
+  else
+    printf "%s\n" "$@"
+  fi
+  exit 1
 }
 
 # print stderr error in red but do not exit
 std_error() {
+  if [[ "$COLOR" = "1" ]]
+  then
     printf "\033[31mERROR: %s\033[0m\n" "$@"
+  else
+    printf "%s\n" "$@"
+  fi
 }
 
 build_packages() {
@@ -36,12 +58,16 @@ build_packages() {
 # subdirectory of your GAP installation.
 
 # You can also run it from other locations, but then you need to tell the
-# script where your GAP root directory is, by passing it as first argument
+# script where your GAP root directory is, by passing it as _first_ argument
 # to the script with '--with-gaproot='. By default, the script assumes that
 # the parent of the current working directory is the GAP root directory.
 
-# If arguments are added, then they are considered packages. In that case
-# only these packages will be built, and all others are ignored.
+# By default the script colors its output, even in the log files. One can
+# turn it off by adding the argument --no-color _after_ --with-gaproot= (if
+# added) but _before_ all further arguments.
+
+# If further arguments are added, then they are considered packages. In that
+# case only these packages will be built, and all others are ignored.
 
 # You need at least 'gzip', GNU 'tar', a C compiler, sed, pdftex to run this.
 # Some packages also need a C++ compiler.
@@ -52,13 +78,6 @@ build_packages() {
 # Even if it doesn't work completely automatically for you, you may get
 # an idea what to do for a complete installation of GAP.
 
-
-# Is someone trying to run us from inside the 'bin' directory?
-if [[ -f gapicon.bmp ]]
-then
-  error "This script must be run from inside the pkg directory" \
-        "Type: cd ../pkg; ../bin/BuildPackages.sh"
-fi
 
 # CURDIR
 CURDIR="$(pwd)"
@@ -86,6 +105,28 @@ then
   GAPDIR="$(pwd)"
   popd
 fi
+
+# check if coloring should be turned off
+if [[ "$#" -ge 1 ]]
+then
+  case "$1" in
+    --no-color|--no-colors|--no-colour|--no-colours|\
+    --nocolor|--nocolors|--nocolour|--nocolours)
+      COLOR=0
+      shift
+    ;;
+  esac
+fi
+
+# after colors are turned on or off we continue the script
+
+# Is someone trying to run us from inside the 'bin' directory?
+if [[ -f gapicon.bmp ]]
+then
+  error "This script must be run from inside the pkg directory" \
+        "Type: cd ../pkg; ../bin/BuildPackages.sh"
+fi
+
 notice "Using GAP location: $GAPDIR"
 
 # We need to test if $GAPDIR is right
@@ -102,6 +143,7 @@ then
   ABI32=YES
   CONFIGFLAGS="CFLAGS=-m32 LDFLAGS=-m32 LOPTS=-m32 CXXFLAGS=-m32"
 fi
+
 
 # packages to build
 if [[ "$#" -ge 1 ]]


### PR DESCRIPTION
Quick fix for #1120. Then we could move from here. 

By default colouring is turned on everywhere (terminal, log files). 
If --no-color is used, then colouring is turned off everywhere (terminal, log files). 