### PR TITLE
Fix issue #1258

### DIFF
--- a/lib/fpmon.gi
+++ b/lib/fpmon.gi
@@ -404,7 +404,7 @@ function(M)
   FMtoFS := function(id, w)
     local wlist, i;
 
-    wlist := ShallowCopy(ExtRepOfObj(w));
+    wlist := ExtRepOfObj(w);
 
     if Length(wlist) = 0 then # it is the identity
       return id;
@@ -412,6 +412,7 @@ function(M)
 
     # have to increment the generators by one to shift past the identity
     # generator
+    wlist := ShallowCopy(wlist);
     for i in [1 .. 1 / 2 * (Length(wlist))] do
       wlist[2 * i - 1] := wlist[2 * i - 1] + 1;
     od;
@@ -430,6 +431,7 @@ function(M)
     fi;
     
     # have to decrease each entry by one because of the identity generator
+    wlist := ShallowCopy(wlist);
     for i in [1 .. 1 / 2 * (Length(wlist))] do
       wlist[2 * i - 1] := wlist[2 * i - 1] - 1;
     od;

--- a/tst/testinstall/fpmon.tst
+++ b/tst/testinstall/fpmon.tst
@@ -30,5 +30,25 @@ gap> rels := [ [ F.1^2, F.1 ], [ F.2^2, F.2 ] ];;
 gap> FactorFreeMonoidByRelations(F, rels);
 Error, first argument <F> should be a free monoid
 
+# Test isomorphisms from fp monoids to fp semigroups and vice versa
+gap> F := FreeMonoid(2);;
+gap> M := F / [[F.2 ^ 2, F.2]];;
+gap> iso := IsomorphismFpSemigroup(M);;
+gap> S := Range(iso);;
+gap> x := S.2 * S.3 * S.2;;
+gap> y := x ^ InverseGeneralMapping(iso);
+m1*m2*m1
+gap> y := x ^ InverseGeneralMapping(iso);
+m1*m2*m1
+gap> y in M;
+true
+gap> x := M.1 * M.2 * M.1;;
+gap> y := x ^ iso;
+m1*m2*m1
+gap> y := x ^ iso;
+m1*m2*m1
+gap> y in S;
+true
+
 #
 gap> STOP_TEST( "fpmon.tst", 1);


### PR DESCRIPTION
This is a fix for Issue #1258, based on the patch suggested by @fingolfin which takes a shallow copy of `wlist` in the `FMtoFS` and `FStoFM` functions in `IsomorphismFpSemigroup`, to avoid a bug related to mutability.

I've added tests which demonstrate the fix.