### PR TITLE
.appveyor.yml: enable HPC-GAP builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,11 +6,11 @@ environment:
   LDFLAGS: "-fprofile-arcs"
   TEST_SUITES: testinstall
   matrix:
-    - CYG_ARCH: x86
-      CYG_ROOT: C:\cygwin
-      ABI: 32
-    - CYG_ARCH: x86_64
-      CYG_ROOT: C:\cygwin64
+#    - CYG_ARCH: x86
+#      CYG_ROOT: C:\cygwin
+#      ABI: 32
+#    - CYG_ARCH: x86_64
+#      CYG_ROOT: C:\cygwin64
     - CYG_ARCH: x86
       CYG_ROOT: C:\cygwin
       ABI: 32

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,17 +11,15 @@ environment:
       ABI: 32
     - CYG_ARCH: x86_64
       CYG_ROOT: C:\cygwin64
-# FIXME: HPC-GAP builds on AppVeyor are disabled for now, as they experience
-# weird errors in building ward (which I cannot replicate on a Windows VM).
-#    - CYG_ARCH: x86
-#      CYG_ROOT: C:\cygwin
-#      ABI: 32
-#      HPCGAP: yes
-#      BUILDDIR: build       # HPC-GAP only supports kernel extensions for of out-of-tree builds
-#    - CYG_ARCH: x86_64
-#      CYG_ROOT: C:\cygwin64
-#      HPCGAP: yes
-#      BUILDDIR: build       # HPC-GAP only supports kernel extensions for of out-of-tree builds
+    - CYG_ARCH: x86
+      CYG_ROOT: C:\cygwin
+      ABI: 32
+      HPCGAP: yes
+      BUILDDIR: build       # HPC-GAP only supports kernel extensions for of out-of-tree builds
+    - CYG_ARCH: x86_64
+      CYG_ROOT: C:\cygwin64
+      HPCGAP: yes
+      BUILDDIR: build       # HPC-GAP only supports kernel extensions for of out-of-tree builds
 
 # change to packages-stable-X.Y.tar.gz in the stable branch
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,95 +22,95 @@ addons:
 matrix:
   include:
     # general test suite (subsumes testinstall tests, too)
-    - env: TEST_SUITES="docomp testtravis" CONFIGFLAGS="--enable-debug"
-    - env: TEST_SUITES="docomp testtravis" ABI=32
-      addons:
-        apt_packages:
-          - gcc-multilib
-          - g++-multilib
-          - libgmp-dev:i386
-          - libreadline-dev:i386
-
-    # compiler packages and run package tests
-    - env: TEST_SUITES=testpackages CONFIGFLAGS="--enable-debug"
-      addons:
-        apt_packages:
-          - gcc-multilib
-          - g++-multilib
-          - libgmp-dev
-          - libgmp-dev:i386         # for anupq
-          - libreadline-dev
-          - libboost-dev            # for NormalizInterface
-          - libmpfr-dev             # for float
-          - libmpfi-dev             # for float
-          - libmpc-dev              # for float
-          #- libfplll-dev           # for float
-          - pari-gp                 # for alnuth
-          - libzmq3-dev             # for ZeroMQInterface
-
-    - env: TEST_SUITES=testpackages ABI=32 CONFIGFLAGS="--enable-debug"
-      addons:
-        apt_packages:
-          - gcc-multilib
-          - g++-multilib
-          - libgmp-dev:i386
-          - libreadline-dev:i386
-          - libncurses5-dev:i386    # for Browse
-          - libboost-dev:i386       # for NormalizInterface
-          - libmpfr-dev:i386        # for float
-          - libmpfi-dev:i386        # for float
-          - libmpc-dev:i386         # for float
-          #- libfplll-dev:i386      # for float
-          - pari-gp:i386            # for alnuth
-          - libzmq3-dev:i386        # for ZeroMQInterface
-
-    # OS X builds: since those are slow and limited on Travis, we only run testinstall
-    - env: TEST_SUITES="docomp testinstall"
-      os: osx
-      compiler: clang
-
-    # test creating the manual
-    - env: TEST_SUITES=makemanuals CONFIGFLAGS="--enable-debug"
-      addons:
-        apt_packages:
-          - texlive-latex-base
-          - texlive-latex-recommended
-          - texlive-latex-extra
-          - texlive-extra-utils
-          - texlive-fonts-recommended
-          - texlive-fonts-extra
-
-    # run tests contained in the manual
-    - env: TEST_SUITES=testmanuals CONFIGFLAGS="--enable-debug"
-
-    # HPC-GAP builds (for efficiency, we don't build all combinations)
-    # FIXME: the 32bit build removes -O2 to avoid an internal compiler error for vecgf2.c
-    - env: TEST_SUITES="docomp testinstall" ABI=64 HPCGAP=yes CONFIGFLAGS="--enable-debug"
-    - env: TEST_SUITES="docomp testinstall" ABI=32 HPCGAP=yes BUILDDIR=build CONFIGFLAGS="--with-gmp=builtin" CFLAGS="-fprofile-arcs -ftest-coverage"
-      addons:
-        apt_packages:
-          - gcc-multilib
-          - g++-multilib
-          - libgmp-dev:i386
-          - libreadline-dev:i386
-          - texinfo # for building GMP
-
-    # out of tree builds -- these are mainly done to verify that the build
-    # system work in this scenario. Since we don't expect the test results to
-    # vary compared to the in-tree builds, we turn off coverage reporting by
-    # setting NO_COVERAGE=1; this has the extra benefit of also running the
-    # tests at least once with the ReproducibleBehaviour option turned off.
-    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=64 BUILDDIR=build CONFIGFLAGS="--enable-debug"
-    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=32 BUILDDIR=build
-      addons:
-        apt_packages:
-          - gcc-multilib
-          - g++-multilib
-          - libgmp-dev:i386
-          - libreadline-dev:i386
-
-    # run bugfix regression tests
-    - env: TEST_SUITES=testbugfix CONFIGFLAGS="--enable-debug"
+#    - env: TEST_SUITES="docomp testtravis" CONFIGFLAGS="--enable-debug"
+#    - env: TEST_SUITES="docomp testtravis" ABI=32
+#      addons:
+#        apt_packages:
+#          - gcc-multilib
+#          - g++-multilib
+#          - libgmp-dev:i386
+#          - libreadline-dev:i386
+#
+#    # compiler packages and run package tests
+#    - env: TEST_SUITES=testpackages CONFIGFLAGS="--enable-debug"
+#      addons:
+#        apt_packages:
+#          - gcc-multilib
+#          - g++-multilib
+#          - libgmp-dev
+#          - libgmp-dev:i386         # for anupq
+#          - libreadline-dev
+#          - libboost-dev            # for NormalizInterface
+#          - libmpfr-dev             # for float
+#          - libmpfi-dev             # for float
+#          - libmpc-dev              # for float
+#          #- libfplll-dev           # for float
+#          - pari-gp                 # for alnuth
+#          - libzmq3-dev             # for ZeroMQInterface
+#
+#    - env: TEST_SUITES=testpackages ABI=32 CONFIGFLAGS="--enable-debug"
+#      addons:
+#        apt_packages:
+#          - gcc-multilib
+#          - g++-multilib
+#          - libgmp-dev:i386
+#          - libreadline-dev:i386
+#          - libncurses5-dev:i386    # for Browse
+#          - libboost-dev:i386       # for NormalizInterface
+#          - libmpfr-dev:i386        # for float
+#          - libmpfi-dev:i386        # for float
+#          - libmpc-dev:i386         # for float
+#          #- libfplll-dev:i386      # for float
+#          - pari-gp:i386            # for alnuth
+#          - libzmq3-dev:i386        # for ZeroMQInterface
+#
+#    # OS X builds: since those are slow and limited on Travis, we only run testinstall
+#    - env: TEST_SUITES="docomp testinstall"
+#      os: osx
+#      compiler: clang
+#
+#    # test creating the manual
+#    - env: TEST_SUITES=makemanuals CONFIGFLAGS="--enable-debug"
+#      addons:
+#        apt_packages:
+#          - texlive-latex-base
+#          - texlive-latex-recommended
+#          - texlive-latex-extra
+#          - texlive-extra-utils
+#          - texlive-fonts-recommended
+#          - texlive-fonts-extra
+#
+#    # run tests contained in the manual
+#    - env: TEST_SUITES=testmanuals CONFIGFLAGS="--enable-debug"
+#
+#    # HPC-GAP builds (for efficiency, we don't build all combinations)
+#    # FIXME: the 32bit build removes -O2 to avoid an internal compiler error for vecgf2.c
+#    - env: TEST_SUITES="docomp testinstall" ABI=64 HPCGAP=yes CONFIGFLAGS="--enable-debug"
+#    - env: TEST_SUITES="docomp testinstall" ABI=32 HPCGAP=yes BUILDDIR=build CONFIGFLAGS="--with-gmp=builtin" CFLAGS="-fprofile-arcs -ftest-coverage"
+#      addons:
+#        apt_packages:
+#          - gcc-multilib
+#          - g++-multilib
+#          - libgmp-dev:i386
+#          - libreadline-dev:i386
+#          - texinfo # for building GMP
+#
+#    # out of tree builds -- these are mainly done to verify that the build
+#    # system work in this scenario. Since we don't expect the test results to
+#    # vary compared to the in-tree builds, we turn off coverage reporting by
+#    # setting NO_COVERAGE=1; this has the extra benefit of also running the
+#    # tests at least once with the ReproducibleBehaviour option turned off.
+#    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=64 BUILDDIR=build CONFIGFLAGS="--enable-debug"
+#    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=32 BUILDDIR=build
+#      addons:
+#        apt_packages:
+#          - gcc-multilib
+#          - g++-multilib
+#          - libgmp-dev:i386
+#          - libreadline-dev:i386
+#
+#    # run bugfix regression tests
+#    - env: TEST_SUITES=testbugfix CONFIGFLAGS="--enable-debug"
 
     # test error reporting and compiling (quickest job in this test suite)
     - env: TEST_SUITES=testspecial CONFIGFLAGS="--enable-debug"

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -19,7 +19,7 @@ BUILDDIR=$PWD
 # for HPC-GAP we install ward inside BUILDDIR
 if [[ $HPCGAP = yes ]]
 then
-  git clone https://github.com/gap-system/ward
+  git clone -b mh/HACK https://github.com/fingolfin/ward
   cd ward
   CFLAGS= LDFLAGS= ./build.sh
   cd ..


### PR DESCRIPTION
The tests currently fail while building ward. But similar tests seem to work fine on a local Windows VM.

To tackle this, I think it would make sense to first add AppVeyor tests to https://github.com/gap-system/ward/. If we can reproduce the issue there, it's much easier and faster to debug it there If it doesn't occur there, we can try to figure out what the difference is.