### PR TITLE
Backporting some MatrixObj changes to master

### DIFF
--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1290,15 +1290,6 @@ InstallMethod( CompatibleVector, "for an 8bit matrix",
     return ShallowCopy(m[1]);
   end );
 
-InstallMethod( CompatibleMatrix, "for an 8bit vector",
-  [ Is8BitVectorRep ],
-  function( v )
-    local m;
-    m := [ShallowCopy(v)];
-    ConvertToMatrixRep(m,Q_VEC8BIT(v));
-    return m;
-  end );
-
 InstallMethod( WeightOfVector, "for an 8bit vector",
   [ Is8BitVectorRep ],
   function( v )

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1164,7 +1164,7 @@ InstallOtherMethod( KroneckerProduct, "for two 8bit matrices",
   end );
 
 InstallMethod( Fold, "for an 8bit vector, a positive int, and an 8bit matrix",
-  [ IsRowVectorObj and Is8BitVectorRep, IsPosInt, Is8BitMatrixRep ],
+  [ IsVectorObj and Is8BitVectorRep, IsPosInt, Is8BitMatrixRep ],
   function( v, rl, t )
     local rows,i,tt,m;
     m := [];

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1078,7 +1078,7 @@ InstallMethod( Matrix, "for a list of vecs, an integer, and an 8bit mat",
   [IsList, IsInt, Is8BitMatrixRep],
   function(l,rl,m)
     local q,i,li;
-    if not(IsList(l[1])) then
+    if not IsList(l[1]) then
         li := [];
         for i in [1..QuoInt(Length(l),rl)] do
             li[i] := l{[(i-1)*rl+1..i*rl]};
@@ -1310,7 +1310,7 @@ InstallMethod( NewCompanionMatrix,
     one := One(bd);
     l := CoefficientsOfUnivariatePolynomial(po);
     n := Length(l)-1;
-    if not(IsOne(l[n+1])) then
+    if not IsOne(l[n+1]) then
         Error("CompanionMatrix: polynomial is not monic");
         return fail;
     fi;

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1187,7 +1187,7 @@ InstallMethod( BaseField, "for a compressed 8bit matrix",
 InstallMethod( BaseField, "for a compressed 8bit vector",
   [Is8BitVectorRep], function(v) return GF(Q_VEC8BIT(v)); end );
 
-InstallMethod( NewRowVector, "for Is8BitVectorRep, GF(q), and a list",
+InstallMethod( NewVector, "for Is8BitVectorRep, GF(q), and a list",
   [ Is8BitVectorRep, IsField and IsFinite, IsList ],
   function( filter, f, l )
     return CopyToVectorRep(l,Size(f));

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2427,7 +2427,7 @@ InstallMethod( Matrix, "for a list of vecs, an integer, and a gf2 mat",
   [IsList, IsInt, IsGF2MatrixRep],
   function(l,rl,m)
     local i,li;
-    if not(IsList(l[1])) then
+    if not IsList(l[1]) then
         li := [];
         for i in [1..QuoInt(Length(l),rl)] do
             li[i] := l{[(i-1)*rl+1..i*rl]};
@@ -2691,7 +2691,7 @@ InstallMethod( NewCompanionMatrix,
     one := One(bd);
     l := CoefficientsOfUnivariatePolynomial(po);
     n := Length(l)-1;
-    if not(IsOne(l[n+1])) then
+    if not IsOne(l[n+1]) then
         Error("CompanionMatrix: polynomial is not monic");
         return fail;
     fi;

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2571,7 +2571,7 @@ InstallMethod( BaseField, "for a compressed gf2 matrix",
 InstallMethod( BaseField, "for a compressed gf2 vector",
   [IsGF2VectorRep], function(v) return GF(2); end );
 
-InstallMethod( NewRowVector, "for IsGF2VectorRep, GF(2), and a list",
+InstallMethod( NewVector, "for IsGF2VectorRep, GF(2), and a list",
   [ IsGF2VectorRep, IsField and IsFinite, IsList ],
   function( filter, f, l )
     return CopyToVectorRep(l,2);

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2671,15 +2671,6 @@ InstallMethod( CompatibleVector, "for a gf2 matrix",
     return ShallowCopy(m[1]);
   end );
 
-InstallMethod( CompatibleMatrix, "for a gf2 vector",
-  [ IsGF2VectorRep ],
-  function( v )
-    local m;
-    m := [ShallowCopy(v)];
-    ConvertToMatrixRep(m,2);
-    return m;
-  end );
-
 InstallMethod( WeightOfVector, "for a gf2 vector",
   [ IsGF2VectorRep ],
   function( v )

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2455,7 +2455,7 @@ BindGlobal( "PositionLastNonZeroFunc2",
   end );
 
 InstallMethod( PositionLastNonZero, "for a row vector obj",
-  [IsRowVectorObj], PositionLastNonZeroFunc );
+  [IsVectorObj], PositionLastNonZeroFunc );
 InstallMethod( PositionLastNonZero, "for a matrix obj",
   [IsMatrixObj], PositionLastNonZeroFunc );
 InstallMethod( PositionLastNonZero, "for a matrix obj, and an index",
@@ -2548,7 +2548,7 @@ InstallOtherMethod( KroneckerProduct, "for two gf2 matrices",
   KRONECKERPRODUCT_GF2MAT_GF2MAT );
 
 InstallMethod( Fold, "for a gf2 vector, a positive int, and a gf2 matrix",
-  [ IsRowVectorObj and IsGF2VectorRep, IsPosInt, IsGF2MatrixRep ],
+  [ IsVectorObj and IsGF2VectorRep, IsPosInt, IsGF2MatrixRep ],
   function( v, rl, t )
     local rows,i,tt,m;
     m := [];

--- a/hpcgap/tst/comprvec.tst
+++ b/hpcgap/tst/comprvec.tst
@@ -15,7 +15,7 @@ gap> IsIdenticalObj(z1,z2);
 false
 gap> z1=z2;
 true
-gap> NewRowVector(IsGF2VectorRep,GF(2),[Z(2),Z(2)]);
+gap> NewVector(IsGF2VectorRep,GF(2),[Z(2),Z(2)]);
 <a GF2 vector of length 2>
 gap> CopyToVectorRep(z,2);
 <a GF2 vector of length 3>

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -13,7 +13,7 @@
 
 
 InstallMethod( WeightOfVector, "generic method",
-  [IsRowVectorObj],
+  [IsVectorObj],
   function(v)
     local i,n;
     n := 0;
@@ -26,7 +26,7 @@ InstallMethod( WeightOfVector, "generic method",
   end );
 
 InstallMethod( DistanceOfVectors, "generic method",
-  [IsRowVectorObj, IsRowVectorObj],
+  [IsVectorObj, IsVectorObj],
   function( v, w)
     local i,n;
     if Length(v) <> Length(w) then
@@ -49,7 +49,7 @@ InstallMethod( Matrix, "generic convenience method with 2 args",
         Error("Matrix: two-argument version not allowed with empty first arg");
         return;
     fi;
-    if not (IsList(l[1]) or IsRowVectorObj(l[1])) then
+    if not (IsList(l[1]) or IsVectorObj(l[1])) then
         Error("Matrix: flat data not supported in two-argument version");
         return;
     fi;
@@ -57,7 +57,7 @@ InstallMethod( Matrix, "generic convenience method with 2 args",
   end );
 
 InstallMethod( Unfold, "for a matrix object, and a vector object",
-  [ IsMatrixObj, IsRowVectorObj ],
+  [ IsMatrixObj, IsVectorObj ],
   function( m, w )
     local v,i,l;
     if Length(m) = 0 then
@@ -73,7 +73,7 @@ InstallMethod( Unfold, "for a matrix object, and a vector object",
   end );
 
 InstallMethod( Fold, "for a vector, a positive int, and a matrix",
-  [ IsRowVectorObj, IsPosInt, IsMatrixObj ],
+  [ IsVectorObj, IsPosInt, IsMatrixObj ],
   function( v, rl, t )
     local rows,i,tt,m;
     m := Matrix([],rl,t);
@@ -215,13 +215,13 @@ InstallGlobalFunction( MakeMatrix,
   end );
 
 InstallMethod( ExtractSubVector, "generic method",
-  [ IsRowVectorObj, IsList ],
+  [ IsVectorObj, IsList ],
   function( v, l )
     return v{l};
   end );
 
 InstallOtherMethod( ScalarProduct, "generic method",
-  [ IsRowVectorObj, IsRowVectorObj ],
+  [ IsVectorObj, IsVectorObj ],
   function( v, w )
     local bd,i,s;
     bd := BaseDomain(v);

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -18,7 +18,7 @@ InstallMethod( WeightOfVector, "generic method",
     local i,n;
     n := 0;
     for i in [1..Length(v)] do
-        if not(IsZero(v[i])) then
+        if not IsZero(v[i]) then
             n := n + 1;
         fi;
     od;
@@ -49,7 +49,7 @@ InstallMethod( Matrix, "generic convenience method with 2 args",
         Error("Matrix: two-argument version not allowed with empty first arg");
         return;
     fi;
-    if not(IsList(l[1]) or IsRowVectorObj(l[1])) then
+    if not (IsList(l[1]) or IsRowVectorObj(l[1])) then
         Error("Matrix: flat data not supported in two-argument version");
         return;
     fi;
@@ -93,7 +93,7 @@ InstallMethod( CompanionMatrix, "for a polynomial and a matrix",
     one := One(bd);
     l := CoefficientsOfUnivariatePolynomial(po);
     n := Length(l)-1;
-    if not(IsOne(l[n+1])) then
+    if not IsOne(l[n+1]) then
         Error("CompanionMatrix: polynomial is not monic");
         return fail;
     fi;
@@ -112,7 +112,7 @@ InstallMethod( KroneckerProduct, "for two matrices",
   function( A, B )
     local rowsA, rowsB, colsA, colsB, newclass, AxB, i, j;
 
-    if not(IsIdenticalObj(BaseDomain(A),BaseDomain(B))) then
+    if not IsIdenticalObj(BaseDomain(A),BaseDomain(B)) then
         Error("KroneckerProduct: Matrices not over same base domain");
         return;
     fi;
@@ -135,7 +135,7 @@ InstallMethod( KroneckerProduct, "for two matrices",
       od;
     od;
 
-    if not(IsMutable(A)) and not(IsMutable(B)) then
+    if not IsMutable(A) and not IsMutable(B) then
         MakeImmutable(AxB);
     fi;
 

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -182,7 +182,7 @@ InstallGlobalFunction( MakeVector,
     else
         ty := IsPlistVectorRep;
     fi;
-    return NewRowVector(ty,bd,l);
+    return NewVector(ty,bd,l);
   end );
 
 InstallGlobalFunction( MakeMatrix,

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -42,47 +42,6 @@ InstallMethod( DistanceOfVectors, "generic method",
     return n;
   end );
 
-InstallMethod( AddMatrix, "for two row list matrices and a scalar",
-  [ IsMutable and IsRowListMatrix, IsRowListMatrix, IsMultiplicativeElement ],
-  function( A, B, s )
-    local i;
-    if Length(A) <> Length(B) then
-        Error("Matrices must have equal length");
-        return;
-    fi;
-    for i in [1..Length(A)] do
-        AddRowVector(A[i],B[i],s);
-    od;
-  end );
-
-InstallMethod( AddMatrix, "for two row list matrices",
-  [ IsMutable and IsRowListMatrix, IsRowListMatrix ],
-  function( A, B )
-    local i;
-    if Length(A) <> Length(B) then
-        Error("Matrices must have equal length");
-        return;
-    fi;
-    for i in [1..Length(A)] do
-        AddRowVector(A[i],B[i]);
-    od;
-  end );
-
-InstallMethod( MultMatrix, "for a row list matrix",
-  [ IsMutable and IsRowListMatrix, IsMultiplicativeElement ],
-  function( A, s )
-    local i;
-    for i in [1..Length(A)] do
-        MultRowVector(A[i],s);
-    od;
-  end );
-
-InstallMethod( ProductTransposedMatMat, "generic method",
-  [ IsMatrixObj, IsMatrixObj ],
-  function( A, B )
-    return TransposedMat(A) * B;
-  end );
-
 InstallMethod( Matrix, "generic convenience method with 2 args",
   [IsList,IsMatrixObj],
   function( l, m )

--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -57,10 +57,3 @@ DeclareCategory( "IsRowListMatrix", IsMatrixObj );
 # Different matrices in this category can share rows and the same row can
 # occur more than once in a matrix. Row access just gives a reference
 # to the row object.
-
-DeclareCategory( "IsFlatMatrix", IsMatrixObj );
-# The category of "flatly" stored matrices. They behave as if all their rows
-# were in one single chunk of memory, such that rows are not individual
-# GAP objects. Writing row access and slicing always copies.
-# Note that read-accessing the i-th row of a flat matrix twice can
-# yield two non-identical objects!

--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -21,14 +21,20 @@
 ############################################################################
 
 
-DeclareCategory( "IsRowVectorObj", IsVector and IsCopyable );
+DeclareCategory( "IsVectorObj", IsVector and IsCopyable );
 # All the arithmetical filters come from IsVector.
-# RowVectors are no longer necessarily lists, since they do not promise all
+# Vectors are no longer necessarily lists, since they do not promise all
 # list operations. Of course, in specific implementations the objects
 # may still be lists. But beware: Some matrix representations might
 # rely on the fact that vectors cannot change their length!
-# The family of an object in IsRowVectorObj is the same as the family of
+# The family of an object in IsVectorObj is the same as the family of
 # the base domain.
+
+DeclareSynonym( "IsRowVectorObj", IsVectorObj );
+# FIXME: Declare IsRowVectorObj for backwards compatibility, so that existing
+# code which already used it keeps working (most notably, the cvec package).
+# We should eventually remove this synonym.
+
 
 # There are one main category for matrices and two disjoint sub-categories:
 

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -389,13 +389,13 @@ DeclareOperation( "RankMatDestructive", [ IsMatrixObj ] );
 # In the following sense matrices behave like lists:
 ############################################################################
 
-DeclareOperation( "[]", [IsMatrixObj,IsPosInt] );
+DeclareOperation( "[]", [IsMatrixObj,IsPosInt] );  # <mat>, <pos>
 # This is guaranteed to return a vector object that has the property
-# that changing it changes the matrix!
-# A flat matrix has to create an intermediate object that refers to some
+# that changing it changes <pos>th row (?) of the matrix <mat>!
+# A matrix which is not a row-lists internally has to create an intermediate object that refers to some
 # row within it to allow the old GAP syntax M[i][j] for read and write
 # access to work. Note that this will never be particularly efficient
-# for flat matrices. Efficient code will have to use MatElm and
+# for matrices which are not row-lists. Efficient code will have to use MatElm and
 # SetMatElm instead.
 
 # These should probably only be defined for RowListMatrices???
@@ -473,7 +473,7 @@ DeclareOperation( "CopySubMatrix", [IsMatrixObj,IsMatrixObj,
                                     IsList,IsList,IsList,IsList] );
 
 ############################################################################
-# New element access for matrices (especially necessary for flat mats:
+# New element access for matrices
 ############################################################################
 
 DeclareOperation( "MatElm", [IsMatrixObj,IsPosInt,IsPosInt] );
@@ -729,38 +729,6 @@ DeclareOperation( "ListOp", [IsRowListMatrix, IsFunction] );
 # they do not have to lie in the filter IsList.
 ############################################################################
 
-
-############################################################################
-############################################################################
-# Operations for flat matrices:
-############################################################################
-############################################################################
-
-
-############################################################################
-# List operations with some modifications:
-############################################################################
-
-DeclareOperation( "[]:=", [IsFlatMatrix,IsPosInt,IsObject] );
-# Only guaranteed to work for the position in [1..Length(VECTOR)] and only
-# for elements in a suitable vector type.
-# Here this is always a copying operation!
-# Behaviour otherwise is undefined (from "unpacking" to Error all is possible)
-
-DeclareOperation( "{}", [IsFlatMatrix,IsList] );
-# Again this is defined to be a copying operation!
-
-# The following list operations are not supported for flat matrices:
-# Add, Remove, IsBound[], Unbind[], {}:=, Append
-
-# ShallowCopy is in fact a structural copy here:
-# DeclareOperation( "ShallowCopy", [IsFlatMatrix] );
-
-
-############################################################################
-# Rule:
-# Objects in IsFlatMatrix are not lists and do not behave like them.
-############################################################################
 
 
 ############################################################################

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -286,8 +286,6 @@ DeclareOperation( "Vector", [IsList,IsRowVectorObj]);
 
 DeclareOperation( "ConstructingFilter", [IsRowVectorObj] );
 
-DeclareOperation( "CompatibleMatrix", [IsRowVectorObj] );
-
 DeclareConstructor( "NewRowVector", [IsRowVectorObj,IsRing,IsList] );
 # A constructor. The first argument must be a filter indicating the
 # representation the vector will be in, the second is the base domain.

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -533,18 +533,6 @@ DeclareOperation( "SetMatElm", [IsMatrixObj,IsPosInt,IsPosInt,IsObject] );
 # Problem: How about inverses of integer matrices that exist as
 # elements of rationals matrix?
 
-DeclareOperation( "AddMatrix", [IsMutable and IsMatrixObj,IsMatrixObj] );
-DeclareOperation( "AddMatrix", 
-  [IsMutable and IsMatrixObj,IsMatrixObj,IsMultiplicativeElement] );
-DeclareOperation( "MultMatrix", 
-  [IsMutable and IsMatrixObj,IsMultiplicativeElement] );
-
-# Changes first argument in place, matrices have to be of same
-# dimension and over same base domain.
-
-DeclareOperation( "ProductTransposedMatMat", [IsMatrixObj, IsMatrixObj] );
-# Computes the product TransposedMat(A)*B, possibly without
-# first computing TransposedMat(A).
 
 DeclareOperation( "TraceMat", [IsMatrixObj] );
 # The sum of the diagonal entries. Error for a non-square matrix.

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -117,12 +117,12 @@
 
 
 # The following are guaranteed to be always set or cheaply calculable:
-DeclareAttribute( "BaseDomain", IsRowVectorObj );
+DeclareAttribute( "BaseDomain", IsVectorObj );
 # Typically, the base domain will be a ring, it need not be commutative
 # nor associative. For non-associative base domains powering of matrices
 # is defined by the behaviour of POW_OBJ_INT.
 
-DeclareAttribute( "Length", IsRowVectorObj );    # can be zero
+DeclareAttribute( "Length", IsVectorObj );    # can be zero
 # We have to declare this since a row vector is not necessarily
 # a list! Correspondingly we have to use InstallOtherMethod
 # for those row vector types that are lists.
@@ -152,29 +152,29 @@ DeclareAttribute( "Length", IsRowVectorObj );    # can be zero
 # In the following sense vectors behave like lists:
 ############################################################################
 
-DeclareOperation( "[]", [IsRowVectorObj,IsPosInt] );
+DeclareOperation( "[]", [IsVectorObj,IsPosInt] );
 # This is only defined for positions in [1..Length(VECTOR)]. 
 
-DeclareOperation( "[]:=", [IsRowVectorObj,IsPosInt,IsObject] );
+DeclareOperation( "[]:=", [IsVectorObj,IsPosInt,IsObject] );
 # This is only guaranteed to work for the position in [1..Length(VECTOR)] 
 # and only for elements in the BaseDomain(VECTOR)! 
 # Behaviour otherwise is undefined (from "unpacking" to Error all is possible)
 
-DeclareOperation( "{}", [IsRowVectorObj,IsList] );
+DeclareOperation( "{}", [IsVectorObj,IsList] );
 # Of course the positions must all lie in [1..Length(VECTOR)].
 # Returns a vector in the same representation!
 
-DeclareOperation( "PositionNonZero", [IsRowVectorObj] );
+DeclareOperation( "PositionNonZero", [IsVectorObj] );
 
-DeclareOperation( "PositionLastNonZero", [IsRowVectorObj] );
+DeclareOperation( "PositionLastNonZero", [IsVectorObj] );
 
-DeclareOperation( "ListOp", [IsRowVectorObj] );
-DeclareOperation( "ListOp", [IsRowVectorObj,IsFunction] );
+DeclareOperation( "ListOp", [IsVectorObj] );
+DeclareOperation( "ListOp", [IsVectorObj,IsFunction] );
 # This is an unpacking operation returning a mutable copy in form of a list.
 # It enables the "List" function to work.
 
 # The following unwraps a vector to a list:
-DeclareOperation( "Unpack", [IsRowVectorObj] );
+DeclareOperation( "Unpack", [IsVectorObj] );
 # It guarantees to copy, that is changing the returned object does
 # not change the original object.
 
@@ -195,7 +195,7 @@ DeclareOperation( "Unpack", [IsRowVectorObj] );
 # Thus we need:
 DeclareGlobalFunction( "ConcatenationOfVectors" );
 
-DeclareOperation( "ExtractSubVector", [IsRowVectorObj,IsList] );
+DeclareOperation( "ExtractSubVector", [IsVectorObj,IsList] );
 # Does the same as slicing v{l} but is here to be similar to
 # ExtractSubMatrix.
 
@@ -207,21 +207,21 @@ DeclareOperation( "ExtractSubVector", [IsRowVectorObj,IsList] );
 # to have a complete interface description in one place. Of course, vectors
 # have to implement those:
 
-# DeclareOperation( "ShallowCopy", [IsRowVectorObj] );
+# DeclareOperation( "ShallowCopy", [IsVectorObj] );
 
-# DeclareGlobalFunction( "StructuralCopy", [IsRowVectorObj] );
+# DeclareGlobalFunction( "StructuralCopy", [IsVectorObj] );
 
-# DeclareOperation( "ViewObj", [IsRowVectorObj] );
+# DeclareOperation( "ViewObj", [IsVectorObj] );
 
-# DeclareOperation( "PrintObj", [IsRowVectorObj] );
+# DeclareOperation( "PrintObj", [IsVectorObj] );
 # This must produce GAP readable input reproducing the representation!
 
-# DeclareAttribute( "String", IsRowVectorObj );
-# DeclareOperation( "String", [IsRowVectorObj,IsInt] );
+# DeclareAttribute( "String", IsVectorObj );
+# DeclareOperation( "String", [IsVectorObj,IsInt] );
 
-# DeclareOperation( "Display", [IsRowVectorObj] );
+# DeclareOperation( "Display", [IsVectorObj] );
 
-# DeclareOperation( "MakeImmutable", [IsRowVectorObj] );
+# DeclareOperation( "MakeImmutable", [IsVectorObj] );
 #  (this is a global function in the GAP library)
 
 
@@ -238,15 +238,15 @@ DeclareOperation( "ExtractSubVector", [IsRowVectorObj,IsList] );
 
 # The following "in place" operations exist with the same restrictions:
 DeclareOperation( "AddRowVector", 
-  [ IsRowVectorObj and IsMutable, IsRowVectorObj ] );
+  [ IsVectorObj and IsMutable, IsVectorObj ] );
 DeclareOperation( "AddRowVector", 
-  [ IsRowVectorObj and IsMutable, IsRowVectorObj, IsObject ] );
+  [ IsVectorObj and IsMutable, IsVectorObj, IsObject ] );
 DeclareOperation( "AddRowVector", 
-  [ IsRowVectorObj and IsMutable,IsRowVectorObj,IsObject,IsPosInt,IsPosInt ] );
+  [ IsVectorObj and IsMutable,IsVectorObj,IsObject,IsPosInt,IsPosInt ] );
 DeclareOperation( "MultRowVector",
-  [ IsRowVectorObj and IsMutable, IsObject ] );
+  [ IsVectorObj and IsMutable, IsObject ] );
 DeclareOperation( "MultRowVector",
-  [ IsRowVectorObj and IsMutable, IsList, IsRowVectorObj, IsList, IsObject ] );
+  [ IsVectorObj and IsMutable, IsList, IsVectorObj, IsList, IsObject ] );
 
 # The following operations for scalars and vectors are possible of course
 # only for scalars in the BaseDomain:
@@ -257,7 +257,7 @@ DeclareOperation( "MultRowVector",
 #    AdditiveInverseSameMutability, ZeroImmutable, ZeroMutable, 
 #    ZeroSameMutability, IsZero, Characteristic
 
-DeclareOperation( "ScalarProduct", [ IsRowVectorObj, IsRowVectorObj ] );
+DeclareOperation( "ScalarProduct", [ IsVectorObj, IsVectorObj ] );
 # This is defined for two vectors of equal length, it returns the standard
 # scalar product.
 
@@ -265,7 +265,7 @@ DeclareOperation( "ScalarProduct", [ IsRowVectorObj, IsRowVectorObj ] );
 # The "representation-preserving" contructor methods:
 ############################################################################
 
-DeclareOperation( "ZeroVector", [IsInt,IsRowVectorObj] );
+DeclareOperation( "ZeroVector", [IsInt,IsVectorObj] );
 # Returns a new mutable zero vector in the same rep as the given one with
 # a possible different length.
 
@@ -273,7 +273,7 @@ DeclareOperation( "ZeroVector", [IsInt,IsMatrixObj] );
 # Returns a new mutable zero vector in a rep that is compatible with
 # the matrix but of possibly different length.
 
-DeclareOperation( "Vector", [IsList,IsRowVectorObj]);
+DeclareOperation( "Vector", [IsList,IsVectorObj]);
 # Creates a new vector in the same representation but with entries from list.
 # The length is given by the length of the first argument.
 # It is *not* guaranteed that the list is copied!
@@ -284,18 +284,18 @@ DeclareOperation( "Vector", [IsList,IsRowVectorObj]);
 ## the matrix but of possibly different length given by the first
 ## argument. It is *not* guaranteed that the list is copied!
 
-DeclareOperation( "ConstructingFilter", [IsRowVectorObj] );
+DeclareOperation( "ConstructingFilter", [IsVectorObj] );
 
-DeclareConstructor( "NewRowVector", [IsRowVectorObj,IsRing,IsList] );
+DeclareConstructor( "NewRowVector", [IsVectorObj,IsRing,IsList] );
 # A constructor. The first argument must be a filter indicating the
 # representation the vector will be in, the second is the base domain.
 # The last argument is guaranteed not to be changed!
 
-DeclareConstructor( "NewZeroVector", [IsRowVectorObj,IsRing,IsInt] );
+DeclareConstructor( "NewZeroVector", [IsVectorObj,IsRing,IsInt] );
 # A similar constructor to construct a zero vector, the last argument
 # is the base domain.
 
-DeclareOperation( "ChangedBaseDomain", [IsRowVectorObj,IsRing] );
+DeclareOperation( "ChangedBaseDomain", [IsVectorObj,IsRing] );
 # Changes the base domain. A copy of the row vector in the first argument is
 # created, which comes in a "similar" representation but over the new
 # base domain that is given in the second argument.
@@ -310,12 +310,12 @@ DeclareGlobalFunction( "MakeVector" );
 # Some things that fit nowhere else:
 ############################################################################
 
-DeclareOperation( "Randomize", [IsRowVectorObj and IsMutable] );
+DeclareOperation( "Randomize", [IsVectorObj and IsMutable] );
 # Changes the mutable argument in place, every entry is replaced
 # by a random element from BaseDomain.
 # The argument is also returned by the function.
 
-DeclareOperation( "Randomize", [IsRowVectorObj and IsMutable,IsRandomSource] );
+DeclareOperation( "Randomize", [IsVectorObj and IsMutable,IsRandomSource] );
 # The same, use the second argument to provide "randomness".
 # The vector argument is also returned by the function.
 
@@ -338,13 +338,13 @@ DeclareOperation( "Randomize", [IsRowVectorObj and IsMutable,IsRandomSource] );
 ##  <#/GAPDoc>
 ##
 DeclareOperation( "CopySubVector", 
-  [IsRowVectorObj,IsRowVectorObj and IsMutable, IsList,IsList] );
+  [IsVectorObj,IsVectorObj and IsMutable, IsList,IsList] );
 
-DeclareOperation( "WeightOfVector", [IsRowVectorObj] );
+DeclareOperation( "WeightOfVector", [IsVectorObj] );
 # This computes the Hamming weight of a vector, i.e. the number of
 # nonzero entries.
 
-DeclareOperation( "DistanceOfVectors", [IsRowVectorObj, IsRowVectorObj] );
+DeclareOperation( "DistanceOfVectors", [IsVectorObj, IsVectorObj] );
 # This computes the Hamming distance of two vectors, i.e. the number
 # of positions, in which the vectors differ. The vectors must have the
 # same length.
@@ -400,12 +400,12 @@ DeclareOperation( "PositionNonZero", [IsMatrixObj, IsInt] );
 DeclareOperation( "PositionLastNonZero", [IsMatrixObj] );
 DeclareOperation( "PositionLastNonZero", [IsMatrixObj, IsInt] );
 
-DeclareOperation( "Position", [IsMatrixObj, IsRowVectorObj] );
-DeclareOperation( "Position", [IsMatrixObj, IsRowVectorObj, IsInt] );
+DeclareOperation( "Position", [IsMatrixObj, IsVectorObj] );
+DeclareOperation( "Position", [IsMatrixObj, IsVectorObj, IsInt] );
 
 # This allows for usage of PositionSorted:
-DeclareOperation( "PositionSortedOp", [IsMatrixObj, IsRowVectorObj] );
-DeclareOperation( "PositionSortedOp",[IsMatrixObj,IsRowVectorObj,IsFunction]);
+DeclareOperation( "PositionSortedOp", [IsMatrixObj, IsVectorObj] );
+DeclareOperation( "PositionSortedOp",[IsMatrixObj,IsVectorObj,IsFunction]);
 
 # I intentionally left out "PositionNot" here.
 
@@ -653,11 +653,11 @@ DeclareOperation( "IsLowerTriangularMat", [IsMatrixObj] );
 DeclareOperation( "KroneckerProduct", [IsMatrixObj,IsMatrixObj] );
 # The result is fully mutable.
 
-DeclareOperation( "Unfold", [IsMatrixObj, IsRowVectorObj] );
+DeclareOperation( "Unfold", [IsMatrixObj, IsVectorObj] );
 # Concatenates all rows of a matrix to one single vector in the same
 # representation as the given template vector. Usually this must
 # be compatible with the representation of the matrix given.
-DeclareOperation( "Fold", [IsRowVectorObj, IsPosInt, IsMatrixObj] );
+DeclareOperation( "Fold", [IsVectorObj, IsPosInt, IsMatrixObj] );
 # Cuts the row vector into pieces of length the second argument
 # and forms a matrix out of the pieces in the same representation 
 # as the third argument. The length of the vector must be a multiple
@@ -688,8 +688,8 @@ DeclareOperation( "[]:=", [IsRowListMatrix,IsPosInt,IsObject] );
 DeclareOperation( "{}", [IsRowListMatrix,IsList] );
 # Produces *not* a list of rows but a matrix in the same rep as the input!
 
-DeclareOperation( "Add", [IsRowListMatrix,IsRowVectorObj] );
-DeclareOperation( "Add", [IsRowListMatrix,IsRowVectorObj,IsPosInt] );
+DeclareOperation( "Add", [IsRowListMatrix,IsVectorObj] );
+DeclareOperation( "Add", [IsRowListMatrix,IsVectorObj,IsPosInt] );
 
 DeclareOperation( "Remove", [IsRowListMatrix] );
 DeclareOperation( "Remove", [IsRowListMatrix,IsPosInt] );
@@ -718,7 +718,7 @@ DeclareOperation( "ListOp", [IsRowListMatrix, IsFunction] );
 ############################################################################
 # Rule:
 # This all means that objects in IsRowListMatrix behave like lists that
-# insist on being dense and having only IsRowVectorObjs over the right
+# insist on being dense and having only IsVectorObjs over the right
 # BaseDomain and with the right length as entries. However, formally
 # they do not have to lie in the filter IsList.
 ############################################################################
@@ -761,9 +761,9 @@ DeclareOperation( "{}", [IsFlatMatrix,IsList] );
 # Arithmetic involving vectors and matrices:
 ############################################################################
 
-# DeclareOperation( "*", [IsRowVectorObj, IsMatrixObj] );
+# DeclareOperation( "*", [IsVectorObj, IsMatrixObj] );
 
-# DeclareOperation( "^", [IsRowVectorObj, IsMatrixObj] );
+# DeclareOperation( "^", [IsVectorObj, IsMatrixObj] );
 
 # Only in this direction since vectors are row vectors. The standard
 # list arithmetic rules apply only in this sense here which is the

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -286,10 +286,16 @@ DeclareOperation( "Vector", [IsList,IsVectorObj]);
 
 DeclareOperation( "ConstructingFilter", [IsVectorObj] );
 
-DeclareConstructor( "NewRowVector", [IsVectorObj,IsRing,IsList] );
+DeclareConstructor( "NewVector", [IsVectorObj,IsRing,IsList] );
 # A constructor. The first argument must be a filter indicating the
 # representation the vector will be in, the second is the base domain.
 # The last argument is guaranteed not to be changed!
+
+DeclareSynonym( "NewRowVector", NewVector );
+# FIXME: Declare NewRowVector for backwards compatibility, so that existing
+# code which already used it keeps working (most notably, the cvec and fining
+# packages). We should eventually remove this synonym.
+
 
 DeclareConstructor( "NewZeroVector", [IsVectorObj,IsRing,IsInt] );
 # A similar constructor to construct a zero vector, the last argument

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -119,8 +119,8 @@
 # The following are guaranteed to be always set or cheaply calculable:
 DeclareAttribute( "BaseDomain", IsVectorObj );
 # Typically, the base domain will be a ring, it need not be commutative
-# nor associative. For non-associative base domains powering of matrices
-# is defined by the behaviour of POW_OBJ_INT.
+# nor associative. For non-associative base domains, the behavior of
+# powering matrices is undefined.
 
 DeclareAttribute( "Length", IsVectorObj );    # can be zero
 # We have to declare this since a row vector is not necessarily
@@ -370,8 +370,8 @@ DeclareOperation( "DistanceOfVectors", [IsVectorObj, IsVectorObj] );
 # The following are guaranteed to be always set or cheaply calculable:
 DeclareAttribute( "BaseDomain", IsMatrixObj );
 # Typically, the base domain will be a ring, it need not be commutative
-# nor associative. For non-associative base domains powering of matrices
-# is defined by the behaviour of POW_OBJ_INT in the kernel.
+# nor associative. For non-associative base domains, the behavior of
+# powering matrices is undefined.
 
 DeclareAttribute( "Length", IsMatrixObj );
 # We have to declare this since matrix objects need not be lists.
@@ -525,6 +525,9 @@ DeclareOperation( "SetMatElm", [IsMatrixObj,IsPosInt,IsPosInt,IsObject] );
 
 # For non-empty square matrices we have:
 #    ^ integer
+# (this is only well-defined over associative base domains, 
+#  do not use it over non-associative base domains.
+# // The behavior of ^ on non-associative base domains is undefined.
 
 # The following unary arithmetical operations are possible for matrices:
 #    AdditiveInverseImmutable, AdditiveInverseMutable, 

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -19,7 +19,7 @@
 # Overview:
 #
 # <#GAPDoc Label="MatObj_Overview">
-# The whole idea of this interface is that (row-) vectors and matrices must
+# The whole idea of this interface is that vectors and matrices must
 # be proper objects with a stored type (i.e. created by Objectify allowing
 # inheritance) to benefit from method selection. We therefore refer
 # to the new style vectors and matrices as <Q>vector objects</Q> and
@@ -771,15 +771,6 @@ DeclareOperation( "{}", [IsFlatMatrix,IsList] );
 
 # DeclareOperation( "^", [IsVectorObj, IsMatrixObj] );
 
-# Only in this direction since vectors are row vectors. The standard
-# list arithmetic rules apply only in this sense here which is the
-# standard mathematical vector matrix multiplication.
-
-
-############################################################################
-# Rule:
-# Note that vectors are by convention row vectors.
-############################################################################
 
 
 ############################################################################

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -286,7 +286,7 @@ DeclareOperation( "Vector", [IsList,IsVectorObj]);
 
 DeclareOperation( "ConstructingFilter", [IsVectorObj] );
 
-DeclareConstructor( "NewVector", [IsVectorObj,IsRing,IsList] );
+DeclareConstructor( "NewVector", [IsVectorObj,IsSemiring,IsList] );
 # A constructor. The first argument must be a filter indicating the
 # representation the vector will be in, the second is the base domain.
 # The last argument is guaranteed not to be changed!
@@ -297,11 +297,11 @@ DeclareSynonym( "NewRowVector", NewVector );
 # packages). We should eventually remove this synonym.
 
 
-DeclareConstructor( "NewZeroVector", [IsVectorObj,IsRing,IsInt] );
+DeclareConstructor( "NewZeroVector", [IsVectorObj,IsSemiring,IsInt] );
 # A similar constructor to construct a zero vector, the last argument
 # is the base domain.
 
-DeclareOperation( "ChangedBaseDomain", [IsVectorObj,IsRing] );
+DeclareOperation( "ChangedBaseDomain", [IsVectorObj,IsSemiring] );
 # Changes the base domain. A copy of the row vector in the first argument is
 # created, which comes in a "similar" representation but over the new
 # base domain that is given in the second argument.
@@ -571,7 +571,7 @@ DeclareOperation( "ZeroMatrix", [IsInt,IsInt,IsMatrixObj] );
 # possibly different dimensions. First argument is number of rows, second
 # is number of columns.
 
-DeclareConstructor( "NewZeroMatrix", [IsMatrixObj,IsRing,IsInt,IsInt]);
+DeclareConstructor( "NewZeroMatrix", [IsMatrixObj,IsSemiring,IsInt,IsInt]);
 # Returns a new fully mutable zero matrix over the base domain in the
 # 2nd argument. The integers are the number of rows and columns.
 
@@ -579,7 +579,7 @@ DeclareOperation( "IdentityMatrix", [IsInt,IsMatrixObj] );
 # Returns a new mutable identity matrix in the same rep as the given one with
 # possibly different dimensions.
 
-DeclareConstructor( "NewIdentityMatrix", [IsMatrixObj,IsRing,IsInt]);
+DeclareConstructor( "NewIdentityMatrix", [IsMatrixObj,IsSemiring,IsInt]);
 # Returns a new fully mutable identity matrix over the base domain in the
 # 2nd argument. The integer is the number of rows and columns.
 
@@ -589,7 +589,7 @@ DeclareOperation( "CompanionMatrix", [IsUnivariatePolynomial,IsMatrixObj] );
 # monic and its coefficients must lie in the BaseDomain of the matrix.
 
 DeclareConstructor( "NewCompanionMatrix", 
-  [IsMatrixObj, IsUnivariatePolynomial, IsRing] );
+  [IsMatrixObj, IsUnivariatePolynomial, IsSemiring] );
 # The constructor variant of <Ref Oper="CompanionMatrix"/>.
 
 # The following are already declared in the library:
@@ -617,7 +617,7 @@ DeclareOperation( "Matrix", [IsList,IsMatrixObj] );
 # Note that it is not possible to generate a matrix via "Matrix" without
 # a template matrix object. Use the constructor methods instead:
 
-DeclareConstructor( "NewMatrix", [IsMatrixObj, IsRing, IsInt, IsList] );
+DeclareConstructor( "NewMatrix", [IsMatrixObj, IsSemiring, IsInt, IsList] );
 # Constructs a new fully mutable matrix. The first argument has to be a filter
 # indicating the representation. The second the base domain, the third
 # the row length and the last a list containing either row vectors
@@ -629,7 +629,7 @@ DeclareOperation( "ConstructingFilter", [IsMatrixObj] );
 
 DeclareOperation( "CompatibleVector", [IsMatrixObj] );
 
-DeclareOperation( "ChangedBaseDomain", [IsMatrixObj,IsRing] );
+DeclareOperation( "ChangedBaseDomain", [IsMatrixObj,IsSemiring] );
 # Changes the base domain. A copy of the matrix in the first argument is
 # created, which comes in a "similar" representation but over the new
 # base domain that is given in the second argument.

--- a/lib/matobjplist.gd
+++ b/lib/matobjplist.gd
@@ -14,7 +14,7 @@
 
 
 DeclareRepresentation( "IsPlistVectorRep", 
-   IsRowVectorObj and IsPositionalObjectRep, [] );
+   IsVectorObj and IsPositionalObjectRep, [] );
 # 2 positions used:
 # ![1] : BaseDomain
 # ![2] : the elements as plain list

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -67,7 +67,7 @@ InstallMethod( NewMatrix,
     m := 0*[1..Length(l)];
     e := NewRowVector(filter2, basedomain, []);
     for i in [1..Length(l)] do
-        if IsRowVectorObj(l[i]) and IsPlistVectorRep(l[i]) then
+        if IsVectorObj(l[i]) and IsPlistVectorRep(l[i]) then
             m[i] := ShallowCopy(l[i]);
         else
             m[i] := Vector( l[i], e );
@@ -805,7 +805,7 @@ InstallMethod( Matrix, "for a list and a plist matrix",
     local i,l,nrrows,res,t;
     t := m![EMPOS];
     if Length(rows) > 0 then
-        if IsRowVectorObj(rows[1]) and IsPlistVectorRep(rows[1]) then
+        if IsVectorObj(rows[1]) and IsPlistVectorRep(rows[1]) then
             nrrows := Length(rows);
             l := rows;
         elif IsList(rows[1]) then

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -134,7 +134,7 @@ InstallMethod( NewIdentityMatrix,
 
 InstallMethod( ViewObj, "for a plist vector", [ IsPlistVectorRep ],
   function( v )
-    if not(IsMutable(v)) then
+    if not IsMutable(v) then
         Print("<immutable ");
     else
         Print("<");
@@ -214,7 +214,7 @@ InstallMethod( ZeroVector, "for an integer and a plist vector",
     local v;
     v := Objectify(TypeObj(t),
                    [t![BDPOS],ListWithIdenticalEntries(l,Zero(t![BDPOS]))]);
-    if not(IsMutable(v)) then SetFilterObj(v,IsMutable); fi;
+    if not IsMutable(v) then SetFilterObj(v,IsMutable); fi;
     return v;
   end );
 
@@ -224,7 +224,7 @@ InstallMethod( ZeroVector, "for an integer and a plist matrix",
     local v;
     v := Objectify(TypeObj(m![EMPOS]),
                    [m![BDPOS],ListWithIdenticalEntries(l,Zero(m![BDPOS]))]);
-    if not(IsMutable(v)) then SetFilterObj(v,IsMutable); fi;
+    if not IsMutable(v) then SetFilterObj(v,IsMutable); fi;
     return v;
   end );
 
@@ -233,7 +233,7 @@ InstallMethod( Vector, "for a plain list and a plist vector",
   function( l, t )
     local v;
     v := Objectify(TypeObj(t),[t![BDPOS],l]);
-    if not(IsMutable(v)) then SetFilterObj(v,IsMutable); fi;
+    if not IsMutable(v) then SetFilterObj(v,IsMutable); fi;
     return v;
   end );
 
@@ -248,7 +248,7 @@ InstallMethod( Vector, "for a list and a plist vector",
         PLAIN_VEC8BIT(v);
     fi;
     v := Objectify(TypeObj(t),[t![BDPOS],v]);
-    if not(IsMutable(v)) then SetFilterObj(v,IsMutable); fi;
+    if not IsMutable(v) then SetFilterObj(v,IsMutable); fi;
     return v;
   end );
 
@@ -270,7 +270,7 @@ InstallMethod( \[\]\:\=,
         Error("\\[\\]\\:\\=: Assignment out of bounds!");
         return;
     fi;
-    if not(ob in v![BDPOS]) then
+    if not ob in v![BDPOS] then
         Error("\\[\\]\\:\\=: Object to be assigned is not in base domain");
         return;
     fi;
@@ -333,7 +333,7 @@ InstallMethod( ShallowCopy, "for a plist vector", [ IsPlistVectorRep ],
   function( v )
     local res;
     res := Objectify(TypeObj(v),[v![BDPOS],ShallowCopy(v![ELSPOS])]);
-    if not(IsMutable(v)) then SetFilterObj(res,IsMutable); fi;
+    if not IsMutable(v) then SetFilterObj(res,IsMutable); fi;
     return res;
   end );
 
@@ -353,7 +353,7 @@ InstallMethod( \+, "for two plist vectors",
   [ IsPlistVectorRep, IsPlistVectorRep ],
   function( a, b )
     local ty;
-    if not(IsMutable(a)) and IsMutable(b) then
+    if not IsMutable(a) and IsMutable(b) then
         ty := TypeObj(b);
     else
         ty := TypeObj(a);
@@ -371,11 +371,11 @@ InstallMethod( \+, "for two checking plist vectors",
         Error("\\+: Cannot add vectors of different length");
         return fail;
     fi;
-    if not(IsIdenticalObj(a![BDPOS],b![BDPOS])) then
+    if not IsIdenticalObj(a![BDPOS],b![BDPOS]) then
         Error("\\+: Cannot add vectors over different base domains");
         return fail;
     fi;
-    if not(IsMutable(a)) and IsMutable(b) then
+    if not IsMutable(a) and IsMutable(b) then
         ty := TypeObj(b);
     else
         ty := TypeObj(a);
@@ -388,7 +388,7 @@ InstallMethod( \-, "for two plist vectors",
   [ IsPlistVectorRep, IsPlistVectorRep ],
   function( a, b )
     local ty;
-    if not(IsMutable(a)) and IsMutable(b) then
+    if not IsMutable(a) and IsMutable(b) then
         ty := TypeObj(b);
     else
         ty := TypeObj(a);
@@ -406,11 +406,11 @@ InstallMethod( \-, "for two checking plist vectors",
         Error("\\-: Cannot subtract vectors of different length");
         return fail;
     fi;
-    if not(IsIdenticalObj(a![BDPOS],b![BDPOS])) then
+    if not IsIdenticalObj(a![BDPOS],b![BDPOS]) then
         Error("\\-: Cannot subtract vectors over different base domains");
         return fail;
     fi;
-    if not(IsMutable(a)) and IsMutable(b) then
+    if not IsMutable(a) and IsMutable(b) then
         ty := TypeObj(b);
     else
         ty := TypeObj(a);
@@ -445,7 +445,7 @@ InstallMethod( AddRowVector, "for two checking plist vectors",
         Error("AddRowVector: Cannot add vectors of different length");
         return;
     fi;
-    if not(IsIdenticalObj(a![BDPOS],b![BDPOS])) then
+    if not IsIdenticalObj(a![BDPOS],b![BDPOS]) then
         Error("AddRowVector: Cannot add vectors over different base domains");
         return;
     fi;
@@ -474,7 +474,7 @@ InstallMethod( AddRowVector, "for two checking plist vectors, and a scalar",
         Error("AddRowVector: Cannot subtract vectors of different length");
         return;
     fi;
-    if not(IsIdenticalObj(a![BDPOS],b![BDPOS])) then
+    if not IsIdenticalObj(a![BDPOS],b![BDPOS]) then
         Error("AddRowVector: Cannot add vectors over different base domains");
         return;
     fi;
@@ -510,7 +510,7 @@ InstallMethod( AddRowVector,
         Error("AddRowVector: Cannot add vectors of different length");
         return;
     fi;
-    if not(IsIdenticalObj(a![BDPOS],b![BDPOS])) then
+    if not IsIdenticalObj(a![BDPOS],b![BDPOS]) then
         Error("AddRowVector: Cannot add vectors over different base domains");
         return;
     fi;
@@ -539,7 +539,7 @@ InstallMethod( MultRowVector, "for a plist vector, and a scalar",
 InstallMethod( MultRowVector, "for a checking plist vector, and a scalar",
   [ IsPlistVectorRep and IsCheckingVector and IsMutable, IsObject ],
   function( v, s )
-    if not(s in v![BDPOS]) then
+    if not s in v![BDPOS] then
         Error("MultRowVector: Scalar is not in base domain");
         return;
     fi;
@@ -571,15 +571,15 @@ InstallMethod( MultRowVector,
   function( a, pa, b, pb, s )
     local l;
     l := Length(a![ELSPOS]);
-    if not(ForAll(pa,x->x >= 1 and x <= l)) then
+    if not ForAll(pa,x->x >= 1 and x <= l) then
         Error("MultRowVector: Positions pa must lie in first vector");
         return;
     fi;
-    if not(IsIdenticalObj(a![BDPOS],b![BDPOS])) then
+    if not IsIdenticalObj(a![BDPOS],b![BDPOS]) then
         Error("MultRowVector: Cannot add vectors over different base domains");
         return;
     fi;
-    if not(s in a![BDPOS]) then
+    if not s in a![BDPOS] then
         Error("MultRowVector: Scalar not in base domain");
         return;
     fi;
@@ -596,7 +596,7 @@ InstallMethod( \*, "for a plist vector and a scalar",
 InstallMethod( \*, "for a checking plist vector and a scalar",
   [ IsPlistVectorRep, IsScalar ],
   function( v, s )
-    if not(s in v![BDPOS]) then
+    if not s in v![BDPOS] then
         Error("\\*: Scalar not in base domain");
         return;
     fi;
@@ -614,7 +614,7 @@ InstallMethod( \*, "for a scalar and a plist vector",
 InstallMethod( \*, "for a scalar and a checking plist vector",
   [ IsScalar, IsPlistVectorRep ],
   function( s, v )
-    if not(s in v![BDPOS]) then
+    if not s in v![BDPOS] then
         Error("\\*: Scalar not in base domain");
         return;
     fi;
@@ -633,13 +633,13 @@ InstallMethod( \/, "for a checking plist vector and a scalar",
   [ IsPlistVectorRep and IsCheckingVector, IsScalar ],
   function( v, s )
     local res;
-    if not(s in v![BDPOS]) then
+    if not s in v![BDPOS] then
         Error("\\/: Scalar not in base domain");
         return;
     fi;
     res := Objectify( TypeObj(v),
              [v![BDPOS],PROD_LIST_SCL_DEFAULT(v![ELSPOS],s^-1)] );
-    if IsIntVector(v) and not(ForAll(res![ELSPOS],IsInt)) then
+    if IsIntVector(v) and not ForAll(res![ELSPOS],IsInt) then
         Error("\\/: Result is not an integer vector");
         return;
     fi;
@@ -669,7 +669,7 @@ InstallMethod( AdditiveInverseMutable, "for a plist vector",
     local res;
     res := Objectify(TypeObj(v),
                      [v![BDPOS],AdditiveInverseMutable(v![ELSPOS])]);
-    if not(IsMutable(v)) then SetFilterObj(res,IsMutable); fi;
+    if not IsMutable(v) then SetFilterObj(res,IsMutable); fi;
     return res;
   end );
 
@@ -691,7 +691,7 @@ InstallMethod( ZeroMutable, "for a plist vector", [ IsPlistVectorRep ],
     local res;
     res := Objectify(TypeObj(v),
                      [v![BDPOS],ZeroMutable(v![ELSPOS])]);
-    if not(IsMutable(v)) then SetFilterObj(res,IsMutable); fi;
+    if not IsMutable(v) then SetFilterObj(res,IsMutable); fi;
     return res;
   end );
 
@@ -776,7 +776,7 @@ InstallMethod( ZeroMatrix, "for two integers and a plist matrix",
     t := m![EMPOS];
     l := List([1..rows],i->ZeroVector(cols,t));
     res := Objectify( TypeObj(m), [m![BDPOS],t,cols,l] );
-    if not(IsMutable(m)) then
+    if not IsMutable(m) then
         SetFilterObj(res,IsMutable);
     fi;
     return res;
@@ -793,7 +793,7 @@ InstallMethod( IdentityMatrix, "for an integer and a plist matrix",
         l[i][i] := o;
     od;
     res := Objectify( TypeObj(m), [m![BDPOS],t,rows,l] );
-    if not(IsMutable(m)) then
+    if not IsMutable(m) then
         SetFilterObj(res,IsMutable);
     fi;
     return res;
@@ -826,7 +826,7 @@ InstallMethod( Matrix, "for a list and a plist matrix",
         nrrows := 0;
     fi;
     res := Objectify( TypeObj(m), [m![BDPOS],t,rowlen,l] );
-    if not(IsMutable(m)) then
+    if not IsMutable(m) then
         SetFilterObj(res,IsMutable);
     fi;
     return res;
@@ -859,11 +859,11 @@ InstallMethod( \[\]\:\=,
         Error("\\[\\]\\:\\=: Matrices must be dense, you cannot assign here");
         return;
     fi;
-    if not(IsIdenticalObj(m![BDPOS],v![BDPOS])) then
+    if not IsIdenticalObj(m![BDPOS],v![BDPOS]) then
         Error("\\[\\]\\:\\=: Vector and matrix must be over the same base domain");
         return;
     fi;
-    if not(m![RLPOS] = Length(v![ELSPOS])) then
+    if not m![RLPOS] = Length(v![ELSPOS]) then
         Error("\\[\\]\\:\\=: Vector does not have the right length");
         return;
     fi;
@@ -888,11 +888,11 @@ InstallMethod( Add, "for a checking plist matrix and a plist vector",
   [ IsPlistMatrixRep and IsCheckingMatrix and IsMutable,
     IsPlistVectorRep ],
   function( m, v )
-    if not(IsIdenticalObj(m![BDPOS],v![BDPOS])) then
+    if not IsIdenticalObj(m![BDPOS],v![BDPOS]) then
         Error("Add: Vector and matrix must be over the same base domain");
         return;
     fi;
-    if not(m![RLPOS] = Length(v![ELSPOS])) then
+    if not m![RLPOS] = Length(v![ELSPOS]) then
         Error("Add: Vector does not have the right length");
         return;
     fi;
@@ -913,11 +913,11 @@ InstallMethod( Add, "for a checking plist matrix, a plist vector, and a pos",
         Error("Add: Matrices must be dense, you cannot assign here");
         return;
     fi;
-    if not(IsIdenticalObj(m![BDPOS],v![BDPOS])) then
+    if not IsIdenticalObj(m![BDPOS],v![BDPOS]) then
         Error("Add: Vector and matrix must be over the same base domain");
         return;
     fi;
-    if not(m![RLPOS] = Length(v![ELSPOS])) then
+    if not m![RLPOS] = Length(v![ELSPOS]) then
         Error("Add: Vector does not have the right length");
         return;
     fi;
@@ -968,11 +968,11 @@ InstallMethod( \{\}\:\=,
         Error("\\{\\}\\:\\=: Positions must be in the matrix");
         return;
     fi;
-    if not(IsIdenticalObj(m![BDPOS],n![BDPOS])) then
+    if not IsIdenticalObj(m![BDPOS],n![BDPOS]) then
         Error("\\{\\}\\:\\=: Both matrices must be over the same base domain");
         return;
     fi;
-    if not(m![RLPOS] = n![RLPOS]) then
+    if not m![RLPOS] = n![RLPOS] then
         Error("\\{\\}\\:\\=: Row lengths are not equal");
         return;
     fi;
@@ -989,11 +989,11 @@ InstallMethod( Append, "for a checking plist matrix, and a plist matrix",
   [ IsPlistMatrixRep and IsMutable and IsCheckingMatrix,
     IsPlistMatrixRep ],
   function( m, n )
-    if not(IsIdenticalObj(m![BDPOS],n![BDPOS])) then
+    if not IsIdenticalObj(m![BDPOS],n![BDPOS]) then
         Error("Append: Both matrices must be over the same base domain");
         return;
     fi;
-    if not(m![RLPOS] = n![RLPOS]) then
+    if not m![RLPOS] = n![RLPOS] then
         Error("Append: Row lengths are not equal");
         return;
     fi;
@@ -1006,7 +1006,7 @@ InstallMethod( ShallowCopy, "for a plist matrix",
     local res;
     res := Objectify(TypeObj(m),[m![BDPOS],m![EMPOS],m![RLPOS],
                                  ShallowCopy(m![ROWSPOS])]);
-    if not(IsMutable(m)) then
+    if not IsMutable(m) then
         SetFilterObj(res,IsMutable);
     fi;
     return res;
@@ -1136,7 +1136,7 @@ InstallMethod( MutableCopyMat, "for a plist matrix",
     local l,res;
     l := List(m![ROWSPOS],ShallowCopy);
     res := Objectify(TypeObj(m),[m![BDPOS],m![EMPOS],m![RLPOS],l]);
-    if not(IsMutable(m)) then
+    if not IsMutable(m) then
         SetFilterObj(res,IsMutable);
     fi;
     return res;
@@ -1187,7 +1187,7 @@ InstallMethod( CopySubMatrix,
     IsList, IsList, IsList, IsList ],
   function( m, n, srcrows, dstrows, srccols, dstcols )
     local i;
-    if not(ForAll(dstcols,x->x <= n![RLPOS])) then
+    if not ForAll(dstcols,x->x <= n![RLPOS]) then
         Error("CopySubMatrix: Destination column positions out of range");
         return;
     fi;
@@ -1222,7 +1222,7 @@ InstallMethod( SetMatElm,
         Error("SetMatElm: Row or column number out of bounds");
         return;
     fi;
-    if not( ob in m![BDPOS] ) then
+    if not  ob in m![BDPOS]  then
         Error("SetMatElm: Value to be assigned is not in base domain");
         return;
     fi;
@@ -1238,7 +1238,7 @@ InstallMethod( ViewObj, "for a plist matrix", [ IsPlistMatrixRep ],
   function( m )
     Print("<");
     if IsCheckingMatrix(m) then Print("checking "); fi;
-    if not(IsMutable(m)) then Print("immutable "); fi;
+    if not IsMutable(m) then Print("immutable "); fi;
     Print(Length(m![ROWSPOS]),"x",m![RLPOS],"-matrix over ",m![BDPOS],">");
   end );
 
@@ -1261,7 +1261,7 @@ InstallMethod( Display, "for a plist matrix", [ IsPlistMatrixRep ],
     local i;
     Print("<");
     if IsCheckingMatrix(m) then Print("checking "); fi;
-    if not(IsMutable(m)) then Print("immutable "); fi;
+    if not IsMutable(m) then Print("immutable "); fi;
     Print(Length(m![ROWSPOS]),"x",m![RLPOS],"-matrix over ",m![BDPOS],":\n");
     for i in [1..Length(m![ROWSPOS])] do
         if i = 1 then
@@ -1305,7 +1305,7 @@ InstallMethod( \+, "for two plist matrices",
   [ IsPlistMatrixRep, IsPlistMatrixRep ],
   function( a, b )
     local ty;
-    if not(IsMutable(a)) and IsMutable(b) then
+    if not IsMutable(a) and IsMutable(b) then
         ty := TypeObj(b);
     else
         ty := TypeObj(a);
@@ -1324,11 +1324,11 @@ InstallMethod( \+, "for two checking plist matrices",
         Error("\\+: Dimensions do not fit together");
         return;
     fi;
-    if not(IsIdenticalObj(a![BDPOS],b![BDPOS])) then
+    if not IsIdenticalObj(a![BDPOS],b![BDPOS]) then
         Error("\\+: BaseDomains are not the same");
         return;
     fi;
-    if not(IsMutable(a)) and IsMutable(b) then
+    if not IsMutable(a) and IsMutable(b) then
         ty := TypeObj(b);
     else
         ty := TypeObj(a);
@@ -1341,7 +1341,7 @@ InstallMethod( \-, "for two plist matrices",
   [ IsPlistMatrixRep, IsPlistMatrixRep ],
   function( a, b )
     local ty;
-    if not(IsMutable(a)) and IsMutable(b) then
+    if not IsMutable(a) and IsMutable(b) then
         ty := TypeObj(b);
     else
         ty := TypeObj(a);
@@ -1360,11 +1360,11 @@ InstallMethod( \-, "for two checking plist matrices",
         Error("\\-: Dimensions do not fit together");
         return;
     fi;
-    if not(IsIdenticalObj(a![BDPOS],b![BDPOS])) then
+    if not IsIdenticalObj(a![BDPOS],b![BDPOS]) then
         Error("\\-: BaseDomains are not the same");
         return;
     fi;
-    if not(IsMutable(a)) and IsMutable(b) then
+    if not IsMutable(a) and IsMutable(b) then
         ty := TypeObj(b);
     else
         ty := TypeObj(a);
@@ -1378,16 +1378,16 @@ InstallMethod( \*, "for two plist matrices",
   function( a, b )
     # Here we do full checking since it is rather cheap!
     local i,j,l,ty,v,w;
-    if not(IsMutable(a)) and IsMutable(b) then
+    if not IsMutable(a) and IsMutable(b) then
         ty := TypeObj(b);
     else
         ty := TypeObj(a);
     fi;
-    if not(a![RLPOS] = Length(b![ROWSPOS])) then
+    if not a![RLPOS] = Length(b![ROWSPOS]) then
         Error("\\*: Matrices do not fit together");
         return;
     fi;
-    if not(IsIdenticalObj(a![BDPOS],b![BDPOS])) then
+    if not IsIdenticalObj(a![BDPOS],b![BDPOS]) then
         Error("\\*: Matrices not over same base domain");
         return;
     fi;
@@ -1404,7 +1404,7 @@ InstallMethod( \*, "for two plist matrices",
             l[i] := w;
         fi;
     od;
-    if not(IsMutable(a)) and not(IsMutable(b)) then
+    if not IsMutable(a) and not IsMutable(b) then
         MakeImmutable(l);
     fi;
     return Objectify( ty, [a![BDPOS],a![EMPOS],b![RLPOS],l] );
@@ -1427,7 +1427,7 @@ InstallMethod( AdditiveInverseSameMutability, "for a plist matrix",
   function( m )
     local l;
     l := List(m![ROWSPOS],AdditiveInverseSameMutability);
-    if not(IsMutable(m)) then
+    if not IsMutable(m) then
         MakeImmutable(l);
     fi;
     return Objectify( TypeObj(m), [m![BDPOS],m![EMPOS],m![RLPOS],l] );
@@ -1449,7 +1449,7 @@ InstallMethod( AdditiveInverseMutable, "for a plist matrix",
     local l,res;
     l := List(m![ROWSPOS],AdditiveInverseMutable);
     res := Objectify( TypeObj(m), [m![BDPOS],m![EMPOS],m![RLPOS],l] );
-    if not(IsMutable(m)) then
+    if not IsMutable(m) then
         SetFilterObj(res,IsMutable);
     fi;
     return res;
@@ -1460,7 +1460,7 @@ InstallMethod( ZeroSameMutability, "for a plist matrix",
   function( m )
     local l;
     l := List(m![ROWSPOS],ZeroSameMutability);
-    if not(IsMutable(m)) then
+    if not IsMutable(m) then
         MakeImmutable(l);
     fi;
     return Objectify( TypeObj(m), [m![BDPOS],m![EMPOS],m![RLPOS],l] );
@@ -1482,7 +1482,7 @@ InstallMethod( ZeroMutable, "for a plist matrix",
     local l,res;
     l := List(m![ROWSPOS],ZeroMutable);
     res := Objectify( TypeObj(m), [m![BDPOS],m![EMPOS],m![RLPOS],l] );
-    if not(IsMutable(m)) then
+    if not IsMutable(m) then
         SetFilterObj(res,IsMutable);
     fi;
     return res;
@@ -1493,7 +1493,7 @@ InstallMethod( IsZero, "for a plist matrix",
   function( m )
     local i;
     for i in [1..Length(m![ROWSPOS])] do
-        if not(IsZero(m![ROWSPOS][i])) then
+        if not IsZero(m![ROWSPOS][i]) then
             return false;
         fi;
     od;
@@ -1510,12 +1510,12 @@ InstallMethod( IsOne, "for a plist matrix",
     fi;
     n := m![RLPOS];
     for i in [1..n] do
-        if not(IsOne(m![ROWSPOS][i]![ELSPOS][i])) then return false; fi;
+        if not IsOne(m![ROWSPOS][i]![ELSPOS][i]) then return false; fi;
         for j in [1..i-1] do
-            if not(IsZero(m![ROWSPOS][i]![ELSPOS][j])) then return false; fi;
+            if not IsZero(m![ROWSPOS][i]![ELSPOS][j]) then return false; fi;
         od;
         for j in [i+1..n] do
-            if not(IsZero(m![ROWSPOS][i]![ELSPOS][j])) then return false; fi;
+            if not IsZero(m![ROWSPOS][i]![ELSPOS][j]) then return false; fi;
         od;
     od;
     return true;
@@ -1531,7 +1531,7 @@ InstallMethod( OneSameMutability, "for a plist matrix",
         return fail;
     fi;
     o := IdentityMatrix(m![RLPOS],m);
-    if not(IsMutable(m)) then
+    if not IsMutable(m) then
         MakeImmutable(o);
     fi;
     return o;
@@ -1613,7 +1613,7 @@ InstallMethod( InverseSameMutability, "for a plist matrix",
     n := InverseMutable(n);  # Invert!
     if n = fail then return fail; fi;
     n := Matrix(n,Length(n),m);
-    if not(IsMutable(m)) then
+    if not IsMutable(m) then
         MakeImmutable(n);
     fi;
     return n;
@@ -1650,12 +1650,12 @@ InstallMethod( IsDiagonalMat, "for a plist matrix",
     for i in [1..n] do
         l := m![ROWSPOS][i]![ELSPOS];
         for j in [1..i-1] do
-            if not(IsZero(l[j])) then
+            if not IsZero(l[j]) then
                 return false;
             fi;
         od;
         for j in [i+1..n] do
-            if not(IsZero(l[j])) then
+            if not IsZero(l[j]) then
                 return false;
             fi;
         od;
@@ -1675,7 +1675,7 @@ InstallMethod( IsLowerTriangularMat, "for a plist matrix",
     for i in [1..n] do
         l := m![ROWSPOS][i]![ELSPOS];
         for j in [i+1..n] do
-            if not(IsZero(l[j])) then
+            if not IsZero(l[j]) then
                 return false;
             fi;
         od;
@@ -1695,7 +1695,7 @@ InstallMethod( IsUpperTriangularMat, "for a plist matrix",
     for i in [1..n] do
         l := m![ROWSPOS][i]![ELSPOS];
         for j in [1..i-1] do
-            if not(IsZero(l[j])) then
+            if not IsZero(l[j]) then
                 return false;
             fi;
         od;
@@ -1731,11 +1731,11 @@ InstallMethod( \*, "for a plist vector and a plist matrix",
     res := ZeroVector(m![RLPOS],m![EMPOS]);
     for i in [1..Length(v![ELSPOS])] do
         s := v![ELSPOS][i];
-        if not(IsZero(s)) then
+        if not IsZero(s) then
             AddRowVector(res,m![ROWSPOS][i],v![ELSPOS][i]);
         fi;
     od;
-    if not(IsMutable(v)) and not(IsMutable(m)) then
+    if not IsMutable(v) and not IsMutable(m) then
         MakeImmutable(res);
     fi;
     return res;
@@ -1852,7 +1852,7 @@ InstallMethod( NewCompanionMatrix,
     one := One(bd);
     l := CoefficientsOfUnivariatePolynomial(po);
     n := Length(l)-1;
-    if not(IsOne(l[n+1])) then
+    if not IsOne(l[n+1]) then
         Error("CompanionMatrix: polynomial is not monic");
         return fail;
     fi;
@@ -1874,7 +1874,7 @@ InstallMethod( NewCompanionMatrix,
     one := One(bd);
     l := CoefficientsOfUnivariatePolynomial(po);
     n := Length(l)-1;
-    if not(IsOne(l[n+1])) then
+    if not IsOne(l[n+1]) then
         Error("CompanionMatrix: polynomial is not monic");
         return fail;
     fi;

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -728,12 +728,6 @@ InstallMethod( CopySubVector, "for two plist vectors and two lists",
     b![ELSPOS]{pb} := a![ELSPOS]{pa};
   end );
 
-InstallMethod( CompatibleMatrix, "for a plist vector",
-  [ IsPlistVectorRep ],
-  function( v )
-    return NewMatrix(IsPlistMatrixRep,BaseDomain(v),Length(v),[v]);
-  end );
-
 
 ############################################################################
 ############################################################################

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -34,7 +34,7 @@ InstallGlobalFunction( MakePlistVectorType,
     return T;
   end);
 
-InstallMethod( NewRowVector, "for IsPlistVectorRep, a ring, and a list",
+InstallMethod( NewVector, "for IsPlistVectorRep, a ring, and a list",
   [ IsPlistVectorRep and IsCheckingVector, IsRing, IsList ],
   function( filter, basedomain, l )
     local typ, v;
@@ -65,7 +65,7 @@ InstallMethod( NewMatrix,
         filter2 := IsPlistVectorRep and IsCheckingVector;
     fi;
     m := 0*[1..Length(l)];
-    e := NewRowVector(filter2, basedomain, []);
+    e := NewVector(filter2, basedomain, []);
     for i in [1..Length(l)] do
         if IsVectorObj(l[i]) and IsPlistVectorRep(l[i]) then
             m[i] := ShallowCopy(l[i]);
@@ -95,7 +95,7 @@ InstallMethod( NewZeroMatrix,
         filter2 := IsPlistVectorRep and IsCheckingVector;
     fi;
     m := 0*[1..rows];
-    e := NewRowVector(filter2, basedomain, []);
+    e := NewVector(filter2, basedomain, []);
     for i in [1..rows] do
         m[i] := ZeroVector( cols, e );
     od;
@@ -116,7 +116,7 @@ InstallMethod( NewIdentityMatrix,
         filter2 := IsPlistVectorRep and IsCheckingVector;
     fi;
     m := 0*[1..rows];
-    e := NewRowVector(IsPlistVectorRep, basedomain, []);
+    e := NewVector(IsPlistVectorRep, basedomain, []);
     for i in [1..rows] do
         m[i] := ZeroVector( rows, e );
         m[i][i] := One(basedomain);
@@ -145,7 +145,7 @@ InstallMethod( ViewObj, "for a plist vector", [ IsPlistVectorRep ],
 
 InstallMethod( PrintObj, "for a plist vector", [ IsPlistVectorRep ],
   function( v )
-    Print("NewRowVector(IsPlistVectorRep");
+    Print("NewVector(IsPlistVectorRep");
     if IsCheckingVector(v) then
         Print(" and IsCheckingVector");
     fi;
@@ -159,7 +159,7 @@ InstallMethod( PrintObj, "for a plist vector", [ IsPlistVectorRep ],
 InstallMethod( String, "for a plist vector", [ IsPlistVectorRep ],
   function( v )
     local st;
-    st := "NewRowVector(IsPlistVectorRep";
+    st := "NewVector(IsPlistVectorRep";
     if IsCheckingVector(v) then
         Append(st," and IsCheckingVector");
     fi;
@@ -1815,13 +1815,13 @@ InstallMethod( ConstructingFilter, "for a plist matrix",
 InstallMethod( ChangedBaseDomain, "for a plist vector, and a domain",
   [ IsPlistVectorRep, IsRing ],
   function( v, r )
-    return NewRowVector( IsPlistVectorRep, r, v![ELSPOS] );
+    return NewVector( IsPlistVectorRep, r, v![ELSPOS] );
   end );
 
 InstallMethod( ChangedBaseDomain, "for a checking plist vector, and a domain",
   [ IsPlistVectorRep and IsCheckingVector, IsRing ],
   function( v, r )
-    return NewRowVector(IsPlistVectorRep and IsCheckingVector, r, v![ELSPOS]);
+    return NewVector(IsPlistVectorRep and IsCheckingVector, r, v![ELSPOS]);
   end );
 
 InstallMethod( ChangedBaseDomain, "for a plist matrix, and a domain",

--- a/lib/vec8bit.gd
+++ b/lib/vec8bit.gd
@@ -26,7 +26,7 @@ MakeImmutable(PRIMES_COMPACT_FIELDS);
 #R  Is8BitVectorRep( <obj> ) . . . compressed vector over GFQ (3 <= q <= 256)
 ##
 DeclareRepresentation( "Is8BitVectorRep", 
-        IsDataObjectRep and IsRowVectorObj,[],
+        IsDataObjectRep and IsVectorObj,[],
         IsRowVector and IsSmallList );
 
 #############################################################################

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1121,7 +1121,7 @@ InstallOtherMethod( KroneckerProduct, "for two 8bit matrices",
   end );
 
 InstallMethod( Fold, "for an 8bit vector, a positive int, and an 8bit matrix",
-  [ IsRowVectorObj and Is8BitVectorRep, IsPosInt, Is8BitMatrixRep ],
+  [ IsVectorObj and Is8BitVectorRep, IsPosInt, Is8BitMatrixRep ],
   function( v, rl, t )
     local rows,i,tt,m;
     m := [];

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1144,7 +1144,7 @@ InstallMethod( BaseField, "for a compressed 8bit matrix",
 InstallMethod( BaseField, "for a compressed 8bit vector",
   [Is8BitVectorRep], function(v) return GF(Q_VEC8BIT(v)); end );
 
-InstallMethod( NewRowVector, "for Is8BitVectorRep, GF(q), and a list",
+InstallMethod( NewVector, "for Is8BitVectorRep, GF(q), and a list",
   [ Is8BitVectorRep, IsField and IsFinite, IsList ],
   function( filter, f, l )
     local v;

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1035,7 +1035,7 @@ InstallMethod( Matrix, "for a list of vecs, an integer, and an 8bit mat",
   [IsList, IsInt, Is8BitMatrixRep],
   function(l,rl,m)
     local q,i,li;
-    if not(IsList(l[1])) then
+    if not IsList(l[1]) then
         li := [];
         for i in [1..QuoInt(Length(l),rl)] do
             li[i] := l{[(i-1)*rl+1..i*rl]};
@@ -1270,7 +1270,7 @@ InstallMethod( NewCompanionMatrix,
     one := One(bd);
     l := CoefficientsOfUnivariatePolynomial(po);
     n := Length(l)-1;
-    if not(IsOne(l[n+1])) then
+    if not IsOne(l[n+1]) then
         Error("CompanionMatrix: polynomial is not monic");
         return fail;
     fi;

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1250,15 +1250,6 @@ InstallMethod( CompatibleVector, "for an 8bit matrix",
     return ShallowCopy(m[1]);
   end );
 
-InstallMethod( CompatibleMatrix, "for an 8bit vector",
-  [ Is8BitVectorRep ],
-  function( v )
-    local m;
-    m := [ShallowCopy(v)];
-    ConvertToMatrixRep(m,Q_VEC8BIT(v));
-    return m;
-  end );
-
 InstallMethod( WeightOfVector, "for an 8bit vector",
   [ Is8BitVectorRep ],
   function( v )

--- a/lib/vecmat.gd
+++ b/lib/vecmat.gd
@@ -39,7 +39,7 @@ BIND_GLOBAL( "GF2Zero", 0*Z(2) );
 ##
 DeclareRepresentation(
     "IsGF2VectorRep",
-    IsDataObjectRep and IsRowVectorObj, [],
+    IsDataObjectRep and IsVectorObj, [],
     IsRowVector );
 
 

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2469,15 +2469,6 @@ InstallMethod( CompatibleVector, "for a gf2 matrix",
     return ShallowCopy(m[1]);
   end );
 
-InstallMethod( CompatibleMatrix, "for a gf2 vector",
-  [ IsGF2VectorRep ],
-  function( v )
-    local m;
-    m := [ShallowCopy(v)];
-    ConvertToMatrixRep(m,2);
-    return m;
-  end );
-
 InstallMethod( WeightOfVector, "for a gf2 vector",
   [ IsGF2VectorRep ],
   function( v )

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2366,7 +2366,7 @@ InstallMethod( BaseField, "for a compressed gf2 matrix",
 InstallMethod( BaseField, "for a compressed gf2 vector",
   [IsGF2VectorRep], function(v) return GF(2); end );
 
-InstallMethod( NewRowVector, "for IsGF2VectorRep, GF(2), and a list",
+InstallMethod( NewVector, "for IsGF2VectorRep, GF(2), and a list",
   [ IsGF2VectorRep, IsField and IsFinite, IsList ],
   function( filter, f, l )
     local v;

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2250,7 +2250,7 @@ BindGlobal( "PositionLastNonZeroFunc2",
   end );
 
 InstallMethod( PositionLastNonZero, "for a row vector obj",
-  [IsRowVectorObj], PositionLastNonZeroFunc );
+  [IsVectorObj], PositionLastNonZeroFunc );
 InstallMethod( PositionLastNonZero, "for a matrix obj",
   [IsMatrixObj], PositionLastNonZeroFunc );
 InstallMethod( PositionLastNonZero, "for a matrix obj, and an index",
@@ -2343,7 +2343,7 @@ InstallOtherMethod( KroneckerProduct, "for two gf2 matrices",
   KRONECKERPRODUCT_GF2MAT_GF2MAT );
 
 InstallMethod( Fold, "for a gf2 vector, a positive int, and a gf2 matrix",
-  [ IsRowVectorObj and IsGF2VectorRep, IsPosInt, IsGF2MatrixRep ],
+  [ IsVectorObj and IsGF2VectorRep, IsPosInt, IsGF2MatrixRep ],
   function( v, rl, t )
     local rows,i,tt,m;
     m := [];

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2222,7 +2222,7 @@ InstallMethod( Matrix, "for a list of vecs, an integer, and a gf2 mat",
   [IsList, IsInt, IsGF2MatrixRep],
   function(l,rl,m)
     local i,li;
-    if not(IsList(l[1])) then
+    if not IsList(l[1]) then
         li := [];
         for i in [1..QuoInt(Length(l),rl)] do
             li[i] := l{[(i-1)*rl+1..i*rl]};
@@ -2489,7 +2489,7 @@ InstallMethod( NewCompanionMatrix,
     one := One(bd);
     l := CoefficientsOfUnivariatePolynomial(po);
     n := Length(l)-1;
-    if not(IsOne(l[n+1])) then
+    if not IsOne(l[n+1]) then
         Error("CompanionMatrix: polynomial is not monic");
         return fail;
     fi;


### PR DESCRIPTION
This PR adds some code from the `MatrixObj` branch (see also PR #1454).

The problem with the `MatrixObj` branch is the same as with any long lived feature branch: It starts to diverge from master, and constant merges will make it hard to understand; there is also a risk of conflicting development on both branch.

I think we are much better off doing multiple short-lived feature branches which we quickly merge, at least where possible. Towards this goal, I plan to backport the changes already on the `MatrixObj` branch to `master`, possibly after some cleanup.

We can then rebase (not merge!) the `MatrixObj` branch on master, and rince-and-repeat the process. The only drawback of that is that when a rebase happens, everybody collaborating on `MatrixObj` would have to be careful to get the rebased version, else chaos can ensue. If people are concerned about that, I could also name the rebased versions of the branch `MarixObj2`,  `MarixObj3` etc., i.e. create a new branch each time.

I wold try to keep the more messy changes (including things that add tons o FIXME and TODO comments) out of master, though.