### PR TITLE
buildsys: remove code dealing with HPC-GAP headers

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -127,11 +127,6 @@ ifneq ($(top_builddir),$(srcdir))
   GAP_CPPFLAGS += -I$(top_builddir)
 endif
 
-ifeq ($(HPCGAP),yes)
-  # Prefer headers from hpcgap/src/ over those in src/
-  GAP_CPPFLAGS += -I$(srcdir)/hpcgap
-endif
-
 # Finally look into srcdir
 GAP_CPPFLAGS += -I$(srcdir)
 
@@ -473,7 +468,6 @@ install-headers:
 	$(QUIET_INSTALL)$(INSTALL) -d -m 0755 $(DESTDIR)$(includedir)/gap/hpc
 	$(QUIET_INSTALL)$(INSTALL) -m 0644 $(srcdir)/src/*.h $(DESTDIR)$(includedir)/gap
 	$(QUIET_INSTALL)$(INSTALL) -m 0644 $(srcdir)/src/hpc/*.h $(DESTDIR)$(includedir)/gap/hpc
-	$(QUIET_INSTALL)$(INSTALL) -m 0644 $(srcdir)/hpcgap/src/*.h $(DESTDIR)$(includedir)/gap
 	sed -i -E -e 's;#include <src/([^>]+)>;#include "\1";' $(DESTDIR)$(includedir)/gap/*.h
 	sed -i -E -e 's;#include <src/([^>]+)>;#include "\1";' $(DESTDIR)$(includedir)/gap/hpc/*.h
 	# TODO: take care of config.h
@@ -629,15 +623,10 @@ bin/gap.sh: $(srcdir)/cnf/compat/gap.sh.in config.status
 	$(SHELL) ./config.status $@
 
 # regenerate bin/$(GAPARCH)/src symlink if necessary
-ifeq ($(HPCGAP),yes)
-compat_src_symlink=$(abs_top_srcdir)/hpcgap/src
-else
-compat_src_symlink=$(abs_top_srcdir)/src
-endif
 all: bin/$(GAPARCH)/src
 bin/$(GAPARCH)/src: config.status
 	@$(MKDIR_P) bin/$(GAPARCH)
-	@ln -sf $(compat_src_symlink) $(@D)
+	@ln -sf $(abs_top_srcdir)/src $(@D)
 
 all: bin/$(GAPARCH)/gac
 bin/$(GAPARCH)/gac:

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -55,9 +55,8 @@ fi
 
 if [[ $HPCGAP = yes ]]
 then
-  # Add flags so that Boehm GC and libatomic headers are found, as well as HPC-GAP headers
+  # Add flags so that Boehm GC and libatomic headers are found
   CPPFLAGS="-I$PWD/extern/install/gc/include -I$PWD/extern/install/libatomic_ops/include $CPPFLAGS"
-  CPPFLAGS="-I$SRCDIR/hpcgap -I$SRCDIR $CPPFLAGS"
   export CPPFLAGS
 fi
 


### PR DESCRIPTION
Now that there are no header files left in hpcgap/src/, we can remove all code
that dealt with them.

This also enhances compatibility with packages that build kernel extensions.
In particular, we can now build edim for HPC-GAP again under Travis. (which
doesn't mean it works, but at least it is one step closer to working)