### PR TITLE
Check the input of FactorFreeSemigroup/MonoidByRelations

### DIFF
--- a/lib/fpmon.gi
+++ b/lib/fpmon.gi
@@ -180,6 +180,10 @@ function( F, rels )
       fi;
     od;
 
+    if not (HasIsFreeMonoid(F) and IsFreeMonoid(F)) then
+      Error("first argument <F> should be a free monoid");
+    fi;
+
     # Create a new family.
     fam := NewFamily( "FamilyElementsFpMonoid", IsElementOfFpMonoid);
 

--- a/lib/fpsemi.gi
+++ b/lib/fpsemi.gi
@@ -151,6 +151,10 @@ function( F, rels )
 			fi;
 		od;
 
+    if not (HasIsFreeSemigroup(F) and IsFreeSemigroup(F)) then
+      Error("first argument <F> should be a free semigroup");
+    fi;
+
     # Create a new family.
     fam := NewFamily( "FamilyElementsFpSemigroup", IsElementOfFpSemigroup );
 

--- a/tst/testinstall/fpmon.tst
+++ b/tst/testinstall/fpmon.tst
@@ -20,5 +20,15 @@ gap> inv := InverseGeneralMapping(map);;
 gap> ForAll(S, x -> (x ^ map) ^ inv = x);
 true
 
+# Test that free monoids cannot be used to make fp semigroups or vice versa
+gap> F := FreeMonoid(2);;
+gap> rels := [ [ F.1^2, F.1 ], [ F.2^2, F.2 ] ];;
+gap> FactorFreeSemigroupByRelations(F, rels);
+Error, first argument <F> should be a free semigroup
+gap> F := FreeSemigroup(2);;
+gap> rels := [ [ F.1^2, F.1 ], [ F.2^2, F.2 ] ];;
+gap> FactorFreeMonoidByRelations(F, rels);
+Error, first argument <F> should be a free monoid
+
 #
 gap> STOP_TEST( "fpmon.tst", 10000);


### PR DESCRIPTION
This PR causes `FactorFreeSemigroupByRelations` to check that the input is known to be a free semigroup, and `FactorFreeMonoidByRelations` to check that the input is known to be a free monoid.  Before these changes, `FactorFreeSemigroupByRelations` would happily accept a monoid and then behave in a surprising and incorrect way, which took me a long time to debug.

I've added some short tests to `fpmon.tst` to check that it works.