### PR TITLE
Fix two issues in FuncSTRONGLY_CONNECTED_COMPONENTS_DIGRAPH

### DIFF
--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1502,7 +1502,7 @@ static Obj FuncSTRONGLY_CONNECTED_COMPONENTS_DIGRAPH(Obj self, Obj digraph)
                     i = l;
                     do {
                       x = INT_INTOBJ(ELM_PLIST(stack, i));
-                      SET_ELM_PLIST(val, x, INTOBJ_INT(n+1));
+                      ((UInt *)ADDR_OBJ(val))[x] = n+1;
                       i--;
                     } while (x != fptr[0]);
                     comp = NEW_PLIST(T_PLIST_CYC, l-i);


### PR DESCRIPTION
This fixes a line of code in a way that makes no different, but stops us
misusing functions in confusing ways.

SET_PLIST_ELM is equivalent to setting ((UInt *)ADDR_OBJ(val))[x], but
we should not be using PLIST functions on a DATOBJ, as the new kernel
debugging rejects it.

Also this line should not use INTOBJ_INT, as 'val' contains normal
C ints. However, all this particular int is used for it to denote a value
larger than n, and INTOBJ_INT(n+1) is 4*(n+1)+1, so the code still
worked fine.