### PR TITLE
11th HPC-GAP sync PR

### DIFF
--- a/hpcgap/src/gvars.c
+++ b/hpcgap/src/gvars.c
@@ -57,12 +57,12 @@
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/aobjects.h>           /* atomic objects */
 
-#include <src/hpc/systhread.h>          /* system thread primitives */
-
 #include <src/util.h>
 
+#ifdef HPCGAP
+#include <src/hpc/systhread.h>          /* system thread primitives */
 #include <stdio.h>
-
+#endif
 
 /****************************************************************************
 **
@@ -82,6 +82,10 @@
 Obj   ValGVars[GVAR_BUCKETS];
 
 Obj * PtrGVars[GVAR_BUCKETS];
+
+
+
+#ifdef HPCGAP
 
 /****************************************************************************
 **
@@ -129,6 +133,8 @@ void UnlockGVars() {
   }
   pthread_rwlock_unlock(&GVarLock);
 }
+
+#endif
 
 /****************************************************************************
 **
@@ -1477,8 +1483,10 @@ static Int PostSave (
 static Int InitLibrary (
     StructInitInfo *    module )
 {
+#ifdef HPCGAP
     /* Init lock */
     pthread_rwlock_init(&GVarLock, NULL);
+#endif
 
     /* make the error functions for 'AssGVar'                              */
     ErrorMustEvalToFuncFunc = NewFunctionC(
@@ -1488,10 +1496,12 @@ static Int InitLibrary (
         "ErrorMustHaveAssObj", -1L,"args", ErrorMustHaveAssObjHandler );
 
     /* make the list of global variables                                   */
-    SizeGVars  = 997;
+    SizeGVars  = 14033;
     TableGVars = NEW_PLIST( T_PLIST, SizeGVars );
-    MakeBagPublic(TableGVars);
     SET_LEN_PLIST( TableGVars, SizeGVars );
+#ifdef HPCGAP
+    MakeBagPublic(TableGVars);
+#endif
 
     /* Create the current namespace: */
     STATE(CurrNamespace) = NEW_STRING(0);

--- a/hpcgap/src/gvars.c
+++ b/hpcgap/src/gvars.c
@@ -867,38 +867,36 @@ UInt            completion_gvar (
 Obj FuncIDENTS_GVAR (
     Obj                 self )
 {
-    /*QQ extern Obj          NameGVars;   */
     Obj                 copy;
     UInt                i;
-    UInt		num_gvars;
+    UInt                numGVars;
 
     LockGVars(0);
-    num_gvars = CountGVars;
+    numGVars = CountGVars;
     UnlockGVars();
 
-    copy = NEW_PLIST( T_PLIST+IMMUTABLE, num_gvars );
-    for ( i = 1;  i <= num_gvars;  i++ ) {
+    copy = NEW_PLIST( T_PLIST+IMMUTABLE, numGVars );
+    for ( i = 1;  i <= numGVars;  i++ ) {
         SET_ELM_PLIST( copy, i,
 	  ELM_PLIST( NameGVars[GVAR_BUCKET(i)], GVAR_INDEX(i) ) );
     }
-    SET_LEN_PLIST( copy, num_gvars );
+    SET_LEN_PLIST( copy, numGVars );
     return copy;
 }
 
 Obj FuncIDENTS_BOUND_GVARS (
     Obj                 self )
 {
-    /*QQ extern Obj          NameGVars;   */
     Obj                 copy;
     UInt                i, j;
-    UInt		num_gvars;
+    UInt                numGVars;
 
     LockGVars(0);
-    num_gvars = CountGVars;
+    numGVars = CountGVars;
     UnlockGVars();
 
-    copy = NEW_PLIST( T_PLIST+IMMUTABLE, num_gvars );
-    for ( i = 1, j = 1;  i <= num_gvars;  i++ ) {
+    copy = NEW_PLIST( T_PLIST+IMMUTABLE, numGVars );
+    for ( i = 1, j = 1;  i <= numGVars;  i++ ) {
         if ( VAL_GVAR( i ) ||
 	     ELM_PLIST( ExprGVars[GVAR_BUCKET(i)], GVAR_INDEX(i) )) {
            SET_ELM_PLIST( copy, j,

--- a/hpcgap/src/gvars.c
+++ b/hpcgap/src/gvars.c
@@ -143,7 +143,7 @@ void UnlockGVars() {
 **  'VAL_GVAR' is defined in the declaration part of this package as follows
 **
 #define VAL_GVAR(gvar)          (PtrGVars[GVAR_BUCKET(gvar)] \
-				[GVAR_INDEX(gvar)-1])
+                                [GVAR_INDEX(gvar)-1])
 */
 
 
@@ -238,13 +238,13 @@ void            AssGVar (
     Obj *               copy;           /* one copy                        */
     UInt                i;              /* loop variable                   */
     Obj                 onam;           /* object of <name>                */
-    UInt		gvar_bucket = GVAR_BUCKET(gvar);
-    UInt		gvar_index = GVAR_INDEX(gvar);
+    UInt                gvar_bucket = GVAR_BUCKET(gvar);
+    UInt                gvar_index = GVAR_INDEX(gvar);
 
     /* make certain that the variable is not read only                     */
     while ( (REREADING != True) &&
             (ELM_PLIST( WriteGVars[gvar_bucket], gvar_index )
-	      == INTOBJ_INT(0)) ) {
+              == INTOBJ_INT(0)) ) {
         ErrorReturnVoid(
             "Variable: '%s' is read only",
             (Int)NameGVar(gvar), 0L,
@@ -254,10 +254,10 @@ void            AssGVar (
     /* assign the value to the global variable                             */
     if (!VAL_GVAR(gvar)) {
         Obj expr = ELM_PLIST(ExprGVars[gvar_bucket], gvar_index);
-	if (IS_INTOBJ(expr)) {
-	  AssTLRecord(TLVars, INT_INTOBJ(expr), val);
-	  return;
-	}
+        if (IS_INTOBJ(expr)) {
+          AssTLRecord(TLVars, INT_INTOBJ(expr), val);
+          return;
+        }
     }
     MEMBAR_WRITE();
     VAL_GVAR(gvar) = val;
@@ -278,12 +278,12 @@ void            AssGVar (
     /* if the value is a function, assign it to all the internal fopies    */
     cops = ELM_PLIST( FopiesGVars[gvar_bucket], gvar_index );
     if (IS_BAG_REF(val) && REGION(val) == 0) { /* public region? */
-	if ( cops != 0 && val != 0 && TNUM_OBJ(val) == T_FUNCTION ) {
-	    for ( i = 1; i <= LEN_PLIST(cops); i++ ) {
-		copy  = (Obj*) ELM_PLIST(cops,i);
-		*copy = val;
-	    }
-	}
+        if ( cops != 0 && val != 0 && TNUM_OBJ(val) == T_FUNCTION ) {
+            for ( i = 1; i <= LEN_PLIST(cops); i++ ) {
+                copy  = (Obj*) ELM_PLIST(cops,i);
+                *copy = val;
+            }
+        }
     }
 
     /* if the values is not a function, assign the error function          */
@@ -325,21 +325,21 @@ void            AssGVar (
 Obj             ValAutoGVar (
     UInt                gvar )
 {
-    Obj			expr;
+    Obj                 expr;
     Obj                 func;           /* function to call for automatic  */
     Obj                 arg;            /* argument to pass for automatic  */
-    Obj			val;
-    UInt		gvar_bucket = GVAR_BUCKET(gvar);
-    UInt		gvar_index  = GVAR_INDEX(gvar);
+    Obj                 val;
+    UInt                gvar_bucket = GVAR_BUCKET(gvar);
+    UInt                gvar_index  = GVAR_INDEX(gvar);
 
     /* if this is an automatic variable, make the function call            */
     val = ValGVar(gvar);
     if ( val == 0 && (expr = ExprGVar(gvar)) != 0 ) {
 
-	if (IS_INTOBJ(expr)) {
-	  /* thread-local variable */
-	  return GetTLRecordField(TLVars, INT_INTOBJ(expr));
-	}
+        if (IS_INTOBJ(expr)) {
+          /* thread-local variable */
+          return GetTLRecordField(TLVars, INT_INTOBJ(expr));
+        }
         /* make the function call                                          */
         func = ELM_PLIST( expr, 1 );
         arg  = ELM_PLIST( expr, 2 );
@@ -352,7 +352,7 @@ Obj             ValAutoGVar (
        "Variable: automatic variable '%s' must get a value by function call",
             (Int)NameGVar(gvar), 0L,
             "you can 'return;' after assigning a value" );
-	    val = ValGVar(gvar);
+            val = ValGVar(gvar);
         }
 
     }
@@ -371,19 +371,19 @@ Obj             ValAutoGVar (
 Obj             ValGVarTL (
     UInt                gvar )
 {
-    Obj			expr;
-    Obj			val;
-    UInt		gvar_bucket = GVAR_BUCKET(gvar);
-    UInt		gvar_index  = GVAR_INDEX(gvar);
+    Obj                 expr;
+    Obj                 val;
+    UInt                gvar_bucket = GVAR_BUCKET(gvar);
+    UInt                gvar_index  = GVAR_INDEX(gvar);
 
     val = ValGVar(gvar);
     /* is this a thread-local variable? */
     if ( val == 0 && (expr = ExprGVar(gvar)) != 0 ) {
 
-	if (IS_INTOBJ(expr)) {
-	  /* thread-local variable */
-	  return GetTLRecordField(TLVars, INT_INTOBJ(expr));
-	}
+        if (IS_INTOBJ(expr)) {
+          /* thread-local variable */
+          return GetTLRecordField(TLVars, INT_INTOBJ(expr));
+        }
     }
 
     /* return the value                                                    */
@@ -394,7 +394,7 @@ Obj FuncIsThreadLocalGvar( Obj self, Obj name) {
   UInt gvar, gvar_bucket, gvar_index;
   if (!IsStringConv(name))
     ErrorMayQuit("IsThreadLocalGVar: argument must be a string (not a %s)",
-		 (Int)TNAM_OBJ(name), 0L);
+                 (Int)TNAM_OBJ(name), 0L);
 
   gvar = GVarName(CSTR_STRING(name));
   gvar_bucket = GVAR_BUCKET(gvar);
@@ -505,15 +505,15 @@ UInt GVarName (
     }
     if (gvar == 0 && !PreThreadCreation) {
         /* upgrade to write lock and repeat search */
-	UnlockGVars();
-	LockGVars(1);
-	i = pos;
+        UnlockGVars();
+        LockGVars(1);
+        i = pos;
 
-	/* look through the table until we find a free slot or the global  */
-	while ( (gvar = ELM_PLIST( TableGVars, i )) != 0
-	     && strncmp( NameGVar( INT_INTOBJ(gvar) ), name, 1023 ) ) {
-	    i = (i % SizeGVars) + 1;
-	}
+        /* look through the table until we find a free slot or the global  */
+        while ( (gvar = ELM_PLIST( TableGVars, i )) != 0
+             && strncmp( NameGVar( INT_INTOBJ(gvar) ), name, 1023 ) ) {
+            i = (i % SizeGVars) + 1;
+        }
     }
 
     /* if we did not find the global variable, make a new one and enter it */
@@ -761,7 +761,7 @@ Obj             AUTOHandler (
     Obj                 name;           /* one name (as a GAP string)      */
     UInt                gvar;           /* one global variable             */
     UInt                i;              /* loop variable                   */
-    UInt		gvar_bucket, gvar_index;
+    UInt                gvar_bucket, gvar_index;
 
     /* check that there are enough arguments                               */
     if ( LEN_LIST(args) < 2 ) {
@@ -1128,7 +1128,7 @@ void UpdateCopyFopyInfo ( void )
     UInt                gvar;
     const Char *        name;           /* name of the variable            */
     Obj *               copy;           /* address of the copy             */
-    UInt		gvar_bucket, gvar_index;
+    UInt                gvar_bucket, gvar_index;
 
     LockGVars(1);
     /* loop over new copies and fopies                                     */

--- a/hpcgap/src/gvars.h
+++ b/hpcgap/src/gvars.h
@@ -172,6 +172,16 @@ extern  Obj            NameGVarObj (
 
 /****************************************************************************
 **
+*F  ExprGVar(<gvar>)  . . . . . .  expression of an automatic global variable
+**
+**  'ExprGVar' returns the expression of the automatic global variable <gvar>.
+*/
+extern  Obj            ExprGVar (
+            UInt                gvar );
+
+
+/****************************************************************************
+**
 *F  GVarName(<name>)  . . . . . . . . . . . . . .  global variable for a name
 **
 **  'GVarName' returns the global variable with the name <name>.

--- a/hpcgap/src/read.c
+++ b/hpcgap/src/read.c
@@ -177,9 +177,6 @@ UInt GlobalComesFromEnclosingForLoop (UInt var)
 **        |  <Var> '.' <Ident>
 **        |  <Var> '(' [ <Expr> { ',' <Expr> } ] [':' [ <options> ]] ')'
 */
-extern Obj ExprGVars[GVAR_BUCKETS];
-/* TL: extern Obj ErrorLVars; */
-/* TL: extern Obj BottomLVars; */
 
 /* This function reads the options part at the end of a function call
    The syntax is
@@ -509,7 +506,7 @@ void ReadCallVarAss (
       && var != STATE(CurrLHSGVar)
       && var != Tilde
       && VAL_GVAR(var) == 0
-      && ELM_PLIST(ExprGVars[GVAR_BUCKET(var)], GVAR_INDEX(var)) == 0
+      && ExprGVar(var) == 0
       && ! STATE(IntrIgnoring)
       && ! GlobalComesFromEnclosingForLoop(var)
       && (GAPInfo == 0 || !IS_REC(GAPInfo) || !ISB_REC(GAPInfo,WarnOnUnboundGlobalsRNam) ||

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -50,7 +50,6 @@ typedef struct GAPState {
     UInt      CurrLHSGVar;
     UInt      CurrentGlobalForLoopVariables[100];
     UInt      CurrentGlobalForLoopDepth;
-    Obj       ExprGVars;
     Obj       ReadEvalResult;
 
     /* From scanner.c */

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -711,33 +711,35 @@ UInt            completion_gvar (
 Obj FuncIDENTS_GVAR (
     Obj                 self )
 {
-    /*QQ extern Obj          NameGVars;   */
     Obj                 copy;
     UInt                i;
+    UInt                numGVars;
     Obj                 strcopy;
 
-    copy = NEW_PLIST( T_PLIST+IMMUTABLE, LEN_PLIST(NameGVars) );
-    for ( i = 1;  i <= LEN_PLIST(NameGVars);  i++ ) {
+    numGVars = LEN_PLIST(NameGVars);
+    copy = NEW_PLIST( T_PLIST+IMMUTABLE, numGVars );
+    for ( i = 1;  i <= numGVars;  i++ ) {
         /* Copy the string here, because we do not want members of NameGVars
          * accessable to users, as these strings must not be changed */
         strcopy = CopyToStringRep( ELM_PLIST( NameGVars, i ) );
         SET_ELM_PLIST( copy, i, strcopy );
         CHANGED_BAG( copy );
     }
-    SET_LEN_PLIST( copy, LEN_PLIST(NameGVars) );
+    SET_LEN_PLIST( copy, numGVars );
     return copy;
 }
 
 Obj FuncIDENTS_BOUND_GVARS (
     Obj                 self )
 {
-    /*QQ extern Obj          NameGVars;   */
     Obj                 copy;
     UInt                i, j;
+    UInt                numGVars;
     Obj                 strcopy;
 
-    copy = NEW_PLIST( T_PLIST+IMMUTABLE, LEN_PLIST(NameGVars) );
-    for ( i = 1, j = 1;  i <= LEN_PLIST(NameGVars);  i++ ) {
+    numGVars = LEN_PLIST(NameGVars);
+    copy = NEW_PLIST( T_PLIST+IMMUTABLE, numGVars );
+    for ( i = 1, j = 1;  i <= numGVars;  i++ ) {
         if ( VAL_GVAR( i ) || ELM_PLIST( ExprGVars, i )) {
            /* Copy the string here, because we do not want members of
             * NameGVars accessable to users, as these strings must not be

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -790,7 +790,7 @@ Obj FuncIDENTS_GVAR (
     copy = NEW_PLIST( T_PLIST+IMMUTABLE, numGVars );
     for ( i = 1;  i <= numGVars;  i++ ) {
         /* Copy the string here, because we do not want members of NameGVars
-         * accessable to users, as these strings must not be changed */
+         * accessible to users, as these strings must not be changed */
         strcopy = CopyToStringRep( NameGVarObj( i ) );
         SET_ELM_PLIST( copy, i, strcopy );
         CHANGED_BAG( copy );
@@ -812,7 +812,7 @@ Obj FuncIDENTS_BOUND_GVARS (
     for ( i = 1, j = 1;  i <= numGVars;  i++ ) {
         if ( VAL_GVAR( i ) || ELM_GVAR_LIST( ExprGVars, i ) ) {
            /* Copy the string here, because we do not want members of
-            * NameGVars accessable to users, as these strings must not be
+            * NameGVars accessible to users, as these strings must not be
             * changed */
            strcopy = CopyToStringRep( NameGVarObj( i ) );
            SET_ELM_PLIST( copy, j, strcopy );

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -217,7 +217,7 @@ void            AssGVar (
         else {
             ErrorReturnVoid(
                 "Variable: '%s' is read only",
-                (Int)CSTR_STRING( ELM_PLIST(NameGVars,gvar) ), 0L,
+                (Int)NameGVar(gvar), 0L,
                 "you can 'return;' after making it writable" );
         }
     }
@@ -288,18 +288,18 @@ Obj             ValAutoGVar (
     Obj                 arg;            /* argument to pass for automatic  */
 
     /* if this is an automatic variable, make the function call            */
-    if ( VAL_GVAR(gvar) == 0 && ELM_PLIST( ExprGVars, gvar ) != 0 ) {
+    if ( VAL_GVAR(gvar) == 0 && ExprGVar( gvar ) != 0 ) {
 
         /* make the function call                                          */
-        func = ELM_PLIST( ELM_PLIST( ExprGVars, gvar ), 1 );
-        arg  = ELM_PLIST( ELM_PLIST( ExprGVars, gvar ), 2 );
+        func = ELM_PLIST( ExprGVar( gvar ), 1 );
+        arg  = ELM_PLIST( ExprGVar( gvar ), 2 );
         CALL_1ARGS( func, arg );
 
         /* if this is still an automatic variable, this is an error        */
         while ( VAL_GVAR(gvar) == 0 ) {
             ErrorReturnVoid(
        "Variable: automatic variable '%s' must get a value by function call",
-                (Int)CSTR_STRING( ELM_PLIST(NameGVars,gvar) ), 0L,
+                (Int)NameGVar(gvar), 0L,
                 "you can 'return;' after assigning a value" );
         }
 
@@ -325,6 +325,11 @@ Char *          NameGVar (
 Obj NameGVarObj ( UInt gvar )
 {
     return ELM_PLIST( NameGVars, gvar );
+}
+
+Obj ExprGVar ( UInt gvar )
+{
+    return ELM_PLIST( ExprGVars, gvar );
 }
 
 #define NSCHAR '@'
@@ -682,7 +687,7 @@ UInt            completion_gvar (
     next = 0;
     for ( i = 1; i <= CountGVars; i++ ) {
         /* consider only variables which are currently bound for completion */
-        if ( VAL_GVAR( i ) || ELM_PLIST( ExprGVars, i )) {
+        if ( VAL_GVAR( i ) || ExprGVar( i )) {
             curr = NameGVar( i );
             for ( k = 0; name[k] != 0 && curr[k] == name[k]; k++ ) ;
             if ( k < len || curr[k] <= name[k] )  continue;
@@ -721,7 +726,7 @@ Obj FuncIDENTS_GVAR (
     for ( i = 1;  i <= numGVars;  i++ ) {
         /* Copy the string here, because we do not want members of NameGVars
          * accessable to users, as these strings must not be changed */
-        strcopy = CopyToStringRep( ELM_PLIST( NameGVars, i ) );
+        strcopy = CopyToStringRep( NameGVarObj( i ) );
         SET_ELM_PLIST( copy, i, strcopy );
         CHANGED_BAG( copy );
     }
@@ -740,11 +745,11 @@ Obj FuncIDENTS_BOUND_GVARS (
     numGVars = LEN_PLIST(NameGVars);
     copy = NEW_PLIST( T_PLIST+IMMUTABLE, numGVars );
     for ( i = 1, j = 1;  i <= numGVars;  i++ ) {
-        if ( VAL_GVAR( i ) || ELM_PLIST( ExprGVars, i )) {
+        if ( VAL_GVAR( i ) || ExprGVar( i ) ) {
            /* Copy the string here, because we do not want members of
             * NameGVars accessable to users, as these strings must not be
             * changed */
-           strcopy = CopyToStringRep( ELM_PLIST( NameGVars, i ) );
+           strcopy = CopyToStringRep( NameGVarObj( i ) );
            SET_ELM_PLIST( copy, j, strcopy );
            CHANGED_BAG( copy );
            j++;
@@ -794,8 +799,7 @@ Obj FuncISB_GVAR (
     }
 
     gv = GVarName( CSTR_STRING(gvar) );
-    return ( VAL_GVAR( gv ) ||
-             ELM_PLIST( ExprGVars, gv )) ? True : False;
+    return ( VAL_GVAR( gv ) || ExprGVar( gv )) ? True : False;
 }
 
 

--- a/src/gvars.h
+++ b/src/gvars.h
@@ -162,6 +162,16 @@ extern  Obj            NameGVarObj (
 
 /****************************************************************************
 **
+*F  ExprGVar(<gvar>)  . . . . . .  expression of an automatic global variable
+**
+**  'ExprGVar' returns the expression of the automatic global variable <gvar>.
+*/
+extern  Obj            ExprGVar (
+            UInt                gvar );
+
+
+/****************************************************************************
+**
 *F  GVarName(<name>)  . . . . . . . . . . . . . .  global variable for a name
 **
 **  'GVarName' returns the global variable with the name <name>.

--- a/src/plist.c
+++ b/src/plist.c
@@ -1303,7 +1303,8 @@ Obj             ElmvPlistDense (
 **  value at any of  the positions in <poss>, or  if an element of  <poss> is
 **  larger than the length of <list>.
 **
-**  'ElmsPlist' is the function in 'ElmsListFuncs' for plain lists.
+**  'ElmsPlist' is the function in 'ElmsListFuncs' for plain lists which are 
+**  not known to be dense.
 */
 Obj             ElmsPlist (
     Obj                 list,
@@ -1332,8 +1333,7 @@ Obj             ElmsPlist (
         lenPoss = LEN_LIST( poss );
 
         /* make the result list                                            */
-        /* do not assert "dense", list might be homogeneous                */
-        elms = NEW_PLIST( T_PLIST, lenPoss );
+        elms = NEW_PLIST( T_PLIST_DENSE, lenPoss );
         SET_LEN_PLIST( elms, lenPoss );
 
         /* loop over the entries of <positions> and select                 */
@@ -1397,8 +1397,7 @@ Obj             ElmsPlist (
         }
 
         /* make the result list                                            */
-        /* do not assert "dense", list might be homogeneous                */
-        elms = NEW_PLIST( T_PLIST, lenPoss );
+        elms = NEW_PLIST( T_PLIST_DENSE, lenPoss );
         SET_LEN_PLIST( elms, lenPoss );
 
         /* loop over the entries of <positions> and select                 */
@@ -1427,6 +1426,9 @@ Obj             ElmsPlist (
     /* return the result                                                   */
     return elms;
 }
+
+/* This version for lists which are known to be at least dense 
+   and might be better */
 
 Obj             ElmsPlistDense (
     Obj                 list,
@@ -1461,6 +1463,8 @@ Obj             ElmsPlistDense (
 	    elms = NEW_PLIST( MUTABLE_TNUM(TNUM_OBJ(list)), lenPoss);
 	    RESET_FILT_LIST( elms, FN_IS_NHOMOG); /* can't deduce this one */
 	  }
+	else if (HAS_FILT_LIST(list, FN_IS_RECT))
+	  elms = NEW_PLIST( T_PLIST_TAB_RECT, lenPoss );
 	else if (HAS_FILT_LIST(list, FN_IS_TABLE))
 	  elms = NEW_PLIST( T_PLIST_TAB, lenPoss );
 	else if (T_PLIST_CYC <= TNUM_OBJ(list) && TNUM_OBJ(list) <= 
@@ -1472,7 +1476,7 @@ Obj             ElmsPlistDense (
 	else if (HAS_FILT_LIST(list, FN_IS_HOMOG))
 	  elms = NEW_PLIST( T_PLIST_HOM, lenPoss );
 	else
-	  elms = NEW_PLIST( T_PLIST, lenPoss);
+	  elms = NEW_PLIST( T_PLIST_DENSE, lenPoss);
 	  
         SET_LEN_PLIST( elms, lenPoss );
 
@@ -1540,6 +1544,8 @@ Obj             ElmsPlistDense (
 		  SET_FILT_LIST(elms, FN_IS_NSORT);
 		}  */
 	  }
+	else if (HAS_FILT_LIST(list, FN_IS_RECT))
+	  elms = NEW_PLIST( T_PLIST_TAB_RECT, lenPoss );
 	else if (HAS_FILT_LIST(list, FN_IS_TABLE))
 	  elms = NEW_PLIST( T_PLIST_TAB, lenPoss );
 	else if (T_PLIST_CYC <= TNUM_OBJ(list) && TNUM_OBJ(list) <= 

--- a/src/read.c
+++ b/src/read.c
@@ -177,9 +177,6 @@ UInt GlobalComesFromEnclosingForLoop (UInt var)
 **        |  <Var> '.' <Ident>
 **        |  <Var> '(' [ <Expr> { ',' <Expr> } ] [':' [ <options> ]] ')'
 */
-extern Obj ExprGVars;
-/* TL: extern Obj ErrorLVars; */
-/* TL: extern Obj BottomLVars; */
 
 /* This function reads the options part at the end of a function call
    The syntax is
@@ -509,7 +506,7 @@ void ReadCallVarAss (
       && var != STATE(CurrLHSGVar)
       && var != Tilde
       && VAL_GVAR(var) == 0
-      && ELM_PLIST(ExprGVars,var) == 0
+      && ExprGVar(var) == 0
       && ! STATE(IntrIgnoring)
       && ! GlobalComesFromEnclosingForLoop(var)
       && (GAPInfo == 0 || !IS_REC(GAPInfo) || !ISB_REC(GAPInfo,WarnOnUnboundGlobalsRNam) ||


### PR DESCRIPTION
This PR mostly reduces differences between GVar handling in HPC-GAP and GAP. While we might want to start using the new bucket based gvar code in classic GAP, too, I figured that reducing the diffs is still worthwhile, as it makes it easier to see what actually did change. More work could be done here, too, but I didn't have a chance to do it yet.

This should be independent from PR #1302, so it could be be reviewed and merged before that one.