### PR TITLE
Define _GNU_SOURCE only locally, where it is needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,12 +24,6 @@ AC_LANG([C])
 
 
 dnl
-dnl Use _GNU_SOURCE enable extensions like exp10 in glibc
-dnl
-AC_DEFINE([_GNU_SOURCE], [], [Enable GNU extensions in glibc])
-
-
-dnl
 dnl ABI settings
 dnl
 AC_ARG_VAR(ABI, [Set this equal to 32 or 64 to build GAP (and GMP provided you

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -11,6 +11,17 @@
 **
 ** macfloats are stored as bags containing a 64 bit value
 */
+
+
+// glibc only declares exp10 in its headers if we define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <math.h>
+
+
+
 #include <src/system.h>                 /* system dependent part */
 #include <src/gapstate.h>
 
@@ -42,7 +53,6 @@ extern Double LoadDouble( void);
 extern void SaveDouble( Double d);
 
 #include <stdio.h>
-#include <math.h>
 #include <stdlib.h>
 
 #define SIZE_MACFLOAT   sizeof(Double)


### PR DESCRIPTION
Resolves #1437
