### PR TITLE
Switch ~ from a global variable to being handled in the parser.

### DIFF
--- a/hpcgap/src/exprs.c
+++ b/hpcgap/src/exprs.c
@@ -883,6 +883,20 @@ Obj             EvalIntExpr (
     return val;
 }
 
+/****************************************************************************
+**
+*F  EvalTildeExpr(<expr>)  . . . . . . . . .  evaluate tilde expression
+**
+**  'EvalTrueExpr' evaluates the tilde expression and returns its value.
+*/
+Obj             EvalTildeExpr (
+    Expr                expr )
+{
+    if( ! (STATE(Tilde)) ) {
+        ErrorQuit("'~' does not have a value here",0L,0L);
+    }
+    return STATE(Tilde);
+}
 
 /****************************************************************************
 **
@@ -1082,19 +1096,19 @@ Obj             EvalListTildeExpr (
     Obj                 tilde;          /* old value of tilde              */
 
     /* remember the old value of '~'                                       */
-    tilde = ValAutoGVar( Tilde );
+    tilde = STATE( Tilde );
 
     /* create the list value                                               */
     list = ListExpr1( expr );
 
     /* assign the list to '~'                                              */
-    AssGVar( Tilde, list );
+    STATE( Tilde ) = list;
 
     /* evaluate the subexpressions into the list value                     */
     ListExpr2( list, expr );
 
     /* restore old value of '~'                                            */
-    AssGVar( Tilde, tilde );
+    STATE( Tilde ) = tilde;
 
     /* return the list value                                               */
     return list;
@@ -1437,19 +1451,19 @@ Obj             EvalRecTildeExpr (
     Obj                 tilde;          /* old value of tilde              */
 
     /* remember the old value of '~'                                       */
-    tilde = ValAutoGVar( Tilde );
+    tilde = STATE( Tilde );
 
     /* create the record value                                             */
     rec = RecExpr1( expr );
 
     /* assign the record value to the variable '~'                         */
-    AssGVar( Tilde, rec );
+    STATE( Tilde ) = rec;
 
     /* evaluate the subexpressions into the record value                   */
     RecExpr2( rec, expr );
 
     /* restore the old value of '~'                                        */
-    AssGVar( Tilde, tilde );
+    STATE( Tilde ) = tilde;
 
     /* return the record value                                             */
     return rec;
@@ -1745,6 +1759,16 @@ void            PrintIntExpr (
 
 /****************************************************************************
 **
+*F  PrintTildeExpr(<expr>) . . . . . . . . . . . print tilde expression
+*/
+void            PrintTildeExpr (
+    Expr                expr )
+{
+    Pr( "~", 0L, 0L );
+}
+
+/****************************************************************************
+**
 *F  PrintTrueExpr(<expr>) . . . . . . . . . . . print literal true expression
 */
 void            PrintTrueExpr (
@@ -2037,6 +2061,7 @@ static Int InitKernel (
     InstallEvalExprFunc( T_INT_EXPR       , EvalIntExpr);
     InstallEvalExprFunc( T_TRUE_EXPR      , EvalTrueExpr);
     InstallEvalExprFunc( T_FALSE_EXPR     , EvalFalseExpr);
+    InstallEvalExprFunc( T_TILDE_EXPR     , EvalTildeExpr);
     InstallEvalExprFunc( T_CHAR_EXPR      , EvalCharExpr);
     InstallEvalExprFunc( T_PERM_EXPR      , EvalPermExpr);
 
@@ -2084,6 +2109,7 @@ static Int InitKernel (
     InstallPrintExprFunc( T_INT_EXPR       , PrintIntExpr);
     InstallPrintExprFunc( T_TRUE_EXPR      , PrintTrueExpr);
     InstallPrintExprFunc( T_FALSE_EXPR     , PrintFalseExpr);
+    InstallPrintExprFunc( T_TILDE_EXPR     , PrintTildeExpr);
     InstallPrintExprFunc( T_CHAR_EXPR      , PrintCharExpr);
     InstallPrintExprFunc( T_PERM_EXPR      , PrintPermExpr);
 

--- a/hpcgap/src/gvars.c
+++ b/hpcgap/src/gvars.c
@@ -571,20 +571,6 @@ UInt GVarName (
 
 /****************************************************************************
 **
-
-*V  Tilde . . . . . . . . . . . . . . . . . . . . . . . . global variable '~'
-**
-**  'Tilde' is  the global variable '~', the  one used in expressions such as
-**  '[ [ 1, 2 ], ~[1] ]'.
-**
-**  Actually  when such expressions  appear in functions, one should probably
-**  use a local variable.  But for now this is good enough.
-*/
-UInt Tilde;
-
-
-/****************************************************************************
-**
 *F  MakeReadOnlyGVar( <gvar> )  . . . . . .  make a global variable read only
 */
 void MakeReadOnlyGVar (
@@ -1435,15 +1421,6 @@ static Int PostRestore (
     CountGVars = LEN_PLIST( ValGVars );
     PtrGVars   = ADDR_OBJ( ValGVars );
     SizeGVars  = LEN_PLIST( TableGVars );
-#endif
-
-    /* create the global variable '~'                                      */
-    Tilde = GVarName( "~" );
-
-#if !defined(HPCGAP)
-    /* stop unauthorised changes to '~'                                    */
-    // FIXME: enabling this causes HPC-GAP to crash
-    MakeReadOnlyGVar(Tilde);
 #endif
 
     /* update fopies and copies                                            */

--- a/hpcgap/src/gvars.h
+++ b/hpcgap/src/gvars.h
@@ -192,19 +192,6 @@ extern UInt GVarName (
 
 /****************************************************************************
 **
-*V  Tilde . . . . . . . . . . . . . . . . . . . . . . . . global variable '~'
-**
-**  'Tilde' is the  identifier for the global variable  '~', the one  used in
-**  expressions such as '[ [ 1, 2 ], ~[1] ]'.
-**
-**  Actually  when such expressions  appear in functions, one should probably
-**  use a local variable.  But for now this is good enough.
-*/
-extern  UInt            Tilde;
-
-
-/****************************************************************************
-**
 *F  iscomplete_gvar( <name>, <len> )  . . . . . . . . . . . . .  check <name>
 */
 extern UInt iscomplete_gvar (

--- a/hpcgap/src/intrprtr.c
+++ b/hpcgap/src/intrprtr.c
@@ -2190,6 +2190,28 @@ void            IntrFalseExpr ( void )
 
 /****************************************************************************
 **
+*F  IntrTildeExpr()  . . . . . . . . . . . . interpret tilde expression
+**
+**  'IntrTildeExpr' is the action to interpret a tilde expression.
+*/
+void            IntrTildeExpr ( void )
+{
+    /* ignore or code                                                      */
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeTildeExpr(); return; }
+
+    if(! (STATE(Tilde)) ) {
+        ErrorQuit("'~' does not have a value here", 0L, 0L);
+    }
+
+    /* push the value                                                      */
+    PushObj( STATE(Tilde) );
+}
+
+
+/****************************************************************************
+**
 *F  IntrCharExpr(<chr>) . . . . . . .  interpret literal character expression
 **
 **  'IntrCharExpr' is the action to interpret a literal character expression.
@@ -2374,10 +2396,10 @@ void            IntrListExprBegin (
     /* if this is an outmost list, save it for reference in '~'            */
     /* (and save the old value of '~' on the values stack)                 */
     if ( top ) {
-        old = ValAutoGVar( Tilde );
+        old = STATE( Tilde );
         if ( old != 0 ) { PushObj( old ); }
         else            { PushVoidObj();  }
-        AssGVar( Tilde, list );
+        STATE( Tilde ) = list;
     }
 
     /* push the list                                                       */
@@ -2450,7 +2472,7 @@ void            IntrListExprEnd (
     if ( top ) {
         list = PopObj();
         old = PopVoidObj();
-        AssGVar( Tilde, old );
+        STATE( Tilde ) = old;
         PushObj( list );
     }
 
@@ -2587,10 +2609,10 @@ void            IntrRecExprBegin (
     /* if this is an outmost record, save it for reference in '~'          */
     /* (and save the old value of '~' on the values stack)                 */
     if ( top ) {
-        old = ValAutoGVar( Tilde );
+        old = STATE( Tilde );
         if ( old != 0 ) { PushObj( old ); }
         else            { PushVoidObj();  }
-        AssGVar( Tilde, record );
+        STATE( Tilde ) = record;
     }
 
     /* push the record                                                     */
@@ -2673,7 +2695,7 @@ void            IntrRecExprEnd (
     if ( top ) {
         record = PopObj();
         old = PopVoidObj();
-        AssGVar( Tilde, old );
+        STATE( Tilde ) = old;
         PushObj( record );
     }
 }

--- a/hpcgap/src/read.c
+++ b/hpcgap/src/read.c
@@ -504,7 +504,6 @@ void ReadCallVarAss (
     if ( type == 'g'
       && STATE(CountNams) != 0
       && var != STATE(CurrLHSGVar)
-      && var != Tilde
       && VAL_GVAR(var) == 0
       && ExprGVar(var) == 0
       && ! STATE(IntrIgnoring)
@@ -515,9 +514,6 @@ void ReadCallVarAss (
     {
         SyntaxWarning("Unbound global variable");
     }
-
-    /* check whether this is a reference to the global variable '~'        */
-    if ( type == 'g' && var == Tilde ) { STATE(ReadTilde) = 1; }
 
     /* followed by one or more selectors                                   */
     while ( IS_IN( STATE(Symbol), S_LPAREN|S_LBRACK|S_LBRACE|S_DOT ) ) {
@@ -1103,7 +1099,10 @@ void ReadListExpr (
     /* '['                                                                 */
     Match( S_LBRACK, "[", follow );
     STATE(ReadTop)++;
-    if ( STATE(ReadTop) == 1 ) { STATE(ReadTilde) = 0; }
+    if ( STATE(ReadTop) == 1 ) {
+        STATE(ReadTilde) = 0;
+        STATE(Tilde) = 0;
+    }
     TRY_READ { IntrListExprBegin( (STATE(ReadTop) == 1) ); }
     pos   = 1;
     nr    = 0;
@@ -1159,7 +1158,10 @@ void ReadListExpr (
     TRY_READ {
         IntrListExprEnd( nr, range, (STATE(ReadTop) == 1), (STATE(ReadTilde) == 1) );
     }
-    if ( STATE(ReadTop) == 1 ) { STATE(ReadTilde) = 0; }
+    if ( STATE(ReadTop) == 1 ) {
+        STATE(ReadTilde) = 0;
+        STATE(Tilde) = 0;
+    }
     STATE(ReadTop)--;
 }
 
@@ -1183,7 +1185,10 @@ void ReadRecExpr (
     Match( S_REC, "rec", follow );
     Match( S_LPAREN, "(", follow|S_RPAREN|S_COMMA );
     STATE(ReadTop)++;
-    if ( STATE(ReadTop) == 1 ) { STATE(ReadTilde) = 0; }
+    if ( STATE(ReadTop) == 1 ) {
+        STATE(ReadTilde) = 0;
+        STATE(Tilde) = 0;
+    }
     TRY_READ { IntrRecExprBegin( (STATE(ReadTop) == 1) ); }
     nr = 0;
 
@@ -1226,7 +1231,10 @@ void ReadRecExpr (
     TRY_READ {
         IntrRecExprEnd( nr, (STATE(ReadTop) == 1), (STATE(ReadTilde) == 1) );
     }
-    if ( STATE(ReadTop) == 1) { STATE(ReadTilde) = 0; }
+    if ( STATE(ReadTop) == 1) {
+        STATE(ReadTilde) = 0;
+        STATE(Tilde) = 0;
+    }
     STATE(ReadTop)--;
 }
 
@@ -1624,6 +1632,13 @@ void ReadLiteral (
         IntrFalseExpr();
         break;
 
+    /* '~'                                                                 */
+    case S_TILDE:
+        STATE(ReadTilde) = 1;
+        TRY_READ { IntrTildeExpr(); }
+        Match( S_TILDE, "~", follow );
+        break;
+
     /* <Char>                                                              */
     case S_CHAR:
         TRY_READ { IntrCharExpr( STATE(Value)[0] ); }
@@ -1717,7 +1732,7 @@ void ReadAtom (
     }
     /* otherwise read a literal expression                                 */
     else if (IS_IN(STATE(Symbol),S_INT|S_TRUE|S_FALSE|S_CHAR|S_STRING|S_LBRACK|
-                          S_REC|S_FUNCTION|
+                          S_TILDE|S_REC|S_FUNCTION|
 #ifdef HPCGAP
                           S_DO|
 #endif

--- a/hpcgap/src/scanner.c
+++ b/hpcgap/src/scanner.c
@@ -2206,8 +2206,7 @@ void GetSymbol ( void )
   case '\\':                                          GetIdent();  break;
   case '_':                                           GetIdent();  break;
   case '@':                                           GetIdent();  break;
-  case '~':   STATE(Value)[0] = '~';  STATE(Value)[1] = '\0';
-    STATE(Symbol) = S_IDENT;                       GET_CHAR();  break;
+  case '~':   STATE(Symbol) = S_TILDE;                GET_CHAR();  break;
 
   case '0': case '1': case '2': case '3': case '4':
   case '5': case '6': case '7': case '8': case '9':

--- a/src/code.c
+++ b/src/code.c
@@ -1789,6 +1789,17 @@ void CodeLongIntExpr (
 
 /****************************************************************************
 **
+*F  CodeTildeExpr()  . . . . . . . . . . . . . .  code tilde expression
+**
+**  'CodeTildeExpr' is the action to code a tilde expression.
+*/
+void CodeTildeExpr ( void )
+{
+    PushExpr( NewExpr( T_TILDE_EXPR, 0L ) );
+}
+
+/****************************************************************************
+**
 *F  CodeTrueExpr()  . . . . . . . . . . . . . .  code literal true expression
 **
 **  'CodeTrueExpr' is the action to code a literal true expression.

--- a/src/code.h
+++ b/src/code.h
@@ -89,93 +89,96 @@ void SET_ENDLINE_BODY(Obj body, Obj val);
 */
 #define FIRST_STAT_TNUM         (0UL)
 
-#define T_PROCCALL_0ARGS        (FIRST_STAT_TNUM+ 0)
-#define T_PROCCALL_1ARGS        (FIRST_STAT_TNUM+ 1)
-#define T_PROCCALL_2ARGS        (FIRST_STAT_TNUM+ 2)
-#define T_PROCCALL_3ARGS        (FIRST_STAT_TNUM+ 3)
-#define T_PROCCALL_4ARGS        (FIRST_STAT_TNUM+ 4)
-#define T_PROCCALL_5ARGS        (FIRST_STAT_TNUM+ 5)
-#define T_PROCCALL_6ARGS        (FIRST_STAT_TNUM+ 6)
-#define T_PROCCALL_XARGS        (FIRST_STAT_TNUM+ 7)
+enum STAT_TNUMS {
 
-#define T_SEQ_STAT              (FIRST_STAT_TNUM+ 8)
-#define T_SEQ_STAT2             (FIRST_STAT_TNUM+ 9)
-#define T_SEQ_STAT3             (FIRST_STAT_TNUM+10)
-#define T_SEQ_STAT4             (FIRST_STAT_TNUM+11)
-#define T_SEQ_STAT5             (FIRST_STAT_TNUM+12)
-#define T_SEQ_STAT6             (FIRST_STAT_TNUM+13)
-#define T_SEQ_STAT7             (FIRST_STAT_TNUM+14)
-#define T_IF                    (FIRST_STAT_TNUM+15)
-#define T_IF_ELSE               (FIRST_STAT_TNUM+16)
-#define T_IF_ELIF               (FIRST_STAT_TNUM+17)
-#define T_IF_ELIF_ELSE          (FIRST_STAT_TNUM+18)
-#define T_FOR                   (FIRST_STAT_TNUM+19)
-#define T_FOR2                  (FIRST_STAT_TNUM+20)
-#define T_FOR3                  (FIRST_STAT_TNUM+21)
-#define T_FOR_RANGE             (FIRST_STAT_TNUM+22)
-#define T_FOR_RANGE2            (FIRST_STAT_TNUM+23)
-#define T_FOR_RANGE3            (FIRST_STAT_TNUM+24)
-#define T_WHILE                 (FIRST_STAT_TNUM+25)
-#define T_WHILE2                (FIRST_STAT_TNUM+26)
-#define T_WHILE3                (FIRST_STAT_TNUM+27)
-#define T_REPEAT                (FIRST_STAT_TNUM+28)
-#define T_REPEAT2               (FIRST_STAT_TNUM+29)
-#define T_REPEAT3               (FIRST_STAT_TNUM+30)
-#define T_BREAK                 (FIRST_STAT_TNUM+31)
-#define T_CONTINUE              (FIRST_STAT_TNUM+32)
-#define T_RETURN_OBJ            (FIRST_STAT_TNUM+33)
-#define T_RETURN_VOID           (FIRST_STAT_TNUM+34)
+    T_PROCCALL_0ARGS,
+    T_PROCCALL_1ARGS,
+    T_PROCCALL_2ARGS,
+    T_PROCCALL_3ARGS,
+    T_PROCCALL_4ARGS,
+    T_PROCCALL_5ARGS,
+    T_PROCCALL_6ARGS,
+    T_PROCCALL_XARGS,
 
-#define T_ASS_LVAR              (FIRST_STAT_TNUM+35)
-#define T_ASS_LVAR_01           (FIRST_STAT_TNUM+36)
-#define T_ASS_LVAR_02           (FIRST_STAT_TNUM+37)
-#define T_ASS_LVAR_03           (FIRST_STAT_TNUM+38)
-#define T_ASS_LVAR_04           (FIRST_STAT_TNUM+39)
-#define T_ASS_LVAR_05           (FIRST_STAT_TNUM+40)
-#define T_ASS_LVAR_06           (FIRST_STAT_TNUM+41)
-#define T_ASS_LVAR_07           (FIRST_STAT_TNUM+42)
-#define T_ASS_LVAR_08           (FIRST_STAT_TNUM+43)
-#define T_ASS_LVAR_09           (FIRST_STAT_TNUM+44)
-#define T_ASS_LVAR_10           (FIRST_STAT_TNUM+45)
-#define T_ASS_LVAR_11           (FIRST_STAT_TNUM+46)
-#define T_ASS_LVAR_12           (FIRST_STAT_TNUM+47)
-#define T_ASS_LVAR_13           (FIRST_STAT_TNUM+48)
-#define T_ASS_LVAR_14           (FIRST_STAT_TNUM+49)
-#define T_ASS_LVAR_15           (FIRST_STAT_TNUM+50)
-#define T_ASS_LVAR_16           (FIRST_STAT_TNUM+51)
-#define T_UNB_LVAR              (FIRST_STAT_TNUM+52)
-#define T_ASS_HVAR              (FIRST_STAT_TNUM+53)
-#define T_UNB_HVAR              (FIRST_STAT_TNUM+54)
-#define T_ASS_GVAR              (FIRST_STAT_TNUM+55)
-#define T_UNB_GVAR              (FIRST_STAT_TNUM+56)
-#define T_ASS_LIST              (FIRST_STAT_TNUM+57)
-#define T_ASSS_LIST             (FIRST_STAT_TNUM+58)
-#define T_ASS_LIST_LEV          (FIRST_STAT_TNUM+59)
-#define T_ASSS_LIST_LEV         (FIRST_STAT_TNUM+60)
-#define T_UNB_LIST              (FIRST_STAT_TNUM+61)
-#define T_ASS_REC_NAME          (FIRST_STAT_TNUM+62)
-#define T_ASS_REC_EXPR          (FIRST_STAT_TNUM+63)
-#define T_UNB_REC_NAME          (FIRST_STAT_TNUM+64)
-#define T_UNB_REC_EXPR          (FIRST_STAT_TNUM+65)
-#define T_ASS_POSOBJ            (FIRST_STAT_TNUM+66)
-#define T_ASSS_POSOBJ           (FIRST_STAT_TNUM+67)
-#define T_ASS_POSOBJ_LEV        (FIRST_STAT_TNUM+68)
-#define T_ASSS_POSOBJ_LEV       (FIRST_STAT_TNUM+69)
-#define T_UNB_POSOBJ            (FIRST_STAT_TNUM+70)
-#define T_ASS_COMOBJ_NAME       (FIRST_STAT_TNUM+71)
-#define T_ASS_COMOBJ_EXPR       (FIRST_STAT_TNUM+72)
-#define T_UNB_COMOBJ_NAME       (FIRST_STAT_TNUM+73)
-#define T_UNB_COMOBJ_EXPR       (FIRST_STAT_TNUM+74)
+    T_SEQ_STAT,
+    T_SEQ_STAT2,
+    T_SEQ_STAT3,
+    T_SEQ_STAT4,
+    T_SEQ_STAT5,
+    T_SEQ_STAT6,
+    T_SEQ_STAT7,
+    T_IF,
+    T_IF_ELSE,
+    T_IF_ELIF,
+    T_IF_ELIF_ELSE,
+    T_FOR,
+    T_FOR2,
+    T_FOR3,
+    T_FOR_RANGE,
+    T_FOR_RANGE2,
+    T_FOR_RANGE3,
+    T_WHILE,
+    T_WHILE2,
+    T_WHILE3,
+    T_REPEAT,
+    T_REPEAT2,
+    T_REPEAT3,
+    T_BREAK,
+    T_CONTINUE,
+    T_RETURN_OBJ,
+    T_RETURN_VOID,
 
-#define T_INFO                  (FIRST_STAT_TNUM+75)
-#define T_ASSERT_2ARGS          (FIRST_STAT_TNUM+76)
-#define T_ASSERT_3ARGS          (FIRST_STAT_TNUM+77)
+    T_ASS_LVAR,
+    T_ASS_LVAR_01,
+    T_ASS_LVAR_02,
+    T_ASS_LVAR_03,
+    T_ASS_LVAR_04,
+    T_ASS_LVAR_05,
+    T_ASS_LVAR_06,
+    T_ASS_LVAR_07,
+    T_ASS_LVAR_08,
+    T_ASS_LVAR_09,
+    T_ASS_LVAR_10,
+    T_ASS_LVAR_11,
+    T_ASS_LVAR_12,
+    T_ASS_LVAR_13,
+    T_ASS_LVAR_14,
+    T_ASS_LVAR_15,
+    T_ASS_LVAR_16,
+    T_UNB_LVAR,
+    T_ASS_HVAR,
+    T_UNB_HVAR,
+    T_ASS_GVAR,
+    T_UNB_GVAR,
+    T_ASS_LIST,
+    T_ASSS_LIST,
+    T_ASS_LIST_LEV,
+    T_ASSS_LIST_LEV,
+    T_UNB_LIST,
+    T_ASS_REC_NAME,
+    T_ASS_REC_EXPR,
+    T_UNB_REC_NAME,
+    T_UNB_REC_EXPR,
+    T_ASS_POSOBJ,
+    T_ASSS_POSOBJ,
+    T_ASS_POSOBJ_LEV,
+    T_ASSS_POSOBJ_LEV,
+    T_UNB_POSOBJ,
+    T_ASS_COMOBJ_NAME,
+    T_ASS_COMOBJ_EXPR,
+    T_UNB_COMOBJ_NAME,
+    T_UNB_COMOBJ_EXPR,
 
-#define T_EMPTY                 (FIRST_STAT_TNUM+78)
+    T_INFO,
+    T_ASSERT_2ARGS,
+    T_ASSERT_3ARGS,
 
-#define T_PROCCALL_OPTS         (FIRST_STAT_TNUM+ 79)
+    T_EMPTY,
 
-#define T_ATOMIC               (FIRST_STAT_TNUM+80)
+    T_PROCCALL_OPTS,
+
+    T_ATOMIC,
+};
 
 #define LAST_STAT_TNUM          T_ATOMIC
 
@@ -320,85 +323,88 @@ typedef Stat Expr;
 **  As long as  expressions  are represented by  bags,  these types must  not
 **  overlap with the object types, lest Gasman becomes confused.
 */
+
 #define FIRST_EXPR_TNUM         ((UInt)128)
 
-#define T_FUNCCALL_0ARGS        (FIRST_EXPR_TNUM+ 0)
-#define T_FUNCCALL_1ARGS        (FIRST_EXPR_TNUM+ 1)
-#define T_FUNCCALL_2ARGS        (FIRST_EXPR_TNUM+ 2)
-#define T_FUNCCALL_3ARGS        (FIRST_EXPR_TNUM+ 3)
-#define T_FUNCCALL_4ARGS        (FIRST_EXPR_TNUM+ 4)
-#define T_FUNCCALL_5ARGS        (FIRST_EXPR_TNUM+ 5)
-#define T_FUNCCALL_6ARGS        (FIRST_EXPR_TNUM+ 6)
-#define T_FUNCCALL_XARGS        (FIRST_EXPR_TNUM+ 7)
-#define T_FUNC_EXPR             (FIRST_EXPR_TNUM+ 8)
+enum EXPR_TNUM {
+    T_FUNCCALL_0ARGS = FIRST_EXPR_TNUM,
+    T_FUNCCALL_1ARGS,
+    T_FUNCCALL_2ARGS,
+    T_FUNCCALL_3ARGS,
+    T_FUNCCALL_4ARGS,
+    T_FUNCCALL_5ARGS,
+    T_FUNCCALL_6ARGS,
+    T_FUNCCALL_XARGS,
+    T_FUNC_EXPR,
 
-#define T_OR                    (FIRST_EXPR_TNUM+ 9)
-#define T_AND                   (FIRST_EXPR_TNUM+10)
-#define T_NOT                   (FIRST_EXPR_TNUM+11)
-#define T_EQ                    (FIRST_EXPR_TNUM+12)
-#define T_NE                    (FIRST_EXPR_TNUM+13)
-#define T_LT                    (FIRST_EXPR_TNUM+14)
-#define T_GE                    (FIRST_EXPR_TNUM+15)
-#define T_GT                    (FIRST_EXPR_TNUM+16)
-#define T_LE                    (FIRST_EXPR_TNUM+17)
-#define T_IN                    (FIRST_EXPR_TNUM+18)
-#define T_SUM                   (FIRST_EXPR_TNUM+19)
-#define T_AINV                  (FIRST_EXPR_TNUM+20)
-#define T_DIFF                  (FIRST_EXPR_TNUM+21)
-#define T_PROD                  (FIRST_EXPR_TNUM+22)
-#define T_INV                   (FIRST_EXPR_TNUM+23)
-#define T_QUO                   (FIRST_EXPR_TNUM+24)
-#define T_MOD                   (FIRST_EXPR_TNUM+25)
-#define T_POW                   (FIRST_EXPR_TNUM+26)
+    T_OR,
+    T_AND,
+    T_NOT,
+    T_EQ,
+    T_NE,
+    T_LT,
+    T_GE,
+    T_GT,
+    T_LE,
+    T_IN,
+    T_SUM,
+    T_AINV,
+    T_DIFF,
+    T_PROD,
+    T_INV,
+    T_QUO,
+    T_MOD,
+    T_POW,
 
-#define T_INTEXPR               (FIRST_EXPR_TNUM+27)
-#define T_INT_EXPR              (FIRST_EXPR_TNUM+28)
-#define T_TRUE_EXPR             (FIRST_EXPR_TNUM+29)
-#define T_FALSE_EXPR            (FIRST_EXPR_TNUM+30)
-#define T_CHAR_EXPR             (FIRST_EXPR_TNUM+31)
-#define T_PERM_EXPR             (FIRST_EXPR_TNUM+32)
-#define T_PERM_CYCLE            (FIRST_EXPR_TNUM+33)
-#define T_LIST_EXPR             (FIRST_EXPR_TNUM+34)
-#define T_LIST_TILD_EXPR        (FIRST_EXPR_TNUM+35)
-#define T_RANGE_EXPR            (FIRST_EXPR_TNUM+36)
-#define T_STRING_EXPR           (FIRST_EXPR_TNUM+37)
-#define T_REC_EXPR              (FIRST_EXPR_TNUM+38)
-#define T_REC_TILD_EXPR         (FIRST_EXPR_TNUM+39)
+    T_INTEXPR,
+    T_INT_EXPR,
+    T_TRUE_EXPR,
+    T_FALSE_EXPR,
+    T_CHAR_EXPR,
+    T_PERM_EXPR,
+    T_PERM_CYCLE,
+    T_LIST_EXPR,
+    T_LIST_TILD_EXPR,
+    T_RANGE_EXPR,
+    T_STRING_EXPR,
+    T_REC_EXPR,
+    T_REC_TILD_EXPR,
 
-#define T_REFLVAR               (FIRST_EXPR_TNUM+40)
+    T_REFLVAR,
 
-#define T_ISB_LVAR              (FIRST_EXPR_TNUM+58)
-#define T_REF_HVAR              (FIRST_EXPR_TNUM+59)
-#define T_ISB_HVAR              (FIRST_EXPR_TNUM+60)
-#define T_REF_GVAR              (FIRST_EXPR_TNUM+61)
-#define T_ISB_GVAR              (FIRST_EXPR_TNUM+62)
-#define T_ELM_LIST              (FIRST_EXPR_TNUM+63)
-#define T_ELMS_LIST             (FIRST_EXPR_TNUM+64)
-#define T_ELM_LIST_LEV          (FIRST_EXPR_TNUM+65)
-#define T_ELMS_LIST_LEV         (FIRST_EXPR_TNUM+66)
-#define T_ISB_LIST              (FIRST_EXPR_TNUM+67)
-#define T_ELM_REC_NAME          (FIRST_EXPR_TNUM+68)
-#define T_ELM_REC_EXPR          (FIRST_EXPR_TNUM+69)
-#define T_ISB_REC_NAME          (FIRST_EXPR_TNUM+70)
-#define T_ISB_REC_EXPR          (FIRST_EXPR_TNUM+71)
-#define T_ELM_POSOBJ            (FIRST_EXPR_TNUM+72)
-#define T_ELMS_POSOBJ           (FIRST_EXPR_TNUM+73)
-#define T_ELM_POSOBJ_LEV        (FIRST_EXPR_TNUM+74)
-#define T_ELMS_POSOBJ_LEV       (FIRST_EXPR_TNUM+75)
-#define T_ISB_POSOBJ            (FIRST_EXPR_TNUM+76)
-#define T_ELM_COMOBJ_NAME       (FIRST_EXPR_TNUM+77)
-#define T_ELM_COMOBJ_EXPR       (FIRST_EXPR_TNUM+78)
-#define T_ISB_COMOBJ_NAME       (FIRST_EXPR_TNUM+79)
-#define T_ISB_COMOBJ_EXPR       (FIRST_EXPR_TNUM+80)
+    T_ISB_LVAR,
+    T_REF_HVAR,
+    T_ISB_HVAR,
+    T_REF_GVAR,
+    T_ISB_GVAR,
+    T_ELM_LIST,
+    T_ELMS_LIST,
+    T_ELM_LIST_LEV,
+    T_ELMS_LIST_LEV,
+    T_ISB_LIST,
+    T_ELM_REC_NAME,
+    T_ELM_REC_EXPR,
+    T_ISB_REC_NAME,
+    T_ISB_REC_EXPR,
+    T_ELM_POSOBJ,
+    T_ELMS_POSOBJ,
+    T_ELM_POSOBJ_LEV,
+    T_ELMS_POSOBJ_LEV,
+    T_ISB_POSOBJ,
+    T_ELM_COMOBJ_NAME,
+    T_ELM_COMOBJ_EXPR,
+    T_ISB_COMOBJ_NAME,
+    T_ISB_COMOBJ_EXPR,
 
-#define T_FUNCCALL_OPTS         (FIRST_EXPR_TNUM+81)
-#define T_FLOAT_EXPR_EAGER      (FIRST_EXPR_TNUM+82)
-#define T_FLOAT_EXPR_LAZY       (FIRST_EXPR_TNUM+83)
+    T_FUNCCALL_OPTS,
+    T_FLOAT_EXPR_EAGER,
+    T_FLOAT_EXPR_LAZY,
 
-#define T_ELM2_LIST             (FIRST_EXPR_TNUM+84)
-#define T_ELMX_LIST             (FIRST_EXPR_TNUM+85)
-#define T_ASS2_LIST             (FIRST_EXPR_TNUM+86)
-#define T_ASSX_LIST             (FIRST_EXPR_TNUM+87)
+    T_ELM2_LIST,
+    T_ELMX_LIST,
+    T_ASS2_LIST,
+    T_ASSX_LIST,
+};
 
 #define LAST_EXPR_TNUM          T_ASSX_LIST
 

--- a/src/code.h
+++ b/src/code.h
@@ -360,6 +360,7 @@ enum EXPR_TNUM {
     T_INT_EXPR,
     T_TRUE_EXPR,
     T_FALSE_EXPR,
+    T_TILDE_EXPR,
     T_CHAR_EXPR,
     T_PERM_EXPR,
     T_PERM_CYCLE,
@@ -941,6 +942,14 @@ extern  void            CodeIntExpr (
             Char *              str );
 extern  void            CodeLongIntExpr (
             Obj                 string ); 
+
+/****************************************************************************
+**
+*F  CodeTildeExpr()  . . . . . . . . . . . . . .  code tilde expression
+**
+**  'CodeTildeExpr' is the action to code a tilde expression.
+*/
+extern  void            CodeTildeExpr ( void );
 
 /****************************************************************************
 **

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2377,6 +2377,27 @@ CVar CompIntExpr (
     }
 }
 
+/****************************************************************************
+**
+*F  CompTildeExpr( <expr> )  . . . . . . . . . . . . . . . . . . T_TILDE_EXPR
+*/
+CVar CompTildeExpr (
+    Expr                expr )
+{
+    Emit( "if ( ! STATE(Tilde) ) {\n");
+    Emit( "    ErrorMayQuit(\"'~' does not have a value here\",0L,0L);\n" );
+    Emit( "}\n" );
+    CVar                val;            /* value, result                   */
+
+    /* allocate a new temporary for the 'true' value                       */
+    val = CVAR_TEMP( NewTemp( "val" ) );
+
+    /* emit the code                                                       */
+    Emit( "%c = STATE(Tilde);\n", val );
+
+    /* return '~'                                                       */
+    return val;
+}
 
 /****************************************************************************
 **
@@ -2546,19 +2567,19 @@ CVar CompListTildeExpr (
 
     /* remember the old value of '~'                                       */
     tilde = CVAR_TEMP( NewTemp( "tilde" ) );
-    Emit( "%c = VAL_GVAR( Tilde );\n", tilde );
+    Emit( "%c = STATE( Tilde );\n", tilde );
 
     /* create the list value                                               */
     list = CompListExpr1( expr );
 
     /* assign the list to '~'                                              */
-    Emit( "AssGVarUnsafe( Tilde, %c );\n", list );
+    Emit( "STATE(Tilde) = %c;\n", list );
 
     /* evaluate the subexpressions into the list value                     */
     CompListExpr2( list, expr );
 
     /* restore old value of '~'                                            */
-    Emit( "AssGVarUnsafe( Tilde, %c );\n", tilde );
+    Emit( "STATE(Tilde) = %c;\n", tilde );
     if ( IS_TEMP_CVAR( tilde ) )  FreeTemp( TEMP_CVAR( tilde ) );
 
     /* return the list value                                               */
@@ -2764,19 +2785,19 @@ CVar CompRecTildeExpr (
 
     /* remember the old value of '~'                                       */
     tilde = CVAR_TEMP( NewTemp( "tilde" ) );
-    Emit( "%c = VAL_GVAR( Tilde );\n", tilde );
+    Emit( "%c = STATE( Tilde );\n", tilde );
 
     /* create the record value                                             */
     rec = CompRecExpr1( expr );
 
     /* assign the record value to the variable '~'                         */
-    Emit( "AssGVarUnsafe( Tilde, %c );\n", rec );
+    Emit( "STATE( Tilde ) = %c;\n", rec );
 
     /* evaluate the subexpressions into the record value                   */
     CompRecExpr2( rec, expr );
 
     /* restore the old value of '~'                                        */
-    Emit( "AssGVarUnsafe( Tilde, %c );\n", tilde );
+    Emit( "STATE( Tilde ) = %c;\n", tilde );
     if ( IS_TEMP_CVAR( tilde ) )  FreeTemp( TEMP_CVAR( tilde ) );
 
     /* return the record value                                             */
@@ -5983,6 +6004,7 @@ static Int InitKernel (
     CompExprFuncs[ T_INT_EXPR        ] = CompIntExpr;
     CompExprFuncs[ T_TRUE_EXPR       ] = CompTrueExpr;
     CompExprFuncs[ T_FALSE_EXPR      ] = CompFalseExpr;
+    CompExprFuncs[ T_TILDE_EXPR      ] = CompTildeExpr;
     CompExprFuncs[ T_CHAR_EXPR       ] = CompCharExpr;
     CompExprFuncs[ T_PERM_EXPR       ] = CompPermExpr;
     CompExprFuncs[ T_PERM_CYCLE      ] = CompUnknownExpr;

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -883,6 +883,20 @@ Obj             EvalIntExpr (
     return val;
 }
 
+/****************************************************************************
+**
+*F  EvalTildeExpr(<expr>)  . . . . . . . . .  evaluate tilde expression
+**
+**  'EvalTrueExpr' evaluates the tilde expression and returns its value.
+*/
+Obj             EvalTildeExpr (
+    Expr                expr )
+{
+    if( ! (STATE(Tilde)) ) {
+        ErrorQuit("'~' does not have a value here",0L,0L);
+    }
+    return STATE(Tilde);
+}
 
 /****************************************************************************
 **
@@ -1082,19 +1096,19 @@ Obj             EvalListTildeExpr (
     Obj                 tilde;          /* old value of tilde              */
 
     /* remember the old value of '~'                                       */
-    tilde = VAL_GVAR( Tilde );
+    tilde = STATE( Tilde );
 
     /* create the list value                                               */
     list = ListExpr1( expr );
 
     /* assign the list to '~'                                              */
-    AssGVarUnsafe( Tilde, list );
+    STATE(Tilde) = list;
 
     /* evaluate the subexpressions into the list value                     */
     ListExpr2( list, expr );
 
     /* restore old value of '~'                                            */
-    AssGVarUnsafe( Tilde, tilde );
+    STATE(Tilde) = tilde;
 
     /* return the list value                                               */
     return list;
@@ -1436,19 +1450,19 @@ Obj             EvalRecTildeExpr (
     Obj                 tilde;          /* old value of tilde              */
 
     /* remember the old value of '~'                                       */
-    tilde = VAL_GVAR( Tilde );
+    tilde = STATE( Tilde );
 
     /* create the record value                                             */
     rec = RecExpr1( expr );
 
     /* assign the record value to the variable '~'                         */
-    AssGVarUnsafe( Tilde, rec );
+    STATE(Tilde) = rec;
 
     /* evaluate the subexpressions into the record value                   */
     RecExpr2( rec, expr );
 
     /* restore the old value of '~'                                        */
-    AssGVarUnsafe( Tilde, tilde );
+    STATE(Tilde) = tilde;
 
     /* return the record value                                             */
     return rec;
@@ -1744,6 +1758,16 @@ void            PrintIntExpr (
 
 /****************************************************************************
 **
+*F  PrintTildeExpr(<expr>) . . . . . . . . . . . print tilde expression
+*/
+void            PrintTildeExpr (
+    Expr                expr )
+{
+    Pr( "~", 0L, 0L );
+}
+
+/****************************************************************************
+**
 *F  PrintTrueExpr(<expr>) . . . . . . . . . . . print literal true expression
 */
 void            PrintTrueExpr (
@@ -2036,6 +2060,7 @@ static Int InitKernel (
     InstallEvalExprFunc( T_INT_EXPR       , EvalIntExpr);
     InstallEvalExprFunc( T_TRUE_EXPR      , EvalTrueExpr);
     InstallEvalExprFunc( T_FALSE_EXPR     , EvalFalseExpr);
+    InstallEvalExprFunc( T_TILDE_EXPR     , EvalTildeExpr);
     InstallEvalExprFunc( T_CHAR_EXPR      , EvalCharExpr);
     InstallEvalExprFunc( T_PERM_EXPR      , EvalPermExpr);
 
@@ -2083,6 +2108,7 @@ static Int InitKernel (
     InstallPrintExprFunc( T_INT_EXPR       , PrintIntExpr);
     InstallPrintExprFunc( T_TRUE_EXPR      , PrintTrueExpr);
     InstallPrintExprFunc( T_FALSE_EXPR     , PrintFalseExpr);
+    InstallPrintExprFunc( T_TILDE_EXPR     , PrintTildeExpr);
     InstallPrintExprFunc( T_CHAR_EXPR      , PrintCharExpr);
     InstallPrintExprFunc( T_PERM_EXPR      , PrintPermExpr);
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -1106,7 +1106,7 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, volatile Obj args )
     currLVars = STATE(CurrLVars);
     currStat = STATE(CurrStat);
     recursionDepth = STATE(RecursionDepth);
-    tilde = VAL_GVAR(Tilde);
+    tilde = STATE(Tilde);
     res = NEW_PLIST(T_PLIST_DENSE+IMMUTABLE,2);
 #ifdef HPCGAP
     int lockSP = RegionLockSP();
@@ -1124,13 +1124,13 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, volatile Obj args )
       STATE(CurrStat) = currStat;
       STATE(RecursionDepth) = recursionDepth;
 #ifdef HPCGAP
-      AssGVar(Tilde, tilde);
+      STATE(Tilde) = tilde;
       PopRegionLocks(lockSP);
       TLS(currentRegion) = savedRegion;
       if (TLS(CurrentHashLock))
         HashUnlock(TLS(CurrentHashLock));
 #else
-      AssGVarUnsafe(Tilde, tilde);
+      STATE(Tilde) = tilde;
 #endif
     } else {
       Obj result = CallFuncList(func, args);

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -28,6 +28,7 @@ typedef struct GAPState {
     Obj  IntrState;
     Obj  StackObj;
     Int  CountObj;
+    Obj  Tilde;
 
     /* From gvar.c */
     Obj CurrNamespace;

--- a/src/gvars.h
+++ b/src/gvars.h
@@ -104,17 +104,6 @@ extern  void            AssGVar (
 
 /****************************************************************************
 **
-*F  AssGVarUnsafe(<gvar>,<val>) . . assign to a global variable with checks
-**
-**  'AssGVarUnsafe' assigns the value <val> to the global variable <gvar>
-**  without readonly checks or copie/fopie checking.
-*/
-extern  void            AssGVarUnsafe (
-            UInt                gvar,
-            Obj                 val );
-
-/****************************************************************************
-**
 *F  ValAutoGVar(<gvar>) . . . . . . . .  value of a automatic global variable
 **
 **  'ValAutoGVar' returns the value of the global variable <gvar>.  This will
@@ -178,19 +167,6 @@ extern  Obj            ExprGVar (
 */
 extern UInt GVarName (
             const Char *              name );
-
-
-/****************************************************************************
-**
-*V  Tilde . . . . . . . . . . . . . . . . . . . . . . . . global variable '~'
-**
-**  'Tilde' is the  identifier for the global variable  '~', the one  used in
-**  expressions such as '[ [ 1, 2 ], ~[1] ]'.
-**
-**  Actually  when such expressions  appear in functions, one should probably
-**  use a local variable.  But for now this is good enough.
-*/
-extern  UInt            Tilde;
 
 
 /****************************************************************************

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -584,6 +584,13 @@ extern  void            IntrTrueExpr ( void );
 */
 extern  void            IntrFalseExpr ( void );
 
+/****************************************************************************
+**
+*F  IntrTildeExpr() . . . . . . . . . . . . . . . interpret tilde expression
+**
+**  'IntrTildeExpr' is the action to interpret a tilde expression.
+*/
+extern  void            IntrTildeExpr ( void );
 
 /****************************************************************************
 **

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2099,8 +2099,7 @@ void GetSymbol ( void )
   case '\\':                                          GetIdent();  break;
   case '_':                                           GetIdent();  break;
   case '@':                                           GetIdent();  break;
-  case '~':   STATE(Value)[0] = '~';  STATE(Value)[1] = '\0';
-    STATE(Symbol) = S_IDENT;                       GET_CHAR();  break;
+  case '~':   STATE(Symbol) = S_TILDE;                GET_CHAR();  break;
 
   case '0': case '1': case '2': case '3': case '4':
   case '5': case '6': case '7': case '8': case '9':

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -91,6 +91,7 @@
 #define S_STRING        ((1UL<<11)+3)
 #define S_PARTIALSTRING ((1UL<<11)+4)
 #define S_PARTIALTRIPSTRING   ((1UL<<11)+5)
+#define S_TILDE         ((1UL<< 3)+6)
 
 #define S_REC           ((1UL<<12)+0)
 #define S_BACKQUOTE     ((1UL<<12)+1)
@@ -210,7 +211,7 @@ typedef UInt            TypSymbolSet;
 **
 **  'STATBEGIN' is the set of symbols that might start a stament.
 */
-#define EXPRBEGIN  (S_IDENT|S_ISBOUND|S_INT|S_TRUE|S_FALSE \
+#define EXPRBEGIN  (S_IDENT|S_ISBOUND|S_INT|S_TRUE|S_FALSE|S_TILDE \
                     |S_CHAR|S_STRING|S_LBRACK|S_REC|S_FUNCTION \
                     |S_PLUS|S_MINUS|S_NOT|S_LPAREN)
 

--- a/tst/testinstall/tilde.tst
+++ b/tst/testinstall/tilde.tst
@@ -4,8 +4,6 @@ Error, Variable: 'aqq' must have a value
 Syntax error: ; expected in stream:1
 aqq~ := 1;
    ^
-gap> ~ := 1;
-Error, '~' cannot be assigned
 gap> l := [2, ~];
 [ 2, ~ ]
 gap> l = l[2];
@@ -21,35 +19,43 @@ rec( x := ~, y := [ 1, 2, ~ ] )
 gap> r.y[3];
 rec( x := ~, y := [ 1, 2, ~ ] )
 gap> f := function(~) local a; end;
-Syntax error: ~ is not a valid name for an argument in stream:1
+Syntax error: identifier expected in stream:1
 f := function(~) local a; end;
               ^
 gap> f := function(a,~) local a; end;
-Syntax error: ~ is not a valid name for an argument in stream:1
+Syntax error: Expect identifier in stream:1
 f := function(a,~) local a; end;
                 ^
 gap> f := function(a,b) local ~; end;
-Syntax error: ~ is not a valid name for a local identifier in stream:1
+Syntax error: identifier expected in stream:1
 f := function(a,b) local ~; end;
                          ^
 gap> f := function(a,b) local x,~; end;
-Syntax error: ~ is not a valid name for a local identifier in stream:1
+Syntax error: identifier expected in stream:1
 f := function(a,b) local x,~; end;
                            ^
 gap> {~} -> ~;
-Syntax error: ~ is not a valid name for an argument in stream:1
+Syntax error: identifier expected in stream:1
 {~} -> ~;
  ^
 gap> {~,~} -> 2;
-Syntax error: ~ is not a valid name for an argument in stream:1
+Syntax error: identifier expected in stream:1
 {~,~} -> 2;
  ^
-gap> ({} -> ~);
-function(  ) ... end
 gap> list1 := [1,~];
 [ 1, ~ ]
 gap> list2 := [1,[1,[1,[1,0]]]];
 [ 1, [ 1, [ 1, [ 1, 0 ] ] ] ]
+gap> f := function(a) local y; y := [1,~,a]; return y; end;;
+gap> f(2);
+[ 1, ~, 2 ]
+gap> f(2)[2];
+[ 1, ~, 2 ]
+gap> f := function(a) local y; y := rec( x := 1 ,y := ~, z := a); return y; end;;
+gap> f(2);
+rec( x := 1, y := ~, z := 2 )
+gap> f(2).y;
+rec( x := 1, y := ~, z := 2 )
 
 # Check that the RecursionDepth counter in the kernel is incremented and
 # decremented correctly. If it isn't decremented correctly, then it will


### PR DESCRIPTION
This removes various horrible hacks for handling ~, by pretending it is a normal variable.

This is quite a long patch, but fairly mechanical. Checked in both GAP and HPC-GAP.