### PR TITLE
Document `RecFields`.

### DIFF
--- a/lib/record.g
+++ b/lib/record.g
@@ -131,10 +131,11 @@ DeclareOperationKernel( "Unbind.", [ IsObject, IsObject ], UNB_REC );
 ##  <#GAPDoc Label="RecNames">
 ##  <ManSection>
 ##  <Attr Name="RecNames" Arg='record'/>
+##  <Attr Name="RecFields" Arg='record'/>
 ##
 ##  <Description>
-##  returns a list of strings corresponding to the names of the record
-##  components of the record <A>record</A>.
+##  These synonym attributes return a list of strings corresponding 
+##  to the names of the record components of the record <A>record</A>.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> r := rec( a := 1, b := 2 );;


### PR DESCRIPTION
It seems that it was forgotten to mention `RecFields` in the documentation.
It was (re-)introduced to the library in 2000 as synonym to `RecNames` after
a discussion about name changes/incompatibilities between GAP 3 and GAP 4.

This is an alternative pull request to "Replace RecFields by RecNames, mark it as obsolete" (#1331).