### PR TITLE
hpcgap: remove FIXED_REGION object flag

### DIFF
--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -905,7 +905,6 @@ Obj FuncTRYLOCK(Obj self, Obj args);
 Obj FuncUNLOCK(Obj self, Obj args);
 Obj FuncCURRENT_LOCKS(Obj self);
 Obj FuncREFINE_TYPE(Obj self, Obj obj);
-Obj FuncFIX_OBJ_REGION(Obj self, Obj obj);
 Obj FuncSHARE_NORECURSE(Obj self, Obj obj, Obj name, Obj prec);
 Obj FuncNEW_REGION(Obj self, Obj name, Obj prec);
 Obj FuncREGION_PRECEDENCE(Obj self, Obj regobj);
@@ -1150,9 +1149,6 @@ static StructGVarFunc GVarFuncs [] = {
 
     { "REFINE_TYPE", 1, "obj",
       FuncREFINE_TYPE, "src/threadapi.c:REFINE_TYPE" },
-
-    { "FIX_OBJ_REGION", 1, "obj",
-      FuncFIX_OBJ_REGION, "src/threadapi.c:FIX_OBJ_REGION" },
 
     { "SHARE_NORECURSE", 3, "obj, string, integer",
       FuncSHARE_NORECURSE, "src/threadapi.c:SHARE_NORECURSE" },
@@ -2678,8 +2674,6 @@ static int MigrateObjects(int count, Obj *objects, Region *target, int retype)
     Region *region;
     if (IS_BAG_REF(objects[i])) {
       region = (Region *)(REGION(objects[i]));
-      if (TEST_OBJ_FLAG(objects[i], FIXED_REGION))
-        return 0;
       if (!region || region->owner != realTLS)
         return 0;
     }
@@ -2708,17 +2702,6 @@ Obj FuncFORCE_MAKE_PUBLIC(Obj self, Obj obj)
   if (!IS_BAG_REF(obj))
     return ArgumentError("FORCE_MAKE_PUBLIC: Argument is a short integer or finite-field element");
   MakeBagPublic(obj);
-  return obj;
-}
-
-
-Obj FuncFIX_OBJ_REGION(Obj self, Obj obj)
-{
-  if (!IS_BAG_REF(obj))
-    return ArgumentError("FIX_OBJ_REGION: Argument must not be a short integer or finite field element");
-  if (!CheckExclusiveWriteAccess(obj))
-    return ArgumentError("FIX_OBJ_REGION: Thread does not have exclusive access to object");
-  SET_OBJ_FLAG(obj, FIXED_REGION);
   return obj;
 }
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -454,7 +454,6 @@ Int RegisterPackageTNUM( const char *name, Obj (*typeObjFunc)(Obj obj) );
 
 #define TESTING (1 << 0)
 #define TESTED (1 << 1)
-#define FIXED_REGION (1 << 2)
 
 #else
 


### PR DESCRIPTION
This reverts commit 941d2d252c34bdf27e2667d5de20a0fa44a8425d. Fixed
regions are not currently used by anything; they were / are intended for
interacting with external parallelized code.

In any case, the current implementation is certainly incomplete; e.g.
all kinds of actions currently reset object flags, which violates the
purpose of the FIXED_REGION flag.

If / when this feature is actually needed in the future, we can of
course reintroduce it.


This change was discussed with @rbehrends quite some time ago, but somehow I forgot to open a PR for this branch.