### PR TITLE
Some gvars cleanup and refactoring

### DIFF
--- a/src/gvars.c
+++ b/src/gvars.c
@@ -621,34 +621,28 @@ UInt GVarName (
            CopiesGVars[gvar_bucket] = NewGVarBucket();
            FopiesGVars[gvar_bucket] = NewGVarBucket();
         }
+#else
+        GROW_PLIST(    ValGVars,    CountGVars );
+        SET_LEN_PLIST( ValGVars,    CountGVars );
+        GROW_PLIST(    NameGVars,   CountGVars );
+        SET_LEN_PLIST( NameGVars,   CountGVars );
+        GROW_PLIST(    WriteGVars,  CountGVars );
+        SET_LEN_PLIST( WriteGVars,  CountGVars );
+        GROW_PLIST(    ExprGVars,   CountGVars );
+        SET_LEN_PLIST( ExprGVars,   CountGVars );
+        GROW_PLIST(    CopiesGVars, CountGVars );
+        SET_LEN_PLIST( CopiesGVars, CountGVars );
+        GROW_PLIST(    FopiesGVars, CountGVars );
+        SET_LEN_PLIST( FopiesGVars, CountGVars );
+        PtrGVars = ADDR_OBJ( ValGVars );
+#endif
         SET_ELM_GVAR_LIST( ValGVars,    CountGVars, 0 );
         SET_ELM_GVAR_LIST( NameGVars,   CountGVars, string );
+        CHANGED_GVAR_LIST( NameGVars,   CountGVars );
         SET_ELM_GVAR_LIST( WriteGVars,  CountGVars, INTOBJ_INT(1) );
         SET_ELM_GVAR_LIST( ExprGVars,   CountGVars, 0 );
         SET_ELM_GVAR_LIST( CopiesGVars, CountGVars, 0 );
         SET_ELM_GVAR_LIST( FopiesGVars, CountGVars, 0 );
-#else
-        GROW_PLIST(    ValGVars,    CountGVars );
-        SET_LEN_PLIST( ValGVars,    CountGVars );
-        SET_ELM_PLIST( ValGVars,    CountGVars, 0 );
-        GROW_PLIST(    NameGVars,   CountGVars );
-        SET_LEN_PLIST( NameGVars,   CountGVars );
-        SET_ELM_PLIST( NameGVars,   CountGVars, string );
-        CHANGED_BAG(   NameGVars );
-        GROW_PLIST(    WriteGVars,  CountGVars );
-        SET_LEN_PLIST( WriteGVars,  CountGVars );
-        SET_ELM_PLIST( WriteGVars,  CountGVars, INTOBJ_INT(1) );
-        GROW_PLIST(    ExprGVars,   CountGVars );
-        SET_LEN_PLIST( ExprGVars,   CountGVars );
-        SET_ELM_PLIST( ExprGVars,   CountGVars, 0 );
-        GROW_PLIST(    CopiesGVars, CountGVars );
-        SET_LEN_PLIST( CopiesGVars, CountGVars );
-        SET_ELM_PLIST( CopiesGVars, CountGVars, 0 );
-        GROW_PLIST(    FopiesGVars, CountGVars );
-        SET_LEN_PLIST( FopiesGVars, CountGVars );
-        SET_ELM_PLIST( FopiesGVars, CountGVars, 0 );
-        PtrGVars = ADDR_OBJ( ValGVars );
-#endif
 
         /* if the table is too crowded, make a larger one, rehash the names     */
         if ( SizeGVars < 3 * CountGVars / 2 ) {

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -562,7 +562,6 @@ UInt GVarName (
     Char                gvarbuf[1024];  /* temporary copy for namespace    */
     Char *              cns;            /* Pointer to current namespace    */
     UInt                pos;            /* hash position                   */
-    Char                namx [1024];    /* temporary copy of <name>        */
     Obj                 string;         /* temporary string value <name>   */
     Obj                 table;          /* temporary copy of <TableGVars>  */
     Obj                 gvar2;          /* one element of <table>          */
@@ -614,8 +613,9 @@ UInt GVarName (
         CountGVars++;
         gvar = INTOBJ_INT(CountGVars);
         SET_ELM_PLIST( TableGVars, pos, gvar );
-        strlcpy(namx, name, sizeof(namx));
-        string = MakeImmString(namx);
+        if (name != gvarbuf)
+            strlcpy(gvarbuf, name, sizeof(gvarbuf));
+        string = MakeImmString(gvarbuf);
 
         RESET_FILT_LIST( string, FN_IS_MUTABLE );
 #ifdef USE_GVAR_BUCKETS

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -838,8 +838,6 @@ static Obj FuncIsReadOnlyGVar (
 **  cause the execution  of an assignment to  that global variable, otherwise
 **  an error is signalled.
 */
-Obj             AUTOFunc;
-
 Obj             AUTOHandler (
     Obj                 self,
     Obj                 args )
@@ -1139,9 +1137,9 @@ typedef struct  {
     const Char *        name;
 } StructCopyGVar;
 
-#ifndef MAX_COPY_AND_FOPY_GVARS
-#define MAX_COPY_AND_FOPY_GVARS         30000
-#endif
+enum {
+    MAX_COPY_AND_FOPY_GVARS = 30000
+};
 
 static StructCopyGVar CopyAndFopyGVars[MAX_COPY_AND_FOPY_GVARS];
 static Int NCopyAndFopyGVars = 0;

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -89,8 +89,8 @@
 **  'PtrGVars' is a pointer  to the 'ValGVars' bag+1. This makes it faster to
 **  access global variables.
 */
-Obj   ValGVars[GVAR_BUCKETS];
-Obj * PtrGVars[GVAR_BUCKETS];
+static Obj   ValGVars[GVAR_BUCKETS];
+static Obj * PtrGVars[GVAR_BUCKETS];
 #else
 /*
 **  'ValGVars' is the bag containing the values of the global variables.
@@ -102,8 +102,8 @@ Obj * PtrGVars[GVAR_BUCKETS];
 **  'PtrGVars' must be  revalculated afterwards.   This is done in function
 **  'GVarsAfterCollectBags' which is called by 'VarsAfterCollectBags'.
 */
-Obj   ValGVars;
-Obj * PtrGVars;
+static Obj   ValGVars;
+static Obj * PtrGVars;
 #endif
 
 
@@ -124,11 +124,11 @@ static Obj TLVars;
 **  than index and to initialize copy/fopy information.
 */
 
-pthread_rwlock_t GVarLock;
-void *GVarLockOwner;
-UInt GVarLockDepth;
+static pthread_rwlock_t GVarLock;
+static void *GVarLockOwner;
+static UInt GVarLockDepth;
 
-void LockGVars(int write) {
+static void LockGVars(int write) {
   if (PreThreadCreation)
     return;
   if (GVarLockOwner == realTLS) {
@@ -144,7 +144,7 @@ void LockGVars(int write) {
     pthread_rwlock_rdlock(&GVarLock);
 }
 
-void UnlockGVars() {
+static void UnlockGVars() {
   if (PreThreadCreation)
     return;
   if (GVarLockOwner == realTLS) {
@@ -205,12 +205,12 @@ inline Obj ValGVar(UInt gvar) {
 *V  CountGVars  . . . . . . . . . . . . . . . . .  number of global variables
 */
 #ifdef HPCGAP
-Obj             NameGVars[GVAR_BUCKETS];
-Obj             WriteGVars[GVAR_BUCKETS];
-Obj             ExprGVars[GVAR_BUCKETS];
-Obj             CopiesGVars[GVAR_BUCKETS];
-Obj             FopiesGVars[GVAR_BUCKETS];
-UInt            CountGVars;
+static Obj             NameGVars[GVAR_BUCKETS];
+static Obj             WriteGVars[GVAR_BUCKETS];
+static Obj             ExprGVars[GVAR_BUCKETS];
+static Obj             CopiesGVars[GVAR_BUCKETS];
+static Obj             FopiesGVars[GVAR_BUCKETS];
+static UInt            CountGVars;
 
 #define ELM_GVAR_LIST( list, gvar ) \
     ELM_PLIST( list[GVAR_BUCKET(gvar)], GVAR_INDEX(gvar) )
@@ -223,12 +223,12 @@ UInt            CountGVars;
 
 #else   // HPCGAP
 
-Obj             NameGVars;
-Obj             WriteGVars;
-Obj             ExprGVars;
-Obj             CopiesGVars;
-Obj             FopiesGVars;
-UInt            CountGVars;
+static Obj             NameGVars;
+static Obj             WriteGVars;
+static Obj             ExprGVars;
+static Obj             CopiesGVars;
+static Obj             FopiesGVars;
+static UInt            CountGVars;
 
 #define ELM_GVAR_LIST( list, gvar ) \
     ELM_PLIST( list, gvar )
@@ -247,8 +247,8 @@ UInt            CountGVars;
 *V  TableGVars  . . . . . . . . . . . . . .  hashed table of global variables
 *V  SizeGVars . . . . . . .  current size of hashed table of global variables
 */
-Obj             TableGVars;
-UInt            SizeGVars;
+static Obj             TableGVars;
+static UInt            SizeGVars;
 
 
 /****************************************************************************


### PR DESCRIPTION
This PR contains additional gvars related cleanup and refactoring.

It marks a bunch of local functions and variables as static, which might help the compiler optimize the code, and in any case, helps protect against somebody (ab)using direct access to these internal things.

It also introduces a new `#define USE_GVAR_BUCKETS`; the idea of that is that we now can turn on use of gvar buckets for non-HPC GAP, too, so we can evaluate how it impacts performance (positive? negative? neutral?), and potentially enable it for plain GAP, too.

However, note that if I actually do that, then weird errors occur, and I don't understand why; in particular, tests fail, complaining that `UnslicedPerm@` is not defined. Yet in interactive tests, this works fine.

Alas, as long as everything works in this PR, I don't think this is a blocker for merging it; still, if anybody has an idea what might be causing it, please speak up.