### PR TITLE
Fix SySetGapRootPath when multiple paths separated by ; are given

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -1508,14 +1508,15 @@ static void SySetGapRootPath( const Char * string )
             *q   = '\0';
         }
         if ( *p ) {
-            p++;  n++;
+            p++;
         }
+        n++;
 #ifdef HPCGAP
         // or each root <ROOT> we also add <ROOT/hpcgap> as a root (and first)
         if( n < MAX_GAP_DIRS ) {
-            strlcpy( SyGapRootPaths[n+1], SyGapRootPaths[n], sizeof(SyGapRootPaths[n]) );
+            strlcpy( SyGapRootPaths[n], SyGapRootPaths[n-1], sizeof(SyGapRootPaths[n]) );
         }
-        strxcat( SyGapRootPaths[n], "hpcgap/", sizeof(SyGapRootPaths[n]) );
+        strxcat( SyGapRootPaths[n-1], "hpcgap/", sizeof(SyGapRootPaths[n-1]) );
         n++;
 #endif
     }


### PR DESCRIPTION
This fixes a regression introduced when I integrated HPC-GAP: Back then,
I changed SySetGapRootPath to add two root paths for each path
given to it: Given path XYZ, it adds `XYZ/hpcgap/` and then `XYZ`. This
allows us to transparently override parts of the library for HPC-GAP.

However, I neglected to test with arguments to the `-l` command line
option which contain a semicolon to separate multiple paths, and of
course I broke that. This commit fixes this regression.

This might also fix PR #1501.