### PR TITLE
Add 'MAPPINGPERMLISTLIST_NEW', which moves as few points as possible.

### DIFF
--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -101,7 +101,7 @@ local dom,dom2,sortfun,max,cd,ce,rep,dp,ep;
       ce:=ShallowCopy(Cycles(e,[1..max]));
       Sort(cd,sortfun);
       Sort(ce,sortfun);
-      rep:=MappingPermListList(Concatenation(cd),Concatenation(ce));
+      rep:=MAPPINGPERMLISTLIST_NEW(Concatenation(cd),Concatenation(ce));
       if SignPerm(rep)=-1 then
         dom2:=Difference(dom,Union(Concatenation(cd),Concatenation(ce)));
 	if Length(dom2)>1 then
@@ -145,7 +145,7 @@ local dom,dom2,sortfun,max,cd,ce,rep,dp,ep;
       return fail;
     fi;
     if IsSubset(dom,Set(d)) and IsSubset(dom,Set(e)) then
-      rep:=MappingPermListList(d,e);
+      rep:=MAPPINGPERMLISTLIST_NEW(d,e);
       if SignPerm(rep)=-1 then
 	cd:=Difference(dom,e);
 	if Length(cd)>1 then
@@ -1509,14 +1509,14 @@ local dom,n,sortfun,max,cd,ce,p1,p2;
       ce:=ShallowCopy(Cycles(e,[1..max]));
       Sort(cd,sortfun);
       Sort(ce,sortfun);
-      return MappingPermListList(Concatenation(cd),Concatenation(ce));
+      return MAPPINGPERMLISTLIST_NEW(Concatenation(cd),Concatenation(ce));
     elif IsPermGroup(d) and IsPermGroup(e) 
       #and IsTransitive(d,dom) and IsTransitive(e,dom) 
       and IsSubset(G,d) and IsSubset(G,e) then
 
       if dom<>[1..n] then
 	# translate
-	p1:=MappingPermListList(dom,[1..n]);
+	p1:=MAPPINGPERMLISTLIST_NEW(dom,[1..n]);
 	p2:=SubgpConjSymmgp(G^p1,d^p1,e^p1);
 	if p2=false then
 	    TryNextMethod();
@@ -1538,7 +1538,7 @@ local dom,n,sortfun,max,cd,ce,p1,p2;
       return fail;
     fi;
     if IsSubset(dom,Set(d)) and IsSubset(dom,Set(e)) then
-      return MappingPermListList(d,e);
+      return MAPPINGPERMLISTLIST_NEW(d,e);
     fi;
   fi;
   TryNextMethod(); 

--- a/lib/permutat.g
+++ b/lib/permutat.g
@@ -583,6 +583,34 @@ BIND_GLOBAL( "MappingPermListList", function( src, dst )
 end );
 
 
+# This is a variant of MappingPermListList which only moves points contained
+# in one of src or dst. In GAP 4.9 and higher this method replaces
+# MappingPermListList. In GAP 4.8 it is kept seperate to avoid changing
+# behaviour in a minor release update.
+BIND_GLOBAL( "MAPPINGPERMLISTLIST_NEW", function( src, dst )
+    local merged;
+    if not IsList(src) or not IsList(dst) or Length(src) <> Length(dst)  then
+       Error("usage: MappingPermListList( <lst1>, <lst2> )");
+    fi;
+
+    if IsEmpty( src )  then
+        return ();
+    fi;
+
+    merged := Union(src, dst);
+    src := Concatenation( src, Difference( merged, src ) );
+    dst := Concatenation( dst, Difference( merged, dst ) );
+    src := Concatenation( src, Difference([1..Maximum(merged)], src));
+    dst := Concatenation( dst, Difference([1..Maximum(merged)], dst));
+    src := PermList(src);
+    if src = fail then return fail; fi;
+    dst := PermList(dst);
+    if dst = fail then return fail; fi;
+
+    return LeftQuotient( src, dst );
+end );
+
+
 #############################################################################
 ##
 #m  SmallestMovedPoint( <perm> )  . . . . . . . . . . .  for permutations

--- a/tst/teststandard/bugfix.tst
+++ b/tst/teststandard/bugfix.tst
@@ -2856,6 +2856,17 @@ false
 gap> IsSortedList(c);
 false
 
+# These functions all worked incorrectly when given symmetric or alternating groups
+# Which were not not defined on a domain of the form [1..n]
+gap> RepresentativeAction(SymmetricGroup([5,7,11,15]),[7,11],[5,15],OnTuples);
+(5,7)(11,15)
+gap> RepresentativeAction(AlternatingGroup([5,7,11,15]),[7,11],[5,15],OnTuples);
+(5,7)(11,15)
+gap> RepresentativeAction(SymmetricGroup([5,7,11,15]),[7,11],[5,15],OnSets);
+(5,7)(11,15)
+gap> RepresentativeAction(AlternatingGroup([5,7,11,15]),[7,11],[5,15],OnSets);
+(5,7)(11,15)
+
 #############################################################################
 #
 # Tests requiring loading some packages must be performed at the end.


### PR DESCRIPTION
This fixes RepresentativeAction for symmetric and alternating groups.

In the master branch I changed `MappingPermListList`, but in 4.8.x I have added a new function `MAPPINGPERMLISTLIST_NEW` to the behaviour of existing code as little as possible.