### PR TITLE
bin/BuildPackages.sh: fix echo_run for args with spaces

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -123,7 +123,7 @@ echo_run() {
   # when printf is given a format string with only one format specification,
   # it applies that format string to each argument in sequence
   notice "Running $(printf "'%s' " "$@")"
-  eval "$@"
+  "$@"
 }
 
 build_carat() {


### PR DESCRIPTION
The eval was redundant for our uses. This fixes e.g. compilation of kbmag,
where the argument COPTS="-O2 -g" was split into two by eval, lading to
an error.