### PR TITLE
WIP: MatrixObj work (revised)

### DIFF
--- a/doc/ref/lists.xml
+++ b/doc/ref/lists.xml
@@ -1657,6 +1657,7 @@ with possibly slightly different meaning for lists and non-list collections.
 <#Include Label="DuplicateFreeList">
 <#Include Label="AsDuplicateFreeList">
 <#Include Label="Flat">
+<#Include Label="FoldList">
 <#Include Label="Reversed">
 <#Include Label="Shuffle">
 <#Include Label="IsLexicographicallyLess">

--- a/doc/ref/matobj.xml
+++ b/doc/ref/matobj.xml
@@ -4,8 +4,8 @@
 <!--   Copyright (C) 2011 The GAP Group                                   -->
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 
-<Chapter Label="Matrix objects">
-<Heading>Vector and matrix objects</Heading>
+<Chapter Label="Vector and Matrix Objects">
+<Heading>Vector and Matrix Objects</Heading>
 
 This chapter is work in progress. It will eventually describe the new
 interface to vector and matrix objects.
@@ -20,34 +20,33 @@ To eventually solve
 this problem, this chapter describes a new programming interface to
 vectors and matrices.
 
-<Section>
-    <Heading>Fundamental ideas and rules</Heading>
+<Section Label="Fundamental Ideas and Rules">
+    <Heading>Fundamental Ideas and Rules</Heading>
 
 <#Include Label="MatObj_Overview">
 
 </Section>
 
-<Section>
-    <Heading>Categories of vectors and matrices</Heading>
+<Section Label="Categories of Vectors and Matrices">
+    <Heading>Categories of Vectors and Matrices</Heading>
 
 </Section>
 
-<Section>
-    <Heading>Constructing vector and matrix objects</Heading>
+<Section Label="Constructing Vector and Matrix Objects">
+    <Heading>Constructing Vector and Matrix Objects</Heading>
 </Section>
 
-<Section>
-    <Heading>Operations for row vector objects</Heading>
+<Section Label="Operations for Vector Objects">
+    <Heading>Operations for Vector Objects</Heading>
+</Section>
+
+<Section Label="Operations for Row List Matrix Objects">
+    <Heading>Operations for Row List Matrix Objects</Heading>
 
 </Section>
 
-<Section>
-    <Heading>Operations for row list matrix objects</Heading>
-
-</Section>
-
-<Section>
-    <Heading>Operations for flat matrix objects</Heading>
+<Section Label="Operations for Flat Matrix Objects">
+    <Heading>Operations for Flat Matrix Objects</Heading>
 
 </Section>
 

--- a/doc/ref/matobj.xml
+++ b/doc/ref/matobj.xml
@@ -38,6 +38,19 @@ vectors and matrices.
 
 <Section Label="Operations for Vector Objects">
     <Heading>Operations for Vector Objects</Heading>
+
+    <#Include Label="MatObj_PositionNonZero">
+    <#Include Label="MatObj_PositionLastNonZero">
+    <#Include Label="MatObj_ListOp">
+    <#Include Label="MatObj_UnpackVector">
+    <#Include Label="MatObj_ConcatenationOfVectors">
+    <#Include Label="MatObj_ExtractSubVector">
+    <#Include Label="MatObj_ZeroVector">
+    <#Include Label="MatObj_ConstructingFilter_Vector">
+    <#Include Label="MatObj_Randomize_Vectors">
+    <#Include Label="MatObj_WeightOfVector">
+    <#Include Label="MatObj_DistanceOfVectors">
+
 </Section>
 
 <Section Label="Operations for Row List Matrix Objects">

--- a/doc/ref/matrix.xml
+++ b/doc/ref/matrix.xml
@@ -13,7 +13,7 @@
 
 Matrices are represented in &GAP; by lists of row vectors
 (see <Ref Chap="Row Vectors"/>) (for future changes to this
-policy see Chapter <Ref Chap="Matrix objects"/>).
+policy see Chapter <Ref Chap="Vector and Matrix Objects"/>).
 The vectors must all have the same length, and their elements must lie in
 a common ring. However, since checking rectangularness can be expensive
 functions and methods of operations for matrices often will not give an error

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -223,7 +223,8 @@ InstallMethod( \+, "For a GF2 vector and an 8 bit vector of char 2",
     if IsLockedRepresentationVector(v) then
         TryNextMethod();
     else
-        return CopyToVectorRep(v,Q_VEC8BIT(w)) + w;
+        v := CopyToVectorRep(v,Q_VEC8BIT(w));
+        return v+w;
     fi;
 end);
 
@@ -234,7 +235,8 @@ InstallMethod( \+, "For an 8 bit vector of char 2 and a GF2 vector",
     if IsLockedRepresentationVector(v) then
         TryNextMethod();
     else
-        return w + CopyToVectorRep(v,Q_VEC8BIT(w));
+        v := CopyToVectorRep(v,Q_VEC8BIT(w));
+        return w+v;
     fi;
 end);
 
@@ -354,7 +356,8 @@ function( a, b )
     if DegreeFFE(a) > 8 or IsLockedRepresentationVector(b) then
         TryNextMethod();
     else
-        return a*CopyToVectorRep(b,Size(Field(a)));
+        b := CopyToVectorRep(b,Size(Field(a)));
+        return a*b;
     fi;
 end );
 
@@ -388,7 +391,8 @@ function( b, a )
     if DegreeFFE(b) > 8 or IsLockedRepresentationVector(a) then
         TryNextMethod();
     else
-        return b*CopyToVectorRep(a,Size(Field(b)));
+        a := CopyToVectorRep(a,Size(Field(b)));
+        return b*a;
     fi;
 end );
 
@@ -410,7 +414,8 @@ InstallMethod( \-, "For a GF2 vector and an 8 bit vector of char 2",
     if IsLockedRepresentationVector(v) then
         TryNextMethod();
     else
-        return CopyToVectorRep(v,Q_VEC8BIT(w))-w;
+        v := CopyToVectorRep(v,Q_VEC8BIT(w));
+        return v-w;
     fi;
 end);
 
@@ -421,7 +426,8 @@ InstallMethod( \-, "For an 8 bit vector of char 2 and a GF2 vector",
     if IsLockedRepresentationVector(v) then
         TryNextMethod();
     else
-        return w-CopyToVectorRep(v,Q_VEC8BIT(w));
+        v := CopyToVectorRep(v,Q_VEC8BIT(w));
+        return w-v;
     fi;
 end);
 
@@ -529,7 +535,8 @@ InstallMethod( \*, "For a GF2 vector and an 8 bit vector of char 2",
     if IsLockedRepresentationVector(v) then
         TryNextMethod();
     else
-        return CopyToVectorRep(v,Q_VEC8BIT(w))*w;
+        v := CopyToVectorRep(v,Q_VEC8BIT(w));
+        return v*w;
     fi;
 end);
 
@@ -540,7 +547,8 @@ InstallMethod( \*, "For an 8 bit vector of char 2 and a GF2 vector",
     if IsLockedRepresentationVector(v) then
         TryNextMethod();
     else
-        return w*CopyToVectorRep(v,Q_VEC8BIT(w));
+        v := CopyToVectorRep(v,Q_VEC8BIT(w));
+        return w*v;
     fi;
 end);
 
@@ -694,7 +702,8 @@ InstallOtherMethod( AddCoeffs, "8 bit vector and GF2 vector", IsCollsCollsElms,
     if IsLockedRepresentationVector(w) then
         TryNextMethod();
     else
-        return ADD_COEFFS_VEC8BIT_3(v,CopyToVectorRep(w, Q_VEC8BIT(v)),x);
+        w := CopyToVectorRep(w, Q_VEC8BIT(v));
+        return ADD_COEFFS_VEC8BIT_3(v,w,x);
     fi;
 end);
 
@@ -727,7 +736,8 @@ InstallOtherMethod( AddCoeffs, "8 bit vector and GF2 vector", IsIdenticalObj,
     if IsLockedRepresentationVector(w) then
         TryNextMethod();
     else
-        return ADD_COEFFS_VEC8BIT_2(v,CopyToVectorRep(w, Q_VEC8BIT(v)));
+        w := CopyToVectorRep(w, Q_VEC8BIT(v));
+        return ADD_COEFFS_VEC8BIT_2(v,w);
     fi;
 end);
 

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1032,8 +1032,10 @@ InstallMethod( BaseDomain, "for an 8bit vector",
   [ Is8BitVectorRep ], function( v ) return GF(Q_VEC8BIT(v)); end );
 InstallMethod( BaseDomain, "for an 8bit matrix",
   [ Is8BitMatrixRep ], function( m ) return GF(Q_VEC8BIT(m[1])); end );
+InstallMethod( NumberRows, "for an 8bit matrix",
+  [ Is8BitMatrixRep ], m -> m![1]);
 # FIXME: this breaks down for matrices with 0 rows
-InstallMethod( RowLength, "for an 8bit matrix",
+InstallMethod( NumberColumns, "for an 8bit matrix",
   [ Is8BitMatrixRep ], function( m ) return Length(m[1]); end );
 # FIXME: this breaks down for matrices with 0 rows
 InstallMethod( Vector, "for a plist of finite field elements and an 8bitvector",

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2331,7 +2331,9 @@ InstallMethod( BaseDomain, "for a gf2 vector",
   [ IsGF2VectorRep ], function( v ) return GF(2); end );
 InstallMethod( BaseDomain, "for a gf2 matrix",
   [ IsGF2MatrixRep ], function( m ) return GF(2); end );
-InstallMethod( RowLength, "for a gf2 matrix",
+InstallMethod( NumberRows, "for a gf2 matrix",
+  [ IsGF2MatrixRep ], m -> m![1]);
+InstallMethod( NumberColumns, "for a gf2 matrix",
   [ IsGF2MatrixRep ], function( m ) return Length(m[1]); end );
 # FIXME: this breaks down for matrices with 0 rows
 InstallMethod( Vector, "for a list of gf2 elements and a gf2 vector",

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2411,10 +2411,10 @@ BindGlobal( "PositionLastNonZeroFunc2",
 
 InstallMethod( PositionLastNonZero, "for a row vector obj",
   [IsVectorObj], PositionLastNonZeroFunc );
-InstallMethod( PositionLastNonZero, "for a matrix obj",
-  [IsMatrixObj], PositionLastNonZeroFunc );
-InstallMethod( PositionLastNonZero, "for a matrix obj, and an index",
-  [IsMatrixObj, IsPosInt], PositionLastNonZeroFunc2 );
+# InstallMethod( PositionLastNonZero, "for a matrix obj",
+#   [IsMatrixObj], PositionLastNonZeroFunc );
+# InstallMethod( PositionLastNonZero, "for a matrix obj, and an index",
+#   [IsMatrixObj, IsPosInt], PositionLastNonZeroFunc2 );
         
 InstallMethod( ExtractSubMatrix, "for a gf2 matrix, and two lists",
   [IsGF2MatrixRep, IsList, IsList],

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -1398,6 +1398,31 @@ DeclareOperation( "DifferenceLists", [IsList, IsList] );
 ##
 DeclareOperation( "Flat", [ IsList ] );
 
+#############################################################################
+##
+#O  FoldList( <list>, <len> )  . . . . fold list to sublists of length len
+##
+##  <#GAPDoc Label="FoldList">
+##  <ManSection>
+##  <Oper Name="FoldList" Arg='list, len'/>
+##
+##  <Description>
+##  returns a list of sublists of <A>list</A> of length <A>len</A>. 
+##  More precisely, the i-th sublist in the result is
+##  <A>list</A><C>{[(i-1)<A>len</A>+1..i <A>len</A>]}</C>.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> fl := FoldList([1,2,3,4,5,6], 3);
+##  [ [ 1, 2, 3 ], [ 4, 5, 6 ] ]
+##  gap> Flat(fl);
+##  [ 1, 2, 3, 4, 5, 6 ]
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation( "FoldList", [ IsList, IS_INT ] );
+
 
 #############################################################################
 ##

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -2089,6 +2089,26 @@ InstallMethod( Flat,
 
 #############################################################################
 ##
+#M  FoldList( <list>, <len> )  . . . . . . fold list to sublists of length len
+##
+InstallMethod( FoldList,
+    "for a list and posint",
+    [IsList, IsPosInt],
+    function( list, rlen )
+      local res, len, i;
+      res := [];
+      i := 0;
+      len := Length(list);
+      while i < len do
+        Add(res, list{[i+1..i+rlen]});
+        i := i + rlen;
+      od;
+      return res;
+    end);
+
+
+#############################################################################
+##
 #F  Reversed( <list> )  . . . . . . . . . . .  reverse the elements in a list
 ##
 ##  Note that the special case that <list> is a range is dealt with by the

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -438,64 +438,65 @@ InstallMethod( TraceMat, "generic method",
 
 
 InstallMethod(PositionNonZero,
-  "General method for a row vector",
-  true,[IsRowVector],0,
+  "generic method for a row vector",
+  [IsRowVector],
   function(vec)
   local i;
   for i in [1..Length(vec)] do
-    if not IsZero(vec[i]) then return i;fi;
+    if not IsZero(vec[i]) then return i; fi;
   od;
-  return Length(vec)+1;
+  return i+1;
 end);
 
 InstallMethod(PositionNonZero,
-  "General method for a vector",
-  true,[IsVectorObj],0,
+  "generic method for a vector object",
+  [ IsVectorObj ],
   function(vec)
   local i;
   for i in [1..Length(vec)] do
-    if not IsZero(vec[i]) then return i;fi;
+    if not IsZero(vec[i]) then return i; fi;
   od;
-  return Length(vec)+1;
+  return i+1;
 end);
 
 InstallMethod( ListOp,
-  "General method for a vector",
-  true,[IsVectorObj],0,
+  "generic method for a vector object",
+  [ IsVectorObj ],
   function(vec)
-  local return_list, i, length_vector;
-  length_vector := Length(vec);
-  return_list := [];
-  return_list[length_vector] := vec[length_vector];
-  for i in [ 1 .. length_vector - 1 ] do
-    return_list[i] := vec[i];
+  local result, i, len;
+  len := Length(vec);
+  result := [];
+  result[len] := vec[len];
+  for i in [ 1 .. len - 1 ] do
+    result[i] := vec[i];
   od;
-  return return_list;
+  return result;
 end );
 
 InstallMethod( ListOp,
-  "General method for a vector and a function",
-  true,[IsVectorObj,IsFunction],0,
+  "generic method for a vector object and a function",
+  [ IsVectorObj, IsFunction ],
   function(vec,func)
-  local return_list, i, length_vector;
-  length_vector := Length(vec);
-  return_list := [];
-  return_list[length_vector] := func(vec[length_vector]);
-  for i in [ 1 .. length_vector - 1 ] do
-    return_list[i] := func(vec[i]);
+  local result, i, len;
+  len := Length(vec);
+  result := [];
+  result[len] := func(vec[len]);
+  for i in [ 1 .. len - 1 ] do
+    result[i] := func(vec[i]);
   od;
-  return return_list;
+  return result;
 end );
 
 InstallMethod( Unpack,
-  "General method for a vector",
-  true,[IsVectorObj],0,
+  "generic method for a vector object",
+  [ IsVectorObj ],
   ListOp ); ## Potentially slower than a direct implementation,
-            ## but avoids code multiplication.
+            ## but avoids code duplication.
 
 
 InstallMethod( \{\},
-               [IsVectorObj,IsList],
+  "generic method for a vector object and a list",
+  [ IsVectorObj, IsList ],
   function(vec,pos)
     local vec_list;
     vec_list := ListOp(vec);
@@ -504,8 +505,8 @@ InstallMethod( \{\},
 end );
 
 InstallMethod( CopySubVector,
-  "General method for vectors",
-  true,[IsVectorObj and IsMutable, IsList, IsVectorObj, IsList],0,
+  "generic method for vectors",
+  [ IsVectorObj and IsMutable, IsList, IsVectorObj, IsList ],
   function(dst, dcols, src, scols)
     local i;
     if not Length( dcols ) = Length( scols ) then
@@ -519,15 +520,15 @@ end );
 
 ## Backwards compatible version
 InstallMethod( CopySubVector,
-  "Fallback method for vectors",
-  true,[IsVectorObj,IsVectorObj and IsMutable, IsList, IsList],0,
+  "generic method for vectors",
+  [ IsVectorObj, IsVectorObj and IsMutable, IsList, IsList ],
   function(src, dst, scols, dcols)
     CopySubVector(dst,dcols,src,scols);
 end );
 
 InstallMethod( Randomize,
-  "general method for vectors",
-  true, [ IsVectorObj and IsMutable ],0,
+  "generic method for a vector",
+  [ IsVectorObj and IsMutable ],
   function(vec)
     local basedomain, i;
     basedomain := BaseDomain( vec );
@@ -537,8 +538,8 @@ InstallMethod( Randomize,
 end );
 
 InstallMethod( Randomize,
-  "general method for vectors",
-  true, [ IsVectorObj and IsMutable, IsRandomSource ],0,
+  "generic method for a vector and a random source",
+  [ IsVectorObj and IsMutable, IsRandomSource ],
   function(vec, rs)
     local basedomain, i;
     basedomain := BaseDomain( vec );

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -20,7 +20,6 @@ InstallOtherMethod( \[\], [ IsMatrixObj, IsList ], {m,l} -> MatElm(m,l[1],l[2]))
 InstallOtherMethod( \[\]\:\=, [ IsMatrixObj, IsList, IsObject ], function(m,l,o) SetMatElm(m, l[1], l[2], o); end);
 
 
-
 InstallMethod( WeightOfVector, "generic method",
   [IsVectorObj],
   function(v)
@@ -437,3 +436,113 @@ InstallMethod( TraceMat, "generic method",
     return s;
   end );
 
+
+InstallMethod(PositionNonZero,
+  "General method for a row vector",
+  true,[IsRowVector],0,
+  function(vec)
+  local i;
+  for i in [1..Length(vec)] do
+    if not IsZero(vec[i]) then return i;fi;
+  od;
+  return Length(vec)+1;
+end);
+
+InstallMethod(PositionNonZero,
+  "General method for a vector",
+  true,[IsVectorObj],0,
+  function(vec)
+  local i;
+  for i in [1..Length(vec)] do
+    if not IsZero(vec[i]) then return i;fi;
+  od;
+  return Length(vec)+1;
+end);
+
+InstallMethod( ListOp,
+  "General method for a vector",
+  true,[IsVectorObj],0,
+  function(vec)
+  local return_list, i, length_vector;
+  length_vector := Length(vec);
+  return_list := [];
+  return_list[length_vector] := vec[length_vector];
+  for i in [ 1 .. length_vector - 1 ] do
+    return_list[i] := vec[i];
+  od;
+  return return_list;
+end );
+
+InstallMethod( ListOp,
+  "General method for a vector and a function",
+  true,[IsVectorObj,IsFunction],0,
+  function(vec,func)
+  local return_list, i, length_vector;
+  length_vector := Length(vec);
+  return_list := [];
+  return_list[length_vector] := func(vec[length_vector]);
+  for i in [ 1 .. length_vector - 1 ] do
+    return_list[i] := func(vec[i]);
+  od;
+  return return_list;
+end );
+
+InstallMethod( Unpack,
+  "General method for a vector",
+  true,[IsVectorObj],0,
+  ListOp ); ## Potentially slower than a direct implementation,
+            ## but avoids code multiplication.
+
+
+InstallMethod( \{\},
+               [IsVectorObj,IsList],
+  function(vec,pos)
+    local vec_list;
+    vec_list := ListOp(vec);
+    vec_list := vec_list{[pos]};
+    return Vector(vec_list,vec);
+end );
+
+InstallMethod( CopySubVector,
+  "General method for vectors",
+  true,[IsVectorObj and IsMutable, IsList, IsVectorObj, IsList],0,
+  function(dst, dcols, src, scols)
+    local i;
+    if not Length( dcols ) = Length( scols ) then
+      Error( "source and destination index lists must be of equal length" );
+      return;
+    fi;
+    for i in [ 1 .. Length( dcols ) ] do
+      dst[dcols[i]] := src[scols[i]];
+    od;
+end );
+
+## Backwards compatible version
+InstallMethod( CopySubVector,
+  "Fallback method for vectors",
+  true,[IsVectorObj,IsVectorObj and IsMutable, IsList, IsList],0,
+  function(src, dst, scols, dcols)
+    CopySubVector(dst,dcols,src,scols);
+end );
+
+InstallMethod( Randomize,
+  "general method for vectors",
+  true, [ IsVectorObj and IsMutable ],0,
+  function(vec)
+    local basedomain, i;
+    basedomain := BaseDomain( vec );
+    for i in [ 1 .. Length( vec ) ] do
+        vec[ i ] := Random( basedomain );
+    od;
+end );
+
+InstallMethod( Randomize,
+  "general method for vectors",
+  true, [ IsVectorObj and IsMutable, IsRandomSource ],0,
+  function(vec, rs)
+    local basedomain, i;
+    basedomain := BaseDomain( vec );
+    for i in [ 1 .. Length( vec ) ] do
+        vec[ i ] := Random( rs, basedomain );
+    od;
+end );

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -12,6 +12,15 @@
 ############################################################################
 
 
+# TEMPORARY HACK
+InstallOtherMethod( \[\], [ IsMatrix, IsList ], {m,l} -> m[l[1]][l[2]] );
+InstallOtherMethod( \[\]\:\=, [ IsMatrix and IsMutable, IsList, IsObject ], function(m,l,o) m[l[1]][l[2]] := o; end);
+
+InstallOtherMethod( \[\], [ IsMatrixObj, IsList ], {m,l} -> MatElm(m,l[1],l[2]));
+InstallOtherMethod( \[\]\:\=, [ IsMatrixObj, IsList, IsObject ], function(m,l,o) SetMatElm(m, l[1], l[2], o); end);
+
+
+
 InstallMethod( WeightOfVector, "generic method",
   [IsVectorObj],
   function(v)

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -54,6 +54,15 @@ InstallMethod( DistanceOfVectors, "generic method",
 #
 # TODO: possibly rename the following
 #
+BindGlobal( "DefaultVectorRepForBaseDomain",
+function( basedomain )
+    if IsFinite(basedomain) and IsField(basedomain) and Size(basedomain) = 2 then
+        return IsGF2VectorRep;
+    elif IsFinite(basedomain) and IsField(basedomain) and Size(basedomain) <= 256 then
+        return Is8BitVectorRep;
+    fi;
+    return IsPlistVectorRep;
+end);
 BindGlobal( "DefaultMatrixRepForBaseDomain",
 function( basedomain )
     if IsFinite(basedomain) and IsField(basedomain) and Size(basedomain) = 2 then
@@ -64,6 +73,53 @@ function( basedomain )
     return IsPlistMatrixRep;
 end);
 
+
+
+# methods to create vectors
+
+InstallMethod( Vector,
+  [IsOperation, IsSemiring,  IsList],
+function(rep, base, l)
+  return NewVector(rep, base, l);
+end);
+
+InstallMethod( Vector,
+  [IsOperation, IsSemiring,  IsVectorObj],
+function(rep, base, v)
+  return NewVector(rep, base, Unpack(v));
+end);
+
+InstallMethod( Vector,
+  [IsSemiring,  IsList],
+function(base, l)
+  return NewVector(DefaultVectorRepForBaseDomain(base), base, l);
+end);
+
+InstallMethod( Vector,
+  [IsSemiring,  IsVectorObj],
+function(base, v)
+  return NewVector(DefaultVectorRepForBaseDomain(base), base, Unpack(v));
+end);
+
+InstallMethod( Vector,
+  [IsList, IsVectorObj],
+function(l, example)
+  return NewVector(ConstructingFilter(example), BaseDomain(example), l);
+end);
+
+InstallMethod( Vector,
+  [IsVectorObj, IsVectorObj],
+function(v, example)
+  return NewVector(ConstructingFilter(example), BaseDomain(example), Unpack(v));
+end);
+
+InstallMethod( Vector,
+  [IsList],
+function(l)
+  local dom;
+  dom := DefaultScalarDomainOfMatrixList([[l]]);
+  return NewVector(DefaultVectorRepForBaseDomain(dom), dom, l);
+end);
 #
 #
 #

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -42,17 +42,169 @@ InstallMethod( DistanceOfVectors, "generic method",
     return n;
   end );
 
+#
+# TODO: possibly rename the following
+#
+BindGlobal( "DefaultMatrixRepForBaseDomain",
+function( basedomain )
+    if IsFinite(basedomain) and IsField(basedomain) and Size(basedomain) = 2 then
+        return IsGF2MatrixRep;
+    elif IsFinite(basedomain) and IsField(basedomain) and Size(basedomain) <= 256 then
+        return Is8BitMatrixRep;
+    fi;
+    return IsPlistMatrixRep;
+end);
+
+#
+#
+#
+InstallMethod( Matrix,
+  [IsOperation, IsSemiring, IsList, IsInt],
+  function( rep, basedomain, list, nrCols )
+    # TODO: adjust NewMatrix to use same arg order as Matrix (or vice-versa)
+    return NewMatrix( rep, basedomain, nrCols, list );
+  end );
+
+InstallMethod( Matrix,
+  [IsOperation, IsSemiring, IsList],
+  function( rep, basedomain, list )
+    if Length(list) = 0 then Error("list must be not empty; to create empty matrices, please specify nrCols"); fi;
+    return NewMatrix( rep, basedomain, Length(list[1]), list );
+  end );
+
+InstallMethod( Matrix,
+  [IsOperation, IsSemiring, IsMatrixObj],
+  function( rep, basedomain, mat )
+    # TODO: can we do better? encourage MatrixObj implementors to overload this?
+    return NewMatrix( rep, basedomain, NrCols(mat), Unpack(mat) );
+  end );
+
+#
+#
+#
+InstallMethod( Matrix,
+  [IsSemiring, IsList, IsInt],
+  function( basedomain, list, nrCols )
+    local rep;
+    rep := DefaultMatrixRepForBaseDomain(basedomain);
+    return NewMatrix( rep, basedomain, nrCols, list );
+  end );
+
+InstallMethod( Matrix,
+  [IsSemiring, IsList],
+  function( basedomain, list )
+    local rep;
+    if Length(list) = 0 then Error("list must be not empty"); fi;
+    rep := DefaultMatrixRepForBaseDomain(basedomain);
+    return NewMatrix( rep, basedomain, Length(list[1]), list );
+  end );
+
+InstallMethod( Matrix,
+  [IsSemiring, IsMatrixObj],
+  function( basedomain, mat )
+    # TODO: can we do better? encourage MatrixObj implementors to overload this?
+    return NewMatrix( DefaultMatrixRepForBaseDomain(basedomain), basedomain, NrCols(mat), Unpack(mat) );
+  end );
+
+#
+#
+#
+InstallMethod( Matrix,
+  [IsList, IsInt],
+  function( list, nrCols )
+    local basedomain, rep;
+    if Length(list) = 0 then Error("list must be not empty"); fi;
+    if Length(list[1]) = 0 then Error("list[1] must be not empty, please specify base domain explicitly"); fi;
+    basedomain := DefaultScalarDomainOfMatrixList([list]);
+    rep := DefaultMatrixRepForBaseDomain(basedomain);
+    return NewMatrix( rep, basedomain, nrCols, list );
+  end );
+
+InstallMethod( Matrix,
+  [IsList],
+  function( list )
+    local rep, basedomain;
+    if Length(list) = 0 then Error("list must be not empty"); fi;
+    if Length(list[1]) = 0 then Error("list[1] must be not empty, please specify base domain explicitly"); fi;
+    basedomain := DefaultScalarDomainOfMatrixList([list]);
+    rep := DefaultMatrixRepForBaseDomain(basedomain);
+    return NewMatrix( rep, basedomain, Length(list[1]), list );
+  end );
+
+#
+# matrix constructors using example objects (as last argument)
+#
+InstallMethod( Matrix,
+  [IsList, IsInt, IsMatrixObj],
+  function( list, nrCols, example )
+    return NewMatrix( ConstructingFilter(example), BaseDomain(example), nrCols, list );
+  end );
+
 InstallMethod( Matrix, "generic convenience method with 2 args",
-  [IsList,IsMatrixObj],
-  function( l, m )
-    if Length(l) = 0 then
+  [IsList, IsMatrixObj],
+  function( list, example )
+    if Length(list) = 0 then
         ErrorNoReturn("Matrix: two-argument version not allowed with empty first arg");
     fi;
-    if not (IsList(l[1]) or IsVectorObj(l[1])) then
+    if not (IsList(list[1]) or IsVectorObj(list[1])) then
         ErrorNoReturn("Matrix: flat data not supported in two-argument version");
     fi;
-    return Matrix(l,Length(l[1]),m);
+    return NewMatrix( ConstructingFilter(example), BaseDomain(example), Length(list[1]), list );
   end );
+
+InstallMethod( Matrix,
+  [IsMatrixObj, IsMatrixObj],
+  function( mat, example )
+    # TODO: can we avoid using Unpack? resp. make this more efficient
+    # perhaps adjust NewMatrix to take an IsMatrixObj?
+    return NewMatrix( ConstructingFilter(example), BaseDomain(example), NrCols(mat), Unpack(mat) );
+  end );
+
+#
+#
+#
+InstallMethod( ZeroMatrix,
+  [IsInt, IsInt, IsMatrixObj],
+  function( rows, cols, example )
+    return ZeroMatrix( ConstructingFilter(example), BaseDomain(example), rows, cols );
+  end );
+
+InstallMethod( ZeroMatrix,
+  [IsSemiring, IsInt, IsInt],
+  function( basedomain, rows, cols )
+    return ZeroMatrix( DefaultMatrixRepForBaseDomain(basedomain), basedomain, rows, cols );
+  end );
+
+InstallMethod( ZeroMatrix,
+  [IsOperation, IsSemiring, IsInt, IsInt],
+  function( rep, basedomain, rows, cols )
+    # TODO: urge matrixobj implementors to overload this
+    return NewMatrix( rep, basedomain, cols, ListWithIdenticalEntries( rows * cols, Zero(basedomain) ) );
+  end );
+
+#
+#
+#
+InstallMethod( IdentityMatrix,
+  [IsInt, IsMatrixObj],
+  function( dim, example )
+    return IdentityMatrix( ConstructingFilter(example), BaseDomain(example), dim );
+  end );
+
+InstallMethod( IdentityMatrix,
+  [IsSemiring, IsInt],
+  function( basedomain, dim )
+    return IdentityMatrix( DefaultMatrixRepForBaseDomain(basedomain), basedomain, dim );
+  end );
+
+InstallMethod( IdentityMatrix,
+  [IsOperation, IsSemiring, IsInt],
+  function( rep, basedomain, dim )
+    # TODO: avoid using IdentityMat eventually
+    return NewMatrix( rep, basedomain, dim, IdentityMat( dim, basedomain ) );
+  end );
+
+
 
 InstallMethod( Unfold, "for a matrix object, and a vector object",
   [ IsMatrixObj, IsVectorObj ],
@@ -180,35 +332,6 @@ InstallGlobalFunction( MakeVector,
         ty := IsPlistVectorRep;
     fi;
     return NewVector(ty,bd,l);
-  end );
-
-InstallGlobalFunction( MakeMatrix,
-  function( arg )
-    local bd,l,len,rowlen,ty;
-    if Length(arg) = 1 then
-        l := arg[1];
-        bd := DefaultFieldOfMatrix(l);
-    elif Length(arg) <> 2 then
-        Error("usage: MakeVector( <list> [,<basedomain>] )");
-        return fail;
-    else
-        l := arg[1];
-        bd := arg[2];
-    fi;
-    len := Length(l);
-    if len = 0 then
-        Error("does not work for matrices with zero rows");
-        return fail;
-    fi;
-    rowlen := Length(l[1]);
-    if IsFinite(bd) and IsField(bd) and Size(bd) = 2 then
-        ty := IsGF2MatrixRep;
-    elif IsFinite(bd) and IsField(bd) and Size(bd) <= 256 then
-        ty := Is8BitMatrixRep;
-    else
-        ty := IsPlistMatrixRep;
-    fi;
-    return NewMatrix(ty,bd,rowlen,l);
   end );
 
 InstallMethod( ExtractSubVector, "generic method",

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -61,7 +61,7 @@ InstallMethod( Unfold, "for a matrix object, and a vector object",
     if Length(m) = 0 then
         return ZeroVector(0,w);
     else
-        l := RowLength(m);
+        l := NumberColumns(m);
         v := ZeroVector(Length(m)*l,w);
         for i in [1..Length(m)] do
             CopySubVector( m[i], v, [1..l], [(i-1)*l+1..i*l] );
@@ -114,10 +114,10 @@ InstallMethod( KroneckerProduct, "for two matrices",
         ErrorNoReturn("KroneckerProduct: Matrices not over same base domain");
     fi;
 
-    rowsA := Length(A);
-    colsA := RowLength(A);
-    rowsB := Length(B);
-    colsB := RowLength(B);
+    rowsA := NumberRows(A);
+    colsA := NumberColumns(A);
+    rowsB := NumberRows(B);
+    colsB := NumberColumns(B);
 
     AxB := ZeroMatrix( rowsA * rowsB, colsA * colsB, A );
 
@@ -239,11 +239,11 @@ InstallMethod( TraceMat, "generic method",
     local bd,i,s;
     bd := BaseDomain(m);
     s := Zero(bd);
-    if Length(m) <> RowLength(m) then
+    if NumberRows(m) <> NumberColumns(m) then
         Error("matrix must be square");
         return fail;
     fi;
-    for i in [1..Length(m)] do
+    for i in [1..NumberRows(m)] do
         s := s + MatElm(m,i,i);
     od;
     return s;

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -397,21 +397,20 @@ DeclareOperation( "[]", [IsMatrixObj,IsPosInt] );  # <mat>, <pos>
 # access to work. Note that this will never be particularly efficient
 # for matrices which are not row-lists. Efficient code will have to use MatElm and
 # SetMatElm instead.
-
+# FIXME: Actually, we should probably not defined these for matrices, only for vectors
 # These should probably only be defined for RowListMatrices???
-
-DeclareOperation( "PositionNonZero", [IsMatrixObj] );
-DeclareOperation( "PositionNonZero", [IsMatrixObj, IsInt] );
-
-DeclareOperation( "PositionLastNonZero", [IsMatrixObj] );
-DeclareOperation( "PositionLastNonZero", [IsMatrixObj, IsInt] );
-
-DeclareOperation( "Position", [IsMatrixObj, IsVectorObj] );
-DeclareOperation( "Position", [IsMatrixObj, IsVectorObj, IsInt] );
-
-# This allows for usage of PositionSorted:
-DeclareOperation( "PositionSortedOp", [IsMatrixObj, IsVectorObj] );
-DeclareOperation( "PositionSortedOp",[IsMatrixObj,IsVectorObj,IsFunction]);
+#DeclareOperation( "PositionNonZero", [IsMatrixObj] );
+#DeclareOperation( "PositionNonZero", [IsMatrixObj, IsInt] );
+#
+#DeclareOperation( "PositionLastNonZero", [IsMatrixObj] );
+#DeclareOperation( "PositionLastNonZero", [IsMatrixObj, IsInt] );
+#
+#DeclareOperation( "Position", [IsMatrixObj, IsVectorObj] );
+#DeclareOperation( "Position", [IsMatrixObj, IsVectorObj, IsInt] );
+#
+## This allows for usage of PositionSorted:
+#DeclareOperation( "PositionSortedOp", [IsMatrixObj, IsVectorObj] );
+#DeclareOperation( "PositionSortedOp", [IsMatrixObj, IsVectorObj,IsFunction]);
 
 # I intentionally left out "PositionNot" here.
 

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -408,6 +408,9 @@ DeclareOperation( "ZeroVector", [IsInt,IsMatrixObj] );
 
 # Operation to create vector objects.
 # The first just delegate to NewVector:
+# TODO: replace IsOperation by something nicer, like IsFilter (but sadly that
+# isn't a filter...)
+# TODO: actually, should these be global functions instead of operations?
 DeclareOperation( "Vector", [IsOperation, IsSemiring,  IsList]);
 DeclareOperation( "Vector", [IsOperation, IsSemiring,  IsVectorObj]);
 

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -167,17 +167,63 @@ DeclareOperation( "{}", [IsVectorObj,IsList] );
 # Of course the positions must all lie in [1..Length(VECTOR)].
 # Returns a vector in the same representation!
 
+##  <#GAPDoc Label="MatObj_PositionNonZero">
+##  <ManSection>
+##    <Oper Arg="V" Name="PositionNonZero" Label="for vectors"/>
+##    <Returns>An integer</Returns>
+##    <Description>
+##     Returns the index of the first entry in the vector <A>V</A> which is not
+##     zero. If all entries are zero, the function
+##     returns <C>Length(<A>V</A>) + 1</C>.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "PositionNonZero", [IsVectorObj] );
 
+##  <#GAPDoc Label="MatObj_PositionLastNonZero">
+##  <ManSection>
+##    <Oper Arg="V" Name="PositionLastNonZero"/>
+##    <Returns>An integer</Returns>
+##    <Description>
+##     Returns the index of the last entry in the vector <A>V</A> which is not
+##     zero. If all entries are zero, the function
+##     returns 0.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "PositionLastNonZero", [IsVectorObj] );
 
+##  <#GAPDoc Label="MatObj_ListOp">
+##  <ManSection>
+##    <Oper Arg="V[, func]" Name="ListOp" 
+##                          Label="for IsVectorObj, IsFunction"/>
+##    <Returns>A plain list</Returns>
+##    <Description>
+##     Applies <A>func</A> to each entry of the vector <A>V</A> and returns
+##     the results as a plain list. This allows for calling 
+##     <Ref Func="List" Label="for a collection"/> on vectors.
+##     If the argument <A>func</A> is not provided, applies 
+##     <Ref Func="IdFunc"/> to all entries.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "ListOp", [IsVectorObj] );
 DeclareOperation( "ListOp", [IsVectorObj,IsFunction] );
 # This is an unpacking operation returning a mutable copy in form of a list.
 # It enables the "List" function to work.
 
-# The following unwraps a vector to a list:
-DeclareOperation( "Unpack", [IsVectorObj] );
+##  <#GAPDoc Label="MatObj_UnpackVector">
+##  <ManSection>
+##    <Oper Arg="V" Name="Unpack" Label="for IsVectorObj"/>
+##    <Returns>A plain list</Returns>
+##    <Description>
+##      Returns a new plain list containing the entries of <A>V</A>.
+##      Guarantees to return a new list which can be manipulated without
+##      changing <A>V</A>. The entries itself are not copied.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+DeclareOperation( "Unpack", [IsVectorObj] ); 
 # It guarantees to copy, that is changing the returned object does
 # not change the original object.
 # TODO: replace by AsList ?
@@ -203,8 +249,32 @@ DeclareOperation( "Unpack", [IsVectorObj] );
 # Note that since Concatenation is a function using Append, it will
 # not work for vectors and it cannot be overloaded!
 # Thus we need:
+
+##  <#GAPDoc Label="MatObj_ConcatenationOfVectors">
+##  <ManSection>
+##    <Func Arg="V1,V2,..." Name="ConcatenationOfVectors" 
+##                          Label="for IsVectorObj"/>
+##    <Func Arg="Vlist" Name="ConcatenationOfVectors" 
+##                      Label="for list of IsVectorObj"/>
+##    <Returns>a vector object</Returns>
+##    <Description>
+##      Returns a new vector containing the entries of <A>V1</A>, 
+##      <A>V2</A>, etc. As prototype <A>V1</A> is used.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareGlobalFunction( "ConcatenationOfVectors" );
 
+##  <#GAPDoc Label="MatObj_ExtractSubVector">
+##  <ManSection>
+##    <Func Arg="V,l" Name="ExtractSubVector" Label="for IsVectorObj,IsList"/>
+##    <Returns>a vector object</Returns>
+##    <Description>
+##      Returns a new vector containing the entries of <A>V</A>
+##      at the positions in <A>l</A>.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "ExtractSubVector", [IsVectorObj,IsList] );
 # Does the same as slicing v{l} but is here to be similar to
 # ExtractSubMatrix.
@@ -318,6 +388,16 @@ DeclareOperation( "MultRowVector",
 # The "representation-preserving" contructor methods:
 ############################################################################
 
+##  <#GAPDoc Label="MatObj_ZeroVector">
+##  <ManSection>
+##    <Oper Arg="l,V" Name="ZeroVector" Label="for IsInt,IsVectorObj"/>
+##    <Returns>a vector object</Returns>
+##    <Description>
+##      Returns a new vector of length <A>l</A> in the same representation 
+##      as <A>V</A> containing only zeros.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "ZeroVector", [IsInt,IsVectorObj] );
 # Returns a new mutable zero vector in the same rep as the given one with
 # a possible different length.
@@ -354,9 +434,18 @@ DeclareOperation( "Vector", [IsList]);
 ## the matrix but of possibly different length given by the first
 ## argument. It is *not* guaranteed that the list is copied!
 
+##  <#GAPDoc Label="MatObj_ConstructingFilter_Vector">
+##  <ManSection>
+##    <Oper Arg="V" Name="ConstructingFilter" Label="for IsVectorObj"/>
+##    <Returns>a filter</Returns>
+##    <Description>
+##      Returns a filter <C>f</C> such that if <Ref Oper="NewVector"/> is
+##      called with <C>f</C> a vector in the same representation as <A>V</A>
+##      is produced.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "ConstructingFilter", [IsVectorObj] );
-# given a vector <v>, produce a filter such that  NewVector called with this filter
-# will produce vectors in the same representation as <v>
 
 DeclareConstructor( "NewVector", [IsVectorObj,IsSemiring,IsList] );
 # A constructor. The first argument must be a filter indicating the
@@ -401,6 +490,18 @@ DeclareGlobalFunction( "MakeVector" );
 # Some things that fit nowhere else:
 ############################################################################
 
+##  <#GAPDoc Label="MatObj_Randomize_Vectors">
+##  <ManSection>
+##    <Oper Arg="V" Name="Randomize" Label="for IsVectorObj"/>
+##    <Oper Arg="V,Rs" Name="Randomize" Label="for IsVectorObj,IsRandomSources"/>
+##    <Description>
+##      Replaces every entry in <A>V</A> with a random one from the base
+##      domain. If given, the random source <A>Rs</A> is used to compute the
+##      random elements. Note that in this case, the random function for the
+##      base domain must support the random source argument.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "Randomize", [IsVectorObj and IsMutable] );
 DeclareOperation( "Randomize", [IsVectorObj and IsMutable,IsRandomSource] );
 # Changes the mutable argument in place, every entry is replaced
@@ -418,14 +519,10 @@ DeclareOperation( "Randomize", [IsVectorObj and IsMutable,IsRandomSource] );
 ##
 ##  <#GAPDoc Label="CopySubVector">
 ##  <ManSection>
-##  <Oper Name="CopySubVector" Arg='src, dst, scols, dcols'/>
-## TODO: turn this into
 ##  <Oper Name="CopySubVector" Arg='dst, dcols, src, scols'/>
-## and provide an (undocumented) method for backwards compatibility
-##  which converts from the old to the new convention (and remove that again the future???)
-##
 ##  <Description>
-##  returns nothing. Does <C><A>dst</A>{<A>dcols</A>} := <A>src</A>{<A>scols</A>}</C>
+##  <Returns>nothing</Returns>
+##  Does <C><A>dst</A>{<A>dcols</A>} := <A>src</A>{<A>scols</A>}</C>
 ##  without creating an intermediate object and thus - at least in
 ##  special cases - much more efficiently. For certain objects like
 ##  compressed vectors this might be significantly more efficient if 
@@ -442,16 +539,38 @@ DeclareOperation( "Randomize", [IsVectorObj and IsMutable,IsRandomSource] );
 ## TODO: Maybe also have a version of this as follows:
 ##    CopySubVector( dst, dst_from, dst_to,  src, src_form, src_to );
 DeclareOperation( "CopySubVector", 
+  [IsVectorObj and IsMutable, IsList, IsVectorObj, IsList] );
+## TODO: the following declaration is deprecated and only kept for compatibility
+DeclareOperation( "CopySubVector", 
   [IsVectorObj,IsVectorObj and IsMutable, IsList,IsList] );
 
+##  <#GAPDoc Label="MatObj_WeightOfVector">
+##  <ManSection>
+##    <Oper Arg="V" Name="WeightOfVector" Label="for IsVectorObj"/>
+##    <Returns>an integer</Returns>
+##    <Description>
+##      Computes the Hamming weight of the vector <A>V</A>, i.e., the number of 
+##      nonzero entries.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "WeightOfVector", [IsVectorObj] );
-# This computes the Hamming weight of a vector, i.e. the number of
-# nonzero entries.
 
+
+##  <#GAPDoc Label="MatObj_DistanceOfVectors">
+##  <ManSection>
+##    <Oper Arg="V1,V2" Name="DistanceOfVectors" 
+##                      Label="for IsVectorObj,IsVectorObj"/>
+##    <Returns>an integer</Returns>
+##    <Description>
+##      Computes the Hamming distance of the vectors <A>V1</A> and <A>V2</A>,
+##      i.e., the number of entries in which the vectors differ. The vectors
+##      must be of equal length.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 DeclareOperation( "DistanceOfVectors", [IsVectorObj, IsVectorObj] );
-# This computes the Hamming distance of two vectors, i.e. the number
-# of positions, in which the vectors differ. The vectors must have the
-# same length.
+
 
 
 ############################################################################
@@ -601,7 +720,9 @@ DeclareOperation( "MutableCopyMat", [IsMatrixObj] );
 ##  <Oper Name="CopySubMatrix" Arg='src, dst, srows, drows, scols, dcols'/>
 ##
 ##  <Description>
-##  returns nothing. Does <C><A>dst</A>{<A>drows</A>}{<A>dcols</A>} := <A>src</A>{<A>srows</A>}{<A>scols</A>}</C>
+##  <Returns>nothing</Returns>
+##  Does <C><A>dst</A>{<A>drows</A>}{<A>dcols</A>} := 
+##  <A>src</A>{<A>srows</A>}{<A>scols</A>}</C>
 ##  without creating an intermediate object and thus - at least in
 ##  special cases - much more efficiently. For certain objects like
 ##  compressed vectors this might be significantly more efficient if 

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -820,48 +820,29 @@ DeclareOperation( "Matrix", [IsList, IsInt, IsMatrixObj]);
 DeclareOperation( "Matrix", [IsList,        IsMatrixObj]);  # <- no need to overload this one
 DeclareOperation( "Matrix", [IsMatrixObj,   IsMatrixObj]);
 
-# Creates a new matrix in the same representation as the fourth argument
-# but with entries from list, the second argument is the number of
-# columns. The first argument can be:
-#  - a plain list of vectors of the correct row length in a representation 
-#          fitting to the matrix rep.
-#  - a plain list of plain lists where each sublist has the length of the rows
-#  - a plain list with length rows*cols with matrix entries given row-wise
-# If the first argument is empty, then the number of rows is zero.
-# Otherwise the first entry decides which case is given.
-# The outer list is guaranteed to be copied, however, the entries of that
-# list (the rows) need not be copied.
-# The following convenience versions exist:
-# With two arguments the first must not be empty and must not be a flat
-# list. Then the number of rows is deduced from the length of the first
-# argument and the number of columns is deduced from the length of the
-# element of the first argument (done with a generic method):
-DeclareOperation( "Matrix", [IsList,IsMatrixObj] );
-
 # perhaps also (or instead?) have this:
 #DeclareOperation( "MatrixWithRows", [IsList (of vectors),IsMatrixObj]); ??
 #DeclareOperation( "MatrixWithColumns", [IsList (of vectors),IsMatrixObj]); ??
 
 
 
-# Note that it is not possible to generate a matrix via "Matrix" without
-# a template matrix object. Use the constructor methods instead:
-
 DeclareConstructor( "NewMatrix", [IsMatrixObj, IsSemiring, IsInt, IsList] );
 # Constructs a new fully mutable matrix. The first argument has to be a filter
-# indicating the representation. The second the base domain, the third
-# the row length and the last a list containing either row vectors
-# of the right length or lists with base domain elements.
+# indicating the representation, the second the base domain, the third
+# the row length. The last argument can be:
+#  - a plain list of vector objects of correct length
+#  - a plain list of plain lists of correct length
+#  - a flat plain list with rows*cols entries in row major order
+#    (FoldList turns a flat list into a list of lists)
+# where the corresponding entries must be in or compatible with the base domain.
+# If the last argument already contains vector objects, they are copied.
 # The last argument is guaranteed not to be changed!
-# If the last argument already contains row vectors, they are copied.
 
-# TODO: so a flat list of scalars is not possible (compare to <Matrix>, where it is) ???
-#  it should be symmetric, either both support it or none...
-#
-#  Idea: require NewMatrix methods to support flat lists (as well as lists-of-lists aka row lists;
-#  but provide a helper function which turns a flat list into a row list:
-#     RowListFromFlatMat( cols, list )
-
+# TODO: what does "flat" above mean???
+# TODO: from an old comment on Matrix / NewMatrix, wrt to the last argument
+# The outer list is guaranteed to be copied, however, the entries of that
+# list (the rows) need not be copied.
+# TODO: Isn't it inconsistent to copy the rows if they are vector objects, but otherwise not? Also: matobjplist.gi uses NewVector, which copies its list-argument
 
 # FIXME: why is IsInt,IsList reversed compared to Matrix(), where it is IsList,IsInt
 

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -326,7 +326,24 @@ DeclareOperation( "ZeroVector", [IsInt,IsMatrixObj] );
 # Returns a new mutable zero vector in a rep that is compatible with
 # the matrix but of possibly different length.
 
-DeclareOperation( "Vector", [IsList,IsVectorObj]);
+# Operation to create vector objects.
+# The first just delegate to NewVector:
+DeclareOperation( "Vector", [IsOperation, IsSemiring,  IsList]);
+DeclareOperation( "Vector", [IsOperation, IsSemiring,  IsVectorObj]);
+
+# Here we implement default choices for the representation, depending
+# in base domain:
+DeclareOperation( "Vector", [IsSemiring,  IsList]);
+DeclareOperation( "Vector", [IsSemiring,  IsVectorObj]);
+
+# And here are the variants with example object (as last argument):
+DeclareOperation( "Vector", [IsList, IsVectorObj]);
+DeclareOperation( "Vector", [IsVectorObj, IsVectorObj]);
+
+# And here guess everything:
+DeclareOperation( "Vector", [IsList]);
+
+
 # Creates a new vector in the same representation but with entries from list.
 # The length is given by the length of the first argument.
 # It is *not* guaranteed that the list is copied!
@@ -785,9 +802,9 @@ DeclareConstructor( "NewCompanionMatrix",
 # Eventually here will be the right place to do this.
 
 # variant with new filter + base domain (dispatches to NewMatrix)
-DeclareOperation( "Matrix", [IsOperation,IsSemiring,  IsList, IsInt]);
-DeclareOperation( "Matrix", [IsOperation,IsSemiring,  IsList]);
-DeclareOperation( "Matrix", [IsOperation,IsSemiring,  IsMatrixObj]);
+DeclareOperation( "Matrix", [IsOperation, IsSemiring,  IsList, IsInt]);
+DeclareOperation( "Matrix", [IsOperation, IsSemiring,  IsList]);
+DeclareOperation( "Matrix", [IsOperation, IsSemiring,  IsMatrixObj]);
 
 # variant with new base domain -> "guesses" good rep, then dispatches to NewMatrix
 DeclareOperation( "Matrix", [IsSemiring,    IsList, IsInt]);

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -373,12 +373,21 @@ DeclareAttribute( "BaseDomain", IsMatrixObj );
 # nor associative. For non-associative base domains, the behavior of
 # powering matrices is undefined.
 
-DeclareAttribute( "Length", IsMatrixObj );
+DeclareAttribute( "NumberRows", IsMatrixObj );
+DeclareAttribute( "NumberColumns", IsMatrixObj );
+DeclareSynonym( "NrRows", NumberRows );
+DeclareSynonym( "NrCols", NumberColumns );
+
+# DO NOT declare Length ?!? (or maybe for backwards compatibilty??)
+DeclareAttribute( "Length", IsMatrixObj ); # ????
 # We have to declare this since matrix objects need not be lists.
 # We have to use InstallOtherMethod for those matrix types that are
 # lists.
 
-DeclareAttribute( "RowLength", IsMatrixObj );
+# HACK: this was in the old version of MatrixObj; we want to get rid of it;
+# but for now, keep it in to allow us to start GAP
+DeclareSynonym( "RowLength", NumberColumns );
+
 
 DeclareAttribute( "DimensionsMat", IsMatrixObj );   # returns [rows,cols]
 

--- a/lib/matobj2.gd.mod
+++ b/lib/matobj2.gd.mod
@@ -122,8 +122,8 @@
 # The following are guaranteed to be always set or cheaply calculable:
 DeclareAttribute( "BaseDomain", IsVectorObj );
 # Typically, the base domain will be a ring, it need not be commutative
-# nor associative. For non-associative base domains, the behavior of
-# powering matrices is undefined.
+# nor associative. For non-associative base domains powering of matrices
+# is defined by the behaviour of POW_OBJ_INT.
 
 DeclareAttribute( "Length", IsVectorObj );    # can be zero
 # We have to declare this since a row vector is not necessarily
@@ -177,12 +177,9 @@ DeclareOperation( "ListOp", [IsVectorObj,IsFunction] );
 # It enables the "List" function to work.
 
 # The following unwraps a vector to a list:
-DeclareOperation( "Unpack", [IsVectorObj] );
+DeclareOperation( "Unpack", [IsVectorObj] ); # TODO: replace by AsList ?
 # It guarantees to copy, that is changing the returned object does
 # not change the original object.
-# TODO: replace by AsList ?
-# TODO: this is already used by the fining package
-
 
 # "PositionNot" is intentionally left out here because it can rarely
 # be implemented much more efficiently than by running through the vector.
@@ -246,47 +243,37 @@ DeclareOperation( "ExtractSubVector", [IsVectorObj,IsList] );
 # Note2: If sorting is not done lexicographically then the objects
 #        in that representation cannot be lists!
 
-# TODO: rename AddRowVector to AddVector; but keep in mind that
-# historically there already was AddRowVector, so be careful to not break that
-
 # The following "in place" operations exist with the same restrictions:
-DeclareOperation( "AddRowVector", 
+DeclareOperation( "AddVector", 
   [ IsVectorObj and IsMutable, IsVectorObj ] );
 
 # vec = vec2 * scal
-DeclareOperation( "AddRowVector", 
+DeclareOperation( "AddVector", 
   [ IsVectorObj and IsMutable,  IsVectorObj, IsObject ] );
 # vec = scal * vec2
-DeclareOperation( "AddRowVector", 
+DeclareOperation( "AddVector", 
   [ IsVectorObj and IsMutable, IsObject, IsVectorObj ] );
 
 # vec := vec2{[to..from]} * scal
-DeclareOperation( "AddRowVector", 
+DeclareOperation( "AddVector", 
   [ IsVectorObj and IsMutable, IsVectorObj, IsObject, IsPosInt, IsPosInt ] );
 
 # vec := scal * vec2{[to..from]}
-DeclareOperation( "AddRowVector", 
+DeclareOperation( "AddVector", 
   [ IsVectorObj and IsMutable, IsObject, IsVectorObj, IsPosInt, IsPosInt ] );
 
 
-
-# TODO: rename MultRowVector to MultVector; but keep in mind that
-# historically there already was MultRowVector, so be careful to not break that
-DeclareOperation( "MultRowVector",
+DeclareOperation( "MultVectorFromLeft",
+  [ IsVectorObj and IsMutable, IsObject ] );
+DeclareOperation( "MultVectorFromRight",
   [ IsVectorObj and IsMutable, IsObject ] );
 
-#
-# Also, make it explicit from which side we multiply
-# DeclareOperation( "MultRowVectorFromLeft",
-#   [ IsVectorObj and IsMutable, IsObject ] );
-# DeclareOperation( "MultRowVectorFromRight",
-#   [ IsVectorObj and IsMutable, IsObject ] );
-#DeclareSynonym( "MultRowVector", MultRowVectorFromRight );
+DeclareSynonym( "MultVector", MultVectorFromRight );
 
 # do we really need the following? for what? is any code using this right now?
 # ( a, pa, b, pb, s ) ->  a{pa} := b{pb} * s;
-DeclareOperation( "MultRowVector",
-  [ IsVectorObj and IsMutable, IsList, IsVectorObj, IsList, IsObject ] );
+#DeclareOperation( "MultVector",
+#  [ IsVectorObj and IsMutable, IsList, IsVectorObj, IsList, IsObject ] );
 
 # maybe have this:   vec := vec{[from..to]} * scal ?? cvec has it
 
@@ -323,6 +310,7 @@ DeclareOperation( "ZeroVector", [IsInt,IsVectorObj] );
 # a possible different length.
 
 DeclareOperation( "ZeroVector", [IsInt,IsMatrixObj] );
+
 # Returns a new mutable zero vector in a rep that is compatible with
 # the matrix but of possibly different length.
 
@@ -337,35 +325,33 @@ DeclareOperation( "Vector", [IsList,IsVectorObj]);
 ## the matrix but of possibly different length given by the first
 ## argument. It is *not* guaranteed that the list is copied!
 
-DeclareOperation( "ConstructingFilter", [IsVectorObj] );
-# given a vector <v>, produce a filter such that  NewVector called with this filter
+# given a vector <v>, produce a filter such that  NewRowVector called with this filter
 # will produce vectors in the same representation as <v>
+DeclareOperation( "ConstructingFilter", [IsVectorObj] );
 
-DeclareConstructor( "NewVector", [IsVectorObj,IsSemiring,IsList] );
+# TODO: what is this doing, exactly? apparently it converts a vector <v> into the matrix [v],
+# with v as the single row.
+# Do we really need this? Maybe more helpful to have a way to turn a list of vectors into
+# a matrix with these vectors as row resp. columns.
+#  e.g.  NewMatrixWithColumns / WithRows ????
+DeclareOperation( "CompatibleMatrix", [IsVectorObj] );
+
+DeclareConstructor( "NewRowVector", [IsVectorObj,IsRing,IsList] );
 # A constructor. The first argument must be a filter indicating the
 # representation the vector will be in, the second is the base domain.
 # The last argument is guaranteed not to be changed!
 
-DeclareSynonym( "NewRowVector", NewVector );
-# FIXME: Declare NewRowVector for backwards compatibility, so that existing
-# code which already used it keeps working (most notably, the cvec and fining
-# packages). We should eventually remove this synonym.
-
-
-DeclareConstructor( "NewZeroVector", [IsVectorObj,IsSemiring,IsInt] );
+DeclareConstructor( "NewZeroVector", [IsVectorObj,IsRing,IsInt] );
 # A similar constructor to construct a zero vector, the last argument
 # is the base domain.
 
-DeclareOperation( "ChangedBaseDomain", [IsVectorObj,IsSemiring] );
+DeclareOperation( "ChangedBaseDomain", [IsVectorObj,IsRing] );
 # Changes the base domain. A copy of the row vector in the first argument is
 # created, which comes in a "similar" representation but over the new
 # base domain that is given in the second argument.
 # example: given a vector over GF(2),  create a new vector over GF(4) with "identical" content
 #  so it's kind of a type conversion / coercion
 # TODO: better name, e.g. VectorWithChangedBasedDomain
-#  or maybe just turn this into a constructor resp. a new constructor special case :
-# like
-#  DeclareConstructor( "NewVector", [IsVectorObj,IsSemiring,IsVectorObj] );
 
 
 DeclareGlobalFunction( "MakeVector" );
@@ -384,16 +370,14 @@ DeclareGlobalFunction( "MakeVector" );
 # Some things that fit nowhere else:
 ############################################################################
 
-DeclareOperation( "Randomize", [IsVectorObj and IsMutable] );
+#DeclareOperation( "Randomize", [IsVectorObj and IsMutable] );
 DeclareOperation( "Randomize", [IsVectorObj and IsMutable,IsRandomSource] );
 # Changes the mutable argument in place, every entry is replaced
 # by a random element from BaseDomain.
 # The second argument is used to provide "randomness".
 # The vector argument is also returned by the function.
 
-# TODO: change this to use InstallMethodWithRandomSource; for this, we'll have
-# to change the argument order (a method for the old order, to ensure backwards
-# compatibility, could remain).
+# TODO: only keep the first operation and suggest using InstallMethodWithRandomSource
 
 #############################################################################
 ##
@@ -404,7 +388,7 @@ DeclareOperation( "Randomize", [IsVectorObj and IsMutable,IsRandomSource] );
 ##  <Oper Name="CopySubVector" Arg='src, dst, scols, dcols'/>
 ## TODO: turn this into
 ##  <Oper Name="CopySubVector" Arg='dst, dcols, src, scols'/>
-## and provide an (undocumented) method for backwards compatibility
+## and provide an (undocumnented) method for backwards compatibility
 ##  which converts from the old to the new convention (and remove that again the future???)
 ##
 ##  <Description>
@@ -419,7 +403,7 @@ DeclareOperation( "Randomize", [IsVectorObj and IsMutable,IsRandomSource] );
 ##
 ## TODO: link to ExtractSubVector
 ## 
-## TODO: In AddRowVector and MultRowVector, the destination is always the first argument;
+## TODO: In AddVector and MultVector, the destination is always the first argument;
 ##   it would be better if we were consistent...
 ##
 ## TODO: Maybe also have a version of this as follows:
@@ -451,8 +435,8 @@ DeclareOperation( "DistanceOfVectors", [IsVectorObj, IsVectorObj] );
 # The following are guaranteed to be always set or cheaply calculable:
 DeclareAttribute( "BaseDomain", IsMatrixObj );
 # Typically, the base domain will be a ring, it need not be commutative
-# nor associative. For non-associative base domains, the behavior of
-# powering matrices is undefined.
+# nor associative. For non-associative base domains powering of matrices
+# is defined by the behaviour of POW_OBJ_INT in the kernel.
 
 DeclareAttribute( "NumberRows", IsMatrixObj );
 DeclareAttribute( "NumberColumns", IsMatrixObj );
@@ -465,11 +449,6 @@ DeclareAttribute( "Length", IsMatrixObj ); # ????
 # We have to use InstallOtherMethod for those matrix types that are
 # lists.
 
-# HACK: this was in the old version of MatrixObj; we want to get rid of it;
-# but for now, keep it in to allow us to start GAP
-DeclareSynonym( "RowLength", NumberColumns );
-
-
 # WARNING: the following attributes should not be stored if the matrix is mutable...
 DeclareAttribute( "DimensionsMat", IsMatrixObj );
 # returns [NrRows(mat),NrCols(mat)]
@@ -477,9 +456,6 @@ DeclareAttribute( "DimensionsMat", IsMatrixObj );
 
 DeclareAttribute( "RankMat", IsMatrixObj );
 DeclareOperation( "RankMatDestructive", [ IsMatrixObj ] );
-# TODO: danger: RankMat should not be stored for mutable matrices... 
-# 
-
 
 ############################################################################
 # In the following sense matrices behave like lists:
@@ -488,13 +464,13 @@ DeclareOperation( "RankMatDestructive", [ IsMatrixObj ] );
 DeclareOperation( "[]", [IsMatrixObj,IsPosInt] );  # <mat>, <pos>
 # This is guaranteed to return a vector object that has the property
 # that changing it changes <pos>th row (?) of the matrix <mat>!
-# A matrix which is not a row-lists internally has to create an intermediate object that refers to some
+# A flat matrix has to create an intermediate object that refers to some
 # row within it to allow the old GAP syntax M[i][j] for read and write
 # access to work. Note that this will never be particularly efficient
-# for matrices which are not row-lists. Efficient code will have to use MatElm and
+# for flat matrices. Efficient code will have to use MatElm and
 # SetMatElm instead.
 # TODO:   ... resp. it will use use M[i,j]
-# TODO: provide a default method which creates a proxy object for the given row
+# TODO: provide a default method which creates a proxy object for th givn row
 # and translates accesses to it to corresponding MatElm / SetMatElm calls;
 #  creating such a proxy object prints an InfoWarning;
 # but for the method for plist matrices, no warning is shown, as it is efficient
@@ -505,9 +481,20 @@ DeclareOperation( "[]", [IsMatrixObj,IsPosInt] );  # <mat>, <pos>
 # these again must be objects which are "linked" to the original matrix, as above...
 # TODO: perhaps also have ExtractRow(mat, i) and ExtractColumn(mat, i)
 
+# TODO: provide a method so that mat[i,j] actually works, like this:
+#    InstallMethod( \[\],
+#  [ IsMatrix and IsMutable, IsList ],
+#  function( m, l )
+#    return m[l[1]][l[2]];
+#  end );
+ 
+# TODO: benchmark all of this stuff vs. existing matrices
+# TODO: provide a hotpath in kernel for m[i,j] notation which avoids creating
+#   the temporary list [i,j], and avoids methods selection if possible
 
-# FIXME: Actually, we should probably not defined these for matrices, only for vectors
+
 # These should probably only be defined for RowListMatrices???
+# Actually, we should probably not defined these for matrices, only for vectors
 #DeclareOperation( "PositionNonZero", [IsMatrixObj] );
 #DeclareOperation( "PositionNonZero", [IsMatrixObj, IsInt] );
 #
@@ -519,7 +506,7 @@ DeclareOperation( "[]", [IsMatrixObj,IsPosInt] );  # <mat>, <pos>
 #
 ## This allows for usage of PositionSorted:
 #DeclareOperation( "PositionSortedOp", [IsMatrixObj, IsVectorObj] );
-#DeclareOperation( "PositionSortedOp", [IsMatrixObj, IsVectorObj,IsFunction]);
+#DeclareOperation( "PositionSortedOp", [IsMatrixObj,IsVectorObj,IsFunction]);
 
 # I intentionally left out "PositionNot" here.
 
@@ -556,7 +543,7 @@ DeclareOperation( "[]", [IsMatrixObj,IsPosInt] );  # <mat>, <pos>
 ##
 DeclareOperation( "ExtractSubMatrix", [IsMatrixObj,IsList,IsList] );
 
-# TODO: perhaps also add ExtractSubMatrix( mat, row_from, row_to, col_from, col_to ) ???
+# TODO: perhap also add ExtractSubMatrix( mat, row_from, row_to, col_from, col_to ) ???
 # probably not needed... one can use ranges + TryNextMethod ...
 # but let's look at some places where this function is used
 
@@ -569,9 +556,7 @@ DeclareOperation( "MutableCopyMat", [IsMatrixObj] );
 # TODO: perhaps also add a recursive version of ShallowCopy with a parameter limiting the depth..
 
 # TODO: can we also have a version of ShallowCopy which has a name starting with "Mutable"
-# to make it easier to discover??? Like MutableCopyVec (which might just be an alias
-# for ShallowCopy).
-# Or at least mention ShallowCopy in the MutableCopyMat 
+# to make it easier to discover???
 
 
 
@@ -600,7 +585,7 @@ DeclareOperation( "CopySubMatrix", [IsMatrixObj,IsMatrixObj,
 #    dst, drows, dcols,  src, srows, scols
 
 ############################################################################
-# New element access for matrices
+# New element access for matrices (especially necessary for flat mats:
 ############################################################################
 
 DeclareOperation( "MatElm", [IsMatrixObj,IsPosInt,IsPosInt] );
@@ -609,6 +594,9 @@ DeclareOperation( "MatElm", [IsMatrixObj,IsPosInt,IsPosInt] );
 DeclareOperation( "SetMatElm", [IsMatrixObj,IsPosInt,IsPosInt,IsObject] );
 # second and third arguments are row and column index
 
+# TODO: Also document and provid  x:=mat[i,j] resp.  mat[i,j]:=a;
+
+# TODO: benchmark all of this...
 
 ############################################################################
 # Standard operations for all objects:
@@ -617,11 +605,10 @@ DeclareOperation( "SetMatElm", [IsMatrixObj,IsPosInt,IsPosInt,IsObject] );
 # The following are implicitly there for all objects, we mention them here
 # to have a complete interface description in one place:
 
-# ShallowCopy is missing here since its behaviour depends on the internal
-# representation of the matrix objects (e.g. list-of-lists resp. list-of-vectors
-#  versus a "flat" matrix, or a shallow matrix, or ...)!
+# ShallowCopy is missing here since its behaviour depends on the matrix
+# being in IsRowListMatrix or in IsFlatMatrix!
 
-# TODO: for mutable matrices, a difference between StructuralCopy and MutableCopyMat
+# TODO: for mutable matrices, a differnce between StructuralCopy and MutableCopyMat
 # occurs if the matrix is a row list, and one row is immutable, another mutable;
 # then StructuralCopy will return a new list of vectors, which again contains the
 # same (identical) immutable vectors, and mutable copies of the other vectors.
@@ -690,16 +677,28 @@ DeclareOperation( "SetMatElm", [IsMatrixObj,IsPosInt,IsPosInt,IsObject] );
 # Also, we can have other methods for e.g. subdomains of the cyclotomics.
 #
 
+DeclareOperation( "AddMatrix", [IsMutable and IsMatrixObj,IsMatrixObj] );
+
+# TODO: the following need to be extended for both left and right scalar matrices
+DeclareOperation( "AddMatrix", 
+  [IsMutable and IsMatrixObj,IsMatrixObj,IsMultiplicativeElement] );
+
+# TODO: the following need to be extended for both left and right scalar matrices
+DeclareOperation( "MultMatrix", 
+  [IsMutable and IsMatrixObj,IsMultiplicativeElement] );
+
+# Changes first argument in place, matrices have to be of same
+# dimension and over same base domain.
+
+# TODO: is the following really useful in general?
+DeclareOperation( "ProductTransposedMatMat", [IsMatrixObj, IsMatrixObj] );
+# Computes the product TransposedMat(A)*B, possibly without
+# first computing TransposedMat(A).
 
 DeclareOperation( "TraceMat", [IsMatrixObj] );
 # The sum of the diagonal entries. Error for a non-square matrix.
 
-
-#DeclareOperation( "DeterminantMat", [IsMatrixObj] );
-# TODO: this only makes sense over commutative domains;
-# be careful regarding default implementation (base domain = field vs.
-#  base domain = any commutative ring, possibly with zero divisors)
-
+# TODO: what about Determinant (at least for commutative base domains)
 
 ############################################################################
 # Rule:
@@ -708,13 +707,6 @@ DeclareOperation( "TraceMat", [IsMatrixObj] );
 # One for non-square matrices.
 # Inverse for non-square matrices
 # Inverse for square, non-invertible matrices.
-
-# FIXME: what is the rationale for the above? OK, inverting a square matrix:
-#   it is non-trivial to decide if the matrix is invertible, so it might be
-#   useful to be able to just try and invert it, and do something else if that "fail"s
-#   But it is cheap to verify that a matrix is non-square, so why not error for that?
-#   Same for One, ...
-
 #
 # An exception are properties:
 # IsOne for non-square matrices returns false.
@@ -729,36 +721,21 @@ DeclareOperation( "TraceMat", [IsMatrixObj] );
 ############################################################################
 
 DeclareOperation( "ZeroMatrix", [IsInt,IsInt,IsMatrixObj] );
-DeclareOperation( "ZeroMatrix", [IsSemiring, IsInt,IsInt] );  # warning: NullMat has ring arg last
-DeclareOperation( "ZeroMatrix", [IsOperation, IsSemiring, IsInt,IsInt] );
 # Returns a new fully mutable zero matrix in the same rep as the given one with
 # possibly different dimensions. First argument is number of rows, second
 # is number of columns.
 
-DeclareConstructor( "NewZeroMatrix", [IsMatrixObj,IsSemiring,IsInt,IsInt]);
-# constructor -> first argument must be a filter, like e.g. IsPlistMatrixRep
-#
+DeclareConstructor( "NewZeroMatrix", [IsMatrixObj,IsRing,IsInt,IsInt]);
 # Returns a new fully mutable zero matrix over the base domain in the
 # 2nd argument. The integers are the number of rows and columns.
 
 DeclareOperation( "IdentityMatrix", [IsInt,IsMatrixObj] );
-DeclareOperation( "IdentityMatrix", [IsSemiring, IsInt] );  # warning: IdentityMat has ring arg last
-DeclareOperation( "IdentityMatrix", [IsOperation, IsSemiring, IsInt] );
 # Returns a new mutable identity matrix in the same rep as the given one with
 # possibly different dimensions.
 
-DeclareConstructor( "NewIdentityMatrix", [IsMatrixObj,IsSemiring,IsInt]);
+DeclareConstructor( "NewIdentityMatrix", [IsMatrixObj,IsRing,IsInt]);
 # Returns a new fully mutable identity matrix over the base domain in the
 # 2nd argument. The integer is the number of rows and columns.
-
-# TODO: perhaps imitate what we do for e.g. group constructors, and allow
-# user to omit the filter; in that case, try to choose a "good" default
-# representation ????
-
-# TODO: perhaps add DiagonalMatrix?
-
-# TODO: convert (New)IdentityMatrix and (New)ZeroMatrix to be more similar to Matrix()
-
 
 DeclareOperation( "CompanionMatrix", [IsUnivariatePolynomial,IsMatrixObj] );
 # Returns the companion matrix of the first argument in the representation
@@ -766,43 +743,13 @@ DeclareOperation( "CompanionMatrix", [IsUnivariatePolynomial,IsMatrixObj] );
 # monic and its coefficients must lie in the BaseDomain of the matrix.
 
 DeclareConstructor( "NewCompanionMatrix", 
-  [IsMatrixObj, IsUnivariatePolynomial, IsSemiring] );
+  [IsMatrixObj, IsUnivariatePolynomial, IsRing] );
 # The constructor variant of <Ref Oper="CompanionMatrix"/>.
-# TODO: get rid of NewCompanionMatrix, at least for now -- if somebody *REALLY*
-# needs it, we can still reconsider... Instead allow this:
-# DeclareOperation( "CompanionMatrix", [IsFilter, IsUnivariatePolynomial, IsSemiring] );
-# which roughly does this:
-#   InstallMethod( CompanionMatrix, ...
-#     function(filt, f, R)
-#       n := Degree(f);
-#       mat := NewZeroMatrix(filt, R, n, n);
-#       ... set entries of mat ...
-#     end);
-
-
 
 # The following are already declared in the library:
 # Eventually here will be the right place to do this.
 
-# variant with new filter + base domain (dispatches to NewMatrix)
-DeclareOperation( "Matrix", [IsOperation,IsSemiring,  IsList, IsInt]);
-DeclareOperation( "Matrix", [IsOperation,IsSemiring,  IsList]);
-DeclareOperation( "Matrix", [IsOperation,IsSemiring,  IsMatrixObj]);
-
-# variant with new base domain -> "guesses" good rep, then dispatches to NewMatrix
-DeclareOperation( "Matrix", [IsSemiring,    IsList, IsInt]);
-DeclareOperation( "Matrix", [IsSemiring,    IsList]);
-DeclareOperation( "Matrix", [IsSemiring,    IsMatrixObj]);
-
-# the following two operations use DefaultFieldOfMatrix to "guess" the base domain
-DeclareOperation( "Matrix", [IsList, IsInt]);
-DeclareAttribute( "Matrix", IsList, "mutable"); # HACK: because there already is an attribute Matrix
-
-# variant with example object at end (input is first)
-DeclareOperation( "Matrix", [IsList, IsInt, IsMatrixObj]);
-DeclareOperation( "Matrix", [IsList,        IsMatrixObj]);  # <- no need to overload this one
-DeclareOperation( "Matrix", [IsMatrixObj,   IsMatrixObj]);
-
+DeclareOperation( "Matrix", [IsList,IsInt,IsMatrixObj]);
 # Creates a new matrix in the same representation as the fourth argument
 # but with entries from list, the second argument is the number of
 # columns. The first argument can be:
@@ -821,16 +768,10 @@ DeclareOperation( "Matrix", [IsMatrixObj,   IsMatrixObj]);
 # element of the first argument (done with a generic method):
 DeclareOperation( "Matrix", [IsList,IsMatrixObj] );
 
-# perhaps also (or instead?) have this:
-#DeclareOperation( "MatrixWithRows", [IsList (of vectors),IsMatrixObj]); ??
-#DeclareOperation( "MatrixWithColumns", [IsList (of vectors),IsMatrixObj]); ??
-
-
-
 # Note that it is not possible to generate a matrix via "Matrix" without
 # a template matrix object. Use the constructor methods instead:
 
-DeclareConstructor( "NewMatrix", [IsMatrixObj, IsSemiring, IsInt, IsList] );
+DeclareConstructor( "NewMatrix", [IsMatrixObj, IsRing, IsInt, IsList] );
 # Constructs a new fully mutable matrix. The first argument has to be a filter
 # indicating the representation. The second the base domain, the third
 # the row length and the last a list containing either row vectors
@@ -838,54 +779,20 @@ DeclareConstructor( "NewMatrix", [IsMatrixObj, IsSemiring, IsInt, IsList] );
 # The last argument is guaranteed not to be changed!
 # If the last argument already contains row vectors, they are copied.
 
-# TODO: so a flat list of scalars is not possible (compare to <Matrix>, where it is) ???
-#  it should be symmetric, either both support it or none...
-#
-#  Idea: require NewMatrix methods to support flat lists (as well as lists-of-lists aka row lists;
-#  but provide a helper function which turns a flat list into a row list:
-#     RowListFromFlatMat( cols, list )
-
-
-# FIXME: why is IsInt,IsList reversed compared to Matrix(), where it is IsList,IsInt
-
-
-
-
-# given a matrix <m>, produce a filter such that  NewMatrix called with this filter
-# will produce a matrix in the same representation as <m>
 DeclareOperation( "ConstructingFilter", [IsMatrixObj] );
 
-# TODO: what does this do?
-# Implementation: given an n x m matrix <m>, create a new zero vector <v> of
-# length n (= NrRows) in a representation "compatible" with that of <m>, i.e.
-# there "should be" a fast action  <v>*<m>
-# FIXME: is this really useful? Compare to, say, `ExtractRow(mat,1)` etc. ???
 DeclareOperation( "CompatibleVector", [IsMatrixObj] );
 
-DeclareOperation( "ChangedBaseDomain", [IsMatrixObj,IsSemiring] );
+DeclareOperation( "ChangedBaseDomain", [IsMatrixObj,IsRing] );
 # Changes the base domain. A copy of the matrix in the first argument is
 # created, which comes in a "similar" representation but over the new
 # base domain that is given in the second argument.
-# TODO: better name, e.g. MatrixWithChangedBasedDomain
-#  or maybe just turn this into a constructor resp. a new constructor special case :
-# like
-#  DeclareConstructor( "NewMatrix", [IsMatrixObj,IsSemiring,IsMatrixObj] );
 
-
-
-
-# usage: MakeVector( <list> [,<basedomain>] )
+DeclareGlobalFunction( "MakeMatrix" );
 # A convenience function for users to choose some appropriate representation
 # and guess the base domain if not supplied as second argument.
 # This is not guaranteed to be efficient and should never be used
 # in library or package code.
-# It is mainly useful to help migrate existing code incrementally to use
-# the new MatrixObj interface.
-
-
-# TODO: how useful are all these constructors in practice? 
-# Ideally we should try to limit their number, focusing on a few useful ones..
-#  best to see what actual code needs
 
 
 ############################################################################
@@ -898,53 +805,16 @@ DeclareOperation( "Randomize", [IsMatrixObj and IsMutable,IsRandomSource] );
 # by a random element from BaseDomain.
 # The second version will come when we have random sources.
 
-# TODO: only keep the first operation and suggest using InstallMethodWithRandomSource
-
-
 DeclareAttribute( "TransposedMatImmutable", IsMatrixObj );
 DeclareOperation( "TransposedMatMutable", [IsMatrixObj] );
-# TODO: one problem with DeclareAttribute: it only really makes sense if the
-#  matrix is immutable; but we have no way of declaring this; so it is very
-#  easy to end up having a mutable, attribute storing matrix, which stores
-#  its transpose "by accident", and then gets modified later on
-#
-
 
 DeclareOperation( "IsDiagonalMat", [IsMatrixObj] );
+
 DeclareOperation( "IsUpperTriangularMat", [IsMatrixObj] );
 DeclareOperation( "IsLowerTriangularMat", [IsMatrixObj] );
-# TODO: if we allow attributes, we might just as well do the above to be
-# declared as properties, so that this information is stored; but once
-# again, we would only want to allow this for immutable matrix objects.
-# ...
-
-# TODO: what about the following (and also note the names...):
-#   - IsScalarMat, IsSquareMat, ... ?
-
-# TODO: Why do we call them RankMat, IsDiagonalMat, etc.
-#  and not RankMatrix, IsDiagonalMatrix, etc. ?
-#  in contrast to Matrix(), NewMatrix(), ExtractSubMatrix(), ...
-#
-# One reasons is backwards compatibility of course, but this could
-# also be achieved with synonyms.
-# Another argument for "Mat" is brevity, but is that really so important/useful
-#   versus "clarity"
-# Still, we could unify these names, always using "Matrix".
-#
-# Of course we could also introduce a rule when to use "Matrix" and when to use "Mat",
-# but this rule will invariably be ignored or forgotten and inconsistency will 
-# occur.
-#
-# So new plan: Always use "Matrix", but provide "Mat" aliases for
-# backwards compatibility (if the operation already exists with that name),
-# and perhaps (????) for "convenience"
-#
 
 DeclareOperation( "KroneckerProduct", [IsMatrixObj,IsMatrixObj] );
 # The result is fully mutable.
-
-# FIXME: what is the purpose of Unfold and Fold?
-# Maybe remove them, and wait if somebody asks for / needs this
 
 DeclareOperation( "Unfold", [IsMatrixObj, IsVectorObj] );
 # Concatenates all rows of a matrix to one single vector in the same
@@ -960,7 +830,6 @@ DeclareOperation( "Fold", [IsVectorObj, IsPosInt, IsMatrixObj] );
 DeclareOperation( "Unpack", [IsRowListMatrix] );
 # It guarantees to copy, that is changing the returned object does
 # not change the original object.
-# TODO: this is already used by the fining package
 
 
 ############################################################################
@@ -973,17 +842,6 @@ DeclareOperation( "Unpack", [IsRowListMatrix] );
 ############################################################################
 # List operations with some restrictions:
 ############################################################################
-
-# TODO: what is this good for? Theory: it would probably help when migrating
-# existing code to MatrixObj, as you could change your lists-of-list matrices
-# to MatrixObjs, and then incrementally adapt your code to *not* use the 
-# following operations.
-#
-# In that case, we should make it very clear that using these functions is
-# discouraged....
-
-# TODO: let's see if this is really useful when e.g. adapting the library.
-# If not, then we might not even need `IsRowListMatrix`
 
 DeclareOperation( "[]:=", [IsRowListMatrix,IsPosInt,IsObject] );
 # Only guaranteed to work for the position in [1..Length(VECTOR)] and only
@@ -1029,19 +887,56 @@ DeclareOperation( "ListOp", [IsRowListMatrix, IsFunction] );
 ############################################################################
 
 
+############################################################################
+############################################################################
+# Operations for flat matrices:
+############################################################################
+############################################################################
+
+
+############################################################################
+# List operations with some modifications:
+############################################################################
+
+DeclareOperation( "[]:=", [IsFlatMatrix,IsPosInt,IsObject] );
+# Only guaranteed to work for the position in [1..Length(VECTOR)] and only
+# for elements in a suitable vector type.
+# Here this is always a copying operation!
+# Behaviour otherwise is undefined (from "unpacking" to Error all is possible)
+
+DeclareOperation( "{}", [IsFlatMatrix,IsList] );
+# Again this is defined to be a copying operation!
+
+# The following list operations are not supported for flat matrices:
+# Add, Remove, IsBound[], Unbind[], {}:=, Append
+
+# ShallowCopy is in fact a structural copy here:
+# DeclareOperation( "ShallowCopy", [IsFlatMatrix] );
+
+
+############################################################################
+# Rule:
+# Objects in IsFlatMatrix are not lists and do not behave like them.
+############################################################################
+
 
 ############################################################################
 # Arithmetic involving vectors and matrices:
 ############################################################################
 
 # DeclareOperation( "*", [IsVectorObj, IsMatrixObj] );
-# DeclareOperation( "*", [IsMatrixObj, IsVectorObj] );
 
-# TODO: the following does the same as "*", but is useful 
-# as convenience for Orbit-ish operations.
-# We otherwise discourage its use in "naked" code -- use * instead
 # DeclareOperation( "^", [IsVectorObj, IsMatrixObj] );
 
+# Only in this direction since vectors are row vectors. The standard
+# list arithmetic rules apply only in this sense here which is the
+# standard mathematical vector matrix multiplication.
+
+
+############################################################################
+# Rule:
+# Note that vectors are by convention row vectors.
+############################################################################
 
 
 ############################################################################
@@ -1050,23 +945,3 @@ DeclareOperation( "ListOp", [IsRowListMatrix, IsFunction] );
 
 # AsList
 # AddCoeffs
-
-
-
-# while we are at it also make the naming of following more uniform ???
-
-#   TriangulizeIntegerMat
-#   TriangulizedIntegerMat(Transform)
-#   HermiteNormalFormIntegerMat(Transform)
-#   SmithNormalFormIntegerMat(Transform)
-# and contrast them to these:
-#   BaseIntMat
-#   BaseIntersectionIntMats
-#   ComplementIntMat
-#   DeterminantIntMat
-#   DiagonalizeIntMat
-#   NormalFormIntMat
-#   NullspaceIntMat
-#   SolutionIntMat
-#   SolutionNullspaceIntMat
-

--- a/lib/matobjplist.gd
+++ b/lib/matobjplist.gd
@@ -42,6 +42,7 @@ DeclareFilter( "IsIntVector" );
 DeclareFilter( "IsFFEVector" );
 
 # Another pair of filters that slow down things:
+# TODO: document this (setting these filters seems to activate additional bounds checking)
 DeclareFilter( "IsCheckingVector" );
 DeclareFilter( "IsCheckingMatrix" );
 

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -729,13 +729,13 @@ InstallMethod( BaseDomain, "for a plist matrix",
     return m![BDPOS];
   end );
 
-InstallMethod( Length, "for a plist matrix",
+InstallMethod( NumberRows, "for a plist matrix",
   [ IsPlistMatrixRep ],
   function( m )
     return Length(m![ROWSPOS]);
   end );
 
-InstallMethod( RowLength, "for a plist matrix",
+InstallMethod( NumberColumns, "for a plist matrix",
   [ IsPlistMatrixRep ],
   function( m )
     return m![RLPOS];
@@ -1218,7 +1218,7 @@ InstallMethod( PrintObj, "for a plist matrix", [ IsPlistMatrixRep ],
     else
         Print(",",String(m![BDPOS]),",");
     fi;
-    Print(RowLength(m),",",Unpack(m),")");
+    Print(NumberColumns(m),",",Unpack(m),")");
   end );
 
 InstallMethod( Display, "for a plist matrix", [ IsPlistMatrixRep ],
@@ -1255,7 +1255,7 @@ InstallMethod( String, "for plist matrix", [ IsPlistMatrixRep ],
         Append(st,String(m![BDPOS]));
         Append(st,",");
     fi;
-    Append(st,String(RowLength(m)));
+    Append(st,String(NumberColumns(m)));
     Add(st,',');
     Append(st,String(Unpack(m)));
     Add(st,')');
@@ -1783,21 +1783,21 @@ InstallMethod( ChangedBaseDomain, "for a checking plist vector, and a domain",
 InstallMethod( ChangedBaseDomain, "for a plist matrix, and a domain",
   [ IsPlistMatrixRep, IsRing ],
   function( m, r )
-    return NewMatrix(IsPlistMatrixRep, r, RowLength(m),
+    return NewMatrix(IsPlistMatrixRep, r, NumberColumns(m),
                      List(m![ROWSPOS], x-> x![ELSPOS]));
   end );
 
 InstallMethod( ChangedBaseDomain, "for a checking plist matrix, and a domain",
   [ IsPlistMatrixRep and IsCheckingMatrix, IsRing ],
   function( m, r )
-    return NewMatrix(IsPlistMatrixRep and IsCheckingMatrix, r, RowLength(m),
+    return NewMatrix(IsPlistMatrixRep and IsCheckingMatrix, r, NumberColumns(m),
                      List(m![ROWSPOS], x-> x![ELSPOS]));
   end );
 
 InstallMethod( CompatibleVector, "for a plist matrix",
   [ IsPlistMatrixRep ],
   function( v )
-    return NewZeroVector(IsPlistVectorRep,BaseDomain(v),Length(v));
+    return NewZeroVector(IsPlistVectorRep,BaseDomain(v),NumberRows(v));
   end );
 
 InstallMethod( NewCompanionMatrix,

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -58,10 +58,16 @@ InstallMethod( NewMatrix,
   "for IsPlistMatrixRep, a ring, an int, and a list",
   [ IsPlistMatrixRep and IsCheckingMatrix, IsRing, IsInt, IsList ],
   function( filter, basedomain, rl, l )
-    local m,i,e,filter2;
+    local m,i,e,filter2, nd;
 
 # TODO: verify that rl actually matches the data in l, if not, show an error
-
+    # check if l is flat list
+    if Length(l) > 0 and not IsVectorObj(l[1]) then
+      nd := NestingDepthA(l);
+      if nd < 2 or nd mod 2 = 1 then
+        l := FoldList(l, rl);
+      fi;
+    fi;
     if IsIdenticalObj(IsPlistMatrixRep,filter) then
         filter2 := IsPlistVectorRep;
     else

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -1005,99 +1005,99 @@ InstallMethod( Unpack, "for a plist matrix",
     return List(m![ROWSPOS],v->ShallowCopy(v![ELSPOS]));
   end );
 
-InstallMethod( PositionNonZero, "for a plist matrix",
-  [ IsPlistMatrixRep ],
-  function( m )
-    local i,l,le;
-    l := m![ROWSPOS];
-    le := Length(l);
-    i := 1;
-    while i <= le and IsZero(l[i]) do i := i + 1; od;
-    return i;
-  end );
-
-InstallMethod( PositionNonZero, "for a plist matrix, and a position",
-  [ IsPlistMatrixRep, IsInt ],
-  function( m, p )
-    local i,l,le;
-    l := m![ROWSPOS];
-    le := Length(l);
-    i := p+1;
-    while i <= le and IsZero(l[i]) do i := i + 1; od;
-    if i > le+1 then
-        return le+1;
-    else
-        return i;
-    fi;
-  end );
-
-InstallMethod( PositionLastNonZero, "for a plist matrix",
-  [ IsPlistMatrixRep ],
-  function( m )
-    local i,l,le;
-    l := m![ROWSPOS];
-    le := Length(l);
-    i := le;
-    while i >= 1 and IsZero(l[i]) do i := i - 1; od;
-    return i;
-  end );
-
-InstallMethod( PositionLastNonZero, "for a plist matrix, and a position",
-  [ IsPlistMatrixRep, IsInt ],
-  function( m, p )
-    local i,l,le;
-    l := m![ROWSPOS];
-    le := Length(l);
-    i := p-1;
-    while i >= 1 and IsZero(l[i]) do i := i - 1; od;
-    if i < 0 then
-        return 0;
-    else
-        return i;
-    fi;
-  end );
-
-InstallMethod( Position, "for a plist matrix, and a plist vector",
-  [ IsPlistMatrixRep, IsPlistVectorRep ],
-  function( m, v )
-    local i,l,le;
-    l := m![ROWSPOS];
-    le := Length(l);
-    i := 1;
-    while i <= le and l[i] <> v do i := i + 1; od;
-    if i > le then
-        return fail;
-    else
-        return i;
-    fi;
-  end );
-
-InstallMethod( Position, "for a plist matrix, and a plist vector",
-  [ IsPlistMatrixRep, IsPlistVectorRep, IsInt ],
-  function( m, v, p )
-    local i,l,le;
-    l := m![ROWSPOS];
-    le := Length(l);
-    i := p+1;
-    while i <= le and l[i] <> v do i := i + 1; od;
-    if i > le then
-        return fail;
-    else
-        return i;
-    fi;
-  end );
-
-InstallMethod( PositionSortedOp, "for a plist matrix, and a plist vector",
-  [ IsPlistMatrixRep, IsPlistVectorRep ],
-  function( m, v )
-    return POSITION_SORTED_LIST(m![ROWSPOS],v);
-  end );
-
-InstallMethod( PositionSortedOp, "for a plist matrix, and a plist vector",
-  [ IsPlistMatrixRep, IsPlistVectorRep, IsFunction ],
-  function( m, v, f )
-    return POSITION_SORTED_LIST_COMP(m![ROWSPOS],v);
-  end );
+# InstallMethod( PositionNonZero, "for a plist matrix",
+#   [ IsPlistMatrixRep ],
+#   function( m )
+#     local i,l,le;
+#     l := m![ROWSPOS];
+#     le := Length(l);
+#     i := 1;
+#     while i <= le and IsZero(l[i]) do i := i + 1; od;
+#     return i;
+#   end );
+# 
+# InstallMethod( PositionNonZero, "for a plist matrix, and a position",
+#   [ IsPlistMatrixRep, IsInt ],
+#   function( m, p )
+#     local i,l,le;
+#     l := m![ROWSPOS];
+#     le := Length(l);
+#     i := p+1;
+#     while i <= le and IsZero(l[i]) do i := i + 1; od;
+#     if i > le+1 then
+#         return le+1;
+#     else
+#         return i;
+#     fi;
+#   end );
+# 
+# InstallMethod( PositionLastNonZero, "for a plist matrix",
+#   [ IsPlistMatrixRep ],
+#   function( m )
+#     local i,l,le;
+#     l := m![ROWSPOS];
+#     le := Length(l);
+#     i := le;
+#     while i >= 1 and IsZero(l[i]) do i := i - 1; od;
+#     return i;
+#   end );
+# 
+# InstallMethod( PositionLastNonZero, "for a plist matrix, and a position",
+#   [ IsPlistMatrixRep, IsInt ],
+#   function( m, p )
+#     local i,l,le;
+#     l := m![ROWSPOS];
+#     le := Length(l);
+#     i := p-1;
+#     while i >= 1 and IsZero(l[i]) do i := i - 1; od;
+#     if i < 0 then
+#         return 0;
+#     else
+#         return i;
+#     fi;
+#   end );
+# 
+# InstallMethod( Position, "for a plist matrix, and a plist vector",
+#   [ IsPlistMatrixRep, IsPlistVectorRep ],
+#   function( m, v )
+#     local i,l,le;
+#     l := m![ROWSPOS];
+#     le := Length(l);
+#     i := 1;
+#     while i <= le and l[i] <> v do i := i + 1; od;
+#     if i > le then
+#         return fail;
+#     else
+#         return i;
+#     fi;
+#   end );
+# 
+# InstallMethod( Position, "for a plist matrix, and a plist vector",
+#   [ IsPlistMatrixRep, IsPlistVectorRep, IsInt ],
+#   function( m, v, p )
+#     local i,l,le;
+#     l := m![ROWSPOS];
+#     le := Length(l);
+#     i := p+1;
+#     while i <= le and l[i] <> v do i := i + 1; od;
+#     if i > le then
+#         return fail;
+#     else
+#         return i;
+#     fi;
+#   end );
+# 
+# InstallMethod( PositionSortedOp, "for a plist matrix, and a plist vector",
+#   [ IsPlistMatrixRep, IsPlistVectorRep ],
+#   function( m, v )
+#     return POSITION_SORTED_LIST(m![ROWSPOS],v);
+#   end );
+# 
+# InstallMethod( PositionSortedOp, "for a plist matrix, and a plist vector",
+#   [ IsPlistMatrixRep, IsPlistVectorRep, IsFunction ],
+#   function( m, v, f )
+#     return POSITION_SORTED_LIST_COMP(m![ROWSPOS],v);
+#   end );
 
 InstallMethod( MutableCopyMat, "for a plist matrix",
   [ IsPlistMatrixRep ],

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -59,6 +59,9 @@ InstallMethod( NewMatrix,
   [ IsPlistMatrixRep and IsCheckingMatrix, IsRing, IsInt, IsList ],
   function( filter, basedomain, rl, l )
     local m,i,e,filter2;
+
+# TODO: verify that rl actually matches the data in l, if not, show an error
+
     if IsIdenticalObj(IsPlistMatrixRep,filter) then
         filter2 := IsPlistVectorRep;
     else

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -17,9 +17,10 @@
 InstallGlobalFunction( MakePlistVectorType,
   function( basedomain, filter )
     local T, filter2;
+    filter2 := filter and IsMutable;
     if HasCanEasilyCompareElements(Representative(basedomain)) and
        CanEasilyCompareElements(Representative(basedomain)) then
-        filter2 := filter and IsMutable and CanEasilyCompareElements;
+        filter2 := filter2 and CanEasilyCompareElements;
     fi;
     if IsIdenticalObj(basedomain,Integers) then
         T := NewType(FamilyObj(basedomain),
@@ -35,20 +36,20 @@ InstallGlobalFunction( MakePlistVectorType,
   end);
 
 InstallMethod( NewVector, "for IsPlistVectorRep, a ring, and a list",
-  [ IsPlistVectorRep and IsCheckingVector, IsRing, IsList ],
+  [ IsPlistVectorRep, IsRing, IsList ],
   function( filter, basedomain, l )
     local typ, v;
-    typ := MakePlistVectorType(basedomain,filter);
+    typ := MakePlistVectorType(basedomain,IsPlistVectorRep);
     v := [basedomain,ShallowCopy(l)];
     Objectify(typ,v);
     return v;
   end );
 
 InstallMethod( NewZeroVector, "for IsPlistVectorRep, a ring, and an int",
-  [ IsPlistVectorRep and IsCheckingVector, IsRing, IsInt ],
+  [ IsPlistVectorRep, IsRing, IsInt ],
   function( filter, basedomain, l )
     local typ, v;
-    typ := MakePlistVectorType(basedomain,filter);
+    typ := MakePlistVectorType(basedomain,IsPlistVectorRep);
     v := [basedomain,Zero(basedomain)*[1..l]];
     Objectify(typ,v);
     return v;
@@ -56,34 +57,34 @@ InstallMethod( NewZeroVector, "for IsPlistVectorRep, a ring, and an int",
 
 InstallMethod( NewMatrix,
   "for IsPlistMatrixRep, a ring, an int, and a list",
-  [ IsPlistMatrixRep and IsCheckingMatrix, IsRing, IsInt, IsList ],
+  [ IsPlistMatrixRep, IsRing, IsInt, IsList ],
   function( filter, basedomain, rl, l )
-    local m,i,e,filter2, nd;
-
-# TODO: verify that rl actually matches the data in l, if not, show an error
+    local nd, filterVectors, m, e, filter2, i;
     # check if l is flat list
     if Length(l) > 0 and not IsVectorObj(l[1]) then
       nd := NestingDepthA(l);
       if nd < 2 or nd mod 2 = 1 then
         l := FoldList(l, rl);
+      elif Length(l) mod rl <> 0 then
+        Error( "NewMatrix: Length of l is not a multiple of rl" );
       fi;
     fi;
     if IsIdenticalObj(IsPlistMatrixRep,filter) then
-        filter2 := IsPlistVectorRep;
+        filterVectors := IsPlistVectorRep;
     else
-        filter2 := IsPlistVectorRep and IsCheckingVector;
+        filterVectors := IsPlistVectorRep and IsCheckingVector;
     fi;
     m := 0*[1..Length(l)];
-    e := NewVector(filter2, basedomain, []);
     for i in [1..Length(l)] do
         if IsVectorObj(l[i]) and IsPlistVectorRep(l[i]) then
             m[i] := ShallowCopy(l[i]);
         else
-            m[i] := Vector( l[i], e );
+            m[i] := NewVector( filterVectors, basedomain, l[i] );
         fi;
     od;
+    e := NewVector(filterVectors, basedomain, []);
     m := [basedomain,e,rl,m];
-    filter2 := filter and IsMutable;
+    filter2 := IsPlistMatrixRep and IsMutable;
     if HasCanEasilyCompareElements(Representative(basedomain)) and
        CanEasilyCompareElements(Representative(basedomain)) then
         filter2 := filter2 and CanEasilyCompareElements;
@@ -95,7 +96,7 @@ InstallMethod( NewMatrix,
 
 InstallMethod( NewZeroMatrix,
   "for IsPlistMatrixRep, a ring, and two ints",
-  [ IsPlistMatrixRep and IsCheckingMatrix, IsRing, IsInt, IsInt ],
+  [ IsPlistMatrixRep, IsRing, IsInt, IsInt ],
   function( filter, basedomain, rows, cols )
     local m,i,e,filter2;
     if IsIdenticalObj(IsPlistMatrixRep,filter) then
@@ -116,16 +117,16 @@ InstallMethod( NewZeroMatrix,
 
 InstallMethod( NewIdentityMatrix,
   "for IsPlistMatrixRep, a ring, and an int",
-  [ IsPlistMatrixRep and IsCheckingMatrix, IsRing, IsInt ],
+  [ IsPlistMatrixRep, IsRing, IsInt ],
   function( filter, basedomain, rows )
-    local m,i,e,filter2;
+    local filterVectors, m, e, i;
     if IsIdenticalObj(IsPlistMatrixRep,filter) then
-        filter2 := IsPlistVectorRep;
+        filterVectors := IsPlistVectorRep;
     else
-        filter2 := IsPlistVectorRep and IsCheckingVector;
+        filterVectors := IsPlistVectorRep and IsCheckingVector;
     fi;
     m := 0*[1..rows];
-    e := NewVector(IsPlistVectorRep, basedomain, []);
+    e := NewVector(filterVectors, basedomain, []);
     for i in [1..rows] do
         m[i] := ZeroVector( rows, e );
         m[i][i] := One(basedomain);
@@ -1812,7 +1813,7 @@ InstallMethod( CompatibleVector, "for a plist matrix",
 InstallMethod( NewCompanionMatrix,
   "for IsPlistMatrixRep, a polynomial and a ring",
   [ IsPlistMatrixRep, IsUnivariatePolynomial, IsRing ],
-  function( ty, po, bd )
+  function( filter, po, bd )
     local i,l,ll,n,one;
     one := One(bd);
     l := CoefficientsOfUnivariatePolynomial(po);
@@ -1821,7 +1822,7 @@ InstallMethod( NewCompanionMatrix,
         Error("CompanionMatrix: polynomial is not monic");
         return fail;
     fi;
-    ll := NewMatrix(ty,bd,n,[]);
+    ll := NewMatrix(IsPlistMatrixRep,bd,n,[]);
     l := Vector(-l{[1..n]},CompatibleVector(ll));
     for i in [1..n-1] do
         Add(ll,ZeroMutable(l));
@@ -1831,24 +1832,25 @@ InstallMethod( NewCompanionMatrix,
     return ll;
   end );
 
-InstallMethod( NewCompanionMatrix,
-  "for IsPlistMatrixRep and IsCheckingMatrix, a polynomial and a ring",
-  [ IsPlistMatrixRep and IsCheckingMatrix, IsUnivariatePolynomial, IsRing ],
-  function( ty, po, bd )
-    local i,l,ll,n,one;
-    one := One(bd);
-    l := CoefficientsOfUnivariatePolynomial(po);
-    n := Length(l)-1;
-    if not IsOne(l[n+1]) then
-        Error("CompanionMatrix: polynomial is not monic");
-        return fail;
-    fi;
-    ll := NewMatrix(ty,bd,n,[]);
-    l := Vector(-l{[1..n]},CompatibleVector(ll));
-    for i in [1..n-1] do
-        Add(ll,ZeroMutable(l));
-        ll[i][i+1] := one;
-    od;
-    Add(ll,l);
-    return ll;
-  end );
+## Duplicate of the Constructor without IsCheckingMatrix
+## InstallMethod( NewCompanionMatrix,
+##   "for IsPlistMatrixRep and IsCheckingMatrix, a polynomial and a ring",
+##   [ IsPlistMatrixRep and IsCheckingMatrix, IsUnivariatePolynomial, IsRing ],
+##   function( ty, po, bd )
+##     local i,l,ll,n,one;
+##     one := One(bd);
+##     l := CoefficientsOfUnivariatePolynomial(po);
+##     n := Length(l)-1;
+##     if not IsOne(l[n+1]) then
+##         Error("CompanionMatrix: polynomial is not monic");
+##         return fail;
+##     fi;
+##     ll := NewMatrix(ty,bd,n,[]);
+##     l := Vector(-l{[1..n]},CompatibleVector(ll));
+##     for i in [1..n-1] do
+##         Add(ll,ZeroMutable(l));
+##         ll[i][i+1] := one;
+##     od;
+##     Add(ll,l);
+##     return ll;
+##   end );

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -989,8 +989,10 @@ InstallMethod( BaseDomain, "for an 8bit vector",
   [ Is8BitVectorRep ], function( v ) return GF(Q_VEC8BIT(v)); end );
 InstallMethod( BaseDomain, "for an 8bit matrix",
   [ Is8BitMatrixRep ], function( m ) return GF(Q_VEC8BIT(m[1])); end );
+InstallMethod( NumberRows, "for an 8bit matrix",
+  [ Is8BitMatrixRep ], m -> m![1]);
 # FIXME: this breaks down for matrices with 0 rows
-InstallMethod( RowLength, "for an 8bit matrix",
+InstallMethod( NumberColumns, "for an 8bit matrix",
   [ Is8BitMatrixRep ], function( m ) return Length(m[1]); end );
 # FIXME: this breaks down for matrices with 0 rows
 InstallMethod( Vector, "for a plist of finite field elements and an 8bitvector",

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2206,10 +2206,10 @@ BindGlobal( "PositionLastNonZeroFunc2",
 
 InstallMethod( PositionLastNonZero, "for a row vector obj",
   [IsVectorObj], PositionLastNonZeroFunc );
-InstallMethod( PositionLastNonZero, "for a matrix obj",
-  [IsMatrixObj], PositionLastNonZeroFunc );
-InstallMethod( PositionLastNonZero, "for a matrix obj, and an index",
-  [IsMatrixObj, IsPosInt], PositionLastNonZeroFunc2 );
+# InstallMethod( PositionLastNonZero, "for a matrix obj",
+#   [IsMatrixObj], PositionLastNonZeroFunc );
+# InstallMethod( PositionLastNonZero, "for a matrix obj, and an index",
+#   [IsMatrixObj, IsPosInt], PositionLastNonZeroFunc2 );
         
 InstallMethod( ExtractSubMatrix, "for a gf2 matrix, and two lists",
   [IsGF2MatrixRep, IsList, IsList],

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2126,7 +2126,9 @@ InstallMethod( BaseDomain, "for a gf2 vector",
   [ IsGF2VectorRep ], function( v ) return GF(2); end );
 InstallMethod( BaseDomain, "for a gf2 matrix",
   [ IsGF2MatrixRep ], function( m ) return GF(2); end );
-InstallMethod( RowLength, "for a gf2 matrix",
+InstallMethod( NumberRows, "for a gf2 matrix",
+  [ IsGF2MatrixRep ], m -> m![1]);
+InstallMethod( NumberColumns, "for a gf2 matrix",
   [ IsGF2MatrixRep ], function( m ) return Length(m[1]); end );
 # FIXME: this breaks down for matrices with 0 rows
 InstallMethod( Vector, "for a list of gf2 elements and a gf2 vector",

--- a/tst/test-matobj.g
+++ b/tst/test-matobj.g
@@ -1,0 +1,3 @@
+TestDirectory( [ DirectoriesLibrary( "tst/test-matobj" ) ],
+               rec(exitGAP := true, testOptions := rec( compareFunction := "uptowhitespace" ) ) );
+

--- a/tst/test-matobj/ConcatenationOfVectors.tst
+++ b/tst/test-matobj/ConcatenationOfVectors.tst
@@ -1,0 +1,22 @@
+gap> START_TEST("ConcatenationOfVectors.tst");
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> l2 := [6,2,7,4,5,6];
+[ 6, 2, 7, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> v2 := Vector(IsPlistVectorRep, Rationals, l2);
+<plist vector over Rationals of length 6>
+gap> vv := ConcatenationOfVectors( v1, v2, v2 );
+<plist vector over Rationals of length 18>
+gap> Unpack( vv );
+[ 1, 2, 3, 4, 5, 6, 6, 2, 7, 4, 5, 6, 6, 2, 7, 4, 5, 6 ]
+gap> v3 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> v4 := Vector(GF(5), l2*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5), Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> vv := ConcatenationOfVectors( [ v3, v4, v3 ] );
+< mutable compressed vector length 18 over GF(5) >
+gap> Unpack( vv );
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5)^2, 0*Z(5), Z(5)^0, Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> STOP_TEST("ConcatenationOfVectors.tst",1);

--- a/tst/test-matobj/CopySubVector.tst
+++ b/tst/test-matobj/CopySubVector.tst
@@ -1,0 +1,20 @@
+gap> START_TEST("CopySubVector.tst");
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> l2 := [1,1,1,2,2,2,3,3,3];
+[ 1, 1, 1, 2, 2, 2, 3, 3, 3 ]
+gap> v2 := Vector(IsPlistVectorRep, Rationals, l2);
+<plist vector over Rationals of length 9>
+gap> CopySubVector( v1, [2,4,6], v2, [1,2,4] );
+gap> Unpack(v1);
+[ 1, 1, 3, 1, 5, 2 ]
+gap> v3 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> v4 := Vector(GF(5), l2*One(GF(5)));
+[ Z(5)^0, Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5), Z(5)^3, Z(5)^3, Z(5)^3 ]
+gap> CopySubVector( v4, [2,4,6], v3, [1,2,3] );
+gap> v4;
+[ Z(5)^0, Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5)^3, Z(5)^3, Z(5)^3, Z(5)^3 ]
+gap> STOP_TEST("CopySubVector.tst",1);

--- a/tst/test-matobj/DistanceOfVectors.tst
+++ b/tst/test-matobj/DistanceOfVectors.tst
@@ -1,0 +1,32 @@
+gap> START_TEST( "DistanceOfVectors.tst" );
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> l2 := [0,2,3,0,5,6];
+[ 0, 2, 3, 0, 5, 6 ]
+gap> v2 := Vector(IsPlistVectorRep, Rationals, l2);
+<plist vector over Rationals of length 6>
+gap> l3 := [0,0,0,0,0,0];
+[ 0, 0, 0, 0, 0, 0 ]
+gap> v3 := Vector(IsPlistVectorRep, Rationals, l3);
+<plist vector over Rationals of length 6>
+gap> DistanceOfVectors( v1, v2 );
+2
+gap> DistanceOfVectors( v2, v3 );
+4
+gap> DistanceOfVectors( v1, v3 );
+6
+gap> v4 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> v5 := Vector(GF(5), l2*One(GF(5)));
+[ 0*Z(5), Z(5), Z(5)^3, 0*Z(5), 0*Z(5), Z(5)^0 ]
+gap> v6 := Vector(GF(5), l3*One(GF(5)));
+[ 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5) ]
+gap> DistanceOfVectors( v4, v5 );
+2
+gap> DistanceOfVectors( v5, v6 );
+3
+gap> DistanceOfVectors( v4, v6 );
+5
+gap> STOP_TEST( "DistanceOfVectors.tst", 1);

--- a/tst/test-matobj/ExtractSubvector.tst
+++ b/tst/test-matobj/ExtractSubvector.tst
@@ -1,0 +1,14 @@
+gap> START_TEST("ExtractSubVector.tst");
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v3 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> ExtractSubVector( v3, [1,2,4] );
+[ Z(5)^0, Z(5), Z(5)^2 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> ExtractSubVector( v1, [1,2,4] );
+<plist vector over Rationals of length 3>
+gap> Unpack( last );
+[ 1, 2, 4 ]
+gap> STOP_TEST("ExtractSubVector.tst",1);

--- a/tst/test-matobj/ListOp.tst
+++ b/tst/test-matobj/ListOp.tst
@@ -1,0 +1,14 @@
+gap> START_TEST("ListOp.tst");
+gap> ll := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, ll);
+<plist vector over Rationals of length 6>
+gap> List( v1 );
+[ 1, 2, 3, 4, 5, 6 ]
+gap> List( v1, x->x^2 );
+[ 1, 4, 9, 16, 25, 36 ]
+gap> v5 := Vector(GF(5), ll*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> List( v5, x->x^2 );
+[ Z(5)^0, Z(5)^2, Z(5)^2, Z(5)^0, 0*Z(5), Z(5)^0 ]
+gap> STOP_TEST( "ListOp.tst", 1);

--- a/tst/test-matobj/PositionNonZero.tst
+++ b/tst/test-matobj/PositionNonZero.tst
@@ -1,0 +1,32 @@
+gap> START_TEST( "PositionNonZero.tst" );
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> PositionNonZero( v1 );
+1
+gap> l2 := [0,2,3,0,5,6];
+[ 0, 2, 3, 0, 5, 6 ]
+gap> v2 := Vector(IsPlistVectorRep, Rationals, l2);
+<plist vector over Rationals of length 6>
+gap> PositionNonZero( v2 );
+2
+gap> l3 := [0,0,0,0,0,0];
+[ 0, 0, 0, 0, 0, 0 ]
+gap> v3 := Vector(IsPlistVectorRep, Rationals, l3);
+<plist vector over Rationals of length 6>
+gap> PositionNonZero( v3 );
+7
+gap> v4 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> PositionNonZero( v4 );
+1
+gap> v5 := Vector(GF(5), l2*One(GF(5)));
+[ 0*Z(5), Z(5), Z(5)^3, 0*Z(5), 0*Z(5), Z(5)^0 ]
+gap> PositionNonZero( v5 );
+2
+gap> v6 := Vector(GF(5), l3*One(GF(5)));
+[ 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5) ]
+gap> PositionNonZero( v6 );
+7
+gap> STOP_TEST( "PositionNonZero.tst", 1);

--- a/tst/test-matobj/Randomize.tst
+++ b/tst/test-matobj/Randomize.tst
@@ -1,0 +1,22 @@
+gap> START_TEST("Randomize.tst");
+gap> ll := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, ll);
+<plist vector over Rationals of length 6>
+gap> Randomize( v1 );
+gap> Unpack( v1 );
+[ -2/3, 2, 1, -4, 0, 1 ]
+gap> Randomize( v1 );
+gap> Unpack( v1 );
+[ -1, -1, 1/2, 0, -2, 1/2 ]
+gap> v2 := Vector(GF(5), ll*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> Randomize( v2 );
+[ 0*Z(5), Z(5)^2, Z(5)^0, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> v2;
+[ 0*Z(5), Z(5)^2, Z(5)^0, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> Randomize( v2 );
+[ Z(5), Z(5)^0, 0*Z(5), Z(5)^3, Z(5)^3, Z(5)^3 ]
+gap> v2;
+[ Z(5), Z(5)^0, 0*Z(5), Z(5)^3, Z(5)^3, Z(5)^3 ]
+gap> STOP_TEST( "Randomize.tst", 1);

--- a/tst/test-matobj/TraceMat.tst
+++ b/tst/test-matobj/TraceMat.tst
@@ -1,0 +1,16 @@
+gap> START_TEST( "TraceMat.tst" );
+gap> l := [[1,2],[3,4]];
+[ [ 1, 2 ], [ 3, 4 ] ]
+gap> m1 := Matrix(l);
+<2x2-matrix over Rationals>
+gap> m2 := Matrix(Integers,l);
+<2x2-matrix over Integers>
+gap> m3 := Matrix(GF(7),l*One(GF(7)));
+[ [ Z(7)^0, Z(7)^2 ], [ Z(7), Z(7)^4 ] ]
+gap> TraceMat( m1 );
+5
+gap> TraceMat( m2 );
+5
+gap> TraceMat( m3 );
+Z(7)^5
+gap> STOP_TEST( "TraceMat.tst", 1);

--- a/tst/test-matobj/Unpack.tst
+++ b/tst/test-matobj/Unpack.tst
@@ -1,0 +1,12 @@
+gap> START_TEST("Unpack.tst");
+gap> ll := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, ll);
+<plist vector over Rationals of length 6>
+gap> Unpack( v1 );
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v5 := Vector(GF(5), ll*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> Unpack( v5 );
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> STOP_TEST( "Unpack.tst", 1);

--- a/tst/test-matobj/WeightOfVector.tst
+++ b/tst/test-matobj/WeightOfVector.tst
@@ -1,0 +1,32 @@
+gap> START_TEST( "WeightOfVector.tst" );
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> WeightOfVector( v1 );
+6
+gap> l2 := [0,2,3,0,5,6];
+[ 0, 2, 3, 0, 5, 6 ]
+gap> v2 := Vector(IsPlistVectorRep, Rationals, l2);
+<plist vector over Rationals of length 6>
+gap> WeightOfVector( v2 );
+4
+gap> l3 := [0,0,0,0,0,0];
+[ 0, 0, 0, 0, 0, 0 ]
+gap> v3 := Vector(IsPlistVectorRep, Rationals, l3);
+<plist vector over Rationals of length 6> 
+gap> WeightOfVector( v3 );
+0 
+gap> v4 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> WeightOfVector( v4 );
+5 
+gap> v5 := Vector(GF(5), l2*One(GF(5)));
+[ 0*Z(5), Z(5), Z(5)^3, 0*Z(5), 0*Z(5), Z(5)^0 ]
+gap> WeightOfVector( v5 );
+3 
+gap> v6 := Vector(GF(5), l3*One(GF(5)));
+[ 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5) ]
+gap> WeightOfVector( v6 );
+0
+gap> STOP_TEST( "WeightOfVector.tst", 1);

--- a/tst/test-matobj/ZeroVector.tst
+++ b/tst/test-matobj/ZeroVector.tst
@@ -1,0 +1,16 @@
+gap> START_TEST("ZeroVector.tst");
+gap> l1 := [1,2,3,4,5,6];
+[ 1, 2, 3, 4, 5, 6 ]
+gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
+<plist vector over Rationals of length 6>
+gap> v0 := ZeroVector( 15, v1 );
+<plist vector over Rationals of length 15>
+gap> Unpack( v0 );
+[ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+gap> v3 := Vector(GF(5), l1*One(GF(5)));
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+gap> v0 := ZeroVector( 12, v3 );
+< mutable compressed vector length 12 over GF(5) >
+gap> Unpack( v0 );
+[ 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5) ]
+gap> STOP_TEST("ZeroVector.tst",1);


### PR DESCRIPTION
This is a revised version of PR #1454. I put this on a separate branch in my fork, because it rewrites history, and I did not want to rewrite the shared branch `MatrixObj` without some coordination.

This PR takes the work from those branches, and rebases them on master (where by now parts of the original `MatrixObj` have been integrated, see PR #1505).

Some notes

* I am still unhappy about the name `FoldList`, and the whole function, and question whether we really need this as a full blown generic and documented function. It seems to be used only once right now
* I squashed @sebasguts work (and some fixes by others) into a single commit, simply because the existing commits were not broken into logical blocks (and often, contained changes not mentioned in the commit message). This can of course be split into separate commits again later on, though I actually don't think it's necessary for this
* I also made some cleanups to @sebasguts commit, which I'd squash into his commit, except I wanted to give people a chance to review them before doing that
* also, there is some duplication between code @sebasguts added, existing code we just commented out in this PR, and some code generic code which for some reason ended up in `vecmat.gi` (even though that file is meant for GF2 code only -- which its name sadly does not reflect).
* I'd like to rename `vecmat.{gi,gd}` to e.g. `vecmat_gf2.{gi,gd}`, to indicate the purpose of those files; and then remove any generic methods for (compressed) matrices and vectors from those files
* GF2 and 8bit matrices in GAP actually do *not* support empty matrices, as they only store the number of rows but not their length. We should simply reverse this: the number of rows can easily be derived via `LEN_POSOBJ(mat)-1`, so we should simply store the number of columns
* it turns out that doing things with gf2 and 8bit matrix objects can silently convert them to plists-of-plists; e.g. it is allows to unbind an element in the middle, or assign something in cross characteristic, etc. etc. and all of these work and silently convert the matrix/vector. I can't think of situations where I'd want that -- I'd really prefer to require the user to perform a manual conversion, and instead let accesses like the above generate an error, to help track down bugs.
* ...