### PR TITLE
hpcgap: remove autolock feature for regions

### DIFF
--- a/hpcgap/lib/hpc/thread1.g
+++ b/hpcgap/lib/hpc/thread1.g
@@ -159,28 +159,6 @@ NewSpecialRegion := function(arg)
   return NewRegionWithPrecedence(arg, REGION_NO_PREC);
 end;
 
-ShareAutoReadObj := function(obj)
-  SHARE(obj, fail, REGION_INTERNAL_PREC);
-  SetAutoLockRegion(obj, true);
-  return obj;
-end;
-
-AutoReadLock := function(obj)
-  SetAutoLockRegion(obj, true);
-  return obj;
-end;
-
-NewAutoReadRegion := function(arg)
-  local region;
-  if LEN_LIST(arg) = 0 then
-    region := NewRegion();
-  else
-    region := NewRegion(arg[1]);
-  fi;
-  SetAutoLockRegion(region, true);
-  return region;
-end;
-
 LockAndMigrateObj := function(obj, target)
   local lock;
   if IsShared(target) and not HaveWriteAccess(target) then

--- a/lib/hpc/thread1.g
+++ b/lib/hpc/thread1.g
@@ -143,14 +143,6 @@ BIND_GLOBAL("NewKernelRegion", NewRegion);
 BIND_GLOBAL("NewInternalRegion", NewRegion);
 BIND_GLOBAL("NewSpecialRegion", NewRegion);
 
-BIND_GLOBAL("ShareAutoReadObj", ID_FUNC);
-
-BIND_GLOBAL("AutoReadLock", ID_FUNC);
-
-BIND_GLOBAL("NewAutoReadRegion", function(arg1)
-  return 0;
-end);
-
 BIND_GLOBAL("LockAndMigrateObj", RETURN_FIRST);
 
 BIND_GLOBAL("LockAndAdoptObj", ID_FUNC);

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -1191,7 +1191,6 @@ typedef struct
     Bag name;         /* name of the region, or a null pointer */
     Int prec;         /* locking precedence */
     int fixed_owner;
-    int autolock;
     void *owner;      /* opaque thread descriptor */
     void *alt_owner;  /* for paused threads */
     int count_active; /* whether we counts number of (contended) locks */

--- a/src/hpc/thread.h
+++ b/src/hpc/thread.h
@@ -79,9 +79,7 @@ int LockObjects(int count, Obj *objects, int *mode);
 int TryLockObjects(int count, Obj *objects, int *mode);
 void PushRegionLock(Region *region);
 void PopRegionLocks(int newSP);
-void PopRegionAutoLocks(int newSP);
 int RegionLockSP();
-int AutoLockObj(Obj obj);
 
 void HashLock(void *obj);
 void HashLockShared(void *obj);

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -619,35 +619,6 @@ Obj FuncRegionOf(Obj self, Obj obj) {
   return region == NULL ? PublicRegion : region->obj;
 }
 
-/****************************************************************************
-**
-*F FuncSetAutoLockRegion ... change the autolock status of a region
-*F FuncIsAutoLockRegion ... query the autolock status of a region
-**
-*/
-
-Obj FuncSetAutoLockRegion(Obj self, Obj obj, Obj flag) {
-  Region *region = GetRegionOf(obj);
-  if (!region || region->fixed_owner) {
-    return ArgumentError("SetAutoLockRegion: cannot change autolock status of this region");
-  }
-  if (flag == True) {
-    region->autolock = 1;
-    return (Obj) 0;
-  } else if (flag == False || flag == Fail) {
-    region->autolock = 0;
-    return (Obj) 0;
-  } else {
-    return ArgumentError("SetAutoLockRegion: Second argument must be boolean");
-  }
-}
-
-Obj FuncIsAutoLockRegion(Obj self, Obj obj) {
-  Region *region = GetRegionOf(obj);
-  if (!region)
-    return False;
-  return region->autolock ? True : False;
-}
 
 
 
@@ -1037,12 +1008,6 @@ static StructGVarFunc GVarFuncs [] = {
 
     { "RegionOf", 1, "object",
       FuncRegionOf, "src/threadapi.c:RegionOf" },
-
-    { "SetAutoLockRegion", 2, "object, boolean",
-      FuncSetAutoLockRegion, "src/threadapi.c:SetAutoLockRegion" },
-
-    { "IsAutoLockRegion", 1, "object",
-      FuncIsAutoLockRegion, "src/threadapi.c:IsAutoLockRegion" },
 
     { "SetRegionName", 2, "obj, name",
       FuncSetRegionName, "src/threadapi.c:SetRegionName" },

--- a/src/read.c
+++ b/src/read.c
@@ -2883,9 +2883,6 @@ ExecStatus ReadEvalCommand ( Obj context, UInt *dualSemicolon )
        state to execute ReadLine on an input stream, leading to crashes */
     TRY_READ {
         type = IntrEnd( 0UL );
-#ifdef HPCGAP
-        PopRegionAutoLocks(lockSP); // FIXME: is this in the right place?
-#endif
 
         /* check for dual semicolon */
         if ( *STATE(In) == ';' ) {


### PR DESCRIPTION
This feature was added in 41f719c03072d5b7c53d2e51017c80dc898d9e1d, five years ago, but nothing uses it. As such, it is unclear to me for what one could or should use them.

Note that this also removes a FIXME from `read.c` that was added earlier today as part of PR #1319 -- actually that directly lead to this PR.

@rbehrends It would be great if you could comment on this. If there are strong reasons to keep this undocumented autolock feature, please tell us!