### PR TITLE
kernel: remove PREALLOCATE_TABLES code

### DIFF
--- a/hpcgap/src/opers.c
+++ b/hpcgap/src/opers.c
@@ -3138,11 +3138,6 @@ Obj NewOperation (
     ObjFunc             hdlr )
 {
     Obj                 oper;
-#ifdef  PREALLOCATE_TABLES
-    Obj                 cache;
-    Obj                 methods;
-    UInt                i;
-#endif
 
     /* create the function                                                 */
     oper = NewFunctionT( T_FUNCTION, SIZE_OPER, name, narg, nams, hdlr );
@@ -3168,20 +3163,6 @@ Obj NewOperation (
     SETTR_FILT(oper) = False;
     TESTR_FILT(oper) = False;
     
-    /* create caches and methods lists                                     */
-#ifdef  PREALLOCATE_TABLES
-    for ( i = 0; i <= 7; i++ ) {
-        methods = NEW_PLIST( T_PLIST, 0 );
-        METHS_OPER( oper, i ) = methods;
-/* TODO: Is there a better solution for this? */
-#if 0
-        cache = NEW_PLIST( T_PLIST, (i < 7 ? 4 * (i+2) : 4 * (1+2)) );
-        CACHE_OPER( oper, i ) = cache;
-#endif
-        CHANGED_BAG(oper);
-    }
-#endif
-
     /* This isn't an attribute (yet) */
     SET_ENABLED_ATTR(oper, 0);
 
@@ -4611,11 +4592,6 @@ Obj NewConstructor (
     ObjFunc             hdlr )
 {
     Obj                 oper;
-#ifdef  PREALLOCATE_TABLES
-    Obj                 cache;
-    Obj                 methods;
-    UInt                i;
-#endif
 
     /* create the function                                                 */
     oper = NewFunctionT( T_FUNCTION, SIZE_OPER, name, narg, nams, hdlr );
@@ -4639,19 +4615,6 @@ Obj NewConstructor (
     SETTR_FILT(oper) = False;
     TESTR_FILT(oper) = False;
     
-#ifdef  PREALLOCATE_TABLES
-    /* create caches and methods lists                                     */
-    for ( i = 0; i <= 7; i++ ) {
-        methods = NEW_PLIST( T_PLIST, 0 );
-        METHS_OPER( oper, i ) = methods;
-#if 0
-        cache = NEW_PLIST( T_PLIST, (i < 7 ? 4 * (i+1) : 4 * (1+1)) );
-        CACHE_OPER( oper, i ) = cache;
-#endif
-        CHANGED_BAG(oper);
-    }
-#endif
-
     /* return constructor                                                  */
     return oper;
 }

--- a/src/opers.c
+++ b/src/opers.c
@@ -3030,11 +3030,6 @@ Obj NewOperation (
     ObjFunc             hdlr )
 {
     Obj                 oper;
-#ifdef  PREALLOCATE_TABLES
-    Obj                 cache;
-    Obj                 methods;
-    UInt                i;
-#endif
 
     /* create the function                                                 */
     oper = NewFunctionT( T_FUNCTION, SIZE_OPER, name, narg, nams, hdlr );
@@ -3060,17 +3055,6 @@ Obj NewOperation (
     SETTR_FILT(oper) = False;
     TESTR_FILT(oper) = False;
     
-    /* create caches and methods lists                                     */
-#ifdef  PREALLOCATE_TABLES
-    for ( i = 0; i <= 7; i++ ) {
-        methods = NEW_PLIST( T_PLIST, 0 );
-        METHS_OPER( oper, i ) = methods;
-        cache = NEW_PLIST( T_PLIST, (i < 7 ? CACHE_SIZE * (i+2) : CACHE_SIZE * (1+2)) );
-        CACHE_OPER( oper, i ) = cache;
-        CHANGED_BAG(oper);
-    }
-#endif
-
     /* This isn't an attribute (yet) */
     SET_ENABLED_ATTR(oper, 0);
 
@@ -4486,11 +4470,6 @@ Obj NewConstructor (
     ObjFunc             hdlr )
 {
     Obj                 oper;
-#ifdef  PREALLOCATE_TABLES
-    Obj                 cache;
-    Obj                 methods;
-    UInt                i;
-#endif
 
     /* create the function                                                 */
     oper = NewFunctionT( T_FUNCTION, SIZE_OPER, name, narg, nams, hdlr );
@@ -4514,17 +4493,6 @@ Obj NewConstructor (
     SETTR_FILT(oper) = False;
     TESTR_FILT(oper) = False;
     
-#ifdef  PREALLOCATE_TABLES
-    /* create caches and methods lists                                     */
-    for ( i = 0; i <= 7; i++ ) {
-        methods = NEW_PLIST( T_PLIST, 0 );
-        METHS_OPER( oper, i ) = methods;
-        cache = NEW_PLIST( T_PLIST, (i < 7 ? CACHE_SIZE * (i+1) : CACHE_SIZE * (1+1)) );
-        CACHE_OPER( oper, i ) = cache;
-        CHANGED_BAG(oper);
-    }
-#endif
-
     /* return constructor                                                  */
     return oper;
 }


### PR DESCRIPTION
GAP has not been preallocating these tables since 1997