### PR TITLE
Macroing

### DIFF
--- a/hpcgap/lib/type1.g
+++ b/hpcgap/lib/type1.g
@@ -497,7 +497,7 @@ BIND_GLOBAL( "FlagsType", K -> K![2] );
 BIND_GLOBAL( "DataType", K -> K![ POS_DATA_TYPE ] );
 
 BIND_GLOBAL( "SetDataType", function ( K, data )
-    StrictBindOnce(K, POS_DATA_TYPE, `data);
+    StrictBindOnce(K, POS_DATA_TYPE, MakeImmutable(data));
 end );
 
 

--- a/hpcgap/src/c_filter1.c
+++ b/hpcgap/src/c_filter1.c
@@ -565,7 +565,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 15, "CLEAR_IMP_CACHE" );
+ t_2 = MakeString( "CLEAR_IMP_CACHE" );
  t_3 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -616,7 +616,7 @@ static Obj  HdlrFunc1 (
       return with;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 15, "WITH_IMPS_FLAGS" );
+ t_2 = MakeString( "WITH_IMPS_FLAGS" );
  t_3 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -647,7 +647,7 @@ static Obj  HdlrFunc1 (
       return rank;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "RankFilter" );
+ t_2 = MakeString( "RankFilter" );
  t_3 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -752,8 +752,8 @@ static Int InitLibrary ( StructInitInfo * module )
  /* record names used in handlers */
  
  /* information for the functions */
- C_NEW_STRING( DefaultName, 14, "local function" );
- C_NEW_STRING( FileName, 21, "GAPROOT/lib/filter1.g" );
+ DefaultName = MakeString( "local function" );
+ FileName = MakeString( "GAPROOT/lib/filter1.g" );
  NameFunc[1] = DefaultName;
  NamsFunc[1] = 0;
  NargFunc[1] = 0;

--- a/hpcgap/src/c_oper1.c
+++ b/hpcgap/src/c_oper1.c
@@ -424,14 +424,14 @@ static Obj  HdlrFunc2 (
        
        /* Print( "#I  immediate: ", NAME_FUNC( imm[i + 1] ), "\n" ); */
        t_9 = GF_Print;
-       C_NEW_STRING( t_10, 15, "#I  immediate: " );
+       t_10 = MakeString( "#I  immediate: " );
        t_12 = GF_NAME__FUNC;
        C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
        CHECK_INT_POS( t_14 )
        C_ELM_LIST_FPL( t_13, l_imm, t_14 )
        t_11 = CALL_1ARGS( t_12, t_13 );
        CHECK_FUNC_RESULT( t_11 )
-       C_NEW_STRING( t_12, 1, "\n" );
+       t_12 = MakeString( "\n" );
        CALL_3ARGS( t_9, t_10, t_11, t_12 );
        
       }
@@ -441,18 +441,18 @@ static Obj  HdlrFunc2 (
        
        /* Print( "#I  immediate: ", NAME_FUNC( imm[i + 1] ), ": ", imm[i + 7], "\n" ); */
        t_9 = GF_Print;
-       C_NEW_STRING( t_10, 15, "#I  immediate: " );
+       t_10 = MakeString( "#I  immediate: " );
        t_12 = GF_NAME__FUNC;
        C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
        CHECK_INT_POS( t_14 )
        C_ELM_LIST_FPL( t_13, l_imm, t_14 )
        t_11 = CALL_1ARGS( t_12, t_13 );
        CHECK_FUNC_RESULT( t_11 )
-       C_NEW_STRING( t_12, 2, ": " );
+       t_12 = MakeString( ": " );
        C_SUM_FIA( t_14, l_i, INTOBJ_INT(7) )
        CHECK_INT_POS( t_14 )
        C_ELM_LIST_FPL( t_13, l_imm, t_14 )
-       C_NEW_STRING( t_14, 1, "\n" );
+       t_14 = MakeString( "\n" );
        CALL_5ARGS( t_9, t_10, t_11, t_12, t_13, t_14 );
        
       }
@@ -718,7 +718,7 @@ static Obj  HdlrFunc3 (
   
   /* APPEND_LIST_INTR( k, ": " ); */
   t_1 = GF_APPEND__LIST__INTR;
-  C_NEW_STRING( t_2, 2, ": " );
+  t_2 = MakeString( ": " );
   CALL_2ARGS( t_1, l_k, t_2 );
   
   /* APPEND_LIST_INTR( k, info ); */
@@ -984,8 +984,8 @@ static Obj  HdlrFunc3 (
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
       CHECK_FUNC_RESULT( t_2 )
-      C_NEW_STRING( t_3, 23, ": <famrel> must accept " );
-      C_NEW_STRING( t_4, 10, " arguments" );
+      t_3 = MakeString( ": <famrel> must accept " );
+      t_4 = MakeString( " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
       
      }
@@ -1009,7 +1009,7 @@ static Obj  HdlrFunc3 (
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
     CHECK_FUNC_RESULT( t_2 )
-    C_NEW_STRING( t_3, 49, ": <famrel> must be a function, `true', or `false'" );
+    t_3 = MakeString( ": <famrel> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
    }
@@ -1121,8 +1121,8 @@ static Obj  HdlrFunc3 (
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
       CHECK_FUNC_RESULT( t_2 )
-      C_NEW_STRING( t_3, 23, ": <method> must accept " );
-      C_NEW_STRING( t_4, 10, " arguments" );
+      t_3 = MakeString( ": <method> must accept " );
+      t_4 = MakeString( " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
       
      }
@@ -1147,7 +1147,7 @@ static Obj  HdlrFunc3 (
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
     CHECK_FUNC_RESULT( t_2 )
-    C_NEW_STRING( t_3, 49, ": <method> must be a function, `true', or `false'" );
+    t_3 = MakeString( ": <method> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
    }
@@ -1320,7 +1320,7 @@ static Obj  HdlrFunc6 (
   
   /* Error( "too few arguments given in <arglist>" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 36, "too few arguments given in <arglist>" );
+  t_2 = MakeString( "too few arguments given in <arglist>" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -1341,7 +1341,7 @@ static Obj  HdlrFunc6 (
   
   /* Error( "<opr> is not an operation" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 25, "<opr> is not an operation" );
+  t_2 = MakeString( "<opr> is not an operation" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -1434,8 +1434,8 @@ static Obj  HdlrFunc6 (
   
   /* Error( "<arglist>[", pos, "] must be a list of filters" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 10, "<arglist>[" );
-  C_NEW_STRING( t_3, 27, "] must be a list of filters" );
+  t_2 = MakeString( "<arglist>[" );
+  t_3 = MakeString( "] must be a list of filters" );
   CALL_3ARGS( t_1, t_2, l_pos, t_3 );
   
  }
@@ -1457,11 +1457,11 @@ static Obj  HdlrFunc6 (
   
   /* Error( "methods can have at most ", GAPInfo.MaxNrArgsMethod, " arguments" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 25, "methods can have at most " );
+  t_2 = MakeString( "methods can have at most " );
   t_4 = GC_GAPInfo;
   CHECK_BOUND( t_4, "GAPInfo" )
   t_3 = ELM_REC( t_4, R_MaxNrArgsMethod );
-  C_NEW_STRING( t_4, 10, " arguments" );
+  t_4 = MakeString( " arguments" );
   CALL_3ARGS( t_1, t_2, t_3, t_4 );
   
  }
@@ -1475,7 +1475,7 @@ static Obj  HdlrFunc6 (
  if ( t_1 ) {
   
   /* info1 := "[ "; */
-  C_NEW_STRING( t_1, 2, "[ " );
+  t_1 = MakeString( "[ " );
   l_info1 = t_1;
   
   /* isstr := true; */
@@ -1508,7 +1508,7 @@ static Obj  HdlrFunc6 (
     
     /* APPEND_LIST_INTR( info1, ", " ); */
     t_3 = GF_APPEND__LIST__INTR;
-    C_NEW_STRING( t_4, 2, ", " );
+    t_4 = MakeString( ", " );
     CALL_2ARGS( t_3, l_info1, t_4 );
     
     /* filters[i] := EvalString( filters[i] ); */
@@ -1530,7 +1530,7 @@ static Obj  HdlrFunc6 (
      
      /* Error( "string does not evaluate to a function" ); */
      t_3 = GF_Error;
-     C_NEW_STRING( t_4, 38, "string does not evaluate to a function" );
+     t_4 = MakeString( "string does not evaluate to a function" );
      CALL_1ARGS( t_3, t_4 );
      
     }
@@ -1641,7 +1641,7 @@ static Obj  HdlrFunc6 (
   
   /* Error( "the method is missing in <arglist>" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 34, "the method is missing in <arglist>" );
+  t_2 = MakeString( "the method is missing in <arglist>" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -1685,7 +1685,7 @@ static Obj  HdlrFunc6 (
   
   /* Error( "the method is missing in <arglist>" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 34, "the method is missing in <arglist>" );
+  t_2 = MakeString( "the method is missing in <arglist>" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -1741,7 +1741,7 @@ static Obj  HdlrFunc6 (
   t_3 = GF_NAME__FUNC;
   t_2 = CALL_1ARGS( t_3, l_opr );
   CHECK_FUNC_RESULT( t_2 )
-  C_NEW_STRING( t_3, 35, ": use `InstallTrueMethod' for <opr>" );
+  t_3 = MakeString( ": use `InstallTrueMethod' for <opr>" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
  }
@@ -1768,13 +1768,13 @@ static Obj  HdlrFunc6 (
    
    /* INFO_DEBUG( 1, "a method is installed for the wrapper operation ", NAME_FUNC( opr ), "\n", "#I  probably it should be installed for (one of) its\n", "#I  underlying operation(s)" ); */
    t_1 = GF_INFO__DEBUG;
-   C_NEW_STRING( t_2, 48, "a method is installed for the wrapper operation " );
+   t_2 = MakeString( "a method is installed for the wrapper operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
    CHECK_FUNC_RESULT( t_3 )
-   C_NEW_STRING( t_4, 1, "\n" );
-   C_NEW_STRING( t_5, 53, "#I  probably it should be installed for (one of) its\n" );
-   C_NEW_STRING( t_6, 27, "#I  underlying operation(s)" );
+   t_4 = MakeString( "\n" );
+   t_5 = MakeString( "#I  probably it should be installed for (one of) its\n" );
+   t_6 = MakeString( "#I  underlying operation(s)" );
    CALL_6ARGS( t_1, INTOBJ_INT(1), t_2, t_3, t_4, t_5, t_6 );
    
   }
@@ -1849,7 +1849,7 @@ static Obj  HdlrFunc6 (
    
    /* Error( "unknown operation ", NAME_FUNC( opr ) ); */
    t_1 = GF_Error;
-   C_NEW_STRING( t_2, 18, "unknown operation " );
+   t_2 = MakeString( "unknown operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
    CHECK_FUNC_RESULT( t_3 )
@@ -2007,7 +2007,7 @@ static Obj  HdlrFunc6 (
     
     /* Error( "the number of arguments does not match a declaration of ", NAME_FUNC( opr ) ); */
     t_1 = GF_Error;
-    C_NEW_STRING( t_2, 56, "the number of arguments does not match a declaration of " );
+    t_2 = MakeString( "the number of arguments does not match a declaration of " );
     t_4 = GF_NAME__FUNC;
     t_3 = CALL_1ARGS( t_4, l_opr );
     CHECK_FUNC_RESULT( t_3 )
@@ -2020,17 +2020,17 @@ static Obj  HdlrFunc6 (
     
     /* Error( "required filters ", NamesFilter( imp[notmatch] ), "\nfor ", Ordinal( notmatch ), " argument do not match a declaration of ", NAME_FUNC( opr ) ); */
     t_1 = GF_Error;
-    C_NEW_STRING( t_2, 17, "required filters " );
+    t_2 = MakeString( "required filters " );
     t_4 = GF_NamesFilter;
     CHECK_INT_POS( l_notmatch )
     C_ELM_LIST_FPL( t_5, l_imp, l_notmatch )
     t_3 = CALL_1ARGS( t_4, t_5 );
     CHECK_FUNC_RESULT( t_3 )
-    C_NEW_STRING( t_4, 5, "\nfor " );
+    t_4 = MakeString( "\nfor " );
     t_6 = GF_Ordinal;
     t_5 = CALL_1ARGS( t_6, l_notmatch );
     CHECK_FUNC_RESULT( t_5 )
-    C_NEW_STRING( t_6, 40, " argument do not match a declaration of " );
+    t_6 = MakeString( " argument do not match a declaration of " );
     t_8 = GF_NAME__FUNC;
     t_7 = CALL_1ARGS( t_8, l_opr );
     CHECK_FUNC_RESULT( t_7 )
@@ -2123,11 +2123,11 @@ static Obj  HdlrFunc6 (
       
       /* INFO_DEBUG( 1, "method installed for ", NAME_FUNC( opr ), " matches more than one declaration" ); */
       t_4 = GF_INFO__DEBUG;
-      C_NEW_STRING( t_5, 21, "method installed for " );
+      t_5 = MakeString( "method installed for " );
       t_7 = GF_NAME__FUNC;
       t_6 = CALL_1ARGS( t_7, l_opr );
       CHECK_FUNC_RESULT( t_6 )
-      C_NEW_STRING( t_7, 34, " matches more than one declaration" );
+      t_7 = MakeString( " matches more than one declaration" );
       CALL_4ARGS( t_4, INTOBJ_INT(1), t_5, t_6, t_7 );
       
      }
@@ -2507,7 +2507,7 @@ static Obj  HdlrFunc7 (
    t_1 = GF_InstallOtherMethod;
    t_2 = OBJ_LVAR( 1 );
    CHECK_BOUND( t_2, "getter" )
-   C_NEW_STRING( t_3, 59, "default method requiring categories and checking properties" );
+   t_3 = MakeString( "default method requiring categories and checking properties" );
    t_4 = True;
    t_5 = NEW_PLIST( T_PLIST, 1 );
    SET_LEN_PLIST( t_5, 1 );
@@ -2565,7 +2565,7 @@ static Obj  HdlrFunc9 (
  
  /* InstallOtherMethod( setter, "default method, does nothing", true, [ IS_OBJECT, IS_OBJECT ], 0, DO_NOTHING_SETTER ); */
  t_1 = GF_InstallOtherMethod;
- C_NEW_STRING( t_2, 28, "default method, does nothing" );
+ t_2 = MakeString( "default method, does nothing" );
  t_3 = True;
  t_4 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_4, 2 );
@@ -2717,7 +2717,7 @@ static Obj  HdlrFunc12 (
   t_1 = GF_Error;
   t_2 = OBJ_LVAR_1UP( 1 );
   CHECK_BOUND( t_2, "name" )
-  C_NEW_STRING( t_3, 21, ": <p> must be a prime" );
+  t_3 = MakeString( ": <p> must be a prime" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
  }
@@ -3095,7 +3095,7 @@ static Obj  HdlrFunc11 (
  /* if keytest = "prime" then */
  t_2 = OBJ_LVAR( 2 );
  CHECK_BOUND( t_2, "keytest" )
- C_NEW_STRING( t_3, 5, "prime" );
+ t_3 = MakeString( "prime" );
  t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
  if ( t_1 ) {
   
@@ -3128,7 +3128,7 @@ static Obj  HdlrFunc11 (
  
  /* APPEND_LIST_INTR( str, "Op" ); */
  t_1 = GF_APPEND__LIST__INTR;
- C_NEW_STRING( t_2, 2, "Op" );
+ t_2 = MakeString( "Op" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareOperation( str, [ domreq, keyreq ] ); */
@@ -3148,7 +3148,7 @@ static Obj  HdlrFunc11 (
  ASS_LVAR( 3, t_1 );
  
  /* str := "Computed"; */
- C_NEW_STRING( t_1, 8, "Computed" );
+ t_1 = MakeString( "Computed" );
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, name ); */
@@ -3159,12 +3159,12 @@ static Obj  HdlrFunc11 (
  
  /* APPEND_LIST_INTR( str, "s" ); */
  t_1 = GF_APPEND__LIST__INTR;
- C_NEW_STRING( t_2, 1, "s" );
+ t_2 = MakeString( "s" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareAttribute( str, domreq, "mutable" ); */
  t_1 = GF_DeclareAttribute;
- C_NEW_STRING( t_2, 7, "mutable" );
+ t_2 = MakeString( "mutable" );
  CALL_3ARGS( t_1, l_str, a_domreq, t_2 );
  
  /* attr := VALUE_GLOBAL( str ); */
@@ -3179,7 +3179,7 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallMethod;
  t_2 = OBJ_LVAR( 4 );
  CHECK_BOUND( t_2, "attr" )
- C_NEW_STRING( t_3, 14, "default method" );
+ t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_5, 1 );
@@ -3252,7 +3252,7 @@ static Obj  HdlrFunc11 (
  CHECK_BOUND( t_4, "name" )
  t_2 = CALL_1ARGS( t_3, t_4 );
  CHECK_FUNC_RESULT( t_2 )
- C_NEW_STRING( t_3, 14, "default method" );
+ t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_5, 2 );
@@ -3271,7 +3271,7 @@ static Obj  HdlrFunc11 (
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* str := "Has"; */
- C_NEW_STRING( t_1, 3, "Has" );
+ t_1 = MakeString( "Has" );
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, name ); */
@@ -3301,7 +3301,7 @@ static Obj  HdlrFunc11 (
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
  CHECK_FUNC_RESULT( t_2 )
- C_NEW_STRING( t_3, 14, "default method" );
+ t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_5, 2 );
@@ -3320,7 +3320,7 @@ static Obj  HdlrFunc11 (
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* str := "Set"; */
- C_NEW_STRING( t_1, 3, "Set" );
+ t_1 = MakeString( "Set" );
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, name ); */
@@ -3359,7 +3359,7 @@ static Obj  HdlrFunc11 (
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
  CHECK_FUNC_RESULT( t_2 )
- C_NEW_STRING( t_3, 14, "default method" );
+ t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_5, 3 );
@@ -3623,7 +3623,7 @@ static Obj  HdlrFunc17 (
   ASS_LVAR( 1, t_1 );
   
   /* info := " fallback method to test conditions"; */
-  C_NEW_STRING( t_1, 35, " fallback method to test conditions" );
+  t_1 = MakeString( " fallback method to test conditions" );
   l_info = t_1;
   
   /* fampred := arg[2]; */
@@ -3683,7 +3683,7 @@ static Obj  HdlrFunc17 (
    
    /* Error( "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" ); */
    t_1 = GF_Error;
-   C_NEW_STRING( t_2, 63, "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" );
+   t_2 = MakeString( "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" );
    CALL_1ARGS( t_1, t_2 );
    
   }
@@ -3845,7 +3845,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 19, "RunImmediateMethods" );
+ t_2 = MakeString( "RunImmediateMethods" );
  t_3 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3858,9 +3858,9 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "METHODS_OPERATION_REGION", NewSpecialRegion( "operation methods" ) ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 24, "METHODS_OPERATION_REGION" );
+ t_2 = MakeString( "METHODS_OPERATION_REGION" );
  t_4 = GF_NewSpecialRegion;
- C_NEW_STRING( t_5, 17, "operation methods" );
+ t_5 = MakeString( "operation methods" );
  t_3 = CALL_1ARGS( t_4, t_5 );
  CHECK_FUNC_RESULT( t_3 )
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -3954,7 +3954,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 20, "INSTALL_METHOD_FLAGS" );
+ t_2 = MakeString( "INSTALL_METHOD_FLAGS" );
  t_3 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3970,7 +3970,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 13, "InstallMethod" );
+ t_2 = MakeString( "InstallMethod" );
  t_3 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3986,7 +3986,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 18, "InstallOtherMethod" );
+ t_2 = MakeString( "InstallOtherMethod" );
  t_3 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3999,7 +3999,7 @@ static Obj  HdlrFunc1 (
  
  /* DeclareGlobalFunction( "EvalString" ); */
  t_1 = GF_DeclareGlobalFunction;
- C_NEW_STRING( t_2, 10, "EvalString" );
+ t_2 = MakeString( "EvalString" );
  CALL_1ARGS( t_1, t_2 );
  
  /* Unbind( INSTALL_METHOD ); */
@@ -4146,7 +4146,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 14, "INSTALL_METHOD" );
+ t_2 = MakeString( "INSTALL_METHOD" );
  t_3 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4250,7 +4250,7 @@ static Obj  HdlrFunc1 (
       return k;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 26, "PositionSortedOddPositions" );
+ t_2 = MakeString( "PositionSortedOddPositions" );
  t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4262,7 +4262,7 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* IsPrimeInt := "2b defined"; */
- C_NEW_STRING( t_1, 10, "2b defined" );
+ t_1 = MakeString( "2b defined" );
  AssGVar( G_IsPrimeInt, t_1 );
  
  /* BIND_GLOBAL( "KeyDependentOperation", function ( name, domreq, keyreq, keytest )
@@ -4335,7 +4335,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 21, "KeyDependentOperation" );
+ t_2 = MakeString( "KeyDependentOperation" );
  t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4347,7 +4347,7 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* CallFuncList := "2b defined"; */
- C_NEW_STRING( t_1, 10, "2b defined" );
+ t_1 = MakeString( "2b defined" );
  AssGVar( G_CallFuncList, t_1 );
  
  /* BIND_GLOBAL( "RedispatchOnCondition", function ( arg... )
@@ -4387,7 +4387,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 21, "RedispatchOnCondition" );
+ t_2 = MakeString( "RedispatchOnCondition" );
  t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4402,7 +4402,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_InstallMethod;
  t_2 = GC_ViewObj;
  CHECK_BOUND( t_2, "ViewObj" )
- C_NEW_STRING( t_3, 31, "default method using `PrintObj'" );
+ t_3 = MakeString( "default method using `PrintObj'" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_5, 1 );
@@ -4657,8 +4657,8 @@ static Int InitLibrary ( StructInitInfo * module )
  R_MaxNrArgsMethod = RNamName( "MaxNrArgsMethod" );
  
  /* information for the functions */
- C_NEW_STRING( DefaultName, 14, "local function" );
- C_NEW_STRING( FileName, 19, "GAPROOT/lib/oper1.g" );
+ DefaultName = MakeString( "local function" );
+ FileName = MakeString( "GAPROOT/lib/oper1.g" );
  NameFunc[1] = DefaultName;
  NamsFunc[1] = 0;
  NargFunc[1] = 0;

--- a/hpcgap/src/c_type1.c
+++ b/hpcgap/src/c_type1.c
@@ -186,8 +186,6 @@ static GVar G_SupType2;
 static Obj  GF_SupType2;
 static GVar G_SupType3;
 static Obj  GF_SupType3;
-static GVar G_MakeLiteral;
-static Obj  GF_MakeLiteral;
 static GVar G_FlagsType;
 static Obj  GF_FlagsType;
 static GVar G_TypeObj;
@@ -277,7 +275,7 @@ static Obj  HdlrFunc2 (
  
  /* InstallOtherMethod( getter, "system getter", true, [ IsAttributeStoringRep and tester ], GETTER_FLAGS, GETTER_FUNCTION( name ) ); */
  t_1 = GF_InstallOtherMethod;
- C_NEW_STRING( t_2, 13, "system getter" );
+ t_2 = MakeString( "system getter" );
  t_3 = True;
  t_4 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_4, 1 );
@@ -401,7 +399,7 @@ static Obj  HdlrFunc3 (
       return;
   end ); */
   t_1 = GF_InstallOtherMethod;
-  C_NEW_STRING( t_2, 21, "system mutable setter" );
+  t_2 = MakeString( "system mutable setter" );
   t_3 = True;
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
@@ -430,7 +428,7 @@ static Obj  HdlrFunc3 (
   
   /* InstallOtherMethod( setter, "system setter", true, [ IsAttributeStoringRep, IS_OBJECT ], 0, SETTER_FUNCTION( name, tester ) ); */
   t_1 = GF_InstallOtherMethod;
-  C_NEW_STRING( t_2, 13, "system setter" );
+  t_2 = MakeString( "system setter" );
   t_3 = True;
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
@@ -976,7 +974,7 @@ static Obj  HdlrFunc10 (
      
      /* Error( "usage: NewFamily( <name>, [ <req> [, <imp> ]] )" ); */
      t_1 = GF_Error;
-     C_NEW_STRING( t_2, 47, "usage: NewFamily( <name>, [ <req> [, <imp> ]] )" );
+     t_2 = MakeString( "usage: NewFamily( <name>, [ <req> [, <imp> ]] )" );
      CALL_1ARGS( t_1, t_2 );
      
     }
@@ -1377,7 +1375,7 @@ static Obj  HdlrFunc11 (
   
   /* GASMAN( "collect" ); */
   t_1 = GF_GASMAN;
-  C_NEW_STRING( t_2, 7, "collect" );
+  t_2 = MakeString( "collect" );
   CALL_1ARGS( t_1, t_2 );
   
   /* FLUSH_ALL_METHOD_CACHES(  ); */
@@ -1808,7 +1806,7 @@ static Obj  HdlrFunc14 (
   
   /* Error( "<family> must be a family" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 25, "<family> must be a family" );
+  t_2 = MakeString( "<family> must be a family" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -1859,7 +1857,7 @@ static Obj  HdlrFunc14 (
    
    /* Error( "usage: NewType( <family>, <filter> [, <data> ] )" ); */
    t_1 = GF_Error;
-   C_NEW_STRING( t_2, 48, "usage: NewType( <family>, <filter> [, <data> ] )" );
+   t_2 = MakeString( "usage: NewType( <family>, <filter> [, <data> ] )" );
    CALL_1ARGS( t_1, t_2 );
    
   }
@@ -2024,7 +2022,7 @@ static Obj  HdlrFunc17 (
   
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 21, "<type> must be a type" );
+  t_2 = MakeString( "<type> must be a type" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -2210,7 +2208,7 @@ static Obj  HdlrFunc20 (
   
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 21, "<type> must be a type" );
+  t_2 = MakeString( "<type> must be a type" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -2363,11 +2361,11 @@ static Obj  HdlrFunc24 (
  REM_BRK_CURR_STAT();
  SET_BRK_CURR_STAT(0);
  
- /* StrictBindOnce( K, POS_DATA_TYPE, MakeLiteral( data ) ); */
+ /* StrictBindOnce( K, POS_DATA_TYPE, MakeImmutable( data ) ); */
  t_1 = GF_StrictBindOnce;
  t_2 = GC_POS__DATA__TYPE;
  CHECK_BOUND( t_2, "POS_DATA_TYPE" )
- t_4 = GF_MakeLiteral;
+ t_4 = GF_MakeImmutable;
  t_3 = CALL_1ARGS( t_4, a_data );
  CHECK_FUNC_RESULT( t_3 )
  CALL_3ARGS( t_1, a_K, t_2, t_3 );
@@ -2480,7 +2478,7 @@ static Obj  HdlrFunc27 (
   
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 21, "<type> must be a type" );
+  t_2 = MakeString( "<type> must be a type" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -2576,7 +2574,7 @@ static Obj  HdlrFunc28 (
   
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 21, "<type> must be a type" );
+  t_2 = MakeString( "<type> must be a type" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -2764,7 +2762,7 @@ static Obj  HdlrFunc29 (
   
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 21, "<type> must be a type" );
+  t_2 = MakeString( "<type> must be a type" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -3099,7 +3097,7 @@ static Obj  HdlrFunc30 (
         
         /* Error( "cannot set filter for internal object" ); */
         t_1 = GF_Error;
-        C_NEW_STRING( t_2, 37, "cannot set filter for internal object" );
+        t_2 = MakeString( "cannot set filter for internal object" );
         CALL_1ARGS( t_1, t_2 );
         
        }
@@ -3151,7 +3149,7 @@ static Obj  HdlrFunc31 (
   
   /* Error( "You can't reset an \"and-filter\". Reset components individually." ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 63, "You can't reset an \"and-filter\". Reset components individually." );
+  t_2 = MakeString( "You can't reset an \"and-filter\". Reset components individually." );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -3284,7 +3282,7 @@ static Obj  HdlrFunc31 (
         
         /* Error( "cannot reset filter for internal object" ); */
         t_1 = GF_Error;
-        C_NEW_STRING( t_2, 39, "cannot reset filter for internal object" );
+        t_2 = MakeString( "cannot reset filter for internal object" );
         CALL_1ARGS( t_1, t_2 );
         
        }
@@ -3809,8 +3807,8 @@ static Obj  HdlrFunc34 (
   
   /* INFO_OWA( "#W ObjectifyWithAttributes called ", "for non-attribute storing rep\n" ); */
   t_1 = GF_INFO__OWA;
-  C_NEW_STRING( t_2, 34, "#W ObjectifyWithAttributes called " );
-  C_NEW_STRING( t_3, 30, "for non-attribute storing rep\n" );
+  t_2 = MakeString( "#W ObjectifyWithAttributes called " );
+  t_3 = MakeString( "for non-attribute storing rep\n" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
   /* Objectify( type, obj ); */
@@ -4057,12 +4055,12 @@ static Obj  HdlrFunc34 (
    
    /* INFO_OWA( "#W  Supplied type has tester of ", NAME_FUNC( extra[i] ), "with non-standard setter\n" ); */
    t_5 = GF_INFO__OWA;
-   C_NEW_STRING( t_6, 32, "#W  Supplied type has tester of " );
+   t_6 = MakeString( "#W  Supplied type has tester of " );
    t_8 = GF_NAME__FUNC;
    C_ELM_LIST_FPL( t_9, l_extra, l_i )
    t_7 = CALL_1ARGS( t_8, t_9 );
    CHECK_FUNC_RESULT( t_7 )
-   C_NEW_STRING( t_8, 25, "with non-standard setter\n" );
+   t_8 = MakeString( "with non-standard setter\n" );
    CALL_3ARGS( t_5, t_6, t_7, t_8 );
    
    /* ResetFilterObj( obj, Tester( extra[i] ) ); */
@@ -4163,7 +4161,7 @@ static Obj  HdlrFunc1 (
  CALL_1ARGS( t_1, t_2 );
  
  /* Subtype := "defined below"; */
- C_NEW_STRING( t_1, 13, "defined below" );
+ t_1 = MakeString( "defined below" );
  AssGVar( G_Subtype, t_1 );
  
  /* DS_TYPE_CACHE := ShareSpecialObj( [  ] ); */
@@ -4199,7 +4197,7 @@ static Obj  HdlrFunc1 (
       return family;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "NEW_FAMILY" );
+ t_2 = MakeString( "NEW_FAMILY" );
  t_3 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4214,7 +4212,7 @@ static Obj  HdlrFunc1 (
       return NEW_FAMILY( typeOfFamilies, name, EMPTY_FLAGS, EMPTY_FLAGS );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "NewFamily2" );
+ t_2 = MakeString( "NewFamily2" );
  t_3 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4229,7 +4227,7 @@ static Obj  HdlrFunc1 (
       return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), EMPTY_FLAGS );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "NewFamily3" );
+ t_2 = MakeString( "NewFamily3" );
  t_3 = NewFunction( NameFunc[7], NargFunc[7], NamsFunc[7], HdlrFunc7 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4244,7 +4242,7 @@ static Obj  HdlrFunc1 (
       return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "NewFamily4" );
+ t_2 = MakeString( "NewFamily4" );
  t_3 = NewFunction( NameFunc[8], NargFunc[8], NamsFunc[8], HdlrFunc8 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4259,7 +4257,7 @@ static Obj  HdlrFunc1 (
       return NEW_FAMILY( Subtype( typeOfFamilies, filter ), name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "NewFamily5" );
+ t_2 = MakeString( "NewFamily5" );
  t_3 = NewFunction( NameFunc[9], NargFunc[9], NamsFunc[9], HdlrFunc9 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4285,7 +4283,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 9, "NewFamily" );
+ t_2 = MakeString( "NewFamily" );
  t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4383,7 +4381,7 @@ static Obj  HdlrFunc1 (
       return type;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "NEW_TYPE" );
+ t_2 = MakeString( "NEW_TYPE" );
  t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4398,7 +4396,7 @@ static Obj  HdlrFunc1 (
       return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail, fail );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "NewType3" );
+ t_2 = MakeString( "NewType3" );
  t_3 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4413,7 +4411,7 @@ static Obj  HdlrFunc1 (
       return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, fail );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "NewType4" );
+ t_2 = MakeString( "NewType4" );
  t_3 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4439,7 +4437,7 @@ static Obj  HdlrFunc1 (
       return type;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 7, "NewType" );
+ t_2 = MakeString( "NewType" );
  t_3 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4454,7 +4452,7 @@ static Obj  HdlrFunc1 (
       return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![POS_DATA_TYPE], type );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "Subtype2" );
+ t_2 = MakeString( "Subtype2" );
  t_3 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4469,7 +4467,7 @@ static Obj  HdlrFunc1 (
       return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "Subtype3" );
+ t_2 = MakeString( "Subtype3" );
  t_3 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4498,7 +4496,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 7, "Subtype" );
+ t_2 = MakeString( "Subtype" );
  t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4513,7 +4511,7 @@ static Obj  HdlrFunc1 (
       return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![POS_DATA_TYPE], type );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "SupType2" );
+ t_2 = MakeString( "SupType2" );
  t_3 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4528,7 +4526,7 @@ static Obj  HdlrFunc1 (
       return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "SupType3" );
+ t_2 = MakeString( "SupType3" );
  t_3 = NewFunction( NameFunc[19], NargFunc[19], NamsFunc[19], HdlrFunc19 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4551,7 +4549,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 7, "SupType" );
+ t_2 = MakeString( "SupType" );
  t_3 = NewFunction( NameFunc[20], NargFunc[20], NamsFunc[20], HdlrFunc20 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4566,7 +4564,7 @@ static Obj  HdlrFunc1 (
       return K![1];
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "FamilyType" );
+ t_2 = MakeString( "FamilyType" );
  t_3 = NewFunction( NameFunc[21], NargFunc[21], NamsFunc[21], HdlrFunc21 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4581,7 +4579,7 @@ static Obj  HdlrFunc1 (
       return K![2];
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 9, "FlagsType" );
+ t_2 = MakeString( "FlagsType" );
  t_3 = NewFunction( NameFunc[22], NargFunc[22], NamsFunc[22], HdlrFunc22 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4596,7 +4594,7 @@ static Obj  HdlrFunc1 (
       return K![POS_DATA_TYPE];
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "DataType" );
+ t_2 = MakeString( "DataType" );
  t_3 = NewFunction( NameFunc[23], NargFunc[23], NamsFunc[23], HdlrFunc23 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4608,11 +4606,11 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetDataType", function ( K, data )
-      StrictBindOnce( K, POS_DATA_TYPE, MakeLiteral( data ) );
+      StrictBindOnce( K, POS_DATA_TYPE, MakeImmutable( data ) );
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 11, "SetDataType" );
+ t_2 = MakeString( "SetDataType" );
  t_3 = NewFunction( NameFunc[24], NargFunc[24], NamsFunc[24], HdlrFunc24 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4625,14 +4623,14 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "TypeObj", TYPE_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 7, "TypeObj" );
+ t_2 = MakeString( "TypeObj" );
  t_3 = GC_TYPE__OBJ;
  CHECK_BOUND( t_3, "TYPE_OBJ" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FamilyObj", FAMILY_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 9, "FamilyObj" );
+ t_2 = MakeString( "FamilyObj" );
  t_3 = GC_FAMILY__OBJ;
  CHECK_BOUND( t_3, "FAMILY_OBJ" )
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -4641,7 +4639,7 @@ static Obj  HdlrFunc1 (
       return FlagsType( TypeObj( obj ) );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "FlagsObj" );
+ t_2 = MakeString( "FlagsObj" );
  t_3 = NewFunction( NameFunc[25], NargFunc[25], NamsFunc[25], HdlrFunc25 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4656,7 +4654,7 @@ static Obj  HdlrFunc1 (
       return DataType( TypeObj( obj ) );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 7, "DataObj" );
+ t_2 = MakeString( "DataObj" );
  t_3 = NewFunction( NameFunc[26], NargFunc[26], NamsFunc[26], HdlrFunc26 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4682,7 +4680,7 @@ static Obj  HdlrFunc1 (
       return obj;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "SetTypeObj" );
+ t_2 = MakeString( "SetTypeObj" );
  t_3 = NewFunction( NameFunc[27], NargFunc[27], NamsFunc[27], HdlrFunc27 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4695,7 +4693,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "IsNonAtomicComponentObjectRepFlags", FLAGS_FILTER( IsNonAtomicComponentObjectRep ) ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 34, "IsNonAtomicComponentObjectRepFlags" );
+ t_2 = MakeString( "IsNonAtomicComponentObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsNonAtomicComponentObjectRep;
  CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" )
@@ -4705,7 +4703,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "IsAtomicPositionalObjectRepFlags", FLAGS_FILTER( IsAtomicPositionalObjectRep ) ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 32, "IsAtomicPositionalObjectRepFlags" );
+ t_2 = MakeString( "IsAtomicPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAtomicPositionalObjectRep;
  CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" )
@@ -4715,7 +4713,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "IsReadOnlyPositionalObjectRepFlags", FLAGS_FILTER( IsReadOnlyPositionalObjectRep ) ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 34, "IsReadOnlyPositionalObjectRepFlags" );
+ t_2 = MakeString( "IsReadOnlyPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsReadOnlyPositionalObjectRep;
  CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" )
@@ -4753,7 +4751,7 @@ static Obj  HdlrFunc1 (
       return obj;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 9, "Objectify" );
+ t_2 = MakeString( "Objectify" );
  t_3 = NewFunction( NameFunc[28], NargFunc[28], NamsFunc[28], HdlrFunc28 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4781,7 +4779,7 @@ static Obj  HdlrFunc1 (
       return obj;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 13, "ChangeTypeObj" );
+ t_2 = MakeString( "ChangeTypeObj" );
  t_3 = NewFunction( NameFunc[29], NargFunc[29], NamsFunc[29], HdlrFunc29 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4794,7 +4792,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "ReObjectify", ChangeTypeObj ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 11, "ReObjectify" );
+ t_2 = MakeString( "ReObjectify" );
  t_3 = GC_ChangeTypeObj;
  CHECK_BOUND( t_3, "ChangeTypeObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -4839,7 +4837,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 12, "SetFilterObj" );
+ t_2 = MakeString( "SetFilterObj" );
  t_3 = NewFunction( NameFunc[30], NargFunc[30], NamsFunc[30], HdlrFunc30 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4852,7 +4850,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "SET_FILTER_OBJ", SetFilterObj ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 14, "SET_FILTER_OBJ" );
+ t_2 = MakeString( "SET_FILTER_OBJ" );
  t_3 = GC_SetFilterObj;
  CHECK_BOUND( t_3, "SetFilterObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -4881,7 +4879,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 14, "ResetFilterObj" );
+ t_2 = MakeString( "ResetFilterObj" );
  t_3 = NewFunction( NameFunc[31], NargFunc[31], NamsFunc[31], HdlrFunc31 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4894,7 +4892,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "RESET_FILTER_OBJ", ResetFilterObj ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 16, "RESET_FILTER_OBJ" );
+ t_2 = MakeString( "RESET_FILTER_OBJ" );
  t_3 = GC_ResetFilterObj;
  CHECK_BOUND( t_3, "ResetFilterObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -4908,7 +4906,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 13, "SetFeatureObj" );
+ t_2 = MakeString( "SetFeatureObj" );
  t_3 = NewFunction( NameFunc[32], NargFunc[32], NamsFunc[32], HdlrFunc32 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4961,7 +4959,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 21, "SetMultipleAttributes" );
+ t_2 = MakeString( "SetMultipleAttributes" );
  t_3 = NewFunction( NameFunc[33], NargFunc[33], NamsFunc[33], HdlrFunc33 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4974,7 +4972,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 26, "IsAttributeStoringRepFlags" );
+ t_2 = MakeString( "IsAttributeStoringRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAttributeStoringRep;
  CHECK_BOUND( t_5, "IsAttributeStoringRep" )
@@ -4984,14 +4982,14 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "INFO_OWA", Ignore ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "INFO_OWA" );
+ t_2 = MakeString( "INFO_OWA" );
  t_3 = GC_Ignore;
  CHECK_BOUND( t_3, "Ignore" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* MAKE_READ_WRITE_GLOBAL( "INFO_OWA" ); */
  t_1 = GF_MAKE__READ__WRITE__GLOBAL;
- C_NEW_STRING( t_2, 8, "INFO_OWA" );
+ t_2 = MakeString( "INFO_OWA" );
  CALL_1ARGS( t_1, t_2 );
  
  /* BIND_GLOBAL( "ObjectifyWithAttributes", function ( arg... )
@@ -5040,7 +5038,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 23, "ObjectifyWithAttributes" );
+ t_2 = MakeString( "ObjectifyWithAttributes" );
  t_3 = NewFunction( NameFunc[34], NargFunc[34], NamsFunc[34], HdlrFunc34 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -5160,7 +5158,6 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "Subtype3", &GF_Subtype3 );
  InitFopyGVar( "SupType2", &GF_SupType2 );
  InitFopyGVar( "SupType3", &GF_SupType3 );
- InitFopyGVar( "MakeLiteral", &GF_MakeLiteral );
  InitFopyGVar( "FlagsType", &GF_FlagsType );
  InitFopyGVar( "TypeObj", &GF_TypeObj );
  InitFopyGVar( "DataType", &GF_DataType );
@@ -5187,76 +5184,76 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "Objectify", &GF_Objectify );
  
  /* information for the functions */
- InitGlobalBag( &DefaultName, "GAPROOT/lib/type1.g:DefaultName(-64414770)" );
- InitGlobalBag( &FileName, "GAPROOT/lib/type1.g:FileName(-64414770)" );
- InitHandlerFunc( HdlrFunc1, "GAPROOT/lib/type1.g:HdlrFunc1(-64414770)" );
- InitGlobalBag( &(NameFunc[1]), "GAPROOT/lib/type1.g:NameFunc[1](-64414770)" );
- InitHandlerFunc( HdlrFunc2, "GAPROOT/lib/type1.g:HdlrFunc2(-64414770)" );
- InitGlobalBag( &(NameFunc[2]), "GAPROOT/lib/type1.g:NameFunc[2](-64414770)" );
- InitHandlerFunc( HdlrFunc3, "GAPROOT/lib/type1.g:HdlrFunc3(-64414770)" );
- InitGlobalBag( &(NameFunc[3]), "GAPROOT/lib/type1.g:NameFunc[3](-64414770)" );
- InitHandlerFunc( HdlrFunc4, "GAPROOT/lib/type1.g:HdlrFunc4(-64414770)" );
- InitGlobalBag( &(NameFunc[4]), "GAPROOT/lib/type1.g:NameFunc[4](-64414770)" );
- InitHandlerFunc( HdlrFunc5, "GAPROOT/lib/type1.g:HdlrFunc5(-64414770)" );
- InitGlobalBag( &(NameFunc[5]), "GAPROOT/lib/type1.g:NameFunc[5](-64414770)" );
- InitHandlerFunc( HdlrFunc6, "GAPROOT/lib/type1.g:HdlrFunc6(-64414770)" );
- InitGlobalBag( &(NameFunc[6]), "GAPROOT/lib/type1.g:NameFunc[6](-64414770)" );
- InitHandlerFunc( HdlrFunc7, "GAPROOT/lib/type1.g:HdlrFunc7(-64414770)" );
- InitGlobalBag( &(NameFunc[7]), "GAPROOT/lib/type1.g:NameFunc[7](-64414770)" );
- InitHandlerFunc( HdlrFunc8, "GAPROOT/lib/type1.g:HdlrFunc8(-64414770)" );
- InitGlobalBag( &(NameFunc[8]), "GAPROOT/lib/type1.g:NameFunc[8](-64414770)" );
- InitHandlerFunc( HdlrFunc9, "GAPROOT/lib/type1.g:HdlrFunc9(-64414770)" );
- InitGlobalBag( &(NameFunc[9]), "GAPROOT/lib/type1.g:NameFunc[9](-64414770)" );
- InitHandlerFunc( HdlrFunc10, "GAPROOT/lib/type1.g:HdlrFunc10(-64414770)" );
- InitGlobalBag( &(NameFunc[10]), "GAPROOT/lib/type1.g:NameFunc[10](-64414770)" );
- InitHandlerFunc( HdlrFunc11, "GAPROOT/lib/type1.g:HdlrFunc11(-64414770)" );
- InitGlobalBag( &(NameFunc[11]), "GAPROOT/lib/type1.g:NameFunc[11](-64414770)" );
- InitHandlerFunc( HdlrFunc12, "GAPROOT/lib/type1.g:HdlrFunc12(-64414770)" );
- InitGlobalBag( &(NameFunc[12]), "GAPROOT/lib/type1.g:NameFunc[12](-64414770)" );
- InitHandlerFunc( HdlrFunc13, "GAPROOT/lib/type1.g:HdlrFunc13(-64414770)" );
- InitGlobalBag( &(NameFunc[13]), "GAPROOT/lib/type1.g:NameFunc[13](-64414770)" );
- InitHandlerFunc( HdlrFunc14, "GAPROOT/lib/type1.g:HdlrFunc14(-64414770)" );
- InitGlobalBag( &(NameFunc[14]), "GAPROOT/lib/type1.g:NameFunc[14](-64414770)" );
- InitHandlerFunc( HdlrFunc15, "GAPROOT/lib/type1.g:HdlrFunc15(-64414770)" );
- InitGlobalBag( &(NameFunc[15]), "GAPROOT/lib/type1.g:NameFunc[15](-64414770)" );
- InitHandlerFunc( HdlrFunc16, "GAPROOT/lib/type1.g:HdlrFunc16(-64414770)" );
- InitGlobalBag( &(NameFunc[16]), "GAPROOT/lib/type1.g:NameFunc[16](-64414770)" );
- InitHandlerFunc( HdlrFunc17, "GAPROOT/lib/type1.g:HdlrFunc17(-64414770)" );
- InitGlobalBag( &(NameFunc[17]), "GAPROOT/lib/type1.g:NameFunc[17](-64414770)" );
- InitHandlerFunc( HdlrFunc18, "GAPROOT/lib/type1.g:HdlrFunc18(-64414770)" );
- InitGlobalBag( &(NameFunc[18]), "GAPROOT/lib/type1.g:NameFunc[18](-64414770)" );
- InitHandlerFunc( HdlrFunc19, "GAPROOT/lib/type1.g:HdlrFunc19(-64414770)" );
- InitGlobalBag( &(NameFunc[19]), "GAPROOT/lib/type1.g:NameFunc[19](-64414770)" );
- InitHandlerFunc( HdlrFunc20, "GAPROOT/lib/type1.g:HdlrFunc20(-64414770)" );
- InitGlobalBag( &(NameFunc[20]), "GAPROOT/lib/type1.g:NameFunc[20](-64414770)" );
- InitHandlerFunc( HdlrFunc21, "GAPROOT/lib/type1.g:HdlrFunc21(-64414770)" );
- InitGlobalBag( &(NameFunc[21]), "GAPROOT/lib/type1.g:NameFunc[21](-64414770)" );
- InitHandlerFunc( HdlrFunc22, "GAPROOT/lib/type1.g:HdlrFunc22(-64414770)" );
- InitGlobalBag( &(NameFunc[22]), "GAPROOT/lib/type1.g:NameFunc[22](-64414770)" );
- InitHandlerFunc( HdlrFunc23, "GAPROOT/lib/type1.g:HdlrFunc23(-64414770)" );
- InitGlobalBag( &(NameFunc[23]), "GAPROOT/lib/type1.g:NameFunc[23](-64414770)" );
- InitHandlerFunc( HdlrFunc24, "GAPROOT/lib/type1.g:HdlrFunc24(-64414770)" );
- InitGlobalBag( &(NameFunc[24]), "GAPROOT/lib/type1.g:NameFunc[24](-64414770)" );
- InitHandlerFunc( HdlrFunc25, "GAPROOT/lib/type1.g:HdlrFunc25(-64414770)" );
- InitGlobalBag( &(NameFunc[25]), "GAPROOT/lib/type1.g:NameFunc[25](-64414770)" );
- InitHandlerFunc( HdlrFunc26, "GAPROOT/lib/type1.g:HdlrFunc26(-64414770)" );
- InitGlobalBag( &(NameFunc[26]), "GAPROOT/lib/type1.g:NameFunc[26](-64414770)" );
- InitHandlerFunc( HdlrFunc27, "GAPROOT/lib/type1.g:HdlrFunc27(-64414770)" );
- InitGlobalBag( &(NameFunc[27]), "GAPROOT/lib/type1.g:NameFunc[27](-64414770)" );
- InitHandlerFunc( HdlrFunc28, "GAPROOT/lib/type1.g:HdlrFunc28(-64414770)" );
- InitGlobalBag( &(NameFunc[28]), "GAPROOT/lib/type1.g:NameFunc[28](-64414770)" );
- InitHandlerFunc( HdlrFunc29, "GAPROOT/lib/type1.g:HdlrFunc29(-64414770)" );
- InitGlobalBag( &(NameFunc[29]), "GAPROOT/lib/type1.g:NameFunc[29](-64414770)" );
- InitHandlerFunc( HdlrFunc30, "GAPROOT/lib/type1.g:HdlrFunc30(-64414770)" );
- InitGlobalBag( &(NameFunc[30]), "GAPROOT/lib/type1.g:NameFunc[30](-64414770)" );
- InitHandlerFunc( HdlrFunc31, "GAPROOT/lib/type1.g:HdlrFunc31(-64414770)" );
- InitGlobalBag( &(NameFunc[31]), "GAPROOT/lib/type1.g:NameFunc[31](-64414770)" );
- InitHandlerFunc( HdlrFunc32, "GAPROOT/lib/type1.g:HdlrFunc32(-64414770)" );
- InitGlobalBag( &(NameFunc[32]), "GAPROOT/lib/type1.g:NameFunc[32](-64414770)" );
- InitHandlerFunc( HdlrFunc33, "GAPROOT/lib/type1.g:HdlrFunc33(-64414770)" );
- InitGlobalBag( &(NameFunc[33]), "GAPROOT/lib/type1.g:NameFunc[33](-64414770)" );
- InitHandlerFunc( HdlrFunc34, "GAPROOT/lib/type1.g:HdlrFunc34(-64414770)" );
- InitGlobalBag( &(NameFunc[34]), "GAPROOT/lib/type1.g:NameFunc[34](-64414770)" );
+ InitGlobalBag( &DefaultName, "GAPROOT/lib/type1.g:DefaultName(-132653476)" );
+ InitGlobalBag( &FileName, "GAPROOT/lib/type1.g:FileName(-132653476)" );
+ InitHandlerFunc( HdlrFunc1, "GAPROOT/lib/type1.g:HdlrFunc1(-132653476)" );
+ InitGlobalBag( &(NameFunc[1]), "GAPROOT/lib/type1.g:NameFunc[1](-132653476)" );
+ InitHandlerFunc( HdlrFunc2, "GAPROOT/lib/type1.g:HdlrFunc2(-132653476)" );
+ InitGlobalBag( &(NameFunc[2]), "GAPROOT/lib/type1.g:NameFunc[2](-132653476)" );
+ InitHandlerFunc( HdlrFunc3, "GAPROOT/lib/type1.g:HdlrFunc3(-132653476)" );
+ InitGlobalBag( &(NameFunc[3]), "GAPROOT/lib/type1.g:NameFunc[3](-132653476)" );
+ InitHandlerFunc( HdlrFunc4, "GAPROOT/lib/type1.g:HdlrFunc4(-132653476)" );
+ InitGlobalBag( &(NameFunc[4]), "GAPROOT/lib/type1.g:NameFunc[4](-132653476)" );
+ InitHandlerFunc( HdlrFunc5, "GAPROOT/lib/type1.g:HdlrFunc5(-132653476)" );
+ InitGlobalBag( &(NameFunc[5]), "GAPROOT/lib/type1.g:NameFunc[5](-132653476)" );
+ InitHandlerFunc( HdlrFunc6, "GAPROOT/lib/type1.g:HdlrFunc6(-132653476)" );
+ InitGlobalBag( &(NameFunc[6]), "GAPROOT/lib/type1.g:NameFunc[6](-132653476)" );
+ InitHandlerFunc( HdlrFunc7, "GAPROOT/lib/type1.g:HdlrFunc7(-132653476)" );
+ InitGlobalBag( &(NameFunc[7]), "GAPROOT/lib/type1.g:NameFunc[7](-132653476)" );
+ InitHandlerFunc( HdlrFunc8, "GAPROOT/lib/type1.g:HdlrFunc8(-132653476)" );
+ InitGlobalBag( &(NameFunc[8]), "GAPROOT/lib/type1.g:NameFunc[8](-132653476)" );
+ InitHandlerFunc( HdlrFunc9, "GAPROOT/lib/type1.g:HdlrFunc9(-132653476)" );
+ InitGlobalBag( &(NameFunc[9]), "GAPROOT/lib/type1.g:NameFunc[9](-132653476)" );
+ InitHandlerFunc( HdlrFunc10, "GAPROOT/lib/type1.g:HdlrFunc10(-132653476)" );
+ InitGlobalBag( &(NameFunc[10]), "GAPROOT/lib/type1.g:NameFunc[10](-132653476)" );
+ InitHandlerFunc( HdlrFunc11, "GAPROOT/lib/type1.g:HdlrFunc11(-132653476)" );
+ InitGlobalBag( &(NameFunc[11]), "GAPROOT/lib/type1.g:NameFunc[11](-132653476)" );
+ InitHandlerFunc( HdlrFunc12, "GAPROOT/lib/type1.g:HdlrFunc12(-132653476)" );
+ InitGlobalBag( &(NameFunc[12]), "GAPROOT/lib/type1.g:NameFunc[12](-132653476)" );
+ InitHandlerFunc( HdlrFunc13, "GAPROOT/lib/type1.g:HdlrFunc13(-132653476)" );
+ InitGlobalBag( &(NameFunc[13]), "GAPROOT/lib/type1.g:NameFunc[13](-132653476)" );
+ InitHandlerFunc( HdlrFunc14, "GAPROOT/lib/type1.g:HdlrFunc14(-132653476)" );
+ InitGlobalBag( &(NameFunc[14]), "GAPROOT/lib/type1.g:NameFunc[14](-132653476)" );
+ InitHandlerFunc( HdlrFunc15, "GAPROOT/lib/type1.g:HdlrFunc15(-132653476)" );
+ InitGlobalBag( &(NameFunc[15]), "GAPROOT/lib/type1.g:NameFunc[15](-132653476)" );
+ InitHandlerFunc( HdlrFunc16, "GAPROOT/lib/type1.g:HdlrFunc16(-132653476)" );
+ InitGlobalBag( &(NameFunc[16]), "GAPROOT/lib/type1.g:NameFunc[16](-132653476)" );
+ InitHandlerFunc( HdlrFunc17, "GAPROOT/lib/type1.g:HdlrFunc17(-132653476)" );
+ InitGlobalBag( &(NameFunc[17]), "GAPROOT/lib/type1.g:NameFunc[17](-132653476)" );
+ InitHandlerFunc( HdlrFunc18, "GAPROOT/lib/type1.g:HdlrFunc18(-132653476)" );
+ InitGlobalBag( &(NameFunc[18]), "GAPROOT/lib/type1.g:NameFunc[18](-132653476)" );
+ InitHandlerFunc( HdlrFunc19, "GAPROOT/lib/type1.g:HdlrFunc19(-132653476)" );
+ InitGlobalBag( &(NameFunc[19]), "GAPROOT/lib/type1.g:NameFunc[19](-132653476)" );
+ InitHandlerFunc( HdlrFunc20, "GAPROOT/lib/type1.g:HdlrFunc20(-132653476)" );
+ InitGlobalBag( &(NameFunc[20]), "GAPROOT/lib/type1.g:NameFunc[20](-132653476)" );
+ InitHandlerFunc( HdlrFunc21, "GAPROOT/lib/type1.g:HdlrFunc21(-132653476)" );
+ InitGlobalBag( &(NameFunc[21]), "GAPROOT/lib/type1.g:NameFunc[21](-132653476)" );
+ InitHandlerFunc( HdlrFunc22, "GAPROOT/lib/type1.g:HdlrFunc22(-132653476)" );
+ InitGlobalBag( &(NameFunc[22]), "GAPROOT/lib/type1.g:NameFunc[22](-132653476)" );
+ InitHandlerFunc( HdlrFunc23, "GAPROOT/lib/type1.g:HdlrFunc23(-132653476)" );
+ InitGlobalBag( &(NameFunc[23]), "GAPROOT/lib/type1.g:NameFunc[23](-132653476)" );
+ InitHandlerFunc( HdlrFunc24, "GAPROOT/lib/type1.g:HdlrFunc24(-132653476)" );
+ InitGlobalBag( &(NameFunc[24]), "GAPROOT/lib/type1.g:NameFunc[24](-132653476)" );
+ InitHandlerFunc( HdlrFunc25, "GAPROOT/lib/type1.g:HdlrFunc25(-132653476)" );
+ InitGlobalBag( &(NameFunc[25]), "GAPROOT/lib/type1.g:NameFunc[25](-132653476)" );
+ InitHandlerFunc( HdlrFunc26, "GAPROOT/lib/type1.g:HdlrFunc26(-132653476)" );
+ InitGlobalBag( &(NameFunc[26]), "GAPROOT/lib/type1.g:NameFunc[26](-132653476)" );
+ InitHandlerFunc( HdlrFunc27, "GAPROOT/lib/type1.g:HdlrFunc27(-132653476)" );
+ InitGlobalBag( &(NameFunc[27]), "GAPROOT/lib/type1.g:NameFunc[27](-132653476)" );
+ InitHandlerFunc( HdlrFunc28, "GAPROOT/lib/type1.g:HdlrFunc28(-132653476)" );
+ InitGlobalBag( &(NameFunc[28]), "GAPROOT/lib/type1.g:NameFunc[28](-132653476)" );
+ InitHandlerFunc( HdlrFunc29, "GAPROOT/lib/type1.g:HdlrFunc29(-132653476)" );
+ InitGlobalBag( &(NameFunc[29]), "GAPROOT/lib/type1.g:NameFunc[29](-132653476)" );
+ InitHandlerFunc( HdlrFunc30, "GAPROOT/lib/type1.g:HdlrFunc30(-132653476)" );
+ InitGlobalBag( &(NameFunc[30]), "GAPROOT/lib/type1.g:NameFunc[30](-132653476)" );
+ InitHandlerFunc( HdlrFunc31, "GAPROOT/lib/type1.g:HdlrFunc31(-132653476)" );
+ InitGlobalBag( &(NameFunc[31]), "GAPROOT/lib/type1.g:NameFunc[31](-132653476)" );
+ InitHandlerFunc( HdlrFunc32, "GAPROOT/lib/type1.g:HdlrFunc32(-132653476)" );
+ InitGlobalBag( &(NameFunc[32]), "GAPROOT/lib/type1.g:NameFunc[32](-132653476)" );
+ InitHandlerFunc( HdlrFunc33, "GAPROOT/lib/type1.g:HdlrFunc33(-132653476)" );
+ InitGlobalBag( &(NameFunc[33]), "GAPROOT/lib/type1.g:NameFunc[33](-132653476)" );
+ InitHandlerFunc( HdlrFunc34, "GAPROOT/lib/type1.g:HdlrFunc34(-132653476)" );
+ InitGlobalBag( &(NameFunc[34]), "GAPROOT/lib/type1.g:NameFunc[34](-132653476)" );
  
  /* return success */
  return 0;
@@ -5363,7 +5360,6 @@ static Int InitLibrary ( StructInitInfo * module )
  G_Subtype3 = GVarName( "Subtype3" );
  G_SupType2 = GVarName( "SupType2" );
  G_SupType3 = GVarName( "SupType3" );
- G_MakeLiteral = GVarName( "MakeLiteral" );
  G_FlagsType = GVarName( "FlagsType" );
  G_TypeObj = GVarName( "TypeObj" );
  G_DataType = GVarName( "DataType" );
@@ -5396,8 +5392,8 @@ static Int InitLibrary ( StructInitInfo * module )
  R_HASH__SIZE = RNamName( "HASH_SIZE" );
  
  /* information for the functions */
- C_NEW_STRING( DefaultName, 14, "local function" );
- C_NEW_STRING( FileName, 19, "GAPROOT/lib/type1.g" );
+ DefaultName = MakeString( "local function" );
+ FileName = MakeString( "GAPROOT/lib/type1.g" );
  NameFunc[1] = DefaultName;
  NamsFunc[1] = 0;
  NargFunc[1] = 0;
@@ -5610,7 +5606,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_Subtype3 = GVarName( "Subtype3" );
  G_SupType2 = GVarName( "SupType2" );
  G_SupType3 = GVarName( "SupType3" );
- G_MakeLiteral = GVarName( "MakeLiteral" );
  G_FlagsType = GVarName( "FlagsType" );
  G_TypeObj = GVarName( "TypeObj" );
  G_DataType = GVarName( "DataType" );
@@ -5759,7 +5754,7 @@ static StructInitInfo module = {
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,
  /* version     = */ 0,
- /* crc         = */ -64414770,
+ /* crc         = */ -132653476,
  /* initKernel  = */ InitKernel,
  /* initLibrary = */ InitLibrary,
  /* checkInit   = */ 0,

--- a/src/c_filter1.c
+++ b/src/c_filter1.c
@@ -488,7 +488,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 15, "CLEAR_IMP_CACHE" );
+ t_2 = MakeString( "CLEAR_IMP_CACHE" );
  t_3 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -535,7 +535,7 @@ static Obj  HdlrFunc1 (
       return with;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 15, "WITH_IMPS_FLAGS" );
+ t_2 = MakeString( "WITH_IMPS_FLAGS" );
  t_3 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -564,7 +564,7 @@ static Obj  HdlrFunc1 (
       return rank;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "RankFilter" );
+ t_2 = MakeString( "RankFilter" );
  t_3 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -657,8 +657,8 @@ static Int InitLibrary ( StructInitInfo * module )
  /* record names used in handlers */
  
  /* information for the functions */
- C_NEW_STRING( DefaultName, 14, "local function" );
- C_NEW_STRING( FileName, 21, "GAPROOT/lib/filter1.g" );
+ DefaultName = MakeString( "local function" );
+ FileName = MakeString( "GAPROOT/lib/filter1.g" );
  NameFunc[1] = DefaultName;
  NamsFunc[1] = 0;
  NargFunc[1] = 0;

--- a/src/c_methsel1.c
+++ b/src/c_methsel1.c
@@ -1096,7 +1096,7 @@ static Obj  HdlrFunc9 (
  
  /* Error( "not supported yet" ); */
  t_1 = GF_Error;
- C_NEW_STRING( t_2, 17, "not supported yet" );
+ t_2 = MakeString( "not supported yet" );
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
@@ -2265,7 +2265,7 @@ static Obj  HdlrFunc17 (
  
  /* Error( "not supported yet" ); */
  t_1 = GF_Error;
- C_NEW_STRING( t_2, 17, "not supported yet" );
+ t_2 = MakeString( "not supported yet" );
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
@@ -2461,7 +2461,7 @@ static Obj  HdlrFunc18 (
  
  /* Error( "No applicable method found for attribute" ); */
  t_1 = GF_Error;
- C_NEW_STRING( t_2, 40, "No applicable method found for attribute" );
+ t_2 = MakeString( "No applicable method found for attribute" );
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
@@ -3460,7 +3460,7 @@ static Obj  HdlrFunc26 (
  
  /* Error( "not supported yet" ); */
  t_1 = GF_Error;
- C_NEW_STRING( t_2, 17, "not supported yet" );
+ t_2 = MakeString( "not supported yet" );
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
@@ -4616,7 +4616,7 @@ static Obj  HdlrFunc34 (
  
  /* Error( "not supported yet" ); */
  t_1 = GF_Error;
- C_NEW_STRING( t_2, 17, "not supported yet" );
+ t_2 = MakeString( "not supported yet" );
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
@@ -5534,8 +5534,8 @@ static Int InitLibrary ( StructInitInfo * module )
  /* record names used in handlers */
  
  /* information for the functions */
- C_NEW_STRING( DefaultName, 14, "local function" );
- C_NEW_STRING( FileName, 22, "GAPROOT/lib/methsel1.g" );
+ DefaultName = MakeString( "local function" );
+ FileName = MakeString( "GAPROOT/lib/methsel1.g" );
  NameFunc[1] = DefaultName;
  NamsFunc[1] = 0;
  NargFunc[1] = 0;

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -404,14 +404,14 @@ static Obj  HdlrFunc2 (
        
        /* Print( "#I  immediate: ", NAME_FUNC( imm[i + 1] ), "\n" ); */
        t_9 = GF_Print;
-       C_NEW_STRING( t_10, 15, "#I  immediate: " );
+       t_10 = MakeString( "#I  immediate: " );
        t_12 = GF_NAME__FUNC;
        C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
        CHECK_INT_POS( t_14 )
        C_ELM_LIST_FPL( t_13, l_imm, t_14 )
        t_11 = CALL_1ARGS( t_12, t_13 );
        CHECK_FUNC_RESULT( t_11 )
-       C_NEW_STRING( t_12, 1, "\n" );
+       t_12 = MakeString( "\n" );
        CALL_3ARGS( t_9, t_10, t_11, t_12 );
        
       }
@@ -421,18 +421,18 @@ static Obj  HdlrFunc2 (
        
        /* Print( "#I  immediate: ", NAME_FUNC( imm[i + 1] ), ": ", imm[i + 7], "\n" ); */
        t_9 = GF_Print;
-       C_NEW_STRING( t_10, 15, "#I  immediate: " );
+       t_10 = MakeString( "#I  immediate: " );
        t_12 = GF_NAME__FUNC;
        C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
        CHECK_INT_POS( t_14 )
        C_ELM_LIST_FPL( t_13, l_imm, t_14 )
        t_11 = CALL_1ARGS( t_12, t_13 );
        CHECK_FUNC_RESULT( t_11 )
-       C_NEW_STRING( t_12, 2, ": " );
+       t_12 = MakeString( ": " );
        C_SUM_FIA( t_14, l_i, INTOBJ_INT(7) )
        CHECK_INT_POS( t_14 )
        C_ELM_LIST_FPL( t_13, l_imm, t_14 )
-       C_NEW_STRING( t_14, 1, "\n" );
+       t_14 = MakeString( "\n" );
        CALL_5ARGS( t_9, t_10, t_11, t_12, t_13, t_14 );
        
       }
@@ -681,7 +681,7 @@ static Obj  HdlrFunc3 (
   
   /* APPEND_LIST_INTR( k, ": " ); */
   t_1 = GF_APPEND__LIST__INTR;
-  C_NEW_STRING( t_2, 2, ": " );
+  t_2 = MakeString( ": " );
   CALL_2ARGS( t_1, l_k, t_2 );
   
   /* APPEND_LIST_INTR( k, info ); */
@@ -947,8 +947,8 @@ static Obj  HdlrFunc3 (
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
       CHECK_FUNC_RESULT( t_2 )
-      C_NEW_STRING( t_3, 23, ": <famrel> must accept " );
-      C_NEW_STRING( t_4, 10, " arguments" );
+      t_3 = MakeString( ": <famrel> must accept " );
+      t_4 = MakeString( " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
       
      }
@@ -972,7 +972,7 @@ static Obj  HdlrFunc3 (
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
     CHECK_FUNC_RESULT( t_2 )
-    C_NEW_STRING( t_3, 49, ": <famrel> must be a function, `true', or `false'" );
+    t_3 = MakeString( ": <famrel> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
    }
@@ -1084,8 +1084,8 @@ static Obj  HdlrFunc3 (
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
       CHECK_FUNC_RESULT( t_2 )
-      C_NEW_STRING( t_3, 23, ": <method> must accept " );
-      C_NEW_STRING( t_4, 10, " arguments" );
+      t_3 = MakeString( ": <method> must accept " );
+      t_4 = MakeString( " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
       
      }
@@ -1110,7 +1110,7 @@ static Obj  HdlrFunc3 (
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
     CHECK_FUNC_RESULT( t_2 )
-    C_NEW_STRING( t_3, 49, ": <method> must be a function, `true', or `false'" );
+    t_3 = MakeString( ": <method> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
    }
@@ -1267,7 +1267,7 @@ static Obj  HdlrFunc6 (
   
   /* Error( "too few arguments given in <arglist>" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 36, "too few arguments given in <arglist>" );
+  t_2 = MakeString( "too few arguments given in <arglist>" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -1288,7 +1288,7 @@ static Obj  HdlrFunc6 (
   
   /* Error( "<opr> is not an operation" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 25, "<opr> is not an operation" );
+  t_2 = MakeString( "<opr> is not an operation" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -1381,8 +1381,8 @@ static Obj  HdlrFunc6 (
   
   /* Error( "<arglist>[", pos, "] must be a list of filters" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 10, "<arglist>[" );
-  C_NEW_STRING( t_3, 27, "] must be a list of filters" );
+  t_2 = MakeString( "<arglist>[" );
+  t_3 = MakeString( "] must be a list of filters" );
   CALL_3ARGS( t_1, t_2, l_pos, t_3 );
   
  }
@@ -1404,11 +1404,11 @@ static Obj  HdlrFunc6 (
   
   /* Error( "methods can have at most ", GAPInfo.MaxNrArgsMethod, " arguments" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 25, "methods can have at most " );
+  t_2 = MakeString( "methods can have at most " );
   t_4 = GC_GAPInfo;
   CHECK_BOUND( t_4, "GAPInfo" )
   t_3 = ELM_REC( t_4, R_MaxNrArgsMethod );
-  C_NEW_STRING( t_4, 10, " arguments" );
+  t_4 = MakeString( " arguments" );
   CALL_3ARGS( t_1, t_2, t_3, t_4 );
   
  }
@@ -1422,7 +1422,7 @@ static Obj  HdlrFunc6 (
  if ( t_1 ) {
   
   /* info1 := "[ "; */
-  C_NEW_STRING( t_1, 2, "[ " );
+  t_1 = MakeString( "[ " );
   l_info1 = t_1;
   
   /* isstr := true; */
@@ -1455,7 +1455,7 @@ static Obj  HdlrFunc6 (
     
     /* APPEND_LIST_INTR( info1, ", " ); */
     t_3 = GF_APPEND__LIST__INTR;
-    C_NEW_STRING( t_4, 2, ", " );
+    t_4 = MakeString( ", " );
     CALL_2ARGS( t_3, l_info1, t_4 );
     
     /* filters[i] := EvalString( filters[i] ); */
@@ -1477,7 +1477,7 @@ static Obj  HdlrFunc6 (
      
      /* Error( "string does not evaluate to a function" ); */
      t_3 = GF_Error;
-     C_NEW_STRING( t_4, 38, "string does not evaluate to a function" );
+     t_4 = MakeString( "string does not evaluate to a function" );
      CALL_1ARGS( t_3, t_4 );
      
     }
@@ -1588,7 +1588,7 @@ static Obj  HdlrFunc6 (
   
   /* Error( "the method is missing in <arglist>" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 34, "the method is missing in <arglist>" );
+  t_2 = MakeString( "the method is missing in <arglist>" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -1632,7 +1632,7 @@ static Obj  HdlrFunc6 (
   
   /* Error( "the method is missing in <arglist>" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 34, "the method is missing in <arglist>" );
+  t_2 = MakeString( "the method is missing in <arglist>" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -1688,7 +1688,7 @@ static Obj  HdlrFunc6 (
   t_3 = GF_NAME__FUNC;
   t_2 = CALL_1ARGS( t_3, l_opr );
   CHECK_FUNC_RESULT( t_2 )
-  C_NEW_STRING( t_3, 35, ": use `InstallTrueMethod' for <opr>" );
+  t_3 = MakeString( ": use `InstallTrueMethod' for <opr>" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
  }
@@ -1715,13 +1715,13 @@ static Obj  HdlrFunc6 (
    
    /* INFO_DEBUG( 1, "a method is installed for the wrapper operation ", NAME_FUNC( opr ), "\n", "#I  probably it should be installed for (one of) its\n", "#I  underlying operation(s)" ); */
    t_1 = GF_INFO__DEBUG;
-   C_NEW_STRING( t_2, 48, "a method is installed for the wrapper operation " );
+   t_2 = MakeString( "a method is installed for the wrapper operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
    CHECK_FUNC_RESULT( t_3 )
-   C_NEW_STRING( t_4, 1, "\n" );
-   C_NEW_STRING( t_5, 53, "#I  probably it should be installed for (one of) its\n" );
-   C_NEW_STRING( t_6, 27, "#I  underlying operation(s)" );
+   t_4 = MakeString( "\n" );
+   t_5 = MakeString( "#I  probably it should be installed for (one of) its\n" );
+   t_6 = MakeString( "#I  underlying operation(s)" );
    CALL_6ARGS( t_1, INTOBJ_INT(1), t_2, t_3, t_4, t_5, t_6 );
    
   }
@@ -1796,7 +1796,7 @@ static Obj  HdlrFunc6 (
    
    /* Error( "unknown operation ", NAME_FUNC( opr ) ); */
    t_1 = GF_Error;
-   C_NEW_STRING( t_2, 18, "unknown operation " );
+   t_2 = MakeString( "unknown operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
    CHECK_FUNC_RESULT( t_3 )
@@ -1954,7 +1954,7 @@ static Obj  HdlrFunc6 (
     
     /* Error( "the number of arguments does not match a declaration of ", NAME_FUNC( opr ) ); */
     t_1 = GF_Error;
-    C_NEW_STRING( t_2, 56, "the number of arguments does not match a declaration of " );
+    t_2 = MakeString( "the number of arguments does not match a declaration of " );
     t_4 = GF_NAME__FUNC;
     t_3 = CALL_1ARGS( t_4, l_opr );
     CHECK_FUNC_RESULT( t_3 )
@@ -1967,17 +1967,17 @@ static Obj  HdlrFunc6 (
     
     /* Error( "required filters ", NamesFilter( imp[notmatch] ), "\nfor ", Ordinal( notmatch ), " argument do not match a declaration of ", NAME_FUNC( opr ) ); */
     t_1 = GF_Error;
-    C_NEW_STRING( t_2, 17, "required filters " );
+    t_2 = MakeString( "required filters " );
     t_4 = GF_NamesFilter;
     CHECK_INT_POS( l_notmatch )
     C_ELM_LIST_FPL( t_5, l_imp, l_notmatch )
     t_3 = CALL_1ARGS( t_4, t_5 );
     CHECK_FUNC_RESULT( t_3 )
-    C_NEW_STRING( t_4, 5, "\nfor " );
+    t_4 = MakeString( "\nfor " );
     t_6 = GF_Ordinal;
     t_5 = CALL_1ARGS( t_6, l_notmatch );
     CHECK_FUNC_RESULT( t_5 )
-    C_NEW_STRING( t_6, 40, " argument do not match a declaration of " );
+    t_6 = MakeString( " argument do not match a declaration of " );
     t_8 = GF_NAME__FUNC;
     t_7 = CALL_1ARGS( t_8, l_opr );
     CHECK_FUNC_RESULT( t_7 )
@@ -2070,11 +2070,11 @@ static Obj  HdlrFunc6 (
       
       /* INFO_DEBUG( 1, "method installed for ", NAME_FUNC( opr ), " matches more than one declaration" ); */
       t_4 = GF_INFO__DEBUG;
-      C_NEW_STRING( t_5, 21, "method installed for " );
+      t_5 = MakeString( "method installed for " );
       t_7 = GF_NAME__FUNC;
       t_6 = CALL_1ARGS( t_7, l_opr );
       CHECK_FUNC_RESULT( t_6 )
-      C_NEW_STRING( t_7, 34, " matches more than one declaration" );
+      t_7 = MakeString( " matches more than one declaration" );
       CALL_4ARGS( t_4, INTOBJ_INT(1), t_5, t_6, t_7 );
       
      }
@@ -2428,7 +2428,7 @@ static Obj  HdlrFunc7 (
    t_1 = GF_InstallOtherMethod;
    t_2 = OBJ_LVAR( 1 );
    CHECK_BOUND( t_2, "getter" )
-   C_NEW_STRING( t_3, 59, "default method requiring categories and checking properties" );
+   t_3 = MakeString( "default method requiring categories and checking properties" );
    t_4 = True;
    t_5 = NEW_PLIST( T_PLIST, 1 );
    SET_LEN_PLIST( t_5, 1 );
@@ -2486,7 +2486,7 @@ static Obj  HdlrFunc9 (
  
  /* InstallOtherMethod( setter, "default method, does nothing", true, [ IS_OBJECT, IS_OBJECT ], 0, DO_NOTHING_SETTER ); */
  t_1 = GF_InstallOtherMethod;
- C_NEW_STRING( t_2, 28, "default method, does nothing" );
+ t_2 = MakeString( "default method, does nothing" );
  t_3 = True;
  t_4 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_4, 2 );
@@ -2638,7 +2638,7 @@ static Obj  HdlrFunc12 (
   t_1 = GF_Error;
   t_2 = OBJ_LVAR_1UP( 1 );
   CHECK_BOUND( t_2, "name" )
-  C_NEW_STRING( t_3, 21, ": <p> must be a prime" );
+  t_3 = MakeString( ": <p> must be a prime" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
  }
@@ -3015,7 +3015,7 @@ static Obj  HdlrFunc11 (
  /* if keytest = "prime" then */
  t_2 = OBJ_LVAR( 2 );
  CHECK_BOUND( t_2, "keytest" )
- C_NEW_STRING( t_3, 5, "prime" );
+ t_3 = MakeString( "prime" );
  t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
  if ( t_1 ) {
   
@@ -3048,7 +3048,7 @@ static Obj  HdlrFunc11 (
  
  /* APPEND_LIST_INTR( str, "Op" ); */
  t_1 = GF_APPEND__LIST__INTR;
- C_NEW_STRING( t_2, 2, "Op" );
+ t_2 = MakeString( "Op" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareOperation( str, [ domreq, keyreq ] ); */
@@ -3068,7 +3068,7 @@ static Obj  HdlrFunc11 (
  ASS_LVAR( 3, t_1 );
  
  /* str := "Computed"; */
- C_NEW_STRING( t_1, 8, "Computed" );
+ t_1 = MakeString( "Computed" );
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, name ); */
@@ -3079,12 +3079,12 @@ static Obj  HdlrFunc11 (
  
  /* APPEND_LIST_INTR( str, "s" ); */
  t_1 = GF_APPEND__LIST__INTR;
- C_NEW_STRING( t_2, 1, "s" );
+ t_2 = MakeString( "s" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareAttribute( str, domreq, "mutable" ); */
  t_1 = GF_DeclareAttribute;
- C_NEW_STRING( t_2, 7, "mutable" );
+ t_2 = MakeString( "mutable" );
  CALL_3ARGS( t_1, l_str, a_domreq, t_2 );
  
  /* attr := VALUE_GLOBAL( str ); */
@@ -3099,7 +3099,7 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallMethod;
  t_2 = OBJ_LVAR( 4 );
  CHECK_BOUND( t_2, "attr" )
- C_NEW_STRING( t_3, 14, "default method" );
+ t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_5, 1 );
@@ -3160,7 +3160,7 @@ static Obj  HdlrFunc11 (
  CHECK_BOUND( t_4, "name" )
  t_2 = CALL_1ARGS( t_3, t_4 );
  CHECK_FUNC_RESULT( t_2 )
- C_NEW_STRING( t_3, 14, "default method" );
+ t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_5, 2 );
@@ -3179,7 +3179,7 @@ static Obj  HdlrFunc11 (
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* str := "Has"; */
- C_NEW_STRING( t_1, 3, "Has" );
+ t_1 = MakeString( "Has" );
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, name ); */
@@ -3209,7 +3209,7 @@ static Obj  HdlrFunc11 (
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
  CHECK_FUNC_RESULT( t_2 )
- C_NEW_STRING( t_3, 14, "default method" );
+ t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_5, 2 );
@@ -3228,7 +3228,7 @@ static Obj  HdlrFunc11 (
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* str := "Set"; */
- C_NEW_STRING( t_1, 3, "Set" );
+ t_1 = MakeString( "Set" );
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, name ); */
@@ -3267,7 +3267,7 @@ static Obj  HdlrFunc11 (
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
  CHECK_FUNC_RESULT( t_2 )
- C_NEW_STRING( t_3, 14, "default method" );
+ t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_5, 3 );
@@ -3531,7 +3531,7 @@ static Obj  HdlrFunc17 (
   ASS_LVAR( 1, t_1 );
   
   /* info := " fallback method to test conditions"; */
-  C_NEW_STRING( t_1, 35, " fallback method to test conditions" );
+  t_1 = MakeString( " fallback method to test conditions" );
   l_info = t_1;
   
   /* fampred := arg[2]; */
@@ -3591,7 +3591,7 @@ static Obj  HdlrFunc17 (
    
    /* Error( "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" ); */
    t_1 = GF_Error;
-   C_NEW_STRING( t_2, 63, "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" );
+   t_2 = MakeString( "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" );
    CALL_1ARGS( t_1, t_2 );
    
   }
@@ -3753,7 +3753,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 19, "RunImmediateMethods" );
+ t_2 = MakeString( "RunImmediateMethods" );
  t_3 = NewFunction( NameFunc[2], NargFunc[2], NamsFunc[2], HdlrFunc2 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3850,7 +3850,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 20, "INSTALL_METHOD_FLAGS" );
+ t_2 = MakeString( "INSTALL_METHOD_FLAGS" );
  t_3 = NewFunction( NameFunc[3], NargFunc[3], NamsFunc[3], HdlrFunc3 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3866,7 +3866,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 13, "InstallMethod" );
+ t_2 = MakeString( "InstallMethod" );
  t_3 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3882,7 +3882,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 18, "InstallOtherMethod" );
+ t_2 = MakeString( "InstallOtherMethod" );
  t_3 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3895,7 +3895,7 @@ static Obj  HdlrFunc1 (
  
  /* DeclareGlobalFunction( "EvalString" ); */
  t_1 = GF_DeclareGlobalFunction;
- C_NEW_STRING( t_2, 10, "EvalString" );
+ t_2 = MakeString( "EvalString" );
  CALL_1ARGS( t_1, t_2 );
  
  /* Unbind( INSTALL_METHOD ); */
@@ -4040,7 +4040,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 14, "INSTALL_METHOD" );
+ t_2 = MakeString( "INSTALL_METHOD" );
  t_3 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4141,7 +4141,7 @@ static Obj  HdlrFunc1 (
       return k;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 26, "PositionSortedOddPositions" );
+ t_2 = MakeString( "PositionSortedOddPositions" );
  t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4153,7 +4153,7 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* IsPrimeInt := "2b defined"; */
- C_NEW_STRING( t_1, 10, "2b defined" );
+ t_1 = MakeString( "2b defined" );
  AssGVar( G_IsPrimeInt, t_1 );
  
  /* BIND_GLOBAL( "KeyDependentOperation", function ( name, domreq, keyreq, keytest )
@@ -4224,7 +4224,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 21, "KeyDependentOperation" );
+ t_2 = MakeString( "KeyDependentOperation" );
  t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4236,7 +4236,7 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* CallFuncList := "2b defined"; */
- C_NEW_STRING( t_1, 10, "2b defined" );
+ t_1 = MakeString( "2b defined" );
  AssGVar( G_CallFuncList, t_1 );
  
  /* BIND_GLOBAL( "RedispatchOnCondition", function ( arg... )
@@ -4276,7 +4276,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 21, "RedispatchOnCondition" );
+ t_2 = MakeString( "RedispatchOnCondition" );
  t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4291,7 +4291,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_InstallMethod;
  t_2 = GC_ViewObj;
  CHECK_BOUND( t_2, "ViewObj" )
- C_NEW_STRING( t_3, 31, "default method using `PrintObj'" );
+ t_3 = MakeString( "default method using `PrintObj'" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_5, 1 );
@@ -4526,8 +4526,8 @@ static Int InitLibrary ( StructInitInfo * module )
  R_MaxNrArgsMethod = RNamName( "MaxNrArgsMethod" );
  
  /* information for the functions */
- C_NEW_STRING( DefaultName, 14, "local function" );
- C_NEW_STRING( FileName, 19, "GAPROOT/lib/oper1.g" );
+ DefaultName = MakeString( "local function" );
+ FileName = MakeString( "GAPROOT/lib/oper1.g" );
  NameFunc[1] = DefaultName;
  NamsFunc[1] = 0;
  NargFunc[1] = 0;

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -238,7 +238,7 @@ static Obj  HdlrFunc2 (
  
  /* InstallOtherMethod( getter, "system getter", true, [ IsAttributeStoringRep and tester ], GETTER_FLAGS, GETTER_FUNCTION( name ) ); */
  t_1 = GF_InstallOtherMethod;
- C_NEW_STRING( t_2, 13, "system getter" );
+ t_2 = MakeString( "system getter" );
  t_3 = True;
  t_4 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_4, 1 );
@@ -362,7 +362,7 @@ static Obj  HdlrFunc3 (
       return;
   end ); */
   t_1 = GF_InstallOtherMethod;
-  C_NEW_STRING( t_2, 21, "system mutable setter" );
+  t_2 = MakeString( "system mutable setter" );
   t_3 = True;
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
@@ -391,7 +391,7 @@ static Obj  HdlrFunc3 (
   
   /* InstallOtherMethod( setter, "system setter", true, [ IsAttributeStoringRep, IS_OBJECT ], 0, SETTER_FUNCTION( name, tester ) ); */
   t_1 = GF_InstallOtherMethod;
-  C_NEW_STRING( t_2, 13, "system setter" );
+  t_2 = MakeString( "system setter" );
   t_3 = True;
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
@@ -916,7 +916,7 @@ static Obj  HdlrFunc10 (
      
      /* Error( "usage: NewFamily( <name>, [ <req> [, <imp> ]] )" ); */
      t_1 = GF_Error;
-     C_NEW_STRING( t_2, 47, "usage: NewFamily( <name>, [ <req> [, <imp> ]] )" );
+     t_2 = MakeString( "usage: NewFamily( <name>, [ <req> [, <imp> ]] )" );
      CALL_1ARGS( t_1, t_2 );
      
     }
@@ -1300,7 +1300,7 @@ static Obj  HdlrFunc11 (
   
   /* GASMAN( "collect" ); */
   t_1 = GF_GASMAN;
-  C_NEW_STRING( t_2, 7, "collect" );
+  t_2 = MakeString( "collect" );
   CALL_1ARGS( t_1, t_2 );
   
   /* FLUSH_ALL_METHOD_CACHES(  ); */
@@ -1715,7 +1715,7 @@ static Obj  HdlrFunc14 (
   
   /* Error( "<family> must be a family" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 25, "<family> must be a family" );
+  t_2 = MakeString( "<family> must be a family" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -1766,7 +1766,7 @@ static Obj  HdlrFunc14 (
    
    /* Error( "usage: NewType( <family>, <filter> [, <data> ] )" ); */
    t_1 = GF_Error;
-   C_NEW_STRING( t_2, 48, "usage: NewType( <family>, <filter> [, <data> ] )" );
+   t_2 = MakeString( "usage: NewType( <family>, <filter> [, <data> ] )" );
    CALL_1ARGS( t_1, t_2 );
    
   }
@@ -1924,7 +1924,7 @@ static Obj  HdlrFunc17 (
   
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 21, "<type> must be a type" );
+  t_2 = MakeString( "<type> must be a type" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -2106,7 +2106,7 @@ static Obj  HdlrFunc20 (
   
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 21, "<type> must be a type" );
+  t_2 = MakeString( "<type> must be a type" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -2370,7 +2370,7 @@ static Obj  HdlrFunc27 (
   
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 21, "<type> must be a type" );
+  t_2 = MakeString( "<type> must be a type" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -2464,7 +2464,7 @@ static Obj  HdlrFunc28 (
   
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 21, "<type> must be a type" );
+  t_2 = MakeString( "<type> must be a type" );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -2799,7 +2799,7 @@ static Obj  HdlrFunc29 (
         
         /* Error( "cannot set filter for internal object" ); */
         t_1 = GF_Error;
-        C_NEW_STRING( t_2, 37, "cannot set filter for internal object" );
+        t_2 = MakeString( "cannot set filter for internal object" );
         CALL_1ARGS( t_1, t_2 );
         
        }
@@ -2851,7 +2851,7 @@ static Obj  HdlrFunc30 (
   
   /* Error( "You can't reset an \"and-filter\". Reset components individually." ); */
   t_1 = GF_Error;
-  C_NEW_STRING( t_2, 63, "You can't reset an \"and-filter\". Reset components individually." );
+  t_2 = MakeString( "You can't reset an \"and-filter\". Reset components individually." );
   CALL_1ARGS( t_1, t_2 );
   
  }
@@ -2984,7 +2984,7 @@ static Obj  HdlrFunc30 (
         
         /* Error( "cannot reset filter for internal object" ); */
         t_1 = GF_Error;
-        C_NEW_STRING( t_2, 39, "cannot reset filter for internal object" );
+        t_2 = MakeString( "cannot reset filter for internal object" );
         CALL_1ARGS( t_1, t_2 );
         
        }
@@ -3509,8 +3509,8 @@ static Obj  HdlrFunc33 (
   
   /* INFO_OWA( "#W ObjectifyWithAttributes called ", "for non-attribute storing rep\n" ); */
   t_1 = GF_INFO__OWA;
-  C_NEW_STRING( t_2, 34, "#W ObjectifyWithAttributes called " );
-  C_NEW_STRING( t_3, 30, "for non-attribute storing rep\n" );
+  t_2 = MakeString( "#W ObjectifyWithAttributes called " );
+  t_3 = MakeString( "for non-attribute storing rep\n" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
   /* Objectify( type, obj ); */
@@ -3757,12 +3757,12 @@ static Obj  HdlrFunc33 (
    
    /* INFO_OWA( "#W  Supplied type has tester of ", NAME_FUNC( extra[i] ), "with non-standard setter\n" ); */
    t_5 = GF_INFO__OWA;
-   C_NEW_STRING( t_6, 32, "#W  Supplied type has tester of " );
+   t_6 = MakeString( "#W  Supplied type has tester of " );
    t_8 = GF_NAME__FUNC;
    C_ELM_LIST_FPL( t_9, l_extra, l_i )
    t_7 = CALL_1ARGS( t_8, t_9 );
    CHECK_FUNC_RESULT( t_7 )
-   C_NEW_STRING( t_8, 25, "with non-standard setter\n" );
+   t_8 = MakeString( "with non-standard setter\n" );
    CALL_3ARGS( t_5, t_6, t_7, t_8 );
    
    /* ResetFilterObj( obj, Tester( extra[i] ) ); */
@@ -3863,7 +3863,7 @@ static Obj  HdlrFunc1 (
  CALL_1ARGS( t_1, t_2 );
  
  /* Subtype := "defined below"; */
- C_NEW_STRING( t_1, 13, "defined below" );
+ t_1 = MakeString( "defined below" );
  AssGVar( G_Subtype, t_1 );
  
  /* BIND_GLOBAL( "NEW_FAMILY", function ( typeOfFamilies, name, req_filter, imp_filter )
@@ -3889,7 +3889,7 @@ static Obj  HdlrFunc1 (
       return family;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "NEW_FAMILY" );
+ t_2 = MakeString( "NEW_FAMILY" );
  t_3 = NewFunction( NameFunc[5], NargFunc[5], NamsFunc[5], HdlrFunc5 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3904,7 +3904,7 @@ static Obj  HdlrFunc1 (
       return NEW_FAMILY( typeOfFamilies, name, EMPTY_FLAGS, EMPTY_FLAGS );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "NewFamily2" );
+ t_2 = MakeString( "NewFamily2" );
  t_3 = NewFunction( NameFunc[6], NargFunc[6], NamsFunc[6], HdlrFunc6 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3919,7 +3919,7 @@ static Obj  HdlrFunc1 (
       return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), EMPTY_FLAGS );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "NewFamily3" );
+ t_2 = MakeString( "NewFamily3" );
  t_3 = NewFunction( NameFunc[7], NargFunc[7], NamsFunc[7], HdlrFunc7 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3934,7 +3934,7 @@ static Obj  HdlrFunc1 (
       return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "NewFamily4" );
+ t_2 = MakeString( "NewFamily4" );
  t_3 = NewFunction( NameFunc[8], NargFunc[8], NamsFunc[8], HdlrFunc8 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3949,7 +3949,7 @@ static Obj  HdlrFunc1 (
       return NEW_FAMILY( Subtype( typeOfFamilies, filter ), name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "NewFamily5" );
+ t_2 = MakeString( "NewFamily5" );
  t_3 = NewFunction( NameFunc[9], NargFunc[9], NamsFunc[9], HdlrFunc9 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -3975,7 +3975,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 9, "NewFamily" );
+ t_2 = MakeString( "NewFamily" );
  t_3 = NewFunction( NameFunc[10], NargFunc[10], NamsFunc[10], HdlrFunc10 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4068,7 +4068,7 @@ static Obj  HdlrFunc1 (
       return type;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "NEW_TYPE" );
+ t_2 = MakeString( "NEW_TYPE" );
  t_3 = NewFunction( NameFunc[11], NargFunc[11], NamsFunc[11], HdlrFunc11 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4083,7 +4083,7 @@ static Obj  HdlrFunc1 (
       return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail, fail );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "NewType3" );
+ t_2 = MakeString( "NewType3" );
  t_3 = NewFunction( NameFunc[12], NargFunc[12], NamsFunc[12], HdlrFunc12 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4098,7 +4098,7 @@ static Obj  HdlrFunc1 (
       return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, fail );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "NewType4" );
+ t_2 = MakeString( "NewType4" );
  t_3 = NewFunction( NameFunc[13], NargFunc[13], NamsFunc[13], HdlrFunc13 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4124,7 +4124,7 @@ static Obj  HdlrFunc1 (
       return type;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 7, "NewType" );
+ t_2 = MakeString( "NewType" );
  t_3 = NewFunction( NameFunc[14], NargFunc[14], NamsFunc[14], HdlrFunc14 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4139,7 +4139,7 @@ static Obj  HdlrFunc1 (
       return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![POS_DATA_TYPE], type );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "Subtype2" );
+ t_2 = MakeString( "Subtype2" );
  t_3 = NewFunction( NameFunc[15], NargFunc[15], NamsFunc[15], HdlrFunc15 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4154,7 +4154,7 @@ static Obj  HdlrFunc1 (
       return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "Subtype3" );
+ t_2 = MakeString( "Subtype3" );
  t_3 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4180,7 +4180,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 7, "Subtype" );
+ t_2 = MakeString( "Subtype" );
  t_3 = NewFunction( NameFunc[17], NargFunc[17], NamsFunc[17], HdlrFunc17 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4195,7 +4195,7 @@ static Obj  HdlrFunc1 (
       return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![POS_DATA_TYPE], type );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "SupType2" );
+ t_2 = MakeString( "SupType2" );
  t_3 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4210,7 +4210,7 @@ static Obj  HdlrFunc1 (
       return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "SupType3" );
+ t_2 = MakeString( "SupType3" );
  t_3 = NewFunction( NameFunc[19], NargFunc[19], NamsFunc[19], HdlrFunc19 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4233,7 +4233,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 7, "SupType" );
+ t_2 = MakeString( "SupType" );
  t_3 = NewFunction( NameFunc[20], NargFunc[20], NamsFunc[20], HdlrFunc20 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4248,7 +4248,7 @@ static Obj  HdlrFunc1 (
       return K![1];
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "FamilyType" );
+ t_2 = MakeString( "FamilyType" );
  t_3 = NewFunction( NameFunc[21], NargFunc[21], NamsFunc[21], HdlrFunc21 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4263,7 +4263,7 @@ static Obj  HdlrFunc1 (
       return K![2];
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 9, "FlagsType" );
+ t_2 = MakeString( "FlagsType" );
  t_3 = NewFunction( NameFunc[22], NargFunc[22], NamsFunc[22], HdlrFunc22 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4278,7 +4278,7 @@ static Obj  HdlrFunc1 (
       return K![POS_DATA_TYPE];
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "DataType" );
+ t_2 = MakeString( "DataType" );
  t_3 = NewFunction( NameFunc[23], NargFunc[23], NamsFunc[23], HdlrFunc23 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4294,7 +4294,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 11, "SetDataType" );
+ t_2 = MakeString( "SetDataType" );
  t_3 = NewFunction( NameFunc[24], NargFunc[24], NamsFunc[24], HdlrFunc24 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4307,14 +4307,14 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "TypeObj", TYPE_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 7, "TypeObj" );
+ t_2 = MakeString( "TypeObj" );
  t_3 = GC_TYPE__OBJ;
  CHECK_BOUND( t_3, "TYPE_OBJ" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FamilyObj", FAMILY_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 9, "FamilyObj" );
+ t_2 = MakeString( "FamilyObj" );
  t_3 = GC_FAMILY__OBJ;
  CHECK_BOUND( t_3, "FAMILY_OBJ" )
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -4323,7 +4323,7 @@ static Obj  HdlrFunc1 (
       return FlagsType( TypeObj( obj ) );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "FlagsObj" );
+ t_2 = MakeString( "FlagsObj" );
  t_3 = NewFunction( NameFunc[25], NargFunc[25], NamsFunc[25], HdlrFunc25 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4338,7 +4338,7 @@ static Obj  HdlrFunc1 (
       return DataType( TypeObj( obj ) );
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 7, "DataObj" );
+ t_2 = MakeString( "DataObj" );
  t_3 = NewFunction( NameFunc[26], NargFunc[26], NamsFunc[26], HdlrFunc26 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4364,7 +4364,7 @@ static Obj  HdlrFunc1 (
       return obj;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 10, "SetTypeObj" );
+ t_2 = MakeString( "SetTypeObj" );
  t_3 = NewFunction( NameFunc[27], NargFunc[27], NamsFunc[27], HdlrFunc27 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4377,7 +4377,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "IsNonAtomicComponentObjectRepFlags", FLAGS_FILTER( IsNonAtomicComponentObjectRep ) ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 34, "IsNonAtomicComponentObjectRepFlags" );
+ t_2 = MakeString( "IsNonAtomicComponentObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsNonAtomicComponentObjectRep;
  CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" )
@@ -4387,7 +4387,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "IsAtomicPositionalObjectRepFlags", FLAGS_FILTER( IsAtomicPositionalObjectRep ) ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 32, "IsAtomicPositionalObjectRepFlags" );
+ t_2 = MakeString( "IsAtomicPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAtomicPositionalObjectRep;
  CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" )
@@ -4397,7 +4397,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "IsReadOnlyPositionalObjectRepFlags", FLAGS_FILTER( IsReadOnlyPositionalObjectRep ) ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 34, "IsReadOnlyPositionalObjectRepFlags" );
+ t_2 = MakeString( "IsReadOnlyPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsReadOnlyPositionalObjectRep;
  CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" )
@@ -4407,7 +4407,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "Objectify", SetTypeObj ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 9, "Objectify" );
+ t_2 = MakeString( "Objectify" );
  t_3 = GC_SetTypeObj;
  CHECK_BOUND( t_3, "SetTypeObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -4429,7 +4429,7 @@ static Obj  HdlrFunc1 (
       return obj;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 13, "ChangeTypeObj" );
+ t_2 = MakeString( "ChangeTypeObj" );
  t_3 = NewFunction( NameFunc[28], NargFunc[28], NamsFunc[28], HdlrFunc28 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4442,7 +4442,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "ReObjectify", ChangeTypeObj ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 11, "ReObjectify" );
+ t_2 = MakeString( "ReObjectify" );
  t_3 = GC_ChangeTypeObj;
  CHECK_BOUND( t_3, "ChangeTypeObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -4487,7 +4487,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 12, "SetFilterObj" );
+ t_2 = MakeString( "SetFilterObj" );
  t_3 = NewFunction( NameFunc[29], NargFunc[29], NamsFunc[29], HdlrFunc29 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4500,7 +4500,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "SET_FILTER_OBJ", SetFilterObj ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 14, "SET_FILTER_OBJ" );
+ t_2 = MakeString( "SET_FILTER_OBJ" );
  t_3 = GC_SetFilterObj;
  CHECK_BOUND( t_3, "SetFilterObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -4529,7 +4529,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 14, "ResetFilterObj" );
+ t_2 = MakeString( "ResetFilterObj" );
  t_3 = NewFunction( NameFunc[30], NargFunc[30], NamsFunc[30], HdlrFunc30 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4542,7 +4542,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "RESET_FILTER_OBJ", ResetFilterObj ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 16, "RESET_FILTER_OBJ" );
+ t_2 = MakeString( "RESET_FILTER_OBJ" );
  t_3 = GC_ResetFilterObj;
  CHECK_BOUND( t_3, "ResetFilterObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -4556,7 +4556,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 13, "SetFeatureObj" );
+ t_2 = MakeString( "SetFeatureObj" );
  t_3 = NewFunction( NameFunc[31], NargFunc[31], NamsFunc[31], HdlrFunc31 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4609,7 +4609,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 21, "SetMultipleAttributes" );
+ t_2 = MakeString( "SetMultipleAttributes" );
  t_3 = NewFunction( NameFunc[32], NargFunc[32], NamsFunc[32], HdlrFunc32 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4622,7 +4622,7 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 26, "IsAttributeStoringRepFlags" );
+ t_2 = MakeString( "IsAttributeStoringRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAttributeStoringRep;
  CHECK_BOUND( t_5, "IsAttributeStoringRep" )
@@ -4632,14 +4632,14 @@ static Obj  HdlrFunc1 (
  
  /* BIND_GLOBAL( "INFO_OWA", Ignore ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 8, "INFO_OWA" );
+ t_2 = MakeString( "INFO_OWA" );
  t_3 = GC_Ignore;
  CHECK_BOUND( t_3, "Ignore" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* MAKE_READ_WRITE_GLOBAL( "INFO_OWA" ); */
  t_1 = GF_MAKE__READ__WRITE__GLOBAL;
- C_NEW_STRING( t_2, 8, "INFO_OWA" );
+ t_2 = MakeString( "INFO_OWA" );
  CALL_1ARGS( t_1, t_2 );
  
  /* BIND_GLOBAL( "ObjectifyWithAttributes", function ( arg... )
@@ -4688,7 +4688,7 @@ static Obj  HdlrFunc1 (
       return;
   end ); */
  t_1 = GF_BIND__GLOBAL;
- C_NEW_STRING( t_2, 23, "ObjectifyWithAttributes" );
+ t_2 = MakeString( "ObjectifyWithAttributes" );
  t_3 = NewFunction( NameFunc[33], NargFunc[33], NamsFunc[33], HdlrFunc33 );
  ENVI_FUNC( t_3 ) = STATE(CurrLVars);
  t_4 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -5003,8 +5003,8 @@ static Int InitLibrary ( StructInitInfo * module )
  R_HASH__SIZE = RNamName( "HASH_SIZE" );
  
  /* information for the functions */
- C_NEW_STRING( DefaultName, 14, "local function" );
- C_NEW_STRING( FileName, 19, "GAPROOT/lib/type1.g" );
+ DefaultName = MakeString( "local function" );
+ FileName = MakeString( "GAPROOT/lib/type1.g" );
  NameFunc[1] = DefaultName;
  NamsFunc[1] = 0;
  NargFunc[1] = 0;

--- a/src/calls.c
+++ b/src/calls.c
@@ -1995,7 +1995,7 @@ Obj FuncHandlerCookieOfFunction(Obj self, Obj func)
     narg = 7;
   hdlr = HDLR_FUNC(func, narg);
   cookie = CookieOfHandler(hdlr);
-  C_NEW_STRING_DYN(cookieStr, cookie);
+  cookieStr = MakeString(cookie);
   return cookieStr;
 }
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2730,12 +2730,10 @@ CVar CompStringExpr (
     string = CVAR_TEMP( NewTemp( "string" ) );
 
     /* create the string and copy the stuff                                */
-    Emit( "C_NEW_STRING( %c, %d, \"%C\" );\n",
-
+    Emit( "%c = MakeString( \"%C\" );\n",
           /* the sizeof(UInt) offset is to get past the length of the string
              which is now stored in the front of the literal */
-          string, SIZE_EXPR(expr)-1-sizeof(UInt),
-          sizeof(UInt)+ (Char*)ADDR_EXPR(expr) );
+          string, sizeof(UInt)+ (Char*)ADDR_EXPR(expr) );
 
     /* we know that the result is a list                                   */
     SetInfoCVar( string, W_LIST );
@@ -5726,13 +5724,12 @@ Int CompileFunc (
         }
     }
     Emit( "\n/* information for the functions */\n" );
-    Emit( "C_NEW_STRING( DefaultName, 14, \"local function\" );\n" );
-    Emit( "C_NEW_STRING( FileName, %d, \"%s\" );\n", strlen(magic2), magic2 );
+    Emit( "DefaultName = MakeString( \"local function\" );\n" );
+    Emit( "FileName = MakeString( \"%s\" );\n", magic2 );
     for ( i = 1; i <= CompFunctionsNr; i++ ) {
         n = NAME_FUNC(ELM_PLIST(CompFunctions,i));
         if ( n != 0 && IsStringConv(n) ) {
-            Emit( "C_NEW_STRING( NameFunc[%d], %d, \"%S\" );\n",
-                  i, strlen(CSTR_STRING(n)), CSTR_STRING(n) );
+            Emit( "NameFunc[%d] = MakeString(\"%S\");\n", i, CSTR_STRING(n) );
         }
         else {
             Emit( "NameFunc[%d] = DefaultName;\n", i );

--- a/src/costab.c
+++ b/src/costab.c
@@ -208,7 +208,7 @@ static void CompressDeductionList ( void )
     }
 
     /* run through the lists and compress them                             */
-    ptTable = &(ELM_PLIST(objTable,1)) - 1;
+    ptTable = BASE_PTR_PLIST(objTable) - 1;
     j = 0;
     for ( i = dedfst; i < dedlst; i++ ) {
         if ( INT_INTOBJ(ELM_PLIST(ptTable[dedgen[i]],dedcos[i])) > 0
@@ -262,9 +262,9 @@ static void HandleCoinc (
     if ( cos1 == cos2 )  return;
 
     /* get some pointers                                                   */
-    ptTable = &(ELM_PLIST(objTable,1)) - 1;
-    ptNext  = &(ELM_PLIST(objNext,1)) - 1;
-    ptPrev  = &(ELM_PLIST(objPrev,1)) - 1;
+    ptTable = BASE_PTR_PLIST(objTable) - 1;
+    ptNext = BASE_PTR_PLIST(objNext) - 1;
+    ptPrev = BASE_PTR_PLIST(objPrev) - 1;
 
     /* take the smaller one as new representative                          */
     if ( cos2 < cos1 ) { c3 = cos1;  cos1 = cos2;  cos2 = c3;  }
@@ -294,9 +294,9 @@ static void HandleCoinc (
         /* replace <firstCoinc> by its representative in the table         */
         cos1 = INT_INTOBJ( ptPrev[firstCoinc] );  cos2 = firstCoinc;
         for ( i = 1; i <= LEN_PLIST(objTable); i++ ) {
-            gen = &(ELM_PLIST(ptTable[i],1)) - 1;
+            gen = BASE_PTR_PLIST(ptTable[i]) - 1;
             /* inv = ADDR_OBJ(ptTable[ ((i-1)^1)+1 ] ); */
-            inv = &(ELM_PLIST( ptTable[ i + 2*(i % 2) - 1 ], 1 ) ) - 1;
+            inv = BASE_PTR_PLIST(ptTable[i + 2 * (i % 2) - 1]) - 1;
 
             /* replace <cos2> by <cos1> in the column of <gen>^-1          */
             c2 = INT_INTOBJ( gen[cos2] );
@@ -458,9 +458,9 @@ Obj FuncMakeConsequences (
         for ( i = LEN_LIST( hdSubs ); 1 <= i; i-- ) {
           if ( ELM_PLIST( hdSubs, i ) != 0 ) {
             objNums = ELM_PLIST( ELM_PLIST( hdSubs, i ), 1 );
-            ptNums  = &(ELM_PLIST(objNums,1)) - 1;
+            ptNums = BASE_PTR_PLIST(objNums) - 1;
             objRel  = ELM_PLIST( ELM_PLIST( hdSubs, i ), 2 );
-            ptRel   = &(ELM_PLIST(objRel,1)) - 1;
+            ptRel = BASE_PTR_PLIST(objRel) - 1;
 
             lp = 2;
             lc = 1;
@@ -519,9 +519,9 @@ Obj FuncMakeConsequences (
         objRels = ELM_PLIST( ELM_PLIST( list, 4 ), dedgen[dedfst] );
         for ( i = 1; i <= LEN_LIST( objRels ); i++ ) {
             objNums = ELM_PLIST( ELM_PLIST(objRels,i), 1 );
-            ptNums  = &(ELM_PLIST(objNums,1)) - 1;
+            ptNums = BASE_PTR_PLIST(objNums) - 1;
             objRel  = ELM_PLIST( ELM_PLIST(objRels,i), 2 );
-            ptRel   = &(ELM_PLIST(objRel,1)) - 1;
+            ptRel = BASE_PTR_PLIST(objRel) - 1;
 
             lp = INT_INTOBJ( ELM_PLIST( ELM_PLIST(objRels,i), 3 ) );
             lc = dedcos[ dedfst ];
@@ -640,9 +640,9 @@ Obj FuncMakeConsequencesPres (
         objRels = ELM_PLIST( ELM_PLIST( list, 6 ), gen );
         for ( i = 1; i <= LEN_LIST( objRels ); i++ ) {
             objNums = ELM_PLIST( ELM_PLIST(objRels,i), 1 );
-            ptNums  = &(ELM_PLIST(objNums,1)) - 1;
+            ptNums = BASE_PTR_PLIST(objNums) - 1;
             objRel  = ELM_PLIST( ELM_PLIST(objRels,i), 2 );
-            ptRel   = &(ELM_PLIST(objRel,1)) - 1;
+            ptRel = BASE_PTR_PLIST(objRel) - 1;
 
             lp = INT_INTOBJ( ELM_PLIST( ELM_PLIST(objRels,i), 3 ) );
             lc = coset;
@@ -727,7 +727,7 @@ Obj FuncStandardizeTableC (
                    (Int)TNAM_OBJ(objTable), 0L );
         return 0;
     }
-    ptTable  = &(ELM_PLIST(objTable,1)) - 1;
+    ptTable = BASE_PTR_PLIST(objTable) - 1;
     nrgen    = LEN_PLIST(objTable) / 2;
     for ( j = 1;  j <= nrgen*2;  j++ ) {
         if ( ! IS_PLIST(ptTable[j]) ) {
@@ -755,7 +755,7 @@ Obj FuncStandardizeTableC (
         /* scan through all columns of acos                                */
         for ( j = 1;  j <= nloop;  j++ ) {
             k = ( nloop == nrgen ) ? 2*j - 1 : j;
-            g = &(ELM_PLIST(ptTable[k],1)) - 1;
+            g = BASE_PTR_PLIST(ptTable[k]) - 1;
 
             /* if we haven't seen this coset yet                           */
             if ( lcos+1 < INT_INTOBJ( g[acos] ) ) {
@@ -764,8 +764,8 @@ Obj FuncStandardizeTableC (
                 lcos = lcos + 1;
                 mcos = INT_INTOBJ( g[acos] );
                 for ( k = 1;  k <= nrgen;  k++ ) {
-                    h = &(ELM_PLIST(ptTable[2*k-1],1)) - 1;
-                    i = &(ELM_PLIST(ptTable[2*k],1)) - 1;
+                    h = BASE_PTR_PLIST(ptTable[2 * k - 1]) - 1;
+                    i = BASE_PTR_PLIST(ptTable[2 * k]) - 1;
                     c1 = INT_INTOBJ( h[lcos] );
                     c2 = INT_INTOBJ( h[mcos] );
                     if ( c1 != 0 )  i[c1] = INTOBJ_INT( mcos );
@@ -832,7 +832,7 @@ static void InitializeCosetFactorWord ( void )
 
     /* handle the abelianized case                                         */
     else if ( treeType == 0 ) {
-        ptWord = &(ELM_PLIST(objTree2,1)) - 1;
+        ptWord = BASE_PTR_PLIST(objTree2) - 1;
         for ( i = 1;  i <= treeWordLength;  i++ ) {
             ptWord[i] = INTOBJ_INT(0);
         }
@@ -880,15 +880,15 @@ static Int TreeEntryC ( void )
     Int                 uabs, vabs;     /* generator values                */
 
     /*  Get the tree components                                            */
-    ptTree1  = &(ELM_PLIST(objTree1,1)) - 1;
-    ptTree2  = &(ELM_PLIST(objTree2,1)) - 1;
+    ptTree1 = BASE_PTR_PLIST(objTree1) - 1;
+    ptTree2 = BASE_PTR_PLIST(objTree2) - 1;
     treesize = LEN_PLIST(objTree1);
     numgens  = INT_INTOBJ( ELM_PLIST( objTree, 3 ) );
 
     /* handle the abelianized case                                         */
     if ( treeType == 0 )
     {
-        ptWord = &(ELM_PLIST(objTree2,1)) - 1;
+        ptWord = BASE_PTR_PLIST(objTree2) - 1;
         for ( leng = treeWordLength;  leng >= 1;  leng-- ) {
             if ( ptWord[leng] != INTOBJ_INT(0) )  {
                 break;
@@ -912,7 +912,7 @@ static Int TreeEntryC ( void )
             }
         }
         for ( k = 1; k <= numgens; k++ ) {
-            ptFac = &(ELM_PLIST(ptTree1[k],1)) - 1;
+            ptFac = BASE_PTR_PLIST(ptTree1[k]) - 1;
             if ( LEN_PLIST(ptTree1[k]) == leng ) {
                 for ( i = 1;  i <= leng;  i++ ) {
                     if ( ptFac[i] != ptWord[i] )  {
@@ -942,8 +942,8 @@ static Int TreeEntryC ( void )
         CHANGED_BAG(objTree1);
 
         /* copy the word to the new bag                                    */
-        ptWord = &(ELM_PLIST(objTree2,1)) - 1;
-        ptNew  = &(ELM_PLIST(objNew,1)) - 1;
+        ptWord = BASE_PTR_PLIST(objTree2) - 1;
+        ptNew = BASE_PTR_PLIST(objNew) - 1;
         while ( leng > 0 ) {
             ptNew[leng] = ptWord[leng];
             leng--;
@@ -1032,8 +1032,8 @@ static Int TreeEntryC ( void )
                     treesize = 2 * treesize;
                     GROW_PLIST( objTree1, treesize );
                     GROW_PLIST( objTree2, treesize );
-                    ptTree1 = &(ELM_PLIST(objTree1,1)) - 1;
-                    ptTree2 = &(ELM_PLIST(objTree2,1)) - 1;
+                    ptTree1 = BASE_PTR_PLIST(objTree1) - 1;
+                    ptTree2 = BASE_PTR_PLIST(objTree2) - 1;
                     SET_LEN_PLIST( objTree1, treesize );
                     SET_LEN_PLIST( objTree2, treesize );
                     CHANGED_BAG(objTree);
@@ -1075,10 +1075,10 @@ static void AddCosetFactor2 (
 
     /* handle the abelianized case                                         */
     if ( treeType == 0 ) {
-        ptWord = &(ELM_PLIST(objTree2,1)) - 1;
+        ptWord = BASE_PTR_PLIST(objTree2) - 1;
         if ( factor > 0 ) {
             tmp   = ELM_PLIST( objTree1, factor );
-            ptFac = &(ELM_PLIST(tmp,1)) - 1;
+            ptFac = BASE_PTR_PLIST(tmp) - 1;
             leng  = LEN_PLIST(tmp);
             for ( i = 1;  i <= leng;  i++ ) {
                 if ( ! SUM_INTOBJS( sum, ptWord[i], ptFac[i] ) ) {
@@ -1093,7 +1093,7 @@ static void AddCosetFactor2 (
         else
         {
             tmp   = ELM_PLIST( objTree1, -factor );
-            ptFac = &(ELM_PLIST(tmp,1)) - 1;
+            ptFac = BASE_PTR_PLIST(tmp) - 1;
             leng  = LEN_PLIST(tmp);
             for ( i = 1;  i <= leng;  i++ ) {
                 if ( ! DIFF_INTOBJS( sum, ptWord[i], ptFac[i] ) ) {
@@ -1175,7 +1175,7 @@ Obj FuncApplyRel2 (
                    (Int) LEN_PLIST(app), 0L );
         return 0;
     }
-    ptApp = &(ELM_PLIST(app,1)) - 1;
+    ptApp = BASE_PTR_PLIST(app) - 1;
 
     /* get the components of the proper application list                   */
     lp = INT_INTOBJ( ptApp[1] );
@@ -1266,7 +1266,7 @@ Obj FuncApplyRel2 (
             objTree  = ptApp[8];
             objTree1 = ELM_PLIST( objTree, 1 );
             objTree2 = ELM_PLIST( objTree, 2 );
-            ptTree   = &(ELM_PLIST(objTree,1)) - 1;
+            ptTree = BASE_PTR_PLIST(objTree) - 1;
             treeWordLength = INT_INTOBJ( ptTree[4] );
             if ( LEN_PLIST(objTree2) != treeWordLength ) {
                 ErrorQuit( "ApplyRel2: illegal word length", 0L, 0L );
@@ -1307,8 +1307,8 @@ Obj FuncApplyRel2 (
             }
 
             /* initialize some local variables                             */
-            ptWord  = &(ELM_PLIST(word,1)) - 1;
-            ptTree2 = &(ELM_PLIST(objTree2,1)) - 1;
+            ptWord = BASE_PTR_PLIST(word) - 1;
+            ptTree2 = BASE_PTR_PLIST(objTree2) - 1;
 
             /* copy the result to its destination, if necessary            */
             if ( ptWord != ptTree2 ) {
@@ -1336,10 +1336,10 @@ Obj FuncApplyRel2 (
             }
 
             /* initialize some local variables                             */
-            ptRel   = &(ELM_PLIST(objRel,1)) - 1;
-            ptNums  = &(ELM_PLIST(objNums,1)) - 1;
-            ptTabl2 = &(ELM_PLIST(objTable2,1)) - 1;
-            ptWord  = &(ELM_PLIST(word,1)) - 1;
+            ptRel = BASE_PTR_PLIST(objRel) - 1;
+            ptNums = BASE_PTR_PLIST(objNums) - 1;
+            ptTabl2 = BASE_PTR_PLIST(objTable2) - 1;
+            ptWord = BASE_PTR_PLIST(word) - 1;
             last    = 0;
 
             /* scan as long as possible from the left to the right         */
@@ -1432,8 +1432,8 @@ Obj FuncCopyRel (
     /*  Allocate a bag for the copy                                        */
     copy   = NEW_PLIST( T_PLIST, leng );
     SET_LEN_PLIST( copy, leng );
-    ptRel  = &(ELM_PLIST(rel,1));
-    ptCopy = &(ELM_PLIST(copy,1));
+    ptRel = BASE_PTR_PLIST(rel);
+    ptCopy = BASE_PTR_PLIST(copy);
 
     /*  Copy the relator to the new bag                                    */
     while ( leng > 0 ) {
@@ -1475,7 +1475,7 @@ Obj FuncMakeCanonical (
     if (leng == 0) {
         return 0;
     }
-    ptRel = &(ELM_PLIST(rel, 1));
+    ptRel = BASE_PTR_PLIST(rel);
     leng1 = leng - 1;
 
     /*  cyclically reduce the relator, if necessary                        */
@@ -1654,8 +1654,8 @@ Obj FuncTreeEntry(
         ErrorQuit( "invalid <tree>[2]", 0L, 0L );
         return 0;
     }
-    ptTree1  = &(ELM_PLIST(objTree1,1)) - 1;
-    ptTree2  = &(ELM_PLIST(objTree2,1)) - 1;
+    ptTree1 = BASE_PTR_PLIST(objTree1) - 1;
+    ptTree2 = BASE_PTR_PLIST(objTree2) - 1;
     treesize = LEN_PLIST(objTree1);
     numgens  = INT_INTOBJ( ELM_PLIST( objTree, 3 ) );
     treeWordLength = INT_INTOBJ( ELM_PLIST( objTree, 4 ) );
@@ -1668,13 +1668,13 @@ Obj FuncTreeEntry(
     }
 
     /* handle the abelianized case                                         */
-    ptWord = &(ELM_PLIST(word,1)) - 1;
+    ptWord = BASE_PTR_PLIST(word) - 1;
     if ( treeType == 0 ) {
         if ( LEN_PLIST(word) != treeWordLength ) {
             ErrorQuit( "inconsistent <word> length", 0L, 0L );
             return 0;
         }
-        ptWord = &(ELM_PLIST(objTree2,1)) - 1;
+        ptWord = BASE_PTR_PLIST(objTree2) - 1;
         for ( leng = treeWordLength;  leng >= 1;  leng-- ) {
             if ( ptWord[leng] != INTOBJ_INT(0) ) {
                 break;
@@ -1700,7 +1700,7 @@ Obj FuncTreeEntry(
         }
 
         for ( k = 1;  k <= numgens;  k++ ) {
-            ptFac = &(ELM_PLIST(ptTree1[k],1)) - 1;
+            ptFac = BASE_PTR_PLIST(ptTree1[k]) - 1;
             if ( LEN_PLIST(ptTree1[k]) == leng ) {
                 for ( i = 1;  i <= leng;  i++ ) {
                     if ( ptFac[i] != ptWord[i] ) {
@@ -1729,8 +1729,8 @@ Obj FuncTreeEntry(
         CHANGED_BAG(objTree1);
 
         /* copy the word to the new bag                                    */
-        ptWord = &(ELM_PLIST(objTree2,1)) - 1;
-        ptNew  = &(ELM_PLIST(new,1)) - 1;
+        ptWord = BASE_PTR_PLIST(objTree2) - 1;
+        ptNew = BASE_PTR_PLIST(new) - 1;
         while ( leng > 0 ) {
             ptNew[leng] = ptWord[leng];
             leng--;
@@ -1854,8 +1854,8 @@ Obj FuncTreeEntry(
                     GROW_PLIST( objTree2, treesize );
                     SET_LEN_PLIST( objTree1, treesize );
                     SET_LEN_PLIST( objTree2, treesize );
-                    ptTree1 = &(ELM_PLIST(objTree1,1)) - 1;
-                    ptTree2 = &(ELM_PLIST(objTree2,1)) - 1;
+                    ptTree1 = BASE_PTR_PLIST(objTree1) - 1;
+                    ptTree2 = BASE_PTR_PLIST(objTree2) - 1;
                     CHANGED_BAG(objTree);
                 }
                 ptTree1[numgens] = INTOBJ_INT( t1 );
@@ -1912,7 +1912,7 @@ Obj FuncStandardizeTable2C (
                    (Int)TNAM_OBJ(objTable), 0L );
         return 0;
     }
-    ptTable = &(ELM_PLIST(objTable,1)) - 1;
+    ptTable = BASE_PTR_PLIST(objTable) - 1;
     nrgen   = LEN_PLIST(objTable) / 2;
     for ( j = 1;  j <= nrgen*2;  j++ ) {
         if ( ! IS_PLIST(ptTable[j]) ) {
@@ -1929,7 +1929,7 @@ Obj FuncStandardizeTable2C (
                    (Int)TNAM_OBJ(objTable), 0L );
         return 0;
     }
-    ptTabl2 = &(ELM_PLIST(objTable2,1)) - 1;
+    ptTabl2 = BASE_PTR_PLIST(objTable2) - 1;
     if ( IS_INTOBJ(stan) && INT_INTOBJ(stan) == 1 ) {
        /* use semilenlex standard                                          */
        nloop = nrgen;
@@ -1947,7 +1947,7 @@ Obj FuncStandardizeTable2C (
         /* scan through all columns of acos                                */
         for ( j = 1;  j <= nloop;  j++ ) {
             k = ( nloop == nrgen ) ? 2*j - 1 : j;
-            g = &(ELM_PLIST(ptTable[k],1)) - 1;
+            g = BASE_PTR_PLIST(ptTable[k]) - 1;
 
             /* if we haven't seen this coset yet                           */
             if ( lcos+1 < INT_INTOBJ( g[acos] ) ) {
@@ -1956,10 +1956,10 @@ Obj FuncStandardizeTable2C (
                 lcos = lcos + 1;
                 mcos = INT_INTOBJ( g[acos] );
                 for ( k = 1;  k <= nrgen;  k++ ) {
-                    h  = &(ELM_PLIST(ptTable[2*k-1],1)) - 1;
-                    i  = &(ELM_PLIST(ptTable[2*k],1)) - 1;
-                    h2 = &(ELM_PLIST(ptTabl2[2*k-1],1)) - 1;
-                    i2 = &(ELM_PLIST(ptTabl2[2*k],1)) - 1;
+                    h = BASE_PTR_PLIST(ptTable[2 * k - 1]) - 1;
+                    i = BASE_PTR_PLIST(ptTable[2 * k]) - 1;
+                    h2 = BASE_PTR_PLIST(ptTabl2[2 * k - 1]) - 1;
+                    i2 = BASE_PTR_PLIST(ptTabl2[2 * k]) - 1;
                     c1 = INT_INTOBJ( h[lcos] );
                     c2 = INT_INTOBJ( h[mcos] );
                     if ( c1 != 0 )  i[c1] = INTOBJ_INT( mcos );
@@ -2034,7 +2034,7 @@ Obj FuncAddAbelianRelator (
             (Int)TNAM_OBJ(rels), 0L );
         return 0;
     }
-    ptRels = &(ELM_PLIST(rels,1)) - 1;
+    ptRels = BASE_PTR_PLIST(rels) - 1;
     if ( !IS_INTOBJ(number) ) {
         ErrorQuit( "<number> must be a small integer (not a %s)",
             (Int)TNAM_OBJ(number), 0L );
@@ -2052,7 +2052,7 @@ Obj FuncAddAbelianRelator (
         ErrorQuit( "inconsistent relator number", 0L, 0L );
         return 0;
     }
-    pt2 = &(ELM_PLIST(tmp,1)) - 1;
+    pt2 = BASE_PTR_PLIST(tmp) - 1;
 
     /* get the length of the exponent vectors (the number of generators)   */
     numcols = LEN_PLIST(tmp);
@@ -2076,7 +2076,7 @@ Obj FuncAddAbelianRelator (
 
     /* if the last relator occurs twice, remove one of its occurrences     */
     for ( i = 1;  i < numrows;  i++ ) {
-        pt1 = &(ELM_PLIST(ptRels[i],1)) - 1;
+        pt1 = BASE_PTR_PLIST(ptRels[i]) - 1;
         for ( j = 1;  j <= numcols;  j++ ) {
             if ( pt1[j] != pt2[j] ) {
                 break;

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -149,12 +149,12 @@ void GrowResultCyc(UInt size) {
     UInt i;
     if (STATE(ResultCyc) == 0) {
         STATE(ResultCyc) = NEW_PLIST( T_PLIST, size );
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         for ( i = 0; i < size; i++ ) { res[i] = INTOBJ_INT(0); }
     } else if ( LEN_PLIST(STATE(ResultCyc)) < size ) {
         GROW_PLIST( STATE(ResultCyc), size );
         SET_LEN_PLIST( STATE(ResultCyc), size );
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         for ( i = 0; i < size; i++ ) { res[i] = INTOBJ_INT(0); }
     }
 }
@@ -456,7 +456,7 @@ void            ConvertToBase (
     Obj                 sum;            /* sum of two coefficients         */
 
     /* get a pointer to the cyclotomic and a copy of n to factor           */
-    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+    res = BASE_PTR_PLIST(STATE(ResultCyc));
     nn  = n;
 
     /* first handle 2                                                      */
@@ -475,7 +475,7 @@ void            ConvertToBase (
                       || ! DIFF_INTOBJS( sum, res[l], res[k] ) ) {
                         CHANGED_BAG( STATE(ResultCyc) );
                         sum = DIFF( res[l], res[k] );
-                        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                        res = BASE_PTR_PLIST(STATE(ResultCyc));
                     }
                     res[l] = sum;
                     res[k] = INTOBJ_INT(0);
@@ -490,7 +490,7 @@ void            ConvertToBase (
                       || ! DIFF_INTOBJS( sum, res[l], res[k] ) ) {
                         CHANGED_BAG( STATE(ResultCyc) );
                         sum = DIFF( res[l], res[k] );
-                        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                        res = BASE_PTR_PLIST(STATE(ResultCyc));
                     }
                     res[l] = sum;
                     res[k] = INTOBJ_INT(0);
@@ -522,7 +522,7 @@ void            ConvertToBase (
                           || ! DIFF_INTOBJS( sum, res[l%n], res[k] ) ) {
                             CHANGED_BAG( STATE(ResultCyc) );
                             sum = DIFF( res[l%n], res[k] );
-                            res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                            res = BASE_PTR_PLIST(STATE(ResultCyc));
                         }
                         res[l%n] = sum;
                     }
@@ -538,7 +538,7 @@ void            ConvertToBase (
                           || ! DIFF_INTOBJS( sum, res[l%n], res[k] ) ) {
                             CHANGED_BAG( STATE(ResultCyc) );
                             sum = DIFF( res[l%n], res[k] );
-                            res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                            res = BASE_PTR_PLIST(STATE(ResultCyc));
                         }
                         res[l%n] = sum;
                     }
@@ -606,7 +606,7 @@ Obj             Cyclotomic (
     static UInt         nrp;            /* number of its prime factors     */
 
     /* get a pointer to the cyclotomic and a copy of n to factor           */
-    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+    res = BASE_PTR_PLIST(STATE(ResultCyc));
 
     /* count the terms and compute the gcd of the exponents with n         */
     len = 0;
@@ -699,7 +699,7 @@ Obj             Cyclotomic (
                       || (cof == INTOBJ_INT(-(1L<<NR_SMALL_INT_BITS))) ) {
                         CHANGED_BAG( STATE(ResultCyc) );
                         cof = DIFF( INTOBJ_INT(0), cof );
-                        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                        res = BASE_PTR_PLIST(STATE(ResultCyc));
                         res[i] = cof;
                     }
                     else {
@@ -738,7 +738,7 @@ Obj             Cyclotomic (
         cfs[0] = INTOBJ_INT(n);
         exs[0] = 0;
         k = 1;
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         for ( i = 0; i < n; i++ ) {
             if ( res[i] != INTOBJ_INT(0) ) {
                 cfs[k] = res[i];
@@ -881,7 +881,7 @@ Obj             SumCyc (
  
     /* Copy the left operand into the result                               */
     if ( TNUM_OBJ(opL) != T_CYC ) {
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         res[0] = opL;
         CHANGED_BAG( STATE(ResultCyc) );
     }
@@ -889,7 +889,7 @@ Obj             SumCyc (
         len = SIZE_CYC(opL);
         cfs = COEFS_CYC(opL);
         exs = EXPOS_CYC(opL,len);
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         if ( ml == 1 ) {
             for ( i = 1; i < len; i++ )
                 res[exs[i]] = cfs[i];
@@ -903,9 +903,9 @@ Obj             SumCyc (
 
     /* add the right operand to the result                                 */
     if ( TNUM_OBJ(opR) != T_CYC ) {
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         sum = SUM( res[0], opR );
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         res[0] = sum;
         CHANGED_BAG( STATE(ResultCyc) );
     }
@@ -913,7 +913,7 @@ Obj             SumCyc (
         len = SIZE_CYC(opR);
         cfs = COEFS_CYC(opR);
         exs = EXPOS_CYC(opR,len);
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         for ( i = 1; i < len; i++ ) {
             if ( ! ARE_INTOBJS( res[exs[i]*mr], cfs[i] )
               || ! SUM_INTOBJS( sum, res[exs[i]*mr], cfs[i] ) ) {
@@ -921,7 +921,7 @@ Obj             SumCyc (
                 sum = SUM( res[exs[i]*mr], cfs[i] );
                 cfs = COEFS_CYC(opR);
                 exs = EXPOS_CYC(opR,len);
-                res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                res = BASE_PTR_PLIST(STATE(ResultCyc));
             }
             res[exs[i]*mr] = sum;
         }
@@ -1027,7 +1027,7 @@ Obj             DiffCyc (
 
     /* copy the left operand into the result                               */
     if ( TNUM_OBJ(opL) != T_CYC ) {
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         res[0] = opL;
         CHANGED_BAG( STATE(ResultCyc) );
     }
@@ -1035,7 +1035,7 @@ Obj             DiffCyc (
         len = SIZE_CYC(opL);
         cfs = COEFS_CYC(opL);
         exs = EXPOS_CYC(opL,len);
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         if ( ml == 1 ) {
             for ( i = 1; i < len; i++ )
                 res[exs[i]] = cfs[i];
@@ -1049,9 +1049,9 @@ Obj             DiffCyc (
 
     /* subtract the right operand from the result                          */
     if ( TNUM_OBJ(opR) != T_CYC ) {
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         sum = DIFF( res[0], opR );
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         res[0] = sum;
         CHANGED_BAG( STATE(ResultCyc) );
     }
@@ -1059,7 +1059,7 @@ Obj             DiffCyc (
         len = SIZE_CYC(opR);
         cfs = COEFS_CYC(opR);
         exs = EXPOS_CYC(opR,len);
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         for ( i = 1; i < len; i++ ) {
             if ( ! ARE_INTOBJS( res[exs[i]*mr], cfs[i] )
               || ! DIFF_INTOBJS( sum, res[exs[i]*mr], cfs[i] ) ) {
@@ -1067,7 +1067,7 @@ Obj             DiffCyc (
                 sum = DIFF( res[exs[i]*mr], cfs[i] );
                 cfs = COEFS_CYC(opR);
                 exs = EXPOS_CYC(opR,len);
-                res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                res = BASE_PTR_PLIST(STATE(ResultCyc));
             }
             res[exs[i]*mr] = sum;
         }
@@ -1233,7 +1233,7 @@ Obj             ProdCyc (
             len = SIZE_CYC(opL);
             cfs = COEFS_CYC(opL);
             exs = EXPOS_CYC(opL,len);
-            res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+            res = BASE_PTR_PLIST(STATE(ResultCyc));
             for ( i = 1; i < len; i++ ) {
                 if ( ! ARE_INTOBJS( res[(e+exs[i]*ml)%n], cfs[i] )
                   || ! SUM_INTOBJS( sum, res[(e+exs[i]*ml)%n], cfs[i] ) ) {
@@ -1241,7 +1241,7 @@ Obj             ProdCyc (
                     sum = SUM( res[(e+exs[i]*ml)%n], cfs[i] );
                     cfs = COEFS_CYC(opL);
                     exs = EXPOS_CYC(opL,len);
-                    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                    res = BASE_PTR_PLIST(STATE(ResultCyc));
                 }
                 res[(e+exs[i]*ml)%n] = sum;
             }
@@ -1253,7 +1253,7 @@ Obj             ProdCyc (
             len = SIZE_CYC(opL);
             cfs = COEFS_CYC(opL);
             exs = EXPOS_CYC(opL,len);
-            res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+            res = BASE_PTR_PLIST(STATE(ResultCyc));
             for ( i = 1; i < len; i++ ) {
                 if ( ! ARE_INTOBJS( res[(e+exs[i]*ml)%n], cfs[i] )
                   || ! DIFF_INTOBJS( sum, res[(e+exs[i]*ml)%n], cfs[i] ) ) {
@@ -1261,7 +1261,7 @@ Obj             ProdCyc (
                     sum = DIFF( res[(e+exs[i]*ml)%n], cfs[i] );
                     cfs = COEFS_CYC(opL);
                     exs = EXPOS_CYC(opL,len);
-                    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                    res = BASE_PTR_PLIST(STATE(ResultCyc));
                 }
                 res[(e+exs[i]*ml)%n] = sum;
             }
@@ -1273,7 +1273,7 @@ Obj             ProdCyc (
             len = SIZE_CYC(opL);
             cfs = COEFS_CYC(opL);
             exs = EXPOS_CYC(opL,len);
-            res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+            res = BASE_PTR_PLIST(STATE(ResultCyc));
             for ( i = 1; i < len; i++ ) {
                 if ( ! ARE_INTOBJS( cfs[i], res[(e+exs[i]*ml)%n] )
                   || ! PROD_INTOBJS( prd, cfs[i], c )
@@ -1281,11 +1281,11 @@ Obj             ProdCyc (
                     CHANGED_BAG( STATE(ResultCyc) );
                     prd = PROD( cfs[i], c );
                     exs = EXPOS_CYC(opL,len);
-                    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                    res = BASE_PTR_PLIST(STATE(ResultCyc));
                     sum = SUM( res[(e+exs[i]*ml)%n], prd );
                     cfs = COEFS_CYC(opL);
                     exs = EXPOS_CYC(opL,len);
-                    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                    res = BASE_PTR_PLIST(STATE(ResultCyc));
                 }
                 res[(e+exs[i]*ml)%n] = sum;
             }
@@ -1300,10 +1300,10 @@ Obj             ProdCyc (
                 cfs = COEFS_CYC(opL);
                 prd = PROD( cfs[i], c );
                 exs = EXPOS_CYC(opL,len);
-                res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                res = BASE_PTR_PLIST(STATE(ResultCyc));
                 sum = SUM( res[(e+exs[i]*ml)%n], prd );
                 exs = EXPOS_CYC(opL,len);
-                res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                res = BASE_PTR_PLIST(STATE(ResultCyc));
                 res[(e+exs[i]*ml)%n] = sum;
             }
             CHANGED_BAG( STATE(ResultCyc) );
@@ -1375,7 +1375,7 @@ Obj             InvCyc (
             /* permute the terms                                           */
             cfs = COEFS_CYC(op);
             exs = EXPOS_CYC(op,len);
-            res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+            res = BASE_PTR_PLIST(STATE(ResultCyc));
             for ( k = 1; k < len; k++ )
                 res[(i*exs[k])%n] = cfs[k];
             CHANGED_BAG( STATE(ResultCyc) );
@@ -1516,7 +1516,7 @@ Obj FuncE (
     if ( STATE(LastNCyc) != INT_INTOBJ(n) ) {
         STATE(LastNCyc) = INT_INTOBJ(n);
         GrowResultCyc(STATE(LastNCyc));
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         res[1] = INTOBJ_INT(1);
         CHANGED_BAG( STATE(ResultCyc) );
         ConvertToBase( STATE(LastNCyc) );
@@ -1883,7 +1883,7 @@ Obj FuncGALOIS_CYC (
         len = SIZE_CYC(cyc);
         cfs = COEFS_CYC(cyc);
         exs = EXPOS_CYC(cyc,len);
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         for ( i = 1; i < len; i++ ) {
             res[(UInt8)exs[i]*(UInt8)o%(UInt8)n] = cfs[i];
         }
@@ -1907,7 +1907,7 @@ Obj FuncGALOIS_CYC (
         len = SIZE_CYC(cyc);
         cfs = COEFS_CYC(cyc);
         exs = EXPOS_CYC(cyc,len);
-        res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+        res = BASE_PTR_PLIST(STATE(ResultCyc));
         for ( i = 1; i < len; i++ ) {
             if ( ! ARE_INTOBJS( res[(UInt8)exs[i]*(UInt8)o%(UInt8)n], cfs[i] )
               || ! SUM_INTOBJS( sum, res[(UInt8)exs[i]*(UInt8)o%(UInt8)n], cfs[i] ) ) {
@@ -1915,7 +1915,7 @@ Obj FuncGALOIS_CYC (
                 sum = SUM( res[(UInt8)exs[i]*(UInt8)o%(UInt8)n], cfs[i] );
                 cfs = COEFS_CYC(cyc);
                 exs = EXPOS_CYC(cyc,len);
-                res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+                res = BASE_PTR_PLIST(STATE(ResultCyc));
             }
             res[exs[i]*o%n] = sum;
         }
@@ -1975,7 +1975,7 @@ Obj FuncCycList (
     GrowResultCyc(n);
 
     /* transfer the coefficients into the buffer                           */
-    res = &(ELM_PLIST( STATE(ResultCyc), 1 ));
+    res = BASE_PTR_PLIST(STATE(ResultCyc));
     for ( i = 0; i < n; i++ ) {
         val = ELM_PLIST( list, i+1 );
         if ( ! ( IS_INTOBJ(val) ||

--- a/src/gap.c
+++ b/src/gap.c
@@ -916,10 +916,10 @@ Obj FuncWindowCmd (
 
   /* if the first entry is one signal an error */
   if ( ELM_LIST(list,1) == INTOBJ_INT(1) ) {
-    C_NEW_STRING_CONST(tmp, "window system: ");
-    SET_ELM_PLIST( list, 1, tmp );
-    SET_LEN_PLIST( list, i-1 );
-    return CALL_XARGS(Error,list);
+      tmp = MakeString("window system: ");
+      SET_ELM_PLIST(list, 1, tmp);
+      SET_LEN_PLIST(list, i - 1);
+      return CALL_XARGS(Error, list);
   }
   else {
     for ( m = 1;  m <= i-2;  m++ )
@@ -1210,7 +1210,7 @@ static Obj ErrorMessageToGAPString(
   Obj Message;
   SPrTo(message, sizeof(message), msg, arg1, arg2);
   message[sizeof(message)-1] = '\0';
-  C_NEW_STRING_DYN(Message, message);
+  Message = MakeString(message);
   return Message;
 }
 
@@ -1407,7 +1407,7 @@ Obj ErrorReturnObj (
     const Char *        msg2 )
 {
   Obj LateMsg;
-  C_NEW_STRING_DYN(LateMsg, msg2);
+  LateMsg = MakeString(msg2);
   return CallErrorInner(msg, arg1, arg2, 0, 0, 1, LateMsg, 1);
 }
 
@@ -1423,7 +1423,7 @@ void ErrorReturnVoid (
     const Char *        msg2 )
 {
   Obj LateMsg;
-  C_NEW_STRING_DYN(LateMsg, msg2);
+  LateMsg = MakeString(msg2);
   CallErrorInner( msg, arg1, arg2, 0,1,0,LateMsg, 1);
   /*    ErrorMode( msg, arg1, arg2, (Obj)0, msg2, 'x' ); */
 }

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2123,7 +2123,7 @@ void            IntrFloatExpr (
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
     if ( STATE(IntrCoding)    > 0 ) {  CodeFloatExpr( str );   return; }
 
-    C_NEW_STRING_DYN(val, str);
+    val = MakeString(str);
     PushObj(ConvertFloatLiteralEager(val));
 }
 

--- a/src/lists.h
+++ b/src/lists.h
@@ -67,6 +67,79 @@ static inline Int IS_SMALL_LIST(Obj obj)
     return (*IsSmallListFuncs[TNUM_OBJ(obj)])(obj);
 }
 
+/****************************************************************************
+**
+*F  IS_DENSE_LIST(<list>) . . . . . . . . . . . . . . .  test for dense lists
+*V  IsDenseListFuncs[<type>]  . . . . . .  table of dense list test functions
+**
+**  'IS_DENSE_LIST'  returns 1 if the   list <list> is a   dense  list and  0
+**  otherwise, i.e., if either <list> is not a list, or if it is not dense.
+**
+**  A package  implementing a list type  <type> must provide such  a function
+**  and  install it in  'IsDenseListFuncs[<type>]'.   This function must loop
+**  over the list and test for holes, unless  the type of the list guarantees
+**  already that the list is dense (e.g. for sets).
+*/
+
+extern Int (*IsDenseListFuncs[LAST_REAL_TNUM + 1])(Obj list);
+
+extern Int IsDenseListDefault(Obj list);
+
+static inline Int IS_DENSE_LIST(Obj list)
+{
+    return (*IsDenseListFuncs[TNUM_OBJ(list)])(list);
+}
+
+/****************************************************************************
+**
+*F  IS_HOMOG_LIST(<list>) . . . . . . . . . . . .  test for homogeneous lists
+*V  IsHomogListFuncs[<type>]  . . .  table of homogeneous list test functions
+**
+**  'IS_HOMOG_LIST' returns 1 if  the list <list>  is a  homogeneous list and
+**  0 otherwise, i.e., if either <list> is not  a  list,  or  if  it  is  not
+**  homogeneous.
+**
+**  A  package implementing a list  type <type> must  provide such a function
+**  and install  it  in 'IsHomogListFuncs[<type>]'.  This function  must loop
+**  over the list   and test whether all  elements  lie in  the  same family,
+**  unless  the type  of   the list  guarantees    already that the  list  is
+**  homogeneous (e.g. for sets).
+*/
+
+extern Int (*IsHomogListFuncs[LAST_REAL_TNUM + 1])(Obj list);
+
+extern Int IsHomogListDefault(Obj list);
+
+static inline Int IS_HOMOG_LIST(Obj list)
+{
+    return (*IsHomogListFuncs[TNUM_OBJ(list)])(list);
+}
+
+/****************************************************************************
+**
+*F  IS_POSS_LIST(<list>)  . . . . . . . . . . . . .  test for positions lists
+*V  IsPossListFuncs[<type>] . . . . . . table of positions list test function
+**
+**  'IS_POSS_LIST' returns  1 if the list  <list> is  a dense list containing
+**  only positive  integers and 0 otherwise, i.e.,  if either <list> is not a
+**  list, or if it is not dense,  or if it contains  an element that is not a
+**  positive integer.
+**
+**  A package  implementing a list type  <type> must provide such  a function
+**  and install  it  in 'IsPossListFuncs[<type>]'.   This function  must loop
+**  over the list  and  test for holes   and elements that are  not  positive
+**  integers, unless the type of the list guarantees already that the list is
+**  acceptable (e.g. a range with positive <low> and <high> values).
+*/
+
+extern Int (*IsPossListFuncs[LAST_REAL_TNUM + 1])(Obj list);
+
+extern Int IsPossListDefault(Obj list);
+
+static inline Int IS_POSS_LIST(Obj list)
+{
+    return (*IsPossListFuncs[TNUM_OBJ(list)])(list);
+}
 
 /****************************************************************************
 **
@@ -116,17 +189,17 @@ static inline Obj LENGTH(Obj list)
 **  the  responsibility of  the  caller to  ensure that  <pos> is a  positive
 **  integer.
 **
-**  Note that 'ISB_LIST' is a macro, so do not call it with arguments that
-**  have side effects.
-**
 **  A  package implementing a  list type <type>  must  provide a function for
 **  'ISB_LIST' and install it in 'IsbListFuncs[<type>]'.
 **
 */
-#define ISB_LIST(list,pos) \
-                        ((*IsbListFuncs[TNUM_OBJ(list)])(list,pos))
 
 extern  Int             (*IsbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
+
+static inline Int ISB_LIST(Obj list, Int pos)
+{
+    return (*IsbListFuncs[TNUM_OBJ(list)])(list, pos);
+}
 
 extern Int ISBB_LIST( Obj list, Obj pos );
 
@@ -155,11 +228,11 @@ extern Obj (*Elm0ListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 **  or 0 if <list>  has no assigned  object at position  <pos>.  An  error is
 **  signalled if <list>  is  not a list.  It   is the responsibility   of the
 **  caller to ensure that <pos> is a positive integer.
-**
-**  Note that 'ELM0_LIST' is a  macro, so do  not call it with arguments that
-**  have side effects.
 */
-#define ELM0_LIST(list,pos)     ((*Elm0ListFuncs[TNUM_OBJ(list)])(list,pos))
+static inline Obj ELM0_LIST(Obj list, Int pos)
+{
+    return (*Elm0ListFuncs[TNUM_OBJ(list)])(list, pos);
+}
 
 
 /****************************************************************************
@@ -181,11 +254,11 @@ extern  Obj (*Elm0vListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 **  'ELMV0_LIST' does the same as 'ELM0_LIST', but the caller also guarantees
 **  that <list> is a list and that <pos> is less than  or equal to the length
 **  of <list>.
-**
-**  Note that 'ELMV0_LIST' is a macro, so do not call  it with arguments that
-**  have side effects.
 */
-#define ELMV0_LIST(list,pos)    ((*Elm0vListFuncs[TNUM_OBJ(list)])(list,pos))
+static inline Obj ELMV0_LIST(Obj list, Int pos)
+{
+    return (*Elm0vListFuncs[TNUM_OBJ(list)])(list, pos);
+}
 
 
 /****************************************************************************
@@ -211,17 +284,20 @@ extern Obj (*ElmListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 **  is the responsibility  of the caller to  ensure that <pos>  is a positive
 **  integer.
 **
-**  Note that 'ELM_LIST', 'ELMV_LIST', and  'ELMW_LIST' are macros, so do not
-**  call them with arguments that have side effects.
-**
 **  The difference between ELM_LIST and ELMB_LIST is that ELMB_LIST accepts
 **  an object as the second argument
 **  It is intended as an interface for access to elements of large external
 **  lists, on the rare occasions when the kernel needs to do this.
 */
-#define ELM_LIST(list,pos)      ((*ElmListFuncs[TNUM_OBJ(list)])(list,pos))
-
 extern Obj ELMB_LIST( Obj list, Obj pos );
+
+static inline Obj ELM_LIST(Obj list, Int pos)
+{
+    Obj ret = (*ElmListFuncs[TNUM_OBJ(list)])(list, pos);
+    GAP_ASSERT(ret != 0);
+    return ret;
+}
+
 
 /****************************************************************************
 **
@@ -230,11 +306,17 @@ extern Obj ELMB_LIST( Obj list, Obj pos );
 
 extern Obj Elm2List(Obj list, Obj pos1, Obj pos2);
 
-#define ELM2_LIST(list, pos1, pos2) Elm2List(list, pos1, pos2)
+static inline Obj ELM2_LIST(Obj list, Obj pos1, Obj pos2)
+{
+    return Elm2List(list, pos1, pos2);
+}
 
 extern void Ass2List(Obj list, Obj pos1, Obj pos2, Obj obj);
 
-#define ASS2_LIST(list, pos1, pos2, obj) Ass2List(list, pos1, pos2, obj)
+static inline void ASS2_LIST(Obj list, Obj pos1, Obj pos2, Obj obj)
+{
+    Ass2List(list, pos1, pos2, obj);
+}
 
 
 /****************************************************************************
@@ -257,11 +339,13 @@ extern Obj (*ElmvListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 **  'ELMV_LIST' does  the same as 'ELM_LIST', but  the caller also guarantees
 **  that <list> is a list and that <pos> is less  than or equal to the length
 **  of <list>.
-**
-**  Note that 'ELM_LIST', 'ELMV_LIST', and  'ELMW_LIST' are macros, so do not
-**  call them with arguments that have side effects.
 */
-#define ELMV_LIST(list,pos)     ((*ElmvListFuncs[TNUM_OBJ(list)])(list,pos))
+static inline Obj ELMV_LIST(Obj list, Int pos)
+{
+    GAP_ASSERT(pos > 0);
+    GAP_ASSERT(pos <= LEN_LIST(list));
+    return (*ElmvListFuncs[TNUM_OBJ(list)])(list, pos);
+}
 
 
 /****************************************************************************
@@ -282,11 +366,15 @@ extern Obj (*ElmwListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 **
 **  'ELMW_LIST' does the same as 'ELMV_LIST', but  the caller also guarantees
 **  that <list> has an assigned object at the position <pos>.
-**
-**  Note that 'ELM_LIST', 'ELMV_LIST', and  'ELMW_LIST' are macros, so do not
-**  call them with arguments that have side effects.
 */
-#define ELMW_LIST(list,pos)     ((*ElmwListFuncs[TNUM_OBJ(list)])(list,pos))
+static inline Obj ELMW_LIST(Obj list, Int pos)
+{
+    GAP_ASSERT(pos > 0);
+    GAP_ASSERT(pos <= LEN_LIST(list));
+    Obj ret = (*ElmwListFuncs[TNUM_OBJ(list)])(list, pos);
+    GAP_ASSERT(ret != 0);
+    return ret;
+}
 
 
 /****************************************************************************
@@ -317,12 +405,12 @@ extern Obj (*ElmsListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj poss );
 **  of  <list>, or if <list> has  no assigned object at any of the positions.
 **  It is the responsibility of the  caller to ensure  that <poss> is a dense
 **  list of positive integers.
-**
-**  Note that 'ELMS_LIST' is a  macro, so do not call it with arguments  that
-**  have side effects.
 */
-#define ELMS_LIST(list,poss)    ((*ElmsListFuncs[TNUM_OBJ(list)])(list,poss))
-
+static inline Obj ELMS_LIST(Obj list, Obj poss)
+{
+    GAP_ASSERT(IS_POSS_LIST(poss));
+    return (*ElmsListFuncs[TNUM_OBJ(list)])(list, poss);
+}
 
 
 /****************************************************************************
@@ -363,21 +451,22 @@ extern void ElmsListLevelCheck (
 **  <list>.  An error is signalled if  <list>  is  not  a  list.  It  is  the
 **  responsibility of the caller to ensure that <pos> is a positive integer.
 **
-**  Note that 'UNB_LIST' is a macro, so do not call it  with  arguments  that
-**  have side effects.
-**
 **  A package implementing a list type <type> must provide  such  a  function
 **  and install it in 'UnbListFuncs[<type>]'.  This function must change  the
 **  representation of <list> to that of a plain list if necessary.
 */
-#define UNB_LIST(list,pos) \
-                        ((*UnbListFuncs[TNUM_OBJ(list)])(list,pos))
 
 extern void             (*UnbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
 extern void UNBB_LIST( Obj list, Obj pos );
 
 extern void UnbListDefault( Obj list, Int  pos );
+
+static inline void UNB_LIST(Obj list, Int pos)
+{
+    GAP_ASSERT(pos > 0);
+    return (*UnbListFuncs[TNUM_OBJ(list)])(list, pos);
+}
 
 
 /****************************************************************************
@@ -391,20 +480,23 @@ extern void UnbListDefault( Obj list, Int  pos );
 **  responsibility of the caller to ensure that <pos>  is a positive integer,
 **  and that <obj> is not 0.
 **
-**  Note that 'ASS_LIST' is a macro,  so do not  call it with arguments  that
-**  have side effects.
-**
 **  A package  implementing a list type  <type> must provide  such a function
 **  and   install it in  'AssListFuncs[<type>]'.   This  function must extend
 **  <list> if <pos> is larger than the length of  <list> and must also change
 **  the representation of <list> to that of a plain list if necessary.
 */
-#define ASS_LIST(list,pos,obj) \
-                        ((*AssListFuncs[TNUM_OBJ(list)])(list,pos,obj))
+
 
 extern  void            (*AssListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos, Obj obj );
 
 extern void ASSB_LIST( Obj list, Obj pos, Obj obj );
+
+static inline void ASS_LIST(Obj list, Int pos, Obj obj)
+{
+    GAP_ASSERT(pos > 0);
+    GAP_ASSERT(obj != 0);
+    (*AssListFuncs[TNUM_OBJ(list)])(list, pos, obj);
+}
 
 
 /****************************************************************************
@@ -419,18 +511,12 @@ extern void ASSB_LIST( Obj list, Obj pos, Obj obj );
 **  caller to ensure that  <poss> is a dense  list  of positive  integers and
 **  that <objs> is a dense list of the same length as <poss>.
 **
-**  Note that 'ASSS_LIST' is a macro, so do not call it with  arguments  that
-**  have side effects.
-**
 **  A package implementing  a list type <type> must  provide  such a function
 **  and install it in 'AsssListFuncs[<type>]'.  This function must extend the
 **  <list> if any of the  positions is larger than the  length of <list>  and
 **  must also change the representation of <list> to that  of a plain list if
 **  necessary.
 */
-#define ASSS_LIST(list,poss,objs) \
-                        ((*AsssListFuncs[TNUM_OBJ(list)])(list,poss,objs))
-
 extern  void            (*AsssListFuncs[LAST_REAL_TNUM+1]) (Obj list, Obj poss, Obj objs);
 
 extern  void            AsssListDefault (
@@ -438,6 +524,13 @@ extern  void            AsssListDefault (
             Obj                 poss,
             Obj                 objs );
 
+static inline void ASSS_LIST(Obj list, Obj poss, Obj objs)
+{
+    GAP_ASSERT(IS_POSS_LIST(poss));
+    GAP_ASSERT(IS_DENSE_LIST(objs));
+    GAP_ASSERT(LEN_LIST(poss) == LEN_LIST(objs));
+    (*AsssListFuncs[TNUM_OBJ(list)])(list, poss, objs);
+}
 
 /****************************************************************************
 **
@@ -451,66 +544,11 @@ extern void AssListObject (
 
 /****************************************************************************
 **
-*F  IS_DENSE_LIST(<list>) . . . . . . . . . . . . . . .  test for dense lists
-*V  IsDenseListFuncs[<type>]  . . . . . .  table of dense list test functions
-**
-**  'IS_DENSE_LIST'  returns 1 if the   list <list> is a   dense  list and  0
-**  otherwise, i.e., if either <list> is not a list, or if it is not dense.
-**
-**  Note that  'IS_DENSE_LIST' is a macro, so  do not call it  with arguments
-**  that have side effects.
-**
-**  A package  implementing a list type  <type> must provide such  a function
-**  and  install it in  'IsDenseListFuncs[<type>]'.   This function must loop
-**  over the list and test for holes, unless  the type of the list guarantees
-**  already that the list is dense (e.g. for sets).
-*/
-#define IS_DENSE_LIST(list) \
-                        ((*IsDenseListFuncs[TNUM_OBJ(list)])(list))
-
-extern  Int             (*IsDenseListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
-
-extern  Int             IsDenseListDefault (
-            Obj                 list );
-
-
-/****************************************************************************
-**
-*F  IS_HOMOG_LIST(<list>) . . . . . . . . . . . .  test for homogeneous lists
-*V  IsHomogListFuncs[<type>]  . . .  table of homogeneous list test functions
-**
-**  'IS_HOMOG_LIST' returns 1 if  the list <list>  is a  homogeneous list and
-**  0 otherwise, i.e., if either <list> is not  a  list,  or  if  it  is  not
-**  homogeneous.
-**
-**  'IS_HOMOG_LIST' is a macro, so do not call it with  arguments  that  have
-**  side effects.
-**
-**  A  package implementing a list  type <type> must  provide such a function
-**  and install  it  in 'IsHomogListFuncs[<type>]'.  This function  must loop
-**  over the list   and test whether all  elements  lie in  the  same family,
-**  unless  the type  of   the list  guarantees    already that the  list  is
-**  homogeneous (e.g. for sets).
-*/
-#define IS_HOMOG_LIST(list) \
-                        ((*IsHomogListFuncs[TNUM_OBJ(list)])(list))
-
-extern  Int             (*IsHomogListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
-
-extern  Int             IsHomogListDefault (
-            Obj                 list );
-
-
-/****************************************************************************
-**
 *F  IS_TABLE_LIST(<list>) . . . . . . . . . . . . . . .  test for table lists
 *V  IsTableListFuncs[<type>]  . . . . . .  table of table list test functions
 **
 **  'IS_TABLE_LIST'  returns  1 if  the  list  <list>  is  a  table, i.e.,  a
 **  homogeneous list of homogeneous lists of equal length, and 0 otherwise.
-**
-**  'IS_TABLE_LIST' is a macro, so do not call it with  arguments  that  have
-**  side effects.
 **
 **  A  package implementing a list  type <type> must  provide such a function
 **  and install it in  'IsTableListFuncs[<type>]'.   This function must  loop
@@ -518,14 +556,16 @@ extern  Int             IsHomogListDefault (
 **  homogenous lists, and have  the same length, unless the  type of the list
 **  guarantees already that the list has this property.
 */
-#define IS_TABLE_LIST(list) \
-                        ((*IsTableListFuncs[TNUM_OBJ(list)])(list))
 
 extern  Int             (*IsTableListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
 extern  Int             IsTableListDefault (
             Obj                 list );
 
+static inline Int IS_TABLE_LIST(Obj list)
+{
+    return (*IsTableListFuncs[TNUM_OBJ(list)])(list);
+}
 
 /****************************************************************************
 **
@@ -536,22 +576,21 @@ extern  Int             IsTableListDefault (
 **  and 0 otherwise,  i.e., if either <list>  is not a list,  or if it is not
 **  strictly sorted.
 **
-**  'IS_SSORT_LIST' is a macro, so do not call it  with arguments  that  have
-**  side effects.
-**
 **  A  package implementing a  list type <type>  must provide such a function
 **  and install it  in  'IsSSortListFuncs[<type>]'.  This function must  loop
 **  over the list and compare each element with the next one, unless the type
 **  of the list guarantees already that the list is strictly sorted.
 */
-#define IS_SSORT_LIST(list) \
-                        ((*IsSSortListFuncs[TNUM_OBJ(list)])(list))
 
 extern  Int             (*IsSSortListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
 extern  Int             IsSSortListDefault (
             Obj                 list );
 
+static inline Int IS_SSORT_LIST(Obj list)
+{
+    return (*IsSSortListFuncs[TNUM_OBJ(list)])(list);
+}
 
 /****************************************************************************
 **
@@ -566,35 +605,6 @@ extern Obj IsSSortListProp;
 */
 extern Obj IsNSortListProp;
 
-
-/****************************************************************************
-**
-*F  IS_POSS_LIST(<list>)  . . . . . . . . . . . . .  test for positions lists
-*V  IsPossListFuncs[<type>] . . . . . . table of positions list test function
-**
-**  'IS_POSS_LIST' returns  1 if the list  <list> is  a dense list containing
-**  only positive  integers and 0 otherwise, i.e.,  if either <list> is not a
-**  list, or if it is not dense,  or if it contains  an element that is not a
-**  positive integer.
-**
-**  Note that  'IS_POSS_LIST' is a macro,  so  do not  call it with arguments
-**  that have side effects.
-**
-**  A package  implementing a list type  <type> must provide such  a function
-**  and install  it  in 'IsPossListFuncs[<type>]'.   This function  must loop
-**  over the list  and  test for holes   and elements that are  not  positive
-**  integers, unless the type of the list guarantees already that the list is
-**  acceptable (e.g. a range with positive <low> and <high> values).
-*/
-#define IS_POSS_LIST(list) \
-                        ((*IsPossListFuncs[TNUM_OBJ(list)])(list))
-
-extern  Int             (*IsPossListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
-
-extern  Int             IsPossListDefault (
-            Obj                 list );
-
-
 /****************************************************************************
 **
 *F  POS_LIST(<list>,<obj>,<start>)  . . . . . . . . find an element in a list
@@ -605,14 +615,9 @@ extern  Int             IsPossListDefault (
 **  position  <start> as GAP Integer.  Fail is returned if  <obj> is not in the
 **  list after <start>.  An error is signalled if <list> is not a list.
 **
-**  Note that 'POS_LIST'  is a macro,  so do  not call it with arguments that
-**  have side effects.
-**
 **  A package implementing a list  type <type> must  provide such a  function
 **  and install it in 'PosListFuncs[<type>]'.
 */
-#define POS_LIST(list,obj,start) \
-                        ((*PosListFuncs[TNUM_OBJ(list)])(list,obj,start))
 
 extern  Obj             (*PosListFuncs[LAST_REAL_TNUM+1]) (Obj list, Obj obj, Obj start);
 
@@ -621,6 +626,10 @@ extern  Obj             PosListDefault (
             Obj                 obj,
             Obj                 start );
 
+static inline Obj POS_LIST(Obj list, Obj obj, Obj start)
+{
+    return (*PosListFuncs[TNUM_OBJ(list)])(list, obj, start);
+}
 
 /****************************************************************************
 **
@@ -742,16 +751,16 @@ extern  void            AsssListLevel (
 **  it could also be 'T_SET' or 'T_VECTOR'.  An  error is signalled if <list>
 **  is not a list.
 **
-**  Note that 'PLAIN_LIST' is a macro, so do not call  it with arguments that
-**  have side effects.
-**
 **  A package implementing a  list type <type>  must provide such  a function
 **  and install it in 'PlainListFuncs[<type>]'.
 */
-#define PLAIN_LIST(list) \
-                        ((*PlainListFuncs[TNUM_OBJ(list)])(list))
 
 extern  void            (*PlainListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+
+static inline void PLAIN_LIST(Obj list)
+{
+    ((*PlainListFuncs[TNUM_OBJ(list)])(list));
+}
 
 
 /****************************************************************************

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -429,7 +429,7 @@ Obj FuncSTRING_DIGITS_MACFLOAT( Obj self, Obj gapprec, Obj f)
   if (prec > 40) /* too much anyways, and would risk buffer overrun */
     prec = 40;
   snprintf(buf, sizeof(buf), "%.*" PRINTFFORMAT, prec, (TOPRINTFFORMAT)VAL_MACFLOAT(f));
-  C_NEW_STRING_DYN(str, buf);
+  str = MakeString(buf);
   return str;
 }
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -543,7 +543,8 @@ static inline const Char * TNAM_OBJ(Obj obj)
 **  will renumber all IDs.  Therefore the  corresponding routine must excatly
 **  know where such numbers are stored.
 */
-#define ID_TYPE(type)           ELM_PLIST( type, 4 )
+#define ID_TYPE(type) ELM_PLIST(type, 4)
+#define SET_ID_TYPE(type, val) SET_ELM_PLIST(type, 4, val)
 
 
 /****************************************************************************

--- a/src/opers.c
+++ b/src/opers.c
@@ -832,8 +832,8 @@ Obj FuncInstallHiddenTrueMethod(Obj self, Obj filter, Obj filters)
     UInt len = LEN_PLIST(HIDDEN_IMPS);
     GROW_PLIST(HIDDEN_IMPS, len + 2);
     SET_LEN_PLIST(HIDDEN_IMPS, len + 2);
-    ELM_PLIST(HIDDEN_IMPS, len + 1) = imp;
-    ELM_PLIST(HIDDEN_IMPS, len + 2) = imps;
+    SET_ELM_PLIST(HIDDEN_IMPS, len + 1, imp);
+    SET_ELM_PLIST(HIDDEN_IMPS, len + 2, imps);
 #ifdef HPCGAP
     RegionWriteUnlock(REGION(HIDDEN_IMPS));
 #endif
@@ -856,8 +856,8 @@ Obj FuncCLEAR_HIDDEN_IMP_CACHE(Obj self, Obj filter)
     if(ELM_PLIST(WITH_HIDDEN_IMPS_FLAGS_CACHE, i) &&
        FuncIS_SUBSET_FLAGS(0, ELM_PLIST(WITH_HIDDEN_IMPS_FLAGS_CACHE, i+1), flags) == True)
     {
-        ELM_PLIST(WITH_HIDDEN_IMPS_FLAGS_CACHE, i) = 0;
-        ELM_PLIST(WITH_HIDDEN_IMPS_FLAGS_CACHE, i+1) = 0;
+        SET_ELM_PLIST(WITH_HIDDEN_IMPS_FLAGS_CACHE, i, 0);
+        SET_ELM_PLIST(WITH_HIDDEN_IMPS_FLAGS_CACHE, i + 1, 0);
         CHANGED_BAG(WITH_HIDDEN_IMPS_FLAGS_CACHE);
     }
   }
@@ -936,10 +936,10 @@ Obj FuncWITH_HIDDEN_IMPS_FLAGS(Obj self, Obj flags)
         old_with = ELM_PLIST(WITH_HIDDEN_IMPS_FLAGS_CACHE, hash*2+2);
         old_moving = 1;
       }
-      
-      ELM_PLIST(WITH_HIDDEN_IMPS_FLAGS_CACHE, hash*2+1) = new_flags;
-      ELM_PLIST(WITH_HIDDEN_IMPS_FLAGS_CACHE, hash*2+2) = new_with;
-      
+
+      SET_ELM_PLIST(WITH_HIDDEN_IMPS_FLAGS_CACHE, hash * 2 + 1, new_flags);
+      SET_ELM_PLIST(WITH_HIDDEN_IMPS_FLAGS_CACHE, hash * 2 + 2, new_with);
+
       if(old_moving)
       {
         new_flags = old_flags;
@@ -1691,7 +1691,7 @@ static void FixTypeIDs( Bag b ) {
   if ( (TNUM_OBJ( b )  == T_POSOBJ) &&
        (DoFilter(IsType, b ) == True ))
     {
-      ID_TYPE(b) = INTOBJ_INT(NextTypeID);
+      SET_ID_TYPE(b, INTOBJ_INT(NextTypeID));
       NextTypeID++;
     } 
 }

--- a/src/opers.c
+++ b/src/opers.c
@@ -5634,7 +5634,7 @@ Obj FuncNEW_OPERATION_ARGS (
     }
 
     /* make the new operation                                              */
-    C_NEW_STRING_CONST( args, "args" )
+    args = MakeString("args");
     list = NEW_PLIST( T_PLIST, 1 );
     SET_LEN_PLIST( list, 1 );
     SET_ELM_PLIST( list, 1, args );
@@ -6533,23 +6533,23 @@ static Int InitLibrary (
     Obj                 str;
 
     /* share between uncompleted functions                                 */
-    C_NEW_STRING_CONST( StringFilterSetter, "<<filter-setter>>" );
+    StringFilterSetter = MakeString("<<filter-setter>>");
     RESET_FILT_LIST( StringFilterSetter, FN_IS_MUTABLE );
 
     ArglistObj = NEW_PLIST( T_PLIST+IMMUTABLE, 1 );
     SET_LEN_PLIST( ArglistObj, 1 );
-    C_NEW_STRING_CONST( str, "obj" );
+    str = MakeString("obj");
     RESET_FILT_LIST( str, FN_IS_MUTABLE );
     SET_ELM_PLIST( ArglistObj, 1, str );
     CHANGED_BAG( ArglistObj );
 
     ArglistObjVal = NEW_PLIST( T_PLIST+IMMUTABLE, 2 );
     SET_LEN_PLIST( ArglistObjVal, 2 );
-    C_NEW_STRING_CONST( str, "obj" );
+    str = MakeString("obj");
     RESET_FILT_LIST( str, FN_IS_MUTABLE );
     SET_ELM_PLIST( ArglistObjVal, 1, str );
     CHANGED_BAG( ArglistObjVal );
-    C_NEW_STRING_CONST( str, "val" );
+    str = MakeString("val");
     RESET_FILT_LIST( str, FN_IS_MUTABLE );
     SET_ELM_PLIST( ArglistObjVal, 2, str );
     CHANGED_BAG( ArglistObjVal );
@@ -6570,7 +6570,7 @@ static Int InitLibrary (
 
     /* install the (function) copies of global variables                   */
     /* for the inside-out (kernel to library) interface                    */
-    C_NEW_STRING_CONST(TRY_NEXT_METHOD, "TRY_NEXT_METHOD");
+    TRY_NEXT_METHOD = MakeString("TRY_NEXT_METHOD");
     RetypeBag(TRY_NEXT_METHOD, T_STRING+IMMUTABLE);
     AssGVar( GVarName("TRY_NEXT_METHOD"), TRY_NEXT_METHOD );
 

--- a/src/plist.h
+++ b/src/plist.h
@@ -180,23 +180,36 @@ static inline void SET_ELM_PLIST(Obj list, Int pos, Obj val)
 **  be a positive  integer  less than  or  equal  to the  physical  length of
 **  <list>.  If <list> has no assigned element at position <pos>, 'ELM_PLIST'
 **  returns 0.
-**
-**  Note that  'ELM_PLIST' is a macro, so do  not call it with arguments that
-**  have side effects.
 */
-#define ELM_PLIST(list,pos)             (ADDR_OBJ(list)[pos])
+static inline Obj ELM_PLIST(Obj list, Int pos)
+{
+    GAP_ASSERT(IS_PLIST_OR_POSOBJ(list));
+    GAP_ASSERT(pos >= 1);
+    GAP_ASSERT(pos <= CAPACITY_PLIST(list));
+    return ADDR_OBJ(list)[pos];
+}
 
-
-
-
+/****************************************************************************
+**
+*F  BASE_PTR_PLIST(<list>)  . . . . . . . . . . . . . element of a plain list
+**
+**  'BASE_PTR_PLIST' returns a point to the first element of the plist <list>
+**
+**  This point will be invalidated whenever a garbage collection occurs.
+*/
+static inline Obj * BASE_PTR_PLIST(Obj list)
+{
+    GAP_ASSERT(IS_PLIST_OR_POSOBJ(list));
+    return ADDR_OBJ(list) + 1;
+}
 /****************************************************************************
 **
 *F  IS_DENSE_PLIST( <list> )  . . . . . check if <list> is a dense plain list
 **
-** Note that this only checks for plists that are known to be dense.  This is  
-** very fast.  If you want  to also handle plists  for which it  is now known      
-** whether they  are dense or not  (i.e. of type T_PLIST),  use IS_DENSE_LIST 
-** instead.                                                                   
+** Note that this only checks for plists that are known to be dense.  This is
+** very fast.  If you want  to also handle plists  for which it  is now known
+** whether they  are dense or not  (i.e. of type T_PLIST),  use IS_DENSE_LIST
+** instead.
 */
 static inline Int IS_DENSE_PLIST(Obj list)
 {

--- a/src/read.c
+++ b/src/read.c
@@ -850,7 +850,7 @@ void ReadLongNumber(
 
      /* string in which to accumulate number */
      len = strlen(STATE(Value));
-     C_NEW_STRING( string, len, (void *)STATE(Value));
+     string = MakeString(STATE(Value));
      done = 0;
 
      while (!done) {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1104,9 +1104,9 @@ static Int GetLine2 (
 #endif
 
     if ( input->isstream ) {
-        if ( input->sline == 0
-          || GET_LEN_STRING(input->sline) <= input->spos )
-        {
+        if (input->sline == 0 ||
+            (IS_STRING(input->sline) &&
+             GET_LEN_STRING(input->sline) <= input->spos)) {
             input->sline = CALL_1ARGS( ReadLineFunc, input->stream );
             input->spos  = 0;
         }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2587,7 +2587,7 @@ Obj FuncToggleEcho( Obj self)
 Obj FuncCPROMPT( Obj self)
 {
   Obj p;
-  C_NEW_STRING_DYN( p, STATE(Prompt) );
+  p = MakeString(STATE(Prompt));
   return p;
 }
 
@@ -2957,9 +2957,9 @@ void SPrTo(Char *buffer, UInt maxlen, const Char *format, Int arg1, Int arg2)
 Obj FuncINPUT_FILENAME( Obj self) {
   Obj s;
   if (STATE(Input)) {
-    C_NEW_STRING_DYN( s, STATE(Input)->name );
+      s = MakeString(STATE(Input)->name);
   } else {
-    C_NEW_STRING_CONST( s, "*defin*" );
+      s = MakeString("*defin*");
   }
   return s;
 }

--- a/src/streams.c
+++ b/src/streams.c
@@ -1183,7 +1183,7 @@ Obj FuncTmpName (
     tmp = SyTmpname();
     if ( tmp == 0 )
         return Fail;
-    C_NEW_STRING_DYN( name, tmp );
+    name = MakeString(tmp);
     return name;
 }
 
@@ -1201,7 +1201,7 @@ Obj FuncTmpDirectory (
     tmp = SyTmpdir("tm");
     if ( tmp == 0 )
         return Fail;
-    C_NEW_STRING_DYN( name, tmp );
+    name = MakeString(tmp);
     return name;
 }
 
@@ -1313,14 +1313,14 @@ Obj FuncLastSystemError (
     /* check if an errors has occured                                      */
     if ( SyLastErrorNo != 0 ) {
         ASS_REC( err, ErrorNumberRNam, INTOBJ_INT(SyLastErrorNo) );
-        C_NEW_STRING_DYN(msg, SyLastErrorMessage);
+        msg = MakeString(SyLastErrorMessage);
         ASS_REC( err, ErrorMessageRNam, msg );
     }
 
     /* no error has occured                                                */
     else {
         ASS_REC( err, ErrorNumberRNam, INTOBJ_INT(0) );
-        C_NEW_STRING_CONST( msg, "no error" );
+        msg = MakeString("no error");
         ASS_REC( err, ErrorMessageRNam, msg );
     }
 

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -1462,14 +1462,6 @@ void MakeImmutableString( Obj str )
     RetypeBag(str, IMMUTABLE_TNUM(TNUM_OBJ(str)));
 }
 
-
-Obj MakeString(const Char *cstr)
-{
-  Obj result;
-  C_NEW_STRING(result, strlen(cstr), cstr);
-  return result;
-}
-
 Obj MakeString2(const Char *cstr1, const Char *cstr2)
 {
   Obj result;
@@ -1488,13 +1480,6 @@ Obj MakeString3(const Char *cstr1, const Char *cstr2, const Char *cstr3)
   memcpy(CSTR_STRING(result), cstr1, len1);
   memcpy(CSTR_STRING(result)+len1, cstr2, len2);
   memcpy(CSTR_STRING(result)+len1+len2, cstr3, len3);
-  return result;
-}
-
-Obj MakeImmString(const Char *cstr)
-{
-  Obj result = MakeString(cstr);
-  MakeImmutableString(result);
   return result;
 }
 
@@ -1923,7 +1908,7 @@ Obj FuncSplitString (
         part = NEW_STRING(l);
         /* in case of garbage collection we need update */
         s = CHARS_STRING(string);
-        COPY_CHARS(part, s+a, l);
+        COPY_CHARS(part, s + a, l);
         CHARS_STRING(part)[l] = 0;
         pos++;
         AssPlist(res, pos, part);
@@ -1939,7 +1924,7 @@ Obj FuncSplitString (
         l = z-a;
         part = NEW_STRING(l);
         s = CHARS_STRING(string);
-        COPY_CHARS(part, s+a, l);
+        COPY_CHARS(part, s + a, l);
         CHARS_STRING(part)[l] = 0;
         pos++;
         AssPlist(res, pos, part);
@@ -1955,7 +1940,7 @@ Obj FuncSplitString (
     l = z-a;
     part = NEW_STRING(l);
     s = CHARS_STRING(string);
-    COPY_CHARS(part, s+a, l);
+    COPY_CHARS(part, s + a, l);
     CHARS_STRING(part)[l] = 0;
     pos++;
     AssPlist(res, pos, part);

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -1909,7 +1909,7 @@ int GAP_rl_func(int count, int key)
    Int   len, n, hook, dlen, max, i;
 
    /* we shift indices 0-based on C-level and 1-based on GAP level */
-   C_NEW_STRING_DYN(linestr, rl_line_buffer);
+   linestr = MakeString(rl_line_buffer);
    okey = INTOBJ_INT(key + 1000*GAPMacroNumber);
    GAPMacroNumber = 0;
    rldata = NEW_PLIST(T_PLIST, 6);
@@ -2299,8 +2299,8 @@ Char * syFgets (
                    [linestr, ppos, yankstr]
                or an integer, interpreted as number of Esc('N')
                calls for the next lines.                                  */
-            C_NEW_STRING_DYN(linestr,line);
-            C_NEW_STRING_DYN(yankstr,yank);
+            linestr = MakeString(line);
+            yankstr = MakeString(yank);
             args = NEW_PLIST(T_PLIST, 5);
             SET_LEN_PLIST(args, 5);
             SET_ELM_PLIST(args,1,linestr);
@@ -2703,15 +2703,15 @@ Char * syFgets (
     if (line[1] != '\0') {
       /* Now we put the new string into the history,
          we use key handler with key 0 to update the command line history */
-        C_NEW_STRING_DYN(linestr,line);
-        args = NEW_PLIST(T_PLIST, 5);
-        SET_LEN_PLIST(args, 5);
-        SET_ELM_PLIST(args,1,linestr);
-        SET_ELM_PLIST(args,2,INTOBJ_INT(0));
-        SET_ELM_PLIST(args,3,INTOBJ_INT(1));
-        SET_ELM_PLIST(args,4,INTOBJ_INT(length));
-        SET_ELM_PLIST(args,5,linestr);
-        Call1ArgsInNewReader(LineEditKeyHandler, args);
+      linestr = MakeString(line);
+      args = NEW_PLIST(T_PLIST, 5);
+      SET_LEN_PLIST(args, 5);
+      SET_ELM_PLIST(args, 1, linestr);
+      SET_ELM_PLIST(args, 2, INTOBJ_INT(0));
+      SET_ELM_PLIST(args, 3, INTOBJ_INT(1));
+      SET_ELM_PLIST(args, 4, INTOBJ_INT(length));
+      SET_ELM_PLIST(args, 5, linestr);
+      Call1ArgsInNewReader(LineEditKeyHandler, args);
     }
 
     /* send the whole line (unclipped) to the window handler               */


### PR DESCRIPTION
This patch continues moving macros into functions, and adding calls to `GAP_ASSERT`. The only bug uncovered is in the commit 'Only call GET_LEN_STRING after we check we have a string'.

I have not yet removed `C_NEW_STRING_CONST` and `C_NEW_STRING_DYN`, as they are used in packages (mine at least), I will work on getting them removed from packages later.

Note, as mentioned in the pull request, I use the fact that gcc and clang will both, at `-O`, inline `MakeString`, and then evaluate `strlen` on a constant string, so there is no need to special case constant strings.

Some calls to `MakeString` could probably be `MakeImmString`, but I decided to keep constifying of the kernel/library to seperate PRs.