### PR TITLE
kernel: avoid using flexible array in gasman.h

### DIFF
--- a/src/gasman.h
+++ b/src/gasman.h
@@ -91,7 +91,6 @@ typedef struct {
     uint32_t size : 32;
 #endif
     Bag link;
-    Bag data[];
 } BagHeader;
 
 

--- a/src/hpc/boehm_gc.h
+++ b/src/hpc/boehm_gc.h
@@ -465,7 +465,7 @@ Bag NewBag (
     header->link = bag;
 
     /* set the masterpointer                                               */
-    PTR_BAG(bag) = header->data;
+    PTR_BAG(bag) = DATA(header);
     switch (DSInfoBags[type]) {
     case DSI_TL:
       REGION(bag) = CurrentRegion();
@@ -552,12 +552,12 @@ UInt ResizeBag (
 
         /* set the masterpointer                                           */
         src = PTR_BAG(bag);
-        PTR_BAG(bag) = header->data;
+        PTR_BAG(bag) = DATA(header);
 
-        if (header->data != src) {
-            memcpy( header->data, src, old_size < new_size ? old_size : new_size );
+        if (DATA(header) != src) {
+            memcpy( DATA(header), src, old_size < new_size ? old_size : new_size );
         } else if (new_size < old_size) {
-            memset(header->data+new_size, 0, old_size - new_size);
+            memset(DATA(header)+new_size, 0, old_size - new_size);
         }
     }
     /* return success                                                      */


### PR DESCRIPTION
This is a C99 feature, but unfortunately not supported by C++. This creates
an unfortunate hurdle for kernel extensions written in C++.
This PR gets rid of this, replacing it with an accessor function used
inside gasman.c.

Fixes #1387 

@james-d-mitchell please check whether that really resolves the warning for you