### PR TITLE
kernel: stop checking USE_PRECOMPILED

### DIFF
--- a/src/fibhash.h
+++ b/src/fibhash.h
@@ -3,7 +3,7 @@
 
 #include <gen/config.h>
 
-#if !defined(SIZEOF_VOID_P) && !defined(USE_PRECOMPILED)
+#if !defined(SIZEOF_VOID_P)
 #error Require SIZEOF_VOID_P to be defined
 #endif
 

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -53,10 +53,7 @@
 
 #if SIZEOF_VOID_P == 8
 #define USE_NEWSHAPE
-#elif !defined(SIZEOF_VOID_P) && !defined(USE_PRECOMPILED)
-/* If SIZEOF_VOID_P has not been defined, and we are not currently
-   re-making the dependency list (via cnf/Makefile), then trigger
-   an error. */
+#elif !defined(SIZEOF_VOID_P)
 #error Something is wrong with this GAP installation: SIZEOF_VOID_P not defined
 #endif
 

--- a/src/gmpints.h
+++ b/src/gmpints.h
@@ -41,13 +41,13 @@ extern "C" {
 #define NR_SMALL_INT_BITS  (32 - 4)
 #endif
 
-#if (GMP_LIMB_BITS != INTEGER_UNIT_SIZE * 8) && !defined(USE_PRECOMPILED)
+#if (GMP_LIMB_BITS != INTEGER_UNIT_SIZE * 8)
 #error Aborting compile: unexpected GMP limb size
 #endif
 #if GMP_NAIL_BITS != 0
 #error Aborting compile: GAP does not support non-zero GMP nail size
 #endif
-#if !defined(__GNU_MP_RELEASE) && !defined(USE_PRECOMPILED)
+#if !defined(__GNU_MP_RELEASE)
  #if __GMP_MP_RELEASE < 50002
  #error Aborting compile: GAP requires GMP 5.0.2 or newer
  #endif

--- a/src/system.h
+++ b/src/system.h
@@ -78,10 +78,7 @@
 /* check if we are on a 64 bit machine                                     */
 #if SIZEOF_VOID_P == 8
 # define SYS_IS_64_BIT          1
-#elif !defined(SIZEOF_VOID_P) && !defined(USE_PRECOMPILED)
-/* If SIZEOF_VOID_P has not been defined, and we are not currently
-   re-making the dependency list (via cnf/Makefile), then trigger
-   an error. */
+#elif !defined(SIZEOF_VOID_P)
 # error Something is wrong with this GAP installation: SIZEOF_VOID_P not defined
 #endif
 


### PR DESCRIPTION
This is a left-over from the old build system, and not needed anymore.