### PR TITLE
Refactor GASMAN GC Bag headers into a a bitfield struct

### DIFF
--- a/src/gasman.c
+++ b/src/gasman.c
@@ -874,26 +874,22 @@ void StartRestoringBags( UInt nBags, UInt maxSize)
   return;
 }
 
-Bag NextBagRestoring( UInt size, UInt type)
+Bag NextBagRestoring( UInt type, UInt flags, UInt size )
 {
   Bag bag;
   UInt i;
-  *(Bag **)NextMptrRestoring = (AllocBags+BAG_HEADER_SIZE);
+  BagHeader * header = (BagHeader *)AllocBags;
+  *(Bag **)NextMptrRestoring = AllocBags = header->data;
   bag = NextMptrRestoring;
-#ifdef USE_NEWSHAPE
-  ((UInt *)AllocBags)[0] = (size << 16 | type);
-#else
-  ((UInt *)AllocBags)[0] = type;
-  ((UInt *)AllocBags)[1] = size;
-#endif
-
-  ((Bag *)AllocBags)[BAG_HEADER_SIZE-1] = NextMptrRestoring;
+  header->type = type;
+  header->flags = flags;
+  header->size = size;
+  header->link = NextMptrRestoring;
   NextMptrRestoring++;
 #ifdef DEBUG_LOADING
   if ((Bag *)NextMptrRestoring >= OldBags)
     (*AbortFuncBags)("Overran Masterpointer area");
 #endif
-  AllocBags += BAG_HEADER_SIZE;
 
   for (i = 0; i < WORDS_BAG(size); i++)
     *AllocBags++ = (Bag)0;

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1120,7 +1120,6 @@ Bag NewBag (
     UInt                size )
 {
     Bag                 bag;            /* identifier of the new bag       */
-    Bag *               dst;            /* destination of the new bag      */
 
 #ifdef TREMBLE_HEAP
     CollectBags(0,0);
@@ -1148,24 +1147,20 @@ Bag NewBag (
     FreeMptrBags = *(Bag*)bag;
     CLEAR_CANARY();
     /* allocate the storage for the bag                                    */
-    dst       = AllocBags;
-    AllocBags = dst + BAG_HEADER_SIZE + WORDS_BAG(size);
+    BagHeader * header = (BagHeader *)AllocBags;
+    AllocBags = header->data + WORDS_BAG(size);
     ADD_CANARY();
 
     /* enter size-type words                                               */
-#ifdef USE_NEWSHAPE
-    *dst++ = (Bag)(size << 16 | type);
-#else
-    *dst++ = (Bag)(type);
-    *dst++ = (Bag)(size);
-#endif
-
+    header->type = type;
+    header->flags = 0;
+    header->size = size;
 
     /* enter link word                                                     */
-    *dst++ = bag;
+    header->link = bag;
 
     /* set the masterpointer                                               */
-    PTR_BAG(bag) = dst;
+    PTR_BAG(bag) = header->data;
 
     /* return the identifier of the new bag                                */
     return bag;

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -114,14 +114,13 @@
 #include <src/system.h>                 /* Ints, UInts */
 #include <src/gapstate.h>
 
-
-
 #include <src/gasman.h>                 /* garbage collector */
 
 #include <src/objects.h>                /* objects */
 #include <src/scanner.h>                /* scanner */
 
 
+#include <stddef.h>
 
 
 /****************************************************************************
@@ -1038,6 +1037,12 @@ void            InitBags (
     StackFuncBags   = stack_func;
     StackBottomBags = stack_bottom;
     StackAlignBags  = stack_align;
+
+    if ( sizeof(BagHeader) % sizeof(Bag) != 0 )
+        (*AbortFuncBags)("BagHeader size is not a multiple of word size.");
+
+    if ( sizeof(BagHeader) != offsetof(BagHeader, data) )
+        (*AbortFuncBags)("BagHeader's data member has invalid offset.");
 
     /* first get some storage from the operating system                    */
     initial_size    = (initial_size + 511) & ~(511);

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -304,8 +304,8 @@ void CLEAR_CANARY() {
 
 void CHANGED_BAG_IMPL(Bag bag) {
     CANARY_DISABLE_VALGRIND();
-    if ( PTR_BAG(bag) <= YoungBags && PTR_BAG(bag)[-1] == (bag) ) {
-        PTR_BAG(bag)[-1] = ChangedBags;
+    if ( PTR_BAG(bag) <= YoungBags && LINK_BAG(bag) == (bag) ) {
+        LINK_BAG(bag) = ChangedBags;
         ChangedBags = (bag);
     }
     CANARY_ENABLE_VALGRIND();
@@ -1422,8 +1422,8 @@ UInt ResizeBag (
 
         CANARY_DISABLE_VALGRIND();
         /* if the bag is already on the changed bags list, keep it there   */
-        if ( PTR_BAG(bag)[-1] != bag ) {
-            *dst++ = PTR_BAG(bag)[-1];
+        if ( LINK_BAG(bag) != bag ) {
+            *dst++ = LINK_BAG(bag);
         }
 
 
@@ -1755,8 +1755,8 @@ again:
         /* empty the list of changed old bags                              */
         while ( ChangedBags != 0 ) {
             first = ChangedBags;
-            ChangedBags = PTR_BAG(first)[-1];
-            PTR_BAG(first)[-1] = first;
+            ChangedBags = LINK_BAG(first);
+            LINK_BAG(first) = first;
         }
 
         /* Also time to change the tag for dead children of weak
@@ -1800,8 +1800,8 @@ again:
     /* mark the subbags of the changed old bags                            */
     while ( ChangedBags != 0 ) {
         first = ChangedBags;
-        ChangedBags = PTR_BAG(first)[-1];
-        PTR_BAG(first)[-1] = first;
+        ChangedBags = LINK_BAG(first);
+        LINK_BAG(first) = first;
         if ( PTR_BAG(first) <= YoungBags )
             (*TabMarkFuncBags[TNUM_BAG(first)])( first );
         else
@@ -1814,8 +1814,8 @@ again:
     sizeLiveBags = 0;
     while ( MarkedBags != 0 ) {
         first = MarkedBags;
-        MarkedBags = PTR_BAG(first)[-1];
-        PTR_BAG(first)[-1] = MARKED_ALIVE(first);
+        MarkedBags = LINK_BAG(first);
+        LINK_BAG(first) = MARKED_ALIVE(first);
         (*TabMarkFuncBags[TNUM_BAG(first)])( first );
         nrLiveBags++;
         sizeLiveBags += SIZE_BAG(first);
@@ -2334,16 +2334,16 @@ void SwapMasterPoint (
     ptr2 = PTR_BAG(bag2);
 
     /* check and update the link field and changed bags                    */
-    if ( PTR_BAG(bag1)[-1] == bag1 && PTR_BAG(bag2)[-1] == bag2 ) {
-        PTR_BAG(bag1)[-1] = bag2;
-        PTR_BAG(bag2)[-1] = bag1;
+    if ( LINK_BAG(bag1) == bag1 && LINK_BAG(bag2) == bag2 ) {
+        LINK_BAG(bag1) = bag2;
+        LINK_BAG(bag2) = bag1;
     }
-    else if ( PTR_BAG(bag1)[-1] == bag1 ) {
-        PTR_BAG(bag1)[-1] = ChangedBags;
+    else if ( LINK_BAG(bag1) == bag1 ) {
+        LINK_BAG(bag1) = ChangedBags;
         ChangedBags = bag1;
     }
-    else if ( PTR_BAG(bag2)[-1] == bag2 ) {
-        PTR_BAG(bag2)[-1] = ChangedBags;
+    else if ( LINK_BAG(bag2) == bag2 ) {
+        LINK_BAG(bag2) = ChangedBags;
         ChangedBags = bag2;
     }
 

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -137,12 +137,12 @@
 **    +---------+
 **    |<masterp>|
 **    +---------+
-**          \____________
-**                       \
-**                        V
-**    +---------+---------+--------------------------------------------+----+
-**    |<sz>.<tp>|  <link> |         .         .         .         .    | pad|
-**    +---------+---------+--------------------------------------------+----+
+**          \________________________
+**                                   \
+**                                    V
+**    +------+-------+------+---------+--------------------------------+----+
+**    |<size>|<flags>|<type>|  <link> |         .         .         ...| pad|
+**    +------+-------+------+---------+--------------------------------+----+
 **
 **  A bag consists of a masterpointer, and a body.
 **
@@ -157,14 +157,12 @@
 **  masterpointer  of  the bag.   Thus   'PTR_BAG(<bag>)' is simply '\*<bag>'
 **  plus a cast.
 **
-**  The *body* of a  bag consists of  the size-type word,  the link word, the
-**  data area, and the padding.
+**  The *body* of a bag consists of a header, the data area, and the padding.
 **
-**  The *size-type word* contains the size of the bag in the upper  (at least
-**  24) bits, and the type (abbreviated as <tp> in the  above picture) in the
-**  lower 8  bits.  Thus 'SIZE_BAG'   simply extracts the size-type  word and
-**  shifts it 8 bits to the right, and 'TNUM_BAG' extracts the size-type word
-**  and masks out everything except the lower 8 bits.
+**  The header in turn consists of the *type byte*, *flags byte* and the
+**  *size field*, which is either 32 bits or 48 bits (on 32 resp. 64 bit systems),
+**  followed by a link word.  The 'BagHeader' struct describes the exact
+**  structure of the header.
 **
 **  The  *link word* usually   contains the identifier of  the  bag,  i.e., a
 **  pointer to the masterpointer of the bag.  Thus the garbage collection can
@@ -182,14 +180,14 @@
 **  returns the number  of words occupied  by the data  area and padding of a
 **  bag of size <size>.
 **
-**  A body in the workspace  whose  size-type word contains  the value 255 in
-**  the lower 8 bits is the remainder of a 'ResizeBag'.  That  is it consists
-**  either of the unused words after a bag has been shrunk or of the old body
-**  of the bag after the contents of the body have  been copied elsewhere for
-**  an extension.  The upper (at least 24) bits of the first word contain the
-**  number of bytes in this area excluding the first  word itself.  Note that
-**  such a body   has no link   word,  because  such  a  remainder  does  not
-**  correspond to a bag (see "Implementation of ResizeBag").
+**  A body in the workspace whose type byte contains the value 255 is the
+**  remainder of a 'ResizeBag'. That is it consists either of the unused words
+**  after a bag has been shrunk, or of the old body of the bag after the
+**  contents of the body have been copied elsewhere for an extension. The
+**  upper (at least 24) bits of the first word contain the number of bytes in
+**  this area excluding the first word itself. Note that such a body  has no
+**  link  word, because such a remainder does not correspond to a bag (see
+**  "Implementation of ResizeBag").
 **
 **  A masterpointer with a value  congruent to 1  mod 4 is   the relic of  an
 **  object  that was  weakly but not   strongly  marked in  a recent  garbage

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1182,6 +1182,7 @@ void            RetypeBag (
     Bag                 bag,
     UInt                new_type )
 {
+    BagHeader * header = BAG_HEADER(bag);
 
 #ifdef  COUNT_BAGS
     /* update the statistics      */
@@ -1189,8 +1190,8 @@ void            RetypeBag (
           UInt                old_type;       /* old type of the bag */
           UInt                size;
 
-          old_type = TNUM_BAG(bag);
-          size = SIZE_BAG(bag);
+          old_type = header->type;
+          size = header->size;
           InfoBags[old_type].nrLive   -= 1;
           InfoBags[new_type].nrLive   += 1;
           InfoBags[old_type].nrAll    -= 1;
@@ -1202,13 +1203,7 @@ void            RetypeBag (
     }
 #endif
 
-    /* change the size-type word                                           */
-#ifdef USE_NEWSHAPE
-    *(*bag-BAG_HEADER_SIZE) &= 0xFFFFFFFFFFFFFF00L;
-    *(*bag-BAG_HEADER_SIZE) |= new_type;
-#else
-    *(*bag-BAG_HEADER_SIZE) = new_type;
-#endif
+    header->type = new_type;
 }
 #endif
 

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1126,7 +1126,7 @@ Bag NewBag (
 #endif
 
     /* check that a masterpointer and enough storage are available         */
-    if ( (FreeMptrBags == 0 || SizeAllocationArea < BAG_HEADER_SIZE+WORDS_BAG(size))
+    if ( (FreeMptrBags == 0 || SizeAllocationArea < WORDS_BAG(sizeof(BagHeader)+size))
       && CollectBags( size, 0 ) == 0 )
     {
         return 0;
@@ -1359,7 +1359,7 @@ UInt ResizeBag (
     else {
 
         /* check that enough storage for the new bag is available          */
-        if ( SizeAllocationArea <  BAG_HEADER_SIZE+WORDS_BAG(new_size)
+        if ( SizeAllocationArea <  WORDS_BAG(sizeof(BagHeader)+new_size)
               && CollectBags( new_size, 0 ) == 0 ) {
             return 0;
         }
@@ -1371,7 +1371,7 @@ UInt ResizeBag (
         // leave magic size-type word  for the sweeper, type must be 255
         header->type = 255;
         header->flags = 0;
-        header->size = (BAG_HEADER_SIZE+WORDS_BAG(old_size) - 1) * sizeof(Bag);
+        header->size = sizeof(BagHeader) + (WORDS_BAG(old_size) - 1) * sizeof(Bag);
 
         /* allocate the storage for the bag                                */
         BagHeader * newHeader = (BagHeader *)AllocBags;
@@ -2023,7 +2023,7 @@ again:
     /* * * * * * * * * * * * * * * check phase * * * * * * * * * * * * * * */
 
     /* temporarily store in 'StopBags' where this allocation takes us      */
-    StopBags = AllocBags + BAG_HEADER_SIZE + WORDS_BAG(size);
+    StopBags = AllocBags + WORDS_BAG(sizeof(BagHeader)+size);
 
 
 

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -2023,12 +2023,7 @@ again:
 
     /* clear the new free area                                             */
     if (!DirtyBags)
-      memset((void *)dst, 0, ((Char  *)src)-((Char *)dst));
-
-    /*    if ( ! DirtyBags ) {
-        while ( dst < src )
-            *dst++ = 0;
-            } */
+      memset((void *)dst, 0, ((Char *)src)-((Char *)dst));
 
     /* information after the sweep phase                                   */
     NrDeadBags += nrDeadBags;
@@ -2319,19 +2314,19 @@ Bag BAG (
 UInt TNUM_BAG (
     Bag                 bag )
 {
-    return (*(*(bag)-3) & 0xFFL);
+    return BAG_HEADER(bag)->type;
 }
 
 const Char * TNAM_BAG (
     Bag                 bag )
 {
-    return InfoBags[ (*(*(bag)-3) & 0xFFL) ].name;
+    return InfoBags[ BAG_HEADER(bag)->type ].name;
 }
 
 UInt SIZE_BAG (
     Bag                 bag )
 {
-    return (*(*(bag)-2));
+    return BAG_HEADER(bag)->size;
 }
 
 Bag * PTR_BAG (

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -96,17 +96,35 @@ typedef struct {
     Bag data[];
 } BagHeader;
 
+
 #define BAG_HEADER_SIZE     (sizeof(BagHeader)/sizeof(Bag))
 
-#define BAG_HEADER_CONTENTS(data)   (((BagHeader *)data) - 1)
-#define BAG_HEADER(bag)             BAG_HEADER_CONTENTS(*(bag))
+
+/****************************************************************************
+**
+*F  BAG_HEADER(<bag>) . . . . . . . . . . . . . . . . . . . . header of a bag
+**
+**  'BAG_HEADER' returns the header of the bag with the identifier <bag>.
+*/
+static inline BagHeader * BAG_HEADER(Bag bag) {
+    return (((BagHeader *)*bag) - 1);
+}
+
+
+/****************************************************************************
+**
+*F  BAG_HEADER_CONTENTS(<ptr>) . . . . . . . . . . . . . . .  header of a bag
+**
+**  'BAG_HEADER' returns the header of the bag whose contents start at <ptr>.
+*/
+static inline BagHeader * BAG_HEADER_CONTENTS(void *ptr) {
+    return (((BagHeader *)ptr) - 1);
+}
 
 
 /****************************************************************************
 **
 *F  TNUM_BAG(<bag>) . . . . . . . . . . . . . . . . . . . . . . type of a bag
-**
-**  'TNUM_BAG( <bag> )'
 **
 **  'TNUM_BAG' returns the type of the bag with the identifier <bag>.
 **
@@ -119,11 +137,10 @@ typedef struct {
 **  {\Gasman} needs to know the type of a bag so that it knows which function
 **  to  call  to  mark all subbags  of a  given bag (see "InitMarkFuncBags").
 **  Apart from that {\Gasman} does not care at all about types.
-**
-**  Note  that 'TNUM_BAG' is a macro, so do not call  it with arguments  that
-**  have side effects.
 */
-#define TNUM_BAG(bag)  (BAG_HEADER(bag)->type)
+static inline UInt TNUM_BAG(Bag bag) {
+    return BAG_HEADER(bag)->type;
+}
 
 
 /****************************************************************************
@@ -152,9 +169,17 @@ typedef struct {
 **  of the form (1 << i). Currently, 'i' must be in the range from 0 to
 **  7 (inclusive).
 */
-#define TEST_OBJ_FLAG(bag, flag)    (BAG_HEADER(bag)->flags & (flag))
-#define SET_OBJ_FLAG(bag, flag)     (BAG_HEADER(bag)->flags |= (flag))
-#define CLEAR_OBJ_FLAG(bag, flag)   (BAG_HEADER(bag)->flags &= ~(flag))
+static inline uint8_t TEST_OBJ_FLAG(Bag bag, uint8_t flag) {
+    return BAG_HEADER(bag)->flags & flag;
+}
+
+static inline void SET_OBJ_FLAG(Bag bag, uint8_t flag) {
+    BAG_HEADER(bag)->flags |= flag;
+}
+
+static inline void CLEAR_OBJ_FLAG(Bag bag, uint8_t flag) {
+    BAG_HEADER(bag)->flags &= ~flag;
+}
 
 
 /****************************************************************************
@@ -170,11 +195,10 @@ typedef struct {
 **  The  size must  be a   value between   0 and $2^{24}-1$.  The application
 **  specifies the size of a bag when it  allocates  it  with 'NewBag' and may
 **  later change it with 'ResizeBag' (see "NewBag" and "ResizeBag").
-**
-**  Note that  'SIZE_BAG' is  a macro,  so do not call it with arguments that
-**  have side effects.
 */
-#define SIZE_BAG(bag)   (BAG_HEADER(bag)->size)
+static inline UInt SIZE_BAG(Bag bag) {
+    return BAG_HEADER(bag)->size;
+}
 
 
 /****************************************************************************
@@ -186,15 +210,19 @@ typedef struct {
 **  atomic operations that require a memory barrier in between dereferencing
 **  the bag pointer and accessing the contents of the bag.
 */
-#define SIZE_BAG_CONTENTS(ptr)   (BAG_HEADER_CONTENTS(ptr)->size)
+static inline UInt SIZE_BAG_CONTENTS(void *ptr) {
+    return BAG_HEADER_CONTENTS(ptr)->size;
+}
 
 
 /****************************************************************************
 **
-*F  LINK_BAG(<bag>) . . . . . . . . . . . . . . . . . . . link field of a bag
+*F  LINK_BAG(<bag>) . . . . . . . . . . . . . . . . . . link pointer of a bag
 **
-**  TODO: document this
+**  'LINK_BAG' returns the link pointer of the bag with the identifier <bag>.
 **
+**  Note that  'LINK_BAG' is  a macro,  so do not call it with arguments that
+**  have side effects.
 */
 #define LINK_BAG(bag)   (BAG_HEADER(bag)->link)
 
@@ -309,7 +337,8 @@ extern  Bag *                   YoungBags;
 
 extern  Bag                     ChangedBags;
 
-/*****
+/****************************************************************************
+**
 **  MEMORY_CANARY provides (basic) support for catching out-of-bounds memory
 **  problems in GAP. This is done through the excellent 'valgrind' program.
 **  valgrind is of limited use in GAP normally, because it doesn't understand

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -93,6 +93,12 @@
 typedef UInt * *        Bag;
 */
 
+#ifdef USE_NEWSHAPE
+#define BAG_HEADER_SIZE 2
+#else
+#define BAG_HEADER_SIZE 3
+#endif
+
 
 /****************************************************************************
 **
@@ -116,13 +122,7 @@ typedef UInt * *        Bag;
 **  have side effects.
 */
 
-#ifdef USE_NEWSHAPE
-#define BAG_TNUM_OFFSET (-2)
-#else
-#define BAG_TNUM_OFFSET (-3)
-#endif
-
-#define TNUM_BAG(bag)  (*(*(bag) + BAG_TNUM_OFFSET) & 0xFFL)
+#define TNUM_BAG(bag)  (*(*(bag) - BAG_HEADER_SIZE) & 0xFFL)
 
 
 /****************************************************************************
@@ -153,13 +153,13 @@ typedef UInt * *        Bag;
 */
 
 #define TEST_OBJ_FLAG(bag, flag) \
-	(*(*(bag) + BAG_TNUM_OFFSET) & (flag))
+	(*(*(bag) - BAG_HEADER_SIZE) & (flag))
 
 #define SET_OBJ_FLAG(bag, flag) \
-	(*(*(bag) + BAG_TNUM_OFFSET) |= (flag))
+	(*(*(bag) - BAG_HEADER_SIZE) |= (flag))
 
 #define CLEAR_OBJ_FLAG(bag, flag) \
-	(*(*(bag) + BAG_TNUM_OFFSET) &= ~(flag))
+	(*(*(bag) - BAG_HEADER_SIZE) &= ~(flag))
 
 
 /****************************************************************************

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -999,7 +999,7 @@ extern Bag * GlobalByCookie(
 extern void StartRestoringBags( UInt nBags, UInt maxSize);
 
 
-extern Bag NextBagRestoring( UInt size,  UInt type);
+extern Bag NextBagRestoring( UInt type, UInt flags, UInt size );
 
 
 extern void FinishedRestoringBags( void );

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -338,8 +338,8 @@ extern void CHANGED_BAG_IMPL(Bag b);
 #else
 #define CHANGED_BAG(bag)                                                    \
                 if (   PTR_BAG(bag) <= YoungBags                              \
-                  && PTR_BAG(bag)[-1] == (bag) ) {                          \
-                    PTR_BAG(bag)[-1] = ChangedBags; ChangedBags = (bag);    }
+                  && LINK_BAG(bag) == (bag) ) {                          \
+                    LINK_BAG(bag) = ChangedBags; ChangedBags = (bag);    }
 
 #endif // MEMORY_CANARY
 
@@ -832,9 +832,9 @@ extern  Bag                     MarkedBags;
 #define MARKED_DEAD(x)  (x)
 #define MARKED_ALIVE(x) ((Bag)(((Char *)(x))+1))
 #define MARKED_HALFDEAD(x) ((Bag)(((Char *)(x))+2))
-#define IS_MARKED_ALIVE(bag) ((PTR_BAG(bag)[-1]) == MARKED_ALIVE(bag))
-#define IS_MARKED_DEAD(bag) ((PTR_BAG(bag)[-1]) == MARKED_DEAD(bag))
-#define IS_MARKED_HALFDEAD(bag) ((PTR_BAG(bag)[-1]) == MARKED_HALFDEAD(bag))
+#define IS_MARKED_ALIVE(bag) ((LINK_BAG(bag)) == MARKED_ALIVE(bag))
+#define IS_MARKED_DEAD(bag) ((LINK_BAG(bag)) == MARKED_DEAD(bag))
+#define IS_MARKED_HALFDEAD(bag) ((LINK_BAG(bag)) == MARKED_HALFDEAD(bag))
 #define UNMARKED_DEAD(x)  (x)
 #define UNMARKED_ALIVE(x) ((Bag)(((Char *)(x))-1))
 #define UNMARKED_HALFDEAD(x) ((Bag)(((Char *)(x))-2))
@@ -848,7 +848,7 @@ extern  Bag                     MarkedBags;
                   && YoungBags < PTR_BAG(bag)  && PTR_BAG(bag) <= AllocBags \
                   && (IS_MARKED_DEAD(bag) || IS_MARKED_HALFDEAD(bag)) ) \
                   {                                                          \
-                    PTR_BAG(bag)[-1] = MarkedBags; MarkedBags = (bag);      }
+                    LINK_BAG(bag) = MarkedBags; MarkedBags = (bag);      }
 
 #else
 

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -95,9 +95,6 @@ typedef struct {
 } BagHeader;
 
 
-#define BAG_HEADER_SIZE     (sizeof(BagHeader)/sizeof(Bag))
-
-
 /****************************************************************************
 **
 *F  BAG_HEADER(<bag>) . . . . . . . . . . . . . . . . . . . . header of a bag

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -85,10 +85,8 @@ typedef struct {
     uint8_t type : 8;
     uint8_t flags : 8;
 #if SIZEOF_VOID_P == 8
-#define USE_NEWSHAPE
     uint64_t size : 48;
 #elif SIZEOF_VOID_P == 4
-#undef USE_NEWSHAPE
     uint16_t reserved : 16;
     uint32_t size : 32;
 #endif

--- a/src/hpc/boehm_gc.h
+++ b/src/hpc/boehm_gc.h
@@ -614,7 +614,7 @@ void CallbackForAllBags(
 void StartRestoringBags( UInt nBags, UInt maxSize)
 { }
 
-Bag NextBagRestoring( UInt size, UInt type)
+Bag NextBagRestoring( UInt type, UInt flags, UInt size )
 { return 0; }
 
 void FinishedRestoringBags( void )

--- a/src/hpc/boehm_gc.h
+++ b/src/hpc/boehm_gc.h
@@ -372,16 +372,11 @@ void            RetypeBag (
     Bag                 bag,
     UInt                new_type )
 {
-
-    UInt old_type = TNUM_BAG(bag);
+    BagHeader   *header = BAG_HEADER(bag);
+    UInt old_type = header->type;
 
     /* change the size-type word                                           */
-#ifdef USE_NEWSHAPE
-    *(*bag-BAG_HEADER_SIZE) &= 0xFFFFFFFFFFFFFF00L;
-    *(*bag-BAG_HEADER_SIZE) |= new_type;
-#else
-    *(*bag-BAG_HEADER_SIZE) = new_type;
-#endif
+    header->type = new_type;
     {
       int old_gctype, new_gctype;
       UInt size;

--- a/src/hpc/boehm_gc.h
+++ b/src/hpc/boehm_gc.h
@@ -137,11 +137,12 @@ void BuildPrefixGCDescriptor(unsigned prefix_len) {
   if (prefix_len) {
     GC_word bits[1] = {0};
     unsigned i;
+    const UInt wordsInBagHeader = sizeof(BagHeader)/sizeof(Bag);
     for (i=0; i<prefix_len; i++)
-      GC_set_bit(bits, (i + BAG_HEADER_SIZE));
-    GCDesc[prefix_len] = GC_make_descriptor(bits, prefix_len + BAG_HEADER_SIZE);
+      GC_set_bit(bits, (i + wordsInBagHeader));
+    GCDesc[prefix_len] = GC_make_descriptor(bits, prefix_len + wordsInBagHeader);
     GC_set_bit(bits, 0);
-    GCMDesc[prefix_len] = GC_make_descriptor(bits, prefix_len + BAG_HEADER_SIZE);
+    GCMDesc[prefix_len] = GC_make_descriptor(bits, prefix_len + wordsInBagHeader);
   } else {
     GCDesc[prefix_len] = GC_DS_LENGTH;
     GCMDesc[prefix_len] = GC_DS_LENGTH | sizeof(void *);

--- a/src/objects.h
+++ b/src/objects.h
@@ -440,9 +440,9 @@ Int RegisterPackageTNUM( const char *name, Obj (*typeObjFunc)(Obj obj) );
 **
 */
 
-#define TESTING (1 << 8)
-#define TESTED (1 << 9)
-#define FIXED_REGION (1 << 10)
+#define TESTING (1 << 0)
+#define TESTED (1 << 1)
+#define FIXED_REGION (1 << 2)
 
 #else
 

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -424,13 +424,13 @@ Double LoadDouble( void )
 
 static void SaveBagData (Bag bag )
 {
-#ifndef USE_NEWSHAPE
-  SaveUInt((UInt)PTR_BAG(bag)[-3]);
-#endif
-  SaveUInt((UInt)PTR_BAG(bag)[-2]);
+  BagHeader * header = BAG_HEADER(bag);
+  SaveUInt1(header->type);
+  SaveUInt1(header->flags);
+  SaveUInt(header->size);
 
   /* dispatch */
-  (*(SaveObjFuncs[ TNUM_BAG( bag )]))(bag);
+  (*(SaveObjFuncs[ header->type]))(bag);
 
 }
 
@@ -439,18 +439,12 @@ static void SaveBagData (Bag bag )
 static void LoadBagData ( void )
 {
   Bag bag;
-  UInt size;
-  UInt type;
+  UInt type, flags, size;
   
   /* Recover the size & type */
-#ifdef USE_NEWSHAPE
+  type = LoadUInt1();
+  flags = LoadUInt1();
   size = LoadUInt();
-  type = size & 0xFFL;
-  size >>= 16;
-#else
-  type = LoadUInt();
-  size = LoadUInt();
-#endif
 
 #ifdef DEBUG_LOADING
   {
@@ -464,7 +458,7 @@ static void LoadBagData ( void )
 #endif  
 
   /* Get GASMAN to set up the bag for me */
-  bag = NextBagRestoring( size, type );
+  bag = NextBagRestoring( type, flags, size );
   
   /* despatch */
   (*(LoadObjFuncs[ type ]))(bag);


### PR DESCRIPTION
This is some work in progress on refactoring our GC code to use fewer magic constants; also gets rid of tons of `#ifdef USE_NEWSHAPE` case distinctions. 