### PR TITLE
Improving HPCGAP thread testing

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -427,6 +427,17 @@ In the read-eval-print loop,
 </Description>
 </ManSection>
 
+<ManSection>
+<Func Name="Sleep" Arg='time'/>
+<Func Name="NanoSleep" Arg='time'/>
+
+<Description>
+These functions make GAP stop execution for a given period of time. The time
+to stop is given to <Ref Func="Sleep"/> in seconds and <Ref Func="NanoSleep"/>
+in nanoseconds.
+</Description>
+</ManSection>
+
 </Section>
 
 

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -37,9 +37,17 @@ echo 'Print("GAP started successfully\n");QUIT_GAP(0);' | ./gap -q -T
 # connection is refused, to work around intermittent failures
 make bootstrap-pkg-full WGET="wget -N --no-check-certificate --tries=5 --waitretry=5 --retry-connrefused"
 
+# TEMPORARY FIX : factint is not HPC-GAP compatible
+if [[ $HPCGAP = yes ]]
+then
+    rm -rf pkg/factint*
+fi;
+
+
 # packages must be placed inside SRCDIR, as only that
 # is a GAP root, while BUILDDIR is not.
 if [[ ! -d "$SRCDIR/pkg" ]]
 then
   mv pkg "$SRCDIR/"
 fi
+

--- a/lib/hpc/tasks.g
+++ b/lib/hpc/tasks.g
@@ -1,0 +1,25 @@
+#############################################################################
+##
+#W  tasks.g                       GAP library                 Chris Jefferson
+##
+##
+##  This file provides trivial mocks of task-related primitives for
+##  traditional GAP.
+##
+##  The major design decision here it to make these mocks fast and simple,
+##  rather than try to make them as accurate as possible.
+##
+
+RunTask := function(func, args...)
+    local result;
+    result := CallFuncListWrap(func, args);
+    if result = [] then
+        return rec(taskresult := fail);
+    else
+        return rec(taskresult := result[1]);
+    fi;
+end;
+
+TaskResult := function(task)
+    return task.taskresult;
+end;

--- a/lib/read1.g
+++ b/lib/read1.g
@@ -88,3 +88,5 @@ ReadLib( "macfloat.g"  );
 
 ReadLib( "error.g"   );
 ReadLib( "session.g" );
+
+ReadLib( "hpc/tasks.g" );

--- a/src/gap.c
+++ b/src/gap.c
@@ -2694,8 +2694,6 @@ Obj FuncSleep( Obj self, Obj secs )
 }
 
 
-#ifdef HPCGAP
-
 /****************************************************************************
 **
 *F  FuncMicroSleep( <self>, <secs> )
@@ -2716,7 +2714,11 @@ Obj FuncMicroSleep( Obj self, Obj msecs )
     SyUSleep((UInt)s);
   
   /* either we used up the time, or we were interrupted. */
+#ifdef HPCGAP
   if (HaveInterrupt())
+#else
+  if (SyIsIntr())
+#endif
     {
       ClearError(); /* The interrupt may still be pending */
       ErrorReturnVoid("user interrupt in microsleep", 0L, 0L,
@@ -2725,8 +2727,6 @@ Obj FuncMicroSleep( Obj self, Obj msecs )
   
   return (Obj) 0;
 }
-
-#endif
 
 
 // Common code in the next 3 methods.
@@ -3080,10 +3080,8 @@ static StructGVarFunc GVarFuncs [] = {
     { "WindowCmd", 1, "arg-list",
       FuncWindowCmd, "src/gap.c:WindowCmd" },
 
-#ifdef HPCGAP
     { "MicroSleep", 1, "msecs",
       FuncMicroSleep, "src/gap.c:MicroSleep" },
-#endif
 
     { "Sleep", 1, "secs",
       FuncSleep, "src/gap.c:Sleep" },

--- a/tst/testinstall/hpc/task.tst
+++ b/tst/testinstall/hpc/task.tst
@@ -1,11 +1,11 @@
 #############################################################################
 ##
-#W  access.tst                 GAP tests                   Alexander Konovalov
+#W  task.tst                 GAP tests                   Alexander Konovalov
 ##
 ##
 #Y  Copyright (C)  2012
 ##
-gap> START_TEST("access.tst");
+gap> START_TEST("task.tst");
 gap> CallAsTask := function(arg)
 > return TaskResult( RunTask( CallFuncList, arg[1], arg{[2..Length(arg)]} ) );
 > end;;
@@ -75,7 +75,7 @@ rec( B := [  ], basis := [  ], mue := [  ] )
 gap> CallAsTask(LLLReducedBasis,[ [ 0, 0 ], [ 0, 0 ] ], "linearcomb" );
 rec( B := [  ], basis := [  ], mue := [  ], 
   relations := [ [ 1, 0 ], [ 0, 1 ] ], transformation := [  ] )
-gap> STOP_TEST( "access.tst", 1 );
+gap> STOP_TEST( "task.tst", 1 );
 #############################################################################
 ##
 #E

--- a/tst/testinstall/hpc/threads.tst
+++ b/tst/testinstall/hpc/threads.tst
@@ -1,0 +1,60 @@
+#############################################################################
+##
+#W  threads.tst               GAP tests                       Chris Jefferson
+##
+##
+#Y  Copyright (C) 2017
+##
+gap> START_TEST("threads.tst");
+gap> f := function(val) local x; MicroSleep(10); x := val; MicroSleep(10); return x; end;;
+gap> l := List([1..10000], x -> RunTask(f, x));;
+gap> ret := List(l, TaskResult);;
+gap> ret = [1..10000];
+true
+gap> a := AtomicList([0]);
+[ 0 ]
+gap> f := function(val) local x; MicroSleep(10); a[val] := val; MicroSleep(10); return val; end;;
+gap> l := List([1..10000], x -> RunTask(f, x));;
+gap> ret := List(l, TaskResult);;
+gap> ret = [1..10000];
+true
+gap> ForAll([1..10000], i -> a[i] = i);
+true
+gap> a := FixedAtomicList(10000, 0);;
+gap> f := function(val) local x; MicroSleep(10); a[val] := val; MicroSleep(10); return val; end;;
+gap> l := List([1..10000], x -> RunTask(f, x));;
+gap> ret := List(l, TaskResult);;
+gap> ret = [1..10000];
+true
+gap> ForAll([1..10000], i -> a[i] = i);
+true
+gap> a := FixedAtomicList(2, 0);;
+gap> a[2] := -50005000;;
+gap> f := function(val)
+> MicroSleep(10); ATOMIC_ADDITION(a, 1, val);
+> MicroSleep(10); ATOMIC_ADDITION(a, 2, val);
+> end;;
+gap> l := List([1..10000], x -> RunTask(f, x));;
+gap> ret := List(l, TaskResult);;
+gap> ret = List([1..10000], x -> fail);
+true
+gap> a;
+[ 50005000, 0 ]
+gap> a := [0, -50005000];;
+gap> ShareSpecialObj(a);;
+gap> f := function(q)
+> local val;
+> MicroSleep(10); atomic readwrite a do val := a[1]; a[1] := val + q; od;
+> MicroSleep(10); atomic readwrite a do val := a[2]; a[2] := val + q; od;
+> end;;
+gap> l := List([1..10000], x -> RunTask(f, x));;
+gap> ret := List(l, TaskResult);;
+gap> ret = List([1..10000], x -> fail);
+true
+gap> atomic readwrite a do Print(a,"\n"); od;
+[ 50005000, 0 ]
+gap> STOP_TEST( "threads.tst", 1 );
+#############################################################################
+##
+#E
+


### PR DESCRIPTION
This patch's aim to to test HPCGAP threading. Partly to test it, partly because threading-related code is one of the sources of variance in test coverage, and this stresses it more.

To accomplish this, we do three things (I could put these in seperate PRs, but I think they are all very small and trivial).

* Enable `MicroSleep` in non-HPCGAP, and document it.
* Add a simple fake implementation of `RunTask` and `TaskResult` in non-HPC GAP, so the same test can be run in HPCGAP and GAP.
* Remove the `factint` package, because it doesn't work even in the main thread of HPC-GAP (this can be changed later when `factint` is fixed).