### PR TITLE
Remove command line options `-U` and `-i`

### DIFF
--- a/cnf/GAP-C-GEN
+++ b/cnf/GAP-C-GEN
@@ -27,8 +27,7 @@ fi
 
 # invoke GAP in compiler mode
 echo "#ifndef AVOID_PRECOMPILED" > "$C_FILE.tmp"
-"$GAPBIN" -U FAST_PLAIN_LISTS,FAST_INT_ARITH \
-          -C "*stdout*" \
+"$GAPBIN" -C "*stdout*" \
           "$GAP_FILE" \
           "Init_$STEM" \
           GAPROOT/lib/$STEM.g >> "$C_FILE.tmp"

--- a/cnf/gac.in
+++ b/cnf/gac.in
@@ -33,19 +33,6 @@
 ##
 ##  The option '-save-temps' tells 'gac' to not delete any intermediate files
 ##
-##  The option  '-ffast-int-arith' tells  'gac' to emit  code for  arithmetic
-##  operations, which works faster if both  operands are  small integers  and
-##  slower otherwise.
-##
-##  The option '-ffast-plain-lists' tells 'gac' to emit code for list access,
-##  which works faster if the list is a plain list and slower otherwise.
-##
-##  The option '-ffast-list-funcs' tells 'gac' to inline  the functions 'Add'
-##  and 'Length' the code, which makes it a bit faster.
-##
-##  The option '-fno-check-types' tells 'gac' to  emit  no  error checks  for
-##  list access, which makes it faster but may dump core if an error happens.
-#
 ##  The option '-p <option>' tells 'gac' to pass the option  <option> to  the
 ##  C compiler.
 ##
@@ -82,9 +69,6 @@ gap_compiler="${gap_bin}/gap"
 # is evaluated relative to this
 gap_binary="${gap_bin}"
 
-# options to pass to the GAP executable when it is invokes as compiler
-gap_options=""
-
 libtool="$SHELL $abs_top_builddir/libtool"
 CC="@CC@"
 
@@ -113,8 +97,8 @@ OBJECTS="@OBJECTS@"
 #F  gap_compile <output> <input> <module-name> <identifier>
 ##
 gap_compile () {
-    echo ${gap_compiler} ${gap_options} -C $1 $2 $3 $4
-    ${gap_compiler} ${gap_options} -C "$1" "$2" "$3" "$4"
+    echo ${gap_compiler} -C $1 $2 $3 $4
+    ${gap_compiler} -C "$1" "$2" "$3" "$4"
 }
 
 
@@ -297,37 +281,6 @@ while [ $# -gt 0 ]; do
     -r)                   comp_static_root_relative="yes";;
 
     -save-temps)          savetemps="true";;
-
-    -ffast-int-arith)     if [ "X${gap_options}" = "X" ]; then
-                              gap_options="-U FAST_INT_ARITH"
-                          else
-                              gap_options="${gap_options},FAST_INT_ARITH"
-                          fi;;
-
-    -ffast-plain-lists)   if [ "X${gap_options}" = "X" ]; then
-                              gap_options="-U FAST_PLAIN_LISTS"
-                          else
-                              gap_options="${gap_options},FAST_PLAIN_LISTS"
-                          fi;;
-
-    -ffast-list-funcs)   # echo "$0: option $1 is not currently allowed, ignoring it";;
-                          if [ "X${gap_options}" = "X" ]; then
-                              gap_options="-U FAST_LIST_FUNCS"
-                          else
-                              gap_options="${gap_options},FAST_LIST_FUNCS"
-                          fi;;
-
-    -fno-check-types)     if [ "X${gap_options}" = "X" ]; then
-                              gap_options="-U NO_CHECK_TYPES"
-                          else
-                              gap_options="${gap_options},NO_CHECK_TYPES"
-                          fi;;
-
-    -fno-check-list-elms) if [ "X${gap_options}" = "X" ]; then
-                              gap_options="-U NO_CHECK_LIST_ELMS"
-                          else
-                              gap_options="${gap_options},NO_CHECK_LIST_ELMS"
-                          fi;;
 
     -f*)                  echo "$0: no such option '$1'"
                           exit 1;;

--- a/doc/ref/run.xml
+++ b/doc/ref/run.xml
@@ -437,10 +437,9 @@ If a file cannot be opened &GAP; will print an error message and will abort.
 </List>
 <P/>
 <Index Subkey="command line, internal">options</Index>
-<Index Key="-C"><C>-C</C></Index><Index Key="-U"><C>-U</C></Index>
 <Index Key="-P"><C>-P</C></Index><Index Key="-W"><C>-W</C></Index>
 <Index Key="-z"><C>-z</C></Index><Index Key="-p"><C>-p</C></Index>
-Additional options, <C>-C</C>, <C>-U</C>, <C>-P</C>, <C>-W</C>, <C>-p</C>
+Additional options, <C>-C</C>, <C>-P</C>, <C>-W</C>, <C>-p</C>
 and <C>-z</C> are  used  
 internally by the <Package>gac</Package> script (see <Ref Label="Kernel modules"/>)
 and/or on specific operating systems.

--- a/doc/ref/run.xml
+++ b/doc/ref/run.xml
@@ -217,12 +217,6 @@ tells &GAP; to print a summary of all available options (<C>-h</C> is mnemonic
 for <Q>help</Q>). &GAP; exits after printing the summary, all other options
 are ignored.
 </Item>
-<Mark><Index Key="-i"><C>-i</C></Index>
-<C>-i </C><A>filename</A></Mark>
-<Item>
-changes  the  name  of  the  init  file  from  the  default  <F>init.g</F>  to
-<A>filename</A>. (Usually not needed.)
-</Item>
 <Mark><Index Key="-K"><C>-K</C></Index> 
 <C>-K </C><A>memory</A></Mark>
 <Item>

--- a/hpcgap/lib/system.g
+++ b/hpcgap/lib/system.g
@@ -96,7 +96,6 @@ BIND_GLOBAL( "GAPInfo", AtomicRecord(rec(
       rec( short:= "X", default := false, help := ["enable/disable CRC checking for compiled modules"] ),
       rec( short:= "T", default := false, help := ["disable/enable break loop"] ),
       rec( long := "quitonbreak", default := false, help := ["quit GAP with non-zero return value instead of entering break loop"]),
-      rec( short:= "i", default := "", arg := "<file>", help := [ "change the name of the init file"] ),
       ,
       rec( short:= "L", default := "", arg := "<file>", help := [ "restore a saved workspace"] ),
       rec( short:= "R", default := false, help := ["prevent restoring of workspace (ignoring -L)"] ),

--- a/hpcgap/lib/system.g
+++ b/hpcgap/lib/system.g
@@ -103,7 +103,6 @@ BIND_GLOBAL( "GAPInfo", AtomicRecord(rec(
       ,
       rec( short:= "p", default := false, help := ["enable/disable package output mode"] ),
       rec( short := "E", default :=false ),
-      rec( short := "U", default := "" ),     # -C -U undocumented options to the compiler
       rec( short := "s", default := "4g" ),
       rec( short := "z", default := "20" ),
       rec( long := "prof", default := "", arg := "<file>",

--- a/hpcgap/src/gap.c
+++ b/hpcgap/src/gap.c
@@ -508,8 +508,6 @@ int realmain( int argc, char * argv[], char * environ[] )
       }
       func = READ_AS_FUNC();
       crc  = SyGAPCRC(SyCompileInput);
-      if (strlen(SyCompileOptions) != 0)
-        SetCompileOpts(SyCompileOptions);
       type = CompileFunc(
                          SyCompileOutput,
                          func,

--- a/hpcgap/src/gap.c
+++ b/hpcgap/src/gap.c
@@ -3628,12 +3628,12 @@ void InitializeGap (
        this now actually runs the GAP session, we only get 
        past here when we're about to exit. 
                                            */
-    if ( SySystemInitFile[0] ) {
+    if ( SyLoadSystemInitFile ) {
       TRY_READ {
-        if ( READ_GAP_ROOT(SySystemInitFile) == 0 ) {
+        if ( READ_GAP_ROOT("lib/init.g") == 0 ) {
           /*             if ( ! SyQuiet ) { */
-                Pr( "gap: hmm, I cannot find '%s' maybe",
-                    (Int)SySystemInitFile, 0L );
+                Pr( "gap: hmm, I cannot find 'lib/init.g' maybe",
+                    0L, 0L );
                 Pr( " use option '-l <gaproot>'?\n If you ran the GAP"
                     " binary directly, try running the 'gap.sh' or 'gap.bat'"
                     " script instead.", 0L, 0L );

--- a/lib/system.g
+++ b/lib/system.g
@@ -95,7 +95,6 @@ BIND_GLOBAL( "GAPInfo", rec(
       rec( short:= "X", default := false, help := ["enable/disable CRC checking for compiled modules"] ),
       rec( short:= "T", default := false, help := ["disable/enable break loop"] ),
       rec( long := "quitonbreak", default := false, help := ["quit GAP with non-zero return value instead of entering break loop"]),
-      rec( short:= "i", default := "", arg := "<file>", help := [ "change the name of the init file"] ),
       ,
       rec( short:= "L", default := "", arg := "<file>", help := [ "restore a saved workspace"] ),
       rec( short:= "R", default := false, help := ["prevent restoring of workspace (ignoring -L)"] ),

--- a/lib/system.g
+++ b/lib/system.g
@@ -102,7 +102,6 @@ BIND_GLOBAL( "GAPInfo", rec(
       ,
       rec( short:= "p", default := false, help := ["enable/disable package output mode"] ),
       rec( short := "E", default :=false ),
-      rec( short := "U", default := "" ),     # -C -U undocumented options to the compiler
       rec( short := "s", default := "4g" ),
       rec( short := "z", default := "20" ),
       rec( long := "prof", default := "", arg := "<file>",

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -96,59 +96,6 @@ Int CompCheckTypes ;
 */
 Int CompCheckListElements;
 
-/****************************************************************************
-**
-*V  CompOptNames . .  names for all the compiler options passed by gac
-**
-*/
-
-struct CompOptStruc { const Char *extname;
-  Int *variable;
-  Int val;};
-
-struct CompOptStruc CompOptNames[] = {
-  { "FAST_INT_ARITH", &CompFastIntArith, 1 },
-  { "FAST_PLAIN_LISTS", &CompFastPlainLists, 1 },
-  { "FAST_LIST_FUNCS", &CompFastListFuncs, 1 },
-  { "NO_CHECK_TYPES", &CompCheckTypes, 0 },
-  { "NO_CHECK_LIST_ELMS", &CompCheckListElements, 0 }};
-
-#define N_CompOpts  (sizeof(CompOptNames)/sizeof(struct CompOptStruc))
-
-
-/****************************************************************************
-**
-*F  SetCompileOpts( <string> ) . . parse the compiler options from <string>
-**                                 and set the appropriate variables
-**                                 unrecognised options are ignored for now
-*/
-#include <ctype.h>
-
-void SetCompileOpts( Char *opts )
-{
-  Char *s = opts;
-  Int i;
-  while (*s)
-    {
-      while (IsSpace(*s))
-        s++;
-      for (i = 0; i < N_CompOpts; i++)
-        {
-          if (0 == strncmp(CompOptNames[i].extname,
-                             s,
-                             strlen(CompOptNames[i].extname)))
-            {
-              *(CompOptNames[i].variable) = CompOptNames[i].val;
-              break;
-            }
-        }
-      while (*s && *s != ',')
-        s++;
-      if (*s == ',')
-        s++;
-    }
-  return;
-}
 
 /****************************************************************************
 **

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -26,15 +26,6 @@ extern Int CompileFunc (
             Int                 magic1,
             Char *              magic2 );
 
-/****************************************************************************
-**
-*F  SetCompileOpts( <string> ) . . parse the compiler options from <string>
-**                                 and set the appropriate variables
-**                                 unrecognised options are ignored for now
-*/
-
-extern void SetCompileOpts( Char *opts );
-
 
 /****************************************************************************
 **

--- a/src/gap.c
+++ b/src/gap.c
@@ -3660,12 +3660,12 @@ void InitializeGap (
        this now actually runs the GAP session, we only get 
        past here when we're about to exit. 
                                            */
-    if ( SySystemInitFile[0] ) {
+    if ( SyLoadSystemInitFile ) {
       TRY_READ {
-        if ( READ_GAP_ROOT(SySystemInitFile) == 0 ) {
+        if ( READ_GAP_ROOT("lib/init.g") == 0 ) {
           /*             if ( ! SyQuiet ) { */
-                Pr( "gap: hmm, I cannot find '%s' maybe",
-                    (Int)SySystemInitFile, 0L );
+                Pr( "gap: hmm, I cannot find 'lib/init.g' maybe",
+                    0L, 0L );
                 Pr( " use option '-l <gaproot>'?\n If you ran the GAP"
                     " binary directly, try running the 'gap.sh' or 'gap.bat'"
                     " script instead.", 0L, 0L );

--- a/src/gap.c
+++ b/src/gap.c
@@ -509,8 +509,6 @@ int realmain( int argc, char * argv[], char * environ[] )
       }
       func = READ_AS_FUNC();
       crc  = SyGAPCRC(SyCompileInput);
-      if (strlen(SyCompileOptions) != 0)
-        SetCompileOpts(SyCompileOptions);
       type = CompileFunc(
                          SyCompileOutput,
                          func,

--- a/src/system.c
+++ b/src/system.c
@@ -159,12 +159,6 @@ Char SyCompileName[256];
 */
 Char SyCompileOutput[GAP_PATH_MAX];
 
-/****************************************************************************
-**
-*V  SyCompileOutput . . . . . . . . . . . . . . . . . . into this output file
-*/
-Char SyCompileOptions[256] = {'\0'};
-
 
 /****************************************************************************
 **
@@ -1770,7 +1764,6 @@ struct optInfo options[] = {
   { 'M', "", toggle, &SyUseModule, 0}, /* must be handled in kernel */
   { 'X', "", toggle, &SyCheckCRCCompiledModule, 0}, /* must be handled in kernel */
   { 'R', "", unsetString, &SyRestoring, 0}, /* kernel */
-  { 'U', "", storeString, SyCompileOptions, 1}, /* kernel */
   { 'a', "", storeMemory, &preAllocAmount, 1 }, /* kernel -- is this still useful */
   { 'e', "", toggle, &SyCTRD, 0 }, /* kernel */
   { 'f', "", forceLineEditing, (void *)2, 0 }, /* probably library now */

--- a/src/system.c
+++ b/src/system.c
@@ -386,9 +386,9 @@ Int SyStorMin;
 
 /****************************************************************************
 **
-*V  SySystemInitFile  . . . . . . . . . . .  name of the system "init.g" file
+*V  SyLoadSystemInitFile  . . . . . . should GAP load 'lib/init.g' at startup
 */
-Char SySystemInitFile[GAP_PATH_MAX];
+Int SyLoadSystemInitFile = 1;
 
 
 /****************************************************************************
@@ -1768,7 +1768,6 @@ struct optInfo options[] = {
   { 'e', "", toggle, &SyCTRD, 0 }, /* kernel */
   { 'f', "", forceLineEditing, (void *)2, 0 }, /* probably library now */
   { 'E', "", toggle, &SyUseReadline, 0 }, /* kernel */
-  { 'i', "", storeString, SySystemInitFile, 1}, /* kernel */
   { 'l', "roots", setGapRootPath, 0, 1}, /* kernel */
   { 'm', "", storeMemory2, &SyStorMin, 1 }, /* kernel */
   { 'r', "", toggle, &IgnoreGapRC, 0 }, /* kernel */
@@ -1909,8 +1908,6 @@ void InitSystem (
     
     SyInstallAnswerIntr();
 
-    SySystemInitFile[0] = '\0';
-    strxcpy( SySystemInitFile, "lib/init.g", sizeof(SySystemInitFile) );
 #if SYS_IS_CYGWIN32
     SySetGapRootPath( SyWindowsPath );
 #elif defined(SYS_DEFAULT_PATHS)
@@ -2033,9 +2030,9 @@ void InitSystem (
       if ( ptr != 0 )  free( ptr ); */
     }
 
-    /* try to find 'LIBNAME/init.g' to read it upon initialization         */
+    /* should GAP load 'init/lib.g' on initialization */
     if ( SyCompilePlease || SyRestoring ) {
-        SySystemInitFile[0] = 0;
+        SyLoadSystemInitFile = 0;
     }
 
     /* the compiler will *not* read in the .gaprc file                     

--- a/src/system.h
+++ b/src/system.h
@@ -237,12 +237,6 @@ extern Char SyCompileName[256];
 */
 extern Char SyCompileOutput[GAP_PATH_MAX];
 
-/****************************************************************************
-**
-*V  SyCompileOptions . . . . . . . . . . . . . . . . . with these options
-*/
-extern Char SyCompileOptions[256];
-
 
 /****************************************************************************
 **

--- a/src/system.h
+++ b/src/system.h
@@ -496,9 +496,9 @@ extern Int SyStorMin;
 
 /****************************************************************************
 **
-*V  SySystemInitFile  . . . . . . . . . . .  name of the system "init.g" file
+*V  SyLoadSystemInitFile  . . . . . . should GAP load 'lib/init.g' at startup
 */
-extern Char SySystemInitFile[GAP_PATH_MAX];
+extern Int SyLoadSystemInitFile;
 
 
 /****************************************************************************


### PR DESCRIPTION
The two command line options `-U` (set compiler options) and `-i` (set GAP root file) have been broken since at least 4.7.2, so let's remove them.

The reason this came to light is the way in which `-U` is broken causes the code coverage to wobble. The option was ignored anyway. Any use of `-i` would just cause GAP to not start correctly with a weird error message.