### PR TITLE
src/gapstate.h: in HPCGAP, include hpc/tls.h

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -184,7 +184,11 @@ typedef struct GAPState {
 #endif
 } GAPState;
 
-#if !defined(HPCGAP)
+#if defined(HPCGAP)
+
+#include <src/hpc/tls.h>
+
+#else
 
 extern GAPState * MainGAPState;
 #define STATE(x) (MainGAPState->x)


### PR DESCRIPTION
This way, code that needs to use STATE only has to include gapstate.h,
and does not need to worry about include hpc/tls.h for HPC-GAP.