### PR TITLE
Avoid irreducibility test in `AlgebraicExtension`

### DIFF
--- a/lib/algfld.gi
+++ b/lib/algfld.gi
@@ -65,10 +65,8 @@ InstallMethod(AlgebraicElementsFamily,"generic",true,
   [IsField,IsUnivariatePolynomial],0,
 function(f,p)
 local fam,i,cof,red,rchar,impattr,deg;
-  if not
-  IsIrreducibleRingElement(PolynomialRing(f,
-             [IndeterminateNumberOfLaurentPolynomial(p)]),p) then
-    Error("<p> must be irreducible over f");
+  if not ForAll(CoefficientsOfUnivariatePolynomial(p), c-> c in f) then
+    Error("<p> must be an irreducible polynomial with coefficients in <f>");
   fi;
   fam:=AlgebraicElementsFamilies(p);
   i:=PositionProperty(fam,i->i[1]=f);

--- a/tst/testbugfix/2017-07-06-FastAlgebraicExtension.tst
+++ b/tst/testbugfix/2017-07-06-FastAlgebraicExtension.tst
@@ -1,0 +1,13 @@
+# this should be fast and avoid irreducibility tests
+gap> t := Runtime();;
+gap> f0 := GF(13);;
+gap> p1 := CyclotomicPolynomial(f0, 5);;
+gap> f1 := AlgebraicExtension(f0, p1);;
+gap> p2 := Indeterminate(f1)^5 - RootOfDefiningPolynomial(f1);;
+gap> f2 := AlgebraicExtension(f1, p2);;
+gap> p3 := Indeterminate(f2)^5 - RootOfDefiningPolynomial(f2);;
+gap> f3 := AlgebraicExtension(f2, p3);;
+gap> p4 := Indeterminate(f3)^5 - RootOfDefiningPolynomial(f3);;
+gap> f4 := AlgebraicExtension(f3, p4);;
+gap> Runtime() - t < 1000;
+true


### PR DESCRIPTION
`AlgebraicExtension` is mainly an administrative function. It should not
spend considerable time with testing its input polynomial for irreducibility
(it is an error anyway if the polynomial is reducible, this should be tested
by the user beforehand, or be clear from the mathematical context).

This pull request substitutes the irreducibility test by the much cheaper
test, if the given polynomial has coefficients in the base field.
This test seems sensible, for example in case of iterated algebraic
extensions, where a user may want to use a polynomial over a subfield which
first needs to be rewritten over the larger field.