### PR TITLE
semigrp: generalise TrueMethod for IsIdempotentGenerated

### DIFF
--- a/lib/semigrp.gd
+++ b/lib/semigrp.gd
@@ -590,7 +590,7 @@ InstallTrueMethod(IsCliffordSemigroup, IsSemilattice);
 InstallTrueMethod(IsCompletelyRegularSemigroup, IsCliffordSemigroup);
 InstallTrueMethod(IsCompletelyRegularSemigroup, IsSimpleSemigroup);
 InstallTrueMethod(IsCompletelySimpleSemigroup, IsSimpleSemigroup and IsFinite);
-InstallTrueMethod(IsIdempotentGenerated, IsSemilattice);
+InstallTrueMethod(IsIdempotentGenerated, IsBand);
 InstallTrueMethod(IsInverseSemigroup, IsSemilattice);
 InstallTrueMethod(IsInverseSemigroup, IsCliffordSemigroup);
 InstallTrueMethod(IsInverseSemigroup, IsGroupAsSemigroup);

--- a/tst/testinstall/semigrp.tst
+++ b/tst/testinstall/semigrp.tst
@@ -424,6 +424,55 @@ gap> Size(S);
 gap> S;
 <inverse transformation monoid of size 18, degree 9 with 5 generators>
 
+#T# Test TrueMethod: IsBand => IsIdempotentGenerated
+gap> S := Monoid(Transformation([1, 1]), Transformation([2, 2]));
+<transformation monoid of degree 2 with 2 generators>
+gap> HasIsIdempotentGenerated(S);
+false
+gap> ForAll(S, IsIdempotent);
+true
+gap> HasIsBand(S) or HasIsIdempotentGenerated(S);
+false
+gap> SetIsBand(S, true);
+gap> HasIsBand(S) and IsBand(S);
+true
+gap> HasIsIdempotentGenerated(S) and IsIdempotentGenerated(S);
+true
+gap> Semigroup(Idempotents(S)) = S;
+true
+
+#T# Test TrueMethod: IsCommutative and IsBand => IsSemilattice
+gap> S := Monoid([PartialPerm([1]), PartialPerm([0, 2]), PartialPerm([])]);;
+gap> HasIsSemilattice(S);
+false
+gap> IsCommutative(S);
+true
+gap> ForAll(S, IsIdempotent);
+true
+gap> HasIsBand(S) or HasIsSemilattice(S);
+false
+gap> SetIsBand(S, true);
+gap> HasIsBand(S) and IsBand(S);
+true
+gap> HasIsSemilattice(S) and IsSemilattice(S);
+true
+
+#T# Test TrueMethod: IsCommutative and IsSemilattice => IsIdempotentGenerated
+gap> S := Monoid([PartialPerm([1]), PartialPerm([0, 2]), PartialPerm([])]);;
+gap> HasIsIdempotentGenerated(S);
+false
+gap> ForAll(S, IsIdempotent) and IsCommutative(S);
+true
+gap> HasIsSemilattice(S) or HasIsIdempotentGenerated(S);
+false
+gap> SetIsSemilattice(S, true);
+gap> HasIsSemilattice(S) and IsSemilattice(S);
+true
+gap> HasIsIdempotentGenerated(S) and IsIdempotentGenerated(S);
+true
+gap> Semigroup(Idempotents(S)) = S;
+true
+
 #
 gap> STOP_TEST( "semigrp.tst", 1090000);
 


### PR DESCRIPTION
Please make sure that this pull request:

- [ ] is submitted to the correct branch (the stable branch is only for bugfixes)
- [ ] contains an accurate description of changes for the release notes below
- [x] provides new tests or relies on existing ones
- [ ] correctly refers to other issues and related pull requests

### Tick all what applies to this pull request

- [ ] Adds new features
- [x] Improves and extends functionality
- [ ] Fixes bugs that could lead to crashes
- [ ] Fixes bugs that could lead to incorrect results
- [ ] Fixes bugs that could lead to break loops

### Write below the description of changes (for the release notes)

_This PR adds a method which means that bands automatically know that they are idempotent generated._

A semigroup is idempotent generated if its set of idempotents generates the whole semigroup. A band is a semigroup each of whose elements is an idempotent, and a semilattice is a commutative band.

There is currently a true method in `semigrp.gd` which sets `IsIdempotentGenerated` to be `true` for a semigroup which satisfies the property `IsSemilattice`. However, every band is idempotent generated. Thus the more general true method is:
```
InstallTrueMethod(IsIdempotentGenerated, IsBand);
```
Since every semilattice knows that it is a band by line 587 `InstallTrueMethod(IsBand, IsSemilattice);`, replacing the original true method by the one above is an improvement.

I cannot add any tests for this change since the relevant properties are only declared in `semigrp.gd`; no methods are installed in the library itself (methods exist in the Semigroups and smallsemi packages).