### PR TITLE
Rename util.h -> utils.h

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -103,7 +103,7 @@
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/tls.h>                /* thread-local storage */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 
 /****************************************************************************

--- a/src/gap.c
+++ b/src/gap.c
@@ -117,7 +117,7 @@
 #include <src/intfuncs.h>
 #include <src/iostream.h>
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 /****************************************************************************
 **

--- a/src/gaputils.h
+++ b/src/gaputils.h
@@ -4,8 +4,8 @@
 **
 */
 
-#ifndef GAP_UTIL_H
-#define GAP_UTIL_H
+#ifndef GAP_UTILS_H
+#define GAP_UTILS_H
 
 /****************************************************************************
 **
@@ -17,4 +17,4 @@
 static inline Int AlwaysYes(Obj obj) { return 1; }
 static inline Int AlwaysNo(Obj obj) { return 0; }
 
-#endif // GAP_UTIL_H
+#endif // GAP_UTILS_H

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -57,7 +57,7 @@
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/aobjects.h>           /* atomic objects */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 #ifdef HPCGAP
 #include <src/hpc/systhread.h>          /* system thread primitives */

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -49,7 +49,7 @@
 #include <src/hpc/thread.h>
 #include <src/hpc/tls.h>
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 /* List of active hooks */
 struct InterpreterHooks * activeHooks[HookCount];

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -62,7 +62,7 @@
 
 #include <src/compiler.h>               /* compiler */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 
 Obj TYPE_ALIST;

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -65,7 +65,7 @@
 
 #include <src/compiler.h>               /* compiler */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 
 struct WaitList {

--- a/src/lists.c
+++ b/src/lists.c
@@ -54,7 +54,7 @@
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/tls.h>                /* thread-local storage */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 
 /****************************************************************************

--- a/src/objects.c
+++ b/src/objects.c
@@ -47,7 +47,7 @@
 #include <src/hpc/traverse.h>           /* object traversal */
 #include <src/hpc/tls.h>                /* thread-local storage */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 
 static Int lastFreePackageTNUM = FIRST_PACKAGE_TNUM;

--- a/src/objset.c
+++ b/src/objset.c
@@ -32,7 +32,7 @@
 
 #include <src/hpc/tls.h>
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 Obj TYPE_OBJSET;
 Obj TYPE_OBJMAP;

--- a/src/plist.c
+++ b/src/plist.c
@@ -70,7 +70,7 @@
 #include <src/hpc/thread.h>
 #include <src/hpc/tls.h>
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 #include <assert.h>
 

--- a/src/precord.c
+++ b/src/precord.c
@@ -61,7 +61,7 @@
 #include <src/hpc/tls.h>                /* thread-local storage */
 #include <src/hpc/aobjects.h>           /* thread-local storage */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 
 /****************************************************************************

--- a/src/range.c
+++ b/src/range.c
@@ -82,7 +82,7 @@
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/tls.h>                /* thread-local storage */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 
 /****************************************************************************

--- a/src/records.c
+++ b/src/records.c
@@ -43,7 +43,7 @@
 
 #include <src/hpc/systhread.h>          /* system thread primitives */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 
 /****************************************************************************

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -38,7 +38,7 @@
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/tls.h>                /* thread-local storage */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 /***************************************************************************
 **

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -67,7 +67,7 @@
 
 #include <src/code.h>                   /* FilenameCache */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 #include <assert.h>
 #include <limits.h>

--- a/src/stats.c
+++ b/src/stats.c
@@ -57,7 +57,7 @@
 
 #include <src/hookintrprtr.h>           /* visit statements for profiling */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 
 /****************************************************************************

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -81,7 +81,7 @@
 #include <src/saveload.h>               /* saving and loading */
 #include <src/hpc/tls.h>                /* thread-local storage */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 #include <assert.h>
 

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -45,7 +45,7 @@
 
 #include <src/read.h>                   /* reader */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 #include <assert.h>
 #include <fcntl.h>

--- a/src/system.c
+++ b/src/system.c
@@ -26,7 +26,7 @@
 
 #include <src/sysfiles.h>               /* file input/output */
 #include <src/gasman.h>
-#include <src/util.h>
+#include <src/gaputils.h>
 
 #ifdef HPCGAP
 #include <src/hpc/misc.h>

--- a/src/vars.c
+++ b/src/vars.c
@@ -55,7 +55,7 @@
 
 #include <src/hookintrprtr.h>           /* installing methods */
 
-#include <src/util.h>
+#include <src/gaputils.h>
 
 
 /****************************************************************************


### PR DESCRIPTION
This avoids a name clash with a BSD system header.