### PR TITLE
Revised list of packages loaded by default

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1742,13 +1742,10 @@ InstallGlobalFunction( InstalledPackageVersion, function( name )
 DeclareUserPreference( rec(
   name:= "PackagesToLoad",
   description:= [
-    "A list of names of packages which should be loaded during startup. \
-For backwards compatibility, the default lists most of packages \
-that were autoloaded in GAP 4.4 (add or remove packages as you like)."
+    "A list of names of packages which should be loaded during startup."
     ],
   default:= [ "autpgrp", "alnuth", "crisp", "ctbllib", "factint", "fga", 
-              "irredsol", "laguna", "polenta", "polycyclic", "resclasses", 
-              "sophus", "tomlib" ],
+              "irredsol", "polenta", "polycyclic", "tomlib" ],
   values:= function() return RecNames( GAPInfo.PackagesInfo ); end,
   multi:= true,
   ) );


### PR DESCRIPTION
This PR is to check how continuous integration tests respond if some packages are excluded from the list of packages  loaded by default when GAP starts. To start with, I've removed LAGUNA, Sophus and ResClasses.