### PR TITLE
hpcgap: get rid of protected region and single threaded mode

### DIFF
--- a/hpcgap/src/opers.c
+++ b/hpcgap/src/opers.c
@@ -6495,7 +6495,7 @@ static Int InitKernel (
     SaveObjFuncs[ T_FLAGS ] = SaveFlags;
     LoadObjFuncs[ T_FLAGS ] = LoadFlags;
 
-    /* flags are protected objects by default */
+    /* flags are public objects by default */
     MakeBagTypePublic(T_FLAGS);
 
     /* import copy of REREADING */

--- a/lib/hpc/thread1.g
+++ b/lib/hpc/thread1.g
@@ -24,12 +24,9 @@ BIND_GLOBAL("ThreadVar", rec());
 BIND_GLOBAL("MakeThreadLocal", ID_FUNC);
 BIND_GLOBAL("MakeReadOnly", ID_FUNC);
 BIND_GLOBAL("MakeReadOnlyRaw", ID_FUNC);
-BIND_GLOBAL("MakeProtected", ID_FUNC);
-BIND_GLOBAL("MakeProjectedObj", ID_FUNC);
 BIND_GLOBAL("MakeReadOnlyObj", ID_FUNC);
 
 BIND_GLOBAL("IsReadOnly", RETURN_FALSE);
-BIND_GLOBAL("IsProtected", RETURN_FALSE);
 
 BIND_GLOBAL("AtomicList", function(arg)
   local l, i;

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -625,12 +625,10 @@ extern  TNumInfoBags            InfoBags [ 256 ];
 
 #ifdef HPCGAP
 void MakeBagTypePublic(int type);
-void MakeBagTypeProtected(int type);
 Bag MakeBagPublic(Bag bag);
 Bag MakeBagReadOnly(Bag bag);
 #else
 #define MakeBagTypePublic(type)     do { } while(0)
-#define MakeBagTypeProtected(type)  do { } while(0)
 #define MakeBagPublic(bag)          do { } while(0)
 #define MakeBagReadOnly(bag)        do { } while(0)
 #endif

--- a/src/hpc/boehm_gc.h
+++ b/src/hpc/boehm_gc.h
@@ -51,16 +51,10 @@ static char DSInfoBags[NTYPES];
 
 #define DSI_TL 0
 #define DSI_PUBLIC 1
-#define DSI_PROTECTED 2
 
 void MakeBagTypePublic(int type)
 {
     DSInfoBags[type] = DSI_PUBLIC;
-}
-
-void MakeBagTypeProtected(int type)
-{
-    DSInfoBags[type] = DSI_PROTECTED;
 }
 
 Bag MakeBagPublic(Bag bag)
@@ -407,9 +401,6 @@ void            RetypeBag (
       case DSI_PUBLIC:
         REGION(bag) = NULL;
         break;
-      case DSI_PROTECTED:
-        REGION(bag) = ProtectedRegion;
-        break;
     }
 }
 
@@ -493,9 +484,6 @@ Bag NewBag (
       break;
     case DSI_PUBLIC:
       REGION(bag) = NULL;
-      break;
-    case DSI_PROTECTED:
-      REGION(bag) = ProtectedRegion;
       break;
     }
 

--- a/src/hpc/thread.h
+++ b/src/hpc/thread.h
@@ -52,7 +52,7 @@ void RegionReadUnlock(Region *region);
 void RegionUnlock(Region *region);
 Region *CurrentRegion();
 Region *GetRegionOf(Obj obj);
-extern Region *LimboRegion, *ReadOnlyRegion, *ProtectedRegion;
+extern Region *LimboRegion, *ReadOnlyRegion;
 extern Obj PublicRegion;
 extern Obj PublicRegionName;
 
@@ -67,10 +67,6 @@ void UnlockThreadControl(void);
 void GCThreadHandler();
 
 void InitMainThread();
-
-int IsSingleThreaded();
-void BeginSingleThreaded();
-void EndSingleThreaded();
 
 int IsLocked(Region *region);
 void GetLockStatus(int count, Obj *objects, int *status);

--- a/src/opers.c
+++ b/src/opers.c
@@ -6352,7 +6352,7 @@ static Int InitKernel (
     SaveObjFuncs[ T_FLAGS ] = SaveFlags;
     LoadObjFuncs[ T_FLAGS ] = LoadFlags;
 
-    /* flags are protected objects by default */
+    /* flags are public objects by default */
     MakeBagTypePublic(T_FLAGS);
 
     /* import copy of REREADING */


### PR DESCRIPTION
Neither was used or really usable. According to Reimer, they were from the
early stages of the HPC-GAP project, and if we wanted something like that,
we likely should redo it carefully from scratch anyway.