### PR TITLE
Check when we manually increment stack depth, we correctly decrement it on return

### DIFF
--- a/tst/testinstall/tilde.tst
+++ b/tst/testinstall/tilde.tst
@@ -46,4 +46,34 @@ Syntax error: ~ is not a valid name for an argument in stream:1
  ^
 gap> ({} -> ~);
 function(  ) ... end
+gap> list1 := [1,~];
+[ 1, ~ ]
+gap> list2 := [1,[1,[1,[1,0]]]];
+[ 1, [ 1, [ 1, [ 1, 0 ] ] ] ]
+
+# Check that the RecursionDepth counter in the kernel is incremented and
+# decremented correctly. If it isn't decremented correctly, then it will
+# eventually exceed the `RecursionTrapInterval` (which normally is
+# 5000), and the test will fail due to an unexpected error message.
+gap> ForAny([1..10000], x -> (list1 = list2));
+false
+gap> ForAny([1..10000], x -> (list1 < list2));
+false
+gap> ForAny([1..10000], x -> (list1 <= list2));
+false
+gap> ForAll([1..10000], x -> (list1 <> list2));
+true
+gap> rec1 := rec( x := ~ );
+rec( x := ~ )
+gap> rec2 := rec( x := rec( x := rec( x := rec( x := rec( x := rec() ) ) ) ) );
+rec( x := rec( x := rec( x := rec( x := rec( x := rec(  ) ) ) ) ) )
+gap> ForAny([1..10000], q -> (rec1 = rec2));
+false
+gap> ForAll([1..10000], q -> (rec1 <> rec2));
+true
+
+# This can be different every time GAP starts
+gap> bool := (rec1 < rec2);;
+gap> ForAll([1..10000], q -> ( (rec1 < rec2) = bool) );
+true
 gap> STOP_TEST( "tilde.tst", 1);


### PR DESCRIPTION
This just adds some more tests for #1151, to check the incrementing and decrementing of stack depth works correctly by doing lots of calls in a loop.