### PR TITLE
kernel: introduce AlwaysYes and AlwaysNo

### DIFF
--- a/hpcgap/src/objects.c
+++ b/hpcgap/src/objects.c
@@ -47,6 +47,8 @@
 #include <src/hpc/traverse.h>           /* object traversal */
 #include <src/hpc/tls.h>                /* thread-local storage */
 
+#include <src/util.h>
+
 
 static Int lastFreePackageTNUM = FIRST_PACKAGE_TNUM;
 
@@ -191,12 +193,6 @@ Int IsMutableObjError (
     return 0;
 }
 
-Int IsMutableObjNot (
-    Obj                 obj )
-{
-    return 0L;
-}
-
 Int IsMutableObjObject (
     Obj                 obj )
 {
@@ -257,12 +253,6 @@ Int IsCopyableObjError (
     ErrorQuit(
         "Panic: tried to test copyability of unknown type '%d'",
         (Int)TNUM_OBJ(obj), 0L );
-    return 0L;
-}
-
-Int IsCopyableObjNot (
-    Obj                 obj )
-{
     return 0L;
 }
 
@@ -2004,7 +1994,7 @@ static Int InitKernel (
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ )
         IsMutableObjFuncs[ t ] = IsMutableObjError;
     for ( t = FIRST_CONSTANT_TNUM; t <= LAST_CONSTANT_TNUM; t++ )
-        IsMutableObjFuncs[ t ] = IsMutableObjNot;
+        IsMutableObjFuncs[ t ] = AlwaysNo;
     for ( t = FIRST_EXTERNAL_TNUM; t <= LAST_EXTERNAL_TNUM; t++ )
         IsMutableObjFuncs[ t ] = IsMutableObjObject;
 
@@ -2012,7 +2002,7 @@ static Int InitKernel (
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ )
         IsCopyableObjFuncs[ t ] = IsCopyableObjError;
     for ( t = FIRST_CONSTANT_TNUM; t <= LAST_CONSTANT_TNUM; t++ )
-        IsCopyableObjFuncs[ t ] = IsCopyableObjNot;
+        IsCopyableObjFuncs[ t ] = AlwaysNo;
     for ( t = FIRST_EXTERNAL_TNUM; t <= LAST_EXTERNAL_TNUM; t++ )
         IsCopyableObjFuncs[ t ] = IsCopyableObjObject;
 
@@ -2136,7 +2126,6 @@ static Int InitLibrary (
 
     AssGVar(GVarName("LAST_IMM_MUT_TNUM"), INTOBJ_INT(LAST_IMM_MUT_TNUM));
     MakeReadOnlyGVar(GVarName("LAST_IMM_MUT_TNUM"));
-    
 
     /* return success                                                      */
     return 0;

--- a/hpcgap/src/plist.c
+++ b/hpcgap/src/plist.c
@@ -70,7 +70,11 @@
 #include <src/hpc/thread.h>
 #include <src/hpc/tls.h>
 
+#include <src/util.h>
+
 #include <assert.h>
+
+
 /****************************************************************************
 **
 
@@ -2122,18 +2126,6 @@ Int             IsDensePlist (
     return 1L;
 }
 
-Int             IsDensePlistNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsDensePlistYes (
-    Obj                 list )
-{
-    return 1L;
-}
-
 
 /****************************************************************************
 **
@@ -2152,18 +2144,6 @@ Int             IsHomogPlist (
     return (T_PLIST_HOM <= tnum);
 }
 
-Int             IsHomogPlistNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsHomogPlistYes (
-    Obj                 list )
-{
-    return 1L;
-}
-
 
 /****************************************************************************
 **
@@ -2180,18 +2160,6 @@ Int             IsTablePlist (
     Int                 tnum;
     tnum = KTNumPlist( list, (Obj *)0 );
     return (T_PLIST_TAB <= tnum && tnum <= T_PLIST_TAB_RECT_SSORT);
-}
-
-Int             IsTablePlistNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsTablePlistYes (
-    Obj                 list )
-{
-    return 1L;
 }
 
 
@@ -2400,18 +2368,6 @@ Int             IsSSortPlistHom (
 
 }
 
-
-Int             IsSSortPlistNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsSSortPlistYes (
-    Obj                 list )
-{
-    return 2L;
-}
 
 Obj FuncSetIsSSortedPlist (Obj self, Obj list)
 {
@@ -4752,117 +4708,117 @@ static Int InitKernel (
     /* install the dense list test methods                                 */
     IsDenseListFuncs[ T_PLIST                   ] = IsDensePlist;
     IsDenseListFuncs[ T_PLIST        +IMMUTABLE ] = IsDensePlist;
-    IsDenseListFuncs[ T_PLIST_NDENSE            ] = IsDensePlistNot;
-    IsDenseListFuncs[ T_PLIST_NDENSE +IMMUTABLE ] = IsDensePlistNot;
+    IsDenseListFuncs[ T_PLIST_NDENSE            ] = AlwaysNo;
+    IsDenseListFuncs[ T_PLIST_NDENSE +IMMUTABLE ] = AlwaysNo;
     for ( t1 = T_PLIST_DENSE; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
-        IsDenseListFuncs[ t1            ] = IsDensePlistYes;
-        IsDenseListFuncs[ t1 +IMMUTABLE ] = IsDensePlistYes;
+        IsDenseListFuncs[ t1            ] = AlwaysYes;
+        IsDenseListFuncs[ t1 +IMMUTABLE ] = AlwaysYes;
     }
 
 
     /* install the homogeneous list test methods                           */
     IsHomogListFuncs[ T_PLIST                       ] = IsHomogPlist;
     IsHomogListFuncs[ T_PLIST            +IMMUTABLE ] = IsHomogPlist;
-    IsHomogListFuncs[ T_PLIST_NDENSE                ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_NDENSE     +IMMUTABLE ] = IsHomogPlistNot;
+    IsHomogListFuncs[ T_PLIST_NDENSE                ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_NDENSE     +IMMUTABLE ] = AlwaysNo;
     IsHomogListFuncs[ T_PLIST_DENSE                 ] = IsHomogPlist;
     IsHomogListFuncs[ T_PLIST_DENSE      +IMMUTABLE ] = IsHomogPlist;
-    IsHomogListFuncs[ T_PLIST_DENSE_NHOM            ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_DENSE_NHOM +IMMUTABLE ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_SSORT      ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_SSORT+IMMUTABLE ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_NSORT      ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_EMPTY                 ] = IsHomogPlistYes;
-    IsHomogListFuncs[ T_PLIST_EMPTY      +IMMUTABLE ] = IsHomogPlistYes;
+    IsHomogListFuncs[ T_PLIST_DENSE_NHOM            ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_DENSE_NHOM +IMMUTABLE ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_SSORT      ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_SSORT+IMMUTABLE ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_NSORT      ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_EMPTY                 ] = AlwaysYes;
+    IsHomogListFuncs[ T_PLIST_EMPTY      +IMMUTABLE ] = AlwaysYes;
     for ( t1 = T_PLIST_HOM; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
-        IsHomogListFuncs[ t1            ] = IsHomogPlistYes;
-        IsHomogListFuncs[ t1 +IMMUTABLE ] = IsHomogPlistYes;
+        IsHomogListFuncs[ t1            ] = AlwaysYes;
+        IsHomogListFuncs[ t1 +IMMUTABLE ] = AlwaysYes;
     }
 
 
     /* install the equal length list test methods                          */
     IsTableListFuncs[ T_PLIST                       ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST            +IMMUTABLE ] = IsTablePlist;
-    IsTableListFuncs[ T_PLIST_NDENSE                ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_NDENSE     +IMMUTABLE ] = IsTablePlistNot;
+    IsTableListFuncs[ T_PLIST_NDENSE                ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_NDENSE     +IMMUTABLE ] = AlwaysNo;
     IsTableListFuncs[ T_PLIST_DENSE                 ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST_DENSE      +IMMUTABLE ] = IsTablePlist;
-    IsTableListFuncs[ T_PLIST_DENSE_NHOM            ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_DENSE_NHOM +IMMUTABLE ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_DENSE_NHOM_SSORT      ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_DENSE_NHOM_SSORT +IMMUTABLE ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_DENSE_NHOM_NSORT      ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_EMPTY                 ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_EMPTY      +IMMUTABLE ] = IsTablePlistNot;
+    IsTableListFuncs[ T_PLIST_DENSE_NHOM            ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_DENSE_NHOM +IMMUTABLE ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_DENSE_NHOM_SSORT      ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_DENSE_NHOM_SSORT +IMMUTABLE ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_DENSE_NHOM_NSORT      ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_EMPTY                 ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_EMPTY      +IMMUTABLE ] = AlwaysNo;
     IsTableListFuncs[ T_PLIST_HOM                   ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST_HOM        +IMMUTABLE ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST_HOM_NSORT             ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST_HOM_NSORT  +IMMUTABLE ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST_HOM_SSORT             ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST_HOM_SSORT  +IMMUTABLE ] = IsTablePlist;
-    IsTableListFuncs[ T_PLIST_TAB                   ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB        +IMMUTABLE ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_NSORT             ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_NSORT  +IMMUTABLE ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_SSORT             ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_SSORT  +IMMUTABLE ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_RECT                   ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_RECT        +IMMUTABLE ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_RECT_NSORT             ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_RECT_NSORT  +IMMUTABLE ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_RECT_SSORT             ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_RECT_SSORT  +IMMUTABLE ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_CYC                   ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_CYC        +IMMUTABLE ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_CYC_NSORT             ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_CYC_NSORT  +IMMUTABLE ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_CYC_SSORT             ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_CYC_SSORT  +IMMUTABLE ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_FFE                   ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_FFE        +IMMUTABLE ] = IsTablePlistNot;
+    IsTableListFuncs[ T_PLIST_TAB                   ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB        +IMMUTABLE ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_NSORT             ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_NSORT  +IMMUTABLE ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_SSORT             ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_SSORT  +IMMUTABLE ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_RECT                   ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_RECT        +IMMUTABLE ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_RECT_NSORT             ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_RECT_NSORT  +IMMUTABLE ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_RECT_SSORT             ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_RECT_SSORT  +IMMUTABLE ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_CYC                   ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_CYC        +IMMUTABLE ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_CYC_NSORT             ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_CYC_NSORT  +IMMUTABLE ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_CYC_SSORT             ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_CYC_SSORT  +IMMUTABLE ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_FFE                   ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_FFE        +IMMUTABLE ] = AlwaysNo;
 
 
     /* install the strictly sorted list test methods                       */
     IsSSortListFuncs[ T_PLIST                      ] = IsSSortPlist;
     IsSSortListFuncs[ T_PLIST           +IMMUTABLE ] = IsSSortPlist;
-    IsSSortListFuncs[ T_PLIST_NDENSE               ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_NDENSE    +IMMUTABLE ] = IsSSortPlistNot;
+    IsSSortListFuncs[ T_PLIST_NDENSE               ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_NDENSE    +IMMUTABLE ] = AlwaysNo;
     IsSSortListFuncs[ T_PLIST_DENSE                ] = IsSSortPlistDense;
     IsSSortListFuncs[ T_PLIST_DENSE     +IMMUTABLE ] = IsSSortPlistDense;
     IsSSortListFuncs[ T_PLIST_DENSE_NHOM           ] = IsSSortPlistDense;
     IsSSortListFuncs[ T_PLIST_DENSE_NHOM+IMMUTABLE ] = IsSSortPlistDense;
-    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_SSORT     ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_SSORT+IMMUTABLE ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_NSORT     ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_NSORT+IMMUTABLE ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_EMPTY                ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_EMPTY     +IMMUTABLE ] = IsSSortPlistYes;
+    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_SSORT     ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_SSORT+IMMUTABLE ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_NSORT     ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_NSORT+IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_EMPTY                ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_EMPTY     +IMMUTABLE ] = AlwaysYes;
     IsSSortListFuncs[ T_PLIST_HOM                  ] = IsSSortPlistHom;
     IsSSortListFuncs[ T_PLIST_HOM       +IMMUTABLE ] = IsSSortPlistHom;
-    IsSSortListFuncs[ T_PLIST_HOM_NSORT            ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_HOM_NSORT +IMMUTABLE ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_HOM_SSORT            ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_HOM_SSORT +IMMUTABLE ] = IsSSortPlistYes;
+    IsSSortListFuncs[ T_PLIST_HOM_NSORT            ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_HOM_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_HOM_SSORT            ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_HOM_SSORT +IMMUTABLE ] = AlwaysYes;
     IsSSortListFuncs[ T_PLIST_TAB                  ] = IsSSortPlistHom;
     IsSSortListFuncs[ T_PLIST_TAB       +IMMUTABLE ] = IsSSortPlistHom;
-    IsSSortListFuncs[ T_PLIST_TAB_NSORT            ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_TAB_NSORT +IMMUTABLE ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_TAB_SSORT            ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_TAB_SSORT +IMMUTABLE ] = IsSSortPlistYes;
+    IsSSortListFuncs[ T_PLIST_TAB_NSORT            ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_TAB_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_TAB_SSORT            ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_TAB_SSORT +IMMUTABLE ] = AlwaysYes;
     IsSSortListFuncs[ T_PLIST_TAB_RECT                  ] = IsSSortPlistHom;
     IsSSortListFuncs[ T_PLIST_TAB_RECT       +IMMUTABLE ] = IsSSortPlistHom;
-    IsSSortListFuncs[ T_PLIST_TAB_RECT_NSORT            ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_TAB_RECT_NSORT +IMMUTABLE ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_TAB_RECT_SSORT            ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_TAB_RECT_SSORT +IMMUTABLE ] = IsSSortPlistYes;
+    IsSSortListFuncs[ T_PLIST_TAB_RECT_NSORT            ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_TAB_RECT_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_TAB_RECT_SSORT            ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_TAB_RECT_SSORT +IMMUTABLE ] = AlwaysYes;
     IsSSortListFuncs[ T_PLIST_CYC                  ] = IsSSortPlistHom;
     IsSSortListFuncs[ T_PLIST_CYC       +IMMUTABLE ] = IsSSortPlistHom;
-    IsSSortListFuncs[ T_PLIST_CYC_NSORT            ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_CYC_NSORT +IMMUTABLE ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_CYC_SSORT            ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_CYC_SSORT +IMMUTABLE ] = IsSSortPlistYes;
+    IsSSortListFuncs[ T_PLIST_CYC_NSORT            ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_CYC_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_CYC_SSORT            ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_CYC_SSORT +IMMUTABLE ] = AlwaysYes;
     IsSSortListFuncs[ T_PLIST_FFE                  ] = IsSSortPlistHom;
     IsSSortListFuncs[ T_PLIST_FFE       +IMMUTABLE ] = IsSSortPlistHom;
 
@@ -4918,11 +4874,7 @@ static Int InitKernel (
     for ( t1 = T_PLIST; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
         MakeBagTypePublic(t1 +IMMUTABLE);
     }
-    
 
-
-      
-    
     /* return success                                                      */
     return 0;
 }

--- a/hpcgap/src/precord.c
+++ b/hpcgap/src/precord.c
@@ -61,6 +61,8 @@
 #include <src/hpc/tls.h>                /* thread-local storage */
 #include <src/hpc/aobjects.h>           /* thread-local storage */
 
+#include <src/util.h>
+
 
 /****************************************************************************
 **
@@ -108,46 +110,6 @@ void SetTypePRecToComObj( Obj rec, Obj kind )
   CHANGED_BAG(rec);
 }
 
-
-/****************************************************************************
-**
-*F  IsMutablePRecYes( <rec> ) . . . . . . mutability test for mutable records
-*F  IsMutablePRecNo( <rec> )  . . . . . mutability test for immutable records
-**
-**  'IsMutablePRecYes' simply returns 1.  'IsMutablePRecNo' simply returns 0.
-**  Note that we can decide from the type number whether  a record is mutable
-**  or immutable.
-**
-**  'IsMutablePRecYes'  is the function   in 'IsMutableObjFuncs'  for mutable
-**  records.   'IsMutablePRecNo' is  the function  in 'IsMutableObjFuncs' for
-**  immutable records.
-*/
-Int IsMutablePRecYes (
-    Obj                 rec )
-{
-    return 1;
-}
-
-Int IsMutablePRecNo (
-    Obj                 rec )
-{
-    return 0;
-}
-
-
-/****************************************************************************
-**
-*F  IsCopyablePRecYes( <rec> )  . . . . . . . .  copyability test for records
-**
-**  'IsCopyablePRec' simply returns 1.  Note that all records are copyable.
-**
-**  'IsCopyablePRec' is the function in 'IsCopyableObjFuncs' for records.
-*/
-Int IsCopyablePRecYes (
-    Obj                 rec )
-{
-    return 1;
-}
 
 /****************************************************************************
 **
@@ -1008,10 +970,10 @@ static Int InitKernel (
     UnbRecFuncs[ T_PREC +IMMUTABLE ] = UnbPRecImm;
 
     /* install mutability test                                             */
-    IsMutableObjFuncs[  T_PREC            ] = IsMutablePRecYes;
-    IsMutableObjFuncs[  T_PREC +IMMUTABLE ] = IsMutablePRecNo;
-    IsCopyableObjFuncs[ T_PREC            ] = IsCopyablePRecYes;
-    IsCopyableObjFuncs[ T_PREC +IMMUTABLE ] = IsCopyablePRecYes;
+    IsMutableObjFuncs[  T_PREC            ] = AlwaysYes;
+    IsMutableObjFuncs[  T_PREC +IMMUTABLE ] = AlwaysNo;
+    IsCopyableObjFuncs[ T_PREC            ] = AlwaysYes;
+    IsCopyableObjFuncs[ T_PREC +IMMUTABLE ] = AlwaysYes;
 
     /* install into copy function tables                                  */
     CopyObjFuncs [ T_PREC                     ] = CopyPRec;

--- a/hpcgap/src/scanner.c
+++ b/hpcgap/src/scanner.c
@@ -65,6 +65,8 @@
 #include <src/hpc/tls.h>
 #include <src/hpc/thread.h>
 
+#include <src/code.h>                   /* FilenameCache */
+
 #include <src/util.h>
 
 #include <assert.h>
@@ -2942,6 +2944,11 @@ Obj FuncSET_PRINT_FORMATTING_STDOUT(Obj self, Obj val) {
   else
     (STATE(OutputFiles)[1])->format = 1;
   return val;
+}
+
+Obj FuncGET_FILENAME_CACHE(Obj self)
+{
+  return CopyObj(FilenameCache, 1);
 }
 
 

--- a/src/blister.c
+++ b/src/blister.c
@@ -54,7 +54,7 @@
 **
 **  The  second  part  consists  of  the  functions  'LenBlist',  'ElmBlist',
 **  'ElmsBlist',   'AssBlist',    'AsssBlist',   'PosBlist',    'PlainBlist',
-**  'IsDenseBlist',  'IsPossBlist', 'EqBlist', and  'LtBlist'.  They  are the
+**  'IsPossBlist', 'EqBlist', and  'LtBlist'.  They  are the
 **  functions required by the  generic lists  package.  Using these functions
 **  the other parts of  the {\GAP} kernel can access and modify boolean lists
 **  without actually being aware that they are dealing with a boolean list.
@@ -102,6 +102,8 @@
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/tls.h>                /* thread-local storage */
+
+#include <src/util.h>
 
 
 /****************************************************************************
@@ -940,22 +942,6 @@ Int IsPossBlist (
 
 /****************************************************************************
 **
-
-*F  IsDenseBlist( <list> )  . . .  dense list test function for boolean lists
-**
-**  'IsDenseBlist' returns 1, since boolean lists are always dense.
-**
-**  'IsDenseBlist' is the function in 'IsDenseBlistFuncs' for boolean lists.
-*/
-Int IsDenseBlist (
-    Obj                 list )
-{
-    return 1L;
-}
-
-
-/****************************************************************************
-**
 *F  IsHomogBlist( <list> )  . . . . . . . . . . check if <list> is homogenous
 */
 Int IsHomogBlist (
@@ -986,28 +972,6 @@ Int IsSSortBlist (
     SET_FILT_LIST( list, (isSort ? FN_IS_SSORT : FN_IS_NSORT) );
 
     return isSort;
-}
-
-
-/****************************************************************************
-**
-*F  IsSSortBlistNot( <list> ) . . . . . . . . . . . . . unsorted boolean list
-*/
-Int IsSSortBlistNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-
-/****************************************************************************
-**
-*F  IsSSortBlistYes( <list> ) . . . . . . . . . . . . . . sorted boolean list
-*/
-Int IsSSortBlistYes (
-    Obj                 list )
-{
-    return 1L;
 }
 
 
@@ -2272,7 +2236,9 @@ Obj FuncSUBTR_BLIST (
         *ptr1++ &= ~ *ptr2++; 
       }
 
-    /* return nothing, this function is a procedure */ return 0; }
+    /* return nothing, this function is a procedure */
+    return 0;
+}
 
 /****************************************************************************
 **
@@ -2778,8 +2744,8 @@ static Int InitKernel (
         AssListFuncs    [ t1 +IMMUTABLE ] = AssBlistImm;
         AsssListFuncs   [ t1            ] = AsssListDefault;
         AsssListFuncs   [ t1 +IMMUTABLE ] = AsssBlistImm;
-        IsDenseListFuncs[ t1            ] = IsDenseBlist;
-        IsDenseListFuncs[ t1 +IMMUTABLE ] = IsDenseBlist;
+        IsDenseListFuncs[ t1            ] = AlwaysYes;
+        IsDenseListFuncs[ t1 +IMMUTABLE ] = AlwaysYes;
         IsHomogListFuncs[ t1            ] = IsHomogBlist;
         IsHomogListFuncs[ t1 +IMMUTABLE ] = IsHomogBlist;
         IsSSortListFuncs[ t1            ] = IsSSortBlist;
@@ -2792,10 +2758,10 @@ static Int InitKernel (
         PlainListFuncs  [ t1 +IMMUTABLE ] = PlainBlist;
         MakeImmutableObjFuncs [ t1      ] = MakeImmutableBlist;
     }
-    IsSSortListFuncs[ T_BLIST_NSORT            ] = IsSSortBlistNot;
-    IsSSortListFuncs[ T_BLIST_NSORT +IMMUTABLE ] = IsSSortBlistNot;
-    IsSSortListFuncs[ T_BLIST_SSORT            ] = IsSSortBlistYes;
-    IsSSortListFuncs[ T_BLIST_SSORT +IMMUTABLE ] = IsSSortBlistYes;
+    IsSSortListFuncs[ T_BLIST_NSORT            ] = AlwaysNo;
+    IsSSortListFuncs[ T_BLIST_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_BLIST_SSORT            ] = AlwaysYes;
+    IsSSortListFuncs[ T_BLIST_SSORT +IMMUTABLE ] = AlwaysYes;
 
     /* Import the types of blists: */
     ImportGVarFromLibrary( "TYPE_BLIST_MUT", &TYPE_BLIST_MUT );

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -62,6 +62,9 @@
 
 #include <src/compiler.h>               /* compiler */
 
+#include <src/util.h>
+
+
 Obj TYPE_ALIST;
 Obj TYPE_AREC;
 Obj TYPE_TLREC;
@@ -149,11 +152,6 @@ void SetTypeARecord(Obj obj, Obj kind)
   MEMBAR_WRITE();
 }
 
-
-static Int AlwaysMutable( Obj obj)
-{
-  return 1;
-}
 
 static void ArgumentError(char *message)
 {
@@ -1348,26 +1346,6 @@ static Obj FuncSetTLConstructor(Obj self, Obj record, Obj name, Obj function)
   return (Obj) 0;
 }
 
-static Int IsListAList(Obj list)
-{
-  return 1;
-}
-
-static Int IsSmallListAList(Obj list)
-{
-  return 1;
-}
-
-static Int IsRecNot(Obj obj)
-{
-  return 0;
-}
-
-static Int IsRecYes(Obj obj)
-{
-  return 1;
-}
-
 static Int LenListAList(Obj list)
 {
   MEMBAR_READ();
@@ -2006,9 +1984,9 @@ static Int InitKernel (
   PrintObjFuncs[ T_AREC ] = PrintAtomicRecord;
   PrintObjFuncs[ T_TLREC ] = PrintTLRecord;
   /* install mutability functions */
-  IsMutableObjFuncs [ T_ALIST ] = AlwaysMutable;
-  IsMutableObjFuncs [ T_FIXALIST ] = AlwaysMutable;
-  IsMutableObjFuncs [ T_AREC ] = AlwaysMutable;
+  IsMutableObjFuncs [ T_ALIST ] = AlwaysYes;
+  IsMutableObjFuncs [ T_FIXALIST ] = AlwaysYes;
+  IsMutableObjFuncs [ T_AREC ] = AlwaysYes;
   /* mutability for T_ACOMOBJ and T_APOSOBJ is set in objects.c */
   MakeBagTypePublic(T_ALIST);
   MakeBagTypePublic(T_FIXALIST);
@@ -2020,8 +1998,8 @@ static Int InitKernel (
   MakeBagTypePublic(T_TLREC_INNER);
   /* install list functions */
   /* install list functions */
-  IsListFuncs[T_FIXALIST] = IsListAList;
-  IsSmallListFuncs[T_FIXALIST] = IsSmallListAList;
+  IsListFuncs[T_FIXALIST] = AlwaysYes;
+  IsSmallListFuncs[T_FIXALIST] = AlwaysYes;
   LenListFuncs[T_FIXALIST] = LenListAList;
   LengthFuncs[T_FIXALIST] = LengthAList;
   Elm0ListFuncs[T_FIXALIST] = Elm0AList;
@@ -2034,8 +2012,8 @@ static Int InitKernel (
   IsbListFuncs[T_FIXALIST] = IsbAList;
   CopyObjFuncs[ T_FIXALIST ] = CopyAList;
   CleanObjFuncs[ T_FIXALIST ] = CleanAList;
-  IsListFuncs[T_ALIST] = IsListAList;
-  IsSmallListFuncs[T_ALIST] = IsSmallListAList;
+  IsListFuncs[T_ALIST] = AlwaysYes;
+  IsSmallListFuncs[T_ALIST] = AlwaysYes;
   LenListFuncs[T_ALIST] = LenListAList;
   LengthFuncs[T_ALIST] = LengthAList;
   Elm0ListFuncs[T_ALIST] = Elm0AList;
@@ -2058,15 +2036,15 @@ static Int InitKernel (
   CopyObjFuncs[ T_AREC ] = CopyARecord;
   ShallowCopyObjFuncs[ T_AREC ] = ShallowCopyARecord;
   CleanObjFuncs[ T_AREC ] = CleanARecord;
-  IsRecFuncs[ T_AREC ] = IsRecYes;
+  IsRecFuncs[ T_AREC ] = AlwaysYes;
   UnbRecFuncs[ T_AREC ] = UnbARecord;
   CopyObjFuncs[ T_ACOMOBJ ] = CopyARecord;
   CleanObjFuncs[ T_ACOMOBJ ] = CleanARecord;
-  IsRecFuncs[ T_ACOMOBJ ] = IsRecNot;
+  IsRecFuncs[ T_ACOMOBJ ] = AlwaysNo;
   ElmRecFuncs[ T_TLREC ] = ElmTLRecord;
   IsbRecFuncs[ T_TLREC ] = IsbTLRecord;
   AssRecFuncs[ T_TLREC ] = AssTLRecord;
-  IsRecFuncs[ T_TLREC ] = IsRecYes;
+  IsRecFuncs[ T_TLREC ] = AlwaysYes;
   UnbRecFuncs[ T_TLREC ] = UnbTLRecord;
   /* return success                                                      */
   return 0;

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -65,6 +65,9 @@
 
 #include <src/compiler.h>               /* compiler */
 
+#include <src/util.h>
+
+
 struct WaitList {
   struct WaitList *prev;
   struct WaitList *next;
@@ -1374,16 +1377,6 @@ Obj TypeRegion(Obj obj)
   return TYPE_REGION;
 }
 
-static Int AlwaysMutable( Obj obj)
-{
-  return 1;
-}
-
-static Int NeverMutable(Obj obj)
-{
-  return 0;
-}
-
 #ifndef BOEHM_GC
 static void MarkSemaphoreBag(Bag);
 static void MarkChannelBag(Bag);
@@ -1460,12 +1453,12 @@ static Int InitKernel (
     PrintObjFuncs[ T_SYNCVAR ] = PrintSyncVar;
     PrintObjFuncs[ T_REGION ] = PrintRegion;
     /* install mutability functions */
-    IsMutableObjFuncs [ T_THREAD ] = NeverMutable;
-    IsMutableObjFuncs [ T_SEMAPHORE ] = AlwaysMutable;
-    IsMutableObjFuncs [ T_CHANNEL ] = AlwaysMutable;
-    IsMutableObjFuncs [ T_BARRIER ] = AlwaysMutable;
-    IsMutableObjFuncs [ T_SYNCVAR ] = AlwaysMutable;
-    IsMutableObjFuncs [ T_REGION ] = AlwaysMutable;
+    IsMutableObjFuncs [ T_THREAD ] = AlwaysNo;
+    IsMutableObjFuncs [ T_SEMAPHORE ] = AlwaysYes;
+    IsMutableObjFuncs [ T_CHANNEL ] = AlwaysYes;
+    IsMutableObjFuncs [ T_BARRIER ] = AlwaysYes;
+    IsMutableObjFuncs [ T_SYNCVAR ] = AlwaysYes;
+    IsMutableObjFuncs [ T_REGION ] = AlwaysYes;
     MakeBagTypePublic(T_THREAD);
     MakeBagTypePublic(T_SEMAPHORE);
     MakeBagTypePublic(T_CHANNEL);

--- a/src/lists.c
+++ b/src/lists.c
@@ -54,6 +54,7 @@
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/tls.h>                /* thread-local storage */
 
+#include <src/util.h>
 
 
 /****************************************************************************
@@ -77,18 +78,6 @@ Obj             FuncIS_LIST (
     Obj                 obj )
 {
     return (IS_LIST( obj ) ? True : False);
-}
-
-Int             IsListNot (
-    Obj                 obj )
-{
-    return 0L;
-}
-
-Int             IsListYes (
-    Obj                 obj )
-{
-    return 1L;
 }
 
 Int             IsListObject (
@@ -135,18 +124,6 @@ Obj             IsSmallListFilt;
 Obj             HasIsSmallListFilt;
 Obj             LengthAttr;
 Obj             SetIsSmallList;
-
-Int             IsSmallListNot (
-    Obj                 obj )
-{
-    return 0L;
-}
-
-Int             IsSmallListYes (
-    Obj                 obj )
-{
-    return 1L;
-}
 
 Int             IsSmallListObject (
     Obj                 obj )
@@ -1132,12 +1109,11 @@ Obj FuncASSS_LIST_DEFAULT (
 **
 *F  IS_DENSE_LIST(<list>) . . . . . . . . . . . . . . .  test for dense lists
 *V  IsDenseListFuncs[<type>]  . . . . . . table for dense list test functions
-*F  IsDenseListNot(<list>)  . . . . .  dense list test function for non lists
 **
 **  'IS_DENSE_LIST'  only     calls   the      function   pointed    to    by
 **  'IsDenseListFuncs[<type>]', passing <list> as argument.  If <type> is not
 **  the   type  of  a    list,  then  'IsDenseListFuncs[<type>]'  points   to
-**  'IsDenseListNot', which just returns 0.
+**  'AlwaysNo', which just returns 0.
 **
 **  'IS_DENSE_LIST'  is defined in the declaration  part  of this  package as
 **  follows
@@ -1154,18 +1130,6 @@ Obj             FuncIS_DENSE_LIST (
     Obj                 obj )
 {
     return (IS_DENSE_LIST( obj ) ? True : False);
-}
-
-Int             IsDenseListNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsDenseListYes (
-    Obj                 list )
-{
-    return 1L;
 }
 
 Int             IsDenseListDefault (
@@ -1204,12 +1168,11 @@ Int             IsDenseListObject (
 **
 *F  IS_HOMOG_LIST(<list>) . . . . . . . . . . . .  test for homogeneous lists
 *V  IsHomogListFuncs[<type>]  . . . table for homogeneous list test functions
-*F  IsHomogListNot(<list>)  . .  homogeneous list test function for non lists
 **
 **  'IS_HOMOG_LIST' only calls the function pointed to by
 **  'IsHomogListFuncs[<type>]', passing <list> as argument.  If <type> is not
 **  the type of a list, then 'IsHomogListFuncs[<type>]' points to
-**  'IsHomogListNot', which just returns 0.
+**  'AlwaysNo', which just returns 0.
 **
 **  'IS_HOMOG_LIST' is defined in the declaration part  of  this  package  as
 **  follows
@@ -1226,18 +1189,6 @@ Obj             FuncIS_HOMOG_LIST (
     Obj                 obj )
 {
     return (IS_HOMOG_LIST( obj ) ? True : False);
-}
-
-Int             IsHomogListNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsHomogListYes (
-    Obj                 list )
-{
-    return 1L;
 }
 
 Int             IsHomogListDefault (
@@ -1286,12 +1237,11 @@ Int             IsHomogListObject (
 **
 *F  IS_TABLE_LIST(<list>) . . . . . . . . . . . . . . .  test for table lists
 *V  IsTableListFuncs[<type>]  . . . . . . table for table list test functions
-*F  IsTableListNot(<list>)  . . . . .  table list test function for non lists
 **
 **  'IS_TABLE_LIST' only calls the function pointed to by
 **  'IsTableListFuncs[<type>]', passing <list> as argument.  If <type> is not
 **  the type of a list, then 'IsTableListFuncs[<type>]' points to
-**  'IsTableListNot', which just returns 0.
+**  'AlwaysNo', which just returns 0.
 **
 **  'IS_TABLE_LIST' is defined in the declaration part  of  this  package  as
 **  follows
@@ -1308,18 +1258,6 @@ Obj             Func_IS_TABLE_LIST (
     Obj                 obj )
 {
     return (IS_TABLE_LIST( obj ) ? True : False);
-}
-
-Int             IsTableListNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsTableListYes (
-    Obj                 list )
-{
-    return 1L;
 }
 
 Int             IsTableListDefault (
@@ -1376,12 +1314,11 @@ Int             IsTableListObject (
 **
 *F  IS_SSORT_LIST( <list> ) . . . . . . . . .  test for strictly sorted lists
 *V  IsSSortListFuncs[<type>]  .  table of strictly sorted list test functions
-*F  IsSSortListNot( <list> ) strictly sorted list test function for non lists
 **
 **  'IS_SSORT_LIST' only calls the function pointed to by
 **  'IsSSortListFuncs[<type>]', passing <list> as argument.
 **  If <type> is not the type of a list, then 'IsSSortListFuncs[<type>]'
-**  points to 'IsSSortListNot', which just returns 0.
+**  points to 'AlwaysNo', which just returns 0.
 **
 **  'IS_SSORTED_LIST'  is defined in the  declaration part of this package as
 **  follows
@@ -1398,18 +1335,6 @@ Obj FuncIS_SSORT_LIST (
     Obj                 obj )
 {
     return (IS_SSORT_LIST( obj ) ? True : False);
-}
-
-Int IsSSortListNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int IsSSortListYes (
-    Obj                 list )
-{
-    return 1L;
 }
 
 Int IsSSortListDefault (
@@ -1483,7 +1408,6 @@ Obj FuncIS_NSORT_LIST (
 **
 *F  IS_POSS_LIST(<list>)  . . . . . . . . . . . . .  test for positions lists
 *V  IsPossListFuncs[<type>] . . . . . . table of positions list test function
-*F  IsPossListNot(<list>) . . . .  positions list test function for non lists
 **
 **  'IS_POSS_LIST'     only   calls    the     function  pointed      to   by
 **  'IsPossListFuncs[<type>]', passing <list> as  argument.  If <type> is not
@@ -1505,18 +1429,6 @@ Obj             FuncIS_POSS_LIST (
     Obj                 obj )
 {
     return (IS_POSS_LIST(obj) ? True : False);
-}
-
-Int             IsPossListNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsPossListYes (
-    Obj                 list )
-{
-    return 1L;
 }
 
 Int             IsPossListDefault (
@@ -2084,47 +1996,6 @@ Obj             TYPES_LIST_FAM (
 
 /****************************************************************************
 **
-*F  IsMutableListYes(<list>)  . . . . . . . mutability test for mutable lists
-*F  IsMutableListNo(<list>) . . . . . . . mutability test for immutable lists
-**
-**  'IsMutableListYes' simply returns 1.  'IsMutableListNo' simply returns 0.
-**  Note that we can decide from the type number whether a list is mutable or
-**  immutable.
-**
-**  'IsMutableListYes' is  the function  in 'IsMutableObjFuncs'   for mutable
-**  lists.   'IsMutableListNo'  is  the function  in 'IsMutableObjFuncs'  for
-**  immutable lists.
-*/
-Int             IsMutableListNo (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsMutableListYes (
-    Obj                 list )
-{
-    return 1L;
-}
-
-
-/****************************************************************************
-**
-*F  IsCopyableListYes(<list>) . . . . . . . . . .  copyability test for lists
-**
-**  'IsCopyableListYes' simply returns 1.  Note that all lists are copyable.
-**
-**  'IsCopyableListYes' is the function in 'IsCopyableObjFuncs' for lists.
-*/
-Int             IsCopyableListYes (
-    Obj                     list )
-{
-    return 1;
-}
-
-
-/****************************************************************************
-**
 *F  PrintListDefault(<list>)  . . . . . . . . . . . . . . . . .  print a list
 *F  PrintPathList(<list>,<indx>)  . . . . . . . . . . . . . print a list path
 **
@@ -2541,10 +2412,10 @@ static Int InitKernel (
 
     /* make and install the 'IS_LIST' filter                               */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        IsListFuncs[ type ] = IsListNot;
+        IsListFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
-        IsListFuncs[ type ] = IsListYes;
+        IsListFuncs[ type ] = AlwaysYes;
     }
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         IsListFuncs[ type ] = IsListObject;
@@ -2553,11 +2424,11 @@ static Int InitKernel (
     /* make and install the 'IS_SMALL_LIST' filter                   */
     /* non-lists are not small lists */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        IsSmallListFuncs[ type ] = IsSmallListNot;
+        IsSmallListFuncs[ type ] = AlwaysNo;
     }
     /* internal lists ARE small lists */
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
-        IsSmallListFuncs[ type ] = IsSmallListYes;
+        IsSmallListFuncs[ type ] = AlwaysYes;
     }
     /* external lists need to be asked */
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
@@ -2669,7 +2540,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_DENSE_LIST' filter                         */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        IsDenseListFuncs[ type ] = IsDenseListNot;
+        IsDenseListFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
         IsDenseListFuncs[ type ] = IsDenseListDefault;
@@ -2681,7 +2552,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_HOMOG_LIST' filter                         */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        IsHomogListFuncs[ type ] = IsHomogListNot;
+        IsHomogListFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
         IsHomogListFuncs[ type ] = IsHomogListDefault;
@@ -2693,7 +2564,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_TABLE_LIST' filter                         */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        IsTableListFuncs[ type ] = IsTableListNot;
+        IsTableListFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
         IsTableListFuncs[ type ] = IsTableListDefault;
@@ -2705,7 +2576,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_SSORT_LIST' property                       */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        IsSSortListFuncs[ type ] = IsSSortListNot;
+        IsSSortListFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
         IsSSortListFuncs[ type ] = IsSSortListDefault;
@@ -2717,7 +2588,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_POSS_LIST' property                        */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        IsPossListFuncs[ type ] = IsPossListNot;
+        IsPossListFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
         IsPossListFuncs[ type ] = IsPossListDefault;
@@ -2747,10 +2618,10 @@ static Int InitKernel (
 
     /* install the generic mutability test function                        */
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type += 2 ) {
-        IsMutableObjFuncs[  type           ] = IsMutableListYes;
-        IsMutableObjFuncs[  type+IMMUTABLE ] = IsMutableListNo;
-        IsCopyableObjFuncs[ type           ] = IsCopyableListYes;
-        IsCopyableObjFuncs[ type+IMMUTABLE ] = IsCopyableListYes;
+        IsMutableObjFuncs[  type           ] = AlwaysYes;
+        IsMutableObjFuncs[  type+IMMUTABLE ] = AlwaysNo;
+        IsCopyableObjFuncs[ type           ] = AlwaysYes;
+        IsCopyableObjFuncs[ type+IMMUTABLE ] = AlwaysYes;
     }
 
     /* install the default printers                                        */

--- a/src/objects.c
+++ b/src/objects.c
@@ -47,6 +47,8 @@
 //#include <src/hpc/traverse.h>            /* object traversal                */
 #include <src/hpc/tls.h>                /* thread-local storage */
 
+#include <src/util.h>
+
 
 static Int lastFreePackageTNUM = FIRST_PACKAGE_TNUM;
 
@@ -155,12 +157,6 @@ Int IsMutableObjError (
     return 0;
 }
 
-Int IsMutableObjNot (
-    Obj                 obj )
-{
-    return 0L;
-}
-
 Int IsMutableObjObject (
     Obj                 obj )
 {
@@ -199,12 +195,6 @@ Int IsCopyableObjError (
     ErrorQuit(
         "Panic: tried to test copyability of unknown type '%d'",
         (Int)TNUM_OBJ(obj), 0L );
-    return 0L;
-}
-
-Int IsCopyableObjNot (
-    Obj                 obj )
-{
     return 0L;
 }
 
@@ -1719,7 +1709,7 @@ static Int InitKernel (
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ )
         IsMutableObjFuncs[ t ] = IsMutableObjError;
     for ( t = FIRST_CONSTANT_TNUM; t <= LAST_CONSTANT_TNUM; t++ )
-        IsMutableObjFuncs[ t ] = IsMutableObjNot;
+        IsMutableObjFuncs[ t ] = AlwaysNo;
     for ( t = FIRST_EXTERNAL_TNUM; t <= LAST_EXTERNAL_TNUM; t++ )
         IsMutableObjFuncs[ t ] = IsMutableObjObject;
 
@@ -1727,7 +1717,7 @@ static Int InitKernel (
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ )
         IsCopyableObjFuncs[ t ] = IsCopyableObjError;
     for ( t = FIRST_CONSTANT_TNUM; t <= LAST_CONSTANT_TNUM; t++ )
-        IsCopyableObjFuncs[ t ] = IsCopyableObjNot;
+        IsCopyableObjFuncs[ t ] = AlwaysNo;
     for ( t = FIRST_EXTERNAL_TNUM; t <= LAST_EXTERNAL_TNUM; t++ )
         IsCopyableObjFuncs[ t ] = IsCopyableObjObject;
 
@@ -1852,7 +1842,6 @@ static Int InitLibrary (
 
     AssGVar(GVarName("LAST_IMM_MUT_TNUM"), INTOBJ_INT(LAST_IMM_MUT_TNUM));
     MakeReadOnlyGVar(GVarName("LAST_IMM_MUT_TNUM"));
-    
 
     /* return success                                                      */
     return 0;

--- a/src/objset.c
+++ b/src/objset.c
@@ -32,16 +32,10 @@
 
 #include <src/hpc/tls.h>
 
+#include <src/util.h>
+
 Obj TYPE_OBJSET;
 Obj TYPE_OBJMAP;
-
-static Int AlwaysMutable(Obj obj) {
-  return 1;
-}
-
-static Int NeverMutable(Obj obj) {
-  return 0;
-}
 
 static Obj TypeObjSet(Obj obj) {
   return TYPE_OBJSET;
@@ -968,10 +962,10 @@ static Int InitKernel (
   PrintObjFuncs[ T_OBJMAP ] = PrintObjMap;
   PrintObjFuncs[ T_OBJMAP+IMMUTABLE ] = PrintObjMap;
   /* install mutability functions */
-  IsMutableObjFuncs [ T_OBJSET ] = AlwaysMutable;
-  IsMutableObjFuncs [ T_OBJSET+IMMUTABLE ] = NeverMutable;
-  IsMutableObjFuncs [ T_OBJMAP ] = AlwaysMutable;
-  IsMutableObjFuncs [ T_OBJMAP+IMMUTABLE ] = NeverMutable;
+  IsMutableObjFuncs [ T_OBJSET ] = AlwaysYes;
+  IsMutableObjFuncs [ T_OBJSET+IMMUTABLE ] = AlwaysNo;
+  IsMutableObjFuncs [ T_OBJMAP ] = AlwaysYes;
+  IsMutableObjFuncs [ T_OBJMAP+IMMUTABLE ] = AlwaysNo;
   /* return success                                                      */
   return 0;
 }

--- a/src/plist.c
+++ b/src/plist.c
@@ -70,7 +70,11 @@
 #include <src/hpc/thread.h>
 #include <src/hpc/tls.h>
 
+#include <src/util.h>
+
 #include <assert.h>
+
+
 /****************************************************************************
 **
 
@@ -2096,18 +2100,6 @@ Int             IsDensePlist (
     return 1L;
 }
 
-Int             IsDensePlistNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsDensePlistYes (
-    Obj                 list )
-{
-    return 1L;
-}
-
 
 /****************************************************************************
 **
@@ -2126,18 +2118,6 @@ Int             IsHomogPlist (
     return (T_PLIST_HOM <= tnum);
 }
 
-Int             IsHomogPlistNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsHomogPlistYes (
-    Obj                 list )
-{
-    return 1L;
-}
-
 
 /****************************************************************************
 **
@@ -2154,18 +2134,6 @@ Int             IsTablePlist (
     Int                 tnum;
     tnum = KTNumPlist( list, (Obj *)0 );
     return (T_PLIST_TAB <= tnum && tnum <= T_PLIST_TAB_RECT_SSORT);
-}
-
-Int             IsTablePlistNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsTablePlistYes (
-    Obj                 list )
-{
-    return 1L;
 }
 
 
@@ -2362,18 +2330,6 @@ Int             IsSSortPlistHom (
 
 }
 
-
-Int             IsSSortPlistNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int             IsSSortPlistYes (
-    Obj                 list )
-{
-    return 2L;
-}
 
 Obj FuncSetIsSSortedPlist (Obj self, Obj list)
 {
@@ -4710,117 +4666,117 @@ static Int InitKernel (
     /* install the dense list test methods                                 */
     IsDenseListFuncs[ T_PLIST                   ] = IsDensePlist;
     IsDenseListFuncs[ T_PLIST        +IMMUTABLE ] = IsDensePlist;
-    IsDenseListFuncs[ T_PLIST_NDENSE            ] = IsDensePlistNot;
-    IsDenseListFuncs[ T_PLIST_NDENSE +IMMUTABLE ] = IsDensePlistNot;
+    IsDenseListFuncs[ T_PLIST_NDENSE            ] = AlwaysNo;
+    IsDenseListFuncs[ T_PLIST_NDENSE +IMMUTABLE ] = AlwaysNo;
     for ( t1 = T_PLIST_DENSE; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
-        IsDenseListFuncs[ t1            ] = IsDensePlistYes;
-        IsDenseListFuncs[ t1 +IMMUTABLE ] = IsDensePlistYes;
+        IsDenseListFuncs[ t1            ] = AlwaysYes;
+        IsDenseListFuncs[ t1 +IMMUTABLE ] = AlwaysYes;
     }
 
 
     /* install the homogeneous list test methods                           */
     IsHomogListFuncs[ T_PLIST                       ] = IsHomogPlist;
     IsHomogListFuncs[ T_PLIST            +IMMUTABLE ] = IsHomogPlist;
-    IsHomogListFuncs[ T_PLIST_NDENSE                ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_NDENSE     +IMMUTABLE ] = IsHomogPlistNot;
+    IsHomogListFuncs[ T_PLIST_NDENSE                ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_NDENSE     +IMMUTABLE ] = AlwaysNo;
     IsHomogListFuncs[ T_PLIST_DENSE                 ] = IsHomogPlist;
     IsHomogListFuncs[ T_PLIST_DENSE      +IMMUTABLE ] = IsHomogPlist;
-    IsHomogListFuncs[ T_PLIST_DENSE_NHOM            ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_DENSE_NHOM +IMMUTABLE ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_SSORT      ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_SSORT+IMMUTABLE ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_NSORT      ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE ] = IsHomogPlistNot;
-    IsHomogListFuncs[ T_PLIST_EMPTY                 ] = IsHomogPlistYes;
-    IsHomogListFuncs[ T_PLIST_EMPTY      +IMMUTABLE ] = IsHomogPlistYes;
+    IsHomogListFuncs[ T_PLIST_DENSE_NHOM            ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_DENSE_NHOM +IMMUTABLE ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_SSORT      ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_SSORT+IMMUTABLE ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_NSORT      ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsHomogListFuncs[ T_PLIST_EMPTY                 ] = AlwaysYes;
+    IsHomogListFuncs[ T_PLIST_EMPTY      +IMMUTABLE ] = AlwaysYes;
     for ( t1 = T_PLIST_HOM; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
-        IsHomogListFuncs[ t1            ] = IsHomogPlistYes;
-        IsHomogListFuncs[ t1 +IMMUTABLE ] = IsHomogPlistYes;
+        IsHomogListFuncs[ t1            ] = AlwaysYes;
+        IsHomogListFuncs[ t1 +IMMUTABLE ] = AlwaysYes;
     }
 
 
     /* install the equal length list test methods                          */
     IsTableListFuncs[ T_PLIST                       ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST            +IMMUTABLE ] = IsTablePlist;
-    IsTableListFuncs[ T_PLIST_NDENSE                ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_NDENSE     +IMMUTABLE ] = IsTablePlistNot;
+    IsTableListFuncs[ T_PLIST_NDENSE                ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_NDENSE     +IMMUTABLE ] = AlwaysNo;
     IsTableListFuncs[ T_PLIST_DENSE                 ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST_DENSE      +IMMUTABLE ] = IsTablePlist;
-    IsTableListFuncs[ T_PLIST_DENSE_NHOM            ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_DENSE_NHOM +IMMUTABLE ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_DENSE_NHOM_SSORT      ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_DENSE_NHOM_SSORT +IMMUTABLE ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_DENSE_NHOM_NSORT      ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_EMPTY                 ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_EMPTY      +IMMUTABLE ] = IsTablePlistNot;
+    IsTableListFuncs[ T_PLIST_DENSE_NHOM            ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_DENSE_NHOM +IMMUTABLE ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_DENSE_NHOM_SSORT      ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_DENSE_NHOM_SSORT +IMMUTABLE ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_DENSE_NHOM_NSORT      ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_EMPTY                 ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_EMPTY      +IMMUTABLE ] = AlwaysNo;
     IsTableListFuncs[ T_PLIST_HOM                   ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST_HOM        +IMMUTABLE ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST_HOM_NSORT             ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST_HOM_NSORT  +IMMUTABLE ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST_HOM_SSORT             ] = IsTablePlist;
     IsTableListFuncs[ T_PLIST_HOM_SSORT  +IMMUTABLE ] = IsTablePlist;
-    IsTableListFuncs[ T_PLIST_TAB                   ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB        +IMMUTABLE ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_NSORT             ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_NSORT  +IMMUTABLE ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_SSORT             ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_SSORT  +IMMUTABLE ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_RECT                   ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_RECT        +IMMUTABLE ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_RECT_NSORT             ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_RECT_NSORT  +IMMUTABLE ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_RECT_SSORT             ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_TAB_RECT_SSORT  +IMMUTABLE ] = IsTablePlistYes;
-    IsTableListFuncs[ T_PLIST_CYC                   ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_CYC        +IMMUTABLE ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_CYC_NSORT             ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_CYC_NSORT  +IMMUTABLE ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_CYC_SSORT             ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_CYC_SSORT  +IMMUTABLE ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_FFE                   ] = IsTablePlistNot;
-    IsTableListFuncs[ T_PLIST_FFE        +IMMUTABLE ] = IsTablePlistNot;
+    IsTableListFuncs[ T_PLIST_TAB                   ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB        +IMMUTABLE ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_NSORT             ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_NSORT  +IMMUTABLE ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_SSORT             ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_SSORT  +IMMUTABLE ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_RECT                   ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_RECT        +IMMUTABLE ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_RECT_NSORT             ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_RECT_NSORT  +IMMUTABLE ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_RECT_SSORT             ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_TAB_RECT_SSORT  +IMMUTABLE ] = AlwaysYes;
+    IsTableListFuncs[ T_PLIST_CYC                   ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_CYC        +IMMUTABLE ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_CYC_NSORT             ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_CYC_NSORT  +IMMUTABLE ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_CYC_SSORT             ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_CYC_SSORT  +IMMUTABLE ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_FFE                   ] = AlwaysNo;
+    IsTableListFuncs[ T_PLIST_FFE        +IMMUTABLE ] = AlwaysNo;
 
 
     /* install the strictly sorted list test methods                       */
     IsSSortListFuncs[ T_PLIST                      ] = IsSSortPlist;
     IsSSortListFuncs[ T_PLIST           +IMMUTABLE ] = IsSSortPlist;
-    IsSSortListFuncs[ T_PLIST_NDENSE               ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_NDENSE    +IMMUTABLE ] = IsSSortPlistNot;
+    IsSSortListFuncs[ T_PLIST_NDENSE               ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_NDENSE    +IMMUTABLE ] = AlwaysNo;
     IsSSortListFuncs[ T_PLIST_DENSE                ] = IsSSortPlistDense;
     IsSSortListFuncs[ T_PLIST_DENSE     +IMMUTABLE ] = IsSSortPlistDense;
     IsSSortListFuncs[ T_PLIST_DENSE_NHOM           ] = IsSSortPlistDense;
     IsSSortListFuncs[ T_PLIST_DENSE_NHOM+IMMUTABLE ] = IsSSortPlistDense;
-    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_SSORT     ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_SSORT+IMMUTABLE ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_NSORT     ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_NSORT+IMMUTABLE ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_EMPTY                ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_EMPTY     +IMMUTABLE ] = IsSSortPlistYes;
+    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_SSORT     ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_SSORT+IMMUTABLE ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_NSORT     ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_DENSE_NHOM_NSORT+IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_EMPTY                ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_EMPTY     +IMMUTABLE ] = AlwaysYes;
     IsSSortListFuncs[ T_PLIST_HOM                  ] = IsSSortPlistHom;
     IsSSortListFuncs[ T_PLIST_HOM       +IMMUTABLE ] = IsSSortPlistHom;
-    IsSSortListFuncs[ T_PLIST_HOM_NSORT            ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_HOM_NSORT +IMMUTABLE ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_HOM_SSORT            ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_HOM_SSORT +IMMUTABLE ] = IsSSortPlistYes;
+    IsSSortListFuncs[ T_PLIST_HOM_NSORT            ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_HOM_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_HOM_SSORT            ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_HOM_SSORT +IMMUTABLE ] = AlwaysYes;
     IsSSortListFuncs[ T_PLIST_TAB                  ] = IsSSortPlistHom;
     IsSSortListFuncs[ T_PLIST_TAB       +IMMUTABLE ] = IsSSortPlistHom;
-    IsSSortListFuncs[ T_PLIST_TAB_NSORT            ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_TAB_NSORT +IMMUTABLE ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_TAB_SSORT            ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_TAB_SSORT +IMMUTABLE ] = IsSSortPlistYes;
+    IsSSortListFuncs[ T_PLIST_TAB_NSORT            ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_TAB_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_TAB_SSORT            ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_TAB_SSORT +IMMUTABLE ] = AlwaysYes;
     IsSSortListFuncs[ T_PLIST_TAB_RECT                  ] = IsSSortPlistHom;
     IsSSortListFuncs[ T_PLIST_TAB_RECT       +IMMUTABLE ] = IsSSortPlistHom;
-    IsSSortListFuncs[ T_PLIST_TAB_RECT_NSORT            ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_TAB_RECT_NSORT +IMMUTABLE ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_TAB_RECT_SSORT            ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_TAB_RECT_SSORT +IMMUTABLE ] = IsSSortPlistYes;
+    IsSSortListFuncs[ T_PLIST_TAB_RECT_NSORT            ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_TAB_RECT_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_TAB_RECT_SSORT            ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_TAB_RECT_SSORT +IMMUTABLE ] = AlwaysYes;
     IsSSortListFuncs[ T_PLIST_CYC                  ] = IsSSortPlistHom;
     IsSSortListFuncs[ T_PLIST_CYC       +IMMUTABLE ] = IsSSortPlistHom;
-    IsSSortListFuncs[ T_PLIST_CYC_NSORT            ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_CYC_NSORT +IMMUTABLE ] = IsSSortPlistNot;
-    IsSSortListFuncs[ T_PLIST_CYC_SSORT            ] = IsSSortPlistYes;
-    IsSSortListFuncs[ T_PLIST_CYC_SSORT +IMMUTABLE ] = IsSSortPlistYes;
+    IsSSortListFuncs[ T_PLIST_CYC_NSORT            ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_CYC_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_PLIST_CYC_SSORT            ] = AlwaysYes;
+    IsSSortListFuncs[ T_PLIST_CYC_SSORT +IMMUTABLE ] = AlwaysYes;
     IsSSortListFuncs[ T_PLIST_FFE                  ] = IsSSortPlistHom;
     IsSSortListFuncs[ T_PLIST_FFE       +IMMUTABLE ] = IsSSortPlistHom;
 
@@ -4868,10 +4824,6 @@ static Int InitKernel (
 
     /* mutable tables may have mutable rows */
       MakeImmutableObjFuncs[T_PLIST_TAB] = MakeImmutablePlistInHom;
-    
-
-
-      
     
     /* return success                                                      */
     return 0;

--- a/src/precord.c
+++ b/src/precord.c
@@ -61,6 +61,8 @@
 #include <src/hpc/tls.h>                /* thread-local storage */
 #include <src/hpc/aobjects.h>           /* thread-local storage */
 
+#include <src/util.h>
+
 
 /****************************************************************************
 **
@@ -95,46 +97,6 @@ Obj TypePRecImm (
     return TYPE_PREC_IMMUTABLE;
 }
 
-
-/****************************************************************************
-**
-*F  IsMutablePRecYes( <rec> ) . . . . . . mutability test for mutable records
-*F  IsMutablePRecNo( <rec> )  . . . . . mutability test for immutable records
-**
-**  'IsMutablePRecYes' simply returns 1.  'IsMutablePRecNo' simply returns 0.
-**  Note that we can decide from the type number whether  a record is mutable
-**  or immutable.
-**
-**  'IsMutablePRecYes'  is the function   in 'IsMutableObjFuncs'  for mutable
-**  records.   'IsMutablePRecNo' is  the function  in 'IsMutableObjFuncs' for
-**  immutable records.
-*/
-Int IsMutablePRecYes (
-    Obj                 rec )
-{
-    return 1;
-}
-
-Int IsMutablePRecNo (
-    Obj                 rec )
-{
-    return 0;
-}
-
-
-/****************************************************************************
-**
-*F  IsCopyablePRecYes( <rec> )  . . . . . . . .  copyability test for records
-**
-**  'IsCopyablePRec' simply returns 1.  Note that all records are copyable.
-**
-**  'IsCopyablePRec' is the function in 'IsCopyableObjFuncs' for records.
-*/
-Int IsCopyablePRecYes (
-    Obj                 rec )
-{
-    return 1;
-}
 
 /****************************************************************************
 **
@@ -982,10 +944,10 @@ static Int InitKernel (
     UnbRecFuncs[ T_PREC +IMMUTABLE ] = UnbPRecImm;
 
     /* install mutability test                                             */
-    IsMutableObjFuncs[  T_PREC            ] = IsMutablePRecYes;
-    IsMutableObjFuncs[  T_PREC +IMMUTABLE ] = IsMutablePRecNo;
-    IsCopyableObjFuncs[ T_PREC            ] = IsCopyablePRecYes;
-    IsCopyableObjFuncs[ T_PREC +IMMUTABLE ] = IsCopyablePRecYes;
+    IsMutableObjFuncs[  T_PREC            ] = AlwaysYes;
+    IsMutableObjFuncs[  T_PREC +IMMUTABLE ] = AlwaysNo;
+    IsCopyableObjFuncs[ T_PREC            ] = AlwaysYes;
+    IsCopyableObjFuncs[ T_PREC +IMMUTABLE ] = AlwaysYes;
 
     /* install into copy function tables                                  */
     CopyObjFuncs [ T_PREC                     ] = CopyPRec;

--- a/src/range.c
+++ b/src/range.c
@@ -42,7 +42,7 @@
 **
 **  The  second part  consists  of   the functions  'LenRange',   'ElmRange',
 **  'ElmsRange',   'AssRange',      'AsssRange',   'PosRange',  'PlainRange',
-**  'IsDenseRange',   'IsPossRange', 'PrintRange', 'EqRange', and  'LtRange'.
+**  'IsPossRange', 'PrintRange', 'EqRange', and  'LtRange'.
 **  They  are the  functions required by  the generic   lists package.  Using
 **  these functions the other parts of the {\GAP} kernel can access or modify
 **  ranges without actually being aware that they are dealing with a range.
@@ -81,6 +81,8 @@
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/tls.h>                /* thread-local storage */
+
+#include <src/util.h>
 
 
 /****************************************************************************
@@ -765,49 +767,6 @@ void            AsssRangeImm (
         "Lists Assignments: <list> must be a mutable list",
         0L, 0L,
         "you can 'return;' and ignore the assignment" );
-}
-
-
-/****************************************************************************
-**
-*F  IsDenseRange(<list>)  . . . . . . . . dense list test function for ranges
-**
-**  'IsDenseRange' returns 1, since ranges are always dense.
-**
-**  'IsDenseRange' is the function in 'IsDenseListFuncs' for ranges.
-*/
-Int             IsDenseRange (
-    Obj                 list )
-{
-    return 1;
-}
-
-
-/****************************************************************************
-**
-*F  IsHomogRange(<list>)
-*/
-Int             IsHomogRange (
-    Obj                 list )
-{
-    return 1;
-}
-
-
-/****************************************************************************
-**
-*F  IsSSortRange(<list>)
-*/
-Int             IsSSortRangeNot (
-    Obj                 list )
-{
-    return 0;
-}
-
-Int             IsSSortRangeYes (
-    Obj                 list )
-{
-    return 1;
 }
 
 
@@ -1722,18 +1681,18 @@ static Int InitKernel (
     AsssListFuncs   [ T_RANGE_NSORT +IMMUTABLE ] = AsssRangeImm;
     AsssListFuncs   [ T_RANGE_SSORT            ] = AsssRange;
     AsssListFuncs   [ T_RANGE_SSORT +IMMUTABLE ] = AsssRangeImm;
-    IsDenseListFuncs[ T_RANGE_NSORT            ] = IsDenseRange;
-    IsDenseListFuncs[ T_RANGE_NSORT +IMMUTABLE ] = IsDenseRange;
-    IsDenseListFuncs[ T_RANGE_SSORT            ] = IsDenseRange;
-    IsDenseListFuncs[ T_RANGE_SSORT +IMMUTABLE ] = IsDenseRange;
-    IsHomogListFuncs[ T_RANGE_NSORT            ] = IsHomogRange;
-    IsHomogListFuncs[ T_RANGE_NSORT +IMMUTABLE ] = IsHomogRange;
-    IsHomogListFuncs[ T_RANGE_SSORT            ] = IsHomogRange;
-    IsHomogListFuncs[ T_RANGE_SSORT +IMMUTABLE ] = IsHomogRange;
-    IsSSortListFuncs[ T_RANGE_NSORT            ] = IsSSortRangeNot;
-    IsSSortListFuncs[ T_RANGE_NSORT +IMMUTABLE ] = IsSSortRangeNot;
-    IsSSortListFuncs[ T_RANGE_SSORT            ] = IsSSortRangeYes;
-    IsSSortListFuncs[ T_RANGE_SSORT +IMMUTABLE ] = IsSSortRangeYes;
+    IsDenseListFuncs[ T_RANGE_NSORT            ] = AlwaysYes;
+    IsDenseListFuncs[ T_RANGE_NSORT +IMMUTABLE ] = AlwaysYes;
+    IsDenseListFuncs[ T_RANGE_SSORT            ] = AlwaysYes;
+    IsDenseListFuncs[ T_RANGE_SSORT +IMMUTABLE ] = AlwaysYes;
+    IsHomogListFuncs[ T_RANGE_NSORT            ] = AlwaysYes;
+    IsHomogListFuncs[ T_RANGE_NSORT +IMMUTABLE ] = AlwaysYes;
+    IsHomogListFuncs[ T_RANGE_SSORT            ] = AlwaysYes;
+    IsHomogListFuncs[ T_RANGE_SSORT +IMMUTABLE ] = AlwaysYes;
+    IsSSortListFuncs[ T_RANGE_NSORT            ] = AlwaysNo;
+    IsSSortListFuncs[ T_RANGE_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_RANGE_SSORT            ] = AlwaysYes;
+    IsSSortListFuncs[ T_RANGE_SSORT +IMMUTABLE ] = AlwaysYes;
     IsPossListFuncs [ T_RANGE_NSORT            ] = IsPossRange;
     IsPossListFuncs [ T_RANGE_NSORT +IMMUTABLE ] = IsPossRange;
     IsPossListFuncs [ T_RANGE_SSORT            ] = IsPossRange;

--- a/src/records.c
+++ b/src/records.c
@@ -43,6 +43,8 @@
 
 #include <src/hpc/systhread.h>          /* system thread primitives */
 
+#include <src/util.h>
+
 
 /****************************************************************************
 **
@@ -352,18 +354,6 @@ Obj             IsRecHandler (
     Obj                 obj )
 {
     return (IS_REC(obj) ? True : False);
-}
-
-Int             IsRecNot (
-    Obj                 obj )
-{
-    return 0L;
-}
-
-Int             IsRecYes (
-    Obj                 obj )
-{
-    return 1L;
 }
 
 Int             IsRecObject (
@@ -721,10 +711,10 @@ static Int InitKernel (
 
     /* make and install the 'IS_REC' filter                                */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        IsRecFuncs[ type ] = IsRecNot;
+        IsRecFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_RECORD_TNUM; type <= LAST_RECORD_TNUM; type++ ) {
-        IsRecFuncs[ type ] = IsRecYes;
+        IsRecFuncs[ type ] = AlwaysYes;
     }
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         IsRecFuncs[ type ] = IsRecObject;

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -40,7 +40,7 @@
 **  use the detailed knowledge about the respresentation of strings.
 **  
 **  The second part  consists  of  the  functions  'LenString',  'ElmString',
-**  'ElmsStrings', 'AssString',  'AsssString', PlainString', 'IsDenseString',
+**  'ElmsStrings', 'AssString',  'AsssString', PlainString',
 **  and 'IsPossString'.  They are the functions requried by the generic lists
 **  package.  Using these functions the other  parts of the {\GAP} kernel can
 **  access and  modify strings  without actually  being aware  that they  are
@@ -80,6 +80,8 @@
 
 #include <src/saveload.h>               /* saving and loading */
 #include <src/hpc/tls.h>                /* thread-local storage */
+
+#include <src/util.h>
 
 #include <assert.h>
 
@@ -1181,21 +1183,6 @@ void AsssStringImm (
 
 /****************************************************************************
 **
-*F  IsDenseString(<list>) . . . . . . .  dense list test function for strings
-**
-**  'IsDenseString' returns 1, since every string is dense.
-**
-**  'IsDenseString' is the function in 'IsDenseListFuncs' for strings.
-*/
-Int IsDenseString (
-    Obj                 list )
-{
-    return 1L;
-}
-
-
-/****************************************************************************
-**
 *F  IsHomogString(<list>) . . . .  homogeneous list test function for strings
 **
 **  'IsHomogString' returns  1 if  the string  <list>  is homogeneous.  Every
@@ -1237,18 +1224,6 @@ Int IsSSortString (
     /* retype according to the outcome                                     */
     SET_FILT_LIST( list, (len <= i) ? FN_IS_SSORT : FN_IS_NSORT );
     return (len <= i);
-}
-
-Int IsSSortStringNot (
-    Obj                 list )
-{
-    return 0L;
-}
-
-Int IsSSortStringYes (
-    Obj                 list )
-{
-    return 1L;
 }
 
 
@@ -1365,18 +1340,6 @@ void PlainString (
 Int (*IsStringFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
 
 Obj IsStringFilt;
-
-Int IsStringNot (
-    Obj                 obj )
-{
-    return 0;
-}
-
-Int IsStringYes (
-    Obj                 obj )
-{
-    return 1;
-}
 
 Int IsStringList (
     Obj                 list )
@@ -2709,8 +2672,8 @@ static Int InitKernel (
         AssListFuncs    [ t1 +IMMUTABLE ] = AssStringImm;
         AsssListFuncs   [ t1            ] = AsssString;
         AsssListFuncs   [ t1 +IMMUTABLE ] = AsssStringImm;
-        IsDenseListFuncs[ t1            ] = IsDenseString;
-        IsDenseListFuncs[ t1 +IMMUTABLE ] = IsDenseString;
+        IsDenseListFuncs[ t1            ] = AlwaysYes;
+        IsDenseListFuncs[ t1 +IMMUTABLE ] = AlwaysYes;
         IsHomogListFuncs[ t1            ] = IsHomogString;
         IsHomogListFuncs[ t1 +IMMUTABLE ] = IsHomogString;
         IsSSortListFuncs[ t1            ] = IsSSortString;
@@ -2722,15 +2685,15 @@ static Int InitKernel (
         PlainListFuncs  [ t1            ] = PlainString;
         PlainListFuncs  [ t1 +IMMUTABLE ] = PlainString;
     }
-    IsSSortListFuncs[ T_STRING_NSORT            ] = IsSSortStringNot;
-    IsSSortListFuncs[ T_STRING_NSORT +IMMUTABLE ] = IsSSortStringNot;
-    IsSSortListFuncs[ T_STRING_SSORT            ] = IsSSortStringYes;
-    IsSSortListFuncs[ T_STRING_SSORT +IMMUTABLE ] = IsSSortStringYes;
+    IsSSortListFuncs[ T_STRING_NSORT            ] = AlwaysNo;
+    IsSSortListFuncs[ T_STRING_NSORT +IMMUTABLE ] = AlwaysNo;
+    IsSSortListFuncs[ T_STRING_SSORT            ] = AlwaysYes;
+    IsSSortListFuncs[ T_STRING_SSORT +IMMUTABLE ] = AlwaysYes;
 
 
     /* install the `IsString' functions                                    */
     for ( t1 = FIRST_REAL_TNUM; t1 <= LAST_REAL_TNUM; t1++ ) {
-        IsStringFuncs[ t1 ] = IsStringNot;
+        IsStringFuncs[ t1 ] = AlwaysNo;
     }
 
     for ( t1 = FIRST_LIST_TNUM; t1 <= LAST_LIST_TNUM; t1++ ) {
@@ -2738,7 +2701,7 @@ static Int InitKernel (
     }
 
     for ( t1 = T_STRING; t1 <= T_STRING_SSORT; t1++ ) {
-        IsStringFuncs[ t1 ] = IsStringYes;
+        IsStringFuncs[ t1 ] = AlwaysYes;
     }
 
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
@@ -2753,7 +2716,6 @@ static Int InitKernel (
     MakeImmutableObjFuncs[ T_STRING       ] = MakeImmutableString;
     MakeImmutableObjFuncs[ T_STRING_SSORT ] = MakeImmutableString;
     MakeImmutableObjFuncs[ T_STRING_NSORT ] = MakeImmutableString;
-    
 
     /* return success                                                      */
     return 0;

--- a/src/util.h
+++ b/src/util.h
@@ -13,4 +13,8 @@
 **/
 #define ARRAY_SIZE(arr)     ( sizeof(arr) / sizeof((arr)[0]) )
 
+
+static inline Int AlwaysYes(Obj obj) { return 1; }
+static inline Int AlwaysNo(Obj obj) { return 0; }
+
 #endif // GAP_UTIL_H


### PR DESCRIPTION
These two function take a single Obj, and return 0 resp. 1. They replace
many such functions (e.g. IsSSortStringYes, IsSSortStringNot, IsStringNot,
IsHomogRange, ...). This way, when reading initialization code of some
IsFOOBARFuncs array, it is immediately clear what the meaning is when one
such function is used

Note that this commit also replaces IsSSortPlistYes by AlwaysYes, even
though IsSSortPlistYes returns 2. This is intentional: the value 2 is used
by internal functions to distinguish between sorted and strictly sort lists
(= sets), but using it for IsSSortPlistYes actually never made sense nor
had it any impact.