### PR TITLE
Combine coverage reports before submission

### DIFF
--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -100,11 +100,15 @@ if LoadPackage("profiling") <> true then
     FORCE_QUIT_GAP(1);
 fi;
 d := Directory("$COVDIR");;
+covs := [];;
 for f in DirectoryContents(d) do
     if f in [".", ".."] then continue; fi;
-    Print("Converting ", f, " to JSON\n");
-    OutputJsonCoverage(Filename(d, f), Concatenation(f, ".json"));
+    Add(covs, Filename(d, f));
 od;
+Print("Merging coverage results\n");
+r := MergeLineByLineProfiles(covs);;
+Print("Outputting JSON\n");
+OutputJsonCoverage(r, "gap-coverage.json");;
 QUIT_GAP(0);
 GAPInput
 


### PR DESCRIPTION
This should improve coverage a bit.

Because we are using a workspace to test manual examples, quite a few lines are not read, and hence ignored by the coverage output. We have three options
 * Ignore that they have not been read
 * Do not use workspaces
 * Take coverage data when we make the workspace and somehow merge coverage datasets

This PR tests whether this is true.