### PR TITLE
Stop testing from entering the break loop

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -653,8 +653,8 @@ endif
 ########################################################################
 
 GAPARGS=
-TESTGAP = $(abs_top_builddir)/bin/gap.sh -b -m 100m -o 1g -q -x 80 -r -A $(GAPARGS)
-TESTGAPauto = $(abs_top_builddir)/bin/gap.sh -b -m 100m -o 1g -q -x 80 -r $(GAPARGS)
+TESTGAP = $(abs_top_builddir)/bin/gap.sh --quitonbreak -b -m 100m -o 1g -q -x 80 -r -A $(GAPARGS)
+TESTGAPauto = $(abs_top_builddir)/bin/gap.sh --quitonbreak -b -m 100m -o 1g -q -x 80 -r $(GAPARGS)
 
 ########################################################################
 # Documentation rules


### PR DESCRIPTION
At the moment, `make testpackages` enters the break loop when a package misbehaves. This is quite annoying. This PR stops any tests run from the main makefile entering the break loop, by using `--quitonbreak`.