### PR TITLE
Added the FLOAT_PSEUDOFIELD variable which seems to have disappeared …

### DIFF
--- a/lib/float.gi
+++ b/lib/float.gi
@@ -30,6 +30,7 @@ MAX_FLOAT_LITERAL_CACHE_SIZE := 0; # cache all float literals by default.
 
 FLOAT_DEFAULT_REP := fail;
 FLOAT_STRING := fail;
+FLOAT_PSEUDOFIELD := fail;
 FLOAT := fail; # holds the constants
 BindGlobal("EAGER_FLOAT_LITERAL_CONVERTERS", rec());
 
@@ -64,6 +65,9 @@ InstallGlobalFunction(SetFloats, function(arg)
         fi;
         if IsBound(r.creator) then
             FLOAT_STRING := r.creator;
+        fi;
+        if IsBound(r.field) then
+            FLOAT_PSEUDOFIELD := r.field;
         fi;
     fi;
     


### PR DESCRIPTION
This should go to every branch, I thought it was there but perhaps it got lost.

- [x] Adds new features

Rather, adds a feature that was promised (to create univariate polynomials with floating-point coefficients).

Sample test:

`gap> x := Indeterminate(FLOAT_PSEUDOFIELD); (x+1)^2;`