### PR TITLE
lib/string.gi: add \+ for strings, shows more helpful error

### DIFF
--- a/lib/string.gi
+++ b/lib/string.gi
@@ -1221,6 +1221,23 @@ local f,i,j,format,cold,a,e,z,str,new,box,lc,mini,color,alt,renum;
   AppendTo(file,"\\end{tabular}\n");
 end);
 
+
+#############################################################################
+##
+#F  Convenience method to inform users how to concatenate strings.
+##
+##  Note that we could also have this method do the following
+##     return Concatenation(a,b);
+##  instead of raising an error. But this leads to inefficient code when
+##  concatenating many strings. So in order to not encourage such bad code,
+##  we instead tell the user the proper way to do this.
+##
+InstallOtherMethod(\+, [IsString,IsString],
+function(a,b)
+    Error("concatenating strings via + is not supported, use Concatenation(<a>,<b>) instead");
+end);
+
+
 #############################################################################
 ##
 #E


### PR DESCRIPTION
This is an alternative to PR #1313, which instead actually concatenates its inputs.