### PR TITLE
Fix EqFloat to actually work correctly

### DIFF
--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -94,6 +94,7 @@ Int EqMacfloat (
 }
 
 Obj FuncEqMacfloat (
+    Obj                 self,
     Obj                 macfloatL,
     Obj                 macfloatR )
 {

--- a/tst/testinstall/float.tst
+++ b/tst/testinstall/float.tst
@@ -145,6 +145,18 @@ gap> -MakeFloat(1.0, infinity) = neginf;
 true
 gap> MakeFloat(1.0, -infinity) = neginf;
 true
+
+#
+gap> EqFloat(1.0, 1.1);
+false
+gap> EqFloat(1.0, 1.0);
+true
+gap> EqFloat(0.0/0.0,0.0/0.0);
+false
+gap> EqFloat(0.0,0.0/0.0);
+false
+
+#
 gap> STOP_TEST( "float.tst", 1);
 
 #############################################################################


### PR DESCRIPTION
This always returned false for machine floats in the past, due to a missing argument.
