### PR TITLE
kernel: add back SET_TYPE_DATOBJ

### DIFF
--- a/src/objects.h
+++ b/src/objects.h
@@ -871,6 +871,8 @@ extern void SetTypeDatObj( Obj obj, Obj type );
 #define SetTypeDatObj(obj, type)  (ADDR_OBJ(obj)[0] = (type))
 #endif
 
+#define SET_TYPE_DATOBJ(obj, type)  SetTypeDatObj(obj, type)
+
 
 /****************************************************************************
 **


### PR DESCRIPTION
This macro was replaced by SetTypeDatObj, but at least the cvec package
makes use of it, so add it back, as an alias for SetTypeDatObj.