### PR TITLE
kernel: fix heisenbug in PrintInt

### DIFF
--- a/src/gmpints.c
+++ b/src/gmpints.c
@@ -614,7 +614,9 @@ void PrintInt ( Obj op )
   }
   else {
     Obj str = CALL_1ARGS( String, op );
-    Pr("%>%s%<",(Int)(CHARS_STRING(str)), 0);
+    Pr("%>", 0, 0);
+    PrintString1(str);
+    Pr("%<", 0, 0);
     /* for a long time Print of large ints did not follow the general idea
      * that Print should produce something that can be read back into GAP:
        Pr("<<an integer too large to be printed>>",0L,0L); */


### PR DESCRIPTION
On rare occasions, our test suite would fail in a test which
prints 2^(64*1050). After some research, we discovered that this
is caused by a garbage collection problem, which this commit
hopefully resolves.

Fixes #1147