### PR TITLE
Stop clang-format reordering includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,3 +23,4 @@ MaxEmptyLinesToKeep: 2
 PointerBindsToType: Middle
 SpacesBeforeTrailingComments: 4
 UseTab: Never
+SortIncludes: false


### PR DESCRIPTION
This small change just changes our clang-format from reordering includes into alphabetical order, because GAP headers are extremely sensitive to ordering.