### PR TITLE
Several documentation, generic methods and tests

### DIFF
--- a/doc/ref/matobj.xml
+++ b/doc/ref/matobj.xml
@@ -29,7 +29,7 @@ vectors and matrices.
 
 <Section>
     <Heading>Categories of vectors and matrices</Heading>
-
+    
 </Section>
 
 <Section>
@@ -38,6 +38,18 @@ vectors and matrices.
 
 <Section>
     <Heading>Operations for row vector objects</Heading>
+
+    <#Include Label="MatObj_PositionNonZero">
+    <#Include Label="MatObj_PositionLastNonZero">
+    <#Include Label="MatObj_ListOp">
+    <#Include Label="MatObj_UnpackVector">
+    <#Include Label="MatObj_ConcatenationOfVectors">
+    <#Include Label="MatObj_ExtractSubVector">
+    <#Include Label="MatObj_ZeroVector">
+    <#Include Label="MatObj_ConstructingFilter_Vector">
+    <#Include Label="MatObj_Randomize_Vectors">
+    <#Include Label="MatObj_WeightOfVector">
+    <#Include Label="MatObj_DistanceOfVectors">
 
 </Section>
 

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -505,3 +505,25 @@ InstallMethod( \{\},
     vec_list := vec_list{[pos]};
     return Vector(vec_list,vec);
 end );
+
+InstallMethod( CopySubVector,
+  "General method for vectors",
+  true,[IsVectorObj and IsMutable, IsList, IsVectorObj, IsList],0,
+  function(dst, dcols, src, scols)
+    local i;
+    if not Length( dcols ) = Length( scols ) then
+      Error( "source and destination index lists must be of equal length" );
+      return;
+    fi;
+    for i in [ 1 .. Length( dcols ) ] do
+      dst[dcols[i]] := src[scols[i]];
+    od;
+end );
+
+## Backwards compatible version
+InstallMethod( CopySubVector,
+  "Fallback method for vectors",
+  true,[IsVectorObj,IsVectorObj and IsMutable, IsList, IsList],0,
+  function(src, dst, scols, dcols)
+    CopySubVector(dst,dcols,src,scols);
+end );

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -440,3 +440,25 @@ InstallMethod( TraceMat, "generic method",
     return s;
   end );
 
+
+InstallMethod(PositionNonZero,
+  "General method for a row vector",
+  true,[IsRowVector],0,
+  function(vec)
+  local i;
+  for i in [1..Length(vec)] do
+    if not IsZero(vec[i]) then return i;fi;
+  od;
+  return Length(vec)+1;
+end);
+
+InstallMethod(PositionNonZero,
+  "General method for a row vector",
+  true,[IsVectorObj],0,
+  function(vec)
+  local i;
+  for i in [1..Length(vec)] do
+    if not IsZero(vec[i]) then return i;fi;
+  od;
+  return Length(vec)+1;
+end);

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -20,7 +20,6 @@ InstallOtherMethod( \[\], [ IsMatrixObj, IsList ], {m,l} -> MatElm(m,l[1],l[2]))
 InstallOtherMethod( \[\]\:\=, [ IsMatrixObj, IsList, IsObject ], function(m,l,o) SetMatElm(m, l[1], l[2], o); end);
 
 
-
 InstallMethod( WeightOfVector, "generic method",
   [IsVectorObj],
   function(v)
@@ -496,3 +495,13 @@ InstallMethod( Unpack,
   true,[IsVectorObj],0,
   ListOp ); ## Potentially slower than a direct implemtation,
             ## but avoids code multiplication.
+
+
+InstallMethod( \{\},
+               [IsVectorObj,IsList],
+  function(vec,pos)
+    local vec_list;
+    vec_list := ListOp(vec);
+    vec_list := vec_list{[pos]};
+    return Vector(vec_list,vec);
+end );

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -462,3 +462,31 @@ InstallMethod(PositionNonZero,
   od;
   return Length(vec)+1;
 end);
+
+InstallMethod( ListOp,
+  "General method for a vector",
+  true,[IsVectorObj],0,
+  function(vec)
+  local return_list, i, length_vector;
+  length_vector := Length(vec);
+  return_list := [];
+  return_list[length_vector] := vec[length_vector];
+  for i in [ 1 .. length_vector - 1 ] do
+    return_list[i] := vec[i];
+  od;
+  return return_list;
+end );
+
+InstallMethod( ListOp,
+  "General method for a vector and a function",
+  true,[IsVectorObj,IsFunction],0,
+  function(vec,func)
+  local return_list, i, length_vector;
+  length_vector := Length(vec);
+  return_list := [];
+  return_list[length_vector] := func(vec[length_vector]);
+  for i in [ 1 .. length_vector - 1 ] do
+    return_list[i] := func(vec[i]);
+  od;
+  return return_list;
+end );

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -490,3 +490,9 @@ InstallMethod( ListOp,
   od;
   return return_list;
 end );
+
+InstallMethod( Unpack,
+  "General method for a vector",
+  true,[IsVectorObj],0,
+  ListOp ); ## Potentially slower than a direct implemtation,
+            ## but avoids code multiplication.

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -527,3 +527,25 @@ InstallMethod( CopySubVector,
   function(src, dst, scols, dcols)
     CopySubVector(dst,dcols,src,scols);
 end );
+
+InstallMethod( Randomize,
+  "general method for vectors",
+  true, [ IsVectorObj and IsMutable ],0,
+  function(vec)
+    local basedomain, i;
+    basedomain := BaseDomain( vec );
+    for i in [ 1 .. Length( vec ) ] do
+        vec[ i ] := Random( basedomain );
+    od;
+end );
+
+InstallMethod( Randomize,
+  "general method for vectors",
+  true, [ IsVectorObj and IsMutable, IsRandomSource ],0,
+  function(vec, rs)
+    local basedomain, i;
+    basedomain := BaseDomain( vec );
+    for i in [ 1 .. Length( vec ) ] do
+        vec[ i ] := Random( rs, basedomain );
+    od;
+end );

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -391,7 +391,6 @@ DeclareOperation( "MultRowVector",
 ##    <Description>
 ##      Returns a new vector of length <A>l</A> in the same representation as <A>V</A> containing only
 ##      zeros.
-##      at the positions in <A>l</A>.
 ##    </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -434,6 +433,17 @@ DeclareOperation( "Vector", [IsList]);
 
 # given a vector <v>, produce a filter such that  NewVector called with this filter
 # will produce vectors in the same representation as <v>
+##  <#GAPDoc Label="MatObj_ConstructingFilter_Vector">
+##  <ManSection>
+##    <Func Arg="V" Name="ConstructingFilter" Label="for IsVectorObj"/>
+##    <Returns>a filter</Returns>
+##    <Description>
+##      Returns a filter <C>f</C> such that if <Ref Oper="NewVector"/> is
+##      called with <C>f</C> a vector in the same representation as <A>V</A>
+##      is produced.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "ConstructingFilter", [IsVectorObj] );
 
 DeclareConstructor( "NewVector", [IsVectorObj,IsSemiring,IsList] );

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -200,8 +200,8 @@ DeclareOperation( "PositionLastNonZero", [IsVectorObj] );
 ##    <Returns>A plain list</Returns>
 ##    <Description>
 ##     Applies <A>func</A> to each entry of the vector <A>V</A> and returns the results
-##     as a plain list. Necessary to call <Ref Func="List"/> on vectors.
-##     If the argument <A>func</A> is not provided, applies <Ref Func="IdFunc"> to all entries.
+##     as a plain list. Necessary to call <Ref Oper="List"/> on vectors.
+##     If the argument <A>func</A> is not provided, applies <Ref Func="IdFunc"/> to all entries.
 ##    </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -386,7 +386,7 @@ DeclareOperation( "MultRowVector",
 
 ##  <#GAPDoc Label="MatObj_ZeroVector">
 ##  <ManSection>
-##    <Func Arg="l,V" Name="ZeroVector" Label="for IsInt,IsVectorObj"/>
+##    <Oper Arg="l,V" Name="ZeroVector" Label="for IsInt,IsVectorObj"/>
 ##    <Returns>a vector object</Returns>
 ##    <Description>
 ##      Returns a new vector of length <A>l</A> in the same representation as <A>V</A> containing only
@@ -435,7 +435,7 @@ DeclareOperation( "Vector", [IsList]);
 # will produce vectors in the same representation as <v>
 ##  <#GAPDoc Label="MatObj_ConstructingFilter_Vector">
 ##  <ManSection>
-##    <Func Arg="V" Name="ConstructingFilter" Label="for IsVectorObj"/>
+##    <Oper Arg="V" Name="ConstructingFilter" Label="for IsVectorObj"/>
 ##    <Returns>a filter</Returns>
 ##    <Description>
 ##      Returns a filter <C>f</C> such that if <Ref Oper="NewVector"/> is
@@ -536,7 +536,7 @@ DeclareOperation( "CopySubVector",
 
 ##  <#GAPDoc Label="MatObj_WeightOfVector">
 ##  <ManSection>
-##    <Func Arg="V" Name="WeightOfVector" Label="for IsVectorObj"/>
+##    <Oper Arg="V" Name="WeightOfVector" Label="for IsVectorObj"/>
 ##    <Returns>an integer</Returns>
 ##    <Description>
 ##      Computes the Hamming weight of the vector <A>V</A>, i.e., the number of 
@@ -549,7 +549,7 @@ DeclareOperation( "WeightOfVector", [IsVectorObj] );
 
 ##  <#GAPDoc Label="MatObj_DistanceOfVectors">
 ##  <ManSection>
-##    <Func Arg="V1,V2" Name="DistanceOfVectors" Label="for IsVectorObj,IsVectorObj"/>
+##    <Oper Arg="V1,V2" Name="DistanceOfVectors" Label="for IsVectorObj,IsVectorObj"/>
 ##    <Returns>an integer</Returns>
 ##    <Description>
 ##      Computes the Hamming distance of the vectors <A>V1</A> and <A>V2</A>, i.e., the number of 

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -247,6 +247,18 @@ DeclareOperation( "Unpack", [IsVectorObj] );
 # Note that since Concatenation is a function using Append, it will
 # not work for vectors and it cannot be overloaded!
 # Thus we need:
+
+##  <#GAPDoc Label="MatObj_ConcatenationOfVectors">
+##  <ManSection>
+##    <Func Arg="V1,V2,..." Name="ConcatenationOfVectors" Label="for IsVectorObj"/>
+##    <Func Arg="Vlist" Name="ConcatenationOfVectors" Label="for list of IsVectorObj"/>
+##    <Returns>a vector object</Returns>
+##    <Description>
+##      Returns a new vector containing the entries of <A>V1</A>, <A>V2</A>, etc.
+##      As prototype <A>V1</A> is used.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareGlobalFunction( "ConcatenationOfVectors" );
 
 DeclareOperation( "ExtractSubVector", [IsVectorObj,IsList] );

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -384,6 +384,17 @@ DeclareOperation( "MultRowVector",
 # The "representation-preserving" contructor methods:
 ############################################################################
 
+##  <#GAPDoc Label="MatObj_ZeroVector">
+##  <ManSection>
+##    <Func Arg="l,V" Name="ZeroVector" Label="for IsInt,IsVectorObj"/>
+##    <Returns>a vector object</Returns>
+##    <Description>
+##      Returns a new vector of length <A>l</A> in the same representation as <A>V</A> containing only
+##      zeros.
+##      at the positions in <A>l</A>.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "ZeroVector", [IsInt,IsVectorObj] );
 # Returns a new mutable zero vector in the same rep as the given one with
 # a possible different length.

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -483,6 +483,18 @@ DeclareGlobalFunction( "MakeVector" );
 # Some things that fit nowhere else:
 ############################################################################
 
+##  <#GAPDoc Label="MatObj_Randomize_Vectors">
+##  <ManSection>
+##    <Oper Arg="V" Name="Randomize" Label="for IsVectorObj"/>
+##    <Oper Arg="V,Rs" Name="Randomize" Label="for IsVectorObj,IsRandomSources"/>
+##    <Description>
+##      Replaces every entry in <A>V</A> with a random one from the base domain.
+##      If given, the random source <A>Rs</A> is used to compute the random elements.
+##      Note that in this case, the random function for the base domain must support
+##      the random source argument.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "Randomize", [IsVectorObj and IsMutable] );
 DeclareOperation( "Randomize", [IsVectorObj and IsMutable,IsRandomSource] );
 # Changes the mutable argument in place, every entry is replaced

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -522,9 +522,17 @@ DeclareOperation( "CopySubVector",
 DeclareOperation( "CopySubVector", 
   [IsVectorObj,IsVectorObj and IsMutable, IsList,IsList] );
 
+##  <#GAPDoc Label="MatObj_WeightOfVector">
+##  <ManSection>
+##    <Func Arg="V" Name="WeightOfVector" Label="for IsVectorObj"/>
+##    <Returns>an integer</Returns>
+##    <Description>
+##      Computes the Hamming weight of the vector <A>V</A>, i.e., the number of 
+##      nonzero entries.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "WeightOfVector", [IsVectorObj] );
-# This computes the Hamming weight of a vector, i.e. the number of
-# nonzero entries.
 
 DeclareOperation( "DistanceOfVectors", [IsVectorObj, IsVectorObj] );
 # This computes the Hamming distance of two vectors, i.e. the number

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -534,10 +534,19 @@ DeclareOperation( "CopySubVector",
 ##  <#/GAPDoc>
 DeclareOperation( "WeightOfVector", [IsVectorObj] );
 
+
+##  <#GAPDoc Label="MatObj_DistanceOfVectors">
+##  <ManSection>
+##    <Func Arg="V1,V2" Name="DistanceOfVectors" Label="for IsVectorObj,IsVectorObj"/>
+##    <Returns>an integer</Returns>
+##    <Description>
+##      Computes the Hamming distance of the vectors <A>V1</A> and <A>V2</A>, i.e., the number of 
+##      entries in which the vectors differ. The vectors must be of equal length.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "DistanceOfVectors", [IsVectorObj, IsVectorObj] );
-# This computes the Hamming distance of two vectors, i.e. the number
-# of positions, in which the vectors differ. The vectors must have the
-# same length.
+
 
 
 ############################################################################

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -193,6 +193,18 @@ DeclareOperation( "PositionNonZero", [IsVectorObj] );
 ##  <#/GAPDoc>
 DeclareOperation( "PositionLastNonZero", [IsVectorObj] );
 
+##  <#GAPDoc Label="MatObj_ListOp">
+##  <ManSection>
+##    <Oper Arg="V" Name="ListOp" Label="for IsVectorObj"/>
+##    <Oper Arg="V,func" Name="ListOp" Label="for IsVectorObj,IsFunction"/>
+##    <Returns>A plain list</Returns>
+##    <Description>
+##     Applies <A>func</A> to each entry of the vector <A>V</A> and returns the results
+##     as a plain list. Necessary to call <Ref Func="List"/> on vectors.
+##     If the argument <A>func</A> is not provided, applies <Ref Func="IdFunc"> to all entries.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "ListOp", [IsVectorObj] );
 DeclareOperation( "ListOp", [IsVectorObj,IsFunction] );
 # This is an unpacking operation returning a mutable copy in form of a list.

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -498,12 +498,7 @@ DeclareOperation( "Randomize", [IsVectorObj and IsMutable,IsRandomSource] );
 ##
 ##  <#GAPDoc Label="CopySubVector">
 ##  <ManSection>
-##  <Oper Name="CopySubVector" Arg='src, dst, scols, dcols'/>
-## TODO: turn this into
 ##  <Oper Name="CopySubVector" Arg='dst, dcols, src, scols'/>
-## and provide an (undocumnented) method for backwards compatibility
-##  which converts from the old to the new convention (and remove that again the future???)
-##
 ##  <Description>
 ##  returns nothing. Does <C><A>dst</A>{<A>dcols</A>} := <A>src</A>{<A>scols</A>}</C>
 ##  without creating an intermediate object and thus - at least in
@@ -521,6 +516,9 @@ DeclareOperation( "Randomize", [IsVectorObj and IsMutable,IsRandomSource] );
 ##
 ## TODO: Maybe also have a version of this as follows:
 ##    CopySubVector( dst, dst_from, dst_to,  src, src_form, src_to );
+DeclareOperation( "CopySubVector", 
+  [IsVectorObj and IsMutable, IsList, IsVectorObj, IsList] );
+## TODO: the following declaration is deprecated and only kept for compatibility
 DeclareOperation( "CopySubVector", 
   [IsVectorObj,IsVectorObj and IsMutable, IsList,IsList] );
 

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -167,6 +167,17 @@ DeclareOperation( "{}", [IsVectorObj,IsList] );
 # Of course the positions must all lie in [1..Length(VECTOR)].
 # Returns a vector in the same representation!
 
+##  <#GAPDoc Label="MatObj_PositionNonZero">
+##  <ManSection>
+##    <Oper Arg="V" Name="PositionNonZero"/>
+##    <Returns>An integer or <C>fail</C></Returns>
+##    <Description>
+##     Returns the index of the first entry of the vector <A>V</A> which is not
+##     zero. If all entries are zero, the function
+##     returns <C>Length</C>(<A>V</A>) + 1.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "PositionNonZero", [IsVectorObj] );
 
 DeclareOperation( "PositionLastNonZero", [IsVectorObj] );

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -210,7 +210,17 @@ DeclareOperation( "ListOp", [IsVectorObj,IsFunction] );
 # This is an unpacking operation returning a mutable copy in form of a list.
 # It enables the "List" function to work.
 
-# The following unwraps a vector to a list:
+##  <#GAPDoc Label="MatObj_UnpackVector">
+##  <ManSection>
+##    <Oper Arg="V" Name="Unpack" Label="for IsVectorObj"/>
+##    <Returns>A plain list</Returns>
+##    <Description>
+##      Returns a new plain list containing the entries of <A>V</A>.
+##      Guarantees to return a new list which can be manipulated without
+##      changing <A>V</A>. The entries itself are not copied.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "Unpack", [IsVectorObj] ); 
 # It guarantees to copy, that is changing the returned object does
 # not change the original object.

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -261,6 +261,16 @@ DeclareOperation( "Unpack", [IsVectorObj] );
 ##  <#/GAPDoc>
 DeclareGlobalFunction( "ConcatenationOfVectors" );
 
+##  <#GAPDoc Label="MatObj_ExtractSubVector">
+##  <ManSection>
+##    <Func Arg="V,l" Name="ExtractSubVector" Label="for IsVectorObj,IsList"/>
+##    <Returns>a vector object</Returns>
+##    <Description>
+##      Returns a new vector containing the entries of <A>V</A>
+##      at the positions in <A>l</A>.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "ExtractSubVector", [IsVectorObj,IsList] );
 # Does the same as slicing v{l} but is here to be similar to
 # ExtractSubMatrix.

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -170,9 +170,9 @@ DeclareOperation( "{}", [IsVectorObj,IsList] );
 ##  <#GAPDoc Label="MatObj_PositionNonZero">
 ##  <ManSection>
 ##    <Oper Arg="V" Name="PositionNonZero"/>
-##    <Returns>An integer or <C>fail</C></Returns>
+##    <Returns>An integer</Returns>
 ##    <Description>
-##     Returns the index of the first entry of the vector <A>V</A> which is not
+##     Returns the index of the first entry in the vector <A>V</A> which is not
 ##     zero. If all entries are zero, the function
 ##     returns <C>Length</C>(<A>V</A>) + 1.
 ##    </Description>
@@ -180,6 +180,17 @@ DeclareOperation( "{}", [IsVectorObj,IsList] );
 ##  <#/GAPDoc>
 DeclareOperation( "PositionNonZero", [IsVectorObj] );
 
+##  <#GAPDoc Label="MatObj_PositionLastNonZero">
+##  <ManSection>
+##    <Oper Arg="V" Name="PositionLastNonZero"/>
+##    <Returns>An integer</Returns>
+##    <Description>
+##     Returns the index of the last entry in the vector <A>V</A> which is not
+##     zero. If all entries are zero, the function
+##     returns 0.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "PositionLastNonZero", [IsVectorObj] );
 
 DeclareOperation( "ListOp", [IsVectorObj] );

--- a/tst/test-matobj.g
+++ b/tst/test-matobj.g
@@ -1,0 +1,3 @@
+TestDirectory( [ DirectoriesLibrary( "tst/test-matobj" ) ],
+               rec(exitGAP := true, testOptions := rec( compareFunction := "uptowhitespace" ) ) );
+

--- a/tst/test-matobj/ConcatenationOfVectors.tst
+++ b/tst/test-matobj/ConcatenationOfVectors.tst
@@ -1,4 +1,4 @@
-START_TEST("ConcatenationOfVectors.tst");
+gap> START_TEST("ConcatenationOfVectors.tst");
 gap> l1 := [1,2,3,4,5,6];
 [ 1, 2, 3, 4, 5, 6 ]
 gap> l2 := [6,2,7,4,5,6];
@@ -19,4 +19,4 @@ gap> vv := ConcatenationOfVectors( [ v3, v4, v3 ] );
 < mutable compressed vector length 18 over GF(5) >
 gap> Unpack( vv );
 [ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5)^2, 0*Z(5), Z(5)^0, Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
-END_TEST("ConcatenationOfVectors.tst",1);
+gap> END_TEST("ConcatenationOfVectors.tst",1);

--- a/tst/test-matobj/ConcatenationOfVectors.tst
+++ b/tst/test-matobj/ConcatenationOfVectors.tst
@@ -19,4 +19,4 @@ gap> vv := ConcatenationOfVectors( [ v3, v4, v3 ] );
 < mutable compressed vector length 18 over GF(5) >
 gap> Unpack( vv );
 [ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5)^2, 0*Z(5), Z(5)^0, Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
-gap> END_TEST("ConcatenationOfVectors.tst",1);
+gap> STOP_TEST("ConcatenationOfVectors.tst",1);

--- a/tst/test-matobj/ConcatenationOfVectors.tst
+++ b/tst/test-matobj/ConcatenationOfVectors.tst
@@ -1,0 +1,22 @@
+START_TEST("ConcatenationOfVectors.tst");
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> l2 := [6,2,7,4,5,6];
+[ 6, 2, 7, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> v2 := Vector(IsPlistVectorRep, Rationals, l2);
+<plist vector over Rationals of length 6>
+gap> vv := ConcatenationOfVectors( v1, v2, v2 );
+<plist vector over Rationals of length 18>
+gap> Unpack( vv );
+[ 1, 2, 3, 4, 5, 6, 6, 2, 7, 4, 5, 6, 6, 2, 7, 4, 5, 6 ]
+gap> v3 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> v4 := Vector(GF(5), l2*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5), Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> vv := ConcatenationOfVectors( [ v3, v4, v3 ] );
+< mutable compressed vector length 18 over GF(5) >
+gap> Unpack( vv );
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5)^2, 0*Z(5), Z(5)^0, Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+END_TEST("ConcatenationOfVectors.tst",1);

--- a/tst/test-matobj/CopySubVector.tst
+++ b/tst/test-matobj/CopySubVector.tst
@@ -1,0 +1,20 @@
+gap> START_TEST("CopySubVector.tst");
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> l2 := [1,1,1,2,2,2,3,3,3];
+[ 1, 1, 1, 2, 2, 2, 3, 3, 3 ]
+gap> v2 := Vector(IsPlistVectorRep, Rationals, l2);
+<plist vector over Rationals of length 9>
+gap> CopySubVector( v1, [2,4,6], v2, [1,2,4] );
+gap> Unpack(v1);
+[ 1, 1, 3, 1, 5, 2 ]
+gap> v3 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> v4 := Vector(GF(5), l2*One(GF(5)));
+[ Z(5)^0, Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5), Z(5)^3, Z(5)^3, Z(5)^3 ]
+gap> CopySubVector( v4, [2,4,6], v3, [1,2,3] );
+gap> v4;
+[ Z(5)^0, Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5)^3, Z(5)^3, Z(5)^3, Z(5)^3 ]
+gap> STOP_TEST("CopySubVector.tst",1);

--- a/tst/test-matobj/DistanceOfVectors.tst
+++ b/tst/test-matobj/DistanceOfVectors.tst
@@ -1,0 +1,32 @@
+gap> START_TEST( "DistanceOfVectors.tst" );
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> l2 := [0,2,3,0,5,6];
+[ 0, 2, 3, 0, 5, 6 ]
+gap> v2 := Vector(IsPlistVectorRep, Rationals, l2);
+<plist vector over Rationals of length 6>
+gap> l3 := [0,0,0,0,0,0];
+[ 0, 0, 0, 0, 0, 0 ]
+gap> v3 := Vector(IsPlistVectorRep, Rationals, l3);
+<plist vector over Rationals of length 6>
+gap> DistanceOfVectors( v1, v2 );
+2
+gap> DistanceOfVectors( v2, v3 );
+4
+gap> DistanceOfVectors( v1, v3 );
+6
+gap> v4 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> v5 := Vector(GF(5), l2*One(GF(5)));
+[ 0*Z(5), Z(5), Z(5)^3, 0*Z(5), 0*Z(5), Z(5)^0 ]
+gap> v6 := Vector(GF(5), l3*One(GF(5)));
+[ 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5) ]
+gap> DistanceOfVectors( v4, v5 );
+2
+gap> DistanceOfVectors( v5, v6 );
+3
+gap> DistanceOfVectors( v4, v6 );
+5
+gap> STOP_TEST( "DistanceOfVectors.tst", 1);

--- a/tst/test-matobj/ExtractSubvector.tst
+++ b/tst/test-matobj/ExtractSubvector.tst
@@ -11,4 +11,4 @@ gap> ExtractSubVector( v1, [1,2,4] );
 <plist vector over Rationals of length 3>
 gap> Unpack( last );
 [ 1, 2, 4 ]
-gap> END_TEST("ExtractSubVector.tst",1);
+gap> STOP_TEST("ExtractSubVector.tst",1);

--- a/tst/test-matobj/ExtractSubvector.tst
+++ b/tst/test-matobj/ExtractSubvector.tst
@@ -1,0 +1,14 @@
+gap> START_TEST("ExtractSubVector.tst");
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v3 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> ExtractSubVector( v3, [1,2,4] );
+[ Z(5)^0, Z(5), Z(5)^2 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> ExtractSubVector( v1, [1,2,4] );
+<plist vector over Rationals of length 3>
+gap> Unpack( last );
+[ 1, 2, 4 ]
+gap> END_TEST("ExtractSubVector.tst",1);

--- a/tst/test-matobj/ListOp.tst
+++ b/tst/test-matobj/ListOp.tst
@@ -1,0 +1,14 @@
+gap> START_TEST("ListOp.tst");
+gap> ll := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, ll);
+<plist vector over Rationals of length 6>
+gap> List( v1 );
+[ 1, 2, 3, 4, 5, 6 ]
+gap> List( v1, x->x^2 );
+[ 1, 4, 9, 16, 25, 36 ]
+gap> v5 := Vector(GF(5), ll*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> List( v5, x->x^2 );
+[ Z(5)^0, Z(5)^2, Z(5)^2, Z(5)^0, 0*Z(5), Z(5)^0 ]
+gap> STOP_TEST( "ListOp.tst", 1);

--- a/tst/test-matobj/PositionNonZero.tst
+++ b/tst/test-matobj/PositionNonZero.tst
@@ -1,0 +1,32 @@
+gap> START_TEST( "PositionNonZero.tst" );
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> PositionNonZero( v1 );
+1
+gap> l2 := [0,2,3,0,5,6];
+[ 0, 2, 3, 0, 5, 6 ]
+gap> v2 := Vector(IsPlistVectorRep, Rationals, l2);
+<plist vector over Rationals of length 6>
+gap> PositionNonZero( v2 );
+2
+gap> l3 := [0,0,0,0,0,0];
+[ 0, 0, 0, 0, 0, 0 ]
+gap> v3 := Vector(IsPlistVectorRep, Rationals, l3);
+<plist vector over Rationals of length 6>
+gap> PositionNonZero( v3 );
+7
+gap> v4 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> PositionNonZero( v4 );
+1
+gap> v5 := Vector(GF(5), l2*One(GF(5)));
+[ 0*Z(5), Z(5), Z(5)^3, 0*Z(5), 0*Z(5), Z(5)^0 ]
+gap> PositionNonZero( v5 );
+2
+gap> v6 := Vector(GF(5), l3*One(GF(5)));
+[ 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5) ]
+gap> PositionNonZero( v6 );
+7
+gap> STOP_TEST( "PositionNonZero.tst", 1);

--- a/tst/test-matobj/Randomize.tst
+++ b/tst/test-matobj/Randomize.tst
@@ -1,0 +1,25 @@
+gap> START_TEST("Randomize.tst");
+gap> Reset( GlobalMerseeneTwister, 0 );
+Error, Variable: 'GlobalMerseeneTwister' must have a value
+not in any function at *stdin*:2
+gap> ll := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, ll);
+<plist vector over Rationals of length 6>
+gap> Randomize( v1 );
+gap> Unpack( v1 );
+[ -2/3, 2, 1, -4, 0, 1 ]
+gap> Randomize( v1 );
+gap> Unpack( v1 );
+[ -1, -1, 1/2, 0, -2, 1/2 ]
+gap> v2 := Vector(GF(5), ll*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> Randomize( v2 );
+[ 0*Z(5), Z(5)^2, Z(5)^0, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> v2;
+[ 0*Z(5), Z(5)^2, Z(5)^0, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> Randomize( v2 );
+[ Z(5), Z(5)^0, 0*Z(5), Z(5)^3, Z(5)^3, Z(5)^3 ]
+gap> v2;
+[ Z(5), Z(5)^0, 0*Z(5), Z(5)^3, Z(5)^3, Z(5)^3 ]
+gap> STOP_TEST( "Randomize.tst", 1);

--- a/tst/test-matobj/Randomize.tst
+++ b/tst/test-matobj/Randomize.tst
@@ -1,7 +1,4 @@
 gap> START_TEST("Randomize.tst");
-gap> Reset( GlobalMerseeneTwister, 0 );
-Error, Variable: 'GlobalMerseeneTwister' must have a value
-not in any function at *stdin*:2
 gap> ll := [1,2,3,4,5,6];
 [ 1, 2, 3, 4, 5, 6 ]
 gap> v1 := Vector(IsPlistVectorRep, Rationals, ll);

--- a/tst/test-matobj/TraceMat.tst
+++ b/tst/test-matobj/TraceMat.tst
@@ -1,0 +1,16 @@
+gap> START_TEST( "TraceMat.tst" );
+gap> l := [[1,2],[3,4]];
+[ [ 1, 2 ], [ 3, 4 ] ]
+gap> m1 := Matrix(l);
+<2x2-matrix over Rationals>
+gap> m2 := Matrix(Integers,l);
+<2x2-matrix over Integers>
+gap> m3 := Matrix(GF(7),l*One(GF(7)));
+[ [ Z(7)^0, Z(7)^2 ], [ Z(7), Z(7)^4 ] ]
+gap> TraceMat( m1 );
+5
+gap> TraceMat( m2 );
+5
+gap> TraceMat( m3 );
+Z(7)^5
+gap> STOP_TEST( "TraceMat.tst", 1);

--- a/tst/test-matobj/Unpack.tst
+++ b/tst/test-matobj/Unpack.tst
@@ -1,0 +1,12 @@
+gap> START_TEST("Unpack.tst");
+gap> ll := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, ll);
+<plist vector over Rationals of length 6>
+gap> Unpack( v1 );
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v5 := Vector(GF(5), ll*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> Unpack( v5 );
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> STOP_TEST( "Unpack.tst", 1);

--- a/tst/test-matobj/WeightOfVector.tst
+++ b/tst/test-matobj/WeightOfVector.tst
@@ -1,0 +1,32 @@
+gap> START_TEST( "WeightOfVector.tst" );
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> WeightOfVector( v1 );
+6
+gap> l2 := [0,2,3,0,5,6];
+[ 0, 2, 3, 0, 5, 6 ]
+gap> v2 := Vector(IsPlistVectorRep, Rationals, l2);
+<plist vector over Rationals of length 6>
+gap> WeightOfVector( v2 );
+4
+gap> l3 := [0,0,0,0,0,0];
+[ 0, 0, 0, 0, 0, 0 ]
+gap> v3 := Vector(IsPlistVectorRep, Rationals, l3);
+<plist vector over Rationals of length 6> 
+gap> WeightOfVector( v3 );
+0 
+gap> v4 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> WeightOfVector( v4 );
+5 
+gap> v5 := Vector(GF(5), l2*One(GF(5)));
+[ 0*Z(5), Z(5), Z(5)^3, 0*Z(5), 0*Z(5), Z(5)^0 ]
+gap> WeightOfVector( v5 );
+3 
+gap> v6 := Vector(GF(5), l3*One(GF(5)));
+[ 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5) ]
+gap> WeightOfVector( v6 );
+0
+gap> STOP_TEST( "WeightOfVector.tst", 1);

--- a/tst/test-matobj/ZeroVector.tst
+++ b/tst/test-matobj/ZeroVector.tst
@@ -1,0 +1,16 @@
+gap> START_TEST("ZeroVector.tst");
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> v0 := ZeroVector( 15, v1 );
+<plist vector over Rationals of length 15>
+gap> Unpack( v0 );
+[ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+gap> v3 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> v0 := ZeroVector( 12, v3 );
+< mutable compressed vector length 12 over GF(5) >
+gap> Unpack( v0 );
+[ 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5) ]
+gap> STOP_TEST("ZeroVector.tst",1);


### PR DESCRIPTION
In this PR are accumulated documentation, tests, and generic methods (if not there already) for the following operations for `IsVectorObj` and `IsMatrixObj`:

* PositionNonZero
* PositionLastNonZero
* ListOp
* UnpackVector
* ConcatenationOfVectors
* ExtractSubVector
* ZeroVector
* ConstructingFilter
* Randomize
* WeightOfVector
* DistanceOfVectors

I also put a file `test-matobj.g` in the `tst` folder to start the new matrix object tests.