### PR TITLE
kernel: add util.h and ARRAY_SIZE macro

### DIFF
--- a/hpcgap/src/gap.c
+++ b/hpcgap/src/gap.c
@@ -117,6 +117,8 @@
 #include <src/intfuncs.h>
 #include <src/iostream.h>
 
+#include <src/util.h>
+
 /****************************************************************************
 **
 
@@ -1375,14 +1377,12 @@ Obj FuncRESUME_TIMEOUT( Obj self, Obj state ) {
 ** by longjmping. This should be tracked with RegisterSyLongjmpObserver.
 */
 
-enum {signalBreakFuncListLen = 16 };
-
-static intfunc signalBreakFuncList[signalBreakFuncListLen];
+static intfunc signalBreakFuncList[16];
 
 Int RegisterBreakloopObserver(intfunc func)
 {
     Int i;
-    for (i = 0; i < signalBreakFuncListLen; ++i) {
+    for (i = 0; i < ARRAY_SIZE(signalBreakFuncList); ++i) {
         if (signalBreakFuncList[i] == 0) {
             signalBreakFuncList[i] = func;
             return 1;

--- a/hpcgap/src/scanner.c
+++ b/hpcgap/src/scanner.c
@@ -65,6 +65,8 @@
 #include <src/hpc/tls.h>
 #include <src/hpc/thread.h>
 
+#include <src/util.h>
+
 #include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -359,7 +361,7 @@ UInt OpenInput (
     int sp;
 
     /* fail if we can not handle another open input file                   */
-    if ( STATE(InputFilesSP) == (sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0]))-1 )
+    if ( STATE(InputFilesSP) == (ARRAY_SIZE(STATE(InputFiles)))-1 )
         return 0;
 
     /* Handle *defin*; redirect *errin* to *defin* if the default
@@ -419,7 +421,7 @@ UInt OpenInputStream (
 {
     int sp;
     /* fail if we can not handle another open input file                   */
-    if ( STATE(InputFilesSP) == (sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0]))-1 )
+    if ( STATE(InputFilesSP) == (ARRAY_SIZE(STATE(InputFiles)))-1 )
         return 0;
 
     /* remember the current position in the current file                   */
@@ -851,7 +853,7 @@ UInt OpenOutput (
     }
 
     /* fail if we can not handle another open output file                  */
-    if ( STATE(OutputFilesSP) == sizeof(STATE(OutputFiles))/sizeof(STATE(OutputFiles)[0]))
+    if ( STATE(OutputFilesSP) == ARRAY_SIZE(STATE(OutputFiles)))
         return 0;
 
     /* Handle *defout* specially; also, redirect *errout* if we already
@@ -901,7 +903,7 @@ UInt OpenOutputStream (
 {
     int sp;
     /* fail if we can not handle another open output file                  */
-    if ( STATE(OutputFilesSP) == sizeof(STATE(OutputFiles))/sizeof(STATE(OutputFiles)[0]))
+    if ( STATE(OutputFilesSP) == ARRAY_SIZE(STATE(OutputFiles)))
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
@@ -990,7 +992,7 @@ UInt OpenAppend (
     int sp;
 
     /* fail if we can not handle another open output file                  */
-    if ( STATE(OutputFilesSP) == sizeof(STATE(OutputFiles))/sizeof(STATE(OutputFiles)[0]))
+    if ( STATE(OutputFilesSP) == ARRAY_SIZE(STATE(OutputFiles)))
         return 0;
 
     if ( ! strcmp( filename, "*defout*") )
@@ -2781,7 +2783,7 @@ void FormatOutput(void (*put_a_char)(Char c), const Char *format, Int arg1, Int 
 
       /* check if q matches a keyword    */
       q = (Char*)arg1;
-      for ( i = 0; i < sizeof(AllKeywords)/sizeof(AllKeywords[0]); i++ ) {
+      for ( i = 0; i < ARRAY_SIZE(AllKeywords); i++ ) {
         if ( strcmp(q, AllKeywords[i].name) == 0 ) {
           found_keyword = 1;
           break;
@@ -2926,7 +2928,7 @@ Obj FuncALL_KEYWORDS(Obj self) {
   UInt i;
   l = NEW_PLIST(T_PLIST_EMPTY, 0);
   SET_LEN_PLIST(l,0);
-  for (i = 0; i < sizeof(AllKeywords)/sizeof(AllKeywords[0]); i++) {
+  for (i = 0; i < ARRAY_SIZE(AllKeywords); i++) {
     C_NEW_STRING_DYN(s,AllKeywords[i].name);
     ASS_LIST(l, i+1, s);
   }
@@ -3000,9 +3002,9 @@ static Int InitLibrary (
  *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
  */
 #if !defined(HPCGAP)
-static Char Cookie[sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])][9];
-static Char MoreCookie[sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])][9];
-static Char StillMoreCookie[sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])][9];
+static Char Cookie[ARRAY_SIZE(STATE(InputFiles))][9];
+static Char MoreCookie[ARRAY_SIZE(STATE(InputFiles))][9];
+static Char StillMoreCookie[ARRAY_SIZE(STATE(InputFiles))][9];
 #endif
 
 static Int InitKernel (
@@ -3029,7 +3031,7 @@ static Int InitKernel (
     /* For HPC-GAP we don't need the cookies anymore, since the data got moved to thread-local
      * storage. */
     Int i;
-    for ( i = 0;  i < sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0]);  i++ ) {
+    for ( i = 0;  i < ARRAY_SIZE(STATE(InputFiles));  i++ ) {
       Cookie[i][0] = 's';  Cookie[i][1] = 't';  Cookie[i][2] = 'r';
       Cookie[i][3] = 'e';  Cookie[i][4] = 'a';  Cookie[i][5] = 'm';
       Cookie[i][6] = ' ';  Cookie[i][7] = '0'+i;

--- a/hpcgap/src/stats.c
+++ b/hpcgap/src/stats.c
@@ -56,6 +56,9 @@
 #include <src/hookintrprtr.h>
 #include <src/profile.h>                /* visit statements for profiling */
 
+#include <src/util.h>
+
+
 /****************************************************************************
 **
 
@@ -1773,7 +1776,7 @@ void InitIntrExecStats ( void )
     for (i = T_SEQ_STAT; i < T_RETURN_VOID; i++)
       IntrExecStatFuncs[i] = ExecStatFuncs[i];
     for ( i = T_RETURN_VOID;
-          i < sizeof(ExecStatFuncs)/sizeof(ExecStatFuncs[0]);
+          i < ARRAY_SIZE(ExecStatFuncs);
           i++ ) {
         IntrExecStatFuncs[i] = ExecIntrStat;
     }
@@ -2229,7 +2232,7 @@ static Int InitKernel (
     ImportFuncFromLibrary( "IsStandardIterator",   &STD_ITER );
 
     /* install executors for non-statements                                */
-    for ( i = 0; i < sizeof(ExecStatFuncs)/sizeof(ExecStatFuncs[0]); i++ ) {
+    for ( i = 0; i < ARRAY_SIZE(ExecStatFuncs); i++ ) {
         InstallExecStatFunc(i, ExecUnknownStat);
     }
 
@@ -2268,7 +2271,7 @@ static Int InitKernel (
     InstallExecStatFunc( T_ATOMIC         , ExecAtomic);
 
     /* install printers for non-statements                                */
-    for ( i = 0; i < sizeof(PrintStatFuncs)/sizeof(PrintStatFuncs[0]); i++ ) {
+    for ( i = 0; i < ARRAY_SIZE(PrintStatFuncs); i++ ) {
         InstallPrintStatFunc(i, PrintUnknownStat);
     }
     /* install printing functions for compound statements                  */

--- a/hpcgap/src/vars.c
+++ b/hpcgap/src/vars.c
@@ -55,6 +55,7 @@
 
 #include <src/hookintrprtr.h>           /* installing methods */
 
+#include <src/util.h>
 
 
 /****************************************************************************
@@ -119,7 +120,7 @@ Obj             ObjLVar (
 
 Bag NewLVarsBag(UInt slots) {
   Bag result;
-  if (slots < sizeof(TLS(LVarsPool))/(sizeof(TLS(LVarsPool)[0]))) {
+  if (slots < ARRAY_SIZE(TLS(LVarsPool))) {
     result = TLS(LVarsPool)[slots];
     if (result) {
       TLS(LVarsPool)[slots] = ADDR_OBJ(result)[0];
@@ -131,7 +132,7 @@ Bag NewLVarsBag(UInt slots) {
 
 void FreeLVarsBag(Bag bag) {
   UInt slots = SIZE_BAG(bag) / sizeof(Obj) - 3;
-  if (slots < sizeof(TLS(LVarsPool))/(sizeof(TLS(LVarsPool)[0]))) {
+  if (slots < ARRAY_SIZE(TLS(LVarsPool))) {
     memset(PTR_BAG(bag), 0, SIZE_BAG(bag));
     ADDR_OBJ(bag)[0] = TLS(LVarsPool)[slots];
     TLS(LVarsPool)[slots] = bag;

--- a/src/gap.c
+++ b/src/gap.c
@@ -117,6 +117,8 @@
 #include <src/intfuncs.h>
 #include <src/iostream.h>
 
+#include <src/util.h>
+
 /****************************************************************************
 **
 
@@ -1375,14 +1377,12 @@ Obj FuncRESUME_TIMEOUT( Obj self, Obj state ) {
 ** by longjmping. This should be tracked with RegisterSyLongjmpObserver.
 */
 
-enum {signalBreakFuncListLen = 16 };
-
-static intfunc signalBreakFuncList[signalBreakFuncListLen];
+static intfunc signalBreakFuncList[16];
 
 Int RegisterBreakloopObserver(intfunc func)
 {
     Int i;
-    for (i = 0; i < signalBreakFuncListLen; ++i) {
+    for (i = 0; i < ARRAY_SIZE(signalBreakFuncList); ++i) {
         if (signalBreakFuncList[i] == 0) {
             signalBreakFuncList[i] = func;
             return 1;

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -49,6 +49,8 @@
 #include <src/hpc/thread.h>
 #include <src/hpc/tls.h>
 
+#include <src/util.h>
+
 /* List of active hooks */
 struct InterpreterHooks * activeHooks[HookCount];
 
@@ -181,7 +183,7 @@ Int ActivateHooks(struct InterpreterHooks * hook)
         }
     }
 
-    for (i = 0; i < sizeof(ExecStatFuncs) / sizeof(ExecStatFuncs[0]); i++) {
+    for (i = 0; i < ARRAY_SIZE(ExecStatFuncs); i++) {
         ExecStatFuncs[i] = ProfileStatPassthrough;
         EvalExprFuncs[i] = ProfileEvalExprPassthrough;
         EvalBoolFuncs[i] = ProfileEvalBoolPassthrough;
@@ -212,7 +214,7 @@ Int DeactivateHooks(struct InterpreterHooks * hook)
     }
 
     if (HookActiveCount == 0) {
-        for (i = 0; i < sizeof(ExecStatFuncs) / sizeof(ExecStatFuncs[0]); i++) {
+        for (i = 0; i < ARRAY_SIZE(ExecStatFuncs); i++) {
             ExecStatFuncs[i] = OriginalExecStatFuncsForHook[i];
             EvalExprFuncs[i] = OriginalEvalExprFuncsForHook[i];
             EvalBoolFuncs[i] = OriginalEvalBoolFuncsForHook[i];
@@ -289,11 +291,11 @@ void ActivatePrintHooks(struct PrintHooks * hook)
 {
     Int i;
 
-    if(PrintHookActive) {
+    if (PrintHookActive) {
         return;
     }
     PrintHookActive = 1;
-    for (i = 0; i < sizeof(ExecStatFuncs) / sizeof(ExecStatFuncs[0]); i++) {
+    for (i = 0; i < ARRAY_SIZE(ExecStatFuncs); i++) {
         if (hook->printStatPassthrough) {
             PrintStatFuncs[i] = hook->printStatPassthrough;
         }
@@ -307,11 +309,11 @@ void DeactivatePrintHooks(struct PrintHooks * hook)
 {
     Int i;
 
-    if(!PrintHookActive) {
+    if (!PrintHookActive) {
         return;
     }
     PrintHookActive = 0;
-    for (i = 0; i < sizeof(ExecStatFuncs) / sizeof(ExecStatFuncs[0]); i++) {
+    for (i = 0; i < ARRAY_SIZE(ExecStatFuncs); i++) {
         PrintStatFuncs[i] = OriginalPrintStatFuncsForHook[i];
         PrintExprFuncs[i] = OriginalPrintExprFuncsForHook[i];
     }

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -38,6 +38,7 @@
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/tls.h>                /* thread-local storage */
 
+#include <src/util.h>
 
 /***************************************************************************
 **

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -67,6 +67,8 @@
 
 #include <src/code.h>                   /* FilenameCache */
 
+#include <src/util.h>
+
 #include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -296,7 +298,7 @@ UInt OpenInput (
     Int                 file;
 
     /* fail if we can not handle another open input file                   */
-    if ( STATE(Input)+1 == STATE(InputFiles)+(sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])) )
+    if ( STATE(Input)+1 == STATE(InputFiles)+(ARRAY_SIZE(STATE(InputFiles))) )
         return 0;
 
     /* try to open the input file                                          */
@@ -347,7 +349,7 @@ UInt OpenInputStream (
     Obj                 stream )
 {
     /* fail if we can not handle another open input file                   */
-    if ( STATE(Input)+1 == STATE(InputFiles)+(sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])) )
+    if ( STATE(Input)+1 == STATE(InputFiles)+(ARRAY_SIZE(STATE(InputFiles))) )
         return 0;
 
     assert(STATE(Input) != 0);
@@ -772,7 +774,7 @@ UInt OpenOutput (
     }
 
     /* fail if we can not handle another open output file                  */
-    if ( STATE(Output)+1==STATE(OutputFiles)+(sizeof(STATE(OutputFiles))/sizeof(STATE(OutputFiles)[0])) )
+    if ( STATE(Output)+1==STATE(OutputFiles)+(ARRAY_SIZE(STATE(OutputFiles))) )
         return 0;
 
     /* try to open the file                                                */
@@ -813,7 +815,7 @@ UInt OpenOutputStream (
     Obj                 stream )
 {
     /* fail if we can not handle another open output file                  */
-    if ( STATE(Output)+1==STATE(OutputFiles)+(sizeof(STATE(OutputFiles))/sizeof(STATE(OutputFiles)[0])) )
+    if ( STATE(Output)+1==STATE(OutputFiles)+(ARRAY_SIZE(STATE(OutputFiles))) )
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
@@ -893,7 +895,7 @@ UInt OpenAppend (
     Int                 file;
 
     /* fail if we can not handle another open output file                  */
-    if ( STATE(Output)+1==STATE(OutputFiles)+(sizeof(STATE(OutputFiles))/sizeof(STATE(OutputFiles)[0])) )
+    if ( STATE(Output)+1==STATE(OutputFiles)+(ARRAY_SIZE(STATE(OutputFiles))) )
         return 0;
 
     /* try to open the file                                                */
@@ -2666,7 +2668,7 @@ void FormatOutput(void (*put_a_char)(Char c), const Char *format, Int arg1, Int 
 
       /* check if q matches a keyword    */
       q = (Char*)arg1;
-      for ( i = 0; i < sizeof(AllKeywords)/sizeof(AllKeywords[0]); i++ ) {
+      for ( i = 0; i < ARRAY_SIZE(AllKeywords); i++ ) {
         if ( strcmp(q, AllKeywords[i].name) == 0 ) {
           found_keyword = 1;
           break;
@@ -2811,7 +2813,7 @@ Obj FuncALL_KEYWORDS(Obj self) {
   UInt i;
   l = NEW_PLIST(T_PLIST_EMPTY, 0);
   SET_LEN_PLIST(l,0);
-  for (i = 0; i < sizeof(AllKeywords)/sizeof(AllKeywords[0]); i++) {
+  for (i = 0; i < ARRAY_SIZE(AllKeywords); i++) {
     C_NEW_STRING_DYN(s,AllKeywords[i].name);
     ASS_LIST(l, i+1, s);
   }
@@ -2893,9 +2895,9 @@ static Int InitLibrary (
  *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
  */
 #if !defined(HPCGAP)
-static Char Cookie[sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])][9];
-static Char MoreCookie[sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])][9];
-static Char StillMoreCookie[sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0])][9];
+static Char Cookie[ARRAY_SIZE(STATE(InputFiles))][9];
+static Char MoreCookie[ARRAY_SIZE(STATE(InputFiles))][9];
+static Char StillMoreCookie[ARRAY_SIZE(STATE(InputFiles))][9];
 #endif
 
 static Int InitKernel (
@@ -2922,7 +2924,7 @@ static Int InitKernel (
     /* For HPC-GAP we don't need the cookies anymore, since the data got moved to thread-local
      * storage. */
     Int i;
-    for ( i = 0;  i < sizeof(STATE(InputFiles))/sizeof(STATE(InputFiles)[0]);  i++ ) {
+    for ( i = 0;  i < ARRAY_SIZE(STATE(InputFiles));  i++ ) {
       Cookie[i][0] = 's';  Cookie[i][1] = 't';  Cookie[i][2] = 'r';
       Cookie[i][3] = 'e';  Cookie[i][4] = 'a';  Cookie[i][5] = 'm';
       Cookie[i][6] = ' ';  Cookie[i][7] = '0'+i;

--- a/src/stats.c
+++ b/src/stats.c
@@ -57,6 +57,9 @@
 
 #include <src/hookintrprtr.h>           /* visit statements for profiling */
 
+#include <src/util.h>
+
+
 /****************************************************************************
 **
 
@@ -1720,7 +1723,7 @@ UInt TakeInterrupt( void ) {
 void UnInterruptExecStat() {
   UInt i;
   assert(RealExecStatCopied);
-  for ( i=0; i<sizeof(ExecStatFuncs)/sizeof(ExecStatFuncs[0]); i++ ) {
+  for ( i=0; i<ARRAY_SIZE(ExecStatFuncs); i++ ) {
     ExecStatFuncs[i] = RealExecStatFuncs[i];
   }
   RealExecStatCopied = 0;
@@ -1791,7 +1794,7 @@ void InterruptExecStat ( void )
 
     /* remember the original entries from the table 'ExecStatFuncs'        */
     if ( ! RealExecStatCopied ) {
-        for ( i=0; i<sizeof(ExecStatFuncs)/sizeof(ExecStatFuncs[0]); i++ ) {
+        for ( i=0; i<ARRAY_SIZE(ExecStatFuncs); i++ ) {
             RealExecStatFuncs[i] = ExecStatFuncs[i];
         }
         RealExecStatCopied = 1;
@@ -1804,7 +1807,7 @@ void InterruptExecStat ( void )
         ExecStatFuncs[i] = ExecIntrStat;
     }
     for ( i = T_RETURN_VOID;
-          i < sizeof(ExecStatFuncs)/sizeof(ExecStatFuncs[0]);
+          i < ARRAY_SIZE(ExecStatFuncs);
           i++ ) {
         ExecStatFuncs[i] = ExecIntrStat;
     }
@@ -2263,7 +2266,7 @@ static Int InitKernel (
     ImportFuncFromLibrary( "IsStandardIterator",   &STD_ITER );
 
     /* install executors for non-statements                                */
-    for ( i = 0; i < sizeof(ExecStatFuncs)/sizeof(ExecStatFuncs[0]); i++ ) {
+    for ( i = 0; i < ARRAY_SIZE(ExecStatFuncs); i++ ) {
         InstallExecStatFunc(i, ExecUnknownStat);
     }
 
@@ -2302,7 +2305,7 @@ static Int InitKernel (
     InstallExecStatFunc( T_ATOMIC         , ExecAtomic);
 
     /* install printers for non-statements                                */
-    for ( i = 0; i < sizeof(PrintStatFuncs)/sizeof(PrintStatFuncs[0]); i++ ) {
+    for ( i = 0; i < ARRAY_SIZE(PrintStatFuncs); i++ ) {
         InstallPrintStatFunc(i, PrintUnknownStat);
     }
     /* install printing functions for compound statements                  */

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -45,6 +45,7 @@
 
 #include <src/read.h>                   /* reader */
 
+#include <src/util.h>
 
 #include <assert.h>
 #include <fcntl.h>
@@ -759,11 +760,11 @@ Int SyFopen (
 
     HashLock(&syBuf);
     /* try to find an unused file identifier                               */
-    for ( fid = 4; fid < sizeof(syBuf)/sizeof(syBuf[0]); ++fid )
+    for ( fid = 4; fid < ARRAY_SIZE(syBuf); ++fid )
         if ( syBuf[fid].fp == -1 )
           break;
     
-    if ( fid == sizeof(syBuf)/sizeof(syBuf[0]) ) {
+    if ( fid == ARRAY_SIZE(syBuf) ) {
         HashUnlock(&syBuf);
         return (Int)-1;
     }
@@ -842,10 +843,10 @@ UInt SySetBuffering( UInt fid )
 
   bufno = 0;
   HashLock(&syBuf);
-  while (bufno < sizeof(syBuffers)/sizeof(syBuffers[0]) &&
+  while (bufno < ARRAY_SIZE(syBuffers) &&
          syBuffers[bufno].inuse != 0)
     bufno++;
-  if (bufno >= sizeof(syBuffers)/sizeof(syBuffers[0])) {
+  if (bufno >= ARRAY_SIZE(syBuffers)) {
       HashUnlock(&syBuf);
       return 0;
   }
@@ -868,7 +869,7 @@ Int SyFclose (
     Int                 fid )
 {
     /* check file identifier                                               */
-    if ( sizeof(syBuf)/sizeof(syBuf[0]) <= fid || fid < 0 ) {
+    if ( ARRAY_SIZE(syBuf) <= fid || fid < 0 ) {
         fputs("gap: panic 'SyFclose' asked to close illegal fid!\n",stderr);
         return -1;
     }
@@ -914,7 +915,7 @@ Int SyIsEndOfFile (
     Int                 fid )
 {
     /* check file identifier                                               */
-    if ( sizeof(syBuf)/sizeof(syBuf[0]) <= fid || fid < 0 ) {
+    if ( ARRAY_SIZE(syBuf) <= fid || fid < 0 ) {
         return -1;
     }
     if ( syBuf[fid].fp == -1 ) {
@@ -1281,7 +1282,7 @@ Int SyEchoch (
     Int                 fid )
 {
     /* check file identifier                                               */
-    if ( sizeof(syBuf)/sizeof(syBuf[0]) <= fid || fid < 0 ) {
+    if ( ARRAY_SIZE(syBuf) <= fid || fid < 0 ) {
         return -1;
     }
     if ( syBuf[fid].fp == -1 ) {
@@ -1380,7 +1381,7 @@ Int SyFtell (
     Int                 fid )
 {
     /* check file identifier                                               */
-    if ( sizeof(syBuf)/sizeof(syBuf[0]) <= fid || fid < 0 ) {
+    if ( ARRAY_SIZE(syBuf) <= fid || fid < 0 ) {
         return -1;
     }
     if ( syBuf[fid].fp == -1 ) {
@@ -1408,7 +1409,7 @@ Int SyFseek (
     Int                 pos )
 {
     /* check file identifier                                               */
-    if ( sizeof(syBuf)/sizeof(syBuf[0]) <= fid || fid < 0 ) {
+    if ( ARRAY_SIZE(syBuf) <= fid || fid < 0 ) {
         return -1;
     }
     if ( syBuf[fid].fp == -1 ) {
@@ -1611,7 +1612,7 @@ Int SyGetch (
     Int                 ch;
 
     /* check file identifier                                               */
-    if ( sizeof(syBuf)/sizeof(syBuf[0]) <= fid || fid < 0 ) {
+    if ( ARRAY_SIZE(syBuf) <= fid || fid < 0 ) {
         return -1;
     }
         /* on the Mac, syBuf[fid].fp is -1 for stdin, stdout, errin, errout
@@ -1848,7 +1849,7 @@ Int HasAvailableBytes( UInt fid )
   Int ret;
 #endif
   UInt bufno;
-  if (fid > sizeof(syBuf)/sizeof(syBuf[0]) ||
+  if (fid > ARRAY_SIZE(syBuf) ||
       syBuf[fid].fp == -1)
     return -1;
 
@@ -2235,7 +2236,7 @@ Char * syFgets (
     Obj                 linestr, yankstr, args, res;
 
     /* check file identifier                                               */
-    if ( sizeof(syBuf)/sizeof(syBuf[0]) <= fid || fid < 0 ) {
+    if ( ARRAY_SIZE(syBuf) <= fid || fid < 0 ) {
         return (Char*)0;
     }
     if ( syBuf[fid].fp == -1 ) {
@@ -3303,7 +3304,7 @@ Char * SyFindGapRootFile ( const Char * filename, Char * buffer, size_t bufferSi
 {
     Int k;
 
-    for ( k = 0; k < sizeof(SyGapRootPaths)/sizeof(SyGapRootPaths[0]); k++ ) {
+    for ( k = 0; k < ARRAY_SIZE(SyGapRootPaths); k++ ) {
         if ( SyGapRootPaths[k][0] ) {
             if (strlcpy( buffer, SyGapRootPaths[k], bufferSize ) >= bufferSize)
                 continue;

--- a/src/system.c
+++ b/src/system.c
@@ -25,7 +25,8 @@
 #include <src/gap.h>                    /* get UserHasQUIT */
 
 #include <src/sysfiles.h>               /* file input/output */
-#include <src/gasman.h>            
+#include <src/gasman.h>
+#include <src/util.h>
 
 #ifdef HPCGAP
 #include <src/hpc/misc.h>
@@ -1616,7 +1617,7 @@ static UInt ParseMemory( Char * s)
   maxmem = 4000000000UL;
 #endif
   
-  for (i = 0; i < sizeof(memoryUnits)/sizeof(memoryUnits[0]); i++) {
+  for (i = 0; i < ARRAY_SIZE(memoryUnits); i++) {
     if (symbol == memoryUnits[i].symbol) {
       UInt value = memoryUnits[i].value;
       if (size > maxmem/value)
@@ -1868,10 +1869,10 @@ void InitSystem (
     setbuf(stderr, (char *)0);
 #endif
 
-    for (i = 4; i < sizeof(syBuf)/sizeof(syBuf[0]); i++)
+    for (i = 4; i < ARRAY_SIZE(syBuf); i++)
       syBuf[i].fp = -1;
     
-    for (i = 0; i < sizeof(syBuffers)/sizeof(syBuffers[0]); i++)
+    for (i = 0; i < ARRAY_SIZE(syBuffers); i++)
           syBuffers[i].inuse = 0;
 
 #if HAVE_LIBREADLINE

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,16 @@
+/****************************************************************************
+**
+**  Copyright (C) 2017 The GAP Group
+**
+*/
+
+#ifndef GAP_UTIL_H
+#define GAP_UTIL_H
+
+/****************************************************************************
+**
+** Compute the number of elements of a given C array.
+**/
+#define ARRAY_SIZE(arr)     ( sizeof(arr) / sizeof((arr)[0]) )
+
+#endif // GAP_UTIL_H


### PR DESCRIPTION
The new macro IMHO improves readability and reduces duplication. And we can move additional functions and defines into the new header (e.g. we might move some things out of system.h and gap.h).