### PR TITLE
Run clang-format on src/hpc/*.c

### DIFF
--- a/src/hpc/misc.c
+++ b/src/hpc/misc.c
@@ -35,56 +35,64 @@ UInt SyNumProcessors = 4;
 UInt SyNumGCThreads = 0;
 
 
-
 /****************************************************************************
 **
 *F  MergeSort helpers
 **
 */
 
-static void Merge(char *to, char *from1, UInt size1, char *from2,
-  UInt size2, UInt width, int (*lessThan)(const void *a, const void *b))
+static void Merge(char * to,
+                  char * from1,
+                  UInt   size1,
+                  char * from2,
+                  UInt   size2,
+                  UInt   width,
+                  int (*lessThan)(const void * a, const void * b))
 {
-  while (size1 && size2) {
-    if (lessThan(from1, from2)) {
-      memcpy(to, from1, width);
-      from1 += width;
-      size1--;
-    } else {
-      memcpy(to, from2, width);
-      from2 += width;
-      size2--;
+    while (size1 && size2) {
+        if (lessThan(from1, from2)) {
+            memcpy(to, from1, width);
+            from1 += width;
+            size1--;
+        }
+        else {
+            memcpy(to, from2, width);
+            from2 += width;
+            size2--;
+        }
+        to += width;
     }
-    to += width;
-  }
-  if (size1)
-    memcpy(to, from1, size1*width);
-  else
-    memcpy(to, from2, size2*width);
+    if (size1)
+        memcpy(to, from1, size1 * width);
+    else
+        memcpy(to, from2, size2 * width);
 }
 
-static void MergeSortRecurse(char *data, char *aux, UInt count, UInt width,
-  int (*lessThan)(const void *a, const void *))
+static void MergeSortRecurse(char * data,
+                             char * aux,
+                             UInt   count,
+                             UInt   width,
+                             int (*lessThan)(const void * a, const void *))
 {
-  UInt nleft, nright;
-  /* assert(count > 1); */
-  if (count == 2) {
-    if (!lessThan(data, data+width))
-    {
-      memcpy(aux, data, width);
-      memcpy(data, data+width, width);
-      memcpy(data+width, aux, width);
+    UInt nleft, nright;
+    /* assert(count > 1); */
+    if (count == 2) {
+        if (!lessThan(data, data + width)) {
+            memcpy(aux, data, width);
+            memcpy(data, data + width, width);
+            memcpy(data + width, aux, width);
+        }
+        return;
     }
-    return;
-  }
-  nleft = count/2;
-  nright = count-nleft;
-  if (nleft > 1)
-    MergeSortRecurse(data, aux, nleft, width, lessThan);
-  if (nright > 1)
-    MergeSortRecurse(data+nleft*width, aux+nleft*width, nright, width, lessThan);
-  memcpy(aux, data, count*width);
-  Merge(data, aux, nleft, aux+nleft*width, nright, width, lessThan);
+    nleft = count / 2;
+    nright = count - nleft;
+    if (nleft > 1)
+        MergeSortRecurse(data, aux, nleft, width, lessThan);
+    if (nright > 1)
+        MergeSortRecurse(data + nleft * width, aux + nleft * width, nright,
+                         width, lessThan);
+    memcpy(aux, data, count * width);
+    Merge(data, aux, nleft, aux + nleft * width, nright, width, lessThan);
 }
 
 /****************************************************************************
@@ -97,10 +105,12 @@ static void MergeSortRecurse(char *data, char *aux, UInt count, UInt width,
 **  than the second argument, zero otherwise.
 */
 
-void MergeSort(void *data, UInt count, UInt width,
-  int (*lessThan)(const void *a, const void *))
+void MergeSort(void * data,
+               UInt   count,
+               UInt   width,
+               int (*lessThan)(const void * a, const void *))
 {
-  char *aux = alloca(count * width);
-  if (count > 1)
-    MergeSortRecurse(data, aux, count, width, lessThan);
+    char * aux = alloca(count * width);
+    if (count > 1)
+        MergeSortRecurse(data, aux, count, width, lessThan);
 }

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -21,11 +21,10 @@
 #include <string.h>
 #include <stdio.h>
 
-#define SERIALIZER \
-	((SerializerInterface *)(STATE(SerializationDispatcher)))
+#define SERIALIZER ((SerializerInterface *)(STATE(SerializationDispatcher)))
 
-#define DESERIALIZER \
-	((DeserializerInterface *)(STATE(SerializationDispatcher)))
+#define DESERIALIZER                                                         \
+    ((DeserializerInterface *)(STATE(SerializationDispatcher)))
 
 /**
  *  `POS_NUMB_TYPE`
@@ -41,621 +40,694 @@
 
 #ifndef WARD_ENABLED
 
-SerializationFunction SerializationFuncByTNum[256];
+SerializationFunction   SerializationFuncByTNum[256];
 DeserializationFunction DeserializationFuncByTNum[256];
 
 
-static void DeserializationError() {
-  ErrorQuit("Bad deserialization input", 0L, 0L);
+static void DeserializationError()
+{
+    ErrorQuit("Bad deserialization input", 0L, 0L);
 }
 
 /* Manage serialization state */
 
 typedef struct SerializationState {
-  Obj SerializationObj;
-  UInt SerializationIndex;
-  void *SerializationDispatcher;
-  Obj SerializationRegistry;
-  Obj SerializationStack;
+    Obj    SerializationObj;
+    UInt   SerializationIndex;
+    void * SerializationDispatcher;
+    Obj    SerializationRegistry;
+    Obj    SerializationStack;
 } SerializationState;
 
-void SaveSerializationState(volatile SerializationState *state) {
-  state->SerializationObj = STATE(SerializationObj);
-  state->SerializationIndex = STATE(SerializationIndex);
-  state->SerializationDispatcher = STATE(SerializationDispatcher);
-  state->SerializationRegistry = STATE(SerializationRegistry);
-  state->SerializationStack = STATE(SerializationStack);
+void SaveSerializationState(volatile SerializationState * state)
+{
+    state->SerializationObj = STATE(SerializationObj);
+    state->SerializationIndex = STATE(SerializationIndex);
+    state->SerializationDispatcher = STATE(SerializationDispatcher);
+    state->SerializationRegistry = STATE(SerializationRegistry);
+    state->SerializationStack = STATE(SerializationStack);
 }
 
-void RestoreSerializationState(volatile SerializationState *state) {
-  STATE(SerializationObj) = state->SerializationObj;
-  STATE(SerializationIndex) = state->SerializationIndex;
-  STATE(SerializationDispatcher) = state->SerializationDispatcher;
-  STATE(SerializationRegistry) = state->SerializationRegistry;
-  STATE(SerializationStack) = state->SerializationStack;
+void RestoreSerializationState(volatile SerializationState * state)
+{
+    STATE(SerializationObj) = state->SerializationObj;
+    STATE(SerializationIndex) = state->SerializationIndex;
+    STATE(SerializationDispatcher) = state->SerializationDispatcher;
+    STATE(SerializationRegistry) = state->SerializationRegistry;
+    STATE(SerializationStack) = state->SerializationStack;
 }
 
 
 /* Native string serialization */
 
-static void ReserveBytesNativeString(UInt count) {
-  Obj target = STATE(SerializationObj);
-  UInt size = GET_LEN_STRING(target);
-  GROW_STRING(target, size + count + 1);
+static void ReserveBytesNativeString(UInt count)
+{
+    Obj  target = STATE(SerializationObj);
+    UInt size = GET_LEN_STRING(target);
+    GROW_STRING(target, size + count + 1);
 }
 
-static void WriteBytesNativeStringDirect(void *addr, UInt count) {
-  Obj target = STATE(SerializationObj);
-  UInt size = GET_LEN_STRING(target);
-  memcpy(CSTR_STRING(target)+size, addr, count);
-  SET_LEN_STRING(target, size+count);
+static void WriteBytesNativeStringDirect(void * addr, UInt count)
+{
+    Obj  target = STATE(SerializationObj);
+    UInt size = GET_LEN_STRING(target);
+    memcpy(CSTR_STRING(target) + size, addr, count);
+    SET_LEN_STRING(target, size + count);
 }
 
-static void WriteBytesNativeString(void *addr, UInt count) {
-  Obj target = STATE(SerializationObj);
-  UInt size = GET_LEN_STRING(target);
-  GROW_STRING(target, size + count + 1);
-  memcpy(CSTR_STRING(target) + size, addr, count);
-  SET_LEN_STRING(target, size + count);
+static void WriteBytesNativeString(void * addr, UInt count)
+{
+    Obj  target = STATE(SerializationObj);
+    UInt size = GET_LEN_STRING(target);
+    GROW_STRING(target, size + count + 1);
+    memcpy(CSTR_STRING(target) + size, addr, count);
+    SET_LEN_STRING(target, size + count);
 }
 
-static void WriteTNumNativeString(UInt tnum) {
-  UChar buf[1];
-  buf[0] = (UChar) tnum;
-  WriteBytesNativeString(buf, 1);
+static void WriteTNumNativeString(UInt tnum)
+{
+    UChar buf[1];
+    buf[0] = (UChar)tnum;
+    WriteBytesNativeString(buf, 1);
 }
 
-static void WriteByteNativeString(UChar byte) {
-  UChar buf[1];
-  buf[0] = (UChar) byte;
-  WriteBytesNativeString(buf, 1);
+static void WriteByteNativeString(UChar byte)
+{
+    UChar buf[1];
+    buf[0] = (UChar)byte;
+    WriteBytesNativeString(buf, 1);
 }
 
 #define ADDR_BYTE(obj) ((UChar *)ADDR_OBJ(obj))
 
-static void WriteByteBlockNativeString(Obj obj, UInt offset, UInt len) {
-  WriteBytesNativeString(&len, sizeof(len));
-  ReserveBytesNativeString(len);
-  WriteBytesNativeStringDirect(ADDR_BYTE(obj) + offset, len);
+static void WriteByteBlockNativeString(Obj obj, UInt offset, UInt len)
+{
+    WriteBytesNativeString(&len, sizeof(len));
+    ReserveBytesNativeString(len);
+    WriteBytesNativeStringDirect(ADDR_BYTE(obj) + offset, len);
 }
 
-static void WriteImmediateObjNativeString(Obj obj) {
-  WriteBytesNativeString(&obj, sizeof(obj));
+static void WriteImmediateObjNativeString(Obj obj)
+{
+    WriteBytesNativeString(&obj, sizeof(obj));
 }
 
 static SerializerInterface NativeStringSerializer = {
-  WriteTNumNativeString,
-  WriteByteNativeString,
-  WriteByteBlockNativeString,
-  WriteImmediateObjNativeString,
+    WriteTNumNativeString, WriteByteNativeString, WriteByteBlockNativeString,
+    WriteImmediateObjNativeString,
 };
 
-static void InitNativeStringSerializer(Obj string) {
-  STATE(SerializationStack) = NEW_PLIST(T_PLIST, 0);
-  STATE(SerializationRegistry) = NewObjMap();
-  STATE(SerializationDispatcher) = &NativeStringSerializer;
-  STATE(SerializationObj) = string;
-  STATE(SerializationIndex) = 0;
+static void InitNativeStringSerializer(Obj string)
+{
+    STATE(SerializationStack) = NEW_PLIST(T_PLIST, 0);
+    STATE(SerializationRegistry) = NewObjMap();
+    STATE(SerializationDispatcher) = &NativeStringSerializer;
+    STATE(SerializationObj) = string;
+    STATE(SerializationIndex) = 0;
 }
 
 /* Native string deserialization */
 
-static void ReadBytesNativeString(void *addr, UInt size) {
-  Obj str = STATE(SerializationObj);
-  UInt max = GET_LEN_STRING(str);
-  UInt off = STATE(SerializationIndex);
-  if (off + size > max)
-    DeserializationError();
-  memcpy(addr, CSTR_STRING(str)+off, size);
-  STATE(SerializationIndex) += size;
+static void ReadBytesNativeString(void * addr, UInt size)
+{
+    Obj  str = STATE(SerializationObj);
+    UInt max = GET_LEN_STRING(str);
+    UInt off = STATE(SerializationIndex);
+    if (off + size > max)
+        DeserializationError();
+    memcpy(addr, CSTR_STRING(str) + off, size);
+    STATE(SerializationIndex) += size;
 }
 
-static UInt ReadTNumNativeString() {
-  UChar buf[1];
-  ReadBytesNativeString(buf, 1);
-  return buf[0];
+static UInt ReadTNumNativeString()
+{
+    UChar buf[1];
+    ReadBytesNativeString(buf, 1);
+    return buf[0];
 }
 
-static UChar ReadByteNativeString() {
-  UChar buf[1];
-  ReadBytesNativeString(buf, 1);
-  return buf[0];
+static UChar ReadByteNativeString()
+{
+    UChar buf[1];
+    ReadBytesNativeString(buf, 1);
+    return buf[0];
 }
 
-static UInt ReadByteBlockLengthNativeString() {
-  UInt len;
-  ReadBytesNativeString(&len, sizeof(len));
-  /* The following is to prevent out-of-memory errors on malformed input,
-   * where incorrect values can result in huge length values: */
-  if (len + STATE(SerializationIndex) > GET_LEN_STRING(STATE(SerializationObj)))
-    DeserializationError();
-  return len;
+static UInt ReadByteBlockLengthNativeString()
+{
+    UInt len;
+    ReadBytesNativeString(&len, sizeof(len));
+    /* The following is to prevent out-of-memory errors on malformed input,
+     * where incorrect values can result in huge length values: */
+    if (len + STATE(SerializationIndex) >
+        GET_LEN_STRING(STATE(SerializationObj)))
+        DeserializationError();
+    return len;
 }
 
-static void ReadByteBlockDataNativeString(Obj obj, UInt offset, UInt len) {
-  ReadBytesNativeString(ADDR_BYTE(obj)+offset, len);
+static void ReadByteBlockDataNativeString(Obj obj, UInt offset, UInt len)
+{
+    ReadBytesNativeString(ADDR_BYTE(obj) + offset, len);
 }
 
-static Obj ReadImmediateObjNativeString() {
-  Obj obj;
-  ReadBytesNativeString(&obj, sizeof(obj));
-  return obj;
+static Obj ReadImmediateObjNativeString()
+{
+    Obj obj;
+    ReadBytesNativeString(&obj, sizeof(obj));
+    return obj;
 }
 
 static DeserializerInterface NativeStringDeserializer = {
-  ReadTNumNativeString,
-  ReadByteNativeString,
-  ReadByteBlockLengthNativeString,
-  ReadByteBlockDataNativeString,
-  ReadImmediateObjNativeString,
+    ReadTNumNativeString,
+    ReadByteNativeString,
+    ReadByteBlockLengthNativeString,
+    ReadByteBlockDataNativeString,
+    ReadImmediateObjNativeString,
 };
 
-static void InitNativeStringDeserializer(Obj string) {
-  STATE(SerializationStack) = NEW_PLIST(T_PLIST, 0);
-  STATE(SerializationDispatcher) = &NativeStringDeserializer;
-  STATE(SerializationObj) = string;
-  STATE(SerializationIndex) = 0;
+static void InitNativeStringDeserializer(Obj string)
+{
+    STATE(SerializationStack) = NEW_PLIST(T_PLIST, 0);
+    STATE(SerializationDispatcher) = &NativeStringDeserializer;
+    STATE(SerializationObj) = string;
+    STATE(SerializationIndex) = 0;
 }
 
 /* Dispatch functions */
 
-static inline void WriteTNum(UInt tnum) {
-  SERIALIZER->WriteTNum(tnum);
+static inline void WriteTNum(UInt tnum)
+{
+    SERIALIZER->WriteTNum(tnum);
 }
 
-static inline void WriteByte(UChar byte) {
-  SERIALIZER->WriteByte(byte);
+static inline void WriteByte(UChar byte)
+{
+    SERIALIZER->WriteByte(byte);
 }
 
-static inline void WriteByteBlock(Obj obj, UInt offset, UInt len) {
-  SERIALIZER->WriteByteBlock(obj, offset, len);
+static inline void WriteByteBlock(Obj obj, UInt offset, UInt len)
+{
+    SERIALIZER->WriteByteBlock(obj, offset, len);
 }
 
-static inline void WriteImmediateObj(Obj obj) {
-  SERIALIZER->WriteImmediateObj(obj);
+static inline void WriteImmediateObj(Obj obj)
+{
+    SERIALIZER->WriteImmediateObj(obj);
 }
 
-static inline UInt ReadTNum(void) {
-  return DESERIALIZER->ReadTNum();
+static inline UInt ReadTNum(void)
+{
+    return DESERIALIZER->ReadTNum();
 }
 
-static inline UChar ReadByte(void) {
-  return DESERIALIZER->ReadByte();
+static inline UChar ReadByte(void)
+{
+    return DESERIALIZER->ReadByte();
 }
 
-static inline UInt ReadByteBlockLength(void) {
-  return DESERIALIZER->ReadByteBlockLength();
+static inline UInt ReadByteBlockLength(void)
+{
+    return DESERIALIZER->ReadByteBlockLength();
 }
 
-static inline void ReadByteBlockData(Obj obj, UInt offset, UInt len) {
-  DESERIALIZER->ReadByteBlockData(obj, offset, len);
+static inline void ReadByteBlockData(Obj obj, UInt offset, UInt len)
+{
+    DESERIALIZER->ReadByteBlockData(obj, offset, len);
 }
 
-static inline Obj ReadImmediateObj(void) {
-  return DESERIALIZER->ReadImmediateObj();
+static inline Obj ReadImmediateObj(void)
+{
+    return DESERIALIZER->ReadImmediateObj();
 }
 
 /* Auxiliary serialization/deserialization functions */
 
-static void SerializeBinary(Obj obj) {
-  WriteTNum(TNUM_OBJ(obj));
-  WriteByteBlock(obj, 0, SIZE_OBJ(obj));
+static void SerializeBinary(Obj obj)
+{
+    WriteTNum(TNUM_OBJ(obj));
+    WriteByteBlock(obj, 0, SIZE_OBJ(obj));
 }
 
-static Obj DeserializeBinary(UInt tnum) {
-  UInt len = ReadByteBlockLength();
-  Obj result = NewBag(tnum, len);
-  ReadByteBlockData(result, 0, len);
-  return result;
+static Obj DeserializeBinary(UInt tnum)
+{
+    UInt len = ReadByteBlockLength();
+    Obj  result = NewBag(tnum, len);
+    ReadByteBlockData(result, 0, len);
+    return result;
 }
 
-static inline int IsBasicObj(Obj obj) {
-  return !obj || TNUM_OBJ(obj) <= T_MACFLOAT;
+static inline int IsBasicObj(Obj obj)
+{
+    return !obj || TNUM_OBJ(obj) <= T_MACFLOAT;
 }
 
-static inline void PushObj(Obj obj) {
-  Obj stack = STATE(SerializationStack);
-  UInt len = LEN_PLIST(stack);
-  len++;
-  GROW_PLIST(stack, len);
-  SET_LEN_PLIST(stack, len);
-  SET_ELM_PLIST(stack, len, obj);
+static inline void PushObj(Obj obj)
+{
+    Obj  stack = STATE(SerializationStack);
+    UInt len = LEN_PLIST(stack);
+    len++;
+    GROW_PLIST(stack, len);
+    SET_LEN_PLIST(stack, len);
+    SET_ELM_PLIST(stack, len, obj);
 }
 
-static inline Obj PopObj(void) {
-  Obj stack = STATE(SerializationStack);
-  UInt len = LEN_PLIST(stack);
-  Obj result = ELM_PLIST(stack, len);
-  SET_ELM_PLIST(stack, len, (Obj) 0);
-  len--;
-  SET_LEN_PLIST(stack, len);
-  return result;
+static inline Obj PopObj(void)
+{
+    Obj  stack = STATE(SerializationStack);
+    UInt len = LEN_PLIST(stack);
+    Obj  result = ELM_PLIST(stack, len);
+    SET_ELM_PLIST(stack, len, (Obj)0);
+    len--;
+    SET_LEN_PLIST(stack, len);
+    return result;
 }
 
 #define T_BACKREF 255
 #define OBJ_BACKREF(x) ((Obj)((x) << 2))
 #define BACKREF_OBJ(obj) (((UInt)(obj)) >> 2)
 
-int SerializedAlready(Obj obj) {
-  Obj ref = LookupObjMap(STATE(SerializationRegistry), obj);
-  if (ref) {
-    WriteTNum(T_BACKREF);
-    WriteImmediateObj(OBJ_BACKREF(INT_INTOBJ(ref)));
-    return 1;
-  } else {
-    STATE(SerializationIndex)++;
-    AddObjMap(STATE(SerializationRegistry), obj,
-        INTOBJ_INT(STATE(SerializationIndex)));
-    return 0;
-  }
+int SerializedAlready(Obj obj)
+{
+    Obj ref = LookupObjMap(STATE(SerializationRegistry), obj);
+    if (ref) {
+        WriteTNum(T_BACKREF);
+        WriteImmediateObj(OBJ_BACKREF(INT_INTOBJ(ref)));
+        return 1;
+    }
+    else {
+        STATE(SerializationIndex)++;
+        AddObjMap(STATE(SerializationRegistry), obj,
+                  INTOBJ_INT(STATE(SerializationIndex)));
+        return 0;
+    }
 }
 
 /* TNum-specific serialization/deserialization functions */
 
-void RegisterSerializerFunctions(UInt tnum,
-	SerializationFunction sfun, DeserializationFunction dfun)
+void RegisterSerializerFunctions(UInt                    tnum,
+                                 SerializationFunction   sfun,
+                                 DeserializationFunction dfun)
 {
-  SerializationFuncByTNum[tnum] = sfun;
-  DeserializationFuncByTNum[tnum] = dfun;
+    SerializationFuncByTNum[tnum] = sfun;
+    DeserializationFuncByTNum[tnum] = dfun;
 }
 
-void SerializeUnbound() {
-  WriteTNum(T_BACKREF);
-  WriteImmediateObj(INTOBJ_INT(0));
+void SerializeUnbound()
+{
+    WriteTNum(T_BACKREF);
+    WriteImmediateObj(INTOBJ_INT(0));
 }
 
-void SerializeObj(Obj obj) {
-  if (!obj) {
-    /* Handle unbound list elements correctly */
-    SerializeUnbound();
-    return;
-  }
-  SerializationFuncByTNum[TNUM_OBJ(obj)](obj);
+void SerializeObj(Obj obj)
+{
+    if (!obj) {
+        /* Handle unbound list elements correctly */
+        SerializeUnbound();
+        return;
+    }
+    SerializationFuncByTNum[TNUM_OBJ(obj)](obj);
 }
 
-Obj DeserializeObj() {
-  UInt tnum = ReadTNum();
-  return DeserializationFuncByTNum[tnum](tnum);
+Obj DeserializeObj()
+{
+    UInt tnum = ReadTNum();
+    return DeserializationFuncByTNum[tnum](tnum);
 }
 
-void SerializeInt(Obj obj) {
-  Int n = INT_INTOBJ(obj);
-  WriteTNum(T_INT);
-  if (n >= -32 && n <= 31) {
-    WriteByte(((n + 32) << 2) + 1);
-  } else if (n >= -8192 && n <= 8191) {
-    n += 8192;
-    WriteByte(((n >> 8) << 2) + 2);
-    WriteByte(n & 0xff);
-  }
-  else {
-    WriteByte(0);
-    WriteImmediateObj(obj);
-  }
+void SerializeInt(Obj obj)
+{
+    Int n = INT_INTOBJ(obj);
+    WriteTNum(T_INT);
+    if (n >= -32 && n <= 31) {
+        WriteByte(((n + 32) << 2) + 1);
+    }
+    else if (n >= -8192 && n <= 8191) {
+        n += 8192;
+        WriteByte(((n >> 8) << 2) + 2);
+        WriteByte(n & 0xff);
+    }
+    else {
+        WriteByte(0);
+        WriteImmediateObj(obj);
+    }
 }
 
-Obj DeserializeInt() {
-  Int n = ReadByte();
-  switch (n & 3) {
+Obj DeserializeInt()
+{
+    Int n = ReadByte();
+    switch (n & 3) {
     case 1:
-      n >>= 2;
-      n -= 32;
-      return INTOBJ_INT(n);
+        n >>= 2;
+        n -= 32;
+        return INTOBJ_INT(n);
     case 2:
-      n >>= 2;
-      n <<= 8;
-      n += ReadByte();
-      n -= 8192;
-      return INTOBJ_INT(n);
+        n >>= 2;
+        n <<= 8;
+        n += ReadByte();
+        n -= 8192;
+        return INTOBJ_INT(n);
     default:
-      if (n)
-        DeserializationError();
-      return ReadImmediateObj();
-  }
+        if (n)
+            DeserializationError();
+        return ReadImmediateObj();
+    }
 }
 
-void SerializeFFE(Obj obj) {
-  UInt ffe = (UInt) obj;
-  WriteTNum(T_FFE);
-  WriteByte((ffe >> 24) & 0xff);
-  WriteByte((ffe >> 16) & 0xff);
-  WriteByte((ffe >> 8) & 0xff);
-  WriteByte(ffe & 0xff);
+void SerializeFFE(Obj obj)
+{
+    UInt ffe = (UInt)obj;
+    WriteTNum(T_FFE);
+    WriteByte((ffe >> 24) & 0xff);
+    WriteByte((ffe >> 16) & 0xff);
+    WriteByte((ffe >> 8) & 0xff);
+    WriteByte(ffe & 0xff);
 }
 
-Obj DeserializeFFE() {
-  UInt ffe = 0;
-  ffe = ReadByte();
-  ffe <<= 8;
-  ffe |= ReadByte();
-  ffe <<= 8;
-  ffe |= ReadByte();
-  ffe <<= 8;
-  ffe |= ReadByte();
-  return (Obj) ffe;
+Obj DeserializeFFE()
+{
+    UInt ffe = 0;
+    ffe = ReadByte();
+    ffe <<= 8;
+    ffe |= ReadByte();
+    ffe <<= 8;
+    ffe |= ReadByte();
+    ffe <<= 8;
+    ffe |= ReadByte();
+    return (Obj)ffe;
 }
 
-void SerializeChar(Obj obj) {
-  UChar ch = *(char *)ADDR_OBJ(obj);
-  WriteTNum(T_CHAR);
-  WriteByte(ch);
+void SerializeChar(Obj obj)
+{
+    UChar ch = *(char *)ADDR_OBJ(obj);
+    WriteTNum(T_CHAR);
+    WriteByte(ch);
 }
 
-Obj DeserializeChar(UInt tnum) {
-  UChar ch = ReadByte();
-  return ObjsChar[ch];
+Obj DeserializeChar(UInt tnum)
+{
+    UChar ch = ReadByte();
+    return ObjsChar[ch];
 }
 
 /* Defines from rational.c: */
-#define NUM_RAT(rat)    ADDR_OBJ(rat)[0]
-#define DEN_RAT(rat)    ADDR_OBJ(rat)[1]
+#define NUM_RAT(rat) ADDR_OBJ(rat)[0]
+#define DEN_RAT(rat) ADDR_OBJ(rat)[1]
 
-void SerializeRat(Obj obj) {
-  WriteTNum(T_RAT);
-  SerializeObj(NUM_RAT(obj));
-  SerializeObj(DEN_RAT(obj));
+void SerializeRat(Obj obj)
+{
+    WriteTNum(T_RAT);
+    SerializeObj(NUM_RAT(obj));
+    SerializeObj(DEN_RAT(obj));
 }
 
-Obj DeserializeRat(UInt tnum) {
-  Obj num = DeserializeObj();
-  Obj den = DeserializeObj();
-  Obj result = NewBag(tnum, 2 * sizeof(Obj));
-  NUM_RAT(result) = num;
-  DEN_RAT(result) = den;
-  return result;
+Obj DeserializeRat(UInt tnum)
+{
+    Obj num = DeserializeObj();
+    Obj den = DeserializeObj();
+    Obj result = NewBag(tnum, 2 * sizeof(Obj));
+    NUM_RAT(result) = num;
+    DEN_RAT(result) = den;
+    return result;
 }
 
 /* Defines from cyclotom.c: */
-#define SIZE_CYC(cyc)           (SIZE_OBJ(cyc) / (sizeof(Obj)+sizeof(UInt4)))
-#define COEFS_CYC(cyc)          (ADDR_OBJ(cyc))
-#define EXPOS_CYC(cyc,len)      ((UInt4*)(ADDR_OBJ(cyc)+(len)))
+#define SIZE_CYC(cyc) (SIZE_OBJ(cyc) / (sizeof(Obj) + sizeof(UInt4)))
+#define COEFS_CYC(cyc) (ADDR_OBJ(cyc))
+#define EXPOS_CYC(cyc, len) ((UInt4 *)(ADDR_OBJ(cyc) + (len)))
 
-void SerializeCyc(Obj obj) {
-  UInt len, i;
-  WriteTNum(T_CYC);
-  len = SIZE_CYC(obj);
-  WriteImmediateObj(INTOBJ_INT(len));
-  for (i=0; i<len; i++) {
-    SerializeObj(COEFS_CYC(obj)[i]);
-  }
-  for (i=1; i<len; i++) {
-    WriteImmediateObj(INTOBJ_INT(EXPOS_CYC(obj,len)[i]));
-  }
+void SerializeCyc(Obj obj)
+{
+    UInt len, i;
+    WriteTNum(T_CYC);
+    len = SIZE_CYC(obj);
+    WriteImmediateObj(INTOBJ_INT(len));
+    for (i = 0; i < len; i++) {
+        SerializeObj(COEFS_CYC(obj)[i]);
+    }
+    for (i = 1; i < len; i++) {
+        WriteImmediateObj(INTOBJ_INT(EXPOS_CYC(obj, len)[i]));
+    }
 }
 
-Obj DeserializeCyc(UInt tnum) {
-  Obj result;
-  UInt i, len;
-  len = INT_INTOBJ(ReadImmediateObj());
-  result = NewBag( T_CYC, len * (sizeof(Obj) + sizeof(UInt4)));
-  for (i=0; i<len; i++)
-    COEFS_CYC(result)[i] = DeserializeObj();
-  for (i=1; i<len; i++)
-    EXPOS_CYC(result, len)[i] = INT_INTOBJ(ReadImmediateObj());
-  return result;
+Obj DeserializeCyc(UInt tnum)
+{
+    Obj  result;
+    UInt i, len;
+    len = INT_INTOBJ(ReadImmediateObj());
+    result = NewBag(T_CYC, len * (sizeof(Obj) + sizeof(UInt4)));
+    for (i = 0; i < len; i++)
+        COEFS_CYC(result)[i] = DeserializeObj();
+    for (i = 1; i < len; i++)
+        EXPOS_CYC(result, len)[i] = INT_INTOBJ(ReadImmediateObj());
+    return result;
 }
 
-void SerializeBool(Obj obj) {
-  WriteTNum(T_BOOL);
-  if (obj == False) {
-    WriteByte(0);
-  } else if (obj == True) {
-    WriteByte(1);
-  } else if (obj == Fail) {
-    WriteByte(2);
-  } else if (obj == SuPeRfail) {
-    WriteByte(3);
-  } else
-    ErrorQuit("Internal serialization error: Bad boolean value", 0L, 0L);
+void SerializeBool(Obj obj)
+{
+    WriteTNum(T_BOOL);
+    if (obj == False) {
+        WriteByte(0);
+    }
+    else if (obj == True) {
+        WriteByte(1);
+    }
+    else if (obj == Fail) {
+        WriteByte(2);
+    }
+    else if (obj == SuPeRfail) {
+        WriteByte(3);
+    }
+    else
+        ErrorQuit("Internal serialization error: Bad boolean value", 0L, 0L);
 }
 
-Obj DeserializeBool(UInt tnum) {
-  UChar byte = ReadByte();
-  switch (byte) {
-    case 0: return False;
-    case 1: return True;
-    case 2: return Fail;
-    case 3: return SuPeRfail;
+Obj DeserializeBool(UInt tnum)
+{
+    UChar byte = ReadByte();
+    switch (byte) {
+    case 0:
+        return False;
+    case 1:
+        return True;
+    case 2:
+        return Fail;
+    case 3:
+        return SuPeRfail;
     default:
-      DeserializationError();
-      return (Obj) 0; /* flow control hint */
-  }
-}
-
-void SerializeList(Obj obj) {
-  UInt i, j, len;
-  if (SerializedAlready(obj))
-    return;
-  len = LEN_PLIST(obj);
-  WriteTNum(TNUM_OBJ(obj));
-  WriteImmediateObj(INTOBJ_INT(len));
-  for (i=1; i<=len; i++) {
-    Obj el = ELM_PLIST(obj, i);
-    if (IsBasicObj(el))
-      SerializeObj(el);
-    else {
-      break;
+        DeserializationError();
+        return (Obj)0; /* flow control hint */
     }
-  }
-  for (j=len; j>=i; j--) {
-    Obj el = ELM_PLIST(obj, j);
-    PushObj(el);
-  }
 }
 
-Obj DeserializeList(UInt tnum) {
-  UInt i, len = INT_INTOBJ(ReadImmediateObj());
-  Obj result = NEW_PLIST(tnum, len);
-  SET_LEN_PLIST(result, len);
-  PushObj(result);
-  for (i=1; i<=len; i++)
-    SET_ELM_PLIST(result, i, DeserializeObj());
-  return result;
-}
-
-void SerializeObjSet(Obj obj) {
-  UInt i, len;
-  if (SerializedAlready(obj))
-    return;
-  len = (UInt)(ADDR_OBJ(obj)[OBJSET_USED]);
-  WriteTNum(TNUM_OBJ(obj));
-  WriteImmediateObj(INTOBJ_INT(len));
-  len = (UInt)(ADDR_OBJ(obj)[OBJSET_SIZE]);
-  for (i=0; i<len; i++) {
-    Obj el = ADDR_OBJ(obj)[OBJSET_HDRSIZE+i];
-    if (!el || el == Undefined)
-      continue;
-    if (IsBasicObj(el))
-      SerializeObj(el);
-    else {
-      PushObj(el);
+void SerializeList(Obj obj)
+{
+    UInt i, j, len;
+    if (SerializedAlready(obj))
+        return;
+    len = LEN_PLIST(obj);
+    WriteTNum(TNUM_OBJ(obj));
+    WriteImmediateObj(INTOBJ_INT(len));
+    for (i = 1; i <= len; i++) {
+        Obj el = ELM_PLIST(obj, i);
+        if (IsBasicObj(el))
+            SerializeObj(el);
+        else {
+            break;
+        }
     }
-  }
-}
-
-Obj DeserializeObjSet(UInt tnum) {
-  UInt i, len = INT_INTOBJ(ReadImmediateObj());
-  Obj result = NewObjSet();
-  PushObj(result);
-  for (i=1; i<=len; i++)
-    AddObjSet(result, DeserializeObj());
-  return result;
-}
-
-void SerializeObjMap(Obj obj) {
-  UInt i, len;
-  if (SerializedAlready(obj))
-    return;
-  len = (UInt)(ADDR_OBJ(obj)[OBJSET_USED]);
-  WriteTNum(TNUM_OBJ(obj));
-  WriteImmediateObj(INTOBJ_INT(len));
-  len = (UInt)(ADDR_OBJ(obj)[OBJSET_SIZE]);
-  for (i=0; i<len; i++) {
-    Obj key = ADDR_OBJ(obj)[OBJSET_HDRSIZE+2*i];
-    Obj val = ADDR_OBJ(obj)[OBJSET_HDRSIZE+2*i+1];
-    if (!key || key == Undefined)
-      continue;
-    if (IsBasicObj(key) && IsBasicObj(val)) {
-      SerializeObj(key);
-      SerializeObj(val);
-    } else {
-      PushObj(val);
-      PushObj(key);
+    for (j = len; j >= i; j--) {
+        Obj el = ELM_PLIST(obj, j);
+        PushObj(el);
     }
-  }
 }
 
-Obj DeserializeObjMap(UInt tnum) {
-  UInt i, len = INT_INTOBJ(ReadImmediateObj());
-  Obj result = NewObjSet();
-  PushObj(result);
-  for (i=1; i<=len; i++) {
-    Obj key = DeserializeObj();
-    Obj val = DeserializeObj();
-    AddObjMap(result, key, val);
-  }
-  return result;
+Obj DeserializeList(UInt tnum)
+{
+    UInt i, len = INT_INTOBJ(ReadImmediateObj());
+    Obj  result = NEW_PLIST(tnum, len);
+    SET_LEN_PLIST(result, len);
+    PushObj(result);
+    for (i = 1; i <= len; i++)
+        SET_ELM_PLIST(result, i, DeserializeObj());
+    return result;
 }
 
-void SerializeRecord(Obj obj) {
-  UInt i, j, len;
-  if (SerializedAlready(obj))
-    return;
-  WriteTNum(TNUM_OBJ(obj));
-  len = LEN_PREC(obj);
-  WriteImmediateObj(INTOBJ_INT(len));
-  for (i=1; i<=len; i++) {
-    UInt rnam = GET_RNAM_PREC(obj, i);
-    Obj rnams = ELM_PLIST(NamesRNam, rnam);
-    WriteByteBlock(rnams, sizeof(UInt), GET_LEN_STRING(rnams));
-  }
-  for (i=1; i<=len; i++) {
-    Obj el = GET_ELM_PREC(obj, i);
-    if (IsBasicObj(el))
-      SerializeObj(el);
-    else {
-      break;
+void SerializeObjSet(Obj obj)
+{
+    UInt i, len;
+    if (SerializedAlready(obj))
+        return;
+    len = (UInt)(ADDR_OBJ(obj)[OBJSET_USED]);
+    WriteTNum(TNUM_OBJ(obj));
+    WriteImmediateObj(INTOBJ_INT(len));
+    len = (UInt)(ADDR_OBJ(obj)[OBJSET_SIZE]);
+    for (i = 0; i < len; i++) {
+        Obj el = ADDR_OBJ(obj)[OBJSET_HDRSIZE + i];
+        if (!el || el == Undefined)
+            continue;
+        if (IsBasicObj(el))
+            SerializeObj(el);
+        else {
+            PushObj(el);
+        }
     }
-  }
-  for (j=len; j>=i; j--) {
-    Obj el = GET_ELM_PREC(obj, j);
-    PushObj(el);
-  }
 }
 
-Obj DeserializeRecord(UInt tnum) {
-  UInt i, len = INT_INTOBJ(ReadImmediateObj());
-  Obj result = NEW_PREC(len);
-  Obj rnams = NEW_STRING(11);
-  SET_LEN_PREC(result, len);
-  PushObj(result);
-  for (i=1; i<=len; i++) {
-    UInt rnam, rnamlen = ReadByteBlockLength();
-    GROW_STRING(rnams, rnamlen+1);
-    ReadByteBlockData(rnams, sizeof(Obj), rnamlen);
-    CSTR_STRING(rnams)[rnamlen] = '\0';
-    rnam = RNamName(CSTR_STRING(rnams));
-    SET_RNAM_PREC(result, i, rnam);
-  }
-  for (i=1; i<=len; i++) {
-    Obj el = DeserializeObj();
-    SET_ELM_PREC(result, i, el);
-  }
-  SortPRecRNam(result, 1);
-  if (tnum == T_PREC+IMMUTABLE)
-    RetypeBag(result, tnum);
-  return result;
+Obj DeserializeObjSet(UInt tnum)
+{
+    UInt i, len = INT_INTOBJ(ReadImmediateObj());
+    Obj  result = NewObjSet();
+    PushObj(result);
+    for (i = 1; i <= len; i++)
+        AddObjSet(result, DeserializeObj());
+    return result;
 }
 
-void SerializeString(Obj obj) {
-  if (SerializedAlready(obj))
-    return;
-  WriteTNum(TNUM_OBJ(obj));
-  WriteByteBlock(obj, sizeof(UInt), GET_LEN_STRING(obj));
+void SerializeObjMap(Obj obj)
+{
+    UInt i, len;
+    if (SerializedAlready(obj))
+        return;
+    len = (UInt)(ADDR_OBJ(obj)[OBJSET_USED]);
+    WriteTNum(TNUM_OBJ(obj));
+    WriteImmediateObj(INTOBJ_INT(len));
+    len = (UInt)(ADDR_OBJ(obj)[OBJSET_SIZE]);
+    for (i = 0; i < len; i++) {
+        Obj key = ADDR_OBJ(obj)[OBJSET_HDRSIZE + 2 * i];
+        Obj val = ADDR_OBJ(obj)[OBJSET_HDRSIZE + 2 * i + 1];
+        if (!key || key == Undefined)
+            continue;
+        if (IsBasicObj(key) && IsBasicObj(val)) {
+            SerializeObj(key);
+            SerializeObj(val);
+        }
+        else {
+            PushObj(val);
+            PushObj(key);
+        }
+    }
 }
 
-Obj DeserializeString(UInt tnum) {
-  UInt len = ReadByteBlockLength();
-  Obj result = NewBag(tnum, SIZEBAG_STRINGLEN(len));
-  SET_LEN_STRING(result, len);
-  ReadByteBlockData(result, sizeof(UInt), len);
-  CSTR_STRING(result)[len] = '\0';
-  PushObj(result);
-  return result;
+Obj DeserializeObjMap(UInt tnum)
+{
+    UInt i, len = INT_INTOBJ(ReadImmediateObj());
+    Obj  result = NewObjSet();
+    PushObj(result);
+    for (i = 1; i <= len; i++) {
+        Obj key = DeserializeObj();
+        Obj val = DeserializeObj();
+        AddObjMap(result, key, val);
+    }
+    return result;
 }
 
-void SerializeBlist(Obj obj) {
-  if (SerializedAlready(obj))
-    return;
-  WriteTNum(TNUM_OBJ(obj));
-  WriteByteBlock(obj, 0, SIZE_OBJ(obj));
+void SerializeRecord(Obj obj)
+{
+    UInt i, j, len;
+    if (SerializedAlready(obj))
+        return;
+    WriteTNum(TNUM_OBJ(obj));
+    len = LEN_PREC(obj);
+    WriteImmediateObj(INTOBJ_INT(len));
+    for (i = 1; i <= len; i++) {
+        UInt rnam = GET_RNAM_PREC(obj, i);
+        Obj  rnams = ELM_PLIST(NamesRNam, rnam);
+        WriteByteBlock(rnams, sizeof(UInt), GET_LEN_STRING(rnams));
+    }
+    for (i = 1; i <= len; i++) {
+        Obj el = GET_ELM_PREC(obj, i);
+        if (IsBasicObj(el))
+            SerializeObj(el);
+        else {
+            break;
+        }
+    }
+    for (j = len; j >= i; j--) {
+        Obj el = GET_ELM_PREC(obj, j);
+        PushObj(el);
+    }
 }
 
-Obj DeserializeBlist(UInt tnum) {
-  UInt len = ReadByteBlockLength();
-  Obj result = NewBag(tnum, len);
-  ReadByteBlockData(result, 0, len);
-  PushObj(result);
-  return result;
+Obj DeserializeRecord(UInt tnum)
+{
+    UInt i, len = INT_INTOBJ(ReadImmediateObj());
+    Obj  result = NEW_PREC(len);
+    Obj  rnams = NEW_STRING(11);
+    SET_LEN_PREC(result, len);
+    PushObj(result);
+    for (i = 1; i <= len; i++) {
+        UInt rnam, rnamlen = ReadByteBlockLength();
+        GROW_STRING(rnams, rnamlen + 1);
+        ReadByteBlockData(rnams, sizeof(Obj), rnamlen);
+        CSTR_STRING(rnams)[rnamlen] = '\0';
+        rnam = RNamName(CSTR_STRING(rnams));
+        SET_RNAM_PREC(result, i, rnam);
+    }
+    for (i = 1; i <= len; i++) {
+        Obj el = DeserializeObj();
+        SET_ELM_PREC(result, i, el);
+    }
+    SortPRecRNam(result, 1);
+    if (tnum == T_PREC + IMMUTABLE)
+        RetypeBag(result, tnum);
+    return result;
 }
 
-void SerializeRange(Obj obj) {
-  WriteTNum(TNUM_OBJ(obj));
-  WriteImmediateObj(ADDR_OBJ(obj)[0]);
-  WriteImmediateObj(ADDR_OBJ(obj)[1]);
-  WriteImmediateObj(ADDR_OBJ(obj)[2]);
+void SerializeString(Obj obj)
+{
+    if (SerializedAlready(obj))
+        return;
+    WriteTNum(TNUM_OBJ(obj));
+    WriteByteBlock(obj, sizeof(UInt), GET_LEN_STRING(obj));
 }
 
-Obj DeserializeRange(UInt tnum) {
-  Obj result, r1, r2, r3;
-  r1 = ReadImmediateObj();
-  r2 = ReadImmediateObj();
-  r3 = ReadImmediateObj();
-  result = NewBag(tnum, 3 * sizeof(Obj));
-  ADDR_OBJ(result)[0] = r1;
-  ADDR_OBJ(result)[1] = r2;
-  ADDR_OBJ(result)[2] = r3;
-  return result;
+Obj DeserializeString(UInt tnum)
+{
+    UInt len = ReadByteBlockLength();
+    Obj  result = NewBag(tnum, SIZEBAG_STRINGLEN(len));
+    SET_LEN_STRING(result, len);
+    ReadByteBlockData(result, sizeof(UInt), len);
+    CSTR_STRING(result)[len] = '\0';
+    PushObj(result);
+    return result;
+}
+
+void SerializeBlist(Obj obj)
+{
+    if (SerializedAlready(obj))
+        return;
+    WriteTNum(TNUM_OBJ(obj));
+    WriteByteBlock(obj, 0, SIZE_OBJ(obj));
+}
+
+Obj DeserializeBlist(UInt tnum)
+{
+    UInt len = ReadByteBlockLength();
+    Obj  result = NewBag(tnum, len);
+    ReadByteBlockData(result, 0, len);
+    PushObj(result);
+    return result;
+}
+
+void SerializeRange(Obj obj)
+{
+    WriteTNum(TNUM_OBJ(obj));
+    WriteImmediateObj(ADDR_OBJ(obj)[0]);
+    WriteImmediateObj(ADDR_OBJ(obj)[1]);
+    WriteImmediateObj(ADDR_OBJ(obj)[2]);
+}
+
+Obj DeserializeRange(UInt tnum)
+{
+    Obj result, r1, r2, r3;
+    r1 = ReadImmediateObj();
+    r2 = ReadImmediateObj();
+    r3 = ReadImmediateObj();
+    result = NewBag(tnum, 3 * sizeof(Obj));
+    ADDR_OBJ(result)[0] = r1;
+    ADDR_OBJ(result)[1] = r2;
+    ADDR_OBJ(result)[2] = r3;
+    return result;
 }
 
 static GVarDescriptor SerializableRepresentationGVar;
@@ -667,17 +739,21 @@ static GVarDescriptor DESERIALIZATION_TAG_STRING_GVar;
 static GVarDescriptor SERIALIZATION_UPDATE_TAGS_GVar;
 static GVarDescriptor SERIALIZATION_TAGS_NEED_UPDATE_GVar;
 
-static void SerRepError() {
-  ErrorQuit("SerializableRepresentation must return a list prefixed by a string or integer and string", 0L, 0L);
+static void SerRepError()
+{
+    ErrorQuit("SerializableRepresentation must return a list prefixed by a "
+              "string or integer and string",
+              0L, 0L);
 }
 
-static Obj PosObjToList(Obj obj) {
-  UInt i, len = SIZE_OBJ(obj)/sizeof(Obj) - 1;
-  Obj result = NEW_PLIST(T_PLIST, len);
-  SET_LEN_PLIST(result, len);
-  for (i=1; i<=len; i++)
-    SET_ELM_PLIST(result, i, ELM_PLIST(obj, i));
-  return result;
+static Obj PosObjToList(Obj obj)
+{
+    UInt i, len = SIZE_OBJ(obj) / sizeof(Obj) - 1;
+    Obj  result = NEW_PLIST(T_PLIST, len);
+    SET_LEN_PLIST(result, len);
+    for (i = 1; i <= len; i++)
+        SET_ELM_PLIST(result, i, ELM_PLIST(obj, i));
+    return result;
 }
 
 /**
@@ -712,348 +788,356 @@ static Obj PosObjToList(Obj obj) {
  *
  */
 
-Obj LookupIntTag(Obj tag) {
-  Obj map = GVarObj(&DESERIALIZATION_TAG_INT_GVar);
-  Obj func = (Obj) 0;
-  Obj result;
-  retry:
-  switch (map ? TNUM_OBJ(map):-1) {
+Obj LookupIntTag(Obj tag)
+{
+    Obj map = GVarObj(&DESERIALIZATION_TAG_INT_GVar);
+    Obj func = (Obj)0;
+    Obj result;
+retry:
+    switch (map ? TNUM_OBJ(map) : -1) {
     case T_OBJMAP:
-    case T_OBJMAP+IMMUTABLE:
-      result = LookupObjMap(map, tag);
-      if (result || func)
-        return result;
-      if (GVarObj(&SERIALIZATION_TAGS_NEED_UPDATE_GVar) == False)
-        return (Obj) 0;
-      func = GVarFunction(&SERIALIZATION_UPDATE_TAGS_GVar);
-      if (!func)
-        return (Obj) 0;
-      CALL_0ARGS(func);
-      map = GVarObj(&DESERIALIZATION_TAG_INT_GVar);
-      goto retry; /* more readable than a loop around the switch */
+    case T_OBJMAP + IMMUTABLE:
+        result = LookupObjMap(map, tag);
+        if (result || func)
+            return result;
+        if (GVarObj(&SERIALIZATION_TAGS_NEED_UPDATE_GVar) == False)
+            return (Obj)0;
+        func = GVarFunction(&SERIALIZATION_UPDATE_TAGS_GVar);
+        if (!func)
+            return (Obj)0;
+        CALL_0ARGS(func);
+        map = GVarObj(&DESERIALIZATION_TAG_INT_GVar);
+        goto retry; /* more readable than a loop around the switch */
     default:
-      ErrorQuit("Deserialization tag map for int tags is corrupted", 0L, 0L);
-      return (Obj) 0; /* flow control hint */
-  }
+        ErrorQuit("Deserialization tag map for int tags is corrupted", 0L,
+                  0L);
+        return (Obj)0; /* flow control hint */
+    }
 }
 
-Obj DeserializeTypedObj(UInt tnum) {
-  UInt namelen, len, i;
-  Obj name, args, deserialization_rec, func, type, tag;
-  Obj result;
-  UInt rnam, tagtnum;
-  tagtnum = ReadTNum();
-  switch (tagtnum) {
+Obj DeserializeTypedObj(UInt tnum)
+{
+    UInt namelen, len, i;
+    Obj  name, args, deserialization_rec, func, type, tag;
+    Obj  result;
+    UInt rnam, tagtnum;
+    tagtnum = ReadTNum();
+    switch (tagtnum) {
     case T_INT:
     case T_STRING:
-    case T_STRING+IMMUTABLE:
-      if (tagtnum == T_INT) {
-        tag = DeserializeInt();
-	type = LookupIntTag(tag);
-      } else {
-        tag = DeserializeString(T_STRING);
-        rnam = RNamObj(tag);
-	type = ELM_REC(GVarObj(&DESERIALIZATION_TAG_STRING_GVar), rnam);
-      }
-      if (!type || TNUM_OBJ(type) != T_POSOBJ)
-        DeserializationError();
-      switch (tnum) {
-	case T_DATOBJ:
-	  len = ReadByteBlockLength();
-	  result = NewBag(T_DATOBJ, len + sizeof(Obj));
-	  ReadByteBlockData(result, sizeof(Obj), len);
-	  break;
-	case T_POSOBJ:
-	  result = DeserializeObj();
-	  if (!IS_PLIST(result))
-	    DeserializationError();
-	  break;
-	case T_PREC:
-	  result = DeserializeObj();
-	  if (TNUM_OBJ(result) != T_COMOBJ)
-	    DeserializationError();
-	  break;
-      }
-      SET_TYPE_OBJ(result, type);
-      return result;
+    case T_STRING + IMMUTABLE:
+        if (tagtnum == T_INT) {
+            tag = DeserializeInt();
+            type = LookupIntTag(tag);
+        }
+        else {
+            tag = DeserializeString(T_STRING);
+            rnam = RNamObj(tag);
+            type = ELM_REC(GVarObj(&DESERIALIZATION_TAG_STRING_GVar), rnam);
+        }
+        if (!type || TNUM_OBJ(type) != T_POSOBJ)
+            DeserializationError();
+        switch (tnum) {
+        case T_DATOBJ:
+            len = ReadByteBlockLength();
+            result = NewBag(T_DATOBJ, len + sizeof(Obj));
+            ReadByteBlockData(result, sizeof(Obj), len);
+            break;
+        case T_POSOBJ:
+            result = DeserializeObj();
+            if (!IS_PLIST(result))
+                DeserializationError();
+            break;
+        case T_PREC:
+            result = DeserializeObj();
+            if (TNUM_OBJ(result) != T_COMOBJ)
+                DeserializationError();
+            break;
+        }
+        SET_TYPE_OBJ(result, type);
+        return result;
     case T_PLIST:
-      /* continue on to the more general deserialization method */
-      break;
+        /* continue on to the more general deserialization method */
+        break;
     default:
-      DeserializationError();
-      return (Obj) 0; /* flow control hint */
-  }
-  namelen = ReadByteBlockLength();
-  name = NEW_STRING(namelen);
-  ReadByteBlockData(name, sizeof(UInt), namelen);
-  rnam = RNamName(CSTR_STRING(name));
-  len = INT_INTOBJ(ReadImmediateObj());
-  args = NEW_PLIST(T_PLIST, len);
-  SET_LEN_PLIST(args, len);
-  for (i=1; i<=len; i++) {
-    if (ReadByte()) {
-      Obj obj;
-      UInt blen;
-      switch (ReadTNum()) {
-	case T_DATOBJ:
-	  blen = ReadByteBlockLength();
-	  obj = NewBag(T_DATOBJ, blen + sizeof(Obj));
-	  ReadByteBlockData(obj, sizeof(Obj), blen);
-	  SET_TYPE_OBJ(obj, GVarObj(&TYPE_UNKNOWN_GVar));
-	  break;
-	default:
-	  obj = DeserializeObj();
-	  break;
-      }
-      SET_ELM_PLIST(args, i, obj);
-    } else {
-      Obj obj = DeserializeObj();
-      SET_ELM_PLIST(args, i, obj);
+        DeserializationError();
+        return (Obj)0; /* flow control hint */
     }
-  }
-  deserialization_rec = GVarObj(&DESERIALIZER_GVar);
-  if (!deserialization_rec)
-    DeserializationError();
-  func = ELM_REC(deserialization_rec, rnam);
-  if (!func || TNUM_OBJ(func) != T_FUNCTION)
-    DeserializationError();
-  switch (len) {
+    namelen = ReadByteBlockLength();
+    name = NEW_STRING(namelen);
+    ReadByteBlockData(name, sizeof(UInt), namelen);
+    rnam = RNamName(CSTR_STRING(name));
+    len = INT_INTOBJ(ReadImmediateObj());
+    args = NEW_PLIST(T_PLIST, len);
+    SET_LEN_PLIST(args, len);
+    for (i = 1; i <= len; i++) {
+        if (ReadByte()) {
+            Obj  obj;
+            UInt blen;
+            switch (ReadTNum()) {
+            case T_DATOBJ:
+                blen = ReadByteBlockLength();
+                obj = NewBag(T_DATOBJ, blen + sizeof(Obj));
+                ReadByteBlockData(obj, sizeof(Obj), blen);
+                SET_TYPE_OBJ(obj, GVarObj(&TYPE_UNKNOWN_GVar));
+                break;
+            default:
+                obj = DeserializeObj();
+                break;
+            }
+            SET_ELM_PLIST(args, i, obj);
+        }
+        else {
+            Obj obj = DeserializeObj();
+            SET_ELM_PLIST(args, i, obj);
+        }
+    }
+    deserialization_rec = GVarObj(&DESERIALIZER_GVar);
+    if (!deserialization_rec)
+        DeserializationError();
+    func = ELM_REC(deserialization_rec, rnam);
+    if (!func || TNUM_OBJ(func) != T_FUNCTION)
+        DeserializationError();
+    switch (len) {
     case 0:
-      result = CALL_0ARGS(func); break;
+        result = CALL_0ARGS(func);
+        break;
     case 1:
-      result = CALL_1ARGS(func, ELM_PLIST(args, 1)); break;
+        result = CALL_1ARGS(func, ELM_PLIST(args, 1));
+        break;
     case 2:
-      result = CALL_2ARGS(func,
-        ELM_PLIST(args, 1),
-	ELM_PLIST(args, 2)); break;
+        result = CALL_2ARGS(func, ELM_PLIST(args, 1), ELM_PLIST(args, 2));
+        break;
     case 3:
-      result = CALL_3ARGS(func,
-        ELM_PLIST(args, 1),
-        ELM_PLIST(args, 2),
-	ELM_PLIST(args, 3)); break;
+        result = CALL_3ARGS(func, ELM_PLIST(args, 1), ELM_PLIST(args, 2),
+                            ELM_PLIST(args, 3));
+        break;
     case 4:
-      result = CALL_4ARGS(func,
-        ELM_PLIST(args, 1),
-        ELM_PLIST(args, 2),
-        ELM_PLIST(args, 3),
-	ELM_PLIST(args, 4)); break;
+        result = CALL_4ARGS(func, ELM_PLIST(args, 1), ELM_PLIST(args, 2),
+                            ELM_PLIST(args, 3), ELM_PLIST(args, 4));
+        break;
     case 5:
-      result = CALL_5ARGS(func,
-        ELM_PLIST(args, 1),
-        ELM_PLIST(args, 2),
-        ELM_PLIST(args, 3),
-        ELM_PLIST(args, 4),
-	ELM_PLIST(args, 5)); break;
+        result = CALL_5ARGS(func, ELM_PLIST(args, 1), ELM_PLIST(args, 2),
+                            ELM_PLIST(args, 3), ELM_PLIST(args, 4),
+                            ELM_PLIST(args, 5));
+        break;
     case 6:
-      result = CALL_6ARGS(func,
-        ELM_PLIST(args, 1),
-        ELM_PLIST(args, 2),
-        ELM_PLIST(args, 3),
-        ELM_PLIST(args, 4),
-        ELM_PLIST(args, 5),
-	ELM_PLIST(args, 6)); break;
+        result = CALL_6ARGS(func, ELM_PLIST(args, 1), ELM_PLIST(args, 2),
+                            ELM_PLIST(args, 3), ELM_PLIST(args, 4),
+                            ELM_PLIST(args, 5), ELM_PLIST(args, 6));
+        break;
     default:
-      result = CALL_XARGS(func, args); break;
-  }
-  return result;
-}
-
-Obj LookupTypeTag(Obj type) {
-  Obj tags = GVarObj(&SERIALIZATION_TAG_GVar);
-  Obj func, result;
-  if (tags && TNUM_OBJ(tags) == T_OBJMAP) {
-    result = LookupObjMap(tags, type);
-    if (result)
-      return result;
-    if (GVarObj(&SERIALIZATION_TAGS_NEED_UPDATE_GVar) == False)
-      return (Obj) 0;
-    func = GVarFunction(&SERIALIZATION_UPDATE_TAGS_GVar);
-    if (func)
-      CALL_0ARGS(func);
-    tags = GVarObj(&SERIALIZATION_TAG_GVar);
-    result = LookupObjMap(tags, type);
+        result = CALL_XARGS(func, args);
+        break;
+    }
     return result;
-  }
-  return (Obj) 0;
 }
 
-void SerializeTypedObj(Obj obj) {
-  Obj type, rep, el1, el2, name;
-  Int skip, start, len;
-  static char typeerror[] =
-    "Serialization has encountered an object with a missing type";
-  if (SerializedAlready(obj))
-    return;
-  type = *(ADDR_OBJ(obj));
-  if (!type)
-    ErrorQuit(typeerror, 0L, 0L);
-  if ((rep = LookupTypeTag(type))) {
+Obj LookupTypeTag(Obj type)
+{
+    Obj tags = GVarObj(&SERIALIZATION_TAG_GVar);
+    Obj func, result;
+    if (tags && TNUM_OBJ(tags) == T_OBJMAP) {
+        result = LookupObjMap(tags, type);
+        if (result)
+            return result;
+        if (GVarObj(&SERIALIZATION_TAGS_NEED_UPDATE_GVar) == False)
+            return (Obj)0;
+        func = GVarFunction(&SERIALIZATION_UPDATE_TAGS_GVar);
+        if (func)
+            CALL_0ARGS(func);
+        tags = GVarObj(&SERIALIZATION_TAG_GVar);
+        result = LookupObjMap(tags, type);
+        return result;
+    }
+    return (Obj)0;
+}
+
+void SerializeTypedObj(Obj obj)
+{
+    Obj         type, rep, el1, el2, name;
+    Int         skip, start, len;
+    static char typeerror[] =
+        "Serialization has encountered an object with a missing type";
+    if (SerializedAlready(obj))
+        return;
+    type = *(ADDR_OBJ(obj));
+    if (!type)
+        ErrorQuit(typeerror, 0L, 0L);
+    if ((rep = LookupTypeTag(type))) {
+        WriteTNum(TNUM_OBJ(obj));
+        switch (TNUM_OBJ(rep)) {
+        case T_INT:
+        case T_STRING:
+        case T_STRING + IMMUTABLE:
+            SerializeObj(rep);
+            UInt sp = LEN_PLIST(STATE(SerializationStack));
+            switch (TNUM_OBJ(obj)) {
+            case T_DATOBJ:
+                WriteByteBlock(obj, sizeof(Obj), SIZE_OBJ(obj) - sizeof(Obj));
+                break;
+            case T_POSOBJ:
+                SerializeList(PosObjToList(obj));
+                break;
+            case T_COMOBJ:
+                SerializeRecord(obj);
+                break;
+            }
+            while (LEN_PLIST(STATE(SerializationStack)) > sp) {
+                SerializeObj(PopObj());
+            }
+            return;
+        }
+    }
     WriteTNum(TNUM_OBJ(obj));
-    switch (TNUM_OBJ(rep)) {
-      case T_INT:
-      case T_STRING:
-      case T_STRING+IMMUTABLE:
-        SerializeObj(rep);
-	UInt sp = LEN_PLIST(STATE(SerializationStack));
-	switch (TNUM_OBJ(obj)) {
-	  case T_DATOBJ:
-	    WriteByteBlock(obj, sizeof(Obj), SIZE_OBJ(obj) - sizeof(Obj));
-	    break;
-	  case T_POSOBJ:
-	    SerializeList(PosObjToList(obj));
-	    break;
-	  case T_COMOBJ:
-	    SerializeRecord(obj);
-	    break;
-	}
-	while (LEN_PLIST(STATE(SerializationStack)) > sp) {
-	  SerializeObj(PopObj());
-	}
-	return;
+    rep = CALL_1ARGS(GVarFunction(&SerializableRepresentationGVar), obj);
+    if (!rep || !IS_PLIST(rep) || LEN_PLIST(rep) == 0) {
+        SerRepError();
+        return;
     }
-  }
-  WriteTNum(TNUM_OBJ(obj));
-  rep = CALL_1ARGS(GVarFunction(&SerializableRepresentationGVar), obj);
-  if (!rep || !IS_PLIST(rep) || LEN_PLIST(rep) == 0) {
-    SerRepError();
-    return;
-  }
-  WriteByte(T_PLIST);
-  el1 = ELM_PLIST(rep, 1);
-  len = LEN_PLIST(rep);
-  if (len >= 2)
-    el2 = ELM_PLIST(rep, 2);
-  else
-    el2 = 0;
-  if (IS_STRING(el1)) {
-    skip = 0;
-    start = 2;
-    name = el1;
-  } else {
-    if (!IS_INTOBJ(el1))
-      SerRepError();
-    skip = INT_INTOBJ(el1);
-    if (skip < 0 || skip + 2 > len)
-      SerRepError();
-    start = 3;
-    name = el2;
-    if (!name || !IS_STRING(name))
-      SerRepError();
-  }
-  WriteByteBlock(name, sizeof(UInt), GET_LEN_STRING(name));
-  WriteImmediateObj(INTOBJ_INT(len - start + 1));
-  while (start <= len && skip > 0) {
-    Obj el = ELM_PLIST(rep, start);
-    UInt sp = LEN_PLIST(STATE(SerializationStack));
-    switch (TNUM_OBJ(el)) {
-      case T_DATOBJ:
-	WriteByte(1);
-	WriteTNum(T_DATOBJ);
-	WriteByteBlock(el, sizeof(Obj), SIZE_OBJ(el) - sizeof(Obj));
-	break;
-      case T_POSOBJ:
-	WriteByte(0);
-        SerializeList(PosObjToList(el));
-	break;
-      case T_COMOBJ:
-	WriteByte(0);
-        SerializeRecord(el);
-	break;
-      case T_APOSOBJ:
-	WriteByte(0);
-        SerializeObj(FromAtomicList(el));
-	break;
-      case T_ACOMOBJ:
-	WriteByte(0);
-        SerializeObj(FromAtomicRecord(el));
-	break;
-      default:
-	WriteByte(0);
+    WriteByte(T_PLIST);
+    el1 = ELM_PLIST(rep, 1);
+    len = LEN_PLIST(rep);
+    if (len >= 2)
+        el2 = ELM_PLIST(rep, 2);
+    else
+        el2 = 0;
+    if (IS_STRING(el1)) {
+        skip = 0;
+        start = 2;
+        name = el1;
+    }
+    else {
+        if (!IS_INTOBJ(el1))
+            SerRepError();
+        skip = INT_INTOBJ(el1);
+        if (skip < 0 || skip + 2 > len)
+            SerRepError();
+        start = 3;
+        name = el2;
+        if (!name || !IS_STRING(name))
+            SerRepError();
+    }
+    WriteByteBlock(name, sizeof(UInt), GET_LEN_STRING(name));
+    WriteImmediateObj(INTOBJ_INT(len - start + 1));
+    while (start <= len && skip > 0) {
+        Obj  el = ELM_PLIST(rep, start);
+        UInt sp = LEN_PLIST(STATE(SerializationStack));
+        switch (TNUM_OBJ(el)) {
+        case T_DATOBJ:
+            WriteByte(1);
+            WriteTNum(T_DATOBJ);
+            WriteByteBlock(el, sizeof(Obj), SIZE_OBJ(el) - sizeof(Obj));
+            break;
+        case T_POSOBJ:
+            WriteByte(0);
+            SerializeList(PosObjToList(el));
+            break;
+        case T_COMOBJ:
+            WriteByte(0);
+            SerializeRecord(el);
+            break;
+        case T_APOSOBJ:
+            WriteByte(0);
+            SerializeObj(FromAtomicList(el));
+            break;
+        case T_ACOMOBJ:
+            WriteByte(0);
+            SerializeObj(FromAtomicRecord(el));
+            break;
+        default:
+            WriteByte(0);
+            SerializeObj(el);
+        }
+        while (LEN_PLIST(STATE(SerializationStack)) > sp) {
+            SerializeObj(PopObj());
+        }
+        start++;
+        skip--;
+    }
+    while (start <= len) {
+        Obj  el = ELM_PLIST(rep, start);
+        UInt sp = LEN_PLIST(STATE(SerializationStack));
+        WriteByte(0);
         SerializeObj(el);
+        while (LEN_PLIST(STATE(SerializationStack)) > sp) {
+            SerializeObj(PopObj());
+        }
+        start++;
     }
-    while (LEN_PLIST(STATE(SerializationStack)) > sp) {
-      SerializeObj(PopObj());
-    }
-    start++;
-    skip--;
-  }
-  while (start <= len) {
-    Obj el = ELM_PLIST(rep, start);
-    UInt sp = LEN_PLIST(STATE(SerializationStack));
-    WriteByte(0);
-    SerializeObj(el);
-    while (LEN_PLIST(STATE(SerializationStack)) > sp) {
-      SerializeObj(PopObj());
-    }
-    start++;
-  }
 }
 
-Obj DeserializeBackRef(UInt tnum) {
-  UInt ref = BACKREF_OBJ(ReadImmediateObj());
-  if (!ref) /* special case for unbound entries */
-    return (Obj) 0;
-  if (ref > LEN_PLIST(STATE(SerializationStack)))
+Obj DeserializeBackRef(UInt tnum)
+{
+    UInt ref = BACKREF_OBJ(ReadImmediateObj());
+    if (!ref) /* special case for unbound entries */
+        return (Obj)0;
+    if (ref > LEN_PLIST(STATE(SerializationStack)))
+        DeserializationError();
+    return ELM_PLIST(STATE(SerializationStack), ref);
+}
+
+void SerializeError(Obj obj)
+{
+    char         buf[16];
+    const Char * type = InfoBags[TNUM_OBJ(obj)].name;
+    if (!type) {
+        sprintf(buf, "<%d>", (int)TNUM_OBJ(obj));
+        type = buf;
+    }
+    ErrorQuit("Cannot serialize object of type %s", (UInt)type, 0L);
+}
+
+Obj DeserializeError(UInt tnum)
+{
     DeserializationError();
-  return ELM_PLIST(STATE(SerializationStack), ref);
+    return Fail;
 }
 
-void SerializeError(Obj obj) {
-  char buf[16];
-  const Char *type = InfoBags[TNUM_OBJ(obj)].name;
-  if (!type) {
-    sprintf(buf, "<%d>", (int) TNUM_OBJ(obj));
-    type = buf;
-  }
-  ErrorQuit("Cannot serialize object of type %s", (UInt) type, 0L);
-}
-
-Obj DeserializeError(UInt tnum) {
-  DeserializationError();
-  return Fail;
-}
-
-Obj FuncSERIALIZE_NATIVE_STRING(Obj self, Obj obj) {
-  Obj result;
-  volatile SerializationState state;
-  syJmp_buf readJmpError;
-  SaveSerializationState(&state);
-  InitNativeStringSerializer(NEW_STRING(0));
-  memcpy(readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf));
-  if (sySetjmp(STATE(ReadJmpError))) {
+Obj FuncSERIALIZE_NATIVE_STRING(Obj self, Obj obj)
+{
+    Obj                         result;
+    volatile SerializationState state;
+    syJmp_buf                   readJmpError;
+    SaveSerializationState(&state);
+    InitNativeStringSerializer(NEW_STRING(0));
+    memcpy(readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf));
+    if (sySetjmp(STATE(ReadJmpError))) {
+        memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+        RestoreSerializationState(&state);
+        syLongjmp(&(STATE(ReadJmpError)), 1);
+    }
+    SerializeObj(obj);
+    while (LEN_PLIST(STATE(SerializationStack)) > 0)
+        SerializeObj(PopObj());
+    result = STATE(SerializationObj);
     memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
     RestoreSerializationState(&state);
-    syLongjmp(&(STATE(ReadJmpError)), 1);
-  }
-  SerializeObj(obj);
-  while (LEN_PLIST(STATE(SerializationStack)) > 0)
-    SerializeObj(PopObj());
-  result = STATE(SerializationObj);
-  memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
-  RestoreSerializationState(&state);
-  return result;
+    return result;
 }
 
-Obj FuncDESERIALIZE_NATIVE_STRING(Obj self, Obj string) {
-  Obj result;
-  volatile SerializationState state;
-  syJmp_buf readJmpError;
+Obj FuncDESERIALIZE_NATIVE_STRING(Obj self, Obj string)
+{
+    Obj                         result;
+    volatile SerializationState state;
+    syJmp_buf                   readJmpError;
 
-  SaveSerializationState(&state);
+    SaveSerializationState(&state);
 
-  if (!IS_STRING(string))
-    ErrorQuit("DESERIALIZE_NATIVE_STRING: argument must be a string", 0L, 0L);
-  memcpy(readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf));
-  if (sySetjmp(STATE(ReadJmpError))) {
+    if (!IS_STRING(string))
+        ErrorQuit("DESERIALIZE_NATIVE_STRING: argument must be a string", 0L,
+                  0L);
+    memcpy(readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf));
+    if (sySetjmp(STATE(ReadJmpError))) {
+        memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+        RestoreSerializationState(&state);
+        syLongjmp(&(STATE(ReadJmpError)), 1);
+    }
+    InitNativeStringDeserializer(string);
+    result = DeserializeObj();
     memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
     RestoreSerializationState(&state);
-    syLongjmp(&(STATE(ReadJmpError)), 1);
-  }
-  InitNativeStringDeserializer(string);
-  result = DeserializeObj();
-  memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
-  RestoreSerializationState(&state);
-  return result;
+    return result;
 }
 
 /****************************************************************************
@@ -1061,13 +1145,13 @@ Obj FuncDESERIALIZE_NATIVE_STRING(Obj self, Obj string) {
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
 
-static StructGVarFunc GVarFuncs [] = {
+static StructGVarFunc GVarFuncs[] = {
 
-    { "SERIALIZE_TO_NATIVE_STRING", 1, "obj",
-      FuncSERIALIZE_NATIVE_STRING, "src/objset.c:SERIALIZE_NATIVE_STRING" },
+    { "SERIALIZE_TO_NATIVE_STRING", 1, "obj", FuncSERIALIZE_NATIVE_STRING,
+      "src/objset.c:SERIALIZE_NATIVE_STRING" },
 
-    { "DESERIALIZE_NATIVE_STRING", 1, "string",
-      FuncDESERIALIZE_NATIVE_STRING, "src/objset.c:DESERIALIZE_NATIVE_STRING" },
+    { "DESERIALIZE_NATIVE_STRING", 1, "string", FuncDESERIALIZE_NATIVE_STRING,
+      "src/objset.c:DESERIALIZE_NATIVE_STRING" },
 
     { 0, 0, 0, 0, 0 }
 
@@ -1078,68 +1162,68 @@ static StructGVarFunc GVarFuncs [] = {
 **
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
 */
-static Int InitKernel (
-    StructInitInfo *    module )
+static Int InitKernel(StructInitInfo * module)
 {
-  UInt i;
-  static unsigned char binary_serializable_tnums[] =
-    { T_INTPOS, T_INTNEG, T_RAT, T_PERM2, T_PERM4, T_MACFLOAT };
-  static unsigned char typed_serializable_tnums[] =
-    { T_DATOBJ, T_POSOBJ, T_COMOBJ, T_APOSOBJ, T_ACOMOBJ };
-  for (i=0; i <= T_BACKREF; i++) {
-    RegisterSerializerFunctions(i, SerializeError, DeserializeError);
-  }
-  for (i=0; i < sizeof(binary_serializable_tnums); i++) {
-    RegisterSerializerFunctions(binary_serializable_tnums[i],
-        SerializeBinary, DeserializeBinary);
-  }
-  RegisterSerializerFunctions(T_INT, SerializeInt, DeserializeInt);
-  RegisterSerializerFunctions(T_FFE, SerializeFFE, DeserializeFFE);
-  RegisterSerializerFunctions(T_BOOL, SerializeBool, DeserializeBool);
-  RegisterSerializerFunctions(T_CHAR, SerializeChar, DeserializeChar);
-  RegisterSerializerFunctions(T_CYC, SerializeCyc, DeserializeCyc);
-  for (i=FIRST_PLIST_TNUM; i<=LAST_PLIST_TNUM; i++) {
-    RegisterSerializerFunctions(i, SerializeList, DeserializeList);
-  }
-  for (i=FIRST_RECORD_TNUM; i<=LAST_RECORD_TNUM; i++) {
-    RegisterSerializerFunctions(i, SerializeRecord, DeserializeRecord);
-  }
-  for (i=T_RANGE_NSORT; i<T_BLIST; i++) {
-    RegisterSerializerFunctions(i, SerializeRange, DeserializeRange);
-  }
-  for (i=T_BLIST; i<T_STRING; i++) {
-    RegisterSerializerFunctions(i, SerializeBlist, DeserializeBlist);
-  }
-  for (i=T_STRING; i<=T_STRING_SSORT+IMMUTABLE; i++) {
-    RegisterSerializerFunctions(i, SerializeString, DeserializeString);
-  }
-  for (i=0; i < sizeof(typed_serializable_tnums); i++) {
-    RegisterSerializerFunctions(typed_serializable_tnums[i],
-        SerializeTypedObj, DeserializeTypedObj);
-  }
+    UInt                 i;
+    static unsigned char binary_serializable_tnums[] = {
+        T_INTPOS, T_INTNEG, T_RAT, T_PERM2, T_PERM4, T_MACFLOAT
+    };
+    static unsigned char typed_serializable_tnums[] = { T_DATOBJ, T_POSOBJ,
+                                                        T_COMOBJ, T_APOSOBJ,
+                                                        T_ACOMOBJ };
+    for (i = 0; i <= T_BACKREF; i++) {
+        RegisterSerializerFunctions(i, SerializeError, DeserializeError);
+    }
+    for (i = 0; i < sizeof(binary_serializable_tnums); i++) {
+        RegisterSerializerFunctions(binary_serializable_tnums[i],
+                                    SerializeBinary, DeserializeBinary);
+    }
+    RegisterSerializerFunctions(T_INT, SerializeInt, DeserializeInt);
+    RegisterSerializerFunctions(T_FFE, SerializeFFE, DeserializeFFE);
+    RegisterSerializerFunctions(T_BOOL, SerializeBool, DeserializeBool);
+    RegisterSerializerFunctions(T_CHAR, SerializeChar, DeserializeChar);
+    RegisterSerializerFunctions(T_CYC, SerializeCyc, DeserializeCyc);
+    for (i = FIRST_PLIST_TNUM; i <= LAST_PLIST_TNUM; i++) {
+        RegisterSerializerFunctions(i, SerializeList, DeserializeList);
+    }
+    for (i = FIRST_RECORD_TNUM; i <= LAST_RECORD_TNUM; i++) {
+        RegisterSerializerFunctions(i, SerializeRecord, DeserializeRecord);
+    }
+    for (i = T_RANGE_NSORT; i < T_BLIST; i++) {
+        RegisterSerializerFunctions(i, SerializeRange, DeserializeRange);
+    }
+    for (i = T_BLIST; i < T_STRING; i++) {
+        RegisterSerializerFunctions(i, SerializeBlist, DeserializeBlist);
+    }
+    for (i = T_STRING; i <= T_STRING_SSORT + IMMUTABLE; i++) {
+        RegisterSerializerFunctions(i, SerializeString, DeserializeString);
+    }
+    for (i = 0; i < sizeof(typed_serializable_tnums); i++) {
+        RegisterSerializerFunctions(typed_serializable_tnums[i],
+                                    SerializeTypedObj, DeserializeTypedObj);
+    }
 
-  RegisterSerializerFunctions(T_OBJSET, SerializeObjSet, DeserializeObjSet);
-  RegisterSerializerFunctions(T_OBJMAP, SerializeObjMap, DeserializeObjMap);
+    RegisterSerializerFunctions(T_OBJSET, SerializeObjSet, DeserializeObjSet);
+    RegisterSerializerFunctions(T_OBJMAP, SerializeObjMap, DeserializeObjMap);
 
-  RegisterSerializerFunctions(T_BACKREF, SerializeError, DeserializeBackRef);
+    RegisterSerializerFunctions(T_BACKREF, SerializeError,
+                                DeserializeBackRef);
 
-  /* gvars */
-  DeclareGVar(&SerializableRepresentationGVar, "SerializableRepresentation");
-  DeclareGVar(&TYPE_UNKNOWN_GVar, "TYPE_UNKNOWN");
-  DeclareGVar(&DESERIALIZER_GVar, "DESERIALIZER");
-  DeclareGVar(&SERIALIZATION_TAG_GVar,
-    "SERIALIZATION_TAG");
-  DeclareGVar(&DESERIALIZATION_TAG_INT_GVar,
-    "DESERIALIZATION_TAG_INT");
-  DeclareGVar(&DESERIALIZATION_TAG_STRING_GVar,
-    "DESERIALIZATION_TAG_STRING");
-  DeclareGVar(&SERIALIZATION_UPDATE_TAGS_GVar,
-    "SERIALIZATION_UPDATE_TAGS");
-  DeclareGVar(&SERIALIZATION_TAGS_NEED_UPDATE_GVar,
-    "SERIALIZATION_TAGS_NEED_UPDATE");
+    /* gvars */
+    DeclareGVar(&SerializableRepresentationGVar,
+                "SerializableRepresentation");
+    DeclareGVar(&TYPE_UNKNOWN_GVar, "TYPE_UNKNOWN");
+    DeclareGVar(&DESERIALIZER_GVar, "DESERIALIZER");
+    DeclareGVar(&SERIALIZATION_TAG_GVar, "SERIALIZATION_TAG");
+    DeclareGVar(&DESERIALIZATION_TAG_INT_GVar, "DESERIALIZATION_TAG_INT");
+    DeclareGVar(&DESERIALIZATION_TAG_STRING_GVar,
+                "DESERIALIZATION_TAG_STRING");
+    DeclareGVar(&SERIALIZATION_UPDATE_TAGS_GVar, "SERIALIZATION_UPDATE_TAGS");
+    DeclareGVar(&SERIALIZATION_TAGS_NEED_UPDATE_GVar,
+                "SERIALIZATION_TAGS_NEED_UPDATE");
 
-  /* return success                                                      */
-  return 0;
+    /* return success                                                      */
+    return 0;
 }
 
 
@@ -1147,11 +1231,10 @@ static Int InitKernel (
 **
 *F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
 */
-static Int InitLibrary (
-    StructInitInfo *    module )
+static Int InitLibrary(StructInitInfo * module)
 {
     /* init filters and functions                                          */
-    InitGVarFuncsFromTable( GVarFuncs );
+    InitGVarFuncsFromTable(GVarFuncs);
 
     /* return success                                                      */
     return 0;
@@ -1162,21 +1245,21 @@ static Int InitLibrary (
 *F  InitInfoObjSet() . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "serialize",                        /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                         		/* postRestore                    */
+    MODULE_BUILTIN, /* type                           */
+    "serialize",    /* name                           */
+    0,              /* revision entry of c file       */
+    0,              /* revision entry of h file       */
+    0,              /* version                        */
+    0,              /* crc                            */
+    InitKernel,     /* initKernel                     */
+    InitLibrary,    /* initLibrary                    */
+    0,              /* checkInit                      */
+    0,              /* preSave                        */
+    0,              /* postSave                       */
+    0               /* postRestore                    */
 };
 
-StructInitInfo * InitInfoSerialize ( void )
+StructInitInfo * InitInfoSerialize(void)
 {
     return &module;
 }

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -37,39 +37,41 @@
 #ifndef WARD_ENABLED
 
 typedef struct ThreadData {
-  pthread_t pthread_id;
-  pthread_mutex_t *lock;
-  pthread_cond_t *cond;
-  int joined;
-  int system;
-  AtomicUInt state;
-  void *tls;
-  void (*start)(void *);
-  void *arg;
-  Obj thread_object;
-  Obj region_name;
-  struct ThreadData *next;
+    pthread_t         pthread_id;
+    pthread_mutex_t * lock;
+    pthread_cond_t *  cond;
+    int               joined;
+    int               system;
+    AtomicUInt        state;
+    void *            tls;
+    void (*start)(void *);
+    void *              arg;
+    Obj                 thread_object;
+    Obj                 region_name;
+    struct ThreadData * next;
 } ThreadData;
 
 Region *LimboRegion, *ReadOnlyRegion;
-Obj PublicRegion;
-Obj PublicRegionName;
+Obj     PublicRegion;
+Obj     PublicRegionName;
 
-static int GlobalPauseInProgress;
+static int        GlobalPauseInProgress;
 static AtomicUInt ThreadCounter = 1;
 
-static inline void IncThreadCounter() {
-  ATOMIC_INC(&ThreadCounter);
+static inline void IncThreadCounter()
+{
+    ATOMIC_INC(&ThreadCounter);
 }
 
-static inline void DecThreadCounter() {
-  ATOMIC_DEC(&ThreadCounter);
+static inline void DecThreadCounter()
+{
+    ATOMIC_DEC(&ThreadCounter);
 }
 
-static ThreadData thread_data[MAX_THREADS];
-static ThreadData *paused_threads[MAX_THREADS];
-static ThreadData *thread_free_list;
-static int num_paused_threads;
+static ThreadData   thread_data[MAX_THREADS];
+static ThreadData * paused_threads[MAX_THREADS];
+static ThreadData * thread_free_list;
+static int          num_paused_threads;
 
 static pthread_rwlock_t master_lock;
 
@@ -77,15 +79,17 @@ static pthread_rwlock_t ObjLock[NUM_LOCKS];
 
 int PreThreadCreation = 1;
 
-void LockThreadControl(int modify) {
-  if (modify)
-    pthread_rwlock_wrlock(&master_lock);
-  else
-    pthread_rwlock_rdlock(&master_lock);
+void LockThreadControl(int modify)
+{
+    if (modify)
+        pthread_rwlock_wrlock(&master_lock);
+    else
+        pthread_rwlock_rdlock(&master_lock);
 }
 
-void UnlockThreadControl(void) {
-  pthread_rwlock_unlock(&master_lock);
+void UnlockThreadControl(void)
+{
+    pthread_rwlock_unlock(&master_lock);
 }
 
 #ifndef MAP_ANONYMOUS
@@ -94,30 +98,33 @@ void UnlockThreadControl(void) {
 
 #ifndef HAVE_NATIVE_TLS
 
-void *AllocateTLS()
+void * AllocateTLS()
 {
-  void *addr;
-  void *result;
-  size_t pagesize = getpagesize();
-  size_t tlssize = (sizeof(ThreadLocalStorage)+pagesize-1) & ~ (pagesize-1);
-  addr = mmap(0, 2 * TLS_SIZE, PROT_READ|PROT_WRITE,
-    MAP_PRIVATE|MAP_ANONYMOUS, -1 , 0);
-  result = (void *)((((uintptr_t) addr) + (TLS_SIZE-1)) & TLS_MASK);
-  munmap(addr, (char *)result-(char *)addr);
-  munmap((char *)result+TLS_SIZE, (char *)addr-(char *)result+TLS_SIZE);
-  /* generate a stack overflow protection area */
+    void * addr;
+    void * result;
+    size_t pagesize = getpagesize();
+    size_t tlssize =
+        (sizeof(ThreadLocalStorage) + pagesize - 1) & ~(pagesize - 1);
+    addr = mmap(0, 2 * TLS_SIZE, PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    result = (void *)((((uintptr_t)addr) + (TLS_SIZE - 1)) & TLS_MASK);
+    munmap(addr, (char *)result - (char *)addr);
+    munmap((char *)result + TLS_SIZE,
+           (char *)addr - (char *)result + TLS_SIZE);
+/* generate a stack overflow protection area */
 #ifdef STACK_GROWS_UP
-  mprotect((char *) result + TLS_SIZE - tlssize - pagesize, pagesize, PROT_NONE);
+    mprotect((char *)result + TLS_SIZE - tlssize - pagesize, pagesize,
+             PROT_NONE);
 #else
-  mprotect((char *) result + tlssize, pagesize, PROT_NONE);
+    mprotect((char *)result + tlssize, pagesize, PROT_NONE);
 #endif
-  return result;
+    return result;
 }
 
-void FreeTLS(void *address)
+void FreeTLS(void * address)
 {
-  /* We currently cannot free this memory because of garbage collector
-   * issues. Instead, it will be reused */
+/* We currently cannot free this memory because of garbage collector
+ * issues. Instead, it will be reused */
 #if 0
   munmap(address, TLS_STACK_SIZE);
 #endif
@@ -128,17 +135,17 @@ void FreeTLS(void *address)
 #ifndef DISABLE_GC
 void AddGCRoots()
 {
-  void *p = realTLS;
-  GC_add_roots(p, (char *)p + sizeof(ThreadLocalStorage));
+    void * p = realTLS;
+    GC_add_roots(p, (char *)p + sizeof(ThreadLocalStorage));
 }
 
 void RemoveGCRoots()
 {
-  void *p = realTLS;
+    void * p = realTLS;
 #if defined(__CYGWIN__) || defined(__CYGWIN32__)
-  memset(p, '\0', sizeof(ThreadLocalStorage));
+    memset(p, '\0', sizeof(ThreadLocalStorage));
 #else
-  GC_remove_roots(p, (char *)p + sizeof(ThreadLocalStorage));
+    GC_remove_roots(p, (char *)p + sizeof(ThreadLocalStorage));
 #endif
 }
 #endif /* DISABLE_GC */
@@ -167,844 +174,872 @@ static void GrowStack() __attribute__((noinline));
 
 static void GrowStack()
 {
-  char *tls = (char *) realTLS;
-  size_t pagesize = getpagesize();
-  /* p needs to be a volatile pointer so that the memory writes are not
-   * removed by the optimizer */
-  volatile char *p = alloca(pagesize);
-  while (p > tls)
-  {
-    /* touch memory */
-    *p = '\0';
-    p = alloca(pagesize);
-  }
+    char * tls = (char *)realTLS;
+    size_t pagesize = getpagesize();
+    /* p needs to be a volatile pointer so that the memory writes are not
+     * removed by the optimizer */
+    volatile char * p = alloca(pagesize);
+    while (p > tls) {
+        /* touch memory */
+        *p = '\0';
+        p = alloca(pagesize);
+    }
 }
 #endif
 
 static void SetupTLS()
 {
 #ifndef HAVE_NATIVE_TLS
-  GrowStack();
+    GrowStack();
 #endif
-  InitializeTLS();
-  MainThreadTLS = realTLS;
-  TLS(threadID) = 0;
+    InitializeTLS();
+    MainThreadTLS = realTLS;
+    TLS(threadID) = 0;
 }
 
-Obj NewThreadObject(UInt id) {
-  Obj result = NewBag(T_THREAD, 3*sizeof(UInt));
-  ADDR_OBJ(result)[0] = (Bag) 0;
-  ADDR_OBJ(result)[1] = (Bag) id;
-  ADDR_OBJ(result)[2] = (Bag) 0;
-  return result;
+Obj NewThreadObject(UInt id)
+{
+    Obj result = NewBag(T_THREAD, 3 * sizeof(UInt));
+    ADDR_OBJ(result)[0] = (Bag)0;
+    ADDR_OBJ(result)[1] = (Bag)id;
+    ADDR_OBJ(result)[2] = (Bag)0;
+    return result;
 }
 
 void InitMainThread()
 {
-  TLS(threadObject) = NewThreadObject(0);
+    TLS(threadObject) = NewThreadObject(0);
 }
 
-static void RunThreadedMain2(
-  int (*mainFunction)(int, char **, char **),
-  int argc,
-  char **argv,
-  char **environ )
+static void RunThreadedMain2(int (*mainFunction)(int, char **, char **),
+                             int     argc,
+                             char ** argv,
+                             char ** environ)
 #ifdef __GNUC__
-  __attribute__((noinline))
+    __attribute__((noinline))
 #endif
-;
+    ;
 
-void RunThreadedMain(
-  int (*mainFunction)(int, char **, char **),
-  int argc,
-  char **argv,
-  char **environ )
+void RunThreadedMain(int (*mainFunction)(int, char **, char **),
+                     int     argc,
+                     char ** argv,
+                     char ** environ)
 {
 #ifndef HAVE_NATIVE_TLS
 #ifdef STACK_GROWS_UP
 #error Upward growing stack not yet supported
 #else
-  /* We need to ensure that the stack pointer and frame pointer
-   * of the called function begin at the top end of a memory
-   * segment whose beginning and end address are a multiple of
-   * TLS_SIZE (which is a power of 2). To that end, we look at
-   * an approximation of the current stack pointer by taking
-   * the address of a local variable, then mask out the lowest
-   * bits and use alloca() to allocate at least that many bytes
-   * on the stack. We also need to touch the pages in that area;
-   * see the comments on GrowStack() for the reason why.
-   */
-  volatile int dummy[1];
-  size_t amount;
-  amount = ((uintptr_t) dummy) & ~TLS_MASK;
-  volatile char *p = alloca(((uintptr_t) dummy) &~TLS_MASK);
-  volatile char *q;
-  for (q = p + amount - 1; (void *)q >= (void *)p; q -= 1024) {
-    /* touch memory */
-    *q = '\0';
-  }
+    /* We need to ensure that the stack pointer and frame pointer
+     * of the called function begin at the top end of a memory
+     * segment whose beginning and end address are a multiple of
+     * TLS_SIZE (which is a power of 2). To that end, we look at
+     * an approximation of the current stack pointer by taking
+     * the address of a local variable, then mask out the lowest
+     * bits and use alloca() to allocate at least that many bytes
+     * on the stack. We also need to touch the pages in that area;
+     * see the comments on GrowStack() for the reason why.
+     */
+    volatile int dummy[1];
+    size_t       amount;
+    amount = ((uintptr_t)dummy) & ~TLS_MASK;
+    volatile char * p = alloca(((uintptr_t)dummy) & ~TLS_MASK);
+    volatile char * q;
+    for (q = p + amount - 1; (void *)q >= (void *)p; q -= 1024) {
+        /* touch memory */
+        *q = '\0';
+    }
 #endif
 #endif
-  RunThreadedMain2(mainFunction, argc, argv, environ);
+    RunThreadedMain2(mainFunction, argc, argv, environ);
 }
 
-static void RunThreadedMain2(
-  int (*mainFunction)(int, char **, char **),
-  int argc,
-  char **argv,
-  char **environ )
+static void RunThreadedMain2(int (*mainFunction)(int, char **, char **),
+                             int     argc,
+                             char ** argv,
+                             char ** environ)
 {
-  void InitTraversal();
-  int i;
-  static pthread_mutex_t main_thread_mutex;
-  static pthread_cond_t main_thread_cond;
-  void InitTraversalModule();
-  SetupTLS();
-  for (i=1; i<MAX_THREADS-1; i++)
-    thread_data[i].next = thread_data+i+1;
-  thread_data[0].next = NULL;
-  for (i=0; i<NUM_LOCKS; i++)
-    pthread_rwlock_init(&ObjLock[i], 0);
-  thread_data[MAX_THREADS-1].next = NULL;
-  for (i=0; i<MAX_THREADS; i++) {
-    thread_data[i].tls = 0;
-    thread_data[i].state = TSTATE_TERMINATED;
-    thread_data[i].system = 0;
-  }
-  thread_free_list = thread_data+1;
-  pthread_rwlock_init(&master_lock, 0);
-  pthread_mutex_init(&main_thread_mutex, 0);
-  pthread_cond_init(&main_thread_cond, 0);
-  TLS(threadLock) = &main_thread_mutex;
-  TLS(threadSignal) = &main_thread_cond;
-  thread_data[0].lock = TLS(threadLock);
-  thread_data[0].cond = TLS(threadSignal);
-  thread_data[0].state = TSTATE_RUNNING;
-  thread_data[0].tls = realTLS;
-  InitSignals();
-  if (sySetjmp(TLS(threadExit)))
-    exit(0);
-  /* Traversal functionality may be needed during the initialization
-   * of some modules, so we set it up now. */
-  InitTraversalModule();
-  exit((*mainFunction)(argc, argv, environ));
+    void                   InitTraversal();
+    int                    i;
+    static pthread_mutex_t main_thread_mutex;
+    static pthread_cond_t  main_thread_cond;
+    void                   InitTraversalModule();
+    SetupTLS();
+    for (i = 1; i < MAX_THREADS - 1; i++)
+        thread_data[i].next = thread_data + i + 1;
+    thread_data[0].next = NULL;
+    for (i = 0; i < NUM_LOCKS; i++)
+        pthread_rwlock_init(&ObjLock[i], 0);
+    thread_data[MAX_THREADS - 1].next = NULL;
+    for (i = 0; i < MAX_THREADS; i++) {
+        thread_data[i].tls = 0;
+        thread_data[i].state = TSTATE_TERMINATED;
+        thread_data[i].system = 0;
+    }
+    thread_free_list = thread_data + 1;
+    pthread_rwlock_init(&master_lock, 0);
+    pthread_mutex_init(&main_thread_mutex, 0);
+    pthread_cond_init(&main_thread_cond, 0);
+    TLS(threadLock) = &main_thread_mutex;
+    TLS(threadSignal) = &main_thread_cond;
+    thread_data[0].lock = TLS(threadLock);
+    thread_data[0].cond = TLS(threadSignal);
+    thread_data[0].state = TSTATE_RUNNING;
+    thread_data[0].tls = realTLS;
+    InitSignals();
+    if (sySetjmp(TLS(threadExit)))
+        exit(0);
+    /* Traversal functionality may be needed during the initialization
+     * of some modules, so we set it up now. */
+    InitTraversalModule();
+    exit((*mainFunction)(argc, argv, environ));
 }
 
 void CreateMainRegion()
 {
-  int i;
-  TLS(currentRegion) = NewRegion();
-  TLS(threadRegion) = TLS(currentRegion);
-  ((Region *)TLS(currentRegion))->fixed_owner = 1;
-  RegionWriteLock(TLS(currentRegion));
-  ((Region *)TLS(currentRegion))->name = MakeImmString("thread region #0");
-  PublicRegionName = MakeImmString("public region");
-  LimboRegion = NewRegion();
-  LimboRegion->fixed_owner = 1;
-  LimboRegion->name = MakeImmString("limbo region");
-  ReadOnlyRegion = NewRegion();
-  ReadOnlyRegion->name = MakeImmString("read-only region");
-  ReadOnlyRegion->fixed_owner = 1;
-  for (i=0; i<=MAX_THREADS; i++) {
-    ReadOnlyRegion->readers[i] = 1;
-  }
+    int i;
+    TLS(currentRegion) = NewRegion();
+    TLS(threadRegion) = TLS(currentRegion);
+    ((Region *)TLS(currentRegion))->fixed_owner = 1;
+    RegionWriteLock(TLS(currentRegion));
+    ((Region *)TLS(currentRegion))->name = MakeImmString("thread region #0");
+    PublicRegionName = MakeImmString("public region");
+    LimboRegion = NewRegion();
+    LimboRegion->fixed_owner = 1;
+    LimboRegion->name = MakeImmString("limbo region");
+    ReadOnlyRegion = NewRegion();
+    ReadOnlyRegion->name = MakeImmString("read-only region");
+    ReadOnlyRegion->fixed_owner = 1;
+    for (i = 0; i <= MAX_THREADS; i++) {
+        ReadOnlyRegion->readers[i] = 1;
+    }
 }
 
-void *DispatchThread(void *arg)
+void * DispatchThread(void * arg)
 {
-  ThreadData *this_thread = arg;
-  Region *region;
-  InitializeTLS();
-  TLS(threadID) = this_thread - thread_data;
+    ThreadData * this_thread = arg;
+    Region *     region;
+    InitializeTLS();
+    TLS(threadID) = this_thread - thread_data;
 #ifndef DISABLE_GC
-  AddGCRoots();
+    AddGCRoots();
 #endif
-  InitTLS();
-  TLS(currentRegion) = region = NewRegion();
-  TLS(threadRegion) = TLS(currentRegion);
-  TLS(threadLock) = this_thread->lock;
-  TLS(threadSignal) = this_thread->cond;
-  region->fixed_owner = 1;
-  region->name = this_thread->region_name;
-  RegionWriteLock(region);
-  if (!this_thread->region_name) {
-    char buf[8];
-    sprintf(buf, "%d", TLS(threadID));
-    this_thread->region_name = MakeImmString2("thread #", buf);
-  }
-  SetRegionName(region, this_thread->region_name);
-  TLS(threadObject) = this_thread->thread_object;
-  pthread_mutex_lock(this_thread->lock);
-  *(ThreadLocalStorage **)(ADDR_OBJ(TLS(threadObject))) = realTLS;
-  pthread_cond_broadcast(this_thread->cond);
-  pthread_mutex_unlock(this_thread->lock);
-  this_thread->start(this_thread->arg);
-  *(UInt *)(ADDR_OBJ(TLS(threadObject))+2) |= THREAD_TERMINATED;
-  region->fixed_owner = 0;
-  RegionWriteUnlock(region);
-  DestroyTLS();
-  memset(realTLS, 0, sizeof(ThreadLocalStorage));
+    InitTLS();
+    TLS(currentRegion) = region = NewRegion();
+    TLS(threadRegion) = TLS(currentRegion);
+    TLS(threadLock) = this_thread->lock;
+    TLS(threadSignal) = this_thread->cond;
+    region->fixed_owner = 1;
+    region->name = this_thread->region_name;
+    RegionWriteLock(region);
+    if (!this_thread->region_name) {
+        char buf[8];
+        sprintf(buf, "%d", TLS(threadID));
+        this_thread->region_name = MakeImmString2("thread #", buf);
+    }
+    SetRegionName(region, this_thread->region_name);
+    TLS(threadObject) = this_thread->thread_object;
+    pthread_mutex_lock(this_thread->lock);
+    *(ThreadLocalStorage **)(ADDR_OBJ(TLS(threadObject))) = realTLS;
+    pthread_cond_broadcast(this_thread->cond);
+    pthread_mutex_unlock(this_thread->lock);
+    this_thread->start(this_thread->arg);
+    *(UInt *)(ADDR_OBJ(TLS(threadObject)) + 2) |= THREAD_TERMINATED;
+    region->fixed_owner = 0;
+    RegionWriteUnlock(region);
+    DestroyTLS();
+    memset(realTLS, 0, sizeof(ThreadLocalStorage));
 #ifndef DISABLE_GC
-  RemoveGCRoots();
+    RemoveGCRoots();
 #endif
-  this_thread->state = TSTATE_TERMINATED;
-  DecThreadCounter();
-  return 0;
-}
-
-Obj RunThread(void (*start)(void *), void *arg)
-{
-  ThreadData *result;
-#ifndef HAVE_NATIVE_TLS
-  void *tls;
-#endif
-  pthread_attr_t thread_attr;
-  size_t pagesize = getpagesize();
-  LockThreadControl(1);
-  PreThreadCreation = 0;
-  /* allocate a new thread id */
-  if (thread_free_list == NULL)
-  {
-    UnlockThreadControl();
-    errno = ENOMEM;
-    return (Obj) 0;
-  }
-  result = thread_free_list;
-  thread_free_list = thread_free_list->next;
-#ifndef HAVE_NATIVE_TLS
-  if (!result->tls)
-    result->tls = AllocateTLS();
-  tls = result->tls;
-#endif
-  if (!result->lock) {
-    result->lock = AllocateMemoryBlock(sizeof(pthread_mutex_t));
-    result->cond = AllocateMemoryBlock(sizeof(pthread_cond_t));
-    pthread_mutex_init(result->lock, 0);
-    pthread_cond_init(result->cond, 0);
-  }
-  result->arg = arg;
-  result->start = start;
-  result->joined = 0;
-  if (GlobalPauseInProgress) {
-    /* New threads will be automatically paused */
-    result->state = TSTATE_PAUSED;
-    HandleInterrupts(0, T_NO_STAT);
-  } else {
-    result->state = TSTATE_RUNNING;
-  }
-  result->thread_object = NewThreadObject(result-thread_data);
-  /* set up the thread attribute to support a custom stack in our TLS */
-  pthread_attr_init(&thread_attr);
-#ifndef HAVE_NATIVE_TLS
-  pthread_attr_setstack(&thread_attr, (char *)tls + pagesize * 2,
-      TLS_SIZE-pagesize*2);
-#endif
-  UnlockThreadControl();
-  /* fork the thread */
-  IncThreadCounter();
-  if (pthread_create(&result->pthread_id, &thread_attr,
-                     DispatchThread, result) < 0) {
-    /* No more threads available */
+    this_thread->state = TSTATE_TERMINATED;
     DecThreadCounter();
-    LockThreadControl(1);
-    result->next = thread_free_list;
-    thread_free_list = result;
-    UnlockThreadControl();
-    pthread_attr_destroy(&thread_attr);
+    return 0;
+}
+
+Obj RunThread(void (*start)(void *), void * arg)
+{
+    ThreadData * result;
 #ifndef HAVE_NATIVE_TLS
-    FreeTLS(tls);
+    void * tls;
 #endif
-    return (Obj)0;
-  }
-  pthread_attr_destroy(&thread_attr);
-  return result->thread_object;
+    pthread_attr_t thread_attr;
+    size_t         pagesize = getpagesize();
+    LockThreadControl(1);
+    PreThreadCreation = 0;
+    /* allocate a new thread id */
+    if (thread_free_list == NULL) {
+        UnlockThreadControl();
+        errno = ENOMEM;
+        return (Obj)0;
+    }
+    result = thread_free_list;
+    thread_free_list = thread_free_list->next;
+#ifndef HAVE_NATIVE_TLS
+    if (!result->tls)
+        result->tls = AllocateTLS();
+    tls = result->tls;
+#endif
+    if (!result->lock) {
+        result->lock = AllocateMemoryBlock(sizeof(pthread_mutex_t));
+        result->cond = AllocateMemoryBlock(sizeof(pthread_cond_t));
+        pthread_mutex_init(result->lock, 0);
+        pthread_cond_init(result->cond, 0);
+    }
+    result->arg = arg;
+    result->start = start;
+    result->joined = 0;
+    if (GlobalPauseInProgress) {
+        /* New threads will be automatically paused */
+        result->state = TSTATE_PAUSED;
+        HandleInterrupts(0, T_NO_STAT);
+    }
+    else {
+        result->state = TSTATE_RUNNING;
+    }
+    result->thread_object = NewThreadObject(result - thread_data);
+    /* set up the thread attribute to support a custom stack in our TLS */
+    pthread_attr_init(&thread_attr);
+#ifndef HAVE_NATIVE_TLS
+    pthread_attr_setstack(&thread_attr, (char *)tls + pagesize * 2,
+                          TLS_SIZE - pagesize * 2);
+#endif
+    UnlockThreadControl();
+    /* fork the thread */
+    IncThreadCounter();
+    if (pthread_create(&result->pthread_id, &thread_attr, DispatchThread,
+                       result) < 0) {
+        /* No more threads available */
+        DecThreadCounter();
+        LockThreadControl(1);
+        result->next = thread_free_list;
+        thread_free_list = result;
+        UnlockThreadControl();
+        pthread_attr_destroy(&thread_attr);
+#ifndef HAVE_NATIVE_TLS
+        FreeTLS(tls);
+#endif
+        return (Obj)0;
+    }
+    pthread_attr_destroy(&thread_attr);
+    return result->thread_object;
 }
 
 int JoinThread(int id)
 {
-  pthread_t pthread_id;
-  void (*start)(void *);
+    pthread_t pthread_id;
+    void (*start)(void *);
 #ifndef HAVE_NATIVE_TLS
-  void *tls;
+    void * tls;
 #endif
-  if (id < 0 || id >= MAX_THREADS)
-    return 0;
-  LockThreadControl(1);
-  pthread_id = thread_data[id].pthread_id;
-  start = thread_data[id].start;
+    if (id < 0 || id >= MAX_THREADS)
+        return 0;
+    LockThreadControl(1);
+    pthread_id = thread_data[id].pthread_id;
+    start = thread_data[id].start;
 #ifndef HAVE_NATIVE_TLS
-  tls = thread_data[id].tls;
+    tls = thread_data[id].tls;
 #endif
-  if (thread_data[id].joined || start == NULL)
-  {
+    if (thread_data[id].joined || start == NULL) {
+        UnlockThreadControl();
+        return 0;
+    }
+    thread_data[id].joined = 1;
     UnlockThreadControl();
-    return 0;
-  }
-  thread_data[id].joined = 1;
-  UnlockThreadControl();
-  pthread_join(pthread_id, NULL);
-  LockThreadControl(1);
-  thread_data[id].next = thread_free_list;
-  thread_free_list = thread_data+id;
-  /*
-  FreeTLS(thread_data[id].tls);
-  thread_data[id].tls = NULL;
-  */
-  thread_data[id].start = NULL;
-  UnlockThreadControl();
+    pthread_join(pthread_id, NULL);
+    LockThreadControl(1);
+    thread_data[id].next = thread_free_list;
+    thread_free_list = thread_data + id;
+    /*
+    FreeTLS(thread_data[id].tls);
+    thread_data[id].tls = NULL;
+    */
+    thread_data[id].start = NULL;
+    UnlockThreadControl();
 #ifndef HAVE_NATIVE_TLS
-  FreeTLS(tls);
+    FreeTLS(tls);
 #endif
-  return 1;
+    return 1;
 }
 
 Int ThreadID(Obj thread)
 {
-  return *(UInt *)(ADDR_OBJ(thread)+1);
+    return *(UInt *)(ADDR_OBJ(thread) + 1);
 }
 
-void *ThreadTLS(Obj thread)
+void * ThreadTLS(Obj thread)
 {
-  return *(ThreadLocalStorage **)(ADDR_OBJ(thread)+1);
+    return *(ThreadLocalStorage **)(ADDR_OBJ(thread) + 1);
 }
 
 
-static UInt LockID(void *object) {
+static UInt LockID(void * object)
+{
 #if CUSTOM_OBJECT_HASH
-  UInt p = (UInt) object;
-  if (sizeof(void *) == 4)
-    return ((p >> 2)
-      ^ (p >> (2 + LOG2_NUM_LOCKS))
-      ^ (p << (LOG2_NUM_LOCKS - 2))) % NUM_LOCKS;
-  else
-    return ((p >> 3)
-      ^ (p >> (3 + LOG2_NUM_LOCKS))
-      ^ (p << (LOG2_NUM_LOCKS - 3))) % NUM_LOCKS;
+    UInt p = (UInt)object;
+    if (sizeof(void *) == 4)
+        return ((p >> 2) ^ (p >> (2 + LOG2_NUM_LOCKS)) ^
+                (p << (LOG2_NUM_LOCKS - 2))) %
+               NUM_LOCKS;
+    else
+        return ((p >> 3) ^ (p >> (3 + LOG2_NUM_LOCKS)) ^
+                (p << (LOG2_NUM_LOCKS - 3))) %
+               NUM_LOCKS;
 #else
-  return FibHash((UInt) object, LOG2_NUM_LOCKS);
+    return FibHash((UInt)object, LOG2_NUM_LOCKS);
 #endif
 }
 
-void HashLock(void *object) {
-  if (TLS(CurrentHashLock))
-    ErrorQuit("Nested hash locks", 0L, 0L);
-  TLS(CurrentHashLock) = object;
-  pthread_rwlock_wrlock(&ObjLock[LockID(object)]);
-}
-
-void HashLockShared(void *object) {
-  if (TLS(CurrentHashLock))
-    ErrorQuit("Nested hash locks", 0L, 0L);
-  TLS(CurrentHashLock) = object;
-  pthread_rwlock_rdlock(&ObjLock[LockID(object)]);
-}
-
-void HashUnlock(void *object) {
-  if (TLS(CurrentHashLock) != object)
-    ErrorQuit("Improperly matched hash lock/unlock calls", 0L, 0L);
-  TLS(CurrentHashLock) = 0;
-  pthread_rwlock_unlock(&ObjLock[LockID(object)]);
-}
-
-void HashUnlockShared(void *object) {
-  if (TLS(CurrentHashLock) != object)
-    ErrorQuit("Improperly matched hash lock/unlock calls", 0L, 0L);
-  TLS(CurrentHashLock) = 0;
-  pthread_rwlock_unlock(&ObjLock[LockID(object)]);
-}
-
-void RegionWriteLock(Region *region)
+void HashLock(void * object)
 {
-  int result = 0;
-  assert(region->owner != realTLS);
+    if (TLS(CurrentHashLock))
+        ErrorQuit("Nested hash locks", 0L, 0L);
+    TLS(CurrentHashLock) = object;
+    pthread_rwlock_wrlock(&ObjLock[LockID(object)]);
+}
 
-  if (region->count_active || TLS(CountActive)) {
+void HashLockShared(void * object)
+{
+    if (TLS(CurrentHashLock))
+        ErrorQuit("Nested hash locks", 0L, 0L);
+    TLS(CurrentHashLock) = object;
+    pthread_rwlock_rdlock(&ObjLock[LockID(object)]);
+}
+
+void HashUnlock(void * object)
+{
+    if (TLS(CurrentHashLock) != object)
+        ErrorQuit("Improperly matched hash lock/unlock calls", 0L, 0L);
+    TLS(CurrentHashLock) = 0;
+    pthread_rwlock_unlock(&ObjLock[LockID(object)]);
+}
+
+void HashUnlockShared(void * object)
+{
+    if (TLS(CurrentHashLock) != object)
+        ErrorQuit("Improperly matched hash lock/unlock calls", 0L, 0L);
+    TLS(CurrentHashLock) = 0;
+    pthread_rwlock_unlock(&ObjLock[LockID(object)]);
+}
+
+void RegionWriteLock(Region * region)
+{
+    int result = 0;
+    assert(region->owner != realTLS);
+
+    if (region->count_active || TLS(CountActive)) {
+        result = !pthread_rwlock_trywrlock(region->lock);
+
+        if (result) {
+            if (region->count_active)
+                region->locks_acquired++;
+            if (TLS(CountActive))
+                TLS(LocksAcquired)++;
+        }
+        else {
+            if (region->count_active)
+                region->locks_contended++;
+            if (TLS(CountActive))
+                TLS(LocksContended)++;
+            pthread_rwlock_wrlock(region->lock);
+        }
+    }
+    else {
+        pthread_rwlock_wrlock(region->lock);
+    }
+
+    region->owner = realTLS;
+}
+
+int RegionTryWriteLock(Region * region)
+{
+    int result;
+    assert(region->owner != realTLS);
     result = !pthread_rwlock_trywrlock(region->lock);
 
-    if(result) {
-      if(region->count_active)
-	region->locks_acquired++;
-      if(TLS(CountActive))
-	TLS(LocksAcquired)++;
-    } else {
-      if(region->count_active)
-	region->locks_contended++;
-      if(TLS(CountActive))
-	TLS(LocksContended)++;
-      pthread_rwlock_wrlock(region->lock);
+    if (result) {
+        if (region->count_active)
+            region->locks_acquired++;
+        if (TLS(CountActive))
+            TLS(LocksAcquired)++;
+        region->owner = realTLS;
     }
-  } else {
-    pthread_rwlock_wrlock(region->lock);
-  }
-
-  region->owner = realTLS;
-}
-
-int RegionTryWriteLock(Region *region)
-{
-  int result;
-  assert(region->owner != realTLS);
-  result = !pthread_rwlock_trywrlock(region->lock);
-
-  if (result) {
-    if(region->count_active)
-      region->locks_acquired++;
-    if(TLS(CountActive))
-      TLS(LocksAcquired)++;
-    region->owner = realTLS;
-  } else {
-    if(region->count_active)
-      region->locks_contended++;
-    if(TLS(CountActive))
-      TLS(LocksContended)++;
-  }
-  return result;
-}
-
-void RegionWriteUnlock(Region *region)
-{
-  assert(region->owner == realTLS);
-  region->owner = NULL;
-  pthread_rwlock_unlock(region->lock);
-}
-
-void RegionReadLock(Region *region)
-{
-  int result = 0;
-  assert(region->owner != realTLS);
-  assert(region->readers[TLS(threadID)] == 0);
-
-  if(region->count_active || TLS(CountActive)) {
-    result = !pthread_rwlock_rdlock(region->lock);
-
-    if(result) {
-      if(region->count_active)
-	ATOMIC_INC(&region->locks_acquired);
-      if(TLS(CountActive))
-	TLS(LocksAcquired)++;
-    } else {
-      if(region->count_active)
-	ATOMIC_INC(&region->locks_contended);
-      if(TLS(CountActive))
-	TLS(LocksAcquired)++;
-      pthread_rwlock_rdlock(region->lock);
+    else {
+        if (region->count_active)
+            region->locks_contended++;
+        if (TLS(CountActive))
+            TLS(LocksContended)++;
     }
-  } else {
-      pthread_rwlock_rdlock(region->lock);
-  }
-  region->readers[TLS(threadID)] = 1;
+    return result;
 }
 
-int RegionTryReadLock(Region *region)
+void RegionWriteUnlock(Region * region)
 {
-  int result = !pthread_rwlock_rdlock(region->lock);
-  assert(region->owner != realTLS);
-  assert(region->readers[TLS(threadID)] == 0);
-
-  if (result) {
-    if(region->count_active)
-      ATOMIC_INC(&region->locks_acquired);
-    if(TLS(CountActive))
-      TLS(LocksAcquired)++;
-    region->readers[TLS(threadID)] = 1;
-  } else {
-    if(region->count_active)
-      ATOMIC_INC(&region->locks_contended);
-    if(TLS(CountActive))
-      TLS(LocksContended)++;
-  }
-  return result;
-}
-
-void RegionReadUnlock(Region *region)
-{
-  assert(region->readers[TLS(threadID)]);
-  region->readers[TLS(threadID)] = 0;
-  pthread_rwlock_unlock(region->lock);
-}
-
-void RegionUnlock(Region *region)
-{
-  assert(region->owner == realTLS || region->readers[TLS(threadID)]);
-  if (region->owner == realTLS)
+    assert(region->owner == realTLS);
     region->owner = NULL;
-  region->readers[TLS(threadID)] = 0;
-  pthread_rwlock_unlock(region->lock);
+    pthread_rwlock_unlock(region->lock);
 }
 
-int IsLocked(Region *region)
+void RegionReadLock(Region * region)
 {
-  if (!region)
-    return 0; /* public region */
-  if (region->owner == realTLS)
-    return 1;
-  if (region->readers[TLS(threadID)])
-    return 2;
-  return 0;
+    int result = 0;
+    assert(region->owner != realTLS);
+    assert(region->readers[TLS(threadID)] == 0);
+
+    if (region->count_active || TLS(CountActive)) {
+        result = !pthread_rwlock_rdlock(region->lock);
+
+        if (result) {
+            if (region->count_active)
+                ATOMIC_INC(&region->locks_acquired);
+            if (TLS(CountActive))
+                TLS(LocksAcquired)++;
+        }
+        else {
+            if (region->count_active)
+                ATOMIC_INC(&region->locks_contended);
+            if (TLS(CountActive))
+                TLS(LocksAcquired)++;
+            pthread_rwlock_rdlock(region->lock);
+        }
+    }
+    else {
+        pthread_rwlock_rdlock(region->lock);
+    }
+    region->readers[TLS(threadID)] = 1;
 }
 
-Region *GetRegionOf(Obj obj)
+int RegionTryReadLock(Region * region)
 {
-  if (!IS_BAG_REF(obj))
-    return NULL;
-  if (TNUM_OBJ(obj) == T_REGION)
-    return *(Region **)(ADDR_OBJ(obj));
-  return REGION(obj);
+    int result = !pthread_rwlock_rdlock(region->lock);
+    assert(region->owner != realTLS);
+    assert(region->readers[TLS(threadID)] == 0);
+
+    if (result) {
+        if (region->count_active)
+            ATOMIC_INC(&region->locks_acquired);
+        if (TLS(CountActive))
+            TLS(LocksAcquired)++;
+        region->readers[TLS(threadID)] = 1;
+    }
+    else {
+        if (region->count_active)
+            ATOMIC_INC(&region->locks_contended);
+        if (TLS(CountActive))
+            TLS(LocksContended)++;
+    }
+    return result;
 }
 
-void SetRegionName(Region *region, Obj name)
+void RegionReadUnlock(Region * region)
 {
-  if (name) {
-    if (!IS_STRING(name))
-      return;
-    if (IS_MUTABLE_OBJ(name))
-      name = CopyObj(name, 0);
-  }
-  MEMBAR_WRITE();
-  region->name = name;
+    assert(region->readers[TLS(threadID)]);
+    region->readers[TLS(threadID)] = 0;
+    pthread_rwlock_unlock(region->lock);
 }
 
-Obj GetRegionName(Region *region)
+void RegionUnlock(Region * region)
 {
-  Obj result;
-  if (region)
-    result = region->name;
-  else
-    result = PublicRegionName;
-  MEMBAR_READ();
-  return result;
+    assert(region->owner == realTLS || region->readers[TLS(threadID)]);
+    if (region->owner == realTLS)
+        region->owner = NULL;
+    region->readers[TLS(threadID)] = 0;
+    pthread_rwlock_unlock(region->lock);
 }
 
-void GetLockStatus(int count, Obj *objects, int *status)
+int IsLocked(Region * region)
 {
-  int i;
-  for (i=0; i<count; i++)
-    status[i] = IsLocked(REGION(objects[i]));
+    if (!region)
+        return 0; /* public region */
+    if (region->owner == realTLS)
+        return 1;
+    if (region->readers[TLS(threadID)])
+        return 2;
+    return 0;
+}
+
+Region * GetRegionOf(Obj obj)
+{
+    if (!IS_BAG_REF(obj))
+        return NULL;
+    if (TNUM_OBJ(obj) == T_REGION)
+        return *(Region **)(ADDR_OBJ(obj));
+    return REGION(obj);
+}
+
+void SetRegionName(Region * region, Obj name)
+{
+    if (name) {
+        if (!IS_STRING(name))
+            return;
+        if (IS_MUTABLE_OBJ(name))
+            name = CopyObj(name, 0);
+    }
+    MEMBAR_WRITE();
+    region->name = name;
+}
+
+Obj GetRegionName(Region * region)
+{
+    Obj result;
+    if (region)
+        result = region->name;
+    else
+        result = PublicRegionName;
+    MEMBAR_READ();
+    return result;
+}
+
+void GetLockStatus(int count, Obj * objects, int * status)
+{
+    int i;
+    for (i = 0; i < count; i++)
+        status[i] = IsLocked(REGION(objects[i]));
 }
 
 static Obj NewList(UInt size)
 {
-  Obj list;
-  list = NEW_PLIST(size == 0 ? T_PLIST_EMPTY : T_PLIST, size);
-  SET_LEN_PLIST(list, size);
-  return list;
+    Obj list;
+    list = NEW_PLIST(size == 0 ? T_PLIST_EMPTY : T_PLIST, size);
+    SET_LEN_PLIST(list, size);
+    return list;
 }
 
-Obj GetRegionLockCounters(Region *region)
+Obj GetRegionLockCounters(Region * region)
 {
-  Obj result = NewList(2);
+    Obj result = NewList(2);
 
-  if (region) {
-    SET_ELM_PLIST(result,1,INTOBJ_INT(region->locks_acquired));
-    SET_ELM_PLIST(result,2,INTOBJ_INT(region->locks_contended));
-  }
-  MEMBAR_READ();
-  return result;
+    if (region) {
+        SET_ELM_PLIST(result, 1, INTOBJ_INT(region->locks_acquired));
+        SET_ELM_PLIST(result, 2, INTOBJ_INT(region->locks_contended));
+    }
+    MEMBAR_READ();
+    return result;
 }
 
-void ResetRegionLockCounters(Region *region)
+void ResetRegionLockCounters(Region * region)
 {
-  if (region) {
-      region->locks_acquired
-      = region->locks_contended
-      = 0;
-  }
-  MEMBAR_WRITE();
+    if (region) {
+        region->locks_acquired = region->locks_contended = 0;
+    }
+    MEMBAR_WRITE();
 }
 
 #define MAX_LOCKS 1024
 
-typedef struct
-{
-  Obj obj;
-  Region *region;
-  int mode;
+typedef struct {
+    Obj      obj;
+    Region * region;
+    int      mode;
 } LockRequest;
 
-static int LessThanLockRequest(const void *a, const void *b)
+static int LessThanLockRequest(const void * a, const void * b)
 {
-  Region *region_a = ((LockRequest *)a)->region;
-  Region *region_b = ((LockRequest *)b)->region;
-  Int prec_diff;
-  if (region_a == region_b) /* prioritize writes */
-    return ((LockRequest *)a)->mode>((LockRequest *)b)->mode;
-  prec_diff = region_a->prec - region_b->prec;
-  return prec_diff > 0 || (prec_diff == 0 && (char *)region_a < (char *)region_b);
+    Region * region_a = ((LockRequest *)a)->region;
+    Region * region_b = ((LockRequest *)b)->region;
+    Int      prec_diff;
+    if (region_a == region_b) /* prioritize writes */
+        return ((LockRequest *)a)->mode > ((LockRequest *)b)->mode;
+    prec_diff = region_a->prec - region_b->prec;
+    return prec_diff > 0 ||
+           (prec_diff == 0 && (char *)region_a < (char *)region_b);
 }
 
-void PushRegionLock(Region *region) {
-  if (!TLS(lockStack)) {
-    TLS(lockStack) = NewList(16);
-    TLS(lockStackPointer) = 0;
-  } else if (LEN_PLIST(TLS(lockStack)) == TLS(lockStackPointer)) {
-    int newlen = TLS(lockStackPointer) * 3 / 2;
-    GROW_PLIST(TLS(lockStack), newlen);
-  }
-  TLS(lockStackPointer)++;
-  SET_ELM_PLIST(TLS(lockStack), TLS(lockStackPointer),
-    region ? region->obj : (Obj) 0);
+void PushRegionLock(Region * region)
+{
+    if (!TLS(lockStack)) {
+        TLS(lockStack) = NewList(16);
+        TLS(lockStackPointer) = 0;
+    }
+    else if (LEN_PLIST(TLS(lockStack)) == TLS(lockStackPointer)) {
+        int newlen = TLS(lockStackPointer) * 3 / 2;
+        GROW_PLIST(TLS(lockStack), newlen);
+    }
+    TLS(lockStackPointer)++;
+    SET_ELM_PLIST(TLS(lockStack), TLS(lockStackPointer),
+                  region ? region->obj : (Obj)0);
 }
 
-void PopRegionLocks(int newSP) {
-  while (newSP < TLS(lockStackPointer))
-  {
-    int p = TLS(lockStackPointer)--;
-    Obj region_obj = ELM_PLIST(TLS(lockStack), p);
-    if (!region_obj)
-      continue;
-    Region *region = *(Region **)(ADDR_OBJ(region_obj));
-    RegionUnlock(region);
-    SET_ELM_PLIST(TLS(lockStack), p, (Obj) 0);
-  }
+void PopRegionLocks(int newSP)
+{
+    while (newSP < TLS(lockStackPointer)) {
+        int p = TLS(lockStackPointer)--;
+        Obj region_obj = ELM_PLIST(TLS(lockStack), p);
+        if (!region_obj)
+            continue;
+        Region * region = *(Region **)(ADDR_OBJ(region_obj));
+        RegionUnlock(region);
+        SET_ELM_PLIST(TLS(lockStack), p, (Obj)0);
+    }
 }
 
-int RegionLockSP() {
-  return TLS(lockStackPointer);
+int RegionLockSP()
+{
+    return TLS(lockStackPointer);
 }
 
-int GetThreadState(int threadID) {
-  return (int)(thread_data[threadID].state);
+int GetThreadState(int threadID)
+{
+    return (int)(thread_data[threadID].state);
 }
 
-int UpdateThreadState(int threadID, int oldState, int newState) {
-  return COMPARE_AND_SWAP(&thread_data[threadID].state,
-    (AtomicUInt) oldState, (AtomicUInt) newState);
+int UpdateThreadState(int threadID, int oldState, int newState)
+{
+    return COMPARE_AND_SWAP(&thread_data[threadID].state,
+                            (AtomicUInt)oldState, (AtomicUInt)newState);
 }
 
-static void SetInterrupt(int threadID) {
-  ThreadLocalStorage *tls = thread_data[threadID].tls;
-  MEMBAR_FULL();
-  tls->state.CurrExecStatFuncs = IntrExecStatFuncs;
+static void SetInterrupt(int threadID)
+{
+    ThreadLocalStorage * tls = thread_data[threadID].tls;
+    MEMBAR_FULL();
+    tls->state.CurrExecStatFuncs = IntrExecStatFuncs;
 }
 
-static int LockAndUpdateThreadState(int threadID, int oldState, int newState) {
-  if (pthread_mutex_trylock(thread_data[threadID].lock) < 0) {
-    return 0;
-  }
-  if (!UpdateThreadState(threadID, oldState, newState)) {
+static int LockAndUpdateThreadState(int threadID, int oldState, int newState)
+{
+    if (pthread_mutex_trylock(thread_data[threadID].lock) < 0) {
+        return 0;
+    }
+    if (!UpdateThreadState(threadID, oldState, newState)) {
+        pthread_mutex_unlock(thread_data[threadID].lock);
+        return 0;
+    }
+    SetInterrupt(threadID);
+    pthread_cond_signal(thread_data[threadID].cond);
     pthread_mutex_unlock(thread_data[threadID].lock);
-    return 0;
-  }
-  SetInterrupt(threadID);
-  pthread_cond_signal(thread_data[threadID].cond);
-  pthread_mutex_unlock(thread_data[threadID].lock);
-  return 1;
+    return 1;
 }
 
-void PauseThread(int threadID) {
-  for (;;) {
-    int state = GetThreadState(threadID);
-    switch (state & TSTATE_MASK) {
-    case TSTATE_RUNNING:
-      if (UpdateThreadState(threadID,
-          TSTATE_RUNNING, TSTATE_PAUSED|(TLS(threadID) << TSTATE_SHIFT))) {
-	SetInterrupt(threadID);
+void PauseThread(int threadID)
+{
+    for (;;) {
+        int state = GetThreadState(threadID);
+        switch (state & TSTATE_MASK) {
+        case TSTATE_RUNNING:
+            if (UpdateThreadState(threadID, TSTATE_RUNNING,
+                                  TSTATE_PAUSED |
+                                      (TLS(threadID) << TSTATE_SHIFT))) {
+                SetInterrupt(threadID);
+                return;
+            }
+            break;
+        case TSTATE_BLOCKED:
+        case TSTATE_SYSCALL:
+            if (LockAndUpdateThreadState(threadID, state,
+                                         TSTATE_PAUSED |
+                                             (TLS(threadID) << TSTATE_SHIFT)))
+                return;
+            break;
+        case TSTATE_PAUSED:
+        case TSTATE_TERMINATED:
+        case TSTATE_KILLED:
+        case TSTATE_INTERRUPTED:
+            return;
+        }
+    }
+}
+
+static void TerminateCurrentThread(int locked)
+{
+    ThreadData * thread = thread_data + TLS(threadID);
+    if (locked)
+        pthread_mutex_unlock(thread->lock);
+    PopRegionLocks(0);
+    if (TLS(CurrentHashLock))
+        HashUnlock(TLS(CurrentHashLock));
+    syLongjmp(&(TLS(threadExit)), 1);
+}
+
+static void PauseCurrentThread(int locked)
+{
+    ThreadData * thread = thread_data + TLS(threadID);
+    if (!locked)
+        pthread_mutex_lock(thread->lock);
+    for (;;) {
+        int state = GetThreadState(TLS(threadID));
+        if ((state & TSTATE_MASK) == TSTATE_KILLED)
+            TerminateCurrentThread(1);
+        if ((state & TSTATE_MASK) != TSTATE_PAUSED)
+            break;
+        ((Region *)(TLS(currentRegion)))->alt_owner =
+            thread_data[state >> TSTATE_SHIFT].tls;
+        pthread_cond_wait(thread->cond, thread->lock);
+        // TODO: This really should go in ResumeThread()
+        ((Region *)(TLS(currentRegion)))->alt_owner = NULL;
+    }
+    if (!locked)
+        pthread_mutex_unlock(thread->lock);
+}
+
+static void InterruptCurrentThread(int locked, Stat stat)
+{
+    ThreadData * thread = thread_data + TLS(threadID);
+    int          state;
+    Obj FuncCALL_WITH_CATCH(Obj self, Obj func, Obj args);
+    Obj handler = (Obj)0;
+    if (stat == T_NO_STAT)
         return;
-      }
-      break;
-    case TSTATE_BLOCKED:
-    case TSTATE_SYSCALL:
-      if (LockAndUpdateThreadState(threadID,
-          state, TSTATE_PAUSED|(TLS(threadID) << TSTATE_SHIFT)))
-	return;
-      break;
+    if (!locked)
+        pthread_mutex_lock(thread->lock);
+    STATE(CurrExecStatFuncs) = ExecStatFuncs;
+    SET_BRK_CURR_STAT(stat);
+    state = GetThreadState(TLS(threadID));
+    if ((state & TSTATE_MASK) == TSTATE_INTERRUPTED)
+        UpdateThreadState(TLS(threadID), state, TSTATE_RUNNING);
+    if (state >> TSTATE_SHIFT) {
+        Int n = state >> TSTATE_SHIFT;
+        if (TLS(interruptHandlers)) {
+            if (n >= 1 && n <= LEN_PLIST(TLS(interruptHandlers)))
+                handler = ELM_PLIST(TLS(interruptHandlers), n);
+        }
+    }
+    if (handler)
+        FuncCALL_WITH_CATCH((Obj)0, handler, NEW_PLIST(T_PLIST, 0));
+    else
+        ErrorReturnVoid("system interrupt", 0L, 0L, "you can 'return;'");
+    if (!locked)
+        pthread_mutex_unlock(thread->lock);
+}
+
+void SetInterruptHandler(int handler, Obj func)
+{
+    if (!TLS(interruptHandlers)) {
+        TLS(interruptHandlers) = NEW_PLIST(T_PLIST, MAX_INTERRUPT);
+        SET_LEN_PLIST(TLS(interruptHandlers), MAX_INTERRUPT);
+    }
+    SET_ELM_PLIST(TLS(interruptHandlers), handler, func);
+}
+
+void HandleInterrupts(int locked, Stat stat)
+{
+    switch (GetThreadState(TLS(threadID)) & TSTATE_MASK) {
     case TSTATE_PAUSED:
-    case TSTATE_TERMINATED:
-    case TSTATE_KILLED:
-    case TSTATE_INTERRUPTED:
-      return;
-    }
-  }
-}
-
-static void TerminateCurrentThread(int locked) {
-  ThreadData *thread = thread_data + TLS(threadID);
-  if (locked)
-    pthread_mutex_unlock(thread->lock);
-  PopRegionLocks(0);
-  if (TLS(CurrentHashLock))
-    HashUnlock(TLS(CurrentHashLock));
-  syLongjmp(&(TLS(threadExit)), 1);
-}
-
-static void PauseCurrentThread(int locked) {
-  ThreadData *thread = thread_data + TLS(threadID);
-  if (!locked)
-    pthread_mutex_lock(thread->lock);
-  for (;;) {
-    int state = GetThreadState(TLS(threadID));
-    if ((state & TSTATE_MASK) == TSTATE_KILLED)
-      TerminateCurrentThread(1);
-    if ((state & TSTATE_MASK) != TSTATE_PAUSED)
-      break;
-    ((Region *)(TLS(currentRegion)))->alt_owner =
-      thread_data[state >> TSTATE_SHIFT].tls;
-    pthread_cond_wait(thread->cond, thread->lock);
-    // TODO: This really should go in ResumeThread()
-    ((Region *)(TLS(currentRegion)))->alt_owner = NULL;
-  }
-  if (!locked)
-    pthread_mutex_unlock(thread->lock);
-}
-
-static void InterruptCurrentThread(int locked, Stat stat) {
-  ThreadData *thread = thread_data + TLS(threadID);
-  int state;
-  Obj FuncCALL_WITH_CATCH(Obj self, Obj func, Obj args);
-  Obj handler = (Obj) 0;
-  if (stat == T_NO_STAT)
-    return;
-  if (!locked)
-    pthread_mutex_lock(thread->lock);
-  STATE(CurrExecStatFuncs) = ExecStatFuncs;
-  SET_BRK_CURR_STAT(stat);
-  state = GetThreadState(TLS(threadID));
-  if ((state & TSTATE_MASK) == TSTATE_INTERRUPTED)
-    UpdateThreadState(TLS(threadID), state, TSTATE_RUNNING);
-  if (state >> TSTATE_SHIFT) {
-    Int n = state >> TSTATE_SHIFT;
-    if (TLS(interruptHandlers)) {
-      if (n >= 1 && n <= LEN_PLIST(TLS(interruptHandlers)))
-        handler = ELM_PLIST(TLS(interruptHandlers), n);
-    }
-  }
-  if (handler)
-    FuncCALL_WITH_CATCH((Obj) 0, handler, NEW_PLIST(T_PLIST, 0));
-  else
-    ErrorReturnVoid("system interrupt", 0L, 0L, "you can 'return;'");
-  if (!locked)
-    pthread_mutex_unlock(thread->lock);
-}
-
-void SetInterruptHandler(int handler, Obj func) {
-  if (!TLS(interruptHandlers)) {
-    TLS(interruptHandlers) = NEW_PLIST(T_PLIST, MAX_INTERRUPT);
-    SET_LEN_PLIST(TLS(interruptHandlers), MAX_INTERRUPT);
-  }
-  SET_ELM_PLIST(TLS(interruptHandlers), handler, func);
-}
-
-void HandleInterrupts(int locked, Stat stat) {
-   switch (GetThreadState(TLS(threadID)) & TSTATE_MASK) {
-     case TSTATE_PAUSED:
-       PauseCurrentThread(locked);
-       break;
-     case TSTATE_INTERRUPTED:
-       InterruptCurrentThread(locked, stat);
-       break;
-     case TSTATE_KILLED:
-       TerminateCurrentThread(locked);
-       break;
-   }
-}
-
-void KillThread(int threadID) {
-  for (;;) {
-    int state = GetThreadState(threadID);
-    switch (state & TSTATE_MASK) {
-    case TSTATE_RUNNING:
-      if (UpdateThreadState(threadID, TSTATE_RUNNING, TSTATE_KILLED)) {
-	SetInterrupt(threadID);
-        return;
-      }
-      break;
-    case TSTATE_BLOCKED:
-      if (LockAndUpdateThreadState(threadID, state, TSTATE_KILLED))
-        return;
-      break;
-    case TSTATE_SYSCALL:
-      if (UpdateThreadState(threadID, state, TSTATE_KILLED)) {
-	  return;
-      }
-      break;
-    case TSTATE_INTERRUPTED:
-      if (UpdateThreadState(threadID, state, TSTATE_KILLED)) {
-          SetInterrupt(threadID);
-	  return;
-      }
-      break;
-    case TSTATE_PAUSED:
-      if (LockAndUpdateThreadState(threadID, state, TSTATE_KILLED)) {
-        return;
-      }
-      break;
-    case TSTATE_TERMINATED:
-    case TSTATE_KILLED:
-      return;
-    }
-  }
-}
-
-void InterruptThread(int threadID, int handler) {
-  for (;;) {
-    int state = GetThreadState(threadID);
-    switch (state & TSTATE_MASK) {
-    case TSTATE_RUNNING:
-      if (UpdateThreadState(threadID, TSTATE_RUNNING,
-        TSTATE_INTERRUPTED | (handler << TSTATE_SHIFT))) {
-	SetInterrupt(threadID);
-        return;
-      }
-      break;
-    case TSTATE_BLOCKED:
-      if (LockAndUpdateThreadState(threadID, state,
-        TSTATE_INTERRUPTED | (handler << TSTATE_SHIFT)))
-        return;
-      break;
-    case TSTATE_SYSCALL:
-      if (UpdateThreadState(threadID, state,
-        TSTATE_INTERRUPTED | (handler << TSTATE_SHIFT)))
-        return;
-      break;
-    case TSTATE_PAUSED:
-    case TSTATE_TERMINATED:
-    case TSTATE_KILLED:
-    case TSTATE_INTERRUPTED:
-      /* We do not interrupt threads that are interrupted */
-      return;
-    }
-  }
-}
-
-void ResumeThread(int threadID) {
-  int state = GetThreadState(threadID);
-  if ((state & TSTATE_MASK) == TSTATE_PAUSED) {
-    LockAndUpdateThreadState(threadID, state, TSTATE_RUNNING);
-  }
-}
-
-int PauseAllThreads() {
-  int i, n;
-  LockThreadControl(1);
-  if (GlobalPauseInProgress) {
-    UnlockThreadControl();
-    return 0;
-  }
-  GlobalPauseInProgress = 1;
-  for (i=0, n=0; i<MAX_THREADS; i++) {
-    switch (GetThreadState(i) & TSTATE_MASK) {
-      case TSTATE_TERMINATED:
-      case TSTATE_KILLED:
+        PauseCurrentThread(locked);
         break;
-      default:
-	if (!thread_data[i].system)
-          paused_threads[n++] = thread_data + i;
-	break;
+    case TSTATE_INTERRUPTED:
+        InterruptCurrentThread(locked, stat);
+        break;
+    case TSTATE_KILLED:
+        TerminateCurrentThread(locked);
+        break;
     }
-  }
-  num_paused_threads = n;
-  UnlockThreadControl();
-  for (i=0; i<n; i++)
-    PauseThread(i);
-  return 1;
 }
 
-void ResumeAllThreads() {
-  int i, n;
-  n = num_paused_threads;
-  for (i=0; i<n; i++) {
-    ResumeThread(i);
-  }
+void KillThread(int threadID)
+{
+    for (;;) {
+        int state = GetThreadState(threadID);
+        switch (state & TSTATE_MASK) {
+        case TSTATE_RUNNING:
+            if (UpdateThreadState(threadID, TSTATE_RUNNING, TSTATE_KILLED)) {
+                SetInterrupt(threadID);
+                return;
+            }
+            break;
+        case TSTATE_BLOCKED:
+            if (LockAndUpdateThreadState(threadID, state, TSTATE_KILLED))
+                return;
+            break;
+        case TSTATE_SYSCALL:
+            if (UpdateThreadState(threadID, state, TSTATE_KILLED)) {
+                return;
+            }
+            break;
+        case TSTATE_INTERRUPTED:
+            if (UpdateThreadState(threadID, state, TSTATE_KILLED)) {
+                SetInterrupt(threadID);
+                return;
+            }
+            break;
+        case TSTATE_PAUSED:
+            if (LockAndUpdateThreadState(threadID, state, TSTATE_KILLED)) {
+                return;
+            }
+            break;
+        case TSTATE_TERMINATED:
+        case TSTATE_KILLED:
+            return;
+        }
+    }
+}
+
+void InterruptThread(int threadID, int handler)
+{
+    for (;;) {
+        int state = GetThreadState(threadID);
+        switch (state & TSTATE_MASK) {
+        case TSTATE_RUNNING:
+            if (UpdateThreadState(threadID, TSTATE_RUNNING,
+                                  TSTATE_INTERRUPTED |
+                                      (handler << TSTATE_SHIFT))) {
+                SetInterrupt(threadID);
+                return;
+            }
+            break;
+        case TSTATE_BLOCKED:
+            if (LockAndUpdateThreadState(threadID, state,
+                                         TSTATE_INTERRUPTED |
+                                             (handler << TSTATE_SHIFT)))
+                return;
+            break;
+        case TSTATE_SYSCALL:
+            if (UpdateThreadState(threadID, state,
+                                  TSTATE_INTERRUPTED |
+                                      (handler << TSTATE_SHIFT)))
+                return;
+            break;
+        case TSTATE_PAUSED:
+        case TSTATE_TERMINATED:
+        case TSTATE_KILLED:
+        case TSTATE_INTERRUPTED:
+            /* We do not interrupt threads that are interrupted */
+            return;
+        }
+    }
+}
+
+void ResumeThread(int threadID)
+{
+    int state = GetThreadState(threadID);
+    if ((state & TSTATE_MASK) == TSTATE_PAUSED) {
+        LockAndUpdateThreadState(threadID, state, TSTATE_RUNNING);
+    }
+}
+
+int PauseAllThreads()
+{
+    int i, n;
+    LockThreadControl(1);
+    if (GlobalPauseInProgress) {
+        UnlockThreadControl();
+        return 0;
+    }
+    GlobalPauseInProgress = 1;
+    for (i = 0, n = 0; i < MAX_THREADS; i++) {
+        switch (GetThreadState(i) & TSTATE_MASK) {
+        case TSTATE_TERMINATED:
+        case TSTATE_KILLED:
+            break;
+        default:
+            if (!thread_data[i].system)
+                paused_threads[n++] = thread_data + i;
+            break;
+        }
+    }
+    num_paused_threads = n;
+    UnlockThreadControl();
+    for (i = 0; i < n; i++)
+        PauseThread(i);
+    return 1;
+}
+
+void ResumeAllThreads()
+{
+    int i, n;
+    n = num_paused_threads;
+    for (i = 0; i < n; i++) {
+        ResumeThread(i);
+    }
 }
 
 /**
@@ -1022,236 +1057,248 @@ void ResumeAllThreads() {
  *  embedded in a total ordering.
  */
 
-static Int CurrentRegionPrecedence() {
-  Int sp;
-  if (!DeadlockCheck || !TLS(lockStack))
-    return -1;
-  sp = TLS(lockStackPointer);
-  while (sp > 0) {
-    Obj region_obj = ELM_PLIST(TLS(lockStack), sp);
-    if (region_obj) {
-      Int prec = ((Region *)(*ADDR_OBJ(region_obj)))->prec;
-      if (prec >= 0)
-        return prec;
-    }
-    sp--;
-  }
-  return -1;
-}
-
-int LockObject(Obj obj, int mode) {
-  Region *region = GetRegionOf(obj);
-  int locked;
-  int result = TLS(lockStackPointer);
-  if (!region)
-    return result;
-  locked = IsLocked(region);
-  if (locked == 2 && mode)
-    return -1;
-  if (!locked) {
-    Int prec = CurrentRegionPrecedence();
-    if (prec >= 0 && region->prec >= prec && region->prec >= 0)
-      return -1;
-    if (region->fixed_owner)
-      return -1;
-    if (mode)
-      RegionWriteLock(region);
-    else
-      RegionReadLock(region);
-    PushRegionLock(region);
-  }
-  return result;
-}
-
-int LockObjects(int count, Obj *objects, int *mode)
+static Int CurrentRegionPrecedence()
 {
-  int result;
-  int i, p;
-  int locked;
-  Int curr_prec;
-  LockRequest *order;
-  if (count == 1) /* fast path */
-    return LockObject(objects[0], mode[0]);
-  if (count > MAX_LOCKS)
-    return -1;
-  order = alloca(sizeof(LockRequest)*count);
-  for (i=0, p=0; i<count; i++)
-  {
-    Region *r = GetRegionOf(objects[i]);
-    if (r) {
-      order[p].obj = objects[i];
-      order[p].region = GetRegionOf(objects[i]);
-      order[p].mode = mode[i];
-      p++;
+    Int sp;
+    if (!DeadlockCheck || !TLS(lockStack))
+        return -1;
+    sp = TLS(lockStackPointer);
+    while (sp > 0) {
+        Obj region_obj = ELM_PLIST(TLS(lockStack), sp);
+        if (region_obj) {
+            Int prec = ((Region *)(*ADDR_OBJ(region_obj)))->prec;
+            if (prec >= 0)
+                return prec;
+        }
+        sp--;
     }
-  }
-  count = p;
-  if (p > 1)
-    MergeSort(order, count, sizeof(LockRequest), LessThanLockRequest);
-  result = TLS(lockStackPointer);
-  curr_prec = CurrentRegionPrecedence();
-  for (i=0; i<count; i++)
-  {
-    Region *region = order[i].region;
-    /* If there are multiple lock requests with different modes,
-     * they have been sorted for writes to occur first, so deadlock
-     * cannot occur from doing readlocks before writelocks.
-     */
-    if (i > 0 && region == order[i-1].region)
-      continue; /* skip duplicates */
+    return -1;
+}
+
+int LockObject(Obj obj, int mode)
+{
+    Region * region = GetRegionOf(obj);
+    int      locked;
+    int      result = TLS(lockStackPointer);
     if (!region)
-      continue;
+        return result;
     locked = IsLocked(region);
-    if (locked == 2 && order[i].mode) {
-      /* trying to upgrade read lock to write lock */
-      PopRegionLocks(result);
-      return -1;
-    }
+    if (locked == 2 && mode)
+        return -1;
     if (!locked) {
-      if (curr_prec >= 0 && region->prec >= curr_prec && region->prec >= 0) {
-	PopRegionLocks(result);
-	return -1;
-      }
-      if (region->fixed_owner) {
-	PopRegionLocks(result);
-	return -1;
-      }
-      if (order[i].mode)
-	RegionWriteLock(region);
-      else
-	RegionReadLock(region);
-      PushRegionLock(region);
+        Int prec = CurrentRegionPrecedence();
+        if (prec >= 0 && region->prec >= prec && region->prec >= 0)
+            return -1;
+        if (region->fixed_owner)
+            return -1;
+        if (mode)
+            RegionWriteLock(region);
+        else
+            RegionReadLock(region);
+        PushRegionLock(region);
     }
-    if (GetRegionOf(order[i].obj) != region)
-    {
-      /* Race condition, revert locks and fail */
-      PopRegionLocks(result);
-      return -1;
-    }
-  }
-  return result;
+    return result;
 }
 
-int TryLockObjects(int count, Obj *objects, int *mode)
+int LockObjects(int count, Obj * objects, int * mode)
 {
-  int result;
-  int i;
-  int locked;
-  LockRequest *order;
-  if (count > MAX_LOCKS)
-    return -1;
-  order = alloca(sizeof(LockRequest)*count);
-  for (i=0; i<count; i++)
-  {
-    order[i].obj = objects[i];
-    order[i].region = GetRegionOf(objects[i]);
-    order[i].mode = mode[i];
-  }
-  MergeSort(order, count, sizeof(LockRequest), LessThanLockRequest);
-  result = TLS(lockStackPointer);
-  for (i=0; i<count; i++)
-  {
-    Region *region = order[i].region;
-    /* If there are multiple lock requests with different modes,
-     * they have been sorted for writes to occur first, so deadlock
-     * cannot occur from doing readlocks before writelocks.
-     */
-    if (i > 0 && region == order[i-1].region)
-      continue; /* skip duplicates */
-    if (!region || region->fixed_owner) { /* public or thread-local region */
-      PopRegionLocks(result);
-      return -1;
+    int           result;
+    int           i, p;
+    int           locked;
+    Int           curr_prec;
+    LockRequest * order;
+    if (count == 1) /* fast path */
+        return LockObject(objects[0], mode[0]);
+    if (count > MAX_LOCKS)
+        return -1;
+    order = alloca(sizeof(LockRequest) * count);
+    for (i = 0, p = 0; i < count; i++) {
+        Region * r = GetRegionOf(objects[i]);
+        if (r) {
+            order[p].obj = objects[i];
+            order[p].region = GetRegionOf(objects[i]);
+            order[p].mode = mode[i];
+            p++;
+        }
     }
-    locked = IsLocked(region);
-    if (locked == 2 && order[i].mode) {
-      /* trying to upgrade read lock to write lock */
-      PopRegionLocks(result);
-      return -1;
+    count = p;
+    if (p > 1)
+        MergeSort(order, count, sizeof(LockRequest), LessThanLockRequest);
+    result = TLS(lockStackPointer);
+    curr_prec = CurrentRegionPrecedence();
+    for (i = 0; i < count; i++) {
+        Region * region = order[i].region;
+        /* If there are multiple lock requests with different modes,
+         * they have been sorted for writes to occur first, so deadlock
+         * cannot occur from doing readlocks before writelocks.
+         */
+        if (i > 0 && region == order[i - 1].region)
+            continue; /* skip duplicates */
+        if (!region)
+            continue;
+        locked = IsLocked(region);
+        if (locked == 2 && order[i].mode) {
+            /* trying to upgrade read lock to write lock */
+            PopRegionLocks(result);
+            return -1;
+        }
+        if (!locked) {
+            if (curr_prec >= 0 && region->prec >= curr_prec &&
+                region->prec >= 0) {
+                PopRegionLocks(result);
+                return -1;
+            }
+            if (region->fixed_owner) {
+                PopRegionLocks(result);
+                return -1;
+            }
+            if (order[i].mode)
+                RegionWriteLock(region);
+            else
+                RegionReadLock(region);
+            PushRegionLock(region);
+        }
+        if (GetRegionOf(order[i].obj) != region) {
+            /* Race condition, revert locks and fail */
+            PopRegionLocks(result);
+            return -1;
+        }
     }
-    if (!locked) {
-      if (order[i].mode) {
-	if (!RegionTryWriteLock(region)) {
-	  PopRegionLocks(result);
-	  return -1;
-	}
-      } else {
-	if (!RegionTryReadLock(region)) {
-	  PopRegionLocks(result);
-	  return -1;
-	}
-      }
-      PushRegionLock(region);
-    }
-    if (GetRegionOf(order[i].obj) != region)
-    {
-      /* Race condition, revert locks and fail */
-      PopRegionLocks(result);
-      return -1;
-    }
-  }
-  return result;
+    return result;
 }
 
-Region *CurrentRegion()
+int TryLockObjects(int count, Obj * objects, int * mode)
 {
-  return TLS(currentRegion);
+    int           result;
+    int           i;
+    int           locked;
+    LockRequest * order;
+    if (count > MAX_LOCKS)
+        return -1;
+    order = alloca(sizeof(LockRequest) * count);
+    for (i = 0; i < count; i++) {
+        order[i].obj = objects[i];
+        order[i].region = GetRegionOf(objects[i]);
+        order[i].mode = mode[i];
+    }
+    MergeSort(order, count, sizeof(LockRequest), LessThanLockRequest);
+    result = TLS(lockStackPointer);
+    for (i = 0; i < count; i++) {
+        Region * region = order[i].region;
+        /* If there are multiple lock requests with different modes,
+         * they have been sorted for writes to occur first, so deadlock
+         * cannot occur from doing readlocks before writelocks.
+         */
+        if (i > 0 && region == order[i - 1].region)
+            continue; /* skip duplicates */
+        if (!region ||
+            region->fixed_owner) { /* public or thread-local region */
+            PopRegionLocks(result);
+            return -1;
+        }
+        locked = IsLocked(region);
+        if (locked == 2 && order[i].mode) {
+            /* trying to upgrade read lock to write lock */
+            PopRegionLocks(result);
+            return -1;
+        }
+        if (!locked) {
+            if (order[i].mode) {
+                if (!RegionTryWriteLock(region)) {
+                    PopRegionLocks(result);
+                    return -1;
+                }
+            }
+            else {
+                if (!RegionTryReadLock(region)) {
+                    PopRegionLocks(result);
+                    return -1;
+                }
+            }
+            PushRegionLock(region);
+        }
+        if (GetRegionOf(order[i].obj) != region) {
+            /* Race condition, revert locks and fail */
+            PopRegionLocks(result);
+            return -1;
+        }
+    }
+    return result;
+}
+
+Region * CurrentRegion()
+{
+    return TLS(currentRegion);
 }
 
 extern GVarDescriptor LastInaccessibleGVar;
 
 #ifdef VERBOSE_GUARDS
 
-static void PrintGuardError(char *buffer, char *mode,
-  Obj obj, const char *file, unsigned line, const char *func, const char *expr)
+static void PrintGuardError(char *       buffer,
+                            char *       mode,
+                            Obj          obj,
+                            const char * file,
+                            unsigned     line,
+                            const char * func,
+                            const char * expr)
 {
-  sprintf(buffer, "No %s access to object %llu of type %s\n"
-    "in %s, line %u, function %s(), accessing %s",
-      mode, (unsigned long long) (UInt) obj, TNAM_OBJ(obj),
-      file, line, func, expr);
+    sprintf(buffer, "No %s access to object %llu of type %s\n"
+                    "in %s, line %u, function %s(), accessing %s",
+            mode, (unsigned long long)(UInt)obj, TNAM_OBJ(obj), file, line,
+            func, expr);
 }
-void WriteGuardError(Obj o, const char *file, unsigned line,
-                     const char *func, const char *expr)
+void WriteGuardError(Obj          o,
+                     const char * file,
+                     unsigned     line,
+                     const char * func,
+                     const char * expr)
 {
-  char * buffer =
-    alloca(strlen(file) + strlen(func) + strlen(expr) + 200);
-  ImpliedReadGuard(o);
-  if (TLS(DisableGuards))
-    return;
-  SetGVar(&LastInaccessibleGVar, o);
-  PrintGuardError(buffer, "write", o, file, line, func, expr);
-  ErrorMayQuit("%s", (UInt) buffer, 0L);
+    char * buffer = alloca(strlen(file) + strlen(func) + strlen(expr) + 200);
+    ImpliedReadGuard(o);
+    if (TLS(DisableGuards))
+        return;
+    SetGVar(&LastInaccessibleGVar, o);
+    PrintGuardError(buffer, "write", o, file, line, func, expr);
+    ErrorMayQuit("%s", (UInt)buffer, 0L);
 }
 
-void ReadGuardError(Obj o, const char *file, unsigned line,
-                    const char *func, const char *expr)
+void ReadGuardError(Obj          o,
+                    const char * file,
+                    unsigned     line,
+                    const char * func,
+                    const char * expr)
 {
-  char * buffer =
-    alloca(strlen(file) + strlen(func) + strlen(expr) + 200);
-  ImpliedReadGuard(o);
-  if (TLS(DisableGuards))
-    return;
-  SetGVar(&LastInaccessibleGVar, o);
-  PrintGuardError(buffer, "read", o, file, line, func, expr);
-  ErrorMayQuit("%s", (UInt) buffer, 0L);
+    char * buffer = alloca(strlen(file) + strlen(func) + strlen(expr) + 200);
+    ImpliedReadGuard(o);
+    if (TLS(DisableGuards))
+        return;
+    SetGVar(&LastInaccessibleGVar, o);
+    PrintGuardError(buffer, "read", o, file, line, func, expr);
+    ErrorMayQuit("%s", (UInt)buffer, 0L);
 }
 
 #else
 void WriteGuardError(Obj o)
 {
-  ImpliedReadGuard(o);
-  if (TLS(DisableGuards))
-    return;
-  SetGVar(&LastInaccessibleGVar, o);
-  ErrorMayQuit("Attempt to write object %i of type %s without having write access", (Int)o, (Int)TNAM_OBJ(o));
+    ImpliedReadGuard(o);
+    if (TLS(DisableGuards))
+        return;
+    SetGVar(&LastInaccessibleGVar, o);
+    ErrorMayQuit(
+        "Attempt to write object %i of type %s without having write access",
+        (Int)o, (Int)TNAM_OBJ(o));
 }
 
 void ReadGuardError(Obj o)
 {
-  ImpliedReadGuard(o);
-  if (TLS(DisableGuards))
-    return;
-  SetGVar(&LastInaccessibleGVar, o);
-  ErrorMayQuit("Attempt to read object %i of type %s without having read access", (Int)o, (Int)TNAM_OBJ(o));
+    ImpliedReadGuard(o);
+    if (TLS(DisableGuards))
+        return;
+    SetGVar(&LastInaccessibleGVar, o);
+    ErrorMayQuit(
+        "Attempt to read object %i of type %s without having read access",
+        (Int)o, (Int)TNAM_OBJ(o));
 }
 #endif
 

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -69,130 +69,123 @@
 
 
 struct WaitList {
-  struct WaitList *prev;
-  struct WaitList *next;
-  ThreadLocalStorage *thread;
+    struct WaitList *    prev;
+    struct WaitList *    next;
+    ThreadLocalStorage * thread;
 };
 
-typedef struct Channel
-{
-  Obj monitor;
-  Obj queue;
-  int waiting;
-  int dynamic;
-  UInt head, tail;
-  UInt size, capacity;
+typedef struct Channel {
+    Obj  monitor;
+    Obj  queue;
+    int  waiting;
+    int  dynamic;
+    UInt head, tail;
+    UInt size, capacity;
 } Channel;
 
-typedef struct Semaphore
-{
-  Obj monitor;
-  UInt count;
-  int waiting;
+typedef struct Semaphore {
+    Obj  monitor;
+    UInt count;
+    int  waiting;
 } Semaphore;
 
-typedef struct Barrier
-{
-  Obj monitor;
-  UInt count;
-  UInt phase;
-  int waiting;
+typedef struct Barrier {
+    Obj  monitor;
+    UInt count;
+    UInt phase;
+    int  waiting;
 } Barrier;
 
-typedef struct SyncVar
-{
-  Obj monitor;
-  Obj value;
-  int written;
+typedef struct SyncVar {
+    Obj monitor;
+    Obj value;
+    int written;
 } SyncVar;
 
 
-static void AddWaitList(Monitor *monitor, struct WaitList *node)
+static void AddWaitList(Monitor * monitor, struct WaitList * node)
 {
-  if (monitor->tail)
-  {
-    monitor->tail->next = node;
-    node->prev = monitor->tail;
-    node->next = NULL;
-    monitor->tail = node;
-  }
-  else
-  {
-    monitor->head = monitor->tail = node;
-    node->next = node->prev = NULL;
-  }
+    if (monitor->tail) {
+        monitor->tail->next = node;
+        node->prev = monitor->tail;
+        node->next = NULL;
+        monitor->tail = node;
+    }
+    else {
+        monitor->head = monitor->tail = node;
+        node->next = node->prev = NULL;
+    }
 }
 
-static void RemoveWaitList(Monitor *monitor, struct WaitList *node)
+static void RemoveWaitList(Monitor * monitor, struct WaitList * node)
 {
-  if (monitor->head)
-  {
-    if (node->prev)
-      node->prev->next = node->next;
-    else
-      monitor->head = node->next;
-    if (node->next)
-      node->next->prev = node->prev;
-    else
-      monitor->tail = node->prev;
-  }
+    if (monitor->head) {
+        if (node->prev)
+            node->prev->next = node->next;
+        else
+            monitor->head = node->next;
+        if (node->next)
+            node->next->prev = node->prev;
+        else
+            monitor->tail = node->prev;
+    }
 }
 
-static inline void *ObjPtr(Obj obj)
+static inline void * ObjPtr(Obj obj)
 {
-  return PTR_BAG(obj);
+    return PTR_BAG(obj);
 }
 
 Obj NewMonitor()
 {
-  Bag monitorBag;
-  Monitor *monitor;
-  monitorBag = NewBag(T_MONITOR, sizeof(Monitor));
-  monitor = ObjPtr(monitorBag);
-  pthread_mutex_init(&monitor->lock, 0);
-  monitor->head = monitor->tail = NULL;
-  return monitorBag;
+    Bag       monitorBag;
+    Monitor * monitor;
+    monitorBag = NewBag(T_MONITOR, sizeof(Monitor));
+    monitor = ObjPtr(monitorBag);
+    pthread_mutex_init(&monitor->lock, 0);
+    monitor->head = monitor->tail = NULL;
+    return monitorBag;
 }
 
-void LockThread(ThreadLocalStorage *thread)
+void LockThread(ThreadLocalStorage * thread)
 {
-  pthread_mutex_lock(thread->threadLock);
+    pthread_mutex_lock(thread->threadLock);
 }
 
-void UnlockThread(ThreadLocalStorage *thread)
+void UnlockThread(ThreadLocalStorage * thread)
 {
-  pthread_mutex_unlock(thread->threadLock);
+    pthread_mutex_unlock(thread->threadLock);
 }
 
-void SignalThread(ThreadLocalStorage *thread)
+void SignalThread(ThreadLocalStorage * thread)
 {
-  pthread_cond_signal(thread->threadSignal);
+    pthread_cond_signal(thread->threadSignal);
 }
 
 void WaitThreadSignal()
 {
-  int id = TLS(threadID);
-  if (!UpdateThreadState(id, TSTATE_RUNNING, TSTATE_BLOCKED))
-    HandleInterrupts(1, T_NO_STAT);
-  pthread_cond_wait(TLS(threadSignal), TLS(threadLock));
-  if (!UpdateThreadState(id, TSTATE_BLOCKED, TSTATE_RUNNING) &&
-    GetThreadState(id) != TSTATE_RUNNING)
-    HandleInterrupts(1, T_NO_STAT);
+    int id = TLS(threadID);
+    if (!UpdateThreadState(id, TSTATE_RUNNING, TSTATE_BLOCKED))
+        HandleInterrupts(1, T_NO_STAT);
+    pthread_cond_wait(TLS(threadSignal), TLS(threadLock));
+    if (!UpdateThreadState(id, TSTATE_BLOCKED, TSTATE_RUNNING) &&
+        GetThreadState(id) != TSTATE_RUNNING)
+        HandleInterrupts(1, T_NO_STAT);
 }
 
-void LockMonitor(Monitor *monitor)
+void LockMonitor(Monitor * monitor)
 {
-   pthread_mutex_lock(&monitor->lock);
+    pthread_mutex_lock(&monitor->lock);
 }
 
-int TryLockMonitor(Monitor *monitor)
+int TryLockMonitor(Monitor * monitor)
 {
-   return !pthread_mutex_trylock(&monitor->lock);
+    return !pthread_mutex_trylock(&monitor->lock);
 }
 
-void UnlockMonitor(Monitor *monitor)
+void UnlockMonitor(Monitor * monitor)
 {
-   pthread_mutex_unlock(&monitor->lock);
+    pthread_mutex_unlock(&monitor->lock);
 }
 
 /****************************************************************************
@@ -204,72 +197,71 @@ void UnlockMonitor(Monitor *monitor)
  ** again upon exit.
  */
 
-void WaitForMonitor(Monitor *monitor)
+void WaitForMonitor(Monitor * monitor)
 {
-  struct WaitList node;
-  node.thread = realTLS;
-  AddWaitList(monitor, &node);
-  UnlockMonitor(monitor);
-  LockThread(realTLS);
-  while (!TLS(acquiredMonitor))
-    WaitThreadSignal();
-  if (!TryLockMonitor(monitor))
-  {
-    UnlockThread(realTLS);
-    LockMonitor(monitor);
+    struct WaitList node;
+    node.thread = realTLS;
+    AddWaitList(monitor, &node);
+    UnlockMonitor(monitor);
     LockThread(realTLS);
-  }
-  TLS(acquiredMonitor) = NULL;
-  RemoveWaitList(monitor, &node);
-  UnlockThread(realTLS);
+    while (!TLS(acquiredMonitor))
+        WaitThreadSignal();
+    if (!TryLockMonitor(monitor)) {
+        UnlockThread(realTLS);
+        LockMonitor(monitor);
+        LockThread(realTLS);
+    }
+    TLS(acquiredMonitor) = NULL;
+    RemoveWaitList(monitor, &node);
+    UnlockThread(realTLS);
 }
 
-static int MonitorOrder(const void *r1, const void *r2)
+static int MonitorOrder(const void * r1, const void * r2)
 {
-  const char *p1 = *(const char **)r1;
-  const char *p2 = *(const char **)r2;
-  return p1 < p2;
+    const char * p1 = *(const char **)r1;
+    const char * p2 = *(const char **)r2;
+    return p1 < p2;
 }
 
-void SortMonitors(UInt count, Monitor **monitors)
+void SortMonitors(UInt count, Monitor ** monitors)
 {
-  MergeSort(monitors, count, sizeof(Monitor *), MonitorOrder);
+    MergeSort(monitors, count, sizeof(Monitor *), MonitorOrder);
 }
 
-static int ChannelOrder(const void *c1, const void *c2)
+static int ChannelOrder(const void * c1, const void * c2)
 {
-  const char *p1 = (const char *)ObjPtr((*(Channel **) c1)->monitor);
-  const char *p2 = (const char *)ObjPtr((*(Channel **) c2)->monitor);
-  return p1 < p2;
+    const char * p1 = (const char *)ObjPtr((*(Channel **)c1)->monitor);
+    const char * p2 = (const char *)ObjPtr((*(Channel **)c2)->monitor);
+    return p1 < p2;
 }
 
-static void SortChannels(UInt count, Channel **channels)
+static void SortChannels(UInt count, Channel ** channels)
 {
-  MergeSort(channels, count, sizeof(Channel *), ChannelOrder);
+    MergeSort(channels, count, sizeof(Channel *), ChannelOrder);
 }
 
-static int MonitorsAreSorted(UInt count, Monitor **monitors)
+static int MonitorsAreSorted(UInt count, Monitor ** monitors)
 {
-  UInt i;
-  for (i=1; i<count; i++)
-    if ((char *)(monitors[i-1]) > (char *)(monitors[i]))
-      return 0;
-  return 1;
+    UInt i;
+    for (i = 1; i < count; i++)
+        if ((char *)(monitors[i - 1]) > (char *)(monitors[i]))
+            return 0;
+    return 1;
 }
 
-void LockMonitors(UInt count, Monitor **monitors)
+void LockMonitors(UInt count, Monitor ** monitors)
 {
-  UInt i;
-  assert(MonitorsAreSorted(count, monitors));
-  for (i=0; i<count; i++)
-    LockMonitor(monitors[i]);
+    UInt i;
+    assert(MonitorsAreSorted(count, monitors));
+    for (i = 0; i < count; i++)
+        LockMonitor(monitors[i]);
 }
 
-void UnlockMonitors(UInt count, Monitor **monitors)
+void UnlockMonitors(UInt count, Monitor ** monitors)
 {
-  UInt i;
-  for (i=0; i<count; i++)
-    UnlockMonitor(monitors[i]);
+    UInt i;
+    for (i = 0; i < count; i++)
+        UnlockMonitor(monitors[i]);
 }
 
 
@@ -290,44 +282,41 @@ void UnlockMonitors(UInt count, Monitor **monitors)
  ** unlocked.
  */
 
-UInt WaitForAnyMonitor(UInt count, Monitor **monitors)
+UInt WaitForAnyMonitor(UInt count, Monitor ** monitors)
 {
-  struct WaitList *nodes;
-  Monitor *monitor;
-  UInt i;
-  Int result;
-  assert(MonitorsAreSorted(count, monitors));
-  nodes = alloca(sizeof(struct WaitList) * count);
-  for (i=0; i<count; i++)
-    nodes[i].thread = realTLS;
-  for (i=0; i<count; i++)
-    AddWaitList(monitors[i], &nodes[i]);
-  for (i=0; i<count; i++)
-    UnlockMonitor(monitors[i]);
-  LockThread(realTLS);
-  while (!TLS(acquiredMonitor))
-    WaitThreadSignal();
-  monitor = TLS(acquiredMonitor);
-  UnlockThread(realTLS);
-  for (i=0; i<count; i++)
-  {
-    LockMonitor(monitors[i]);
-    if (monitors[i] == monitor)
-    {
-      RemoveWaitList(monitors[i], &nodes[i]);
-      result = i;
-      /* keep it locked for further processing by caller */
+    struct WaitList * nodes;
+    Monitor *         monitor;
+    UInt              i;
+    Int               result;
+    assert(MonitorsAreSorted(count, monitors));
+    nodes = alloca(sizeof(struct WaitList) * count);
+    for (i = 0; i < count; i++)
+        nodes[i].thread = realTLS;
+    for (i = 0; i < count; i++)
+        AddWaitList(monitors[i], &nodes[i]);
+    for (i = 0; i < count; i++)
+        UnlockMonitor(monitors[i]);
+    LockThread(realTLS);
+    while (!TLS(acquiredMonitor))
+        WaitThreadSignal();
+    monitor = TLS(acquiredMonitor);
+    UnlockThread(realTLS);
+    for (i = 0; i < count; i++) {
+        LockMonitor(monitors[i]);
+        if (monitors[i] == monitor) {
+            RemoveWaitList(monitors[i], &nodes[i]);
+            result = i;
+            /* keep it locked for further processing by caller */
+        }
+        else {
+            RemoveWaitList(monitors[i], &nodes[i]);
+            UnlockMonitor(monitors[i]);
+        }
     }
-    else
-    {
-      RemoveWaitList(monitors[i], &nodes[i]);
-      UnlockMonitor(monitors[i]);
-    }
-  }
-  LockThread(realTLS);
-  TLS(acquiredMonitor) = NULL;
-  UnlockThread(realTLS);
-  return result;
+    LockThread(realTLS);
+    TLS(acquiredMonitor) = NULL;
+    UnlockThread(realTLS);
+    return result;
 }
 
 /****************************************************************************
@@ -339,38 +328,36 @@ UInt WaitForAnyMonitor(UInt count, Monitor **monitors)
  ** exit. If no thread is waiting for the monitor, no operation will occur.
  */
 
-void SignalMonitor(Monitor *monitor)
+void SignalMonitor(Monitor * monitor)
 {
-  struct WaitList *queue;
-  ThreadLocalStorage *thread = NULL;
-  queue = monitor->head;
-  if (queue != NULL)
-  {
-    do {
-      thread = queue->thread;
-      LockThread(thread);
-      if (!thread->acquiredMonitor)
-      {
-        thread->acquiredMonitor = monitor;
-	SignalThread(thread);
-	UnlockThread(thread);
-	break;
-      }
-      UnlockThread(thread);
-      queue = queue->next;
-    } while (queue != NULL);
-  }
+    struct WaitList *    queue;
+    ThreadLocalStorage * thread = NULL;
+    queue = monitor->head;
+    if (queue != NULL) {
+        do {
+            thread = queue->thread;
+            LockThread(thread);
+            if (!thread->acquiredMonitor) {
+                thread->acquiredMonitor = monitor;
+                SignalThread(thread);
+                UnlockThread(thread);
+                break;
+            }
+            UnlockThread(thread);
+            queue = queue->next;
+        } while (queue != NULL);
+    }
 }
 
-static Obj ArgumentError(char *message)
+static Obj ArgumentError(char * message)
 {
-  ErrorQuit(message, 0, 0);
-  return 0;
+    ErrorQuit(message, 0, 0);
+    return 0;
 }
 
 /* TODO: register globals */
-Obj FirstKeepAlive;
-Obj LastKeepAlive;
+Obj             FirstKeepAlive;
+Obj             LastKeepAlive;
 pthread_mutex_t KeepAliveLock;
 
 #define PREV_KEPT(obj) (ADDR_OBJ(obj)[2])
@@ -378,36 +365,36 @@ pthread_mutex_t KeepAliveLock;
 
 Obj KeepAlive(Obj obj)
 {
-  Obj newKeepAlive = NewBag( T_PLIST, 4*sizeof(Obj) );
-  pthread_mutex_lock(&KeepAliveLock);
-  ADDR_OBJ(newKeepAlive)[0] = (Obj) 3; /* Length 3 */
-  KEPTALIVE(newKeepAlive) = obj;
-  PREV_KEPT(newKeepAlive) = LastKeepAlive;
-  NEXT_KEPT(newKeepAlive) = (Obj) 0;
-  if (LastKeepAlive)
-    NEXT_KEPT(LastKeepAlive) = newKeepAlive;
-  else
-    FirstKeepAlive = LastKeepAlive = newKeepAlive;
-  pthread_mutex_unlock(&KeepAliveLock);
-  return newKeepAlive;
+    Obj newKeepAlive = NewBag(T_PLIST, 4 * sizeof(Obj));
+    pthread_mutex_lock(&KeepAliveLock);
+    ADDR_OBJ(newKeepAlive)[0] = (Obj)3; /* Length 3 */
+    KEPTALIVE(newKeepAlive) = obj;
+    PREV_KEPT(newKeepAlive) = LastKeepAlive;
+    NEXT_KEPT(newKeepAlive) = (Obj)0;
+    if (LastKeepAlive)
+        NEXT_KEPT(LastKeepAlive) = newKeepAlive;
+    else
+        FirstKeepAlive = LastKeepAlive = newKeepAlive;
+    pthread_mutex_unlock(&KeepAliveLock);
+    return newKeepAlive;
 }
 
 void StopKeepAlive(Obj node)
 {
 #ifndef WARD_ENABLED
-  Obj pred, succ;
-  pthread_mutex_lock(&KeepAliveLock);
-  pred = PREV_KEPT(node);
-  succ = NEXT_KEPT(node);
-  if (pred)
-    NEXT_KEPT(pred) = succ;
-  else
-    FirstKeepAlive = succ;
-  if (succ)
-    PREV_KEPT(succ) = pred;
-  else
-    LastKeepAlive = pred;
-  pthread_mutex_unlock(&KeepAliveLock);
+    Obj pred, succ;
+    pthread_mutex_lock(&KeepAliveLock);
+    pred = PREV_KEPT(node);
+    succ = NEXT_KEPT(node);
+    if (pred)
+        NEXT_KEPT(pred) = succ;
+    else
+        FirstKeepAlive = succ;
+    if (succ)
+        PREV_KEPT(succ) = pred;
+    else
+        LastKeepAlive = pred;
+    pthread_mutex_unlock(&KeepAliveLock);
 #endif
 }
 
@@ -420,23 +407,25 @@ void StopKeepAlive(Obj node)
 ** is a unique identifier for the thread.
 */
 
-Obj FuncCreateThread(Obj self, Obj funcargs) {
-  Int i, n;
-  Obj thread;
-  void ThreadedInterpreter(void *);
-  Obj templist;
-  n = LEN_PLIST(funcargs);
-  if (n == 0 || !IS_FUNC(ELM_PLIST(funcargs, 1)))
-    return ArgumentError("CreateThread: Needs at least one function argument");
-  templist = NEW_PLIST(T_PLIST, n);
-  SET_LEN_PLIST(templist, n);
-  REGION(templist) = NULL; /* make it public */
-  for (i=1; i<=n; i++)
-    SET_ELM_PLIST(templist, i, ELM_PLIST(funcargs, i));
-  thread = RunThread(ThreadedInterpreter, KeepAlive(templist));
-  if (!thread)
-    return Fail;
-  return thread;
+Obj FuncCreateThread(Obj self, Obj funcargs)
+{
+    Int  i, n;
+    Obj  thread;
+    void ThreadedInterpreter(void *);
+    Obj  templist;
+    n = LEN_PLIST(funcargs);
+    if (n == 0 || !IS_FUNC(ELM_PLIST(funcargs, 1)))
+        return ArgumentError(
+            "CreateThread: Needs at least one function argument");
+    templist = NEW_PLIST(T_PLIST, n);
+    SET_LEN_PLIST(templist, n);
+    REGION(templist) = NULL; /* make it public */
+    for (i = 1; i <= n; i++)
+        SET_ELM_PLIST(templist, i, ELM_PLIST(funcargs, i));
+    thread = RunThread(ThreadedInterpreter, KeepAlive(templist));
+    if (!thread)
+        return Fail;
+    return thread;
 }
 
 /****************************************************************************
@@ -446,24 +435,25 @@ Obj FuncCreateThread(Obj self, Obj funcargs) {
 ** The function waits for an existing thread to finish.
 */
 
-Obj FuncWaitThread(Obj self, Obj thread) {
-  UInt thread_num;
-  UInt thread_status;
-  char *error = NULL;
-  if (TNUM_OBJ(thread) != T_THREAD)
-    return ArgumentError("WaitThread: Argument must be a thread object");
-  LockThreadControl(1);
-  thread_num = *(UInt *)(ADDR_OBJ(thread)+1);
-  thread_status = *(UInt *)(ADDR_OBJ(thread)+2);
-  if (thread_status & THREAD_JOINED)
-    error = "Thread is already being waited for";
-  *(UInt *)(ADDR_OBJ(thread)+2) |= THREAD_JOINED;
-  UnlockThreadControl();
-  if (error)
-    ErrorQuit("WaitThread: %s", (UInt) error, 0L);
-  if (!JoinThread(thread_num))
-    ErrorQuit("WaitThread: Invalid thread id", 0L, 0L);
-  return (Obj) 0;
+Obj FuncWaitThread(Obj self, Obj thread)
+{
+    UInt   thread_num;
+    UInt   thread_status;
+    char * error = NULL;
+    if (TNUM_OBJ(thread) != T_THREAD)
+        return ArgumentError("WaitThread: Argument must be a thread object");
+    LockThreadControl(1);
+    thread_num = *(UInt *)(ADDR_OBJ(thread) + 1);
+    thread_status = *(UInt *)(ADDR_OBJ(thread) + 2);
+    if (thread_status & THREAD_JOINED)
+        error = "Thread is already being waited for";
+    *(UInt *)(ADDR_OBJ(thread) + 2) |= THREAD_JOINED;
+    UnlockThreadControl();
+    if (error)
+        ErrorQuit("WaitThread: %s", (UInt)error, 0L);
+    if (!JoinThread(thread_num))
+        ErrorQuit("WaitThread: Invalid thread id", 0L, 0L);
+    return (Obj)0;
 }
 
 /****************************************************************************
@@ -472,8 +462,9 @@ Obj FuncWaitThread(Obj self, Obj thread) {
 **
 */
 
-Obj FuncCurrentThread(Obj self) {
-  return TLS(threadObject);
+Obj FuncCurrentThread(Obj self)
+{
+    return TLS(threadObject);
 }
 
 /****************************************************************************
@@ -482,10 +473,11 @@ Obj FuncCurrentThread(Obj self) {
 **
 */
 
-Obj FuncThreadID(Obj self, Obj thread) {
-  if (TNUM_OBJ(thread) != T_THREAD)
-    return ArgumentError("ThreadID: Argument must be a thread object");
-  return INTOBJ_INT(ThreadID(thread));
+Obj FuncThreadID(Obj self, Obj thread)
+{
+    if (TNUM_OBJ(thread) != T_THREAD)
+        return ArgumentError("ThreadID: Argument must be a thread object");
+    return INTOBJ_INT(ThreadID(thread));
 }
 
 /****************************************************************************
@@ -494,18 +486,21 @@ Obj FuncThreadID(Obj self, Obj thread) {
 **
 */
 
-Obj FuncKillThread(Obj self, Obj thread) {
-  int id;
-  if (IS_INTOBJ(thread)) {
-    id = INT_INTOBJ(thread);
-    if (id < 0 || id >= MAX_THREADS)
-      return ArgumentError("KillThread: Thread ID out of range");
-  } else if (TNUM_OBJ(thread) == T_THREAD) {
-    id = ThreadID(thread);
-  } else
-    return ArgumentError("KillThread: Argument must be a thread object");
-  KillThread(id);
-  return (Obj) 0;
+Obj FuncKillThread(Obj self, Obj thread)
+{
+    int id;
+    if (IS_INTOBJ(thread)) {
+        id = INT_INTOBJ(thread);
+        if (id < 0 || id >= MAX_THREADS)
+            return ArgumentError("KillThread: Thread ID out of range");
+    }
+    else if (TNUM_OBJ(thread) == T_THREAD) {
+        id = ThreadID(thread);
+    }
+    else
+        return ArgumentError("KillThread: Argument must be a thread object");
+    KillThread(id);
+    return (Obj)0;
 }
 
 
@@ -518,22 +513,27 @@ Obj FuncKillThread(Obj self, Obj thread) {
 #define AS_STRING(s) #s
 
 
-Obj FuncInterruptThread(Obj self, Obj thread, Obj handler) {
-  int id;
-  if (IS_INTOBJ(thread)) {
-    id = INT_INTOBJ(thread);
-    if (id < 0 || id >= MAX_THREADS)
-      return ArgumentError("InterruptThread: Thread ID out of range");
-  } else if (TNUM_OBJ(thread) == T_THREAD) {
-    id = ThreadID(thread);
-  } else
-    return ArgumentError("InterruptThread: First argument must identify a thread");
-  if (!IS_INTOBJ(handler) || INT_INTOBJ(handler) < 0 ||
-      INT_INTOBJ(handler) > MAX_INTERRUPT)
-    return ArgumentError("InterruptThread: Second argument must be an integer "
-      "between 0 and " AS_STRING(MAX_INTERRUPT));
-  InterruptThread(id, (int)(INT_INTOBJ(handler)));
-  return (Obj) 0;
+Obj FuncInterruptThread(Obj self, Obj thread, Obj handler)
+{
+    int id;
+    if (IS_INTOBJ(thread)) {
+        id = INT_INTOBJ(thread);
+        if (id < 0 || id >= MAX_THREADS)
+            return ArgumentError("InterruptThread: Thread ID out of range");
+    }
+    else if (TNUM_OBJ(thread) == T_THREAD) {
+        id = ThreadID(thread);
+    }
+    else
+        return ArgumentError(
+            "InterruptThread: First argument must identify a thread");
+    if (!IS_INTOBJ(handler) || INT_INTOBJ(handler) < 0 ||
+        INT_INTOBJ(handler) > MAX_INTERRUPT)
+        return ArgumentError(
+            "InterruptThread: Second argument must be an integer "
+            "between 0 and " AS_STRING(MAX_INTERRUPT));
+    InterruptThread(id, (int)(INT_INTOBJ(handler)));
+    return (Obj)0;
 }
 
 /****************************************************************************
@@ -542,19 +542,23 @@ Obj FuncInterruptThread(Obj self, Obj thread, Obj handler) {
 **
 */
 
-Obj FuncSetInterruptHandler(Obj self, Obj handler, Obj func) {
-  if (!IS_INTOBJ(handler) || INT_INTOBJ(handler) < 1 ||
-      INT_INTOBJ(handler) > MAX_INTERRUPT)
-    return ArgumentError("SetInterruptHandler: First argument must be an integer "
-      "between 1 and " AS_STRING(MAX_INTERRUPT));
-  if (func == Fail) {
-    SetInterruptHandler((int)(INT_INTOBJ(handler)), (Obj) 0);
-    return (Obj) 0;
-  }
-  if (TNUM_OBJ(func) != T_FUNCTION || NARG_FUNC(func) != 0 || !BODY_FUNC(func))
-    return ArgumentError("SetInterruptHandler: Second argument must be a parameterless function or 'fail'");
-  SetInterruptHandler((int)(INT_INTOBJ(handler)), func);
-  return (Obj) 0;
+Obj FuncSetInterruptHandler(Obj self, Obj handler, Obj func)
+{
+    if (!IS_INTOBJ(handler) || INT_INTOBJ(handler) < 1 ||
+        INT_INTOBJ(handler) > MAX_INTERRUPT)
+        return ArgumentError(
+            "SetInterruptHandler: First argument must be an integer "
+            "between 1 and " AS_STRING(MAX_INTERRUPT));
+    if (func == Fail) {
+        SetInterruptHandler((int)(INT_INTOBJ(handler)), (Obj)0);
+        return (Obj)0;
+    }
+    if (TNUM_OBJ(func) != T_FUNCTION || NARG_FUNC(func) != 0 ||
+        !BODY_FUNC(func))
+        return ArgumentError("SetInterruptHandler: Second argument must be a "
+                             "parameterless function or 'fail'");
+    SetInterruptHandler((int)(INT_INTOBJ(handler)), func);
+    return (Obj)0;
 }
 
 #undef AS_STRING
@@ -567,18 +571,21 @@ Obj FuncSetInterruptHandler(Obj self, Obj handler, Obj func) {
 */
 
 
-Obj FuncPauseThread(Obj self, Obj thread) {
-  int id;
-  if (IS_INTOBJ(thread)) {
-    id = INT_INTOBJ(thread);
-    if (id < 0 || id >= MAX_THREADS)
-      return ArgumentError("PauseThread: Thread ID out of range");
-  } else if (TNUM_OBJ(thread) == T_THREAD) {
-    id = ThreadID(thread);
-  } else
-    return ArgumentError("PauseThread: Argument must be a thread object");
-  PauseThread(id);
-  return (Obj) 0;
+Obj FuncPauseThread(Obj self, Obj thread)
+{
+    int id;
+    if (IS_INTOBJ(thread)) {
+        id = INT_INTOBJ(thread);
+        if (id < 0 || id >= MAX_THREADS)
+            return ArgumentError("PauseThread: Thread ID out of range");
+    }
+    else if (TNUM_OBJ(thread) == T_THREAD) {
+        id = ThreadID(thread);
+    }
+    else
+        return ArgumentError("PauseThread: Argument must be a thread object");
+    PauseThread(id);
+    return (Obj)0;
 }
 
 
@@ -589,22 +596,23 @@ Obj FuncPauseThread(Obj self, Obj thread) {
 */
 
 
-Obj FuncResumeThread(Obj self, Obj thread) {
-  int id;
-  if (IS_INTOBJ(thread)) {
-    id = INT_INTOBJ(thread);
-    if (id < 0 || id >= MAX_THREADS)
-      return ArgumentError("ResumeThread: Thread ID out of range");
-  } else if (TNUM_OBJ(thread) == T_THREAD) {
-    id = ThreadID(thread);
-  } else
-    return ArgumentError("ResumeThread: Argument must be a thread object");
-  ResumeThread(id);
-  return (Obj) 0;
+Obj FuncResumeThread(Obj self, Obj thread)
+{
+    int id;
+    if (IS_INTOBJ(thread)) {
+        id = INT_INTOBJ(thread);
+        if (id < 0 || id >= MAX_THREADS)
+            return ArgumentError("ResumeThread: Thread ID out of range");
+    }
+    else if (TNUM_OBJ(thread) == T_THREAD) {
+        id = ThreadID(thread);
+    }
+    else
+        return ArgumentError(
+            "ResumeThread: Argument must be a thread object");
+    ResumeThread(id);
+    return (Obj)0;
 }
-
-
-
 
 
 /****************************************************************************
@@ -614,12 +622,11 @@ Obj FuncResumeThread(Obj self, Obj thread) {
 */
 
 
-Obj FuncRegionOf(Obj self, Obj obj) {
-  Region *region = GetRegionOf(obj);
-  return region == NULL ? PublicRegion : region->obj;
+Obj FuncRegionOf(Obj self, Obj obj)
+{
+    Region * region = GetRegionOf(obj);
+    return region == NULL ? PublicRegion : region->obj;
 }
-
-
 
 
 /****************************************************************************
@@ -631,31 +638,36 @@ Obj FuncRegionOf(Obj self, Obj obj) {
 */
 
 
-Obj FuncSetRegionName(Obj self, Obj obj, Obj name) {
-  Region *region = GetRegionOf(obj);
-  if (!region)
-    return ArgumentError("SetRegionName: Cannot change name of the public region");
-  if (!IsStringConv(name))
-    return ArgumentError("SetRegionName: Region name must be a string");
-  SetRegionName(region, name);
-  return (Obj) 0;
+Obj FuncSetRegionName(Obj self, Obj obj, Obj name)
+{
+    Region * region = GetRegionOf(obj);
+    if (!region)
+        return ArgumentError(
+            "SetRegionName: Cannot change name of the public region");
+    if (!IsStringConv(name))
+        return ArgumentError("SetRegionName: Region name must be a string");
+    SetRegionName(region, name);
+    return (Obj)0;
 }
 
-Obj FuncClearRegionName(Obj self, Obj obj) {
-  Region *region = GetRegionOf(obj);
-  if (!region)
-    return ArgumentError("ClearRegionName: Cannot change name of the public region");
-  SetRegionName(region, (Obj) 0);
-  return (Obj) 0;
+Obj FuncClearRegionName(Obj self, Obj obj)
+{
+    Region * region = GetRegionOf(obj);
+    if (!region)
+        return ArgumentError(
+            "ClearRegionName: Cannot change name of the public region");
+    SetRegionName(region, (Obj)0);
+    return (Obj)0;
 }
 
-Obj FuncRegionName(Obj self, Obj obj) {
-  Obj result;
-  Region *region = GetRegionOf(obj);
-  result = GetRegionName(region);
-  if (!result)
-    result = Fail;
-  return result;
+Obj FuncRegionName(Obj self, Obj obj)
+{
+    Obj      result;
+    Region * region = GetRegionOf(obj);
+    result = GetRegionName(region);
+    if (!result)
+        result = Fail;
+    return result;
 }
 
 
@@ -665,9 +677,10 @@ Obj FuncRegionName(Obj self, Obj obj) {
 **
 */
 
-Obj FuncIsShared(Obj self, Obj obj) {
-  Region *region = GetRegionOf(obj);
-  return (region && !region->fixed_owner) ? True : False;
+Obj FuncIsShared(Obj self, Obj obj)
+{
+    Region * region = GetRegionOf(obj);
+    return (region && !region->fixed_owner) ? True : False;
 }
 
 /****************************************************************************
@@ -676,9 +689,10 @@ Obj FuncIsShared(Obj self, Obj obj) {
 **
 */
 
-Obj FuncIsPublic(Obj self, Obj obj) {
-  Region *region = GetRegionOf(obj);
-  return region == NULL ? True : False;
+Obj FuncIsPublic(Obj self, Obj obj)
+{
+    Region * region = GetRegionOf(obj);
+    return region == NULL ? True : False;
 }
 
 /****************************************************************************
@@ -687,9 +701,12 @@ Obj FuncIsPublic(Obj self, Obj obj) {
 **
 */
 
-Obj FuncIsThreadLocal(Obj self, Obj obj) {
-  Region *region = GetRegionOf(obj);
-  return (region && region->fixed_owner && region->owner == realTLS) ? True : False;
+Obj FuncIsThreadLocal(Obj self, Obj obj)
+{
+    Region * region = GetRegionOf(obj);
+    return (region && region->fixed_owner && region->owner == realTLS)
+               ? True
+               : False;
 }
 
 /****************************************************************************
@@ -700,11 +717,12 @@ Obj FuncIsThreadLocal(Obj self, Obj obj) {
 
 Obj FuncHaveWriteAccess(Obj self, Obj obj)
 {
-  Region* region = GetRegionOf(obj);
-  if (region != NULL && (region->owner == realTLS || region->alt_owner == realTLS))
-    return True;
-  else
-    return False;
+    Region * region = GetRegionOf(obj);
+    if (region != NULL &&
+        (region->owner == realTLS || region->alt_owner == realTLS))
+        return True;
+    else
+        return False;
 }
 
 /****************************************************************************
@@ -715,11 +733,11 @@ Obj FuncHaveWriteAccess(Obj self, Obj obj)
 
 Obj FuncHaveReadAccess(Obj self, Obj obj)
 {
-  Region* region = GetRegionOf(obj);
-  if (region != NULL && CheckReadAccess(obj))
-    return True;
-  else
-    return False;
+    Region * region = GetRegionOf(obj);
+    if (region != NULL && CheckReadAccess(obj))
+        return True;
+    else
+        return False;
 }
 
 
@@ -733,64 +751,74 @@ Obj FuncHaveReadAccess(Obj self, Obj obj)
 */
 
 
-Obj FuncHASH_LOCK(Obj self, Obj target) {
-  HashLock(target);
-  return (Obj) 0;
+Obj FuncHASH_LOCK(Obj self, Obj target)
+{
+    HashLock(target);
+    return (Obj)0;
 }
 
-Obj FuncHASH_UNLOCK(Obj self, Obj target) {
-  HashUnlock(target);
-  return (Obj) 0;
+Obj FuncHASH_UNLOCK(Obj self, Obj target)
+{
+    HashUnlock(target);
+    return (Obj)0;
 }
 
-Obj FuncHASH_LOCK_SHARED(Obj self, Obj target) {
-  HashLockShared(target);
-  return (Obj) 0;
+Obj FuncHASH_LOCK_SHARED(Obj self, Obj target)
+{
+    HashLockShared(target);
+    return (Obj)0;
 }
-Obj FuncHASH_UNLOCK_SHARED(Obj self, Obj target) {
-  HashUnlockShared(target);
-  return (Obj) 0;
+Obj FuncHASH_UNLOCK_SHARED(Obj self, Obj target)
+{
+    HashUnlockShared(target);
+    return (Obj)0;
 }
 
 /****************************************************************************
 **
-*F FuncHASH_SYNCHRONIZED ......... execute a function while holding a write lock.
-*F FuncHASH_SYNCHRONIZED_SHARED ... execute a function while holding a read lock.
+*F FuncHASH_SYNCHRONIZED ......... execute a function while holding a write
+*lock.
+*F FuncHASH_SYNCHRONIZED_SHARED ... execute a function while holding a read
+*lock.
 **
 */
 
-Obj FuncHASH_SYNCHRONIZED(Obj self, Obj target, Obj function) {
-  volatile int locked = 0;
-  jmp_buf readJmpError;
-  memcpy( readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
-  TRY_READ {
-    HashLock(target);
-    locked = 1;
-    CALL_0ARGS(function);
-    locked = 0;
-    HashUnlock(target);
-  }
-  if (locked)
-    HashUnlock(target);
-  memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
-  return (Obj) 0;
+Obj FuncHASH_SYNCHRONIZED(Obj self, Obj target, Obj function)
+{
+    volatile int locked = 0;
+    jmp_buf      readJmpError;
+    memcpy(readJmpError, STATE(ReadJmpError), sizeof(jmp_buf));
+    TRY_READ
+    {
+        HashLock(target);
+        locked = 1;
+        CALL_0ARGS(function);
+        locked = 0;
+        HashUnlock(target);
+    }
+    if (locked)
+        HashUnlock(target);
+    memcpy(STATE(ReadJmpError), readJmpError, sizeof(jmp_buf));
+    return (Obj)0;
 }
 
-Obj FuncHASH_SYNCHRONIZED_SHARED(Obj self, Obj target, Obj function) {
-  volatile int locked = 0;
-  jmp_buf readJmpError;
-  memcpy( readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
-  TRY_READ {
-    HashLockShared(target);
-    locked = 1;
-    CALL_0ARGS(function);
-    locked = 0;
-    HashUnlockShared(target);
-  }
-  if (locked)
-    HashUnlockShared(target);
-  memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
-  return (Obj) 0;
+Obj FuncHASH_SYNCHRONIZED_SHARED(Obj self, Obj target, Obj function)
+{
+    volatile int locked = 0;
+    jmp_buf      readJmpError;
+    memcpy(readJmpError, STATE(ReadJmpError), sizeof(jmp_buf));
+    TRY_READ
+    {
+        HashLockShared(target);
+        locked = 1;
+        CALL_0ARGS(function);
+        locked = 0;
+        HashUnlockShared(target);
+    }
+    if (locked)
+        HashUnlockShared(target);
+    memcpy(STATE(ReadJmpError), readJmpError, sizeof(jmp_buf));
+    return (Obj)0;
 }
 
 /****************************************************************************
@@ -799,61 +827,67 @@ Obj FuncHASH_SYNCHRONIZED_SHARED(Obj self, Obj target, Obj function) {
 **
 */
 
-Obj FuncCREATOR_OF(Obj self, Obj obj) {
+Obj FuncCREATOR_OF(Obj self, Obj obj)
+{
 #ifdef TRACK_CREATOR
-  Obj result = NEW_PLIST(T_PLIST+IMMUTABLE, 2);
-  SET_LEN_PLIST(result, 2);
-  if (!IS_BAG_REF(obj)) {
-    SET_ELM_PLIST(result, 1, Fail);
-    SET_ELM_PLIST(result, 2, Fail);
+    Obj result = NEW_PLIST(T_PLIST + IMMUTABLE, 2);
+    SET_LEN_PLIST(result, 2);
+    if (!IS_BAG_REF(obj)) {
+        SET_ELM_PLIST(result, 1, Fail);
+        SET_ELM_PLIST(result, 2, Fail);
+        return result;
+    }
+    if (obj[2])
+        SET_ELM_PLIST(result, 1, (Obj)(obj[2]));
+    else
+        SET_ELM_PLIST(result, 1, Fail);
+    if (obj[3])
+        SET_ELM_PLIST(result, 2, (Obj)(obj[3]));
+    else
+        SET_ELM_PLIST(result, 2, Fail);
     return result;
-  }
-  if (obj[2])
-    SET_ELM_PLIST(result, 1, (Obj)(obj[2]));
-  else
-    SET_ELM_PLIST(result, 1, Fail);
-  if (obj[3])
-    SET_ELM_PLIST(result, 2, (Obj)(obj[3]));
-  else
-    SET_ELM_PLIST(result, 2, Fail);
-  return result;
 #else
-  return Fail;
+    return Fail;
 #endif
 }
 
-Obj FuncDISABLE_GUARDS(Obj self, Obj flag) {
-  if (flag == False)
-    TLS(DisableGuards) = 0;
-  else if (flag == True)
-    TLS(DisableGuards) = 1;
-  else if (IS_INTOBJ(flag))
-    TLS(DisableGuards) = (int) (INT_INTOBJ(flag));
-  else
-    ErrorQuit("DISABLE_GUARDS: Argument must be boolean or integer", 0L, 0L);
-  return (Obj) 0;
+Obj FuncDISABLE_GUARDS(Obj self, Obj flag)
+{
+    if (flag == False)
+        TLS(DisableGuards) = 0;
+    else if (flag == True)
+        TLS(DisableGuards) = 1;
+    else if (IS_INTOBJ(flag))
+        TLS(DisableGuards) = (int)(INT_INTOBJ(flag));
+    else
+        ErrorQuit("DISABLE_GUARDS: Argument must be boolean or integer", 0L,
+                  0L);
+    return (Obj)0;
 }
 
-Obj FuncWITH_TARGET_REGION(Obj self, Obj obj, Obj func) {
-  Region * volatile oldRegion = TLS(currentRegion);
-  Region * volatile region = GetRegionOf(obj);
-  syJmp_buf readJmpError;
+Obj FuncWITH_TARGET_REGION(Obj self, Obj obj, Obj func)
+{
+    Region * volatile oldRegion = TLS(currentRegion);
+    Region * volatile region = GetRegionOf(obj);
+    syJmp_buf readJmpError;
 
-  if (TNUM_OBJ(func) != T_FUNCTION)
-    return ArgumentError("WITH_TARGET_REGION: Second argument must be a function");
-  if (!region || !CheckExclusiveWriteAccess(obj))
-    return ArgumentError("WITH_TARGET_REGION: Requires write access to target region");
-  memcpy(readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf));
-  if (sySetjmp(STATE(ReadJmpError))) {
+    if (TNUM_OBJ(func) != T_FUNCTION)
+        return ArgumentError(
+            "WITH_TARGET_REGION: Second argument must be a function");
+    if (!region || !CheckExclusiveWriteAccess(obj))
+        return ArgumentError(
+            "WITH_TARGET_REGION: Requires write access to target region");
+    memcpy(readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf));
+    if (sySetjmp(STATE(ReadJmpError))) {
+        memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+        TLS(currentRegion) = oldRegion;
+        syLongjmp(&(STATE(ReadJmpError)), 1);
+    }
+    TLS(currentRegion) = region;
+    CALL_0ARGS(func);
     memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
     TLS(currentRegion) = oldRegion;
-    syLongjmp(&(STATE(ReadJmpError)), 1);
-  }
-  TLS(currentRegion) = region;
-  CALL_0ARGS(func);
-  memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
-  TLS(currentRegion) = oldRegion;
-  return (Obj) 0;
+    return (Obj)0;
 }
 
 
@@ -948,330 +982,309 @@ Obj FuncTHREAD_COUNTERS_GET(Obj self);
 Obj FuncTHREAD_COUNTERS_RESET(Obj self);
 
 
-
 /****************************************************************************
 **
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
-static StructGVarFunc GVarFuncs [] = {
+static StructGVarFunc GVarFuncs[] = {
 
-    { "CreateThread", -1, "function",
-      FuncCreateThread, "src/threadapi.c:CreateThread" },
+    { "CreateThread", -1, "function", FuncCreateThread,
+      "src/threadapi.c:CreateThread" },
 
-    { "CurrentThread", 0, "",
-      FuncCurrentThread, "src/threadapi.c:CurrentThread" },
+    { "CurrentThread", 0, "", FuncCurrentThread,
+      "src/threadapi.c:CurrentThread" },
 
-    { "ThreadID", 1, "thread",
-      FuncThreadID, "src/threadapi.c:ThreadID" },
+    { "ThreadID", 1, "thread", FuncThreadID, "src/threadapi.c:ThreadID" },
 
-    { "WaitThread", 1, "thread",
-      FuncWaitThread, "src/threadapi.c:WaitThread" },
+    { "WaitThread", 1, "thread", FuncWaitThread,
+      "src/threadapi.c:WaitThread" },
 
-    { "KillThread", 1, "thread",
-      FuncKillThread, "src/threadapi.c:KillThread" },
+    { "KillThread", 1, "thread", FuncKillThread,
+      "src/threadapi.c:KillThread" },
 
-    { "InterruptThread", 2, "thread, handler",
-      FuncInterruptThread, "src/threadapi.c:InterruptThread" },
+    { "InterruptThread", 2, "thread, handler", FuncInterruptThread,
+      "src/threadapi.c:InterruptThread" },
 
-    { "SetInterruptHandler", 2, "handler, function",
-      FuncSetInterruptHandler, "src/threadapi.c:SetInterruptHandler" },
+    { "SetInterruptHandler", 2, "handler, function", FuncSetInterruptHandler,
+      "src/threadapi.c:SetInterruptHandler" },
 
-    { "PauseThread", 1, "thread",
-      FuncPauseThread, "src/threadapi.c:PauseThread" },
+    { "PauseThread", 1, "thread", FuncPauseThread,
+      "src/threadapi.c:PauseThread" },
 
-    { "ResumeThread", 1, "thread",
-      FuncResumeThread, "src/threadapi.c:ResumeThread" },
+    { "ResumeThread", 1, "thread", FuncResumeThread,
+      "src/threadapi.c:ResumeThread" },
 
-    { "HASH_LOCK", 1, "object",
-      FuncHASH_LOCK, "src/threadapi.c:HASH_LOCK" },
+    { "HASH_LOCK", 1, "object", FuncHASH_LOCK, "src/threadapi.c:HASH_LOCK" },
 
-    { "HASH_LOCK_SHARED", 1, "object",
-      FuncHASH_LOCK_SHARED, "src/threadapi.c:HASH_LOCK_SHARED" },
+    { "HASH_LOCK_SHARED", 1, "object", FuncHASH_LOCK_SHARED,
+      "src/threadapi.c:HASH_LOCK_SHARED" },
 
-    { "HASH_UNLOCK", 1, "object",
-      FuncHASH_UNLOCK, "src/threadapi.c:HASH_UNLOCK" },
+    { "HASH_UNLOCK", 1, "object", FuncHASH_UNLOCK,
+      "src/threadapi.c:HASH_UNLOCK" },
 
-    { "HASH_UNLOCK_SHARED", 1, "object",
-      FuncHASH_UNLOCK_SHARED, "src/threadapi.c:HASH_UNLOCK_SHARED" },
+    { "HASH_UNLOCK_SHARED", 1, "object", FuncHASH_UNLOCK_SHARED,
+      "src/threadapi.c:HASH_UNLOCK_SHARED" },
 
-    { "HASH_SYNCHRONIZED", 2, "object, function",
-      FuncHASH_SYNCHRONIZED, "src/threadapi.c:HASH_SYNCHRONIZED" },
+    { "HASH_SYNCHRONIZED", 2, "object, function", FuncHASH_SYNCHRONIZED,
+      "src/threadapi.c:HASH_SYNCHRONIZED" },
 
     { "SynchronizedShared", 2, "object, function",
       FuncHASH_SYNCHRONIZED_SHARED, "src/threadapi.c:SynchronizedShared" },
 
-    { "RegionOf", 1, "object",
-      FuncRegionOf, "src/threadapi.c:RegionOf" },
+    { "RegionOf", 1, "object", FuncRegionOf, "src/threadapi.c:RegionOf" },
 
-    { "SetRegionName", 2, "obj, name",
-      FuncSetRegionName, "src/threadapi.c:SetRegionName" },
+    { "SetRegionName", 2, "obj, name", FuncSetRegionName,
+      "src/threadapi.c:SetRegionName" },
 
-    { "ClearRegionName", 1, "obj",
-      FuncClearRegionName, "src/threadapi.c:ClearRegionName" },
+    { "ClearRegionName", 1, "obj", FuncClearRegionName,
+      "src/threadapi.c:ClearRegionName" },
 
-    { "RegionName", 1, "obj",
-      FuncRegionName, "src/threadapi.c:RegionName" },
+    { "RegionName", 1, "obj", FuncRegionName, "src/threadapi.c:RegionName" },
 
-    { "WITH_TARGET_REGION", 2, "region, function",
-      FuncWITH_TARGET_REGION, "src/threadapi.c:WITH_TARGET_REGION" },
+    { "WITH_TARGET_REGION", 2, "region, function", FuncWITH_TARGET_REGION,
+      "src/threadapi.c:WITH_TARGET_REGION" },
 
-    { "IsShared", 1, "object",
-      FuncIsShared, "src/threadapi.c:IsShared" },
+    { "IsShared", 1, "object", FuncIsShared, "src/threadapi.c:IsShared" },
 
-    { "IsPublic", 1, "object",
-      FuncIsPublic, "src/threadapi.c:IsPublic" },
+    { "IsPublic", 1, "object", FuncIsPublic, "src/threadapi.c:IsPublic" },
 
-    { "IsThreadLocal", 1, "object",
-      FuncIsThreadLocal, "src/threadapi.c:IsThreadLocal" },
+    { "IsThreadLocal", 1, "object", FuncIsThreadLocal,
+      "src/threadapi.c:IsThreadLocal" },
 
-    { "HaveWriteAccess", 1, "object",
-      FuncHaveWriteAccess, "src/threadapi.c:HaveWriteAccess" },
+    { "HaveWriteAccess", 1, "object", FuncHaveWriteAccess,
+      "src/threadapi.c:HaveWriteAccess" },
 
-    { "HaveReadAccess", 1, "object",
-      FuncHaveReadAccess, "src/threadapi.c:HaveReadAccess" },
+    { "HaveReadAccess", 1, "object", FuncHaveReadAccess,
+      "src/threadapi.c:HaveReadAccess" },
 
-    { "CreateSemaphore", -1, "[count]",
-      FuncCreateSemaphore, "src/threadapi.c:CreateSemaphore" },
+    { "CreateSemaphore", -1, "[count]", FuncCreateSemaphore,
+      "src/threadapi.c:CreateSemaphore" },
 
-    { "SignalSemaphore", 1, "semaphore",
-      FuncSignalSemaphore, "src/threadapi.c:SignalSemaphore" },
+    { "SignalSemaphore", 1, "semaphore", FuncSignalSemaphore,
+      "src/threadapi.c:SignalSemaphore" },
 
-    { "WaitSemaphore", 1, "semaphore",
-      FuncWaitSemaphore, "src/threadapi.c:WaitSemaphore" },
+    { "WaitSemaphore", 1, "semaphore", FuncWaitSemaphore,
+      "src/threadapi.c:WaitSemaphore" },
 
-    { "TryWaitSemaphore", 1, "semaphore",
-      FuncTryWaitSemaphore, "src/threadapi.c:TryWaitSemaphore" },
+    { "TryWaitSemaphore", 1, "semaphore", FuncTryWaitSemaphore,
+      "src/threadapi.c:TryWaitSemaphore" },
 
-    { "CreateChannel", -1, "[size]",
-      FuncCreateChannel, "src/threadapi.c:CreateChannel" },
+    { "CreateChannel", -1, "[size]", FuncCreateChannel,
+      "src/threadapi.c:CreateChannel" },
 
-    { "DestroyChannel", 1, "channel",
-      FuncDestroyChannel, "src/threadapi.c:DestroyChannel" },
+    { "DestroyChannel", 1, "channel", FuncDestroyChannel,
+      "src/threadapi.c:DestroyChannel" },
 
-    { "TallyChannel", 1, "channel",
-      FuncTallyChannel, "src/threadapi.c:TallyChannel" },
+    { "TallyChannel", 1, "channel", FuncTallyChannel,
+      "src/threadapi.c:TallyChannel" },
 
-    { "SendChannel", 2, "channel, obj",
-      FuncSendChannel, "src/threadapi.c:SendChannel" },
+    { "SendChannel", 2, "channel, obj", FuncSendChannel,
+      "src/threadapi.c:SendChannel" },
 
-    { "TransmitChannel", 2, "channel, obj",
-      FuncTransmitChannel, "src/threadapi.c:TransmitChannel" },
+    { "TransmitChannel", 2, "channel, obj", FuncTransmitChannel,
+      "src/threadapi.c:TransmitChannel" },
 
-    { "ReceiveChannel", 1, "channel",
-      FuncReceiveChannel, "src/threadapi:ReceiveChannel" },
+    { "ReceiveChannel", 1, "channel", FuncReceiveChannel,
+      "src/threadapi:ReceiveChannel" },
 
-    { "ReceiveAnyChannel", -1, "channel list",
-      FuncReceiveAnyChannel, "src/threadapi:ReceiveAnyChannel" },
+    { "ReceiveAnyChannel", -1, "channel list", FuncReceiveAnyChannel,
+      "src/threadapi:ReceiveAnyChannel" },
 
     { "ReceiveAnyChannelWithIndex", -1, "channel list",
-      FuncReceiveAnyChannelWithIndex, "src/threadapi:ReceiveAnyChannelWithIndex" },
+      FuncReceiveAnyChannelWithIndex,
+      "src/threadapi:ReceiveAnyChannelWithIndex" },
 
-    { "MultiReceiveChannel", 2, "channel, count",
-      FuncMultiReceiveChannel, "src/threadapi:MultiReceiveChannel" },
+    { "MultiReceiveChannel", 2, "channel, count", FuncMultiReceiveChannel,
+      "src/threadapi:MultiReceiveChannel" },
 
-    { "TryReceiveChannel", 2, "channel, obj",
-      FuncTryReceiveChannel, "src/threadapi.c:TryReceiveChannel" },
+    { "TryReceiveChannel", 2, "channel, obj", FuncTryReceiveChannel,
+      "src/threadapi.c:TryReceiveChannel" },
 
-    { "MultiSendChannel", 2, "channel, list",
-      FuncMultiSendChannel, "src/threadapi:MultiSendChannel" },
+    { "MultiSendChannel", 2, "channel, list", FuncMultiSendChannel,
+      "src/threadapi:MultiSendChannel" },
 
-    { "TryMultiSendChannel", 2, "channel, list",
-      FuncTryMultiSendChannel, "src/threadapi:TryMultiSendChannel" },
+    { "TryMultiSendChannel", 2, "channel, list", FuncTryMultiSendChannel,
+      "src/threadapi:TryMultiSendChannel" },
 
-    { "TrySendChannel", 2, "channel, obj",
-      FuncTrySendChannel, "src/threadapi.c:TrySendChannel" },
+    { "TrySendChannel", 2, "channel, obj", FuncTrySendChannel,
+      "src/threadapi.c:TrySendChannel" },
 
-    { "MultiTransmitChannel", 2, "channel, list",
-      FuncMultiTransmitChannel, "src/threadapi:MultiTransmitChannel" },
+    { "MultiTransmitChannel", 2, "channel, list", FuncMultiTransmitChannel,
+      "src/threadapi:MultiTransmitChannel" },
 
     { "TryMultiTransmitChannel", 2, "channel, list",
       FuncTryMultiTransmitChannel, "src/threadapi:TryMultiTransmitChannel" },
 
-    { "TryTransmitChannel", 2, "channel, obj",
-      FuncTryTransmitChannel, "src/threadapi.c:TryTransmitChannel" },
+    { "TryTransmitChannel", 2, "channel, obj", FuncTryTransmitChannel,
+      "src/threadapi.c:TryTransmitChannel" },
 
-    { "InspectChannel", 1, "channel, obj",
-      FuncInspectChannel, "src/threadapi.c:InspectChannel" },
+    { "InspectChannel", 1, "channel, obj", FuncInspectChannel,
+      "src/threadapi.c:InspectChannel" },
 
-    { "CreateBarrier", 0, "",
-      FuncCreateBarrier, "src/threadapi.c:CreateBarrier" },
+    { "CreateBarrier", 0, "", FuncCreateBarrier,
+      "src/threadapi.c:CreateBarrier" },
 
-    { "StartBarrier", 2, "barrier, count",
-      FuncStartBarrier, "src/threadapi.c:StartBarrier" },
+    { "StartBarrier", 2, "barrier, count", FuncStartBarrier,
+      "src/threadapi.c:StartBarrier" },
 
-    { "WaitBarrier", 1, "barrier",
-      FuncWaitBarrier, "src/threadapi.c:WaitBarrier" },
+    { "WaitBarrier", 1, "barrier", FuncWaitBarrier,
+      "src/threadapi.c:WaitBarrier" },
 
-    { "CreateSyncVar", 0, "",
-      FuncCreateSyncVar, "src/threadapi.c:CreateSyncVar" },
+    { "CreateSyncVar", 0, "", FuncCreateSyncVar,
+      "src/threadapi.c:CreateSyncVar" },
 
-    { "SyncWrite", 2, "syncvar, obj",
-      FuncSyncWrite, "src/threadapi.c:SyncWrite" },
+    { "SyncWrite", 2, "syncvar, obj", FuncSyncWrite,
+      "src/threadapi.c:SyncWrite" },
 
-    { "SyncTryWrite", 2, "syncvar, obj",
-      FuncSyncTryWrite, "src/threadapi.c:SyncTryWrite" },
+    { "SyncTryWrite", 2, "syncvar, obj", FuncSyncTryWrite,
+      "src/threadapi.c:SyncTryWrite" },
 
-    { "SyncRead", 1, "syncvar",
-      FuncSyncRead, "src/threadapi.c:SyncRead" },
+    { "SyncRead", 1, "syncvar", FuncSyncRead, "src/threadapi.c:SyncRead" },
 
-    { "SyncIsBound", 1, "syncvar",
-      FuncSyncIsBound, "src/threadapi.c:SyncIsBound" },
+    { "SyncIsBound", 1, "syncvar", FuncSyncIsBound,
+      "src/threadapi.c:SyncIsBound" },
 
-    { "IS_LOCKED", 1, "obj",
-      FuncIS_LOCKED, "src/threadapi.c:IS_LOCKED" },
+    { "IS_LOCKED", 1, "obj", FuncIS_LOCKED, "src/threadapi.c:IS_LOCKED" },
 
-    { "WriteLock", -1, "obj, ...",
-      FuncWriteLock, "src/threadapi.c:WriteLock" },
+    { "WriteLock", -1, "obj, ...", FuncWriteLock,
+      "src/threadapi.c:WriteLock" },
 
-    { "ReadLock", -1, "obj, ...",
-      FuncReadLock, "src/threadapi.c:ReadLock" },
+    { "ReadLock", -1, "obj, ...", FuncReadLock, "src/threadapi.c:ReadLock" },
 
-    { "LOCK", -1, "obj, ...",
-      FuncLOCK, "src/threadapi.c:LOCK" },
+    { "LOCK", -1, "obj, ...", FuncLOCK, "src/threadapi.c:LOCK" },
 
-    { "DO_LOCK", -1, "obj, ...",
-      FuncDO_LOCK, "src/threadapi.c:DO_LOCK" },
+    { "DO_LOCK", -1, "obj, ...", FuncDO_LOCK, "src/threadapi.c:DO_LOCK" },
 
-    { "WRITE_LOCK", 1, "obj",
-      FuncWRITE_LOCK, "src/threadapi.c:WRITE_LOCK" },
+    { "WRITE_LOCK", 1, "obj", FuncWRITE_LOCK, "src/threadapi.c:WRITE_LOCK" },
 
-    { "READ_LOCK", 1, "obj",
-      FuncREAD_LOCK, "src/threadapi.c:READ_LOCK" },
+    { "READ_LOCK", 1, "obj", FuncREAD_LOCK, "src/threadapi.c:READ_LOCK" },
 
-    { "TRYLOCK", -1, "obj, ...",
-      FuncTRYLOCK, "src/threadapi.c:TRYLOCK" },
+    { "TRYLOCK", -1, "obj, ...", FuncTRYLOCK, "src/threadapi.c:TRYLOCK" },
 
-    { "UNLOCK", 1, "obj, newsp",
-      FuncUNLOCK, "src/threadapi.c:LOCK" },
+    { "UNLOCK", 1, "obj, newsp", FuncUNLOCK, "src/threadapi.c:LOCK" },
 
-    { "CURRENT_LOCKS", 0, "",
-      FuncCURRENT_LOCKS, "src/threadapi.c:FuncCURRENT_LOCKS" },
+    { "CURRENT_LOCKS", 0, "", FuncCURRENT_LOCKS,
+      "src/threadapi.c:FuncCURRENT_LOCKS" },
 
-    { "REFINE_TYPE", 1, "obj",
-      FuncREFINE_TYPE, "src/threadapi.c:REFINE_TYPE" },
+    { "REFINE_TYPE", 1, "obj", FuncREFINE_TYPE,
+      "src/threadapi.c:REFINE_TYPE" },
 
-    { "SHARE_NORECURSE", 3, "obj, string, integer",
-      FuncSHARE_NORECURSE, "src/threadapi.c:SHARE_NORECURSE" },
+    { "SHARE_NORECURSE", 3, "obj, string, integer", FuncSHARE_NORECURSE,
+      "src/threadapi.c:SHARE_NORECURSE" },
 
-    { "ADOPT_NORECURSE", 1, "obj",
-      FuncADOPT_NORECURSE, "src/threadapi.c:ADOPT_NORECURSE" },
+    { "ADOPT_NORECURSE", 1, "obj", FuncADOPT_NORECURSE,
+      "src/threadapi.c:ADOPT_NORECURSE" },
 
-    { "MIGRATE_NORECURSE", 2, "obj, target",
-      FuncMIGRATE_NORECURSE, "src/threadapi.c:MIGRATE_NORECURSE" },
+    { "MIGRATE_NORECURSE", 2, "obj, target", FuncMIGRATE_NORECURSE,
+      "src/threadapi.c:MIGRATE_NORECURSE" },
 
-    { "NEW_REGION", 2, "string, integer",
-      FuncNEW_REGION, "src/threadapi.c:NEW_REGION" },
+    { "NEW_REGION", 2, "string, integer", FuncNEW_REGION,
+      "src/threadapi.c:NEW_REGION" },
 
-    { "REGION_PRECEDENCE", 1, "obj",
-      FuncREGION_PRECEDENCE, "src/threadapi.c:REGION_PRECEDENCE" },
+    { "REGION_PRECEDENCE", 1, "obj", FuncREGION_PRECEDENCE,
+      "src/threadapi.c:REGION_PRECEDENCE" },
 
-    { "SHARE", 3, "obj, string, integer",
-      FuncSHARE, "src/threadapi.c:SHARE" },
+    { "SHARE", 3, "obj, string, integer", FuncSHARE,
+      "src/threadapi.c:SHARE" },
 
-    { "SHARE_RAW", 3, "obj, string, integer",
-      FuncSHARE_RAW, "src/threadapi.c:SHARE_RAW" },
+    { "SHARE_RAW", 3, "obj, string, integer", FuncSHARE_RAW,
+      "src/threadapi.c:SHARE_RAW" },
 
-    { "ADOPT", 1, "obj",
-      FuncADOPT, "src/threadapi.c:ADOPT" },
+    { "ADOPT", 1, "obj", FuncADOPT, "src/threadapi.c:ADOPT" },
 
-    { "MIGRATE", 2, "obj, target",
-      FuncMIGRATE, "src/threadapi.c:MIGRATE" },
+    { "MIGRATE", 2, "obj, target", FuncMIGRATE, "src/threadapi.c:MIGRATE" },
 
-    { "MIGRATE_RAW", 2, "obj, target",
-      FuncMIGRATE_RAW, "src/threadapi.c:MIGRATE_RAW" },
+    { "MIGRATE_RAW", 2, "obj, target", FuncMIGRATE_RAW,
+      "src/threadapi.c:MIGRATE_RAW" },
 
-    { "MAKE_PUBLIC_NORECURSE", 1, "obj",
-      FuncMAKE_PUBLIC_NORECURSE, "src/threadapi.c:MAKE_PUBLIC_NORECURSE" },
+    { "MAKE_PUBLIC_NORECURSE", 1, "obj", FuncMAKE_PUBLIC_NORECURSE,
+      "src/threadapi.c:MAKE_PUBLIC_NORECURSE" },
 
-    { "MAKE_PUBLIC", 1, "obj",
-      FuncMAKE_PUBLIC, "src/threadapi.c:MAKE_PUBLIC" },
+    { "MAKE_PUBLIC", 1, "obj", FuncMAKE_PUBLIC,
+      "src/threadapi.c:MAKE_PUBLIC" },
 
-    { "FORCE_MAKE_PUBLIC", 1, "obj",
-      FuncFORCE_MAKE_PUBLIC, "src/threadapi.c:FORCE_MAKE_PUBLIC" },
+    { "FORCE_MAKE_PUBLIC", 1, "obj", FuncFORCE_MAKE_PUBLIC,
+      "src/threadapi.c:FORCE_MAKE_PUBLIC" },
 
-    { "REACHABLE", 1, "obj",
-      FuncREACHABLE, "src/threadapi.c:REACHABLE" },
+    { "REACHABLE", 1, "obj", FuncREACHABLE, "src/threadapi.c:REACHABLE" },
 
-    { "CLONE_REACHABLE", 1, "obj",
-      FuncCLONE_REACHABLE, "src/threadapi.c:CLONE_REACHABLE" },
+    { "CLONE_REACHABLE", 1, "obj", FuncCLONE_REACHABLE,
+      "src/threadapi.c:CLONE_REACHABLE" },
 
-    { "CLONE_DELIMITED", 1, "obj",
-      FuncCLONE_DELIMITED, "src/threadapi.c:CLONE_DELIMITED" },
+    { "CLONE_DELIMITED", 1, "obj", FuncCLONE_DELIMITED,
+      "src/threadapi.c:CLONE_DELIMITED" },
 
-    { "MakeThreadLocal", 1, "variable name",
-      FuncMakeThreadLocal, "src/threadapi.c:MakeThreadLocal" },
+    { "MakeThreadLocal", 1, "variable name", FuncMakeThreadLocal,
+      "src/threadapi.c:MakeThreadLocal" },
 
-    { "MakeReadOnly", 1, "obj",
-      FuncMakeReadOnly, "src/threadapi.c:MakeReadOnly" },
+    { "MakeReadOnly", 1, "obj", FuncMakeReadOnly,
+      "src/threadapi.c:MakeReadOnly" },
 
-    { "MakeReadOnlyRaw", 1, "obj",
-      FuncMakeReadOnlyRaw, "src/threadapi.c:MakeReadOnlyRaw" },
+    { "MakeReadOnlyRaw", 1, "obj", FuncMakeReadOnlyRaw,
+      "src/threadapi.c:MakeReadOnlyRaw" },
 
-    { "MakeReadOnlyObj", 1, "obj",
-      FuncMakeReadOnlyObj, "src/threadapi.c:MakeReadOnlyObj" },
+    { "MakeReadOnlyObj", 1, "obj", FuncMakeReadOnlyObj,
+      "src/threadapi.c:MakeReadOnlyObj" },
 
-    { "IsReadOnly", 1, "obj",
-      FuncIsReadOnly, "src/threadapi.c:IsReadOnly" },
+    { "IsReadOnly", 1, "obj", FuncIsReadOnly, "src/threadapi.c:IsReadOnly" },
 
-    { "ENABLE_AUTO_RETYPING", 0, "",
-      FuncENABLE_AUTO_RETYPING, "src/threadapi.c:ENABLE_AUTO_RETYPING" },
+    { "ENABLE_AUTO_RETYPING", 0, "", FuncENABLE_AUTO_RETYPING,
+      "src/threadapi.c:ENABLE_AUTO_RETYPING" },
 
-    { "ORDERED_READ", 1, "obj",
-      FuncORDERED_READ, "src/threadapi.c:ORDERED_READ" },
+    { "ORDERED_READ", 1, "obj", FuncORDERED_READ,
+      "src/threadapi.c:ORDERED_READ" },
 
-    { "ORDERED_WRITE", 1, "obj",
-      FuncORDERED_WRITE, "src/threadapi.c:ORDERED_WRITE" },
+    { "ORDERED_WRITE", 1, "obj", FuncORDERED_WRITE,
+      "src/threadapi.c:ORDERED_WRITE" },
 
-    { "CREATOR_OF", 1, "obj",
-      FuncCREATOR_OF, "src/threadapi.c:CREATOR_OF" },
+    { "CREATOR_OF", 1, "obj", FuncCREATOR_OF, "src/threadapi.c:CREATOR_OF" },
 
-    { "DISABLE_GUARDS", 1, "flag",
-      FuncDISABLE_GUARDS, "src/threadapi.c:DISABLE_GUARDS" },
+    { "DISABLE_GUARDS", 1, "flag", FuncDISABLE_GUARDS,
+      "src/threadapi.c:DISABLE_GUARDS" },
 
-    { "DEFAULT_SIGINT_HANDLER", 0, "",
-      FuncDEFAULT_SIGINT_HANDLER, "src/threadapi.c:DEFAULT_SIGINT_HANDLER" },
+    { "DEFAULT_SIGINT_HANDLER", 0, "", FuncDEFAULT_SIGINT_HANDLER,
+      "src/threadapi.c:DEFAULT_SIGINT_HANDLER" },
 
-    { "DEFAULT_SIGVTALRM_HANDLER", 0, "",
-      FuncDEFAULT_SIGVTALRM_HANDLER, "src/threadapi.c:DEFAULT_SIGVTALRM_HANDLER" },
+    { "DEFAULT_SIGVTALRM_HANDLER", 0, "", FuncDEFAULT_SIGVTALRM_HANDLER,
+      "src/threadapi.c:DEFAULT_SIGVTALRM_HANDLER" },
 
-    { "DEFAULT_SIGWINCH_HANDLER", 0, "",
-      FuncDEFAULT_SIGWINCH_HANDLER, "src/threadapi.c:DEFAULT_SIGWINCH_HANDLER" },
+    { "DEFAULT_SIGWINCH_HANDLER", 0, "", FuncDEFAULT_SIGWINCH_HANDLER,
+      "src/threadapi.c:DEFAULT_SIGWINCH_HANDLER" },
 
-    { "SIGWAIT", 1, "record",
-      FuncSIGWAIT, "src/threadapi.c:SIGWAIT" },
+    { "SIGWAIT", 1, "record", FuncSIGWAIT, "src/threadapi.c:SIGWAIT" },
 
-    { "PERIODIC_CHECK", 2, "count, function",
-      FuncPERIODIC_CHECK, "src/threadapi.c:PERIODIC_CHECK" },
+    { "PERIODIC_CHECK", 2, "count, function", FuncPERIODIC_CHECK,
+      "src/threadapi.c:PERIODIC_CHECK" },
 
-    { "REGION_COUNTERS_ENABLE", 1, "region",
-      FuncREGION_COUNTERS_ENABLE, "src/threadapi.c:REGION_COUNTERS_ENABLE" },
+    { "REGION_COUNTERS_ENABLE", 1, "region", FuncREGION_COUNTERS_ENABLE,
+      "src/threadapi.c:REGION_COUNTERS_ENABLE" },
 
-    { "REGION_COUNTERS_DISABLE", 1, "region",
-      FuncREGION_COUNTERS_DISABLE, "src/threadapi.c:REGION_COUNTERS_DISABLE" },
+    { "REGION_COUNTERS_DISABLE", 1, "region", FuncREGION_COUNTERS_DISABLE,
+      "src/threadapi.c:REGION_COUNTERS_DISABLE" },
 
-    { "REGION_COUNTERS_GET_STATE", 1, "region",
-      FuncREGION_COUNTERS_GET_STATE, "src/threadapi.c:REGION_COUNTERS_GET_STATE" },
+    { "REGION_COUNTERS_GET_STATE", 1, "region", FuncREGION_COUNTERS_GET_STATE,
+      "src/threadapi.c:REGION_COUNTERS_GET_STATE" },
 
-    { "REGION_COUNTERS_GET", 1, "region",
-      FuncREGION_COUNTERS_GET, "src/threadapi.c:REGION_COUNTERS_GET" },
+    { "REGION_COUNTERS_GET", 1, "region", FuncREGION_COUNTERS_GET,
+      "src/threadapi.c:REGION_COUNTERS_GET" },
 
-    { "REGION_COUNTERS_RESET", 1, "region",
-      FuncREGION_COUNTERS_RESET, "src/threadapi.c:REGION_COUNTERS_RESET" },
+    { "REGION_COUNTERS_RESET", 1, "region", FuncREGION_COUNTERS_RESET,
+      "src/threadapi.c:REGION_COUNTERS_RESET" },
 
-    { "THREAD_COUNTERS_ENABLE", 0, "",
-      FuncTHREAD_COUNTERS_ENABLE, "src/threadapi.c:THREAD_COUNTERS_ENABLE" },
+    { "THREAD_COUNTERS_ENABLE", 0, "", FuncTHREAD_COUNTERS_ENABLE,
+      "src/threadapi.c:THREAD_COUNTERS_ENABLE" },
 
-    { "THREAD_COUNTERS_DISABLE", 0, "",
-      FuncTHREAD_COUNTERS_DISABLE, "src/threadapi.c:THREAD_COUNTERS_DISABLE" },
+    { "THREAD_COUNTERS_DISABLE", 0, "", FuncTHREAD_COUNTERS_DISABLE,
+      "src/threadapi.c:THREAD_COUNTERS_DISABLE" },
 
-    { "THREAD_COUNTERS_GET_STATE", 0, "",
-      FuncTHREAD_COUNTERS_GET_STATE, "src/threadapi.c:THREAD_COUNTERS_GET_STATE" },
+    { "THREAD_COUNTERS_GET_STATE", 0, "", FuncTHREAD_COUNTERS_GET_STATE,
+      "src/threadapi.c:THREAD_COUNTERS_GET_STATE" },
 
-    { "THREAD_COUNTERS_GET", 0, "",
-      FuncTHREAD_COUNTERS_GET, "src/threadapi.c:THREAD_COUNTERS_GET" },
+    { "THREAD_COUNTERS_GET", 0, "", FuncTHREAD_COUNTERS_GET,
+      "src/threadapi.c:THREAD_COUNTERS_GET" },
 
-    { "THREAD_COUNTERS_RESET", 0, "",
-      FuncTHREAD_COUNTERS_RESET, "src/threadapi.c:THREAD_COUNTERS_RESET" },
+    { "THREAD_COUNTERS_RESET", 0, "", FuncTHREAD_COUNTERS_RESET,
+      "src/threadapi.c:THREAD_COUNTERS_RESET" },
 
     { 0, 0, 0, 0, 0 }
 
@@ -1286,32 +1299,32 @@ Obj TYPE_REGION;
 
 Obj TypeThread(Obj obj)
 {
-  return TYPE_THREAD;
+    return TYPE_THREAD;
 }
 
 Obj TypeSemaphore(Obj obj)
 {
-  return TYPE_SEMAPHORE;
+    return TYPE_SEMAPHORE;
 }
 
 Obj TypeChannel(Obj obj)
 {
-  return TYPE_CHANNEL;
+    return TYPE_CHANNEL;
 }
 
 Obj TypeBarrier(Obj obj)
 {
-  return TYPE_BARRIER;
+    return TYPE_BARRIER;
 }
 
 Obj TypeSyncVar(Obj obj)
 {
-  return TYPE_SYNCVAR;
+    return TYPE_SYNCVAR;
 }
 
 Obj TypeRegion(Obj obj)
 {
-  return TYPE_REGION;
+    return TYPE_REGION;
 }
 
 #ifndef BOEHM_GC
@@ -1343,24 +1356,23 @@ static UInt RNAM_SIGWINCH;
 **
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
 */
-static Int InitKernel (
-    StructInitInfo *    module )
+static Int InitKernel(StructInitInfo * module)
 {
-  /* install info string */
-  InfoBags[T_THREAD].name = "thread";
-  InfoBags[T_SEMAPHORE].name = "channel";
-  InfoBags[T_CHANNEL].name = "channel";
-  InfoBags[T_BARRIER].name = "barrier";
-  InfoBags[T_SYNCVAR].name = "syncvar";
-  InfoBags[T_REGION].name = "region";
+    /* install info string */
+    InfoBags[T_THREAD].name = "thread";
+    InfoBags[T_SEMAPHORE].name = "channel";
+    InfoBags[T_CHANNEL].name = "channel";
+    InfoBags[T_BARRIER].name = "barrier";
+    InfoBags[T_SYNCVAR].name = "syncvar";
+    InfoBags[T_REGION].name = "region";
 
     /* install the kind methods */
-    TypeObjFuncs[ T_THREAD ] = TypeThread;
-    TypeObjFuncs[ T_SEMAPHORE ] = TypeSemaphore;
-    TypeObjFuncs[ T_CHANNEL ] = TypeChannel;
-    TypeObjFuncs[ T_BARRIER ] = TypeBarrier;
-    TypeObjFuncs[ T_SYNCVAR ] = TypeSyncVar;
-    TypeObjFuncs[ T_REGION ] = TypeRegion;
+    TypeObjFuncs[T_THREAD] = TypeThread;
+    TypeObjFuncs[T_SEMAPHORE] = TypeSemaphore;
+    TypeObjFuncs[T_CHANNEL] = TypeChannel;
+    TypeObjFuncs[T_BARRIER] = TypeBarrier;
+    TypeObjFuncs[T_SYNCVAR] = TypeSyncVar;
+    TypeObjFuncs[T_REGION] = TypeRegion;
     /* install global variables */
     InitCopyGVar("TYPE_THREAD", &TYPE_THREAD);
     InitCopyGVar("TYPE_SEMAPHORE", &TYPE_SEMAPHORE);
@@ -1368,8 +1380,8 @@ static Int InitKernel (
     InitCopyGVar("TYPE_BARRIER", &TYPE_BARRIER);
     InitCopyGVar("TYPE_SYNCVAR", &TYPE_SYNCVAR);
     InitCopyGVar("TYPE_REGION", &TYPE_REGION);
-    DeclareGVar(&LastInaccessibleGVar,"LastInaccessible");
-    DeclareGVar(&MAX_INTERRUPTGVar,"MAX_INTERRUPT");
+    DeclareGVar(&LastInaccessibleGVar, "LastInaccessible");
+    DeclareGVar(&MAX_INTERRUPTGVar, "MAX_INTERRUPT");
     /* install mark functions */
     InitMarkFuncBags(T_THREAD, MarkNoSubBags);
 #ifndef BOEHM_GC
@@ -1382,19 +1394,19 @@ static Int InitKernel (
     InitMarkFuncBags(T_REGION, MarkAllSubBags);
     InitFinalizerFuncBags(T_MONITOR, FinalizeMonitor);
     /* install print functions */
-    PrintObjFuncs[ T_THREAD ] = PrintThread;
-    PrintObjFuncs[ T_SEMAPHORE ] = PrintSemaphore;
-    PrintObjFuncs[ T_CHANNEL ] = PrintChannel;
-    PrintObjFuncs[ T_BARRIER ] = PrintBarrier;
-    PrintObjFuncs[ T_SYNCVAR ] = PrintSyncVar;
-    PrintObjFuncs[ T_REGION ] = PrintRegion;
+    PrintObjFuncs[T_THREAD] = PrintThread;
+    PrintObjFuncs[T_SEMAPHORE] = PrintSemaphore;
+    PrintObjFuncs[T_CHANNEL] = PrintChannel;
+    PrintObjFuncs[T_BARRIER] = PrintBarrier;
+    PrintObjFuncs[T_SYNCVAR] = PrintSyncVar;
+    PrintObjFuncs[T_REGION] = PrintRegion;
     /* install mutability functions */
-    IsMutableObjFuncs [ T_THREAD ] = AlwaysNo;
-    IsMutableObjFuncs [ T_SEMAPHORE ] = AlwaysYes;
-    IsMutableObjFuncs [ T_CHANNEL ] = AlwaysYes;
-    IsMutableObjFuncs [ T_BARRIER ] = AlwaysYes;
-    IsMutableObjFuncs [ T_SYNCVAR ] = AlwaysYes;
-    IsMutableObjFuncs [ T_REGION ] = AlwaysYes;
+    IsMutableObjFuncs[T_THREAD] = AlwaysNo;
+    IsMutableObjFuncs[T_SEMAPHORE] = AlwaysYes;
+    IsMutableObjFuncs[T_CHANNEL] = AlwaysYes;
+    IsMutableObjFuncs[T_BARRIER] = AlwaysYes;
+    IsMutableObjFuncs[T_SYNCVAR] = AlwaysYes;
+    IsMutableObjFuncs[T_REGION] = AlwaysYes;
     MakeBagTypePublic(T_THREAD);
     MakeBagTypePublic(T_SEMAPHORE);
     MakeBagTypePublic(T_CHANNEL);
@@ -1411,13 +1423,12 @@ static Int InitKernel (
 **
 *F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
 */
-static Int InitLibrary (
-    StructInitInfo *    module )
+static Int InitLibrary(StructInitInfo * module)
 {
     extern pthread_mutex_t KeepAliveLock;
 
     /* init filters and functions                                          */
-    InitGVarFuncsFromTable( GVarFuncs );
+    InitGVarFuncsFromTable(GVarFuncs);
     SetGVar(&MAX_INTERRUPTGVar, INTOBJ_INT(MAX_INTERRUPT));
     MakeReadOnlyGVar(GVarName("MAX_INTERRUPT"));
     /* define signal handler values */
@@ -1449,21 +1460,21 @@ void DestroyThreadAPIState()
 *F  InitInfoThreadAPI() . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "threadapi",                        /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                         		/* postRestore                    */
+    MODULE_BUILTIN, /* type                           */
+    "threadapi",    /* name                           */
+    0,              /* revision entry of c file       */
+    0,              /* revision entry of h file       */
+    0,              /* version                        */
+    0,              /* crc                            */
+    InitKernel,     /* initKernel                     */
+    InitLibrary,    /* initLibrary                    */
+    0,              /* checkInit                      */
+    0,              /* preSave                        */
+    0,              /* postSave                       */
+    0               /* postRestore                    */
 };
 
-StructInitInfo * InitInfoThreadAPI ( void )
+StructInitInfo * InitInfoThreadAPI(void)
 {
     return &module;
 }
@@ -1471,1556 +1482,1593 @@ StructInitInfo * InitInfoThreadAPI ( void )
 #ifndef BOEHM_GC
 static void MarkSemaphoreBag(Bag bag)
 {
-  Semaphore *sem = (Semaphore *)(PTR_BAG(bag));
-  MarkBag(sem->monitor);
+    Semaphore * sem = (Semaphore *)(PTR_BAG(bag));
+    MarkBag(sem->monitor);
 }
 
 static void MarkChannelBag(Bag bag)
 {
-  Channel *channel = (Channel *)(PTR_BAG(bag));
-  MarkBag(channel->queue);
-  MarkBag(channel->monitor);
+    Channel * channel = (Channel *)(PTR_BAG(bag));
+    MarkBag(channel->queue);
+    MarkBag(channel->monitor);
 }
 
 static void MarkBarrierBag(Bag bag)
 {
-  Barrier *barrier = (Barrier *)(PTR_BAG(bag));
-  MarkBag(barrier->monitor);
+    Barrier * barrier = (Barrier *)(PTR_BAG(bag));
+    MarkBag(barrier->monitor);
 }
 
 static void MarkSyncVarBag(Bag bag)
 {
-  SyncVar *syncvar = (SyncVar *)(PTR_BAG(bag));
-  MarkBag(syncvar->queue);
-  MarkBag(syncvar->monitor);
+    SyncVar * syncvar = (SyncVar *)(PTR_BAG(bag));
+    MarkBag(syncvar->queue);
+    MarkBag(syncvar->monitor);
 }
 #endif
 
 static void FinalizeMonitor(Bag bag)
 {
-  Monitor *monitor = (Monitor *)(PTR_BAG(bag));
-  pthread_mutex_destroy(&monitor->lock);
+    Monitor * monitor = (Monitor *)(PTR_BAG(bag));
+    pthread_mutex_destroy(&monitor->lock);
 }
 
-static void LockChannel(Channel *channel)
+static void LockChannel(Channel * channel)
 {
-  LockMonitor(ObjPtr(channel->monitor));
+    LockMonitor(ObjPtr(channel->monitor));
 }
 
-static void UnlockChannel(Channel *channel)
+static void UnlockChannel(Channel * channel)
 {
-  UnlockMonitor(ObjPtr(channel->monitor));
+    UnlockMonitor(ObjPtr(channel->monitor));
 }
 
-static void SignalChannel(Channel *channel)
+static void SignalChannel(Channel * channel)
 {
-  if (channel->waiting)
-    SignalMonitor(ObjPtr(channel->monitor));
+    if (channel->waiting)
+        SignalMonitor(ObjPtr(channel->monitor));
 }
 
-static void WaitChannel(Channel *channel)
+static void WaitChannel(Channel * channel)
 {
-  channel->waiting++;
-  WaitForMonitor(ObjPtr(channel->monitor));
-  channel->waiting--;
+    channel->waiting++;
+    WaitForMonitor(ObjPtr(channel->monitor));
+    channel->waiting--;
 }
 
 #ifndef WARD_ENABLED
-static void ExpandChannel(Channel *channel)
+static void ExpandChannel(Channel * channel)
 {
-  /* Growth ratio should be less than the golden ratio */
-  UInt oldCapacity = channel->capacity;
-  UInt newCapacity = ((oldCapacity * 25 / 16) | 1) + 1;
-  UInt i, tail;
-  Obj newqueue;
-  if (newCapacity == oldCapacity)
-    newCapacity+=2;
-  newqueue = NEW_PLIST(T_PLIST, newCapacity);
-  SET_LEN_PLIST(newqueue, newCapacity);
-  REGION(newqueue) = REGION(channel->queue);
-  channel->capacity = newCapacity;
-  /* assert(channel->head == channel->tail); */
-  for (i = channel->head; i < oldCapacity; i++)
-    ADDR_OBJ(newqueue)[i+1] = ADDR_OBJ(channel->queue)[i+1];
-  for (i = 0; i < channel->tail; i++)
-  {
-    UInt d = oldCapacity+i;
-    if (d >= newCapacity)
-      d -= newCapacity;
-    ADDR_OBJ(newqueue)[d+1] = ADDR_OBJ(channel->queue)[i+1];
-  }
-  tail = channel->head + oldCapacity;
-  if (tail >= newCapacity)
-    tail -= newCapacity;
-  channel->tail = tail;
-  channel->queue = newqueue;
+    /* Growth ratio should be less than the golden ratio */
+    UInt oldCapacity = channel->capacity;
+    UInt newCapacity = ((oldCapacity * 25 / 16) | 1) + 1;
+    UInt i, tail;
+    Obj  newqueue;
+    if (newCapacity == oldCapacity)
+        newCapacity += 2;
+    newqueue = NEW_PLIST(T_PLIST, newCapacity);
+    SET_LEN_PLIST(newqueue, newCapacity);
+    REGION(newqueue) = REGION(channel->queue);
+    channel->capacity = newCapacity;
+    /* assert(channel->head == channel->tail); */
+    for (i = channel->head; i < oldCapacity; i++)
+        ADDR_OBJ(newqueue)[i + 1] = ADDR_OBJ(channel->queue)[i + 1];
+    for (i = 0; i < channel->tail; i++) {
+        UInt d = oldCapacity + i;
+        if (d >= newCapacity)
+            d -= newCapacity;
+        ADDR_OBJ(newqueue)[d + 1] = ADDR_OBJ(channel->queue)[i + 1];
+    }
+    tail = channel->head + oldCapacity;
+    if (tail >= newCapacity)
+        tail -= newCapacity;
+    channel->tail = tail;
+    channel->queue = newqueue;
 }
 
-static void AddToChannel(Channel *channel, Obj obj, int migrate)
+static void AddToChannel(Channel * channel, Obj obj, int migrate)
 {
-  Obj children;
-  Region *region = REGION(channel->queue);
-  UInt i, len;
-  if (migrate && IS_BAG_REF(obj) &&
-      REGION(obj) && REGION(obj)->owner == realTLS && REGION(obj)->fixed_owner) {
-    children = ReachableObjectsFrom(obj);
-    len = children ? LEN_PLIST(children) : 0;
-  } else {
-    children = 0;
-    len = 0;
-  }
-  for (i=1; i<= len; i++) {
-    Obj item = ELM_PLIST(children, i);
-    REGION(item) = region;
-  }
-  ADDR_OBJ(channel->queue)[++channel->tail] = obj;
-  ADDR_OBJ(channel->queue)[++channel->tail] = children;
-  if (channel->tail == channel->capacity)
-    channel->tail = 0;
-  channel->size += 2;
+    Obj      children;
+    Region * region = REGION(channel->queue);
+    UInt     i, len;
+    if (migrate && IS_BAG_REF(obj) && REGION(obj) &&
+        REGION(obj)->owner == realTLS && REGION(obj)->fixed_owner) {
+        children = ReachableObjectsFrom(obj);
+        len = children ? LEN_PLIST(children) : 0;
+    }
+    else {
+        children = 0;
+        len = 0;
+    }
+    for (i = 1; i <= len; i++) {
+        Obj item = ELM_PLIST(children, i);
+        REGION(item) = region;
+    }
+    ADDR_OBJ(channel->queue)[++channel->tail] = obj;
+    ADDR_OBJ(channel->queue)[++channel->tail] = children;
+    if (channel->tail == channel->capacity)
+        channel->tail = 0;
+    channel->size += 2;
 }
 
-static Obj RetrieveFromChannel(Channel *channel)
+static Obj RetrieveFromChannel(Channel * channel)
 {
-  Obj obj = ADDR_OBJ(channel->queue)[++channel->head];
-  Obj children = ADDR_OBJ(channel->queue)[++channel->head];
-  Region *region = TLS(currentRegion);
-  UInt i, len = children ? LEN_PLIST(children) : 0;
-  ADDR_OBJ(channel->queue)[channel->head-1] = 0;
-  ADDR_OBJ(channel->queue)[channel->head] = 0;
-  if (channel->head == channel->capacity)
-    channel->head = 0;
-  for (i=1; i<= len; i++) {
-    Obj item = ELM_PLIST(children, i);
-    REGION(item) = region;
-  }
-  channel->size -= 2;
-  return obj;
+    Obj      obj = ADDR_OBJ(channel->queue)[++channel->head];
+    Obj      children = ADDR_OBJ(channel->queue)[++channel->head];
+    Region * region = TLS(currentRegion);
+    UInt     i, len = children ? LEN_PLIST(children) : 0;
+    ADDR_OBJ(channel->queue)[channel->head - 1] = 0;
+    ADDR_OBJ(channel->queue)[channel->head] = 0;
+    if (channel->head == channel->capacity)
+        channel->head = 0;
+    for (i = 1; i <= len; i++) {
+        Obj item = ELM_PLIST(children, i);
+        REGION(item) = region;
+    }
+    channel->size -= 2;
+    return obj;
 }
 #endif
 
-static Int TallyChannel(Channel *channel)
+static Int TallyChannel(Channel * channel)
 {
-  Int result;
-  LockChannel(channel);
-  result = channel->size/2;
-  UnlockChannel(channel);
-  return result;
-}
-
-static void SendChannel(Channel *channel, Obj obj)
-{
-  LockChannel(channel);
-  if (channel->size == channel->capacity && channel->dynamic)
-    ExpandChannel(channel);
-  while (channel->size == channel->capacity)
-    WaitChannel(channel);
-  AddToChannel(channel, obj, 1);
-  SignalChannel(channel);
-  UnlockChannel(channel);
-}
-
-static void TransmitChannel(Channel *channel, Obj obj)
-{
-  LockChannel(channel);
-  if (channel->size == channel->capacity && channel->dynamic)
-    ExpandChannel(channel);
-  while (channel->size == channel->capacity)
-    WaitChannel(channel);
-  AddToChannel(channel, obj, 0);
-  SignalChannel(channel);
-  UnlockChannel(channel);
-}
-
-
-static void MultiSendChannel(Channel *channel, Obj list)
-{
-  int listsize = LEN_LIST(list);
-  int i;
-  Obj obj;
-  LockChannel(channel);
-  for (i = 1; i <= listsize; i++)
-  {
-    if (channel->size == channel->capacity && channel->dynamic)
-      ExpandChannel(channel);
-    while (channel->size == channel->capacity)
-      WaitChannel(channel);
-    obj = ELM_LIST(list, i);
-    AddToChannel(channel, obj, 1);
-  }
-  SignalChannel(channel);
-  UnlockChannel(channel);
-}
-
-static void MultiTransmitChannel(Channel *channel, Obj list)
-{
-  int listsize = LEN_LIST(list);
-  int i;
-  Obj obj;
-  LockChannel(channel);
-  for (i = 1; i <= listsize; i++)
-  {
-    if (channel->size == channel->capacity && channel->dynamic)
-      ExpandChannel(channel);
-    while (channel->size == channel->capacity)
-      WaitChannel(channel);
-    obj = ELM_LIST(list, i);
-    AddToChannel(channel, obj, 0);
-  }
-  SignalChannel(channel);
-  UnlockChannel(channel);
-}
-
-static int TryMultiSendChannel(Channel *channel, Obj list)
-{
-  int result = 0;
-  int listsize = LEN_LIST(list);
-  int i;
-  Obj obj;
-  LockChannel(channel);
-  for (i = 1; i <= listsize; i++)
-  {
-    if (channel->size == channel->capacity && channel->dynamic)
-      ExpandChannel(channel);
-    if (channel->size == channel->capacity)
-      break;
-    obj = ELM_LIST(list, i);
-    AddToChannel(channel, obj, 1);
-    result++;
-  }
-  SignalChannel(channel);
-  UnlockChannel(channel);
-  return result;
-}
-
-static int TryMultiTransmitChannel(Channel *channel, Obj list)
-{
-  int result = 0;
-  int listsize = LEN_LIST(list);
-  int i;
-  Obj obj;
-  LockChannel(channel);
-  for (i = 1; i <= listsize; i++)
-  {
-    if (channel->size == channel->capacity && channel->dynamic)
-      ExpandChannel(channel);
-    if (channel->size == channel->capacity)
-      break;
-    obj = ELM_LIST(list, i);
-    AddToChannel(channel, obj, 0);
-    result++;
-  }
-  SignalChannel(channel);
-  UnlockChannel(channel);
-  return result;
-}
-
-static int TrySendChannel(Channel *channel, Obj obj)
-{
-  LockChannel(channel);
-  if (channel->size == channel->capacity && channel->dynamic)
-    ExpandChannel(channel);
-  if (channel->size == channel->capacity)
-  {
+    Int result;
+    LockChannel(channel);
+    result = channel->size / 2;
     UnlockChannel(channel);
-    return 0;
-  }
-  AddToChannel(channel, obj, 1);
-  SignalChannel(channel);
-  UnlockChannel(channel);
-  return 1;
+    return result;
 }
 
-static int TryTransmitChannel(Channel *channel, Obj obj)
+static void SendChannel(Channel * channel, Obj obj)
 {
-  LockChannel(channel);
-  if (channel->size == channel->capacity && channel->dynamic)
-    ExpandChannel(channel);
-  if (channel->size == channel->capacity)
-  {
+    LockChannel(channel);
+    if (channel->size == channel->capacity && channel->dynamic)
+        ExpandChannel(channel);
+    while (channel->size == channel->capacity)
+        WaitChannel(channel);
+    AddToChannel(channel, obj, 1);
+    SignalChannel(channel);
     UnlockChannel(channel);
-    return 0;
-  }
-  AddToChannel(channel, obj, 0);
-  SignalChannel(channel);
-  UnlockChannel(channel);
-  return 1;
 }
 
-static Obj ReceiveChannel(Channel *channel)
+static void TransmitChannel(Channel * channel, Obj obj)
 {
-  Obj result;
-  LockChannel(channel);
-  while (channel->size == 0)
-    WaitChannel(channel);
-  result = RetrieveFromChannel(channel);
-  SignalChannel(channel);
-  UnlockChannel(channel);
-  return result;
+    LockChannel(channel);
+    if (channel->size == channel->capacity && channel->dynamic)
+        ExpandChannel(channel);
+    while (channel->size == channel->capacity)
+        WaitChannel(channel);
+    AddToChannel(channel, obj, 0);
+    SignalChannel(channel);
+    UnlockChannel(channel);
+}
+
+
+static void MultiSendChannel(Channel * channel, Obj list)
+{
+    int listsize = LEN_LIST(list);
+    int i;
+    Obj obj;
+    LockChannel(channel);
+    for (i = 1; i <= listsize; i++) {
+        if (channel->size == channel->capacity && channel->dynamic)
+            ExpandChannel(channel);
+        while (channel->size == channel->capacity)
+            WaitChannel(channel);
+        obj = ELM_LIST(list, i);
+        AddToChannel(channel, obj, 1);
+    }
+    SignalChannel(channel);
+    UnlockChannel(channel);
+}
+
+static void MultiTransmitChannel(Channel * channel, Obj list)
+{
+    int listsize = LEN_LIST(list);
+    int i;
+    Obj obj;
+    LockChannel(channel);
+    for (i = 1; i <= listsize; i++) {
+        if (channel->size == channel->capacity && channel->dynamic)
+            ExpandChannel(channel);
+        while (channel->size == channel->capacity)
+            WaitChannel(channel);
+        obj = ELM_LIST(list, i);
+        AddToChannel(channel, obj, 0);
+    }
+    SignalChannel(channel);
+    UnlockChannel(channel);
+}
+
+static int TryMultiSendChannel(Channel * channel, Obj list)
+{
+    int result = 0;
+    int listsize = LEN_LIST(list);
+    int i;
+    Obj obj;
+    LockChannel(channel);
+    for (i = 1; i <= listsize; i++) {
+        if (channel->size == channel->capacity && channel->dynamic)
+            ExpandChannel(channel);
+        if (channel->size == channel->capacity)
+            break;
+        obj = ELM_LIST(list, i);
+        AddToChannel(channel, obj, 1);
+        result++;
+    }
+    SignalChannel(channel);
+    UnlockChannel(channel);
+    return result;
+}
+
+static int TryMultiTransmitChannel(Channel * channel, Obj list)
+{
+    int result = 0;
+    int listsize = LEN_LIST(list);
+    int i;
+    Obj obj;
+    LockChannel(channel);
+    for (i = 1; i <= listsize; i++) {
+        if (channel->size == channel->capacity && channel->dynamic)
+            ExpandChannel(channel);
+        if (channel->size == channel->capacity)
+            break;
+        obj = ELM_LIST(list, i);
+        AddToChannel(channel, obj, 0);
+        result++;
+    }
+    SignalChannel(channel);
+    UnlockChannel(channel);
+    return result;
+}
+
+static int TrySendChannel(Channel * channel, Obj obj)
+{
+    LockChannel(channel);
+    if (channel->size == channel->capacity && channel->dynamic)
+        ExpandChannel(channel);
+    if (channel->size == channel->capacity) {
+        UnlockChannel(channel);
+        return 0;
+    }
+    AddToChannel(channel, obj, 1);
+    SignalChannel(channel);
+    UnlockChannel(channel);
+    return 1;
+}
+
+static int TryTransmitChannel(Channel * channel, Obj obj)
+{
+    LockChannel(channel);
+    if (channel->size == channel->capacity && channel->dynamic)
+        ExpandChannel(channel);
+    if (channel->size == channel->capacity) {
+        UnlockChannel(channel);
+        return 0;
+    }
+    AddToChannel(channel, obj, 0);
+    SignalChannel(channel);
+    UnlockChannel(channel);
+    return 1;
+}
+
+static Obj ReceiveChannel(Channel * channel)
+{
+    Obj result;
+    LockChannel(channel);
+    while (channel->size == 0)
+        WaitChannel(channel);
+    result = RetrieveFromChannel(channel);
+    SignalChannel(channel);
+    UnlockChannel(channel);
+    return result;
 }
 
 static Obj ReceiveAnyChannel(Obj channelList, int with_index)
 {
-  UInt count = LEN_PLIST(channelList);
-  UInt i, p;
-  Monitor **monitors = alloca(count * sizeof(Monitor *));
-  Channel **channels = alloca(count * sizeof(Channel *));
-  Obj result;
-  Channel *channel;
-  for (i = 0; i<count; i++)
-    channels[i] = ObjPtr(ELM_PLIST(channelList, i+1));
-  SortChannels(count, channels);
-  for (i = 0; i<count; i++)
-    monitors[i] = ObjPtr(channels[i]->monitor);
-  LockMonitors(count, monitors);
-  p = TLS(multiplexRandomSeed);
-  p = (p * 5 + 1);
-  TLS(multiplexRandomSeed) = p;
-  p %= count;
-  for (i=0; i<count; i++)
-  {
-    channel = channels[p];
-    if (channel->size > 0)
-      break;
-    p++;
-    if (p >= count)
-      p = 0;
-  }
-  if (i < count) /* found a channel with data */
-  {
-    p = i;
-    for (i=0; i<count; i++)
-      if (i != p)
-        UnlockMonitor(monitors[i]);
-  }
-  else /* all channels are empty */
-    for (;;)
-    {
-      for (i=0; i<count; i++)
-        channels[i]->waiting++;
-      p = WaitForAnyMonitor(count, monitors);
-      for (i=0; i<count; i++)
-        channels[i]->waiting--;
-      channel = channels[p];
-      if (channel->size > 0)
-	break;
-      UnlockMonitor(monitors[p]);
-      LockMonitors(count, monitors);
+    UInt       count = LEN_PLIST(channelList);
+    UInt       i, p;
+    Monitor ** monitors = alloca(count * sizeof(Monitor *));
+    Channel ** channels = alloca(count * sizeof(Channel *));
+    Obj        result;
+    Channel *  channel;
+    for (i = 0; i < count; i++)
+        channels[i] = ObjPtr(ELM_PLIST(channelList, i + 1));
+    SortChannels(count, channels);
+    for (i = 0; i < count; i++)
+        monitors[i] = ObjPtr(channels[i]->monitor);
+    LockMonitors(count, monitors);
+    p = TLS(multiplexRandomSeed);
+    p = (p * 5 + 1);
+    TLS(multiplexRandomSeed) = p;
+    p %= count;
+    for (i = 0; i < count; i++) {
+        channel = channels[p];
+        if (channel->size > 0)
+            break;
+        p++;
+        if (p >= count)
+            p = 0;
     }
-  result = RetrieveFromChannel(channel);
-  SignalChannel(channel);
-  UnlockMonitor(monitors[p]);
-  if (with_index)
-  {
-    Obj list = NEW_PLIST(T_PLIST, 2);
-    SET_LEN_PLIST(list, 2);
-    SET_ELM_PLIST(list, 1, result);
-    for (i=1; i<=count; i++)
-      if (ObjPtr(ELM_PLIST(channelList, i)) == channel) {
-        SET_ELM_PLIST(list, 2, INTOBJ_INT(i));
-	break;
-      }
-    return list;
-  }
-  else
+    if (i < count) /* found a channel with data */
+    {
+        p = i;
+        for (i = 0; i < count; i++)
+            if (i != p)
+                UnlockMonitor(monitors[i]);
+    }
+    else /* all channels are empty */
+        for (;;) {
+            for (i = 0; i < count; i++)
+                channels[i]->waiting++;
+            p = WaitForAnyMonitor(count, monitors);
+            for (i = 0; i < count; i++)
+                channels[i]->waiting--;
+            channel = channels[p];
+            if (channel->size > 0)
+                break;
+            UnlockMonitor(monitors[p]);
+            LockMonitors(count, monitors);
+        }
+    result = RetrieveFromChannel(channel);
+    SignalChannel(channel);
+    UnlockMonitor(monitors[p]);
+    if (with_index) {
+        Obj list = NEW_PLIST(T_PLIST, 2);
+        SET_LEN_PLIST(list, 2);
+        SET_ELM_PLIST(list, 1, result);
+        for (i = 1; i <= count; i++)
+            if (ObjPtr(ELM_PLIST(channelList, i)) == channel) {
+                SET_ELM_PLIST(list, 2, INTOBJ_INT(i));
+                break;
+            }
+        return list;
+    }
+    else
+        return result;
+}
+
+static Obj MultiReceiveChannel(Channel * channel, UInt max)
+{
+    Obj  result;
+    UInt count;
+    UInt i;
+    LockChannel(channel);
+    if (max > channel->size / 2)
+        count = channel->size / 2;
+    else
+        count = max;
+    result = NEW_PLIST(T_PLIST, count);
+    SET_LEN_PLIST(result, count);
+    for (i = 0; i < count; i++) {
+        Obj item = RetrieveFromChannel(channel);
+        SET_ELM_PLIST(result, i + 1, item);
+    }
+    SignalChannel(channel);
+    UnlockChannel(channel);
     return result;
 }
 
-static Obj MultiReceiveChannel(Channel *channel, UInt max)
+static Obj InspectChannel(Channel * channel)
 {
-  Obj result;
-  UInt count;
-  UInt i;
-  LockChannel(channel);
-  if (max > channel->size/2)
-    count = channel->size/2;
-  else
-    count = max;
-  result = NEW_PLIST(T_PLIST, count);
-  SET_LEN_PLIST(result, count);
-  for (i=0; i<count; i++)
-  {
-    Obj item = RetrieveFromChannel(channel);
-    SET_ELM_PLIST(result, i+1, item);
-  }
-  SignalChannel(channel);
-  UnlockChannel(channel);
-  return result;
-}
-
-static Obj InspectChannel(Channel *channel)
-{
-  Obj result;
-  int i, p;
-  LockChannel(channel);
-  result = NEW_PLIST(T_PLIST, channel->size/2);
-  SET_LEN_PLIST(result, channel->size/2);
-  for (i = 0, p = channel->head; i < channel->size; i++) {
-    SET_ELM_PLIST(result, i+1, ELM_PLIST(channel->queue, p+1));
-    p+=2;
-    if (p == channel->capacity)
-      p = 0;
-  }
-  UnlockChannel(channel);
-  return result;
-}
-
-static Obj TryReceiveChannel(Channel *channel, Obj defaultobj)
-{
-  Obj result;
-  LockChannel(channel);
-  if (channel->size == 0)
-  {
+    Obj result;
+    int i, p;
+    LockChannel(channel);
+    result = NEW_PLIST(T_PLIST, channel->size / 2);
+    SET_LEN_PLIST(result, channel->size / 2);
+    for (i = 0, p = channel->head; i < channel->size; i++) {
+        SET_ELM_PLIST(result, i + 1, ELM_PLIST(channel->queue, p + 1));
+        p += 2;
+        if (p == channel->capacity)
+            p = 0;
+    }
     UnlockChannel(channel);
-    return defaultobj;
-  }
-  result = RetrieveFromChannel(channel);
-  SignalChannel(channel);
-  UnlockChannel(channel);
-  return result;
+    return result;
+}
+
+static Obj TryReceiveChannel(Channel * channel, Obj defaultobj)
+{
+    Obj result;
+    LockChannel(channel);
+    if (channel->size == 0) {
+        UnlockChannel(channel);
+        return defaultobj;
+    }
+    result = RetrieveFromChannel(channel);
+    SignalChannel(channel);
+    UnlockChannel(channel);
+    return result;
 }
 
 static Obj CreateChannel(int capacity)
 {
-  Channel *channel;
-  Bag channelBag;
-  channelBag = NewBag(T_CHANNEL, sizeof(Channel));
-  channel = ObjPtr(channelBag);
-  channel->monitor = NewMonitor();
-  channel->size = channel->head = channel->tail = 0;
-  channel->capacity = (capacity < 0) ? 20 : capacity * 2;
-  channel->dynamic = (capacity < 0);
-  channel->waiting = 0;
-  channel->queue = NEW_PLIST( T_PLIST, channel->capacity);
-  REGION(channel->queue) = LimboRegion;
-  SET_LEN_PLIST(channel->queue, channel->capacity);
-  return channelBag;
+    Channel * channel;
+    Bag       channelBag;
+    channelBag = NewBag(T_CHANNEL, sizeof(Channel));
+    channel = ObjPtr(channelBag);
+    channel->monitor = NewMonitor();
+    channel->size = channel->head = channel->tail = 0;
+    channel->capacity = (capacity < 0) ? 20 : capacity * 2;
+    channel->dynamic = (capacity < 0);
+    channel->waiting = 0;
+    channel->queue = NEW_PLIST(T_PLIST, channel->capacity);
+    REGION(channel->queue) = LimboRegion;
+    SET_LEN_PLIST(channel->queue, channel->capacity);
+    return channelBag;
 }
 
-static int DestroyChannel(Channel *channel)
+static int DestroyChannel(Channel * channel)
 {
-  return 1;
+    return 1;
 }
 
 Obj FuncCreateChannel(Obj self, Obj args)
 {
-  int capacity;
-  switch (LEN_PLIST(args))
-  {
+    int capacity;
+    switch (LEN_PLIST(args)) {
     case 0:
-      capacity = -1;
-      break;
+        capacity = -1;
+        break;
     case 1:
-      if (IS_INTOBJ(ELM_PLIST(args, 1)))
-      {
-	capacity = INT_INTOBJ(ELM_PLIST(args, 1));
-	if (capacity <= 0)
-	  return ArgumentError("CreateChannel: Capacity must be positive");
-	break;
-      }
-      return ArgumentError("CreateChannel: Argument must be capacity of the channel");
+        if (IS_INTOBJ(ELM_PLIST(args, 1))) {
+            capacity = INT_INTOBJ(ELM_PLIST(args, 1));
+            if (capacity <= 0)
+                return ArgumentError(
+                    "CreateChannel: Capacity must be positive");
+            break;
+        }
+        return ArgumentError(
+            "CreateChannel: Argument must be capacity of the channel");
     default:
-      return ArgumentError("CreateChannel: Function takes up to two arguments");
-  }
-  return CreateChannel(capacity);
+        return ArgumentError(
+            "CreateChannel: Function takes up to two arguments");
+    }
+    return CreateChannel(capacity);
 }
 
 static int IsChannel(Obj obj)
 {
-  return obj && TNUM_OBJ(obj) == T_CHANNEL;
+    return obj && TNUM_OBJ(obj) == T_CHANNEL;
 }
 
 Obj FuncDestroyChannel(Obj self, Obj channel)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("DestroyChannel: Argument is not a channel");
-  if (!DestroyChannel(ObjPtr(channel)))
-    return ArgumentError("DestroyChannel: Channel is in use");
-  return (Obj) 0;
+    if (!IsChannel(channel))
+        return ArgumentError("DestroyChannel: Argument is not a channel");
+    if (!DestroyChannel(ObjPtr(channel)))
+        return ArgumentError("DestroyChannel: Channel is in use");
+    return (Obj)0;
 }
 
 Obj FuncTallyChannel(Obj self, Obj channel)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("TallyChannel: First argument must be a channel");
-  return INTOBJ_INT(TallyChannel(ObjPtr(channel)));
+    if (!IsChannel(channel))
+        return ArgumentError(
+            "TallyChannel: First argument must be a channel");
+    return INTOBJ_INT(TallyChannel(ObjPtr(channel)));
 }
 
 Obj FuncSendChannel(Obj self, Obj channel, Obj obj)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("SendChannel: First argument must be a channel");
-  SendChannel(ObjPtr(channel), obj);
-  return (Obj) 0;
+    if (!IsChannel(channel))
+        return ArgumentError("SendChannel: First argument must be a channel");
+    SendChannel(ObjPtr(channel), obj);
+    return (Obj)0;
 }
 
 Obj FuncTransmitChannel(Obj self, Obj channel, Obj obj)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("TransmitChannel: First argument must be a channel");
-  TransmitChannel(ObjPtr(channel), obj);
-  return (Obj) 0;
+    if (!IsChannel(channel))
+        return ArgumentError(
+            "TransmitChannel: First argument must be a channel");
+    TransmitChannel(ObjPtr(channel), obj);
+    return (Obj)0;
 }
 
 Obj FuncMultiSendChannel(Obj self, Obj channel, Obj list)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("MultiSendChannel: First argument must be a channel");
-  if (!IS_DENSE_LIST(list))
-    return ArgumentError("MultiSendChannel: Second argument must be a dense list");
-  MultiSendChannel(ObjPtr(channel), list);
-  return (Obj) 0;
+    if (!IsChannel(channel))
+        return ArgumentError(
+            "MultiSendChannel: First argument must be a channel");
+    if (!IS_DENSE_LIST(list))
+        return ArgumentError(
+            "MultiSendChannel: Second argument must be a dense list");
+    MultiSendChannel(ObjPtr(channel), list);
+    return (Obj)0;
 }
 
 Obj FuncMultiTransmitChannel(Obj self, Obj channel, Obj list)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("MultiTransmitChannel: First argument must be a channel");
-  if (!IS_DENSE_LIST(list))
-    return ArgumentError("MultiTransmitChannel: Second argument must be a dense list");
-  MultiTransmitChannel(ObjPtr(channel), list);
-  return (Obj) 0;
+    if (!IsChannel(channel))
+        return ArgumentError(
+            "MultiTransmitChannel: First argument must be a channel");
+    if (!IS_DENSE_LIST(list))
+        return ArgumentError(
+            "MultiTransmitChannel: Second argument must be a dense list");
+    MultiTransmitChannel(ObjPtr(channel), list);
+    return (Obj)0;
 }
 
 Obj FuncTryMultiSendChannel(Obj self, Obj channel, Obj list)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("TryMultiSendChannel: First argument must be a channel");
-  if (!IS_DENSE_LIST(list))
-    return ArgumentError("TryMultiSendChannel: Second argument must be a dense list");
-  return INTOBJ_INT(TryMultiSendChannel(ObjPtr(channel), list));
+    if (!IsChannel(channel))
+        return ArgumentError(
+            "TryMultiSendChannel: First argument must be a channel");
+    if (!IS_DENSE_LIST(list))
+        return ArgumentError(
+            "TryMultiSendChannel: Second argument must be a dense list");
+    return INTOBJ_INT(TryMultiSendChannel(ObjPtr(channel), list));
 }
 
 
 Obj FuncTryMultiTransmitChannel(Obj self, Obj channel, Obj list)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("TryMultiTransmitChannel: First argument must be a channel");
-  if (!IS_DENSE_LIST(list))
-    return ArgumentError("TryMultiTransmitChannel: Second argument must be a dense list");
-  return INTOBJ_INT(TryMultiTransmitChannel(ObjPtr(channel), list));
+    if (!IsChannel(channel))
+        return ArgumentError(
+            "TryMultiTransmitChannel: First argument must be a channel");
+    if (!IS_DENSE_LIST(list))
+        return ArgumentError(
+            "TryMultiTransmitChannel: Second argument must be a dense list");
+    return INTOBJ_INT(TryMultiTransmitChannel(ObjPtr(channel), list));
 }
 
 
 Obj FuncTrySendChannel(Obj self, Obj channel, Obj obj)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("TrySendChannel: Argument is not a channel");
-  return TrySendChannel(ObjPtr(channel), obj) ? True : False;
+    if (!IsChannel(channel))
+        return ArgumentError("TrySendChannel: Argument is not a channel");
+    return TrySendChannel(ObjPtr(channel), obj) ? True : False;
 }
 
 Obj FuncTryTransmitChannel(Obj self, Obj channel, Obj obj)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("TryTransmitChannel: Argument is not a channel");
-  return TryTransmitChannel(ObjPtr(channel), obj) ? True : False;
+    if (!IsChannel(channel))
+        return ArgumentError("TryTransmitChannel: Argument is not a channel");
+    return TryTransmitChannel(ObjPtr(channel), obj) ? True : False;
 }
 
 Obj FuncReceiveChannel(Obj self, Obj channel)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("ReceiveChannel: Argument is not a channel");
-  return ReceiveChannel(ObjPtr(channel));
+    if (!IsChannel(channel))
+        return ArgumentError("ReceiveChannel: Argument is not a channel");
+    return ReceiveChannel(ObjPtr(channel));
 }
 
 int IsChannelList(Obj list)
 {
-  int len = LEN_PLIST(list);
-  int i;
-  for (i=1; i<=len; i++)
-    if (!IsChannel(ELM_PLIST(list, i)))
-      return 0;
-  return 1;
+    int len = LEN_PLIST(list);
+    int i;
+    for (i = 1; i <= len; i++)
+        if (!IsChannel(ELM_PLIST(list, i)))
+            return 0;
+    return 1;
 }
 
 Obj FuncReceiveAnyChannel(Obj self, Obj args)
 {
-  if (IsChannelList(args))
-    return ReceiveAnyChannel(args, 0);
-  else
-  {
-    if (LEN_PLIST(args) == 1 && IS_PLIST(ELM_PLIST(args, 1))
-        && IsChannelList(ELM_PLIST(args, 1)))
-      return ReceiveAnyChannel(ELM_PLIST(args, 1), 0);
-    else
-      return ArgumentError("ReceiveAnyChannel: Argument list must be channels");
-  }
+    if (IsChannelList(args))
+        return ReceiveAnyChannel(args, 0);
+    else {
+        if (LEN_PLIST(args) == 1 && IS_PLIST(ELM_PLIST(args, 1)) &&
+            IsChannelList(ELM_PLIST(args, 1)))
+            return ReceiveAnyChannel(ELM_PLIST(args, 1), 0);
+        else
+            return ArgumentError(
+                "ReceiveAnyChannel: Argument list must be channels");
+    }
 }
 
 Obj FuncReceiveAnyChannelWithIndex(Obj self, Obj args)
 {
-  if (IsChannelList(args))
-    return ReceiveAnyChannel(args, 1);
-  else
-  {
-    if (LEN_PLIST(args) == 1 && IS_PLIST(ELM_PLIST(args, 1))
-        && IsChannelList(ELM_PLIST(args, 1)))
-      return ReceiveAnyChannel(ELM_PLIST(args, 1), 1);
-    else
-      return ArgumentError("ReceiveAnyChannel: Argument list must be channels");
-  }
+    if (IsChannelList(args))
+        return ReceiveAnyChannel(args, 1);
+    else {
+        if (LEN_PLIST(args) == 1 && IS_PLIST(ELM_PLIST(args, 1)) &&
+            IsChannelList(ELM_PLIST(args, 1)))
+            return ReceiveAnyChannel(ELM_PLIST(args, 1), 1);
+        else
+            return ArgumentError(
+                "ReceiveAnyChannel: Argument list must be channels");
+    }
 }
 
 Obj FuncMultiReceiveChannel(Obj self, Obj channel, Obj countobj)
 {
-  int count;
-  if (!IsChannel(channel))
-    return ArgumentError("MultiReceiveChannel: Argument is not a channel");
-  if (!IS_INTOBJ(countobj))
-    return ArgumentError("MultiReceiveChannel: Size must be a number");
-  count = INT_INTOBJ(countobj);
-  if (count < 0)
-    return ArgumentError("MultiReceiveChannel: Size must be non-negative");
-  return MultiReceiveChannel(ObjPtr(channel), count);
+    int count;
+    if (!IsChannel(channel))
+        return ArgumentError(
+            "MultiReceiveChannel: Argument is not a channel");
+    if (!IS_INTOBJ(countobj))
+        return ArgumentError("MultiReceiveChannel: Size must be a number");
+    count = INT_INTOBJ(countobj);
+    if (count < 0)
+        return ArgumentError(
+            "MultiReceiveChannel: Size must be non-negative");
+    return MultiReceiveChannel(ObjPtr(channel), count);
 }
 
 Obj FuncInspectChannel(Obj self, Obj channel)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("InspectChannel: Argument is not a channel");
-  return InspectChannel(ObjPtr(channel));
+    if (!IsChannel(channel))
+        return ArgumentError("InspectChannel: Argument is not a channel");
+    return InspectChannel(ObjPtr(channel));
 }
 
 Obj FuncTryReceiveChannel(Obj self, Obj channel, Obj obj)
 {
-  if (!IsChannel(channel))
-    return ArgumentError("TryReceiveChannel: Argument must be a channel");
-  return TryReceiveChannel(ObjPtr(channel), obj);
+    if (!IsChannel(channel))
+        return ArgumentError("TryReceiveChannel: Argument must be a channel");
+    return TryReceiveChannel(ObjPtr(channel), obj);
 }
 
 static Obj CreateSemaphore(UInt count)
 {
-  Semaphore *sem;
-  Bag semBag;
-  semBag = NewBag(T_SEMAPHORE, sizeof(Semaphore));
-  sem = ObjPtr(semBag);
-  sem->monitor = NewMonitor();
-  sem->count = count;
-  sem->waiting = 0;
-  return semBag;
+    Semaphore * sem;
+    Bag         semBag;
+    semBag = NewBag(T_SEMAPHORE, sizeof(Semaphore));
+    sem = ObjPtr(semBag);
+    sem->monitor = NewMonitor();
+    sem->count = count;
+    sem->waiting = 0;
+    return semBag;
 }
 
 Obj FuncCreateSemaphore(Obj self, Obj args)
 {
-  Int count;
-  switch (LEN_PLIST(args))
-  {
+    Int count;
+    switch (LEN_PLIST(args)) {
     case 0:
-      count = 0;
-      break;
+        count = 0;
+        break;
     case 1:
-      if (IS_INTOBJ(ELM_PLIST(args, 1)))
-      {
-	count = INT_INTOBJ(ELM_PLIST(args, 1));
-	if (count < 0)
-	  return ArgumentError("CreateSemaphore: Initial count must be non-negative");
-	break;
-      }
-      return ArgumentError("CreateSemaphore: Argument must be initial count");
+        if (IS_INTOBJ(ELM_PLIST(args, 1))) {
+            count = INT_INTOBJ(ELM_PLIST(args, 1));
+            if (count < 0)
+                return ArgumentError(
+                    "CreateSemaphore: Initial count must be non-negative");
+            break;
+        }
+        return ArgumentError(
+            "CreateSemaphore: Argument must be initial count");
     default:
-      return ArgumentError("CreateSemaphore: Function takes up to two arguments");
-  }
-  return CreateSemaphore(count);
+        return ArgumentError(
+            "CreateSemaphore: Function takes up to two arguments");
+    }
+    return CreateSemaphore(count);
 }
 
 Obj FuncSignalSemaphore(Obj self, Obj semaphore)
 {
-  Semaphore *sem;
-  if (TNUM_OBJ(semaphore) != T_SEMAPHORE)
-    return ArgumentError("SignalSemaphore: Argument must be a semaphore");
-  sem = ObjPtr(semaphore);
-  LockMonitor(ObjPtr(sem->monitor));
-  sem->count++;
-  if (sem->waiting)
-    SignalMonitor(ObjPtr(sem->monitor));
-  UnlockMonitor(ObjPtr(sem->monitor));
-  return (Obj) 0;
+    Semaphore * sem;
+    if (TNUM_OBJ(semaphore) != T_SEMAPHORE)
+        return ArgumentError("SignalSemaphore: Argument must be a semaphore");
+    sem = ObjPtr(semaphore);
+    LockMonitor(ObjPtr(sem->monitor));
+    sem->count++;
+    if (sem->waiting)
+        SignalMonitor(ObjPtr(sem->monitor));
+    UnlockMonitor(ObjPtr(sem->monitor));
+    return (Obj)0;
 }
 
 Obj FuncWaitSemaphore(Obj self, Obj semaphore)
 {
-  Semaphore *sem;
-  if (TNUM_OBJ(semaphore) != T_SEMAPHORE)
-    return ArgumentError("WaitSemaphore: Argument must be a semaphore");
-  sem = ObjPtr(semaphore);
-  LockMonitor(ObjPtr(sem->monitor));
-  sem->waiting++;
-  while (sem->count == 0)
-    WaitForMonitor(ObjPtr(sem->monitor));
-  sem->count--;
-  sem->waiting--;
-  if (sem->waiting && sem->count > 0)
-    SignalMonitor(ObjPtr(sem->monitor));
-  UnlockMonitor(ObjPtr(sem->monitor));
-  return (Obj) 0;
+    Semaphore * sem;
+    if (TNUM_OBJ(semaphore) != T_SEMAPHORE)
+        return ArgumentError("WaitSemaphore: Argument must be a semaphore");
+    sem = ObjPtr(semaphore);
+    LockMonitor(ObjPtr(sem->monitor));
+    sem->waiting++;
+    while (sem->count == 0)
+        WaitForMonitor(ObjPtr(sem->monitor));
+    sem->count--;
+    sem->waiting--;
+    if (sem->waiting && sem->count > 0)
+        SignalMonitor(ObjPtr(sem->monitor));
+    UnlockMonitor(ObjPtr(sem->monitor));
+    return (Obj)0;
 }
 
 Obj FuncTryWaitSemaphore(Obj self, Obj semaphore)
 {
-  Semaphore *sem;
-  int success;
-  if (TNUM_OBJ(semaphore) != T_SEMAPHORE)
-    return ArgumentError("WaitSemaphore: Argument must be a semaphore");
-  sem = ObjPtr(semaphore);
-  LockMonitor(ObjPtr(sem->monitor));
-  success = (sem->count > 0);
-  if (success)
-    sem->count--;
-  sem->waiting--;
-  if (sem->waiting && sem->count > 0)
-    SignalMonitor(ObjPtr(sem->monitor));
-  UnlockMonitor(ObjPtr(sem->monitor));
-  return success ? True: False;
+    Semaphore * sem;
+    int         success;
+    if (TNUM_OBJ(semaphore) != T_SEMAPHORE)
+        return ArgumentError("WaitSemaphore: Argument must be a semaphore");
+    sem = ObjPtr(semaphore);
+    LockMonitor(ObjPtr(sem->monitor));
+    success = (sem->count > 0);
+    if (success)
+        sem->count--;
+    sem->waiting--;
+    if (sem->waiting && sem->count > 0)
+        SignalMonitor(ObjPtr(sem->monitor));
+    UnlockMonitor(ObjPtr(sem->monitor));
+    return success ? True : False;
 }
 
-void LockBarrier(Barrier *barrier)
+void LockBarrier(Barrier * barrier)
 {
-  LockMonitor(ObjPtr(barrier->monitor));
+    LockMonitor(ObjPtr(barrier->monitor));
 }
 
-void UnlockBarrier(Barrier *barrier)
+void UnlockBarrier(Barrier * barrier)
 {
-  UnlockMonitor(ObjPtr(barrier->monitor));
+    UnlockMonitor(ObjPtr(barrier->monitor));
 }
 
-void JoinBarrier(Barrier *barrier)
+void JoinBarrier(Barrier * barrier)
 {
-  barrier->waiting++;
-  WaitForMonitor(ObjPtr(barrier->monitor));
-  barrier->waiting--;
+    barrier->waiting++;
+    WaitForMonitor(ObjPtr(barrier->monitor));
+    barrier->waiting--;
 }
 
-void SignalBarrier(Barrier *barrier)
+void SignalBarrier(Barrier * barrier)
 {
-  if (barrier->waiting)
-    SignalMonitor(ObjPtr(barrier->monitor));
+    if (barrier->waiting)
+        SignalMonitor(ObjPtr(barrier->monitor));
 }
 
 Obj CreateBarrier()
 {
-  Bag barrierBag;
-  Barrier *barrier;
-  barrierBag = NewBag(T_BARRIER, sizeof(Barrier));
-  barrier = ObjPtr(barrierBag);
-  barrier->monitor = NewMonitor();
-  barrier->count = 0;
-  barrier->phase = 0;
-  barrier->waiting = 0;
-  return barrierBag;
+    Bag       barrierBag;
+    Barrier * barrier;
+    barrierBag = NewBag(T_BARRIER, sizeof(Barrier));
+    barrier = ObjPtr(barrierBag);
+    barrier->monitor = NewMonitor();
+    barrier->count = 0;
+    barrier->phase = 0;
+    barrier->waiting = 0;
+    return barrierBag;
 }
 
-void StartBarrier(Barrier *barrier, UInt count)
+void StartBarrier(Barrier * barrier, UInt count)
 {
-  LockBarrier(barrier);
-  barrier->count = count;
-  barrier->phase++;
-  UnlockBarrier(barrier);
+    LockBarrier(barrier);
+    barrier->count = count;
+    barrier->phase++;
+    UnlockBarrier(barrier);
 }
 
-void WaitBarrier(Barrier *barrier)
+void WaitBarrier(Barrier * barrier)
 {
-  UInt phaseDelta;
-  LockBarrier(barrier);
-  phaseDelta = barrier->phase;
-  if (--barrier->count > 0)
-    JoinBarrier(barrier);
-  SignalBarrier(barrier);
-  phaseDelta -= barrier->phase;
-  UnlockBarrier(barrier);
-  if (phaseDelta != 0)
-    ArgumentError("WaitBarrier: Barrier was reset");
+    UInt phaseDelta;
+    LockBarrier(barrier);
+    phaseDelta = barrier->phase;
+    if (--barrier->count > 0)
+        JoinBarrier(barrier);
+    SignalBarrier(barrier);
+    phaseDelta -= barrier->phase;
+    UnlockBarrier(barrier);
+    if (phaseDelta != 0)
+        ArgumentError("WaitBarrier: Barrier was reset");
 }
 
 Obj FuncCreateBarrier(Obj self)
 {
-  return CreateBarrier();
+    return CreateBarrier();
 }
 
 Obj FuncDestroyBarrier(Obj self, Obj barrier)
 {
-  return (Obj) 0;
+    return (Obj)0;
 }
 
 int IsBarrier(Obj obj)
 {
-  return obj && TNUM_OBJ(obj) == T_BARRIER;
+    return obj && TNUM_OBJ(obj) == T_BARRIER;
 }
 
 Obj FuncStartBarrier(Obj self, Obj barrier, Obj count)
 {
-  if (!IsBarrier(barrier))
-    return ArgumentError("StartBarrier: First argument must be a barrier");
-  if (!IS_INTOBJ(count))
-    return ArgumentError("StartBarrier: Second argument must be the number of threads to synchronize");
-  StartBarrier(ObjPtr(barrier), INT_INTOBJ(count));
-  return (Obj) 0;
+    if (!IsBarrier(barrier))
+        return ArgumentError(
+            "StartBarrier: First argument must be a barrier");
+    if (!IS_INTOBJ(count))
+        return ArgumentError("StartBarrier: Second argument must be the "
+                             "number of threads to synchronize");
+    StartBarrier(ObjPtr(barrier), INT_INTOBJ(count));
+    return (Obj)0;
 }
 
 Obj FuncWaitBarrier(Obj self, Obj barrier)
 {
-  if (!IsBarrier(barrier))
-    return ArgumentError("StartBarrier: Argument must be a barrier");
-  WaitBarrier(ObjPtr(barrier));
-  return (Obj) 0;
+    if (!IsBarrier(barrier))
+        return ArgumentError("StartBarrier: Argument must be a barrier");
+    WaitBarrier(ObjPtr(barrier));
+    return (Obj)0;
 }
 
-void SyncWrite(SyncVar *var, Obj value)
+void SyncWrite(SyncVar * var, Obj value)
 {
-  Monitor *monitor = ObjPtr(var->monitor);
-  LockMonitor(monitor);
-  if (var->written)
-  {
+    Monitor * monitor = ObjPtr(var->monitor);
+    LockMonitor(monitor);
+    if (var->written) {
+        UnlockMonitor(monitor);
+        ArgumentError("SyncWrite: Variable already has a value");
+        return;
+    }
+    var->written = 1;
+    var->value = value;
+    SignalMonitor(monitor);
     UnlockMonitor(monitor);
-    ArgumentError("SyncWrite: Variable already has a value");
-    return;
-  }
-  var->written = 1;
-  var->value = value;
-  SignalMonitor(monitor);
-  UnlockMonitor(monitor);
 }
 
-int SyncTryWrite(SyncVar *var, Obj value)
+int SyncTryWrite(SyncVar * var, Obj value)
 {
-  Monitor *monitor = ObjPtr(var->monitor);
-  LockMonitor(monitor);
-  if (var->written)
-  {
+    Monitor * monitor = ObjPtr(var->monitor);
+    LockMonitor(monitor);
+    if (var->written) {
+        UnlockMonitor(monitor);
+        return 0;
+    }
+    var->written = 1;
+    var->value = value;
+    SignalMonitor(monitor);
     UnlockMonitor(monitor);
-    return 0;
-  }
-  var->written = 1;
-  var->value = value;
-  SignalMonitor(monitor);
-  UnlockMonitor(monitor);
-  return 1;
+    return 1;
 }
 
 Obj CreateSyncVar()
 {
-  Bag syncvarBag;
-  SyncVar *syncvar;
-  syncvarBag = NewBag(T_SYNCVAR, sizeof(SyncVar));
-  syncvar = ObjPtr(syncvarBag);
-  syncvar->monitor = NewMonitor();
-  syncvar->written = 0;
-  syncvar->value = (Obj) 0;
-  return syncvarBag;
+    Bag       syncvarBag;
+    SyncVar * syncvar;
+    syncvarBag = NewBag(T_SYNCVAR, sizeof(SyncVar));
+    syncvar = ObjPtr(syncvarBag);
+    syncvar->monitor = NewMonitor();
+    syncvar->written = 0;
+    syncvar->value = (Obj)0;
+    return syncvarBag;
 }
 
 
-Obj SyncRead(SyncVar *var)
+Obj SyncRead(SyncVar * var)
 {
-  Monitor *monitor = ObjPtr(var->monitor);
-  LockMonitor(monitor);
-  while (!var->written)
-    WaitForMonitor(monitor);
-  if (monitor->head != NULL)
-    SignalMonitor(monitor);
-  UnlockMonitor(monitor);
-  return var->value;
+    Monitor * monitor = ObjPtr(var->monitor);
+    LockMonitor(monitor);
+    while (!var->written)
+        WaitForMonitor(monitor);
+    if (monitor->head != NULL)
+        SignalMonitor(monitor);
+    UnlockMonitor(monitor);
+    return var->value;
 }
 
-Obj SyncIsBound(SyncVar *var)
+Obj SyncIsBound(SyncVar * var)
 {
-  return var->value ? True : False;
+    return var->value ? True : False;
 }
 
 int IsSyncVar(Obj var)
 {
-  return var && TNUM_OBJ(var) == T_SYNCVAR;
+    return var && TNUM_OBJ(var) == T_SYNCVAR;
 }
 
 Obj FuncCreateSyncVar(Obj self)
 {
-  return CreateSyncVar();
+    return CreateSyncVar();
 }
 
 Obj FuncSyncWrite(Obj self, Obj var, Obj value)
 {
-  if (!IsSyncVar(var))
-    return ArgumentError("SyncWrite: First argument must be a synchronization variable");
-  SyncWrite(ObjPtr(var), value);
-  return (Obj) 0;
+    if (!IsSyncVar(var))
+        return ArgumentError(
+            "SyncWrite: First argument must be a synchronization variable");
+    SyncWrite(ObjPtr(var), value);
+    return (Obj)0;
 }
 
 Obj FuncSyncTryWrite(Obj self, Obj var, Obj value)
 {
-  if (!IsSyncVar(var))
-    return ArgumentError("SyncTryWrite: First argument must be a synchronization variable");
-  return SyncTryWrite(ObjPtr(var), value) ? True : False;
+    if (!IsSyncVar(var))
+        return ArgumentError("SyncTryWrite: First argument must be a "
+                             "synchronization variable");
+    return SyncTryWrite(ObjPtr(var), value) ? True : False;
 }
 
 Obj FuncSyncRead(Obj self, Obj var)
 {
-  if (!IsSyncVar(var))
-    return ArgumentError("SyncRead: Argument must be a synchronization variable");
-  return SyncRead(ObjPtr(var));
+    if (!IsSyncVar(var))
+        return ArgumentError(
+            "SyncRead: Argument must be a synchronization variable");
+    return SyncRead(ObjPtr(var));
 }
 
 Obj FuncSyncIsBound(Obj self, Obj var)
 {
-  if (!IsSyncVar(var))
-    return ArgumentError("SyncRead: Argument must be a synchronization variable");
-  return SyncIsBound(ObjPtr(var));
+    if (!IsSyncVar(var))
+        return ArgumentError(
+            "SyncRead: Argument must be a synchronization variable");
+    return SyncIsBound(ObjPtr(var));
 }
 
 
 static void PrintThread(Obj obj)
 {
-  char buf[100];
-  char *status_message;
-  Int status;
-  Int id;
-  LockThreadControl(0);
-  id = *(UInt *)(ADDR_OBJ(obj)+1);
-  status = *(UInt *)(ADDR_OBJ(obj)+2);
-  switch (status)
-  {
+    char   buf[100];
+    char * status_message;
+    Int    status;
+    Int    id;
+    LockThreadControl(0);
+    id = *(UInt *)(ADDR_OBJ(obj) + 1);
+    status = *(UInt *)(ADDR_OBJ(obj) + 2);
+    switch (status) {
     case 0:
-      status_message = "running";
-      break;
+        status_message = "running";
+        break;
     case THREAD_TERMINATED:
-      status_message = "terminated";
-      break;
+        status_message = "terminated";
+        break;
     case THREAD_JOINED:
-      status_message = "running, waited for";
-      break;
+        status_message = "running, waited for";
+        break;
     case THREAD_TERMINATED | THREAD_JOINED:
-      status_message = "terminated, waited for";
-      break;
+        status_message = "terminated, waited for";
+        break;
     default:
-      status_message = "unknown status";
-      break;
-  }
-  sprintf(buf, "<thread #%ld: %s>", (long) id, status_message);
-  UnlockThreadControl();
-  Pr("%s", (Int) buf, 0L);
+        status_message = "unknown status";
+        break;
+    }
+    sprintf(buf, "<thread #%ld: %s>", (long)id, status_message);
+    UnlockThreadControl();
+    Pr("%s", (Int)buf, 0L);
 }
 
 static void PrintSemaphore(Obj obj)
 {
-  Semaphore *sem = ObjPtr(obj);
-  Int count;
-  char buffer[100];
-  LockMonitor(ObjPtr(sem->monitor));
-  count = sem->count;
-  UnlockMonitor(ObjPtr(sem->monitor));
-  sprintf(buffer, "<semaphore %p: count = %ld>", (void *)sem, (long) count);
-  Pr("%s", (Int) buffer, 0L);
+    Semaphore * sem = ObjPtr(obj);
+    Int         count;
+    char        buffer[100];
+    LockMonitor(ObjPtr(sem->monitor));
+    count = sem->count;
+    UnlockMonitor(ObjPtr(sem->monitor));
+    sprintf(buffer, "<semaphore %p: count = %ld>", (void *)sem, (long)count);
+    Pr("%s", (Int)buffer, 0L);
 }
 
 static void PrintChannel(Obj obj)
 {
-  Channel *channel = ObjPtr(obj);
-  Int size, waiting, capacity;
-  char buffer[20];
-  Pr("<channel ", 0L, 0L);
-  sprintf(buffer, "%p: ", (void *)channel);
-  Pr(buffer, 0L, 0L);
-  LockChannel(channel);
-  size = channel->size;
-  waiting = channel->waiting;
-  if (channel->dynamic)
-    capacity = -1;
-  else
-    capacity = channel->capacity;
-  UnlockChannel(channel);
-  if (capacity < 0)
-    Pr("%d elements, %d waiting>", size/2, waiting);
-  else
-  {
-    Pr("%d/%d elements, ", size/2, capacity/2);
-    Pr("%d waiting>", waiting, 0L);
-  }
+    Channel * channel = ObjPtr(obj);
+    Int       size, waiting, capacity;
+    char      buffer[20];
+    Pr("<channel ", 0L, 0L);
+    sprintf(buffer, "%p: ", (void *)channel);
+    Pr(buffer, 0L, 0L);
+    LockChannel(channel);
+    size = channel->size;
+    waiting = channel->waiting;
+    if (channel->dynamic)
+        capacity = -1;
+    else
+        capacity = channel->capacity;
+    UnlockChannel(channel);
+    if (capacity < 0)
+        Pr("%d elements, %d waiting>", size / 2, waiting);
+    else {
+        Pr("%d/%d elements, ", size / 2, capacity / 2);
+        Pr("%d waiting>", waiting, 0L);
+    }
 }
 
 static void PrintBarrier(Obj obj)
 {
-  Barrier *barrier = ObjPtr(obj);
-  Int count, waiting;
-  char buffer[20];
-  Pr("<barrier ", 0L, 0L);
-  sprintf(buffer, "%p: ", (void *)barrier);
-  Pr(buffer, 0L, 0L);
-  LockBarrier(barrier);
-  count = barrier->count;
-  waiting = barrier->waiting;
-  UnlockBarrier(barrier);
-  Pr("%d of %d threads arrived>", waiting, count);
+    Barrier * barrier = ObjPtr(obj);
+    Int       count, waiting;
+    char      buffer[20];
+    Pr("<barrier ", 0L, 0L);
+    sprintf(buffer, "%p: ", (void *)barrier);
+    Pr(buffer, 0L, 0L);
+    LockBarrier(barrier);
+    count = barrier->count;
+    waiting = barrier->waiting;
+    UnlockBarrier(barrier);
+    Pr("%d of %d threads arrived>", waiting, count);
 }
 
 static void PrintSyncVar(Obj obj)
 {
-  SyncVar *syncvar = ObjPtr(obj);
-  char buffer[20];
-  int written;
-  LockMonitor(ObjPtr(syncvar->monitor));
-  written = syncvar->written;
-  UnlockMonitor(ObjPtr(syncvar->monitor));
-  if (written)
-    Pr("<initialized syncvar ", 0L, 0L);
-  else
-    Pr("<uninitialized syncvar ", 0L, 0L);
-  sprintf(buffer, "%p>", (void *)syncvar);
-  Pr(buffer, 0L, 0L);
+    SyncVar * syncvar = ObjPtr(obj);
+    char      buffer[20];
+    int       written;
+    LockMonitor(ObjPtr(syncvar->monitor));
+    written = syncvar->written;
+    UnlockMonitor(ObjPtr(syncvar->monitor));
+    if (written)
+        Pr("<initialized syncvar ", 0L, 0L);
+    else
+        Pr("<uninitialized syncvar ", 0L, 0L);
+    sprintf(buffer, "%p>", (void *)syncvar);
+    Pr(buffer, 0L, 0L);
 }
 
 static void PrintRegion(Obj obj)
 {
-  char buffer[32];
-  Region *region = GetRegionOf(obj);
-  Obj name = GetRegionName(region);
+    char     buffer[32];
+    Region * region = GetRegionOf(obj);
+    Obj      name = GetRegionName(region);
 
-  if (name) {
-    Pr("<region: %s", (Int)(CSTR_STRING(name)), 0L);
-  } else {
-    snprintf(buffer, 32, "<region %p", (void *)GetRegionOf(obj));
-    Pr(buffer, 0L, 0L);
-  }
-  if (region && region->count_active) {
-    snprintf(buffer, 32, " (locked %zu/contended %zu)"
-	     , region->locks_acquired, region->locks_contended);
-    Pr(buffer, 0L, 0L);
-  }
-  Pr(">", 0L, 0L);
+    if (name) {
+        Pr("<region: %s", (Int)(CSTR_STRING(name)), 0L);
+    }
+    else {
+        snprintf(buffer, 32, "<region %p", (void *)GetRegionOf(obj));
+        Pr(buffer, 0L, 0L);
+    }
+    if (region && region->count_active) {
+        snprintf(buffer, 32, " (locked %zu/contended %zu)",
+                 region->locks_acquired, region->locks_contended);
+        Pr(buffer, 0L, 0L);
+    }
+    Pr(">", 0L, 0L);
 }
 
 Obj FuncIS_LOCKED(Obj self, Obj obj)
 {
-  Region *region = IS_BAG_REF(obj) ? REGION(obj) : NULL;
-  if (!region)
-    return INTOBJ_INT(0);
-  return INTOBJ_INT(IsLocked(region));
+    Region * region = IS_BAG_REF(obj) ? REGION(obj) : NULL;
+    if (!region)
+        return INTOBJ_INT(0);
+    return INTOBJ_INT(IsLocked(region));
 }
 
 void DoLockFunc(Obj args, int mode)
 {
-  Int numargs = LEN_PLIST(args);
-  int *modes;
-  Int i;
-  if (numargs > 1024) {
-    ErrorQuit("%s: Too many arguments",
-      mode ? (UInt) "WriteLock" : (UInt) "ReadLock", 0L);
-  }
-  if (TLS(lockStackPointer) == 0) {
-    ErrorQuit("%s: Not inside an atomic region or function",
-      mode ? (UInt) "WriteLock" : (UInt) "ReadLock", 0L);
-  }
-  modes = alloca(sizeof(int) * numargs);
-  for (i=0; i<numargs; i++) {
-    modes[i] = mode;
-  }
-  if (LockObjects((int) numargs, ADDR_OBJ(args)+1, modes) < 0) {
-    ErrorQuit("%s: Could not lock objects",
-      mode ? (UInt) "WriteLock" : (UInt) "ReadLock", 0L);
-  }
+    Int   numargs = LEN_PLIST(args);
+    int * modes;
+    Int   i;
+    if (numargs > 1024) {
+        ErrorQuit("%s: Too many arguments",
+                  mode ? (UInt) "WriteLock" : (UInt) "ReadLock", 0L);
+    }
+    if (TLS(lockStackPointer) == 0) {
+        ErrorQuit("%s: Not inside an atomic region or function",
+                  mode ? (UInt) "WriteLock" : (UInt) "ReadLock", 0L);
+    }
+    modes = alloca(sizeof(int) * numargs);
+    for (i = 0; i < numargs; i++) {
+        modes[i] = mode;
+    }
+    if (LockObjects((int)numargs, ADDR_OBJ(args) + 1, modes) < 0) {
+        ErrorQuit("%s: Could not lock objects",
+                  mode ? (UInt) "WriteLock" : (UInt) "ReadLock", 0L);
+    }
 }
 
 
 Obj FuncWriteLock(Obj self, Obj args)
 {
-  DoLockFunc(args, 1);
-  return (Obj) 0;
+    DoLockFunc(args, 1);
+    return (Obj)0;
 }
 
 Obj FuncReadLock(Obj self, Obj args)
 {
-  DoLockFunc(args, 0);
-  return (Obj) 0;
+    DoLockFunc(args, 0);
+    return (Obj)0;
 }
 
 Obj FuncLOCK(Obj self, Obj args)
 {
-  int numargs = LEN_PLIST(args);
-  int count = 0;
-  Obj *objects;
-  int *modes;
-  int mode = 1;
-  int i;
-  int result;
+    int   numargs = LEN_PLIST(args);
+    int   count = 0;
+    Obj * objects;
+    int * modes;
+    int   mode = 1;
+    int   i;
+    int   result;
 
-  if (numargs > 1024)
-    return ArgumentError("LOCK: Too many arguments");
-  objects = alloca(sizeof(Obj) * numargs);
-  modes = alloca(sizeof(int) * numargs);
-  for (i=1; i<=numargs; i++)
-  {
-    Obj obj;
-    obj = ELM_PLIST(args, i);
-    if (obj == True)
-      mode = 1;
-    else if (obj == False)
-      mode = 0;
-    else if (IS_INTOBJ(obj))
-      mode = (INT_INTOBJ(obj) && 1);
-    else {
-      objects[count] = obj;
-      modes[count] = mode;
-      count++;
+    if (numargs > 1024)
+        return ArgumentError("LOCK: Too many arguments");
+    objects = alloca(sizeof(Obj) * numargs);
+    modes = alloca(sizeof(int) * numargs);
+    for (i = 1; i <= numargs; i++) {
+        Obj obj;
+        obj = ELM_PLIST(args, i);
+        if (obj == True)
+            mode = 1;
+        else if (obj == False)
+            mode = 0;
+        else if (IS_INTOBJ(obj))
+            mode = (INT_INTOBJ(obj) && 1);
+        else {
+            objects[count] = obj;
+            modes[count] = mode;
+            count++;
+        }
     }
-  }
-  result = LockObjects(count, objects, modes);
-  if (result >= 0)
-    return INTOBJ_INT(result);
-  return Fail;
+    result = LockObjects(count, objects, modes);
+    if (result >= 0)
+        return INTOBJ_INT(result);
+    return Fail;
 }
 
 Obj FuncDO_LOCK(Obj self, Obj args)
 {
-  Obj result = FuncLOCK(self, args);
-  if (result == Fail)
-    ErrorMayQuit("Cannot lock required regions", 0L, 0L);
-  return result;
+    Obj result = FuncLOCK(self, args);
+    if (result == Fail)
+        ErrorMayQuit("Cannot lock required regions", 0L, 0L);
+    return result;
 }
 
 Obj FuncWRITE_LOCK(Obj self, Obj obj)
 {
-  int result;
-  static int modes[] = { 1 };
-  result = LockObjects(1, &obj, modes);
-  if (result >= 0)
-    return INTOBJ_INT(result);
-  ErrorMayQuit("Cannot lock required regions", 0L, 0L);
-  return (Obj) 0; /* flow control hint */
+    int        result;
+    static int modes[] = { 1 };
+    result = LockObjects(1, &obj, modes);
+    if (result >= 0)
+        return INTOBJ_INT(result);
+    ErrorMayQuit("Cannot lock required regions", 0L, 0L);
+    return (Obj)0; /* flow control hint */
 }
 
 Obj FuncREAD_LOCK(Obj self, Obj obj)
 {
-  int result;
-  static int modes[] = { 0, 0, 0, 0, 0, 0 };
-  result = LockObjects(1, &obj, modes);
-  if (result >= 0)
-    return INTOBJ_INT(result);
-  ErrorMayQuit("Cannot lock required regions", 0L, 0L);
-  return (Obj) 0; /* flow control hint */
+    int        result;
+    static int modes[] = { 0, 0, 0, 0, 0, 0 };
+    result = LockObjects(1, &obj, modes);
+    if (result >= 0)
+        return INTOBJ_INT(result);
+    ErrorMayQuit("Cannot lock required regions", 0L, 0L);
+    return (Obj)0; /* flow control hint */
 }
 
 Obj FuncTRYLOCK(Obj self, Obj args)
 {
-  int numargs = LEN_PLIST(args);
-  int count = 0;
-  Obj *objects;
-  int *modes;
-  int mode = 1;
-  int i;
-  int result;
+    int   numargs = LEN_PLIST(args);
+    int   count = 0;
+    Obj * objects;
+    int * modes;
+    int   mode = 1;
+    int   i;
+    int   result;
 
-  if (numargs > 1024)
-    return ArgumentError("TRYLOCK: Too many arguments");
-  objects = alloca(sizeof(Obj) * numargs);
-  modes = alloca(sizeof(int) * numargs);
-  for (i=1; i<=numargs; i++)
-  {
-    Obj obj;
-    obj = ELM_PLIST(args, i);
-    if (obj == True)
-      mode = 1;
-    else if (obj == False)
-      mode = 0;
-    else if (IS_INTOBJ(obj))
-      mode = (INT_INTOBJ(obj) && 1);
-    else {
-      objects[count] = obj;
-      modes[count] = mode;
-      count++;
+    if (numargs > 1024)
+        return ArgumentError("TRYLOCK: Too many arguments");
+    objects = alloca(sizeof(Obj) * numargs);
+    modes = alloca(sizeof(int) * numargs);
+    for (i = 1; i <= numargs; i++) {
+        Obj obj;
+        obj = ELM_PLIST(args, i);
+        if (obj == True)
+            mode = 1;
+        else if (obj == False)
+            mode = 0;
+        else if (IS_INTOBJ(obj))
+            mode = (INT_INTOBJ(obj) && 1);
+        else {
+            objects[count] = obj;
+            modes[count] = mode;
+            count++;
+        }
     }
-  }
-  result = TryLockObjects(count, objects, modes);
-  if (result >= 0)
-    return INTOBJ_INT(result);
-  return Fail;
+    result = TryLockObjects(count, objects, modes);
+    if (result >= 0)
+        return INTOBJ_INT(result);
+    return Fail;
 }
 
 Obj FuncUNLOCK(Obj self, Obj sp)
 {
-  if (!IS_INTOBJ(sp) || INT_INTOBJ(sp) < 0)
-    return ArgumentError("UNLOCK: argument must be a non-negative integer");
-  PopRegionLocks(INT_INTOBJ(sp));
-  return (Obj) 0;
+    if (!IS_INTOBJ(sp) || INT_INTOBJ(sp) < 0)
+        return ArgumentError(
+            "UNLOCK: argument must be a non-negative integer");
+    PopRegionLocks(INT_INTOBJ(sp));
+    return (Obj)0;
 }
 
 Obj FuncCURRENT_LOCKS(Obj self)
 {
-  UInt i, len = TLS(lockStackPointer);
-  Obj result = NEW_PLIST(T_PLIST, len);
-  SET_LEN_PLIST(result, len);
-  for (i=1; i<=len; i++)
-    SET_ELM_PLIST(result, i, ELM_PLIST(TLS(lockStack), i));
-  return result;
+    UInt i, len = TLS(lockStackPointer);
+    Obj  result = NEW_PLIST(T_PLIST, len);
+    SET_LEN_PLIST(result, len);
+    for (i = 1; i <= len; i++)
+        SET_ELM_PLIST(result, i, ELM_PLIST(TLS(lockStack), i));
+    return result;
 }
 
 static int AutoRetyping = 0;
 
-static int MigrateObjects(int count, Obj *objects, Region *target, int retype)
+static int
+MigrateObjects(int count, Obj * objects, Region * target, int retype)
 {
-  int i;
-  if (retype && IS_BAG_REF(objects[0]) && REGION(objects[0])->owner == realTLS
-      && AutoRetyping) {
-    for (i=0; i<count; i++)
-      if (REGION(objects[i])->owner == realTLS)
-	CLEAR_OBJ_FLAG(objects[i], TESTED);
-    for (i=0; i<count; i++) {
-      if (REGION(objects[i])->owner == realTLS && IS_PLIST(objects[i])) {
-        if (!TEST_OBJ_FLAG(objects[i], TESTED))
-	  TYPE_OBJ(objects[i]);
-	if (retype >= 2)
-	  IsSet(objects[i]);
-      }
+    int i;
+    if (retype && IS_BAG_REF(objects[0]) &&
+        REGION(objects[0])->owner == realTLS && AutoRetyping) {
+        for (i = 0; i < count; i++)
+            if (REGION(objects[i])->owner == realTLS)
+                CLEAR_OBJ_FLAG(objects[i], TESTED);
+        for (i = 0; i < count; i++) {
+            if (REGION(objects[i])->owner == realTLS &&
+                IS_PLIST(objects[i])) {
+                if (!TEST_OBJ_FLAG(objects[i], TESTED))
+                    TYPE_OBJ(objects[i]);
+                if (retype >= 2)
+                    IsSet(objects[i]);
+            }
+        }
     }
-  }
-  for (i=0; i<count; i++) {
-    Region *region;
-    if (IS_BAG_REF(objects[i])) {
-      region = (Region *)(REGION(objects[i]));
-      if (!region || region->owner != realTLS)
-        return 0;
+    for (i = 0; i < count; i++) {
+        Region * region;
+        if (IS_BAG_REF(objects[i])) {
+            region = (Region *)(REGION(objects[i]));
+            if (!region || region->owner != realTLS)
+                return 0;
+        }
     }
-  }
-  for (i=0; i<count; i++)
-    REGION(objects[i]) = target;
-  return 1;
+    for (i = 0; i < count; i++)
+        REGION(objects[i]) = target;
+    return 1;
 }
 
-Obj FuncREFINE_TYPE(Obj self, Obj obj) {
-  if (IS_BAG_REF(obj) && CheckExclusiveWriteAccess(obj)) {
-    TYPE_OBJ(obj);
-  }
-  return obj;
+Obj FuncREFINE_TYPE(Obj self, Obj obj)
+{
+    if (IS_BAG_REF(obj) && CheckExclusiveWriteAccess(obj)) {
+        TYPE_OBJ(obj);
+    }
+    return obj;
 }
 
 Obj FuncMAKE_PUBLIC_NORECURSE(Obj self, Obj obj)
 {
-  if (!MigrateObjects(1, &obj, NULL, 0))
-    return ArgumentError("MAKE_PUBLIC_NORECURSE: Thread does not have exclusive access to objects");
-  return obj;
+    if (!MigrateObjects(1, &obj, NULL, 0))
+        return ArgumentError("MAKE_PUBLIC_NORECURSE: Thread does not have "
+                             "exclusive access to objects");
+    return obj;
 }
 
 Obj FuncFORCE_MAKE_PUBLIC(Obj self, Obj obj)
 {
-  if (!IS_BAG_REF(obj))
-    return ArgumentError("FORCE_MAKE_PUBLIC: Argument is a short integer or finite-field element");
-  MakeBagPublic(obj);
-  return obj;
+    if (!IS_BAG_REF(obj))
+        return ArgumentError("FORCE_MAKE_PUBLIC: Argument is a short integer "
+                             "or finite-field element");
+    MakeBagPublic(obj);
+    return obj;
 }
 
 Obj FuncSHARE_NORECURSE(Obj self, Obj obj, Obj name, Obj prec)
 {
-  Region *region = NewRegion();
-  if (name != Fail && !IsStringConv(name))
-    return ArgumentError("SHARE_NORECURSE: Second argument must be a string or fail");
-  if (!IS_INTOBJ(prec))
-    return ArgumentError("SHARE_NORECURSE: Third argument must be an integer");
-  region->prec = INT_INTOBJ(prec);
-  if (!MigrateObjects(1, &obj, region, 0))
-    return ArgumentError("SHARE_NORECURSE: Thread does not have exclusive access to objects");
-  if (name != Fail)
-    SetRegionName(region, name);
-  return obj;
+    Region * region = NewRegion();
+    if (name != Fail && !IsStringConv(name))
+        return ArgumentError(
+            "SHARE_NORECURSE: Second argument must be a string or fail");
+    if (!IS_INTOBJ(prec))
+        return ArgumentError(
+            "SHARE_NORECURSE: Third argument must be an integer");
+    region->prec = INT_INTOBJ(prec);
+    if (!MigrateObjects(1, &obj, region, 0))
+        return ArgumentError("SHARE_NORECURSE: Thread does not have "
+                             "exclusive access to objects");
+    if (name != Fail)
+        SetRegionName(region, name);
+    return obj;
 }
 
 Obj FuncMIGRATE_NORECURSE(Obj self, Obj obj, Obj target)
 {
-  Region *target_region = GetRegionOf(target);
-  if (!target_region || IsLocked(target_region) != 1)
-    return ArgumentError("MIGRATE_NORECURSE: Thread does not have exclusive access to target region");
-  if (!MigrateObjects(1, &obj, target_region, 0))
-    return ArgumentError("MIGRATE_NORECURSE: Thread does not have exclusive access to object");
-  return obj;
+    Region * target_region = GetRegionOf(target);
+    if (!target_region || IsLocked(target_region) != 1)
+        return ArgumentError("MIGRATE_NORECURSE: Thread does not have "
+                             "exclusive access to target region");
+    if (!MigrateObjects(1, &obj, target_region, 0))
+        return ArgumentError("MIGRATE_NORECURSE: Thread does not have "
+                             "exclusive access to object");
+    return obj;
 }
 
 Obj FuncADOPT_NORECURSE(Obj self, Obj obj)
 {
-  if (!MigrateObjects(1, &obj, TLS(threadRegion), 0))
-    return ArgumentError("ADOPT_NORECURSE: Thread does not have exclusive access to objects");
-  return obj;
+    if (!MigrateObjects(1, &obj, TLS(threadRegion), 0))
+        return ArgumentError("ADOPT_NORECURSE: Thread does not have "
+                             "exclusive access to objects");
+    return obj;
 }
 
 Obj FuncREACHABLE(Obj self, Obj obj)
 {
-  Obj result = ReachableObjectsFrom(obj);
-  if (result == NULL) {
-    result = NEW_PLIST(T_PLIST, 1);
-    SET_LEN_PLIST(result, 1);
-    SET_ELM_PLIST(result, 1, obj);
-  }
-  return result;
+    Obj result = ReachableObjectsFrom(obj);
+    if (result == NULL) {
+        result = NEW_PLIST(T_PLIST, 1);
+        SET_LEN_PLIST(result, 1);
+        SET_ELM_PLIST(result, 1, obj);
+    }
+    return result;
 }
 
 Obj FuncCLONE_REACHABLE(Obj self, Obj obj)
 {
-  return CopyReachableObjectsFrom(obj, 0, 0, 0);
+    return CopyReachableObjectsFrom(obj, 0, 0, 0);
 }
 
 Obj FuncCLONE_DELIMITED(Obj self, Obj obj)
 {
-  return CopyReachableObjectsFrom(obj, 1, 0, 0);
+    return CopyReachableObjectsFrom(obj, 1, 0, 0);
 }
 
 Obj FuncNEW_REGION(Obj self, Obj name, Obj prec)
 {
-  Region *region = NewRegion();
-  if (name != Fail && !IsStringConv(name))
-    return ArgumentError("NEW_REGION: Second argument must be a string or fail");
-  if (!IS_INTOBJ(prec))
-    return ArgumentError("NEW_REGION: Third argument must be an integer");
-  region->prec = INT_INTOBJ(prec);
-  if (name != Fail)
-    SetRegionName(region, name);
-  return region->obj;
+    Region * region = NewRegion();
+    if (name != Fail && !IsStringConv(name))
+        return ArgumentError(
+            "NEW_REGION: Second argument must be a string or fail");
+    if (!IS_INTOBJ(prec))
+        return ArgumentError("NEW_REGION: Third argument must be an integer");
+    region->prec = INT_INTOBJ(prec);
+    if (name != Fail)
+        SetRegionName(region, name);
+    return region->obj;
 }
 
 Obj FuncREGION_PRECEDENCE(Obj self, Obj regobj)
 {
-  Region *region = GetRegionOf(regobj);
-  return region == NULL ? INTOBJ_INT(0) : INTOBJ_INT(region->prec);
+    Region * region = GetRegionOf(regobj);
+    return region == NULL ? INTOBJ_INT(0) : INTOBJ_INT(region->prec);
 }
 
 Obj FuncSHARE(Obj self, Obj obj, Obj name, Obj prec)
 {
-  Region *region = NewRegion();
-  Obj reachable;
-  if (name != Fail && !IsStringConv(name))
-    return ArgumentError("SHARE: Second argument must be a string or fail");
-  if (!IS_INTOBJ(prec))
-    return ArgumentError("SHARE: Third argument must be an integer");
-  region->prec = INT_INTOBJ(prec);
-  reachable = ReachableObjectsFrom(obj);
-  if (!MigrateObjects(LEN_PLIST(reachable),
-       ADDR_OBJ(reachable)+1, region, 1))
-    return ArgumentError("SHARE: Thread does not have exclusive access to objects");
-  if (name != Fail)
-    SetRegionName(region, name);
-  return obj;
+    Region * region = NewRegion();
+    Obj      reachable;
+    if (name != Fail && !IsStringConv(name))
+        return ArgumentError(
+            "SHARE: Second argument must be a string or fail");
+    if (!IS_INTOBJ(prec))
+        return ArgumentError("SHARE: Third argument must be an integer");
+    region->prec = INT_INTOBJ(prec);
+    reachable = ReachableObjectsFrom(obj);
+    if (!MigrateObjects(LEN_PLIST(reachable), ADDR_OBJ(reachable) + 1, region,
+                        1))
+        return ArgumentError(
+            "SHARE: Thread does not have exclusive access to objects");
+    if (name != Fail)
+        SetRegionName(region, name);
+    return obj;
 }
 
 Obj FuncSHARE_RAW(Obj self, Obj obj, Obj name, Obj prec)
 {
-  Region *region = NewRegion();
-  Obj reachable;
-  if (name != Fail && !IsStringConv(name))
-    return ArgumentError("SHARE_RAW: Second argument must be a string or fail");
-  if (!IS_INTOBJ(prec))
-    return ArgumentError("SHARE_RAW: Third argument must be an integer");
-  region->prec = INT_INTOBJ(prec);
-  reachable = ReachableObjectsFrom(obj);
-  if (!MigrateObjects(LEN_PLIST(reachable),
-       ADDR_OBJ(reachable)+1, region, 0))
-    return ArgumentError("SHARE_RAW: Thread does not have exclusive access to objects");
-  if (name != Fail)
-    SetRegionName(region, name);
-  return obj;
+    Region * region = NewRegion();
+    Obj      reachable;
+    if (name != Fail && !IsStringConv(name))
+        return ArgumentError(
+            "SHARE_RAW: Second argument must be a string or fail");
+    if (!IS_INTOBJ(prec))
+        return ArgumentError("SHARE_RAW: Third argument must be an integer");
+    region->prec = INT_INTOBJ(prec);
+    reachable = ReachableObjectsFrom(obj);
+    if (!MigrateObjects(LEN_PLIST(reachable), ADDR_OBJ(reachable) + 1, region,
+                        0))
+        return ArgumentError(
+            "SHARE_RAW: Thread does not have exclusive access to objects");
+    if (name != Fail)
+        SetRegionName(region, name);
+    return obj;
 }
 
 Obj FuncADOPT(Obj self, Obj obj)
 {
-  Obj reachable = ReachableObjectsFrom(obj);
-  if (!MigrateObjects(LEN_PLIST(reachable),
-       ADDR_OBJ(reachable)+1, TLS(threadRegion), 0))
-    return ArgumentError("ADOPT: Thread does not have exclusive access to objects");
-  return obj;
+    Obj reachable = ReachableObjectsFrom(obj);
+    if (!MigrateObjects(LEN_PLIST(reachable), ADDR_OBJ(reachable) + 1,
+                        TLS(threadRegion), 0))
+        return ArgumentError(
+            "ADOPT: Thread does not have exclusive access to objects");
+    return obj;
 }
 
 Obj FuncMAKE_PUBLIC(Obj self, Obj obj)
 {
-  Obj reachable = ReachableObjectsFrom(obj);
-  if (!MigrateObjects(LEN_PLIST(reachable),
-       ADDR_OBJ(reachable)+1, NULL, 0))
-    return ArgumentError("MAKE_PUBLIC: Thread does not have exclusive access to objects");
-  return obj;
+    Obj reachable = ReachableObjectsFrom(obj);
+    if (!MigrateObjects(LEN_PLIST(reachable), ADDR_OBJ(reachable) + 1, NULL,
+                        0))
+        return ArgumentError(
+            "MAKE_PUBLIC: Thread does not have exclusive access to objects");
+    return obj;
 }
 
 Obj FuncMIGRATE(Obj self, Obj obj, Obj target)
 {
-  Region *target_region = GetRegionOf(target);
-  Obj reachable;
-  if (!target_region || IsLocked(target_region) != 1)
-    return ArgumentError("MIGRATE: Thread does not have exclusive access to target region");
-  reachable = ReachableObjectsFrom(obj);
-  if (!MigrateObjects(LEN_PLIST(reachable),
-       ADDR_OBJ(reachable)+1, target_region, 1))
-    return ArgumentError("MIGRATE: Thread does not have exclusive access to objects");
-  return obj;
+    Region * target_region = GetRegionOf(target);
+    Obj      reachable;
+    if (!target_region || IsLocked(target_region) != 1)
+        return ArgumentError("MIGRATE: Thread does not have exclusive access "
+                             "to target region");
+    reachable = ReachableObjectsFrom(obj);
+    if (!MigrateObjects(LEN_PLIST(reachable), ADDR_OBJ(reachable) + 1,
+                        target_region, 1))
+        return ArgumentError(
+            "MIGRATE: Thread does not have exclusive access to objects");
+    return obj;
 }
 
 Obj FuncMIGRATE_RAW(Obj self, Obj obj, Obj target)
 {
-  Region *target_region = GetRegionOf(target);
-  Obj reachable;
-  if (!target_region || IsLocked(target_region) != 1)
-    return ArgumentError("MIGRATE: Thread does not have exclusive access to target region");
-  reachable = ReachableObjectsFrom(obj);
-  if (!MigrateObjects(LEN_PLIST(reachable),
-       ADDR_OBJ(reachable)+1, target_region, 0))
-    return ArgumentError("MIGRATE: Thread does not have exclusive access to objects");
-  return obj;
+    Region * target_region = GetRegionOf(target);
+    Obj      reachable;
+    if (!target_region || IsLocked(target_region) != 1)
+        return ArgumentError("MIGRATE: Thread does not have exclusive access "
+                             "to target region");
+    reachable = ReachableObjectsFrom(obj);
+    if (!MigrateObjects(LEN_PLIST(reachable), ADDR_OBJ(reachable) + 1,
+                        target_region, 0))
+        return ArgumentError(
+            "MIGRATE: Thread does not have exclusive access to objects");
+    return obj;
 }
 
 Obj FuncMakeThreadLocal(Obj self, Obj var)
 {
-  char *name;
-  UInt gvar;
-  if (!IsStringConv(var) || GET_LEN_STRING(var) == 0)
-    return ArgumentError("MakeThreadLocal: Argument must be a variable name");
-  name = CSTR_STRING(var);
-  gvar = GVarName(name);
-  name = NameGVar(gvar); /* to apply namespace scopes where needed. */
-  MakeThreadLocalVar(gvar, RNamName(name));
-  return (Obj) 0;
+    char * name;
+    UInt   gvar;
+    if (!IsStringConv(var) || GET_LEN_STRING(var) == 0)
+        return ArgumentError(
+            "MakeThreadLocal: Argument must be a variable name");
+    name = CSTR_STRING(var);
+    gvar = GVarName(name);
+    name = NameGVar(gvar); /* to apply namespace scopes where needed. */
+    MakeThreadLocalVar(gvar, RNamName(name));
+    return (Obj)0;
 }
 
 Obj FuncMakeReadOnly(Obj self, Obj obj)
 {
-  Region *region = GetRegionOf(obj);
-  Obj reachable;
-  if (!region || region == ReadOnlyRegion)
+    Region * region = GetRegionOf(obj);
+    Obj      reachable;
+    if (!region || region == ReadOnlyRegion)
+        return obj;
+    reachable = ReachableObjectsFrom(obj);
+    if (!MigrateObjects(LEN_PLIST(reachable), ADDR_OBJ(reachable) + 1,
+                        ReadOnlyRegion, 1))
+        return ArgumentError(
+            "MakeReadOnly: Thread does not have exclusive access to objects");
     return obj;
-  reachable = ReachableObjectsFrom(obj);
-  if (!MigrateObjects(LEN_PLIST(reachable),
-       ADDR_OBJ(reachable)+1, ReadOnlyRegion, 1))
-    return ArgumentError("MakeReadOnly: Thread does not have exclusive access to objects");
-  return obj;
 }
 
 Obj FuncMakeReadOnlyRaw(Obj self, Obj obj)
 {
-  Region *region = GetRegionOf(obj);
-  Obj reachable;
-  if (!region || region == ReadOnlyRegion)
+    Region * region = GetRegionOf(obj);
+    Obj      reachable;
+    if (!region || region == ReadOnlyRegion)
+        return obj;
+    reachable = ReachableObjectsFrom(obj);
+    if (!MigrateObjects(LEN_PLIST(reachable), ADDR_OBJ(reachable) + 1,
+                        ReadOnlyRegion, 0))
+        return ArgumentError(
+            "MakeReadOnly: Thread does not have exclusive access to objects");
     return obj;
-  reachable = ReachableObjectsFrom(obj);
-  if (!MigrateObjects(LEN_PLIST(reachable),
-       ADDR_OBJ(reachable)+1, ReadOnlyRegion, 0))
-    return ArgumentError("MakeReadOnly: Thread does not have exclusive access to objects");
-  return obj;
 }
 
 Obj FuncMakeReadOnlyObj(Obj self, Obj obj)
 {
-  Region *region = GetRegionOf(obj);
-  if (!region || region == ReadOnlyRegion)
+    Region * region = GetRegionOf(obj);
+    if (!region || region == ReadOnlyRegion)
+        return obj;
+    if (!MigrateObjects(1, &obj, ReadOnlyRegion, 0))
+        return ArgumentError("MakeReadOnlyObj: Thread does not have "
+                             "exclusive access to object");
     return obj;
-  if (!MigrateObjects(1, &obj, ReadOnlyRegion, 0))
-    return ArgumentError("MakeReadOnlyObj: Thread does not have exclusive access to object");
-  return obj;
 }
 
 Obj FuncIsReadOnly(Obj self, Obj obj)
 {
-  Region *region = GetRegionOf(obj);
-  return (region == ReadOnlyRegion) ? True : False;
+    Region * region = GetRegionOf(obj);
+    return (region == ReadOnlyRegion) ? True : False;
 }
 
 Obj FuncENABLE_AUTO_RETYPING(Obj self)
 {
-  AutoRetyping = 1;
-  return (Obj) 0;
+    AutoRetyping = 1;
+    return (Obj)0;
 }
 
 Obj FuncORDERED_READ(Obj self, Obj obj)
 {
-  MEMBAR_READ();
-  return obj;
+    MEMBAR_READ();
+    return obj;
 }
 
 Obj FuncORDERED_WRITE(Obj self, Obj obj)
 {
-  MEMBAR_WRITE();
-  return obj;
+    MEMBAR_WRITE();
+    return obj;
 }
 
-Obj FuncDEFAULT_SIGINT_HANDLER(Obj self) {
-  /* do nothing */
-  return (Obj) 0;
+Obj FuncDEFAULT_SIGINT_HANDLER(Obj self)
+{
+    /* do nothing */
+    return (Obj)0;
 }
 
 UInt SigVTALRMCounter = 0;
 
-Obj FuncDEFAULT_SIGVTALRM_HANDLER(Obj self) {
-  SigVTALRMCounter++;
-  return (Obj) 0;
+Obj FuncDEFAULT_SIGVTALRM_HANDLER(Obj self)
+{
+    SigVTALRMCounter++;
+    return (Obj)0;
 }
 
-Obj FuncDEFAULT_SIGWINCH_HANDLER(Obj self) {
+Obj FuncDEFAULT_SIGWINCH_HANDLER(Obj self)
+{
 #ifdef SIGWINCH
-  extern void syWindowChangeIntr(int signr);
-  syWindowChangeIntr(SIGWINCH);
+    extern void syWindowChangeIntr(int signr);
+    syWindowChangeIntr(SIGWINCH);
 #endif
-  return (Obj) 0;
+    return (Obj)0;
 }
 
 static void HandleSignal(Obj handlers, UInt rnam)
 {
-  Obj func = ELM_REC(handlers, rnam);
-  if (!func || TNUM_OBJ(func) != T_FUNCTION || NARG_FUNC(func) > 0)
-    return;
-  CALL_0ARGS(func);
+    Obj func = ELM_REC(handlers, rnam);
+    if (!func || TNUM_OBJ(func) != T_FUNCTION || NARG_FUNC(func) > 0)
+        return;
+    CALL_0ARGS(func);
 }
 
 static sigset_t GAPSignals;
 
 Obj FuncSIGWAIT(Obj self, Obj handlers)
 {
-  int sig;
-  if (!IS_REC(handlers))
-    return ArgumentError("SIGWAIT: Argument must be a record");
-  if (sigwait(&GAPSignals, &sig) >= 0) {
-    switch (sig) {
-      case SIGINT:
-        HandleSignal(handlers, RNAM_SIGINT);
-	break;
-      case SIGCHLD:
-        HandleSignal(handlers, RNAM_SIGCHLD);
-	break;
-      case SIGVTALRM:
-        HandleSignal(handlers, RNAM_SIGVTALRM);
-	break;
+    int sig;
+    if (!IS_REC(handlers))
+        return ArgumentError("SIGWAIT: Argument must be a record");
+    if (sigwait(&GAPSignals, &sig) >= 0) {
+        switch (sig) {
+        case SIGINT:
+            HandleSignal(handlers, RNAM_SIGINT);
+            break;
+        case SIGCHLD:
+            HandleSignal(handlers, RNAM_SIGCHLD);
+            break;
+        case SIGVTALRM:
+            HandleSignal(handlers, RNAM_SIGVTALRM);
+            break;
 #ifdef SIGWINCH
-      case SIGWINCH:
-        HandleSignal(handlers, RNAM_SIGWINCH);
-	break;
+        case SIGWINCH:
+            HandleSignal(handlers, RNAM_SIGWINCH);
+            break;
 #endif
+        }
     }
-  }
-  return (Obj) 0;
+    return (Obj)0;
 }
 
-void InitSignals() {
-  struct itimerval timer;
-  sigemptyset(&GAPSignals);
-  sigaddset(&GAPSignals, SIGINT);
-  sigaddset(&GAPSignals, SIGCHLD);
-  sigaddset(&GAPSignals, SIGVTALRM);
+void InitSignals()
+{
+    struct itimerval timer;
+    sigemptyset(&GAPSignals);
+    sigaddset(&GAPSignals, SIGINT);
+    sigaddset(&GAPSignals, SIGCHLD);
+    sigaddset(&GAPSignals, SIGVTALRM);
 #ifdef SIGWINCH
-  sigaddset(&GAPSignals, SIGWINCH);
+    sigaddset(&GAPSignals, SIGWINCH);
 #endif
-  pthread_sigmask(SIG_BLOCK, &GAPSignals, NULL);
-  /* Run a timer signal every 10 ms, i.e. 100 times per second */
-  timer.it_interval.tv_sec = 0;
-  timer.it_interval.tv_usec = 10000;
-  timer.it_value.tv_sec = 0;
-  timer.it_value.tv_usec = 10000;
-  setitimer(ITIMER_VIRTUAL, &timer, NULL);
+    pthread_sigmask(SIG_BLOCK, &GAPSignals, NULL);
+    /* Run a timer signal every 10 ms, i.e. 100 times per second */
+    timer.it_interval.tv_sec = 0;
+    timer.it_interval.tv_usec = 10000;
+    timer.it_value.tv_sec = 0;
+    timer.it_value.tv_usec = 10000;
+    setitimer(ITIMER_VIRTUAL, &timer, NULL);
 }
 
 Obj FuncPERIODIC_CHECK(Obj self, Obj count, Obj func)
 {
-  UInt n;
-  if (!IS_INTOBJ(count) || INT_INTOBJ(count) < 0)
-    return ArgumentError("PERIODIC_CHECK: First argument must be a non-negative small integer");
-  if (TNUM_OBJ(func) != T_FUNCTION)
-    return ArgumentError("PERIODIC_CHECK: Second argument must be a function");
-  /*
-   * The following read of SigVTALRMCounter is a dirty read. We don't
-   * need to synchronize access to it because it's a monotonically
-   * increasing value and we only need it to succeed eventually.
-   */
-  n = INT_INTOBJ(count)/10;
-  if (TLS(PeriodicCheckCount) + n < SigVTALRMCounter) {
-    TLS(PeriodicCheckCount) = SigVTALRMCounter;
-    CALL_0ARGS(func);
-  }
-  return (Obj) 0;
+    UInt n;
+    if (!IS_INTOBJ(count) || INT_INTOBJ(count) < 0)
+        return ArgumentError("PERIODIC_CHECK: First argument must be a "
+                             "non-negative small integer");
+    if (TNUM_OBJ(func) != T_FUNCTION)
+        return ArgumentError(
+            "PERIODIC_CHECK: Second argument must be a function");
+    /*
+     * The following read of SigVTALRMCounter is a dirty read. We don't
+     * need to synchronize access to it because it's a monotonically
+     * increasing value and we only need it to succeed eventually.
+     */
+    n = INT_INTOBJ(count) / 10;
+    if (TLS(PeriodicCheckCount) + n < SigVTALRMCounter) {
+        TLS(PeriodicCheckCount) = SigVTALRMCounter;
+        CALL_0ARGS(func);
+    }
+    return (Obj)0;
 }
 
 
@@ -3029,99 +3077,104 @@ Obj FuncPERIODIC_CHECK(Obj self, Obj count, Obj func)
  */
 Obj FuncREGION_COUNTERS_ENABLE(Obj self, Obj obj)
 {
-  Region *region = GetRegionOf(obj);
+    Region * region = GetRegionOf(obj);
 
-  if(!region)
-    return ArgumentError("REGION_COUNTERS_ENABLE: Cannot enable counters for this region");
+    if (!region)
+        return ArgumentError(
+            "REGION_COUNTERS_ENABLE: Cannot enable counters for this region");
 
-  region->count_active = 1;
-  return (Obj) 0;
+    region->count_active = 1;
+    return (Obj)0;
 }
 
 Obj FuncREGION_COUNTERS_DISABLE(Obj self, Obj obj)
 {
-  Region *region = GetRegionOf(obj);
+    Region * region = GetRegionOf(obj);
 
-  if(!region)
-    return ArgumentError("REGION_COUNTERS_DISABLE: Cannot disable counters for this region");
+    if (!region)
+        return ArgumentError("REGION_COUNTERS_DISABLE: Cannot disable "
+                             "counters for this region");
 
-  region->count_active = 0;
-  return (Obj) 0;
+    region->count_active = 0;
+    return (Obj)0;
 }
 
 Obj FuncREGION_COUNTERS_GET_STATE(Obj self, Obj obj)
 {
-  Obj result;
-  Region *region = GetRegionOf(obj);
+    Obj      result;
+    Region * region = GetRegionOf(obj);
 
-  if(!region)
-    return ArgumentError("REGION_COUNTERS_GET_STATE: Cannot get counters for this region");
+    if (!region)
+        return ArgumentError(
+            "REGION_COUNTERS_GET_STATE: Cannot get counters for this region");
 
-  result = INTOBJ_INT(region->count_active);
+    result = INTOBJ_INT(region->count_active);
 
-  return result;
+    return result;
 }
 
 Obj FuncREGION_COUNTERS_GET(Obj self, Obj obj)
 {
-  Region *region = GetRegionOf(obj);
+    Region * region = GetRegionOf(obj);
 
-  if(!region)
-    return ArgumentError("REGION_COUNTERS_GET: Cannot get counters for this region");
+    if (!region)
+        return ArgumentError(
+            "REGION_COUNTERS_GET: Cannot get counters for this region");
 
-  return GetRegionLockCounters(region);
+    return GetRegionLockCounters(region);
 }
 
 Obj FuncREGION_COUNTERS_RESET(Obj self, Obj obj)
 {
-  Region *region = GetRegionOf(obj);
+    Region * region = GetRegionOf(obj);
 
-  if(!region)
-    return ArgumentError("REGION_COUNTERS_RESET: Cannot reset counters for this region");
+    if (!region)
+        return ArgumentError(
+            "REGION_COUNTERS_RESET: Cannot reset counters for this region");
 
-  ResetRegionLockCounters(region);
+    ResetRegionLockCounters(region);
 
-  return (Obj) 0;
+    return (Obj)0;
 }
 
 Obj FuncTHREAD_COUNTERS_ENABLE(Obj self)
 {
-  TLS(CountActive) = 1;
+    TLS(CountActive) = 1;
 
-  return (Obj) 0;
+    return (Obj)0;
 }
 
 Obj FuncTHREAD_COUNTERS_DISABLE(Obj self)
 {
-  TLS(CountActive) = 0;
+    TLS(CountActive) = 0;
 
-  return (Obj) 0;
+    return (Obj)0;
 }
 
 Obj FuncTHREAD_COUNTERS_GET_STATE(Obj self)
 {
-  Obj result;
+    Obj result;
 
-  result = INTOBJ_INT(TLS(CountActive));
+    result = INTOBJ_INT(TLS(CountActive));
 
-  return result;
+    return result;
 }
 
 Obj FuncTHREAD_COUNTERS_RESET(Obj self)
 {
-  TLS(LocksAcquired) = TLS(LocksContended) = 0;
+    TLS(LocksAcquired) = TLS(LocksContended) = 0;
 
-  return (Obj) 0;
+    return (Obj)0;
 }
 
 Obj FuncTHREAD_COUNTERS_GET(Obj self)
 {
-  Obj result;
+    Obj result;
 
-  result = NEW_PLIST(T_PLIST, 2);
-  SET_LEN_PLIST(result, 2);
-  SET_ELM_PLIST(result, 1, INTOBJ_INT(TLS(LocksAcquired)));
-  SET_ELM_PLIST(result, 2, INTOBJ_INT(TLS(LocksContended)));
+    result = NEW_PLIST(T_PLIST, 2);
+    SET_LEN_PLIST(result, 2);
+    SET_ELM_PLIST(result, 1, INTOBJ_INT(TLS(LocksAcquired)));
+    SET_ELM_PLIST(result, 2, INTOBJ_INT(TLS(LocksContended)));
 
-  return result;
+    return result;
 }

--- a/src/hpc/tls.c
+++ b/src/hpc/tls.c
@@ -14,9 +14,9 @@
 #define MAX_TLS_HANDLERS (TLS_NUM_EXTRA * 2)
 
 static TLSHandler TLSHandlers[MAX_TLS_HANDLERS];
-static Int TLSHandlerCount = 0;
+static Int        TLSHandlerCount = 0;
 
-ThreadLocalStorage *MainThreadTLS;
+ThreadLocalStorage * MainThreadTLS;
 
 #ifdef HAVE_NATIVE_TLS
 
@@ -26,57 +26,56 @@ __thread ThreadLocalStorage TLSInstance;
 
 void InitializeTLS()
 {
-  memset((void *)(realTLS), 0, sizeof(ThreadLocalStorage));
+    memset((void *)(realTLS), 0, sizeof(ThreadLocalStorage));
 }
 
-void InstallTLSHandler(
-	void (*constructor)(),
-	void (*destructor)() )
+void InstallTLSHandler(void (*constructor)(), void (*destructor)())
 {
-  TLSHandler *handler;
-  if (!constructor && !destructor)
-    return;
-  if (TLSHandlerCount >= MAX_TLS_HANDLERS)
-    abort();
-  handler = TLSHandlers + TLSHandlerCount++;
-  handler->constructor = constructor;
-  handler->destructor = destructor;
+    TLSHandler * handler;
+    if (!constructor && !destructor)
+        return;
+    if (TLSHandlerCount >= MAX_TLS_HANDLERS)
+        abort();
+    handler = TLSHandlers + TLSHandlerCount++;
+    handler->constructor = constructor;
+    handler->destructor = destructor;
 }
 
 void RunTLSConstructors()
 {
-  Int i;
-  for (i = 0; i < TLSHandlerCount; i++) {
-    TLSHandler *handler = TLSHandlers + i;
-    if (handler->constructor)
-      handler->constructor();
-  }
+    Int i;
+    for (i = 0; i < TLSHandlerCount; i++) {
+        TLSHandler * handler = TLSHandlers + i;
+        if (handler->constructor)
+            handler->constructor();
+    }
 }
 
 void RunTLSDestructors()
 {
-  Int i;
-  for (i = 0; i < TLSHandlerCount; i++) {
-    TLSHandler *handler = TLSHandlers + i;
-    if (handler->destructor)
-      handler->destructor();
-  }
+    Int i;
+    for (i = 0; i < TLSHandlerCount; i++) {
+        TLSHandler * handler = TLSHandlers + i;
+        if (handler->destructor)
+            handler->destructor();
+    }
 }
 
 static Int ExtraTLSSlot = 0;
 
-Int AllocateExtraTLSSlot() {
-  Int result;
-  HashLock(0);
-  result = ExtraTLSSlot;
-  if (result < TLS_NUM_EXTRA) {
-    ExtraTLSSlot++;
-  }
-  HashUnlock(0);
-  if (result < ExtraTLSSlot)
-    return result;
-  else
-    return -1;
+Int AllocateExtraTLSSlot()
+{
+    Int result;
+    HashLock(0);
+    result = ExtraTLSSlot;
+    if (result < TLS_NUM_EXTRA) {
+        ExtraTLSSlot++;
+    }
+    HashUnlock(0);
+    if (result < ExtraTLSSlot)
+        return result;
+    else
+        return -1;
 }
 
 void InitTLS()

--- a/src/hpc/traverse.c
+++ b/src/hpc/traverse.c
@@ -30,31 +30,32 @@
 #ifndef WARD_ENABLED
 
 typedef struct TraversalState {
-  struct TraversalState *previousTraversal;
-  Obj list;
-  UInt listSize;
-  UInt listCurrent;
-  UInt listCapacity;
-  Obj hashTable;
-  Obj copyMap;
-  UInt hashSize;
-  UInt hashCapacity;
-  UInt hashBits;
-  Region *region;
-  int border;
-  int (*traversalCheck)(Bag bag);
+    struct TraversalState * previousTraversal;
+    Obj                     list;
+    UInt                    listSize;
+    UInt                    listCurrent;
+    UInt                    listCapacity;
+    Obj                     hashTable;
+    Obj                     copyMap;
+    UInt                    hashSize;
+    UInt                    hashCapacity;
+    UInt                    hashBits;
+    Region *                region;
+    int                     border;
+    int (*traversalCheck)(Bag bag);
 } TraversalState;
 
-static inline TraversalState *currentTraversal() {
-  return TLS(traversalState);
+static inline TraversalState * currentTraversal()
+{
+    return TLS(traversalState);
 }
 
 static Obj NewList(UInt size)
 {
-  Obj list;
-  list = NEW_PLIST(size == 0 ? T_PLIST_EMPTY : T_PLIST, size);
-  SET_LEN_PLIST(list, size);
-  return list;
+    Obj list;
+    list = NEW_PLIST(size == 0 ? T_PLIST_EMPTY : T_PLIST, size);
+    SET_LEN_PLIST(list, size);
+    return list;
 }
 
 
@@ -62,205 +63,202 @@ void QueueForTraversal(Obj obj);
 
 #define TRAVERSE_NONE (1)
 #define TRAVERSE_ALL (~0U)
-#define TRAVERSE_ALL_BUT(n) (1 | ((~0U) << (1+(n))))
+#define TRAVERSE_ALL_BUT(n) (1 | ((~0U) << (1 + (n))))
 #define TRAVERSE_BY_FUNCTION (0)
 
 typedef void (*TraversalCopyFunction)(Obj copy, Obj original);
 
-TraversalFunction TraversalFunc[LAST_REAL_TNUM+1];
-TraversalCopyFunction TraversalCopyFunc[LAST_REAL_TNUM+1];
-int TraversalMask[LAST_REAL_TNUM+1];
+TraversalFunction     TraversalFunc[LAST_REAL_TNUM + 1];
+TraversalCopyFunction TraversalCopyFunc[LAST_REAL_TNUM + 1];
+int                   TraversalMask[LAST_REAL_TNUM + 1];
 
 void TraversePList(Obj obj)
 {
-  UInt len = LEN_PLIST(obj);
-  Obj *ptr = ADDR_OBJ(obj)+1;
-  while (len)
-  {
-    QueueForTraversal(*ptr++);
-    len--;
-  }
+    UInt  len = LEN_PLIST(obj);
+    Obj * ptr = ADDR_OBJ(obj) + 1;
+    while (len) {
+        QueueForTraversal(*ptr++);
+        len--;
+    }
 }
 
 void TraverseWPObj(Obj obj)
 {
-  /* This is a hack, we rely on weak pointer objects
-   * having the same layout as plain lists, so we don't
-   * have to replicate the macro here.
-   */
-  UInt len = LEN_PLIST(obj);
-  Obj *ptr = ADDR_OBJ(obj)+1;
-  while (len)
-  {
-    volatile Obj tmp = *ptr;
-    MEMBAR_READ();
-    if (tmp && *ptr)
-      QueueForTraversal(*ptr);
-    ptr++;
-    len--;
-  }
+    /* This is a hack, we rely on weak pointer objects
+     * having the same layout as plain lists, so we don't
+     * have to replicate the macro here.
+     */
+    UInt  len = LEN_PLIST(obj);
+    Obj * ptr = ADDR_OBJ(obj) + 1;
+    while (len) {
+        volatile Obj tmp = *ptr;
+        MEMBAR_READ();
+        if (tmp && *ptr)
+            QueueForTraversal(*ptr);
+        ptr++;
+        len--;
+    }
 }
 
 static UInt FindTraversedObj(Obj);
 
 static inline Obj ReplaceByCopy(Obj obj)
 {
-  TraversalState *traversal = currentTraversal();
-  UInt found = FindTraversedObj(obj);
-  if (found)
-    return ELM_PLIST(traversal->copyMap, found);
-  else if (traversal->border) {
-    if (!IS_BAG_REF(obj) || !REGION(obj) || REGION(obj) == traversal->region)
-      return obj;
+    TraversalState * traversal = currentTraversal();
+    UInt             found = FindTraversedObj(obj);
+    if (found)
+        return ELM_PLIST(traversal->copyMap, found);
+    else if (traversal->border) {
+        if (!IS_BAG_REF(obj) || !REGION(obj) ||
+            REGION(obj) == traversal->region)
+            return obj;
+        else
+            return GetRegionOf(obj)->obj;
+    }
     else
-      return GetRegionOf(obj)->obj;
-  }
-  else
-    return obj;
+        return obj;
 }
 
 void CopyPList(Obj copy, Obj original)
 {
-  UInt len = LEN_PLIST(original);
-  Obj *ptr = ADDR_OBJ(original)+1;
-  Obj *copyptr = ADDR_OBJ(copy)+1;
-  while (len)
-  {
-    *copyptr++ = ReplaceByCopy(*ptr++);
-    len--;
-  }
+    UInt  len = LEN_PLIST(original);
+    Obj * ptr = ADDR_OBJ(original) + 1;
+    Obj * copyptr = ADDR_OBJ(copy) + 1;
+    while (len) {
+        *copyptr++ = ReplaceByCopy(*ptr++);
+        len--;
+    }
 }
 
 void CopyWPObj(Obj copy, Obj original)
 {
-  /* This is a hack, we rely on weak pointer objects
-   * having the same layout as plain lists, so we don't
-   * have to replicate the macro here.
-   */
-  UInt len = LEN_PLIST(original);
-  Obj *ptr = ADDR_OBJ(original)+1;
-  Obj *copyptr = ADDR_OBJ(copy)+1;
-  while (len) {
-    volatile Obj tmp = *ptr;
-    MEMBAR_READ();
-    if (tmp && *ptr)
-      *copyptr = ReplaceByCopy(tmp);
-    REGISTER_WP(copyptr, tmp);
-    ptr++;
-    copyptr++;
-  }
+    /* This is a hack, we rely on weak pointer objects
+     * having the same layout as plain lists, so we don't
+     * have to replicate the macro here.
+     */
+    UInt  len = LEN_PLIST(original);
+    Obj * ptr = ADDR_OBJ(original) + 1;
+    Obj * copyptr = ADDR_OBJ(copy) + 1;
+    while (len) {
+        volatile Obj tmp = *ptr;
+        MEMBAR_READ();
+        if (tmp && *ptr)
+            *copyptr = ReplaceByCopy(tmp);
+        REGISTER_WP(copyptr, tmp);
+        ptr++;
+        copyptr++;
+    }
 }
 
 void TraversePRecord(Obj obj)
 {
-  UInt i, len = LEN_PREC(obj);
-  for (i=1; i<=len; i++)
-    QueueForTraversal((Obj)GET_ELM_PREC(obj, i));
+    UInt i, len = LEN_PREC(obj);
+    for (i = 1; i <= len; i++)
+        QueueForTraversal((Obj)GET_ELM_PREC(obj, i));
 }
 
 void CopyPRecord(Obj copy, Obj original)
 {
-  UInt i,len = LEN_PREC(original);
-  for (i=1; i<=len; i++)
-    SET_ELM_PREC(copy, i, ReplaceByCopy(GET_ELM_PREC(original, i)));
+    UInt i, len = LEN_PREC(original);
+    for (i = 1; i <= len; i++)
+        SET_ELM_PREC(copy, i, ReplaceByCopy(GET_ELM_PREC(original, i)));
 }
 
 void TraverseObjSet(Obj obj)
 {
-  UInt i, len = *(UInt *)(ADDR_OBJ(obj)+OBJSET_SIZE);
-  for (i=0; i<len; i++) {
-    Obj item = ADDR_OBJ(obj)[OBJSET_HDRSIZE+i];
-    if (item && item != Undefined)
-      QueueForTraversal(item);
-  }
+    UInt i, len = *(UInt *)(ADDR_OBJ(obj) + OBJSET_SIZE);
+    for (i = 0; i < len; i++) {
+        Obj item = ADDR_OBJ(obj)[OBJSET_HDRSIZE + i];
+        if (item && item != Undefined)
+            QueueForTraversal(item);
+    }
 }
 
 void CopyObjSet(Obj copy, Obj original)
 {
-  UInt i, len = *(UInt *)(ADDR_OBJ(original)+OBJSET_SIZE);
-  for (i=0; i<len; i++) {
-    Obj item = ADDR_OBJ(original)[OBJSET_HDRSIZE+i];
-    ADDR_OBJ(copy)[OBJSET_HDRSIZE+i] = ReplaceByCopy(item);
-  }
+    UInt i, len = *(UInt *)(ADDR_OBJ(original) + OBJSET_SIZE);
+    for (i = 0; i < len; i++) {
+        Obj item = ADDR_OBJ(original)[OBJSET_HDRSIZE + i];
+        ADDR_OBJ(copy)[OBJSET_HDRSIZE + i] = ReplaceByCopy(item);
+    }
 }
 
 void TraverseObjMap(Obj obj)
 {
-  UInt i, len = *(UInt *)(ADDR_OBJ(obj)+OBJSET_SIZE);
-  for (i=0; i<len; i++) {
-    Obj key = ADDR_OBJ(obj)[OBJSET_HDRSIZE+2*i];
-    Obj val = ADDR_OBJ(obj)[OBJSET_HDRSIZE+2*i+1];
-    if (key && key != Undefined) {
-      QueueForTraversal(key);
-      QueueForTraversal(val);
+    UInt i, len = *(UInt *)(ADDR_OBJ(obj) + OBJSET_SIZE);
+    for (i = 0; i < len; i++) {
+        Obj key = ADDR_OBJ(obj)[OBJSET_HDRSIZE + 2 * i];
+        Obj val = ADDR_OBJ(obj)[OBJSET_HDRSIZE + 2 * i + 1];
+        if (key && key != Undefined) {
+            QueueForTraversal(key);
+            QueueForTraversal(val);
+        }
     }
-  }
 }
 
 void CopyObjMap(Obj copy, Obj original)
 {
-  UInt i, len = *(UInt *)(ADDR_OBJ(original)+OBJSET_SIZE);
-  for (i=0; i<len; i++) {
-    Obj key = ADDR_OBJ(original)[OBJSET_HDRSIZE+2*i];
-    Obj val = ADDR_OBJ(original)[OBJSET_HDRSIZE+2*i+1];
-    ADDR_OBJ(copy)[OBJSET_HDRSIZE+2*i] = ReplaceByCopy(key);
-    ADDR_OBJ(copy)[OBJSET_HDRSIZE+2*i+1] = ReplaceByCopy(val);
-  }
+    UInt i, len = *(UInt *)(ADDR_OBJ(original) + OBJSET_SIZE);
+    for (i = 0; i < len; i++) {
+        Obj key = ADDR_OBJ(original)[OBJSET_HDRSIZE + 2 * i];
+        Obj val = ADDR_OBJ(original)[OBJSET_HDRSIZE + 2 * i + 1];
+        ADDR_OBJ(copy)[OBJSET_HDRSIZE + 2 * i] = ReplaceByCopy(key);
+        ADDR_OBJ(copy)[OBJSET_HDRSIZE + 2 * i + 1] = ReplaceByCopy(val);
+    }
 }
 
 void InitTraversalModule()
 {
-  int i;
-  for (i=FIRST_REAL_TNUM; i<=LAST_REAL_TNUM; i++)
-    TraversalMask[i] = TRAVERSE_NONE;
-  TraversalMask[T_PREC] = TRAVERSE_BY_FUNCTION;
-  TraversalMask[T_PREC+IMMUTABLE] = TRAVERSE_BY_FUNCTION;
-  TraversalFunc[T_PREC] = TraversePRecord;
-  TraversalCopyFunc[T_PREC] = CopyPRecord;
-  TraversalFunc[T_PREC+IMMUTABLE] = TraversePRecord;
-  TraversalCopyFunc[T_PREC+IMMUTABLE] = CopyPRecord;
-  for (i=FIRST_PLIST_TNUM; i<=LAST_PLIST_TNUM; i++)
-  {
-    TraversalMask[i] = TRAVERSE_BY_FUNCTION;
-    TraversalFunc[i] = TraversePList;
-    TraversalCopyFunc[i] = CopyPList;
-  }
-  TraversalMask[T_PLIST_CYC] = TRAVERSE_NONE;
-  TraversalMask[T_PLIST_CYC_NSORT] = TRAVERSE_NONE;
-  TraversalMask[T_PLIST_CYC_SSORT] = TRAVERSE_NONE;
-  TraversalMask[T_PLIST_FFE] = TRAVERSE_NONE;
-  TraversalMask[T_POSOBJ] = TRAVERSE_ALL_BUT(1);
-  TraversalMask[T_COMOBJ] = TRAVERSE_BY_FUNCTION;
-  TraversalFunc[T_COMOBJ] = TraversePRecord;
-  TraversalCopyFunc[T_COMOBJ] = CopyPRecord;
-  TraversalFunc[T_WPOBJ] = TraverseWPObj;
-  TraversalCopyFunc[T_WPOBJ] = CopyWPObj;
-  TraversalMask[T_DATOBJ] = TRAVERSE_NONE;
-  TraversalMask[T_OBJSET] = TRAVERSE_BY_FUNCTION;
-  TraversalFunc[T_OBJSET] = TraverseObjSet;
-  TraversalCopyFunc[T_OBJSET] = CopyObjSet;
-  TraversalMask[T_OBJMAP] = TRAVERSE_BY_FUNCTION;
-  TraversalFunc[T_OBJMAP] = TraverseObjMap;
-  TraversalCopyFunc[T_OBJMAP] = CopyObjMap;
+    int i;
+    for (i = FIRST_REAL_TNUM; i <= LAST_REAL_TNUM; i++)
+        TraversalMask[i] = TRAVERSE_NONE;
+    TraversalMask[T_PREC] = TRAVERSE_BY_FUNCTION;
+    TraversalMask[T_PREC + IMMUTABLE] = TRAVERSE_BY_FUNCTION;
+    TraversalFunc[T_PREC] = TraversePRecord;
+    TraversalCopyFunc[T_PREC] = CopyPRecord;
+    TraversalFunc[T_PREC + IMMUTABLE] = TraversePRecord;
+    TraversalCopyFunc[T_PREC + IMMUTABLE] = CopyPRecord;
+    for (i = FIRST_PLIST_TNUM; i <= LAST_PLIST_TNUM; i++) {
+        TraversalMask[i] = TRAVERSE_BY_FUNCTION;
+        TraversalFunc[i] = TraversePList;
+        TraversalCopyFunc[i] = CopyPList;
+    }
+    TraversalMask[T_PLIST_CYC] = TRAVERSE_NONE;
+    TraversalMask[T_PLIST_CYC_NSORT] = TRAVERSE_NONE;
+    TraversalMask[T_PLIST_CYC_SSORT] = TRAVERSE_NONE;
+    TraversalMask[T_PLIST_FFE] = TRAVERSE_NONE;
+    TraversalMask[T_POSOBJ] = TRAVERSE_ALL_BUT(1);
+    TraversalMask[T_COMOBJ] = TRAVERSE_BY_FUNCTION;
+    TraversalFunc[T_COMOBJ] = TraversePRecord;
+    TraversalCopyFunc[T_COMOBJ] = CopyPRecord;
+    TraversalFunc[T_WPOBJ] = TraverseWPObj;
+    TraversalCopyFunc[T_WPOBJ] = CopyWPObj;
+    TraversalMask[T_DATOBJ] = TRAVERSE_NONE;
+    TraversalMask[T_OBJSET] = TRAVERSE_BY_FUNCTION;
+    TraversalFunc[T_OBJSET] = TraverseObjSet;
+    TraversalCopyFunc[T_OBJSET] = CopyObjSet;
+    TraversalMask[T_OBJMAP] = TRAVERSE_BY_FUNCTION;
+    TraversalFunc[T_OBJMAP] = TraverseObjMap;
+    TraversalCopyFunc[T_OBJMAP] = CopyObjMap;
 }
 
-static void BeginTraversal(TraversalState *traversal)
+static void BeginTraversal(TraversalState * traversal)
 {
-  traversal->hashTable = NewList(16);
-  traversal->hashSize = 0;
-  traversal->hashCapacity = 16;
-  traversal->hashBits = 4;
-  traversal->list = NewList(10);
-  traversal->listSize = 0;
-  traversal->listCapacity = 10;
-  traversal->listCurrent = 0;
-  traversal->previousTraversal = currentTraversal();
-  TLS(traversalState) = traversal;
+    traversal->hashTable = NewList(16);
+    traversal->hashSize = 0;
+    traversal->hashCapacity = 16;
+    traversal->hashBits = 4;
+    traversal->list = NewList(10);
+    traversal->listSize = 0;
+    traversal->listCapacity = 10;
+    traversal->listCurrent = 0;
+    traversal->previousTraversal = currentTraversal();
+    TLS(traversalState) = traversal;
 }
 
 static void EndTraversal()
 {
-  TLS(traversalState) = currentTraversal()->previousTraversal;
+    TLS(traversalState) = currentTraversal()->previousTraversal;
 }
 
 #if SIZEOF_VOID_P == 4
@@ -270,302 +268,295 @@ static void EndTraversal()
 #endif
 #define TRAV_HASH_BITS (SIZEOF_VOID_P * 8)
 
-static void TraversalRehash(TraversalState *traversal);
+static void TraversalRehash(TraversalState * traversal);
 
 static int SeenDuringTraversal(Obj obj)
 {
-  TraversalState *traversal = currentTraversal();
-  Obj *hashTable;
-  unsigned long hash;
-  if (!IS_BAG_REF(obj))
-    return 0;
-  if (traversal->hashSize * 3 / 2 >= traversal->hashCapacity)
-    TraversalRehash(traversal);
-  hash = ((unsigned long) obj) * TRAV_HASH_MULT;
-  hash >>= TRAV_HASH_BITS - traversal->hashBits;
-  hashTable = ADDR_OBJ(traversal->hashTable)+1;
-  for (;;)
-  {
-    if (hashTable[hash] == NULL)
-    {
-      hashTable[hash] = obj;
-      traversal->hashSize++;
-      return 1;
+    TraversalState * traversal = currentTraversal();
+    Obj *            hashTable;
+    unsigned long    hash;
+    if (!IS_BAG_REF(obj))
+        return 0;
+    if (traversal->hashSize * 3 / 2 >= traversal->hashCapacity)
+        TraversalRehash(traversal);
+    hash = ((unsigned long)obj) * TRAV_HASH_MULT;
+    hash >>= TRAV_HASH_BITS - traversal->hashBits;
+    hashTable = ADDR_OBJ(traversal->hashTable) + 1;
+    for (;;) {
+        if (hashTable[hash] == NULL) {
+            hashTable[hash] = obj;
+            traversal->hashSize++;
+            return 1;
+        }
+        if (hashTable[hash] == obj)
+            return 0;
+        hash = (hash + 1) & (traversal->hashCapacity - 1);
     }
-    if (hashTable[hash] == obj)
-      return 0;
-    hash = (hash + 1) & (traversal->hashCapacity-1);
-  }
 }
 
 static UInt FindTraversedObj(Obj obj)
 {
-  TraversalState *traversal = currentTraversal();
-  Obj *hashTable = ADDR_OBJ(traversal->hashTable)+1;
-  UInt hash;
-  if (!IS_BAG_REF(obj))
-    return 0;
-  hash = ((UInt) obj) * TRAV_HASH_MULT;
-  hash >>= TRAV_HASH_BITS - traversal->hashBits;
-  for (;;)
-  {
-    if (hashTable[hash] == obj)
-      return (int) hash+1;
-    if (hashTable[hash] == NULL)
-      return 0;
-    hash = (hash + 1) & (traversal->hashCapacity-1);
-  }
+    TraversalState * traversal = currentTraversal();
+    Obj *            hashTable = ADDR_OBJ(traversal->hashTable) + 1;
+    UInt             hash;
+    if (!IS_BAG_REF(obj))
+        return 0;
+    hash = ((UInt)obj) * TRAV_HASH_MULT;
+    hash >>= TRAV_HASH_BITS - traversal->hashBits;
+    for (;;) {
+        if (hashTable[hash] == obj)
+            return (int)hash + 1;
+        if (hashTable[hash] == NULL)
+            return 0;
+        hash = (hash + 1) & (traversal->hashCapacity - 1);
+    }
 }
 
-static void TraversalRehash(TraversalState *traversal)
+static void TraversalRehash(TraversalState * traversal)
 {
-  Obj list = NewList(traversal->hashCapacity * 2);
-  int oldsize = traversal->hashCapacity;
-  int i;
-  Obj oldlist = traversal->hashTable;
-  traversal->hashCapacity *= 2;
-  traversal->hashTable = list;
-  traversal->hashSize = 0;
-  traversal->hashBits++;
-  for (i = 1; i <= oldsize; i++)
-  {
-    Obj obj = ADDR_OBJ(oldlist)[i];
-    if (obj != NULL)
-      SeenDuringTraversal(obj);
-  }
+    Obj list = NewList(traversal->hashCapacity * 2);
+    int oldsize = traversal->hashCapacity;
+    int i;
+    Obj oldlist = traversal->hashTable;
+    traversal->hashCapacity *= 2;
+    traversal->hashTable = list;
+    traversal->hashSize = 0;
+    traversal->hashBits++;
+    for (i = 1; i <= oldsize; i++) {
+        Obj obj = ADDR_OBJ(oldlist)[i];
+        if (obj != NULL)
+            SeenDuringTraversal(obj);
+    }
 }
 
 void QueueForTraversal(Obj obj)
 {
-  int i;
-  TraversalState *traversal;
-  if (!IS_BAG_REF(obj))
-    return; /* skip ojects that aren't bags */
-  traversal = currentTraversal();
-  if (!traversal->traversalCheck(obj))
-    return;
-  if (!SeenDuringTraversal(obj))
-    return; /* don't revisit objects that we've already seen */
-  if (traversal->listSize == traversal->listCapacity)
-  {
-    unsigned oldcapacity = traversal->listCapacity;
-    unsigned newcapacity = oldcapacity * 25/16; /* 25/16 < golden ratio */
-    Obj oldlist = traversal->list;
-    Obj list = NewList(newcapacity);
-    for (i=1; i<=oldcapacity; i++)
-      ADDR_OBJ(list)[i] = ADDR_OBJ(oldlist)[i];
-    traversal->list = list;
-    traversal->listCapacity = newcapacity;
-  }
-  ADDR_OBJ(traversal->list)[++traversal->listSize] = obj;
+    int              i;
+    TraversalState * traversal;
+    if (!IS_BAG_REF(obj))
+        return; /* skip ojects that aren't bags */
+    traversal = currentTraversal();
+    if (!traversal->traversalCheck(obj))
+        return;
+    if (!SeenDuringTraversal(obj))
+        return; /* don't revisit objects that we've already seen */
+    if (traversal->listSize == traversal->listCapacity) {
+        unsigned oldcapacity = traversal->listCapacity;
+        unsigned newcapacity =
+            oldcapacity * 25 / 16; /* 25/16 < golden ratio */
+        Obj oldlist = traversal->list;
+        Obj list = NewList(newcapacity);
+        for (i = 1; i <= oldcapacity; i++)
+            ADDR_OBJ(list)[i] = ADDR_OBJ(oldlist)[i];
+        traversal->list = list;
+        traversal->listCapacity = newcapacity;
+    }
+    ADDR_OBJ(traversal->list)[++traversal->listSize] = obj;
 }
 
-void TraverseRegionFrom(
-    TraversalState *traversal,
-    Obj obj,
-    int (*traversalCheck)(Obj)
-)
+void TraverseRegionFrom(TraversalState * traversal,
+                        Obj              obj,
+                        int (*traversalCheck)(Obj))
 {
-  if (!IS_BAG_REF(obj) || !REGION(obj) || !CheckReadAccess(obj)) {
-    traversal->list = NewList(0);
-    return;
-  }
-  traversal->traversalCheck = traversalCheck;
-  traversal->region = REGION(obj);
-  QueueForTraversal(obj);
-  while (traversal->listCurrent < traversal->listSize)
-  {
-    Obj current = ADDR_OBJ(traversal->list)[++traversal->listCurrent];
-    int tnum = TNUM_BAG(current);
-    int mask = TraversalMask[TNUM_BAG(current)];
-    if (!mask)
-      TraversalFunc[tnum](current);
-    else
-    {
-      int size = SIZE_BAG(current)/sizeof(Obj);
-      Obj *ptr = PTR_BAG(current);
-      mask >>= 1;
-      while (mask && size)
-      {
-        if (mask & 1)
-	  QueueForTraversal(*ptr);
-	ptr++;
-	size--;
-	mask >>= 1;
-      }
+    if (!IS_BAG_REF(obj) || !REGION(obj) || !CheckReadAccess(obj)) {
+        traversal->list = NewList(0);
+        return;
     }
-  }
-  SET_LEN_PLIST(traversal->list, traversal->listSize);
+    traversal->traversalCheck = traversalCheck;
+    traversal->region = REGION(obj);
+    QueueForTraversal(obj);
+    while (traversal->listCurrent < traversal->listSize) {
+        Obj current = ADDR_OBJ(traversal->list)[++traversal->listCurrent];
+        int tnum = TNUM_BAG(current);
+        int mask = TraversalMask[TNUM_BAG(current)];
+        if (!mask)
+            TraversalFunc[tnum](current);
+        else {
+            int   size = SIZE_BAG(current) / sizeof(Obj);
+            Obj * ptr = PTR_BAG(current);
+            mask >>= 1;
+            while (mask && size) {
+                if (mask & 1)
+                    QueueForTraversal(*ptr);
+                ptr++;
+                size--;
+                mask >>= 1;
+            }
+        }
+    }
+    SET_LEN_PLIST(traversal->list, traversal->listSize);
 }
 
 // static int IsReadable(Obj obj) {
 //   return CheckReadAccess(obj);
 // }
 
-static int IsSameRegion(Obj obj) {
-  return REGION(obj) == currentTraversal()->region;
+static int IsSameRegion(Obj obj)
+{
+    return REGION(obj) == currentTraversal()->region;
 }
 
-static int IsMutable(Obj obj) {
-  return CheckReadAccess(obj) && IS_MUTABLE_OBJ(obj);
+static int IsMutable(Obj obj)
+{
+    return CheckReadAccess(obj) && IS_MUTABLE_OBJ(obj);
 }
 
-static int IsWritableOrImmutable(Obj obj) {
-  int writable = CheckExclusiveWriteAccess(obj);
-  if (!writable && IS_MUTABLE_OBJ(obj)) {
-    currentTraversal()->border = 1;
-    return 0;
-  }
-  return 1;
+static int IsWritableOrImmutable(Obj obj)
+{
+    int writable = CheckExclusiveWriteAccess(obj);
+    if (!writable && IS_MUTABLE_OBJ(obj)) {
+        currentTraversal()->border = 1;
+        return 0;
+    }
+    return 1;
 }
 
 Obj ReachableObjectsFrom(Obj obj)
 {
-  TraversalState traversal;
-  if (!IS_BAG_REF(obj) || REGION(obj) == NULL)
-    return NewList(0);
-  BeginTraversal(&traversal);
-  traversal.traversalCheck = IsSameRegion;
-  TraverseRegionFrom(&traversal, obj, IsSameRegion);
-  EndTraversal();
-  return traversal.list;
+    TraversalState traversal;
+    if (!IS_BAG_REF(obj) || REGION(obj) == NULL)
+        return NewList(0);
+    BeginTraversal(&traversal);
+    traversal.traversalCheck = IsSameRegion;
+    TraverseRegionFrom(&traversal, obj, IsSameRegion);
+    EndTraversal();
+    return traversal.list;
 }
 
 static Obj CopyBag(Obj copy, Obj original)
 {
-  UInt size = SIZE_BAG(original);
-  UInt type = TNUM_BAG(original);
-  int mask = TraversalMask[type];
-  memcpy(ADDR_OBJ(copy), ADDR_OBJ(original), size);
-  if (mask)
-  {
-    Obj *ptr = ADDR_OBJ(copy);
-    size = size / sizeof(Obj);
-    mask >>= 1;
-    while (size && mask)
-    {
-      if (mask & 1)
-        *ptr = ReplaceByCopy(*ptr);
-      ptr++;
-      size -= 1;
-      mask >>= 1;
+    UInt size = SIZE_BAG(original);
+    UInt type = TNUM_BAG(original);
+    int  mask = TraversalMask[type];
+    memcpy(ADDR_OBJ(copy), ADDR_OBJ(original), size);
+    if (mask) {
+        Obj * ptr = ADDR_OBJ(copy);
+        size = size / sizeof(Obj);
+        mask >>= 1;
+        while (size && mask) {
+            if (mask & 1)
+                *ptr = ReplaceByCopy(*ptr);
+            ptr++;
+            size -= 1;
+            mask >>= 1;
+        }
     }
-  } else {
-    TraversalCopyFunc[type](copy, original);
-  }
-  return copy;
+    else {
+        TraversalCopyFunc[type](copy, original);
+    }
+    return copy;
 }
 
 int PreMakeImmutableCheck(Obj obj)
 {
-  TraversalState traversal;
-  if (!IS_BAG_REF(obj))
-    return 1;
-  if (!IS_MUTABLE_OBJ(obj))
-    return 1;
-  if (!CheckExclusiveWriteAccess(obj))
-    return 0;
-  switch (TNUM_OBJ(obj)) {
+    TraversalState traversal;
+    if (!IS_BAG_REF(obj))
+        return 1;
+    if (!IS_MUTABLE_OBJ(obj))
+        return 1;
+    if (!CheckExclusiveWriteAccess(obj))
+        return 0;
+    switch (TNUM_OBJ(obj)) {
     case T_STRING:
-      return 1;
-  }
-  BeginTraversal(&traversal);
-  traversal.border = 0;
-  TraverseRegionFrom(&traversal, obj, IsWritableOrImmutable);
-  EndTraversal();
-  return !traversal.border;
+        return 1;
+    }
+    BeginTraversal(&traversal);
+    traversal.border = 0;
+    TraverseRegionFrom(&traversal, obj, IsWritableOrImmutable);
+    EndTraversal();
+    return !traversal.border;
 }
 
 Obj CopyReachableObjectsFrom(Obj obj, int delimited, int asList, int imm)
 {
-  Obj *traversed, *copies, copyList;
-  TraversalState traversal;
-  UInt len, i;
-  if (!IS_BAG_REF(obj) || REGION(obj) == NULL)
-  {
-    if (asList) {
-      copyList = NewList(1);
-      SET_ELM_PLIST(copyList, 1, obj);
-      return copyList;
-    } else
-      return obj;
-  }
-  BeginTraversal(&traversal);
-  if (imm) {
-    if (!IS_MUTABLE_OBJ(obj))
-      return obj;
-    TraverseRegionFrom(&traversal, obj, IsMutable);
-  }
-  else
-    TraverseRegionFrom(&traversal, obj, IsSameRegion);
-  traversed = ADDR_OBJ(traversal.list);
-  len = LEN_PLIST(traversal.list);
-  copyList = NewList(len);
-  copies = ADDR_OBJ(copyList);
-  traversal.border = delimited;
-  if (len == 0) {
+    Obj *          traversed, *copies, copyList;
+    TraversalState traversal;
+    UInt           len, i;
+    if (!IS_BAG_REF(obj) || REGION(obj) == NULL) {
+        if (asList) {
+            copyList = NewList(1);
+            SET_ELM_PLIST(copyList, 1, obj);
+            return copyList;
+        }
+        else
+            return obj;
+    }
+    BeginTraversal(&traversal);
+    if (imm) {
+        if (!IS_MUTABLE_OBJ(obj))
+            return obj;
+        TraverseRegionFrom(&traversal, obj, IsMutable);
+    }
+    else
+        TraverseRegionFrom(&traversal, obj, IsSameRegion);
+    traversed = ADDR_OBJ(traversal.list);
+    len = LEN_PLIST(traversal.list);
+    copyList = NewList(len);
+    copies = ADDR_OBJ(copyList);
+    traversal.border = delimited;
+    if (len == 0) {
+        EndTraversal();
+        if (delimited)
+            return GetRegionOf(obj)->obj;
+        ErrorQuit("Object not in a readable region", 0L, 0L);
+    }
+    traversal.copyMap = NewList(LEN_PLIST(traversal.hashTable));
+    for (i = 1; i <= len; i++) {
+        UInt loc = FindTraversedObj(traversed[i]);
+        if (loc) {
+            Obj original = traversed[i];
+            Obj copy;
+            copy = NewBag(TNUM_BAG(original), SIZE_BAG(original));
+            SET_ELM_PLIST(traversal.copyMap, loc, copy);
+            copies[i] = copy;
+        }
+    }
+    for (i = 1; i <= len; i++)
+        if (copies[i])
+            CopyBag(copies[i], traversed[i]);
     EndTraversal();
-    if (delimited)
-      return GetRegionOf(obj)->obj;
-    ErrorQuit("Object not in a readable region", 0L, 0L);
-  }
-  traversal.copyMap = NewList(LEN_PLIST(traversal.hashTable));
-  for (i = 1; i<=len; i++) {
-    UInt loc = FindTraversedObj(traversed[i]);
-    if (loc) {
-      Obj original = traversed[i];
-      Obj copy;
-      copy = NewBag(TNUM_BAG(original), SIZE_BAG(original));
-      SET_ELM_PLIST(traversal.copyMap, loc, copy);
-      copies[i] = copy;
+    if (imm) {
+        for (i = 1; i <= len; i++) {
+            if (copies[i])
+                MakeImmutable(copies[i]);
+        }
     }
-  }
-  for (i=1; i<=len; i++)
-    if (copies[i])
-      CopyBag(copies[i], traversed[i]);
-  EndTraversal();
-  if (imm) {
-    for (i=1; i<=len; i++) {
-      if (copies[i])
-        MakeImmutable(copies[i]);
-    }
-  }
-  if (asList)
-    return copyList;
-  else
-    return copies[1];
+    if (asList)
+        return copyList;
+    else
+        return copies[1];
 }
 
 Obj CopyTraversed(Obj traversedList)
 {
-  Obj copyList, *copies, *traversed;
-  TraversalState traversal;
-  UInt len, i;
-  traversed = ADDR_OBJ(traversedList);
-  BeginTraversal(&traversal);
-  len = LEN_PLIST(traversedList);
-  if (len == 1) {
-    Obj obj = traversed[1];
-    if (!IS_BAG_REF(obj) || REGION(obj) == NULL)
-      return obj;
-  }
-  for (i=1; i<=len; i++)
-    SeenDuringTraversal(traversed[i]);
-  copyList = NewList(len);
-  copies = ADDR_OBJ(copyList);
-  traversal.copyMap = NewList(LEN_PLIST(traversal.hashTable));
-  for (i=1; i<=len; i++) {
-    Obj original = traversed[i];
-    UInt loc = FindTraversedObj(original);
-    Obj copy;
-    copy = NewBag(TNUM_BAG(original), SIZE_BAG(original));
-    SET_ELM_PLIST(traversal.copyMap, loc, copy);
-    copies[i] = copy;
-  }
-  for (i=1; i<=len; i++)
-    CopyBag(copies[i], traversed[i]);
-  EndTraversal();
-  return copies[1];
+    Obj            copyList, *copies, *traversed;
+    TraversalState traversal;
+    UInt           len, i;
+    traversed = ADDR_OBJ(traversedList);
+    BeginTraversal(&traversal);
+    len = LEN_PLIST(traversedList);
+    if (len == 1) {
+        Obj obj = traversed[1];
+        if (!IS_BAG_REF(obj) || REGION(obj) == NULL)
+            return obj;
+    }
+    for (i = 1; i <= len; i++)
+        SeenDuringTraversal(traversed[i]);
+    copyList = NewList(len);
+    copies = ADDR_OBJ(copyList);
+    traversal.copyMap = NewList(LEN_PLIST(traversal.hashTable));
+    for (i = 1; i <= len; i++) {
+        Obj  original = traversed[i];
+        UInt loc = FindTraversedObj(original);
+        Obj  copy;
+        copy = NewBag(TNUM_BAG(original), SIZE_BAG(original));
+        SET_ELM_PLIST(traversal.copyMap, loc, copy);
+        copies[i] = copy;
+    }
+    for (i = 1; i <= len; i++)
+        CopyBag(copies[i], traversed[i]);
+    EndTraversal();
+    return copies[1];
 }
 
 #endif


### PR DESCRIPTION
This PR reformats all `src/hpc/*.c` files using `clang-format`. This is because I had to modify some of them, and didn't want to imitate the arguably "wrong" code formatting in my fixes. (Those files mixed tabs and spaces and otherwise wildly diverged from our code formatting elsewhere, yet are light enough on comments to make the default clang-format usable with almost no manual post-processing).