### PR TITLE
Remove HPCGAP no-argument lambdas

### DIFF
--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -1844,15 +1844,6 @@ gap> list;
 gap> f := {x,y...} -> y;;
 gap> f(1,2,3,4);
 [ 2, 3, 4 ]
-]]></Example>
-<P/>
-The <C>{</C> and <C>}</C> may be omitted for
-functions with one and zero arguments:
-<Example><![CDATA[
-gap> Sum( List( [1..100], {x} -> x^2 ) );
-338350
-gap> Sum( List( [1..100], x -> x^2 ) );
-338350
 gap> f := {} -> 2;
 function(  ) ... end
 gap> Print(f);
@@ -1861,14 +1852,15 @@ function (  )
 end
 gap> f();
 2
-gap> g := -> 2;
-function(  ) ... end
-gap> Print(g);
-function (  )
-    return 2;
-end
-gap> g();
-2
+]]></Example>
+<P/>
+The <C>{</C> and <C>}</C> may be omitted for
+functions with one argument:
+<Example><![CDATA[
+gap> Sum( List( [1..100], {x} -> x^2 ) );
+338350
+gap> Sum( List( [1..100], x -> x^2 ) );
+338350
 ]]></Example>
 
 <P/>

--- a/hpcgap/demo/cancel.g
+++ b/hpcgap/demo/cancel.g
@@ -1,6 +1,6 @@
 task := RunTask(function()
   while true do
-    OnTaskCancellation(->99);
+    OnTaskCancellation({}->99);
   od;
 end);
 

--- a/hpcgap/doc/ref/language.xml
+++ b/hpcgap/doc/ref/language.xml
@@ -1841,15 +1841,6 @@ gap> list;
 gap> f := {x,y...} -> y;;
 gap> f(1,2,3,4);
 [ 2, 3, 4 ]
-]]></Example>
-<P/>
-The <C>{</C> and <C>}</C> may be omitted for
-functions with one and zero arguments:
-<Example><![CDATA[
-gap> Sum( List( [1..100], {x} -> x^2 ) );
-338350
-gap> Sum( List( [1..100], x -> x^2 ) );
-338350
 gap> f := {} -> 2;
 function(  ) ... end
 gap> Print(f);
@@ -1858,14 +1849,15 @@ function (  )
 end
 gap> f();
 2
-gap> g := -> 2;
-function(  ) ... end
-gap> Print(g);
-function (  )
-    return 2;
-end
-gap> g();
-2
+]]></Example>
+<P/>
+The <C>{</C> and <C>}</C> may be omitted for
+functions with one argument:
+<Example><![CDATA[
+gap> Sum( List( [1..100], {x} -> x^2 ) );
+338350
+gap> Sum( List( [1..100], x -> x^2 ) );
+338350
 ]]></Example>
 
 <P/>

--- a/hpcgap/lib/hpc/stdtasks.g
+++ b/hpcgap/lib/hpc/stdtasks.g
@@ -613,7 +613,7 @@ BindGlobal("OnTaskCancellation", function(exit)
 end);
 
 BindGlobal("OnTaskCancellationReturn", function(value)
-  OnTaskCancellation(->value);
+  OnTaskCancellation({}->value);
 end);
 
 

--- a/hpcgap/tst/testinstall/flush.tst
+++ b/hpcgap/tst/testinstall/flush.tst
@@ -5,8 +5,8 @@ gap> cheesefun;
 << cheesefun to be defined>>
 gap> cheeseval;
 << cheeseval to be defined>>
-gap> InstallFlushableValueFromFunction(cheesefun, -> [1] );
-gap> InstallFlushableValueFromFunction(cheeseval, -> [2] );
+gap> InstallFlushableValueFromFunction(cheesefun, {} -> [1] );
+gap> InstallFlushableValueFromFunction(cheeseval, {} -> [2] );
 gap> cheesefun;
 [ 1 ]
 gap> cheeseval;

--- a/hpcgap/tst/testinstall/function.tst
+++ b/hpcgap/tst/testinstall/function.tst
@@ -108,14 +108,6 @@ gap> Print(x->x, "\n");
 function ( x )
     return x;
 end
-gap> ->1;
-function(  ) ... end
-gap> (->1)();
-1
-gap> Print(->1, "\n");
-function (  )
-    return 1;
-end
 gap> x -> y -> x+y;
 function( x ) ... end
 gap> Print(x -> y -> x+y, "\n");

--- a/src/read.c
+++ b/src/read.c
@@ -112,9 +112,6 @@ UInt            ReadStats (
 void            ReadFuncExpr1 (
     TypSymbolSet        follow );
 
-void            ReadFuncExpr0 (
-    TypSymbolSet        follow );
-
 void ReadAtom (
     TypSymbolSet        follow,
     Char                mode );
@@ -1638,29 +1635,6 @@ void ReadFuncExpr1 (
 
 /****************************************************************************
 **
-*F  ReadFuncExpr0(<follow>) . . . . . . . . . . .  read a function expression
-**
-**  'ReadFuncExpr0' reads  an abbreviated  function literal   expression.  In
-**  case of an error it skips all symbols up to one contained in <follow>.
-**
-**      <Function>      := '->' <Expr>
-*/
-void ReadFuncExpr0 (
-    TypSymbolSet        follow )
-{
-    volatile Obj        nams;           /* list of local variables names   */
-
-    /* make and push the new local variables list                          */
-    nams = NEW_PLIST( T_PLIST, 0 );
-    SET_LEN_PLIST( nams, 0 );
-    STATE(CountNams)++;
-    ASS_LIST( STATE(StackNams), STATE(CountNams), nams );
-
-    ReadFuncExprBody(follow, nams, 0);
-}
-
-/****************************************************************************
-**
 *F  ReadLiteral( <follow>, <mode> ) . . . . . . . . . . . . . .  read an atom
 **
 **  'ReadLiteral' reads a  literal expression.  In  case of an error it skips
@@ -1779,10 +1753,6 @@ void ReadLiteral (
         STATE(Value)[0] = '.';
         STATE(Value)[1] = '\0';
         ReadLongNumber( follow );
-        break;
-
-    case S_MAPTO:
-        ReadFuncExpr0( follow );
         break;
 
     case S_LBRACE:

--- a/tst/testinstall/bound.tst
+++ b/tst/testinstall/bound.tst
@@ -4,9 +4,9 @@ gap> IsBound(S!.cheese);
 false
 gap> IsBound(S!.Size);
 true
-gap> f := ( -> IsBound(S!.cheese) );; f();
+gap> f := ({} -> IsBound(S!.cheese) );; f();
 false
-gap> f := ( -> IsBound(S!.Size) );; f();
+gap> f := ({} -> IsBound(S!.Size) );; f();
 true
 gap> r := rec(a := 2, b := fail);;
 gap> IsBound(r.a);
@@ -15,27 +15,27 @@ gap> IsBound(r.b);
 true
 gap> IsBound(r.c);
 false
-gap> f := ( -> IsBound(r.a) );; f();
+gap> f := ({} -> IsBound(r.a) );; f();
 true
-gap> f := ( -> IsBound(r.b) );; f();
+gap> f := ({} -> IsBound(r.b) );; f();
 true
-gap> f := ( -> IsBound(r.c) );; f();
+gap> f := ({} -> IsBound(r.c) );; f();
 false
-gap> f := ( -> IsBound(BADVARNAME) );; f();
+gap> f := ({} -> IsBound(BADVARNAME) );; f();
 false
-gap> f := ( -> IsBound(BADVARNAME.BADRECNAME) );;
+gap> f := ({} -> IsBound(BADVARNAME.BADRECNAME) );;
 gap> f();
 Error, Variable: 'BADVARNAME' must have an assigned value
-gap> f := ( -> BADVARNAME );;
+gap> f := ({} -> BADVARNAME );;
 Syntax warning: Unbound global variable in stream:1
-f := ( -> BADVARNAME );;
-                     ^
+f := ({} -> BADVARNAME );;
+                       ^
 gap> f();
 Error, Variable: 'BADVARNAME' must have an assigned value
-gap> f := ( -> IsBound(BADVARNAME[BADLISTNAME]) );;
+gap> f := ({} -> IsBound(BADVARNAME[BADLISTNAME]) );;
 Syntax warning: Unbound global variable in stream:1
-f := ( -> IsBound(BADVARNAME[BADLISTNAME]) );;
-                                        ^
+f := ({} -> IsBound(BADVARNAME[BADLISTNAME]) );;
+                                          ^
 gap> f();
 Error, Variable: 'BADVARNAME' must have an assigned value
 gap> STOP_TEST("bound.tst", 1);

--- a/tst/testinstall/flush.tst
+++ b/tst/testinstall/flush.tst
@@ -5,8 +5,8 @@ gap> cheesefun;
 << cheesefun to be defined>>
 gap> cheeseval;
 << cheeseval to be defined>>
-gap> InstallFlushableValueFromFunction(cheesefun, -> [1] );
-gap> InstallFlushableValueFromFunction(cheeseval, -> [2] );
+gap> InstallFlushableValueFromFunction(cheesefun, {} -> [1] );
+gap> InstallFlushableValueFromFunction(cheeseval, {} -> [2] );
 gap> cheesefun;
 [ 1 ]
 gap> cheeseval;

--- a/tst/testinstall/function.tst
+++ b/tst/testinstall/function.tst
@@ -108,18 +108,10 @@ gap> Print(x->x, "\n");
 function ( x )
     return x;
 end
-gap> ->1;
-function(  ) ... end
-gap> (->1)();
-1
 gap> {}->1;
 function(  ) ... end
 gap> ({}->1)();
 1
-gap> Print(->1, "\n");
-function (  )
-    return 1;
-end
 gap> Print({}->1, "\n");
 function (  )
     return 1;

--- a/tst/testinstall/modifiers.tst
+++ b/tst/testinstall/modifiers.tst
@@ -16,7 +16,7 @@ gap> x.2.3 := 5;
 5
 gap> x;
 rec( 2 := rec( 3 := 5 ) )
-gap> x.f := -> rec();
+gap> x.f := {} -> rec();
 function(  ) ... end
 gap> x;
 rec( 2 := rec( 3 := 5 ), f := function(  ) ... end )
@@ -28,7 +28,7 @@ gap> x := rec( a := 3 );
 rec( a := 3 )
 gap> 1 + x.a;
 4
-gap> x.f := -> [4];
+gap> x.f := {} -> [4];
 function(  ) ... end
 gap> 4 + x.f()[1];
 8


### PR DESCRIPTION
Per #1102, this removes the undocumented HPCGAP notation for no argument lambdas `( -> expr)`, as we now have the nicer `({} -> expr)` instead. This has never been documented, or announced.

There was only one occurrence of this in the library (there could exist other examples in HPC-GAP example code of course).