### PR TITLE
Add MakeImm and Imm

### DIFF
--- a/doc/ref/objects.xml
+++ b/doc/ref/objects.xml
@@ -185,6 +185,7 @@ can assign values to components of a mutable record, or unbind them.
 
 <ManSection>
 <Func Name="MakeImmutable" Arg='obj'/>
+<Func Name="MakeImm" Arg='obj'/>
 
 <Description>
 One can turn the (mutable or immutable) object <A>obj</A> into an immutable
@@ -193,6 +194,7 @@ note that this also makes all subobjects of <A>obj</A> immutable,
 so one should call <Ref Func="MakeImmutable"/> only if <A>obj</A> and
 its mutable subobjects are newly created.
 If one is not sure about this, <Ref Func="Immutable"/> should be used.
+<Ref Func="MakeImm"/> provides a shorthand for <Ref Func="MakeImmutable"/>.
 <P/>
 Note that it is <E>not</E> possible to turn an immutable object into a
 mutable one;

--- a/hpcgap/lib/object.gd
+++ b/hpcgap/lib/object.gd
@@ -252,6 +252,7 @@ InstallTrueMethod( IsCopyable, IsMutable);
 ##  <#GAPDoc Label="Immutable">
 ##  <ManSection>
 ##  <Func Name="Immutable" Arg='obj'/>
+##  <Func Name="Imm" Arg='obj'/>
 ##
 ##  <Description>
 ##  returns an immutable structural copy
@@ -263,12 +264,15 @@ InstallTrueMethod( IsCopyable, IsMutable);
 ##  <P/>
 ##  &GAP; will complain with an error if one tries to change an
 ##  immutable object.
+##  <P/>
+##  <Ref Func="Imm"/> povides a shorthand for <Ref Func="Immutable"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL( "Immutable", IMMUTABLE_COPY_OBJ );
-
+BIND_GLOBAL( "Imm", IMMUTABLE_COPY_OBJ );
+BIND_GLOBAL( "MakeImm", MakeImmutable );
 
 #############################################################################
 ##

--- a/lib/object.gd
+++ b/lib/object.gd
@@ -226,6 +226,7 @@ InstallTrueMethod( IsCopyable, IsMutable);
 ##  <#GAPDoc Label="Immutable">
 ##  <ManSection>
 ##  <Func Name="Immutable" Arg='obj'/>
+##  <Func Name="Imm" Arg='obj'/>
 ##
 ##  <Description>
 ##  returns an immutable structural copy
@@ -237,12 +238,15 @@ InstallTrueMethod( IsCopyable, IsMutable);
 ##  <P/>
 ##  &GAP; will complain with an error if one tries to change an
 ##  immutable object.
+##  <P/>
+##  <Ref Func="Imm"/> povides a shorthand for <Ref Func="Immutable"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL( "Immutable", IMMUTABLE_COPY_OBJ );
-
+BIND_GLOBAL( "Imm", IMMUTABLE_COPY_OBJ );
+BIND_GLOBAL( "MakeImm", MakeImmutable );
 
 #############################################################################
 ##

--- a/tst/testinstall/immutable.tst
+++ b/tst/testinstall/immutable.tst
@@ -1,0 +1,60 @@
+#############################################################################
+##
+#W  immutable.tst                GAP Library
+##
+##
+#Y  Copyright (C) 2017,  University of St Andrews, Scotland
+##
+##
+gap> START_TEST("immutable.tst");
+gap> IS_IDENTICAL_OBJ(Immutable, Imm);
+true
+gap> IS_IDENTICAL_OBJ(MakeImmutable, MakeImm);
+true
+gap> IS_IDENTICAL_OBJ(Immutable, MakeImmutable);
+false
+gap> IsMutable(1);
+false
+gap> IS_IDENTICAL_OBJ(1,Immutable(1));
+true
+gap> IS_IDENTICAL_OBJ(1,Imm(1));
+true
+gap> IS_IDENTICAL_OBJ(1,MakeImmutable(1));
+true
+gap> IS_IDENTICAL_OBJ(1,MakeImm(1));
+true
+gap> x := [1,2,3];
+[ 1, 2, 3 ]
+gap> IsMutable(x);
+true
+gap> IsMutable(Immutable(x));
+false
+gap> x = Immutable(x);
+true
+gap> IsMutable(Imm(x));
+false
+gap> x = Imm(x);
+true
+gap> IS_IDENTICAL_OBJ(x, Imm(x));
+false
+gap> IsMutable(x);
+true
+gap> x;
+[ 1, 2, 3 ]
+gap> IS_IDENTICAL_OBJ(x, MakeImmutable(x));
+true
+gap> IsMutable(x);
+false
+gap> x;
+[ 1, 2, 3 ]
+gap> IsMutable(Group(()));
+false
+gap> IsMutable(StabChainImmutable(Group(())));
+false
+gap> IsMutable(StabChainMutable(Group(())));
+true
+gap> STOP_TEST( "immutable.tst", 1);
+
+#############################################################################
+##
+#E


### PR DESCRIPTION
This adds two shorthands, `MakeImm` for `MakeImmutable`, and `Imm` for `Immutable`. These are because we want to call these functions a lot in HPC-GAP, and so having shorter names is useful.