### PR TITLE
Move LowLayerSubgroups test from testinstall to testextra

### DIFF
--- a/tst/testextra/grpperm.tst
+++ b/tst/testextra/grpperm.tst
@@ -194,6 +194,10 @@ gap> g:=SymmetricGroup(17);;s:=SylowSubgroup(g,NrMovedPoints(g));;
 gap> ac:=AscendingChain(g,s);;
 gap> Maximum(List([2..Length(ac)],x->Index(ac[x],ac[x-1])))<10^11;
 true
+gap> g:=PSL(4,5);;
+gap> l:=LowLayerSubgroups(g,3,x->Index(g,x)<=10000);;
+gap> Sum(List(l,x->Index(g,x)));
+89655
 gap> STOP_TEST( "grpperm.tst", 1);
 
 #############################################################################

--- a/tst/testinstall/grpperm.tst
+++ b/tst/testinstall/grpperm.tst
@@ -59,8 +59,4 @@ gap> G := SylowSubgroup(SymmetricGroup(2^7),2);;
 gap> N := Center(G);;
 gap> HasSolvableFactorGroup(G,N);
 true
-gap> g:=PSL(4,5);;
-gap> l:=LowLayerSubgroups(g,3,x->Index(g,x)<=10000);;
-gap> Sum(List(l,x->Index(g,x)));
-89655
 gap> STOP_TEST( "grpperm.tst", 1);


### PR DESCRIPTION
It takes several minutes to complete on my system, while testinstall
test files should not take more than a few seconds to complete.

This test was explicitly added by @hulpke in ae86f3cb25ea5dd5e811f0ea44b852eab1b97f73 to testinstall. I wonder if it was much faster back then, and we are looking at a speed regression?