### PR TITLE
Travis: remove oracle-java9-installer as a workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ matrix:
       sudo: required    # trusty containers are missing libgmp:i386, use sudo-enabled infrastructure instead
       before_install:
         - sudo apt-get -qq update
-        - sudo apt-get install gcc-multilib g++-multilib # libgmp-dev:i386 is currently broken
+        - sudo apt-get remove oracle-java9-installer # workaround bug
+        - sudo apt-get install gcc-multilib g++-multilib libgmp-dev:i386
 
     # OS X builds: since those are slow and limited on Travis, we only run testinstall
     - env: TEST_SUITE=testinstall
@@ -62,7 +63,8 @@ matrix:
       sudo: required    # trusty containers are missing libgmp:i386, use sudo-enabled infrastructure instead
       before_install:
         - sudo apt-get -qq update
-        - sudo apt-get install gcc-multilib g++-multilib # libgmp-dev:i386 is currently broken
+        - sudo apt-get remove oracle-java9-installer # workaround bug
+        - sudo apt-get install gcc-multilib g++-multilib libgmp-dev:i386
 
     # run bugfix regression tests
     - env: TEST_SUITE=testbugfix CONFIGFLAGS="--enable-debug"


### PR DESCRIPTION
For some reasons, installing libgmp-dev:i386 causes apt-get to try and update `oracle-java9-installer`, which fails. To work around that, we simply remove `oracle-java9-installer` first.