### PR TITLE
RunTests: show even more information

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -87,7 +87,7 @@ InstallGlobalFunction(ParseTestFile, function(arg)
 end);
 
 InstallGlobalFunction(RunTests, function(arg)
-  local tests, opts, breakOnError, inp, outp, pos, cmp, times, ttime, 
+  local tests, opts, breakOnError, inp, outp, pos, cmp, times, ttime, nrlines,
         s, res, fres, t, f, i;
   # don't enter break loop in case of error during test
   tests := arg[1];
@@ -108,11 +108,15 @@ InstallGlobalFunction(RunTests, function(arg)
   cmp := [];
   times := [];
   ttime := Runtime();
+  nrlines := pos[Length(pos) - 1];
   for i in [1..Length(inp)] do
     if opts.showProgress = true then
       Print("# line ", pos[i], ", input:\n",inp[i]);
     elif opts.showProgress = "some" then
-      Print("\r# line ", pos[i], "\c");
+      Print("\r# line ", pos[i],
+            " of ", nrlines,
+            " (", Int(Round(Float(pos[i] / nrlines * 100))), "%)",
+            "\c");
     fi;
     s := InputTextString(inp[i]);
     res := "";

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -97,8 +97,6 @@ InstallGlobalFunction(RunTests, function(arg)
       opts.(f) := arg[2].(f);
     od;
   fi;
-  breakOnError := BreakOnError;
-  BreakOnError := opts.breakOnError;
 
   # we collect outputs and add them as 4th entry to 'tests'
   # also collect timings and add them as 5th entry to 'tests'
@@ -107,6 +105,16 @@ InstallGlobalFunction(RunTests, function(arg)
   pos := tests[3];
   cmp := [];
   times := [];
+  tests[4] := cmp;
+  tests[5] := times;
+
+  if Length(inp) = 0 then
+    return;
+  fi;
+
+  breakOnError := BreakOnError;
+  BreakOnError := opts.breakOnError;
+
   ttime := Runtime();
   nrlines := pos[Length(pos) - 1];
   for i in [1..Length(inp)] do
@@ -135,8 +143,6 @@ InstallGlobalFunction(RunTests, function(arg)
   fi;
   # add total time to 'times'
   Add(times, Runtime() - ttime);
-  tests[4] := cmp;
-  tests[5] := times;
   # reset
   BreakOnError := breakOnError;
 end);


### PR DESCRIPTION
I was delighted to see the recent change in `RunTests`, which defaults to `showProgress := "some"` and therefore displays which line we are on.

This PR adds to that message the total number of lines in the file and the progress as a percentage of the file.  That is, for `showProgress := "some"`, it changes the output from 
```
# line 530
```
to
```
# line 530 of 1668 (32%)
```
You can try it by running `Test(...)` with any test file in the GAP directory.

I really just made this change for my own use, but it occurred to me that others might find it useful.  Please feel free to close this PR if this isn't actually the sort of thing we want to include - I can understand if we want the output to stay simple.