### PR TITLE
Do not copy jmp_bufs

### DIFF
--- a/hpcgap/src/gap.c
+++ b/hpcgap/src/gap.c
@@ -1159,7 +1159,7 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, volatile Obj args )
 Obj FuncJUMP_TO_CATCH( Obj self, Obj payload)
 {
   STATE(ThrownObject) = payload;
-  syLongjmp(STATE(ReadJmpError), 1);
+  syLongjmp(&(STATE(ReadJmpError)), 1);
   return 0;
 }
 

--- a/hpcgap/src/read.c
+++ b/hpcgap/src/read.c
@@ -2952,7 +2952,7 @@ void            ReadEvalError ( void )
 {
     STATE(PtrBody)  = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
     STATE(PtrLVars) = PTR_BAG(STATE(CurrLVars));
-    syLongjmp( STATE(ReadJmpError), 1 );
+    syLongjmp( &(STATE(ReadJmpError)), 1 );
 }
 
 

--- a/hpcgap/src/stats.c
+++ b/hpcgap/src/stats.c
@@ -1681,7 +1681,7 @@ int volatile RealExecStatCopied;
 static void CheckAndRespondToAlarm(void) {
   if ( SyAlarmHasGoneOff ) {
     assert(NumAlarmJumpBuffers);
-    syLongjmp(AlarmJumpBuffers[--NumAlarmJumpBuffers],1);
+    syLongjmp(&(AlarmJumpBuffers[--NumAlarmJumpBuffers]),1);
   }
 }
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -1160,7 +1160,7 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, Obj args )
 Obj FuncJUMP_TO_CATCH( Obj self, Obj payload)
 {
   STATE(ThrownObject) = payload;
-  syLongjmp(STATE(ReadJmpError), 1);
+  syLongjmp(&(STATE(ReadJmpError)), 1);
   return 0;
 }
 

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -1023,7 +1023,7 @@ Obj FuncSERIALIZE_NATIVE_STRING(Obj self, Obj obj) {
   if (sySetjmp(STATE(ReadJmpError))) {
     memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
     RestoreSerializationState(&state);
-    syLongjmp(STATE(ReadJmpError), 1);
+    syLongjmp(&(STATE(ReadJmpError)), 1);
   }
   SerializeObj(obj);
   while (LEN_PLIST(STATE(SerializationStack)) > 0)
@@ -1047,7 +1047,7 @@ Obj FuncDESERIALIZE_NATIVE_STRING(Obj self, Obj string) {
   if (sySetjmp(STATE(ReadJmpError))) {
     memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
     RestoreSerializationState(&state);
-    syLongjmp(STATE(ReadJmpError), 1);
+    syLongjmp(&(STATE(ReadJmpError)), 1);
   }
   InitNativeStringDeserializer(string);
   result = DeserializeObj();

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -858,7 +858,7 @@ static void TerminateCurrentThread(int locked) {
   PopRegionLocks(0);
   if (TLS(CurrentHashLock))
     HashUnlock(TLS(CurrentHashLock));
-  syLongjmp(TLS(threadExit), 1);
+  syLongjmp(&(TLS(threadExit)), 1);
 }
 
 static void PauseCurrentThread(int locked) {

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -873,7 +873,7 @@ Obj FuncWITH_TARGET_REGION(Obj self, Obj obj, Obj func) {
   if (sySetjmp(STATE(ReadJmpError))) {
     memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
     TLS(currentRegion) = oldRegion;
-    syLongjmp(STATE(ReadJmpError), 1);
+    syLongjmp(&(STATE(ReadJmpError)), 1);
   }
   TLS(currentRegion) = region;
   CALL_0ARGS(func);

--- a/src/read.c
+++ b/src/read.c
@@ -3011,7 +3011,7 @@ void            ReadEvalError ( void )
 {
     STATE(PtrBody)  = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
     STATE(PtrLVars) = PTR_BAG(STATE(CurrLVars));
-    syLongjmp( STATE(ReadJmpError), 1 );
+    syLongjmp( &(STATE(ReadJmpError)), 1 );
 }
 
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -1681,7 +1681,7 @@ static void CheckAndRespondToAlarm(void) {
   if ( SyAlarmHasGoneOff ) {
     SyAlarmHasGoneOff = 0;
     assert(NumAlarmJumpBuffers);
-    syLongjmp(AlarmJumpBuffers[--NumAlarmJumpBuffers],1);
+    syLongjmp(&(AlarmJumpBuffers[--NumAlarmJumpBuffers]),1);
   }
 }
 

--- a/src/system.c
+++ b/src/system.c
@@ -1602,12 +1602,12 @@ Int RegisterSyLongjmpObserver(voidfunc func)
     return 0;
 }
 
-void syLongjmp(syJmp_buf buf, int val)
+void syLongjmp(syJmp_buf* buf, int val)
 {
     Int i;
     for (i = 0; i < signalSyLongjmpFuncsLen && signalSyLongjmpFuncs[i]; ++i)
         (signalSyLongjmpFuncs[i])();
-    syLongjmpInternal(buf, val);
+    syLongjmpInternal(*buf, val);
 }
 
 /****************************************************************************

--- a/src/system.h
+++ b/src/system.h
@@ -1046,7 +1046,7 @@ extern Char *getOptionArg(Char key, UInt which);
 #endif
 #endif
 
-void syLongjmp(syJmp_buf buf, int val);
+void syLongjmp(syJmp_buf* buf, int val);
 
 /****************************************************************************
 **


### PR DESCRIPTION
This stops us copying longjmp jmp_bufs. While this sometimes works, it isn't technically valid C, and doesn't work in cygwin.