### PR TITLE
Collection of improvements and fixes

### DIFF
--- a/doc/ref/groups.xml
+++ b/doc/ref/groups.xml
@@ -472,6 +472,10 @@ the series without destroying the properties of the series.
 <#Include Label="DotFileLatticeSubgroups">
 <#Include Label="MaximalSubgroupsLattice">
 <#Include Label="MinimalSupergroupsLattice">
+<#Include Label="LowLayerSubgroups">
+<#Include Label="ContainedConjugates">
+<#Include Label="ContainedConjugates">
+<#Include Label="ContainingConjugates">
 <#Include Label="RepresentativesPerfectSubgroups">
 <#Include Label="ConjugacyClassesPerfectSubgroups">
 <#Include Label="Zuppos">

--- a/grp/simple.gi
+++ b/grp/simple.gi
@@ -1180,12 +1180,15 @@ local H,d,id,hom,field,C,dom,orbs;
      and Image(hom)=G then
     d:=IdentityMapping(G);
   else
+    # only force isomorphism if we really want it -- e.g. maximal subgroups
+    if ValueOption("classicepiuseiso")<>true then
+      return fail;
+    fi;
     # Image(hom) is the better group to search in, e.g. classes.
     d:=Image(hom);
     d!.actionHomomorphism:=hom;
-    return fail;
-    Error("QQQ");
-    d:=IsomorphismGroups(G,Image(hom));
+    # option to avoid infinite recursion
+    d:=IsomorphismGroups(G,Image(hom):classicepiuseiso:=false);
   fi;
   if d=fail then
     Error("inconsistent image 2");

--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -177,6 +177,7 @@ local clT,	# classes T
       scj,	# size(centralizers[j])
       dsz,	# Divisors(scj);
       pper,
+      cbs,cbi,
       faillim,
       failcnt;
 
@@ -431,15 +432,31 @@ local clT,	# classes T
 
   Info(InfoHomClass,1,Length(reps)," classreps constructed");
 
+  # allow for faster sorting through color bars
+  cbs:=ShallowCopy(colourbar);
+  cbi:=[1..Length(cbs)];
+  SortParallel(cbs,cbi);
+
   # further fusion among bars
   newreps:=[];
   Info(InfoHomClass,2,"computing centralizers");
   k:=0;
   for bar in bars do
     k:=k+1;
+    #Info(InfoHomClass,4,"k-",k);
     CompletionBar(InfoHomClass,3,"Color Bars ",k/Length(bars));
     b1:=Immutable(bar[1]);
-    select:=Filtered([1..Length(reps)],i->colourbar[i]=b1);
+    select:=[];
+    i:=PositionSorted(cbs,b1);
+    if i<>fail and i<=Length(cbs) and cbs[i]=b1 then
+      AddSet(select,cbi[i]);
+      while i<Length(cbs) and cbs[i+1]=b1 do
+	i:=i+1;
+        AddSet(select,cbi[i]);
+      od;
+    fi;
+    #Assert(1,select=Filtered([1..Length(reps)],i->colourbar[i]=b1));
+
     if Length(select)>1 then
       Info(InfoHomClass,2,"test ",Length(select)," classes for fusion");
     fi;

--- a/lib/csetgrp.gd
+++ b/lib/csetgrp.gd
@@ -414,3 +414,6 @@ DeclareOperation("RightCosetsNC",[IsGroup,IsGroup]);
 ##
 DeclareGlobalFunction("IntermediateGroup");
 
+# forward declaration for recursive call.
+DeclareGlobalFunction("DoConjugateInto");
+

--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -78,20 +78,180 @@ local c,i;
   fi;
 end );
 
+# Find element in G to conjugate B into A
+# call with G,A,B;
+InstallGlobalFunction(DoConjugateInto,function(g,a,b,onlyone)
+local cla,clb,i,j,k,imgs,bd,r,rep,b2,ex2,split,dc,
+  gens,conjugate;
+
+  conjugate:=function(act,asub,genl,nr)
+  local i,dc,j,z,r,r2,found;
+    found:=[];
+    Info(InfoCoset,2,"conjugate ",Size(act)," ",Size(asub)," ",nr);
+
+    z:=Centralizer(act,genl[nr]);
+    if Index(act,z)<Maximum(List(cla[nr],Size)) then
+      Info(InfoCoset,2,"!orbsize ",Index(act,z));
+      # asub orbits on the act-class of genl[nr]
+      dc:=DoubleCosetRepsAndSizes(act,z,asub);
+      for j in dc do
+        z:=genl[nr]^j[1];
+        if z in a then
+          r:=j[1];
+          if nr=Length(genl) then
+            Add(found,r);
+            if onlyone then return found; fi;
+          else
+            r2:=conjugate(Centralizer(act,z),Centralizer(asub,z),
+              List(genl,x->x^r),nr+1);
+            if Length(r2)>0 then
+              Append(found,r*r2);
+              if onlyone then return found; fi;
+            fi;
+          fi;
+        fi;
+      od;
+    else
+      for i in cla[nr] do
+        Info(InfoCoset,2,"!classize ",Size(i)," ",
+          Index(act,Centralizer(act,genl[nr]))," ",
+          QuoInt(Size(a),Size(Centralizer(i))*Size(asub)));
+
+        # split up a-classes to asub-classes
+        dc:=DoubleCosetRepsAndSizes(a,Centralizer(i),asub);
+        Info(InfoCoset,2,Length(dc)," double cosets");
+        for j in dc do
+          z:=Representative(i)^j[1];
+          r:=RepresentativeAction(act,genl[nr],z);
+          if r<>fail then
+            if nr=Length(genl) then
+              Add(found,r);
+              if onlyone then return found; fi;
+            else
+              r2:=conjugate(Centralizer(act,z),Centralizer(asub,z),
+                List(genl,x->x^r),nr+1);
+              if Length(r2)>0 then
+                Append(found,r*r2);
+                if onlyone then return found; fi;
+              fi;
+            fi;
+          fi;
+        od;
+      od;
+    fi;
+
+    return found;
+  end;
+
+  gens:=MorFindGeneratingSystem(b,MorMaxFusClasses(MorRatClasses(b)));
+  clb:=ConjugacyClasses(a);
+  cla:=[];
+  r:=[];
+  for i in gens do
+    b2:=Centralizer(g,i);
+    bd:=Size(Centralizer(b,i));
+    k:=Order(i);
+    rep:=[];
+    for j in [1..Length(clb)] do
+      if Order(Representative(clb[j]))=k 
+         and (Size(a)/Size(clb[j])) mod bd=0 then
+        if not IsBound(r[j]) then
+          r[j]:=Size(Centralizer(g,Representative(clb[j])));
+        fi;
+        if r[j]=Size(b2) then
+          Add(rep,clb[j]);
+        fi;
+      fi;
+    od;
+    Add(cla,rep);
+  od;
+  r:=List(cla,x->-Maximum(List(x,Size)));
+  r:=Sortex(r);
+  gens:=Permuted(gens,r);
+  cla:=Permuted(cla,r);
+
+  r:=conjugate(g,a,gens,1);
+
+  if onlyone then 
+    # get one
+    if Length(r)=0 then
+      return fail;
+    else
+      return r[1];
+    fi;
+  fi;
+
+  Info(InfoCoset,2,"Found ",Length(r)," reps");
+  # remove duplicate groups
+  rep:=[];
+  b2:=[];
+  for i in r do
+    bd:=b^i;
+    if ForAll(b2,x->RepresentativeAction(a,x,bd)=fail) then
+      Add(b2,bd);
+      Add(rep,i);
+    fi;
+  od;
+  return rep;
+end);
+
+
 #############################################################################
 ##
 ##  IntermediateGroup(<G>,<U>)  . . . . . . . . . subgroup of G containing U
 ##
 ##  This routine tries to find a subgroup E of G, such that G>E>U. If U is
-##  maximal, it returns fail. This is done by finding minimal blocks for
+##  maximal, it returns fail. This is done by using the maximal subgroups machinery or
+##  finding minimal blocks for
 ##  the operation of G on the Right Cosets of U.
 ##
 InstallGlobalFunction( IntermediateGroup, function(G,U)
-local o,b,img,G1;
+local o,b,img,G1,c,m,hardlimit,gens,t,k;
 
   if U=G then
     return fail;
   fi;
+
+  # use maximals
+  m:=MaximalSubgroupClassReps(G:cheap);
+
+  m:=Filtered(m,x->Size(x) mod Size(U)=0 and Size(x)>Size(U));
+  SortBy(m,x->Size(G)/Size(x));
+  
+  gens:=SmallGeneratingSet(U);
+  for c in m do
+    if Index(G,c)<50000 then
+      t:=RightTransversal(G,c:noascendingchain); # conjugates
+      for k in t do
+        if ForAll(gens,x->k*x/k in c) then
+	  Info(InfoCoset,2,"Found Size ",Size(c),"\n");
+          # U is contained in c^k
+          return c^k;
+        fi;
+      od;
+    else
+      t:=DoConjugateInto(G,c,U,true);
+      if t<>fail then 
+	Info(InfoCoset,2,"Found Size ",Size(c),"\n");
+        return c^(Inverse(t));
+      fi;
+    fi;
+  od;
+
+  Info(InfoCoset,2,"Found no intermediate subgroup ",Size(G)," ",Size(U));
+  return fail;
+
+  # old code -- obsolete
+
+  c:=ValueOption("refineChainActionLimit");
+  if IsInt(c) then
+    hardlimit:=c;
+  else
+    hardlimit:=100000;
+  fi;
+
+  if Index(G,U)>hardlimit then return fail;fi;
+
   if IsPermGroup(G) and Length(GeneratorsOfGroup(G))>3 then
     G1:=Group(SmallGeneratingSet(G));
     if HasSize(G) then
@@ -117,7 +277,7 @@ end );
 #F  RefinedChain(<G>,<c>) . . . . . . . . . . . . . . . .  refine chain links
 ##
 InstallGlobalFunction(RefinedChain,function(G,cc)
-local bound,a,b,c,cnt,r,i,j,bb,normalStep,gens,hardlimit,cheap;
+local bound,a,b,c,cnt,r,i,j,bb,normalStep,gens,hardlimit,cheap,olda;
   bound:=(10*LogInt(Size(G),10)+1)*Maximum(Factors(Size(G)));
   bound:=Minimum(bound,20000);
   cheap:=ValueOption("cheap")=true;
@@ -125,19 +285,15 @@ local bound,a,b,c,cnt,r,i,j,bb,normalStep,gens,hardlimit,cheap;
   if IsInt(c) then
     bound:=c;
   fi;
-  c:=ValueOption("refineChainActionLimit");
-  if IsInt(c) then
-    hardlimit:=c;
-  else
-    hardlimit:=100000;
-  fi;
 
   c:=[];  
   for i in [2..Length(cc)] do  
     Add(c,cc[i-1]);
     if Index(cc[i],cc[i-1]) > bound then
       a:=AsSubgroup(Parent(cc[i]),cc[i-1]);
-      while Index(cc[i],a)>bound do
+      olda:=TrivialSubgroup(a);
+      while Index(cc[i],a)>bound and Size(a)>Size(olda) do
+	olda:=a;
 	# try extension via normalizer
 	b:=Normalizer(cc[i],a);
 	if Size(b)>Size(a) then
@@ -153,7 +309,7 @@ local bound,a,b,c,cnt,r,i,j,bb,normalStep,gens,hardlimit,cheap;
 	  cnt:=8+2^(LogInt(Index(bb,a),9));
 	  if cheap then cnt:=Minimum(cnt,50);fi;
 	  repeat
-	    if Index(bb,a)<hardlimit and cnt<20 and not cheap then
+	    if cnt<20 and not cheap then
 	      # if random failed: do hard work
 	      b:=IntermediateGroup(bb,a);
 	      if b=fail then
@@ -190,10 +346,19 @@ local bound,a,b,c,cnt,r,i,j,bb,normalStep,gens,hardlimit,cheap;
 	    fi;
 	  until Index(bb,a)<=bound or cnt<1;
 	fi;
+	if Index(b,a)>bound and Length(c)>1 then
+	  bb:=IntermediateGroup(b,c[Length(c)-1]);
+	  if bb<>fail and Size(bb)>Size(c[Length(c)]) then
+	    c:=Concatenation(c{[1..Length(c)-1]},[bb],Filtered(cc,x->Size(x)>=Size(b)));
+	    return RefinedChain(G,c);
+	  fi;
+	fi;
+
 	a:=b;
 	if a<>cc[i] then #not upper level
 	  Add(c,a);
 	fi;
+
       od;
     fi;
   od;
@@ -621,7 +786,7 @@ local c, flip, maxidx, refineChainActionLimit, cano, tryfct, p, r, t,
 	  fi;
 	fi;
 	if Index(G,G1)<maxidx(c) and (
-	  maxidx(c)>badlimit or Size(a1)>Size(c[1])) then
+	  maxidx(c)>10*actlimit or Size(a1)>Size(c[1])) then
 	  c1:=AscendingChain(G1,a1:refineChainActionLimit:=actlimit);
 	  if maxidx(c1)<maxidx(c) then
 	    c:=Concatenation(c1,[G]);
@@ -652,7 +817,7 @@ local c, flip, maxidx, refineChainActionLimit, cano, tryfct, p, r, t,
 	  
     fi;
     
-    if maxidx(c)>badlimit then
+    if maxidx(c)>10*actlimit then
 
       r:=ShallowCopy(MaximalSubgroupClassReps(a:cheap));
       r:=Filtered(r,x->Index(a,x)<uplimit);
@@ -1035,7 +1200,7 @@ local c, flip, maxidx, refineChainActionLimit, cano, tryfct, p, r, t,
 
   fi;
 
-  if AssertionLevel()>1 then
+  if AssertionLevel()>2 then
     # test
     bsz:=Size(G);
     t:=[];

--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -163,6 +163,9 @@ local cla,clb,i,j,k,imgs,bd,r,rep,b2,ex2,split,dc,
         fi;
       fi;
     od;
+    if Length(rep)=0 then
+      return []; # cannot have any
+    fi;
     Add(cla,rep);
   od;
   r:=List(cla,x->-Maximum(List(x,Size)));
@@ -206,14 +209,20 @@ end);
 ##  the operation of G on the Right Cosets of U.
 ##
 InstallGlobalFunction( IntermediateGroup, function(G,U)
-local o,b,img,G1,c,m,hardlimit,gens,t,k;
+local o,b,img,G1,c,m,hardlimit,gens,t,k,intersize;
 
   if U=G then
     return fail;
   fi;
 
+  intersize:=Size(G);
+  m:=ValueOption("intersize");
+  if IsInt(m) and m<=intersize then
+    return fail; # avoid infinite recursion
+  fi;
+
   # use maximals
-  m:=MaximalSubgroupClassReps(G:cheap);
+  m:=MaximalSubgroupClassReps(G:cheap,intersize:=intersize);
 
   m:=Filtered(m,x->Size(x) mod Size(U)=0 and Size(x)>Size(U));
   SortBy(m,x->Size(G)/Size(x));
@@ -230,7 +239,7 @@ local o,b,img,G1,c,m,hardlimit,gens,t,k;
         fi;
       od;
     else
-      t:=DoConjugateInto(G,c,U,true);
+      t:=DoConjugateInto(G,c,U,true:intersize:=intersize);
       if t<>fail then 
 	Info(InfoCoset,2,"Found Size ",Size(c),"\n");
         return c^(Inverse(t));

--- a/lib/grplatt.gd
+++ b/lib/grplatt.gd
@@ -439,28 +439,60 @@ DeclareGlobalFunction("TomDataSubgroupsAlmostSimple");
 ##  returned. If also a function <A>dosub</A> is given, maximal subgroups
 ##  are only attempted if this function returns true (this is separated for
 ##  performance reasons).
-##  <P>
-##  In the example, the result would be the same with leaving out the
-##  fourth function, but calculation this way is slightly faster.
-##  <P/>
-##  <Example><![CDATA[
-##  gap> g:=DirectProduct(SimpleGroup("J1"),PSL(2,113));;
-##  gap> l:=LowLayerSubgroups(g,2,
-##  > x->not IsSolvableGroup(x) and Index(g,x)<=30000,
-##  > x->Index(g,x)<=15000);;
-##  gap> Collected(List(l,x->Index(g,x)));
-##  [ [ 1, 1 ], [ 114, 1 ], [ 228, 1 ], [ 266, 1 ], [ 798, 1 ], [ 1045, 1 ],
-##    [ 1463, 1 ], [ 1540, 1 ], [ 1596, 1 ], [ 2926, 3 ], [ 3080, 1 ],
-##    [ 3135, 1 ], [ 3192, 1 ], [ 4180, 1 ], [ 4620, 1 ], [ 5852, 3 ],
-##    [ 6328, 1 ], [ 6441, 1 ], [ 7315, 1 ], [ 7980, 1 ], [ 8360, 1 ],
-##    [ 8778, 1 ], [ 12540, 1 ], [ 12656, 1 ], [ 12882, 3 ], [ 14630, 1 ],
-##    [ 17556, 1 ], [ 18984, 1 ], [ 29260, 1 ] ]
-##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction("LowLayerSubgroups");
+
+#############################################################################
+##
+#O  ContainedConjugates(<G>,<A>,<B>)
+##
+##  <#GAPDoc Label="ContainedConjugates">
+##  <ManSection>
+##  <Func Name="ContainedConjugates" Arg='G, A, B'/>
+##
+##  <Description>
+##  For <M>G\ge A,B</M> this operation returns representatives of the <A>A</A> conjugacy classes
+##  of subgroups that are
+##  conjugate to <A>B</A> under <A>G</A>.
+##  The function returns a list of pairs of subgroup and conjugating element.
+##  <Example><![CDATA[
+##  gap> g:=SymmetricGroup(8);;
+##  gap> a:=TransitiveGroup(8,47);;b:=TransitiveGroup(8,7);;
+##  gap> ContainedConjugates(g,a,b);
+##  [ [ Group([ (1,4,2,5,3,6,8,7), (1,3)(2,8) ]), (2,4,5,3)(7,8) ] ]
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation("ContainedConjugates",[IsGroup,IsGroup,IsGroup]);
+
+#############################################################################
+##
+#O  ContainingConjugates(<G>,<A>,<B>)
+##
+##  <#GAPDoc Label="ContainingConjugates">
+##  <ManSection>
+##  <Func Name="ContainingConjugates" Arg='G, A, B'/>
+##
+##  <Description>
+##  For <M>G\ge A,B</M> this operation returns all <A>G</A> conjugates of <A>A</A> 
+##  that contain <A>B</A>.
+##  The function returns a list of pairs of subgroup and conjugating element.
+##  <Example><![CDATA[
+##  gap> g:=SymmetricGroup(8);;
+##  gap> a:=TransitiveGroup(8,47);;b:=TransitiveGroup(8,7);;
+##  gap> ContainingConjugates(g,a,b);
+##  [ [ Group([ (1,3,5,7), (3,5), (1,4)(2,7)(3,6)(5,8) ]), (2,3,5,4)(7,8) ] ]
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation("ContainingConjugates",[IsGroup,IsGroup,IsGroup]);
 
 #############################################################################
 ##

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -2092,6 +2092,37 @@ DeclareOperation("BaseField",[IsObject]);
 ##
 DeclareGlobalFunction( "SimplexMethod" );
 
+#############################################################################
+##
+#O  RationalCanonicalFormTransform( <A> )
+##
+##  <#GAPDoc Label="Frobenius Normal Form">
+##  <ManSection>
+##  <Oper Name="RationalCanonicalFormTransform" Arg='A'/>
+##
+##  <Description>
+##  For a matrix <A>A</A> return a matrix <A>P</A> such that
+##  <M><A>A</A>^<A>P</A></M> is in rational canonical form (also called Frobenius normal form).
+##  The algorithm used is the basic textbook version and thus not of optimal complexity.
+##  <Example><![CDATA[
+##  gap> aa:=[ [ 0, -8, 12, 40, -36, 4, 0, 59, 15, -9 ], [ -2, -2, -2, 6, -11, 1, -1, 10, 1, 0 ],
+##  >   [ 1, 5, 0, -6, 12, -2, 0, -12, -4, 2 ], [ 0, 0, 0, 2, 0, 0, 0, 7, 0, 0 ],
+##  >   [ 0, 2, -3, -7, 8, -1, 0, -7, -3, 2 ], [ -5, -4, -6, 18, -30, 2, -2, 35, 5, -1 ],
+##  >   [ -1, -6, 6, 20, -28, 3, 0, 24, 10, -6 ], [ 0, 0, 0, -1, 0, 0, 0, -3, 0, 0 ],
+##  >   [ 0, 0, -1, -2, -2, 0, -1, -7, 0, 0 ], [ 0, -8, 9, 21, -36, 4, -2, 12, 12, -8 ] ];;
+##  gap> t:=RationalCanonicalFormTransform(aa);;
+##  gap> aa^t;
+##  [ [ 0, 0, 0, 1, 0, 0, 0, 0, 0, 0 ], [ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 ], [ 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
+##    [ 0, 0, 1, 0, 0, 0, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 ], [ 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 ],
+##    [ 0, 0, 0, 0, 0, 1, 0, 0, 0, 1 ], [ 0, 0, 0, 0, 0, 0, 1, 0, 0, 0 ], [ 0, 0, 0, 0, 0, 0, 0, 1, 0, -1 ],
+##    [ 0, 0, 0, 0, 0, 0, 0, 0, 1, -1 ] ]
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction( "RationalCanonicalFormTransform" );
+
 
 #############################################################################
 ##

--- a/lib/maxsub.gi
+++ b/lib/maxsub.gi
@@ -575,7 +575,7 @@ local id,m,epi,cnt,h;
     elif id.idSimple.series="L" then
       m:=ClassicalMaximals("L",id.idSimple.parameter[1],id.idSimple.parameter[2]);
       if m<>fail then
-	epi:=EpimorphismFromClassical(G);
+	epi:=EpimorphismFromClassical(G:classicepiuseiso:=true);
 	if epi<>fail then
 	  m:=List(m,x->SubgroupNC(Range(epi),
 	      List(GeneratorsOfGroup(x),y->ImageElm(epi,y))));

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -589,7 +589,7 @@ end );
 #M  ActionHomomorphismConstructor( <xset>, <surj> )
 ##
 InstallGlobalFunction( ActionHomomorphismConstructor, function(arg)
-local   xset,surj,G,  D,  act,  fam,  filter,  hom,  i;
+local   xset,surj,G,  D,  act,  fam,  filter,  hom,  i,blockacttest;
 
     xset:=arg[1];surj:=arg[2];
     G := ActingDomain( xset );
@@ -605,6 +605,24 @@ local   xset,surj,G,  D,  act,  fam,  filter,  hom,  i;
     if IsPermGroup( G )  then
 	filter := filter and IsPermGroupGeneralMapping;
     fi;
+
+    blockacttest:=function()
+    local a,b,g,p;
+      D:=List(D,Immutable); # to store sorted
+      if not ForAll( D, IsList and IsSSortedList ) then
+        return false;
+      fi;
+      for b in D do
+	for g in GeneratorsOfGroup(G) do
+	  a:=b[1]^g;
+	  p:=PositionProperty(D,x->a in x);
+	  if OnSets(b,g)<>D[p] then
+	    return false;
+	  fi;
+	od;
+      od;
+      return true;
+    end;
 
     hom := rec(  );
     if Length(arg)>2 then
@@ -659,16 +677,16 @@ local   xset,surj,G,  D,  act,  fam,  filter,  hom,  i;
 
 
     # test for action on disjoint sets of numbers, preserved by group -> blocks homomorphism
+
     elif not IsExternalSubset( xset )
          and IsPermGroup( G )
          and IsList( D )
-         and ForAll( D, IsList and IsSSortedList )
-	 and Length(D)>0 and Length(D[1])>0 and IsInt(D[1][1])
          and act = OnSets
-	 # disjointness test
-	 and Length(Set(Flat(D)))=Sum(List(D,Length))
+	 and Length(D)>0 and Length(D[1])>0 and IsInt(D[1][1])
+	 and Length(Set(List(D,Length)))=1 # all same length
+	 and Length(Set(Concatenation(D)))=Sum(List(D,Length)) # disjoint
 	 # preserved test
-	 and ForAll(D,b->ForAll(GeneratorsOfGroup(G),g->OnSets(b,g) in D))
+	 and blockacttest()
 	 then
         filter := IsBlocksHomomorphism;
         hom.reps := [  ];

--- a/lib/permdeco.gi
+++ b/lib/permdeco.gi
@@ -160,7 +160,7 @@ local G0,a0,tryrep,sel,selin,a,s,dom,iso,stabs,outs,map,i,j,p,found,seln,
      Info(InfoGroup,2,"Trying degree ",NrMovedPoints(Gi));
      maps:=List(sel,x->InducedAutomorphism(rep,autos[x]));
      #for v in maps do SetIsBijective(v,true); od;
-     if ForAll(maps,IsConjugatorAutomorphism) then
+     if ForAll(maps,x->IsConjugatorAutomorphism(x:cheap)) then
         # the representation extends
         v:=List( maps, ConjugatorOfConjugatorIsomorphism );
         w:=ClosureGroup(Gi,v);
@@ -205,7 +205,7 @@ local G0,a0,tryrep,sel,selin,a,s,dom,iso,stabs,outs,map,i,j,p,found,seln,
                 4*NrMovedPoints(G));
   else
     a:=tryrep(IdentityMapping(G),4*NrMovedPoints(G));
-    if a=fail and ForAll(autos,IsConjugatorAutomorphism) then
+    if a=fail and ForAll(autos,x->IsConjugatorAutomorphism(x:cheap)) then
       a:=tryrep(SmallerDegreePermutationRepresentation(G),4*NrMovedPoints(G));
     fi;
   fi;

--- a/lib/ringhom.gi
+++ b/lib/ringhom.gi
@@ -544,7 +544,8 @@ end);
 InstallMethod( NaturalHomomorphismByIdeal,"sc rings",IsIdenticalObj,
     [ IsSubringSCRing,IsSubringSCRing],
 function( R, I )
-  local hom, R2, nat, Rgens, std, moduli, newmod, posi, q, t, dec, x, i, j, k;
+  local hom, R2, nat, Rgens, std, moduli, newmod, posi, q, t, dec, x, i, j,
+  k,rels,genwords;
   if not IsIdeal(R,I) then
     Error("I is not an ideal!");
   fi;
@@ -555,63 +556,84 @@ function( R, I )
     nat:=NaturalHomomorphismByIdeal(R2,I);
     return RingHomomorphismByImages(R,Range(nat),GeneratorsOfRing(R),
              List(GeneratorsOfRing(R),x->Image(nat,Image(hom,i))));
-  else
-    if I=R then
-      # catch trivial case
-      q:=SmallRing(1,1);
-      return RingHomomorphismByImages(R,q,GeneratorsOfRing(R),
-        List(GeneratorsOfRing(R),x->Zero(q)));
+  fi;
+
+  if I=R then
+    # catch trivial case
+    q:=SmallRing(1,1);
+    return RingHomomorphismByImages(R,q,GeneratorsOfRing(R),
+      List(GeneratorsOfRing(R),x->Zero(q)));
+  fi;
+
+
+  # old relations -- standard form
+  moduli:=FamilyObj(Zero(R))!.moduli;
+  rels:=[];
+  for i in [1..Length(moduli)] do
+    q:=List(moduli,x->0);
+    q[i]:=moduli[i];
+    Add(rels,q);
+  od;
+
+  # extra kernel generators
+  std:=StandardGeneratorsSubringSCRing(I);
+  for i in std[1] do
+    Add(rels,ShallowCopy(i));
+  od;
+
+  # now rels is a relator matrix for the quotient. Use SNF to find
+  # structure
+  rels:=SmithNormalFormIntegerMatTransforms(rels);
+
+  # Let x,y be ring generators and M the original relator matrix. Then
+  # M*(x,y)^T=0 by definition of relators.
+  # SNF gives R*M*C=D, so $R^-1*D*C^-1*(x,y)^T=0$, implying that D are
+  # relations that hold amongst C^-1*(x,y). Thus:
+  # The rows of C^-1 express the new generators in terms of the old, i.e.
+  # are base chance new-> old as row vectors.
+  # the rows of C convert old->new
+  # Thus the rows of C give coefficients for images of old generators
+
+  Rgens:=GeneratorsOfRing(R);
+  genwords:=Inverse(rels.coltrans)*GeneratorsOfRing(R);
+  # nontrivial generators
+  newmod:=[];
+  posi:=[];
+  for i in [1..Length(moduli)] do
+    if rels.normal[i][i]>1 then
+      Add(newmod,rels.normal[i][i]);
+      Add(posi,i);
     fi;
-    # R is the full ring. We can read of the factor ring structures from the
-    # standard generators of R
-    Rgens:=GeneratorsOfRing(R);
-    std:=StandardGeneratorsSubringSCRing(I);
-    moduli:=FamilyObj(Zero(R))!.moduli;
-    newmod:=[];
-    posi:=[]; # generator positions
-    for i in [1..Length(moduli)] do
-      if not IsBound(std[2][i]) then
-        # the generator survives as it is
-	Add(newmod,moduli[i]);
-	Add(posi,i);
-      else
-        t:=std[1][std[2][i]][i]; 
-        if t=1 then
-	  # the generator vanishes in the factor
-	  Add(newmod,false);
-	else
-	  # the generator has a smaller order in the factor
-	  q:=Gcd(moduli[i],t); 
-	  Add(newmod,q);
-	  Add(posi,i);
-	fi;
+  od;
+
+
+  # now determine the multiplication
+  t:=EmptySCTable(Length(posi),0);
+  for i in [1..Length(posi)] do
+    for j in [1..Length(posi)] do
+      # product of generators
+      q:=genwords[posi[i]]*genwords[posi[j]];
+      q:=q![1]; # the coefficients
+      q:=ShallowCopy(q*rels.coltrans); # coefficients wrt factor basis
+      dec:=[];
+      for k in [1..Length(posi)] do
+        x:=q[posi[k]] mod newmod[k];
+        if x<>0 then
+          Add(dec,x);
+          Add(dec,k);
+        fi;
+      od;
+      if Length(dec)>0 then
+        SetEntrySCTable(t,i,j,dec);
       fi;
     od;
-    # now determine the multiplication
-    t:=EmptySCTable(Length(posi),0);
-    for i in [1..Length(posi)] do
-      for j in [1..Length(posi)] do
-	# product of generators
-        q:=Rgens[posi[i]]*Rgens[posi[j]];
-	q:=q![1]; # the coefficients
-	dec:=[];
-	for k in [1..Length(posi)] do
-	  x:=q[posi[k]] mod newmod[posi[k]];
-	  if x<>0 then
-	    Add(dec,x);
-	    Add(dec,k);
-	  fi;
-	od;
-	if Length(dec)>0 then
-	  SetEntrySCTable(t,i,j,dec);
-	fi;
-      od;
-    od;
-  fi;
-  q:=RingByStructureConstants(newmod{posi},t,"q");
+  od;
+
+  q:=RingByStructureConstants(newmod,t,"q");
   # image list: Generators are mapped to their images
-  x:=List(GeneratorsOfRing(R),x->Zero(q));
-  x{posi}:=GeneratorsOfRing(q);
+  # rows of coltrans give expressions in new basis, but only posi indices
+  # count.
+  x:=(rels.coltrans{[1..Length(rels.coltrans)]}{posi})*GeneratorsOfRing(q);
   hom:=RingHomomorphismByImages(R,q,GeneratorsOfRing(R),x);
   SetIsSurjective(hom,true);
   SetKernelOfAdditiveGeneralMapping(hom,I);

--- a/tst/testextra/grpperm.tst
+++ b/tst/testextra/grpperm.tst
@@ -190,6 +190,10 @@ gap> SetInfoLevel(InfoPerformance,0);
 gap> s:=SymmetricGroup(56);;
 gap> List([1..7],x->Size(Normalizer(s,PrimitiveGroup(56,x))));
 [ 80640, 80640, 80640, 80640, 80640, 40320, 40320 ]
+gap> g:=SymmetricGroup(17);;s:=SylowSubgroup(g,NrMovedPoints(g));;
+gap> ac:=AscendingChain(g,s);;
+gap> Maximum(List([2..Length(ac)],x->Index(ac[x],ac[x-1])))<10^11;
+true
 gap> STOP_TEST( "grpperm.tst", 1);
 
 #############################################################################

--- a/tst/testinstall/alghom.tst
+++ b/tst/testinstall/alghom.tst
@@ -77,6 +77,28 @@ gap> I := Ideal(P, pols);;
 gap> pr := NaturalHomomorphismByIdeal(P, I);;
 gap> IsZero(Image(pr,x));
 false
+
+# example for structure constant rings, Martin Brandenburg on stackexchange
+gap> ExampleRing := function(n)
+> local T,O;
+> T := EmptySCTable(2,0);       # 2 generators e,x as Z-module
+> O := [2^n,2];                 # ord(e)=2^n and ord(x)=2
+> SetEntrySCTable(T,1,1,[1,1]); # e*e = 1*e
+> SetEntrySCTable(T,1,2,[1,2]); # e*x = 1*x
+> SetEntrySCTable(T,2,1,[1,2]); # x*e = 1*x
+> SetEntrySCTable(T,2,2,[]);    # x*x = 0
+> return RingByStructureConstants(O,T,["e","x"]);
+> end;;
+gap> R := ExampleRing(4);
+<ring with 2 generators>
+gap> id:=Ideal(R,[4*R.1-R.2]);
+<two-sided ideal in <ring with 2 generators>, (1 generators)>
+gap> Elements(id);
+[ 0*e, 4*e+x, 8*e, 12*e+x ]
+gap> Q:=R/id;
+<ring with 1 generators>
+gap> Elements(Q);
+[ 0*q1, q1, 2*q1, 3*q1, 4*q1, 5*q1, 6*q1, -q1 ]
 gap> STOP_TEST( "alghom.tst", 1);
 
 #############################################################################

--- a/tst/testinstall/numtheor.tst
+++ b/tst/testinstall/numtheor.tst
@@ -8,12 +8,10 @@ gap> oldLevel := InfoLevel(InfoPrimeInt);;
 gap> SetInfoLevel(InfoPrimeInt, 0); # turn off warnings
 gap> c := 87665785060273447596735547586847436354365986897267;;
 gap> d := 5676193656034756392656593936564928264920283748503726385950382638505826243749593626948538293405737101;;
-gap> RootMod(c,d); time < 20;
+gap> RootMod(c,d); 
 fail
-true
-gap> n:=2^2203-1;; RootMod(39,n); time < 300;
+gap> n:=2^2203-1;; RootMod(39,n);
 fail
-true
 
 #
 # PValuation

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -21,6 +21,11 @@ gap> g:=SymmetricGroup(13);;s:=SylowSubgroup(g,NrMovedPoints(g));;
 gap> ac:=AscendingChain(g,s);;
 gap> Maximum(List([2..Length(ac)],x->Index(ac[x],ac[x-1])))<600000;
 true
+gap> g:=SL(6,2);;
+gap> p:=Image(IsomorphismPermGroup(g));;
+gap> s:=SylowSubgroup(p,7);;
+gap> Length(IntermediateSubgroups(p,s).subgroups);
+71
 gap> STOP_TEST( "permgrp.tst", 1);
 
 #############################################################################

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -12,6 +12,15 @@ gap> Size(Normalizer(SymmetricGroup(100),PrimitiveGroup(100,1)));
 gap> g:=Image(RegularActionHomomorphism(AbelianGroup([4,5,5])));;
 gap> Size(Normalizer(SymmetricGroup(100),g));       
 96000
+gap> g:=SymmetricGroup(11);;s:=SylowSubgroup(g,NrMovedPoints(g));;
+gap> dc:=DoubleCosetRepsAndSizes(g,s,s);;
+gap> Length(dc);Sum(dc,x->x[2])=Size(g);
+329900
+true
+gap> g:=SymmetricGroup(13);;s:=SylowSubgroup(g,NrMovedPoints(g));;
+gap> ac:=AscendingChain(g,s);;
+gap> Maximum(List([2..Length(ac)],x->Index(ac[x],ac[x-1])))<600000;
+true
 gap> STOP_TEST( "permgrp.tst", 1);
 
 #############################################################################


### PR DESCRIPTION
Collection of improvements and fixes for 4.9. It contains:

- A fix for quotient rings of rings by structure constatnst (reported on stackexchange)
- Generic routine for transformation matrix to rational canonical form
- Speed improvements to block homomorphisms
- New routines for conjugates or subgroups with desired containment
- Performance improvement for conjugacy classes in groups with a huge number of classes.

The latter gives significant improvements to
- IntermediateSubgroups (try 7-Sylow in PSL(7,2))
- Ascending Chain and thus in turn improvement to
- Double coset calculations (and in turn routines that rely on it)
