### PR TITLE
kernel: add check to ON_KERNEL_ANTI_ACTION

### DIFF
--- a/src/trans.c
+++ b/src/trans.c
@@ -1500,16 +1500,24 @@ Obj FuncON_KERNEL_ANTI_ACTION (Obj self, Obj ker, Obj f, Obj n) {
   UInt    deg, i, j, rank, len;
   Obj     out;
 
-  if (INT_INTOBJ(ELM_LIST(ker, LEN_LIST(ker))) == 0) {
+  assert(IS_LIST(ker));
+  assert(IS_INTOBJ(n));
+
+  len = LEN_LIST(ker);
+  if (len == 1 && INT_INTOBJ(ELM_LIST(ker, 1)) == 0) {
     return FuncFLAT_KERNEL_TRANS_INT(self, f, n);
   }
 
-  len = LEN_LIST(ker);
   rank = 1;
 
   if (TNUM_OBJ(f) == T_TRANS2) {
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
     if (len >= deg) {
+      if (len == 0) {
+        out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        SET_LEN_PLIST(out, 0);
+        return out;
+      }
       out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, len);
       SET_LEN_PLIST(out, len);
       pttmp = ResizeInitTmpTrans(len);
@@ -1539,6 +1547,11 @@ Obj FuncON_KERNEL_ANTI_ACTION (Obj self, Obj ker, Obj f, Obj n) {
   } else if (TNUM_OBJ(f) == T_TRANS4) {
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
     if (len >= deg) {
+      if (len == 0) {
+        out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        SET_LEN_PLIST(out, 0);
+        return out;
+      }
       out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, len);
       SET_LEN_PLIST(out, len);
       pttmp = ResizeInitTmpTrans(len);

--- a/tst/testinstall/trans.tst
+++ b/tst/testinstall/trans.tst
@@ -1176,6 +1176,17 @@ gap> ON_KERNEL_ANTI_ACTION([1 .. 5], IdentityTransformation, 0);
 gap> ON_KERNEL_ANTI_ACTION([1 .. 5], (), 0);
 Error, ON_KERNEL_ANTI_ACTION: the argument must be a transformation (not a per\
 mutation (small))
+gap> ON_KERNEL_ANTI_ACTION([], IdentityTransformation, 10);
+[  ]
+gap> ON_KERNEL_ANTI_ACTION([], IdentityTransformation, 10);
+[  ]
+gap> f := ID_TRANS4;;
+gap> IsTrans4Rep(f);
+true
+gap> ON_KERNEL_ANTI_ACTION([], f, 10);
+[  ]
+gap> ON_KERNEL_ANTI_ACTION([], f, 10);
+[  ]
 
 # INV_KER_TRANS
 gap> f := Transformation([9, 5, 3, 5, 10, 3, 1, 9, 6, 7]);;


### PR DESCRIPTION
This PR adds a check that the argument ker has zero length, and if it
does, just returns it. Previously if `ker` was of length 0, then the
behaviour was undefined since the value of `ELM_LIST(ker, 1)` was used but
not defined. I also added an assert to the start of the function, and some related tests.