### PR TITLE
Fix MatrixObj branch build failures on HPC-GAP

### DIFF
--- a/hpcgap/lib/list.gd
+++ b/hpcgap/lib/list.gd
@@ -1398,6 +1398,31 @@ DeclareOperation( "DifferenceLists", [IsList, IsList] );
 ##
 DeclareOperation( "Flat", [ IsList ] );
 
+#############################################################################
+##
+#O  FoldList( <list>, <len> )  . . . . fold list to sublists of length len
+##
+##  <#GAPDoc Label="FoldList">
+##  <ManSection>
+##  <Oper Name="FoldList" Arg='list, len'/>
+##
+##  <Description>
+##  returns a list of sublists of <A>list</A> of length <A>len</A>. 
+##  More precisely, the i-th sublist in the result is
+##  <A>list</A><C>{[(i-1)<A>len</A>+1..i <A>len</A>]}</C>.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> fl := FoldList([1,2,3,4,5,6], 3);
+##  [ [ 1, 2, 3 ], [ 4, 5, 6 ] ]
+##  gap> Flat(fl);
+##  [ 1, 2, 3, 4, 5, 6 ]
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation( "FoldList", [ IsList, IS_INT ] );
+
 
 #############################################################################
 ##

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2383,10 +2383,10 @@ BindGlobal( "PositionLastNonZeroFunc2",
 
 InstallMethod( PositionLastNonZero, "for a row vector obj",
   [IsVectorObj], PositionLastNonZeroFunc );
-InstallMethod( PositionLastNonZero, "for a matrix obj",
-  [IsMatrixObj], PositionLastNonZeroFunc );
-InstallMethod( PositionLastNonZero, "for a matrix obj, and an index",
-  [IsMatrixObj, IsPosInt], PositionLastNonZeroFunc2 );
+# InstallMethod( PositionLastNonZero, "for a matrix obj",
+#   [IsMatrixObj], PositionLastNonZeroFunc );
+# InstallMethod( PositionLastNonZero, "for a matrix obj, and an index",
+#   [IsMatrixObj, IsPosInt], PositionLastNonZeroFunc2 );
         
 InstallMethod( ExtractSubMatrix, "for a gf2 matrix, and two lists",
   [IsGF2MatrixRep, IsList, IsList],


### PR DESCRIPTION
This should hopefully resolve the build failures on HPC-GAP.

I'd also like to use this opportunity that I am unhappy about the name `FoldList`. The term "list folding" has a well-established meaning in functional programming that is incompatible with this.