### PR TITLE
fastpath for `a:=mat[i,j]` and `mat[i,j]:=a`

### DIFF
--- a/doc/ref/lists.xml
+++ b/doc/ref/lists.xml
@@ -104,6 +104,7 @@ may have to be paid (see&nbsp;<Ref Func="ConstantTimeAccessList"/>).
 <Index Subkey="operation">list boundedness test</Index>
 <Index Subkey="operation">list assignment</Index>
 <Index Subkey="operation">list unbind</Index>
+
 <ManSection>
 <Oper Name="\[\]" Arg='list, ix'/>
 <Oper Name="IsBound\[\]" Arg='list, ix'/>
@@ -128,14 +129,6 @@ which clearly will usually be preferred;
 the former is useful mainly if one wants to access the operation itself,
 for example if one wants to install a method for element access in a
 special kind of lists.
-<P/>
-The syntax <C><A>list</A>[ <A>ix1</A>, <A>ix2</A>,.... <A>ixn</A>
-]</C>, with two or more indices is treated as a shorthand for
-<C><A>list</A>[[ <A>ix1</A>, <A>ix2</A>,.... <A>ixn</A>]]</C>
-
-This is intended to provide a nicer syntax for accessing elements of
-matrices and tensors.
-
 <P/>
 Similarly,
 <Ref Oper="IsBound\[\]"/> is used explicitly mainly in method installations.
@@ -174,11 +167,8 @@ gap> l := [ 2, 3, 5, 7, 11, 13 ];;  l[1];  l[2];  l[6];
 If <A>list</A> is not a built-in list, or <A>ix</A> does not evaluate to a
 positive integer, method selection is invoked to try and find a way of
 indexing <A>list</A> with index <A>ix</A>. If this fails, or the
-selected method finds that
-<C><A>list</A>[<A>ix</A>]</C> is unbound, an error is signalled.
-<P/>
-<Index>multiple indices</Index>
-<C><A>list</A>[ <A>ix1</A>,<A>ix2</A>,...]</C> <P/> is a short-hand for <C><A>list</A>[[<A>ix1</A>,<A>ix2</A>,...]]</C>
+selected method finds that <C><A>list</A>[<A>ix</A>]</C> is unbound,
+an error is signalled.
 <P/>
 
 <Index>sublist</Index>
@@ -322,13 +312,12 @@ thus this list must be mutable
 See&nbsp;<Ref Sect="Identical Lists"/> for subtleties of changing lists.
 <P/>
 If <A>list</A> does not evaluate to a list, <A>pos</A> does not evaluate to a
-positive integer or <A>object</A> is a call to a function which does not
+positive integer, method selection is invoked to try and find a way of
+indexing <A>list</A> with index <A>pos</A>. If this fails, or the
+selected method finds that <C><A>list</A>[<A>pos</A>]</C> is unbound,
+or if <A>object</A> is a call to a function which does not
 return a value (for example <C>Print</C>) an error is signalled.
 <P/>
-<Index Subkey="assignment">multiple indices</Index>
-<C><A>list</A>[ <A>ix1</A>,<A>ix2</A>,...] := <A>obj</A></C>
-<P/> is a short-hand for <C><A>list</A>[[<A>ix1</A>,<A>ix2</A>,...]]
-:= <A>obj</A></C>.<P/>
 <Index Subkey="assignment">sublist</Index>
 <C><A>list</A>{ <A>poss</A> } := <A>objects</A>;</C>
 <P/>

--- a/hpcgap/lib/mat8bit.gi
+++ b/hpcgap/lib/mat8bit.gi
@@ -67,7 +67,7 @@ end);
 #M  Length( <mat> )
 ##
 
-InstallOtherMethod( Length, "For a compressed MatFFE", 
+InstallOtherMethod( Length, "For a compressed MatFFE",
         true, [IsList and Is8BitMatrixRep], 0, m->m![1]);
 
 #############################################################################
@@ -75,9 +75,19 @@ InstallOtherMethod( Length, "For a compressed MatFFE",
 #M  <mat> [ <pos> ]
 ##
 
-InstallOtherMethod( \[\],  "For a compressed MatFFE", 
+InstallOtherMethod( \[\],  "For a compressed MatFFE",
         [IsList and Is8BitMatrixRep, IsPosInt],
         ELM_MAT8BIT
+        );
+
+#############################################################################
+##
+#M  <mat> [ <pos1>, <pos2> ]
+##
+
+InstallMethod( \[\],  "For a compressed MatFFE",
+        [Is8BitMatrixRep, IsPosInt, IsPosInt],
+        MAT_ELM_MAT8BIT
         );
 
 #############################################################################
@@ -87,10 +97,20 @@ InstallOtherMethod( \[\],  "For a compressed MatFFE",
 ##  This may involve turning <mat> into a plain list, if <mat> does
 ##  not lie in the appropriate field.
 ##
-               
-InstallOtherMethod( \[\]\:\=,  "For a compressed MatFE", 
+
+InstallOtherMethod( \[\]\:\=,  "For a compressed MatFE",
         [IsMutable and IsList and Is8BitMatrixRep, IsPosInt, IsObject],
         ASS_MAT8BIT
+        );
+
+#############################################################################
+##
+#M  <mat> [ <pos1>, <pos2> ] := <val>
+##
+
+InstallMethod( \[\]\:\=,  "For a compressed MatFE",
+        [IsMutable and Is8BitMatrixRep, IsPosInt, IsPosInt, IsObject],
+        SET_MAT_ELM_MAT8BIT
         );
 
 #############################################################################

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -581,6 +581,11 @@ InstallOtherMethod( \[\], "for GF2 matrix",
       IsPosInt ],
     ELM_GF2MAT );
 
+InstallMethod( \[\], "for GF2 matrix",
+    [ IsGF2MatrixRep,
+      IsPosInt, IsPosInt ],
+    MAT_ELM_GF2MAT );
+
 
 #############################################################################
 ##
@@ -599,6 +604,13 @@ InstallOtherMethod( \[\]\:\=,
       IsPosInt,
       IsObject ],
     ASS_GF2MAT );
+
+InstallMethod( \[\]\:\=,
+    "for GF2 matrix",
+    [ IsGF2MatrixRep,
+      IsPosInt, IsPosInt,
+      IsObject ],
+    SET_MAT_ELM_GF2MAT );
 
 
 #############################################################################

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -140,18 +140,17 @@ InstallTrueMethod(HasLength,IsPlistRep);
 #############################################################################
 ##
 #O  IsBound( <list>[<pos>] )  . . . . . . . . test for an element from a list
-#O  IsBound( <list>[<ix1>,<ix2>,...] )  . . . . . . . . test for an element from a list
 ##
 ##  <#GAPDoc Label="IsBound_list">
 ##  <ManSection>
 ##  <Oper Name="IsBound" Arg='list[n]' Label="for a list index"/>
-##  <Oper Name="IsBound" Arg='list[ix1,ix2,...]' Label="for multiple indices"/>
 ##
 ##  <Description>
 ##  <Ref Func="IsBound" Label="for a list index"/> returns <K>true</K>
-##  if the list <A>list</A> has a element at index <A>n</A>,
+##  if the list <A>list</A> has an element at index <A>n</A>,
 ##  and <K>false</K> otherwise.
-##  <A>list</A> must evaluate to a list, otherwise an error is signalled.
+##  <A>list</A> must evaluate to a list, or to an object for which a suitable
+##  method for <C>IsBound\[\]</C> has been installed, otherwise an error is signalled.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> l := [ , 2, 3, , 5, , 7, , , , 11 ];;
@@ -162,9 +161,6 @@ InstallTrueMethod(HasLength,IsPlistRep);
 ##  gap> IsBound( l[101] );
 ##  false
 ##  ]]></Example>
-##
-##  <C>IsBound(<A>list</A>[<A>ix1</A>,<A>ix2</A>,...])</C> is a short-hand for
-##  <C>IsBound(<A>list</A>[[<A>ix1</A>,<A>ix2</A>,...]])</C>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -208,17 +204,17 @@ DeclareOperationKernel( "Elm0List",
 ##  <#GAPDoc Label="Unbind_list">
 ##  <ManSection>
 ##  <Oper Name="Unbind" Arg='list[n]' Label="unbind a list entry"/>
-##  <Oper Name="Unbind" Arg='list[ix1,ix2,...]' Label="for multiple indices"/>
 ##
 ##  <Description>
-##  <Ref Func="Unbind" Label="unbind a list entry"/> deletes the element with index
-##  <A>n</A> in the mutable list <A>list</A>.  That is, after
+##  <Ref Func="Unbind" Label="unbind a list entry"/> deletes the element with
+##  index <A>n</A> in the mutable list <A>list</A>.  That is, after
 ##  execution of <Ref Func="Unbind" Label="unbind a list entry"/>,
 ##  <A>list</A> no longer has an assigned value with index <A>n</A>.
 ##  Thus <Ref Func="Unbind" Label="unbind a list entry"/> can be used to
 ##  produce holes in a list.
 ##  Note that it is not an error to unbind a nonexistant list element.
-##  <A>list</A> must evaluate to a list, otherwise an error is signalled.
+##  <A>list</A> must evaluate to a list, or to an object for which a suitable
+##  method for <C>Unbind\[\]</C> has been installed, otherwise an error is signalled.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> l := [ , 2, 3, 5, , 7, , , , 11 ];;
@@ -236,8 +232,6 @@ DeclareOperationKernel( "Elm0List",
 ##  and there would be no way to tell
 ##  <Ref Func="Unbind" Label="unbind a list entry"/>
 ##  which component to remove.
-##  <C>Unbind(<A>list</A>[<A>ix1</A>,<A>ix2</A>,...])</C> is a short-hand for
-##  <C>Unbind(<A>list</A>[[<A>ix1</A>,<A>ix2</A>,...]])</C>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -64,7 +64,7 @@ end);
 #M  Length( <mat> )
 ##
 
-InstallOtherMethod( Length, "For a compressed MatFFE", 
+InstallOtherMethod( Length, "For a compressed MatFFE",
         true, [IsList and Is8BitMatrixRep], 0, m->m![1]);
 
 #############################################################################
@@ -72,9 +72,19 @@ InstallOtherMethod( Length, "For a compressed MatFFE",
 #M  <mat> [ <pos> ]
 ##
 
-InstallOtherMethod( \[\],  "For a compressed MatFFE", 
+InstallOtherMethod( \[\],  "For a compressed MatFFE",
         [IsList and Is8BitMatrixRep, IsPosInt],
         ELM_MAT8BIT
+        );
+
+#############################################################################
+##
+#M  <mat> [ <pos1>, <pos2> ]
+##
+
+InstallMethod( \[\],  "For a compressed MatFFE",
+        [Is8BitMatrixRep, IsPosInt, IsPosInt],
+        MAT_ELM_MAT8BIT
         );
 
 #############################################################################
@@ -84,10 +94,20 @@ InstallOtherMethod( \[\],  "For a compressed MatFFE",
 ##  This may involve turning <mat> into a plain list, if <mat> does
 ##  not lie in the appropriate field.
 ##
-               
-InstallOtherMethod( \[\]\:\=,  "For a compressed MatFE", 
+
+InstallOtherMethod( \[\]\:\=,  "For a compressed MatFE",
         [IsMutable and IsList and Is8BitMatrixRep, IsPosInt, IsObject],
         ASS_MAT8BIT
+        );
+
+#############################################################################
+##
+#M  <mat> [ <pos1>, <pos2> ] := <val>
+##
+
+InstallMethod( \[\]\:\=,  "For a compressed MatFE",
+        [IsMutable and Is8BitMatrixRep, IsPosInt, IsPosInt, IsObject],
+        SET_MAT_ELM_MAT8BIT
         );
 
 #############################################################################

--- a/lib/matblock.gi
+++ b/lib/matblock.gi
@@ -167,6 +167,29 @@ InstallMethod( \[\],
     return row;
     end );
 
+#############################################################################
+##
+#M  \[\]( <blockmat>, <row>, <col> ) . . . . . . . . . . . for a block matrix
+##
+InstallOtherMethod( \[\],
+    "for an ordinary block matrix and two positive integers",
+    [ IsOrdinaryMatrix and IsBlockMatrixRep, IsPosInt, IsPosInt ],
+    function( blockmat, row, col )
+    local block_row, block_col, block;
+
+    # `n-1 = qr[1] * blockmat!.rpb + qr[2]'.
+    block_row := QuoInt(row - 1, blockmat!.rpb) + 1;
+    block_col := QuoInt(col - 1, blockmat!.cpb) + 1;
+    block := First(blockmat!.blocks, b -> b[1] = block_row and
+                                          b[2] = block_col);
+    if block = fail then
+        return blockmat!.zero;
+    fi;
+    row := row - (block_row - 1) * blockmat!.rpb;
+    col := col - (block_col - 1) * blockmat!.cpb;
+    return block[3][row,col];
+    end );
+
 
 #############################################################################
 ##

--- a/lib/matint.gi
+++ b/lib/matint.gi
@@ -177,7 +177,7 @@ local k,g,b,ii,m1,m2,t,tt,si,n,m,i,j,r,jj,piv,d,gt,tmp,A,T,TT,kk;
     T := NullMat(n,m);
     for j in [1..m] do
       for i in [1..Minimum(r,j)] do
-        T[i][j]:=R[i][piv[j]];
+        T[i,j]:=R[i,piv[j]];
       od;
     od;
   fi;
@@ -188,13 +188,13 @@ local k,g,b,ii,m1,m2,t,tt,si,n,m,i,j,r,jj,piv,d,gt,tmp,A,T,TT,kk;
   for k in [1..m] do
     Info(InfoMatInt,2,"SNFofREF - working on column ",k);
     if k<=r then
-      d := d*AbsInt(T[k][k]);
+      d := d*AbsInt(T[k,k]);
       Apply(T[k],x->x mod (2*d));
     fi;
 
     t := Minimum(k,r);
     for i in [t-1,t-2..si] do
-      t := MATINTmgcdex(A[i],T[i][k],[T[i+1][k]])[1];
+      t := MATINTmgcdex(A[i],T[i,k],[T[i+1,k]])[1];
       if t<>0 then
         AddRowVector(T[i],T[i+1],t);
         Apply(T[i],x->x mod A[i]);
@@ -202,21 +202,21 @@ local k,g,b,ii,m1,m2,t,tt,si,n,m,i,j,r,jj,piv,d,gt,tmp,A,T,TT,kk;
     od;
 
     for i in [si..Minimum(k-1,r)] do
-      g := Gcdex(A[i],T[i][k]);
-      T[i][k] := 0;
+      g := Gcdex(A[i],T[i,k]);
+      T[i,k] := 0;
       if g.gcd<>A[i] then
         b := QuoInt(A[i],g.gcd);
         A[i] := g.gcd;
         for ii in [i+1..Minimum(k-1,r)] do
-          AddRowVector(T[ii],T[i],-g.coeff2*QuoInt(T[ii][k],A[i]) mod A[ii]);
-          T[ii][k] := b*T[ii][k];
+          AddRowVector(T[ii],T[i],-g.coeff2*QuoInt(T[ii,k],A[i]) mod A[ii]);
+          T[ii,k] := b*T[ii,k];
 
           Apply(T[ii],x->x mod A[ii]);
         od;
         if k<=r then
-          t := g.coeff2*QuoInt(T[k][k],g.gcd);
+          t := g.coeff2*QuoInt(T[k,k],g.gcd);
           AddRowVector(T[k],T[i],-t);
-          T[k][k]:=b*T[k][k];
+          T[k,k]:=b*T[k,k];
         fi;
         Apply(T[i],x->x mod A[i]);
         if A[i]=1 then si := i+1; fi;
@@ -224,13 +224,13 @@ local k,g,b,ii,m1,m2,t,tt,si,n,m,i,j,r,jj,piv,d,gt,tmp,A,T,TT,kk;
     od;
 
     if k<=r then
-      A[k] := AbsInt(T[k][k]);
+      A[k] := AbsInt(T[k,k]);
       Apply(T[k],x->x mod A[k]);
     fi;
 
   od;
 
-  for i in [1..r] do T[i][i] := A[i]; od;
+  for i in [1..r] do T[i,i] := A[i]; od;
 
   return T;
 
@@ -313,7 +313,7 @@ local opt, sig, n, m, A, C, Q, B, P, r, c2, rp, c1, j, k, N, L, b, a, g, c,
 
   #Embed arg[1] in 2 larger "id" matrix
   n := Length(arg[1])+2;
-  m := Length(arg[1][1])+2;
+  m := Length(arg[1,1])+2;
   k:=ListWithIdenticalEntries(m,0);
   if opt[5] then
     # change the matrix
@@ -326,21 +326,21 @@ local opt, sig, n, m, A, C, Q, B, P, r, c2, rp, c1, j, k, N, L, b, a, g, c,
     A := [];
     for i in [2..n-1] do
       #A[i] := [0];
-      #Append(A[i],arg[1][i-1]);
-      #A[i][m] := 0;
+      #Append(A[i],arg[1,i-1]);
+      #A[i,m] := 0;
       A[i]:=ShallowCopy(k);
-      A[i]{[2..m-1]}:=arg[1][i-1];
+      A[i]{[2..m-1]}:=arg[1,i-1];
     od;
   fi;
   A[1]:=ShallowCopy(k);
   A[n]:=k;
-  A[1][1] := 1;
-  A[n][m] := 1;
+  A[1,1] := 1;
+  A[n,m] := 1;
 
   if opt[3] then
     C := IdentityMat(n);
     Q := NullMat(n,n);
-    Q[1][1] := 1;
+    Q[1,1] := 1;
   fi;
 
   if opt[1] and opt[4] then
@@ -356,12 +356,12 @@ local opt, sig, n, m, A, C, Q, B, P, r, c2, rp, c1, j, k, N, L, b, a, g, c,
     r := r+1;
     c1 := c2;
     rp[r] := c1;
-    if opt[3] then Q[r+1][r+1] := 1; fi;
+    if opt[3] then Q[r+1,r+1] := 1; fi;
 
     j := c1+1;
     while j<=m do
       k := r+1;
-      while k<=n and A[r][c1]*A[k][j]=A[k][c1]*A[r][j] do k := k+1; od;
+      while k<=n and A[r,c1]*A[k,j]=A[k,c1]*A[r,j] do k := k+1; od;
       if k<=n then c2 := j; j := m; fi;
       j := j+1;
     od;
@@ -373,75 +373,75 @@ local opt, sig, n, m, A, C, Q, B, P, r, c2, rp, c1, j, k, N, L, b, a, g, c,
       Add(L,c2);
       for j in L do
         if j=c2 then
-          b:=A[r][c2];a:=A[r][c1];
+          b:=A[r,c2];a:=A[r,c1];
           for i in [r+1..n] do
             if b<>1 then
-              g:=Gcdex(b,A[i][c2]);
+              g:=Gcdex(b,A[i,c2]);
               b:=g.gcd;
-              a:=g.coeff1*a+g.coeff2*A[i][c1];
+              a:=g.coeff1*a+g.coeff2*A[i,c1];
             fi;
           od;
           N:=0;
           for i in [r..n] do
-            if N<>1 then N:=GcdInt(N,A[i][c1]-QuoInt(A[i][c2],b)*a);fi;
+            if N<>1 then N:=GcdInt(N,A[i,c1]-QuoInt(A[i,c2],b)*a);fi;
           od;
         else
-          c := MATINTmgcdex(N,A[r][j],A{[r+1..n]}[j]);
-          b := A[r][j]+c*A{[r+1..n]}[j];
-          a := A[r][c1]+c*A{[r+1..n]}[c1];
+          c := MATINTmgcdex(N,A[r,j],A{[r+1..n]}[j]);
+          b := A[r,j]+c*A{[r+1..n]}[j];
+          a := A[r,c1]+c*A{[r+1..n]}[c1];
         fi;
         t := MATINTmgcdex(N,a,[b])[1];
-        tmp := A[r][c1]+t*A[r][j];
-        while tmp=0 or tmp*A[k][c2]=(A[k][c1]+t*A[k][j])*A[r][c2] do
+        tmp := A[r,c1]+t*A[r,j];
+        while tmp=0 or tmp*A[k,c2]=(A[k,c1]+t*A[k,j])*A[r,c2] do
           t := t+1+MATINTmgcdex(N,a+t*b+b,[b])[1];
-          tmp := A[r][c1]+t*A[r][j];
+          tmp := A[r,c1]+t*A[r,j];
         od;
         if t>0 then
-          for i in [1..n] do A[i][c1] := A[i][c1]+t*A[i][j]; od;
-          if opt[4] then B[j][c1] := B[j][c1]+t; fi;
+          for i in [1..n] do A[i,c1] := A[i,c1]+t*A[i,j]; od;
+          if opt[4] then B[j,c1] := B[j,c1]+t; fi;
         fi;
       od;
-      if A[r][c1]*A[k][c1+1]=A[k][c1]*A[r][c1+1] then
-        for i in [1..n] do A[i][c1+1] := A[i][c1+1]+A[i][c2]; od;
-        if opt[4] then B[c2][c1+1] := 1; fi;
+      if A[r,c1]*A[k,c1+1]=A[k,c1]*A[r,c1+1] then
+        for i in [1..n] do A[i,c1+1] := A[i,c1+1]+A[i,c2]; od;
+        if opt[4] then B[c2,c1+1] := 1; fi;
       fi;
       c2 := c1+1;
     fi;
 
-    c := MATINTmgcdex(AbsInt(A[r][c1]),A[r+1][c1],A{[r+2..n]}[c1]);
+    c := MATINTmgcdex(AbsInt(A[r,c1]),A[r+1,c1],A{[r+2..n]}[c1]);
     for i in [r+2..n] do
       if c[i-r-1]<>0 then
         AddRowVector(A[r+1],A[i],c[i-r-1]);
         if opt[3] then
-          C[r+1][i] := c[i-r-1];
+          C[r+1,i] := c[i-r-1];
           AddRowVector(Q[r+1],Q[i],c[i-r-1]);
         fi;
       fi;
     od;
 
     i := r+1;
-    while A[r][c1]*A[i][c2]=A[i][c1]*A[r][c2] do i := i+1; od;
+    while A[r,c1]*A[i,c2]=A[i,c1]*A[r,c2] do i := i+1; od;
     if i>r+1 then
-      c := MATINTmgcdex(AbsInt(A[r][c1]),A[r+1][c1]+A[i][c1],[A[i][c1]])[1]+1;;
+      c := MATINTmgcdex(AbsInt(A[r,c1]),A[r+1,c1]+A[i,c1],[A[i,c1]])[1]+1;;
       AddRowVector(A[r+1],A[i],c);
       if opt[3] then
-        C[r+1][i] := C[r+1][i]+c;
+        C[r+1,i] := C[r+1,i]+c;
         AddRowVector(Q[r+1],Q[i],c);
       fi;
     fi;
 
-    g := MATINTbezout(A[r][c1],A[r][c2],A[r+1][c1],A[r+1][c2]);
-    sig:=sig*SignInt(A[r][c1]*A[r+1][c2]-A[r][c2]*A[r+1][c1]);
+    g := MATINTbezout(A[r,c1],A[r,c2],A[r+1,c1],A[r+1,c2]);
+    sig:=sig*SignInt(A[r,c1]*A[r+1,c2]-A[r,c2]*A[r+1,c1]);
     A{[r,r+1]} := [[g.coeff1,g.coeff2],[g.coeff3,g.coeff4]]*A{[r,r+1]};
     if opt[3] then
       Q{[r,r+1]} := [[g.coeff1,g.coeff2],[g.coeff3,g.coeff4]]*Q{[r,r+1]};
     fi;
 
     for i in [r+2..n] do
-      q := QuoInt(A[i][c1],A[r][c1]);
+      q := QuoInt(A[i,c1],A[r,c1]);
       AddRowVector(A[i],A[r],-q);
       if opt[3] then AddRowVector(Q[i],Q[r],-q); fi;
-      q := QuoInt(A[i][c2],A[r+1][c2]);
+      q := QuoInt(A[i,c2],A[r+1,c2]);
       AddRowVector(A[i],A[r+1],-q);
       if opt[3] then AddRowVector(Q[i],Q[r+1],-q); fi;
     od;
@@ -469,15 +469,15 @@ local opt, sig, n, m, A, C, Q, B, P, r, c2, rp, c1, j, k, N, L, b, a, g, c,
     for i in [r, r-1 .. 1] do
       Info(InfoMatInt,2,"DoNFIM - reducing row ",i);
       for j in [i+1 .. r+1] do
-        q := QuoInt(A[i][rp[j]]-(A[i][rp[j]] mod A[j][rp[j]]),A[j][rp[j]]);
+        q := QuoInt(A[i,rp[j]]-(A[i,rp[j]] mod A[j,rp[j]]),A[j,rp[j]]);
         AddRowVector(A[i],A[j],-q);
         if opt[3] then AddRowVector(Q[i],Q[j],-q); fi;
       od;
       if opt[1] and i<r then
         for j in [i+1..m] do
-          q := QuoInt(A[i][j],A[i][i]);
-          for k in [1..i] do A[k][j] := A[k][j]-q*A[k][i]; od;
-          if opt[4] then P[i][j] := -q; fi;
+          q := QuoInt(A[i,j],A[i,i]);
+          for k in [1..i] do A[k,j] := A[k,j]-q*A[k,i]; od;
+          if opt[4] then P[i,j] := -q; fi;
         od;
       fi;
     od;
@@ -486,47 +486,47 @@ local opt, sig, n, m, A, C, Q, B, P, r, c2, rp, c1, j, k, N, L, b, a, g, c,
   #Smith w/ row but not col transforms
   if opt[1] and opt[3] and not opt[4] then
     for i in [1..r-1] do
-      t := A[i][i];
+      t := A[i,i];
       A[i] := List([1..m],x->0);
-      A[i][i] := t;
+      A[i,i] := t;
     od;
     for j in [r+1..m-1] do
-      A[r][r] := GcdInt(A[r][r],A[r][j]);
-      A[r][j] := 0;
+      A[r,r] := GcdInt(A[r,r],A[r,j]);
+      A[r,j] := 0;
     od;
   fi;
 
   #smith w/ col transforms
   if opt[1] and opt[4] and r<m-1 then
-    c := MATINTmgcdex(A[r][r],A[r][r+1],A[r]{[r+2..m-1]});
+    c := MATINTmgcdex(A[r,r],A[r,r+1],A[r]{[r+2..m-1]});
     for j in [r+2..m-1] do
-      A[r][r+1] := A[r][r+1]+c[j-r-1]*A[r][j];
-      B[j][r+1] := c[j-r-1];
-      for i in [1..r] do P[i][r+1] := P[i][r+1]+c[j-r-1]*P[i][j]; od;
+      A[r,r+1] := A[r,r+1]+c[j-r-1]*A[r,j];
+      B[j,r+1] := c[j-r-1];
+      for i in [1..r] do P[i,r+1] := P[i,r+1]+c[j-r-1]*P[i,j]; od;
     od;
     P[r+1] := List([1..m],x->0);
-    P[r+1][r+1] := 1;
-    g := Gcdex(A[r][r],A[r][r+1]);
-    A[r][r] := g.gcd;
-    A[r][r+1] := 0;
+    P[r+1,r+1] := 1;
+    g := Gcdex(A[r,r],A[r,r+1]);
+    A[r,r] := g.gcd;
+    A[r,r+1] := 0;
     for i in [1..r+1] do
-      t := P[i][r];
-      P[i][r] := P[i][r]*g.coeff1+P[i][r+1]*g.coeff2;
-      P[i][r+1] := t*g.coeff3+P[i][r+1]*g.coeff4;
+      t := P[i,r];
+      P[i,r] := P[i,r]*g.coeff1+P[i,r+1]*g.coeff2;
+      P[i,r+1] := t*g.coeff3+P[i,r+1]*g.coeff4;
     od;
     for j in [r+2..m-1] do
-      q := QuoInt(A[r][j],A[r][r]);
-      for i in [1..r+1] do P[i][j] := P[i][j]-q*P[i][r]; od;
-      A[r][j] := 0;
+      q := QuoInt(A[r,j],A[r,r]);
+      for i in [1..r+1] do P[i,j] := P[i,j]-q*P[i,r]; od;
+      A[r,j] := 0;
     od;
     for i in [r+2..m-1] do
       P[i] := List([1..m],x->0);
-      P[i][i] := 1;
+      P[i,i] := 1;
     od;
   fi;
 
   #row transforms finisher
-  if opt[3] then for i in [r+2..n] do Q[i][i]:= 1; od; fi;
+  if opt[3] then for i in [r+2..n] do Q[i,i]:= 1; od; fi;
 
   for i in [2..n-1] do
     A[i-1]:=A[i]{[2..m-1]};
@@ -807,7 +807,7 @@ local F, S, M, r, T, R;
   M := r.coltrans^-1 * F;
   R := rec( complement := BaseIntMat( M{[1+r.rank..Length(M)]} ),
             sub := r.rowtrans * T * F,
-            moduli := List( [1..r.rank], i -> r.normal[i][i] ) );
+            moduli := List( [1..r.rank], i -> r.normal[i,i] ) );
   return R;
 end);
 
@@ -852,7 +852,7 @@ local norm, rs, t, M, r;
   M := Concatenation( rs, [v] );
   r := NormalFormIntMat( M, 4 );
   if r.rank = Length(r.normal) or
-     r.rowtrans[Length(M)][Length(M)] <> 1 then
+     r.rowtrans[Length(M),Length(M)] <> 1 then
     return fail;
   fi;
   return -r.rowtrans[Length(M)]{[1..r.rank]} * t{[1..r.rank]};
@@ -888,7 +888,7 @@ local norm, rs, t, M, r, kern, len;
   M := Concatenation( rs, [v] );
   r := NormalFormIntMat( M, 4 );
   if r.rank = Length(r.normal) or
-     r.rowtrans[Length(M)][Length(M)] <> 1 then
+     r.rowtrans[Length(M),Length(M)] <> 1 then
     return [fail,kern];
   fi;
   return [-r.rowtrans[Length(M)]{[1..r.rank]} * t{[1..r.rank]}, kern];
@@ -918,10 +918,10 @@ local sig, n, m, A, r, c2, c1, j, k, c, i, g, q;
   for i in [2..n-1] do
     A[i] := [0];
     Append(A[i],mat[i-1]);
-    A[i][m] := 0;
+    A[i,m] := 0;
   od;
   A[n] := List([1..m],x->0);
-  A[1][1] := 1;      A[n][m] := 1;
+  A[1,1] := 1;      A[n,m] := 1;
 
   r := 0;    c2 := 1;
   while m>c2 do
@@ -932,12 +932,12 @@ local sig, n, m, A, r, c2, c1, j, k, c, i, g, q;
     j := c1+1;
     while j<=m do
       k := r+1;
-      while k<=n and A[r][c1]*A[k][j]=A[k][c1]*A[r][j] do k := k+1; od;
+      while k<=n and A[r,c1]*A[k,j]=A[k,c1]*A[r,j] do k := k+1; od;
       if k<=n then c2 := j; j := m; fi;
       j := j+1;
     od;
 
-    c := MATINTmgcdex(AbsInt(A[r][c1]),A[r+1][c1],A{[r+2..n]}[c1]);
+    c := MATINTmgcdex(AbsInt(A[r,c1]),A[r+1,c1],A{[r+2..n]}[c1]);
     for i in [r+2..n] do
       if c[i-r-1]<>0 then
         AddRowVector(A[r+1],A[i],c[i-r-1]);
@@ -945,30 +945,30 @@ local sig, n, m, A, r, c2, c1, j, k, c, i, g, q;
     od;
 
     i := r+1;
-    while A[r][c1]*A[i][c2]=A[i][c1]*A[r][c2] do
+    while A[r,c1]*A[i,c2]=A[i,c1]*A[r,c2] do
       i := i+1;
     od;
 
     if i>r+1 then
-      c := MATINTmgcdex(AbsInt(A[r][c1]),A[r+1][c1]+A[i][c1],[A[i][c1]])[1]+1;;
+      c := MATINTmgcdex(AbsInt(A[r,c1]),A[r+1,c1]+A[i,c1],[A[i,c1]])[1]+1;;
       AddRowVector(A[r+1],A[i],c);
     fi;
 
-    g := MATINTbezout(A[r][c1],A[r][c2],A[r+1][c1],A[r+1][c2]);
-    sig:=sig*SignInt(A[r][c1]*A[r+1][c2]-A[r][c2]*A[r+1][c1]);
+    g := MATINTbezout(A[r,c1],A[r,c2],A[r+1,c1],A[r+1,c2]);
+    sig:=sig*SignInt(A[r,c1]*A[r+1,c2]-A[r,c2]*A[r+1,c1]);
     if sig=0 then return 0;fi;
     A{[r,r+1]} := [[g.coeff1,g.coeff2],[g.coeff3,g.coeff4]]*A{[r,r+1]};
 
     for i in [r+2..n] do
-      q := QuoInt(A[i][c1],A[r][c1]);
+      q := QuoInt(A[i,c1],A[r,c1]);
       AddRowVector(A[i],A[r],-q);
-      q := QuoInt(A[i][c2],A[r+1][c2]);
+      q := QuoInt(A[i,c2],A[r+1,c2]);
       AddRowVector(A[i],A[r+1],-q);
     od;
   od;
 
   for i in [2..r+1] do
-    sig:=sig*A[i][i];
+    sig:=sig*A[i,i];
   od;
 
   return sig;

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -481,9 +481,11 @@ DeclareOperation( "CopySubMatrix", [IsMatrixObj,IsMatrixObj,
 ############################################################################
 
 DeclareOperation( "MatElm", [IsMatrixObj,IsPosInt,IsPosInt] );
+DeclareOperation( "[]", [IsMatrixObj,IsPosInt,IsPosInt] );
 # second and third arguments are row and column index
 
 DeclareOperation( "SetMatElm", [IsMatrixObj,IsPosInt,IsPosInt,IsObject] );
+DeclareOperation( "[]:=", [IsMatrixObj,IsPosInt,IsPosInt,IsObject] );
 # second and third arguments are row and column index
 
 

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -23,6 +23,15 @@ InstallMethod(Zero,
         [IsRectangularTable and IsAdditiveElementWithZeroCollColl and IsInternalRep],
         ZERO_ATTR_MAT);
 
+# Fallback methods for matrix entry access. We lower the rank
+# so that these are only used as a last resort.
+InstallOtherMethod( \[\], [ IsMatrix, IsPosInt, IsPosInt ],
+    -RankFilter(IsMatrix),
+    function (m,i,j) return m[i][j]; end );
+InstallOtherMethod( \[\]\:\=, [ IsMatrix and IsMutable, IsPosInt, IsPosInt, IsObject ],
+    -RankFilter(IsMatrix),
+    function (m,i,j,o) m[i][j]:=o; end );
+
 #############################################################################
 ##
 #F  PrintArray( <array> ) . . . . . . . . . . . . . . . . pretty print matrix

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -127,17 +127,17 @@ InstallMethod( IsGeneralizedCartanMatrix,
 
     n:= Length( A );
     for i in [ 1 .. n ] do
-      if A[i][i] <> 2 then
+      if A[i,i] <> 2 then
         return false;
       fi;
     od;
     for i in [ 1 .. n ] do
       for j in [ i+1 .. n ] do
-        if not IsInt( A[i][j] ) or not IsInt( A[j][i] )
-           or 0 < A[i][j] or 0 < A[j][i] then
+        if not IsInt( A[i,j] ) or not IsInt( A[j,i] )
+           or 0 < A[i,j] or 0 < A[j,i] then
           return false;
-        elif  ( A[i][j] = 0 and A[j][i] <> 0 )
-           or ( A[j][i] = 0 and A[i][j] <> 0 ) then
+        elif  ( A[i,j] = 0 and A[j,i] <> 0 )
+           or ( A[j,i] = 0 and A[i,j] <> 0 ) then
           return false;
         fi;
       od;
@@ -156,10 +156,10 @@ InstallMethod( IsDiagonalMat,
     function( mat )
    local  i, j,z;
     if IsEmpty(mat) then return true;fi;
-    z:=Zero(mat[1][1]);
+    z:=Zero(mat[1,1]);
     for i  in [ 1 .. Length( mat ) ]  do
         for j  in [ 1 .. Length( mat[i] ) ]  do
-            if mat[i][j] <> z and i <> j  then
+            if mat[i,j] <> z and i <> j  then
                 return false;
             fi;
         od;
@@ -180,10 +180,10 @@ InstallMethod( IsUpperTriangularMat,
     function( mat )
     local  i, j,z;
     if IsEmpty(mat) then return true;fi;
-    z:=Zero(mat[1][1]);
+    z:=Zero(mat[1,1]);
     for i  in [ 1 .. Length( mat ) ]  do
         for j  in [ 1 .. i-1]  do
-            if mat[i][j] <> z  then
+            if mat[i,j] <> z  then
                 return false;
             fi;
         od;
@@ -201,10 +201,10 @@ InstallMethod( IsLowerTriangularMat,
     function( mat )
     local  i, j,z;
     if IsEmpty(mat) then return true;fi;
-    z:=Zero(mat[1][1]);
+    z:=Zero(mat[1,1]);
     for i  in [ 1 .. Length( mat ) ]  do
         for j  in [ i+1 .. Length( mat[i] ) ]  do
-            if mat[i][j] <> z  then
+            if mat[i,j] <> z  then
                 return false;
             fi;
         od;
@@ -222,11 +222,11 @@ InstallGlobalFunction( DiagonalOfMat, function ( mat )
     diag := [];
     i := 1;
     while i <= Length(mat) and i <= Length(mat[1]) do
-        diag[i] := mat[i][i];
+        diag[i] := mat[i,i];
         i := i + 1;
     od;
     while 1 <= Length(mat) and i <= Length(mat[1]) do
-        diag[i] := mat[1][1] - mat[1][1];
+        diag[i] := mat[1,1] - mat[1,1];
         i := i + 1;
     od;
     return diag;
@@ -558,7 +558,7 @@ function( m )
     if Length(m[1]) = 0 then
         TryNextMethod();
     fi;
-    if  IsZmodnZObj(m[1][1]) then
+    if  IsZmodnZObj(m[1,1]) then
       # this case mostly applies to large characteristic, in
       # which the regular code for FFE elements does not work
       # (e.g. it tries to create the range [2..chr], which
@@ -566,12 +566,12 @@ function( m )
       Print("ZmodnZ matrix:\n");
       t:=List(m,i->List(i,i->i![1]));
       Display(t);
-      Print("modulo ",Characteristic(m[1][1]),"\n");
+      Print("modulo ",Characteristic(m[1,1]),"\n");
     else
       # get the degree and characteristic
       deg  := Lcm( List( m, DegreeFFE ) );
-      chr  := Characteristic(m[1][1]);
-      zero := Zero(m[1][1]);
+      chr  := Characteristic(m[1,1]);
+      zero := Zero(m[1,1]);
 
       # if it is a finite prime field,  use integers for display
       if deg = 1  then
@@ -644,7 +644,7 @@ InstallMethod( Display,
     "for matrix over Integers mod n",
     [ IsZmodnZObjNonprimeCollColl and IsMatrix ],
     function( m )
-    Print( "matrix over Integers mod ", Characteristic( m[1][1] ),
+    Print( "matrix over Integers mod ", Characteristic( m[1,1] ),
            ":\n" );
     Display( List( m, i -> List( i, i -> i![1] ) ) );
     end );
@@ -1095,7 +1095,7 @@ InstallMethod( Order, "ordinary matrix of finite field elements", true,
     if Length(mat) <> Length(mat[1]) then
         Error("Order of non-square matrix is not defined");
     fi;
-    o:=Characteristic(mat[1][1])^DegreeFFE(mat[1][1]); # size of field of
+    o:=Characteristic(mat[1,1])^DegreeFFE(mat[1,1]); # size of field of
                                                      # first entry
     o:=QuoInt(Length(mat),o)*5; 
 
@@ -1122,7 +1122,7 @@ InstallMethod( IsZero,
           row;    # loop over rows in 'obj'
 
     ncols:= DimensionsMat( mat )[2];
-    zero:= Zero( mat[1][1] );
+    zero:= Zero( mat[1,1] );
     for row in mat do
       if PositionNot( row, zero ) <= ncols then
         return false;
@@ -1205,10 +1205,10 @@ function( mat )
 
     # find the correct layer of <m>
     dim  := Length(mat);
-    zero := Zero(mat[1][1]);
+    zero := Zero(mat[1,1]);
     for i  in [ 1 .. dim-1 ]  do
         for j  in [ 1 .. dim-i ]  do
-            if mat[j][i+j] <> zero  then
+            if mat[j,i+j] <> zero  then
                 return i;
             fi;
         od;
@@ -1259,7 +1259,7 @@ InstallMethod( DeterminantMatDestructive,
 
     # check that the argument is a square matrix and get the size
     m := Length(mat);
-    zero := Zero(mat[1][1]);
+    zero := Zero(mat[1,1]);
     if m <> Length(mat[1])  then
         Error("DeterminantMat: <mat> must be a square matrix");
     fi;
@@ -1271,7 +1271,7 @@ InstallMethod( DeterminantMatDestructive,
         # find a nonzero entry in this column
         #N  26-Oct-91 martin if <mat> is a rational matrix look for a pivot
         j := i + 1;
-        while j <= m and mat[j][k] = zero  do j := j+1;  od;
+        while j <= m and mat[j,k] = zero  do j := j+1;  od;
 
         # if there is a nonzero entry
         if j <= m  then
@@ -1337,7 +1337,7 @@ function( mat )
     if m = 0 or m <> Length(mat[1])  then
         Error( "<mat> must be a square matrix at least 1x1" );
     fi;
-    zero := Zero(mat[1][1]);
+    zero := Zero(mat[1,1]);
 
     # normalize rows using the inverse
     if IsFFECollColl(mat)  then
@@ -1354,7 +1354,7 @@ function( mat )
 
         # look for a nonzero entry in this column
         j := k;
-        while j <= m and mat[j][k] = zero  do
+        while j <= m and mat[j,k] = zero  do
             j := j+1;
         od;
 
@@ -1469,10 +1469,10 @@ InstallMethod( DeterminantMatDivFree,
         ## initialze the final sum, the vertex set, initial parity
         ## and level indexes
         ##
-        zero := Zero(M[1][1]);
+        zero := Zero(M[1,1]);
         Vs := zero;
         V := [];
-        pmone := (-One(M[1][1]))^((n mod 2)+1);
+        pmone := (-One(M[1,1]))^((n mod 2)+1);
         clevel := 1; nlevel := 2;
 
         ##  Vertices are indexed [u,v,i] holding the (partial) monomials
@@ -1615,11 +1615,11 @@ local R,M,transform,divide,swaprow, swapcol, addcol, addrow, multcol, multrow, l
   addcol:=function(a,b,m)
   local i;
     for i in [1..l] do
-      M[i][a]:=M[i][a]+m*M[i][b];
+      M[i,a]:=M[i,a]+m*M[i,b];
     od;
     if transform then
       for i in [1..n] do
-        right[i][a]:=right[i][a]+m*right[i][b];
+        right[i,a]:=right[i,a]+m*right[i,b];
       od;
     fi;
   end;
@@ -1637,11 +1637,11 @@ local R,M,transform,divide,swaprow, swapcol, addcol, addrow, multcol, multrow, l
   multcol:=function(a,m)
   local i;
     for i in [1..l] do
-      M[i][a]:=M[i][a]*m;
+      M[i,a]:=M[i,a]*m;
     od;
     if transform then
       for i in [1..n] do
-        right[i][a]:=right[i][a]*m;
+        right[i,a]:=right[i,a]*m;
       od;
     fi;
   end;
@@ -1664,9 +1664,9 @@ local R,M,transform,divide,swaprow, swapcol, addcol, addrow, multcol, multrow, l
       for i in [start+1..n] do
         a:=i;
         b:=start;
-        if not IsZero(M[start][b]) then
+        if not IsZero(M[start,b]) then
           repeat
-            qr:=QuotientRemainder(R,M[start][a],M[start][b]);
+            qr:=QuotientRemainder(R,M[start,a],M[start,b]);
             addcol(a,b,-qr[1]);
             c:=a;a:=b;b:=c;
           until IsZero(qr[2]);
@@ -1676,7 +1676,7 @@ local R,M,transform,divide,swaprow, swapcol, addcol, addrow, multcol, multrow, l
         fi;
 
         # normalize
-        qr:=StandardAssociateUnit(R,M[start][start]);
+        qr:=StandardAssociateUnit(R,M[start,start]);
         multcol(start,qr);
 
       od;
@@ -1684,9 +1684,9 @@ local R,M,transform,divide,swaprow, swapcol, addcol, addrow, multcol, multrow, l
       for i in [start+1..l] do
         a:=i;
         b:=start;
-        if not IsZero(M[b][start]) then
+        if not IsZero(M[b,start]) then
           repeat
-            qr:=QuotientRemainder(R,M[a][start],M[b][start]);
+            qr:=QuotientRemainder(R,M[a,start],M[b,start]);
             addrow(a,b,-qr[1]);
             c:=a;a:=b;b:=c;
           until IsZero(qr[2]);
@@ -1695,11 +1695,11 @@ local R,M,transform,divide,swaprow, swapcol, addcol, addrow, multcol, multrow, l
           fi;
         fi;
 
-        qr:=StandardAssociateUnit(R,M[start][start]);
+        qr:=StandardAssociateUnit(R,M[start,start]);
         multrow(start,qr);
 
       od;
-    until ForAll([start+1..n],i->IsZero(M[start][i]));
+    until ForAll([start+1..n],i->IsZero(M[start,i]));
   end;
 
   start:=1;
@@ -1712,8 +1712,8 @@ local R,M,transform,divide,swaprow, swapcol, addcol, addrow, multcol, multrow, l
 
     for i in [start..l] do
       for j in [start..n] do
-        if not IsZero(M[i][j]) then
-          ed:=EuclideanDegree(R,M[i][j]);
+        if not IsZero(M[i,j]) then
+          ed:=EuclideanDegree(R,M[i,j]);
           if ed<d then
             d:=ed;
             posi:=i;
@@ -1739,7 +1739,7 @@ local R,M,transform,divide,swaprow, swapcol, addcol, addrow, multcol, multrow, l
           #make sure the pivot also divides the rest
           for i in [start+1..l] do
             for j in [start+1..n] do
-              if Quotient(M[i][j],M[start][start])=fail then
+              if Quotient(M[i,j],M[start,start])=fail then
                 alldivide:=false;
                 # do gcd
                 addrow(start,i,One(R));
@@ -1752,7 +1752,7 @@ local R,M,transform,divide,swaprow, swapcol, addcol, addrow, multcol, multrow, l
       fi;
 
       # normalize
-      qr:=StandardAssociateUnit(R,M[start][start]);
+      qr:=StandardAssociateUnit(R,M[start,start]);
       multcol(start,qr);
 
     fi;
@@ -1922,11 +1922,11 @@ InstallOtherMethod( MutableTransposedMat,
           if IsBound(t[i]) then
               if IsList(t[i]) then
                   for j in [1..Length(t[i])] do
-                      if IsBound(t[i][j]) then
+                      if IsBound(t[i,j]) then
                           if not IsBound(res[j]) then
                               res[j] := [];
                           fi;
-                          res[j][i] := t[i][j];
+                          res[j,i] := t[i,j];
                       fi;
                   od;
               else
@@ -1963,9 +1963,9 @@ InstallMethod( MutableTransposedMatDestructive,
     # swap the entries in the "square part" of the matrix.
     for i in [1..min] do
         for j in [i+1..min] do
-            store:= mat[i][j];
-            mat[i][j]:= mat[j][i];
-            mat[j][i]:= store;
+            store:= mat[i,j];
+            mat[i,j]:= mat[j,i];
+            mat[j,i]:= store;
         od;
     od;
 
@@ -1975,7 +1975,7 @@ InstallMethod( MutableTransposedMatDestructive,
         for i in [1..n-m] do
             store:= [ ];
             for j in [1..m] do
-                store[j]:= mat[j][m+i];
+                store[j]:= mat[j,m+i];
                 Unbind( mat[j][m+i] );
             od;
             Add( mat, store );
@@ -1988,7 +1988,7 @@ InstallMethod( MutableTransposedMatDestructive,
     if m > n then
         for i in [n+1..m] do
             for j in [1..n] do
-                mat[j][i]:= mat[i][j];
+                mat[j,i]:= mat[i,j];
             od;
             Unbind( mat[i] );
         od;
@@ -2038,15 +2038,15 @@ InstallMethod( TriangulizedNullspaceMatNT,
     TriangulizeMat( mat );
     m := Length(mat);
     n := Length(mat[1]);
-    zero := Zero( mat[1][1] );
-    one  := One( mat[1][1] );
+    zero := Zero( mat[1,1] );
+    one  := One( mat[1,1] );
     min := Minimum( m, n );
 
     # insert empty rows to bring the leading term of each row on the diagonal
     empty := 0*mat[1];
     i := 1;
     while i <= Length(mat)  do
-        if i < n  and mat[i][i] = zero  then
+        if i < n  and mat[i,i] = zero  then
             for k in Reversed([i..Minimum(Length(mat),n-1)])  do
                 mat[k+1] := mat[k];
             od;
@@ -2063,9 +2063,9 @@ InstallMethod( TriangulizedNullspaceMatNT,
     # by replacing this 0 by a -1, in  this  example  [2,-1,0,0], [2,0,3,-1].
     nullspace := [];
     for k  in Reversed([1..n]) do
-        if mat[k][k] = zero  then
+        if mat[k,k] = zero  then
             row := [];
-            for i  in [1..k-1]  do row[n-i+1] := -mat[i][k];  od;
+            for i  in [1..k-1]  do row[n-i+1] := -mat[i,k];  od;
             row[n-k+1] := one;
             for i  in [k+1..n]  do row[n-i+1] := zero;  od;
             ConvertToVectorRepNC( row );
@@ -2223,7 +2223,7 @@ InstallMethod( SemiEchelonMatDestructive,
     nrows:= Length( mat );
     ncols:= Length( mat[1] );
 
-    zero:= Zero( mat[1][1] );
+    zero:= Zero( mat[1,1] );
 
     heads:= ListWithIdenticalEntries( ncols, 0 );
     nzheads := [];
@@ -2317,7 +2317,7 @@ InstallMethod( SemiEchelonMatTransformationDestructive,
     
     f := DefaultFieldOfMatrix(mat);
     if f = fail then
-        f := mat[1][1];
+        f := mat[1,1];
     fi;
     zero := Zero(f);
     
@@ -2390,7 +2390,7 @@ InstallGlobalFunction( SemiEchelonMatsNoCo, function( mats )
           scalar,
           x;
 
-    zero:= Zero( mats[1][1][1] );
+    zero:= Zero( mats[1][1,1] );
     m:= Length( mats[1]    );
     n:= Length( mats[1][1] );
 
@@ -2404,10 +2404,10 @@ InstallGlobalFunction( SemiEchelonMatsNoCo, function( mats )
       # Reduce the matrix modulo 'ech'.
       for i in [ 1 .. m ] do
         for j in [ 1 .. n ] do
-          if heads[i][j] <> 0 and mat[i][j] <> zero then
+          if heads[i][j] <> 0 and mat[i,j] <> zero then
 
-            # Compute 'mat:= mat - mat[i][j] * vectors[ heads[i][j] ];'
-            scalar:= - mat[i][j];
+            # Compute 'mat:= mat - mat[i,j] * vectors[ heads[i][j] ];'
+            scalar:= - mat[i,j];
             v:= vectors[ heads[i][j] ];
             for k in [ 1 .. m ] do
               AddRowVector( mat[k], v[k], scalar );
@@ -2428,14 +2428,14 @@ InstallGlobalFunction( SemiEchelonMatsNoCo, function( mats )
       if j <= n then
 
         # We found a new basis vector.
-        mij:= mat[i][j];
+        mij:= mat[i,j];
         for k in [ 1 .. m ] do
           for l in [ 1 .. n ] do
             x:= Inverse( mij );
             if x = fail then
               TryNextMethod();
             fi;
-            mat[k][l]:= mat[k][l] * x;
+            mat[k,l]:= mat[k,l] * x;
           od;
         od;
 
@@ -2512,7 +2512,7 @@ InstallMethod( IsMonomialMatrix,
           row,   # loop over rows
           j;     # position of first non-zero element
 
-    zero:= Zero(M[1][1]);
+    zero:= Zero(M[1,1]);
     len:= Length( M[1] );
     if Length( M ) <> len  then
         return false;
@@ -2558,7 +2558,7 @@ function( mat, m )
     for i  in [ 1 .. n ]  do
 
         pj := 1;
-        while MM[i][pj] = 0  do
+        while MM[i,pj] = 0  do
             pj := pj + 1;
             if pj > n then
               # <mat> is not invertible mod <m>
@@ -2566,14 +2566,14 @@ function( mat, m )
             fi;
         od;
         perm[pj] := i;
-        elem   := MM[i][pj];
+        elem   := MM[i,pj];
         MM[i]  := List( MM[i],  x -> (x/elem) mod m );
         inv[i] := List( inv[i], x -> (x/elem) mod m );
 
         liste  := [ 1 .. i-1 ];
         Append( liste, [i+1..n] );
         for l in liste do
-            elem   := MM[l][pj];
+            elem   := MM[l,pj];
             MM[l]  := MM[l] - MM[i] * elem;
             MM[l]  := List( MM[l], x -> x mod m );
             inv[l] := inv[l] - inv[i] * elem;
@@ -2653,7 +2653,7 @@ InstallMethod( SolutionMatDestructive,
         function( mat, vec )
     local i,ncols,sem, vno, z,x, row, sol;
     ncols := Length(vec);
-    z := Zero(mat[1][1]);
+    z := Zero(mat[1,1]);
     sol := ListWithIdenticalEntries(Length(mat),z);
     ConvertToVectorRepNC(sol);
     if ncols <> Length(mat[1]) then
@@ -2690,7 +2690,7 @@ end);
 #    vec  := ShallowCopy( vec );
 #    l    := Length( mat );
 #    r    := 0;
-#    zero := Zero( mat[1][1] );
+#    zero := Zero( mat[1,1] );
 #    Info( InfoMatrix, 1, "SolutionMat called" );
 #
 #    # Run through all columns of the matrix.
@@ -2699,7 +2699,7 @@ end);
 #
 #        # Find a nonzero entry in this column.
 #        s := r + 1;
-#        while s <= l and mat[ s ][ c ] = zero  do s := s + 1;  od;
+#        while s <= l and mat[ s , c ] = zero  do s := s + 1;  od;
 #
 #        # If there is a nonzero entry,
 #        if s <= l  then
@@ -2709,14 +2709,14 @@ end);
 #            r := r + 1;
 #
 #            # Make its row the current row and normalize it.
-#            tmp := mat[ s ][ c ] ^ -1;
+#            tmp := mat[ s , c ] ^ -1;
 #            v := mat[ s ];  mat[ s ] := mat[ r ];  mat[ r ] := tmp * v;
 #            v := vec[ s ];  vec[ s ] := vec[ r ];  vec[ r ] := tmp * v;
 #
 #            # Clear all entries in this column.
 #            for s  in [ 1 .. Length( mat ) ]  do
-#                if s <> r and mat[ s ][ c ] <> zero  then
-#                    tmp := mat[ s ][ c ];
+#                if s <> r and mat[ s , c ] <> zero  then
+#                    tmp := mat[ s , c ];
 #                    mat[ s ] := mat[ s ] - tmp * mat[ r ];
 #                    vec[ s ] := vec[ s ] - tmp * vec[ r ];
 #                fi;
@@ -2731,11 +2731,11 @@ end);
 #    od;
 #    h := [];
 #    s := Length( mat[ 1 ] );
-#    v := Zero( mat[ 1 ][ 1 ] );
+#    v := Zero( mat[ 1 , 1 ] );
 #    r := 1;
 #    c := 1;
 #    while c <= s and r <= l  do
-#        while c <= s and mat[ r ][ c ] = zero  do
+#        while c <= s and mat[ r , c ] = zero  do
 #            c := c + 1;
 #            Add( h, v );
 #        od;
@@ -2801,7 +2801,7 @@ function( M1, M2 )
       return [ M1, M2 ];
     elif Length( M1[1] ) <> Length( M2[1] ) then
       Error( "dimensions of matrices are not compatible" );
-    elif Zero( M1[1][1] ) <> Zero( M2[1][1] ) then
+    elif Zero( M1[1,1] ) <> Zero( M2[1,1] ) then
       Error( "fields of matrices are not compatible" );
     fi;
 
@@ -2867,7 +2867,7 @@ InstallMethod( TriangulizeMat,
        # get the size of the matrix
        m := Length(mat);
        n := Length(mat[1]);
-       zero := Zero( mat[1][1] );
+       zero := Zero( mat[1,1] );
 
        # make sure that the rows are mutable
        for i in [ 1 .. m ] do
@@ -2882,7 +2882,7 @@ InstallMethod( TriangulizeMat,
 
            # find a nonzero entry in this column
            j := i + 1;
-           while j <= m and mat[j][k] = zero  do j := j + 1;  od;
+           while j <= m and mat[j,k] = zero  do j := j + 1;  od;
 
            # if there is a nonzero entry
            if j <= m  then
@@ -2956,7 +2956,7 @@ function( mat, l )
 
     # run through the diagonal
     for i  in [ 1 .. dim-l ]  do
-        Add( exp, mat[i][l+i] );
+        Add( exp, mat[i,l+i] );
     od;
 
     # and return
@@ -3033,7 +3033,7 @@ local z,l,b,i,j,k,stop,v,dim,h,zv;
   while Length(b)<l do
     stop:=false;
     repeat
-      if j<=dim and (Length(mat)<i or mat[i][j]=z) then
+      if j<=dim and (Length(mat)<i or mat[i,j]=z) then
         # Add vector from bas with j-th component not zero (if any exists)
         v:=PositionProperty(bas,k->k[j]<>z);
         if v<>fail then
@@ -3072,7 +3072,7 @@ local z,l,b,i,j,k,stop,v,dim,h,zv;
   od;
   # add subspace indices
   while i<=Length(mat) do
-    if mat[i][j]<>z then
+    if mat[i,j]<>z then
       h[j]:=-i;
       i:=i+1;
     fi;
@@ -3180,7 +3180,7 @@ InstallGlobalFunction( IdentityMat, function ( arg )
     id := [];
     for i  in [1..m]  do
         id[i] := ShallowCopy( row );
-        id[i][i] := one;
+        id[i,i] := one;
     od;
 
     # We do *not* call ConvertToMatrixRep here, as that can cause
@@ -3296,8 +3296,8 @@ InstallGlobalFunction( NullspaceModQ, function( E, q )
                     #new := e + ( p^(i-1) * List( o * elem[j] + sol, IntFFE ) );
                     new:=ShallowCopy(e);
                     for k in ran do
-                      #new[k]:=new[k]+pex * IntFFE(o*elem[j][k]+ sol[k]);
-                      new[k]:=new[k]+pex * ((elem[j][k]+ sol[k]) mod p);
+                      #new[k]:=new[k]+pex * IntFFE(o*elem[j,k]+ sol[k]);
+                      new[k]:=new[k]+pex * ((elem[j,k]+ sol[k]) mod p);
                     od;
 #T !
                     MakeImmutable(new); # otherwise newelem does not remember
@@ -3341,7 +3341,7 @@ InstallGlobalFunction (BasisNullspaceModN, function (M, n)
     null := IdentityMat (Length (M));
     
     for i in [1..snf.rank] do
-        null[i][i] := n/GcdInt (n, snf.normal[i][i]);
+        null[i,i] := n/GcdInt (n, snf.normal[i,i]);
     od;
     
     # nullM = null*R is the nullspace of M C mod n
@@ -3381,7 +3381,7 @@ InstallGlobalFunction( PermutationMat, function( arg )
     mat:= NullMat( dim, dim, F );
 
     for i in [ 1 .. dim ] do
-        mat[i][ i^perm ]:= One( F );
+        mat[i, i^perm ]:= One( F );
     od;
 
     return mat;
@@ -3403,7 +3403,7 @@ InstallGlobalFunction( DiagonalMat, function( vector )
 
     for i in [ 1 .. Length( vector ) ] do
       M[i]:= ShallowCopy( zerovec );
-      M[i][i]:= vector[i];
+      M[i,i]:= vector[i];
       ConvertToVectorRepNC(M[i]);
     od;
 
@@ -3616,9 +3616,10 @@ InstallGlobalFunction( RandomUnimodularMat, function ( m )
             gcd := Gcdex( a, b );
         until gcd.gcd = 1;
         for i  in [1..m]  do
-            v := mat[i][k];  w := mat[i][l];
-            mat[i][k] := gcd.coeff1 * v + gcd.coeff2 * w;
-            mat[i][l] := gcd.coeff3 * v + gcd.coeff4 * w;
+            v := mat[i,k];  w := mat[i,l];
+            mat[i,k] := gcd.coeff1 * v + gcd.coeff2 * w;
+            mat[i,l] := gcd.coeff3 * v + gcd.coeff4 * w;
+            ConvertToVectorRepNC( mat[i] );
         od;
 
     od;
@@ -3680,7 +3681,7 @@ InstallGlobalFunction( SimultaneousEigenvalues,
 
     # compute ksi
     if Length( arg ) = 2 then
-        q := Characteristic( matlist[1][1][1] );
+        q := Characteristic( matlist[1][1,1] );
 
         # get splitting field
         r := 1;
@@ -3768,7 +3769,7 @@ InstallGlobalFunction( DirectSumMat, function (arg)
       m:= arg[r]; r:=r+1;
     od;
     if m <> [ ] then
-      F:= DefaultField( m[1][1] );
+      F:= DefaultField( m[1,1] );
     else
       F:= Rationals;
     fi;
@@ -3799,9 +3800,9 @@ InstallMethod( TraceMat, "method for lists", [ IsList ],
     fi;
 
     # sum all the diagonal entries
-    trc := mat[1][1];
+    trc := mat[1,1];
     for i  in [2..m]  do
-        trc := trc + mat[i][i];
+        trc := trc + mat[i,i];
     od;
 
     # return the trace
@@ -3922,7 +3923,7 @@ local i,j,k,fg,f;
   if Length(l)=0 or ForAny(l,i->not IsMatrix(i)) then
     Error("<l> must be a list of matrices");
   fi;
-  fg:=[l[1][1][1]];
+  fg:=[l[1][1,1]];
   f:=Field(fg);
   for i in l do
     for j in i do
@@ -3949,7 +3950,7 @@ local i,j,k,fg,f;
   if Length(l)=0 or ForAny(l,i->not IsMatrix(i)) then
     Error("<l> must be a list of matrices");
   fi;
-  fg:=[l[1][1][1]];
+  fg:=[l[1][1,1]];
   if Characteristic(fg)=0 then
     f:=DefaultField(fg);
   else
@@ -4106,7 +4107,7 @@ local M, n, p, vars, slackVars, i, id, bestMove,
   Val:=function(M,vars,slackVars,len,x) 
       if x in vars then 
           return 0; 
-      else return M[Position(slackVars,x)+1][len]; 
+      else return M[Position(slackVars,x)+1,len]; 
       fi; 
   end;
 
@@ -4146,8 +4147,8 @@ local M, n, p, vars, slackVars, i, id, bestMove,
    TriangulizeMatPivotColumns(M,Concatenation([1],slackVars));
    #Display(M);
    #bestMove is the coeff var that will become nonzero
-   bestMove:=Minimum(List(vars,i->M[1][i]));
-   newNonzero:=vars[Position(List(vars,i->M[1][i]),bestMove)];
+   bestMove:=Minimum(List(vars,i->M[1,i]));
+   newNonzero:=vars[Position(List(vars,i->M[1,i]),bestMove)];
    
    #Print(newNonzero, " is the new nonzero guy \n");
    
@@ -4155,8 +4156,8 @@ local M, n, p, vars, slackVars, i, id, bestMove,
         
        #see if figure is unbounded
        #Print("about to do some ratios \n");
-       #Print(List([1..p],x-> M[x+1][newNonzero]), " is what we're going to divide by \n");
-       ratios:=List([1..p], function(x) if M[x+1][newNonzero]=0 then return infinity; else return M[x+1][len]/M[x+1][newNonzero]; fi; end);
+       #Print(List([1..p],x-> M[x+1,newNonzero]), " is what we're going to divide by \n");
+       ratios:=List([1..p], function(x) if M[x+1,newNonzero]=0 then return infinity; else return M[x+1,len]/M[x+1,newNonzero]; fi; end);
        #Print("done doing some ratios");
        positiveRatios:=Filtered(ratios,x -> x>0);
        if Size(positiveRatios)=0 then return "Feasible region unbounded!"; fi;
@@ -4181,9 +4182,9 @@ local M, n, p, vars, slackVars, i, id, bestMove,
 
        TriangulizeMatPivotColumns(M,Concatenation([1],slackVars));
        #Display(M);
-       bestMove:=Minimum(List(vars,i->M[1][i]));
+       bestMove:=Minimum(List(vars,i->M[1,i]));
        
-       newNonzero:=vars[Position(List(vars,i->M[1][i]),bestMove)];
+       newNonzero:=vars[Position(List(vars,i->M[1,i]),bestMove)];
        #Print(newNonzero," is the new nonzero guy");
 
    od;
@@ -4296,13 +4297,13 @@ BindGlobal("POW_MAT_INT", function(mat, n)
     fi;
     i := i-1;
     for j in [1..Length(mat)] do
-      val[j][j] := val[j][j]+c[i];
+      val[j,j] := val[j,j]+c[i];
     od;
     while 1 < i  do
       val := mat * val;
       i := i - 1;
       for j in [1..Length(mat)] do
-        val[j][j] := val[j][j]+c[i];
+        val[j,j] := val[j,j]+c[i];
       od;
     od;
     if 0 <> f[2]  then

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -560,6 +560,11 @@ InstallOtherMethod( \[\], "for GF2 matrix",
       IsPosInt ],
     ELM_GF2MAT );
 
+InstallMethod( \[\], "for GF2 matrix",
+    [ IsGF2MatrixRep,
+      IsPosInt, IsPosInt ],
+    MAT_ELM_GF2MAT );
+
 
 #############################################################################
 ##
@@ -578,6 +583,13 @@ InstallOtherMethod( \[\]\:\=,
       IsPosInt,
       IsObject ],
     ASS_GF2MAT );
+
+InstallMethod( \[\]\:\=,
+    "for GF2 matrix",
+    [ IsGF2MatrixRep,
+      IsPosInt, IsPosInt,
+      IsObject ],
+    SET_MAT_ELM_GF2MAT );
 
 
 #############################################################################

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -3354,6 +3354,13 @@ void            IntrUnbList ( Int narg )
         UNBB_LIST(list, pos);
       }
     }
+    else if (narg == 2) {
+      Obj pos2 = PopObj();
+      Obj pos1 = PopObj();
+      list = PopObj();
+
+      UNB2_LIST(list, pos1, pos2);
+    }
     else {
       Obj ixs = NEW_PLIST(T_PLIST,narg);
       for (Int i = narg; i > 0; i--) {
@@ -3556,6 +3563,13 @@ void            IntrIsbList ( Int narg )
       } else {
         isb = ISBB_LIST( list, pos ) ? True : False;
       }
+    }
+    else if (narg == 2) {
+      Obj pos2 = PopObj();
+      Obj pos1 = PopObj();
+      list = PopObj();
+
+      isb = ISB2_LIST(list, pos1, pos2) ? True : False;
     }
     else {
       Obj ixs = NEW_PLIST(T_PLIST,narg);

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -3198,15 +3198,7 @@ void            IntrAssList ( Int narg )
       ASS2_LIST(list, pos1, pos2, rhs);
     }
     else {
-      Obj ixs = NEW_PLIST(T_PLIST, narg);
-      for (Int i = narg; i > 0; i--) {
-        pos = PopObj();
-        SET_ELM_PLIST(ixs, i, pos);
-        CHANGED_BAG(ixs);
-      }
-      SET_LEN_PLIST(ixs, narg);
-      list = PopObj();
-      ASSB_LIST(list, ixs, rhs);
+      SyntaxError("[]:= only supports 1 or 2 indices");
     }
 
     /* push the right hand side again                                      */
@@ -3362,15 +3354,7 @@ void            IntrUnbList ( Int narg )
       UNB2_LIST(list, pos1, pos2);
     }
     else {
-      Obj ixs = NEW_PLIST(T_PLIST,narg);
-      for (Int i = narg; i > 0; i--) {
-        pos = PopObj();
-        SET_ELM_PLIST(ixs, i, pos);
-        CHANGED_BAG(ixs);
-      }
-      SET_LEN_PLIST(ixs, narg);
-      list = PopObj();
-      UNBB_LIST(list, ixs);
+      SyntaxError("Unbind[] only supports 1 or 2 indices");
     }
 
     /* push void                                                           */
@@ -3422,15 +3406,8 @@ void            IntrElmList ( Int narg )
       elm = ELM2_LIST(list, pos1, pos2);
     }
     else {
-      Obj ixs = NEW_PLIST(T_PLIST,narg);
-      for (Int i = narg; i > 0; i--) {
-        pos = PopObj();
-        SET_ELM_PLIST(ixs, i, pos);
-        CHANGED_BAG(ixs);
-      }
-      SET_LEN_PLIST(ixs, narg);
-      list = PopObj();
-      elm = ELMB_LIST(list, ixs);
+      SyntaxError("[] only supports 1 or 2 indices");
+      return;
     }
 
     /* push the element                                                    */
@@ -3572,15 +3549,8 @@ void            IntrIsbList ( Int narg )
       isb = ISB2_LIST(list, pos1, pos2) ? True : False;
     }
     else {
-      Obj ixs = NEW_PLIST(T_PLIST,narg);
-      for (Int i = narg; i > 0; i--) {
-        pos = PopObj();
-        SET_ELM_PLIST(ixs, i, pos);
-        CHANGED_BAG(ixs);
-      }
-      SET_LEN_PLIST(ixs, narg);
-      list = PopObj();
-      isb = ISBB_LIST(list, ixs) ? True: False;
+      SyntaxError("IsBound[] only supports 1 or 2 indices");
+      isb = Fail;
     }
 
     /* push the result                                                     */

--- a/src/lists.c
+++ b/src/lists.c
@@ -86,22 +86,6 @@ Int             IsListObject (
 }
 
 
-Obj Elm2List(Obj list, Obj pos1, Obj pos2) {
-  Obj ixs = NEW_PLIST(T_PLIST,2);
-  SET_ELM_PLIST(ixs,1,pos1);
-  SET_ELM_PLIST(ixs,2,pos2);
-  SET_LEN_PLIST(ixs,2);
-  return ELMB_LIST(list, ixs);
-}
-
-void Ass2List(Obj list, Obj pos1, Obj pos2, Obj obj) {
-  Obj ixs = NEW_PLIST(T_PLIST,2);
-  SET_ELM_PLIST(ixs,1,pos1);
-  SET_ELM_PLIST(ixs,2,pos2);
-  SET_LEN_PLIST(ixs,2);
-  ASSB_LIST(list, ixs, obj);
-}
-
 /****************************************************************************
 **
 *F  IS_SMALL_LIST(<obj>)  . . . . . . . . . . . . . . . . . . . is an object a list
@@ -558,6 +542,17 @@ Obj ELMB_LIST(Obj list, Obj pos)
     return elm;
 }
 
+Obj ELM2_LIST(Obj list, Obj pos1, Obj pos2)
+{
+    Obj elm = DoOperation3Args( ElmListOper, list, pos1, pos2 );
+    while ( elm == 0 ) {
+        elm = ErrorReturnObj(
+            "List access method must return a value", 0L, 0L,
+            "you can supply a value <val> via 'return <val>;'" );
+    }
+    return elm;
+}
+
 
 /****************************************************************************
 **
@@ -957,6 +952,11 @@ void ASSB_LIST (
     Obj                 obj )
 {
     DoOperation3Args( AssListOper, list, pos, obj );
+}
+
+void ASS2_LIST(Obj list, Obj pos1, Obj pos2, Obj obj)
+{
+    DoOperation4Args( AssListOper, list, pos1, pos2, obj );
 }
 
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -544,6 +544,22 @@ Obj ELMB_LIST(Obj list, Obj pos)
 
 Obj ELM2_LIST(Obj list, Obj pos1, Obj pos2)
 {
+    if (IS_POS_INTOBJ(pos1) && IS_POS_INTOBJ(pos2) && IS_PLIST(list)) {
+        Int p1 = INT_INTOBJ(pos1);
+        if ( p1 <= LEN_PLIST(list) ) {
+            Obj row = ELM_PLIST( list, p1 );
+            Int p2 = INT_INTOBJ(pos2);
+
+            if ( IS_PLIST(row) && p2 <= LEN_PLIST(row) ) {
+                return ELM_PLIST( row, p2 );
+            }
+
+            // fallback to generic list access code (also triggers error if
+            // row isn't a list)
+            return ELM_LIST( row, p2 );
+        }
+    }
+
     Obj elm = DoOperation3Args( ElmListOper, list, pos1, pos2 );
     while ( elm == 0 ) {
         elm = ErrorReturnObj(
@@ -956,6 +972,30 @@ void ASSB_LIST (
 
 void ASS2_LIST(Obj list, Obj pos1, Obj pos2, Obj obj)
 {
+    if (!IS_MUTABLE_OBJ(list)) {
+        ErrorReturnVoid(
+            "Matrix Assignment: <mat> must be a mutable matrix",
+            0L, 0L,
+            "you can 'return;' and ignore the assignment" );
+    }
+    if (IS_POS_INTOBJ(pos1) && IS_POS_INTOBJ(pos2) && IS_PLIST(list)) {
+        Int p1 = INT_INTOBJ(pos1);
+        if ( p1 <= LEN_PLIST(list) ) {
+            Obj row = ELM_PLIST( list, p1 );
+            Int p2 = INT_INTOBJ(pos2);
+
+            if ( IS_PLIST( row ) ) {
+                AssPlist( row, p2, obj );
+                return;
+            }
+
+            // fallback to generic list access code (also triggers error if
+            // row isn't a list)
+            ASS_LIST( row, p2, obj );
+            return;
+        }
+    }
+
     DoOperation4Args( AssListOper, list, pos1, pos2, obj );
 }
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -355,6 +355,11 @@ Int             ISBB_LIST (
     return DoOperation2Args( IsbListOper, list, pos ) == True;
 }
 
+Int ISB2_LIST(Obj list, Obj pos1, Obj pos2)
+{
+    return DoOperation3Args( IsbListOper, list, pos1, pos2 ) == True;
+}
+
 
 /****************************************************************************
 **
@@ -892,6 +897,11 @@ void            UNBB_LIST (
     Obj                 pos )
 {
     DoOperation2Args( UnbListOper, list, pos );
+}
+
+void UNB2_LIST(Obj list, Obj pos1, Obj pos2)
+{
+    DoOperation3Args( UnbListOper, list, pos1, pos2 );
 }
 
 /****************************************************************************

--- a/src/lists.h
+++ b/src/lists.h
@@ -302,21 +302,13 @@ static inline Obj ELM_LIST(Obj list, Int pos)
 /****************************************************************************
 **
 *F  ELM2_LIST( <list>, <pos1>, <pos2> ) . . . . select an element from a list
+**
+**  'ELM2_LIST' implements 'list[pos1,pos2]', which for lists of lists is
+**  defined as 'list[pos1][pos2]', and for other kind of objects is handled
+**  by method dispatch through the GAP attribute 'ELM_LIST' with three
+**  arguments.
 */
-
-extern Obj Elm2List(Obj list, Obj pos1, Obj pos2);
-
-static inline Obj ELM2_LIST(Obj list, Obj pos1, Obj pos2)
-{
-    return Elm2List(list, pos1, pos2);
-}
-
-extern void Ass2List(Obj list, Obj pos1, Obj pos2, Obj obj);
-
-static inline void ASS2_LIST(Obj list, Obj pos1, Obj pos2, Obj obj)
-{
-    Ass2List(list, pos1, pos2, obj);
-}
+extern Obj ELM2_LIST(Obj list, Obj pos1, Obj pos2);
 
 
 /****************************************************************************
@@ -497,6 +489,18 @@ static inline void ASS_LIST(Obj list, Int pos, Obj obj)
     GAP_ASSERT(obj != 0);
     (*AssListFuncs[TNUM_OBJ(list)])(list, pos, obj);
 }
+
+
+/****************************************************************************
+**
+*F  ASS2_LIST( <list>, <pos1>, <pos2>, <obj> )
+**
+**  'ASS2_LIST' implements 'list[pos1,pos2]:=obj', which for lists of lists
+**  is defined as 'list[pos1][pos2]:=obj', and for other kind of objects is
+**  handled by method dispatch through the GAP attribute 'ASS_LIST' with
+**  three arguments.
+*/
+extern void ASS2_LIST(Obj list, Obj pos1, Obj pos2, Obj obj);
 
 
 /****************************************************************************

--- a/src/lists.h
+++ b/src/lists.h
@@ -203,6 +203,8 @@ static inline Int ISB_LIST(Obj list, Int pos)
 
 extern Int ISBB_LIST( Obj list, Obj pos );
 
+extern Int ISB2_LIST(Obj list, Obj pos1, Obj pos2);
+
 
 /****************************************************************************
 **
@@ -459,6 +461,8 @@ static inline void UNB_LIST(Obj list, Int pos)
     GAP_ASSERT(pos > 0);
     return (*UnbListFuncs[TNUM_OBJ(list)])(list, pos);
 }
+
+extern void UNB2_LIST(Obj list, Obj pos1, Obj pos2);
 
 
 /****************************************************************************

--- a/tst/test-error/bad-array-double-1.g.out
+++ b/tst/test-error/bad-array-double-1.g.out
@@ -1,5 +1,5 @@
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[]' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+Error, no 1st choice method found for `[]' on 3 arguments at GAPROOT/lib/methsel2.g:241 called from
 <compiled or corrupted statement>  called from
 <function "f">( <arguments> )
  called from read-eval loop at bad-array-double-1.g:4

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -8,6 +8,8 @@
 gap> START_TEST("listindex.tst");
 gap> r := NewCategory("ListTestObject",IsList and HasLength and HasIsFinite);
 <Category "ListTestObject">
+
+#
 gap> InstallOtherMethod(\[\],[r,IsObject],function(l,ix) 
 >     return ix;
 > end);
@@ -21,6 +23,23 @@ gap> InstallOtherMethod(IsBound\[\],[r and IsMutable,IsObject],function(l,ix)
 >     Print ("IsBound ",ix,"\n");
 >     return false;
 > end);
+
+#
+gap> InstallOtherMethod(\[\],[r,IsPosInt,IsPosInt],function(l,i,j) 
+>     return [i,j];
+> end);
+gap> InstallOtherMethod(\[\]\:\=,[r and IsMutable,IsPosInt,IsPosInt, IsObject],function(l,i,j,x) 
+>     Print ("Assign [",i,"][",j,"] := ",x,"\n");
+> end);
+gap> InstallOtherMethod(Unbind\[\],[r and IsMutable,IsPosInt,IsPosInt],function(l,i,j) 
+>     Print ("Unbind [",i,"][",j,"]\n");
+> end);
+gap> InstallOtherMethod(IsBound\[\],[r and IsMutable,IsPosInt,IsPosInt],function(l,i,j) 
+>     Print ("IsBound [",i,"][",j,"]\n");
+>     return false;
+> end);
+
+#
 gap> InstallMethod(Length,[r],l->infinity);
 gap> InstallMethod(IsFinite,[r],ReturnFalse);
 gap> t := NewType(ListsFamily, r and IsMutable and IsPositionalObjectRep);;
@@ -35,8 +54,6 @@ gap> o[[1,2]];
 [ 1, 2 ]
 gap> o[3,4];
 [ 3, 4 ]
-gap> o[3,4,5];
-[ 3, 4, 5 ]
 gap> o["abc"];
 "abc"
 gap> o[2] := 3;
@@ -51,12 +68,6 @@ Assign E(4) i
 gap> o[[12,34,56]] := 99;
 Assign [ 12, 34, 56 ] 99
 99
-gap> o[-1,"e"] := 1.0;
-Assign [ -1, "e" ] 1
-1.
-gap> o[2.0,3.0,4.5] := infinity;
-Assign [ 2, 3, 4.5 ] infinity
-infinity
 gap> Unbind(o[1]);
 Unbind 1
 gap> Unbind(o[-17]);
@@ -66,9 +77,7 @@ Unbind Z(3)
 gap> Unbind(o[[1,2]]);
 Unbind [ 1, 2 ]
 gap> Unbind(o[3,4]);
-Unbind [ 3, 4 ]
-gap> Unbind(o[3,4,5]);
-Unbind [ 3, 4, 5 ]
+Unbind [3][4]
 gap> Unbind(o["abc"]);
 Unbind abc
 gap> IsBound(o[1]);
@@ -84,10 +93,7 @@ gap> IsBound(o[[1,2]]);
 IsBound [ 1, 2 ]
 false
 gap> IsBound(o[3,4]);
-IsBound [ 3, 4 ]
-false
-gap> IsBound(o[3,4,5]);
-IsBound [ 3, 4, 5 ]
+IsBound [3][4]
 false
 gap> IsBound(o["abc"]);
 IsBound abc

--- a/tst/testinstall/matblock.tst
+++ b/tst/testinstall/matblock.tst
@@ -100,6 +100,22 @@ gap> o2:= One( z );
 <block matrix of dimensions (3*2)x(3*2)>
 gap> o1 = o2;
 true
+
+# New style access to block matrix
+gap> dim := DimensionsMat( m1 );;
+gap> tmp := List([1..dim[1]], row->List([1..dim[2]], col -> m1[row,col]));;
+gap> tmp = MatrixByBlockMatrix(m1);
+true
+gap> dim := DimensionsMat( m2 );;
+gap> tmp := List([1..dim[1]], row->List([1..dim[2]], col -> m2[row,col]));;
+gap> tmp = MatrixByBlockMatrix(m2);
+true
+
+# block matrices are immutable
+gap> m1[1,2] := 5;
+Error, Matrix Assignment: <mat> must be a mutable matrix
+
+#
 gap> STOP_TEST( "matblock.tst", 1);
 
 #############################################################################

--- a/tst/testinstall/vecmat.tst
+++ b/tst/testinstall/vecmat.tst
@@ -260,4 +260,51 @@ gap> IsMutable(m);
 false
 
 #
+# Test matrix access functions (see also listindex.tst)
+#
+gap> TestReadMatEntry := function(m)
+>     local dim;
+>     dim := DimensionsMat(m);
+>     dim := [ [1..dim[1]], [1..dim[2]] ];
+>     return ForAll(dim[1], row->ForAll(dim[2], col-> m[row,col] = m[row][col]));
+> end;;
+
+#
+gap> F := GF(2);; m := IdentityMat( 3, F );;
+gap> TestReadMatEntry(m);
+true
+gap> m[1,4];
+Error, List Element: <list>[4] must have an assigned value
+gap> m[4,1];
+Error, List Element: <list>[4] must have an assigned value
+
+#
+gap> m := ImmutableMatrix( 2, m );
+<an immutable 3x3 matrix over GF2>
+gap> TestReadMatEntry(m);
+true
+gap> m[1,4];
+Error, column index 4 exceeds 3, the number of columns
+gap> m[4,1];
+Error, row index 4 exceeds 3, the number of rows
+
+#
+gap> F := GF(9);; m := IdentityMat( 3, F );;
+gap> TestReadMatEntry(m);
+true
+gap> m[1,4];
+Error, List Element: <list>[4] must have an assigned value
+gap> m[4,1];
+Error, List Element: <list>[4] must have an assigned value
+
+#
+gap> m := ImmutableMatrix( 9, m );;
+gap> TestReadMatEntry(m);
+true
+gap> m[1,4];
+Error, column index 4 exceeds 3, the number of columns
+gap> m[4,1];
+Error, row index 4 exceeds 3, the number of rows
+
+#
 gap> STOP_TEST("vecmat.tst");


### PR DESCRIPTION
This PR is work in progress, and was started during the MatrixObj GAP Days in Aachen.

This does several things:
* adds code to allow writing `mat[i,j]` as an alias for `mat[i][j]`
* adds new kernel methods to accessing entries of compressed matrices
* adds a set of benchmarks for the various ways to access matrix entries (this benchmark will be either removed in the final version; or perhaps be kept, but then renamed and moved to a more appropriate location; for now I keep it as `bench-mat.g` in the root directory of the repos, for my convenience). The benchmark tests various ways to access entries of various kinds of matrices:
  1. `mat[i][j]`
  2. `mat[i,j]`
  3. `MatElm(mat,i,j)`
  4. `MatElm(mat,i,j)` with prefetched method (to avoid method selection)

With this PR, using `mat[i,j]` actually is always as fast or even faster than `mat[i][j]`, both for reading and writing matrix entries; for plists of plists, for plists of compressed vectors, for compressed matrices (except prefetched `SetMatElm` for a GF(7) matrix -- but (a) you can also prefetch the `[]:=` method, and (b) I can add 8bit matrices to the hotpath, just like GF(2) matrices, and it'll be faster again). Here are some benchmarking results (using GCC 7, on my 2012 MacBook Pro):
```
+------------------------+
| Testing integer matrix |
+------------------------+
Testing m[i][j]:
  260 iterations per second
Testing m[i,j]:
  287 iterations per second
Testing MatElm(m,i,j):
  18 iterations per second
Testing MatElm(m,i,j) with prefetched method:
  91 iterations per second
...now testing write access...
Testing m[i][j]:=elm:
  231 iterations per second
Testing m[i,j]:=elm:
  298 iterations per second
Testing SetMatElm(m,i,j,elm):
  18 iterations per second
Testing SetMatElm(m,i,j,elm) with prefetched method:
  81 iterations per second

+-----------------------+
| Testing GF(2) rowlist |
+-----------------------+
Testing m[i][j]:
  184 iterations per second
Testing m[i,j]:
  222 iterations per second
Testing MatElm(m,i,j):
  24 iterations per second
Testing MatElm(m,i,j) with prefetched method:
  78 iterations per second
...now testing write access...
Testing m[i][j]:=elm:
  149 iterations per second
Testing m[i,j]:=elm:
  158 iterations per second
Testing SetMatElm(m,i,j,elm):
  23 iterations per second
Testing SetMatElm(m,i,j,elm) with prefetched method:
  71 iterations per second

+---------------------------------+
| Testing GF(2) compressed matrix |
+---------------------------------+
Testing m[i][j]:
  147 iterations per second
Testing m[i,j]:
  195 iterations per second
Testing MatElm(m,i,j):
  177 iterations per second
Testing MatElm(m,i,j) with prefetched method:
  194 iterations per second
...now testing write access...
Testing m[i][j]:=elm:
  108 iterations per second
Testing m[i,j]:=elm:
  162 iterations per second
Testing SetMatElm(m,i,j,elm):
  139 iterations per second
Testing SetMatElm(m,i,j,elm) with prefetched method:
  181 iterations per second

+-----------------------+
| Testing GF(7) rowlist |
+-----------------------+
Testing m[i][j]:
  150 iterations per second
Testing m[i,j]:
  142 iterations per second
Testing MatElm(m,i,j):
  24 iterations per second
Testing MatElm(m,i,j) with prefetched method:
  74 iterations per second
...now testing write access...
Testing m[i][j]:=elm:
  91 iterations per second
Testing m[i,j]:=elm:
  93 iterations per second
Testing SetMatElm(m,i,j,elm):
  22 iterations per second
Testing SetMatElm(m,i,j,elm) with prefetched method:
  53 iterations per second

+---------------------------------+
| Testing GF(7) compressed matrix |
+---------------------------------+
Testing m[i][j]:
  118 iterations per second
Testing m[i,j]:
  153 iterations per second
Testing MatElm(m,i,j):
  141 iterations per second
Testing MatElm(m,i,j) with prefetched method:
  148 iterations per second
...now testing write access...
Testing m[i][j]:=elm:
  73 iterations per second
Testing m[i,j]:=elm:
  78 iterations per second
Testing SetMatElm(m,i,j,elm):
  78 iterations per second
Testing SetMatElm(m,i,j,elm) with prefetched method:
  90 iterations per second
```

Things that need to be done:
* [ ] add comprehensive tests for everything
* [ ] clean up various hacks
* [ ] document the `[i,j]` syntax in the manual
* [ ] in light of the benchmark results, talk with folks (on mailing list?) about MatrixObj; in particular, whether we should remove `MatElm` and `SetMatElm` from the `MatrixObj` API again, instead requiring that suitable `[]` and `[]:=` methods be provided.
* [ ] Discuss what to do with `foo[a,b,c]` with more than two arguments. Previously, we allowed that, by stuffing all indices into a plist. With this PR, I instead invoke the `[]` and `[]:=` operations with additional arguments for each index (and in fact, only 1 or 2 indices are currently supported in this PR). The reasons for this change are: 1. we avoid creating a temporary plist, 2. it becomes easier to install methods with precise filters, 3. we avoid having `IsList` filters in the method selection for `[]` and `[]:=` -- and avoiding the overhead for `IsList` in method selection is one of the driving forces of the MatrixObj project. My inclination right now is to have 3 or more indices trigger an error; and if anybody ever wants to use 3 or more indices for some project, we can re-activate it then, in a manner that makes sense for that actual use case.
* [ ] Decide on semantics for out-of-bounds access; then implement it, add tests, ensure error messages are consistent and helpful.
* [ ] react to feedback y'all have on this work :-)