### PR TITLE
Make prompt same length as maximum line

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -1325,7 +1325,7 @@ void syEchos (
 **  'SyFputs' is called to put the  <line>  to the file identified  by <fid>.
 */
 UInt   syNrchar;                        /* nr of chars already on the line */
-Char   syPrompt [256];                  /* characters already on the line   */
+Char   syPrompt [MAXLENOUTPUTLINE];     /* characters already on the line  */
 
 
 


### PR DESCRIPTION
This partly fixes #1235, which involves too long lines.

This patch doesn't completely look at all parts of this issue, but it does handle all known crashes (the one in #1235, and another one I came across today, printing records when `ScreenSize` is set to 1000).