### PR TITLE
travis: print gcov version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ matrix:
     - env: TEST_SUITE=testerror CONFIGFLAGS="--enable-debug"
 
 script:
+  - gcov --version
   - bash etc/ci-prepare.sh
   - bash etc/ci.sh
 


### PR DESCRIPTION
Some versions of gcov are buggy, so it's useful to be able to see in build logs which version was used to gather coverage.