### PR TITLE
Remove SyCacheSize and the "-c" command line option

### DIFF
--- a/hpcgap/lib/system.g
+++ b/hpcgap/lib/system.g
@@ -76,7 +76,6 @@ BIND_GLOBAL( "GAPInfo", AtomicRecord(rec(
            help := [ "set hint for maximal workspace size (GAP may", "allocate more)"] ),
       rec( short:= "K", long := "limitworkspace", default := "0", arg := "<mem>",
            help := [ "set maximal workspace size (GAP never", "allocates more)"] ),
-      rec( short:= "c", default := "0", arg := "<mem>", help := [ "set the cache size value"] ),
       rec( short:= "s", default := "4g", arg := "<mem", help := [ "set the initially mapped virtual memory" ] ),
       rec( short:= "a", default := "0",  arg := "<mem>",help := [ "set amount to pre-malloc-ate",
              "postfix 'k' = *1024, 'm' = *1024*1024,", "'g' = *1024*1024*1024"] ),

--- a/hpcgap/src/gap.c
+++ b/hpcgap/src/gap.c
@@ -3353,7 +3353,7 @@ void InitializeGap (
     /* Initialise memory  -- have to do this here to make sure we are at top of C stack */
     InitBags( SyAllocBags, SyStorMin,
               0, (Bag*)(((UInt)pargc/SyStackAlign)*SyStackAlign), SyStackAlign,
-              SyCacheSize, 0, SyAbortBags );
+              0, SyAbortBags );
               InitMsgsFuncBags( SyMsgsBags ); 
 
     TLS(StackNams)    = NEW_PLIST( T_PLIST, 16 );

--- a/hpcgap/src/system.c
+++ b/hpcgap/src/system.c
@@ -118,22 +118,6 @@ UInt SyCTRD;
 
 /****************************************************************************
 **
-*V  SyCacheSize . . . . . . . . . . . . . . . . . . . . . . size of the cache
-**
-**  'SyCacheSize' is the size of the data cache.
-**
-**  This is per  default 0, which means that  there is no usuable data cache.
-**  It is usually changed with the '-c' option in the script that starts GAP.
-**
-**  This value is passed to 'InitBags'.
-**
-**  Put in this package because the command line processing takes place here.
-*/
-UInt SyCacheSize;
-
-
-/****************************************************************************
-**
 *V  SyCheckCRCCompiledModule  . . .  check crc while loading compiled modules
 */
 Int SyCheckCRCCompiledModule;
@@ -1859,8 +1843,6 @@ struct optInfo options[] = {
   { 'R', "", unsetString, &SyRestoring, 0}, /* kernel */
   { 'U', "", storeString, SyCompileOptions, 1}, /* kernel */
   { 'a', "", storeMemory, &preAllocAmount, 1 }, /* kernel -- is this still useful */
-  { 'c', "", storeMemory, &SyCacheSize, 1 }, /* kernel, unless we provided a hook to set it from library, 
-                                           never seems to be useful */
   { 'e', "", toggle, &SyCTRD, 0 }, /* kernel */
   { 'f', "", forceLineEditing, (void *)2, 0 }, /* probably library now */
   { 'E', "", toggle, &SyUseReadline, 0 }, /* kernel */
@@ -1898,7 +1880,6 @@ void InitSystem (
     /* Initialize global and static variables. Do it here rather than
        with initializers to allow for restart */
     SyCTRD = 1;             
-    SyCacheSize = 0;
     SyCheckCRCCompiledModule = 0;
     SyCompilePlease = 0;
     SyDebugLoading = 0;

--- a/hpcgap/src/system.h
+++ b/hpcgap/src/system.h
@@ -204,22 +204,6 @@ extern UInt SyCTRD;
 
 
 /****************************************************************************
-**
-*V  SyCacheSize . . . . . . . . . . . . . . . . . . . . . . size of the cache
-**
-**  'SyCacheSize' is the size of the data cache, in kilobytes
-**
-**  This is per  default 0, which means that  there is no usuable data cache.
-**  It is usually changed with the '-c' option in the script that starts GAP.
-**
-**  This value is passed to 'InitBags'.
-**
-**  Put in this package because the command line processing takes place here.
-*/
-extern UInt SyCacheSize;
-
-
-/****************************************************************************
  **
  *V  SyCheckCRCCompiledModule  . . .  check crc while loading compiled modules
  */

--- a/lib/system.g
+++ b/lib/system.g
@@ -75,7 +75,6 @@ BIND_GLOBAL( "GAPInfo", rec(
            help := [ "set hint for maximal workspace size (GAP may", "allocate more)"] ),
       rec( short:= "K", long := "limitworkspace", default := "0", arg := "<mem>",
            help := [ "set maximal workspace size (GAP never", "allocates more)"] ),
-      rec( short:= "c", default := "0", arg := "<mem>", help := [ "set the cache size value"] ),
       rec( short:= "s", default := "4g", arg := "<mem", help := [ "set the initially mapped virtual memory" ] ),
       rec( short:= "a", default := "0",  arg := "<mem>",help := [ "set amount to pre-malloc-ate",
              "postfix 'k' = *1024, 'm' = *1024*1024,", "'g' = *1024*1024*1024"] ),

--- a/src/gap.c
+++ b/src/gap.c
@@ -3260,7 +3260,7 @@ void InitializeGap (
     /* Initialise memory  -- have to do this here to make sure we are at top of C stack */
     InitBags( SyAllocBags, SyStorMin,
               0, (Bag*)(((UInt)pargc/SyStackAlign)*SyStackAlign), SyStackAlign,
-              SyCacheSize, 0, SyAbortBags );
+              0, SyAbortBags );
               InitMsgsFuncBags( SyMsgsBags ); 
 
     TLS(StackNams)    = NEW_PLIST( T_PLIST, 16 );

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -1067,7 +1067,7 @@ extern void CheckMasterPointers( void );
 **
 **  InitBags( <alloc-func>, <initial-size>,
 **            <stack-func>, <stack-start>, <stack-align>,
-**            <cache-size>, <dirty>, <abort-func> )
+**            <dirty>, <abort-func> )
 **
 **  'InitBags'  initializes {\Gasman}.  It  must be called from a application
 **  using {\Gasman} before any bags can be allocated.
@@ -1128,20 +1128,6 @@ extern void CheckMasterPointers( void );
 **  on  the   machine,  the  operating system,   and   the compiler.   If the
 **  application provides another <stack-func>, <stack-align> is ignored.
 **
-**  <cache-size>  informs {\Gasman} whether  the  processor has a usable data
-**  cache and how large it is  measured in bytes.   If the application passes
-**  0, {\Gasman} assumes that the processor has no data cache or a data cache
-**  to small to be   useful.  In this case  the  entire free storage is  made
-**  available for allocations after garbage  collections.  If the application
-**  passes a  nonzero value, {\Gasman}  assumes that this is  the size of the
-**  part of the data cache that should  be used for  the allocation area, and
-**  tries  to keep the allocation  area small enough  so that it fits.  For a
-**  processor that has separate  data and instruction caches, the application
-**  should pass the size of the data cache minus 65536.  For a processor with
-**  a  unified cache,  the application  should  pass the size  of the unified
-**  cache minus   131072.  The application probably should   not pass a value
-**  less than 131072.
-**
 **  The initialization  flag  <dirty> determines  whether  bags allocated  by
 **  'NewBag' are initialized to contain only 0 or not.   If <dirty> is 0, the
 **  bags are  initialized to  contain only 0.    If  <dirty> is  1, the  bags
@@ -1169,7 +1155,6 @@ extern  void            InitBags (
             TNumStackFuncBags   stack_func,
             Bag *               stack_bottom,
             UInt                stack_align,
-            UInt                cache_size,
             UInt                dirty,
             TNumAbortFuncBags   abort_func );
 

--- a/src/hpc/boehm_gc.h
+++ b/src/hpc/boehm_gc.h
@@ -304,7 +304,6 @@ void            InitBags (
     TNumStackFuncBags   stack_func,
     Bag *               stack_bottom,
     UInt                stack_align,
-    UInt                cache_size,
     UInt                dirty,
     TNumAbortFuncBags   abort_func )
 {

--- a/src/system.c
+++ b/src/system.c
@@ -118,22 +118,6 @@ UInt SyCTRD;
 
 /****************************************************************************
 **
-*V  SyCacheSize . . . . . . . . . . . . . . . . . . . . . . size of the cache
-**
-**  'SyCacheSize' is the size of the data cache.
-**
-**  This is per  default 0, which means that  there is no usuable data cache.
-**  It is usually changed with the '-c' option in the script that starts GAP.
-**
-**  This value is passed to 'InitBags'.
-**
-**  Put in this package because the command line processing takes place here.
-*/
-UInt SyCacheSize;
-
-
-/****************************************************************************
-**
 *V  SyCheckCRCCompiledModule  . . .  check crc while loading compiled modules
 */
 Int SyCheckCRCCompiledModule;
@@ -1804,8 +1788,6 @@ struct optInfo options[] = {
   { 'R', "", unsetString, &SyRestoring, 0}, /* kernel */
   { 'U', "", storeString, SyCompileOptions, 1}, /* kernel */
   { 'a', "", storeMemory, &preAllocAmount, 1 }, /* kernel -- is this still useful */
-  { 'c', "", storeMemory, &SyCacheSize, 1 }, /* kernel, unless we provided a hook to set it from library, 
-                                           never seems to be useful */
   { 'e', "", toggle, &SyCTRD, 0 }, /* kernel */
   { 'f', "", forceLineEditing, (void *)2, 0 }, /* probably library now */
   { 'E', "", toggle, &SyUseReadline, 0 }, /* kernel */
@@ -1839,7 +1821,6 @@ void InitSystem (
     /* Initialize global and static variables. Do it here rather than
        with initializers to allow for restart */
     SyCTRD = 1;             
-    SyCacheSize = 0;
     SyCheckCRCCompiledModule = 0;
     SyCompilePlease = 0;
     SyDebugLoading = 0;

--- a/src/system.h
+++ b/src/system.h
@@ -204,22 +204,6 @@ extern UInt SyCTRD;
 
 
 /****************************************************************************
-**
-*V  SyCacheSize . . . . . . . . . . . . . . . . . . . . . . size of the cache
-**
-**  'SyCacheSize' is the size of the data cache, in kilobytes
-**
-**  This is per  default 0, which means that  there is no usuable data cache.
-**  It is usually changed with the '-c' option in the script that starts GAP.
-**
-**  This value is passed to 'InitBags'.
-**
-**  Put in this package because the command line processing takes place here.
-*/
-extern UInt SyCacheSize;
-
-
-/****************************************************************************
  **
  *V  SyCheckCRCCompiledModule  . . .  check crc while loading compiled modules
  */


### PR DESCRIPTION
This code was meant as an optimization for CPUs with data cache (i.e.
nowadays every CPU), but in practice it seems to have no noticeable
impact.

Resolves #273