### PR TITLE
HPC-GAP: Tweak NEW_TYPE cache

### DIFF
--- a/hpcgap/lib/type1.g
+++ b/hpcgap/lib/type1.g
@@ -235,7 +235,7 @@ BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data, parent )
                         return cached;
                     fi;
                 fi;
-                # if there is a parent type, make sure the any extra data in it
+                # if there is a parent type, make sure that any extra data in it
                 # matches what is in the cache
                 if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached ) then
                     match := true;


### PR DESCRIPTION
This PR resumes work on issue #125. As there, let
```gap
stat:=function() return [NEW_TYPE_CACHE_HIT,NEW_TYPE_CACHE_MISS,NEW_TYPE_NEXT_ID]; end;;
```

Then before this PR, I get this:
Results for GAP:
```
gap> old:=stat();; g:=WreathProduct(MathieuGroup(9),Group((1,2)));; ConjugacyClassesSubgroups(g);; time; stat() - old;
3218
[ 218079, 997, 2532 ]
gap> old:=stat();; g:=WreathProduct(MathieuGroup(9),Group((1,2)));; ConjugacyClassesSubgroups(g);; time; stat() - old;
3151
[ 216761, 812, 864 ]
```

Results for HPC-GAP:
```
gap> old:=stat();; g:=WreathProduct(MathieuGroup(9),Group((1,2)));; ConjugacyClassesSubgroups(g);; time; stat() - old;
6579
[ 182171, 36834, 38436 ]
gap> old:=stat();; g:=WreathProduct(MathieuGroup(9),Group((1,2)));; ConjugacyClassesSubgroups(g);; time; stat() - old;
6412
[ 181780, 35794, 35870 ]
```

With this PR, I get this:

Results for GAP:
```
gap> old:=stat();; g:=WreathProduct(MathieuGroup(9),Group((1,2)));; ConjugacyClassesSubgroups(g);; time; stat() - old;
3312
[ 218052, 1023, 2559 ]
gap> old:=stat();; g:=WreathProduct(MathieuGroup(9),Group((1,2)));; ConjugacyClassesSubgroups(g);; time; stat() - old;
3192
[ 216760, 813, 865 ]
```

Results for HPC-GAP:
```
gap> old:=stat();; g:=WreathProduct(MathieuGroupgap> (9),Group((1,2)));; ConjugacyClassesSubgroups(g);; time; stat() - old;
6446
[ 216463, 2584, 4144 ]
gap> old:=stat();; g:=WreathProduct(MathieuGroup(9),Group((1,2)));; ConjugacyClassesSubgroups(g);; time; stat() - old;
6369
[ 216691, 890, 959 ]
```

So the number of cache misses shrinks dramatically for HPC-GAP; on the second run, it's basically comparable to GAP. Unfortunately, the timing does not really change, so we still have a performance bottleneck in there :-/.

By the way, I really wonder what causes all those type objects for which `LEN_POSOBJ` return 6, yet only 4 entries in them are bound...