### PR TITLE
Fix gac on HPC-GAP and re-enable edim (WIP, DO NOT MERGE)

### DIFF
--- a/cnf/compat/sysinfo.gap.in
+++ b/cnf/compat/sysinfo.gap.in
@@ -1,3 +1,4 @@
 GAParch=@GAPARCH@
 GAParch_system=@GAPARCH@
 GAParch_abi=@ABI@-bit
+CONFIGNAME=@CONFIGNAME@

--- a/configure.ac
+++ b/configure.ac
@@ -395,6 +395,7 @@ BASECC=`basename ${CC}`
 GAPARCH="$host-$BASECC-${CONFIGNAME}"
 AC_DEFINE_UNQUOTED([CONFIGNAME], ["$CONFIGNAME"], [for backwards compatibility])
 AC_DEFINE_UNQUOTED([SYS_ARCH], ["$GAPARCH"], [for backwards compatibility])
+AC_SUBST([CONFIGNAME])
 AC_SUBST([GAPARCH])
 
 AC_ARG_ENABLE([compat-mode],
@@ -409,7 +410,7 @@ AC_SUBST([COMPAT_MODE], [$enable_compat_mode])
 AS_IF([test "x$enable_compat_mode" = xyes],
     [
     AC_CONFIG_FILES([bin/gap.sh:cnf/compat/gap.sh.in], [chmod +x bin/gap.sh])
-    AC_CONFIG_FILES([sysinfo.gap:cnf/compat/sysinfo.gap.in], [ln -s sysinfo.gap sysinfo.gap-$CONFIGNAME], [CONFIGNAME='$CONFIGNAME'])
+    AC_CONFIG_FILES([sysinfo.gap:cnf/compat/sysinfo.gap.in], [rm -f sysinfo.gap-$CONFIGNAME && ln -s sysinfo.gap sysinfo.gap-$CONFIGNAME], [CONFIGNAME='$CONFIGNAME'])
     AC_CONFIG_LINKS([bin/$GAPARCH/config.h:gen/config.h])
     AS_IF([test x$BUILD_GMP = xyes],[
       AC_CONFIG_FILES([bin/$GAPARCH/extern/gmp/include/gmp.h:cnf/compat/gmp.h.in])

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -116,11 +116,12 @@ then
 fi
 
 
-# Compile edim to test gac (but not on HPC-GAP and not on Cygwin, where gac is known to be broken)
-if [[ $HPCGAP != yes && $OSTYPE = Cygwin* ]]
+# Compile edim to test gac (but not on Cygwin, where gac is known to be broken)
+if [[ $OSTYPE != Cygwin* ]]
 then
+    source $BUILDDIR/sysinfo.gap
     cd edim
-    ./configure $BUILDDIR
+    ./configure $BUILDDIR CONFIGNAME=$CONFIGNAME
     make
     cd ..
 fi


### PR DESCRIPTION
This is some work on getting `gac` to work for HPC-GAP, and to thus resolve issue #1295. Right now, it does not yet actually change `gac`, but at least it enables the test (namely, trying to build `edim`) which reveals this.

Help with this is welcome! :-).