### PR TITLE
Add assertions to the GAP kernel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,39 +21,40 @@ addons:
 matrix:
   include:
     # run testerror first; this is by far the quickest job, so we get some feedback ASAP
-    - env: TEST_SUITE=testerror
+    - env: TEST_SUITE=testerror CONFIGFLAGS="--enable-debug"
 
     # plain in-tree builds -- note that 32bit GMP is not yet available on trusty,
     # so we only test 32bit builds with the builtin GMP
-    - env: TEST_SUITE=testinstall ABI=32 CONFIGFLAGS=--with-gmp=builtin
-    - env: TEST_SUITE=testinstall ABI=64
+    - env: TEST_SUITE=testinstall ABI=32 CONFIGFLAGS="--enable-debug --with-gmp=builtin"
+    - env: TEST_SUITE=testinstall ABI=64 CONFIGFLAGS="--enable-debug"
 
     # out of tree builds -- these are mainly done to verify that the build
     # system work in this scenario. Since we don't expect the test results to
     # vary compared to the in-tree builds, we turn off coverage reporting by
     # setting NO_COVERAGE=1; this has the extra benefit of also running the
     # tests at least once with the ReproducibleBehaviour option turned off.
-    - env: TEST_SUITE=testinstall NO_COVERAGE=1 ABI=32 BUILDDIR=build CONFIGFLAGS=--with-gmp=builtin
-    - env: TEST_SUITE=testinstall NO_COVERAGE=1 ABI=64 BUILDDIR=build
+    - env: TEST_SUITE=testinstall NO_COVERAGE=1 ABI=32 BUILDDIR=build CONFIGFLAGS="--enable-debug --with-gmp=builtin"
+    - env: TEST_SUITE=testinstall NO_COVERAGE=1 ABI=64 BUILDDIR=build CONFIGFLAGS="--enable-debug"
 
     # HPC-GAP builds (for efficiency, we don't build all combinations)
     # FIXME: the 32bit build removes -O2 to avoid an internal compiler error for vecgf2.c
-    - env: TEST_SUITE=testinstall ABI=32 HPCGAP=yes BUILDDIR=build CONFIGFLAGS=--with-gmp=builtin CFLAGS="-fprofile-arcs -ftest-coverage"
-    - env: TEST_SUITE=testinstall ABI=64 HPCGAP=yes
+    - env: TEST_SUITE=testinstall ABI=32 HPCGAP=yes BUILDDIR=build CONFIGFLAGS="--enable-debug --with-gmp=builtin" CFLAGS="-fprofile-arcs -ftest-coverage"
+    - env: TEST_SUITE=testinstall ABI=64 HPCGAP=yes CONFIGFLAGS="--enable-debug"
 
     # OS X builds: since those are slow and limited on Travis,
     # we only run testinstall
+    # Also, we don't pass --enable-debug, both for speed and to check GAP works without debugging
     - env: TEST_SUITE=testinstall
       os: osx
       compiler: clang
 
     # 64bit linux builds with GCC
-    - env: TEST_SUITE=testtravis
-    - env: TEST_SUITE=testmanuals
-    - env: TEST_SUITE=testbugfix
+    - env: TEST_SUITE=testtravis CONFIGFLAGS="--enable-debug"
+    - env: TEST_SUITE=testmanuals CONFIGFLAGS="--enable-debug"
+    - env: TEST_SUITE=testbugfix CONFIGFLAGS="--enable-debug"
 
     # test creating the manual
-    - env: TEST_SUITE=makemanuals
+    - env: TEST_SUITE=makemanuals CONFIGFLAGS="--enable-debug"
       addons:
         apt_packages:
           - texlive-latex-base
@@ -64,7 +65,7 @@ matrix:
           - texlive-fonts-extra
 
     # 32bit linux builds with GCC
-    - env: TEST_SUITE=testtravis ABI=32
+    - env: TEST_SUITE=testtravis ABI=32 CONFIGFLAGS="--enable-debug"
       dist: precise # trusty is missing 32bit gmp, see https://github.com/travis-ci/apt-package-whitelist/pull/4018
       addons:
         apt_packages:

--- a/configure.ac
+++ b/configure.ac
@@ -207,7 +207,7 @@ dnl enable/disable C level assertions, etc.
 dnl
 AC_ARG_ENABLE([debug],
     [AS_HELP_STRING([--enable-debug], [enable debug mode])],
-    [AC_DEFINE([DEBUG], [1], [define if building in debug mode])],
+    [AC_DEFINE([GAP_KERNEL_DEBUG], [1], [define if building in debug mode])],
     [enable_debug=no]
     )
 AC_MSG_CHECKING([whether to enable debug mode])

--- a/src/blister.c
+++ b/src/blister.c
@@ -919,7 +919,7 @@ void PlainBlist (
     /* replace the bits by 'True' or 'False' as the case may be            */
     /* this must of course be done from the end of the list backwards      */
     for ( i = len; 0 < i; i-- )
-        SET_ELM_PLIST( list, i, ELM_BLIST( list, i ) );
+        SET_ELM_PLIST(list, i, ELM_BLIST_UNSAFE(list, i));
 
     /* 'CHANGED_BAG' not needed, 'True' and 'False' are safe           */
 }
@@ -1005,7 +1005,7 @@ void ConvBlist (
             block |= bit;
         bit = bit << 1;
         if ( bit == 0 || i == len ) {
-            BLOCK_ELM_BLIST(list,i) = block;
+            BLOCK_ELM_BLIST_UNSAFE(list, i) = block;
             block = 0;
             bit = 1;
         }

--- a/src/costab.c
+++ b/src/costab.c
@@ -2200,8 +2200,8 @@ Obj FuncLOWINDEX_COSET_SCAN (
   sd=LEN_PLIST(s1);
   s1a=(UInt*)ADDR_OBJ(s1);
   s2a=(UInt*)ADDR_OBJ(s2);
-  s1a[1]=INT_INTOBJ(s1a[1]);
-  s2a[1]=INT_INTOBJ(s2a[1]);
+  s1a[1]=INT_INTOBJ((Obj)s1a[1]);
+  s2a[1]=INT_INTOBJ((Obj)s2a[1]);
   while ((ok==1) && (j>0)) {
     d=s1a[j];
     x=s2a[j];
@@ -2342,7 +2342,7 @@ Obj FuncLOWINDEX_PREPARE_RELS (
       l=LEN_PLIST(rel);
       rp=(UInt*)ADDR_OBJ(rel);
       for (k=1;k<=l;k++) 
-        rp[k]=INT_INTOBJ(rp[k]); /* convert relator entries to C-integers */
+        rp[k]=INT_INTOBJ((Obj)rp[k]); /* convert relator entries to C-integers */
       /* change type */
       TYPE_DATOBJ(rel) = TYPE_LOWINDEX_DATA;
       RetypeBag(rel,T_DATOBJ);

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,28 @@
+/****************************************************************************
+**
+*W  debug.h                     GAP source               Chris Jefferson
+**
+**
+*Y  Copyright (C)  2017, University of St Andrews, Scotland
+**
+**  This file declares kernel debugging functionality.
+**
+*/
+
+#ifndef GAP_DEBUG_H
+#define GAP_DEBUG_H
+
+#include <src/system.h> /* system dependent part */
+#include <assert.h>     /* for assert            */
+
+/* GAP_ASSERT is a version of 'assert' which is enabled by the
+** configure option --enable-debug
+*/
+
+#ifdef GAP_KERNEL_DEBUG
+#define GAP_ASSERT(x) assert(x)
+#else
+#define GAP_ASSERT(x)
+#endif
+
+#endif

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1494,7 +1494,7 @@ static Obj FuncSTRONGLY_CONNECTED_COMPONENTS_DIGRAPH(Obj self, Obj digraph)
           fptr[2] = 1;
           fptr[3] = (UInt)adj;
           while (level > 0 ) {
-            if (fptr[2] > LEN_PLIST(fptr[3]))
+            if (fptr[2] > LEN_PLIST((Obj)fptr[3]))
               {
                 if (fptr[1] == ((UInt *)ADDR_OBJ(val))[fptr[0]])
                   {

--- a/src/lists.h
+++ b/src/lists.h
@@ -18,7 +18,7 @@
 #ifndef GAP_LISTS_H
 #define GAP_LISTS_H
 
-
+#include <src/plist.h>
 
 extern  Obj             TYPE_LIST_EMPTY_MUTABLE;
 extern  Obj             TYPE_LIST_EMPTY_IMMUTABLE;
@@ -33,17 +33,18 @@ extern  Obj             TYPE_LIST_HOM;
 **  'IS_LIST' returns a nonzero value if  the object <obj> is a list and zero
 **  otherwise.
 **
-**  Note that 'IS_LIST'  is a macro,  so do not  call it with arguments  that
-**  have side effects.
-**
 **  A package implementing  an ordinary list type <type>   must set the  flag
 **  'IsListFlag[<type>]'  for  this type to '1'.   A  package  implementing a
 **  vector type must set  it to '2'.  A  package implementing an matrix  type
 **  must set it to '3'.
 */
-#define IS_LIST(obj)    ((*IsListFuncs[ TNUM_OBJ( obj ) ])( obj ))
-
 extern  Int             (*IsListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
+
+static inline Int IS_LIST(Obj obj)
+{
+    return (*IsListFuncs[TNUM_OBJ(obj)])(obj);
+}
+
 
 /****************************************************************************
 **
@@ -59,10 +60,12 @@ extern  Int             (*IsListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
 **  instead it will check if the object HasIsSmallList and IsSmallList, or
 **  HasLength in which case Length will be checked
 */
+extern Int (*IsSmallListFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
-#define IS_SMALL_LIST(obj)    ((*IsSmallListFuncs[ TNUM_OBJ( obj ) ])( obj ))
-
-extern  Int                (*IsSmallListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
+static inline Int IS_SMALL_LIST(Obj obj)
+{
+    return (*IsSmallListFuncs[TNUM_OBJ(obj)])(obj);
+}
 
 
 /****************************************************************************
@@ -70,18 +73,18 @@ extern  Int                (*IsSmallListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
 *F  LEN_LIST(<list>)  . . . . . . . . . . . . . . . . . . .  length of a list
 *V  LenListFuncs[<type>]  . . . . . . . . . . . . . table of length functions
 **
-**  'LEN_LIST' returns the logical length of the list <list>  as a C integer.
-**  An error is signalled if <list> is not a small list.
-**
 **  Note that  'LEN_LIST' is a  macro, so do  not call it with arguments that
 **  have side effects.
 **
 **  A package  implementing a list type <type>  must  provide such a function
 **  and install it in 'LenListFuncs[<type>]'.
 */
-#define LEN_LIST(list)  ((*LenListFuncs[ TNUM_OBJ(list) ])( list ))
-
 extern  Int             (*LenListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+
+static inline Int LEN_LIST(Obj list)
+{
+    return (*LenListFuncs[TNUM_OBJ(list)])(list);
+}
 
 
 /****************************************************************************
@@ -92,15 +95,15 @@ extern  Int             (*LenListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 **  'LENGTH' returns the logical length of the list <list>  as a GAP object
 **  An error is signalled if <list> is not a list.
 **
-**  Note that  'LENGTH' is a  macro, so do  not call it with arguments that
-**  have side effects.
-**
 **  A package  implementing a list type <type>  must  provide such a function
 **  and install it in 'LengthFuncs[<type>]'.
 */
-#define LENGTH(list)    ((*LengthFuncs[ TNUM_OBJ(list) ])( list ))
-
 extern  Obj             (*LengthFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+
+static inline Obj LENGTH(Obj list)
+{
+    return (*LengthFuncs[TNUM_OBJ(list)])(list);
+}
 
 
 /****************************************************************************

--- a/src/objects.h
+++ b/src/objects.h
@@ -17,6 +17,7 @@
 #ifndef GAP_OBJECTS_H
 #define GAP_OBJECTS_H
 
+#include <src/debug.h>
 
 /****************************************************************************
 **
@@ -38,8 +39,10 @@
 **  'IS_INTOBJ' returns 1 if the object <o> is an (immediate) integer object,
 **  and 0 otherwise.
 */
-#define IS_INTOBJ(o) \
-    ((Int)(o) & 0x01)
+static inline Int IS_INTOBJ(Obj o)
+{
+    return (Int)o & 0x01;
+}
 
 
 /****************************************************************************
@@ -49,8 +52,10 @@
 **  'IS_POS_INTOBJ' returns 1 if the object <o> is an (immediate) integer
 **  object encoding a positive integer, and 0 otherwise.
 */
-#define IS_POS_INTOBJ(o) \
-    (((Int)(o) & 0x01) && ((Int)(o) > 0x01))
+static inline Int IS_POS_INTOBJ(Obj o)
+{
+    return ((Int)o & 0x01) && ((Int)o > 0x01);
+}
 
 
 /****************************************************************************
@@ -60,18 +65,10 @@
 **  'ARE_INTOBJS' returns 1 if the objects <o1> and <o2> are both (immediate)
 **  integer objects.
 */
-#define ARE_INTOBJS(o1,o2) \
-    ((Int)(o1) & (Int)(o2) & 0x01)
-
-
-/****************************************************************************
-**
-*F  INTOBJ_INT( <i> ) . . . . . . .  convert a C integer to an integer object
-**
-**  'INTOBJ_INT' converts the C integer <i> to an (immediate) integer object.
-*/
-#define INTOBJ_INT(i) \
-    ((Obj)(((UInt)(Int)(i) << 2) + 0x01))
+static inline Int ARE_INTOBJS(Obj o1, Obj o2)
+{
+    return (Int)o1 & (Int)o2 & 0x01;
+}
 
 
 /****************************************************************************
@@ -83,15 +80,30 @@
 /* Note that the C standard does not define what >> does here if the
  * value is negative. So we have to be careful if the C compiler
  * chooses to do a logical right shift. */
+static inline Int INT_INTOBJ(Obj o)
+{
+    GAP_ASSERT(IS_INTOBJ(o));
 #if HAVE_ARITHRIGHTSHIFT
-#define INT_INTOBJ(o) \
-    ((Int)(o) >> 2)
+    return (Int)o >> 2;
 #else
-#define INT_INTOBJ(o) \
-    (((Int)(o)-1) / 4)
+    return ((Int)o - 1) / 4;
 #endif
+}
 
 
+/****************************************************************************
+**
+*F  INTOBJ_INT( <i> ) . . . . . . .  convert a C integer to an integer object
+**
+**  'INTOBJ_INT' converts the C integer <i> to an (immediate) integer object.
+*/
+static inline Obj INTOBJ_INT(Int i)
+{
+    Obj o;
+    o = (Obj)(((UInt)i << 2) + 0x01);
+    GAP_ASSERT(INT_INTOBJ(o) == i);
+    return o;
+}
 
 /****************************************************************************
 **

--- a/src/objects.h
+++ b/src/objects.h
@@ -473,15 +473,24 @@ Int RegisterPackageTNUM( const char *name, Obj (*typeObjFunc)(Obj obj) );
 **
 **  'TNUM_OBJ' returns the type of the object <obj>.
 */
-#define TNUM_OBJ(obj)   (IS_INTOBJ( obj ) ? T_INT : \
-                         (IS_FFE( obj ) ? T_FFE : TNUM_BAG( obj )))
+static inline Int TNUM_OBJ(Obj obj)
+{
+    if (IS_INTOBJ(obj))
+        return T_INT;
+    if (IS_FFE(obj))
+        return T_FFE;
+    return TNUM_BAG(obj);
+}
 
 
 /****************************************************************************
 **
 *F  TNAM_OBJ( <obj> ) . . . . . . . . . . . . . name of the type of an object
 */
-#define TNAM_OBJ(obj)   (InfoBags[TNUM_OBJ(obj)].name)
+static inline const Char * TNAM_OBJ(Obj obj)
+{
+    return InfoBags[TNUM_OBJ(obj)].name;
+}
 
 
 /****************************************************************************

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -2861,7 +2861,7 @@ Obj             FuncCycleStructurePerm (
     }
 
     for (pnt=1; pnt<max;pnt++) {
-      if (ptList[pnt]!=0) { ptList[pnt]=INTOBJ_INT(ptList[pnt]);}
+      if (ptList[pnt]!=0) { ptList[pnt]=INTOBJ_INT((UInt)ptList[pnt]);}
     } 
 
     /* return the list                                                     */

--- a/src/range.h
+++ b/src/range.h
@@ -34,9 +34,15 @@
 **  'NEW_RANGE' returns a new range.  Note that  you must set the length, the
 **  low value, and the increment before you can use the range.
 */
-#define NEW_RANGE_NSORT() NewBag( T_RANGE_NSORT, 3 * sizeof(Obj) )
-#define NEW_RANGE_SSORT() NewBag( T_RANGE_SSORT, 3 * sizeof(Obj) )
+static inline Obj NEW_RANGE_NSORT()
+{
+    return NewBag(T_RANGE_NSORT, 3 * sizeof(Obj));
+}
 
+static inline Obj NEW_RANGE_SSORT()
+{
+    return NewBag(T_RANGE_SSORT, 3 * sizeof(Obj));
+}
 
 /****************************************************************************
 **
@@ -46,11 +52,12 @@
 **  otherwise.  Note that a list for which 'IS_RANGE' returns  0 may still be
 **  a range, but  the kernel does not know  this yet.  Use  'IsRange' to test
 **  whether a list is a range.
-**
-**  Note that  'IS_RANGE' is a  macro, so do not  call it with arguments that
-**  have side effects.
 */
-#define IS_RANGE(val)   (TNUM_OBJ(val)==T_RANGE_NSORT || TNUM_OBJ(val)==T_RANGE_SSORT)
+static inline Int IS_RANGE(Obj val)
+{
+    return TNUM_OBJ(val) >= T_RANGE_NSORT &&
+           TNUM_OBJ(val) <= T_RANGE_SSORT + IMMUTABLE;
+}
 
 
 /****************************************************************************
@@ -59,11 +66,12 @@
 **
 **  'SET_LEN_RANGE' sets the length  of the range <list>  to the value <len>,
 **  which must be a C integer larger than 1.
-**
-**  Note that 'SET_LEN_RANGE' is a macro,  so  do not  call it with arguments
-**  that have side effects.
 */
-#define SET_LEN_RANGE(list,len)         (ADDR_OBJ(list)[0] = INTOBJ_INT(len))
+static inline void SET_LEN_RANGE(Obj list, Int len)
+{
+    GAP_ASSERT(IS_RANGE(list));
+    ADDR_OBJ(list)[0] = INTOBJ_INT(len);
+}
 
 
 /****************************************************************************
@@ -72,11 +80,12 @@
 **
 **  'GET_LEN_RANGE' returns the  logical length of  the range <list>, as  a C
 **  integer.
-**
-**  Note that  'GET_LEN_RANGE' is a macro, so  do not call  it with arguments
-**  that have side effects.
 */
-#define GET_LEN_RANGE(list)             INT_INTOBJ( ADDR_OBJ(list)[0] )
+static inline Int GET_LEN_RANGE(Obj list)
+{
+    GAP_ASSERT(IS_RANGE(list));
+    return INT_INTOBJ(ADDR_OBJ(list)[0]);
+}
 
 
 /****************************************************************************
@@ -85,11 +94,12 @@
 **
 **  'SET_LOW_RANGE' sets the  first element of the range  <list> to the value
 **  <low>, which must be a C integer.
-**
-**  Note  that 'SET_LOW_RANGE' is a macro, so do not call  it with  arguments
-**  that have side effects.
 */
-#define SET_LOW_RANGE(list,low)         (ADDR_OBJ(list)[1] = INTOBJ_INT(low))
+static inline void SET_LOW_RANGE(Obj list, Int low)
+{
+    GAP_ASSERT(IS_RANGE(list));
+    ADDR_OBJ(list)[1] = INTOBJ_INT(low);
+}
 
 
 /****************************************************************************
@@ -98,11 +108,12 @@
 **
 **  'GET_LOW_RANGE' returns the first  element  of the  range  <list> as a  C
 **  integer.
-**
-**  Note that 'GET_LOW_RANGE' is a  macro, so do not  call it with  arguments
-**  that have side effects.
 */
-#define GET_LOW_RANGE(list)             INT_INTOBJ( ADDR_OBJ(list)[1] )
+static inline Int GET_LOW_RANGE(Obj list)
+{
+    GAP_ASSERT(IS_RANGE(list));
+    return INT_INTOBJ(ADDR_OBJ(list)[1]);
+}
 
 
 /****************************************************************************
@@ -111,11 +122,12 @@
 **
 **  'SET_INC_RANGE' sets  the  increment of  the range  <list>   to the value
 **  <inc>, which must be a C integer.
-**
-**  Note that  'SET_INC_RANGE' is a macro,  so do  not call it with arguments
-**  that have side effects.
 */
-#define SET_INC_RANGE(list,inc)         (ADDR_OBJ(list)[2] = INTOBJ_INT(inc))
+static inline void SET_INC_RANGE(Obj list, Int inc)
+{
+    GAP_ASSERT(IS_RANGE(list));
+    ADDR_OBJ(list)[2] = INTOBJ_INT(inc);
+}
 
 
 /****************************************************************************
@@ -123,11 +135,12 @@
 *F  GET_INC_RANGE(<list>) . . . . . . . . . . . . . . .  increment of a range
 **
 **  'GET_INC_RANGE' returns the increment of the range <list> as a C integer.
-**
-**  Note  that 'GET_INC_RANGE' is  a macro, so  do not call it with arguments
-**  that have side effects.
 */
-#define GET_INC_RANGE(list)             INT_INTOBJ( ADDR_OBJ(list)[2] )
+static inline Int GET_INC_RANGE(Obj list)
+{
+    GAP_ASSERT(IS_RANGE(list));
+    return INT_INTOBJ(ADDR_OBJ(list)[2]);
+}
 
 
 /****************************************************************************
@@ -136,13 +149,15 @@
 **
 **  'GET_ELM_RANGE' return  the <pos>-th element  of the range <list>.  <pos>
 **  must be a positive integer less than or equal to the length of <list>.
-**
-**  Note that 'GET_ELM_RANGE'  is a macro, so do  not call  it with arguments
-**  that have side effects.
 */
-#define GET_ELM_RANGE(list,pos)         INTOBJ_INT( GET_LOW_RANGE(list) \
-                                          + ((pos)-1) * GET_INC_RANGE(list) )
-
+static inline Obj GET_ELM_RANGE(Obj list, Int pos)
+{
+    Int val;
+    GAP_ASSERT(IS_RANGE(list));
+    val = GET_LOW_RANGE(list) + ((pos)-1) * GET_INC_RANGE(list);
+    GAP_ASSERT(pos >= 1 && pos <= GET_LEN_RANGE(list));
+    return INTOBJ_INT(val);
+}
 
 /****************************************************************************
 **

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -3450,10 +3450,30 @@ Obj FuncPROD_VEC8BIT_MATRIX( Obj self, Obj vec, Obj mat)
 *F  * * * * * * *  special rep for matrices over these fields * * * * * * *
 */
 
-#define LEN_MAT8BIT(mat)                   INT_INTOBJ(ADDR_OBJ(mat)[1])
-#define SET_LEN_MAT8BIT(mat, l)            (ADDR_OBJ(mat)[1] = INTOBJ_INT(l))
-#define ELM_MAT8BIT(mat, i)                ADDR_OBJ(mat)[i+1]
-#define SET_ELM_MAT8BIT(mat, i, row)       (ADDR_OBJ(mat)[i+1] = row)
+static inline Int LEN_MAT8BIT(Obj mat)
+{
+    return INT_INTOBJ(ADDR_OBJ(mat)[1]);
+}
+static inline void SET_LEN_MAT8BIT(Obj mat, Int l)
+{
+    GAP_ASSERT(l >= 0);
+    GAP_ASSERT(l <= SIZE_OBJ(mat) / sizeof(Obj) - 1);
+    ADDR_OBJ(mat)[1] = INTOBJ_INT(l);
+}
+
+static inline Obj ELM_MAT8BIT(Obj mat, Int i)
+{
+    GAP_ASSERT(i >= 1);
+    GAP_ASSERT(i <= SIZE_OBJ(mat) / sizeof(Obj) - 1);
+    return ADDR_OBJ(mat)[i + 1];
+}
+static inline void SET_ELM_MAT8BIT(Obj mat, Int i, Obj row)
+{
+    GAP_ASSERT(i >= 1);
+    GAP_ASSERT(i <= SIZE_OBJ(mat) / sizeof(Obj) - 1);
+    GAP_ASSERT(IS_LIST(row));
+    ADDR_OBJ(mat)[i + 1] = row;
+}
 
 /****************************************************************************
 **

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -1103,6 +1103,7 @@ void PlainVec8Bit (
     Obj                 info;
     UInt1              *gettab;
     UInt                tnum;
+    Obj                 fieldobj;
     Char *              startblank;
     Char *              endblank;
 
@@ -1142,11 +1143,11 @@ void PlainVec8Bit (
 
         /* replace the bits by FF elts as the case may be        */
         /* this must of course be done from the end of the list backwards      */
-        for (i = len;  2 < i;  i--)
-            SET_ELM_PLIST(list, i,
-            FFE_FELT_FIELDINFO_8BIT(info)
-            [gettab[256 * ((i - 1) % elts) +
-            BYTES_VEC8BIT(list)[(i - 1) / elts]]]);
+        for (i = len; 2 < i; i--) {
+            fieldobj = FFE_FELT_FIELDINFO_8BIT(info)
+            [gettab[256 * ((i - 1) % elts) + BYTES_VEC8BIT(list)[(i - 1) / elts]]];
+            SET_ELM_PLIST(list, i, fieldobj);
+        }
         if (len > 1)
             SET_ELM_PLIST(list, 2, second);
         SET_ELM_PLIST(list, 1, first);


### PR DESCRIPTION
This patch adds assertions to various functions in the GAP kernel. This is built on top of #1340, which fixes the assertions which these new checks trigger.

To enable these checks, pass `--enable-debug` to configure.

I'm mainly posting this mainly to check if anyone has an fundamental opinions. I plan on doing some small tidy ups before merging.