### PR TITLE
Fix issue 395

### DIFF
--- a/lib/semirel.gi
+++ b/lib/semirel.gi
@@ -498,28 +498,30 @@ x->GreensJClasses(Source(x)));
 ##
 ##  returns the XClass containing <hclass>, <lclass>, or <rclass>
 
-InstallMethod(RClassOfHClass, "for a Green's H-class", true, [IsGreensHClass], 0,
-    function(hc)
-    local x;
-    x:=GreensRClasses(ParentAttr(hc));
-    return First(x, y-> Representative(hc) in y);
+InstallMethod(RClassOfHClass, "for a Green's H-class", [IsGreensHClass],
+function(H)
+  return GreensRClassOfElement(Parent(H), Representative(H));
 end);
 
-InstallMethod(LClassOfHClass, "for a Green's H-class", true, [IsGreensHClass], 0,
-  function(hc)
-       local x;
-    x:=GreensLClasses(ParentAttr(hc));
-    return First(x, y-> Representative(hc) in y);
+InstallMethod(LClassOfHClass, "for a Green's H-class", [IsGreensHClass],
+function(H)
+  return GreensLClassOfElement(Parent(H), Representative(H));
 end);
 
-InstallMethod(DClassOfHClass, "for a Green's H-class", true, [IsGreensHClass], 0,
- x-> DClassOfHClass(CanonicalGreensClass(x)));
+InstallMethod(DClassOfHClass, "for a Green's H-class", [IsGreensHClass],
+function(H)
+  return GreensDClassOfElement(Parent(H), Representative(H));
+end);
 
-InstallMethod(DClassOfLClass, "for a Green's L-class", true, [IsGreensLClass], 0,
- x-> DClassOfLClass(CanonicalGreensClass(x)));
+InstallMethod(DClassOfLClass, "for a Green's L-class", [IsGreensLClass],
+function(L)
+  return GreensDClassOfElement(Parent(L), Representative(L));
+end);
 
-InstallMethod(DClassOfRClass, "for a Green's R-class", true, [IsGreensRClass], 0,
- x-> DClassOfRClass(CanonicalGreensClass(x)));
+InstallMethod(DClassOfRClass, "for a Green's R-class", [IsGreensRClass],
+function(R)
+  return GreensDClassOfElement(Parent(R), Representative(R));
+end);
 
 #################
 #################

--- a/tst/testinstall/semirel.tst
+++ b/tst/testinstall/semirel.tst
@@ -114,6 +114,27 @@ gap> ForAll(GreensHClasses(t4),
 > and KernelOfTransformation(j,4) = KernelOfTransformation(Representative(i),4)
 > ));
 true
+
+# Issue 395 (recursion depth trap in DClassOfLClass)
+gap> S := Semigroup(Transformation([2, 4, 3, 4]), 
+>                   Transformation([3, 3, 2, 3]));
+<transformation semigroup of degree 4 with 2 generators>
+gap> L := GreensLClassOfElement(S, S.1);
+<Green's L-class: Transformation( [ 2, 4, 3, 4 ] )>
+gap> DClassOfLClass(L);
+<Green's D-class: Transformation( [ 2, 4, 3, 4 ] )>
+gap> R := GreensRClassOfElement(S, S.1);
+<Green's R-class: Transformation( [ 2, 4, 3, 4 ] )>
+gap> DClassOfRClass(R);
+<Green's D-class: Transformation( [ 2, 4, 3, 4 ] )>
+gap> H := GreensHClassOfElement(S, S.1);
+<Green's H-class: Transformation( [ 2, 4, 3, 4 ] )>
+gap> DClassOfHClass(H);
+<Green's D-class: Transformation( [ 2, 4, 3, 4 ] )>
+gap> LClassOfHClass(H);
+<Green's L-class: Transformation( [ 2, 4, 3, 4 ] )>
+gap> RClassOfHClass(H);
+<Green's R-class: Transformation( [ 2, 4, 3, 4 ] )>
 gap> STOP_TEST( "semirel.tst", 1);
 
 #############################################################################


### PR DESCRIPTION
This commit resolves Issue #395 by installing a working method for
`DClassOfLClass`, `DClassOfRClass`, and `DClassOfHClass`, which previously ended in a recursion depth trap. The new methods are more robust and simpler than the previous ones. 