### PR TITLE
Fix gcov invocation on Travis and AppVeyor

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -894,8 +894,12 @@ teststandard: all
           ReadGapRoot( "tst/teststandard.g" );' | $(TESTGAP) | \
             tee `date -u +dev/log/teststandard2_%Y-%m-%d-%H-%M` )
 
+coverage:
+	gcov -o . $(SOURCES)
+
 .PHONY: testinstall testmanuals testobsoletes teststandard
 .PHONY: testpackage testpackages testpackagesload testpackagesvars
+.PHONY: coverage
 
 ########################################################################
 # Bootstrap rules

--- a/etc/ci-gather-coverage.sh
+++ b/etc/ci-gather-coverage.sh
@@ -45,7 +45,4 @@ QUIT_GAP(0);
 GAPInput
 
 # generate kernel coverage reports by running gcov
-. sysinfo.gap
-cd bin/${GAParch}
-gcov -o . ../../src/*
-cd ../..
+make coverage


### PR DESCRIPTION
This is not yet done, DO NOT MERGE

Also, once we enable tests for HPC-GAP, we may need to add an if/else, and point gcov at `gen/*.c` and/or `hpcgap/src/*.c`

Also, I wonder about `src/hpc/*.c` -- shouldn't we add that, too?

All in all, it might be better to add a `coverage` target to `Makefile.rules`, which runs `gcov $(SOURCES)` or so.