### PR TITLE
Retry "make bootstrap" on CI servers a few times

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -901,17 +901,18 @@ coverage:
 # Bootstrap rules
 ########################################################################
 
-PKG_BOOTSTRAP_URL="https://www.gap-system.org/pub/gap/gap4pkgs/"
-PKG_MINIMAL="bootstrap-pkg-minimal.tar.gz"
-PKG_FULL="bootstrap-pkg-full.tar.gz"
+PKG_BOOTSTRAP_URL = https://www.gap-system.org/pub/gap/gap4pkgs/
+PKG_MINIMAL = bootstrap-pkg-minimal.tar.gz
+PKG_FULL = bootstrap-pkg-full.tar.gz
+WGET = wget -N
 
 bootstrap-pkg-minimal:
 	@if test -e pkg; then \
         echo "The pkg directory already exists. Please move or remove it to proceed."; \
     else \
-        wget -N $(PKG_BOOTSTRAP_URL)$(PKG_MINIMAL) ; \
-        mkdir pkg ; \
-        cd pkg ; \
+        $(WGET) $(PKG_BOOTSTRAP_URL)$(PKG_MINIMAL) && \
+        mkdir pkg && \
+        cd pkg && \
         tar xzf ../$(PKG_MINIMAL) ; \
     fi;
 
@@ -919,9 +920,9 @@ bootstrap-pkg-full:
 	@if test -e pkg; then \
         echo "The pkg directory already exists. Please move or remove it to proceed" ; \
     else \
-        wget -N $(PKG_BOOTSTRAP_URL)$(PKG_FULL) ; \
-        mkdir pkg ; \
-        cd pkg ; \
+        $(WGET) $(PKG_BOOTSTRAP_URL)$(PKG_FULL) && \
+        mkdir pkg && \
+        cd pkg && \
         tar xzf ../$(PKG_FULL) ; \
     fi;
 

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -33,8 +33,9 @@ make V=1 -j4
 # check that GAP is at least apple to start
 echo 'Print("GAP started successfully\n");QUIT_GAP(0);' | ./gap -q -T
 
-# download packages
-make bootstrap-pkg-full
+# download packages; instruct wget to retry several times if the
+# connection is refused, to work around intermittent failures
+make bootstrap-pkg-full WGET="wget -N --no-check-certificate --tries=5 --waitretry=5 --retry-connrefused"
 
 # packages must be placed inside SRCDIR, as only that
 # is a GAP root, while BUILDDIR is not.


### PR DESCRIPTION
Travis builds sometimes fail on the `make bootstrap-pkg-full` step, due
to an "Connection refused" error from the server. This is likely caused
by the server being overloaded (a dozen or so CI builds start
simultaneously and if things align badly, will try to perform the
boostrap around the same time.

With this change, we instruct wget to retry the download up to 5 times,
with 5 seconds between each try.

As a side effect, user's can in general override the arguments we pass
to wget (and even switch things to use e.g. curl instead).