### PR TITLE
opers.c: fix typos

### DIFF
--- a/doc/hpc/vars.xml
+++ b/doc/hpc/vars.xml
@@ -7,7 +7,7 @@ semantics of global variables that are only accessed by a single thread remain u
   <Section Label="Global variables">
     <Heading>Global variables</Heading>
 
-Global variables in HPC-GAP an be accessed by all threads concurrently without explicit synchronization. Concurrent
+Global variables in HPC-GAP can be accessed by all threads concurrently without explicit synchronization. Concurrent
 access is safe, but it is not deterministic. If multiple threads attempt to modify the same global variable
 simultaneously, the resulting value of the variable is random; it will be one of the values assigned by a thread, but it
 is impossible to predict with certainty which specific one will be assigned.

--- a/doc/ref/fpsemi.xml
+++ b/doc/ref/fpsemi.xml
@@ -87,7 +87,7 @@ finitely presented monoid). Conversely elements of the finitely presented
 semigroup (resp. finitely presented monoid) are not words of the free
 semigroup (resp. free monoid).
 <P/>
-Calculations comparing elements of an finitely presented semigroup
+Calculations comparing elements of a finitely presented semigroup
 may run into problems: there are finitely presented semigroups for 
 which no algorithm exists (it is known that no such algorithm can exist) 
 that will tell for two arbitrary words in the generators whether the 

--- a/hpcgap/lib/info.gi
+++ b/hpcgap/lib/info.gi
@@ -16,7 +16,7 @@
 ##  InfoSelector, and classes and selectors may be built up with \+
 #N  I wanted to use \or, but this isn't at operation
 ##  
-##  An message is associated with a selector and a level and is
+##  A message is associated with a selector and a level and is
 ##  printed when the desired level for any of the classes in the selector
 ##  equals or exceeds  the level of the message
 ##
@@ -330,7 +330,7 @@ BIND_GLOBAL( "InfoDecision", function(selectors, level)
         fi;
     fi;
    
-    # store the class an level
+    # store the class and level
     atomic InfoData do
 	if IsInfoClass(selectors) then
 	  InfoData.LastClass := selectors;

--- a/hpcgap/src/opers.c
+++ b/hpcgap/src/opers.c
@@ -5861,7 +5861,7 @@ Obj DoGetterFunction (
         return GetARecordField( obj, (UInt)INT_INTOBJ(ENVI_FUNC(self)) );
 #endif
       default:
-        ErrorQuit( "<obj> must be an component object", 0L, 0L );
+        ErrorQuit( "<obj> must be a component object", 0L, 0L );
         return 0L;
     }
 }

--- a/hpcgap/src/scanner.c
+++ b/hpcgap/src/scanner.c
@@ -207,7 +207,7 @@ void            SyntaxWarning (
 **  This is used if the parser knows that the current  symbol is correct, for
 **  example in 'RdReturn'  the   first symbol must be 'S_RETURN',   otherwise
 **  'RdReturn' would not have been  called.  Called this  way 'Match' will of
-**  course never raise an syntax error,  therefore <msg>  and <skipto> are of
+**  course never raise a syntax error,  therefore <msg>  and <skipto> are of
 **  no concern, they are passed nevertheless  to please  lint.  The effect of
 **  this call is merely to read the next symbol from input.
 **

--- a/lib/ctblsolv.gi
+++ b/lib/ctblsolv.gi
@@ -918,7 +918,7 @@ InstallMethod( BaumClausenInfo,
           i,             # current position in the iteration: $G_i$
           p,             # size of current composition factor
           pexp,          # exponent vector of `pcgs[i]^p'
-          root,          # value of an xtension
+          root,          # value of an extension
           roots,         # list of $p$-th roots (relative to `e')
           mulmoma,       # product of two monomial matrices
           poweval,       # representing matrix for power of generator

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1036,7 +1036,7 @@ InstallOtherMethod( ElementaryAbelianSeries,
 
     local i, A, f;
 
-    # if <G> is a list compute a elementary series through a given normal one
+    # if <G> is a list compute an elementary series through a given normal one
     if not IsSolvableGroup( G[1] )  then
       Error( "<G> must be solvable" );
     fi;

--- a/lib/info.gi
+++ b/lib/info.gi
@@ -16,7 +16,7 @@
 ##  InfoSelector, and classes and selectors may be built up with \+
 #N  I wanted to use \or, but this isn't at operation
 ##  
-##  An message is associated with a selector and a level and is
+##  A message is associated with a selector and a level and is
 ##  printed when the desired level for any of the classes in the selector
 ##  equals or exceeds  the level of the message
 ##
@@ -303,7 +303,7 @@ BIND_GLOBAL( "InfoDecision", function(selectors, level)
         fi;
     fi;
    
-    # store the class an level
+    # store the class and level
     if IsInfoClass(selectors) then
       InfoData.LastClass := selectors;
     else

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -1877,7 +1877,7 @@ DeclareOperation( "MinimumList", [ IsList, IsObject ] );
 ##  That means that the first element <A>tup1</A> of <A>cart</A> contains
 ##  the first element from <A>list1</A>, from <A>list2</A> and so on.
 ##  The second element <A>tup2</A> of <A>cart</A> contains the first element
-##  from <A>list1</A>, the first from <A>list2</A>, an so on,
+##  from <A>list1</A>, the first from <A>list2</A>, and so on,
 ##  but the last element of <A>tup2</A> is the second element of the last
 ##  argument list.
 ##  This implies that <A>cart</A> is a proper set if and only if all argument

--- a/lib/mapprep.gi
+++ b/lib/mapprep.gi
@@ -255,7 +255,7 @@ InstallMethod( ImagesElm,
 #M  ImagesSet( <map>, <elms> )  . . . . . . . . . . . for composition mapping
 ##
 InstallMethod( ImagesSet,
-    "for a composition mapping, and an collection",
+    "for a composition mapping, and a collection",
     CollFamSourceEqFamElms,
     [ IsCompositionMappingRep, IsCollection ], 0,
     function ( com, elms )
@@ -325,7 +325,7 @@ InstallMethod( PreImagesElm,
 #M  PreImagesSet( <map>, <elm> )  . . . . . . . . . . for composition mapping
 ##
 InstallMethod( PreImagesSet,
-    "for a composition mapping, and an collection",
+    "for a composition mapping, and a collection",
     CollFamRangeEqFamElms,
     [ IsCompositionMappingRep, IsCollection ], 0,
     function( com, elms )
@@ -1747,7 +1747,7 @@ InstallMethod( ImagesElm,
 #M  ImagesSet( <map>, <elms> )  . . . . . . . . . . . for restricted mapping
 ##
 InstallMethod( ImagesSet,
-    "for a restricted mapping, and an collection",
+    "for a restricted mapping, and a collection",
     CollFamSourceEqFamElms,
     [ IsGeneralRestrictedMappingRep, IsCollection ], 0,
     function ( res, elms )
@@ -1811,7 +1811,7 @@ end );
 #M  PreImagesSet( <map>, <elm> )  . . . . . . . . . . for restricted mapping
 ##
 InstallMethod( PreImagesSet,
-    "for a restricted mapping, and an collection",
+    "for a restricted mapping, and a collection",
     CollFamRangeEqFamElms,
     [ IsGeneralRestrictedMappingRep, IsCollection ], 0,
     function( res, elms )

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -1269,7 +1269,7 @@ InstallMethod( DeterminantMatDestructive,
     for k  in [1..m]  do
 
         # find a nonzero entry in this column
-        #N  26-Oct-91 martin if <mat> is an rational matrix look for a pivot
+        #N  26-Oct-91 martin if <mat> is a rational matrix look for a pivot
         j := i + 1;
         while j <= m and mat[j][k] = zero  do j := j+1;  od;
 

--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -1165,7 +1165,7 @@ end);
 
 #############################################################################
 ##
-#F  MorFindGeneratingSystem(<G>,<cl>) . .  find generating system with an few 
+#F  MorFindGeneratingSystem(<G>,<cl>) . .  find generating system with as few 
 ##                      as possible generators from the first classes in <cl>
 ##
 InstallGlobalFunction(MorFindGeneratingSystem,function(arg)

--- a/lib/onecohom.gd
+++ b/lib/onecohom.gd
@@ -432,7 +432,7 @@ DeclareOperation("OCAddComplement",
 ##  <Func Name="OCOneCocycles" Arg='ocr, onlySplit'/>
 ##
 ##  <Description>
-##  is the more technical function to compute 1-cocycles. It takes an record
+##  is the more technical function to compute 1-cocycles. It takes a record
 ##  <A>ocr</A> as first argument which must contain at least the components
 ##  <C>group</C> for the group and <C>modulePcgs</C> for a (modulo) pcgs of
 ##  the module. This record

--- a/lib/pcgsind.gi
+++ b/lib/pcgsind.gi
@@ -884,7 +884,7 @@ RedispatchOnCondition( CanonicalPcgs, true,
 ##
 #M  CanonicalPcgs( <cgs> )
 ##
-InstallOtherMethod( CanonicalPcgs,"of an canonical pcgs",
+InstallOtherMethod( CanonicalPcgs,"of a canonical pcgs",
     true, [ IsCanonicalPcgs ],
     SUM_FLAGS, # the best we can do
     x -> x );

--- a/lib/pquot.gi
+++ b/lib/pquot.gi
@@ -183,7 +183,7 @@ end;
 
 #############################################################################
 ##
-#F  RowEchelonFormLTM . . . .  row echelon form of an lower triangular matrix
+#F  RowEchelonFormLTM . . . .  row echelon form of a lower triangular matrix
 ##
 RowEchelonFormLTM := function( LTM )
     local   i,  j;

--- a/lib/ringhom.gi
+++ b/lib/ringhom.gi
@@ -96,7 +96,7 @@ end );
 ##
 #M  ViewObj( <map> )  . . . . . . . . . . . . . . . . .  for ring g.m.b.i.
 ##
-InstallMethod( ViewObj, "for an ring g.m.b.i", true,
+InstallMethod( ViewObj, "for a ring g.m.b.i", true,
     [ IsGeneralMapping and IsRingGeneralMappingByImagesDefaultRep ], 0,
 function( map )
 local mapi;
@@ -111,7 +111,7 @@ end );
 ##
 #M  PrintObj( <map> ) . . . . . . . . . . . . . . . . .  for ring g.m.b.i.
 ##
-InstallMethod( PrintObj, "for an ring hom. b.i.", true,
+InstallMethod( PrintObj, "for a ring hom. b.i.", true,
     [     IsMapping
       and IsRingGeneralMappingByImagesDefaultRep ], 0,
 function( map )
@@ -122,7 +122,7 @@ local mapi;
 	  mapi[1], ", ", mapi[2], " )" );
 end );
 
-InstallMethod( PrintObj, "for an ring g.m.b.i", true,
+InstallMethod( PrintObj, "for a ring g.m.b.i", true,
     [     IsGeneralMapping
       and IsRingGeneralMappingByImagesDefaultRep ], 0,
 function( map )
@@ -224,7 +224,7 @@ end);
 #M  ImagesSource( <map> ) . . . . . . . . . . . . . . .  for ring g.m.b.i.
 ##
 InstallMethod( ImagesSource,
-    "for an ring g.m.b.i.",
+    "for a ring g.m.b.i.",
     [ IsRingGeneralMapping and IsRingGeneralMappingByImagesDefaultRep ],
 function( map )
   return Subring(Range(map),MappingGeneratorsImages(map)[2]);
@@ -235,7 +235,7 @@ end );
 #M  PreImagesRange( <map> ) . . . . . . . . . . . . . .  for ring g.m.b.i.
 ##
 InstallMethod( PreImagesRange,
-    "for an ring g.m.b.i.",
+    "for a ring g.m.b.i.",
     [ IsGeneralMapping and IsRingGeneralMappingByImagesDefaultRep ],
 function( map )
   return Subring(Source(map),MappingGeneratorsImages(map)[1]);
@@ -246,7 +246,7 @@ end );
 #M  InverseGeneralMapping( <map> ) . . . . . . . . . . . .  for ring g.m.b.i.
 ##
 InstallMethod( InverseGeneralMapping,
-    "for an ring g.m.b.i.",
+    "for a ring g.m.b.i.",
     [ IsGeneralMapping and IsRingGeneralMappingByImagesDefaultRep ],
 function( map )
 local mapi;

--- a/lib/schur.gd
+++ b/lib/schur.gd
@@ -244,7 +244,7 @@ DeclareGlobalFunction("SchuMu");
 ##
 ##  <Description>
 ##  evaluate corestriction mapping.
-##  <A>FH</A> is an homomorphism from a finitely presented group onto a finite
+##  <A>FH</A> is a homomorphism from a finitely presented group onto a finite
 ##  group <A>G</A>. <A>s</A> an epimorphism onto a p-Sylow subgroup of <A>G</A> as obtained
 ##  from <C>SchuMu</C>.
 ##  This function evaluates the relators of the source of <A>FH</A> in the

--- a/lib/sgpres.gd
+++ b/lib/sgpres.gd
@@ -178,7 +178,7 @@ AbelianInvariantsSubgroupFpGroup := AbelianInvariantsSubgroupFpGroupRrs;
 ##  <P/>
 ##  It is mutable so we are permitted to add further entries. However
 ##  existing entries may not be changed. Any entries added however should
-##  correspond to the subgroup only and not to an homomorphism.
+##  correspond to the subgroup only and not to a homomorphism.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -205,7 +205,7 @@ BindGlobal("TABLE_TYPE_MTC",2);
 ##  <P/>
 ##  It is mutable so we are permitted to add further entries, however
 ##  existing entries may not be changed. Any entries added however should
-##  correspond to the subgroup only and not to an homomorphism.
+##  correspond to the subgroup only and not to a homomorphism.
 ##  </Description>
 ##  </ManSection>
 ##
@@ -226,7 +226,7 @@ DeclareAttribute("AugmentedCosetTableMtcInWholeGroup",IsGroup,"mutable");
 ##  <P/>
 ##  It is mutable so we are permitted to add further entries, however
 ##  existing entries may not be changed. Any entries added however should
-##  correspond to the subgroup only and not to an homomorphism.
+##  correspond to the subgroup only and not to a homomorphism.
 ##  </Description>
 ##  </ManSection>
 ##

--- a/lib/tom.gi
+++ b/lib/tom.gi
@@ -2072,7 +2072,7 @@ InstallMethod( DerivedSubgroupTom,
       # for each such intersection the derived subgroup must be
       # contained in one of the possible intersections returned by
       # `IntersectionsTom'.
-      # Additionally there must be an chain of
+      # Additionally there must be a chain of
       # normal extensions connecting the derived subgroup and the groupext;
       result:=Filtered(subs[normalsubs[1]], x-> x in ext);
       for i in [1..Length(normalsubs)] do

--- a/src/dt.c
+++ b/src/dt.c
@@ -98,7 +98,7 @@
 *F  SET_DT_POS(tree, index, obj) . . . assign the position of(<tree>, index)
 **
 **  'SET_DT_POS sets pos(<a>) to the object <obj>, where <a> is the subtree
-**  of <tree>,  rooted at (<tree>, index).  <index> has to be an positive
+**  of <tree>,  rooted at (<tree>, index).  <index> has to be a positive
 **  integer less or equal to the number of nodes of <tree>
 */
 #define  SET_DT_POS(tree, index, obj) \
@@ -122,7 +122,7 @@
 *F  SET_DT_GEN(tree, index, obj) . . . assign the generator of(<tree>, index)
 **
 **  'SET_DT_GEN sets num(<a>) to the object <obj>, where <a> is the subtree
-**  of <tree>,  rooted at (<tree>, index).  <index> has to be an positive
+**  of <tree>,  rooted at (<tree>, index).  <index> has to be a positive
 **  integer less or equal to the number of nodes of <tree>
 */
 #define  SET_DT_GEN(tree, index, obj) \

--- a/src/gmpints.c
+++ b/src/gmpints.c
@@ -228,7 +228,7 @@ Obj TypeIntLargeNeg ( Obj val )
 **
 **  'IsInt( <val> )'
 **
-**  'IsInt'  returns 'true'  if the  value  <val>  is an small integer or a
+**  'IsInt'  returns 'true'  if the  value  <val>  is a small integer or a
 **  large int, and 'false' otherwise.
 */
 Obj FuncIS_INT ( Obj self, Obj val )

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -210,7 +210,7 @@ UInt4 nextrandMT_int32(UInt4* mt)
 **
 **  'HASHKEY_BAG( <obj>, <seed>, <offset>, <maxlen> )'
 **
-**  takes an non-immediate object and a small integer <seed> and computes a
+**  takes a non-immediate object and a small integer <seed> and computes a
 **  hash value for the contents of the bag from these. (For this to be
 **  usable in algorithms, we need that objects of this kind are stored uniquely
 **  internally.

--- a/src/lists.h
+++ b/src/lists.h
@@ -35,7 +35,7 @@ extern  Obj             TYPE_LIST_HOM;
 **
 **  A package implementing  an ordinary list type <type>   must set the  flag
 **  'IsListFlag[<type>]'  for  this type to '1'.   A  package  implementing a
-**  vector type must set  it to '2'.  A  package implementing an matrix  type
+**  vector type must set  it to '2'.  A  package implementing a matrix  type
 **  must set it to '3'.
 */
 extern  Int             (*IsListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );

--- a/src/opers.c
+++ b/src/opers.c
@@ -5660,7 +5660,7 @@ Obj DoSetterFunction (
     Obj                 type;
 
     if ( TNUM_OBJ(obj) != T_COMOBJ ) {
-        ErrorQuit( "<obj> must be an component object", 0L, 0L );
+        ErrorQuit( "<obj> must be a component object", 0L, 0L );
         return 0L;
     }
 
@@ -5723,7 +5723,7 @@ Obj DoGetterFunction (
         return GetARecordField( obj, (UInt)INT_INTOBJ(ENVI_FUNC(self)) );
 #endif
       default:
-        ErrorQuit( "<obj> must be an component object", 0L, 0L );
+        ErrorQuit( "<obj> must be a component object", 0L, 0L );
         return 0L;
     }
 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -207,7 +207,7 @@ void            SyntaxWarning (
 **  This is used if the parser knows that the current  symbol is correct, for
 **  example in 'RdReturn'  the   first symbol must be 'S_RETURN',   otherwise
 **  'RdReturn' would not have been  called.  Called this  way 'Match' will of
-**  course never raise an syntax error,  therefore <msg>  and <skipto> are of
+**  course never raise a syntax error,  therefore <msg>  and <skipto> are of
 **  no concern, they are passed nevertheless  to please  lint.  The effect of
 **  this call is merely to read the next symbol from input.
 **

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -371,7 +371,7 @@ extern  void            SyntaxWarning (
 **  This is used if the parser knows that the current  symbol is correct, for
 **  example in 'RdReturn'  the   first symbol must be 'S_RETURN',   otherwise
 **  'RdReturn' would not have been  called.  Called this  way 'Match' will of
-**  course never raise an syntax error,  therefore <msg>  and <skipto> are of
+**  course never raise a syntax error,  therefore <msg>  and <skipto> are of
 **  no concern, they are passed nevertheless  to please  lint.  The effect of
 **  this call is merely to read the next symbol from input.
 **

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -52,7 +52,7 @@
 
 /****************************************************************************
 **
-*F  SumFFEVecFFE(<elmL>,<vecR>) . . . .  sum of an fin field elm and a vector
+*F  SumFFEVecFFE(<elmL>,<vecR>) . . . .  sum of a finite field elm and a vector
 **
 **  'SumFFEVecFFE' returns the sum of the fin field elm <elmL> and the vector
 **  <vecR>.  The sum is a  list, where each element is  the sum of <elmL> and


### PR DESCRIPTION
More instances of the typo that I corrected in #1411. Thanks to @fingolfin for pointing them out.

Edit: I had a look for some more typos involving "an"