### PR TITLE
Make bin/BuildPackages.sh compatible with bash 3

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -56,8 +56,10 @@ then
   # Put package directory names into a bash array to avoid issues with
   # spaces in filenames. This code will still break if there are newlines
   # in the name.
+  old_IFS=$IFS
   IFS=$'\n' PACKAGES=($(find . -maxdepth 2 -type f -name PackageInfo.g))
-  PACKAGES=("${PACKAGES[@]%/PackageInfo.g}")
+  IFS=$old_IFS
+  PACKAGES=( "${PACKAGES[@]%/PackageInfo.g}" )
 fi
 
 # Some helper functions for printing user messages


### PR DESCRIPTION
This should the issues @alex-konovalov reported to me on Mac OS X, which ships with 3.2.57 -- the problems never occurred for me, as I have manually installed bash 4.4.5 on my OS X machine.