### PR TITLE
kernel: fix compiler warnings

### DIFF
--- a/src/gasman.h
+++ b/src/gasman.h
@@ -101,7 +101,7 @@ typedef struct {
 **
 **  'BAG_HEADER' returns the header of the bag with the identifier <bag>.
 */
-static inline BagHeader * BAG_HEADER(Bag bag) {
+inline BagHeader * BAG_HEADER(Bag bag) {
     return (((BagHeader *)*bag) - 1);
 }
 


### PR DESCRIPTION
The static inline function `BAG_HEADER` is used in the macro `LINK_BAG`,
which is used in the macro `IS_MARKED_DEAD`, which is used in the
inline function `MarkBag` which is declared extern in the header.
This produces a compiler warning, which this PR removes.

The compiler warnings are:

    src/gasman.c:645:14: warning: static function 'BAG_HEADER' is used in an inline
          function with external linkage [-Wstatic-in-inline]
             && (IS_MARKED_DEAD(bag) || IS_MARKED_HALFDEAD(bag)) )
                 ^
    src/gasman.c:564:31: note: expanded from macro 'IS_MARKED_DEAD'
    #define IS_MARKED_DEAD(bag) ((LINK_BAG(bag)) == MARKED_DEAD(bag))
                                  ^
    ./src/gasman.h:234:26: note: expanded from macro 'LINK_BAG'
    #define LINK_BAG(bag)   (BAG_HEADER(bag)->link)
                             ^
    ./src/gasman.h:104:27: note: 'BAG_HEADER' declared here
    static inline BagHeader * BAG_HEADER(Bag bag) {
                              ^
    src/gasman.c:645:37: warning: static function 'BAG_HEADER' is used in an inline
          function with external linkage [-Wstatic-in-inline]
             && (IS_MARKED_DEAD(bag) || IS_MARKED_HALFDEAD(bag)) )
                                        ^
    src/gasman.c:565:35: note: expanded from macro 'IS_MARKED_HALFDEAD'
    #define IS_MARKED_HALFDEAD(bag) ((LINK_BAG(bag)) == MARKED_HALFDEAD(bag))
                                      ^
    ./src/gasman.h:234:26: note: expanded from macro 'LINK_BAG'
    #define LINK_BAG(bag)   (BAG_HEADER(bag)->link)
                             ^
    ./src/gasman.h:104:27: note: 'BAG_HEADER' declared here
    static inline BagHeader * BAG_HEADER(Bag bag) {
                              ^
    src/gasman.c:647:9: warning: static function 'BAG_HEADER' is used in an inline
          function with external linkage [-Wstatic-in-inline]
            LINK_BAG(bag) = MarkedBags;
            ^
    ./src/gasman.h:234:26: note: expanded from macro 'LINK_BAG'
    #define LINK_BAG(bag)   (BAG_HEADER(bag)->link)
                             ^
    ./src/gasman.h:104:27: note: 'BAG_HEADER' declared here
    static inline BagHeader * BAG_HEADER(Bag bag) {
