### PR TITLE
hpcgap/src/gvars.c: fix HPC-GAP crash (regression)

### DIFF
--- a/hpcgap/src/gvars.c
+++ b/hpcgap/src/gvars.c
@@ -1452,8 +1452,11 @@ static Int PostRestore (
     /* create the global variable '~'                                      */
     Tilde = GVarName( "~" );
 
+#if !defined(HPCGAP)
     /* stop unauthorised changes to '~'                                    */
+    // FIXME: enabling this causes HPC-GAP to crash
     MakeReadOnlyGVar(Tilde);
+#endif
 
     /* update fopies and copies                                            */
     UpdateCopyFopyInfo();

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1164,8 +1164,11 @@ static Int PostRestore (
     /* create the global variable '~'                                      */
     Tilde = GVarName( "~" );
 
+#if !defined(HPCGAP)
     /* stop unauthorised changes to '~'                                    */
+    // FIXME: enabling this causes HPC-GAP to crash
     MakeReadOnlyGVar(Tilde);
+#endif
 
     /* update fopies and copies                                            */
     UpdateCopyFopyInfo();


### PR DESCRIPTION
HPC-GAP was crashing for me on OS X. I found this fix via bisecting. Have not yet looked into *why* it crashes (I guess `Tilde` is initialized later in HPC-GAP), so this patch only papers over the source of the crash. A proper fix should retain the `MakeReadOnlyGVar(Tilde);` but in a non-crashing way...