### PR TITLE
Do not reset tilde in ClearError, as ClearError is often called when there is no error

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -1783,9 +1783,8 @@ void ClearError ( void )
         }
     }
 
-    /* reset <TLS(NrError)> and Tilde                                      */
+    /* reset <TLS(NrError)>                                                */
     TLS(NrError) = 0;
-    AssGVarUnsafe(Tilde, 0);
 }
 
 /****************************************************************************

--- a/tst/testinstall/tilde.tst
+++ b/tst/testinstall/tilde.tst
@@ -4,11 +4,6 @@ Error, Variable: 'aqq' must have a value
 Syntax error: ; expected in stream:1
 aqq~ := 1;
    ^
-gap> ~a := 1;
-Error, Variable: '~' must have a value
-Syntax error: ; expected in stream:1
-~a := 1;
- ^
 gap> ~ := 1;
 Error, '~' cannot be assigned
 gap> l := [2, ~];
@@ -51,6 +46,4 @@ Syntax error: ~ is not a valid name for an argument in stream:1
  ^
 gap> ({} -> ~);
 function(  ) ... end
-gap> ({} -> ~)();
-Error, Variable: '~' must have an assigned value
 gap> STOP_TEST( "tilde.tst", 1);


### PR DESCRIPTION
Fixes RCWA.

This is undoing an earlier fix. The problem was that the ~ variable is not
cleared when exiting a break loop, or after an error. Reseting it's value
in ClearError fixed this, but it turns out ClearError is called even when there
are no errors, for example after reading a file.

This does reintroduce a tilde problem -- but it will only be hit by programs
which cause an error, then try to read tilde and find it has a value,
when it shouldn't.

A true fix will be reasonably irritating surgery, and still wouldn't properly fix the problem.
The real fix is to start storing, and restoring, tilde, every time we longjmp/setjmp, but the
cost of that might add up for such a little used feature (and it only matters after we have
an error, or exit the break loop).