### PR TITLE
Assorted cleanup

### DIFF
--- a/hpcgap/src/opers.c
+++ b/hpcgap/src/opers.c
@@ -491,6 +491,9 @@ static Obj UncheckedIS_SUBSET_FLAGS (
                 return False;
             }
         }
+        if ( len2 == 0 ) {
+            return True;
+        }
         if ( len2 < 3 ) {
 #ifdef COUNT_OPERS
             IsSubsetFlagsCalls2++;

--- a/hpcgap/src/opers.c
+++ b/hpcgap/src/opers.c
@@ -678,10 +678,15 @@ Obj FuncAND_FLAGS (
             "you can replace <flags2> via 'return <flags2>;'" );
     }
 
-    /* check the cache                                                     */
+    // check the cache
 #   ifdef AND_FLAGS_HASH_SIZE
         locked = (Obj) 0;
-        if ( INT_INTOBJ(flags1) < INT_INTOBJ(flags2) ) {
+        // We want to ensure if we calculate 'flags1 and flags2', then
+        // later do 'flags2 and flags1', we will get the value from the cache.
+        // Therefore we just compare the location of the Bag masterpointers
+        // for both flags (which doesn't change), and use the cache of the
+        // smaller.
+        if ( flags1 < flags2 ) {
             flagsX = flags2;
             if (!PreThreadCreation) {
               locked = flags1;
@@ -709,7 +714,7 @@ Obj FuncAND_FLAGS (
                 CHANGED_BAG(flags2);
             }
         }
-        hash = (UInt)INT_INTOBJ(flagsX);
+        hash = (UInt)flagsX;
         for ( i = 0;  i < 24;  i++ ) {
             hash2 = (hash + 97*i) % AND_FLAGS_HASH_SIZE;
             entry = ELM_PLIST( cache, 2*hash2+1 );

--- a/src/blister.c
+++ b/src/blister.c
@@ -596,7 +596,7 @@ Obj ElmsBlist (
     else {
 
         /* get the length of <list>                                        */
-        lenList = LEN_PLIST( list );
+        lenList = LEN_BLIST( list );
 
         /* get the length of <positions>, the first elements, and the inc. */
         lenPoss = GET_LEN_RANGE( poss );

--- a/src/costab.c
+++ b/src/costab.c
@@ -1473,8 +1473,11 @@ Obj FuncMakeCanonical (
                    (Int)TNAM_OBJ(rel), 0L );
         return 0;
     }
-    ptRel = &(ELM_PLIST(rel,1));
     leng  = LEN_PLIST(rel);
+    if (leng == 0) {
+        return 0;
+    }
+    ptRel = &(ELM_PLIST(rel, 1));
     leng1 = leng - 1;
 
     /*  cyclically reduce the relator, if necessary                        */

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -698,13 +698,15 @@ Obj             Cyclotomic (
                 /* is just the inverse transformation of 'ConvertToBase'   */
                 for ( i = 0; i < n; i += p ) {
                     cof = res[(i+n/p)%n];
-                    res[i] = INTOBJ_INT( - INT_INTOBJ(cof) );
                     if ( ! IS_INTOBJ(cof)
                       || (cof == INTOBJ_INT(-(1L<<NR_SMALL_INT_BITS))) ) {
                         CHANGED_BAG( STATE(ResultCyc) );
                         cof = DIFF( INTOBJ_INT(0), cof );
                         res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
                         res[i] = cof;
+                    }
+                    else {
+                        res[i] = INTOBJ_INT( - INT_INTOBJ(cof) );
                     }
                     for ( k = i+n/p; k < i+n && eql; k += n/p )
                         res[k%n] = INTOBJ_INT(0);
@@ -975,7 +977,6 @@ Obj             AInvCyc (
     exs = EXPOS_CYC(op,len);
     exp = EXPOS_CYC(res,len);
     for ( i = 1; i < len; i++ ) {
-        prd = INTOBJ_INT( - INT_INTOBJ(cfs[i]) );
         if ( ! IS_INTOBJ( cfs[i] ) || 
                cfs[i] == INTOBJ_INT(-(1L<<NR_SMALL_INT_BITS)) ) {
             CHANGED_BAG( res );
@@ -984,6 +985,9 @@ Obj             AInvCyc (
             cfp = COEFS_CYC(res);
             exs = EXPOS_CYC(op,len);
             exp = EXPOS_CYC(res,len);
+        }
+        else {
+            prd = INTOBJ_INT( - INT_INTOBJ(cfs[i]) );
         }
         cfp[i] = prd;
         exp[i] = exs[i];

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2483,7 +2483,6 @@ void            IntrListExprEnd (
 
     /* if this was a range, convert the list to a range                    */
     if ( range ) {
-
         /* get the list                                                    */
         list = PopObj();
 
@@ -2565,7 +2564,10 @@ void            IntrListExprEnd (
     else {
         /* give back unneeded memory */
         list = PopObj( );
-        SHRINK_PLIST( list, LEN_PLIST(list) );
+        /* Might have transformed into another type of list */
+        if (IS_PLIST(list)) {
+            SHRINK_PLIST(list, LEN_PLIST(list));
+        }
         PushObj( list );
     }
 }

--- a/src/opers.c
+++ b/src/opers.c
@@ -676,9 +676,14 @@ Obj FuncAND_FLAGS (
             "you can replace <flags2> via 'return <flags2>;'" );
     }
 
-    /* check the cache                                                     */
+    // check the cache
 #   ifdef AND_FLAGS_HASH_SIZE
-        if ( INT_INTOBJ(flags1) < INT_INTOBJ(flags2) ) {
+        // We want to ensure if we calculate 'flags1 and flags2', then
+        // later do 'flags2 and flags1', we will get the value from the cache.
+        // Therefore we just compare the location of the Bag masterpointers
+        // for both flags (which doesn't change), and use the cache of the
+        // smaller.
+        if ( flags1 < flags2 ) {
             flagsX = flags2;
             cache  = AND_CACHE_FLAGS(flags1);
             if ( cache == 0 ) {
@@ -698,7 +703,7 @@ Obj FuncAND_FLAGS (
                 CHANGED_BAG(flags2);
             }
         }
-        hash = (UInt)INT_INTOBJ(flagsX);
+        hash = (UInt)flagsX;
         for ( i = 0;  i < 24;  i++ ) {
             hash2 = (hash + 97*i) % AND_FLAGS_HASH_SIZE;
             entry = ELM_PLIST( cache, 2*hash2+1 );

--- a/src/opers.c
+++ b/src/opers.c
@@ -490,6 +490,9 @@ static Obj UncheckedIS_SUBSET_FLAGS (
                 return False;
             }
         }
+        if ( len2 == 0 ) {
+            return True;
+        }
         if ( len2 < 3 ) {
 #ifdef COUNT_OPERS
             IsSubsetFlagsCalls2++;

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -2054,12 +2054,14 @@ int GAP_rl_func(int count, int key)
    if (len > n) {
       n++;
       m = ELM_LIST(res, n);
-      if IS_INTOBJ(m) rl_point = INT_INTOBJ(m)-1;
+      if (IS_INTOBJ(m))
+          rl_point = INT_INTOBJ(m) - 1;
    }
    if (len > n) {
       n++;
       m = ELM_LIST(res, n);
-      if IS_INTOBJ(m) rl_mark = INT_INTOBJ(m)-1;
+      if (IS_INTOBJ(m))
+          rl_mark = INT_INTOBJ(m) - 1;
    }
    return 0;
 }

--- a/src/vars.c
+++ b/src/vars.c
@@ -2750,8 +2750,8 @@ Obj FuncContentsLVars (Obj self, Obj lvars )
   AssPRec(contents, RNamName("func"), func);
   AssPRec(contents,RNamName("names"), nams);
   memcpy((void *)(1+ADDR_OBJ(values)), (void *)(3+ADDR_OBJ(lvars)), len*sizeof(Obj));
-  while (ELM_PLIST(values, len) == 0)
-    len--;
+  while (len > 0 && ELM_PLIST(values, len) == 0)
+      len--;
   SET_LEN_PLIST(values, len);
   AssPRec(contents, RNamName("values"), values);
   if (ENVI_FUNC(func) != STATE(BottomLVars))

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -1103,6 +1103,8 @@ void PlainVec8Bit (
     Obj                 info;
     UInt1              *gettab;
     UInt                tnum;
+    Char *              startblank;
+    Char *              endblank;
 
     /* resize the list and retype it, in this order                        */
     if (True == DoFilter(IsLockedRepresentationVector, list)) {
@@ -1149,9 +1151,12 @@ void PlainVec8Bit (
             SET_ELM_PLIST(list, 2, second);
         SET_ELM_PLIST(list, 1, first);
     }
-    /* Null out any entries after the end of valid data */
-    for (i = len + 1; i < (SIZE_BAG(list) + sizeof(Obj) - 1) / sizeof(Obj); i++)
-        SET_ELM_PLIST(list, i, (Obj) 0);
+    // Null out any entries after the end of valid data
+    // As the size of the VEC8BIT might not evenly divide sizeof(Int), we
+    // cannot use PLIST methods to set the end of the list to zero
+    startblank = (Char *)(PTR_BAG(list) + (len + 1));
+    endblank = (Char *)PTR_BAG(list) + SIZE_BAG(list);
+    memset(startblank, 0, endblank - startblank);
 
     CHANGED_BAG(list);
 }

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -4094,8 +4094,8 @@ Obj SumMat8BitMat8Bit( Obj ml, Obj mr)
     Obj type;
     ll = LEN_MAT8BIT(ml);
     lr = LEN_MAT8BIT(mr);
-    wl = LEN_MAT8BIT(ELM_MAT8BIT(ml, 1));
-    wr = LEN_MAT8BIT(ELM_MAT8BIT(mr, 1));
+    wl = LEN_VEC8BIT(ELM_MAT8BIT(ml, 1));
+    wr = LEN_VEC8BIT(ELM_MAT8BIT(mr, 1));
 
     /* We have to track the cases where the result is not rectangular */
     if (((ll > lr) && (wr > wl)) ||
@@ -4173,8 +4173,8 @@ Obj DiffMat8BitMat8Bit( Obj ml, Obj mr)
 
     ll = LEN_MAT8BIT(ml);
     lr = LEN_MAT8BIT(mr);
-    wl = LEN_MAT8BIT(ELM_MAT8BIT(ml, 1));
-    wr = LEN_MAT8BIT(ELM_MAT8BIT(mr, 1));
+    wl = LEN_VEC8BIT(ELM_MAT8BIT(ml, 1));
+    wr = LEN_VEC8BIT(ELM_MAT8BIT(mr, 1));
 
     /* We have to track the cases where the result is not rectangular */
     if (((ll > lr) && (wr > wl)) ||

--- a/tst/testbugfix/2017-05-13-blist.tst
+++ b/tst/testbugfix/2017-05-13-blist.tst
@@ -1,0 +1,17 @@
+# Test bad slices in blists
+gap> l := List([true,true,true]);
+[ true, true, true ]
+gap> IsBlist(l);
+true
+gap> l{[1..1]};
+[ true ]
+gap> l{[1..2]};
+[ true, true ]
+gap> l{[1..3]};
+[ true, true, true ]
+gap> l{[1..4]};
+Error, List Elements: <list>[4] must have an assigned value
+gap> l{[1..5]};
+Error, List Elements: <list>[5] must have an assigned value
+gap> l{[1..15]};
+Error, List Elements: <list>[15] must have an assigned value

--- a/tst/testbugfix/2017-05-14-lvars.tst
+++ b/tst/testbugfix/2017-05-14-lvars.tst
@@ -1,0 +1,19 @@
+gap> GetCurrentLVars();
+<lvars bag>
+gap> ContentsLVars(GetCurrentLVars());
+false
+gap> f := function() return ContentsLVars(GetCurrentLVars()); end;
+function(  ) ... end
+gap> f();
+rec( func := function(  ) ... end, names := [  ], values := [  ] )
+gap> f := function() local x; return ContentsLVars(GetCurrentLVars()); end;;
+gap> f();
+rec( func := function(  ) ... end, names := [ "x" ], values := [  ] )
+gap> f := function(a,b,c) local x,y,z; y := 2; return ContentsLVars(GetCurrentLVars()); end;;
+gap> f(1,2,3);
+rec( func := function( a, b, c ) ... end, 
+  names := [ "a", "b", "c", "x", "y", "z" ], values := [ 1, 2, 3,, 2 ] )
+gap> f := function(a,b,c...) local x,y,z; y := 2; return ContentsLVars(GetCurrentLVars()); end;;
+gap> f(1,2,3);
+rec( func := function( a, b, c... ) ... end, 
+  names := [ "a", "b", "c", "x", "y", "z" ], values := [ 1, 2, [ 3 ],, 2 ] )


### PR DESCRIPTION
I have been working on adding asserts to the GAP kernel on many common functions, such as checking we only call LEN_PLIST on PLISTs, or we only call INT_INTOBJs on INTOBJs. This patch contains a number of fixes related to this.

It also includes some small testing fixes, which are designed to improve testing on travis.

I can pull this into multiple pull requests if reviewers want, or explain any of the changes in more depth.