### PR TITLE
Some fixes for MPI code

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -104,11 +104,12 @@ else
   SOURCES += src/gasman.c
 endif
 
+ifeq ($(GAPMPI),yes)
+  SOURCES += src/hpc/gapmpi.c
+endif
+
 ifeq ($(HPCGAP),yes)
   SOURCES += src/hpc/aobjects.c
-  ifeq ($(GAPMPI),yes)
-    SOURCES += src/hpc/gapmpi.c
-  endif
   SOURCES += src/hpc/misc.c
   SOURCES += src/hpc/serialize.c
   SOURCES += src/hpc/thread.c

--- a/src/hpc/gapmpi.c
+++ b/src/hpc/gapmpi.c
@@ -105,7 +105,7 @@ Obj UNIX_Realtime( Obj self ) /* Time since beginning in seconds */
 }
 
 Obj UNIX_Alarm( Obj self, Obj seconds )
-{ if ( seconds > 0 )
+{ if ( INT_INTOBJ(seconds) > 0 )
     Pr("This process will die in %d seconds.  Call with arg, 0, to cancel.\n",
        INT_INTOBJ(seconds), 0L);
   else Pr("Alarm cancelled", 0L, 0L);
@@ -367,7 +367,6 @@ Obj MPIcomm_rank( Obj self )
 /* This assumes same datatype units as last receive, or MPI_CHAR if no recv */
 Obj MPIget_count( Obj self )
 { int count, b;
-  Obj bob;
   if (last_datatype == UNINITIALIZED) last_datatype = MPI_CHAR;
   MPI_Comm_rank (MPI_COMM_WORLD, &b);
   MPI_Get_count(&last_status, last_datatype, &count);
@@ -421,7 +420,7 @@ Obj MPIattr_get( Obj self, Obj keyval )
   MPI_Attr_get(MPI_COMM_WORLD, INT_INTOBJ(keyval), &attribute_val, &flag);
 /* if (INT_INTOBJ(keyval) == MPI_HOST) flag = 0; */
   if (!flag) return False;
-  return INTOBJ_INT(attribute_val);
+  return INTOBJ_INT((Int)attribute_val);
 }
 
 
@@ -446,13 +445,12 @@ Obj MPIsend( Obj self, Obj args )
 
 Obj MPIbinsend( Obj self, Obj args )
 { Obj buf, dest, tag, size;
-  int s,i;
   MPIARGCHK(3, 4, MPI_Binsend( <string buf>, <int dest>, <int size>, [, <opt int tag = 0> ] ));
   buf = ELM_LIST( args, 1 );
   dest = ELM_LIST( args, 2 );
   size = ELM_LIST (args, 3);
   tag = ( LEN_LIST(args) > 3 ? ELM_LIST( args, 4 ) : 0 );
-  s = MPI_Send( ((char*)CSTR_STRING(buf)),
+  MPI_Send( ((char*)CSTR_STRING(buf)),
             INT_INTOBJ(size), /* don't incl. \0 */
             MPI_CHAR, INT_INTOBJ(dest), INT_INTOBJ(tag),
             MPI_COMM_WORLD);
@@ -675,7 +673,7 @@ static StructGVarFunc GVarFuncs [] = {
     { "MPI_Probe" , -1, "args", MPIprobe, "src/gapmpi.c:MPI_Probe" },
     { "MPI_Iprobe" , -1, "args", MPIiprobe, "src/gapmpi.c:MPI_Iprobe" },
 
-    { 0, 0, 0, 0, 0, 0 }
+    { 0, 0, 0, 0, 0 }
 
 };
 


### PR DESCRIPTION
Note that even with these changes, and with CPPFLAGS / LDFLAGS suitably set to ensure `mpi.h` is includeable, and also GAP is linked against an MPI lib, one still cannot compile the code, as it uses `READ_ERROR`, which was replaced by `TRY_READ` in 4ded0567feb5bdd2a719fc68b06f28d4d96a4b92

Now, I could try to "fix" that in the code, in the sense of making it compile again. But I have absolutely no idea how to then actually *test* the result.

Also, just looking at the other unresolved warnings shows that `MPIattr_get` is buggy (it treats a void pointer as an int), and also the MPI function `MPI_Attr_get` it calls is "is deprecated as of MPI-2, and was deleted in MPI-3", according to <https://www.open-mpi.org/doc/v2.1/man3/MPI_Attr_get.3.php>

Looking at the code in there, it seems to not have been maintained for years, and overall is in a bad shape. Unless somebody steps up to fix it (and/or the pargap package), I think we are better off removing it, and also removing the pargap package from distribution.

Of course such a step should be discussed on the gap mailing list, too.