### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/opers.c
+++ b/src/opers.c
@@ -4774,15 +4774,15 @@ Obj DoVerboseMutableAttribute (
     do { \
         UInt name_len = GET_LEN_STRING(name); \
         UInt addon_len = sizeof(addon) - 1; \
-        char *tmp; \
+        char *ptr; \
         fname = NEW_STRING( name_len + addon_len + 2 ); \
         ImpliedWriteGuard(fname); \
-        tmp = CSTR_STRING(fname); \
-        memcpy( tmp, addon, addon_len ); tmp += addon_len; \
-        *tmp++ = '('; \
-        memcpy( tmp, CSTR_STRING(name), name_len ); tmp += name_len; \
-        *tmp++ = ')'; \
-        *tmp = 0; \
+        ptr = CSTR_STRING(fname); \
+        memcpy( ptr, addon, addon_len ); ptr += addon_len; \
+        *ptr++ = '('; \
+        memcpy( ptr, CSTR_STRING(name), name_len ); ptr += name_len; \
+        *ptr++ = ')'; \
+        *ptr = 0; \
         RetypeBag( fname, IMMUTABLE_TNUM(TNUM_OBJ(fname)) ); \
     } while(0)
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1657,7 +1657,7 @@ static inline Char CharHexDigit( const Char ch ) {
     } else {
         return (ch - '0');
     }
-};
+}
 
 Char GetEscapedChar( void )
 {


### PR DESCRIPTION
This PR fixes two compiler warnings generated using clang:

    ~/gap]$ clang -v
    Apple LLVM version 8.1.0 (clang-802.0.42)
    Target: x86_64-apple-darwin16.5.0
    Thread model: posix
    InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

The compiler warnings that are fixed are:

    src/opers.c:5719:5: warning: declaration shadows a local variable [-Wshadow]
        WRAP_NAME(fname, name, "SetterFunc");
        ^
    src/opers.c:4777:15: note: expanded from macro 'WRAP_NAME'
            char *tmp; \
                  ^
    src/opers.c:5714:25: note: previous declaration is here
        Obj                 tmp;

and 

    src/scanner.c:1660:2: warning: extra ';' outside of a function [-Wextra-semi]
    
The former is fixed by renaming`tmp` to `ptr` in the macro `WRAP_NAME` and the latter by removing the semicolon. 

There is currently a third compiler warning:

    src/read.c:1825:2: warning: embedding a directive within macro arguments has
          undefined behavior [-Wembedded-directive]

which is caused by using the macro `S_DO` inside a `#ifdef HPC_GAP` block. It wasn't clear to me how to fix this one. 


