### PR TITLE
Fix DoImmutableMatrix for finite fields

### DIFF
--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1399,7 +1399,7 @@ end);
 ##
 #F  ImmutableMatrix( <field>, <matrix> [,<change>] ) 
 ##
-DoImmutableMatrix:=function(field,matrix,change)
+BindGlobal("DoImmutableMatrix", function(field,matrix,change)
 local sf, rep, ind, ind2, row, i,big,l;
   if not (IsPlistRep(matrix) or IsGF2MatrixRep(matrix) or
     Is8BitMatrixRep(matrix)) then
@@ -1411,12 +1411,12 @@ local sf, rep, ind, ind2, row, i,big,l;
   else
     if not IsField(field) then
       # not a field
-      return Immutable(matrix);
+      return matrix;
     fi;
     sf:=Size(field);
   fi;
 
-  big:=sf>256 or sf=0;
+  big:=sf>256 or sf=0 or (sf <= 256 and not field=GF(sf));
 
   # the representation we want the rows to be in
   if sf=2 then
@@ -1473,18 +1473,20 @@ local sf, rep, ind, ind2, row, i,big,l;
   fi;
 
   # this can only happen if not big
-  for i in ind do
-    ConvertToVectorRepNC(matrix[i],sf);
-  od;
+  if not big then
+    for i in ind do
+      ConvertToVectorRepNC(matrix[i],sf);
+    od;
+  fi;
 
   MakeImmutable(matrix);
-  if sf=2 and not IsGF2MatrixRep(matrix) then
+  if not big and sf=2 and not IsGF2MatrixRep(matrix) then
     CONV_GF2MAT(matrix);
-  elif sf>2 and sf<=256 and not Is8BitMatrixRep(matrix) then
+  elif not big and sf>2 and sf<=256 and not Is8BitMatrixRep(matrix) then
     CONV_MAT8BIT(matrix,sf);
   fi;
   return matrix;
-end;
+end);
 
 InstallMethod( ImmutableMatrix,"general,2",[IsObject,IsMatrix],0,
 function(f,m)

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1411,12 +1411,12 @@ local sf, rep, ind, ind2, row, i,big,l;
   else
     if not IsField(field) then
       # not a field
-      return matrix;
+      return Immutable(matrix);
     fi;
     sf:=Size(field);
   fi;
 
-  big:=sf>256 or sf=0 or (sf <= 256 and not field=GF(sf));
+  big:=sf>256 or sf=0 or not IsFFECollection(field);
 
   # the representation we want the rows to be in
   if sf=2 then

--- a/tst/testbugfix/2017-07-06-DoImmutableMatrix.tst
+++ b/tst/testbugfix/2017-07-06-DoImmutableMatrix.tst
@@ -1,0 +1,9 @@
+# handling of finite fields of size q <= 256 but not GF(q)
+gap> f1 := AlgebraicExtension(GF(3), CyclotomicPolynomial(GF(3), 5));
+<algebra-with-one of dimension 4 over GF(3)>
+gap> a := RootOfDefiningPolynomial(f1);
+a
+gap> mat := [[a]];
+[ [ a ] ]
+gap> DoImmutableMatrix(f1, mat, false);
+[ [ a ] ]


### PR DESCRIPTION
DoImmutableMatrix wrongly assumed that finite fields of order q <= 256
are represented as GF(q) and applied the NC versions of ConvertToMatrixRep
to matrices over such fields which produced corrupted objects. E.g.:
```
gap> f1 := AlgebraicExtension(GF(3), CyclotomicPolynomial(GF(3), 5));;
gap> a := RootOfDefiningPolynomial(f1);;
gap> mat := [[a]];;
gap> DoImmutableMatrix(f1, mat, false);
< immutable compressed matrix 1x393286524 over GF(26) >
```