### PR TITLE
Increase warning level for Conway polynomial

### DIFF
--- a/hpcgap/lib/polyconw.gi
+++ b/hpcgap/lib/polyconw.gi
@@ -318,7 +318,7 @@ InstallGlobalFunction( ConwayPol, function( p, n )
   
   if cachedata = fail then
 
-      Info( InfoWarning, 1,
+      Info( InfoWarning, 2,
             "computing Conway polynomial for p = ", p, " and n = ", n );
 
       F:= GF(p);

--- a/lib/polyconw.gi
+++ b/lib/polyconw.gi
@@ -273,7 +273,7 @@ InstallGlobalFunction( ConwayPol, function( p, n )
     fi;
     if not IsBound( cachelist[n] ) then
 
-      Info( InfoWarning, 1,
+      Info( InfoWarning, 2,
             "computing Conway polynomial for p = ", p, " and n = ", n );
 
       F:= GF(p);


### PR DESCRIPTION
This just increases the warning level of calculating conway polynomials. I don't feel this message is necessary for most users, and it is causing problems with some new tests I'm writing (and annoys me generally)