### PR TITLE
Add Handler for Copying Immutable Plists and Strings

### DIFF
--- a/src/plist.c
+++ b/src/plist.c
@@ -971,18 +971,19 @@ Obj FuncIS_PLIST_REP (
 **
 **  'CleanPlist' is the function in 'CleanObjFuncs' for plain lists.
 */
-Obj CopyPlist (
-    Obj                 list,
-    Int                 mut )
+Obj CopyPlistImm(Obj list, Int mut)
+{
+    GAP_ASSERT(!IS_MUTABLE_OBJ(list));
+    return list;
+}
+
+Obj CopyPlist(Obj list, Int mut)
 {
     Obj                 copy;           /* copy, result                    */
     Obj                 tmp;            /* temporary variable              */
     UInt                i;              /* loop variable                   */
 
-    /* don't change immutable objects                                      */
-    if ( ! IS_MUTABLE_OBJ(list) ) {
-        return list;
-    }
+    GAP_ASSERT(IS_MUTABLE_OBJ(list));
 
     /* make a copy                                                         */
     if ( mut ) {
@@ -4619,7 +4620,7 @@ static Int InitKernel (
     /* install the copy list methods                                       */
     for ( t1 = T_PLIST; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
         CopyObjFuncs [ t1                     ] = CopyPlist;
-        CopyObjFuncs [ t1 +IMMUTABLE          ] = CopyPlist;
+        CopyObjFuncs [ t1 +IMMUTABLE          ] = CopyPlistImm;
         CopyObjFuncs [ t1            +COPYING ] = CopyPlistCopy;
         CopyObjFuncs [ t1 +IMMUTABLE +COPYING ] = CopyPlistCopy;
         CleanObjFuncs[ t1                     ] = CleanPlist;

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -586,16 +586,19 @@ Obj TypeString (
 **
 **  'CleanString' is the function in 'CleanObjFuncs' for strings.
 */
+Obj CopyStringImm(Obj list, Int mut)
+{
+    GAP_ASSERT(!IS_MUTABLE_OBJ(list));
+    return list;
+}
+
 Obj CopyString (
     Obj                 list,
     Int                 mut )
 {
     Obj                 copy;           /* handle of the copy, result      */
 
-    /* just return immutable objects                                       */
-    if ( ! IS_MUTABLE_OBJ(list) ) {
-        return list;
-    }
+    GAP_ASSERT(IS_MUTABLE_OBJ(list));
 
     /* make object for  copy                                               */
     if ( mut ) {
@@ -2565,7 +2568,7 @@ static Int InitKernel (
     /* install the copy method                                             */
     for ( t1 = T_STRING; t1 <= T_STRING_SSORT; t1++ ) {
         CopyObjFuncs [ t1                     ] = CopyString;
-        CopyObjFuncs [ t1          +IMMUTABLE ] = CopyString;
+        CopyObjFuncs [ t1          +IMMUTABLE ] = CopyStringImm;
         CleanObjFuncs[ t1                     ] = CleanString;
         CleanObjFuncs[ t1          +IMMUTABLE ] = CleanString;
         CopyObjFuncs [ t1 +COPYING            ] = CopyStringCopy;

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -2566,7 +2566,7 @@ static Int InitKernel (
     }
 
     /* install the copy method                                             */
-    for ( t1 = T_STRING; t1 <= T_STRING_SSORT; t1++ ) {
+    for ( t1 = T_STRING; t1 <= T_STRING_SSORT; t1+=2 ) {
         CopyObjFuncs [ t1                     ] = CopyString;
         CopyObjFuncs [ t1          +IMMUTABLE ] = CopyStringImm;
         CleanObjFuncs[ t1                     ] = CleanString;


### PR DESCRIPTION
This does the same for Plists and String Objects as is done for Blists in #1514, and adds `GAP_ASSERT`s