### PR TITLE
etc/ci.sh: don't run tests on HPC-GAP

### DIFF
--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -129,7 +129,13 @@ GAPInput
         exit 1
     fi
 
-    $GAP --cover $COVDIR/${TEST_SUITE}.coverage \
+    if [[ $HPCGAP = yes ]]
+    then
+        # FIXME/HACK: some tests currently hang for HPC-GAP, so we skip them for now
+        echo "Skipping tests for HPC-GAP"
+    else
+        $GAP --cover $COVDIR/${TEST_SUITE}.coverage \
                <(echo 'SetUserPreference("ReproducibleBehaviour", true);') \
-               $SRCDIR/tst/${TEST_SUITE}.g || [[ $HPCGAP = yes ]] # HPCGAP HACK TO MAKE TEST PASS
+               $SRCDIR/tst/${TEST_SUITE}.g
+    fi
 esac;


### PR DESCRIPTION
Several of them currently hang, likely due to incomplete or broken
library syncing. Since a lot of test files are affected, we skip the
tests completely for now. Of course this should eventually be resolved
by fixing the tests resp. the underlying bugs.

This PR is an alternative to PR #1225 -- there are at least half a dozen .tst files with hangs in them (I did not investigate fully), so IMHO it doesn't make sense to try to find them all individually. Instead, we should work on the hangs separately, then once they are fixed, re-enable tests.