### PR TITLE
kernel: fix support for sparc64

### DIFF
--- a/cnf/aclocal.m4
+++ b/cnf/aclocal.m4
@@ -53,7 +53,7 @@ AC_DEFUN(GP_C_LONG_ALIGN,
 case "$host" in
    alpha* )
         gp_cv_c_long_align=8;;
-   mips-* | sparc-* )
+   mips* | sparc* )
         gp_cv_c_long_align=$ac_cv_sizeof_void_p;;
    i586-* | i686-* )
         gp_cv_c_long_align=2;;

--- a/cnf/configure.out
+++ b/cnf/configure.out
@@ -3459,7 +3459,7 @@ else
 case "$host" in
    alpha* )
         gp_cv_c_long_align=8;;
-   mips-* | sparc-* )
+   mips* | sparc* )
         gp_cv_c_long_align=$ac_cv_sizeof_void_p;;
    i586-* | i686-* )
         gp_cv_c_long_align=2;;


### PR DESCRIPTION
Thanks to Bill Allombert for reporting this and providing an earlier version of this change.
