### PR TITLE
fix typos in Chapter 51 : Semigroups and Monoids

### DIFF
--- a/lib/fpmon.gd
+++ b/lib/fpmon.gd
@@ -1,6 +1,6 @@
 #############################################################################
 ##
-#W  fpmon.gd           GAP library        										Isabel Araújo
+#W  fpmon.gd                GAP library      			Isabel Araújo
 ##
 ##
 #Y  Copyright (C)  1997,  Lehrstuhl D für Mathematik,  RWTH Aachen,  Germany

--- a/lib/monoid.gd
+++ b/lib/monoid.gd
@@ -237,7 +237,8 @@ DeclareSynonymAttr( "TrivialSubmonoid", TrivialSubmagmaWithOne );
 ##  (see&nbsp;<Ref Sect="Representations for Associative Words"/>).
 ##  If no such filter is given, a letter representation is used.
 ##  <P/>
-##  Also see Chapter&nbsp;<Ref Chap="Semigroups"/>.
+##  For more on associative words see 
+##  Chapter&nbsp;<Ref Chap="Associative Words"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/semigrp.gd
+++ b/lib/semigrp.gd
@@ -193,7 +193,7 @@ DeclareSynonymAttr( "GeneratorsOfSemigroup", GeneratorsOfMagma );
 ##  <Prop Name="IsGeneratorsOfSemigroup" Arg='C'/>
 ##
 ##  <Description>
-##  This property reflects wheter the list or collection <A>C</A> generates
+##  This property reflects whether the list or collection <A>C</A> generates
 ##  a semigroup.
 ##  <Ref Prop="IsAssociativeElementCollection"/> implies 
 ##  &nbsp;<Ref Prop="IsGeneratorsOfSemigroup"/>,
@@ -299,7 +299,8 @@ DeclareAttribute("CayleyGraphDualSemigroup",IsSemigroup);
 ##  <free semigroup on the generators [ gen1, gen2 ]>
 ##  ]]></Example>
 ##  <P/>
-##  Also see Chapter&nbsp;<Ref Chap="Semigroups"/>.
+##  For more on associative words see 
+##  Chapter&nbsp;<Ref Chap="Associative Words"/>.
 ##  <P/>
 ##  Each free object defines a unique alphabet (and a unique family of words).
 ##  Its generators are the letters of this alphabet,


### PR DESCRIPTION
Previous text was "Also see Chapter 51." which makes no sense within that chapter - so now refers to Chapter 37.