### PR TITLE
When printing function bodies, avoid some redundant spaces

### DIFF
--- a/hpcgap/src/c_filter1.c
+++ b/hpcgap/src/c_filter1.c
@@ -555,7 +555,7 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CLEAR__IMP__CACHE, 0 );
  
  /* BIND_GLOBAL( "CLEAR_IMP_CACHE", function (  )
-      local  lock;
+      local lock;
       lock := WRITE_LOCK( IMPLICATIONS );
       WITH_IMPS_FLAGS_CACHE := MigrateObj( [  ], IMPLICATIONS );
       UNLOCK( lock );
@@ -574,13 +574,13 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "WITH_IMPS_FLAGS", function ( flags )
-      local  with, changed, imp, hash, hash2, i, lock;
+      local with, changed, imp, hash, hash2, i, lock;
       hash := HASH_FLAGS( flags ) mod 11001;
       lock := WRITE_LOCK( IMPLICATIONS );
-      for i  in [ 0 .. 3 ]  do
+      for i in [ 0 .. 3 ] do
           hash2 := 2 * ((hash + 31 * i) mod 11001) + 1;
-          if IsBound( WITH_IMPS_FLAGS_CACHE[hash2] )  then
-              if IS_IDENTICAL_OBJ( WITH_IMPS_FLAGS_CACHE[hash2], flags )  then
+          if IsBound( WITH_IMPS_FLAGS_CACHE[hash2] ) then
+              if IS_IDENTICAL_OBJ( WITH_IMPS_FLAGS_CACHE[hash2], flags ) then
                   WITH_IMPS_FLAGS_CACHE_HIT := WITH_IMPS_FLAGS_CACHE_HIT + 1;
                   with := WITH_IMPS_FLAGS_CACHE[hash2 + 1];
                   UNLOCK( lock );
@@ -590,7 +590,7 @@ static Obj  HdlrFunc1 (
               break;
           fi;
       od;
-      if i = 3  then
+      if i = 3 then
           WITH_IMPS_FLAGS_COUNT := (WITH_IMPS_FLAGS_COUNT + 1) mod 4;
           i := WITH_IMPS_FLAGS_COUNT;
           hash2 := 2 * ((hash + 31 * i) mod 11001) + 1;
@@ -598,10 +598,10 @@ static Obj  HdlrFunc1 (
       WITH_IMPS_FLAGS_CACHE_MISS := WITH_IMPS_FLAGS_CACHE_MISS + 1;
       with := flags;
       changed := true;
-      while changed  do
+      while changed do
           changed := false;
-          for imp  in IMPLICATIONS  do
-              if IS_SUBSET_FLAGS( with, imp[2] ) and not IS_SUBSET_FLAGS( with, imp[1] )  then
+          for imp in IMPLICATIONS do
+              if IS_SUBSET_FLAGS( with, imp[2] ) and not IS_SUBSET_FLAGS( with, imp[1] ) then
                   with := AND_FLAGS( with, imp[1] );
                   changed := true;
               fi;
@@ -625,16 +625,16 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "RankFilter", function ( filter )
-      local  rank, flags, i, lock;
+      local rank, flags, i, lock;
       rank := 0;
-      if IS_FUNCTION( filter )  then
+      if IS_FUNCTION( filter ) then
           flags := FLAGS_FILTER( filter );
       else
           flags := filter;
       fi;
       lock := WRITE_LOCK( FILTER_REGION );
-      for i  in TRUES_FLAGS( WITH_HIDDEN_IMPS_FLAGS( flags ) )  do
-          if IsBound( RANK_FILTERS[i] )  then
+      for i in TRUES_FLAGS( WITH_HIDDEN_IMPS_FLAGS( flags ) ) do
+          if IsBound( RANK_FILTERS[i] ) then
               rank := rank + RANK_FILTERS[i];
           else
               rank := rank + 1;

--- a/hpcgap/src/c_methsel1.c
+++ b/hpcgap/src/c_methsel1.c
@@ -4642,10 +4642,10 @@ static Obj  HdlrFunc1 (
  SET_BRK_CURR_STAT(0);
  
  /* METHOD_0ARGS := function ( operation )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 0 );
-      for i  in [ 1, 5 .. LEN_LIST( methods ) - 3 ]  do
-          if methods[i](  )  then
+      for i in [ 1, 5 .. LEN_LIST( methods ) - 3 ] do
+          if methods[i](  ) then
               return methods[i + 1];
           fi;
       od;
@@ -4662,10 +4662,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__0ARGS, t_1 );
  
  /* METHOD_1ARGS := function ( operation, type1 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 1 );
-      for i  in [ 1, 6 .. LEN_LIST( methods ) - 4 ]  do
-          if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and methods[i]( type1![1] )  then
+      for i in [ 1, 6 .. LEN_LIST( methods ) - 4 ] do
+          if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and methods[i]( type1![1] ) then
               return methods[i + 2];
           fi;
       od;
@@ -4682,10 +4682,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__1ARGS, t_1 );
  
  /* METHOD_2ARGS := function ( operation, type1, type2 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 2 );
-      for i  in [ 1, 7 .. LEN_LIST( methods ) - 5 ]  do
-          if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and methods[i]( type1![1], type2![1] )  then
+      for i in [ 1, 7 .. LEN_LIST( methods ) - 5 ] do
+          if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and methods[i]( type1![1], type2![1] ) then
               return methods[i + 3];
           fi;
       od;
@@ -4702,10 +4702,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__2ARGS, t_1 );
  
  /* METHOD_3ARGS := function ( operation, type1, type2, type3 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 3 );
-      for i  in [ 1, 8 .. LEN_LIST( methods ) - 6 ]  do
-          if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and IS_SUBSET_FLAGS( type3![2], methods[i + 3] ) and methods[i]( type1![1], type2![1], type3![1] )  then
+      for i in [ 1, 8 .. LEN_LIST( methods ) - 6 ] do
+          if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and IS_SUBSET_FLAGS( type3![2], methods[i + 3] ) and methods[i]( type1![1], type2![1], type3![1] ) then
               return methods[i + 4];
           fi;
       od;
@@ -4722,11 +4722,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__3ARGS, t_1 );
  
  /* METHOD_4ARGS := function ( operation, type1, type2, type3, type4 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 4 );
-      for i  in [ 1, 9 .. LEN_LIST( methods ) - 7 ]  do
+      for i in [ 1, 9 .. LEN_LIST( methods ) - 7 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and IS_SUBSET_FLAGS( type3![2], methods[i + 3] ) and IS_SUBSET_FLAGS( type4![2], methods[i + 4] ) 
-              and methods[i]( type1![1], type2![1], type3![1], type4![1] )  then
+              and methods[i]( type1![1], type2![1], type3![1], type4![1] ) then
               return methods[i + 5];
           fi;
       od;
@@ -4743,11 +4743,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__4ARGS, t_1 );
  
  /* METHOD_5ARGS := function ( operation, type1, type2, type3, type4, type5 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 5 );
-      for i  in [ 1, 10 .. LEN_LIST( methods ) - 8 ]  do
+      for i in [ 1, 10 .. LEN_LIST( methods ) - 8 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and IS_SUBSET_FLAGS( type3![2], methods[i + 3] ) and IS_SUBSET_FLAGS( type4![2], methods[i + 4] ) and IS_SUBSET_FLAGS( type5![2], methods[i + 5] )
-              and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1] )  then
+              and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1] ) then
               return methods[i + 6];
           fi;
       od;
@@ -4764,11 +4764,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__5ARGS, t_1 );
  
  /* METHOD_6ARGS := function ( operation, type1, type2, type3, type4, type5, type6 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 6 );
-      for i  in [ 1, 11 .. LEN_LIST( methods ) - 9 ]  do
+      for i in [ 1, 11 .. LEN_LIST( methods ) - 9 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and IS_SUBSET_FLAGS( type3![2], methods[i + 3] ) and IS_SUBSET_FLAGS( type4![2], methods[i + 4] ) and IS_SUBSET_FLAGS( type5![2], methods[i + 5] )
-                and IS_SUBSET_FLAGS( type6![2], methods[i + 6] ) and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1], type6![1] )  then
+                and IS_SUBSET_FLAGS( type6![2], methods[i + 6] ) and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1], type6![1] ) then
               return methods[i + 7];
           fi;
       od;
@@ -4799,12 +4799,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__XARGS, t_1 );
  
  /* NEXT_METHOD_0ARGS := function ( operation, k )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 0 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 4 ]  do
-          if methods[4 * (i - 1) + 1](  )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 4 ] do
+          if methods[4 * (i - 1) + 1](  ) then
+              if k = j then
                   return methods[4 * (i - 1) + 2];
               else
                   j := j + 1;
@@ -4824,12 +4824,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__0ARGS, t_1 );
  
  /* NEXT_METHOD_1ARGS := function ( operation, k, type1 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 1 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 5 ]  do
-          if IS_SUBSET_FLAGS( type1![2], methods[5 * (i - 1) + 2] ) and methods[5 * (i - 1) + 1]( type1![1] )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 5 ] do
+          if IS_SUBSET_FLAGS( type1![2], methods[5 * (i - 1) + 2] ) and methods[5 * (i - 1) + 1]( type1![1] ) then
+              if k = j then
                   return methods[5 * (i - 1) + 3];
               else
                   j := j + 1;
@@ -4849,12 +4849,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__1ARGS, t_1 );
  
  /* NEXT_METHOD_2ARGS := function ( operation, k, type1, type2 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 2 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 6 ]  do
-          if IS_SUBSET_FLAGS( type1![2], methods[6 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( type1![1], type2![1] )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 6 ] do
+          if IS_SUBSET_FLAGS( type1![2], methods[6 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( type1![1], type2![1] ) then
+              if k = j then
                   return methods[6 * (i - 1) + 4];
               else
                   j := j + 1;
@@ -4874,13 +4874,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__2ARGS, t_1 );
  
  /* NEXT_METHOD_3ARGS := function ( operation, k, type1, type2, type3 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 3 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 7 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 7 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[7 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( type1![1], type2![1], type3![1] )
-               then
-              if k = j  then
+              then
+              if k = j then
                   return methods[7 * (i - 1) + 5];
               else
                   j := j + 1;
@@ -4900,13 +4900,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__3ARGS, t_1 );
  
  /* NEXT_METHOD_4ARGS := function ( operation, k, type1, type2, type3, type4 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 4 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 8 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 8 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[8 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[8 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[8 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[8 * (i - 1) + 5] ) 
-              and methods[8 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1] )  then
-              if k = j  then
+              and methods[8 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1] ) then
+              if k = j then
                   return methods[8 * (i - 1) + 6];
               else
                   j := j + 1;
@@ -4926,13 +4926,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__4ARGS, t_1 );
  
  /* NEXT_METHOD_5ARGS := function ( operation, k, type1, type2, type3, type4, type5 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 5 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 9 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 9 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[9 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[9 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[9 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[9 * (i - 1) + 5] ) 
-                and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1], type5![1] )  then
-              if k = j  then
+                and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1], type5![1] ) then
+              if k = j then
                   return methods[9 * (i - 1) + 7];
               else
                   j := j + 1;
@@ -4952,13 +4952,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__5ARGS, t_1 );
  
  /* NEXT_METHOD_6ARGS := function ( operation, k, type1, type2, type3, type4, type5, type6 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 6 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 10 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 10 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[10 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[10 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[10 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[10 * (i - 1) + 5] ) 
-                  and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1], type5![1], type6![1] )  then
-              if k = j  then
+                  and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1], type5![1], type6![1] ) then
+              if k = j then
                   return methods[10 * (i - 1) + 8];
               else
                   j := j + 1;
@@ -4992,20 +4992,20 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__XARGS, t_1 );
  
  /* AttributeValueNotSet := function ( attr, obj )
-      local  type, fam, methods, i, flag, erg;
+      local type, fam, methods, i, flag, erg;
       type := TypeObj( obj );
       fam := FamilyObj( obj );
       methods := METHODS_OPERATION( attr, 1 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 5 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 5 ] do
           flag := true;
           flag := flag and IS_SUBSET_FLAGS( type![2], methods[5 * (i - 1) + 2] );
-          if flag  then
+          if flag then
               flag := flag and methods[5 * (i - 1) + 1]( fam );
           fi;
-          if flag  then
+          if flag then
               attr := methods[5 * (i - 1) + 3];
               erg := attr( obj );
-              if not IS_IDENTICAL_OBJ( erg, TRY_NEXT_METHOD )  then
+              if not IS_IDENTICAL_OBJ( erg, TRY_NEXT_METHOD ) then
                   return erg;
               fi;
           fi;
@@ -5024,10 +5024,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_AttributeValueNotSet, t_1 );
  
  /* CONSTRUCTOR_0ARGS := function ( operation )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 0 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 4 ]  do
-          if methods[4 * (i - 1) + 1](  )  then
+      for i in [ 1 .. LEN_LIST( methods ) / 4 ] do
+          if methods[4 * (i - 1) + 1](  ) then
               return methods[4 * (i - 1) + 2];
           fi;
       od;
@@ -5044,10 +5044,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__0ARGS, t_1 );
  
  /* CONSTRUCTOR_1ARGS := function ( operation, flags1 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 1 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 5 ]  do
-          if IS_SUBSET_FLAGS( methods[5 * (i - 1) + 2], flags1 ) and methods[5 * (i - 1) + 1]( flags1 )  then
+      for i in [ 1 .. LEN_LIST( methods ) / 5 ] do
+          if IS_SUBSET_FLAGS( methods[5 * (i - 1) + 2], flags1 ) and methods[5 * (i - 1) + 1]( flags1 ) then
               return methods[5 * (i - 1) + 3];
           fi;
       od;
@@ -5064,10 +5064,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__1ARGS, t_1 );
  
  /* CONSTRUCTOR_2ARGS := function ( operation, flags1, type2 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 2 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 6 ]  do
-          if IS_SUBSET_FLAGS( methods[6 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( flags1, type2![1] )  then
+      for i in [ 1 .. LEN_LIST( methods ) / 6 ] do
+          if IS_SUBSET_FLAGS( methods[6 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( flags1, type2![1] ) then
               return methods[6 * (i - 1) + 4];
           fi;
       od;
@@ -5084,10 +5084,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__2ARGS, t_1 );
  
  /* CONSTRUCTOR_3ARGS := function ( operation, flags1, type2, type3 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 3 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 7 ]  do
-          if IS_SUBSET_FLAGS( methods[7 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( flags1, type2![1], type3![1] )  then
+      for i in [ 1 .. LEN_LIST( methods ) / 7 ] do
+          if IS_SUBSET_FLAGS( methods[7 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( flags1, type2![1], type3![1] ) then
               return methods[7 * (i - 1) + 5];
           fi;
       od;
@@ -5104,11 +5104,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__3ARGS, t_1 );
  
  /* CONSTRUCTOR_4ARGS := function ( operation, flags1, type2, type3, type4 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 4 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 8 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 8 ] do
           if IS_SUBSET_FLAGS( methods[8 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[8 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[8 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[8 * (i - 1) + 5] ) 
-              and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] )  then
+              and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then
               return methods[8 * (i - 1) + 6];
           fi;
       od;
@@ -5125,11 +5125,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__4ARGS, t_1 );
  
  /* CONSTRUCTOR_5ARGS := function ( operation, flags1, type2, type3, type4, type5 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 5 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 9 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 9 ] do
           if IS_SUBSET_FLAGS( methods[9 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[9 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[9 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[9 * (i - 1) + 5] ) 
-                and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1] )  then
+                and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1] ) then
               return methods[9 * (i - 1) + 7];
           fi;
       od;
@@ -5146,11 +5146,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__5ARGS, t_1 );
  
  /* CONSTRUCTOR_6ARGS := function ( operation, flags1, type2, type3, type4, type5, type6 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 6 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 10 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 10 ] do
           if IS_SUBSET_FLAGS( methods[10 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[10 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[10 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[10 * (i - 1) + 5] ) 
-                  and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1], type6![1] )  then
+                  and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1], type6![1] ) then
               return methods[10 * (i - 1) + 8];
           fi;
       od;
@@ -5181,12 +5181,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__XARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_0ARGS := function ( operation, k )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 0 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 4 ]  do
-          if methods[4 * (i - 1) + 1](  )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 4 ] do
+          if methods[4 * (i - 1) + 1](  ) then
+              if k = j then
                   return methods[4 * (i - 1) + 2];
               else
                   j := j + 1;
@@ -5206,12 +5206,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__CONSTRUCTOR__0ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_1ARGS := function ( operation, k, flags1 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 1 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 5 ]  do
-          if IS_SUBSET_FLAGS( methods[5 * (i - 1) + 2], flags1 ) and methods[5 * (i - 1) + 1]( flags1 )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 5 ] do
+          if IS_SUBSET_FLAGS( methods[5 * (i - 1) + 2], flags1 ) and methods[5 * (i - 1) + 1]( flags1 ) then
+              if k = j then
                   return methods[5 * (i - 1) + 3];
               else
                   j := j + 1;
@@ -5231,12 +5231,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__CONSTRUCTOR__1ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_2ARGS := function ( operation, k, flags1, type2 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 2 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 6 ]  do
-          if IS_SUBSET_FLAGS( methods[6 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( flags1, type2![1] )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 6 ] do
+          if IS_SUBSET_FLAGS( methods[6 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( flags1, type2![1] ) then
+              if k = j then
                   return methods[6 * (i - 1) + 4];
               else
                   j := j + 1;
@@ -5256,12 +5256,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__CONSTRUCTOR__2ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_3ARGS := function ( operation, k, flags1, type2, type3 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 3 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 7 ]  do
-          if IS_SUBSET_FLAGS( methods[7 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( flags1, type2![1], type3![1] )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 7 ] do
+          if IS_SUBSET_FLAGS( methods[7 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( flags1, type2![1], type3![1] ) then
+              if k = j then
                   return methods[7 * (i - 1) + 5];
               else
                   j := j + 1;
@@ -5281,13 +5281,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__CONSTRUCTOR__3ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_4ARGS := function ( operation, k, flags1, type2, type3, type4 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 4 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 8 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 8 ] do
           if IS_SUBSET_FLAGS( methods[8 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[8 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[8 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[8 * (i - 1) + 5] ) 
-              and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] )  then
-              if k = j  then
+              and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then
+              if k = j then
                   return methods[8 * (i - 1) + 6];
               else
                   j := j + 1;
@@ -5307,13 +5307,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__CONSTRUCTOR__4ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_5ARGS := function ( operation, k, flags1, type2, type3, type4, type5 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 5 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 9 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 9 ] do
           if IS_SUBSET_FLAGS( methods[9 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[9 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[9 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[9 * (i - 1) + 5] ) 
-                and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1] )  then
-              if k = j  then
+                and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1] ) then
+              if k = j then
                   return methods[9 * (i - 1) + 7];
               else
                   j := j + 1;
@@ -5333,13 +5333,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__CONSTRUCTOR__5ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_6ARGS := function ( operation, k, flags1, type2, type3, type4, type5, type6 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 6 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 10 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 10 ] do
           if IS_SUBSET_FLAGS( methods[10 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[10 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[10 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[10 * (i - 1) + 5] ) 
-                  and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1], type6![1] )  then
-              if k = j  then
+                  and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1], type6![1] ) then
+              if k = j then
                   return methods[10 * (i - 1) + 8];
               else
                   j := j + 1;

--- a/hpcgap/src/c_oper1.c
+++ b/hpcgap/src/c_oper1.c
@@ -2484,17 +2484,17 @@ static Obj  HdlrFunc7 (
   if ( t_1 ) {
    
    /* InstallOtherMethod( getter, "default method requiring categories and checking properties", true, [ cats ], rank, function ( obj )
-      local  found, prop;
+      local found, prop;
       found := false;
-      for prop  in props  do
-          if not Tester( prop )( obj )  then
+      for prop in props do
+          if not Tester( prop )( obj ) then
               found := true;
-              if not (prop( obj ) and Tester( prop )( obj ))  then
+              if not (prop( obj ) and Tester( prop )( obj )) then
                   TryNextMethod();
               fi;
           fi;
       od;
-      if found  then
+      if found then
           return getter( obj );
       else
           TryNextMethod();
@@ -3097,7 +3097,7 @@ static Obj  HdlrFunc11 (
  if ( t_1 ) {
   
   /* keytest := function ( key )
-      if not IsPrimeInt( key )  then
+      if not IsPrimeInt( key ) then
           Error( name, ": <p> must be a prime" );
       fi;
       return;
@@ -3228,14 +3228,14 @@ static Obj  HdlrFunc11 (
  CALL_1ARGS( t_1, l_lk );
  
  /* InstallOtherMethod( VALUE_GLOBAL( name ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
-      local  known, i, erg;
+      local known, i, erg;
       keytest( key );
       known := attr( D );
       i := PositionSortedOddPositions( known, key );
-      if LEN_LIST( known ) < i or known[i] <> key  then
+      if LEN_LIST( known ) < i or known[i] <> key then
           erg := oper( D, key );
           i := PositionSortedOddPositions( known, key );
-          if LEN_LIST( known ) < i or known[i] <> key  then
+          if LEN_LIST( known ) < i or known[i] <> key then
               known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
               known[i] := IMMUTABLE_COPY_OBJ( key );
               known[i + 1] := IMMUTABLE_COPY_OBJ( erg );
@@ -3288,7 +3288,7 @@ static Obj  HdlrFunc11 (
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
-      local  known, i;
+      local known, i;
       keytest( key );
       known := attr( D );
       i := PositionSortedOddPositions( known, key );
@@ -3341,11 +3341,11 @@ static Obj  HdlrFunc11 (
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq, IS_OBJECT ], 0, function ( D, key, obj )
-      local  known, i;
+      local known, i;
       keytest( key );
       known := attr( D );
       i := PositionSortedOddPositions( known, key );
-      if LEN_LIST( known ) < i or known[i] <> key  then
+      if LEN_LIST( known ) < i or known[i] <> key then
           known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
           known[i] := IMMUTABLE_COPY_OBJ( key );
           known[i + 1] := IMMUTABLE_COPY_OBJ( obj );
@@ -3732,10 +3732,10 @@ static Obj  HdlrFunc17 (
  
  /* InstallOtherMethod( oper, info, fampred, reqs, val, function ( arg... )
       re := false;
-      for i  in [ 1 .. LEN_LIST( reqs ) ]  do
+      for i in [ 1 .. LEN_LIST( reqs ) ] do
           re := re or IsBound( cond[i] ) and not Tester( cond[i] )( arg[i] ) and cond[i]( arg[i] ) and Tester( cond[i] )( arg[i] );
       od;
-      if re  then
+      if re then
           return CallFuncList( oper, arg );
       else
           TryNextMethod();
@@ -3795,11 +3795,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_RUN__IMMEDIATE__METHODS__HITS, INTOBJ_INT(0) );
  
  /* BIND_GLOBAL( "RunImmediateMethods", function ( obj, flags )
-      local  flagspos, tried, type, j, imm, i, res, newflags;
-      if IGNORE_IMMEDIATE_METHODS  then
+      local flagspos, tried, type, j, imm, i, res, newflags;
+      if IGNORE_IMMEDIATE_METHODS then
           return;
       fi;
-      if IS_SUBSET_FLAGS( IMM_FLAGS, flags )  then
+      if IS_SUBSET_FLAGS( IMM_FLAGS, flags ) then
           return;
       fi;
       flags := SUB_FLAGS( flags, IMM_FLAGS );
@@ -3807,27 +3807,27 @@ static Obj  HdlrFunc1 (
       tried := [  ];
       type := TYPE_OBJ( obj );
       flags := type![2];
-      for j  in flagspos  do
-          if IsBound( IMMEDIATES[j] )  then
+      for j in flagspos do
+          if IsBound( IMMEDIATES[j] ) then
               imm := IMMEDIATES[j];
-              for i  in [ 0, 7 .. LEN_LIST( imm ) - 7 ]  do
-                  if IS_SUBSET_FLAGS( flags, imm[i + 4] ) and not IS_SUBSET_FLAGS( flags, imm[i + 3] ) and not imm[i + 6] in tried  then
+              for i in [ 0, 7 .. LEN_LIST( imm ) - 7 ] do
+                  if IS_SUBSET_FLAGS( flags, imm[i + 4] ) and not IS_SUBSET_FLAGS( flags, imm[i + 3] ) and not imm[i + 6] in tried then
                       res := IMMEDIATE_METHODS[imm[i + 6]]( obj );
                       ADD_LIST( tried, imm[i + 6] );
                       RUN_IMMEDIATE_METHODS_CHECKS := RUN_IMMEDIATE_METHODS_CHECKS + 1;
-                      if TRACE_IMMEDIATE_METHODS  then
-                          if imm[i + 7] = false  then
+                      if TRACE_IMMEDIATE_METHODS then
+                          if imm[i + 7] = false then
                               Print( "#I  immediate: ", NAME_FUNC( imm[i + 1] ), "\n" );
                           else
                               Print( "#I  immediate: ", NAME_FUNC( imm[i + 1] ), ": ", imm[i + 7], "\n" );
                           fi;
                       fi;
-                      if res <> TRY_NEXT_METHOD  then
+                      if res <> TRY_NEXT_METHOD then
                           IGNORE_IMMEDIATE_METHODS := true;
                           imm[i + 2]( obj, res );
                           IGNORE_IMMEDIATE_METHODS := false;
                           RUN_IMMEDIATE_METHODS_HITS := RUN_IMMEDIATE_METHODS_HITS + 1;
-                          if not IS_IDENTICAL_OBJ( TYPE_OBJ( obj ), type )  then
+                          if not IS_IDENTICAL_OBJ( TYPE_OBJ( obj ), type ) then
                               type := TYPE_OBJ( obj );
                               newflags := SUB_FLAGS( type![2], IMM_FLAGS );
                               newflags := SUB_FLAGS( newflags, flags );
@@ -3863,21 +3863,21 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "INSTALL_METHOD_FLAGS", function ( opr, info, rel, flags, rank, method )
-      local  methods, narg, i, k, tmp, replace, match, j, lk;
+      local methods, narg, i, k, tmp, replace, match, j, lk;
       lk := WRITE_LOCK( METHODS_OPERATION_REGION );
-      if IS_CONSTRUCTOR( opr )  then
-          if 0 < LEN_LIST( flags )  then
+      if IS_CONSTRUCTOR( opr ) then
+          if 0 < LEN_LIST( flags ) then
               rank := rank - RankFilter( flags[1] );
           fi;
       else
-          for i  in flags  do
+          for i in flags do
               rank := rank + RankFilter( i );
           od;
       fi;
       narg := LEN_LIST( flags );
       methods := METHODS_OPERATION( opr, narg );
       methods := methods{[ 1 .. LEN_LIST( methods ) ]};
-      if info = false  then
+      if info = false then
           info := NAME_FUNC( opr );
       else
           k := SHALLOW_COPY_OBJ( NAME_FUNC( opr ) );
@@ -3887,19 +3887,19 @@ static Obj  HdlrFunc1 (
           CONV_STRING( info );
       fi;
       i := 0;
-      while i < LEN_LIST( methods ) and rank < methods[i + (narg + 3)]  do
+      while i < LEN_LIST( methods ) and rank < methods[i + (narg + 3)] do
           i := i + (narg + 4);
       od;
       replace := false;
-      if REREADING  then
+      if REREADING then
           k := i;
-          while k < LEN_LIST( methods ) and rank = methods[k + narg + 3]  do
-              if info = methods[k + narg + 4]  then
+          while k < LEN_LIST( methods ) and rank = methods[k + narg + 3] do
+              if info = methods[k + narg + 4] then
                   match := false;
-                  for j  in [ 1 .. narg ]  do
+                  for j in [ 1 .. narg ] do
                       match := match and methods[k + j + 1] = flags[j];
                   od;
-                  if match  then
+                  if match then
                       replace := true;
                       i := k;
                       break;
@@ -3908,17 +3908,17 @@ static Obj  HdlrFunc1 (
               k := k + narg + 4;
           od;
       fi;
-      if not REREADING or not replace  then
+      if not REREADING or not replace then
           methods{[ narg + 4 + i + 1 .. narg + 4 + LEN_LIST( methods ) ]} := methods{[ i + 1 .. LEN_LIST( methods ) ]};
       fi;
-      if rel = true  then
+      if rel = true then
           methods[i + 1] := RETURN_TRUE;
-      elif rel = false  then
+      elif rel = false then
           methods[i + 1] := RETURN_FALSE;
-      elif IS_FUNCTION( rel )  then
-          if CHECK_INSTALL_METHOD  then
+      elif IS_FUNCTION( rel ) then
+          if CHECK_INSTALL_METHOD then
               tmp := NARG_FUNC( rel );
-              if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg  then
+              if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then
                   Error( NAME_FUNC( opr ), ": <famrel> must accept ", narg, " arguments" );
               fi;
           fi;
@@ -3926,17 +3926,17 @@ static Obj  HdlrFunc1 (
       else
           Error( NAME_FUNC( opr ), ": <famrel> must be a function, `true', or `false'" );
       fi;
-      for k  in [ 1 .. narg ]  do
+      for k in [ 1 .. narg ] do
           methods[i + k + 1] := flags[k];
       od;
-      if method = true  then
+      if method = true then
           methods[i + (narg + 2)] := RETURN_TRUE;
-      elif method = false  then
+      elif method = false then
           methods[i + (narg + 2)] := RETURN_FALSE;
-      elif IS_FUNCTION( method )  then
-          if CHECK_INSTALL_METHOD and not IS_OPERATION( method )  then
+      elif IS_FUNCTION( method ) then
+          if CHECK_INSTALL_METHOD and not IS_OPERATION( method ) then
               tmp := NARG_FUNC( method );
-              if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg  then
+              if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then
                   Error( NAME_FUNC( opr ), ": <method> must accept ", narg, " arguments" );
               fi;
           fi;
@@ -4003,45 +4003,45 @@ static Obj  HdlrFunc1 (
  AssGVar( G_INSTALL__METHOD, 0 );
  
  /* BIND_GLOBAL( "INSTALL_METHOD", function ( arglist, check )
-      local  len, opr, info, pos, rel, filters, info1, isstr, flags, i, rank, method, oreqs, req, reqs, match, j, k, imp, notmatch, lk;
+      local len, opr, info, pos, rel, filters, info1, isstr, flags, i, rank, method, oreqs, req, reqs, match, j, k, imp, notmatch, lk;
       lk := READ_LOCK( OPERATIONS_REGION );
       len := LEN_LIST( arglist );
-      if len < 3  then
+      if len < 3 then
           Error( "too few arguments given in <arglist>" );
       fi;
       opr := arglist[1];
-      if not IS_OPERATION( opr )  then
+      if not IS_OPERATION( opr ) then
           Error( "<opr> is not an operation" );
       fi;
-      if IS_STRING_REP( arglist[2] )  then
+      if IS_STRING_REP( arglist[2] ) then
           info := arglist[2];
           pos := 3;
       else
           info := false;
           pos := 2;
       fi;
-      if arglist[pos] = true or IS_FUNCTION( arglist[pos] )  then
+      if arglist[pos] = true or IS_FUNCTION( arglist[pos] ) then
           rel := arglist[pos];
           pos := pos + 1;
       else
           rel := true;
       fi;
-      if not IsBound( arglist[pos] ) or not IS_LIST( arglist[pos] )  then
+      if not IsBound( arglist[pos] ) or not IS_LIST( arglist[pos] ) then
           Error( "<arglist>[", pos, "] must be a list of filters" );
       fi;
       filters := arglist[pos];
-      if GAPInfo.MaxNrArgsMethod < LEN_LIST( filters )  then
+      if GAPInfo.MaxNrArgsMethod < LEN_LIST( filters ) then
           Error( "methods can have at most ", GAPInfo.MaxNrArgsMethod, " arguments" );
       fi;
-      if 0 < LEN_LIST( filters )  then
+      if 0 < LEN_LIST( filters ) then
           info1 := "[ ";
           isstr := true;
-          for i  in [ 1 .. LEN_LIST( filters ) ]  do
-              if IS_STRING_REP( filters[i] )  then
+          for i in [ 1 .. LEN_LIST( filters ) ] do
+              if IS_STRING_REP( filters[i] ) then
                   APPEND_LIST_INTR( info1, filters[i] );
                   APPEND_LIST_INTR( info1, ", " );
                   filters[i] := EvalString( filters[i] );
-                  if not IS_FUNCTION( filters[i] )  then
+                  if not IS_FUNCTION( filters[i] ) then
                       Error( "string does not evaluate to a function" );
                   fi;
               else
@@ -4049,7 +4049,7 @@ static Obj  HdlrFunc1 (
                   break;
               fi;
           od;
-          if isstr and info = false  then
+          if isstr and info = false then
               info1[LEN_LIST( info1 ) - 1] := ' ';
               info1[LEN_LIST( info1 )] := ']';
               info := info1;
@@ -4057,81 +4057,81 @@ static Obj  HdlrFunc1 (
       fi;
       pos := pos + 1;
       flags := [  ];
-      for i  in filters  do
+      for i in filters do
           ADD_LIST( flags, FLAGS_FILTER( i ) );
       od;
-      if not IsBound( arglist[pos] )  then
+      if not IsBound( arglist[pos] ) then
           Error( "the method is missing in <arglist>" );
-      elif IS_INT( arglist[pos] )  then
+      elif IS_INT( arglist[pos] ) then
           rank := arglist[pos];
           pos := pos + 1;
       else
           rank := 0;
       fi;
-      if not IsBound( arglist[pos] )  then
+      if not IsBound( arglist[pos] ) then
           Error( "the method is missing in <arglist>" );
       fi;
       method := arglist[pos];
-      if FLAG1_FILTER( opr ) <> 0 and (rel = true or rel = RETURN_TRUE) and LEN_LIST( filters ) = 1 and (method = true or method = RETURN_TRUE)  then
+      if FLAG1_FILTER( opr ) <> 0 and (rel = true or rel = RETURN_TRUE) and LEN_LIST( filters ) = 1 and (method = true or method = RETURN_TRUE) then
           Error( NAME_FUNC( opr ), ": use `InstallTrueMethod' for <opr>" );
       fi;
-      if CHECK_INSTALL_METHOD and check  then
-          if opr in WRAPPER_OPERATIONS  then
+      if CHECK_INSTALL_METHOD and check then
+          if opr in WRAPPER_OPERATIONS then
               INFO_DEBUG( 1, "a method is installed for the wrapper operation ", NAME_FUNC( opr ), "\n", "#I  probably it should be installed for (one of) its\n", "#I  underlying operation(s)" );
           fi;
           req := false;
-          for i  in [ 1, 3 .. LEN_LIST( OPERATIONS ) - 1 ]  do
-              if IS_IDENTICAL_OBJ( OPERATIONS[i], opr )  then
+          for i in [ 1, 3 .. LEN_LIST( OPERATIONS ) - 1 ] do
+              if IS_IDENTICAL_OBJ( OPERATIONS[i], opr ) then
                   req := OPERATIONS[i + 1];
                   break;
               fi;
           od;
-          if req = false  then
+          if req = false then
               Error( "unknown operation ", NAME_FUNC( opr ) );
           fi;
           imp := [  ];
-          for i  in flags  do
+          for i in flags do
               ADD_LIST( imp, WITH_HIDDEN_IMPS_FLAGS( i ) );
           od;
           j := 0;
           match := false;
           notmatch := 0;
-          while j < LEN_LIST( req ) and not match  do
+          while j < LEN_LIST( req ) and not match do
               j := j + 1;
               reqs := req[j];
-              if LEN_LIST( reqs ) = LEN_LIST( imp )  then
+              if LEN_LIST( reqs ) = LEN_LIST( imp ) then
                   match := true;
-                  for i  in [ 1 .. LEN_LIST( reqs ) ]  do
-                      if not IS_SUBSET_FLAGS( imp[i], reqs[i] )  then
+                  for i in [ 1 .. LEN_LIST( reqs ) ] do
+                      if not IS_SUBSET_FLAGS( imp[i], reqs[i] ) then
                           match := false;
                           notmatch := i;
                           break;
                       fi;
                   od;
-                  if match  then
+                  if match then
                       break;
                   fi;
               fi;
           od;
-          if not match  then
-              if notmatch = 0  then
+          if not match then
+              if notmatch = 0 then
                   Error( "the number of arguments does not match a declaration of ", NAME_FUNC( opr ) );
               else
                   Error( "required filters ", NamesFilter( imp[notmatch] ), "\nfor ", Ordinal( notmatch ), " argument do not match a declaration of ", NAME_FUNC( opr ) );
               fi;
           else
               oreqs := reqs;
-              for k  in [ j + 1 .. LEN_LIST( req ) ]  do
+              for k in [ j + 1 .. LEN_LIST( req ) ] do
                   reqs := req[k];
-                  if LEN_LIST( reqs ) = LEN_LIST( imp )  then
+                  if LEN_LIST( reqs ) = LEN_LIST( imp ) then
                       match := true;
-                      for i  in [ 1 .. LEN_LIST( reqs ) ]  do
-                          if not IS_SUBSET_FLAGS( imp[i], reqs[i] )  then
+                      for i in [ 1 .. LEN_LIST( reqs ) ] do
+                          if not IS_SUBSET_FLAGS( imp[i], reqs[i] ) then
                               match := false;
                               break;
                           fi;
                       od;
-                      if match and reqs <> oreqs  then
+                      if match and reqs <> oreqs then
                           INFO_DEBUG( 1, "method installed for ", NAME_FUNC( opr ), " matches more than one declaration" );
                       fi;
                   fi;
@@ -4161,38 +4161,38 @@ static Obj  HdlrFunc1 (
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
-      local  flags, rank, cats, props, i, lk;
-      if not IS_IDENTICAL_OBJ( filter, IS_OBJECT )  then
+      local flags, rank, cats, props, i, lk;
+      if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then
           flags := FLAGS_FILTER( filter );
           rank := 0;
           cats := IS_OBJECT;
           props := [  ];
           lk := DO_LOCK( FILTER_REGION, false, CATS_AND_REPS );
-          for i  in [ 1 .. LEN_FLAGS( flags ) ]  do
-              if ELM_FLAGS( flags, i )  then
-                  if i in CATS_AND_REPS  then
+          for i in [ 1 .. LEN_FLAGS( flags ) ] do
+              if ELM_FLAGS( flags, i ) then
+                  if i in CATS_AND_REPS then
                       cats := cats and FILTERS[i];
                       rank := rank - RankFilter( FILTERS[i] );
-                  elif i in NUMBERS_PROPERTY_GETTERS  then
+                  elif i in NUMBERS_PROPERTY_GETTERS then
                       ADD_LIST( props, FILTERS[i] );
                   fi;
               fi;
           od;
           UNLOCK( lk );
           MakeImmutable( props );
-          if 0 < LEN_LIST( props )  then
+          if 0 < LEN_LIST( props ) then
               InstallOtherMethod( getter, "default method requiring categories and checking properties", true, [ cats ], rank, function ( obj )
-                    local  found, prop;
+                    local found, prop;
                     found := false;
-                    for prop  in props  do
-                        if not Tester( prop )( obj )  then
+                    for prop in props do
+                        if not Tester( prop )( obj ) then
                             found := true;
-                            if not (prop( obj ) and Tester( prop )( obj ))  then
+                            if not (prop( obj ) and Tester( prop )( obj )) then
                                 TryNextMethod();
                             fi;
                         fi;
                     od;
-                    if found  then
+                    if found then
                         return getter( obj );
                     else
                         TryNextMethod();
@@ -4230,15 +4230,15 @@ static Obj  HdlrFunc1 (
  CALL_1ARGS( t_1, t_2 );
  
  /* BIND_GLOBAL( "PositionSortedOddPositions", function ( list, elm )
-      local  i, j, k;
+      local i, j, k;
       k := LEN_LIST( list ) + 1;
-      if k mod 2 = 0  then
+      if k mod 2 = 0 then
           k := k + 1;
       fi;
       i := -1;
-      while i + 2 < k  do
+      while i + 2 < k do
           j := 2 * QUO_INT( (i + k + 2), 4 ) - 1;
-          if list[j] < elm  then
+          if list[j] < elm then
               i := j;
           else
               k := j;
@@ -4263,10 +4263,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_IsPrimeInt, t_1 );
  
  /* BIND_GLOBAL( "KeyDependentOperation", function ( name, domreq, keyreq, keytest )
-      local  str, oper, attr, lk;
-      if keytest = "prime"  then
+      local str, oper, attr, lk;
+      if keytest = "prime" then
           keytest := function ( key )
-                if not IsPrimeInt( key )  then
+                if not IsPrimeInt( key ) then
                     Error( name, ": <p> must be a prime" );
                 fi;
                 return;
@@ -4289,14 +4289,14 @@ static Obj  HdlrFunc1 (
       ADD_LIST( WRAPPER_OPERATIONS, VALUE_GLOBAL( name ) );
       UNLOCK( lk );
       InstallOtherMethod( VALUE_GLOBAL( name ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
-            local  known, i, erg;
+            local known, i, erg;
             keytest( key );
             known := attr( D );
             i := PositionSortedOddPositions( known, key );
-            if LEN_LIST( known ) < i or known[i] <> key  then
+            if LEN_LIST( known ) < i or known[i] <> key then
                 erg := oper( D, key );
                 i := PositionSortedOddPositions( known, key );
-                if LEN_LIST( known ) < i or known[i] <> key  then
+                if LEN_LIST( known ) < i or known[i] <> key then
                     known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
                     known[i] := IMMUTABLE_COPY_OBJ( key );
                     known[i + 1] := IMMUTABLE_COPY_OBJ( erg );
@@ -4308,7 +4308,7 @@ static Obj  HdlrFunc1 (
       APPEND_LIST_INTR( str, name );
       DeclareOperation( str, [ domreq, keyreq ] );
       InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
-            local  known, i;
+            local known, i;
             keytest( key );
             known := attr( D );
             i := PositionSortedOddPositions( known, key );
@@ -4318,11 +4318,11 @@ static Obj  HdlrFunc1 (
       APPEND_LIST_INTR( str, name );
       DeclareOperation( str, [ domreq, keyreq, IS_OBJECT ] );
       InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq, IS_OBJECT ], 0, function ( D, key, obj )
-            local  known, i;
+            local known, i;
             keytest( key );
             known := attr( D );
             i := PositionSortedOddPositions( known, key );
-            if LEN_LIST( known ) < i or known[i] <> key  then
+            if LEN_LIST( known ) < i or known[i] <> key then
                 known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
                 known[i] := IMMUTABLE_COPY_OBJ( key );
                 known[i + 1] := IMMUTABLE_COPY_OBJ( obj );
@@ -4348,15 +4348,15 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CallFuncList, t_1 );
  
  /* BIND_GLOBAL( "RedispatchOnCondition", function ( arg... )
-      local  oper, info, fampred, reqs, cond, val, re, i;
-      if LEN_LIST( arg ) = 5  then
+      local oper, info, fampred, reqs, cond, val, re, i;
+      if LEN_LIST( arg ) = 5 then
           oper := arg[1];
           info := " fallback method to test conditions";
           fampred := arg[2];
           reqs := arg[3];
           cond := arg[4];
           val := arg[5];
-      elif LEN_LIST( arg ) = 6  then
+      elif LEN_LIST( arg ) = 6 then
           oper := arg[1];
           info := arg[2];
           fampred := arg[3];
@@ -4366,15 +4366,15 @@ static Obj  HdlrFunc1 (
       else
           Error( "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" );
       fi;
-      for i  in reqs  do
+      for i in reqs do
           val := val - SIZE_FLAGS( WITH_HIDDEN_IMPS_FLAGS( FLAGS_FILTER( i ) ) );
       od;
       InstallOtherMethod( oper, info, fampred, reqs, val, function ( arg... )
             re := false;
-            for i  in [ 1 .. LEN_LIST( reqs ) ]  do
+            for i in [ 1 .. LEN_LIST( reqs ) ] do
                 re := re or IsBound( cond[i] ) and not Tester( cond[i] )( arg[i] ) and cond[i]( arg[i] ) and Tester( cond[i] )( arg[i] );
             od;
-            if re  then
+            if re then
                 return CallFuncList( oper, arg );
             else
                 TryNextMethod();

--- a/hpcgap/src/c_type1.c
+++ b/hpcgap/src/c_type1.c
@@ -1142,7 +1142,7 @@ static Obj  HdlrFunc11 (
            t_1 = (Obj)(((UInt)t_1)+4) ) {
       l_i = t_1;
       
-      /* if IsBound( cached![i]) then */
+      /* if IsBound( cached![i] ) then */
       CHECK_INT_SMALL_POS( l_i )
       if ( TNUM_OBJ(l_cached) == T_POSOBJ ) {
        t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_cached)/sizeof(Obj)-1
@@ -1223,7 +1223,7 @@ static Obj  HdlrFunc11 (
            t_1 = (Obj)(((UInt)t_1)+4) ) {
       l_i = t_1;
       
-      /* if IsBound( parent![i]) <> IsBound( cached![i]) then */
+      /* if IsBound( parent![i] ) <> IsBound( cached![i] ) then */
       CHECK_INT_SMALL_POS( l_i )
       if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
        t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
@@ -1260,7 +1260,7 @@ static Obj  HdlrFunc11 (
       }
       /* fi */
       
-      /* if IsBound( parent![i]) and IsBound( cached![i]) and not IS_IDENTICAL_OBJ( parent![i], cached![i] ) then */
+      /* if IsBound( parent![i] ) and IsBound( cached![i] ) and not IS_IDENTICAL_OBJ( parent![i], cached![i] ) then */
       if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
        t_7 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
           && ELM_PLIST(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False);
@@ -1438,7 +1438,7 @@ static Obj  HdlrFunc11 (
         t_1 = (Obj)(((UInt)t_1)+4) ) {
    l_i = t_1;
    
-   /* if IsBound( parent![i]) and not IsBound( type[i] ) then */
+   /* if IsBound( parent![i] ) and not IsBound( type[i] ) then */
    CHECK_INT_SMALL_POS( l_i )
    if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
     t_6 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
@@ -4135,7 +4135,7 @@ static Obj  HdlrFunc1 (
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
-      if mutflag  then
+      if mutflag then
           InstallOtherMethod( setter, "system mutable setter", true, [ IsAttributeStoringRep, IS_OBJECT ], 0, function ( obj, val )
                 obj!.(name) := val;
                 SetFilterObj( obj, tester );
@@ -4170,12 +4170,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_DS__TYPE__CACHE, t_1 );
  
  /* BIND_GLOBAL( "NEW_FAMILY", function ( typeOfFamilies, name, req_filter, imp_filter )
-      local  lock, type, pair, family;
+      local lock, type, pair, family;
       imp_filter := WITH_IMPS_FLAGS( AND_FLAGS( imp_filter, req_filter ) );
       type := Subtype( typeOfFamilies, IsAttributeStoringRep );
       lock := READ_LOCK( CATEGORIES_FAMILY );
-      for pair  in CATEGORIES_FAMILY  do
-          if IS_SUBSET_FLAGS( imp_filter, pair[1] )  then
+      for pair in CATEGORIES_FAMILY do
+          if IS_SUBSET_FLAGS( imp_filter, pair[1] ) then
               type := Subtype( type, pair[2] );
           fi;
       od;
@@ -4266,13 +4266,13 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily", function ( arg... )
-      if LEN_LIST( arg ) = 1  then
+      if LEN_LIST( arg ) = 1 then
           return NewFamily2( TypeOfFamilies, arg[1] );
-      elif LEN_LIST( arg ) = 2  then
+      elif LEN_LIST( arg ) = 2 then
           return NewFamily3( TypeOfFamilies, arg[1], arg[2] );
-      elif LEN_LIST( arg ) = 3  then
+      elif LEN_LIST( arg ) = 3 then
           return NewFamily4( TypeOfFamilies, arg[1], arg[2], arg[3] );
-      elif LEN_LIST( arg ) = 4  then
+      elif LEN_LIST( arg ) = 4 then
           return NewFamily5( TypeOfFamilies, arg[1], arg[2], arg[3], arg[4] );
       else
           Error( "usage: NewFamily( <name>, [ <req> [, <imp> ]] )" );
@@ -4298,42 +4298,42 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEW__TYPE__CACHE__HIT, INTOBJ_INT(0) );
  
  /* BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data, parent )
-      local  lock, hash, cache, cached, type, ncache, ncl, t, i, match;
+      local lock, hash, cache, cached, type, ncache, ncl, t, i, match;
       lock := WRITE_LOCK( DS_TYPE_CACHE );
       cache := family!.TYPES;
       hash := HASH_FLAGS( flags ) mod family!.HASH_SIZE + 1;
-      if IsBound( cache[hash] )  then
+      if IsBound( cache[hash] ) then
           cached := cache[hash];
-          if IS_EQUAL_FLAGS( flags, cached![2] )  then
+          if IS_EQUAL_FLAGS( flags, cached![2] ) then
               flags := cached![2];
-              if IS_IDENTICAL_OBJ( data, cached![POS_DATA_TYPE] ) and IS_IDENTICAL_OBJ( typeOfTypes, TYPE_OBJ( cached ) )  then
-                  if IS_IDENTICAL_OBJ( parent, fail )  then
+              if IS_IDENTICAL_OBJ( data, cached![POS_DATA_TYPE] ) and IS_IDENTICAL_OBJ( typeOfTypes, TYPE_OBJ( cached ) ) then
+                  if IS_IDENTICAL_OBJ( parent, fail ) then
                       match := true;
-                      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( cached ) ]  do
-                          if IsBound( cached![i])  then
+                      for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( cached ) ] do
+                          if IsBound( cached![i] ) then
                               match := false;
                               break;
                           fi;
                       od;
-                      if match  then
+                      if match then
                           NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1;
                           UNLOCK( lock );
                           return cached;
                       fi;
                   fi;
-                  if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached )  then
+                  if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached ) then
                       match := true;
-                      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ]  do
-                          if IsBound( parent![i]) <> IsBound( cached![i])  then
+                      for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ] do
+                          if IsBound( parent![i] ) <> IsBound( cached![i] ) then
                               match := false;
                               break;
                           fi;
-                          if IsBound( parent![i]) and IsBound( cached![i]) and not IS_IDENTICAL_OBJ( parent![i], cached![i] )  then
+                          if IsBound( parent![i] ) and IsBound( cached![i] ) and not IS_IDENTICAL_OBJ( parent![i], cached![i] ) then
                               match := false;
                               break;
                           fi;
                       od;
-                      if match  then
+                      if match then
                           NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1;
                           UNLOCK( lock );
                           return cached;
@@ -4344,7 +4344,7 @@ static Obj  HdlrFunc1 (
           NEW_TYPE_CACHE_MISS := NEW_TYPE_CACHE_MISS + 1;
       fi;
       NEW_TYPE_NEXT_ID := NEW_TYPE_NEXT_ID + 1;
-      if NEW_TYPE_NEXT_ID >= NEW_TYPE_ID_LIMIT  then
+      if NEW_TYPE_NEXT_ID >= NEW_TYPE_ID_LIMIT then
           GASMAN( "collect" );
           FLUSH_ALL_METHOD_CACHES(  );
           NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS(  );
@@ -4352,18 +4352,18 @@ static Obj  HdlrFunc1 (
       type := [ family, flags ];
       type[POS_DATA_TYPE] := MakeReadOnly( data );
       type[POS_NUMB_TYPE] := NEW_TYPE_NEXT_ID;
-      if not IS_IDENTICAL_OBJ( parent, fail )  then
-          for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ]  do
-              if IsBound( parent![i]) and not IsBound( type[i] )  then
+      if not IS_IDENTICAL_OBJ( parent, fail ) then
+          for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ] do
+              if IsBound( parent![i] ) and not IsBound( type[i] ) then
                   type[i] := parent![i];
               fi;
           od;
       fi;
       SET_TYPE_POSOBJ( type, typeOfTypes );
-      if 3 * family!.nTYPES > family!.HASH_SIZE  then
+      if 3 * family!.nTYPES > family!.HASH_SIZE then
           ncache := MIGRATE_RAW( [  ], DS_TYPE_CACHE );
           ncl := 3 * family!.HASH_SIZE + 1;
-          for t  in cache  do
+          for t in cache do
               ncache[HASH_FLAGS( t![2] ) mod ncl + 1] := t;
           od;
           family!.HASH_SIZE := ncl;
@@ -4420,13 +4420,13 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType", function ( arg... )
-      local  type;
-      if not IsFamily( arg[1] )  then
+      local type;
+      if not IsFamily( arg[1] ) then
           Error( "<family> must be a family" );
       fi;
-      if LEN_LIST( arg ) = 2  then
+      if LEN_LIST( arg ) = 2 then
           type := NewType3( TypeOfTypes, arg[1], arg[2] );
-      elif LEN_LIST( arg ) = 3  then
+      elif LEN_LIST( arg ) = 3 then
           type := NewType4( TypeOfTypes, arg[1], arg[2], arg[3] );
       else
           Error( "usage: NewType( <family>, <filter> [, <data> ] )" );
@@ -4479,12 +4479,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_Subtype, 0 );
  
  /* BIND_GLOBAL( "Subtype", function ( arg... )
-      local  p;
+      local p;
       p := READ_LOCK( arg );
-      if not IsType( arg[1] )  then
+      if not IsType( arg[1] ) then
           Error( "<type> must be a type" );
       fi;
-      if LEN_LIST( arg ) = 2  then
+      if LEN_LIST( arg ) = 2 then
           return Subtype2( arg[1], arg[2] );
       else
           return Subtype3( arg[1], arg[2], arg[3] );
@@ -4535,10 +4535,10 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType", function ( arg... )
-      if not IsType( arg[1] )  then
+      if not IsType( arg[1] ) then
           Error( "<type> must be a type" );
       fi;
-      if LEN_LIST( arg ) = 2  then
+      if LEN_LIST( arg ) = 2 then
           return SupType2( arg[1], arg[2] );
       else
           return SupType3( arg[1], arg[2], arg[3] );
@@ -4663,15 +4663,15 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetTypeObj", function ( type, obj )
-      if not IsType( type )  then
+      if not IsType( type ) then
           Error( "<type> must be a type" );
       fi;
-      if IS_LIST( obj )  then
+      if IS_LIST( obj ) then
           SET_TYPE_POSOBJ( obj, type );
-      elif IS_REC( obj )  then
+      elif IS_REC( obj ) then
           SET_TYPE_COMOBJ( obj, type );
       fi;
-      if not IsNoImmediateMethodsObject( obj )  then
+      if not IsNoImmediateMethodsObject( obj ) then
           RunImmediateMethods( obj, type![2] );
       fi;
       return obj;
@@ -4719,30 +4719,30 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Objectify", function ( type, obj )
-      local  flags;
-      if not IsType( type )  then
+      local flags;
+      if not IsType( type ) then
           Error( "<type> must be a type" );
       fi;
       flags := FlagsType( type );
-      if IS_LIST( obj )  then
-          if IS_SUBSET_FLAGS( flags, IsAtomicPositionalObjectRepFlags )  then
+      if IS_LIST( obj ) then
+          if IS_SUBSET_FLAGS( flags, IsAtomicPositionalObjectRepFlags ) then
               FORCE_SWITCH_OBJ( obj, FixedAtomicList( obj ) );
           fi;
           SET_TYPE_POSOBJ( obj, type );
-      elif IS_REC( obj )  then
-          if IS_ATOMIC_RECORD( obj )  then
-              if IS_SUBSET_FLAGS( flags, IsNonAtomicComponentObjectRepFlags )  then
+      elif IS_REC( obj ) then
+          if IS_ATOMIC_RECORD( obj ) then
+              if IS_SUBSET_FLAGS( flags, IsNonAtomicComponentObjectRepFlags ) then
                   FORCE_SWITCH_OBJ( obj, FromAtomicRecord( obj ) );
               fi;
-          elif not IS_SUBSET_FLAGS( flags, IsNonAtomicComponentObjectRepFlags )  then
+          elif not IS_SUBSET_FLAGS( flags, IsNonAtomicComponentObjectRepFlags ) then
               FORCE_SWITCH_OBJ( obj, AtomicRecord( obj ) );
           fi;
           SET_TYPE_COMOBJ( obj, type );
       fi;
-      if not IsNoImmediateMethodsObject( obj )  then
+      if not IsNoImmediateMethodsObject( obj ) then
           RunImmediateMethods( obj, type![2] );
       fi;
-      if IsReadOnlyPositionalObjectRep( obj )  then
+      if IsReadOnlyPositionalObjectRep( obj ) then
           MakeReadOnlyObj( obj );
       fi;
       return obj;
@@ -4760,17 +4760,17 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ChangeTypeObj", function ( type, obj )
-      if not IsType( type )  then
+      if not IsType( type ) then
           Error( "<type> must be a type" );
       fi;
-      if IS_POSOBJ( obj )  then
+      if IS_POSOBJ( obj ) then
           SET_TYPE_POSOBJ( obj, type );
-      elif IS_COMOBJ( obj )  then
+      elif IS_COMOBJ( obj ) then
           SET_TYPE_COMOBJ( obj, type );
-      elif IS_DATOBJ( obj )  then
+      elif IS_DATOBJ( obj ) then
           SET_TYPE_DATOBJ( obj, type );
       fi;
-      if not IsNoImmediateMethodsObject( obj )  then
+      if not IsNoImmediateMethodsObject( obj ) then
           RunImmediateMethods( obj, type![2] );
       fi;
       return obj;
@@ -4798,35 +4798,35 @@ static Obj  HdlrFunc1 (
  AssGVar( G_SetFilterObj, 0 );
  
  /* BIND_GLOBAL( "SetFilterObj", function ( obj, filter )
-      local  type, newtype;
-      if IS_POSOBJ( obj )  then
+      local type, newtype;
+      if IS_POSOBJ( obj ) then
           type := TYPE_OBJ( obj );
           newtype := Subtype2( type, filter );
           SET_TYPE_POSOBJ( obj, newtype );
-          if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj ))  then
+          if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then
               RunImmediateMethods( obj, SUB_FLAGS( newtype![2], type![2] ) );
           fi;
-      elif IS_COMOBJ( obj )  then
+      elif IS_COMOBJ( obj ) then
           type := TYPE_OBJ( obj );
           newtype := Subtype2( type, filter );
           SET_TYPE_COMOBJ( obj, newtype );
-          if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj ))  then
+          if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then
               RunImmediateMethods( obj, SUB_FLAGS( newtype![2], type![2] ) );
           fi;
-      elif IS_DATOBJ( obj )  then
+      elif IS_DATOBJ( obj ) then
           type := TYPE_OBJ( obj );
           newtype := Subtype2( type, filter );
           SET_TYPE_DATOBJ( obj, newtype );
-          if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj ))  then
+          if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then
               RunImmediateMethods( obj, SUB_FLAGS( newtype![2], type![2] ) );
           fi;
-      elif IS_PLIST_REP( obj )  then
+      elif IS_PLIST_REP( obj ) then
           SET_FILTER_LIST( obj, filter );
-      elif IS_STRING_REP( obj )  then
+      elif IS_STRING_REP( obj ) then
           SET_FILTER_LIST( obj, filter );
-      elif IS_BLIST( obj )  then
+      elif IS_BLIST( obj ) then
           SET_FILTER_LIST( obj, filter );
-      elif IS_RANGE( obj )  then
+      elif IS_RANGE( obj ) then
           SET_FILTER_LIST( obj, filter );
       else
           Error( "cannot set filter for internal object" );
@@ -4853,22 +4853,22 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ResetFilterObj", function ( obj, filter )
-      if IS_AND_FILTER( filter )  then
+      if IS_AND_FILTER( filter ) then
           Error( "You can't reset an \"and-filter\". Reset components individually." );
       fi;
-      if IS_POSOBJ( obj )  then
+      if IS_POSOBJ( obj ) then
           SET_TYPE_POSOBJ( obj, SupType2( TYPE_OBJ( obj ), filter ) );
-      elif IS_COMOBJ( obj )  then
+      elif IS_COMOBJ( obj ) then
           SET_TYPE_COMOBJ( obj, SupType2( TYPE_OBJ( obj ), filter ) );
-      elif IS_DATOBJ( obj )  then
+      elif IS_DATOBJ( obj ) then
           SET_TYPE_DATOBJ( obj, SupType2( TYPE_OBJ( obj ), filter ) );
-      elif IS_PLIST_REP( obj )  then
+      elif IS_PLIST_REP( obj ) then
           RESET_FILTER_LIST( obj, filter );
-      elif IS_STRING_REP( obj )  then
+      elif IS_STRING_REP( obj ) then
           RESET_FILTER_LIST( obj, filter );
-      elif IS_BLIST( obj )  then
+      elif IS_BLIST( obj ) then
           RESET_FILTER_LIST( obj, filter );
-      elif IS_RANGE( obj )  then
+      elif IS_RANGE( obj ) then
           RESET_FILTER_LIST( obj, filter );
       else
           Error( "cannot reset filter for internal object" );
@@ -4895,7 +4895,7 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetFeatureObj", function ( obj, filter, val )
-      if val  then
+      if val then
           SetFilterObj( obj, filter );
       else
           ResetFilterObj( obj, filter );
@@ -4915,23 +4915,23 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetMultipleAttributes", function ( arg... )
-      local  obj, type, flags, attr, val, i, extra, nfilt, nflags;
+      local obj, type, flags, attr, val, i, extra, nfilt, nflags;
       obj := arg[1];
-      if IsAttributeStoringRep( obj )  then
+      if IsAttributeStoringRep( obj ) then
           extra := [  ];
           type := TypeObj( obj );
           flags := FlagsType( type );
           nfilt := IS_OBJECT;
-          for i  in [ 2, 4 .. LEN_LIST( arg ) - 1 ]  do
+          for i in [ 2, 4 .. LEN_LIST( arg ) - 1 ] do
               attr := arg[i];
               val := arg[i + 1];
-              if 0 <> FLAG1_FILTER( attr )  then
-                  if val  then
+              if 0 <> FLAG1_FILTER( attr ) then
+                  if val then
                       nfilt := nfilt and attr;
                   else
                       nfilt := nfilt and Tester( attr );
                   fi;
-              elif LEN_LIST( METHODS_OPERATION( Setter( attr ), 2 ) ) <> 12  then
+              elif LEN_LIST( METHODS_OPERATION( Setter( attr ), 2 ) ) <> 12 then
                   ADD_LIST( extra, attr );
                   ADD_LIST( extra, val );
               else
@@ -4940,16 +4940,16 @@ static Obj  HdlrFunc1 (
               fi;
           od;
           nflags := FLAGS_FILTER( nfilt );
-          if not IS_SUBSET_FLAGS( flags, nflags )  then
+          if not IS_SUBSET_FLAGS( flags, nflags ) then
               flags := WITH_IMPS_FLAGS( AND_FLAGS( flags, nflags ) );
               ChangeTypeObj( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ) ), obj );
           fi;
-          for i  in [ 2, 4 .. LEN_LIST( extra ) ]  do
+          for i in [ 2, 4 .. LEN_LIST( extra ) ] do
               Setter( extra[i - 1] )( obj, extra[i] );
           od;
       else
           extra := arg;
-          for i  in [ 2, 4 .. LEN_LIST( extra ) ]  do
+          for i in [ 2, 4 .. LEN_LIST( extra ) ] do
               Setter( extra[i] )( obj, extra[i + 1] );
           od;
       fi;
@@ -4990,27 +4990,27 @@ static Obj  HdlrFunc1 (
  CALL_1ARGS( t_1, t_2 );
  
  /* BIND_GLOBAL( "ObjectifyWithAttributes", function ( arg... )
-      local  obj, type, flags, attr, val, i, extra, nflags;
+      local obj, type, flags, attr, val, i, extra, nflags;
       obj := arg[1];
       type := arg[2];
       flags := FlagsType( type );
       extra := [  ];
-      if not IS_SUBSET_FLAGS( flags, IsAttributeStoringRepFlags )  then
+      if not IS_SUBSET_FLAGS( flags, IsAttributeStoringRepFlags ) then
           extra := arg{[ 3 .. LEN_LIST( arg ) ]};
           INFO_OWA( "#W ObjectifyWithAttributes called ", "for non-attribute storing rep\n" );
           Objectify( type, obj );
       else
           nflags := EMPTY_FLAGS;
-          for i  in [ 3, 5 .. LEN_LIST( arg ) - 1 ]  do
+          for i in [ 3, 5 .. LEN_LIST( arg ) - 1 ] do
               attr := arg[i];
               val := arg[i + 1];
-              if 0 <> FLAG1_FILTER( attr )  then
-                  if val  then
+              if 0 <> FLAG1_FILTER( attr ) then
+                  if val then
                       nflags := AND_FLAGS( nflags, FLAGS_FILTER( attr ) );
                   else
                       nflags := AND_FLAGS( nflags, FLAGS_FILTER( Tester( attr ) ) );
                   fi;
-              elif LEN_LIST( METHODS_OPERATION( Setter( attr ), 2 ) ) <> LENGTH_SETTER_METHODS_2  then
+              elif LEN_LIST( METHODS_OPERATION( Setter( attr ), 2 ) ) <> LENGTH_SETTER_METHODS_2 then
                   ADD_LIST( extra, attr );
                   ADD_LIST( extra, val );
               else
@@ -5018,15 +5018,15 @@ static Obj  HdlrFunc1 (
                   nflags := AND_FLAGS( nflags, FLAGS_FILTER( Tester( attr ) ) );
               fi;
           od;
-          if not IS_SUBSET_FLAGS( flags, nflags )  then
+          if not IS_SUBSET_FLAGS( flags, nflags ) then
               flags := WITH_IMPS_FLAGS( AND_FLAGS( flags, nflags ) );
               Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ), fail ), obj );
           else
               Objectify( type, obj );
           fi;
       fi;
-      for i  in [ 1, 3 .. LEN_LIST( extra ) - 1 ]  do
-          if Tester( extra[i] )( obj )  then
+      for i in [ 1, 3 .. LEN_LIST( extra ) - 1 ] do
+          if Tester( extra[i] )( obj ) then
               INFO_OWA( "#W  Supplied type has tester of ", NAME_FUNC( extra[i] ), "with non-standard setter\n" );
               ResetFilterObj( obj, Tester( extra[i] ) );
           fi;

--- a/src/c_filter1.c
+++ b/src/c_filter1.c
@@ -497,12 +497,12 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "WITH_IMPS_FLAGS", function ( flags )
-      local  with, changed, imp, hash, hash2, i;
+      local with, changed, imp, hash, hash2, i;
       hash := HASH_FLAGS( flags ) mod 11001;
-      for i  in [ 0 .. 3 ]  do
+      for i in [ 0 .. 3 ] do
           hash2 := 2 * ((hash + 31 * i) mod 11001) + 1;
-          if IsBound( WITH_IMPS_FLAGS_CACHE[hash2] )  then
-              if IS_IDENTICAL_OBJ( WITH_IMPS_FLAGS_CACHE[hash2], flags )  then
+          if IsBound( WITH_IMPS_FLAGS_CACHE[hash2] ) then
+              if IS_IDENTICAL_OBJ( WITH_IMPS_FLAGS_CACHE[hash2], flags ) then
                   WITH_IMPS_FLAGS_CACHE_HIT := WITH_IMPS_FLAGS_CACHE_HIT + 1;
                   return WITH_IMPS_FLAGS_CACHE[hash2 + 1];
               fi;
@@ -510,7 +510,7 @@ static Obj  HdlrFunc1 (
               break;
           fi;
       od;
-      if i = 3  then
+      if i = 3 then
           WITH_IMPS_FLAGS_COUNT := (WITH_IMPS_FLAGS_COUNT + 1) mod 4;
           i := WITH_IMPS_FLAGS_COUNT;
           hash2 := 2 * ((hash + 31 * i) mod 11001) + 1;
@@ -518,10 +518,10 @@ static Obj  HdlrFunc1 (
       WITH_IMPS_FLAGS_CACHE_MISS := WITH_IMPS_FLAGS_CACHE_MISS + 1;
       with := flags;
       changed := true;
-      while changed  do
+      while changed do
           changed := false;
-          for imp  in IMPLICATIONS  do
-              if IS_SUBSET_FLAGS( with, imp[2] ) and not IS_SUBSET_FLAGS( with, imp[1] )  then
+          for imp in IMPLICATIONS do
+              if IS_SUBSET_FLAGS( with, imp[2] ) and not IS_SUBSET_FLAGS( with, imp[1] ) then
                   with := AND_FLAGS( with, imp[1] );
                   changed := true;
               fi;
@@ -544,15 +544,15 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "RankFilter", function ( filter )
-      local  rank, flags, i;
+      local rank, flags, i;
       rank := 0;
-      if IS_FUNCTION( filter )  then
+      if IS_FUNCTION( filter ) then
           flags := FLAGS_FILTER( filter );
       else
           flags := filter;
       fi;
-      for i  in TRUES_FLAGS( WITH_HIDDEN_IMPS_FLAGS( flags ) )  do
-          if IsBound( RANK_FILTERS[i] )  then
+      for i in TRUES_FLAGS( WITH_HIDDEN_IMPS_FLAGS( flags ) ) do
+          if IsBound( RANK_FILTERS[i] ) then
               rank := rank + RANK_FILTERS[i];
           else
               rank := rank + 1;

--- a/src/c_methsel1.c
+++ b/src/c_methsel1.c
@@ -4642,10 +4642,10 @@ static Obj  HdlrFunc1 (
  SET_BRK_CURR_STAT(0);
  
  /* METHOD_0ARGS := function ( operation )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 0 );
-      for i  in [ 1, 5 .. LEN_LIST( methods ) - 3 ]  do
-          if methods[i](  )  then
+      for i in [ 1, 5 .. LEN_LIST( methods ) - 3 ] do
+          if methods[i](  ) then
               return methods[i + 1];
           fi;
       od;
@@ -4662,10 +4662,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__0ARGS, t_1 );
  
  /* METHOD_1ARGS := function ( operation, type1 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 1 );
-      for i  in [ 1, 6 .. LEN_LIST( methods ) - 4 ]  do
-          if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and methods[i]( type1![1] )  then
+      for i in [ 1, 6 .. LEN_LIST( methods ) - 4 ] do
+          if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and methods[i]( type1![1] ) then
               return methods[i + 2];
           fi;
       od;
@@ -4682,10 +4682,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__1ARGS, t_1 );
  
  /* METHOD_2ARGS := function ( operation, type1, type2 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 2 );
-      for i  in [ 1, 7 .. LEN_LIST( methods ) - 5 ]  do
-          if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and methods[i]( type1![1], type2![1] )  then
+      for i in [ 1, 7 .. LEN_LIST( methods ) - 5 ] do
+          if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and methods[i]( type1![1], type2![1] ) then
               return methods[i + 3];
           fi;
       od;
@@ -4702,10 +4702,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__2ARGS, t_1 );
  
  /* METHOD_3ARGS := function ( operation, type1, type2, type3 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 3 );
-      for i  in [ 1, 8 .. LEN_LIST( methods ) - 6 ]  do
-          if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and IS_SUBSET_FLAGS( type3![2], methods[i + 3] ) and methods[i]( type1![1], type2![1], type3![1] )  then
+      for i in [ 1, 8 .. LEN_LIST( methods ) - 6 ] do
+          if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and IS_SUBSET_FLAGS( type3![2], methods[i + 3] ) and methods[i]( type1![1], type2![1], type3![1] ) then
               return methods[i + 4];
           fi;
       od;
@@ -4722,11 +4722,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__3ARGS, t_1 );
  
  /* METHOD_4ARGS := function ( operation, type1, type2, type3, type4 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 4 );
-      for i  in [ 1, 9 .. LEN_LIST( methods ) - 7 ]  do
+      for i in [ 1, 9 .. LEN_LIST( methods ) - 7 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and IS_SUBSET_FLAGS( type3![2], methods[i + 3] ) and IS_SUBSET_FLAGS( type4![2], methods[i + 4] ) 
-              and methods[i]( type1![1], type2![1], type3![1], type4![1] )  then
+              and methods[i]( type1![1], type2![1], type3![1], type4![1] ) then
               return methods[i + 5];
           fi;
       od;
@@ -4743,11 +4743,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__4ARGS, t_1 );
  
  /* METHOD_5ARGS := function ( operation, type1, type2, type3, type4, type5 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 5 );
-      for i  in [ 1, 10 .. LEN_LIST( methods ) - 8 ]  do
+      for i in [ 1, 10 .. LEN_LIST( methods ) - 8 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and IS_SUBSET_FLAGS( type3![2], methods[i + 3] ) and IS_SUBSET_FLAGS( type4![2], methods[i + 4] ) and IS_SUBSET_FLAGS( type5![2], methods[i + 5] )
-              and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1] )  then
+              and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1] ) then
               return methods[i + 6];
           fi;
       od;
@@ -4764,11 +4764,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__5ARGS, t_1 );
  
  /* METHOD_6ARGS := function ( operation, type1, type2, type3, type4, type5, type6 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 6 );
-      for i  in [ 1, 11 .. LEN_LIST( methods ) - 9 ]  do
+      for i in [ 1, 11 .. LEN_LIST( methods ) - 9 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and IS_SUBSET_FLAGS( type3![2], methods[i + 3] ) and IS_SUBSET_FLAGS( type4![2], methods[i + 4] ) and IS_SUBSET_FLAGS( type5![2], methods[i + 5] )
-                and IS_SUBSET_FLAGS( type6![2], methods[i + 6] ) and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1], type6![1] )  then
+                and IS_SUBSET_FLAGS( type6![2], methods[i + 6] ) and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1], type6![1] ) then
               return methods[i + 7];
           fi;
       od;
@@ -4799,12 +4799,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_METHOD__XARGS, t_1 );
  
  /* NEXT_METHOD_0ARGS := function ( operation, k )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 0 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 4 ]  do
-          if methods[4 * (i - 1) + 1](  )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 4 ] do
+          if methods[4 * (i - 1) + 1](  ) then
+              if k = j then
                   return methods[4 * (i - 1) + 2];
               else
                   j := j + 1;
@@ -4824,12 +4824,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__0ARGS, t_1 );
  
  /* NEXT_METHOD_1ARGS := function ( operation, k, type1 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 1 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 5 ]  do
-          if IS_SUBSET_FLAGS( type1![2], methods[5 * (i - 1) + 2] ) and methods[5 * (i - 1) + 1]( type1![1] )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 5 ] do
+          if IS_SUBSET_FLAGS( type1![2], methods[5 * (i - 1) + 2] ) and methods[5 * (i - 1) + 1]( type1![1] ) then
+              if k = j then
                   return methods[5 * (i - 1) + 3];
               else
                   j := j + 1;
@@ -4849,12 +4849,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__1ARGS, t_1 );
  
  /* NEXT_METHOD_2ARGS := function ( operation, k, type1, type2 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 2 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 6 ]  do
-          if IS_SUBSET_FLAGS( type1![2], methods[6 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( type1![1], type2![1] )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 6 ] do
+          if IS_SUBSET_FLAGS( type1![2], methods[6 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( type1![1], type2![1] ) then
+              if k = j then
                   return methods[6 * (i - 1) + 4];
               else
                   j := j + 1;
@@ -4874,13 +4874,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__2ARGS, t_1 );
  
  /* NEXT_METHOD_3ARGS := function ( operation, k, type1, type2, type3 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 3 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 7 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 7 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[7 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( type1![1], type2![1], type3![1] )
-               then
-              if k = j  then
+              then
+              if k = j then
                   return methods[7 * (i - 1) + 5];
               else
                   j := j + 1;
@@ -4900,13 +4900,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__3ARGS, t_1 );
  
  /* NEXT_METHOD_4ARGS := function ( operation, k, type1, type2, type3, type4 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 4 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 8 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 8 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[8 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[8 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[8 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[8 * (i - 1) + 5] ) 
-              and methods[8 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1] )  then
-              if k = j  then
+              and methods[8 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1] ) then
+              if k = j then
                   return methods[8 * (i - 1) + 6];
               else
                   j := j + 1;
@@ -4926,13 +4926,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__4ARGS, t_1 );
  
  /* NEXT_METHOD_5ARGS := function ( operation, k, type1, type2, type3, type4, type5 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 5 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 9 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 9 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[9 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[9 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[9 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[9 * (i - 1) + 5] ) 
-                and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1], type5![1] )  then
-              if k = j  then
+                and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1], type5![1] ) then
+              if k = j then
                   return methods[9 * (i - 1) + 7];
               else
                   j := j + 1;
@@ -4952,13 +4952,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__5ARGS, t_1 );
  
  /* NEXT_METHOD_6ARGS := function ( operation, k, type1, type2, type3, type4, type5, type6 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 6 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 10 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 10 ] do
           if IS_SUBSET_FLAGS( type1![2], methods[10 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[10 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[10 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[10 * (i - 1) + 5] ) 
-                  and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1], type5![1], type6![1] )  then
-              if k = j  then
+                  and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1], type5![1], type6![1] ) then
+              if k = j then
                   return methods[10 * (i - 1) + 8];
               else
                   j := j + 1;
@@ -4992,20 +4992,20 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__METHOD__XARGS, t_1 );
  
  /* AttributeValueNotSet := function ( attr, obj )
-      local  type, fam, methods, i, flag, erg;
+      local type, fam, methods, i, flag, erg;
       type := TypeObj( obj );
       fam := FamilyObj( obj );
       methods := METHODS_OPERATION( attr, 1 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 5 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 5 ] do
           flag := true;
           flag := flag and IS_SUBSET_FLAGS( type![2], methods[5 * (i - 1) + 2] );
-          if flag  then
+          if flag then
               flag := flag and methods[5 * (i - 1) + 1]( fam );
           fi;
-          if flag  then
+          if flag then
               attr := methods[5 * (i - 1) + 3];
               erg := attr( obj );
-              if not IS_IDENTICAL_OBJ( erg, TRY_NEXT_METHOD )  then
+              if not IS_IDENTICAL_OBJ( erg, TRY_NEXT_METHOD ) then
                   return erg;
               fi;
           fi;
@@ -5024,10 +5024,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_AttributeValueNotSet, t_1 );
  
  /* CONSTRUCTOR_0ARGS := function ( operation )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 0 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 4 ]  do
-          if methods[4 * (i - 1) + 1](  )  then
+      for i in [ 1 .. LEN_LIST( methods ) / 4 ] do
+          if methods[4 * (i - 1) + 1](  ) then
               return methods[4 * (i - 1) + 2];
           fi;
       od;
@@ -5044,10 +5044,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__0ARGS, t_1 );
  
  /* CONSTRUCTOR_1ARGS := function ( operation, flags1 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 1 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 5 ]  do
-          if IS_SUBSET_FLAGS( methods[5 * (i - 1) + 2], flags1 ) and methods[5 * (i - 1) + 1]( flags1 )  then
+      for i in [ 1 .. LEN_LIST( methods ) / 5 ] do
+          if IS_SUBSET_FLAGS( methods[5 * (i - 1) + 2], flags1 ) and methods[5 * (i - 1) + 1]( flags1 ) then
               return methods[5 * (i - 1) + 3];
           fi;
       od;
@@ -5064,10 +5064,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__1ARGS, t_1 );
  
  /* CONSTRUCTOR_2ARGS := function ( operation, flags1, type2 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 2 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 6 ]  do
-          if IS_SUBSET_FLAGS( methods[6 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( flags1, type2![1] )  then
+      for i in [ 1 .. LEN_LIST( methods ) / 6 ] do
+          if IS_SUBSET_FLAGS( methods[6 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( flags1, type2![1] ) then
               return methods[6 * (i - 1) + 4];
           fi;
       od;
@@ -5084,10 +5084,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__2ARGS, t_1 );
  
  /* CONSTRUCTOR_3ARGS := function ( operation, flags1, type2, type3 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 3 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 7 ]  do
-          if IS_SUBSET_FLAGS( methods[7 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( flags1, type2![1], type3![1] )  then
+      for i in [ 1 .. LEN_LIST( methods ) / 7 ] do
+          if IS_SUBSET_FLAGS( methods[7 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( flags1, type2![1], type3![1] ) then
               return methods[7 * (i - 1) + 5];
           fi;
       od;
@@ -5104,11 +5104,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__3ARGS, t_1 );
  
  /* CONSTRUCTOR_4ARGS := function ( operation, flags1, type2, type3, type4 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 4 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 8 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 8 ] do
           if IS_SUBSET_FLAGS( methods[8 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[8 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[8 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[8 * (i - 1) + 5] ) 
-              and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] )  then
+              and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then
               return methods[8 * (i - 1) + 6];
           fi;
       od;
@@ -5125,11 +5125,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__4ARGS, t_1 );
  
  /* CONSTRUCTOR_5ARGS := function ( operation, flags1, type2, type3, type4, type5 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 5 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 9 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 9 ] do
           if IS_SUBSET_FLAGS( methods[9 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[9 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[9 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[9 * (i - 1) + 5] ) 
-                and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1] )  then
+                and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1] ) then
               return methods[9 * (i - 1) + 7];
           fi;
       od;
@@ -5146,11 +5146,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__5ARGS, t_1 );
  
  /* CONSTRUCTOR_6ARGS := function ( operation, flags1, type2, type3, type4, type5, type6 )
-      local  methods, i;
+      local methods, i;
       methods := METHODS_OPERATION( operation, 6 );
-      for i  in [ 1 .. LEN_LIST( methods ) / 10 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 10 ] do
           if IS_SUBSET_FLAGS( methods[10 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[10 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[10 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[10 * (i - 1) + 5] ) 
-                  and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1], type6![1] )  then
+                  and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1], type6![1] ) then
               return methods[10 * (i - 1) + 8];
           fi;
       od;
@@ -5181,12 +5181,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CONSTRUCTOR__XARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_0ARGS := function ( operation, k )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 0 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 4 ]  do
-          if methods[4 * (i - 1) + 1](  )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 4 ] do
+          if methods[4 * (i - 1) + 1](  ) then
+              if k = j then
                   return methods[4 * (i - 1) + 2];
               else
                   j := j + 1;
@@ -5206,12 +5206,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__CONSTRUCTOR__0ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_1ARGS := function ( operation, k, flags1 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 1 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 5 ]  do
-          if IS_SUBSET_FLAGS( methods[5 * (i - 1) + 2], flags1 ) and methods[5 * (i - 1) + 1]( flags1 )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 5 ] do
+          if IS_SUBSET_FLAGS( methods[5 * (i - 1) + 2], flags1 ) and methods[5 * (i - 1) + 1]( flags1 ) then
+              if k = j then
                   return methods[5 * (i - 1) + 3];
               else
                   j := j + 1;
@@ -5231,12 +5231,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__CONSTRUCTOR__1ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_2ARGS := function ( operation, k, flags1, type2 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 2 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 6 ]  do
-          if IS_SUBSET_FLAGS( methods[6 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( flags1, type2![1] )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 6 ] do
+          if IS_SUBSET_FLAGS( methods[6 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( flags1, type2![1] ) then
+              if k = j then
                   return methods[6 * (i - 1) + 4];
               else
                   j := j + 1;
@@ -5256,12 +5256,12 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__CONSTRUCTOR__2ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_3ARGS := function ( operation, k, flags1, type2, type3 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 3 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 7 ]  do
-          if IS_SUBSET_FLAGS( methods[7 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( flags1, type2![1], type3![1] )  then
-              if k = j  then
+      for i in [ 1 .. LEN_LIST( methods ) / 7 ] do
+          if IS_SUBSET_FLAGS( methods[7 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( flags1, type2![1], type3![1] ) then
+              if k = j then
                   return methods[7 * (i - 1) + 5];
               else
                   j := j + 1;
@@ -5281,13 +5281,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__CONSTRUCTOR__3ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_4ARGS := function ( operation, k, flags1, type2, type3, type4 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 4 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 8 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 8 ] do
           if IS_SUBSET_FLAGS( methods[8 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[8 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[8 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[8 * (i - 1) + 5] ) 
-              and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] )  then
-              if k = j  then
+              and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then
+              if k = j then
                   return methods[8 * (i - 1) + 6];
               else
                   j := j + 1;
@@ -5307,13 +5307,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__CONSTRUCTOR__4ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_5ARGS := function ( operation, k, flags1, type2, type3, type4, type5 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 5 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 9 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 9 ] do
           if IS_SUBSET_FLAGS( methods[9 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[9 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[9 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[9 * (i - 1) + 5] ) 
-                and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1] )  then
-              if k = j  then
+                and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1] ) then
+              if k = j then
                   return methods[9 * (i - 1) + 7];
               else
                   j := j + 1;
@@ -5333,13 +5333,13 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEXT__CONSTRUCTOR__5ARGS, t_1 );
  
  /* NEXT_CONSTRUCTOR_6ARGS := function ( operation, k, flags1, type2, type3, type4, type5, type6 )
-      local  methods, i, j;
+      local methods, i, j;
       methods := METHODS_OPERATION( operation, 6 );
       j := 0;
-      for i  in [ 1 .. LEN_LIST( methods ) / 10 ]  do
+      for i in [ 1 .. LEN_LIST( methods ) / 10 ] do
           if IS_SUBSET_FLAGS( methods[10 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[10 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[10 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[10 * (i - 1) + 5] ) 
-                  and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1], type6![1] )  then
-              if k = j  then
+                  and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1], type6![1] ) then
+              if k = j then
                   return methods[10 * (i - 1) + 8];
               else
                   j := j + 1;

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -2405,17 +2405,17 @@ static Obj  HdlrFunc7 (
   if ( t_1 ) {
    
    /* InstallOtherMethod( getter, "default method requiring categories and checking properties", true, [ cats ], rank, function ( obj )
-      local  found, prop;
+      local found, prop;
       found := false;
-      for prop  in props  do
-          if not Tester( prop )( obj )  then
+      for prop in props do
+          if not Tester( prop )( obj ) then
               found := true;
-              if not (prop( obj ) and Tester( prop )( obj ))  then
+              if not (prop( obj ) and Tester( prop )( obj )) then
                   TryNextMethod();
               fi;
           fi;
       od;
-      if found  then
+      if found then
           return getter( obj );
       else
           TryNextMethod();
@@ -3017,7 +3017,7 @@ static Obj  HdlrFunc11 (
  if ( t_1 ) {
   
   /* keytest := function ( key )
-      if not IsPrimeInt( key )  then
+      if not IsPrimeInt( key ) then
           Error( name, ": <p> must be a prime" );
       fi;
       return;
@@ -3136,14 +3136,14 @@ static Obj  HdlrFunc11 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* InstallOtherMethod( VALUE_GLOBAL( name ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
-      local  known, i, erg;
+      local known, i, erg;
       keytest( key );
       known := attr( D );
       i := PositionSortedOddPositions( known, key );
-      if LEN_LIST( known ) < i or known[i] <> key  then
+      if LEN_LIST( known ) < i or known[i] <> key then
           erg := oper( D, key );
           i := PositionSortedOddPositions( known, key );
-          if LEN_LIST( known ) < i or known[i] <> key  then
+          if LEN_LIST( known ) < i or known[i] <> key then
               known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
               known[i] := IMMUTABLE_COPY_OBJ( key );
               known[i + 1] := IMMUTABLE_COPY_OBJ( erg );
@@ -3196,7 +3196,7 @@ static Obj  HdlrFunc11 (
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
-      local  known, i;
+      local known, i;
       keytest( key );
       known := attr( D );
       i := PositionSortedOddPositions( known, key );
@@ -3249,11 +3249,11 @@ static Obj  HdlrFunc11 (
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq, IS_OBJECT ], 0, function ( D, key, obj )
-      local  known, i;
+      local known, i;
       keytest( key );
       known := attr( D );
       i := PositionSortedOddPositions( known, key );
-      if LEN_LIST( known ) < i or known[i] <> key  then
+      if LEN_LIST( known ) < i or known[i] <> key then
           known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
           known[i] := IMMUTABLE_COPY_OBJ( key );
           known[i + 1] := IMMUTABLE_COPY_OBJ( obj );
@@ -3640,10 +3640,10 @@ static Obj  HdlrFunc17 (
  
  /* InstallOtherMethod( oper, info, fampred, reqs, val, function ( arg... )
       re := false;
-      for i  in [ 1 .. LEN_LIST( reqs ) ]  do
+      for i in [ 1 .. LEN_LIST( reqs ) ] do
           re := re or IsBound( cond[i] ) and not Tester( cond[i] )( arg[i] ) and cond[i]( arg[i] ) and Tester( cond[i] )( arg[i] );
       od;
-      if re  then
+      if re then
           return CallFuncList( oper, arg );
       else
           TryNextMethod();
@@ -3703,11 +3703,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_RUN__IMMEDIATE__METHODS__HITS, INTOBJ_INT(0) );
  
  /* BIND_GLOBAL( "RunImmediateMethods", function ( obj, flags )
-      local  flagspos, tried, type, j, imm, i, res, newflags;
-      if IGNORE_IMMEDIATE_METHODS  then
+      local flagspos, tried, type, j, imm, i, res, newflags;
+      if IGNORE_IMMEDIATE_METHODS then
           return;
       fi;
-      if IS_SUBSET_FLAGS( IMM_FLAGS, flags )  then
+      if IS_SUBSET_FLAGS( IMM_FLAGS, flags ) then
           return;
       fi;
       flags := SUB_FLAGS( flags, IMM_FLAGS );
@@ -3715,27 +3715,27 @@ static Obj  HdlrFunc1 (
       tried := [  ];
       type := TYPE_OBJ( obj );
       flags := type![2];
-      for j  in flagspos  do
-          if IsBound( IMMEDIATES[j] )  then
+      for j in flagspos do
+          if IsBound( IMMEDIATES[j] ) then
               imm := IMMEDIATES[j];
-              for i  in [ 0, 7 .. LEN_LIST( imm ) - 7 ]  do
-                  if IS_SUBSET_FLAGS( flags, imm[i + 4] ) and not IS_SUBSET_FLAGS( flags, imm[i + 3] ) and not imm[i + 6] in tried  then
+              for i in [ 0, 7 .. LEN_LIST( imm ) - 7 ] do
+                  if IS_SUBSET_FLAGS( flags, imm[i + 4] ) and not IS_SUBSET_FLAGS( flags, imm[i + 3] ) and not imm[i + 6] in tried then
                       res := IMMEDIATE_METHODS[imm[i + 6]]( obj );
                       ADD_LIST( tried, imm[i + 6] );
                       RUN_IMMEDIATE_METHODS_CHECKS := RUN_IMMEDIATE_METHODS_CHECKS + 1;
-                      if TRACE_IMMEDIATE_METHODS  then
-                          if imm[i + 7] = false  then
+                      if TRACE_IMMEDIATE_METHODS then
+                          if imm[i + 7] = false then
                               Print( "#I  immediate: ", NAME_FUNC( imm[i + 1] ), "\n" );
                           else
                               Print( "#I  immediate: ", NAME_FUNC( imm[i + 1] ), ": ", imm[i + 7], "\n" );
                           fi;
                       fi;
-                      if res <> TRY_NEXT_METHOD  then
+                      if res <> TRY_NEXT_METHOD then
                           IGNORE_IMMEDIATE_METHODS := true;
                           imm[i + 2]( obj, res );
                           IGNORE_IMMEDIATE_METHODS := false;
                           RUN_IMMEDIATE_METHODS_HITS := RUN_IMMEDIATE_METHODS_HITS + 1;
-                          if not IS_IDENTICAL_OBJ( TYPE_OBJ( obj ), type )  then
+                          if not IS_IDENTICAL_OBJ( TYPE_OBJ( obj ), type ) then
                               type := TYPE_OBJ( obj );
                               newflags := SUB_FLAGS( type![2], IMM_FLAGS );
                               newflags := SUB_FLAGS( newflags, flags );
@@ -3762,19 +3762,19 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "INSTALL_METHOD_FLAGS", function ( opr, info, rel, flags, rank, method )
-      local  methods, narg, i, k, tmp, replace, match, j;
-      if IS_CONSTRUCTOR( opr )  then
-          if 0 < LEN_LIST( flags )  then
+      local methods, narg, i, k, tmp, replace, match, j;
+      if IS_CONSTRUCTOR( opr ) then
+          if 0 < LEN_LIST( flags ) then
               rank := rank - RankFilter( flags[1] );
           fi;
       else
-          for i  in flags  do
+          for i in flags do
               rank := rank + RankFilter( i );
           od;
       fi;
       narg := LEN_LIST( flags );
       methods := METHODS_OPERATION( opr, narg );
-      if info = false  then
+      if info = false then
           info := NAME_FUNC( opr );
       else
           k := SHALLOW_COPY_OBJ( NAME_FUNC( opr ) );
@@ -3784,19 +3784,19 @@ static Obj  HdlrFunc1 (
           CONV_STRING( info );
       fi;
       i := 0;
-      while i < LEN_LIST( methods ) and rank < methods[i + (narg + 3)]  do
+      while i < LEN_LIST( methods ) and rank < methods[i + (narg + 3)] do
           i := i + (narg + 4);
       od;
       replace := false;
-      if REREADING  then
+      if REREADING then
           k := i;
-          while k < LEN_LIST( methods ) and rank = methods[k + narg + 3]  do
-              if info = methods[k + narg + 4]  then
+          while k < LEN_LIST( methods ) and rank = methods[k + narg + 3] do
+              if info = methods[k + narg + 4] then
                   match := false;
-                  for j  in [ 1 .. narg ]  do
+                  for j in [ 1 .. narg ] do
                       match := match and methods[k + j + 1] = flags[j];
                   od;
-                  if match  then
+                  if match then
                       replace := true;
                       i := k;
                       break;
@@ -3805,17 +3805,17 @@ static Obj  HdlrFunc1 (
               k := k + narg + 4;
           od;
       fi;
-      if not REREADING or not replace  then
+      if not REREADING or not replace then
           methods{[ narg + 4 + i + 1 .. narg + 4 + LEN_LIST( methods ) ]} := methods{[ i + 1 .. LEN_LIST( methods ) ]};
       fi;
-      if rel = true  then
+      if rel = true then
           methods[i + 1] := RETURN_TRUE;
-      elif rel = false  then
+      elif rel = false then
           methods[i + 1] := RETURN_FALSE;
-      elif IS_FUNCTION( rel )  then
-          if CHECK_INSTALL_METHOD  then
+      elif IS_FUNCTION( rel ) then
+          if CHECK_INSTALL_METHOD then
               tmp := NARG_FUNC( rel );
-              if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg  then
+              if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then
                   Error( NAME_FUNC( opr ), ": <famrel> must accept ", narg, " arguments" );
               fi;
           fi;
@@ -3823,17 +3823,17 @@ static Obj  HdlrFunc1 (
       else
           Error( NAME_FUNC( opr ), ": <famrel> must be a function, `true', or `false'" );
       fi;
-      for k  in [ 1 .. narg ]  do
+      for k in [ 1 .. narg ] do
           methods[i + k + 1] := flags[k];
       od;
-      if method = true  then
+      if method = true then
           methods[i + (narg + 2)] := RETURN_TRUE;
-      elif method = false  then
+      elif method = false then
           methods[i + (narg + 2)] := RETURN_FALSE;
-      elif IS_FUNCTION( method )  then
-          if CHECK_INSTALL_METHOD and not IS_OPERATION( method )  then
+      elif IS_FUNCTION( method ) then
+          if CHECK_INSTALL_METHOD and not IS_OPERATION( method ) then
               tmp := NARG_FUNC( method );
-              if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg  then
+              if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then
                   Error( NAME_FUNC( opr ), ": <method> must accept ", narg, " arguments" );
               fi;
           fi;
@@ -3899,44 +3899,44 @@ static Obj  HdlrFunc1 (
  AssGVar( G_INSTALL__METHOD, 0 );
  
  /* BIND_GLOBAL( "INSTALL_METHOD", function ( arglist, check )
-      local  len, opr, info, pos, rel, filters, info1, isstr, flags, i, rank, method, oreqs, req, reqs, match, j, k, imp, notmatch;
+      local len, opr, info, pos, rel, filters, info1, isstr, flags, i, rank, method, oreqs, req, reqs, match, j, k, imp, notmatch;
       len := LEN_LIST( arglist );
-      if len < 3  then
+      if len < 3 then
           Error( "too few arguments given in <arglist>" );
       fi;
       opr := arglist[1];
-      if not IS_OPERATION( opr )  then
+      if not IS_OPERATION( opr ) then
           Error( "<opr> is not an operation" );
       fi;
-      if IS_STRING_REP( arglist[2] )  then
+      if IS_STRING_REP( arglist[2] ) then
           info := arglist[2];
           pos := 3;
       else
           info := false;
           pos := 2;
       fi;
-      if arglist[pos] = true or IS_FUNCTION( arglist[pos] )  then
+      if arglist[pos] = true or IS_FUNCTION( arglist[pos] ) then
           rel := arglist[pos];
           pos := pos + 1;
       else
           rel := true;
       fi;
-      if not IsBound( arglist[pos] ) or not IS_LIST( arglist[pos] )  then
+      if not IsBound( arglist[pos] ) or not IS_LIST( arglist[pos] ) then
           Error( "<arglist>[", pos, "] must be a list of filters" );
       fi;
       filters := arglist[pos];
-      if GAPInfo.MaxNrArgsMethod < LEN_LIST( filters )  then
+      if GAPInfo.MaxNrArgsMethod < LEN_LIST( filters ) then
           Error( "methods can have at most ", GAPInfo.MaxNrArgsMethod, " arguments" );
       fi;
-      if 0 < LEN_LIST( filters )  then
+      if 0 < LEN_LIST( filters ) then
           info1 := "[ ";
           isstr := true;
-          for i  in [ 1 .. LEN_LIST( filters ) ]  do
-              if IS_STRING_REP( filters[i] )  then
+          for i in [ 1 .. LEN_LIST( filters ) ] do
+              if IS_STRING_REP( filters[i] ) then
                   APPEND_LIST_INTR( info1, filters[i] );
                   APPEND_LIST_INTR( info1, ", " );
                   filters[i] := EvalString( filters[i] );
-                  if not IS_FUNCTION( filters[i] )  then
+                  if not IS_FUNCTION( filters[i] ) then
                       Error( "string does not evaluate to a function" );
                   fi;
               else
@@ -3944,7 +3944,7 @@ static Obj  HdlrFunc1 (
                   break;
               fi;
           od;
-          if isstr and info = false  then
+          if isstr and info = false then
               info1[LEN_LIST( info1 ) - 1] := ' ';
               info1[LEN_LIST( info1 )] := ']';
               info := info1;
@@ -3952,81 +3952,81 @@ static Obj  HdlrFunc1 (
       fi;
       pos := pos + 1;
       flags := [  ];
-      for i  in filters  do
+      for i in filters do
           ADD_LIST( flags, FLAGS_FILTER( i ) );
       od;
-      if not IsBound( arglist[pos] )  then
+      if not IsBound( arglist[pos] ) then
           Error( "the method is missing in <arglist>" );
-      elif IS_INT( arglist[pos] )  then
+      elif IS_INT( arglist[pos] ) then
           rank := arglist[pos];
           pos := pos + 1;
       else
           rank := 0;
       fi;
-      if not IsBound( arglist[pos] )  then
+      if not IsBound( arglist[pos] ) then
           Error( "the method is missing in <arglist>" );
       fi;
       method := arglist[pos];
-      if FLAG1_FILTER( opr ) <> 0 and (rel = true or rel = RETURN_TRUE) and LEN_LIST( filters ) = 1 and (method = true or method = RETURN_TRUE)  then
+      if FLAG1_FILTER( opr ) <> 0 and (rel = true or rel = RETURN_TRUE) and LEN_LIST( filters ) = 1 and (method = true or method = RETURN_TRUE) then
           Error( NAME_FUNC( opr ), ": use `InstallTrueMethod' for <opr>" );
       fi;
-      if CHECK_INSTALL_METHOD and check  then
-          if opr in WRAPPER_OPERATIONS  then
+      if CHECK_INSTALL_METHOD and check then
+          if opr in WRAPPER_OPERATIONS then
               INFO_DEBUG( 1, "a method is installed for the wrapper operation ", NAME_FUNC( opr ), "\n", "#I  probably it should be installed for (one of) its\n", "#I  underlying operation(s)" );
           fi;
           req := false;
-          for i  in [ 1, 3 .. LEN_LIST( OPERATIONS ) - 1 ]  do
-              if IS_IDENTICAL_OBJ( OPERATIONS[i], opr )  then
+          for i in [ 1, 3 .. LEN_LIST( OPERATIONS ) - 1 ] do
+              if IS_IDENTICAL_OBJ( OPERATIONS[i], opr ) then
                   req := OPERATIONS[i + 1];
                   break;
               fi;
           od;
-          if req = false  then
+          if req = false then
               Error( "unknown operation ", NAME_FUNC( opr ) );
           fi;
           imp := [  ];
-          for i  in flags  do
+          for i in flags do
               ADD_LIST( imp, WITH_HIDDEN_IMPS_FLAGS( i ) );
           od;
           j := 0;
           match := false;
           notmatch := 0;
-          while j < LEN_LIST( req ) and not match  do
+          while j < LEN_LIST( req ) and not match do
               j := j + 1;
               reqs := req[j];
-              if LEN_LIST( reqs ) = LEN_LIST( imp )  then
+              if LEN_LIST( reqs ) = LEN_LIST( imp ) then
                   match := true;
-                  for i  in [ 1 .. LEN_LIST( reqs ) ]  do
-                      if not IS_SUBSET_FLAGS( imp[i], reqs[i] )  then
+                  for i in [ 1 .. LEN_LIST( reqs ) ] do
+                      if not IS_SUBSET_FLAGS( imp[i], reqs[i] ) then
                           match := false;
                           notmatch := i;
                           break;
                       fi;
                   od;
-                  if match  then
+                  if match then
                       break;
                   fi;
               fi;
           od;
-          if not match  then
-              if notmatch = 0  then
+          if not match then
+              if notmatch = 0 then
                   Error( "the number of arguments does not match a declaration of ", NAME_FUNC( opr ) );
               else
                   Error( "required filters ", NamesFilter( imp[notmatch] ), "\nfor ", Ordinal( notmatch ), " argument do not match a declaration of ", NAME_FUNC( opr ) );
               fi;
           else
               oreqs := reqs;
-              for k  in [ j + 1 .. LEN_LIST( req ) ]  do
+              for k in [ j + 1 .. LEN_LIST( req ) ] do
                   reqs := req[k];
-                  if LEN_LIST( reqs ) = LEN_LIST( imp )  then
+                  if LEN_LIST( reqs ) = LEN_LIST( imp ) then
                       match := true;
-                      for i  in [ 1 .. LEN_LIST( reqs ) ]  do
-                          if not IS_SUBSET_FLAGS( imp[i], reqs[i] )  then
+                      for i in [ 1 .. LEN_LIST( reqs ) ] do
+                          if not IS_SUBSET_FLAGS( imp[i], reqs[i] ) then
                               match := false;
                               break;
                           fi;
                       od;
-                      if match and reqs <> oreqs  then
+                      if match and reqs <> oreqs then
                           INFO_DEBUG( 1, "method installed for ", NAME_FUNC( opr ), " matches more than one declaration" );
                       fi;
                   fi;
@@ -4055,35 +4055,35 @@ static Obj  HdlrFunc1 (
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
-      local  flags, rank, cats, props, i;
-      if not IS_IDENTICAL_OBJ( filter, IS_OBJECT )  then
+      local flags, rank, cats, props, i;
+      if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then
           flags := FLAGS_FILTER( filter );
           rank := 0;
           cats := IS_OBJECT;
           props := [  ];
-          for i  in [ 1 .. LEN_FLAGS( flags ) ]  do
-              if ELM_FLAGS( flags, i )  then
-                  if i in CATS_AND_REPS  then
+          for i in [ 1 .. LEN_FLAGS( flags ) ] do
+              if ELM_FLAGS( flags, i ) then
+                  if i in CATS_AND_REPS then
                       cats := cats and FILTERS[i];
                       rank := rank - RankFilter( FILTERS[i] );
-                  elif i in NUMBERS_PROPERTY_GETTERS  then
+                  elif i in NUMBERS_PROPERTY_GETTERS then
                       ADD_LIST( props, FILTERS[i] );
                   fi;
               fi;
           od;
-          if 0 < LEN_LIST( props )  then
+          if 0 < LEN_LIST( props ) then
               InstallOtherMethod( getter, "default method requiring categories and checking properties", true, [ cats ], rank, function ( obj )
-                    local  found, prop;
+                    local found, prop;
                     found := false;
-                    for prop  in props  do
-                        if not Tester( prop )( obj )  then
+                    for prop in props do
+                        if not Tester( prop )( obj ) then
                             found := true;
-                            if not (prop( obj ) and Tester( prop )( obj ))  then
+                            if not (prop( obj ) and Tester( prop )( obj )) then
                                 TryNextMethod();
                             fi;
                         fi;
                     od;
-                    if found  then
+                    if found then
                         return getter( obj );
                     else
                         TryNextMethod();
@@ -4121,15 +4121,15 @@ static Obj  HdlrFunc1 (
  CALL_1ARGS( t_1, t_2 );
  
  /* BIND_GLOBAL( "PositionSortedOddPositions", function ( list, elm )
-      local  i, j, k;
+      local i, j, k;
       k := LEN_LIST( list ) + 1;
-      if k mod 2 = 0  then
+      if k mod 2 = 0 then
           k := k + 1;
       fi;
       i := -1;
-      while i + 2 < k  do
+      while i + 2 < k do
           j := 2 * QUO_INT( (i + k + 2), 4 ) - 1;
-          if list[j] < elm  then
+          if list[j] < elm then
               i := j;
           else
               k := j;
@@ -4154,10 +4154,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_IsPrimeInt, t_1 );
  
  /* BIND_GLOBAL( "KeyDependentOperation", function ( name, domreq, keyreq, keytest )
-      local  str, oper, attr;
-      if keytest = "prime"  then
+      local str, oper, attr;
+      if keytest = "prime" then
           keytest := function ( key )
-                if not IsPrimeInt( key )  then
+                if not IsPrimeInt( key ) then
                     Error( name, ": <p> must be a prime" );
                 fi;
                 return;
@@ -4178,14 +4178,14 @@ static Obj  HdlrFunc1 (
       DeclareOperation( name, [ domreq, keyreq ] );
       ADD_LIST( WRAPPER_OPERATIONS, VALUE_GLOBAL( name ) );
       InstallOtherMethod( VALUE_GLOBAL( name ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
-            local  known, i, erg;
+            local known, i, erg;
             keytest( key );
             known := attr( D );
             i := PositionSortedOddPositions( known, key );
-            if LEN_LIST( known ) < i or known[i] <> key  then
+            if LEN_LIST( known ) < i or known[i] <> key then
                 erg := oper( D, key );
                 i := PositionSortedOddPositions( known, key );
-                if LEN_LIST( known ) < i or known[i] <> key  then
+                if LEN_LIST( known ) < i or known[i] <> key then
                     known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
                     known[i] := IMMUTABLE_COPY_OBJ( key );
                     known[i + 1] := IMMUTABLE_COPY_OBJ( erg );
@@ -4197,7 +4197,7 @@ static Obj  HdlrFunc1 (
       APPEND_LIST_INTR( str, name );
       DeclareOperation( str, [ domreq, keyreq ] );
       InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
-            local  known, i;
+            local known, i;
             keytest( key );
             known := attr( D );
             i := PositionSortedOddPositions( known, key );
@@ -4207,11 +4207,11 @@ static Obj  HdlrFunc1 (
       APPEND_LIST_INTR( str, name );
       DeclareOperation( str, [ domreq, keyreq, IS_OBJECT ] );
       InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq, IS_OBJECT ], 0, function ( D, key, obj )
-            local  known, i;
+            local known, i;
             keytest( key );
             known := attr( D );
             i := PositionSortedOddPositions( known, key );
-            if LEN_LIST( known ) < i or known[i] <> key  then
+            if LEN_LIST( known ) < i or known[i] <> key then
                 known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]};
                 known[i] := IMMUTABLE_COPY_OBJ( key );
                 known[i + 1] := IMMUTABLE_COPY_OBJ( obj );
@@ -4237,15 +4237,15 @@ static Obj  HdlrFunc1 (
  AssGVar( G_CallFuncList, t_1 );
  
  /* BIND_GLOBAL( "RedispatchOnCondition", function ( arg... )
-      local  oper, info, fampred, reqs, cond, val, re, i;
-      if LEN_LIST( arg ) = 5  then
+      local oper, info, fampred, reqs, cond, val, re, i;
+      if LEN_LIST( arg ) = 5 then
           oper := arg[1];
           info := " fallback method to test conditions";
           fampred := arg[2];
           reqs := arg[3];
           cond := arg[4];
           val := arg[5];
-      elif LEN_LIST( arg ) = 6  then
+      elif LEN_LIST( arg ) = 6 then
           oper := arg[1];
           info := arg[2];
           fampred := arg[3];
@@ -4255,15 +4255,15 @@ static Obj  HdlrFunc1 (
       else
           Error( "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" );
       fi;
-      for i  in reqs  do
+      for i in reqs do
           val := val - SIZE_FLAGS( WITH_HIDDEN_IMPS_FLAGS( FLAGS_FILTER( i ) ) );
       od;
       InstallOtherMethod( oper, info, fampred, reqs, val, function ( arg... )
             re := false;
-            for i  in [ 1 .. LEN_LIST( reqs ) ]  do
+            for i in [ 1 .. LEN_LIST( reqs ) ] do
                 re := re or IsBound( cond[i] ) and not Tester( cond[i] )( arg[i] ) and cond[i]( arg[i] ) and Tester( cond[i] )( arg[i] );
             od;
-            if re  then
+            if re then
                 return CallFuncList( oper, arg );
             else
                 TryNextMethod();

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -1075,7 +1075,7 @@ static Obj  HdlrFunc11 (
            t_1 = (Obj)(((UInt)t_1)+4) ) {
       l_i = t_1;
       
-      /* if IsBound( cached![i]) then */
+      /* if IsBound( cached![i] ) then */
       CHECK_INT_SMALL_POS( l_i )
       if ( TNUM_OBJ(l_cached) == T_POSOBJ ) {
        t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_cached)/sizeof(Obj)-1
@@ -1152,7 +1152,7 @@ static Obj  HdlrFunc11 (
            t_1 = (Obj)(((UInt)t_1)+4) ) {
       l_i = t_1;
       
-      /* if IsBound( parent![i]) <> IsBound( cached![i]) then */
+      /* if IsBound( parent![i] ) <> IsBound( cached![i] ) then */
       CHECK_INT_SMALL_POS( l_i )
       if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
        t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
@@ -1189,7 +1189,7 @@ static Obj  HdlrFunc11 (
       }
       /* fi */
       
-      /* if IsBound( parent![i]) and IsBound( cached![i]) and not IS_IDENTICAL_OBJ( parent![i], cached![i] ) then */
+      /* if IsBound( parent![i] ) and IsBound( cached![i] ) and not IS_IDENTICAL_OBJ( parent![i], cached![i] ) then */
       if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
        t_7 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
           && ELM_PLIST(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False);
@@ -1360,7 +1360,7 @@ static Obj  HdlrFunc11 (
         t_1 = (Obj)(((UInt)t_1)+4) ) {
    l_i = t_1;
    
-   /* if IsBound( parent![i]) and not IsBound( type[i] ) then */
+   /* if IsBound( parent![i] ) and not IsBound( type[i] ) then */
    CHECK_INT_SMALL_POS( l_i )
    if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
     t_6 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
@@ -3837,7 +3837,7 @@ static Obj  HdlrFunc1 (
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
-      if mutflag  then
+      if mutflag then
           InstallOtherMethod( setter, "system mutable setter", true, [ IsAttributeStoringRep, IS_OBJECT ], 0, function ( obj, val )
                 obj!.(name) := val;
                 SetFilterObj( obj, tester );
@@ -3864,11 +3864,11 @@ static Obj  HdlrFunc1 (
  AssGVar( G_Subtype, t_1 );
  
  /* BIND_GLOBAL( "NEW_FAMILY", function ( typeOfFamilies, name, req_filter, imp_filter )
-      local  type, pair, family;
+      local type, pair, family;
       imp_filter := WITH_IMPS_FLAGS( AND_FLAGS( imp_filter, req_filter ) );
       type := Subtype( typeOfFamilies, IsAttributeStoringRep );
-      for pair  in CATEGORIES_FAMILY  do
-          if IS_SUBSET_FLAGS( imp_filter, pair[1] )  then
+      for pair in CATEGORIES_FAMILY do
+          if IS_SUBSET_FLAGS( imp_filter, pair[1] ) then
               type := Subtype( type, pair[2] );
           fi;
       od;
@@ -3958,13 +3958,13 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewFamily", function ( arg... )
-      if LEN_LIST( arg ) = 1  then
+      if LEN_LIST( arg ) = 1 then
           return NewFamily2( TypeOfFamilies, arg[1] );
-      elif LEN_LIST( arg ) = 2  then
+      elif LEN_LIST( arg ) = 2 then
           return NewFamily3( TypeOfFamilies, arg[1], arg[2] );
-      elif LEN_LIST( arg ) = 3  then
+      elif LEN_LIST( arg ) = 3 then
           return NewFamily4( TypeOfFamilies, arg[1], arg[2], arg[3] );
-      elif LEN_LIST( arg ) = 4  then
+      elif LEN_LIST( arg ) = 4 then
           return NewFamily5( TypeOfFamilies, arg[1], arg[2], arg[3], arg[4] );
       else
           Error( "usage: NewFamily( <name>, [ <req> [, <imp> ]] )" );
@@ -3990,40 +3990,40 @@ static Obj  HdlrFunc1 (
  AssGVar( G_NEW__TYPE__CACHE__HIT, INTOBJ_INT(0) );
  
  /* BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data, parent )
-      local  hash, cache, cached, type, ncache, ncl, t, i, match;
+      local hash, cache, cached, type, ncache, ncl, t, i, match;
       cache := family!.TYPES;
       hash := HASH_FLAGS( flags ) mod family!.HASH_SIZE + 1;
-      if IsBound( cache[hash] )  then
+      if IsBound( cache[hash] ) then
           cached := cache[hash];
-          if IS_EQUAL_FLAGS( flags, cached![2] )  then
+          if IS_EQUAL_FLAGS( flags, cached![2] ) then
               flags := cached![2];
-              if IS_IDENTICAL_OBJ( data, cached![POS_DATA_TYPE] ) and IS_IDENTICAL_OBJ( typeOfTypes, TYPE_OBJ( cached ) )  then
-                  if IS_IDENTICAL_OBJ( parent, fail )  then
+              if IS_IDENTICAL_OBJ( data, cached![POS_DATA_TYPE] ) and IS_IDENTICAL_OBJ( typeOfTypes, TYPE_OBJ( cached ) ) then
+                  if IS_IDENTICAL_OBJ( parent, fail ) then
                       match := true;
-                      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( cached ) ]  do
-                          if IsBound( cached![i])  then
+                      for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( cached ) ] do
+                          if IsBound( cached![i] ) then
                               match := false;
                               break;
                           fi;
                       od;
-                      if match  then
+                      if match then
                           NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1;
                           return cached;
                       fi;
                   fi;
-                  if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached )  then
+                  if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached ) then
                       match := true;
-                      for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ]  do
-                          if IsBound( parent![i]) <> IsBound( cached![i])  then
+                      for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ] do
+                          if IsBound( parent![i] ) <> IsBound( cached![i] ) then
                               match := false;
                               break;
                           fi;
-                          if IsBound( parent![i]) and IsBound( cached![i]) and not IS_IDENTICAL_OBJ( parent![i], cached![i] )  then
+                          if IsBound( parent![i] ) and IsBound( cached![i] ) and not IS_IDENTICAL_OBJ( parent![i], cached![i] ) then
                               match := false;
                               break;
                           fi;
                       od;
-                      if match  then
+                      if match then
                           NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1;
                           return cached;
                       fi;
@@ -4033,7 +4033,7 @@ static Obj  HdlrFunc1 (
           NEW_TYPE_CACHE_MISS := NEW_TYPE_CACHE_MISS + 1;
       fi;
       NEW_TYPE_NEXT_ID := NEW_TYPE_NEXT_ID + 1;
-      if NEW_TYPE_NEXT_ID >= NEW_TYPE_ID_LIMIT  then
+      if NEW_TYPE_NEXT_ID >= NEW_TYPE_ID_LIMIT then
           GASMAN( "collect" );
           FLUSH_ALL_METHOD_CACHES(  );
           NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS(  );
@@ -4041,18 +4041,18 @@ static Obj  HdlrFunc1 (
       type := [ family, flags ];
       type[POS_DATA_TYPE] := data;
       type[POS_NUMB_TYPE] := NEW_TYPE_NEXT_ID;
-      if not IS_IDENTICAL_OBJ( parent, fail )  then
-          for i  in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ]  do
-              if IsBound( parent![i]) and not IsBound( type[i] )  then
+      if not IS_IDENTICAL_OBJ( parent, fail ) then
+          for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( parent ) ] do
+              if IsBound( parent![i] ) and not IsBound( type[i] ) then
                   type[i] := parent![i];
               fi;
           od;
       fi;
       SET_TYPE_POSOBJ( type, typeOfTypes );
-      if 3 * family!.nTYPES > family!.HASH_SIZE  then
+      if 3 * family!.nTYPES > family!.HASH_SIZE then
           ncache := [  ];
           ncl := 3 * family!.HASH_SIZE + 1;
-          for t  in cache  do
+          for t in cache do
               ncache[HASH_FLAGS( t![2] ) mod ncl + 1] := t;
           od;
           family!.HASH_SIZE := ncl;
@@ -4107,13 +4107,13 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "NewType", function ( arg... )
-      local  type;
-      if not IsFamily( arg[1] )  then
+      local type;
+      if not IsFamily( arg[1] ) then
           Error( "<family> must be a family" );
       fi;
-      if LEN_LIST( arg ) = 2  then
+      if LEN_LIST( arg ) = 2 then
           type := NewType3( TypeOfTypes, arg[1], arg[2] );
-      elif LEN_LIST( arg ) = 3  then
+      elif LEN_LIST( arg ) = 3 then
           type := NewType4( TypeOfTypes, arg[1], arg[2], arg[3] );
       else
           Error( "usage: NewType( <family>, <filter> [, <data> ] )" );
@@ -4166,10 +4166,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_Subtype, 0 );
  
  /* BIND_GLOBAL( "Subtype", function ( arg... )
-      if not IsType( arg[1] )  then
+      if not IsType( arg[1] ) then
           Error( "<type> must be a type" );
       fi;
-      if LEN_LIST( arg ) = 2  then
+      if LEN_LIST( arg ) = 2 then
           return Subtype2( arg[1], arg[2] );
       else
           return Subtype3( arg[1], arg[2], arg[3] );
@@ -4219,10 +4219,10 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SupType", function ( arg... )
-      if not IsType( arg[1] )  then
+      if not IsType( arg[1] ) then
           Error( "<type> must be a type" );
       fi;
-      if LEN_LIST( arg ) = 2  then
+      if LEN_LIST( arg ) = 2 then
           return SupType2( arg[1], arg[2] );
       else
           return SupType3( arg[1], arg[2], arg[3] );
@@ -4347,15 +4347,15 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetTypeObj", function ( type, obj )
-      if not IsType( type )  then
+      if not IsType( type ) then
           Error( "<type> must be a type" );
       fi;
-      if IS_LIST( obj )  then
+      if IS_LIST( obj ) then
           SET_TYPE_POSOBJ( obj, type );
-      elif IS_REC( obj )  then
+      elif IS_REC( obj ) then
           SET_TYPE_COMOBJ( obj, type );
       fi;
-      if not IsNoImmediateMethodsObject( obj )  then
+      if not IsNoImmediateMethodsObject( obj ) then
           RunImmediateMethods( obj, type![2] );
       fi;
       return obj;
@@ -4410,17 +4410,17 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ChangeTypeObj", function ( type, obj )
-      if not IsType( type )  then
+      if not IsType( type ) then
           Error( "<type> must be a type" );
       fi;
-      if IS_POSOBJ( obj )  then
+      if IS_POSOBJ( obj ) then
           SET_TYPE_POSOBJ( obj, type );
-      elif IS_COMOBJ( obj )  then
+      elif IS_COMOBJ( obj ) then
           SET_TYPE_COMOBJ( obj, type );
-      elif IS_DATOBJ( obj )  then
+      elif IS_DATOBJ( obj ) then
           SET_TYPE_DATOBJ( obj, type );
       fi;
-      if not IsNoImmediateMethodsObject( obj )  then
+      if not IsNoImmediateMethodsObject( obj ) then
           RunImmediateMethods( obj, type![2] );
       fi;
       return obj;
@@ -4448,35 +4448,35 @@ static Obj  HdlrFunc1 (
  AssGVar( G_SetFilterObj, 0 );
  
  /* BIND_GLOBAL( "SetFilterObj", function ( obj, filter )
-      local  type, newtype;
-      if IS_POSOBJ( obj )  then
+      local type, newtype;
+      if IS_POSOBJ( obj ) then
           type := TYPE_OBJ( obj );
           newtype := Subtype2( type, filter );
           SET_TYPE_POSOBJ( obj, newtype );
-          if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj ))  then
+          if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then
               RunImmediateMethods( obj, SUB_FLAGS( newtype![2], type![2] ) );
           fi;
-      elif IS_COMOBJ( obj )  then
+      elif IS_COMOBJ( obj ) then
           type := TYPE_OBJ( obj );
           newtype := Subtype2( type, filter );
           SET_TYPE_COMOBJ( obj, newtype );
-          if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj ))  then
+          if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then
               RunImmediateMethods( obj, SUB_FLAGS( newtype![2], type![2] ) );
           fi;
-      elif IS_DATOBJ( obj )  then
+      elif IS_DATOBJ( obj ) then
           type := TYPE_OBJ( obj );
           newtype := Subtype2( type, filter );
           SET_TYPE_DATOBJ( obj, newtype );
-          if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj ))  then
+          if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then
               RunImmediateMethods( obj, SUB_FLAGS( newtype![2], type![2] ) );
           fi;
-      elif IS_PLIST_REP( obj )  then
+      elif IS_PLIST_REP( obj ) then
           SET_FILTER_LIST( obj, filter );
-      elif IS_STRING_REP( obj )  then
+      elif IS_STRING_REP( obj ) then
           SET_FILTER_LIST( obj, filter );
-      elif IS_BLIST( obj )  then
+      elif IS_BLIST( obj ) then
           SET_FILTER_LIST( obj, filter );
-      elif IS_RANGE( obj )  then
+      elif IS_RANGE( obj ) then
           SET_FILTER_LIST( obj, filter );
       else
           Error( "cannot set filter for internal object" );
@@ -4503,22 +4503,22 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ResetFilterObj", function ( obj, filter )
-      if IS_AND_FILTER( filter )  then
+      if IS_AND_FILTER( filter ) then
           Error( "You can't reset an \"and-filter\". Reset components individually." );
       fi;
-      if IS_POSOBJ( obj )  then
+      if IS_POSOBJ( obj ) then
           SET_TYPE_POSOBJ( obj, SupType2( TYPE_OBJ( obj ), filter ) );
-      elif IS_COMOBJ( obj )  then
+      elif IS_COMOBJ( obj ) then
           SET_TYPE_COMOBJ( obj, SupType2( TYPE_OBJ( obj ), filter ) );
-      elif IS_DATOBJ( obj )  then
+      elif IS_DATOBJ( obj ) then
           SET_TYPE_DATOBJ( obj, SupType2( TYPE_OBJ( obj ), filter ) );
-      elif IS_PLIST_REP( obj )  then
+      elif IS_PLIST_REP( obj ) then
           RESET_FILTER_LIST( obj, filter );
-      elif IS_STRING_REP( obj )  then
+      elif IS_STRING_REP( obj ) then
           RESET_FILTER_LIST( obj, filter );
-      elif IS_BLIST( obj )  then
+      elif IS_BLIST( obj ) then
           RESET_FILTER_LIST( obj, filter );
-      elif IS_RANGE( obj )  then
+      elif IS_RANGE( obj ) then
           RESET_FILTER_LIST( obj, filter );
       else
           Error( "cannot reset filter for internal object" );
@@ -4545,7 +4545,7 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetFeatureObj", function ( obj, filter, val )
-      if val  then
+      if val then
           SetFilterObj( obj, filter );
       else
           ResetFilterObj( obj, filter );
@@ -4565,23 +4565,23 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetMultipleAttributes", function ( arg... )
-      local  obj, type, flags, attr, val, i, extra, nfilt, nflags;
+      local obj, type, flags, attr, val, i, extra, nfilt, nflags;
       obj := arg[1];
-      if IsAttributeStoringRep( obj )  then
+      if IsAttributeStoringRep( obj ) then
           extra := [  ];
           type := TypeObj( obj );
           flags := FlagsType( type );
           nfilt := IS_OBJECT;
-          for i  in [ 2, 4 .. LEN_LIST( arg ) - 1 ]  do
+          for i in [ 2, 4 .. LEN_LIST( arg ) - 1 ] do
               attr := arg[i];
               val := arg[i + 1];
-              if 0 <> FLAG1_FILTER( attr )  then
-                  if val  then
+              if 0 <> FLAG1_FILTER( attr ) then
+                  if val then
                       nfilt := nfilt and attr;
                   else
                       nfilt := nfilt and Tester( attr );
                   fi;
-              elif LEN_LIST( METHODS_OPERATION( Setter( attr ), 2 ) ) <> 12  then
+              elif LEN_LIST( METHODS_OPERATION( Setter( attr ), 2 ) ) <> 12 then
                   ADD_LIST( extra, attr );
                   ADD_LIST( extra, val );
               else
@@ -4590,16 +4590,16 @@ static Obj  HdlrFunc1 (
               fi;
           od;
           nflags := FLAGS_FILTER( nfilt );
-          if not IS_SUBSET_FLAGS( flags, nflags )  then
+          if not IS_SUBSET_FLAGS( flags, nflags ) then
               flags := WITH_IMPS_FLAGS( AND_FLAGS( flags, nflags ) );
               ChangeTypeObj( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ) ), obj );
           fi;
-          for i  in [ 2, 4 .. LEN_LIST( extra ) ]  do
+          for i in [ 2, 4 .. LEN_LIST( extra ) ] do
               Setter( extra[i - 1] )( obj, extra[i] );
           od;
       else
           extra := arg;
-          for i  in [ 2, 4 .. LEN_LIST( extra ) ]  do
+          for i in [ 2, 4 .. LEN_LIST( extra ) ] do
               Setter( extra[i] )( obj, extra[i + 1] );
           od;
       fi;
@@ -4640,27 +4640,27 @@ static Obj  HdlrFunc1 (
  CALL_1ARGS( t_1, t_2 );
  
  /* BIND_GLOBAL( "ObjectifyWithAttributes", function ( arg... )
-      local  obj, type, flags, attr, val, i, extra, nflags;
+      local obj, type, flags, attr, val, i, extra, nflags;
       obj := arg[1];
       type := arg[2];
       flags := FlagsType( type );
       extra := [  ];
-      if not IS_SUBSET_FLAGS( flags, IsAttributeStoringRepFlags )  then
+      if not IS_SUBSET_FLAGS( flags, IsAttributeStoringRepFlags ) then
           extra := arg{[ 3 .. LEN_LIST( arg ) ]};
           INFO_OWA( "#W ObjectifyWithAttributes called ", "for non-attribute storing rep\n" );
           Objectify( type, obj );
       else
           nflags := EMPTY_FLAGS;
-          for i  in [ 3, 5 .. LEN_LIST( arg ) - 1 ]  do
+          for i in [ 3, 5 .. LEN_LIST( arg ) - 1 ] do
               attr := arg[i];
               val := arg[i + 1];
-              if 0 <> FLAG1_FILTER( attr )  then
-                  if val  then
+              if 0 <> FLAG1_FILTER( attr ) then
+                  if val then
                       nflags := AND_FLAGS( nflags, FLAGS_FILTER( attr ) );
                   else
                       nflags := AND_FLAGS( nflags, FLAGS_FILTER( Tester( attr ) ) );
                   fi;
-              elif LEN_LIST( METHODS_OPERATION( Setter( attr ), 2 ) ) <> LENGTH_SETTER_METHODS_2  then
+              elif LEN_LIST( METHODS_OPERATION( Setter( attr ), 2 ) ) <> LENGTH_SETTER_METHODS_2 then
                   ADD_LIST( extra, attr );
                   ADD_LIST( extra, val );
               else
@@ -4668,15 +4668,15 @@ static Obj  HdlrFunc1 (
                   nflags := AND_FLAGS( nflags, FLAGS_FILTER( Tester( attr ) ) );
               fi;
           od;
-          if not IS_SUBSET_FLAGS( flags, nflags )  then
+          if not IS_SUBSET_FLAGS( flags, nflags ) then
               flags := WITH_IMPS_FLAGS( AND_FLAGS( flags, nflags ) );
               Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ), fail ), obj );
           else
               Objectify( type, obj );
           fi;
       fi;
-      for i  in [ 1, 3 .. LEN_LIST( extra ) - 1 ]  do
-          if Tester( extra[i] )( obj )  then
+      for i in [ 1, 3 .. LEN_LIST( extra ) - 1 ] do
+          if Tester( extra[i] )( obj ) then
               INFO_OWA( "#W  Supplied type has tester of ", NAME_FUNC( extra[i] ), "with non-standard setter\n" );
               ResetFilterObj( obj, Tester( extra[i] ) );
           fi;

--- a/src/calls.c
+++ b/src/calls.c
@@ -1351,7 +1351,7 @@ void PrintFunction (
         /* print the locals                                                */
         nloc = NLOC_FUNC(func);
         if ( nloc >= 1 ) {
-            Pr("%>local  ",0L,0L);
+            Pr("%>local ",0L,0L);
             for ( i = 1; i <= nloc; i++ ) {
                 if ( NAMS_FUNC(func) != 0 )
                     Pr( "%I", (Int)NAMI_FUNC( func, (Int)(narg+i) ), 0L );

--- a/src/stats.c
+++ b/src/stats.c
@@ -1976,7 +1976,7 @@ void            PrintIf (
     /* print the 'if' branch                                               */
     Pr( "if%4> ", 0L, 0L );
     PrintExpr( ADDR_STAT(stat)[0] );
-    Pr( "%2<  then%2>\n", 0L, 0L );
+    Pr( "%2< then%2>\n", 0L, 0L );
     PrintStat( ADDR_STAT(stat)[1] );
     Pr( "%4<\n", 0L, 0L );
 
@@ -1988,7 +1988,7 @@ void            PrintIf (
         else {
             Pr( "elif%4> ", 0L, 0L );
             PrintExpr( ADDR_STAT(stat)[2*(i-1)] );
-            Pr( "%2<  then%2>\n", 0L, 0L );
+            Pr( "%2< then%2>\n", 0L, 0L );
         }
         PrintStat( ADDR_STAT(stat)[2*(i-1)+1] );
         Pr( "%4<\n", 0L, 0L );
@@ -2015,9 +2015,9 @@ void            PrintFor (
 
     Pr( "for%4> ", 0L, 0L );
     PrintExpr( ADDR_STAT(stat)[0] );
-    Pr( "%2<  in%2> ", 0L, 0L );
+    Pr( "%2< in%2> ", 0L, 0L );
     PrintExpr( ADDR_STAT(stat)[1] );
-    Pr( "%2<  do%2>\n", 0L, 0L );
+    Pr( "%2< do%2>\n", 0L, 0L );
     for ( i = 2; i <= SIZE_STAT(stat)/sizeof(Stat)-1; i++ ) {
         PrintStat( ADDR_STAT(stat)[i] );
         if ( i < SIZE_STAT(stat)/sizeof(Stat)-1 )  Pr( "\n", 0L, 0L );
@@ -2042,7 +2042,7 @@ void            PrintWhile (
 
     Pr( "while%4> ", 0L, 0L );
     PrintExpr( ADDR_STAT(stat)[0] );
-    Pr( "%2<  do%2>\n", 0L, 0L );
+    Pr( "%2< do%2>\n", 0L, 0L );
     for ( i = 1; i <= SIZE_STAT(stat)/sizeof(Stat)-1; i++ ) {
         PrintStat( ADDR_STAT(stat)[i] );
         if ( i < SIZE_STAT(stat)/sizeof(Stat)-1 )  Pr( "\n", 0L, 0L );
@@ -2079,7 +2079,7 @@ void            PrintAtomic (
       }
       PrintExpr(ADDR_STAT(stat)[2*i]);
     }
-    Pr( "%2<  do%2>\n", 0L, 0L );
+    Pr( "%2< do%2>\n", 0L, 0L );
     PrintStat( ADDR_STAT(stat)[0]);
     Pr( "%4<\nod;", 0L, 0L );
 }

--- a/src/vars.c
+++ b/src/vars.c
@@ -228,7 +228,7 @@ void            PrintIsbLVar (
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr( "%I", (Int)NAME_LVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
-    Pr( ")", 0L, 0L );
+    Pr( " )", 0L, 0L );
 }
 
 
@@ -425,7 +425,7 @@ void            PrintIsbHVar (
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr( "%I", (Int)NAME_HVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
-    Pr( ")", 0L, 0L );
+    Pr( " )", 0L, 0L );
 }
 
 
@@ -540,7 +540,7 @@ void            PrintIsbGVar (
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr( "%I", (Int)NameGVar( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
-    Pr( ")", 0L, 0L );
+    Pr( " )", 0L, 0L );
 }
 
 
@@ -1984,7 +1984,7 @@ void            PrintIsbPosObj (
     Pr("%<![",0L,0L);
     PrintExpr( ADDR_EXPR(expr)[1] );
     Pr("%<]",0L,0L);
-    Pr( ")", 0L, 0L );
+    Pr( " )", 0L, 0L );
 }
 
 

--- a/tst/testinstall/atomic_basic.tst
+++ b/tst/testinstall/atomic_basic.tst
@@ -28,7 +28,7 @@ gap> f(1);
 2
 gap> Print(f,"\n");
 function ( x )
-    atomic L  do
+    atomic L do
         return x + 1;
     od;
     return;
@@ -36,7 +36,7 @@ end
 gap> g := function(x) atomic readwrite L do return x+1; od; end;;
 gap> Print(g,"\n");
 function ( x )
-    atomic readwrite L  do
+    atomic readwrite L do
         return x + 1;
     od;
     return;
@@ -44,7 +44,7 @@ end
 gap> h := function(x) atomic readonly L do return x+1; od; end;;
 gap> Print(h,"\n");
 function ( x )
-    atomic readonly L  do
+    atomic readonly L do
         return x + 1;
     od;
     return;
@@ -52,7 +52,7 @@ end
 gap> h2 := function(x) atomic readonly L,M do return x+1; od; end;;
 gap> Print(h2,"\n");
 function ( x )
-    atomic readonly L, M  do
+    atomic readonly L, M do
         return x + 1;
     od;
     return;

--- a/tst/testinstall/bound.tst
+++ b/tst/testinstall/bound.tst
@@ -38,4 +38,14 @@ f := ({} -> IsBound(BADVARNAME[BADLISTNAME]) );;
                                           ^
 gap> f();
 Error, Variable: 'BADVARNAME' must have an assigned value
+
+# Printing IsBound statements
+gap> Display(function(l,n) return IsBound(l[n]);end);
+function ( l, n )
+    return IsBound( l[n] );
+end
+gap> Display(function(l,n) return IsBound(l.(n));end);
+function ( l, n )
+    return IsBound( l.(n) );
+end
 gap> STOP_TEST("bound.tst", 1);

--- a/tst/testinstall/localvars.tst
+++ b/tst/testinstall/localvars.tst
@@ -12,23 +12,23 @@ gap> f := function()
 gap> f();
 gap> Print(f,"\n");
 function (  )
-    local  a, b, c;
-    if IsBound( a)  then
+    local a, b, c;
+    if IsBound( a ) then
         Print( "1" );
     fi;
     a := 2;
-    if not IsBound( a)  then
+    if not IsBound( a ) then
         Print( "2" );
     fi;
-    if IsBound( b)  then
+    if IsBound( b ) then
         Print( "3" );
     fi;
     Unbind( a );
     Unbind( b );
-    if IsBound( a)  then
+    if IsBound( a ) then
         Print( "4" );
     fi;
-    if IsBound( b)  then
+    if IsBound( b ) then
         Print( "4" );
     fi;
     return;
@@ -52,24 +52,24 @@ gap> g := function()
 gap> func := g();;
 gap> Print(g, "\n");
 function (  )
-    local  a, b, f;
+    local a, b, f;
     f := function (  )
-          if IsBound( a)  then
+          if IsBound( a ) then
               Print( "1" );
           fi;
           a := 2;
-          if not IsBound( a)  then
+          if not IsBound( a ) then
               Print( "2" );
           fi;
-          if IsBound( b)  then
+          if IsBound( b ) then
               Print( "3" );
           fi;
           Unbind( a );
           Unbind( b );
-          if IsBound( a)  then
+          if IsBound( a ) then
               Print( "4" );
           fi;
-          if IsBound( b)  then
+          if IsBound( b ) then
               Print( "4" );
           fi;
           return;
@@ -78,22 +78,22 @@ function (  )
 end
 gap> Print(func, "\n");
 function (  )
-    if IsBound( a)  then
+    if IsBound( a ) then
         Print( "1" );
     fi;
     a := 2;
-    if not IsBound( a)  then
+    if not IsBound( a ) then
         Print( "2" );
     fi;
-    if IsBound( b)  then
+    if IsBound( b ) then
         Print( "3" );
     fi;
     Unbind( a );
     Unbind( b );
-    if IsBound( a)  then
+    if IsBound( a ) then
         Print( "4" );
     fi;
-    if IsBound( b)  then
+    if IsBound( b ) then
         Print( "4" );
     fi;
     return;


### PR DESCRIPTION
In particular, don't print 'if x  then', but rather 'if x then' (note the extra space in the former), and similar after "local", and before "do".

Resolves #473

This PR will fail lots of tests, because so many of them contain printed code, which now of course is "formatted wrong". It shouldn't be too hard to fix all that with some calls to `sed` or `perl`, but I don't have the time to do that now, and perhaps somebody wants to step up and do it?