### PR TITLE
Build/Load GAP Development manual if it is present

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -220,12 +220,16 @@ manuals: compile
           ../../$(TESTGAP) -L ../wsp.g | tee make_manuals.out )
 	( cd doc/changes; echo 'Read( "makedocrel.g" );' | \
           ../../$(TESTGAP) -L ../wsp.g | tee make_manuals.out )
+	( if [[ ! -f doc/dev ]] ; then cd doc/dev; echo 'Read( "makedocrelx.g" );' | \
+          ../../$(TESTGAP) -L ../wsp.g | tee make_manuals.out; fi )
 	( cd doc/ref; echo 'Read( "makedocrel.g" );' | \
           ../../$(TESTGAP) -L ../wsp.g | tee make_manuals.out )
 	( cd doc/tut; echo 'Read( "makedocrel.g" );' | \
           ../../$(TESTGAP) -L ../wsp.g | tee make_manuals.out )
 	( cd doc/changes; echo 'Read( "makedocrel.g" );' | \
           ../../$(TESTGAP) -L ../wsp.g | tee make_manuals.out )
+	( if [[ ! -f doc/dev ]] ; then cd doc/dev; echo 'Read( "makedocrelx.g" );' | \
+          ../../$(TESTGAP) -L ../wsp.g | tee make_manuals.out; fi )
 	( rm doc/wsp.g )
 
 check: compile

--- a/lib/helpbase.gi
+++ b/lib/helpbase.gi
@@ -498,6 +498,10 @@ InstallGlobalFunction(HELP_ADD_BOOK, function( short, long, dir )
   sortfun := function(a, b)
     local main, pa, pb;
     main := ["tutorial", "reference", "changes"];
+    if ForAny( GAPInfo.RootPaths,
+               rp -> IsExistingFile( Concatenation( rp, "/doc/dev" ) ) ) then
+      Add( main, "development" );
+    fi;
     pa := Position(main, a);
     pb := Position(main, b);
     if pa <> fail then

--- a/lib/init.g
+++ b/lib/init.g
@@ -1038,7 +1038,10 @@ end);
 HELP_ADD_BOOK("Tutorial", "GAP 4 Tutorial", "doc/tut");
 HELP_ADD_BOOK("Reference", "GAP 4 Reference Manual", "doc/ref");
 HELP_ADD_BOOK("Changes", "Changes from Earlier Versions", "doc/changes");
-
+if ForAny( GAPInfo.RootPaths,
+           rp -> IsExistingFile( Concatenation( rp, "/doc/dev" ) ) ) then
+  HELP_ADD_BOOK("Development", "GAP 4 Development Manual", "doc/dev");
+fi;
 
 #############################################################################
 ##


### PR DESCRIPTION
This pull request closes #1161. It ensures that if `doc/dev` directory is present in the system then the GAP Development manual will be also built by `make manuals` and will be loaded when GAP starts (of course, that also may be made a user preference). For example, `??GASMAN` would now also return three entries from the GAP Development manual.

I hope this make the Development manual more visible and having better chances of getting improved eventually (I've started some cleanup in #506, but haven't made much progress since then).