### PR TITLE
Enable compiler warnings, fixes warnings

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -144,6 +144,9 @@ GAP_CPPFLAGS += $(READLINE_CPPFLAGS)
 GAP_CPPFLAGS += $(BOEHM_GC_CPPFLAGS)
 GAP_CPPFLAGS += $(LIBATOMIC_OPS_CPPFLAGS)
 
+# Enable warnings
+GAP_CPPFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers
+
 # Finally add user provided flags
 GAP_CPPFLAGS += $(CPPFLAGS)
 

--- a/hpcgap/src/system.c
+++ b/hpcgap/src/system.c
@@ -1763,6 +1763,7 @@ static Int toggle( Char ** argv, void *Variable )
   return 0;
 }
 
+#ifdef HPCGAP
 static Int storePosInteger( Char **argv, void *Where )
 {
   UInt *where = (UInt *)Where;
@@ -1778,6 +1779,7 @@ static Int storePosInteger( Char **argv, void *Where )
   *where = n;
   return 1;
 }
+#endif
 
 static Int storeString( Char **argv, void *Where )
 {

--- a/src/gap.c
+++ b/src/gap.c
@@ -1157,7 +1157,7 @@ Obj FuncCALL_WITH_TIMEOUT( Obj self, Obj seconds, Obj microseconds, Obj func, Ob
   Obj result;
   volatile Int recursionDepth;
   volatile Stat currStat;
-  UInt newJumpBuf = 1;
+  volatile UInt newJumpBuf = 1;
   volatile UInt mayNeedToRestore = 0;
   volatile Int iseconds, imicroseconds;
   volatile Int curr_seconds= 0, curr_microseconds=0, curr_nanoseconds=0;

--- a/src/read.c
+++ b/src/read.c
@@ -245,10 +245,10 @@ static UInt WarnOnUnboundGlobalsRNam;
 
 void ReadReferenceModifiers( TypSymbolSet follow )
 {
-    char type = ' ';
-    UInt level = 0;
-    UInt narg = 0;
-    UInt rnam  = 0;
+    volatile char type = ' ';
+    volatile UInt level = 0;
+    volatile UInt narg = 0;
+    volatile UInt rnam  = 0;
     /* followed by one or more selectors                                   */
     while ( IS_IN( STATE(Symbol), S_LPAREN|S_LBRACK|S_LBRACE|S_DOT ) ) {
         /* <Var> '[' <Expr> ']'  list selector                             */

--- a/src/system.c
+++ b/src/system.c
@@ -1724,6 +1724,7 @@ static Int toggle( Char ** argv, void *Variable )
   return 0;
 }
 
+#ifdef HPCGAP
 static Int storePosInteger( Char **argv, void *Where )
 {
   UInt *where = (UInt *)Where;
@@ -1739,6 +1740,7 @@ static Int storePosInteger( Char **argv, void *Where )
   *where = n;
   return 1;
 }
+#endif
 
 static Int storeString( Char **argv, void *Where )
 {


### PR DESCRIPTION
I completely missed that we removed `-Wall` from the compiler flags with the new build system. This PR corrects that and enables additional warnings, and fixes a few warnings.