### PR TITLE
Remove Isbv methods, as they are never used

### DIFF
--- a/hpcgap/src/plist.c
+++ b/hpcgap/src/plist.c
@@ -1124,15 +1124,10 @@ Int             LenPlistEmpty (
 /****************************************************************************
 **
 *F  IsbPlist(<list>,<pos>)  . . . . . . test for an element from a plain list
-*F  IsbvPlist(<list>,<pos>) . . . . . . test for an element from a plain list
 **
 **  'IsbPlist' returns 1 if the list <list> has an entry  at  position  <pos>
 **  and 0 otherwise.  It is the responsibility of the caller to  ensure  that
 **  <pos> is a positive integer.
-**
-**  'IsbvPlist' does the  same thing than  'IsbList', but need not check that
-**  <pos>  is less  than or  equal  to the  length of   <list>,  this is  the
-**  responsibility of the caller.
 */
 Int             IsbPlist (
     Obj                 list,
@@ -1146,20 +1141,6 @@ Int             IsbPlistDense (
     Int                 pos )
 {
     return (pos <= LEN_PLIST( list ));
-}
-
-Int             IsbvPlist (
-    Obj                 list,
-    Int                 pos )
-{
-    return (ELM_PLIST( list, pos ) != 0);
-}
-
-Int             IsbvPlistDense (
-    Obj                 list,
-    Int                 pos )
-{
-    return (1L);
 }
 
 
@@ -4616,14 +4597,6 @@ static Int InitKernel (
     for ( t1 = T_PLIST_DENSE; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
         IsbListFuncs  [ t1            ] = IsbPlistDense;
         IsbListFuncs  [ t1 +IMMUTABLE ] = IsbPlistDense;
-    }
-    for ( t1 = T_PLIST; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
-        IsbvListFuncs [ t1            ] = IsbvPlist;
-        IsbvListFuncs [ t1 +IMMUTABLE ] = IsbvPlist;
-    }
-    for ( t1 = T_PLIST_DENSE; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
-        IsbvListFuncs [ t1            ] = IsbvPlistDense;
-        IsbvListFuncs [ t1 +IMMUTABLE ] = IsbvPlistDense;
     }
 
 

--- a/src/blister.c
+++ b/src/blister.c
@@ -425,18 +425,6 @@ Int IsbBlist (
 
 /****************************************************************************
 **
-*F  IsbvBlist( <list>, <pos> )  . . . . test for an element of a boolean list
-*/
-Int IsbvBlist (
-    Obj                 list,
-    Int                 pos )
-{
-    return 1L;
-}
-
-
-/****************************************************************************
-**
 
 *F  Elm0Blist( <list>, <pos> )  . . . . . select an element of a boolean list
 **
@@ -2726,8 +2714,6 @@ static Int InitKernel (
         LenListFuncs    [ t1 +IMMUTABLE ] = LenBlist;
         IsbListFuncs    [ t1            ] = IsbBlist;
         IsbListFuncs    [ t1 +IMMUTABLE ] = IsbBlist;
-        IsbvListFuncs   [ t1            ] = IsbvBlist;
-        IsbvListFuncs   [ t1 +IMMUTABLE ] = IsbvBlist;
         Elm0ListFuncs   [ t1            ] = Elm0Blist;
         Elm0ListFuncs   [ t1 +IMMUTABLE ] = Elm0Blist;
         Elm0vListFuncs  [ t1            ] = Elm0vBlist;

--- a/src/lists.c
+++ b/src/lists.c
@@ -319,27 +319,20 @@ Obj LengthInternal (
 /****************************************************************************
 **
 *F  ISB_LIST(<list>,<pos>)  . . . . . . . . . .  test for element from a list
-*F  ISBV_LIST(<list>,<pos>) . . . . . . . . . .  test for element from a list
 *V  IsbListFuncs[<type>]  . . . . . . . . . . . . . . table of test functions
-*V  IsbvListFuncs[<type>] . . . . . . . . . . . . . . table of test functions
 **
 **  'ISB_LIST' only calls the function pointed to by  'IsbListFuncs[<type>]',
 **  passing <list> and <pos> as arguments.  If <type> is not the  type  of  a
 **  list, then 'IsbListFuncs[<type>]' points to 'IsbListError', which signals
 **  the error.
 **
-**  'ISB_LIST' and 'ISBV_LIST'  are defined in  the declaration  part of this
+**  'ISB_LIST' is defined in  the declaration  part of this
 **  package as follows
 **
 #define ISB_LIST(list,pos) \
                         ((*IsbListFuncs[TNUM_OBJ(list)])(list,pos))
-
-#define ISBV_LIST(list,pos) \
-                        ((*IsbvListFuncs[TNUM_OBJ(list)])(list,pos))
 */
 Int             (*IsbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
-
-Int             (*IsbvListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
 Obj             IsbListOper;
 
@@ -2459,11 +2452,9 @@ static Int InitKernel (
     /* make and install the 'ISB_LIST' operation                           */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
         IsbListFuncs[  type ] = IsbListError;
-        IsbvListFuncs[ type ] = IsbListError;
     }
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
         IsbListFuncs[  type ] = IsbListObject;
-        IsbvListFuncs[ type ] = IsbListObject;
     }
 
     /* make and install the 'ELM0_LIST' operation                          */

--- a/src/lists.h
+++ b/src/lists.h
@@ -109,39 +109,24 @@ static inline Obj LENGTH(Obj list)
 /****************************************************************************
 **
 *F  ISB_LIST(<list>,<pos>)  . . . . . . . . . .  test for element from a list
-*F  ISBV_LIST(<list>,<pos>) . . . . . . . . . .  test for element from a list
 *V  IsbListFuncs[<type>]  . . . . . . . . . . . . . . table of test functions
-*V  IsbvListFuncs[<type>] . . . . . . . . . . . . . . table of test functions
 **
 **  'ISB_LIST' returns 1  if the list <list>  has an entry at  position <pos>
 **  and 0 otherwise.  An error is signalled  if <list> is not  a list.  It is
 **  the  responsibility of  the  caller to  ensure that  <pos> is a  positive
 **  integer.
 **
-**  'ISBV_LIST'  does the same as  'ISB_LIST', but the caller also guarantees
-**  that <list> ist a list and that <pos> is less than or equal to the length
-**  of <list>.
-**
-**  Note that 'ISB_LIST' and 'ISBV_LIST are macros, so  do not call them with
-**  arguments that have side effects.
+**  Note that 'ISB_LIST' is a macro, so do not call it with arguments that
+**  have side effects.
 **
 **  A  package implementing a  list type <type>  must  provide a function for
 **  'ISB_LIST' and install it in 'IsbListFuncs[<type>]'.
 **
-**  A package  implementing  a list type  <type> must  provide a function for
-**  'ISBV_LIST' and  install  it in 'IsbvListFuncs[<type>]'.   This  function
-**  need not  test whether  <pos> is less  than   or equal to the   length of
-**  <list>.
 */
 #define ISB_LIST(list,pos) \
                         ((*IsbListFuncs[TNUM_OBJ(list)])(list,pos))
 
-#define ISBV_LIST(list,pos) \
-                        ((*IsbvListFuncs[TNUM_OBJ(list)])(list,pos))
-
 extern  Int             (*IsbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
-
-extern  Int             (*IsbvListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
 extern Int ISBB_LIST( Obj list, Obj pos );
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -1123,15 +1123,10 @@ Int             LenPlistEmpty (
 /****************************************************************************
 **
 *F  IsbPlist(<list>,<pos>)  . . . . . . test for an element from a plain list
-*F  IsbvPlist(<list>,<pos>) . . . . . . test for an element from a plain list
 **
 **  'IsbPlist' returns 1 if the list <list> has an entry  at  position  <pos>
 **  and 0 otherwise.  It is the responsibility of the caller to  ensure  that
 **  <pos> is a positive integer.
-**
-**  'IsbvPlist' does the  same thing than  'IsbList', but need not check that
-**  <pos>  is less  than or  equal  to the  length of   <list>,  this is  the
-**  responsibility of the caller.
 */
 Int             IsbPlist (
     Obj                 list,
@@ -1145,20 +1140,6 @@ Int             IsbPlistDense (
     Int                 pos )
 {
     return (pos <= LEN_PLIST( list ));
-}
-
-Int             IsbvPlist (
-    Obj                 list,
-    Int                 pos )
-{
-    return (ELM_PLIST( list, pos ) != 0);
-}
-
-Int             IsbvPlistDense (
-    Obj                 list,
-    Int                 pos )
-{
-    return (1L);
 }
 
 
@@ -4615,14 +4596,6 @@ static Int InitKernel (
     for ( t1 = T_PLIST_DENSE; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
         IsbListFuncs  [ t1            ] = IsbPlistDense;
         IsbListFuncs  [ t1 +IMMUTABLE ] = IsbPlistDense;
-    }
-    for ( t1 = T_PLIST; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
-        IsbvListFuncs [ t1            ] = IsbvPlist;
-        IsbvListFuncs [ t1 +IMMUTABLE ] = IsbvPlist;
-    }
-    for ( t1 = T_PLIST_DENSE; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
-        IsbvListFuncs [ t1            ] = IsbvPlistDense;
-        IsbvListFuncs [ t1 +IMMUTABLE ] = IsbvPlistDense;
     }
 
 

--- a/src/range.c
+++ b/src/range.c
@@ -498,13 +498,6 @@ Int             IsbRange (
     return (pos <= GET_LEN_RANGE(list));
 }
 
-Int             IsbvRange (
-    Obj                 list,
-    Int                 pos )
-{
-    return 1L;
-}
-
 
 /****************************************************************************
 **
@@ -1644,10 +1637,6 @@ static Int InitKernel (
     IsbListFuncs    [ T_RANGE_NSORT +IMMUTABLE ] = IsbRange;
     IsbListFuncs    [ T_RANGE_SSORT            ] = IsbRange;
     IsbListFuncs    [ T_RANGE_SSORT +IMMUTABLE ] = IsbRange;
-    IsbvListFuncs   [ T_RANGE_NSORT            ] = IsbvRange;
-    IsbvListFuncs   [ T_RANGE_NSORT +IMMUTABLE ] = IsbvRange;
-    IsbvListFuncs   [ T_RANGE_SSORT            ] = IsbvRange;
-    IsbvListFuncs   [ T_RANGE_SSORT +IMMUTABLE ] = IsbvRange;
     Elm0ListFuncs   [ T_RANGE_NSORT            ] = Elm0Range;
     Elm0ListFuncs   [ T_RANGE_NSORT +IMMUTABLE ] = Elm0Range;
     Elm0ListFuncs   [ T_RANGE_SSORT            ] = Elm0Range;

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -869,17 +869,12 @@ Int LenString (
 /****************************************************************************
 **
 *F  IsbString(<list>,<pos>) . . . . . . . . . test for an element of a string
-*F  IsbvString(<list>,<pos>)  . . . . . . . . test for an element of a string
 **
 **  'IsbString' returns 1 if the string <list> contains
 **  a character at the position <pos> and 0 otherwise.
 **  It can rely on <pos> being a positive integer.
 **
-**  'IsbvString' does the same thing as 'IsbString', but it can 
-**  also rely on <pos> not being larger than the length of <list>.
-**
 **  'IsbString'  is the function in 'IsbListFuncs'  for strings.
-**  'IsbvString' is the function in 'IsbvListFuncs' for strings.
 */
 Int IsbString (
     Obj                 list,
@@ -887,14 +882,6 @@ Int IsbString (
 {
     /* since strings are dense, this must only test for the length         */
     return (pos <= GET_LEN_STRING(list));
-}
-
-Int IsbvString (
-    Obj                 list,
-    Int                 pos )
-{
-    /* since strings are dense, this can only return 1                     */
-    return 1L;
 }
 
 
@@ -2654,8 +2641,6 @@ static Int InitKernel (
         LenListFuncs    [ t1 +IMMUTABLE ] = LenString;
         IsbListFuncs    [ t1            ] = IsbString;
         IsbListFuncs    [ t1 +IMMUTABLE ] = IsbString;
-        IsbvListFuncs   [ t1            ] = IsbvString;
-        IsbvListFuncs   [ t1 +IMMUTABLE ] = IsbvString;
         Elm0ListFuncs   [ t1            ] = Elm0String;
         Elm0ListFuncs   [ t1 +IMMUTABLE ] = Elm0String;
         Elm0vListFuncs  [ t1            ] = Elm0vString;


### PR DESCRIPTION
The `isbv` methods are supposed to check if a value in a list is bound, without doing a bounds check. It's never used, at least one of the methods was faulty, and it seems (to me) to be risky without any great value. Therefore let's clean it out.