### PR TITLE
Replace RecFields by RecNames, mark it as obsolete

### DIFF
--- a/lib/memusage.gi
+++ b/lib/memusage.gi
@@ -194,7 +194,7 @@ InstallMethod( MemoryUsage, "for a record",
         MEMUSAGECACHE_DEPTH := MEMUSAGECACHE_DEPTH + 1;
         mem := SHALLOW_SIZE(o) + MU_MemBagHeader + MU_MemPointer;
         # Again the bag, its header, and the master pointer
-        for i in RecFields(o) do
+        for i in RecNames(o) do
             s := o.(i);
             if SHALLOW_SIZE(s) > 0 then    # a subobject!
                 mem := mem + MemoryUsage(s);

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -555,5 +555,14 @@ DeclareGlobalFunction( "USER_HOME_EXPAND" );
 
 #############################################################################
 ##
+#F  RecFields
+##
+##  This name stems from GAP 3 days.
+##
+## still used by Browse, ctbllib, gapdoc, genss, io, orb (05/2017)
+DeclareObsoleteSynonym( "RecFields", "RecNames", "4.0" );
+
+#############################################################################
+##
 #E
 

--- a/lib/record.g
+++ b/lib/record.g
@@ -153,8 +153,6 @@ DeclareOperationKernel( "Unbind.", [ IsObject, IsObject ], UNB_REC );
 ##
 DeclareAttribute( "RecNames", IsRecord );
 
-DeclareSynonym( "RecFields", RecNames );
-
 
 #############################################################################
 ##

--- a/lib/sgpres.gi
+++ b/lib/sgpres.gi
@@ -655,7 +655,7 @@ InstallGlobalFunction( AugmentedCosetTableRrs,
     fi;
 
     # ensure that all components of the augmented coset table are immutable.
-    for field in RecFields( aug ) do
+    for field in RecNames( aug ) do
       MakeImmutable( aug.(field) );
     od;
 

--- a/lib/string.gi
+++ b/lib/string.gi
@@ -1007,7 +1007,7 @@ InstallGlobalFunction(PrintCSV,function(arg)
   else
     rf:=[];
     for i in l do
-      r:=RecFields(i);
+      r:=RecNames(i);
       for j in r do
 	if not j in rf then
 	  Add(rf,j);
@@ -1070,7 +1070,7 @@ local f,i,j,format,cold,a,e,z,str,new,box,lc,mini,color,alt,renum;
   color:=fail;
   # row 1 indicates which columns are relevant and their formatting
   cold:=ShallowCopy(l[1]);
-  f:=RecFields(cold);
+  f:=RecNames(cold);
   renum:=[];
   for i in ShallowCopy(f) do
 

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -93,7 +93,7 @@ InstallGlobalFunction(RunTests, function(arg)
   tests := arg[1];
   opts := rec( breakOnError := false, showProgress := "some" );
   if Length(arg) > 1 and IsRecord(arg[2]) then
-    for f in RecFields(arg[2]) do
+    for f in RecNames(arg[2]) do
       opts.(f) := arg[2].(f);
     od;
   fi;
@@ -372,7 +372,7 @@ InstallGlobalFunction("Test", function(arg)
            end,
            subsWindowsLineBreaks := true,
          );
-  for c in RecFields(nopts) do
+  for c in RecNames(nopts) do
     opts.(c) := nopts.(c);
   od;
   # check shortcuts
@@ -592,7 +592,7 @@ InstallGlobalFunction( "TestDirectory", function(arg)
     exitGAP := false,
   );
   
-  for c in RecFields(nopts) do
+  for c in RecNames(nopts) do
     opts.(c) := nopts.(c);
   od;
   


### PR DESCRIPTION
This function name was used in GAP 3 but has been deprecated in GAP 4.