### PR TITLE
Suppress 'Unbound global variable' warning in IsBound

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -502,6 +502,7 @@ void ReadCallVarAss (
       WarnOnUnboundGlobalsRNam = RNamName("WarnOnUnboundGlobals");
 
     if ( type == 'g'
+      && mode != 'i'
       && STATE(CountNams) != 0
       && var != STATE(CurrLHSGVar)
       && VAL_GVAR(var) == 0

--- a/src/read.c
+++ b/src/read.c
@@ -501,17 +501,18 @@ void ReadCallVarAss (
     if (WarnOnUnboundGlobalsRNam == 0)
       WarnOnUnboundGlobalsRNam = RNamName("WarnOnUnboundGlobals");
 
-    if ( type == 'g'
-      && mode != 'i'
-      && STATE(CountNams) != 0
-      && var != STATE(CurrLHSGVar)
-      && VAL_GVAR(var) == 0
-      && ExprGVar(var) == 0
-      && ! STATE(IntrIgnoring)
-      && ! GlobalComesFromEnclosingForLoop(var)
-      && (GAPInfo == 0 || !IS_REC(GAPInfo) || !ISB_REC(GAPInfo,WarnOnUnboundGlobalsRNam) ||
-             ELM_REC(GAPInfo,WarnOnUnboundGlobalsRNam) != False )
-      && ! SyCompilePlease )
+    if ( type == 'g'                // Reading a global variable
+      && mode != 'i'                // Not inside 'IsBound'
+      && STATE(CountNams) != 0      // Inside a function
+      && var != STATE(CurrLHSGVar)  // Not LHS of assignment
+      && VAL_GVAR(var) == 0         // Not an existing global var
+      && ExprGVar(var) == 0         // Or an auto var
+      && ! STATE(IntrIgnoring)      // Not currently ignoring parsed code
+      && ! GlobalComesFromEnclosingForLoop(var) // Not loop variable
+      && (GAPInfo == 0 || !IS_REC(GAPInfo)
+          || !ISB_REC(GAPInfo,WarnOnUnboundGlobalsRNam) // Warning enabled
+          ||  ELM_REC(GAPInfo,WarnOnUnboundGlobalsRNam) != False )
+      && ! SyCompilePlease )        // Not compiling
     {
         SyntaxWarning("Unbound global variable");
     }

--- a/tst/testinstall/bound.tst
+++ b/tst/testinstall/bound.tst
@@ -21,4 +21,21 @@ gap> f := ( -> IsBound(r.b) );; f();
 true
 gap> f := ( -> IsBound(r.c) );; f();
 false
+gap> f := ( -> IsBound(BADVARNAME) );; f();
+false
+gap> f := ( -> IsBound(BADVARNAME.BADRECNAME) );;
+gap> f();
+Error, Variable: 'BADVARNAME' must have an assigned value
+gap> f := ( -> BADVARNAME );;
+Syntax warning: Unbound global variable in stream:1
+f := ( -> BADVARNAME );;
+                     ^
+gap> f();
+Error, Variable: 'BADVARNAME' must have an assigned value
+gap> f := ( -> IsBound(BADVARNAME[BADLISTNAME]) );;
+Syntax warning: Unbound global variable in stream:1
+f := ( -> IsBound(BADVARNAME[BADLISTNAME]) );;
+                                        ^
+gap> f();
+Error, Variable: 'BADVARNAME' must have an assigned value
 gap> STOP_TEST("bound.tst", 1);


### PR DESCRIPTION
At the moment, IsBound(HPCGAP) produces an `Syntax warning: Unbound global variable` warning when used in a function. This is a long-standing issue, but this easy change fixes it.