### PR TITLE
Fix crash when comparing recursive data structures

### DIFF
--- a/src/ariths.h
+++ b/src/ariths.h
@@ -294,9 +294,6 @@ extern void InstallInvMutObject ( Int );
                          (!ARE_INTOBJS(opL,opR) && \
                           (*EqFuncs[TNUM_OBJ(opL)][TNUM_OBJ(opR)])(opL,opR)))
 
-#define EQ2(opL,opR)    ((opL) == (opR) || \
-                          (*EqFuncs[TNUM_OBJ(opL)][TNUM_OBJ(opR)])(opL,opR))
-
 extern Obj EqOper;
 
 
@@ -325,9 +322,6 @@ extern void InstallEqObject ( Int );
 #define LT(opL,opR)     ((opL) == (opR) ? 0 : \
                          (ARE_INTOBJS(opL,opR) ? (Int)(opL) < (Int)(opR) : \
                           (*LtFuncs[TNUM_OBJ(opL)][TNUM_OBJ(opR)])(opL,opR)))
-
-#define LT2(opL,opR)    ((opL) == (opR) ? 0 : \
-                          (*LtFuncs[TNUM_OBJ(opL)][TNUM_OBJ(opR)])(opL,opR))
 
 extern Obj LtOper;
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -766,9 +766,9 @@ Obj             EvalFunccallXargs (
 */
 
 /* TL: Int RecursionDepth; */
-static UInt RecursionTrapInterval;
+UInt RecursionTrapInterval;
 
-static void RecursionDepthTrap( void )
+void RecursionDepthTrap( void )
 {
     Int recursionDepth;
     /* in interactive work the RecursionDepth could become slightly negative
@@ -785,15 +785,6 @@ static void RecursionDepthTrap( void )
     }
 }
      
-static inline void CheckRecursionBefore( void )
-{
-    TLS(RecursionDepth)++;                                           
-    if ( RecursionTrapInterval &&                                
-         0 == (TLS(RecursionDepth) % RecursionTrapInterval) )
-      RecursionDepthTrap();
-}
-
-
 Obj STEVES_TRACING;
 
 #define CHECK_RECURSION_BEFORE \

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -778,8 +778,8 @@ static void RecursionDepthTrap( void )
     if (TLS(RecursionDepth) > 0) {
         recursionDepth = TLS(RecursionDepth);
         TLS(RecursionDepth) = 0;
-        ErrorReturnVoid( "recursion depth trap (%d)\n",         
-                         (Int)recursionDepth, 0L,               
+        ErrorReturnVoid( "recursion depth trap (%d)",
+                         (Int)recursionDepth, 0L,
                          "you may 'return;'" );
         TLS(RecursionDepth) = recursionDepth;
     }

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -43,9 +43,20 @@ extern  void            ExecEnd (
 
 
 /* TL: extern Int RecursionDepth; */
+extern UInt RecursionTrapInterval;
+extern void RecursionDepthTrap( void );
+
+static inline void CheckRecursionBefore( void )
+{
+    TLS(RecursionDepth)++;
+    if ( RecursionTrapInterval &&
+         0 == (TLS(RecursionDepth) % RecursionTrapInterval) )
+      RecursionDepthTrap();
+}
+
+
 /****************************************************************************
 **
-
 *F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * *
 */
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -43,6 +43,8 @@
 
 #include        "gap.h"                 /* error handling, initialisation  */
 
+#include        "funcs.h"
+
 #include        "gvars.h"               /* global variables                */
 
 #include        "calls.h"               /* generic call mechanism          */
@@ -1012,22 +1014,20 @@ Int             EqPlist (
         return 0L;
     }
 
+    CheckRecursionBefore();
+
     /* loop over the elements and compare them                             */
     for ( i = 1; i <= lenL; i++ ) {
         elmL = ELM_PLIST( left, i );
         elmR = ELM_PLIST( right, i );
-        if ( elmL == 0 && elmR != 0 ) {
-            return 0L;
-        }
-        else if ( elmR == 0 && elmL != 0 ) {
-            return 0L;
-        }
-        else if ( ! EQ( elmL, elmR ) ) {
+        if ( ( (elmL == 0 ) != (elmR == 0) ) || ! EQ( elmL, elmR ) ) {
+            TLS(RecursionDepth)--;
             return 0L;
         }
     }
 
     /* no differences found, the lists are equal                           */
+    TLS(RecursionDepth)--;
     return 1L;
 }
 
@@ -1050,28 +1050,36 @@ Int             LtPlist (
     Obj                 elmL;           /* element of the left operand     */
     Obj                 elmR;           /* element of the right operand    */
     Int                 i;              /* loop variable                   */
+    Int                 res;            /* result of comparison            */
 
     /* get the lengths of the lists and compare them                       */
     lenL = LEN_PLIST( left );
     lenR = LEN_PLIST( right );
+    res = (lenL < lenR);
+
+    CheckRecursionBefore();
 
     /* loop over the elements and compare them                             */
     for ( i = 1; i <= lenL && i <= lenR; i++ ) {
         elmL = ELM_PLIST( left, i );
         elmR = ELM_PLIST( right, i );
         if ( elmL == 0 && elmR != 0 ) {
-            return 1L;
+            res = 1L;
+            break;
         }
         else if ( elmR == 0 && elmL != 0 ) {
-            return 0L;
+            res = 0L;
+            break;
         }
         else if ( ! EQ( elmL, elmR ) ) {
-            return LT( elmL, elmR );
+            res = LT( elmL, elmR );
+            break;
         }
     }
 
     /* reached the end of at least one list                                */
-    return (lenL < lenR);
+    TLS(RecursionDepth)--;
+    return res;
 }
 
 

--- a/tst/testbugfix/00351.tst
+++ b/tst/testbugfix/00351.tst
@@ -1,0 +1,10 @@
+# 2017-02-18 (MH): Comparing recursive data structures should not
+# crash. See issue #1150
+gap> [~] < [~];
+Error, recursion depth trap (5000)
+gap> [~] = [~];
+Error, recursion depth trap (5000)
+gap> rec(a:=~) = rec(a:=~);
+Error, recursion depth trap (5000)
+gap> rec(a:=~) < rec(a:=~);
+Error, recursion depth trap (5000)


### PR DESCRIPTION
This fixes crashes when comparing recursive data structures (see #1150). With this PR, we get these errors (instead of crashes):
```
gap> [~] < [~];
Error, recursion depth trap (5000)

not in any function at *stdin*:1
you may 'return;'
brk>
```
and
```
gap> rec(a:=~) = rec(a:=~);
Error, recursion depth trap (5000)

not in any function at *stdin*:1
you may 'return;'
brk>
```
etc. etc.

Note that the user can still choose to continue the recursion, and doing so often enough will still crash. That seems acceptable to me, but if desired, we could also produce a variant of this code which prevents the user from returning here.

Also, we should add test cases for these (former) crashes.

Finally, I wonder if other function share similar problems? E.g. are there lists/record types which are not plists / precords and which can also be recursive?