### PR TITLE
Info improvement

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -204,6 +204,8 @@ gap> InfoLevel(InfoWarning);
 <Heading>Customizing <Ref Func="Info"/> statements</Heading>
 <Func Arg="infoclass, handler" Name="SetInfoHandler" />
 <Func Arg="infoclass, out" Name="SetInfoOutput" />
+<Func Arg="infoclass" Name="UnbindInfoOutput" />
+<Func Arg="infoclass" Name="InfoOutput" />
 <Func Arg="out" Name="SetDefaultInfoOutput" />
 <Returns>nothing</Returns>
 <Description>
@@ -223,8 +225,10 @@ If the first argument of an <Ref Func="Info"/> statement is a sum of
 Info classes, the handler of the first summand is used.
 <P/>
 The file or stream to which <Ref Func="Info"/> statements for individual
-<Ref Func="Info"/> classes print can be changed with 
-<Ref Func="SetInfoOutput"/>. The initial default for all <Ref Func="Info"/>
+<Ref Func="Info"/> classes print can be overriden with
+<Ref Func="SetInfoOutput"/>, retrieved with <Ref Func="InfoOutput"/>
+and reset to the default with <Ref Func="UnbindInfoOutput"/>.
+The initial default for all <Ref Func="Info"/>
 classes is the string <C>"*Print*"</C> which means the current output
 file. The default can be changed with <Ref Func="SetDefaultInfoOutput"/>.  
 The argument <A>out</A> can be a filename or an open stream, 

--- a/hpcgap/lib/info.gi
+++ b/hpcgap/lib/info.gi
@@ -314,10 +314,26 @@ end);
 
 #############################################################################
 ##
+#F  InfoDecisionFast( <index>, <selector>, <level>)
 #F  InfoDecision( <selector>, <level>) .  decide whether a message is printed
 ##
-##  This is called by the kernel
+##  These are called by the kernel. InfoDecisionFast is used when
+##  <selectors> is a single object of type 'IsInfoClassListRep' and
+##  <level> is a positive small integer. In that case, <index> is
+##  <selectors![1]>.
 ##
+
+BIND_GLOBAL( "InfoDecisionFast", function(index, selector, level)
+    atomic InfoData do
+        if InfoData.CurrentLevels[index] >= level then
+            InfoData.LastClass := selector;
+            InfoData.LastLevel := level;
+            return true;
+        else
+            return false;
+        fi;
+    od;
+end);
 
 BIND_GLOBAL( "InfoDecision", function(selectors, level)
     local usage, ret;

--- a/hpcgap/lib/info.gi
+++ b/hpcgap/lib/info.gi
@@ -320,35 +320,39 @@ end);
 ##
 
 BIND_GLOBAL( "InfoDecision", function(selectors, level)
-    local usage;
-    usage := "Usage : InfoDecision(<selectors>, <level>)";
+    local usage, ret;
+    usage := "usage : Info(<selectors>, <level>, ...)";
     if not IsInt(level) or level <= 0 then
         if level = 0 then
-            Error("Level 0 info messages are not allowed");
+            Error("level 0 Info messages are not allowed");
         else
             Error(usage);
         fi;
     fi;
-   
-    # store the class and level
-    atomic InfoData do
-	if IsInfoClass(selectors) then
-	  InfoData.LastClass := selectors;
-	else
-	  InfoData.LastClass := selectors[1];
-	fi;
-        InfoData.LastLevel := level;
-    od;
 
     if IsInfoClass(selectors) then
-        return InfoLevel(selectors) >= level;
+        ret := InfoLevel(selectors) >= level;
     elif IsInfoSelector(selectors)  then
 
         # note that we 'or' the classes together
-        return ForAny(selectors, ic -> InfoLevel(ic) >= level);
+        ret := ForAny(selectors, ic -> InfoLevel(ic) >= level);
     else
         Error(usage);
     fi;
+
+    if ret then
+        # store the class and level
+        atomic InfoData do
+            if IsInfoClass(selectors) then
+                InfoData.LastClass := selectors;
+            else
+                InfoData.LastClass := selectors[1];
+            fi;
+            InfoData.LastLevel := level;
+        od;
+    fi;
+
+    return ret;
 end );
     
 #############################################################################

--- a/hpcgap/lib/info.gi
+++ b/hpcgap/lib/info.gi
@@ -71,15 +71,8 @@ InstallGlobalFunction( "SetDefaultInfoOutput", function( out )
 end);
 
 InstallGlobalFunction( "DefaultInfoHandler", function( infoclass, level, list )
-  local cl, out, fun, s;
-  atomic readonly InfoData do
-  cl := InfoData.LastClass![1];
-  if IsBound(InfoData.Output[cl]) then
-    out := InfoData.Output[cl];
-  else
-    out := DefaultInfoOutput;
-  fi;
-  od;
+  local out, fun, s;
+  out := InfoOutput(infoclass);
 
   if out = "*Print*" then
     if IsBoundGlobal( "PrintFormattedString" ) then
@@ -191,6 +184,22 @@ InstallGlobalFunction( SetInfoOutput, function(class, out)
     atomic readwrite InfoData do
     InfoData.Output[class![1]] := out;
     od;
+end);
+
+InstallGlobalFunction( UnbindInfoOutput, function(class)
+  atomic readwrite InfoData do
+  Unbind(InfoData.Output[class![1]]);
+  od;
+end);
+
+InstallGlobalFunction( InfoOutput, function(class)
+  atomic readwrite InfoData do
+  if IsBound(InfoData.Output[class![1]]) then
+    return InfoData.Output[class![1]];
+  else
+    return DefaultInfoOutput;
+  fi;
+  od;
 end);
 
 #############################################################################

--- a/lib/info.gd
+++ b/lib/info.gd
@@ -132,11 +132,10 @@ DeclareGlobalFunction("DefaultInfoHandler");
 
 #############################################################################
 ##
-#O  SetInfoOutput( <selector>, <out> )
 ##  
-##  <out> must be output file name or stream
-##  
+DeclareGlobalFunction("UnbindInfoOutput");
 DeclareGlobalFunction("SetInfoOutput");
+DeclareGlobalFunction("InfoOutput");
 DeclareGlobalFunction("SetDefaultInfoOutput");
 BIND_GLOBAL("DefaultInfoOutput", MakeImmutable("*Print*"));
 

--- a/lib/info.gi
+++ b/lib/info.gi
@@ -287,10 +287,24 @@ end);
 
 #############################################################################
 ##
+#F  InfoDecisionFast( <index>, <selector>, <level>)
 #F  InfoDecision( <selector>, <level>) .  decide whether a message is printed
 ##
-##  This is called by the kernel
+##  These are called by the kernel. InfoDecisionFast is used when
+##  <selectors> is a single object of type 'IsInfoClassListRep' and
+##  <level> is a positive small integer. In that case, <index> is
+##  <selectors![1]>.
 ##
+
+BIND_GLOBAL( "InfoDecisionFast", function(index, selector, level)
+    if InfoData.CurrentLevels[index] >= level then
+        InfoData.LastClass := selector;
+        InfoData.LastLevel := level;
+        return true;
+    else
+        return false;
+    fi;
+end);
 
 BIND_GLOBAL( "InfoDecision", function(selectors, level)
     local usage, ret;

--- a/lib/info.gi
+++ b/lib/info.gi
@@ -71,13 +71,8 @@ InstallGlobalFunction( "SetDefaultInfoOutput", function( out )
 end);
 
 InstallGlobalFunction( "DefaultInfoHandler", function( infoclass, level, list )
-  local cl, out, fun, s;
-  cl := InfoData.LastClass![1];
-  if IsBound(InfoData.Output[cl]) then
-    out := InfoData.Output[cl];
-  else
-    out := DefaultInfoOutput;
-  fi;
+  local out, fun, s;
+  out := InfoOutput(infoclass);
   if out = "*Print*" then
     if IsBoundGlobal( "PrintFormattedString" ) then
       fun := function(s)
@@ -175,6 +170,18 @@ end);
 ##
 InstallGlobalFunction( SetInfoOutput, function(class, out)
   InfoData.Output[class![1]] := out;
+end);
+
+InstallGlobalFunction( UnbindInfoOutput, function(class)
+  Unbind(InfoData.Output[class![1]]);
+end);
+
+InstallGlobalFunction( InfoOutput, function(class)
+  if IsBound(InfoData.Output[class![1]]) then
+    return InfoData.Output[class![1]];
+  else
+    return DefaultInfoOutput;
+  fi;
 end);
 
 #############################################################################

--- a/lib/info.gi
+++ b/lib/info.gi
@@ -293,33 +293,38 @@ end);
 ##
 
 BIND_GLOBAL( "InfoDecision", function(selectors, level)
-    local usage;
-    usage := "Usage : InfoDecision(<selectors>, <level>)";
+    local usage, ret;
+    usage := "usage : Info(<selectors>, <level>, ...)";
     if not IsInt(level) or level <= 0 then
         if level = 0 then
-            Error("Level 0 info messages are not allowed");
+            Error("level 0 Info messages are not allowed");
         else
             Error(usage);
         fi;
     fi;
-   
-    # store the class and level
-    if IsInfoClass(selectors) then
-      InfoData.LastClass := selectors;
-    else
-      InfoData.LastClass := selectors[1];
-    fi;
-    InfoData.LastLevel := level;
 
+    ret := false;
+    
     if IsInfoClass(selectors) then
-        return InfoLevel(selectors) >= level;
+        ret := InfoLevel(selectors) >= level;
     elif IsInfoSelector(selectors)  then
-
         # note that we 'or' the classes together
-        return ForAny(selectors, ic -> InfoLevel(ic) >= level);
+        ret :=  ForAny(selectors, ic -> InfoLevel(ic) >= level);
     else
         Error(usage);
     fi;
+
+    if ret then
+        # store the class and level
+        if IsInfoClass(selectors) then
+            InfoData.LastClass := selectors;
+        else
+            InfoData.LastClass := selectors[1];
+        fi;
+        InfoData.LastLevel := level;
+    fi;
+
+    return ret;
 end );
     
 #############################################################################

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -4682,7 +4682,22 @@ void            IntrInfoBegin( void )
 
 }
 
-Obj             InfoDecision;
+static Obj InfoDecision;
+static Obj InfoDecisionFast;
+static Obj IsInfoClassListRep;
+
+Obj InfoCheckLevel(Obj selectors, Obj level)
+{
+    if (IS_POS_INTOBJ(level) &&
+        CALL_1ARGS(IsInfoClassListRep, selectors) == True) {
+        Obj index = ELM_PLIST(selectors, 1);
+        return CALL_3ARGS(InfoDecisionFast, index, selectors, level);
+    }
+    else {
+        return CALL_2ARGS(InfoDecision, selectors, level);
+    }
+}
+
 
 void            IntrInfoMiddle( void )
 {
@@ -4700,7 +4715,9 @@ void            IntrInfoMiddle( void )
 
     level = PopObj();
     selectors = PopObj();
-    selected = CALL_2ARGS( InfoDecision, selectors, level);
+
+    selected = InfoCheckLevel(selectors, level);
+
     if (selected == False)
       STATE(IntrIgnoring) = 1;
     return;
@@ -4882,7 +4899,9 @@ static Int InitKernel (
 
     /* The work of handling Info messages is delegated to the GAP level */
     ImportFuncFromLibrary( "InfoDecision", &InfoDecision );
+    ImportFuncFromLibrary("InfoDecisionFast", &InfoDecisionFast);
     ImportFuncFromLibrary( "InfoDoPrint",  &InfoDoPrint  );
+    ImportFuncFromLibrary("IsInfoClassListRep", &IsInfoClassListRep);
 
     /* The work of handling Options is also delegated*/
     ImportFuncFromLibrary( "PushOptions", &PushOptions );

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -918,7 +918,7 @@ extern void             IntrEmpty ( void );
 *F  IntrInfoBegin() . . . . . . . . .  start interpretation of Info statement
 *F  IntrInfoMiddle()  . . . . . .  shift to interpreting printable arguments
 *F  IntrInfoEnd( <narg> ) . . Info statement complete, <narg> things to print
-*V  InfoDecision . . . . . . . . . . .  fopy of the InfoDecision GAP function
+*V  InfoCheckLevel(<selectors>,<level>) . . . . . check if Info should output
 *V  InfoDoPrint  . . . . . . . . . . .  fopy of the InfoDoPrint GAP function
 */
 
@@ -926,7 +926,7 @@ extern void             IntrInfoBegin ( void );
 extern void             IntrInfoMiddle( void );
 extern void             IntrInfoEnd   (
            UInt                   narg );
-extern Obj              InfoDecision;
+extern Obj              InfoCheckLevel(Obj, Obj);
 extern Obj              InfoDoPrint;
 
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -1494,7 +1494,7 @@ UInt ExecInfo (
     SET_BRK_CALL_TO( stat );
     SET_BRK_CURR_STAT( stat );
 
-    selected = CALL_2ARGS(InfoDecision, selectors, level);
+    selected = InfoCheckLevel(selectors, level);
     if (selected == True) {
 
         /* Get the number of arguments to be printed                       */

--- a/tst/teststandard/info.tst
+++ b/tst/teststandard/info.tst
@@ -45,6 +45,28 @@ gap> Info(InfoTest1 + InfoTest2, 0);
 Error, level 0 Info messages are not allowed
 gap> Info(InfoTest1 + InfoTest2, "apple");
 Error, usage : Info(<selectors>, <level>, ...)
+gap> str := "";;
+gap> str2 := "";;
+gap> SetDefaultInfoOutput(OutputTextString(str, false));
+gap> SetInfoOutput(InfoTest1, OutputTextString(str2, false));
+gap> Info(InfoTest1, 2, "No");
+gap> Info(InfoTest1, 1, "One");
+gap> Info(InfoTest2, 2, "Two");
+gap> Info(InfoTest1 + InfoTest2, 2, "OneTwo");
+gap> Info(InfoTest2 + InfoTest1, 2, "TwoOne");
+gap> IsOutputTextStringRep(InfoOutput(InfoTest2));
+true
+gap> IsOutputTextStringRep(InfoOutput(InfoTest1));
+true
+gap> UnbindInfoOutput(InfoTest1);
+gap> Info(InfoTest1, 1, "NormalOut");
+gap> str;
+"#I  Two\n#I  NormalOut\n"
+gap> str2;
+"#I  One\n#I  OneTwo\n#I  TwoOne\n"
+gap> SetDefaultInfoOutput(MakeImmutable("*Print*"));
+gap> Info(InfoTest2, 1, "NormalOut");
+#I  NormalOut
 gap> STOP_TEST("info.tst", 1);
 
 #############################################################################

--- a/tst/teststandard/info.tst
+++ b/tst/teststandard/info.tst
@@ -8,6 +8,7 @@
 ##
 gap> START_TEST("info.tst");
 gap> InfoTest1 := NewInfoClass("InfoTest1");;
+gap> InfoTest2 := NewInfoClass("InfoTest2");;
 gap> InfoLevel(InfoTest1);
 0
 gap> Info(InfoTest1, 1, "No");
@@ -25,6 +26,25 @@ gap> Info(InfoTest1, 1, (1,2)(3,4));
 #I  (1,2)(3,4)
 gap> Info(InfoTest1, 1, ['a', 'b', 'c']);
 #I  abc
+gap> Info(InfoTest2, 1, "apple");
+gap> Info(InfoTest1 + InfoTest2, 1, "apple");
+#I  apple
+gap> SetInfoLevel(InfoTest2, 2);
+gap> Info(InfoTest2, 2, "apple");
+#I  apple
+gap> Info(InfoTest1 + InfoTest2, 2, "apple");
+#I  apple
+gap> Info(InfoTest1 + InfoTest2, 3, "apple");
+gap> Info(1,2,3);
+Error, usage : Info(<selectors>, <level>, ...)
+gap> Info(InfoTest1,0,3);
+Error, level 0 Info messages are not allowed
+gap> Info(InfoTest1,"apple",3);
+Error, usage : Info(<selectors>, <level>, ...)
+gap> Info(InfoTest1 + InfoTest2, 0);
+Error, level 0 Info messages are not allowed
+gap> Info(InfoTest1 + InfoTest2, "apple");
+Error, usage : Info(<selectors>, <level>, ...)
 gap> STOP_TEST("info.tst", 1);
 
 #############################################################################


### PR DESCRIPTION
I was surprised to find that `Info` is slower than writing `if gvar >= value then Print(...); fi;` -- around 30 times slower.

This adds a fast-path optimisation which reduces this to 5 times slower. It also adds some more tests.

I have a patch which reduces the gap down to 2x, but it requires changing the data structures used in `Info` which breaks GAPDoc, as GAPDoc digs around inside `Info`s current datastructures.

EDIT: Added some more methods, which should remove the need for GAPDoc (and anyone else) to look inside the datastructures which `Info` is built on. This will mean after GAPDoc is changed we can rearrange the datastructures to make them (a) more efficient and (b) more easily thread-safe.