### PR TITLE
Initialize the HPCGAP global variable in the kernel

### DIFF
--- a/hpcgap/lib/hpc/thread1.g
+++ b/hpcgap/lib/hpc/thread1.g
@@ -10,10 +10,6 @@
 ##  early in GAP's initialization process. The rest can be found in thread.g.
 ##
 
-# Global variable to show that we're using HPCGAP.
-
-BIND_GLOBAL("HPCGAP", true);
-
 
 # Convenience aliases
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -3241,6 +3241,12 @@ static Int InitLibrary (
     /* create windows command buffer                                       */
     WindowCmdString = NEW_STRING( 1000 );
 
+#ifdef HPCGAP
+    UInt var = GVarName( "HPCGAP" );
+    AssGVar( var, True );
+    MakeReadOnlyGVar( var );
+#endif
+
     /* return success                                                      */
     return PostRestore( module );
 }


### PR DESCRIPTION
This way, it is set much earlier, and also be used in e.g. init.g