### PR TITLE
All help matches pointing to same subsection

### DIFF
--- a/doc/ref/helpintf.xml
+++ b/doc/ref/helpintf.xml
@@ -217,6 +217,11 @@ gap> stream := InputTextFile( file );;
   <A>type</A> which currently must be handled and the corresponding result format
   are described in the list below.
 </Item>
+<Mark><C>SubsectionNumber( <A>info</A>, <A>i</A> )</C> </Mark>
+<Item>
+  This returns some &GAP; object that identifies the position in the book
+  where the display of this entry is started.
+</Item>
 </List>
 <P/>
 The <C>HELP_BOOK_HANDLER.<A>myownformat</A>.HelpData</C> function must recognize the

--- a/doc/ref/helpintf.xml
+++ b/doc/ref/helpintf.xml
@@ -220,7 +220,8 @@ gap> stream := InputTextFile( file );;
 <Mark><C>SubsectionNumber( <A>info</A>, <A>i</A> )</C> </Mark>
 <Item>
   This returns some &GAP; object that identifies the position in the book
-  where the display of this entry is started.
+  where the display of this entry is started. This can be useful to detect
+  if several help book entries actually point to the same place.
 </Item>
 </List>
 <P/>

--- a/lib/helpbase.gi
+++ b/lib/helpbase.gi
@@ -978,9 +978,12 @@ InstallGlobalFunction(HELP_GET_MATCHES, function( books, topic, frombegin )
   # Note: before GAP 4.5 this was only done in case of substring search.
   match := Concatenation(exact, match);
   exact := [];
-  # check if all matches point to the same subsection of the same book
+  
+  # check if all matches point to the same subsection of the same book,
+  # in that case we only keep the first match which then will be displayed
+  # immediately
 
-  # this function makes shure that nothing breaks if the help book handler
+  # this function makes sure that nothing breaks if the help book handler
   # has no support for SubsectionNumber
   getsecnum := function(m)
     if IsBound(HELP_BOOK_HANDLER.(m[1].handler).SubsectionNumber) then

--- a/lib/helpbase.gi
+++ b/lib/helpbase.gi
@@ -938,7 +938,7 @@ end);
 ##  remaining ones.
 ##
 InstallGlobalFunction(HELP_GET_MATCHES, function( books, topic, frombegin )
-  local exact, match, em, b, x, topics, transatl, pair, newtopic;
+  local exact, match, em, b, x, topics, transatl, pair, newtopic, getsecnum;
 
   # First we try to produce some suggestions for possible different spellings
   # (see the global variable 'TRANSATL' for the list of spelling patterns).
@@ -978,6 +978,21 @@ InstallGlobalFunction(HELP_GET_MATCHES, function( books, topic, frombegin )
   # Note: before GAP 4.5 this was only done in case of substring search.
   match := Concatenation(exact, match);
   exact := [];
+  # check if all matches point to the same subsection of the same book
+
+  # this function makes shure that nothing breaks if the help book handler
+  # has no support for SubsectionNumber
+  getsecnum := function(m)
+    if IsBound(HELP_BOOK_HANDLER.(m[1].handler).SubsectionNumber) then
+      return HELP_BOOK_HANDLER.(m[1].handler).SubsectionNumber(m[1], m[2]);
+    else
+      return m[2];
+    fi;
+  end;
+  if Length(match) > 1 and Length(Set(List(match, 
+                            m-> [m[1].bookname,getsecnum(m)]))) = 1 then
+    match := [match[1]];
+  fi;
 
   return [exact, match];
 end);

--- a/lib/helpdef.gi
+++ b/lib/helpdef.gi
@@ -702,3 +702,6 @@ HELP_BOOK_HANDLER.default.HelpData := function(book, entrynr, type)
   return fail;
 end;
 
+HELP_BOOK_HANDLER.default.SubsectionNumber := function(info, entrynr)
+  return info.entries[entrynr]{[4,5]};
+end;


### PR DESCRIPTION
Sometimes the help system finds several matches for a query, but
all of them actually point to the same subsection of the same book
(e.g., when several functions are documented in one ManSection
of a GAPDoc manual). With this patch the corresponding subsection
will be displayed directly (instead of offering the user a choice).

To implement this a new utility function .SubsectionNumber is
needed from the help book handlers.

For the "default" handler (old gapmacro.tex manuals) this new function
is also contained here. For GAPDoc manuals this will be provided with
the upcoming GAPDoc 1.6 release.

There is a sensible fallback if a help book handler does not provide
the new utility function.