### PR TITLE
Travis: switch 32 bit builds to use container based builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ addons:
   apt_packages:
     - libgmp-dev
     - libreadline-dev
+    - libgmp-dev:i386
+    - libreadline-dev:i386
     - gcc-multilib
     - g++-multilib
     - texinfo
@@ -23,10 +25,6 @@ matrix:
     # general test suite (subsumes testinstall tests, too)
     - env: TEST_SUITE=testtravis CONFIGFLAGS="--enable-debug"
     - env: TEST_SUITE=testtravis ABI=32 CONFIGFLAGS="--enable-debug"
-      sudo: required    # trusty containers are missing libgmp:i386, use sudo-enabled infrastructure instead
-      before_install:
-        - sudo apt-get -qq update
-        - sudo apt-get install gcc-multilib g++-multilib # libgmp-dev:i386 is currently broken
 
     # OS X builds: since those are slow and limited on Travis, we only run testinstall
     - env: TEST_SUITE=testinstall
@@ -59,10 +57,6 @@ matrix:
     # tests at least once with the ReproducibleBehaviour option turned off.
     - env: TEST_SUITE=testinstall NO_COVERAGE=1 ABI=64 BUILDDIR=build CONFIGFLAGS="--enable-debug"
     - env: TEST_SUITE=testinstall NO_COVERAGE=1 ABI=32 BUILDDIR=build CONFIGFLAGS="--enable-debug"
-      sudo: required    # trusty containers are missing libgmp:i386, use sudo-enabled infrastructure instead
-      before_install:
-        - sudo apt-get -qq update
-        - sudo apt-get install gcc-multilib g++-multilib # libgmp-dev:i386 is currently broken
 
     # run bugfix regression tests
     - env: TEST_SUITE=testbugfix CONFIGFLAGS="--enable-debug"


### PR DESCRIPTION
Container based builds start faster.

This is an alternative to PR #1509 (but most likely, it just won't work, due to `libgmp-dev:i386` (still) not being available in the container builds... but I figured it's worth a try.