### PR TITLE
RunTests: fully clear output of showProgress=some

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -139,7 +139,7 @@ InstallGlobalFunction(RunTests, function(arg)
     Add(times, Runtime()-t);
   od;
   if opts.showProgress = "some" then
-    Print("\r                      \c\r"); # clear the line
+    Print("\r                                    \c\r"); # clear the line
   fi;
   # add total time to 'times'
   Add(times, Runtime() - ttime);


### PR DESCRIPTION
Without this, the incremental progress report displayed by `showProgress="some"` may not be full cleared, leaving e.g. stray `%)` in the terminal output, like here:
```
gap> Test("tst/testinstall/intarith.tst");
intarith.tst          00%)
msecs: 608
true
gap> 
```