### PR TITLE
hpcgap: change FuncVAL_GVAR to use ValAutoGVar...

### DIFF
--- a/hpcgap/src/gvars.c
+++ b/hpcgap/src/gvars.c
@@ -969,7 +969,7 @@ Obj FuncISB_GVAR (
       return True;
     expr = ExprGVar(gv);
     if (expr && !IS_INTOBJ(expr)) /* auto gvar */
-      return False;
+      return True;
     if (!expr || !TLVars)
       return False;
     return GetTLRecordField(TLVars, INT_INTOBJ(expr)) ? True : False;
@@ -995,7 +995,7 @@ Obj FuncVAL_GVAR (
     }
 
     /* get the value */
-    val = ValGVarTL( GVarName( CSTR_STRING(gvar) ) );
+    val = ValAutoGVar( GVarName( CSTR_STRING(gvar) ) );
 
     while (val == (Obj) 0)
       val = ErrorReturnObj("VAL_GVAR: No value bound to %s",


### PR DESCRIPTION
... instead of ValGVarTL, which matches what GAP does. Also change FuncISB_GVAR to return True for auto gvars, as it does in GAP.

This partially reverts 2a6b4cadb27bd56a680332dc3b024574f0e2750c by @rbehrends . I do not understand that commit, and why it made HPC-GAP deviate on how automatic variables are treated. Perhaps there is a good reason for that, but then that reason should be documented (at the very least with a code comment, but since this affects users of GAP, it should also be mentioned in the GAP reference manual.

Please do not merge this PR until @rbehrends had a chance to comment.