### PR TITLE
ThreadLocalStorage -> GlobalState merge

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -53,11 +53,7 @@ SOURCES += src/funcs.c
 SOURCES += src/gap.c
 SOURCES += gen/gap_version.c	# generated source file
 SOURCES += src/gasman.c
-ifeq ($(HPCGAP),no)
-# FIXME: HPC-GAP are compatible, but some functions still
-# need to be merged between hpc/tls.c and globalstate.c
 SOURCES += src/gapstate.c
-endif
 SOURCES += src/gmpints.c
 SOURCES += src/gvars.c
 SOURCES += src/intfuncs.c

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -54,9 +54,9 @@ SOURCES += src/gap.c
 SOURCES += gen/gap_version.c	# generated source file
 SOURCES += src/gasman.c
 ifeq ($(HPCGAP),no)
-# FIXME: HPC-GAP and src/globalstate.c are not yet compatible; need to "merge"
-# struct GlobalState with ThreadLocalStorage from hpc/tls.h
-SOURCES += src/globalstate.c
+# FIXME: HPC-GAP are compatible, but some functions still
+# need to be merged between hpc/tls.c and globalstate.c
+SOURCES += src/gapstate.c
 endif
 SOURCES += src/gmpints.c
 SOURCES += src/gvars.c

--- a/hpcgap/src/c_filter1.c
+++ b/hpcgap/src/c_filter1.c
@@ -567,13 +567,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 15, "CLEAR_IMP_CACHE" );
  t_3 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(38));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(43));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "WITH_IMPS_FLAGS", function ( flags )
@@ -618,13 +618,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 15, "WITH_IMPS_FLAGS" );
  t_3 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(46));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(89));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "RankFilter", function ( filter )
@@ -649,13 +649,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "RankFilter" );
  t_3 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(98));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(117));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
@@ -769,8 +769,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = TLS(CurrLVars);
- CHANGED_BAG( TLS(CurrLVars) );
+ ENVI_FUNC( func1 ) = STATE(CurrLVars);
+ CHANGED_BAG( STATE(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/hpcgap/src/c_oper1.c
+++ b/hpcgap/src/c_oper1.c
@@ -2514,13 +2514,13 @@ static Obj  HdlrFunc7 (
    SET_ELM_PLIST( t_5, 1, l_cats );
    CHANGED_BAG( t_5 );
    t_6 = NewFunction( NameFunc[8], NargFunc[8], NamsFunc[8], HdlrFunc8 );
-   ENVI_FUNC( t_6 ) = TLS(CurrLVars);
+   ENVI_FUNC( t_6 ) = STATE(CurrLVars);
    t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
    SET_STARTLINE_BODY(t_7, INTOBJ_INT(606));
    SET_ENDLINE_BODY(t_7, INTOBJ_INT(624));
    SET_FILENAME_BODY(t_7, FileName);
    BODY_FUNC(t_6) = t_7;
-   CHANGED_BAG( TLS(CurrLVars) );
+   CHANGED_BAG( STATE(CurrLVars) );
    CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, l_rank, t_6 );
    
   }
@@ -3106,13 +3106,13 @@ static Obj  HdlrFunc11 (
       return;
   end; */
   t_1 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
-  ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+  ENVI_FUNC( t_1 ) = STATE(CurrLVars);
   t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
   SET_STARTLINE_BODY(t_2, INTOBJ_INT(803));
   SET_ENDLINE_BODY(t_2, INTOBJ_INT(807));
   SET_FILENAME_BODY(t_2, FileName);
   BODY_FUNC(t_1) = t_2;
-  CHANGED_BAG( TLS(CurrLVars) );
+  CHANGED_BAG( STATE(CurrLVars) );
   ASS_LVAR( 2, t_1 );
   
  }
@@ -3186,13 +3186,13 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 1, a_domreq );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
- ENVI_FUNC( t_6 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_6 ) = STATE(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_7, INTOBJ_INT(824));
  SET_ENDLINE_BODY(t_7, INTOBJ_INT(824));
  SET_FILENAME_BODY(t_7, FileName);
  BODY_FUNC(t_6) = t_7;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* DeclareOperation( name, [ domreq, keyreq ] ); */
@@ -3261,13 +3261,13 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 2, a_keyreq );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
- ENVI_FUNC( t_6 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_6 ) = STATE(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_7, INTOBJ_INT(840));
  SET_ENDLINE_BODY(t_7, INTOBJ_INT(863));
  SET_FILENAME_BODY(t_7, FileName);
  BODY_FUNC(t_6) = t_7;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* str := "Has"; */
@@ -3310,13 +3310,13 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 2, a_keyreq );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
- ENVI_FUNC( t_6 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_6 ) = STATE(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_7, INTOBJ_INT(873));
  SET_ENDLINE_BODY(t_7, INTOBJ_INT(881));
  SET_FILENAME_BODY(t_7, FileName);
  BODY_FUNC(t_6) = t_7;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* str := "Set"; */
@@ -3372,13 +3372,13 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 3, t_6 );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
- ENVI_FUNC( t_6 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_6 ) = STATE(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_7, INTOBJ_INT(890));
  SET_ENDLINE_BODY(t_7, INTOBJ_INT(903));
  SET_FILENAME_BODY(t_7, FileName);
  BODY_FUNC(t_6) = t_7;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* return; */
@@ -3753,13 +3753,13 @@ static Obj  HdlrFunc17 (
  t_3 = OBJ_LVAR( 2 );
  CHECK_BOUND( t_3, "reqs" )
  t_4 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
- ENVI_FUNC( t_4 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_4 ) = STATE(CurrLVars);
  t_5 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_5, INTOBJ_INT(971));
  SET_ENDLINE_BODY(t_5, INTOBJ_INT(987));
  SET_FILENAME_BODY(t_5, FileName);
  BODY_FUNC(t_4) = t_5;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_6ARGS( t_1, t_2, l_info, l_fampred, t_3, l_val, t_4 );
  
  /* return; */
@@ -3847,13 +3847,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 19, "RunImmediateMethods" );
  t_3 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(26));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(117));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "METHODS_OPERATION_REGION", NewSpecialRegion( "operation methods" ) ); */
@@ -3956,13 +3956,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 20, "INSTALL_METHOD_FLAGS" );
  t_3 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(136));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(250));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "InstallMethod", function ( arg... )
@@ -3972,13 +3972,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "InstallMethod" );
  t_3 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(297));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(299));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "InstallOtherMethod", function ( arg... )
@@ -3988,13 +3988,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 18, "InstallOtherMethod" );
  t_3 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(324));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(326));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* DeclareGlobalFunction( "EvalString" ); */
@@ -4148,13 +4148,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 14, "INSTALL_METHOD" );
  t_3 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(337));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(548));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + 6; */
@@ -4208,13 +4208,13 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_InstallAttributeFunction;
  t_2 = NewFunction( NameFunc[7], NargFunc[7], NamsFunc[7], HdlrFunc7 );
- ENVI_FUNC( t_2 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_2 ) = STATE(CurrLVars);
  t_3 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_3, INTOBJ_INT(567));
  SET_ENDLINE_BODY(t_3, INTOBJ_INT(628));
  SET_FILENAME_BODY(t_3, FileName);
  BODY_FUNC(t_2) = t_3;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
@@ -4223,13 +4223,13 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_InstallAttributeFunction;
  t_2 = NewFunction( NameFunc[9], NargFunc[9], NamsFunc[9], HdlrFunc9 );
- ENVI_FUNC( t_2 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_2 ) = STATE(CurrLVars);
  t_3 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_3, INTOBJ_INT(631));
  SET_ENDLINE_BODY(t_3, INTOBJ_INT(637));
  SET_FILENAME_BODY(t_3, FileName);
  BODY_FUNC(t_2) = t_3;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
  /* BIND_GLOBAL( "PositionSortedOddPositions", function ( list, elm )
@@ -4252,13 +4252,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 26, "PositionSortedOddPositions" );
  t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(650));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(674));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* IsPrimeInt := "2b defined"; */
@@ -4337,13 +4337,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "KeyDependentOperation" );
  t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(799));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(904));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* CallFuncList := "2b defined"; */
@@ -4389,13 +4389,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "RedispatchOnCondition" );
  t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(939));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(988));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* InstallMethod( ViewObj, "default method using `PrintObj'", true, [ IS_OBJECT ], 0, PRINT_OBJ ); */
@@ -4716,8 +4716,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = TLS(CurrLVars);
- CHANGED_BAG( TLS(CurrLVars) );
+ ENVI_FUNC( func1 ) = STATE(CurrLVars);
+ CHANGED_BAG( STATE(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/hpcgap/src/c_random.c
+++ b/hpcgap/src/c_random.c
@@ -391,13 +391,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 23, "GET_RANDOM_SEED_COUNTER" );
  t_3 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(25));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(29));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* R_228 := 2 ^ 28; */
@@ -413,13 +413,13 @@ static Obj  HdlrFunc1 (
       return list[QUO_INT( r_x[r_n] * LEN_LIST( list ), R_228 ) + 1];
   end; */
  t_1 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(34));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(41));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_RANDOM__LIST, t_1 );
  
  /* RANDOM_SEED := function ( n )
@@ -438,13 +438,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(43));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(55));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_RANDOM__SEED, t_1 );
  
  /* BIND_GLOBAL( "RANDOM_SEED_CONSTRUCTOR", function (  )
@@ -455,13 +455,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 23, "RANDOM_SEED_CONSTRUCTOR" );
  t_3 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(57));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(60));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BindThreadLocalConstructor( _R_N, RANDOM_SEED_CONSTRUCTOR ); */
@@ -585,8 +585,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = TLS(CurrLVars);
- CHANGED_BAG( TLS(CurrLVars) );
+ ENVI_FUNC( func1 ) = STATE(CurrLVars);
+ CHANGED_BAG( STATE(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/hpcgap/src/c_type1.c
+++ b/hpcgap/src/c_type1.c
@@ -414,13 +414,13 @@ static Obj  HdlrFunc3 (
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
-  ENVI_FUNC( t_5 ) = TLS(CurrLVars);
+  ENVI_FUNC( t_5 ) = STATE(CurrLVars);
   t_6 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
   SET_STARTLINE_BODY(t_6, INTOBJ_INT(39));
   SET_ENDLINE_BODY(t_6, INTOBJ_INT(42));
   SET_FILENAME_BODY(t_6, FileName);
   BODY_FUNC(t_5) = t_6;
-  CHANGED_BAG( TLS(CurrLVars) );
+  CHANGED_BAG( STATE(CurrLVars) );
   CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
   
  }
@@ -4082,13 +4082,13 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_InstallAttributeFunction;
  t_2 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_2 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_2 ) = STATE(CurrLVars);
  t_3 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_3, INTOBJ_INT(19));
  SET_ENDLINE_BODY(t_3, INTOBJ_INT(26));
  SET_FILENAME_BODY(t_3, FileName);
  BODY_FUNC(t_2) = t_3;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + 6; */
@@ -4111,13 +4111,13 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_InstallAttributeFunction;
  t_2 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_2 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_2 ) = STATE(CurrLVars);
  t_3 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_3, INTOBJ_INT(31));
  SET_ENDLINE_BODY(t_3, INTOBJ_INT(52));
  SET_FILENAME_BODY(t_3, FileName);
  BODY_FUNC(t_2) = t_3;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
  /* Subtype := "defined below"; */
@@ -4159,13 +4159,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NEW_FAMILY" );
  t_3 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(90));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(120));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily2", function ( typeOfFamilies, name )
@@ -4174,13 +4174,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NewFamily2" );
  t_3 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(123));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(128));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily3", function ( typeOfFamilies, name, req )
@@ -4189,13 +4189,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NewFamily3" );
  t_3 = NewFunction( NameFunc[7], NargFunc[7], NamsFunc[7], HdlrFunc7 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(131));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(136));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily4", function ( typeOfFamilies, name, req, imp )
@@ -4204,13 +4204,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NewFamily4" );
  t_3 = NewFunction( NameFunc[8], NargFunc[8], NamsFunc[8], HdlrFunc8 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(139));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(144));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily5", function ( typeOfFamilies, name, req, imp, filter )
@@ -4219,13 +4219,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NewFamily5" );
  t_3 = NewFunction( NameFunc[9], NargFunc[9], NamsFunc[9], HdlrFunc9 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(148));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(153));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily", function ( arg... )
@@ -4245,13 +4245,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "NewFamily" );
  t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(156));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(179));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* NEW_TYPE_CACHE_MISS := 0; */
@@ -4334,13 +4334,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NEW_TYPE" );
  t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(207));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(296));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType3", function ( typeOfTypes, family, filter )
@@ -4349,13 +4349,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType3" );
  t_3 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(300));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(307));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType4", function ( typeOfTypes, family, filter, data )
@@ -4364,13 +4364,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType4" );
  t_3 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(310));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(317));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType", function ( arg... )
@@ -4390,13 +4390,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "NewType" );
  t_3 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(320));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(344));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Subtype2", function ( type, filter )
@@ -4405,13 +4405,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "Subtype2" );
  t_3 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(357));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(364));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Subtype3", function ( type, filter, data )
@@ -4420,13 +4420,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "Subtype3" );
  t_3 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(367));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(374));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Unbind( Subtype ); */
@@ -4449,13 +4449,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "Subtype" );
  t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(378));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(393));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType2", function ( type, filter )
@@ -4464,13 +4464,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "SupType2" );
  t_3 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(407));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(414));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType3", function ( type, filter, data )
@@ -4479,13 +4479,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "SupType3" );
  t_3 = NewFunction( NameFunc[19], NargFunc[19], NamsFunc[19], HdlrFunc19 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(417));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(424));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType", function ( arg... )
@@ -4502,13 +4502,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "SupType" );
  t_3 = NewFunction( NameFunc[20], NargFunc[20], NamsFunc[20], HdlrFunc20 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(427));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(441));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FamilyType", function ( K )
@@ -4517,13 +4517,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "FamilyType" );
  t_3 = NewFunction( NameFunc[21], NargFunc[21], NamsFunc[21], HdlrFunc21 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(455));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(455));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FlagsType", function ( K )
@@ -4532,13 +4532,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "FlagsType" );
  t_3 = NewFunction( NameFunc[22], NargFunc[22], NamsFunc[22], HdlrFunc22 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(469));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(469));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "DataType", function ( K )
@@ -4547,13 +4547,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "DataType" );
  t_3 = NewFunction( NameFunc[23], NargFunc[23], NamsFunc[23], HdlrFunc23 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(485));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(485));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetDataType", function ( K, data )
@@ -4563,13 +4563,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 11, "SetDataType" );
  t_3 = NewFunction( NameFunc[24], NargFunc[24], NamsFunc[24], HdlrFunc24 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(487));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(489));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "TypeObj", TYPE_OBJ ); */
@@ -4592,13 +4592,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "FlagsObj" );
  t_3 = NewFunction( NameFunc[25], NargFunc[25], NamsFunc[25], HdlrFunc25 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(588));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(588));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "DataObj", function ( obj )
@@ -4607,13 +4607,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "DataObj" );
  t_3 = NewFunction( NameFunc[26], NargFunc[26], NamsFunc[26], HdlrFunc26 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(602));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(602));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetTypeObj", function ( type, obj )
@@ -4633,13 +4633,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "SetTypeObj" );
  t_3 = NewFunction( NameFunc[27], NargFunc[27], NamsFunc[27], HdlrFunc27 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(616));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(629));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsNonAtomicComponentObjectRepFlags", FLAGS_FILTER( IsNonAtomicComponentObjectRep ) ); */
@@ -4704,13 +4704,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "Objectify" );
  t_3 = NewFunction( NameFunc[28], NargFunc[28], NamsFunc[28], HdlrFunc28 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(639));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(668));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ChangeTypeObj", function ( type, obj )
@@ -4732,13 +4732,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "ChangeTypeObj" );
  t_3 = NewFunction( NameFunc[29], NargFunc[29], NamsFunc[29], HdlrFunc29 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(682));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(697));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ReObjectify", ChangeTypeObj ); */
@@ -4790,13 +4790,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 12, "SetFilterObj" );
  t_3 = NewFunction( NameFunc[30], NargFunc[30], NamsFunc[30], HdlrFunc30 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(721));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(759));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SET_FILTER_OBJ", SetFilterObj ); */
@@ -4832,13 +4832,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 14, "ResetFilterObj" );
  t_3 = NewFunction( NameFunc[31], NargFunc[31], NamsFunc[31], HdlrFunc31 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(781));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(803));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "RESET_FILTER_OBJ", ResetFilterObj ); */
@@ -4859,13 +4859,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "SetFeatureObj" );
  t_3 = NewFunction( NameFunc[32], NargFunc[32], NamsFunc[32], HdlrFunc32 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(819));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(825));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetMultipleAttributes", function ( arg... )
@@ -4912,13 +4912,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "SetMultipleAttributes" );
  t_3 = NewFunction( NameFunc[33], NargFunc[33], NamsFunc[33], HdlrFunc33 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(846));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(898));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
@@ -4991,13 +4991,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 23, "ObjectifyWithAttributes" );
  t_3 = NewFunction( NameFunc[34], NargFunc[34], NamsFunc[34], HdlrFunc34 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(945));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(1010));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
@@ -5452,8 +5452,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = TLS(CurrLVars);
- CHANGED_BAG( TLS(CurrLVars) );
+ ENVI_FUNC( func1 ) = STATE(CurrLVars);
+ CHANGED_BAG( STATE(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/hpcgap/src/code.c
+++ b/hpcgap/src/code.c
@@ -90,28 +90,28 @@ Obj FilenameCache;
 /* TL: UInt LoopStackCount = 0; */
 
 static inline void PushOffsBody( void ) {
-  assert(TLS(OffsBodyCount) <= MAX_FUNC_EXPR_NESTING-1);
-  TLS(OffsBodyStack)[TLS(OffsBodyCount)++] = TLS(OffsBody);
+  assert(STATE(OffsBodyCount) <= MAX_FUNC_EXPR_NESTING-1);
+  STATE(OffsBodyStack)[STATE(OffsBodyCount)++] = STATE(OffsBody);
 }
 
 static inline void PopOffsBody( void ) {
-  assert(TLS(OffsBodyCount));
-  TLS(OffsBody) = TLS(OffsBodyStack)[--TLS(OffsBodyCount)];
+  assert(STATE(OffsBodyCount));
+  STATE(OffsBody) = STATE(OffsBodyStack)[--STATE(OffsBodyCount)];
 }
 
 static void SetupOffsBodyStackAndLoopStack() {
-  TLS(OffsBodyStack) = AllocateMemoryBlock(MAX_FUNC_EXPR_NESTING*sizeof(Stat));
-  TLS(LoopStack) = AllocateMemoryBlock(MAX_FUNC_EXPR_NESTING*sizeof(UInt));
+  STATE(OffsBodyStack) = AllocateMemoryBlock(MAX_FUNC_EXPR_NESTING*sizeof(Stat));
+  STATE(LoopStack) = AllocateMemoryBlock(MAX_FUNC_EXPR_NESTING*sizeof(UInt));
 }
 
 static inline void PushLoopNesting( void ) {
-  assert(TLS(LoopStackCount) <= MAX_FUNC_EXPR_NESTING-1);
-  TLS(LoopStack)[TLS(LoopStackCount)++] = TLS(LoopNesting);
+  assert(STATE(LoopStackCount) <= MAX_FUNC_EXPR_NESTING-1);
+  STATE(LoopStack)[STATE(LoopStackCount)++] = STATE(LoopNesting);
 }
 
 static inline void PopLoopNesting( void ) {
-  assert(TLS(LoopStackCount));
-  TLS(LoopNesting) = TLS(LoopStack)[--TLS(LoopStackCount)];
+  assert(STATE(LoopStackCount));
+  STATE(LoopNesting) = STATE(LoopStack)[--STATE(LoopStackCount)];
 }
 
 static inline void setup_gapname(TypInputFile* i)
@@ -226,24 +226,24 @@ Stat NewStatWithLine (
     Stat                stat;           /* result                          */
 
     /* this is where the new statement goes                                */
-    stat = TLS(OffsBody) + FIRST_STAT_CURR_FUNC;
+    stat = STATE(OffsBody) + FIRST_STAT_CURR_FUNC;
 
     /* increase the offset                                                 */
-    TLS(OffsBody) = stat + ((size+sizeof(Stat)-1) / sizeof(Stat)) * sizeof(Stat);
+    STATE(OffsBody) = stat + ((size+sizeof(Stat)-1) / sizeof(Stat)) * sizeof(Stat);
 
     /* make certain that the current body bag is large enough              */
     if ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) == 0 ) {
-      ResizeBag( BODY_FUNC(CURR_FUNC), TLS(OffsBody) + NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
-        TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
+      ResizeBag( BODY_FUNC(CURR_FUNC), STATE(OffsBody) + NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
+        STATE(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
-    while ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) < TLS(OffsBody) + NUMBER_HEADER_ITEMS_BODY*sizeof(Obj)  ) {
+    while ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) < STATE(OffsBody) + NUMBER_HEADER_ITEMS_BODY*sizeof(Obj)  ) {
         ResizeBag( BODY_FUNC(CURR_FUNC), 2*SIZE_BAG(BODY_FUNC(CURR_FUNC)) );
-        TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
+        STATE(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
-    setup_gapname(TLS(Input));
+    setup_gapname(STATE(Input));
     
     /* enter type and size                                                 */
-    ADDR_STAT(stat)[-1] = fillFilenameLine(TLS(Input)->gapnameid, line, size, type);
+    ADDR_STAT(stat)[-1] = fillFilenameLine(STATE(Input)->gapnameid, line, size, type);
     RegisterStatWithProfiling(stat);
     /* return the new statement                                            */
     return stat;
@@ -253,7 +253,7 @@ Stat NewStat (
     UInt                type,
     UInt                size)
 {
-    return NewStatWithLine(type, size, TLS(Input)->number);
+    return NewStatWithLine(type, size, STATE(Input)->number);
 }
 
 
@@ -271,24 +271,24 @@ Expr            NewExpr (
     Expr                expr;           /* result                          */
 
     /* this is where the new expression goes                               */
-    expr = TLS(OffsBody) + FIRST_STAT_CURR_FUNC;
+    expr = STATE(OffsBody) + FIRST_STAT_CURR_FUNC;
 
     /* increase the offset                                                 */
-    TLS(OffsBody) = expr + ((size+sizeof(Expr)-1) / sizeof(Expr)) * sizeof(Expr);
+    STATE(OffsBody) = expr + ((size+sizeof(Expr)-1) / sizeof(Expr)) * sizeof(Expr);
 
     /* make certain that the current body bag is large enough              */
     if ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) == 0 ) {
-        ResizeBag( BODY_FUNC(CURR_FUNC), TLS(OffsBody) );
-        TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
+        ResizeBag( BODY_FUNC(CURR_FUNC), STATE(OffsBody) );
+        STATE(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
-    while ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) < TLS(OffsBody) ) {
+    while ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) < STATE(OffsBody) ) {
         ResizeBag( BODY_FUNC(CURR_FUNC), 2*SIZE_BAG(BODY_FUNC(CURR_FUNC)) );
-        TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
+        STATE(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
 
     /* enter type and size                                                 */
-    ADDR_EXPR(expr)[-1] = fillFilenameLine(TLS(Input)->gapnameid,
-                                           TLS(Input)->number, size, type);
+    ADDR_EXPR(expr)[-1] = fillFilenameLine(STATE(Input)->gapnameid,
+                                           STATE(Input)->number, size, type);
     RegisterStatWithProfiling(expr);
     /* return the new expression                                           */
     return expr;
@@ -331,17 +331,17 @@ void PushStat (
     Stat                stat )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( TLS(StackStat) != 0 );
-    assert( 0 <= TLS(CountStat) );
-    assert( TLS(CountStat) <= SIZE_BAG(TLS(StackStat))/sizeof(Stat) );
+    assert( STATE(StackStat) != 0 );
+    assert( 0 <= STATE(CountStat) );
+    assert( STATE(CountStat) <= SIZE_BAG(STATE(StackStat))/sizeof(Stat) );
     assert( stat != 0 );
 
     /* count up and put the statement onto the stack                       */
-    if ( TLS(CountStat) == SIZE_BAG(TLS(StackStat))/sizeof(Stat) ) {
-        ResizeBag( TLS(StackStat), 2*TLS(CountStat)*sizeof(Stat) );
+    if ( STATE(CountStat) == SIZE_BAG(STATE(StackStat))/sizeof(Stat) ) {
+        ResizeBag( STATE(StackStat), 2*STATE(CountStat)*sizeof(Stat) );
     }
-    ((Stat*)PTR_BAG(TLS(StackStat)))[TLS(CountStat)] = stat;
-    TLS(CountStat)++;
+    ((Stat*)PTR_BAG(STATE(StackStat)))[STATE(CountStat)] = stat;
+    STATE(CountStat)++;
 }
 
 Stat PopStat ( void )
@@ -349,13 +349,13 @@ Stat PopStat ( void )
     Stat                stat;
 
     /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( TLS(StackStat) != 0 );
-    assert( 1 <= TLS(CountStat) );
-    assert( TLS(CountStat) <= SIZE_BAG(TLS(StackStat))/sizeof(Stat) );
+    assert( STATE(StackStat) != 0 );
+    assert( 1 <= STATE(CountStat) );
+    assert( STATE(CountStat) <= SIZE_BAG(STATE(StackStat))/sizeof(Stat) );
 
     /* get the top statement from the stack, and count down                */
-    TLS(CountStat)--;
-    stat = ((Stat*)PTR_BAG(TLS(StackStat)))[TLS(CountStat)];
+    STATE(CountStat)--;
+    stat = ((Stat*)PTR_BAG(STATE(StackStat)))[STATE(CountStat)];
 
     /* return the popped statement                                         */
     return stat;
@@ -425,17 +425,17 @@ void PushExpr (
     Expr                expr )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( TLS(StackExpr) != 0 );
-    assert( 0 <= TLS(CountExpr) );
-    assert( TLS(CountExpr) <= SIZE_BAG(TLS(StackExpr))/sizeof(Expr) );
+    assert( STATE(StackExpr) != 0 );
+    assert( 0 <= STATE(CountExpr) );
+    assert( STATE(CountExpr) <= SIZE_BAG(STATE(StackExpr))/sizeof(Expr) );
     assert( expr != 0 );
 
     /* count up and put the expression onto the stack                      */
-    if ( TLS(CountExpr) == SIZE_BAG(TLS(StackExpr))/sizeof(Expr) ) {
-        ResizeBag( TLS(StackExpr), 2*TLS(CountExpr)*sizeof(Expr) );
+    if ( STATE(CountExpr) == SIZE_BAG(STATE(StackExpr))/sizeof(Expr) ) {
+        ResizeBag( STATE(StackExpr), 2*STATE(CountExpr)*sizeof(Expr) );
     }
-    ((Expr*)PTR_BAG(TLS(StackExpr)))[TLS(CountExpr)] = expr;
-    TLS(CountExpr)++;
+    ((Expr*)PTR_BAG(STATE(StackExpr)))[STATE(CountExpr)] = expr;
+    STATE(CountExpr)++;
 }
 
 Expr PopExpr ( void )
@@ -443,13 +443,13 @@ Expr PopExpr ( void )
     Expr                expr;
 
     /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( TLS(StackExpr) != 0 );
-    assert( 1 <= TLS(CountExpr) );
-    assert( TLS(CountExpr) <= SIZE_BAG(TLS(StackExpr))/sizeof(Expr) );
+    assert( STATE(StackExpr) != 0 );
+    assert( 1 <= STATE(CountExpr) );
+    assert( STATE(CountExpr) <= SIZE_BAG(STATE(StackExpr))/sizeof(Expr) );
 
     /* get the top expression from the stack, and count down               */
-    TLS(CountExpr)--;
-    expr = ((Expr*)PTR_BAG(TLS(StackExpr)))[TLS(CountExpr)];
+    STATE(CountExpr)--;
+    expr = ((Expr*)PTR_BAG(STATE(StackExpr)))[STATE(CountExpr)];
 
     /* return the popped expression                                        */
     return expr;
@@ -604,14 +604,14 @@ void            CodeFuncCallOptionsEnd ( UInt nr )
 void CodeBegin ( void )
 {
     /* the stacks must be empty                                            */
-    assert( TLS(CountStat) == 0 );
-    assert( TLS(CountExpr) == 0 );
+    assert( STATE(CountStat) == 0 );
+    assert( STATE(CountExpr) == 0 );
 
     /* remember the current frame                                          */
-    TLS(CodeLVars) = TLS(CurrLVars);
+    STATE(CodeLVars) = STATE(CurrLVars);
 
     /* clear the code result bag                                           */
-    TLS(CodeResult) = 0;
+    STATE(CodeResult) = 0;
 }
 
 UInt CodeEnd (
@@ -621,24 +621,24 @@ UInt CodeEnd (
     if ( ! error ) {
 
         /* the stacks must be empty                                        */
-        assert( TLS(CountStat) == 0 );
-        assert( TLS(CountExpr) == 0 );
+        assert( STATE(CountStat) == 0 );
+        assert( STATE(CountExpr) == 0 );
 
-        /* we must be back to 'TLS(CurrLVars)'                                  */
-        assert( TLS(CurrLVars) == TLS(CodeLVars) );
+        /* we must be back to 'STATE(CurrLVars)'                                  */
+        assert( STATE(CurrLVars) == STATE(CodeLVars) );
 
-        /* 'CodeFuncExprEnd' left the function already in 'TLS(CodeResult)'     */
+        /* 'CodeFuncExprEnd' left the function already in 'STATE(CodeResult)'     */
     }
 
     /* otherwise clean up the mess                                         */
     else {
 
         /* empty the stacks                                                */
-        TLS(CountStat) = 0;
-        TLS(CountExpr) = 0;
+        STATE(CountStat) = 0;
+        STATE(CountExpr) = 0;
 
         /* go back to the correct frame                                    */
-        SWITCH_TO_OLD_LVARS( TLS(CodeLVars) );
+        SWITCH_TO_OLD_LVARS( STATE(CodeLVars) );
     }
 
     /* return value is ignored                                             */
@@ -779,18 +779,18 @@ void CodeFuncExprBegin (
     CHANGED_BAG( fexp );
 
     /* record where we are reading from */
-    setup_gapname(TLS(Input));
-    SET_FILENAME_BODY(body, TLS(Input)->gapname);
+    setup_gapname(STATE(Input));
+    SET_FILENAME_BODY(body, STATE(Input)->gapname);
     SET_STARTLINE_BODY(body, INTOBJ_INT(startLine));
-    /*    Pr("Coding begin at %s:%d ",(Int)(TLS(Input)->name),TLS(Input)->number);
+    /*    Pr("Coding begin at %s:%d ",(Int)(STATE(Input)->name),STATE(Input)->number);
           Pr(" Body id %d\n",(Int)(body),0L); */
-    TLS(OffsBody) = 0;
-    TLS(LoopNesting) = 0;
+    STATE(OffsBody) = 0;
+    STATE(LoopNesting) = 0;
 
     /* give it an environment                                              */
-    ENVI_FUNC( fexp ) = TLS(CurrLVars);
+    ENVI_FUNC( fexp ) = STATE(CurrLVars);
     CHANGED_BAG( fexp );
-    MakeHighVars(TLS(CurrLVars));
+    MakeHighVars(STATE(CurrLVars));
 
     /* switch to this function                                             */
     SWITCH_TO_NEW_LVARS( fexp, (narg >0 ? narg : -narg), nloc, old );
@@ -818,7 +818,7 @@ void CodeFuncExprEnd (
 
     /* get the function expression                                         */
     fexp = CURR_FUNC;
-    assert(!TLS(LoopNesting));
+    assert(!STATE(LoopNesting));
     
     /* get the body of the function                                        */
     /* push an additional return-void-statement if neccessary              */
@@ -857,9 +857,9 @@ void CodeFuncExprEnd (
     }
 
     /* make the body smaller                                               */
-    ResizeBag( BODY_FUNC(fexp), TLS(OffsBody)+NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
-    SET_ENDLINE_BODY(BODY_FUNC(fexp), INTOBJ_INT(TLS(Input)->number));
-    /*    Pr("  finished coding %d at line %d\n",(Int)(BODY_FUNC(fexp)), TLS(Input)->number); */
+    ResizeBag( BODY_FUNC(fexp), STATE(OffsBody)+NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
+    SET_ENDLINE_BODY(BODY_FUNC(fexp), INTOBJ_INT(STATE(Input)->number));
+    /*    Pr("  finished coding %d at line %d\n",(Int)(BODY_FUNC(fexp)), STATE(Input)->number); */
 
     /* switch back to the previous function                                */
     SWITCH_TO_OLD_LVARS( ENVI_FUNC(fexp) );
@@ -868,12 +868,12 @@ void CodeFuncExprEnd (
     PopLoopNesting();
     
     /* restore the remembered offset                                       */
-    TLS(OffsBody) = BRK_CALL_TO();
+    STATE(OffsBody) = BRK_CALL_TO();
     PopOffsBody();
 
     /* if this was inside another function definition, make the expression */
     /* and store it in the function expression list of the outer function  */
-    if ( TLS(CurrLVars) != TLS(CodeLVars) ) {
+    if ( STATE(CurrLVars) != STATE(CodeLVars) ) {
         fexs = FEXS_FUNC( CURR_FUNC );
         len = LEN_PLIST( fexs );
         GROW_PLIST(      fexs, len+1 );
@@ -885,9 +885,9 @@ void CodeFuncExprEnd (
         PushExpr( expr );
     }
 
-    /* otherwise, make the function and store it in 'TLS(CodeResult)'           */
+    /* otherwise, make the function and store it in 'STATE(CodeResult)'           */
     else {
-        TLS(CodeResult) = MakeFunction( fexp );
+        STATE(CodeResult) = MakeFunction( fexp );
     }
 
 }
@@ -1033,7 +1033,7 @@ void CodeForIn ( void )
 
 void CodeForBeginBody ( void )
 {
-  TLS(LoopNesting)++;
+  STATE(LoopNesting)++;
 }
 
 void CodeForEndBody (
@@ -1095,7 +1095,7 @@ void CodeForEndBody (
     PushStat( stat );
 
     /* decrement loop nesting count */
-    TLS(LoopNesting)--;
+    STATE(LoopNesting)--;
 }
 
 void CodeForEnd ( void )
@@ -1236,7 +1236,7 @@ void CodeWhileBegin ( void )
 
 void CodeWhileBeginBody ( void )
 {
-  TLS(LoopNesting)++;
+  STATE(LoopNesting)++;
 }
 
 void CodeWhileEndBody (
@@ -1274,7 +1274,7 @@ void CodeWhileEndBody (
     ADDR_STAT(stat)[0] = cond;
 
     /* decrmement loop nesting */
-    TLS(LoopNesting)--;
+    STATE(LoopNesting)--;
     
     /* push the while-statement                                            */
     PushStat( stat );
@@ -1314,7 +1314,7 @@ void CodeRepeatBegin ( void )
 
 void CodeRepeatBeginBody ( void )
 {
-  TLS(LoopNesting)++;
+  STATE(LoopNesting)++;
 }
 
 void CodeRepeatEndBody (
@@ -1322,7 +1322,7 @@ void CodeRepeatEndBody (
 {
     /* leave the number of statements in the body on the expression stack  */
     PushExpr( INTEXPR_INT(nr) );
-    TLS(LoopNesting)--;
+    STATE(LoopNesting)--;
 }
 
 void CodeRepeatEnd ( void )
@@ -1381,7 +1381,7 @@ void            CodeBreak ( void )
 {
     Stat                stat;           /* break-statement, result         */
 
-    if (!TLS(LoopNesting))
+    if (!STATE(LoopNesting))
       SyntaxError("'break' statement not enclosed in a loop");
     
     /* allocate the break-statement                                        */
@@ -1402,7 +1402,7 @@ void            CodeContinue ( void )
 {
     Stat                stat;           /* continue-statement, result         */
 
-    if (!TLS(LoopNesting))
+    if (!STATE(LoopNesting))
       SyntaxError("'continue' statement not enclosed in a loop");
 
     /* allocate the continue-statement                                        */
@@ -3450,8 +3450,8 @@ void LoadBody ( Obj body )
 
 void InitCoderTLS( void )
 {
-    TLS(StackStat) = NewBag( T_BODY, 64*sizeof(Stat) );
-    TLS(StackExpr) = NewBag( T_BODY, 64*sizeof(Expr) );
+    STATE(StackStat) = NewBag( T_BODY, 64*sizeof(Stat) );
+    STATE(StackExpr) = NewBag( T_BODY, 64*sizeof(Expr) );
 }
 
 void DestroyCoderTLS( void )
@@ -3481,8 +3481,8 @@ static Int InitKernel (
     InitGlobalBag( &FilenameCache, "FilenameCache" );
 
     /* allocate the statements and expressions stacks                      */
-    InitGlobalBag( &TLS(StackStat), "TLS(StackStat)" );
-    InitGlobalBag( &TLS(StackExpr), "TLS(StackExpr)" );
+    InitGlobalBag( &STATE(StackStat), "STATE(StackStat)" );
+    InitGlobalBag( &STATE(StackExpr), "STATE(StackExpr)" );
 
     /* some functions and globals needed for float conversion */
     InitCopyGVar( "EAGER_FLOAT_LITERAL_CACHE", &EAGER_FLOAT_LITERAL_CACHE);
@@ -3504,8 +3504,8 @@ static Int InitLibrary (
   UInt gv;
   Obj cache;
     /* allocate the statements and expressions stacks                      */
-    TLS(StackStat) = NewBag( T_BODY, 64*sizeof(Stat) );
-    TLS(StackExpr) = NewBag( T_BODY, 64*sizeof(Expr) );
+    STATE(StackStat) = NewBag( T_BODY, 64*sizeof(Stat) );
+    STATE(StackExpr) = NewBag( T_BODY, 64*sizeof(Expr) );
     FilenameCache = NewAtomicList(0);
 
     GVAR_SAVED_FLOAT_INDEX = GVarName("SavedFloatIndex");
@@ -3541,17 +3541,17 @@ static Int PreSave (
   UInt i;
 
   /* Can't save in mid-parsing */
-  if (TLS(CountExpr) || TLS(CountStat))
+  if (STATE(CountExpr) || STATE(CountStat))
     return 1;
 
   /* push the FP cache index out into a GAP Variable */
   AssGVar(GVAR_SAVED_FLOAT_INDEX, INTOBJ_INT(NextFloatExprNumber));
 
   /* clean any old data out of the statement and expression stacks */
-  for (i = 0; i < SIZE_BAG(TLS(StackStat))/sizeof(UInt); i++)
-    ADDR_OBJ(TLS(StackStat))[i] = (Obj)0;
-  for (i = 0; i < SIZE_BAG(TLS(StackExpr))/sizeof(UInt); i++)
-    ADDR_OBJ(TLS(StackExpr))[i] = (Obj)0;
+  for (i = 0; i < SIZE_BAG(STATE(StackStat))/sizeof(UInt); i++)
+    ADDR_OBJ(STATE(StackStat))[i] = (Obj)0;
+  for (i = 0; i < SIZE_BAG(STATE(StackExpr))/sizeof(UInt); i++)
+    ADDR_OBJ(STATE(StackExpr))[i] = (Obj)0;
   /* return success                                                      */
   return 0;
 }

--- a/hpcgap/src/code.c
+++ b/hpcgap/src/code.c
@@ -3448,13 +3448,13 @@ void LoadBody ( Obj body )
 *F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * *
 */
 
-void InitCoderTLS( void )
+void InitCoderState(GAPState * state)
 {
-    STATE(StackStat) = NewBag( T_BODY, 64*sizeof(Stat) );
-    STATE(StackExpr) = NewBag( T_BODY, 64*sizeof(Expr) );
+    state->StackStat = NewBag( T_BODY, 64*sizeof(Stat) );
+    state->StackExpr = NewBag( T_BODY, 64*sizeof(Expr) );
 }
 
-void DestroyCoderTLS( void )
+void DestroyCoderState(GAPState * state)
 {
 }
 

--- a/hpcgap/src/code.h
+++ b/hpcgap/src/code.h
@@ -243,7 +243,7 @@ Obj FILENAME_STAT(Stat stat);
 **  'ADDR_STAT' returns   the  absolute address of the    memory block of the
 **  statement <stat>.
 */
-#define ADDR_STAT(stat) ((Stat*)(((char*)TLS(PtrBody))+(stat)))
+#define ADDR_STAT(stat) ((Stat*)(((char*)STATE(PtrBody))+(stat)))
 
 
 /****************************************************************************

--- a/hpcgap/src/exprs.c
+++ b/hpcgap/src/exprs.c
@@ -73,8 +73,8 @@
 #endif
 #ifndef NO_LVAR_CHECKS
 #define OBJ_REFLVAR(expr)       \
-                        (*(Obj*)(((char*)TLS(PtrLVars))+(expr)+5) != 0 ? \
-                         *(Obj*)(((char*)TLS(PtrLVars))+(expr)+5) : \
+                        (*(Obj*)(((char*)STATE(PtrLVars))+(expr)+5) != 0 ? \
+                         *(Obj*)(((char*)STATE(PtrLVars))+(expr)+5) : \
                          ObjLVar( LVAR_REFLVAR( expr ) ) )
 #endif
 */
@@ -2148,7 +2148,7 @@ static Int InitLibrary (
 
 void InitExprTLS()
 {
-    TLS(CurrEvalExprFuncs) = EvalExprFuncs;
+    STATE(CurrEvalExprFuncs) = EvalExprFuncs;
 }
 
 void DestroyExprTLS()

--- a/hpcgap/src/exprs.c
+++ b/hpcgap/src/exprs.c
@@ -2146,12 +2146,12 @@ static Int InitLibrary (
     return 0;
 }
 
-void InitExprTLS()
+void InitExprState(GAPState * state)
 {
-    STATE(CurrEvalExprFuncs) = EvalExprFuncs;
+    state->CurrEvalExprFuncs = EvalExprFuncs;
 }
 
-void DestroyExprTLS()
+void DestroyExprState(GAPState * state)
 {
 }
 

--- a/hpcgap/src/funcs.c
+++ b/hpcgap/src/funcs.c
@@ -145,7 +145,7 @@ UInt            ExecProccall0args (
     else {
       CALL_0ARGS( func );
     }
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -173,7 +173,7 @@ UInt            ExecProccall1args (
       SET_BRK_CALL_TO( call );
       CALL_1ARGS( func, arg1 );
     } 
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -203,7 +203,7 @@ UInt            ExecProccall2args (
       SET_BRK_CALL_TO( call );
       CALL_2ARGS( func, arg1, arg2 );
     }
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -235,7 +235,7 @@ UInt            ExecProccall3args (
       SET_BRK_CALL_TO( call );
       CALL_3ARGS( func, arg1, arg2, arg3 );
     }
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -269,7 +269,7 @@ UInt            ExecProccall4args (
       SET_BRK_CALL_TO( call );
       CALL_4ARGS( func, arg1, arg2, arg3, arg4 );
     }
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -311,7 +311,7 @@ UInt            ExecProccall5args (
       SET_BRK_CALL_TO( call );
       CALL_5ARGS( func, arg1, arg2, arg3, arg4, arg5 );
     }
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -349,7 +349,7 @@ UInt            ExecProccall6args (
       SET_BRK_CALL_TO( call );
       CALL_6ARGS( func, arg1, arg2, arg3, arg4, arg5, arg6 );
     }
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -387,7 +387,7 @@ UInt            ExecProccallXargs (
       CALL_XARGS( func, args );
     }
 
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -453,7 +453,7 @@ Obj             EvalFunccall0args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_0ARGS( func );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -485,7 +485,7 @@ Obj             EvalFunccall1args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_1ARGS( func, arg1 );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -520,7 +520,7 @@ Obj             EvalFunccall2args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_2ARGS( func, arg1, arg2 );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -557,7 +557,7 @@ Obj             EvalFunccall3args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_3ARGS( func, arg1, arg2, arg3 );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -595,7 +595,7 @@ Obj             EvalFunccall4args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_4ARGS( func, arg1, arg2, arg3, arg4 );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -636,7 +636,7 @@ Obj             EvalFunccall5args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_5ARGS( func, arg1, arg2, arg3, arg4, arg5 );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -679,7 +679,7 @@ Obj             EvalFunccall6args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_6ARGS( func, arg1, arg2, arg3, arg4, arg5, arg6 );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -720,7 +720,7 @@ Obj             EvalFunccallXargs (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_XARGS( func, args );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -756,7 +756,7 @@ Obj             EvalFunccallXargs (
 **  'DoExecFunc<i>args' first switches  to a new  values bag.  Then it enters
 **  the arguments <arg1>, <arg2>, and so on in this new  values bag.  Then it
 **  executes  the function body.   After  that it  switches back  to  the old
-**  values bag.  Finally it returns the result from 'TLS(ReturnObjStat)'.
+**  values bag.  Finally it returns the result from 'STATE(ReturnObjStat)'.
 **
 **  Note that these functions are never called directly, they are only called
 **  through the function call mechanism.
@@ -775,13 +775,13 @@ void RecursionDepthTrap( void )
      * when quit-ting a higher level brk-loop to a lower level one.
      * Therefore we don't do anything if  RecursionDepth <= 0
     */
-    if (TLS(RecursionDepth) > 0) {
-        recursionDepth = TLS(RecursionDepth);
-        TLS(RecursionDepth) = 0;
+    if (STATE(RecursionDepth) > 0) {
+        recursionDepth = STATE(RecursionDepth);
+        STATE(RecursionDepth) = 0;
         ErrorReturnVoid( "recursion depth trap (%d)",
                          (Int)recursionDepth, 0L,
                          "you may 'return;'" );
-        TLS(RecursionDepth) = recursionDepth;
+        STATE(RecursionDepth) = recursionDepth;
     }
 }
      
@@ -792,7 +792,7 @@ Obj STEVES_TRACING;
             ProfileLineByLineIntoFunction(func);
 
 #define CHECK_RECURSION_AFTER \
-            TLS(RecursionDepth)--; \
+            STATE(RecursionDepth)--; \
             ProfileLineByLineOutFunction(func);
 
 #define REMEMBER_LOCKSTACK() \
@@ -833,8 +833,8 @@ Obj DoExecFunc0args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -873,8 +873,8 @@ Obj             DoExecFunc1args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -915,8 +915,8 @@ Obj             DoExecFunc2args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -959,8 +959,8 @@ Obj             DoExecFunc3args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1005,8 +1005,8 @@ Obj             DoExecFunc4args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1053,8 +1053,8 @@ Obj             DoExecFunc5args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1103,8 +1103,8 @@ Obj             DoExecFunc6args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1157,8 +1157,8 @@ Obj             DoExecFuncXargs (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1234,8 +1234,8 @@ Obj             DoExecFunc0argsL (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1279,8 +1279,8 @@ Obj             DoExecFunc1argsL (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1326,8 +1326,8 @@ Obj             DoExecFunc2argsL (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1377,8 +1377,8 @@ Obj             DoExecFunc3argsL (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1430,8 +1430,8 @@ Obj             DoExecFunc4argsL (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1486,8 +1486,8 @@ Obj             DoExecFunc5argsL (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1545,8 +1545,8 @@ Obj             DoExecFunc6argsL (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1602,8 +1602,8 @@ Obj             DoExecFuncXargsL (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1656,8 +1656,8 @@ Obj DoPartialUnWrapFunc(Obj func, Obj args) {
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }  
 }
@@ -1709,10 +1709,10 @@ Obj             MakeFunction (
     /* install the things an interpreted function needs                    */
     NLOC_FUNC( func ) = NLOC_FUNC( fexp );
     BODY_FUNC( func ) = BODY_FUNC( fexp );
-    ENVI_FUNC( func ) = TLS(CurrLVars);
-    /* the 'CHANGED_BAG(TLS(CurrLVars))' is needed because it is delayed        */
-    CHANGED_BAG( TLS(CurrLVars) );
-    MakeHighVars(TLS(CurrLVars));
+    ENVI_FUNC( func ) = STATE(CurrLVars);
+    /* the 'CHANGED_BAG(STATE(CurrLVars))' is needed because it is delayed        */
+    CHANGED_BAG( STATE(CurrLVars) );
+    MakeHighVars(STATE(CurrLVars));
     LCKS_FUNC( func ) = locks;
     FEXS_FUNC( func ) = FEXS_FUNC( fexp );
 
@@ -1854,12 +1854,12 @@ void            ExecBegin ( Obj frame )
     /* remember the old execution state                                    */
     execState = NewBag( T_PLIST, 4*sizeof(Obj) );
     ADDR_OBJ(execState)[0] = (Obj)3;
-    ADDR_OBJ(execState)[1] = TLS(ExecState);
-    ADDR_OBJ(execState)[2] = TLS(CurrLVars);
-    /* the 'CHANGED_BAG(TLS(CurrLVars))' is needed because it is delayed        */
-    CHANGED_BAG( TLS(CurrLVars) );
-    ADDR_OBJ(execState)[3] = INTOBJ_INT((Int)TLS(CurrStat));
-    TLS(ExecState) = execState;
+    ADDR_OBJ(execState)[1] = STATE(ExecState);
+    ADDR_OBJ(execState)[2] = STATE(CurrLVars);
+    /* the 'CHANGED_BAG(STATE(CurrLVars))' is needed because it is delayed        */
+    CHANGED_BAG( STATE(CurrLVars) );
+    ADDR_OBJ(execState)[3] = INTOBJ_INT((Int)STATE(CurrStat));
+    STATE(ExecState) = execState;
 
     /* set up new state                                                    */
     SWITCH_TO_OLD_LVARS( frame );
@@ -1873,14 +1873,14 @@ void            ExecEnd (
     if ( ! error ) {
 
         /* the state must be primal again                                  */
-        assert( TLS(CurrStat)  == 0 );
+        assert( STATE(CurrStat)  == 0 );
 
     }
 
     /* switch back to the old state                                    */
-    SET_BRK_CURR_STAT( (Stat)INT_INTOBJ((ADDR_OBJ(TLS(ExecState))[3]) ));
-    SWITCH_TO_OLD_LVARS( ADDR_OBJ(TLS(ExecState))[2] );
-    TLS(ExecState) = ADDR_OBJ(TLS(ExecState))[1];
+    SET_BRK_CURR_STAT( (Stat)INT_INTOBJ((ADDR_OBJ(STATE(ExecState))[3]) ));
+    SWITCH_TO_OLD_LVARS( ADDR_OBJ(STATE(ExecState))[2] );
+    STATE(ExecState) = ADDR_OBJ(STATE(ExecState))[1];
 }
 
 /****************************************************************************

--- a/hpcgap/src/funcs.h
+++ b/hpcgap/src/funcs.h
@@ -17,7 +17,7 @@
 #ifndef GAP_FUNCS_H
 #define GAP_FUNCS_H
 
-/* HACK: need to include this for TLS() below in CheckRecursionBefore */
+/* HACK: need to include this for STATE() below in CheckRecursionBefore */
 #include "src/hpc/tls.h"
 
 /****************************************************************************
@@ -34,7 +34,7 @@ extern  Obj             MakeFunction (
 /****************************************************************************
 **
 *F  ExecBegin( <frame> ) . . . . . . . . .begin an execution in context frame
-**  if in doubt, pass TLS(BottomLVars) as <frame>
+**  if in doubt, pass STATE(BottomLVars) as <frame>
 **
 *F  ExecEnd(<error>)  . . . . . . . . . . . . . . . . . . .  end an execution
 */
@@ -50,9 +50,9 @@ extern void RecursionDepthTrap( void );
 
 static inline void CheckRecursionBefore( void )
 {
-    TLS(RecursionDepth)++;
+    STATE(RecursionDepth)++;
     if ( RecursionTrapInterval &&
-         0 == (TLS(RecursionDepth) % RecursionTrapInterval) )
+         0 == (STATE(RecursionDepth) % RecursionTrapInterval) )
       RecursionDepthTrap();
 }
 

--- a/hpcgap/src/gap.c
+++ b/hpcgap/src/gap.c
@@ -168,7 +168,7 @@ void ViewObjHandler ( Obj obj )
   func = ValAutoGVar(ViewObjGVar);
 
   /* if non-zero use this function, otherwise use `PrintObj'             */
-  memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+  memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
   TRY_READ {
     if ( func != 0 && TNUM_OBJ(func) == T_FUNCTION ) {
       ViewObj(obj);
@@ -178,7 +178,7 @@ void ViewObjHandler ( Obj obj )
     }
     Pr( "\n", 0L, 0L );
   }
-  memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+  memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
 }
 
 
@@ -232,11 +232,11 @@ Obj Shell ( Obj context,
   Obj oldShellContext;
   Obj oldBaseShellContext;
   Int oldRecursionDepth;
-  oldShellContext = TLS(ShellContext);
-  TLS(ShellContext) = context;
-  oldBaseShellContext = TLS(BaseShellContext);
-  TLS(BaseShellContext) = context;
-  oldRecursionDepth = TLS(RecursionDepth);
+  oldShellContext = STATE(ShellContext);
+  STATE(ShellContext) = context;
+  oldBaseShellContext = STATE(BaseShellContext);
+  STATE(BaseShellContext) = context;
+  oldRecursionDepth = STATE(RecursionDepth);
   
   /* read-eval-print loop                                                */
   if (!OpenOutput(outFile))
@@ -248,10 +248,10 @@ Obj Shell ( Obj context,
       ErrorQuit("SHELL: can't open infile %s",(Int)inFile,0);
     }
   
-  oldPrintDepth = TLS(PrintObjDepth);
-  TLS(PrintObjDepth) = 0;
-  oldindent = TLS(Output)->indent;
-  TLS(Output)->indent = 0;
+  oldPrintDepth = STATE(PrintObjDepth);
+  STATE(PrintObjDepth) = 0;
+  oldindent = STATE(Output)->indent;
+  STATE(Output)->indent = 0;
 
   while ( 1 ) {
 
@@ -260,11 +260,11 @@ Obj Shell ( Obj context,
       time = SyTime();
 
     /* read and evaluate one command                                   */
-    TLS(Prompt) = prompt;
+    STATE(Prompt) = prompt;
     ClearError();
-    TLS(PrintObjDepth) = 0;
-    TLS(Output)->indent = 0;
-    TLS(RecursionDepth) = 0;
+    STATE(PrintObjDepth) = 0;
+    STATE(Output)->indent = 0;
+    STATE(RecursionDepth) = 0;
       
     /* here is a hook: */
     if (preCommandHook) {
@@ -276,19 +276,19 @@ Obj Shell ( Obj context,
         {
           Call0ArgsInNewReader(preCommandHook);
           /* Recover from a potential break loop: */
-          TLS(Prompt) = prompt;
+          STATE(Prompt) = prompt;
           ClearError();
         }
     }
 
     /* now  read and evaluate and view one command  */
-    status = ReadEvalCommand(TLS(ShellContext), &dualSemicolon);
-    if (TLS(UserHasQUIT))
+    status = ReadEvalCommand(STATE(ShellContext), &dualSemicolon);
+    if (STATE(UserHasQUIT))
       break;
 
 
     /* handle ordinary command                                         */
-    if ( status == STATUS_END && TLS(ReadEvalResult) != 0 ) {
+    if ( status == STATUS_END && STATE(ReadEvalResult) != 0 ) {
 
       /* remember the value in 'last'    */
       if (lastDepth >= 3)
@@ -296,11 +296,11 @@ Obj Shell ( Obj context,
       if (lastDepth >= 2)
         AssGVar( Last2, ValGVarTL( Last  ) );
       if (lastDepth >= 1)
-        AssGVar( Last,  TLS(ReadEvalResult)   );
+        AssGVar( Last,  STATE(ReadEvalResult)   );
 
       /* print the result                                            */
       if ( ! dualSemicolon ) {
-        ViewObjHandler( TLS(ReadEvalResult) );
+        ViewObjHandler( STATE(ReadEvalResult) );
       }
             
     }
@@ -322,14 +322,14 @@ Obj Shell ( Obj context,
     
     /* handle quit command or <end-of-file>                            */
     else if ( status & (STATUS_EOF | STATUS_QUIT ) ) {
-      TLS(RecursionDepth) = 0;
-      TLS(UserHasQuit) = 1;
+      STATE(RecursionDepth) = 0;
+      STATE(UserHasQuit) = 1;
       break;
     }
         
     /* handle QUIT */
     else if (status & (STATUS_QQUIT)) {
-      TLS(UserHasQUIT) = 1;
+      STATE(UserHasQUIT) = 1;
       break;
     }
         
@@ -337,26 +337,26 @@ Obj Shell ( Obj context,
     if (setTime)
       AssGVar( Time, INTOBJ_INT( SyTime() - time ) );
 
-    if (TLS(UserHasQuit))
+    if (STATE(UserHasQuit))
       {
         FlushRestOfInputLine();
-        TLS(UserHasQuit) = 0;        /* quit has done its job if we are here */
+        STATE(UserHasQuit) = 0;        /* quit has done its job if we are here */
       }
 
   }
   
-  TLS(PrintObjDepth) = oldPrintDepth;
-  TLS(Output)->indent = oldindent;
+  STATE(PrintObjDepth) = oldPrintDepth;
+  STATE(Output)->indent = oldindent;
   CloseInput();
   CloseOutput();
-  TLS(BaseShellContext) = oldBaseShellContext;
-  TLS(ShellContext) = oldShellContext;
-  TLS(RecursionDepth) = oldRecursionDepth;
-  if (TLS(UserHasQUIT))
+  STATE(BaseShellContext) = oldBaseShellContext;
+  STATE(ShellContext) = oldShellContext;
+  STATE(RecursionDepth) = oldRecursionDepth;
+  if (STATE(UserHasQUIT))
     {
       if (catchQUIT)
         {
-          TLS(UserHasQUIT) = 0;
+          STATE(UserHasQUIT) = 0;
           MakeReadWriteGVar(QUITTINGGVar);
           AssGVar(QUITTINGGVar, True);
           MakeReadOnlyGVar(QUITTINGGVar);
@@ -380,7 +380,7 @@ Obj Shell ( Obj context,
     {
       res = NEW_PLIST(T_PLIST_HOM,1);
       SET_LEN_PLIST(res,1);
-      SET_ELM_PLIST(res,1,TLS(ReadEvalResult));
+      SET_ELM_PLIST(res,1,STATE(ReadEvalResult));
       return res;
     }
   assert(0); 
@@ -478,7 +478,7 @@ Obj FuncSHELL (Obj self, Obj args)
   res =  Shell(context, canReturnVoid, canReturnObj, lastDepth, setTime, promptBuffer, preCommandHook, catchQUIT,
                CSTR_STRING(infile), CSTR_STRING(outfile));
 
-  TLS(UserHasQuit) = 0;
+  STATE(UserHasQuit) = 0;
   return res;
 }
 
@@ -513,7 +513,7 @@ int main (
 
   /* initialize everything and read init.g which runs the GAP session */
   InitializeGap( &argc, argv, environ );
-  if (!TLS(UserHasQUIT)) {         /* maybe the user QUIT from the initial
+  if (!STATE(UserHasQUIT)) {         /* maybe the user QUIT from the initial
                                    read of init.g  somehow*/
     /* maybe compile in which case init.g got skipped */
     if ( SyCompilePlease ) {
@@ -941,23 +941,23 @@ void DownEnvInner( Int depth )
   /* if we are asked to go up ... */
   if ( depth < 0 ) {
     /* ... we determine which level we are supposed to end up on ... */
-    depth = TLS(ErrorLLevel) + depth;
+    depth = STATE(ErrorLLevel) + depth;
     if (depth < 0) {
       depth = 0;
     }
     /* ... then go back to the top, and later go down to the appropriate level. */
-    TLS(ErrorLVars) = TLS(ErrorLVars0);
-    TLS(ErrorLLevel) = 0;
-    TLS(ShellContext) = TLS(BaseShellContext);
+    STATE(ErrorLVars) = STATE(ErrorLVars0);
+    STATE(ErrorLLevel) = 0;
+    STATE(ShellContext) = STATE(BaseShellContext);
   }
   
   /* now go down */
   while ( 0 < depth
-          && TLS(ErrorLVars) != TLS(BottomLVars)
-          && PARENT_LVARS(TLS(ErrorLVars)) != TLS(BottomLVars) ) {
-    TLS(ErrorLVars) = PARENT_LVARS(TLS(ErrorLVars));
-    TLS(ErrorLLevel)++;
-    TLS(ShellContext) = PARENT_LVARS(TLS(ShellContext));
+          && STATE(ErrorLVars) != STATE(BottomLVars)
+          && PARENT_LVARS(STATE(ErrorLVars)) != STATE(BottomLVars) ) {
+    STATE(ErrorLVars) = PARENT_LVARS(STATE(ErrorLVars));
+    STATE(ErrorLLevel)++;
+    STATE(ShellContext) = PARENT_LVARS(STATE(ShellContext));
     depth--;
   }
 }
@@ -978,7 +978,7 @@ Obj FuncDownEnv (
     ErrorQuit( "usage: DownEnv( [ <depth> ] )", 0L, 0L );
     return 0;
   }
-  if ( TLS(ErrorLVars) == TLS(BottomLVars) ) {
+  if ( STATE(ErrorLVars) == STATE(BottomLVars) ) {
     Pr( "not in any function\n", 0L, 0L );
     return 0;
   }
@@ -1002,7 +1002,7 @@ Obj FuncUpEnv (
     ErrorQuit( "usage: UpEnv( [ <depth> ] )", 0L, 0L );
     return 0;
   }
-  if ( TLS(ErrorLVars) == TLS(BottomLVars) ) {
+  if ( STATE(ErrorLVars) == STATE(BottomLVars) ) {
     Pr( "not in any function\n", 0L, 0L );
     return 0;
   }
@@ -1013,13 +1013,13 @@ Obj FuncUpEnv (
 
 Obj FuncExecutingStatementLocation(Obj self, Obj context)
 {
-  Obj currLVars = TLS(CurrLVars);
+  Obj currLVars = STATE(CurrLVars);
   Expr call;
   Int line;
   Obj filename;
   Obj retlist;
   retlist = Fail;
-  if (context == TLS(BottomLVars))
+  if (context == STATE(BottomLVars))
     return Fail;
   SWITCH_TO_OLD_LVARS(context);
   call = BRK_CALL_TO();
@@ -1046,9 +1046,9 @@ Obj FuncExecutingStatementLocation(Obj self, Obj context)
 
 Obj FuncPrintExecutingStatement(Obj self, Obj context)
 {
-  Obj currLVars = TLS(CurrLVars);
+  Obj currLVars = STATE(CurrLVars);
   Expr call;
-  if (context == TLS(BottomLVars))
+  if (context == STATE(BottomLVars))
     return (Obj) 0;
   SWITCH_TO_OLD_LVARS(context);
   call = BRK_CALL_TO();
@@ -1102,25 +1102,25 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
       PLAIN_LIST(args);
     }
 
-    memcpy((void *)&readJmpError, (void *)&TLS(ReadJmpError), sizeof(syJmp_buf));
-    currLVars = TLS(CurrLVars);
-    currStat = TLS(CurrStat);
-    recursionDepth = TLS(RecursionDepth);
+    memcpy((void *)&readJmpError, (void *)&STATE(ReadJmpError), sizeof(syJmp_buf));
+    currLVars = STATE(CurrLVars);
+    currStat = STATE(CurrStat);
+    recursionDepth = STATE(RecursionDepth);
     tilde = VAL_GVAR(Tilde);
     res = NEW_PLIST(T_PLIST_DENSE+IMMUTABLE,2);
     lockSP = RegionLockSP();
     savedRegion = TLS(currentRegion);
-    if (sySetjmp(TLS(ReadJmpError))) {
+    if (sySetjmp(STATE(ReadJmpError))) {
       SET_LEN_PLIST(res,2);
       SET_ELM_PLIST(res,1,False);
-      SET_ELM_PLIST(res,2,TLS(ThrownObject));
+      SET_ELM_PLIST(res,2,STATE(ThrownObject));
       CHANGED_BAG(res);
-      TLS(ThrownObject) = 0;
-      TLS(CurrLVars) = currLVars;
-      TLS(PtrLVars) = PTR_BAG(TLS(CurrLVars));
-      TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
-      TLS(CurrStat) = currStat;
-      TLS(RecursionDepth) = recursionDepth;
+      STATE(ThrownObject) = 0;
+      STATE(CurrLVars) = currLVars;
+      STATE(PtrLVars) = PTR_BAG(STATE(CurrLVars));
+      STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+      STATE(CurrStat) = currStat;
+      STATE(RecursionDepth) = recursionDepth;
       PopRegionLocks(lockSP);
       TLS(currentRegion) = savedRegion;
       if (TLS(CurrentHashLock))
@@ -1138,14 +1138,14 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
       } else
         SET_LEN_PLIST(res,1);
     }
-    memcpy((void *)&TLS(ReadJmpError), (void *)&readJmpError, sizeof(syJmp_buf));
+    memcpy((void *)&STATE(ReadJmpError), (void *)&readJmpError, sizeof(syJmp_buf));
     return res;
 }
 
 Obj FuncJUMP_TO_CATCH( Obj self, Obj payload)
 {
-  TLS(ThrownObject) = payload;
-  syLongjmp(TLS(ReadJmpError), 1);
+  STATE(ThrownObject) = payload;
+  syLongjmp(STATE(ReadJmpError), 1);
   return 0;
 }
 
@@ -1156,9 +1156,9 @@ UInt SystemErrorCode;
 
 Obj FuncSetUserHasQuit( Obj Self, Obj value)
 {
-  TLS(UserHasQuit) = INT_INTOBJ(value);
-  if (TLS(UserHasQuit))
-    TLS(RecursionDepth) = 0;
+  STATE(UserHasQuit) = INT_INTOBJ(value);
+  if (STATE(UserHasQuit))
+    STATE(RecursionDepth) = 0;
   return 0;
 }
 
@@ -1208,16 +1208,16 @@ Obj FuncCALL_WITH_TIMEOUT( Obj self, Obj seconds, Obj microseconds, Obj func, Ob
          " There is already a timeout running", 0, 0);
   if (NumAlarmJumpBuffers >= MAX_TIMEOUT_NESTING_DEPTH-1)
     ErrorMayQuit("Nesting depth of timeouts via break loops limited to %i", MAX_TIMEOUT_NESTING_DEPTH, 0L);
-  currLVars = TLS(CurrLVars);
-  currStat = TLS(CurrStat);
-  recursionDepth = TLS(RecursionDepth);
+  currLVars = STATE(CurrLVars);
+  currStat = STATE(CurrStat);
+  recursionDepth = STATE(RecursionDepth);
   if (sySetjmp(AlarmJumpBuffers[NumAlarmJumpBuffers++])) {
     /* Timeout happened */
-    TLS(CurrLVars) = currLVars;
-    TLS(PtrLVars) = PTR_BAG(TLS(CurrLVars));
-    TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
-    TLS(CurrStat) = currStat;
-    TLS(RecursionDepth) = recursionDepth;
+    STATE(CurrLVars) = currLVars;
+    STATE(PtrLVars) = PTR_BAG(STATE(CurrLVars));
+    STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+    STATE(CurrStat) = currStat;
+    STATE(RecursionDepth) = recursionDepth;
     res = Fail;
   } else {
     SyInstallAlarm( INT_INTOBJ(seconds), 1000*INT_INTOBJ(microseconds));
@@ -1314,7 +1314,7 @@ Obj CallErrorInner (
   Region *savedRegion = TLS(currentRegion);
   TLS(currentRegion) = TLS(threadRegion);
   EarlyMsg = ErrorMessageToGAPString(msg, arg1, arg2);
-  AssPRec(r, RNamName("context"), TLS(CurrLVars));
+  AssPRec(r, RNamName("context"), STATE(CurrLVars));
   AssPRec(r, RNamName("justQuit"), justQuit? True : False);
   AssPRec(r, RNamName("mayReturnObj"), mayReturnObj? True : False);
   AssPRec(r, RNamName("mayReturnVoid"), mayReturnVoid? True : False);
@@ -1323,9 +1323,9 @@ Obj CallErrorInner (
   l = NEW_PLIST(T_PLIST_HOM+IMMUTABLE, 1);
   SET_ELM_PLIST(l,1,EarlyMsg);
   SET_LEN_PLIST(l,1);
-  SET_BRK_CALL_TO(TLS(CurrStat));
+  SET_BRK_CALL_TO(STATE(CurrStat));
   Obj res = CALL_2ARGS(ErrorInner,r,l);
-  TLS(currentRegion) = savedRegion;
+  
   return res;
 }
 
@@ -1627,7 +1627,7 @@ Obj FuncLOAD_DYN (
 
     /* Start a new executor to run the outer function of the module
        in global context */
-    ExecBegin( TLS(BottomLVars) );
+    ExecBegin( STATE(BottomLVars) );
     res = res || (info->initLibrary)(info);
     ExecEnd(res ? STATUS_ERROR : STATUS_END);
     if ( res ) {
@@ -1706,7 +1706,7 @@ Obj FuncLOAD_STAT (
     UpdateCopyFopyInfo();
     /* Start a new executor to run the outer function of the module
        in global context */
-    ExecBegin( TLS(BottomLVars) );
+    ExecBegin( STATE(BottomLVars) );
     res = res || (info->initLibrary)(info);
     ExecEnd(res ? STATUS_ERROR : STATUS_END);
     if ( res ) {
@@ -2653,7 +2653,7 @@ Obj FuncQUIT_GAP( Obj self, Obj args )
     ErrorQuit( "usage: QUIT_GAP( [ <return value> ] )", 0L, 0L );
     return 0;
   }
-  TLS(UserHasQUIT) = 1;
+  STATE(UserHasQUIT) = 1;
   ReadEvalError();
   return (Obj)0; 
 }
@@ -2839,23 +2839,23 @@ void ThreadedInterpreter(void *funcargs) {
   int i;
 
   /* intialize everything and begin an interpreter                       */
-  TLS(StackNams)   = NEW_PLIST( T_PLIST, 16 );
-  TLS(CountNams)   = 0;
-  TLS(ReadTop)     = 0;
-  TLS(ReadTilde)   = 0;
-  TLS(CurrLHSGVar) = 0;
-  TLS(IntrCoding) = 0;
-  TLS(IntrIgnoring) = 0;
-  TLS(NrError) = 0;
-  TLS(ThrownObject) = 0;
-  TLS(BottomLVars) = NewBag( T_HVARS, 3*sizeof(Obj) );
+  STATE(StackNams)   = NEW_PLIST( T_PLIST, 16 );
+  STATE(CountNams)   = 0;
+  STATE(ReadTop)     = 0;
+  STATE(ReadTilde)   = 0;
+  STATE(CurrLHSGVar) = 0;
+  STATE(IntrCoding) = 0;
+  STATE(IntrIgnoring) = 0;
+  STATE(NrError) = 0;
+  STATE(ThrownObject) = 0;
+  STATE(BottomLVars) = NewBag( T_HVARS, 3*sizeof(Obj) );
   tmp = NewFunctionC( "bottom", 0, "", 0 );
-  PTR_BAG(TLS(BottomLVars))[0] = tmp;
+  PTR_BAG(STATE(BottomLVars))[0] = tmp;
   tmp = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
-  BODY_FUNC( PTR_BAG(TLS(BottomLVars))[0] ) = tmp;
-  TLS(CurrLVars) = TLS(BottomLVars);
+  BODY_FUNC( PTR_BAG(STATE(BottomLVars))[0] ) = tmp;
+  STATE(CurrLVars) = STATE(BottomLVars);
 
-  IntrBegin( TLS(BottomLVars) );
+  IntrBegin( STATE(BottomLVars) );
   tmp = KEPTALIVE(funcargs);
   StopKeepAlive(funcargs);
   func = ELM_PLIST(tmp, 1);
@@ -2868,7 +2868,7 @@ void ThreadedInterpreter(void *funcargs) {
 
   TRY_READ {
     Obj init, exit;
-    if (sySetjmp(TLS(threadExit)))
+    if (sySetjmp(STATE(threadExit)))
       return;
     init = GVarOptFunction(&GVarTHREAD_INIT);
     if (init) CALL_0ARGS(init);
@@ -3370,17 +3370,17 @@ void InitializeGap (
               0, SyAbortBags );
               InitMsgsFuncBags( SyMsgsBags ); 
 
-    TLS(StackNams)    = NEW_PLIST( T_PLIST, 16 );
-    TLS(CountNams)    = 0;
-    TLS(ReadTop)      = 0;
-    TLS(ReadTilde)    = 0;
-    TLS(CurrLHSGVar)  = 0;
-    TLS(IntrCoding)   = 0;
-    TLS(IntrIgnoring) = 0;
-    TLS(NrError)      = 0;
-    TLS(ThrownObject) = 0;
-    TLS(UserHasQUIT) = 0;
-    TLS(UserHasQuit) = 0;
+    STATE(StackNams)    = NEW_PLIST( T_PLIST, 16 );
+    STATE(CountNams)    = 0;
+    STATE(ReadTop)      = 0;
+    STATE(ReadTilde)    = 0;
+    STATE(CurrLHSGVar)  = 0;
+    STATE(IntrCoding)   = 0;
+    STATE(IntrIgnoring) = 0;
+    STATE(NrError)      = 0;
+    STATE(ThrownObject) = 0;
+    STATE(UserHasQUIT) = 0;
+    STATE(UserHasQuit) = 0;
 
     NrImportedGVars = 0;
     NrImportedFuncs = 0;

--- a/hpcgap/src/gvars.c
+++ b/hpcgap/src/gvars.c
@@ -453,13 +453,13 @@ Obj NameGVarObj ( UInt gvar )
 
 Obj FuncSET_NAMESPACE(Obj self, Obj str)
 {
-    TLS(CurrNamespace) = str;
+    STATE(CurrNamespace) = str;
     return 0;
 }
 
 Obj FuncGET_NAMESPACE(Obj self)
 {
-    return TLS(CurrNamespace);
+    return STATE(CurrNamespace);
 }
 
 /****************************************************************************
@@ -484,7 +484,7 @@ UInt GVarName (
     Int                 len;            /* length of name                  */
 
     /* First see whether it could be namespace-local: */
-    cns = TLS(CurrNamespace) ? CSTR_STRING(TLS(CurrNamespace)) : "";
+    cns = STATE(CurrNamespace) ? CSTR_STRING(STATE(CurrNamespace)) : "";
     if (*cns) {   /* only if a namespace is set */
         len = strlen(name);
         if (name[len-1] == NSCHAR) {
@@ -1530,8 +1530,8 @@ static Int InitLibrary (
     SET_LEN_PLIST( TableGVars, SizeGVars );
 
     /* Create the current namespace: */
-    TLS(CurrNamespace) = NEW_STRING(0);
-    SET_LEN_STRING(TLS(CurrNamespace),0);
+    STATE(CurrNamespace) = NEW_STRING(0);
+    SET_LEN_STRING(STATE(CurrNamespace),0);
     
     /* fix C vars                                                          */
     PostRestore( module );

--- a/hpcgap/src/intrprtr.c
+++ b/hpcgap/src/intrprtr.c
@@ -153,16 +153,16 @@ void            PushObj (
     Obj                 val )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( TLS(StackObj) != 0 );
-    assert( 0 <= TLS(CountObj) && TLS(CountObj) == LEN_PLIST(TLS(StackObj)) );
+    assert( STATE(StackObj) != 0 );
+    assert( 0 <= STATE(CountObj) && STATE(CountObj) == LEN_PLIST(STATE(StackObj)) );
     assert( val != 0 );
 
     /* count up and put the value onto the stack                           */
-    TLS(CountObj)++;
-    GROW_PLIST(    TLS(StackObj), TLS(CountObj) );
-    SET_LEN_PLIST( TLS(StackObj), TLS(CountObj) );
-    SET_ELM_PLIST( TLS(StackObj), TLS(CountObj), val );
-    CHANGED_BAG(   TLS(StackObj) );
+    STATE(CountObj)++;
+    GROW_PLIST(    STATE(StackObj), STATE(CountObj) );
+    SET_LEN_PLIST( STATE(StackObj), STATE(CountObj) );
+    SET_ELM_PLIST( STATE(StackObj), STATE(CountObj), val );
+    CHANGED_BAG(   STATE(StackObj) );
 }
 
 /* Special marker value to denote that a function returned no value, so we
@@ -177,27 +177,27 @@ Obj VoidReturnMarker;
 void            PushFunctionVoidReturn ( void )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( TLS(StackObj) != 0 );
-    assert( 0 <= TLS(CountObj) && TLS(CountObj) == LEN_PLIST(TLS(StackObj)) );
+    assert( STATE(StackObj) != 0 );
+    assert( 0 <= STATE(CountObj) && STATE(CountObj) == LEN_PLIST(STATE(StackObj)) );
 
     /* count up and put the void value onto the stack                      */
-    TLS(CountObj)++;
-    GROW_PLIST(    TLS(StackObj), TLS(CountObj) );
-    SET_LEN_PLIST( TLS(StackObj), TLS(CountObj) );
-    SET_ELM_PLIST( TLS(StackObj), TLS(CountObj), (Obj)&VoidReturnMarker );
+    STATE(CountObj)++;
+    GROW_PLIST(    STATE(StackObj), STATE(CountObj) );
+    SET_LEN_PLIST( STATE(StackObj), STATE(CountObj) );
+    SET_ELM_PLIST( STATE(StackObj), STATE(CountObj), (Obj)&VoidReturnMarker );
 }
 
 void            PushVoidObj ( void )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( TLS(StackObj) != 0 );
-    assert( 0 <= TLS(CountObj) && TLS(CountObj) == LEN_PLIST(TLS(StackObj)) );
+    assert( STATE(StackObj) != 0 );
+    assert( 0 <= STATE(CountObj) && STATE(CountObj) == LEN_PLIST(STATE(StackObj)) );
 
     /* count up and put the void value onto the stack                      */
-    TLS(CountObj)++;
-    GROW_PLIST(    TLS(StackObj), TLS(CountObj) );
-    SET_LEN_PLIST( TLS(StackObj), TLS(CountObj) );
-    SET_ELM_PLIST( TLS(StackObj), TLS(CountObj), (Obj)0 );
+    STATE(CountObj)++;
+    GROW_PLIST(    STATE(StackObj), STATE(CountObj) );
+    SET_LEN_PLIST( STATE(StackObj), STATE(CountObj) );
+    SET_ELM_PLIST( STATE(StackObj), STATE(CountObj), (Obj)0 );
 }
 
 Obj             PopObj ( void )
@@ -205,14 +205,14 @@ Obj             PopObj ( void )
     Obj                 val;
 
     /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( TLS(StackObj) != 0 );
-    assert( 1 <= TLS(CountObj) && TLS(CountObj) == LEN_LIST(TLS(StackObj)) );
+    assert( STATE(StackObj) != 0 );
+    assert( 1 <= STATE(CountObj) && STATE(CountObj) == LEN_LIST(STATE(StackObj)) );
 
     /* get the top element from the stack and count down                   */
-    val = ELM_PLIST( TLS(StackObj), TLS(CountObj) );
-    SET_ELM_PLIST( TLS(StackObj), TLS(CountObj), 0 );
-    SET_LEN_PLIST( TLS(StackObj), TLS(CountObj)-1  );
-    TLS(CountObj)--;
+    val = ELM_PLIST( STATE(StackObj), STATE(CountObj) );
+    SET_ELM_PLIST( STATE(StackObj), STATE(CountObj), 0 );
+    SET_LEN_PLIST( STATE(StackObj), STATE(CountObj)-1  );
+    STATE(CountObj)--;
 
     if(val == (Obj)&VoidReturnMarker) {
         ErrorQuit(
@@ -229,14 +229,14 @@ Obj             PopVoidObj ( void )
     Obj                 val;
 
     /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( TLS(StackObj) != 0 );
-    assert( 1 <= TLS(CountObj) && TLS(CountObj) == LEN_LIST(TLS(StackObj)) );
+    assert( STATE(StackObj) != 0 );
+    assert( 1 <= STATE(CountObj) && STATE(CountObj) == LEN_LIST(STATE(StackObj)) );
 
     /* get the top element from the stack and count down                   */
-    val = ELM_PLIST( TLS(StackObj), TLS(CountObj) );
-    SET_ELM_PLIST( TLS(StackObj), TLS(CountObj), 0 );
-    SET_LEN_PLIST( TLS(StackObj), TLS(CountObj)-1  );
-    TLS(CountObj)--;
+    val = ELM_PLIST( STATE(StackObj), STATE(CountObj) );
+    SET_ELM_PLIST( STATE(StackObj), STATE(CountObj), 0 );
+    SET_LEN_PLIST( STATE(StackObj), STATE(CountObj)-1  );
+    STATE(CountObj)--;
 
     /* Treat a function which returned no value the same as 'void'         */
     if(val == (Obj)&VoidReturnMarker) {
@@ -263,7 +263,7 @@ Obj             PopVoidObj ( void )
 **
 **  If 'IntrEnd' returns  0, then no  return-statement or quit-statement  was
 **  interpreted.  If  'IntrEnd' returns 1,  then a return-value-statement was
-**  interpreted and in this case the  return value is stored in 'TLS(IntrResult)'.
+**  interpreted and in this case the  return value is stored in 'STATE(IntrResult)'.
 **  If  'IntrEnd' returns 2, then a  return-void-statement  was  interpreted.
 **  If 'IntrEnd' returns 8, then a quit-statement was interpreted.
 */
@@ -276,22 +276,22 @@ void IntrBegin ( Obj frame )
        place from which we might call SaveWorkspace */
     intrState = NewBag( T_PLIST, 4*sizeof(Obj) );
     ADDR_OBJ(intrState)[0] = (Obj)3;
-    ADDR_OBJ(intrState)[1] = TLS(IntrState);
-    ADDR_OBJ(intrState)[2] = TLS(StackObj);
-    ADDR_OBJ(intrState)[3] = INTOBJ_INT(TLS(CountObj));
-    TLS(IntrState) = intrState;
+    ADDR_OBJ(intrState)[1] = STATE(IntrState);
+    ADDR_OBJ(intrState)[2] = STATE(StackObj);
+    ADDR_OBJ(intrState)[3] = INTOBJ_INT(STATE(CountObj));
+    STATE(IntrState) = intrState;
 
     /* allocate a new values stack                                         */
-    TLS(StackObj) = NEW_PLIST( T_PLIST, 64 );
-    SET_LEN_PLIST( TLS(StackObj), 0 );
-    TLS(CountObj) = 0;
+    STATE(StackObj) = NEW_PLIST( T_PLIST, 64 );
+    SET_LEN_PLIST( STATE(StackObj), 0 );
+    STATE(CountObj) = 0;
 
     /* must be in immediate (non-ignoring, non-coding) mode                */
-    assert( TLS(IntrIgnoring) == 0 );
-    assert( TLS(IntrCoding)   == 0 );
+    assert( STATE(IntrIgnoring) == 0 );
+    assert( STATE(IntrCoding)   == 0 );
 
     /* no return-statement was yet interpreted                             */
-    TLS(IntrReturning) = 0;
+    STATE(IntrReturning) = 0;
 
     /* start an execution environment                                      */
     ExecBegin(frame);
@@ -309,21 +309,21 @@ ExecStatus IntrEnd (
         ExecEnd( 0UL );
 
         /* remember whether the interpreter interpreted a return-statement */
-        intrReturning = TLS(IntrReturning);
-        TLS(IntrReturning) = 0;
+        intrReturning = STATE(IntrReturning);
+        STATE(IntrReturning) = 0;
 
         /* must be back in immediate (non-ignoring, non-coding) mode       */
-        assert( TLS(IntrIgnoring) == 0 );
-        assert( TLS(IntrCoding)   == 0 );
+        assert( STATE(IntrIgnoring) == 0 );
+        assert( STATE(IntrCoding)   == 0 );
 
         /* and the stack must contain the result value (which may be void) */
-        assert( TLS(CountObj) == 1 );
-        TLS(IntrResult) = PopVoidObj();
+        assert( STATE(CountObj) == 1 );
+        STATE(IntrResult) = PopVoidObj();
 
         /* switch back to the old state                                    */
-        TLS(CountObj)  = INT_INTOBJ( ADDR_OBJ(TLS(IntrState))[3] );
-        TLS(StackObj)  = ADDR_OBJ(TLS(IntrState))[2];
-        TLS(IntrState) = ADDR_OBJ(TLS(IntrState))[1];
+        STATE(CountObj)  = INT_INTOBJ( ADDR_OBJ(STATE(IntrState))[3] );
+        STATE(StackObj)  = ADDR_OBJ(STATE(IntrState))[2];
+        STATE(IntrState) = ADDR_OBJ(STATE(IntrState))[1];
 
     }
 
@@ -334,23 +334,23 @@ ExecStatus IntrEnd (
         ExecEnd( 1UL );
 
         /* clean up the coder too                                          */
-        if ( TLS(IntrCoding) > 0 ) { CodeEnd( 1UL ); }
+        if ( STATE(IntrCoding) > 0 ) { CodeEnd( 1UL ); }
 
         /* remember that we had an error                                   */
         intrReturning = STATUS_ERROR;
-        TLS(IntrReturning) = 0;
+        STATE(IntrReturning) = 0;
 
         /* must be back in immediate (non-ignoring, non-coding) mode       */
-        TLS(IntrIgnoring) = 0;
-        TLS(IntrCoding)   = 0;
+        STATE(IntrIgnoring) = 0;
+        STATE(IntrCoding)   = 0;
 
         /* dummy result value (probably ignored)                           */
-        TLS(IntrResult) = (Obj)0;
+        STATE(IntrResult) = (Obj)0;
 
         /* switch back to the old state                                    */
-        TLS(CountObj)  = INT_INTOBJ( ADDR_OBJ(TLS(IntrState))[3] );
-        TLS(StackObj)  = ADDR_OBJ(TLS(IntrState))[2];
-        TLS(IntrState) = ADDR_OBJ(TLS(IntrState))[1];
+        STATE(CountObj)  = INT_INTOBJ( ADDR_OBJ(STATE(IntrState))[3] );
+        STATE(StackObj)  = ADDR_OBJ(STATE(IntrState))[2];
+        STATE(IntrState) = ADDR_OBJ(STATE(IntrState))[1];
 
     }
 
@@ -378,9 +378,9 @@ ExecStatus IntrEnd (
 void            IntrFuncCallBegin ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallBegin(); return; }
 
 }
 
@@ -406,9 +406,9 @@ void            IntrFuncCallEnd (
     UInt                i;              /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) {
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) {
       CodeFuncCallEnd( funccall, options, nr );
       return; }
 
@@ -461,7 +461,7 @@ void            IntrFuncCallEnd (
       else if ( 6 == nr ) { val = CALL_6ARGS( func, a1, a2, a3, a4, a5, a6 ); }
       else                { val = CALL_XARGS( func, args ); }
 
-      if (TLS(UserHasQuit) || TLS(UserHasQUIT)) {
+      if (STATE(UserHasQuit) || STATE(UserHasQUIT)) {
         /* the procedure must have called READ() and the user quit
            from a break loop inside it */
         ReadEvalError();
@@ -501,17 +501,17 @@ void            IntrFuncExprBegin (
     Int                 startLine)
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) {
-        TLS(IntrCoding)++;
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) {
+        STATE(IntrCoding)++;
         CodeFuncExprBegin( narg, nloc, nams, startLine );
         return;
     }
 
     /* switch to coding mode now                                           */
     CodeBegin();
-    TLS(IntrCoding) = 1;
+    STATE(IntrCoding) = 1;
 
     /* code a function expression                                          */
     CodeFuncExprBegin( narg, nloc, nams, startLine );
@@ -524,24 +524,24 @@ void            IntrFuncExprEnd (
     Obj                 func;           /* the function, result            */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 1 ) {
-        TLS(IntrCoding)--;
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 1 ) {
+        STATE(IntrCoding)--;
         CodeFuncExprEnd( nr, mapsto );
         return;
     }
 
     /* must be coding                                                      */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
 
     /* code a function expression                                          */
     CodeFuncExprEnd( nr, mapsto );
 
     /* switch back to immediate mode, get the function                     */
     CodeEnd(0);
-    TLS(IntrCoding) = 0;
-    func = TLS(CodeResult);
+    STATE(IntrCoding) = 0;
+    func = STATE(CodeResult);
 
     /* push the function                                                   */
     PushObj(func);
@@ -583,27 +583,27 @@ void            IntrFuncExprEnd (
 void            IntrIfBegin ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIfBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIfBegin(); return; }
 
 }
 
 void            IntrIfElif ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIfElif(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIfElif(); return; }
 
 }
 
 void            IntrIfElse ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIfElse(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIfElse(); return; }
 
 
     /* push 'true' (to execute body of else-branch)                        */
@@ -615,9 +615,9 @@ void            IntrIfBeginBody ( void )
     Obj                 cond;           /* value of condition              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIfBeginBody(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIfBeginBody(); return; }
 
 
     /* get and check the condition                                         */
@@ -630,7 +630,7 @@ void            IntrIfBeginBody ( void )
 
     /* if the condition is 'false', ignore the body                        */
     if ( cond == False ) {
-        TLS(IntrIgnoring) = 1;
+        STATE(IntrIgnoring) = 1;
     }
 }
 
@@ -640,14 +640,14 @@ void            IntrIfEndBody (
     UInt                i;              /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 1 ) { TLS(IntrIgnoring)--; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIfEndBody( nr ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 1 ) { STATE(IntrIgnoring)--; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIfEndBody( nr ); return; }
 
 
     /* if the condition was 'false', the body was ignored                  */
-    if ( TLS(IntrIgnoring) == 1 ) {
-        TLS(IntrIgnoring) = 0;
+    if ( STATE(IntrIgnoring) == 1 ) {
+        STATE(IntrIgnoring) = 0;
         return;
     }
 
@@ -657,21 +657,21 @@ void            IntrIfEndBody (
     }
 
     /* one branch of the if-statement was executed, ignore the others      */
-    TLS(IntrIgnoring) = 1;
+    STATE(IntrIgnoring) = 1;
 }
 
 void            IntrIfEnd (
     UInt                nr )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 1 ) { TLS(IntrIgnoring)--; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIfEnd( nr ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 1 ) { STATE(IntrIgnoring)--; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIfEnd( nr ); return; }
 
 
     /* if one branch was executed (ignoring the others)                    */
-    if ( TLS(IntrIgnoring) == 1 ) {
-        TLS(IntrIgnoring) = 0;
+    if ( STATE(IntrIgnoring) == 1 ) {
+        STATE(IntrIgnoring) = 0;
         PushVoidObj();
     }
 
@@ -718,14 +718,14 @@ void IntrForBegin ( void )
     Obj                 nams;           /* (empty) list of names           */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { TLS(IntrCoding)++; CodeForBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { STATE(IntrCoding)++; CodeForBegin(); return; }
 
 
     /* switch to coding mode now                                           */
     CodeBegin();
-    TLS(IntrCoding) = 1;
+    STATE(IntrCoding) = 1;
 
     /* code a function expression (with no arguments and locals)           */
     nams = NEW_PLIST( T_PLIST, 0 );
@@ -737,10 +737,10 @@ void IntrForBegin ( void )
 
        If we are not in a break loop, then this would be a waste of time and effort */
 
-    if (TLS(CountNams) > 0) {
-        GROW_PLIST(TLS(StackNams), ++TLS(CountNams));
-        SET_ELM_PLIST(TLS(StackNams), TLS(CountNams), nams);
-        SET_LEN_PLIST(TLS(StackNams), TLS(CountNams));
+    if (STATE(CountNams) > 0) {
+        GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
+        SET_ELM_PLIST(STATE(StackNams), STATE(CountNams), nams);
+        SET_LEN_PLIST(STATE(StackNams), STATE(CountNams));
     }
 
     CodeFuncExprBegin( 0, 0, nams, 0 );
@@ -752,24 +752,24 @@ void IntrForBegin ( void )
 void IntrForIn ( void )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeForIn();
 }
 
 void IntrForBeginBody ( void )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeForBeginBody();
 }
 
@@ -777,11 +777,11 @@ void IntrForEndBody (
     UInt                nr )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) != 0 ) {
+    if ( STATE(IntrCoding) != 0 ) {
         CodeForEndBody( nr );
     }
 }
@@ -791,26 +791,26 @@ void IntrForEnd ( void )
     Obj                 func;           /* the function, result            */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 1 ) { TLS(IntrCoding)--; CodeForEnd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 1 ) { STATE(IntrCoding)--; CodeForEnd(); return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
 
     /* code a function expression (with one statement in the body)         */
     CodeFuncExprEnd( 1UL, 0UL );
 
     /* switch back to immediate mode, get the function                     */
-    TLS(IntrCoding) = 0;
+    STATE(IntrCoding) = 0;
     CodeEnd( 0 );
     /* If we are in a break loop, then we will have created a "dummy" local
        variable names list to get the counts right. Remove it */
-    if (TLS(CountNams) > 0)
-      TLS(CountNams)--;
+    if (STATE(CountNams) > 0)
+      STATE(CountNams)--;
 
-    func = TLS(CodeResult);
+    func = STATE(CodeResult);
 
     /* call the function                                                   */
     CALL_0ARGS( func );
@@ -851,14 +851,14 @@ void            IntrWhileBegin ( void )
     Obj                 nams;           /* (empty) list of names           */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { TLS(IntrCoding)++; CodeWhileBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { STATE(IntrCoding)++; CodeWhileBegin(); return; }
 
 
     /* switch to coding mode now                                           */
     CodeBegin();
-    TLS(IntrCoding) = 1;
+    STATE(IntrCoding) = 1;
 
     /* code a function expression (with no arguments and locals)           */
     nams = NEW_PLIST( T_PLIST, 0 );
@@ -870,10 +870,10 @@ void            IntrWhileBegin ( void )
 
        If we are not in a break loop, then this would be a waste of time and effort */
 
-    if (TLS(CountNams) > 0) {
-        GROW_PLIST(TLS(StackNams), ++TLS(CountNams));
-        SET_ELM_PLIST(TLS(StackNams), TLS(CountNams), nams);
-        SET_LEN_PLIST(TLS(StackNams), TLS(CountNams));
+    if (STATE(CountNams) > 0) {
+        GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
+        SET_ELM_PLIST(STATE(StackNams), STATE(CountNams), nams);
+        SET_LEN_PLIST(STATE(StackNams), STATE(CountNams));
     }
 
     CodeFuncExprBegin( 0, 0, nams, 0 );
@@ -885,12 +885,12 @@ void            IntrWhileBegin ( void )
 void            IntrWhileBeginBody ( void )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeWhileBeginBody();
 }
 
@@ -898,11 +898,11 @@ void            IntrWhileEndBody (
     UInt                nr )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeWhileEndBody( nr );
 }
 
@@ -911,13 +911,13 @@ void            IntrWhileEnd ( void )
     Obj                 func;           /* the function, result            */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 1 ) { TLS(IntrCoding)--; CodeWhileEnd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 1 ) { STATE(IntrCoding)--; CodeWhileEnd(); return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeWhileEnd();
 
     /* code a function expression (with one statement in the body)         */
@@ -925,15 +925,15 @@ void            IntrWhileEnd ( void )
 
 
     /* switch back to immediate mode, get the function                     */
-    TLS(IntrCoding) = 0;
+    STATE(IntrCoding) = 0;
     CodeEnd( 0 );
 
     /* If we are in a break loop, then we will have created a "dummy" local
        variable names list to get the counts right. Remove it */
-    if (TLS(CountNams) > 0)
-      TLS(CountNams)--;
+    if (STATE(CountNams) > 0)
+      STATE(CountNams)--;
 
-    func = TLS(CodeResult);
+    func = STATE(CodeResult);
 
 
     /* call the function                                                   */
@@ -956,9 +956,9 @@ void            IntrWhileEnd ( void )
 void IntrQualifiedExprBegin(UInt qual) 
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeQualifiedExprBegin(qual); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeQualifiedExprBegin(qual); return; }
     PushObj(INTOBJ_INT(qual));
     return;
 }
@@ -966,9 +966,9 @@ void IntrQualifiedExprBegin(UInt qual)
 void IntrQualifiedExprEnd( void ) 
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)--; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeQualifiedExprEnd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)--; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeQualifiedExprEnd(); return; }
     return;
 }
 
@@ -1001,9 +1001,9 @@ void            IntrAtomicBegin ( void )
 {
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAtomicBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAtomicBegin(); return; }
     /* nothing to do here */
     return;
   
@@ -1014,16 +1014,16 @@ void            IntrAtomicBeginBody ( UInt nrexprs )
   Obj nams;
 
     /* ignore    or code                                                          */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { TLS(IntrCoding)++; CodeAtomicBeginBody(nrexprs); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { STATE(IntrCoding)++; CodeAtomicBeginBody(nrexprs); return; }
 
 
     /* leave the expressions and qualifiers on the stack, switch to coding to process the body
        of the Atomic expression */
     PushObj(INTOBJ_INT(nrexprs));
     CodeBegin();
-    TLS(IntrCoding) = 1;
+    STATE(IntrCoding) = 1;
     
     
     /* code a function expression (with no arguments and locals)           */
@@ -1037,14 +1037,14 @@ void            IntrAtomicBeginBody ( UInt nrexprs )
        
        If we are not in a break loop, then this would be a waste of time and effort */
     
-    if (TLS(CountNams) > 0)
+    if (STATE(CountNams) > 0)
       {
-	GROW_PLIST(TLS(StackNams), ++TLS(CountNams));
-	SET_ELM_PLIST(TLS(StackNams), TLS(CountNams), nams);
-	SET_LEN_PLIST(TLS(StackNams), TLS(CountNams));
+	GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
+	SET_ELM_PLIST(STATE(StackNams), STATE(CountNams), nams);
+	SET_LEN_PLIST(STATE(StackNams), STATE(CountNams));
       }
     
-    CodeFuncExprBegin( 0, 0, nams, TLS(Input)->number );
+    CodeFuncExprBegin( 0, 0, nams, STATE(Input)->number );
 }
 
 void            IntrAtomicEndBody (
@@ -1053,31 +1053,31 @@ void            IntrAtomicEndBody (
   Obj body;
 
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
-    if (TLS(IntrCoding) == 1) {
+    if (STATE(IntrCoding) == 1) {
       /* This is the case where we are really immediately interpreting an atomic
 	 statement, but we switched to coding to store the body until we have it all */
 
     /* If we are in a break loop, then we will have created a "dummy" local
        variable names list to get the counts right. Remove it */
-      if (TLS(CountNams) > 0)
-	TLS(CountNams)--;
+      if (STATE(CountNams) > 0)
+	STATE(CountNams)--;
 
       /* Code the body as a function expression */
       CodeFuncExprEnd( nrstats, 0UL );
     
 
       /* switch back to immediate mode, get the function                     */
-      TLS(IntrCoding) = 0;
+      STATE(IntrCoding) = 0;
       CodeEnd( 0 );
-      body = TLS(CodeResult);
+      body = STATE(CodeResult);
       PushObj(body);
       return;
     } else {
       
-        assert( TLS(IntrCoding) > 0 );
+        assert( STATE(IntrCoding) > 0 );
         CodeAtomicEndBody( nrstats );
     }
 }
@@ -1096,9 +1096,9 @@ void            IntrAtomicEnd ( void )
     Obj o;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { TLS(IntrCoding)--; CodeAtomicEnd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { STATE(IntrCoding)--; CodeAtomicEnd(); return; }
     /* Now we need to recover the objects to lock, and go to work */
 
     body = PopObj();
@@ -1184,14 +1184,14 @@ void            IntrRepeatBegin ( void )
     Obj                 nams;           /* (empty) list of names           */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { TLS(IntrCoding)++; CodeRepeatBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { STATE(IntrCoding)++; CodeRepeatBegin(); return; }
 
 
     /* switch to coding mode now                                           */
     CodeBegin();
-    TLS(IntrCoding) = 1;
+    STATE(IntrCoding) = 1;
 
     /* code a function expression (with no arguments and locals)           */
     nams = NEW_PLIST( T_PLIST, 0 );
@@ -1203,13 +1203,13 @@ void            IntrRepeatBegin ( void )
 
        If we are not in a break loop, then this would be a waste of time and effort */
 
-    if (TLS(CountNams) > 0) {
-        GROW_PLIST(TLS(StackNams), ++TLS(CountNams));
-        SET_ELM_PLIST(TLS(StackNams), TLS(CountNams), nams);
-        SET_LEN_PLIST(TLS(StackNams), TLS(CountNams));
+    if (STATE(CountNams) > 0) {
+        GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
+        SET_ELM_PLIST(STATE(StackNams), STATE(CountNams), nams);
+        SET_LEN_PLIST(STATE(StackNams), STATE(CountNams));
     }
 
-    CodeFuncExprBegin( 0, 0, nams, TLS(Input)->number );
+    CodeFuncExprBegin( 0, 0, nams, STATE(Input)->number );
 
     /* code a repeat loop                                                  */
     CodeRepeatBegin();
@@ -1218,12 +1218,12 @@ void            IntrRepeatBegin ( void )
 void            IntrRepeatBeginBody ( void )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeRepeatBeginBody();
 }
 
@@ -1231,11 +1231,11 @@ void            IntrRepeatEndBody (
     UInt                nr )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeRepeatEndBody( nr );
 }
 
@@ -1244,26 +1244,26 @@ void            IntrRepeatEnd ( void )
     Obj                 func;           /* the function, result            */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 1 ) { TLS(IntrCoding)--; CodeRepeatEnd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 1 ) { STATE(IntrCoding)--; CodeRepeatEnd(); return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeRepeatEnd();
 
     /* code a function expression (with one statement in the body)         */
     CodeFuncExprEnd( 1UL, 0UL );
 
     /* switch back to immediate mode, get the function                     */
-    TLS(IntrCoding) = 0;
+    STATE(IntrCoding) = 0;
     CodeEnd( 0 );
     /* If we are in a break loop, then we will have created a "dummy" local
        variable names list to get the counts right. Remove it */
-    if (TLS(CountNams) > 0)
-      TLS(CountNams)--;
-    func = TLS(CodeResult);
+    if (STATE(CountNams) > 0)
+      STATE(CountNams)--;
+    func = STATE(CodeResult);
 
     /* call the function                                                   */
     CALL_0ARGS( func );
@@ -1286,11 +1286,11 @@ void            IntrRepeatEnd ( void )
 void            IntrBreak ( void )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) == 0 )
+    if ( STATE(IntrCoding) == 0 )
       ErrorQuit("'break' statement can only appear inside a loop",0L,0L);
     else
       CodeBreak();
@@ -1311,11 +1311,11 @@ void            IntrBreak ( void )
 void            IntrContinue ( void )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) == 0 )
+    if ( STATE(IntrCoding) == 0 )
       ErrorQuit("'continue' statement can only appear inside a loop",0L,0L);
     else
       CodeContinue();
@@ -1336,19 +1336,19 @@ void            IntrReturnObj ( void )
     Obj                 val;            /* return value                    */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeReturnObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeReturnObj(); return; }
 
 
     /* empty the values stack and push the return value                    */
     val = PopObj();
-    SET_LEN_PLIST( TLS(StackObj), 0 );
-    TLS(CountObj) = 0;
+    SET_LEN_PLIST( STATE(StackObj), 0 );
+    STATE(CountObj) = 0;
     PushObj( val );
 
     /* indicate that a return-value-statement was interpreted              */
-    TLS(IntrReturning) = 1;
+    STATE(IntrReturning) = 1;
 }
 
 
@@ -1362,18 +1362,18 @@ void            IntrReturnObj ( void )
 void            IntrReturnVoid ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeReturnVoid(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeReturnVoid(); return; }
 
 
     /* empty the values stack and push the void value                      */
-    SET_LEN_PLIST( TLS(StackObj), 0 );
-    TLS(CountObj) = 0;
+    SET_LEN_PLIST( STATE(StackObj), 0 );
+    STATE(CountObj) = 0;
     PushVoidObj();
 
     /* indicate that a return-void-statement was interpreted               */
-    TLS(IntrReturning) = 2;
+    STATE(IntrReturning) = 2;
 }
 
 
@@ -1387,23 +1387,23 @@ void            IntrReturnVoid ( void )
 void            IntrQuit ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* 'quit' is not allowed in functions (by the reader)                  */
-    /* assert( TLS(IntrCoding) == 0 ); */
-    if ( TLS(IntrCoding) > 0 ) {
+    /* assert( STATE(IntrCoding) == 0 ); */
+    if ( STATE(IntrCoding) > 0 ) {
       SyntaxError("'quit;' cannot be used in this context");
     }
 
     /* empty the values stack and push the void value                      */
-    SET_LEN_PLIST( TLS(StackObj), 0 );
-    TLS(CountObj) = 0;
+    SET_LEN_PLIST( STATE(StackObj), 0 );
+    STATE(CountObj) = 0;
     PushVoidObj();
 
 
     /* indicate that a quit-statement was interpreted                      */
-    TLS(IntrReturning) = STATUS_QUIT;
+    STATE(IntrReturning) = STATUS_QUIT;
 }
 
 /****************************************************************************
@@ -1416,20 +1416,20 @@ void            IntrQuit ( void )
 void            IntrQUIT ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* 'quit' is not allowed in functions (by the reader)                  */
-    assert( TLS(IntrCoding) == 0 );
+    assert( STATE(IntrCoding) == 0 );
 
     /* empty the values stack and push the void value                      */
-    SET_LEN_PLIST( TLS(StackObj), 0 );
-    TLS(CountObj) = 0;
+    SET_LEN_PLIST( STATE(StackObj), 0 );
+    STATE(CountObj) = 0;
     PushVoidObj();
 
 
     /* indicate that a quit-statement was interpreted                      */
-    TLS(IntrReturning) = STATUS_QQUIT;
+    STATE(IntrReturning) = STATUS_QQUIT;
 }
 
 
@@ -1451,9 +1451,9 @@ void            IntrOrL ( void )
     Obj                 opL;            /* value of left operand           */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeOrL(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeOrL(); return; }
 
 
     /* if the left operand is 'true', ignore the right operand             */
@@ -1461,7 +1461,7 @@ void            IntrOrL ( void )
     PushObj( opL );
     if ( opL == True ) {
         PushObj( opL );
-        TLS(IntrIgnoring) = 1;
+        STATE(IntrIgnoring) = 1;
     }
 }
 
@@ -1471,13 +1471,13 @@ void            IntrOr ( void )
     Obj                 opR;            /* value of right operand          */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 1 ) { TLS(IntrIgnoring)--; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeOr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 1 ) { STATE(IntrIgnoring)--; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeOr(); return; }
 
 
     /* stop ignoring things now                                            */
-    TLS(IntrIgnoring) = 0;
+    STATE(IntrIgnoring) = 0;
 
     /* get the operands                                                    */
     opR = PopObj();
@@ -1525,9 +1525,9 @@ void            IntrAndL ( void )
     Obj                 opL;            /* value of left operand           */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAndL(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAndL(); return; }
 
 
     /* if the left operand is 'false', ignore the right operand            */
@@ -1535,7 +1535,7 @@ void            IntrAndL ( void )
     PushObj( opL );
     if ( opL == False ) {
         PushObj( opL );
-        TLS(IntrIgnoring) = 1;
+        STATE(IntrIgnoring) = 1;
     }
 }
 
@@ -1549,13 +1549,13 @@ void            IntrAnd ( void )
     Obj                 opR;            /* value of right operand          */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 1 ) { TLS(IntrIgnoring)--; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAnd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 1 ) { STATE(IntrIgnoring)--; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAnd(); return; }
 
 
     /* stop ignoring things now                                            */
-    TLS(IntrIgnoring) = 0;
+    STATE(IntrIgnoring) = 0;
 
     /* get the operands                                                    */
     opR = PopObj();
@@ -1612,8 +1612,8 @@ void            IntrNot ( void )
     Obj                 op;             /* operand                         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrIgnoring) > 0 ) { return; }
-    if ( TLS(IntrCoding)   > 0 ) { CodeNot(); return; }
+    if ( STATE(IntrIgnoring) > 0 ) { return; }
+    if ( STATE(IntrCoding)   > 0 ) { CodeNot(); return; }
 
 
     /* get and check the operand                                           */
@@ -1666,9 +1666,9 @@ void            IntrEq ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeEq(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeEq(); return; }
 
 
     /* get the operands                                                    */
@@ -1685,9 +1685,9 @@ void            IntrEq ( void )
 void            IntrNe ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeNe(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeNe(); return; }
 
 
     /* '<left> <> <right>' is 'not <left> = <right>'                       */
@@ -1702,9 +1702,9 @@ void            IntrLt ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeLt(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeLt(); return; }
 
 
     /* get the operands                                                    */
@@ -1721,9 +1721,9 @@ void            IntrLt ( void )
 void            IntrGe ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeGe(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeGe(); return; }
 
 
     /* '<left> >= <right>' is 'not <left> < <right>'                       */
@@ -1734,9 +1734,9 @@ void            IntrGe ( void )
 void            IntrGt ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeGt(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeGt(); return; }
 
 
     /* '<left> > <right>' is '<right> < <left>'                            */
@@ -1747,9 +1747,9 @@ void            IntrGt ( void )
 void            IntrLe ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeLe(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeLe(); return; }
 
 
     /* '<left> <= <right>' is 'not <right> < <left>'                       */
@@ -1773,9 +1773,9 @@ void            IntrIn ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIn(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIn(); return; }
 
 
     /* get the operands                                                    */
@@ -1812,9 +1812,9 @@ void            IntrSum ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeSum(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeSum(); return; }
 
 
     /* get the operands                                                    */
@@ -1834,9 +1834,9 @@ void            IntrAInv ( void )
     Obj                 opL;            /* left operand                    */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAInv(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAInv(); return; }
 
 
     /* get the operand                                                     */
@@ -1856,9 +1856,9 @@ void            IntrDiff ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeDiff(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeDiff(); return; }
 
 
     /* get the operands                                                    */
@@ -1879,9 +1879,9 @@ void            IntrProd ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeProd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeProd(); return; }
 
 
     /* get the operands                                                    */
@@ -1901,9 +1901,9 @@ void            IntrInv ( void )
     Obj                 opL;            /* left operand                    */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeInv(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeInv(); return; }
 
 
     /* get the operand                                                     */
@@ -1923,9 +1923,9 @@ void            IntrQuo ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeQuo(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeQuo(); return; }
 
 
     /* get the operands                                                    */
@@ -1946,9 +1946,9 @@ void            IntrMod ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeMod(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeMod(); return; }
 
 
     /* get the operands                                                    */
@@ -1969,9 +1969,9 @@ void            IntrPow ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodePow(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodePow(); return; }
 
 
     /* get the operands                                                    */
@@ -2004,9 +2004,9 @@ void            IntrIntExpr (
     UInt                i;              /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIntExpr( str ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIntExpr( str ); return; }
 
     
     /* get the signs, if any                                                */
@@ -2063,9 +2063,9 @@ void            IntrLongIntExpr (
 {
     Obj                 ret;            /* integer encoded as GAP obj      */
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeLongIntExpr( string ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeLongIntExpr( string ); return; }
 
     ret = IntStringInternal(string);
     
@@ -2109,9 +2109,9 @@ void            IntrFloatExpr (
     Obj                 val;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) {  CodeFloatExpr( str );   return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) {  CodeFloatExpr( str );   return; }
 
     C_NEW_STRING_DYN(val, str);
     PushObj(ConvertFloatLiteralEager(val));
@@ -2129,9 +2129,9 @@ void            IntrLongFloatExpr (
     Obj               string )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeLongFloatExpr( string );  return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeLongFloatExpr( string );  return; }
 
     PushObj(ConvertFloatLiteralEager(string));
 }
@@ -2145,9 +2145,9 @@ void            IntrLongFloatExpr (
 void            IntrTrueExpr ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeTrueExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeTrueExpr(); return; }
 
 
     /* push the value                                                      */
@@ -2164,9 +2164,9 @@ void            IntrTrueExpr ( void )
 void            IntrFalseExpr ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFalseExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFalseExpr(); return; }
 
 
     /* push the value                                                      */
@@ -2185,9 +2185,9 @@ void            IntrCharExpr (
     Char                chr )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeCharExpr( chr ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeCharExpr( chr ); return; }
 
 
     /* push the value                                                      */
@@ -2212,9 +2212,9 @@ void            IntrPermCycle (
     UInt                j, k;           /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodePermCycle(nrx,nrc); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodePermCycle(nrx,nrc); return; }
 
 
     /* get the permutation (allocate for the first cycle)                  */
@@ -2224,8 +2224,8 @@ void            IntrPermCycle (
         ptr4 = ADDR_PERM4( perm );
     }
     else {
-        m = INT_INTOBJ( ELM_LIST( TLS(StackObj), TLS(CountObj) - nrx ) );
-        perm = ELM_LIST( TLS(StackObj), TLS(CountObj) - nrx - 1 );
+        m = INT_INTOBJ( ELM_LIST( STATE(StackObj), STATE(CountObj) - nrx ) );
+        perm = ELM_LIST( STATE(StackObj), STATE(CountObj) - nrx - 1 );
         ptr4 = ADDR_PERM4( perm );
     }
 
@@ -2296,9 +2296,9 @@ void            IntrPerm (
     UInt                k;              /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodePerm(nrc); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodePerm(nrc); return; }
 
 
     /* special case for identity permutation                               */
@@ -2350,9 +2350,9 @@ void            IntrListExprBegin (
     Obj                 old;            /* old value of '~'                */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeListExprBegin( top ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeListExprBegin( top ); return; }
 
 
     /* allocate the new list                                               */
@@ -2376,9 +2376,9 @@ void            IntrListExprBeginElm (
     UInt                pos )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeListExprBeginElm( pos ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeListExprBeginElm( pos ); return; }
 
 
     /* remember this position on the values stack                          */
@@ -2393,9 +2393,9 @@ void            IntrListExprEndElm ( void )
     Obj                 val;            /* value to assign into list       */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeListExprEndElm(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeListExprEndElm(); return; }
 
 
     /* get the value                                                       */
@@ -2429,9 +2429,9 @@ void            IntrListExprEnd (
     Obj                 val;            /* temporary value                 */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeListExprEnd(nr,range,top,tilde); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeListExprEnd(nr,range,top,tilde); return; }
 
 
     /* if this was a top level expression, restore the value of '~'        */
@@ -2540,9 +2540,9 @@ void           IntrStringExpr (
     Obj               string )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeStringExpr( string ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeStringExpr( string ); return; }
 
 
     /* push the string, already newly created                              */
@@ -2564,9 +2564,9 @@ void            IntrRecExprBegin (
     Obj                 old;            /* old value of '~'                */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeRecExprBegin( top ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeRecExprBegin( top ); return; }
 
 
     /* allocate the new record                                             */
@@ -2589,9 +2589,9 @@ void            IntrRecExprBeginElmName (
     UInt                rnam )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeRecExprBeginElmName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeRecExprBeginElmName( rnam ); return; }
 
 
     /* remember the name on the values stack                               */
@@ -2603,9 +2603,9 @@ void            IntrRecExprBeginElmExpr ( void )
     UInt                rnam;           /* record name                     */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeRecExprBeginElmExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeRecExprBeginElmExpr(); return; }
 
 
     /* convert the expression to a record name                             */
@@ -2622,9 +2622,9 @@ void            IntrRecExprEndElm ( void )
     Obj                 val;            /* value of record element         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeRecExprEndElm(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeRecExprEndElm(); return; }
 
 
     /* get the value                                                       */
@@ -2652,9 +2652,9 @@ void            IntrRecExprEnd (
     Obj                 old;            /* old value of '~'                */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeRecExprEnd(nr,top,tilde); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeRecExprEnd(nr,top,tilde); return; }
 
 
     /* if this was a top level expression, restore the value of '~'        */
@@ -2683,9 +2683,9 @@ void            IntrFuncCallOptionsBegin ( void )
     Obj                 record;         /* new record                      */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallOptionsBegin( ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsBegin( ); return; }
 
 
     /* allocate the new record                                             */
@@ -2698,9 +2698,9 @@ void            IntrFuncCallOptionsBeginElmName (
     UInt                rnam )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallOptionsBeginElmName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsBeginElmName( rnam ); return; }
 
 
     /* remember the name on the values stack                               */
@@ -2712,9 +2712,9 @@ void            IntrFuncCallOptionsBeginElmExpr ( void )
     UInt                rnam;           /* record name                     */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallOptionsBeginElmExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsBeginElmExpr(); return; }
 
 
     /* convert the expression to a record name                             */
@@ -2731,9 +2731,9 @@ void            IntrFuncCallOptionsEndElm ( void )
     Obj                 val;            /* value of record element         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallOptionsEndElm(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsEndElm(); return; }
 
 
     /* get the value                                                       */
@@ -2759,9 +2759,9 @@ void            IntrFuncCallOptionsEndElmEmpty ( void )
     Obj                 val;            /* value of record element         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallOptionsEndElmEmpty(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsEndElmEmpty(); return; }
 
 
     /* get the value                                                       */
@@ -2783,9 +2783,9 @@ void            IntrFuncCallOptionsEndElmEmpty ( void )
 void            IntrFuncCallOptionsEnd ( UInt nr )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallOptionsEnd(nr); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsEnd(nr); return; }
 
 
 }
@@ -2800,11 +2800,11 @@ void            IntrAssLVar (
 {
   Obj val;
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) > 0 )
+    if ( STATE(IntrCoding) > 0 )
       CodeAssLVar( lvar );
 
     /* Or in the break loop */
@@ -2819,11 +2819,11 @@ void            IntrUnbLVar (
     UInt                lvar )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) > 0 )
+    if ( STATE(IntrCoding) > 0 )
       CodeUnbLVar( lvar );
 
     /* or in the break loop */
@@ -2843,11 +2843,11 @@ void            IntrRefLVar (
 {
   Obj val;
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) > 0 )
+    if ( STATE(IntrCoding) > 0 )
       CodeRefLVar( lvar );
 
     /* or in the break loop */
@@ -2868,11 +2868,11 @@ void            IntrIsbLVar (
     UInt                lvar )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if( TLS(IntrCoding) > 0 )
+    if( STATE(IntrCoding) > 0 )
       CodeIsbLVar( lvar );
 
     /* or debugging */
@@ -2891,11 +2891,11 @@ void            IntrAssHVar (
 {
   Obj val;
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if( TLS(IntrCoding) > 0 )
+    if( STATE(IntrCoding) > 0 )
       CodeAssHVar( hvar );
     /* Or in the break loop */
     else {
@@ -2909,11 +2909,11 @@ void            IntrUnbHVar (
     UInt                hvar )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) > 0 )
+    if ( STATE(IntrCoding) > 0 )
       CodeUnbHVar( hvar );
     /* or debugging */
     else {
@@ -2932,11 +2932,11 @@ void            IntrRefHVar (
 {
   Obj val;
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if( TLS(IntrCoding) > 0 )
+    if( STATE(IntrCoding) > 0 )
       CodeRefHVar( hvar );
     /* or debugging */
     else {
@@ -2955,11 +2955,11 @@ void            IntrIsbHVar (
     UInt                hvar )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if( TLS(IntrCoding) > 0 )
+    if( STATE(IntrCoding) > 0 )
       CodeIsbHVar( hvar );
     /* or debugging */
     else
@@ -2981,12 +2981,12 @@ void            IntrAssDVar (
     Obj                 currLVars;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    /* if ( TLS(IntrCoding)    > 0 ) { CodeAssDVar( gvar ); return; } */
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    /* if ( STATE(IntrCoding)    > 0 ) { CodeAssDVar( gvar ); return; } */
 
 
-    if ( TLS(IntrCoding) > 0 ) {
+    if ( STATE(IntrCoding) > 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
                    dvar >> 10, dvar & 0x3FF );
     }
@@ -2996,10 +2996,10 @@ void            IntrAssDVar (
     rhs = PopObj();
 
     /* assign the right hand side                                          */
-    currLVars = TLS(CurrLVars);
-    SWITCH_TO_OLD_LVARS( TLS(ErrorLVars) );
+    currLVars = STATE(CurrLVars);
+    SWITCH_TO_OLD_LVARS( STATE(ErrorLVars) );
     while (depth--)
-      SWITCH_TO_OLD_LVARS( PARENT_LVARS(TLS(CurrLVars)) );
+      SWITCH_TO_OLD_LVARS( PARENT_LVARS(STATE(CurrLVars)) );
     ASS_HVAR( dvar, rhs );
     SWITCH_TO_OLD_LVARS( currLVars  );
 
@@ -3014,21 +3014,21 @@ void            IntrUnbDVar (
     Obj                 currLVars;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    /* if ( TLS(IntrCoding)    > 0 ) { CodeUnbGVar( gvar ); return; } */
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    /* if ( STATE(IntrCoding)    > 0 ) { CodeUnbGVar( gvar ); return; } */
 
 
-    if ( TLS(IntrCoding) > 0 ) {
+    if ( STATE(IntrCoding) > 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
                    dvar >> 10, dvar & 0x3FF );
     }
 
     /* assign the right hand side                                          */
-    currLVars = TLS(CurrLVars);
-    SWITCH_TO_OLD_LVARS( TLS(ErrorLVars) );
+    currLVars = STATE(CurrLVars);
+    SWITCH_TO_OLD_LVARS( STATE(ErrorLVars) );
     while (depth--)
-      SWITCH_TO_OLD_LVARS( PARENT_LVARS(TLS(CurrLVars)) );
+      SWITCH_TO_OLD_LVARS( PARENT_LVARS(STATE(CurrLVars)) );
     ASS_HVAR( dvar, (Obj)0 );
     SWITCH_TO_OLD_LVARS( currLVars  );
 
@@ -3049,21 +3049,21 @@ void            IntrRefDVar (
     Obj                 currLVars;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    /* if ( TLS(IntrCoding)    > 0 ) { CodeRefGVar( gvar ); return; } */
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    /* if ( STATE(IntrCoding)    > 0 ) { CodeRefGVar( gvar ); return; } */
 
 
-    if ( TLS(IntrCoding) > 0 ) {
+    if ( STATE(IntrCoding) > 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
                    dvar >> 10, dvar & 0x3FF );
     }
 
     /* get and check the value                                             */
-    currLVars = TLS(CurrLVars);
-    SWITCH_TO_OLD_LVARS( TLS(ErrorLVars) );
+    currLVars = STATE(CurrLVars);
+    SWITCH_TO_OLD_LVARS( STATE(ErrorLVars) );
     while (depth--)
-      SWITCH_TO_OLD_LVARS( PARENT_LVARS(TLS(CurrLVars)) );
+      SWITCH_TO_OLD_LVARS( PARENT_LVARS(STATE(CurrLVars)) );
     val = OBJ_HVAR( dvar );
     SWITCH_TO_OLD_LVARS( currLVars  );
     if ( val == 0 ) {
@@ -3083,16 +3083,16 @@ void            IntrIsbDVar (
     Obj                 currLVars;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    /* if ( TLS(IntrCoding)    > 0 ) { CodeIsbGVar( gvar ); return; } */
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    /* if ( STATE(IntrCoding)    > 0 ) { CodeIsbGVar( gvar ); return; } */
 
 
     /* get the value                                                       */
-    currLVars = TLS(CurrLVars);
-    SWITCH_TO_OLD_LVARS( TLS(ErrorLVars) );
+    currLVars = STATE(CurrLVars);
+    SWITCH_TO_OLD_LVARS( STATE(ErrorLVars) );
     while (depth--)
-      SWITCH_TO_OLD_LVARS( PARENT_LVARS(TLS(CurrLVars)) );
+      SWITCH_TO_OLD_LVARS( PARENT_LVARS(STATE(CurrLVars)) );
     val = OBJ_HVAR( dvar );
     SWITCH_TO_OLD_LVARS( currLVars  );
 
@@ -3111,9 +3111,9 @@ void            IntrAssGVar (
     Obj                 rhs;            /* right hand side                 */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssGVar( gvar ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssGVar( gvar ); return; }
 
 
     /* get the right hand side                                             */
@@ -3130,9 +3130,9 @@ void            IntrUnbGVar (
     UInt                gvar )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbGVar( gvar ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbGVar( gvar ); return; }
 
 
     /* assign the right hand side                                          */
@@ -3153,9 +3153,9 @@ void            IntrRefGVar (
     Obj                 val;            /* value, result                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeRefGVar( gvar ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeRefGVar( gvar ); return; }
 
 
     /* get and check the value                                             */
@@ -3175,9 +3175,9 @@ void            IntrIsbGVar (
     Obj                 val;            /* value, result                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbGVar( gvar ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbGVar( gvar ); return; }
 
 
     /* get the value                                                       */
@@ -3205,9 +3205,9 @@ void            IntrAssList ( Int narg )
     Int i;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssList( narg); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssList( narg); return; }
 
     /* get the right hand side                                             */
     rhs = PopObj();
@@ -3260,9 +3260,9 @@ void            IntrAsssList ( void )
     Obj                 rhss;           /* right hand sides                */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAsssList(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAsssList(); return; }
 
 
     /* get the right hand sides                                            */
@@ -3307,9 +3307,9 @@ void            IntrAssListLevel (
     Int i;
     
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssListLevel( narg, level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssListLevel( narg, level ); return; }
 
     /* get right hand sides (checking is done by 'AssListLevel')           */
     rhss = PopObj();
@@ -3342,9 +3342,9 @@ void            IntrAsssListLevel (
     Obj                 rhss;           /* right hand sides, right operand */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAsssListLevel( level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAsssListLevel( level ); return; }
 
 
     /* get right hand sides (checking is done by 'AsssListLevel')          */
@@ -3377,9 +3377,9 @@ void            IntrUnbList ( Int narg )
     Int                 i;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbList( narg); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbList( narg); return; }
 
     if (narg == 1) {
       /* get and check the position                                          */
@@ -3430,9 +3430,9 @@ void            IntrElmList ( Int narg )
     Obj                 pos2;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmList( narg ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmList( narg ); return; }
 
     if (narg <= 0)
       SyntaxError("This should never happen");
@@ -3482,9 +3482,9 @@ void            IntrElmsList ( void )
     Obj                 poss;           /* positions, right operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmsList(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmsList(); return; }
 
 
     /* get and check the positions                                         */
@@ -3514,9 +3514,9 @@ void            IntrElmListLevel ( Int narg,
     Int i;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmListLevel( narg, level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmListLevel( narg, level ); return; }
 
     /* get the positions */
     ixs = NEW_PLIST(T_PLIST, narg);
@@ -3553,9 +3553,9 @@ void            IntrElmsListLevel (
     Obj                 poss;           /* positions, right operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmsListLevel( level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmsListLevel( level ); return; }
 
 
     /* get and check the positions                                         */
@@ -3586,9 +3586,9 @@ void            IntrIsbList ( Int narg )
     Int i;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbList(narg); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbList(narg); return; }
 
     if (narg == 1) {
       /* get and check the position                                          */
@@ -3633,9 +3633,9 @@ void            IntrAssRecName (
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssRecName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssRecName( rnam ); return; }
 
 
     /* get the right hand side                                             */
@@ -3658,9 +3658,9 @@ void            IntrAssRecExpr ( void )
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssRecExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssRecExpr(); return; }
 
 
     /* get the right hand side                                             */
@@ -3685,9 +3685,9 @@ void            IntrUnbRecName (
     Obj                 record;         /* record, left operand            */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbRecName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbRecName( rnam ); return; }
 
 
     /* get the record (checking is done by 'UNB_REC')                      */
@@ -3706,9 +3706,9 @@ void            IntrUnbRecExpr ( void )
     UInt                rnam;           /* name, left operand              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbRecExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbRecExpr(); return; }
 
 
     /* get the name and convert it to a record name                        */
@@ -3737,9 +3737,9 @@ void            IntrElmRecName (
     Obj                 record;         /* the record, left operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmRecName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmRecName( rnam ); return; }
 
 
     /* get the record (checking is done by 'ELM_REC')                      */
@@ -3759,9 +3759,9 @@ void            IntrElmRecExpr ( void )
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmRecExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmRecExpr(); return; }
 
 
     /* get the name and convert it to a record name                        */
@@ -3784,9 +3784,9 @@ void            IntrIsbRecName (
     Obj                 record;         /* the record, left operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbRecName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbRecName( rnam ); return; }
 
 
     /* get the record (checking is done by 'ISB_REC')                      */
@@ -3806,9 +3806,9 @@ void            IntrIsbRecExpr ( void )
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbRecExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbRecExpr(); return; }
 
 
     /* get the name and convert it to a record name                        */
@@ -3840,9 +3840,9 @@ void            IntrAssPosObj ( void )
     Obj                 rhs;            /* right hand side                 */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssPosObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssPosObj(); return; }
 
 
     /* get the right hand side                                             */
@@ -3891,9 +3891,9 @@ void            IntrAsssPosObj ( void )
     Obj                 rhss;           /* right hand sides                */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAsssPosObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAsssPosObj(); return; }
 
 
     /* get the right hand sides                                            */
@@ -3939,9 +3939,9 @@ void            IntrAssPosObjLevel (
     Obj                 rhss;           /* right hand sides, right operand */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssPosObjLevel( level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssPosObjLevel( level ); return; }
 
 
     /* get right hand sides (checking is done by 'AssPosObjLevel')           */
@@ -3971,9 +3971,9 @@ void            IntrAsssPosObjLevel (
     Obj                 rhss;           /* right hand sides, right operand */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAsssPosObjLevel( level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAsssPosObjLevel( level ); return; }
 
 
     /* get right hand sides (checking is done by 'AsssPosObjLevel')          */
@@ -4003,9 +4003,9 @@ void            IntrUnbPosObj ( void )
     Int                 p;              /* position, as a C integer        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbPosObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbPosObj(); return; }
 
 
     /* get and check the position                                          */
@@ -4058,9 +4058,9 @@ void            IntrElmPosObj ( void )
     Int                 p;              /* position, as C integer          */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmPosObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmPosObj(); return; }
 
 
     /* get and check the position                                          */
@@ -4113,9 +4113,9 @@ void            IntrElmsPosObj ( void )
     Obj                 poss;           /* positions, right operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmsPosObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmsPosObj(); return; }
 
 
     /* get and check the positions                                         */
@@ -4149,9 +4149,9 @@ void            IntrElmPosObjLevel (
     Obj                 pos;            /* position, right operand         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmPosObjLevel( level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmPosObjLevel( level ); return; }
 
 
     /* get and check the position                                          */
@@ -4182,9 +4182,9 @@ void            IntrElmsPosObjLevel (
     Obj                 poss;           /* positions, right operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmsPosObjLevel( level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmsPosObjLevel( level ); return; }
 
 
     /* get and check the positions                                         */
@@ -4216,9 +4216,9 @@ void            IntrIsbPosObj ( void )
     Int                 p;              /* position, as C integer          */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbPosObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbPosObj(); return; }
 
 
     /* get and check the position                                          */
@@ -4269,9 +4269,9 @@ void            IntrAssComObjName (
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssComObjName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssComObjName( rnam ); return; }
 
 
     /* get the right hand side                                             */
@@ -4304,9 +4304,9 @@ void            IntrAssComObjExpr ( void )
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssComObjExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssComObjExpr(); return; }
 
 
     /* get the right hand side                                             */
@@ -4341,9 +4341,9 @@ void            IntrUnbComObjName (
     Obj                 record;         /* record, left operand            */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbComObjName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbComObjName( rnam ); return; }
 
 
     /* get the record (checking is done by 'UNB_REC')                      */
@@ -4372,9 +4372,9 @@ void            IntrUnbComObjExpr ( void )
     UInt                rnam;           /* name, left operand              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbComObjExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbComObjExpr(); return; }
 
 
     /* get the name and convert it to a record name                        */
@@ -4413,9 +4413,9 @@ void            IntrElmComObjName (
     Obj                 record;         /* the record, left operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmComObjName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmComObjName( rnam ); return; }
 
 
     /* get the record (checking is done by 'ELM_REC')                      */
@@ -4446,9 +4446,9 @@ void            IntrElmComObjExpr ( void )
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmComObjExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmComObjExpr(); return; }
 
 
     /* get the name and convert it to a record name                        */
@@ -4481,9 +4481,9 @@ void            IntrIsbComObjName (
     Obj                 record;         /* the record, left operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbComObjName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbComObjName( rnam ); return; }
 
 
     /* get the record (checking is done by 'ISB_REC')                      */
@@ -4513,9 +4513,9 @@ void            IntrIsbComObjExpr ( void )
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbComObjExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbComObjExpr(); return; }
 
 
     /* get the name and convert it to a record name                        */
@@ -4550,9 +4550,9 @@ void            IntrIsbComObjExpr ( void )
 void             IntrEmpty ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeEmpty(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeEmpty(); return; }
 
 
     /* interpret */
@@ -4586,9 +4586,9 @@ void             IntrEmpty ( void )
 void            IntrInfoBegin( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeInfoBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeInfoBegin(); return; }
 
 }
 
@@ -4603,16 +4603,16 @@ void            IntrInfoMiddle( void )
                         gets printed or not */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeInfoMiddle(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeInfoMiddle(); return; }
 
 
     level = PopObj();
     selectors = PopObj();
     selected = CALL_2ARGS( InfoDecision, selectors, level);
     if (selected == False)
-      TLS(IntrIgnoring) = 1;
+      STATE(IntrIgnoring) = 1;
     return;
 }
 
@@ -4624,13 +4624,13 @@ void            IntrInfoEnd( UInt narg )
      Obj args;    /* gathers up the arguments to be printed */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeInfoEnd( narg ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeInfoEnd( narg ); return; }
 
 
     /* print if necessary                                                  */
-    if ( TLS(IntrIgnoring)  > 0 )
-      TLS(IntrIgnoring)--;
+    if ( STATE(IntrIgnoring)  > 0 )
+      STATE(IntrIgnoring)--;
     else
       {
         args = NEW_PLIST( T_PLIST, narg);
@@ -4644,7 +4644,7 @@ void            IntrInfoEnd( UInt narg )
 
     /* If we actually executed this statement at all
        (even if we printed nothing) then return a Void */
-    if (TLS(IntrIgnoring) == 0)
+    if (STATE(IntrIgnoring) == 0)
       PushVoidObj();
     return;
 }
@@ -4669,7 +4669,7 @@ void            IntrInfoEnd( UInt narg )
 *V  CurrentAssertionLevel  . .  . . . . . . . . . . . .  copy of GAP variable
 **
 **
-**  TLS(IntrIgnoring) is increased by (a total of) 2 if an assertion either is not
+**  STATE(IntrIgnoring) is increased by (a total of) 2 if an assertion either is not
 **  tested (because we were Ignoring when we got to it, or due to level)
 **  or is tested and passes
 */
@@ -4679,9 +4679,9 @@ Obj              CurrentAssertionLevel;
 void              IntrAssertBegin ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssertBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssertBegin(); return; }
 
 }
 
@@ -4691,15 +4691,15 @@ void             IntrAssertAfterLevel ( void )
   Obj level;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssertAfterLevel(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssertAfterLevel(); return; }
 
 
     level = PopObj();
 
     if (LT( CurrentAssertionLevel, level))
-           TLS(IntrIgnoring) = 1;
+           STATE(IntrIgnoring) = 1;
 }
 
 void             IntrAssertAfterCondition ( void )
@@ -4707,15 +4707,15 @@ void             IntrAssertAfterCondition ( void )
   Obj condition;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssertAfterCondition(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssertAfterCondition(); return; }
 
 
     condition = PopObj();
 
     if (condition == True)
-      TLS(IntrIgnoring)= 2;
+      STATE(IntrIgnoring)= 2;
     else if (condition != False)
         ErrorQuit(
             "<condition> in Assert must yield 'true' or 'false' (not a %s)",
@@ -4725,16 +4725,16 @@ void             IntrAssertAfterCondition ( void )
 void             IntrAssertEnd2Args ( void )
 {
       /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssertEnd2Args(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssertEnd2Args(); return; }
 
 
-    if ( TLS(IntrIgnoring)  == 0 )
+    if ( STATE(IntrIgnoring)  == 0 )
       ErrorQuit("Assertion Failure", 0, 0);
     else
-      TLS(IntrIgnoring) -= 2;
+      STATE(IntrIgnoring) -= 2;
 
-    if (TLS(IntrIgnoring) == 0)
+    if (STATE(IntrIgnoring) == 0)
       PushVoidObj();
     return;
 }
@@ -4744,11 +4744,11 @@ void             IntrAssertEnd3Args ( void )
 {
   Obj message;
   /* ignore or code                                                      */
-  if ( TLS(IntrReturning) > 0 ) { return; }
-  if ( TLS(IntrCoding)    > 0 ) { CodeAssertEnd3Args(); return; }
+  if ( STATE(IntrReturning) > 0 ) { return; }
+  if ( STATE(IntrCoding)    > 0 ) { CodeAssertEnd3Args(); return; }
 
 
-  if ( TLS(IntrIgnoring)  == 0 ) {
+  if ( STATE(IntrIgnoring)  == 0 ) {
       message = PopVoidObj();
       if (message != (Obj) 0 ) {
           if (IS_STRING_REP( message ))
@@ -4757,9 +4757,9 @@ void             IntrAssertEnd3Args ( void )
             PrintObj(message);
       }
   } else
-      TLS(IntrIgnoring) -= 2;
+      STATE(IntrIgnoring) -= 2;
 
-  if (TLS(IntrIgnoring) == 0)
+  if (STATE(IntrIgnoring) == 0)
       PushVoidObj();
   return;
 }

--- a/hpcgap/src/intrprtr.h
+++ b/hpcgap/src/intrprtr.h
@@ -72,7 +72,7 @@
 *F  IntrEnd(<error>)  . . . . . . . . . . . . . . . . . . stop an interpreter
 **
 **  'IntrBegin( <frame> )' starts a new interpreter in context <frame>
-**  if in doubt, pass TLS(BottomLVars) as <frame>
+**  if in doubt, pass STATE(BottomLVars) as <frame>
 **
 **  'IntrEnd(<error>)' stops the current interpreter.
 **

--- a/hpcgap/src/lists.c
+++ b/hpcgap/src/lists.c
@@ -2130,14 +2130,14 @@ void            PrintListDefault (
     }
 
     Pr("%2>[ %2>",0L,0L);
-    for ( TLS(PrintObjIndex)=1; TLS(PrintObjIndex)<=LEN_LIST(list); TLS(PrintObjIndex)++ ) {
-        elm = ELMV0_LIST( list, TLS(PrintObjIndex) );
+    for ( STATE(PrintObjIndex)=1; STATE(PrintObjIndex)<=LEN_LIST(list); STATE(PrintObjIndex)++ ) {
+        elm = ELMV0_LIST( list, STATE(PrintObjIndex) );
         if ( elm != 0 ) {
-            if ( 1 < TLS(PrintObjIndex) )  Pr( "%<,%< %2>", 0L, 0L );
+            if ( 1 < STATE(PrintObjIndex) )  Pr( "%<,%< %2>", 0L, 0L );
             PrintObj( elm );
         }
         else {
-            if ( 1 < TLS(PrintObjIndex) )  Pr( "%2<,%2>", 0L, 0L );
+            if ( 1 < STATE(PrintObjIndex) )  Pr( "%2<,%2>", 0L, 0L );
         }
     }
     Pr(" %4<]",0L,0L);

--- a/hpcgap/src/objscoll-impl.h
+++ b/hpcgap/src/objscoll-impl.h
@@ -120,7 +120,7 @@ Int VectorWord ( Obj vv, Obj v, Int num )
 */
 #define SC_PUSH_WORD( word, exp ) \
     if ( ++sp == max ) { \
-        TLS(SC_MAX_STACK_SIZE) *= 2; \
+        STATE(SC_MAX_STACK_SIZE) *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(word); \
@@ -257,22 +257,22 @@ Int SingleCollectWord ( Obj sc, Obj vv, Obj w )
     exps = 1UL << (ebits-1);
 
     /* <nw> contains the stack of words to insert                          */
-    vnw = TLS(SC_NW_STACK);
+    vnw = STATE(SC_NW_STACK);
 
     /* <lw> contains the word end of the word in <nw>                      */
-    vlw = TLS(SC_LW_STACK);
+    vlw = STATE(SC_LW_STACK);
 
     /* <pw> contains the position of the word in <nw> to look at           */
-    vpw = TLS(SC_PW_STACK);
+    vpw = STATE(SC_PW_STACK);
 
     /* <ew> contains the unprocessed exponents at position <pw>            */
-    vew = TLS(SC_EW_STACK);
+    vew = STATE(SC_EW_STACK);
 
     /* <ge> contains the global exponent of the word                       */
-    vge = TLS(SC_GE_STACK);
+    vge = STATE(SC_GE_STACK);
 
     /* get the maximal stack size                                          */
-    max = TLS(SC_MAX_STACK_SIZE);
+    max = STATE(SC_MAX_STACK_SIZE);
 
     /* ensure that the stacks are large enough                             */
     if ( SIZE_OBJ(vnw)/sizeof(Obj) < max+1 ) {

--- a/hpcgap/src/opers.c
+++ b/hpcgap/src/opers.c
@@ -1797,29 +1797,29 @@ static inline Obj CacheOper (
     }
     else
       cacheIndex = INT_INTOBJ(cache);
-    if (cacheIndex > TLS(MethodCacheSize))
+    if (cacheIndex > STATE(MethodCacheSize))
     {
-      UInt len = TLS(MethodCacheSize);
+      UInt len = STATE(MethodCacheSize);
       while (cacheIndex > len)
 	len *= 2;
-      GROW_PLIST(TLS(MethodCache), len);
-      SET_LEN_PLIST(TLS(MethodCache), len);
-      TLS(MethodCacheItems) = ADDR_OBJ(TLS(MethodCache));
-      TLS(MethodCacheSize) = len;
+      GROW_PLIST(STATE(MethodCache), len);
+      SET_LEN_PLIST(STATE(MethodCache), len);
+      STATE(MethodCacheItems) = ADDR_OBJ(STATE(MethodCache));
+      STATE(MethodCacheSize) = len;
     }
-    cache = ELM_PLIST(TLS(MethodCache), cacheIndex);
+    cache = ELM_PLIST(STATE(MethodCache), cacheIndex);
     if ( cache == 0 ) {
         len = (i < 7 ? CACHE_SIZE * (i+2) : CACHE_SIZE * (1+2));
         cache = NEW_PLIST( T_PLIST, len);
         SET_LEN_PLIST( cache, len ); 
-        SET_ELM_PLIST( TLS(MethodCache), cacheIndex, cache );
-        CHANGED_BAG( TLS(MethodCache) );
+        SET_ELM_PLIST( STATE(MethodCache), cacheIndex, cache );
+        CHANGED_BAG( STATE(MethodCache) );
     }
     return cache;
 }
 
 #define GET_METHOD_CACHE( oper, i ) \
-  ( TLS(MethodCacheItems)[INT_INTOBJ( CACHE_OPER ( oper, i ))] )
+  ( STATE(MethodCacheItems)[INT_INTOBJ( CACHE_OPER ( oper, i ))] )
 
 Obj DoOperation0Args (
     Obj                 oper )
@@ -1874,9 +1874,9 @@ Obj DoOperation0Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 0 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[2*TLS(CacheIndex)] = method;
-              cache[2*TLS(CacheIndex)+1] = prec;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[2*STATE(CacheIndex)] = method;
+              cache[2*STATE(CacheIndex)+1] = prec;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -1964,10 +1964,10 @@ Obj DoOperation1Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 1 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[3*TLS(CacheIndex)] = method;
-              cache[3*TLS(CacheIndex)+1] = prec;
-              cache[3*TLS(CacheIndex)+2] = id1;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[3*STATE(CacheIndex)] = method;
+              cache[3*STATE(CacheIndex)+1] = prec;
+              cache[3*STATE(CacheIndex)+2] = id1;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -2063,11 +2063,11 @@ Obj DoOperation2Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 2 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[4*TLS(CacheIndex)] = method;
-              cache[4*TLS(CacheIndex)+1] = prec;
-              cache[4*TLS(CacheIndex)+2] = id1;
-              cache[4*TLS(CacheIndex)+3] = id2;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[4*STATE(CacheIndex)] = method;
+              cache[4*STATE(CacheIndex)+1] = prec;
+              cache[4*STATE(CacheIndex)+2] = id1;
+              cache[4*STATE(CacheIndex)+3] = id2;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -2168,12 +2168,12 @@ Obj DoOperation3Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 3 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[5*TLS(CacheIndex)] = method;
-              cache[5*TLS(CacheIndex)+1] = prec;
-              cache[5*TLS(CacheIndex)+2] = id1;
-              cache[5*TLS(CacheIndex)+3] = id2;
-              cache[5*TLS(CacheIndex)+4] = id3;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[5*STATE(CacheIndex)] = method;
+              cache[5*STATE(CacheIndex)+1] = prec;
+              cache[5*STATE(CacheIndex)+2] = id1;
+              cache[5*STATE(CacheIndex)+3] = id2;
+              cache[5*STATE(CacheIndex)+4] = id3;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -2282,13 +2282,13 @@ Obj DoOperation4Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 4 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[6*TLS(CacheIndex)] = method;
-              cache[6*TLS(CacheIndex)+1] = prec;
-              cache[6*TLS(CacheIndex)+2] = id1;
-              cache[6*TLS(CacheIndex)+3] = id2;
-              cache[6*TLS(CacheIndex)+4] = id3;
-              cache[6*TLS(CacheIndex)+5] = id4;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[6*STATE(CacheIndex)] = method;
+              cache[6*STATE(CacheIndex)+1] = prec;
+              cache[6*STATE(CacheIndex)+2] = id1;
+              cache[6*STATE(CacheIndex)+3] = id2;
+              cache[6*STATE(CacheIndex)+4] = id3;
+              cache[6*STATE(CacheIndex)+5] = id4;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -2417,14 +2417,14 @@ Obj DoOperation5Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 5 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[7*TLS(CacheIndex)] = method;
-              cache[7*TLS(CacheIndex)+1] = prec;
-              cache[7*TLS(CacheIndex)+2] = id1;
-              cache[7*TLS(CacheIndex)+3] = id2;
-              cache[7*TLS(CacheIndex)+4] = id3;
-              cache[7*TLS(CacheIndex)+5] = id4;
-              cache[7*TLS(CacheIndex)+6] = id5;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[7*STATE(CacheIndex)] = method;
+              cache[7*STATE(CacheIndex)+1] = prec;
+              cache[7*STATE(CacheIndex)+2] = id1;
+              cache[7*STATE(CacheIndex)+3] = id2;
+              cache[7*STATE(CacheIndex)+4] = id3;
+              cache[7*STATE(CacheIndex)+5] = id4;
+              cache[7*STATE(CacheIndex)+6] = id5;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -2573,15 +2573,15 @@ Obj DoOperation6Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 6 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[8*TLS(CacheIndex)] = method;
-              cache[8*TLS(CacheIndex)+1] = prec;
-              cache[8*TLS(CacheIndex)+2] = id1;
-              cache[8*TLS(CacheIndex)+3] = id2;
-              cache[8*TLS(CacheIndex)+4] = id3;
-              cache[8*TLS(CacheIndex)+5] = id4;
-              cache[8*TLS(CacheIndex)+6] = id5;
-              cache[8*TLS(CacheIndex)+7] = id6;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[8*STATE(CacheIndex)] = method;
+              cache[8*STATE(CacheIndex)+1] = prec;
+              cache[8*STATE(CacheIndex)+2] = id1;
+              cache[8*STATE(CacheIndex)+3] = id2;
+              cache[8*STATE(CacheIndex)+4] = id3;
+              cache[8*STATE(CacheIndex)+5] = id4;
+              cache[8*STATE(CacheIndex)+6] = id5;
+              cache[8*STATE(CacheIndex)+7] = id6;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3279,9 +3279,9 @@ Obj DoConstructor0Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 0 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[2*TLS(CacheIndex)] = method;
-              cache[2*TLS(CacheIndex)+1] = prec;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[2*STATE(CacheIndex)] = method;
+              cache[2*STATE(CacheIndex)+1] = prec;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3373,10 +3373,10 @@ Obj DoConstructor1Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 1 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[3*TLS(CacheIndex)] = method;
-              cache[3*TLS(CacheIndex)+1] = prec;
-              cache[3*TLS(CacheIndex)+2] = type1;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[3*STATE(CacheIndex)] = method;
+              cache[3*STATE(CacheIndex)+1] = prec;
+              cache[3*STATE(CacheIndex)+2] = type1;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3473,11 +3473,11 @@ Obj DoConstructor2Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 2 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[4*TLS(CacheIndex)] = method;
-              cache[4*TLS(CacheIndex)+1] = prec;
-              cache[4*TLS(CacheIndex)+2] = type1;
-              cache[4*TLS(CacheIndex)+3] = id2;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[4*STATE(CacheIndex)] = method;
+              cache[4*STATE(CacheIndex)+1] = prec;
+              cache[4*STATE(CacheIndex)+2] = type1;
+              cache[4*STATE(CacheIndex)+3] = id2;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3582,12 +3582,12 @@ Obj DoConstructor3Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 3 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[5*TLS(CacheIndex)] = method;
-              cache[5*TLS(CacheIndex)+1] = prec;
-              cache[5*TLS(CacheIndex)+2] = type1;
-              cache[5*TLS(CacheIndex)+3] = id2;
-              cache[5*TLS(CacheIndex)+4] = id3;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[5*STATE(CacheIndex)] = method;
+              cache[5*STATE(CacheIndex)+1] = prec;
+              cache[5*STATE(CacheIndex)+2] = type1;
+              cache[5*STATE(CacheIndex)+3] = id2;
+              cache[5*STATE(CacheIndex)+4] = id3;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3699,13 +3699,13 @@ Obj DoConstructor4Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 4 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[6*TLS(CacheIndex)] = method;
-              cache[6*TLS(CacheIndex)+1] = prec;
-              cache[6*TLS(CacheIndex)+2] = type1;
-              cache[6*TLS(CacheIndex)+3] = id2;
-              cache[6*TLS(CacheIndex)+4] = id3;
-              cache[6*TLS(CacheIndex)+5] = id4;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[6*STATE(CacheIndex)] = method;
+              cache[6*STATE(CacheIndex)+1] = prec;
+              cache[6*STATE(CacheIndex)+2] = type1;
+              cache[6*STATE(CacheIndex)+3] = id2;
+              cache[6*STATE(CacheIndex)+4] = id3;
+              cache[6*STATE(CacheIndex)+5] = id4;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3836,14 +3836,14 @@ Obj DoConstructor5Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 5 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[7*TLS(CacheIndex)] = method;
-              cache[7*TLS(CacheIndex)+1] = prec;
-              cache[7*TLS(CacheIndex)+2] = type1;
-              cache[7*TLS(CacheIndex)+3] = id2;
-              cache[7*TLS(CacheIndex)+4] = id3;
-              cache[7*TLS(CacheIndex)+5] = id4;
-              cache[7*TLS(CacheIndex)+6] = id5;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[7*STATE(CacheIndex)] = method;
+              cache[7*STATE(CacheIndex)+1] = prec;
+              cache[7*STATE(CacheIndex)+2] = type1;
+              cache[7*STATE(CacheIndex)+3] = id2;
+              cache[7*STATE(CacheIndex)+4] = id3;
+              cache[7*STATE(CacheIndex)+5] = id4;
+              cache[7*STATE(CacheIndex)+6] = id5;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3994,15 +3994,15 @@ Obj DoConstructor6Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 6 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[8*TLS(CacheIndex)] = method;
-              cache[8*TLS(CacheIndex)+1] = prec;
-              cache[8*TLS(CacheIndex)+2] = type1;
-              cache[8*TLS(CacheIndex)+3] = id2;
-              cache[8*TLS(CacheIndex)+4] = id3;
-              cache[8*TLS(CacheIndex)+5] = id4;
-              cache[8*TLS(CacheIndex)+6] = id5;
-              cache[8*TLS(CacheIndex)+7] = id6;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[8*STATE(CacheIndex)] = method;
+              cache[8*STATE(CacheIndex)+1] = prec;
+              cache[8*STATE(CacheIndex)+2] = type1;
+              cache[8*STATE(CacheIndex)+3] = id2;
+              cache[8*STATE(CacheIndex)+4] = id3;
+              cache[8*STATE(CacheIndex)+5] = id4;
+              cache[8*STATE(CacheIndex)+6] = id5;
+              cache[8*STATE(CacheIndex)+7] = id6;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -6590,10 +6590,10 @@ StructInitInfo * InitInfoOpers ( void )
 
 void InitOpersTLS()
 {
-  TLS(MethodCache) = NEW_PLIST(T_PLIST, 1);
-  TLS(MethodCacheItems) = ADDR_OBJ(TLS(MethodCache));
-  TLS(MethodCacheSize) = 1;
-  SET_LEN_PLIST(TLS(MethodCache), 1);
+  STATE(MethodCache) = NEW_PLIST(T_PLIST, 1);
+  STATE(MethodCacheItems) = ADDR_OBJ(STATE(MethodCache));
+  STATE(MethodCacheSize) = 1;
+  SET_LEN_PLIST(STATE(MethodCache), 1);
 }
 
 void DestroyOpersTLS()

--- a/hpcgap/src/opers.c
+++ b/hpcgap/src/opers.c
@@ -6582,23 +6582,16 @@ StructInitInfo * InitInfoOpers ( void )
     return &module;
 }
 
-/****************************************************************************
-**
-*F  InitOpersTLS() . . . . . . . . . . . . . . . . . . . . . . initialize TLS
-*F  DestroyOpersTLS()  . . . . . . . . . . . . . . . . . . . . .  destroy TLS
-*/
-
-void InitOpersTLS()
+void InitOpersState(GAPState * state)
 {
-  STATE(MethodCache) = NEW_PLIST(T_PLIST, 1);
-  STATE(MethodCacheItems) = ADDR_OBJ(STATE(MethodCache));
-  STATE(MethodCacheSize) = 1;
-  SET_LEN_PLIST(STATE(MethodCache), 1);
+    state->MethodCache = NEW_PLIST(T_PLIST, 1);
+    state->MethodCacheItems = ADDR_OBJ(state->MethodCache);
+    state->MethodCacheSize = 1;
+    SET_LEN_PLIST(state->MethodCache, 1);
 }
 
-void DestroyOpersTLS()
+void DestroyOpersState(GAPState * state)
 {
-  /* Nothing for now. */
 }
 
 

--- a/hpcgap/src/plist.c
+++ b/hpcgap/src/plist.c
@@ -1035,13 +1035,13 @@ Int             EqPlist (
         elmL = ELM_PLIST( left, i );
         elmR = ELM_PLIST( right, i );
         if ( ( (elmL == 0 ) != (elmR == 0) ) || ! EQ( elmL, elmR ) ) {
-            TLS(RecursionDepth)--;
+            STATE(RecursionDepth)--;
             return 0L;
         }
     }
 
     /* no differences found, the lists are equal                           */
-    TLS(RecursionDepth)--;
+    STATE(RecursionDepth)--;
     return 1L;
 }
 
@@ -1092,7 +1092,7 @@ Int             LtPlist (
     }
 
     /* reached the end of at least one list                                */
-    TLS(RecursionDepth)--;
+    STATE(RecursionDepth)--;
     return res;
 }
 

--- a/hpcgap/src/precord.c
+++ b/hpcgap/src/precord.c
@@ -809,19 +809,19 @@ Obj FuncEQ_PREC (
 
         /* compare the names                                               */
         if ( GET_RNAM_PREC(left,i) != GET_RNAM_PREC(right,i) ) {
-            TLS(RecursionDepth)--;
+            STATE(RecursionDepth)--;
             return False;
         }
 
         /* compare the values                                              */
         if ( ! EQ(GET_ELM_PREC(left,i),GET_ELM_PREC(right,i)) ) {
-            TLS(RecursionDepth)--;
+            STATE(RecursionDepth)--;
             return False;
         }
     }
 
     /* the records are equal                                               */
-    TLS(RecursionDepth)--;
+    STATE(RecursionDepth)--;
     return True;
 }
 
@@ -882,7 +882,7 @@ Obj FuncLT_PREC (
     }
 
     /* the records are equal or the right is a prefix of the left          */
-    TLS(RecursionDepth)--;
+    STATE(RecursionDepth)--;
     return res ? True : False;
 }
 

--- a/hpcgap/src/read.c
+++ b/hpcgap/src/read.c
@@ -123,25 +123,25 @@ void ReadAtom (
 
 void PushGlobalForLoopVariable( UInt var)
 {
-  if (TLS(CurrentGlobalForLoopDepth) < 100)
-    TLS(CurrentGlobalForLoopVariables)[TLS(CurrentGlobalForLoopDepth)] = var;
-  TLS(CurrentGlobalForLoopDepth)++;
+  if (STATE(CurrentGlobalForLoopDepth) < 100)
+    STATE(CurrentGlobalForLoopVariables)[STATE(CurrentGlobalForLoopDepth)] = var;
+  STATE(CurrentGlobalForLoopDepth)++;
 }
 
 void PopGlobalForLoopVariable( void )
 {
-  assert(TLS(CurrentGlobalForLoopDepth));
-  TLS(CurrentGlobalForLoopDepth)--;
+  assert(STATE(CurrentGlobalForLoopDepth));
+  STATE(CurrentGlobalForLoopDepth)--;
 }
 
 UInt GlobalComesFromEnclosingForLoop (UInt var)
 {
   UInt i;
-  for (i = 0; i < TLS(CurrentGlobalForLoopDepth); i++)
+  for (i = 0; i < STATE(CurrentGlobalForLoopDepth); i++)
     {
       if (i==100)
 	return 0;
-      if (TLS(CurrentGlobalForLoopVariables)[i] == var)
+      if (STATE(CurrentGlobalForLoopVariables)[i] == var)
 	return 1;
     }
   return 0;
@@ -191,12 +191,12 @@ extern Obj ExprGVars[GVAR_BUCKETS];
 void ReadFuncCallOption( TypSymbolSet follow )
 {
   volatile UInt       rnam;           /* record component name           */
-  if ( TLS(Symbol) == S_IDENT ) {
-    rnam = RNamName( TLS(Value) );
+  if ( STATE(Symbol) == S_IDENT ) {
+    rnam = RNamName( STATE(Value) );
     Match( S_IDENT, "identifier", S_COMMA | follow );
     TRY_READ { IntrFuncCallOptionsBeginElmName( rnam ); }
   }
-  else if ( TLS(Symbol) == S_LPAREN ) {
+  else if ( STATE(Symbol) == S_LPAREN ) {
     Match( S_LPAREN, "(", S_COMMA | follow );
     ReadExpr( follow, 'r' );
     Match( S_RPAREN, ")", S_COMMA | follow );
@@ -205,7 +205,7 @@ void ReadFuncCallOption( TypSymbolSet follow )
   else {
     SyntaxError("Identifier expected");
   }
-  if ( TLS(Symbol) == S_ASSIGN )
+  if ( STATE(Symbol) == S_ASSIGN )
     {
       Match( S_ASSIGN, ":=", S_COMMA | follow );
       ReadExpr( S_COMMA | S_RPAREN|follow, 'r' );
@@ -224,7 +224,7 @@ void ReadFuncCallOptions( TypSymbolSet follow )
   TRY_READ { IntrFuncCallOptionsBegin( ); }
   ReadFuncCallOption( follow);
   nr = 1;
-  while ( TLS(Symbol) == S_COMMA )
+  while ( STATE(Symbol) == S_COMMA )
     {
       Match(S_COMMA, ",", follow );
       ReadFuncCallOption( follow );
@@ -249,13 +249,13 @@ void ReadReferenceModifiers( TypSymbolSet follow )
     UInt narg = 0;
     UInt rnam  = 0;
     /* followed by one or more selectors                                   */
-    while ( IS_IN( TLS(Symbol), S_LPAREN|S_LBRACK|S_LBRACE|S_DOT ) ) {
+    while ( IS_IN( STATE(Symbol), S_LPAREN|S_LBRACK|S_LBRACE|S_DOT ) ) {
         /* <Var> '[' <Expr> ']'  list selector                             */
-        if ( TLS(Symbol) == S_LBRACK ) {
+        if ( STATE(Symbol) == S_LBRACK ) {
             Match( S_LBRACK, "[", follow );
             ReadExpr( S_COMMA|S_RBRACK|follow, 'r' );
             narg = 1;
-            while ( TLS(Symbol) == S_COMMA) {
+            while ( STATE(Symbol) == S_COMMA) {
               Match(S_COMMA,",", follow|S_RBRACK);
               ReadExpr(S_COMMA|S_RBRACK|follow, 'r' );
               narg++;
@@ -265,7 +265,7 @@ void ReadReferenceModifiers( TypSymbolSet follow )
         }
 
         /* <Var> '{' <Expr> '}'  sublist selector                          */
-        else if ( TLS(Symbol) == S_LBRACE ) {
+        else if ( STATE(Symbol) == S_LBRACE ) {
             Match( S_LBRACE, "{", follow );
             ReadExpr( S_RBRACE|follow, 'r' );
             Match( S_RBRACE, "}", follow );
@@ -273,7 +273,7 @@ void ReadReferenceModifiers( TypSymbolSet follow )
         }
 
         /* <Var> '![' <Expr> ']'  list selector                            */
-        else if ( TLS(Symbol) == S_BLBRACK ) {
+        else if ( STATE(Symbol) == S_BLBRACK ) {
             Match( S_BLBRACK, "![", follow );
             ReadExpr( S_RBRACK|follow, 'r' );
             Match( S_RBRACK, "]", follow );
@@ -281,7 +281,7 @@ void ReadReferenceModifiers( TypSymbolSet follow )
         }
 
         /* <Var> '!{' <Expr> '}'  sublist selector                         */
-        else if ( TLS(Symbol) == S_BLBRACE ) {
+        else if ( STATE(Symbol) == S_BLBRACE ) {
             Match( S_BLBRACE, "!{", follow );
             ReadExpr( S_RBRACE|follow, 'r' );
             Match( S_RBRACE, "}", follow );
@@ -289,14 +289,14 @@ void ReadReferenceModifiers( TypSymbolSet follow )
         }
 
         /* <Var> '.' <Ident>  record selector                              */
-        else if ( TLS(Symbol) == S_DOT ) {
+        else if ( STATE(Symbol) == S_DOT ) {
             Match( S_DOT, ".", follow );
-            if ( TLS(Symbol) == S_IDENT || TLS(Symbol) == S_INT ) {
-                rnam = RNamName( TLS(Value) );
-                Match( TLS(Symbol), "identifier", follow );
+            if ( STATE(Symbol) == S_IDENT || STATE(Symbol) == S_INT ) {
+                rnam = RNamName( STATE(Value) );
+                Match( STATE(Symbol), "identifier", follow );
                 type = '.';
             }
-            else if ( TLS(Symbol) == S_LPAREN ) {
+            else if ( STATE(Symbol) == S_LPAREN ) {
                 Match( S_LPAREN, "(", follow );
                 ReadExpr( S_RPAREN|follow, 'r' );
                 Match( S_RPAREN, ")", follow );
@@ -309,14 +309,14 @@ void ReadReferenceModifiers( TypSymbolSet follow )
         }
 
         /* <Var> '!.' <Ident>  record selector                             */
-        else if ( TLS(Symbol) == S_BDOT ) {
+        else if ( STATE(Symbol) == S_BDOT ) {
             Match( S_BDOT, "!.", follow );
-            if ( TLS(Symbol) == S_IDENT || TLS(Symbol) == S_INT ) {
-                rnam = RNamName( TLS(Value) );
-                Match( TLS(Symbol), "identifier", follow );
+            if ( STATE(Symbol) == S_IDENT || STATE(Symbol) == S_INT ) {
+                rnam = RNamName( STATE(Value) );
+                Match( STATE(Symbol), "identifier", follow );
                 type = '!';
             }
-            else if ( TLS(Symbol) == S_LPAREN ) {
+            else if ( STATE(Symbol) == S_LPAREN ) {
                 Match( S_LPAREN, "(", follow );
                 ReadExpr( S_RPAREN|follow, 'r' );
                 Match( S_RPAREN, ")", follow );
@@ -329,23 +329,23 @@ void ReadReferenceModifiers( TypSymbolSet follow )
         }
 
         /* <Var> '(' [ <Expr> { ',' <Expr> } ] ')'  function call          */
-        else if ( TLS(Symbol) == S_LPAREN ) {
+        else if ( STATE(Symbol) == S_LPAREN ) {
             Match( S_LPAREN, "(", follow );
             TRY_READ { IntrFuncCallBegin(); }
             narg = 0;
-            if ( TLS(Symbol) != S_RPAREN && TLS(Symbol) != S_COLON) {
+            if ( STATE(Symbol) != S_RPAREN && STATE(Symbol) != S_COLON) {
                 ReadExpr( S_RPAREN|follow, 'r' );
                 narg++;
             }
-            while ( TLS(Symbol) == S_COMMA ) {
+            while ( STATE(Symbol) == S_COMMA ) {
                 Match( S_COMMA, ",", follow );
                 ReadExpr( S_RPAREN|follow, 'r' );
                 narg++;
             }
             type = 'c';
-            if (TLS(Symbol) == S_COLON ) {
+            if (STATE(Symbol) == S_COLON ) {
               Match( S_COLON, ":", follow );
-              if ( TLS(Symbol) != S_RPAREN ) /* save work for empty options */
+              if ( STATE(Symbol) != S_RPAREN ) /* save work for empty options */
                 {
                   ReadFuncCallOptions(S_RPAREN | follow);
                   type = 'C';
@@ -394,17 +394,17 @@ void ReadCallVarAss (
     Char                varname[MAX_VALUE_LEN]; /* copy of variable name   */
 
     /* all variables must begin with an identifier                         */
-    if ( TLS(Symbol) != S_IDENT ) {
+    if ( STATE(Symbol) != S_IDENT ) {
         SyntaxError( "Identifier expected" );
         return;
     }
 
     /* try to look up the variable on the stack of local variables         */
     nest = 0;
-    while ( type == ' ' && nest < TLS(CountNams) ) {
-        nams = ELM_LIST( TLS(StackNams), TLS(CountNams)-nest );
+    while ( type == ' ' && nest < STATE(CountNams) ) {
+        nams = ELM_LIST( STATE(StackNams), STATE(CountNams)-nest );
         for ( indx = LEN_LIST( nams ); 1 <= indx; indx-- ) {
-            if ( strcmp( TLS(Value), CSTR_STRING(ELM_LIST(nams,indx)) ) == 0 ) {
+            if ( strcmp( STATE(Value), CSTR_STRING(ELM_LIST(nams,indx)) ) == 0 ) {
                 if ( nest == 0 ) {
                     type = 'l';
                     var = indx;
@@ -424,12 +424,12 @@ void ReadCallVarAss (
     /* try to look up the variable on the error stack                      */
     /* the outer loop runs up the calling stack, while the inner loop runs
        up the static definition stack for each call function */
-    lvars0 = TLS(ErrorLVars);
+    lvars0 = STATE(ErrorLVars);
     nest0 = 0;
-    while ( type == ' ' && lvars0 != 0 && lvars0 != TLS(BottomLVars)) {
+    while ( type == ' ' && lvars0 != 0 && lvars0 != STATE(BottomLVars)) {
       lvars = lvars0;
       nest = 0;
-      while ( type == ' ' && lvars != 0 && lvars != TLS(BottomLVars) ) {
+      while ( type == ' ' && lvars != 0 && lvars != STATE(BottomLVars) ) {
 	nams = NAMS_FUNC(PTR_BAG(lvars)[0]);
 	if (nams != (Obj) 0)
 	  {
@@ -437,12 +437,12 @@ void ReadCallVarAss (
 	    if (indx >= 1024)
 	      {
 		Pr("Warning; Ignoring local names after 1024th in search for %s\n",
-		   (Int) TLS(Value),
+		   (Int) STATE(Value),
 		   0L);
 		indx = 1023;
 	      }
 	    for ( ; 1 <= indx; indx-- ) {
-	      if ( strcmp( TLS(Value), CSTR_STRING(ELM_LIST(nams,indx)) ) == 0 ) {
+	      if ( strcmp( STATE(Value), CSTR_STRING(ELM_LIST(nams,indx)) ) == 0 ) {
 		type = 'd';
 
 		/* Ultrix 4.2 cc get's confused if the UInt is missing     */
@@ -456,7 +456,7 @@ void ReadCallVarAss (
 	if (nest >= 65536)
 	  {
 	    Pr("Warning: abandoning search for %s at 65536th higher frame\n",
-	       (Int)TLS(Value),0L);
+	       (Int)STATE(Value),0L);
 	    break;
 	  }
       }
@@ -465,7 +465,7 @@ void ReadCallVarAss (
 	if (nest0 >= 65536)
 	  {
 	    Pr("Warning: abandoning search for %s 65536 frames up stack\n",
-	       (Int)TLS(Value),0L);
+	       (Int)STATE(Value),0L);
 	    break;
 	  }
     }
@@ -475,7 +475,7 @@ void ReadCallVarAss (
         type = 'g';
         /* we do not want to call GVarName on this value until after we
          * have checked if this is the argument to a lambda function       */
-        strlcpy(varname, TLS(Value), sizeof(varname));
+        strlcpy(varname, STATE(Value), sizeof(varname));
     }
 
     /* match away the identifier, now that we know the variable            */
@@ -483,7 +483,7 @@ void ReadCallVarAss (
 
     /* if this was actually the beginning of a function literal            */
     /* then we are in the wrong function                                   */
-    if ( TLS(Symbol) == S_MAPTO ) {
+    if ( STATE(Symbol) == S_MAPTO ) {
       if (mode == 'r' || mode == 'x')
 	{
 	  ReadFuncExpr1( follow );
@@ -504,12 +504,12 @@ void ReadCallVarAss (
       WarnOnUnboundGlobalsRNam = RNamName("WarnOnUnboundGlobals");
 
     if ( type == 'g'
-      && TLS(CountNams) != 0
-      && var != TLS(CurrLHSGVar)
+      && STATE(CountNams) != 0
+      && var != STATE(CurrLHSGVar)
       && var != Tilde
       && VAL_GVAR(var) == 0
       && ELM_PLIST(ExprGVars[GVAR_BUCKET(var)], GVAR_INDEX(var)) == 0
-      && ! TLS(IntrIgnoring)
+      && ! STATE(IntrIgnoring)
       && ! GlobalComesFromEnclosingForLoop(var)
       && (GAPInfo == 0 || !IS_REC(GAPInfo) || !ISB_REC(GAPInfo,WarnOnUnboundGlobalsRNam) ||
              ELM_REC(GAPInfo,WarnOnUnboundGlobalsRNam) != False )
@@ -519,10 +519,10 @@ void ReadCallVarAss (
     }
 
     /* check whether this is a reference to the global variable '~'        */
-    if ( type == 'g' && var == Tilde ) { TLS(ReadTilde) = 1; }
+    if ( type == 'g' && var == Tilde ) { STATE(ReadTilde) = 1; }
 
     /* followed by one or more selectors                                   */
-    while ( IS_IN( TLS(Symbol), S_LPAREN|S_LBRACK|S_LBRACE|S_DOT ) ) {
+    while ( IS_IN( STATE(Symbol), S_LPAREN|S_LBRACK|S_LBRACE|S_DOT ) ) {
 
         /* so the prefix was a reference                                   */
         TRY_READ {
@@ -546,11 +546,11 @@ void ReadCallVarAss (
 	  { IntrFuncCallEnd( 1UL, type == 'C', narg ); level=0; }
         } /* end TRY_READ */
         /* <Var> '[' <Expr> ']'  list selector                             */
-        if ( TLS(Symbol) == S_LBRACK ) {
+        if ( STATE(Symbol) == S_LBRACK ) {
             Match( S_LBRACK, "[", follow );
 	    ReadExpr( S_COMMA|S_RBRACK|follow, 'r' );
 	    narg = 1;
-	    while ( TLS(Symbol) == S_COMMA) {
+	    while ( STATE(Symbol) == S_COMMA) {
 	      Match(S_COMMA,",", follow|S_RBRACK);
 	      ReadExpr(S_COMMA|S_RBRACK|follow, 'r' );
 	      narg++;
@@ -560,7 +560,7 @@ void ReadCallVarAss (
         }
 
         /* <Var> '{' <Expr> '}'  sublist selector                          */
-        else if ( TLS(Symbol) == S_LBRACE ) {
+        else if ( STATE(Symbol) == S_LBRACE ) {
             Match( S_LBRACE, "{", follow );
             ReadExpr( S_RBRACE|follow, 'r' );
             Match( S_RBRACE, "}", follow );
@@ -568,7 +568,7 @@ void ReadCallVarAss (
         }
 
         /* <Var> '![' <Expr> ']'  list selector                            */
-        else if ( TLS(Symbol) == S_BLBRACK ) {
+        else if ( STATE(Symbol) == S_BLBRACK ) {
             Match( S_BLBRACK, "![", follow );
             ReadExpr( S_RBRACK|follow, 'r' );
             Match( S_RBRACK, "]", follow );
@@ -576,7 +576,7 @@ void ReadCallVarAss (
         }
 
         /* <Var> '!{' <Expr> '}'  sublist selector                         */
-        else if ( TLS(Symbol) == S_BLBRACE ) {
+        else if ( STATE(Symbol) == S_BLBRACE ) {
             Match( S_BLBRACE, "!{", follow );
             ReadExpr( S_RBRACE|follow, 'r' );
             Match( S_RBRACE, "}", follow );
@@ -584,14 +584,14 @@ void ReadCallVarAss (
         }
 
         /* <Var> '.' <Ident>  record selector                              */
-        else if ( TLS(Symbol) == S_DOT ) {
+        else if ( STATE(Symbol) == S_DOT ) {
             Match( S_DOT, ".", follow );
-            if ( TLS(Symbol) == S_IDENT || TLS(Symbol) == S_INT ) {
-                rnam = RNamName( TLS(Value) );
-                Match( TLS(Symbol), "identifier", follow );
+            if ( STATE(Symbol) == S_IDENT || STATE(Symbol) == S_INT ) {
+                rnam = RNamName( STATE(Value) );
+                Match( STATE(Symbol), "identifier", follow );
                 type = '.';
             }
-            else if ( TLS(Symbol) == S_LPAREN ) {
+            else if ( STATE(Symbol) == S_LPAREN ) {
                 Match( S_LPAREN, "(", follow );
                 ReadExpr( S_RPAREN|follow, 'r' );
                 Match( S_RPAREN, ")", follow );
@@ -604,14 +604,14 @@ void ReadCallVarAss (
         }
 
         /* <Var> '!.' <Ident>  record selector                             */
-        else if ( TLS(Symbol) == S_BDOT ) {
+        else if ( STATE(Symbol) == S_BDOT ) {
             Match( S_BDOT, "!.", follow );
-            if ( TLS(Symbol) == S_IDENT || TLS(Symbol) == S_INT ) {
-                rnam = RNamName( TLS(Value) );
-                Match( TLS(Symbol), "identifier", follow );
+            if ( STATE(Symbol) == S_IDENT || STATE(Symbol) == S_INT ) {
+                rnam = RNamName( STATE(Value) );
+                Match( STATE(Symbol), "identifier", follow );
                 type = '!';
             }
-            else if ( TLS(Symbol) == S_LPAREN ) {
+            else if ( STATE(Symbol) == S_LPAREN ) {
                 Match( S_LPAREN, "(", follow );
                 ReadExpr( S_RPAREN|follow, 'r' );
                 Match( S_RPAREN, ")", follow );
@@ -624,23 +624,23 @@ void ReadCallVarAss (
         }
 
         /* <Var> '(' [ <Expr> { ',' <Expr> } ] ')'  function call          */
-        else if ( TLS(Symbol) == S_LPAREN ) {
+        else if ( STATE(Symbol) == S_LPAREN ) {
             Match( S_LPAREN, "(", follow );
             TRY_READ { IntrFuncCallBegin(); }
             narg = 0;
-            if ( TLS(Symbol) != S_RPAREN && TLS(Symbol) != S_COLON) {
+            if ( STATE(Symbol) != S_RPAREN && STATE(Symbol) != S_COLON) {
                 ReadExpr( S_RPAREN|follow, 'r' );
                 narg++;
             }
-            while ( TLS(Symbol) == S_COMMA ) {
+            while ( STATE(Symbol) == S_COMMA ) {
                 Match( S_COMMA, ",", follow );
                 ReadExpr( S_RPAREN|follow, 'r' );
                 narg++;
             }
 	    type = 'c';
-	    if (TLS(Symbol) == S_COLON ) {
+	    if (STATE(Symbol) == S_COLON ) {
 	      Match( S_COLON, ":", follow );
-	      if ( TLS(Symbol) != S_RPAREN ) /* save work for empty options */
+	      if ( STATE(Symbol) != S_RPAREN ) /* save work for empty options */
 		{
 		  ReadFuncCallOptions(S_RPAREN | follow);
 		  type = 'C';
@@ -652,7 +652,7 @@ void ReadCallVarAss (
     }
 
     /* if we need a reference                                              */
-    if ( mode == 'r' || (mode == 'x' && !IS_IN(TLS(Symbol), S_ASSIGN)) ) {
+    if ( mode == 'r' || (mode == 'x' && !IS_IN(STATE(Symbol), S_ASSIGN)) ) {
       TRY_READ {
              if ( type == 'l' ) { IntrRefLVar( var );             }
         else if ( type == 'h' ) { IntrRefHVar( var );             }
@@ -671,7 +671,7 @@ void ReadCallVarAss (
         else if ( type == '!' ) { IntrElmComObjName( rnam );      }
         else if ( type == '|' ) { IntrElmComObjExpr();            }
         else if ( type == 'c' || type == 'C') {
-            if ( mode == 'x' && TLS(Symbol) == S_SEMICOLON ) {
+            if ( mode == 'x' && STATE(Symbol) == S_SEMICOLON ) {
                 IntrFuncCallEnd( 0UL, type == 'C', narg );
             }
             else {
@@ -688,13 +688,13 @@ void ReadCallVarAss (
 #endif
 
     /* if we need a statement                                              */
-    else if ( mode == 's' || (mode == 'x' && IS_IN(TLS(Symbol), S_ASSIGN)) ) {
+    else if ( mode == 's' || (mode == 'x' && IS_IN(STATE(Symbol), S_ASSIGN)) ) {
         if ( type != 'c' && type != 'C') {
-	    if (TLS(Symbol) != S_ASSIGN)
+	    if (STATE(Symbol) != S_ASSIGN)
 	      Match( S_INCORPORATE, ASSIGN_ERROR_MESSAGE, follow);
 	    else
 	      Match( S_ASSIGN, ASSIGN_ERROR_MESSAGE, follow );
-            if ( TLS(CountNams) == 0 || !TLS(IntrCoding) ) { TLS(CurrLHSGVar) = (type == 'g' ? var : 0); }
+            if ( STATE(CountNams) == 0 || !STATE(IntrCoding) ) { STATE(CurrLHSGVar) = (type == 'g' ? var : 0); }
             ReadExpr( follow, 'r' );
         }
       TRY_READ {
@@ -721,7 +721,7 @@ void ReadCallVarAss (
 
     /*  if we need an unbind                                               */
     else if ( mode == 'u' ) {
-      if (TLS(Symbol) != S_RPAREN) {
+      if (STATE(Symbol) != S_RPAREN) {
 	SyntaxError("'Unbind': argument should be followed by ')'");
       }
       TRY_READ {
@@ -801,7 +801,7 @@ void ReadPerm (
 
     /* read the first cycle (first expression has already been read)       */
     nrx = 1;
-    while ( TLS(Symbol) == S_COMMA ) {
+    while ( STATE(Symbol) == S_COMMA ) {
         Match( S_COMMA, ",", follow );
         ReadExpr( S_COMMA|S_RPAREN|follow, 'r' );
         nrx++;
@@ -811,11 +811,11 @@ void ReadPerm (
     TRY_READ { IntrPermCycle( nrx, nrc ); }
 
     /* read the remaining cycles                                           */
-    while ( TLS(Symbol) == S_LPAREN ) {
+    while ( STATE(Symbol) == S_LPAREN ) {
         Match( S_LPAREN, "(", follow );
         ReadExpr( S_COMMA|S_RPAREN|follow, 'r' );
         nrx = 1;
-        while ( TLS(Symbol) == S_COMMA ) {
+        while ( STATE(Symbol) == S_COMMA ) {
             Match( S_COMMA, ",", follow );
             ReadExpr( S_COMMA|S_RPAREN|follow, 'r' );
             nrx++;
@@ -833,17 +833,17 @@ void ReadPerm (
 **
 *F  ReadLongNumber( <follow> )  . . . . . . . . . . . . . . . read a long integer
 **
-**  A `long integer' here means one whose digits don't fit into `TLS(Value)',
-**  see scanner.c.  This function copies repeatedly  digits from `TLS(Value)'
+**  A `long integer' here means one whose digits don't fit into `STATE(Value)',
+**  see scanner.c.  This function copies repeatedly  digits from `STATE(Value)'
 **  into a GAP string until the full integer is read.
 **
 */
 
 static UInt appendToString(Obj string, UInt len)
 {
-       UInt len1 = strlen(TLS(Value));
+       UInt len1 = strlen(STATE(Value));
        GROW_STRING(string, len+len1+1);
-       memcpy(CHARS_STRING(string) + len, (void *)TLS(Value), len1+1);
+       memcpy(CHARS_STRING(string) + len, (void *)STATE(Value), len1+1);
        SET_LEN_STRING(string, len+len1);
        return len + len1;
 }
@@ -857,19 +857,19 @@ void ReadLongNumber(
      UInt done;
 
      /* string in which to accumulate number */
-     len = strlen(TLS(Value));
-     C_NEW_STRING( string, len, (void *)TLS(Value));
+     len = strlen(STATE(Value));
+     C_NEW_STRING( string, len, (void *)STATE(Value));
      done = 0;
 
      while (!done) {
        /* remember the current symbol and get the next one */
-       status = TLS(Symbol);
-       Match(TLS(Symbol), "partial number", follow);
+       status = STATE(Symbol);
+       Match(STATE(Symbol), "partial number", follow);
 
        /* Now there are just lots of cases */
        switch (status) {
        case S_PARTIALINT:
-	 switch (TLS(Symbol)) {
+	 switch (STATE(Symbol)) {
 	 case S_INT:
 	   len = appendToString(string, len);
 	   Match(S_INT, "integer", follow);
@@ -890,9 +890,9 @@ void ReadLongNumber(
 	 case S_PARTIALFLOAT2:
 	 case S_PARTIALFLOAT3:
 	 case S_PARTIALFLOAT4:
-	   status = TLS(Symbol);
+	   status = STATE(Symbol);
 	   len = appendToString(string, len);
-	   /* Match(TLS(Symbol), "float", follow); */
+	   /* Match(STATE(Symbol), "float", follow); */
 	   break;
 
 	 case S_FLOAT:
@@ -913,7 +913,7 @@ void ReadLongNumber(
 	 break;
 
        case S_PARTIALFLOAT1:
-	 switch (TLS(Symbol)) {
+	 switch (STATE(Symbol)) {
 	 case S_INT:
 	 case S_PARTIALINT:
 	 case S_PARTIALFLOAT1:
@@ -925,9 +925,9 @@ void ReadLongNumber(
 	 case S_PARTIALFLOAT2:
 	 case S_PARTIALFLOAT3:
 	 case S_PARTIALFLOAT4:
-	   status = TLS(Symbol);
+	   status = STATE(Symbol);
 	   len = appendToString(string, len);
-	   /* Match(TLS(Symbol), "float", follow); */
+	   /* Match(STATE(Symbol), "float", follow); */
 	   break;
 
 	 case S_FLOAT:
@@ -943,7 +943,7 @@ void ReadLongNumber(
 	 break;
 
        case S_PARTIALFLOAT2:
-	 switch (TLS(Symbol)) {
+	 switch (STATE(Symbol)) {
 	 case S_INT:
 	 case S_PARTIALINT:
 	 case S_PARTIALFLOAT1:
@@ -955,9 +955,9 @@ void ReadLongNumber(
 	 case S_PARTIALFLOAT2:
 	 case S_PARTIALFLOAT3:
 	 case S_PARTIALFLOAT4:
-	   status = TLS(Symbol);
+	   status = STATE(Symbol);
 	   len = appendToString(string, len);
-	   /* Match(TLS(Symbol), "float", follow); */
+	   /* Match(STATE(Symbol), "float", follow); */
 	   break;
 
 	 case S_FLOAT:
@@ -979,7 +979,7 @@ void ReadLongNumber(
 	 break;
 
        case S_PARTIALFLOAT3:
-	 switch (TLS(Symbol)) {
+	 switch (STATE(Symbol)) {
 	 case S_INT:
 	 case S_PARTIALINT:
 	 case S_PARTIALFLOAT1:
@@ -991,9 +991,9 @@ void ReadLongNumber(
 
 
 	 case S_PARTIALFLOAT4:
-	   status = TLS(Symbol);
+	   status = STATE(Symbol);
 	   len = appendToString(string, len);
-	   /* Match(TLS(Symbol), "float", follow); */
+	   /* Match(STATE(Symbol), "float", follow); */
 	   break;
 
 	 case S_FLOAT:
@@ -1010,7 +1010,7 @@ void ReadLongNumber(
 	 }
 	 break;
        case S_PARTIALFLOAT4:
-	 switch (TLS(Symbol)) {
+	 switch (STATE(Symbol)) {
 	 case S_INT:
 	 case S_PARTIALINT:
 	 case S_PARTIALFLOAT1:
@@ -1022,9 +1022,9 @@ void ReadLongNumber(
 
 
 	 case S_PARTIALFLOAT4:
-	   status = TLS(Symbol);
+	   status = STATE(Symbol);
 	   len = appendToString(string, len);
-	   /* Match(TLS(Symbol), "float", follow); */
+	   /* Match(STATE(Symbol), "float", follow); */
 	   break;
 
 	 case S_FLOAT:
@@ -1056,8 +1056,8 @@ void ReadLongNumber(
 **
 *F  ReadString( <follow> )  . . . . . . . . . . . . . . read a (long) string
 **
-**  A string is  read by copying parts of `TLS(Value)'  (see scanner.c) given
-**  by `TLS(ValueLen)' into  a string GAP object. This is  repeated until the
+**  A string is  read by copying parts of `STATE(Value)'  (see scanner.c) given
+**  by `STATE(ValueLen)' into  a string GAP object. This is  repeated until the
 **  end of the string is reached.
 **
 */
@@ -1067,15 +1067,15 @@ void ReadString(
      Obj  string;
      UInt len;
 
-     C_NEW_STRING( string, TLS(ValueLen), (void *)TLS(Value) );
-     len = TLS(ValueLen);
+     C_NEW_STRING( string, STATE(ValueLen), (void *)STATE(Value) );
+     len = STATE(ValueLen);
 
-     while (TLS(Symbol) == S_PARTIALSTRING || TLS(Symbol) == S_PARTIALTRIPSTRING) {
-         Match(TLS(Symbol), "", follow);
-         GROW_STRING(string, len + TLS(ValueLen));
-         memcpy(CHARS_STRING(string) + len, (void *)TLS(Value),
-                                        TLS(ValueLen));
-         len += TLS(ValueLen);
+     while (STATE(Symbol) == S_PARTIALSTRING || STATE(Symbol) == S_PARTIALTRIPSTRING) {
+         Match(STATE(Symbol), "", follow);
+         GROW_STRING(string, len + STATE(ValueLen));
+         memcpy(CHARS_STRING(string) + len, (void *)STATE(Value),
+                                        STATE(ValueLen));
+         len += STATE(ValueLen);
      }
 
      Match(S_STRING, "", follow);
@@ -1104,15 +1104,15 @@ void ReadListExpr (
 
     /* '['                                                                 */
     Match( S_LBRACK, "[", follow );
-    TLS(ReadTop)++;
-    if ( TLS(ReadTop) == 1 ) { TLS(ReadTilde) = 0; }
-    TRY_READ { IntrListExprBegin( (TLS(ReadTop) == 1) ); }
+    STATE(ReadTop)++;
+    if ( STATE(ReadTop) == 1 ) { STATE(ReadTilde) = 0; }
+    TRY_READ { IntrListExprBegin( (STATE(ReadTop) == 1) ); }
     pos   = 1;
     nr    = 0;
     range = 0;
 
     /* [ <Expr> ]                                                          */
-    if ( TLS(Symbol) != S_COMMA && TLS(Symbol) != S_RBRACK ) {
+    if ( STATE(Symbol) != S_COMMA && STATE(Symbol) != S_RBRACK ) {
         TRY_READ { IntrListExprBeginElm( pos ); }
         ReadExpr( S_RBRACK|follow, 'r' );
         TRY_READ { IntrListExprEndElm(); }
@@ -1120,10 +1120,10 @@ void ReadListExpr (
     }
 
     /* {',' [ <Expr> ] }                                                   */
-    while ( TLS(Symbol) == S_COMMA ) {
+    while ( STATE(Symbol) == S_COMMA ) {
         Match( S_COMMA, ",", follow );
         pos++;
-        if ( TLS(Symbol) != S_COMMA && TLS(Symbol) != S_RBRACK ) {
+        if ( STATE(Symbol) != S_COMMA && STATE(Symbol) != S_RBRACK ) {
             TRY_READ { IntrListExprBeginElm( pos ); }
             ReadExpr( S_RBRACK|follow, 'r' );
             TRY_READ { IntrListExprEndElm(); }
@@ -1132,12 +1132,12 @@ void ReadListExpr (
     }
 
     /* incorrect place for three dots                                      */
-    if (TLS(Symbol) == S_DOTDOTDOT) {
+    if (STATE(Symbol) == S_DOTDOTDOT) {
             SyntaxError("Only two dots in a range");
     }
 
     /* '..' <Expr> ']'                                                     */
-    if ( TLS(Symbol) == S_DOTDOT ) {
+    if ( STATE(Symbol) == S_DOTDOT ) {
         if ( pos != nr ) {
             SyntaxError("Must have no unbound entries in range");
         }
@@ -1151,7 +1151,7 @@ void ReadListExpr (
         ReadExpr( S_RBRACK|follow, 'r' );
         TRY_READ { IntrListExprEndElm(); }
         nr++;
-        if ( TLS(ReadTop) == 1 && TLS(ReadTilde) == 1 ) {
+        if ( STATE(ReadTop) == 1 && STATE(ReadTilde) == 1 ) {
             SyntaxError("Sorry, '~' not allowed in range");
         }
     }
@@ -1159,10 +1159,10 @@ void ReadListExpr (
     /* ']'                                                                 */
     Match( S_RBRACK, "]", follow );
     TRY_READ {
-        IntrListExprEnd( nr, range, (TLS(ReadTop) == 1), (TLS(ReadTilde) == 1) );
+        IntrListExprEnd( nr, range, (STATE(ReadTop) == 1), (STATE(ReadTilde) == 1) );
     }
-    if ( TLS(ReadTop) == 1 ) { TLS(ReadTilde) = 0; }
-    TLS(ReadTop)--;
+    if ( STATE(ReadTop) == 1 ) { STATE(ReadTilde) = 0; }
+    STATE(ReadTop)--;
 }
 
 
@@ -1184,28 +1184,28 @@ void ReadRecExpr (
     /* 'rec('                                                              */
     Match( S_REC, "rec", follow );
     Match( S_LPAREN, "(", follow|S_RPAREN|S_COMMA );
-    TLS(ReadTop)++;
-    if ( TLS(ReadTop) == 1 ) { TLS(ReadTilde) = 0; }
-    TRY_READ { IntrRecExprBegin( (TLS(ReadTop) == 1) ); }
+    STATE(ReadTop)++;
+    if ( STATE(ReadTop) == 1 ) { STATE(ReadTilde) = 0; }
+    TRY_READ { IntrRecExprBegin( (STATE(ReadTop) == 1) ); }
     nr = 0;
 
     /* [ <Ident> | '(' <Expr> ')' ':=' <Expr>                              */
     do {
-      if (nr || TLS(Symbol) == S_COMMA) {
+      if (nr || STATE(Symbol) == S_COMMA) {
 	Match(S_COMMA, ",", follow);
       }
-      if ( TLS(Symbol) != S_RPAREN ) {
-        if ( TLS(Symbol) == S_INT ) {
-	  rnam = RNamName( TLS(Value) );
+      if ( STATE(Symbol) != S_RPAREN ) {
+        if ( STATE(Symbol) == S_INT ) {
+	  rnam = RNamName( STATE(Value) );
 	  Match( S_INT, "integer", follow );
 	  TRY_READ { IntrRecExprBeginElmName( rnam ); }
         }
-        else if ( TLS(Symbol) == S_IDENT ) {
-	  rnam = RNamName( TLS(Value) );
+        else if ( STATE(Symbol) == S_IDENT ) {
+	  rnam = RNamName( STATE(Value) );
 	  Match( S_IDENT, "identifier", follow );
 	  TRY_READ { IntrRecExprBeginElmName( rnam ); }
         }
-        else if ( TLS(Symbol) == S_LPAREN ) {
+        else if ( STATE(Symbol) == S_LPAREN ) {
 	  Match( S_LPAREN, "(", follow );
 	  ReadExpr( follow, 'r' );
 	  Match( S_RPAREN, ")", follow );
@@ -1221,15 +1221,15 @@ void ReadRecExpr (
       }
 
     }
-  while ( TLS(Symbol) == S_COMMA );
+  while ( STATE(Symbol) == S_COMMA );
 
     /* ')'                                                                 */
     Match( S_RPAREN, ")", follow );
     TRY_READ {
-        IntrRecExprEnd( nr, (TLS(ReadTop) == 1), (TLS(ReadTilde) == 1) );
+        IntrRecExprEnd( nr, (STATE(ReadTop) == 1), (STATE(ReadTilde) == 1) );
     }
-    if ( TLS(ReadTop) == 1) { TLS(ReadTilde) = 0; }
-    TLS(ReadTop)--;
+    if ( STATE(ReadTop) == 1) { STATE(ReadTilde) = 0; }
+    STATE(ReadTop)--;
 }
 
 
@@ -1256,8 +1256,8 @@ void ReadFuncExpr (
     volatile UInt       nloc;           /* number of locals                */
     volatile UInt       nr;             /* number of statements            */
     volatile UInt       i;              /* loop variable                   */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>             */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>          */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>             */
     volatile Int        startLine;      /* line number of function keyword */
     volatile int        is_block = 0;   /* is this a do ... od block?      */
     volatile int        is_atomic = 0;  /* is this an atomic function?      */
@@ -1265,12 +1265,12 @@ void ReadFuncExpr (
     volatile Bag        locks = 0;      /* locks of the function */
 
     /* begin the function               */
-    startLine = TLS(Input)->number;
-    if (TLS(Symbol) == S_DO) {
+    startLine = STATE(Input)->number;
+    if (STATE(Symbol) == S_DO) {
 	Match( S_DO, "do", follow );
         is_block = 1;
     } else {
-	if (TLS(Symbol) == S_ATOMIC) {
+	if (STATE(Symbol) == S_ATOMIC) {
 	    Match(S_ATOMIC, "atomic", follow);
 	    is_atomic = 1;
 	} else if (mode == 'a') { /* in this case the atomic keyword
@@ -1289,12 +1289,12 @@ void ReadFuncExpr (
     narg = nloc = 0;
     nams = NEW_PLIST( T_PLIST, narg+nloc );
     SET_LEN_PLIST( nams, narg+nloc );
-    TLS(CountNams) += 1;
-    ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
+    STATE(CountNams) += 1;
+    ASS_LIST( STATE(StackNams), STATE(CountNams), nams );
     if (!is_block) {
-	if ( TLS(Symbol) != S_RPAREN ) {
+	if ( STATE(Symbol) != S_RPAREN ) {
 	    lockmode = 0;
-	    switch (TLS(Symbol)) {
+	    switch (STATE(Symbol)) {
 	      case S_READWRITE:
 	        if (!is_atomic) {
 		  SyntaxError("'readwrite' argument of non-atomic function");
@@ -1313,29 +1313,29 @@ void ReadFuncExpr (
 		SET_LEN_STRING(locks, 1);
                 GetSymbol();
 	    }
-        C_NEW_STRING_DYN( name, TLS(Value) );
+        C_NEW_STRING_DYN( name, STATE(Value) );
 	    MakeImmutableString(name);
 	    narg += 1;
 	    ASS_LIST( nams, narg+nloc, name );
 	    Match(S_IDENT,"identifier",S_RPAREN|S_LOCAL|STATBEGIN|S_END|follow);
 	}
 
-	if(TLS(Symbol) == S_DOTDOT) {
+	if(STATE(Symbol) == S_DOTDOT) {
 	    SyntaxError("Three dots required for variadic argument list");
 	}
-	if(TLS(Symbol) == S_DOTDOTDOT) {
+	if(STATE(Symbol) == S_DOTDOTDOT) {
 	    isvarg = 1;
 	    GetSymbol();
     }
 
-	while ( TLS(Symbol) == S_COMMA ) {
+	while ( STATE(Symbol) == S_COMMA ) {
 	    if (isvarg) {
 	        SyntaxError("Only final argument can be variadic");
 	    }
 
 	    Match( S_COMMA, ",", follow );
 	    lockmode = 0;
-	    switch (TLS(Symbol)) {
+	    switch (STATE(Symbol)) {
 	      case S_READWRITE:
 	        if (!is_atomic) {
 		  SyntaxError("'readwrite' argument of non-atomic function");
@@ -1356,63 +1356,63 @@ void ReadFuncExpr (
 	        GetSymbol();
 	    }
 
-	    if(TLS(Symbol) != S_IDENT) {
+	    if(STATE(Symbol) != S_IDENT) {
 	        SyntaxError("Expect identifier");
 	    }
 
 	    for ( i = 1; i <= narg; i++ ) {
-		if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
+		if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),STATE(Value)) == 0 ) {
 		    SyntaxError("Name used for two arguments");
 		}
 	    }
-        C_NEW_STRING_DYN( name, TLS(Value) );
+        C_NEW_STRING_DYN( name, STATE(Value) );
 	    MakeImmutableString(name);
 	    narg += 1;
 	    ASS_LIST( nams, narg+nloc, name );
 	    Match(S_IDENT,"identifier",S_RPAREN|S_LOCAL|STATBEGIN|S_END|follow);
-	    if(TLS(Symbol) == S_DOTDOT) {
+	    if(STATE(Symbol) == S_DOTDOT) {
 	        SyntaxError("Three dots required for variadic argument list");
 	    }
-	    if(TLS(Symbol) == S_DOTDOTDOT) {
+	    if(STATE(Symbol) == S_DOTDOTDOT) {
 	        isvarg = 1;
 	        GetSymbol();
 	    }
 	}
         Match( S_RPAREN, ")", S_LOCAL|STATBEGIN|S_END|follow );
     }
-    if ( TLS(Symbol) == S_LOCAL ) {
+    if ( STATE(Symbol) == S_LOCAL ) {
         Match( S_LOCAL, "local", follow );
         for ( i = 1; i <= narg; i++ ) {
-            if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
+            if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),STATE(Value)) == 0 ) {
                 SyntaxError("Name used for argument and local");
             }
         }
-        if ( strcmp("~", TLS(Value)) == 0 ) {
+        if ( strcmp("~", STATE(Value)) == 0 ) {
                 SyntaxError("~ is not a valid name for a local identifier");
         }
-        C_NEW_STRING_DYN( name, TLS(Value) );
+        C_NEW_STRING_DYN( name, STATE(Value) );
 	      MakeImmutableString(name);
         nloc += 1;
         ASS_LIST( nams, narg+nloc, name );
         Match( S_IDENT, "identifier", STATBEGIN|S_END|follow );
-        while ( TLS(Symbol) == S_COMMA ) {
+        while ( STATE(Symbol) == S_COMMA ) {
             /* init to avoid strange message in case of empty string */
-            TLS(Value)[0] = '\0';
+            STATE(Value)[0] = '\0';
             Match( S_COMMA, ",", follow );
             for ( i = 1; i <= narg; i++ ) {
-                if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
+                if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),STATE(Value)) == 0 ) {
                     SyntaxError("Name used for argument and local");
                 }
             }
             for ( i = narg+1; i <= narg+nloc; i++ ) {
-                if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
+                if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),STATE(Value)) == 0 ) {
                     SyntaxError("Name used for two locals");
                 }
             }
-            if ( strcmp("~", TLS(Value)) == 0 ) {
+            if ( strcmp("~", STATE(Value)) == 0 ) {
                 SyntaxError("~ is not a valid name for a local identifier");
             }
-            C_NEW_STRING_DYN( name, TLS(Value) );
+            C_NEW_STRING_DYN( name, STATE(Value) );
 	          MakeImmutableString(name);
             nloc += 1;
             ASS_LIST( nams, narg+nloc, name );
@@ -1432,8 +1432,8 @@ void ReadFuncExpr (
 	   narg = -1; */
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
 
     /* now finally begin the function                                      */
     TRY_READ { IntrFuncExprBegin( narg, nloc, nams, startLine ); }
@@ -1448,17 +1448,17 @@ void ReadFuncExpr (
     }
 
     /* an error has occured *after* the 'IntrFuncExprEnd'                  */
-    else if ( nrError == 0 && TLS(IntrCoding) ) {
+    else if ( nrError == 0 && STATE(IntrCoding) ) {
         CodeEnd(1);
-        TLS(IntrCoding)--;
-        TLS(CurrLVars) = currLVars;
-        TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-        TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+        STATE(IntrCoding)--;
+        STATE(CurrLVars) = currLVars;
+        STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+        STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
     }
 
     /* pop the new local variables list                                    */
-    assert(TLS(CountNams) > 0);
-    TLS(CountNams)--;
+    assert(STATE(CountNams) > 0);
+    STATE(CountNams)--;
 
     /* 'end'                                                               */
     if (is_block)
@@ -1482,15 +1482,15 @@ void ReadFuncExpr1 (
 {
     volatile Obj        nams;           /* list of local variables names   */
     volatile Obj        name;           /* one local variable name         */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>        */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>          */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>        */
 
     /* make and push the new local variables list                          */
     nams = NEW_PLIST( T_PLIST, 1 );
     SET_LEN_PLIST( nams, 0 );
-    TLS(CountNams)++;
-    ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
-    C_NEW_STRING_DYN( name, TLS(Value) );
+    STATE(CountNams)++;
+    ASS_LIST( STATE(StackNams), STATE(CountNams), nams );
+    C_NEW_STRING_DYN( name, STATE(Value) );
     MakeImmutableString( name );
     ASS_LIST( nams, 1, name );
 
@@ -1498,12 +1498,12 @@ void ReadFuncExpr1 (
     Match( S_MAPTO, "->", follow );
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
 
     /* begin interpreting the function expression (with 1 argument)        */
     TRY_READ {
-        IntrFuncExprBegin( 1L, 0L, nams, TLS(Input)->number );
+        IntrFuncExprBegin( 1L, 0L, nams, STATE(Input)->number );
     }
 
     /* read the expression and turn it into a return-statement             */
@@ -1516,17 +1516,17 @@ void ReadFuncExpr1 (
     }
 
     /* an error has occured *after* the 'IntrFuncExprEnd'                  */
-    else if ( nrError == 0  && TLS(IntrCoding) ) {
+    else if ( nrError == 0  && STATE(IntrCoding) ) {
         CodeEnd(1);
-        TLS(IntrCoding)--;
-        TLS(CurrLVars) = currLVars;
-        TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-        TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+        STATE(IntrCoding)--;
+        STATE(CurrLVars) = currLVars;
+        STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+        STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
     }
 
     /* pop the new local variables list                                    */
-    assert(TLS(CountNams) > 0);
-    TLS(CountNams)--;
+    assert(STATE(CountNams) > 0);
+    STATE(CountNams)--;
 }
 
 /****************************************************************************
@@ -1542,25 +1542,25 @@ void ReadFuncExpr0 (
     TypSymbolSet        follow )
 {
     volatile Obj        nams;           /* list of local variables names   */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>             */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>          */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>             */
 
     /* make and push the new local variables list                          */
     nams = NEW_PLIST( T_PLIST, 0 );
     SET_LEN_PLIST( nams, 0 );
-    TLS(CountNams)++;
-    ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
+    STATE(CountNams)++;
+    ASS_LIST( STATE(StackNams), STATE(CountNams), nams );
 
     /* match away the '->'                                                 */
     Match( S_MAPTO, "->", follow );
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
 
     /* begin interpreting the function expression (with 1 argument)        */
     TRY_READ {
-        IntrFuncExprBegin( 0L, 0L, nams, TLS(Input)->number );
+        IntrFuncExprBegin( 0L, 0L, nams, STATE(Input)->number );
     }
 
     /* read the expression and turn it into a return-statement             */
@@ -1573,16 +1573,16 @@ void ReadFuncExpr0 (
     }
 
     /* an error has occured *after* the 'IntrFuncExprEnd'                  */
-    else if ( nrError == 0  && TLS(IntrCoding) ) {
+    else if ( nrError == 0  && STATE(IntrCoding) ) {
         CodeEnd(1);
-        TLS(IntrCoding)--;
-        TLS(CurrLVars) = currLVars;
-        TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-        TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+        STATE(IntrCoding)--;
+        STATE(CurrLVars) = currLVars;
+        STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+        STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
     }
 
     /* pop the new local variables list                                    */
-    TLS(CountNams)--;
+    STATE(CountNams)--;
 }
 
 /****************************************************************************
@@ -1612,17 +1612,17 @@ void ReadLiteral (
     TypSymbolSet        follow,
     Char mode)
 {
-    switch (TLS(Symbol)) {
+    switch (STATE(Symbol)) {
 
     /* <Int>                                                               */
     case S_INT:
-        TRY_READ { IntrIntExpr( TLS(Value) ); }
+        TRY_READ { IntrIntExpr( STATE(Value) ); }
         Match( S_INT, "integer", follow );
         break;
 
     /* <Float> */
     case S_FLOAT:
-        TRY_READ { IntrFloatExpr( TLS(Value) ); }
+        TRY_READ { IntrFloatExpr( STATE(Value) ); }
         Match( S_FLOAT, "float", follow );
         break;
 
@@ -1647,7 +1647,7 @@ void ReadLiteral (
 
     /* <Char>                                                              */
     case S_CHAR:
-        TRY_READ { IntrCharExpr( TLS(Value)[0] ); }
+        TRY_READ { IntrCharExpr( STATE(Value)[0] ); }
         Match( S_CHAR, "character", follow );
         break;
 
@@ -1694,9 +1694,9 @@ void ReadLiteral (
            of the right kind to end with a . and an associated value and dive
            into the long float literal handler in the parser
          */
-        TLS(Symbol) = S_PARTIALFLOAT1;
-        TLS(Value)[0] = '.';
-        TLS(Value)[1] = '\0';
+        STATE(Symbol) = S_PARTIALFLOAT1;
+        STATE(Value)[0] = '.';
+        STATE(Value)[1] = '\0';
         ReadLongNumber( follow );
         break;
 
@@ -1728,16 +1728,16 @@ void ReadAtom (
     Char                mode )
 {
     /* read a variable                                                     */
-    if ( TLS(Symbol) == S_IDENT ) {
+    if ( STATE(Symbol) == S_IDENT ) {
         ReadCallVarAss( follow, mode );
     }
 
     /* 'IsBound' '(' <Var> ')'                                             */
-    else if ( TLS(Symbol) == S_ISBOUND ) {
+    else if ( STATE(Symbol) == S_ISBOUND ) {
         ReadIsBound( follow );
     }
     /* otherwise read a literal expression                                 */
-    else if (IS_IN(TLS(Symbol),S_INT|S_TRUE|S_FALSE|S_CHAR|S_STRING|S_LBRACK|
+    else if (IS_IN(STATE(Symbol),S_INT|S_TRUE|S_FALSE|S_CHAR|S_STRING|S_LBRACK|
                           S_REC|S_FUNCTION|
 #ifdef HPCGAP
                           S_DO|
@@ -1748,15 +1748,15 @@ void ReadAtom (
     }
 
     /* '(' <Expr> ')'                                                      */
-    else if ( TLS(Symbol) == S_LPAREN ) {
+    else if ( STATE(Symbol) == S_LPAREN ) {
         Match( S_LPAREN, "(", follow );
-        if ( TLS(Symbol) == S_RPAREN ) {
+        if ( STATE(Symbol) == S_RPAREN ) {
             Match( S_RPAREN, ")", follow );
             TRY_READ { IntrPerm( 0UL ); }
             return;
         }
         ReadExpr( S_RPAREN|follow, 'r' );
-        if ( TLS(Symbol) == S_COMMA ) {
+        if ( STATE(Symbol) == S_COMMA ) {
             ReadPerm( follow );
             return;
         }
@@ -1790,27 +1790,27 @@ void ReadFactor (
 
     /* { '+'|'-' }  leading sign                                           */
     sign1 = 0;
-    if ( TLS(Symbol) == S_MINUS  || TLS(Symbol) == S_PLUS ) {
+    if ( STATE(Symbol) == S_MINUS  || STATE(Symbol) == S_PLUS ) {
         if ( sign1 == 0 )  sign1 = 1;
-        if ( TLS(Symbol) == S_MINUS ) { sign1 = -sign1; }
-        Match( TLS(Symbol), "unary + or -", follow );
+        if ( STATE(Symbol) == S_MINUS ) { sign1 = -sign1; }
+        Match( STATE(Symbol), "unary + or -", follow );
     }
 
     /* <Atom>                                                              */
     ReadAtom( follow, (sign1 == 0 ? mode : 'r') );
 
     /* ['^' <Atom> ] implemented as {'^' <Atom> } for better error message */
-    while ( TLS(Symbol) == S_POW ) {
+    while ( STATE(Symbol) == S_POW ) {
 
         /* match the '^' away                                              */
         Match( S_POW, "^", follow );
 
         /* { '+'|'-' }  leading sign                                       */
         sign2 = 0;
-        if ( TLS(Symbol) == S_MINUS  || TLS(Symbol) == S_PLUS ) {
+        if ( STATE(Symbol) == S_MINUS  || STATE(Symbol) == S_PLUS ) {
             if ( sign2 == 0 )  sign2 = 1;
-            if ( TLS(Symbol) == S_MINUS ) { sign2 = -sign2; }
-            Match( TLS(Symbol), "unary + or -", follow );
+            if ( STATE(Symbol) == S_MINUS ) { sign2 = -sign2; }
+            Match( STATE(Symbol), "unary + or -", follow );
         }
 
         /* ['^' <Atom>]                                                    */
@@ -1825,7 +1825,7 @@ void ReadFactor (
         TRY_READ { IntrPow(); }
 
         /* check for multiple '^'                                          */
-        if ( TLS(Symbol) == S_POW ) { SyntaxError("'^' is not associative"); }
+        if ( STATE(Symbol) == S_POW ) { SyntaxError("'^' is not associative"); }
 
     }
 
@@ -1856,9 +1856,9 @@ void ReadTerm (
 
     /* { '*'|'/'|'mod' <Factor> }                                          */
     /* do not use 'IS_IN', since 'IS_IN(S_POW,S_MULT|S_DIV|S_MOD)' is true */
-    while ( TLS(Symbol) == S_MULT || TLS(Symbol) == S_DIV || TLS(Symbol) == S_MOD ) {
-        symbol = TLS(Symbol);
-        Match( TLS(Symbol), "*, /, or mod", follow );
+    while ( STATE(Symbol) == S_MULT || STATE(Symbol) == S_DIV || STATE(Symbol) == S_MOD ) {
+        symbol = STATE(Symbol);
+        Match( STATE(Symbol), "*, /, or mod", follow );
         ReadFactor( follow, 'r' );
         TRY_READ {
             if      ( symbol == S_MULT ) { IntrProd(); }
@@ -1888,9 +1888,9 @@ void ReadAri (
     ReadTerm( follow, mode );
 
     /* { '+'|'-' <Term> }                                                  */
-    while ( IS_IN( TLS(Symbol), S_PLUS|S_MINUS ) ) {
-        symbol = TLS(Symbol);
-        Match( TLS(Symbol), "+ or -", follow );
+    while ( IS_IN( STATE(Symbol), S_PLUS|S_MINUS ) ) {
+        symbol = STATE(Symbol);
+        Match( STATE(Symbol), "+ or -", follow );
         ReadTerm( follow, 'r' );
         TRY_READ {
             if      ( symbol == S_PLUS  ) { IntrSum();  }
@@ -1918,7 +1918,7 @@ void ReadRel (
 
     /* { 'not' }                                                           */
     isNot = 0;
-    while ( TLS(Symbol) == S_NOT ) {
+    while ( STATE(Symbol) == S_NOT ) {
         isNot++;
         Match( S_NOT, "not", follow );
     }
@@ -1927,9 +1927,9 @@ void ReadRel (
     ReadAri( follow, (isNot == 0 ? mode : 'r') );
 
     /* { '=|<>|<|>|<=|>=|in' <Arith> }                                     */
-    if ( IS_IN( TLS(Symbol), S_EQ|S_LT|S_GT|S_NE|S_LE|S_GE|S_IN ) ) {
-        symbol = TLS(Symbol);
-        Match( TLS(Symbol), "comparison operator", follow );
+    if ( IS_IN( STATE(Symbol), S_EQ|S_LT|S_GT|S_NE|S_LE|S_GE|S_IN ) ) {
+        symbol = STATE(Symbol);
+        Match( STATE(Symbol), "comparison operator", follow );
         ReadAri( follow, 'r' );
         TRY_READ {
             if      ( symbol == S_EQ ) { IntrEq(); }
@@ -1966,7 +1966,7 @@ void ReadAnd (
     ReadRel( follow, mode );
 
     /* { 'and' <Rel> }                                                     */
-    while ( TLS(Symbol) == S_AND ) {
+    while ( STATE(Symbol) == S_AND ) {
         Match( S_AND, "and", follow );
         TRY_READ { IntrAndL(); }
         ReadRel( follow, 'r' );
@@ -1990,12 +1990,12 @@ void ReadQualifiedExpr (
     Char                mode )
 {
   UInt access  = 0;
-  if (TLS(Symbol) == S_READWRITE) 
+  if (STATE(Symbol) == S_READWRITE) 
     {
       Match( S_READWRITE, "readwrite", follow | EXPRBEGIN );
       access = 2;
     }
-  else if (TLS(Symbol) == S_READONLY) 
+  else if (STATE(Symbol) == S_READONLY) 
     {
       Match( S_READONLY, "readonly", follow | EXPRBEGIN );
       access = 1;
@@ -2035,7 +2035,7 @@ void ReadExpr (
     ReadAnd( follow, mode );
 
     /* { 'or' <And> }                                                      */
-    while ( TLS(Symbol) == S_OR ) {
+    while ( STATE(Symbol) == S_OR ) {
         Match( S_OR, "or", follow );
         TRY_READ { IntrOrL(); }
         ReadAnd( follow, 'r' );
@@ -2099,7 +2099,7 @@ void ReadInfo (
     ReadExpr( S_RPAREN | S_COMMA | follow, 'r');
     TRY_READ { IntrInfoMiddle(); }
     narg = 0;
-    while ( TLS(Symbol) == S_COMMA ) {
+    while ( STATE(Symbol) == S_COMMA ) {
         narg++;
         Match( S_COMMA, "", 0L);
         ReadExpr( S_RPAREN | S_COMMA | follow, 'r');
@@ -2129,7 +2129,7 @@ void ReadAssert (
     Match( S_COMMA, ",", S_RPAREN|follow );
     ReadExpr( S_RPAREN | S_COMMA | follow, 'r' );
     TRY_READ { IntrAssertAfterCondition(); }
-    if ( TLS(Symbol) == S_COMMA )
+    if ( STATE(Symbol) == S_COMMA )
       {
         Match( S_COMMA, "", 0L);
         ReadExpr( S_RPAREN |  follow, 'r' );
@@ -2173,7 +2173,7 @@ void ReadIf (
     nrb++;
 
     /* { 'elif' <Expr>  'then' <Statments> }                               */
-    while ( TLS(Symbol) == S_ELIF ) {
+    while ( STATE(Symbol) == S_ELIF ) {
         TRY_READ { IntrIfElif(); }
         Match( S_ELIF, "elif", follow );
         ReadExpr( S_THEN|S_ELIF|S_ELSE|S_FI|follow, 'r' );
@@ -2185,7 +2185,7 @@ void ReadIf (
     }
 
     /* [ 'else' <Statments> ]                                              */
-    if ( TLS(Symbol) == S_ELSE ) {
+    if ( STATE(Symbol) == S_ELSE ) {
         TRY_READ { IntrIfElse(); }
         Match( S_ELSE, "else", follow );
         TRY_READ { IntrIfBeginBody(); }
@@ -2217,12 +2217,12 @@ void ReadFor (
     TypSymbolSet        follow )
 {
     volatile UInt       nrs;            /* number of statements in body    */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>               */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>             */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>               */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>             */
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
 
     /* 'for'                                                               */
     TRY_READ { IntrForBegin(); }
@@ -2252,12 +2252,12 @@ void ReadFor (
         /* If we hadn't actually come out of coding the body, we need
            to recover. Otherwise it was probably an error in executing the
            body and we just return */
-        if ( nrError == 0 && TLS(IntrCoding) ) {
+        if ( nrError == 0 && STATE(IntrCoding) ) {
             CodeEnd(1);
-            TLS(IntrCoding)--;
-            TLS(CurrLVars) = currLVars;
-            TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-            TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+            STATE(IntrCoding)--;
+            STATE(CurrLVars) = currLVars;
+            STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+            STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
         }
     }
 }
@@ -2278,12 +2278,12 @@ void ReadWhile (
     TypSymbolSet        follow )
 {
     volatile UInt       nrs;            /* number of statements in body    */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>             */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>          */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>             */
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
 
     /* 'while' <Expr>  'do'                                                */
     TRY_READ { IntrWhileBegin(); }
@@ -2306,12 +2306,12 @@ void ReadWhile (
         /* If we hadn't actually come out of coding the body, we need
            to recover. Otherwise it was probably an error in executing the
            body and we just return */
-        if ( nrError == 0 && TLS(IntrCoding) ) {
+        if ( nrError == 0 && STATE(IntrCoding) ) {
             CodeEnd(1);
-            TLS(IntrCoding)--;
-            TLS(CurrLVars) = currLVars;
-            TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-            TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+            STATE(IntrCoding)--;
+            STATE(CurrLVars) = currLVars;
+            STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+            STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
         }
     }
 }
@@ -2331,18 +2331,18 @@ void ReadAtomic (
 {
     volatile UInt       nrs;            /* number of statements in body    */
     volatile UInt       nexprs;         /* number of statements in body    */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>        */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>          */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>        */
     volatile int        lockSP;         /* lock stack */
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
     lockSP    = RegionLockSP();
 
     Match( S_ATOMIC, "atomic", follow );
     /* Might just be an atomic function literal as an expression */
-    if (TLS(Symbol) == S_FUNCTION) {
+    if (STATE(Symbol) == S_FUNCTION) {
       ReadExpr(follow, 'a');
       return; }
 
@@ -2351,7 +2351,7 @@ void ReadAtomic (
 
     ReadQualifiedExpr( S_DO|S_OD|follow, 'r' );
     nexprs = 1;
-    while (TLS(Symbol) == S_COMMA) {
+    while (STATE(Symbol) == S_COMMA) {
       Match( S_COMMA, "comma", follow | S_DO | S_OD );
       ReadQualifiedExpr( S_DO|S_OD|follow, 'r' );
       nexprs ++;
@@ -2378,12 +2378,12 @@ void ReadAtomic (
         /* If we hadn't actually come out of coding the body, we need
            to recover. Otherwise it was probably an error in executing the
            body and we just return */
-        if ( nrError == 0 && TLS(IntrCoding) ) {
+        if ( nrError == 0 && STATE(IntrCoding) ) {
             CodeEnd(1);
-            TLS(IntrCoding)--;
-            TLS(CurrLVars) = currLVars;
-            TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-            TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+            STATE(IntrCoding)--;
+            STATE(CurrLVars) = currLVars;
+            STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+            STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
         }
     }
     /* This is a no-op if IntrAtomicEnd() succeeded, otherwise it restores
@@ -2407,12 +2407,12 @@ void ReadRepeat (
     TypSymbolSet        follow )
 {
     volatile UInt       nrs;            /* number of statements in body    */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>        */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>          */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>        */
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
 
     /* 'repeat'                                                            */
     TRY_READ { IntrRepeatBegin(); }
@@ -2434,12 +2434,12 @@ void ReadRepeat (
         /* If we hadn't actually come out of coding the body, we need
            to recover. Otherwise it was probably an error in executing the
            body and we just return */
-        if ( nrError == 0 && TLS(IntrCoding) ) {
+        if ( nrError == 0 && STATE(IntrCoding) ) {
             CodeEnd(1);
-            TLS(IntrCoding)--;
-            TLS(CurrLVars) = currLVars;
-            TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-            TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+            STATE(IntrCoding)--;
+            STATE(CurrLVars) = currLVars;
+            STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+            STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
         }
     }
 }
@@ -2504,7 +2504,7 @@ void ReadReturn (
     Match( S_RETURN, "return", follow );
 
     /* 'return' with no expression following                               */
-    if ( TLS(Symbol) == S_SEMICOLON ) {
+    if ( STATE(Symbol) == S_SEMICOLON ) {
         TRY_READ { IntrReturnVoid(); }
     }
 
@@ -2607,23 +2607,23 @@ UInt ReadStats (
 
     /* read the statements                                                 */
     nr = 0;
-    while ( IS_IN( TLS(Symbol), STATBEGIN|S_SEMICOLON ) ) {
+    while ( IS_IN( STATE(Symbol), STATBEGIN|S_SEMICOLON ) ) {
 
         /* read a statement                                                */
-        if      ( TLS(Symbol) == S_IDENT  ) ReadCallVarAss(follow,'s');
-        else if ( TLS(Symbol) == S_UNBIND ) ReadUnbind(    follow    );
-        else if ( TLS(Symbol) == S_INFO   ) ReadInfo(      follow    );
-        else if ( TLS(Symbol) == S_ASSERT ) ReadAssert(    follow    );
-        else if ( TLS(Symbol) == S_IF     ) ReadIf(        follow    );
-        else if ( TLS(Symbol) == S_FOR    ) ReadFor(       follow    );
-        else if ( TLS(Symbol) == S_WHILE  ) ReadWhile(     follow    );
-        else if ( TLS(Symbol) == S_REPEAT ) ReadRepeat(    follow    );
-        else if ( TLS(Symbol) == S_BREAK  ) ReadBreak(     follow    );
-        else if ( TLS(Symbol) == S_CONTINUE) ReadContinue(     follow    );
-        else if ( TLS(Symbol) == S_RETURN ) ReadReturn(    follow    );
-        else if ( TLS(Symbol) == S_TRYNEXT) ReadTryNext(   follow    );
-	else if ( TLS(Symbol) == S_QUIT   ) ReadQuit(      follow    );
-	else if ( TLS(Symbol) == S_ATOMIC ) ReadAtomic(    follow    );
+        if      ( STATE(Symbol) == S_IDENT  ) ReadCallVarAss(follow,'s');
+        else if ( STATE(Symbol) == S_UNBIND ) ReadUnbind(    follow    );
+        else if ( STATE(Symbol) == S_INFO   ) ReadInfo(      follow    );
+        else if ( STATE(Symbol) == S_ASSERT ) ReadAssert(    follow    );
+        else if ( STATE(Symbol) == S_IF     ) ReadIf(        follow    );
+        else if ( STATE(Symbol) == S_FOR    ) ReadFor(       follow    );
+        else if ( STATE(Symbol) == S_WHILE  ) ReadWhile(     follow    );
+        else if ( STATE(Symbol) == S_REPEAT ) ReadRepeat(    follow    );
+        else if ( STATE(Symbol) == S_BREAK  ) ReadBreak(     follow    );
+        else if ( STATE(Symbol) == S_CONTINUE) ReadContinue(     follow    );
+        else if ( STATE(Symbol) == S_RETURN ) ReadReturn(    follow    );
+        else if ( STATE(Symbol) == S_TRYNEXT) ReadTryNext(   follow    );
+	else if ( STATE(Symbol) == S_QUIT   ) ReadQuit(      follow    );
+	else if ( STATE(Symbol) == S_ATOMIC ) ReadAtomic(    follow    );
 	else                           ReadEmpty(     follow    );
 	nr++;
         Match( S_SEMICOLON, ";", follow );
@@ -2667,27 +2667,27 @@ void RecreateStackNams( Obj context )
   Obj lvars = context;
   Obj nams;
   UInt i;
-  while (lvars != TLS(BottomLVars) && lvars != (Obj)0)
+  while (lvars != STATE(BottomLVars) && lvars != (Obj)0)
     {
       nams = NAMS_FUNC(PTR_BAG(lvars)[0]);
       if (nams != (Obj) 0)
 	{
-	  GROW_PLIST(TLS(StackNams), ++TLS(CountNams));
-	  SET_ELM_PLIST( TLS(StackNams), TLS(CountNams), nams);
-	  SET_LEN_PLIST( TLS(StackNams), TLS(CountNams));
+	  GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
+	  SET_ELM_PLIST( STATE(StackNams), STATE(CountNams), nams);
+	  SET_LEN_PLIST( STATE(StackNams), STATE(CountNams));
 	}
       lvars = ENVI_FUNC(PTR_BAG(lvars)[0]);
     }
 
   /* At this point we have the stack upside down, so invert it */
-  for (i = 1; i <= TLS(CountNams)/2; i++)
+  for (i = 1; i <= STATE(CountNams)/2; i++)
     {
-      nams = ELM_PLIST(TLS(StackNams), i);
-      SET_ELM_PLIST( TLS(StackNams),
+      nams = ELM_PLIST(STATE(StackNams), i);
+      SET_ELM_PLIST( STATE(StackNams),
 		     i,
-		     ELM_PLIST(TLS(StackNams), TLS(CountNams) + 1 -i));
-      SET_ELM_PLIST( TLS(StackNams),
-		     TLS(CountNams) + 1 -i,
+		     ELM_PLIST(STATE(StackNams), STATE(CountNams) + 1 -i));
+      SET_ELM_PLIST( STATE(StackNams),
+		     STATE(CountNams) + 1 -i,
 		     nams);
     }
 }
@@ -2707,76 +2707,76 @@ ExecStatus ReadEvalCommand ( Obj context, UInt *dualSemicolon )
     int			lockSP;
 
     /* get the first symbol from the input                                 */
-    Match( TLS(Symbol), "", 0UL );
+    Match( STATE(Symbol), "", 0UL );
 
     /* using TRY_READ sets the jump buffer and mucks up the interpreter    */
-    if (TLS(NrError)) {
+    if (STATE(NrError)) {
         return STATUS_ERROR;
     }
 
     /* if we have hit <end-of-file>, then give up                          */
-    if ( TLS(Symbol) == S_EOF )  { return STATUS_EOF; }
+    if ( STATE(Symbol) == S_EOF )  { return STATUS_EOF; }
 
     /* print only a partial prompt from now on                             */
     if ( !SyQuiet )
-      TLS(Prompt) = "> ";
+      STATE(Prompt) = "> ";
     else
-      TLS(Prompt) = "";
+      STATE(Prompt) = "";
 
     /* remember the old reader context                                     */
-    stackNams   = TLS(StackNams);
-    countNams   = TLS(CountNams);
-    readTop     = TLS(ReadTop);
-    readTilde   = TLS(ReadTilde);
-    currLHSGVar = TLS(CurrLHSGVar);
-    memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+    stackNams   = STATE(StackNams);
+    countNams   = STATE(CountNams);
+    readTop     = STATE(ReadTop);
+    readTilde   = STATE(ReadTilde);
+    currLHSGVar = STATE(CurrLHSGVar);
+    memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
 
     /* intialize everything and begin an interpreter                       */
-    TLS(StackNams)   = NEW_PLIST( T_PLIST, 16 );
-    TLS(CountNams)   = 0;
-    TLS(ReadTop)     = 0;
-    TLS(ReadTilde)   = 0;
-    TLS(CurrLHSGVar) = 0;
+    STATE(StackNams)   = NEW_PLIST( T_PLIST, 16 );
+    STATE(CountNams)   = 0;
+    STATE(ReadTop)     = 0;
+    STATE(ReadTilde)   = 0;
+    STATE(CurrLHSGVar) = 0;
     RecreateStackNams(context);
-    errorLVars = TLS(ErrorLVars);
-    errorLVars0 = TLS(ErrorLVars0);
-    TLS(ErrorLVars) = context;
-    TLS(ErrorLVars0) = TLS(ErrorLVars);
+    errorLVars = STATE(ErrorLVars);
+    errorLVars0 = STATE(ErrorLVars0);
+    STATE(ErrorLVars) = context;
+    STATE(ErrorLVars0) = STATE(ErrorLVars);
     lockSP = RegionLockSP();
 
     IntrBegin( context );
 
     /* read an expression or an assignment or a procedure call             */
-    if      (TLS(Symbol) == S_IDENT   ) { ReadExpr(    S_SEMICOLON|S_EOF, 'x' ); }
+    if      (STATE(Symbol) == S_IDENT   ) { ReadExpr(    S_SEMICOLON|S_EOF, 'x' ); }
 
     /* otherwise read a statement                                          */
-    else if (TLS(Symbol)==S_UNBIND    ) { ReadUnbind(  S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_INFO      ) { ReadInfo(    S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_ASSERT    ) { ReadAssert(  S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_IF        ) { ReadIf(      S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_FOR       ) { ReadFor(     S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_WHILE     ) { ReadWhile(   S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_REPEAT    ) { ReadRepeat(  S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_BREAK     ) { ReadBreak(   S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_CONTINUE  ) { ReadContinue(S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_RETURN    ) { ReadReturn(  S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_TRYNEXT   ) { ReadTryNext( S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_QUIT      ) { ReadQuit(    S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_QQUIT     ) { ReadQUIT(    S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_SEMICOLON ) { ReadEmpty(   S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_ATOMIC    ) { ReadAtomic(  S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_UNBIND    ) { ReadUnbind(  S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_INFO      ) { ReadInfo(    S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_ASSERT    ) { ReadAssert(  S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_IF        ) { ReadIf(      S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_FOR       ) { ReadFor(     S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_WHILE     ) { ReadWhile(   S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_REPEAT    ) { ReadRepeat(  S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_BREAK     ) { ReadBreak(   S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_CONTINUE  ) { ReadContinue(S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_RETURN    ) { ReadReturn(  S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_TRYNEXT   ) { ReadTryNext( S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_QUIT      ) { ReadQuit(    S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_QQUIT     ) { ReadQUIT(    S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_SEMICOLON ) { ReadEmpty(   S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_ATOMIC    ) { ReadAtomic(  S_SEMICOLON|S_EOF      ); }
 
     /* otherwise try to read an expression                                 */
     /* Unless the statement is empty, in which case do nothing             */
     else                           { ReadExpr(    S_SEMICOLON|S_EOF, 'r' ); }
 
     /* every statement must be terminated by a semicolon                  */
-    if ( TLS(Symbol) != S_SEMICOLON ) {
+    if ( STATE(Symbol) != S_SEMICOLON ) {
         SyntaxError( "; expected");
     }
 
     /* check for dual semicolon                                            */
-    if ( *TLS(In) == ';' ) {
+    if ( *STATE(In) == ';' ) {
         GetSymbol();
         if (dualSemicolon) *dualSemicolon = 1;
     }
@@ -2798,17 +2798,17 @@ ExecStatus ReadEvalCommand ( Obj context, UInt *dualSemicolon )
     }
 
     /* switch back to the old reader context                               */
-    memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
-    TLS(StackNams)   = stackNams;
-    TLS(CountNams)   = countNams;
-    TLS(ReadTop)     = readTop;
-    TLS(ReadTilde)   = readTilde;
-    TLS(CurrLHSGVar) = currLHSGVar;
-    TLS(ErrorLVars) = errorLVars;
-    TLS(ErrorLVars0) = errorLVars0;
+    memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+    STATE(StackNams)   = stackNams;
+    STATE(CountNams)   = countNams;
+    STATE(ReadTop)     = readTop;
+    STATE(ReadTilde)   = readTilde;
+    STATE(CurrLHSGVar) = currLHSGVar;
+    STATE(ErrorLVars) = errorLVars;
+    STATE(ErrorLVars0) = errorLVars0;
 
     /* copy the result (if any)                                            */
-    TLS(ReadEvalResult) = TLS(IntrResult);
+    STATE(ReadEvalResult) = STATE(IntrResult);
 
     /* return whether a return-statement or a quit-statement were executed */
     return type;
@@ -2841,55 +2841,55 @@ UInt ReadEvalFile ( void )
     volatile int	lockSP;
 
     /* get the first symbol from the input                                 */
-    Match( TLS(Symbol), "", 0UL );
+    Match( STATE(Symbol), "", 0UL );
 
     /* if we have hit <end-of-file>, then give up                          */
-    if ( TLS(Symbol) == S_EOF )  { return STATUS_EOF; }
+    if ( STATE(Symbol) == S_EOF )  { return STATUS_EOF; }
 
     /* print only a partial prompt from now on                             */
     if ( !SyQuiet )
-      TLS(Prompt) = "> ";
+      STATE(Prompt) = "> ";
     else
-      TLS(Prompt) = "";
+      STATE(Prompt) = "";
 
     /* remember the old reader context                                     */
-    stackNams   = TLS(StackNams);
-    countNams   = TLS(CountNams);
-    readTop     = TLS(ReadTop);
-    readTilde   = TLS(ReadTilde);
-    currLHSGVar = TLS(CurrLHSGVar);
+    stackNams   = STATE(StackNams);
+    countNams   = STATE(CountNams);
+    readTop     = STATE(ReadTop);
+    readTilde   = STATE(ReadTilde);
+    currLHSGVar = STATE(CurrLHSGVar);
     lockSP      = RegionLockSP();
-    memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+    memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
 
     /* intialize everything and begin an interpreter                       */
-    TLS(StackNams)   = NEW_PLIST( T_PLIST, 16 );
-    TLS(CountNams)   = 0;
-    TLS(ReadTop)     = 0;
-    TLS(ReadTilde)   = 0;
-    TLS(CurrLHSGVar) = 0;
-    IntrBegin(TLS(BottomLVars));
+    STATE(StackNams)   = NEW_PLIST( T_PLIST, 16 );
+    STATE(CountNams)   = 0;
+    STATE(ReadTop)     = 0;
+    STATE(ReadTilde)   = 0;
+    STATE(CurrLHSGVar) = 0;
+    IntrBegin(STATE(BottomLVars));
 
     /* check for local variables                                           */
     nloc = 0;
     nams = NEW_PLIST( T_PLIST, nloc );
     SET_LEN_PLIST( nams, nloc );
-    TLS(CountNams) += 1;
-    ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
-    if ( TLS(Symbol) == S_LOCAL ) {
+    STATE(CountNams) += 1;
+    ASS_LIST( STATE(StackNams), STATE(CountNams), nams );
+    if ( STATE(Symbol) == S_LOCAL ) {
         Match( S_LOCAL, "local", 0L );
-        C_NEW_STRING_DYN( name, TLS(Value) );
+        C_NEW_STRING_DYN( name, STATE(Value) );
         nloc += 1;
         ASS_LIST( nams, nloc, name );
         Match( S_IDENT, "identifier", STATBEGIN|S_END );
-        while ( TLS(Symbol) == S_COMMA ) {
-            TLS(Value)[0] = '\0';
+        while ( STATE(Symbol) == S_COMMA ) {
+            STATE(Value)[0] = '\0';
             Match( S_COMMA, ",", 0L );
             for ( i = 1; i <= nloc; i++ ) {
-                if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
+                if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),STATE(Value)) == 0 ) {
                     SyntaxError("Name used for two locals");
                 }
             }
-            C_NEW_STRING_DYN( name, TLS(Value) );
+            C_NEW_STRING_DYN( name, STATE(Value) );
             nloc += 1;
             ASS_LIST( nams, nloc, name );
             Match( S_IDENT, "identifier", STATBEGIN|S_END );
@@ -2898,13 +2898,13 @@ UInt ReadEvalFile ( void )
     }
 
     /* fake the 'function ()'                                              */
-    IntrFuncExprBegin( 0L, nloc, nams, TLS(Input)->number );
+    IntrFuncExprBegin( 0L, nloc, nams, STATE(Input)->number );
 
     /* read the statements                                                 */
     nr = ReadStats( S_SEMICOLON | S_EOF );
 
     /* we now want to be at <end-of-file>                                  */
-    if ( TLS(Symbol) != S_EOF ) {
+    if ( STATE(Symbol) != S_EOF ) {
         SyntaxError("<end-of-file> expected");
     }
 
@@ -2915,7 +2915,7 @@ UInt ReadEvalFile ( void )
     CATCH_READ_ERROR {
         Obj fexp;
         CodeEnd(1);
-        TLS(IntrCoding)--;
+        STATE(IntrCoding)--;
         fexp = CURR_FUNC;
         if (fexp && ENVI_FUNC(fexp))  SWITCH_TO_OLD_LVARS(ENVI_FUNC(fexp));
     }
@@ -2930,18 +2930,18 @@ UInt ReadEvalFile ( void )
     }
 
     /* switch back to the old reader context                               */
-    memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+    memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
     PopRegionLocks(lockSP);
     if (TLS(CurrentHashLock))
       HashUnlock(TLS(CurrentHashLock));
-    TLS(StackNams)   = stackNams;
-    TLS(CountNams)   = countNams;
-    TLS(ReadTop)     = readTop;
-    TLS(ReadTilde)   = readTilde;
-    TLS(CurrLHSGVar) = currLHSGVar;
+    STATE(StackNams)   = stackNams;
+    STATE(CountNams)   = countNams;
+    STATE(ReadTop)     = readTop;
+    STATE(ReadTilde)   = readTilde;
+    STATE(CurrLHSGVar) = currLHSGVar;
 
     /* copy the result (if any)                                            */
-    TLS(ReadEvalResult) = TLS(IntrResult);
+    STATE(ReadEvalResult) = STATE(IntrResult);
 
     /* return whether a return-statement or a quit-statement were executed */
     return type;
@@ -2954,9 +2954,9 @@ UInt ReadEvalFile ( void )
 */
 void            ReadEvalError ( void )
 {
-    TLS(PtrBody)  = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
-    TLS(PtrLVars) = PTR_BAG(TLS(CurrLVars));
-    syLongjmp( TLS(ReadJmpError), 1 );
+    STATE(PtrBody)  = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+    STATE(PtrLVars) = PTR_BAG(STATE(CurrLVars));
+    syLongjmp( STATE(ReadJmpError), 1 );
 }
 
 
@@ -2983,44 +2983,44 @@ struct SavedReaderState {
 };
 
 static void SaveReaderState( struct SavedReaderState *s) {
-  s->stackNams   = TLS(StackNams);
-  s->countNams   = TLS(CountNams);
-  s->readTop     = TLS(ReadTop);
-  s->readTilde   = TLS(ReadTilde);
-  s->currLHSGVar = TLS(CurrLHSGVar);
-  s->userHasQuit = TLS(UserHasQuit);
-  s->intrCoding = TLS(IntrCoding);
-  s->intrIgnoring = TLS(IntrIgnoring);
-  s->intrReturning = TLS(IntrReturning);
-  s->nrError = TLS(NrError);
-  memcpy( s->readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+  s->stackNams   = STATE(StackNams);
+  s->countNams   = STATE(CountNams);
+  s->readTop     = STATE(ReadTop);
+  s->readTilde   = STATE(ReadTilde);
+  s->currLHSGVar = STATE(CurrLHSGVar);
+  s->userHasQuit = STATE(UserHasQuit);
+  s->intrCoding = STATE(IntrCoding);
+  s->intrIgnoring = STATE(IntrIgnoring);
+  s->intrReturning = STATE(IntrReturning);
+  s->nrError = STATE(NrError);
+  memcpy( s->readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
 }
 
 static void ClearReaderState( void ) {
-  TLS(StackNams)   = NEW_PLIST( T_PLIST, 16 );
-  TLS(CountNams)   = 0;
-  TLS(ReadTop)     = 0;
-  TLS(ReadTilde)   = 0;
-  TLS(CurrLHSGVar) = 0;
-  TLS(UserHasQuit) = 0;
-  TLS(IntrCoding) = 0;
-  TLS(IntrIgnoring) = 0;
-  TLS(IntrReturning) = 0;
-  TLS(NrError) = 0;
+  STATE(StackNams)   = NEW_PLIST( T_PLIST, 16 );
+  STATE(CountNams)   = 0;
+  STATE(ReadTop)     = 0;
+  STATE(ReadTilde)   = 0;
+  STATE(CurrLHSGVar) = 0;
+  STATE(UserHasQuit) = 0;
+  STATE(IntrCoding) = 0;
+  STATE(IntrIgnoring) = 0;
+  STATE(IntrReturning) = 0;
+  STATE(NrError) = 0;
 }
 
 static void RestoreReaderState( const struct SavedReaderState *s) {
-  memcpy( TLS(ReadJmpError), s->readJmpError, sizeof(syJmp_buf) );
-  TLS(UserHasQuit) = s->userHasQuit;
-  TLS(StackNams)   = s->stackNams;
-  TLS(CountNams)   = s->countNams;
-  TLS(ReadTop)     = s->readTop;
-  TLS(ReadTilde)   = s->readTilde;
-  TLS(CurrLHSGVar) = s->currLHSGVar;
-  TLS(IntrCoding) = s->intrCoding;
-  TLS(IntrIgnoring) = s->intrIgnoring;
-  TLS(IntrReturning) = s->intrReturning;
-  TLS(NrError) = s->nrError;
+  memcpy( STATE(ReadJmpError), s->readJmpError, sizeof(syJmp_buf) );
+  STATE(UserHasQuit) = s->userHasQuit;
+  STATE(StackNams)   = s->stackNams;
+  STATE(CountNams)   = s->countNams;
+  STATE(ReadTop)     = s->readTop;
+  STATE(ReadTilde)   = s->readTilde;
+  STATE(CurrLHSGVar) = s->currLHSGVar;
+  STATE(IntrCoding) = s->intrCoding;
+  STATE(IntrIgnoring) = s->intrIgnoring;
+  STATE(IntrReturning) = s->intrReturning;
+  STATE(NrError) = s->nrError;
 }
 
 
@@ -3043,7 +3043,7 @@ Obj Call0ArgsInNewReader(Obj f)
 
   /* intialize everything and begin an interpreter                       */
   ClearReaderState();
-  IntrBegin( TLS(BottomLVars) );
+  IntrBegin( STATE(BottomLVars) );
 
   TRY_READ {
     result = CALL_0ARGS(f);
@@ -3082,7 +3082,7 @@ Obj Call1ArgsInNewReader(Obj f,Obj a)
 
   /* intialize everything and begin an interpreter                       */
   ClearReaderState();
-  IntrBegin( TLS(BottomLVars) );
+  IntrBegin( STATE(BottomLVars) );
 
   TRY_READ {
     result = CALL_1ARGS(f,a);
@@ -3115,8 +3115,8 @@ Obj Call1ArgsInNewReader(Obj f,Obj a)
 static Int InitKernel (
     StructInitInfo *    module )
 {
-    TLS(ErrorLVars) = (UInt **)0;
-    TLS(CurrentGlobalForLoopDepth) = 0;
+    STATE(ErrorLVars) = (UInt **)0;
+    STATE(CurrentGlobalForLoopDepth) = 0;
     /* TL: InitGlobalBag( &ReadEvalResult, "src/read.c:ReadEvalResult" ); */
     /* TL: InitGlobalBag( &StackNams,      "src/read.c:StackNams"      ); */
     InitCopyGVar( "GAPInfo", &GAPInfo);

--- a/hpcgap/src/scanner.c
+++ b/hpcgap/src/scanner.c
@@ -3093,18 +3093,12 @@ StructInitInfo * InitInfoScanner ( void )
   return &module;
 }
 
-/****************************************************************************
- **
- *F  InitScannerTLS() . . . . . . . . . . . . . . . . . . . . . initialize TLS
- *F  DestroyScannerTLS()  . . . . . . . . . . . . . . . . . . . .  destroy TLS
- */
-
-void InitScannerTLS()
+void InitScannerState(GAPState * state)
 {
-  STATE(HELPSubsOn) = 1;
+    state->HELPSubsOn = 1;
 }
 
-void DestroyScannerTLS()
+void DestroyScannerState(GAPState * state)
 {
 }
 

--- a/hpcgap/src/scanner.c
+++ b/hpcgap/src/scanner.c
@@ -107,36 +107,36 @@ void            SyntaxError (
 
     /* open error output                                                   */
     OpenOutput( "*errout*" );
-    assert(TLS(Output));
+    assert(STATE(Output));
 
     /* one more error                                                      */
-    TLS(NrError)++;
-    TLS(NrErrLine)++;
+    STATE(NrError)++;
+    STATE(NrErrLine)++;
 
     /* do not print a message if we found one already on the current line  */
-    if ( TLS(NrErrLine) == 1 )
+    if ( STATE(NrErrLine) == 1 )
 
       {
         /* print the message and the filename, unless it is '*stdin*'          */
         Pr( "Syntax error: %s", (Int)msg, 0L );
-        if ( strcmp( "*stdin*", TLS(Input)->name ) != 0 )
-          Pr( " in %s:%d", (Int)TLS(Input)->name, (Int)TLS(Input)->number );
+        if ( strcmp( "*stdin*", STATE(Input)->name ) != 0 )
+          Pr( " in %s:%d", (Int)STATE(Input)->name, (Int)STATE(Input)->number );
         Pr( "\n", 0L, 0L );
 
         /* print the current line                                              */
-        Pr( "%s", (Int)TLS(Input)->line, 0L );
+        Pr( "%s", (Int)STATE(Input)->line, 0L );
 
         /* print a '^' pointing to the current position                        */
-        for ( i = 0; i < TLS(In) - TLS(Input)->line - 1; i++ ) {
-          if ( TLS(Input)->line[i] == '\t' )  Pr("\t",0L,0L);
+        for ( i = 0; i < STATE(In) - STATE(Input)->line - 1; i++ ) {
+          if ( STATE(Input)->line[i] == '\t' )  Pr("\t",0L,0L);
           else  Pr(" ",0L,0L);
         }
         Pr( "^\n", 0L, 0L );
       }
     /* close error output                                                  */
-    assert(TLS(Output));
+    assert(STATE(Output));
     CloseOutput();
-    assert(TLS(Output));
+    assert(STATE(Output));
 }
 
 /****************************************************************************
@@ -151,33 +151,33 @@ void            SyntaxWarning (
 
     /* open error output                                                   */
     OpenOutput( "*errout*" );
-    assert(TLS(Output));
+    assert(STATE(Output));
 
 
     /* do not print a message if we found one already on the current line  */
-    if ( TLS(NrErrLine) == 0 )
+    if ( STATE(NrErrLine) == 0 )
 
       {
         /* print the message and the filename, unless it is '*stdin*'          */
         Pr( "Syntax warning: %s", (Int)msg, 0L );
-        if ( strcmp( "*stdin*", TLS(Input)->name ) != 0 )
-          Pr( " in %s:%d", (Int)TLS(Input)->name, (Int)TLS(Input)->number );
+        if ( strcmp( "*stdin*", STATE(Input)->name ) != 0 )
+          Pr( " in %s:%d", (Int)STATE(Input)->name, (Int)STATE(Input)->number );
         Pr( "\n", 0L, 0L );
 
         /* print the current line                                              */
-        Pr( "%s", (Int)TLS(Input)->line, 0L );
+        Pr( "%s", (Int)STATE(Input)->line, 0L );
 
         /* print a '^' pointing to the current position                        */
-        for ( i = 0; i < TLS(In) - TLS(Input)->line - 1; i++ ) {
-          if ( TLS(Input)->line[i] == '\t' )  Pr("\t",0L,0L);
+        for ( i = 0; i < STATE(In) - STATE(Input)->line - 1; i++ ) {
+          if ( STATE(Input)->line[i] == '\t' )  Pr("\t",0L,0L);
           else  Pr(" ",0L,0L);
         }
         Pr( "^\n", 0L, 0L );
       }
     /* close error output                                                  */
-    assert(TLS(Output));
+    assert(STATE(Output));
     CloseOutput();
-    assert(TLS(Output));
+    assert(STATE(Output));
 }
 
 
@@ -231,8 +231,8 @@ void Match (
 {
     Char                errmsg [256];
 
-    /* if 'TLS(Symbol)' is the expected symbol match it away                    */
-    if ( symbol == TLS(Symbol) ) {
+    /* if 'STATE(Symbol)' is the expected symbol match it away                    */
+    if ( symbol == STATE(Symbol) ) {
         GetSymbol();
     }
 
@@ -241,7 +241,7 @@ void Match (
         strlcpy( errmsg, msg, sizeof(errmsg) );
         strlcat( errmsg, " expected", sizeof(errmsg) );
         SyntaxError( errmsg );
-        while ( ! IS_IN( TLS(Symbol), skipto ) )
+        while ( ! IS_IN( STATE(Symbol), skipto ) )
             GetSymbol();
     }
 }
@@ -277,7 +277,7 @@ GVarDescriptor DEFAULT_OUTPUT_STREAM;
 UInt OpenDefaultInput( void )
 {
   Obj func, stream;
-  stream = TLS(DefaultInput);
+  stream = STATE(DefaultInput);
   if (stream)
     return OpenInputStream(stream);
   func = GVarOptFunction(&DEFAULT_INPUT_STREAM);
@@ -288,14 +288,14 @@ UInt OpenDefaultInput( void )
     ErrorQuit("DEFAULT_INPUT_STREAM() did not return a stream", 0L, 0L);
   if (IsStringConv(stream))
     return OpenInput(CSTR_STRING(stream));
-  TLS(DefaultInput) = stream;
+  STATE(DefaultInput) = stream;
   return OpenInputStream(stream);
 }
 
 UInt OpenDefaultOutput( void )
 {
   Obj func, stream;
-  stream = TLS(DefaultOutput);
+  stream = STATE(DefaultOutput);
   if (stream)
     return OpenOutputStream(stream);
   func = GVarOptFunction(&DEFAULT_OUTPUT_STREAM);
@@ -306,15 +306,15 @@ UInt OpenDefaultOutput( void )
     ErrorQuit("DEFAULT_OUTPUT_STREAM() did not return a stream", 0L, 0L);
   if (IsStringConv(stream))
     return OpenOutput(CSTR_STRING(stream));
-  TLS(DefaultOutput) = stream;
+  STATE(DefaultOutput) = stream;
   return OpenOutputStream(stream);
 }
 
 TypOutputFile *GetCurrentOutput() {
-  if (!TLS(Output)) {
+  if (!STATE(Output)) {
     OpenDefaultOutput();
   }
-  return TLS(Output);
+  return STATE(Output);
 }
 
 
@@ -358,13 +358,13 @@ UInt OpenInput (
     int sp;
 
     /* fail if we can not handle another open input file                   */
-    if ( TLS(InputFilesSP) == (sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0]))-1 )
+    if ( STATE(InputFilesSP) == (sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0]))-1 )
         return 0;
 
     /* Handle *defin*; redirect *errin* to *defin* if the default
      * channel is already open. */
     if (! strcmp(filename, "*defin*") ||
-        (! strcmp(filename, "*errin*") && TLS(DefaultInput)) )
+        (! strcmp(filename, "*errin*") && STATE(DefaultInput)) )
         return OpenDefaultInput();
     /* try to open the input file                                          */
     file = SyFopen( filename, "r" );
@@ -372,33 +372,33 @@ UInt OpenInput (
         return 0;
 
     /* remember the current position in the current file                   */
-    if ( TLS(InputFilesSP) != 0 ) {
-        TLS(Input)->ptr    = TLS(In);
-        TLS(Input)->symbol = TLS(Symbol);
+    if ( STATE(InputFilesSP) != 0 ) {
+        STATE(Input)->ptr    = STATE(In);
+        STATE(Input)->symbol = STATE(Symbol);
     }
 
     /* enter the file identifier and the file name                         */
-    sp = TLS(InputFilesSP)++;
-    if (!TLS(InputFiles)[sp])
+    sp = STATE(InputFilesSP)++;
+    if (!STATE(InputFiles)[sp])
     {
-      TLS(InputFiles)[sp] = NewInput();
+      STATE(InputFiles)[sp] = NewInput();
     }
-    TLS(Input) = TLS(InputFiles)[sp];
-    TLS(Input)->isstream = 0;
-    TLS(Input)->file = file;
-    TLS(Input)->name[0] = '\0';
+    STATE(Input) = STATE(InputFiles)[sp];
+    STATE(Input)->isstream = 0;
+    STATE(Input)->file = file;
+    STATE(Input)->name[0] = '\0';
     if (strcmp("*errin*", filename) && strcmp("*stdin*", filename))
-      TLS(Input)->echo = 0;
+      STATE(Input)->echo = 0;
     else
-      TLS(Input)->echo = 1;
-    strlcpy( TLS(Input)->name, filename, sizeof(TLS(Input)->name) );
-    TLS(Input)->gapname = (Obj) 0;
+      STATE(Input)->echo = 1;
+    strlcpy( STATE(Input)->name, filename, sizeof(STATE(Input)->name) );
+    STATE(Input)->gapname = (Obj) 0;
 
     /* start with an empty line and no symbol                              */
-    TLS(In) = TLS(Input)->line;
-    TLS(In)[0] = TLS(In)[1] = '\0';
-    TLS(Symbol) = S_ILLEGAL;
-    TLS(Input)->number = 1;
+    STATE(In) = STATE(Input)->line;
+    STATE(In)[0] = STATE(In)[1] = '\0';
+    STATE(Symbol) = S_ILLEGAL;
+    STATE(Input)->number = 1;
 
     /* indicate success                                                    */
     return 1;
@@ -418,42 +418,42 @@ UInt OpenInputStream (
 {
     int sp;
     /* fail if we can not handle another open input file                   */
-    if ( TLS(InputFilesSP) == (sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0]))-1 )
+    if ( STATE(InputFilesSP) == (sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0]))-1 )
         return 0;
 
     /* remember the current position in the current file                   */
-    if ( TLS(InputFilesSP) != 0 ) {
-        TLS(Input)->ptr    = TLS(In);
-        TLS(Input)->symbol = TLS(Symbol);
+    if ( STATE(InputFilesSP) != 0 ) {
+        STATE(Input)->ptr    = STATE(In);
+        STATE(Input)->symbol = STATE(Symbol);
     }
 
     /* enter the file identifier and the file name                         */
-    sp = TLS(InputFilesSP)++;
-    if (!TLS(InputFiles)[sp])
+    sp = STATE(InputFilesSP)++;
+    if (!STATE(InputFiles)[sp])
     {
-      TLS(InputFiles)[sp] = NewInput();
+      STATE(InputFiles)[sp] = NewInput();
     }
-    TLS(Input) = TLS(InputFiles)[sp];
-    TLS(Input)->isstream = 1;
-    TLS(Input)->stream = stream;
-    TLS(Input)->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
-    if (TLS(Input)->isstringstream) {
-        TLS(Input)->sline = ADDR_OBJ(stream)[2];
-        TLS(Input)->spos = INT_INTOBJ(ADDR_OBJ(stream)[1]);
+    STATE(Input) = STATE(InputFiles)[sp];
+    STATE(Input)->isstream = 1;
+    STATE(Input)->stream = stream;
+    STATE(Input)->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
+    if (STATE(Input)->isstringstream) {
+        STATE(Input)->sline = ADDR_OBJ(stream)[2];
+        STATE(Input)->spos = INT_INTOBJ(ADDR_OBJ(stream)[1]);
     }
     else {
-        TLS(Input)->sline = 0;
+        STATE(Input)->sline = 0;
     }
-    TLS(Input)->name[0] = '\0';
-    TLS(Input)->file = -1;
-    TLS(Input)->echo = 0;
-    strlcpy( TLS(Input)->name, "stream", sizeof(TLS(Input)->name) );
+    STATE(Input)->name[0] = '\0';
+    STATE(Input)->file = -1;
+    STATE(Input)->echo = 0;
+    strlcpy( STATE(Input)->name, "stream", sizeof(STATE(Input)->name) );
 
     /* start with an empty line and no symbol                              */
-    TLS(In) = TLS(Input)->line;
-    TLS(In)[0] = TLS(In)[1] = '\0';
-    TLS(Symbol) = S_ILLEGAL;
-    TLS(Input)->number = 1;
+    STATE(In) = STATE(Input)->line;
+    STATE(In)[0] = STATE(In)[1] = '\0';
+    STATE(Symbol) = S_ILLEGAL;
+    STATE(Input)->number = 1;
 
     /* indicate success                                                    */
     return 1;
@@ -478,22 +478,22 @@ UInt OpenInputStream (
 UInt CloseInput ( void )
 {
     /* refuse to close the initial input file                              */
-    if ( TLS(InputFilesSP) <= 1)
+    if ( STATE(InputFilesSP) <= 1)
         return 1;
 
     /* close the input file                                                */
-    if ( ! TLS(Input)->isstream ) {
-        SyFclose( TLS(Input)->file );
+    if ( ! STATE(Input)->isstream ) {
+        SyFclose( STATE(Input)->file );
     }
 
     /* don't keep GAP objects alive unnecessarily */
-    TLS(Input)->gapname = 0;
-    TLS(Input)->sline = 0;
+    STATE(Input)->gapname = 0;
+    STATE(Input)->sline = 0;
 
     /* revert to last file                                                 */
-    TLS(Input) = TLS(InputFiles)[--TLS(InputFilesSP)-1];
-    TLS(In)     = TLS(Input)->ptr;
-    TLS(Symbol) = TLS(Input)->symbol;
+    STATE(Input) = STATE(InputFiles)[--STATE(InputFilesSP)-1];
+    STATE(In)     = STATE(Input)->ptr;
+    STATE(Symbol) = STATE(Input)->symbol;
 
     /* indicate success                                                    */
     return 1;
@@ -507,9 +507,9 @@ UInt CloseInput ( void )
 
 void FlushRestOfInputLine( void )
 {
-  TLS(In)[0] = TLS(In)[1] = '\0';
-  /* TLS(Input)->number = 1; */
-  TLS(Symbol) = S_ILLEGAL;
+  STATE(In)[0] = STATE(In)[1] = '\0';
+  /* STATE(Input)->number = 1; */
+  STATE(Symbol) = S_ILLEGAL;
 }
 
 /****************************************************************************
@@ -535,17 +535,17 @@ UInt OpenLog (
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( TLS(InputLog) != 0 || TLS(OutputLog) != 0 )
+    if ( STATE(InputLog) != 0 || STATE(OutputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    TLS(LogFile).file = SyFopen( filename, "w" );
-    TLS(LogFile).isstream = 0;
-    if ( TLS(LogFile).file == -1 )
+    STATE(LogFile).file = SyFopen( filename, "w" );
+    STATE(LogFile).isstream = 0;
+    if ( STATE(LogFile).file == -1 )
         return 0;
 
-    TLS(InputLog)  = &TLS(LogFile);
-    TLS(OutputLog) = &TLS(LogFile);
+    STATE(InputLog)  = &STATE(LogFile);
+    STATE(OutputLog) = &STATE(LogFile);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -565,16 +565,16 @@ UInt OpenLogStream (
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( TLS(InputLog) != 0 || TLS(OutputLog) != 0 )
+    if ( STATE(InputLog) != 0 || STATE(OutputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    TLS(LogStream).isstream = 1;
-    TLS(LogStream).stream = stream;
-    TLS(LogStream).file = -1;
+    STATE(LogStream).isstream = 1;
+    STATE(LogStream).stream = stream;
+    STATE(LogStream).file = -1;
 
-    TLS(InputLog)  = &TLS(LogStream);
-    TLS(OutputLog) = &TLS(LogStream);
+    STATE(InputLog)  = &STATE(LogStream);
+    STATE(OutputLog) = &STATE(LogStream);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -595,15 +595,15 @@ UInt OpenLogStream (
 UInt CloseLog ( void )
 {
     /* refuse to close a non existent logfile                              */
-    if ( TLS(InputLog) == 0 || TLS(OutputLog) == 0 || TLS(InputLog) != TLS(OutputLog) )
+    if ( STATE(InputLog) == 0 || STATE(OutputLog) == 0 || STATE(InputLog) != STATE(OutputLog) )
         return 0;
 
     /* close the logfile                                                   */
-    if ( ! TLS(InputLog)->isstream ) {
-        SyFclose( TLS(InputLog)->file );
+    if ( ! STATE(InputLog)->isstream ) {
+        SyFclose( STATE(InputLog)->file );
     }
-    TLS(InputLog)  = 0;
-    TLS(OutputLog) = 0;
+    STATE(InputLog)  = 0;
+    STATE(OutputLog) = 0;
 
     /* indicate success                                                    */
     return 1;
@@ -632,16 +632,16 @@ UInt OpenInputLog (
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( TLS(InputLog) != 0 )
+    if ( STATE(InputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    TLS(InputLogFile).file = SyFopen( filename, "w" );
-    TLS(InputLogFile).isstream = 0;
-    if ( TLS(InputLogFile).file == -1 )
+    STATE(InputLogFile).file = SyFopen( filename, "w" );
+    STATE(InputLogFile).isstream = 0;
+    if ( STATE(InputLogFile).file == -1 )
         return 0;
 
-    TLS(InputLog) = &TLS(InputLogFile);
+    STATE(InputLog) = &STATE(InputLogFile);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -661,15 +661,15 @@ UInt OpenInputLogStream (
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( TLS(InputLog) != 0 )
+    if ( STATE(InputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    TLS(InputLogStream).isstream = 1;
-    TLS(InputLogStream).stream = stream;
-    TLS(InputLogStream).file = -1;
+    STATE(InputLogStream).isstream = 1;
+    STATE(InputLogStream).stream = stream;
+    STATE(InputLogStream).file = -1;
 
-    TLS(InputLog) = &TLS(InputLogStream);
+    STATE(InputLog) = &STATE(InputLogStream);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -690,19 +690,19 @@ UInt OpenInputLogStream (
 UInt CloseInputLog ( void )
 {
     /* refuse to close a non existent logfile                              */
-    if ( TLS(InputLog) == 0 )
+    if ( STATE(InputLog) == 0 )
         return 0;
 
     /* refuse to close a log opened with LogTo */
-    if (TLS(InputLog) == TLS(OutputLog))
+    if (STATE(InputLog) == STATE(OutputLog))
       return 0;
     
     /* close the logfile                                                   */
-    if ( ! TLS(InputLog)->isstream ) {
-        SyFclose( TLS(InputLog)->file );
+    if ( ! STATE(InputLog)->isstream ) {
+        SyFclose( STATE(InputLog)->file );
     }
 
-    TLS(InputLog) = 0;
+    STATE(InputLog) = 0;
 
     /* indicate success                                                    */
     return 1;
@@ -731,16 +731,16 @@ UInt OpenOutputLog (
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( TLS(OutputLog) != 0 )
+    if ( STATE(OutputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    TLS(OutputLogFile).file = SyFopen( filename, "w" );
-    TLS(OutputLogFile).isstream = 0;
-    if ( TLS(OutputLogFile).file == -1 )
+    STATE(OutputLogFile).file = SyFopen( filename, "w" );
+    STATE(OutputLogFile).isstream = 0;
+    if ( STATE(OutputLogFile).file == -1 )
         return 0;
 
-    TLS(OutputLog) = &TLS(OutputLogFile);
+    STATE(OutputLog) = &STATE(OutputLogFile);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -760,15 +760,15 @@ UInt OpenOutputLogStream (
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( TLS(OutputLog) != 0 )
+    if ( STATE(OutputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    TLS(OutputLogStream).isstream = 1;
-    TLS(OutputLogStream).stream = stream;
-    TLS(OutputLogStream).file = -1;
+    STATE(OutputLogStream).isstream = 1;
+    STATE(OutputLogStream).stream = stream;
+    STATE(OutputLogStream).file = -1;
 
-    TLS(OutputLog) = &TLS(OutputLogStream);
+    STATE(OutputLog) = &STATE(OutputLogStream);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -789,19 +789,19 @@ UInt OpenOutputLogStream (
 UInt CloseOutputLog ( void )
 {
     /* refuse to close a non existent logfile                              */
-    if ( TLS(OutputLog) == 0 )
+    if ( STATE(OutputLog) == 0 )
         return 0;
 
     /* refuse to close a log opened with LogTo */
-    if (TLS(OutputLog) == TLS(InputLog))
+    if (STATE(OutputLog) == STATE(InputLog))
       return 0;
 
     /* close the logfile                                                   */
-    if ( ! TLS(OutputLog)->isstream ) {
-        SyFclose( TLS(OutputLog)->file );
+    if ( ! STATE(OutputLog)->isstream ) {
+        SyFclose( STATE(OutputLog)->file );
     }
 
-    TLS(OutputLog) = 0;
+    STATE(OutputLog) = 0;
 
     /* indicate success                                                    */
     return 1;
@@ -843,14 +843,14 @@ UInt OpenOutput (
     int sp;
 
     /* do nothing for stdout and errout if catched */
-    if ( TLS(Output) != NULL && TLS(IgnoreStdoutErrout) == TLS(Output) &&
+    if ( STATE(Output) != NULL && STATE(IgnoreStdoutErrout) == STATE(Output) &&
           ( strcmp( filename, "*errout*" ) == 0
            || strcmp( filename, "*stdout*" ) == 0 ) ) {
         return 1;
     }
 
     /* fail if we can not handle another open output file                  */
-    if ( TLS(OutputFilesSP) == sizeof(TLS(OutputFiles))/sizeof(TLS(OutputFiles)[0]))
+    if ( STATE(OutputFilesSP) == sizeof(STATE(OutputFiles))/sizeof(STATE(OutputFiles)[0]))
         return 0;
 
     /* Handle *defout* specially; also, redirect *errout* if we already
@@ -865,21 +865,21 @@ UInt OpenOutput (
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
-    sp = TLS(OutputFilesSP)++;
-    if (!TLS(OutputFiles)[sp])
+    sp = STATE(OutputFilesSP)++;
+    if (!STATE(OutputFiles)[sp])
     {
-      TLS(OutputFiles)[sp] = NewOutput();
+      STATE(OutputFiles)[sp] = NewOutput();
     }
-    TLS(Output) = TLS(OutputFiles)[sp];
-    TLS(Output)->file     = file;
-    TLS(Output)->line[0]  = '\0';
-    TLS(Output)->pos      = 0;
-    TLS(Output)->indent   = 0;
-    TLS(Output)->isstream = 0;
-    TLS(Output)->format   = 1;
+    STATE(Output) = STATE(OutputFiles)[sp];
+    STATE(Output)->file     = file;
+    STATE(Output)->line[0]  = '\0';
+    STATE(Output)->pos      = 0;
+    STATE(Output)->indent   = 0;
+    STATE(Output)->isstream = 0;
+    STATE(Output)->format   = 1;
 
     /* variables related to line splitting, very bad place to split        */
-    TLS(Output)->hints[0] = -1;
+    STATE(Output)->hints[0] = -1;
 
     /* indicate success                                                    */
     return 1;
@@ -900,27 +900,27 @@ UInt OpenOutputStream (
 {
     int sp;
     /* fail if we can not handle another open output file                  */
-    if ( TLS(OutputFilesSP) == sizeof(TLS(OutputFiles))/sizeof(TLS(OutputFiles)[0]))
+    if ( STATE(OutputFilesSP) == sizeof(STATE(OutputFiles))/sizeof(STATE(OutputFiles)[0]))
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
-    sp = TLS(OutputFilesSP)++;
-    if (!TLS(OutputFiles)[sp])
+    sp = STATE(OutputFilesSP)++;
+    if (!STATE(OutputFiles)[sp])
     {
-      TLS(OutputFiles)[sp] = NewOutput();
+      STATE(OutputFiles)[sp] = NewOutput();
     }
 
-    TLS(Output) = TLS(OutputFiles)[sp];
-    TLS(Output)->stream   = stream;
-    TLS(Output)->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
-    TLS(Output)->format   = (CALL_1ARGS(PrintFormattingStatus, stream) == True);
-    TLS(Output)->line[0]  = '\0';
-    TLS(Output)->pos      = 0;
-    TLS(Output)->indent   = 0;
-    TLS(Output)->isstream = 1;
+    STATE(Output) = STATE(OutputFiles)[sp];
+    STATE(Output)->stream   = stream;
+    STATE(Output)->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
+    STATE(Output)->format   = (CALL_1ARGS(PrintFormattingStatus, stream) == True);
+    STATE(Output)->line[0]  = '\0';
+    STATE(Output)->pos      = 0;
+    STATE(Output)->indent   = 0;
+    STATE(Output)->isstream = 1;
 
     /* variables related to line splitting, very bad place to split        */
-    TLS(Output)->hints[0] = -1;
+    STATE(Output)->hints[0] = -1;
 
     /* indicate success                                                    */
     return 1;
@@ -946,27 +946,27 @@ UInt OpenOutputStream (
 */
 UInt CloseOutput ( void )
 {
-    if ( TLS(IgnoreStdoutErrout) == TLS(Output) )
+    if ( STATE(IgnoreStdoutErrout) == STATE(Output) )
         return 1;
 
     /* refuse to close the initial output file '*stdout*'                  */
-    if ( TLS(OutputFilesSP) <= 1 && TLS(Output)->isstream
-         && TLS(DefaultOutput) == TLS(Output)->stream)
+    if ( STATE(OutputFilesSP) <= 1 && STATE(Output)->isstream
+         && STATE(DefaultOutput) == STATE(Output)->stream)
       return 1;
 
 
     /* flush output and close the file                                     */
     Pr( "%c", (Int)'\03', 0L );
-    if ( ! TLS(Output)->isstream ) {
-        SyFclose( TLS(Output)->file );
+    if ( ! STATE(Output)->isstream ) {
+        SyFclose( STATE(Output)->file );
     }
 
     /* revert to previous output file and indicate success                 */
-    --TLS(OutputFilesSP);
-    if (TLS(OutputFilesSP))
-      TLS(Output) = TLS(OutputFiles)[TLS(OutputFilesSP)-1];
+    --STATE(OutputFilesSP);
+    if (STATE(OutputFilesSP))
+      STATE(Output) = STATE(OutputFiles)[STATE(OutputFilesSP)-1];
     else
-      TLS(Output) = 0;
+      STATE(Output) = 0;
     return 1;
 }
 
@@ -989,7 +989,7 @@ UInt OpenAppend (
     int sp;
 
     /* fail if we can not handle another open output file                  */
-    if ( TLS(OutputFilesSP) == sizeof(TLS(OutputFiles))/sizeof(TLS(OutputFiles)[0]))
+    if ( STATE(OutputFilesSP) == sizeof(STATE(OutputFiles))/sizeof(STATE(OutputFiles)[0]))
         return 0;
 
     if ( ! strcmp( filename, "*defout*") )
@@ -1001,21 +1001,21 @@ UInt OpenAppend (
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
-    sp = TLS(OutputFilesSP)++;
-    if (!TLS(OutputFiles)[sp])
+    sp = STATE(OutputFilesSP)++;
+    if (!STATE(OutputFiles)[sp])
     {
-      TLS(OutputFiles)[sp] = NewOutput();
+      STATE(OutputFiles)[sp] = NewOutput();
     }
 
-    TLS(Output) = TLS(OutputFiles)[sp];
-    TLS(Output)->file     = file;
-    TLS(Output)->line[0]  = '\0';
-    TLS(Output)->pos      = 0;
-    TLS(Output)->indent   = 0;
-    TLS(Output)->isstream = 0;
+    STATE(Output) = STATE(OutputFiles)[sp];
+    STATE(Output)->file     = file;
+    STATE(Output)->line[0]  = '\0';
+    STATE(Output)->pos      = 0;
+    STATE(Output)->indent   = 0;
+    STATE(Output)->isstream = 0;
 
     /* variables related to line splitting, very bad place to split        */
-    TLS(Output)->hints[0] = -1;
+    STATE(Output)->hints[0] = -1;
 
     /* indicate success                                                    */
     return 1;
@@ -1047,9 +1047,9 @@ static Int GetLine2 (
     UInt                    length )
 {
     if ( ! input ) {
-      input = TLS(Input);
+      input = STATE(Input);
       if ( ! input ) OpenDefaultInput();
-      input = TLS(Input);
+      input = STATE(Input);
     }
 
     if ( input->isstream ) {
@@ -1136,40 +1136,40 @@ Char GetLine ( void )
     /* if file is '*stdin*' or '*errin*' print the prompt and flush it     */
     /* if the GAP function `PrintPromptHook' is defined then it is called  */
     /* for printing the prompt, see also `EndLineHook'                     */
-    if ( ! TLS(Input)->isstream ) {
-       if ( TLS(Input)->file == 0 ) {
+    if ( ! STATE(Input)->isstream ) {
+       if ( STATE(Input)->file == 0 ) {
             if ( ! SyQuiet ) {
-                if (TLS(Output)->pos > 0)
+                if (STATE(Output)->pos > 0)
                     Pr("\n", 0L, 0L);
                 if ( PrintPromptHook )
                      Call0ArgsInNewReader( PrintPromptHook );
                 else
-                     Pr( "%s%c", (Int)TLS(Prompt), (Int)'\03' );
+                     Pr( "%s%c", (Int)STATE(Prompt), (Int)'\03' );
             } else
                 Pr( "%c", (Int)'\03', 0L );
         }
-        else if ( TLS(Input)->file == 2 ) {
-            if (TLS(Output)->pos > 0)
+        else if ( STATE(Input)->file == 2 ) {
+            if (STATE(Output)->pos > 0)
                 Pr("\n", 0L, 0L);
             if ( PrintPromptHook )
                  Call0ArgsInNewReader( PrintPromptHook );
             else
-                 Pr( "%s%c", (Int)TLS(Prompt), (Int)'\03' );
+                 Pr( "%s%c", (Int)STATE(Prompt), (Int)'\03' );
         }
     }
 
     /* bump the line number                                                */
-    if ( TLS(Input)->line < TLS(In) && (*(TLS(In)-1) == '\n' || *(TLS(In)-1) == '\r') ) {
-        TLS(Input)->number++;
+    if ( STATE(Input)->line < STATE(In) && (*(STATE(In)-1) == '\n' || *(STATE(In)-1) == '\r') ) {
+        STATE(Input)->number++;
     }
 
-    /* initialize 'TLS(In)', no errors on this line so far                      */
-    TLS(In) = TLS(Input)->line;  TLS(In)[0] = '\0';
-    TLS(NrErrLine) = 0;
+    /* initialize 'STATE(In)', no errors on this line so far                      */
+    STATE(In) = STATE(Input)->line;  STATE(In)[0] = '\0';
+    STATE(NrErrLine) = 0;
 
     /* try to read a line                                              */
-    if ( ! GetLine2( TLS(Input), TLS(Input)->line, sizeof(TLS(Input)->line) ) ) {
-        TLS(In)[0] = '\377';  TLS(In)[1] = '\0';
+    if ( ! GetLine2( STATE(Input), STATE(Input)->line, sizeof(STATE(Input)->line) ) ) {
+        STATE(In)[0] = '\377';  STATE(In)[1] = '\0';
     }
 
 
@@ -1177,10 +1177,10 @@ Char GetLine ( void )
        (if not inside reading long string which may have line
        or chunk from GetLine starting with '?')                        */
 
-    if ( TLS(In)[0] == '?' && TLS(HELPSubsOn) == 1) {
-        strlcpy( buf, TLS(In)+1, sizeof(buf) );
-        strcpy( TLS(In), "HELP(\"" );
-        for ( p = TLS(In)+6,  q = buf;  *q;  q++ ) {
+    if ( STATE(In)[0] == '?' && STATE(HELPSubsOn) == 1) {
+        strlcpy( buf, STATE(In)+1, sizeof(buf) );
+        strcpy( STATE(In), "HELP(\"" );
+        for ( p = STATE(In)+6,  q = buf;  *q;  q++ ) {
             if ( *q != '"' && *q != '\n' ) {
                 *p++ = *q;
             }
@@ -1191,16 +1191,16 @@ Char GetLine ( void )
         }
         *p = '\0';
         /* FIXME: We should do bounds checking, but don't know what 'In' points to */
-        strcat( TLS(In), "\");\n" );
+        strcat( STATE(In), "\");\n" );
     }
 
     /* if necessary echo the line to the logfile                      */
-    if( TLS(InputLog) != 0 && TLS(Input)->echo == 1)
-        if ( !(TLS(In)[0] == '\377' && TLS(In)[1] == '\0') )
-            PutLine2( TLS(InputLog), TLS(In), strlen(TLS(In)) );
+    if( STATE(InputLog) != 0 && STATE(Input)->echo == 1)
+        if ( !(STATE(In)[0] == '\377' && STATE(In)[1] == '\0') )
+            PutLine2( STATE(InputLog), STATE(In), strlen(STATE(In)) );
 
     /* return the current character                                        */
-    return *TLS(In);
+    return *STATE(In);
 }
 
 
@@ -1221,19 +1221,19 @@ static Char Pushback = '\0';
 static Char *RealIn;
 
 static inline void GET_CHAR( void ) {
-  if (TLS(In) == &Pushback) {
-      TLS(In) = RealIn;
+  if (STATE(In) == &Pushback) {
+      STATE(In) = RealIn;
   } else
-    TLS(In)++;
-  if (!*TLS(In))
+    STATE(In)++;
+  if (!*STATE(In))
     GetLine();
 }
 
 static inline void UNGET_CHAR( Char c ) {
-  assert(TLS(In) != &Pushback);
+  assert(STATE(In) != &Pushback);
   Pushback = c;
-  RealIn = TLS(In);
-  TLS(In) = &Pushback;
+  RealIn = STATE(In);
+  STATE(In) = &Pushback;
 }
 
 
@@ -1242,10 +1242,10 @@ static inline void UNGET_CHAR( Char c ) {
 *F  GetIdent()  . . . . . . . . . . . . . get an identifier or keyword, local
 **
 **  'GetIdent' reads   an identifier from  the current  input  file  into the
-**  variable 'TLS(Value)' and sets 'Symbol' to 'S_IDENT'.   The first character of
+**  variable 'STATE(Value)' and sets 'Symbol' to 'S_IDENT'.   The first character of
 **  the   identifier  is  the current character  pointed to  by 'In'.  If the
 **  characters make  up   a  keyword 'GetIdent'  will  set   'Symbol'  to the
-**  corresponding value.  The parser will ignore 'TLS(Value)' in this case.
+**  corresponding value.  The parser will ignore 'STATE(Value)' in this case.
 **
 **  An  identifier consists of a letter  followed by more letters, digits and
 **  underscores '_'.  An identifier is terminated by the first  character not
@@ -1254,19 +1254,19 @@ static inline void UNGET_CHAR( Char c ) {
 **  '\' can be used  to include special characters like  '('  in identifiers.
 **  For example 'G\(2\,5\)' is an identifier not a call to a function 'G'.
 **
-**  The size  of 'TLS(Value)' limits the  number  of significant characters  in an
+**  The size  of 'STATE(Value)' limits the  number  of significant characters  in an
 **  identifier.   If  an  identifier   has more characters    'GetIdent' will
 **  silently truncate it.
 **
 **  After reading the identifier 'GetIdent'  looks at the  first and the last
-**  character  of  'TLS(Value)' to see if  it  could possibly  be  a keyword.  For
+**  character  of  'STATE(Value)' to see if  it  could possibly  be  a keyword.  For
 **  example 'test'  could  not be  a  keyword  because there  is  no  keyword
 **  starting and ending with a 't'.  After that  test either 'GetIdent' knows
-**  that 'TLS(Value)' is not a keyword, or there is a unique possible keyword that
+**  that 'STATE(Value)' is not a keyword, or there is a unique possible keyword that
 **  could match, because   no two  keywords  have  identical  first and  last
-**  characters.  For example if 'TLS(Value)' starts with 'f' and ends with 'n' the
+**  characters.  For example if 'STATE(Value)' starts with 'f' and ends with 'n' the
 **  only possible keyword  is 'function'.   Thus in this case  'GetIdent' can
-**  decide with one string comparison if 'TLS(Value)' holds a keyword or not.
+**  decide with one string comparison if 'STATE(Value)' holds a keyword or not.
 */
 extern void GetSymbol ( void );
 
@@ -1322,39 +1322,39 @@ void GetIdent ( void )
     /* initially it could be a keyword                                     */
     isQuoted = 0;
 
-    /* read all characters into 'TLS(Value)'                                    */
-    for ( i=0; IsIdent(*TLS(In)) || IsDigit(*TLS(In)) || *TLS(In)=='\\'; i++ ) {
+    /* read all characters into 'STATE(Value)'                                    */
+    for ( i=0; IsIdent(*STATE(In)) || IsDigit(*STATE(In)) || *STATE(In)=='\\'; i++ ) {
 
         fetch = 1;
         /* handle escape sequences                                         */
         /* we ignore '\ newline' by decrementing i, except at the
            very start of the identifier, when we cannot do that
            so we recurse instead                                           */
-        if ( *TLS(In) == '\\' ) {
+        if ( *STATE(In) == '\\' ) {
             GET_CHAR();
-            if      ( *TLS(In) == '\n' && i == 0 )  { GetSymbol();  return; }
-            else if ( *TLS(In) == '\r' )  {
+            if      ( *STATE(In) == '\n' && i == 0 )  { GetSymbol();  return; }
+            else if ( *STATE(In) == '\r' )  {
                 GET_CHAR();
-                if  ( *TLS(In) == '\n' )  {
+                if  ( *STATE(In) == '\n' )  {
                      if (i == 0) { GetSymbol();  return; }
                      else i--;
                 }
-                else  {TLS(Value)[i] = '\r'; fetch = 0;}
+                else  {STATE(Value)[i] = '\r'; fetch = 0;}
             }
-            else if ( *TLS(In) == '\n' && i < SAFE_VALUE_SIZE-1 )  i--;
-            else if ( *TLS(In) == 'n'  && i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = '\n';
-            else if ( *TLS(In) == 't'  && i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = '\t';
-            else if ( *TLS(In) == 'r'  && i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = '\r';
-            else if ( *TLS(In) == 'b'  && i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = '\b';
+            else if ( *STATE(In) == '\n' && i < SAFE_VALUE_SIZE-1 )  i--;
+            else if ( *STATE(In) == 'n'  && i < SAFE_VALUE_SIZE-1 )  STATE(Value)[i] = '\n';
+            else if ( *STATE(In) == 't'  && i < SAFE_VALUE_SIZE-1 )  STATE(Value)[i] = '\t';
+            else if ( *STATE(In) == 'r'  && i < SAFE_VALUE_SIZE-1 )  STATE(Value)[i] = '\r';
+            else if ( *STATE(In) == 'b'  && i < SAFE_VALUE_SIZE-1 )  STATE(Value)[i] = '\b';
             else if ( i < SAFE_VALUE_SIZE-1 )  {
-                TLS(Value)[i] = *TLS(In);
+                STATE(Value)[i] = *STATE(In);
                 isQuoted = 1;
             }
         }
 
-        /* put normal chars into 'TLS(Value)' but only if there is room         */
+        /* put normal chars into 'STATE(Value)' but only if there is room         */
         else {
-            if ( i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = *TLS(In);
+            if ( i < SAFE_VALUE_SIZE-1 )  STATE(Value)[i] = *STATE(In);
         }
 
         /* read the next character                                         */
@@ -1364,59 +1364,59 @@ void GetIdent ( void )
 
     /* terminate the identifier and lets assume that it is not a keyword   */
     if ( i < SAFE_VALUE_SIZE-1 )
-        TLS(Value)[i] = '\0';
+        STATE(Value)[i] = '\0';
     else {
         SyntaxError("Identifiers in GAP must consist of less than 1023 characters.");
         i =  SAFE_VALUE_SIZE-1;
-        TLS(Value)[i] = '\0';
+        STATE(Value)[i] = '\0';
     }
-    TLS(Symbol) = S_IDENT;
+    STATE(Symbol) = S_IDENT;
 
-    /* now check if 'TLS(Value)' holds a keyword                                */
-    switch ( 256*TLS(Value)[0]+TLS(Value)[i-1] ) {
-    case 256*'a'+'d': if(!strcmp(TLS(Value),"and"))     TLS(Symbol)=S_AND;     break;
-    case 256*'a'+'c': if(!strcmp(TLS(Value),"atomic"))  TLS(Symbol)=S_ATOMIC;  break;
-    case 256*'b'+'k': if(!strcmp(TLS(Value),"break"))   TLS(Symbol)=S_BREAK;   break;
-    case 256*'c'+'e': if(!strcmp(TLS(Value),"continue"))   TLS(Symbol)=S_CONTINUE;   break;
-    case 256*'d'+'o': if(!strcmp(TLS(Value),"do"))      TLS(Symbol)=S_DO;      break;
-    case 256*'e'+'f': if(!strcmp(TLS(Value),"elif"))    TLS(Symbol)=S_ELIF;    break;
-    case 256*'e'+'e': if(!strcmp(TLS(Value),"else"))    TLS(Symbol)=S_ELSE;    break;
-    case 256*'e'+'d': if(!strcmp(TLS(Value),"end"))     TLS(Symbol)=S_END;     break;
-    case 256*'f'+'e': if(!strcmp(TLS(Value),"false"))   TLS(Symbol)=S_FALSE;   break;
-    case 256*'f'+'i': if(!strcmp(TLS(Value),"fi"))      TLS(Symbol)=S_FI;      break;
-    case 256*'f'+'r': if(!strcmp(TLS(Value),"for"))     TLS(Symbol)=S_FOR;     break;
-    case 256*'f'+'n': if(!strcmp(TLS(Value),"function"))TLS(Symbol)=S_FUNCTION;break;
-    case 256*'i'+'f': if(!strcmp(TLS(Value),"if"))      TLS(Symbol)=S_IF;      break;
-    case 256*'i'+'n': if(!strcmp(TLS(Value),"in"))      TLS(Symbol)=S_IN;      break;
-    case 256*'l'+'l': if(!strcmp(TLS(Value),"local"))   TLS(Symbol)=S_LOCAL;   break;
-    case 256*'m'+'d': if(!strcmp(TLS(Value),"mod"))     TLS(Symbol)=S_MOD;     break;
-    case 256*'n'+'t': if(!strcmp(TLS(Value),"not"))     TLS(Symbol)=S_NOT;     break;
-    case 256*'o'+'d': if(!strcmp(TLS(Value),"od"))      TLS(Symbol)=S_OD;      break;
-    case 256*'o'+'r': if(!strcmp(TLS(Value),"or"))      TLS(Symbol)=S_OR;      break;
-    case 256*'r'+'e': if(!strcmp(TLS(Value),"readwrite")) TLS(Symbol)=S_READWRITE;     break;
-    case 256*'r'+'y': if(!strcmp(TLS(Value),"readonly"))  TLS(Symbol)=S_READONLY;     break;
-    case 256*'r'+'c': if(!strcmp(TLS(Value),"rec"))     TLS(Symbol)=S_REC;     break;
-    case 256*'r'+'t': if(!strcmp(TLS(Value),"repeat"))  TLS(Symbol)=S_REPEAT;  break;
-    case 256*'r'+'n': if(!strcmp(TLS(Value),"return"))  TLS(Symbol)=S_RETURN;  break;
-    case 256*'t'+'n': if(!strcmp(TLS(Value),"then"))    TLS(Symbol)=S_THEN;    break;
-    case 256*'t'+'e': if(!strcmp(TLS(Value),"true"))    TLS(Symbol)=S_TRUE;    break;
-    case 256*'u'+'l': if(!strcmp(TLS(Value),"until"))   TLS(Symbol)=S_UNTIL;   break;
-    case 256*'w'+'e': if(!strcmp(TLS(Value),"while"))   TLS(Symbol)=S_WHILE;   break;
-    case 256*'q'+'t': if(!strcmp(TLS(Value),"quit"))    TLS(Symbol)=S_QUIT;    break;
-    case 256*'Q'+'T': if(!strcmp(TLS(Value),"QUIT"))    TLS(Symbol)=S_QQUIT;   break;
+    /* now check if 'STATE(Value)' holds a keyword                                */
+    switch ( 256*STATE(Value)[0]+STATE(Value)[i-1] ) {
+    case 256*'a'+'d': if(!strcmp(STATE(Value),"and"))     STATE(Symbol)=S_AND;     break;
+    case 256*'a'+'c': if(!strcmp(STATE(Value),"atomic"))  STATE(Symbol)=S_ATOMIC;  break;
+    case 256*'b'+'k': if(!strcmp(STATE(Value),"break"))   STATE(Symbol)=S_BREAK;   break;
+    case 256*'c'+'e': if(!strcmp(STATE(Value),"continue"))   STATE(Symbol)=S_CONTINUE;   break;
+    case 256*'d'+'o': if(!strcmp(STATE(Value),"do"))      STATE(Symbol)=S_DO;      break;
+    case 256*'e'+'f': if(!strcmp(STATE(Value),"elif"))    STATE(Symbol)=S_ELIF;    break;
+    case 256*'e'+'e': if(!strcmp(STATE(Value),"else"))    STATE(Symbol)=S_ELSE;    break;
+    case 256*'e'+'d': if(!strcmp(STATE(Value),"end"))     STATE(Symbol)=S_END;     break;
+    case 256*'f'+'e': if(!strcmp(STATE(Value),"false"))   STATE(Symbol)=S_FALSE;   break;
+    case 256*'f'+'i': if(!strcmp(STATE(Value),"fi"))      STATE(Symbol)=S_FI;      break;
+    case 256*'f'+'r': if(!strcmp(STATE(Value),"for"))     STATE(Symbol)=S_FOR;     break;
+    case 256*'f'+'n': if(!strcmp(STATE(Value),"function"))STATE(Symbol)=S_FUNCTION;break;
+    case 256*'i'+'f': if(!strcmp(STATE(Value),"if"))      STATE(Symbol)=S_IF;      break;
+    case 256*'i'+'n': if(!strcmp(STATE(Value),"in"))      STATE(Symbol)=S_IN;      break;
+    case 256*'l'+'l': if(!strcmp(STATE(Value),"local"))   STATE(Symbol)=S_LOCAL;   break;
+    case 256*'m'+'d': if(!strcmp(STATE(Value),"mod"))     STATE(Symbol)=S_MOD;     break;
+    case 256*'n'+'t': if(!strcmp(STATE(Value),"not"))     STATE(Symbol)=S_NOT;     break;
+    case 256*'o'+'d': if(!strcmp(STATE(Value),"od"))      STATE(Symbol)=S_OD;      break;
+    case 256*'o'+'r': if(!strcmp(STATE(Value),"or"))      STATE(Symbol)=S_OR;      break;
+    case 256*'r'+'e': if(!strcmp(STATE(Value),"readwrite")) STATE(Symbol)=S_READWRITE;     break;
+    case 256*'r'+'y': if(!strcmp(STATE(Value),"readonly"))  STATE(Symbol)=S_READONLY;     break;
+    case 256*'r'+'c': if(!strcmp(STATE(Value),"rec"))     STATE(Symbol)=S_REC;     break;
+    case 256*'r'+'t': if(!strcmp(STATE(Value),"repeat"))  STATE(Symbol)=S_REPEAT;  break;
+    case 256*'r'+'n': if(!strcmp(STATE(Value),"return"))  STATE(Symbol)=S_RETURN;  break;
+    case 256*'t'+'n': if(!strcmp(STATE(Value),"then"))    STATE(Symbol)=S_THEN;    break;
+    case 256*'t'+'e': if(!strcmp(STATE(Value),"true"))    STATE(Symbol)=S_TRUE;    break;
+    case 256*'u'+'l': if(!strcmp(STATE(Value),"until"))   STATE(Symbol)=S_UNTIL;   break;
+    case 256*'w'+'e': if(!strcmp(STATE(Value),"while"))   STATE(Symbol)=S_WHILE;   break;
+    case 256*'q'+'t': if(!strcmp(STATE(Value),"quit"))    STATE(Symbol)=S_QUIT;    break;
+    case 256*'Q'+'T': if(!strcmp(STATE(Value),"QUIT"))    STATE(Symbol)=S_QQUIT;   break;
 
-    case 256*'I'+'d': if(!strcmp(TLS(Value),"IsBound")) TLS(Symbol)=S_ISBOUND; break;
-    case 256*'U'+'d': if(!strcmp(TLS(Value),"Unbind"))  TLS(Symbol)=S_UNBIND;  break;
-    case 256*'T'+'d': if(!strcmp(TLS(Value),"TryNextMethod"))
-                                                     TLS(Symbol)=S_TRYNEXT; break;
-    case 256*'I'+'o': if(!strcmp(TLS(Value),"Info"))    TLS(Symbol)=S_INFO;    break;
-    case 256*'A'+'t': if(!strcmp(TLS(Value),"Assert"))  TLS(Symbol)=S_ASSERT;  break;
+    case 256*'I'+'d': if(!strcmp(STATE(Value),"IsBound")) STATE(Symbol)=S_ISBOUND; break;
+    case 256*'U'+'d': if(!strcmp(STATE(Value),"Unbind"))  STATE(Symbol)=S_UNBIND;  break;
+    case 256*'T'+'d': if(!strcmp(STATE(Value),"TryNextMethod"))
+                                                     STATE(Symbol)=S_TRYNEXT; break;
+    case 256*'I'+'o': if(!strcmp(STATE(Value),"Info"))    STATE(Symbol)=S_INFO;    break;
+    case 256*'A'+'t': if(!strcmp(STATE(Value),"Assert"))  STATE(Symbol)=S_ASSERT;  break;
 
     default: ;
     }
 
     /* if it is quoted it is an identifier                                 */
-    if ( isQuoted )  TLS(Symbol) = S_IDENT;
+    if ( isQuoted )  STATE(Symbol) = S_IDENT;
 
 
 }
@@ -1426,7 +1426,7 @@ void GetIdent ( void )
 *F  GetNumber()  . . . . . . . . . . . . . .  get an integer or float literal
 **
 **  'GetNumber' reads  a number from  the  current  input file into the
-**  variable  'TLS(Value)' and sets  'Symbol' to 'S_INT', 'S_PARTIALINT',
+**  variable  'STATE(Value)' and sets  'Symbol' to 'S_INT', 'S_PARTIALINT',
 **  'S_FLOAT' or 'S_PARTIALFLOAT'.   The first character of
 **  the number is the current character pointed to by 'In'.
 **
@@ -1437,7 +1437,7 @@ void GetIdent ( void )
 **  As we read, we keep track of whether we have seen a . or exponent notation
 **  and so whether we will return S_[PARTIAL]INT or S_[PARTIAL]FLOAT.
 **
-**  When TLS(Value) is  completely filled we have to check  if the reading of
+**  When STATE(Value) is  completely filled we have to check  if the reading of
 **  the number  is complete  or not to  decide whether to return a PARTIAL type.
 **
 **  The argument reflects how far we are through reading a possibly very long number
@@ -1451,32 +1451,32 @@ void GetIdent ( void )
 static Char GetCleanedChar( UInt *wasEscaped ) {
   GET_CHAR();
   *wasEscaped = 0;
-  if (*TLS(In) == '\\') {
+  if (*STATE(In) == '\\') {
     GET_CHAR();
-    if      ( *TLS(In) == '\n')
+    if      ( *STATE(In) == '\n')
       return GetCleanedChar(wasEscaped);
-    else if ( *TLS(In) == '\r' )  {
+    else if ( *STATE(In) == '\r' )  {
       GET_CHAR();
-      if  ( *TLS(In) == '\n' )
+      if  ( *STATE(In) == '\n' )
         return GetCleanedChar(wasEscaped);
       else {
-        UNGET_CHAR(*TLS(In));
+        UNGET_CHAR(*STATE(In));
         *wasEscaped = 1;
         return '\r';
       }
     }
     else {
       *wasEscaped = 1;
-      if ( *TLS(In) == 'n')  return '\n';
-      else if ( *TLS(In) == 't')  return '\t';
-      else if ( *TLS(In) == 'r')  return '\r';
-      else if ( *TLS(In) == 'b')  return '\b';
-      else if ( *TLS(In) == '>')  return '\01';
-      else if ( *TLS(In) == '<')  return '\02';
-      else if ( *TLS(In) == 'c')  return '\03';
+      if ( *STATE(In) == 'n')  return '\n';
+      else if ( *STATE(In) == 't')  return '\t';
+      else if ( *STATE(In) == 'r')  return '\r';
+      else if ( *STATE(In) == 'b')  return '\b';
+      else if ( *STATE(In) == '>')  return '\01';
+      else if ( *STATE(In) == '<')  return '\02';
+      else if ( *STATE(In) == 'c')  return '\03';
     }
   }
-  return *TLS(In);
+  return *STATE(In);
 }
 
 
@@ -1489,11 +1489,11 @@ void GetNumber ( UInt StartingStatus )
   UInt seenADigit = (StartingStatus != 0 && StartingStatus != 2);
   UInt seenExpDigit = (StartingStatus ==5);
 
-  c = *TLS(In);
+  c = *STATE(In);
   if (StartingStatus  <  2) {
     /* read initial sequence of digits into 'Value'             */
     for (i = 0; !wasEscaped && IsDigit(c) && i < SAFE_VALUE_SIZE-1; i++) {
-      TLS(Value)[i] = c;
+      STATE(Value)[i] = c;
       seenADigit = 1;
       c = GetCleanedChar(&wasEscaped);
     }
@@ -1502,26 +1502,26 @@ void GetNumber ( UInt StartingStatus )
     /* maybe we saw an identifier character and realised that this is an identifier we are reading */
     if (wasEscaped || IsIdent(c)) {
       /* Now we know we have an identifier read the rest of it */
-      TLS(Value)[i++] = c;
+      STATE(Value)[i++] = c;
       c = GetCleanedChar(&wasEscaped);
       for (; wasEscaped || IsIdent(c) || IsDigit(c); i++) {
         if (i < SAFE_VALUE_SIZE -1)
-          TLS(Value)[i] = c;
+          STATE(Value)[i] = c;
         c = GetCleanedChar(&wasEscaped);
       }
       if (i < SAFE_VALUE_SIZE -1)
-        TLS(Value)[i] = '\0';
+        STATE(Value)[i] = '\0';
       else
-        TLS(Value)[SAFE_VALUE_SIZE-1] = '\0';
-      TLS(Symbol) = S_IDENT;
+        STATE(Value)[SAFE_VALUE_SIZE-1] = '\0';
+      STATE(Symbol) = S_IDENT;
       return;
     }
 
     /* Or maybe we just ran out of space */
     if (IsDigit(c)) {
       assert(i >= SAFE_VALUE_SIZE-1);
-      TLS(Symbol) = S_PARTIALINT;
-      TLS(Value)[SAFE_VALUE_SIZE-1] = '\0';
+      STATE(Symbol) = S_PARTIALINT;
+      STATE(Value)[SAFE_VALUE_SIZE-1] = '\0';
       return;
     }
 
@@ -1533,35 +1533,35 @@ void GetNumber ( UInt StartingStatus )
          look for a float.
 
       This is a bit fragile  */
-      if (TLS(Symbol) == S_DOT || TLS(Symbol) == S_BDOT) {
-        TLS(Value)[i]  = '\0';
-        TLS(Symbol) = S_INT;
+      if (STATE(Symbol) == S_DOT || STATE(Symbol) == S_BDOT) {
+        STATE(Value)[i]  = '\0';
+        STATE(Symbol) = S_INT;
         return;
       }
       
       /* peek ahead to decide which */
       GET_CHAR();
-      if (*TLS(In) == '.') {
+      if (*STATE(In) == '.') {
         /* It was .. */
-        UNGET_CHAR(*TLS(In));
-        TLS(Symbol) = S_INT;
-        TLS(Value)[i] = '\0';
+        UNGET_CHAR(*STATE(In));
+        STATE(Symbol) = S_INT;
+        STATE(Value)[i] = '\0';
         return;
       }
 
 
       /* Not .. Put back the character we peeked at */
-      UNGET_CHAR(*TLS(In));
+      UNGET_CHAR(*STATE(In));
       /* Now the . must be part of our number
          store it and move on */
-      TLS(Value)[i++] = c;
+      STATE(Value)[i++] = c;
       c = GetCleanedChar(&wasEscaped);
     }
 
     else {
       /* Anything else we see tells us that the token is done */
-      TLS(Value)[i]  = '\0';
-      TLS(Symbol) = S_INT;
+      STATE(Value)[i]  = '\0';
+      STATE(Symbol) = S_INT;
       return;
     }
   }
@@ -1580,7 +1580,7 @@ void GetNumber ( UInt StartingStatus )
 
     /* read digits */
     for (; !wasEscaped && IsDigit(c) && i < SAFE_VALUE_SIZE-1; i++) {
-      TLS(Value)[i] = c;
+      STATE(Value)[i] = c;
       seenADigit = 1;
       c = GetCleanedChar(&wasEscaped);
     }
@@ -1595,24 +1595,24 @@ void GetNumber ( UInt StartingStatus )
        C99 style */
       if (!wasEscaped) {
         if (IsAlpha(c)) {
-          TLS(Value)[i++] = c;
+          STATE(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
         }
         /* independently of that, we allow an _ signalling immediate conversion */
         if (c == '_') {
-          TLS(Value)[i++] = c;
+          STATE(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
           /* After which there may be one character signifying the conversion style */
           if (IsAlpha(c)) {
-            TLS(Value)[i++] = c;
+            STATE(Value)[i++] = c;
             c = GetCleanedChar(&wasEscaped);
           }
         }
         /* Now if the next character is alphanumerical, or an identifier type symbol then we
            really do have an error, otherwise we return a result */
         if (!IsIdent(c) && !IsDigit(c)) {
-          TLS(Value)[i] = '\0';
-          TLS(Symbol) = S_FLOAT;
+          STATE(Value)[i] = '\0';
+          STATE(Symbol) = S_FLOAT;
           return;
         }
       }
@@ -1625,19 +1625,19 @@ void GetNumber ( UInt StartingStatus )
         if (!seenADigit)
           SyntaxError("Badly formed number: need a digit before or after the decimal point");
         seenExp = 1;
-        TLS(Value)[i++] = c;
+        STATE(Value)[i++] = c;
         c = GetCleanedChar(&wasEscaped);
         if (!wasEscaped && (c == '+' || c == '-'))
           {
-            TLS(Value)[i++] = c;
+            STATE(Value)[i++] = c;
             c = GetCleanedChar(&wasEscaped);
           }
       }
 
     /* Now deal with full buffer case */
     if (i >= SAFE_VALUE_SIZE -1) {
-      TLS(Symbol) = seenExp ? S_PARTIALFLOAT3 : S_PARTIALFLOAT2;
-      TLS(Value)[i] = '\0';
+      STATE(Symbol) = seenExp ? S_PARTIALFLOAT3 : S_PARTIALFLOAT2;
+      STATE(Value)[i] = '\0';
       return;
     }
 
@@ -1649,23 +1649,23 @@ void GetNumber ( UInt StartingStatus )
       /* Might be a conversion marker */
       if (!wasEscaped) {
         if (IsAlpha(c) && c != 'e' && c != 'E' && c != 'd' && c != 'D' && c != 'q' && c != 'Q') {
-          TLS(Value)[i++] = c;
+          STATE(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
         }
         /* independently of that, we allow an _ signalling immediate conversion */
         if (c == '_') {
-          TLS(Value)[i++] = c;
+          STATE(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
           /* After which there may be one character signifying the conversion style */
           if (IsAlpha(c))
-            TLS(Value)[i++] = c;
+            STATE(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
         }
         /* Now if the next character is alphanumerical, or an identifier type symbol then we
            really do have an error, otherwise we return a result */
         if (!IsIdent(c) && !IsDigit(c)) {
-          TLS(Value)[i] = '\0';
-          TLS(Symbol) = S_FLOAT;
+          STATE(Value)[i] = '\0';
+          STATE(Symbol) = S_FLOAT;
           return;
         }
       }
@@ -1677,7 +1677,7 @@ void GetNumber ( UInt StartingStatus )
   /* Here we are into the unsigned exponent of a number
      in scientific notation, so we just read digits */
   for (; !wasEscaped && IsDigit(c) && i < SAFE_VALUE_SIZE-1; i++) {
-    TLS(Value)[i] = c;
+    STATE(Value)[i] = c;
     seenExpDigit = 1;
     c = GetCleanedChar(&wasEscaped);
   }
@@ -1686,38 +1686,38 @@ void GetNumber ( UInt StartingStatus )
      which could be a conversion marker */
   if (seenExpDigit) {
     if (IsAlpha(c)) {
-      TLS(Value)[i] = c;
+      STATE(Value)[i] = c;
       c = GetCleanedChar(&wasEscaped);
-      TLS(Value)[i+1] = '\0';
-      TLS(Symbol) = S_FLOAT;
+      STATE(Value)[i+1] = '\0';
+      STATE(Symbol) = S_FLOAT;
       return;
     }
     if (c == '_') {
-      TLS(Value)[i++] = c;
+      STATE(Value)[i++] = c;
       c = GetCleanedChar(&wasEscaped);
       /* After which there may be one character signifying the conversion style */
       if (IsAlpha(c)) {
-        TLS(Value)[i++] = c;
+        STATE(Value)[i++] = c;
         c = GetCleanedChar(&wasEscaped);
       }
-      TLS(Value)[i] = '\0';
-      TLS(Symbol) = S_FLOAT;
+      STATE(Value)[i] = '\0';
+      STATE(Symbol) = S_FLOAT;
       return;
     }
   }
 
   /* If we ran off the end */
   if (i >= SAFE_VALUE_SIZE -1) {
-    TLS(Symbol) = seenExpDigit ? S_PARTIALFLOAT4 : S_PARTIALFLOAT3;
-    TLS(Value)[i] = '\0';
+    STATE(Symbol) = seenExpDigit ? S_PARTIALFLOAT4 : S_PARTIALFLOAT3;
+    STATE(Value)[i] = '\0';
     return;
   }
 
   /* Otherwise this is the end of the token */
   if (!seenExpDigit)
     SyntaxError("Badly Formed Number: need at least one digit in the exponent");
-  TLS(Symbol) = S_FLOAT;
-  TLS(Value)[i] = '\0';
+  STATE(Symbol) = S_FLOAT;
+  STATE(Value)[i] = '\0';
   return;
 }
 
@@ -1734,13 +1734,13 @@ static inline Char GetOctalDigits( void )
 {
     Char c;
 
-    if ( *TLS(In) < '0' || *TLS(In) > '7' )
+    if ( *STATE(In) < '0' || *STATE(In) > '7' )
         SyntaxError("Expecting octal digit");
-    c = 8 * (*TLS(In) - '0');
+    c = 8 * (*STATE(In) - '0');
     GET_CHAR();
-    if ( *TLS(In) < '0' || *TLS(In) > '7' )
+    if ( *STATE(In) < '0' || *STATE(In) > '7' )
         SyntaxError("Expecting octal digit");
-    c = c + (*TLS(In) - '0');
+    c = c + (*STATE(In) - '0');
 
     return c;
 }
@@ -1767,39 +1767,39 @@ Char GetEscapedChar( void )
 
   c = 0;
 
-  if ( *TLS(In) == 'n'  )       c = '\n';
-  else if ( *TLS(In) == 't'  )  c = '\t';
-  else if ( *TLS(In) == 'r'  )  c = '\r';
-  else if ( *TLS(In) == 'b'  )  c = '\b';
-  else if ( *TLS(In) == '>'  )  c = '\01';
-  else if ( *TLS(In) == '<'  )  c = '\02';
-  else if ( *TLS(In) == 'c'  )  c = '\03';
-  else if ( *TLS(In) == '"'  )  c = '"';
-  else if ( *TLS(In) == '\\' )  c = '\\';
-  else if ( *TLS(In) == '\'' )  c = '\'';
-  else if ( *TLS(In) == '0'  ) {
+  if ( *STATE(In) == 'n'  )       c = '\n';
+  else if ( *STATE(In) == 't'  )  c = '\t';
+  else if ( *STATE(In) == 'r'  )  c = '\r';
+  else if ( *STATE(In) == 'b'  )  c = '\b';
+  else if ( *STATE(In) == '>'  )  c = '\01';
+  else if ( *STATE(In) == '<'  )  c = '\02';
+  else if ( *STATE(In) == 'c'  )  c = '\03';
+  else if ( *STATE(In) == '"'  )  c = '"';
+  else if ( *STATE(In) == '\\' )  c = '\\';
+  else if ( *STATE(In) == '\'' )  c = '\'';
+  else if ( *STATE(In) == '0'  ) {
     /* from here we can either read a hex-escape or three digit
        octal numbers */
     GET_CHAR();
-    if (*TLS(In) == 'x') {
+    if (*STATE(In) == 'x') {
         GET_CHAR();
-        if (!IsHexDigit(*TLS(In))) {
+        if (!IsHexDigit(*STATE(In))) {
             SyntaxError("Expecting hexadecimal digit");
         }
-        c = 16 * CharHexDigit(*TLS(In));
+        c = 16 * CharHexDigit(*STATE(In));
         GET_CHAR();
-        if (!IsHexDigit(*TLS(In))) {
+        if (!IsHexDigit(*STATE(In))) {
             SyntaxError("Expecting hexadecimal digit");
         }
-        c += CharHexDigit(*TLS(In));
-    } else if (*TLS(In) >= '0' && *TLS(In) <= '7' ) {
+        c += CharHexDigit(*STATE(In));
+    } else if (*STATE(In) >= '0' && *STATE(In) <= '7' ) {
         c += GetOctalDigits();
     } else {
         SyntaxError("Expecting hexadecimal escape, or two more octal digits");
     }
-  } else if ( *TLS(In) >= '1' && *TLS(In) <= '7' ) {
+  } else if ( *STATE(In) >= '1' && *STATE(In) <= '7' ) {
     /* escaped three digit octal numbers are allowed in input */
-    c = 64 * (*TLS(In) - '0');
+    c = 64 * (*STATE(In) - '0');
     GET_CHAR();
     c += GetOctalDigits();
   } else {
@@ -1807,10 +1807,10 @@ Char GetEscapedChar( void )
          disabled for backwards compatibility; some code relies on this behaviour
          and tests break with the warning enabled */
       /*
-      if (IsAlpha(*TLS(In)))
+      if (IsAlpha(*STATE(In)))
           SyntaxWarning("Alphabet letter after \\");
       */
-      c = *TLS(In);
+      c = *STATE(In);
   }
   return c;
 }
@@ -1820,7 +1820,7 @@ Char GetEscapedChar( void )
  *F  GetStr()  . . . . . . . . . . . . . . . . . . . . . . get a string, local
  **
  **  'GetStr' reads  a  string from the  current input file into  the variable
- **  'TLS(Value)' and sets 'Symbol'   to  'S_STRING'.  The opening double quote '"'
+ **  'STATE(Value)' and sets 'Symbol'   to  'S_STRING'.  The opening double quote '"'
  **  of the string is the current character pointed to by 'In'.
  **
  **  A string is a sequence of characters delimited  by double quotes '"'.  It
@@ -1831,7 +1831,7 @@ Char GetEscapedChar( void )
  **  An error is raised if the string includes a <newline> character or if the
  **  file ends before the closing '"'.
  **
- **  When TLS(Value) is  completely filled we have to check  if the reading of
+ **  When STATE(Value) is  completely filled we have to check  if the reading of
  **  the string is  complete or not to decide  between Symbol=S_STRING or
  **  S_PARTIALSTRING.
  */
@@ -1840,39 +1840,39 @@ void GetStr ( void )
   Int                 i = 0, fetch;
 
   /* Avoid substitution of '?' in beginning of GetLine chunks */
-  TLS(HELPSubsOn) = 0;
+  STATE(HELPSubsOn) = 0;
 
   /* read all characters into 'Value'                                    */
-  for ( i = 0; i < SAFE_VALUE_SIZE-1 && *TLS(In) != '"'
-           && *TLS(In) != '\n' && *TLS(In) != '\377'; i++ ) {
+  for ( i = 0; i < SAFE_VALUE_SIZE-1 && *STATE(In) != '"'
+           && *STATE(In) != '\n' && *STATE(In) != '\377'; i++ ) {
 
     fetch = 1;
     /* handle escape sequences                                         */
-    if ( *TLS(In) == '\\' ) {
+    if ( *STATE(In) == '\\' ) {
       GET_CHAR();
       /* if next is another '\\' followed by '\n' it must be ignored */
-      while ( *TLS(In) == '\\' ) {
+      while ( *STATE(In) == '\\' ) {
         GET_CHAR();
-        if ( *TLS(In) == '\n' )
+        if ( *STATE(In) == '\n' )
           GET_CHAR();
         else {
           UNGET_CHAR( '\\' );
           break;
         }
       }
-      if      ( *TLS(In) == '\n' )  i--;
-      else if ( *TLS(In) == '\r' )  {
+      if      ( *STATE(In) == '\n' )  i--;
+      else if ( *STATE(In) == '\r' )  {
         GET_CHAR();
-        if  ( *TLS(In) == '\n' )  i--;
-        else  {TLS(Value)[i] = '\r'; fetch = 0;}
+        if  ( *STATE(In) == '\n' )  i--;
+        else  {STATE(Value)[i] = '\r'; fetch = 0;}
       } else {
-          TLS(Value)[i] = GetEscapedChar();
+          STATE(Value)[i] = GetEscapedChar();
       }
     }
 
     /* put normal chars into 'Value' but only if there is room         */
     else {
-      TLS(Value)[i] = *TLS(In);
+      STATE(Value)[i] = *STATE(In);
     }
 
     /* read the next character                                         */
@@ -1883,25 +1883,25 @@ void GetStr ( void )
   /* XXX although we have ValueLen we need trailing \000 here,
      in gap.c, function FuncMAKE_INIT this is still used as C-string
      and long integers and strings are not yet supported!    */
-  TLS(Value)[i] = '\0';
+  STATE(Value)[i] = '\0';
 
   /* check for error conditions                                          */
-  if ( *TLS(In) == '\n'  )
+  if ( *STATE(In) == '\n'  )
     SyntaxError("String must not include <newline>");
-  if ( *TLS(In) == '\377' )
+  if ( *STATE(In) == '\377' )
     SyntaxError("String must end with \" before end of file");
 
   /* set length of string, set 'Symbol' and skip trailing '"'            */
-  TLS(ValueLen) = i;
+  STATE(ValueLen) = i;
   if ( i < SAFE_VALUE_SIZE-1 )  {
-    TLS(Symbol) = S_STRING;
-    if ( *TLS(In) == '"' )  GET_CHAR();
+    STATE(Symbol) = S_STRING;
+    if ( *STATE(In) == '"' )  GET_CHAR();
   }
   else
-    TLS(Symbol) = S_PARTIALSTRING;
+    STATE(Symbol) = S_PARTIALSTRING;
 
   /* switching on substitution of '?' */
-  TLS(HELPSubsOn) = 1;
+  STATE(HELPSubsOn) = 1;
 }
 
 /****************************************************************************
@@ -1927,32 +1927,32 @@ void GetTripStr ( void )
   Int                 i = 0;
 
   /* Avoid substitution of '?' in beginning of GetLine chunks */
-  TLS(HELPSubsOn) = 0;
+  STATE(HELPSubsOn) = 0;
   
   /* print only a partial prompt while reading a triple string           */
   if ( !SyQuiet )
-    TLS(Prompt) = "> ";
+    STATE(Prompt) = "> ";
   else
-    TLS(Prompt) = "";
+    STATE(Prompt) = "";
   
   /* read all characters into 'Value'                                    */
-  for ( i = 0; i < SAFE_VALUE_SIZE-1 && *TLS(In) != '\377'; i++ ) {
+  for ( i = 0; i < SAFE_VALUE_SIZE-1 && *STATE(In) != '\377'; i++ ) {
     // Only thing to check for is a triple quote.
     
-    if ( *TLS(In) == '"') {
+    if ( *STATE(In) == '"') {
         GET_CHAR();
-        if (*TLS(In) == '"') {
+        if (*STATE(In) == '"') {
             GET_CHAR();
-            if(*TLS(In) == '"' ) {
+            if(*STATE(In) == '"' ) {
                 break;
             }
-            TLS(Value)[i] = '"';
+            STATE(Value)[i] = '"';
             i++;
         }
-        TLS(Value)[i] = '"';
+        STATE(Value)[i] = '"';
         i++;
     }
-    TLS(Value)[i] = *TLS(In);
+    STATE(Value)[i] = *STATE(In);
 
 
     /* read the next character                                         */
@@ -1962,23 +1962,23 @@ void GetTripStr ( void )
   /* XXX although we have ValueLen we need trailing \000 here,
      in gap.c, function FuncMAKE_INIT this is still used as C-string
      and long integers and strings are not yet supported!    */
-  TLS(Value)[i] = '\0';
+  STATE(Value)[i] = '\0';
 
   /* check for error conditions                                          */
-  if ( *TLS(In) == '\377' )
+  if ( *STATE(In) == '\377' )
     SyntaxError("String must end with \" before end of file");
 
   /* set length of string, set 'Symbol' and skip trailing '"'            */
-  TLS(ValueLen) = i;
+  STATE(ValueLen) = i;
   if ( i < SAFE_VALUE_SIZE-1 )  {
-    TLS(Symbol) = S_STRING;
-    if ( *TLS(In) == '"' )  GET_CHAR();
+    STATE(Symbol) = S_STRING;
+    if ( *STATE(In) == '"' )  GET_CHAR();
   }
   else
-    TLS(Symbol) = S_PARTIALTRIPSTRING;
+    STATE(Symbol) = S_PARTIALTRIPSTRING;
 
   /* switching on substitution of '?' */
-  TLS(HELPSubsOn) = 1;
+  STATE(HELPSubsOn) = 1;
 }
 
 /****************************************************************************
@@ -1992,21 +1992,21 @@ void GetTripStr ( void )
 void GetMaybeTripStr ( void )
 {
     /* Avoid substitution of '?' in beginning of GetLine chunks */
-    TLS(HELPSubsOn) = 0;
+    STATE(HELPSubsOn) = 0;
     
     /* This is just a normal string! */
-    if ( *TLS(In) != '"' ) {
+    if ( *STATE(In) != '"' ) {
         GetStr();
         return;
     }
     
     GET_CHAR();
     /* This was just an empty string! */
-    if ( *TLS(In) != '"' ) {
-        TLS(Value)[0] = '\0';
-        TLS(ValueLen) = 0;
-        TLS(Symbol) = S_STRING;
-        TLS(HELPSubsOn) = 1;
+    if ( *STATE(In) != '"' ) {
+        STATE(Value)[0] = '\0';
+        STATE(ValueLen) = 0;
+        STATE(Symbol) = S_STRING;
+        STATE(HELPSubsOn) = 1;
         return;
     }
     
@@ -2021,7 +2021,7 @@ void GetMaybeTripStr ( void )
  *F  GetChar() . . . . . . . . . . . . . . . . . get a single character, local
  **
  **  'GetChar' reads the next  character from the current input file  into the
- **  variable 'TLS(Value)' and sets 'Symbol' to 'S_CHAR'.  The opening single quote
+ **  variable 'STATE(Value)' and sets 'Symbol' to 'S_CHAR'.  The opening single quote
  **  '\'' of the character is the current character pointed to by 'In'.
  **
  **  A  character is  a  single character delimited by single quotes '\''.  It
@@ -2034,25 +2034,25 @@ void GetChar ( void )
   GET_CHAR();
 
   /* Make sure symbol is set */
-  TLS(Symbol) = S_CHAR;
+  STATE(Symbol) = S_CHAR;
 
   /* handle escape equences                                              */
-  if ( *TLS(In) == '\n' ) {
+  if ( *STATE(In) == '\n' ) {
     SyntaxError("Character literal must not include <newline>");
   } else {
-    if ( *TLS(In) == '\\' ) {
+    if ( *STATE(In) == '\\' ) {
       GET_CHAR();
-      TLS(Value)[0] = GetEscapedChar();
+      STATE(Value)[0] = GetEscapedChar();
     } else {
-      /* put normal chars into 'TLS(Value)' */
-      TLS(Value)[0] = *TLS(In);
+      /* put normal chars into 'STATE(Value)' */
+      STATE(Value)[0] = *STATE(In);
     }
 
     /* read the next character */
     GET_CHAR();
 
     /* check for terminating single quote, and skip */
-    if ( *TLS(In) == '\'' ) {
+    if ( *STATE(In) == '\'' ) {
       GET_CHAR();
     } else {
       SyntaxError("Missing single quote in character constant");
@@ -2066,7 +2066,7 @@ void GetChar ( void )
  **
  **  'GetSymbol' reads  the  next symbol from   the  input,  storing it in the
  **  variable 'Symbol'.  If 'Symbol' is  'S_IDENT', 'S_INT' or 'S_STRING'  the
- **  value of the symbol is stored in the variable 'TLS(Value)'.  'GetSymbol' first
+ **  value of the symbol is stored in the variable 'STATE(Value)'.  'GetSymbol' first
  **  skips all <space>, <tab> and <newline> characters and comments.
  **
  **  After reading  a  symbol the current  character   is the first  character
@@ -2075,125 +2075,125 @@ void GetChar ( void )
 void GetSymbol ( void )
 {
   /* special case if reading of a long token is not finished */
-  if (TLS(Symbol) == S_PARTIALSTRING) {
+  if (STATE(Symbol) == S_PARTIALSTRING) {
     GetStr();
     return;
   }
   
-  if (TLS(Symbol) == S_PARTIALTRIPSTRING) {
+  if (STATE(Symbol) == S_PARTIALTRIPSTRING) {
       GetTripStr();
       return;
   }
   
-  if (TLS(Symbol) == S_PARTIALINT) {
-    if (TLS(Value)[0] == '\0')
+  if (STATE(Symbol) == S_PARTIALINT) {
+    if (STATE(Value)[0] == '\0')
       GetNumber(0);
     else
       GetNumber(1);
     return;
   }
-  if (TLS(Symbol) == S_PARTIALFLOAT1) {
+  if (STATE(Symbol) == S_PARTIALFLOAT1) {
     GetNumber(2);
     return;
   }
 
-  if (TLS(Symbol) == S_PARTIALFLOAT2) {
+  if (STATE(Symbol) == S_PARTIALFLOAT2) {
     GetNumber(3);
     return;
   }
-  if (TLS(Symbol) == S_PARTIALFLOAT3) {
+  if (STATE(Symbol) == S_PARTIALFLOAT3) {
     GetNumber(4);
     return;
   }
 
-  if (TLS(Symbol) == S_PARTIALFLOAT4) {
+  if (STATE(Symbol) == S_PARTIALFLOAT4) {
     GetNumber(5);
     return;
   }
 
 
   /* if no character is available then get one                           */
-  if ( *TLS(In) == '\0' )
-    { TLS(In)--;
+  if ( *STATE(In) == '\0' )
+    { STATE(In)--;
       GET_CHAR();
     }
 
   /* skip over <spaces>, <tabs>, <newlines> and comments                 */
-  while (*TLS(In)==' '||*TLS(In)=='\t'||*TLS(In)=='\n'||*TLS(In)=='\r'||*TLS(In)=='\f'||*TLS(In)=='#') {
-    if ( *TLS(In) == '#' ) {
-      while ( *TLS(In) != '\n' && *TLS(In) != '\r' && *TLS(In) != '\377' )
+  while (*STATE(In)==' '||*STATE(In)=='\t'||*STATE(In)=='\n'||*STATE(In)=='\r'||*STATE(In)=='\f'||*STATE(In)=='#') {
+    if ( *STATE(In) == '#' ) {
+      while ( *STATE(In) != '\n' && *STATE(In) != '\r' && *STATE(In) != '\377' )
         GET_CHAR();
     }
     GET_CHAR();
   }
 
   /* switch according to the character                                   */
-  switch ( *TLS(In) ) {
+  switch ( *STATE(In) ) {
 
-  case '.':   TLS(Symbol) = S_DOT;                         GET_CHAR();
-    /*            if ( *TLS(In) == '\\' ) { GET_CHAR();
-            if ( *TLS(In) == '\n' ) { GET_CHAR(); } }   */
-    if ( *TLS(In) == '.' ) { 
-            TLS(Symbol) = S_DOTDOT; GET_CHAR();
-            if ( *TLS(In) == '.') {
-                    TLS(Symbol) = S_DOTDOTDOT; GET_CHAR();
+  case '.':   STATE(Symbol) = S_DOT;                         GET_CHAR();
+    /*            if ( *STATE(In) == '\\' ) { GET_CHAR();
+            if ( *STATE(In) == '\n' ) { GET_CHAR(); } }   */
+    if ( *STATE(In) == '.' ) { 
+            STATE(Symbol) = S_DOTDOT; GET_CHAR();
+            if ( *STATE(In) == '.') {
+                    STATE(Symbol) = S_DOTDOTDOT; GET_CHAR();
             }
     }
     break;
 
-  case '!':   TLS(Symbol) = S_ILLEGAL;                     GET_CHAR();
-    if ( *TLS(In) == '\\' ) { GET_CHAR();
-      if ( *TLS(In) == '\n' ) { GET_CHAR(); } }
-    if ( *TLS(In) == '.' ) { TLS(Symbol) = S_BDOT;    GET_CHAR();  break; }
-    if ( *TLS(In) == '[' ) { TLS(Symbol) = S_BLBRACK; GET_CHAR();  break; }
-    if ( *TLS(In) == '{' ) { TLS(Symbol) = S_BLBRACE; GET_CHAR();  break; }
+  case '!':   STATE(Symbol) = S_ILLEGAL;                     GET_CHAR();
+    if ( *STATE(In) == '\\' ) { GET_CHAR();
+      if ( *STATE(In) == '\n' ) { GET_CHAR(); } }
+    if ( *STATE(In) == '.' ) { STATE(Symbol) = S_BDOT;    GET_CHAR();  break; }
+    if ( *STATE(In) == '[' ) { STATE(Symbol) = S_BLBRACK; GET_CHAR();  break; }
+    if ( *STATE(In) == '{' ) { STATE(Symbol) = S_BLBRACE; GET_CHAR();  break; }
     break;
-  case '[':   TLS(Symbol) = S_LBRACK;                      GET_CHAR();  break;
-  case ']':   TLS(Symbol) = S_RBRACK;                      GET_CHAR();  break;
-  case '{':   TLS(Symbol) = S_LBRACE;                      GET_CHAR();  break;
-  case '}':   TLS(Symbol) = S_RBRACE;                      GET_CHAR();  break;
-  case '(':   TLS(Symbol) = S_LPAREN;                      GET_CHAR();  break;
-  case ')':   TLS(Symbol) = S_RPAREN;                      GET_CHAR();  break;
-  case ',':   TLS(Symbol) = S_COMMA;                       GET_CHAR();  break;
+  case '[':   STATE(Symbol) = S_LBRACK;                      GET_CHAR();  break;
+  case ']':   STATE(Symbol) = S_RBRACK;                      GET_CHAR();  break;
+  case '{':   STATE(Symbol) = S_LBRACE;                      GET_CHAR();  break;
+  case '}':   STATE(Symbol) = S_RBRACE;                      GET_CHAR();  break;
+  case '(':   STATE(Symbol) = S_LPAREN;                      GET_CHAR();  break;
+  case ')':   STATE(Symbol) = S_RPAREN;                      GET_CHAR();  break;
+  case ',':   STATE(Symbol) = S_COMMA;                       GET_CHAR();  break;
 
-  case ':':   TLS(Symbol) = S_COLON;                       GET_CHAR();
-    if ( *TLS(In) == '\\' ) {
+  case ':':   STATE(Symbol) = S_COLON;                       GET_CHAR();
+    if ( *STATE(In) == '\\' ) {
       GET_CHAR();
-      if ( *TLS(In) == '\n' )
+      if ( *STATE(In) == '\n' )
         { GET_CHAR(); }
     }
-    if ( *TLS(In) == '=' ) { TLS(Symbol) = S_ASSIGN;  GET_CHAR(); break; }
-    if ( TLS(In)[0] == ':' && TLS(In)[1] == '=') {
-      TLS(Symbol) = S_INCORPORATE; GET_CHAR(); GET_CHAR(); break;
+    if ( *STATE(In) == '=' ) { STATE(Symbol) = S_ASSIGN;  GET_CHAR(); break; }
+    if ( STATE(In)[0] == ':' && STATE(In)[1] == '=') {
+      STATE(Symbol) = S_INCORPORATE; GET_CHAR(); GET_CHAR(); break;
     }
     break;
 
-  case ';':   TLS(Symbol) = S_SEMICOLON;                   GET_CHAR();  break;
+  case ';':   STATE(Symbol) = S_SEMICOLON;                   GET_CHAR();  break;
 
-  case '=':   TLS(Symbol) = S_EQ;                          GET_CHAR();  break;
-  case '<':   TLS(Symbol) = S_LT;                          GET_CHAR();
-    if ( *TLS(In) == '\\' ) { GET_CHAR();
-      if ( *TLS(In) == '\n' ) { GET_CHAR(); } }
-    if ( *TLS(In) == '=' ) { TLS(Symbol) = S_LE;      GET_CHAR();  break; }
-    if ( *TLS(In) == '>' ) { TLS(Symbol) = S_NE;      GET_CHAR();  break; }
+  case '=':   STATE(Symbol) = S_EQ;                          GET_CHAR();  break;
+  case '<':   STATE(Symbol) = S_LT;                          GET_CHAR();
+    if ( *STATE(In) == '\\' ) { GET_CHAR();
+      if ( *STATE(In) == '\n' ) { GET_CHAR(); } }
+    if ( *STATE(In) == '=' ) { STATE(Symbol) = S_LE;      GET_CHAR();  break; }
+    if ( *STATE(In) == '>' ) { STATE(Symbol) = S_NE;      GET_CHAR();  break; }
     break;
-  case '>':   TLS(Symbol) = S_GT;                          GET_CHAR();
-    if ( *TLS(In) == '\\' ) { GET_CHAR();
-      if ( *TLS(In) == '\n' ) { GET_CHAR(); } }
-    if ( *TLS(In) == '=' ) { TLS(Symbol) = S_GE;      GET_CHAR();  break; }
+  case '>':   STATE(Symbol) = S_GT;                          GET_CHAR();
+    if ( *STATE(In) == '\\' ) { GET_CHAR();
+      if ( *STATE(In) == '\n' ) { GET_CHAR(); } }
+    if ( *STATE(In) == '=' ) { STATE(Symbol) = S_GE;      GET_CHAR();  break; }
     break;
 
-  case '+':   TLS(Symbol) = S_PLUS;                        GET_CHAR();  break;
-  case '-':   TLS(Symbol) = S_MINUS;                       GET_CHAR();
-    if ( *TLS(In) == '\\' ) { GET_CHAR();
-      if ( *TLS(In) == '\n' ) { GET_CHAR(); } }
-    if ( *TLS(In) == '>' ) { TLS(Symbol)=S_MAPTO;     GET_CHAR();  break; }
+  case '+':   STATE(Symbol) = S_PLUS;                        GET_CHAR();  break;
+  case '-':   STATE(Symbol) = S_MINUS;                       GET_CHAR();
+    if ( *STATE(In) == '\\' ) { GET_CHAR();
+      if ( *STATE(In) == '\n' ) { GET_CHAR(); } }
+    if ( *STATE(In) == '>' ) { STATE(Symbol)=S_MAPTO;     GET_CHAR();  break; }
     break;
-  case '*':   TLS(Symbol) = S_MULT;                        GET_CHAR();  break;
-  case '/':   TLS(Symbol) = S_DIV;                         GET_CHAR();  break;
-  case '^':   TLS(Symbol) = S_POW;                         GET_CHAR();  break;
+  case '*':   STATE(Symbol) = S_MULT;                        GET_CHAR();  break;
+  case '/':   STATE(Symbol) = S_DIV;                         GET_CHAR();  break;
+  case '^':   STATE(Symbol) = S_POW;                         GET_CHAR();  break;
 #ifdef HPCGAP
-  case '`':   TLS(Symbol) = S_BACKQUOTE;                   GET_CHAR();  break;
+  case '`':   STATE(Symbol) = S_BACKQUOTE;                   GET_CHAR();  break;
 #endif
 
   case '"':                        GET_CHAR(); GetMaybeTripStr();  break;
@@ -2201,17 +2201,17 @@ void GetSymbol ( void )
   case '\\':                                          GetIdent();  break;
   case '_':                                           GetIdent();  break;
   case '@':                                           GetIdent();  break;
-  case '~':   TLS(Value)[0] = '~';  TLS(Value)[1] = '\0';
-    TLS(Symbol) = S_IDENT;                       GET_CHAR();  break;
+  case '~':   STATE(Value)[0] = '~';  STATE(Value)[1] = '\0';
+    STATE(Symbol) = S_IDENT;                       GET_CHAR();  break;
 
   case '0': case '1': case '2': case '3': case '4':
   case '5': case '6': case '7': case '8': case '9':
     GetNumber(0);    break;
 
-  case '\377': TLS(Symbol) = S_EOF;                        *TLS(In) = '\0';  break;
+  case '\377': STATE(Symbol) = S_EOF;                        *STATE(In) = '\0';  break;
 
-  default :   if ( IsAlpha(*TLS(In)) )                   { GetIdent();  break; }
-    TLS(Symbol) = S_ILLEGAL;                     GET_CHAR();  break;
+  default :   if ( IsAlpha(*STATE(In)) )                   { GetIdent();  break; }
+    STATE(Symbol) = S_ILLEGAL;                     GET_CHAR();  break;
   }
 }
 
@@ -2292,9 +2292,9 @@ void PutLineTo ( KOutputStream stream, UInt len )
   PutLine2( stream, stream->line, len );
 
   /* if neccessary echo it to the logfile                                */
-  if ( TLS(OutputLog) != 0 && ! stream->isstream ) {
+  if ( STATE(OutputLog) != 0 && ! stream->isstream ) {
     if ( stream->file == 1 || stream->file == 3 ) {
-      PutLine2( TLS(OutputLog), stream->line, len );
+      PutLine2( STATE(OutputLog), stream->line, len );
     }
   }
 }
@@ -2434,7 +2434,7 @@ void PutChrTo (
   /* normal character, room on the current line                          */
   /* TODO: For threads other than the main thread, reserve some extra
      space for the thread id indicator. See issue #136. */
-  else if ( stream->pos < SyNrCols-2-6*(TLS(threadID) != 0)-TLS(NoSplitLine) ) {
+  else if ( stream->pos < SyNrCols-2-6*(TLS(threadID) != 0)-STATE(NoSplitLine) ) {
 
     /* put the character on this line                                  */
     stream->line[ stream->pos++ ] = ch;
@@ -2524,7 +2524,7 @@ void PutChrTo (
 
 Obj FuncToggleEcho( Obj self)
 {
-  TLS(Input)->echo = 1 - TLS(Input)->echo;
+  STATE(Input)->echo = 1 - STATE(Input)->echo;
   return (Obj)0;
 }
 
@@ -2537,7 +2537,7 @@ Obj FuncToggleEcho( Obj self)
 Obj FuncCPROMPT( Obj self)
 {
   Obj p;
-  C_NEW_STRING_DYN( p, TLS(Prompt) );
+  C_NEW_STRING_DYN( p, STATE(Prompt) );
   return p;
 }
 
@@ -2558,9 +2558,9 @@ Obj FuncPRINT_CPROMPT( Obj self, Obj prompt )
     /* by assigning to Prompt we also tell readline (if used) what the
        current prompt is  */
     strlcpy(promptBuf, CSTR_STRING(prompt), sizeof(promptBuf));
-    TLS(Prompt) = promptBuf;
+    STATE(Prompt) = promptBuf;
   }
-  Pr("%s%c", (Int)TLS(Prompt), (Int)'\03' );
+  Pr("%s%c", (Int)STATE(Prompt), (Int)'\03' );
   return (Obj) 0;
 }
 
@@ -2679,14 +2679,14 @@ void FormatOutput(void (*put_a_char)(Char c), const Char *format, Int arg1, Int 
       /* must be careful that line breaks don't go inside
          escaped sequences \n or \123 or similar */
       for ( q = (Char*)arg1; *q != '\0'; q++ ) {
-        if (*q == '\\' && TLS(NoSplitLine) == 0) {
+        if (*q == '\\' && STATE(NoSplitLine) == 0) {
           if (*(q+1) < '8' && *(q+1) >= '0')
-            TLS(NoSplitLine) = 3;
+            STATE(NoSplitLine) = 3;
           else
-            TLS(NoSplitLine) = 1;
+            STATE(NoSplitLine) = 1;
         }
-        else if (TLS(NoSplitLine) > 0)
-          TLS(NoSplitLine)--;
+        else if (STATE(NoSplitLine) > 0)
+          STATE(NoSplitLine)--;
         put_a_char( *q );
       }
 
@@ -2855,7 +2855,7 @@ void FormatOutput(void (*put_a_char)(Char c), const Char *format, Int arg1, Int 
 /* TL: static KOutputStream TheStream; */
 
 static void putToTheStream( Char c) {
-  PutChrTo(TLS(TheStream), c);
+  PutChrTo(STATE(TheStream), c);
 }
 
 void PrTo (
@@ -2864,10 +2864,10 @@ void PrTo (
            Int                 arg1,
            Int                 arg2 )
 {
-  KOutputStream savedStream = TLS(TheStream);
-  TLS(TheStream) = stream;
+  KOutputStream savedStream = STATE(TheStream);
+  STATE(TheStream) = stream;
   FormatOutput( putToTheStream, format, arg1, arg2);
-  TLS(TheStream) = savedStream;
+  STATE(TheStream) = savedStream;
 }
 
 void Pr (
@@ -2884,30 +2884,30 @@ void Pr (
 
 static void putToTheBuffer( Char c)
 {
-  if (TLS(TheCount) < TLS(TheLimit))
-    TLS(TheBuffer)[TLS(TheCount)++] = c;
+  if (STATE(TheCount) < STATE(TheLimit))
+    STATE(TheBuffer)[STATE(TheCount)++] = c;
 }
 
 void SPrTo(Char *buffer, UInt maxlen, const Char *format, Int arg1, Int arg2)
 {
-  Char *savedBuffer = TLS(TheBuffer);
-  UInt savedCount = TLS(TheCount);
-  UInt savedLimit = TLS(TheLimit);
-  TLS(TheBuffer) = buffer;
-  TLS(TheCount) = 0;
-  TLS(TheLimit) = maxlen;
+  Char *savedBuffer = STATE(TheBuffer);
+  UInt savedCount = STATE(TheCount);
+  UInt savedLimit = STATE(TheLimit);
+  STATE(TheBuffer) = buffer;
+  STATE(TheCount) = 0;
+  STATE(TheLimit) = maxlen;
   FormatOutput(putToTheBuffer, format, arg1, arg2);
   putToTheBuffer('\0');
-  TLS(TheBuffer) = savedBuffer;
-  TLS(TheCount) = savedCount;
-  TLS(TheLimit) = savedLimit;
+  STATE(TheBuffer) = savedBuffer;
+  STATE(TheCount) = savedCount;
+  STATE(TheLimit) = savedLimit;
 }
 
 
 Obj FuncINPUT_FILENAME( Obj self) {
   Obj s;
-  if (TLS(Input)) {
-    C_NEW_STRING_DYN( s, TLS(Input)->name );
+  if (STATE(Input)) {
+    C_NEW_STRING_DYN( s, STATE(Input)->name );
   } else {
     C_NEW_STRING_CONST( s, "*defin*" );
   }
@@ -2915,7 +2915,7 @@ Obj FuncINPUT_FILENAME( Obj self) {
 }
 
 Obj FuncINPUT_LINENUMBER( Obj self) {
-  return INTOBJ_INT(TLS(Input) ? TLS(Input)->number : 0);
+  return INTOBJ_INT(STATE(Input) ? STATE(Input)->number : 0);
 }
 
 Obj FuncALL_KEYWORDS(Obj self) {
@@ -2935,9 +2935,9 @@ Obj FuncALL_KEYWORDS(Obj self) {
 
 Obj FuncSET_PRINT_FORMATTING_STDOUT(Obj self, Obj val) {
   if (val == False)
-    (TLS(OutputFiles)[1])->format = 0;
+    (STATE(OutputFiles)[1])->format = 0;
   else
-    (TLS(OutputFiles)[1])->format = 1;
+    (STATE(OutputFiles)[1])->format = 1;
   return val;
 }
 
@@ -3007,14 +3007,14 @@ static Int InitKernel (
 {
     Int                 i;
 
-    TLS(Input) = 0;
+    STATE(Input) = 0;
     (void)OpenInput(  "*stdin*"  );
-    TLS(Input)->echo = 1; /* echo stdin */
+    STATE(Input)->echo = 1; /* echo stdin */
 
-    TLS(Output) = 0;
+    STATE(Output) = 0;
     (void)OpenOutput( "*stdout*" );
 
-    TLS(InputLog)  = 0;  TLS(OutputLog)  = 0;
+    STATE(InputLog)  = 0;  STATE(OutputLog)  = 0;
 
     /* Initialize default stream functions */
 
@@ -3101,7 +3101,7 @@ StructInitInfo * InitInfoScanner ( void )
 
 void InitScannerTLS()
 {
-  TLS(HELPSubsOn) = 1;
+  STATE(HELPSubsOn) = 1;
 }
 
 void DestroyScannerTLS()

--- a/hpcgap/src/stats.c
+++ b/hpcgap/src/stats.c
@@ -77,7 +77,7 @@
 **
 **  'EXEC_STAT' is defined in the declaration part of this package as follows:
 **
-#define EXEC_STAT(stat) ( (*TLS(CurrExecStatFuncs)[ TNUM_STAT(stat) ]) ( stat ) )
+#define EXEC_STAT(stat) ( (*STATE(CurrExecStatFuncs)[ TNUM_STAT(stat) ]) ( stat ) )
 */
 
 
@@ -141,7 +141,7 @@ UInt            ExecUnknownStat (
 */
 
 UInt HaveInterrupt( void ) {
-  return TLS(CurrExecStatFuncs) == IntrExecStatFuncs;
+  return STATE(CurrExecStatFuncs) == IntrExecStatFuncs;
 }
 
 
@@ -1640,7 +1640,7 @@ UInt            ExecReturnObj (
 
     /* evaluate the expression                                             */
     SET_BRK_CURR_STAT( stat );
-    TLS(ReturnObjStat) = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    STATE(ReturnObjStat) = EVAL_EXPR( ADDR_STAT(stat)[0] );
 
     /* return up to function interpreter                                   */
     return 1;
@@ -1670,8 +1670,8 @@ UInt            ExecReturnVoid (
     }
 #endif
 
-    /* set 'TLS(ReturnObjStat)' to void                                         */
-    TLS(ReturnObjStat) = 0;
+    /* set 'STATE(ReturnObjStat)' to void                                         */
+    STATE(ReturnObjStat) = 0;
 
     /* return up to function interpreter                                   */
     return 2;
@@ -1714,9 +1714,9 @@ static void CheckAndRespondToAlarm(void) {
 
 UInt TakeInterrupt( void ) {
   UInt i;
-  if (TLS(CurrExecStatFuncs) == IntrExecStatFuncs) {
-      assert(TLS(CurrExecStatFuncs) != ExecStatFuncs);
-      TLS(CurrExecStatFuncs) = ExecStatFuncs;
+  if (STATE(CurrExecStatFuncs) == IntrExecStatFuncs) {
+      assert(STATE(CurrExecStatFuncs) != ExecStatFuncs);
+      STATE(CurrExecStatFuncs) = ExecStatFuncs;
       CheckAndRespondToAlarm();
       ErrorReturnVoid( "user interrupt", 0L, 0L, "you can 'return;'" );
       return 1;
@@ -1740,7 +1740,7 @@ UInt ExecIntrStat (
 {
 
     /* change the entries in 'ExecStatFuncs' back to the original          */
-    TLS(CurrExecStatFuncs) = ExecStatFuncs;
+    STATE(CurrExecStatFuncs) = ExecStatFuncs;
 
     /* One reason we might be here is a timeout. If so longjump out to the 
        CallWithTimeLimit where we started */
@@ -1771,7 +1771,7 @@ UInt ExecIntrStat (
 void InterruptExecStat ( void )
 {
     /* remember the original entries from the table 'ExecStatFuncs'        */
-    TLS(CurrExecStatFuncs) = IntrExecStatFuncs;
+    STATE(CurrExecStatFuncs) = IntrExecStatFuncs;
 
 }
 
@@ -1799,15 +1799,15 @@ void InitIntrExecStats ( void )
 */
 
 Int BreakLoopPending( void ) {
-     return TLS(CurrExecStatFuncs) == IntrExecStatFuncs;
+     return STATE(CurrExecStatFuncs) == IntrExecStatFuncs;
 }
 
 void ClearError ( void )
 {
 
     /* change the entries in 'ExecStatFuncs' back to the original          */
-    if ( TLS(CurrExecStatFuncs) == IntrExecStatFuncs ) {
-        TLS(CurrExecStatFuncs) = ExecStatFuncs;
+    if ( STATE(CurrExecStatFuncs) == IntrExecStatFuncs ) {
+        STATE(CurrExecStatFuncs) = ExecStatFuncs;
         /* check for user interrupt */
         if ( HaveInterrupt() ) {
           Pr("Noticed user interrupt, but you are back in main loop anyway.\n",
@@ -1821,8 +1821,8 @@ void ClearError ( void )
         }
     }
 
-    /* reset <TLS(NrError)>                                                     */
-    TLS(NrError) = 0;
+    /* reset <STATE(NrError)>                                                     */
+    STATE(NrError) = 0;
 }
 
 /****************************************************************************
@@ -2326,11 +2326,11 @@ static Int InitKernel (
 
 void InitStatTLS()
 {
-  TLS(CurrExecStatFuncs) = ExecStatFuncs;
+  STATE(CurrExecStatFuncs) = ExecStatFuncs;
   MEMBAR_FULL();
   if (GetThreadState(TLS(threadID)) >= TSTATE_INTERRUPT) {
     MEMBAR_FULL();
-    TLS(CurrExecStatFuncs) = IntrExecStatFuncs;
+    STATE(CurrExecStatFuncs) = IntrExecStatFuncs;
   }
 }
 

--- a/hpcgap/src/stats.c
+++ b/hpcgap/src/stats.c
@@ -2324,17 +2324,17 @@ static Int InitKernel (
     return 0;
 }
 
-void InitStatTLS()
+void InitStatState(GAPState * state)
 {
-  STATE(CurrExecStatFuncs) = ExecStatFuncs;
-  MEMBAR_FULL();
-  if (GetThreadState(TLS(threadID)) >= TSTATE_INTERRUPT) {
+    state->CurrExecStatFuncs = ExecStatFuncs;
     MEMBAR_FULL();
-    STATE(CurrExecStatFuncs) = IntrExecStatFuncs;
-  }
+    if (GetThreadState(TLS(threadID)) >= TSTATE_INTERRUPT) {
+        MEMBAR_FULL();
+        state->CurrExecStatFuncs = IntrExecStatFuncs;
+    }
 }
 
-void DestroyStatTLS()
+void DestroyStatState(GAPState * state)
 {
 }
 

--- a/hpcgap/src/stats.h
+++ b/hpcgap/src/stats.h
@@ -47,7 +47,7 @@ extern  UInt            (* ExecStatFuncs[256]) ( Stat stat );
 **  executor, i.e., to the  function that executes statements  of the type of
 **  <stat>.
 */
-#define EXEC_STAT(stat) ( (*TLS(CurrExecStatFuncs)[ TNUM_STAT(stat) ]) ( stat ) )
+#define EXEC_STAT(stat) ( (*STATE(CurrExecStatFuncs)[ TNUM_STAT(stat) ]) ( stat ) )
 
 /****************************************************************************
 **
@@ -92,10 +92,10 @@ extern  UInt 		(* IntrExecStatFuncs[256]) ( Stat stat );
 *F  RES_BRK_CURR_STAT() . . . . . . . . restore currently executing statement
 */
 #ifndef NO_BRK_CURR_STAT
-#define SET_BRK_CURR_STAT(stat) (TLS(CurrStat) = (stat))
+#define SET_BRK_CURR_STAT(stat) (STATE(CurrStat) = (stat))
 #define OLD_BRK_CURR_STAT       Stat oldStat;
-#define REM_BRK_CURR_STAT()     (oldStat = TLS(CurrStat))
-#define RES_BRK_CURR_STAT()     (TLS(CurrStat) = oldStat)
+#define REM_BRK_CURR_STAT()     (oldStat = STATE(CurrStat))
+#define RES_BRK_CURR_STAT()     (STATE(CurrStat) = oldStat)
 #endif
 #ifdef  NO_BRK_CURR_STAT
 #define SET_BRK_CURR_STAT(stat) /* do nothing */

--- a/hpcgap/src/streams.c
+++ b/hpcgap/src/streams.c
@@ -55,7 +55,7 @@
 
 #include <src/hpc/tls.h>
 
-#include <src/vars.h>                   /* TLS(BottomLVars) for execution contexts */
+#include <src/vars.h>                   /* STATE(BottomLVars) for execution contexts */
 
 
 /****************************************************************************
@@ -69,11 +69,11 @@ Int READ_COMMAND ( void )
     ExecStatus    status;
 
     ClearError();
-    status = ReadEvalCommand(TLS(BottomLVars), 0);
+    status = ReadEvalCommand(STATE(BottomLVars), 0);
     if( status == STATUS_EOF )
         return 0;
 
-    if ( TLS(UserHasQuit) || TLS(UserHasQUIT) )
+    if ( STATE(UserHasQuit) || STATE(UserHasQUIT) )
         return 0;
     
     /* handle return-value or return-void command                          */
@@ -83,11 +83,11 @@ Int READ_COMMAND ( void )
 
     /* handle quit command                                 */
     else if (status == STATUS_QUIT) {
-        TLS(RecursionDepth) = 0;
-        TLS(UserHasQuit) = 1;
+        STATE(RecursionDepth) = 0;
+        STATE(UserHasQuit) = 1;
     }
     else if (status == STATUS_QQUIT) {
-        TLS(UserHasQUIT) = 1;
+        STATE(UserHasQUIT) = 1;
     }
     ClearError();
 
@@ -122,14 +122,14 @@ Obj FuncREAD_ALL_COMMANDS( Obj self, Obj stream, Obj echo )
     SET_LEN_PLIST(resultList, resultCount);
 
     if (echo == True) {
-        TLS(Input)->echo = 1;
+        STATE(Input)->echo = 1;
     } else {
-        TLS(Input)->echo = 0;
+        STATE(Input)->echo = 0;
     }
 
     do {
         ClearError();
-        status = ReadEvalCommand(TLS(BottomLVars), 0);
+        status = ReadEvalCommand(STATE(BottomLVars), 0);
 
         if(!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT))) {
             resultCount++;
@@ -145,9 +145,9 @@ Obj FuncREAD_ALL_COMMANDS( Obj self, Obj stream, Obj echo )
 
             if(!(status & STATUS_ERROR)) {
                 SET_ELM_PLIST(result, 1, True);
-                if (TLS(ReadEvalResult)) {
+                if (STATE(ReadEvalResult)) {
                     SET_LEN_PLIST(result, 2);
-                    SET_ELM_PLIST(result, 2, TLS(ReadEvalResult));
+                    SET_ELM_PLIST(result, 2, STATE(ReadEvalResult));
                 }
             }
         }
@@ -180,9 +180,9 @@ Obj FuncREAD_COMMAND_REAL ( Obj self, Obj stream, Obj echo )
     }
 
     if (echo == True)
-      TLS(Input)->echo = 1;
+      STATE(Input)->echo = 1;
     else
-      TLS(Input)->echo = 0;
+      STATE(Input)->echo = 0;
 
     status = READ_COMMAND();
     
@@ -190,19 +190,19 @@ Obj FuncREAD_COMMAND_REAL ( Obj self, Obj stream, Obj echo )
 
     if( status == 0 ) return result;
 
-    if (TLS(UserHasQUIT)) {
-      TLS(UserHasQUIT) = 0;
+    if (STATE(UserHasQUIT)) {
+      STATE(UserHasQUIT) = 0;
       return result;
     }
 
-    if (TLS(UserHasQuit)) {
-      TLS(UserHasQuit) = 0;
+    if (STATE(UserHasQuit)) {
+      STATE(UserHasQuit) = 0;
     }
     
     SET_ELM_PLIST(result, 1, True);
-    if (TLS(ReadEvalResult)) {
+    if (STATE(ReadEvalResult)) {
         SET_LEN_PLIST(result, 2);
-        SET_ELM_PLIST(result, 2, TLS(ReadEvalResult));
+        SET_ELM_PLIST(result, 2, STATE(ReadEvalResult));
     }
     return result;
 }
@@ -232,15 +232,15 @@ static Int READ_INNER ( UInt UseUHQ )
 {
     ExecStatus                status;
 
-    if (TLS(UserHasQuit))
+    if (STATE(UserHasQuit))
       {
         Pr("Warning: Entering READ with UserHasQuit set, this should never happen, resetting",0,0);
-        TLS(UserHasQuit) = 0;
+        STATE(UserHasQuit) = 0;
       }
-    if (TLS(UserHasQUIT))
+    if (STATE(UserHasQUIT))
       {
         Pr("Warning: Entering READ with UserHasQUIT set, this should never happen, resetting",0,0);
-        TLS(UserHasQUIT) = 0;
+        STATE(UserHasQUIT) = 0;
       }
     MakeReadWriteGVar(LastReadValueGVar);
     AssGVar( LastReadValueGVar, 0);
@@ -248,8 +248,8 @@ static Int READ_INNER ( UInt UseUHQ )
     /* now do the reading                                                  */
     while ( 1 ) {
         ClearError();
-        status = ReadEvalCommand(TLS(BottomLVars), 0);
-	if (TLS(UserHasQuit) || TLS(UserHasQUIT))
+        status = ReadEvalCommand(STATE(BottomLVars), 0);
+	if (STATE(UserHasQuit) || STATE(UserHasQUIT))
 	  break;
         /* handle return-value or return-void command                      */
         if ( status & (STATUS_RETURN_VAL | STATUS_RETURN_VOID) ) {
@@ -262,18 +262,18 @@ static Int READ_INNER ( UInt UseUHQ )
         else if ( status  & (STATUS_ERROR | STATUS_EOF)) 
           break;
         else if (status == STATUS_QUIT) {
-          TLS(RecursionDepth) = 0;
-          TLS(UserHasQuit) = 1;
+          STATE(RecursionDepth) = 0;
+          STATE(UserHasQuit) = 1;
           break;
         }
         else if (status == STATUS_QQUIT) {
-          TLS(UserHasQUIT) = 1;
+          STATE(UserHasQUIT) = 1;
           break;
         }
-        if (TLS(ReadEvalResult))
+        if (STATE(ReadEvalResult))
           {
             MakeReadWriteGVar(LastReadValueGVar);
-            AssGVar( LastReadValueGVar, TLS(ReadEvalResult));
+            AssGVar( LastReadValueGVar, STATE(ReadEvalResult));
             MakeReadOnlyGVar(LastReadValueGVar);
           }
         
@@ -288,8 +288,8 @@ static Int READ_INNER ( UInt UseUHQ )
     }
     ClearError();
 
-    if (!UseUHQ && TLS(UserHasQuit)) {
-      TLS(UserHasQuit) = 0; /* stop recovery here */
+    if (!UseUHQ && STATE(UserHasQuit)) {
+      STATE(UserHasQuit) = 0; /* stop recovery here */
       return 2;
     }
 
@@ -322,7 +322,7 @@ Obj READ_AS_FUNC ( void )
 
     /* get the function                                                    */
     if ( type == 0 ) {
-        func = TLS(ReadEvalResult);
+        func = STATE(ReadEvalResult);
     }
     else {
         func = Fail;
@@ -355,23 +355,23 @@ static void READ_TEST_OR_LOOP(void)
 
         /* read and evaluate the command                                   */
         ClearError();
-        type = ReadEvalCommand(TLS(BottomLVars), &dualSemicolon);
+        type = ReadEvalCommand(STATE(BottomLVars), &dualSemicolon);
 
         /* stop the stopwatch                                              */
         AssGVar( Time, INTOBJ_INT( SyTime() - oldtime ) );
 
         /* handle ordinary command                                         */
-        if ( type == 0 && TLS(ReadEvalResult) != 0 ) {
+        if ( type == 0 && STATE(ReadEvalResult) != 0 ) {
 
             /* remember the value in 'last' and the time in 'time'         */
             AssGVar( Last3, ValGVarTL( Last2 ) );
             AssGVar( Last2, ValGVarTL( Last  ) );
-            AssGVar( Last,  TLS(ReadEvalResult)   );
+            AssGVar( Last,  STATE(ReadEvalResult)   );
 
             /* print the result                                            */
             if ( ! dualSemicolon ) {
-                Bag currLVars = TLS(CurrLVars); /* in case view runs into error */
-                ViewObjHandler( TLS(ReadEvalResult) );
+                Bag currLVars = STATE(CurrLVars); /* in case view runs into error */
+                ViewObjHandler( STATE(ReadEvalResult) );
                 SWITCH_TO_OLD_LVARS(currLVars);
             }
         }
@@ -500,11 +500,11 @@ Int READ_GAP_ROOT ( Char * filename )
                 (Int)filename, 0L );
         }
         if ( OpenInput(result.pathname) ) {
-          SySetBuffering(TLS(Input)->file);
+          SySetBuffering(STATE(Input)->file);
             while ( 1 ) {
                 ClearError();
-                type = ReadEvalCommand(TLS(BottomLVars), 0);
-                if (TLS(UserHasQuit) || TLS(UserHasQUIT))
+                type = ReadEvalCommand(STATE(BottomLVars), 0);
+                if (STATE(UserHasQuit) || STATE(UserHasQUIT))
                   break;
                 if ( type & (STATUS_RETURN_VAL | STATUS_RETURN_VOID) ) {
                     Pr( "'return' must not be used in file", 0L, 0L );
@@ -774,17 +774,17 @@ Obj FuncPrint (
             PrintFunction( arg );
         }
         else {
-            memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+            memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
 
             /* if an error occurs stop printing                            */
             TRY_READ {
                 PrintObj( arg );
             }
             CATCH_READ_ERROR {
-                memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+                memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
                 ReadEvalError();
             }
-            memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+            memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
         }
     }
 
@@ -827,12 +827,12 @@ static Obj PRINT_OR_APPEND_TO(Obj args, int append)
             PrintString1(arg);
         }
         else if ( TNUM_OBJ(arg) == T_FUNCTION ) {
-            TLS(PrintObjFull) = 1;
+            STATE(PrintObjFull) = 1;
             PrintFunction( arg );
-            TLS(PrintObjFull) = 0;
+            STATE(PrintObjFull) = 0;
         }
         else {
-            memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+            memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
 
             /* if an error occurs stop printing                            */
             TRY_READ {
@@ -840,10 +840,10 @@ static Obj PRINT_OR_APPEND_TO(Obj args, int append)
             }
             CATCH_READ_ERROR {
                 CloseOutput();
-                memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+                memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
                 ReadEvalError();
             }
-            memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+            memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
         }
     }
 
@@ -880,7 +880,7 @@ static Obj PRINT_OR_APPEND_TO_STREAM(Obj args, int append)
         arg = ELM_LIST(args,i);
 
         /* if an error occurs stop printing                                */
-        memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+        memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
         TRY_READ {
             if ( IS_PLIST(arg) && 0 < LEN_PLIST(arg) && IsStringConv(arg) ) {
                 PrintString1(arg);
@@ -889,9 +889,9 @@ static Obj PRINT_OR_APPEND_TO_STREAM(Obj args, int append)
                 PrintString1(arg);
             }
             else if ( TNUM_OBJ( arg ) == T_FUNCTION ) {
-                TLS(PrintObjFull) = 1;
+                STATE(PrintObjFull) = 1;
                 PrintFunction( arg );
-                TLS(PrintObjFull) = 0;
+                STATE(PrintObjFull) = 0;
             }
             else {
                 PrintObj( arg );
@@ -899,10 +899,10 @@ static Obj PRINT_OR_APPEND_TO_STREAM(Obj args, int append)
         }
         CATCH_READ_ERROR {
             CloseOutput();
-            memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+            memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
             ReadEvalError();
         }
-        memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+        memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
     }
 
     /* close the output file again, and return nothing                     */
@@ -1036,7 +1036,7 @@ Obj FuncREAD (
         return False;
     }
 
-    SySetBuffering(TLS(Input)->file);
+    SySetBuffering(STATE(Input)->file);
    
     /* read the test file                                                  */
     return READ() ? True : False;
@@ -1068,7 +1068,7 @@ Obj FuncREAD_NORECOVERY (
         return False;
     }
 
-    SySetBuffering(TLS(Input)->file);
+    SySetBuffering(STATE(Input)->file);
    
     /* read the file */
     switch (READ_NORECOVERY()) {
@@ -1111,14 +1111,14 @@ Obj FuncREAD_STREAM_LOOP (
         return False;
     }
     if ( catcherrstdout == True )
-      TLS(IgnoreStdoutErrout) = GetCurrentOutput();
+      STATE(IgnoreStdoutErrout) = GetCurrentOutput();
     else
-      TLS(IgnoreStdoutErrout) = NULL;
+      STATE(IgnoreStdoutErrout) = NULL;
 
 
     /* read the test file                                                  */
     READ_LOOP();
-    TLS(IgnoreStdoutErrout) = NULL;
+    STATE(IgnoreStdoutErrout) = NULL;
     return True;
 }
 
@@ -1144,7 +1144,7 @@ Obj FuncREAD_AS_FUNC (
         return Fail;
     }
 
-    SySetBuffering(TLS(Input)->file);
+    SySetBuffering(STATE(Input)->file);
     
     /* read the function                                                   */
     return READ_AS_FUNC();

--- a/hpcgap/src/sysfiles.c
+++ b/hpcgap/src/sysfiles.c
@@ -2272,13 +2272,13 @@ Char * readlineFgets (
 #endif
   /* now do the real work */
   doingReadline = 1;
-  rlres = readline(TLS(Prompt));
+  rlres = readline(STATE(Prompt));
   doingReadline = 0;
   /* we get a NULL pointer on EOF, say by pressing Ctr-d  */
   if (!rlres) {
     if (!SyCTRD) {
       while (!rlres)
-        rlres = readline(TLS(Prompt));
+        rlres = readline(STATE(Prompt));
     }
     else {
       printf("\n");fflush(stdout);

--- a/hpcgap/src/vars.h
+++ b/hpcgap/src/vars.h
@@ -96,7 +96,7 @@
 **  This  is  in this package,  because  it is stored   along  with the local
 **  variables in the local variables bag.
 */
-#define CURR_FUNC       FUNC_LVARS_PTR(TLS(PtrLVars))
+#define CURR_FUNC       FUNC_LVARS_PTR(STATE(PtrLVars))
 
 
 /****************************************************************************
@@ -114,17 +114,17 @@ extern Obj True;
 static inline void SetBrkCallTo( Expr expr, char * file, int line ) {
   if (STEVES_TRACING == True) {
     fprintf(stderr,"SBCT: %i %x %s %i\n",
-            (int)expr, (int)TLS(CurrLVars), file, line);
+            (int)expr, (int)STATE(CurrLVars), file, line);
   }
-  (TLS(PtrLVars)[1] = (Obj)(Int)(expr));
+  (STATE(PtrLVars)[1] = (Obj)(Int)(expr));
 }
 
 #else
-#define SetBrkCallTo(expr, file, line)  (TLS(PtrLVars)[1] = (Obj)(Int)(expr))
+#define SetBrkCallTo(expr, file, line)  (STATE(PtrLVars)[1] = (Obj)(Int)(expr))
 #endif
 
 #ifndef NO_BRK_CALLS
-#define BRK_CALL_TO()                   ((Expr)(Int)(TLS(PtrLVars)[1]))
+#define BRK_CALL_TO()                   ((Expr)(Int)(STATE(PtrLVars)[1]))
 #define SET_BRK_CALL_TO(expr)           SetBrkCallTo(expr, __FILE__, __LINE__)
 #else
 #define BRK_CALL_TO()                   /* do nothing */
@@ -138,8 +138,8 @@ static inline void SetBrkCallTo( Expr expr, char * file, int line ) {
 *F  SET_BRK_CALL_FROM(lvars)  . .  set frame from which this frame was called
 */
 #ifndef NO_BRK_CALLS
-#define BRK_CALL_FROM()                 PARENT_LVARS_PTR(TLS(PtrLVars))
-#define SET_BRK_CALL_FROM(lvars)        (PARENT_LVARS_PTR(TLS(PtrLVars)) = (lvars))
+#define BRK_CALL_FROM()                 PARENT_LVARS_PTR(STATE(PtrLVars))
+#define SET_BRK_CALL_FROM(lvars)        (PARENT_LVARS_PTR(STATE(PtrLVars)) = (lvars))
 #else
 #define BRK_CALL_FROM()                 /* do nothing */
 #define SET_BRK_CALL_FROM(lvars)        /* do nothing */
@@ -191,19 +191,19 @@ static inline Obj SwitchToNewLvars(Obj func, UInt narg, UInt nloc
 #endif
 )
 {
-  Obj old = TLS(CurrLVars);
+  Obj old = STATE(CurrLVars);
   CHANGED_BAG( old );
-  TLS(CurrLVars) = NewLVarsBag( narg+nloc );
-  TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
+  STATE(CurrLVars) = NewLVarsBag( narg+nloc );
+  STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
   CURR_FUNC = func;
-  TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+  STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
   SET_BRK_CALL_FROM( old );
 #ifdef TRACEFRAMES
   if (STEVES_TRACING == True) {
     Obj n = NAME_FUNC(func);
     Char *s = ((UInt)n) ? (Char *)CHARS_STRING(n) : (Char *)"nameless";
     fprintf(stderr,"STNL: %s %i\n   func %lx narg %i nloc %i function name %s\n     old lvars %lx new lvars %lx\n",
-            file, line, (UInt) func, (int)narg, (int)nloc,s,(UInt)old, (UInt)TLS(CurrLVars));
+            file, line, (UInt) func, (int)narg, (int)nloc,s,(UInt)old, (UInt)STATE(CurrLVars));
   }
 #endif
   return old;
@@ -232,13 +232,13 @@ static inline void SwitchToOldLVars( Obj old
 #ifdef TRACEFRAMES
   if (STEVES_TRACING == True) {
     fprintf(stderr,"STOL:  %s %i old lvars %lx new lvars %lx\n",
-           file, line, (UInt)TLS(CurrLVars),(UInt)old);
+           file, line, (UInt)STATE(CurrLVars),(UInt)old);
   }
 #endif
-  CHANGED_BAG( TLS(CurrLVars) );
-  TLS(CurrLVars) = (old);
-  TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-  TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+  CHANGED_BAG( STATE(CurrLVars) );
+  STATE(CurrLVars) = (old);
+  STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+  STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
 }
 
 static inline void SwitchToOldLVarsAndFree( Obj old
@@ -250,15 +250,15 @@ static inline void SwitchToOldLVarsAndFree( Obj old
 #ifdef TRACEFRAMES
   if (STEVES_TRACING == True) {
     fprintf(stderr,"STOL:  %s %i old lvars %lx new lvars %lx\n",
-           file, line, (UInt)TLS(CurrLVars),(UInt)old);
+           file, line, (UInt)STATE(CurrLVars),(UInt)old);
   }
 #endif
-  CHANGED_BAG( TLS(CurrLVars) );
-  if (TLS(CurrLVars) != old && TNUM_OBJ(TLS(CurrLVars)) == T_LVARS)
-    FreeLVarsBag(TLS(CurrLVars));
-  TLS(CurrLVars) = (old);
-  TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-  TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+  CHANGED_BAG( STATE(CurrLVars) );
+  if (STATE(CurrLVars) != old && TNUM_OBJ(STATE(CurrLVars)) == T_LVARS)
+    FreeLVarsBag(STATE(CurrLVars));
+  STATE(CurrLVars) = (old);
+  STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+  STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
 }
 
 
@@ -281,7 +281,7 @@ static inline void SwitchToOldLVarsAndFree( Obj old
 **
 **  'ASS_LVAR' assigns the value <val> to the local variable <lvar>.
 */
-#define ASS_LVAR(lvar,val)      (TLS(PtrLVars)[(lvar)+2] = (val))
+#define ASS_LVAR(lvar,val)      (STATE(PtrLVars)[(lvar)+2] = (val))
 
 
 /****************************************************************************
@@ -290,7 +290,7 @@ static inline void SwitchToOldLVarsAndFree( Obj old
 **
 **  'OBJ_LVAR' returns the value of the local variable <lvar>.
 */
-#define OBJ_LVAR(lvar)          (TLS(PtrLVars)[(lvar)+2])
+#define OBJ_LVAR(lvar)          (STATE(PtrLVars)[(lvar)+2])
 
 
 /****************************************************************************

--- a/src/c_filter1.c
+++ b/src/c_filter1.c
@@ -490,13 +490,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 15, "CLEAR_IMP_CACHE" );
  t_3 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(38));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(40));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "WITH_IMPS_FLAGS", function ( flags )
@@ -537,13 +537,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 15, "WITH_IMPS_FLAGS" );
  t_3 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(43));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(82));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "RankFilter", function ( filter )
@@ -566,13 +566,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "RankFilter" );
  t_3 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(91));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(108));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
@@ -674,8 +674,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = TLS(CurrLVars);
- CHANGED_BAG( TLS(CurrLVars) );
+ ENVI_FUNC( func1 ) = STATE(CurrLVars);
+ CHANGED_BAG( STATE(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/src/c_methsel1.c
+++ b/src/c_methsel1.c
@@ -4655,13 +4655,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(19));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(30));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_METHOD__0ARGS, t_1 );
  
  /* METHOD_1ARGS := function ( operation, type1 )
@@ -4675,13 +4675,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(37));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(49));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_METHOD__1ARGS, t_1 );
  
  /* METHOD_2ARGS := function ( operation, type1, type2 )
@@ -4695,13 +4695,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(56));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(69));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_METHOD__2ARGS, t_1 );
  
  /* METHOD_3ARGS := function ( operation, type1, type2, type3 )
@@ -4715,13 +4715,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(76));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(90));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_METHOD__3ARGS, t_1 );
  
  /* METHOD_4ARGS := function ( operation, type1, type2, type3, type4 )
@@ -4736,13 +4736,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(97));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(114));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_METHOD__4ARGS, t_1 );
  
  /* METHOD_5ARGS := function ( operation, type1, type2, type3, type4, type5 )
@@ -4757,13 +4757,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[7], NargFunc[7], NamsFunc[7], HdlrFunc7 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(121));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(139));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_METHOD__5ARGS, t_1 );
  
  /* METHOD_6ARGS := function ( operation, type1, type2, type3, type4, type5, type6 )
@@ -4778,13 +4778,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[8], NargFunc[8], NamsFunc[8], HdlrFunc8 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(146));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(165));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_METHOD__6ARGS, t_1 );
  
  /* METHOD_XARGS := function ( arg... )
@@ -4792,13 +4792,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[9], NargFunc[9], NamsFunc[9], HdlrFunc9 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(172));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(174));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_METHOD__XARGS, t_1 );
  
  /* NEXT_METHOD_0ARGS := function ( operation, k )
@@ -4817,13 +4817,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(189));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(205));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__METHOD__0ARGS, t_1 );
  
  /* NEXT_METHOD_1ARGS := function ( operation, k, type1 )
@@ -4842,13 +4842,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(212));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(229));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__METHOD__1ARGS, t_1 );
  
  /* NEXT_METHOD_2ARGS := function ( operation, k, type1, type2 )
@@ -4867,13 +4867,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(236));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(254));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__METHOD__2ARGS, t_1 );
  
  /* NEXT_METHOD_3ARGS := function ( operation, k, type1, type2, type3 )
@@ -4893,13 +4893,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(261));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(280));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__METHOD__3ARGS, t_1 );
  
  /* NEXT_METHOD_4ARGS := function ( operation, k, type1, type2, type3, type4 )
@@ -4919,13 +4919,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(287));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(309));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__METHOD__4ARGS, t_1 );
  
  /* NEXT_METHOD_5ARGS := function ( operation, k, type1, type2, type3, type4, type5 )
@@ -4945,13 +4945,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(316));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(339));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__METHOD__5ARGS, t_1 );
  
  /* NEXT_METHOD_6ARGS := function ( operation, k, type1, type2, type3, type4, type5, type6 )
@@ -4971,13 +4971,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(346));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(370));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__METHOD__6ARGS, t_1 );
  
  /* NEXT_METHOD_XARGS := function ( arg... )
@@ -4985,13 +4985,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(377));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(379));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__METHOD__XARGS, t_1 );
  
  /* AttributeValueNotSet := function ( attr, obj )
@@ -5017,13 +5017,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(385));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(406));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_AttributeValueNotSet, t_1 );
  
  /* CONSTRUCTOR_0ARGS := function ( operation )
@@ -5037,13 +5037,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[19], NargFunc[19], NamsFunc[19], HdlrFunc19 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(419));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(430));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__0ARGS, t_1 );
  
  /* CONSTRUCTOR_1ARGS := function ( operation, flags1 )
@@ -5057,13 +5057,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[20], NargFunc[20], NamsFunc[20], HdlrFunc20 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(437));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(449));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__1ARGS, t_1 );
  
  /* CONSTRUCTOR_2ARGS := function ( operation, flags1, type2 )
@@ -5077,13 +5077,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[21], NargFunc[21], NamsFunc[21], HdlrFunc21 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(456));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(469));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__2ARGS, t_1 );
  
  /* CONSTRUCTOR_3ARGS := function ( operation, flags1, type2, type3 )
@@ -5097,13 +5097,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[22], NargFunc[22], NamsFunc[22], HdlrFunc22 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(476));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(490));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__3ARGS, t_1 );
  
  /* CONSTRUCTOR_4ARGS := function ( operation, flags1, type2, type3, type4 )
@@ -5118,13 +5118,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[23], NargFunc[23], NamsFunc[23], HdlrFunc23 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(497));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(514));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__4ARGS, t_1 );
  
  /* CONSTRUCTOR_5ARGS := function ( operation, flags1, type2, type3, type4, type5 )
@@ -5139,13 +5139,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[24], NargFunc[24], NamsFunc[24], HdlrFunc24 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(521));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(539));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__5ARGS, t_1 );
  
  /* CONSTRUCTOR_6ARGS := function ( operation, flags1, type2, type3, type4, type5, type6 )
@@ -5160,13 +5160,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[25], NargFunc[25], NamsFunc[25], HdlrFunc25 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(546));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(565));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__6ARGS, t_1 );
  
  /* CONSTRUCTOR_XARGS := function ( arg... )
@@ -5174,13 +5174,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[26], NargFunc[26], NamsFunc[26], HdlrFunc26 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(572));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(574));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_CONSTRUCTOR__XARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_0ARGS := function ( operation, k )
@@ -5199,13 +5199,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[27], NargFunc[27], NamsFunc[27], HdlrFunc27 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(589));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(605));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__0ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_1ARGS := function ( operation, k, flags1 )
@@ -5224,13 +5224,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[28], NargFunc[28], NamsFunc[28], HdlrFunc28 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(612));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(629));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__1ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_2ARGS := function ( operation, k, flags1, type2 )
@@ -5249,13 +5249,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[29], NargFunc[29], NamsFunc[29], HdlrFunc29 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(636));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(654));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__2ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_3ARGS := function ( operation, k, flags1, type2, type3 )
@@ -5274,13 +5274,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[30], NargFunc[30], NamsFunc[30], HdlrFunc30 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(661));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(680));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__3ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_4ARGS := function ( operation, k, flags1, type2, type3, type4 )
@@ -5300,13 +5300,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[31], NargFunc[31], NamsFunc[31], HdlrFunc31 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(687));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(709));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__4ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_5ARGS := function ( operation, k, flags1, type2, type3, type4, type5 )
@@ -5326,13 +5326,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[32], NargFunc[32], NamsFunc[32], HdlrFunc32 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(716));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(739));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__5ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_6ARGS := function ( operation, k, flags1, type2, type3, type4, type5, type6 )
@@ -5352,13 +5352,13 @@ static Obj  HdlrFunc1 (
       return fail;
   end; */
  t_1 = NewFunction( NameFunc[33], NargFunc[33], NamsFunc[33], HdlrFunc33 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(746));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(770));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__6ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_XARGS := function ( arg... )
@@ -5366,13 +5366,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[34], NargFunc[34], NamsFunc[34], HdlrFunc34 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(777));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(779));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_NEXT__CONSTRUCTOR__XARGS, t_1 );
  
  /* return; */
@@ -5641,8 +5641,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = TLS(CurrLVars);
- CHANGED_BAG( TLS(CurrLVars) );
+ ENVI_FUNC( func1 ) = STATE(CurrLVars);
+ CHANGED_BAG( STATE(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -2435,13 +2435,13 @@ static Obj  HdlrFunc7 (
    SET_ELM_PLIST( t_5, 1, l_cats );
    CHANGED_BAG( t_5 );
    t_6 = NewFunction( NameFunc[8], NargFunc[8], NamsFunc[8], HdlrFunc8 );
-   ENVI_FUNC( t_6 ) = TLS(CurrLVars);
+   ENVI_FUNC( t_6 ) = STATE(CurrLVars);
    t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
    SET_STARTLINE_BODY(t_7, INTOBJ_INT(580));
    SET_ENDLINE_BODY(t_7, INTOBJ_INT(598));
    SET_FILENAME_BODY(t_7, FileName);
    BODY_FUNC(t_6) = t_7;
-   CHANGED_BAG( TLS(CurrLVars) );
+   CHANGED_BAG( STATE(CurrLVars) );
    CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, l_rank, t_6 );
    
   }
@@ -3026,13 +3026,13 @@ static Obj  HdlrFunc11 (
       return;
   end; */
   t_1 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
-  ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+  ENVI_FUNC( t_1 ) = STATE(CurrLVars);
   t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
   SET_STARTLINE_BODY(t_2, INTOBJ_INT(777));
   SET_ENDLINE_BODY(t_2, INTOBJ_INT(781));
   SET_FILENAME_BODY(t_2, FileName);
   BODY_FUNC(t_1) = t_2;
-  CHANGED_BAG( TLS(CurrLVars) );
+  CHANGED_BAG( STATE(CurrLVars) );
   ASS_LVAR( 2, t_1 );
   
  }
@@ -3106,13 +3106,13 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 1, a_domreq );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
- ENVI_FUNC( t_6 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_6 ) = STATE(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_7, INTOBJ_INT(798));
  SET_ENDLINE_BODY(t_7, INTOBJ_INT(798));
  SET_FILENAME_BODY(t_7, FileName);
  BODY_FUNC(t_6) = t_7;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* DeclareOperation( name, [ domreq, keyreq ] ); */
@@ -3169,13 +3169,13 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 2, a_keyreq );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
- ENVI_FUNC( t_6 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_6 ) = STATE(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_7, INTOBJ_INT(811));
  SET_ENDLINE_BODY(t_7, INTOBJ_INT(834));
  SET_FILENAME_BODY(t_7, FileName);
  BODY_FUNC(t_6) = t_7;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* str := "Has"; */
@@ -3218,13 +3218,13 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 2, a_keyreq );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
- ENVI_FUNC( t_6 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_6 ) = STATE(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_7, INTOBJ_INT(844));
  SET_ENDLINE_BODY(t_7, INTOBJ_INT(852));
  SET_FILENAME_BODY(t_7, FileName);
  BODY_FUNC(t_6) = t_7;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* str := "Set"; */
@@ -3280,13 +3280,13 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 3, t_6 );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
- ENVI_FUNC( t_6 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_6 ) = STATE(CurrLVars);
  t_7 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_7, INTOBJ_INT(861));
  SET_ENDLINE_BODY(t_7, INTOBJ_INT(874));
  SET_FILENAME_BODY(t_7, FileName);
  BODY_FUNC(t_6) = t_7;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* return; */
@@ -3661,13 +3661,13 @@ static Obj  HdlrFunc17 (
  t_3 = OBJ_LVAR( 2 );
  CHECK_BOUND( t_3, "reqs" )
  t_4 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
- ENVI_FUNC( t_4 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_4 ) = STATE(CurrLVars);
  t_5 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_5, INTOBJ_INT(942));
  SET_ENDLINE_BODY(t_5, INTOBJ_INT(958));
  SET_FILENAME_BODY(t_5, FileName);
  BODY_FUNC(t_4) = t_5;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_6ARGS( t_1, t_2, l_info, l_fampred, t_3, l_val, t_4 );
  
  /* return; */
@@ -3755,13 +3755,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 19, "RunImmediateMethods" );
  t_3 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(26));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(117));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "INSTALL_METHOD_FLAGS", function ( opr, info, rel, flags, rank, method )
@@ -3852,13 +3852,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 20, "INSTALL_METHOD_FLAGS" );
  t_3 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(124));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(235));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "InstallMethod", function ( arg... )
@@ -3868,13 +3868,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "InstallMethod" );
  t_3 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(282));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(284));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "InstallOtherMethod", function ( arg... )
@@ -3884,13 +3884,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 18, "InstallOtherMethod" );
  t_3 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(309));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(311));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* DeclareGlobalFunction( "EvalString" ); */
@@ -4042,13 +4042,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 14, "INSTALL_METHOD" );
  t_3 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(322));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(529));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + 6; */
@@ -4099,13 +4099,13 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_InstallAttributeFunction;
  t_2 = NewFunction( NameFunc[7], NargFunc[7], NamsFunc[7], HdlrFunc7 );
- ENVI_FUNC( t_2 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_2 ) = STATE(CurrLVars);
  t_3 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_3, INTOBJ_INT(548));
  SET_ENDLINE_BODY(t_3, INTOBJ_INT(602));
  SET_FILENAME_BODY(t_3, FileName);
  BODY_FUNC(t_2) = t_3;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
@@ -4114,13 +4114,13 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_InstallAttributeFunction;
  t_2 = NewFunction( NameFunc[9], NargFunc[9], NamsFunc[9], HdlrFunc9 );
- ENVI_FUNC( t_2 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_2 ) = STATE(CurrLVars);
  t_3 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_3, INTOBJ_INT(605));
  SET_ENDLINE_BODY(t_3, INTOBJ_INT(611));
  SET_FILENAME_BODY(t_3, FileName);
  BODY_FUNC(t_2) = t_3;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
  /* BIND_GLOBAL( "PositionSortedOddPositions", function ( list, elm )
@@ -4143,13 +4143,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 26, "PositionSortedOddPositions" );
  t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(624));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(648));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* IsPrimeInt := "2b defined"; */
@@ -4226,13 +4226,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "KeyDependentOperation" );
  t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(773));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(875));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* CallFuncList := "2b defined"; */
@@ -4278,13 +4278,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "RedispatchOnCondition" );
  t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(910));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(959));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* InstallMethod( ViewObj, "default method using `PrintObj'", true, [ IS_OBJECT ], 0, PRINT_OBJ ); */
@@ -4585,8 +4585,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = TLS(CurrLVars);
- CHANGED_BAG( TLS(CurrLVars) );
+ ENVI_FUNC( func1 ) = STATE(CurrLVars);
+ CHANGED_BAG( STATE(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/src/c_random.c
+++ b/src/c_random.c
@@ -263,13 +263,13 @@ static Obj  HdlrFunc1 (
       return list[QUO_INT( R_X[R_N] * LEN_LIST( list ), R_228 ) + 1];
   end; */
  t_1 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(23));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(27));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_RANDOM__LIST, t_1 );
  
  /* RANDOM_SEED := function ( n )
@@ -286,13 +286,13 @@ static Obj  HdlrFunc1 (
       return;
   end; */
  t_1 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_1 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_1 ) = STATE(CurrLVars);
  t_2 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_2, INTOBJ_INT(29));
  SET_ENDLINE_BODY(t_2, INTOBJ_INT(39));
  SET_FILENAME_BODY(t_2, FileName);
  BODY_FUNC(t_1) = t_2;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  AssGVar( G_RANDOM__SEED, t_1 );
  
  /* if R_X = [  ] then */
@@ -383,8 +383,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = TLS(CurrLVars);
- CHANGED_BAG( TLS(CurrLVars) );
+ ENVI_FUNC( func1 ) = STATE(CurrLVars);
+ CHANGED_BAG( STATE(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -373,13 +373,13 @@ static Obj  HdlrFunc3 (
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
-  ENVI_FUNC( t_5 ) = TLS(CurrLVars);
+  ENVI_FUNC( t_5 ) = STATE(CurrLVars);
   t_6 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
   SET_STARTLINE_BODY(t_6, INTOBJ_INT(39));
   SET_ENDLINE_BODY(t_6, INTOBJ_INT(42));
   SET_FILENAME_BODY(t_6, FileName);
   BODY_FUNC(t_5) = t_6;
-  CHANGED_BAG( TLS(CurrLVars) );
+  CHANGED_BAG( STATE(CurrLVars) );
   CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
   
  }
@@ -3724,13 +3724,13 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_InstallAttributeFunction;
  t_2 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
- ENVI_FUNC( t_2 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_2 ) = STATE(CurrLVars);
  t_3 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_3, INTOBJ_INT(19));
  SET_ENDLINE_BODY(t_3, INTOBJ_INT(26));
  SET_FILENAME_BODY(t_3, FileName);
  BODY_FUNC(t_2) = t_3;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + 6; */
@@ -3753,13 +3753,13 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_InstallAttributeFunction;
  t_2 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
- ENVI_FUNC( t_2 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_2 ) = STATE(CurrLVars);
  t_3 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_3, INTOBJ_INT(31));
  SET_ENDLINE_BODY(t_3, INTOBJ_INT(52));
  SET_FILENAME_BODY(t_3, FileName);
  BODY_FUNC(t_2) = t_3;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_1ARGS( t_1, t_2 );
  
  /* Subtype := "defined below"; */
@@ -3791,13 +3791,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NEW_FAMILY" );
  t_3 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(89));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(117));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily2", function ( typeOfFamilies, name )
@@ -3806,13 +3806,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NewFamily2" );
  t_3 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(120));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(125));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily3", function ( typeOfFamilies, name, req )
@@ -3821,13 +3821,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NewFamily3" );
  t_3 = NewFunction( NameFunc[7], NargFunc[7], NamsFunc[7], HdlrFunc7 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(128));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(133));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily4", function ( typeOfFamilies, name, req, imp )
@@ -3836,13 +3836,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NewFamily4" );
  t_3 = NewFunction( NameFunc[8], NargFunc[8], NamsFunc[8], HdlrFunc8 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(136));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(141));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily5", function ( typeOfFamilies, name, req, imp, filter )
@@ -3851,13 +3851,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "NewFamily5" );
  t_3 = NewFunction( NameFunc[9], NargFunc[9], NamsFunc[9], HdlrFunc9 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(145));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(150));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily", function ( arg... )
@@ -3877,13 +3877,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "NewFamily" );
  t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(153));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(176));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* NEW_TYPE_CACHE_MISS := 0; */
@@ -3936,13 +3936,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NEW_TYPE" );
  t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(204));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(259));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType3", function ( typeOfTypes, family, filter )
@@ -3951,13 +3951,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType3" );
  t_3 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(263));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(270));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType4", function ( typeOfTypes, family, filter, data )
@@ -3966,13 +3966,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "NewType4" );
  t_3 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(273));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(280));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType", function ( arg... )
@@ -3992,13 +3992,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "NewType" );
  t_3 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(283));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(307));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Subtype2", function ( type, filter )
@@ -4014,13 +4014,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "Subtype2" );
  t_3 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(320));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(334));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Subtype3", function ( type, filter, data )
@@ -4036,13 +4036,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "Subtype3" );
  t_3 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(337));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(351));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Unbind( Subtype ); */
@@ -4062,13 +4062,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "Subtype" );
  t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(355));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(369));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType2", function ( type, filter )
@@ -4084,13 +4084,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "SupType2" );
  t_3 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(383));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(397));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType3", function ( type, filter, data )
@@ -4106,13 +4106,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "SupType3" );
  t_3 = NewFunction( NameFunc[19], NargFunc[19], NamsFunc[19], HdlrFunc19 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(400));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(414));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType", function ( arg... )
@@ -4129,13 +4129,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "SupType" );
  t_3 = NewFunction( NameFunc[20], NargFunc[20], NamsFunc[20], HdlrFunc20 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(417));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(431));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FamilyType", function ( K )
@@ -4144,13 +4144,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "FamilyType" );
  t_3 = NewFunction( NameFunc[21], NargFunc[21], NamsFunc[21], HdlrFunc21 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(445));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(445));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FlagsType", function ( K )
@@ -4159,13 +4159,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "FlagsType" );
  t_3 = NewFunction( NameFunc[22], NargFunc[22], NamsFunc[22], HdlrFunc22 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(459));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(459));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "DataType", function ( K )
@@ -4174,13 +4174,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "DataType" );
  t_3 = NewFunction( NameFunc[23], NargFunc[23], NamsFunc[23], HdlrFunc23 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(475));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(475));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetDataType", function ( K, data )
@@ -4190,13 +4190,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 11, "SetDataType" );
  t_3 = NewFunction( NameFunc[24], NargFunc[24], NamsFunc[24], HdlrFunc24 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(477));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(479));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "TypeObj", TYPE_OBJ ); */
@@ -4219,13 +4219,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "FlagsObj" );
  t_3 = NewFunction( NameFunc[25], NargFunc[25], NamsFunc[25], HdlrFunc25 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(578));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(578));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "DataObj", function ( obj )
@@ -4234,13 +4234,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "DataObj" );
  t_3 = NewFunction( NameFunc[26], NargFunc[26], NamsFunc[26], HdlrFunc26 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(592));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(592));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetTypeObj", function ( type, obj )
@@ -4260,13 +4260,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 10, "SetTypeObj" );
  t_3 = NewFunction( NameFunc[27], NargFunc[27], NamsFunc[27], HdlrFunc27 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(606));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(619));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsNonAtomicComponentObjectRepFlags", FLAGS_FILTER( IsNonAtomicComponentObjectRep ) ); */
@@ -4325,13 +4325,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "ChangeTypeObj" );
  t_3 = NewFunction( NameFunc[28], NargFunc[28], NamsFunc[28], HdlrFunc28 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(643));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(658));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ReObjectify", ChangeTypeObj ); */
@@ -4383,13 +4383,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 12, "SetFilterObj" );
  t_3 = NewFunction( NameFunc[29], NargFunc[29], NamsFunc[29], HdlrFunc29 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(682));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(720));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SET_FILTER_OBJ", SetFilterObj ); */
@@ -4425,13 +4425,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 14, "ResetFilterObj" );
  t_3 = NewFunction( NameFunc[30], NargFunc[30], NamsFunc[30], HdlrFunc30 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(742));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(764));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "RESET_FILTER_OBJ", ResetFilterObj ); */
@@ -4452,13 +4452,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 13, "SetFeatureObj" );
  t_3 = NewFunction( NameFunc[31], NargFunc[31], NamsFunc[31], HdlrFunc31 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(780));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(786));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetMultipleAttributes", function ( arg... )
@@ -4505,13 +4505,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 21, "SetMultipleAttributes" );
  t_3 = NewFunction( NameFunc[32], NargFunc[32], NamsFunc[32], HdlrFunc32 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(807));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(859));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
@@ -4584,13 +4584,13 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 23, "ObjectifyWithAttributes" );
  t_3 = NewFunction( NameFunc[33], NargFunc[33], NamsFunc[33], HdlrFunc33 );
- ENVI_FUNC( t_3 ) = TLS(CurrLVars);
+ ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
  SET_STARTLINE_BODY(t_4, INTOBJ_INT(906));
  SET_ENDLINE_BODY(t_4, INTOBJ_INT(971));
  SET_FILENAME_BODY(t_4, FileName);
  BODY_FUNC(t_3) = t_4;
- CHANGED_BAG( TLS(CurrLVars) );
+ CHANGED_BAG( STATE(CurrLVars) );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
@@ -4999,8 +4999,8 @@ static Int InitLibrary ( StructInitInfo * module )
  
  /* create all the functions defined in this module */
  func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);
- ENVI_FUNC( func1 ) = TLS(CurrLVars);
- CHANGED_BAG( TLS(CurrLVars) );
+ ENVI_FUNC( func1 ) = STATE(CurrLVars);
+ CHANGED_BAG( STATE(CurrLVars) );
  body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));
  BODY_FUNC( func1 ) = body1;
  CHANGED_BAG( func1 );

--- a/src/calls.c
+++ b/src/calls.c
@@ -34,7 +34,7 @@
 **  ...what the other components are...
 */
 #include <src/system.h>                 /* system dependent part */
-
+#include <src/gapstate.h>               /* system dependent part */
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/code.c
+++ b/src/code.c
@@ -92,31 +92,31 @@ Obj FilenameCache;
 /* TL: UInt LoopStackCount = 0; */
 
 static inline void PushOffsBody( void ) {
-  assert(TLS(OffsBodyCount) <= MAX_FUNC_EXPR_NESTING-1);
-  TLS(OffsBodyStack)[TLS(OffsBodyCount)++] = TLS(OffsBody);
+  assert(STATE(OffsBodyCount) <= MAX_FUNC_EXPR_NESTING-1);
+  STATE(OffsBodyStack)[STATE(OffsBodyCount)++] = STATE(OffsBody);
 }
 
 static inline void PopOffsBody( void ) {
-  assert(TLS(OffsBodyCount));
-  TLS(OffsBody) = TLS(OffsBodyStack)[--TLS(OffsBodyCount)];
+  assert(STATE(OffsBodyCount));
+  STATE(OffsBody) = STATE(OffsBodyStack)[--STATE(OffsBodyCount)];
 }
 
 static void SetupOffsBodyStackAndLoopStack() {
   // Careful: Malloc without free
 /* Since this mallocs we use a global variable at the moment
-  TLS(OffsBodyStack) = malloc(MAX_FUNC_EXPR_NESTING*sizeof(Stat));
-  TLS(LoopStack) = malloc(MAX_FUNC_EXPR_NESTING*sizeof(UInt));
+  STATE(OffsBodyStack) = malloc(MAX_FUNC_EXPR_NESTING*sizeof(Stat));
+  STATE(LoopStack) = malloc(MAX_FUNC_EXPR_NESTING*sizeof(UInt));
 */
 }
 
 static inline void PushLoopNesting( void ) {
-  assert(TLS(LoopStackCount) <= MAX_FUNC_EXPR_NESTING-1);
-  TLS(LoopStack)[TLS(LoopStackCount)++] = TLS(LoopNesting);
+  assert(STATE(LoopStackCount) <= MAX_FUNC_EXPR_NESTING-1);
+  STATE(LoopStack)[STATE(LoopStackCount)++] = STATE(LoopNesting);
 }
 
 static inline void PopLoopNesting( void ) {
-  assert(TLS(LoopStackCount));
-  TLS(LoopNesting) = TLS(LoopStack)[--TLS(LoopStackCount)];
+  assert(STATE(LoopStackCount));
+  STATE(LoopNesting) = STATE(LoopStack)[--STATE(LoopStackCount)];
 }
 
 static inline void setup_gapname(TypInputFile* i)
@@ -247,19 +247,19 @@ static Stat NewStatWithProf (
     Stat                stat;           /* result                          */
 
     /* this is where the new statement goes                                */
-    stat = TLS(OffsBody) + FIRST_STAT_CURR_FUNC;
+    stat = STATE(OffsBody) + FIRST_STAT_CURR_FUNC;
 
     /* increase the offset                                                 */
-    TLS(OffsBody) = stat + ((size+sizeof(Stat)-1) / sizeof(Stat)) * sizeof(Stat);
+    STATE(OffsBody) = stat + ((size+sizeof(Stat)-1) / sizeof(Stat)) * sizeof(Stat);
 
     /* make certain that the current body bag is large enough              */
     if ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) == 0 ) {
-      ResizeBag( BODY_FUNC(CURR_FUNC), TLS(OffsBody) + NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
-        TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
+      ResizeBag( BODY_FUNC(CURR_FUNC), STATE(OffsBody) + NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
+        STATE(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
-    while ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) < TLS(OffsBody) + NUMBER_HEADER_ITEMS_BODY*sizeof(Obj)  ) {
+    while ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) < STATE(OffsBody) + NUMBER_HEADER_ITEMS_BODY*sizeof(Obj)  ) {
         ResizeBag( BODY_FUNC(CURR_FUNC), 2*SIZE_BAG(BODY_FUNC(CURR_FUNC)) );
-        TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
+        STATE(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
     
     /* enter type and size                                                 */
@@ -273,9 +273,9 @@ Stat NewStat (
     UInt                type,
     UInt                size)
 {
-    setup_gapname(TLS(Input));
+    setup_gapname(STATE(Input));
 
-    return NewStatWithProf(type, size, TLS(Input)->number, TLS(Input)->gapnameid);
+    return NewStatWithProf(type, size, STATE(Input)->number, STATE(Input)->gapnameid);
 }
 
 
@@ -294,24 +294,24 @@ Expr            NewExpr (
     Expr                expr;           /* result                          */
 
     /* this is where the new expression goes                               */
-    expr = TLS(OffsBody) + FIRST_STAT_CURR_FUNC;
+    expr = STATE(OffsBody) + FIRST_STAT_CURR_FUNC;
 
     /* increase the offset                                                 */
-    TLS(OffsBody) = expr + ((size+sizeof(Expr)-1) / sizeof(Expr)) * sizeof(Expr);
+    STATE(OffsBody) = expr + ((size+sizeof(Expr)-1) / sizeof(Expr)) * sizeof(Expr);
 
     /* make certain that the current body bag is large enough              */
     if ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) == 0 ) {
-        ResizeBag( BODY_FUNC(CURR_FUNC), TLS(OffsBody) );
-        TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
+        ResizeBag( BODY_FUNC(CURR_FUNC), STATE(OffsBody) );
+        STATE(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
-    while ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) < TLS(OffsBody) ) {
+    while ( SIZE_BAG(BODY_FUNC(CURR_FUNC)) < STATE(OffsBody) ) {
         ResizeBag( BODY_FUNC(CURR_FUNC), 2*SIZE_BAG(BODY_FUNC(CURR_FUNC)) );
-        TLS(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
+        STATE(PtrBody) = (Stat*)PTR_BAG( BODY_FUNC(CURR_FUNC) );
     }
 
     /* enter type and size                                                 */
-    ADDR_EXPR(expr)[-1] = fillFilenameLine(TLS(Input)->gapnameid,
-                                           TLS(Input)->number, size, type);
+    ADDR_EXPR(expr)[-1] = fillFilenameLine(STATE(Input)->gapnameid,
+                                           STATE(Input)->number, size, type);
     RegisterStatWithProfiling(expr);
     /* return the new expression                                           */
     return expr;
@@ -354,17 +354,17 @@ void PushStat (
     Stat                stat )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( TLS(StackStat) != 0 );
-    assert( 0 <= TLS(CountStat) );
-    assert( TLS(CountStat) <= SIZE_BAG(TLS(StackStat))/sizeof(Stat) );
+    assert( STATE(StackStat) != 0 );
+    assert( 0 <= STATE(CountStat) );
+    assert( STATE(CountStat) <= SIZE_BAG(STATE(StackStat))/sizeof(Stat) );
     assert( stat != 0 );
 
     /* count up and put the statement onto the stack                       */
-    if ( TLS(CountStat) == SIZE_BAG(TLS(StackStat))/sizeof(Stat) ) {
-        ResizeBag( TLS(StackStat), 2*TLS(CountStat)*sizeof(Stat) );
+    if ( STATE(CountStat) == SIZE_BAG(STATE(StackStat))/sizeof(Stat) ) {
+        ResizeBag( STATE(StackStat), 2*STATE(CountStat)*sizeof(Stat) );
     }
-    ((Stat*)PTR_BAG(TLS(StackStat)))[TLS(CountStat)] = stat;
-    TLS(CountStat)++;
+    ((Stat*)PTR_BAG(STATE(StackStat)))[STATE(CountStat)] = stat;
+    STATE(CountStat)++;
 }
 
 Stat PopStat ( void )
@@ -372,13 +372,13 @@ Stat PopStat ( void )
     Stat                stat;
 
     /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( TLS(StackStat) != 0 );
-    assert( 1 <= TLS(CountStat) );
-    assert( TLS(CountStat) <= SIZE_BAG(TLS(StackStat))/sizeof(Stat) );
+    assert( STATE(StackStat) != 0 );
+    assert( 1 <= STATE(CountStat) );
+    assert( STATE(CountStat) <= SIZE_BAG(STATE(StackStat))/sizeof(Stat) );
 
     /* get the top statement from the stack, and count down                */
-    TLS(CountStat)--;
-    stat = ((Stat*)PTR_BAG(TLS(StackStat)))[TLS(CountStat)];
+    STATE(CountStat)--;
+    stat = ((Stat*)PTR_BAG(STATE(StackStat)))[STATE(CountStat)];
 
     /* return the popped statement                                         */
     return stat;
@@ -448,17 +448,17 @@ void PushExpr (
     Expr                expr )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( TLS(StackExpr) != 0 );
-    assert( 0 <= TLS(CountExpr) );
-    assert( TLS(CountExpr) <= SIZE_BAG(TLS(StackExpr))/sizeof(Expr) );
+    assert( STATE(StackExpr) != 0 );
+    assert( 0 <= STATE(CountExpr) );
+    assert( STATE(CountExpr) <= SIZE_BAG(STATE(StackExpr))/sizeof(Expr) );
     assert( expr != 0 );
 
     /* count up and put the expression onto the stack                      */
-    if ( TLS(CountExpr) == SIZE_BAG(TLS(StackExpr))/sizeof(Expr) ) {
-        ResizeBag( TLS(StackExpr), 2*TLS(CountExpr)*sizeof(Expr) );
+    if ( STATE(CountExpr) == SIZE_BAG(STATE(StackExpr))/sizeof(Expr) ) {
+        ResizeBag( STATE(StackExpr), 2*STATE(CountExpr)*sizeof(Expr) );
     }
-    ((Expr*)PTR_BAG(TLS(StackExpr)))[TLS(CountExpr)] = expr;
-    TLS(CountExpr)++;
+    ((Expr*)PTR_BAG(STATE(StackExpr)))[STATE(CountExpr)] = expr;
+    STATE(CountExpr)++;
 }
 
 Expr PopExpr ( void )
@@ -466,13 +466,13 @@ Expr PopExpr ( void )
     Expr                expr;
 
     /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( TLS(StackExpr) != 0 );
-    assert( 1 <= TLS(CountExpr) );
-    assert( TLS(CountExpr) <= SIZE_BAG(TLS(StackExpr))/sizeof(Expr) );
+    assert( STATE(StackExpr) != 0 );
+    assert( 1 <= STATE(CountExpr) );
+    assert( STATE(CountExpr) <= SIZE_BAG(STATE(StackExpr))/sizeof(Expr) );
 
     /* get the top expression from the stack, and count down               */
-    TLS(CountExpr)--;
-    expr = ((Expr*)PTR_BAG(TLS(StackExpr)))[TLS(CountExpr)];
+    STATE(CountExpr)--;
+    expr = ((Expr*)PTR_BAG(STATE(StackExpr)))[STATE(CountExpr)];
 
     /* return the popped expression                                        */
     return expr;
@@ -627,14 +627,14 @@ void            CodeFuncCallOptionsEnd ( UInt nr )
 void CodeBegin ( void )
 {
     /* the stacks must be empty                                            */
-    assert( TLS(CountStat) == 0 );
-    assert( TLS(CountExpr) == 0 );
+    assert( STATE(CountStat) == 0 );
+    assert( STATE(CountExpr) == 0 );
 
     /* remember the current frame                                          */
-    TLS(CodeLVars) = TLS(CurrLVars);
+    STATE(CodeLVars) = STATE(CurrLVars);
 
     /* clear the code result bag                                           */
-    TLS(CodeResult) = 0;
+    STATE(CodeResult) = 0;
 }
 
 UInt CodeEnd (
@@ -644,24 +644,24 @@ UInt CodeEnd (
     if ( ! error ) {
 
         /* the stacks must be empty                                        */
-        assert( TLS(CountStat) == 0 );
-        assert( TLS(CountExpr) == 0 );
+        assert( STATE(CountStat) == 0 );
+        assert( STATE(CountExpr) == 0 );
 
-        /* we must be back to 'TLS(CurrLVars)'                                  */
-        assert( TLS(CurrLVars) == TLS(CodeLVars) );
+        /* we must be back to 'STATE(CurrLVars)'                                  */
+        assert( STATE(CurrLVars) == STATE(CodeLVars) );
 
-        /* 'CodeFuncExprEnd' left the function already in 'TLS(CodeResult)'     */
+        /* 'CodeFuncExprEnd' left the function already in 'STATE(CodeResult)'     */
     }
 
     /* otherwise clean up the mess                                         */
     else {
 
         /* empty the stacks                                                */
-        TLS(CountStat) = 0;
-        TLS(CountExpr) = 0;
+        STATE(CountStat) = 0;
+        STATE(CountExpr) = 0;
 
         /* go back to the correct frame                                    */
-        SWITCH_TO_OLD_LVARS( TLS(CodeLVars) );
+        SWITCH_TO_OLD_LVARS( STATE(CodeLVars) );
     }
 
     /* return value is ignored                                             */
@@ -801,16 +801,16 @@ void CodeFuncExprBegin (
     CHANGED_BAG( fexp );
 
     /* record where we are reading from */
-    setup_gapname(TLS(Input));
-    SET_FILENAME_BODY(body, TLS(Input)->gapname);
+    setup_gapname(STATE(Input));
+    SET_FILENAME_BODY(body, STATE(Input)->gapname);
     SET_STARTLINE_BODY(body, INTOBJ_INT(startLine));
-    /*    Pr("Coding begin at %s:%d ",(Int)(TLS(Input)->name),TLS(Input)->number);
+    /*    Pr("Coding begin at %s:%d ",(Int)(STATE(Input)->name),STATE(Input)->number);
           Pr(" Body id %d\n",(Int)(body),0L); */
-    TLS(OffsBody) = 0;
-    TLS(LoopNesting) = 0;
+    STATE(OffsBody) = 0;
+    STATE(LoopNesting) = 0;
 
     /* give it an environment                                              */
-    ENVI_FUNC( fexp ) = TLS(CurrLVars);
+    ENVI_FUNC( fexp ) = STATE(CurrLVars);
     CHANGED_BAG( fexp );
 
     /* switch to this function                                             */
@@ -835,7 +835,7 @@ void CodeFuncExprEnd (
 
     /* get the function expression                                         */
     fexp = CURR_FUNC;
-    assert(!TLS(LoopNesting));
+    assert(!STATE(LoopNesting));
     
     /* get the body of the function                                        */
     /* push an additional return-void-statement if neccessary              */
@@ -874,9 +874,9 @@ void CodeFuncExprEnd (
     }
 
     /* make the body smaller                                               */
-    ResizeBag( BODY_FUNC(fexp), TLS(OffsBody)+NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
-    SET_ENDLINE_BODY(BODY_FUNC(fexp), INTOBJ_INT(TLS(Input)->number));
-    /*    Pr("  finished coding %d at line %d\n",(Int)(BODY_FUNC(fexp)), TLS(Input)->number); */
+    ResizeBag( BODY_FUNC(fexp), STATE(OffsBody)+NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
+    SET_ENDLINE_BODY(BODY_FUNC(fexp), INTOBJ_INT(STATE(Input)->number));
+    /*    Pr("  finished coding %d at line %d\n",(Int)(BODY_FUNC(fexp)), STATE(Input)->number); */
 
     /* switch back to the previous function                                */
     SWITCH_TO_OLD_LVARS( ENVI_FUNC(fexp) );
@@ -885,12 +885,12 @@ void CodeFuncExprEnd (
     PopLoopNesting();
     
     /* restore the remembered offset                                       */
-    TLS(OffsBody) = BRK_CALL_TO();
+    STATE(OffsBody) = BRK_CALL_TO();
     PopOffsBody();
 
     /* if this was inside another function definition, make the expression */
     /* and store it in the function expression list of the outer function  */
-    if ( TLS(CurrLVars) != TLS(CodeLVars) ) {
+    if ( STATE(CurrLVars) != STATE(CodeLVars) ) {
         fexs = FEXS_FUNC( CURR_FUNC );
         len = LEN_PLIST( fexs );
         GROW_PLIST(      fexs, len+1 );
@@ -902,9 +902,9 @@ void CodeFuncExprEnd (
         PushExpr( expr );
     }
 
-    /* otherwise, make the function and store it in 'TLS(CodeResult)'           */
+    /* otherwise, make the function and store it in 'STATE(CodeResult)'           */
     else {
-        TLS(CodeResult) = MakeFunction( fexp );
+        STATE(CodeResult) = MakeFunction( fexp );
     }
 
 }
@@ -1050,7 +1050,7 @@ void CodeForIn ( void )
 
 void CodeForBeginBody ( void )
 {
-  TLS(LoopNesting)++;
+  STATE(LoopNesting)++;
 }
 
 void CodeForEndBody (
@@ -1112,7 +1112,7 @@ void CodeForEndBody (
     PushStat( stat );
 
     /* decrement loop nesting count */
-    TLS(LoopNesting)--;
+    STATE(LoopNesting)--;
 }
 
 void CodeForEnd ( void )
@@ -1255,7 +1255,7 @@ void CodeWhileBegin ( void )
 
 void CodeWhileBeginBody ( void )
 {
-  TLS(LoopNesting)++;
+  STATE(LoopNesting)++;
 }
 
 void CodeWhileEndBody (
@@ -1293,7 +1293,7 @@ void CodeWhileEndBody (
     ADDR_STAT(stat)[0] = cond;
 
     /* decrmement loop nesting */
-    TLS(LoopNesting)--;
+    STATE(LoopNesting)--;
     
     /* push the while-statement                                            */
     PushStat( stat );
@@ -1333,7 +1333,7 @@ void CodeRepeatBegin ( void )
 
 void CodeRepeatBeginBody ( void )
 {
-  TLS(LoopNesting)++;
+  STATE(LoopNesting)++;
 }
 
 void CodeRepeatEndBody (
@@ -1341,7 +1341,7 @@ void CodeRepeatEndBody (
 {
     /* leave the number of statements in the body on the expression stack  */
     PushExpr( INTEXPR_INT(nr) );
-    TLS(LoopNesting)--;
+    STATE(LoopNesting)--;
 }
 
 void CodeRepeatEnd ( void )
@@ -1400,7 +1400,7 @@ void            CodeBreak ( void )
 {
     Stat                stat;           /* break-statement, result         */
 
-    if (!TLS(LoopNesting))
+    if (!STATE(LoopNesting))
       SyntaxError("'break' statement not enclosed in a loop");
     
     /* allocate the break-statement                                        */
@@ -1421,7 +1421,7 @@ void            CodeContinue ( void )
 {
     Stat                stat;           /* continue-statement, result         */
 
-    if (!TLS(LoopNesting))
+    if (!STATE(LoopNesting))
       SyntaxError("'continue' statement not enclosed in a loop");
 
     /* allocate the continue-statement                                        */
@@ -3518,13 +3518,13 @@ static Int InitKernel (
     MakeBagTypePublic(T_BODY);
 
     /* make the result variable known to Gasman                            */
-    InitGlobalBag( &TLS(CodeResult), "CodeResult" );
+    InitGlobalBag( &STATE(CodeResult), "CodeResult" );
 
     InitGlobalBag( &FilenameCache, "FilenameCache" );
 
     /* allocate the statements and expressions stacks                      */
-    InitGlobalBag( &TLS(StackStat), "TLS(StackStat)" );
-    InitGlobalBag( &TLS(StackExpr), "TLS(StackExpr)" );
+    InitGlobalBag( &STATE(StackStat), "STATE(StackStat)" );
+    InitGlobalBag( &STATE(StackExpr), "STATE(StackExpr)" );
 
     /* some functions and globals needed for float conversion */
     InitCopyGVar( "EAGER_FLOAT_LITERAL_CACHE", &EAGER_FLOAT_LITERAL_CACHE);
@@ -3546,8 +3546,8 @@ static Int InitLibrary (
   UInt gv;
   Obj cache;
     /* allocate the statements and expressions stacks                      */
-    TLS(StackStat) = NewBag( T_BODY, 64*sizeof(Stat) );
-    TLS(StackExpr) = NewBag( T_BODY, 64*sizeof(Expr) );
+    STATE(StackStat) = NewBag( T_BODY, 64*sizeof(Stat) );
+    STATE(StackExpr) = NewBag( T_BODY, 64*sizeof(Expr) );
     FilenameCache = NEW_PLIST(T_PLIST, 0);
 
     GVAR_SAVED_FLOAT_INDEX = GVarName("SavedFloatIndex");
@@ -3584,17 +3584,17 @@ static Int PreSave (
   UInt i;
 
   /* Can't save in mid-parsing */
-  if (TLS(CountExpr) || TLS(CountStat))
+  if (STATE(CountExpr) || STATE(CountStat))
     return 1;
 
   /* push the FP cache index out into a GAP Variable */
   AssGVar(GVAR_SAVED_FLOAT_INDEX, INTOBJ_INT(NextFloatExprNumber));
 
   /* clean any old data out of the statement and expression stacks */
-  for (i = 0; i < SIZE_BAG(TLS(StackStat))/sizeof(UInt); i++)
-    ADDR_OBJ(TLS(StackStat))[i] = (Obj)0;
-  for (i = 0; i < SIZE_BAG(TLS(StackExpr))/sizeof(UInt); i++)
-    ADDR_OBJ(TLS(StackExpr))[i] = (Obj)0;
+  for (i = 0; i < SIZE_BAG(STATE(StackStat))/sizeof(UInt); i++)
+    ADDR_OBJ(STATE(StackStat))[i] = (Obj)0;
+  for (i = 0; i < SIZE_BAG(STATE(StackExpr))/sizeof(UInt); i++)
+    ADDR_OBJ(STATE(StackExpr))[i] = (Obj)0;
   /* return success                                                      */
   return 0;
 }

--- a/src/code.c
+++ b/src/code.c
@@ -16,7 +16,7 @@
                                            but does not include stdio.h    */
 #include <assert.h>                     /* assert */
 #include <src/system.h>                 /* Ints, UInts */
-
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/code.c
+++ b/src/code.c
@@ -3487,7 +3487,7 @@ void LoadBody ( Obj body )
 *F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * *
 */
 
-void InitCoderState(GlobalState *state)
+void InitCoderState(GAPState *state)
 {
     state->OffsBodyCount = 0;
     state->LoopNesting = 0;
@@ -3496,7 +3496,7 @@ void InitCoderState(GlobalState *state)
     state->StackExpr = NewBag( T_BODY, 64*sizeof(Expr) );
 }
 
-void DestroyCoderState(GlobalState *state)
+void DestroyCoderState(GAPState *state)
 {
 }
 

--- a/src/code.h
+++ b/src/code.h
@@ -243,7 +243,7 @@ Obj FILENAME_STAT(Stat stat);
 **  'ADDR_STAT' returns   the  absolute address of the    memory block of the
 **  statement <stat>.
 */
-#define ADDR_STAT(stat) ((Stat*)(((char*)TLS(PtrBody))+(stat)))
+#define ADDR_STAT(stat) ((Stat*)(((char*)STATE(PtrBody))+(stat)))
 
 
 /****************************************************************************

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -75,7 +75,7 @@ extern "C" {
 
 
 #include <src/intrprtr.h>               /* interpreter */
-#include <src/globalstate.h>    /* */
+#include <src/gapstate.h>    /* */
 
 #include <src/compiler.h>               /* compiler */
 

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -140,7 +140,7 @@ typedef UInt    RNam;
 #define SWITCH_TO_NEW_FRAME     SWITCH_TO_NEW_LVARS
 #define SWITCH_TO_OLD_FRAME     SWITCH_TO_OLD_LVARS
 
-#define CURR_FRAME              TLS(CurrLVars)
+#define CURR_FRAME              STATE(CurrLVars)
 #define CURR_FRAME_1UP          ENVI_FUNC( PTR_BAG( CURR_FRAME     )[0] )
 #define CURR_FRAME_2UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_1UP )[0] )
 #define CURR_FRAME_3UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_2UP )[0] )
@@ -149,7 +149,7 @@ typedef UInt    RNam;
 #define CURR_FRAME_6UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_5UP )[0] )
 #define CURR_FRAME_7UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_6UP )[0] )
 
-/* #define OBJ_LVAR(lvar)  TLS(PtrLVars)[(lvar)+2] */
+/* #define OBJ_LVAR(lvar)  STATE(PtrLVars)[(lvar)+2] */
 #define OBJ_LVAR_0UP(lvar) \
     OBJ_LVAR(lvar)
 #define OBJ_LVAR_1UP(lvar) \
@@ -169,7 +169,7 @@ typedef UInt    RNam;
 #define OBJ_LVAR_8UP(lvar) \
     PTR_BAG(CURR_FRAME_8UP)[(lvar)+2]
 
-/* #define ASS_LVAR(lvar,obj) do { TLS(PtrLVars)[(lvar)+2] = (obj); } while ( 0 ) */
+/* #define ASS_LVAR(lvar,obj) do { STATE(PtrLVars)[(lvar)+2] = (obj); } while ( 0 ) */
 #define ASS_LVAR_0UP(lvar,obj) \
     ASS_LVAR(lvar,obj)
 #define ASS_LVAR_1UP(lvar,obj) \

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -15,6 +15,7 @@ extern "C" {
 #endif
 
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */
@@ -75,7 +76,6 @@ extern "C" {
 
 
 #include <src/intrprtr.h>               /* interpreter */
-#include <src/gapstate.h>    /* */
 
 #include <src/compiler.h>               /* compiler */
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -13,6 +13,7 @@
 */
 #include <stdarg.h>                     /* variable argument list macros */
 #include <src/system.h>                 /* Ints, UInts */
+#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1269,7 +1269,7 @@ CVar CompFuncExpr (
     Emit( ", HdlrFunc%d );\n", nr );
 
     /* this should probably be done by 'NewFunction'                       */
-    Emit( "ENVI_FUNC( %c ) = TLS(CurrLVars);\n", func );
+    Emit( "ENVI_FUNC( %c ) = STATE(CurrLVars);\n", func );
     tmp = CVAR_TEMP( NewTemp( "body" ) );
     Emit( "%c = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );\n", tmp );
     Emit( "SET_STARTLINE_BODY(%c, INTOBJ_INT(%d));\n", tmp, INT_INTOBJ(GET_STARTLINE_BODY(BODY_FUNC(fexp))));
@@ -1278,7 +1278,7 @@ CVar CompFuncExpr (
     Emit( "BODY_FUNC(%c) = %c;\n", func, tmp );
     FreeTemp( TEMP_CVAR( tmp ) );
 
-    Emit( "CHANGED_BAG( TLS(CurrLVars) );\n" );
+    Emit( "CHANGED_BAG( STATE(CurrLVars) );\n" );
 
     /* we know that the result is a function                               */
     SetInfoCVar( func, W_FUNC );
@@ -5602,7 +5602,7 @@ void CompFunc (
     }
     else {
         Emit( "\n/* restoring old stack frame */\n" );
-        Emit( "oldFrame = TLS(CurrLVars);\n" );
+        Emit( "oldFrame = STATE(CurrLVars);\n" );
         Emit( "SWITCH_TO_OLD_FRAME(ENVI_FUNC(self));\n" );
     }
 
@@ -5787,8 +5787,8 @@ Int CompileFunc (
     }
     Emit( "\n/* create all the functions defined in this module */\n" );
     Emit( "func1 = NewFunction(NameFunc[1],NargFunc[1],NamsFunc[1],HdlrFunc1);\n" );
-    Emit( "ENVI_FUNC( func1 ) = TLS(CurrLVars);\n" );
-    Emit( "CHANGED_BAG( TLS(CurrLVars) );\n" );
+    Emit( "ENVI_FUNC( func1 ) = STATE(CurrLVars);\n" );
+    Emit( "CHANGED_BAG( STATE(CurrLVars) );\n" );
     Emit( "body1 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj));\n" );
     Emit( "BODY_FUNC( func1 ) = body1;\n" );
     Emit( "CHANGED_BAG( func1 );\n");

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -89,7 +89,7 @@
 **  Chnaged the exponent size from 2 to 4 bytes to avoid overflows SL, 2008
 */
 #include <src/system.h>                 /* Ints, UInts */
-
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -149,14 +149,14 @@
 void GrowResultCyc(UInt size) {
     Obj *res;
     UInt i;
-    if (TLS(ResultCyc) == 0) {
-        TLS(ResultCyc) = NEW_PLIST( T_PLIST, size );
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+    if (STATE(ResultCyc) == 0) {
+        STATE(ResultCyc) = NEW_PLIST( T_PLIST, size );
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         for ( i = 0; i < size; i++ ) { res[i] = INTOBJ_INT(0); }
-    } else if ( LEN_PLIST(TLS(ResultCyc)) < size ) {
-        GROW_PLIST( TLS(ResultCyc), size );
-        SET_LEN_PLIST( TLS(ResultCyc), size );
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+    } else if ( LEN_PLIST(STATE(ResultCyc)) < size ) {
+        GROW_PLIST( STATE(ResultCyc), size );
+        SET_LEN_PLIST( STATE(ResultCyc), size );
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         for ( i = 0; i < size; i++ ) { res[i] = INTOBJ_INT(0); }
     }
 }
@@ -180,7 +180,7 @@ void GrowResultCyc(UInt size) {
 **  1 at the <i>th place in 'ResultCyc' and then calling 'Cyclotomic'.
 */
 /* TL: Obj  LastECyc; */
-/* TL: UInt TLS(LastNCyc); */
+/* TL: UInt STATE(LastNCyc); */
 
 
 /****************************************************************************
@@ -396,19 +396,19 @@ Int             LtCycNot (
 **
 *F  ConvertToBase(<n>)  . . . . . . convert a cyclotomic into the base, local
 **
-**  'ConvertToBase'  converts the cyclotomic  'TLS(ResultCyc)' from the cyclotomic
+**  'ConvertToBase'  converts the cyclotomic  'STATE(ResultCyc)' from the cyclotomic
 **  field  of <n>th roots of  unity, into the base  form.  This means that it
 **  replaces every root $e_n^i$ that does not belong to the  base by a sum of
 **  other roots that do.
 **
-**  Suppose that $c*e_n^i$ appears in 'TLS(ResultCyc)' but $e_n^i$ does not lie in
+**  Suppose that $c*e_n^i$ appears in 'STATE(ResultCyc)' but $e_n^i$ does not lie in
 **  the base.  This happens  because, for some  prime $p$ dividing $n$,  with
 **  maximal power $q$, $i \in (n/q)*[-(q/p-1)/2..(q/p-1)/2]$ mod $q$.
 **
 **  We take the identity  $1+e_p+e_p^2+..+e_p^{p-1}=0$, write it  using $n$th
 **  roots of unity, $0=1+e_n^{n/p}+e_n^{2n/p}+..+e_n^{(p-1)n/p}$ and multiply
 **  it  by $e_n^i$,   $0=e_n^i+e_n^{n/p+i}+e_n^{2n/p+i}+..+e_n^{(p-1)n/p+i}$.
-**  Now we subtract $c$ times the left hand side from 'TLS(ResultCyc)'.
+**  Now we subtract $c$ times the left hand side from 'STATE(ResultCyc)'.
 **
 **  If $p^2$  does not divide  $n$ then the roots  that are  not in the  base
 **  because of $p$ are those  whose exponent is divisable  by $p$.  But $n/p$
@@ -425,10 +425,10 @@ Int             LtCycNot (
 **  which remove the roots that are not in the base because of larger primes,
 **  will not add new roots that do not lie in the base because of $p$ again.
 **
-**  For an example, suppose 'TLS(ResultCyc)' is $e_{45}+e_{45}^5 =: e+e^5$.  $e^5$
+**  For an example, suppose 'STATE(ResultCyc)' is $e_{45}+e_{45}^5 =: e+e^5$.  $e^5$
 **  does  not lie in the  base  because $5  \in 5*[-1,0,1]$  mod $9$ and also
 **  because it is  divisable  by 5.  After  subtracting  $e^5*(1+e_3+e_3^2) =
-**  e^5+e^{20}+e^{35}$ from  'TLS(ResultCyc)' we get $e-e^{20}-e^{35}$.  Those two
+**  e^5+e^{20}+e^{35}$ from  'STATE(ResultCyc)' we get $e-e^{20}-e^{35}$.  Those two
 **  roots are  still not  in the  base because of  5.  But  after subtracting
 **  $-e^{20}*(1+e_5+e_5^2+e_5^3+e_5^4)=-e^{20}-e^{29}-e^{38}-e^2-e^{11}$  and
 **  $-e^{35}*(1+e_5+e_5^2+e_5^3+e_5^4)=-e^{35}-e^{44}-e^8-e^{17}-e^{26}$   we
@@ -458,7 +458,7 @@ void            ConvertToBase (
     Obj                 sum;            /* sum of two coefficients         */
 
     /* get a pointer to the cyclotomic and a copy of n to factor           */
-    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
     nn  = n;
 
     /* first handle 2                                                      */
@@ -475,9 +475,9 @@ void            ConvertToBase (
                     l = (k + n/2) % n;
                     if ( ! ARE_INTOBJS( res[l], res[k] )
                       || ! DIFF_INTOBJS( sum, res[l], res[k] ) ) {
-                        CHANGED_BAG( TLS(ResultCyc) );
+                        CHANGED_BAG( STATE(ResultCyc) );
                         sum = DIFF( res[l], res[k] );
-                        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
                     }
                     res[l] = sum;
                     res[k] = INTOBJ_INT(0);
@@ -490,9 +490,9 @@ void            ConvertToBase (
                     l = (k + n/2) % n;
                     if ( ! ARE_INTOBJS( res[l], res[k] )
                       || ! DIFF_INTOBJS( sum, res[l], res[k] ) ) {
-                        CHANGED_BAG( TLS(ResultCyc) );
+                        CHANGED_BAG( STATE(ResultCyc) );
                         sum = DIFF( res[l], res[k] );
-                        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
                     }
                     res[l] = sum;
                     res[k] = INTOBJ_INT(0);
@@ -522,9 +522,9 @@ void            ConvertToBase (
                     for ( l = k+n/p; l < k+n; l += n/p ) {
                         if ( ! ARE_INTOBJS( res[l%n], res[k] )
                           || ! DIFF_INTOBJS( sum, res[l%n], res[k] ) ) {
-                            CHANGED_BAG( TLS(ResultCyc) );
+                            CHANGED_BAG( STATE(ResultCyc) );
                             sum = DIFF( res[l%n], res[k] );
-                            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                            res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
                         }
                         res[l%n] = sum;
                     }
@@ -538,9 +538,9 @@ void            ConvertToBase (
                     for ( l = k+n/p; l < k+n; l += n/p ) {
                         if ( ! ARE_INTOBJS( res[l%n], res[k] )
                           || ! DIFF_INTOBJS( sum, res[l%n], res[k] ) ) {
-                            CHANGED_BAG( TLS(ResultCyc) );
+                            CHANGED_BAG( STATE(ResultCyc) );
                             sum = DIFF( res[l%n], res[k] );
-                            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                            res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
                         }
                         res[l%n] = sum;
                     }
@@ -551,7 +551,7 @@ void            ConvertToBase (
     }
 
     /* notify Gasman                                                       */
-    CHANGED_BAG( TLS(ResultCyc) );
+    CHANGED_BAG( STATE(ResultCyc) );
 }
 
 
@@ -559,10 +559,10 @@ void            ConvertToBase (
 **
 *F  Cyclotomic(<n>,<m>) . . . . . . . . . . create a packed cyclotomic, local
 **
-**  'Cyclotomic'    reduces  the cyclotomic   'TLS(ResultCyc)'   into the smallest
+**  'Cyclotomic'    reduces  the cyclotomic   'STATE(ResultCyc)'   into the smallest
 **  possible cyclotomic subfield and returns it in packed form.
 **
-**  'TLS(ResultCyc)'  must   also    be already converted      into  the base   by
+**  'STATE(ResultCyc)'  must   also    be already converted      into  the base   by
 **  'ConvertToBase'.   <n> must be  the order of the  primitive root in which
 **  written.
 **
@@ -576,7 +576,7 @@ void            ConvertToBase (
 **  rational.  If this is the case 'Cyclotomic' reduces it into the rationals
 **  and returns it as a rational.
 **
-**  After 'Cyclotomic' has  done its work it clears  the 'TLS(ResultCyc)'  bag, so
+**  After 'Cyclotomic' has  done its work it clears  the 'STATE(ResultCyc)'  bag, so
 **  that it only contains 'INTOBJ_INT(0)'.  Thus the arithmetic functions can
 **  use this buffer without clearing it first.
 **
@@ -608,7 +608,7 @@ Obj             Cyclotomic (
     static UInt         nrp;            /* number of its prime factors     */
 
     /* get a pointer to the cyclotomic and a copy of n to factor           */
-    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
 
     /* count the terms and compute the gcd of the exponents with n         */
     len = 0;
@@ -662,12 +662,12 @@ Obj             Cyclotomic (
         if ( nrp % 2 == 0 )
             res[0] = cof;
         else {
-            CHANGED_BAG( TLS(ResultCyc) );
+            CHANGED_BAG( STATE(ResultCyc) );
             res[0] = DIFF( INTOBJ_INT(0), cof );
         }
         n = 1;
     }
-    CHANGED_BAG( TLS(ResultCyc) );
+    CHANGED_BAG( STATE(ResultCyc) );
 
     /* for all primes $p$ try to reduce from $Q(e_n)$ into $Q(e_{n/p})$    */
     gcd = phi; s = len; while ( s != 0 ) { t = s; s = gcd % s; gcd = t; }
@@ -700,16 +700,16 @@ Obj             Cyclotomic (
                     res[i] = INTOBJ_INT( - INT_INTOBJ(cof) );
                     if ( ! IS_INTOBJ(cof)
                       || (cof == INTOBJ_INT(-(1L<<NR_SMALL_INT_BITS))) ) {
-                        CHANGED_BAG( TLS(ResultCyc) );
+                        CHANGED_BAG( STATE(ResultCyc) );
                         cof = DIFF( INTOBJ_INT(0), cof );
-                        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
                         res[i] = cof;
                     }
                     for ( k = i+n/p; k < i+n && eql; k += n/p )
                         res[k%n] = INTOBJ_INT(0);
                 }
                 len = len / (p-1);
-                CHANGED_BAG( TLS(ResultCyc) );
+                CHANGED_BAG( STATE(ResultCyc) );
 
                 /* now replace $e_n^{i*p}$ by $e_{n/p}^{i}$                */
                 for ( i = 1; i < n/p; i++ ) {
@@ -730,7 +730,7 @@ Obj             Cyclotomic (
         res[0] = INTOBJ_INT(0);
     }
 
-    /* otherwise copy terms into a new 'T_CYC' bag and clear 'TLS(ResultCyc)'   */
+    /* otherwise copy terms into a new 'T_CYC' bag and clear 'STATE(ResultCyc)'   */
     else {
         cyc = NewBag( T_CYC, (len+1)*(sizeof(Obj)+sizeof(UInt4)) );
         cfs = COEFS_CYC(cyc);
@@ -738,7 +738,7 @@ Obj             Cyclotomic (
         cfs[0] = INTOBJ_INT(n);
         exs[0] = 0;
         k = 1;
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         for ( i = 0; i < n; i++ ) {
             if ( res[i] != INTOBJ_INT(0) ) {
                 cfs[k] = res[i];
@@ -881,15 +881,15 @@ Obj             SumCyc (
  
     /* Copy the left operand into the result                               */
     if ( TNUM_OBJ(opL) != T_CYC ) {
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         res[0] = opL;
-        CHANGED_BAG( TLS(ResultCyc) );
+        CHANGED_BAG( STATE(ResultCyc) );
     }
     else {
         len = SIZE_CYC(opL);
         cfs = COEFS_CYC(opL);
         exs = EXPOS_CYC(opL,len);
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         if ( ml == 1 ) {
             for ( i = 1; i < len; i++ )
                 res[exs[i]] = cfs[i];
@@ -898,34 +898,34 @@ Obj             SumCyc (
             for ( i = 1; i < len; i++ )
                 res[exs[i]*ml] = cfs[i];
         }
-        CHANGED_BAG( TLS(ResultCyc) );
+        CHANGED_BAG( STATE(ResultCyc) );
     }
 
     /* add the right operand to the result                                 */
     if ( TNUM_OBJ(opR) != T_CYC ) {
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         sum = SUM( res[0], opR );
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         res[0] = sum;
-        CHANGED_BAG( TLS(ResultCyc) );
+        CHANGED_BAG( STATE(ResultCyc) );
     }
     else {
         len = SIZE_CYC(opR);
         cfs = COEFS_CYC(opR);
         exs = EXPOS_CYC(opR,len);
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         for ( i = 1; i < len; i++ ) {
             if ( ! ARE_INTOBJS( res[exs[i]*mr], cfs[i] )
               || ! SUM_INTOBJS( sum, res[exs[i]*mr], cfs[i] ) ) {
-                CHANGED_BAG( TLS(ResultCyc) );
+                CHANGED_BAG( STATE(ResultCyc) );
                 sum = SUM( res[exs[i]*mr], cfs[i] );
                 cfs = COEFS_CYC(opR);
                 exs = EXPOS_CYC(opR,len);
-                res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
             }
             res[exs[i]*mr] = sum;
         }
-        CHANGED_BAG( TLS(ResultCyc) );
+        CHANGED_BAG( STATE(ResultCyc) );
     }
 
     /* return the base reduced packed cyclotomic                           */
@@ -1025,15 +1025,15 @@ Obj             DiffCyc (
 
     /* copy the left operand into the result                               */
     if ( TNUM_OBJ(opL) != T_CYC ) {
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         res[0] = opL;
-        CHANGED_BAG( TLS(ResultCyc) );
+        CHANGED_BAG( STATE(ResultCyc) );
     }
     else {
         len = SIZE_CYC(opL);
         cfs = COEFS_CYC(opL);
         exs = EXPOS_CYC(opL,len);
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         if ( ml == 1 ) {
             for ( i = 1; i < len; i++ )
                 res[exs[i]] = cfs[i];
@@ -1042,34 +1042,34 @@ Obj             DiffCyc (
             for ( i = 1; i < len; i++ )
                 res[exs[i]*ml] = cfs[i];
         }
-        CHANGED_BAG( TLS(ResultCyc) );
+        CHANGED_BAG( STATE(ResultCyc) );
     }
 
     /* subtract the right operand from the result                          */
     if ( TNUM_OBJ(opR) != T_CYC ) {
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         sum = DIFF( res[0], opR );
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         res[0] = sum;
-        CHANGED_BAG( TLS(ResultCyc) );
+        CHANGED_BAG( STATE(ResultCyc) );
     }
     else {
         len = SIZE_CYC(opR);
         cfs = COEFS_CYC(opR);
         exs = EXPOS_CYC(opR,len);
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         for ( i = 1; i < len; i++ ) {
             if ( ! ARE_INTOBJS( res[exs[i]*mr], cfs[i] )
               || ! DIFF_INTOBJS( sum, res[exs[i]*mr], cfs[i] ) ) {
-                CHANGED_BAG( TLS(ResultCyc) );
+                CHANGED_BAG( STATE(ResultCyc) );
                 sum = DIFF( res[exs[i]*mr], cfs[i] );
                 cfs = COEFS_CYC(opR);
                 exs = EXPOS_CYC(opR,len);
-                res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
             }
             res[exs[i]*mr] = sum;
         }
-        CHANGED_BAG( TLS(ResultCyc) );
+        CHANGED_BAG( STATE(ResultCyc) );
     }
 
     /* return the base reduced packed cyclotomic                           */
@@ -1231,19 +1231,19 @@ Obj             ProdCyc (
             len = SIZE_CYC(opL);
             cfs = COEFS_CYC(opL);
             exs = EXPOS_CYC(opL,len);
-            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+            res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
             for ( i = 1; i < len; i++ ) {
                 if ( ! ARE_INTOBJS( res[(e+exs[i]*ml)%n], cfs[i] )
                   || ! SUM_INTOBJS( sum, res[(e+exs[i]*ml)%n], cfs[i] ) ) {
-                    CHANGED_BAG( TLS(ResultCyc) );
+                    CHANGED_BAG( STATE(ResultCyc) );
                     sum = SUM( res[(e+exs[i]*ml)%n], cfs[i] );
                     cfs = COEFS_CYC(opL);
                     exs = EXPOS_CYC(opL,len);
-                    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
                 }
                 res[(e+exs[i]*ml)%n] = sum;
             }
-            CHANGED_BAG( TLS(ResultCyc) );
+            CHANGED_BAG( STATE(ResultCyc) );
         }
 
         /* if the coefficient is -1 just subtract                          */
@@ -1251,19 +1251,19 @@ Obj             ProdCyc (
             len = SIZE_CYC(opL);
             cfs = COEFS_CYC(opL);
             exs = EXPOS_CYC(opL,len);
-            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+            res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
             for ( i = 1; i < len; i++ ) {
                 if ( ! ARE_INTOBJS( res[(e+exs[i]*ml)%n], cfs[i] )
                   || ! DIFF_INTOBJS( sum, res[(e+exs[i]*ml)%n], cfs[i] ) ) {
-                    CHANGED_BAG( TLS(ResultCyc) );
+                    CHANGED_BAG( STATE(ResultCyc) );
                     sum = DIFF( res[(e+exs[i]*ml)%n], cfs[i] );
                     cfs = COEFS_CYC(opL);
                     exs = EXPOS_CYC(opL,len);
-                    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
                 }
                 res[(e+exs[i]*ml)%n] = sum;
             }
-            CHANGED_BAG( TLS(ResultCyc) );
+            CHANGED_BAG( STATE(ResultCyc) );
         }
 
         /* if the coefficient is a small integer use immediate operations  */
@@ -1271,40 +1271,40 @@ Obj             ProdCyc (
             len = SIZE_CYC(opL);
             cfs = COEFS_CYC(opL);
             exs = EXPOS_CYC(opL,len);
-            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+            res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
             for ( i = 1; i < len; i++ ) {
                 if ( ! ARE_INTOBJS( cfs[i], res[(e+exs[i]*ml)%n] )
                   || ! PROD_INTOBJS( prd, cfs[i], c )
                   || ! SUM_INTOBJS( sum, res[(e+exs[i]*ml)%n], prd ) ) {
-                    CHANGED_BAG( TLS(ResultCyc) );
+                    CHANGED_BAG( STATE(ResultCyc) );
                     prd = PROD( cfs[i], c );
                     exs = EXPOS_CYC(opL,len);
-                    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
                     sum = SUM( res[(e+exs[i]*ml)%n], prd );
                     cfs = COEFS_CYC(opL);
                     exs = EXPOS_CYC(opL,len);
-                    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
                 }
                 res[(e+exs[i]*ml)%n] = sum;
             }
-            CHANGED_BAG( TLS(ResultCyc) );
+            CHANGED_BAG( STATE(ResultCyc) );
         }
 
         /* otherwise do it the normal way                                  */
         else {
             len = SIZE_CYC(opL);
             for ( i = 1; i < len; i++ ) {
-                CHANGED_BAG( TLS(ResultCyc) );
+                CHANGED_BAG( STATE(ResultCyc) );
                 cfs = COEFS_CYC(opL);
                 prd = PROD( cfs[i], c );
                 exs = EXPOS_CYC(opL,len);
-                res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
                 sum = SUM( res[(e+exs[i]*ml)%n], prd );
                 exs = EXPOS_CYC(opL,len);
-                res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
                 res[(e+exs[i]*ml)%n] = sum;
             }
-            CHANGED_BAG( TLS(ResultCyc) );
+            CHANGED_BAG( STATE(ResultCyc) );
         }
 
     }
@@ -1373,10 +1373,10 @@ Obj             InvCyc (
             /* permute the terms                                           */
             cfs = COEFS_CYC(op);
             exs = EXPOS_CYC(op,len);
-            res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+            res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
             for ( k = 1; k < len; k++ )
                 res[(i*exs[k])%n] = cfs[k];
-            CHANGED_BAG( TLS(ResultCyc) );
+            CHANGED_BAG( STATE(ResultCyc) );
 
             /* if n is squarefree conversion and reduction are unnecessary */
             if ( n < sqr*sqr ) {
@@ -1428,12 +1428,12 @@ Obj             PowCyc (
     }
 
     /* for $e_n^exp$ just put a 1 at the <exp>th position and convert      */
-    else if ( opL == TLS(LastECyc) ) {
-        exp = (exp % TLS(LastNCyc) + TLS(LastNCyc)) % TLS(LastNCyc);
-        SET_ELM_PLIST( TLS(ResultCyc), exp, INTOBJ_INT(1) );
-        CHANGED_BAG( TLS(ResultCyc) );
-        ConvertToBase( TLS(LastNCyc) );
-        pow = Cyclotomic( TLS(LastNCyc), 1 );
+    else if ( opL == STATE(LastECyc) ) {
+        exp = (exp % STATE(LastNCyc) + STATE(LastNCyc)) % STATE(LastNCyc);
+        SET_ELM_PLIST( STATE(ResultCyc), exp, INTOBJ_INT(1) );
+        CHANGED_BAG( STATE(ResultCyc) );
+        ConvertToBase( STATE(LastNCyc) );
+        pow = Cyclotomic( STATE(LastNCyc), 1 );
     }
 
     /* for $(c*e_n^i)^exp$ if $e_n^i$ belongs to the base put 1 at $i*exp$ */
@@ -1441,9 +1441,9 @@ Obj             PowCyc (
         n = INT_INTOBJ( NOF_CYC(opL) );
         pow = POW( COEFS_CYC(opL)[1], opR );
         i = EXPOS_CYC(opL,2)[1];
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         res[((exp*i)%n+n)%n] = pow;
-        CHANGED_BAG( TLS(ResultCyc) );
+        CHANGED_BAG( STATE(ResultCyc) );
         ConvertToBase( n );
         pow = Cyclotomic( n, 1 );
     }
@@ -1511,18 +1511,18 @@ Obj FuncE (
         return INTOBJ_INT(-1);
 
     /* if the root is not known already construct it                       */
-    if ( TLS(LastNCyc) != INT_INTOBJ(n) ) {
-        TLS(LastNCyc) = INT_INTOBJ(n);
-        GrowResultCyc(TLS(LastNCyc));
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+    if ( STATE(LastNCyc) != INT_INTOBJ(n) ) {
+        STATE(LastNCyc) = INT_INTOBJ(n);
+        GrowResultCyc(STATE(LastNCyc));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         res[1] = INTOBJ_INT(1);
-        CHANGED_BAG( TLS(ResultCyc) );
-        ConvertToBase( TLS(LastNCyc) );
-        TLS(LastECyc) = Cyclotomic( TLS(LastNCyc), 1 );
+        CHANGED_BAG( STATE(ResultCyc) );
+        ConvertToBase( STATE(LastNCyc) );
+        STATE(LastECyc) = Cyclotomic( STATE(LastNCyc), 1 );
     }
 
     /* return the root                                                     */
-    return TLS(LastECyc);
+    return STATE(LastECyc);
 }
 
 
@@ -1881,11 +1881,11 @@ Obj FuncGALOIS_CYC (
         len = SIZE_CYC(cyc);
         cfs = COEFS_CYC(cyc);
         exs = EXPOS_CYC(cyc,len);
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         for ( i = 1; i < len; i++ ) {
             res[(UInt8)exs[i]*(UInt8)o%(UInt8)n] = cfs[i];
         }
-        CHANGED_BAG( TLS(ResultCyc) );
+        CHANGED_BAG( STATE(ResultCyc) );
 
         /* if n is squarefree conversion and reduction are unnecessary     */
         if ( n < sqr*sqr || (o == n-1 && n % 2 != 0) ) {
@@ -1905,19 +1905,19 @@ Obj FuncGALOIS_CYC (
         len = SIZE_CYC(cyc);
         cfs = COEFS_CYC(cyc);
         exs = EXPOS_CYC(cyc,len);
-        res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
         for ( i = 1; i < len; i++ ) {
             if ( ! ARE_INTOBJS( res[(UInt8)exs[i]*(UInt8)o%(UInt8)n], cfs[i] )
               || ! SUM_INTOBJS( sum, res[(UInt8)exs[i]*(UInt8)o%(UInt8)n], cfs[i] ) ) {
-                CHANGED_BAG( TLS(ResultCyc) );
+                CHANGED_BAG( STATE(ResultCyc) );
                 sum = SUM( res[(UInt8)exs[i]*(UInt8)o%(UInt8)n], cfs[i] );
                 cfs = COEFS_CYC(cyc);
                 exs = EXPOS_CYC(cyc,len);
-                res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+                res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
             }
             res[exs[i]*o%n] = sum;
         }
-        CHANGED_BAG( TLS(ResultCyc) );
+        CHANGED_BAG( STATE(ResultCyc) );
 
         /* if n is squarefree conversion and reduction are unnecessary     */
         if ( n < sqr*sqr ) {
@@ -1973,7 +1973,7 @@ Obj FuncCycList (
     GrowResultCyc(n);
 
     /* transfer the coefficients into the buffer                           */
-    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
     for ( i = 0; i < n; i++ ) {
         val = ELM_PLIST( list, i+1 );
         if ( ! ( IS_INTOBJ(val) ||
@@ -1987,7 +1987,7 @@ Obj FuncCycList (
     }
 
     /* return the base reduced packed cyclotomic                           */
-    CHANGED_BAG( TLS(ResultCyc) );
+    CHANGED_BAG( STATE(ResultCyc) );
     ConvertToBase( n );
     return Cyclotomic( n, 1 );
 }
@@ -2146,18 +2146,18 @@ static StructGVarFunc GVarFuncs [] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
-    TLS(LastECyc) = (Obj)0;
-    TLS(LastNCyc) = 0;
+    STATE(LastECyc) = (Obj)0;
+    STATE(LastNCyc) = 0;
   
     /* install the marking function                                        */
     InfoBags[ T_CYC ].name = "cyclotomic";
     InitMarkFuncBags( T_CYC, MarkCycSubBags );
 
     /* create the result buffer                                            */
-    InitGlobalBag( &TLS(ResultCyc) , "src/cyclotom.c:ResultCyc" );
+    InitGlobalBag( &STATE(ResultCyc) , "src/cyclotom.c:ResultCyc" );
 
     /* tell Gasman about the place were we remember the primitive root     */
-    InitGlobalBag( &TLS(LastECyc), "src/cyclotom.c:LastECyc" );
+    InitGlobalBag( &STATE(LastECyc), "src/cyclotom.c:LastECyc" );
 
     /* install the type function                                           */
     ImportGVarFromLibrary( "TYPE_CYC", &TYPE_CYC );
@@ -2244,9 +2244,9 @@ static Int InitLibrary (
     UInt                i;              /* loop variable                   */
 
     /* create the result buffer                                            */
-    TLS(ResultCyc) = NEW_PLIST( T_PLIST, 1024 );
-    SET_LEN_PLIST( TLS(ResultCyc), 1024 );
-    res = &(ELM_PLIST( TLS(ResultCyc), 1 ));
+    STATE(ResultCyc) = NEW_PLIST( T_PLIST, 1024 );
+    SET_LEN_PLIST( STATE(ResultCyc), 1024 );
+    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
     for ( i = 0; i < 1024; i++ ) { res[i] = INTOBJ_INT(0); }
 
     /* init filters and functions                                          */

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -73,8 +73,8 @@
 #endif
 #ifndef NO_LVAR_CHECKS
 #define OBJ_REFLVAR(expr)       \
-                        (*(Obj*)(((char*)TLS(PtrLVars))+(expr)+5) != 0 ? \
-                         *(Obj*)(((char*)TLS(PtrLVars))+(expr)+5) : \
+                        (*(Obj*)(((char*)STATE(PtrLVars))+(expr)+5) != 0 ? \
+                         *(Obj*)(((char*)STATE(PtrLVars))+(expr)+5) : \
                          ObjLVar( LVAR_REFLVAR( expr ) ) )
 #endif
 */

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -2107,12 +2107,12 @@ static Int InitLibrary (
     return 0;
 }
 
-void InitExprState(GlobalState *state)
+void InitExprState(GAPState *state)
 {
     state->CurrEvalExprFuncs = EvalExprFuncs;
 }
 
-void DestroyExprState(GlobalState *state)
+void DestroyExprState(GAPState *state)
 {
 }
 

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -13,6 +13,7 @@
 **  expressions to their values and prints expressions.
 */
 #include <src/system.h>                 /* Ints, UInts */
+#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/exprs.h
+++ b/src/exprs.h
@@ -37,8 +37,8 @@
 #endif
 
 #define OBJ_REFLVAR(expr)       \
-                        (*(Obj*)(((char*)TLS(PtrLVars))+OFFSET_REFLVAR(expr)) != 0 ? \
-                         *(Obj*)(((char*)TLS(PtrLVars))+OFFSET_REFLVAR(expr)) : \
+                        (*(Obj*)(((char*)STATE(PtrLVars))+OFFSET_REFLVAR(expr)) != 0 ? \
+                         *(Obj*)(((char*)STATE(PtrLVars))+OFFSET_REFLVAR(expr)) : \
                          ObjLVar( LVAR_REFLVAR( expr ) ) )
 #endif
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -145,7 +145,7 @@ UInt            ExecProccall0args (
     else {
       CALL_0ARGS( func );
     }
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -173,7 +173,7 @@ UInt            ExecProccall1args (
       SET_BRK_CALL_TO( call );
       CALL_1ARGS( func, arg1 );
     } 
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -203,7 +203,7 @@ UInt            ExecProccall2args (
       SET_BRK_CALL_TO( call );
       CALL_2ARGS( func, arg1, arg2 );
     }
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -235,7 +235,7 @@ UInt            ExecProccall3args (
       SET_BRK_CALL_TO( call );
       CALL_3ARGS( func, arg1, arg2, arg3 );
     }
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -269,7 +269,7 @@ UInt            ExecProccall4args (
       SET_BRK_CALL_TO( call );
       CALL_4ARGS( func, arg1, arg2, arg3, arg4 );
     }
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -311,7 +311,7 @@ UInt            ExecProccall5args (
       SET_BRK_CALL_TO( call );
       CALL_5ARGS( func, arg1, arg2, arg3, arg4, arg5 );
     }
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -349,7 +349,7 @@ UInt            ExecProccall6args (
       SET_BRK_CALL_TO( call );
       CALL_6ARGS( func, arg1, arg2, arg3, arg4, arg5, arg6 );
     }
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -387,7 +387,7 @@ UInt            ExecProccallXargs (
       CALL_XARGS( func, args );
     }
 
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -453,7 +453,7 @@ Obj             EvalFunccall0args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_0ARGS( func );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -485,7 +485,7 @@ Obj             EvalFunccall1args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_1ARGS( func, arg1 );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -520,7 +520,7 @@ Obj             EvalFunccall2args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_2ARGS( func, arg1, arg2 );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -557,7 +557,7 @@ Obj             EvalFunccall3args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_3ARGS( func, arg1, arg2, arg3 );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -595,7 +595,7 @@ Obj             EvalFunccall4args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_4ARGS( func, arg1, arg2, arg3, arg4 );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -636,7 +636,7 @@ Obj             EvalFunccall5args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_5ARGS( func, arg1, arg2, arg3, arg4, arg5 );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -679,7 +679,7 @@ Obj             EvalFunccall6args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_6ARGS( func, arg1, arg2, arg3, arg4, arg5, arg6 );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -720,7 +720,7 @@ Obj             EvalFunccallXargs (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     result = CALL_XARGS( func, args );
-    if (TLS(UserHasQuit) || TLS(UserHasQUIT)) /* the procedure must have called
+    if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
       ReadEvalError();
@@ -756,7 +756,7 @@ Obj             EvalFunccallXargs (
 **  'DoExecFunc<i>args' first switches  to a new  values bag.  Then it enters
 **  the arguments <arg1>, <arg2>, and so on in this new  values bag.  Then it
 **  executes  the function body.   After  that it  switches back  to  the old
-**  values bag.  Finally it returns the result from 'TLS(ReturnObjStat)'.
+**  values bag.  Finally it returns the result from 'STATE(ReturnObjStat)'.
 **
 **  Note that these functions are never called directly, they are only called
 **  through the function call mechanism.
@@ -775,13 +775,13 @@ void RecursionDepthTrap( void )
      * when quit-ting a higher level brk-loop to a lower level one.
      * Therefore we don't do anything if  RecursionDepth <= 0
     */
-    if (TLS(RecursionDepth) > 0) {
-        recursionDepth = TLS(RecursionDepth);
-        TLS(RecursionDepth) = 0;
+    if (STATE(RecursionDepth) > 0) {
+        recursionDepth = STATE(RecursionDepth);
+        STATE(RecursionDepth) = 0;
         ErrorReturnVoid( "recursion depth trap (%d)",
                          (Int)recursionDepth, 0L,
                          "you may 'return;'" );
-        TLS(RecursionDepth) = recursionDepth;
+        STATE(RecursionDepth) = recursionDepth;
     }
 }
      
@@ -792,7 +792,7 @@ Obj STEVES_TRACING;
             ProfileLineByLineIntoFunction(func);
 
 #define CHECK_RECURSION_AFTER \
-            TLS(RecursionDepth)--; \
+            STATE(RecursionDepth)--; \
             ProfileLineByLineOutFunction(func);
 
 #define REMEMBER_LOCKSTACK() \
@@ -832,8 +832,8 @@ Obj DoExecFunc0args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -872,8 +872,8 @@ Obj             DoExecFunc1args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -914,8 +914,8 @@ Obj             DoExecFunc2args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -958,8 +958,8 @@ Obj             DoExecFunc3args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1004,8 +1004,8 @@ Obj             DoExecFunc4args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1052,8 +1052,8 @@ Obj             DoExecFunc5args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1102,8 +1102,8 @@ Obj             DoExecFunc6args (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1156,8 +1156,8 @@ Obj             DoExecFuncXargs (
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }
 }
@@ -1215,8 +1215,8 @@ Obj DoPartialUnWrapFunc(Obj func, Obj args)
     /* return the result                                                   */
       {
         Obj                 returnObjStat;
-        returnObjStat = TLS(ReturnObjStat);
-        TLS(ReturnObjStat) = (Obj)0;
+        returnObjStat = STATE(ReturnObjStat);
+        STATE(ReturnObjStat) = (Obj)0;
         return returnObjStat;
       }  
 }
@@ -1254,9 +1254,9 @@ Obj             MakeFunction (
     /* install the things an interpreted function needs                    */
     NLOC_FUNC( func ) = NLOC_FUNC( fexp );
     BODY_FUNC( func ) = BODY_FUNC( fexp );
-    ENVI_FUNC( func ) = TLS(CurrLVars);
-    /* the 'CHANGED_BAG(TLS(CurrLVars))' is needed because it is delayed        */
-    CHANGED_BAG( TLS(CurrLVars) );
+    ENVI_FUNC( func ) = STATE(CurrLVars);
+    /* the 'CHANGED_BAG(STATE(CurrLVars))' is needed because it is delayed        */
+    CHANGED_BAG( STATE(CurrLVars) );
     FEXS_FUNC( func ) = FEXS_FUNC( fexp );
 
     /* return the function                                                 */
@@ -1397,12 +1397,12 @@ void            ExecBegin ( Obj frame )
     /* remember the old execution state                                    */
     execState = NewBag( T_PLIST, 4*sizeof(Obj) );
     ADDR_OBJ(execState)[0] = (Obj)3;
-    ADDR_OBJ(execState)[1] = TLS(ExecState);
-    ADDR_OBJ(execState)[2] = TLS(CurrLVars);
-    /* the 'CHANGED_BAG(TLS(CurrLVars))' is needed because it is delayed        */
-    CHANGED_BAG( TLS(CurrLVars) );
-    ADDR_OBJ(execState)[3] = INTOBJ_INT((Int)TLS(CurrStat));
-    TLS(ExecState) = execState;
+    ADDR_OBJ(execState)[1] = STATE(ExecState);
+    ADDR_OBJ(execState)[2] = STATE(CurrLVars);
+    /* the 'CHANGED_BAG(STATE(CurrLVars))' is needed because it is delayed        */
+    CHANGED_BAG( STATE(CurrLVars) );
+    ADDR_OBJ(execState)[3] = INTOBJ_INT((Int)STATE(CurrStat));
+    STATE(ExecState) = execState;
 
     /* set up new state                                                    */
     SWITCH_TO_OLD_LVARS( frame );
@@ -1416,14 +1416,14 @@ void            ExecEnd (
     if ( ! error ) {
 
         /* the state must be primal again                                  */
-        assert( TLS(CurrStat)  == 0 );
+        assert( STATE(CurrStat)  == 0 );
 
     }
 
     /* switch back to the old state                                    */
-    SET_BRK_CURR_STAT( (Stat)INT_INTOBJ((ADDR_OBJ(TLS(ExecState))[3]) ));
-    SWITCH_TO_OLD_LVARS( ADDR_OBJ(TLS(ExecState))[2] );
-    TLS(ExecState) = ADDR_OBJ(TLS(ExecState))[1];
+    SET_BRK_CURR_STAT( (Stat)INT_INTOBJ((ADDR_OBJ(STATE(ExecState))[3]) ));
+    SWITCH_TO_OLD_LVARS( ADDR_OBJ(STATE(ExecState))[2] );
+    STATE(ExecState) = ADDR_OBJ(STATE(ExecState))[1];
 }
 
 /****************************************************************************
@@ -1490,7 +1490,7 @@ static Int InitKernel (
     InitCopyGVar("STEVES_TRACING", &STEVES_TRACING);
   
     /* make the global variable known to Gasman                            */
-    InitGlobalBag( &TLS(ExecState), "src/funcs.c:ExecState" );
+    InitGlobalBag( &STATE(ExecState), "src/funcs.c:ExecState" );
 
     /* Register the handler for our exported function                      */
     InitHdlrFuncsFromTable( GVarFuncs );

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -19,8 +19,9 @@
                                            but does not include stdio.h    */
 #include <assert.h>                     /* assert */
 #include <src/system.h>                 /* Ints, UInts */
-#include <src/bool.h>
+#include <src/gapstate.h>
 
+#include <src/bool.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -32,7 +32,7 @@ extern  Obj             MakeFunction (
 /****************************************************************************
 **
 *F  ExecBegin( <frame> ) . . . . . . . . .begin an execution in context frame
-**  if in doubt, pass TLS(BottomLVars) as <frame>
+**  if in doubt, pass STATE(BottomLVars) as <frame>
 **
 *F  ExecEnd(<error>)  . . . . . . . . . . . . . . . . . . .  end an execution
 */
@@ -48,9 +48,9 @@ extern void RecursionDepthTrap( void );
 
 static inline void CheckRecursionBefore( void )
 {
-    TLS(RecursionDepth)++;
+    STATE(RecursionDepth)++;
     if ( RecursionTrapInterval &&
-         0 == (TLS(RecursionDepth) % RecursionTrapInterval) )
+         0 == (STATE(RecursionDepth) % RecursionTrapInterval) )
       RecursionDepthTrap();
 }
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 #include <sys/stat.h>
 #include <sys/time.h>

--- a/src/gap.c
+++ b/src/gap.c
@@ -166,7 +166,7 @@ void ViewObjHandler ( Obj obj )
   func = ValAutoGVar(ViewObjGVar);
 
   /* if non-zero use this function, otherwise use `PrintObj'             */
-  memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+  memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
   TRY_READ {
     if ( func != 0 && TNUM_OBJ(func) == T_FUNCTION ) {
       ViewObj(obj);
@@ -176,7 +176,7 @@ void ViewObjHandler ( Obj obj )
     }
     Pr( "\n", 0L, 0L );
   }
-  memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+  memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
 }
 
 
@@ -229,11 +229,11 @@ Obj Shell ( Obj context,
   Obj oldShellContext;
   Obj oldBaseShellContext;
   Int oldRecursionDepth;
-  oldShellContext = TLS(ShellContext);
-  TLS(ShellContext) = context;
-  oldBaseShellContext = TLS(BaseShellContext);
-  TLS(BaseShellContext) = context;
-  oldRecursionDepth = TLS(RecursionDepth);
+  oldShellContext = STATE(ShellContext);
+  STATE(ShellContext) = context;
+  oldBaseShellContext = STATE(BaseShellContext);
+  STATE(BaseShellContext) = context;
+  oldRecursionDepth = STATE(RecursionDepth);
   
   /* read-eval-print loop                                                */
   if (!OpenOutput(outFile))
@@ -245,10 +245,10 @@ Obj Shell ( Obj context,
       ErrorQuit("SHELL: can't open infile %s",(Int)inFile,0);
     }
   
-  oldPrintDepth = TLS(PrintObjDepth);
-  TLS(PrintObjDepth) = 0;
-  oldindent = TLS(Output)->indent;
-  TLS(Output)->indent = 0;
+  oldPrintDepth = STATE(PrintObjDepth);
+  STATE(PrintObjDepth) = 0;
+  oldindent = STATE(Output)->indent;
+  STATE(Output)->indent = 0;
 
   while ( 1 ) {
 
@@ -257,11 +257,11 @@ Obj Shell ( Obj context,
       time = SyTime();
 
     /* read and evaluate one command                                   */
-    TLS(Prompt) = prompt;
+    STATE(Prompt) = prompt;
     ClearError();
-    TLS(PrintObjDepth) = 0;
-    TLS(Output)->indent = 0;
-    TLS(RecursionDepth) = 0;
+    STATE(PrintObjDepth) = 0;
+    STATE(Output)->indent = 0;
+    STATE(RecursionDepth) = 0;
       
     /* here is a hook: */
     if (preCommandHook) {
@@ -273,19 +273,19 @@ Obj Shell ( Obj context,
         {
           Call0ArgsInNewReader(preCommandHook);
           /* Recover from a potential break loop: */
-          TLS(Prompt) = prompt;
+          STATE(Prompt) = prompt;
           ClearError();
         }
     }
 
     /* now  read and evaluate and view one command  */
-    status = ReadEvalCommand(TLS(ShellContext), &dualSemicolon);
-    if (TLS(UserHasQUIT))
+    status = ReadEvalCommand(STATE(ShellContext), &dualSemicolon);
+    if (STATE(UserHasQUIT))
       break;
 
 
     /* handle ordinary command                                         */
-    if ( status == STATUS_END && TLS(ReadEvalResult) != 0 ) {
+    if ( status == STATUS_END && STATE(ReadEvalResult) != 0 ) {
 
       /* remember the value in 'last'    */
       if (lastDepth >= 3)
@@ -293,11 +293,11 @@ Obj Shell ( Obj context,
       if (lastDepth >= 2)
         AssGVar( Last2, VAL_GVAR( Last  ) );
       if (lastDepth >= 1)
-        AssGVar( Last,  TLS(ReadEvalResult)   );
+        AssGVar( Last,  STATE(ReadEvalResult)   );
 
       /* print the result                                            */
       if ( ! dualSemicolon ) {
-        ViewObjHandler( TLS(ReadEvalResult) );
+        ViewObjHandler( STATE(ReadEvalResult) );
       }
             
     }
@@ -319,14 +319,14 @@ Obj Shell ( Obj context,
     
     /* handle quit command or <end-of-file>                            */
     else if ( status & (STATUS_EOF | STATUS_QUIT ) ) {
-      TLS(RecursionDepth) = 0;
-      TLS(UserHasQuit) = 1;
+      STATE(RecursionDepth) = 0;
+      STATE(UserHasQuit) = 1;
       break;
     }
         
     /* handle QUIT */
     else if (status & (STATUS_QQUIT)) {
-      TLS(UserHasQUIT) = 1;
+      STATE(UserHasQUIT) = 1;
       break;
     }
         
@@ -334,26 +334,26 @@ Obj Shell ( Obj context,
     if (setTime)
       AssGVar( Time, INTOBJ_INT( SyTime() - time ) );
 
-    if (TLS(UserHasQuit))
+    if (STATE(UserHasQuit))
       {
         FlushRestOfInputLine();
-        TLS(UserHasQuit) = 0;        /* quit has done its job if we are here */
+        STATE(UserHasQuit) = 0;        /* quit has done its job if we are here */
       }
 
   }
   
-  TLS(PrintObjDepth) = oldPrintDepth;
-  TLS(Output)->indent = oldindent;
+  STATE(PrintObjDepth) = oldPrintDepth;
+  STATE(Output)->indent = oldindent;
   CloseInput();
   CloseOutput();
-  TLS(BaseShellContext) = oldBaseShellContext;
-  TLS(ShellContext) = oldShellContext;
-  TLS(RecursionDepth) = oldRecursionDepth;
-  if (TLS(UserHasQUIT))
+  STATE(BaseShellContext) = oldBaseShellContext;
+  STATE(ShellContext) = oldShellContext;
+  STATE(RecursionDepth) = oldRecursionDepth;
+  if (STATE(UserHasQUIT))
     {
       if (catchQUIT)
         {
-          TLS(UserHasQUIT) = 0;
+          STATE(UserHasQUIT) = 0;
           MakeReadWriteGVar(QUITTINGGVar);
           AssGVar(QUITTINGGVar, True);
           MakeReadOnlyGVar(QUITTINGGVar);
@@ -377,7 +377,7 @@ Obj Shell ( Obj context,
     {
       res = NEW_PLIST(T_PLIST_HOM,1);
       SET_LEN_PLIST(res,1);
-      SET_ELM_PLIST(res,1,TLS(ReadEvalResult));
+      SET_ELM_PLIST(res,1,STATE(ReadEvalResult));
       return res;
     }
   assert(0); 
@@ -475,7 +475,7 @@ Obj FuncSHELL (Obj self, Obj args)
   res =  Shell(context, canReturnVoid, canReturnObj, lastDepth, setTime, promptBuffer, preCommandHook, catchQUIT,
                CSTR_STRING(infile), CSTR_STRING(outfile));
 
-  TLS(UserHasQuit) = 0;
+  STATE(UserHasQuit) = 0;
   return res;
 }
 
@@ -501,7 +501,7 @@ int main (
 
   /* initialize everything and read init.g which runs the GAP session */
   InitializeGap( &argc, argv, environ );
-  if (!TLS(UserHasQUIT)) {         /* maybe the user QUIT from the initial
+  if (!STATE(UserHasQUIT)) {         /* maybe the user QUIT from the initial
                                    read of init.g  somehow*/
     /* maybe compile in which case init.g got skipped */
     if ( SyCompilePlease ) {
@@ -929,23 +929,23 @@ void DownEnvInner( Int depth )
   /* if we are asked to go up ... */
   if ( depth < 0 ) {
     /* ... we determine which level we are supposed to end up on ... */
-    depth = TLS(ErrorLLevel) + depth;
+    depth = STATE(ErrorLLevel) + depth;
     if (depth < 0) {
       depth = 0;
     }
     /* ... then go back to the top, and later go down to the appropriate level. */
-    TLS(ErrorLVars) = TLS(ErrorLVars0);
-    TLS(ErrorLLevel) = 0;
-    TLS(ShellContext) = TLS(BaseShellContext);
+    STATE(ErrorLVars) = STATE(ErrorLVars0);
+    STATE(ErrorLLevel) = 0;
+    STATE(ShellContext) = STATE(BaseShellContext);
   }
   
   /* now go down */
   while ( 0 < depth
-          && TLS(ErrorLVars) != TLS(BottomLVars)
-          && PARENT_LVARS(TLS(ErrorLVars)) != TLS(BottomLVars) ) {
-    TLS(ErrorLVars) = PARENT_LVARS(TLS(ErrorLVars));
-    TLS(ErrorLLevel)++;
-    TLS(ShellContext) = PARENT_LVARS(TLS(ShellContext));
+          && STATE(ErrorLVars) != STATE(BottomLVars)
+          && PARENT_LVARS(STATE(ErrorLVars)) != STATE(BottomLVars) ) {
+    STATE(ErrorLVars) = PARENT_LVARS(STATE(ErrorLVars));
+    STATE(ErrorLLevel)++;
+    STATE(ShellContext) = PARENT_LVARS(STATE(ShellContext));
     depth--;
   }
 }
@@ -966,7 +966,7 @@ Obj FuncDownEnv (
     ErrorQuit( "usage: DownEnv( [ <depth> ] )", 0L, 0L );
     return 0;
   }
-  if ( TLS(ErrorLVars) == TLS(BottomLVars) ) {
+  if ( STATE(ErrorLVars) == STATE(BottomLVars) ) {
     Pr( "not in any function\n", 0L, 0L );
     return 0;
   }
@@ -990,7 +990,7 @@ Obj FuncUpEnv (
     ErrorQuit( "usage: UpEnv( [ <depth> ] )", 0L, 0L );
     return 0;
   }
-  if ( TLS(ErrorLVars) == TLS(BottomLVars) ) {
+  if ( STATE(ErrorLVars) == STATE(BottomLVars) ) {
     Pr( "not in any function\n", 0L, 0L );
     return 0;
   }
@@ -1001,13 +1001,13 @@ Obj FuncUpEnv (
 
 Obj FuncExecutingStatementLocation(Obj self, Obj context)
 {
-  Obj currLVars = TLS(CurrLVars);
+  Obj currLVars = STATE(CurrLVars);
   Expr call;
   Int line;
   Obj filename;
   Obj retlist;
   retlist = Fail;
-  if (context == TLS(BottomLVars))
+  if (context == STATE(BottomLVars))
     return Fail;
   SWITCH_TO_OLD_LVARS(context);
   call = BRK_CALL_TO();
@@ -1034,9 +1034,9 @@ Obj FuncExecutingStatementLocation(Obj self, Obj context)
 
 Obj FuncPrintExecutingStatement(Obj self, Obj context)
 {
-  Obj currLVars = TLS(CurrLVars);
+  Obj currLVars = STATE(CurrLVars);
   Expr call;
-  if (context == TLS(BottomLVars))
+  if (context == STATE(BottomLVars))
     return (Obj) 0;
   SWITCH_TO_OLD_LVARS(context);
   call = BRK_CALL_TO();
@@ -1084,23 +1084,23 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
     if (!IS_LIST(args))
       ErrorMayQuit("CALL_WITH_CATCH(<func>, <args>): <args> must be a list",0,0);
 
-    memcpy((void *)&readJmpError, (void *)&TLS(ReadJmpError), sizeof(syJmp_buf));
-    currLVars = TLS(CurrLVars);
-    currStat = TLS(CurrStat);
-    recursionDepth = TLS(RecursionDepth);
+    memcpy((void *)&readJmpError, (void *)&STATE(ReadJmpError), sizeof(syJmp_buf));
+    currLVars = STATE(CurrLVars);
+    currStat = STATE(CurrStat);
+    recursionDepth = STATE(RecursionDepth);
     tilde = VAL_GVAR(Tilde);
     res = NEW_PLIST(T_PLIST_DENSE+IMMUTABLE,2);
-    if (sySetjmp(TLS(ReadJmpError))) {
+    if (sySetjmp(STATE(ReadJmpError))) {
       SET_LEN_PLIST(res,2);
       SET_ELM_PLIST(res,1,False);
-      SET_ELM_PLIST(res,2,TLS(ThrownObject));
+      SET_ELM_PLIST(res,2,STATE(ThrownObject));
       CHANGED_BAG(res);
-      TLS(ThrownObject) = 0;
-      TLS(CurrLVars) = currLVars;
-      TLS(PtrLVars) = PTR_BAG(TLS(CurrLVars));
-      TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
-      TLS(CurrStat) = currStat;
-      TLS(RecursionDepth) = recursionDepth;
+      STATE(ThrownObject) = 0;
+      STATE(CurrLVars) = currLVars;
+      STATE(PtrLVars) = PTR_BAG(STATE(CurrLVars));
+      STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+      STATE(CurrStat) = currStat;
+      STATE(RecursionDepth) = recursionDepth;
       AssGVarUnsafe(Tilde, tilde);
     } else {
       Obj result = CallFuncList(func, args);
@@ -1112,14 +1112,14 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
       } else
         SET_LEN_PLIST(res,1);
     }
-    memcpy((void *)&TLS(ReadJmpError), (void *)&readJmpError, sizeof(syJmp_buf));
+    memcpy((void *)&STATE(ReadJmpError), (void *)&readJmpError, sizeof(syJmp_buf));
     return res;
 }
 
 Obj FuncJUMP_TO_CATCH( Obj self, Obj payload)
 {
-  TLS(ThrownObject) = payload;
-  syLongjmp(TLS(ReadJmpError), 1);
+  STATE(ThrownObject) = payload;
+  syLongjmp(STATE(ReadJmpError), 1);
   return 0;
 }
 
@@ -1130,9 +1130,9 @@ UInt SystemErrorCode;
 
 Obj FuncSetUserHasQuit( Obj Self, Obj value)
 {
-  TLS(UserHasQuit) = INT_INTOBJ(value);
-  if (TLS(UserHasQuit))
-    TLS(RecursionDepth) = 0;
+  STATE(UserHasQuit) = INT_INTOBJ(value);
+  if (STATE(UserHasQuit))
+    STATE(RecursionDepth) = 0;
   return 0;
 }
 
@@ -1201,16 +1201,16 @@ Obj FuncCALL_WITH_TIMEOUT( Obj self, Obj seconds, Obj microseconds, Obj func, Ob
   if (newJumpBuf) {
     if (NumAlarmJumpBuffers >= MAX_TIMEOUT_NESTING_DEPTH-1)
       ErrorMayQuit("Nesting depth of timeouts limited to %i", MAX_TIMEOUT_NESTING_DEPTH, 0L);
-    currLVars = TLS(CurrLVars);
-    currStat = TLS(CurrStat);
-    recursionDepth = TLS(RecursionDepth);
+    currLVars = STATE(CurrLVars);
+    currStat = STATE(CurrStat);
+    recursionDepth = STATE(RecursionDepth);
     if (sySetjmp(AlarmJumpBuffers[NumAlarmJumpBuffers++])) {
       /* Timeout happened */
-      TLS(CurrLVars) = currLVars;
-      TLS(PtrLVars) = PTR_BAG(TLS(CurrLVars));
-      TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
-      TLS(CurrStat) = currStat;
-      TLS(RecursionDepth) = recursionDepth;
+      STATE(CurrLVars) = currLVars;
+      STATE(PtrLVars) = PTR_BAG(STATE(CurrLVars));
+      STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+      STATE(CurrStat) = currStat;
+      STATE(RecursionDepth) = recursionDepth;
       if (mayNeedToRestore) {
         /* In this case we used our ration of CPU time,
            so we know how much we need to restore 
@@ -1360,7 +1360,7 @@ Obj CallErrorInner (
   Obj r = NEW_PREC(0);
   Obj l;
   EarlyMsg = ErrorMessageToGAPString(msg, arg1, arg2);
-  AssPRec(r, RNamName("context"), TLS(CurrLVars));
+  AssPRec(r, RNamName("context"), STATE(CurrLVars));
   AssPRec(r, RNamName("justQuit"), justQuit? True : False);
   AssPRec(r, RNamName("mayReturnObj"), mayReturnObj? True : False);
   AssPRec(r, RNamName("mayReturnVoid"), mayReturnVoid? True : False);
@@ -1369,7 +1369,7 @@ Obj CallErrorInner (
   l = NEW_PLIST(T_PLIST_HOM+IMMUTABLE, 1);
   SET_ELM_PLIST(l,1,EarlyMsg);
   SET_LEN_PLIST(l,1);
-  SET_BRK_CALL_TO(TLS(CurrStat));
+  SET_BRK_CALL_TO(STATE(CurrStat));
   Obj res = CALL_2ARGS(ErrorInner,r,l);
   return res;
 }
@@ -1672,7 +1672,7 @@ Obj FuncLOAD_DYN (
 
     /* Start a new executor to run the outer function of the module
        in global context */
-    ExecBegin( TLS(BottomLVars) );
+    ExecBegin( STATE(BottomLVars) );
     res = res || (info->initLibrary)(info);
     ExecEnd(res ? STATUS_ERROR : STATUS_END);
     if ( res ) {
@@ -1751,7 +1751,7 @@ Obj FuncLOAD_STAT (
     UpdateCopyFopyInfo();
     /* Start a new executor to run the outer function of the module
        in global context */
-    ExecBegin( TLS(BottomLVars) );
+    ExecBegin( STATE(BottomLVars) );
     res = res || (info->initLibrary)(info);
     ExecEnd(res ? STATUS_ERROR : STATUS_END);
     if ( res ) {
@@ -2666,7 +2666,7 @@ Obj FuncQUIT_GAP( Obj self, Obj args )
     ErrorQuit( "usage: QUIT_GAP( [ <return value> ] )", 0L, 0L );
     return 0;
   }
-  TLS(UserHasQUIT) = 1;
+  STATE(UserHasQUIT) = 1;
   ReadEvalError();
   return (Obj)0; 
 }
@@ -2976,7 +2976,7 @@ static Int InitKernel (
     StructInitInfo *    module )
 {
     /* init the completion function                                        */
-    InitGlobalBag( &TLS(ThrownObject), "src/gap.c:ThrownObject"      );
+    InitGlobalBag( &STATE(ThrownObject), "src/gap.c:ThrownObject"      );
 
     /* list of exit functions                                              */
     InitGlobalBag( &WindowCmdString, "src/gap.c:WindowCmdString" );
@@ -3276,17 +3276,17 @@ void InitializeGap (
               0, SyAbortBags );
               InitMsgsFuncBags( SyMsgsBags ); 
 
-    TLS(StackNams)    = NEW_PLIST( T_PLIST, 16 );
-    TLS(CountNams)    = 0;
-    TLS(ReadTop)      = 0;
-    TLS(ReadTilde)    = 0;
-    TLS(CurrLHSGVar)  = 0;
-    TLS(IntrCoding)   = 0;
-    TLS(IntrIgnoring) = 0;
-    TLS(NrError)      = 0;
-    TLS(ThrownObject) = 0;
-    TLS(UserHasQUIT) = 0;
-    TLS(UserHasQuit) = 0;
+    STATE(StackNams)    = NEW_PLIST( T_PLIST, 16 );
+    STATE(CountNams)    = 0;
+    STATE(ReadTop)      = 0;
+    STATE(ReadTilde)    = 0;
+    STATE(CurrLHSGVar)  = 0;
+    STATE(IntrCoding)   = 0;
+    STATE(IntrIgnoring) = 0;
+    STATE(NrError)      = 0;
+    STATE(ThrownObject) = 0;
+    STATE(UserHasQUIT) = 0;
+    STATE(UserHasQuit) = 0;
 
     NrImportedGVars = 0;
     NrImportedFuncs = 0;

--- a/src/gap.c
+++ b/src/gap.c
@@ -93,7 +93,7 @@
 #include <src/weakptr.h>                /* weak pointers */
 #include <src/profile.h>                /* profiling */
 
-#include <src/globalstate.h>            /* Global State */
+#include <src/gapstate.h>            /* Global State */
 
 #ifdef GAPMPI
 #include <src/hpc/gapmpi.h>             /* ParGAP/MPI */
@@ -497,7 +497,7 @@ int main (
   InstallBacktraceHandlers();
 #endif
 
-  InitMainGlobalState();
+  InitMainGAPState();
 
   /* initialize everything and read init.g which runs the GAP session */
   InitializeGap( &argc, argv, environ );
@@ -3326,7 +3326,7 @@ void InitializeGap (
         }
     }
 
-    InitGlobalState(MainGlobalState);
+    InitGAPState(MainGAPState);
 
     InitGlobalBag(&POST_RESTORE, "gap.c: POST_RESTORE");
     InitFopyGVar( "POST_RESTORE", &POST_RESTORE);

--- a/src/gapstate.c
+++ b/src/gapstate.c
@@ -39,7 +39,7 @@ void InitGAPState(GAPState *state)
     // RunConstructors?
 }
 
-void DestroyGlobal(GAPState *state)
+void DestroyGAPState(GAPState *state)
 {
     DestroyScannerState(state);
     DestroyStatState(state);

--- a/src/gapstate.c
+++ b/src/gapstate.c
@@ -1,6 +1,6 @@
 /***********************************************************************
  **
- *W  globalstate.c      GAP source                 Markus Pfeiffer
+ *W  gapstate.c      GAP source                 Markus Pfeiffer
  **
  **
  ** This file declares all variables that are considered state for the
@@ -8,27 +8,27 @@
  **
  */
 
-#include <src/globalstate.h>
+#include <src/gapstate.h>
 
 #define MAX_FUNC_EXPR_NESTING 1024
 
 static Stat MainOffsBodyStack[MAX_FUNC_EXPR_NESTING];
 static UInt MainLoopStack[MAX_FUNC_EXPR_NESTING];
 
-static GlobalState _MainGlobalState;
+static GAPState _MainGAPState;
 
-GlobalState *MainGlobalState = 0;
+GAPState *MainGAPState = 0;
 
-void InitMainGlobalState(void)
+void InitMainGAPState(void)
 {
     // with GASMAN mallocing this struct could
     // lead to unwanted effects.
-    MainGlobalState = &_MainGlobalState;
-    MainGlobalState->OffsBodyStack = MainOffsBodyStack;
-    MainGlobalState->LoopStack = MainLoopStack;
+    MainGAPState = &_MainGAPState;
+    MainGAPState->OffsBodyStack = MainOffsBodyStack;
+    MainGAPState->LoopStack = MainLoopStack;
 }
 
-void InitGlobalState(GlobalState *state)
+void InitGAPState(GAPState *state)
 {
     InitScannerState(state);
     InitStatState(state);
@@ -39,7 +39,7 @@ void InitGlobalState(GlobalState *state)
     // RunConstructors?
 }
 
-void DestroyGlobal(GlobalState *state)
+void DestroyGlobal(GAPState *state)
 {
     DestroyScannerState(state);
     DestroyStatState(state);

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -197,6 +197,10 @@ typedef struct GAPState
 
 extern GAPState *MainGAPState;
 
+#if !defined(HPCGAP)
+#define STATE(x) MainGAPState->x
+#endif
+
 void InitMainGAPState(void);
 
 void InitScannerState(GAPState *);

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -1,14 +1,14 @@
-/***********************************************************************
+	/***********************************************************************
  **
- *W  globalstate.h      GAP source                 Markus Pfeiffer
+ *W  gapstate.h      GAP source                 Markus Pfeiffer
  **
  **
  ** This file declares all variables that are considered state for the
  ** interpreter
  **
  */
-#ifndef GAP_GLOBAL_STATE_H
-#define GAP_GLOBAL_STATE_H
+#ifndef GAP_GAPSTATE_H
+#define GAP_GAPSTATE_H
 
 #include <stdint.h>
 
@@ -19,7 +19,7 @@
 
 #define MAXPRINTDEPTH 1024L
 
-typedef struct GlobalState
+typedef struct GAPState
 {
   /* From intrprtr.c */
   Obj IntrResult;
@@ -193,25 +193,25 @@ typedef struct GlobalState
 #define MAX_GC_PREFIX_DESC 4
   void **FreeList[MAX_GC_PREFIX_DESC+2];
 #endif
-} GlobalState;
+} GAPState;
 
-extern GlobalState *MainGlobalState;
+extern GAPState *MainGAPState;
 
-void InitMainGlobalState(void);
+void InitMainGAPState(void);
 
-void InitScannerState(GlobalState *);
-void InitStatState(GlobalState *);
-void InitExprState(GlobalState *);
-void InitCoderState(GlobalState *);
-void InitOpersState(GlobalState *);
+void InitScannerState(GAPState *);
+void InitStatState(GAPState *);
+void InitExprState(GAPState *);
+void InitCoderState(GAPState *);
+void InitOpersState(GAPState *);
 
-void DestroyScannerState(GlobalState *);
-void DestroyStatState(GlobalState *);
-void DestroyExprState(GlobalState *);
-void DestroyCoderState(GlobalState *);
-void DestroyOpersState(GlobalState *);
+void DestroyScannerState(GAPState *);
+void DestroyStatState(GAPState *);
+void DestroyExprState(GAPState *);
+void DestroyCoderState(GAPState *);
+void DestroyOpersState(GAPState *);
 
-void InitGlobalState(GlobalState *state);
-void DestroyGlobalState(GlobalState *state);
+void InitGAPState(GAPState *state);
+void DestroyGAPState(GAPState *state);
 
-#endif // GAP_GLOBAL_STATE_H
+#endif // GAP_GAPSTATE_H

--- a/src/globalstate.h
+++ b/src/globalstate.h
@@ -64,8 +64,13 @@ typedef struct GlobalState
   UInt NrErrLine;
   UInt            Symbol;
   Char *          Prompt;
-  TypInputFile   InputFiles[16];
+#if defined(HPCGAP)
+  TypInputFile * InputFiles[16];
+  TypOutputFile * OutputFiles[16];
+#else
+  TypInputFile InputFiles[16];
   TypOutputFile OutputFiles[16];
+#endif
   int InputFilesSP;
   int OutputFilesSP;
   TypInputFile *  Input;
@@ -154,13 +159,18 @@ typedef struct GlobalState
   Int PrintObjIndex;
   Int PrintObjDepth;
   Int PrintObjFull;
-  // HPC-GAP Obj PrintObjThissObj;
+#if defined(HPCGAP)
+  Obj PrintObjThissObj;
+  Obj *PrintObjThiss;
+  Obj PrintObjIndicesObj;
+  Int *PrintObjIndices;
+#else
   Obj PrintObjThiss[MAXPRINTDEPTH];
-  // HPC-GAP Obj PrintObjIndicesObj;
   Int PrintObjIndices[MAXPRINTDEPTH];
+#endif
 
 #if defined(HPCGAP)
-  /* For serializer.c */
+  /* For serialize.c */
   Obj SerializationObj;
   UInt SerializationIndex;
   void *SerializationDispatcher;
@@ -178,19 +188,11 @@ typedef struct GlobalState
   Obj SC_CW2_VECTOR;
   UInt SC_MAX_STACK_SIZE;
 
-#if defined(HPCGAP)
-  /* Profiling */
-  UInt CountActive;
-  UInt LocksAcquired;
-  UInt LocksContended;
-#endif
-
   /* Allocation */
 #ifdef BOEHM_GC
 #define MAX_GC_PREFIX_DESC 4
   void **FreeList[MAX_GC_PREFIX_DESC+2];
 #endif
-  /* Extra storage */
 } GlobalState;
 
 extern GlobalState *MainGlobalState;

--- a/src/gmpints.c
+++ b/src/gmpints.c
@@ -66,6 +66,7 @@
 **  GMP_NORMALIZE and GMP_REDUCE can be used to ensure this.
 */
 #include <src/system.h>                 /* Ints, UInts */
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -27,7 +27,7 @@
 **  Otherwise the internal copies reference functions that signal an error.
 */
 #include <src/system.h>                 /* Ints, UInts */
-
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -332,13 +332,13 @@ Obj NameGVarObj ( UInt gvar )
 
 Obj FuncSET_NAMESPACE(Obj self, Obj str)
 {
-    TLS(CurrNamespace) = str;
+    STATE(CurrNamespace) = str;
     return 0;
 }
 
 Obj FuncGET_NAMESPACE(Obj self)
 {
-    return TLS(CurrNamespace);
+    return STATE(CurrNamespace);
 }
 
 /****************************************************************************
@@ -363,7 +363,7 @@ UInt GVarName (
     Int                 len;            /* length of name                  */
 
     /* First see whether it could be namespace-local: */
-    cns = CSTR_STRING(TLS(CurrNamespace));
+    cns = CSTR_STRING(STATE(CurrNamespace));
     if (*cns) {   /* only if a namespace is set */
         len = strlen(name);
         if (name[len-1] == NSCHAR) {
@@ -1127,7 +1127,7 @@ static Int InitKernel (
                    "src/gvars.c:FopiesGVars"  );
     InitGlobalBag( &TableGVars,
                    "src/gvars.c:TableGVars" );
-    InitGlobalBag( &TLS(CurrNamespace),
+    InitGlobalBag( &STATE(CurrNamespace),
                    "src/gvars.c:CurrNamespace" );
 
     InitHandlerFunc( ErrorMustEvalToFuncHandler,
@@ -1235,8 +1235,8 @@ static Int InitLibrary (
     SET_LEN_PLIST( TableGVars, SizeGVars );
 
     /* Create the current namespace: */
-    TLS(CurrNamespace) = NEW_STRING(0);
-    SET_LEN_STRING(TLS(CurrNamespace),0);
+    STATE(CurrNamespace) = NEW_STRING(0);
+    SET_LEN_STRING(STATE(CurrNamespace),0);
     
     /* fix C vars                                                          */
     PostRestore( module );

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -1593,11 +1593,11 @@ void UnbAList(Obj list, Int pos)
   HashUnlockShared(list);
 }
 
-void InitAObjectsTLS() {
+void InitAObjectsState() {
   TLS(tlRecords) = (Obj) 0;
 }
 
-void DestroyAObjectsTLS() {
+void DestroyAObjectsState() {
   Obj records;
   UInt i, len;
   records = TLS(tlRecords);

--- a/src/hpc/aobjects.h
+++ b/src/hpc/aobjects.h
@@ -9,6 +9,9 @@
 
 #else
 
+void InitAObjectsState();
+void DestroyAObjectsState();
+
 StructInitInfo *InitInfoAObjects(void);
 Obj NewAtomicRecord(UInt capacity);
 Obj SetARecordField(Obj record, UInt field, Obj obj);

--- a/src/hpc/boehm_gc.h
+++ b/src/hpc/boehm_gc.h
@@ -193,7 +193,7 @@ static void TLAllocatorInit(void) {
     k ++;
   }
   TLAllocatorMaxSeg = k;
-  if (MAX_GC_PREFIX_DESC * sizeof(void *) > sizeof(TLS(FreeList)))
+  if (MAX_GC_PREFIX_DESC * sizeof(void *) > sizeof(STATE(FreeList)))
     abort();
 }
 
@@ -217,18 +217,18 @@ void *AllocateBagMemory(int gc_type, int type, UInt size)
       alloc_size = (size + GRANULE_SIZE - 1 ) / GRANULE_SIZE;
       alloc_seg = TLAllocatorSeg[alloc_size];
       alloc_size = TLAllocatorSize[alloc_seg];
-      if (!TLS(FreeList)[gc_type+1])
-        TLS(FreeList)[gc_type+1] =
+      if (!STATE(FreeList)[gc_type+1])
+        STATE(FreeList)[gc_type+1] =
           GC_malloc(sizeof(void *) * TLAllocatorMaxSeg);
-      if (!(result = TLS(FreeList)[gc_type+1][alloc_seg])) {
+      if (!(result = STATE(FreeList)[gc_type+1][alloc_seg])) {
         if (gc_type < 0)
-          TLS(FreeList)[0][alloc_seg] = GC_malloc_many(alloc_size);
+          STATE(FreeList)[0][alloc_seg] = GC_malloc_many(alloc_size);
         else
           GC_generic_malloc_many(alloc_size, GCMKind[gc_type],
-            &TLS(FreeList)[gc_type+1][alloc_seg]);
-        result = TLS(FreeList)[gc_type+1][alloc_seg];
+            &STATE(FreeList)[gc_type+1][alloc_seg]);
+        result = STATE(FreeList)[gc_type+1][alloc_seg];
       }
-      TLS(FreeList)[gc_type+1][alloc_seg] = *(void **)result;
+      STATE(FreeList)[gc_type+1][alloc_seg] = *(void **)result;
       memset(result, 0, alloc_size);
     } else {
       if (gc_type >= 0)

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -1517,11 +1517,11 @@ static Int InitLibrary (
     return 0;
 }
 
-void InitThreadAPITLS()
+void InitThreadAPIState()
 {
 }
 
-void DestroyThreadAPITLS()
+void DestroyThreadAPIState()
 {
 }
 

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -791,7 +791,7 @@ Obj FuncHASH_UNLOCK_SHARED(Obj self, Obj target) {
 Obj FuncHASH_SYNCHRONIZED(Obj self, Obj target, Obj function) {
   volatile int locked = 0;
   jmp_buf readJmpError;
-  memcpy( readJmpError, TLS(ReadJmpError), sizeof(jmp_buf) );
+  memcpy( readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
   TRY_READ {
     HashLock(target);
     locked = 1;
@@ -801,14 +801,14 @@ Obj FuncHASH_SYNCHRONIZED(Obj self, Obj target, Obj function) {
   }
   if (locked)
     HashUnlock(target);
-  memcpy( TLS(ReadJmpError), readJmpError, sizeof(jmp_buf) );
+  memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
   return (Obj) 0;
 }
 
 Obj FuncHASH_SYNCHRONIZED_SHARED(Obj self, Obj target, Obj function) {
   volatile int locked = 0;
   jmp_buf readJmpError;
-  memcpy( readJmpError, TLS(ReadJmpError), sizeof(jmp_buf) );
+  memcpy( readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
   TRY_READ {
     HashLockShared(target);
     locked = 1;
@@ -818,7 +818,7 @@ Obj FuncHASH_SYNCHRONIZED_SHARED(Obj self, Obj target, Obj function) {
   }
   if (locked)
     HashUnlockShared(target);
-  memcpy( TLS(ReadJmpError), readJmpError, sizeof(jmp_buf) );
+  memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
   return (Obj) 0;
 }
 
@@ -872,15 +872,15 @@ Obj FuncWITH_TARGET_REGION(Obj self, Obj obj, Obj func) {
     ArgumentError("WITH_TARGET_REGION: Second argument must be a function");
   if (!region || !CheckExclusiveWriteAccess(obj))
     ArgumentError("WITH_TARGET_REGION: Requires write access to target region");
-  memcpy(readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf));
-  if (sySetjmp(TLS(ReadJmpError))) {
-    memcpy(TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+  memcpy(readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf));
+  if (sySetjmp(STATE(ReadJmpError))) {
+    memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
     TLS(currentRegion) = oldRegion;
-    syLongjmp(TLS(ReadJmpError), 1);
+    syLongjmp(STATE(ReadJmpError), 1);
   }
   TLS(currentRegion) = region;
   CALL_0ARGS(func);
-  memcpy(TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+  memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
   TLS(currentRegion) = oldRegion;
   return (Obj) 0;
 }
@@ -3179,8 +3179,8 @@ Obj FuncPERIODIC_CHECK(Obj self, Obj count, Obj func)
    * increasing value and we only need it to succeed eventually.
    */
   n = INT_INTOBJ(count)/10;
-  if (TLS(PeriodicCheckCount) + n < SigVTALRMCounter) {
-    TLS(PeriodicCheckCount) = SigVTALRMCounter;
+  if (STATE(PeriodicCheckCount) + n < SigVTALRMCounter) {
+    STATE(PeriodicCheckCount) = SigVTALRMCounter;
     CALL_0ARGS(func);
   }
   return (Obj) 0;

--- a/src/hpc/threadapi.h
+++ b/src/hpc/threadapi.h
@@ -30,6 +30,8 @@ void LockMonitors(UInt count, Monitor **monitors);
 void UnlockMonitors(UInt count, Monitor **monitors);
 
 void InitSignals();
+void InitThreadAPIState();
+void DestroyThreadAPIState();
 
 
 /****************************************************************************

--- a/src/hpc/tls.c
+++ b/src/hpc/tls.c
@@ -78,39 +78,21 @@ Int AllocateExtraTLSSlot() {
 
 void InitTLS()
 {
-  void InitScannerTLS();
-  void InitStatTLS();
-  void InitExprTLS();
-  void InitCoderTLS();
-  void InitThreadAPITLS();
-  void InitOpersTLS();
-  void InitAObjectsTLS();
-  InitScannerTLS();
-  InitStatTLS();
-  InitExprTLS();
-  InitCoderTLS();
-  InitThreadAPITLS();
-  InitOpersTLS();
-  InitAObjectsTLS();
+  InitGAPState(&TLS(state));
+
+  InitThreadAPIState();
+  InitAObjectsState();
+
   RunTLSConstructors();
   TLS(CountActive) = 1;
 }
 
 void DestroyTLS()
 {
-  void DestroyScannerTLS();
-  void DestroyStatTLS();
-  void DestroyExprTLS();
-  void DestroyCoderTLS();
-  void DestroyThreadAPITLS();
-  void DestroyOpersTLS();
-  void DestroyAObjectsTLS();
-  DestroyScannerTLS();
-  DestroyStatTLS();
-  DestroyExprTLS();
-  DestroyCoderTLS();
-  DestroyThreadAPITLS();
-  DestroyOpersTLS();
-  DestroyAObjectsTLS();
+  DestroyGAPState(&TLS(state));
+
+  DestroyThreadAPIState();
+  DestroyAObjectsState();
+
   RunTLSDestructors();
 }

--- a/src/hpc/tls.h
+++ b/src/hpc/tls.h
@@ -19,7 +19,7 @@ static inline Bag ImpliedWriteGuard(Bag bag)
 
 #include <stdint.h>
 
-#include <src/globalstate.h>
+#include <src/gapstate.h>
 #include <src/code.h>
 #include <src/hpc/tlsconfig.h>
 #include <src/scanner.h>
@@ -50,7 +50,7 @@ typedef struct ThreadLocalStorage
   GlobalState state;
   /* Extra storage */
   void *Extra[TLS_NUM_EXTRA];
-};
+} ThreadLocalStorage;
 
 extern ThreadLocalStorage *MainThreadTLS;
 

--- a/src/hpc/tls.h
+++ b/src/hpc/tls.h
@@ -47,7 +47,11 @@ typedef struct ThreadLocalStorage
   char *CurrFuncName;
   int DisableGuards;
 
-  GlobalState state;
+  UInt LocksAcquired;
+  UInt LocksContended;
+  UInt CountActive;
+
+  GAPState state;
   /* Extra storage */
   void *Extra[TLS_NUM_EXTRA];
 } ThreadLocalStorage;
@@ -103,6 +107,7 @@ static ALWAYS_INLINE ThreadLocalStorage *GetTLS()
 #endif /* HAVE_NATIVE_TLS */
 
 #define TLS(x) realTLS->x
+#define STATE(x) TLS(state).x
 
 #define IS_BAG_REF(bag) (bag && !((Int)(bag)& 0x03))
 

--- a/src/hpc/tls.h
+++ b/src/hpc/tls.h
@@ -19,6 +19,7 @@ static inline Bag ImpliedWriteGuard(Bag bag)
 
 #include <stdint.h>
 
+#include <src/globalstate.h>
 #include <src/code.h>
 #include <src/hpc/tlsconfig.h>
 #include <src/scanner.h>
@@ -46,178 +47,10 @@ typedef struct ThreadLocalStorage
   char *CurrFuncName;
   int DisableGuards;
 
-  /* From intrprtr.c */
-  Obj IntrResult;
-  UInt IntrIgnoring;
-  UInt IntrReturning;
-  UInt IntrCoding;
-  Obj IntrState;
-  Obj StackObj;
-  Int CountObj;
-#if defined(HPCGAP)
-  UInt PeriodicCheckCount;
-#endif
-
-  /* From gvar.c */
-  Obj CurrNamespace;
-
-  /* From vars.c */
-  Bag BottomLVars;
-  Bag CurrLVars;
-  Obj *PtrLVars;
-#if defined(HPCGAP)
-  Bag LVarsPool[16];
-#endif
-
-  /* From read.c */
-  syJmp_buf ReadJmpError;
-  syJmp_buf threadExit;
-  Obj StackNams;
-  UInt CountNams;
-  UInt ReadTop;
-  UInt ReadTilde;
-  UInt CurrLHSGVar;
-  UInt CurrentGlobalForLoopVariables[100];
-  UInt CurrentGlobalForLoopDepth;
-  Obj ExprGVars;
-  Obj ReadEvalResult;
-
-  /* From scanner.c */
-  Char Value[MAX_VALUE_LEN];
-  UInt ValueLen;
-  UInt NrError;
-  UInt NrErrLine;
-  UInt            Symbol;
-  Char *          Prompt;
-  TypInputFile *  InputFiles[16];
-  TypOutputFile* OutputFiles[16];
-  int InputFilesSP;
-  int OutputFilesSP;
-  TypInputFile *  Input;
-  Char *          In;
-  TypOutputFile * Output;
-  TypOutputFile * InputLog;
-  TypOutputFile * OutputLog;
-  TypOutputFile * IgnoreStdoutErrout;
-#if defined(HPCGAP)
-  Obj		  DefaultOutput;
-  Obj		  DefaultInput;
-#endif
-  TypOutputFile LogFile;
-  TypOutputFile LogStream;
-  TypOutputFile InputLogFile;
-  TypOutputFile InputLogStream;
-  TypOutputFile OutputLogFile;
-  TypOutputFile OutputLogStream;
-  Int HELPSubsOn;
-  Int NoSplitLine;
-  KOutputStream TheStream;
-  Char *TheBuffer;
-  UInt TheCount;
-  UInt TheLimit;
-
-  /* From exprs.c */
-  Obj (**CurrEvalExprFuncs)(Expr);
-
-  /* From stats.c */
-  Stat CurrStat;
-  Obj ReturnObjStat;
-  UInt (**CurrExecStatFuncs)(Stat);
-
-  /* From code.c */
-  Stat *PtrBody;
-  Stat OffsBody;
-  Stat *OffsBodyStack;
-  UInt OffsBodyCount;
-  UInt LoopNesting;
-  UInt *LoopStack;
-  UInt LoopStackCount;
-
-  Obj CodeResult;
-  Bag StackStat;
-  Int CountStat;
-  Bag StackExpr;
-  Int CountExpr;
-  Bag CodeLVars;
-
-  /* From funcs.h */
-  Int RecursionDepth;
-  Obj ExecState;
-
-  /* From opers.c */
-  Obj MethodCache;
-  Obj *MethodCacheItems;
-  UInt MethodCacheSize;
-  UInt CacheIndex;
-
-  /* From cyclotom.c */
-  Obj ResultCyc;
-  Obj  LastECyc;
-  UInt LastNCyc;
-
-  /* From permutat.c */
-  Obj TmpPerm;
-
-  /* From trans.c */
-  Obj TmpTrans;
-
-  /* From pperm.c */
-  Obj TmpPPerm;
-
-  /* From gap.c */
-  Obj ThrownObject;
-  UInt UserHasQuit;
-  UInt UserHasQUIT;
-  Obj ShellContext;
-  Obj BaseShellContext;
-  Int ErrorLLevel;
-  Obj ErrorLVars;
-  Obj ErrorLVars0;
-
-  /* From objects.c */
-  Obj PrintObjThis;
-  Int PrintObjIndex;
-  Int PrintObjDepth;
-  Int PrintObjFull;
-  Obj PrintObjThissObj;
-  Obj *PrintObjThiss;
-  Obj PrintObjIndicesObj;
-  Int *PrintObjIndices;
-
-#if defined(HPCGAP)
-  /* For serializer.c */
-  Obj SerializationObj;
-  UInt SerializationIndex;
-  void *SerializationDispatcher;
-  Obj SerializationRegistry;
-  Obj SerializationStack;
-#endif
-
-  /* For objscoll*, objccoll* */
-  Obj SC_NW_STACK;
-  Obj SC_LW_STACK;
-  Obj SC_PW_STACK;
-  Obj SC_EW_STACK;
-  Obj SC_GE_STACK;
-  Obj SC_CW_VECTOR;
-  Obj SC_CW2_VECTOR;
-  UInt SC_MAX_STACK_SIZE;
-
-#if defined(HPCGAP)
-  /* Profiling */
-  UInt CountActive;
-  UInt LocksAcquired;
-  UInt LocksContended;
-#endif
-
-  /* Allocation */
-#ifdef BOEHM_GC
-#define MAX_GC_PREFIX_DESC 4
-  void **FreeList[MAX_GC_PREFIX_DESC+2];
-#endif
+  GlobalState state;
   /* Extra storage */
   void *Extra[TLS_NUM_EXTRA];
-} ThreadLocalStorage;
+};
 
 extern ThreadLocalStorage *MainThreadTLS;
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -153,16 +153,16 @@ void            PushObj (
     Obj                 val )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( TLS(StackObj) != 0 );
-    assert( 0 <= TLS(CountObj) && TLS(CountObj) == LEN_PLIST(TLS(StackObj)) );
+    assert( STATE(StackObj) != 0 );
+    assert( 0 <= STATE(CountObj) && STATE(CountObj) == LEN_PLIST(STATE(StackObj)) );
     assert( val != 0 );
 
     /* count up and put the value onto the stack                           */
-    TLS(CountObj)++;
-    GROW_PLIST(    TLS(StackObj), TLS(CountObj) );
-    SET_LEN_PLIST( TLS(StackObj), TLS(CountObj) );
-    SET_ELM_PLIST( TLS(StackObj), TLS(CountObj), val );
-    CHANGED_BAG(   TLS(StackObj) );
+    STATE(CountObj)++;
+    GROW_PLIST(    STATE(StackObj), STATE(CountObj) );
+    SET_LEN_PLIST( STATE(StackObj), STATE(CountObj) );
+    SET_ELM_PLIST( STATE(StackObj), STATE(CountObj), val );
+    CHANGED_BAG(   STATE(StackObj) );
 }
 
 /* Special marker value to denote that a function returned no value, so we
@@ -177,27 +177,27 @@ Obj VoidReturnMarker;
 void            PushFunctionVoidReturn ( void )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( TLS(StackObj) != 0 );
-    assert( 0 <= TLS(CountObj) && TLS(CountObj) == LEN_PLIST(TLS(StackObj)) );
+    assert( STATE(StackObj) != 0 );
+    assert( 0 <= STATE(CountObj) && STATE(CountObj) == LEN_PLIST(STATE(StackObj)) );
 
     /* count up and put the void value onto the stack                      */
-    TLS(CountObj)++;
-    GROW_PLIST(    TLS(StackObj), TLS(CountObj) );
-    SET_LEN_PLIST( TLS(StackObj), TLS(CountObj) );
-    SET_ELM_PLIST( TLS(StackObj), TLS(CountObj), (Obj)&VoidReturnMarker );
+    STATE(CountObj)++;
+    GROW_PLIST(    STATE(StackObj), STATE(CountObj) );
+    SET_LEN_PLIST( STATE(StackObj), STATE(CountObj) );
+    SET_ELM_PLIST( STATE(StackObj), STATE(CountObj), (Obj)&VoidReturnMarker );
 }
 
 void            PushVoidObj ( void )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( TLS(StackObj) != 0 );
-    assert( 0 <= TLS(CountObj) && TLS(CountObj) == LEN_PLIST(TLS(StackObj)) );
+    assert( STATE(StackObj) != 0 );
+    assert( 0 <= STATE(CountObj) && STATE(CountObj) == LEN_PLIST(STATE(StackObj)) );
 
     /* count up and put the void value onto the stack                      */
-    TLS(CountObj)++;
-    GROW_PLIST(    TLS(StackObj), TLS(CountObj) );
-    SET_LEN_PLIST( TLS(StackObj), TLS(CountObj) );
-    SET_ELM_PLIST( TLS(StackObj), TLS(CountObj), (Obj)0 );
+    STATE(CountObj)++;
+    GROW_PLIST(    STATE(StackObj), STATE(CountObj) );
+    SET_LEN_PLIST( STATE(StackObj), STATE(CountObj) );
+    SET_ELM_PLIST( STATE(StackObj), STATE(CountObj), (Obj)0 );
 }
 
 Obj             PopObj ( void )
@@ -205,14 +205,14 @@ Obj             PopObj ( void )
     Obj                 val;
 
     /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( TLS(StackObj) != 0 );
-    assert( 1 <= TLS(CountObj) && TLS(CountObj) == LEN_LIST(TLS(StackObj)) );
+    assert( STATE(StackObj) != 0 );
+    assert( 1 <= STATE(CountObj) && STATE(CountObj) == LEN_LIST(STATE(StackObj)) );
 
     /* get the top element from the stack and count down                   */
-    val = ELM_PLIST( TLS(StackObj), TLS(CountObj) );
-    SET_ELM_PLIST( TLS(StackObj), TLS(CountObj), 0 );
-    SET_LEN_PLIST( TLS(StackObj), TLS(CountObj)-1  );
-    TLS(CountObj)--;
+    val = ELM_PLIST( STATE(StackObj), STATE(CountObj) );
+    SET_ELM_PLIST( STATE(StackObj), STATE(CountObj), 0 );
+    SET_LEN_PLIST( STATE(StackObj), STATE(CountObj)-1  );
+    STATE(CountObj)--;
 
     if(val == (Obj)&VoidReturnMarker) {
         ErrorQuit(
@@ -229,14 +229,14 @@ Obj             PopVoidObj ( void )
     Obj                 val;
 
     /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( TLS(StackObj) != 0 );
-    assert( 1 <= TLS(CountObj) && TLS(CountObj) == LEN_LIST(TLS(StackObj)) );
+    assert( STATE(StackObj) != 0 );
+    assert( 1 <= STATE(CountObj) && STATE(CountObj) == LEN_LIST(STATE(StackObj)) );
 
     /* get the top element from the stack and count down                   */
-    val = ELM_PLIST( TLS(StackObj), TLS(CountObj) );
-    SET_ELM_PLIST( TLS(StackObj), TLS(CountObj), 0 );
-    SET_LEN_PLIST( TLS(StackObj), TLS(CountObj)-1  );
-    TLS(CountObj)--;
+    val = ELM_PLIST( STATE(StackObj), STATE(CountObj) );
+    SET_ELM_PLIST( STATE(StackObj), STATE(CountObj), 0 );
+    SET_LEN_PLIST( STATE(StackObj), STATE(CountObj)-1  );
+    STATE(CountObj)--;
 
     /* Treat a function which returned no value the same as 'void'         */
     if(val == (Obj)&VoidReturnMarker) {
@@ -263,7 +263,7 @@ Obj             PopVoidObj ( void )
 **
 **  If 'IntrEnd' returns  0, then no  return-statement or quit-statement  was
 **  interpreted.  If  'IntrEnd' returns 1,  then a return-value-statement was
-**  interpreted and in this case the  return value is stored in 'TLS(IntrResult)'.
+**  interpreted and in this case the  return value is stored in 'STATE(IntrResult)'.
 **  If  'IntrEnd' returns 2, then a  return-void-statement  was  interpreted.
 **  If 'IntrEnd' returns 8, then a quit-statement was interpreted.
 */
@@ -276,22 +276,22 @@ void IntrBegin ( Obj frame )
        place from which we might call SaveWorkspace */
     intrState = NewBag( T_PLIST, 4*sizeof(Obj) );
     ADDR_OBJ(intrState)[0] = (Obj)3;
-    ADDR_OBJ(intrState)[1] = TLS(IntrState);
-    ADDR_OBJ(intrState)[2] = TLS(StackObj);
-    ADDR_OBJ(intrState)[3] = INTOBJ_INT(TLS(CountObj));
-    TLS(IntrState) = intrState;
+    ADDR_OBJ(intrState)[1] = STATE(IntrState);
+    ADDR_OBJ(intrState)[2] = STATE(StackObj);
+    ADDR_OBJ(intrState)[3] = INTOBJ_INT(STATE(CountObj));
+    STATE(IntrState) = intrState;
 
     /* allocate a new values stack                                         */
-    TLS(StackObj) = NEW_PLIST( T_PLIST, 64 );
-    SET_LEN_PLIST( TLS(StackObj), 0 );
-    TLS(CountObj) = 0;
+    STATE(StackObj) = NEW_PLIST( T_PLIST, 64 );
+    SET_LEN_PLIST( STATE(StackObj), 0 );
+    STATE(CountObj) = 0;
 
     /* must be in immediate (non-ignoring, non-coding) mode                */
-    assert( TLS(IntrIgnoring) == 0 );
-    assert( TLS(IntrCoding)   == 0 );
+    assert( STATE(IntrIgnoring) == 0 );
+    assert( STATE(IntrCoding)   == 0 );
 
     /* no return-statement was yet interpreted                             */
-    TLS(IntrReturning) = 0;
+    STATE(IntrReturning) = 0;
 
     /* start an execution environment                                      */
     ExecBegin(frame);
@@ -309,21 +309,21 @@ ExecStatus IntrEnd (
         ExecEnd( 0UL );
 
         /* remember whether the interpreter interpreted a return-statement */
-        intrReturning = TLS(IntrReturning);
-        TLS(IntrReturning) = 0;
+        intrReturning = STATE(IntrReturning);
+        STATE(IntrReturning) = 0;
 
         /* must be back in immediate (non-ignoring, non-coding) mode       */
-        assert( TLS(IntrIgnoring) == 0 );
-        assert( TLS(IntrCoding)   == 0 );
+        assert( STATE(IntrIgnoring) == 0 );
+        assert( STATE(IntrCoding)   == 0 );
 
         /* and the stack must contain the result value (which may be void) */
-        assert( TLS(CountObj) == 1 );
-        TLS(IntrResult) = PopVoidObj();
+        assert( STATE(CountObj) == 1 );
+        STATE(IntrResult) = PopVoidObj();
 
         /* switch back to the old state                                    */
-        TLS(CountObj)  = INT_INTOBJ( ADDR_OBJ(TLS(IntrState))[3] );
-        TLS(StackObj)  = ADDR_OBJ(TLS(IntrState))[2];
-        TLS(IntrState) = ADDR_OBJ(TLS(IntrState))[1];
+        STATE(CountObj)  = INT_INTOBJ( ADDR_OBJ(STATE(IntrState))[3] );
+        STATE(StackObj)  = ADDR_OBJ(STATE(IntrState))[2];
+        STATE(IntrState) = ADDR_OBJ(STATE(IntrState))[1];
 
     }
 
@@ -334,23 +334,23 @@ ExecStatus IntrEnd (
         ExecEnd( 1UL );
 
         /* clean up the coder too                                          */
-        if ( TLS(IntrCoding) > 0 ) { CodeEnd( 1UL ); }
+        if ( STATE(IntrCoding) > 0 ) { CodeEnd( 1UL ); }
 
         /* remember that we had an error                                   */
         intrReturning = STATUS_ERROR;
-        TLS(IntrReturning) = 0;
+        STATE(IntrReturning) = 0;
 
         /* must be back in immediate (non-ignoring, non-coding) mode       */
-        TLS(IntrIgnoring) = 0;
-        TLS(IntrCoding)   = 0;
+        STATE(IntrIgnoring) = 0;
+        STATE(IntrCoding)   = 0;
 
         /* dummy result value (probably ignored)                           */
-        TLS(IntrResult) = (Obj)0;
+        STATE(IntrResult) = (Obj)0;
 
         /* switch back to the old state                                    */
-        TLS(CountObj)  = INT_INTOBJ( ADDR_OBJ(TLS(IntrState))[3] );
-        TLS(StackObj)  = ADDR_OBJ(TLS(IntrState))[2];
-        TLS(IntrState) = ADDR_OBJ(TLS(IntrState))[1];
+        STATE(CountObj)  = INT_INTOBJ( ADDR_OBJ(STATE(IntrState))[3] );
+        STATE(StackObj)  = ADDR_OBJ(STATE(IntrState))[2];
+        STATE(IntrState) = ADDR_OBJ(STATE(IntrState))[1];
 
     }
 
@@ -378,9 +378,9 @@ ExecStatus IntrEnd (
 void            IntrFuncCallBegin ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallBegin(); return; }
 
 }
 
@@ -406,9 +406,9 @@ void            IntrFuncCallEnd (
     UInt                i;              /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) {
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) {
       CodeFuncCallEnd( funccall, options, nr );
       return; }
 
@@ -461,7 +461,7 @@ void            IntrFuncCallEnd (
       else if ( 6 == nr ) { val = CALL_6ARGS( func, a1, a2, a3, a4, a5, a6 ); }
       else                { val = CALL_XARGS( func, args ); }
 
-      if (TLS(UserHasQuit) || TLS(UserHasQUIT)) {
+      if (STATE(UserHasQuit) || STATE(UserHasQUIT)) {
         /* the procedure must have called READ() and the user quit
            from a break loop inside it */
         ReadEvalError();
@@ -501,17 +501,17 @@ void            IntrFuncExprBegin (
     Int                 startLine)
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) {
-        TLS(IntrCoding)++;
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) {
+        STATE(IntrCoding)++;
         CodeFuncExprBegin( narg, nloc, nams, startLine );
         return;
     }
 
     /* switch to coding mode now                                           */
     CodeBegin();
-    TLS(IntrCoding) = 1;
+    STATE(IntrCoding) = 1;
 
     /* code a function expression                                          */
     CodeFuncExprBegin( narg, nloc, nams, startLine );
@@ -524,24 +524,24 @@ void            IntrFuncExprEnd (
     Obj                 func;           /* the function, result            */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 1 ) {
-        TLS(IntrCoding)--;
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 1 ) {
+        STATE(IntrCoding)--;
         CodeFuncExprEnd( nr, mapsto );
         return;
     }
 
     /* must be coding                                                      */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
 
     /* code a function expression                                          */
     CodeFuncExprEnd( nr, mapsto );
 
     /* switch back to immediate mode, get the function                     */
     CodeEnd(0);
-    TLS(IntrCoding) = 0;
-    func = TLS(CodeResult);
+    STATE(IntrCoding) = 0;
+    func = STATE(CodeResult);
 
     /* push the function                                                   */
     PushObj(func);
@@ -583,27 +583,27 @@ void            IntrFuncExprEnd (
 void            IntrIfBegin ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIfBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIfBegin(); return; }
 
 }
 
 void            IntrIfElif ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIfElif(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIfElif(); return; }
 
 }
 
 void            IntrIfElse ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIfElse(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIfElse(); return; }
 
 
     /* push 'true' (to execute body of else-branch)                        */
@@ -615,9 +615,9 @@ void            IntrIfBeginBody ( void )
     Obj                 cond;           /* value of condition              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIfBeginBody(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIfBeginBody(); return; }
 
 
     /* get and check the condition                                         */
@@ -630,7 +630,7 @@ void            IntrIfBeginBody ( void )
 
     /* if the condition is 'false', ignore the body                        */
     if ( cond == False ) {
-        TLS(IntrIgnoring) = 1;
+        STATE(IntrIgnoring) = 1;
     }
 }
 
@@ -640,14 +640,14 @@ void            IntrIfEndBody (
     UInt                i;              /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 1 ) { TLS(IntrIgnoring)--; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIfEndBody( nr ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 1 ) { STATE(IntrIgnoring)--; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIfEndBody( nr ); return; }
 
 
     /* if the condition was 'false', the body was ignored                  */
-    if ( TLS(IntrIgnoring) == 1 ) {
-        TLS(IntrIgnoring) = 0;
+    if ( STATE(IntrIgnoring) == 1 ) {
+        STATE(IntrIgnoring) = 0;
         return;
     }
 
@@ -657,21 +657,21 @@ void            IntrIfEndBody (
     }
 
     /* one branch of the if-statement was executed, ignore the others      */
-    TLS(IntrIgnoring) = 1;
+    STATE(IntrIgnoring) = 1;
 }
 
 void            IntrIfEnd (
     UInt                nr )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 1 ) { TLS(IntrIgnoring)--; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIfEnd( nr ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 1 ) { STATE(IntrIgnoring)--; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIfEnd( nr ); return; }
 
 
     /* if one branch was executed (ignoring the others)                    */
-    if ( TLS(IntrIgnoring) == 1 ) {
-        TLS(IntrIgnoring) = 0;
+    if ( STATE(IntrIgnoring) == 1 ) {
+        STATE(IntrIgnoring) = 0;
         PushVoidObj();
     }
 
@@ -718,14 +718,14 @@ void IntrForBegin ( void )
     Obj                 nams;           /* (empty) list of names           */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { TLS(IntrCoding)++; CodeForBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { STATE(IntrCoding)++; CodeForBegin(); return; }
 
 
     /* switch to coding mode now                                           */
     CodeBegin();
-    TLS(IntrCoding) = 1;
+    STATE(IntrCoding) = 1;
 
     /* code a function expression (with no arguments and locals)           */
     nams = NEW_PLIST( T_PLIST, 0 );
@@ -737,10 +737,10 @@ void IntrForBegin ( void )
 
        If we are not in a break loop, then this would be a waste of time and effort */
 
-    if (TLS(CountNams) > 0) {
-        GROW_PLIST(TLS(StackNams), ++TLS(CountNams));
-        SET_ELM_PLIST(TLS(StackNams), TLS(CountNams), nams);
-        SET_LEN_PLIST(TLS(StackNams), TLS(CountNams));
+    if (STATE(CountNams) > 0) {
+        GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
+        SET_ELM_PLIST(STATE(StackNams), STATE(CountNams), nams);
+        SET_LEN_PLIST(STATE(StackNams), STATE(CountNams));
     }
 
     CodeFuncExprBegin( 0, 0, nams, 0 );
@@ -752,24 +752,24 @@ void IntrForBegin ( void )
 void IntrForIn ( void )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeForIn();
 }
 
 void IntrForBeginBody ( void )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeForBeginBody();
 }
 
@@ -777,11 +777,11 @@ void IntrForEndBody (
     UInt                nr )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) != 0 ) {
+    if ( STATE(IntrCoding) != 0 ) {
         CodeForEndBody( nr );
     }
 }
@@ -791,26 +791,26 @@ void IntrForEnd ( void )
     Obj                 func;           /* the function, result            */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 1 ) { TLS(IntrCoding)--; CodeForEnd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 1 ) { STATE(IntrCoding)--; CodeForEnd(); return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
 
     /* code a function expression (with one statement in the body)         */
     CodeFuncExprEnd( 1UL, 0UL );
 
     /* switch back to immediate mode, get the function                     */
-    TLS(IntrCoding) = 0;
+    STATE(IntrCoding) = 0;
     CodeEnd( 0 );
     /* If we are in a break loop, then we will have created a "dummy" local
        variable names list to get the counts right. Remove it */
-    if (TLS(CountNams) > 0)
-      TLS(CountNams)--;
+    if (STATE(CountNams) > 0)
+      STATE(CountNams)--;
 
-    func = TLS(CodeResult);
+    func = STATE(CodeResult);
 
     /* call the function                                                   */
     CALL_0ARGS( func );
@@ -851,14 +851,14 @@ void            IntrWhileBegin ( void )
     Obj                 nams;           /* (empty) list of names           */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { TLS(IntrCoding)++; CodeWhileBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { STATE(IntrCoding)++; CodeWhileBegin(); return; }
 
 
     /* switch to coding mode now                                           */
     CodeBegin();
-    TLS(IntrCoding) = 1;
+    STATE(IntrCoding) = 1;
 
     /* code a function expression (with no arguments and locals)           */
     nams = NEW_PLIST( T_PLIST, 0 );
@@ -870,10 +870,10 @@ void            IntrWhileBegin ( void )
 
        If we are not in a break loop, then this would be a waste of time and effort */
 
-    if (TLS(CountNams) > 0) {
-        GROW_PLIST(TLS(StackNams), ++TLS(CountNams));
-        SET_ELM_PLIST(TLS(StackNams), TLS(CountNams), nams);
-        SET_LEN_PLIST(TLS(StackNams), TLS(CountNams));
+    if (STATE(CountNams) > 0) {
+        GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
+        SET_ELM_PLIST(STATE(StackNams), STATE(CountNams), nams);
+        SET_LEN_PLIST(STATE(StackNams), STATE(CountNams));
     }
 
     CodeFuncExprBegin( 0, 0, nams, 0 );
@@ -885,12 +885,12 @@ void            IntrWhileBegin ( void )
 void            IntrWhileBeginBody ( void )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeWhileBeginBody();
 }
 
@@ -898,11 +898,11 @@ void            IntrWhileEndBody (
     UInt                nr )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeWhileEndBody( nr );
 }
 
@@ -911,13 +911,13 @@ void            IntrWhileEnd ( void )
     Obj                 func;           /* the function, result            */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 1 ) { TLS(IntrCoding)--; CodeWhileEnd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 1 ) { STATE(IntrCoding)--; CodeWhileEnd(); return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeWhileEnd();
 
     /* code a function expression (with one statement in the body)         */
@@ -925,15 +925,15 @@ void            IntrWhileEnd ( void )
 
 
     /* switch back to immediate mode, get the function                     */
-    TLS(IntrCoding) = 0;
+    STATE(IntrCoding) = 0;
     CodeEnd( 0 );
 
     /* If we are in a break loop, then we will have created a "dummy" local
        variable names list to get the counts right. Remove it */
-    if (TLS(CountNams) > 0)
-      TLS(CountNams)--;
+    if (STATE(CountNams) > 0)
+      STATE(CountNams)--;
 
-    func = TLS(CodeResult);
+    func = STATE(CodeResult);
 
 
     /* call the function                                                   */
@@ -956,9 +956,9 @@ void            IntrWhileEnd ( void )
 void IntrQualifiedExprBegin(UInt qual) 
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeQualifiedExprBegin(qual); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeQualifiedExprBegin(qual); return; }
     PushObj(INTOBJ_INT(qual));
     return;
 }
@@ -966,9 +966,9 @@ void IntrQualifiedExprBegin(UInt qual)
 void IntrQualifiedExprEnd( void ) 
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)--; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeQualifiedExprEnd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)--; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeQualifiedExprEnd(); return; }
     return;
 }
 
@@ -1003,9 +1003,9 @@ void            IntrAtomicBegin ( void )
 {
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAtomicBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAtomicBegin(); return; }
     /* nothing to do here */
     return;
   
@@ -1016,16 +1016,16 @@ void            IntrAtomicBeginBody ( UInt nrexprs )
   Obj nams;
 
     /* ignore    or code                                                          */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { TLS(IntrCoding)++; CodeAtomicBeginBody(nrexprs); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { STATE(IntrCoding)++; CodeAtomicBeginBody(nrexprs); return; }
 
 
     /* leave the expressions and qualifiers on the stack, switch to coding to process the body
        of the Atomic expression */
     PushObj(INTOBJ_INT(nrexprs));
     CodeBegin();
-    TLS(IntrCoding) = 1;
+    STATE(IntrCoding) = 1;
     
     
     /* code a function expression (with no arguments and locals)           */
@@ -1039,14 +1039,14 @@ void            IntrAtomicBeginBody ( UInt nrexprs )
        
        If we are not in a break loop, then this would be a waste of time and effort */
     
-    if (TLS(CountNams) > 0)
+    if (STATE(CountNams) > 0)
       {
-	GROW_PLIST(TLS(StackNams), ++TLS(CountNams));
-	SET_ELM_PLIST(TLS(StackNams), TLS(CountNams), nams);
-	SET_LEN_PLIST(TLS(StackNams), TLS(CountNams));
+	GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
+	SET_ELM_PLIST(STATE(StackNams), STATE(CountNams), nams);
+	SET_LEN_PLIST(STATE(StackNams), STATE(CountNams));
       }
     
-    CodeFuncExprBegin( 0, 0, nams, TLS(Input)->number );
+    CodeFuncExprBegin( 0, 0, nams, STATE(Input)->number );
 }
 
 void            IntrAtomicEndBody (
@@ -1055,31 +1055,31 @@ void            IntrAtomicEndBody (
   Obj body;
 
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
-    if (TLS(IntrCoding) == 1) {
+    if (STATE(IntrCoding) == 1) {
       /* This is the case where we are really immediately interpreting an atomic
 	 statement, but we switched to coding to store the body until we have it all */
 
     /* If we are in a break loop, then we will have created a "dummy" local
        variable names list to get the counts right. Remove it */
-      if (TLS(CountNams) > 0)
-	TLS(CountNams)--;
+      if (STATE(CountNams) > 0)
+	STATE(CountNams)--;
 
       /* Code the body as a function expression */
       CodeFuncExprEnd( nrstats, 0UL );
     
 
       /* switch back to immediate mode, get the function                     */
-      TLS(IntrCoding) = 0;
+      STATE(IntrCoding) = 0;
       CodeEnd( 0 );
-      body = TLS(CodeResult);
+      body = STATE(CodeResult);
       PushObj(body);
       return;
     } else {
       
-        assert( TLS(IntrCoding) > 0 );
+        assert( STATE(IntrCoding) > 0 );
         CodeAtomicEndBody( nrstats );
     }
 }
@@ -1092,9 +1092,9 @@ void            IntrAtomicEnd ( void )
     UInt                i;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { TLS(IntrCoding)--; CodeAtomicEnd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { STATE(IntrCoding)--; CodeAtomicEnd(); return; }
     /* Now we need to recover the objects to lock, and go to work */
 
     body = PopObj();
@@ -1144,14 +1144,14 @@ void            IntrRepeatBegin ( void )
     Obj                 nams;           /* (empty) list of names           */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { TLS(IntrCoding)++; CodeRepeatBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { STATE(IntrCoding)++; CodeRepeatBegin(); return; }
 
 
     /* switch to coding mode now                                           */
     CodeBegin();
-    TLS(IntrCoding) = 1;
+    STATE(IntrCoding) = 1;
 
     /* code a function expression (with no arguments and locals)           */
     nams = NEW_PLIST( T_PLIST, 0 );
@@ -1163,13 +1163,13 @@ void            IntrRepeatBegin ( void )
 
        If we are not in a break loop, then this would be a waste of time and effort */
 
-    if (TLS(CountNams) > 0) {
-        GROW_PLIST(TLS(StackNams), ++TLS(CountNams));
-        SET_ELM_PLIST(TLS(StackNams), TLS(CountNams), nams);
-        SET_LEN_PLIST(TLS(StackNams), TLS(CountNams));
+    if (STATE(CountNams) > 0) {
+        GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
+        SET_ELM_PLIST(STATE(StackNams), STATE(CountNams), nams);
+        SET_LEN_PLIST(STATE(StackNams), STATE(CountNams));
     }
 
-    CodeFuncExprBegin( 0, 0, nams, TLS(Input)->number );
+    CodeFuncExprBegin( 0, 0, nams, STATE(Input)->number );
 
     /* code a repeat loop                                                  */
     CodeRepeatBegin();
@@ -1178,12 +1178,12 @@ void            IntrRepeatBegin ( void )
 void            IntrRepeatBeginBody ( void )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeRepeatBeginBody();
 }
 
@@ -1191,11 +1191,11 @@ void            IntrRepeatEndBody (
     UInt                nr )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeRepeatEndBody( nr );
 }
 
@@ -1204,26 +1204,26 @@ void            IntrRepeatEnd ( void )
     Obj                 func;           /* the function, result            */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 1 ) { TLS(IntrCoding)--; CodeRepeatEnd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 1 ) { STATE(IntrCoding)--; CodeRepeatEnd(); return; }
 
 
     /* otherwise must be coding                                            */
-    assert( TLS(IntrCoding) > 0 );
+    assert( STATE(IntrCoding) > 0 );
     CodeRepeatEnd();
 
     /* code a function expression (with one statement in the body)         */
     CodeFuncExprEnd( 1UL, 0UL );
 
     /* switch back to immediate mode, get the function                     */
-    TLS(IntrCoding) = 0;
+    STATE(IntrCoding) = 0;
     CodeEnd( 0 );
     /* If we are in a break loop, then we will have created a "dummy" local
        variable names list to get the counts right. Remove it */
-    if (TLS(CountNams) > 0)
-      TLS(CountNams)--;
-    func = TLS(CodeResult);
+    if (STATE(CountNams) > 0)
+      STATE(CountNams)--;
+    func = STATE(CodeResult);
 
     /* call the function                                                   */
     CALL_0ARGS( func );
@@ -1246,11 +1246,11 @@ void            IntrRepeatEnd ( void )
 void            IntrBreak ( void )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) == 0 )
+    if ( STATE(IntrCoding) == 0 )
       ErrorQuit("'break' statement can only appear inside a loop",0L,0L);
     else
       CodeBreak();
@@ -1271,11 +1271,11 @@ void            IntrBreak ( void )
 void            IntrContinue ( void )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) == 0 )
+    if ( STATE(IntrCoding) == 0 )
       ErrorQuit("'continue' statement can only appear inside a loop",0L,0L);
     else
       CodeContinue();
@@ -1296,19 +1296,19 @@ void            IntrReturnObj ( void )
     Obj                 val;            /* return value                    */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeReturnObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeReturnObj(); return; }
 
 
     /* empty the values stack and push the return value                    */
     val = PopObj();
-    SET_LEN_PLIST( TLS(StackObj), 0 );
-    TLS(CountObj) = 0;
+    SET_LEN_PLIST( STATE(StackObj), 0 );
+    STATE(CountObj) = 0;
     PushObj( val );
 
     /* indicate that a return-value-statement was interpreted              */
-    TLS(IntrReturning) = 1;
+    STATE(IntrReturning) = 1;
 }
 
 
@@ -1322,18 +1322,18 @@ void            IntrReturnObj ( void )
 void            IntrReturnVoid ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeReturnVoid(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeReturnVoid(); return; }
 
 
     /* empty the values stack and push the void value                      */
-    SET_LEN_PLIST( TLS(StackObj), 0 );
-    TLS(CountObj) = 0;
+    SET_LEN_PLIST( STATE(StackObj), 0 );
+    STATE(CountObj) = 0;
     PushVoidObj();
 
     /* indicate that a return-void-statement was interpreted               */
-    TLS(IntrReturning) = 2;
+    STATE(IntrReturning) = 2;
 }
 
 
@@ -1347,23 +1347,23 @@ void            IntrReturnVoid ( void )
 void            IntrQuit ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* 'quit' is not allowed in functions (by the reader)                  */
-    /* assert( TLS(IntrCoding) == 0 ); */
-    if ( TLS(IntrCoding) > 0 ) {
+    /* assert( STATE(IntrCoding) == 0 ); */
+    if ( STATE(IntrCoding) > 0 ) {
       SyntaxError("'quit;' cannot be used in this context");
     }
 
     /* empty the values stack and push the void value                      */
-    SET_LEN_PLIST( TLS(StackObj), 0 );
-    TLS(CountObj) = 0;
+    SET_LEN_PLIST( STATE(StackObj), 0 );
+    STATE(CountObj) = 0;
     PushVoidObj();
 
 
     /* indicate that a quit-statement was interpreted                      */
-    TLS(IntrReturning) = STATUS_QUIT;
+    STATE(IntrReturning) = STATUS_QUIT;
 }
 
 /****************************************************************************
@@ -1376,20 +1376,20 @@ void            IntrQuit ( void )
 void            IntrQUIT ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* 'quit' is not allowed in functions (by the reader)                  */
-    assert( TLS(IntrCoding) == 0 );
+    assert( STATE(IntrCoding) == 0 );
 
     /* empty the values stack and push the void value                      */
-    SET_LEN_PLIST( TLS(StackObj), 0 );
-    TLS(CountObj) = 0;
+    SET_LEN_PLIST( STATE(StackObj), 0 );
+    STATE(CountObj) = 0;
     PushVoidObj();
 
 
     /* indicate that a quit-statement was interpreted                      */
-    TLS(IntrReturning) = STATUS_QQUIT;
+    STATE(IntrReturning) = STATUS_QQUIT;
 }
 
 
@@ -1411,9 +1411,9 @@ void            IntrOrL ( void )
     Obj                 opL;            /* value of left operand           */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeOrL(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeOrL(); return; }
 
 
     /* if the left operand is 'true', ignore the right operand             */
@@ -1421,7 +1421,7 @@ void            IntrOrL ( void )
     PushObj( opL );
     if ( opL == True ) {
         PushObj( opL );
-        TLS(IntrIgnoring) = 1;
+        STATE(IntrIgnoring) = 1;
     }
 }
 
@@ -1431,13 +1431,13 @@ void            IntrOr ( void )
     Obj                 opR;            /* value of right operand          */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 1 ) { TLS(IntrIgnoring)--; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeOr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 1 ) { STATE(IntrIgnoring)--; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeOr(); return; }
 
 
     /* stop ignoring things now                                            */
-    TLS(IntrIgnoring) = 0;
+    STATE(IntrIgnoring) = 0;
 
     /* get the operands                                                    */
     opR = PopObj();
@@ -1485,9 +1485,9 @@ void            IntrAndL ( void )
     Obj                 opL;            /* value of left operand           */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAndL(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAndL(); return; }
 
 
     /* if the left operand is 'false', ignore the right operand            */
@@ -1495,7 +1495,7 @@ void            IntrAndL ( void )
     PushObj( opL );
     if ( opL == False ) {
         PushObj( opL );
-        TLS(IntrIgnoring) = 1;
+        STATE(IntrIgnoring) = 1;
     }
 }
 
@@ -1509,13 +1509,13 @@ void            IntrAnd ( void )
     Obj                 opR;            /* value of right operand          */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 1 ) { TLS(IntrIgnoring)--; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAnd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 1 ) { STATE(IntrIgnoring)--; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAnd(); return; }
 
 
     /* stop ignoring things now                                            */
-    TLS(IntrIgnoring) = 0;
+    STATE(IntrIgnoring) = 0;
 
     /* get the operands                                                    */
     opR = PopObj();
@@ -1572,8 +1572,8 @@ void            IntrNot ( void )
     Obj                 op;             /* operand                         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrIgnoring) > 0 ) { return; }
-    if ( TLS(IntrCoding)   > 0 ) { CodeNot(); return; }
+    if ( STATE(IntrIgnoring) > 0 ) { return; }
+    if ( STATE(IntrCoding)   > 0 ) { CodeNot(); return; }
 
 
     /* get and check the operand                                           */
@@ -1626,9 +1626,9 @@ void            IntrEq ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeEq(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeEq(); return; }
 
 
     /* get the operands                                                    */
@@ -1645,9 +1645,9 @@ void            IntrEq ( void )
 void            IntrNe ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeNe(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeNe(); return; }
 
 
     /* '<left> <> <right>' is 'not <left> = <right>'                       */
@@ -1662,9 +1662,9 @@ void            IntrLt ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeLt(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeLt(); return; }
 
 
     /* get the operands                                                    */
@@ -1681,9 +1681,9 @@ void            IntrLt ( void )
 void            IntrGe ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeGe(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeGe(); return; }
 
 
     /* '<left> >= <right>' is 'not <left> < <right>'                       */
@@ -1694,9 +1694,9 @@ void            IntrGe ( void )
 void            IntrGt ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeGt(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeGt(); return; }
 
 
     /* '<left> > <right>' is '<right> < <left>'                            */
@@ -1707,9 +1707,9 @@ void            IntrGt ( void )
 void            IntrLe ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeLe(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeLe(); return; }
 
 
     /* '<left> <= <right>' is 'not <right> < <left>'                       */
@@ -1733,9 +1733,9 @@ void            IntrIn ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIn(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIn(); return; }
 
 
     /* get the operands                                                    */
@@ -1772,9 +1772,9 @@ void            IntrSum ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeSum(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeSum(); return; }
 
 
     /* get the operands                                                    */
@@ -1794,9 +1794,9 @@ void            IntrAInv ( void )
     Obj                 opL;            /* left operand                    */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAInv(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAInv(); return; }
 
 
     /* get the operand                                                     */
@@ -1816,9 +1816,9 @@ void            IntrDiff ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeDiff(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeDiff(); return; }
 
 
     /* get the operands                                                    */
@@ -1839,9 +1839,9 @@ void            IntrProd ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeProd(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeProd(); return; }
 
 
     /* get the operands                                                    */
@@ -1861,9 +1861,9 @@ void            IntrInv ( void )
     Obj                 opL;            /* left operand                    */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeInv(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeInv(); return; }
 
 
     /* get the operand                                                     */
@@ -1883,9 +1883,9 @@ void            IntrQuo ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeQuo(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeQuo(); return; }
 
 
     /* get the operands                                                    */
@@ -1906,9 +1906,9 @@ void            IntrMod ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeMod(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeMod(); return; }
 
 
     /* get the operands                                                    */
@@ -1929,9 +1929,9 @@ void            IntrPow ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodePow(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodePow(); return; }
 
 
     /* get the operands                                                    */
@@ -1964,9 +1964,9 @@ void            IntrIntExpr (
     UInt                i;              /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIntExpr( str ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIntExpr( str ); return; }
 
     
     /* get the signs, if any                                                */
@@ -2023,9 +2023,9 @@ void            IntrLongIntExpr (
 {
     Obj                 ret;            /* integer encoded as GAP obj      */
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeLongIntExpr( string ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeLongIntExpr( string ); return; }
 
     ret = IntStringInternal(string);
     
@@ -2069,9 +2069,9 @@ void            IntrFloatExpr (
     Obj                 val;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) {  CodeFloatExpr( str );   return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) {  CodeFloatExpr( str );   return; }
 
     C_NEW_STRING_DYN(val, str);
     PushObj(ConvertFloatLiteralEager(val));
@@ -2089,9 +2089,9 @@ void            IntrLongFloatExpr (
     Obj               string )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeLongFloatExpr( string );  return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeLongFloatExpr( string );  return; }
 
     PushObj(ConvertFloatLiteralEager(string));
 }
@@ -2105,9 +2105,9 @@ void            IntrLongFloatExpr (
 void            IntrTrueExpr ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeTrueExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeTrueExpr(); return; }
 
 
     /* push the value                                                      */
@@ -2124,9 +2124,9 @@ void            IntrTrueExpr ( void )
 void            IntrFalseExpr ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFalseExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFalseExpr(); return; }
 
 
     /* push the value                                                      */
@@ -2145,9 +2145,9 @@ void            IntrCharExpr (
     Char                chr )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeCharExpr( chr ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeCharExpr( chr ); return; }
 
 
     /* push the value                                                      */
@@ -2172,9 +2172,9 @@ void            IntrPermCycle (
     UInt                j, k;           /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodePermCycle(nrx,nrc); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodePermCycle(nrx,nrc); return; }
 
 
     /* get the permutation (allocate for the first cycle)                  */
@@ -2184,8 +2184,8 @@ void            IntrPermCycle (
         ptr4 = ADDR_PERM4( perm );
     }
     else {
-        m = INT_INTOBJ( ELM_LIST( TLS(StackObj), TLS(CountObj) - nrx ) );
-        perm = ELM_LIST( TLS(StackObj), TLS(CountObj) - nrx - 1 );
+        m = INT_INTOBJ( ELM_LIST( STATE(StackObj), STATE(CountObj) - nrx ) );
+        perm = ELM_LIST( STATE(StackObj), STATE(CountObj) - nrx - 1 );
         ptr4 = ADDR_PERM4( perm );
     }
 
@@ -2256,9 +2256,9 @@ void            IntrPerm (
     UInt                k;              /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodePerm(nrc); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodePerm(nrc); return; }
 
 
     /* special case for identity permutation                               */
@@ -2310,9 +2310,9 @@ void            IntrListExprBegin (
     Obj                 old;            /* old value of '~'                */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeListExprBegin( top ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeListExprBegin( top ); return; }
 
 
     /* allocate the new list                                               */
@@ -2336,9 +2336,9 @@ void            IntrListExprBeginElm (
     UInt                pos )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeListExprBeginElm( pos ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeListExprBeginElm( pos ); return; }
 
 
     /* remember this position on the values stack                          */
@@ -2353,9 +2353,9 @@ void            IntrListExprEndElm ( void )
     Obj                 val;            /* value to assign into list       */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeListExprEndElm(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeListExprEndElm(); return; }
 
 
     /* get the value                                                       */
@@ -2389,9 +2389,9 @@ void            IntrListExprEnd (
     Obj                 val;            /* temporary value                 */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeListExprEnd(nr,range,top,tilde); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeListExprEnd(nr,range,top,tilde); return; }
 
 
     /* if this was a top level expression, restore the value of '~'        */
@@ -2500,9 +2500,9 @@ void           IntrStringExpr (
     Obj               string )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeStringExpr( string ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeStringExpr( string ); return; }
 
 
     /* push the string, already newly created                              */
@@ -2524,9 +2524,9 @@ void            IntrRecExprBegin (
     Obj                 old;            /* old value of '~'                */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeRecExprBegin( top ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeRecExprBegin( top ); return; }
 
 
     /* allocate the new record                                             */
@@ -2549,9 +2549,9 @@ void            IntrRecExprBeginElmName (
     UInt                rnam )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeRecExprBeginElmName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeRecExprBeginElmName( rnam ); return; }
 
 
     /* remember the name on the values stack                               */
@@ -2563,9 +2563,9 @@ void            IntrRecExprBeginElmExpr ( void )
     UInt                rnam;           /* record name                     */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeRecExprBeginElmExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeRecExprBeginElmExpr(); return; }
 
 
     /* convert the expression to a record name                             */
@@ -2582,9 +2582,9 @@ void            IntrRecExprEndElm ( void )
     Obj                 val;            /* value of record element         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeRecExprEndElm(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeRecExprEndElm(); return; }
 
 
     /* get the value                                                       */
@@ -2612,9 +2612,9 @@ void            IntrRecExprEnd (
     Obj                 old;            /* old value of '~'                */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeRecExprEnd(nr,top,tilde); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeRecExprEnd(nr,top,tilde); return; }
 
 
     /* if this was a top level expression, restore the value of '~'        */
@@ -2643,9 +2643,9 @@ void            IntrFuncCallOptionsBegin ( void )
     Obj                 record;         /* new record                      */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallOptionsBegin( ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsBegin( ); return; }
 
 
     /* allocate the new record                                             */
@@ -2658,9 +2658,9 @@ void            IntrFuncCallOptionsBeginElmName (
     UInt                rnam )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallOptionsBeginElmName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsBeginElmName( rnam ); return; }
 
 
     /* remember the name on the values stack                               */
@@ -2672,9 +2672,9 @@ void            IntrFuncCallOptionsBeginElmExpr ( void )
     UInt                rnam;           /* record name                     */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallOptionsBeginElmExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsBeginElmExpr(); return; }
 
 
     /* convert the expression to a record name                             */
@@ -2691,9 +2691,9 @@ void            IntrFuncCallOptionsEndElm ( void )
     Obj                 val;            /* value of record element         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallOptionsEndElm(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsEndElm(); return; }
 
 
     /* get the value                                                       */
@@ -2719,9 +2719,9 @@ void            IntrFuncCallOptionsEndElmEmpty ( void )
     Obj                 val;            /* value of record element         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallOptionsEndElmEmpty(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsEndElmEmpty(); return; }
 
 
     /* get the value                                                       */
@@ -2743,9 +2743,9 @@ void            IntrFuncCallOptionsEndElmEmpty ( void )
 void            IntrFuncCallOptionsEnd ( UInt nr )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeFuncCallOptionsEnd(nr); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsEnd(nr); return; }
 
 
 }
@@ -2760,11 +2760,11 @@ void            IntrAssLVar (
 {
   Obj val;
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) > 0 )
+    if ( STATE(IntrCoding) > 0 )
       CodeAssLVar( lvar );
 
     /* Or in the break loop */
@@ -2779,11 +2779,11 @@ void            IntrUnbLVar (
     UInt                lvar )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) > 0 )
+    if ( STATE(IntrCoding) > 0 )
       CodeUnbLVar( lvar );
 
     /* or in the break loop */
@@ -2803,11 +2803,11 @@ void            IntrRefLVar (
 {
   Obj val;
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) > 0 )
+    if ( STATE(IntrCoding) > 0 )
       CodeRefLVar( lvar );
 
     /* or in the break loop */
@@ -2828,11 +2828,11 @@ void            IntrIsbLVar (
     UInt                lvar )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if( TLS(IntrCoding) > 0 )
+    if( STATE(IntrCoding) > 0 )
       CodeIsbLVar( lvar );
 
     /* or debugging */
@@ -2851,11 +2851,11 @@ void            IntrAssHVar (
 {
   Obj val;
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if( TLS(IntrCoding) > 0 )
+    if( STATE(IntrCoding) > 0 )
       CodeAssHVar( hvar );
     /* Or in the break loop */
     else {
@@ -2869,11 +2869,11 @@ void            IntrUnbHVar (
     UInt                hvar )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if ( TLS(IntrCoding) > 0 )
+    if ( STATE(IntrCoding) > 0 )
       CodeUnbHVar( hvar );
     /* or debugging */
     else {
@@ -2892,11 +2892,11 @@ void            IntrRefHVar (
 {
   Obj val;
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if( TLS(IntrCoding) > 0 )
+    if( STATE(IntrCoding) > 0 )
       CodeRefHVar( hvar );
     /* or debugging */
     else {
@@ -2915,11 +2915,11 @@ void            IntrIsbHVar (
     UInt                hvar )
 {
     /* ignore                                                              */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    if( TLS(IntrCoding) > 0 )
+    if( STATE(IntrCoding) > 0 )
       CodeIsbHVar( hvar );
     /* or debugging */
     else
@@ -2941,12 +2941,12 @@ void            IntrAssDVar (
     Obj                 currLVars;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    /* if ( TLS(IntrCoding)    > 0 ) { CodeAssDVar( gvar ); return; } */
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    /* if ( STATE(IntrCoding)    > 0 ) { CodeAssDVar( gvar ); return; } */
 
 
-    if ( TLS(IntrCoding) > 0 ) {
+    if ( STATE(IntrCoding) > 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
                    dvar >> 10, dvar & 0x3FF );
     }
@@ -2956,10 +2956,10 @@ void            IntrAssDVar (
     rhs = PopObj();
 
     /* assign the right hand side                                          */
-    currLVars = TLS(CurrLVars);
-    SWITCH_TO_OLD_LVARS( TLS(ErrorLVars) );
+    currLVars = STATE(CurrLVars);
+    SWITCH_TO_OLD_LVARS( STATE(ErrorLVars) );
     while (depth--)
-      SWITCH_TO_OLD_LVARS( PARENT_LVARS(TLS(CurrLVars)) );
+      SWITCH_TO_OLD_LVARS( PARENT_LVARS(STATE(CurrLVars)) );
     ASS_HVAR( dvar, rhs );
     SWITCH_TO_OLD_LVARS( currLVars  );
 
@@ -2974,21 +2974,21 @@ void            IntrUnbDVar (
     Obj                 currLVars;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    /* if ( TLS(IntrCoding)    > 0 ) { CodeUnbGVar( gvar ); return; } */
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    /* if ( STATE(IntrCoding)    > 0 ) { CodeUnbGVar( gvar ); return; } */
 
 
-    if ( TLS(IntrCoding) > 0 ) {
+    if ( STATE(IntrCoding) > 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
                    dvar >> 10, dvar & 0x3FF );
     }
 
     /* assign the right hand side                                          */
-    currLVars = TLS(CurrLVars);
-    SWITCH_TO_OLD_LVARS( TLS(ErrorLVars) );
+    currLVars = STATE(CurrLVars);
+    SWITCH_TO_OLD_LVARS( STATE(ErrorLVars) );
     while (depth--)
-      SWITCH_TO_OLD_LVARS( PARENT_LVARS(TLS(CurrLVars)) );
+      SWITCH_TO_OLD_LVARS( PARENT_LVARS(STATE(CurrLVars)) );
     ASS_HVAR( dvar, (Obj)0 );
     SWITCH_TO_OLD_LVARS( currLVars  );
 
@@ -3009,21 +3009,21 @@ void            IntrRefDVar (
     Obj                 currLVars;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    /* if ( TLS(IntrCoding)    > 0 ) { CodeRefGVar( gvar ); return; } */
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    /* if ( STATE(IntrCoding)    > 0 ) { CodeRefGVar( gvar ); return; } */
 
 
-    if ( TLS(IntrCoding) > 0 ) {
+    if ( STATE(IntrCoding) > 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
                    dvar >> 10, dvar & 0x3FF );
     }
 
     /* get and check the value                                             */
-    currLVars = TLS(CurrLVars);
-    SWITCH_TO_OLD_LVARS( TLS(ErrorLVars) );
+    currLVars = STATE(CurrLVars);
+    SWITCH_TO_OLD_LVARS( STATE(ErrorLVars) );
     while (depth--)
-      SWITCH_TO_OLD_LVARS( PARENT_LVARS(TLS(CurrLVars)) );
+      SWITCH_TO_OLD_LVARS( PARENT_LVARS(STATE(CurrLVars)) );
     val = OBJ_HVAR( dvar );
     SWITCH_TO_OLD_LVARS( currLVars  );
     if ( val == 0 ) {
@@ -3043,16 +3043,16 @@ void            IntrIsbDVar (
     Obj                 currLVars;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    /* if ( TLS(IntrCoding)    > 0 ) { CodeIsbGVar( gvar ); return; } */
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    /* if ( STATE(IntrCoding)    > 0 ) { CodeIsbGVar( gvar ); return; } */
 
 
     /* get the value                                                       */
-    currLVars = TLS(CurrLVars);
-    SWITCH_TO_OLD_LVARS( TLS(ErrorLVars) );
+    currLVars = STATE(CurrLVars);
+    SWITCH_TO_OLD_LVARS( STATE(ErrorLVars) );
     while (depth--)
-      SWITCH_TO_OLD_LVARS( PARENT_LVARS(TLS(CurrLVars)) );
+      SWITCH_TO_OLD_LVARS( PARENT_LVARS(STATE(CurrLVars)) );
     val = OBJ_HVAR( dvar );
     SWITCH_TO_OLD_LVARS( currLVars  );
 
@@ -3071,9 +3071,9 @@ void            IntrAssGVar (
     Obj                 rhs;            /* right hand side                 */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssGVar( gvar ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssGVar( gvar ); return; }
 
 
     /* get the right hand side                                             */
@@ -3090,9 +3090,9 @@ void            IntrUnbGVar (
     UInt                gvar )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbGVar( gvar ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbGVar( gvar ); return; }
 
 
     /* assign the right hand side                                          */
@@ -3113,9 +3113,9 @@ void            IntrRefGVar (
     Obj                 val;            /* value, result                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeRefGVar( gvar ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeRefGVar( gvar ); return; }
 
 
     /* get and check the value                                             */
@@ -3135,9 +3135,9 @@ void            IntrIsbGVar (
     Obj                 val;            /* value, result                   */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbGVar( gvar ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbGVar( gvar ); return; }
 
 
     /* get the value                                                       */
@@ -3165,9 +3165,9 @@ void            IntrAssList ( Int narg )
     Int i;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssList( narg); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssList( narg); return; }
 
     /* get the right hand side                                             */
     rhs = PopObj();
@@ -3220,9 +3220,9 @@ void            IntrAsssList ( void )
     Obj                 rhss;           /* right hand sides                */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAsssList(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAsssList(); return; }
 
 
     /* get the right hand sides                                            */
@@ -3267,9 +3267,9 @@ void            IntrAssListLevel (
     Int i;
     
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssListLevel( narg, level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssListLevel( narg, level ); return; }
 
     /* get right hand sides (checking is done by 'AssListLevel')           */
     rhss = PopObj();
@@ -3302,9 +3302,9 @@ void            IntrAsssListLevel (
     Obj                 rhss;           /* right hand sides, right operand */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAsssListLevel( level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAsssListLevel( level ); return; }
 
 
     /* get right hand sides (checking is done by 'AsssListLevel')          */
@@ -3337,9 +3337,9 @@ void            IntrUnbList ( Int narg )
     Int                 i;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbList( narg); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbList( narg); return; }
 
     if (narg == 1) {
       /* get and check the position                                          */
@@ -3390,9 +3390,9 @@ void            IntrElmList ( Int narg )
     Obj                 pos2;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmList( narg ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmList( narg ); return; }
 
     if (narg <= 0)
       SyntaxError("This should never happen");
@@ -3442,9 +3442,9 @@ void            IntrElmsList ( void )
     Obj                 poss;           /* positions, right operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmsList(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmsList(); return; }
 
 
     /* get and check the positions                                         */
@@ -3474,9 +3474,9 @@ void            IntrElmListLevel ( Int narg,
     Int i;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmListLevel( narg, level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmListLevel( narg, level ); return; }
 
     /* get the positions */
     ixs = NEW_PLIST(T_PLIST, narg);
@@ -3513,9 +3513,9 @@ void            IntrElmsListLevel (
     Obj                 poss;           /* positions, right operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmsListLevel( level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmsListLevel( level ); return; }
 
 
     /* get and check the positions                                         */
@@ -3546,9 +3546,9 @@ void            IntrIsbList ( Int narg )
     Int i;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbList(narg); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbList(narg); return; }
 
     if (narg == 1) {
       /* get and check the position                                          */
@@ -3593,9 +3593,9 @@ void            IntrAssRecName (
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssRecName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssRecName( rnam ); return; }
 
 
     /* get the right hand side                                             */
@@ -3618,9 +3618,9 @@ void            IntrAssRecExpr ( void )
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssRecExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssRecExpr(); return; }
 
 
     /* get the right hand side                                             */
@@ -3645,9 +3645,9 @@ void            IntrUnbRecName (
     Obj                 record;         /* record, left operand            */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbRecName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbRecName( rnam ); return; }
 
 
     /* get the record (checking is done by 'UNB_REC')                      */
@@ -3666,9 +3666,9 @@ void            IntrUnbRecExpr ( void )
     UInt                rnam;           /* name, left operand              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbRecExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbRecExpr(); return; }
 
 
     /* get the name and convert it to a record name                        */
@@ -3697,9 +3697,9 @@ void            IntrElmRecName (
     Obj                 record;         /* the record, left operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmRecName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmRecName( rnam ); return; }
 
 
     /* get the record (checking is done by 'ELM_REC')                      */
@@ -3719,9 +3719,9 @@ void            IntrElmRecExpr ( void )
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmRecExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmRecExpr(); return; }
 
 
     /* get the name and convert it to a record name                        */
@@ -3744,9 +3744,9 @@ void            IntrIsbRecName (
     Obj                 record;         /* the record, left operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbRecName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbRecName( rnam ); return; }
 
 
     /* get the record (checking is done by 'ISB_REC')                      */
@@ -3766,9 +3766,9 @@ void            IntrIsbRecExpr ( void )
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbRecExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbRecExpr(); return; }
 
 
     /* get the name and convert it to a record name                        */
@@ -3800,9 +3800,9 @@ void            IntrAssPosObj ( void )
     Obj                 rhs;            /* right hand side                 */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssPosObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssPosObj(); return; }
 
 
     /* get the right hand side                                             */
@@ -3843,9 +3843,9 @@ void            IntrAsssPosObj ( void )
     Obj                 rhss;           /* right hand sides                */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAsssPosObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAsssPosObj(); return; }
 
 
     /* get the right hand sides                                            */
@@ -3891,9 +3891,9 @@ void            IntrAssPosObjLevel (
     Obj                 rhss;           /* right hand sides, right operand */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssPosObjLevel( level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssPosObjLevel( level ); return; }
 
 
     /* get right hand sides (checking is done by 'AssPosObjLevel')           */
@@ -3923,9 +3923,9 @@ void            IntrAsssPosObjLevel (
     Obj                 rhss;           /* right hand sides, right operand */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAsssPosObjLevel( level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAsssPosObjLevel( level ); return; }
 
 
     /* get right hand sides (checking is done by 'AsssPosObjLevel')          */
@@ -3955,9 +3955,9 @@ void            IntrUnbPosObj ( void )
     Int                 p;              /* position, as a C integer        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbPosObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbPosObj(); return; }
 
 
     /* get and check the position                                          */
@@ -4002,9 +4002,9 @@ void            IntrElmPosObj ( void )
     Int                 p;              /* position, as C integer          */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmPosObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmPosObj(); return; }
 
 
     /* get and check the position                                          */
@@ -4048,9 +4048,9 @@ void            IntrElmsPosObj ( void )
     Obj                 poss;           /* positions, right operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmsPosObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmsPosObj(); return; }
 
 
     /* get and check the positions                                         */
@@ -4084,9 +4084,9 @@ void            IntrElmPosObjLevel (
     Obj                 pos;            /* position, right operand         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmPosObjLevel( level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmPosObjLevel( level ); return; }
 
 
     /* get and check the position                                          */
@@ -4117,9 +4117,9 @@ void            IntrElmsPosObjLevel (
     Obj                 poss;           /* positions, right operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmsPosObjLevel( level ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmsPosObjLevel( level ); return; }
 
 
     /* get and check the positions                                         */
@@ -4151,9 +4151,9 @@ void            IntrIsbPosObj ( void )
     Int                 p;              /* position, as C integer          */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbPosObj(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbPosObj(); return; }
 
 
     /* get and check the position                                          */
@@ -4194,9 +4194,9 @@ void            IntrAssComObjName (
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssComObjName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssComObjName( rnam ); return; }
 
 
     /* get the right hand side                                             */
@@ -4226,9 +4226,9 @@ void            IntrAssComObjExpr ( void )
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssComObjExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssComObjExpr(); return; }
 
 
     /* get the right hand side                                             */
@@ -4260,9 +4260,9 @@ void            IntrUnbComObjName (
     Obj                 record;         /* record, left operand            */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbComObjName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbComObjName( rnam ); return; }
 
 
     /* get the record (checking is done by 'UNB_REC')                      */
@@ -4288,9 +4288,9 @@ void            IntrUnbComObjExpr ( void )
     UInt                rnam;           /* name, left operand              */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeUnbComObjExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeUnbComObjExpr(); return; }
 
 
     /* get the name and convert it to a record name                        */
@@ -4326,9 +4326,9 @@ void            IntrElmComObjName (
     Obj                 record;         /* the record, left operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmComObjName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmComObjName( rnam ); return; }
 
 
     /* get the record (checking is done by 'ELM_REC')                      */
@@ -4356,9 +4356,9 @@ void            IntrElmComObjExpr ( void )
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeElmComObjExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeElmComObjExpr(); return; }
 
 
     /* get the name and convert it to a record name                        */
@@ -4388,9 +4388,9 @@ void            IntrIsbComObjName (
     Obj                 record;         /* the record, left operand        */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbComObjName( rnam ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbComObjName( rnam ); return; }
 
 
     /* get the record (checking is done by 'ISB_REC')                      */
@@ -4417,9 +4417,9 @@ void            IntrIsbComObjExpr ( void )
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeIsbComObjExpr(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeIsbComObjExpr(); return; }
 
 
     /* get the name and convert it to a record name                        */
@@ -4451,9 +4451,9 @@ void            IntrIsbComObjExpr ( void )
 void             IntrEmpty ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeEmpty(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeEmpty(); return; }
 
 
     /* interpret */
@@ -4487,9 +4487,9 @@ void             IntrEmpty ( void )
 void            IntrInfoBegin( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeInfoBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeInfoBegin(); return; }
 
 }
 
@@ -4504,16 +4504,16 @@ void            IntrInfoMiddle( void )
                         gets printed or not */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeInfoMiddle(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeInfoMiddle(); return; }
 
 
     level = PopObj();
     selectors = PopObj();
     selected = CALL_2ARGS( InfoDecision, selectors, level);
     if (selected == False)
-      TLS(IntrIgnoring) = 1;
+      STATE(IntrIgnoring) = 1;
     return;
 }
 
@@ -4525,13 +4525,13 @@ void            IntrInfoEnd( UInt narg )
      Obj args;    /* gathers up the arguments to be printed */
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeInfoEnd( narg ); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeInfoEnd( narg ); return; }
 
 
     /* print if necessary                                                  */
-    if ( TLS(IntrIgnoring)  > 0 )
-      TLS(IntrIgnoring)--;
+    if ( STATE(IntrIgnoring)  > 0 )
+      STATE(IntrIgnoring)--;
     else
       {
         args = NEW_PLIST( T_PLIST, narg);
@@ -4545,7 +4545,7 @@ void            IntrInfoEnd( UInt narg )
 
     /* If we actually executed this statement at all
        (even if we printed nothing) then return a Void */
-    if (TLS(IntrIgnoring) == 0)
+    if (STATE(IntrIgnoring) == 0)
       PushVoidObj();
     return;
 }
@@ -4570,7 +4570,7 @@ void            IntrInfoEnd( UInt narg )
 *V  CurrentAssertionLevel  . .  . . . . . . . . . . . .  copy of GAP variable
 **
 **
-**  TLS(IntrIgnoring) is increased by (a total of) 2 if an assertion either is not
+**  STATE(IntrIgnoring) is increased by (a total of) 2 if an assertion either is not
 **  tested (because we were Ignoring when we got to it, or due to level)
 **  or is tested and passes
 */
@@ -4580,9 +4580,9 @@ Obj              CurrentAssertionLevel;
 void              IntrAssertBegin ( void )
 {
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssertBegin(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssertBegin(); return; }
 
 }
 
@@ -4592,15 +4592,15 @@ void             IntrAssertAfterLevel ( void )
   Obj level;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssertAfterLevel(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssertAfterLevel(); return; }
 
 
     level = PopObj();
 
     if (LT( CurrentAssertionLevel, level))
-           TLS(IntrIgnoring) = 1;
+           STATE(IntrIgnoring) = 1;
 }
 
 void             IntrAssertAfterCondition ( void )
@@ -4608,15 +4608,15 @@ void             IntrAssertAfterCondition ( void )
   Obj condition;
 
     /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrIgnoring)  > 0 ) { TLS(IntrIgnoring)++; return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssertAfterCondition(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssertAfterCondition(); return; }
 
 
     condition = PopObj();
 
     if (condition == True)
-      TLS(IntrIgnoring)= 2;
+      STATE(IntrIgnoring)= 2;
     else if (condition != False)
         ErrorQuit(
             "<condition> in Assert must yield 'true' or 'false' (not a %s)",
@@ -4626,16 +4626,16 @@ void             IntrAssertAfterCondition ( void )
 void             IntrAssertEnd2Args ( void )
 {
       /* ignore or code                                                      */
-    if ( TLS(IntrReturning) > 0 ) { return; }
-    if ( TLS(IntrCoding)    > 0 ) { CodeAssertEnd2Args(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeAssertEnd2Args(); return; }
 
 
-    if ( TLS(IntrIgnoring)  == 0 )
+    if ( STATE(IntrIgnoring)  == 0 )
       ErrorQuit("Assertion Failure", 0, 0);
     else
-      TLS(IntrIgnoring) -= 2;
+      STATE(IntrIgnoring) -= 2;
 
-    if (TLS(IntrIgnoring) == 0)
+    if (STATE(IntrIgnoring) == 0)
       PushVoidObj();
     return;
 }
@@ -4645,11 +4645,11 @@ void             IntrAssertEnd3Args ( void )
 {
   Obj message;
   /* ignore or code                                                      */
-  if ( TLS(IntrReturning) > 0 ) { return; }
-  if ( TLS(IntrCoding)    > 0 ) { CodeAssertEnd3Args(); return; }
+  if ( STATE(IntrReturning) > 0 ) { return; }
+  if ( STATE(IntrCoding)    > 0 ) { CodeAssertEnd3Args(); return; }
 
 
-  if ( TLS(IntrIgnoring)  == 0 ) {
+  if ( STATE(IntrIgnoring)  == 0 ) {
       message = PopVoidObj();
       if (message != (Obj) 0 ) {
           if (IS_STRING_REP( message ))
@@ -4658,9 +4658,9 @@ void             IntrAssertEnd3Args ( void )
             PrintObj(message);
       }
   } else
-      TLS(IntrIgnoring) -= 2;
+      STATE(IntrIgnoring) -= 2;
 
-  if (TLS(IntrIgnoring) == 0)
+  if (STATE(IntrIgnoring) == 0)
       PushVoidObj();
   return;
 }
@@ -4681,9 +4681,9 @@ void             IntrAssertEnd3Args ( void )
 static Int InitKernel (
     StructInitInfo *    module )
 {
-    InitGlobalBag( &TLS(IntrResult), "src/intrprtr.c:IntrResult" );
-    InitGlobalBag( &TLS(IntrState),  "src/intrprtr.c:IntrState"  );
-    InitGlobalBag( &TLS(StackObj),   "src/intrprtr.c:StackObj"   );
+    InitGlobalBag( &STATE(IntrResult), "src/intrprtr.c:IntrResult" );
+    InitGlobalBag( &STATE(IntrState),  "src/intrprtr.c:IntrState"  );
+    InitGlobalBag( &STATE(StackObj),   "src/intrprtr.c:StackObj"   );
     InitCopyGVar( "CurrentAssertionLevel", &CurrentAssertionLevel );
     InitFopyGVar( "CONVERT_FLOAT_LITERAL_EAGER", &CONVERT_FLOAT_LITERAL_EAGER);
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -17,6 +17,7 @@
 */
 #include <assert.h>                     /* assert */
 #include <src/system.h>                 /* Ints, UInts */
+#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -72,7 +72,7 @@
 *F  IntrEnd(<error>)  . . . . . . . . . . . . . . . . . . stop an interpreter
 **
 **  'IntrBegin( <frame> )' starts a new interpreter in context <frame>
-**  if in doubt, pass TLS(BottomLVars) as <frame>
+**  if in doubt, pass STATE(BottomLVars) as <frame>
 **
 **  'IntrEnd(<error>)' stops the current interpreter.
 **

--- a/src/lists.c
+++ b/src/lists.c
@@ -20,7 +20,7 @@
 **  by the plain list package to access and modify plain lists.
 */
 #include <src/system.h>                 /* Ints, UInts */
-
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/lists.c
+++ b/src/lists.c
@@ -2112,14 +2112,14 @@ void            PrintListDefault (
     }
 
     Pr("%2>[ %2>",0L,0L);
-    for ( TLS(PrintObjIndex)=1; TLS(PrintObjIndex)<=LEN_LIST(list); TLS(PrintObjIndex)++ ) {
-        elm = ELMV0_LIST( list, TLS(PrintObjIndex) );
+    for ( STATE(PrintObjIndex)=1; STATE(PrintObjIndex)<=LEN_LIST(list); STATE(PrintObjIndex)++ ) {
+        elm = ELMV0_LIST( list, STATE(PrintObjIndex) );
         if ( elm != 0 ) {
-            if ( 1 < TLS(PrintObjIndex) )  Pr( "%<,%< %2>", 0L, 0L );
+            if ( 1 < STATE(PrintObjIndex) )  Pr( "%<,%< %2>", 0L, 0L );
             PrintObj( elm );
         }
         else {
-            if ( 1 < TLS(PrintObjIndex) )  Pr( "%2<,%2>", 0L, 0L );
+            if ( 1 < STATE(PrintObjIndex) )  Pr( "%2<,%2>", 0L, 0L );
         }
     }
     Pr(" %4<]",0L,0L);

--- a/src/objccoll-impl.h
+++ b/src/objccoll-impl.h
@@ -16,7 +16,7 @@
 */
 #define SC_PUSH_WORD( word, exp ) \
     if ( ++sp == max ) { \
-        TLS(SC_MAX_STACK_SIZE) *= 2; \
+        STATE(SC_MAX_STACK_SIZE) *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(word); \
@@ -27,7 +27,7 @@
 
 #define SC_PUSH_GEN( gen, exp ) \
     if ( ++sp == max ) { \
-        TLS(SC_MAX_STACK_SIZE) *= 2; \
+        STATE(SC_MAX_STACK_SIZE) *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(gen); \
@@ -186,22 +186,22 @@ Int CombiCollectWord ( Obj sc, Obj vv, Obj w )
     exps = 1UL << (ebits-1);
 
     /* <nw> contains the stack of words to insert                          */
-    vnw = TLS(SC_NW_STACK);
+    vnw = STATE(SC_NW_STACK);
 
     /* <lw> contains the word end of the word in <nw>                      */
-    vlw = TLS(SC_LW_STACK);
+    vlw = STATE(SC_LW_STACK);
 
     /* <pw> contains the position of the word in <nw> to look at           */
-    vpw = TLS(SC_PW_STACK);
+    vpw = STATE(SC_PW_STACK);
 
     /* <ew> contains the unprocessed exponents at position <pw>            */
-    vew = TLS(SC_EW_STACK);
+    vew = STATE(SC_EW_STACK);
 
     /* <ge> contains the global exponent of the word                       */
-    vge = TLS(SC_GE_STACK);
+    vge = STATE(SC_GE_STACK);
 
     /* get the maximal stack size                                          */
-    max = TLS(SC_MAX_STACK_SIZE);
+    max = STATE(SC_MAX_STACK_SIZE);
 
     /* ensure that the stacks are large enough                             */
     if ( SIZE_OBJ(vnw)/sizeof(Obj) < max+1 ) {

--- a/src/objccoll.c
+++ b/src/objccoll.c
@@ -14,6 +14,7 @@
 **
 */
 #include <src/system.h>                 /* Ints, UInts */
+#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/objects.c
+++ b/src/objects.c
@@ -12,7 +12,7 @@
 #include <stdlib.h>
 
 #include <src/system.h>                 /* Ints, UInts, SyIsIntr */
-
+#include <src/gapstate.h>
 
 #include <src/sysfiles.h>               /* file input/output */
 

--- a/src/objscoll-impl.h
+++ b/src/objscoll-impl.h
@@ -119,7 +119,7 @@ Int VectorWord ( Obj vv, Obj v, Int num )
 */
 #define SC_PUSH_WORD( word, exp ) \
     if ( ++sp == max ) { \
-        TLS(SC_MAX_STACK_SIZE) *= 2; \
+        STATE(SC_MAX_STACK_SIZE) *= 2; \
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(word); \
@@ -256,22 +256,22 @@ Int SingleCollectWord ( Obj sc, Obj vv, Obj w )
     exps = 1UL << (ebits-1);
 
     /* <nw> contains the stack of words to insert                          */
-    vnw = TLS(SC_NW_STACK);
+    vnw = STATE(SC_NW_STACK);
 
     /* <lw> contains the word end of the word in <nw>                      */
-    vlw = TLS(SC_LW_STACK);
+    vlw = STATE(SC_LW_STACK);
 
     /* <pw> contains the position of the word in <nw> to look at           */
-    vpw = TLS(SC_PW_STACK);
+    vpw = STATE(SC_PW_STACK);
 
     /* <ew> contains the unprocessed exponents at position <pw>            */
-    vew = TLS(SC_EW_STACK);
+    vew = STATE(SC_EW_STACK);
 
     /* <ge> contains the global exponent of the word                       */
-    vge = TLS(SC_GE_STACK);
+    vge = STATE(SC_GE_STACK);
 
     /* get the maximal stack size                                          */
-    max = TLS(SC_MAX_STACK_SIZE);
+    max = STATE(SC_MAX_STACK_SIZE);
 
     /* ensure that the stacks are large enough                             */
     if ( SIZE_OBJ(vnw)/sizeof(Obj) < max+1 ) {

--- a/src/objscoll.c
+++ b/src/objscoll.c
@@ -22,6 +22,7 @@
 **  assume that the vectors are cleared.
 */
 #include <src/system.h>                 /* Ints, UInts */
+#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/objscoll.c
+++ b/src/objscoll.c
@@ -287,7 +287,7 @@ Obj ReducedComm (
     Int *               qtr;        /* pointer into the collect vector     */
 
     /* use 'cwVector' to collect word <u>*<w> to                           */
-    vcw = TLS(SC_CW_VECTOR);
+    vcw = STATE(SC_CW_VECTOR);
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     /* check that it has the correct length, unpack <u> into it            */
@@ -305,7 +305,7 @@ Obj ReducedComm (
     }
 
     /* use 'cw2Vector' to collect word <w>*<u> to                          */
-    vc2 = TLS(SC_CW2_VECTOR);
+    vc2 = STATE(SC_CW2_VECTOR);
 
     /* check that it has the correct length, unpack <w> into it            */
     if ( fc->vectorWord( vc2, w, num ) == -1 ) {
@@ -357,7 +357,7 @@ Obj ReducedForm (
     Int *               qtr;    /* pointer into the collect vector         */
 
     /* use 'cwVector' to collect word <w> to                               */
-    vcw = TLS(SC_CW_VECTOR);
+    vcw = STATE(SC_CW_VECTOR);
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     /* check that it has the correct length                                */
@@ -397,7 +397,7 @@ Obj ReducedLeftQuotient (
     Int *               qtr;        /* pointer into the collect vector     */
 
     /* use 'cwVector' to collect word <w> to                               */
-    vcw = TLS(SC_CW_VECTOR);
+    vcw = STATE(SC_CW_VECTOR);
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     /* check that it has the correct length, unpack <w> into it            */
@@ -408,7 +408,7 @@ Obj ReducedLeftQuotient (
     }
 
     /* use 'cw2Vector' to collect word <u> to                              */
-    vc2 = TLS(SC_CW2_VECTOR);
+    vc2 = STATE(SC_CW2_VECTOR);
 
     /* check that it has the correct length, unpack <u> into it            */
     if ( fc->vectorWord( vc2, u, num ) == -1 ) {
@@ -452,7 +452,7 @@ Obj ReducedProduct (
     Int *               qtr;        /* pointer into the collect vector     */
 
     /* use 'cwVector' to collect word <w> to                               */
-    vcw = TLS(SC_CW_VECTOR);
+    vcw = STATE(SC_CW_VECTOR);
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     /* check that it has the correct length, unpack <w> into it            */
@@ -498,8 +498,8 @@ Obj ReducedPowerSmallInt (
     pow = INT_INTOBJ(vpow);
 
     /* use 'cwVector' and 'cw2Vector to collect words to                   */
-    vcw  = TLS(SC_CW_VECTOR);
-    vc2  = TLS(SC_CW2_VECTOR);
+    vcw  = STATE(SC_CW_VECTOR);
+    vc2  = STATE(SC_CW2_VECTOR);
     num  = SC_NUMBER_RWS_GENERATORS(sc);
     type = SC_DEFAULT_TYPE(sc);
 
@@ -596,8 +596,8 @@ Obj ReducedQuotient (
     Int *               qtr;        /* pointer into the collect vector     */
 
     /* use 'cwVector' to collect word <w> to                               */
-    vcw  = TLS(SC_CW_VECTOR);
-    vc2  = TLS(SC_CW2_VECTOR);
+    vcw  = STATE(SC_CW_VECTOR);
+    vc2  = STATE(SC_CW2_VECTOR);
     num  = SC_NUMBER_RWS_GENERATORS(sc);
     type = SC_DEFAULT_TYPE(sc);
 
@@ -723,7 +723,7 @@ Obj FuncFinPowConjCol_ReducedQuotient ( Obj self, Obj sc, Obj w, Obj u )
 Obj FuncSET_SCOBJ_MAX_STACK_SIZE ( Obj self, Obj size )
 {
     if (IS_INTOBJ(size) && INT_INTOBJ(size) > 0)
-        TLS(SC_MAX_STACK_SIZE) = INT_INTOBJ(size);
+        STATE(SC_MAX_STACK_SIZE) = INT_INTOBJ(size);
     else
         ErrorQuit( "collect vector must be a positive small integer not a %s",
                    (Int)TNAM_OBJ(size), 0L );
@@ -801,14 +801,14 @@ static inline Obj NewPlist( UInt tnum, UInt len, UInt reserved )
 static void SetupCollectorStacks()
 {
     const UInt maxStackSize = 256;
-    TLS(SC_NW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    TLS(SC_LW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    TLS(SC_PW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    TLS(SC_EW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    TLS(SC_GE_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    TLS(SC_CW_VECTOR) = NEW_STRING( 0 );
-    TLS(SC_CW2_VECTOR) = NEW_STRING( 0 );
-    TLS(SC_MAX_STACK_SIZE) = maxStackSize;
+    STATE(SC_NW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    STATE(SC_LW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    STATE(SC_PW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    STATE(SC_EW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    STATE(SC_GE_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
+    STATE(SC_CW_VECTOR) = NEW_STRING( 0 );
+    STATE(SC_CW2_VECTOR) = NEW_STRING( 0 );
+    STATE(SC_MAX_STACK_SIZE) = maxStackSize;
 }
 
 
@@ -825,13 +825,13 @@ static Int InitKernel (
 #ifdef HPCGAP
     InstallTLSHandler(SetupCollectorStacks, NULL);
 #else
-    InitGlobalBag( &TLS(SC_NW_STACK), "SC_NW_STACK" );
-    InitGlobalBag( &TLS(SC_LW_STACK), "SC_LW_STACK" );
-    InitGlobalBag( &TLS(SC_PW_STACK), "SC_PW_STACK" );
-    InitGlobalBag( &TLS(SC_EW_STACK), "SC_EW_STACK" );
-    InitGlobalBag( &TLS(SC_GE_STACK), "SC_GE_STACK" );
-    InitGlobalBag( &TLS(SC_CW_VECTOR), "SC_CW_VECTOR" );
-    InitGlobalBag( &TLS(SC_CW2_VECTOR), "SC_CW2_VECTOR" );
+    InitGlobalBag( &STATE(SC_NW_STACK), "SC_NW_STACK" );
+    InitGlobalBag( &STATE(SC_LW_STACK), "SC_LW_STACK" );
+    InitGlobalBag( &STATE(SC_PW_STACK), "SC_PW_STACK" );
+    InitGlobalBag( &STATE(SC_EW_STACK), "SC_EW_STACK" );
+    InitGlobalBag( &STATE(SC_GE_STACK), "SC_GE_STACK" );
+    InitGlobalBag( &STATE(SC_CW_VECTOR), "SC_CW_VECTOR" );
+    InitGlobalBag( &STATE(SC_CW2_VECTOR), "SC_CW2_VECTOR" );
 #endif
 
     /* return success                                                      */

--- a/src/opers.c
+++ b/src/opers.c
@@ -14,7 +14,7 @@
 #include <assert.h>
 
 #include <src/system.h>                 /* Ints, UInts */
-
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/opers.c
+++ b/src/opers.c
@@ -1792,9 +1792,9 @@ Obj DoOperation0Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 0 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[2*TLS(CacheIndex)] = method;
-              cache[2*TLS(CacheIndex)+1] = prec;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[2*STATE(CacheIndex)] = method;
+              cache[2*STATE(CacheIndex)+1] = prec;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -1881,10 +1881,10 @@ Obj DoOperation1Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 1 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[3*TLS(CacheIndex)] = method;
-              cache[3*TLS(CacheIndex)+1] = prec;
-              cache[3*TLS(CacheIndex)+2] = id1;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[3*STATE(CacheIndex)] = method;
+              cache[3*STATE(CacheIndex)+1] = prec;
+              cache[3*STATE(CacheIndex)+2] = id1;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -1978,11 +1978,11 @@ Obj DoOperation2Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 2 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[4*TLS(CacheIndex)] = method;
-              cache[4*TLS(CacheIndex)+1] = prec;
-              cache[4*TLS(CacheIndex)+2] = id1;
-              cache[4*TLS(CacheIndex)+3] = id2;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[4*STATE(CacheIndex)] = method;
+              cache[4*STATE(CacheIndex)+1] = prec;
+              cache[4*STATE(CacheIndex)+2] = id1;
+              cache[4*STATE(CacheIndex)+3] = id2;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -2081,12 +2081,12 @@ Obj DoOperation3Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 3 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[5*TLS(CacheIndex)] = method;
-              cache[5*TLS(CacheIndex)+1] = prec;
-              cache[5*TLS(CacheIndex)+2] = id1;
-              cache[5*TLS(CacheIndex)+3] = id2;
-              cache[5*TLS(CacheIndex)+4] = id3;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[5*STATE(CacheIndex)] = method;
+              cache[5*STATE(CacheIndex)+1] = prec;
+              cache[5*STATE(CacheIndex)+2] = id1;
+              cache[5*STATE(CacheIndex)+3] = id2;
+              cache[5*STATE(CacheIndex)+4] = id3;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -2191,13 +2191,13 @@ Obj DoOperation4Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 4 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[6*TLS(CacheIndex)] = method;
-              cache[6*TLS(CacheIndex)+1] = prec;
-              cache[6*TLS(CacheIndex)+2] = id1;
-              cache[6*TLS(CacheIndex)+3] = id2;
-              cache[6*TLS(CacheIndex)+4] = id3;
-              cache[6*TLS(CacheIndex)+5] = id4;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[6*STATE(CacheIndex)] = method;
+              cache[6*STATE(CacheIndex)+1] = prec;
+              cache[6*STATE(CacheIndex)+2] = id1;
+              cache[6*STATE(CacheIndex)+3] = id2;
+              cache[6*STATE(CacheIndex)+4] = id3;
+              cache[6*STATE(CacheIndex)+5] = id4;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -2321,14 +2321,14 @@ Obj DoOperation5Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 5 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[7*TLS(CacheIndex)] = method;
-              cache[7*TLS(CacheIndex)+1] = prec;
-              cache[7*TLS(CacheIndex)+2] = id1;
-              cache[7*TLS(CacheIndex)+3] = id2;
-              cache[7*TLS(CacheIndex)+4] = id3;
-              cache[7*TLS(CacheIndex)+5] = id4;
-              cache[7*TLS(CacheIndex)+6] = id5;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[7*STATE(CacheIndex)] = method;
+              cache[7*STATE(CacheIndex)+1] = prec;
+              cache[7*STATE(CacheIndex)+2] = id1;
+              cache[7*STATE(CacheIndex)+3] = id2;
+              cache[7*STATE(CacheIndex)+4] = id3;
+              cache[7*STATE(CacheIndex)+5] = id4;
+              cache[7*STATE(CacheIndex)+6] = id5;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -2471,15 +2471,15 @@ Obj DoOperation6Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 6 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[8*TLS(CacheIndex)] = method;
-              cache[8*TLS(CacheIndex)+1] = prec;
-              cache[8*TLS(CacheIndex)+2] = id1;
-              cache[8*TLS(CacheIndex)+3] = id2;
-              cache[8*TLS(CacheIndex)+4] = id3;
-              cache[8*TLS(CacheIndex)+5] = id4;
-              cache[8*TLS(CacheIndex)+6] = id5;
-              cache[8*TLS(CacheIndex)+7] = id6;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[8*STATE(CacheIndex)] = method;
+              cache[8*STATE(CacheIndex)+1] = prec;
+              cache[8*STATE(CacheIndex)+2] = id1;
+              cache[8*STATE(CacheIndex)+3] = id2;
+              cache[8*STATE(CacheIndex)+4] = id3;
+              cache[8*STATE(CacheIndex)+5] = id4;
+              cache[8*STATE(CacheIndex)+6] = id5;
+              cache[8*STATE(CacheIndex)+7] = id6;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3174,9 +3174,9 @@ Obj DoConstructor0Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 0 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[2*TLS(CacheIndex)] = method;
-              cache[2*TLS(CacheIndex)+1] = prec;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[2*STATE(CacheIndex)] = method;
+              cache[2*STATE(CacheIndex)+1] = prec;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3268,10 +3268,10 @@ Obj DoConstructor1Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 1 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[3*TLS(CacheIndex)] = method;
-              cache[3*TLS(CacheIndex)+1] = prec;
-              cache[3*TLS(CacheIndex)+2] = type1;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[3*STATE(CacheIndex)] = method;
+              cache[3*STATE(CacheIndex)+1] = prec;
+              cache[3*STATE(CacheIndex)+2] = type1;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3368,11 +3368,11 @@ Obj DoConstructor2Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 2 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[4*TLS(CacheIndex)] = method;
-              cache[4*TLS(CacheIndex)+1] = prec;
-              cache[4*TLS(CacheIndex)+2] = type1;
-              cache[4*TLS(CacheIndex)+3] = id2;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[4*STATE(CacheIndex)] = method;
+              cache[4*STATE(CacheIndex)+1] = prec;
+              cache[4*STATE(CacheIndex)+2] = type1;
+              cache[4*STATE(CacheIndex)+3] = id2;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3475,12 +3475,12 @@ Obj DoConstructor3Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 3 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[5*TLS(CacheIndex)] = method;
-              cache[5*TLS(CacheIndex)+1] = prec;
-              cache[5*TLS(CacheIndex)+2] = type1;
-              cache[5*TLS(CacheIndex)+3] = id2;
-              cache[5*TLS(CacheIndex)+4] = id3;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[5*STATE(CacheIndex)] = method;
+              cache[5*STATE(CacheIndex)+1] = prec;
+              cache[5*STATE(CacheIndex)+2] = type1;
+              cache[5*STATE(CacheIndex)+3] = id2;
+              cache[5*STATE(CacheIndex)+4] = id3;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3589,13 +3589,13 @@ Obj DoConstructor4Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 4 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[6*TLS(CacheIndex)] = method;
-              cache[6*TLS(CacheIndex)+1] = prec;
-              cache[6*TLS(CacheIndex)+2] = type1;
-              cache[6*TLS(CacheIndex)+3] = id2;
-              cache[6*TLS(CacheIndex)+4] = id3;
-              cache[6*TLS(CacheIndex)+5] = id4;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[6*STATE(CacheIndex)] = method;
+              cache[6*STATE(CacheIndex)+1] = prec;
+              cache[6*STATE(CacheIndex)+2] = type1;
+              cache[6*STATE(CacheIndex)+3] = id2;
+              cache[6*STATE(CacheIndex)+4] = id3;
+              cache[6*STATE(CacheIndex)+5] = id4;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3722,14 +3722,14 @@ Obj DoConstructor5Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 5 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[7*TLS(CacheIndex)] = method;
-              cache[7*TLS(CacheIndex)+1] = prec;
-              cache[7*TLS(CacheIndex)+2] = type1;
-              cache[7*TLS(CacheIndex)+3] = id2;
-              cache[7*TLS(CacheIndex)+4] = id3;
-              cache[7*TLS(CacheIndex)+5] = id4;
-              cache[7*TLS(CacheIndex)+6] = id5;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[7*STATE(CacheIndex)] = method;
+              cache[7*STATE(CacheIndex)+1] = prec;
+              cache[7*STATE(CacheIndex)+2] = type1;
+              cache[7*STATE(CacheIndex)+3] = id2;
+              cache[7*STATE(CacheIndex)+4] = id3;
+              cache[7*STATE(CacheIndex)+5] = id4;
+              cache[7*STATE(CacheIndex)+6] = id5;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS
@@ -3875,15 +3875,15 @@ Obj DoConstructor6Args (
             {
               Bag cacheBag = GET_METHOD_CACHE( oper, 6 );
               cache = 1+ADDR_OBJ( cacheBag );
-              cache[8*TLS(CacheIndex)] = method;
-              cache[8*TLS(CacheIndex)+1] = prec;
-              cache[8*TLS(CacheIndex)+2] = type1;
-              cache[8*TLS(CacheIndex)+3] = id2;
-              cache[8*TLS(CacheIndex)+4] = id3;
-              cache[8*TLS(CacheIndex)+5] = id4;
-              cache[8*TLS(CacheIndex)+6] = id5;
-              cache[8*TLS(CacheIndex)+7] = id6;
-              TLS(CacheIndex) = (TLS(CacheIndex) + 1) % CACHE_SIZE;
+              cache[8*STATE(CacheIndex)] = method;
+              cache[8*STATE(CacheIndex)+1] = prec;
+              cache[8*STATE(CacheIndex)+2] = type1;
+              cache[8*STATE(CacheIndex)+3] = id2;
+              cache[8*STATE(CacheIndex)+4] = id3;
+              cache[8*STATE(CacheIndex)+5] = id4;
+              cache[8*STATE(CacheIndex)+6] = id5;
+              cache[8*STATE(CacheIndex)+7] = id6;
+              STATE(CacheIndex) = (STATE(CacheIndex) + 1) % CACHE_SIZE;
               CHANGED_BAG( cacheBag );
             }
 #ifdef COUNT_OPERS

--- a/src/opers.c
+++ b/src/opers.c
@@ -6425,7 +6425,7 @@ StructInitInfo * InitInfoOpers ( void )
 *F  DestroyOpersTLS()  . . . . . . . . . . . . . . . . . . . . .  destroy TLS
 */
 
-void InitOpersState(GlobalState *state)
+void InitOpersState(GAPState *state)
 {
   state->MethodCache = NEW_PLIST(T_PLIST, 1);
   state->MethodCacheItems = ADDR_OBJ(state->MethodCache);
@@ -6433,7 +6433,7 @@ void InitOpersState(GlobalState *state)
   SET_LEN_PLIST(state->MethodCache, 1);
 }
 
-void DestroyOpersState(GlobalState *state)
+void DestroyOpersState(GAPState *state)
 {
   /* Nothing for now. */
 }

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -38,7 +38,7 @@
 *N  13-Jan-91 martin should add 'CyclesPerm', 'CycleLengthsPerm'
 */
 #include <src/system.h>                 /* system dependent part */
-
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -146,7 +146,7 @@ Obj             IdentityPerm;
 **  costs (particularly when starting new threads).
 **  Use the UseTmpPerm(<size>) utility function to ensure it is constructed!
 */
-#define  TmpPerm TLS(TmpPerm)
+#define  TmpPerm STATE(TmpPerm)
 
 static void UseTmpPerm( UInt size) {
   if (TmpPerm == (Obj)0)

--- a/src/plist.c
+++ b/src/plist.c
@@ -35,7 +35,7 @@
 **  functions called from the generic lists package.
 */
 #include <src/system.h>                 /* system dependent part */
-
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/plist.c
+++ b/src/plist.c
@@ -1021,13 +1021,13 @@ Int             EqPlist (
         elmL = ELM_PLIST( left, i );
         elmR = ELM_PLIST( right, i );
         if ( ( (elmL == 0 ) != (elmR == 0) ) || ! EQ( elmL, elmR ) ) {
-            TLS(RecursionDepth)--;
+            STATE(RecursionDepth)--;
             return 0L;
         }
     }
 
     /* no differences found, the lists are equal                           */
-    TLS(RecursionDepth)--;
+    STATE(RecursionDepth)--;
     return 1L;
 }
 
@@ -1078,7 +1078,7 @@ Int             LtPlist (
     }
 
     /* reached the end of at least one list                                */
-    TLS(RecursionDepth)--;
+    STATE(RecursionDepth)--;
     return res;
 }
 

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -51,7 +51,7 @@ Obj   EmptyPartialPerm;
 **  that require a zero-initialization need to do this at the start.
 */
 /* TL: Obj TmpPPerm; */
-#define  TmpPPerm TLS(TmpPPerm)
+#define  TmpPPerm STATE(TmpPPerm)
 
 static inline void ResizeTmpPPerm( UInt len ){
   if (TmpPPerm == (Obj)0) {

--- a/src/pperm.h
+++ b/src/pperm.h
@@ -1,5 +1,6 @@
 
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/precord.c
+++ b/src/precord.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>                     /* for qsort */
 #include <sys/time.h>                   /* for gettimeofday() */
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/precord.c
+++ b/src/precord.c
@@ -783,19 +783,19 @@ Obj FuncEQ_PREC (
 
         /* compare the names                                               */
         if ( GET_RNAM_PREC(left,i) != GET_RNAM_PREC(right,i) ) {
-            TLS(RecursionDepth)--;
+            STATE(RecursionDepth)--;
             return False;
         }
 
         /* compare the values                                              */
         if ( ! EQ(GET_ELM_PREC(left,i),GET_ELM_PREC(right,i)) ) {
-            TLS(RecursionDepth)--;
+            STATE(RecursionDepth)--;
             return False;
         }
     }
 
     /* the records are equal                                               */
-    TLS(RecursionDepth)--;
+    STATE(RecursionDepth)--;
     return True;
 }
 
@@ -856,7 +856,7 @@ Obj FuncLT_PREC (
     }
 
     /* the records are equal or the right is a prefix of the left          */
-    TLS(RecursionDepth)--;
+    STATE(RecursionDepth)--;
     return res ? True : False;
 }
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -463,7 +463,7 @@ static inline void outputStat(Stat stat, int exec, int visited)
 void visitStat(Stat stat)
 {
 #ifdef HPCGAP
-  if(profileState.profiledThread != TLS(threadID))
+  if(profileState.profiledThread != STATE(threadID))
     return;
 #endif
 
@@ -617,7 +617,7 @@ void enableAtStartup(char* filename, Int repeats)
     profileState_Active = 1;
     profileState.profiledPreviously = 1;
 #ifdef HPCGAP
-    profileState.profiledThread = TLS(threadID);
+    profileState.profiledThread = STATE(threadID);
 #endif
     profileState.lastNotOutputted.line = -1;
 #ifdef HAVE_GETTIMEOFDAY
@@ -748,7 +748,7 @@ Obj FuncACTIVATE_PROFILING (
     profileState_Active = 1;
     profileState.profiledPreviously = 1;
 #ifdef HPCGAP
-    profileState.profiledThread = TLS(threadID);
+    profileState.profiledThread = STATE(threadID);
 #endif
     profileState.lastNotOutputted.line = -1;
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -9,7 +9,7 @@
 **
 */
 #include <src/system.h>                 /* system dependent part */
-
+#include <src/gapstate.h>
 
 #include <src/sysfiles.h>               /* file input/output */
 

--- a/src/read.c
+++ b/src/read.c
@@ -123,25 +123,25 @@ void ReadAtom (
 
 void PushGlobalForLoopVariable( UInt var)
 {
-  if (TLS(CurrentGlobalForLoopDepth) < 100)
-    TLS(CurrentGlobalForLoopVariables)[TLS(CurrentGlobalForLoopDepth)] = var;
-  TLS(CurrentGlobalForLoopDepth)++;
+  if (STATE(CurrentGlobalForLoopDepth) < 100)
+    STATE(CurrentGlobalForLoopVariables)[STATE(CurrentGlobalForLoopDepth)] = var;
+  STATE(CurrentGlobalForLoopDepth)++;
 }
 
 void PopGlobalForLoopVariable( void )
 {
-  assert(TLS(CurrentGlobalForLoopDepth));
-  TLS(CurrentGlobalForLoopDepth)--;
+  assert(STATE(CurrentGlobalForLoopDepth));
+  STATE(CurrentGlobalForLoopDepth)--;
 }
 
 UInt GlobalComesFromEnclosingForLoop (UInt var)
 {
   UInt i;
-  for (i = 0; i < TLS(CurrentGlobalForLoopDepth); i++)
+  for (i = 0; i < STATE(CurrentGlobalForLoopDepth); i++)
     {
       if (i==100)
 	return 0;
-      if (TLS(CurrentGlobalForLoopVariables)[i] == var)
+      if (STATE(CurrentGlobalForLoopVariables)[i] == var)
 	return 1;
     }
   return 0;
@@ -191,12 +191,12 @@ extern Obj ExprGVars;
 void ReadFuncCallOption( TypSymbolSet follow )
 {
   volatile UInt       rnam;           /* record component name           */
-  if ( TLS(Symbol) == S_IDENT ) {
-    rnam = RNamName( TLS(Value) );
+  if ( STATE(Symbol) == S_IDENT ) {
+    rnam = RNamName( STATE(Value) );
     Match( S_IDENT, "identifier", S_COMMA | follow );
     TRY_READ { IntrFuncCallOptionsBeginElmName( rnam ); }
   }
-  else if ( TLS(Symbol) == S_LPAREN ) {
+  else if ( STATE(Symbol) == S_LPAREN ) {
     Match( S_LPAREN, "(", S_COMMA | follow );
     ReadExpr( follow, 'r' );
     Match( S_RPAREN, ")", S_COMMA | follow );
@@ -205,7 +205,7 @@ void ReadFuncCallOption( TypSymbolSet follow )
   else {
     SyntaxError("Identifier expected");
   }
-  if ( TLS(Symbol) == S_ASSIGN )
+  if ( STATE(Symbol) == S_ASSIGN )
     {
       Match( S_ASSIGN, ":=", S_COMMA | follow );
       ReadExpr( S_COMMA | S_RPAREN|follow, 'r' );
@@ -224,7 +224,7 @@ void ReadFuncCallOptions( TypSymbolSet follow )
   TRY_READ { IntrFuncCallOptionsBegin( ); }
   ReadFuncCallOption( follow);
   nr = 1;
-  while ( TLS(Symbol) == S_COMMA )
+  while ( STATE(Symbol) == S_COMMA )
     {
       Match(S_COMMA, ",", follow );
       ReadFuncCallOption( follow );
@@ -249,13 +249,13 @@ void ReadReferenceModifiers( TypSymbolSet follow )
     UInt narg = 0;
     UInt rnam  = 0;
     /* followed by one or more selectors                                   */
-    while ( IS_IN( TLS(Symbol), S_LPAREN|S_LBRACK|S_LBRACE|S_DOT ) ) {
+    while ( IS_IN( STATE(Symbol), S_LPAREN|S_LBRACK|S_LBRACE|S_DOT ) ) {
         /* <Var> '[' <Expr> ']'  list selector                             */
-        if ( TLS(Symbol) == S_LBRACK ) {
+        if ( STATE(Symbol) == S_LBRACK ) {
             Match( S_LBRACK, "[", follow );
             ReadExpr( S_COMMA|S_RBRACK|follow, 'r' );
             narg = 1;
-            while ( TLS(Symbol) == S_COMMA) {
+            while ( STATE(Symbol) == S_COMMA) {
               Match(S_COMMA,",", follow|S_RBRACK);
               ReadExpr(S_COMMA|S_RBRACK|follow, 'r' );
               narg++;
@@ -265,7 +265,7 @@ void ReadReferenceModifiers( TypSymbolSet follow )
         }
 
         /* <Var> '{' <Expr> '}'  sublist selector                          */
-        else if ( TLS(Symbol) == S_LBRACE ) {
+        else if ( STATE(Symbol) == S_LBRACE ) {
             Match( S_LBRACE, "{", follow );
             ReadExpr( S_RBRACE|follow, 'r' );
             Match( S_RBRACE, "}", follow );
@@ -273,7 +273,7 @@ void ReadReferenceModifiers( TypSymbolSet follow )
         }
 
         /* <Var> '![' <Expr> ']'  list selector                            */
-        else if ( TLS(Symbol) == S_BLBRACK ) {
+        else if ( STATE(Symbol) == S_BLBRACK ) {
             Match( S_BLBRACK, "![", follow );
             ReadExpr( S_RBRACK|follow, 'r' );
             Match( S_RBRACK, "]", follow );
@@ -281,7 +281,7 @@ void ReadReferenceModifiers( TypSymbolSet follow )
         }
 
         /* <Var> '!{' <Expr> '}'  sublist selector                         */
-        else if ( TLS(Symbol) == S_BLBRACE ) {
+        else if ( STATE(Symbol) == S_BLBRACE ) {
             Match( S_BLBRACE, "!{", follow );
             ReadExpr( S_RBRACE|follow, 'r' );
             Match( S_RBRACE, "}", follow );
@@ -289,14 +289,14 @@ void ReadReferenceModifiers( TypSymbolSet follow )
         }
 
         /* <Var> '.' <Ident>  record selector                              */
-        else if ( TLS(Symbol) == S_DOT ) {
+        else if ( STATE(Symbol) == S_DOT ) {
             Match( S_DOT, ".", follow );
-            if ( TLS(Symbol) == S_IDENT || TLS(Symbol) == S_INT ) {
-                rnam = RNamName( TLS(Value) );
-                Match( TLS(Symbol), "identifier", follow );
+            if ( STATE(Symbol) == S_IDENT || STATE(Symbol) == S_INT ) {
+                rnam = RNamName( STATE(Value) );
+                Match( STATE(Symbol), "identifier", follow );
                 type = '.';
             }
-            else if ( TLS(Symbol) == S_LPAREN ) {
+            else if ( STATE(Symbol) == S_LPAREN ) {
                 Match( S_LPAREN, "(", follow );
                 ReadExpr( S_RPAREN|follow, 'r' );
                 Match( S_RPAREN, ")", follow );
@@ -309,14 +309,14 @@ void ReadReferenceModifiers( TypSymbolSet follow )
         }
 
         /* <Var> '!.' <Ident>  record selector                             */
-        else if ( TLS(Symbol) == S_BDOT ) {
+        else if ( STATE(Symbol) == S_BDOT ) {
             Match( S_BDOT, "!.", follow );
-            if ( TLS(Symbol) == S_IDENT || TLS(Symbol) == S_INT ) {
-                rnam = RNamName( TLS(Value) );
-                Match( TLS(Symbol), "identifier", follow );
+            if ( STATE(Symbol) == S_IDENT || STATE(Symbol) == S_INT ) {
+                rnam = RNamName( STATE(Value) );
+                Match( STATE(Symbol), "identifier", follow );
                 type = '!';
             }
-            else if ( TLS(Symbol) == S_LPAREN ) {
+            else if ( STATE(Symbol) == S_LPAREN ) {
                 Match( S_LPAREN, "(", follow );
                 ReadExpr( S_RPAREN|follow, 'r' );
                 Match( S_RPAREN, ")", follow );
@@ -329,23 +329,23 @@ void ReadReferenceModifiers( TypSymbolSet follow )
         }
 
         /* <Var> '(' [ <Expr> { ',' <Expr> } ] ')'  function call          */
-        else if ( TLS(Symbol) == S_LPAREN ) {
+        else if ( STATE(Symbol) == S_LPAREN ) {
             Match( S_LPAREN, "(", follow );
             TRY_READ { IntrFuncCallBegin(); }
             narg = 0;
-            if ( TLS(Symbol) != S_RPAREN && TLS(Symbol) != S_COLON) {
+            if ( STATE(Symbol) != S_RPAREN && STATE(Symbol) != S_COLON) {
                 ReadExpr( S_RPAREN|follow, 'r' );
                 narg++;
             }
-            while ( TLS(Symbol) == S_COMMA ) {
+            while ( STATE(Symbol) == S_COMMA ) {
                 Match( S_COMMA, ",", follow );
                 ReadExpr( S_RPAREN|follow, 'r' );
                 narg++;
             }
             type = 'c';
-            if (TLS(Symbol) == S_COLON ) {
+            if (STATE(Symbol) == S_COLON ) {
               Match( S_COLON, ":", follow );
-              if ( TLS(Symbol) != S_RPAREN ) /* save work for empty options */
+              if ( STATE(Symbol) != S_RPAREN ) /* save work for empty options */
                 {
                   ReadFuncCallOptions(S_RPAREN | follow);
                   type = 'C';
@@ -394,17 +394,17 @@ void ReadCallVarAss (
     Char                varname[MAX_VALUE_LEN]; /* copy of variable name   */
 
     /* all variables must begin with an identifier                         */
-    if ( TLS(Symbol) != S_IDENT ) {
+    if ( STATE(Symbol) != S_IDENT ) {
         SyntaxError( "Identifier expected" );
         return;
     }
 
     /* try to look up the variable on the stack of local variables         */
     nest = 0;
-    while ( type == ' ' && nest < TLS(CountNams) ) {
-        nams = ELM_LIST( TLS(StackNams), TLS(CountNams)-nest );
+    while ( type == ' ' && nest < STATE(CountNams) ) {
+        nams = ELM_LIST( STATE(StackNams), STATE(CountNams)-nest );
         for ( indx = LEN_LIST( nams ); 1 <= indx; indx-- ) {
-            if ( strcmp( TLS(Value), CSTR_STRING(ELM_LIST(nams,indx)) ) == 0 ) {
+            if ( strcmp( STATE(Value), CSTR_STRING(ELM_LIST(nams,indx)) ) == 0 ) {
                 if ( nest == 0 ) {
                     type = 'l';
                     var = indx;
@@ -424,12 +424,12 @@ void ReadCallVarAss (
     /* try to look up the variable on the error stack                      */
     /* the outer loop runs up the calling stack, while the inner loop runs
        up the static definition stack for each call function */
-    lvars0 = TLS(ErrorLVars);
+    lvars0 = STATE(ErrorLVars);
     nest0 = 0;
-    while ( type == ' ' && lvars0 != 0 && lvars0 != TLS(BottomLVars)) {
+    while ( type == ' ' && lvars0 != 0 && lvars0 != STATE(BottomLVars)) {
       lvars = lvars0;
       nest = 0;
-      while ( type == ' ' && lvars != 0 && lvars != TLS(BottomLVars) ) {
+      while ( type == ' ' && lvars != 0 && lvars != STATE(BottomLVars) ) {
 	nams = NAMS_FUNC(PTR_BAG(lvars)[0]);
 	if (nams != (Obj) 0)
 	  {
@@ -437,12 +437,12 @@ void ReadCallVarAss (
 	    if (indx >= 1024)
 	      {
 		Pr("Warning; Ignoring local names after 1024th in search for %s\n",
-		   (Int) TLS(Value),
+		   (Int) STATE(Value),
 		   0L);
 		indx = 1023;
 	      }
 	    for ( ; 1 <= indx; indx-- ) {
-	      if ( strcmp( TLS(Value), CSTR_STRING(ELM_LIST(nams,indx)) ) == 0 ) {
+	      if ( strcmp( STATE(Value), CSTR_STRING(ELM_LIST(nams,indx)) ) == 0 ) {
 		type = 'd';
 
 		/* Ultrix 4.2 cc get's confused if the UInt is missing     */
@@ -456,7 +456,7 @@ void ReadCallVarAss (
 	if (nest >= 65536)
 	  {
 	    Pr("Warning: abandoning search for %s at 65536th higher frame\n",
-	       (Int)TLS(Value),0L);
+	       (Int)STATE(Value),0L);
 	    break;
 	  }
       }
@@ -465,7 +465,7 @@ void ReadCallVarAss (
 	if (nest0 >= 65536)
 	  {
 	    Pr("Warning: abandoning search for %s 65536 frames up stack\n",
-	       (Int)TLS(Value),0L);
+	       (Int)STATE(Value),0L);
 	    break;
 	  }
     }
@@ -475,7 +475,7 @@ void ReadCallVarAss (
         type = 'g';
         /* we do not want to call GVarName on this value until after we
          * have checked if this is the argument to a lambda function       */
-        strlcpy(varname, TLS(Value), sizeof(varname));
+        strlcpy(varname, STATE(Value), sizeof(varname));
     }
 
     /* match away the identifier, now that we know the variable            */
@@ -483,7 +483,7 @@ void ReadCallVarAss (
 
     /* if this was actually the beginning of a function literal            */
     /* then we are in the wrong function                                   */
-    if ( TLS(Symbol) == S_MAPTO ) {
+    if ( STATE(Symbol) == S_MAPTO ) {
       if (mode == 'r' || mode == 'x')
 	{
 	  ReadFuncExpr1( follow );
@@ -504,12 +504,12 @@ void ReadCallVarAss (
       WarnOnUnboundGlobalsRNam = RNamName("WarnOnUnboundGlobals");
 
     if ( type == 'g'
-      && TLS(CountNams) != 0
-      && var != TLS(CurrLHSGVar)
+      && STATE(CountNams) != 0
+      && var != STATE(CurrLHSGVar)
       && var != Tilde
       && VAL_GVAR(var) == 0
       && ELM_PLIST(ExprGVars,var) == 0
-      && ! TLS(IntrIgnoring)
+      && ! STATE(IntrIgnoring)
       && ! GlobalComesFromEnclosingForLoop(var)
       && (GAPInfo == 0 || !IS_REC(GAPInfo) || !ISB_REC(GAPInfo,WarnOnUnboundGlobalsRNam) ||
              ELM_REC(GAPInfo,WarnOnUnboundGlobalsRNam) != False )
@@ -519,10 +519,10 @@ void ReadCallVarAss (
     }
 
     /* check whether this is a reference to the global variable '~'        */
-    if ( type == 'g' && var == Tilde ) { TLS(ReadTilde) = 1; }
+    if ( type == 'g' && var == Tilde ) { STATE(ReadTilde) = 1; }
 
     /* followed by one or more selectors                                   */
-    while ( IS_IN( TLS(Symbol), S_LPAREN|S_LBRACK|S_LBRACE|S_DOT ) ) {
+    while ( IS_IN( STATE(Symbol), S_LPAREN|S_LBRACK|S_LBRACE|S_DOT ) ) {
 
         /* so the prefix was a reference                                   */
         TRY_READ {
@@ -546,11 +546,11 @@ void ReadCallVarAss (
 	  { IntrFuncCallEnd( 1UL, type == 'C', narg ); level=0; }
         } /* end TRY_READ */
         /* <Var> '[' <Expr> ']'  list selector                             */
-        if ( TLS(Symbol) == S_LBRACK ) {
+        if ( STATE(Symbol) == S_LBRACK ) {
             Match( S_LBRACK, "[", follow );
 	    ReadExpr( S_COMMA|S_RBRACK|follow, 'r' );
 	    narg = 1;
-	    while ( TLS(Symbol) == S_COMMA) {
+	    while ( STATE(Symbol) == S_COMMA) {
 	      Match(S_COMMA,",", follow|S_RBRACK);
 	      ReadExpr(S_COMMA|S_RBRACK|follow, 'r' );
 	      narg++;
@@ -560,7 +560,7 @@ void ReadCallVarAss (
         }
 
         /* <Var> '{' <Expr> '}'  sublist selector                          */
-        else if ( TLS(Symbol) == S_LBRACE ) {
+        else if ( STATE(Symbol) == S_LBRACE ) {
             Match( S_LBRACE, "{", follow );
             ReadExpr( S_RBRACE|follow, 'r' );
             Match( S_RBRACE, "}", follow );
@@ -568,7 +568,7 @@ void ReadCallVarAss (
         }
 
         /* <Var> '![' <Expr> ']'  list selector                            */
-        else if ( TLS(Symbol) == S_BLBRACK ) {
+        else if ( STATE(Symbol) == S_BLBRACK ) {
             Match( S_BLBRACK, "![", follow );
             ReadExpr( S_RBRACK|follow, 'r' );
             Match( S_RBRACK, "]", follow );
@@ -576,7 +576,7 @@ void ReadCallVarAss (
         }
 
         /* <Var> '!{' <Expr> '}'  sublist selector                         */
-        else if ( TLS(Symbol) == S_BLBRACE ) {
+        else if ( STATE(Symbol) == S_BLBRACE ) {
             Match( S_BLBRACE, "!{", follow );
             ReadExpr( S_RBRACE|follow, 'r' );
             Match( S_RBRACE, "}", follow );
@@ -584,14 +584,14 @@ void ReadCallVarAss (
         }
 
         /* <Var> '.' <Ident>  record selector                              */
-        else if ( TLS(Symbol) == S_DOT ) {
+        else if ( STATE(Symbol) == S_DOT ) {
             Match( S_DOT, ".", follow );
-            if ( TLS(Symbol) == S_IDENT || TLS(Symbol) == S_INT ) {
-                rnam = RNamName( TLS(Value) );
-                Match( TLS(Symbol), "identifier", follow );
+            if ( STATE(Symbol) == S_IDENT || STATE(Symbol) == S_INT ) {
+                rnam = RNamName( STATE(Value) );
+                Match( STATE(Symbol), "identifier", follow );
                 type = '.';
             }
-            else if ( TLS(Symbol) == S_LPAREN ) {
+            else if ( STATE(Symbol) == S_LPAREN ) {
                 Match( S_LPAREN, "(", follow );
                 ReadExpr( S_RPAREN|follow, 'r' );
                 Match( S_RPAREN, ")", follow );
@@ -604,14 +604,14 @@ void ReadCallVarAss (
         }
 
         /* <Var> '!.' <Ident>  record selector                             */
-        else if ( TLS(Symbol) == S_BDOT ) {
+        else if ( STATE(Symbol) == S_BDOT ) {
             Match( S_BDOT, "!.", follow );
-            if ( TLS(Symbol) == S_IDENT || TLS(Symbol) == S_INT ) {
-                rnam = RNamName( TLS(Value) );
-                Match( TLS(Symbol), "identifier", follow );
+            if ( STATE(Symbol) == S_IDENT || STATE(Symbol) == S_INT ) {
+                rnam = RNamName( STATE(Value) );
+                Match( STATE(Symbol), "identifier", follow );
                 type = '!';
             }
-            else if ( TLS(Symbol) == S_LPAREN ) {
+            else if ( STATE(Symbol) == S_LPAREN ) {
                 Match( S_LPAREN, "(", follow );
                 ReadExpr( S_RPAREN|follow, 'r' );
                 Match( S_RPAREN, ")", follow );
@@ -624,23 +624,23 @@ void ReadCallVarAss (
         }
 
         /* <Var> '(' [ <Expr> { ',' <Expr> } ] ')'  function call          */
-        else if ( TLS(Symbol) == S_LPAREN ) {
+        else if ( STATE(Symbol) == S_LPAREN ) {
             Match( S_LPAREN, "(", follow );
             TRY_READ { IntrFuncCallBegin(); }
             narg = 0;
-            if ( TLS(Symbol) != S_RPAREN && TLS(Symbol) != S_COLON) {
+            if ( STATE(Symbol) != S_RPAREN && STATE(Symbol) != S_COLON) {
                 ReadExpr( S_RPAREN|follow, 'r' );
                 narg++;
             }
-            while ( TLS(Symbol) == S_COMMA ) {
+            while ( STATE(Symbol) == S_COMMA ) {
                 Match( S_COMMA, ",", follow );
                 ReadExpr( S_RPAREN|follow, 'r' );
                 narg++;
             }
 	    type = 'c';
-	    if (TLS(Symbol) == S_COLON ) {
+	    if (STATE(Symbol) == S_COLON ) {
 	      Match( S_COLON, ":", follow );
-	      if ( TLS(Symbol) != S_RPAREN ) /* save work for empty options */
+	      if ( STATE(Symbol) != S_RPAREN ) /* save work for empty options */
 		{
 		  ReadFuncCallOptions(S_RPAREN | follow);
 		  type = 'C';
@@ -652,7 +652,7 @@ void ReadCallVarAss (
     }
 
     /* if we need a reference                                              */
-    if ( mode == 'r' || (mode == 'x' && !IS_IN(TLS(Symbol), S_ASSIGN)) ) {
+    if ( mode == 'r' || (mode == 'x' && !IS_IN(STATE(Symbol), S_ASSIGN)) ) {
       TRY_READ {
              if ( type == 'l' ) { IntrRefLVar( var );             }
         else if ( type == 'h' ) { IntrRefHVar( var );             }
@@ -671,7 +671,7 @@ void ReadCallVarAss (
         else if ( type == '!' ) { IntrElmComObjName( rnam );      }
         else if ( type == '|' ) { IntrElmComObjExpr();            }
         else if ( type == 'c' || type == 'C') {
-            if ( mode == 'x' && TLS(Symbol) == S_SEMICOLON ) {
+            if ( mode == 'x' && STATE(Symbol) == S_SEMICOLON ) {
                 IntrFuncCallEnd( 0UL, type == 'C', narg );
             }
             else {
@@ -688,13 +688,13 @@ void ReadCallVarAss (
 #endif
 
     /* if we need a statement                                              */
-    else if ( mode == 's' || (mode == 'x' && IS_IN(TLS(Symbol), S_ASSIGN)) ) {
+    else if ( mode == 's' || (mode == 'x' && IS_IN(STATE(Symbol), S_ASSIGN)) ) {
         if ( type != 'c' && type != 'C') {
-	    if (TLS(Symbol) != S_ASSIGN)
+	    if (STATE(Symbol) != S_ASSIGN)
 	      Match( S_INCORPORATE, ASSIGN_ERROR_MESSAGE, follow);
 	    else
 	      Match( S_ASSIGN, ASSIGN_ERROR_MESSAGE, follow );
-            if ( TLS(CountNams) == 0 || !TLS(IntrCoding) ) { TLS(CurrLHSGVar) = (type == 'g' ? var : 0); }
+            if ( STATE(CountNams) == 0 || !STATE(IntrCoding) ) { STATE(CurrLHSGVar) = (type == 'g' ? var : 0); }
             ReadExpr( follow, 'r' );
         }
       TRY_READ {
@@ -721,7 +721,7 @@ void ReadCallVarAss (
 
     /*  if we need an unbind                                               */
     else if ( mode == 'u' ) {
-      if (TLS(Symbol) != S_RPAREN) {
+      if (STATE(Symbol) != S_RPAREN) {
 	SyntaxError("'Unbind': argument should be followed by ')'");
       }
       TRY_READ {
@@ -801,7 +801,7 @@ void ReadPerm (
 
     /* read the first cycle (first expression has already been read)       */
     nrx = 1;
-    while ( TLS(Symbol) == S_COMMA ) {
+    while ( STATE(Symbol) == S_COMMA ) {
         Match( S_COMMA, ",", follow );
         ReadExpr( S_COMMA|S_RPAREN|follow, 'r' );
         nrx++;
@@ -811,11 +811,11 @@ void ReadPerm (
     TRY_READ { IntrPermCycle( nrx, nrc ); }
 
     /* read the remaining cycles                                           */
-    while ( TLS(Symbol) == S_LPAREN ) {
+    while ( STATE(Symbol) == S_LPAREN ) {
         Match( S_LPAREN, "(", follow );
         ReadExpr( S_COMMA|S_RPAREN|follow, 'r' );
         nrx = 1;
-        while ( TLS(Symbol) == S_COMMA ) {
+        while ( STATE(Symbol) == S_COMMA ) {
             Match( S_COMMA, ",", follow );
             ReadExpr( S_COMMA|S_RPAREN|follow, 'r' );
             nrx++;
@@ -833,17 +833,17 @@ void ReadPerm (
 **
 *F  ReadLongNumber( <follow> )  . . . . . . . . . . . . . . . read a long integer
 **
-**  A `long integer' here means one whose digits don't fit into `TLS(Value)',
-**  see scanner.c.  This function copies repeatedly  digits from `TLS(Value)'
+**  A `long integer' here means one whose digits don't fit into `STATE(Value)',
+**  see scanner.c.  This function copies repeatedly  digits from `STATE(Value)'
 **  into a GAP string until the full integer is read.
 **
 */
 
 static UInt appendToString(Obj string, UInt len)
 {
-       UInt len1 = strlen(TLS(Value));
+       UInt len1 = strlen(STATE(Value));
        GROW_STRING(string, len+len1+1);
-       memcpy(CHARS_STRING(string) + len, (void *)TLS(Value), len1+1);
+       memcpy(CHARS_STRING(string) + len, (void *)STATE(Value), len1+1);
        SET_LEN_STRING(string, len+len1);
        return len + len1;
 }
@@ -857,19 +857,19 @@ void ReadLongNumber(
      UInt done;
 
      /* string in which to accumulate number */
-     len = strlen(TLS(Value));
-     C_NEW_STRING( string, len, (void *)TLS(Value));
+     len = strlen(STATE(Value));
+     C_NEW_STRING( string, len, (void *)STATE(Value));
      done = 0;
 
      while (!done) {
        /* remember the current symbol and get the next one */
-       status = TLS(Symbol);
-       Match(TLS(Symbol), "partial number", follow);
+       status = STATE(Symbol);
+       Match(STATE(Symbol), "partial number", follow);
 
        /* Now there are just lots of cases */
        switch (status) {
        case S_PARTIALINT:
-	 switch (TLS(Symbol)) {
+	 switch (STATE(Symbol)) {
 	 case S_INT:
 	   len = appendToString(string, len);
 	   Match(S_INT, "integer", follow);
@@ -890,9 +890,9 @@ void ReadLongNumber(
 	 case S_PARTIALFLOAT2:
 	 case S_PARTIALFLOAT3:
 	 case S_PARTIALFLOAT4:
-	   status = TLS(Symbol);
+	   status = STATE(Symbol);
 	   len = appendToString(string, len);
-	   /* Match(TLS(Symbol), "float", follow); */
+	   /* Match(STATE(Symbol), "float", follow); */
 	   break;
 
 	 case S_FLOAT:
@@ -913,7 +913,7 @@ void ReadLongNumber(
 	 break;
 
        case S_PARTIALFLOAT1:
-	 switch (TLS(Symbol)) {
+	 switch (STATE(Symbol)) {
 	 case S_INT:
 	 case S_PARTIALINT:
 	 case S_PARTIALFLOAT1:
@@ -925,9 +925,9 @@ void ReadLongNumber(
 	 case S_PARTIALFLOAT2:
 	 case S_PARTIALFLOAT3:
 	 case S_PARTIALFLOAT4:
-	   status = TLS(Symbol);
+	   status = STATE(Symbol);
 	   len = appendToString(string, len);
-	   /* Match(TLS(Symbol), "float", follow); */
+	   /* Match(STATE(Symbol), "float", follow); */
 	   break;
 
 	 case S_FLOAT:
@@ -943,7 +943,7 @@ void ReadLongNumber(
 	 break;
 
        case S_PARTIALFLOAT2:
-	 switch (TLS(Symbol)) {
+	 switch (STATE(Symbol)) {
 	 case S_INT:
 	 case S_PARTIALINT:
 	 case S_PARTIALFLOAT1:
@@ -955,9 +955,9 @@ void ReadLongNumber(
 	 case S_PARTIALFLOAT2:
 	 case S_PARTIALFLOAT3:
 	 case S_PARTIALFLOAT4:
-	   status = TLS(Symbol);
+	   status = STATE(Symbol);
 	   len = appendToString(string, len);
-	   /* Match(TLS(Symbol), "float", follow); */
+	   /* Match(STATE(Symbol), "float", follow); */
 	   break;
 
 	 case S_FLOAT:
@@ -979,7 +979,7 @@ void ReadLongNumber(
 	 break;
 
        case S_PARTIALFLOAT3:
-	 switch (TLS(Symbol)) {
+	 switch (STATE(Symbol)) {
 	 case S_INT:
 	 case S_PARTIALINT:
 	 case S_PARTIALFLOAT1:
@@ -991,9 +991,9 @@ void ReadLongNumber(
 
 
 	 case S_PARTIALFLOAT4:
-	   status = TLS(Symbol);
+	   status = STATE(Symbol);
 	   len = appendToString(string, len);
-	   /* Match(TLS(Symbol), "float", follow); */
+	   /* Match(STATE(Symbol), "float", follow); */
 	   break;
 
 	 case S_FLOAT:
@@ -1010,7 +1010,7 @@ void ReadLongNumber(
 	 }
 	 break;
        case S_PARTIALFLOAT4:
-	 switch (TLS(Symbol)) {
+	 switch (STATE(Symbol)) {
 	 case S_INT:
 	 case S_PARTIALINT:
 	 case S_PARTIALFLOAT1:
@@ -1022,9 +1022,9 @@ void ReadLongNumber(
 
 
 	 case S_PARTIALFLOAT4:
-	   status = TLS(Symbol);
+	   status = STATE(Symbol);
 	   len = appendToString(string, len);
-	   /* Match(TLS(Symbol), "float", follow); */
+	   /* Match(STATE(Symbol), "float", follow); */
 	   break;
 
 	 case S_FLOAT:
@@ -1056,8 +1056,8 @@ void ReadLongNumber(
 **
 *F  ReadString( <follow> )  . . . . . . . . . . . . . . read a (long) string
 **
-**  A string is  read by copying parts of `TLS(Value)'  (see scanner.c) given
-**  by `TLS(ValueLen)' into  a string GAP object. This is  repeated until the
+**  A string is  read by copying parts of `STATE(Value)'  (see scanner.c) given
+**  by `STATE(ValueLen)' into  a string GAP object. This is  repeated until the
 **  end of the string is reached.
 **
 */
@@ -1067,15 +1067,15 @@ void ReadString(
      Obj  string;
      UInt len;
 
-     C_NEW_STRING( string, TLS(ValueLen), (void *)TLS(Value) );
-     len = TLS(ValueLen);
+     C_NEW_STRING( string, STATE(ValueLen), (void *)STATE(Value) );
+     len = STATE(ValueLen);
 
-     while (TLS(Symbol) == S_PARTIALSTRING || TLS(Symbol) == S_PARTIALTRIPSTRING) {
-         Match(TLS(Symbol), "", follow);
-         GROW_STRING(string, len + TLS(ValueLen));
-         memcpy(CHARS_STRING(string) + len, (void *)TLS(Value),
-                                        TLS(ValueLen));
-         len += TLS(ValueLen);
+     while (STATE(Symbol) == S_PARTIALSTRING || STATE(Symbol) == S_PARTIALTRIPSTRING) {
+         Match(STATE(Symbol), "", follow);
+         GROW_STRING(string, len + STATE(ValueLen));
+         memcpy(CHARS_STRING(string) + len, (void *)STATE(Value),
+                                        STATE(ValueLen));
+         len += STATE(ValueLen);
      }
 
      Match(S_STRING, "", follow);
@@ -1104,15 +1104,15 @@ void ReadListExpr (
 
     /* '['                                                                 */
     Match( S_LBRACK, "[", follow );
-    TLS(ReadTop)++;
-    if ( TLS(ReadTop) == 1 ) { TLS(ReadTilde) = 0; }
-    TRY_READ { IntrListExprBegin( (TLS(ReadTop) == 1) ); }
+    STATE(ReadTop)++;
+    if ( STATE(ReadTop) == 1 ) { STATE(ReadTilde) = 0; }
+    TRY_READ { IntrListExprBegin( (STATE(ReadTop) == 1) ); }
     pos   = 1;
     nr    = 0;
     range = 0;
 
     /* [ <Expr> ]                                                          */
-    if ( TLS(Symbol) != S_COMMA && TLS(Symbol) != S_RBRACK ) {
+    if ( STATE(Symbol) != S_COMMA && STATE(Symbol) != S_RBRACK ) {
         TRY_READ { IntrListExprBeginElm( pos ); }
         ReadExpr( S_RBRACK|follow, 'r' );
         TRY_READ { IntrListExprEndElm(); }
@@ -1120,10 +1120,10 @@ void ReadListExpr (
     }
 
     /* {',' [ <Expr> ] }                                                   */
-    while ( TLS(Symbol) == S_COMMA ) {
+    while ( STATE(Symbol) == S_COMMA ) {
         Match( S_COMMA, ",", follow );
         pos++;
-        if ( TLS(Symbol) != S_COMMA && TLS(Symbol) != S_RBRACK ) {
+        if ( STATE(Symbol) != S_COMMA && STATE(Symbol) != S_RBRACK ) {
             TRY_READ { IntrListExprBeginElm( pos ); }
             ReadExpr( S_RBRACK|follow, 'r' );
             TRY_READ { IntrListExprEndElm(); }
@@ -1132,12 +1132,12 @@ void ReadListExpr (
     }
 
     /* incorrect place for three dots                                      */
-    if (TLS(Symbol) == S_DOTDOTDOT) {
+    if (STATE(Symbol) == S_DOTDOTDOT) {
             SyntaxError("Only two dots in a range");
     }
 
     /* '..' <Expr> ']'                                                     */
-    if ( TLS(Symbol) == S_DOTDOT ) {
+    if ( STATE(Symbol) == S_DOTDOT ) {
         if ( pos != nr ) {
             SyntaxError("Must have no unbound entries in range");
         }
@@ -1151,7 +1151,7 @@ void ReadListExpr (
         ReadExpr( S_RBRACK|follow, 'r' );
         TRY_READ { IntrListExprEndElm(); }
         nr++;
-        if ( TLS(ReadTop) == 1 && TLS(ReadTilde) == 1 ) {
+        if ( STATE(ReadTop) == 1 && STATE(ReadTilde) == 1 ) {
             SyntaxError("Sorry, '~' not allowed in range");
         }
     }
@@ -1159,10 +1159,10 @@ void ReadListExpr (
     /* ']'                                                                 */
     Match( S_RBRACK, "]", follow );
     TRY_READ {
-        IntrListExprEnd( nr, range, (TLS(ReadTop) == 1), (TLS(ReadTilde) == 1) );
+        IntrListExprEnd( nr, range, (STATE(ReadTop) == 1), (STATE(ReadTilde) == 1) );
     }
-    if ( TLS(ReadTop) == 1 ) { TLS(ReadTilde) = 0; }
-    TLS(ReadTop)--;
+    if ( STATE(ReadTop) == 1 ) { STATE(ReadTilde) = 0; }
+    STATE(ReadTop)--;
 }
 
 
@@ -1184,28 +1184,28 @@ void ReadRecExpr (
     /* 'rec('                                                              */
     Match( S_REC, "rec", follow );
     Match( S_LPAREN, "(", follow|S_RPAREN|S_COMMA );
-    TLS(ReadTop)++;
-    if ( TLS(ReadTop) == 1 ) { TLS(ReadTilde) = 0; }
-    TRY_READ { IntrRecExprBegin( (TLS(ReadTop) == 1) ); }
+    STATE(ReadTop)++;
+    if ( STATE(ReadTop) == 1 ) { STATE(ReadTilde) = 0; }
+    TRY_READ { IntrRecExprBegin( (STATE(ReadTop) == 1) ); }
     nr = 0;
 
     /* [ <Ident> | '(' <Expr> ')' ':=' <Expr>                              */
     do {
-      if (nr || TLS(Symbol) == S_COMMA) {
+      if (nr || STATE(Symbol) == S_COMMA) {
 	Match(S_COMMA, ",", follow);
       }
-      if ( TLS(Symbol) != S_RPAREN ) {
-        if ( TLS(Symbol) == S_INT ) {
-	  rnam = RNamName( TLS(Value) );
+      if ( STATE(Symbol) != S_RPAREN ) {
+        if ( STATE(Symbol) == S_INT ) {
+	  rnam = RNamName( STATE(Value) );
 	  Match( S_INT, "integer", follow );
 	  TRY_READ { IntrRecExprBeginElmName( rnam ); }
         }
-        else if ( TLS(Symbol) == S_IDENT ) {
-	  rnam = RNamName( TLS(Value) );
+        else if ( STATE(Symbol) == S_IDENT ) {
+	  rnam = RNamName( STATE(Value) );
 	  Match( S_IDENT, "identifier", follow );
 	  TRY_READ { IntrRecExprBeginElmName( rnam ); }
         }
-        else if ( TLS(Symbol) == S_LPAREN ) {
+        else if ( STATE(Symbol) == S_LPAREN ) {
 	  Match( S_LPAREN, "(", follow );
 	  ReadExpr( follow, 'r' );
 	  Match( S_RPAREN, ")", follow );
@@ -1221,15 +1221,15 @@ void ReadRecExpr (
       }
 
     }
-  while ( TLS(Symbol) == S_COMMA );
+  while ( STATE(Symbol) == S_COMMA );
 
     /* ')'                                                                 */
     Match( S_RPAREN, ")", follow );
     TRY_READ {
-        IntrRecExprEnd( nr, (TLS(ReadTop) == 1), (TLS(ReadTilde) == 1) );
+        IntrRecExprEnd( nr, (STATE(ReadTop) == 1), (STATE(ReadTilde) == 1) );
     }
-    if ( TLS(ReadTop) == 1) { TLS(ReadTilde) = 0; }
-    TLS(ReadTop)--;
+    if ( STATE(ReadTop) == 1) { STATE(ReadTilde) = 0; }
+    STATE(ReadTop)--;
 }
 
 /****************************************************************************
@@ -1285,11 +1285,11 @@ struct ArgList ReadFuncArgList(
     narg = 0;
     nams = NEW_PLIST( T_PLIST, narg );
     SET_LEN_PLIST( nams, narg );
-    TLS(CountNams) += 1;
-    ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
-    if ( TLS(Symbol) != symbol ) {
+    STATE(CountNams) += 1;
+    ASS_LIST( STATE(StackNams), STATE(CountNams), nams );
+    if ( STATE(Symbol) != symbol ) {
         lockmode = 0;
-        switch (TLS(Symbol)) {
+        switch (STATE(Symbol)) {
             case S_READWRITE:
             if (!is_atomic) {
                 SyntaxError("'readwrite' argument of non-atomic function");
@@ -1308,31 +1308,31 @@ struct ArgList ReadFuncArgList(
             SET_LEN_STRING(locks, 1);
             GetSymbol();
         }
-        if ( strcmp("~", TLS(Value)) == 0 ) {
+        if ( strcmp("~", STATE(Value)) == 0 ) {
                 SyntaxError("~ is not a valid name for an argument");
         }
-        C_NEW_STRING_DYN( name, TLS(Value) );
+        C_NEW_STRING_DYN( name, STATE(Value) );
         narg += 1;
         ASS_LIST( nams, narg, name );
         Match(S_IDENT,"identifier",symbol|S_LOCAL|STATBEGIN|S_END|follow);
     }
 
-    if(TLS(Symbol) == S_DOTDOT) {
+    if(STATE(Symbol) == S_DOTDOT) {
         SyntaxError("Three dots required for variadic argument list");
     }
-    if(TLS(Symbol) == S_DOTDOTDOT) {
+    if(STATE(Symbol) == S_DOTDOTDOT) {
         isvarg = 1;
         GetSymbol();
     }
 
-    while ( TLS(Symbol) == S_COMMA ) {
+    while ( STATE(Symbol) == S_COMMA ) {
         if (isvarg) {
             SyntaxError("Only final argument can be variadic");
         }
 
         Match( S_COMMA, ",", follow );
         lockmode = 0;
-        switch (TLS(Symbol)) {
+        switch (STATE(Symbol)) {
             case S_READWRITE:
             if (!is_atomic) {
                 SyntaxError("'readwrite' argument of non-atomic function");
@@ -1353,26 +1353,26 @@ struct ArgList ReadFuncArgList(
             GetSymbol();
         }
 
-        if(TLS(Symbol) != S_IDENT) {
+        if(STATE(Symbol) != S_IDENT) {
             SyntaxError("Expect identifier");
         }
 
         for (i = 1; i <= narg; i++ ) {
-            if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
+            if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),STATE(Value)) == 0 ) {
                 SyntaxError("Name used for two arguments");
             }
         }
-        if ( strcmp("~", TLS(Value)) == 0 ) {
+        if ( strcmp("~", STATE(Value)) == 0 ) {
                 SyntaxError("~ is not a valid name for an argument");
         }
-        C_NEW_STRING_DYN( name, TLS(Value) );
+        C_NEW_STRING_DYN( name, STATE(Value) );
         narg += 1;
         ASS_LIST( nams, narg, name );
         Match(S_IDENT,"identifier",symbol|S_LOCAL|STATBEGIN|S_END|follow);
-        if(TLS(Symbol) == S_DOTDOT) {
+        if(STATE(Symbol) == S_DOTDOT) {
             SyntaxError("Three dots required for variadic argument list");
         }
-        if(TLS(Symbol) == S_DOTDOTDOT) {
+        if(STATE(Symbol) == S_DOTDOTDOT) {
             isvarg = 1;
             GetSymbol();
         }
@@ -1403,8 +1403,8 @@ void ReadFuncExpr (
     volatile Obj        name;           /* one local variable name         */
     volatile UInt       nr;             /* number of statements            */
     volatile UInt       i;              /* loop variable                   */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>             */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>          */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>             */
     volatile Int        startLine;      /* line number of function keyword */
     volatile int        is_block = 0;   /* is this a do ... od block?      */
     volatile int        is_atomic = 0;  /* is this an atomic function?      */
@@ -1415,18 +1415,18 @@ void ReadFuncExpr (
     nloc = 0;
 
     /* begin the function               */
-    startLine = TLS(Input)->number;
-    if (TLS(Symbol) == S_DO) {
+    startLine = STATE(Input)->number;
+    if (STATE(Symbol) == S_DO) {
 	Match( S_DO, "do", follow );
         is_block = 1;
         /* make and push the new local variables list (args and locals)        */
         narg = 0;
         nams = NEW_PLIST( T_PLIST, narg );
         SET_LEN_PLIST( nams, narg );
-        TLS(CountNams) += 1;
-        ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
+        STATE(CountNams) += 1;
+        ASS_LIST( STATE(StackNams), STATE(CountNams), nams );
     } else {
-        if (TLS(Symbol) == S_ATOMIC) {
+        if (STATE(Symbol) == S_ATOMIC) {
             Match(S_ATOMIC, "atomic", follow);
             is_atomic = 1;
         } else if (mode == 'a') { /* in this case the atomic keyword
@@ -1443,38 +1443,38 @@ void ReadFuncExpr (
     }
 
 
-    if ( TLS(Symbol) == S_LOCAL ) {
+    if ( STATE(Symbol) == S_LOCAL ) {
         Match( S_LOCAL, "local", follow );
         for ( i = 1; i <= narg; i++ ) {
-            if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
+            if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),STATE(Value)) == 0 ) {
                 SyntaxError("Name used for argument and local");
             }
         }
-        if ( strcmp("~", TLS(Value)) == 0 ) {
+        if ( strcmp("~", STATE(Value)) == 0 ) {
                 SyntaxError("~ is not a valid name for a local identifier");
         }
-        C_NEW_STRING_DYN( name, TLS(Value) );
+        C_NEW_STRING_DYN( name, STATE(Value) );
         nloc += 1;
         ASS_LIST( nams, narg+nloc, name );
         Match( S_IDENT, "identifier", STATBEGIN|S_END|follow );
-        while ( TLS(Symbol) == S_COMMA ) {
+        while ( STATE(Symbol) == S_COMMA ) {
             /* init to avoid strange message in case of empty string */
-            TLS(Value)[0] = '\0';
+            STATE(Value)[0] = '\0';
             Match( S_COMMA, ",", follow );
             for ( i = 1; i <= narg; i++ ) {
-                if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
+                if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),STATE(Value)) == 0 ) {
                     SyntaxError("Name used for argument and local");
                 }
             }
             for ( i = narg+1; i <= narg+nloc; i++ ) {
-                if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
+                if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),STATE(Value)) == 0 ) {
                     SyntaxError("Name used for two locals");
                 }
             }
-            if ( strcmp("~", TLS(Value)) == 0 ) {
+            if ( strcmp("~", STATE(Value)) == 0 ) {
                 SyntaxError("~ is not a valid name for a local identifier");
             }
-            C_NEW_STRING_DYN( name, TLS(Value) );
+            C_NEW_STRING_DYN( name, STATE(Value) );
             nloc += 1;
             ASS_LIST( nams, narg+nloc, name );
             Match( S_IDENT, "identifier", STATBEGIN|S_END|follow );
@@ -1493,8 +1493,8 @@ void ReadFuncExpr (
 	   narg = -1; */
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
 
     /* now finally begin the function                                      */
     TRY_READ { IntrFuncExprBegin( narg, nloc, nams, startLine ); }
@@ -1508,17 +1508,17 @@ void ReadFuncExpr (
     }
 
     /* an error has occured *after* the 'IntrFuncExprEnd'                  */
-    else if ( nrError == 0 && TLS(IntrCoding) ) {
+    else if ( nrError == 0 && STATE(IntrCoding) ) {
         CodeEnd(1);
-        TLS(IntrCoding)--;
-        TLS(CurrLVars) = currLVars;
-        TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-        TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+        STATE(IntrCoding)--;
+        STATE(CurrLVars) = currLVars;
+        STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+        STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
     }
 
     /* pop the new local variables list                                    */
-    assert(TLS(CountNams) > 0);
-    TLS(CountNams)--;
+    assert(STATE(CountNams) > 0);
+    STATE(CountNams)--;
 
     /* 'end'                                                               */
     if (is_block)
@@ -1543,19 +1543,19 @@ void ReadFuncExprBody (
     Obj nams,
     UInt narg)
 {
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>        */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>          */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>        */
 
     /* match away the '->'                                                 */
     Match( S_MAPTO, "->", follow );
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
 
     /* begin interpreting the function expression (with 1 argument)        */
     TRY_READ {
-        IntrFuncExprBegin( narg, 0L, nams, TLS(Input)->number );
+        IntrFuncExprBegin( narg, 0L, nams, STATE(Input)->number );
     }
 
     /* read the expression and turn it into a return-statement             */
@@ -1568,17 +1568,17 @@ void ReadFuncExprBody (
     }
 
     /* an error has occured *after* the 'IntrFuncExprEnd'                  */
-    else if ( nrError == 0  && TLS(IntrCoding) ) {
+    else if ( nrError == 0  && STATE(IntrCoding) ) {
         CodeEnd(1);
-        TLS(IntrCoding)--;
-        TLS(CurrLVars) = currLVars;
-        TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-        TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+        STATE(IntrCoding)--;
+        STATE(CurrLVars) = currLVars;
+        STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+        STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
     }
 
     /* pop the new local variables list                                    */
-    assert(TLS(CountNams) > 0);
-    TLS(CountNams)--;
+    assert(STATE(CountNams) > 0);
+    STATE(CountNams)--;
 }
 
 /****************************************************************************
@@ -1629,9 +1629,9 @@ void ReadFuncExpr1 (
     /* make and push the new local variables list                          */
     nams = NEW_PLIST( T_PLIST, 1 );
     SET_LEN_PLIST( nams, 0 );
-    TLS(CountNams)++;
-    ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
-    C_NEW_STRING_DYN( name, TLS(Value) );
+    STATE(CountNams)++;
+    ASS_LIST( STATE(StackNams), STATE(CountNams), nams );
+    C_NEW_STRING_DYN( name, STATE(Value) );
     ASS_LIST( nams, 1, name );
 
     ReadFuncExprBody(follow, nams, 1);
@@ -1654,8 +1654,8 @@ void ReadFuncExpr0 (
     /* make and push the new local variables list                          */
     nams = NEW_PLIST( T_PLIST, 0 );
     SET_LEN_PLIST( nams, 0 );
-    TLS(CountNams)++;
-    ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
+    STATE(CountNams)++;
+    ASS_LIST( STATE(StackNams), STATE(CountNams), nams );
 
     ReadFuncExprBody(follow, nams, 0);
 }
@@ -1687,17 +1687,17 @@ void ReadLiteral (
     TypSymbolSet        follow,
     Char mode)
 {
-    switch (TLS(Symbol)) {
+    switch (STATE(Symbol)) {
 
     /* <Int>                                                               */
     case S_INT:
-        TRY_READ { IntrIntExpr( TLS(Value) ); }
+        TRY_READ { IntrIntExpr( STATE(Value) ); }
         Match( S_INT, "integer", follow );
         break;
 
     /* <Float> */
     case S_FLOAT:
-        TRY_READ { IntrFloatExpr( TLS(Value) ); }
+        TRY_READ { IntrFloatExpr( STATE(Value) ); }
         Match( S_FLOAT, "float", follow );
         break;
 
@@ -1722,7 +1722,7 @@ void ReadLiteral (
 
     /* <Char>                                                              */
     case S_CHAR:
-        TRY_READ { IntrCharExpr( TLS(Value)[0] ); }
+        TRY_READ { IntrCharExpr( STATE(Value)[0] ); }
         Match( S_CHAR, "character", follow );
         break;
 
@@ -1769,9 +1769,9 @@ void ReadLiteral (
            of the right kind to end with a . and an associated value and dive
            into the long float literal handler in the parser
          */
-        TLS(Symbol) = S_PARTIALFLOAT1;
-        TLS(Value)[0] = '.';
-        TLS(Value)[1] = '\0';
+        STATE(Symbol) = S_PARTIALFLOAT1;
+        STATE(Value)[0] = '.';
+        STATE(Value)[1] = '\0';
         ReadLongNumber( follow );
         break;
 
@@ -1807,16 +1807,16 @@ void ReadAtom (
     Char                mode )
 {
     /* read a variable                                                     */
-    if ( TLS(Symbol) == S_IDENT ) {
+    if ( STATE(Symbol) == S_IDENT ) {
         ReadCallVarAss( follow, mode );
     }
 
     /* 'IsBound' '(' <Var> ')'                                             */
-    else if ( TLS(Symbol) == S_ISBOUND ) {
+    else if ( STATE(Symbol) == S_ISBOUND ) {
         ReadIsBound( follow );
     }
     /* otherwise read a literal expression                                 */
-    else if (IS_IN(TLS(Symbol),S_INT|S_TRUE|S_FALSE|S_CHAR|S_STRING|S_LBRACK|
+    else if (IS_IN(STATE(Symbol),S_INT|S_TRUE|S_FALSE|S_CHAR|S_STRING|S_LBRACK|
                           S_REC|S_FUNCTION|
 #ifdef HPCGAP
                           S_DO|
@@ -1827,15 +1827,15 @@ void ReadAtom (
     }
 
     /* '(' <Expr> ')'                                                      */
-    else if ( TLS(Symbol) == S_LPAREN ) {
+    else if ( STATE(Symbol) == S_LPAREN ) {
         Match( S_LPAREN, "(", follow );
-        if ( TLS(Symbol) == S_RPAREN ) {
+        if ( STATE(Symbol) == S_RPAREN ) {
             Match( S_RPAREN, ")", follow );
             TRY_READ { IntrPerm( 0UL ); }
             return;
         }
         ReadExpr( S_RPAREN|follow, 'r' );
-        if ( TLS(Symbol) == S_COMMA ) {
+        if ( STATE(Symbol) == S_COMMA ) {
             ReadPerm( follow );
             return;
         }
@@ -1869,27 +1869,27 @@ void ReadFactor (
 
     /* { '+'|'-' }  leading sign                                           */
     sign1 = 0;
-    if ( TLS(Symbol) == S_MINUS  || TLS(Symbol) == S_PLUS ) {
+    if ( STATE(Symbol) == S_MINUS  || STATE(Symbol) == S_PLUS ) {
         if ( sign1 == 0 )  sign1 = 1;
-        if ( TLS(Symbol) == S_MINUS ) { sign1 = -sign1; }
-        Match( TLS(Symbol), "unary + or -", follow );
+        if ( STATE(Symbol) == S_MINUS ) { sign1 = -sign1; }
+        Match( STATE(Symbol), "unary + or -", follow );
     }
 
     /* <Atom>                                                              */
     ReadAtom( follow, (sign1 == 0 ? mode : 'r') );
 
     /* ['^' <Atom> ] implemented as {'^' <Atom> } for better error message */
-    while ( TLS(Symbol) == S_POW ) {
+    while ( STATE(Symbol) == S_POW ) {
 
         /* match the '^' away                                              */
         Match( S_POW, "^", follow );
 
         /* { '+'|'-' }  leading sign                                       */
         sign2 = 0;
-        if ( TLS(Symbol) == S_MINUS  || TLS(Symbol) == S_PLUS ) {
+        if ( STATE(Symbol) == S_MINUS  || STATE(Symbol) == S_PLUS ) {
             if ( sign2 == 0 )  sign2 = 1;
-            if ( TLS(Symbol) == S_MINUS ) { sign2 = -sign2; }
-            Match( TLS(Symbol), "unary + or -", follow );
+            if ( STATE(Symbol) == S_MINUS ) { sign2 = -sign2; }
+            Match( STATE(Symbol), "unary + or -", follow );
         }
 
         /* ['^' <Atom>]                                                    */
@@ -1904,7 +1904,7 @@ void ReadFactor (
         TRY_READ { IntrPow(); }
 
         /* check for multiple '^'                                          */
-        if ( TLS(Symbol) == S_POW ) { SyntaxError("'^' is not associative"); }
+        if ( STATE(Symbol) == S_POW ) { SyntaxError("'^' is not associative"); }
 
     }
 
@@ -1935,9 +1935,9 @@ void ReadTerm (
 
     /* { '*'|'/'|'mod' <Factor> }                                          */
     /* do not use 'IS_IN', since 'IS_IN(S_POW,S_MULT|S_DIV|S_MOD)' is true */
-    while ( TLS(Symbol) == S_MULT || TLS(Symbol) == S_DIV || TLS(Symbol) == S_MOD ) {
-        symbol = TLS(Symbol);
-        Match( TLS(Symbol), "*, /, or mod", follow );
+    while ( STATE(Symbol) == S_MULT || STATE(Symbol) == S_DIV || STATE(Symbol) == S_MOD ) {
+        symbol = STATE(Symbol);
+        Match( STATE(Symbol), "*, /, or mod", follow );
         ReadFactor( follow, 'r' );
         TRY_READ {
             if      ( symbol == S_MULT ) { IntrProd(); }
@@ -1967,9 +1967,9 @@ void ReadAri (
     ReadTerm( follow, mode );
 
     /* { '+'|'-' <Term> }                                                  */
-    while ( IS_IN( TLS(Symbol), S_PLUS|S_MINUS ) ) {
-        symbol = TLS(Symbol);
-        Match( TLS(Symbol), "+ or -", follow );
+    while ( IS_IN( STATE(Symbol), S_PLUS|S_MINUS ) ) {
+        symbol = STATE(Symbol);
+        Match( STATE(Symbol), "+ or -", follow );
         ReadTerm( follow, 'r' );
         TRY_READ {
             if      ( symbol == S_PLUS  ) { IntrSum();  }
@@ -1997,7 +1997,7 @@ void ReadRel (
 
     /* { 'not' }                                                           */
     isNot = 0;
-    while ( TLS(Symbol) == S_NOT ) {
+    while ( STATE(Symbol) == S_NOT ) {
         isNot++;
         Match( S_NOT, "not", follow );
     }
@@ -2006,9 +2006,9 @@ void ReadRel (
     ReadAri( follow, (isNot == 0 ? mode : 'r') );
 
     /* { '=|<>|<|>|<=|>=|in' <Arith> }                                     */
-    if ( IS_IN( TLS(Symbol), S_EQ|S_LT|S_GT|S_NE|S_LE|S_GE|S_IN ) ) {
-        symbol = TLS(Symbol);
-        Match( TLS(Symbol), "comparison operator", follow );
+    if ( IS_IN( STATE(Symbol), S_EQ|S_LT|S_GT|S_NE|S_LE|S_GE|S_IN ) ) {
+        symbol = STATE(Symbol);
+        Match( STATE(Symbol), "comparison operator", follow );
         ReadAri( follow, 'r' );
         TRY_READ {
             if      ( symbol == S_EQ ) { IntrEq(); }
@@ -2045,7 +2045,7 @@ void ReadAnd (
     ReadRel( follow, mode );
 
     /* { 'and' <Rel> }                                                     */
-    while ( TLS(Symbol) == S_AND ) {
+    while ( STATE(Symbol) == S_AND ) {
         Match( S_AND, "and", follow );
         TRY_READ { IntrAndL(); }
         ReadRel( follow, 'r' );
@@ -2072,12 +2072,12 @@ void ReadQualifiedExpr (
     Char                mode )
 {
   UInt access  = 0;
-  if (TLS(Symbol) == S_READWRITE) 
+  if (STATE(Symbol) == S_READWRITE) 
     {
       Match( S_READWRITE, "readwrite", follow | EXPRBEGIN );
       access = 2;
     }
-  else if (TLS(Symbol) == S_READONLY) 
+  else if (STATE(Symbol) == S_READONLY) 
     {
       Match( S_READONLY, "readonly", follow | EXPRBEGIN );
       access = 1;
@@ -2106,7 +2106,7 @@ void ReadExpr (
     ReadAnd( follow, mode );
 
     /* { 'or' <And> }                                                      */
-    while ( TLS(Symbol) == S_OR ) {
+    while ( STATE(Symbol) == S_OR ) {
         Match( S_OR, "or", follow );
         TRY_READ { IntrOrL(); }
         ReadAnd( follow, 'r' );
@@ -2170,7 +2170,7 @@ void ReadInfo (
     ReadExpr( S_RPAREN | S_COMMA | follow, 'r');
     TRY_READ { IntrInfoMiddle(); }
     narg = 0;
-    while ( TLS(Symbol) == S_COMMA ) {
+    while ( STATE(Symbol) == S_COMMA ) {
         narg++;
         Match( S_COMMA, "", 0L);
         ReadExpr( S_RPAREN | S_COMMA | follow, 'r');
@@ -2200,7 +2200,7 @@ void ReadAssert (
     Match( S_COMMA, ",", S_RPAREN|follow );
     ReadExpr( S_RPAREN | S_COMMA | follow, 'r' );
     TRY_READ { IntrAssertAfterCondition(); }
-    if ( TLS(Symbol) == S_COMMA )
+    if ( STATE(Symbol) == S_COMMA )
       {
         Match( S_COMMA, "", 0L);
         ReadExpr( S_RPAREN |  follow, 'r' );
@@ -2244,7 +2244,7 @@ void ReadIf (
     nrb++;
 
     /* { 'elif' <Expr>  'then' <Statments> }                               */
-    while ( TLS(Symbol) == S_ELIF ) {
+    while ( STATE(Symbol) == S_ELIF ) {
         TRY_READ { IntrIfElif(); }
         Match( S_ELIF, "elif", follow );
         ReadExpr( S_THEN|S_ELIF|S_ELSE|S_FI|follow, 'r' );
@@ -2256,7 +2256,7 @@ void ReadIf (
     }
 
     /* [ 'else' <Statments> ]                                              */
-    if ( TLS(Symbol) == S_ELSE ) {
+    if ( STATE(Symbol) == S_ELSE ) {
         TRY_READ { IntrIfElse(); }
         Match( S_ELSE, "else", follow );
         TRY_READ { IntrIfBeginBody(); }
@@ -2288,12 +2288,12 @@ void ReadFor (
     TypSymbolSet        follow )
 {
     volatile UInt       nrs;            /* number of statements in body    */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>               */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>             */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>               */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>             */
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
 
     /* 'for'                                                               */
     TRY_READ { IntrForBegin(); }
@@ -2323,12 +2323,12 @@ void ReadFor (
         /* If we hadn't actually come out of coding the body, we need
            to recover. Otherwise it was probably an error in executing the
            body and we just return */
-        if ( nrError == 0 && TLS(IntrCoding) ) {
+        if ( nrError == 0 && STATE(IntrCoding) ) {
             CodeEnd(1);
-            TLS(IntrCoding)--;
-            TLS(CurrLVars) = currLVars;
-            TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-            TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+            STATE(IntrCoding)--;
+            STATE(CurrLVars) = currLVars;
+            STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+            STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
         }
     }
 }
@@ -2349,12 +2349,12 @@ void ReadWhile (
     TypSymbolSet        follow )
 {
     volatile UInt       nrs;            /* number of statements in body    */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>             */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>          */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>             */
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
 
     /* 'while' <Expr>  'do'                                                */
     TRY_READ { IntrWhileBegin(); }
@@ -2377,12 +2377,12 @@ void ReadWhile (
         /* If we hadn't actually come out of coding the body, we need
            to recover. Otherwise it was probably an error in executing the
            body and we just return */
-        if ( nrError == 0 && TLS(IntrCoding) ) {
+        if ( nrError == 0 && STATE(IntrCoding) ) {
             CodeEnd(1);
-            TLS(IntrCoding)--;
-            TLS(CurrLVars) = currLVars;
-            TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-            TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+            STATE(IntrCoding)--;
+            STATE(CurrLVars) = currLVars;
+            STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+            STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
         }
     }
 }
@@ -2404,17 +2404,17 @@ void ReadAtomic (
 {
     volatile UInt       nrs;            /* number of statements in body    */
     volatile UInt       nexprs;         /* number of statements in body    */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>        */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>          */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>        */
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
     /* lockSP    = RegionLockSP(); */
 
     Match( S_ATOMIC, "atomic", follow );
     /* Might just be an atomic function literal as an expression */
-    if (TLS(Symbol) == S_FUNCTION) {
+    if (STATE(Symbol) == S_FUNCTION) {
       ReadExpr(follow, 'a');
       return; }
 
@@ -2422,7 +2422,7 @@ void ReadAtomic (
     
     ReadQualifiedExpr( S_DO|S_OD|follow, 'r' );
     nexprs = 1;
-    while (TLS(Symbol) == S_COMMA) {
+    while (STATE(Symbol) == S_COMMA) {
       Match( S_COMMA, "comma", follow | S_DO | S_OD );
       ReadQualifiedExpr( S_DO|S_OD|follow, 'r' );
       nexprs ++;
@@ -2445,12 +2445,12 @@ void ReadAtomic (
         /* If we hadn't actually come out of coding the body, we need
            to recover. Otherwise it was probably an error in executing the
            body and we just return */
-        if ( nrError == 0 && TLS(IntrCoding) ) {
+        if ( nrError == 0 && STATE(IntrCoding) ) {
             CodeEnd(1);
-            TLS(IntrCoding)--;
-            TLS(CurrLVars) = currLVars;
-            TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-            TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+            STATE(IntrCoding)--;
+            STATE(CurrLVars) = currLVars;
+            STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+            STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
         }
     }
 }
@@ -2471,12 +2471,12 @@ void ReadRepeat (
     TypSymbolSet        follow )
 {
     volatile UInt       nrs;            /* number of statements in body    */
-    volatile UInt       nrError;        /* copy of <TLS(NrError)>          */
-    volatile Bag        currLVars;      /* copy of <TLS(CurrLVars)>        */
+    volatile UInt       nrError;        /* copy of <STATE(NrError)>          */
+    volatile Bag        currLVars;      /* copy of <STATE(CurrLVars)>        */
 
     /* remember the current variables in case of an error                  */
-    currLVars = TLS(CurrLVars);
-    nrError   = TLS(NrError);
+    currLVars = STATE(CurrLVars);
+    nrError   = STATE(NrError);
 
     /* 'repeat'                                                            */
     TRY_READ { IntrRepeatBegin(); }
@@ -2498,12 +2498,12 @@ void ReadRepeat (
         /* If we hadn't actually come out of coding the body, we need
            to recover. Otherwise it was probably an error in executing the
            body and we just return */
-        if ( nrError == 0 && TLS(IntrCoding) ) {
+        if ( nrError == 0 && STATE(IntrCoding) ) {
             CodeEnd(1);
-            TLS(IntrCoding)--;
-            TLS(CurrLVars) = currLVars;
-            TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-            TLS(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+            STATE(IntrCoding)--;
+            STATE(CurrLVars) = currLVars;
+            STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+            STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
         }
     }
 }
@@ -2568,7 +2568,7 @@ void ReadReturn (
     Match( S_RETURN, "return", follow );
 
     /* 'return' with no expression following                               */
-    if ( TLS(Symbol) == S_SEMICOLON ) {
+    if ( STATE(Symbol) == S_SEMICOLON ) {
         TRY_READ { IntrReturnVoid(); }
     }
 
@@ -2671,23 +2671,23 @@ UInt ReadStats (
 
     /* read the statements                                                 */
     nr = 0;
-    while ( IS_IN( TLS(Symbol), STATBEGIN|S_SEMICOLON ) ) {
+    while ( IS_IN( STATE(Symbol), STATBEGIN|S_SEMICOLON ) ) {
 
         /* read a statement                                                */
-        if      ( TLS(Symbol) == S_IDENT  ) ReadCallVarAss(follow,'s');
-        else if ( TLS(Symbol) == S_UNBIND ) ReadUnbind(    follow    );
-        else if ( TLS(Symbol) == S_INFO   ) ReadInfo(      follow    );
-        else if ( TLS(Symbol) == S_ASSERT ) ReadAssert(    follow    );
-        else if ( TLS(Symbol) == S_IF     ) ReadIf(        follow    );
-        else if ( TLS(Symbol) == S_FOR    ) ReadFor(       follow    );
-        else if ( TLS(Symbol) == S_WHILE  ) ReadWhile(     follow    );
-        else if ( TLS(Symbol) == S_REPEAT ) ReadRepeat(    follow    );
-        else if ( TLS(Symbol) == S_BREAK  ) ReadBreak(     follow    );
-        else if ( TLS(Symbol) == S_CONTINUE) ReadContinue(     follow    );
-        else if ( TLS(Symbol) == S_RETURN ) ReadReturn(    follow    );
-        else if ( TLS(Symbol) == S_TRYNEXT) ReadTryNext(   follow    );
-	else if ( TLS(Symbol) == S_QUIT   ) ReadQuit(      follow    );
-	else if ( TLS(Symbol) == S_ATOMIC ) ReadAtomic(    follow    );
+        if      ( STATE(Symbol) == S_IDENT  ) ReadCallVarAss(follow,'s');
+        else if ( STATE(Symbol) == S_UNBIND ) ReadUnbind(    follow    );
+        else if ( STATE(Symbol) == S_INFO   ) ReadInfo(      follow    );
+        else if ( STATE(Symbol) == S_ASSERT ) ReadAssert(    follow    );
+        else if ( STATE(Symbol) == S_IF     ) ReadIf(        follow    );
+        else if ( STATE(Symbol) == S_FOR    ) ReadFor(       follow    );
+        else if ( STATE(Symbol) == S_WHILE  ) ReadWhile(     follow    );
+        else if ( STATE(Symbol) == S_REPEAT ) ReadRepeat(    follow    );
+        else if ( STATE(Symbol) == S_BREAK  ) ReadBreak(     follow    );
+        else if ( STATE(Symbol) == S_CONTINUE) ReadContinue(     follow    );
+        else if ( STATE(Symbol) == S_RETURN ) ReadReturn(    follow    );
+        else if ( STATE(Symbol) == S_TRYNEXT) ReadTryNext(   follow    );
+	else if ( STATE(Symbol) == S_QUIT   ) ReadQuit(      follow    );
+	else if ( STATE(Symbol) == S_ATOMIC ) ReadAtomic(    follow    );
 	else                           ReadEmpty(     follow    );
 	nr++;
         Match( S_SEMICOLON, ";", follow );
@@ -2731,27 +2731,27 @@ void RecreateStackNams( Obj context )
   Obj lvars = context;
   Obj nams;
   UInt i;
-  while (lvars != TLS(BottomLVars) && lvars != (Obj)0)
+  while (lvars != STATE(BottomLVars) && lvars != (Obj)0)
     {
       nams = NAMS_FUNC(PTR_BAG(lvars)[0]);
       if (nams != (Obj) 0)
 	{
-	  GROW_PLIST(TLS(StackNams), ++TLS(CountNams));
-	  SET_ELM_PLIST( TLS(StackNams), TLS(CountNams), nams);
-	  SET_LEN_PLIST( TLS(StackNams), TLS(CountNams));
+	  GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
+	  SET_ELM_PLIST( STATE(StackNams), STATE(CountNams), nams);
+	  SET_LEN_PLIST( STATE(StackNams), STATE(CountNams));
 	}
       lvars = ENVI_FUNC(PTR_BAG(lvars)[0]);
     }
 
   /* At this point we have the stack upside down, so invert it */
-  for (i = 1; i <= TLS(CountNams)/2; i++)
+  for (i = 1; i <= STATE(CountNams)/2; i++)
     {
-      nams = ELM_PLIST(TLS(StackNams), i);
-      SET_ELM_PLIST( TLS(StackNams),
+      nams = ELM_PLIST(STATE(StackNams), i);
+      SET_ELM_PLIST( STATE(StackNams),
 		     i,
-		     ELM_PLIST(TLS(StackNams), TLS(CountNams) + 1 -i));
-      SET_ELM_PLIST( TLS(StackNams),
-		     TLS(CountNams) + 1 -i,
+		     ELM_PLIST(STATE(StackNams), STATE(CountNams) + 1 -i));
+      SET_ELM_PLIST( STATE(StackNams),
+		     STATE(CountNams) + 1 -i,
 		     nams);
     }
 }
@@ -2770,70 +2770,70 @@ ExecStatus ReadEvalCommand ( Obj context, UInt *dualSemicolon )
     syJmp_buf           readJmpError;
 
     /* get the first symbol from the input                                 */
-    Match( TLS(Symbol), "", 0UL );
+    Match( STATE(Symbol), "", 0UL );
 
     /* using TRY_READ sets the jump buffer and mucks up the interpreter    */
-    if (TLS(NrError)) {
+    if (STATE(NrError)) {
         return STATUS_ERROR;
     }
 
     /* if we have hit <end-of-file>, then give up                          */
-    if ( TLS(Symbol) == S_EOF )  { return STATUS_EOF; }
+    if ( STATE(Symbol) == S_EOF )  { return STATUS_EOF; }
 
     /* print only a partial prompt from now on                             */
     if ( !SyQuiet )
-      TLS(Prompt) = "> ";
+      STATE(Prompt) = "> ";
     else
-      TLS(Prompt) = "";
+      STATE(Prompt) = "";
 
     /* remember the old reader context                                     */
-    stackNams   = TLS(StackNams);
-    countNams   = TLS(CountNams);
-    readTop     = TLS(ReadTop);
-    readTilde   = TLS(ReadTilde);
-    currLHSGVar = TLS(CurrLHSGVar);
-    memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+    stackNams   = STATE(StackNams);
+    countNams   = STATE(CountNams);
+    readTop     = STATE(ReadTop);
+    readTilde   = STATE(ReadTilde);
+    currLHSGVar = STATE(CurrLHSGVar);
+    memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
 
     /* intialize everything and begin an interpreter                       */
-    TLS(StackNams)   = NEW_PLIST( T_PLIST, 16 );
-    TLS(CountNams)   = 0;
-    TLS(ReadTop)     = 0;
-    TLS(ReadTilde)   = 0;
-    TLS(CurrLHSGVar) = 0;
+    STATE(StackNams)   = NEW_PLIST( T_PLIST, 16 );
+    STATE(CountNams)   = 0;
+    STATE(ReadTop)     = 0;
+    STATE(ReadTilde)   = 0;
+    STATE(CurrLHSGVar) = 0;
     RecreateStackNams(context);
-    errorLVars = TLS(ErrorLVars);
-    errorLVars0 = TLS(ErrorLVars0);
-    TLS(ErrorLVars) = context;
-    TLS(ErrorLVars0) = TLS(ErrorLVars);
+    errorLVars = STATE(ErrorLVars);
+    errorLVars0 = STATE(ErrorLVars0);
+    STATE(ErrorLVars) = context;
+    STATE(ErrorLVars0) = STATE(ErrorLVars);
 
     IntrBegin( context );
 
     /* read an expression or an assignment or a procedure call             */
-    if      (TLS(Symbol) == S_IDENT   ) { ReadExpr(    S_SEMICOLON|S_EOF, 'x' ); }
+    if      (STATE(Symbol) == S_IDENT   ) { ReadExpr(    S_SEMICOLON|S_EOF, 'x' ); }
 
     /* otherwise read a statement                                          */
-    else if (TLS(Symbol)==S_UNBIND    ) { ReadUnbind(  S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_INFO      ) { ReadInfo(    S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_ASSERT    ) { ReadAssert(  S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_IF        ) { ReadIf(      S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_FOR       ) { ReadFor(     S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_WHILE     ) { ReadWhile(   S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_REPEAT    ) { ReadRepeat(  S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_BREAK     ) { ReadBreak(   S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_CONTINUE  ) { ReadContinue(S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_RETURN    ) { ReadReturn(  S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_TRYNEXT   ) { ReadTryNext( S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_QUIT      ) { ReadQuit(    S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_QQUIT     ) { ReadQUIT(    S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_SEMICOLON ) { ReadEmpty(   S_SEMICOLON|S_EOF      ); }
-    else if (TLS(Symbol)==S_ATOMIC    ) { ReadAtomic(  S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_UNBIND    ) { ReadUnbind(  S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_INFO      ) { ReadInfo(    S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_ASSERT    ) { ReadAssert(  S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_IF        ) { ReadIf(      S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_FOR       ) { ReadFor(     S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_WHILE     ) { ReadWhile(   S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_REPEAT    ) { ReadRepeat(  S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_BREAK     ) { ReadBreak(   S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_CONTINUE  ) { ReadContinue(S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_RETURN    ) { ReadReturn(  S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_TRYNEXT   ) { ReadTryNext( S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_QUIT      ) { ReadQuit(    S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_QQUIT     ) { ReadQUIT(    S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_SEMICOLON ) { ReadEmpty(   S_SEMICOLON|S_EOF      ); }
+    else if (STATE(Symbol)==S_ATOMIC    ) { ReadAtomic(  S_SEMICOLON|S_EOF      ); }
 
     /* otherwise try to read an expression                                 */
     /* Unless the statement is empty, in which case do nothing             */
     else                           { ReadExpr(    S_SEMICOLON|S_EOF, 'r' ); }
 
     /* every statement must be terminated by a semicolon                  */
-    if ( TLS(Symbol) != S_SEMICOLON ) {
+    if ( STATE(Symbol) != S_SEMICOLON ) {
         SyntaxError( "; expected");
     }
 
@@ -2844,7 +2844,7 @@ ExecStatus ReadEvalCommand ( Obj context, UInt *dualSemicolon )
         type = IntrEnd( 0UL );
 
         /* check for dual semicolon */
-        if ( *TLS(In) == ';' ) {
+        if ( *STATE(In) == ';' ) {
             GetSymbol();
             if (dualSemicolon) *dualSemicolon = 1;
         } else {
@@ -2857,17 +2857,17 @@ ExecStatus ReadEvalCommand ( Obj context, UInt *dualSemicolon )
     }
 
     /* switch back to the old reader context                               */
-    memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
-    TLS(StackNams)   = stackNams;
-    TLS(CountNams)   = countNams;
-    TLS(ReadTop)     = readTop;
-    TLS(ReadTilde)   = readTilde;
-    TLS(CurrLHSGVar) = currLHSGVar;
-    TLS(ErrorLVars) = errorLVars;
-    TLS(ErrorLVars0) = errorLVars0;
+    memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+    STATE(StackNams)   = stackNams;
+    STATE(CountNams)   = countNams;
+    STATE(ReadTop)     = readTop;
+    STATE(ReadTilde)   = readTilde;
+    STATE(CurrLHSGVar) = currLHSGVar;
+    STATE(ErrorLVars) = errorLVars;
+    STATE(ErrorLVars0) = errorLVars0;
 
     /* copy the result (if any)                                            */
-    TLS(ReadEvalResult) = TLS(IntrResult);
+    STATE(ReadEvalResult) = STATE(IntrResult);
 
     /* return whether a return-statement or a quit-statement were executed */
     return type;
@@ -2899,54 +2899,54 @@ UInt ReadEvalFile ( void )
     volatile Int        i;
 
     /* get the first symbol from the input                                 */
-    Match( TLS(Symbol), "", 0UL );
+    Match( STATE(Symbol), "", 0UL );
 
     /* if we have hit <end-of-file>, then give up                          */
-    if ( TLS(Symbol) == S_EOF )  { return STATUS_EOF; }
+    if ( STATE(Symbol) == S_EOF )  { return STATUS_EOF; }
 
     /* print only a partial prompt from now on                             */
     if ( !SyQuiet )
-      TLS(Prompt) = "> ";
+      STATE(Prompt) = "> ";
     else
-      TLS(Prompt) = "";
+      STATE(Prompt) = "";
 
     /* remember the old reader context                                     */
-    stackNams   = TLS(StackNams);
-    countNams   = TLS(CountNams);
-    readTop     = TLS(ReadTop);
-    readTilde   = TLS(ReadTilde);
-    currLHSGVar = TLS(CurrLHSGVar);
-    memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+    stackNams   = STATE(StackNams);
+    countNams   = STATE(CountNams);
+    readTop     = STATE(ReadTop);
+    readTilde   = STATE(ReadTilde);
+    currLHSGVar = STATE(CurrLHSGVar);
+    memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
 
     /* intialize everything and begin an interpreter                       */
-    TLS(StackNams)   = NEW_PLIST( T_PLIST, 16 );
-    TLS(CountNams)   = 0;
-    TLS(ReadTop)     = 0;
-    TLS(ReadTilde)   = 0;
-    TLS(CurrLHSGVar) = 0;
-    IntrBegin(TLS(BottomLVars));
+    STATE(StackNams)   = NEW_PLIST( T_PLIST, 16 );
+    STATE(CountNams)   = 0;
+    STATE(ReadTop)     = 0;
+    STATE(ReadTilde)   = 0;
+    STATE(CurrLHSGVar) = 0;
+    IntrBegin(STATE(BottomLVars));
 
     /* check for local variables                                           */
     nloc = 0;
     nams = NEW_PLIST( T_PLIST, nloc );
     SET_LEN_PLIST( nams, nloc );
-    TLS(CountNams) += 1;
-    ASS_LIST( TLS(StackNams), TLS(CountNams), nams );
-    if ( TLS(Symbol) == S_LOCAL ) {
+    STATE(CountNams) += 1;
+    ASS_LIST( STATE(StackNams), STATE(CountNams), nams );
+    if ( STATE(Symbol) == S_LOCAL ) {
         Match( S_LOCAL, "local", 0L );
-        C_NEW_STRING_DYN( name, TLS(Value) );
+        C_NEW_STRING_DYN( name, STATE(Value) );
         nloc += 1;
         ASS_LIST( nams, nloc, name );
         Match( S_IDENT, "identifier", STATBEGIN|S_END );
-        while ( TLS(Symbol) == S_COMMA ) {
-            TLS(Value)[0] = '\0';
+        while ( STATE(Symbol) == S_COMMA ) {
+            STATE(Value)[0] = '\0';
             Match( S_COMMA, ",", 0L );
             for ( i = 1; i <= nloc; i++ ) {
-                if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),TLS(Value)) == 0 ) {
+                if ( strcmp(CSTR_STRING(ELM_LIST(nams,i)),STATE(Value)) == 0 ) {
                     SyntaxError("Name used for two locals");
                 }
             }
-            C_NEW_STRING_DYN( name, TLS(Value) );
+            C_NEW_STRING_DYN( name, STATE(Value) );
             nloc += 1;
             ASS_LIST( nams, nloc, name );
             Match( S_IDENT, "identifier", STATBEGIN|S_END );
@@ -2955,13 +2955,13 @@ UInt ReadEvalFile ( void )
     }
 
     /* fake the 'function ()'                                              */
-    IntrFuncExprBegin( 0L, nloc, nams, TLS(Input)->number );
+    IntrFuncExprBegin( 0L, nloc, nams, STATE(Input)->number );
 
     /* read the statements                                                 */
     nr = ReadStats( S_SEMICOLON | S_EOF );
 
     /* we now want to be at <end-of-file>                                  */
-    if ( TLS(Symbol) != S_EOF ) {
+    if ( STATE(Symbol) != S_EOF ) {
         SyntaxError("<end-of-file> expected");
     }
 
@@ -2972,7 +2972,7 @@ UInt ReadEvalFile ( void )
     CATCH_READ_ERROR {
         Obj fexp;
         CodeEnd(1);
-        TLS(IntrCoding)--;
+        STATE(IntrCoding)--;
         fexp = CURR_FUNC;
         if (fexp && ENVI_FUNC(fexp))  SWITCH_TO_OLD_LVARS(ENVI_FUNC(fexp));
     }
@@ -2987,15 +2987,15 @@ UInt ReadEvalFile ( void )
     }
 
     /* switch back to the old reader context                               */
-    memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
-    TLS(StackNams)   = stackNams;
-    TLS(CountNams)   = countNams;
-    TLS(ReadTop)     = readTop;
-    TLS(ReadTilde)   = readTilde;
-    TLS(CurrLHSGVar) = currLHSGVar;
+    memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+    STATE(StackNams)   = stackNams;
+    STATE(CountNams)   = countNams;
+    STATE(ReadTop)     = readTop;
+    STATE(ReadTilde)   = readTilde;
+    STATE(CurrLHSGVar) = currLHSGVar;
 
     /* copy the result (if any)                                            */
-    TLS(ReadEvalResult) = TLS(IntrResult);
+    STATE(ReadEvalResult) = STATE(IntrResult);
 
     /* return whether a return-statement or a quit-statement were executed */
     return type;
@@ -3008,9 +3008,9 @@ UInt ReadEvalFile ( void )
 */
 void            ReadEvalError ( void )
 {
-    TLS(PtrBody)  = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
-    TLS(PtrLVars) = PTR_BAG(TLS(CurrLVars));
-    syLongjmp( TLS(ReadJmpError), 1 );
+    STATE(PtrBody)  = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+    STATE(PtrLVars) = PTR_BAG(STATE(CurrLVars));
+    syLongjmp( STATE(ReadJmpError), 1 );
 }
 
 
@@ -3037,44 +3037,44 @@ struct SavedReaderState {
 };
 
 static void SaveReaderState( struct SavedReaderState *s) {
-  s->stackNams   = TLS(StackNams);
-  s->countNams   = TLS(CountNams);
-  s->readTop     = TLS(ReadTop);
-  s->readTilde   = TLS(ReadTilde);
-  s->currLHSGVar = TLS(CurrLHSGVar);
-  s->userHasQuit = TLS(UserHasQuit);
-  s->intrCoding = TLS(IntrCoding);
-  s->intrIgnoring = TLS(IntrIgnoring);
-  s->intrReturning = TLS(IntrReturning);
-  s->nrError = TLS(NrError);
-  memcpy( s->readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+  s->stackNams   = STATE(StackNams);
+  s->countNams   = STATE(CountNams);
+  s->readTop     = STATE(ReadTop);
+  s->readTilde   = STATE(ReadTilde);
+  s->currLHSGVar = STATE(CurrLHSGVar);
+  s->userHasQuit = STATE(UserHasQuit);
+  s->intrCoding = STATE(IntrCoding);
+  s->intrIgnoring = STATE(IntrIgnoring);
+  s->intrReturning = STATE(IntrReturning);
+  s->nrError = STATE(NrError);
+  memcpy( s->readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
 }
 
 static void ClearReaderState( void ) {
-  TLS(StackNams)   = NEW_PLIST( T_PLIST, 16 );
-  TLS(CountNams)   = 0;
-  TLS(ReadTop)     = 0;
-  TLS(ReadTilde)   = 0;
-  TLS(CurrLHSGVar) = 0;
-  TLS(UserHasQuit) = 0;
-  TLS(IntrCoding) = 0;
-  TLS(IntrIgnoring) = 0;
-  TLS(IntrReturning) = 0;
-  TLS(NrError) = 0;
+  STATE(StackNams)   = NEW_PLIST( T_PLIST, 16 );
+  STATE(CountNams)   = 0;
+  STATE(ReadTop)     = 0;
+  STATE(ReadTilde)   = 0;
+  STATE(CurrLHSGVar) = 0;
+  STATE(UserHasQuit) = 0;
+  STATE(IntrCoding) = 0;
+  STATE(IntrIgnoring) = 0;
+  STATE(IntrReturning) = 0;
+  STATE(NrError) = 0;
 }
 
 static void RestoreReaderState( const struct SavedReaderState *s) {
-  memcpy( TLS(ReadJmpError), s->readJmpError, sizeof(syJmp_buf) );
-  TLS(UserHasQuit) = s->userHasQuit;
-  TLS(StackNams)   = s->stackNams;
-  TLS(CountNams)   = s->countNams;
-  TLS(ReadTop)     = s->readTop;
-  TLS(ReadTilde)   = s->readTilde;
-  TLS(CurrLHSGVar) = s->currLHSGVar;
-  TLS(IntrCoding) = s->intrCoding;
-  TLS(IntrIgnoring) = s->intrIgnoring;
-  TLS(IntrReturning) = s->intrReturning;
-  TLS(NrError) = s->nrError;
+  memcpy( STATE(ReadJmpError), s->readJmpError, sizeof(syJmp_buf) );
+  STATE(UserHasQuit) = s->userHasQuit;
+  STATE(StackNams)   = s->stackNams;
+  STATE(CountNams)   = s->countNams;
+  STATE(ReadTop)     = s->readTop;
+  STATE(ReadTilde)   = s->readTilde;
+  STATE(CurrLHSGVar) = s->currLHSGVar;
+  STATE(IntrCoding) = s->intrCoding;
+  STATE(IntrIgnoring) = s->intrIgnoring;
+  STATE(IntrReturning) = s->intrReturning;
+  STATE(NrError) = s->nrError;
 }
 
 
@@ -3097,7 +3097,7 @@ Obj Call0ArgsInNewReader(Obj f)
 
   /* intialize everything and begin an interpreter                       */
   ClearReaderState();
-  IntrBegin( TLS(BottomLVars) );
+  IntrBegin( STATE(BottomLVars) );
 
   TRY_READ {
     result = CALL_0ARGS(f);
@@ -3136,7 +3136,7 @@ Obj Call1ArgsInNewReader(Obj f,Obj a)
 
   /* intialize everything and begin an interpreter                       */
   ClearReaderState();
-  IntrBegin( TLS(BottomLVars) );
+  IntrBegin( STATE(BottomLVars) );
 
   TRY_READ {
     result = CALL_1ARGS(f,a);
@@ -3169,10 +3169,10 @@ Obj Call1ArgsInNewReader(Obj f,Obj a)
 static Int InitKernel (
     StructInitInfo *    module )
 {
-    TLS(ErrorLVars) = (UInt **)0;
-    TLS(CurrentGlobalForLoopDepth) = 0;
-    InitGlobalBag( &TLS(ReadEvalResult), "src/read.c:ReadEvalResult" );
-    InitGlobalBag( &TLS(StackNams),      "src/read.c:StackNams"      );
+    STATE(ErrorLVars) = (UInt **)0;
+    STATE(CurrentGlobalForLoopDepth) = 0;
+    InitGlobalBag( &STATE(ReadEvalResult), "src/read.c:ReadEvalResult" );
+    InitGlobalBag( &STATE(StackNams),      "src/read.c:StackNams"      );
     InitCopyGVar( "GAPInfo", &GAPInfo);
     /* return success                                                      */
     return 0;

--- a/src/read.c
+++ b/src/read.c
@@ -11,7 +11,7 @@
 */
 #include <string.h>                     /* memcpy */
 #include <src/system.h>                 /* system dependent part */
-
+#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/read.h
+++ b/src/read.h
@@ -45,12 +45,12 @@
 /* TL: extern syJmp_buf ReadJmpError; */
 
 #define TRY_READ \
-    if (!TLS(NrError)) { \
-        if (sySetjmp(TLS(ReadJmpError))) { \
-            TLS(NrError)++; \
+    if (!STATE(NrError)) { \
+        if (sySetjmp(STATE(ReadJmpError))) { \
+            STATE(NrError)++; \
         }\
     }\
-    if (!TLS(NrError))
+    if (!STATE(NrError))
 
 #define CATCH_READ_ERROR \
     else

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -107,36 +107,36 @@ void            SyntaxError (
 
     /* open error output                                                   */
     OpenOutput( "*errout*" );
-    assert(TLS(Output));
+    assert(STATE(Output));
 
     /* one more error                                                      */
-    TLS(NrError)++;
-    TLS(NrErrLine)++;
+    STATE(NrError)++;
+    STATE(NrErrLine)++;
 
     /* do not print a message if we found one already on the current line  */
-    if ( TLS(NrErrLine) == 1 )
+    if ( STATE(NrErrLine) == 1 )
 
       {
         /* print the message and the filename, unless it is '*stdin*'          */
         Pr( "Syntax error: %s", (Int)msg, 0L );
-        if ( strcmp( "*stdin*", TLS(Input)->name ) != 0 )
-          Pr( " in %s:%d", (Int)TLS(Input)->name, (Int)TLS(Input)->number );
+        if ( strcmp( "*stdin*", STATE(Input)->name ) != 0 )
+          Pr( " in %s:%d", (Int)STATE(Input)->name, (Int)STATE(Input)->number );
         Pr( "\n", 0L, 0L );
 
         /* print the current line                                              */
-        Pr( "%s", (Int)TLS(Input)->line, 0L );
+        Pr( "%s", (Int)STATE(Input)->line, 0L );
 
         /* print a '^' pointing to the current position                        */
-        for ( i = 0; i < TLS(In) - TLS(Input)->line - 1; i++ ) {
-          if ( TLS(Input)->line[i] == '\t' )  Pr("\t",0L,0L);
+        for ( i = 0; i < STATE(In) - STATE(Input)->line - 1; i++ ) {
+          if ( STATE(Input)->line[i] == '\t' )  Pr("\t",0L,0L);
           else  Pr(" ",0L,0L);
         }
         Pr( "^\n", 0L, 0L );
       }
     /* close error output                                                  */
-    assert(TLS(Output));
+    assert(STATE(Output));
     CloseOutput();
-    assert(TLS(Output));
+    assert(STATE(Output));
 }
 
 /****************************************************************************
@@ -151,33 +151,33 @@ void            SyntaxWarning (
 
     /* open error output                                                   */
     OpenOutput( "*errout*" );
-    assert(TLS(Output));
+    assert(STATE(Output));
 
 
     /* do not print a message if we found one already on the current line  */
-    if ( TLS(NrErrLine) == 0 )
+    if ( STATE(NrErrLine) == 0 )
 
       {
         /* print the message and the filename, unless it is '*stdin*'          */
         Pr( "Syntax warning: %s", (Int)msg, 0L );
-        if ( strcmp( "*stdin*", TLS(Input)->name ) != 0 )
-          Pr( " in %s:%d", (Int)TLS(Input)->name, (Int)TLS(Input)->number );
+        if ( strcmp( "*stdin*", STATE(Input)->name ) != 0 )
+          Pr( " in %s:%d", (Int)STATE(Input)->name, (Int)STATE(Input)->number );
         Pr( "\n", 0L, 0L );
 
         /* print the current line                                              */
-        Pr( "%s", (Int)TLS(Input)->line, 0L );
+        Pr( "%s", (Int)STATE(Input)->line, 0L );
 
         /* print a '^' pointing to the current position                        */
-        for ( i = 0; i < TLS(In) - TLS(Input)->line - 1; i++ ) {
-          if ( TLS(Input)->line[i] == '\t' )  Pr("\t",0L,0L);
+        for ( i = 0; i < STATE(In) - STATE(Input)->line - 1; i++ ) {
+          if ( STATE(Input)->line[i] == '\t' )  Pr("\t",0L,0L);
           else  Pr(" ",0L,0L);
         }
         Pr( "^\n", 0L, 0L );
       }
     /* close error output                                                  */
-    assert(TLS(Output));
+    assert(STATE(Output));
     CloseOutput();
-    assert(TLS(Output));
+    assert(STATE(Output));
 }
 
 
@@ -231,8 +231,8 @@ void Match (
 {
     Char                errmsg [256];
 
-    /* if 'TLS(Symbol)' is the expected symbol match it away                    */
-    if ( symbol == TLS(Symbol) ) {
+    /* if 'STATE(Symbol)' is the expected symbol match it away                    */
+    if ( symbol == STATE(Symbol) ) {
         GetSymbol();
     }
 
@@ -241,7 +241,7 @@ void Match (
         strlcpy( errmsg, msg, sizeof(errmsg) );
         strlcat( errmsg, " expected", sizeof(errmsg) );
         SyntaxError( errmsg );
-        while ( ! IS_IN( TLS(Symbol), skipto ) )
+        while ( ! IS_IN( STATE(Symbol), skipto ) )
             GetSymbol();
     }
 }
@@ -293,7 +293,7 @@ UInt OpenInput (
     Int                 file;
 
     /* fail if we can not handle another open input file                   */
-    if ( TLS(Input)+1 == TLS(InputFiles)+(sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0])) )
+    if ( STATE(Input)+1 == STATE(InputFiles)+(sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])) )
         return 0;
 
     /* try to open the input file                                          */
@@ -302,30 +302,30 @@ UInt OpenInput (
         return 0;
 
     /* remember the current position in the current file                   */
-    if (TLS(Input) != 0) {
-        TLS(Input)->ptr    = TLS(In);
-        TLS(Input)->symbol = TLS(Symbol);
+    if (STATE(Input) != 0) {
+        STATE(Input)->ptr    = STATE(In);
+        STATE(Input)->symbol = STATE(Symbol);
     }
 
     /* enter the file identifier and the file name                         */
-    if (TLS(Input) == 0)
-        TLS(Input) = TLS(InputFiles);
+    if (STATE(Input) == 0)
+        STATE(Input) = STATE(InputFiles);
     else
-        TLS(Input)++;
-    TLS(Input)->isstream = 0;
-    TLS(Input)->file = file;
+        STATE(Input)++;
+    STATE(Input)->isstream = 0;
+    STATE(Input)->file = file;
     if (strcmp("*errin*", filename) && strcmp("*stdin*", filename))
-      TLS(Input)->echo = 0;
+      STATE(Input)->echo = 0;
     else
-      TLS(Input)->echo = 1;
-    strlcpy( TLS(Input)->name, filename, sizeof(TLS(Input)->name) );
-    TLS(Input)->gapname = (Obj) 0;
+      STATE(Input)->echo = 1;
+    strlcpy( STATE(Input)->name, filename, sizeof(STATE(Input)->name) );
+    STATE(Input)->gapname = (Obj) 0;
 
     /* start with an empty line and no symbol                              */
-    TLS(In) = TLS(Input)->line;
-    TLS(In)[0] = TLS(In)[1] = '\0';
-    TLS(Symbol) = S_ILLEGAL;
-    TLS(Input)->number = 1;
+    STATE(In) = STATE(Input)->line;
+    STATE(In)[0] = STATE(In)[1] = '\0';
+    STATE(Symbol) = S_ILLEGAL;
+    STATE(Input)->number = 1;
 
     /* indicate success                                                    */
     return 1;
@@ -344,36 +344,36 @@ UInt OpenInputStream (
     Obj                 stream )
 {
     /* fail if we can not handle another open input file                   */
-    if ( TLS(Input)+1 == TLS(InputFiles)+(sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0])) )
+    if ( STATE(Input)+1 == STATE(InputFiles)+(sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])) )
         return 0;
 
-    assert(TLS(Input) != 0);
+    assert(STATE(Input) != 0);
 
     /* remember the current position in the current file                   */
-    TLS(Input)->ptr    = TLS(In);
-    TLS(Input)->symbol = TLS(Symbol);
+    STATE(Input)->ptr    = STATE(In);
+    STATE(Input)->symbol = STATE(Symbol);
 
     /* enter the file identifier and the file name                         */
-    TLS(Input)++;
-    TLS(Input)->isstream = 1;
-    TLS(Input)->stream = stream;
-    TLS(Input)->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
-    if (TLS(Input)->isstringstream) {
-        TLS(Input)->sline = ADDR_OBJ(stream)[2];
-        TLS(Input)->spos = INT_INTOBJ(ADDR_OBJ(stream)[1]);
+    STATE(Input)++;
+    STATE(Input)->isstream = 1;
+    STATE(Input)->stream = stream;
+    STATE(Input)->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
+    if (STATE(Input)->isstringstream) {
+        STATE(Input)->sline = ADDR_OBJ(stream)[2];
+        STATE(Input)->spos = INT_INTOBJ(ADDR_OBJ(stream)[1]);
     }
     else {
-        TLS(Input)->sline = 0;
+        STATE(Input)->sline = 0;
     }
-    TLS(Input)->file = -1;
-    TLS(Input)->echo = 0;
-    strlcpy( TLS(Input)->name, "stream", sizeof(TLS(Input)->name) );
+    STATE(Input)->file = -1;
+    STATE(Input)->echo = 0;
+    strlcpy( STATE(Input)->name, "stream", sizeof(STATE(Input)->name) );
 
     /* start with an empty line and no symbol                              */
-    TLS(In) = TLS(Input)->line;
-    TLS(In)[0] = TLS(In)[1] = '\0';
-    TLS(Symbol) = S_ILLEGAL;
-    TLS(Input)->number = 1;
+    STATE(In) = STATE(Input)->line;
+    STATE(In)[0] = STATE(In)[1] = '\0';
+    STATE(Symbol) = S_ILLEGAL;
+    STATE(Input)->number = 1;
 
     /* indicate success                                                    */
     return 1;
@@ -398,22 +398,22 @@ UInt OpenInputStream (
 UInt CloseInput ( void )
 {
     /* refuse to close the initial input file                              */
-    if ( TLS(Input) == TLS(InputFiles) )
+    if ( STATE(Input) == STATE(InputFiles) )
         return 0;
 
     /* close the input file                                                */
-    if ( ! TLS(Input)->isstream ) {
-        SyFclose( TLS(Input)->file );
+    if ( ! STATE(Input)->isstream ) {
+        SyFclose( STATE(Input)->file );
     }
 
     /* don't keep GAP objects alive unnecessarily */
-    TLS(Input)->gapname = 0;
-    TLS(Input)->sline = 0;
+    STATE(Input)->gapname = 0;
+    STATE(Input)->sline = 0;
 
     /* revert to last file                                                 */
-    TLS(Input)--;
-    TLS(In)     = TLS(Input)->ptr;
-    TLS(Symbol) = TLS(Input)->symbol;
+    STATE(Input)--;
+    STATE(In)     = STATE(Input)->ptr;
+    STATE(Symbol) = STATE(Input)->symbol;
 
     /* indicate success                                                    */
     return 1;
@@ -427,9 +427,9 @@ UInt CloseInput ( void )
 
 void FlushRestOfInputLine( void )
 {
-  TLS(In)[0] = TLS(In)[1] = '\0';
-  /* TLS(Input)->number = 1; */
-  TLS(Symbol) = S_ILLEGAL;
+  STATE(In)[0] = STATE(In)[1] = '\0';
+  /* STATE(Input)->number = 1; */
+  STATE(Symbol) = S_ILLEGAL;
 }
 
 /****************************************************************************
@@ -455,17 +455,17 @@ UInt OpenLog (
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( TLS(InputLog) != 0 || TLS(OutputLog) != 0 )
+    if ( STATE(InputLog) != 0 || STATE(OutputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    TLS(LogFile).file = SyFopen( filename, "w" );
-    TLS(LogFile).isstream = 0;
-    if ( TLS(LogFile).file == -1 )
+    STATE(LogFile).file = SyFopen( filename, "w" );
+    STATE(LogFile).isstream = 0;
+    if ( STATE(LogFile).file == -1 )
         return 0;
 
-    TLS(InputLog)  = &TLS(LogFile);
-    TLS(OutputLog) = &TLS(LogFile);
+    STATE(InputLog)  = &STATE(LogFile);
+    STATE(OutputLog) = &STATE(LogFile);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -485,16 +485,16 @@ UInt OpenLogStream (
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( TLS(InputLog) != 0 || TLS(OutputLog) != 0 )
+    if ( STATE(InputLog) != 0 || STATE(OutputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    TLS(LogStream).isstream = 1;
-    TLS(LogStream).stream = stream;
-    TLS(LogStream).file = -1;
+    STATE(LogStream).isstream = 1;
+    STATE(LogStream).stream = stream;
+    STATE(LogStream).file = -1;
 
-    TLS(InputLog)  = &TLS(LogStream);
-    TLS(OutputLog) = &TLS(LogStream);
+    STATE(InputLog)  = &STATE(LogStream);
+    STATE(OutputLog) = &STATE(LogStream);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -515,15 +515,15 @@ UInt OpenLogStream (
 UInt CloseLog ( void )
 {
     /* refuse to close a non existent logfile                              */
-    if ( TLS(InputLog) == 0 || TLS(OutputLog) == 0 || TLS(InputLog) != TLS(OutputLog) )
+    if ( STATE(InputLog) == 0 || STATE(OutputLog) == 0 || STATE(InputLog) != STATE(OutputLog) )
         return 0;
 
     /* close the logfile                                                   */
-    if ( ! TLS(InputLog)->isstream ) {
-        SyFclose( TLS(InputLog)->file );
+    if ( ! STATE(InputLog)->isstream ) {
+        SyFclose( STATE(InputLog)->file );
     }
-    TLS(InputLog)  = 0;
-    TLS(OutputLog) = 0;
+    STATE(InputLog)  = 0;
+    STATE(OutputLog) = 0;
 
     /* indicate success                                                    */
     return 1;
@@ -552,16 +552,16 @@ UInt OpenInputLog (
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( TLS(InputLog) != 0 )
+    if ( STATE(InputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    TLS(InputLogFile).file = SyFopen( filename, "w" );
-    TLS(InputLogFile).isstream = 0;
-    if ( TLS(InputLogFile).file == -1 )
+    STATE(InputLogFile).file = SyFopen( filename, "w" );
+    STATE(InputLogFile).isstream = 0;
+    if ( STATE(InputLogFile).file == -1 )
         return 0;
 
-    TLS(InputLog) = &TLS(InputLogFile);
+    STATE(InputLog) = &STATE(InputLogFile);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -581,15 +581,15 @@ UInt OpenInputLogStream (
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( TLS(InputLog) != 0 )
+    if ( STATE(InputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    TLS(InputLogStream).isstream = 1;
-    TLS(InputLogStream).stream = stream;
-    TLS(InputLogStream).file = -1;
+    STATE(InputLogStream).isstream = 1;
+    STATE(InputLogStream).stream = stream;
+    STATE(InputLogStream).file = -1;
 
-    TLS(InputLog) = &TLS(InputLogStream);
+    STATE(InputLog) = &STATE(InputLogStream);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -610,19 +610,19 @@ UInt OpenInputLogStream (
 UInt CloseInputLog ( void )
 {
     /* refuse to close a non existent logfile                              */
-    if ( TLS(InputLog) == 0 )
+    if ( STATE(InputLog) == 0 )
         return 0;
 
     /* refuse to close a log opened with LogTo */
-    if (TLS(InputLog) == TLS(OutputLog))
+    if (STATE(InputLog) == STATE(OutputLog))
       return 0;
     
     /* close the logfile                                                   */
-    if ( ! TLS(InputLog)->isstream ) {
-        SyFclose( TLS(InputLog)->file );
+    if ( ! STATE(InputLog)->isstream ) {
+        SyFclose( STATE(InputLog)->file );
     }
 
-    TLS(InputLog) = 0;
+    STATE(InputLog) = 0;
 
     /* indicate success                                                    */
     return 1;
@@ -651,16 +651,16 @@ UInt OpenOutputLog (
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( TLS(OutputLog) != 0 )
+    if ( STATE(OutputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    TLS(OutputLogFile).file = SyFopen( filename, "w" );
-    TLS(OutputLogFile).isstream = 0;
-    if ( TLS(OutputLogFile).file == -1 )
+    STATE(OutputLogFile).file = SyFopen( filename, "w" );
+    STATE(OutputLogFile).isstream = 0;
+    if ( STATE(OutputLogFile).file == -1 )
         return 0;
 
-    TLS(OutputLog) = &TLS(OutputLogFile);
+    STATE(OutputLog) = &STATE(OutputLogFile);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -680,15 +680,15 @@ UInt OpenOutputLogStream (
 {
 
     /* refuse to open a logfile if we already log to one                   */
-    if ( TLS(OutputLog) != 0 )
+    if ( STATE(OutputLog) != 0 )
         return 0;
 
     /* try to open the file                                                */
-    TLS(OutputLogStream).isstream = 1;
-    TLS(OutputLogStream).stream = stream;
-    TLS(OutputLogStream).file = -1;
+    STATE(OutputLogStream).isstream = 1;
+    STATE(OutputLogStream).stream = stream;
+    STATE(OutputLogStream).file = -1;
 
-    TLS(OutputLog) = &TLS(OutputLogStream);
+    STATE(OutputLog) = &STATE(OutputLogStream);
 
     /* otherwise indicate success                                          */
     return 1;
@@ -709,19 +709,19 @@ UInt OpenOutputLogStream (
 UInt CloseOutputLog ( void )
 {
     /* refuse to close a non existent logfile                              */
-    if ( TLS(OutputLog) == 0 )
+    if ( STATE(OutputLog) == 0 )
         return 0;
 
     /* refuse to close a log opened with LogTo */
-    if (TLS(OutputLog) == TLS(InputLog))
+    if (STATE(OutputLog) == STATE(InputLog))
       return 0;
 
     /* close the logfile                                                   */
-    if ( ! TLS(OutputLog)->isstream ) {
-        SyFclose( TLS(OutputLog)->file );
+    if ( ! STATE(OutputLog)->isstream ) {
+        SyFclose( STATE(OutputLog)->file );
     }
 
-    TLS(OutputLog) = 0;
+    STATE(OutputLog) = 0;
 
     /* indicate success                                                    */
     return 1;
@@ -762,14 +762,14 @@ UInt OpenOutput (
     Int                 file;
 
     /* do nothing for stdout and errout if catched */
-    if ( TLS(Output) != NULL && TLS(IgnoreStdoutErrout) == TLS(Output) &&
+    if ( STATE(Output) != NULL && STATE(IgnoreStdoutErrout) == STATE(Output) &&
           ( strcmp( filename, "*errout*" ) == 0
            || strcmp( filename, "*stdout*" ) == 0 ) ) {
         return 1;
     }
 
     /* fail if we can not handle another open output file                  */
-    if ( TLS(Output)+1==TLS(OutputFiles)+(sizeof(TLS(OutputFiles))/sizeof(TLS(OutputFiles)[0])) )
+    if ( STATE(Output)+1==STATE(OutputFiles)+(sizeof(STATE(OutputFiles))/sizeof(STATE(OutputFiles)[0])) )
         return 0;
 
     /* try to open the file                                                */
@@ -778,19 +778,19 @@ UInt OpenOutput (
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
-    if (TLS(Output) == 0)
-        TLS(Output) = TLS(OutputFiles);
+    if (STATE(Output) == 0)
+        STATE(Output) = STATE(OutputFiles);
     else
-        TLS(Output)++;
-    TLS(Output)->file     = file;
-    TLS(Output)->line[0]  = '\0';
-    TLS(Output)->pos      = 0;
-    TLS(Output)->indent   = 0;
-    TLS(Output)->isstream = 0;
-    TLS(Output)->format   = 1;
+        STATE(Output)++;
+    STATE(Output)->file     = file;
+    STATE(Output)->line[0]  = '\0';
+    STATE(Output)->pos      = 0;
+    STATE(Output)->indent   = 0;
+    STATE(Output)->isstream = 0;
+    STATE(Output)->format   = 1;
 
     /* variables related to line splitting, very bad place to split        */
-    TLS(Output)->hints[0] = -1;
+    STATE(Output)->hints[0] = -1;
 
     /* indicate success                                                    */
     return 1;
@@ -810,22 +810,22 @@ UInt OpenOutputStream (
     Obj                 stream )
 {
     /* fail if we can not handle another open output file                  */
-    if ( TLS(Output)+1==TLS(OutputFiles)+(sizeof(TLS(OutputFiles))/sizeof(TLS(OutputFiles)[0])) )
+    if ( STATE(Output)+1==STATE(OutputFiles)+(sizeof(STATE(OutputFiles))/sizeof(STATE(OutputFiles)[0])) )
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
-    assert(TLS(Output) != 0);
-    TLS(Output)++;
-    TLS(Output)->stream   = stream;
-    TLS(Output)->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
-    TLS(Output)->format   = (CALL_1ARGS(PrintFormattingStatus, stream) == True);
-    TLS(Output)->line[0]  = '\0';
-    TLS(Output)->pos      = 0;
-    TLS(Output)->indent   = 0;
-    TLS(Output)->isstream = 1;
+    assert(STATE(Output) != 0);
+    STATE(Output)++;
+    STATE(Output)->stream   = stream;
+    STATE(Output)->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
+    STATE(Output)->format   = (CALL_1ARGS(PrintFormattingStatus, stream) == True);
+    STATE(Output)->line[0]  = '\0';
+    STATE(Output)->pos      = 0;
+    STATE(Output)->indent   = 0;
+    STATE(Output)->isstream = 1;
 
     /* variables related to line splitting, very bad place to split        */
-    TLS(Output)->hints[0] = -1;
+    STATE(Output)->hints[0] = -1;
 
     /* indicate success                                                    */
     return 1;
@@ -854,21 +854,21 @@ UInt CloseOutput ( void )
     /* silently refuse to close the test output file this is probably
          an attempt to close *errout* which is silently not opened, so
          lets silently not close it  */
-    if ( TLS(IgnoreStdoutErrout) == TLS(Output) )
+    if ( STATE(IgnoreStdoutErrout) == STATE(Output) )
         return 1;
 
     /* refuse to close the initial output file '*stdout*'                  */
-    if ( TLS(Output) == TLS(OutputFiles) )
+    if ( STATE(Output) == STATE(OutputFiles) )
         return 0;
 
     /* flush output and close the file                                     */
     Pr( "%c", (Int)'\03', 0L );
-    if ( ! TLS(Output)->isstream ) {
-        SyFclose( TLS(Output)->file );
+    if ( ! STATE(Output)->isstream ) {
+        SyFclose( STATE(Output)->file );
     }
 
     /* revert to previous output file and indicate success                 */
-    TLS(Output)--;
+    STATE(Output)--;
     return 1;
 }
 
@@ -890,7 +890,7 @@ UInt OpenAppend (
     Int                 file;
 
     /* fail if we can not handle another open output file                  */
-    if ( TLS(Output)+1==TLS(OutputFiles)+(sizeof(TLS(OutputFiles))/sizeof(TLS(OutputFiles)[0])) )
+    if ( STATE(Output)+1==STATE(OutputFiles)+(sizeof(STATE(OutputFiles))/sizeof(STATE(OutputFiles)[0])) )
         return 0;
 
     /* try to open the file                                                */
@@ -899,16 +899,16 @@ UInt OpenAppend (
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
-    assert(TLS(Output) != 0);
-    TLS(Output)++;
-    TLS(Output)->file     = file;
-    TLS(Output)->line[0]  = '\0';
-    TLS(Output)->pos      = 0;
-    TLS(Output)->indent   = 0;
-    TLS(Output)->isstream = 0;
+    assert(STATE(Output) != 0);
+    STATE(Output)++;
+    STATE(Output)->file     = file;
+    STATE(Output)->line[0]  = '\0';
+    STATE(Output)->pos      = 0;
+    STATE(Output)->indent   = 0;
+    STATE(Output)->isstream = 0;
 
     /* variables related to line splitting, very bad place to split        */
-    TLS(Output)->hints[0] = -1;
+    STATE(Output)->hints[0] = -1;
 
     /* indicate success                                                    */
     return 1;
@@ -1024,40 +1024,40 @@ Char GetLine ( void )
     /* if file is '*stdin*' or '*errin*' print the prompt and flush it     */
     /* if the GAP function `PrintPromptHook' is defined then it is called  */
     /* for printing the prompt, see also `EndLineHook'                     */
-    if ( ! TLS(Input)->isstream ) {
-       if ( TLS(Input)->file == 0 ) {
+    if ( ! STATE(Input)->isstream ) {
+       if ( STATE(Input)->file == 0 ) {
             if ( ! SyQuiet ) {
-                if (TLS(Output)->pos > 0)
+                if (STATE(Output)->pos > 0)
                     Pr("\n", 0L, 0L);
                 if ( PrintPromptHook )
                      Call0ArgsInNewReader( PrintPromptHook );
                 else
-                     Pr( "%s%c", (Int)TLS(Prompt), (Int)'\03' );
+                     Pr( "%s%c", (Int)STATE(Prompt), (Int)'\03' );
             } else
                 Pr( "%c", (Int)'\03', 0L );
         }
-        else if ( TLS(Input)->file == 2 ) {
-            if (TLS(Output)->pos > 0)
+        else if ( STATE(Input)->file == 2 ) {
+            if (STATE(Output)->pos > 0)
                 Pr("\n", 0L, 0L);
             if ( PrintPromptHook )
                  Call0ArgsInNewReader( PrintPromptHook );
             else
-                 Pr( "%s%c", (Int)TLS(Prompt), (Int)'\03' );
+                 Pr( "%s%c", (Int)STATE(Prompt), (Int)'\03' );
         }
     }
 
     /* bump the line number                                                */
-    if ( TLS(Input)->line < TLS(In) && (*(TLS(In)-1) == '\n' || *(TLS(In)-1) == '\r') ) {
-        TLS(Input)->number++;
+    if ( STATE(Input)->line < STATE(In) && (*(STATE(In)-1) == '\n' || *(STATE(In)-1) == '\r') ) {
+        STATE(Input)->number++;
     }
 
-    /* initialize 'TLS(In)', no errors on this line so far                      */
-    TLS(In) = TLS(Input)->line;  TLS(In)[0] = '\0';
-    TLS(NrErrLine) = 0;
+    /* initialize 'STATE(In)', no errors on this line so far                      */
+    STATE(In) = STATE(Input)->line;  STATE(In)[0] = '\0';
+    STATE(NrErrLine) = 0;
 
     /* try to read a line                                              */
-    if ( ! GetLine2( TLS(Input), TLS(Input)->line, sizeof(TLS(Input)->line) ) ) {
-        TLS(In)[0] = '\377';  TLS(In)[1] = '\0';
+    if ( ! GetLine2( STATE(Input), STATE(Input)->line, sizeof(STATE(Input)->line) ) ) {
+        STATE(In)[0] = '\377';  STATE(In)[1] = '\0';
     }
 
 
@@ -1065,10 +1065,10 @@ Char GetLine ( void )
        (if not inside reading long string which may have line
        or chunk from GetLine starting with '?')                        */
 
-    if ( TLS(In)[0] == '?' && TLS(HELPSubsOn) == 1) {
-        strlcpy( buf, TLS(In)+1, sizeof(buf) );
-        strcpy( TLS(In), "HELP(\"" );
-        for ( p = TLS(In)+6,  q = buf;  *q;  q++ ) {
+    if ( STATE(In)[0] == '?' && STATE(HELPSubsOn) == 1) {
+        strlcpy( buf, STATE(In)+1, sizeof(buf) );
+        strcpy( STATE(In), "HELP(\"" );
+        for ( p = STATE(In)+6,  q = buf;  *q;  q++ ) {
             if ( *q != '"' && *q != '\n' ) {
                 *p++ = *q;
             }
@@ -1079,16 +1079,16 @@ Char GetLine ( void )
         }
         *p = '\0';
         /* FIXME: We should do bounds checking, but don't know what 'In' points to */
-        strcat( TLS(In), "\");\n" );
+        strcat( STATE(In), "\");\n" );
     }
 
     /* if necessary echo the line to the logfile                      */
-    if( TLS(InputLog) != 0 && TLS(Input)->echo == 1)
-        if ( !(TLS(In)[0] == '\377' && TLS(In)[1] == '\0') )
-            PutLine2( TLS(InputLog), TLS(In), strlen(TLS(In)) );
+    if( STATE(InputLog) != 0 && STATE(Input)->echo == 1)
+        if ( !(STATE(In)[0] == '\377' && STATE(In)[1] == '\0') )
+            PutLine2( STATE(InputLog), STATE(In), strlen(STATE(In)) );
 
     /* return the current character                                        */
-    return *TLS(In);
+    return *STATE(In);
 }
 
 
@@ -1109,19 +1109,19 @@ static Char Pushback = '\0';
 static Char *RealIn;
 
 static inline void GET_CHAR( void ) {
-  if (TLS(In) == &Pushback) {
-      TLS(In) = RealIn;
+  if (STATE(In) == &Pushback) {
+      STATE(In) = RealIn;
   } else
-    TLS(In)++;
-  if (!*TLS(In))
+    STATE(In)++;
+  if (!*STATE(In))
     GetLine();
 }
 
 static inline void UNGET_CHAR( Char c ) {
-  assert(TLS(In) != &Pushback);
+  assert(STATE(In) != &Pushback);
   Pushback = c;
-  RealIn = TLS(In);
-  TLS(In) = &Pushback;
+  RealIn = STATE(In);
+  STATE(In) = &Pushback;
 }
 
 
@@ -1130,10 +1130,10 @@ static inline void UNGET_CHAR( Char c ) {
 *F  GetIdent()  . . . . . . . . . . . . . get an identifier or keyword, local
 **
 **  'GetIdent' reads   an identifier from  the current  input  file  into the
-**  variable 'TLS(Value)' and sets 'Symbol' to 'S_IDENT'.   The first character of
+**  variable 'STATE(Value)' and sets 'Symbol' to 'S_IDENT'.   The first character of
 **  the   identifier  is  the current character  pointed to  by 'In'.  If the
 **  characters make  up   a  keyword 'GetIdent'  will  set   'Symbol'  to the
-**  corresponding value.  The parser will ignore 'TLS(Value)' in this case.
+**  corresponding value.  The parser will ignore 'STATE(Value)' in this case.
 **
 **  An  identifier consists of a letter  followed by more letters, digits and
 **  underscores '_'.  An identifier is terminated by the first  character not
@@ -1142,19 +1142,19 @@ static inline void UNGET_CHAR( Char c ) {
 **  '\' can be used  to include special characters like  '('  in identifiers.
 **  For example 'G\(2\,5\)' is an identifier not a call to a function 'G'.
 **
-**  The size  of 'TLS(Value)' limits the  number  of significant characters  in an
+**  The size  of 'STATE(Value)' limits the  number  of significant characters  in an
 **  identifier.   If  an  identifier   has more characters    'GetIdent' will
 **  silently truncate it.
 **
 **  After reading the identifier 'GetIdent'  looks at the  first and the last
-**  character  of  'TLS(Value)' to see if  it  could possibly  be  a keyword.  For
+**  character  of  'STATE(Value)' to see if  it  could possibly  be  a keyword.  For
 **  example 'test'  could  not be  a  keyword  because there  is  no  keyword
 **  starting and ending with a 't'.  After that  test either 'GetIdent' knows
-**  that 'TLS(Value)' is not a keyword, or there is a unique possible keyword that
+**  that 'STATE(Value)' is not a keyword, or there is a unique possible keyword that
 **  could match, because   no two  keywords  have  identical  first and  last
-**  characters.  For example if 'TLS(Value)' starts with 'f' and ends with 'n' the
+**  characters.  For example if 'STATE(Value)' starts with 'f' and ends with 'n' the
 **  only possible keyword  is 'function'.   Thus in this case  'GetIdent' can
-**  decide with one string comparison if 'TLS(Value)' holds a keyword or not.
+**  decide with one string comparison if 'STATE(Value)' holds a keyword or not.
 */
 extern void GetSymbol ( void );
 
@@ -1210,39 +1210,39 @@ void GetIdent ( void )
     /* initially it could be a keyword                                     */
     isQuoted = 0;
 
-    /* read all characters into 'TLS(Value)'                                    */
-    for ( i=0; IsIdent(*TLS(In)) || IsDigit(*TLS(In)) || *TLS(In)=='\\'; i++ ) {
+    /* read all characters into 'STATE(Value)'                                    */
+    for ( i=0; IsIdent(*STATE(In)) || IsDigit(*STATE(In)) || *STATE(In)=='\\'; i++ ) {
 
         fetch = 1;
         /* handle escape sequences                                         */
         /* we ignore '\ newline' by decrementing i, except at the
            very start of the identifier, when we cannot do that
            so we recurse instead                                           */
-        if ( *TLS(In) == '\\' ) {
+        if ( *STATE(In) == '\\' ) {
             GET_CHAR();
-            if      ( *TLS(In) == '\n' && i == 0 )  { GetSymbol();  return; }
-            else if ( *TLS(In) == '\r' )  {
+            if      ( *STATE(In) == '\n' && i == 0 )  { GetSymbol();  return; }
+            else if ( *STATE(In) == '\r' )  {
                 GET_CHAR();
-                if  ( *TLS(In) == '\n' )  {
+                if  ( *STATE(In) == '\n' )  {
                      if (i == 0) { GetSymbol();  return; }
                      else i--;
                 }
-                else  {TLS(Value)[i] = '\r'; fetch = 0;}
+                else  {STATE(Value)[i] = '\r'; fetch = 0;}
             }
-            else if ( *TLS(In) == '\n' && i < SAFE_VALUE_SIZE-1 )  i--;
-            else if ( *TLS(In) == 'n'  && i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = '\n';
-            else if ( *TLS(In) == 't'  && i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = '\t';
-            else if ( *TLS(In) == 'r'  && i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = '\r';
-            else if ( *TLS(In) == 'b'  && i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = '\b';
+            else if ( *STATE(In) == '\n' && i < SAFE_VALUE_SIZE-1 )  i--;
+            else if ( *STATE(In) == 'n'  && i < SAFE_VALUE_SIZE-1 )  STATE(Value)[i] = '\n';
+            else if ( *STATE(In) == 't'  && i < SAFE_VALUE_SIZE-1 )  STATE(Value)[i] = '\t';
+            else if ( *STATE(In) == 'r'  && i < SAFE_VALUE_SIZE-1 )  STATE(Value)[i] = '\r';
+            else if ( *STATE(In) == 'b'  && i < SAFE_VALUE_SIZE-1 )  STATE(Value)[i] = '\b';
             else if ( i < SAFE_VALUE_SIZE-1 )  {
-                TLS(Value)[i] = *TLS(In);
+                STATE(Value)[i] = *STATE(In);
                 isQuoted = 1;
             }
         }
 
-        /* put normal chars into 'TLS(Value)' but only if there is room         */
+        /* put normal chars into 'STATE(Value)' but only if there is room         */
         else {
-            if ( i < SAFE_VALUE_SIZE-1 )  TLS(Value)[i] = *TLS(In);
+            if ( i < SAFE_VALUE_SIZE-1 )  STATE(Value)[i] = *STATE(In);
         }
 
         /* read the next character                                         */
@@ -1252,59 +1252,59 @@ void GetIdent ( void )
 
     /* terminate the identifier and lets assume that it is not a keyword   */
     if ( i < SAFE_VALUE_SIZE-1 )
-        TLS(Value)[i] = '\0';
+        STATE(Value)[i] = '\0';
     else {
         SyntaxError("Identifiers in GAP must consist of less than 1023 characters.");
         i =  SAFE_VALUE_SIZE-1;
-        TLS(Value)[i] = '\0';
+        STATE(Value)[i] = '\0';
     }
-    TLS(Symbol) = S_IDENT;
+    STATE(Symbol) = S_IDENT;
 
-    /* now check if 'TLS(Value)' holds a keyword                                */
-    switch ( 256*TLS(Value)[0]+TLS(Value)[i-1] ) {
-    case 256*'a'+'d': if(!strcmp(TLS(Value),"and"))     TLS(Symbol)=S_AND;     break;
-    case 256*'a'+'c': if(!strcmp(TLS(Value),"atomic"))  TLS(Symbol)=S_ATOMIC;  break;
-    case 256*'b'+'k': if(!strcmp(TLS(Value),"break"))   TLS(Symbol)=S_BREAK;   break;
-    case 256*'c'+'e': if(!strcmp(TLS(Value),"continue"))   TLS(Symbol)=S_CONTINUE;   break;
-    case 256*'d'+'o': if(!strcmp(TLS(Value),"do"))      TLS(Symbol)=S_DO;      break;
-    case 256*'e'+'f': if(!strcmp(TLS(Value),"elif"))    TLS(Symbol)=S_ELIF;    break;
-    case 256*'e'+'e': if(!strcmp(TLS(Value),"else"))    TLS(Symbol)=S_ELSE;    break;
-    case 256*'e'+'d': if(!strcmp(TLS(Value),"end"))     TLS(Symbol)=S_END;     break;
-    case 256*'f'+'e': if(!strcmp(TLS(Value),"false"))   TLS(Symbol)=S_FALSE;   break;
-    case 256*'f'+'i': if(!strcmp(TLS(Value),"fi"))      TLS(Symbol)=S_FI;      break;
-    case 256*'f'+'r': if(!strcmp(TLS(Value),"for"))     TLS(Symbol)=S_FOR;     break;
-    case 256*'f'+'n': if(!strcmp(TLS(Value),"function"))TLS(Symbol)=S_FUNCTION;break;
-    case 256*'i'+'f': if(!strcmp(TLS(Value),"if"))      TLS(Symbol)=S_IF;      break;
-    case 256*'i'+'n': if(!strcmp(TLS(Value),"in"))      TLS(Symbol)=S_IN;      break;
-    case 256*'l'+'l': if(!strcmp(TLS(Value),"local"))   TLS(Symbol)=S_LOCAL;   break;
-    case 256*'m'+'d': if(!strcmp(TLS(Value),"mod"))     TLS(Symbol)=S_MOD;     break;
-    case 256*'n'+'t': if(!strcmp(TLS(Value),"not"))     TLS(Symbol)=S_NOT;     break;
-    case 256*'o'+'d': if(!strcmp(TLS(Value),"od"))      TLS(Symbol)=S_OD;      break;
-    case 256*'o'+'r': if(!strcmp(TLS(Value),"or"))      TLS(Symbol)=S_OR;      break;
-    case 256*'r'+'e': if(!strcmp(TLS(Value),"readwrite")) TLS(Symbol)=S_READWRITE;     break;
-    case 256*'r'+'y': if(!strcmp(TLS(Value),"readonly"))  TLS(Symbol)=S_READONLY;     break;
-    case 256*'r'+'c': if(!strcmp(TLS(Value),"rec"))     TLS(Symbol)=S_REC;     break;
-    case 256*'r'+'t': if(!strcmp(TLS(Value),"repeat"))  TLS(Symbol)=S_REPEAT;  break;
-    case 256*'r'+'n': if(!strcmp(TLS(Value),"return"))  TLS(Symbol)=S_RETURN;  break;
-    case 256*'t'+'n': if(!strcmp(TLS(Value),"then"))    TLS(Symbol)=S_THEN;    break;
-    case 256*'t'+'e': if(!strcmp(TLS(Value),"true"))    TLS(Symbol)=S_TRUE;    break;
-    case 256*'u'+'l': if(!strcmp(TLS(Value),"until"))   TLS(Symbol)=S_UNTIL;   break;
-    case 256*'w'+'e': if(!strcmp(TLS(Value),"while"))   TLS(Symbol)=S_WHILE;   break;
-    case 256*'q'+'t': if(!strcmp(TLS(Value),"quit"))    TLS(Symbol)=S_QUIT;    break;
-    case 256*'Q'+'T': if(!strcmp(TLS(Value),"QUIT"))    TLS(Symbol)=S_QQUIT;   break;
+    /* now check if 'STATE(Value)' holds a keyword                                */
+    switch ( 256*STATE(Value)[0]+STATE(Value)[i-1] ) {
+    case 256*'a'+'d': if(!strcmp(STATE(Value),"and"))     STATE(Symbol)=S_AND;     break;
+    case 256*'a'+'c': if(!strcmp(STATE(Value),"atomic"))  STATE(Symbol)=S_ATOMIC;  break;
+    case 256*'b'+'k': if(!strcmp(STATE(Value),"break"))   STATE(Symbol)=S_BREAK;   break;
+    case 256*'c'+'e': if(!strcmp(STATE(Value),"continue"))   STATE(Symbol)=S_CONTINUE;   break;
+    case 256*'d'+'o': if(!strcmp(STATE(Value),"do"))      STATE(Symbol)=S_DO;      break;
+    case 256*'e'+'f': if(!strcmp(STATE(Value),"elif"))    STATE(Symbol)=S_ELIF;    break;
+    case 256*'e'+'e': if(!strcmp(STATE(Value),"else"))    STATE(Symbol)=S_ELSE;    break;
+    case 256*'e'+'d': if(!strcmp(STATE(Value),"end"))     STATE(Symbol)=S_END;     break;
+    case 256*'f'+'e': if(!strcmp(STATE(Value),"false"))   STATE(Symbol)=S_FALSE;   break;
+    case 256*'f'+'i': if(!strcmp(STATE(Value),"fi"))      STATE(Symbol)=S_FI;      break;
+    case 256*'f'+'r': if(!strcmp(STATE(Value),"for"))     STATE(Symbol)=S_FOR;     break;
+    case 256*'f'+'n': if(!strcmp(STATE(Value),"function"))STATE(Symbol)=S_FUNCTION;break;
+    case 256*'i'+'f': if(!strcmp(STATE(Value),"if"))      STATE(Symbol)=S_IF;      break;
+    case 256*'i'+'n': if(!strcmp(STATE(Value),"in"))      STATE(Symbol)=S_IN;      break;
+    case 256*'l'+'l': if(!strcmp(STATE(Value),"local"))   STATE(Symbol)=S_LOCAL;   break;
+    case 256*'m'+'d': if(!strcmp(STATE(Value),"mod"))     STATE(Symbol)=S_MOD;     break;
+    case 256*'n'+'t': if(!strcmp(STATE(Value),"not"))     STATE(Symbol)=S_NOT;     break;
+    case 256*'o'+'d': if(!strcmp(STATE(Value),"od"))      STATE(Symbol)=S_OD;      break;
+    case 256*'o'+'r': if(!strcmp(STATE(Value),"or"))      STATE(Symbol)=S_OR;      break;
+    case 256*'r'+'e': if(!strcmp(STATE(Value),"readwrite")) STATE(Symbol)=S_READWRITE;     break;
+    case 256*'r'+'y': if(!strcmp(STATE(Value),"readonly"))  STATE(Symbol)=S_READONLY;     break;
+    case 256*'r'+'c': if(!strcmp(STATE(Value),"rec"))     STATE(Symbol)=S_REC;     break;
+    case 256*'r'+'t': if(!strcmp(STATE(Value),"repeat"))  STATE(Symbol)=S_REPEAT;  break;
+    case 256*'r'+'n': if(!strcmp(STATE(Value),"return"))  STATE(Symbol)=S_RETURN;  break;
+    case 256*'t'+'n': if(!strcmp(STATE(Value),"then"))    STATE(Symbol)=S_THEN;    break;
+    case 256*'t'+'e': if(!strcmp(STATE(Value),"true"))    STATE(Symbol)=S_TRUE;    break;
+    case 256*'u'+'l': if(!strcmp(STATE(Value),"until"))   STATE(Symbol)=S_UNTIL;   break;
+    case 256*'w'+'e': if(!strcmp(STATE(Value),"while"))   STATE(Symbol)=S_WHILE;   break;
+    case 256*'q'+'t': if(!strcmp(STATE(Value),"quit"))    STATE(Symbol)=S_QUIT;    break;
+    case 256*'Q'+'T': if(!strcmp(STATE(Value),"QUIT"))    STATE(Symbol)=S_QQUIT;   break;
 
-    case 256*'I'+'d': if(!strcmp(TLS(Value),"IsBound")) TLS(Symbol)=S_ISBOUND; break;
-    case 256*'U'+'d': if(!strcmp(TLS(Value),"Unbind"))  TLS(Symbol)=S_UNBIND;  break;
-    case 256*'T'+'d': if(!strcmp(TLS(Value),"TryNextMethod"))
-                                                     TLS(Symbol)=S_TRYNEXT; break;
-    case 256*'I'+'o': if(!strcmp(TLS(Value),"Info"))    TLS(Symbol)=S_INFO;    break;
-    case 256*'A'+'t': if(!strcmp(TLS(Value),"Assert"))  TLS(Symbol)=S_ASSERT;  break;
+    case 256*'I'+'d': if(!strcmp(STATE(Value),"IsBound")) STATE(Symbol)=S_ISBOUND; break;
+    case 256*'U'+'d': if(!strcmp(STATE(Value),"Unbind"))  STATE(Symbol)=S_UNBIND;  break;
+    case 256*'T'+'d': if(!strcmp(STATE(Value),"TryNextMethod"))
+                                                     STATE(Symbol)=S_TRYNEXT; break;
+    case 256*'I'+'o': if(!strcmp(STATE(Value),"Info"))    STATE(Symbol)=S_INFO;    break;
+    case 256*'A'+'t': if(!strcmp(STATE(Value),"Assert"))  STATE(Symbol)=S_ASSERT;  break;
 
     default: ;
     }
 
     /* if it is quoted it is an identifier                                 */
-    if ( isQuoted )  TLS(Symbol) = S_IDENT;
+    if ( isQuoted )  STATE(Symbol) = S_IDENT;
 
 
 }
@@ -1314,7 +1314,7 @@ void GetIdent ( void )
 *F  GetNumber()  . . . . . . . . . . . . . .  get an integer or float literal
 **
 **  'GetNumber' reads  a number from  the  current  input file into the
-**  variable  'TLS(Value)' and sets  'Symbol' to 'S_INT', 'S_PARTIALINT',
+**  variable  'STATE(Value)' and sets  'Symbol' to 'S_INT', 'S_PARTIALINT',
 **  'S_FLOAT' or 'S_PARTIALFLOAT'.   The first character of
 **  the number is the current character pointed to by 'In'.
 **
@@ -1325,7 +1325,7 @@ void GetIdent ( void )
 **  As we read, we keep track of whether we have seen a . or exponent notation
 **  and so whether we will return S_[PARTIAL]INT or S_[PARTIAL]FLOAT.
 **
-**  When TLS(Value) is  completely filled we have to check  if the reading of
+**  When STATE(Value) is  completely filled we have to check  if the reading of
 **  the number  is complete  or not to  decide whether to return a PARTIAL type.
 **
 **  The argument reflects how far we are through reading a possibly very long number
@@ -1339,32 +1339,32 @@ void GetIdent ( void )
 static Char GetCleanedChar( UInt *wasEscaped ) {
   GET_CHAR();
   *wasEscaped = 0;
-  if (*TLS(In) == '\\') {
+  if (*STATE(In) == '\\') {
     GET_CHAR();
-    if      ( *TLS(In) == '\n')
+    if      ( *STATE(In) == '\n')
       return GetCleanedChar(wasEscaped);
-    else if ( *TLS(In) == '\r' )  {
+    else if ( *STATE(In) == '\r' )  {
       GET_CHAR();
-      if  ( *TLS(In) == '\n' )
+      if  ( *STATE(In) == '\n' )
         return GetCleanedChar(wasEscaped);
       else {
-        UNGET_CHAR(*TLS(In));
+        UNGET_CHAR(*STATE(In));
         *wasEscaped = 1;
         return '\r';
       }
     }
     else {
       *wasEscaped = 1;
-      if ( *TLS(In) == 'n')  return '\n';
-      else if ( *TLS(In) == 't')  return '\t';
-      else if ( *TLS(In) == 'r')  return '\r';
-      else if ( *TLS(In) == 'b')  return '\b';
-      else if ( *TLS(In) == '>')  return '\01';
-      else if ( *TLS(In) == '<')  return '\02';
-      else if ( *TLS(In) == 'c')  return '\03';
+      if ( *STATE(In) == 'n')  return '\n';
+      else if ( *STATE(In) == 't')  return '\t';
+      else if ( *STATE(In) == 'r')  return '\r';
+      else if ( *STATE(In) == 'b')  return '\b';
+      else if ( *STATE(In) == '>')  return '\01';
+      else if ( *STATE(In) == '<')  return '\02';
+      else if ( *STATE(In) == 'c')  return '\03';
     }
   }
-  return *TLS(In);
+  return *STATE(In);
 }
 
 
@@ -1377,11 +1377,11 @@ void GetNumber ( UInt StartingStatus )
   UInt seenADigit = (StartingStatus != 0 && StartingStatus != 2);
   UInt seenExpDigit = (StartingStatus ==5);
 
-  c = *TLS(In);
+  c = *STATE(In);
   if (StartingStatus  <  2) {
     /* read initial sequence of digits into 'Value'             */
     for (i = 0; !wasEscaped && IsDigit(c) && i < SAFE_VALUE_SIZE-1; i++) {
-      TLS(Value)[i] = c;
+      STATE(Value)[i] = c;
       seenADigit = 1;
       c = GetCleanedChar(&wasEscaped);
     }
@@ -1390,26 +1390,26 @@ void GetNumber ( UInt StartingStatus )
     /* maybe we saw an identifier character and realised that this is an identifier we are reading */
     if (wasEscaped || IsIdent(c)) {
       /* Now we know we have an identifier read the rest of it */
-      TLS(Value)[i++] = c;
+      STATE(Value)[i++] = c;
       c = GetCleanedChar(&wasEscaped);
       for (; wasEscaped || IsIdent(c) || IsDigit(c); i++) {
         if (i < SAFE_VALUE_SIZE -1)
-          TLS(Value)[i] = c;
+          STATE(Value)[i] = c;
         c = GetCleanedChar(&wasEscaped);
       }
       if (i < SAFE_VALUE_SIZE -1)
-        TLS(Value)[i] = '\0';
+        STATE(Value)[i] = '\0';
       else
-        TLS(Value)[SAFE_VALUE_SIZE-1] = '\0';
-      TLS(Symbol) = S_IDENT;
+        STATE(Value)[SAFE_VALUE_SIZE-1] = '\0';
+      STATE(Symbol) = S_IDENT;
       return;
     }
 
     /* Or maybe we just ran out of space */
     if (IsDigit(c)) {
       assert(i >= SAFE_VALUE_SIZE-1);
-      TLS(Symbol) = S_PARTIALINT;
-      TLS(Value)[SAFE_VALUE_SIZE-1] = '\0';
+      STATE(Symbol) = S_PARTIALINT;
+      STATE(Value)[SAFE_VALUE_SIZE-1] = '\0';
       return;
     }
 
@@ -1421,35 +1421,35 @@ void GetNumber ( UInt StartingStatus )
          look for a float.
 
       This is a bit fragile  */
-      if (TLS(Symbol) == S_DOT || TLS(Symbol) == S_BDOT) {
-        TLS(Value)[i]  = '\0';
-        TLS(Symbol) = S_INT;
+      if (STATE(Symbol) == S_DOT || STATE(Symbol) == S_BDOT) {
+        STATE(Value)[i]  = '\0';
+        STATE(Symbol) = S_INT;
         return;
       }
       
       /* peek ahead to decide which */
       GET_CHAR();
-      if (*TLS(In) == '.') {
+      if (*STATE(In) == '.') {
         /* It was .. */
-        UNGET_CHAR(*TLS(In));
-        TLS(Symbol) = S_INT;
-        TLS(Value)[i] = '\0';
+        UNGET_CHAR(*STATE(In));
+        STATE(Symbol) = S_INT;
+        STATE(Value)[i] = '\0';
         return;
       }
 
 
       /* Not .. Put back the character we peeked at */
-      UNGET_CHAR(*TLS(In));
+      UNGET_CHAR(*STATE(In));
       /* Now the . must be part of our number
          store it and move on */
-      TLS(Value)[i++] = c;
+      STATE(Value)[i++] = c;
       c = GetCleanedChar(&wasEscaped);
     }
 
     else {
       /* Anything else we see tells us that the token is done */
-      TLS(Value)[i]  = '\0';
-      TLS(Symbol) = S_INT;
+      STATE(Value)[i]  = '\0';
+      STATE(Symbol) = S_INT;
       return;
     }
   }
@@ -1468,7 +1468,7 @@ void GetNumber ( UInt StartingStatus )
 
     /* read digits */
     for (; !wasEscaped && IsDigit(c) && i < SAFE_VALUE_SIZE-1; i++) {
-      TLS(Value)[i] = c;
+      STATE(Value)[i] = c;
       seenADigit = 1;
       c = GetCleanedChar(&wasEscaped);
     }
@@ -1483,24 +1483,24 @@ void GetNumber ( UInt StartingStatus )
        C99 style */
       if (!wasEscaped) {
         if (IsAlpha(c)) {
-          TLS(Value)[i++] = c;
+          STATE(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
         }
         /* independently of that, we allow an _ signalling immediate conversion */
         if (c == '_') {
-          TLS(Value)[i++] = c;
+          STATE(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
           /* After which there may be one character signifying the conversion style */
           if (IsAlpha(c)) {
-            TLS(Value)[i++] = c;
+            STATE(Value)[i++] = c;
             c = GetCleanedChar(&wasEscaped);
           }
         }
         /* Now if the next character is alphanumerical, or an identifier type symbol then we
            really do have an error, otherwise we return a result */
         if (!IsIdent(c) && !IsDigit(c)) {
-          TLS(Value)[i] = '\0';
-          TLS(Symbol) = S_FLOAT;
+          STATE(Value)[i] = '\0';
+          STATE(Symbol) = S_FLOAT;
           return;
         }
       }
@@ -1513,19 +1513,19 @@ void GetNumber ( UInt StartingStatus )
         if (!seenADigit)
           SyntaxError("Badly formed number: need a digit before or after the decimal point");
         seenExp = 1;
-        TLS(Value)[i++] = c;
+        STATE(Value)[i++] = c;
         c = GetCleanedChar(&wasEscaped);
         if (!wasEscaped && (c == '+' || c == '-'))
           {
-            TLS(Value)[i++] = c;
+            STATE(Value)[i++] = c;
             c = GetCleanedChar(&wasEscaped);
           }
       }
 
     /* Now deal with full buffer case */
     if (i >= SAFE_VALUE_SIZE -1) {
-      TLS(Symbol) = seenExp ? S_PARTIALFLOAT3 : S_PARTIALFLOAT2;
-      TLS(Value)[i] = '\0';
+      STATE(Symbol) = seenExp ? S_PARTIALFLOAT3 : S_PARTIALFLOAT2;
+      STATE(Value)[i] = '\0';
       return;
     }
 
@@ -1537,23 +1537,23 @@ void GetNumber ( UInt StartingStatus )
       /* Might be a conversion marker */
       if (!wasEscaped) {
         if (IsAlpha(c) && c != 'e' && c != 'E' && c != 'd' && c != 'D' && c != 'q' && c != 'Q') {
-          TLS(Value)[i++] = c;
+          STATE(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
         }
         /* independently of that, we allow an _ signalling immediate conversion */
         if (c == '_') {
-          TLS(Value)[i++] = c;
+          STATE(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
           /* After which there may be one character signifying the conversion style */
           if (IsAlpha(c))
-            TLS(Value)[i++] = c;
+            STATE(Value)[i++] = c;
           c = GetCleanedChar(&wasEscaped);
         }
         /* Now if the next character is alphanumerical, or an identifier type symbol then we
            really do have an error, otherwise we return a result */
         if (!IsIdent(c) && !IsDigit(c)) {
-          TLS(Value)[i] = '\0';
-          TLS(Symbol) = S_FLOAT;
+          STATE(Value)[i] = '\0';
+          STATE(Symbol) = S_FLOAT;
           return;
         }
       }
@@ -1565,7 +1565,7 @@ void GetNumber ( UInt StartingStatus )
   /* Here we are into the unsigned exponent of a number
      in scientific notation, so we just read digits */
   for (; !wasEscaped && IsDigit(c) && i < SAFE_VALUE_SIZE-1; i++) {
-    TLS(Value)[i] = c;
+    STATE(Value)[i] = c;
     seenExpDigit = 1;
     c = GetCleanedChar(&wasEscaped);
   }
@@ -1574,38 +1574,38 @@ void GetNumber ( UInt StartingStatus )
      which could be a conversion marker */
   if (seenExpDigit) {
     if (IsAlpha(c)) {
-      TLS(Value)[i] = c;
+      STATE(Value)[i] = c;
       c = GetCleanedChar(&wasEscaped);
-      TLS(Value)[i+1] = '\0';
-      TLS(Symbol) = S_FLOAT;
+      STATE(Value)[i+1] = '\0';
+      STATE(Symbol) = S_FLOAT;
       return;
     }
     if (c == '_') {
-      TLS(Value)[i++] = c;
+      STATE(Value)[i++] = c;
       c = GetCleanedChar(&wasEscaped);
       /* After which there may be one character signifying the conversion style */
       if (IsAlpha(c)) {
-        TLS(Value)[i++] = c;
+        STATE(Value)[i++] = c;
         c = GetCleanedChar(&wasEscaped);
       }
-      TLS(Value)[i] = '\0';
-      TLS(Symbol) = S_FLOAT;
+      STATE(Value)[i] = '\0';
+      STATE(Symbol) = S_FLOAT;
       return;
     }
   }
 
   /* If we ran off the end */
   if (i >= SAFE_VALUE_SIZE -1) {
-    TLS(Symbol) = seenExpDigit ? S_PARTIALFLOAT4 : S_PARTIALFLOAT3;
-    TLS(Value)[i] = '\0';
+    STATE(Symbol) = seenExpDigit ? S_PARTIALFLOAT4 : S_PARTIALFLOAT3;
+    STATE(Value)[i] = '\0';
     return;
   }
 
   /* Otherwise this is the end of the token */
   if (!seenExpDigit)
     SyntaxError("Badly Formed Number: need at least one digit in the exponent");
-  TLS(Symbol) = S_FLOAT;
-  TLS(Value)[i] = '\0';
+  STATE(Symbol) = S_FLOAT;
+  STATE(Value)[i] = '\0';
   return;
 }
 
@@ -1622,13 +1622,13 @@ static inline Char GetOctalDigits( void )
 {
     Char c;
 
-    if ( *TLS(In) < '0' || *TLS(In) > '7' )
+    if ( *STATE(In) < '0' || *STATE(In) > '7' )
         SyntaxError("Expecting octal digit");
-    c = 8 * (*TLS(In) - '0');
+    c = 8 * (*STATE(In) - '0');
     GET_CHAR();
-    if ( *TLS(In) < '0' || *TLS(In) > '7' )
+    if ( *STATE(In) < '0' || *STATE(In) > '7' )
         SyntaxError("Expecting octal digit");
-    c = c + (*TLS(In) - '0');
+    c = c + (*STATE(In) - '0');
 
     return c;
 }
@@ -1655,39 +1655,39 @@ Char GetEscapedChar( void )
 
   c = 0;
 
-  if ( *TLS(In) == 'n'  )       c = '\n';
-  else if ( *TLS(In) == 't'  )  c = '\t';
-  else if ( *TLS(In) == 'r'  )  c = '\r';
-  else if ( *TLS(In) == 'b'  )  c = '\b';
-  else if ( *TLS(In) == '>'  )  c = '\01';
-  else if ( *TLS(In) == '<'  )  c = '\02';
-  else if ( *TLS(In) == 'c'  )  c = '\03';
-  else if ( *TLS(In) == '"'  )  c = '"';
-  else if ( *TLS(In) == '\\' )  c = '\\';
-  else if ( *TLS(In) == '\'' )  c = '\'';
-  else if ( *TLS(In) == '0'  ) {
+  if ( *STATE(In) == 'n'  )       c = '\n';
+  else if ( *STATE(In) == 't'  )  c = '\t';
+  else if ( *STATE(In) == 'r'  )  c = '\r';
+  else if ( *STATE(In) == 'b'  )  c = '\b';
+  else if ( *STATE(In) == '>'  )  c = '\01';
+  else if ( *STATE(In) == '<'  )  c = '\02';
+  else if ( *STATE(In) == 'c'  )  c = '\03';
+  else if ( *STATE(In) == '"'  )  c = '"';
+  else if ( *STATE(In) == '\\' )  c = '\\';
+  else if ( *STATE(In) == '\'' )  c = '\'';
+  else if ( *STATE(In) == '0'  ) {
     /* from here we can either read a hex-escape or three digit
        octal numbers */
     GET_CHAR();
-    if (*TLS(In) == 'x') {
+    if (*STATE(In) == 'x') {
         GET_CHAR();
-        if (!IsHexDigit(*TLS(In))) {
+        if (!IsHexDigit(*STATE(In))) {
             SyntaxError("Expecting hexadecimal digit");
         }
-        c = 16 * CharHexDigit(*TLS(In));
+        c = 16 * CharHexDigit(*STATE(In));
         GET_CHAR();
-        if (!IsHexDigit(*TLS(In))) {
+        if (!IsHexDigit(*STATE(In))) {
             SyntaxError("Expecting hexadecimal digit");
         }
-        c += CharHexDigit(*TLS(In));
-    } else if (*TLS(In) >= '0' && *TLS(In) <= '7' ) {
+        c += CharHexDigit(*STATE(In));
+    } else if (*STATE(In) >= '0' && *STATE(In) <= '7' ) {
         c += GetOctalDigits();
     } else {
         SyntaxError("Expecting hexadecimal escape, or two more octal digits");
     }
-  } else if ( *TLS(In) >= '1' && *TLS(In) <= '7' ) {
+  } else if ( *STATE(In) >= '1' && *STATE(In) <= '7' ) {
     /* escaped three digit octal numbers are allowed in input */
-    c = 64 * (*TLS(In) - '0');
+    c = 64 * (*STATE(In) - '0');
     GET_CHAR();
     c += GetOctalDigits();
   } else {
@@ -1695,10 +1695,10 @@ Char GetEscapedChar( void )
          disabled for backwards compatibility; some code relies on this behaviour
          and tests break with the warning enabled */
       /*
-      if (IsAlpha(*TLS(In)))
+      if (IsAlpha(*STATE(In)))
           SyntaxWarning("Alphabet letter after \\");
       */
-      c = *TLS(In);
+      c = *STATE(In);
   }
   return c;
 }
@@ -1708,7 +1708,7 @@ Char GetEscapedChar( void )
  *F  GetStr()  . . . . . . . . . . . . . . . . . . . . . . get a string, local
  **
  **  'GetStr' reads  a  string from the  current input file into  the variable
- **  'TLS(Value)' and sets 'Symbol'   to  'S_STRING'.  The opening double quote '"'
+ **  'STATE(Value)' and sets 'Symbol'   to  'S_STRING'.  The opening double quote '"'
  **  of the string is the current character pointed to by 'In'.
  **
  **  A string is a sequence of characters delimited  by double quotes '"'.  It
@@ -1719,7 +1719,7 @@ Char GetEscapedChar( void )
  **  An error is raised if the string includes a <newline> character or if the
  **  file ends before the closing '"'.
  **
- **  When TLS(Value) is  completely filled we have to check  if the reading of
+ **  When STATE(Value) is  completely filled we have to check  if the reading of
  **  the string is  complete or not to decide  between Symbol=S_STRING or
  **  S_PARTIALSTRING.
  */
@@ -1728,39 +1728,39 @@ void GetStr ( void )
   Int                 i = 0, fetch;
 
   /* Avoid substitution of '?' in beginning of GetLine chunks */
-  TLS(HELPSubsOn) = 0;
+  STATE(HELPSubsOn) = 0;
 
   /* read all characters into 'Value'                                    */
-  for ( i = 0; i < SAFE_VALUE_SIZE-1 && *TLS(In) != '"'
-           && *TLS(In) != '\n' && *TLS(In) != '\377'; i++ ) {
+  for ( i = 0; i < SAFE_VALUE_SIZE-1 && *STATE(In) != '"'
+           && *STATE(In) != '\n' && *STATE(In) != '\377'; i++ ) {
 
     fetch = 1;
     /* handle escape sequences                                         */
-    if ( *TLS(In) == '\\' ) {
+    if ( *STATE(In) == '\\' ) {
       GET_CHAR();
       /* if next is another '\\' followed by '\n' it must be ignored */
-      while ( *TLS(In) == '\\' ) {
+      while ( *STATE(In) == '\\' ) {
         GET_CHAR();
-        if ( *TLS(In) == '\n' )
+        if ( *STATE(In) == '\n' )
           GET_CHAR();
         else {
           UNGET_CHAR( '\\' );
           break;
         }
       }
-      if      ( *TLS(In) == '\n' )  i--;
-      else if ( *TLS(In) == '\r' )  {
+      if      ( *STATE(In) == '\n' )  i--;
+      else if ( *STATE(In) == '\r' )  {
         GET_CHAR();
-        if  ( *TLS(In) == '\n' )  i--;
-        else  {TLS(Value)[i] = '\r'; fetch = 0;}
+        if  ( *STATE(In) == '\n' )  i--;
+        else  {STATE(Value)[i] = '\r'; fetch = 0;}
       } else {
-          TLS(Value)[i] = GetEscapedChar();
+          STATE(Value)[i] = GetEscapedChar();
       }
     }
 
     /* put normal chars into 'Value' but only if there is room         */
     else {
-      TLS(Value)[i] = *TLS(In);
+      STATE(Value)[i] = *STATE(In);
     }
 
     /* read the next character                                         */
@@ -1771,25 +1771,25 @@ void GetStr ( void )
   /* XXX although we have ValueLen we need trailing \000 here,
      in gap.c, function FuncMAKE_INIT this is still used as C-string
      and long integers and strings are not yet supported!    */
-  TLS(Value)[i] = '\0';
+  STATE(Value)[i] = '\0';
 
   /* check for error conditions                                          */
-  if ( *TLS(In) == '\n'  )
+  if ( *STATE(In) == '\n'  )
     SyntaxError("String must not include <newline>");
-  if ( *TLS(In) == '\377' )
+  if ( *STATE(In) == '\377' )
     SyntaxError("String must end with \" before end of file");
 
   /* set length of string, set 'Symbol' and skip trailing '"'            */
-  TLS(ValueLen) = i;
+  STATE(ValueLen) = i;
   if ( i < SAFE_VALUE_SIZE-1 )  {
-    TLS(Symbol) = S_STRING;
-    if ( *TLS(In) == '"' )  GET_CHAR();
+    STATE(Symbol) = S_STRING;
+    if ( *STATE(In) == '"' )  GET_CHAR();
   }
   else
-    TLS(Symbol) = S_PARTIALSTRING;
+    STATE(Symbol) = S_PARTIALSTRING;
 
   /* switching on substitution of '?' */
-  TLS(HELPSubsOn) = 1;
+  STATE(HELPSubsOn) = 1;
 }
 
 /****************************************************************************
@@ -1815,32 +1815,32 @@ void GetTripStr ( void )
   Int                 i = 0;
 
   /* Avoid substitution of '?' in beginning of GetLine chunks */
-  TLS(HELPSubsOn) = 0;
+  STATE(HELPSubsOn) = 0;
   
   /* print only a partial prompt while reading a triple string           */
   if ( !SyQuiet )
-    TLS(Prompt) = "> ";
+    STATE(Prompt) = "> ";
   else
-    TLS(Prompt) = "";
+    STATE(Prompt) = "";
   
   /* read all characters into 'Value'                                    */
-  for ( i = 0; i < SAFE_VALUE_SIZE-1 && *TLS(In) != '\377'; i++ ) {
+  for ( i = 0; i < SAFE_VALUE_SIZE-1 && *STATE(In) != '\377'; i++ ) {
     // Only thing to check for is a triple quote.
     
-    if ( *TLS(In) == '"') {
+    if ( *STATE(In) == '"') {
         GET_CHAR();
-        if (*TLS(In) == '"') {
+        if (*STATE(In) == '"') {
             GET_CHAR();
-            if(*TLS(In) == '"' ) {
+            if(*STATE(In) == '"' ) {
                 break;
             }
-            TLS(Value)[i] = '"';
+            STATE(Value)[i] = '"';
             i++;
         }
-        TLS(Value)[i] = '"';
+        STATE(Value)[i] = '"';
         i++;
     }
-    TLS(Value)[i] = *TLS(In);
+    STATE(Value)[i] = *STATE(In);
 
 
     /* read the next character                                         */
@@ -1850,23 +1850,23 @@ void GetTripStr ( void )
   /* XXX although we have ValueLen we need trailing \000 here,
      in gap.c, function FuncMAKE_INIT this is still used as C-string
      and long integers and strings are not yet supported!    */
-  TLS(Value)[i] = '\0';
+  STATE(Value)[i] = '\0';
 
   /* check for error conditions                                          */
-  if ( *TLS(In) == '\377' )
+  if ( *STATE(In) == '\377' )
     SyntaxError("String must end with \" before end of file");
 
   /* set length of string, set 'Symbol' and skip trailing '"'            */
-  TLS(ValueLen) = i;
+  STATE(ValueLen) = i;
   if ( i < SAFE_VALUE_SIZE-1 )  {
-    TLS(Symbol) = S_STRING;
-    if ( *TLS(In) == '"' )  GET_CHAR();
+    STATE(Symbol) = S_STRING;
+    if ( *STATE(In) == '"' )  GET_CHAR();
   }
   else
-    TLS(Symbol) = S_PARTIALTRIPSTRING;
+    STATE(Symbol) = S_PARTIALTRIPSTRING;
 
   /* switching on substitution of '?' */
-  TLS(HELPSubsOn) = 1;
+  STATE(HELPSubsOn) = 1;
 }
 
 /****************************************************************************
@@ -1880,21 +1880,21 @@ void GetTripStr ( void )
 void GetMaybeTripStr ( void )
 {
     /* Avoid substitution of '?' in beginning of GetLine chunks */
-    TLS(HELPSubsOn) = 0;
+    STATE(HELPSubsOn) = 0;
     
     /* This is just a normal string! */
-    if ( *TLS(In) != '"' ) {
+    if ( *STATE(In) != '"' ) {
         GetStr();
         return;
     }
     
     GET_CHAR();
     /* This was just an empty string! */
-    if ( *TLS(In) != '"' ) {
-        TLS(Value)[0] = '\0';
-        TLS(ValueLen) = 0;
-        TLS(Symbol) = S_STRING;
-        TLS(HELPSubsOn) = 1;
+    if ( *STATE(In) != '"' ) {
+        STATE(Value)[0] = '\0';
+        STATE(ValueLen) = 0;
+        STATE(Symbol) = S_STRING;
+        STATE(HELPSubsOn) = 1;
         return;
     }
     
@@ -1909,7 +1909,7 @@ void GetMaybeTripStr ( void )
  *F  GetChar() . . . . . . . . . . . . . . . . . get a single character, local
  **
  **  'GetChar' reads the next  character from the current input file  into the
- **  variable 'TLS(Value)' and sets 'Symbol' to 'S_CHAR'.  The opening single quote
+ **  variable 'STATE(Value)' and sets 'Symbol' to 'S_CHAR'.  The opening single quote
  **  '\'' of the character is the current character pointed to by 'In'.
  **
  **  A  character is  a  single character delimited by single quotes '\''.  It
@@ -1922,25 +1922,25 @@ void GetChar ( void )
   GET_CHAR();
 
   /* Make sure symbol is set */
-  TLS(Symbol) = S_CHAR;
+  STATE(Symbol) = S_CHAR;
 
   /* handle escape equences                                              */
-  if ( *TLS(In) == '\n' ) {
+  if ( *STATE(In) == '\n' ) {
     SyntaxError("Character literal must not include <newline>");
   } else {
-    if ( *TLS(In) == '\\' ) {
+    if ( *STATE(In) == '\\' ) {
       GET_CHAR();
-      TLS(Value)[0] = GetEscapedChar();
+      STATE(Value)[0] = GetEscapedChar();
     } else {
-      /* put normal chars into 'TLS(Value)' */
-      TLS(Value)[0] = *TLS(In);
+      /* put normal chars into 'STATE(Value)' */
+      STATE(Value)[0] = *STATE(In);
     }
 
     /* read the next character */
     GET_CHAR();
 
     /* check for terminating single quote, and skip */
-    if ( *TLS(In) == '\'' ) {
+    if ( *STATE(In) == '\'' ) {
       GET_CHAR();
     } else {
       SyntaxError("Missing single quote in character constant");
@@ -1954,7 +1954,7 @@ void GetChar ( void )
  **
  **  'GetSymbol' reads  the  next symbol from   the  input,  storing it in the
  **  variable 'Symbol'.  If 'Symbol' is  'S_IDENT', 'S_INT' or 'S_STRING'  the
- **  value of the symbol is stored in the variable 'TLS(Value)'.  'GetSymbol' first
+ **  value of the symbol is stored in the variable 'STATE(Value)'.  'GetSymbol' first
  **  skips all <space>, <tab> and <newline> characters and comments.
  **
  **  After reading  a  symbol the current  character   is the first  character
@@ -1963,125 +1963,125 @@ void GetChar ( void )
 void GetSymbol ( void )
 {
   /* special case if reading of a long token is not finished */
-  if (TLS(Symbol) == S_PARTIALSTRING) {
+  if (STATE(Symbol) == S_PARTIALSTRING) {
     GetStr();
     return;
   }
   
-  if (TLS(Symbol) == S_PARTIALTRIPSTRING) {
+  if (STATE(Symbol) == S_PARTIALTRIPSTRING) {
       GetTripStr();
       return;
   }
   
-  if (TLS(Symbol) == S_PARTIALINT) {
-    if (TLS(Value)[0] == '\0')
+  if (STATE(Symbol) == S_PARTIALINT) {
+    if (STATE(Value)[0] == '\0')
       GetNumber(0);
     else
       GetNumber(1);
     return;
   }
-  if (TLS(Symbol) == S_PARTIALFLOAT1) {
+  if (STATE(Symbol) == S_PARTIALFLOAT1) {
     GetNumber(2);
     return;
   }
 
-  if (TLS(Symbol) == S_PARTIALFLOAT2) {
+  if (STATE(Symbol) == S_PARTIALFLOAT2) {
     GetNumber(3);
     return;
   }
-  if (TLS(Symbol) == S_PARTIALFLOAT3) {
+  if (STATE(Symbol) == S_PARTIALFLOAT3) {
     GetNumber(4);
     return;
   }
 
-  if (TLS(Symbol) == S_PARTIALFLOAT4) {
+  if (STATE(Symbol) == S_PARTIALFLOAT4) {
     GetNumber(5);
     return;
   }
 
 
   /* if no character is available then get one                           */
-  if ( *TLS(In) == '\0' )
-    { TLS(In)--;
+  if ( *STATE(In) == '\0' )
+    { STATE(In)--;
       GET_CHAR();
     }
 
   /* skip over <spaces>, <tabs>, <newlines> and comments                 */
-  while (*TLS(In)==' '||*TLS(In)=='\t'||*TLS(In)=='\n'||*TLS(In)=='\r'||*TLS(In)=='\f'||*TLS(In)=='#') {
-    if ( *TLS(In) == '#' ) {
-      while ( *TLS(In) != '\n' && *TLS(In) != '\r' && *TLS(In) != '\377' )
+  while (*STATE(In)==' '||*STATE(In)=='\t'||*STATE(In)=='\n'||*STATE(In)=='\r'||*STATE(In)=='\f'||*STATE(In)=='#') {
+    if ( *STATE(In) == '#' ) {
+      while ( *STATE(In) != '\n' && *STATE(In) != '\r' && *STATE(In) != '\377' )
         GET_CHAR();
     }
     GET_CHAR();
   }
 
   /* switch according to the character                                   */
-  switch ( *TLS(In) ) {
+  switch ( *STATE(In) ) {
 
-  case '.':   TLS(Symbol) = S_DOT;                         GET_CHAR();
-    /*            if ( *TLS(In) == '\\' ) { GET_CHAR();
-            if ( *TLS(In) == '\n' ) { GET_CHAR(); } }   */
-    if ( *TLS(In) == '.' ) { 
-            TLS(Symbol) = S_DOTDOT; GET_CHAR();
-            if ( *TLS(In) == '.') {
-                    TLS(Symbol) = S_DOTDOTDOT; GET_CHAR();
+  case '.':   STATE(Symbol) = S_DOT;                         GET_CHAR();
+    /*            if ( *STATE(In) == '\\' ) { GET_CHAR();
+            if ( *STATE(In) == '\n' ) { GET_CHAR(); } }   */
+    if ( *STATE(In) == '.' ) { 
+            STATE(Symbol) = S_DOTDOT; GET_CHAR();
+            if ( *STATE(In) == '.') {
+                    STATE(Symbol) = S_DOTDOTDOT; GET_CHAR();
             }
     }
     break;
 
-  case '!':   TLS(Symbol) = S_ILLEGAL;                     GET_CHAR();
-    if ( *TLS(In) == '\\' ) { GET_CHAR();
-      if ( *TLS(In) == '\n' ) { GET_CHAR(); } }
-    if ( *TLS(In) == '.' ) { TLS(Symbol) = S_BDOT;    GET_CHAR();  break; }
-    if ( *TLS(In) == '[' ) { TLS(Symbol) = S_BLBRACK; GET_CHAR();  break; }
-    if ( *TLS(In) == '{' ) { TLS(Symbol) = S_BLBRACE; GET_CHAR();  break; }
+  case '!':   STATE(Symbol) = S_ILLEGAL;                     GET_CHAR();
+    if ( *STATE(In) == '\\' ) { GET_CHAR();
+      if ( *STATE(In) == '\n' ) { GET_CHAR(); } }
+    if ( *STATE(In) == '.' ) { STATE(Symbol) = S_BDOT;    GET_CHAR();  break; }
+    if ( *STATE(In) == '[' ) { STATE(Symbol) = S_BLBRACK; GET_CHAR();  break; }
+    if ( *STATE(In) == '{' ) { STATE(Symbol) = S_BLBRACE; GET_CHAR();  break; }
     break;
-  case '[':   TLS(Symbol) = S_LBRACK;                      GET_CHAR();  break;
-  case ']':   TLS(Symbol) = S_RBRACK;                      GET_CHAR();  break;
-  case '{':   TLS(Symbol) = S_LBRACE;                      GET_CHAR();  break;
-  case '}':   TLS(Symbol) = S_RBRACE;                      GET_CHAR();  break;
-  case '(':   TLS(Symbol) = S_LPAREN;                      GET_CHAR();  break;
-  case ')':   TLS(Symbol) = S_RPAREN;                      GET_CHAR();  break;
-  case ',':   TLS(Symbol) = S_COMMA;                       GET_CHAR();  break;
+  case '[':   STATE(Symbol) = S_LBRACK;                      GET_CHAR();  break;
+  case ']':   STATE(Symbol) = S_RBRACK;                      GET_CHAR();  break;
+  case '{':   STATE(Symbol) = S_LBRACE;                      GET_CHAR();  break;
+  case '}':   STATE(Symbol) = S_RBRACE;                      GET_CHAR();  break;
+  case '(':   STATE(Symbol) = S_LPAREN;                      GET_CHAR();  break;
+  case ')':   STATE(Symbol) = S_RPAREN;                      GET_CHAR();  break;
+  case ',':   STATE(Symbol) = S_COMMA;                       GET_CHAR();  break;
 
-  case ':':   TLS(Symbol) = S_COLON;                       GET_CHAR();
-    if ( *TLS(In) == '\\' ) {
+  case ':':   STATE(Symbol) = S_COLON;                       GET_CHAR();
+    if ( *STATE(In) == '\\' ) {
       GET_CHAR();
-      if ( *TLS(In) == '\n' )
+      if ( *STATE(In) == '\n' )
         { GET_CHAR(); }
     }
-    if ( *TLS(In) == '=' ) { TLS(Symbol) = S_ASSIGN;  GET_CHAR(); break; }
-    if ( TLS(In)[0] == ':' && TLS(In)[1] == '=') {
-      TLS(Symbol) = S_INCORPORATE; GET_CHAR(); GET_CHAR(); break;
+    if ( *STATE(In) == '=' ) { STATE(Symbol) = S_ASSIGN;  GET_CHAR(); break; }
+    if ( STATE(In)[0] == ':' && STATE(In)[1] == '=') {
+      STATE(Symbol) = S_INCORPORATE; GET_CHAR(); GET_CHAR(); break;
     }
     break;
 
-  case ';':   TLS(Symbol) = S_SEMICOLON;                   GET_CHAR();  break;
+  case ';':   STATE(Symbol) = S_SEMICOLON;                   GET_CHAR();  break;
 
-  case '=':   TLS(Symbol) = S_EQ;                          GET_CHAR();  break;
-  case '<':   TLS(Symbol) = S_LT;                          GET_CHAR();
-    if ( *TLS(In) == '\\' ) { GET_CHAR();
-      if ( *TLS(In) == '\n' ) { GET_CHAR(); } }
-    if ( *TLS(In) == '=' ) { TLS(Symbol) = S_LE;      GET_CHAR();  break; }
-    if ( *TLS(In) == '>' ) { TLS(Symbol) = S_NE;      GET_CHAR();  break; }
+  case '=':   STATE(Symbol) = S_EQ;                          GET_CHAR();  break;
+  case '<':   STATE(Symbol) = S_LT;                          GET_CHAR();
+    if ( *STATE(In) == '\\' ) { GET_CHAR();
+      if ( *STATE(In) == '\n' ) { GET_CHAR(); } }
+    if ( *STATE(In) == '=' ) { STATE(Symbol) = S_LE;      GET_CHAR();  break; }
+    if ( *STATE(In) == '>' ) { STATE(Symbol) = S_NE;      GET_CHAR();  break; }
     break;
-  case '>':   TLS(Symbol) = S_GT;                          GET_CHAR();
-    if ( *TLS(In) == '\\' ) { GET_CHAR();
-      if ( *TLS(In) == '\n' ) { GET_CHAR(); } }
-    if ( *TLS(In) == '=' ) { TLS(Symbol) = S_GE;      GET_CHAR();  break; }
+  case '>':   STATE(Symbol) = S_GT;                          GET_CHAR();
+    if ( *STATE(In) == '\\' ) { GET_CHAR();
+      if ( *STATE(In) == '\n' ) { GET_CHAR(); } }
+    if ( *STATE(In) == '=' ) { STATE(Symbol) = S_GE;      GET_CHAR();  break; }
     break;
 
-  case '+':   TLS(Symbol) = S_PLUS;                        GET_CHAR();  break;
-  case '-':   TLS(Symbol) = S_MINUS;                       GET_CHAR();
-    if ( *TLS(In) == '\\' ) { GET_CHAR();
-      if ( *TLS(In) == '\n' ) { GET_CHAR(); } }
-    if ( *TLS(In) == '>' ) { TLS(Symbol)=S_MAPTO;     GET_CHAR();  break; }
+  case '+':   STATE(Symbol) = S_PLUS;                        GET_CHAR();  break;
+  case '-':   STATE(Symbol) = S_MINUS;                       GET_CHAR();
+    if ( *STATE(In) == '\\' ) { GET_CHAR();
+      if ( *STATE(In) == '\n' ) { GET_CHAR(); } }
+    if ( *STATE(In) == '>' ) { STATE(Symbol)=S_MAPTO;     GET_CHAR();  break; }
     break;
-  case '*':   TLS(Symbol) = S_MULT;                        GET_CHAR();  break;
-  case '/':   TLS(Symbol) = S_DIV;                         GET_CHAR();  break;
-  case '^':   TLS(Symbol) = S_POW;                         GET_CHAR();  break;
+  case '*':   STATE(Symbol) = S_MULT;                        GET_CHAR();  break;
+  case '/':   STATE(Symbol) = S_DIV;                         GET_CHAR();  break;
+  case '^':   STATE(Symbol) = S_POW;                         GET_CHAR();  break;
 #ifdef HPCGAP
-  case '`':   TLS(Symbol) = S_BACKQUOTE;                   GET_CHAR();  break;
+  case '`':   STATE(Symbol) = S_BACKQUOTE;                   GET_CHAR();  break;
 #endif
 
   case '"':                        GET_CHAR(); GetMaybeTripStr();  break;
@@ -2089,17 +2089,17 @@ void GetSymbol ( void )
   case '\\':                                          GetIdent();  break;
   case '_':                                           GetIdent();  break;
   case '@':                                           GetIdent();  break;
-  case '~':   TLS(Value)[0] = '~';  TLS(Value)[1] = '\0';
-    TLS(Symbol) = S_IDENT;                       GET_CHAR();  break;
+  case '~':   STATE(Value)[0] = '~';  STATE(Value)[1] = '\0';
+    STATE(Symbol) = S_IDENT;                       GET_CHAR();  break;
 
   case '0': case '1': case '2': case '3': case '4':
   case '5': case '6': case '7': case '8': case '9':
     GetNumber(0);    break;
 
-  case '\377': TLS(Symbol) = S_EOF;                        *TLS(In) = '\0';  break;
+  case '\377': STATE(Symbol) = S_EOF;                        *STATE(In) = '\0';  break;
 
-  default :   if ( IsAlpha(*TLS(In)) )                   { GetIdent();  break; }
-    TLS(Symbol) = S_ILLEGAL;                     GET_CHAR();  break;
+  default :   if ( IsAlpha(*STATE(In)) )                   { GetIdent();  break; }
+    STATE(Symbol) = S_ILLEGAL;                     GET_CHAR();  break;
   }
 }
 
@@ -2178,9 +2178,9 @@ void PutLineTo ( KOutputStream stream, UInt len )
   PutLine2( stream, stream->line, len );
 
   /* if neccessary echo it to the logfile                                */
-  if ( TLS(OutputLog) != 0 && ! stream->isstream ) {
+  if ( STATE(OutputLog) != 0 && ! stream->isstream ) {
     if ( stream->file == 1 || stream->file == 3 ) {
-      PutLine2( TLS(OutputLog), stream->line, len );
+      PutLine2( STATE(OutputLog), stream->line, len );
     }
   }
 }
@@ -2318,7 +2318,7 @@ void PutChrTo (
   }
 
   /* normal character, room on the current line                          */
-  else if ( stream->pos < SyNrCols-2-TLS(NoSplitLine) ) {
+  else if ( stream->pos < SyNrCols-2-STATE(NoSplitLine) ) {
 
     /* put the character on this line                                  */
     stream->line[ stream->pos++ ] = ch;
@@ -2408,7 +2408,7 @@ void PutChrTo (
 
 Obj FuncToggleEcho( Obj self)
 {
-  TLS(Input)->echo = 1 - TLS(Input)->echo;
+  STATE(Input)->echo = 1 - STATE(Input)->echo;
   return (Obj)0;
 }
 
@@ -2421,7 +2421,7 @@ Obj FuncToggleEcho( Obj self)
 Obj FuncCPROMPT( Obj self)
 {
   Obj p;
-  C_NEW_STRING_DYN( p, TLS(Prompt) );
+  C_NEW_STRING_DYN( p, STATE(Prompt) );
   return p;
 }
 
@@ -2441,9 +2441,9 @@ Obj FuncPRINT_CPROMPT( Obj self, Obj prompt )
     /* by assigning to Prompt we also tell readline (if used) what the
        current prompt is  */
     strlcpy(promptBuf, CSTR_STRING(prompt), sizeof(promptBuf));
-    TLS(Prompt) = promptBuf;
+    STATE(Prompt) = promptBuf;
   }
-  Pr("%s%c", (Int)TLS(Prompt), (Int)'\03' );
+  Pr("%s%c", (Int)STATE(Prompt), (Int)'\03' );
   return (Obj) 0;
 }
 
@@ -2562,14 +2562,14 @@ void FormatOutput(void (*put_a_char)(Char c), const Char *format, Int arg1, Int 
       /* must be careful that line breaks don't go inside
          escaped sequences \n or \123 or similar */
       for ( q = (Char*)arg1; *q != '\0'; q++ ) {
-        if (*q == '\\' && TLS(NoSplitLine) == 0) {
+        if (*q == '\\' && STATE(NoSplitLine) == 0) {
           if (*(q+1) < '8' && *(q+1) >= '0')
-            TLS(NoSplitLine) = 3;
+            STATE(NoSplitLine) = 3;
           else
-            TLS(NoSplitLine) = 1;
+            STATE(NoSplitLine) = 1;
         }
-        else if (TLS(NoSplitLine) > 0)
-          TLS(NoSplitLine)--;
+        else if (STATE(NoSplitLine) > 0)
+          STATE(NoSplitLine)--;
         put_a_char( *q );
       }
 
@@ -2738,7 +2738,7 @@ void FormatOutput(void (*put_a_char)(Char c), const Char *format, Int arg1, Int 
 /* TL: static KOutputStream TheStream; */
 
 static void putToTheStream( Char c) {
-  PutChrTo(TLS(TheStream), c);
+  PutChrTo(STATE(TheStream), c);
 }
 
 void PrTo (
@@ -2747,10 +2747,10 @@ void PrTo (
            Int                 arg1,
            Int                 arg2 )
 {
-  KOutputStream savedStream = TLS(TheStream);
-  TLS(TheStream) = stream;
+  KOutputStream savedStream = STATE(TheStream);
+  STATE(TheStream) = stream;
   FormatOutput( putToTheStream, format, arg1, arg2);
-  TLS(TheStream) = savedStream;
+  STATE(TheStream) = savedStream;
 }
 
 void Pr (
@@ -2758,7 +2758,7 @@ void Pr (
          Int                 arg1,
          Int                 arg2 )
 {
-  PrTo(TLS(Output), format, arg1, arg2);
+  PrTo(STATE(Output), format, arg1, arg2);
 }
 
 /* TL: static Char *theBuffer; */
@@ -2767,30 +2767,30 @@ void Pr (
 
 static void putToTheBuffer( Char c)
 {
-  if (TLS(TheCount) < TLS(TheLimit))
-    TLS(TheBuffer)[TLS(TheCount)++] = c;
+  if (STATE(TheCount) < STATE(TheLimit))
+    STATE(TheBuffer)[STATE(TheCount)++] = c;
 }
 
 void SPrTo(Char *buffer, UInt maxlen, const Char *format, Int arg1, Int arg2)
 {
-  Char *savedBuffer = TLS(TheBuffer);
-  UInt savedCount = TLS(TheCount);
-  UInt savedLimit = TLS(TheLimit);
-  TLS(TheBuffer) = buffer;
-  TLS(TheCount) = 0;
-  TLS(TheLimit) = maxlen;
+  Char *savedBuffer = STATE(TheBuffer);
+  UInt savedCount = STATE(TheCount);
+  UInt savedLimit = STATE(TheLimit);
+  STATE(TheBuffer) = buffer;
+  STATE(TheCount) = 0;
+  STATE(TheLimit) = maxlen;
   FormatOutput(putToTheBuffer, format, arg1, arg2);
   putToTheBuffer('\0');
-  TLS(TheBuffer) = savedBuffer;
-  TLS(TheCount) = savedCount;
-  TLS(TheLimit) = savedLimit;
+  STATE(TheBuffer) = savedBuffer;
+  STATE(TheCount) = savedCount;
+  STATE(TheLimit) = savedLimit;
 }
 
 
 Obj FuncINPUT_FILENAME( Obj self) {
   Obj s;
-  if (TLS(Input)) {
-    C_NEW_STRING_DYN( s, TLS(Input)->name );
+  if (STATE(Input)) {
+    C_NEW_STRING_DYN( s, STATE(Input)->name );
   } else {
     C_NEW_STRING_CONST( s, "*defin*" );
   }
@@ -2798,7 +2798,7 @@ Obj FuncINPUT_FILENAME( Obj self) {
 }
 
 Obj FuncINPUT_LINENUMBER( Obj self) {
-  return INTOBJ_INT(TLS(Input) ? TLS(Input)->number : 0);
+  return INTOBJ_INT(STATE(Input) ? STATE(Input)->number : 0);
 }
 
 Obj FuncALL_KEYWORDS(Obj self) {
@@ -2818,9 +2818,9 @@ Obj FuncALL_KEYWORDS(Obj self) {
 
 Obj FuncSET_PRINT_FORMATTING_STDOUT(Obj self, Obj val) {
   if (val == False)
-      ((TypOutputFile *)(TLS(OutputFiles)+1))->format = 0;
+      ((TypOutputFile *)(STATE(OutputFiles)+1))->format = 0;
   else
-      ((TypOutputFile *)(TLS(OutputFiles)+1))->format = 1;
+      ((TypOutputFile *)(STATE(OutputFiles)+1))->format = 1;
   return val;
 }
 
@@ -2881,52 +2881,52 @@ static Int InitLibrary (
  **
  *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
  */
-static Char Cookie[sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0])][9];
-static Char MoreCookie[sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0])][9];
-static Char StillMoreCookie[sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0])][9];
+static Char Cookie[sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])][9];
+static Char MoreCookie[sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])][9];
+static Char StillMoreCookie[sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])][9];
 
 static Int InitKernel (
     StructInitInfo *    module )
 {
     Int                 i;
 
-    TLS(Input) = 0;
+    STATE(Input) = 0;
     (void)OpenInput(  "*stdin*"  );
-    TLS(Input)->echo = 1; /* echo stdin */
+    STATE(Input)->echo = 1; /* echo stdin */
 
-    TLS(Output) = 0;
+    STATE(Output) = 0;
     (void)OpenOutput( "*stdout*" );
 
-    TLS(InputLog)  = 0;  TLS(OutputLog)  = 0;
+    STATE(InputLog)  = 0;  STATE(OutputLog)  = 0;
 
     /* initialize cookies for streams                                      */
     /* also initialize the cookies for the GAP strings which hold the
        latest lines read from the streams  and the name of the current input file*/
-    for ( i = 0;  i < sizeof(TLS(InputFiles))/sizeof(TLS(InputFiles)[0]);  i++ ) {
+    for ( i = 0;  i < sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0]);  i++ ) {
       Cookie[i][0] = 's';  Cookie[i][1] = 't';  Cookie[i][2] = 'r';
       Cookie[i][3] = 'e';  Cookie[i][4] = 'a';  Cookie[i][5] = 'm';
       Cookie[i][6] = ' ';  Cookie[i][7] = '0'+i;
       Cookie[i][8] = '\0';
-      InitGlobalBag(&(TLS(InputFiles)[i].stream), &(Cookie[i][0]));
+      InitGlobalBag(&(STATE(InputFiles)[i].stream), &(Cookie[i][0]));
 
       MoreCookie[i][0] = 's';  MoreCookie[i][1] = 'l';  MoreCookie[i][2] = 'i';
       MoreCookie[i][3] = 'n';  MoreCookie[i][4] = 'e';  MoreCookie[i][5] = ' ';
       MoreCookie[i][6] = ' ';  MoreCookie[i][7] = '0'+i;
       MoreCookie[i][8] = '\0';
-      InitGlobalBag(&(TLS(InputFiles)[i].sline), &(MoreCookie[i][0]));
+      InitGlobalBag(&(STATE(InputFiles)[i].sline), &(MoreCookie[i][0]));
 
       StillMoreCookie[i][0] = 'g';  StillMoreCookie[i][1] = 'a';  StillMoreCookie[i][2] = 'p';
       StillMoreCookie[i][3] = 'n';  StillMoreCookie[i][4] = 'a';  StillMoreCookie[i][5] = 'm';
       StillMoreCookie[i][6] = 'e';  StillMoreCookie[i][7] = '0'+i;
       StillMoreCookie[i][8] = '\0';
-      InitGlobalBag(&(TLS(InputFiles)[i].gapname), &(StillMoreCookie[i][0]));
+      InitGlobalBag(&(STATE(InputFiles)[i].gapname), &(StillMoreCookie[i][0]));
     }
 
     /* tell GASMAN about the global bags                                   */
-    InitGlobalBag(&(TLS(LogFile).stream),        "src/scanner.c:LogFile"        );
-    InitGlobalBag(&(TLS(LogStream).stream),      "src/scanner.c:LogStream"      );
-    InitGlobalBag(&(TLS(InputLogStream).stream), "src/scanner.c:InputLogStream" );
-    InitGlobalBag(&(TLS(OutputLogStream).stream),"src/scanner.c:OutputLogStream");
+    InitGlobalBag(&(STATE(LogFile).stream),        "src/scanner.c:LogFile"        );
+    InitGlobalBag(&(STATE(LogStream).stream),      "src/scanner.c:LogStream"      );
+    InitGlobalBag(&(STATE(InputLogStream).stream), "src/scanner.c:InputLogStream" );
+    InitGlobalBag(&(STATE(OutputLogStream).stream),"src/scanner.c:OutputLogStream");
 
 
     /* import functions from the library                                   */

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2973,12 +2973,12 @@ StructInitInfo * InitInfoScanner ( void )
  *F  DestroyScannerTLS()  . . . . . . . . . . . . . . . . . . . .  destroy TLS
  */
 
-void InitScannerState(GlobalState *state)
+void InitScannerState(GAPState *state)
 {
   state->HELPSubsOn = 1;
 }
 
-void DestroyScannerState(GlobalState *state)
+void DestroyScannerState(GAPState *state)
 {
 }
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -33,7 +33,7 @@
 **  dependent module 'system.c' for the low level input/output.
 */
 #include <src/system.h>                 /* system dependent part */
-
+#include <src/gapstate.h>
 
 #include <src/sysfiles.h>               /* file input/output */
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -2286,12 +2286,12 @@ static Int InitKernel (
     return 0;
 }
 
-void InitStatState(GlobalState *state)
+void InitStatState(GAPState *state)
 {
   state->CurrExecStatFuncs = ExecStatFuncs;
 }
 
-void DestroyStatState(GlobalState *state)
+void DestroyStatState(GAPState *state)
 {
 }
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -13,7 +13,7 @@
 **  statements for their effects and prints statements.
 */
 #include <src/system.h>                 /* system dependent part */
-
+#include <src/gapstate.h>
 
 #include <src/sysfiles.h>               /* file input/output */
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -77,7 +77,7 @@
 **
 **  'EXEC_STAT' is defined in the declaration part of this package as follows:
 **
-#define EXEC_STAT(stat) ( (*TLS(CurrExecStatFuncs)[ TNUM_STAT(stat) ]) ( stat ) )
+#define EXEC_STAT(stat) ( (*STATE(CurrExecStatFuncs)[ TNUM_STAT(stat) ]) ( stat ) )
 */
 
 
@@ -1570,7 +1570,7 @@ UInt            ExecReturnObj (
 
     /* evaluate the expression                                             */
     SET_BRK_CURR_STAT( stat );
-    TLS(ReturnObjStat) = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    STATE(ReturnObjStat) = EVAL_EXPR( ADDR_STAT(stat)[0] );
 
     /* return up to function interpreter                                   */
     return 1;
@@ -1600,8 +1600,8 @@ UInt            ExecReturnVoid (
     }
 #endif
 
-    /* set 'TLS(ReturnObjStat)' to void                                         */
-    TLS(ReturnObjStat) = 0;
+    /* set 'STATE(ReturnObjStat)' to void                                         */
+    STATE(ReturnObjStat) = 0;
 
     /* return up to function interpreter                                   */
     return 2;
@@ -1783,8 +1783,8 @@ void ClearError ( void )
         }
     }
 
-    /* reset <TLS(NrError)>                                                */
-    TLS(NrError) = 0;
+    /* reset <STATE(NrError)>                                                */
+    STATE(NrError) = 0;
 }
 
 /****************************************************************************
@@ -2197,7 +2197,7 @@ static Int InitKernel (
     /* furthermore, statements are no longer bags                          */
     /* InitGlobalBag( &CurrStat );                                         */
 
-    InitGlobalBag( &TLS(ReturnObjStat), "src/stats.c:ReturnObjStat" );
+    InitGlobalBag( &STATE(ReturnObjStat), "src/stats.c:ReturnObjStat" );
 
     /* connect to external functions                                       */
     ImportFuncFromLibrary( "Iterator",       &ITERATOR );

--- a/src/stats.h
+++ b/src/stats.h
@@ -76,10 +76,10 @@ static inline UInt EXEC_STAT(Stat stat)
 *F  RES_BRK_CURR_STAT() . . . . . . . . restore currently executing statement
 */
 #ifndef NO_BRK_CURR_STAT
-#define SET_BRK_CURR_STAT(stat) (TLS(CurrStat) = (stat))
+#define SET_BRK_CURR_STAT(stat) (STATE(CurrStat) = (stat))
 #define OLD_BRK_CURR_STAT       Stat oldStat;
-#define REM_BRK_CURR_STAT()     (oldStat = TLS(CurrStat))
-#define RES_BRK_CURR_STAT()     (TLS(CurrStat) = oldStat)
+#define REM_BRK_CURR_STAT()     (oldStat = STATE(CurrStat))
+#define RES_BRK_CURR_STAT()     (STATE(CurrStat) = oldStat)
 #endif
 #ifdef  NO_BRK_CURR_STAT
 #define SET_BRK_CURR_STAT(stat) /* do nothing */

--- a/src/streams.c
+++ b/src/streams.c
@@ -55,7 +55,7 @@
 
 #include <src/hpc/tls.h>
 
-#include <src/vars.h>                   /* TLS(BottomLVars) for execution contexts */
+#include <src/vars.h>                   /* STATE(BottomLVars) for execution contexts */
 
 
 /****************************************************************************
@@ -69,11 +69,11 @@ Int READ_COMMAND ( void )
     ExecStatus    status;
 
     ClearError();
-    status = ReadEvalCommand(TLS(BottomLVars), 0);
+    status = ReadEvalCommand(STATE(BottomLVars), 0);
     if( status == STATUS_EOF )
         return 0;
 
-    if ( TLS(UserHasQuit) || TLS(UserHasQUIT) )
+    if ( STATE(UserHasQuit) || STATE(UserHasQUIT) )
         return 0;
     
     /* handle return-value or return-void command                          */
@@ -83,11 +83,11 @@ Int READ_COMMAND ( void )
 
     /* handle quit command                                 */
     else if (status == STATUS_QUIT) {
-        TLS(RecursionDepth) = 0;
-        TLS(UserHasQuit) = 1;
+        STATE(RecursionDepth) = 0;
+        STATE(UserHasQuit) = 1;
     }
     else if (status == STATUS_QQUIT) {
-        TLS(UserHasQUIT) = 1;
+        STATE(UserHasQUIT) = 1;
     }
     ClearError();
 
@@ -122,14 +122,14 @@ Obj FuncREAD_ALL_COMMANDS( Obj self, Obj stream, Obj echo )
     SET_LEN_PLIST(resultList, resultCount);
 
     if (echo == True) {
-        TLS(Input)->echo = 1;
+        STATE(Input)->echo = 1;
     } else {
-        TLS(Input)->echo = 0;
+        STATE(Input)->echo = 0;
     }
 
     do {
         ClearError();
-        status = ReadEvalCommand(TLS(BottomLVars), 0);
+        status = ReadEvalCommand(STATE(BottomLVars), 0);
 
         if(!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT))) {
             resultCount++;
@@ -145,9 +145,9 @@ Obj FuncREAD_ALL_COMMANDS( Obj self, Obj stream, Obj echo )
 
             if(!(status & STATUS_ERROR)) {
                 SET_ELM_PLIST(result, 1, True);
-                if (TLS(ReadEvalResult)) {
+                if (STATE(ReadEvalResult)) {
                     SET_LEN_PLIST(result, 2);
-                    SET_ELM_PLIST(result, 2, TLS(ReadEvalResult));
+                    SET_ELM_PLIST(result, 2, STATE(ReadEvalResult));
                 }
             }
         }
@@ -180,9 +180,9 @@ Obj FuncREAD_COMMAND_REAL ( Obj self, Obj stream, Obj echo )
     }
 
     if (echo == True)
-      TLS(Input)->echo = 1;
+      STATE(Input)->echo = 1;
     else
-      TLS(Input)->echo = 0;
+      STATE(Input)->echo = 0;
 
     status = READ_COMMAND();
     
@@ -190,19 +190,19 @@ Obj FuncREAD_COMMAND_REAL ( Obj self, Obj stream, Obj echo )
 
     if( status == 0 ) return result;
 
-    if (TLS(UserHasQUIT)) {
-      TLS(UserHasQUIT) = 0;
+    if (STATE(UserHasQUIT)) {
+      STATE(UserHasQUIT) = 0;
       return result;
     }
 
-    if (TLS(UserHasQuit)) {
-      TLS(UserHasQuit) = 0;
+    if (STATE(UserHasQuit)) {
+      STATE(UserHasQuit) = 0;
     }
     
     SET_ELM_PLIST(result, 1, True);
-    if (TLS(ReadEvalResult)) {
+    if (STATE(ReadEvalResult)) {
         SET_LEN_PLIST(result, 2);
-        SET_ELM_PLIST(result, 2, TLS(ReadEvalResult));
+        SET_ELM_PLIST(result, 2, STATE(ReadEvalResult));
     }
     return result;
 }
@@ -232,15 +232,15 @@ static Int READ_INNER ( UInt UseUHQ )
 {
     ExecStatus                status;
 
-    if (TLS(UserHasQuit))
+    if (STATE(UserHasQuit))
       {
         Pr("Warning: Entering READ with UserHasQuit set, this should never happen, resetting",0,0);
-        TLS(UserHasQuit) = 0;
+        STATE(UserHasQuit) = 0;
       }
-    if (TLS(UserHasQUIT))
+    if (STATE(UserHasQUIT))
       {
         Pr("Warning: Entering READ with UserHasQUIT set, this should never happen, resetting",0,0);
-        TLS(UserHasQUIT) = 0;
+        STATE(UserHasQUIT) = 0;
       }
     MakeReadWriteGVar(LastReadValueGVar);
     AssGVar( LastReadValueGVar, 0);
@@ -248,8 +248,8 @@ static Int READ_INNER ( UInt UseUHQ )
     /* now do the reading                                                  */
     while ( 1 ) {
         ClearError();
-        status = ReadEvalCommand(TLS(BottomLVars), 0);
-	if (TLS(UserHasQuit) || TLS(UserHasQUIT))
+        status = ReadEvalCommand(STATE(BottomLVars), 0);
+	if (STATE(UserHasQuit) || STATE(UserHasQUIT))
 	  break;
         /* handle return-value or return-void command                      */
         if ( status & (STATUS_RETURN_VAL | STATUS_RETURN_VOID) ) {
@@ -262,18 +262,18 @@ static Int READ_INNER ( UInt UseUHQ )
         else if ( status  & (STATUS_ERROR | STATUS_EOF)) 
           break;
         else if (status == STATUS_QUIT) {
-          TLS(RecursionDepth) = 0;
-          TLS(UserHasQuit) = 1;
+          STATE(RecursionDepth) = 0;
+          STATE(UserHasQuit) = 1;
           break;
         }
         else if (status == STATUS_QQUIT) {
-          TLS(UserHasQUIT) = 1;
+          STATE(UserHasQUIT) = 1;
           break;
         }
-        if (TLS(ReadEvalResult))
+        if (STATE(ReadEvalResult))
           {
             MakeReadWriteGVar(LastReadValueGVar);
-            AssGVar( LastReadValueGVar, TLS(ReadEvalResult));
+            AssGVar( LastReadValueGVar, STATE(ReadEvalResult));
             MakeReadOnlyGVar(LastReadValueGVar);
           }
         
@@ -288,8 +288,8 @@ static Int READ_INNER ( UInt UseUHQ )
     }
     ClearError();
 
-    if (!UseUHQ && TLS(UserHasQuit)) {
-      TLS(UserHasQuit) = 0; /* stop recovery here */
+    if (!UseUHQ && STATE(UserHasQuit)) {
+      STATE(UserHasQuit) = 0; /* stop recovery here */
       return 2;
     }
 
@@ -322,7 +322,7 @@ Obj READ_AS_FUNC ( void )
 
     /* get the function                                                    */
     if ( type == 0 ) {
-        func = TLS(ReadEvalResult);
+        func = STATE(ReadEvalResult);
     }
     else {
         func = Fail;
@@ -355,23 +355,23 @@ static void READ_TEST_OR_LOOP(void)
 
         /* read and evaluate the command                                   */
         ClearError();
-        type = ReadEvalCommand(TLS(BottomLVars), &dualSemicolon);
+        type = ReadEvalCommand(STATE(BottomLVars), &dualSemicolon);
 
         /* stop the stopwatch                                              */
         AssGVar( Time, INTOBJ_INT( SyTime() - oldtime ) );
 
         /* handle ordinary command                                         */
-        if ( type == 0 && TLS(ReadEvalResult) != 0 ) {
+        if ( type == 0 && STATE(ReadEvalResult) != 0 ) {
 
             /* remember the value in 'last' and the time in 'time'         */
             AssGVar( Last3, VAL_GVAR( Last2 ) );
             AssGVar( Last2, VAL_GVAR( Last  ) );
-            AssGVar( Last,  TLS(ReadEvalResult)   );
+            AssGVar( Last,  STATE(ReadEvalResult)   );
 
             /* print the result                                            */
             if ( ! dualSemicolon ) {
-                Bag currLVars = TLS(CurrLVars); /* in case view runs into error */
-                ViewObjHandler( TLS(ReadEvalResult) );
+                Bag currLVars = STATE(CurrLVars); /* in case view runs into error */
+                ViewObjHandler( STATE(ReadEvalResult) );
                 SWITCH_TO_OLD_LVARS(currLVars);
             }
         }
@@ -500,11 +500,11 @@ Int READ_GAP_ROOT ( Char * filename )
                 (Int)filename, 0L );
         }
         if ( OpenInput(result.pathname) ) {
-          SySetBuffering(TLS(Input)->file);
+          SySetBuffering(STATE(Input)->file);
             while ( 1 ) {
                 ClearError();
-                type = ReadEvalCommand(TLS(BottomLVars), 0);
-                if (TLS(UserHasQuit) || TLS(UserHasQUIT))
+                type = ReadEvalCommand(STATE(BottomLVars), 0);
+                if (STATE(UserHasQuit) || STATE(UserHasQUIT))
                   break;
                 if ( type & (STATUS_RETURN_VAL | STATUS_RETURN_VOID) ) {
                     Pr( "'return' must not be used in file", 0L, 0L );
@@ -774,17 +774,17 @@ Obj FuncPrint (
             PrintFunction( arg );
         }
         else {
-            memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+            memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
 
             /* if an error occurs stop printing                            */
             TRY_READ {
                 PrintObj( arg );
             }
             CATCH_READ_ERROR {
-                memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+                memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
                 ReadEvalError();
             }
-            memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+            memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
         }
     }
 
@@ -827,12 +827,12 @@ static Obj PRINT_OR_APPEND_TO(Obj args, int append)
             PrintString1(arg);
         }
         else if ( TNUM_OBJ(arg) == T_FUNCTION ) {
-            TLS(PrintObjFull) = 1;
+            STATE(PrintObjFull) = 1;
             PrintFunction( arg );
-            TLS(PrintObjFull) = 0;
+            STATE(PrintObjFull) = 0;
         }
         else {
-            memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+            memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
 
             /* if an error occurs stop printing                            */
             TRY_READ {
@@ -840,10 +840,10 @@ static Obj PRINT_OR_APPEND_TO(Obj args, int append)
             }
             CATCH_READ_ERROR {
                 CloseOutput();
-                memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+                memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
                 ReadEvalError();
             }
-            memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+            memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
         }
     }
 
@@ -880,7 +880,7 @@ static Obj PRINT_OR_APPEND_TO_STREAM(Obj args, int append)
         arg = ELM_LIST(args,i);
 
         /* if an error occurs stop printing                                */
-        memcpy( readJmpError, TLS(ReadJmpError), sizeof(syJmp_buf) );
+        memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
         TRY_READ {
             if ( IS_PLIST(arg) && 0 < LEN_PLIST(arg) && IsStringConv(arg) ) {
                 PrintString1(arg);
@@ -889,9 +889,9 @@ static Obj PRINT_OR_APPEND_TO_STREAM(Obj args, int append)
                 PrintString1(arg);
             }
             else if ( TNUM_OBJ( arg ) == T_FUNCTION ) {
-                TLS(PrintObjFull) = 1;
+                STATE(PrintObjFull) = 1;
                 PrintFunction( arg );
-                TLS(PrintObjFull) = 0;
+                STATE(PrintObjFull) = 0;
             }
             else {
                 PrintObj( arg );
@@ -899,10 +899,10 @@ static Obj PRINT_OR_APPEND_TO_STREAM(Obj args, int append)
         }
         CATCH_READ_ERROR {
             CloseOutput();
-            memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+            memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
             ReadEvalError();
         }
-        memcpy( TLS(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+        memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
     }
 
     /* close the output file again, and return nothing                     */
@@ -1036,7 +1036,7 @@ Obj FuncREAD (
         return False;
     }
 
-    SySetBuffering(TLS(Input)->file);
+    SySetBuffering(STATE(Input)->file);
    
     /* read the test file                                                  */
     return READ() ? True : False;
@@ -1068,7 +1068,7 @@ Obj FuncREAD_NORECOVERY (
         return False;
     }
 
-    SySetBuffering(TLS(Input)->file);
+    SySetBuffering(STATE(Input)->file);
    
     /* read the file */
     switch (READ_NORECOVERY()) {
@@ -1111,14 +1111,14 @@ Obj FuncREAD_STREAM_LOOP (
         return False;
     }
     if ( catcherrstdout == True )
-      TLS(IgnoreStdoutErrout) = TLS(Output);
+      STATE(IgnoreStdoutErrout) = STATE(Output);
     else
-      TLS(IgnoreStdoutErrout) = NULL;
+      STATE(IgnoreStdoutErrout) = NULL;
 
 
     /* read the test file                                                  */
     READ_LOOP();
-    TLS(IgnoreStdoutErrout) = NULL;
+    STATE(IgnoreStdoutErrout) = NULL;
     return True;
 }
 
@@ -1144,7 +1144,7 @@ Obj FuncREAD_AS_FUNC (
         return Fail;
     }
 
-    SySetBuffering(TLS(Input)->file);
+    SySetBuffering(STATE(Input)->file);
     
     /* read the function                                                   */
     return READ_AS_FUNC();

--- a/src/streams.c
+++ b/src/streams.c
@@ -13,6 +13,7 @@
 */
 
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 #include <errno.h>
 #include <stdio.h>

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -2266,13 +2266,13 @@ Char * readlineFgets (
 #endif
   /* now do the real work */
   doingReadline = 1;
-  rlres = readline(TLS(Prompt));
+  rlres = readline(STATE(Prompt));
   doingReadline = 0;
   /* we get a NULL pointer on EOF, say by pressing Ctr-d  */
   if (!rlres) {
     if (!SyCTRD) {
       while (!rlres)
-        rlres = readline(TLS(Prompt));
+        rlres = readline(STATE(Prompt));
     }
     else {
       printf("\n");fflush(stdout);

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -16,6 +16,7 @@
 **  are described in "system.c".
 */
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 
 #include <src/sysfiles.h>               /* file input/output */

--- a/src/system.h
+++ b/src/system.h
@@ -1072,11 +1072,11 @@ extern void InitSystem (
             Char *              argv [] );
 
 
-#include <src/globalstate.h>
+#include <src/gapstate.h>
 
 // FIXME: The TLS macro is for compatibility with the HPC-GAP branch, and helps
 // to keep the diffs between it and master branch small(er).
-#define TLS(x) (MainGlobalState->x)
+#define TLS(x) (MainGAPState->x)
 
 
 #endif // GAP_SYSTEM_H

--- a/src/system.h
+++ b/src/system.h
@@ -1072,13 +1072,6 @@ extern void InitSystem (
             Char *              argv [] );
 
 
-#include <src/gapstate.h>
-
-// FIXME: The TLS macro is for compatibility with the HPC-GAP branch, and helps
-// to keep the diffs between it and master branch small(er).
-#define TLS(x) (MainGAPState->x)
-
-
 #endif // GAP_SYSTEM_H
 
 /****************************************************************************

--- a/src/systimers.c
+++ b/src/systimers.c
@@ -15,6 +15,7 @@
 */
 
 #include <src/system.h>
+#include <src/gapstate.h>
 #include <src/gap.h>
 #include <src/objects.h>
 #include <src/stats.h>

--- a/src/tietze.c
+++ b/src/tietze.c
@@ -11,6 +11,7 @@
 **  This file contains the functions for computing with finite presentations.
 */
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 #include <src/code.h>
 #include <src/stats.h>                  /* for TakeInterrupt */
 

--- a/src/trans.c
+++ b/src/trans.c
@@ -41,7 +41,7 @@
 #define MAX(a, b)          (a < b ? b : a)
 
 // TmpTrans is the same as TmpPerm
-#define  TmpTrans TLS(TmpTrans)
+#define  TmpTrans STATE(TmpTrans)
 
 /* mp this will become a ReadOnly object? */
 Obj IdentityTrans;

--- a/src/trans.h
+++ b/src/trans.h
@@ -1,5 +1,6 @@
 
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/vars.c
+++ b/src/vars.c
@@ -17,6 +17,7 @@
 **  global variables, list elements, and record elements.
 */
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/vars.c
+++ b/src/vars.c
@@ -87,7 +87,7 @@
 **
 *V  PtrLVars  . . . . . . . . . . . . . . . .  pointer to local variables bag
 **
-**  'PtrLVars' is a pointer to the 'TLS(CurrLVars)' bag.  This  makes it faster to
+**  'PtrLVars' is a pointer to the 'STATE(CurrLVars)' bag.  This  makes it faster to
 **  access local variables.
 **
 **  Since   a   garbage collection may  move   this  bag  around, the pointer
@@ -480,14 +480,14 @@ void            ASS_HVAR (
     UInt                i;              /* loop variable                   */
 
     /* walk up the environment chain to the correct values bag             */
-    currLVars = TLS(CurrLVars);
+    currLVars = STATE(CurrLVars);
     for ( i = 1; i <= (hvar >> 16); i++ ) {
         SWITCH_TO_OLD_LVARS( ENVI_FUNC( CURR_FUNC ) );
     }
 
     /* assign the value                                                    */
     ASS_LVAR( hvar & 0xFFFF, val );
-    /* CHANGED_BAG( TLS(CurrLVars) ); is done in the switch below               */
+    /* CHANGED_BAG( STATE(CurrLVars) ); is done in the switch below               */
 
     /* switch back to current local variables bag                          */
     SWITCH_TO_OLD_LVARS( currLVars );
@@ -501,7 +501,7 @@ Obj             OBJ_HVAR (
     UInt                i;              /* loop variable                   */
 
     /* walk up the environment chain to the correct values bag             */
-    currLVars = TLS(CurrLVars);
+    currLVars = STATE(CurrLVars);
     for ( i = 1; i <= (hvar >> 16); i++ ) {
         SWITCH_TO_OLD_LVARS( ENVI_FUNC( CURR_FUNC ) );
     }
@@ -524,7 +524,7 @@ Char *          NAME_HVAR (
     UInt                i;              /* loop variable                   */
 
     /* walk up the environment chain to the correct values bag             */
-    currLVars = TLS(CurrLVars);
+    currLVars = STATE(CurrLVars);
     for ( i = 1; i <= (hvar >> 16); i++ ) {
         SWITCH_TO_OLD_LVARS( ENVI_FUNC( CURR_FUNC ) );
     }
@@ -2600,12 +2600,12 @@ void            PrintIsbComObjExpr (
 
 Obj FuncGetCurrentLVars( Obj self )
 {
-  return TLS(CurrLVars);
+  return STATE(CurrLVars);
 }
 
 Obj FuncGetBottomLVars( Obj self )
 {
-  return TLS(BottomLVars);
+  return STATE(BottomLVars);
 }
 
 Obj FuncParentLVars( Obj self, Obj lvars )
@@ -2625,7 +2625,7 @@ Obj FuncContentsLVars (Obj self, Obj lvars )
   Obj nams = NAMS_FUNC(func);
   UInt len = (SIZE_BAG(lvars) - 2*sizeof(Obj) - sizeof(UInt))/sizeof(Obj);
   Obj values = NEW_PLIST(T_PLIST+IMMUTABLE, len);
-  if (lvars == TLS(BottomLVars))
+  if (lvars == STATE(BottomLVars))
     return False;
   AssPRec(contents, RNamName("func"), func);
   AssPRec(contents,RNamName("names"), nams);
@@ -2634,7 +2634,7 @@ Obj FuncContentsLVars (Obj self, Obj lvars )
     len--;
   SET_LEN_PLIST(values, len);
   AssPRec(contents, RNamName("values"), values);
-  if (ENVI_FUNC(func) != TLS(BottomLVars))
+  if (ENVI_FUNC(func) != STATE(BottomLVars))
     AssPRec(contents, RNamName("higher"), ENVI_FUNC(func));
   return contents;
 }
@@ -2646,16 +2646,16 @@ Obj FuncContentsLVars (Obj self, Obj lvars )
 */
 void VarsBeforeCollectBags ( void )
 {
-  if (TLS(CurrLVars))
-    CHANGED_BAG( TLS(CurrLVars) );
+  if (STATE(CurrLVars))
+    CHANGED_BAG( STATE(CurrLVars) );
 }
 
 void VarsAfterCollectBags ( void )
 {
-  if (TLS(CurrLVars))
+  if (STATE(CurrLVars))
     {
-      TLS(PtrLVars) = PTR_BAG( TLS(CurrLVars) );
-      TLS(PtrBody)  = (Stat*)PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+      STATE(PtrLVars) = PTR_BAG( STATE(CurrLVars) );
+      STATE(PtrBody)  = (Stat*)PTR_BAG( BODY_FUNC( CURR_FUNC ) );
     }
   if (ValGVars)
     PtrGVars = PTR_BAG( ValGVars );
@@ -2758,11 +2758,11 @@ static Int InitKernel (
     StructInitInfo *    module )
 {
     UInt                i;              /* loop variable                   */
-    TLS(CurrLVars) = (Bag) 0;
+    STATE(CurrLVars) = (Bag) 0;
 
     /* make 'CurrLVars' known to Gasman                                    */
-    InitGlobalBag( &TLS(CurrLVars),   "src/vars.c:CurrLVars"   );
-    InitGlobalBag( &TLS(BottomLVars), "src/vars.c:BottomLVars" );
+    InitGlobalBag( &STATE(CurrLVars),   "src/vars.c:CurrLVars"   );
+    InitGlobalBag( &STATE(BottomLVars), "src/vars.c:BottomLVars" );
 
     /* install the marking functions for local variables bag               */
     InfoBags[ T_LVARS ].name = "values bag";
@@ -2934,8 +2934,8 @@ static Int InitKernel (
 static Int PostRestore (
     StructInitInfo *    module )
 {
-    TLS(CurrLVars) = TLS(BottomLVars);
-    SWITCH_TO_OLD_LVARS( TLS(BottomLVars) );
+    STATE(CurrLVars) = STATE(BottomLVars);
+    SWITCH_TO_OLD_LVARS( STATE(BottomLVars) );
 
     /* return success                                                      */
     return 0;
@@ -2951,10 +2951,10 @@ static Int InitLibrary (
 {
     Obj tmpFunc, tmpBody;
 
-    TLS(BottomLVars) = NewBag( T_LVARS, 3*sizeof(Obj) );
+    STATE(BottomLVars) = NewBag( T_LVARS, 3*sizeof(Obj) );
     tmpFunc = NewFunctionC( "bottom", 0, "", 0 );
-    FUNC_LVARS( TLS(BottomLVars) ) = tmpFunc;
-    PARENT_LVARS(TLS(BottomLVars)) = Fail;
+    FUNC_LVARS( STATE(BottomLVars) ) = tmpFunc;
+    PARENT_LVARS(STATE(BottomLVars)) = Fail;
     tmpBody = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
     BODY_FUNC( tmpFunc ) = tmpBody;
 

--- a/src/vars.h
+++ b/src/vars.h
@@ -96,7 +96,7 @@
 **  This  is  in this package,  because  it is stored   along  with the local
 **  variables in the local variables bag.
 */
-#define CURR_FUNC       FUNC_LVARS_PTR(TLS(PtrLVars))
+#define CURR_FUNC       FUNC_LVARS_PTR(STATE(PtrLVars))
 
 
 /****************************************************************************
@@ -114,17 +114,17 @@ extern Obj True;
 static inline void SetBrkCallTo( Expr expr, char * file, int line ) {
   if (STEVES_TRACING == True) {
     fprintf(stderr,"SBCT: %i %x %s %i\n",
-            (int)expr, (int)TLS(CurrLVars), file, line);
+            (int)expr, (int)STATE(CurrLVars), file, line);
   }
-  (TLS(PtrLVars)[1] = (Obj)(Int)(expr));
+  (STATE(PtrLVars)[1] = (Obj)(Int)(expr));
 }
 
 #else
-#define SetBrkCallTo(expr, file, line)  (TLS(PtrLVars)[1] = (Obj)(Int)(expr))
+#define SetBrkCallTo(expr, file, line)  (STATE(PtrLVars)[1] = (Obj)(Int)(expr))
 #endif
 
 #ifndef NO_BRK_CALLS
-#define BRK_CALL_TO()                   ((Expr)(Int)(TLS(PtrLVars)[1]))
+#define BRK_CALL_TO()                   ((Expr)(Int)(STATE(PtrLVars)[1]))
 #define SET_BRK_CALL_TO(expr)           SetBrkCallTo(expr, __FILE__, __LINE__)
 #else
 #define BRK_CALL_TO()                   /* do nothing */
@@ -138,8 +138,8 @@ static inline void SetBrkCallTo( Expr expr, char * file, int line ) {
 *F  SET_BRK_CALL_FROM(lvars)  . .  set frame from which this frame was called
 */
 #ifndef NO_BRK_CALLS
-#define BRK_CALL_FROM()                 PARENT_LVARS_PTR(TLS(PtrLVars))
-#define SET_BRK_CALL_FROM(lvars)        (PARENT_LVARS_PTR(TLS(PtrLVars)) = (lvars))
+#define BRK_CALL_FROM()                 PARENT_LVARS_PTR(STATE(PtrLVars))
+#define SET_BRK_CALL_FROM(lvars)        (PARENT_LVARS_PTR(STATE(PtrLVars)) = (lvars))
 #else
 #define BRK_CALL_FROM()                 /* do nothing */
 #define SET_BRK_CALL_FROM(lvars)        /* do nothing */
@@ -166,20 +166,20 @@ static inline Obj SwitchToNewLvars(Obj func, UInt narg, UInt nloc
 #endif
 )
 {
-  Obj old = TLS(CurrLVars);
+  Obj old = STATE(CurrLVars);
   CHANGED_BAG( old );
-  TLS(CurrLVars) = NewBag( T_LVARS,
+  STATE(CurrLVars) = NewBag( T_LVARS,
                       sizeof(Obj)*(3+narg+nloc) );
-  TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
+  STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
   CURR_FUNC = func;
-  TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+  STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
   SET_BRK_CALL_FROM( old );
 #ifdef TRACEFRAMES
   if (STEVES_TRACING == True) {
     Obj n = NAME_FUNC(func);
     Char *s = ((UInt)n) ? (Char *)CHARS_STRING(n) : (Char *)"nameless";
     fprintf(stderr,"STNL: %s %i\n   func %lx narg %i nloc %i function name %s\n     old lvars %lx new lvars %lx\n",
-            file, line, (UInt) func, (int)narg, (int)nloc,s,(UInt)old, (UInt)TLS(CurrLVars));
+            file, line, (UInt) func, (int)narg, (int)nloc,s,(UInt)old, (UInt)STATE(CurrLVars));
   }
 #endif
   return old;
@@ -208,13 +208,13 @@ static inline void SwitchToOldLVars( Obj old
 #ifdef TRACEFRAMES
   if (STEVES_TRACING == True) {
     fprintf(stderr,"STOL:  %s %i old lvars %lx new lvars %lx\n",
-           file, line, (UInt)TLS(CurrLVars),(UInt)old);
+           file, line, (UInt)STATE(CurrLVars),(UInt)old);
   }
 #endif
-  CHANGED_BAG( TLS(CurrLVars) );
-  TLS(CurrLVars) = (old);
-  TLS(PtrLVars)  = PTR_BAG( TLS(CurrLVars) );
-  TLS(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+  CHANGED_BAG( STATE(CurrLVars) );
+  STATE(CurrLVars) = (old);
+  STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
+  STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
 }
 
 #ifdef TRACEFRAMES
@@ -237,7 +237,7 @@ static inline void SwitchToOldLVars( Obj old
 **
 **  'ASS_LVAR' assigns the value <val> to the local variable <lvar>.
 */
-#define ASS_LVAR(lvar,val)      (TLS(PtrLVars)[(lvar)+2] = (val))
+#define ASS_LVAR(lvar,val)      (STATE(PtrLVars)[(lvar)+2] = (val))
 
 
 /****************************************************************************
@@ -246,7 +246,7 @@ static inline void SwitchToOldLVars( Obj old
 **
 **  'OBJ_LVAR' returns the value of the local variable <lvar>.
 */
-#define OBJ_LVAR(lvar)          (TLS(PtrLVars)[(lvar)+2])
+#define OBJ_LVAR(lvar)          (STATE(PtrLVars)[(lvar)+2])
 
 
 /****************************************************************************

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -1,5 +1,5 @@
 #include <src/system.h>                 /* system dependent part */
-
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1,4 +1,5 @@
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/vector.c
+++ b/src/vector.c
@@ -17,6 +17,7 @@
 **  vector flag and the compact representation of vectors over finite fields.
 */
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -16,6 +16,7 @@
 **  in some other kind of object). 
 */
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */


### PR DESCRIPTION
This PR merges the structs `ThreadLocalStorage` and `GlobalState` and replaces use of `ThreadLocalStorage` by `GlobalState`.

It also renames the macro `TLS` to `STATE`. I decided against `GLOBAL`, because the name suggests that data in the struct would be global (when in HPC-GAP it is thread local).

If tests pass and the general direction of this PR is OK, I will do some history cleanup and rewrite.