### PR TITLE
gmpints: add FuncLog2Int back to gmpints.h

### DIFF
--- a/src/gmpints.c
+++ b/src/gmpints.c
@@ -854,7 +854,7 @@ Int CLog2Int(Int a)
 **  
 **  Given to GAP-Level as "Log2Int".
 */
-Obj FuncLog2Int( Obj self, Obj integer)
+Obj FuncLog2Int( Obj self, Obj integer )
 {
   if ( IS_INTOBJ(integer) ) {
     return INTOBJ_INT(CLog2Int(INT_INTOBJ(integer)));

--- a/src/gmpints.h
+++ b/src/gmpints.h
@@ -225,6 +225,9 @@ extern Obj AInvInt( Obj op );
 */
 extern Int CLog2Int( Int intnum );
 
+/* The following function should be internal, but the float package uses it.
+So we keep it here for now. */
+extern Obj FuncLog2Int( Obj self, Obj integer );
 
 /****************************************************************************
 **


### PR DESCRIPTION
Turns out the float package uses it.
