### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,15 @@
 /obj/
 
 /build/
+/extern/build/
+/extern/install/
 
 /gac
 /gap
 /sysinfo.gap
+/sysinfo.gap-*
 
+/doc/make_doc
 /doc/manualbib.xml.bib
 /doc/*/*.html
 /doc/*/*.txt


### PR DESCRIPTION
The new build system places additional gmp folders into /extern.
Compiling the documentation now also creates the file /doc/make_doc.