### PR TITLE
Ensure we reset OutputtedFilenameList in profiling when a workspace is restored

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -1005,6 +1005,16 @@ static Int InitKernel (
     return 0;
 }
 
+static Int PostRestore ( StructInitInfo * module )
+{
+    /* When we restore a workspace, we start a new profile.
+     * 'OutputtedFilenameList' is the only part of the profile which is
+     * stored in the GAP memory space, so we need to clear it in case
+     * it still has a value from a previous profile.
+     */
+    OutputtedFilenameList = NEW_PLIST(T_PLIST, 0);
+    return 0;
+}
 
 /****************************************************************************
 **
@@ -1022,7 +1032,7 @@ static StructInitInfo module = {
     0,                                  /* checkInit                      */
     0,                                  /* preSave                        */
     0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    PostRestore                         /* postRestore                    */
 };
 
 StructInitInfo * InitInfoProfile ( void )


### PR DESCRIPTION
This patch ensures that if we load a saved workspace, we correctly output filenames. This is only required when restoring a workspace where coverage/profile was active, with `--prof` or `--cover`.

The workspace restores the variable `OutputtedFilenameList`, which represents files we have already outputted. We want to clear that file, so our new profile includes the filenames.

This is a pain to add a test for, but easy to eyeball -- looking at profiles generated they were previously missing filenames, now they aren't.