### PR TITLE
Remove double man section.

### DIFF
--- a/doc/ref/groups.xml
+++ b/doc/ref/groups.xml
@@ -474,7 +474,6 @@ the series without destroying the properties of the series.
 <#Include Label="MinimalSupergroupsLattice">
 <#Include Label="LowLayerSubgroups">
 <#Include Label="ContainedConjugates">
-<#Include Label="ContainedConjugates">
 <#Include Label="ContainingConjugates">
 <#Include Label="RepresentativesPerfectSubgroups">
 <#Include Label="ConjugacyClassesPerfectSubgroups">


### PR DESCRIPTION
The man section for 'ContainedConjugates' was include twice.