### PR TITLE
Speed up RootMod and RootsMod for moduli with large prime factors; also add `IS_PROBAB_PRIME_INT` kernel function

### DIFF
--- a/lib/numtheor.gi
+++ b/lib/numtheor.gi
@@ -398,6 +398,14 @@ BindGlobal( "RootModPrime", function ( n, k, p )
     Info( InfoNumtheor, 1, "RootModPrime(", n, ",", k, ",", p, ")" );
     n := n mod p;
 
+    # If n is non-zero, then the code below requires that p is a Fermat
+    # pseudoprime with respect to n, i.e. that $n^(p-1) mod p = 1$ holds.
+    # This is of course automatically true if $p$ is a prime, but for efficiency
+    # reasons we actually use this with pseudo primes.
+    if n <> 0 and PowerModInt( n, p-1, p ) <> 1 then
+        Error( "<p> is not a Fermat pseudoprime with respect to <n>. Please report this error to the GAP team" );
+    fi;
+
     # handle $p = 2$
     if p = 2  then
         r := n;
@@ -554,8 +562,7 @@ InstallGlobalFunction( RootMod, function ( arg )
             r,                  # <k>th root of <n> mod <qq>
             s,                  # <k>th root of <n> mod <q>
 	    f, # factors
-	    i, # loop
-            t;                  # temporary variable
+	    i; # loop
 
     # get the arguments
     if   Length(arg) = 2  then n := arg[1];  k := 2;       m := arg[2];
@@ -593,7 +600,7 @@ InstallGlobalFunction( RootMod, function ( arg )
 
     # combine the root modulo every prime power $p^l$
     r := 0;  qq := 1;
-    for p  in Set( FactorsInt( m ) )  do
+    for p  in Set( FactorsInt( m : UseProbabilisticPrimalityTest ) ) do
 
         # find prime power $q = p^l$
         q := p;  l := 1;
@@ -608,8 +615,7 @@ InstallGlobalFunction( RootMod, function ( arg )
 
         # combine $r$ (the root mod $qq$) with $s$ (the root mod $p^l$)
         ii := 1/qq mod q;
-        t := r + qq * ((s - r)*ii mod q);
-        r := t;
+        r := r + qq * ((s - r)*ii mod q);
         qq := qq * q;
 
     od;
@@ -637,6 +643,14 @@ BindGlobal( "RootsModPrime", function ( n, k, p )
     # reduce $n$ into the range $0..p-1$
     Info( InfoNumtheor, 1, "RootsModPrime(", n, ",", k, ",", p, ")" );
     n := n mod p;
+
+    # If n is non-zero, then the code below requires that p is a Fermat
+    # pseudoprime with respect to n, i.e. that $n^(p-1) mod p = 1$ holds.
+    # This is of course automatically true if $p$ is a prime, but for efficiency
+    # reasons we actually use this with pseudo primes.
+    if n <> 0 and PowerModInt( n, p-1, p ) <> 1 then
+        Error( "<p> is not a Fermat pseudoprime with respect to <n>. Please report this error to the GAP team" );
+    fi;
 
     # handle $p = 2$
     if p = 2  then
@@ -743,6 +757,8 @@ RootsModPrimePower := function ( n, k, p, l )
     # handle the case that the roots split
     elif k = p  then
 
+	Info( InfoNumtheor, 3, "k=p case" );
+
         # compute the root mod $p^{l/2}$, or $p^{l/2+1}$ if 32 divides $p^l$
         if 2 < p  or l < 5  then
             ss := RootsModPrimePower( n, k, p, QuoInt(l+1,2) );
@@ -829,7 +845,7 @@ InstallGlobalFunction( RootsMod, function ( arg )
 
     # combine the roots modulo every prime power $p^l$
     rr := [0];  qq := 1;
-    for p  in Set( FactorsInt( m ) )  do
+    for p  in Set( FactorsInt( m : UseProbabilisticPrimalityTest ) )  do
 
         # find prime power $q = p^l$
         q := p;  l := 1;

--- a/src/gmpints.c
+++ b/src/gmpints.c
@@ -2176,6 +2176,42 @@ Obj FuncPOWERMODINT ( Obj self, Obj base, Obj exp, Obj mod )
 
 /****************************************************************************
 **
+*/
+Obj IsProbablyPrimeInt ( Obj n, Int reps )
+{
+  fake_mpz_t n_mpz;
+  Int res;
+
+  if ( reps < 1 )
+    ErrorMayQuit( "IsProbablyPrimeInt: <reps> must be positive", 0L, 0L );
+
+  CHECK_INT(n);
+
+  FAKEMPZ_GMPorINTOBJ( n_mpz, n );
+
+  res = mpz_probab_prime_p( MPZ_FAKEMPZ(n_mpz), reps );
+
+  if (res == 2) return True; /* definitely prime */
+  if (res == 0) return False; /* definitely not prime */
+  return Fail; /* probably prime */
+}
+
+/****************************************************************************
+**
+*/
+Obj FuncIS_PROBAB_PRIME_INT ( Obj self, Obj n, Obj reps )
+{
+  REQUIRE_INT_ARG( "IsProbablyPrimeInt", "n", n );
+  REQUIRE_INT_ARG( "IsProbablyPrimeInt", "reps", reps );
+  if ( ! IS_INTOBJ(reps) )
+    ErrorMayQuit( "IsProbablyPrimeInt: <reps> is too large", 0L, 0L );
+
+  return IsProbablyPrimeInt( n, INT_INTOBJ(reps) );
+}
+
+
+/****************************************************************************
+**
 ** * * * * * * * "Mersenne twister" random numbers  * * * * * * * * * * * * *
 **
 **  Part of this code for fast generation of 32 bit pseudo random numbers with 
@@ -2325,6 +2361,9 @@ static StructGVarFunc GVarFuncs [] = {
 
   { "POWERMODINT", 3, "base, exp, mod",
     FuncPOWERMODINT, "src/gmpints.c:POWERMODINT" },
+
+  { "IS_PROBAB_PRIME_INT", 2, "n, reps",
+    FuncIS_PROBAB_PRIME_INT, "src/gmpints.c:IS_PROBAB_PRIME_INT" },
 
   { "INVMODINT", 2, "base, mod",
     FuncINVMODINT, "src/gmpints.c:INVMODINT" },

--- a/tst/testinstall/intarith.tst
+++ b/tst/testinstall/intarith.tst
@@ -1260,6 +1260,24 @@ gap> PVALUATION_INT(0,0);
 Error, PValuationInt: <p> must be nonzero
 
 #
+# test IS_PROBAB_PRIME_INT
+#
+gap> ForAll([-100..10000], n -> IS_PROBAB_PRIME_INT(n, 5) = IsProbablyPrimeInt(n));
+true
+gap> Filtered([-100..100], n -> false <> IS_PROBAB_PRIME_INT(2^255+n, 5));
+[ -31, -19, 95 ]
+gap> Filtered([-100..100], n -> false <> IsProbablyPrimeInt(2^255+n));
+[ -31, -19, 95 ]
+gap> IS_PROBAB_PRIME_INT(fail, 1);
+Error, IsProbablyPrimeInt: <n> must be an integer (not a boolean or fail)
+gap> IS_PROBAB_PRIME_INT(1, fail);
+Error, IsProbablyPrimeInt: <reps> must be an integer (not a boolean or fail)
+gap> IS_PROBAB_PRIME_INT(1, 2^100);
+Error, IsProbablyPrimeInt: <reps> is too large
+gap> IS_PROBAB_PRIME_INT(1, 0);
+Error, IsProbablyPrimeInt: <reps> must be positive
+
+#
 gap> STOP_TEST( "intarith.tst", 290000);
 
 #############################################################################

--- a/tst/testinstall/numtheor.tst
+++ b/tst/testinstall/numtheor.tst
@@ -1,5 +1,22 @@
 gap> START_TEST("numtheor.tst");
 
+# RootMod, RootsMod
+#
+# Check issue #758: do not force full factorization for RootMod.
+# It suffices to factor into strong Fermat primes.
+gap> oldLevel := InfoLevel(InfoPrimeInt);;
+gap> SetInfoLevel(InfoPrimeInt, 0); # turn off warnings
+gap> c := 87665785060273447596735547586847436354365986897267;;
+gap> d := 5676193656034756392656593936564928264920283748503726385950382638505826243749593626948538293405737101;;
+gap> RootMod(c,d); time < 20;
+fail
+true
+gap> n:=2^2203-1;; RootMod(39,n); time < 300;
+fail
+true
+
+#
+# PValuation
 #
 gap> PValuation(0,2);
 infinity


### PR DESCRIPTION
For RootMod and RootsMod, all computations are eventually reduced to
prime moduli. This means we have to factor the initial modulus, which
can be very expensive. However, it actually suffices if the factors are
Fermat pseudo primes relative to certain bases... So we switch to using
the UseProbabilisticPrimalityTest option, and add a test which verifies
the required property n^(p-1) = 1 (mod p) where necessary. If this
fails, we could do something clever to recover, but instead, we simply
print an error message requesting that the user reports it to use; for
if it happens, then either there is a bug (which we should fix), or else
we found a BPSW pseudo prime that is not a prime, and this is something
we definitely would want to know about (and publish, too ;-).

Fixes #758

This PR also adds `IS_PROBAB_PRIME_INT`, which calls the GMP function `mpz_probab_prime_p`.