### PR TITLE
Merge overlap between GAPState and ThreadLocalStorage 

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -53,11 +53,7 @@ SOURCES += src/funcs.c
 SOURCES += src/gap.c
 SOURCES += gen/gap_version.c	# generated source file
 SOURCES += src/gasman.c
-ifeq ($(HPCGAP),no)
-# FIXME: HPC-GAP and src/gapstate.c are not yet compatible; need to "merge"
-# struct GlobalState with ThreadLocalStorage from hpc/tls.h
 SOURCES += src/gapstate.c
-endif
 SOURCES += src/gmpints.c
 SOURCES += src/gvars.c
 SOURCES += src/intfuncs.c

--- a/hpcgap/src/code.c
+++ b/hpcgap/src/code.c
@@ -3449,13 +3449,13 @@ void LoadBody ( Obj body )
 *F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * *
 */
 
-void InitCoderTLS( void )
+void InitCoderState(GAPState * state)
 {
-    STATE(StackStat) = NewBag( T_BODY, 64*sizeof(Stat) );
-    STATE(StackExpr) = NewBag( T_BODY, 64*sizeof(Expr) );
+    state->StackStat = NewBag(T_BODY, 64 * sizeof(Stat));
+    state->StackExpr = NewBag(T_BODY, 64 * sizeof(Expr));
 }
 
-void DestroyCoderTLS( void )
+void DestroyCoderState(GAPState * state)
 {
 }
 

--- a/hpcgap/src/exprs.c
+++ b/hpcgap/src/exprs.c
@@ -2147,12 +2147,12 @@ static Int InitLibrary (
     return 0;
 }
 
-void InitExprTLS()
+void InitExprState(GAPState * state)
 {
-    STATE(CurrEvalExprFuncs) = EvalExprFuncs;
+    state->CurrEvalExprFuncs = EvalExprFuncs;
 }
 
-void DestroyExprTLS()
+void DestroyExprState(GAPState * state)
 {
 }
 

--- a/hpcgap/src/funcs.c
+++ b/hpcgap/src/funcs.c
@@ -797,10 +797,10 @@ Obj STEVES_TRACING;
             ProfileLineByLineOutFunction(func);
 
 #define REMEMBER_LOCKSTACK() \
-    int			lockSP = STATE(lockStackPointer)
+    int			lockSP = TLS(lockStackPointer)
 
 #define CLEAR_LOCK_STACK() \
-    if (lockSP != STATE(lockStackPointer)) \
+    if (lockSP != TLS(lockStackPointer)) \
       PopRegionLocks(lockSP)
 
 
@@ -1206,7 +1206,7 @@ Obj             DoExecFunc0argsL (
 {
     Bag                 oldLvars;       /* old values bag                  */
     OLD_BRK_CURR_STAT                   /* old executing statement         */
-    int			lockSP = STATE(lockStackPointer);
+    int			lockSP = TLS(lockStackPointer);
     Obj                 args[1];
     LockFuncArgs(func, args);
 
@@ -1247,7 +1247,7 @@ Obj             DoExecFunc1argsL (
 {
     Bag                 oldLvars;       /* old values bag                  */
     OLD_BRK_CURR_STAT                   /* old executing statement         */
-    int			lockSP = STATE(lockStackPointer);
+    int			lockSP = TLS(lockStackPointer);
     Obj                 args[1];
     args[0] = arg1;
     LockFuncArgs(func, args);
@@ -1293,7 +1293,7 @@ Obj             DoExecFunc2argsL (
 {
     Bag                 oldLvars;       /* old values bag                  */
     OLD_BRK_CURR_STAT                   /* old executing statement         */
-    int			lockSP = STATE(lockStackPointer);
+    int			lockSP = TLS(lockStackPointer);
     Obj                 args[2];
     args[0] = arg1;
     args[1] = arg2;
@@ -1341,7 +1341,7 @@ Obj             DoExecFunc3argsL (
 {
     Bag                 oldLvars;       /* old values bag                  */
     OLD_BRK_CURR_STAT                   /* old executing statement         */
-    int			lockSP = STATE(lockStackPointer);
+    int			lockSP = TLS(lockStackPointer);
     Obj                 args[3];
     args[0] = arg1;
     args[1] = arg2;
@@ -1393,7 +1393,7 @@ Obj             DoExecFunc4argsL (
 {
     Bag                 oldLvars;       /* old values bag                  */
     OLD_BRK_CURR_STAT                   /* old executing statement         */
-    int			lockSP = STATE(lockStackPointer);
+    int			lockSP = TLS(lockStackPointer);
     Obj                 args[4];
     args[0] = arg1;
     args[1] = arg2;
@@ -1447,7 +1447,7 @@ Obj             DoExecFunc5argsL (
 {
     Bag                 oldLvars;       /* old values bag                  */
     OLD_BRK_CURR_STAT                   /* old executing statement         */
-    int			lockSP = STATE(lockStackPointer);
+    int			lockSP = TLS(lockStackPointer);
     Obj                 args[5];
     args[0] = arg1;
     args[1] = arg2;
@@ -1504,7 +1504,7 @@ Obj             DoExecFunc6argsL (
 {
     Bag                 oldLvars;       /* old values bag                  */
     OLD_BRK_CURR_STAT                   /* old executing statement         */
-    int			lockSP = STATE(lockStackPointer);
+    int			lockSP = TLS(lockStackPointer);
     Obj                 args[6];
     args[0] = arg1;
     args[1] = arg2;
@@ -1560,7 +1560,7 @@ Obj             DoExecFuncXargsL (
     OLD_BRK_CURR_STAT                   /* old executing statement         */
     UInt                len;            /* number of arguments             */
     UInt                i;              /* loop variable                   */
-    int			lockSP = STATE(lockStackPointer);
+    int			lockSP = TLS(lockStackPointer);
 
     CHECK_RECURSION_BEFORE
 

--- a/hpcgap/src/gap.c
+++ b/hpcgap/src/gap.c
@@ -1110,7 +1110,7 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
     tilde = VAL_GVAR(Tilde);
     res = NEW_PLIST(T_PLIST_DENSE+IMMUTABLE,2);
     lockSP = RegionLockSP();
-    savedRegion = STATE(currentRegion);
+    savedRegion = TLS(currentRegion);
     if (sySetjmp(STATE(ReadJmpError))) {
       SET_LEN_PLIST(res,2);
       SET_ELM_PLIST(res,1,False);
@@ -1123,14 +1123,14 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
       STATE(CurrStat) = currStat;
       STATE(RecursionDepth) = recursionDepth;
       PopRegionLocks(lockSP);
-      STATE(currentRegion) = savedRegion;
-      if (STATE(CurrentHashLock))
-        HashUnlock(STATE(CurrentHashLock));
+      TLS(currentRegion) = savedRegion;
+      if (TLS(CurrentHashLock))
+        HashUnlock(TLS(CurrentHashLock));
     } else {
       Obj result = CallFuncList(func, args);
       /* There should be no locks to pop off the stack, but better safe than sorry. */
       PopRegionLocks(lockSP);
-      STATE(currentRegion) = savedRegion;
+      TLS(currentRegion) = savedRegion;
       SET_ELM_PLIST(res,1,True);
       if (result) {
         SET_LEN_PLIST(res,2);
@@ -1312,8 +1312,8 @@ Obj CallErrorInner (
   Obj EarlyMsg;
   Obj r = NEW_PREC(0);
   Obj l;
-  Region *savedRegion = STATE(currentRegion);
-  STATE(currentRegion) = STATE(threadRegion);
+  Region *savedRegion = TLS(currentRegion);
+  TLS(currentRegion) = TLS(threadRegion);
   EarlyMsg = ErrorMessageToGAPString(msg, arg1, arg2);
   AssPRec(r, RNamName("context"), STATE(CurrLVars));
   AssPRec(r, RNamName("justQuit"), justQuit? True : False);
@@ -1326,7 +1326,7 @@ Obj CallErrorInner (
   SET_LEN_PLIST(l,1);
   SET_BRK_CALL_TO(STATE(CurrStat));
   Obj res = CALL_2ARGS(ErrorInner,r,l);
-  STATE(currentRegion) = savedRegion;
+  TLS(currentRegion) = savedRegion;
   return res;
 }
 

--- a/hpcgap/src/opers.c
+++ b/hpcgap/src/opers.c
@@ -6583,23 +6583,16 @@ StructInitInfo * InitInfoOpers ( void )
     return &module;
 }
 
-/****************************************************************************
-**
-*F  InitOpersTLS() . . . . . . . . . . . . . . . . . . . . . . initialize TLS
-*F  DestroyOpersTLS()  . . . . . . . . . . . . . . . . . . . . .  destroy TLS
-*/
-
-void InitOpersTLS()
+void InitOpersState(GAPState * state)
 {
-  STATE(MethodCache) = NEW_PLIST(T_PLIST, 1);
-  STATE(MethodCacheItems) = ADDR_OBJ(STATE(MethodCache));
-  STATE(MethodCacheSize) = 1;
-  SET_LEN_PLIST(STATE(MethodCache), 1);
+    state->MethodCache = NEW_PLIST(T_PLIST, 1);
+    state->MethodCacheItems = ADDR_OBJ(STATE(MethodCache));
+    state->MethodCacheSize = 1;
+    SET_LEN_PLIST(state->MethodCache, 1);
 }
 
-void DestroyOpersTLS()
+void DestroyOpersState(GAPState * state)
 {
-  /* Nothing for now. */
 }
 
 

--- a/hpcgap/src/opers.c
+++ b/hpcgap/src/opers.c
@@ -1627,8 +1627,8 @@ Obj CallHandleMethodNotFound( Obj oper,
   Obj r;
   Obj arglist;
   UInt i;
-  Region *savedRegion = STATE(currentRegion);
-  STATE(currentRegion) = STATE(threadRegion);
+  Region *savedRegion = TLS(currentRegion);
+  TLS(currentRegion) = TLS(threadRegion);
 
   r = NEW_PREC(5);
   if (RNamOperation == 0)
@@ -1653,7 +1653,7 @@ Obj CallHandleMethodNotFound( Obj oper,
   AssPRec(r,RNamPrecedence,precedence);
   SortPRecRNam(r,0);
   r = CALL_1ARGS(HandleMethodNotFound, r);
-  STATE(currentRegion) = savedRegion;
+  TLS(currentRegion) = savedRegion;
   return r;
 }
 

--- a/hpcgap/src/profile.c
+++ b/hpcgap/src/profile.c
@@ -471,7 +471,7 @@ static inline void outputStat(Stat stat, int exec, int visited)
 void visitStat(Stat stat)
 {
 #ifdef HPCGAP
-  if(profileState.profiledThread != STATE(threadID))
+  if(profileState.profiledThread != TLS(threadID))
     return;
 #endif
 
@@ -625,7 +625,7 @@ void enableAtStartup(char* filename, Int repeats)
     profileState_Active = 1;
     profileState.profiledPreviously = 1;
 #ifdef HPCGAP
-    profileState.profiledThread = STATE(threadID);
+    profileState.profiledThread = TLS(threadID);
 #endif
     profileState.lastNotOutputted.line = -1;
 #ifdef HAVE_GETTIMEOFDAY
@@ -758,7 +758,7 @@ Obj FuncACTIVATE_PROFILING (
     profileState_Active = 1;
     profileState.profiledPreviously = 1;
 #ifdef HPCGAP
-    profileState.profiledThread = STATE(threadID);
+    profileState.profiledThread = TLS(threadID);
 #endif
     profileState.lastNotOutputted.line = -1;
 

--- a/hpcgap/src/read.c
+++ b/hpcgap/src/read.c
@@ -2789,8 +2789,8 @@ ExecStatus ReadEvalCommand ( Obj context, UInt *dualSemicolon )
         IntrEnd( 1UL );
         type = STATUS_ERROR;
         PopRegionLocks(lockSP);
-        if (STATE(CurrentHashLock))
-            HashUnlock(STATE(CurrentHashLock));
+        if (TLS(CurrentHashLock))
+            HashUnlock(TLS(CurrentHashLock));
     }
 
     /* switch back to the old reader context                               */
@@ -2928,8 +2928,8 @@ UInt ReadEvalFile ( void )
     /* switch back to the old reader context                               */
     memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
     PopRegionLocks(lockSP);
-    if (STATE(CurrentHashLock))
-      HashUnlock(STATE(CurrentHashLock));
+    if (TLS(CurrentHashLock))
+      HashUnlock(TLS(CurrentHashLock));
     STATE(StackNams)   = stackNams;
     STATE(CountNams)   = countNams;
     STATE(ReadTop)     = readTop;

--- a/hpcgap/src/scanner.c
+++ b/hpcgap/src/scanner.c
@@ -3095,18 +3095,12 @@ StructInitInfo * InitInfoScanner ( void )
   return &module;
 }
 
-/****************************************************************************
- **
- *F  InitScannerTLS() . . . . . . . . . . . . . . . . . . . . . initialize TLS
- *F  DestroyScannerTLS()  . . . . . . . . . . . . . . . . . . . .  destroy TLS
- */
-
-void InitScannerTLS()
+void InitScannerState(GAPState * state)
 {
-  STATE(HELPSubsOn) = 1;
+    state->HELPSubsOn = 1;
 }
 
-void DestroyScannerTLS()
+void DestroyScannerState(GAPState * state)
 {
 }
 

--- a/hpcgap/src/scanner.c
+++ b/hpcgap/src/scanner.c
@@ -278,7 +278,7 @@ GVarDescriptor DEFAULT_OUTPUT_STREAM;
 UInt OpenDefaultInput( void )
 {
   Obj func, stream;
-  stream = STATE(DefaultInput);
+  stream = TLS(DefaultInput);
   if (stream)
     return OpenInputStream(stream);
   func = GVarOptFunction(&DEFAULT_INPUT_STREAM);
@@ -289,14 +289,14 @@ UInt OpenDefaultInput( void )
     ErrorQuit("DEFAULT_INPUT_STREAM() did not return a stream", 0L, 0L);
   if (IsStringConv(stream))
     return OpenInput(CSTR_STRING(stream));
-  STATE(DefaultInput) = stream;
+  TLS(DefaultInput) = stream;
   return OpenInputStream(stream);
 }
 
 UInt OpenDefaultOutput( void )
 {
   Obj func, stream;
-  stream = STATE(DefaultOutput);
+  stream = TLS(DefaultOutput);
   if (stream)
     return OpenOutputStream(stream);
   func = GVarOptFunction(&DEFAULT_OUTPUT_STREAM);
@@ -307,7 +307,7 @@ UInt OpenDefaultOutput( void )
     ErrorQuit("DEFAULT_OUTPUT_STREAM() did not return a stream", 0L, 0L);
   if (IsStringConv(stream))
     return OpenOutput(CSTR_STRING(stream));
-  STATE(DefaultOutput) = stream;
+  TLS(DefaultOutput) = stream;
   return OpenOutputStream(stream);
 }
 
@@ -365,7 +365,7 @@ UInt OpenInput (
     /* Handle *defin*; redirect *errin* to *defin* if the default
      * channel is already open. */
     if (! strcmp(filename, "*defin*") ||
-        (! strcmp(filename, "*errin*") && STATE(DefaultInput)) )
+        (! strcmp(filename, "*errin*") && TLS(DefaultInput)) )
         return OpenDefaultInput();
     /* try to open the input file                                          */
     file = SyFopen( filename, "r" );
@@ -857,7 +857,7 @@ UInt OpenOutput (
     /* Handle *defout* specially; also, redirect *errout* if we already
      * have a default channel open. */
     if ( ! strcmp( filename, "*defout*" ) ||
-         (! strcmp( filename, "*errout*" ) && STATE(threadID) != 0) )
+         (! strcmp( filename, "*errout*" ) && TLS(threadID) != 0) )
         return OpenDefaultOutput();
 
     /* try to open the file                                                */
@@ -952,7 +952,7 @@ UInt CloseOutput ( void )
 
     /* refuse to close the initial output file '*stdout*'                  */
     if ( STATE(OutputFilesSP) <= 1 && STATE(Output)->isstream
-         && STATE(DefaultOutput) == STATE(Output)->stream)
+         && TLS(DefaultOutput) == STATE(Output)->stream)
       return 1;
 
 
@@ -2435,7 +2435,7 @@ void PutChrTo (
   /* normal character, room on the current line                          */
   /* TODO: For threads other than the main thread, reserve some extra
      space for the thread id indicator. See issue #136. */
-  else if ( stream->pos < SyNrCols-2-6*(STATE(threadID) != 0)-STATE(NoSplitLine) ) {
+  else if ( stream->pos < SyNrCols-2-6*(TLS(threadID) != 0)-STATE(NoSplitLine) ) {
 
     /* put the character on this line                                  */
     stream->line[ stream->pos++ ] = ch;

--- a/hpcgap/src/stats.c
+++ b/hpcgap/src/stats.c
@@ -2325,17 +2325,17 @@ static Int InitKernel (
     return 0;
 }
 
-void InitStatTLS()
+void InitStatState(GAPState * state)
 {
-  STATE(CurrExecStatFuncs) = ExecStatFuncs;
-  MEMBAR_FULL();
-  if (GetThreadState(TLS(threadID)) >= TSTATE_INTERRUPT) {
+    state->CurrExecStatFuncs = ExecStatFuncs;
     MEMBAR_FULL();
-    STATE(CurrExecStatFuncs) = IntrExecStatFuncs;
-  }
+    if (GetThreadState(TLS(threadID)) >= TSTATE_INTERRUPT) {
+        MEMBAR_FULL();
+        state->CurrExecStatFuncs = IntrExecStatFuncs;
+    }
 }
 
-void DestroyStatTLS()
+void DestroyStatState(GAPState * state)
 {
 }
 

--- a/hpcgap/src/stats.c
+++ b/hpcgap/src/stats.c
@@ -2329,7 +2329,7 @@ void InitStatTLS()
 {
   STATE(CurrExecStatFuncs) = ExecStatFuncs;
   MEMBAR_FULL();
-  if (GetThreadState(STATE(threadID)) >= TSTATE_INTERRUPT) {
+  if (GetThreadState(TLS(threadID)) >= TSTATE_INTERRUPT) {
     MEMBAR_FULL();
     STATE(CurrExecStatFuncs) = IntrExecStatFuncs;
   }

--- a/hpcgap/src/vars.c
+++ b/hpcgap/src/vars.c
@@ -119,10 +119,10 @@ Obj             ObjLVar (
 
 Bag NewLVarsBag(UInt slots) {
   Bag result;
-  if (slots < sizeof(STATE(LVarsPool))/(sizeof(STATE(LVarsPool)[0]))) {
-    result = STATE(LVarsPool)[slots];
+  if (slots < sizeof(TLS(LVarsPool))/(sizeof(TLS(LVarsPool)[0]))) {
+    result = TLS(LVarsPool)[slots];
     if (result) {
-      STATE(LVarsPool)[slots] = ADDR_OBJ(result)[0];
+      TLS(LVarsPool)[slots] = ADDR_OBJ(result)[0];
       return result;
     }
   }
@@ -131,10 +131,10 @@ Bag NewLVarsBag(UInt slots) {
 
 void FreeLVarsBag(Bag bag) {
   UInt slots = SIZE_BAG(bag) / sizeof(Obj) - 3;
-  if (slots < sizeof(STATE(LVarsPool))/(sizeof(STATE(LVarsPool)[0]))) {
+  if (slots < sizeof(TLS(LVarsPool))/(sizeof(TLS(LVarsPool)[0]))) {
     memset(PTR_BAG(bag), 0, SIZE_BAG(bag));
-    ADDR_OBJ(bag)[0] = STATE(LVarsPool)[slots];
-    STATE(LVarsPool)[slots] = bag;
+    ADDR_OBJ(bag)[0] = TLS(LVarsPool)[slots];
+    TLS(LVarsPool)[slots] = bag;
   }
 }
 

--- a/src/gapstate.c
+++ b/src/gapstate.c
@@ -8,6 +8,7 @@
  **
  */
 
+#include <src/system.h>
 #include <src/gapstate.h>
 
 #define MAX_FUNC_EXPR_NESTING 1024

--- a/src/gapstate.c
+++ b/src/gapstate.c
@@ -40,7 +40,7 @@ void InitGAPState(GAPState * state)
     // RunConstructors?
 }
 
-void DestroyGlobal(GAPState * state)
+void DestroyGAPState(GAPState * state)
 {
     DestroyScannerState(state);
     DestroyStatState(state);

--- a/src/gapstate.c
+++ b/src/gapstate.c
@@ -18,7 +18,7 @@ static UInt MainLoopStack[MAX_FUNC_EXPR_NESTING];
 
 static GAPState _MainGAPState;
 
-GAPState *MainGAPState = 0;
+GAPState * MainGAPState = 0;
 
 void InitMainGAPState(void)
 {
@@ -29,7 +29,7 @@ void InitMainGAPState(void)
     MainGAPState->LoopStack = MainLoopStack;
 }
 
-void InitGAPState(GAPState *state)
+void InitGAPState(GAPState * state)
 {
     InitScannerState(state);
     InitStatState(state);
@@ -40,7 +40,7 @@ void InitGAPState(GAPState *state)
     // RunConstructors?
 }
 
-void DestroyGlobal(GAPState *state)
+void DestroyGlobal(GAPState * state)
 {
     DestroyScannerState(state);
     DestroyStatState(state);

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -29,9 +29,6 @@ typedef struct GAPState
   Obj IntrState;
   Obj StackObj;
   Int CountObj;
-#if defined(HPCGAP)
-  UInt PeriodicCheckCount;
-#endif
 
   /* From gvar.c */
   Obj CurrNamespace;
@@ -40,9 +37,6 @@ typedef struct GAPState
   Bag BottomLVars;
   Bag CurrLVars;
   Obj *PtrLVars;
-#if defined(HPCGAP)
-  Bag LVarsPool[16];
-#endif
 
   /* From read.c */
   syJmp_buf ReadJmpError;
@@ -64,8 +58,13 @@ typedef struct GAPState
   UInt NrErrLine;
   UInt            Symbol;
   Char *          Prompt;
+#if defined(HPCGAP)
+  TypInputFile * InputFiles[16];
+  TypOutputFile * OutputFiles[16];
+#else
   TypInputFile   InputFiles[16];
   TypOutputFile OutputFiles[16];
+#endif
   int InputFilesSP;
   int OutputFilesSP;
   TypInputFile *  Input;
@@ -74,10 +73,6 @@ typedef struct GAPState
   TypOutputFile * InputLog;
   TypOutputFile * OutputLog;
   TypOutputFile * IgnoreStdoutErrout;
-#if defined(HPCGAP)
-  Obj		  DefaultOutput;
-  Obj		  DefaultInput;
-#endif
   TypOutputFile LogFile;
   TypOutputFile LogStream;
   TypOutputFile InputLogFile;
@@ -154,10 +149,15 @@ typedef struct GAPState
   Int PrintObjIndex;
   Int PrintObjDepth;
   Int PrintObjFull;
-  // HPC-GAP Obj PrintObjThissObj;
+#if defined(HPCGAP)
+  Obj PrintObjThissObj;
+  Obj *PrintObjThiss;
+  Obj PrintObjIndicesObj;
+  Int *PrintObjIndices;
+#else
   Obj PrintObjThiss[MAXPRINTDEPTH];
-  // HPC-GAP Obj PrintObjIndicesObj;
   Int PrintObjIndices[MAXPRINTDEPTH];
+#endif
 
 #if defined(HPCGAP)
   /* For serializer.c */
@@ -177,13 +177,6 @@ typedef struct GAPState
   Obj SC_CW_VECTOR;
   Obj SC_CW2_VECTOR;
   UInt SC_MAX_STACK_SIZE;
-
-#if defined(HPCGAP)
-  /* Profiling */
-  UInt CountActive;
-  UInt LocksAcquired;
-  UInt LocksContended;
-#endif
 
   /* Allocation */
 #ifdef BOEHM_GC

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -12,182 +12,181 @@
 
 #include <stdint.h>
 
-#include <src/system.h>
 #include <src/code.h>
-#include <src/scanner.h>
 #include <src/gasman.h>
+#include <src/scanner.h>
+#include <src/system.h>
 
 #define MAXPRINTDEPTH 1024L
 
-typedef struct GAPState
-{
-  /* From intrprtr.c */
-  Obj IntrResult;
-  UInt IntrIgnoring;
-  UInt IntrReturning;
-  UInt IntrCoding;
-  Obj IntrState;
-  Obj StackObj;
-  Int CountObj;
+typedef struct GAPState {
+    /* From intrprtr.c */
+    Obj  IntrResult;
+    UInt IntrIgnoring;
+    UInt IntrReturning;
+    UInt IntrCoding;
+    Obj  IntrState;
+    Obj  StackObj;
+    Int  CountObj;
 
-  /* From gvar.c */
-  Obj CurrNamespace;
+    /* From gvar.c */
+    Obj CurrNamespace;
 
-  /* From vars.c */
-  Bag BottomLVars;
-  Bag CurrLVars;
-  Obj *PtrLVars;
+    /* From vars.c */
+    Bag   BottomLVars;
+    Bag   CurrLVars;
+    Obj * PtrLVars;
 
-  /* From read.c */
-  syJmp_buf ReadJmpError;
-  syJmp_buf threadExit;
-  Obj StackNams;
-  UInt CountNams;
-  UInt ReadTop;
-  UInt ReadTilde;
-  UInt CurrLHSGVar;
-  UInt CurrentGlobalForLoopVariables[100];
-  UInt CurrentGlobalForLoopDepth;
-  Obj ExprGVars;
-  Obj ReadEvalResult;
+    /* From read.c */
+    syJmp_buf ReadJmpError;
+    syJmp_buf threadExit;
+    Obj       StackNams;
+    UInt      CountNams;
+    UInt      ReadTop;
+    UInt      ReadTilde;
+    UInt      CurrLHSGVar;
+    UInt      CurrentGlobalForLoopVariables[100];
+    UInt      CurrentGlobalForLoopDepth;
+    Obj       ExprGVars;
+    Obj       ReadEvalResult;
 
-  /* From scanner.c */
-  Char Value[MAX_VALUE_LEN];
-  UInt ValueLen;
-  UInt NrError;
-  UInt NrErrLine;
-  UInt            Symbol;
-  Char *          Prompt;
+    /* From scanner.c */
+    Char   Value[MAX_VALUE_LEN];
+    UInt   ValueLen;
+    UInt   NrError;
+    UInt   NrErrLine;
+    UInt   Symbol;
+    Char * Prompt;
 #if defined(HPCGAP)
-  TypInputFile * InputFiles[16];
-  TypOutputFile * OutputFiles[16];
+    TypInputFile *  InputFiles[16];
+    TypOutputFile * OutputFiles[16];
 #else
-  TypInputFile   InputFiles[16];
-  TypOutputFile OutputFiles[16];
+    TypInputFile  InputFiles[16];
+    TypOutputFile OutputFiles[16];
 #endif
-  int InputFilesSP;
-  int OutputFilesSP;
-  TypInputFile *  Input;
-  Char *          In;
-  TypOutputFile * Output;
-  TypOutputFile * InputLog;
-  TypOutputFile * OutputLog;
-  TypOutputFile * IgnoreStdoutErrout;
-  TypOutputFile LogFile;
-  TypOutputFile LogStream;
-  TypOutputFile InputLogFile;
-  TypOutputFile InputLogStream;
-  TypOutputFile OutputLogFile;
-  TypOutputFile OutputLogStream;
-  Int HELPSubsOn;
-  Int NoSplitLine;
-  KOutputStream TheStream;
-  Char *TheBuffer;
-  UInt TheCount;
-  UInt TheLimit;
+    int             InputFilesSP;
+    int             OutputFilesSP;
+    TypInputFile *  Input;
+    Char *          In;
+    TypOutputFile * Output;
+    TypOutputFile * InputLog;
+    TypOutputFile * OutputLog;
+    TypOutputFile * IgnoreStdoutErrout;
+    TypOutputFile   LogFile;
+    TypOutputFile   LogStream;
+    TypOutputFile   InputLogFile;
+    TypOutputFile   InputLogStream;
+    TypOutputFile   OutputLogFile;
+    TypOutputFile   OutputLogStream;
+    Int             HELPSubsOn;
+    Int             NoSplitLine;
+    KOutputStream   TheStream;
+    Char *          TheBuffer;
+    UInt            TheCount;
+    UInt            TheLimit;
 
-  /* From exprs.c */
-  Obj (**CurrEvalExprFuncs)(Expr);
+    /* From exprs.c */
+    Obj (**CurrEvalExprFuncs)(Expr);
 
-  /* From stats.c */
-  Stat CurrStat;
-  Obj ReturnObjStat;
-  UInt (**CurrExecStatFuncs)(Stat);
+    /* From stats.c */
+    Stat CurrStat;
+    Obj  ReturnObjStat;
+    UInt (**CurrExecStatFuncs)(Stat);
 
-  /* From code.c */
-  Stat *PtrBody;
-  Stat OffsBody;
-  Stat *OffsBodyStack;
-  UInt OffsBodyCount;
-  UInt LoopNesting;
-  UInt *LoopStack;
-  UInt LoopStackCount;
+    /* From code.c */
+    Stat * PtrBody;
+    Stat   OffsBody;
+    Stat * OffsBodyStack;
+    UInt   OffsBodyCount;
+    UInt   LoopNesting;
+    UInt * LoopStack;
+    UInt   LoopStackCount;
 
-  Obj CodeResult;
-  Bag StackStat;
-  Int CountStat;
-  Bag StackExpr;
-  Int CountExpr;
-  Bag CodeLVars;
+    Obj CodeResult;
+    Bag StackStat;
+    Int CountStat;
+    Bag StackExpr;
+    Int CountExpr;
+    Bag CodeLVars;
 
-  /* From funcs.h */
-  Int RecursionDepth;
-  Obj ExecState;
+    /* From funcs.h */
+    Int RecursionDepth;
+    Obj ExecState;
 
-  /* From opers.c */
-  Obj MethodCache;
-  Obj *MethodCacheItems;
-  UInt MethodCacheSize;
-  UInt CacheIndex;
+    /* From opers.c */
+    Obj   MethodCache;
+    Obj * MethodCacheItems;
+    UInt  MethodCacheSize;
+    UInt  CacheIndex;
 
-  /* From cyclotom.c */
-  Obj ResultCyc;
-  Obj  LastECyc;
-  UInt LastNCyc;
+    /* From cyclotom.c */
+    Obj  ResultCyc;
+    Obj  LastECyc;
+    UInt LastNCyc;
 
-  /* From permutat.c */
-  Obj TmpPerm;
+    /* From permutat.c */
+    Obj TmpPerm;
 
-  /* From trans.c */
-  Obj TmpTrans;
+    /* From trans.c */
+    Obj TmpTrans;
 
-  /* From pperm.c */
-  Obj TmpPPerm;
+    /* From pperm.c */
+    Obj TmpPPerm;
 
-  /* From gap.c */
-  Obj ThrownObject;
-  UInt UserHasQuit;
-  UInt UserHasQUIT;
-  Obj ShellContext;
-  Obj BaseShellContext;
-  Int ErrorLLevel;
-  Obj ErrorLVars;
-  Obj ErrorLVars0;
+    /* From gap.c */
+    Obj  ThrownObject;
+    UInt UserHasQuit;
+    UInt UserHasQUIT;
+    Obj  ShellContext;
+    Obj  BaseShellContext;
+    Int  ErrorLLevel;
+    Obj  ErrorLVars;
+    Obj  ErrorLVars0;
 
-  /* From objects.c */
-  Obj PrintObjThis;
-  Int PrintObjIndex;
-  Int PrintObjDepth;
-  Int PrintObjFull;
+    /* From objects.c */
+    Obj PrintObjThis;
+    Int PrintObjIndex;
+    Int PrintObjDepth;
+    Int PrintObjFull;
 #if defined(HPCGAP)
-  Obj PrintObjThissObj;
-  Obj *PrintObjThiss;
-  Obj PrintObjIndicesObj;
-  Int *PrintObjIndices;
+    Obj   PrintObjThissObj;
+    Obj * PrintObjThiss;
+    Obj   PrintObjIndicesObj;
+    Int * PrintObjIndices;
 #else
-  Obj PrintObjThiss[MAXPRINTDEPTH];
-  Int PrintObjIndices[MAXPRINTDEPTH];
+    Obj           PrintObjThiss[MAXPRINTDEPTH];
+    Int           PrintObjIndices[MAXPRINTDEPTH];
 #endif
 
 #if defined(HPCGAP)
-  /* For serializer.c */
-  Obj SerializationObj;
-  UInt SerializationIndex;
-  void *SerializationDispatcher;
-  Obj SerializationRegistry;
-  Obj SerializationStack;
+    /* For serializer.c */
+    Obj    SerializationObj;
+    UInt   SerializationIndex;
+    void * SerializationDispatcher;
+    Obj    SerializationRegistry;
+    Obj    SerializationStack;
 #endif
 
-  /* For objscoll*, objccoll* */
-  Obj SC_NW_STACK;
-  Obj SC_LW_STACK;
-  Obj SC_PW_STACK;
-  Obj SC_EW_STACK;
-  Obj SC_GE_STACK;
-  Obj SC_CW_VECTOR;
-  Obj SC_CW2_VECTOR;
-  UInt SC_MAX_STACK_SIZE;
+    /* For objscoll*, objccoll* */
+    Obj  SC_NW_STACK;
+    Obj  SC_LW_STACK;
+    Obj  SC_PW_STACK;
+    Obj  SC_EW_STACK;
+    Obj  SC_GE_STACK;
+    Obj  SC_CW_VECTOR;
+    Obj  SC_CW2_VECTOR;
+    UInt SC_MAX_STACK_SIZE;
 
-  /* Allocation */
+/* Allocation */
 #ifdef BOEHM_GC
 #define MAX_GC_PREFIX_DESC 4
-  void **FreeList[MAX_GC_PREFIX_DESC+2];
+    void ** FreeList[MAX_GC_PREFIX_DESC + 2];
 #endif
 } GAPState;
 
 #if !defined(HPCGAP)
 
-extern GAPState *MainGAPState;
+extern GAPState * MainGAPState;
 #define STATE(x) (MainGAPState->x)
 
 #endif
@@ -206,7 +205,7 @@ void DestroyExprState(GAPState *);
 void DestroyCoderState(GAPState *);
 void DestroyOpersState(GAPState *);
 
-void InitGAPState(GAPState *state);
-void DestroyGAPState(GAPState *state);
+void InitGAPState(GAPState * state);
+void DestroyGAPState(GAPState * state);
 
-#endif // GAP_GAPSTATE_H
+#endif    // GAP_GAPSTATE_H

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -185,7 +185,12 @@ typedef struct GAPState
 #endif
 } GAPState;
 
+#if !defined(HPCGAP)
+
 extern GAPState *MainGAPState;
+#define STATE(x) (MainGAPState->x)
+
+#endif
 
 void InitMainGAPState(void);
 

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -556,7 +556,7 @@ static void ExpandTLRecord(Obj obj)
   do {
     contents = *ADDR_ATOM(obj);
     table = ADDR_OBJ(contents.obj);
-    UInt thread = STATE(threadID);
+    UInt thread = TLS(threadID);
     if (thread < (UInt)*table)
       return;
     newcontents.obj = NewBag(T_TLREC_INNER, sizeof(Obj) * (thread+TLR_DATA+1));
@@ -612,8 +612,8 @@ static void PrintTLRecord(Obj obj)
   int comma = 0;
   AtomicObj *deftable;
   int i;
-  if (STATE(threadID) < (UInt)table[TLR_SIZE]) {
-    record = table[TLR_DATA+STATE(threadID)];
+  if (TLS(threadID) < (UInt)table[TLR_SIZE]) {
+    record = table[TLR_DATA+TLS(threadID)];
   }
   Pr("%2>rec( %2>", 0L, 0L);
   if (record) {
@@ -1006,7 +1006,7 @@ Obj CopyARecord(Obj obj, Int mutable)
 #if 0
   UInt i, len;
   Obj result;
-  Obj copied = STATE(CopiedObjs);
+  Obj copied = TLS(CopiedObjs);
   if (copied)
   {
     len = LEN_PLIST(copied);
@@ -1018,7 +1018,7 @@ Obj CopyARecord(Obj obj, Int mutable)
   else
   {
     len = 0;
-    STATE(CopiedObjs) = copied = NEW_PLIST(T_PLIST, 2);
+    TLS(CopiedObjs) = copied = NEW_PLIST(T_PLIST, 2);
     SET_LEN_PLIST(copied, 2);
   }
   result = ShallowCopyARecord(obj);
@@ -1047,17 +1047,17 @@ static void UpdateThreadRecord(Obj record, Obj tlrecord)
   Obj inner;
   do {
     inner = GetTLInner(record);
-    ADDR_OBJ(inner)[TLR_DATA+STATE(threadID)] = tlrecord;
+    ADDR_OBJ(inner)[TLR_DATA+TLS(threadID)] = tlrecord;
     MEMBAR_FULL(); /* memory barrier */
   } while (inner != GetTLInner(record));
   if (tlrecord) {
-    if (STATE(tlRecords))
-      AssPlist(STATE(tlRecords), LEN_PLIST(STATE(tlRecords))+1, record);
+    if (TLS(tlRecords))
+      AssPlist(TLS(tlRecords), LEN_PLIST(TLS(tlRecords))+1, record);
     else {
-      STATE(tlRecords) = NEW_PLIST(T_PLIST, 1);
-      SET_LEN_PLIST(STATE(tlRecords), 1);
-      SET_ELM_PLIST(STATE(tlRecords), 1, record);
-      CHANGED_BAG(STATE(tlRecords));
+      TLS(tlRecords) = NEW_PLIST(T_PLIST, 1);
+      SET_LEN_PLIST(TLS(tlRecords), 1);
+      SET_ELM_PLIST(TLS(tlRecords), 1, record);
+      CHANGED_BAG(TLS(tlRecords));
     }
   }
 }
@@ -1067,12 +1067,12 @@ Obj GetTLRecordField(Obj record, UInt rnam)
   Obj contents, *table;
   Obj tlrecord;
   UInt pos;
-  Region *savedRegion = STATE(currentRegion);
-  STATE(currentRegion) = STATE(threadRegion);
+  Region *savedRegion = TLS(currentRegion);
+  TLS(currentRegion) = TLS(threadRegion);
   ExpandTLRecord(record);
   contents = GetTLInner(record);
   table = ADDR_OBJ(contents);
-  tlrecord = table[TLR_DATA+STATE(threadID)];
+  tlrecord = table[TLR_DATA+TLS(threadID)];
   if (!tlrecord || !FindPRec(tlrecord, rnam, &pos, 1)) {
     Obj result;
     Obj defrec = table[TLR_DEFAULTS];
@@ -1084,7 +1084,7 @@ Obj GetTLRecordField(Obj record, UInt rnam)
 	UpdateThreadRecord(record, tlrecord);
       }
       AssPRec(tlrecord, rnam, result);
-      STATE(currentRegion) = savedRegion;
+      TLS(currentRegion) = savedRegion;
       return result;
     } else {
       Obj func;
@@ -1099,7 +1099,7 @@ Obj GetTLRecordField(Obj record, UInt rnam)
 	  result = CALL_0ARGS(func);
 	else
 	  result = CALL_1ARGS(func, record);
-	STATE(currentRegion) = savedRegion;
+	TLS(currentRegion) = savedRegion;
 	if (!result) {
 	  if (!FindPRec(tlrecord, rnam, &pos, 1))
 	    return 0;
@@ -1108,11 +1108,11 @@ Obj GetTLRecordField(Obj record, UInt rnam)
 	AssPRec(tlrecord, rnam, result);
 	return result;
       }
-      STATE(currentRegion) = savedRegion;
+      TLS(currentRegion) = savedRegion;
       return 0;
     }
   }
-  STATE(currentRegion) = savedRegion;
+  TLS(currentRegion) = savedRegion;
   return GET_ELM_PREC(tlrecord, pos);
 }
 
@@ -1136,7 +1136,7 @@ void AssTLRecord(Obj record, UInt rnam, Obj value)
   ExpandTLRecord(record);
   contents = GetTLInner(record);
   table = ADDR_OBJ(contents);
-  tlrecord = table[TLR_DATA+STATE(threadID)];
+  tlrecord = table[TLR_DATA+TLS(threadID)];
   if (!tlrecord) {
     tlrecord = NEW_PREC(0);
     UpdateThreadRecord(record, tlrecord);
@@ -1151,7 +1151,7 @@ void UnbTLRecord(Obj record, UInt rnam)
   ExpandTLRecord(record);
   contents = GetTLInner(record);
   table = ADDR_OBJ(contents);
-  tlrecord = table[TLR_DATA+STATE(threadID)];
+  tlrecord = table[TLR_DATA+TLS(threadID)];
   if (!tlrecord) {
     tlrecord = NEW_PREC(0);
     UpdateThreadRecord(record, tlrecord);
@@ -1253,10 +1253,10 @@ static Obj FuncATOMIC_RECORD_REPLACEMENT(Obj self, Obj record, Obj policy)
 }
 
 static Obj CreateTLDefaults(Obj defrec) {
-  Region *saved_region = STATE(currentRegion);
+  Region *saved_region = TLS(currentRegion);
   Obj result;
   UInt i;
-  STATE(currentRegion) = LimboRegion;
+  TLS(currentRegion) = LimboRegion;
   result = NewBag(T_PREC, SIZE_BAG(defrec));
   memcpy(ADDR_OBJ(result), ADDR_OBJ(defrec), SIZE_BAG(defrec));
   for (i = 1; i <= LEN_PREC(defrec); i++) {
@@ -1264,7 +1264,7 @@ static Obj CreateTLDefaults(Obj defrec) {
       CopyReachableObjectsFrom(GET_ELM_PREC(result, i), 0, 1, 0));
   }
   CHANGED_BAG(result);
-  STATE(currentRegion) = saved_region;
+  TLS(currentRegion) = saved_region;
   return NewAtomicRecordFrom(result);
 }
 
@@ -1605,13 +1605,13 @@ void UnbAList(Obj list, Int pos)
 }
 
 void InitAObjectsTLS() {
-  STATE(tlRecords) = (Obj) 0;
+  TLS(tlRecords) = (Obj) 0;
 }
 
 void DestroyAObjectsTLS() {
   Obj records;
   UInt i, len;
-  records = STATE(tlRecords);
+  records = TLS(tlRecords);
   if (records) {
     len = LEN_PLIST(records);
     for (i=1; i<=len; i++)
@@ -1701,7 +1701,7 @@ Obj FuncMakeStrictWriteOnceAtomic(Obj self, Obj obj) {
 
 
 void FuncError(char *message) {
-  ErrorQuit("%s: %s", (Int)(STATE(CurrFuncName)), (Int)message);
+  ErrorQuit("%s: %s", (Int)(TLS(CurrFuncName)), (Int)message);
 }
 
 Obj BindOncePosObj(Obj obj, Obj index, Obj *new, int eval) {
@@ -1821,14 +1821,14 @@ Obj BindOnce(Obj obj, Obj index, Obj *new, int eval) {
 
 Obj FuncBindOnce(Obj self, Obj obj, Obj index, Obj new) {
   Obj result;
-  STATE(CurrFuncName) = "BindOnce";
+  TLS(CurrFuncName) = "BindOnce";
   result = BindOnce(obj, index, &new, 0);
   return result ? result : new;
 }
 
 Obj FuncStrictBindOnce(Obj self, Obj obj, Obj index, Obj new) {
   Obj result;
-  STATE(CurrFuncName) = "StrictBindOnce";
+  TLS(CurrFuncName) = "StrictBindOnce";
   result = BindOnce(obj, index, &new, 0);
   if (result)
     ErrorQuit("StrictBindOnce: Element already initialized", 0L, 0L);
@@ -1837,21 +1837,21 @@ Obj FuncStrictBindOnce(Obj self, Obj obj, Obj index, Obj new) {
 
 Obj FuncTestBindOnce(Obj self, Obj obj, Obj index, Obj new) {
   Obj result;
-  STATE(CurrFuncName) = "TestBindOnce";
+  TLS(CurrFuncName) = "TestBindOnce";
   result = BindOnce(obj, index, &new, 0);
   return result ? False : True;
 }
 
 Obj FuncBindOnceExpr(Obj self, Obj obj, Obj index, Obj new) {
   Obj result;
-  STATE(CurrFuncName) = "BindOnceExpr";
+  TLS(CurrFuncName) = "BindOnceExpr";
   result = BindOnce(obj, index, &new, 1);
   return result ? result : new;
 }
 
 Obj FuncTestBindOnceExpr(Obj self, Obj obj, Obj index, Obj new) {
   Obj result;
-  STATE(CurrFuncName) = "TestBindOnceExpr";
+  TLS(CurrFuncName) = "TestBindOnceExpr";
   result = BindOnce(obj, index, &new, 1);
   return result ? False : True;
 }

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -1604,19 +1604,21 @@ void UnbAList(Obj list, Int pos)
   HashUnlockShared(list);
 }
 
-void InitAObjectsTLS() {
-  TLS(tlRecords) = (Obj) 0;
+void InitAObjectsState()
+{
+    TLS(tlRecords) = (Obj)0;
 }
 
-void DestroyAObjectsTLS() {
-  Obj records;
-  UInt i, len;
-  records = TLS(tlRecords);
-  if (records) {
-    len = LEN_PLIST(records);
-    for (i=1; i<=len; i++)
-      UpdateThreadRecord(ELM_PLIST(records, i), (Obj) 0);
-  }
+void DestroyAObjectsState()
+{
+    Obj  records;
+    UInt i, len;
+    records = TLS(tlRecords);
+    if (records) {
+        len = LEN_PLIST(records);
+        for (i = 1; i <= len; i++)
+            UpdateThreadRecord(ELM_PLIST(records, i), (Obj)0);
+    }
 }
 
 #endif /* WARD_ENABLED */

--- a/src/hpc/aobjects.h
+++ b/src/hpc/aobjects.h
@@ -28,6 +28,10 @@ Obj ElmAList(Obj list, Int pos);
 Obj Elm0AList(Obj list, Int pos);
 Obj LengthAList(Obj list);
 
+void InitAObjectsState();
+void DestroyAObjectsState();
+
+
 /*****************************************************************************
 **
 *F  CompareAndSwapObj(<addr>, <old>, <new_>)

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -200,7 +200,7 @@ static void SetupTLS()
 #endif
   InitializeTLS();
   MainThreadTLS = realTLS;
-  STATE(threadID) = 0;
+  TLS(threadID) = 0;
 }
 
 Obj NewThreadObject(UInt id) {
@@ -213,7 +213,7 @@ Obj NewThreadObject(UInt id) {
 
 void InitMainThread()
 {
-  STATE(threadObject) = NewThreadObject(0);
+  TLS(threadObject) = NewThreadObject(0);
 }
 
 static void RunThreadedMain2(
@@ -287,14 +287,14 @@ static void RunThreadedMain2(
   pthread_rwlock_init(&master_lock, 0);
   pthread_mutex_init(&main_thread_mutex, 0);
   pthread_cond_init(&main_thread_cond, 0);
-  STATE(threadLock) = &main_thread_mutex;
-  STATE(threadSignal) = &main_thread_cond;
-  thread_data[0].lock = STATE(threadLock);
-  thread_data[0].cond = STATE(threadSignal);
+  TLS(threadLock) = &main_thread_mutex;
+  TLS(threadSignal) = &main_thread_cond;
+  thread_data[0].lock = TLS(threadLock);
+  thread_data[0].cond = TLS(threadSignal);
   thread_data[0].state = TSTATE_RUNNING;
   thread_data[0].tls = realTLS;
   InitSignals();
-  if (sySetjmp(STATE(threadExit)))
+  if (sySetjmp(TLS(threadExit)))
     exit(0);
   /* Traversal functionality may be needed during the initialization
    * of some modules, so we set it up now. */
@@ -305,11 +305,11 @@ static void RunThreadedMain2(
 void CreateMainRegion()
 {
   int i;
-  STATE(currentRegion) = NewRegion();
-  STATE(threadRegion) = STATE(currentRegion);
-  ((Region *)STATE(currentRegion))->fixed_owner = 1;
-  RegionWriteLock(STATE(currentRegion));
-  ((Region *)STATE(currentRegion))->name = MakeImmString("thread region #0");
+  TLS(currentRegion) = NewRegion();
+  TLS(threadRegion) = TLS(currentRegion);
+  ((Region *)TLS(currentRegion))->fixed_owner = 1;
+  RegionWriteLock(TLS(currentRegion));
+  ((Region *)TLS(currentRegion))->name = MakeImmString("thread region #0");
   PublicRegionName = MakeImmString("public region");
   LimboRegion = NewRegion();
   LimboRegion->fixed_owner = 1;
@@ -332,31 +332,31 @@ void *DispatchThread(void *arg)
   ThreadData *this_thread = arg;
   Region *region;
   InitializeTLS();
-  STATE(threadID) = this_thread - thread_data;
+  TLS(threadID) = this_thread - thread_data;
 #ifndef DISABLE_GC
   AddGCRoots();
 #endif
   InitTLS();
-  STATE(currentRegion) = region = NewRegion();
-  STATE(threadRegion) = STATE(currentRegion);
-  STATE(threadLock) = this_thread->lock;
-  STATE(threadSignal) = this_thread->cond;
+  TLS(currentRegion) = region = NewRegion();
+  TLS(threadRegion) = TLS(currentRegion);
+  TLS(threadLock) = this_thread->lock;
+  TLS(threadSignal) = this_thread->cond;
   region->fixed_owner = 1;
   region->name = this_thread->region_name;
   RegionWriteLock(region);
   if (!this_thread->region_name) {
     char buf[8];
-    sprintf(buf, "%d", STATE(threadID));
+    sprintf(buf, "%d", TLS(threadID));
     this_thread->region_name = MakeImmString2("thread #", buf);
   }
   SetRegionName(region, this_thread->region_name);
-  STATE(threadObject) = this_thread->thread_object;
+  TLS(threadObject) = this_thread->thread_object;
   pthread_mutex_lock(this_thread->lock);
-  *(ThreadLocalStorage **)(ADDR_OBJ(STATE(threadObject))) = realTLS;
+  *(ThreadLocalStorage **)(ADDR_OBJ(TLS(threadObject))) = realTLS;
   pthread_cond_broadcast(this_thread->cond);
   pthread_mutex_unlock(this_thread->lock);
   this_thread->start(this_thread->arg);
-  *(UInt *)(ADDR_OBJ(STATE(threadObject))+2) |= THREAD_TERMINATED;
+  *(UInt *)(ADDR_OBJ(TLS(threadObject))+2) |= THREAD_TERMINATED;
   region->fixed_owner = 0;
   RegionWriteUnlock(region);
   DestroyTLS();
@@ -504,30 +504,30 @@ static UInt LockID(void *object) {
 }
 
 void HashLock(void *object) {
-  if (STATE(CurrentHashLock))
+  if (TLS(CurrentHashLock))
     ErrorQuit("Nested hash locks", 0L, 0L);
-  STATE(CurrentHashLock) = object;
+  TLS(CurrentHashLock) = object;
   pthread_rwlock_wrlock(&ObjLock[LockID(object)]);
 }
 
 void HashLockShared(void *object) {
-  if (STATE(CurrentHashLock))
+  if (TLS(CurrentHashLock))
     ErrorQuit("Nested hash locks", 0L, 0L);
-  STATE(CurrentHashLock) = object;
+  TLS(CurrentHashLock) = object;
   pthread_rwlock_rdlock(&ObjLock[LockID(object)]);
 }
 
 void HashUnlock(void *object) {
-  if (STATE(CurrentHashLock) != object)
+  if (TLS(CurrentHashLock) != object)
     ErrorQuit("Improperly matched hash lock/unlock calls", 0L, 0L);
-  STATE(CurrentHashLock) = 0;
+  TLS(CurrentHashLock) = 0;
   pthread_rwlock_unlock(&ObjLock[LockID(object)]);
 }
 
 void HashUnlockShared(void *object) {
-  if (STATE(CurrentHashLock) != object)
+  if (TLS(CurrentHashLock) != object)
     ErrorQuit("Improperly matched hash lock/unlock calls", 0L, 0L);
-  STATE(CurrentHashLock) = 0;
+  TLS(CurrentHashLock) = 0;
   pthread_rwlock_unlock(&ObjLock[LockID(object)]);
 }
 
@@ -536,19 +536,19 @@ void RegionWriteLock(Region *region)
   int result = 0;
   assert(region->owner != realTLS);
 
-  if (region->count_active || STATE(CountActive)) {
+  if (region->count_active || TLS(CountActive)) {
     result = !pthread_rwlock_trywrlock(region->lock);
 
     if(result) {
       if(region->count_active)
 	region->locks_acquired++;
-      if(STATE(CountActive))
-	STATE(LocksAcquired)++;
+      if(TLS(CountActive))
+	TLS(LocksAcquired)++;
     } else {
       if(region->count_active)
 	region->locks_contended++;
-      if(STATE(CountActive))
-	STATE(LocksContended)++;
+      if(TLS(CountActive))
+	TLS(LocksContended)++;
       pthread_rwlock_wrlock(region->lock);
     }
   } else {
@@ -567,14 +567,14 @@ int RegionTryWriteLock(Region *region)
   if (result) {
     if(region->count_active)
       region->locks_acquired++;
-    if(STATE(CountActive))
-      STATE(LocksAcquired)++;
+    if(TLS(CountActive))
+      TLS(LocksAcquired)++;
     region->owner = realTLS;
   } else {
     if(region->count_active)
       region->locks_contended++;
-    if(STATE(CountActive))
-      STATE(LocksContended)++;
+    if(TLS(CountActive))
+      TLS(LocksContended)++;
   }
   return result;
 }
@@ -590,63 +590,63 @@ void RegionReadLock(Region *region)
 {
   int result = 0;
   assert(region->owner != realTLS);
-  assert(region->readers[STATE(threadID)] == 0);
+  assert(region->readers[TLS(threadID)] == 0);
 
-  if(region->count_active || STATE(CountActive)) {
+  if(region->count_active || TLS(CountActive)) {
     result = !pthread_rwlock_rdlock(region->lock);
 
     if(result) {
       if(region->count_active)
 	ATOMIC_INC(&region->locks_acquired);
-      if(STATE(CountActive))
-	STATE(LocksAcquired)++;
+      if(TLS(CountActive))
+	TLS(LocksAcquired)++;
     } else {
       if(region->count_active)
 	ATOMIC_INC(&region->locks_contended);
-      if(STATE(CountActive))
-	STATE(LocksAcquired)++;
+      if(TLS(CountActive))
+	TLS(LocksAcquired)++;
       pthread_rwlock_rdlock(region->lock);
     }
   } else {
       pthread_rwlock_rdlock(region->lock);
   }
-  region->readers[STATE(threadID)] = 1;
+  region->readers[TLS(threadID)] = 1;
 }
 
 int RegionTryReadLock(Region *region)
 {
   int result = !pthread_rwlock_rdlock(region->lock);
   assert(region->owner != realTLS);
-  assert(region->readers[STATE(threadID)] == 0);
+  assert(region->readers[TLS(threadID)] == 0);
 
   if (result) {
     if(region->count_active)
       ATOMIC_INC(&region->locks_acquired);
-    if(STATE(CountActive))
-      STATE(LocksAcquired)++;
-    region->readers[STATE(threadID)] = 1;
+    if(TLS(CountActive))
+      TLS(LocksAcquired)++;
+    region->readers[TLS(threadID)] = 1;
   } else {
     if(region->count_active)
       ATOMIC_INC(&region->locks_contended);
-    if(STATE(CountActive))
-      STATE(LocksContended)++;
+    if(TLS(CountActive))
+      TLS(LocksContended)++;
   }
   return result;
 }
 
 void RegionReadUnlock(Region *region)
 {
-  assert(region->readers[STATE(threadID)]);
-  region->readers[STATE(threadID)] = 0;
+  assert(region->readers[TLS(threadID)]);
+  region->readers[TLS(threadID)] = 0;
   pthread_rwlock_unlock(region->lock);
 }
 
 void RegionUnlock(Region *region)
 {
-  assert(region->owner == realTLS || region->readers[STATE(threadID)]);
+  assert(region->owner == realTLS || region->readers[TLS(threadID)]);
   if (region->owner == realTLS)
     region->owner = NULL;
-  region->readers[STATE(threadID)] = 0;
+  region->readers[TLS(threadID)] = 0;
   pthread_rwlock_unlock(region->lock);
 }
 
@@ -656,7 +656,7 @@ int IsLocked(Region *region)
     return 0; /* public region */
   if (region->owner == realTLS)
     return 1;
-  if (region->readers[STATE(threadID)])
+  if (region->readers[TLS(threadID)])
     return 2;
   return 0;
 }
@@ -751,34 +751,34 @@ static int LessThanLockRequest(const void *a, const void *b)
 }
 
 void PushRegionLock(Region *region) {
-  if (!STATE(lockStack)) {
-    STATE(lockStack) = NewList(16);
-    STATE(lockStackPointer) = 0;
-  } else if (LEN_PLIST(STATE(lockStack)) == STATE(lockStackPointer)) {
-    int newlen = STATE(lockStackPointer) * 3 / 2;
-    GROW_PLIST(STATE(lockStack), newlen);
+  if (!TLS(lockStack)) {
+    TLS(lockStack) = NewList(16);
+    TLS(lockStackPointer) = 0;
+  } else if (LEN_PLIST(TLS(lockStack)) == TLS(lockStackPointer)) {
+    int newlen = TLS(lockStackPointer) * 3 / 2;
+    GROW_PLIST(TLS(lockStack), newlen);
   }
-  STATE(lockStackPointer)++;
-  SET_ELM_PLIST(STATE(lockStack), STATE(lockStackPointer),
+  TLS(lockStackPointer)++;
+  SET_ELM_PLIST(TLS(lockStack), TLS(lockStackPointer),
     region ? region->obj : (Obj) 0);
 }
 
 void PopRegionLocks(int newSP) {
-  while (newSP < STATE(lockStackPointer))
+  while (newSP < TLS(lockStackPointer))
   {
-    int p = STATE(lockStackPointer)--;
-    Obj region_obj = ELM_PLIST(STATE(lockStack), p);
+    int p = TLS(lockStackPointer)--;
+    Obj region_obj = ELM_PLIST(TLS(lockStack), p);
     if (!region_obj) continue;
     RegionUnlock(*(Region **)(ADDR_OBJ(region_obj)));
-    SET_ELM_PLIST(STATE(lockStack), p, (Obj) 0);
+    SET_ELM_PLIST(TLS(lockStack), p, (Obj) 0);
   }
 }
 
 void PopRegionAutoLocks(int newSP) {
-  while (newSP < STATE(lockStackPointer))
+  while (newSP < TLS(lockStackPointer))
   {
-    int p = STATE(lockStackPointer);
-    Obj region_obj = ELM_PLIST(STATE(lockStack), p);
+    int p = TLS(lockStackPointer);
+    Obj region_obj = ELM_PLIST(TLS(lockStack), p);
     Region *region;
     if (!region_obj)
       return;
@@ -786,13 +786,13 @@ void PopRegionAutoLocks(int newSP) {
     if (!region->autolock)
       return;
     RegionUnlock(region);
-    SET_ELM_PLIST(STATE(lockStack), p, (Obj) 0);
-    STATE(lockStackPointer)--;
+    SET_ELM_PLIST(TLS(lockStack), p, (Obj) 0);
+    TLS(lockStackPointer)--;
   }
 }
 
 int RegionLockSP() {
-  return STATE(lockStackPointer);
+  return TLS(lockStackPointer);
 }
 
 int GetThreadState(int threadID) {
@@ -807,7 +807,7 @@ int UpdateThreadState(int threadID, int oldState, int newState) {
 static void SetInterrupt(int threadID) {
   ThreadLocalStorage *tls = thread_data[threadID].tls;
   MEMBAR_FULL();
-  tls->CurrExecStatFuncs = IntrExecStatFuncs;
+  tls->state.CurrExecStatFuncs = IntrExecStatFuncs;
 }
 
 static int LockAndUpdateThreadState(int threadID, int oldState, int newState) {
@@ -830,7 +830,7 @@ void PauseThread(int threadID) {
     switch (state & TSTATE_MASK) {
     case TSTATE_RUNNING:
       if (UpdateThreadState(threadID,
-          TSTATE_RUNNING, TSTATE_PAUSED|(STATE(threadID) << TSTATE_SHIFT))) {
+          TSTATE_RUNNING, TSTATE_PAUSED|(TLS(threadID) << TSTATE_SHIFT))) {
 	SetInterrupt(threadID);
         return;
       }
@@ -838,7 +838,7 @@ void PauseThread(int threadID) {
     case TSTATE_BLOCKED:
     case TSTATE_SYSCALL:
       if (LockAndUpdateThreadState(threadID,
-          state, TSTATE_PAUSED|(STATE(threadID) << TSTATE_SHIFT)))
+          state, TSTATE_PAUSED|(TLS(threadID) << TSTATE_SHIFT)))
 	return;
       break;
     case TSTATE_PAUSED:
@@ -851,37 +851,37 @@ void PauseThread(int threadID) {
 }
 
 static void TerminateCurrentThread(int locked) {
-  ThreadData *thread = thread_data + STATE(threadID);
+  ThreadData *thread = thread_data + TLS(threadID);
   if (locked)
     pthread_mutex_unlock(thread->lock);
   PopRegionLocks(0);
-  if (STATE(CurrentHashLock))
-    HashUnlock(STATE(CurrentHashLock));
-  syLongjmp(STATE(threadExit), 1);
+  if (TLS(CurrentHashLock))
+    HashUnlock(TLS(CurrentHashLock));
+  syLongjmp(TLS(threadExit), 1);
 }
 
 static void PauseCurrentThread(int locked) {
-  ThreadData *thread = thread_data + STATE(threadID);
+  ThreadData *thread = thread_data + TLS(threadID);
   if (!locked)
     pthread_mutex_lock(thread->lock);
   for (;;) {
-    int state = GetThreadState(STATE(threadID));
+    int state = GetThreadState(TLS(threadID));
     if ((state & TSTATE_MASK) == TSTATE_KILLED)
       TerminateCurrentThread(1);
     if ((state & TSTATE_MASK) != TSTATE_PAUSED)
       break;
-    ((Region *)(STATE(currentRegion)))->alt_owner =
+    ((Region *)(TLS(currentRegion)))->alt_owner =
       thread_data[state >> TSTATE_SHIFT].tls;
     pthread_cond_wait(thread->cond, thread->lock);
     // TODO: This really should go in ResumeThread()
-    ((Region *)(STATE(currentRegion)))->alt_owner = NULL;
+    ((Region *)(TLS(currentRegion)))->alt_owner = NULL;
   }
   if (!locked)
     pthread_mutex_unlock(thread->lock);
 }
 
 static void InterruptCurrentThread(int locked, Stat stat) {
-  ThreadData *thread = thread_data + STATE(threadID);
+  ThreadData *thread = thread_data + TLS(threadID);
   int state;
   Obj FuncCALL_WITH_CATCH(Obj self, Obj func, Obj args);
   Obj handler = (Obj) 0;
@@ -891,14 +891,14 @@ static void InterruptCurrentThread(int locked, Stat stat) {
     pthread_mutex_lock(thread->lock);
   STATE(CurrExecStatFuncs) = ExecStatFuncs;
   SET_BRK_CURR_STAT(stat);
-  state = GetThreadState(STATE(threadID));
+  state = GetThreadState(TLS(threadID));
   if ((state & TSTATE_MASK) == TSTATE_INTERRUPTED)
-    UpdateThreadState(STATE(threadID), state, TSTATE_RUNNING);
+    UpdateThreadState(TLS(threadID), state, TSTATE_RUNNING);
   if (state >> TSTATE_SHIFT) {
     Int n = state >> TSTATE_SHIFT;
-    if (STATE(interruptHandlers)) {
-      if (n >= 1 && n <= LEN_PLIST(STATE(interruptHandlers)))
-        handler = ELM_PLIST(STATE(interruptHandlers), n);
+    if (TLS(interruptHandlers)) {
+      if (n >= 1 && n <= LEN_PLIST(TLS(interruptHandlers)))
+        handler = ELM_PLIST(TLS(interruptHandlers), n);
     }
   }
   if (handler)
@@ -910,15 +910,15 @@ static void InterruptCurrentThread(int locked, Stat stat) {
 }
 
 void SetInterruptHandler(int handler, Obj func) {
-  if (!STATE(interruptHandlers)) {
-    STATE(interruptHandlers) = NEW_PLIST(T_PLIST, MAX_INTERRUPT);
-    SET_LEN_PLIST(STATE(interruptHandlers), MAX_INTERRUPT);
+  if (!TLS(interruptHandlers)) {
+    TLS(interruptHandlers) = NEW_PLIST(T_PLIST, MAX_INTERRUPT);
+    SET_LEN_PLIST(TLS(interruptHandlers), MAX_INTERRUPT);
   }
-  SET_ELM_PLIST(STATE(interruptHandlers), handler, func);
+  SET_ELM_PLIST(TLS(interruptHandlers), handler, func);
 }
 
 void HandleInterrupts(int locked, Stat stat) {
-   switch (GetThreadState(STATE(threadID)) & TSTATE_MASK) {
+   switch (GetThreadState(TLS(threadID)) & TSTATE_MASK) {
      case TSTATE_PAUSED:
        PauseCurrentThread(locked);
        break;
@@ -1059,11 +1059,11 @@ extern UInt DeadlockCheck;
 
 static Int CurrentRegionPrecedence() {
   Int sp;
-  if (!DeadlockCheck || !STATE(lockStack))
+  if (!DeadlockCheck || !TLS(lockStack))
     return -1;
-  sp = STATE(lockStackPointer);
+  sp = TLS(lockStackPointer);
   while (sp > 0) {
-    Obj region_obj = ELM_PLIST(STATE(lockStack), sp);
+    Obj region_obj = ELM_PLIST(TLS(lockStack), sp);
     if (region_obj) {
       Int prec = ((Region *)(*ADDR_OBJ(region_obj)))->prec;
       if (prec >= 0)
@@ -1077,7 +1077,7 @@ static Int CurrentRegionPrecedence() {
 int LockObject(Obj obj, int mode) {
   Region *region = GetRegionOf(obj);
   int locked;
-  int result = STATE(lockStackPointer);
+  int result = TLS(lockStackPointer);
   if (!region)
     return result;
   locked = IsLocked(region);
@@ -1123,7 +1123,7 @@ int LockObjects(int count, Obj *objects, int *mode)
   count = p;
   if (p > 1)
     MergeSort(order, count, sizeof(LockRequest), LessThanLockRequest);
-  result = STATE(lockStackPointer);
+  result = TLS(lockStackPointer);
   curr_prec = CurrentRegionPrecedence();
   for (i=0; i<count; i++)
   {
@@ -1183,7 +1183,7 @@ int TryLockObjects(int count, Obj *objects, int *mode)
     order[i].mode = mode[i];
   }
   MergeSort(order, count, sizeof(LockRequest), LessThanLockRequest);
-  result = STATE(lockStackPointer);
+  result = TLS(lockStackPointer);
   for (i=0; i<count; i++)
   {
     Region *region = order[i].region;
@@ -1229,7 +1229,7 @@ int TryLockObjects(int count, Obj *objects, int *mode)
 
 Region *CurrentRegion()
 {
-  return STATE(currentRegion);
+  return TLS(currentRegion);
 }
 
 extern GVarDescriptor LastInaccessibleGVar;
@@ -1250,7 +1250,7 @@ void WriteGuardError(Obj o, const char *file, unsigned line,
   char * buffer =
     alloca(strlen(file) + strlen(func) + strlen(expr) + 200);
   ImpliedReadGuard(o);
-  if (STATE(DisableGuards))
+  if (TLS(DisableGuards))
     return;
   SetGVar(&LastInaccessibleGVar, o);
   PrintGuardError(buffer, "write", o, file, line, func, expr);
@@ -1267,7 +1267,7 @@ void ReadGuardError(Obj o, const char *file, unsigned line,
     if (AutoLockObj(o))
       return;
   }
-  if (STATE(DisableGuards))
+  if (TLS(DisableGuards))
     return;
   SetGVar(&LastInaccessibleGVar, o);
   PrintGuardError(buffer, "read", o, file, line, func, expr);
@@ -1278,7 +1278,7 @@ void ReadGuardError(Obj o, const char *file, unsigned line,
 void WriteGuardError(Obj o)
 {
   ImpliedReadGuard(o);
-  if (STATE(DisableGuards))
+  if (TLS(DisableGuards))
     return;
   SetGVar(&LastInaccessibleGVar, o);
   ErrorMayQuit("Attempt to write object %i of type %s without having write access", (Int)o, (Int)TNAM_OBJ(o));
@@ -1291,7 +1291,7 @@ void ReadGuardError(Obj o)
     if (AutoLockObj(o))
       return;
   }
-  if (STATE(DisableGuards))
+  if (TLS(DisableGuards))
     return;
   SetGVar(&LastInaccessibleGVar, o);
   ErrorMayQuit("Attempt to read object %i of type %s without having read access", (Int)o, (Int)TNAM_OBJ(o));

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -1518,11 +1518,11 @@ static Int InitLibrary (
     return 0;
 }
 
-void InitThreadAPITLS()
+void InitThreadAPIState()
 {
 }
 
-void DestroyThreadAPITLS()
+void DestroyThreadAPIState()
 {
 }
 

--- a/src/hpc/threadapi.h
+++ b/src/hpc/threadapi.h
@@ -31,6 +31,8 @@ void UnlockMonitors(UInt count, Monitor **monitors);
 
 void InitSignals();
 
+void InitThreadAPIState();
+void DestroyThreadAPIState();
 
 /****************************************************************************
 **

--- a/src/hpc/tls.c
+++ b/src/hpc/tls.c
@@ -6,6 +6,8 @@
 #include <src/code.h>
 #include <src/hpc/tls.h>
 #include <src/hpc/thread.h>
+#include <src/hpc/threadapi.h>
+#include <src/hpc/aobjects.h>
 
 #include <string.h>
 
@@ -79,39 +81,18 @@ Int AllocateExtraTLSSlot() {
 
 void InitTLS()
 {
-  void InitScannerTLS();
-  void InitStatTLS();
-  void InitExprTLS();
-  void InitCoderTLS();
-  void InitThreadAPITLS();
-  void InitOpersTLS();
-  void InitAObjectsTLS();
-  InitScannerTLS();
-  InitStatTLS();
-  InitExprTLS();
-  InitCoderTLS();
-  InitThreadAPITLS();
-  InitOpersTLS();
-  InitAObjectsTLS();
-  RunTLSConstructors();
-  TLS(CountActive) = 1;
+    InitGAPState(&TLS(state));
+    InitThreadAPIState();
+    InitAObjectsState();
+    RunTLSConstructors();
+
+    TLS(CountActive) = 1;
 }
 
 void DestroyTLS()
 {
-  void DestroyScannerTLS();
-  void DestroyStatTLS();
-  void DestroyExprTLS();
-  void DestroyCoderTLS();
-  void DestroyThreadAPITLS();
-  void DestroyOpersTLS();
-  void DestroyAObjectsTLS();
-  DestroyScannerTLS();
-  DestroyStatTLS();
-  DestroyExprTLS();
-  DestroyCoderTLS();
-  DestroyThreadAPITLS();
-  DestroyOpersTLS();
-  DestroyAObjectsTLS();
-  RunTLSDestructors();
+    DestroyGAPState(&TLS(state));
+    DestroyThreadAPIState();
+    DestroyAObjectsState();
+    RunTLSDestructors();
 }

--- a/src/hpc/tls.c
+++ b/src/hpc/tls.c
@@ -94,7 +94,7 @@ void InitTLS()
   InitOpersTLS();
   InitAObjectsTLS();
   RunTLSConstructors();
-  STATE(CountActive) = 1;
+  TLS(CountActive) = 1;
 }
 
 void DestroyTLS()

--- a/src/hpc/tls.h
+++ b/src/hpc/tls.h
@@ -18,7 +18,7 @@ static inline Bag ImpliedWriteGuard(Bag bag)
 #else
 
 #include <stdint.h>
-
+#include <src/gapstate.h>
 #include <src/code.h>
 #include <src/hpc/tlsconfig.h>
 #include <src/scanner.h>
@@ -47,174 +47,25 @@ typedef struct ThreadLocalStorage
   int DisableGuards;
 
   /* From intrprtr.c */
-  Obj IntrResult;
-  UInt IntrIgnoring;
-  UInt IntrReturning;
-  UInt IntrCoding;
-  Obj IntrState;
-  Obj StackObj;
-  Int CountObj;
-#if defined(HPCGAP)
   UInt PeriodicCheckCount;
-#endif
-
-  /* From gvar.c */
-  Obj CurrNamespace;
 
   /* From vars.c */
-  Bag BottomLVars;
-  Bag CurrLVars;
-  Obj *PtrLVars;
-#if defined(HPCGAP)
   Bag LVarsPool[16];
-#endif
 
   /* From read.c */
-  syJmp_buf ReadJmpError;
   syJmp_buf threadExit;
-  Obj StackNams;
-  UInt CountNams;
-  UInt ReadTop;
-  UInt ReadTilde;
-  UInt CurrLHSGVar;
-  UInt CurrentGlobalForLoopVariables[100];
-  UInt CurrentGlobalForLoopDepth;
-  Obj ExprGVars;
-  Obj ReadEvalResult;
 
   /* From scanner.c */
-  Char Value[MAX_VALUE_LEN];
-  UInt ValueLen;
-  UInt NrError;
-  UInt NrErrLine;
-  UInt            Symbol;
-  Char *          Prompt;
-  TypInputFile *  InputFiles[16];
-  TypOutputFile* OutputFiles[16];
-  int InputFilesSP;
-  int OutputFilesSP;
-  TypInputFile *  Input;
-  Char *          In;
-  TypOutputFile * Output;
-  TypOutputFile * InputLog;
-  TypOutputFile * OutputLog;
-  TypOutputFile * IgnoreStdoutErrout;
-#if defined(HPCGAP)
   Obj		  DefaultOutput;
   Obj		  DefaultInput;
-#endif
-  TypOutputFile LogFile;
-  TypOutputFile LogStream;
-  TypOutputFile InputLogFile;
-  TypOutputFile InputLogStream;
-  TypOutputFile OutputLogFile;
-  TypOutputFile OutputLogStream;
-  Int HELPSubsOn;
-  Int NoSplitLine;
-  KOutputStream TheStream;
-  Char *TheBuffer;
-  UInt TheCount;
-  UInt TheLimit;
 
-  /* From exprs.c */
-  Obj (**CurrEvalExprFuncs)(Expr);
-
-  /* From stats.c */
-  Stat CurrStat;
-  Obj ReturnObjStat;
-  UInt (**CurrExecStatFuncs)(Stat);
-
-  /* From code.c */
-  Stat *PtrBody;
-  Stat OffsBody;
-  Stat *OffsBodyStack;
-  UInt OffsBodyCount;
-  UInt LoopNesting;
-  UInt *LoopStack;
-  UInt LoopStackCount;
-
-  Obj CodeResult;
-  Bag StackStat;
-  Int CountStat;
-  Bag StackExpr;
-  Int CountExpr;
-  Bag CodeLVars;
-
-  /* From funcs.h */
-  Int RecursionDepth;
-  Obj ExecState;
-
-  /* From opers.c */
-  Obj MethodCache;
-  Obj *MethodCacheItems;
-  UInt MethodCacheSize;
-  UInt CacheIndex;
-
-  /* From cyclotom.c */
-  Obj ResultCyc;
-  Obj  LastECyc;
-  UInt LastNCyc;
-
-  /* From permutat.c */
-  Obj TmpPerm;
-
-  /* From trans.c */
-  Obj TmpTrans;
-
-  /* From pperm.c */
-  Obj TmpPPerm;
-
-  /* From gap.c */
-  Obj ThrownObject;
-  UInt UserHasQuit;
-  UInt UserHasQUIT;
-  Obj ShellContext;
-  Obj BaseShellContext;
-  Int ErrorLLevel;
-  Obj ErrorLVars;
-  Obj ErrorLVars0;
-
-  /* From objects.c */
-  Obj PrintObjThis;
-  Int PrintObjIndex;
-  Int PrintObjDepth;
-  Int PrintObjFull;
-  Obj PrintObjThissObj;
-  Obj *PrintObjThiss;
-  Obj PrintObjIndicesObj;
-  Int *PrintObjIndices;
-
-#if defined(HPCGAP)
-  /* For serializer.c */
-  Obj SerializationObj;
-  UInt SerializationIndex;
-  void *SerializationDispatcher;
-  Obj SerializationRegistry;
-  Obj SerializationStack;
-#endif
-
-  /* For objscoll*, objccoll* */
-  Obj SC_NW_STACK;
-  Obj SC_LW_STACK;
-  Obj SC_PW_STACK;
-  Obj SC_EW_STACK;
-  Obj SC_GE_STACK;
-  Obj SC_CW_VECTOR;
-  Obj SC_CW2_VECTOR;
-  UInt SC_MAX_STACK_SIZE;
-
-#if defined(HPCGAP)
   /* Profiling */
   UInt CountActive;
   UInt LocksAcquired;
   UInt LocksContended;
-#endif
 
-  /* Allocation */
-#ifdef BOEHM_GC
-#define MAX_GC_PREFIX_DESC 4
-  void **FreeList[MAX_GC_PREFIX_DESC+2];
-#endif
+  GAPState state;
+
   /* Extra storage */
   void *Extra[TLS_NUM_EXTRA];
 } ThreadLocalStorage;
@@ -269,7 +120,8 @@ static ALWAYS_INLINE ThreadLocalStorage *GetTLS()
 
 #endif /* HAVE_NATIVE_TLS */
 
-#define STATE(x) realTLS->x
+#define TLS(x) realTLS->x
+#define STATE(x) TLS(state).x
 
 #define IS_BAG_REF(bag) (bag && !((Int)(bag)& 0x03))
 
@@ -322,7 +174,7 @@ static inline int CheckWriteAccess(Bag bag)
     return 1;
   region = REGION(bag);
   return !(region && region->owner != realTLS && region->alt_owner != realTLS)
-    || STATE(DisableGuards) >= 2;
+    || TLS(DisableGuards) >= 2;
 }
 
 static inline int CheckExclusiveWriteAccess(Bag bag)
@@ -334,7 +186,7 @@ static inline int CheckExclusiveWriteAccess(Bag bag)
   if (!region)
     return 0;
   return region->owner == realTLS || region->alt_owner == realTLS
-    || STATE(DisableGuards) >= 2;
+    || TLS(DisableGuards) >= 2;
 }
 
 #ifdef VERBOSE_GUARDS
@@ -349,7 +201,7 @@ static ALWAYS_INLINE Bag ReadGuard(Bag bag)
     return bag;
   region = REGION(bag);
   if (region && region->owner != realTLS &&
-      !region->readers[STATE(threadID)] && region->alt_owner != realTLS)
+      !region->readers[TLS(threadID)] && region->alt_owner != realTLS)
     ReadGuardError(bag
 #ifdef VERBOSE_GUARDS
     , file, line, func, expr
@@ -372,13 +224,13 @@ static ALWAYS_INLINE int CheckReadAccess(Bag bag)
     return 1;
   region = REGION(bag);
   return !(region && region->owner != realTLS &&
-    !region->readers[STATE(threadID)] && region->alt_owner != realTLS)
-    || STATE(DisableGuards) >= 2;
+    !region->readers[TLS(threadID)] && region->alt_owner != realTLS)
+    || TLS(DisableGuards) >= 2;
 }
 
 static inline int IsMainThread()
 {
-  return STATE(threadID) == 0;
+  return TLS(threadID) == 0;
 };
 
 void InitializeTLS();

--- a/src/hpc/traverse.c
+++ b/src/hpc/traverse.c
@@ -49,7 +49,7 @@ typedef struct TraversalState {
 } TraversalState;
 
 static inline TraversalState *currentTraversal() {
-  return STATE(traversalState);
+  return TLS(traversalState);
 }
 
 static Obj NewList(UInt size)
@@ -267,12 +267,12 @@ static void BeginTraversal(TraversalState *traversal)
   traversal->listCapacity = 10;
   traversal->listCurrent = 0;
   traversal->previousTraversal = currentTraversal();
-  STATE(traversalState) = traversal;
+  TLS(traversalState) = traversal;
 }
 
 static void EndTraversal()
 {
-  STATE(traversalState) = currentTraversal()->previousTraversal;
+  TLS(traversalState) = currentTraversal()->previousTraversal;
 }
 
 #if SIZEOF_VOID_P == 4

--- a/src/pperm.h
+++ b/src/pperm.h
@@ -1,5 +1,6 @@
 
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/system.h
+++ b/src/system.h
@@ -1071,17 +1071,6 @@ extern void InitSystem (
             Int                 argc,
             Char *              argv [] );
 
-
-#if !defined(HPCGAP)
-
-#include <src/gapstate.h>
-
-// FIXME: The TLS macro is for compatibility with the HPC-GAP branch, and helps
-// to keep the diffs between it and master branch small(er).
-#define STATE(x) (MainGAPState->x)
-
-#endif
-
 #endif // GAP_SYSTEM_H
 
 /****************************************************************************

--- a/src/trans.h
+++ b/src/trans.h
@@ -1,5 +1,6 @@
 
 #include <src/system.h>                 /* system dependent part */
+#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */


### PR DESCRIPTION
This PR moves the variables that are currently in both HPC-GAP's `ThreadLocalStorage` and GAP's `GAPState` into a single member `state` of `ThreadLocalStorage`. This reduces code duplication between GAP and HPC-GAP, and also the amount of `#if defined` variables in GAPState.

The commits in this PR include #1243, so that should be merged first. 