### PR TITLE
Remove two StructInitInfo members `isGapRootRelative` and `filename`

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -150,7 +150,6 @@ GAP_CPPFLAGS += $(LIBATOMIC_OPS_CPPFLAGS)
 GAP_CPPFLAGS += -Wall -Wextra \
 	-Wno-unused-parameter \
 	-Wno-sign-compare \
-	-Wno-missing-field-initializers \
 	-Wno-implicit-fallthrough
 
 # Finally add user provided flags

--- a/src/gap.h
+++ b/src/gap.h
@@ -454,10 +454,22 @@ extern Obj ErrorInner;
 
 /****************************************************************************
 **
-
 *F  Modules . . . . . . . . . . . . . . . . . . . . . . . . . list of modules
 */
-extern StructInitInfo * Modules [];
+typedef struct {
+
+    // pointer to the actual StructInitInfo
+    StructInitInfo * info;
+
+    // filename relative to GAP_ROOT or absolute
+    Char *           filename;
+
+    // true if the filename is GAP_ROOT relative
+    Int              isGapRootRelative;
+
+} StructInitInfoExt;
+
+extern StructInitInfoExt Modules [];
 extern UInt NrModules;
 extern UInt NrBuiltinModules;
 
@@ -473,6 +485,7 @@ extern UInt NrBuiltinModules;
 */
 extern void RecordLoadedModule (
     StructInitInfo *        module,
+    Int                     isGapRootRelative,
     Char *                  filename );
 
 

--- a/src/hookintrprtr.h
+++ b/src/hookintrprtr.h
@@ -102,7 +102,6 @@ Int DeactivateHooks(struct InterpreterHooks * hook);
 struct PrintHooks {
     void (*printStatPassthrough)(Stat stat);
     void (*printExprPassthrough)(Expr stat);
-    char * hookName;
 };
 
 void ActivatePrintHooks(struct PrintHooks * hook);

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -5977,9 +5977,7 @@ static StructInitInfo module = {
     0,                                  /* checkInit                      */
     0,                                  /* preSave                        */
     0,                                  /* postSave                       */
-    0,                                  /* postRestore                    */
-    "src/pperm.c",                      /* filename                       */
-    1                                   /* isGapRootRelative              */
+    0                                   /* postRestore                    */
 };
 
 StructInitInfo * InitInfoPPerm ( void )

--- a/src/streams.c
+++ b/src/streams.c
@@ -454,8 +454,7 @@ Int READ_GAP_ROOT ( Char * filename )
             Pr( "#W  init functions returned non-zero exit code\n", 0L, 0L );
         }
         
-        info->isGapRootRelative = 1;
-        RecordLoadedModule(info, filename);
+        RecordLoadedModule(info, 1, filename);
         return 1;
     }
 
@@ -474,8 +473,7 @@ Int READ_GAP_ROOT ( Char * filename )
         if ( res ) {
             Pr( "#W  init functions returned non-zero exit code\n", 0L, 0L );
         }
-        info->isGapRootRelative = 1;
-        RecordLoadedModule(info, filename);
+        RecordLoadedModule(info, 1, filename);
         return 1;
     }
 

--- a/src/system.c
+++ b/src/system.c
@@ -1751,7 +1751,7 @@ struct optInfo options[] = {
   { 0  , "prof", enableProfilingAtStartup, 0, 1},    /* enable profiling at startup */
   { 0  , "cover", enableCodeCoverageAtStartup, 0, 1}, /* enable code coverage at startup */
   { 0  , "quitonbreak", toggle, &SyQuitOnBreak, 0}, /* Quit GAP if we enter the break loop */
-  { 0, "",0,0}};
+  { 0, "", 0, 0, 0}};
 
 
 Char ** SyOriginalArgv;

--- a/src/system.h
+++ b/src/system.h
@@ -842,12 +842,6 @@ typedef struct init_info {
     /* function to call after restoring workspace                          */
     Int              (* postRestore)(struct init_info *);
 
-    /* filename relative to GAP_ROOT or absolut                            */
-    Char *           filename;
-
-    /* true if the filename is GAP_ROOT relative                           */
-    Int              isGapRootRelative;
-
 } StructInitInfo;
 
 typedef StructInitInfo* (*InitInfoFunc)(void);

--- a/src/trans.c
+++ b/src/trans.c
@@ -5372,9 +5372,7 @@ static StructInitInfo module = {
     0,                                  /* checkInit                      */
     0,                                  /* preSave                        */
     0,                                  /* postSave                       */
-    0,                                  /* postRestore                    */
-    "src/trans.c",                      /* filename                       */
-    1                                   /* isGapRootRelative              */
+    0                                   /* postRestore                    */
 };
 
 StructInitInfo * InitInfoTrans ( void )


### PR DESCRIPTION
The motivation for this is that these members should not be exposed to kernel extension, as they are initialized by GAP itself, yet if kernel extensions don't init them, they may see annoying compiler warnings.