### PR TITLE
Remove macros from trans.h/c

### DIFF
--- a/src/pperm.c
+++ b/src/pperm.c
@@ -1,15 +1,14 @@
-/*******************************************************************************
-**
-** A partial perm is of the form: 
-**
-** [image set, domain, codegree, entries of image list]
-**
-** An element of the internal rep of a partial perm in T_PPERM2 must be at
-** most 65535 and be of UInt2. The <codegree> is just the degree of the inverse
-** or equivalently the maximum element of the image.
-** 
-*******************************************************************************/
-
+/*****************************************************************************
+*
+* A partial perm is of the form:
+*
+* [image set, domain, codegree, entries of image list]
+*
+* An element of the internal rep of a partial perm in T_PPERM2 must be
+* at most 65535 and be of UInt2. The <codegree> is just the degree of
+* the inverse or equivalently the maximum element of the image.
+*
+*****************************************************************************/
 
 #include <src/system.h>                 /* system dependent part */
 #include <src/gapstate.h>
@@ -52,5968 +51,6739 @@
 
 #include <src/pperm.h>                  /* same header applies */
 
-#define MAX(a,b)          (a<b?b:a)
-#define MIN(a,b)          (a<b?a:b)
+#define MAX(a, b) (a < b ? b : a)
+#define MIN(a, b) (a < b ? a : b)
 
-#define IMG_PPERM(f)      (ADDR_OBJ(f)[0])
-#define DOM_PPERM(f)      (ADDR_OBJ(f)[1])
+#define IMG_PPERM(f) (ADDR_OBJ(f)[0])
+#define DOM_PPERM(f) (ADDR_OBJ(f)[1])
 
-#define NEW_PPERM2(deg)   NewBag(T_PPERM2, (deg+1)*sizeof(UInt2)+2*sizeof(Obj))
-#define CODEG_PPERM2(f)   (*(UInt2*)((Obj*)(ADDR_OBJ(f))+2))
-#define ADDR_PPERM2(f)    ((UInt2*)((Obj*)(ADDR_OBJ(f))+2)+1)
-#define DEG_PPERM2(f)  ((UInt)(SIZE_OBJ(f)-sizeof(UInt2)-2*sizeof(Obj))/sizeof(UInt2))
-#define RANK_PPERM2(f) (IMG_PPERM(f)==NULL?INIT_PPERM2(f):LEN_PLIST(IMG_PPERM(f)))
+#define NEW_PPERM2(deg)                                                      \
+    NewBag(T_PPERM2, (deg + 1) * sizeof(UInt2) + 2 * sizeof(Obj))
+#define CODEG_PPERM2(f) (*(UInt2 *)((Obj *)(ADDR_OBJ(f)) + 2))
+#define ADDR_PPERM2(f) ((UInt2 *)((Obj *)(ADDR_OBJ(f)) + 2) + 1)
+#define DEG_PPERM2(f)                                                        \
+    ((UInt)(SIZE_OBJ(f) - sizeof(UInt2) - 2 * sizeof(Obj)) / sizeof(UInt2))
+#define RANK_PPERM2(f)                                                       \
+    (IMG_PPERM(f) == NULL ? INIT_PPERM2(f) : LEN_PLIST(IMG_PPERM(f)))
 
-#define NEW_PPERM4(deg)   NewBag(T_PPERM4, (deg+1)*sizeof(UInt4)+2*sizeof(Obj))
-#define CODEG_PPERM4(f)   (*(UInt4*)((Obj*)(ADDR_OBJ(f))+2))
-#define ADDR_PPERM4(f)    ((UInt4*)((Obj*)(ADDR_OBJ(f))+2)+1)
-#define DEG_PPERM4(f)     ((UInt)(SIZE_OBJ(f)-sizeof(UInt4)-2*sizeof(Obj))/sizeof(UInt4))
-#define RANK_PPERM4(f) (IMG_PPERM(f)==NULL?INIT_PPERM4(f):LEN_PLIST(IMG_PPERM(f)))
+#define NEW_PPERM4(deg)                                                      \
+    NewBag(T_PPERM4, (deg + 1) * sizeof(UInt4) + 2 * sizeof(Obj))
+#define CODEG_PPERM4(f) (*(UInt4 *)((Obj *)(ADDR_OBJ(f)) + 2))
+#define ADDR_PPERM4(f) ((UInt4 *)((Obj *)(ADDR_OBJ(f)) + 2) + 1)
+#define DEG_PPERM4(f)                                                        \
+    ((UInt)(SIZE_OBJ(f) - sizeof(UInt4) - 2 * sizeof(Obj)) / sizeof(UInt4))
+#define RANK_PPERM4(f)                                                       \
+    (IMG_PPERM(f) == NULL ? INIT_PPERM4(f) : LEN_PLIST(IMG_PPERM(f)))
 
-#define IMAGEPP(i, ptf, deg) (i<=deg?ptf[i-1]:0)
-#define IS_PPERM(f)   (TNUM_OBJ(f)==T_PPERM2||TNUM_OBJ(f)==T_PPERM4)
-#define RANK_PPERM(f) (TNUM_OBJ(f)==T_PPERM2?RANK_PPERM2(f):RANK_PPERM4(f))
-#define DEG_PPERM(f)  (TNUM_OBJ(f)==T_PPERM2?DEG_PPERM2(f):DEG_PPERM4(f))
-#define CODEG_PPERM(f)(TNUM_OBJ(f)==T_PPERM2?CODEG_PPERM2(f):CODEG_PPERM4(f))
+#define IMAGEPP(i, ptf, deg) (i <= deg ? ptf[i - 1] : 0)
+#define IS_PPERM(f) (TNUM_OBJ(f) == T_PPERM2 || TNUM_OBJ(f) == T_PPERM4)
+#define RANK_PPERM(f)                                                        \
+    (TNUM_OBJ(f) == T_PPERM2 ? RANK_PPERM2(f) : RANK_PPERM4(f))
+#define DEG_PPERM(f) (TNUM_OBJ(f) == T_PPERM2 ? DEG_PPERM2(f) : DEG_PPERM4(f))
+#define CODEG_PPERM(f)                                                       \
+    (TNUM_OBJ(f) == T_PPERM2 ? CODEG_PPERM2(f) : CODEG_PPERM4(f))
 
-Obj   EmptyPartialPerm;
+Obj EmptyPartialPerm;
 
-/****************************************************************************
-**
-*V  TmpPPerm . . . . . . . handle of the buffer bag of the pperm package
-**
-**  'TmpPPerm' is the handle of a bag of type 'T_PPERM4', 
-**  which is created at initialization time of this package.  Functions in this
-**  package can use this bag for  whatever purpose they want.  They have to
-**  make sure of course that it is large enough.
-**
-**  The buffer is *not* guaranteed to have any particular value, routines
-**  that require a zero-initialization need to do this at the start.
+/**************************************************************************
+*
+*V TmpPPerm . . . . . . . handle of the buffer bag of the pperm package
+*
+* 'TmpPPerm' is the handle of a bag of type 'T_PPERM4', which is
+* created at initialization time of this package.  Functions in this
+* package can use this bag for  whatever purpose they want.  They have
+* to make sure of course that it is large enough.
+*
+* The buffer is *not* guaranteed to have any particular value, routines
+* that require a zero-initialization need to do this at the start.
 */
 /* TL: Obj TmpPPerm; */
-#define  TmpPPerm STATE(TmpPPerm)
+#define TmpPPerm STATE(TmpPPerm)
 
-static inline void ResizeTmpPPerm( UInt len ){
-  if (TmpPPerm == (Obj)0) {
-    TmpPPerm = NewBag(T_PPERM4, (len + 1) * sizeof(UInt4) + 2 * sizeof(Obj));
-  } else if (SIZE_OBJ(TmpPPerm) < (len + 1) * sizeof(UInt4) + 2 * sizeof(Obj)) {
-    ResizeBag(TmpPPerm,(len + 1) * sizeof(UInt4) + 2 * sizeof(Obj));
-  }
-}
-
-/*******************************************************************************
-** Static functions for partial perms
-*******************************************************************************/
-
-// find domain and img set (unsorted) return the rank 
-
-static UInt INIT_PPERM2(Obj f){ 
-  UInt    deg, rank, i;
-  UInt2   *ptf;
-  Obj     img, dom;
-  
-  deg=DEG_PPERM2(f);
-  
-  if(deg==0){
-    dom=NEW_PLIST(T_PLIST_EMPTY+IMMUTABLE, 0);
-    SET_LEN_PLIST(dom, 0);
-    DOM_PPERM(f)=dom;
-    IMG_PPERM(f)=dom;
-    CHANGED_BAG(f);
-    return deg;
-  }
-
-  dom=NEW_PLIST(T_PLIST_CYC_SSORT+IMMUTABLE, deg);
-  img=NEW_PLIST(T_PLIST_CYC+IMMUTABLE, deg);
-
-  /* renew the ptr in case of garbage collection */
-  ptf=ADDR_PPERM2(f); 
- 
-  rank=0;
-  for(i=0;i<deg;i++){        
-    if(ptf[i]!=0){
-      rank++;
-      SET_ELM_PLIST(dom, rank, INTOBJ_INT(i+1));
-      SET_ELM_PLIST(img, rank, INTOBJ_INT(ptf[i]));
+static inline void ResizeTmpPPerm(UInt len)
+{
+    if (TmpPPerm == (Obj)0) {
+        TmpPPerm =
+            NewBag(T_PPERM4, (len + 1) * sizeof(UInt4) + 2 * sizeof(Obj));
     }
-  }
-  
-  if(rank==0){
-    RetypeBag(img, T_PLIST_EMPTY+IMMUTABLE);
-    RetypeBag(dom, T_PLIST_EMPTY+IMMUTABLE);
-  }
-
-  SHRINK_PLIST(img, (Int) rank);
-  SET_LEN_PLIST(img, (Int) rank);
-  SHRINK_PLIST(dom, (Int) rank);
-  SET_LEN_PLIST(dom, (Int) rank);
-  
-  DOM_PPERM(f)=dom;
-  IMG_PPERM(f)=img;
-  CHANGED_BAG(f);
-  return rank;
-}
-
-static UInt INIT_PPERM4(Obj f){ 
-  UInt    deg, rank, i;
-  UInt4   *ptf;
-  Obj     img, dom;
-
-  deg=DEG_PPERM4(f);
-  
-  if(deg==0){
-    dom=NEW_PLIST(T_PLIST_EMPTY+IMMUTABLE, 0);
-    SET_LEN_PLIST(dom, 0);
-    DOM_PPERM(f)=dom;
-    IMG_PPERM(f)=dom;
-    CHANGED_BAG(f);
-    return deg;
-  }
-  
-  dom=NEW_PLIST(T_PLIST_CYC_SSORT+IMMUTABLE, deg);
-  img=NEW_PLIST(T_PLIST_CYC_NSORT+IMMUTABLE, deg);
-
-  ptf=ADDR_PPERM4(f); 
- 
-  rank=0;
-  for(i=0;i<deg;i++){        
-    if(ptf[i]!=0){
-      rank++;
-      SET_ELM_PLIST(dom, rank, INTOBJ_INT(i+1));
-      SET_ELM_PLIST(img, rank, INTOBJ_INT(ptf[i]));
+    else if (SIZE_OBJ(TmpPPerm) <
+             (len + 1) * sizeof(UInt4) + 2 * sizeof(Obj)) {
+        ResizeBag(TmpPPerm, (len + 1) * sizeof(UInt4) + 2 * sizeof(Obj));
     }
-  }
-
-  if(rank==0){
-    RetypeBag(img, T_PLIST_EMPTY+IMMUTABLE);
-    RetypeBag(dom, T_PLIST_EMPTY+IMMUTABLE);
-  }
-  
-  SHRINK_PLIST(img, (Int) rank);
-  SET_LEN_PLIST(img, (Int) rank);
-  SHRINK_PLIST(dom, (Int) rank);
-  SET_LEN_PLIST(dom, (Int) rank);
-  
-  DOM_PPERM(f)=dom;
-  IMG_PPERM(f)=img;
-  CHANGED_BAG(f);
-  return rank;
 }
 
-static Obj SORT_PLIST_CYC(Obj res){ 
-  Obj     tmp;       
-  UInt    h, i, k, len; 
-   
-  len=LEN_PLIST(res);  
-  if(len==0) return res;
+/*****************************************************************************
+* Static functions for partial perms
+*****************************************************************************/
 
-  h = 1;  while ( 9*h + 4 < len )  h = 3*h + 1; 
-  while ( 0 < h ) { 
-    for ( i = h+1; i <= len; i++ ) { 
-      tmp = ADDR_OBJ(res)[i];  k = i; 
-      while ( h < k && ((Int)tmp < (Int)(ADDR_OBJ(res)[k-h])) ) { 
-        ADDR_OBJ(res)[k] = ADDR_OBJ(res)[k-h]; 
-        k -= h; 
-      } 
-      ADDR_OBJ(res)[k] = tmp; 
-    } 
-    h = h / 3; 
-  } 
-  RetypeBag(res, T_PLIST_CYC_SSORT + IMMUTABLE);  
-  CHANGED_BAG(res);
-  return res;
+// find domain and img set (unsorted) return the rank
+
+static UInt INIT_PPERM2(Obj f)
+{
+    UInt    deg, rank, i;
+    UInt2 * ptf;
+    Obj     img, dom;
+
+    deg = DEG_PPERM2(f);
+
+    if (deg == 0) {
+        dom = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        SET_LEN_PLIST(dom, 0);
+        DOM_PPERM(f) = dom;
+        IMG_PPERM(f) = dom;
+        CHANGED_BAG(f);
+        return deg;
+    }
+
+    dom = NEW_PLIST(T_PLIST_CYC_SSORT + IMMUTABLE, deg);
+    img = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, deg);
+
+    /* renew the ptr in case of garbage collection */
+    ptf = ADDR_PPERM2(f);
+
+    rank = 0;
+    for (i = 0; i < deg; i++) {
+        if (ptf[i] != 0) {
+            rank++;
+            SET_ELM_PLIST(dom, rank, INTOBJ_INT(i + 1));
+            SET_ELM_PLIST(img, rank, INTOBJ_INT(ptf[i]));
+        }
+    }
+
+    if (rank == 0) {
+        RetypeBag(img, T_PLIST_EMPTY + IMMUTABLE);
+        RetypeBag(dom, T_PLIST_EMPTY + IMMUTABLE);
+    }
+
+    SHRINK_PLIST(img, (Int)rank);
+    SET_LEN_PLIST(img, (Int)rank);
+    SHRINK_PLIST(dom, (Int)rank);
+    SET_LEN_PLIST(dom, (Int)rank);
+
+    DOM_PPERM(f) = dom;
+    IMG_PPERM(f) = img;
+    CHANGED_BAG(f);
+    return rank;
 }
 
-static Obj PreImagePPermInt (Obj pt, Obj f){
-  UInt2   *ptf2;
-  UInt4   *ptf4;
-  UInt    i, cpt, deg;
+static UInt INIT_PPERM4(Obj f)
+{
+    UInt    deg, rank, i;
+    UInt4 * ptf;
+    Obj     img, dom;
 
-  cpt=INT_INTOBJ(pt);
-  
-  if(cpt>(TNUM_OBJ(f)==T_PPERM2?CODEG_PPERM2(f):CODEG_PPERM4(f)))
-    return Fail;
+    deg = DEG_PPERM4(f);
 
-  i=0;
-  
-  if(TNUM_OBJ(f)==T_PPERM2){
-    ptf2=ADDR_PPERM2(f);
-    deg=DEG_PPERM2(f);
-    while(ptf2[i]!=cpt&&i<deg) i++;
-    if(ptf2[i]!=cpt) return Fail; 
-  } else {
-    ptf4=ADDR_PPERM4(f);
-    deg=DEG_PPERM4(f);
-    while(ptf4[i]!=cpt&&i<deg) i++;
-    if(ptf4[i]!=cpt) return Fail; 
-  }
-  return INTOBJ_INT(i+1);
+    if (deg == 0) {
+        dom = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        SET_LEN_PLIST(dom, 0);
+        DOM_PPERM(f) = dom;
+        IMG_PPERM(f) = dom;
+        CHANGED_BAG(f);
+        return deg;
+    }
+
+    dom = NEW_PLIST(T_PLIST_CYC_SSORT + IMMUTABLE, deg);
+    img = NEW_PLIST(T_PLIST_CYC_NSORT + IMMUTABLE, deg);
+
+    ptf = ADDR_PPERM4(f);
+
+    rank = 0;
+    for (i = 0; i < deg; i++) {
+        if (ptf[i] != 0) {
+            rank++;
+            SET_ELM_PLIST(dom, rank, INTOBJ_INT(i + 1));
+            SET_ELM_PLIST(img, rank, INTOBJ_INT(ptf[i]));
+        }
+    }
+
+    if (rank == 0) {
+        RetypeBag(img, T_PLIST_EMPTY + IMMUTABLE);
+        RetypeBag(dom, T_PLIST_EMPTY + IMMUTABLE);
+    }
+
+    SHRINK_PLIST(img, (Int)rank);
+    SET_LEN_PLIST(img, (Int)rank);
+    SHRINK_PLIST(dom, (Int)rank);
+    SET_LEN_PLIST(dom, (Int)rank);
+
+    DOM_PPERM(f) = dom;
+    IMG_PPERM(f) = img;
+    CHANGED_BAG(f);
+    return rank;
 }
 
-/*******************************************************************************
-** GAP functions for partial perms
-*******************************************************************************/
+static Obj SORT_PLIST_CYC(Obj res)
+{
+    Obj  tmp;
+    UInt h, i, k, len;
+
+    len = LEN_PLIST(res);
+    if (len == 0)
+        return res;
+
+    h = 1;
+    while (9 * h + 4 < len)
+        h = 3 * h + 1;
+    while (0 < h) {
+        for (i = h + 1; i <= len; i++) {
+            tmp = ADDR_OBJ(res)[i];
+            k = i;
+            while (h < k && ((Int)tmp < (Int)(ADDR_OBJ(res)[k - h]))) {
+                ADDR_OBJ(res)[k] = ADDR_OBJ(res)[k - h];
+                k -= h;
+            }
+            ADDR_OBJ(res)[k] = tmp;
+        }
+        h = h / 3;
+    }
+    RetypeBag(res, T_PLIST_CYC_SSORT + IMMUTABLE);
+    CHANGED_BAG(res);
+    return res;
+}
+
+static Obj PreImagePPermInt(Obj pt, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    i, cpt, deg;
+
+    cpt = INT_INTOBJ(pt);
+
+    if (cpt > (TNUM_OBJ(f) == T_PPERM2 ? CODEG_PPERM2(f) : CODEG_PPERM4(f)))
+        return Fail;
+
+    i = 0;
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        ptf2 = ADDR_PPERM2(f);
+        deg = DEG_PPERM2(f);
+        while (ptf2[i] != cpt && i < deg)
+            i++;
+        if (ptf2[i] != cpt)
+            return Fail;
+    }
+    else {
+        ptf4 = ADDR_PPERM4(f);
+        deg = DEG_PPERM4(f);
+        while (ptf4[i] != cpt && i < deg)
+            i++;
+        if (ptf4[i] != cpt)
+            return Fail;
+    }
+    return INTOBJ_INT(i + 1);
+}
+
+/*****************************************************************************
+* GAP functions for partial perms
+*****************************************************************************/
 
 
-Obj FuncEmptyPartialPerm( Obj self ){
-  return EmptyPartialPerm;
+Obj FuncEmptyPartialPerm(Obj self)
+{
+    return EmptyPartialPerm;
 }
 
 /* method for creating a partial perm */
-Obj FuncDensePartialPermNC( Obj self, Obj img ){ 
-  UInt    deg, i, j, codeg; 
-  UInt2*  ptf2;
-  UInt4*  ptf4;
-  Obj     f; 
+Obj FuncDensePartialPermNC(Obj self, Obj img)
+{
+    UInt    deg, i, j, codeg;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    Obj     f;
 
-  if(LEN_LIST(img)==0) return EmptyPartialPerm;
+    if (LEN_LIST(img) == 0)
+        return EmptyPartialPerm;
 
-  //remove trailing 0s
-  deg=LEN_LIST(img); 
-  while(deg > 0 && INT_INTOBJ(ELM_LIST(img, deg))==0) deg--;
-  
-  if(deg==0) return EmptyPartialPerm;
+    // remove trailing 0s
+    deg = LEN_LIST(img);
+    while (deg > 0 && INT_INTOBJ(ELM_LIST(img, deg)) == 0)
+        deg--;
 
-  //find if we are PPERM2 or PPERM4
-  codeg=0; i=deg;
-  while(codeg<65536&&i>0){
-    j=INT_INTOBJ(ELM_LIST(img, i--));
-    if(j>codeg) codeg=j;
-  }
-  if(codeg<65536){
-    f=NEW_PPERM2(deg);
-    ptf2=ADDR_PPERM2(f);
-    for(i=0;i<deg;i++){
-      j=INT_INTOBJ(ELM_LIST(img, i+1));
-      *ptf2++=(UInt2) j;
+    if (deg == 0)
+        return EmptyPartialPerm;
+
+    // find if we are PPERM2 or PPERM4
+    codeg = 0;
+    i = deg;
+    while (codeg < 65536 && i > 0) {
+        j = INT_INTOBJ(ELM_LIST(img, i--));
+        if (j > codeg)
+            codeg = j;
     }
-    CODEG_PPERM2(f)=(UInt2) codeg; //codeg is already known
-  } else {
-    f=NEW_PPERM4(deg);
-    ptf4=ADDR_PPERM4(f);
-    for(i=0;i<deg;i++){
-      j=INT_INTOBJ(ELM_LIST(img, i+1));
-      if(j>codeg) codeg=j;
-      *ptf4++=(UInt4) j;
+    if (codeg < 65536) {
+        f = NEW_PPERM2(deg);
+        ptf2 = ADDR_PPERM2(f);
+        for (i = 0; i < deg; i++) {
+            j = INT_INTOBJ(ELM_LIST(img, i + 1));
+            *ptf2++ = (UInt2)j;
+        }
+        CODEG_PPERM2(f) = (UInt2)codeg;    // codeg is already known
     }
-    CODEG_PPERM4(f)=(UInt4) codeg;
-  }
-  return f; 
+    else {
+        f = NEW_PPERM4(deg);
+        ptf4 = ADDR_PPERM4(f);
+        for (i = 0; i < deg; i++) {
+            j = INT_INTOBJ(ELM_LIST(img, i + 1));
+            if (j > codeg)
+                codeg = j;
+            *ptf4++ = (UInt4)j;
+        }
+        CODEG_PPERM4(f) = (UInt4)codeg;
+    }
+    return f;
 }
 
 /* assumes that dom is a set and that img is duplicatefree */
-Obj FuncSparsePartialPermNC( Obj self, Obj dom, Obj img ){
-  UInt  rank, deg, i, j, codeg;
-  Obj   f;
-  UInt2 *ptf2;
-  UInt4 *ptf4;
+Obj FuncSparsePartialPermNC(Obj self, Obj dom, Obj img)
+{
+    UInt    rank, deg, i, j, codeg;
+    Obj     f;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
 
-  if(LEN_LIST(dom)==0) return EmptyPartialPerm;
+    if (LEN_LIST(dom) == 0)
+        return EmptyPartialPerm;
 
-  rank=LEN_LIST(dom);
-  deg=INT_INTOBJ(ELM_LIST(dom, rank));
-  
-  // find if we are PPERM2 or PPERM4
-  codeg=0; i=rank;
-  while(codeg<65536&&i>0){
-    j=INT_INTOBJ(ELM_LIST(img, i--));
-    if(j>codeg) codeg=j;
-  }
-  
-  // make sure we have plain lists
-  if(!IS_PLIST(dom)) PLAIN_LIST(dom);
-  if(!IS_PLIST(img)) PLAIN_LIST(img);
+    rank = LEN_LIST(dom);
+    deg = INT_INTOBJ(ELM_LIST(dom, rank));
 
-  // make dom and img immutable
-  MakeImmutable(dom);
-  MakeImmutable(img);
-  
-  // create the pperm
-  if(codeg<65536){ 
-    f=NEW_PPERM2(deg);
-    ptf2=ADDR_PPERM2(f);
-    for(i=1;i<=rank;i++){ 
-      ptf2[INT_INTOBJ(ELM_PLIST(dom, i))-1]=INT_INTOBJ(ELM_PLIST(img, i));
+    // find if we are PPERM2 or PPERM4
+    codeg = 0;
+    i = rank;
+    while (codeg < 65536 && i > 0) {
+        j = INT_INTOBJ(ELM_LIST(img, i--));
+        if (j > codeg)
+            codeg = j;
     }
-    DOM_PPERM(f)=dom;
-    IMG_PPERM(f)=img;
-    CODEG_PPERM2(f)=codeg;
-  } else {
-    f=NEW_PPERM4(deg);
-    ptf4=ADDR_PPERM4(f);
-    for(i=1;i<=rank;i++){ 
-      j=INT_INTOBJ(ELM_PLIST(img, i));
-      if(j>codeg) codeg=j;
-      ptf4[INT_INTOBJ(ELM_PLIST(dom, i))-1]=j;
+
+    // make sure we have plain lists
+    if (!IS_PLIST(dom))
+        PLAIN_LIST(dom);
+    if (!IS_PLIST(img))
+        PLAIN_LIST(img);
+
+    // make dom and img immutable
+    MakeImmutable(dom);
+    MakeImmutable(img);
+
+    // create the pperm
+    if (codeg < 65536) {
+        f = NEW_PPERM2(deg);
+        ptf2 = ADDR_PPERM2(f);
+        for (i = 1; i <= rank; i++) {
+            ptf2[INT_INTOBJ(ELM_PLIST(dom, i)) - 1] =
+                INT_INTOBJ(ELM_PLIST(img, i));
+        }
+        DOM_PPERM(f) = dom;
+        IMG_PPERM(f) = img;
+        CODEG_PPERM2(f) = codeg;
     }
-    DOM_PPERM(f)=dom;
-    IMG_PPERM(f)=img;
-    CODEG_PPERM4(f)=codeg;
-  }
-  CHANGED_BAG(f);
-  return f;
+    else {
+        f = NEW_PPERM4(deg);
+        ptf4 = ADDR_PPERM4(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(img, i));
+            if (j > codeg)
+                codeg = j;
+            ptf4[INT_INTOBJ(ELM_PLIST(dom, i)) - 1] = j;
+        }
+        DOM_PPERM(f) = dom;
+        IMG_PPERM(f) = img;
+        CODEG_PPERM4(f) = codeg;
+    }
+    CHANGED_BAG(f);
+    return f;
 }
 
 /* the degree of pperm is the maximum point where it is defined */
-Obj FuncDegreeOfPartialPerm(Obj self, Obj f){
-  if(TNUM_OBJ(f)==T_PPERM2){ 
-    return INTOBJ_INT(DEG_PPERM2(f));
-  } else if(TNUM_OBJ(f)==T_PPERM4){
-    return INTOBJ_INT(DEG_PPERM4(f));
-  }
-  ErrorQuit("usage: the argument should be a partial perm,", 0L, 0L);
-  return Fail;
+Obj FuncDegreeOfPartialPerm(Obj self, Obj f)
+{
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        return INTOBJ_INT(DEG_PPERM2(f));
+    }
+    else if (TNUM_OBJ(f) == T_PPERM4) {
+        return INTOBJ_INT(DEG_PPERM4(f));
+    }
+    ErrorQuit("usage: the argument should be a partial perm,", 0L, 0L);
+    return Fail;
 }
 
 /* the codegree of pperm is the maximum point in its image */
-Obj FuncCoDegreeOfPartialPerm(Obj self, Obj f){
-  if(TNUM_OBJ(f)==T_PPERM2){ 
-    return INTOBJ_INT(CODEG_PPERM2(f));
-  } else if(TNUM_OBJ(f)==T_PPERM4){
-    return INTOBJ_INT(CODEG_PPERM4(f));
-  }
-  ErrorQuit("usage: the argument should be a partial perm,", 0L, 0L);
-  return Fail;
+Obj FuncCoDegreeOfPartialPerm(Obj self, Obj f)
+{
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        return INTOBJ_INT(CODEG_PPERM2(f));
+    }
+    else if (TNUM_OBJ(f) == T_PPERM4) {
+        return INTOBJ_INT(CODEG_PPERM4(f));
+    }
+    ErrorQuit("usage: the argument should be a partial perm,", 0L, 0L);
+    return Fail;
 }
 
 /* the rank is the number of points where it is defined */
-Obj FuncRankOfPartialPerm (Obj self, Obj f){ 
-  if(TNUM_OBJ(f)==T_PPERM2){
-    return INTOBJ_INT(RANK_PPERM2(f));
-  } else if(TNUM_OBJ(f)==T_PPERM4){
-    return INTOBJ_INT(RANK_PPERM4(f));
-  }
-  ErrorQuit("usage: the argument should be a partial perm,", 0L, 0L);
-  return Fail;
+Obj FuncRankOfPartialPerm(Obj self, Obj f)
+{
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        return INTOBJ_INT(RANK_PPERM2(f));
+    }
+    else if (TNUM_OBJ(f) == T_PPERM4) {
+        return INTOBJ_INT(RANK_PPERM4(f));
+    }
+    ErrorQuit("usage: the argument should be a partial perm,", 0L, 0L);
+    return Fail;
 }
 
 /* domain of a partial perm */
-Obj FuncDOMAIN_PPERM(Obj self, Obj f){ 
-  if(DOM_PPERM(f)==NULL){
-    if(TNUM_OBJ(f)==T_PPERM2){
-      INIT_PPERM2(f);
-    } else {
-      INIT_PPERM4(f);
+Obj FuncDOMAIN_PPERM(Obj self, Obj f)
+{
+    if (DOM_PPERM(f) == NULL) {
+        if (TNUM_OBJ(f) == T_PPERM2) {
+            INIT_PPERM2(f);
+        }
+        else {
+            INIT_PPERM4(f);
+        }
     }
-  }
-  return DOM_PPERM(f);
-} 
+    return DOM_PPERM(f);
+}
 
 /* image list of pperm */
-Obj FuncIMAGE_PPERM(Obj self, Obj f ){ 
-  UInt2*    ptf2;
-  UInt4*    ptf4;
-  UInt      i, rank;
-  Obj       out, dom;
-  if(TNUM_OBJ(f)==T_PPERM2){
-    if(IMG_PPERM(f)==NULL){
-      INIT_PPERM2(f);
-      return IMG_PPERM(f);
-    } else if(!IS_SSORT_LIST(IMG_PPERM(f))){
-      return IMG_PPERM(f);
+Obj FuncIMAGE_PPERM(Obj self, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    i, rank;
+    Obj     out, dom;
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        if (IMG_PPERM(f) == NULL) {
+            INIT_PPERM2(f);
+            return IMG_PPERM(f);
+        }
+        else if (!IS_SSORT_LIST(IMG_PPERM(f))) {
+            return IMG_PPERM(f);
+        }
+        rank = RANK_PPERM2(f);
+        if (rank == 0) {
+            out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+            SET_LEN_PLIST(out, 0);
+            return out;
+        }
+        out = NEW_PLIST(T_PLIST_CYC_NSORT + IMMUTABLE, rank);
+        SET_LEN_PLIST(out, rank);
+        ptf2 = ADDR_PPERM2(f);
+        dom = DOM_PPERM(f);
+        for (i = 1; i <= rank; i++) {
+            SET_ELM_PLIST(
+                out, i, INTOBJ_INT(ptf2[INT_INTOBJ(ELM_PLIST(dom, i)) - 1]));
+        }
     }
-    rank=RANK_PPERM2(f);
-    if(rank==0){
-      out=NEW_PLIST(T_PLIST_EMPTY+IMMUTABLE, 0);
-      SET_LEN_PLIST(out, 0);
-      return out;
+    else {
+        if (IMG_PPERM(f) == NULL) {
+            INIT_PPERM4(f);
+            return IMG_PPERM(f);
+        }
+        else if (!IS_SSORT_LIST(IMG_PPERM(f))) {
+            return IMG_PPERM(f);
+        }
+        rank = RANK_PPERM4(f);
+        if (rank == 0) {
+            out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+            SET_LEN_PLIST(out, 0);
+            return out;
+        }
+        out = NEW_PLIST(T_PLIST_CYC_NSORT + IMMUTABLE, rank);
+        SET_LEN_PLIST(out, rank);
+        ptf4 = ADDR_PPERM4(f);
+        dom = DOM_PPERM(f);
+        for (i = 1; i <= rank; i++) {
+            SET_ELM_PLIST(
+                out, i, INTOBJ_INT(ptf4[INT_INTOBJ(ELM_PLIST(dom, i)) - 1]));
+        }
     }
-    out=NEW_PLIST(T_PLIST_CYC_NSORT+IMMUTABLE, rank);
-    SET_LEN_PLIST(out, rank);
-    ptf2=ADDR_PPERM2(f);
-    dom=DOM_PPERM(f);
-    for(i=1;i<=rank;i++){ 
-      SET_ELM_PLIST(out,i,INTOBJ_INT(ptf2[INT_INTOBJ(ELM_PLIST(dom, i))-1]));
-    }
-  } else {
-    if(IMG_PPERM(f)==NULL){
-      INIT_PPERM4(f);
-      return IMG_PPERM(f);
-    } else if(!IS_SSORT_LIST(IMG_PPERM(f))){
-      return IMG_PPERM(f);
-    }
-    rank=RANK_PPERM4(f);
-    if(rank==0){
-      out=NEW_PLIST(T_PLIST_EMPTY+IMMUTABLE, 0);
-      SET_LEN_PLIST(out, 0);
-      return out;
-    }
-    out=NEW_PLIST(T_PLIST_CYC_NSORT+IMMUTABLE, rank);
-    SET_LEN_PLIST(out, rank);
-    ptf4=ADDR_PPERM4(f);
-    dom=DOM_PPERM(f);
-    for(i=1;i<=rank;i++){ 
-      SET_ELM_PLIST(out,i,INTOBJ_INT(ptf4[INT_INTOBJ(ELM_PLIST(dom, i))-1]));
-    }
-  }
-  return out;
-} 
+    return out;
+}
 
 /* image set of partial perm */
-Obj FuncIMAGE_SET_PPERM (Obj self, Obj f){ 
-  if(TNUM_OBJ(f)==T_PPERM2){
-    if(IMG_PPERM(f)==NULL){
-      INIT_PPERM2(f);
-      return SORT_PLIST_CYC(IMG_PPERM(f));
-    } else if(!IS_SSORT_LIST(IMG_PPERM(f))){
-      return SORT_PLIST_CYC(IMG_PPERM(f));
+Obj FuncIMAGE_SET_PPERM(Obj self, Obj f)
+{
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        if (IMG_PPERM(f) == NULL) {
+            INIT_PPERM2(f);
+            return SORT_PLIST_CYC(IMG_PPERM(f));
+        }
+        else if (!IS_SSORT_LIST(IMG_PPERM(f))) {
+            return SORT_PLIST_CYC(IMG_PPERM(f));
+        }
+        return IMG_PPERM(f);
     }
-    return IMG_PPERM(f);  
-  } else if (TNUM_OBJ(f)==T_PPERM4){
-   if(IMG_PPERM(f)==NULL){
-      INIT_PPERM4(f);
-      return SORT_PLIST_CYC(IMG_PPERM(f));
-    } else if(!IS_SSORT_LIST(IMG_PPERM(f))){
-      return SORT_PLIST_CYC(IMG_PPERM(f));
+    else if (TNUM_OBJ(f) == T_PPERM4) {
+        if (IMG_PPERM(f) == NULL) {
+            INIT_PPERM4(f);
+            return SORT_PLIST_CYC(IMG_PPERM(f));
+        }
+        else if (!IS_SSORT_LIST(IMG_PPERM(f))) {
+            return SORT_PLIST_CYC(IMG_PPERM(f));
+        }
+        return IMG_PPERM(f);
     }
-    return IMG_PPERM(f);
-  } else {
-    ErrorQuit("usage: the argument must be a partial perm,", 0L, 0L);
-  }
-  return Fail;
-} 
+    else {
+        ErrorQuit("usage: the argument must be a partial perm,", 0L, 0L);
+    }
+    return Fail;
+}
 
 /* preimage under a partial perm */
-Obj FuncPREIMAGE_PPERM_INT (Obj self, Obj f, Obj pt){
-  return PreImagePPermInt(pt, f);
+Obj FuncPREIMAGE_PPERM_INT(Obj self, Obj f, Obj pt)
+{
+    return PreImagePPermInt(pt, f);
 }
 
 // the least m, r such that f^m=f^m+r
-Obj FuncINDEX_PERIOD_PPERM(Obj self, Obj f){
-  UInt    i, len, j, pow, gcd, rank, k, deg, n; 
-  UInt2   *ptf2;
-  UInt4   *ptseen, *ptf4;
-  Obj     dom, img, ord, out;
-  
-  pow=0;  ord=INTOBJ_INT(1);  n=MAX(DEG_PPERM(f), CODEG_PPERM(f));
-  
-  ResizeTmpPPerm(n);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  for(i=0;i<n;i++) ptseen[i]=0; 
+Obj FuncINDEX_PERIOD_PPERM(Obj self, Obj f)
+{
+    UInt    i, len, j, pow, gcd, rank, k, deg, n;
+    UInt2 * ptf2;
+    UInt4 * ptseen, *ptf4;
+    Obj     dom, img, ord, out;
 
-  rank=RANK_PPERM(f);   img=IMG_PPERM(f);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  
-  //find img(f)
-  for(i=1;i<=rank;i++) ptseen[INT_INTOBJ(ELM_PLIST(img, i))-1]=1;
-  
-  if(TNUM_OBJ(f)==T_PPERM2){
-    deg=DEG_PPERM2(f);
-    ptf2=ADDR_PPERM2(f);
-    dom=DOM_PPERM(f);
-    
-    //find chains
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptseen[j]==0){
-        ptseen[j]=2;
-        len=1;
-        for(k=ptf2[j];(k<=deg&&ptf2[k-1]!=0);k=ptf2[k-1]){ 
-          len++; ptseen[k-1]=2;
-        }
-        ptseen[k-1]=2;
-        if(len>pow) pow=len;
-      }
-    }
-    
-    //find cycles 
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptseen[j]==1){
-        len=1;
-        for(k=ptf2[j];k!=j+1;k=ptf2[k-1]){ 
-          len++; ptseen[k-1]=0;
-        }
-        gcd=len;  j=INT_INTOBJ(ModInt(ord,INTOBJ_INT(len)));
-        while(j!=0){
-          k=j;  j=gcd%j;  gcd=k;
-        }
-        ord=ProdInt(ord,INTOBJ_INT(len/gcd));
-      }
-    }
-  } else {
-    deg=DEG_PPERM4(f);
-    ptf4=ADDR_PPERM4(f);
-    dom=DOM_PPERM(f);
+    pow = 0;
+    ord = INTOBJ_INT(1);
+    n = MAX(DEG_PPERM(f), CODEG_PPERM(f));
 
-    //find chains
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptseen[j]==0){
-        ptseen[j]=2;
-        len=1;
-        for(k=ptf4[j];(k<=deg&&ptf4[k-1]!=0);k=ptf4[k-1]){ 
-          len++; ptseen[k-1]=2;
-        }
-        ptseen[k-1]=2;
-        if(len>pow) pow=len;
-      }
-    }
+    ResizeTmpPPerm(n);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+    for (i = 0; i < n; i++)
+        ptseen[i] = 0;
 
-    //find cycles 
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptseen[j]==1){
-        len=1;
-        for(k=ptf4[j];k!=j+1;k=ptf4[k-1]){ 
-          len++; ptseen[k-1]=0;
+    rank = RANK_PPERM(f);
+    img = IMG_PPERM(f);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+
+    // find img(f)
+    for (i = 1; i <= rank; i++)
+        ptseen[INT_INTOBJ(ELM_PLIST(img, i)) - 1] = 1;
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        deg = DEG_PPERM2(f);
+        ptf2 = ADDR_PPERM2(f);
+        dom = DOM_PPERM(f);
+
+        // find chains
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptseen[j] == 0) {
+                ptseen[j] = 2;
+                len = 1;
+                for (k = ptf2[j]; (k <= deg && ptf2[k - 1] != 0);
+                     k = ptf2[k - 1]) {
+                    len++;
+                    ptseen[k - 1] = 2;
+                }
+                ptseen[k - 1] = 2;
+                if (len > pow)
+                    pow = len;
+            }
         }
-        gcd=len;  j=INT_INTOBJ(ModInt(ord,INTOBJ_INT(len)));
-        while(j!=0){
-          k=j;  j=gcd%j;  gcd=k;
+
+        // find cycles
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptseen[j] == 1) {
+                len = 1;
+                for (k = ptf2[j]; k != j + 1; k = ptf2[k - 1]) {
+                    len++;
+                    ptseen[k - 1] = 0;
+                }
+                gcd = len;
+                j = INT_INTOBJ(ModInt(ord, INTOBJ_INT(len)));
+                while (j != 0) {
+                    k = j;
+                    j = gcd % j;
+                    gcd = k;
+                }
+                ord = ProdInt(ord, INTOBJ_INT(len / gcd));
+            }
         }
-        ord=ProdInt(ord,INTOBJ_INT(len/gcd));
-      }
     }
-  }
-  out=NEW_PLIST(T_PLIST_CYC, 2);
-  SET_LEN_PLIST(out, 2);
-  SET_ELM_PLIST(out, 1, INTOBJ_INT(pow+1));
-  SET_ELM_PLIST(out, 2, ord);
-  return out;
+    else {
+        deg = DEG_PPERM4(f);
+        ptf4 = ADDR_PPERM4(f);
+        dom = DOM_PPERM(f);
+
+        // find chains
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptseen[j] == 0) {
+                ptseen[j] = 2;
+                len = 1;
+                for (k = ptf4[j]; (k <= deg && ptf4[k - 1] != 0);
+                     k = ptf4[k - 1]) {
+                    len++;
+                    ptseen[k - 1] = 2;
+                }
+                ptseen[k - 1] = 2;
+                if (len > pow)
+                    pow = len;
+            }
+        }
+
+        // find cycles
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptseen[j] == 1) {
+                len = 1;
+                for (k = ptf4[j]; k != j + 1; k = ptf4[k - 1]) {
+                    len++;
+                    ptseen[k - 1] = 0;
+                }
+                gcd = len;
+                j = INT_INTOBJ(ModInt(ord, INTOBJ_INT(len)));
+                while (j != 0) {
+                    k = j;
+                    j = gcd % j;
+                    gcd = k;
+                }
+                ord = ProdInt(ord, INTOBJ_INT(len / gcd));
+            }
+        }
+    }
+    out = NEW_PLIST(T_PLIST_CYC, 2);
+    SET_LEN_PLIST(out, 2);
+    SET_ELM_PLIST(out, 1, INTOBJ_INT(pow + 1));
+    SET_ELM_PLIST(out, 2, ord);
+    return out;
 }
 
 // the least power of <f> which is an idempotent
-Obj FuncSMALLEST_IDEM_POW_PPERM( Obj self, Obj f ){
-  Obj x, ind, per, pow;
+Obj FuncSMALLEST_IDEM_POW_PPERM(Obj self, Obj f)
+{
+    Obj x, ind, per, pow;
 
-  x=FuncINDEX_PERIOD_PPERM(self, f);
-  ind=ELM_PLIST(x, 1);
-  per=ELM_PLIST(x, 2);
-  pow=per;
-  while(LtInt(pow, ind)) pow=SumInt(pow, per);
-  return pow;
+    x = FuncINDEX_PERIOD_PPERM(self, f);
+    ind = ELM_PLIST(x, 1);
+    per = ELM_PLIST(x, 2);
+    pow = per;
+    while (LtInt(pow, ind))
+        pow = SumInt(pow, per);
+    return pow;
 }
 
 /* returns the least list <out> such that for all <i> in [1..degree(f)]
  * there exists <j> in <out> and a pos int <k> such that <j^(f^k)=i>. */
-Obj FuncCOMPONENT_REPS_PPERM(Obj self, Obj f){
-  UInt    i, j, rank, k, deg, nr, n; 
-  UInt2   *ptf2;
-  UInt4   *ptseen, *ptf4;
-  Obj     dom, img, out;
- 
-  n=MAX(DEG_PPERM(f), CODEG_PPERM(f));
+Obj FuncCOMPONENT_REPS_PPERM(Obj self, Obj f)
+{
+    UInt    i, j, rank, k, deg, nr, n;
+    UInt2 * ptf2;
+    UInt4 * ptseen, *ptf4;
+    Obj     dom, img, out;
 
-  if (n == 0) {
-    out = NEW_PLIST(T_PLIST_EMPTY, 0);
-    SET_LEN_PLIST(out, 0);
+    n = MAX(DEG_PPERM(f), CODEG_PPERM(f));
+
+    if (n == 0) {
+        out = NEW_PLIST(T_PLIST_EMPTY, 0);
+        SET_LEN_PLIST(out, 0);
+        return out;
+    }
+
+    ResizeTmpPPerm(n);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+    for (i = 0; i < n; i++)
+        ptseen[i] = 0;
+
+    rank = RANK_PPERM(f);
+    img = IMG_PPERM(f);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+
+    // find img(f)
+    for (i = 1; i <= rank; i++)
+        ptseen[INT_INTOBJ(ELM_PLIST(img, i)) - 1] = 1;
+
+    deg = DEG_PPERM(f);
+    nr = 0;
+    out = NEW_PLIST(T_PLIST_CYC, deg);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        dom = DOM_PPERM(f);
+        ptf2 = ADDR_PPERM2(f);
+
+        // find chains
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i));
+            if (ptseen[j - 1] == 0) {
+                for (k = j; (k <= deg && ptf2[k - 1] != 0); k = ptf2[k - 1])
+                    ptseen[k - 1] = 2;
+                ptseen[k - 1] = 2;
+                SET_ELM_PLIST(out, ++nr, ELM_PLIST(dom, i));
+            }
+        }
+
+        // find cycles
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptseen[j] == 1) {
+                ptseen[j] = 0;
+                for (k = ptf2[j]; k != j + 1; k = ptf2[k - 1])
+                    ptseen[k - 1] = 0;
+                SET_ELM_PLIST(out, ++nr, ELM_PLIST(dom, i));
+            }
+        }
+    }
+    else {
+        dom = DOM_PPERM(f);
+        ptf4 = ADDR_PPERM4(f);
+
+        // find chains
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i));
+            if (ptseen[j - 1] == 0) {
+                for (k = j; (k <= deg && ptf4[k - 1] != 0); k = ptf4[k - 1])
+                    ptseen[k - 1] = 2;
+                ptseen[k - 1] = 2;
+                SET_ELM_PLIST(out, ++nr, ELM_PLIST(dom, i));
+            }
+        }
+
+        // find cycles
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptseen[j] == 1) {
+                ptseen[j] = 0;
+                for (k = ptf4[j]; k != j + 1; k = ptf4[k - 1])
+                    ptseen[k - 1] = 0;
+                SET_ELM_PLIST(out, ++nr, ELM_PLIST(dom, i));
+            }
+        }
+    }
+
+    SHRINK_PLIST(out, (Int)nr);
+    SET_LEN_PLIST(out, (Int)nr);
     return out;
-  }
-
-  ResizeTmpPPerm(n);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  for(i=0;i<n;i++) ptseen[i]=0; 
- 
-  rank=RANK_PPERM(f);   img=IMG_PPERM(f);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  
-  //find img(f)
-  for(i=1;i<=rank;i++) ptseen[INT_INTOBJ(ELM_PLIST(img, i))-1]=1;
-  
-  deg=DEG_PPERM(f);   nr=0;
-  out=NEW_PLIST(T_PLIST_CYC, deg);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-
-  if(TNUM_OBJ(f)==T_PPERM2){  
-    dom=DOM_PPERM(f);
-    ptf2=ADDR_PPERM2(f);
-    
-    //find chains
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i));
-      if(ptseen[j-1]==0){
-        for(k=j;(k<=deg&&ptf2[k-1]!=0);k=ptf2[k-1]) ptseen[k-1]=2;
-        ptseen[k-1]=2;  
-        SET_ELM_PLIST(out, ++nr, ELM_PLIST(dom, i));
-      }
-    }
-    
-    //find cycles 
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptseen[j]==1){
-        ptseen[j]=0;
-        for(k=ptf2[j];k!=j+1;k=ptf2[k-1]) ptseen[k-1]=0;
-        SET_ELM_PLIST(out, ++nr, ELM_PLIST(dom, i));
-      }
-    }
-  } else {
-    dom=DOM_PPERM(f);
-    ptf4=ADDR_PPERM4(f);      
-
-    //find chains
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i));
-      if(ptseen[j-1]==0){
-        for(k=j;(k<=deg&&ptf4[k-1]!=0);k=ptf4[k-1]) ptseen[k-1]=2;
-        ptseen[k-1]=2;  
-        SET_ELM_PLIST(out, ++nr, ELM_PLIST(dom, i));
-      }
-    }
-    
-    //find cycles 
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptseen[j]==1){
-        ptseen[j]=0;
-        for(k=ptf4[j];k!=j+1;k=ptf4[k-1]) ptseen[k-1]=0;
-        SET_ELM_PLIST(out, ++nr, ELM_PLIST(dom, i));
-      }
-    }
-  }
-  
-  SHRINK_PLIST(out, (Int) nr);
-  SET_LEN_PLIST(out, (Int) nr);
-  return out;
 }
 
 /* the number of components of a partial perm (as a functional digraph) */
-Obj FuncNR_COMPONENTS_PPERM(Obj self, Obj f){
-  UInt    i, j, n, rank, k, deg, nr; 
-  UInt2   *ptf2;
-  UInt4   *ptseen, *ptf4;
-  Obj     dom, img;
- 
-  n=MAX(DEG_PPERM(f), CODEG_PPERM(f));
-  ResizeTmpPPerm(n);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  for(i=0;i<n;i++) ptseen[i]=0; 
- 
-  rank=RANK_PPERM(f);   img=IMG_PPERM(f);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  
-  //find img(f)
-  for(i=1;i<=rank;i++) ptseen[INT_INTOBJ(ELM_PLIST(img, i))-1]=1;
-  
-  nr=0;
+Obj FuncNR_COMPONENTS_PPERM(Obj self, Obj f)
+{
+    UInt    i, j, n, rank, k, deg, nr;
+    UInt2 * ptf2;
+    UInt4 * ptseen, *ptf4;
+    Obj     dom, img;
 
-  if(TNUM_OBJ(f)==T_PPERM2){
-    deg=DEG_PPERM2(f);
-    ptf2=ADDR_PPERM2(f);
-    dom=DOM_PPERM(f);
+    n = MAX(DEG_PPERM(f), CODEG_PPERM(f));
+    ResizeTmpPPerm(n);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+    for (i = 0; i < n; i++)
+        ptseen[i] = 0;
 
-    //find chains
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i));
-      if(ptseen[j-1]==0){
-        nr++;
-        for(k=j;(k<=deg&&ptf2[k-1]!=0);k=ptf2[k-1]) ptseen[k-1]=2;
-        ptseen[k-1]=2;  //JDM really required?
-      }
-    }
-    
-    //find cycles 
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptseen[j]==1){
-        nr++;
-        ptseen[j]=0;
-        for(k=ptf2[j];k!=j+1;k=ptf2[k-1]) ptseen[k-1]=0;
-      }
-    }
-  } else {
-    deg=DEG_PPERM4(f);
-    ptf4=ADDR_PPERM4(f);
-    dom=DOM_PPERM(f);
+    rank = RANK_PPERM(f);
+    img = IMG_PPERM(f);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
 
-    //find chains
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i));
-      if(ptseen[j-1]==0){
-        nr++;
-        for(k=j;(k<=deg&&ptf4[k-1]!=0);k=ptf4[k-1]) ptseen[k-1]=2;
-        ptseen[k-1]=2;  //REALLY REQUIRED?? JDM
-      }
+    // find img(f)
+    for (i = 1; i <= rank; i++)
+        ptseen[INT_INTOBJ(ELM_PLIST(img, i)) - 1] = 1;
+
+    nr = 0;
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        deg = DEG_PPERM2(f);
+        ptf2 = ADDR_PPERM2(f);
+        dom = DOM_PPERM(f);
+
+        // find chains
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i));
+            if (ptseen[j - 1] == 0) {
+                nr++;
+                for (k = j; (k <= deg && ptf2[k - 1] != 0); k = ptf2[k - 1])
+                    ptseen[k - 1] = 2;
+                ptseen[k - 1] = 2;    // JDM really required?
+            }
+        }
+
+        // find cycles
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptseen[j] == 1) {
+                nr++;
+                ptseen[j] = 0;
+                for (k = ptf2[j]; k != j + 1; k = ptf2[k - 1])
+                    ptseen[k - 1] = 0;
+            }
+        }
     }
-    
-    //find cycles 
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptseen[j]==1){
-        nr++;
-        ptseen[j]=0;//REALLY REQUIRED??? JDM
-        for(k=ptf4[j];k!=j+1;k=ptf4[k-1]) ptseen[k-1]=0;
-      }
+    else {
+        deg = DEG_PPERM4(f);
+        ptf4 = ADDR_PPERM4(f);
+        dom = DOM_PPERM(f);
+
+        // find chains
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i));
+            if (ptseen[j - 1] == 0) {
+                nr++;
+                for (k = j; (k <= deg && ptf4[k - 1] != 0); k = ptf4[k - 1])
+                    ptseen[k - 1] = 2;
+                ptseen[k - 1] = 2;    // REALLY REQUIRED?? JDM
+            }
+        }
+
+        // find cycles
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptseen[j] == 1) {
+                nr++;
+                ptseen[j] = 0;    // REALLY REQUIRED??? JDM
+                for (k = ptf4[j]; k != j + 1; k = ptf4[k - 1])
+                    ptseen[k - 1] = 0;
+            }
+        }
     }
-  }
-  return INTOBJ_INT(nr);
+    return INTOBJ_INT(nr);
 }
 
 /* the components of a partial perm (as a functional digraph) */
-Obj FuncCOMPONENTS_PPERM(Obj self, Obj f){
-  UInt    i, j, n, rank, k, deg, nr, len; 
-  UInt4   *ptseen;
-  Obj     dom, img, out;
+Obj FuncCOMPONENTS_PPERM(Obj self, Obj f)
+{
+    UInt    i, j, n, rank, k, deg, nr, len;
+    UInt4 * ptseen;
+    Obj     dom, img, out;
 
-  n=MAX(DEG_PPERM(f), CODEG_PPERM(f));
+    n = MAX(DEG_PPERM(f), CODEG_PPERM(f));
 
-  if (n == 0) {
-    out = NEW_PLIST(T_PLIST_EMPTY, 0);
-    SET_LEN_PLIST(out, 0);
+    if (n == 0) {
+        out = NEW_PLIST(T_PLIST_EMPTY, 0);
+        SET_LEN_PLIST(out, 0);
+        return out;
+    }
+
+    // init the buffer
+    ResizeTmpPPerm(n);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+    for (i = 0; i < n; i++)
+        ptseen[i] = 0;
+
+    // find img(f)
+    rank = RANK_PPERM(f);
+    img = IMG_PPERM(f);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+    for (i = 1; i <= rank; i++)
+        ptseen[INT_INTOBJ(ELM_PLIST(img, i)) - 1] = 1;
+
+    nr = 0;
+    out = NEW_PLIST(T_PLIST_CYC, rank);
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        deg = DEG_PPERM2(f);
+        dom = DOM_PPERM(f);
+
+        // find chains
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i));
+            if (((UInt4 *)(ADDR_OBJ(TmpPPerm)))[j - 1] == 0) {
+                SET_ELM_PLIST(out, ++nr, NEW_PLIST(T_PLIST_CYC, 30));
+                CHANGED_BAG(out);
+                len = 0;
+                k = j;
+                do {
+                    AssPlist(ELM_PLIST(out, nr), ++len, INTOBJ_INT(k));
+                    ((UInt4 *)(ADDR_OBJ(TmpPPerm)))[k - 1] = 2;
+                    k = IMAGEPP(k, ADDR_PPERM2(f), deg);
+                } while (k != 0);
+                SHRINK_PLIST(ELM_PLIST(out, nr), len);
+                SET_LEN_PLIST(ELM_PLIST(out, nr), (Int)len);
+                CHANGED_BAG(out);
+            }
+        }
+
+        // find cycles
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i));
+            if (((UInt4 *)(ADDR_OBJ(TmpPPerm)))[j - 1] == 1) {
+                SET_ELM_PLIST(out, ++nr, NEW_PLIST(T_PLIST_CYC, 30));
+                CHANGED_BAG(out);
+                len = 0;
+                k = j;
+                do {
+                    AssPlist(ELM_PLIST(out, nr), ++len, INTOBJ_INT(k));
+                    ((UInt4 *)(ADDR_OBJ(TmpPPerm)))[k - 1] = 0;
+                    k = ADDR_PPERM2(f)[k - 1];
+                } while (k != j);
+                SHRINK_PLIST(ELM_PLIST(out, nr), len);
+                SET_LEN_PLIST(ELM_PLIST(out, nr), (Int)len);
+                CHANGED_BAG(out);
+            }
+        }
+    }
+    else {
+        deg = DEG_PPERM4(f);
+        dom = DOM_PPERM(f);
+
+        // find chains
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i));
+            if (((UInt4 *)(ADDR_OBJ(TmpPPerm)))[j - 1] == 0) {
+                SET_ELM_PLIST(out, ++nr, NEW_PLIST(T_PLIST_CYC, 30));
+                CHANGED_BAG(out);
+                len = 0;
+                k = j;
+                do {
+                    AssPlist(ELM_PLIST(out, nr), ++len, INTOBJ_INT(k));
+                    ((UInt4 *)(ADDR_OBJ(TmpPPerm)))[k - 1] = 2;
+                    k = IMAGEPP(k, ADDR_PPERM4(f), deg);
+                } while (k != 0);
+                SHRINK_PLIST(ELM_PLIST(out, nr), len);
+                SET_LEN_PLIST(ELM_PLIST(out, nr), (Int)len);
+                CHANGED_BAG(out);
+            }
+        }
+
+        // find cycles
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i));
+            if (((UInt4 *)(ADDR_OBJ(TmpPPerm)))[j - 1] == 1) {
+                SET_ELM_PLIST(out, ++nr, NEW_PLIST(T_PLIST_CYC, 30));
+                CHANGED_BAG(out);
+                len = 0;
+                k = j;
+                do {
+                    AssPlist(ELM_PLIST(out, nr), ++len, INTOBJ_INT(k));
+                    ((UInt4 *)(ADDR_OBJ(TmpPPerm)))[k - 1] = 0;
+                    k = ADDR_PPERM4(f)[k - 1];
+                } while (k != j);
+                SHRINK_PLIST(ELM_PLIST(out, nr), len);
+                SET_LEN_PLIST(ELM_PLIST(out, nr), (Int)len);
+                CHANGED_BAG(out);
+            }
+        }
+    }
+
+    SHRINK_PLIST(out, (Int)nr);
+    SET_LEN_PLIST(out, (Int)nr);
     return out;
-  }
-
-  // init the buffer
-  ResizeTmpPPerm(n);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  for(i=0;i<n;i++) ptseen[i]=0; 
- 
-  //find img(f)
-  rank=RANK_PPERM(f);   img=IMG_PPERM(f);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  for(i=1;i<=rank;i++) ptseen[INT_INTOBJ(ELM_PLIST(img, i))-1]=1;
-  
-  nr=0;
-  out=NEW_PLIST(T_PLIST_CYC, rank);
-  
-  if(TNUM_OBJ(f)==T_PPERM2){  
-    deg=DEG_PPERM2(f);
-    dom=DOM_PPERM(f);
-    
-    //find chains
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i));
-      if(((UInt4*)(ADDR_OBJ(TmpPPerm)))[j-1]==0){
-        SET_ELM_PLIST(out, ++nr, NEW_PLIST(T_PLIST_CYC, 30));
-        CHANGED_BAG(out);
-        len=0; k=j;
-        do{
-          AssPlist(ELM_PLIST(out, nr), ++len, INTOBJ_INT(k));
-          ((UInt4*)(ADDR_OBJ(TmpPPerm)))[k-1]=2;
-          k=IMAGEPP(k, ADDR_PPERM2(f), deg);
-        }while(k!=0);
-        SHRINK_PLIST(ELM_PLIST(out, nr), len);
-        SET_LEN_PLIST(ELM_PLIST(out, nr), (Int) len);
-        CHANGED_BAG(out);
-      }
-    }
-    
-    //find cycles 
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i));
-      if(((UInt4*)(ADDR_OBJ(TmpPPerm)))[j-1]==1){
-        SET_ELM_PLIST(out, ++nr, NEW_PLIST(T_PLIST_CYC, 30));
-        CHANGED_BAG(out);
-        len=0; k=j;
-        do{
-          AssPlist(ELM_PLIST(out, nr), ++len, INTOBJ_INT(k));
-          ((UInt4*)(ADDR_OBJ(TmpPPerm)))[k-1]=0; 
-          k=ADDR_PPERM2(f)[k-1];
-        }while(k!=j);
-        SHRINK_PLIST(ELM_PLIST(out, nr), len);
-        SET_LEN_PLIST(ELM_PLIST(out, nr), (Int) len);
-        CHANGED_BAG(out);
-      }
-    }
-  } else {
-    deg=DEG_PPERM4(f);
-    dom=DOM_PPERM(f);
-
-    //find chains
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i));
-      if(((UInt4*)(ADDR_OBJ(TmpPPerm)))[j-1]==0){
-        SET_ELM_PLIST(out, ++nr, NEW_PLIST(T_PLIST_CYC, 30));
-        CHANGED_BAG(out);
-        len=0; k=j;
-        do{
-          AssPlist(ELM_PLIST(out, nr), ++len, INTOBJ_INT(k));
-          ((UInt4*)(ADDR_OBJ(TmpPPerm)))[k-1]=2;
-          k=IMAGEPP(k, ADDR_PPERM4(f), deg);
-        }while(k!=0);
-        SHRINK_PLIST(ELM_PLIST(out, nr), len);
-        SET_LEN_PLIST(ELM_PLIST(out, nr), (Int) len);
-        CHANGED_BAG(out);
-      }
-    }
-    
-    //find cycles 
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i));
-      if(((UInt4*)(ADDR_OBJ(TmpPPerm)))[j-1]==1){
-        SET_ELM_PLIST(out, ++nr, NEW_PLIST(T_PLIST_CYC, 30));
-        CHANGED_BAG(out);
-        len=0; k=j;
-        do{
-          AssPlist(ELM_PLIST(out, nr), ++len, INTOBJ_INT(k));
-          ((UInt4*)(ADDR_OBJ(TmpPPerm)))[k-1]=0; 
-          k=ADDR_PPERM4(f)[k-1];
-        }while(k!=j);
-        SHRINK_PLIST(ELM_PLIST(out, nr), len);
-        SET_LEN_PLIST(ELM_PLIST(out, nr), (Int) len);
-        CHANGED_BAG(out);
-      }
-    }
-  }
-  
-  SHRINK_PLIST(out, (Int) nr);
-  SET_LEN_PLIST(out, (Int) nr);
-  return out;
 }
 
-// the points that can be obtained from <pt> by successively applying <f>. 
-Obj FuncCOMPONENT_PPERM_INT(Obj self, Obj f, Obj pt){
-  UInt    i, j, deg, len; 
-  Obj     out;
+// the points that can be obtained from <pt> by successively applying <f>.
+Obj FuncCOMPONENT_PPERM_INT(Obj self, Obj f, Obj pt)
+{
+    UInt i, j, deg, len;
+    Obj  out;
 
-  i=INT_INTOBJ(pt);
-  
-  if(TNUM_OBJ(f)==T_PPERM2){
-    deg=DEG_PPERM2(f);
-    
-    if(i>deg||(ADDR_PPERM2(f))[i-1]==0){
-      out=NEW_PLIST(T_PLIST_EMPTY, 0);
-      SET_LEN_PLIST(out, 0);
-      return out;
+    i = INT_INTOBJ(pt);
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        deg = DEG_PPERM2(f);
+
+        if (i > deg || (ADDR_PPERM2(f))[i - 1] == 0) {
+            out = NEW_PLIST(T_PLIST_EMPTY, 0);
+            SET_LEN_PLIST(out, 0);
+            return out;
+        }
+
+        out = NEW_PLIST(T_PLIST_CYC, 30);
+        len = 0;
+        j = i;
+
+        do {
+            AssPlist(out, ++len, INTOBJ_INT(j));
+            j = IMAGEPP(j, ADDR_PPERM2(f), deg);
+        } while (j != 0 && j != i);
     }
-    
-    out=NEW_PLIST(T_PLIST_CYC, 30);
-    len=0; j=i;
+    else {
+        deg = DEG_PPERM4(f);
 
-    do{ AssPlist(out, ++len, INTOBJ_INT(j)); j=IMAGEPP(j, ADDR_PPERM2(f), deg);
-    }while(j!=0&&j!=i);
-  } else {
-    deg=DEG_PPERM4(f);
-    
-    if(i>deg||(ADDR_PPERM4(f))[i-1]==0){
-      out=NEW_PLIST(T_PLIST_EMPTY, 0);
-      SET_LEN_PLIST(out, 0);
-      return out;
+        if (i > deg || (ADDR_PPERM4(f))[i - 1] == 0) {
+            out = NEW_PLIST(T_PLIST_EMPTY, 0);
+            SET_LEN_PLIST(out, 0);
+            return out;
+        }
+
+        out = NEW_PLIST(T_PLIST_CYC, 30);
+        len = 0;
+        j = i;
+
+        do {
+            AssPlist(out, ++len, INTOBJ_INT(j));
+            j = IMAGEPP(j, ADDR_PPERM4(f), deg);
+        } while (j != 0 && j != i);
     }
-    
-    out=NEW_PLIST(T_PLIST_CYC, 30);
-    len=0; j=i;
-
-    do{ AssPlist(out, ++len, INTOBJ_INT(j)); j=IMAGEPP(j, ADDR_PPERM4(f), deg);
-    }while(j!=0&&j!=i);
-
-  }
-  SHRINK_PLIST(out, (Int) len);
-  SET_LEN_PLIST(out, (Int) len);
-  return out;
+    SHRINK_PLIST(out, (Int)len);
+    SET_LEN_PLIST(out, (Int)len);
+    return out;
 }
 
-//the fixed points of a partial perm
-Obj FuncFIXED_PTS_PPERM(Obj self, Obj f){
-  UInt    len, i, j, deg, rank;
-  Obj     out, dom;
-  UInt2   *ptf2;
-  UInt4   *ptf4;
-  
-  len=0;
-  if(TNUM_OBJ(f)==T_PPERM2){
-    deg=DEG_PPERM2(f);
-    if(DOM_PPERM(f)==NULL){
-      out=NEW_PLIST(T_PLIST_CYC_SSORT, deg);
-      ptf2=ADDR_PPERM2(f);
-      for(i=0;i<deg;i++){
-        if(ptf2[i]==i+1){ 
-          SET_ELM_PLIST(out, ++len, INTOBJ_INT(i+1));
+// the fixed points of a partial perm
+Obj FuncFIXED_PTS_PPERM(Obj self, Obj f)
+{
+    UInt    len, i, j, deg, rank;
+    Obj     out, dom;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+
+    len = 0;
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        deg = DEG_PPERM2(f);
+        if (DOM_PPERM(f) == NULL) {
+            out = NEW_PLIST(T_PLIST_CYC_SSORT, deg);
+            ptf2 = ADDR_PPERM2(f);
+            for (i = 0; i < deg; i++) {
+                if (ptf2[i] == i + 1) {
+                    SET_ELM_PLIST(out, ++len, INTOBJ_INT(i + 1));
+                }
+            }
         }
-      }
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM2(f);
-      out=NEW_PLIST(T_PLIST_CYC_SSORT, rank);
-      ptf2=ADDR_PPERM2(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i));
-        if(ptf2[j-1]==j){
-          SET_ELM_PLIST(out, ++len, INTOBJ_INT(j));
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM2(f);
+            out = NEW_PLIST(T_PLIST_CYC_SSORT, rank);
+            ptf2 = ADDR_PPERM2(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i));
+                if (ptf2[j - 1] == j) {
+                    SET_ELM_PLIST(out, ++len, INTOBJ_INT(j));
+                }
+            }
         }
-      }
     }
-  } else {
-    deg=DEG_PPERM4(f);
-    if(DOM_PPERM(f)==NULL){
-      out=NEW_PLIST(T_PLIST_CYC_SSORT, deg);
-      ptf4=ADDR_PPERM4(f);
-      for(i=0;i<deg;i++){
-        if(ptf4[i]==i+1){ 
-          SET_ELM_PLIST(out, ++len, INTOBJ_INT(i+1));
+    else {
+        deg = DEG_PPERM4(f);
+        if (DOM_PPERM(f) == NULL) {
+            out = NEW_PLIST(T_PLIST_CYC_SSORT, deg);
+            ptf4 = ADDR_PPERM4(f);
+            for (i = 0; i < deg; i++) {
+                if (ptf4[i] == i + 1) {
+                    SET_ELM_PLIST(out, ++len, INTOBJ_INT(i + 1));
+                }
+            }
         }
-      }
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f); 
-      out=NEW_PLIST(T_PLIST_CYC_SSORT, rank);
-      ptf4=ADDR_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i));
-        if(ptf4[j-1]==j){
-          SET_ELM_PLIST(out, ++len, INTOBJ_INT(j));
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            out = NEW_PLIST(T_PLIST_CYC_SSORT, rank);
+            ptf4 = ADDR_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i));
+                if (ptf4[j - 1] == j) {
+                    SET_ELM_PLIST(out, ++len, INTOBJ_INT(j));
+                }
+            }
         }
-      }
     }
-  }
-  if(len==0) RetypeBag(out, T_PLIST_EMPTY);
-  
-  SHRINK_PLIST(out, len);
-  SET_LEN_PLIST(out, (Int) len);
-  
-  return out;
+    if (len == 0)
+        RetypeBag(out, T_PLIST_EMPTY);
+
+    SHRINK_PLIST(out, len);
+    SET_LEN_PLIST(out, (Int)len);
+
+    return out;
 }
 
-Obj FuncNR_FIXED_PTS_PPERM(Obj self, Obj f){
-  UInt    nr, i, j, deg, rank;
-  Obj     dom;
-  UInt2   *ptf2;
-  UInt4   *ptf4;
-  
-  nr=0;
-  if(TNUM_OBJ(f)==T_PPERM2){
-    deg=DEG_PPERM2(f);
-    ptf2=ADDR_PPERM2(f);
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<deg;i++) if(ptf2[i]==i+1) nr++;
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM2(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf2[j]==j+1) nr++;
-      }
+Obj FuncNR_FIXED_PTS_PPERM(Obj self, Obj f)
+{
+    UInt    nr, i, j, deg, rank;
+    Obj     dom;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+
+    nr = 0;
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        deg = DEG_PPERM2(f);
+        ptf2 = ADDR_PPERM2(f);
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < deg; i++)
+                if (ptf2[i] == i + 1)
+                    nr++;
+        }
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM2(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptf2[j] == j + 1)
+                    nr++;
+            }
+        }
     }
-  } else {
-    deg=DEG_PPERM4(f);
-    ptf4=ADDR_PPERM4(f);
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<deg;i++) if(ptf4[i]==i+1) nr++;
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf4[j]==j+1) nr++;
-      }
+    else {
+        deg = DEG_PPERM4(f);
+        ptf4 = ADDR_PPERM4(f);
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < deg; i++)
+                if (ptf4[i] == i + 1)
+                    nr++;
+        }
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptf4[j] == j + 1)
+                    nr++;
+            }
+        }
     }
-  }
-  return INTOBJ_INT(nr);
+    return INTOBJ_INT(nr);
 }
 
-//the moved points of a partial perm
-Obj FuncMOVED_PTS_PPERM(Obj self, Obj f){
-  UInt    len, i, j, deg, rank;
-  Obj     out, dom;
-  UInt2   *ptf2;
-  UInt4   *ptf4;
-  
-  len=0;
-  if(TNUM_OBJ(f)==T_PPERM2){
-    deg=DEG_PPERM2(f);
-    if(DOM_PPERM(f)==NULL){
-      out=NEW_PLIST(T_PLIST_CYC_SSORT, deg);
-      ptf2=ADDR_PPERM2(f);
-      for(i=0;i<deg;i++){
-        if(ptf2[i]!=0&&ptf2[i]!=i+1){ 
-          SET_ELM_PLIST(out, ++len, INTOBJ_INT(i+1));
+// the moved points of a partial perm
+Obj FuncMOVED_PTS_PPERM(Obj self, Obj f)
+{
+    UInt    len, i, j, deg, rank;
+    Obj     out, dom;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+
+    len = 0;
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        deg = DEG_PPERM2(f);
+        if (DOM_PPERM(f) == NULL) {
+            out = NEW_PLIST(T_PLIST_CYC_SSORT, deg);
+            ptf2 = ADDR_PPERM2(f);
+            for (i = 0; i < deg; i++) {
+                if (ptf2[i] != 0 && ptf2[i] != i + 1) {
+                    SET_ELM_PLIST(out, ++len, INTOBJ_INT(i + 1));
+                }
+            }
         }
-      }
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM2(f);
-      out=NEW_PLIST(T_PLIST_CYC_SSORT, rank);
-      ptf2=ADDR_PPERM2(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf2[j]!=j+1){
-          SET_ELM_PLIST(out, ++len, INTOBJ_INT(j+1));
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM2(f);
+            out = NEW_PLIST(T_PLIST_CYC_SSORT, rank);
+            ptf2 = ADDR_PPERM2(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptf2[j] != j + 1) {
+                    SET_ELM_PLIST(out, ++len, INTOBJ_INT(j + 1));
+                }
+            }
         }
-      }
     }
-  } else {
-    deg=DEG_PPERM4(f);
-    if(DOM_PPERM(f)==NULL){
-      out=NEW_PLIST(T_PLIST_CYC_SSORT, deg);
-      ptf4=ADDR_PPERM4(f);
-      for(i=0;i<deg;i++){
-        if(ptf4[i]!=0&&ptf4[i]!=i+1){ 
-          SET_ELM_PLIST(out, ++len, INTOBJ_INT(i+1));
+    else {
+        deg = DEG_PPERM4(f);
+        if (DOM_PPERM(f) == NULL) {
+            out = NEW_PLIST(T_PLIST_CYC_SSORT, deg);
+            ptf4 = ADDR_PPERM4(f);
+            for (i = 0; i < deg; i++) {
+                if (ptf4[i] != 0 && ptf4[i] != i + 1) {
+                    SET_ELM_PLIST(out, ++len, INTOBJ_INT(i + 1));
+                }
+            }
         }
-      }
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      out=NEW_PLIST(T_PLIST_CYC_SSORT, rank);
-      ptf4=ADDR_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf4[j]!=j+1){
-          SET_ELM_PLIST(out, ++len, INTOBJ_INT(j+1));
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            out = NEW_PLIST(T_PLIST_CYC_SSORT, rank);
+            ptf4 = ADDR_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptf4[j] != j + 1) {
+                    SET_ELM_PLIST(out, ++len, INTOBJ_INT(j + 1));
+                }
+            }
         }
-      }
     }
-  }
-  if(len==0) RetypeBag(out, T_PLIST_EMPTY);
-  SHRINK_PLIST(out, len);
-  SET_LEN_PLIST(out, (Int) len);
-  return out;
+    if (len == 0)
+        RetypeBag(out, T_PLIST_EMPTY);
+    SHRINK_PLIST(out, len);
+    SET_LEN_PLIST(out, (Int)len);
+    return out;
 }
 
-Obj FuncNR_MOVED_PTS_PPERM(Obj self, Obj f){
-  UInt    nr, i, j, deg, rank;
-  Obj     dom;
-  UInt2   *ptf2;
-  UInt4   *ptf4;
-  
-  nr=0;
-  if(TNUM_OBJ(f)==T_PPERM2){
-    deg=DEG_PPERM2(f);
-    ptf2=ADDR_PPERM2(f);
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<deg;i++) if(ptf2[i]!=0&&ptf2[i]!=i+1) nr++;
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM2(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf2[j]!=j+1) nr++;
-      }
+Obj FuncNR_MOVED_PTS_PPERM(Obj self, Obj f)
+{
+    UInt    nr, i, j, deg, rank;
+    Obj     dom;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+
+    nr = 0;
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        deg = DEG_PPERM2(f);
+        ptf2 = ADDR_PPERM2(f);
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < deg; i++)
+                if (ptf2[i] != 0 && ptf2[i] != i + 1)
+                    nr++;
+        }
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM2(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptf2[j] != j + 1)
+                    nr++;
+            }
+        }
     }
-  } else {
-    deg=DEG_PPERM4(f);
-    ptf4=ADDR_PPERM4(f);
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<deg;i++) if(ptf4[i]!=0&&ptf4[i]!=i+1) nr++;
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf4[j]!=j+1) nr++;
-      }
+    else {
+        deg = DEG_PPERM4(f);
+        ptf4 = ADDR_PPERM4(f);
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < deg; i++)
+                if (ptf4[i] != 0 && ptf4[i] != i + 1)
+                    nr++;
+        }
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptf4[j] != j + 1)
+                    nr++;
+            }
+        }
     }
-  }
-  return INTOBJ_INT(nr);
+    return INTOBJ_INT(nr);
 }
 
-Obj FuncLARGEST_MOVED_PT_PPERM(Obj self, Obj f){
-  UInt    i, j, deg;
-  Obj     dom;
-  UInt2   *ptf2;
-  UInt4   *ptf4;
-  
-  if(TNUM_OBJ(f)==T_PPERM2){
-    deg=DEG_PPERM2(f);
-    ptf2=ADDR_PPERM2(f);
-    if(DOM_PPERM(f)==NULL){
-      for(i=deg;i>0;i--){
-        if(ptf2[i-1]!=0&&ptf2[i-1]!=i) return INTOBJ_INT(i);
-      }
-    } else {
-      dom=DOM_PPERM(f);
-      for(i=RANK_PPERM2(f);i>=1;i--){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf2[j]!=j+1) return INTOBJ_INT(j+1);
-      }
+Obj FuncLARGEST_MOVED_PT_PPERM(Obj self, Obj f)
+{
+    UInt    i, j, deg;
+    Obj     dom;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        deg = DEG_PPERM2(f);
+        ptf2 = ADDR_PPERM2(f);
+        if (DOM_PPERM(f) == NULL) {
+            for (i = deg; i > 0; i--) {
+                if (ptf2[i - 1] != 0 && ptf2[i - 1] != i)
+                    return INTOBJ_INT(i);
+            }
+        }
+        else {
+            dom = DOM_PPERM(f);
+            for (i = RANK_PPERM2(f); i >= 1; i--) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptf2[j] != j + 1)
+                    return INTOBJ_INT(j + 1);
+            }
+        }
     }
-  } else {
-    deg=DEG_PPERM4(f);
-    ptf4=ADDR_PPERM4(f);
-    if(DOM_PPERM(f)==NULL){
-      for(i=deg;i>0;i--){
-        if(ptf4[i-1]!=0&&ptf4[i-1]!=i) return INTOBJ_INT(i);
-      }
-    } else {
-      dom=DOM_PPERM(f);
-      for(i=RANK_PPERM4(f);i>=1;i--){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf4[j]!=j+1) return INTOBJ_INT(j+1);
-      }
+    else {
+        deg = DEG_PPERM4(f);
+        ptf4 = ADDR_PPERM4(f);
+        if (DOM_PPERM(f) == NULL) {
+            for (i = deg; i > 0; i--) {
+                if (ptf4[i - 1] != 0 && ptf4[i - 1] != i)
+                    return INTOBJ_INT(i);
+            }
+        }
+        else {
+            dom = DOM_PPERM(f);
+            for (i = RANK_PPERM4(f); i >= 1; i--) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptf4[j] != j + 1)
+                    return INTOBJ_INT(j + 1);
+            }
+        }
     }
-  }
-  return INTOBJ_INT(0);
+    return INTOBJ_INT(0);
 }
 
-Obj FuncSMALLEST_MOVED_PT_PPERM(Obj self, Obj f){
-  UInt    i, j, deg, rank;
-  Obj     dom;
-  UInt2   *ptf2;
-  UInt4   *ptf4;
-  
-  if(TNUM_OBJ(f)==T_PPERM2){
-    deg=DEG_PPERM2(f);
-    ptf2=ADDR_PPERM2(f);
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<deg;i++){
-        if(ptf2[i]!=0&&ptf2[i]!=i+1) return INTOBJ_INT(i+1);
-      }
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM2(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf2[j]!=j+1) return INTOBJ_INT(j+1);
-      }
+Obj FuncSMALLEST_MOVED_PT_PPERM(Obj self, Obj f)
+{
+    UInt    i, j, deg, rank;
+    Obj     dom;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        deg = DEG_PPERM2(f);
+        ptf2 = ADDR_PPERM2(f);
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < deg; i++) {
+                if (ptf2[i] != 0 && ptf2[i] != i + 1)
+                    return INTOBJ_INT(i + 1);
+            }
+        }
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM2(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptf2[j] != j + 1)
+                    return INTOBJ_INT(j + 1);
+            }
+        }
     }
-  } else {
-    deg=DEG_PPERM4(f);
-    ptf4=ADDR_PPERM4(f);
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<deg;i++){
-        if(ptf4[i]!=0&&ptf4[i]!=i+1) return INTOBJ_INT(i+1);
-      }
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf4[j]!=j+1) return INTOBJ_INT(j+1);
-      }
+    else {
+        deg = DEG_PPERM4(f);
+        ptf4 = ADDR_PPERM4(f);
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < deg; i++) {
+                if (ptf4[i] != 0 && ptf4[i] != i + 1)
+                    return INTOBJ_INT(i + 1);
+            }
+        }
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptf4[j] != j + 1)
+                    return INTOBJ_INT(j + 1);
+            }
+        }
     }
-  }
-  return Fail;
+    return Fail;
 }
 
 // convert a T_PPERM4 with codeg<65536 to a T_PPERM2
-Obj FuncTRIM_PPERM (Obj self, Obj f){
-  UInt    deg, i;
-  UInt4   *ptf;
+Obj FuncTRIM_PPERM(Obj self, Obj f)
+{
+    UInt    deg, i;
+    UInt4 * ptf;
 
-  if(TNUM_OBJ(f)!=T_PPERM4||CODEG_PPERM4(f)>65535) return f;
+    if (TNUM_OBJ(f) != T_PPERM4 || CODEG_PPERM4(f) > 65535)
+        return f;
 
-  ptf=ADDR_PPERM4(f)-1;
-  deg=DEG_PPERM4(f);
-  for(i=0;i<deg+1;i++) ((UInt2*)ptf)[i]=(UInt2)ptf[i]; 
+    ptf = ADDR_PPERM4(f) - 1;
+    deg = DEG_PPERM4(f);
+    for (i = 0; i < deg + 1; i++)
+        ((UInt2 *)ptf)[i] = (UInt2)ptf[i];
 
-  RetypeBag(f, T_PPERM2);
-  ResizeBag(f, (deg+1)*sizeof(UInt2)+2*sizeof(Obj));
-  return (Obj)0;
+    RetypeBag(f, T_PPERM2);
+    ResizeBag(f, (deg + 1) * sizeof(UInt2) + 2 * sizeof(Obj));
+    return (Obj)0;
 }
 
-Obj FuncHASH_FUNC_FOR_PPERM(Obj self, Obj f, Obj data){
-  UInt codeg;
+Obj FuncHASH_FUNC_FOR_PPERM(Obj self, Obj f, Obj data)
+{
+    UInt codeg;
 
-  if(TNUM_OBJ(f)==T_PPERM4){
-    codeg=CODEG_PPERM4(f);
-    if(codeg<65536){
-      FuncTRIM_PPERM(self, f);
-    } else {
-      return INTOBJ_INT((HASHKEY_BAG_NC(f, (UInt4) 255, 
-              2*sizeof(Obj)+sizeof(UInt4), (int) 4*DEG_PPERM4(f))
-              % (INT_INTOBJ(data)))+1); 
+    if (TNUM_OBJ(f) == T_PPERM4) {
+        codeg = CODEG_PPERM4(f);
+        if (codeg < 65536) {
+            FuncTRIM_PPERM(self, f);
+        }
+        else {
+            return INTOBJ_INT((HASHKEY_BAG_NC(f, (UInt4)255,
+                                              2 * sizeof(Obj) + sizeof(UInt4),
+                                              (int)4 * DEG_PPERM4(f)) %
+                               (INT_INTOBJ(data))) +
+                              1);
+        }
     }
-  }
-  return INTOBJ_INT((HASHKEY_BAG_NC(f, (UInt4) 255, 
-              2*sizeof(Obj)+sizeof(UInt2), (int) 2*DEG_PPERM2(f))
-              % (INT_INTOBJ(data)))+1); 
+    return INTOBJ_INT(
+        (HASHKEY_BAG_NC(f, (UInt4)255, 2 * sizeof(Obj) + sizeof(UInt2),
+                        (int)2 * DEG_PPERM2(f)) %
+         (INT_INTOBJ(data))) +
+        1);
 }
 
 // test if a partial perm is an idempotent
-Obj FuncIS_IDEM_PPERM(Obj self, Obj f){
-  UInt2*  ptf2;
-  UInt4*  ptf4;
-  UInt    deg, i, j, rank;
-  Obj     dom;
-  
-  if(TNUM_OBJ(f)==T_PPERM2){
-    ptf2=ADDR_PPERM2(f);
-    if(DOM_PPERM(f)==NULL){
-      deg=DEG_PPERM2(f);
-      for(i=0;i<deg;i++){
-        if(ptf2[i]!=0&&ptf2[i]!=i+1) return False;
-      }
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM2(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf2[j]!=0&&ptf2[j]!=j+1) return False;
-      }
+Obj FuncIS_IDEM_PPERM(Obj self, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    deg, i, j, rank;
+    Obj     dom;
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        ptf2 = ADDR_PPERM2(f);
+        if (DOM_PPERM(f) == NULL) {
+            deg = DEG_PPERM2(f);
+            for (i = 0; i < deg; i++) {
+                if (ptf2[i] != 0 && ptf2[i] != i + 1)
+                    return False;
+            }
+        }
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM2(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptf2[j] != 0 && ptf2[j] != j + 1)
+                    return False;
+            }
+        }
     }
-  } else {
-    ptf4=ADDR_PPERM4(f);
-    if(DOM_PPERM(f)==NULL){
-      deg=DEG_PPERM4(f);
-      for(i=0;i<deg;i++){
-        if(ptf4[i]!=0&&ptf4[i]!=i+1) return False;
-      }
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf4[j]!=0&&ptf4[j]!=j+1) return False;
-      }
+    else {
+        ptf4 = ADDR_PPERM4(f);
+        if (DOM_PPERM(f) == NULL) {
+            deg = DEG_PPERM4(f);
+            for (i = 0; i < deg; i++) {
+                if (ptf4[i] != 0 && ptf4[i] != i + 1)
+                    return False;
+            }
+        }
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptf4[j] != 0 && ptf4[j] != j + 1)
+                    return False;
+            }
+        }
     }
-  }
-  return True;
+    return True;
 }
 
 /* an idempotent partial perm <e> with ker(e)=ker(f) */
-Obj FuncLEFT_ONE_PPERM( Obj self, Obj f){
-  Obj     dom, g;
-  UInt    deg, i, j, rank;
-  UInt2   *ptg2;
-  UInt4   *ptg4;
+Obj FuncLEFT_ONE_PPERM(Obj self, Obj f)
+{
+    Obj     dom, g;
+    UInt    deg, i, j, rank;
+    UInt2 * ptg2;
+    UInt4 * ptg4;
 
-  if(TNUM_OBJ(f)==T_PPERM2){
-    rank=RANK_PPERM2(f);
-    dom=DOM_PPERM(f);
-    deg=DEG_PPERM2(f);
-  } else {
-    rank=RANK_PPERM4(f);
-    dom=DOM_PPERM(f);
-    deg=DEG_PPERM4(f);
-  }
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        rank = RANK_PPERM2(f);
+        dom = DOM_PPERM(f);
+        deg = DEG_PPERM2(f);
+    }
+    else {
+        rank = RANK_PPERM4(f);
+        dom = DOM_PPERM(f);
+        deg = DEG_PPERM4(f);
+    }
 
-  if(deg<65536){
-    g=NEW_PPERM2(deg);
-    ptg2=ADDR_PPERM2(g);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptg2[j]=j+1;
+    if (deg < 65536) {
+        g = NEW_PPERM2(deg);
+        ptg2 = ADDR_PPERM2(g);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptg2[j] = j + 1;
+        }
+        CODEG_PPERM2(g) = deg;
+        DOM_PPERM(g) = dom;
+        IMG_PPERM(g) = dom;
     }
-    CODEG_PPERM2(g)=deg;
-    DOM_PPERM(g)=dom;
-    IMG_PPERM(g)=dom;
-  } else {
-    g=NEW_PPERM4(deg);
-    ptg4=ADDR_PPERM4(g);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptg4[j]=j+1;
+    else {
+        g = NEW_PPERM4(deg);
+        ptg4 = ADDR_PPERM4(g);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptg4[j] = j + 1;
+        }
+        CODEG_PPERM4(g) = deg;
+        DOM_PPERM(g) = dom;
+        IMG_PPERM(g) = dom;
     }
-    CODEG_PPERM4(g)=deg;
-    DOM_PPERM(g)=dom;
-    IMG_PPERM(g)=dom;
-  }
-  CHANGED_BAG(g);
-  return g;
+    CHANGED_BAG(g);
+    return g;
 }
 
-// an idempotent partial perm <e> with im(e)=im(f) 
-Obj FuncRIGHT_ONE_PPERM( Obj self, Obj f){
-  Obj     g, img;
-  UInt    i, j, codeg, rank;
-  UInt2   *ptg2;
-  UInt4   *ptg4;
+// an idempotent partial perm <e> with im(e)=im(f)
+Obj FuncRIGHT_ONE_PPERM(Obj self, Obj f)
+{
+    Obj     g, img;
+    UInt    i, j, codeg, rank;
+    UInt2 * ptg2;
+    UInt4 * ptg4;
 
-  if(TNUM_OBJ(f)==T_PPERM2){
-    codeg=CODEG_PPERM2(f);
-    rank=RANK_PPERM2(f);
-    img=IMG_PPERM(f);
-  }else{
-    codeg=CODEG_PPERM4(f);
-    rank=RANK_PPERM4(f);
-    img=IMG_PPERM(f);
-  }
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        codeg = CODEG_PPERM2(f);
+        rank = RANK_PPERM2(f);
+        img = IMG_PPERM(f);
+    }
+    else {
+        codeg = CODEG_PPERM4(f);
+        rank = RANK_PPERM4(f);
+        img = IMG_PPERM(f);
+    }
 
-  if(codeg<65536){ 
-    g=NEW_PPERM2(codeg);
-    ptg2=ADDR_PPERM2(g);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(img, i))-1;
-      ptg2[j]=j+1;
+    if (codeg < 65536) {
+        g = NEW_PPERM2(codeg);
+        ptg2 = ADDR_PPERM2(g);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(img, i)) - 1;
+            ptg2[j] = j + 1;
+        }
+        if (IS_SSORT_LIST(img)) {
+            DOM_PPERM(g) = img;
+            IMG_PPERM(g) = img;
+        }
+        CODEG_PPERM2(g) = codeg;
     }
-    if(IS_SSORT_LIST(img)){
-      DOM_PPERM(g)=img;
-      IMG_PPERM(g)=img;
+    else {
+        g = NEW_PPERM4(codeg);
+        ptg4 = ADDR_PPERM4(g);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(img, i)) - 1;
+            ptg4[j] = j + 1;
+        }
+        if (IS_SSORT_LIST(img)) {
+            DOM_PPERM(g) = img;
+            IMG_PPERM(g) = img;
+        }
+        CODEG_PPERM4(g) = codeg;
     }
-    CODEG_PPERM2(g)=codeg;
-  } else {
-    g=NEW_PPERM4(codeg);
-    ptg4=ADDR_PPERM4(g);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(img, i))-1;
-      ptg4[j]=j+1;
-    }
-    if(IS_SSORT_LIST(img)){
-      DOM_PPERM(g)=img;
-      IMG_PPERM(g)=img;
-    }
-    CODEG_PPERM4(g)=codeg;
-  }
-  CHANGED_BAG(g);
-  return g;
+    CHANGED_BAG(g);
+    return g;
 }
 
 // f<=g if and only if f is a restriction of g
-Obj FuncNaturalLeqPartialPerm(Obj self, Obj f, Obj g){
-  UInt    def, deg, i, j, rank;
-  UInt2   *ptf2, *ptg2;
-  UInt4   *ptf4, *ptg4;
-  Obj     dom;
+Obj FuncNaturalLeqPartialPerm(Obj self, Obj f, Obj g)
+{
+    UInt   def, deg, i, j, rank;
+    UInt2 *ptf2, *ptg2;
+    UInt4 *ptf4, *ptg4;
+    Obj    dom;
 
-  if(TNUM_OBJ(f)==T_PPERM2){
-    def=DEG_PPERM2(f);
-    ptf2=ADDR_PPERM2(f);
-    if(def==0) return True;
-    
-    if(TNUM_OBJ(g)==T_PPERM2){
-      deg=DEG_PPERM2(g);
-      ptg2=ADDR_PPERM2(g);
-      if(DOM_PPERM(f)==NULL){
-        for(i=0;i<def;i++){
-          if(ptf2[i]!=0&&ptf2[i]!=IMAGEPP(i+1, ptg2, deg)) return False;
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        def = DEG_PPERM2(f);
+        ptf2 = ADDR_PPERM2(f);
+        if (def == 0)
+            return True;
+
+        if (TNUM_OBJ(g) == T_PPERM2) {
+            deg = DEG_PPERM2(g);
+            ptg2 = ADDR_PPERM2(g);
+            if (DOM_PPERM(f) == NULL) {
+                for (i = 0; i < def; i++) {
+                    if (ptf2[i] != 0 && ptf2[i] != IMAGEPP(i + 1, ptg2, deg))
+                        return False;
+                }
+            }
+            else {
+                dom = DOM_PPERM(f);
+                rank = RANK_PPERM2(f);
+                for (i = 1; i <= rank; i++) {
+                    j = INT_INTOBJ(ELM_PLIST(dom, i));
+                    if (ptf2[j - 1] != IMAGEPP(j, ptg2, deg))
+                        return False;
+                }
+            }
         }
-      } else {
-        dom=DOM_PPERM(f);
-        rank=RANK_PPERM2(f);
-        for(i=1;i<=rank;i++){
-          j=INT_INTOBJ(ELM_PLIST(dom, i));
-          if(ptf2[j-1]!=IMAGEPP(j, ptg2, deg)) return False;
+        else if (TNUM_OBJ(g) == T_PPERM4) {
+            deg = DEG_PPERM4(g);
+            ptg4 = ADDR_PPERM4(g);
+            if (DOM_PPERM(f) == NULL) {
+                for (i = 0; i < def; i++) {
+                    if (ptf2[i] != 0 && ptf2[i] != IMAGEPP(i + 1, ptg4, deg))
+                        return False;
+                }
+            }
+            else {
+                dom = DOM_PPERM(f);
+                rank = RANK_PPERM2(f);
+                for (i = 1; i <= rank; i++) {
+                    j = INT_INTOBJ(ELM_PLIST(dom, i));
+                    if (ptf2[j - 1] != IMAGEPP(j, ptg4, deg))
+                        return False;
+                }
+            }
         }
-      }
-    } else if(TNUM_OBJ(g)==T_PPERM4){
-      deg=DEG_PPERM4(g);
-      ptg4=ADDR_PPERM4(g);
-      if(DOM_PPERM(f)==NULL){
-        for(i=0;i<def;i++){
-          if(ptf2[i]!=0&&ptf2[i]!=IMAGEPP(i+1, ptg4, deg)) return False;
+        else {
+            ErrorQuit("usage: the arguments must be partial perms,", 0L, 0L);
         }
-      } else {
-        dom=DOM_PPERM(f);
-        rank=RANK_PPERM2(f);
-        for(i=1;i<=rank;i++){
-          j=INT_INTOBJ(ELM_PLIST(dom, i));
-          if(ptf2[j-1]!=IMAGEPP(j, ptg4, deg)) return False;
-        }
-      }
-    } else {
-      ErrorQuit("usage: the arguments must be partial perms,", 0L, 0L);
     }
-  }else if (TNUM_OBJ(f)==T_PPERM4){
-    def=DEG_PPERM4(f);
-    ptf4=ADDR_PPERM4(f);
-    if(def==0) return True;
-    
-    if(TNUM_OBJ(g)==T_PPERM2){
-      deg=DEG_PPERM2(g);
-      ptg2=ADDR_PPERM2(g);
-      if(DOM_PPERM(f)==NULL){
-        for(i=0;i<def;i++){
-          if(ptf4[i]!=0&&ptf4[i]!=IMAGEPP(i+1, ptg2, deg)) return False;
+    else if (TNUM_OBJ(f) == T_PPERM4) {
+        def = DEG_PPERM4(f);
+        ptf4 = ADDR_PPERM4(f);
+        if (def == 0)
+            return True;
+
+        if (TNUM_OBJ(g) == T_PPERM2) {
+            deg = DEG_PPERM2(g);
+            ptg2 = ADDR_PPERM2(g);
+            if (DOM_PPERM(f) == NULL) {
+                for (i = 0; i < def; i++) {
+                    if (ptf4[i] != 0 && ptf4[i] != IMAGEPP(i + 1, ptg2, deg))
+                        return False;
+                }
+            }
+            else {
+                dom = DOM_PPERM(f);
+                rank = RANK_PPERM4(f);
+                for (i = 1; i <= rank; i++) {
+                    j = INT_INTOBJ(ELM_PLIST(dom, i));
+                    if (ptf4[j - 1] != IMAGEPP(j, ptg2, deg))
+                        return False;
+                }
+            }
         }
-      } else {
-        dom=DOM_PPERM(f);
-        rank=RANK_PPERM4(f);
-        for(i=1;i<=rank;i++){
-          j=INT_INTOBJ(ELM_PLIST(dom, i));
-          if(ptf4[j-1]!=IMAGEPP(j, ptg2, deg)) return False;
+        else if (TNUM_OBJ(g) == T_PPERM4) {
+            deg = DEG_PPERM4(g);
+            ptg4 = ADDR_PPERM4(g);
+            if (DOM_PPERM(f) == NULL) {
+                for (i = 0; i < def; i++) {
+                    if (ptf4[i] != 0 && ptf4[i] != IMAGEPP(i + 1, ptg4, deg))
+                        return False;
+                }
+            }
+            else {
+                dom = DOM_PPERM(f);
+                rank = RANK_PPERM4(f);
+                for (i = 1; i <= rank; i++) {
+                    j = INT_INTOBJ(ELM_PLIST(dom, i));
+                    if (ptf4[j - 1] != IMAGEPP(j, ptg4, deg))
+                        return False;
+                }
+            }
         }
-      }
-    } else if(TNUM_OBJ(g)==T_PPERM4){
-      deg=DEG_PPERM4(g);
-      ptg4=ADDR_PPERM4(g);
-      if(DOM_PPERM(f)==NULL){
-        for(i=0;i<def;i++){
-          if(ptf4[i]!=0&&ptf4[i]!=IMAGEPP(i+1, ptg4, deg)) return False;
+        else {
+            ErrorQuit("usage: the arguments must be partial perms,", 0L, 0L);
         }
-      } else {
-        dom=DOM_PPERM(f);
-        rank=RANK_PPERM4(f);
-        for(i=1;i<=rank;i++){
-          j=INT_INTOBJ(ELM_PLIST(dom, i));
-          if(ptf4[j-1]!=IMAGEPP(j, ptg4, deg)) return False;
-        }
-      }
-    } else {
-      ErrorQuit("usage: the arguments must be partial perms,", 0L, 0L);
     }
-  } else {
-    ErrorQuit("usage: the arguments must be partial perms,", 0L, 0L);
-  }
-  return True;
+    else {
+        ErrorQuit("usage: the arguments must be partial perms,", 0L, 0L);
+    }
+    return True;
 }
 
 // could add use of rank to improve things here. JDM
-Obj FuncJOIN_IDEM_PPERMS(Obj self, Obj f, Obj g){
-  UInt  def, deg, dej, i; 
-  Obj   join;
-  UInt2 *ptjoin2, *ptf2, *ptg2;
-  UInt4 *ptjoin4, *ptf4, *ptg4;
-  
-  if(EQ(f,g)) return f;
-  
-  def=DEG_PPERM(f);
-  deg=DEG_PPERM(g);
-  dej=MAX(def, deg);
-  if(dej<65536){
-    join=NEW_PPERM2(dej);
-    CODEG_PPERM2(join)=dej;
-    ptjoin2=ADDR_PPERM2(join);
-    ptf2=ADDR_PPERM2(f);
-    ptg2=ADDR_PPERM2(g);
-    if(def<deg){
-      for(i=0;i<def;i++){
-        if(ptf2[i]!=0){ 
-          ptjoin2[i]=ptf2[i];
-        } else if(ptg2[i]!=0) {
-          ptjoin2[i]=ptg2[i];
+Obj FuncJOIN_IDEM_PPERMS(Obj self, Obj f, Obj g)
+{
+    UInt   def, deg, dej, i;
+    Obj    join;
+    UInt2 *ptjoin2, *ptf2, *ptg2;
+    UInt4 *ptjoin4, *ptf4, *ptg4;
+
+    if (EQ(f, g))
+        return f;
+
+    def = DEG_PPERM(f);
+    deg = DEG_PPERM(g);
+    dej = MAX(def, deg);
+    if (dej < 65536) {
+        join = NEW_PPERM2(dej);
+        CODEG_PPERM2(join) = dej;
+        ptjoin2 = ADDR_PPERM2(join);
+        ptf2 = ADDR_PPERM2(f);
+        ptg2 = ADDR_PPERM2(g);
+        if (def < deg) {
+            for (i = 0; i < def; i++) {
+                if (ptf2[i] != 0) {
+                    ptjoin2[i] = ptf2[i];
+                }
+                else if (ptg2[i] != 0) {
+                    ptjoin2[i] = ptg2[i];
+                }
+            }
+            for (; i < deg; i++) {
+                if (ptg2[i] != 0)
+                    ptjoin2[i] = ptg2[i];
+            }
         }
-      }
-      for(;i<deg;i++){ if(ptg2[i]!=0) ptjoin2[i]=ptg2[i]; }
-    } else {
-      for(i=0;i<deg;i++){
-        if(ptg2[i]!=0){ 
-          ptjoin2[i]=ptg2[i];
-        } else if(ptf2[i]!=0) {
-          ptjoin2[i]=ptf2[i];
+        else {
+            for (i = 0; i < deg; i++) {
+                if (ptg2[i] != 0) {
+                    ptjoin2[i] = ptg2[i];
+                }
+                else if (ptf2[i] != 0) {
+                    ptjoin2[i] = ptf2[i];
+                }
+            }
+            for (; i < def; i++) {
+                if (ptf2[i] != 0)
+                    ptjoin2[i] = ptf2[i];
+            }
         }
-      }
-      for(;i<def;i++){ if(ptf2[i]!=0) ptjoin2[i]=ptf2[i]; }
     }
-  } else if (def>=65536&&deg>=65536){ //3 more cases required
-    join=NEW_PPERM4(dej);
-    CODEG_PPERM4(join)=dej;
-    ptjoin4=ADDR_PPERM4(join);
-    ptf4=ADDR_PPERM4(f);
-    ptg4=ADDR_PPERM4(g);
-    if(def<deg){
-      for(i=0;i<def;i++){
-        if(ptf4[i]!=0){ 
-          ptjoin4[i]=ptf4[i];
-        } else if(ptg4[i]!=0) {
-          ptjoin4[i]=ptg4[i];
+    else if (def >= 65536 && deg >= 65536) {    // 3 more cases required
+        join = NEW_PPERM4(dej);
+        CODEG_PPERM4(join) = dej;
+        ptjoin4 = ADDR_PPERM4(join);
+        ptf4 = ADDR_PPERM4(f);
+        ptg4 = ADDR_PPERM4(g);
+        if (def < deg) {
+            for (i = 0; i < def; i++) {
+                if (ptf4[i] != 0) {
+                    ptjoin4[i] = ptf4[i];
+                }
+                else if (ptg4[i] != 0) {
+                    ptjoin4[i] = ptg4[i];
+                }
+            }
+            for (; i < deg; i++) {
+                if (ptg4[i] != 0)
+                    ptjoin4[i] = ptg4[i];
+            }
         }
-      }
-      for(;i<deg;i++){ if(ptg4[i]!=0) ptjoin4[i]=ptg4[i]; }
-    } else {
-      for(i=0;i<deg;i++){
-        if(ptg4[i]!=0){ 
-          ptjoin4[i]=ptg4[i];
-        } else if(ptf4[i]!=0) {
-          ptjoin4[i]=ptf4[i];
+        else {
+            for (i = 0; i < deg; i++) {
+                if (ptg4[i] != 0) {
+                    ptjoin4[i] = ptg4[i];
+                }
+                else if (ptf4[i] != 0) {
+                    ptjoin4[i] = ptf4[i];
+                }
+            }
+            for (; i < def; i++) {
+                if (ptf4[i] != 0)
+                    ptjoin4[i] = ptf4[i];
+            }
         }
-      }
-      for(;i<def;i++){ if(ptf4[i]!=0) ptjoin4[i]=ptf4[i]; }
     }
-  } else if (def>deg) {// def>=65536>deg
-    join=NEW_PPERM4(dej);
-    CODEG_PPERM4(join)=dej;
-    ptjoin4=ADDR_PPERM4(join);
-    ptf4=ADDR_PPERM4(f);
-    ptg2=ADDR_PPERM2(g);
-    for(i=0;i<deg;i++){
-      if(ptg2[i]!=0){ 
-        ptjoin4[i]=ptg2[i];
-      } else if(ptf4[i]!=0) {
-        ptjoin4[i]=ptf4[i];
-      }
+    else if (def > deg) {    // def>=65536>deg
+        join = NEW_PPERM4(dej);
+        CODEG_PPERM4(join) = dej;
+        ptjoin4 = ADDR_PPERM4(join);
+        ptf4 = ADDR_PPERM4(f);
+        ptg2 = ADDR_PPERM2(g);
+        for (i = 0; i < deg; i++) {
+            if (ptg2[i] != 0) {
+                ptjoin4[i] = ptg2[i];
+            }
+            else if (ptf4[i] != 0) {
+                ptjoin4[i] = ptf4[i];
+            }
+        }
+        for (; i < def; i++) {
+            if (ptf4[i] != 0)
+                ptjoin4[i] = ptf4[i];
+        }
     }
-    for(;i<def;i++){ if(ptf4[i]!=0) ptjoin4[i]=ptf4[i]; }
-  } else {
-    return FuncJOIN_IDEM_PPERMS(self, g, f);
-  }
-  return join;
+    else {
+        return FuncJOIN_IDEM_PPERMS(self, g, f);
+    }
+    return join;
 }
 
 // the union of f and g where this defines an injective function
-Obj FuncJOIN_PPERMS(Obj self, Obj f, Obj g){
-  UInt    deg, i, j, degf, degg, codeg, rank;
-  UInt2   *ptf2, *ptg2, *ptjoin2;
-  UInt4   *ptf4, *ptg4, *ptjoin4, *ptseen;
-  Obj     join, dom;
- 
-  if(EQ(f,g)) return f; 
+Obj FuncJOIN_PPERMS(Obj self, Obj f, Obj g)
+{
+    UInt   deg, i, j, degf, degg, codeg, rank;
+    UInt2 *ptf2, *ptg2, *ptjoin2;
+    UInt4 *ptf4, *ptg4, *ptjoin4, *ptseen;
+    Obj    join, dom;
 
-  //init the buffer
-  codeg=MAX(CODEG_PPERM(f), CODEG_PPERM(g));
-  ResizeTmpPPerm(codeg);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  for(i=0;i<codeg;i++) ptseen[i]=0;
-  
-  if(TNUM_OBJ(f)==T_PPERM4&&TNUM_OBJ(g)==T_PPERM4){
-    degf=DEG_PPERM4(f);
-    degg=DEG_PPERM4(g);
-    deg=MAX(degf, degg);
-    join=NEW_PPERM4(deg);
-    CODEG_PPERM4(join)=codeg;
-    
-    ptjoin4=ADDR_PPERM4(join);
-    ptf4=ADDR_PPERM4(f);
-    ptg4=ADDR_PPERM4(g);
-    ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-    
-    if(DOM_PPERM(f)!=NULL){
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptjoin4[j]=ptf4[j];
-        ptseen[ptf4[j]-1]=1;
-      }
-    }
- 
-    if(DOM_PPERM(g)!=NULL){
-      dom=DOM_PPERM(g);
-      rank=RANK_PPERM4(g);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptjoin4[j]==0){
-          if(ptseen[ptg4[j]-1]==0){
-            ptjoin4[j]=ptg4[j];
-            ptseen[ptg4[j]-1]=1;
-          } else {
-            return Fail;//join is not injective
-          }
-        } else if(ptjoin4[j]!=ptg4[j]){
-          return Fail;
-        }
-      }
-    }
+    if (EQ(f, g))
+        return f;
 
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<degf;i++){
-        if(ptf4[i]!=0){
-          if(ptjoin4[i]==0){
-            if(ptseen[ptf4[i]-1]==0){
-              ptjoin4[i]=ptf4[i];
-              ptseen[ptf4[i]-1]=1;
-            } else {
-              return Fail;
-            }
-          } else if(ptjoin4[i]!=ptf4[i]){ 
-            return Fail;
-          }
-        }
-      }
-    }
-    
-    if(DOM_PPERM(g)==NULL){
-      for(i=0;i<degg;i++){
-        if(ptg4[i]!=0){
-          if(ptjoin4[i]==0){
-            if(ptseen[ptg4[i]-1]==0){
-              ptjoin4[i]=ptg4[i];
-              ptseen[ptg4[i]-1]=1;
-            } else {
-              return Fail;
-            }
-          } else if(ptjoin4[i]!=ptg4[i]){ 
-            return Fail;
-          }
-        }
-      }
-    }
-  } else if (TNUM_OBJ(f)==T_PPERM4&&TNUM_OBJ(g)==T_PPERM2){
-    degf=DEG_PPERM4(f);
-    degg=DEG_PPERM2(g);
-    deg=MAX(degf, degg);
-    join=NEW_PPERM4(deg);
-    CODEG_PPERM4(join)=codeg;
-    
-    ptjoin4=ADDR_PPERM4(join);
-    ptf4=ADDR_PPERM4(f);
-    ptg2=ADDR_PPERM2(g);
-    ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
+    // init the buffer
+    codeg = MAX(CODEG_PPERM(f), CODEG_PPERM(g));
+    ResizeTmpPPerm(codeg);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+    for (i = 0; i < codeg; i++)
+        ptseen[i] = 0;
 
-    if(DOM_PPERM(f)!=NULL){
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptjoin4[j]=ptf4[j];
-        ptseen[ptf4[j]-1]=1;
-      }
-    }
- 
-    if(DOM_PPERM(g)!=NULL){
-      dom=DOM_PPERM(g);
-      rank=RANK_PPERM2(g);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptjoin4[j]==0){
-          if(ptseen[ptg2[j]-1]==0){
-            ptjoin4[j]=ptg2[j];
-            ptseen[ptg2[j]-1]=1;
-          } else {
-            return Fail;//join is not injective
-          }
-        } else if(ptjoin4[j]!=ptg2[j]){
-          return Fail;
-        }
-      }
-    }
+    if (TNUM_OBJ(f) == T_PPERM4 && TNUM_OBJ(g) == T_PPERM4) {
+        degf = DEG_PPERM4(f);
+        degg = DEG_PPERM4(g);
+        deg = MAX(degf, degg);
+        join = NEW_PPERM4(deg);
+        CODEG_PPERM4(join) = codeg;
 
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<degf;i++){
-        if(ptf4[i]!=0){
-          if(ptjoin4[i]==0){
-            if(ptseen[ptf4[i]-1]==0){
-              ptjoin4[i]=ptf4[i];
-              ptseen[ptf4[i]-1]=1;
-            } else {
-              return Fail;
-            }
-          } else if(ptjoin4[i]!=ptf4[i]){ 
-            return Fail;
-          }
-        }
-      }
-    }
-    
-    if(DOM_PPERM(g)==NULL){
-      for(i=0;i<degg;i++){
-        if(ptg2[i]!=0){
-          if(ptjoin4[i]==0){
-            if(ptseen[ptg2[i]-1]==0){
-              ptjoin4[i]=ptg2[i];
-              ptseen[ptg2[i]-1]=1;
-            } else {
-              return Fail;
-            }
-          } else if(ptjoin4[i]!=ptg2[i]){ 
-            return Fail;
-          }
-        }
-      }
-    }
-  } else if (TNUM_OBJ(f)==T_PPERM2&&TNUM_OBJ(g)==T_PPERM4){
-    return FuncJOIN_PPERMS(self, g, f);
-  } else {
-    degf=DEG_PPERM2(f);
-    degg=DEG_PPERM2(g);
-    deg=MAX(degf,degg);
-    join=NEW_PPERM2(deg);
-    CODEG_PPERM2(join)=codeg;
-    
-    ptjoin2=ADDR_PPERM2(join);
-    ptf2=ADDR_PPERM2(f);
-    ptg2=ADDR_PPERM2(g);
-    ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
+        ptjoin4 = ADDR_PPERM4(join);
+        ptf4 = ADDR_PPERM4(f);
+        ptg4 = ADDR_PPERM4(g);
+        ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
 
-    if(DOM_PPERM(f)!=NULL){
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM2(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptjoin2[j]=ptf2[j];
-        ptseen[ptf2[j]-1]=1;
-      }
-    }
- 
-    if(DOM_PPERM(g)!=NULL){
-      dom=DOM_PPERM(g);
-      rank=RANK_PPERM2(g);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptjoin2[j]==0){
-          if(ptseen[ptg2[j]-1]==0){
-            ptjoin2[j]=ptg2[j];
-            ptseen[ptg2[j]-1]=1;
-          } else {
-            return Fail;//join is not injective
-          }
-        } else if(ptjoin2[j]!=ptg2[j]){
-          return Fail;
+        if (DOM_PPERM(f) != NULL) {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptjoin4[j] = ptf4[j];
+                ptseen[ptf4[j] - 1] = 1;
+            }
         }
-      }
-    }
 
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<degf;i++){
-        if(ptf2[i]!=0){
-          if(ptjoin2[i]==0){
-            if(ptseen[ptf2[i]-1]==0){
-              ptjoin2[i]=ptf2[i];
-              ptseen[ptf2[i]-1]=1;
-            } else {
-              return Fail;
+        if (DOM_PPERM(g) != NULL) {
+            dom = DOM_PPERM(g);
+            rank = RANK_PPERM4(g);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptjoin4[j] == 0) {
+                    if (ptseen[ptg4[j] - 1] == 0) {
+                        ptjoin4[j] = ptg4[j];
+                        ptseen[ptg4[j] - 1] = 1;
+                    }
+                    else {
+                        return Fail;    // join is not injective
+                    }
+                }
+                else if (ptjoin4[j] != ptg4[j]) {
+                    return Fail;
+                }
             }
-          } else if(ptjoin2[i]!=ptf2[i]){ 
-            return Fail;
-          }
         }
-      }
-    }
-    
-    if(DOM_PPERM(g)==NULL){
-      for(i=0;i<degg;i++){
-        if(ptg2[i]!=0){
-          if(ptjoin2[i]==0){
-            if(ptseen[ptg2[i]-1]==0){
-              ptjoin2[i]=ptg2[i];
-              ptseen[ptg2[i]-1]=1;
-            } else {
-              return Fail;
+
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < degf; i++) {
+                if (ptf4[i] != 0) {
+                    if (ptjoin4[i] == 0) {
+                        if (ptseen[ptf4[i] - 1] == 0) {
+                            ptjoin4[i] = ptf4[i];
+                            ptseen[ptf4[i] - 1] = 1;
+                        }
+                        else {
+                            return Fail;
+                        }
+                    }
+                    else if (ptjoin4[i] != ptf4[i]) {
+                        return Fail;
+                    }
+                }
             }
-          } else if(ptjoin2[i]!=ptg2[i]){ 
-            return Fail;
-          }
         }
-      }
+
+        if (DOM_PPERM(g) == NULL) {
+            for (i = 0; i < degg; i++) {
+                if (ptg4[i] != 0) {
+                    if (ptjoin4[i] == 0) {
+                        if (ptseen[ptg4[i] - 1] == 0) {
+                            ptjoin4[i] = ptg4[i];
+                            ptseen[ptg4[i] - 1] = 1;
+                        }
+                        else {
+                            return Fail;
+                        }
+                    }
+                    else if (ptjoin4[i] != ptg4[i]) {
+                        return Fail;
+                    }
+                }
+            }
+        }
     }
-  }
-  return join;
+    else if (TNUM_OBJ(f) == T_PPERM4 && TNUM_OBJ(g) == T_PPERM2) {
+        degf = DEG_PPERM4(f);
+        degg = DEG_PPERM2(g);
+        deg = MAX(degf, degg);
+        join = NEW_PPERM4(deg);
+        CODEG_PPERM4(join) = codeg;
+
+        ptjoin4 = ADDR_PPERM4(join);
+        ptf4 = ADDR_PPERM4(f);
+        ptg2 = ADDR_PPERM2(g);
+        ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+
+        if (DOM_PPERM(f) != NULL) {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptjoin4[j] = ptf4[j];
+                ptseen[ptf4[j] - 1] = 1;
+            }
+        }
+
+        if (DOM_PPERM(g) != NULL) {
+            dom = DOM_PPERM(g);
+            rank = RANK_PPERM2(g);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptjoin4[j] == 0) {
+                    if (ptseen[ptg2[j] - 1] == 0) {
+                        ptjoin4[j] = ptg2[j];
+                        ptseen[ptg2[j] - 1] = 1;
+                    }
+                    else {
+                        return Fail;    // join is not injective
+                    }
+                }
+                else if (ptjoin4[j] != ptg2[j]) {
+                    return Fail;
+                }
+            }
+        }
+
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < degf; i++) {
+                if (ptf4[i] != 0) {
+                    if (ptjoin4[i] == 0) {
+                        if (ptseen[ptf4[i] - 1] == 0) {
+                            ptjoin4[i] = ptf4[i];
+                            ptseen[ptf4[i] - 1] = 1;
+                        }
+                        else {
+                            return Fail;
+                        }
+                    }
+                    else if (ptjoin4[i] != ptf4[i]) {
+                        return Fail;
+                    }
+                }
+            }
+        }
+
+        if (DOM_PPERM(g) == NULL) {
+            for (i = 0; i < degg; i++) {
+                if (ptg2[i] != 0) {
+                    if (ptjoin4[i] == 0) {
+                        if (ptseen[ptg2[i] - 1] == 0) {
+                            ptjoin4[i] = ptg2[i];
+                            ptseen[ptg2[i] - 1] = 1;
+                        }
+                        else {
+                            return Fail;
+                        }
+                    }
+                    else if (ptjoin4[i] != ptg2[i]) {
+                        return Fail;
+                    }
+                }
+            }
+        }
+    }
+    else if (TNUM_OBJ(f) == T_PPERM2 && TNUM_OBJ(g) == T_PPERM4) {
+        return FuncJOIN_PPERMS(self, g, f);
+    }
+    else {
+        degf = DEG_PPERM2(f);
+        degg = DEG_PPERM2(g);
+        deg = MAX(degf, degg);
+        join = NEW_PPERM2(deg);
+        CODEG_PPERM2(join) = codeg;
+
+        ptjoin2 = ADDR_PPERM2(join);
+        ptf2 = ADDR_PPERM2(f);
+        ptg2 = ADDR_PPERM2(g);
+        ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+
+        if (DOM_PPERM(f) != NULL) {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM2(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptjoin2[j] = ptf2[j];
+                ptseen[ptf2[j] - 1] = 1;
+            }
+        }
+
+        if (DOM_PPERM(g) != NULL) {
+            dom = DOM_PPERM(g);
+            rank = RANK_PPERM2(g);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptjoin2[j] == 0) {
+                    if (ptseen[ptg2[j] - 1] == 0) {
+                        ptjoin2[j] = ptg2[j];
+                        ptseen[ptg2[j] - 1] = 1;
+                    }
+                    else {
+                        return Fail;    // join is not injective
+                    }
+                }
+                else if (ptjoin2[j] != ptg2[j]) {
+                    return Fail;
+                }
+            }
+        }
+
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < degf; i++) {
+                if (ptf2[i] != 0) {
+                    if (ptjoin2[i] == 0) {
+                        if (ptseen[ptf2[i] - 1] == 0) {
+                            ptjoin2[i] = ptf2[i];
+                            ptseen[ptf2[i] - 1] = 1;
+                        }
+                        else {
+                            return Fail;
+                        }
+                    }
+                    else if (ptjoin2[i] != ptf2[i]) {
+                        return Fail;
+                    }
+                }
+            }
+        }
+
+        if (DOM_PPERM(g) == NULL) {
+            for (i = 0; i < degg; i++) {
+                if (ptg2[i] != 0) {
+                    if (ptjoin2[i] == 0) {
+                        if (ptseen[ptg2[i] - 1] == 0) {
+                            ptjoin2[i] = ptg2[i];
+                            ptseen[ptg2[i] - 1] = 1;
+                        }
+                        else {
+                            return Fail;
+                        }
+                    }
+                    else if (ptjoin2[i] != ptg2[i]) {
+                        return Fail;
+                    }
+                }
+            }
+        }
+    }
+    return join;
 }
 
-Obj FuncMEET_PPERMS(Obj self, Obj f, Obj g){
-  UInt    deg, i, j, degf, degg, codeg;
-  UInt2   *ptf2, *ptg2, *ptmeet2;
-  UInt4   *ptf4, *ptg4, *ptmeet4;
-  Obj     meet;
+Obj FuncMEET_PPERMS(Obj self, Obj f, Obj g)
+{
+    UInt   deg, i, j, degf, degg, codeg;
+    UInt2 *ptf2, *ptg2, *ptmeet2;
+    UInt4 *ptf4, *ptg4, *ptmeet4;
+    Obj    meet;
 
-  codeg=0;
-  if(TNUM_OBJ(f)==T_PPERM2&&TNUM_OBJ(g)==T_PPERM2){
-    degf=DEG_PPERM2(f);
-    degg=DEG_PPERM2(g);
-    ptf2=ADDR_PPERM2(f);
-    ptg2=ADDR_PPERM2(g);
+    codeg = 0;
+    if (TNUM_OBJ(f) == T_PPERM2 && TNUM_OBJ(g) == T_PPERM2) {
+        degf = DEG_PPERM2(f);
+        degg = DEG_PPERM2(g);
+        ptf2 = ADDR_PPERM2(f);
+        ptg2 = ADDR_PPERM2(g);
 
-    //find degree
-    for(deg=MIN(degf,degg);deg>0;deg--){
-      j=IMAGEPP(deg, ptf2, degf);
-      if(j!=0&&j==IMAGEPP(deg, ptg2, degg)) break;
+        // find degree
+        for (deg = MIN(degf, degg); deg > 0; deg--) {
+            j = IMAGEPP(deg, ptf2, degf);
+            if (j != 0 && j == IMAGEPP(deg, ptg2, degg))
+                break;
+        }
+
+        meet = NEW_PPERM2(deg);
+        ptmeet2 = ADDR_PPERM2(meet);
+        ptf2 = ADDR_PPERM2(f);
+        ptg2 = ADDR_PPERM2(g);
+
+        for (i = 0; i < deg; i++) {
+            j = IMAGEPP(i + 1, ptf2, degf);
+            if (IMAGEPP(i + 1, ptg2, degg) == j) {
+                ptmeet2[i] = j;
+                if (j > codeg)
+                    codeg = j;
+            }
+        }
+        CODEG_PPERM2(meet) = codeg;
     }
+    else if (TNUM_OBJ(f) == T_PPERM4 && TNUM_OBJ(g) == T_PPERM2) {
+        degf = DEG_PPERM4(f);
+        degg = DEG_PPERM2(g);
+        ptf4 = ADDR_PPERM4(f);
+        ptg2 = ADDR_PPERM2(g);
 
-    meet=NEW_PPERM2(deg);
-    ptmeet2=ADDR_PPERM2(meet);
-    ptf2=ADDR_PPERM2(f);
-    ptg2=ADDR_PPERM2(g);
-    
-    for(i=0;i<deg;i++){
-      j=IMAGEPP(i+1, ptf2, degf);
-      if(IMAGEPP(i+1, ptg2, degg)==j){ 
-        ptmeet2[i]=j;
-        if(j>codeg) codeg=j;
-      }
-    }
-    CODEG_PPERM2(meet)=codeg;
-  } else if(TNUM_OBJ(f)==T_PPERM4&&TNUM_OBJ(g)==T_PPERM2){
-    degf=DEG_PPERM4(f);
-    degg=DEG_PPERM2(g);
-    ptf4=ADDR_PPERM4(f);
-    ptg2=ADDR_PPERM2(g);
+        // find degree
+        for (deg = (degf < degg ? degf : degg); deg > 0; deg--) {
+            j = IMAGEPP(deg, ptf4, degf);
+            if (j != 0 && j == IMAGEPP(deg, ptg2, degg))
+                break;
+        }
 
-    //find degree
-    for(deg=(degf<degg?degf:degg);deg>0;deg--){
-      j=IMAGEPP(deg, ptf4, degf);
-      if(j!=0&&j==IMAGEPP(deg, ptg2, degg)) break;
-    }
+        meet = NEW_PPERM2(deg);
+        ptmeet2 = ADDR_PPERM2(meet);
+        ptf4 = ADDR_PPERM4(f);
+        ptg2 = ADDR_PPERM2(g);
 
-    meet=NEW_PPERM2(deg);
-    ptmeet2=ADDR_PPERM2(meet);
-    ptf4=ADDR_PPERM4(f);
-    ptg2=ADDR_PPERM2(g);
-    
-    for(i=0;i<deg;i++){
-      j=IMAGEPP(i+1, ptf4, degf);
-      if(IMAGEPP(i+1, ptg2, degg)==j){ 
-        ptmeet2[i]=j;
-        if(j>codeg) codeg=j;
-      }
+        for (i = 0; i < deg; i++) {
+            j = IMAGEPP(i + 1, ptf4, degf);
+            if (IMAGEPP(i + 1, ptg2, degg) == j) {
+                ptmeet2[i] = j;
+                if (j > codeg)
+                    codeg = j;
+            }
+        }
+        CODEG_PPERM2(meet) = codeg;
     }
-    CODEG_PPERM2(meet)=codeg;
-  }else if(TNUM_OBJ(f)==T_PPERM2&&TNUM_OBJ(g)==T_PPERM4){
-    degf=DEG_PPERM2(f);
-    degg=DEG_PPERM4(g);
-    ptf2=ADDR_PPERM2(f);
-    ptg4=ADDR_PPERM4(g);
+    else if (TNUM_OBJ(f) == T_PPERM2 && TNUM_OBJ(g) == T_PPERM4) {
+        degf = DEG_PPERM2(f);
+        degg = DEG_PPERM4(g);
+        ptf2 = ADDR_PPERM2(f);
+        ptg4 = ADDR_PPERM4(g);
 
-    //find degree
-    for(deg=MIN(degf,degg);deg>0;deg--){
-      j=IMAGEPP(deg, ptf2, degf);
-      if(j!=0&&j==IMAGEPP(deg, ptg4, degg)) break;
-    }
+        // find degree
+        for (deg = MIN(degf, degg); deg > 0; deg--) {
+            j = IMAGEPP(deg, ptf2, degf);
+            if (j != 0 && j == IMAGEPP(deg, ptg4, degg))
+                break;
+        }
 
-    meet=NEW_PPERM2(deg);
-    ptmeet2=ADDR_PPERM2(meet);
-    ptf2=ADDR_PPERM2(f);
-    ptg4=ADDR_PPERM4(g);
-    
-    for(i=0;i<deg;i++){
-      j=IMAGEPP(i+1, ptf2, degf);
-      if(IMAGEPP(i+1, ptg4, degg)==j){ 
-        ptmeet2[i]=j;
-        if(j>codeg) codeg=j;
-      }
-    }
-    CODEG_PPERM2(meet)=codeg;
-  } else {
-    degf=DEG_PPERM4(f);
-    degg=DEG_PPERM4(g);
-    ptf4=ADDR_PPERM4(f);
-    ptg4=ADDR_PPERM4(g);
+        meet = NEW_PPERM2(deg);
+        ptmeet2 = ADDR_PPERM2(meet);
+        ptf2 = ADDR_PPERM2(f);
+        ptg4 = ADDR_PPERM4(g);
 
-    //find degree
-    for(deg=MIN(degf,degg);deg>0;deg--){
-      j=IMAGEPP(deg, ptf4, degf);
-      if(j!=0&&j==IMAGEPP(deg, ptg4, degg)) break;
+        for (i = 0; i < deg; i++) {
+            j = IMAGEPP(i + 1, ptf2, degf);
+            if (IMAGEPP(i + 1, ptg4, degg) == j) {
+                ptmeet2[i] = j;
+                if (j > codeg)
+                    codeg = j;
+            }
+        }
+        CODEG_PPERM2(meet) = codeg;
     }
+    else {
+        degf = DEG_PPERM4(f);
+        degg = DEG_PPERM4(g);
+        ptf4 = ADDR_PPERM4(f);
+        ptg4 = ADDR_PPERM4(g);
 
-    meet=NEW_PPERM4(deg);
-    ptmeet4=ADDR_PPERM4(meet);
-    ptf4=ADDR_PPERM4(f);
-    ptg4=ADDR_PPERM4(g);
-    
-    for(i=0;i<deg;i++){
-      j=IMAGEPP(i+1, ptf4, degf);
-      if(IMAGEPP(i+1, ptg4, degg)==j){ 
-        ptmeet4[i]=j;
-        if(j>codeg) codeg=j;
-      }
+        // find degree
+        for (deg = MIN(degf, degg); deg > 0; deg--) {
+            j = IMAGEPP(deg, ptf4, degf);
+            if (j != 0 && j == IMAGEPP(deg, ptg4, degg))
+                break;
+        }
+
+        meet = NEW_PPERM4(deg);
+        ptmeet4 = ADDR_PPERM4(meet);
+        ptf4 = ADDR_PPERM4(f);
+        ptg4 = ADDR_PPERM4(g);
+
+        for (i = 0; i < deg; i++) {
+            j = IMAGEPP(i + 1, ptf4, degf);
+            if (IMAGEPP(i + 1, ptg4, degg) == j) {
+                ptmeet4[i] = j;
+                if (j > codeg)
+                    codeg = j;
+            }
+        }
+        CODEG_PPERM4(meet) = codeg;
     }
-    CODEG_PPERM4(meet)=codeg;
-  }
-  return meet;
+    return meet;
 }
 
 // restricted partial perm where set is assumed to be a set of positive ints
-Obj FuncRESTRICTED_PPERM(Obj self, Obj f, Obj set){
-  UInt    i, j, n, codeg, deg;
-  UInt2   *ptf2, *ptg2;
-  UInt4   *ptf4, *ptg4;
-  Obj     g;
+Obj FuncRESTRICTED_PPERM(Obj self, Obj f, Obj set)
+{
+    UInt   i, j, n, codeg, deg;
+    UInt2 *ptf2, *ptg2;
+    UInt4 *ptf4, *ptg4;
+    Obj    g;
 
-  n=LEN_LIST(set);
-  codeg=0;
+    n = LEN_LIST(set);
+    codeg = 0;
 
-  if(TNUM_OBJ(f)==T_PPERM2){
-    deg=DEG_PPERM2(f);
-    ptf2=ADDR_PPERM2(f);
-    
-    // find pos in list corresponding to degree of new pperm
-    while(n>0&&(UInt) INT_INTOBJ(ELM_LIST(set, n))>deg) n--;
-    while(n>0&&ptf2[INT_INTOBJ(ELM_LIST(set, n))-1]==0) n--;
-    if(n==0) return EmptyPartialPerm;
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        deg = DEG_PPERM2(f);
+        ptf2 = ADDR_PPERM2(f);
 
-    g=NEW_PPERM2(INT_INTOBJ(ELM_LIST(set, n)));
-    ptf2=ADDR_PPERM2(f);
-    ptg2=ADDR_PPERM2(g);
+        // find pos in list corresponding to degree of new pperm
+        while (n > 0 && (UInt)INT_INTOBJ(ELM_LIST(set, n)) > deg)
+            n--;
+        while (n > 0 && ptf2[INT_INTOBJ(ELM_LIST(set, n)) - 1] == 0)
+            n--;
+        if (n == 0)
+            return EmptyPartialPerm;
 
-    for(i=0;i<n;i++){
-      j=INT_INTOBJ(ELM_LIST(set, i+1))-1;
-      ptg2[j]=ptf2[j];
-      if(ptg2[j]>codeg) codeg=ptg2[j];
+        g = NEW_PPERM2(INT_INTOBJ(ELM_LIST(set, n)));
+        ptf2 = ADDR_PPERM2(f);
+        ptg2 = ADDR_PPERM2(g);
+
+        for (i = 0; i < n; i++) {
+            j = INT_INTOBJ(ELM_LIST(set, i + 1)) - 1;
+            ptg2[j] = ptf2[j];
+            if (ptg2[j] > codeg)
+                codeg = ptg2[j];
+        }
+        CODEG_PPERM2(g) = codeg;
+        return g;
     }
-    CODEG_PPERM2(g)=codeg;
-    return g;
-  } else if (TNUM_OBJ(f)==T_PPERM4){
-    deg=DEG_PPERM4(f);
-    ptf4=ADDR_PPERM4(f);
-    
-    while(n>0&&(UInt) INT_INTOBJ(ELM_LIST(set, n))>deg) n--;
-    while(n>0&&ptf4[INT_INTOBJ(ELM_LIST(set, n))-1]==0) n--;
-    if(n==0) return EmptyPartialPerm;
-   
-    g=NEW_PPERM4(INT_INTOBJ(ELM_LIST(set, n)));
-    ptf4=ADDR_PPERM4(f);
-    ptg4=ADDR_PPERM4(g);
+    else if (TNUM_OBJ(f) == T_PPERM4) {
+        deg = DEG_PPERM4(f);
+        ptf4 = ADDR_PPERM4(f);
 
-    for(i=0;i<n;i++){
-      j=INT_INTOBJ(ELM_LIST(set, i+1))-1;
-      ptg4[j]=ptf4[j];
-      if(ptg4[j]>codeg) codeg=ptg4[j];
+        while (n > 0 && (UInt)INT_INTOBJ(ELM_LIST(set, n)) > deg)
+            n--;
+        while (n > 0 && ptf4[INT_INTOBJ(ELM_LIST(set, n)) - 1] == 0)
+            n--;
+        if (n == 0)
+            return EmptyPartialPerm;
+
+        g = NEW_PPERM4(INT_INTOBJ(ELM_LIST(set, n)));
+        ptf4 = ADDR_PPERM4(f);
+        ptg4 = ADDR_PPERM4(g);
+
+        for (i = 0; i < n; i++) {
+            j = INT_INTOBJ(ELM_LIST(set, i + 1)) - 1;
+            ptg4[j] = ptf4[j];
+            if (ptg4[j] > codeg)
+                codeg = ptg4[j];
+        }
+        CODEG_PPERM4(g) = codeg;
+        return g;
     }
-    CODEG_PPERM4(g)=codeg;
-    return g;
-  }
-  return Fail;
+    return Fail;
 }
 
-// convert a permutation <p> to a partial perm on <set>, which is assumed to be
+// convert a permutation <p> to a partial perm on <set>, which is assumed to
+// be
 // a set of positive integers
-Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set){
-  UInt    i, j, n, deg, codeg, dep;
-  UInt2   *ptf2, *ptp2;
-  UInt4   *ptf4, *ptp4;
-  Obj     f;
+Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
+{
+    UInt   i, j, n, deg, codeg, dep;
+    UInt2 *ptf2, *ptp2;
+    UInt4 *ptf4, *ptp4;
+    Obj    f;
 
-  n=LEN_LIST(set);
-  if(n==0) return EmptyPartialPerm; 
-  deg=INT_INTOBJ(ELM_LIST(set, n));
-  codeg=0;
+    n = LEN_LIST(set);
+    if (n == 0)
+        return EmptyPartialPerm;
+    deg = INT_INTOBJ(ELM_LIST(set, n));
+    codeg = 0;
 
-  if(TNUM_OBJ(p)==T_PERM2){
-    dep=DEG_PERM2(p);
-    if(deg<65536){
-      if(dep<deg){
-        //Pr("Case 1\n", 0L, 0L);
-        f=NEW_PPERM2(deg);
-        ptf2=ADDR_PPERM2(f);
-        ptp2=ADDR_PERM2(p);
-        for(i=1;i<=n;i++){
-          j=INT_INTOBJ(ELM_LIST(set, i))-1;
-          ptf2[j]=IMAGE(j, ptp2, dep)+1;
+    if (TNUM_OBJ(p) == T_PERM2) {
+        dep = DEG_PERM2(p);
+        if (deg < 65536) {
+            if (dep < deg) {
+                // Pr("Case 1\n", 0L, 0L);
+                f = NEW_PPERM2(deg);
+                ptf2 = ADDR_PPERM2(f);
+                ptp2 = ADDR_PERM2(p);
+                for (i = 1; i <= n; i++) {
+                    j = INT_INTOBJ(ELM_LIST(set, i)) - 1;
+                    ptf2[j] = IMAGE(j, ptp2, dep) + 1;
+                }
+                CODEG_PPERM2(f) = deg;
+            }
+            else {    // deg(f)<=deg(p)<=65536
+                // Pr("Case 2\n", 0L, 0L);
+                f = NEW_PPERM2(deg);
+                ptf2 = ADDR_PPERM2(f);
+                ptp2 = ADDR_PERM2(p);
+                for (i = 1; i <= n; i++) {
+                    j = INT_INTOBJ(ELM_LIST(set, i)) - 1;
+                    ptf2[j] = ptp2[j] + 1;
+                    if (ptf2[j] > codeg)
+                        codeg = ptf2[j];
+                }
+                CODEG_PPERM2(f) = codeg;
+            }
         }
-        CODEG_PPERM2(f)=deg;
-      } else { //deg(f)<=deg(p)<=65536
-        //Pr("Case 2\n", 0L, 0L);
-        f=NEW_PPERM2(deg);
-        ptf2=ADDR_PPERM2(f);
-        ptp2=ADDR_PERM2(p);
-        for(i=1;i<=n;i++){
-          j=INT_INTOBJ(ELM_LIST(set, i))-1;
-          ptf2[j]=ptp2[j]+1;
-          if(ptf2[j]>codeg) codeg=ptf2[j];
+        else {    // deg(p)<=65536<=deg(f)
+            // Pr("Case 3\n", 0L, 0L);
+            f = NEW_PPERM4(deg);
+            ptf4 = ADDR_PPERM4(f);
+            ptp2 = ADDR_PERM2(p);
+            for (i = 1; i <= n; i++) {
+                j = INT_INTOBJ(ELM_LIST(set, i)) - 1;
+                ptf4[j] = IMAGE(j, ptp2, dep) + 1;
+            }
+            CODEG_PPERM4(f) = deg;
         }
-        CODEG_PPERM2(f)=codeg;
-      }
-    } else { //deg(p)<=65536<=deg(f)
-      //Pr("Case 3\n", 0L, 0L);
-      f=NEW_PPERM4(deg);
-      ptf4=ADDR_PPERM4(f);
-      ptp2=ADDR_PERM2(p);
-      for(i=1;i<=n;i++){
-        j=INT_INTOBJ(ELM_LIST(set, i))-1;
-        ptf4[j]=IMAGE(j, ptp2, dep)+1;
-      }
-      CODEG_PPERM4(f)=deg;
     }
-  } else { // p is PERM4
-    dep=DEG_PERM4(p);
-    if(dep<deg){
-      //Pr("Case 4\n", 0L, 0L);
-      f=NEW_PPERM4(deg);
-      ptf4=ADDR_PPERM4(f);
-      ptp4=ADDR_PERM4(p);
-      for(i=1;i<=n;i++){
-        j=INT_INTOBJ(ELM_LIST(set, i))-1;
-        ptf4[j]=IMAGE(j, ptp4, dep)+1;
-      }
-      CODEG_PPERM4(f)=deg;
-    } else { //deg<=dep 
-      //find the codeg
-      i=deg;
-      ptp4=ADDR_PERM4(p);
-      while(codeg<65536&&i>0){
-        j=ptp4[INT_INTOBJ(ELM_LIST(set, i--))-1]+1;
-        if(j>codeg) codeg=j;
-      }
-      if(codeg<65536){
+    else {    // p is PERM4
+        dep = DEG_PERM4(p);
+        if (dep < deg) {
+            // Pr("Case 4\n", 0L, 0L);
+            f = NEW_PPERM4(deg);
+            ptf4 = ADDR_PPERM4(f);
+            ptp4 = ADDR_PERM4(p);
+            for (i = 1; i <= n; i++) {
+                j = INT_INTOBJ(ELM_LIST(set, i)) - 1;
+                ptf4[j] = IMAGE(j, ptp4, dep) + 1;
+            }
+            CODEG_PPERM4(f) = deg;
+        }
+        else {    // deg<=dep
+            // find the codeg
+            i = deg;
+            ptp4 = ADDR_PERM4(p);
+            while (codeg < 65536 && i > 0) {
+                j = ptp4[INT_INTOBJ(ELM_LIST(set, i--)) - 1] + 1;
+                if (j > codeg)
+                    codeg = j;
+            }
+            if (codeg < 65536) {
 
-        //Pr("Case 5\n", 0L, 0L);
-        f=NEW_PPERM2(deg);
-        ptf2=ADDR_PPERM2(f);
-        ptp4=ADDR_PERM4(p);
-        for(i=1;i<=n;i++){
-          j=INT_INTOBJ(ELM_LIST(set, i))-1;
-          ptf2[j]=ptp4[j]+1;
+                // Pr("Case 5\n", 0L, 0L);
+                f = NEW_PPERM2(deg);
+                ptf2 = ADDR_PPERM2(f);
+                ptp4 = ADDR_PERM4(p);
+                for (i = 1; i <= n; i++) {
+                    j = INT_INTOBJ(ELM_LIST(set, i)) - 1;
+                    ptf2[j] = ptp4[j] + 1;
+                }
+                CODEG_PPERM2(f) = codeg;
+            }
+            else {
+                // Pr("Case 6\n", 0L, 0L);
+                f = NEW_PPERM4(deg);
+                ptf4 = ADDR_PPERM4(f);
+                ptp4 = ADDR_PERM4(p);
+                for (i = 1; i <= n; i++) {
+                    j = INT_INTOBJ(ELM_LIST(set, i)) - 1;
+                    ptf4[j] = ptp4[j] + 1;
+                    if (ptf4[j] > codeg)
+                        codeg = ptf4[j];
+                }
+                CODEG_PPERM4(f) = deg;
+            }
         }
-        CODEG_PPERM2(f)=codeg;
-      } else {
-        //Pr("Case 6\n", 0L, 0L);
-        f=NEW_PPERM4(deg);
-        ptf4=ADDR_PPERM4(f);
-        ptp4=ADDR_PERM4(p);
-        for(i=1;i<=n;i++){
-          j=INT_INTOBJ(ELM_LIST(set, i))-1;
-          ptf4[j]=ptp4[j]+1;
-          if(ptf4[j]>codeg) codeg=ptf4[j];
-        }
-        CODEG_PPERM4(f)=deg;
-      }
     }
-  }
-  return f;
+    return f;
 }
 
 // for a partial perm with equal dom and img
-Obj FuncAS_PERM_PPERM(Obj self, Obj f){
-  UInt2   *ptf2, *ptp2;
-  UInt4   *ptf4, *ptp4;
-  UInt    deg, i, j, rank;
-  Obj     p, dom;
+Obj FuncAS_PERM_PPERM(Obj self, Obj f)
+{
+    UInt2 *ptf2, *ptp2;
+    UInt4 *ptf4, *ptp4;
+    UInt   deg, i, j, rank;
+    Obj    p, dom;
 
-  if(TNUM_OBJ(f)==T_PPERM2){
-    if(!EQ(FuncIMAGE_SET_PPERM(self, f), DOM_PPERM(f))){
-      return Fail;
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        if (!EQ(FuncIMAGE_SET_PPERM(self, f), DOM_PPERM(f))) {
+            return Fail;
+        }
+        deg = DEG_PPERM2(f);
+        p = NEW_PERM2(deg);
+        dom = DOM_PPERM(f);
+        ptp2 = ADDR_PERM2(p);
+        ptf2 = ADDR_PPERM2(f);
+        for (i = 0; i < deg; i++)
+            ptp2[i] = i;
+        rank = RANK_PPERM2(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptp2[j] = ptf2[j] - 1;
+        }
     }
-    deg=DEG_PPERM2(f);
-    p=NEW_PERM2(deg);
-    dom=DOM_PPERM(f);
-    ptp2=ADDR_PERM2(p);
-    ptf2=ADDR_PPERM2(f);
-    for(i=0;i<deg;i++) ptp2[i]=i;
-    rank=RANK_PPERM2(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptp2[j]=ptf2[j]-1;
+    else {
+        if (!EQ(FuncIMAGE_SET_PPERM(self, f), DOM_PPERM(f))) {
+            return Fail;
+        }
+        deg = DEG_PPERM4(f);
+        p = NEW_PERM4(deg);
+        dom = DOM_PPERM(f);
+        ptp4 = ADDR_PERM4(p);
+        ptf4 = ADDR_PPERM4(f);
+        for (i = 0; i < deg; i++)
+            ptp4[i] = i;
+        rank = RANK_PPERM4(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptp4[j] = ptf4[j] - 1;
+        }
     }
-  } else {
-   if(!EQ(FuncIMAGE_SET_PPERM(self, f), DOM_PPERM(f))){
-     return Fail;
-    }
-    deg=DEG_PPERM4(f);
-    p=NEW_PERM4(deg);
-    dom=DOM_PPERM(f);
-    ptp4=ADDR_PERM4(p);
-    ptf4=ADDR_PPERM4(f);
-    for(i=0;i<deg;i++) ptp4[i]=i;
-    rank=RANK_PPERM4(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptp4[j]=ptf4[j]-1;
-    }
-  }
-  return p;  
+    return p;
 }
 
 // the permutation induced on im(f) by f^-1*g when im(g)=im(f)
 // and dom(f)=dom(g), no checking
-Obj FuncPERM_LEFT_QUO_PPERM_NC(Obj self, Obj f, Obj g){
-  UInt    deg, i, j, rank;
-  Obj     perm, dom;
-  UInt2   *ptf2, *ptp2, *ptg2;
-  UInt4   *ptf4, *ptp4, *ptg4;
-  
-  if(TNUM_OBJ(f)==T_PPERM2){
-    deg=CODEG_PPERM2(f);
-    perm=NEW_PERM2(deg);
-    ptp2=ADDR_PERM2(perm);
-    for(i=0;i<deg;i++) ptp2[i]=i;
-    rank=RANK_PPERM2(f);
-    dom=DOM_PPERM(f);
-    //renew pointers since RANK_PPERM can trigger garbage collection
-    ptp2=ADDR_PERM2(perm);
-    ptf2=ADDR_PPERM2(f);
-    if(TNUM_OBJ(g)==T_PPERM2){
-      ptg2=ADDR_PPERM2(g);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptp2[ptf2[j]-1]=ptg2[j]-1;
-      }
-    } else {
-      ptg4=ADDR_PPERM4(g);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptp2[ptf2[j]-1]=ptg4[j]-1;
-      }
+Obj FuncPERM_LEFT_QUO_PPERM_NC(Obj self, Obj f, Obj g)
+{
+    UInt   deg, i, j, rank;
+    Obj    perm, dom;
+    UInt2 *ptf2, *ptp2, *ptg2;
+    UInt4 *ptf4, *ptp4, *ptg4;
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        deg = CODEG_PPERM2(f);
+        perm = NEW_PERM2(deg);
+        ptp2 = ADDR_PERM2(perm);
+        for (i = 0; i < deg; i++)
+            ptp2[i] = i;
+        rank = RANK_PPERM2(f);
+        dom = DOM_PPERM(f);
+        // renew pointers since RANK_PPERM can trigger garbage collection
+        ptp2 = ADDR_PERM2(perm);
+        ptf2 = ADDR_PPERM2(f);
+        if (TNUM_OBJ(g) == T_PPERM2) {
+            ptg2 = ADDR_PPERM2(g);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptp2[ptf2[j] - 1] = ptg2[j] - 1;
+            }
+        }
+        else {
+            ptg4 = ADDR_PPERM4(g);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptp2[ptf2[j] - 1] = ptg4[j] - 1;
+            }
+        }
     }
-  } else {
-    deg=CODEG_PPERM4(f);
-    perm=NEW_PERM4(deg);
-    ptp4=ADDR_PERM4(perm);
-    for(i=0;i<deg;i++) ptp4[i]=i;
-    rank=RANK_PPERM4(f);
-    dom=DOM_PPERM(f);
-    //renew pointers since RANK_PPERM can trigger garbage collection
-    ptp4=ADDR_PERM4(perm);
-    ptf4=ADDR_PPERM4(f);
-    if(TNUM_OBJ(g)==T_PPERM2){
-      ptg2=ADDR_PPERM2(g);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptp4[ptf4[j]-1]=ptg2[j]-1;
-      }
-    } else {
-      ptg4=ADDR_PPERM4(g);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptp4[ptf4[j]-1]=ptg4[j]-1;
-      }
+    else {
+        deg = CODEG_PPERM4(f);
+        perm = NEW_PERM4(deg);
+        ptp4 = ADDR_PERM4(perm);
+        for (i = 0; i < deg; i++)
+            ptp4[i] = i;
+        rank = RANK_PPERM4(f);
+        dom = DOM_PPERM(f);
+        // renew pointers since RANK_PPERM can trigger garbage collection
+        ptp4 = ADDR_PERM4(perm);
+        ptf4 = ADDR_PPERM4(f);
+        if (TNUM_OBJ(g) == T_PPERM2) {
+            ptg2 = ADDR_PPERM2(g);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptp4[ptf4[j] - 1] = ptg2[j] - 1;
+            }
+        }
+        else {
+            ptg4 = ADDR_PPERM4(g);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptp4[ptf4[j] - 1] = ptg4[j] - 1;
+            }
+        }
     }
-  }
-  return perm;
+    return perm;
 }
 
-Obj FuncShortLexLeqPartialPerm( Obj self, Obj f, Obj g){
-  UInt    rankf, rankg, i, j, k;
-  Obj     domf, domg;
-  UInt2   *ptf2, *ptg2;
-  UInt4   *ptf4, *ptg4;
- 
-  if(!IS_PPERM(f)||!IS_PPERM(g)){
-    ErrorQuit("usage: the arguments must be partial perms,", 0L, 0L);
-  }
+Obj FuncShortLexLeqPartialPerm(Obj self, Obj f, Obj g)
+{
+    UInt   rankf, rankg, i, j, k;
+    Obj    domf, domg;
+    UInt2 *ptf2, *ptg2;
+    UInt4 *ptf4, *ptg4;
 
-  if(TNUM_OBJ(f)==T_PPERM2){
-    if(DEG_PPERM2(f)==0) return True;
-    rankf=RANK_PPERM2(f);
-    domf=DOM_PPERM(f);
-  } else {
-    if(DEG_PPERM4(f)==0) return True;
-    rankf=RANK_PPERM4(f);
-    domf=DOM_PPERM(f);
-  }
-
-  if(TNUM_OBJ(g)==T_PPERM2){
-    if(DEG_PPERM2(g)==0) return False;
-    rankg=RANK_PPERM2(g);
-    domg=DOM_PPERM(g);
-  } else {
-    if(DEG_PPERM4(g)==0) return False;
-    rankg=RANK_PPERM4(g);
-    domg=DOM_PPERM(f);
-  }
-  
-  if(rankf!=rankg) return (rankf<rankg?True:False);
-  
-  if(TNUM_OBJ(f)==T_PPERM2){
-    ptf2=ADDR_PPERM2(f);
-    if(TNUM_OBJ(g)==T_PPERM2){
-      ptg2=ADDR_PPERM2(g);
-      for(i=1;i<=rankf;i++){
-        j=INT_INTOBJ(ELM_PLIST(domf, i))-1;
-        k=INT_INTOBJ(ELM_PLIST(domg, i))-1;
-        if(j!=k) return (j<k?True:False);
-        if(ptf2[j]!=ptg2[j]) return (ptf2[j]<ptg2[j]?True:False);
-      }
-    } else {
-      ptg4=ADDR_PPERM4(g);
-      for(i=1;i<=rankf;i++){
-        j=INT_INTOBJ(ELM_PLIST(domf, i))-1;
-        k=INT_INTOBJ(ELM_PLIST(domg, i))-1;
-        if(j!=k) return (j<k?True:False);
-        if(ptf2[j]!=ptg4[j]) return (ptf2[j]<ptg4[j]?True:False);
-      }
+    if (!IS_PPERM(f) || !IS_PPERM(g)) {
+        ErrorQuit("usage: the arguments must be partial perms,", 0L, 0L);
     }
-  } else {
-    ptf4=ADDR_PPERM4(f);
-    if(TNUM_OBJ(g)==T_PPERM2){
-      ptg2=ADDR_PPERM2(g);
-      for(i=1;i<=rankf;i++){
-        j=INT_INTOBJ(ELM_PLIST(domf, i))-1;
-        k=INT_INTOBJ(ELM_PLIST(domg, i))-1;
-        if(j!=k) return (j<k?True:False);
-        if(ptf4[j]!=ptg2[j]) return (ptf4[j]<ptg2[j]?True:False);
-      }
-    } else {
-      ptg4=ADDR_PPERM4(g);
-      for(i=1;i<=rankf;i++){
-        j=INT_INTOBJ(ELM_PLIST(domf, i))-1;
-        k=INT_INTOBJ(ELM_PLIST(domg, i))-1;
-        if(j!=k) return (j<k?True:False);
-        if(ptf4[j]!=ptg4[j]) return (ptf4[j]<ptg4[j]?True:False);
-      }
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        if (DEG_PPERM2(f) == 0)
+            return True;
+        rankf = RANK_PPERM2(f);
+        domf = DOM_PPERM(f);
     }
-  }
+    else {
+        if (DEG_PPERM4(f) == 0)
+            return True;
+        rankf = RANK_PPERM4(f);
+        domf = DOM_PPERM(f);
+    }
 
-  return False;
+    if (TNUM_OBJ(g) == T_PPERM2) {
+        if (DEG_PPERM2(g) == 0)
+            return False;
+        rankg = RANK_PPERM2(g);
+        domg = DOM_PPERM(g);
+    }
+    else {
+        if (DEG_PPERM4(g) == 0)
+            return False;
+        rankg = RANK_PPERM4(g);
+        domg = DOM_PPERM(f);
+    }
+
+    if (rankf != rankg)
+        return (rankf < rankg ? True : False);
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        ptf2 = ADDR_PPERM2(f);
+        if (TNUM_OBJ(g) == T_PPERM2) {
+            ptg2 = ADDR_PPERM2(g);
+            for (i = 1; i <= rankf; i++) {
+                j = INT_INTOBJ(ELM_PLIST(domf, i)) - 1;
+                k = INT_INTOBJ(ELM_PLIST(domg, i)) - 1;
+                if (j != k)
+                    return (j < k ? True : False);
+                if (ptf2[j] != ptg2[j])
+                    return (ptf2[j] < ptg2[j] ? True : False);
+            }
+        }
+        else {
+            ptg4 = ADDR_PPERM4(g);
+            for (i = 1; i <= rankf; i++) {
+                j = INT_INTOBJ(ELM_PLIST(domf, i)) - 1;
+                k = INT_INTOBJ(ELM_PLIST(domg, i)) - 1;
+                if (j != k)
+                    return (j < k ? True : False);
+                if (ptf2[j] != ptg4[j])
+                    return (ptf2[j] < ptg4[j] ? True : False);
+            }
+        }
+    }
+    else {
+        ptf4 = ADDR_PPERM4(f);
+        if (TNUM_OBJ(g) == T_PPERM2) {
+            ptg2 = ADDR_PPERM2(g);
+            for (i = 1; i <= rankf; i++) {
+                j = INT_INTOBJ(ELM_PLIST(domf, i)) - 1;
+                k = INT_INTOBJ(ELM_PLIST(domg, i)) - 1;
+                if (j != k)
+                    return (j < k ? True : False);
+                if (ptf4[j] != ptg2[j])
+                    return (ptf4[j] < ptg2[j] ? True : False);
+            }
+        }
+        else {
+            ptg4 = ADDR_PPERM4(g);
+            for (i = 1; i <= rankf; i++) {
+                j = INT_INTOBJ(ELM_PLIST(domf, i)) - 1;
+                k = INT_INTOBJ(ELM_PLIST(domg, i)) - 1;
+                if (j != k)
+                    return (j < k ? True : False);
+                if (ptf4[j] != ptg4[j])
+                    return (ptf4[j] < ptg4[j] ? True : False);
+            }
+        }
+    }
+
+    return False;
 }
 
-Obj FuncHAS_DOM_PPERM( Obj self, Obj f ){
-  if(TNUM_OBJ(f)==T_PPERM2){
-    return (DOM_PPERM(f)==NULL?False:True);
-  } else if (TNUM_OBJ(f)==T_PPERM4){
-    return (DOM_PPERM(f)==NULL?False:True);
-  }
-  return Fail;
+Obj FuncHAS_DOM_PPERM(Obj self, Obj f)
+{
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        return (DOM_PPERM(f) == NULL ? False : True);
+    }
+    else if (TNUM_OBJ(f) == T_PPERM4) {
+        return (DOM_PPERM(f) == NULL ? False : True);
+    }
+    return Fail;
 }
 
-Obj FuncHAS_IMG_PPERM( Obj self, Obj f ){
-  if(TNUM_OBJ(f)==T_PPERM2){
-    return (IMG_PPERM(f)==NULL?False:True);
-  } else if (TNUM_OBJ(f)==T_PPERM4){
-    return (IMG_PPERM(f)==NULL?False:True);
-  }
-  return Fail;
+Obj FuncHAS_IMG_PPERM(Obj self, Obj f)
+{
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        return (IMG_PPERM(f) == NULL ? False : True);
+    }
+    else if (TNUM_OBJ(f) == T_PPERM4) {
+        return (IMG_PPERM(f) == NULL ? False : True);
+    }
+    return Fail;
 }
 
-/****************************************************************************/
+/**************************************************************************/
 
 /* GAP kernel functions */
 
-// an idempotent partial perm on the union of the domain and image 
-Obj OnePPerm( Obj f){
-  Obj     g, img, dom;
-  UInt    i, j, deg, rank;
-  UInt2   *ptg2;
-  UInt4   *ptg4;
+// an idempotent partial perm on the union of the domain and image
+Obj OnePPerm(Obj f)
+{
+    Obj     g, img, dom;
+    UInt    i, j, deg, rank;
+    UInt2 * ptg2;
+    UInt4 * ptg4;
 
-  if(TNUM_OBJ(f)==T_PPERM2){//this could be shortened
-    deg=MAX(DEG_PPERM2(f),CODEG_PPERM2(f));
-    rank=RANK_PPERM2(f);
-    dom=DOM_PPERM(f);
-    img=IMG_PPERM(f);
-  }else{
-    deg=MAX(DEG_PPERM4(f),CODEG_PPERM4(f));
-    rank=RANK_PPERM4(f);
-    dom=DOM_PPERM(f);
-    img=IMG_PPERM(f);
-  }
+    if (TNUM_OBJ(f) == T_PPERM2) {    // this could be shortened
+        deg = MAX(DEG_PPERM2(f), CODEG_PPERM2(f));
+        rank = RANK_PPERM2(f);
+        dom = DOM_PPERM(f);
+        img = IMG_PPERM(f);
+    }
+    else {
+        deg = MAX(DEG_PPERM4(f), CODEG_PPERM4(f));
+        rank = RANK_PPERM4(f);
+        dom = DOM_PPERM(f);
+        img = IMG_PPERM(f);
+    }
 
-  if(deg<65536){ 
-    g=NEW_PPERM2(deg);
-    ptg2=ADDR_PPERM2(g);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(img, i))-1;
-      ptg2[j]=j+1;
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptg2[j]=j+1;
+    if (deg < 65536) {
+        g = NEW_PPERM2(deg);
+        ptg2 = ADDR_PPERM2(g);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(img, i)) - 1;
+            ptg2[j] = j + 1;
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptg2[j] = j + 1;
+        }
+        CODEG_PPERM2(g) = deg;
     }
-    CODEG_PPERM2(g)=deg;
-  } else {
-    g=NEW_PPERM4(deg);
-    ptg4=ADDR_PPERM4(g);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(img, i))-1;
-      ptg4[j]=j+1;
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptg4[j]=j+1;
+    else {
+        g = NEW_PPERM4(deg);
+        ptg4 = ADDR_PPERM4(g);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(img, i)) - 1;
+            ptg4[j] = j + 1;
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptg4[j] = j + 1;
+        }
+        CODEG_PPERM4(g) = deg;
     }
-    CODEG_PPERM4(g)=deg;
-  }
-  return g;
+    return g;
 }
 
 // print a partial perm in disjoint cycle and chain notation
-Obj PrintPPerm2(Obj self, Obj f){
-  UInt    i, j, n, rank, k, deg; 
-  UInt4   *ptseen; 
-  UInt2   *ptf2;
-  Obj     dom, img;
-  
-  deg=DEG_PPERM2(f);
-  if(deg==0) Pr("<empty partial perm>", 0L, 0L);
-  
-  n=MAX(deg, CODEG_PPERM2(f));
-  ResizeTmpPPerm(n);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  for(i=0;i<n;i++) ptseen[i]=0; 
-  
-  rank=RANK_PPERM2(f);//finds dom and img too
-  dom=DOM_PPERM(f);
-  img=IMG_PPERM(f);
+Obj PrintPPerm2(Obj self, Obj f)
+{
+    UInt    i, j, n, rank, k, deg;
+    UInt4 * ptseen;
+    UInt2 * ptf2;
+    Obj     dom, img;
 
-  ptf2=ADDR_PPERM2(f);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  //find img(f)
-  for(i=1;i<=rank;i++) ptseen[INT_INTOBJ(ELM_PLIST(img, i))-1]=1;
-  
-  //find chains
-  for(i=1;i<=rank;i++){
-    j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-    if(ptseen[j]==0){
-      Pr("%>[%>%d%<", (Int) j+1, 0L);
-      ptseen[j]=2;
-      for(k=ptf2[j];(k<=deg&&ptf2[k-1]!=0);k=ptf2[k-1]){ 
-        Pr(",%>%d%<", (Int) k, 0L);
-        ptseen[k-1]=2;
-      }
-      ptseen[k-1]=2;
-      Pr(",%>%d%<%<]", (Int) k, 0L);
+    deg = DEG_PPERM2(f);
+    if (deg == 0)
+        Pr("<empty partial perm>", 0L, 0L);
+
+    n = MAX(deg, CODEG_PPERM2(f));
+    ResizeTmpPPerm(n);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+    for (i = 0; i < n; i++)
+        ptseen[i] = 0;
+
+    rank = RANK_PPERM2(f);    // finds dom and img too
+    dom = DOM_PPERM(f);
+    img = IMG_PPERM(f);
+
+    ptf2 = ADDR_PPERM2(f);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+    // find img(f)
+    for (i = 1; i <= rank; i++)
+        ptseen[INT_INTOBJ(ELM_PLIST(img, i)) - 1] = 1;
+
+    // find chains
+    for (i = 1; i <= rank; i++) {
+        j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+        if (ptseen[j] == 0) {
+            Pr("%>[%>%d%<", (Int)j + 1, 0L);
+            ptseen[j] = 2;
+            for (k = ptf2[j]; (k <= deg && ptf2[k - 1] != 0);
+                 k = ptf2[k - 1]) {
+                Pr(",%>%d%<", (Int)k, 0L);
+                ptseen[k - 1] = 2;
+            }
+            ptseen[k - 1] = 2;
+            Pr(",%>%d%<%<]", (Int)k, 0L);
+        }
     }
-  }
-  
-  //find cycles 
-  for(i=1;i<=rank;i++){
-    j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-    if(ptseen[j]==1){
-      Pr("%>(%>%d%<", (Int) j+1, 0L);
-      for(k=ptf2[j];k!=j+1;k=ptf2[k-1]){ 
-        Pr(",%>%d%<", (Int) k, 0L);
-        ptseen[k-1]=0;
-      }
-      Pr("%<)", 0L, 0L);
+
+    // find cycles
+    for (i = 1; i <= rank; i++) {
+        j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+        if (ptseen[j] == 1) {
+            Pr("%>(%>%d%<", (Int)j + 1, 0L);
+            for (k = ptf2[j]; k != j + 1; k = ptf2[k - 1]) {
+                Pr(",%>%d%<", (Int)k, 0L);
+                ptseen[k - 1] = 0;
+            }
+            Pr("%<)", 0L, 0L);
+        }
     }
-  }
-  return 0L;
+    return 0L;
 }
 
-Obj PrintPPerm4(Obj self, Obj f){
-  UInt    i, j, n, rank, k, deg; 
-  UInt4   *ptseen, *ptf4;
-  Obj     dom, img;
-  
-  deg=DEG_PPERM4(f);
-  if(deg==0) Pr("<empty partial perm>", 0L, 0L);
-  n=MAX(deg, CODEG_PPERM4(f));
-  ResizeTmpPPerm(n);
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  for(i=0;i<n;i++) ptseen[i]=0; 
-  
-  rank=RANK_PPERM4(f);//finds dom and img too
-  dom=DOM_PPERM(f);
-  img=IMG_PPERM(f);
+Obj PrintPPerm4(Obj self, Obj f)
+{
+    UInt   i, j, n, rank, k, deg;
+    UInt4 *ptseen, *ptf4;
+    Obj    dom, img;
 
-  ptseen=(UInt4*)(ADDR_OBJ(TmpPPerm));
-  ptf4=ADDR_PPERM4(f);
-  //find img(f)
-  for(i=1;i<=rank;i++) ptseen[INT_INTOBJ(ELM_PLIST(img, i))-1]=1;
-  
-  //find chains
-  for(i=1;i<=rank;i++){
-    j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-    if(ptseen[j]==0){
-      Pr("%>[%>%d%<", (Int) j+1, 0L);
-      ptseen[j]=2;
-      for(k=ptf4[j];(k<=deg&&ptf4[k-1]!=0);k=ptf4[k-1]){ 
-        Pr(",%>%d%<", (Int) k, 0L);
-        ptseen[k-1]=2;
-      }
-      ptseen[k-1]=2;
-      Pr(",%>%d%<%<]", (Int) k, 0L);
+    deg = DEG_PPERM4(f);
+    if (deg == 0)
+        Pr("<empty partial perm>", 0L, 0L);
+    n = MAX(deg, CODEG_PPERM4(f));
+    ResizeTmpPPerm(n);
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+    for (i = 0; i < n; i++)
+        ptseen[i] = 0;
+
+    rank = RANK_PPERM4(f);    // finds dom and img too
+    dom = DOM_PPERM(f);
+    img = IMG_PPERM(f);
+
+    ptseen = (UInt4 *)(ADDR_OBJ(TmpPPerm));
+    ptf4 = ADDR_PPERM4(f);
+    // find img(f)
+    for (i = 1; i <= rank; i++)
+        ptseen[INT_INTOBJ(ELM_PLIST(img, i)) - 1] = 1;
+
+    // find chains
+    for (i = 1; i <= rank; i++) {
+        j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+        if (ptseen[j] == 0) {
+            Pr("%>[%>%d%<", (Int)j + 1, 0L);
+            ptseen[j] = 2;
+            for (k = ptf4[j]; (k <= deg && ptf4[k - 1] != 0);
+                 k = ptf4[k - 1]) {
+                Pr(",%>%d%<", (Int)k, 0L);
+                ptseen[k - 1] = 2;
+            }
+            ptseen[k - 1] = 2;
+            Pr(",%>%d%<%<]", (Int)k, 0L);
+        }
     }
-  }
-  
-  //find cycles 
-  for(i=1;i<=rank;i++){
-    j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-    if(ptseen[j]==1){
-      Pr("%>(%>%d%<", (Int) j+1, 0L);
-      for(k=ptf4[j];k!=j+1;k=ptf4[k-1]){ 
-        Pr(",%>%d%<", (Int) k, 0L);
-        ptseen[k-1]=0;
-      }
-      Pr("%<)", 0L, 0L);
+
+    // find cycles
+    for (i = 1; i <= rank; i++) {
+        j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+        if (ptseen[j] == 1) {
+            Pr("%>(%>%d%<", (Int)j + 1, 0L);
+            for (k = ptf4[j]; k != j + 1; k = ptf4[k - 1]) {
+                Pr(",%>%d%<", (Int)k, 0L);
+                ptseen[k - 1] = 0;
+            }
+            Pr("%<)", 0L, 0L);
+        }
     }
-  }
-  return 0L;
+    return 0L;
 }
 
 /* equality for partial perms */
-Int EqPPerm22 (Obj f, Obj g){
-  UInt2*  ptf=ADDR_PPERM2(f);
-  UInt2*  ptg=ADDR_PPERM2(g);
-  UInt    deg=DEG_PPERM2(f);
-  UInt    i, j, rank;
-  Obj     dom;
+Int EqPPerm22(Obj f, Obj g)
+{
+    UInt2 * ptf = ADDR_PPERM2(f);
+    UInt2 * ptg = ADDR_PPERM2(g);
+    UInt    deg = DEG_PPERM2(f);
+    UInt    i, j, rank;
+    Obj     dom;
 
-  if(deg!=DEG_PPERM2(g)||CODEG_PPERM2(f)!=CODEG_PPERM2(g)) return 0L;
-     
-  if(DOM_PPERM(f)==NULL||DOM_PPERM(g)==NULL){ 
-    for(i=0;i<deg;i++) if(*ptf++!=*ptg++) return 0L;
-    return 1L;
-  }
+    if (deg != DEG_PPERM2(g) || CODEG_PPERM2(f) != CODEG_PPERM2(g))
+        return 0L;
 
-  if(RANK_PPERM2(f)!=RANK_PPERM2(g)) return 0L;
-  dom=DOM_PPERM(f);
-  rank=RANK_PPERM2(f);
-  
-  for(i=1;i<=rank;i++){
-    j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-    if(ptf[j]!=ptg[j]){
-      return 0L;
+    if (DOM_PPERM(f) == NULL || DOM_PPERM(g) == NULL) {
+        for (i = 0; i < deg; i++)
+            if (*ptf++ != *ptg++)
+                return 0L;
+        return 1L;
     }
-  }
-  return 1L;
+
+    if (RANK_PPERM2(f) != RANK_PPERM2(g))
+        return 0L;
+    dom = DOM_PPERM(f);
+    rank = RANK_PPERM2(f);
+
+    for (i = 1; i <= rank; i++) {
+        j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+        if (ptf[j] != ptg[j]) {
+            return 0L;
+        }
+    }
+    return 1L;
 }
 
-Int EqPPerm24 (Obj f, Obj g){
-  UInt2*  ptf=ADDR_PPERM2(f);
-  UInt4*  ptg=ADDR_PPERM4(g);
-  UInt    deg=DEG_PPERM2(f);
-  UInt    i, j, rank;
-  Obj     dom;
+Int EqPPerm24(Obj f, Obj g)
+{
+    UInt2 * ptf = ADDR_PPERM2(f);
+    UInt4 * ptg = ADDR_PPERM4(g);
+    UInt    deg = DEG_PPERM2(f);
+    UInt    i, j, rank;
+    Obj     dom;
 
-  if(deg!=DEG_PPERM4(g)||CODEG_PPERM2(f)!=CODEG_PPERM4(g)) return 0L;
-     
-  if(DOM_PPERM(f)==NULL||DOM_PPERM(g)==NULL){ 
-    for(i=0;i<deg;i++) if(*(ptf++)!=*(ptg++)) return 0L;
+    if (deg != DEG_PPERM4(g) || CODEG_PPERM2(f) != CODEG_PPERM4(g))
+        return 0L;
+
+    if (DOM_PPERM(f) == NULL || DOM_PPERM(g) == NULL) {
+        for (i = 0; i < deg; i++)
+            if (*(ptf++) != *(ptg++))
+                return 0L;
+        return 1L;
+    }
+
+    if (RANK_PPERM2(f) != RANK_PPERM4(g))
+        return 0L;
+    dom = DOM_PPERM(f);
+    rank = RANK_PPERM2(f);
+
+    for (i = 1; i <= rank; i++) {
+        j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+        if (ptf[j] != ptg[j])
+            return 0L;
+    }
     return 1L;
-  }
-
-  if(RANK_PPERM2(f)!=RANK_PPERM4(g)) return 0L;
-  dom=DOM_PPERM(f);
-  rank=RANK_PPERM2(f);
-  
-  for(i=1;i<=rank;i++){
-    j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-    if(ptf[j]!=ptg[j]) return 0L;
-  }
-  return 1L;
 }
 
-Int EqPPerm42 (Obj f, Obj g){
-  UInt4*  ptf=ADDR_PPERM4(f);
-  UInt2*  ptg=ADDR_PPERM2(g);
-  UInt    deg=DEG_PPERM4(f);
-  UInt    i, j, rank;
-  Obj     dom;
+Int EqPPerm42(Obj f, Obj g)
+{
+    UInt4 * ptf = ADDR_PPERM4(f);
+    UInt2 * ptg = ADDR_PPERM2(g);
+    UInt    deg = DEG_PPERM4(f);
+    UInt    i, j, rank;
+    Obj     dom;
 
-  if(deg!=DEG_PPERM2(g)||CODEG_PPERM4(f)!=CODEG_PPERM2(g)) return 0L;
-     
-  if(DOM_PPERM(f)==NULL||DOM_PPERM(g)==NULL){ 
-    for(i=0;i<deg;i++) if(*(ptf++)!=*(ptg++)) return 0L;
+    if (deg != DEG_PPERM2(g) || CODEG_PPERM4(f) != CODEG_PPERM2(g))
+        return 0L;
+
+    if (DOM_PPERM(f) == NULL || DOM_PPERM(g) == NULL) {
+        for (i = 0; i < deg; i++)
+            if (*(ptf++) != *(ptg++))
+                return 0L;
+        return 1L;
+    }
+
+    if (RANK_PPERM4(f) != RANK_PPERM2(g))
+        return 0L;
+    dom = DOM_PPERM(f);
+    rank = RANK_PPERM4(f);
+
+    for (i = 1; i <= rank; i++) {
+        j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+        if (ptf[j] != ptg[j])
+            return 0L;
+    }
     return 1L;
-  }
-
-  if(RANK_PPERM4(f)!=RANK_PPERM2(g)) return 0L;
-  dom=DOM_PPERM(f);
-  rank=RANK_PPERM4(f);
-  
-  for(i=1;i<=rank;i++){
-    j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-    if(ptf[j]!=ptg[j]) return 0L;
-  }
-  return 1L;
 }
 
-Int EqPPerm44 (Obj f, Obj g){
-  UInt4*  ptf=ADDR_PPERM4(f);
-  UInt4*  ptg=ADDR_PPERM4(g);
-  UInt    i, j, rank;
-  UInt    deg=DEG_PPERM4(f);
-  Obj     dom;
+Int EqPPerm44(Obj f, Obj g)
+{
+    UInt4 * ptf = ADDR_PPERM4(f);
+    UInt4 * ptg = ADDR_PPERM4(g);
+    UInt    i, j, rank;
+    UInt    deg = DEG_PPERM4(f);
+    Obj     dom;
 
-  if(deg!=DEG_PPERM4(g)||CODEG_PPERM4(f)!=CODEG_PPERM4(g)) return 0L;
-     
-  if(DOM_PPERM(f)==NULL||DOM_PPERM(g)==NULL){ 
-    for(i=0;i<deg;i++) if(*(ptf++)!=*(ptg++)) return 0L;
+    if (deg != DEG_PPERM4(g) || CODEG_PPERM4(f) != CODEG_PPERM4(g))
+        return 0L;
+
+    if (DOM_PPERM(f) == NULL || DOM_PPERM(g) == NULL) {
+        for (i = 0; i < deg; i++)
+            if (*(ptf++) != *(ptg++))
+                return 0L;
+        return 1L;
+    }
+
+    if (RANK_PPERM4(f) != RANK_PPERM4(g))
+        return 0L;
+    dom = DOM_PPERM(f);
+    rank = RANK_PPERM4(f);
+
+    for (i = 1; i <= rank; i++) {
+        j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+        if (ptf[j] != ptg[j])
+            return 0L;
+    }
     return 1L;
-  }
-
-  if(RANK_PPERM4(f)!=RANK_PPERM4(g)) return 0L;
-  dom=DOM_PPERM(f);
-  rank=RANK_PPERM4(f);
-  
-  for(i=1;i<=rank;i++){
-    j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-    if(ptf[j]!=ptg[j]) return 0L;
-  }
-  return 1L;
 }
 
 /* less than for partial perms */
 // beware this is different than it used to be...
-Int LtPPerm22(Obj f, Obj g){ 
-  UInt2*  ptf=ADDR_PPERM2(f);
-  UInt2*  ptg=ADDR_PPERM2(g);
-  UInt    deg, i;
+Int LtPPerm22(Obj f, Obj g)
+{
+    UInt2 * ptf = ADDR_PPERM2(f);
+    UInt2 * ptg = ADDR_PPERM2(g);
+    UInt    deg, i;
 
-  deg=DEG_PPERM2(f);
-  if(deg!=DEG_PPERM2(g)){
-    if(deg<DEG_PPERM2(g)){ 
-      return 1L; 
-    } else { 
-      return 0L; 
+    deg = DEG_PPERM2(f);
+    if (deg != DEG_PPERM2(g)) {
+        if (deg < DEG_PPERM2(g)) {
+            return 1L;
+        }
+        else {
+            return 0L;
+        }
     }
-  }
 
-  for(i=0;i<deg;i++){
-    if(*(ptf++)!=*(ptg++)){
-      if (*(--ptf)< *(--ptg)) return 1L;
-      else                    return 0L;
+    for (i = 0; i < deg; i++) {
+        if (*(ptf++) != *(ptg++)) {
+            if (*(--ptf) < *(--ptg))
+                return 1L;
+            else
+                return 0L;
+        }
     }
-  }
-  return 0L;
+    return 0L;
 }
 
-Int LtPPerm24(Obj f, Obj g){ 
-  UInt2*  ptf=ADDR_PPERM2(f);
-  UInt4*  ptg=ADDR_PPERM4(g);
-  UInt    deg, i;
+Int LtPPerm24(Obj f, Obj g)
+{
+    UInt2 * ptf = ADDR_PPERM2(f);
+    UInt4 * ptg = ADDR_PPERM4(g);
+    UInt    deg, i;
 
-  deg=DEG_PPERM2(f);
-  if(deg!=DEG_PPERM4(g)){
-    if(deg<DEG_PPERM4(g)){ 
-      return 1L; 
-    } else { 
-      return 0L; 
+    deg = DEG_PPERM2(f);
+    if (deg != DEG_PPERM4(g)) {
+        if (deg < DEG_PPERM4(g)) {
+            return 1L;
+        }
+        else {
+            return 0L;
+        }
     }
-  }
 
-  for(i=0;i<deg;i++){
-    if(*(ptf++)!=*(ptg++)){
-      if (*(--ptf)< *(--ptg)) return 1L;
-      else                    return 0L;
+    for (i = 0; i < deg; i++) {
+        if (*(ptf++) != *(ptg++)) {
+            if (*(--ptf) < *(--ptg))
+                return 1L;
+            else
+                return 0L;
+        }
     }
-  }
-  return 0L;
+    return 0L;
 }
 
-Int LtPPerm42(Obj f, Obj g){ 
-  UInt4*  ptf=ADDR_PPERM4(f);
-  UInt2*  ptg=ADDR_PPERM2(g);
-  UInt    deg, i;
+Int LtPPerm42(Obj f, Obj g)
+{
+    UInt4 * ptf = ADDR_PPERM4(f);
+    UInt2 * ptg = ADDR_PPERM2(g);
+    UInt    deg, i;
 
-  deg=DEG_PPERM4(f);
-  if(deg!=DEG_PPERM2(g)){
-    if(deg<DEG_PPERM2(g)){ 
-      return 1L; 
-    } else { 
-      return 0L; 
+    deg = DEG_PPERM4(f);
+    if (deg != DEG_PPERM2(g)) {
+        if (deg < DEG_PPERM2(g)) {
+            return 1L;
+        }
+        else {
+            return 0L;
+        }
     }
-  }
 
-  for(i=0;i<deg;i++){
-    if(*(ptf++)!=*(ptg++)){
-      if (*(--ptf)< *(--ptg)) return 1L;
-      else                    return 0L;
+    for (i = 0; i < deg; i++) {
+        if (*(ptf++) != *(ptg++)) {
+            if (*(--ptf) < *(--ptg))
+                return 1L;
+            else
+                return 0L;
+        }
     }
-  }
-  return 0L;
+    return 0L;
 }
 
-Int LtPPerm44(Obj f, Obj g){ 
-  UInt4*  ptf=ADDR_PPERM4(f);
-  UInt4*  ptg=ADDR_PPERM4(g);
-  UInt    deg, i;
+Int LtPPerm44(Obj f, Obj g)
+{
+    UInt4 * ptf = ADDR_PPERM4(f);
+    UInt4 * ptg = ADDR_PPERM4(g);
+    UInt    deg, i;
 
-  deg=DEG_PPERM4(f);
-  if(deg!=DEG_PPERM4(g)){
-    if(deg<DEG_PPERM4(g)){ 
-      return 1L; 
-    } else { 
-      return 0L; 
+    deg = DEG_PPERM4(f);
+    if (deg != DEG_PPERM4(g)) {
+        if (deg < DEG_PPERM4(g)) {
+            return 1L;
+        }
+        else {
+            return 0L;
+        }
     }
-  }
 
-  for(i=0;i<deg;i++){
-    if(*(ptf++)!=*(ptg++)){
-      if (*(--ptf)< *(--ptg)) return 1L;
-      else                    return 0L;
+    for (i = 0; i < deg; i++) {
+        if (*(ptf++) != *(ptg++)) {
+            if (*(--ptf) < *(--ptg))
+                return 1L;
+            else
+                return 0L;
+        }
     }
-  }
-  return 0L;
+    return 0L;
 }
 
 /* product of partial perm and partial perm */
-Obj ProdPPerm22(Obj f, Obj g){
-  UInt    deg, degg, i, j, rank; 
-  UInt2   *ptf, *ptg, *ptfg, codeg;
-  Obj     fg, dom;
+Obj ProdPPerm22(Obj f, Obj g)
+{
+    UInt   deg, degg, i, j, rank;
+    UInt2 *ptf, *ptg, *ptfg, codeg;
+    Obj    fg, dom;
 
-  if(DEG_PPERM2(g)==0) return EmptyPartialPerm;
+    if (DEG_PPERM2(g) == 0)
+        return EmptyPartialPerm;
 
-  // find the degree
-  deg=DEG_PPERM2(f);
-  degg=DEG_PPERM2(g);
-  ptf=ADDR_PPERM2(f);
-  ptg=ADDR_PPERM2(g);
-  while(deg>0&&(ptf[deg-1]==0||IMAGEPP(ptf[deg-1],ptg,degg)==0)) deg--;
-  if(deg==0) return EmptyPartialPerm;
-  
-  // create new pperm
-  fg=NEW_PPERM2(deg);
-  ptfg=ADDR_PPERM2(fg);
-  ptf=ADDR_PPERM2(f);
-  ptg=ADDR_PPERM2(g);
-  codeg=0;
- 
-  // compose in rank operations
-  if(DOM_PPERM(f)!=NULL){
-    dom=DOM_PPERM(f); 
-    rank=RANK_PPERM2(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(j<deg && ptf[j]<=degg){ 
-        ptfg[j]=ptg[ptf[j]-1];
-        if(ptfg[j]>codeg) codeg=ptfg[j];
-      }
+    // find the degree
+    deg = DEG_PPERM2(f);
+    degg = DEG_PPERM2(g);
+    ptf = ADDR_PPERM2(f);
+    ptg = ADDR_PPERM2(g);
+    while (deg > 0 &&
+           (ptf[deg - 1] == 0 || IMAGEPP(ptf[deg - 1], ptg, degg) == 0))
+        deg--;
+    if (deg == 0)
+        return EmptyPartialPerm;
+
+    // create new pperm
+    fg = NEW_PPERM2(deg);
+    ptfg = ADDR_PPERM2(fg);
+    ptf = ADDR_PPERM2(f);
+    ptg = ADDR_PPERM2(g);
+    codeg = 0;
+
+    // compose in rank operations
+    if (DOM_PPERM(f) != NULL) {
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM2(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (j < deg && ptf[j] <= degg) {
+                ptfg[j] = ptg[ptf[j] - 1];
+                if (ptfg[j] > codeg)
+                    codeg = ptfg[j];
+            }
+        }
     }
-  } else { 
-  // compose in deg operations
-    for(i=0;i<deg;i++){
-      //JDM could have additional case so that we don't have to check
-      //ptf[i]<=degg
-      if(ptf[i]!=0&&ptf[i]<=degg){
-        ptfg[i]=ptg[ptf[i]-1];
-        if(ptfg[i]>codeg) codeg=ptfg[i];
-      }
+    else {
+        // compose in deg operations
+        for (i = 0; i < deg; i++) {
+            // JDM could have additional case so that we don't have to check
+            // ptf[i]<=degg
+            if (ptf[i] != 0 && ptf[i] <= degg) {
+                ptfg[i] = ptg[ptf[i] - 1];
+                if (ptfg[i] > codeg)
+                    codeg = ptfg[i];
+            }
+        }
     }
-  }
-  CODEG_PPERM2(fg)=codeg;
-  return fg;
+    CODEG_PPERM2(fg) = codeg;
+    return fg;
 }
 
 // the product is always pperm2
-Obj ProdPPerm42(Obj f, Obj g){
-  UInt    deg, degg, i, j, rank;
-  UInt4   *ptf;
-  UInt2   *ptg, *ptfg, codeg;
-  Obj     fg, dom;
-  
-  if(DEG_PPERM2(g)==0) return EmptyPartialPerm;
+Obj ProdPPerm42(Obj f, Obj g)
+{
+    UInt    deg, degg, i, j, rank;
+    UInt4 * ptf;
+    UInt2 * ptg, *ptfg, codeg;
+    Obj     fg, dom;
 
-  // find the degree
-  deg=DEG_PPERM4(f);
-  degg=DEG_PPERM2(g);
-  ptf=ADDR_PPERM4(f);
-  ptg=ADDR_PPERM2(g);
-  while(deg>0&&(ptf[deg-1]==0||ptf[deg-1]>degg||ptg[ptf[deg-1]-1]==0)) deg--;
-  if(deg==0) return EmptyPartialPerm;
-  
-  // create new pperm
-  fg=NEW_PPERM2(deg);
-  ptfg=ADDR_PPERM2(fg);
-  ptf=ADDR_PPERM4(f);
-  ptg=ADDR_PPERM2(g);
-  codeg=0;
- 
-  // compose in rank operations
-  if(DOM_PPERM(f)!=NULL){
-    dom=DOM_PPERM(f); 
-    rank=RANK_PPERM4(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(j<deg && ptf[j]<=degg){ 
-        ptfg[j]=ptg[ptf[j]-1];
-        if(ptfg[j]>codeg) codeg=ptfg[j];
-      }
+    if (DEG_PPERM2(g) == 0)
+        return EmptyPartialPerm;
+
+    // find the degree
+    deg = DEG_PPERM4(f);
+    degg = DEG_PPERM2(g);
+    ptf = ADDR_PPERM4(f);
+    ptg = ADDR_PPERM2(g);
+    while (deg > 0 && (ptf[deg - 1] == 0 || ptf[deg - 1] > degg ||
+                       ptg[ptf[deg - 1] - 1] == 0))
+        deg--;
+    if (deg == 0)
+        return EmptyPartialPerm;
+
+    // create new pperm
+    fg = NEW_PPERM2(deg);
+    ptfg = ADDR_PPERM2(fg);
+    ptf = ADDR_PPERM4(f);
+    ptg = ADDR_PPERM2(g);
+    codeg = 0;
+
+    // compose in rank operations
+    if (DOM_PPERM(f) != NULL) {
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM4(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (j < deg && ptf[j] <= degg) {
+                ptfg[j] = ptg[ptf[j] - 1];
+                if (ptfg[j] > codeg)
+                    codeg = ptfg[j];
+            }
+        }
     }
-  } else { 
-  // compose in deg operations
-    for(i=0;i<deg;i++){
-      if(ptf[i]!=0&&ptf[i]<=degg){
-        ptfg[i]=ptg[ptf[i]-1];
-        if(ptfg[i]>codeg) codeg=ptfg[i];
-      }
+    else {
+        // compose in deg operations
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != 0 && ptf[i] <= degg) {
+                ptfg[i] = ptg[ptf[i] - 1];
+                if (ptfg[i] > codeg)
+                    codeg = ptfg[i];
+            }
+        }
     }
-  }
-  CODEG_PPERM2(fg)=codeg;
-  return fg;
+    CODEG_PPERM2(fg) = codeg;
+    return fg;
 }
 
-//it is possible that f*g could be represented as a PPERM2
-Obj ProdPPerm44(Obj f, Obj g){
-  UInt    deg, degg, codeg, i, j, rank; 
-  UInt4   *ptf, *ptg, *ptfg;
-  Obj     fg, dom;
+// it is possible that f*g could be represented as a PPERM2
+Obj ProdPPerm44(Obj f, Obj g)
+{
+    UInt   deg, degg, codeg, i, j, rank;
+    UInt4 *ptf, *ptg, *ptfg;
+    Obj    fg, dom;
 
-  if (DEG_PPERM4(g) == 0) { 
-    return EmptyPartialPerm;
-  }
+    if (DEG_PPERM4(g) == 0) {
+        return EmptyPartialPerm;
+    }
 
-  // find the degree
-  deg = DEG_PPERM4(f);
-  degg = DEG_PPERM4(g);
-  ptf = ADDR_PPERM4(f);
-  ptg = ADDR_PPERM4(g);
-  while (deg > 0 
-      && (ptf[deg - 1] == 0 || ptf[deg - 1] > degg || ptg[ptf[deg - 1] - 1] == 0)){
-    deg--;
-  }
-  
-  if(deg == 0){
-    return EmptyPartialPerm;
-  }
-  
-  // create new pperm
-  fg = NEW_PPERM4(deg);
-  ptfg = ADDR_PPERM4(fg);
-  ptf = ADDR_PPERM4(f);
-  ptg = ADDR_PPERM4(g);
-  codeg = 0;
- 
-  // compose in rank operations
-  if (DOM_PPERM(f) != NULL) {
-    dom = DOM_PPERM(f); 
-    rank = RANK_PPERM4(f);
-    for (i = 1; i <= rank; i++) {
-      j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-      if (j < deg && ptf[j] <= degg) { 
-        ptfg[j] = ptg[ptf[j] - 1];
-        if(ptfg[j] > codeg){
-          codeg = ptfg[j];
-        }
-      }
+    // find the degree
+    deg = DEG_PPERM4(f);
+    degg = DEG_PPERM4(g);
+    ptf = ADDR_PPERM4(f);
+    ptg = ADDR_PPERM4(g);
+    while (deg > 0 && (ptf[deg - 1] == 0 || ptf[deg - 1] > degg ||
+                       ptg[ptf[deg - 1] - 1] == 0)) {
+        deg--;
     }
-  } else { 
-  // compose in deg operations
-    for (i = 0; i < deg; i++) {
-      if (ptf[i] != 0 && ptf[i] <= degg) {
-        ptfg[i] = ptg[ptf[i] - 1];
-        if (ptfg[i] > codeg) {
-          codeg = ptfg[i];
-        }
-      }
+
+    if (deg == 0) {
+        return EmptyPartialPerm;
     }
-  }
-  CODEG_PPERM4(fg) = codeg;
-  return fg;
+
+    // create new pperm
+    fg = NEW_PPERM4(deg);
+    ptfg = ADDR_PPERM4(fg);
+    ptf = ADDR_PPERM4(f);
+    ptg = ADDR_PPERM4(g);
+    codeg = 0;
+
+    // compose in rank operations
+    if (DOM_PPERM(f) != NULL) {
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM4(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (j < deg && ptf[j] <= degg) {
+                ptfg[j] = ptg[ptf[j] - 1];
+                if (ptfg[j] > codeg) {
+                    codeg = ptfg[j];
+                }
+            }
+        }
+    }
+    else {
+        // compose in deg operations
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != 0 && ptf[i] <= degg) {
+                ptfg[i] = ptg[ptf[i] - 1];
+                if (ptfg[i] > codeg) {
+                    codeg = ptfg[i];
+                }
+            }
+        }
+    }
+    CODEG_PPERM4(fg) = codeg;
+    return fg;
 }
 
-//it is possible that f*g could be represented as a PPERM2
-Obj ProdPPerm24(Obj f, Obj g){
-  UInt    deg, degg, i, j, codeg, rank;
-  UInt2   *ptf;
-  UInt4   *ptg, *ptfg;
-  Obj     fg, dom;
+// it is possible that f*g could be represented as a PPERM2
+Obj ProdPPerm24(Obj f, Obj g)
+{
+    UInt    deg, degg, i, j, codeg, rank;
+    UInt2 * ptf;
+    UInt4 * ptg, *ptfg;
+    Obj     fg, dom;
 
-  if(DEG_PPERM4(g)==0) return EmptyPartialPerm;
+    if (DEG_PPERM4(g) == 0)
+        return EmptyPartialPerm;
 
-  // find the degree
-  deg=DEG_PPERM2(f);
-  degg=DEG_PPERM4(g);
-  ptf=ADDR_PPERM2(f);
-  ptg=ADDR_PPERM4(g);
+    // find the degree
+    deg = DEG_PPERM2(f);
+    degg = DEG_PPERM4(g);
+    ptf = ADDR_PPERM2(f);
+    ptg = ADDR_PPERM4(g);
 
-  if(CODEG_PPERM2(f)<=degg){
-    while(deg>0&&(ptf[deg-1]==0||ptg[ptf[deg-1]-1]==0)) deg--;
-  } else {
-    while(deg>0&&(ptf[deg-1]==0||IMAGEPP(ptf[deg-1], ptg, degg)==0)) deg--;
-  }
-  
-  if(deg==0) return EmptyPartialPerm;
-  
-  // create new pperm
-  fg=NEW_PPERM4(deg);
-  ptfg=ADDR_PPERM4(fg);
-  ptf=ADDR_PPERM2(f);
-  ptg=ADDR_PPERM4(g);
-  codeg=0;
- 
-  // compose in rank operations
-  if(DOM_PPERM(f)!=NULL){
-    dom=DOM_PPERM(f); 
-    rank=RANK_PPERM2(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(j<deg && ptf[j]<=degg){ 
-        ptfg[j]=ptg[ptf[j]-1];
-        if(ptfg[j]>codeg) codeg=ptfg[j];
-      }
+    if (CODEG_PPERM2(f) <= degg) {
+        while (deg > 0 && (ptf[deg - 1] == 0 || ptg[ptf[deg - 1] - 1] == 0))
+            deg--;
     }
-  } else { 
-  // compose in deg operations
-    for(i=0;i<deg;i++){
-      if(ptf[i]!=0&&ptf[i]<=degg){
-        ptfg[i]=ptg[ptf[i]-1];
-        if(ptfg[i]>codeg) codeg=ptfg[i];
-      }
+    else {
+        while (deg > 0 &&
+               (ptf[deg - 1] == 0 || IMAGEPP(ptf[deg - 1], ptg, degg) == 0))
+            deg--;
     }
-  }
-  CODEG_PPERM4(fg)=codeg;
-  return fg;
+
+    if (deg == 0)
+        return EmptyPartialPerm;
+
+    // create new pperm
+    fg = NEW_PPERM4(deg);
+    ptfg = ADDR_PPERM4(fg);
+    ptf = ADDR_PPERM2(f);
+    ptg = ADDR_PPERM4(g);
+    codeg = 0;
+
+    // compose in rank operations
+    if (DOM_PPERM(f) != NULL) {
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM2(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (j < deg && ptf[j] <= degg) {
+                ptfg[j] = ptg[ptf[j] - 1];
+                if (ptfg[j] > codeg)
+                    codeg = ptfg[j];
+            }
+        }
+    }
+    else {
+        // compose in deg operations
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != 0 && ptf[i] <= degg) {
+                ptfg[i] = ptg[ptf[i] - 1];
+                if (ptfg[i] > codeg)
+                    codeg = ptfg[i];
+            }
+        }
+    }
+    CODEG_PPERM4(fg) = codeg;
+    return fg;
 }
 
-// compose partial perms and perms 
-Obj ProdPPerm2Perm2( Obj f, Obj p){
-  UInt2   *ptf, *ptp, *ptfp2;
-  UInt4   *ptfp4;
-  Obj     fp, dom;
-  UInt    codeg, dep, deg, i, j, rank;
+// compose partial perms and perms
+Obj ProdPPerm2Perm2(Obj f, Obj p)
+{
+    UInt2 * ptf, *ptp, *ptfp2;
+    UInt4 * ptfp4;
+    Obj     fp, dom;
+    UInt    codeg, dep, deg, i, j, rank;
 
-  dep=DEG_PERM2(p);
-  deg=DEG_PPERM2(f);
-  
-  if(dep<65536){
-    fp=NEW_PPERM2(deg);
-  } else {// i.e. deg(p)=65536
-    fp=NEW_PPERM4(deg);
-  }
-  
-  codeg=CODEG_PPERM2(f);
-  ptf=ADDR_PPERM2(f);
-  ptp=ADDR_PERM2(p);
-  
-  if(dep<65536){
-    ptfp2=ADDR_PPERM2(fp);
-    if(codeg<=dep){
-      codeg=0;
-      if(DOM_PPERM(f)==NULL){
-        //Pr("Case 2\n", 0L, 0L);
-        for(i=0;i<deg;i++){ 
-          if(ptf[i]!=0){
-            ptfp2[i]=ptp[ptf[i]-1]+1;
-            if(ptfp2[i]>codeg) codeg=ptfp2[i];
-          }
-        }
-      } else {
-        //Pr("Case 1\n", 0L, 0L);
-        dom=DOM_PPERM(f);
-        rank=RANK_PPERM2(f);
-        for(i=1;i<=rank;i++){
-          j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-          ptfp2[j]=ptp[ptf[j]-1]+1;
-          if(ptfp2[j]>codeg) codeg=ptfp2[j];
-        }
-      }
-    } else {
-      if(DOM_PPERM(f)==NULL){
-       //Pr("Case 4\n", 0L, 0L);
-        for(i=0;i<deg;i++){
-          if(ptf[i]!=0){
-            ptfp2[i]=IMAGE(ptf[i]-1, ptp, dep)+1;
-          }
-        }
-      }else{
-        //Pr("Case 3\n", 0L, 0L);
-        dom=DOM_PPERM(f);
-        rank=RANK_PPERM2(f);
-        for(i=1;i<=rank;i++){
-          j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-          ptfp2[j]=IMAGE(ptf[j]-1, ptp, dep)+1;
-        }
-      }
+    dep = DEG_PERM2(p);
+    deg = DEG_PPERM2(f);
+
+    if (dep < 65536) {
+        fp = NEW_PPERM2(deg);
     }
-    CODEG_PPERM2(fp)=codeg;
-  } else {
-    ptfp4=ADDR_PPERM4(fp);
-    codeg=0;
-    if(DOM_PPERM(f)==NULL){
-      //Pr("Case 6\n", 0L, 0L);
-      for(i=0;i<deg;i++){
-        if(ptf[i]!=0){
-          ptfp4[i]=ptp[ptf[i]-1]+1;
-          if(ptfp4[i]>codeg) codeg=ptfp4[i];
-        }
-      }
-    } else {
-      //Pr("Case 5\n", 0L, 0L);
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM2(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptfp4[j]=ptp[ptf[j]-1]+1;
-        if(ptfp4[j]>codeg) codeg=ptfp4[j];
-      }
+    else {    // i.e. deg(p)=65536
+        fp = NEW_PPERM4(deg);
     }
-    CODEG_PPERM4(fp)=codeg;
-  }
-  return fp;
+
+    codeg = CODEG_PPERM2(f);
+    ptf = ADDR_PPERM2(f);
+    ptp = ADDR_PERM2(p);
+
+    if (dep < 65536) {
+        ptfp2 = ADDR_PPERM2(fp);
+        if (codeg <= dep) {
+            codeg = 0;
+            if (DOM_PPERM(f) == NULL) {
+                // Pr("Case 2\n", 0L, 0L);
+                for (i = 0; i < deg; i++) {
+                    if (ptf[i] != 0) {
+                        ptfp2[i] = ptp[ptf[i] - 1] + 1;
+                        if (ptfp2[i] > codeg)
+                            codeg = ptfp2[i];
+                    }
+                }
+            }
+            else {
+                // Pr("Case 1\n", 0L, 0L);
+                dom = DOM_PPERM(f);
+                rank = RANK_PPERM2(f);
+                for (i = 1; i <= rank; i++) {
+                    j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                    ptfp2[j] = ptp[ptf[j] - 1] + 1;
+                    if (ptfp2[j] > codeg)
+                        codeg = ptfp2[j];
+                }
+            }
+        }
+        else {
+            if (DOM_PPERM(f) == NULL) {
+                // Pr("Case 4\n", 0L, 0L);
+                for (i = 0; i < deg; i++) {
+                    if (ptf[i] != 0) {
+                        ptfp2[i] = IMAGE(ptf[i] - 1, ptp, dep) + 1;
+                    }
+                }
+            }
+            else {
+                // Pr("Case 3\n", 0L, 0L);
+                dom = DOM_PPERM(f);
+                rank = RANK_PPERM2(f);
+                for (i = 1; i <= rank; i++) {
+                    j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                    ptfp2[j] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
+                }
+            }
+        }
+        CODEG_PPERM2(fp) = codeg;
+    }
+    else {
+        ptfp4 = ADDR_PPERM4(fp);
+        codeg = 0;
+        if (DOM_PPERM(f) == NULL) {
+            // Pr("Case 6\n", 0L, 0L);
+            for (i = 0; i < deg; i++) {
+                if (ptf[i] != 0) {
+                    ptfp4[i] = ptp[ptf[i] - 1] + 1;
+                    if (ptfp4[i] > codeg)
+                        codeg = ptfp4[i];
+                }
+            }
+        }
+        else {
+            // Pr("Case 5\n", 0L, 0L);
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM2(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptfp4[j] = ptp[ptf[j] - 1] + 1;
+                if (ptfp4[j] > codeg)
+                    codeg = ptfp4[j];
+            }
+        }
+        CODEG_PPERM4(fp) = codeg;
+    }
+    return fp;
 }
 
-Obj ProdPPerm4Perm4( Obj f, Obj p){
-  UInt4   *ptf, *ptp, *ptfp;
-  Obj     fp, dom;
-  UInt    codeg, dep, deg, i, j, rank;
+Obj ProdPPerm4Perm4(Obj f, Obj p)
+{
+    UInt4 *ptf, *ptp, *ptfp;
+    Obj    fp, dom;
+    UInt   codeg, dep, deg, i, j, rank;
 
-  deg=DEG_PPERM4(f);
-  fp=NEW_PPERM4(deg);
-  
-  dep=DEG_PERM4(p);
-  codeg=CODEG_PPERM4(f);
-  
-  ptf=ADDR_PPERM4(f);
-  ptp=ADDR_PERM4(p);
-  ptfp=ADDR_PPERM4(fp);
-  
-  if(codeg<=dep){
-    codeg=0;
-    if(DOM_PPERM(f)==NULL){
-      //Pr("case 1\n", 0L, 0L);
-      for(i=0;i<deg;i++){ 
-        if(ptf[i]!=0){
-          ptfp[i]=ptp[ptf[i]-1]+1;
-          if(ptfp[i]>codeg) codeg=ptfp[i];
+    deg = DEG_PPERM4(f);
+    fp = NEW_PPERM4(deg);
+
+    dep = DEG_PERM4(p);
+    codeg = CODEG_PPERM4(f);
+
+    ptf = ADDR_PPERM4(f);
+    ptp = ADDR_PERM4(p);
+    ptfp = ADDR_PPERM4(fp);
+
+    if (codeg <= dep) {
+        codeg = 0;
+        if (DOM_PPERM(f) == NULL) {
+            // Pr("case 1\n", 0L, 0L);
+            for (i = 0; i < deg; i++) {
+                if (ptf[i] != 0) {
+                    ptfp[i] = ptp[ptf[i] - 1] + 1;
+                    if (ptfp[i] > codeg)
+                        codeg = ptfp[i];
+                }
+            }
         }
-      }
-    } else {
-      //Pr("case 2\n", 0L, 0L);
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptfp[j]=ptp[ptf[j]-1]+1;
-        if(ptfp[j]>codeg) codeg=ptfp[j];
-      }
-    }
-  } else {
-    if(DOM_PPERM(f)==NULL){
-      //Pr("case 3\n", 0L, 0L);
-      for(i=0;i<deg;i++){
-        if(ptf[i]!=0){
-          ptfp[i]=IMAGE(ptf[i]-1, ptp, dep)+1;
+        else {
+            // Pr("case 2\n", 0L, 0L);
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptfp[j] = ptp[ptf[j] - 1] + 1;
+                if (ptfp[j] > codeg)
+                    codeg = ptfp[j];
+            }
         }
-      }
-    }else{
-      //Pr("case 4\n", 0L, 0L);
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptfp[j]=IMAGE(ptf[j]-1, ptp, dep)+1;
-      }
     }
-  }
-  CODEG_PPERM4(fp)=codeg;
-  return fp;
+    else {
+        if (DOM_PPERM(f) == NULL) {
+            // Pr("case 3\n", 0L, 0L);
+            for (i = 0; i < deg; i++) {
+                if (ptf[i] != 0) {
+                    ptfp[i] = IMAGE(ptf[i] - 1, ptp, dep) + 1;
+                }
+            }
+        }
+        else {
+            // Pr("case 4\n", 0L, 0L);
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptfp[j] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
+            }
+        }
+    }
+    CODEG_PPERM4(fp) = codeg;
+    return fp;
 }
 
-Obj ProdPPerm2Perm4( Obj f, Obj p){
-  UInt2   *ptf; 
-  UInt4   *ptp, *ptfp;
-  Obj     fp, dom;
-  UInt    deg, codeg, i, j, rank;
+Obj ProdPPerm2Perm4(Obj f, Obj p)
+{
+    UInt2 * ptf;
+    UInt4 * ptp, *ptfp;
+    Obj     fp, dom;
+    UInt    deg, codeg, i, j, rank;
 
-  fp=NEW_PPERM4(DEG_PPERM2(f));
-  ptf=ADDR_PPERM2(f);
-  ptp=ADDR_PERM4(p);
-  ptfp=ADDR_PPERM4(fp);
-  codeg=0;
-  
-  if(DOM_PPERM(f)==NULL){
-    deg=DEG_PPERM2(f);
-    for(i=0;i<deg;i++){
-      if(ptf[i]!=0){
-        ptfp[i]=ptp[ptf[i]-1]+1;
-        if(ptfp[i]>codeg) codeg=ptfp[i];
-      }
+    fp = NEW_PPERM4(DEG_PPERM2(f));
+    ptf = ADDR_PPERM2(f);
+    ptp = ADDR_PERM4(p);
+    ptfp = ADDR_PPERM4(fp);
+    codeg = 0;
+
+    if (DOM_PPERM(f) == NULL) {
+        deg = DEG_PPERM2(f);
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != 0) {
+                ptfp[i] = ptp[ptf[i] - 1] + 1;
+                if (ptfp[i] > codeg)
+                    codeg = ptfp[i];
+            }
+        }
     }
-  } else {
-    dom=DOM_PPERM(f);
-    rank=RANK_PPERM2(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptfp[j]=ptp[ptf[j]-1]+1;
-      if(ptfp[j]>codeg) codeg=ptfp[j];
+    else {
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM2(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptfp[j] = ptp[ptf[j] - 1] + 1;
+            if (ptfp[j] > codeg)
+                codeg = ptfp[j];
+        }
     }
-  }
-  CODEG_PPERM4(fp)=codeg;
-  return fp;
+    CODEG_PPERM4(fp) = codeg;
+    return fp;
 }
 
-Obj ProdPPerm4Perm2( Obj f, Obj p){
-  UInt4   *ptf, *ptfp;
-  UInt2   *ptp, dep; 
-  Obj     fp, dom;
-  UInt    codeg, deg, i, j, rank;
+Obj ProdPPerm4Perm2(Obj f, Obj p)
+{
+    UInt4 *ptf, *ptfp;
+    UInt2 *ptp, dep;
+    Obj    fp, dom;
+    UInt   codeg, deg, i, j, rank;
 
-  deg=DEG_PPERM4(f);
-  fp=NEW_PPERM4(deg);
-  
-  dep=DEG_PERM2(p);
-  codeg=CODEG_PPERM4(f);
-  
-  ptf=ADDR_PPERM4(f);
-  ptp=ADDR_PERM2(p);
-  ptfp=ADDR_PPERM4(fp);
-  
-  if(DOM_PPERM(f)==NULL){
-    //Pr("case 1\n", 0L, 0L);
-    for(i=0;i<deg;i++){
-      if(ptf[i]!=0){
-        ptfp[i]=IMAGE(ptf[i]-1, ptp, dep)+1;
-      }
+    deg = DEG_PPERM4(f);
+    fp = NEW_PPERM4(deg);
+
+    dep = DEG_PERM2(p);
+    codeg = CODEG_PPERM4(f);
+
+    ptf = ADDR_PPERM4(f);
+    ptp = ADDR_PERM2(p);
+    ptfp = ADDR_PPERM4(fp);
+
+    if (DOM_PPERM(f) == NULL) {
+        // Pr("case 1\n", 0L, 0L);
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != 0) {
+                ptfp[i] = IMAGE(ptf[i] - 1, ptp, dep) + 1;
+            }
+        }
     }
-  }else{
-    //Pr("case 2\n", 0L, 0L);
-    dom=DOM_PPERM(f);
-    rank=RANK_PPERM4(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptfp[j]=IMAGE(ptf[j]-1, ptp, dep)+1;
+    else {
+        // Pr("case 2\n", 0L, 0L);
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM4(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptfp[j] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
+        }
     }
-  }
-  CODEG_PPERM4(fp)=codeg;
-  return fp;
+    CODEG_PPERM4(fp) = codeg;
+    return fp;
 }
 
 // product of a perm and a partial perm
-Obj ProdPerm2PPerm2( Obj p, Obj f){
-  UInt2   deg, *ptp, *ptf, *ptpf;
-  UInt    degf, i;
-  Obj     pf;
+Obj ProdPerm2PPerm2(Obj p, Obj f)
+{
+    UInt2 deg, *ptp, *ptf, *ptpf;
+    UInt  degf, i;
+    Obj   pf;
 
-  if(DEG_PPERM2(f)==0) return EmptyPartialPerm;
+    if (DEG_PPERM2(f) == 0)
+        return EmptyPartialPerm;
 
-  deg=DEG_PERM2(p);
-  degf=DEG_PPERM2(f);
-  
-  if(deg<degf){
-    //Pr("case 1\n", 0L, 0L);
-    pf=NEW_PPERM2(degf);
-    ptpf=ADDR_PPERM2(pf);
-    ptp=ADDR_PERM2(p);
-    ptf=ADDR_PPERM2(f);
-    for(i=0;i<deg;i++) *ptpf++=ptf[*ptp++];
-    for(;i<degf;i++) *ptpf++=ptf[i];
-  } else { // deg(f)<=deg(p)
-    //Pr("case 2\n", 0L, 0L);
-    //find the degree
-    ptp=ADDR_PERM2(p);
-    ptf=ADDR_PPERM2(f);
-    while(ptp[deg-1]>=degf||ptf[ptp[deg-1]]==0) deg--;
-    pf=NEW_PPERM2(deg);
-    ptpf=ADDR_PPERM2(pf);
-    ptp=ADDR_PERM2(p);
-    ptf=ADDR_PPERM2(f);
-    for(i=0;i<deg;i++) if(ptp[i]<degf) ptpf[i]=ptf[ptp[i]];
-  }
-  CODEG_PPERM2(pf)=CODEG_PPERM2(f);
-  return pf;
+    deg = DEG_PERM2(p);
+    degf = DEG_PPERM2(f);
+
+    if (deg < degf) {
+        // Pr("case 1\n", 0L, 0L);
+        pf = NEW_PPERM2(degf);
+        ptpf = ADDR_PPERM2(pf);
+        ptp = ADDR_PERM2(p);
+        ptf = ADDR_PPERM2(f);
+        for (i = 0; i < deg; i++)
+            *ptpf++ = ptf[*ptp++];
+        for (; i < degf; i++)
+            *ptpf++ = ptf[i];
+    }
+    else {    // deg(f)<=deg(p)
+        // Pr("case 2\n", 0L, 0L);
+        // find the degree
+        ptp = ADDR_PERM2(p);
+        ptf = ADDR_PPERM2(f);
+        while (ptp[deg - 1] >= degf || ptf[ptp[deg - 1]] == 0)
+            deg--;
+        pf = NEW_PPERM2(deg);
+        ptpf = ADDR_PPERM2(pf);
+        ptp = ADDR_PERM2(p);
+        ptf = ADDR_PPERM2(f);
+        for (i = 0; i < deg; i++)
+            if (ptp[i] < degf)
+                ptpf[i] = ptf[ptp[i]];
+    }
+    CODEG_PPERM2(pf) = CODEG_PPERM2(f);
+    return pf;
 }
 
-Obj ProdPerm4PPerm4( Obj p, Obj f){
-  UInt4   deg, *ptp, *ptf, *ptpf;
-  UInt    degf, i;
-  Obj     pf;
+Obj ProdPerm4PPerm4(Obj p, Obj f)
+{
+    UInt4 deg, *ptp, *ptf, *ptpf;
+    UInt  degf, i;
+    Obj   pf;
 
-  if(DEG_PPERM4(f)==0) return EmptyPartialPerm;
+    if (DEG_PPERM4(f) == 0)
+        return EmptyPartialPerm;
 
-  deg=DEG_PERM4(p);
-  degf=DEG_PPERM4(f);
-  
-  if(deg<degf){
-    //Pr("case 1\n", 0L, 0L);
-    pf=NEW_PPERM4(degf);
-    ptpf=ADDR_PPERM4(pf);
-    ptp=ADDR_PERM4(p);
-    ptf=ADDR_PPERM4(f);
-    for(i=0;i<deg;i++) *ptpf++=ptf[*ptp++];
-    for(;i<degf;i++) *ptpf++=ptf[i];
-  } else { // deg(f)<deg(p)
-    //Pr("case 2\n", 0L, 0L);
-    //fin the degree
-    ptp=ADDR_PERM4(p);
-    ptf=ADDR_PPERM4(f);
-    while(ptp[deg-1]>=degf||ptf[ptp[deg-1]]==0) deg--;
-    pf=NEW_PPERM4(deg);
-    ptpf=ADDR_PPERM4(pf);
-    ptp=ADDR_PERM4(p);
-    ptf=ADDR_PPERM4(f);
-    for(i=0;i<deg;i++) if(ptp[i]<degf) ptpf[i]=ptf[ptp[i]];
-  }
-  CODEG_PPERM4(pf)=CODEG_PPERM4(f);
-  return pf;
+    deg = DEG_PERM4(p);
+    degf = DEG_PPERM4(f);
+
+    if (deg < degf) {
+        // Pr("case 1\n", 0L, 0L);
+        pf = NEW_PPERM4(degf);
+        ptpf = ADDR_PPERM4(pf);
+        ptp = ADDR_PERM4(p);
+        ptf = ADDR_PPERM4(f);
+        for (i = 0; i < deg; i++)
+            *ptpf++ = ptf[*ptp++];
+        for (; i < degf; i++)
+            *ptpf++ = ptf[i];
+    }
+    else {    // deg(f)<deg(p)
+        // Pr("case 2\n", 0L, 0L);
+        // fin the degree
+        ptp = ADDR_PERM4(p);
+        ptf = ADDR_PPERM4(f);
+        while (ptp[deg - 1] >= degf || ptf[ptp[deg - 1]] == 0)
+            deg--;
+        pf = NEW_PPERM4(deg);
+        ptpf = ADDR_PPERM4(pf);
+        ptp = ADDR_PERM4(p);
+        ptf = ADDR_PPERM4(f);
+        for (i = 0; i < deg; i++)
+            if (ptp[i] < degf)
+                ptpf[i] = ptf[ptp[i]];
+    }
+    CODEG_PPERM4(pf) = CODEG_PPERM4(f);
+    return pf;
 }
 
-Obj ProdPerm4PPerm2( Obj p, Obj f){
-  UInt4   deg, *ptp;
-  UInt2   *ptf, *ptpf;
-  UInt    degf, i;
-  Obj     pf;
-  
-  if(DEG_PPERM2(f)==0) return EmptyPartialPerm;
+Obj ProdPerm4PPerm2(Obj p, Obj f)
+{
+    UInt4  deg, *ptp;
+    UInt2 *ptf, *ptpf;
+    UInt   degf, i;
+    Obj    pf;
 
-  deg=DEG_PERM4(p);
-  degf=DEG_PPERM2(f);
-  if(deg<degf){
-    //Pr("case 1\n", 0L, 0L);
-    pf=NEW_PPERM2(degf);
-    ptpf=ADDR_PPERM2(pf);
-    ptp=ADDR_PERM4(p);
-    ptf=ADDR_PPERM2(f);
-    for(i=0;i<deg;i++) *ptpf++=ptf[*ptp++];
-    for(;i<degf;i++) *ptpf++=ptf[i];
-  } else { // deg(f)<=deg(p)
-    //Pr("case 2\n", 0L, 0L);
-    //find the degree
-    ptp=ADDR_PERM4(p);
-    ptf=ADDR_PPERM2(f);
-    while(ptp[deg-1]>=degf||ptf[ptp[deg-1]]==0) deg--;
-    pf=NEW_PPERM2(deg);
-    ptp=ADDR_PERM4(p);
-    ptf=ADDR_PPERM2(f);
-    ptpf=ADDR_PPERM2(pf);
-    for(i=0;i<deg;i++) if(ptp[i]<degf) ptpf[i]=ptf[ptp[i]];
-  }
-  
-  CODEG_PPERM2(pf)=CODEG_PPERM2(f);
-  return pf;
+    if (DEG_PPERM2(f) == 0)
+        return EmptyPartialPerm;
+
+    deg = DEG_PERM4(p);
+    degf = DEG_PPERM2(f);
+    if (deg < degf) {
+        // Pr("case 1\n", 0L, 0L);
+        pf = NEW_PPERM2(degf);
+        ptpf = ADDR_PPERM2(pf);
+        ptp = ADDR_PERM4(p);
+        ptf = ADDR_PPERM2(f);
+        for (i = 0; i < deg; i++)
+            *ptpf++ = ptf[*ptp++];
+        for (; i < degf; i++)
+            *ptpf++ = ptf[i];
+    }
+    else {    // deg(f)<=deg(p)
+        // Pr("case 2\n", 0L, 0L);
+        // find the degree
+        ptp = ADDR_PERM4(p);
+        ptf = ADDR_PPERM2(f);
+        while (ptp[deg - 1] >= degf || ptf[ptp[deg - 1]] == 0)
+            deg--;
+        pf = NEW_PPERM2(deg);
+        ptp = ADDR_PERM4(p);
+        ptf = ADDR_PPERM2(f);
+        ptpf = ADDR_PPERM2(pf);
+        for (i = 0; i < deg; i++)
+            if (ptp[i] < degf)
+                ptpf[i] = ptf[ptp[i]];
+    }
+
+    CODEG_PPERM2(pf) = CODEG_PPERM2(f);
+    return pf;
 }
 
-Obj ProdPerm2PPerm4( Obj p, Obj f){
-  UInt2   *ptp;
-  UInt4   *ptf, *ptpf;
-  UInt    deg, degf, i;
-  Obj     pf;
-  
-  if(DEG_PPERM4(f)==0) return EmptyPartialPerm;
+Obj ProdPerm2PPerm4(Obj p, Obj f)
+{
+    UInt2 * ptp;
+    UInt4 * ptf, *ptpf;
+    UInt    deg, degf, i;
+    Obj     pf;
 
-  deg=DEG_PERM2(p);
-  degf=DEG_PPERM4(f);
-  if(deg<degf){
-    //Pr("case 1\n", 0L, 0L);
-    pf=NEW_PPERM4(degf);
-    ptpf=ADDR_PPERM4(pf);
-    ptp=ADDR_PERM2(p);
-    ptf=ADDR_PPERM4(f);
-    for(i=0;i<deg;i++) *ptpf++=ptf[*ptp++];
-    for(;i<degf;i++) *ptpf++=ptf[i];
-  } else { // deg(f)<deg(p)
-    //Pr("case 2\n", 0L, 0L);
-    //find the degree
-    ptp=ADDR_PERM2(p);
-    ptf=ADDR_PPERM4(f);
-    while(ptp[deg-1]>=degf||ptf[ptp[deg-1]]==0) deg--;
-    pf=NEW_PPERM4(deg);
-    ptpf=ADDR_PPERM4(pf);
-    ptp=ADDR_PERM2(p);
-    ptf=ADDR_PPERM4(f);
-    for(i=0;i<deg;i++) if(ptp[i]<degf) ptpf[i]=ptf[ptp[i]];
-  }
-  
-  CODEG_PPERM4(pf)=CODEG_PPERM4(f);
-  return pf;
+    if (DEG_PPERM4(f) == 0)
+        return EmptyPartialPerm;
+
+    deg = DEG_PERM2(p);
+    degf = DEG_PPERM4(f);
+    if (deg < degf) {
+        // Pr("case 1\n", 0L, 0L);
+        pf = NEW_PPERM4(degf);
+        ptpf = ADDR_PPERM4(pf);
+        ptp = ADDR_PERM2(p);
+        ptf = ADDR_PPERM4(f);
+        for (i = 0; i < deg; i++)
+            *ptpf++ = ptf[*ptp++];
+        for (; i < degf; i++)
+            *ptpf++ = ptf[i];
+    }
+    else {    // deg(f)<deg(p)
+        // Pr("case 2\n", 0L, 0L);
+        // find the degree
+        ptp = ADDR_PERM2(p);
+        ptf = ADDR_PPERM4(f);
+        while (ptp[deg - 1] >= degf || ptf[ptp[deg - 1]] == 0)
+            deg--;
+        pf = NEW_PPERM4(deg);
+        ptpf = ADDR_PPERM4(pf);
+        ptp = ADDR_PERM2(p);
+        ptf = ADDR_PPERM4(f);
+        for (i = 0; i < deg; i++)
+            if (ptp[i] < degf)
+                ptpf[i] = ptf[ptp[i]];
+    }
+
+    CODEG_PPERM4(pf) = CODEG_PPERM4(f);
+    return pf;
 }
 
-//the inverse of a partial perm
-Obj InvPPerm2 (Obj f){
-  UInt    deg, codeg, i, j, rank;
-  UInt2   *ptf, *ptinv2;
-  UInt4   *ptinv4;
-  Obj     inv, dom;
+// the inverse of a partial perm
+Obj InvPPerm2(Obj f)
+{
+    UInt    deg, codeg, i, j, rank;
+    UInt2 * ptf, *ptinv2;
+    UInt4 * ptinv4;
+    Obj     inv, dom;
 
-  deg=DEG_PPERM2(f);
-  codeg=CODEG_PPERM2(f);
+    deg = DEG_PPERM2(f);
+    codeg = CODEG_PPERM2(f);
 
-  if(deg<65536){
-    inv=NEW_PPERM2(codeg);
-    ptf=ADDR_PPERM2(f);
-    ptinv2=ADDR_PPERM2(inv);
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<deg;i++) if(ptf[i]!=0) ptinv2[ptf[i]-1]=i+1;
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM2(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptinv2[ptf[j]-1]=j+1;
-      }
+    if (deg < 65536) {
+        inv = NEW_PPERM2(codeg);
+        ptf = ADDR_PPERM2(f);
+        ptinv2 = ADDR_PPERM2(inv);
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < deg; i++)
+                if (ptf[i] != 0)
+                    ptinv2[ptf[i] - 1] = i + 1;
+        }
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM2(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptinv2[ptf[j] - 1] = j + 1;
+            }
+        }
+        CODEG_PPERM2(inv) = deg;
     }
-    CODEG_PPERM2(inv)=deg;
-  } else { 
-    inv=NEW_PPERM4(codeg);
-    ptf=ADDR_PPERM2(f);
-    ptinv4=ADDR_PPERM4(inv);
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<deg;i++) if(ptf[i]!=0) ptinv4[ptf[i]-1]=i+1;
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM2(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptinv4[ptf[j]-1]=j+1;
-      }
+    else {
+        inv = NEW_PPERM4(codeg);
+        ptf = ADDR_PPERM2(f);
+        ptinv4 = ADDR_PPERM4(inv);
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < deg; i++)
+                if (ptf[i] != 0)
+                    ptinv4[ptf[i] - 1] = i + 1;
+        }
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM2(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptinv4[ptf[j] - 1] = j + 1;
+            }
+        }
+        CODEG_PPERM4(inv) = deg;
     }
-    CODEG_PPERM4(inv)=deg;
-  }
-  return inv;
-}      
+    return inv;
+}
 
-Obj InvPPerm4 (Obj f){
-  UInt    deg, codeg, i, j, rank;
-  UInt2   *ptinv2;
-  UInt4   *ptf, *ptinv4;
-  Obj     inv, dom;
+Obj InvPPerm4(Obj f)
+{
+    UInt    deg, codeg, i, j, rank;
+    UInt2 * ptinv2;
+    UInt4 * ptf, *ptinv4;
+    Obj     inv, dom;
 
-  deg=DEG_PPERM4(f);
-  codeg=CODEG_PPERM4(f);
+    deg = DEG_PPERM4(f);
+    codeg = CODEG_PPERM4(f);
 
-  if(deg<65536){
-    inv=NEW_PPERM2(codeg);
-    ptf=ADDR_PPERM4(f);
-    ptinv2=ADDR_PPERM2(inv);
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<deg;i++) if(ptf[i]!=0) ptinv2[ptf[i]-1]=i+1;
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptinv2[ptf[j]-1]=j+1;
-      }
+    if (deg < 65536) {
+        inv = NEW_PPERM2(codeg);
+        ptf = ADDR_PPERM4(f);
+        ptinv2 = ADDR_PPERM2(inv);
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < deg; i++)
+                if (ptf[i] != 0)
+                    ptinv2[ptf[i] - 1] = i + 1;
+        }
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptinv2[ptf[j] - 1] = j + 1;
+            }
+        }
+        CODEG_PPERM2(inv) = deg;
     }
-    CODEG_PPERM2(inv)=deg;
-  } else { 
-    inv=NEW_PPERM4(codeg);
-    ptf=ADDR_PPERM4(f);
-    ptinv4=ADDR_PPERM4(inv);
-    if(DOM_PPERM(f)==NULL){
-      for(i=0;i<deg;i++) if(ptf[i]!=0) ptinv4[ptf[i]-1]=i+1;
-    } else {
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptinv4[ptf[j]-1]=j+1;
-      }
+    else {
+        inv = NEW_PPERM4(codeg);
+        ptf = ADDR_PPERM4(f);
+        ptinv4 = ADDR_PPERM4(inv);
+        if (DOM_PPERM(f) == NULL) {
+            for (i = 0; i < deg; i++)
+                if (ptf[i] != 0)
+                    ptinv4[ptf[i] - 1] = i + 1;
+        }
+        else {
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptinv4[ptf[j] - 1] = j + 1;
+            }
+        }
+        CODEG_PPERM4(inv) = deg;
     }
-    CODEG_PPERM4(inv)=deg;
-  }
-  return inv;
-}      
+    return inv;
+}
 
-//Conjugation: p^-1*f*p
-// lose the assumption that dom is known and renovate as per LquoPermPPerm 
+// Conjugation: p^-1*f*p
+// lose the assumption that dom is known and renovate as per LquoPermPPerm
 // JDM
-Obj PowPPerm2Perm2(Obj f, Obj p){
-  UInt    deg, rank, degconj, i, j, k, codeg; 
-  UInt2   *ptf, *ptp, *ptconj, dep;
-  Obj     conj, dom;
+Obj PowPPerm2Perm2(Obj f, Obj p)
+{
+    UInt   deg, rank, degconj, i, j, k, codeg;
+    UInt2 *ptf, *ptp, *ptconj, dep;
+    Obj    conj, dom;
 
-  deg=DEG_PPERM2(f);
-  if(deg==0) return EmptyPartialPerm;
-  
-  dep=DEG_PERM2(p); 
-  rank=RANK_PPERM2(f);
-  ptp=ADDR_PERM2(p);
-  dom=DOM_PPERM(f); 
-  
-  //find deg of conjugate
-  if(deg>dep){
-    degconj=deg;
-  } else {
-    degconj=0;
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptp[j]>=degconj) degconj=ptp[j]+1;
-    }
-  }
-  
-  conj=NEW_PPERM2(degconj);
-  ptconj=ADDR_PPERM2(conj);
-  ptp=ADDR_PERM2(p);
-  ptf=ADDR_PPERM2(f);
-  codeg=CODEG_PPERM2(f);
+    deg = DEG_PPERM2(f);
+    if (deg == 0)
+        return EmptyPartialPerm;
 
-  if(codeg>dep){
-    CODEG_PPERM2(conj)=codeg;
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptconj[IMAGE(j, ptp, dep)]=IMAGE(ptf[j]-1, ptp, dep)+1;
-    }
-  } else {
-    codeg=0;
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      k=ptp[ptf[j]-1]+1;
-      ptconj[IMAGE(j, ptp, dep)]=k;
-      if(k>codeg) codeg=k;
-    }
-    CODEG_PPERM2(conj)=codeg;
-  }
+    dep = DEG_PERM2(p);
+    rank = RANK_PPERM2(f);
+    ptp = ADDR_PERM2(p);
+    dom = DOM_PPERM(f);
 
-  return conj;
+    // find deg of conjugate
+    if (deg > dep) {
+        degconj = deg;
+    }
+    else {
+        degconj = 0;
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptp[j] >= degconj)
+                degconj = ptp[j] + 1;
+        }
+    }
+
+    conj = NEW_PPERM2(degconj);
+    ptconj = ADDR_PPERM2(conj);
+    ptp = ADDR_PERM2(p);
+    ptf = ADDR_PPERM2(f);
+    codeg = CODEG_PPERM2(f);
+
+    if (codeg > dep) {
+        CODEG_PPERM2(conj) = codeg;
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptconj[IMAGE(j, ptp, dep)] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
+        }
+    }
+    else {
+        codeg = 0;
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            k = ptp[ptf[j] - 1] + 1;
+            ptconj[IMAGE(j, ptp, dep)] = k;
+            if (k > codeg)
+                codeg = k;
+        }
+        CODEG_PPERM2(conj) = codeg;
+    }
+
+    return conj;
 }
 
-Obj PowPPerm2Perm4(Obj f, Obj p){
-  UInt    deg, rank, degconj, i, j, k, codeg; 
-  UInt2   *ptf;
-  UInt4   *ptp, *ptconj, dep;
-  Obj     conj, dom;
+Obj PowPPerm2Perm4(Obj f, Obj p)
+{
+    UInt    deg, rank, degconj, i, j, k, codeg;
+    UInt2 * ptf;
+    UInt4 * ptp, *ptconj, dep;
+    Obj     conj, dom;
 
-  deg=DEG_PPERM2(f);
-  if(deg==0) return EmptyPartialPerm;
-  
-  dep=DEG_PERM4(p); 
-  rank=RANK_PPERM2(f);
-  ptp=ADDR_PERM4(p);
-  dom=DOM_PPERM(f); 
-  //find deg of conjugate
-  if(deg>dep){
-    degconj=deg;
-  } else {
-    degconj=0;
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptp[j]>=degconj) degconj=ptp[j]+1;
+    deg = DEG_PPERM2(f);
+    if (deg == 0)
+        return EmptyPartialPerm;
+
+    dep = DEG_PERM4(p);
+    rank = RANK_PPERM2(f);
+    ptp = ADDR_PERM4(p);
+    dom = DOM_PPERM(f);
+    // find deg of conjugate
+    if (deg > dep) {
+        degconj = deg;
     }
-  }
-  
-  conj=NEW_PPERM4(degconj);
-  ptconj=ADDR_PPERM4(conj);
-  ptp=ADDR_PERM4(p);
-  ptf=ADDR_PPERM2(f);
-  codeg=0;
+    else {
+        degconj = 0;
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptp[j] >= degconj)
+                degconj = ptp[j] + 1;
+        }
+    }
 
-  for(i=1;i<=rank;i++){
-    j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-    k=ptp[ptf[j]-1]+1;
-    ptconj[IMAGE(j, ptp, dep)]=k;
-    if(k>codeg) codeg=k;
-  }
-  CODEG_PPERM4(conj)=codeg;
+    conj = NEW_PPERM4(degconj);
+    ptconj = ADDR_PPERM4(conj);
+    ptp = ADDR_PERM4(p);
+    ptf = ADDR_PPERM2(f);
+    codeg = 0;
 
-  return conj;
+    for (i = 1; i <= rank; i++) {
+        j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+        k = ptp[ptf[j] - 1] + 1;
+        ptconj[IMAGE(j, ptp, dep)] = k;
+        if (k > codeg)
+            codeg = k;
+    }
+    CODEG_PPERM4(conj) = codeg;
+
+    return conj;
 }
 
-Obj PowPPerm4Perm2(Obj f, Obj p){
-  UInt    deg, rank, degconj, i, j, k, codeg; 
-  UInt4   *ptf, *ptconj, dep;
-  UInt2   *ptp;
-  Obj     conj, dom;
+Obj PowPPerm4Perm2(Obj f, Obj p)
+{
+    UInt    deg, rank, degconj, i, j, k, codeg;
+    UInt4 * ptf, *ptconj, dep;
+    UInt2 * ptp;
+    Obj     conj, dom;
 
-  deg=DEG_PPERM4(f);
-  if(deg==0) return EmptyPartialPerm;
-  
-  dep=DEG_PERM2(p); 
-  rank=RANK_PPERM4(f);
-  ptp=ADDR_PERM2(p);
-  dom=DOM_PPERM(f); 
-  
-  //find deg of conjugate
-  if(deg>dep){
-    degconj=deg;
-  } else {
-    degconj=0;
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptp[j]>=degconj) degconj=ptp[j]+1;
+    deg = DEG_PPERM4(f);
+    if (deg == 0)
+        return EmptyPartialPerm;
+
+    dep = DEG_PERM2(p);
+    rank = RANK_PPERM4(f);
+    ptp = ADDR_PERM2(p);
+    dom = DOM_PPERM(f);
+
+    // find deg of conjugate
+    if (deg > dep) {
+        degconj = deg;
     }
-  }
-  
-  conj=NEW_PPERM4(degconj);
-  ptconj=ADDR_PPERM4(conj);
-  ptp=ADDR_PERM2(p);
-  ptf=ADDR_PPERM4(f);
-  codeg=CODEG_PPERM4(f);
-  
-  if(codeg>dep){
-    CODEG_PPERM4(conj)=codeg;
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptconj[IMAGE(j, ptp, dep)]=IMAGE(ptf[j]-1, ptp, dep)+1;
+    else {
+        degconj = 0;
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptp[j] >= degconj)
+                degconj = ptp[j] + 1;
+        }
     }
-  } else {
-    codeg=0;
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      k=ptp[ptf[j]-1]+1;
-      ptconj[IMAGE(j, ptp, dep)]=k;
-      if(k>codeg) codeg=k;
+
+    conj = NEW_PPERM4(degconj);
+    ptconj = ADDR_PPERM4(conj);
+    ptp = ADDR_PERM2(p);
+    ptf = ADDR_PPERM4(f);
+    codeg = CODEG_PPERM4(f);
+
+    if (codeg > dep) {
+        CODEG_PPERM4(conj) = codeg;
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptconj[IMAGE(j, ptp, dep)] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
+        }
     }
-    CODEG_PPERM4(conj)=codeg;
-  }
-  return conj;
+    else {
+        codeg = 0;
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            k = ptp[ptf[j] - 1] + 1;
+            ptconj[IMAGE(j, ptp, dep)] = k;
+            if (k > codeg)
+                codeg = k;
+        }
+        CODEG_PPERM4(conj) = codeg;
+    }
+    return conj;
 }
 
-Obj PowPPerm4Perm4(Obj f, Obj p){
-  UInt    deg, rank, degconj, i, j, k, codeg; 
-  UInt4   *ptf, *ptp, *ptconj, dep;
-  Obj     conj, dom;
+Obj PowPPerm4Perm4(Obj f, Obj p)
+{
+    UInt   deg, rank, degconj, i, j, k, codeg;
+    UInt4 *ptf, *ptp, *ptconj, dep;
+    Obj    conj, dom;
 
-  deg=DEG_PPERM4(f);
-  if(deg==0) return EmptyPartialPerm;
-  
-  dep=DEG_PERM4(p); 
-  rank=RANK_PPERM4(f);
-  ptp=ADDR_PERM4(p);
-  dom=DOM_PPERM(f); 
-  
-  //find deg of conjugate
-  if(deg>dep){
-    degconj=deg;
-  } else {
-    degconj=0;
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptp[j]>=degconj) degconj=ptp[j]+1;
+    deg = DEG_PPERM4(f);
+    if (deg == 0)
+        return EmptyPartialPerm;
+
+    dep = DEG_PERM4(p);
+    rank = RANK_PPERM4(f);
+    ptp = ADDR_PERM4(p);
+    dom = DOM_PPERM(f);
+
+    // find deg of conjugate
+    if (deg > dep) {
+        degconj = deg;
     }
-  }
-  
-  conj=NEW_PPERM4(degconj);
-  ptconj=ADDR_PPERM4(conj);
-  ptp=ADDR_PERM4(p);
-  ptf=ADDR_PPERM4(f);
-  codeg=CODEG_PPERM4(f);
-  
-  if(codeg>dep){
-    //Pr("case 1\n", 0L, 0L);
-    CODEG_PPERM4(conj)=codeg;
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptconj[IMAGE(j, ptp, dep)]=IMAGE(ptf[j]-1, ptp, dep)+1;
+    else {
+        degconj = 0;
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptp[j] >= degconj)
+                degconj = ptp[j] + 1;
+        }
     }
-  } else { //codeg(f)<=deg(p)
-    //Pr("case 2"\n, 0L, 0L);
-    codeg=0;
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      k=ptp[ptf[j]-1]+1;
-      ptconj[IMAGE(j, ptp, dep)]=k;
-      if(k>codeg) codeg=k;
+
+    conj = NEW_PPERM4(degconj);
+    ptconj = ADDR_PPERM4(conj);
+    ptp = ADDR_PERM4(p);
+    ptf = ADDR_PPERM4(f);
+    codeg = CODEG_PPERM4(f);
+
+    if (codeg > dep) {
+        // Pr("case 1\n", 0L, 0L);
+        CODEG_PPERM4(conj) = codeg;
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptconj[IMAGE(j, ptp, dep)] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
+        }
     }
-    CODEG_PPERM4(conj)=codeg;
-  }
-  return conj;
+    else {    // codeg(f)<=deg(p)
+        // Pr("case 2"\n, 0L, 0L);
+        codeg = 0;
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            k = ptp[ptf[j] - 1] + 1;
+            ptconj[IMAGE(j, ptp, dep)] = k;
+            if (k > codeg)
+                codeg = k;
+        }
+        CODEG_PPERM4(conj) = codeg;
+    }
+    return conj;
 }
 
 // g^-1*f*g
 // JDM not sure this is worth it...
-Obj PowPPerm22( Obj f, Obj g ){
-  UInt2   *ptg, *ptf, *ptconj, img;
-  UInt    i, j, def, deg, dec, codeg, codec, min, len;
-  Obj     dom, conj;
+Obj PowPPerm22(Obj f, Obj g)
+{
+    UInt2 *ptg, *ptf, *ptconj, img;
+    UInt   i, j, def, deg, dec, codeg, codec, min, len;
+    Obj    dom, conj;
 
-  //check if we're in the trivial case
-  def=DEG_PPERM2(f);
-  deg=DEG_PPERM2(g);
-  if(def==0||deg==0) return EmptyPartialPerm;
- 
-  ptf=ADDR_PPERM2(f);
-  ptg=ADDR_PPERM2(g);
-  dom=DOM_PPERM(f);
-  codeg=CODEG_PPERM2(g); 
-  dec=0;
-  codec=0;
-  
-  if(dom==NULL){
-    min=MIN(def,deg);
-    if(CODEG_PPERM2(f)<=deg){
-      //find the degree
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]>dec&&ptg[ptf[i]-1]!=0){
-          dec=ptg[i];
-          if(dec==codeg) break;
-        }
-      }
+    // check if we're in the trivial case
+    def = DEG_PPERM2(f);
+    deg = DEG_PPERM2(g);
+    if (def == 0 || deg == 0)
+        return EmptyPartialPerm;
 
-      if(dec==0) return EmptyPartialPerm;
-    
-      //create new pperm
-      conj=NEW_PPERM2(dec);
-      ptconj=ADDR_PPERM2(conj);
-      ptf=ADDR_PPERM2(f);
-      ptg=ADDR_PPERM2(g);
-      
-      //multiply
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]!=0){
-          img=ptg[ptf[i]-1];
-          if(img!=0){
-            ptconj[ptg[i]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    } else { //codeg(f)>deg(g)
-      //find the degree
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]>dec&&IMAGEPP(ptf[i], ptg, deg)!=0){
-          dec=ptg[i];
-          if(dec==codeg) break;
-        }
-      }
+    ptf = ADDR_PPERM2(f);
+    ptg = ADDR_PPERM2(g);
+    dom = DOM_PPERM(f);
+    codeg = CODEG_PPERM2(g);
+    dec = 0;
+    codec = 0;
 
-      if(dec==0) return EmptyPartialPerm;
-    
-      //create new pperm
-      conj=NEW_PPERM2(dec);
-      ptconj=ADDR_PPERM2(conj);
-      ptf=ADDR_PPERM2(f);
-      ptg=ADDR_PPERM2(g);
-      
-      //multiply
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]!=0){
-          img=IMAGEPP(ptf[i], ptg, deg);
-          if(img!=0){
-            ptconj[ptg[i]-1]=img;
-            if(img>codec) codec=img;
-          }
+    if (dom == NULL) {
+        min = MIN(def, deg);
+        if (CODEG_PPERM2(f) <= deg) {
+            // find the degree
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] > dec && ptg[ptf[i] - 1] != 0) {
+                    dec = ptg[i];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            if (dec == 0)
+                return EmptyPartialPerm;
+
+            // create new pperm
+            conj = NEW_PPERM2(dec);
+            ptconj = ADDR_PPERM2(conj);
+            ptf = ADDR_PPERM2(f);
+            ptg = ADDR_PPERM2(g);
+
+            // multiply
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] != 0) {
+                    img = ptg[ptf[i] - 1];
+                    if (img != 0) {
+                        ptconj[ptg[i] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
         }
-      }
+        else {    // codeg(f)>deg(g)
+            // find the degree
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] > dec &&
+                    IMAGEPP(ptf[i], ptg, deg) != 0) {
+                    dec = ptg[i];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            if (dec == 0)
+                return EmptyPartialPerm;
+
+            // create new pperm
+            conj = NEW_PPERM2(dec);
+            ptconj = ADDR_PPERM2(conj);
+            ptf = ADDR_PPERM2(f);
+            ptg = ADDR_PPERM2(g);
+
+            // multiply
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] != 0) {
+                    img = IMAGEPP(ptf[i], ptg, deg);
+                    if (img != 0) {
+                        ptconj[ptg[i] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
     }
-  } else if(def>deg){ //dom(f) is known
-    if(CODEG_PPERM2(f)<=deg){
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)>dec&&ptg[ptf[j]-1]!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM2(dec);
-      ptconj=ADDR_PPERM2(conj);
-      ptf=ADDR_PPERM2(f);
-      ptg=ADDR_PPERM2(g);
-      len=LEN_PLIST(dom);
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)!=0){
-          img=ptg[ptf[j]-1];
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    } else { //codeg(f)>deg(g)
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)>dec&&IMAGEPP(ptf[j], ptg, deg)!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM2(dec);
-      ptconj=ADDR_PPERM2(conj);
-      ptf=ADDR_PPERM2(f);
-      ptg=ADDR_PPERM2(g);
-      
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)!=0){
-          img=IMAGEPP(ptf[j], ptg, deg);
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    }
-  } else { // def<=deg and dom(f) is known
-    if(CODEG_PPERM2(f)<=deg){
-      //find the degree of conj
-      len=LEN_PLIST(dom); 
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]>dec&&ptg[ptf[j]-1]!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM2(dec);
-      ptconj=ADDR_PPERM2(conj);
-      ptf=ADDR_PPERM2(f);
-      ptg=ADDR_PPERM2(g);
+    else if (def > deg) {    // dom(f) is known
+        if (CODEG_PPERM2(f) <= deg) {
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) > dec && ptg[ptf[j] - 1] != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
 
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]!=0){
-          img=ptg[ptf[j]-1];
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
+            // create new pperm
+            conj = NEW_PPERM2(dec);
+            ptconj = ADDR_PPERM2(conj);
+            ptf = ADDR_PPERM2(f);
+            ptg = ADDR_PPERM2(g);
+            len = LEN_PLIST(dom);
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) != 0) {
+                    img = ptg[ptf[j] - 1];
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
         }
-      }
-    } else {//codeg(f)>deg(g)
-      //find the degree of conj
-      len=LEN_PLIST(dom); 
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]>dec&&IMAGEPP(ptf[j], ptg, deg)!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM2(dec);
-      ptconj=ADDR_PPERM2(conj);
-      ptf=ADDR_PPERM2(f);
-      ptg=ADDR_PPERM2(g);
+        else {    // codeg(f)>deg(g)
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) > dec &&
+                    IMAGEPP(ptf[j], ptg, deg) != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
 
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]!=0){
-          img=IMAGEPP(ptf[j], ptg, deg);
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
+            // create new pperm
+            conj = NEW_PPERM2(dec);
+            ptconj = ADDR_PPERM2(conj);
+            ptf = ADDR_PPERM2(f);
+            ptg = ADDR_PPERM2(g);
+
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) != 0) {
+                    img = IMAGEPP(ptf[j], ptg, deg);
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
         }
-      }
     }
-  }
-  CODEG_PPERM2(conj)=codec;
-  return conj;
+    else {    // def<=deg and dom(f) is known
+        if (CODEG_PPERM2(f) <= deg) {
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] > dec && ptg[ptf[j] - 1] != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            // create new pperm
+            conj = NEW_PPERM2(dec);
+            ptconj = ADDR_PPERM2(conj);
+            ptf = ADDR_PPERM2(f);
+            ptg = ADDR_PPERM2(g);
+
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] != 0) {
+                    img = ptg[ptf[j] - 1];
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
+        else {    // codeg(f)>deg(g)
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] > dec && IMAGEPP(ptf[j], ptg, deg) != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            // create new pperm
+            conj = NEW_PPERM2(dec);
+            ptconj = ADDR_PPERM2(conj);
+            ptf = ADDR_PPERM2(f);
+            ptg = ADDR_PPERM2(g);
+
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] != 0) {
+                    img = IMAGEPP(ptf[j], ptg, deg);
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
+    }
+    CODEG_PPERM2(conj) = codec;
+    return conj;
 }
 
-Obj PowPPerm24( Obj f, Obj g ){
-  UInt4   *ptg, *ptconj;
-  UInt2   *ptf;
-  UInt    i, j, def, deg, dec, codeg, codec, min, img, len;
-  Obj     dom, conj;
+Obj PowPPerm24(Obj f, Obj g)
+{
+    UInt4 * ptg, *ptconj;
+    UInt2 * ptf;
+    UInt    i, j, def, deg, dec, codeg, codec, min, img, len;
+    Obj     dom, conj;
 
-  //check if we're in the trivial case
-  def=DEG_PPERM2(f);
-  deg=DEG_PPERM4(g);
-  if(def==0||deg==0) return EmptyPartialPerm;
- 
-  ptf=ADDR_PPERM2(f);
-  ptg=ADDR_PPERM4(g);
-  dom=DOM_PPERM(f);
-  codeg=CODEG_PPERM4(g); 
-  dec=0;
-  codec=0;
-  
-  if(dom==NULL){
-    min=MIN(def,deg);
-    if(CODEG_PPERM2(f)<=deg){
-      //find the degree
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]>dec&&ptg[ptf[i]-1]!=0){
-          dec=ptg[i];
-          if(dec==codeg) break;
-        }
-      }
+    // check if we're in the trivial case
+    def = DEG_PPERM2(f);
+    deg = DEG_PPERM4(g);
+    if (def == 0 || deg == 0)
+        return EmptyPartialPerm;
 
-      if(dec==0) return EmptyPartialPerm;
-    
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM2(f);
-      ptg=ADDR_PPERM4(g);
-      
-      //multiply
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]!=0){
-          img=ptg[ptf[i]-1];
-          if(img!=0){
-            ptconj[ptg[i]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    } else { //codeg(f)>deg(g)
-      //find the degree
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]>dec&&IMAGEPP(ptf[i], ptg, deg)!=0){
-          dec=ptg[i];
-          if(dec==codeg) break;
-        }
-      }
+    ptf = ADDR_PPERM2(f);
+    ptg = ADDR_PPERM4(g);
+    dom = DOM_PPERM(f);
+    codeg = CODEG_PPERM4(g);
+    dec = 0;
+    codec = 0;
 
-      if(dec==0) return EmptyPartialPerm;
-    
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM2(f);
-      ptg=ADDR_PPERM4(g);
-      
-      //multiply
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]!=0){
-          img=IMAGEPP(ptf[i], ptg, deg);
-          if(img!=0){
-            ptconj[ptg[i]-1]=img;
-            if(img>codec) codec=img;
-          }
+    if (dom == NULL) {
+        min = MIN(def, deg);
+        if (CODEG_PPERM2(f) <= deg) {
+            // find the degree
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] > dec && ptg[ptf[i] - 1] != 0) {
+                    dec = ptg[i];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            if (dec == 0)
+                return EmptyPartialPerm;
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM2(f);
+            ptg = ADDR_PPERM4(g);
+
+            // multiply
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] != 0) {
+                    img = ptg[ptf[i] - 1];
+                    if (img != 0) {
+                        ptconj[ptg[i] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
         }
-      }
+        else {    // codeg(f)>deg(g)
+            // find the degree
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] > dec &&
+                    IMAGEPP(ptf[i], ptg, deg) != 0) {
+                    dec = ptg[i];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            if (dec == 0)
+                return EmptyPartialPerm;
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM2(f);
+            ptg = ADDR_PPERM4(g);
+
+            // multiply
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] != 0) {
+                    img = IMAGEPP(ptf[i], ptg, deg);
+                    if (img != 0) {
+                        ptconj[ptg[i] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
     }
-  } else if(def>deg){ //dom(f) is known
-    if(CODEG_PPERM2(f)<=deg){
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)>dec&&ptg[ptf[j]-1]!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM2(f);
-      ptg=ADDR_PPERM4(g);
-      
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)!=0){
-          img=ptg[ptf[j]-1];
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    } else { //codeg(f)>deg(g)
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)>dec&&IMAGEPP(ptf[j], ptg, deg)!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM2(f);
-      ptg=ADDR_PPERM4(g);
-      
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)!=0){
-          img=IMAGEPP(ptf[j], ptg, deg);
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    }
-  } else { // def<=deg and dom(f) is known
-    if(CODEG_PPERM2(f)<=deg){
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]>dec&&ptg[ptf[j]-1]!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM2(f);
-      ptg=ADDR_PPERM4(g);
+    else if (def > deg) {    // dom(f) is known
+        if (CODEG_PPERM2(f) <= deg) {
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) > dec && ptg[ptf[j] - 1] != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
 
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]!=0){
-          img=ptg[ptf[j]-1];
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    } else {//codeg(f)>deg(g)
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]>dec&&IMAGEPP(ptf[j], ptg, deg)!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM2(f);
-      ptg=ADDR_PPERM4(g);
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM2(f);
+            ptg = ADDR_PPERM4(g);
 
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]!=0){
-          img=IMAGEPP(ptf[j], ptg, deg);
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) != 0) {
+                    img = ptg[ptf[j] - 1];
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
         }
-      }
+        else {    // codeg(f)>deg(g)
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) > dec &&
+                    IMAGEPP(ptf[j], ptg, deg) != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM2(f);
+            ptg = ADDR_PPERM4(g);
+
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) != 0) {
+                    img = IMAGEPP(ptf[j], ptg, deg);
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
     }
-  }
-  CODEG_PPERM4(conj)=codec;
-  return conj;
+    else {    // def<=deg and dom(f) is known
+        if (CODEG_PPERM2(f) <= deg) {
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] > dec && ptg[ptf[j] - 1] != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM2(f);
+            ptg = ADDR_PPERM4(g);
+
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] != 0) {
+                    img = ptg[ptf[j] - 1];
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
+        else {    // codeg(f)>deg(g)
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] > dec && IMAGEPP(ptf[j], ptg, deg) != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM2(f);
+            ptg = ADDR_PPERM4(g);
+
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] != 0) {
+                    img = IMAGEPP(ptf[j], ptg, deg);
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
+    }
+    CODEG_PPERM4(conj) = codec;
+    return conj;
 }
 
-Obj PowPPerm42( Obj f, Obj g ){
-  UInt4   *ptf, *ptconj;
-  UInt2   *ptg;
-  UInt    i, j, def, deg, dec, codeg, codec, min, img, len;
-  Obj     dom, conj;
+Obj PowPPerm42(Obj f, Obj g)
+{
+    UInt4 * ptf, *ptconj;
+    UInt2 * ptg;
+    UInt    i, j, def, deg, dec, codeg, codec, min, img, len;
+    Obj     dom, conj;
 
-  //check if we're in the trivial case
-  def=DEG_PPERM4(f);
-  deg=DEG_PPERM2(g);
-  if(def==0||deg==0) return EmptyPartialPerm;
- 
-  ptf=ADDR_PPERM4(f);
-  ptg=ADDR_PPERM2(g);
-  dom=DOM_PPERM(f);
-  codeg=CODEG_PPERM2(g); 
-  dec=0;
-  codec=0;
-  
-  if(dom==NULL){
-    min=MIN(def,deg);
-    if(CODEG_PPERM4(f)<=deg){
-      //find the degree
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]>dec&&ptg[ptf[i]-1]!=0){
-          dec=ptg[i];
-          if(dec==codeg) break;
-        }
-      }
+    // check if we're in the trivial case
+    def = DEG_PPERM4(f);
+    deg = DEG_PPERM2(g);
+    if (def == 0 || deg == 0)
+        return EmptyPartialPerm;
 
-      if(dec==0) return EmptyPartialPerm;
-    
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM4(f);
-      ptg=ADDR_PPERM2(g);
-      
-      //multiply
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]!=0){
-          img=ptg[ptf[i]-1];
-          if(img!=0){
-            ptconj[ptg[i]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    } else { //codeg(f)>deg(g)
-      //find the degree
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]>dec&&IMAGEPP(ptf[i], ptg, deg)!=0){
-          dec=ptg[i];
-          if(dec==codeg) break;
-        }
-      }
+    ptf = ADDR_PPERM4(f);
+    ptg = ADDR_PPERM2(g);
+    dom = DOM_PPERM(f);
+    codeg = CODEG_PPERM2(g);
+    dec = 0;
+    codec = 0;
 
-      if(dec==0) return EmptyPartialPerm;
-    
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM4(f);
-      ptg=ADDR_PPERM2(g);
-      
-      //multiply
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]!=0){
-          img=IMAGEPP(ptf[i], ptg, deg);
-          if(img!=0){
-            ptconj[ptg[i]-1]=img;
-            if(img>codec) codec=img;
-          }
+    if (dom == NULL) {
+        min = MIN(def, deg);
+        if (CODEG_PPERM4(f) <= deg) {
+            // find the degree
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] > dec && ptg[ptf[i] - 1] != 0) {
+                    dec = ptg[i];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            if (dec == 0)
+                return EmptyPartialPerm;
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM4(f);
+            ptg = ADDR_PPERM2(g);
+
+            // multiply
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] != 0) {
+                    img = ptg[ptf[i] - 1];
+                    if (img != 0) {
+                        ptconj[ptg[i] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
         }
-      }
+        else {    // codeg(f)>deg(g)
+            // find the degree
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] > dec &&
+                    IMAGEPP(ptf[i], ptg, deg) != 0) {
+                    dec = ptg[i];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            if (dec == 0)
+                return EmptyPartialPerm;
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM4(f);
+            ptg = ADDR_PPERM2(g);
+
+            // multiply
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] != 0) {
+                    img = IMAGEPP(ptf[i], ptg, deg);
+                    if (img != 0) {
+                        ptconj[ptg[i] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
     }
-  } else if(def>deg){ //dom(f) is known
-    if(CODEG_PPERM4(f)<=deg){
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)>dec&&ptg[ptf[j]-1]!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM4(f);
-      ptg=ADDR_PPERM2(g);
-      
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)!=0){
-          img=ptg[ptf[j]-1];
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    } else { //codeg(f)>deg(g)
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)>dec&&IMAGEPP(ptf[j], ptg, deg)!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM4(f);
-      ptg=ADDR_PPERM2(g);
-      
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)!=0){
-          img=IMAGEPP(ptf[j], ptg, deg);
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    }
-  } else { // def<=deg and dom(f) is known
-    if(CODEG_PPERM4(f)<=deg){
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]>dec&&ptg[ptf[j]-1]!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM4(f);
-      ptg=ADDR_PPERM2(g);
+    else if (def > deg) {    // dom(f) is known
+        if (CODEG_PPERM4(f) <= deg) {
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) > dec && ptg[ptf[j] - 1] != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
 
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]!=0){
-          img=ptg[ptf[j]-1];
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    } else {//codeg(f)>deg(g)
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]>dec&&IMAGEPP(ptf[j], ptg, deg)!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM4(f);
-      ptg=ADDR_PPERM2(g);
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM4(f);
+            ptg = ADDR_PPERM2(g);
 
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]!=0){
-          img=IMAGEPP(ptf[j], ptg, deg);
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) != 0) {
+                    img = ptg[ptf[j] - 1];
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
         }
-      }
+        else {    // codeg(f)>deg(g)
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) > dec &&
+                    IMAGEPP(ptf[j], ptg, deg) != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM4(f);
+            ptg = ADDR_PPERM2(g);
+
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) != 0) {
+                    img = IMAGEPP(ptf[j], ptg, deg);
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
     }
-  }
-  CODEG_PPERM4(conj)=codec;
-  return conj;
+    else {    // def<=deg and dom(f) is known
+        if (CODEG_PPERM4(f) <= deg) {
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] > dec && ptg[ptf[j] - 1] != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM4(f);
+            ptg = ADDR_PPERM2(g);
+
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] != 0) {
+                    img = ptg[ptf[j] - 1];
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
+        else {    // codeg(f)>deg(g)
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] > dec && IMAGEPP(ptf[j], ptg, deg) != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM4(f);
+            ptg = ADDR_PPERM2(g);
+
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] != 0) {
+                    img = IMAGEPP(ptf[j], ptg, deg);
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
+    }
+    CODEG_PPERM4(conj) = codec;
+    return conj;
 }
 
-Obj PowPPerm44( Obj f, Obj g ){
-  UInt4   *ptg, *ptf, *ptconj, img;
-  UInt    i, j, def, deg, dec, codeg, codec, min, len;
-  Obj     dom, conj;
+Obj PowPPerm44(Obj f, Obj g)
+{
+    UInt4 *ptg, *ptf, *ptconj, img;
+    UInt   i, j, def, deg, dec, codeg, codec, min, len;
+    Obj    dom, conj;
 
-  //check if we're in the trivial case
-  def=DEG_PPERM4(f);
-  deg=DEG_PPERM4(g);
-  if(def==0||deg==0) return EmptyPartialPerm;
- 
-  ptf=ADDR_PPERM4(f);
-  ptg=ADDR_PPERM4(g);
-  dom=DOM_PPERM(f);
-  codeg=CODEG_PPERM4(g); 
-  dec=0;
-  codec=0;
-  
-  if(dom==NULL){
-    min=MIN(def,deg);
-    if(CODEG_PPERM4(f)<=deg){
-      //find the degree
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]>dec&&ptg[ptf[i]-1]!=0){
-          dec=ptg[i];
-          if(dec==codeg) break;
-        }
-      }
+    // check if we're in the trivial case
+    def = DEG_PPERM4(f);
+    deg = DEG_PPERM4(g);
+    if (def == 0 || deg == 0)
+        return EmptyPartialPerm;
 
-      if(dec==0) return EmptyPartialPerm;
-    
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM4(f);
-      ptg=ADDR_PPERM4(g);
-      
-      //multiply
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]!=0){
-          img=ptg[ptf[i]-1];
-          if(img!=0){
-            ptconj[ptg[i]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    } else { //codeg(f)>deg(g)
-      //find the degree
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]>dec&&IMAGEPP(ptf[i], ptg, deg)!=0){
-          dec=ptg[i];
-          if(dec==codeg) break;
-        }
-      }
+    ptf = ADDR_PPERM4(f);
+    ptg = ADDR_PPERM4(g);
+    dom = DOM_PPERM(f);
+    codeg = CODEG_PPERM4(g);
+    dec = 0;
+    codec = 0;
 
-      if(dec==0) return EmptyPartialPerm;
-    
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM4(f);
-      ptg=ADDR_PPERM4(g);
-      
-      //multiply
-      for(i=0;i<min;i++){
-        if(ptf[i]!=0&&ptg[i]!=0){
-          img=IMAGEPP(ptf[i], ptg, deg);
-          if(img!=0){
-            ptconj[ptg[i]-1]=img;
-            if(img>codec) codec=img;
-          }
+    if (dom == NULL) {
+        min = MIN(def, deg);
+        if (CODEG_PPERM4(f) <= deg) {
+            // find the degree
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] > dec && ptg[ptf[i] - 1] != 0) {
+                    dec = ptg[i];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            if (dec == 0)
+                return EmptyPartialPerm;
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM4(f);
+            ptg = ADDR_PPERM4(g);
+
+            // multiply
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] != 0) {
+                    img = ptg[ptf[i] - 1];
+                    if (img != 0) {
+                        ptconj[ptg[i] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
         }
-      }
+        else {    // codeg(f)>deg(g)
+            // find the degree
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] > dec &&
+                    IMAGEPP(ptf[i], ptg, deg) != 0) {
+                    dec = ptg[i];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            if (dec == 0)
+                return EmptyPartialPerm;
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM4(f);
+            ptg = ADDR_PPERM4(g);
+
+            // multiply
+            for (i = 0; i < min; i++) {
+                if (ptf[i] != 0 && ptg[i] != 0) {
+                    img = IMAGEPP(ptf[i], ptg, deg);
+                    if (img != 0) {
+                        ptconj[ptg[i] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
     }
-  } else if(def>deg){ //dom(f) is known
-    if(CODEG_PPERM4(f)<=deg){
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)>dec&&ptg[ptf[j]-1]!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM4(f);
-      ptg=ADDR_PPERM4(g);
-      
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)!=0){
-          img=ptg[ptf[j]-1];
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    } else { //codeg(f)>deg(g)
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)>dec&&IMAGEPP(ptf[j], ptg, deg)!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM4(f);
-      ptg=ADDR_PPERM4(g);
-      
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(IMAGEPP(j+1, ptg, deg)!=0){
-          img=IMAGEPP(ptf[j], ptg, deg);
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    }
-  } else { // def<=deg and dom(f) is known
-    if(CODEG_PPERM4(f)<=deg){
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]>dec&&ptg[ptf[j]-1]!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM4(f);
-      ptg=ADDR_PPERM4(g);
+    else if (def > deg) {    // dom(f) is known
+        if (CODEG_PPERM4(f) <= deg) {
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) > dec && ptg[ptf[j] - 1] != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
 
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]!=0){
-          img=ptg[ptf[j]-1];
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
-        }
-      }
-    } else {//codeg(f)>deg(g)
-      //find the degree of conj
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]>dec&&IMAGEPP(ptf[j], ptg, deg)!=0){
-          dec=ptg[j];
-          if(dec==codeg) break;
-        }
-      }
-     
-      //create new pperm
-      conj=NEW_PPERM4(dec);
-      ptconj=ADDR_PPERM4(conj);
-      ptf=ADDR_PPERM4(f);
-      ptg=ADDR_PPERM4(g);
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM4(f);
+            ptg = ADDR_PPERM4(g);
 
-      //multiply
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptg[j]!=0){
-          img=IMAGEPP(ptf[j], ptg, deg);
-          if(img!=0){
-            ptconj[ptg[j]-1]=img;
-            if(img>codec) codec=img;
-          }
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) != 0) {
+                    img = ptg[ptf[j] - 1];
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
         }
-      }
+        else {    // codeg(f)>deg(g)
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) > dec &&
+                    IMAGEPP(ptf[j], ptg, deg) != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM4(f);
+            ptg = ADDR_PPERM4(g);
+
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (IMAGEPP(j + 1, ptg, deg) != 0) {
+                    img = IMAGEPP(ptf[j], ptg, deg);
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
     }
-  }
-  CODEG_PPERM4(conj)=codec;
-  return conj;
+    else {    // def<=deg and dom(f) is known
+        if (CODEG_PPERM4(f) <= deg) {
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] > dec && ptg[ptf[j] - 1] != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM4(f);
+            ptg = ADDR_PPERM4(g);
+
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] != 0) {
+                    img = ptg[ptf[j] - 1];
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
+        else {    // codeg(f)>deg(g)
+            // find the degree of conj
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] > dec && IMAGEPP(ptf[j], ptg, deg) != 0) {
+                    dec = ptg[j];
+                    if (dec == codeg)
+                        break;
+                }
+            }
+
+            // create new pperm
+            conj = NEW_PPERM4(dec);
+            ptconj = ADDR_PPERM4(conj);
+            ptf = ADDR_PPERM4(f);
+            ptg = ADDR_PPERM4(g);
+
+            // multiply
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptg[j] != 0) {
+                    img = IMAGEPP(ptf[j], ptg, deg);
+                    if (img != 0) {
+                        ptconj[ptg[j] - 1] = img;
+                        if (img > codec)
+                            codec = img;
+                    }
+                }
+            }
+        }
+    }
+    CODEG_PPERM4(conj) = codec;
+    return conj;
 }
 
 // f*p^-1
-Obj QuoPPerm2Perm2(Obj f, Obj p){
-  UInt2   *ptf, *ptp, *ptquo2;
-  UInt4   *ptquo4, *pttmp;
-  Obj     quo, dom;
-  UInt    codeg, lmp, deg, i, j, rank;
+Obj QuoPPerm2Perm2(Obj f, Obj p)
+{
+    UInt2 *ptf, *ptp, *ptquo2;
+    UInt4 *ptquo4, *pttmp;
+    Obj    quo, dom;
+    UInt   codeg, lmp, deg, i, j, rank;
 
-  if(DEG_PPERM2(f)==0) return EmptyPartialPerm;
-  
-  //find the largest moved point
-  lmp=DEG_PERM2(p);
-  ptp=ADDR_PERM2(p);
-  while(lmp>0&&ptp[lmp-1]==lmp-1) lmp--;
-  if(lmp==0) return f;
+    if (DEG_PPERM2(f) == 0)
+        return EmptyPartialPerm;
 
-  //invert the permutation into the buffer bag
-  ResizeTmpPPerm(lmp); 
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  ptp=ADDR_PERM2(p);
-  for(i=0;i<lmp;i++) pttmp[*ptp++]=i; 
+    // find the largest moved point
+    lmp = DEG_PERM2(p);
+    ptp = ADDR_PERM2(p);
+    while (lmp > 0 && ptp[lmp - 1] == lmp - 1)
+        lmp--;
+    if (lmp == 0)
+        return f;
 
-  //create new pperm
-  deg=DEG_PPERM2(f);
-  codeg=CODEG_PPERM2(f);
-  
-  //multiply the partial perm with the inverse
-  if(lmp<65536){
-    quo=NEW_PPERM2(deg);
-    ptf=ADDR_PPERM2(f);
-    pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-    ptquo2=ADDR_PPERM2(quo);
-    if(codeg<=lmp){
-      codeg=0;
-      if(DOM_PPERM(f)==NULL){
-        //Pr("Case 2\n", 0L, 0L);
-        for(i=0;i<deg;i++){ 
-          if(ptf[i]!=0){
-            ptquo2[i]=pttmp[ptf[i]-1]+1;
-            if(ptquo2[i]>codeg) codeg=ptquo2[i];
-          }
+    // invert the permutation into the buffer bag
+    ResizeTmpPPerm(lmp);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    ptp = ADDR_PERM2(p);
+    for (i = 0; i < lmp; i++)
+        pttmp[*ptp++] = i;
+
+    // create new pperm
+    deg = DEG_PPERM2(f);
+    codeg = CODEG_PPERM2(f);
+
+    // multiply the partial perm with the inverse
+    if (lmp < 65536) {
+        quo = NEW_PPERM2(deg);
+        ptf = ADDR_PPERM2(f);
+        pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+        ptquo2 = ADDR_PPERM2(quo);
+        if (codeg <= lmp) {
+            codeg = 0;
+            if (DOM_PPERM(f) == NULL) {
+                // Pr("Case 2\n", 0L, 0L);
+                for (i = 0; i < deg; i++) {
+                    if (ptf[i] != 0) {
+                        ptquo2[i] = pttmp[ptf[i] - 1] + 1;
+                        if (ptquo2[i] > codeg)
+                            codeg = ptquo2[i];
+                    }
+                }
+            }
+            else {
+                // Pr("Case 1\n", 0L, 0L);
+                dom = DOM_PPERM(f);
+                rank = RANK_PPERM2(f);
+                for (i = 1; i <= rank; i++) {
+                    j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                    ptquo2[j] = pttmp[ptf[j] - 1] + 1;
+                    if (ptquo2[j] > codeg)
+                        codeg = ptquo2[j];
+                }
+            }
         }
-      } else {
-        //Pr("Case 1\n", 0L, 0L);
-        dom=DOM_PPERM(f);
-        rank=RANK_PPERM2(f);
-        for(i=1;i<=rank;i++){
-          j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-          ptquo2[j]=pttmp[ptf[j]-1]+1;
-          if(ptquo2[j]>codeg) codeg=ptquo2[j];
+        else {
+            if (DOM_PPERM(f) == NULL) {
+                // Pr("Case 4\n", 0L, 0L);
+                for (i = 0; i < deg; i++) {
+                    if (ptf[i] != 0) {
+                        ptquo2[i] = IMAGE(ptf[i] - 1, pttmp, lmp) + 1;
+                    }
+                }
+            }
+            else {
+                // Pr("Case 3\n", 0L, 0L);
+                dom = DOM_PPERM(f);
+                rank = RANK_PPERM2(f);
+                for (i = 1; i <= rank; i++) {
+                    j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                    ptquo2[j] = IMAGE(ptf[j] - 1, pttmp, lmp) + 1;
+                }
+            }
         }
-      }
-    } else {
-      if(DOM_PPERM(f)==NULL){
-       //Pr("Case 4\n", 0L, 0L);
-        for(i=0;i<deg;i++){
-          if(ptf[i]!=0){
-            ptquo2[i]=IMAGE(ptf[i]-1, pttmp, lmp)+1;
-          }
-        }
-      }else{
-        //Pr("Case 3\n", 0L, 0L);
-        dom=DOM_PPERM(f);
-        rank=RANK_PPERM2(f);
-        for(i=1;i<=rank;i++){
-          j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-          ptquo2[j]=IMAGE(ptf[j]-1, pttmp, lmp)+1;
-        }
-      }
+        CODEG_PPERM2(quo) = codeg;
     }
-    CODEG_PPERM2(quo)=codeg;
-  } else {
-    quo=NEW_PPERM4(deg);
-    ptquo4=ADDR_PPERM4(quo);
-    ptf=ADDR_PPERM2(f);
-    pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-    ptquo4=ADDR_PPERM4(quo);
-    codeg=0;
-    if(DOM_PPERM(f)==NULL){
-      //Pr("Case 6\n", 0L, 0L);
-      for(i=0;i<deg;i++){
-        if(ptf[i]!=0){
-          ptquo4[i]=pttmp[ptf[i]-1]+1;
-          if(ptquo4[i]>codeg) codeg=ptquo4[i];
+    else {
+        quo = NEW_PPERM4(deg);
+        ptquo4 = ADDR_PPERM4(quo);
+        ptf = ADDR_PPERM2(f);
+        pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+        ptquo4 = ADDR_PPERM4(quo);
+        codeg = 0;
+        if (DOM_PPERM(f) == NULL) {
+            // Pr("Case 6\n", 0L, 0L);
+            for (i = 0; i < deg; i++) {
+                if (ptf[i] != 0) {
+                    ptquo4[i] = pttmp[ptf[i] - 1] + 1;
+                    if (ptquo4[i] > codeg)
+                        codeg = ptquo4[i];
+                }
+            }
         }
-      }
-    } else {
-      //Pr("Case 5\n", 0L, 0L);
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM2(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptquo4[j]=pttmp[ptf[j]-1]+1;
-        if(ptquo4[j]>codeg) codeg=ptquo4[j];
-      }
+        else {
+            // Pr("Case 5\n", 0L, 0L);
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM2(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptquo4[j] = pttmp[ptf[j] - 1] + 1;
+                if (ptquo4[j] > codeg)
+                    codeg = ptquo4[j];
+            }
+        }
+        CODEG_PPERM4(quo) = codeg;
     }
-    CODEG_PPERM4(quo)=codeg;
-  }
-  return quo;
+    return quo;
 }
 
-Obj QuoPPerm4Perm4(Obj f, Obj p){
-  UInt4   *ptf, *ptp, *ptquo, *pttmp;
-  Obj     quo, dom;
-  UInt    codeg, lmp, deg, i, j, rank;
+Obj QuoPPerm4Perm4(Obj f, Obj p)
+{
+    UInt4 *ptf, *ptp, *ptquo, *pttmp;
+    Obj    quo, dom;
+    UInt   codeg, lmp, deg, i, j, rank;
 
-  if(DEG_PPERM4(f)==0) return EmptyPartialPerm;
-  
-  //find the largest moved point
-  lmp=DEG_PERM4(p);
-  ptp=ADDR_PERM4(p);
-  while(lmp>0&&ptp[lmp-1]==lmp-1) lmp--;
-  if(lmp==0) return f;
+    if (DEG_PPERM4(f) == 0)
+        return EmptyPartialPerm;
 
-  //invert the permutation into the buffer bag
-  ResizeTmpPPerm(lmp);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  ptp=ADDR_PERM4(p);
-  for(i=0;i<lmp;i++) pttmp[*ptp++]=i; 
+    // find the largest moved point
+    lmp = DEG_PERM4(p);
+    ptp = ADDR_PERM4(p);
+    while (lmp > 0 && ptp[lmp - 1] == lmp - 1)
+        lmp--;
+    if (lmp == 0)
+        return f;
 
-  //create new pperm
-  deg=DEG_PPERM4(f);
-  codeg=CODEG_PPERM4(f);
-  quo=NEW_PPERM4(deg);
-  
-  //renew pointers  
-  ptf=ADDR_PPERM4(f);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  ptquo=ADDR_PPERM4(quo);
+    // invert the permutation into the buffer bag
+    ResizeTmpPPerm(lmp);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    ptp = ADDR_PERM4(p);
+    for (i = 0; i < lmp; i++)
+        pttmp[*ptp++] = i;
 
-  //multiply the partial perm with the inverse
-  if(codeg<=lmp){
-    codeg=0;
-    if(DOM_PPERM(f)==NULL){
-      //Pr("case 1\n", 0L, 0L);
-      for(i=0;i<deg;i++){ 
-        if(ptf[i]!=0){
-          ptquo[i]=pttmp[ptf[i]-1]+1;
-          if(ptquo[i]>codeg) codeg=ptquo[i];
+    // create new pperm
+    deg = DEG_PPERM4(f);
+    codeg = CODEG_PPERM4(f);
+    quo = NEW_PPERM4(deg);
+
+    // renew pointers
+    ptf = ADDR_PPERM4(f);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    ptquo = ADDR_PPERM4(quo);
+
+    // multiply the partial perm with the inverse
+    if (codeg <= lmp) {
+        codeg = 0;
+        if (DOM_PPERM(f) == NULL) {
+            // Pr("case 1\n", 0L, 0L);
+            for (i = 0; i < deg; i++) {
+                if (ptf[i] != 0) {
+                    ptquo[i] = pttmp[ptf[i] - 1] + 1;
+                    if (ptquo[i] > codeg)
+                        codeg = ptquo[i];
+                }
+            }
         }
-      }
-    } else {
-      //Pr("case 2\n", 0L, 0L);
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptquo[j]=pttmp[ptf[j]-1]+1;
-        if(ptquo[j]>codeg) codeg=ptquo[j];
-      }
-    }
-  } else {
-    if(DOM_PPERM(f)==NULL){
-      //Pr("case 3\n", 0L, 0L);
-      for(i=0;i<deg;i++){
-        if(ptf[i]!=0){
-          ptquo[i]=IMAGE(ptf[i]-1, pttmp, lmp)+1;
+        else {
+            // Pr("case 2\n", 0L, 0L);
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptquo[j] = pttmp[ptf[j] - 1] + 1;
+                if (ptquo[j] > codeg)
+                    codeg = ptquo[j];
+            }
         }
-      }
-    }else{
-      //Pr("case 4\n", 0L, 0L);
-      dom=DOM_PPERM(f);
-      rank=RANK_PPERM4(f);
-      for(i=1;i<=rank;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptquo[j]=IMAGE(ptf[j]-1, pttmp, lmp)+1;
-      }
     }
-  }
-  CODEG_PPERM4(quo)=codeg;
-  return quo;
+    else {
+        if (DOM_PPERM(f) == NULL) {
+            // Pr("case 3\n", 0L, 0L);
+            for (i = 0; i < deg; i++) {
+                if (ptf[i] != 0) {
+                    ptquo[i] = IMAGE(ptf[i] - 1, pttmp, lmp) + 1;
+                }
+            }
+        }
+        else {
+            // Pr("case 4\n", 0L, 0L);
+            dom = DOM_PPERM(f);
+            rank = RANK_PPERM4(f);
+            for (i = 1; i <= rank; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptquo[j] = IMAGE(ptf[j] - 1, pttmp, lmp) + 1;
+            }
+        }
+    }
+    CODEG_PPERM4(quo) = codeg;
+    return quo;
 }
 
-Obj QuoPPerm2Perm4(Obj f, Obj p){
-  UInt4   *ptp, *ptquo, *pttmp;
-  UInt2   *ptf;
-  Obj     quo, dom;
-  UInt    codeg, lmp, deg, i, j, rank;
+Obj QuoPPerm2Perm4(Obj f, Obj p)
+{
+    UInt4 * ptp, *ptquo, *pttmp;
+    UInt2 * ptf;
+    Obj     quo, dom;
+    UInt    codeg, lmp, deg, i, j, rank;
 
-  if(DEG_PPERM2(f)==0) return EmptyPartialPerm;
-  
-  //find the largest moved point
-  lmp=DEG_PERM4(p);
-  ptp=ADDR_PERM4(p);
-  while(lmp>0&&ptp[lmp-1]==lmp-1) lmp--;
-  if(lmp==0) return f;
+    if (DEG_PPERM2(f) == 0)
+        return EmptyPartialPerm;
 
-  //invert the permutation into the buffer bag
-  ResizeTmpPPerm(lmp);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  ptp=ADDR_PERM4(p);
-  for(i=0;i<lmp;i++) pttmp[*ptp++]=i; 
+    // find the largest moved point
+    lmp = DEG_PERM4(p);
+    ptp = ADDR_PERM4(p);
+    while (lmp > 0 && ptp[lmp - 1] == lmp - 1)
+        lmp--;
+    if (lmp == 0)
+        return f;
 
-  //create new pperm
-  deg=DEG_PPERM2(f);
-  quo=NEW_PPERM4(deg);
-  
-  //renew pointers  
-  ptf=ADDR_PPERM2(f);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  ptquo=ADDR_PPERM4(quo);
-  
-  //multiply the partial perm with the inverse
-  codeg=0;
-  if(DOM_PPERM(f)==NULL){
-    for(i=0;i<deg;i++){
-      if(ptf[i]!=0){
-        ptquo[i]=pttmp[ptf[i]-1]+1;
-        if(ptquo[i]>codeg) codeg=ptquo[i];
-      }
+    // invert the permutation into the buffer bag
+    ResizeTmpPPerm(lmp);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    ptp = ADDR_PERM4(p);
+    for (i = 0; i < lmp; i++)
+        pttmp[*ptp++] = i;
+
+    // create new pperm
+    deg = DEG_PPERM2(f);
+    quo = NEW_PPERM4(deg);
+
+    // renew pointers
+    ptf = ADDR_PPERM2(f);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    ptquo = ADDR_PPERM4(quo);
+
+    // multiply the partial perm with the inverse
+    codeg = 0;
+    if (DOM_PPERM(f) == NULL) {
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != 0) {
+                ptquo[i] = pttmp[ptf[i] - 1] + 1;
+                if (ptquo[i] > codeg)
+                    codeg = ptquo[i];
+            }
+        }
     }
-  } else {
-    dom=DOM_PPERM(f);
-    rank=RANK_PPERM2(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptquo[j]=pttmp[ptf[j]-1]+1;
-      if(ptquo[j]>codeg) codeg=ptquo[j];
+    else {
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM2(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptquo[j] = pttmp[ptf[j] - 1] + 1;
+            if (ptquo[j] > codeg)
+                codeg = ptquo[j];
+        }
     }
-  }
-  CODEG_PPERM4(quo)=codeg;
-  return quo;
+    CODEG_PPERM4(quo) = codeg;
+    return quo;
 }
 
-Obj QuoPPerm4Perm2( Obj f, Obj p){
-  UInt4   *ptf, *ptquo, *pttmp;
-  UInt2   *ptp;
-  Obj     quo, dom;
-  UInt    lmp, deg, i, j, rank;
+Obj QuoPPerm4Perm2(Obj f, Obj p)
+{
+    UInt4 * ptf, *ptquo, *pttmp;
+    UInt2 * ptp;
+    Obj     quo, dom;
+    UInt    lmp, deg, i, j, rank;
 
-  if(DEG_PPERM4(f)==0) return EmptyPartialPerm;
-  
-  //find the largest moved point
-  lmp=DEG_PERM2(p);
-  ptp=ADDR_PERM2(p);
-  while(lmp>0&&ptp[lmp-1]==lmp-1) lmp--;
-  if(lmp==0) return f;
+    if (DEG_PPERM4(f) == 0)
+        return EmptyPartialPerm;
 
-  //invert the permutation into the buffer bag
-  ResizeTmpPPerm(lmp);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  ptp=ADDR_PERM2(p);
-  for(i=0;i<lmp;i++) pttmp[*ptp++]=i; 
+    // find the largest moved point
+    lmp = DEG_PERM2(p);
+    ptp = ADDR_PERM2(p);
+    while (lmp > 0 && ptp[lmp - 1] == lmp - 1)
+        lmp--;
+    if (lmp == 0)
+        return f;
 
-  //create new pperm
-  deg=DEG_PPERM4(f);
-  quo=NEW_PPERM4(deg);
-  
-  //renew pointers  
-  ptf=ADDR_PPERM4(f);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  ptquo=ADDR_PPERM4(quo);
-  
-  //multiply the partial perm with the inverse
-  if(DOM_PPERM(f)==NULL){
-    //Pr("case 1\n", 0L, 0L);
-    for(i=0;i<deg;i++){
-      if(ptf[i]!=0){
-        ptquo[i]=IMAGE(ptf[i]-1, pttmp, lmp)+1;
-      }
+    // invert the permutation into the buffer bag
+    ResizeTmpPPerm(lmp);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    ptp = ADDR_PERM2(p);
+    for (i = 0; i < lmp; i++)
+        pttmp[*ptp++] = i;
+
+    // create new pperm
+    deg = DEG_PPERM4(f);
+    quo = NEW_PPERM4(deg);
+
+    // renew pointers
+    ptf = ADDR_PPERM4(f);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    ptquo = ADDR_PPERM4(quo);
+
+    // multiply the partial perm with the inverse
+    if (DOM_PPERM(f) == NULL) {
+        // Pr("case 1\n", 0L, 0L);
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != 0) {
+                ptquo[i] = IMAGE(ptf[i] - 1, pttmp, lmp) + 1;
+            }
+        }
     }
-  }else{
-    //Pr("case 2\n", 0L, 0L);
-    dom=DOM_PPERM(f);
-    rank=RANK_PPERM4(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      ptquo[j]=IMAGE(ptf[j]-1, pttmp, lmp)+1;
+    else {
+        // Pr("case 2\n", 0L, 0L);
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM4(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptquo[j] = IMAGE(ptf[j] - 1, pttmp, lmp) + 1;
+        }
     }
-  }
-  CODEG_PPERM4(quo)=CODEG_PPERM4(f);
-  return quo;
+    CODEG_PPERM4(quo) = CODEG_PPERM4(f);
+    return quo;
 }
 
 // f*g^-1 for partial perms
-Obj QuoPPerm22(Obj f, Obj g){
-  UInt    deg, i, j, deginv, codeg, rank; 
-  UInt2   *ptf, *ptg;
-  UInt4   *ptquo, *pttmp;
-  Obj     quo, dom;
+Obj QuoPPerm22(Obj f, Obj g)
+{
+    UInt   deg, i, j, deginv, codeg, rank;
+    UInt2 *ptf, *ptg;
+    UInt4 *ptquo, *pttmp;
+    Obj    quo, dom;
 
-  //do nothing in the trivial case 
-  if(DEG_PPERM2(g)==0||DEG_PPERM2(f)==0) return EmptyPartialPerm;
+    // do nothing in the trivial case
+    if (DEG_PPERM2(g) == 0 || DEG_PPERM2(f) == 0)
+        return EmptyPartialPerm;
 
-  //init the buffer bag
-  deginv=CODEG_PPERM2(g);
-  ResizeTmpPPerm(deginv);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  for(i=0;i<deginv;i++) pttmp[i]=0;
+    // init the buffer bag
+    deginv = CODEG_PPERM2(g);
+    ResizeTmpPPerm(deginv);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    for (i = 0; i < deginv; i++)
+        pttmp[i] = 0;
 
-  //invert g into the buffer bag
-  ptg=ADDR_PPERM2(g);
-  if(DOM_PPERM(g)==NULL){
-    deg=DEG_PPERM2(g);
-    for(i=0;i<deg;i++) if(ptg[i]!=0) pttmp[ptg[i]-1]=i+1; 
-  } else {
-    dom=DOM_PPERM(g);
-    rank=RANK_PPERM2(g);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      pttmp[ptg[j]-1]=j+1;
+    // invert g into the buffer bag
+    ptg = ADDR_PPERM2(g);
+    if (DOM_PPERM(g) == NULL) {
+        deg = DEG_PPERM2(g);
+        for (i = 0; i < deg; i++)
+            if (ptg[i] != 0)
+                pttmp[ptg[i] - 1] = i + 1;
     }
-  }
-
-  // find the degree of the quotient
-  deg=DEG_PPERM2(f); 
-  ptf=ADDR_PPERM2(f);
-  while(deg>0&&(ptf[deg-1]==0||IMAGEPP(ptf[deg-1],pttmp,deginv)==0)) deg--;
-  if(deg==0) return EmptyPartialPerm;
-
-  // create new pperm
-  quo=NEW_PPERM4(deg);
-  ptquo=ADDR_PPERM4(quo);
-  ptf=ADDR_PPERM2(f);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  codeg=0;
- 
-  // compose f with g^-1 in rank operations
-  if(DOM_PPERM(f)!=NULL){
-    dom=DOM_PPERM(f);
-    rank=RANK_PPERM2(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(j<deg && ptf[j]<=deginv){
-        ptquo[j]=pttmp[ptf[j]-1];
-        if(ptquo[j]>codeg) codeg=ptquo[j];
-      }
+    else {
+        dom = DOM_PPERM(g);
+        rank = RANK_PPERM2(g);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            pttmp[ptg[j] - 1] = j + 1;
+        }
     }
-  } else { 
-  // compose f with g^-1 in deg operations
-    for(i=0;i<deg;i++){
-      if(ptf[i]!=0&&ptf[i]<=deginv){
-        ptquo[i]=pttmp[ptf[i]-1];
-        if(ptquo[i]>codeg) codeg=ptquo[i];
-      }
+
+    // find the degree of the quotient
+    deg = DEG_PPERM2(f);
+    ptf = ADDR_PPERM2(f);
+    while (deg > 0 &&
+           (ptf[deg - 1] == 0 || IMAGEPP(ptf[deg - 1], pttmp, deginv) == 0))
+        deg--;
+    if (deg == 0)
+        return EmptyPartialPerm;
+
+    // create new pperm
+    quo = NEW_PPERM4(deg);
+    ptquo = ADDR_PPERM4(quo);
+    ptf = ADDR_PPERM2(f);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    codeg = 0;
+
+    // compose f with g^-1 in rank operations
+    if (DOM_PPERM(f) != NULL) {
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM2(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (j < deg && ptf[j] <= deginv) {
+                ptquo[j] = pttmp[ptf[j] - 1];
+                if (ptquo[j] > codeg)
+                    codeg = ptquo[j];
+            }
+        }
     }
-  }
-  CODEG_PPERM4(quo)=codeg;
-  return quo;
+    else {
+        // compose f with g^-1 in deg operations
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != 0 && ptf[i] <= deginv) {
+                ptquo[i] = pttmp[ptf[i] - 1];
+                if (ptquo[i] > codeg)
+                    codeg = ptquo[i];
+            }
+        }
+    }
+    CODEG_PPERM4(quo) = codeg;
+    return quo;
 }
 
-Obj QuoPPerm24(Obj f, Obj g){
-  UInt    deg, i, j, deginv, codeg, rank; 
-  UInt2   *ptf;
-  UInt4   *ptg, *ptquo, *pttmp;
-  Obj     quo, dom;
+Obj QuoPPerm24(Obj f, Obj g)
+{
+    UInt    deg, i, j, deginv, codeg, rank;
+    UInt2 * ptf;
+    UInt4 * ptg, *ptquo, *pttmp;
+    Obj     quo, dom;
 
-  //do nothing in the trivial case 
-  if(DEG_PPERM4(g)==0||DEG_PPERM2(f)==0) return EmptyPartialPerm;
+    // do nothing in the trivial case
+    if (DEG_PPERM4(g) == 0 || DEG_PPERM2(f) == 0)
+        return EmptyPartialPerm;
 
-  //init the buffer bag
-  deginv=CODEG_PPERM4(g);
-  ResizeTmpPPerm(deginv);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  for(i=0;i<deginv;i++) pttmp[i]=0;
+    // init the buffer bag
+    deginv = CODEG_PPERM4(g);
+    ResizeTmpPPerm(deginv);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    for (i = 0; i < deginv; i++)
+        pttmp[i] = 0;
 
-  //invert g into the buffer bag
-  ptg=ADDR_PPERM4(g);
-  if(DOM_PPERM(g)==NULL){
-    deg=DEG_PPERM4(g);
-    for(i=0;i<deg;i++) if(ptg[i]!=0) pttmp[ptg[i]-1]=i+1; 
-  } else {
-    dom=DOM_PPERM(g);
-    rank=RANK_PPERM4(g);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      pttmp[ptg[j]-1]=j+1;
+    // invert g into the buffer bag
+    ptg = ADDR_PPERM4(g);
+    if (DOM_PPERM(g) == NULL) {
+        deg = DEG_PPERM4(g);
+        for (i = 0; i < deg; i++)
+            if (ptg[i] != 0)
+                pttmp[ptg[i] - 1] = i + 1;
     }
-  }
-
-  // find the degree of the quotient
-  deg=DEG_PPERM2(f);
-  ptf=ADDR_PPERM2(f);
-  if(CODEG_PPERM2(f)<=deginv){
-    while(deg>0&&(ptf[deg-1]==0||pttmp[ptf[deg-1]-1]==0)) deg--;
-  } else {
-    while(deg>0&&(ptf[deg-1]==0||IMAGEPP(ptf[deg-1],pttmp,deginv)==0)) deg--;
-  }
-
-  if(deg==0) return EmptyPartialPerm;
-
-  // create new pperm
-  quo=NEW_PPERM4(deg);
-  ptquo=ADDR_PPERM4(quo);
-  ptf=ADDR_PPERM2(f);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  codeg=0;
-
-  // compose f with g^-1 in rank operations
-  if(DOM_PPERM(f)!=NULL){
-    dom=DOM_PPERM(f); 
-    rank=RANK_PPERM2(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(j<deg && ptf[j]<=deginv){
-        ptquo[j]=pttmp[ptf[j]-1];
-        if(ptquo[j]>codeg) codeg=ptquo[j];
-      }
+    else {
+        dom = DOM_PPERM(g);
+        rank = RANK_PPERM4(g);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            pttmp[ptg[j] - 1] = j + 1;
+        }
     }
-  } else { 
-  // compose f with g^-1 in deg operations
-    for(i=0;i<deg;i++){
-      if(ptf[i]!=0&&ptf[i]<=deginv){
-        ptquo[i]=pttmp[ptf[i]-1];
-        if(ptquo[i]>codeg) codeg=ptquo[i];
-      }
+
+    // find the degree of the quotient
+    deg = DEG_PPERM2(f);
+    ptf = ADDR_PPERM2(f);
+    if (CODEG_PPERM2(f) <= deginv) {
+        while (deg > 0 && (ptf[deg - 1] == 0 || pttmp[ptf[deg - 1] - 1] == 0))
+            deg--;
     }
-  }
-  CODEG_PPERM4(quo)=codeg;
-  return quo;
+    else {
+        while (deg > 0 && (ptf[deg - 1] == 0 ||
+                           IMAGEPP(ptf[deg - 1], pttmp, deginv) == 0))
+            deg--;
+    }
+
+    if (deg == 0)
+        return EmptyPartialPerm;
+
+    // create new pperm
+    quo = NEW_PPERM4(deg);
+    ptquo = ADDR_PPERM4(quo);
+    ptf = ADDR_PPERM2(f);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    codeg = 0;
+
+    // compose f with g^-1 in rank operations
+    if (DOM_PPERM(f) != NULL) {
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM2(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (j < deg && ptf[j] <= deginv) {
+                ptquo[j] = pttmp[ptf[j] - 1];
+                if (ptquo[j] > codeg)
+                    codeg = ptquo[j];
+            }
+        }
+    }
+    else {
+        // compose f with g^-1 in deg operations
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != 0 && ptf[i] <= deginv) {
+                ptquo[i] = pttmp[ptf[i] - 1];
+                if (ptquo[i] > codeg)
+                    codeg = ptquo[i];
+            }
+        }
+    }
+    CODEG_PPERM4(quo) = codeg;
+    return quo;
 }
 
-Obj QuoPPerm42(Obj f, Obj g){
-  UInt    deg, i, j, deginv, codeg, rank; 
-  UInt2   *ptg;
-  UInt4   *ptf, *ptquo, *pttmp;
-  Obj     quo, dom;
+Obj QuoPPerm42(Obj f, Obj g)
+{
+    UInt    deg, i, j, deginv, codeg, rank;
+    UInt2 * ptg;
+    UInt4 * ptf, *ptquo, *pttmp;
+    Obj     quo, dom;
 
-  //do nothing in the trivial case 
-  if(DEG_PPERM2(g)==0||DEG_PPERM4(f)==0) return EmptyPartialPerm;
+    // do nothing in the trivial case
+    if (DEG_PPERM2(g) == 0 || DEG_PPERM4(f) == 0)
+        return EmptyPartialPerm;
 
-  //init the buffer bag
-  deginv=CODEG_PPERM2(g);
-  ResizeTmpPPerm(deginv);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  for(i=0;i<deginv;i++) pttmp[i]=0;
+    // init the buffer bag
+    deginv = CODEG_PPERM2(g);
+    ResizeTmpPPerm(deginv);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    for (i = 0; i < deginv; i++)
+        pttmp[i] = 0;
 
-  //invert g into the buffer bag
-  ptg=ADDR_PPERM2(g);
-  if(DOM_PPERM(g)==NULL){
-    deg=DEG_PPERM2(g);
-    for(i=0;i<deg;i++) if(ptg[i]!=0) pttmp[ptg[i]-1]=i+1; 
-  } else {
-    dom=DOM_PPERM(g);
-    rank=RANK_PPERM2(g);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      pttmp[ptg[j]-1]=j+1;
+    // invert g into the buffer bag
+    ptg = ADDR_PPERM2(g);
+    if (DOM_PPERM(g) == NULL) {
+        deg = DEG_PPERM2(g);
+        for (i = 0; i < deg; i++)
+            if (ptg[i] != 0)
+                pttmp[ptg[i] - 1] = i + 1;
     }
-  }
-
-  // find the degree of the quotient
-  deg=DEG_PPERM4(f);
-  ptf=ADDR_PPERM4(f);
-  if(CODEG_PPERM4(f)<=deginv){
-    while(deg>0&&(ptf[deg-1]==0||pttmp[ptf[deg-1]-1]==0)) deg--;
-  } else {
-    while(deg>0&&(ptf[deg-1]==0||IMAGEPP(ptf[deg-1],pttmp,deginv)==0)) deg--;
-  }
-
-  if(deg==0) return EmptyPartialPerm;
-
-  // create new pperm
-  quo=NEW_PPERM4(deg);
-  ptquo=ADDR_PPERM4(quo);
-  ptf=ADDR_PPERM4(f);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  codeg=0;
-
-  // compose f with g^-1 in rank operations
-  if(DOM_PPERM(f)!=NULL){
-    dom=DOM_PPERM(f); 
-    rank=RANK_PPERM4(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(j<deg && ptf[j]<=deginv){
-        ptquo[j]=pttmp[ptf[j]-1];
-        if(ptquo[j]>codeg) codeg=ptquo[j];
-      }
+    else {
+        dom = DOM_PPERM(g);
+        rank = RANK_PPERM2(g);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            pttmp[ptg[j] - 1] = j + 1;
+        }
     }
-  } else { 
-  // compose f with g^-1 in deg operations
-    for(i=0;i<deg;i++){
-      if(ptf[i]!=0&&ptf[i]<=deginv){
-        ptquo[i]=pttmp[ptf[i]-1];
-        if(ptquo[i]>codeg) codeg=ptquo[i];
-      }
+
+    // find the degree of the quotient
+    deg = DEG_PPERM4(f);
+    ptf = ADDR_PPERM4(f);
+    if (CODEG_PPERM4(f) <= deginv) {
+        while (deg > 0 && (ptf[deg - 1] == 0 || pttmp[ptf[deg - 1] - 1] == 0))
+            deg--;
     }
-  }
-  CODEG_PPERM4(quo)=codeg;
-  return quo;
+    else {
+        while (deg > 0 && (ptf[deg - 1] == 0 ||
+                           IMAGEPP(ptf[deg - 1], pttmp, deginv) == 0))
+            deg--;
+    }
+
+    if (deg == 0)
+        return EmptyPartialPerm;
+
+    // create new pperm
+    quo = NEW_PPERM4(deg);
+    ptquo = ADDR_PPERM4(quo);
+    ptf = ADDR_PPERM4(f);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    codeg = 0;
+
+    // compose f with g^-1 in rank operations
+    if (DOM_PPERM(f) != NULL) {
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM4(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (j < deg && ptf[j] <= deginv) {
+                ptquo[j] = pttmp[ptf[j] - 1];
+                if (ptquo[j] > codeg)
+                    codeg = ptquo[j];
+            }
+        }
+    }
+    else {
+        // compose f with g^-1 in deg operations
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != 0 && ptf[i] <= deginv) {
+                ptquo[i] = pttmp[ptf[i] - 1];
+                if (ptquo[i] > codeg)
+                    codeg = ptquo[i];
+            }
+        }
+    }
+    CODEG_PPERM4(quo) = codeg;
+    return quo;
 }
 
-Obj QuoPPerm44(Obj f, Obj g){
-  UInt    deg, i, j, deginv, codeg, rank; 
-  UInt4   *ptf, *ptg, *ptquo, *pttmp;
-  Obj     quo, dom;
+Obj QuoPPerm44(Obj f, Obj g)
+{
+    UInt   deg, i, j, deginv, codeg, rank;
+    UInt4 *ptf, *ptg, *ptquo, *pttmp;
+    Obj    quo, dom;
 
-  //do nothing in the trivial case 
-  if(DEG_PPERM4(g)==0||DEG_PPERM4(f)==0) return EmptyPartialPerm;
+    // do nothing in the trivial case
+    if (DEG_PPERM4(g) == 0 || DEG_PPERM4(f) == 0)
+        return EmptyPartialPerm;
 
-  //init the buffer bag
-  deginv=CODEG_PPERM4(g);
-  ResizeTmpPPerm(deginv);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  for(i=0;i<deginv;i++) pttmp[i]=0;
+    // init the buffer bag
+    deginv = CODEG_PPERM4(g);
+    ResizeTmpPPerm(deginv);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    for (i = 0; i < deginv; i++)
+        pttmp[i] = 0;
 
-  //invert g into the buffer bag
-  ptg=ADDR_PPERM4(g);
-  if(DOM_PPERM(g)==NULL){
-    deg=DEG_PPERM4(g);
-    for(i=0;i<deg;i++) if(ptg[i]!=0) pttmp[ptg[i]-1]=i+1; 
-  } else {
-    dom=DOM_PPERM(g);
-    rank=RANK_PPERM4(g);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      pttmp[ptg[j]-1]=j+1;
+    // invert g into the buffer bag
+    ptg = ADDR_PPERM4(g);
+    if (DOM_PPERM(g) == NULL) {
+        deg = DEG_PPERM4(g);
+        for (i = 0; i < deg; i++)
+            if (ptg[i] != 0)
+                pttmp[ptg[i] - 1] = i + 1;
     }
-  }
-
-  // find the degree of the quotient
-  deg=DEG_PPERM4(f);
-  ptf=ADDR_PPERM4(f);
-  while(deg>0&&(ptf[deg-1]==0||IMAGEPP(ptf[deg-1],pttmp,deginv)==0)) deg--;
-  if(deg==0) return EmptyPartialPerm;
-
-  // create new pperm
-  quo=NEW_PPERM4(deg);
-  ptquo=ADDR_PPERM4(quo);
-  ptf=ADDR_PPERM4(f);
-  pttmp=((UInt4*)ADDR_OBJ(TmpPPerm));
-  codeg=0;
- 
-  // compose f with g^-1 in rank operations
-  if(DOM_PPERM(f)!=NULL){
-    dom=DOM_PPERM(f);
-    rank=RANK_PPERM4(f);
-    for(i=1;i<=rank;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(j<deg && ptf[j]<=deginv){
-        ptquo[j]=pttmp[ptf[j]-1];
-        if(ptquo[j]>codeg) codeg=ptquo[j];
-      }
+    else {
+        dom = DOM_PPERM(g);
+        rank = RANK_PPERM4(g);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            pttmp[ptg[j] - 1] = j + 1;
+        }
     }
-  } else { 
-  // compose f with g^-1 in deg operations
-    for(i=0;i<deg;i++){
-      if(ptf[i]!=0&&ptf[i]<=deginv){
-        ptquo[i]=pttmp[ptf[i]-1];
-        if(ptquo[i]>codeg) codeg=ptquo[i];
-      }
+
+    // find the degree of the quotient
+    deg = DEG_PPERM4(f);
+    ptf = ADDR_PPERM4(f);
+    while (deg > 0 &&
+           (ptf[deg - 1] == 0 || IMAGEPP(ptf[deg - 1], pttmp, deginv) == 0))
+        deg--;
+    if (deg == 0)
+        return EmptyPartialPerm;
+
+    // create new pperm
+    quo = NEW_PPERM4(deg);
+    ptquo = ADDR_PPERM4(quo);
+    ptf = ADDR_PPERM4(f);
+    pttmp = ((UInt4 *)ADDR_OBJ(TmpPPerm));
+    codeg = 0;
+
+    // compose f with g^-1 in rank operations
+    if (DOM_PPERM(f) != NULL) {
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM4(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (j < deg && ptf[j] <= deginv) {
+                ptquo[j] = pttmp[ptf[j] - 1];
+                if (ptquo[j] > codeg)
+                    codeg = ptquo[j];
+            }
+        }
     }
-  }
-  CODEG_PPERM4(quo)=codeg;
-  return quo;
+    else {
+        // compose f with g^-1 in deg operations
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != 0 && ptf[i] <= deginv) {
+                ptquo[i] = pttmp[ptf[i] - 1];
+                if (ptquo[i] > codeg)
+                    codeg = ptquo[i];
+            }
+        }
+    }
+    CODEG_PPERM4(quo) = codeg;
+    return quo;
 }
 
-// i^f 
-Obj PowIntPPerm2(Obj i, Obj f){
+// i^f
+Obj PowIntPPerm2(Obj i, Obj f)
+{
 
-  if (!IS_INTOBJ(i) || INT_INTOBJ(i)<=0) {
-    ErrorQuit("usage: the first argument should be a positive integer,", 0L, 0L);
-    return 0L;
-  }
-  return INTOBJ_INT(IMAGEPP((UInt) INT_INTOBJ(i), ADDR_PPERM2(f), DEG_PPERM2(f)));
+    if (!IS_INTOBJ(i) || INT_INTOBJ(i) <= 0) {
+        ErrorQuit("usage: the first argument should be a positive integer,",
+                  0L, 0L);
+        return 0L;
+    }
+    return INTOBJ_INT(
+        IMAGEPP((UInt)INT_INTOBJ(i), ADDR_PPERM2(f), DEG_PPERM2(f)));
 }
 
-Obj PowIntPPerm4(Obj i, Obj f){
+Obj PowIntPPerm4(Obj i, Obj f)
+{
 
-  if (!IS_INTOBJ(i) || INT_INTOBJ(i)<=0) {
-    ErrorQuit("usage: the first argument should be a positive integer,", 0L, 0L);
-    return 0L;
-  }
-  return INTOBJ_INT(IMAGEPP((UInt) INT_INTOBJ(i), ADDR_PPERM4(f), DEG_PPERM4(f)));
+    if (!IS_INTOBJ(i) || INT_INTOBJ(i) <= 0) {
+        ErrorQuit("usage: the first argument should be a positive integer,",
+                  0L, 0L);
+        return 0L;
+    }
+    return INTOBJ_INT(
+        IMAGEPP((UInt)INT_INTOBJ(i), ADDR_PPERM4(f), DEG_PPERM4(f)));
 }
 
 // p^-1*f
-Obj LQuoPerm2PPerm2( Obj p, Obj f ){
-  UInt2   *ptp, *ptf, *ptlquo, dep;
-  UInt    def, i, j, del, len;
-  Obj     dom, lquo;
+Obj LQuoPerm2PPerm2(Obj p, Obj f)
+{
+    UInt2 *ptp, *ptf, *ptlquo, dep;
+    UInt   def, i, j, del, len;
+    Obj    dom, lquo;
 
-  def=DEG_PPERM2(f);
-  if(def==0) return EmptyPartialPerm;
-  
-  dep=DEG_PERM2(p);
-  dom=DOM_PPERM(f);
+    def = DEG_PPERM2(f);
+    if (def == 0)
+        return EmptyPartialPerm;
 
-  if(dep<def){
-    lquo=NEW_PPERM2(def);
-    ptlquo=ADDR_PPERM2(lquo);
-    ptp=ADDR_PERM2(p);
-    ptf=ADDR_PPERM2(f);
-    if(dom==NULL){
-      for(i=0;i<dep;i++) ptlquo[ptp[i]]=ptf[i];
-      for(;i<def;i++) ptlquo[i]=ptf[i];
-    } else {
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptlquo[IMAGE(j, ptp, dep)]=ptf[j];
-      }
-    }
-  } else { //deg(p)>=deg(f)
-    del=0;
-    ptp=ADDR_PERM2(p);
-    ptf=ADDR_PPERM2(f);
-    if(dom==NULL){
-      //find the degree
-      for(i=0;i<def;i++){
-        if(ptf[i]!=0&&ptp[i]>=del){
-          del=ptp[i]+1;
-          if(del==dep) break;
+    dep = DEG_PERM2(p);
+    dom = DOM_PPERM(f);
+
+    if (dep < def) {
+        lquo = NEW_PPERM2(def);
+        ptlquo = ADDR_PPERM2(lquo);
+        ptp = ADDR_PERM2(p);
+        ptf = ADDR_PPERM2(f);
+        if (dom == NULL) {
+            for (i = 0; i < dep; i++)
+                ptlquo[ptp[i]] = ptf[i];
+            for (; i < def; i++)
+                ptlquo[i] = ptf[i];
         }
-      }
-      lquo=NEW_PPERM2(del);
-      ptlquo=ADDR_PPERM2(lquo);
-      ptp=ADDR_PERM2(p);
-      ptf=ADDR_PPERM2(f);
-
-      // if required below in case ptp[i]>del but ptf[i]=0
-      for(i=0;i<def;i++) if(ptf[i]!=0) ptlquo[ptp[i]]=ptf[i];
-    } else {//dom(f) is known
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptp[j]>=del){
-          del=ptp[j]+1;
-          if(del==dep) break;
+        else {
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptlquo[IMAGE(j, ptp, dep)] = ptf[j];
+            }
         }
-      }
-      lquo=NEW_PPERM2(del);
-      ptlquo=ADDR_PPERM2(lquo);
-      ptp=ADDR_PERM2(p);
-      ptf=ADDR_PPERM2(f);
-
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptlquo[ptp[j]]=ptf[j];
-      }
     }
-  }
+    else {    // deg(p)>=deg(f)
+        del = 0;
+        ptp = ADDR_PERM2(p);
+        ptf = ADDR_PPERM2(f);
+        if (dom == NULL) {
+            // find the degree
+            for (i = 0; i < def; i++) {
+                if (ptf[i] != 0 && ptp[i] >= del) {
+                    del = ptp[i] + 1;
+                    if (del == dep)
+                        break;
+                }
+            }
+            lquo = NEW_PPERM2(del);
+            ptlquo = ADDR_PPERM2(lquo);
+            ptp = ADDR_PERM2(p);
+            ptf = ADDR_PPERM2(f);
 
-  CODEG_PPERM2(lquo)=CODEG_PPERM2(f);
-  return lquo;
+            // if required below in case ptp[i]>del but ptf[i]=0
+            for (i = 0; i < def; i++)
+                if (ptf[i] != 0)
+                    ptlquo[ptp[i]] = ptf[i];
+        }
+        else {    // dom(f) is known
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptp[j] >= del) {
+                    del = ptp[j] + 1;
+                    if (del == dep)
+                        break;
+                }
+            }
+            lquo = NEW_PPERM2(del);
+            ptlquo = ADDR_PPERM2(lquo);
+            ptp = ADDR_PERM2(p);
+            ptf = ADDR_PPERM2(f);
+
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptlquo[ptp[j]] = ptf[j];
+            }
+        }
+    }
+
+    CODEG_PPERM2(lquo) = CODEG_PPERM2(f);
+    return lquo;
 }
 
-Obj LQuoPerm2PPerm4( Obj p, Obj f ){
-  UInt2   *ptp, dep;
-  UInt4   *ptf, *ptlquo;
-  UInt    def, i, j, del, len;
-  Obj     dom, lquo;
+Obj LQuoPerm2PPerm4(Obj p, Obj f)
+{
+    UInt2 *ptp, dep;
+    UInt4 *ptf, *ptlquo;
+    UInt   def, i, j, del, len;
+    Obj    dom, lquo;
 
-  def=DEG_PPERM4(f);
-  if(def==0) return EmptyPartialPerm;
-  
-  dep=DEG_PERM2(p);
-  dom=DOM_PPERM(f);
+    def = DEG_PPERM4(f);
+    if (def == 0)
+        return EmptyPartialPerm;
 
-  if(dep<def){
-    lquo=NEW_PPERM4(def);
-    ptlquo=ADDR_PPERM4(lquo);
-    ptp=ADDR_PERM2(p);
-    ptf=ADDR_PPERM4(f);
-    if(dom==NULL){
-      for(i=0;i<dep;i++) ptlquo[ptp[i]]=ptf[i];
-      for(;i<def;i++) ptlquo[i]=ptf[i];
-    } else {
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptlquo[IMAGE(j, ptp, dep)]=ptf[j];
-      }
-    }
-  } else { //deg(p)>=deg(f)
-    del=0;
-    ptp=ADDR_PERM2(p);
-    ptf=ADDR_PPERM4(f);
-    if(dom==NULL){
-      //find the degree
-      for(i=0;i<def;i++){
-        if(ptf[i]!=0&&ptp[i]>=del){
-          del=ptp[i]+1;
-          if(del==dep) break;
+    dep = DEG_PERM2(p);
+    dom = DOM_PPERM(f);
+
+    if (dep < def) {
+        lquo = NEW_PPERM4(def);
+        ptlquo = ADDR_PPERM4(lquo);
+        ptp = ADDR_PERM2(p);
+        ptf = ADDR_PPERM4(f);
+        if (dom == NULL) {
+            for (i = 0; i < dep; i++)
+                ptlquo[ptp[i]] = ptf[i];
+            for (; i < def; i++)
+                ptlquo[i] = ptf[i];
         }
-      }
-      lquo=NEW_PPERM4(del);
-      ptlquo=ADDR_PPERM4(lquo);
-      ptp=ADDR_PERM2(p);
-      ptf=ADDR_PPERM4(f);
-
-      // if required below in case ptp[i]>del but ptf[i]=0
-      for(i=0;i<def;i++) if(ptf[i]!=0) ptlquo[ptp[i]]=ptf[i];
-    } else {//dom(f) is known
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptp[j]>=del){
-          del=ptp[j]+1;
-          if(del==dep) break;
+        else {
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptlquo[IMAGE(j, ptp, dep)] = ptf[j];
+            }
         }
-      }
-      lquo=NEW_PPERM4(del);
-      ptlquo=ADDR_PPERM4(lquo);
-      ptp=ADDR_PERM2(p);
-      ptf=ADDR_PPERM4(f);
-
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptlquo[ptp[j]]=ptf[j];
-      }
     }
-  }
+    else {    // deg(p)>=deg(f)
+        del = 0;
+        ptp = ADDR_PERM2(p);
+        ptf = ADDR_PPERM4(f);
+        if (dom == NULL) {
+            // find the degree
+            for (i = 0; i < def; i++) {
+                if (ptf[i] != 0 && ptp[i] >= del) {
+                    del = ptp[i] + 1;
+                    if (del == dep)
+                        break;
+                }
+            }
+            lquo = NEW_PPERM4(del);
+            ptlquo = ADDR_PPERM4(lquo);
+            ptp = ADDR_PERM2(p);
+            ptf = ADDR_PPERM4(f);
 
-  CODEG_PPERM4(lquo)=CODEG_PPERM4(f);
-  return lquo;
+            // if required below in case ptp[i]>del but ptf[i]=0
+            for (i = 0; i < def; i++)
+                if (ptf[i] != 0)
+                    ptlquo[ptp[i]] = ptf[i];
+        }
+        else {    // dom(f) is known
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptp[j] >= del) {
+                    del = ptp[j] + 1;
+                    if (del == dep)
+                        break;
+                }
+            }
+            lquo = NEW_PPERM4(del);
+            ptlquo = ADDR_PPERM4(lquo);
+            ptp = ADDR_PERM2(p);
+            ptf = ADDR_PPERM4(f);
+
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptlquo[ptp[j]] = ptf[j];
+            }
+        }
+    }
+
+    CODEG_PPERM4(lquo) = CODEG_PPERM4(f);
+    return lquo;
 }
 
-Obj LQuoPerm4PPerm2( Obj p, Obj f ){
-  UInt4   *ptp, dep;
-  UInt2   *ptf, *ptlquo;
-  UInt    def, i, j, del, len;
-  Obj     dom, lquo;
+Obj LQuoPerm4PPerm2(Obj p, Obj f)
+{
+    UInt4 *ptp, dep;
+    UInt2 *ptf, *ptlquo;
+    UInt   def, i, j, del, len;
+    Obj    dom, lquo;
 
-  def=DEG_PPERM2(f);
-  if(def==0) return EmptyPartialPerm;
-  
-  dep=DEG_PERM4(p);
-  dom=DOM_PPERM(f);
+    def = DEG_PPERM2(f);
+    if (def == 0)
+        return EmptyPartialPerm;
 
-  if(dep<def){
-    lquo=NEW_PPERM2(def);
-    ptlquo=ADDR_PPERM2(lquo);
-    ptp=ADDR_PERM4(p);
-    ptf=ADDR_PPERM2(f);
-    if(dom==NULL){
-      for(i=0;i<dep;i++) ptlquo[ptp[i]]=ptf[i];
-      for(;i<def;i++) ptlquo[i]=ptf[i];
-    } else {
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptlquo[IMAGE(j, ptp, dep)]=ptf[j];
-      }
-    }
-  } else { //deg(p)>=deg(f)
-    del=0;
-    ptp=ADDR_PERM4(p);
-    ptf=ADDR_PPERM2(f);
-    if(dom==NULL){
-      //find the degree
-      for(i=0;i<def;i++){
-        if(ptf[i]!=0&&ptp[i]>=del){
-          del=ptp[i]+1;
-          if(del==dep) break;
+    dep = DEG_PERM4(p);
+    dom = DOM_PPERM(f);
+
+    if (dep < def) {
+        lquo = NEW_PPERM2(def);
+        ptlquo = ADDR_PPERM2(lquo);
+        ptp = ADDR_PERM4(p);
+        ptf = ADDR_PPERM2(f);
+        if (dom == NULL) {
+            for (i = 0; i < dep; i++)
+                ptlquo[ptp[i]] = ptf[i];
+            for (; i < def; i++)
+                ptlquo[i] = ptf[i];
         }
-      }
-      lquo=NEW_PPERM2(del);
-      ptlquo=ADDR_PPERM2(lquo);
-      ptp=ADDR_PERM4(p);
-      ptf=ADDR_PPERM2(f);
-
-      // if required below in case ptp[i]>del but ptf[i]=0
-      for(i=0;i<def;i++) if(ptf[i]!=0) ptlquo[ptp[i]]=ptf[i];
-    } else {//dom(f) is known
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptp[j]>=del){
-          del=ptp[j]+1;
-          if(del==dep) break;
+        else {
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptlquo[IMAGE(j, ptp, dep)] = ptf[j];
+            }
         }
-      }
-      lquo=NEW_PPERM2(del);
-      ptlquo=ADDR_PPERM2(lquo);
-      ptp=ADDR_PERM4(p);
-      ptf=ADDR_PPERM2(f);
-
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptlquo[ptp[j]]=ptf[j];
-      }
     }
-  }
+    else {    // deg(p)>=deg(f)
+        del = 0;
+        ptp = ADDR_PERM4(p);
+        ptf = ADDR_PPERM2(f);
+        if (dom == NULL) {
+            // find the degree
+            for (i = 0; i < def; i++) {
+                if (ptf[i] != 0 && ptp[i] >= del) {
+                    del = ptp[i] + 1;
+                    if (del == dep)
+                        break;
+                }
+            }
+            lquo = NEW_PPERM2(del);
+            ptlquo = ADDR_PPERM2(lquo);
+            ptp = ADDR_PERM4(p);
+            ptf = ADDR_PPERM2(f);
 
-  CODEG_PPERM2(lquo)=CODEG_PPERM2(f);
-  return lquo;
+            // if required below in case ptp[i]>del but ptf[i]=0
+            for (i = 0; i < def; i++)
+                if (ptf[i] != 0)
+                    ptlquo[ptp[i]] = ptf[i];
+        }
+        else {    // dom(f) is known
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptp[j] >= del) {
+                    del = ptp[j] + 1;
+                    if (del == dep)
+                        break;
+                }
+            }
+            lquo = NEW_PPERM2(del);
+            ptlquo = ADDR_PPERM2(lquo);
+            ptp = ADDR_PERM4(p);
+            ptf = ADDR_PPERM2(f);
+
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptlquo[ptp[j]] = ptf[j];
+            }
+        }
+    }
+
+    CODEG_PPERM2(lquo) = CODEG_PPERM2(f);
+    return lquo;
 }
 
-Obj LQuoPerm4PPerm4( Obj p, Obj f ){
-  UInt4   *ptp, *ptf, *ptlquo, dep;
-  UInt    def, i, j, del, len;
-  Obj     dom, lquo;
+Obj LQuoPerm4PPerm4(Obj p, Obj f)
+{
+    UInt4 *ptp, *ptf, *ptlquo, dep;
+    UInt   def, i, j, del, len;
+    Obj    dom, lquo;
 
-  def=DEG_PPERM4(f);
-  if(def==0) return EmptyPartialPerm;
-  
-  dep=DEG_PERM4(p);
-  dom=DOM_PPERM(f);
+    def = DEG_PPERM4(f);
+    if (def == 0)
+        return EmptyPartialPerm;
 
-  if(dep<def){
-    lquo=NEW_PPERM4(def);
-    ptlquo=ADDR_PPERM4(lquo);
-    ptp=ADDR_PERM4(p);
-    ptf=ADDR_PPERM4(f);
-    if(dom==NULL){
-      for(i=0;i<dep;i++) ptlquo[ptp[i]]=ptf[i];
-      for(;i<def;i++) ptlquo[i]=ptf[i];
-    } else {
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptlquo[IMAGE(j, ptp, dep)]=ptf[j];
-      }
-    }
-  } else { //deg(p)>=deg(f)
-    del=0;
-    ptp=ADDR_PERM4(p);
-    ptf=ADDR_PPERM4(f);
-    if(dom==NULL){
-      //find the degree
-      for(i=0;i<def;i++){
-        if(ptf[i]!=0&&ptp[i]>=del){
-          del=ptp[i]+1;
-          if(del==dep) break;
+    dep = DEG_PERM4(p);
+    dom = DOM_PPERM(f);
+
+    if (dep < def) {
+        lquo = NEW_PPERM4(def);
+        ptlquo = ADDR_PPERM4(lquo);
+        ptp = ADDR_PERM4(p);
+        ptf = ADDR_PPERM4(f);
+        if (dom == NULL) {
+            for (i = 0; i < dep; i++)
+                ptlquo[ptp[i]] = ptf[i];
+            for (; i < def; i++)
+                ptlquo[i] = ptf[i];
         }
-      }
-      lquo=NEW_PPERM4(del);
-      ptlquo=ADDR_PPERM4(lquo);
-      ptp=ADDR_PERM4(p);
-      ptf=ADDR_PPERM4(f);
-
-      // if required below in case ptp[i]>del but ptf[i]=0
-      for(i=0;i<def;i++) if(ptf[i]!=0) ptlquo[ptp[i]]=ptf[i];
-    } else {//dom(f) is known
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptp[j]>=del){
-          del=ptp[j]+1;
-          if(del==dep) break;
+        else {
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptlquo[IMAGE(j, ptp, dep)] = ptf[j];
+            }
         }
-      }
-      lquo=NEW_PPERM4(del);
-      ptlquo=ADDR_PPERM4(lquo);
-      ptp=ADDR_PERM4(p);
-      ptf=ADDR_PPERM4(f);
-
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        ptlquo[ptp[j]]=ptf[j];
-      }
     }
-  }
+    else {    // deg(p)>=deg(f)
+        del = 0;
+        ptp = ADDR_PERM4(p);
+        ptf = ADDR_PPERM4(f);
+        if (dom == NULL) {
+            // find the degree
+            for (i = 0; i < def; i++) {
+                if (ptf[i] != 0 && ptp[i] >= del) {
+                    del = ptp[i] + 1;
+                    if (del == dep)
+                        break;
+                }
+            }
+            lquo = NEW_PPERM4(del);
+            ptlquo = ADDR_PPERM4(lquo);
+            ptp = ADDR_PERM4(p);
+            ptf = ADDR_PPERM4(f);
 
-  CODEG_PPERM4(lquo)=CODEG_PPERM4(f);
-  return lquo;
+            // if required below in case ptp[i]>del but ptf[i]=0
+            for (i = 0; i < def; i++)
+                if (ptf[i] != 0)
+                    ptlquo[ptp[i]] = ptf[i];
+        }
+        else {    // dom(f) is known
+            len = LEN_PLIST(dom);
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                if (ptp[j] >= del) {
+                    del = ptp[j] + 1;
+                    if (del == dep)
+                        break;
+                }
+            }
+            lquo = NEW_PPERM4(del);
+            ptlquo = ADDR_PPERM4(lquo);
+            ptp = ADDR_PERM4(p);
+            ptf = ADDR_PPERM4(f);
+
+            for (i = 1; i <= len; i++) {
+                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+                ptlquo[ptp[j]] = ptf[j];
+            }
+        }
+    }
+
+    CODEG_PPERM4(lquo) = CODEG_PPERM4(f);
+    return lquo;
 }
 
 // f^-1*g
-Obj LQuoPPerm22( Obj f, Obj g ){
-  UInt2   *ptg, *ptf, *ptlquo;
-  UInt    i, j, def, deg, del, codef, codel, min, len;
-  Obj     dom, lquo;
+Obj LQuoPPerm22(Obj f, Obj g)
+{
+    UInt2 *ptg, *ptf, *ptlquo;
+    UInt   i, j, def, deg, del, codef, codel, min, len;
+    Obj    dom, lquo;
 
-  //check if we're in the trivial case
-  def=DEG_PPERM2(f);
-  deg=DEG_PPERM2(g);
-  if(def==0||deg==0) return EmptyPartialPerm;
- 
-  ptf=ADDR_PPERM2(f);
-  ptg=ADDR_PPERM2(g);
-  dom=DOM_PPERM(g);
-  del=0;
-  codef=CODEG_PPERM2(f); 
-  codel=0;
-  
-  if(dom==NULL){
-    //find the degree of lquo
-    min=MIN(def,deg);
-    for(i=0;i<min;i++){
-      if(ptg[i]!=0&&ptf[i]>del){
-        del=ptf[i];
-        if(del==codef) break;
-      }
-    }
-    if(del==0) return EmptyPartialPerm;
-    
-    //create new pperm
-    lquo=NEW_PPERM2(del);
-    ptlquo=ADDR_PPERM2(lquo);
-    ptf=ADDR_PPERM2(f);
-    ptg=ADDR_PPERM2(g);
+    // check if we're in the trivial case
+    def = DEG_PPERM2(f);
+    deg = DEG_PPERM2(g);
+    if (def == 0 || deg == 0)
+        return EmptyPartialPerm;
 
-    //multiply
-    for(i=0;i<min;i++){
-      if(ptf[i]!=0&&ptg[i]!=0){
-        ptlquo[ptf[i]-1]=ptg[i];
-        if(ptg[i]>codel) codel=ptg[i];
-      }
-    }
-  } else if(deg>def){ //dom(g) is known
-    //find the degree of lquo
-    len=LEN_PLIST(dom);
-    for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(IMAGEPP(j+1, ptf, def)>del){
-        del=ptf[j];
-        if(del==codef) break;
-      }
-    }
-   
-    //create new pperm
-    lquo=NEW_PPERM2(del);
-    ptlquo=ADDR_PPERM2(lquo);
-    ptf=ADDR_PPERM2(f);
-    ptg=ADDR_PPERM2(g);
+    ptf = ADDR_PPERM2(f);
+    ptg = ADDR_PPERM2(g);
+    dom = DOM_PPERM(g);
+    del = 0;
+    codef = CODEG_PPERM2(f);
+    codel = 0;
 
-    //multiply
-    for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(IMAGEPP(j+1, ptf, def)!=0){
-        ptlquo[ptf[j]-1]=ptg[j];
-        if(ptg[j]>codel) codel=ptg[j];
-      }
-    }
-  } else { // deg<=def and dom(g) is known
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]>del){
-        del=ptf[j];
-        if(del==codef) break;
-      }
-    }
-   
-    //create new pperm
-    lquo=NEW_PPERM2(del);
-    ptlquo=ADDR_PPERM2(lquo);
-    ptf=ADDR_PPERM2(f);
-    ptg=ADDR_PPERM2(g);
-
-    //multiply
-    for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]!=0){
-        ptlquo[ptf[j]-1]=ptg[j];
-        if(ptg[j]>codel) codel=ptg[j];
-      }
-    }
-  }
-  CODEG_PPERM2(lquo)=codel;
-  return lquo;
-}
-
-Obj LQuoPPerm24( Obj f, Obj g ){
-  UInt4   *ptg, *ptlquo;
-  UInt2   *ptf;
-  UInt    i, j, def, deg, del, codef, codel, min, len;
-  Obj     dom, lquo;
-
-  //check if we're in the trivial case
-  def=DEG_PPERM2(f);
-  deg=DEG_PPERM4(g);
-  if(def==0||deg==0) return EmptyPartialPerm;
- 
-  ptf=ADDR_PPERM2(f);
-  ptg=ADDR_PPERM4(g);
-  dom=DOM_PPERM(g);
-  del=0;
-  codef=CODEG_PPERM2(f); 
-  codel=0;
-  
-  if(dom==NULL){
-    //find the degree of lquo
-    min=MIN(def,deg);
-    for(i=0;i<min;i++){
-      if(ptg[i]!=0&&ptf[i]>del){
-        del=ptf[i];
-        if(del==codef) break;
-      }
-    }
-    if(del==0) return EmptyPartialPerm;
-    
-    //create new pperm
-    lquo=NEW_PPERM4(del);
-    ptlquo=ADDR_PPERM4(lquo);
-    ptf=ADDR_PPERM2(f);
-    ptg=ADDR_PPERM4(g);
-
-    //multiply
-    for(i=0;i<min;i++){
-      if(ptf[i]!=0&&ptg[i]!=0){
-        ptlquo[ptf[i]-1]=ptg[i];
-        if(ptg[i]>codel) codel=ptg[i];
-      }
-    }
-  } else if(deg>def){ //dom(g) is known
-    //find the degree of lquo
-    len=LEN_PLIST(dom);
-    for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(IMAGEPP(j+1, ptf, def)>del){
-        del=ptf[j];
-        if(del==codef) break;
-      }
-    }
-   
-    //create new pperm
-    lquo=NEW_PPERM4(del);
-    ptlquo=ADDR_PPERM4(lquo);
-    ptf=ADDR_PPERM2(f);
-    ptg=ADDR_PPERM4(g);
-
-    //multiply
-    for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(IMAGEPP(j+1, ptf, def)!=0){
-        ptlquo[ptf[j]-1]=ptg[j];
-        if(ptg[j]>codel) codel=ptg[j];
-      }
-    }
-  } else { // deg<=def and dom(g) is known
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]>del){
-        del=ptf[j];
-        if(del==codef) break;
-      }
-    }
-   
-    //create new pperm
-    lquo=NEW_PPERM4(del);
-    ptlquo=ADDR_PPERM4(lquo);
-    ptf=ADDR_PPERM2(f);
-    ptg=ADDR_PPERM4(g);
-
-    //multiply
-    for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]!=0){
-        ptlquo[ptf[j]-1]=ptg[j];
-        if(ptg[j]>codel) codel=ptg[j];
-      }
-    }
-  }
-  CODEG_PPERM4(lquo)=codel;
-  return lquo;
-}
-
-Obj LQuoPPerm42( Obj f, Obj g ){
-  UInt2   *ptg, *ptlquo;
-  UInt4   *ptf;
-  UInt    i, j, def, deg, del, codef, codel, min, len;
-  Obj     dom, lquo;
-
-  //check if we're in the trivial case
-  def=DEG_PPERM4(f);
-  deg=DEG_PPERM2(g);
-  if(def==0||deg==0) return EmptyPartialPerm;
- 
-  ptf=ADDR_PPERM4(f);
-  ptg=ADDR_PPERM2(g);
-  dom=DOM_PPERM(g);
-  del=0;
-  codef=CODEG_PPERM4(f); 
-  codel=0;
-  
-  if(dom==NULL){
-    //find the degree of lquo
-    min=MIN(def, deg);
-    for(i=0;i<min;i++){
-      if(ptg[i]!=0&&ptf[i]>del){
-        del=ptf[i];
-        if(del==codef) break;
-      }
-    }
-    if(del==0) return EmptyPartialPerm;
-    
-    //create new pperm
-    lquo=NEW_PPERM2(del);
-    ptlquo=ADDR_PPERM2(lquo);
-    ptf=ADDR_PPERM4(f);
-    ptg=ADDR_PPERM2(g);
-
-    //multiply
-    for(i=0;i<min;i++){
-      if(ptf[i]!=0&&ptg[i]!=0){
-        ptlquo[ptf[i]-1]=ptg[i];
-        if(ptg[i]>codel) codel=ptg[i];
-      }
-    }
-  } else if(deg>def){ //dom(g) is known
-    //find the degree of lquo
-    len=LEN_PLIST(dom);
-    for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(IMAGEPP(j+1, ptf, def)>del){
-        del=ptf[j];
-        if(del==codef) break;
-      }
-    }
-   
-    //create new pperm
-    lquo=NEW_PPERM2(del);
-    ptlquo=ADDR_PPERM2(lquo);
-    ptf=ADDR_PPERM4(f);
-    ptg=ADDR_PPERM2(g);
-
-    //multiply
-    for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(IMAGEPP(j+1, ptf, def)!=0){
-        ptlquo[ptf[j]-1]=ptg[j];
-        if(ptg[j]>codel) codel=ptg[j];
-      }
-    }
-  } else { // deg<=def and dom(g) is known
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]>del){
-        del=ptf[j];
-        if(del==codef) break;
-      }
-    }
-   
-    //create new pperm
-    lquo=NEW_PPERM2(del);
-    ptlquo=ADDR_PPERM2(lquo);
-    ptf=ADDR_PPERM4(f);
-    ptg=ADDR_PPERM2(g);
-
-    //multiply
-    for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]!=0){
-        ptlquo[ptf[j]-1]=ptg[j];
-        if(ptg[j]>codel) codel=ptg[j];
-      }
-    }
-  }
-  CODEG_PPERM2(lquo)=codel;
-  return lquo;
-}
-
-Obj LQuoPPerm44( Obj f, Obj g ){
-  UInt4   *ptg, *ptf, *ptlquo;
-  UInt    i, j, def, deg, del, codef, codel, min, len;
-  Obj     dom, lquo;
-
-  //check if we're in the trivial case
-  def=DEG_PPERM4(f);
-  deg=DEG_PPERM4(g);
-  if(def==0||deg==0) return EmptyPartialPerm;
- 
-  ptf=ADDR_PPERM4(f);
-  ptg=ADDR_PPERM4(g);
-  dom=DOM_PPERM(g);
-  del=0;
-  codef=CODEG_PPERM4(f); 
-  codel=0;
-  
-  if(dom==NULL){
-    //find the degree of lquo
-    min=MIN(def, deg);
-    for(i=0;i<min;i++){
-      if(ptg[i]!=0&&ptf[i]>del){
-        del=ptf[i];
-        if(del==codef) break;
-      }
-    }
-    if(del==0) return EmptyPartialPerm;
-    
-    //create new pperm
-    lquo=NEW_PPERM4(del);
-    ptlquo=ADDR_PPERM4(lquo);
-    ptf=ADDR_PPERM4(f);
-    ptg=ADDR_PPERM4(g);
-
-    //multiply
-    for(i=0;i<min;i++){
-      if(ptf[i]!=0&&ptg[i]!=0){
-        ptlquo[ptf[i]-1]=ptg[i];
-        if(ptg[i]>codel) codel=ptg[i];
-      }
-    }
-  } else if(deg>def){ //dom(g) is known
-    //find the degree of lquo
-    len=LEN_PLIST(dom);
-    for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(IMAGEPP(j+1, ptf, def)>del){
-        del=ptf[j];
-        if(del==codef) break;
-      }
-    }
-   
-    //create new pperm
-    lquo=NEW_PPERM4(del);
-    ptlquo=ADDR_PPERM4(lquo);
-    ptf=ADDR_PPERM4(f);
-    ptg=ADDR_PPERM4(g);
-
-    //multiply
-    for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(IMAGEPP(j+1, ptf, def)!=0){
-        ptlquo[ptf[j]-1]=ptg[j];
-        if(ptg[j]>codel) codel=ptg[j];
-      }
-    }
-  } else { // deg<=def and dom(g) is known
-      len=LEN_PLIST(dom);
-      for(i=1;i<=len;i++){
-        j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-        if(ptf[j]>del){
-          del=ptf[j];
-          if(del==codef) break;
+    if (dom == NULL) {
+        // find the degree of lquo
+        min = MIN(def, deg);
+        for (i = 0; i < min; i++) {
+            if (ptg[i] != 0 && ptf[i] > del) {
+                del = ptf[i];
+                if (del == codef)
+                    break;
+            }
         }
-      }
-   
-    //create new pperm
-    lquo=NEW_PPERM4(del);
-    ptlquo=ADDR_PPERM4(lquo);
-    ptf=ADDR_PPERM4(f);
-    ptg=ADDR_PPERM4(g);
+        if (del == 0)
+            return EmptyPartialPerm;
 
-    //multiply
-    for(i=1;i<=len;i++){
-      j=INT_INTOBJ(ELM_PLIST(dom, i))-1;
-      if(ptf[j]!=0){
-        ptlquo[ptf[j]-1]=ptg[j];
-        if(ptg[j]>codel) codel=ptg[j];
-      }
+        // create new pperm
+        lquo = NEW_PPERM2(del);
+        ptlquo = ADDR_PPERM2(lquo);
+        ptf = ADDR_PPERM2(f);
+        ptg = ADDR_PPERM2(g);
+
+        // multiply
+        for (i = 0; i < min; i++) {
+            if (ptf[i] != 0 && ptg[i] != 0) {
+                ptlquo[ptf[i] - 1] = ptg[i];
+                if (ptg[i] > codel)
+                    codel = ptg[i];
+            }
+        }
     }
-  }
-  CODEG_PPERM4(lquo)=codel;
-  return lquo;
+    else if (deg > def) {    // dom(g) is known
+        // find the degree of lquo
+        len = LEN_PLIST(dom);
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (IMAGEPP(j + 1, ptf, def) > del) {
+                del = ptf[j];
+                if (del == codef)
+                    break;
+            }
+        }
+
+        // create new pperm
+        lquo = NEW_PPERM2(del);
+        ptlquo = ADDR_PPERM2(lquo);
+        ptf = ADDR_PPERM2(f);
+        ptg = ADDR_PPERM2(g);
+
+        // multiply
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (IMAGEPP(j + 1, ptf, def) != 0) {
+                ptlquo[ptf[j] - 1] = ptg[j];
+                if (ptg[j] > codel)
+                    codel = ptg[j];
+            }
+        }
+    }
+    else {    // deg<=def and dom(g) is known
+        len = LEN_PLIST(dom);
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptf[j] > del) {
+                del = ptf[j];
+                if (del == codef)
+                    break;
+            }
+        }
+
+        // create new pperm
+        lquo = NEW_PPERM2(del);
+        ptlquo = ADDR_PPERM2(lquo);
+        ptf = ADDR_PPERM2(f);
+        ptg = ADDR_PPERM2(g);
+
+        // multiply
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptf[j] != 0) {
+                ptlquo[ptf[j] - 1] = ptg[j];
+                if (ptg[j] > codel)
+                    codel = ptg[j];
+            }
+        }
+    }
+    CODEG_PPERM2(lquo) = codel;
+    return lquo;
 }
 
-Obj OnSetsPPerm (Obj set, Obj f){
-  UInt2  *ptf2;
-  UInt4  *ptf4;
-  UInt   deg;
-  Obj    *ptset, *ptres, tmp, res;
-  UInt   i, isint, k, h, len;
-  
-  if(LEN_LIST(set)==0) return set;
+Obj LQuoPPerm24(Obj f, Obj g)
+{
+    UInt4 * ptg, *ptlquo;
+    UInt2 * ptf;
+    UInt    i, j, def, deg, del, codef, codel, min, len;
+    Obj     dom, lquo;
 
-  res=NEW_PLIST(IS_MUTABLE_PLIST(set)?T_PLIST:T_PLIST+IMMUTABLE,LEN_LIST(set));
+    // check if we're in the trivial case
+    def = DEG_PPERM2(f);
+    deg = DEG_PPERM4(g);
+    if (def == 0 || deg == 0)
+        return EmptyPartialPerm;
 
-  /* get the pointer                                                 */
-  ptset = ADDR_OBJ(set) + LEN_LIST(set);
-  ptres = ADDR_OBJ(res) + 1;
-  len=0;
-  
-  if(TNUM_OBJ(f)==T_PPERM2){   
-    ptf2 = ADDR_PPERM2(f);
-    deg = DEG_PPERM2(f);
-    /* loop over the entries of the tuple                              */
-    isint = 1;
-    for ( i =LEN_LIST(set) ; 1 <= i; i--, ptset-- ) {
-      if ( IS_INTOBJ( *ptset ) && 0 < INT_INTOBJ( *ptset ) ) {
-        k = INT_INTOBJ( *ptset );
-        if (k<=deg&&ptf2[k-1]!=0){
-          tmp = INTOBJ_INT( ptf2[k-1] );
-          len++;
-          *ptres++ = tmp;
+    ptf = ADDR_PPERM2(f);
+    ptg = ADDR_PPERM4(g);
+    dom = DOM_PPERM(g);
+    del = 0;
+    codef = CODEG_PPERM2(f);
+    codel = 0;
+
+    if (dom == NULL) {
+        // find the degree of lquo
+        min = MIN(def, deg);
+        for (i = 0; i < min; i++) {
+            if (ptg[i] != 0 && ptf[i] > del) {
+                del = ptf[i];
+                if (del == codef)
+                    break;
+            }
         }
-      } else {/* this case cannot occur since I think POW is not defined */
-        ErrorQuit("not yet implemented!", 0L, 0L);
-      }
-    }
-  } else {
-    ptf4 = ADDR_PPERM4(f);
-    deg = DEG_PPERM4(f);
+        if (del == 0)
+            return EmptyPartialPerm;
 
-    /* loop over the entries of the tuple                              */
-    isint = 1;
-    for ( i =LEN_LIST(set) ; 1 <= i; i--, ptset-- ) {
-      if ( IS_INTOBJ( *ptset ) && 0 < INT_INTOBJ( *ptset ) ) {
-        k = INT_INTOBJ( *ptset );
-        if (k<=deg&&ptf4[k-1]!=0){
-          tmp = INTOBJ_INT( ptf4[k-1] );
-          len++;
-          *ptres++ = tmp;
+        // create new pperm
+        lquo = NEW_PPERM4(del);
+        ptlquo = ADDR_PPERM4(lquo);
+        ptf = ADDR_PPERM2(f);
+        ptg = ADDR_PPERM4(g);
+
+        // multiply
+        for (i = 0; i < min; i++) {
+            if (ptf[i] != 0 && ptg[i] != 0) {
+                ptlquo[ptf[i] - 1] = ptg[i];
+                if (ptg[i] > codel)
+                    codel = ptg[i];
+            }
         }
-      } else {/* this case cannot occur since I think POW is not defined */
-        ErrorQuit("not yet implemented!", 0L, 0L);
-      }
     }
-  }
-  //maybe a problem here if the result <res> has length 0, this certainly
-  //caused a problem in OnPosIntSetsPPerm...
-  if (len == 0) { 
-    RetypeBag(res, IS_MUTABLE_PLIST(set)?T_PLIST_EMPTY:T_PLIST_EMPTY+IMMUTABLE);
+    else if (deg > def) {    // dom(g) is known
+        // find the degree of lquo
+        len = LEN_PLIST(dom);
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (IMAGEPP(j + 1, ptf, def) > del) {
+                del = ptf[j];
+                if (del == codef)
+                    break;
+            }
+        }
+
+        // create new pperm
+        lquo = NEW_PPERM4(del);
+        ptlquo = ADDR_PPERM4(lquo);
+        ptf = ADDR_PPERM2(f);
+        ptg = ADDR_PPERM4(g);
+
+        // multiply
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (IMAGEPP(j + 1, ptf, def) != 0) {
+                ptlquo[ptf[j] - 1] = ptg[j];
+                if (ptg[j] > codel)
+                    codel = ptg[j];
+            }
+        }
+    }
+    else {    // deg<=def and dom(g) is known
+        len = LEN_PLIST(dom);
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptf[j] > del) {
+                del = ptf[j];
+                if (del == codef)
+                    break;
+            }
+        }
+
+        // create new pperm
+        lquo = NEW_PPERM4(del);
+        ptlquo = ADDR_PPERM4(lquo);
+        ptf = ADDR_PPERM2(f);
+        ptg = ADDR_PPERM4(g);
+
+        // multiply
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptf[j] != 0) {
+                ptlquo[ptf[j] - 1] = ptg[j];
+                if (ptg[j] > codel)
+                    codel = ptg[j];
+            }
+        }
+    }
+    CODEG_PPERM4(lquo) = codel;
+    return lquo;
+}
+
+Obj LQuoPPerm42(Obj f, Obj g)
+{
+    UInt2 * ptg, *ptlquo;
+    UInt4 * ptf;
+    UInt    i, j, def, deg, del, codef, codel, min, len;
+    Obj     dom, lquo;
+
+    // check if we're in the trivial case
+    def = DEG_PPERM4(f);
+    deg = DEG_PPERM2(g);
+    if (def == 0 || deg == 0)
+        return EmptyPartialPerm;
+
+    ptf = ADDR_PPERM4(f);
+    ptg = ADDR_PPERM2(g);
+    dom = DOM_PPERM(g);
+    del = 0;
+    codef = CODEG_PPERM4(f);
+    codel = 0;
+
+    if (dom == NULL) {
+        // find the degree of lquo
+        min = MIN(def, deg);
+        for (i = 0; i < min; i++) {
+            if (ptg[i] != 0 && ptf[i] > del) {
+                del = ptf[i];
+                if (del == codef)
+                    break;
+            }
+        }
+        if (del == 0)
+            return EmptyPartialPerm;
+
+        // create new pperm
+        lquo = NEW_PPERM2(del);
+        ptlquo = ADDR_PPERM2(lquo);
+        ptf = ADDR_PPERM4(f);
+        ptg = ADDR_PPERM2(g);
+
+        // multiply
+        for (i = 0; i < min; i++) {
+            if (ptf[i] != 0 && ptg[i] != 0) {
+                ptlquo[ptf[i] - 1] = ptg[i];
+                if (ptg[i] > codel)
+                    codel = ptg[i];
+            }
+        }
+    }
+    else if (deg > def) {    // dom(g) is known
+        // find the degree of lquo
+        len = LEN_PLIST(dom);
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (IMAGEPP(j + 1, ptf, def) > del) {
+                del = ptf[j];
+                if (del == codef)
+                    break;
+            }
+        }
+
+        // create new pperm
+        lquo = NEW_PPERM2(del);
+        ptlquo = ADDR_PPERM2(lquo);
+        ptf = ADDR_PPERM4(f);
+        ptg = ADDR_PPERM2(g);
+
+        // multiply
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (IMAGEPP(j + 1, ptf, def) != 0) {
+                ptlquo[ptf[j] - 1] = ptg[j];
+                if (ptg[j] > codel)
+                    codel = ptg[j];
+            }
+        }
+    }
+    else {    // deg<=def and dom(g) is known
+        len = LEN_PLIST(dom);
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptf[j] > del) {
+                del = ptf[j];
+                if (del == codef)
+                    break;
+            }
+        }
+
+        // create new pperm
+        lquo = NEW_PPERM2(del);
+        ptlquo = ADDR_PPERM2(lquo);
+        ptf = ADDR_PPERM4(f);
+        ptg = ADDR_PPERM2(g);
+
+        // multiply
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptf[j] != 0) {
+                ptlquo[ptf[j] - 1] = ptg[j];
+                if (ptg[j] > codel)
+                    codel = ptg[j];
+            }
+        }
+    }
+    CODEG_PPERM2(lquo) = codel;
+    return lquo;
+}
+
+Obj LQuoPPerm44(Obj f, Obj g)
+{
+    UInt4 *ptg, *ptf, *ptlquo;
+    UInt   i, j, def, deg, del, codef, codel, min, len;
+    Obj    dom, lquo;
+
+    // check if we're in the trivial case
+    def = DEG_PPERM4(f);
+    deg = DEG_PPERM4(g);
+    if (def == 0 || deg == 0)
+        return EmptyPartialPerm;
+
+    ptf = ADDR_PPERM4(f);
+    ptg = ADDR_PPERM4(g);
+    dom = DOM_PPERM(g);
+    del = 0;
+    codef = CODEG_PPERM4(f);
+    codel = 0;
+
+    if (dom == NULL) {
+        // find the degree of lquo
+        min = MIN(def, deg);
+        for (i = 0; i < min; i++) {
+            if (ptg[i] != 0 && ptf[i] > del) {
+                del = ptf[i];
+                if (del == codef)
+                    break;
+            }
+        }
+        if (del == 0)
+            return EmptyPartialPerm;
+
+        // create new pperm
+        lquo = NEW_PPERM4(del);
+        ptlquo = ADDR_PPERM4(lquo);
+        ptf = ADDR_PPERM4(f);
+        ptg = ADDR_PPERM4(g);
+
+        // multiply
+        for (i = 0; i < min; i++) {
+            if (ptf[i] != 0 && ptg[i] != 0) {
+                ptlquo[ptf[i] - 1] = ptg[i];
+                if (ptg[i] > codel)
+                    codel = ptg[i];
+            }
+        }
+    }
+    else if (deg > def) {    // dom(g) is known
+        // find the degree of lquo
+        len = LEN_PLIST(dom);
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (IMAGEPP(j + 1, ptf, def) > del) {
+                del = ptf[j];
+                if (del == codef)
+                    break;
+            }
+        }
+
+        // create new pperm
+        lquo = NEW_PPERM4(del);
+        ptlquo = ADDR_PPERM4(lquo);
+        ptf = ADDR_PPERM4(f);
+        ptg = ADDR_PPERM4(g);
+
+        // multiply
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (IMAGEPP(j + 1, ptf, def) != 0) {
+                ptlquo[ptf[j] - 1] = ptg[j];
+                if (ptg[j] > codel)
+                    codel = ptg[j];
+            }
+        }
+    }
+    else {    // deg<=def and dom(g) is known
+        len = LEN_PLIST(dom);
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptf[j] > del) {
+                del = ptf[j];
+                if (del == codef)
+                    break;
+            }
+        }
+
+        // create new pperm
+        lquo = NEW_PPERM4(del);
+        ptlquo = ADDR_PPERM4(lquo);
+        ptf = ADDR_PPERM4(f);
+        ptg = ADDR_PPERM4(g);
+
+        // multiply
+        for (i = 1; i <= len; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptf[j] != 0) {
+                ptlquo[ptf[j] - 1] = ptg[j];
+                if (ptg[j] > codel)
+                    codel = ptg[j];
+            }
+        }
+    }
+    CODEG_PPERM4(lquo) = codel;
+    return lquo;
+}
+
+Obj OnSetsPPerm(Obj set, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    deg;
+    Obj *   ptset, *ptres, tmp, res;
+    UInt    i, isint, k, h, len;
+
+    if (LEN_LIST(set) == 0)
+        return set;
+
+    res = NEW_PLIST(IS_MUTABLE_PLIST(set) ? T_PLIST : T_PLIST + IMMUTABLE,
+                    LEN_LIST(set));
+
+    /* get the pointer                                                 */
+    ptset = ADDR_OBJ(set) + LEN_LIST(set);
+    ptres = ADDR_OBJ(res) + 1;
+    len = 0;
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        ptf2 = ADDR_PPERM2(f);
+        deg = DEG_PPERM2(f);
+        /* loop over the entries of the tuple                              */
+        isint = 1;
+        for (i = LEN_LIST(set); 1 <= i; i--, ptset--) {
+            if (IS_INTOBJ(*ptset) && 0 < INT_INTOBJ(*ptset)) {
+                k = INT_INTOBJ(*ptset);
+                if (k <= deg && ptf2[k - 1] != 0) {
+                    tmp = INTOBJ_INT(ptf2[k - 1]);
+                    len++;
+                    *ptres++ = tmp;
+                }
+            }
+            else { /* this case cannot occur since I think POW is not defined
+                      */
+                ErrorQuit("not yet implemented!", 0L, 0L);
+            }
+        }
+    }
+    else {
+        ptf4 = ADDR_PPERM4(f);
+        deg = DEG_PPERM4(f);
+
+        /* loop over the entries of the tuple                              */
+        isint = 1;
+        for (i = LEN_LIST(set); 1 <= i; i--, ptset--) {
+            if (IS_INTOBJ(*ptset) && 0 < INT_INTOBJ(*ptset)) {
+                k = INT_INTOBJ(*ptset);
+                if (k <= deg && ptf4[k - 1] != 0) {
+                    tmp = INTOBJ_INT(ptf4[k - 1]);
+                    len++;
+                    *ptres++ = tmp;
+                }
+            }
+            else { /* this case cannot occur since I think POW is not defined
+                      */
+                ErrorQuit("not yet implemented!", 0L, 0L);
+            }
+        }
+    }
+    // maybe a problem here if the result <res> has length 0, this certainly
+    // caused a problem in OnPosIntSetsPPerm...
+    if (len == 0) {
+        RetypeBag(res, IS_MUTABLE_PLIST(set) ? T_PLIST_EMPTY
+                                             : T_PLIST_EMPTY + IMMUTABLE);
+        return res;
+    }
+    ResizeBag(res, (len + 1) * sizeof(Obj));
+    SET_LEN_PLIST(res, len);
+
+    /* sort the result */
+    h = 1;
+    while (9 * h + 4 < len)
+        h = 3 * h + 1;
+    while (0 < h) {
+        for (i = h + 1; i <= len; i++) {
+            tmp = ADDR_OBJ(res)[i];
+            k = i;
+            while (h < k && ((Int)tmp < (Int)(ADDR_OBJ(res)[k - h]))) {
+                ADDR_OBJ(res)[k] = ADDR_OBJ(res)[k - h];
+                k -= h;
+            }
+            ADDR_OBJ(res)[k] = tmp;
+        }
+        h = h / 3;
+    }
+
+    /* retype if we only have integers */
+    if (isint) {
+        RetypeBag(res, IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
+                                             : T_PLIST_CYC_SSORT + IMMUTABLE);
+    }
+
     return res;
-  }
-  ResizeBag(res, (len+1)*sizeof(Obj));
-  SET_LEN_PLIST(res, len);
-
-  /* sort the result */
-  h = 1;  while ( 9*h + 4 < len )  h = 3*h + 1;
-  while ( 0 < h ) {
-    for ( i = h+1; i <= len; i++ ) {
-      tmp = ADDR_OBJ(res)[i];  k = i;
-      while ( h < k && ((Int)tmp < (Int)(ADDR_OBJ(res)[k-h])) ) {
-        ADDR_OBJ(res)[k] = ADDR_OBJ(res)[k-h];
-        k -= h;
-      }
-      ADDR_OBJ(res)[k] = tmp;
-    }
-    h = h / 3;
-  }
-
-  /* retype if we only have integers */
-  if(isint){
-    RetypeBag( res, IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT :
-     T_PLIST_CYC_SSORT + IMMUTABLE ); 
-  }
-
-  return res;
 }
 
-Obj OnTuplesPPerm (Obj tup, Obj f){
-  UInt2  *ptf2;
-  UInt4  *ptf4;
-  UInt   deg;
-  Obj    *pttup, *ptres, res;
-  UInt   i, k, lentup, len;
-  
-  if(LEN_LIST(tup)==0) return tup;
+Obj OnTuplesPPerm(Obj tup, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    deg;
+    Obj *   pttup, *ptres, res;
+    UInt    i, k, lentup, len;
 
-  res=NEW_PLIST(IS_MUTABLE_PLIST(tup)?T_PLIST_CYC_NSORT:
-     T_PLIST_CYC_NSORT+IMMUTABLE,LEN_LIST(tup));
-   
-  /* get the pointer                                                 */
-  pttup = ADDR_OBJ(tup) + 1;
-  ptres = ADDR_OBJ(res) + 1;
-  len=0;
-  
-  if(TNUM_OBJ(f)==T_PPERM2){   
-    ptf2 = ADDR_PPERM2(f);
-    deg = DEG_PPERM2(f);
-    /* loop over the entries of the tuple                              */
-    lentup=LEN_LIST(tup);
-    for ( i=1 ; i <= lentup; i++, pttup++ ) {
-      if ( IS_INTOBJ( *pttup ) && 0 < INT_INTOBJ( *pttup ) ) {
-        k = INT_INTOBJ( *pttup ) ;
-        if (k<=deg&&ptf2[k-1]!=0){
-          len++;
-          *(ptres++) = INTOBJ_INT( ptf2[k-1] );
+    if (LEN_LIST(tup) == 0)
+        return tup;
+
+    res = NEW_PLIST(IS_MUTABLE_PLIST(tup) ? T_PLIST_CYC_NSORT
+                                          : T_PLIST_CYC_NSORT + IMMUTABLE,
+                    LEN_LIST(tup));
+
+    /* get the pointer                                                 */
+    pttup = ADDR_OBJ(tup) + 1;
+    ptres = ADDR_OBJ(res) + 1;
+    len = 0;
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        ptf2 = ADDR_PPERM2(f);
+        deg = DEG_PPERM2(f);
+        /* loop over the entries of the tuple                              */
+        lentup = LEN_LIST(tup);
+        for (i = 1; i <= lentup; i++, pttup++) {
+            if (IS_INTOBJ(*pttup) && 0 < INT_INTOBJ(*pttup)) {
+                k = INT_INTOBJ(*pttup);
+                if (k <= deg && ptf2[k - 1] != 0) {
+                    len++;
+                    *(ptres++) = INTOBJ_INT(ptf2[k - 1]);
+                }
+            }
+            else { /* this case cannot occur since I think POW is not defined
+                      */
+                ErrorQuit("not yet implemented!", 0L, 0L);
+            }
         }
-      } else {/* this case cannot occur since I think POW is not defined */
-        ErrorQuit("not yet implemented!", 0L, 0L);
-      }
     }
-  } else {
-    ptf4 = ADDR_PPERM4(f);
-    deg = DEG_PPERM4(f);
-    /* loop over the entries of the tuple                              */
-    lentup=LEN_LIST(tup);
-    for ( i=1 ; i <= lentup; i++, pttup++ ) {
-      if ( IS_INTOBJ( *pttup ) && 0 < INT_INTOBJ( *pttup ) ) {
-        k = INT_INTOBJ( *pttup ) ;
-        if (k<=deg&&ptf4[k-1]!=0){
-          len++;
-          *(ptres++) = INTOBJ_INT( ptf4[k-1] );
+    else {
+        ptf4 = ADDR_PPERM4(f);
+        deg = DEG_PPERM4(f);
+        /* loop over the entries of the tuple                              */
+        lentup = LEN_LIST(tup);
+        for (i = 1; i <= lentup; i++, pttup++) {
+            if (IS_INTOBJ(*pttup) && 0 < INT_INTOBJ(*pttup)) {
+                k = INT_INTOBJ(*pttup);
+                if (k <= deg && ptf4[k - 1] != 0) {
+                    len++;
+                    *(ptres++) = INTOBJ_INT(ptf4[k - 1]);
+                }
+            }
+            else { /* this case cannot occur since I think POW is not defined
+                      */
+                ErrorQuit("not yet implemented!", 0L, 0L);
+            }
         }
-      } else {/* this case cannot occur since I think POW is not defined */
-        ErrorQuit("not yet implemented!", 0L, 0L);
-      }
     }
-  }
-  SET_LEN_PLIST(res, (Int) len);
-  SHRINK_PLIST(res, (Int) len);
+    SET_LEN_PLIST(res, (Int)len);
+    SHRINK_PLIST(res, (Int)len);
 
-  return res;
-}
-
-Obj FuncOnPosIntSetsPPerm (Obj self, Obj set, Obj f){
-  UInt2  *ptf2;
-  UInt4  *ptf4;
-  UInt   deg;
-  Obj    *ptset, *ptres, tmp, res;
-  UInt   i, k, h, len;
-  
-  if(LEN_LIST(set)==0) return set;
-  
-  if(LEN_LIST(set)==1&&INT_INTOBJ(ELM_LIST(set, 1))==0){
-    return FuncIMAGE_SET_PPERM(self, f);
-  }
-
-  PLAIN_LIST(set);
-  res=NEW_PLIST(IS_MUTABLE_PLIST(set)?T_PLIST_CYC_SSORT:T_PLIST_CYC_SSORT+IMMUTABLE,LEN_LIST(set));
-
-  /* get the pointer                                                 */
-  ptset = ADDR_OBJ(set) + LEN_LIST(set);
-  ptres = ADDR_OBJ(res) + 1;
-  len=0;
-  
-  if(TNUM_OBJ(f)==T_PPERM2){   
-    ptf2 = ADDR_PPERM2(f);
-    deg = DEG_PPERM2(f);
-    /* loop over the entries of the tuple                              */
-    for ( i =LEN_LIST(set) ; 1 <= i; i--, ptset-- ) {
-      k = INT_INTOBJ( *ptset );
-      if(k<=deg&&ptf2[k-1]!=0){
-        tmp = INTOBJ_INT( ptf2[k-1] );
-        len++;
-        *ptres++ = tmp;
-      }
-    }
-  } else {
-    ptf4 = ADDR_PPERM4(f);
-    deg = DEG_PPERM4(f);
-    /* loop over the entries of the tuple                              */
-    for ( i =LEN_LIST(set) ; 1 <= i; i--, ptset-- ) {
-      k = INT_INTOBJ( *ptset );
-      if (k<=deg&&ptf4[k-1]!=0){
-        tmp = INTOBJ_INT( ptf4[k-1] );
-        len++;
-        *ptres++ = tmp;
-      }
-    }
-  }
-  ResizeBag(res, (len+1)*sizeof(Obj));
-  SET_LEN_PLIST(res, len);
-
-  if(len==0){ 
-    RetypeBag(res, IS_MUTABLE_PLIST(set)?T_PLIST_EMPTY:T_PLIST_EMPTY+IMMUTABLE);
     return res;
-  }
-  
-  /* sort the result */
-  h = 1;  while ( 9*h + 4 < len )  h = 3*h + 1;
-  while ( 0 < h ) {
-    for ( i = h+1; i <= len; i++ ) {
-      tmp = ADDR_OBJ(res)[i];  k = i;
-      while ( h < k && ((Int)tmp < (Int)(ADDR_OBJ(res)[k-h])) ) {
-        ADDR_OBJ(res)[k] = ADDR_OBJ(res)[k-h];
-        k -= h;
-      }
-      ADDR_OBJ(res)[k] = tmp;
-    }
-    h = h / 3;
-  }
-
-  /* retype if we only have integers */
-  return res;
 }
 
-/******************************************************************************/
-/******************************************************************************/
+Obj FuncOnPosIntSetsPPerm(Obj self, Obj set, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    deg;
+    Obj *   ptset, *ptres, tmp, res;
+    UInt    i, k, h, len;
+
+    if (LEN_LIST(set) == 0)
+        return set;
+
+    if (LEN_LIST(set) == 1 && INT_INTOBJ(ELM_LIST(set, 1)) == 0) {
+        return FuncIMAGE_SET_PPERM(self, f);
+    }
+
+    PLAIN_LIST(set);
+    res = NEW_PLIST(IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
+                                          : T_PLIST_CYC_SSORT + IMMUTABLE,
+                    LEN_LIST(set));
+
+    /* get the pointer                                                 */
+    ptset = ADDR_OBJ(set) + LEN_LIST(set);
+    ptres = ADDR_OBJ(res) + 1;
+    len = 0;
+
+    if (TNUM_OBJ(f) == T_PPERM2) {
+        ptf2 = ADDR_PPERM2(f);
+        deg = DEG_PPERM2(f);
+        /* loop over the entries of the tuple                              */
+        for (i = LEN_LIST(set); 1 <= i; i--, ptset--) {
+            k = INT_INTOBJ(*ptset);
+            if (k <= deg && ptf2[k - 1] != 0) {
+                tmp = INTOBJ_INT(ptf2[k - 1]);
+                len++;
+                *ptres++ = tmp;
+            }
+        }
+    }
+    else {
+        ptf4 = ADDR_PPERM4(f);
+        deg = DEG_PPERM4(f);
+        /* loop over the entries of the tuple                              */
+        for (i = LEN_LIST(set); 1 <= i; i--, ptset--) {
+            k = INT_INTOBJ(*ptset);
+            if (k <= deg && ptf4[k - 1] != 0) {
+                tmp = INTOBJ_INT(ptf4[k - 1]);
+                len++;
+                *ptres++ = tmp;
+            }
+        }
+    }
+    ResizeBag(res, (len + 1) * sizeof(Obj));
+    SET_LEN_PLIST(res, len);
+
+    if (len == 0) {
+        RetypeBag(res, IS_MUTABLE_PLIST(set) ? T_PLIST_EMPTY
+                                             : T_PLIST_EMPTY + IMMUTABLE);
+        return res;
+    }
+
+    /* sort the result */
+    h = 1;
+    while (9 * h + 4 < len)
+        h = 3 * h + 1;
+    while (0 < h) {
+        for (i = h + 1; i <= len; i++) {
+            tmp = ADDR_OBJ(res)[i];
+            k = i;
+            while (h < k && ((Int)tmp < (Int)(ADDR_OBJ(res)[k - h]))) {
+                ADDR_OBJ(res)[k] = ADDR_OBJ(res)[k - h];
+                k -= h;
+            }
+            ADDR_OBJ(res)[k] = tmp;
+        }
+        h = h / 3;
+    }
+
+    /* retype if we only have integers */
+    return res;
+}
+
+/****************************************************************************/
+/****************************************************************************/
 
 /* other internal things */
 
 /* Save and load */
-void SavePPerm2( Obj f){
-  UInt2 *ptr;
-  UInt  len, i;
-  len=DEG_PPERM2(f);
-  ptr=ADDR_PPERM2(f)-1;
-  for (i = 0; i < len+1; i++) SaveUInt2(*ptr++);
+void SavePPerm2(Obj f)
+{
+    UInt2 * ptr;
+    UInt    len, i;
+    len = DEG_PPERM2(f);
+    ptr = ADDR_PPERM2(f) - 1;
+    for (i = 0; i < len + 1; i++)
+        SaveUInt2(*ptr++);
 }
 
-void LoadPPerm2( Obj f){
-  UInt2 *ptr;
-  UInt  len, i;
-  len=DEG_PPERM2(f);
-  ptr=ADDR_PPERM2(f)-1;
-  for (i = 0; i < len+1; i++) *ptr++=LoadUInt2();
+void LoadPPerm2(Obj f)
+{
+    UInt2 * ptr;
+    UInt    len, i;
+    len = DEG_PPERM2(f);
+    ptr = ADDR_PPERM2(f) - 1;
+    for (i = 0; i < len + 1; i++)
+        *ptr++ = LoadUInt2();
 }
 
-void SavePPerm4( Obj f){
-  UInt4 *ptr;
-  UInt  len, i;
-  len=DEG_PPERM4(f);
-  ptr=ADDR_PPERM4(f)-1;
-  for (i = 0; i < len+1; i++) SaveUInt4(*ptr++);
+void SavePPerm4(Obj f)
+{
+    UInt4 * ptr;
+    UInt    len, i;
+    len = DEG_PPERM4(f);
+    ptr = ADDR_PPERM4(f) - 1;
+    for (i = 0; i < len + 1; i++)
+        SaveUInt4(*ptr++);
 }
 
-void LoadPPerm4( Obj f){
-  UInt4 *ptr;
-  UInt  len, i;
-  len=DEG_PPERM4(f);
-  ptr=ADDR_PPERM4(f)-1;
-  for (i = 0; i < len+1; i++) *ptr++=LoadUInt4();
+void LoadPPerm4(Obj f)
+{
+    UInt4 * ptr;
+    UInt    len, i;
+    len = DEG_PPERM4(f);
+    ptr = ADDR_PPERM4(f) - 1;
+    for (i = 0; i < len + 1; i++)
+        *ptr++ = LoadUInt4();
 }
 
 Obj TYPE_PPERM2;
 
-Obj TypePPerm2(Obj f){
-  return TYPE_PPERM2;
+Obj TypePPerm2(Obj f)
+{
+    return TYPE_PPERM2;
 }
 
 Obj TYPE_PPERM4;
 
-Obj TypePPerm4(Obj f){
-  return TYPE_PPERM4;
+Obj TypePPerm4(Obj f)
+{
+    return TYPE_PPERM4;
 }
 
 Obj IsPPermFilt;
 
-Obj IsPPermHandler (
-    Obj                 self,
-    Obj                 val )
+Obj IsPPermHandler(Obj self, Obj val)
 {
     /* return 'true' if <val> is a partial perm and 'false' otherwise       */
-    if ( TNUM_OBJ(val) == T_PPERM2 || TNUM_OBJ(val) == T_PPERM4 ) {
+    if (TNUM_OBJ(val) == T_PPERM2 || TNUM_OBJ(val) == T_PPERM4) {
         return True;
     }
-    else if ( TNUM_OBJ(val) < FIRST_EXTERNAL_TNUM ) {
+    else if (TNUM_OBJ(val) < FIRST_EXTERNAL_TNUM) {
         return False;
     }
     else {
-        return DoFilter( self, val );
+        return DoFilter(self, val);
     }
 }
 
-/*F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * */
+/*F * * * * * * * * * * * * initialize package * * * * * * * * * * * * * *
+ */
 
-/****************************************************************************
+/**************************************************************************
 **
 *V  GVarFilts . . . . . . . . . . . . . . . . . . . list of filters to export
 */
-static StructGVarFilt GVarFilts [] = {
+static StructGVarFilt GVarFilts[] = {
 
-    { "IS_PPERM", "obj", &IsPPermFilt,
-      IsPPermHandler, "src/pperm.c:IS_PPERM" },
+    { "IS_PPERM", "obj", &IsPPermFilt, IsPPermHandler,
+      "src/pperm.c:IS_PPERM" },
 
     { 0, 0, 0, 0, 0 }
 
 };
 
-/******************************************************************************
+/****************************************************************************
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
-static StructGVarFunc GVarFuncs [] = {
+static StructGVarFunc GVarFuncs[] = {
 
-  { "EmptyPartialPerm", 0, "",
-     FuncEmptyPartialPerm,
-    "src/pperm.c:FuncEmptyPartialPerm" },
+    { "EmptyPartialPerm", 0, "", FuncEmptyPartialPerm,
+      "src/pperm.c:FuncEmptyPartialPerm" },
 
-  { "DensePartialPermNC", 1, "img",
-     FuncDensePartialPermNC,
-    "src/pperm.c:FuncDensePartialPermNC" },
+    { "DensePartialPermNC", 1, "img", FuncDensePartialPermNC,
+      "src/pperm.c:FuncDensePartialPermNC" },
 
-  { "SparsePartialPermNC", 2, "dom, img",
-     FuncSparsePartialPermNC,
-    "src/pperm.c:FuncSparsePartialPermNC" },
+    { "SparsePartialPermNC", 2, "dom, img", FuncSparsePartialPermNC,
+      "src/pperm.c:FuncSparsePartialPermNC" },
 
-  { "DegreeOfPartialPerm", 1, "f",
-     FuncDegreeOfPartialPerm,
-    "src/pperm.c:FuncDegreeOfPartialPerm" },
+    { "DegreeOfPartialPerm", 1, "f", FuncDegreeOfPartialPerm,
+      "src/pperm.c:FuncDegreeOfPartialPerm" },
 
-  { "CoDegreeOfPartialPerm", 1, "f",
-     FuncCoDegreeOfPartialPerm,
-    "src/pperm.c:FuncCoDegreeOfPartialPerm" },
-  
-  { "RankOfPartialPerm", 1, "f",
-     FuncRankOfPartialPerm,
-    "src/pperm.c:FuncRankOfPartialPerm" },
+    { "CoDegreeOfPartialPerm", 1, "f", FuncCoDegreeOfPartialPerm,
+      "src/pperm.c:FuncCoDegreeOfPartialPerm" },
 
-  { "IMAGE_PPERM", 1, "f",
-     FuncIMAGE_PPERM,
-    "src/pperm.c:FuncIMAGE_PPERM" },
+    { "RankOfPartialPerm", 1, "f", FuncRankOfPartialPerm,
+      "src/pperm.c:FuncRankOfPartialPerm" },
 
-  { "DOMAIN_PPERM", 1, "f",
-     FuncDOMAIN_PPERM,
-    "src/pperm.c:FuncDOMAIN_PPERM" },
+    { "IMAGE_PPERM", 1, "f", FuncIMAGE_PPERM, "src/pperm.c:FuncIMAGE_PPERM" },
 
-  { "IMAGE_SET_PPERM", 1, "f",
-     FuncIMAGE_SET_PPERM,
-    "src/pperm.c:FuncIMAGE_SET_PPERM" },
+    { "DOMAIN_PPERM", 1, "f", FuncDOMAIN_PPERM,
+      "src/pperm.c:FuncDOMAIN_PPERM" },
 
-  { "PREIMAGE_PPERM_INT", 2, "f, i",
-     FuncPREIMAGE_PPERM_INT,
-    "src/pperm.c:FuncPREIMAGE_PPERM_INT" },
+    { "IMAGE_SET_PPERM", 1, "f", FuncIMAGE_SET_PPERM,
+      "src/pperm.c:FuncIMAGE_SET_PPERM" },
 
-  { "INDEX_PERIOD_PPERM", 1, "f",
-     FuncINDEX_PERIOD_PPERM,
-    "src/pperm.c:FuncINDEX_PERIOD_PPERM" },
+    { "PREIMAGE_PPERM_INT", 2, "f, i", FuncPREIMAGE_PPERM_INT,
+      "src/pperm.c:FuncPREIMAGE_PPERM_INT" },
 
-  { "SMALLEST_IDEM_POW_PPERM", 1, "f",
-     FuncSMALLEST_IDEM_POW_PPERM,
-    "src/pperm.c:FuncSMALLEST_IDEM_POW_PPERM" },
-  
-  { "COMPONENT_REPS_PPERM", 1, "f",
-     FuncCOMPONENT_REPS_PPERM,
-    "src/pperm.c:FuncCOMPONENT_REPS_PPERM" },
-  
-  { "NR_COMPONENTS_PPERM", 1, "f",
-     FuncNR_COMPONENTS_PPERM,
-    "src/pperm.c:FuncNR_COMPONENTS_PPERM" },
-  
-  { "COMPONENTS_PPERM", 1, "f",
-     FuncCOMPONENTS_PPERM,
-    "src/pperm.c:FuncCOMPONENTS_PPERM" },
-  
-  { "COMPONENT_PPERM_INT", 2, "f, pt",
-     FuncCOMPONENT_PPERM_INT,
-    "src/pperm.c:FuncCOMPONENT_PPERM_INT" },
-  
-  { "FIXED_PTS_PPERM", 1, "f",
-     FuncFIXED_PTS_PPERM,
-    "src/pperm.c:FuncFIXED_PTS_PPERM" },
-  
-  { "NR_FIXED_PTS_PPERM", 1, "f",
-     FuncNR_FIXED_PTS_PPERM,
-    "src/pperm.c:FuncNR_FIXED_PTS_PPERM" },
-  
-  { "MOVED_PTS_PPERM", 1, "f",
-     FuncMOVED_PTS_PPERM,
-    "src/pperm.c:FuncMOVED_PTS_PPERM" },
-  
-  { "NR_MOVED_PTS_PPERM", 1, "f",
-     FuncNR_MOVED_PTS_PPERM,
-    "src/pperm.c:FuncNR_MOVED_PTS_PPERM" },
-  
-  { "LARGEST_MOVED_PT_PPERM", 1, "f",
-     FuncLARGEST_MOVED_PT_PPERM,
-    "src/pperm.c:FuncLARGEST_MOVED_PT_PPERM" },
-  
-  { "SMALLEST_MOVED_PT_PPERM", 1, "f",
-     FuncSMALLEST_MOVED_PT_PPERM,
-    "src/pperm.c:FuncSMALLEST_MOVED_PT_PPERM" },
-  
-  { "TRIM_PPERM", 1, "f",
-     FuncTRIM_PPERM,
-    "src/pperm.c:FuncTRIM_PPERM" },
+    { "INDEX_PERIOD_PPERM", 1, "f", FuncINDEX_PERIOD_PPERM,
+      "src/pperm.c:FuncINDEX_PERIOD_PPERM" },
 
-  { "HASH_FUNC_FOR_PPERM", 2, "f, data",
-     FuncHASH_FUNC_FOR_PPERM,
-    "src/pperm.c:FuncHASH_FUNC_FOR_PPERM" },
-  
-  { "IS_IDEM_PPERM", 1, "f",
-     FuncIS_IDEM_PPERM,
-    "src/pperm.c:FuncIS_IDEM_PPERM" },
+    { "SMALLEST_IDEM_POW_PPERM", 1, "f", FuncSMALLEST_IDEM_POW_PPERM,
+      "src/pperm.c:FuncSMALLEST_IDEM_POW_PPERM" },
 
-  { "LEFT_ONE_PPERM", 1, "f",
-     FuncLEFT_ONE_PPERM,
-    "src/pperm.c:FuncLEFT_ONE_PPERM" },
+    { "COMPONENT_REPS_PPERM", 1, "f", FuncCOMPONENT_REPS_PPERM,
+      "src/pperm.c:FuncCOMPONENT_REPS_PPERM" },
 
-  { "RIGHT_ONE_PPERM", 1, "f",
-     FuncRIGHT_ONE_PPERM,
-    "src/pperm.c:FuncRIGHT_ONE_PPERM" },
+    { "NR_COMPONENTS_PPERM", 1, "f", FuncNR_COMPONENTS_PPERM,
+      "src/pperm.c:FuncNR_COMPONENTS_PPERM" },
 
-  { "NaturalLeqPartialPerm", 2, "f, g",
-     FuncNaturalLeqPartialPerm,
-    "src/pperm.c:FuncNaturalLeqPartialPerm" },
+    { "COMPONENTS_PPERM", 1, "f", FuncCOMPONENTS_PPERM,
+      "src/pperm.c:FuncCOMPONENTS_PPERM" },
 
-  { "JOIN_PPERMS", 2, "f, g",
-     FuncJOIN_PPERMS,
-    "src/pperm.c:FuncJOIN_PPERMS" },
+    { "COMPONENT_PPERM_INT", 2, "f, pt", FuncCOMPONENT_PPERM_INT,
+      "src/pperm.c:FuncCOMPONENT_PPERM_INT" },
 
-  { "JOIN_IDEM_PPERMS", 2, "f, g",
-     FuncJOIN_IDEM_PPERMS,
-    "src/pperm.c:FuncJOIN_IDEM_PPERMS" },
+    { "FIXED_PTS_PPERM", 1, "f", FuncFIXED_PTS_PPERM,
+      "src/pperm.c:FuncFIXED_PTS_PPERM" },
 
-  { "MEET_PPERMS", 2, "f, g",
-     FuncMEET_PPERMS,
-    "src/pperm.c:FuncMEET_PPERMS" },
+    { "NR_FIXED_PTS_PPERM", 1, "f", FuncNR_FIXED_PTS_PPERM,
+      "src/pperm.c:FuncNR_FIXED_PTS_PPERM" },
 
-  { "RESTRICTED_PPERM", 2, "f, g",
-     FuncRESTRICTED_PPERM,
-    "src/pperm.c:FuncRESTRICTED_PPERM" },
+    { "MOVED_PTS_PPERM", 1, "f", FuncMOVED_PTS_PPERM,
+      "src/pperm.c:FuncMOVED_PTS_PPERM" },
 
-  { "AS_PPERM_PERM", 2, "p, set",
-     FuncAS_PPERM_PERM,
-    "src/pperm.c:FuncAS_PPERM_PERM" },
+    { "NR_MOVED_PTS_PPERM", 1, "f", FuncNR_MOVED_PTS_PPERM,
+      "src/pperm.c:FuncNR_MOVED_PTS_PPERM" },
 
-  { "AS_PERM_PPERM", 1, "f",
-     FuncAS_PERM_PPERM,
-    "src/pperm.c:FuncAS_PERM_PPERM" },
+    { "LARGEST_MOVED_PT_PPERM", 1, "f", FuncLARGEST_MOVED_PT_PPERM,
+      "src/pperm.c:FuncLARGEST_MOVED_PT_PPERM" },
 
-  { "PERM_LEFT_QUO_PPERM_NC", 2, "f, g",
-     FuncPERM_LEFT_QUO_PPERM_NC,
-    "src/pperm.c:FuncPERM_LEFT_QUO_PPERM_NC" },
+    { "SMALLEST_MOVED_PT_PPERM", 1, "f", FuncSMALLEST_MOVED_PT_PPERM,
+      "src/pperm.c:FuncSMALLEST_MOVED_PT_PPERM" },
 
-  { "ShortLexLeqPartialPerm", 2, "f, g",
-     FuncShortLexLeqPartialPerm,
-    "src/pperm.c:FuncShortLexLeqPartialPerm" },
+    { "TRIM_PPERM", 1, "f", FuncTRIM_PPERM, "src/pperm.c:FuncTRIM_PPERM" },
 
-  { "HAS_DOM_PPERM", 1, "f",
-     FuncHAS_DOM_PPERM,
-    "src/pperm.c:FuncHAS_DOM_PPERM" },
+    { "HASH_FUNC_FOR_PPERM", 2, "f, data", FuncHASH_FUNC_FOR_PPERM,
+      "src/pperm.c:FuncHASH_FUNC_FOR_PPERM" },
 
-  { "HAS_IMG_PPERM", 1, "f",
-     FuncHAS_IMG_PPERM,
-    "src/pperm.c:FuncHAS_IMG_PPERM" },
+    { "IS_IDEM_PPERM", 1, "f", FuncIS_IDEM_PPERM,
+      "src/pperm.c:FuncIS_IDEM_PPERM" },
 
-  { "OnPosIntSetsPartialPerm", 2, "set, f", 
-     FuncOnPosIntSetsPPerm, 
-     "src/pperm.c:FuncOnPosIntSetsPPerm" },
+    { "LEFT_ONE_PPERM", 1, "f", FuncLEFT_ONE_PPERM,
+      "src/pperm.c:FuncLEFT_ONE_PPERM" },
 
-  { "PrintPPerm2", 1, "f", 
-     PrintPPerm2, 
-     "src/pperm.c:PrintPPerm2" },
+    { "RIGHT_ONE_PPERM", 1, "f", FuncRIGHT_ONE_PPERM,
+      "src/pperm.c:FuncRIGHT_ONE_PPERM" },
 
-  { "PrintPPerm4", 1, "f", 
-     PrintPPerm4, 
-     "src/pperm.c:PrintPPerm4" },
+    { "NaturalLeqPartialPerm", 2, "f, g", FuncNaturalLeqPartialPerm,
+      "src/pperm.c:FuncNaturalLeqPartialPerm" },
 
-  { 0, 0, 0, 0, 0 }
+    { "JOIN_PPERMS", 2, "f, g", FuncJOIN_PPERMS,
+      "src/pperm.c:FuncJOIN_PPERMS" },
+
+    { "JOIN_IDEM_PPERMS", 2, "f, g", FuncJOIN_IDEM_PPERMS,
+      "src/pperm.c:FuncJOIN_IDEM_PPERMS" },
+
+    { "MEET_PPERMS", 2, "f, g", FuncMEET_PPERMS,
+      "src/pperm.c:FuncMEET_PPERMS" },
+
+    { "RESTRICTED_PPERM", 2, "f, g", FuncRESTRICTED_PPERM,
+      "src/pperm.c:FuncRESTRICTED_PPERM" },
+
+    { "AS_PPERM_PERM", 2, "p, set", FuncAS_PPERM_PERM,
+      "src/pperm.c:FuncAS_PPERM_PERM" },
+
+    { "AS_PERM_PPERM", 1, "f", FuncAS_PERM_PPERM,
+      "src/pperm.c:FuncAS_PERM_PPERM" },
+
+    { "PERM_LEFT_QUO_PPERM_NC", 2, "f, g", FuncPERM_LEFT_QUO_PPERM_NC,
+      "src/pperm.c:FuncPERM_LEFT_QUO_PPERM_NC" },
+
+    { "ShortLexLeqPartialPerm", 2, "f, g", FuncShortLexLeqPartialPerm,
+      "src/pperm.c:FuncShortLexLeqPartialPerm" },
+
+    { "HAS_DOM_PPERM", 1, "f", FuncHAS_DOM_PPERM,
+      "src/pperm.c:FuncHAS_DOM_PPERM" },
+
+    { "HAS_IMG_PPERM", 1, "f", FuncHAS_IMG_PPERM,
+      "src/pperm.c:FuncHAS_IMG_PPERM" },
+
+    { "OnPosIntSetsPartialPerm", 2, "set, f", FuncOnPosIntSetsPPerm,
+      "src/pperm.c:FuncOnPosIntSetsPPerm" },
+
+    { "PrintPPerm2", 1, "f", PrintPPerm2, "src/pperm.c:PrintPPerm2" },
+
+    { "PrintPPerm4", 1, "f", PrintPPerm4, "src/pperm.c:PrintPPerm4" },
+
+    { 0, 0, 0, 0, 0 }
 
 };
 
 
-/******************************************************************************
+/****************************************************************************
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
 */
-static Int InitKernel ( StructInitInfo *module )
+static Int InitKernel(StructInitInfo * module)
 {
 
     /* install the marking function                                        */
-    InfoBags[ T_PPERM2 ].name = "partial perm (small)";
-    InfoBags[ T_PPERM4 ].name = "partial perm (large)";
-    InitMarkFuncBags( T_PPERM2, MarkTwoSubBags );
-    InitMarkFuncBags( T_PPERM4, MarkTwoSubBags );
-    
-    MakeBagTypePublic( T_PPERM2);
-    MakeBagTypePublic( T_PPERM4);
+    InfoBags[T_PPERM2].name = "partial perm (small)";
+    InfoBags[T_PPERM4].name = "partial perm (large)";
+    InitMarkFuncBags(T_PPERM2, MarkTwoSubBags);
+    InitMarkFuncBags(T_PPERM4, MarkTwoSubBags);
+
+    MakeBagTypePublic(T_PPERM2);
+    MakeBagTypePublic(T_PPERM4);
 
     /* install the type function                                           */
-    ImportGVarFromLibrary( "TYPE_PPERM2", &TYPE_PPERM2 );
-    ImportGVarFromLibrary( "TYPE_PPERM4", &TYPE_PPERM4 );
+    ImportGVarFromLibrary("TYPE_PPERM2", &TYPE_PPERM2);
+    ImportGVarFromLibrary("TYPE_PPERM4", &TYPE_PPERM4);
 
-    TypeObjFuncs[ T_PPERM2 ] = TypePPerm2;
-    TypeObjFuncs[ T_PPERM4 ] = TypePPerm4;
+    TypeObjFuncs[T_PPERM2] = TypePPerm2;
+    TypeObjFuncs[T_PPERM4] = TypePPerm4;
 
     /* init filters and functions                                          */
-    InitHdlrFiltsFromTable( GVarFilts );
-    InitHdlrFuncsFromTable( GVarFuncs );
+    InitHdlrFiltsFromTable(GVarFilts);
+    InitHdlrFuncsFromTable(GVarFuncs);
 
-    /* make the buffer bag                                                 */
+/* make the buffer bag                                                 */
 #ifndef HPCGAP
-    InitGlobalBag( &TmpPPerm, "src/pperm.c:TmpPPerm" );
+    InitGlobalBag(&TmpPPerm, "src/pperm.c:TmpPPerm");
 #endif
 
-    InitGlobalBag( &EmptyPartialPerm, "src/pperm.c:EmptyPartialPerm" );
+    InitGlobalBag(&EmptyPartialPerm, "src/pperm.c:EmptyPartialPerm");
 
     /* install the saving functions */
-    SaveObjFuncs[ T_PPERM2 ] = SavePPerm2;
-    LoadObjFuncs[ T_PPERM2 ] = LoadPPerm2;
-    SaveObjFuncs[ T_PPERM4 ] = SavePPerm4;
-    LoadObjFuncs[ T_PPERM4 ] = LoadPPerm4;
-    
+    SaveObjFuncs[T_PPERM2] = SavePPerm2;
+    LoadObjFuncs[T_PPERM2] = LoadPPerm2;
+    SaveObjFuncs[T_PPERM4] = SavePPerm4;
+    LoadObjFuncs[T_PPERM4] = LoadPPerm4;
+
     /* install the comparison methods                                      */
-    EqFuncs  [ T_PPERM2  ][ T_PPERM2  ] = EqPPerm22;
-    EqFuncs  [ T_PPERM4  ][ T_PPERM4  ] = EqPPerm44;
-    EqFuncs  [ T_PPERM4  ][ T_PPERM2  ] = EqPPerm42;
-    EqFuncs  [ T_PPERM2  ][ T_PPERM4  ] = EqPPerm24;
-    LtFuncs  [ T_PPERM2  ][ T_PPERM2  ] = LtPPerm22;
-    LtFuncs  [ T_PPERM4  ][ T_PPERM4  ] = LtPPerm44;
-    LtFuncs  [ T_PPERM2  ][ T_PPERM4  ] = LtPPerm24;
-    LtFuncs  [ T_PPERM4  ][ T_PPERM2  ] = LtPPerm42;
-    
+    EqFuncs[T_PPERM2][T_PPERM2] = EqPPerm22;
+    EqFuncs[T_PPERM4][T_PPERM4] = EqPPerm44;
+    EqFuncs[T_PPERM4][T_PPERM2] = EqPPerm42;
+    EqFuncs[T_PPERM2][T_PPERM4] = EqPPerm24;
+    LtFuncs[T_PPERM2][T_PPERM2] = LtPPerm22;
+    LtFuncs[T_PPERM4][T_PPERM4] = LtPPerm44;
+    LtFuncs[T_PPERM2][T_PPERM4] = LtPPerm24;
+    LtFuncs[T_PPERM4][T_PPERM2] = LtPPerm42;
+
     /* install the binary operations */
-    ProdFuncs [ T_PPERM2  ][ T_PPERM2 ] = ProdPPerm22;
-    ProdFuncs [ T_PPERM4  ][ T_PPERM2 ] = ProdPPerm42;
-    ProdFuncs [ T_PPERM2  ][ T_PPERM4 ] = ProdPPerm24;
-    ProdFuncs [ T_PPERM4  ][ T_PPERM4 ] = ProdPPerm44;
-    ProdFuncs [ T_PPERM2  ][ T_PERM2  ] = ProdPPerm2Perm2;
-    ProdFuncs [ T_PPERM4  ][ T_PERM4  ] = ProdPPerm4Perm4;
-    ProdFuncs [ T_PPERM2  ][ T_PERM4  ] = ProdPPerm2Perm4;
-    ProdFuncs [ T_PPERM4  ][ T_PERM2  ] = ProdPPerm4Perm2;
-    ProdFuncs [ T_PERM2   ][ T_PPERM2 ] = ProdPerm2PPerm2;
-    ProdFuncs [ T_PERM4   ][ T_PPERM4 ] = ProdPerm4PPerm4;
-    ProdFuncs [ T_PERM4   ][ T_PPERM2 ] = ProdPerm4PPerm2;
-    ProdFuncs [ T_PERM2   ][ T_PPERM4 ] = ProdPerm2PPerm4;
-    PowFuncs  [ T_INT     ][ T_PPERM2 ] = PowIntPPerm2;
-    PowFuncs  [ T_INT     ][ T_PPERM4 ] = PowIntPPerm4;
-    PowFuncs  [ T_PPERM2  ][ T_PERM2  ] = PowPPerm2Perm2;
-    PowFuncs  [ T_PPERM2  ][ T_PERM4  ] = PowPPerm2Perm4;
-    PowFuncs  [ T_PPERM4  ][ T_PERM2  ] = PowPPerm4Perm2;
-    PowFuncs  [ T_PPERM4  ][ T_PERM4  ] = PowPPerm4Perm4;
-    PowFuncs  [ T_PPERM2  ][ T_PPERM2 ] = PowPPerm22;
-    PowFuncs  [ T_PPERM2  ][ T_PPERM4 ] = PowPPerm24;
-    PowFuncs  [ T_PPERM4  ][ T_PPERM2 ] = PowPPerm42;
-    PowFuncs  [ T_PPERM4  ][ T_PPERM4 ] = PowPPerm44;
-    QuoFuncs  [ T_PPERM2  ][ T_PERM2  ] = QuoPPerm2Perm2;
-    QuoFuncs  [ T_PPERM4  ][ T_PERM4  ] = QuoPPerm4Perm4;
-    QuoFuncs  [ T_PPERM2  ][ T_PERM4  ] = QuoPPerm2Perm4;
-    QuoFuncs  [ T_PPERM4  ][ T_PERM2  ] = QuoPPerm4Perm2;
-    QuoFuncs  [ T_PPERM2  ][ T_PPERM2 ] = QuoPPerm22;
-    QuoFuncs  [ T_PPERM2  ][ T_PPERM4 ] = QuoPPerm24;
-    QuoFuncs  [ T_PPERM4  ][ T_PPERM2 ] = QuoPPerm42;
-    QuoFuncs  [ T_PPERM4  ][ T_PPERM4 ] = QuoPPerm44;
-    QuoFuncs  [ T_INT     ][ T_PPERM2 ] = PreImagePPermInt;
-    QuoFuncs  [ T_INT     ][ T_PPERM4 ] = PreImagePPermInt;
-    LQuoFuncs [ T_PERM2   ][ T_PPERM2 ] = LQuoPerm2PPerm2;
-    LQuoFuncs [ T_PERM2   ][ T_PPERM4 ] = LQuoPerm2PPerm4;
-    LQuoFuncs [ T_PERM4   ][ T_PPERM2 ] = LQuoPerm4PPerm2;
-    LQuoFuncs [ T_PERM4   ][ T_PPERM4 ] = LQuoPerm4PPerm4;
-    LQuoFuncs [ T_PPERM2  ][ T_PPERM2 ] = LQuoPPerm22;
-    LQuoFuncs [ T_PPERM2  ][ T_PPERM4 ] = LQuoPPerm24;
-    LQuoFuncs [ T_PPERM4  ][ T_PPERM2 ] = LQuoPPerm42;
-    LQuoFuncs [ T_PPERM4  ][ T_PPERM4 ] = LQuoPPerm44;
-    
+    ProdFuncs[T_PPERM2][T_PPERM2] = ProdPPerm22;
+    ProdFuncs[T_PPERM4][T_PPERM2] = ProdPPerm42;
+    ProdFuncs[T_PPERM2][T_PPERM4] = ProdPPerm24;
+    ProdFuncs[T_PPERM4][T_PPERM4] = ProdPPerm44;
+    ProdFuncs[T_PPERM2][T_PERM2] = ProdPPerm2Perm2;
+    ProdFuncs[T_PPERM4][T_PERM4] = ProdPPerm4Perm4;
+    ProdFuncs[T_PPERM2][T_PERM4] = ProdPPerm2Perm4;
+    ProdFuncs[T_PPERM4][T_PERM2] = ProdPPerm4Perm2;
+    ProdFuncs[T_PERM2][T_PPERM2] = ProdPerm2PPerm2;
+    ProdFuncs[T_PERM4][T_PPERM4] = ProdPerm4PPerm4;
+    ProdFuncs[T_PERM4][T_PPERM2] = ProdPerm4PPerm2;
+    ProdFuncs[T_PERM2][T_PPERM4] = ProdPerm2PPerm4;
+    PowFuncs[T_INT][T_PPERM2] = PowIntPPerm2;
+    PowFuncs[T_INT][T_PPERM4] = PowIntPPerm4;
+    PowFuncs[T_PPERM2][T_PERM2] = PowPPerm2Perm2;
+    PowFuncs[T_PPERM2][T_PERM4] = PowPPerm2Perm4;
+    PowFuncs[T_PPERM4][T_PERM2] = PowPPerm4Perm2;
+    PowFuncs[T_PPERM4][T_PERM4] = PowPPerm4Perm4;
+    PowFuncs[T_PPERM2][T_PPERM2] = PowPPerm22;
+    PowFuncs[T_PPERM2][T_PPERM4] = PowPPerm24;
+    PowFuncs[T_PPERM4][T_PPERM2] = PowPPerm42;
+    PowFuncs[T_PPERM4][T_PPERM4] = PowPPerm44;
+    QuoFuncs[T_PPERM2][T_PERM2] = QuoPPerm2Perm2;
+    QuoFuncs[T_PPERM4][T_PERM4] = QuoPPerm4Perm4;
+    QuoFuncs[T_PPERM2][T_PERM4] = QuoPPerm2Perm4;
+    QuoFuncs[T_PPERM4][T_PERM2] = QuoPPerm4Perm2;
+    QuoFuncs[T_PPERM2][T_PPERM2] = QuoPPerm22;
+    QuoFuncs[T_PPERM2][T_PPERM4] = QuoPPerm24;
+    QuoFuncs[T_PPERM4][T_PPERM2] = QuoPPerm42;
+    QuoFuncs[T_PPERM4][T_PPERM4] = QuoPPerm44;
+    QuoFuncs[T_INT][T_PPERM2] = PreImagePPermInt;
+    QuoFuncs[T_INT][T_PPERM4] = PreImagePPermInt;
+    LQuoFuncs[T_PERM2][T_PPERM2] = LQuoPerm2PPerm2;
+    LQuoFuncs[T_PERM2][T_PPERM4] = LQuoPerm2PPerm4;
+    LQuoFuncs[T_PERM4][T_PPERM2] = LQuoPerm4PPerm2;
+    LQuoFuncs[T_PERM4][T_PPERM4] = LQuoPerm4PPerm4;
+    LQuoFuncs[T_PPERM2][T_PPERM2] = LQuoPPerm22;
+    LQuoFuncs[T_PPERM2][T_PPERM4] = LQuoPPerm24;
+    LQuoFuncs[T_PPERM4][T_PPERM2] = LQuoPPerm42;
+    LQuoFuncs[T_PPERM4][T_PPERM4] = LQuoPPerm44;
+
     /* install the one function for partial perms */
-    OneFuncs [T_PPERM2] = OnePPerm;
-    OneFuncs [T_PPERM4] = OnePPerm;
-    OneMutFuncs [T_PPERM2] = OnePPerm;
-    OneMutFuncs [T_PPERM4] = OnePPerm;
+    OneFuncs[T_PPERM2] = OnePPerm;
+    OneFuncs[T_PPERM4] = OnePPerm;
+    OneMutFuncs[T_PPERM2] = OnePPerm;
+    OneMutFuncs[T_PPERM4] = OnePPerm;
 
     /* install the inverse functions for partial perms */
-    InvFuncs[ T_PPERM2 ] = InvPPerm2;
-    InvFuncs[ T_PPERM4 ] = InvPPerm4;
-    InvMutFuncs[ T_PPERM2 ] = InvPPerm2;
-    InvMutFuncs[ T_PPERM4 ] = InvPPerm4;
-    
+    InvFuncs[T_PPERM2] = InvPPerm2;
+    InvFuncs[T_PPERM4] = InvPPerm4;
+    InvMutFuncs[T_PPERM2] = InvPPerm2;
+    InvMutFuncs[T_PPERM4] = InvPPerm4;
+
     /* return success                                                      */
     return 0;
 }
 
-/******************************************************************************
- *F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
+/****************************************************************************
+ *F InitLibrary( <module> ) . . . . . . .  initialise library data structures
  */
-static Int InitLibrary ( StructInitInfo *module )
+static Int InitLibrary(StructInitInfo * module)
 {
-  /* init filters and functions                                          */
-  InitGVarFuncsFromTable( GVarFuncs );
-  InitGVarFiltsFromTable( GVarFilts );
-  TmpPPerm = 0;
+    /* init filters and functions                                          */
+    InitGVarFuncsFromTable(GVarFuncs);
+    InitGVarFiltsFromTable(GVarFilts);
+    TmpPPerm = 0;
 
-  EmptyPartialPerm=NEW_PPERM2(0);
-  
-  /* return success                                                      */
-  return 0;
+    EmptyPartialPerm = NEW_PPERM2(0);
+
+    /* return success                                                      */
+    return 0;
 }
 
-/****************************************************************************
+/**************************************************************************
  **
- *F  InitInfoPPerm()  . . . . . . . . . . . . . . . table of init functions
+ *F InitInfoPPerm()   . . . . . . . . . . . . . . . table of init functions
  */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "pperm",                            /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    MODULE_BUILTIN, /* type                           */
+    "pperm",        /* name                           */
+    0,              /* revision entry of c file       */
+    0,              /* revision entry of h file       */
+    0,              /* version                        */
+    0,              /* crc                            */
+    InitKernel,     /* initKernel                     */
+    InitLibrary,    /* initLibrary                    */
+    0,              /* checkInit                      */
+    0,              /* preSave                        */
+    0,              /* postSave                       */
+    0               /* postRestore                    */
 };
 
-StructInitInfo * InitInfoPPerm ( void )
+StructInitInfo * InitInfoPPerm(void)
 {
     return &module;
 }

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -54,34 +54,7 @@
 #define MAX(a, b) (a < b ? b : a)
 #define MIN(a, b) (a < b ? a : b)
 
-#define IMG_PPERM(f) (ADDR_OBJ(f)[0])
-#define DOM_PPERM(f) (ADDR_OBJ(f)[1])
-
-#define NEW_PPERM2(deg)                                                      \
-    NewBag(T_PPERM2, (deg + 1) * sizeof(UInt2) + 2 * sizeof(Obj))
-#define CODEG_PPERM2(f) (*(UInt2 *)((Obj *)(ADDR_OBJ(f)) + 2))
-#define ADDR_PPERM2(f) ((UInt2 *)((Obj *)(ADDR_OBJ(f)) + 2) + 1)
-#define DEG_PPERM2(f)                                                        \
-    ((UInt)(SIZE_OBJ(f) - sizeof(UInt2) - 2 * sizeof(Obj)) / sizeof(UInt2))
-#define RANK_PPERM2(f)                                                       \
-    (IMG_PPERM(f) == NULL ? INIT_PPERM2(f) : LEN_PLIST(IMG_PPERM(f)))
-
-#define NEW_PPERM4(deg)                                                      \
-    NewBag(T_PPERM4, (deg + 1) * sizeof(UInt4) + 2 * sizeof(Obj))
-#define CODEG_PPERM4(f) (*(UInt4 *)((Obj *)(ADDR_OBJ(f)) + 2))
-#define ADDR_PPERM4(f) ((UInt4 *)((Obj *)(ADDR_OBJ(f)) + 2) + 1)
-#define DEG_PPERM4(f)                                                        \
-    ((UInt)(SIZE_OBJ(f) - sizeof(UInt4) - 2 * sizeof(Obj)) / sizeof(UInt4))
-#define RANK_PPERM4(f)                                                       \
-    (IMG_PPERM(f) == NULL ? INIT_PPERM4(f) : LEN_PLIST(IMG_PPERM(f)))
-
 #define IMAGEPP(i, ptf, deg) (i <= deg ? ptf[i - 1] : 0)
-#define IS_PPERM(f) (TNUM_OBJ(f) == T_PPERM2 || TNUM_OBJ(f) == T_PPERM4)
-#define RANK_PPERM(f)                                                        \
-    (TNUM_OBJ(f) == T_PPERM2 ? RANK_PPERM2(f) : RANK_PPERM4(f))
-#define DEG_PPERM(f) (TNUM_OBJ(f) == T_PPERM2 ? DEG_PPERM2(f) : DEG_PPERM4(f))
-#define CODEG_PPERM(f)                                                       \
-    (TNUM_OBJ(f) == T_PPERM2 ? CODEG_PPERM2(f) : CODEG_PPERM4(f))
 
 Obj EmptyPartialPerm;
 
@@ -116,6 +89,110 @@ static inline void ResizeTmpPPerm(UInt len)
 * Static functions for partial perms
 *****************************************************************************/
 
+static inline UInt GET_CODEG_PPERM2(Obj f)
+{
+    GAP_ASSERT(IS_PPERM(f));
+    return (*(UInt2 *)((Obj *)(ADDR_OBJ(f)) + 2));
+}
+
+static inline void SET_CODEG_PPERM2(Obj f, UInt2 codeg)
+{
+    GAP_ASSERT(IS_PPERM(f));
+    (*(UInt2 *)((Obj *)(ADDR_OBJ(f)) + 2)) = codeg;
+}
+
+UInt CODEG_PPERM2(Obj f)
+{
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    if (GET_CODEG_PPERM2(f) != 0) {
+      return GET_CODEG_PPERM2(f);
+    }
+    UInt codeg = 0;
+    UInt i;
+    UInt2* ptf = ADDR_PPERM2(f);
+    for (i = 0; i < DEG_PPERM2(f); i++) {
+      if (ptf[i] > codeg) {
+        codeg = ptf[i];
+      }
+    }
+    SET_CODEG_PPERM2(f, codeg);
+    return codeg;
+}
+
+static inline UInt GET_CODEG_PPERM4(Obj f)
+{
+    GAP_ASSERT(IS_PPERM(f));
+    return (*(UInt4 *)((Obj *)(ADDR_OBJ(f)) + 2));
+}
+
+static inline void SET_CODEG_PPERM4(Obj f, UInt4 codeg)
+{
+    GAP_ASSERT(IS_PPERM(f));
+    (*(UInt4 *)((Obj *)(ADDR_OBJ(f)) + 2)) = codeg;
+}
+
+UInt CODEG_PPERM4(Obj f)
+{
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    if (GET_CODEG_PPERM4(f) != 0) {
+      return GET_CODEG_PPERM4(f);
+    }
+    UInt codeg = 0;
+    UInt i;
+    UInt4* ptf = ADDR_PPERM4(f);
+    for (i = 0; i < DEG_PPERM4(f); i++) {
+      if (ptf[i] > codeg) {
+        codeg = ptf[i];
+      }
+    }
+    SET_CODEG_PPERM4(f, codeg);
+    return codeg;
+}
+
+Obj NEW_PPERM2(UInt deg)
+{
+    // No assert since the values stored in this pperm must be UInt2s but the
+    // degree might be a UInt4.
+    return NewBag(T_PPERM2, (deg + 1) * sizeof(UInt2) + 2 * sizeof(Obj));
+}
+
+Obj NEW_PPERM4(UInt deg)
+{
+    return NewBag(T_PPERM4, (deg + 1) * sizeof(UInt4) + 2 * sizeof(Obj));
+}
+
+static inline Obj IMG_PPERM(Obj f)
+{
+    GAP_ASSERT(IS_PPERM(f));
+    return ADDR_OBJ(f)[0];
+}
+
+static inline Obj DOM_PPERM(Obj f)
+{
+    GAP_ASSERT(IS_PPERM(f));
+    return ADDR_OBJ(f)[1];
+}
+
+static inline void SET_IMG_PPERM(Obj f, Obj img)
+{
+    GAP_ASSERT(IS_PPERM(f));
+    GAP_ASSERT(IS_PLIST(img) && !IS_MUTABLE_PLIST(img));
+    GAP_ASSERT(DOM_PPERM(f) == NULL ||
+               LEN_PLIST(img) == LEN_PLIST(DOM_PPERM(f)));
+    // TODO Could check entries of img are valid
+    ADDR_OBJ(f)[0] = img;
+}
+
+static inline void SET_DOM_PPERM(Obj f, Obj dom)
+{
+    GAP_ASSERT(IS_PPERM(f));
+    GAP_ASSERT(IS_PLIST(dom) && !IS_MUTABLE_PLIST(dom));
+    GAP_ASSERT(IMG_PPERM(f) == NULL ||
+               LEN_PLIST(dom) == LEN_PLIST(IMG_PPERM(f)));
+    // TODO Could check entries of img are valid
+    ADDR_OBJ(f)[1] = dom;
+}
+
 // find domain and img set (unsorted) return the rank
 
 static UInt INIT_PPERM2(Obj f)
@@ -129,8 +206,8 @@ static UInt INIT_PPERM2(Obj f)
     if (deg == 0) {
         dom = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
         SET_LEN_PLIST(dom, 0);
-        DOM_PPERM(f) = dom;
-        IMG_PPERM(f) = dom;
+        SET_DOM_PPERM(f, dom);
+        SET_IMG_PPERM(f, dom);
         CHANGED_BAG(f);
         return deg;
     }
@@ -160,8 +237,8 @@ static UInt INIT_PPERM2(Obj f)
     SHRINK_PLIST(dom, (Int)rank);
     SET_LEN_PLIST(dom, (Int)rank);
 
-    DOM_PPERM(f) = dom;
-    IMG_PPERM(f) = img;
+    SET_DOM_PPERM(f, dom);
+    SET_IMG_PPERM(f, img);
     CHANGED_BAG(f);
     return rank;
 }
@@ -177,14 +254,14 @@ static UInt INIT_PPERM4(Obj f)
     if (deg == 0) {
         dom = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
         SET_LEN_PLIST(dom, 0);
-        DOM_PPERM(f) = dom;
-        IMG_PPERM(f) = dom;
+        SET_DOM_PPERM(f, dom);
+        SET_IMG_PPERM(f, dom);
         CHANGED_BAG(f);
         return deg;
     }
 
     dom = NEW_PLIST(T_PLIST_CYC_SSORT + IMMUTABLE, deg);
-    img = NEW_PLIST(T_PLIST_CYC_NSORT + IMMUTABLE, deg);
+    img = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, deg);
 
     ptf = ADDR_PPERM4(f);
 
@@ -207,10 +284,22 @@ static UInt INIT_PPERM4(Obj f)
     SHRINK_PLIST(dom, (Int)rank);
     SET_LEN_PLIST(dom, (Int)rank);
 
-    DOM_PPERM(f) = dom;
-    IMG_PPERM(f) = img;
+    SET_DOM_PPERM(f, dom);
+    SET_IMG_PPERM(f, img);
     CHANGED_BAG(f);
     return rank;
+}
+
+UInt RANK_PPERM2(Obj f)
+{
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    return (IMG_PPERM(f) == NULL ? INIT_PPERM2(f) : LEN_PLIST(IMG_PPERM(f)));
+}
+
+UInt RANK_PPERM4(Obj f)
+{
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    return (IMG_PPERM(f) == NULL ? INIT_PPERM4(f) : LEN_PLIST(IMG_PPERM(f)));
 }
 
 static Obj SORT_PLIST_CYC(Obj res)
@@ -318,7 +407,7 @@ Obj FuncDensePartialPermNC(Obj self, Obj img)
             j = INT_INTOBJ(ELM_LIST(img, i + 1));
             *ptf2++ = (UInt2)j;
         }
-        CODEG_PPERM2(f) = (UInt2)codeg;    // codeg is already known
+        SET_CODEG_PPERM2(f, codeg);    // codeg is already known
     }
     else {
         f = NEW_PPERM4(deg);
@@ -329,7 +418,7 @@ Obj FuncDensePartialPermNC(Obj self, Obj img)
                 codeg = j;
             *ptf4++ = (UInt4)j;
         }
-        CODEG_PPERM4(f) = (UInt4)codeg;
+        SET_CODEG_PPERM4(f, codeg);
     }
     return f;
 }
@@ -363,9 +452,9 @@ Obj FuncSparsePartialPermNC(Obj self, Obj dom, Obj img)
     if (!IS_PLIST(img))
         PLAIN_LIST(img);
 
-    // make dom and img immutable
-    MakeImmutable(dom);
+    // make img immutable
     MakeImmutable(img);
+    MakeImmutable(dom);
 
     // create the pperm
     if (codeg < 65536) {
@@ -375,9 +464,9 @@ Obj FuncSparsePartialPermNC(Obj self, Obj dom, Obj img)
             ptf2[INT_INTOBJ(ELM_PLIST(dom, i)) - 1] =
                 INT_INTOBJ(ELM_PLIST(img, i));
         }
-        DOM_PPERM(f) = dom;
-        IMG_PPERM(f) = img;
-        CODEG_PPERM2(f) = codeg;
+        SET_DOM_PPERM(f, dom);
+        SET_IMG_PPERM(f, img);
+        SET_CODEG_PPERM2(f, codeg);
     }
     else {
         f = NEW_PPERM4(deg);
@@ -388,9 +477,9 @@ Obj FuncSparsePartialPermNC(Obj self, Obj dom, Obj img)
                 codeg = j;
             ptf4[INT_INTOBJ(ELM_PLIST(dom, i)) - 1] = j;
         }
-        DOM_PPERM(f) = dom;
-        IMG_PPERM(f) = img;
-        CODEG_PPERM4(f) = codeg;
+        SET_DOM_PPERM(f, dom);
+        SET_IMG_PPERM(f, img);
+        SET_CODEG_PPERM4(f, codeg);
     }
     CHANGED_BAG(f);
     return f;
@@ -410,6 +499,7 @@ Obj FuncDegreeOfPartialPerm(Obj self, Obj f)
 }
 
 /* the codegree of pperm is the maximum point in its image */
+
 Obj FuncCoDegreeOfPartialPerm(Obj self, Obj f)
 {
     if (TNUM_OBJ(f) == T_PPERM2) {
@@ -470,7 +560,7 @@ Obj FuncIMAGE_PPERM(Obj self, Obj f)
             SET_LEN_PLIST(out, 0);
             return out;
         }
-        out = NEW_PLIST(T_PLIST_CYC_NSORT + IMMUTABLE, rank);
+        out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, rank);
         SET_LEN_PLIST(out, rank);
         ptf2 = ADDR_PPERM2(f);
         dom = DOM_PPERM(f);
@@ -493,7 +583,7 @@ Obj FuncIMAGE_PPERM(Obj self, Obj f)
             SET_LEN_PLIST(out, 0);
             return out;
         }
-        out = NEW_PLIST(T_PLIST_CYC_NSORT + IMMUTABLE, rank);
+        out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, rank);
         SET_LEN_PLIST(out, rank);
         ptf4 = ADDR_PPERM4(f);
         dom = DOM_PPERM(f);
@@ -1450,9 +1540,9 @@ Obj FuncLEFT_ONE_PPERM(Obj self, Obj f)
             j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
             ptg2[j] = j + 1;
         }
-        CODEG_PPERM2(g) = deg;
-        DOM_PPERM(g) = dom;
-        IMG_PPERM(g) = dom;
+        SET_CODEG_PPERM2(g, deg);
+        SET_DOM_PPERM(g, dom);
+        SET_IMG_PPERM(g, dom);
     }
     else {
         g = NEW_PPERM4(deg);
@@ -1461,9 +1551,9 @@ Obj FuncLEFT_ONE_PPERM(Obj self, Obj f)
             j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
             ptg4[j] = j + 1;
         }
-        CODEG_PPERM4(g) = deg;
-        DOM_PPERM(g) = dom;
-        IMG_PPERM(g) = dom;
+        SET_CODEG_PPERM4(g, deg);
+        SET_DOM_PPERM(g, dom);
+        SET_IMG_PPERM(g, dom);
     }
     CHANGED_BAG(g);
     return g;
@@ -1496,10 +1586,10 @@ Obj FuncRIGHT_ONE_PPERM(Obj self, Obj f)
             ptg2[j] = j + 1;
         }
         if (IS_SSORT_LIST(img)) {
-            DOM_PPERM(g) = img;
-            IMG_PPERM(g) = img;
+            SET_DOM_PPERM(g, img);
+            SET_IMG_PPERM(g, img);
         }
-        CODEG_PPERM2(g) = codeg;
+        SET_CODEG_PPERM2(g, codeg);
     }
     else {
         g = NEW_PPERM4(codeg);
@@ -1509,10 +1599,10 @@ Obj FuncRIGHT_ONE_PPERM(Obj self, Obj f)
             ptg4[j] = j + 1;
         }
         if (IS_SSORT_LIST(img)) {
-            DOM_PPERM(g) = img;
-            IMG_PPERM(g) = img;
+            SET_DOM_PPERM(g, img);
+            SET_IMG_PPERM(g, img);
         }
-        CODEG_PPERM4(g) = codeg;
+        SET_CODEG_PPERM4(g, codeg);
     }
     CHANGED_BAG(g);
     return g;
@@ -1644,7 +1734,7 @@ Obj FuncJOIN_IDEM_PPERMS(Obj self, Obj f, Obj g)
     dej = MAX(def, deg);
     if (dej < 65536) {
         join = NEW_PPERM2(dej);
-        CODEG_PPERM2(join) = dej;
+        SET_CODEG_PPERM2(join, dej);
         ptjoin2 = ADDR_PPERM2(join);
         ptf2 = ADDR_PPERM2(f);
         ptg2 = ADDR_PPERM2(g);
@@ -1679,7 +1769,7 @@ Obj FuncJOIN_IDEM_PPERMS(Obj self, Obj f, Obj g)
     }
     else if (def >= 65536 && deg >= 65536) {    // 3 more cases required
         join = NEW_PPERM4(dej);
-        CODEG_PPERM4(join) = dej;
+        SET_CODEG_PPERM4(join, dej);
         ptjoin4 = ADDR_PPERM4(join);
         ptf4 = ADDR_PPERM4(f);
         ptg4 = ADDR_PPERM4(g);
@@ -1714,7 +1804,7 @@ Obj FuncJOIN_IDEM_PPERMS(Obj self, Obj f, Obj g)
     }
     else if (def > deg) {    // def>=65536>deg
         join = NEW_PPERM4(dej);
-        CODEG_PPERM4(join) = dej;
+        SET_CODEG_PPERM4(join, dej);
         ptjoin4 = ADDR_PPERM4(join);
         ptf4 = ADDR_PPERM4(f);
         ptg2 = ADDR_PPERM2(g);
@@ -1760,7 +1850,7 @@ Obj FuncJOIN_PPERMS(Obj self, Obj f, Obj g)
         degg = DEG_PPERM4(g);
         deg = MAX(degf, degg);
         join = NEW_PPERM4(deg);
-        CODEG_PPERM4(join) = codeg;
+        SET_CODEG_PPERM4(join, codeg);
 
         ptjoin4 = ADDR_PPERM4(join);
         ptf4 = ADDR_PPERM4(f);
@@ -1840,7 +1930,7 @@ Obj FuncJOIN_PPERMS(Obj self, Obj f, Obj g)
         degg = DEG_PPERM2(g);
         deg = MAX(degf, degg);
         join = NEW_PPERM4(deg);
-        CODEG_PPERM4(join) = codeg;
+        SET_CODEG_PPERM4(join, codeg);
 
         ptjoin4 = ADDR_PPERM4(join);
         ptf4 = ADDR_PPERM4(f);
@@ -1923,7 +2013,7 @@ Obj FuncJOIN_PPERMS(Obj self, Obj f, Obj g)
         degg = DEG_PPERM2(g);
         deg = MAX(degf, degg);
         join = NEW_PPERM2(deg);
-        CODEG_PPERM2(join) = codeg;
+        SET_CODEG_PPERM2(join, codeg);
 
         ptjoin2 = ADDR_PPERM2(join);
         ptf2 = ADDR_PPERM2(f);
@@ -2035,7 +2125,7 @@ Obj FuncMEET_PPERMS(Obj self, Obj f, Obj g)
                     codeg = j;
             }
         }
-        CODEG_PPERM2(meet) = codeg;
+        SET_CODEG_PPERM2(meet, codeg);
     }
     else if (TNUM_OBJ(f) == T_PPERM4 && TNUM_OBJ(g) == T_PPERM2) {
         degf = DEG_PPERM4(f);
@@ -2063,7 +2153,7 @@ Obj FuncMEET_PPERMS(Obj self, Obj f, Obj g)
                     codeg = j;
             }
         }
-        CODEG_PPERM2(meet) = codeg;
+        SET_CODEG_PPERM2(meet, codeg);
     }
     else if (TNUM_OBJ(f) == T_PPERM2 && TNUM_OBJ(g) == T_PPERM4) {
         degf = DEG_PPERM2(f);
@@ -2091,7 +2181,7 @@ Obj FuncMEET_PPERMS(Obj self, Obj f, Obj g)
                     codeg = j;
             }
         }
-        CODEG_PPERM2(meet) = codeg;
+        SET_CODEG_PPERM2(meet, codeg);
     }
     else {
         degf = DEG_PPERM4(f);
@@ -2119,7 +2209,7 @@ Obj FuncMEET_PPERMS(Obj self, Obj f, Obj g)
                     codeg = j;
             }
         }
-        CODEG_PPERM4(meet) = codeg;
+        SET_CODEG_PPERM4(meet, codeg);
     }
     return meet;
 }
@@ -2157,7 +2247,7 @@ Obj FuncRESTRICTED_PPERM(Obj self, Obj f, Obj set)
             if (ptg2[j] > codeg)
                 codeg = ptg2[j];
         }
-        CODEG_PPERM2(g) = codeg;
+        SET_CODEG_PPERM2(g, codeg);
         return g;
     }
     else if (TNUM_OBJ(f) == T_PPERM4) {
@@ -2181,7 +2271,7 @@ Obj FuncRESTRICTED_PPERM(Obj self, Obj f, Obj set)
             if (ptg4[j] > codeg)
                 codeg = ptg4[j];
         }
-        CODEG_PPERM4(g) = codeg;
+        SET_CODEG_PPERM4(g, codeg);
         return g;
     }
     return Fail;
@@ -2215,7 +2305,7 @@ Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
                     j = INT_INTOBJ(ELM_LIST(set, i)) - 1;
                     ptf2[j] = IMAGE(j, ptp2, dep) + 1;
                 }
-                CODEG_PPERM2(f) = deg;
+                SET_CODEG_PPERM2(f, deg);
             }
             else {    // deg(f)<=deg(p)<=65536
                 // Pr("Case 2\n", 0L, 0L);
@@ -2228,7 +2318,7 @@ Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
                     if (ptf2[j] > codeg)
                         codeg = ptf2[j];
                 }
-                CODEG_PPERM2(f) = codeg;
+                SET_CODEG_PPERM2(f, codeg);
             }
         }
         else {    // deg(p)<=65536<=deg(f)
@@ -2240,7 +2330,7 @@ Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
                 j = INT_INTOBJ(ELM_LIST(set, i)) - 1;
                 ptf4[j] = IMAGE(j, ptp2, dep) + 1;
             }
-            CODEG_PPERM4(f) = deg;
+            SET_CODEG_PPERM4(f, deg);
         }
     }
     else {    // p is PERM4
@@ -2254,7 +2344,7 @@ Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
                 j = INT_INTOBJ(ELM_LIST(set, i)) - 1;
                 ptf4[j] = IMAGE(j, ptp4, dep) + 1;
             }
-            CODEG_PPERM4(f) = deg;
+            SET_CODEG_PPERM4(f, deg);
         }
         else {    // deg<=dep
             // find the codeg
@@ -2275,7 +2365,7 @@ Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
                     j = INT_INTOBJ(ELM_LIST(set, i)) - 1;
                     ptf2[j] = ptp4[j] + 1;
                 }
-                CODEG_PPERM2(f) = codeg;
+                SET_CODEG_PPERM2(f, codeg);
             }
             else {
                 // Pr("Case 6\n", 0L, 0L);
@@ -2288,7 +2378,7 @@ Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
                     if (ptf4[j] > codeg)
                         codeg = ptf4[j];
                 }
-                CODEG_PPERM4(f) = deg;
+                SET_CODEG_PPERM4(f, deg);
             }
         }
     }
@@ -2554,7 +2644,7 @@ Obj OnePPerm(Obj f)
             j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
             ptg2[j] = j + 1;
         }
-        CODEG_PPERM2(g) = deg;
+        SET_CODEG_PPERM2(g, deg);
     }
     else {
         g = NEW_PPERM4(deg);
@@ -2565,7 +2655,7 @@ Obj OnePPerm(Obj f)
             j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
             ptg4[j] = j + 1;
         }
-        CODEG_PPERM4(g) = deg;
+        SET_CODEG_PPERM4(g, deg);
     }
     return g;
 }
@@ -2974,7 +3064,7 @@ Obj ProdPPerm22(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM2(fg) = codeg;
+    SET_CODEG_PPERM2(fg, codeg);
     return fg;
 }
 
@@ -3030,7 +3120,7 @@ Obj ProdPPerm42(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM2(fg) = codeg;
+    SET_CODEG_PPERM2(fg, codeg);
     return fg;
 }
 
@@ -3091,7 +3181,7 @@ Obj ProdPPerm44(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM4(fg) = codeg;
+    SET_CODEG_PPERM4(fg, codeg);
     return fg;
 }
 
@@ -3155,7 +3245,7 @@ Obj ProdPPerm24(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM4(fg) = codeg;
+    SET_CODEG_PPERM4(fg, codeg);
     return fg;
 }
 
@@ -3226,7 +3316,7 @@ Obj ProdPPerm2Perm2(Obj f, Obj p)
                 }
             }
         }
-        CODEG_PPERM2(fp) = codeg;
+        SET_CODEG_PPERM2(fp, codeg);
     }
     else {
         ptfp4 = ADDR_PPERM4(fp);
@@ -3252,7 +3342,7 @@ Obj ProdPPerm2Perm2(Obj f, Obj p)
                     codeg = ptfp4[j];
             }
         }
-        CODEG_PPERM4(fp) = codeg;
+        SET_CODEG_PPERM4(fp, codeg);
     }
     return fp;
 }
@@ -3316,7 +3406,7 @@ Obj ProdPPerm4Perm4(Obj f, Obj p)
             }
         }
     }
-    CODEG_PPERM4(fp) = codeg;
+    SET_CODEG_PPERM4(fp, codeg);
     return fp;
 }
 
@@ -3353,7 +3443,7 @@ Obj ProdPPerm2Perm4(Obj f, Obj p)
                 codeg = ptfp[j];
         }
     }
-    CODEG_PPERM4(fp) = codeg;
+    SET_CODEG_PPERM4(fp, codeg);
     return fp;
 }
 
@@ -3391,7 +3481,7 @@ Obj ProdPPerm4Perm2(Obj f, Obj p)
             ptfp[j] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
         }
     }
-    CODEG_PPERM4(fp) = codeg;
+    SET_CODEG_PPERM4(fp, codeg);
     return fp;
 }
 
@@ -3434,7 +3524,7 @@ Obj ProdPerm2PPerm2(Obj p, Obj f)
             if (ptp[i] < degf)
                 ptpf[i] = ptf[ptp[i]];
     }
-    CODEG_PPERM2(pf) = CODEG_PPERM2(f);
+    SET_CODEG_PPERM2(pf, CODEG_PPERM2(f));
     return pf;
 }
 
@@ -3476,7 +3566,7 @@ Obj ProdPerm4PPerm4(Obj p, Obj f)
             if (ptp[i] < degf)
                 ptpf[i] = ptf[ptp[i]];
     }
-    CODEG_PPERM4(pf) = CODEG_PPERM4(f);
+    SET_CODEG_PPERM4(pf, CODEG_PPERM4(f));
     return pf;
 }
 
@@ -3519,7 +3609,7 @@ Obj ProdPerm4PPerm2(Obj p, Obj f)
                 ptpf[i] = ptf[ptp[i]];
     }
 
-    CODEG_PPERM2(pf) = CODEG_PPERM2(f);
+    SET_CODEG_PPERM2(pf, CODEG_PPERM2(f));
     return pf;
 }
 
@@ -3562,7 +3652,7 @@ Obj ProdPerm2PPerm4(Obj p, Obj f)
                 ptpf[i] = ptf[ptp[i]];
     }
 
-    CODEG_PPERM4(pf) = CODEG_PPERM4(f);
+    SET_CODEG_PPERM4(pf, CODEG_PPERM4(f));
     return pf;
 }
 
@@ -3594,7 +3684,7 @@ Obj InvPPerm2(Obj f)
                 ptinv2[ptf[j] - 1] = j + 1;
             }
         }
-        CODEG_PPERM2(inv) = deg;
+        SET_CODEG_PPERM2(inv, deg);
     }
     else {
         inv = NEW_PPERM4(codeg);
@@ -3613,7 +3703,7 @@ Obj InvPPerm2(Obj f)
                 ptinv4[ptf[j] - 1] = j + 1;
             }
         }
-        CODEG_PPERM4(inv) = deg;
+        SET_CODEG_PPERM4(inv, deg);
     }
     return inv;
 }
@@ -3645,7 +3735,7 @@ Obj InvPPerm4(Obj f)
                 ptinv2[ptf[j] - 1] = j + 1;
             }
         }
-        CODEG_PPERM2(inv) = deg;
+        SET_CODEG_PPERM2(inv, deg);
     }
     else {
         inv = NEW_PPERM4(codeg);
@@ -3664,7 +3754,7 @@ Obj InvPPerm4(Obj f)
                 ptinv4[ptf[j] - 1] = j + 1;
             }
         }
-        CODEG_PPERM4(inv) = deg;
+        SET_CODEG_PPERM4(inv, deg);
     }
     return inv;
 }
@@ -3707,7 +3797,7 @@ Obj PowPPerm2Perm2(Obj f, Obj p)
     codeg = CODEG_PPERM2(f);
 
     if (codeg > dep) {
-        CODEG_PPERM2(conj) = codeg;
+        SET_CODEG_PPERM2(conj, codeg);
         for (i = 1; i <= rank; i++) {
             j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
             ptconj[IMAGE(j, ptp, dep)] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
@@ -3722,7 +3812,7 @@ Obj PowPPerm2Perm2(Obj f, Obj p)
             if (k > codeg)
                 codeg = k;
         }
-        CODEG_PPERM2(conj) = codeg;
+        SET_CODEG_PPERM2(conj, codeg);
     }
 
     return conj;
@@ -3769,7 +3859,7 @@ Obj PowPPerm2Perm4(Obj f, Obj p)
         if (k > codeg)
             codeg = k;
     }
-    CODEG_PPERM4(conj) = codeg;
+    SET_CODEG_PPERM4(conj, codeg);
 
     return conj;
 }
@@ -3810,7 +3900,7 @@ Obj PowPPerm4Perm2(Obj f, Obj p)
     codeg = CODEG_PPERM4(f);
 
     if (codeg > dep) {
-        CODEG_PPERM4(conj) = codeg;
+        SET_CODEG_PPERM4(conj, codeg);
         for (i = 1; i <= rank; i++) {
             j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
             ptconj[IMAGE(j, ptp, dep)] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
@@ -3825,7 +3915,7 @@ Obj PowPPerm4Perm2(Obj f, Obj p)
             if (k > codeg)
                 codeg = k;
         }
-        CODEG_PPERM4(conj) = codeg;
+        SET_CODEG_PPERM4(conj, codeg);
     }
     return conj;
 }
@@ -3866,7 +3956,7 @@ Obj PowPPerm4Perm4(Obj f, Obj p)
 
     if (codeg > dep) {
         // Pr("case 1\n", 0L, 0L);
-        CODEG_PPERM4(conj) = codeg;
+        SET_CODEG_PPERM4(conj, codeg);
         for (i = 1; i <= rank; i++) {
             j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
             ptconj[IMAGE(j, ptp, dep)] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
@@ -3882,7 +3972,7 @@ Obj PowPPerm4Perm4(Obj f, Obj p)
             if (k > codeg)
                 codeg = k;
         }
-        CODEG_PPERM4(conj) = codeg;
+        SET_CODEG_PPERM4(conj, codeg);
     }
     return conj;
 }
@@ -4103,7 +4193,7 @@ Obj PowPPerm22(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM2(conj) = codec;
+    SET_CODEG_PPERM2(conj, codec);
     return conj;
 }
 
@@ -4322,7 +4412,7 @@ Obj PowPPerm24(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM4(conj) = codec;
+    SET_CODEG_PPERM4(conj, codec);
     return conj;
 }
 
@@ -4541,7 +4631,7 @@ Obj PowPPerm42(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM4(conj) = codec;
+    SET_CODEG_PPERM4(conj, codec);
     return conj;
 }
 
@@ -4759,7 +4849,7 @@ Obj PowPPerm44(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM4(conj) = codec;
+    SET_CODEG_PPERM4(conj, codec);
     return conj;
 }
 
@@ -4842,7 +4932,7 @@ Obj QuoPPerm2Perm2(Obj f, Obj p)
                 }
             }
         }
-        CODEG_PPERM2(quo) = codeg;
+        SET_CODEG_PPERM2(quo, codeg);
     }
     else {
         quo = NEW_PPERM4(deg);
@@ -4872,7 +4962,7 @@ Obj QuoPPerm2Perm2(Obj f, Obj p)
                     codeg = ptquo4[j];
             }
         }
-        CODEG_PPERM4(quo) = codeg;
+        SET_CODEG_PPERM4(quo, codeg);
     }
     return quo;
 }
@@ -4955,7 +5045,7 @@ Obj QuoPPerm4Perm4(Obj f, Obj p)
             }
         }
     }
-    CODEG_PPERM4(quo) = codeg;
+    SET_CODEG_PPERM4(quo, codeg);
     return quo;
 }
 
@@ -5014,7 +5104,7 @@ Obj QuoPPerm2Perm4(Obj f, Obj p)
                 codeg = ptquo[j];
         }
     }
-    CODEG_PPERM4(quo) = codeg;
+    SET_CODEG_PPERM4(quo, codeg);
     return quo;
 }
 
@@ -5070,7 +5160,7 @@ Obj QuoPPerm4Perm2(Obj f, Obj p)
             ptquo[j] = IMAGE(ptf[j] - 1, pttmp, lmp) + 1;
         }
     }
-    CODEG_PPERM4(quo) = CODEG_PPERM4(f);
+    SET_CODEG_PPERM4(quo, CODEG_PPERM4(f));
     return quo;
 }
 
@@ -5149,7 +5239,7 @@ Obj QuoPPerm22(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM4(quo) = codeg;
+    SET_CODEG_PPERM4(quo, codeg);
     return quo;
 }
 
@@ -5234,7 +5324,7 @@ Obj QuoPPerm24(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM4(quo) = codeg;
+    SET_CODEG_PPERM4(quo, codeg);
     return quo;
 }
 
@@ -5319,7 +5409,7 @@ Obj QuoPPerm42(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM4(quo) = codeg;
+    SET_CODEG_PPERM4(quo, codeg);
     return quo;
 }
 
@@ -5396,7 +5486,7 @@ Obj QuoPPerm44(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM4(quo) = codeg;
+    SET_CODEG_PPERM4(quo, codeg);
     return quo;
 }
 
@@ -5503,7 +5593,7 @@ Obj LQuoPerm2PPerm2(Obj p, Obj f)
         }
     }
 
-    CODEG_PPERM2(lquo) = CODEG_PPERM2(f);
+    SET_CODEG_PPERM2(lquo, CODEG_PPERM2(f));
     return lquo;
 }
 
@@ -5584,8 +5674,7 @@ Obj LQuoPerm2PPerm4(Obj p, Obj f)
             }
         }
     }
-
-    CODEG_PPERM4(lquo) = CODEG_PPERM4(f);
+    SET_CODEG_PPERM4(lquo, CODEG_PPERM4(f));
     return lquo;
 }
 
@@ -5667,7 +5756,7 @@ Obj LQuoPerm4PPerm2(Obj p, Obj f)
         }
     }
 
-    CODEG_PPERM2(lquo) = CODEG_PPERM2(f);
+    SET_CODEG_PPERM2(lquo, CODEG_PPERM2(f));
     return lquo;
 }
 
@@ -5748,7 +5837,7 @@ Obj LQuoPerm4PPerm4(Obj p, Obj f)
         }
     }
 
-    CODEG_PPERM4(lquo) = CODEG_PPERM4(f);
+    SET_CODEG_PPERM4(lquo, CODEG_PPERM4(f));
     return lquo;
 }
 
@@ -5855,7 +5944,7 @@ Obj LQuoPPerm22(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM2(lquo) = codel;
+    SET_CODEG_PPERM2(lquo, codel);
     return lquo;
 }
 
@@ -5962,7 +6051,7 @@ Obj LQuoPPerm24(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM4(lquo) = codel;
+    SET_CODEG_PPERM4(lquo, codel);
     return lquo;
 }
 
@@ -6069,7 +6158,7 @@ Obj LQuoPPerm42(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM2(lquo) = codel;
+    SET_CODEG_PPERM2(lquo, codel);
     return lquo;
 }
 
@@ -6175,7 +6264,7 @@ Obj LQuoPPerm44(Obj f, Obj g)
             }
         }
     }
-    CODEG_PPERM4(lquo) = codel;
+    SET_CODEG_PPERM4(lquo, codel);
     return lquo;
 }
 
@@ -6286,8 +6375,8 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
     if (LEN_LIST(tup) == 0)
         return tup;
 
-    res = NEW_PLIST(IS_MUTABLE_PLIST(tup) ? T_PLIST_CYC_NSORT
-                                          : T_PLIST_CYC_NSORT + IMMUTABLE,
+    res = NEW_PLIST(IS_MUTABLE_PLIST(tup) ? T_PLIST_CYC
+                                          : T_PLIST_CYC + IMMUTABLE,
                     LEN_LIST(tup));
 
     /* get the pointer                                                 */

--- a/src/pperm.h
+++ b/src/pperm.h
@@ -1,6 +1,65 @@
 #ifndef GAP_PPERM_H
 #define GAP_PPERM_H
 
+static inline int IS_PPERM(Obj f)
+{
+    return (TNUM_OBJ(f) == T_PPERM2 || TNUM_OBJ(f) == T_PPERM4);
+}
+
+Obj NEW_PPERM2(UInt deg);
+
+static inline UInt2 * ADDR_PPERM2(Obj f)
+{
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    return ((UInt2 *)((Obj *)(ADDR_OBJ(f)) + 2) + 1);
+}
+
+static inline UInt DEG_PPERM2(Obj f)
+{
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    return ((UInt)(SIZE_OBJ(f) - sizeof(UInt2) - 2 * sizeof(Obj)) /
+            sizeof(UInt2));
+}
+
+UInt CODEG_PPERM2(Obj f);
+UInt RANK_PPERM2(Obj f);
+
+Obj NEW_PPERM4(UInt deg);
+
+static inline UInt4 * ADDR_PPERM4(Obj f)
+{
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    return ((UInt4 *)((Obj *)(ADDR_OBJ(f)) + 2) + 1);
+}
+
+static inline UInt DEG_PPERM4(Obj f)
+{
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    return ((UInt)(SIZE_OBJ(f) - sizeof(UInt4) - 2 * sizeof(Obj)) /
+            sizeof(UInt4));
+}
+
+UInt CODEG_PPERM4(Obj f);
+UInt RANK_PPERM4(Obj f);
+
+static inline UInt DEG_PPERM(Obj f)
+{
+    GAP_ASSERT(IS_PPERM(f));
+    return (TNUM_OBJ(f) == T_PPERM2 ? DEG_PPERM2(f) : DEG_PPERM4(f));
+}
+
+static inline UInt CODEG_PPERM(Obj f)
+{
+    GAP_ASSERT(IS_PPERM(f));
+    return (TNUM_OBJ(f) == T_PPERM2 ? CODEG_PPERM2(f) : CODEG_PPERM4(f));
+}
+
+static inline UInt RANK_PPERM(Obj f)
+{
+    GAP_ASSERT(IS_PPERM(f));
+    return (TNUM_OBJ(f) == T_PPERM2 ? RANK_PPERM2(f) : RANK_PPERM4(f));
+}
+
 /****************************************************************************
 **
 *F  OnTuplesPPerm( <tup>, <f> )  . . . .  operations on tuples of points

--- a/src/pperm.h
+++ b/src/pperm.h
@@ -9,17 +9,17 @@
 **  PPerm <f>.
 */
 
-extern Obj OnTuplesPPerm ( Obj set, Obj f );
+extern Obj OnTuplesPPerm(Obj set, Obj f);
 
 /****************************************************************************
 **
 *F  OnSetsPPerm( <set>, <f> ) . . . . . . . .  operations on sets of points
 **
-**  'OnSetsPPerm' returns the  image of the  tuple <set> under the 
-**  partial perm <f>. 
+**  'OnSetsPPerm' returns the  image of the  tuple <set> under the
+**  partial perm <f>.
 */
 
-extern Obj OnSetsPPerm ( Obj set, Obj f );
+extern Obj OnSetsPPerm(Obj set, Obj f);
 
 /****************************************************************************
 
@@ -30,6 +30,6 @@ extern Obj OnSetsPPerm ( Obj set, Obj f );
 *F  InitInfoPPerm()  . . . . . . . . . . . . . . . table of init functions
 */
 
-StructInitInfo * InitInfoPPerm ( void );
+StructInitInfo * InitInfoPPerm(void);
 
-#endif // GAP_PPERM_H
+#endif    // GAP_PPERM_H

--- a/src/trans.c
+++ b/src/trans.c
@@ -1,39 +1,43 @@
-/*******************************************************************************
+/*****************************************************************************
 *
 * A transformation <f> has internal representation as follows:
 *
-* [Obj* image set, Obj* flat kernel, Obj* external degree, entries image list]
+* [Obj* image set, Obj* flat kernel, Obj* external degree,
+*  entries image list]
 *
-* The <internal degree> of <f> is just the length of <entries image list>, this
-* is accessed here using <DEG_TRANS2> and <DEG_TRANS4>, in GAP it can be accessed
-* using INT_DEG_TRANS (for debugging purposes only).
+* The <internal degree> of <f> is just the length of <entries image
+* list>, this is accessed here using <DEG_TRANS2> and <DEG_TRANS4>, in
+* GAP it can be accessed using INT_DEG_TRANS (for debugging purposes
+* only).
 *
-* Transformations must always have internal degree greater than or equal to the
-* largest point in <entries image list>.
+* Transformations must always have internal degree greater than or equal
+* to the largest point in <entries image list>.
 *
-* An element of <entries image list> of a transformation in T_TRANS2 must be at
-* most 65535 and be UInt2. Hence the internal and external degrees of a T_TRANS2
-* are at most 65536. If <f> is T_TRANS4, then the elements of <entries
-* image list> must be UInt4. The degree of a T_TRANS4 must be 65537 or higher,
-* i.e. do not call NEW_TRANS4(n) when n < 65537.
+* An element of <entries image list> of a transformation in T_TRANS2
+* must be at most 65535 and be UInt2. Hence the internal and external
+* degrees of a T_TRANS2 are at most 65536. If <f> is T_TRANS4, then the
+* elements of <entries image list> must be UInt4. The degree of a
+* T_TRANS4 must be 65537 or higher, i.e. do not call NEW_TRANS4(n) when
+* n < 65537.
 *
-* The <image set> and <flat kernel> are found relative to the internal degree of
-* the transformation, and must not be changed after they are first found.
+* The <image set> and <flat kernel> are found relative to the internal
+* degree of the transformation, and must not be changed after they are
+* first found.
 *
-* The <external degree> is the largest non-negative integer <n> such that
-* n ^ f != n or i ^ f = n  for some i != n, or equivalently the degree of a
-* transformation is the least non-negative <n> such that [n + 1, n + 2, .. ] is
-* fixed pointwise by <f>. This value is an invariant of <f>, in the sense that
-* it does not depend on the internal representation. In GAP,
-* DegreeOfTransformation(f) returns the external degree, so that if f = g,
-* then DegreeOfTransformation(f) = DegreeOfTransformation(g).
+* The <external degree> is the largest non-negative integer <n> such
+* that n ^ f != n or i ^ f = n  for some i != n, or equivalently the
+* degree of a transformation is the least non-negative <n> such that [n
+* + 1, n + 2, .. ] is fixed pointwise by <f>. This value is an invariant
+* of <f>, in the sense that it does not depend on the internal
+* representation. In GAP, DegreeOfTransformation(f) returns the external
+* degree, so that if f = g, then DegreeOfTransformation(f) =
+* DegreeOfTransformation(g).
 *
-* In this file, the external degree of a transformation is accessed using
-* FuncDegreeOfTransformation(self, f), and the internal degree is accessed
-* using DEG_TRANS2/4(f).
+* In this file, the external degree of a transformation is accessed
+* using FuncDegreeOfTransformation(self, f), and the internal degree is
+* accessed using DEG_TRANS2/4(f).
 *
-*******************************************************************************/
-
+*****************************************************************************/
 
 #include <src/system.h>                 /* system dependent part */
 #include <src/gapstate.h>
@@ -42,7 +46,8 @@
 #include <src/objects.h>                /* objects */
 #include <src/scanner.h>                /* scanner */
 
-#include <src/gap.h>                    /* error handling, initialisation */
+#include <src/gap.h>                    /* error handling,
+                                           initialisation */
 
 #include <src/gvars.h>                  /* global variables */
 
@@ -78,11 +83,11 @@
 #include <src/trans.h>                  /* transformations */
 #include <assert.h>
 
-#define MIN(a, b)          (a < b ? a : b)
-#define MAX(a, b)          (a < b ? b : a)
+#define MIN(a, b) (a < b ? a : b)
+#define MAX(a, b) (a < b ? b : a)
 
 // TmpTrans is the same as TmpPerm
-#define  TmpTrans STATE(TmpTrans)
+#define TmpTrans STATE(TmpTrans)
 
 /* mp this will become a ReadOnly object? */
 Obj IdentityTrans;
@@ -97,185 +102,193 @@ Obj FuncIMAGE_SET_TRANS(Obj self, Obj f);
 ** Internal functions for transformations
 *******************************************************************************/
 
-static inline void ResizeTmpTrans (UInt len) {
-  if (TmpTrans == (Obj)0) {
-    TmpTrans = NewBag(T_TRANS4, len * sizeof(UInt4) + 3 * sizeof(Obj));
-  } else if (SIZE_OBJ(TmpTrans) < len * sizeof(UInt4) + 3 * sizeof(Obj)) {
-    ResizeBag(TmpTrans, len * sizeof(UInt4) + 3 * sizeof(Obj));
-  }
+static inline void ResizeTmpTrans(UInt len)
+{
+    if (TmpTrans == (Obj)0) {
+        TmpTrans = NewBag(T_TRANS4, len * sizeof(UInt4) + 3 * sizeof(Obj));
+    }
+    else if (SIZE_OBJ(TmpTrans) < len * sizeof(UInt4) + 3 * sizeof(Obj)) {
+        ResizeBag(TmpTrans, len * sizeof(UInt4) + 3 * sizeof(Obj));
+    }
 }
 
-static inline UInt4* ResizeInitTmpTrans (UInt len) {
-  UInt    i;
-  UInt4   *pttmp;
+static inline UInt4 * ResizeInitTmpTrans(UInt len)
+{
+    UInt    i;
+    UInt4 * pttmp;
 
-  if (TmpTrans == (Obj)0) {
-    TmpTrans = NewBag(T_TRANS4, len * sizeof(UInt4) + 3 * sizeof(Obj));
-  } else if (SIZE_BAG(TmpTrans) < len * sizeof(UInt4) + 3 * sizeof(Obj)) {
-    ResizeBag(TmpTrans, len * sizeof(UInt4) + 3 * sizeof(Obj));
-  }
+    if (TmpTrans == (Obj)0) {
+        TmpTrans = NewBag(T_TRANS4, len * sizeof(UInt4) + 3 * sizeof(Obj));
+    }
+    else if (SIZE_BAG(TmpTrans) < len * sizeof(UInt4) + 3 * sizeof(Obj)) {
+        ResizeBag(TmpTrans, len * sizeof(UInt4) + 3 * sizeof(Obj));
+    }
 
-  pttmp = ADDR_TRANS4(TmpTrans);
-  for (i = 0; i < len; i++) {
-    pttmp[i] = 0;
-  }
-  return pttmp;
+    pttmp = ADDR_TRANS4(TmpTrans);
+    for (i = 0; i < len; i++) {
+        pttmp[i] = 0;
+    }
+    return pttmp;
 }
 
 // Find the rank, flat kernel, and image set (unsorted) of a transformation of
 // degree at most 65536.
 
-extern UInt INIT_TRANS2 (Obj f) {
-  UInt    deg, rank, i, j;
-  UInt2   *ptf;
-  UInt4   *pttmp;
-  Obj     img, ker;
+extern UInt INIT_TRANS2(Obj f)
+{
+    UInt    deg, rank, i, j;
+    UInt2 * ptf;
+    UInt4 * pttmp;
+    Obj     img, ker;
 
-  deg = DEG_TRANS2(f);
+    deg = DEG_TRANS2(f);
 
-  if (deg == 0) {
-    // special case for degree 0
-    img = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
-    SET_LEN_PLIST(img, 0);
+    if (deg == 0) {
+        // special case for degree 0
+        img = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        SET_LEN_PLIST(img, 0);
+        IMG_TRANS(f) = img;
+        KER_TRANS(f) = img;
+        CHANGED_BAG(f);
+        return 0;
+    }
+
+    img = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, deg);
+    ker = NEW_PLIST(T_PLIST_CYC_NSORT + IMMUTABLE, deg);
+    SET_LEN_PLIST(ker, (Int)deg);
+
+    pttmp = ResizeInitTmpTrans(deg);
+    ptf = ADDR_TRANS2(f);
+
+    rank = 0;
+    for (i = 0; i < deg; i++) {
+        j = ptf[i];
+        if (pttmp[j] == 0) {
+            pttmp[j] = ++rank;
+            SET_ELM_PLIST(img, rank, INTOBJ_INT(j + 1));
+        }
+        SET_ELM_PLIST(ker, i + 1, INTOBJ_INT(pttmp[j]));
+    }
+
+    SHRINK_PLIST(img, (Int)rank);
+    SET_LEN_PLIST(img, (Int)rank);
+
     IMG_TRANS(f) = img;
-    KER_TRANS(f) = img;
+    KER_TRANS(f) = ker;
     CHANGED_BAG(f);
-    return 0;
-  }
-
-  img = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, deg);
-  ker = NEW_PLIST(T_PLIST_CYC_NSORT + IMMUTABLE, deg);
-  SET_LEN_PLIST(ker, (Int) deg);
-
-  pttmp = ResizeInitTmpTrans(deg);
-  ptf = ADDR_TRANS2(f);
-
-  rank = 0;
-  for (i = 0; i < deg; i++) {
-    j = ptf[i];
-      if (pttmp[j] == 0) {
-        pttmp[j] = ++rank;
-        SET_ELM_PLIST(img, rank, INTOBJ_INT(j + 1));
-      }
-    SET_ELM_PLIST(ker, i + 1, INTOBJ_INT(pttmp[j]));
-  }
-
-  SHRINK_PLIST(img, (Int) rank);
-  SET_LEN_PLIST(img, (Int) rank);
-
-  IMG_TRANS(f) = img;
-  KER_TRANS(f) = ker;
-  CHANGED_BAG(f);
-  return rank;
+    return rank;
 }
 
 // Find the rank, flat kernel, and image set (unsorted) of a transformation of
 // degree at least 65537.
 
-extern UInt INIT_TRANS4 (Obj f) {
-  UInt    deg, rank, i, j;
-  UInt4   *ptf;
-  UInt4   *pttmp;
-  Obj     img, ker;
+extern UInt INIT_TRANS4(Obj f)
+{
+    UInt    deg, rank, i, j;
+    UInt4 * ptf;
+    UInt4 * pttmp;
+    Obj     img, ker;
 
-  deg = DEG_TRANS4(f);
+    deg = DEG_TRANS4(f);
 
-  if (deg == 0) {
-    // Special case for degree 0.
+    if (deg == 0) {
+        // Special case for degree 0.
 
-    // The only transformation created within this file that is of type
-    // T_TRANS4 and that does not have (internal) degree 65537 or greater
-    // is ID_TRANS4.
+        // The only transformation created within this file that is of type
+        // T_TRANS4 and that does not have (internal) degree 65537 or greater
+        // is ID_TRANS4.
 
-    img = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
-    SET_LEN_PLIST(img, 0);
-    IMG_TRANS(f) = img;
-    KER_TRANS(f) = img;
-    CHANGED_BAG(f);
-    return 0;
-  }
-
-  img = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, deg);
-  ker = NEW_PLIST(T_PLIST_CYC_NSORT + IMMUTABLE, deg);
-  SET_LEN_PLIST(ker, (Int) deg);
-
-  pttmp = ResizeInitTmpTrans(deg);
-  ptf = ADDR_TRANS4(f);
-
-  rank = 0;
-  for (i = 0; i < deg; i++) {
-    j = ptf[i];
-    if (pttmp[j] == 0) {
-      pttmp[j] = ++rank;
-      SET_ELM_PLIST(img, rank, INTOBJ_INT(j + 1));
+        img = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        SET_LEN_PLIST(img, 0);
+        IMG_TRANS(f) = img;
+        KER_TRANS(f) = img;
+        CHANGED_BAG(f);
+        return 0;
     }
-    SET_ELM_PLIST(ker, i + 1, INTOBJ_INT(pttmp[j]));
-  }
 
-  SHRINK_PLIST(img, (Int) rank);
-  SET_LEN_PLIST(img, (Int) rank);
+    img = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, deg);
+    ker = NEW_PLIST(T_PLIST_CYC_NSORT + IMMUTABLE, deg);
+    SET_LEN_PLIST(ker, (Int)deg);
 
-  IMG_TRANS(f) = img;
-  KER_TRANS(f) = ker;
-  CHANGED_BAG(f);
-  return rank;
+    pttmp = ResizeInitTmpTrans(deg);
+    ptf = ADDR_TRANS4(f);
+
+    rank = 0;
+    for (i = 0; i < deg; i++) {
+        j = ptf[i];
+        if (pttmp[j] == 0) {
+            pttmp[j] = ++rank;
+            SET_ELM_PLIST(img, rank, INTOBJ_INT(j + 1));
+        }
+        SET_ELM_PLIST(ker, i + 1, INTOBJ_INT(pttmp[j]));
+    }
+
+    SHRINK_PLIST(img, (Int)rank);
+    SET_LEN_PLIST(img, (Int)rank);
+
+    IMG_TRANS(f) = img;
+    KER_TRANS(f) = ker;
+    CHANGED_BAG(f);
+    return rank;
 }
 
 // TODO should this use the newer sorting algorithm by CAJ in PR #609?
 //
 // Retyping is the responsibility of the caller.
 
-static void SORT_PLIST_CYC (Obj res) {
-  Obj     tmp;
-  UInt    h, i, k, len;
+static void SORT_PLIST_CYC(Obj res)
+{
+    Obj  tmp;
+    UInt h, i, k, len;
 
-  len = LEN_PLIST(res);
+    len = LEN_PLIST(res);
 
-  if (0 < len) {
-    h = 1;
-    while (9 * h + 4 < len) {
-      h = 3 * h + 1;
-    }
-    while (0 < h) {
-      for (i = h + 1; i <= len; i++) {
-        tmp = ADDR_OBJ(res)[i];
-        k = i;
-        while (h < k && ((Int)tmp < (Int)(ADDR_OBJ(res)[k - h]))) {
-          ADDR_OBJ(res)[k] = ADDR_OBJ(res)[k - h];
-          k -= h;
+    if (0 < len) {
+        h = 1;
+        while (9 * h + 4 < len) {
+            h = 3 * h + 1;
         }
-        ADDR_OBJ(res)[k] = tmp;
-      }
-      h = h / 3;
+        while (0 < h) {
+            for (i = h + 1; i <= len; i++) {
+                tmp = ADDR_OBJ(res)[i];
+                k = i;
+                while (h < k && ((Int)tmp < (Int)(ADDR_OBJ(res)[k - h]))) {
+                    ADDR_OBJ(res)[k] = ADDR_OBJ(res)[k - h];
+                    k -= h;
+                }
+                ADDR_OBJ(res)[k] = tmp;
+            }
+            h = h / 3;
+        }
+        CHANGED_BAG(res);
     }
-    CHANGED_BAG(res);
-  }
 }
 
 // Retyping is the responsibility of the caller, this should only be called
 // after a call to SORT_PLIST_CYC.
 
-static void REMOVE_DUPS_PLIST_CYC (Obj res) {
-  Obj     tmp;
-  UInt    i, k, len;
+static void REMOVE_DUPS_PLIST_CYC(Obj res)
+{
+    Obj  tmp;
+    UInt i, k, len;
 
-  len = LEN_PLIST(res);
+    len = LEN_PLIST(res);
 
-  if (0 < len) {
-    tmp = ADDR_OBJ(res)[1];
-    k = 1;
-    for (i = 2; i <= len; i++) {
-      if (tmp != ADDR_OBJ(res)[i]) {
-        k++;
-        tmp = ADDR_OBJ(res)[i];
-        ADDR_OBJ(res)[k] = tmp;
-      }
+    if (0 < len) {
+        tmp = ADDR_OBJ(res)[1];
+        k = 1;
+        for (i = 2; i <= len; i++) {
+            if (tmp != ADDR_OBJ(res)[i]) {
+                k++;
+                tmp = ADDR_OBJ(res)[i];
+                ADDR_OBJ(res)[k] = tmp;
+            }
+        }
+        if (k < len) {
+            ResizeBag(res, (k + 1) * sizeof(Obj));
+            SET_LEN_PLIST(res, k);
+        }
     }
-    if (k < len) {
-      ResizeBag(res, (k + 1) * sizeof(Obj));
-      SET_LEN_PLIST(res, k);
-    }
-  }
 }
 
 /*******************************************************************************
@@ -315,285 +328,311 @@ Obj FuncINT_DEG_TRANS (Obj self, Obj f) {
 // Returns a transformation with list of images <list>, this does not check
 // that <list> is really a list or that its entries define a transformation.
 
-Obj FuncTransformationNC (Obj self, Obj list) {
-  UInt    i, deg;
-  UInt2*  ptf2;
-  UInt4*  ptf4;
-  Obj     f;
+Obj FuncTransformationNC(Obj self, Obj list)
+{
+    UInt    i, deg;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    Obj     f;
 
-  deg = LEN_LIST(list);
+    deg = LEN_LIST(list);
 
-  if (deg <= 65536) {
-    f = NEW_TRANS2(deg);
-    ptf2 = ADDR_TRANS2(f);
-    for (i = 0; i < deg; i++) {
-      ptf2[i] = INT_INTOBJ(ELM_LIST(list, i + 1)) - 1;
+    if (deg <= 65536) {
+        f = NEW_TRANS2(deg);
+        ptf2 = ADDR_TRANS2(f);
+        for (i = 0; i < deg; i++) {
+            ptf2[i] = INT_INTOBJ(ELM_LIST(list, i + 1)) - 1;
+        }
     }
-  } else {
-    f = NEW_TRANS4(deg);
-    ptf4 = ADDR_TRANS4(f);
-    for (i = 0; i < deg; i++){
-      ptf4[i] = INT_INTOBJ(ELM_LIST(list, i + 1)) - 1;
+    else {
+        f = NEW_TRANS4(deg);
+        ptf4 = ADDR_TRANS4(f);
+        for (i = 0; i < deg; i++) {
+            ptf4[i] = INT_INTOBJ(ELM_LIST(list, i + 1)) - 1;
+        }
     }
-  }
-  return f;
+    return f;
 }
 
 // Returns a transformation that maps <src> to <ran>, this does not check that
 // <src> is duplicate-free.
 
-Obj FuncTransformationListListNC (Obj self, Obj src, Obj ran) {
-  Int     deg, i, s, r;
-  Obj     f;
-  UInt2*  ptf2;
-  UInt4*  ptf4;
+Obj FuncTransformationListListNC(Obj self, Obj src, Obj ran)
+{
+    Int     deg, i, s, r;
+    Obj     f;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
 
-  if (!IS_SMALL_LIST(src)) {
-    ErrorQuit("TransformationListListNC: <src> must be a list (not a %s)",
-              (Int) TNAM_OBJ(src), 0L);
-  }
-  if (!IS_SMALL_LIST(ran)) {
-    ErrorQuit("TransformationListListNC: <ran> must be a list (not a %s)",
-              (Int) TNAM_OBJ(ran), 0L);
-  }
-  if (LEN_LIST(src) != LEN_LIST(ran)) {
-    ErrorQuit("TransformationListListNC: <src> and <ran> must have equal "
-              "length,", 0L, 0L);
-  }
-
-  deg = 0;
-  for (i = LEN_LIST(src); 1 <= i; i--) {
-    if (!IS_INTOBJ(ELM_LIST(src, i))) {
-      ErrorQuit("TransformationListListNC: <src>[%d] must be a small integer (not a "
-                "%s)", (Int) i, (Int) TNAM_OBJ(ELM_LIST(src, i)));
+    if (!IS_SMALL_LIST(src)) {
+        ErrorQuit("TransformationListListNC: <src> must be a list (not a %s)",
+                  (Int)TNAM_OBJ(src), 0L);
     }
-    s = INT_INTOBJ(ELM_LIST(src, i));
-    if (s < 1) {
-      ErrorQuit("TransformationListListNC: <src>[%d] must be greater than 0",
-                (Int) i, 0L);
+    if (!IS_SMALL_LIST(ran)) {
+        ErrorQuit("TransformationListListNC: <ran> must be a list (not a %s)",
+                  (Int)TNAM_OBJ(ran), 0L);
+    }
+    if (LEN_LIST(src) != LEN_LIST(ran)) {
+        ErrorQuit("TransformationListListNC: <src> and <ran> must have equal "
+                  "length,",
+                  0L, 0L);
     }
 
-    if (!IS_INTOBJ(ELM_LIST(ran, i))) {
-      ErrorQuit("TransformationListListNC: <ran>[%d] must be a small integer (not a "
-                "%s)", (Int) i, (Int) TNAM_OBJ(ELM_LIST(ran, i)));
-    }
-    r = INT_INTOBJ(ELM_LIST(ran, i));
-    if (r < 1) {
-      ErrorQuit("TransformationListListNC: <ran>[%d] must be greater than 0",
-                (Int) i, 0L);
+    deg = 0;
+    for (i = LEN_LIST(src); 1 <= i; i--) {
+        if (!IS_INTOBJ(ELM_LIST(src, i))) {
+            ErrorQuit("TransformationListListNC: <src>[%d] must be a small "
+                      "integer (not a "
+                      "%s)",
+                      (Int)i, (Int)TNAM_OBJ(ELM_LIST(src, i)));
+        }
+        s = INT_INTOBJ(ELM_LIST(src, i));
+        if (s < 1) {
+            ErrorQuit(
+                "TransformationListListNC: <src>[%d] must be greater than 0",
+                (Int)i, 0L);
+        }
+
+        if (!IS_INTOBJ(ELM_LIST(ran, i))) {
+            ErrorQuit("TransformationListListNC: <ran>[%d] must be a small "
+                      "integer (not a "
+                      "%s)",
+                      (Int)i, (Int)TNAM_OBJ(ELM_LIST(ran, i)));
+        }
+        r = INT_INTOBJ(ELM_LIST(ran, i));
+        if (r < 1) {
+            ErrorQuit(
+                "TransformationListListNC: <ran>[%d] must be greater than 0",
+                (Int)i, 0L);
+        }
+
+        if (s != r) {
+            if (s > deg) {
+                deg = s;
+            }
+            if (r > deg) {
+                deg = r;
+            }
+        }
     }
 
-    if (s != r) {
-      if (s > deg) {
-        deg = s;
-      }
-      if (r > deg) {
-        deg = r;
-      }
+    if (deg <= 65536) {
+        f = NEW_TRANS2(deg);
+        ptf2 = ADDR_TRANS2(f);
+        for (i = 0; i < deg; i++) {
+            ptf2[i] = i;
+        }
+        for (i = LEN_LIST(src); 1 <= i; i--) {
+            ptf2[INT_INTOBJ(ELM_LIST(src, i)) - 1] =
+                INT_INTOBJ(ELM_LIST(ran, i)) - 1;
+        }
     }
-  }
-
-  if (deg <= 65536) {
-    f = NEW_TRANS2(deg);
-    ptf2 = ADDR_TRANS2(f);
-    for (i = 0; i < deg; i++){
-      ptf2[i] = i;
+    else {
+        f = NEW_TRANS4(deg);
+        ptf4 = ADDR_TRANS4(f);
+        for (i = 0; i < deg; i++) {
+            ptf4[i] = i;
+        }
+        for (i = LEN_LIST(src); 1 <= i; i--) {
+            ptf4[INT_INTOBJ(ELM_LIST(src, i)) - 1] =
+                INT_INTOBJ(ELM_LIST(ran, i)) - 1;
+        }
     }
-    for (i = LEN_LIST(src); 1 <= i; i --) {
-      ptf2[INT_INTOBJ(ELM_LIST(src, i)) - 1] = INT_INTOBJ(ELM_LIST(ran, i)) - 1;
-    }
-  } else {
-    f = NEW_TRANS4(deg);
-    ptf4 = ADDR_TRANS4(f);
-    for (i = 0; i < deg; i++) {
-      ptf4[i] = i;
-    }
-    for (i = LEN_LIST(src); 1 <= i; i --) {
-      ptf4[INT_INTOBJ(ELM_LIST(src, i)) - 1] = INT_INTOBJ(ELM_LIST(ran, i)) - 1;
-    }
-  }
-  return f;
+    return f;
 }
 
 // Returns a transformation with image <img> and flat kernel <ker> under the
-// (unchecked) assumption that the arguments are valid and that there is such a
-// transformation, i.e.  that the maximum value in <ker> equals the length of
-// <img>.
+// (unchecked) assumption that the arguments are valid and that there is such
+// a transformation, i.e.  that the maximum value in <ker> equals the length
+// of <img>.
 
-Obj FuncTRANS_IMG_KER_NC (Obj self, Obj img, Obj ker) {
-  Obj     f, copy_img, copy_ker;
-  UInt2*  ptf2;
-  UInt4*  ptf4;
-  UInt    i, pos, deg;
+Obj FuncTRANS_IMG_KER_NC(Obj self, Obj img, Obj ker)
+{
+    Obj     f, copy_img, copy_ker;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    i, pos, deg;
 
-  copy_img = SHALLOW_COPY_OBJ(img);
-  copy_ker = SHALLOW_COPY_OBJ(ker);
+    copy_img = SHALLOW_COPY_OBJ(img);
+    copy_ker = SHALLOW_COPY_OBJ(ker);
 
-  if (!IS_PLIST(copy_img)) {
-    PLAIN_LIST(copy_img);
-  }
-  if (!IS_PLIST(copy_ker)) {
-    PLAIN_LIST(copy_ker);
-  }
-  if (IS_MUTABLE_OBJ(copy_img)) {
-    RetypeBag(copy_img, TNUM_OBJ(copy_img) + IMMUTABLE);
-  }
-  if (IS_MUTABLE_OBJ(copy_ker)) {
-    RetypeBag(copy_ker, TNUM_OBJ(copy_ker) + IMMUTABLE);
-  }
-
-  deg = LEN_LIST(copy_ker);
-
-  if (deg <= 65536) {
-    f = NEW_TRANS2(deg);
-    ptf2 = ADDR_TRANS2(f);
-    for (i = 0; i < deg; i++) {
-      pos = INT_INTOBJ(ELM_PLIST(copy_ker, i + 1));
-      ptf2[i] = INT_INTOBJ(ELM_PLIST(copy_img, pos)) - 1;
+    if (!IS_PLIST(copy_img)) {
+        PLAIN_LIST(copy_img);
     }
-  } else {
-    f = NEW_TRANS4(deg);
-    ptf4 = ADDR_TRANS4(f);
-    for (i = 0; i < deg; i++) {
-      pos = INT_INTOBJ(ELM_PLIST(copy_ker, i + 1));
-      ptf4[i] = INT_INTOBJ(ELM_PLIST(copy_img, pos)) - 1;
+    if (!IS_PLIST(copy_ker)) {
+        PLAIN_LIST(copy_ker);
     }
-  }
+    if (IS_MUTABLE_OBJ(copy_img)) {
+        RetypeBag(copy_img, TNUM_OBJ(copy_img) + IMMUTABLE);
+    }
+    if (IS_MUTABLE_OBJ(copy_ker)) {
+        RetypeBag(copy_ker, TNUM_OBJ(copy_ker) + IMMUTABLE);
+    }
 
-  IMG_TRANS(f) = copy_img;
-  KER_TRANS(f) = copy_ker;
-  CHANGED_BAG(f);
+    deg = LEN_LIST(copy_ker);
 
-  return f;
+    if (deg <= 65536) {
+        f = NEW_TRANS2(deg);
+        ptf2 = ADDR_TRANS2(f);
+        for (i = 0; i < deg; i++) {
+            pos = INT_INTOBJ(ELM_PLIST(copy_ker, i + 1));
+            ptf2[i] = INT_INTOBJ(ELM_PLIST(copy_img, pos)) - 1;
+        }
+    }
+    else {
+        f = NEW_TRANS4(deg);
+        ptf4 = ADDR_TRANS4(f);
+        for (i = 0; i < deg; i++) {
+            pos = INT_INTOBJ(ELM_PLIST(copy_ker, i + 1));
+            ptf4[i] = INT_INTOBJ(ELM_PLIST(copy_img, pos)) - 1;
+        }
+    }
+
+    IMG_TRANS(f) = copy_img;
+    KER_TRANS(f) = copy_ker;
+    CHANGED_BAG(f);
+
+    return f;
 }
 
 // Returns an idempotent transformation with image <img> and flat kernel <ker>
-// under the (unchecked) assumption that the arguments are valid and that there
+// under the (unchecked) assumption that the arguments are valid and that
+// there
 // is such a transformation, i.e.  that the maximum value in <ker> equals the
 // length of <img>.
 //
 // Note that this does not return the same transformation as TRANS_IMG_KER_NC
 // with the same arguments.
 
-Obj FuncIDEM_IMG_KER_NC (Obj self, Obj img, Obj ker) {
-  Obj     f, copy_img, copy_ker;
-  UInt2*  ptf2;
-  UInt4*  ptf4, *pttmp;
-  UInt    i, j, deg, rank;
+Obj FuncIDEM_IMG_KER_NC(Obj self, Obj img, Obj ker)
+{
+    Obj     f, copy_img, copy_ker;
+    UInt2 * ptf2;
+    UInt4 * ptf4, *pttmp;
+    UInt    i, j, deg, rank;
 
-  copy_img = SHALLOW_COPY_OBJ(img);
-  copy_ker = SHALLOW_COPY_OBJ(ker);
+    copy_img = SHALLOW_COPY_OBJ(img);
+    copy_ker = SHALLOW_COPY_OBJ(ker);
 
-  if (!IS_PLIST(copy_img)) {
-    PLAIN_LIST(copy_img);
-  }
-  if (!IS_PLIST(copy_ker)) {
-    PLAIN_LIST(copy_ker);
-  }
-  if (IS_MUTABLE_OBJ(copy_img)) {
-    RetypeBag(copy_img, TNUM_OBJ(copy_img) + IMMUTABLE);
-  }
-  if (IS_MUTABLE_OBJ(copy_ker)) {
-    RetypeBag(copy_ker, TNUM_OBJ(copy_ker) + IMMUTABLE);
-  }
+    if (!IS_PLIST(copy_img)) {
+        PLAIN_LIST(copy_img);
+    }
+    if (!IS_PLIST(copy_ker)) {
+        PLAIN_LIST(copy_ker);
+    }
+    if (IS_MUTABLE_OBJ(copy_img)) {
+        RetypeBag(copy_img, TNUM_OBJ(copy_img) + IMMUTABLE);
+    }
+    if (IS_MUTABLE_OBJ(copy_ker)) {
+        RetypeBag(copy_ker, TNUM_OBJ(copy_ker) + IMMUTABLE);
+    }
 
-  deg = LEN_LIST(copy_ker);
-  rank = LEN_LIST(copy_img);
-  ResizeTmpTrans(deg);
-  pttmp = ADDR_TRANS4(TmpTrans);
-
-  // setup the lookup table
-  for (i = 0; i < rank; i++) {
-    j = INT_INTOBJ(ELM_PLIST(copy_img, i + 1));
-    pttmp[INT_INTOBJ(ELM_PLIST(copy_ker, j)) - 1] = j - 1;
-  }
-  if (deg <= 65536) {
-    f = NEW_TRANS2(deg);
-    ptf2 = ADDR_TRANS2(f);
+    deg = LEN_LIST(copy_ker);
+    rank = LEN_LIST(copy_img);
+    ResizeTmpTrans(deg);
     pttmp = ADDR_TRANS4(TmpTrans);
 
-    for (i = 0; i < deg; i++) {
-      ptf2[i] = pttmp[INT_INTOBJ(ELM_PLIST(copy_ker, i + 1)) - 1];
+    // setup the lookup table
+    for (i = 0; i < rank; i++) {
+        j = INT_INTOBJ(ELM_PLIST(copy_img, i + 1));
+        pttmp[INT_INTOBJ(ELM_PLIST(copy_ker, j)) - 1] = j - 1;
     }
-  } else {
-    f = NEW_TRANS4(deg);
-    ptf4 = ADDR_TRANS4(f);
-    pttmp = ADDR_TRANS4(TmpTrans);
+    if (deg <= 65536) {
+        f = NEW_TRANS2(deg);
+        ptf2 = ADDR_TRANS2(f);
+        pttmp = ADDR_TRANS4(TmpTrans);
 
-    for (i = 0; i < deg; i++) {
-      ptf4[i] = pttmp[INT_INTOBJ(ELM_PLIST(copy_ker, i + 1)) - 1];
+        for (i = 0; i < deg; i++) {
+            ptf2[i] = pttmp[INT_INTOBJ(ELM_PLIST(copy_ker, i + 1)) - 1];
+        }
     }
-  }
+    else {
+        f = NEW_TRANS4(deg);
+        ptf4 = ADDR_TRANS4(f);
+        pttmp = ADDR_TRANS4(TmpTrans);
 
-  IMG_TRANS(f) = copy_img;
-  KER_TRANS(f) = copy_ker;
-  CHANGED_BAG(f);
-  return f;
+        for (i = 0; i < deg; i++) {
+            ptf4[i] = pttmp[INT_INTOBJ(ELM_PLIST(copy_ker, i + 1)) - 1];
+        }
+    }
+
+    IMG_TRANS(f) = copy_img;
+    KER_TRANS(f) = copy_ker;
+    CHANGED_BAG(f);
+    return f;
 }
 
 // Returns an idempotent transformation e with ker(e) = ker(f), where <f> is a
 // transformation.
 
-Obj FuncLEFT_ONE_TRANS (Obj self, Obj f) {
-  Obj   ker, img;
-  UInt  rank, n, i;
+Obj FuncLEFT_ONE_TRANS(Obj self, Obj f)
+{
+    Obj  ker, img;
+    UInt rank, n, i;
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    rank = RANK_TRANS2(f);
-    ker = KER_TRANS(f);
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    rank = RANK_TRANS4(f);
-    ker = KER_TRANS(f);
-  } else {
-    ErrorQuit("LEFT_ONE_TRANS: the first argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-    return 0L;
-  }
-
-  img = NEW_PLIST(T_PLIST_CYC, rank);
-  n = 1;
-
-  for (i = 1; n <= rank; i++) {
-    if ((UInt) INT_INTOBJ(ELM_PLIST(ker, i)) == n) {
-      SET_ELM_PLIST(img, n++, INTOBJ_INT(i));
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        rank = RANK_TRANS2(f);
+        ker = KER_TRANS(f);
     }
-  }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        rank = RANK_TRANS4(f);
+        ker = KER_TRANS(f);
+    }
+    else {
+        ErrorQuit("LEFT_ONE_TRANS: the first argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+        return 0L;
+    }
 
-  SET_LEN_PLIST(img, (Int) n - 1);
-  return FuncIDEM_IMG_KER_NC(self, img, ker);
+    img = NEW_PLIST(T_PLIST_CYC, rank);
+    n = 1;
+
+    for (i = 1; n <= rank; i++) {
+        if ((UInt)INT_INTOBJ(ELM_PLIST(ker, i)) == n) {
+            SET_ELM_PLIST(img, n++, INTOBJ_INT(i));
+        }
+    }
+
+    SET_LEN_PLIST(img, (Int)n - 1);
+    return FuncIDEM_IMG_KER_NC(self, img, ker);
 }
 
 // Returns an idempotent transformation e with im(e) = im(f), where <f> is a
 // transformation.
 
-Obj FuncRIGHT_ONE_TRANS (Obj self, Obj f) {
-  Obj   ker, img;
-  UInt  deg, len, i, j, n;
+Obj FuncRIGHT_ONE_TRANS(Obj self, Obj f)
+{
+    Obj  ker, img;
+    UInt deg, len, i, j, n;
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    deg = DEG_TRANS2(f);
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    deg = DEG_TRANS4(f);
-  } else {
-    ErrorQuit("RIGHT_ONE_TRANS: the first argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-    return 0L;
-  }
-
-  img = FuncIMAGE_SET_TRANS(self, f);
-  ker = NEW_PLIST(T_PLIST_CYC, deg);
-  SET_LEN_PLIST(ker, deg);
-  len = LEN_PLIST(img);
-  j = 1;
-  n = 0;
-
-  for (i = 0; i < deg; i++) {
-    if (j < len && i + 1 == (UInt) INT_INTOBJ(ELM_PLIST(img, j + 1))) {
-      j++;
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        deg = DEG_TRANS2(f);
     }
-    SET_ELM_PLIST(ker, ++n, INTOBJ_INT(j));
-  }
-  return FuncIDEM_IMG_KER_NC(self, img, ker);
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        deg = DEG_TRANS4(f);
+    }
+    else {
+        ErrorQuit("RIGHT_ONE_TRANS: the first argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+        return 0L;
+    }
+
+    img = FuncIMAGE_SET_TRANS(self, f);
+    ker = NEW_PLIST(T_PLIST_CYC, deg);
+    SET_LEN_PLIST(ker, deg);
+    len = LEN_PLIST(img);
+    j = 1;
+    n = 0;
+
+    for (i = 0; i < deg; i++) {
+        if (j < len && i + 1 == (UInt)INT_INTOBJ(ELM_PLIST(img, j + 1))) {
+            j++;
+        }
+        SET_ELM_PLIST(ker, ++n, INTOBJ_INT(j));
+    }
+    return FuncIDEM_IMG_KER_NC(self, img, ker);
 }
 
 /*******************************************************************************
@@ -603,193 +642,214 @@ Obj FuncRIGHT_ONE_TRANS (Obj self, Obj f) {
 // Returns the degree of the transformation <f>, i.e. the least value <n> such
 // that <f> fixes [n + 1, n + 2, .. ].
 
-Obj FuncDegreeOfTransformation (Obj self, Obj f) {
-  UInt    n, i, deg;
-  UInt2   *ptf2;
-  UInt4   *ptf4;
+Obj FuncDegreeOfTransformation(Obj self, Obj f)
+{
+    UInt    n, i, deg;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    if (EXT_TRANS(f) == NULL) {
-      n = DEG_TRANS2(f);
-      ptf2 = ADDR_TRANS2(f);
-      if (ptf2[n - 1] != n - 1) {
-        EXT_TRANS(f) = INTOBJ_INT(n);
-      } else {
-        deg = 0;
-        for (i = 0; i < n; i++) {
-          if (ptf2[i] > i && ptf2[i] + 1 > deg) {
-            deg = ptf2[i] + 1;
-          } else if (ptf2[i] < i && i + 1 > deg) {
-            deg = i + 1;
-          }
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        if (EXT_TRANS(f) == NULL) {
+            n = DEG_TRANS2(f);
+            ptf2 = ADDR_TRANS2(f);
+            if (ptf2[n - 1] != n - 1) {
+                EXT_TRANS(f) = INTOBJ_INT(n);
+            }
+            else {
+                deg = 0;
+                for (i = 0; i < n; i++) {
+                    if (ptf2[i] > i && ptf2[i] + 1 > deg) {
+                        deg = ptf2[i] + 1;
+                    }
+                    else if (ptf2[i] < i && i + 1 > deg) {
+                        deg = i + 1;
+                    }
+                }
+                EXT_TRANS(f) = INTOBJ_INT(deg);
+            }
         }
-        EXT_TRANS(f) = INTOBJ_INT(deg);
-      }
+        return EXT_TRANS(f);
     }
-    return EXT_TRANS(f);
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    if (EXT_TRANS(f) == NULL) {
-      n = DEG_TRANS4(f);
-      ptf4 = ADDR_TRANS4(f);
-      if (ptf4[n - 1] != n - 1) {
-        EXT_TRANS(f) = INTOBJ_INT(n);
-      } else {
-        deg = 0;
-        for (i = 0; i < n; i++) {
-          if (ptf4[i] > i && ptf4[i] + 1 > deg) {
-            deg = ptf4[i] + 1;
-          } else if (ptf4[i] < i && i + 1 > deg) {
-            deg = i + 1;
-          }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        if (EXT_TRANS(f) == NULL) {
+            n = DEG_TRANS4(f);
+            ptf4 = ADDR_TRANS4(f);
+            if (ptf4[n - 1] != n - 1) {
+                EXT_TRANS(f) = INTOBJ_INT(n);
+            }
+            else {
+                deg = 0;
+                for (i = 0; i < n; i++) {
+                    if (ptf4[i] > i && ptf4[i] + 1 > deg) {
+                        deg = ptf4[i] + 1;
+                    }
+                    else if (ptf4[i] < i && i + 1 > deg) {
+                        deg = i + 1;
+                    }
+                }
+                EXT_TRANS(f) = INTOBJ_INT(deg);
+            }
         }
-        EXT_TRANS(f) = INTOBJ_INT(deg);
-      }
+        return EXT_TRANS(f);
     }
-    return EXT_TRANS(f);
-  }
-  ErrorQuit("DegreeOfTransformation: the argument must be a transformation "
-            "(not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("DegreeOfTransformation: the argument must be a transformation "
+              "(not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 // Returns the rank of transformation, i.e. number of distinct values in
 // [(1)f .. (n)f] where n = DegreeOfTransformation(f).
 
-Obj FuncRANK_TRANS (Obj self, Obj f) {
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    return SumInt(INTOBJ_INT(RANK_TRANS2(f) - DEG_TRANS2(f)),
-                  FuncDegreeOfTransformation(self, f));
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    return SumInt(INTOBJ_INT(RANK_TRANS4(f) - DEG_TRANS4(f)),
-                  FuncDegreeOfTransformation(self, f));
-  }
-  ErrorQuit("RANK_TRANS: the argument must be a transformation "
-            "(not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+Obj FuncRANK_TRANS(Obj self, Obj f)
+{
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        return SumInt(INTOBJ_INT(RANK_TRANS2(f) - DEG_TRANS2(f)),
+                      FuncDegreeOfTransformation(self, f));
+    }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        return SumInt(INTOBJ_INT(RANK_TRANS4(f) - DEG_TRANS4(f)),
+                      FuncDegreeOfTransformation(self, f));
+    }
+    ErrorQuit("RANK_TRANS: the argument must be a transformation "
+              "(not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 // Returns the rank of the transformation <f> on [1 .. n], i.e. the number of
 // distinct values in [(1)f .. (n)f].
 
-Obj FuncRANK_TRANS_INT (Obj self, Obj f, Obj n) {
-  UInt    rank, i, m;
-  UInt2   *ptf2;
-  UInt4   *pttmp, *ptf4;
+Obj FuncRANK_TRANS_INT(Obj self, Obj f, Obj n)
+{
+    UInt    rank, i, m;
+    UInt2 * ptf2;
+    UInt4 * pttmp, *ptf4;
 
-  if (!IS_INTOBJ(n) || INT_INTOBJ(n) < 0) {
-    ErrorQuit("RANK_TRANS_INT: <n> must be a non-negative integer",
-              0L, 0L);
+    if (!IS_INTOBJ(n) || INT_INTOBJ(n) < 0) {
+        ErrorQuit("RANK_TRANS_INT: <n> must be a non-negative integer", 0L,
+                  0L);
+        return 0L;
+    }
+
+    m = INT_INTOBJ(n);
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        if (m >= DEG_TRANS2(f)) {
+            return INTOBJ_INT(RANK_TRANS2(f) - DEG_TRANS2(f) + m);
+        }
+        else {
+            pttmp = ResizeInitTmpTrans(DEG_TRANS2(f));
+            ptf2 = ADDR_TRANS2(f);
+            rank = 0;
+            for (i = 0; i < m; i++) {
+                if (pttmp[ptf2[i]] == 0) {
+                    rank++;
+                    pttmp[ptf2[i]] = 1;
+                }
+            }
+            return INTOBJ_INT(rank);
+        }
+    }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        if (m >= DEG_TRANS4(f)) {
+            return INTOBJ_INT(RANK_TRANS4(f) - DEG_TRANS4(f) + m);
+        }
+        else {
+            pttmp = ResizeInitTmpTrans(DEG_TRANS4(f));
+            ptf4 = ADDR_TRANS4(f);
+            rank = 0;
+            for (i = 0; i < m; i++) {
+                if (pttmp[ptf4[i]] == 0) {
+                    rank++;
+                    pttmp[ptf4[i]] = 1;
+                }
+            }
+            return INTOBJ_INT(rank);
+        }
+    }
+    ErrorQuit("RANK_TRANS_INT: <f> must be a transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
     return 0L;
-  }
-
-  m = INT_INTOBJ(n);
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    if (m >= DEG_TRANS2(f)) {
-      return INTOBJ_INT(RANK_TRANS2(f) - DEG_TRANS2(f) + m);
-    } else {
-      pttmp = ResizeInitTmpTrans(DEG_TRANS2(f));
-      ptf2 = ADDR_TRANS2(f);
-      rank = 0;
-      for (i = 0; i < m; i++) {
-        if (pttmp[ptf2[i]] == 0) {
-          rank++;
-          pttmp[ptf2[i]] = 1;
-        }
-      }
-      return INTOBJ_INT(rank);
-    }
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    if (m >= DEG_TRANS4(f)) {
-      return INTOBJ_INT(RANK_TRANS4(f) - DEG_TRANS4(f) + m);
-    } else {
-      pttmp = ResizeInitTmpTrans(DEG_TRANS4(f));
-      ptf4 = ADDR_TRANS4(f);
-      rank = 0;
-      for (i = 0; i < m; i++) {
-        if (pttmp[ptf4[i]] == 0) {
-          rank++;
-          pttmp[ptf4[i]] = 1;
-        }
-      }
-      return INTOBJ_INT(rank);
-    }
-  }
-  ErrorQuit("RANK_TRANS_INT: <f> must be a transformation (not a %s)",
-            (Int) TNAM_OBJ(f), 0L);
-  return 0L;
 }
 
-// Returns the rank of the transformation <f> on the <list>, i.e. the number of
+// Returns the rank of the transformation <f> on the <list>, i.e. the number
+// of
 // distinct values in [(list[1])f .. (list[n])f], where <list> consists of
 // positive ints.
 
-Obj FuncRANK_TRANS_LIST (Obj self, Obj f, Obj list) {
-  UInt    rank, i, j, len, def;
-  UInt2   *ptf2;
-  UInt4   *pttmp, *ptf4;
-  Obj     pt;
+Obj FuncRANK_TRANS_LIST(Obj self, Obj f, Obj list)
+{
+    UInt    rank, i, j, len, def;
+    UInt2 * ptf2;
+    UInt4 * pttmp, *ptf4;
+    Obj     pt;
 
-  if (!IS_LIST(list)) {
-    ErrorQuit("RANK_TRANS_LIST: the second argument must be a list "
-              "(not a %s)", (Int) TNAM_OBJ(list), 0L);
-  }
-
-  len = LEN_LIST(list);
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    def = DEG_TRANS2(f);
-    pttmp = ResizeInitTmpTrans(def);
-    ptf2 = ADDR_TRANS2(f);
-    rank = 0;
-    for (i = 1; i <= len; i++) {
-      pt = ELM_LIST(list, i);
-      if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
-        ErrorQuit("RANK_TRANS_LIST: the second argument <list> must be a "
-                  "list of positive integers (not a %s)",
-                  (Int) TNAM_OBJ(pt),
-                  0L);
-      }
-      j = INT_INTOBJ(pt) - 1;
-      if (j < def) {
-        j = ptf2[j];
-        if (pttmp[j] == 0) {
-          rank++;
-          pttmp[j] = 1;
-        }
-      } else {
-        rank++;
-      }
+    if (!IS_LIST(list)) {
+        ErrorQuit("RANK_TRANS_LIST: the second argument must be a list "
+                  "(not a %s)",
+                  (Int)TNAM_OBJ(list), 0L);
     }
-    return INTOBJ_INT(rank);
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    def = DEG_TRANS4(f);
-    pttmp = ResizeInitTmpTrans(def);
-    ptf4 = ADDR_TRANS4(f);
-    rank = 0;
-    for (i = 1; i <= len; i++) {
-      pt = ELM_LIST(list, i);
-      if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
-        ErrorQuit("RANK_TRANS_LIST: the second argument <list> must be a "
-                  "list of positive integers (not a %s)",
-                  (Int) TNAM_OBJ(pt),
-                  0L);
-      }
-      j = INT_INTOBJ(pt) - 1;
-      if (j < def) {
-        j = ptf4[j];
-        if (pttmp[j] == 0) {
-          rank++;
-          pttmp[j] = 1;
-        }
-      } else {
-        rank++;
-      }
-    }
-    return INTOBJ_INT(rank);
-  }
 
-  ErrorQuit("RANK_TRANS_LIST: the first argument must be a transformation "
-            "(not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    len = LEN_LIST(list);
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        def = DEG_TRANS2(f);
+        pttmp = ResizeInitTmpTrans(def);
+        ptf2 = ADDR_TRANS2(f);
+        rank = 0;
+        for (i = 1; i <= len; i++) {
+            pt = ELM_LIST(list, i);
+            if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
+                ErrorQuit(
+                    "RANK_TRANS_LIST: the second argument <list> must be a "
+                    "list of positive integers (not a %s)",
+                    (Int)TNAM_OBJ(pt), 0L);
+            }
+            j = INT_INTOBJ(pt) - 1;
+            if (j < def) {
+                j = ptf2[j];
+                if (pttmp[j] == 0) {
+                    rank++;
+                    pttmp[j] = 1;
+                }
+            }
+            else {
+                rank++;
+            }
+        }
+        return INTOBJ_INT(rank);
+    }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        def = DEG_TRANS4(f);
+        pttmp = ResizeInitTmpTrans(def);
+        ptf4 = ADDR_TRANS4(f);
+        rank = 0;
+        for (i = 1; i <= len; i++) {
+            pt = ELM_LIST(list, i);
+            if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
+                ErrorQuit(
+                    "RANK_TRANS_LIST: the second argument <list> must be a "
+                    "list of positive integers (not a %s)",
+                    (Int)TNAM_OBJ(pt), 0L);
+            }
+            j = INT_INTOBJ(pt) - 1;
+            if (j < def) {
+                j = ptf4[j];
+                if (pttmp[j] == 0) {
+                    rank++;
+                    pttmp[j] = 1;
+                }
+            }
+            else {
+                rank++;
+            }
+        }
+        return INTOBJ_INT(rank);
+    }
+
+    ErrorQuit("RANK_TRANS_LIST: the first argument must be a transformation "
+              "(not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 /*******************************************************************************
@@ -799,223 +859,245 @@ Obj FuncRANK_TRANS_LIST (Obj self, Obj f, Obj list) {
 // Returns the flat kernel of transformation on
 // [1 .. DegreeOfTransformation(f)].
 
-Obj FuncFLAT_KERNEL_TRANS (Obj self, Obj f) {
+Obj FuncFLAT_KERNEL_TRANS(Obj self, Obj f)
+{
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    if (KER_TRANS(f) == NULL) {
-      INIT_TRANS2(f);
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        if (KER_TRANS(f) == NULL) {
+            INIT_TRANS2(f);
+        }
+        return KER_TRANS(f);
     }
-    return KER_TRANS(f);
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    if (KER_TRANS(f) == NULL) {
-      INIT_TRANS4(f);
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        if (KER_TRANS(f) == NULL) {
+            INIT_TRANS4(f);
+        }
+        return KER_TRANS(f);
     }
-    return KER_TRANS(f);
-  }
 
-  ErrorQuit("FLAT_KERNEL_TRANS: the first argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("FLAT_KERNEL_TRANS: the first argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 // Returns the flat kernel of the transformation <f> on [1 .. n].
 
-Obj FuncFLAT_KERNEL_TRANS_INT (Obj self, Obj f, Obj n) {
-  Obj     new, *ptnew, *ptker;
-  UInt    deg, m, i;
+Obj FuncFLAT_KERNEL_TRANS_INT(Obj self, Obj f, Obj n)
+{
+    Obj new, *ptnew, *ptker;
+    UInt deg, m, i;
 
-  if (!IS_INTOBJ(n) || INT_INTOBJ(n) < 0) {
-    ErrorQuit("FLAT_KERNEL_TRANS_INT: the second argument must be a "
-              "non-negative integer", 0L, 0L);
-  }
-
-  m = INT_INTOBJ(n);
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    if (KER_TRANS(f) == NULL) {
-      INIT_TRANS2(f);
+    if (!IS_INTOBJ(n) || INT_INTOBJ(n) < 0) {
+        ErrorQuit("FLAT_KERNEL_TRANS_INT: the second argument must be a "
+                  "non-negative integer",
+                  0L, 0L);
     }
-    deg = DEG_TRANS2(f);
-    if (m == deg) {
-      return KER_TRANS(f);
-    } else if (m == 0) {
-      new = NEW_PLIST(T_PLIST_EMPTY, 0);
-      SET_LEN_PLIST(new, 0);
-      return new;
-    } else {
-      new = NEW_PLIST(T_PLIST_CYC_NSORT, m);
-      SET_LEN_PLIST(new, m);
 
-      ptker = ADDR_OBJ(KER_TRANS(f)) + 1;
-      ptnew = ADDR_OBJ(new) + 1;
+    m = INT_INTOBJ(n);
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        if (KER_TRANS(f) == NULL) {
+            INIT_TRANS2(f);
+        }
+        deg = DEG_TRANS2(f);
+        if (m == deg) {
+            return KER_TRANS(f);
+        }
+        else if (m == 0) {
+            new = NEW_PLIST(T_PLIST_EMPTY, 0);
+            SET_LEN_PLIST(new, 0);
+            return new;
+        }
+        else {
+            new = NEW_PLIST(T_PLIST_CYC_NSORT, m);
+            SET_LEN_PLIST(new, m);
 
-      //copy the kernel set up to minimum of m, deg
-      if (m < deg) {
-        for (i = 0; i < m; i++) {
-          *ptnew++ = *ptker++;
+            ptker = ADDR_OBJ(KER_TRANS(f)) + 1;
+            ptnew = ADDR_OBJ(new) + 1;
+
+            // copy the kernel set up to minimum of m, deg
+            if (m < deg) {
+                for (i = 0; i < m; i++) {
+                    *ptnew++ = *ptker++;
+                }
+            }
+            else {
+                // m > deg
+                for (i = 0; i < deg; i++) {
+                    *ptnew++ = *ptker++;
+                }
+                // we must now add another (m - deg) points,
+                // starting with the class number (rank + 1)
+                for (i = 1; i <= m - deg; i++) {
+                    *ptnew++ = INTOBJ_INT(i + RANK_TRANS2(f));
+                }
+            }
+            return new;
         }
-      } else {
-        //m > deg
-        for (i = 0; i < deg; i++) {
-          *ptnew++ = *ptker++;
-        }
-        //we must now add another (m - deg) points,
-        //starting with the class number (rank + 1)
-        for (i = 1; i <= m - deg; i++) {
-          *ptnew++ = INTOBJ_INT(i + RANK_TRANS2(f));
-        }
-      }
-      return new;
     }
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
+    else if (TNUM_OBJ(f) == T_TRANS4) {
 
-    if (KER_TRANS(f) == NULL) {
-      INIT_TRANS4(f);
+        if (KER_TRANS(f) == NULL) {
+            INIT_TRANS4(f);
+        }
+        deg = DEG_TRANS4(f);
+        if (m == deg) {
+            return KER_TRANS(f);
+        }
+        else if (m == 0) {
+            new = NEW_PLIST(T_PLIST_EMPTY, 0);
+            SET_LEN_PLIST(new, 0);
+            return new;
+        }
+        else {
+            new = NEW_PLIST(T_PLIST_CYC_NSORT, m);
+            SET_LEN_PLIST(new, m);
+
+            ptker = ADDR_OBJ(KER_TRANS(f)) + 1;
+            ptnew = ADDR_OBJ(new) + 1;
+
+            // copy the kernel set up to minimum of m, deg
+            if (m < deg) {
+                for (i = 0; i < m; i++) {
+                    *ptnew++ = *ptker++;
+                }
+            }
+            else {
+                // m > deg
+                for (i = 0; i < deg; i++) {
+                    *ptnew++ = *ptker++;
+                }
+                // we must now add another (m - deg) points,
+                // starting with the class number (rank + 1)
+                for (i = 1; i <= m - deg; i++) {
+                    *ptnew++ = INTOBJ_INT(i + RANK_TRANS4(f));
+                }
+            }
+            return new;
+        }
     }
-    deg = DEG_TRANS4(f);
-    if (m == deg) {
-      return KER_TRANS(f);
-    } else if (m == 0) {
-      new = NEW_PLIST(T_PLIST_EMPTY, 0);
-      SET_LEN_PLIST(new, 0);
-      return new;
-    } else {
-      new = NEW_PLIST(T_PLIST_CYC_NSORT, m);
-      SET_LEN_PLIST(new, m);
-
-      ptker = ADDR_OBJ(KER_TRANS(f)) + 1;
-      ptnew = ADDR_OBJ(new) + 1;
-
-      //copy the kernel set up to minimum of m, deg
-      if (m < deg) {
-        for (i = 0; i < m; i++) {
-          *ptnew++ = *ptker++;
-        }
-      } else {
-        //m > deg
-        for (i = 0; i < deg; i++) {
-          *ptnew++ = *ptker++;
-        }
-        //we must now add another (m - deg) points,
-        //starting with the class number (rank + 1)
-        for (i = 1; i <= m - deg; i++) {
-          *ptnew++ = INTOBJ_INT(i + RANK_TRANS4(f));
-        }
-      }
-      return new;
-    }
-  }
-  ErrorQuit("FLAT_KERNEL_TRANS_INT: the first argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("FLAT_KERNEL_TRANS_INT: the first argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 // Returns the kernel of a transformation <f> as a partition of [1 .. n].
 
-Obj FuncKERNEL_TRANS (Obj self, Obj f, Obj n) {
-  Obj     ker;
-  UInt    i, j, deg, nr, m, rank, min;
-  UInt4*  pttmp;
+Obj FuncKERNEL_TRANS(Obj self, Obj f, Obj n)
+{
+    Obj     ker;
+    UInt    i, j, deg, nr, m, rank, min;
+    UInt4 * pttmp;
 
-  if (!IS_INTOBJ(n) || INT_INTOBJ(n) < 0) {
-    ErrorQuit("KERNEL_TRANS: the second argument must be a "
-              "non-negative integer", 0L, 0L);
-  } else if (!IS_TRANS(f)) {
-    ErrorQuit("KERNEL_TRANS: the first argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  }
-
-  m = INT_INTOBJ(n);
-
-  //special case for the identity
-  if (m == 0) {
-    ker = NEW_PLIST(T_PLIST_EMPTY, 0);
-    SET_LEN_PLIST(ker, 0);
-    return ker;
-  }
-
-  deg = DEG_TRANS(f);
-  rank = RANK_TRANS(f);
-  min = MIN(m, deg);
-  nr = (min == m ? rank : rank + m - deg);  // the number of classes
-
-  ker = NEW_PLIST(T_PLIST_HOM_SSORT, nr);
-  pttmp = ResizeInitTmpTrans(nr);
-
-  // RANK_TRANS(f) should install KER_TRANS(f)
-  assert(KER_TRANS(f) != NULL);
-
-  nr = 0;
-  // read off flat kernel
-  for (i = 0; i < min; i++) {
-    j = INT_INTOBJ(ELM_PLIST(KER_TRANS(f), i + 1));
-    if (pttmp[j - 1] == 0) {
-      nr++;
-      SET_ELM_PLIST(ker, j, NEW_PLIST(T_PLIST_CYC_SSORT, 1));
-      CHANGED_BAG(ker);
-      pttmp = ADDR_TRANS4(TmpTrans);
+    if (!IS_INTOBJ(n) || INT_INTOBJ(n) < 0) {
+        ErrorQuit("KERNEL_TRANS: the second argument must be a "
+                  "non-negative integer",
+                  0L, 0L);
     }
-    AssPlist(ELM_PLIST(ker, j), (Int) ++pttmp[j - 1], INTOBJ_INT(i + 1));
-    pttmp = ADDR_TRANS4(TmpTrans);
-  }
+    else if (!IS_TRANS(f)) {
+        ErrorQuit("KERNEL_TRANS: the first argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
 
-  // add trailing singletons, if any
-  for (i = deg; i < m; i++) {
-    SET_ELM_PLIST(ker, ++nr, NEW_PLIST(T_PLIST_CYC_SSORT, 1));
-    SET_LEN_PLIST(ELM_PLIST(ker, nr), 1);
-    SET_ELM_PLIST(ELM_PLIST(ker, nr), 1, INTOBJ_INT(i + 1));
-    CHANGED_BAG(ker);
-  }
-  SET_LEN_PLIST(ker, (Int) nr);
-  return ker;
+    m = INT_INTOBJ(n);
+
+    // special case for the identity
+    if (m == 0) {
+        ker = NEW_PLIST(T_PLIST_EMPTY, 0);
+        SET_LEN_PLIST(ker, 0);
+        return ker;
+    }
+
+    deg = DEG_TRANS(f);
+    rank = RANK_TRANS(f);
+    min = MIN(m, deg);
+    nr = (min == m ? rank : rank + m - deg);    // the number of classes
+
+    ker = NEW_PLIST(T_PLIST_HOM_SSORT, nr);
+    pttmp = ResizeInitTmpTrans(nr);
+
+    // RANK_TRANS(f) should install KER_TRANS(f)
+    assert(KER_TRANS(f) != NULL);
+
+    nr = 0;
+    // read off flat kernel
+    for (i = 0; i < min; i++) {
+        j = INT_INTOBJ(ELM_PLIST(KER_TRANS(f), i + 1));
+        if (pttmp[j - 1] == 0) {
+            nr++;
+            SET_ELM_PLIST(ker, j, NEW_PLIST(T_PLIST_CYC_SSORT, 1));
+            CHANGED_BAG(ker);
+            pttmp = ADDR_TRANS4(TmpTrans);
+        }
+        AssPlist(ELM_PLIST(ker, j), (Int)++pttmp[j - 1], INTOBJ_INT(i + 1));
+        pttmp = ADDR_TRANS4(TmpTrans);
+    }
+
+    // add trailing singletons, if any
+    for (i = deg; i < m; i++) {
+        SET_ELM_PLIST(ker, ++nr, NEW_PLIST(T_PLIST_CYC_SSORT, 1));
+        SET_LEN_PLIST(ELM_PLIST(ker, nr), 1);
+        SET_ELM_PLIST(ELM_PLIST(ker, nr), 1, INTOBJ_INT(i + 1));
+        CHANGED_BAG(ker);
+    }
+    SET_LEN_PLIST(ker, (Int)nr);
+    return ker;
 }
 
 // Returns the set (pt)f ^ -1.
 
-Obj FuncPREIMAGES_TRANS_INT (Obj self, Obj f, Obj pt) {
-  UInt    deg, nr, i, j;
-  Obj     out;
+Obj FuncPREIMAGES_TRANS_INT(Obj self, Obj f, Obj pt)
+{
+    UInt deg, nr, i, j;
+    Obj  out;
 
-  if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
-    ErrorQuit("PREIMAGES_TRANS_INT: the second argument must be a "
-              "positive integer", 0L, 0L);
-  } else if (!IS_TRANS(f)) {
-    ErrorQuit("PREIMAGES_TRANS_INT: the first argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  }
+    if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
+        ErrorQuit("PREIMAGES_TRANS_INT: the second argument must be a "
+                  "positive integer",
+                  0L, 0L);
+    }
+    else if (!IS_TRANS(f)) {
+        ErrorQuit("PREIMAGES_TRANS_INT: the first argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
 
-  deg = DEG_TRANS(f);
+    deg = DEG_TRANS(f);
 
-  if ((UInt) INT_INTOBJ(pt) > deg) {
-    out = NEW_PLIST(T_PLIST_CYC, 1);
-    SET_LEN_PLIST(out, 1);
-    SET_ELM_PLIST(out, 1, pt);
+    if ((UInt)INT_INTOBJ(pt) > deg) {
+        out = NEW_PLIST(T_PLIST_CYC, 1);
+        SET_LEN_PLIST(out, 1);
+        SET_ELM_PLIST(out, 1, pt);
+        return out;
+    }
+
+    i = INT_INTOBJ(pt) - 1;
+    out = NEW_PLIST(T_PLIST_CYC_SSORT, 0);
+    nr = 0;
+
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        for (j = 0; j < deg; j++) {
+            if ((ADDR_TRANS2(f))[j] == i) {
+                AssPlist(out, ++nr, INTOBJ_INT(j + 1));
+            }
+        }
+    }
+    else {
+        for (j = 0; j < deg; j++) {
+            if ((ADDR_TRANS4(f))[j] == i) {
+                AssPlist(out, ++nr, INTOBJ_INT(j + 1));
+            }
+        }
+    }
+
+    if (nr == 0) {
+        RetypeBag(out, T_PLIST_EMPTY);
+        SET_LEN_PLIST(out, 0);
+    }
+
     return out;
-  }
-
-  i = INT_INTOBJ(pt) - 1;
-  out = NEW_PLIST(T_PLIST_CYC_SSORT, 0);
-  nr = 0;
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    for (j = 0; j < deg; j++) {
-      if ((ADDR_TRANS2(f))[j] == i) {
-        AssPlist(out, ++nr, INTOBJ_INT(j + 1));
-      }
-    }
-  } else {
-    for (j = 0; j < deg; j++) {
-      if ((ADDR_TRANS4(f))[j] == i) {
-        AssPlist(out, ++nr, INTOBJ_INT(j + 1));
-      }
-    }
-  }
-
-  if (nr == 0) {
-    RetypeBag(out, T_PLIST_EMPTY);
-    SET_LEN_PLIST(out, 0);
-  }
-
-  return out;
 }
 
 /*******************************************************************************
@@ -1025,161 +1107,179 @@ Obj FuncPREIMAGES_TRANS_INT (Obj self, Obj f, Obj pt) {
 // Returns the duplicate free list of images of the transformation f on
 // [1 .. n] where n = DEG_TRANS(f). Note that this might not be sorted.
 
-Obj FuncUNSORTED_IMAGE_SET_TRANS (Obj self, Obj f) {
+Obj FuncUNSORTED_IMAGE_SET_TRANS(Obj self, Obj f)
+{
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    if (IMG_TRANS(f) == NULL) {
-      INIT_TRANS2(f);
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        if (IMG_TRANS(f) == NULL) {
+            INIT_TRANS2(f);
+        }
+        return IMG_TRANS(f);
     }
-    return IMG_TRANS(f);
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    if (IMG_TRANS(f) == NULL) {
-      INIT_TRANS4(f);
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        if (IMG_TRANS(f) == NULL) {
+            INIT_TRANS4(f);
+        }
+        return IMG_TRANS(f);
     }
-    return IMG_TRANS(f);
-  }
-  ErrorQuit("UNSORTED_IMAGE_SET_TRANS: the argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("UNSORTED_IMAGE_SET_TRANS: the argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 // Returns the image set of the transformation f on [1 .. n] where n =
 // DegreeOfTransformation(f).
 
-Obj FuncIMAGE_SET_TRANS (Obj self, Obj f) {
+Obj FuncIMAGE_SET_TRANS(Obj self, Obj f)
+{
 
-  Obj out = FuncUNSORTED_IMAGE_SET_TRANS(self, f);
+    Obj out = FuncUNSORTED_IMAGE_SET_TRANS(self, f);
 
-  if (!IS_SSORT_LIST(out)) {
-    SORT_PLIST_CYC(out);
-    RetypeBag(out, T_PLIST_CYC_SSORT+IMMUTABLE);
-    CHANGED_BAG(out);
+    if (!IS_SSORT_LIST(out)) {
+        SORT_PLIST_CYC(out);
+        RetypeBag(out, T_PLIST_CYC_SSORT + IMMUTABLE);
+        CHANGED_BAG(out);
+        return out;
+    }
     return out;
-  }
-  return out;
 }
 
 // Returns the image set of the transformation f on [1 .. n].
 
-Obj FuncIMAGE_SET_TRANS_INT (Obj self, Obj f, Obj n) {
-  Obj     im, new;
-  UInt    deg, m, len, i, j, rank;
-  Obj     *ptnew, *ptim;
-  UInt4   *pttmp, *ptf4;
-  UInt2   *ptf2;
+Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n)
+{
+    Obj     im, new;
+    UInt    deg, m, len, i, j, rank;
+    Obj *   ptnew, *ptim;
+    UInt4 * pttmp, *ptf4;
+    UInt2 * ptf2;
 
-  if (!IS_INTOBJ(n) || INT_INTOBJ(n) < 0) {
-    ErrorQuit("IMAGE_SET_TRANS_INT: the second argument must be a "
-              "non-negative integer", 0L, 0L);
-  } else if (!IS_TRANS(f)) {
-    ErrorQuit("IMAGE_SET_TRANS_INT: the first argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  }
+    if (!IS_INTOBJ(n) || INT_INTOBJ(n) < 0) {
+        ErrorQuit("IMAGE_SET_TRANS_INT: the second argument must be a "
+                  "non-negative integer",
+                  0L, 0L);
+    }
+    else if (!IS_TRANS(f)) {
+        ErrorQuit("IMAGE_SET_TRANS_INT: the first argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
 
-  m = INT_INTOBJ(n);
-  deg = DEG_TRANS(f);
+    m = INT_INTOBJ(n);
+    deg = DEG_TRANS(f);
 
-  if (m == deg) {
-    return FuncIMAGE_SET_TRANS(self, f);
-  } else if (m == 0) {
-    new = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
-    SET_LEN_PLIST(new, 0);
+    if (m == deg) {
+        return FuncIMAGE_SET_TRANS(self, f);
+    }
+    else if (m == 0) {
+        new = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        SET_LEN_PLIST(new, 0);
+        return new;
+    }
+    else if (m < deg) {
+        pttmp = ResizeInitTmpTrans(deg);
+        new = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, m);
+        pttmp = ADDR_TRANS4(TmpTrans);
+
+        if (TNUM_OBJ(f) == T_TRANS2) {
+            ptf2 = ADDR_TRANS2(f);
+            rank = 0;
+            for (i = 0; i < m; i++) {
+                j = ptf2[i];
+                if (pttmp[j] == 0) {
+                    pttmp[j] = ++rank;
+                    SET_ELM_PLIST(new, rank, INTOBJ_INT(j + 1));
+                }
+            }
+        }
+        else {
+            ptf4 = ADDR_TRANS4(f);
+            rank = 0;
+            for (i = 0; i < m; i++) {
+                j = ptf4[i];
+                if (pttmp[j] == 0) {
+                    pttmp[j] = ++rank;
+                    SET_ELM_PLIST(new, rank, INTOBJ_INT(j + 1));
+                }
+            }
+        }
+        SHRINK_PLIST(new, (Int)rank);
+        SET_LEN_PLIST(new, (Int)rank);
+        SORT_PLIST_CYC(new);
+        RetypeBag(new, T_PLIST_CYC_SSORT);
+        CHANGED_BAG(new);
+    }
+    else {
+        // m > deg and so m is at least 1!
+        im = FuncIMAGE_SET_TRANS(self, f);
+        len = LEN_PLIST(im);
+        new = NEW_PLIST(T_PLIST_CYC_SSORT, m - deg + len);
+        SET_LEN_PLIST(new, m - deg + len);
+
+        ptnew = ADDR_OBJ(new) + 1;
+        ptim = ADDR_OBJ(im) + 1;
+
+        // copy the image set
+        for (i = 0; i < len; i++) {
+            *ptnew++ = *ptim++;
+        }
+        // add new points
+        for (i = deg + 1; i <= m; i++) {
+            *ptnew++ = INTOBJ_INT(i);
+        }
+    }
     return new;
-  } else if (m < deg) {
-    pttmp = ResizeInitTmpTrans(deg);
-    new = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, m);
-    pttmp = ADDR_TRANS4(TmpTrans);
-
-    if (TNUM_OBJ(f) == T_TRANS2) {
-      ptf2 = ADDR_TRANS2(f);
-      rank = 0;
-      for (i = 0; i < m; i++) {
-        j = ptf2[i];
-          if (pttmp[j] == 0) {
-            pttmp[j] = ++rank;
-            SET_ELM_PLIST(new, rank, INTOBJ_INT(j + 1));
-          }
-      }
-    } else {
-      ptf4 = ADDR_TRANS4(f);
-      rank = 0;
-      for (i = 0; i < m; i++) {
-        j = ptf4[i];
-          if (pttmp[j] == 0) {
-            pttmp[j] = ++rank;
-            SET_ELM_PLIST(new, rank, INTOBJ_INT(j + 1));
-          }
-      }
-    }
-    SHRINK_PLIST(new, (Int) rank);
-    SET_LEN_PLIST(new, (Int) rank);
-    SORT_PLIST_CYC(new);
-    RetypeBag(new, T_PLIST_CYC_SSORT);
-    CHANGED_BAG(new);
-  } else {
-    //m > deg and so m is at least 1!
-    im = FuncIMAGE_SET_TRANS(self, f);
-    len = LEN_PLIST(im);
-    new = NEW_PLIST(T_PLIST_CYC_SSORT, m - deg + len);
-    SET_LEN_PLIST(new, m - deg + len);
-
-    ptnew = ADDR_OBJ(new) + 1;
-    ptim = ADDR_OBJ(im) + 1;
-
-    //copy the image set
-    for (i = 0; i < len; i++) {
-      *ptnew++ = *ptim++;
-    }
-    //add new points
-    for (i = deg + 1; i <= m; i++) {
-      *ptnew++ = INTOBJ_INT(i);
-    }
-  }
-  return new;
 }
 
 // Returns the image list [(1)f .. (n)f] of the transformation f.
 
-Obj FuncIMAGE_LIST_TRANS_INT (Obj self, Obj f, Obj n) {
-  UInt2*    ptf2;
-  UInt4*    ptf4;
-  UInt      i, deg, m;
-  Obj       out;
+Obj FuncIMAGE_LIST_TRANS_INT(Obj self, Obj f, Obj n)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    i, deg, m;
+    Obj     out;
 
-  if (!IS_INTOBJ(n) || INT_INTOBJ(n) < 0) {
-    ErrorQuit("IMAGE_LIST_TRANS_INT: the second argument must be a "
-              "non-negative integer", 0L, 0L);
-  } else if (!IS_TRANS(f)) {
-    ErrorQuit("IMAGE_LIST_TRANS_INT: the first argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  }
+    if (!IS_INTOBJ(n) || INT_INTOBJ(n) < 0) {
+        ErrorQuit("IMAGE_LIST_TRANS_INT: the second argument must be a "
+                  "non-negative integer",
+                  0L, 0L);
+    }
+    else if (!IS_TRANS(f)) {
+        ErrorQuit("IMAGE_LIST_TRANS_INT: the first argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
 
-  m = INT_INTOBJ(n);
+    m = INT_INTOBJ(n);
 
-  if (m == 0) {
-    out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
-    SET_LEN_PLIST(out, 0);
+    if (m == 0) {
+        out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        SET_LEN_PLIST(out, 0);
+        return out;
+    }
+
+    out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, m);
+
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        deg = MIN(DEG_TRANS2(f), m);
+        for (i = 0; i < deg; i++) {
+            SET_ELM_PLIST(out, i + 1, INTOBJ_INT(ptf2[i] + 1));
+        }
+    }
+    else {
+        ptf4 = ADDR_TRANS4(f);
+        deg = MIN(DEG_TRANS4(f), m);
+        for (i = 0; i < deg; i++) {
+            SET_ELM_PLIST(out, i + 1, INTOBJ_INT(ptf4[i] + 1));
+        }
+    }
+    for (; i < m; i++)
+        SET_ELM_PLIST(out, i + 1, INTOBJ_INT(i + 1));
+    SET_LEN_PLIST(out, (Int)m);
     return out;
-  }
-
-  out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, m);
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    deg = MIN(DEG_TRANS2(f), m);
-    for (i = 0; i < deg; i++) {
-      SET_ELM_PLIST(out, i + 1, INTOBJ_INT(ptf2[i] + 1));
-    }
-  } else {
-    ptf4 = ADDR_TRANS4(f);
-    deg = MIN(DEG_TRANS4(f), m);
-    for (i = 0; i < deg; i++) {
-      SET_ELM_PLIST(out, i + 1, INTOBJ_INT(ptf4[i] + 1));
-    }
-  }
-  for (; i < m; i++) SET_ELM_PLIST(out, i + 1, INTOBJ_INT(i + 1));
-  SET_LEN_PLIST(out, (Int) m);
-  return out;
 }
 
 /*******************************************************************************
@@ -1188,65 +1288,71 @@ Obj FuncIMAGE_LIST_TRANS_INT (Obj self, Obj f, Obj n) {
 
 // Test if a transformation is the identity.
 
-Obj FuncIS_ID_TRANS (Obj self, Obj f) {
-  UInt2*  ptf2;
-  UInt4*  ptf4;
-  UInt    deg, i;
+Obj FuncIS_ID_TRANS(Obj self, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    deg, i;
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    deg = DEG_TRANS2(f);
-    for (i = 0; i < deg; i++) {
-      if (ptf2[i] != i) {
-        return False;
-      }
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        deg = DEG_TRANS2(f);
+        for (i = 0; i < deg; i++) {
+            if (ptf2[i] != i) {
+                return False;
+            }
+        }
+        return True;
     }
-    return True;
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    ptf4 = ADDR_TRANS4(f);
-    deg = DEG_TRANS4(f);
-    for (i = 0; i < deg; i++) {
-      if (ptf4[i] != i) {
-        return False;
-      }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        ptf4 = ADDR_TRANS4(f);
+        deg = DEG_TRANS4(f);
+        for (i = 0; i < deg; i++) {
+            if (ptf4[i] != i) {
+                return False;
+            }
+        }
+        return True;
     }
-    return True;
-  }
-  ErrorQuit("IS_ID_TRANS: the first argument must be a transformation "
-            "(not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("IS_ID_TRANS: the first argument must be a transformation "
+              "(not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 // Returns true if the transformation <f> is an idempotent and false if it is
 // not.
 
-Obj FuncIS_IDEM_TRANS (Obj self, Obj f) {
-  UInt2 * ptf2;
-  UInt4 * ptf4;
-  UInt    deg, i;
+Obj FuncIS_IDEM_TRANS(Obj self, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    deg, i;
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    deg = DEG_TRANS2(f);
-    ptf2 = ADDR_TRANS2(f);
-    for (i = 0; i < deg; i++) {
-      if (ptf2[ptf2[i]] != ptf2[i]) {
-        return False;
-      }
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        deg = DEG_TRANS2(f);
+        ptf2 = ADDR_TRANS2(f);
+        for (i = 0; i < deg; i++) {
+            if (ptf2[ptf2[i]] != ptf2[i]) {
+                return False;
+            }
+        }
+        return True;
     }
-    return True;
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    deg = DEG_TRANS4(f);
-    ptf4 = ADDR_TRANS4(f);
-    for (i = 0; i < deg; i++) {
-      if (ptf4[ptf4[i]] != ptf4[i]) {
-        return False;
-      }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        deg = DEG_TRANS4(f);
+        ptf4 = ADDR_TRANS4(f);
+        for (i = 0; i < deg; i++) {
+            if (ptf4[ptf4[i]] != ptf4[i]) {
+                return False;
+            }
+        }
+        return True;
     }
-    return True;
-  }
-  ErrorQuit("IS_IDEM_TRANS: the argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("IS_IDEM_TRANS: the argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 /*******************************************************************************
@@ -1256,287 +1362,318 @@ Obj FuncIS_IDEM_TRANS (Obj self, Obj f) {
 // Returns the least m and r such that f ^ (m + r) = f ^ m, where f is a
 // transformation.
 
-Obj FuncIndexPeriodOfTransformation (Obj self, Obj f) {
-  UInt2   *ptf2;
-  UInt4   *seen, *ptf4;
-  UInt    deg, i, pt, dist, pow, len, last_pt;
-  Obj     ord, out;
-  Int     s, t, gcd, cyc;
+Obj FuncIndexPeriodOfTransformation(Obj self, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * seen, *ptf4;
+    UInt    deg, i, pt, dist, pow, len, last_pt;
+    Obj     ord, out;
+    Int     s, t, gcd, cyc;
 
-  if (!IS_TRANS(f)) {
-    ErrorQuit("IndexPeriodOfTransformation: the argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  }
+    if (!IS_TRANS(f)) {
+        ErrorQuit("IndexPeriodOfTransformation: the argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
 
-  deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
+    deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
 
-  if (deg == 0) {
+    if (deg == 0) {
+        out = NEW_PLIST(T_PLIST_CYC, 2);
+
+        SET_LEN_PLIST(out, 2);
+        SET_ELM_PLIST(out, 1, INTOBJ_INT(1));
+        SET_ELM_PLIST(out, 2, INTOBJ_INT(1));
+        return out;
+    }
+
+    // seen[pt] = 0 -> haven't seen pt before
+    //
+    // seen[pt] = d where (1 <= d <= deg)
+    //   -> pt belongs to a component we've seen before and (pt)f ^ (d - 1)
+    //   belongs to a cycle
+    //
+    // seen[pt] = deg + 1 -> pt belongs to a component not seen before
+
+    seen = ResizeInitTmpTrans(deg);
+
+    pow = 2;
+    ord = INTOBJ_INT(1);
+
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        for (i = 0; i < deg; i++) {
+            if (seen[i] == 0) {
+                len = 0;
+                // repeatedly apply f to pt until we see something we've seen
+                // already
+                for (pt = i; seen[pt] == 0; pt = ptf2[pt], len++) {
+                    seen[pt] = deg + 1;
+                }
+                last_pt = pt;
+                if (seen[pt] <= deg) {
+                    // pt belongs to a component we've seen before
+                    dist = seen[pt] + len;
+                    // the distance of i from the cycle in its component + 1
+                }
+                else {
+                    // pt belongs to a component we've not seen before
+
+                    for (cyc = 0; seen[pt] == deg + 1; pt = ptf2[pt], cyc++) {
+                        // go around the cycle again and set the value of
+                        // seen,
+                        // and get the length of the cycle
+                        seen[pt] = 1;
+                    }
+
+                    // compute the gcd of the cycle length with the previous
+                    // order ord
+                    gcd = cyc;
+                    s = INT_INTOBJ(ModInt(ord, INTOBJ_INT(cyc)));
+                    while (s != 0) {
+                        t = s;
+                        s = gcd % s;
+                        gcd = t;
+                    }
+                    ord = ProdInt(ord, INTOBJ_INT(cyc / gcd));
+                    dist = len - cyc + 1;
+                    // the distance of i from the cycle in its component + 1
+                }
+                if (dist > pow) {
+                    pow = dist;
+                }
+                // record the distances of the points from the cycle
+                for (pt = i; pt != last_pt; pt = ptf2[pt]) {
+                    seen[pt] = dist--;
+                }
+            }
+        }
+    }
+    else {
+        ptf4 = ADDR_TRANS4(f);
+        for (i = 0; i < deg; i++) {
+            if (seen[i] == 0) {
+                len = 0;
+                // repeatedly apply f to pt until we see something we've seen
+                // already
+                for (pt = i; seen[pt] == 0; pt = ptf4[pt], len++) {
+                    seen[pt] = deg + 1;
+                }
+                last_pt = pt;
+                if (seen[pt] <= deg) {
+                    // pt belongs to a component we've seen before
+                    dist = seen[pt] + len;
+                    // the distance of i from the cycle in its component + 1
+                }
+                else {
+                    // pt belongs to a component we've not seen before
+
+                    for (cyc = 0; seen[pt] == deg + 1; pt = ptf4[pt], cyc++) {
+                        // go around the cycle again and set the value of
+                        // seen,
+                        // and get the length of the cycle
+                        seen[pt] = 1;
+                    }
+
+                    // compute the gcd of the cycle length with the previous
+                    // order ord
+                    gcd = cyc;
+                    s = INT_INTOBJ(ModInt(ord, INTOBJ_INT(cyc)));
+                    while (s != 0) {
+                        t = s;
+                        s = gcd % s;
+                        gcd = t;
+                    }
+                    ord = ProdInt(ord, INTOBJ_INT(cyc / gcd));
+                    dist = len - cyc + 1;
+                    // the distance of i from the cycle in its component + 1
+                }
+                if (dist > pow) {
+                    pow = dist;
+                }
+                // record the distances of the points from the cycle
+                for (pt = i; pt != last_pt; pt = ptf4[pt]) {
+                    seen[pt] = dist--;
+                }
+            }
+        }
+    }
+
     out = NEW_PLIST(T_PLIST_CYC, 2);
 
     SET_LEN_PLIST(out, 2);
-    SET_ELM_PLIST(out, 1, INTOBJ_INT(1));
-    SET_ELM_PLIST(out, 2, INTOBJ_INT(1));
+    SET_ELM_PLIST(out, 1, INTOBJ_INT(--pow));
+    SET_ELM_PLIST(out, 2, ord);
     return out;
-  }
-
-  // seen[pt] = 0 -> haven't seen pt before
-  //
-  // seen[pt] = d where (1 <= d <= deg)
-  //   -> pt belongs to a component we've seen before and (pt)f ^ (d - 1)
-  //   belongs to a cycle
-  //
-  // seen[pt] = deg + 1 -> pt belongs to a component not seen before
-
-  seen = ResizeInitTmpTrans(deg);
-
-  pow = 2;
-  ord = INTOBJ_INT(1);
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    for (i = 0; i < deg; i++) {
-      if (seen[i] == 0) {
-        len = 0;
-        // repeatedly apply f to pt until we see something we've seen already
-        for (pt = i; seen[pt] == 0; pt = ptf2[pt], len++) {
-          seen[pt] = deg + 1;
-        }
-        last_pt = pt;
-        if (seen[pt] <= deg) {
-          // pt belongs to a component we've seen before
-          dist = seen[pt] + len;
-          // the distance of i from the cycle in its component + 1
-        } else {
-          // pt belongs to a component we've not seen before
-
-          for (cyc = 0; seen[pt] == deg + 1; pt = ptf2[pt], cyc++) {
-            // go around the cycle again and set the value of seen,
-            // and get the length of the cycle
-            seen[pt] = 1;
-          }
-
-          // compute the gcd of the cycle length with the previous order ord
-          gcd = cyc;
-          s = INT_INTOBJ(ModInt(ord, INTOBJ_INT(cyc)));
-          while (s != 0) {
-            t = s;
-            s = gcd % s;
-            gcd = t;
-          }
-          ord = ProdInt(ord, INTOBJ_INT(cyc / gcd));
-          dist = len - cyc + 1;
-          // the distance of i from the cycle in its component + 1
-        }
-        if (dist > pow) {
-          pow = dist;
-        }
-        // record the distances of the points from the cycle
-        for (pt = i; pt != last_pt; pt = ptf2[pt]) {
-          seen[pt] = dist--;
-        }
-      }
-    }
-  } else {
-    ptf4 = ADDR_TRANS4(f);
-    for (i = 0; i < deg; i++) {
-      if (seen[i] == 0) {
-        len = 0;
-        // repeatedly apply f to pt until we see something we've seen already
-        for (pt = i; seen[pt] == 0; pt = ptf4[pt], len++) {
-          seen[pt] = deg + 1;
-        }
-        last_pt = pt;
-        if (seen[pt] <= deg) {
-          // pt belongs to a component we've seen before
-          dist = seen[pt] + len;
-          // the distance of i from the cycle in its component + 1
-        } else {
-          // pt belongs to a component we've not seen before
-
-          for (cyc = 0; seen[pt] == deg + 1; pt = ptf4[pt], cyc++) {
-            // go around the cycle again and set the value of seen,
-            // and get the length of the cycle
-            seen[pt] = 1;
-          }
-
-          // compute the gcd of the cycle length with the previous order ord
-          gcd = cyc;
-          s = INT_INTOBJ(ModInt(ord, INTOBJ_INT(cyc)));
-          while (s != 0) {
-            t = s;
-            s = gcd % s;
-            gcd = t;
-          }
-          ord = ProdInt(ord, INTOBJ_INT(cyc / gcd));
-          dist = len - cyc + 1;
-          // the distance of i from the cycle in its component + 1
-        }
-        if (dist > pow) {
-          pow = dist;
-        }
-        // record the distances of the points from the cycle
-        for (pt = i; pt != last_pt; pt = ptf4[pt]) {
-          seen[pt] = dist--;
-        }
-      }
-    }
-  }
-
-  out = NEW_PLIST(T_PLIST_CYC, 2);
-
-  SET_LEN_PLIST(out, 2);
-  SET_ELM_PLIST(out, 1, INTOBJ_INT(--pow));
-  SET_ELM_PLIST(out, 2, ord);
-  return out;
 }
 
 // Returns the least integer m such that f ^ m is an idempotent.
 
-Obj FuncSMALLEST_IDEM_POW_TRANS (Obj self, Obj f) {
-  Obj x, ind, per, pow;
+Obj FuncSMALLEST_IDEM_POW_TRANS(Obj self, Obj f)
+{
+    Obj x, ind, per, pow;
 
-  x = FuncIndexPeriodOfTransformation(self, f);
-  ind = ELM_PLIST(x, 1);
-  per = ELM_PLIST(x, 2);
-  pow = per;
-  while (LtInt(pow, ind)) {
-    pow = SumInt(pow, per);
-  }
-  return pow;
+    x = FuncIndexPeriodOfTransformation(self, f);
+    ind = ELM_PLIST(x, 1);
+    per = ELM_PLIST(x, 2);
+    pow = per;
+    while (LtInt(pow, ind)) {
+        pow = SumInt(pow, per);
+    }
+    return pow;
 }
 
 /*******************************************************************************
 ** GAP level functions for regularity of transformations
 *******************************************************************************/
 
-// Returns True if the transformation or list <t> is injective on the list <l>.
+// Returns True if the transformation or list <t> is injective on the list
+// <l>.
 
-Obj FuncIsInjectiveListTrans (Obj self, Obj l, Obj t) {
-  UInt    n, i, j;
-  UInt2   *ptt2;
-  UInt4   *pttmp = 0L;
-  UInt4   *ptt4;
-  Obj     val;
+Obj FuncIsInjectiveListTrans(Obj self, Obj l, Obj t)
+{
+    UInt    n, i, j;
+    UInt2 * ptt2;
+    UInt4 * pttmp = 0L;
+    UInt4 * ptt4;
+    Obj     val;
 
-  if (!IS_LIST(l)) {
-      ErrorQuit("the first argument must be a list (not a %s)",
-                (Int)TNAM_OBJ(l), 0L);
-  } else if (!IS_TRANS(t) && !IS_LIST(t)) {
-      ErrorQuit("the second argument must be a transformation or a list "
-                "(not a %s)", (Int)TNAM_OBJ(t), 0L);
-  }
-  // init buffer
-  n = (IS_TRANS(t) ? DEG_TRANS(t) : LEN_LIST(t));
-  pttmp = ResizeInitTmpTrans(n);
-
-  if (TNUM_OBJ(t) == T_TRANS2) {
-    ptt2 = ADDR_TRANS2(t);
-    for (i = LEN_LIST(l); i >= 1; i--) {
-      val = ELM_LIST(l, i);
-      if (!IS_POS_INTOBJ(val)) {
-          ErrorQuit("the entries of the first argument must be positive "
-                    "integers (not a %s)", (Int)TNAM_OBJ(val), 0L);
-      }
-      j = INT_INTOBJ(val);
-      if (j <= n) {
-        if (pttmp[ptt2[j - 1]] != 0) {
-          return False;
-        }
-        pttmp[ptt2[j - 1]] = 1;
-      }
+    if (!IS_LIST(l)) {
+        ErrorQuit("the first argument must be a list (not a %s)",
+                  (Int)TNAM_OBJ(l), 0L);
     }
-  } else if (TNUM_OBJ(t) == T_TRANS4) {
-    ptt4 = ADDR_TRANS4(t);
-    for (i = LEN_LIST(l); i >= 1; i--) {
-      val = ELM_LIST(l, i);
-      if (!IS_POS_INTOBJ(val)) {
-          ErrorQuit("the entries of the first argument must be positive "
-                    "integers (not a %s)", (Int)TNAM_OBJ(val), 0L);
-      }
-      j = INT_INTOBJ(val);
-      if (j <= n) {
-        if (pttmp[ptt4[j - 1]] != 0) {
-          return False;
-        }
-        pttmp[ptt4[j - 1]] = 1;
-      }
+    else if (!IS_TRANS(t) && !IS_LIST(t)) {
+        ErrorQuit("the second argument must be a transformation or a list "
+                  "(not a %s)",
+                  (Int)TNAM_OBJ(t), 0L);
     }
-  } else {
-    // t is a list, first we check it describes a transformation
-    for (i = 1; i <= n; i++) {
-      val = ELM_LIST(t, i);
-      if (!IS_POS_INTOBJ(val)) {
-          ErrorQuit("the second argument must consist of positive integers "
+    // init buffer
+    n = (IS_TRANS(t) ? DEG_TRANS(t) : LEN_LIST(t));
+    pttmp = ResizeInitTmpTrans(n);
+
+    if (TNUM_OBJ(t) == T_TRANS2) {
+        ptt2 = ADDR_TRANS2(t);
+        for (i = LEN_LIST(l); i >= 1; i--) {
+            val = ELM_LIST(l, i);
+            if (!IS_POS_INTOBJ(val)) {
+                ErrorQuit(
+                    "the entries of the first argument must be positive "
+                    "integers (not a %s)",
+                    (Int)TNAM_OBJ(val), 0L);
+            }
+            j = INT_INTOBJ(val);
+            if (j <= n) {
+                if (pttmp[ptt2[j - 1]] != 0) {
+                    return False;
+                }
+                pttmp[ptt2[j - 1]] = 1;
+            }
+        }
+    }
+    else if (TNUM_OBJ(t) == T_TRANS4) {
+        ptt4 = ADDR_TRANS4(t);
+        for (i = LEN_LIST(l); i >= 1; i--) {
+            val = ELM_LIST(l, i);
+            if (!IS_POS_INTOBJ(val)) {
+                ErrorQuit(
+                    "the entries of the first argument must be positive "
+                    "integers (not a %s)",
+                    (Int)TNAM_OBJ(val), 0L);
+            }
+            j = INT_INTOBJ(val);
+            if (j <= n) {
+                if (pttmp[ptt4[j - 1]] != 0) {
+                    return False;
+                }
+                pttmp[ptt4[j - 1]] = 1;
+            }
+        }
+    }
+    else {
+        // t is a list, first we check it describes a transformation
+        for (i = 1; i <= n; i++) {
+            val = ELM_LIST(t, i);
+            if (!IS_POS_INTOBJ(val)) {
+                ErrorQuit(
+                    "the second argument must consist of positive integers "
                     "(not a %s)",
                     (Int)TNAM_OBJ(val), 0L);
-      } else if (INT_INTOBJ(val) > n) {
-          ErrorQuit("the second argument must consist of positive integers "
+            }
+            else if (INT_INTOBJ(val) > n) {
+                ErrorQuit(
+                    "the second argument must consist of positive integers "
                     "in the range [1 .. %d]",
                     (Int)n, 0L);
-      }
-    }
-    for (i = LEN_LIST(l); i >= 1; i--) {
-      val = ELM_LIST(l, i);
-      if (!IS_POS_INTOBJ(val)) {
-          ErrorQuit("the entries of the first argument must be positive "
-                    "integers (not a %s)", (Int)TNAM_OBJ(val), 0L);
-      }
-      j = INT_INTOBJ(val);
-      if (j <= n) {
-        if (pttmp[INT_INTOBJ(ELM_LIST(t, j)) - 1] != 0) {
-          return False;
+            }
         }
-        pttmp[INT_INTOBJ(ELM_LIST(t, j)) - 1] = 1;
-      }
+        for (i = LEN_LIST(l); i >= 1; i--) {
+            val = ELM_LIST(l, i);
+            if (!IS_POS_INTOBJ(val)) {
+                ErrorQuit(
+                    "the entries of the first argument must be positive "
+                    "integers (not a %s)",
+                    (Int)TNAM_OBJ(val), 0L);
+            }
+            j = INT_INTOBJ(val);
+            if (j <= n) {
+                if (pttmp[INT_INTOBJ(ELM_LIST(t, j)) - 1] != 0) {
+                    return False;
+                }
+                pttmp[INT_INTOBJ(ELM_LIST(t, j)) - 1] = 1;
+            }
+        }
     }
-  }
-  return True;
+    return True;
 }
 
 // Returns a transformation g such that transformation f * g * f = f and
 // g * f * g = g, where f is a transformation.
 
-Obj FuncInverseOfTransformation (Obj self, Obj f) {
-  UInt2   *ptf2, *ptg2;
-  UInt4   *ptf4, *ptg4;
-  UInt    deg, i;
-  Obj     g;
+Obj FuncInverseOfTransformation(Obj self, Obj f)
+{
+    UInt2 *ptf2, *ptg2;
+    UInt4 *ptf4, *ptg4;
+    UInt   deg, i;
+    Obj    g;
 
-  if (!IS_TRANS(f)) {
-    ErrorQuit("InverseOfTransformation: the argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  } else if (FuncIS_ID_TRANS(self, f) == True) {
-    return f;
-  }
+    if (!IS_TRANS(f)) {
+        ErrorQuit("InverseOfTransformation: the argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
+    else if (FuncIS_ID_TRANS(self, f) == True) {
+        return f;
+    }
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    deg = DEG_TRANS2(f);
-    g = NEW_TRANS2(deg);
-    ptf2 = ADDR_TRANS2(f);
-    ptg2 = ADDR_TRANS2(g);
-    for (i = 0; i < deg; i++) {
-      ptg2[i] = 0;
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        deg = DEG_TRANS2(f);
+        g = NEW_TRANS2(deg);
+        ptf2 = ADDR_TRANS2(f);
+        ptg2 = ADDR_TRANS2(g);
+        for (i = 0; i < deg; i++) {
+            ptg2[i] = 0;
+        }
+        for (i = deg - 1; i > 0; i--) {
+            ptg2[ptf2[i]] = i;
+        }
+        // to ensure that 1 is in the image and so rank of g equals that of f
+        ptg2[ptf2[0]] = 0;
     }
-    for (i = deg - 1; i > 0; i--) {
-      ptg2[ptf2[i]] = i;
+    else {
+        deg = DEG_TRANS4(f);
+        g = NEW_TRANS4(deg);
+        ptf4 = ADDR_TRANS4(f);
+        ptg4 = ADDR_TRANS4(g);
+        for (i = 0; i < deg; i++) {
+            ptg4[i] = 0;
+        }
+        for (i = deg - 1; i > 0; i--) {
+            ptg4[ptf4[i]] = i;
+        }
+        // to ensure that 1 is in the image and so rank of g equals that of f
+        ptg4[ptf4[0]] = 0;
     }
-    // to ensure that 1 is in the image and so rank of g equals that of f
-    ptg2[ptf2[0]] = 0;
-  } else {
-    deg = DEG_TRANS4(f);
-    g = NEW_TRANS4(deg);
-    ptf4 = ADDR_TRANS4(f);
-    ptg4 = ADDR_TRANS4(g);
-    for (i = 0; i < deg; i++) {
-      ptg4[i] = 0;
-    }
-    for (i = deg - 1; i > 0; i--) {
-      ptg4[ptf4[i]] = i;
-    }
-    // to ensure that 1 is in the image and so rank of g equals that of f
-    ptg4[ptf4[0]] = 0;
-  }
-  return g;
+    return g;
 }
 
 /*******************************************************************************
@@ -1552,94 +1689,99 @@ Obj FuncInverseOfTransformation (Obj self, Obj f) {
 // special case should be removed, and [0] should be replaced by [1 .. n] in
 // the Semigroup package.
 
-Obj FuncON_KERNEL_ANTI_ACTION (Obj self, Obj ker, Obj f, Obj n) {
-  UInt2   *ptf2;
-  UInt4   *ptf4, *pttmp;
-  UInt    deg, i, j, rank, len;
-  Obj     out;
+Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4, *pttmp;
+    UInt    deg, i, j, rank, len;
+    Obj     out;
 
-  assert(IS_LIST(ker));
-  assert(IS_INTOBJ(n));
+    assert(IS_LIST(ker));
+    assert(IS_INTOBJ(n));
 
-  len = LEN_LIST(ker);
-  if (len == 1 && INT_INTOBJ(ELM_LIST(ker, 1)) == 0) {
-    return FuncFLAT_KERNEL_TRANS_INT(self, f, n);
-  }
-
-  rank = 1;
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
-    if (len >= deg) {
-      if (len == 0) {
-        out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
-        SET_LEN_PLIST(out, 0);
-        return out;
-      }
-      out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, len);
-      SET_LEN_PLIST(out, len);
-      pttmp = ResizeInitTmpTrans(len);
-      ptf2 = ADDR_TRANS2(f);
-      for (i = 0; i < deg; i++) {
-        // <f> then <g> with ker(<g>) = <ker>
-        j = INT_INTOBJ(ELM_LIST(ker, ptf2[i] + 1)) - 1; // f first!
-        if (pttmp[j] == 0) {
-          pttmp[j] = rank++;
-        }
-        SET_ELM_PLIST(out, i + 1, INTOBJ_INT(pttmp[j]));
-      }
-      i++;
-      for (; i <= len; i++) {
-        // just <ker>
-        j = INT_INTOBJ(ELM_LIST(ker, i)) - 1;
-        if (pttmp[j] == 0) {
-          pttmp[j] = rank++;
-        }
-        SET_ELM_PLIST(out, i, INTOBJ_INT(pttmp[j]));
-      }
-      return out;
+    len = LEN_LIST(ker);
+    if (len == 1 && INT_INTOBJ(ELM_LIST(ker, 1)) == 0) {
+        return FuncFLAT_KERNEL_TRANS_INT(self, f, n);
     }
-    ErrorQuit("ON_KERNEL_ANTI_ACTION: the length of the first "
-              "argument must be at least %d", (Int) deg, 0L);
-    return 0L;
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
-    if (len >= deg) {
-      if (len == 0) {
-        out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
-        SET_LEN_PLIST(out, 0);
-        return out;
-      }
-      out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, len);
-      SET_LEN_PLIST(out, len);
-      pttmp = ResizeInitTmpTrans(len);
-      ptf4 = ADDR_TRANS4(f);
-      for (i = 0; i < deg; i++) {
-        // <f> then <g> with ker(<g>) = <ker>
-        j = INT_INTOBJ(ELM_LIST(ker, ptf4[i] + 1)) - 1; // f first!
-        if (pttmp[j] == 0) {
-          pttmp[j] = rank++;
+
+    rank = 1;
+
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
+        if (len >= deg) {
+            if (len == 0) {
+                out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+                SET_LEN_PLIST(out, 0);
+                return out;
+            }
+            out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, len);
+            SET_LEN_PLIST(out, len);
+            pttmp = ResizeInitTmpTrans(len);
+            ptf2 = ADDR_TRANS2(f);
+            for (i = 0; i < deg; i++) {
+                // <f> then <g> with ker(<g>) = <ker>
+                j = INT_INTOBJ(ELM_LIST(ker, ptf2[i] + 1)) - 1;    // f first!
+                if (pttmp[j] == 0) {
+                    pttmp[j] = rank++;
+                }
+                SET_ELM_PLIST(out, i + 1, INTOBJ_INT(pttmp[j]));
+            }
+            i++;
+            for (; i <= len; i++) {
+                // just <ker>
+                j = INT_INTOBJ(ELM_LIST(ker, i)) - 1;
+                if (pttmp[j] == 0) {
+                    pttmp[j] = rank++;
+                }
+                SET_ELM_PLIST(out, i, INTOBJ_INT(pttmp[j]));
+            }
+            return out;
         }
-        SET_ELM_PLIST(out, i + 1, INTOBJ_INT(pttmp[j]));
-      }
-      i++;
-      for (; i <= len; i++) {
-        // just <ker>
-        j = INT_INTOBJ(ELM_LIST(ker, i)) - 1;
-        if (pttmp[j] == 0) {
-          pttmp[j] = rank++;
-        }
-        SET_ELM_PLIST(out, i, INTOBJ_INT(pttmp[j]));
-      }
-      return out;
+        ErrorQuit("ON_KERNEL_ANTI_ACTION: the length of the first "
+                  "argument must be at least %d",
+                  (Int)deg, 0L);
+        return 0L;
     }
-    ErrorQuit("ON_KERNEL_ANTI_ACTION: the length of the first "
-              "argument must be at least %d", (Int) deg, 0L);
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
+        if (len >= deg) {
+            if (len == 0) {
+                out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+                SET_LEN_PLIST(out, 0);
+                return out;
+            }
+            out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, len);
+            SET_LEN_PLIST(out, len);
+            pttmp = ResizeInitTmpTrans(len);
+            ptf4 = ADDR_TRANS4(f);
+            for (i = 0; i < deg; i++) {
+                // <f> then <g> with ker(<g>) = <ker>
+                j = INT_INTOBJ(ELM_LIST(ker, ptf4[i] + 1)) - 1;    // f first!
+                if (pttmp[j] == 0) {
+                    pttmp[j] = rank++;
+                }
+                SET_ELM_PLIST(out, i + 1, INTOBJ_INT(pttmp[j]));
+            }
+            i++;
+            for (; i <= len; i++) {
+                // just <ker>
+                j = INT_INTOBJ(ELM_LIST(ker, i)) - 1;
+                if (pttmp[j] == 0) {
+                    pttmp[j] = rank++;
+                }
+                SET_ELM_PLIST(out, i, INTOBJ_INT(pttmp[j]));
+            }
+            return out;
+        }
+        ErrorQuit("ON_KERNEL_ANTI_ACTION: the length of the first "
+                  "argument must be at least %d",
+                  (Int)deg, 0L);
+        return 0L;
+    }
+    ErrorQuit("ON_KERNEL_ANTI_ACTION: the argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
     return 0L;
-  }
-  ErrorQuit("ON_KERNEL_ANTI_ACTION: the argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
 }
 
 /*******************************************************************************
@@ -1652,117 +1794,129 @@ Obj FuncON_KERNEL_ANTI_ACTION (Obj self, Obj ker, Obj f, Obj n) {
 // transformation is not necessarily a permutation (mathematically), when n is
 // less than the largest moved point of p.
 
-Obj FuncAS_TRANS_PERM_INT (Obj self, Obj p, Obj deg) {
-  UInt2   *ptp2, *ptf2;
-  UInt4   *ptp4, *ptf4;
-  Obj     f;
-  UInt    def, dep, i, min, n;
+Obj FuncAS_TRANS_PERM_INT(Obj self, Obj p, Obj deg)
+{
+    UInt2 *ptp2, *ptf2;
+    UInt4 *ptp4, *ptf4;
+    Obj    f;
+    UInt   def, dep, i, min, n;
 
-  if (!IS_INTOBJ(deg) || INT_INTOBJ(deg) < 0) {
-    ErrorQuit("AS_TRANS_PERM_INT: the second argument must be a "
-              "non-negative integer", 0L, 0L);
-  } else if (TNUM_OBJ(p) != T_PERM2 && TNUM_OBJ(p) != T_PERM4) {
-    ErrorQuit("AS_TRANS_PERM_INT: the first argument must be a "
-              "permutation (not a %s)", (Int) TNAM_OBJ(p), 0L);
-  }
+    if (!IS_INTOBJ(deg) || INT_INTOBJ(deg) < 0) {
+        ErrorQuit("AS_TRANS_PERM_INT: the second argument must be a "
+                  "non-negative integer",
+                  0L, 0L);
+    }
+    else if (TNUM_OBJ(p) != T_PERM2 && TNUM_OBJ(p) != T_PERM4) {
+        ErrorQuit("AS_TRANS_PERM_INT: the first argument must be a "
+                  "permutation (not a %s)",
+                  (Int)TNAM_OBJ(p), 0L);
+    }
 
-  n = INT_INTOBJ(deg);
+    n = INT_INTOBJ(deg);
 
-  if (n == 0) {
-    return IdentityTrans;
-  }
+    if (n == 0) {
+        return IdentityTrans;
+    }
 
-  //find the degree of f
-  def = n;
-  dep = (TNUM_OBJ(p) == T_PERM2 ? DEG_PERM2(p) : DEG_PERM4(p));
+    // find the degree of f
+    def = n;
+    dep = (TNUM_OBJ(p) == T_PERM2 ? DEG_PERM2(p) : DEG_PERM4(p));
 
-  if (def < dep) {
-    min = def;
-    if (TNUM_OBJ(p) == T_PERM2) {
-      ptp2 = ADDR_PERM2(p);
-      for (i = 0; i < n; i++) {
-        if (ptp2[i] + 1 > def) {
-          def = ptp2[i] + 1;
+    if (def < dep) {
+        min = def;
+        if (TNUM_OBJ(p) == T_PERM2) {
+            ptp2 = ADDR_PERM2(p);
+            for (i = 0; i < n; i++) {
+                if (ptp2[i] + 1 > def) {
+                    def = ptp2[i] + 1;
+                }
+            }
         }
-      }
-    } else {
-      ptp4 = ADDR_PERM4(p);
-      for (i = 0; i < n; i++) {
-        if (ptp4[i] + 1 > def) {
-          def = ptp4[i] + 1;
+        else {
+            ptp4 = ADDR_PERM4(p);
+            for (i = 0; i < n; i++) {
+                if (ptp4[i] + 1 > def) {
+                    def = ptp4[i] + 1;
+                }
+            }
         }
-      }
     }
-  } else {
-    min = dep;
-    def = dep; // no point in defining <f> to have lots of trailing fixed points
-  }
+    else {
+        min = dep;
+        def = dep;    // no point in defining <f> to have lots of trailing
+                      // fixed points
+    }
 
-  if (def <= 65536) {
-    f = NEW_TRANS2(def);
-    ptf2 = ADDR_TRANS2(f);
+    if (def <= 65536) {
+        f = NEW_TRANS2(def);
+        ptf2 = ADDR_TRANS2(f);
 
-    if (TNUM_OBJ(p) == T_PERM2) {
-      ptp2 = ADDR_PERM2(p);
-      for (i = 0; i < min; i++) {
-        ptf2[i] = ptp2[i];
-      }
-    } else { // TNUM_OBJ(p) == T_PERM4
-      ptp4 = ADDR_PERM4(p);
-      for (i = 0; i < min; i++) {
-        ptf2[i] = ptp4[i];
-      }
+        if (TNUM_OBJ(p) == T_PERM2) {
+            ptp2 = ADDR_PERM2(p);
+            for (i = 0; i < min; i++) {
+                ptf2[i] = ptp2[i];
+            }
+        }
+        else {    // TNUM_OBJ(p) == T_PERM4
+            ptp4 = ADDR_PERM4(p);
+            for (i = 0; i < min; i++) {
+                ptf2[i] = ptp4[i];
+            }
+        }
+        for (; i < def; i++) {
+            ptf2[i] = i;
+        }
     }
-    for (; i < def; i++) {
-      ptf2[i] = i;
+    else {    // dep >= def > 65536
+        f = NEW_TRANS4(def);
+        ptf4 = ADDR_TRANS4(f);
+        assert(TNUM_OBJ(p) == T_PERM4);
+        ptp4 = ADDR_PERM4(p);
+        for (i = 0; i < min; i++) {
+            ptf4[i] = ptp4[i];
+        }
+        for (; i < def; i++) {
+            ptf4[i] = i;
+        }
     }
-  } else { // dep >= def > 65536
-    f = NEW_TRANS4(def);
-    ptf4 = ADDR_TRANS4(f);
-    assert(TNUM_OBJ(p) == T_PERM4);
-    ptp4 = ADDR_PERM4(p);
-    for (i = 0; i < min; i++) {
-      ptf4[i] = ptp4[i];
-    }
-    for (; i < def; i++) {
-      ptf4[i] = i;
-    }
-  }
 
-  return f;
+    return f;
 }
 
 // Returns a transformation <f> such that (i)f = (i)p for all i <= n where <p>
 // is a permutation <p> and <n> is the largest moved point of <p>.
 
-Obj FuncAS_TRANS_PERM (Obj self, Obj p) {
-  UInt2   *ptPerm2;
-  UInt4   *ptPerm4;
-  UInt    sup;
+Obj FuncAS_TRANS_PERM(Obj self, Obj p)
+{
+    UInt2 * ptPerm2;
+    UInt4 * ptPerm4;
+    UInt    sup;
 
-  if (TNUM_OBJ(p) != T_PERM2 && TNUM_OBJ(p) != T_PERM4) {
-    ErrorQuit("AS_TRANS_PERM: the first argument must be a "
-              "permutation (not a %s)", (Int) TNAM_OBJ(p), 0L);
-  }
+    if (TNUM_OBJ(p) != T_PERM2 && TNUM_OBJ(p) != T_PERM4) {
+        ErrorQuit("AS_TRANS_PERM: the first argument must be a "
+                  "permutation (not a %s)",
+                  (Int)TNAM_OBJ(p), 0L);
+    }
 
-  //find largest moved point
-  if (TNUM_OBJ(p) == T_PERM2) {
-    ptPerm2 = ADDR_PERM2(p);
-    for (sup = DEG_PERM2(p); 1 <= sup; sup--) {
-      if (ptPerm2[sup - 1] != sup - 1) {
-        break;
-      }
+    // find largest moved point
+    if (TNUM_OBJ(p) == T_PERM2) {
+        ptPerm2 = ADDR_PERM2(p);
+        for (sup = DEG_PERM2(p); 1 <= sup; sup--) {
+            if (ptPerm2[sup - 1] != sup - 1) {
+                break;
+            }
+        }
+        return FuncAS_TRANS_PERM_INT(self, p, INTOBJ_INT(sup));
     }
-    return FuncAS_TRANS_PERM_INT(self, p, INTOBJ_INT(sup));
-  } else {
-    ptPerm4 = ADDR_PERM4(p);
-    for (sup = DEG_PERM4(p); 1 <= sup; sup--) {
-      if (ptPerm4[sup - 1] != sup - 1) {
-        break;
-      }
+    else {
+        ptPerm4 = ADDR_PERM4(p);
+        for (sup = DEG_PERM4(p); 1 <= sup; sup--) {
+            if (ptPerm4[sup - 1] != sup - 1) {
+                break;
+            }
+        }
+        return FuncAS_TRANS_PERM_INT(self, p, INTOBJ_INT(sup));
     }
-    return FuncAS_TRANS_PERM_INT(self, p, INTOBJ_INT(sup));
-  }
 }
 
 /*******************************************************************************
@@ -1773,212 +1927,225 @@ Obj FuncAS_TRANS_PERM (Obj self, Obj p) {
 // Returns a permutation mathematically equal to the transformation <f> if
 // possible, and returns Fail if it is not possible
 
-Obj FuncAS_PERM_TRANS (Obj self, Obj f) {
-  UInt2   *ptf2, *ptp2;
-  UInt4   *ptf4, *ptp4;
-  UInt    deg, i;
-  Obj     p;
+Obj FuncAS_PERM_TRANS(Obj self, Obj f)
+{
+    UInt2 *ptf2, *ptp2;
+    UInt4 *ptf4, *ptp4;
+    UInt   deg, i;
+    Obj    p;
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    deg = DEG_TRANS2(f);
-    if (RANK_TRANS2(f) != deg) {
-      return Fail;
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        deg = DEG_TRANS2(f);
+        if (RANK_TRANS2(f) != deg) {
+            return Fail;
+        }
+
+        p = NEW_PERM2(deg);
+        ptp2 = ADDR_PERM2(p);
+        ptf2 = ADDR_TRANS2(f);
+
+        for (i = 0; i < deg; i++) {
+            ptp2[i] = ptf2[i];
+        }
+        return p;
     }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        deg = DEG_TRANS4(f);
+        if (RANK_TRANS4(f) != deg) {
+            return Fail;
+        }
 
-    p = NEW_PERM2(deg);
-    ptp2 = ADDR_PERM2(p);
-    ptf2 = ADDR_TRANS2(f);
+        p = NEW_PERM4(deg);
+        ptp4 = ADDR_PERM4(p);
+        ptf4 = ADDR_TRANS4(f);
 
-    for (i = 0; i < deg; i++) {
-      ptp2[i] = ptf2[i];
+        for (i = 0; i < deg; i++) {
+            ptp4[i] = ptf4[i];
+        }
+        return p;
     }
-    return p;
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    deg = DEG_TRANS4(f);
-    if (RANK_TRANS4(f) != deg) {
-      return Fail;
-    }
-
-    p = NEW_PERM4(deg);
-    ptp4 = ADDR_PERM4(p);
-    ptf4 = ADDR_TRANS4(f);
-
-    for (i = 0; i < deg; i++) {
-      ptp4[i] = ptf4[i];
-    }
-    return p;
-  }
-  ErrorQuit("AS_PERM_TRANS: the first argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("AS_PERM_TRANS: the first argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 // Returns the permutation of the image of the transformation <f> induced by
 // <f> if possible, and returns Fail if it is not possible.
 
-Obj FuncPermutationOfImage (Obj self, Obj f) {
-  UInt2   *ptf2, *ptp2;
-  UInt4   *ptf4, *ptp4, *pttmp;
-  UInt    deg, rank, i, j;
-  Obj     p, img;
+Obj FuncPermutationOfImage(Obj self, Obj f)
+{
+    UInt2 *ptf2, *ptp2;
+    UInt4 *ptf4, *ptp4, *pttmp;
+    UInt   deg, rank, i, j;
+    Obj    p, img;
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    rank = RANK_TRANS2(f);
-    deg = DEG_TRANS2(f);
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        rank = RANK_TRANS2(f);
+        deg = DEG_TRANS2(f);
 
-    p = NEW_PERM2(deg);
-    ResizeTmpTrans(deg);
+        p = NEW_PERM2(deg);
+        ResizeTmpTrans(deg);
 
-    pttmp = ADDR_TRANS4(TmpTrans);
-    ptp2 = ADDR_PERM2(p);
-    for (i = 0; i < deg; i++) {
-      pttmp[i] = 0;
-      ptp2[i] = i;
+        pttmp = ADDR_TRANS4(TmpTrans);
+        ptp2 = ADDR_PERM2(p);
+        for (i = 0; i < deg; i++) {
+            pttmp[i] = 0;
+            ptp2[i] = i;
+        }
+
+        ptf2 = ADDR_TRANS2(f);
+        img = IMG_TRANS(f);
+        assert(img != NULL);    // should be installed by RANK_TRANS2
+
+        for (i = 0; i < rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(img, i + 1)) - 1;
+            if (pttmp[ptf2[j]] != 0) {
+                return Fail;
+            }
+            pttmp[ptf2[j]] = 1;
+            ptp2[j] = ptf2[j];
+        }
+        return p;
     }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        rank = RANK_TRANS4(f);
+        deg = DEG_TRANS4(f);
 
-    ptf2 = ADDR_TRANS2(f);
-    img = IMG_TRANS(f);
-    assert(img != NULL); // should be installed by RANK_TRANS2
+        p = NEW_PERM4(deg);
+        ResizeTmpTrans(deg);
 
-    for (i = 0; i < rank; i++) {
-      j = INT_INTOBJ(ELM_PLIST(img, i + 1)) - 1;
-      if (pttmp[ptf2[j]] != 0) {
-        return Fail;
-      }
-      pttmp[ptf2[j]] = 1;
-      ptp2[j] = ptf2[j];
+        pttmp = ADDR_TRANS4(TmpTrans);
+        ptp4 = ADDR_PERM4(p);
+        for (i = 0; i < deg; i++) {
+            pttmp[i] = 0;
+            ptp4[i] = i;
+        }
+
+        ptf4 = ADDR_TRANS4(f);
+        img = IMG_TRANS(f);
+        assert(img != NULL);    // should be installed by RANK_TRANS2
+
+        for (i = 0; i < rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(img, i + 1)) - 1;
+            if (pttmp[ptf4[j]] != 0) {
+                return Fail;
+            }
+            pttmp[ptf4[j]] = 1;
+            ptp4[j] = ptf4[j];
+        }
+        return p;
     }
-    return p;
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    rank = RANK_TRANS4(f);
-    deg = DEG_TRANS4(f);
-
-    p = NEW_PERM4(deg);
-    ResizeTmpTrans(deg);
-
-    pttmp = ADDR_TRANS4(TmpTrans);
-    ptp4 = ADDR_PERM4(p);
-    for (i = 0; i < deg; i++) {
-      pttmp[i] = 0;
-      ptp4[i] = i;
-    }
-
-    ptf4 = ADDR_TRANS4(f);
-    img = IMG_TRANS(f);
-    assert(img != NULL); // should be installed by RANK_TRANS2
-
-    for (i = 0; i < rank; i++) {
-      j = INT_INTOBJ(ELM_PLIST(img, i + 1)) - 1;
-      if (pttmp[ptf4[j]] != 0) {
-        return Fail;
-      }
-      pttmp[ptf4[j]] = 1;
-      ptp4[j] = ptf4[j];
-    }
-    return p;
-  }
-  ErrorQuit("PermutationOfImage: the first argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("PermutationOfImage: the first argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 // Returns the permutation of the im(f) induced by f ^ -1 * g under the
 // (unchecked) assumption that im(f) = im(g) and ker(f) = ker(g).
 
-Obj FuncPermLeftQuoTransformationNC (Obj self, Obj f, Obj g) {
-  UInt2   *ptf2, *ptg2;
-  UInt4   *ptf4, *ptg4, *ptp;
-  UInt    def, deg, i, min, max;
-  Obj     perm;
+Obj FuncPermLeftQuoTransformationNC(Obj self, Obj f, Obj g)
+{
+    UInt2 *ptf2, *ptg2;
+    UInt4 *ptf4, *ptg4, *ptp;
+    UInt   def, deg, i, min, max;
+    Obj    perm;
 
-  if (!IS_TRANS(f) || !IS_TRANS(g)) {
-    ErrorQuit("PermLeftQuoTransformationNC: the arguments must both be "
-              "transformations (not %s and %s)",
-              (Int) TNAM_OBJ(f),
-              (Int) TNAM_OBJ(g));
-  }
+    if (!IS_TRANS(f) || !IS_TRANS(g)) {
+        ErrorQuit("PermLeftQuoTransformationNC: the arguments must both be "
+                  "transformations (not %s and %s)",
+                  (Int)TNAM_OBJ(f), (Int)TNAM_OBJ(g));
+    }
 
-  def = DEG_TRANS(f);
-  deg = DEG_TRANS(g);
-  min = MIN(def, deg);
-  max = MAX(def, deg);
+    def = DEG_TRANS(f);
+    deg = DEG_TRANS(g);
+    min = MIN(def, deg);
+    max = MAX(def, deg);
 
-  // always return a T_PERM4 to reduce the amount of code here.
-  perm = NEW_PERM4(max);
-  ptp = ADDR_PERM4(perm);
+    // always return a T_PERM4 to reduce the amount of code here.
+    perm = NEW_PERM4(max);
+    ptp = ADDR_PERM4(perm);
 
-  if (TNUM_OBJ(f) == T_TRANS2 && TNUM_OBJ(g) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    ptg2 = ADDR_TRANS2(g);
+    if (TNUM_OBJ(f) == T_TRANS2 && TNUM_OBJ(g) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        ptg2 = ADDR_TRANS2(g);
 
-    for (i = 0; i < max; i++) {
-      ptp[i] = i;
+        for (i = 0; i < max; i++) {
+            ptp[i] = i;
+        }
+        for (i = 0; i < min; i++) {
+            ptp[ptf2[i]] = ptg2[i];
+        }
+        for (; i < deg; i++) {
+            ptp[i] = ptg2[i];
+        }
+        for (; i < def; i++) {
+            ptp[ptf2[i]] = i;
+        }
     }
-    for (i = 0; i < min; i++) {
-      ptp[ptf2[i]] = ptg2[i];
-    }
-    for (; i < deg; i++) {
-      ptp[i] = ptg2[i];
-    }
-    for (; i < def; i++) {
-      ptp[ptf2[i]] = i;
-    }
-  } else if (TNUM_OBJ(f) == T_TRANS2 && TNUM_OBJ(g) == T_TRANS4) {
-    ptf2 = ADDR_TRANS2(f);
-    ptg4 = ADDR_TRANS4(g);
+    else if (TNUM_OBJ(f) == T_TRANS2 && TNUM_OBJ(g) == T_TRANS4) {
+        ptf2 = ADDR_TRANS2(f);
+        ptg4 = ADDR_TRANS4(g);
 
-    for (i = 0; i < max; i++) {
-      ptp[i] = i;
+        for (i = 0; i < max; i++) {
+            ptp[i] = i;
+        }
+        for (i = 0; i < min; i++) {
+            ptp[ptf2[i]] = ptg4[i];
+        }
+        for (; i < deg; i++) {
+            ptp[i] = ptg4[i];
+        }
+        for (; i < def; i++) {
+            // The only transformation created within this file that is of
+            // type
+            // T_TRANS4 and that does not have (internal) degree 65537 or
+            // greater
+            // is ID_TRANS4.
+            ptp[ptf2[i]] = i;
+        }
     }
-    for (i = 0; i < min; i++) {
-      ptp[ptf2[i]] = ptg4[i];
-    }
-    for (; i < deg; i++) {
-      ptp[i] = ptg4[i];
-    }
-    for (; i < def; i++) {
-      // The only transformation created within this file that is of type
-      // T_TRANS4 and that does not have (internal) degree 65537 or greater
-      // is ID_TRANS4.
-      ptp[ptf2[i]] = i;
-    }
-  } else if (TNUM_OBJ(f) == T_TRANS4 && TNUM_OBJ(g) == T_TRANS2) {
-    ptf4 = ADDR_TRANS4(f);
-    ptg2 = ADDR_TRANS2(g);
+    else if (TNUM_OBJ(f) == T_TRANS4 && TNUM_OBJ(g) == T_TRANS2) {
+        ptf4 = ADDR_TRANS4(f);
+        ptg2 = ADDR_TRANS2(g);
 
-    for (i = 0; i < max; i++) {
-      ptp[i] = i;
+        for (i = 0; i < max; i++) {
+            ptp[i] = i;
+        }
+        for (i = 0; i < min; i++) {
+            ptp[ptf4[i]] = ptg2[i];
+        }
+        for (; i < deg; i++) {
+            // The only transformation created within this file that is of
+            // type
+            // T_TRANS4 and that does not have (internal) degree 65537 or
+            // greater
+            // is ID_TRANS4.
+            ptp[i] = ptg2[i];
+        }
+        for (; i < def; i++) {
+            ptp[ptf4[i]] = i;
+        }
     }
-    for (i = 0; i < min; i++) {
-      ptp[ptf4[i]] = ptg2[i];
-    }
-    for (; i < deg; i++) {
-      // The only transformation created within this file that is of type
-      // T_TRANS4 and that does not have (internal) degree 65537 or greater
-      // is ID_TRANS4.
-      ptp[i] = ptg2[i];
-    }
-    for (; i < def; i++) {
-      ptp[ptf4[i]] = i;
-    }
-  } else if (TNUM_OBJ(f) == T_TRANS4 && TNUM_OBJ(g) == T_TRANS4) {
-    ptf4 = ADDR_TRANS4(f);
-    ptg4 = ADDR_TRANS4(g);
+    else if (TNUM_OBJ(f) == T_TRANS4 && TNUM_OBJ(g) == T_TRANS4) {
+        ptf4 = ADDR_TRANS4(f);
+        ptg4 = ADDR_TRANS4(g);
 
-    for (i = 0; i < max; i++) {
-      ptp[i] = i;
+        for (i = 0; i < max; i++) {
+            ptp[i] = i;
+        }
+        for (i = 0; i < min; i++) {
+            ptp[ptf4[i]] = ptg4[i];
+        }
+        for (; i < deg; i++) {
+            ptp[i] = ptg4[i];
+        }
+        for (; i < def; i++) {
+            ptp[ptf4[i]] = i;
+        }
     }
-    for (i = 0; i < min; i++) {
-      ptp[ptf4[i]] = ptg4[i];
-    }
-    for (; i < deg; i++) {
-      ptp[i] = ptg4[i];
-    }
-    for (; i < def; i++) {
-      ptp[ptf4[i]] = i;
-    }
-  }
-  return perm;
+    return perm;
 }
 
 /*******************************************************************************
@@ -1989,199 +2156,221 @@ Obj FuncPermLeftQuoTransformationNC (Obj self, Obj f, Obj g) {
 // Returns a transformation g such that (i)g = (i)f for all i in list, and
 // where (i)g = i for every other value of i.
 
-Obj FuncRestrictedTransformation (Obj self, Obj f, Obj list) {
-  UInt    deg, i, k, len;
-  UInt2   *ptf2, *ptg2;
-  UInt4   *ptf4, *ptg4;
-  Obj     g, j;
+Obj FuncRestrictedTransformation(Obj self, Obj f, Obj list)
+{
+    UInt   deg, i, k, len;
+    UInt2 *ptf2, *ptg2;
+    UInt4 *ptf4, *ptg4;
+    Obj    g, j;
 
-  if (!IS_LIST(list)) {
-    ErrorQuit("RestrictedTransformation: the second argument must be a list "
-              "(not a %s)", (Int) TNAM_OBJ(list), 0L);
-  }
-
-  len = LEN_LIST(list);
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    deg = DEG_TRANS2(f);
-    g = NEW_TRANS2(deg);
-
-    ptf2 = ADDR_TRANS2(f);
-    ptg2 = ADDR_TRANS2(g);
-
-    // g fixes every point
-    for (i = 0; i < deg; i++) {
-      ptg2[i] = i;
+    if (!IS_LIST(list)) {
+        ErrorQuit(
+            "RestrictedTransformation: the second argument must be a list "
+            "(not a %s)",
+            (Int)TNAM_OBJ(list), 0L);
     }
 
-    //g acts like f on list * /
-    for (i = 0; i < len; i++) {
-      j = ELM_LIST(list, i + 1);
-      if (!IS_INTOBJ(j) || INT_INTOBJ(j) < 1) {
-        ErrorQuit("RestrictedTransformation: <list>[%d] must be a positive "
-                  " integer (not a %s)", (Int) i + 1, (Int) TNAM_OBJ(j));
-      }
-      k = INT_INTOBJ(j) - 1;
-      if (k < deg) {
-        ptg2[k] = ptf2[k];
-      }
-    }
-    return g;
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    deg = DEG_TRANS4(f);
-    g = NEW_TRANS4(deg);
+    len = LEN_LIST(list);
 
-    ptf4 = ADDR_TRANS4(f);
-    ptg4 = ADDR_TRANS4(g);
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        deg = DEG_TRANS2(f);
+        g = NEW_TRANS2(deg);
 
-    // g fixes every point
-    for (i = 0; i < deg; i++) {
-      ptg4[i] = i;
-    }
+        ptf2 = ADDR_TRANS2(f);
+        ptg2 = ADDR_TRANS2(g);
 
-    // g acts like f on list
-    for (i = 0; i < len; i++) {
-      j = ELM_LIST(list, i + 1);
-      if (!IS_INTOBJ(j) || INT_INTOBJ(j) < 1) {
-        ErrorQuit("RestrictedTransformation: <list>[%d] must be a positive "
-                  " integer (not a %s)", (Int) i + 1, (Int) TNAM_OBJ(j));
-      }
-      k = INT_INTOBJ(j) - 1;
-      if (k < deg) {
-        ptg4[k] = ptf4[k];
-      }
+        // g fixes every point
+        for (i = 0; i < deg; i++) {
+            ptg2[i] = i;
+        }
+
+        // g acts like f on list * /
+        for (i = 0; i < len; i++) {
+            j = ELM_LIST(list, i + 1);
+            if (!IS_INTOBJ(j) || INT_INTOBJ(j) < 1) {
+                ErrorQuit(
+                    "RestrictedTransformation: <list>[%d] must be a positive "
+                    " integer (not a %s)",
+                    (Int)i + 1, (Int)TNAM_OBJ(j));
+            }
+            k = INT_INTOBJ(j) - 1;
+            if (k < deg) {
+                ptg2[k] = ptf2[k];
+            }
+        }
+        return g;
     }
-    return g;
-  }
-  ErrorQuit("RestrictedTransformation: the first argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        deg = DEG_TRANS4(f);
+        g = NEW_TRANS4(deg);
+
+        ptf4 = ADDR_TRANS4(f);
+        ptg4 = ADDR_TRANS4(g);
+
+        // g fixes every point
+        for (i = 0; i < deg; i++) {
+            ptg4[i] = i;
+        }
+
+        // g acts like f on list
+        for (i = 0; i < len; i++) {
+            j = ELM_LIST(list, i + 1);
+            if (!IS_INTOBJ(j) || INT_INTOBJ(j) < 1) {
+                ErrorQuit(
+                    "RestrictedTransformation: <list>[%d] must be a positive "
+                    " integer (not a %s)",
+                    (Int)i + 1, (Int)TNAM_OBJ(j));
+            }
+            k = INT_INTOBJ(j) - 1;
+            if (k < deg) {
+                ptg4[k] = ptf4[k];
+            }
+        }
+        return g;
+    }
+    ErrorQuit("RestrictedTransformation: the first argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
-// AsTransformation for a transformation <f> and a pos int <m> either restricts
+// AsTransformation for a transformation <f> and a pos int <m> either
+// restricts
 // <f> to [1 .. m] or returns <f> depending on whether m is less than or equal
 // DegreeOfTransformation(f) or not.
 
 // In the first form, this is similar to TRIM_TRANS except that a new
 // transformation is returned.
 
-Obj FuncAS_TRANS_TRANS(Obj self, Obj f, Obj m){
-  UInt2   *ptf2, *ptg2;
-  UInt4   *ptf4, *ptg4;
-  UInt    i, n, def;
-  Obj     g;
+Obj FuncAS_TRANS_TRANS(Obj self, Obj f, Obj m)
+{
+    UInt2 *ptf2, *ptg2;
+    UInt4 *ptf4, *ptg4;
+    UInt   i, n, def;
+    Obj    g;
 
-  if (!IS_INTOBJ(m) || INT_INTOBJ(m) < 0) {
-    ErrorQuit("AS_TRANS_TRANS: the second argument must be a non-negative "
-              "integer (not a %s)", (Int) TNAM_OBJ(m), 0L);
-  }
-
-  n = INT_INTOBJ(m);
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    def = DEG_TRANS2(f);
-    if (def <= n) {
-      return f;
+    if (!IS_INTOBJ(m) || INT_INTOBJ(m) < 0) {
+        ErrorQuit(
+            "AS_TRANS_TRANS: the second argument must be a non-negative "
+            "integer (not a %s)",
+            (Int)TNAM_OBJ(m), 0L);
     }
 
-    g = NEW_TRANS2(n);
-    ptf2 = ADDR_TRANS2(f);
-    ptg2 = ADDR_TRANS2(g);
-    for (i = 0; i < n; i++) {
-      if (ptf2[i] > n - 1) {
-        return Fail;
-      }
-      ptg2[i] = ptf2[i];
-    }
-    return g;
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    def = DEG_TRANS4(f);
-    if (def <= n) {
-      return f;
-    }
+    n = INT_INTOBJ(m);
 
-    if (n > 65536) {
-      // g is T_TRANS4
-      g = NEW_TRANS4(n);
-      ptf4 = ADDR_TRANS4(f);
-      ptg4 = ADDR_TRANS4(g);
-      for (i = 0; i < n; i++) {
-        if (ptf4[i] > n - 1) {
-          return Fail;
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        def = DEG_TRANS2(f);
+        if (def <= n) {
+            return f;
         }
-        ptg4[i] = ptf4[i];
-      }
-    } else {
-      //  f is T_TRANS4 but n <= 65536 < def and so g will be T_TRANS2 * /
-      g = NEW_TRANS2(n);
-      ptf4 = ADDR_TRANS4(f);
-      ptg2 = ADDR_TRANS2(g);
-      for (i = 0; i < n; i++) {
-        if (ptf4[i] > n - 1) {
-          return Fail;
+
+        g = NEW_TRANS2(n);
+        ptf2 = ADDR_TRANS2(f);
+        ptg2 = ADDR_TRANS2(g);
+        for (i = 0; i < n; i++) {
+            if (ptf2[i] > n - 1) {
+                return Fail;
+            }
+            ptg2[i] = ptf2[i];
         }
-        ptg2[i] = (UInt2) ptf4[i];
-      }
+        return g;
     }
-    return g;
-  }
-  ErrorQuit("AS_TRANS_TRANS: the first argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        def = DEG_TRANS4(f);
+        if (def <= n) {
+            return f;
+        }
+
+        if (n > 65536) {
+            // g is T_TRANS4
+            g = NEW_TRANS4(n);
+            ptf4 = ADDR_TRANS4(f);
+            ptg4 = ADDR_TRANS4(g);
+            for (i = 0; i < n; i++) {
+                if (ptf4[i] > n - 1) {
+                    return Fail;
+                }
+                ptg4[i] = ptf4[i];
+            }
+        }
+        else {
+            //  f is T_TRANS4 but n <= 65536 < def and so g will be T_TRANS2 *
+            //  /
+            g = NEW_TRANS2(n);
+            ptf4 = ADDR_TRANS4(f);
+            ptg2 = ADDR_TRANS2(g);
+            for (i = 0; i < n; i++) {
+                if (ptf4[i] > n - 1) {
+                    return Fail;
+                }
+                ptg2[i] = (UInt2)ptf4[i];
+            }
+        }
+        return g;
+    }
+    ErrorQuit("AS_TRANS_TRANS: the first argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 // Changes the transformation <f> in-place to reduce the degree to <m>.  It is
 // assumed that f is actually a transformation of [1 .. m], i.e. that i ^ f <=
 // m for all i in [1 .. m].
 
-Obj FuncTRIM_TRANS (Obj self, Obj f, Obj m) {
-  UInt    deg, i;
-  UInt4   *ptf;
+Obj FuncTRIM_TRANS(Obj self, Obj f, Obj m)
+{
+    UInt    deg, i;
+    UInt4 * ptf;
 
-  if (!IS_INTOBJ(m) || INT_INTOBJ(m) < 0) {
-    ErrorQuit("TRIM_TRANS: the second argument must be a non-negative "
-              "integer (not a %s)", (Int) TNAM_OBJ(m), 0L);
-  }
-
-  deg = INT_INTOBJ(m);
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    // output is T_TRANS2
-    if (deg > DEG_TRANS2(f)) {
-      return (Obj)0;
+    if (!IS_INTOBJ(m) || INT_INTOBJ(m) < 0) {
+        ErrorQuit("TRIM_TRANS: the second argument must be a non-negative "
+                  "integer (not a %s)",
+                  (Int)TNAM_OBJ(m), 0L);
     }
-    ResizeBag(f, deg * sizeof(UInt2) + 3 * sizeof(Obj));
-    IMG_TRANS(f) = NULL;
-    KER_TRANS(f) = NULL;
-    EXT_TRANS(f) = NULL;
-    CHANGED_BAG(f);
-    return (Obj)0;
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    if (deg > DEG_TRANS4(f)) {
-      return (Obj)0;
-    }
-    if (deg > 65536UL) {
-      // output is T_TRANS4
-      ResizeBag(f, deg * sizeof(UInt4) + 3 * sizeof(Obj));
-    } else {
-      // output is T_TRANS2
-      ptf = ADDR_TRANS4(f);
-      for (i = 0; i < deg; i++) {
-        ((UInt2 *)ptf)[i] = (UInt2)ptf[i];
-      }
-      RetypeBag(f, T_TRANS2);
-      ResizeBag(f, deg * sizeof(UInt2) + 3 * sizeof(Obj));
-    }
-    IMG_TRANS(f) = NULL;
-    KER_TRANS(f) = NULL;
-    EXT_TRANS(f) = NULL;
-    CHANGED_BAG(f);
-    return (Obj)0;
-  }
 
-  ErrorQuit("TRIM_TRANS: the first argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    deg = INT_INTOBJ(m);
+
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        // output is T_TRANS2
+        if (deg > DEG_TRANS2(f)) {
+            return (Obj)0;
+        }
+        ResizeBag(f, deg * sizeof(UInt2) + 3 * sizeof(Obj));
+        IMG_TRANS(f) = NULL;
+        KER_TRANS(f) = NULL;
+        EXT_TRANS(f) = NULL;
+        CHANGED_BAG(f);
+        return (Obj)0;
+    }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        if (deg > DEG_TRANS4(f)) {
+            return (Obj)0;
+        }
+        if (deg > 65536UL) {
+            // output is T_TRANS4
+            ResizeBag(f, deg * sizeof(UInt4) + 3 * sizeof(Obj));
+        }
+        else {
+            // output is T_TRANS2
+            ptf = ADDR_TRANS4(f);
+            for (i = 0; i < deg; i++) {
+                ((UInt2 *)ptf)[i] = (UInt2)ptf[i];
+            }
+            RetypeBag(f, T_TRANS2);
+            ResizeBag(f, deg * sizeof(UInt2) + 3 * sizeof(Obj));
+        }
+        IMG_TRANS(f) = NULL;
+        KER_TRANS(f) = NULL;
+        EXT_TRANS(f) = NULL;
+        CHANGED_BAG(f);
+        return (Obj)0;
+    }
+
+    ErrorQuit("TRIM_TRANS: the first argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 /*******************************************************************************
@@ -2190,28 +2379,28 @@ Obj FuncTRIM_TRANS (Obj self, Obj f, Obj m) {
 
 // A hash function for transformations.
 
-Obj FuncHASH_FUNC_FOR_TRANS (Obj self, Obj f, Obj data) {
-  UInt deg;
+Obj FuncHASH_FUNC_FOR_TRANS(Obj self, Obj f, Obj data)
+{
+    UInt deg;
 
-  deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
+    deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
 
-  if (TNUM_OBJ(f) == T_TRANS4) {
-    if (deg <= 65536) {
-      FuncTRIM_TRANS(self, f, INTOBJ_INT(deg));
-    } else {
-      return INTOBJ_INT((HASHKEY_BAG_NC(f,
-                                        (UInt4) 255,
-                                        3 * sizeof(Obj),
-                                        (int) 4 * deg)
-                                          % (INT_INTOBJ(data))) + 1);
+    if (TNUM_OBJ(f) == T_TRANS4) {
+        if (deg <= 65536) {
+            FuncTRIM_TRANS(self, f, INTOBJ_INT(deg));
+        }
+        else {
+            return INTOBJ_INT((HASHKEY_BAG_NC(f, (UInt4)255, 3 * sizeof(Obj),
+                                              (int)4 * deg) %
+                               (INT_INTOBJ(data))) +
+                              1);
+        }
     }
-  }
 
-  return INTOBJ_INT((HASHKEY_BAG_NC(f,
-                                    (UInt4) 255,
-                                    3 * sizeof(Obj),
-                                    (int) 2 * deg) % (INT_INTOBJ(data))) + 1);
-
+    return INTOBJ_INT(
+        (HASHKEY_BAG_NC(f, (UInt4)255, 3 * sizeof(Obj), (int)2 * deg) %
+         (INT_INTOBJ(data))) +
+        1);
 }
 
 /*******************************************************************************
@@ -2220,114 +2409,126 @@ Obj FuncHASH_FUNC_FOR_TRANS (Obj self, Obj f, Obj data) {
 
 // Returns the largest value i such that (i)f <> i or 0 if no such i exists.
 
-Obj FuncLARGEST_MOVED_PT_TRANS (Obj self, Obj f) {
-  UInt2   *ptf2;
-  UInt4   *ptf4;
-  UInt    i;
+Obj FuncLARGEST_MOVED_PT_TRANS(Obj self, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    i;
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    for (i = DEG_TRANS2(f); 1 <= i; i--) {
-      if (ptf2[i - 1] != i - 1) {
-        break;
-      }
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        for (i = DEG_TRANS2(f); 1 <= i; i--) {
+            if (ptf2[i - 1] != i - 1) {
+                break;
+            }
+        }
+        return INTOBJ_INT(i);
     }
-    return INTOBJ_INT(i);
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    ptf4 = ADDR_TRANS4(f);
-    for (i = DEG_TRANS4(f); 1 <= i; i--) {
-      if (ptf4[i - 1] != i - 1) {
-        break;
-      }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        ptf4 = ADDR_TRANS4(f);
+        for (i = DEG_TRANS4(f); 1 <= i; i--) {
+            if (ptf4[i - 1] != i - 1) {
+                break;
+            }
+        }
+        return INTOBJ_INT(i);
     }
-    return INTOBJ_INT(i);
-  }
-  ErrorQuit("LARGEST_MOVED_PT_TRANS: the first argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("LARGEST_MOVED_PT_TRANS: the first argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 // Returns the largest value in [(1)f .. (n)f] where n = LargestMovedPoint(f).
 
-Obj FuncLARGEST_IMAGE_PT (Obj self, Obj f) {
-  UInt2   *ptf2;
-  UInt4   *ptf4;
-  UInt    i, max, def;
+Obj FuncLARGEST_IMAGE_PT(Obj self, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    i, max, def;
 
-  max = 0;
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    def = DEG_TRANS2(f);
-    ptf2 = ADDR_TRANS2(f);
-    for (i = DEG_TRANS2(f); 1 <= i; i--) {
-      if (ptf2[i - 1] != i - 1) {
-        break;
-      }
-    }
-    for (; 1 <= i; i--) {
-      if (ptf2[i - 1] + 1 > max) {
-        max = ptf2[i - 1] + 1;
-        if (max == def) {
-          break;
+    max = 0;
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        def = DEG_TRANS2(f);
+        ptf2 = ADDR_TRANS2(f);
+        for (i = DEG_TRANS2(f); 1 <= i; i--) {
+            if (ptf2[i - 1] != i - 1) {
+                break;
+            }
         }
-      }
+        for (; 1 <= i; i--) {
+            if (ptf2[i - 1] + 1 > max) {
+                max = ptf2[i - 1] + 1;
+                if (max == def) {
+                    break;
+                }
+            }
+        }
+        return INTOBJ_INT(max);
     }
-    return INTOBJ_INT(max);
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    def = DEG_TRANS4(f);
-    ptf4 = ADDR_TRANS4(f);
-    for (i = DEG_TRANS4(f); 1 <= i; i--) {
-      if (ptf4[i - 1] != i - 1){
-        break;
-      }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        def = DEG_TRANS4(f);
+        ptf4 = ADDR_TRANS4(f);
+        for (i = DEG_TRANS4(f); 1 <= i; i--) {
+            if (ptf4[i - 1] != i - 1) {
+                break;
+            }
+        }
+        for (; 1 <= i; i--) {
+            if (ptf4[i - 1] + 1 > max) {
+                max = ptf4[i - 1] + 1;
+                if (max == def)
+                    break;
+            }
+        }
+        return INTOBJ_INT(max);
     }
-    for (; 1 <= i; i--) {
-      if (ptf4[i - 1] + 1 > max) {
-        max = ptf4[i - 1] + 1;
-        if (max == def) break;
-      }
-    }
-    return INTOBJ_INT(max);
-  }
-  ErrorQuit("LARGEST_IMAGE_PT: the first argument must be a transformation "
-            "(not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("LARGEST_IMAGE_PT: the first argument must be a transformation "
+              "(not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
-// Returns the smallest value <i> such that (i)f <> i if it exists, and Fail if
+// Returns the smallest value <i> such that (i)f <> i if it exists, and Fail
+// if
 // not. Note that this differs from the GAP level function which returns
 // infinity if (i)f = i for all i.
 
-Obj FuncSMALLEST_MOVED_PT_TRANS (Obj self, Obj f) {
-  UInt2   *ptf2;
-  UInt4   *ptf4;
-  UInt    i, deg;
+Obj FuncSMALLEST_MOVED_PT_TRANS(Obj self, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    i, deg;
 
-  if (!IS_TRANS(f)) {
-    ErrorQuit("SMALLEST_MOVED_PTS_TRANS: the first argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-    return 0L;
-  } else if (FuncIS_ID_TRANS(self, f) == True) {
-    return Fail;
-  }
+    if (!IS_TRANS(f)) {
+        ErrorQuit("SMALLEST_MOVED_PTS_TRANS: the first argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+        return 0L;
+    }
+    else if (FuncIS_ID_TRANS(self, f) == True) {
+        return Fail;
+    }
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    deg = DEG_TRANS2(f);
-    for (i = 1; i <= deg; i++) {
-      if (ptf2[i - 1] != i - 1) {
-        break;
-      }
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        deg = DEG_TRANS2(f);
+        for (i = 1; i <= deg; i++) {
+            if (ptf2[i - 1] != i - 1) {
+                break;
+            }
+        }
     }
-  } else {
-    ptf4 = ADDR_TRANS4(f);
-    deg = DEG_TRANS4(f);
-    for (i = 1; i <= deg; i++) {
-      if (ptf4[i - 1] != i - 1) {
-        break;
-      }
+    else {
+        ptf4 = ADDR_TRANS4(f);
+        deg = DEG_TRANS4(f);
+        for (i = 1; i <= deg; i++) {
+            if (ptf4[i - 1] != i - 1) {
+                break;
+            }
+        }
     }
-  }
-  return INTOBJ_INT(i);
+    return INTOBJ_INT(i);
 }
 
 // Returns the smallest value in [SmallestMovedPoint(f) ..
@@ -2335,116 +2536,126 @@ Obj FuncSMALLEST_MOVED_PT_TRANS (Obj self, Obj f) {
 // this differs from the GAP level function which returns infinity if (i)f = i
 // for all i.
 
-Obj FuncSMALLEST_IMAGE_PT (Obj self, Obj f) {
-  UInt2   *ptf2;
-  UInt4   *ptf4;
-  UInt    i, min, deg;
+Obj FuncSMALLEST_IMAGE_PT(Obj self, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    i, min, deg;
 
-  if (!IS_TRANS(f)) {
-    ErrorQuit("SMALLEST_IMAGE_PT: the first argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-    return 0L;
-  } else if (FuncIS_ID_TRANS(self, f) == True) {
-    return Fail;
-  }
+    if (!IS_TRANS(f)) {
+        ErrorQuit("SMALLEST_IMAGE_PT: the first argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+        return 0L;
+    }
+    else if (FuncIS_ID_TRANS(self, f) == True) {
+        return Fail;
+    }
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    deg = DEG_TRANS2(f);
-    min = deg;
-    for (i = 0; i < deg; i++) {
-      if (ptf2[i] != i && ptf2[i] < min) {
-        min = ptf2[i];
-      }
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        deg = DEG_TRANS2(f);
+        min = deg;
+        for (i = 0; i < deg; i++) {
+            if (ptf2[i] != i && ptf2[i] < min) {
+                min = ptf2[i];
+            }
+        }
+        return INTOBJ_INT(min + 1);
+    }
+    else {
+        ptf4 = ADDR_TRANS4(f);
+        deg = DEG_TRANS4(f);
+        min = deg;
+        for (i = 0; i < deg; i++) {
+            if (ptf4[i] != i && ptf4[i] < min) {
+                min = ptf4[i];
+            }
+        }
     }
     return INTOBJ_INT(min + 1);
-  } else {
-    ptf4 = ADDR_TRANS4(f);
-    deg = DEG_TRANS4(f);
-    min = deg;
-    for (i = 0; i < deg; i++) {
-      if (ptf4[i] != i && ptf4[i] < min) {
-        min = ptf4[i];
-      }
-    }
-  }
-  return INTOBJ_INT(min + 1);
 }
 
 // Returns the number of values <i> in [1 .. n] such that (i)f <> i, where n =
 // DegreeOfTransformation(f).
 
-Obj FuncNR_MOVED_PTS_TRANS (Obj self, Obj f) {
-  UInt    nr, i, deg;
-  UInt2*  ptf2;
-  UInt4*  ptf4;
+Obj FuncNR_MOVED_PTS_TRANS(Obj self, Obj f)
+{
+    UInt    nr, i, deg;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
 
-  nr = 0;
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    deg = DEG_TRANS2(f);
-    for (i = 0; i < deg; i++) {
-      if (ptf2[i] != i) {
-        nr++;
-      }
+    nr = 0;
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        deg = DEG_TRANS2(f);
+        for (i = 0; i < deg; i++) {
+            if (ptf2[i] != i) {
+                nr++;
+            }
+        }
+        return INTOBJ_INT(nr);
     }
-    return INTOBJ_INT(nr);
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    ptf4 = ADDR_TRANS4(f);
-    deg = DEG_TRANS4(f);
-    for (i = 0; i < deg; i++) {
-      if (ptf4[i] != i) {
-        nr++;
-      }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        ptf4 = ADDR_TRANS4(f);
+        deg = DEG_TRANS4(f);
+        for (i = 0; i < deg; i++) {
+            if (ptf4[i] != i) {
+                nr++;
+            }
+        }
+        return INTOBJ_INT(nr);
     }
-    return INTOBJ_INT(nr);
-  }
-  ErrorQuit("NR_MOVED_PTS_TRANS: the first argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("NR_MOVED_PTS_TRANS: the first argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 // Returns the set of values <i> in [1 .. n] such that (i)f <> i, where n =
 // DegreeOfTransformation(f).
 
-Obj FuncMOVED_PTS_TRANS (Obj self, Obj f) {
-  UInt    len, deg, i;
-  Obj     out;
-  UInt2   *ptf2;
-  UInt4   *ptf4;
+Obj FuncMOVED_PTS_TRANS(Obj self, Obj f)
+{
+    UInt    len, deg, i;
+    Obj     out;
+    UInt2 * ptf2;
+    UInt4 * ptf4;
 
-  if (!IS_TRANS(f)) {
-    ErrorQuit("MOVED_PTS_TRANS: the first argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-    return 0L;
-  }
-
-  len = 0;
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    deg = DEG_TRANS2(f);
-    out = NEW_PLIST(T_PLIST_CYC_SSORT, 0);
-    ptf2 = ADDR_TRANS2(f);
-    for (i = 0; i < deg; i++) {
-      if (ptf2[i] != i) {
-        AssPlist(out, ++len, INTOBJ_INT(i + 1));
-      }
+    if (!IS_TRANS(f)) {
+        ErrorQuit("MOVED_PTS_TRANS: the first argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+        return 0L;
     }
-  } else {
-    deg = DEG_TRANS4(f);
-    out = NEW_PLIST(T_PLIST_CYC_SSORT, 0);
-    ptf4 = ADDR_TRANS4(f);
-    for (i = 0; i < deg; i++) {
-      if (ptf4[i] != i) {
-        AssPlist(out, ++len, INTOBJ_INT(i + 1));
-      }
+
+    len = 0;
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        deg = DEG_TRANS2(f);
+        out = NEW_PLIST(T_PLIST_CYC_SSORT, 0);
+        ptf2 = ADDR_TRANS2(f);
+        for (i = 0; i < deg; i++) {
+            if (ptf2[i] != i) {
+                AssPlist(out, ++len, INTOBJ_INT(i + 1));
+            }
+        }
     }
-  }
+    else {
+        deg = DEG_TRANS4(f);
+        out = NEW_PLIST(T_PLIST_CYC_SSORT, 0);
+        ptf4 = ADDR_TRANS4(f);
+        for (i = 0; i < deg; i++) {
+            if (ptf4[i] != i) {
+                AssPlist(out, ++len, INTOBJ_INT(i + 1));
+            }
+        }
+    }
 
-  if (LEN_PLIST(out) == 0) {
-    RetypeBag(out, T_PLIST_EMPTY);
-  }
+    if (LEN_PLIST(out) == 0) {
+        RetypeBag(out, T_PLIST_EMPTY);
+    }
 
-  return out;
+    return out;
 }
 
 /*******************************************************************************
@@ -2457,347 +2668,370 @@ Obj FuncMOVED_PTS_TRANS (Obj self, Obj f) {
 // ^ k) = j. The least number of representatives is returned and these
 // representatives are partitioned according to the component they belong to.
 
-Obj FuncCOMPONENT_REPS_TRANS (Obj self, Obj f) {
-  UInt   deg, i, nr, pt, index;
-  Obj    img, out, comp;
-  UInt2  *ptf2;
-  UInt4  *seen, *ptf4;
+Obj FuncCOMPONENT_REPS_TRANS(Obj self, Obj f)
+{
+    UInt    deg, i, nr, pt, index;
+    Obj     img, out, comp;
+    UInt2 * ptf2;
+    UInt4 * seen, *ptf4;
 
-  if (!IS_TRANS(f)) {
-    ErrorQuit("COMPONENT_REPS_TRANS: the argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  }
+    if (!IS_TRANS(f)) {
+        ErrorQuit("COMPONENT_REPS_TRANS: the argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
 
-  deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
+    deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
 
-  if (deg == 0) {
-    out = NEW_PLIST(T_PLIST_EMPTY, 0);
-    SET_LEN_PLIST(out, 0);
+    if (deg == 0) {
+        out = NEW_PLIST(T_PLIST_EMPTY, 0);
+        SET_LEN_PLIST(out, 0);
+        return out;
+    }
+
+    img = FuncUNSORTED_IMAGE_SET_TRANS(self, f);
+    out = NEW_PLIST(T_PLIST, 1);
+
+    seen = ResizeInitTmpTrans(deg);
+
+    for (i = 1; i <= (UInt)LEN_PLIST(img); i++) {
+        seen[INT_INTOBJ(ELM_PLIST(img, i)) - 1] = 1;
+    }
+
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        nr = 1;
+        for (i = 0; i < deg; i++) {
+            if (seen[i] == 0) {
+                // i belongs to dom(f) but not im(f)
+                // repeatedly apply f to pt until we see something we've seen
+                // already
+                pt = i;
+                do {
+                    seen[pt] = nr + 1;
+                    pt = ptf2[pt];
+                } while (seen[pt] == 1);
+
+                index = seen[pt];
+
+                if (index != nr + 1) {
+                    // pt belongs to a component we've seen before
+                    ptf2 = ADDR_TRANS2(f);
+                    pt = i;
+                    do {
+                        seen[pt] = index;
+                        pt = ptf2[pt];
+                    } while (seen[pt] == nr + 1);
+                    comp = ELM_PLIST(out, seen[pt] - 1);
+                    AssPlist(comp, LEN_PLIST(comp) + 1, INTOBJ_INT(i + 1));
+                }
+                else {
+                    // pt belongs to a component we've not seen before
+                    comp = NEW_PLIST(T_PLIST_CYC, 1);
+                    SET_LEN_PLIST(comp, 1);
+                    SET_ELM_PLIST(comp, 1, INTOBJ_INT(i + 1));
+                    AssPlist(out, nr++, comp);
+                }
+                ptf2 = ADDR_TRANS2(f);
+                seen = ADDR_TRANS4(TmpTrans);
+            }
+        }
+        for (i = 0; i < deg; i++) {
+            if (seen[i] == 1) {
+                // i belongs to a cycle
+                for (pt = i; seen[pt] == 1; pt = ptf2[pt]) {
+                    seen[pt] = 0;
+                }
+                comp = NEW_PLIST(T_PLIST_CYC, 1);
+                SET_LEN_PLIST(comp, 1);
+                SET_ELM_PLIST(comp, 1, INTOBJ_INT(i + 1));
+                AssPlist(out, nr++, comp);
+                ptf2 = ADDR_TRANS2(f);
+                seen = ADDR_TRANS4(TmpTrans);
+            }
+        }
+    }
+    else {
+        ptf4 = ADDR_TRANS4(f);
+        nr = 1;
+        for (i = 0; i < deg; i++) {
+            if (seen[i] == 0) {
+                // i belongs to dom(f) but not im(f)
+                // repeatedly apply f to pt until we see something we've seen
+                // already
+                pt = i;
+                do {
+                    seen[pt] = nr + 1;
+                    pt = ptf4[pt];
+                } while (seen[pt] == 1);
+
+                index = seen[pt];
+
+                if (index != nr + 1) {
+                    // pt belongs to a component we've seen before
+                    pt = i;
+                    do {
+                        seen[pt] = index;
+                        pt = ptf4[pt];
+                    } while (seen[pt] == nr + 1);
+                    comp = ELM_PLIST(out, seen[pt] - 1);
+                    AssPlist(comp, LEN_PLIST(comp) + 1, INTOBJ_INT(i + 1));
+                }
+                else {
+                    // pt belongs to a component we've not seen before
+                    comp = NEW_PLIST(T_PLIST_CYC, 1);
+                    SET_LEN_PLIST(comp, 1);
+                    SET_ELM_PLIST(comp, 1, INTOBJ_INT(i + 1));
+                    AssPlist(out, nr++, comp);
+                }
+                ptf4 = ADDR_TRANS4(f);
+                seen = ADDR_TRANS4(TmpTrans);
+            }
+        }
+        for (i = 0; i < deg; i++) {
+            if (seen[i] == 1) {
+                // i belongs to a cycle
+                for (pt = i; seen[pt] == 1; pt = ptf4[pt]) {
+                    seen[pt] = 0;
+                }
+                comp = NEW_PLIST(T_PLIST_CYC, 1);
+                SET_LEN_PLIST(comp, 1);
+                SET_ELM_PLIST(comp, 1, INTOBJ_INT(i + 1));
+                AssPlist(out, nr++, comp);
+                ptf4 = ADDR_TRANS4(f);
+                seen = ADDR_TRANS4(TmpTrans);
+            }
+        }
+    }
     return out;
-  }
-
-  img = FuncUNSORTED_IMAGE_SET_TRANS(self, f);
-  out = NEW_PLIST(T_PLIST, 1);
-
-  seen = ResizeInitTmpTrans(deg);
-
-  for (i = 1; i <= (UInt) LEN_PLIST(img); i++) {
-    seen[INT_INTOBJ(ELM_PLIST(img, i)) - 1] = 1;
-  }
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    nr = 1;
-    for (i = 0; i < deg; i++) {
-      if (seen[i] == 0) {
-        // i belongs to dom(f) but not im(f)
-        // repeatedly apply f to pt until we see something we've seen already
-        pt = i;
-        do {
-          seen[pt] = nr + 1;
-          pt = ptf2[pt];
-        } while (seen[pt] == 1);
-
-        index = seen[pt];
-
-        if (index != nr + 1) {
-          // pt belongs to a component we've seen before
-          ptf2 = ADDR_TRANS2(f);
-          pt = i;
-          do {
-            seen[pt] = index;
-            pt = ptf2[pt];
-          } while (seen[pt] == nr + 1);
-          comp = ELM_PLIST(out, seen[pt] - 1);
-          AssPlist(comp, LEN_PLIST(comp) + 1, INTOBJ_INT(i + 1));
-        } else {
-          // pt belongs to a component we've not seen before
-          comp = NEW_PLIST(T_PLIST_CYC, 1);
-          SET_LEN_PLIST(comp, 1);
-          SET_ELM_PLIST(comp, 1, INTOBJ_INT(i + 1));
-          AssPlist(out, nr++, comp);
-        }
-        ptf2 = ADDR_TRANS2(f);
-        seen = ADDR_TRANS4(TmpTrans);
-      }
-    }
-    for (i = 0; i < deg; i++) {
-      if (seen[i] == 1) {
-        // i belongs to a cycle
-        for (pt = i; seen[pt] == 1; pt = ptf2[pt]) {
-          seen[pt] = 0;
-        }
-        comp = NEW_PLIST(T_PLIST_CYC, 1);
-        SET_LEN_PLIST(comp, 1);
-        SET_ELM_PLIST(comp, 1, INTOBJ_INT(i + 1));
-        AssPlist(out, nr++, comp);
-        ptf2 = ADDR_TRANS2(f);
-        seen = ADDR_TRANS4(TmpTrans);
-      }
-    }
-  } else {
-    ptf4 = ADDR_TRANS4(f);
-    nr = 1;
-    for (i = 0; i < deg; i++) {
-      if (seen[i] == 0) {
-        // i belongs to dom(f) but not im(f)
-        // repeatedly apply f to pt until we see something we've seen already
-        pt = i;
-        do {
-          seen[pt] = nr + 1;
-          pt = ptf4[pt];
-        } while (seen[pt] == 1);
-
-        index = seen[pt];
-
-        if (index != nr + 1) {
-          // pt belongs to a component we've seen before
-          pt = i;
-          do {
-            seen[pt] = index;
-            pt = ptf4[pt];
-          } while (seen[pt] == nr + 1);
-          comp = ELM_PLIST(out, seen[pt] - 1);
-          AssPlist(comp, LEN_PLIST(comp) + 1, INTOBJ_INT(i + 1));
-        } else {
-          // pt belongs to a component we've not seen before
-          comp = NEW_PLIST(T_PLIST_CYC, 1);
-          SET_LEN_PLIST(comp, 1);
-          SET_ELM_PLIST(comp, 1, INTOBJ_INT(i + 1));
-          AssPlist(out, nr++, comp);
-        }
-        ptf4 = ADDR_TRANS4(f);
-        seen = ADDR_TRANS4(TmpTrans);
-      }
-    }
-    for (i = 0; i < deg; i++) {
-      if (seen[i] == 1) {
-        // i belongs to a cycle
-        for (pt = i; seen[pt] == 1; pt = ptf4[pt]) {
-          seen[pt] = 0;
-        }
-        comp = NEW_PLIST(T_PLIST_CYC, 1);
-        SET_LEN_PLIST(comp, 1);
-        SET_ELM_PLIST(comp, 1, INTOBJ_INT(i + 1));
-        AssPlist(out, nr++, comp);
-        ptf4 = ADDR_TRANS4(f);
-        seen = ADDR_TRANS4(TmpTrans);
-      }
-    }
-  }
-  return out;
 }
 
 // Returns the number of connected components of the transformation <f>,
 // thought of as a functional digraph with DegreeOfTransformation(f) vertices.
 
-Obj FuncNR_COMPONENTS_TRANS (Obj self, Obj f) {
-  UInt    nr, m, i, j, deg;
-  UInt2   *ptf2;
-  UInt4   *ptseen, *ptf4;
+Obj FuncNR_COMPONENTS_TRANS(Obj self, Obj f)
+{
+    UInt    nr, m, i, j, deg;
+    UInt2 * ptf2;
+    UInt4 * ptseen, *ptf4;
 
-  if (!IS_TRANS(f)) {
-    ErrorQuit("NR_COMPONENTS_TRANS: the argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  }
-
-  deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
-  ptseen = ResizeInitTmpTrans(deg);
-  nr = 0; m = 0;
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    for (i = 0; i < deg; i++) {
-      if (ptseen[i] == 0) {
-        m++;
-        for (j = i; ptseen[j] == 0; j = ptf2[j]) {
-          ptseen[j] = m;
-        }
-        if (ptseen[j] == m) {
-          nr++;
-        }
-      }
+    if (!IS_TRANS(f)) {
+        ErrorQuit("NR_COMPONENTS_TRANS: the argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
     }
-  } else {
-    ptf4 = ADDR_TRANS4(f);
-    for (i = 0; i < deg; i++) {
-      if (ptseen[i] == 0) {
-        m++;
-        for (j = i; ptseen[j] == 0; j = ptf4[j]) {
-          ptseen[j] = m;
+
+    deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
+    ptseen = ResizeInitTmpTrans(deg);
+    nr = 0;
+    m = 0;
+
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        for (i = 0; i < deg; i++) {
+            if (ptseen[i] == 0) {
+                m++;
+                for (j = i; ptseen[j] == 0; j = ptf2[j]) {
+                    ptseen[j] = m;
+                }
+                if (ptseen[j] == m) {
+                    nr++;
+                }
+            }
         }
-        if (ptseen[j] == m) {
-          nr++;
-        }
-      }
     }
-  }
-  return INTOBJ_INT(nr);
+    else {
+        ptf4 = ADDR_TRANS4(f);
+        for (i = 0; i < deg; i++) {
+            if (ptseen[i] == 0) {
+                m++;
+                for (j = i; ptseen[j] == 0; j = ptf4[j]) {
+                    ptseen[j] = m;
+                }
+                if (ptseen[j] == m) {
+                    nr++;
+                }
+            }
+        }
+    }
+    return INTOBJ_INT(nr);
 }
 
 // Returns the connected components of the transformation <f>, thought of as a
 // functional digraph with DegreeOfTransformation(f) vertices.
 
-Obj FuncCOMPONENTS_TRANS (Obj self, Obj f) {
-  UInt2   *ptf2;
-  UInt4   *seen, *ptf4;
-  UInt    deg, i, pt, csize, nr, index, pos;
-  Obj     out, comp;
+Obj FuncCOMPONENTS_TRANS(Obj self, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * seen, *ptf4;
+    UInt    deg, i, pt, csize, nr, index, pos;
+    Obj     out, comp;
 
-  if (!IS_TRANS(f)) {
-    ErrorQuit("COMPONENTS_TRANS: the argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  }
+    if (!IS_TRANS(f)) {
+        ErrorQuit("COMPONENTS_TRANS: the argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
 
-  deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
+    deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
 
-  if (deg == 0) {
-    out = NEW_PLIST(T_PLIST_EMPTY, 0);
-    SET_LEN_PLIST(out, 0);
-    return out;
-  }
+    if (deg == 0) {
+        out = NEW_PLIST(T_PLIST_EMPTY, 0);
+        SET_LEN_PLIST(out, 0);
+        return out;
+    }
 
-  seen = ResizeInitTmpTrans(deg);
-  out = NEW_PLIST(T_PLIST, 1);
-  nr = 0;
+    seen = ResizeInitTmpTrans(deg);
+    out = NEW_PLIST(T_PLIST, 1);
+    nr = 0;
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    for (i = 0; i < deg; i++) {
-      if (seen[i] == 0) {
-        // repeatedly apply f to pt until we see something we've seen already
-        csize = 0;
-        pt = i;
-        do {
-          csize++;
-          seen[pt] = deg + 1;
-          pt = ptf2[pt];
-        } while (seen[pt] == 0);
-
-        if (seen[pt] <= deg) {
-          // pt belongs to a component we've seen before
-          index = seen[pt];
-          comp = ELM_PLIST(out, index);
-          pos = LEN_PLIST(comp) + 1;
-          GROW_PLIST(comp, LEN_PLIST(comp) + csize);
-          SET_LEN_PLIST(comp, LEN_PLIST(comp) + csize);
-        } else {
-          // pt belongs to a component we've not seen before
-          index = ++nr;
-          pos = 1;
-
-          comp = NEW_PLIST(T_PLIST_CYC, csize);
-          SET_LEN_PLIST(comp, csize);
-          AssPlist(out, nr, comp);
-        }
-        seen = ADDR_TRANS4(TmpTrans);
+    if (TNUM_OBJ(f) == T_TRANS2) {
         ptf2 = ADDR_TRANS2(f);
+        for (i = 0; i < deg; i++) {
+            if (seen[i] == 0) {
+                // repeatedly apply f to pt until we see something we've seen
+                // already
+                csize = 0;
+                pt = i;
+                do {
+                    csize++;
+                    seen[pt] = deg + 1;
+                    pt = ptf2[pt];
+                } while (seen[pt] == 0);
 
-        pt = i;
-        while (seen[pt] == deg + 1) {
-          SET_ELM_PLIST(comp, pos++, INTOBJ_INT(pt + 1));
-          seen[pt] = index;
-          pt = ptf2[pt];
+                if (seen[pt] <= deg) {
+                    // pt belongs to a component we've seen before
+                    index = seen[pt];
+                    comp = ELM_PLIST(out, index);
+                    pos = LEN_PLIST(comp) + 1;
+                    GROW_PLIST(comp, LEN_PLIST(comp) + csize);
+                    SET_LEN_PLIST(comp, LEN_PLIST(comp) + csize);
+                }
+                else {
+                    // pt belongs to a component we've not seen before
+                    index = ++nr;
+                    pos = 1;
+
+                    comp = NEW_PLIST(T_PLIST_CYC, csize);
+                    SET_LEN_PLIST(comp, csize);
+                    AssPlist(out, nr, comp);
+                }
+                seen = ADDR_TRANS4(TmpTrans);
+                ptf2 = ADDR_TRANS2(f);
+
+                pt = i;
+                while (seen[pt] == deg + 1) {
+                    SET_ELM_PLIST(comp, pos++, INTOBJ_INT(pt + 1));
+                    seen[pt] = index;
+                    pt = ptf2[pt];
+                }
+                CHANGED_BAG(out);
+            }
         }
-        CHANGED_BAG(out);
-      }
     }
-  } else {
-    ptf4 = ADDR_TRANS4(f);
-    for (i = 0; i < deg; i++) {
-      if (seen[i] == 0) {
-        // repeatedly apply f to pt until we see something we've seen already
-        csize = 0;
-        pt = i;
-        do {
-          csize++;
-          seen[pt] = deg + 1;
-          pt = ptf4[pt];
-        } while (seen[pt] == 0);
-
-        if (seen[pt] <= deg) {
-          // pt belongs to a component we've seen before
-          index = seen[pt];
-          comp = ELM_PLIST(out, index);
-          pos = LEN_PLIST(comp) + 1;
-          GROW_PLIST(comp, LEN_PLIST(comp) + csize);
-          SET_LEN_PLIST(comp, LEN_PLIST(comp) + csize);
-        } else {
-          // pt belongs to a component we've not seen before
-          index = ++nr;
-          pos = 1;
-
-          comp = NEW_PLIST(T_PLIST_CYC, csize);
-          SET_LEN_PLIST(comp, csize);
-          AssPlist(out, nr, comp);
-        }
-        seen = ADDR_TRANS4(TmpTrans);
+    else {
         ptf4 = ADDR_TRANS4(f);
+        for (i = 0; i < deg; i++) {
+            if (seen[i] == 0) {
+                // repeatedly apply f to pt until we see something we've seen
+                // already
+                csize = 0;
+                pt = i;
+                do {
+                    csize++;
+                    seen[pt] = deg + 1;
+                    pt = ptf4[pt];
+                } while (seen[pt] == 0);
 
-        pt = i;
-        while (seen[pt] == deg + 1) {
-          SET_ELM_PLIST(comp, pos++, INTOBJ_INT(pt + 1));
-          seen[pt] = index;
-          pt = ptf4[pt];
+                if (seen[pt] <= deg) {
+                    // pt belongs to a component we've seen before
+                    index = seen[pt];
+                    comp = ELM_PLIST(out, index);
+                    pos = LEN_PLIST(comp) + 1;
+                    GROW_PLIST(comp, LEN_PLIST(comp) + csize);
+                    SET_LEN_PLIST(comp, LEN_PLIST(comp) + csize);
+                }
+                else {
+                    // pt belongs to a component we've not seen before
+                    index = ++nr;
+                    pos = 1;
+
+                    comp = NEW_PLIST(T_PLIST_CYC, csize);
+                    SET_LEN_PLIST(comp, csize);
+                    AssPlist(out, nr, comp);
+                }
+                seen = ADDR_TRANS4(TmpTrans);
+                ptf4 = ADDR_TRANS4(f);
+
+                pt = i;
+                while (seen[pt] == deg + 1) {
+                    SET_ELM_PLIST(comp, pos++, INTOBJ_INT(pt + 1));
+                    seen[pt] = index;
+                    pt = ptf4[pt];
+                }
+                CHANGED_BAG(out);
+            }
         }
-        CHANGED_BAG(out);
-      }
     }
-  }
-  return out;
+    return out;
 }
 
 // Returns the list of distinct values [pt, (pt)f, (pt)f ^ 2, ..] where <f> is
 // a transformation and <pt> is a positive integer.
 
-Obj FuncCOMPONENT_TRANS_INT (Obj self, Obj f, Obj pt) {
-  UInt    deg, cpt, len;
-  Obj     out;
-  UInt2   *ptf2;
-  UInt4   *ptseen, *ptf4;
+Obj FuncCOMPONENT_TRANS_INT(Obj self, Obj f, Obj pt)
+{
+    UInt    deg, cpt, len;
+    Obj     out;
+    UInt2 * ptf2;
+    UInt4 * ptseen, *ptf4;
 
-  if (!IS_TRANS(f)) {
-    ErrorQuit("COMPONENT_TRANS_INT: the first argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  } else if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
-    ErrorQuit("COMPONENT_TRANS_INT: the second argument must be a "
-              "positive integer (not a %s)", (Int) TNAM_OBJ(pt), 0L);
-  }
+    if (!IS_TRANS(f)) {
+        ErrorQuit("COMPONENT_TRANS_INT: the first argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
+    else if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
+        ErrorQuit("COMPONENT_TRANS_INT: the second argument must be a "
+                  "positive integer (not a %s)",
+                  (Int)TNAM_OBJ(pt), 0L);
+    }
 
-  deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
-  cpt = INT_INTOBJ(pt) - 1;
+    deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
+    cpt = INT_INTOBJ(pt) - 1;
 
-  if (cpt >= deg) {
-    out = NEW_PLIST(T_PLIST_CYC_SSORT, 1);
-    SET_LEN_PLIST(out, 1);
-    SET_ELM_PLIST(out, 1, pt);
+    if (cpt >= deg) {
+        out = NEW_PLIST(T_PLIST_CYC_SSORT, 1);
+        SET_LEN_PLIST(out, 1);
+        SET_ELM_PLIST(out, 1, pt);
+        return out;
+    }
+    out = NEW_PLIST(T_PLIST_CYC, 0);
+    ptseen = ResizeInitTmpTrans(deg);
+
+    len = 0;
+
+    // install the points
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        do {
+            AssPlist(out, ++len, INTOBJ_INT(cpt + 1));
+            ptseen = ADDR_TRANS4(TmpTrans);
+            ptf2 = ADDR_TRANS2(f);
+            ptseen[cpt] = 1;
+            cpt = ptf2[cpt];
+        } while (ptseen[cpt] == 0);
+    }
+    else {
+        do {
+            AssPlist(out, ++len, INTOBJ_INT(cpt + 1));
+            ptseen = ADDR_TRANS4(TmpTrans);
+            ptf4 = ADDR_TRANS4(f);
+            ptseen[cpt] = 1;
+            cpt = ptf4[cpt];
+        } while (ptseen[cpt] == 0);
+    }
+    SET_LEN_PLIST(out, (Int)len);
     return out;
-  }
-  out = NEW_PLIST(T_PLIST_CYC, 0);
-  ptseen = ResizeInitTmpTrans(deg);
-
-  len = 0;
-
-  //install the points
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    do {
-      AssPlist(out, ++len, INTOBJ_INT(cpt + 1));
-      ptseen = ADDR_TRANS4(TmpTrans);
-      ptf2 = ADDR_TRANS2(f);
-      ptseen[cpt] = 1;
-      cpt = ptf2[cpt];
-    } while (ptseen[cpt] == 0);
-  } else {
-    do {
-      AssPlist(out, ++len, INTOBJ_INT(cpt + 1));
-      ptseen = ADDR_TRANS4(TmpTrans);
-      ptf4 = ADDR_TRANS4(f);
-      ptseen[cpt] = 1;
-      cpt = ptf4[cpt];
-    } while (ptseen[cpt] == 0);
-  }
-  SET_LEN_PLIST(out, (Int) len);
-  return out;
 }
 
 /*******************************************************************************
@@ -2807,269 +3041,293 @@ Obj FuncCOMPONENT_TRANS_INT (Obj self, Obj f, Obj pt) {
 // Returns the cycle contained in the component of the transformation <f>
 // containing the positive integer <pt>.
 
-Obj FuncCYCLE_TRANS_INT (Obj self, Obj f, Obj pt) {
-  UInt    deg, cpt, len, i;
-  Obj     out;
-  UInt2   *ptf2;
-  UInt4   *ptseen, *ptf4;
+Obj FuncCYCLE_TRANS_INT(Obj self, Obj f, Obj pt)
+{
+    UInt    deg, cpt, len, i;
+    Obj     out;
+    UInt2 * ptf2;
+    UInt4 * ptseen, *ptf4;
 
-  if (!IS_TRANS(f)) {
-    ErrorQuit("CYCLE_TRANS_INT: the first argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  } else if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
-    ErrorQuit("CYCLE_TRANS_INT: the second argument must be a "
-              "positive integer (not a %s)", (Int) TNAM_OBJ(pt), 0L);
-  }
+    if (!IS_TRANS(f)) {
+        ErrorQuit("CYCLE_TRANS_INT: the first argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
+    else if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
+        ErrorQuit("CYCLE_TRANS_INT: the second argument must be a "
+                  "positive integer (not a %s)",
+                  (Int)TNAM_OBJ(pt), 0L);
+    }
 
-  deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
-  cpt = INT_INTOBJ(pt) - 1;
+    deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
+    cpt = INT_INTOBJ(pt) - 1;
 
-  if (cpt >= deg) {
-    out = NEW_PLIST(T_PLIST_CYC_SSORT, 1);
-    SET_LEN_PLIST(out, 1);
-    SET_ELM_PLIST(out, 1, pt);
+    if (cpt >= deg) {
+        out = NEW_PLIST(T_PLIST_CYC_SSORT, 1);
+        SET_LEN_PLIST(out, 1);
+        SET_ELM_PLIST(out, 1, pt);
+        return out;
+    }
+
+    out = NEW_PLIST(T_PLIST_CYC, 0);
+    ptseen = ResizeInitTmpTrans(deg);
+    len = 0;
+
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        // find component
+        do {
+            ptseen[cpt] = 1;
+            cpt = ptf2[cpt];
+        } while (ptseen[cpt] == 0);
+        // find cycle
+        i = cpt;
+        do {
+            AssPlist(out, ++len, INTOBJ_INT(i + 1));
+            i = ptf2[i];
+        } while (i != cpt);
+    }
+    else {
+        ptf4 = ADDR_TRANS4(f);
+        // find component
+        do {
+            ptseen[cpt] = 1;
+            cpt = ptf4[cpt];
+        } while (ptseen[cpt] == 0);
+        // find cycle
+        i = cpt;
+        do {
+            AssPlist(out, ++len, INTOBJ_INT(i + 1));
+            i = ptf4[i];
+        } while (i != cpt);
+    }
     return out;
-  }
-
-  out = NEW_PLIST(T_PLIST_CYC, 0);
-  ptseen = ResizeInitTmpTrans(deg);
-  len = 0;
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    //find component
-    do {
-      ptseen[cpt] = 1;
-      cpt = ptf2[cpt];
-    } while (ptseen[cpt] == 0);
-    //find cycle
-    i = cpt;
-    do {
-      AssPlist(out, ++len, INTOBJ_INT(i + 1));
-      i = ptf2[i];
-    } while (i != cpt);
-  } else {
-    ptf4 = ADDR_TRANS4(f);
-    //find component
-    do {
-      ptseen[cpt] = 1;
-      cpt = ptf4[cpt];
-    } while (ptseen[cpt] == 0);
-    //find cycle
-    i = cpt;
-    do {
-      AssPlist(out, ++len, INTOBJ_INT(i + 1));
-      i = ptf4[i];
-    } while (i != cpt);
-  }
-  return out;
 }
 
 // Returns the cycles of the transformation <f>, thought of as a
 // functional digraph with DegreeOfTransformation(f) vertices.
 
-Obj FuncCYCLES_TRANS (Obj self, Obj f) {
-  UInt2   *ptf2;
-  UInt4   *seen, *ptf4;
-  UInt    deg, i, pt, nr;
-  Obj     out, comp;
+Obj FuncCYCLES_TRANS(Obj self, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * seen, *ptf4;
+    UInt    deg, i, pt, nr;
+    Obj     out, comp;
 
-  if (!IS_TRANS(f)) {
-    ErrorQuit("CYCLES_TRANS: the argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  }
+    if (!IS_TRANS(f)) {
+        ErrorQuit("CYCLES_TRANS: the argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
 
-  deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
+    deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
 
-  if (deg == 0) {
-    out = NEW_PLIST(T_PLIST_EMPTY, 0);
-    SET_LEN_PLIST(out, 0);
+    if (deg == 0) {
+        out = NEW_PLIST(T_PLIST_EMPTY, 0);
+        SET_LEN_PLIST(out, 0);
+        return out;
+    }
+
+    seen = ResizeInitTmpTrans(deg);
+    out = NEW_PLIST(T_PLIST, 0);
+    nr = 0;
+
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        for (i = 0; i < deg; i++) {
+            if (seen[i] == 0) {
+                // repeatedly apply f to pt until we see something we've seen
+                // already
+                for (pt = i; seen[pt] == 0; pt = ptf2[pt]) {
+                    seen[pt] = 1;
+                }
+                if (seen[pt] == 1) {
+                    // pt belongs to a component we've not seen before
+
+                    comp = NEW_PLIST(T_PLIST_CYC, 0);
+                    AssPlist(out, ++nr, comp);
+
+                    seen = ADDR_TRANS4(TmpTrans);
+                    ptf2 = ADDR_TRANS2(f);
+
+                    for (; seen[pt] == 1; pt = ptf2[pt]) {
+                        seen[pt] = 2;
+                        AssPlist(comp, LEN_PLIST(comp) + 1,
+                                 INTOBJ_INT(pt + 1));
+                        seen = ADDR_TRANS4(TmpTrans);
+                        ptf2 = ADDR_TRANS2(f);
+                    }
+                }
+                for (pt = i; seen[pt] == 1; pt = ptf2[pt]) {
+                    seen[pt] = 2;
+                }
+            }
+        }
+    }
+    else {
+        ptf4 = ADDR_TRANS4(f);
+        for (i = 0; i < deg; i++) {
+            if (seen[i] == 0) {
+                // repeatedly apply f to pt until we see something we've seen
+                // already
+                for (pt = i; seen[pt] == 0; pt = ptf4[pt]) {
+                    seen[pt] = 1;
+                }
+                if (seen[pt] == 1) {
+                    // pt belongs to a component we've not seen before
+
+                    comp = NEW_PLIST(T_PLIST_CYC, 0);
+                    AssPlist(out, ++nr, comp);
+
+                    seen = ADDR_TRANS4(TmpTrans);
+                    ptf4 = ADDR_TRANS4(f);
+
+                    for (; seen[pt] == 1; pt = ptf4[pt]) {
+                        seen[pt] = 2;
+                        AssPlist(comp, LEN_PLIST(comp) + 1,
+                                 INTOBJ_INT(pt + 1));
+                        seen = ADDR_TRANS4(TmpTrans);
+                        ptf4 = ADDR_TRANS4(f);
+                    }
+                }
+                for (pt = i; seen[pt] == 1; pt = ptf4[pt]) {
+                    seen[pt] = 2;
+                }
+            }
+        }
+    }
     return out;
-  }
-
-  seen = ResizeInitTmpTrans(deg);
-  out = NEW_PLIST(T_PLIST, 0);
-  nr = 0;
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    for (i = 0; i < deg; i++) {
-      if (seen[i] == 0) {
-        // repeatedly apply f to pt until we see something we've seen already
-        for (pt = i; seen[pt] == 0; pt = ptf2[pt]) {
-          seen[pt] = 1;
-        }
-        if (seen[pt] == 1) {
-          // pt belongs to a component we've not seen before
-
-          comp = NEW_PLIST(T_PLIST_CYC, 0);
-          AssPlist(out, ++nr, comp);
-
-          seen = ADDR_TRANS4(TmpTrans);
-          ptf2 = ADDR_TRANS2(f);
-
-          for (; seen[pt] == 1; pt = ptf2[pt]) {
-            seen[pt] = 2;
-            AssPlist(comp, LEN_PLIST(comp) + 1, INTOBJ_INT(pt + 1));
-            seen = ADDR_TRANS4(TmpTrans);
-            ptf2 = ADDR_TRANS2(f);
-          }
-        }
-        for (pt = i; seen[pt] == 1; pt = ptf2[pt]) {
-          seen[pt] = 2;
-        }
-      }
-    }
-  } else {
-    ptf4 = ADDR_TRANS4(f);
-    for (i = 0; i < deg; i++) {
-      if (seen[i] == 0) {
-        // repeatedly apply f to pt until we see something we've seen already
-        for (pt = i; seen[pt] == 0; pt = ptf4[pt]) {
-          seen[pt] = 1;
-        }
-        if (seen[pt] == 1) {
-          // pt belongs to a component we've not seen before
-
-          comp = NEW_PLIST(T_PLIST_CYC, 0);
-          AssPlist(out, ++nr, comp);
-
-          seen = ADDR_TRANS4(TmpTrans);
-          ptf4 = ADDR_TRANS4(f);
-
-          for (; seen[pt] == 1; pt = ptf4[pt]) {
-            seen[pt] = 2;
-            AssPlist(comp, LEN_PLIST(comp) + 1, INTOBJ_INT(pt + 1));
-            seen = ADDR_TRANS4(TmpTrans);
-            ptf4 = ADDR_TRANS4(f);
-          }
-        }
-        for (pt = i; seen[pt] == 1; pt = ptf4[pt]) {
-          seen[pt] = 2;
-        }
-      }
-    }
-  }
-  return out;
 }
 
 // Returns the cycles of the transformation <f> contained in the components of
 // any of the elements in <list>.
 
-Obj FuncCYCLES_TRANS_LIST (Obj self, Obj f, Obj list) {
-  UInt2   *ptf2;
-  UInt4   *seen, *ptf4;
-  UInt    deg, i, j, pt, nr;
-  Obj     out, comp, list_i;
+Obj FuncCYCLES_TRANS_LIST(Obj self, Obj f, Obj list)
+{
+    UInt2 * ptf2;
+    UInt4 * seen, *ptf4;
+    UInt    deg, i, j, pt, nr;
+    Obj     out, comp, list_i;
 
-  if (!IS_TRANS(f)) {
-    ErrorQuit("CYCLES_TRANS_LIST: the first argument must be a "
-              "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  } else if (!IS_LIST(list)) {
-    ErrorQuit("CYCLES_TRANS_LIST: the second argument must be a "
-              "list (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  }
-
-  deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
-
-  if (LEN_LIST(list) == 0) {
-    out = NEW_PLIST(T_PLIST_EMPTY, 0);
-    SET_LEN_PLIST(out, 0);
-    return out;
-  }
-
-  out = NEW_PLIST(T_PLIST, 0);
-  nr = 0;
-
-  seen = ResizeInitTmpTrans(deg);
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    for (i = 1; i <= (UInt) LEN_LIST(list); i++) {
-      list_i = ELM_LIST(list, i);
-      if (!IS_INTOBJ(list_i) || INT_INTOBJ(list_i) < 1) {
+    if (!IS_TRANS(f)) {
+        ErrorQuit("CYCLES_TRANS_LIST: the first argument must be a "
+                  "transformation (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
+    else if (!IS_LIST(list)) {
         ErrorQuit("CYCLES_TRANS_LIST: the second argument must be a "
-                  "list of positive integer (not a %s)",
-                  (Int) TNAM_OBJ(list_i), 0L);
-      }
-      j = INT_INTOBJ(list_i) - 1;
-      if (j >= deg) {
-        comp = NEW_PLIST(T_PLIST_CYC, 1);
-        SET_LEN_PLIST(comp, 1);
-        SET_ELM_PLIST(comp, 1, list_i);
-        AssPlist(out, ++nr, comp);
-        seen = ADDR_TRANS4(TmpTrans);
+                  "list (not a %s)",
+                  (Int)TNAM_OBJ(f), 0L);
+    }
+
+    deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
+
+    if (LEN_LIST(list) == 0) {
+        out = NEW_PLIST(T_PLIST_EMPTY, 0);
+        SET_LEN_PLIST(out, 0);
+        return out;
+    }
+
+    out = NEW_PLIST(T_PLIST, 0);
+    nr = 0;
+
+    seen = ResizeInitTmpTrans(deg);
+
+    if (TNUM_OBJ(f) == T_TRANS2) {
         ptf2 = ADDR_TRANS2(f);
-      } else if (seen[j] == 0) {
-        // repeatedly apply f to pt until we see something we've seen already
-        for (pt = j; seen[pt] == 0; pt = ptf2[pt]) {
-          seen[pt] = 1;
-        }
-        if (seen[pt] == 1) {
-          // pt belongs to a component we've not seen before
+        for (i = 1; i <= (UInt)LEN_LIST(list); i++) {
+            list_i = ELM_LIST(list, i);
+            if (!IS_INTOBJ(list_i) || INT_INTOBJ(list_i) < 1) {
+                ErrorQuit("CYCLES_TRANS_LIST: the second argument must be a "
+                          "list of positive integer (not a %s)",
+                          (Int)TNAM_OBJ(list_i), 0L);
+            }
+            j = INT_INTOBJ(list_i) - 1;
+            if (j >= deg) {
+                comp = NEW_PLIST(T_PLIST_CYC, 1);
+                SET_LEN_PLIST(comp, 1);
+                SET_ELM_PLIST(comp, 1, list_i);
+                AssPlist(out, ++nr, comp);
+                seen = ADDR_TRANS4(TmpTrans);
+                ptf2 = ADDR_TRANS2(f);
+            }
+            else if (seen[j] == 0) {
+                // repeatedly apply f to pt until we see something we've seen
+                // already
+                for (pt = j; seen[pt] == 0; pt = ptf2[pt]) {
+                    seen[pt] = 1;
+                }
+                if (seen[pt] == 1) {
+                    // pt belongs to a component we've not seen before
 
-          comp = NEW_PLIST(T_PLIST_CYC, 0);
-          AssPlist(out, ++nr, comp);
+                    comp = NEW_PLIST(T_PLIST_CYC, 0);
+                    AssPlist(out, ++nr, comp);
 
-          seen = ADDR_TRANS4(TmpTrans);
-          ptf2 = ADDR_TRANS2(f);
+                    seen = ADDR_TRANS4(TmpTrans);
+                    ptf2 = ADDR_TRANS2(f);
 
-          for (; seen[pt] == 1; pt = ptf2[pt]) {
-            seen[pt] = 2;
-            AssPlist(comp, LEN_PLIST(comp) + 1, INTOBJ_INT(pt + 1));
-            seen = ADDR_TRANS4(TmpTrans);
-            ptf2 = ADDR_TRANS2(f);
-          }
+                    for (; seen[pt] == 1; pt = ptf2[pt]) {
+                        seen[pt] = 2;
+                        AssPlist(comp, LEN_PLIST(comp) + 1,
+                                 INTOBJ_INT(pt + 1));
+                        seen = ADDR_TRANS4(TmpTrans);
+                        ptf2 = ADDR_TRANS2(f);
+                    }
+                }
+                for (pt = j; seen[pt] == 1; pt = ptf2[pt]) {
+                    seen[pt] = 2;
+                }
+            }
         }
-        for (pt = j; seen[pt] == 1; pt = ptf2[pt]) {
-          seen[pt] = 2;
-        }
-      }
     }
-  } else {
-    ptf4 = ADDR_TRANS4(f);
-    for (i = 1; i <= (UInt) LEN_LIST(list); i++) {
-      list_i = ELM_LIST(list, i);
-      if (!IS_INTOBJ(list_i) || INT_INTOBJ(list_i) < 1) {
-        ErrorQuit("CYCLES_TRANS_LIST: the second argument must be a "
-                  "positive integer (not a %s)", (Int) TNAM_OBJ(list_i), 0L);
-      }
-      j = INT_INTOBJ(list_i) - 1;
-      if (j >= deg) {
-        comp = NEW_PLIST(T_PLIST_CYC, 1);
-        SET_LEN_PLIST(comp, 1);
-        SET_ELM_PLIST(comp, 1, list_i);
-        AssPlist(out, ++nr, comp);
-        seen = ADDR_TRANS4(TmpTrans);
+    else {
         ptf4 = ADDR_TRANS4(f);
-      } else if (seen[j] == 0) {
-        // repeatedly apply f to pt until we see something we've seen already
-        for (pt = j; seen[pt] == 0; pt = ptf4[pt]) {
-          seen[pt] = 1;
-        }
-        if (seen[pt] == 1) {
-          // pt belongs to a component we've not seen before
+        for (i = 1; i <= (UInt)LEN_LIST(list); i++) {
+            list_i = ELM_LIST(list, i);
+            if (!IS_INTOBJ(list_i) || INT_INTOBJ(list_i) < 1) {
+                ErrorQuit("CYCLES_TRANS_LIST: the second argument must be a "
+                          "positive integer (not a %s)",
+                          (Int)TNAM_OBJ(list_i), 0L);
+            }
+            j = INT_INTOBJ(list_i) - 1;
+            if (j >= deg) {
+                comp = NEW_PLIST(T_PLIST_CYC, 1);
+                SET_LEN_PLIST(comp, 1);
+                SET_ELM_PLIST(comp, 1, list_i);
+                AssPlist(out, ++nr, comp);
+                seen = ADDR_TRANS4(TmpTrans);
+                ptf4 = ADDR_TRANS4(f);
+            }
+            else if (seen[j] == 0) {
+                // repeatedly apply f to pt until we see something we've seen
+                // already
+                for (pt = j; seen[pt] == 0; pt = ptf4[pt]) {
+                    seen[pt] = 1;
+                }
+                if (seen[pt] == 1) {
+                    // pt belongs to a component we've not seen before
 
-          comp = NEW_PLIST(T_PLIST_CYC, 0);
-          AssPlist(out, ++nr, comp);
+                    comp = NEW_PLIST(T_PLIST_CYC, 0);
+                    AssPlist(out, ++nr, comp);
 
-          seen = ADDR_TRANS4(TmpTrans);
-          ptf4 = ADDR_TRANS4(f);
+                    seen = ADDR_TRANS4(TmpTrans);
+                    ptf4 = ADDR_TRANS4(f);
 
-          for (; seen[pt] == 1; pt = ptf4[pt]) {
-            seen[pt] = 2;
-            AssPlist(comp, LEN_PLIST(comp) + 1, INTOBJ_INT(pt + 1));
-            seen = ADDR_TRANS4(TmpTrans);
-            ptf4 = ADDR_TRANS4(f);
-          }
+                    for (; seen[pt] == 1; pt = ptf4[pt]) {
+                        seen[pt] = 2;
+                        AssPlist(comp, LEN_PLIST(comp) + 1,
+                                 INTOBJ_INT(pt + 1));
+                        seen = ADDR_TRANS4(TmpTrans);
+                        ptf4 = ADDR_TRANS4(f);
+                    }
+                }
+                for (pt = j; seen[pt] == 1; pt = ptf4[pt]) {
+                    seen[pt] = 2;
+                }
+            }
         }
-        for (pt = j; seen[pt] == 1; pt = ptf4[pt]) {
-          seen[pt] = 2;
-        }
-      }
     }
-  }
-  return out;
+    return out;
 }
 
 /*******************************************************************************
@@ -3080,64 +3338,72 @@ Obj FuncCYCLES_TRANS_LIST (Obj self, Obj f, Obj list) {
 // it is assumed (and not checked) that the transformation f is injective on
 // list.
 
-Obj FuncINV_LIST_TRANS (Obj self, Obj list, Obj f) {
-  UInt2   *ptf2, *ptg2;
-  UInt4   *ptf4, *ptg4;
-  UInt    deg, i, j;
-  Obj     g, k;
+Obj FuncINV_LIST_TRANS(Obj self, Obj list, Obj f)
+{
+    UInt2 *ptf2, *ptg2;
+    UInt4 *ptf4, *ptg4;
+    UInt   deg, i, j;
+    Obj    g, k;
 
-  if (!IS_LIST(list)) {
-    ErrorQuit("INV_LIST_TRANS: the first argument must be a "
-              "list (not a %s)", (Int) TNAM_OBJ(list), 0L);
-  }
+    if (!IS_LIST(list)) {
+        ErrorQuit("INV_LIST_TRANS: the first argument must be a "
+                  "list (not a %s)",
+                  (Int)TNAM_OBJ(list), 0L);
+    }
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    deg = DEG_TRANS2(f);
-    g = NEW_TRANS2(deg);
-    ptf2 = ADDR_TRANS2(f);
-    ptg2 = ADDR_TRANS2(g);
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        deg = DEG_TRANS2(f);
+        g = NEW_TRANS2(deg);
+        ptf2 = ADDR_TRANS2(f);
+        ptg2 = ADDR_TRANS2(g);
 
-    for (j = 0; j < deg; j++) {
-      ptg2[j] = j;
+        for (j = 0; j < deg; j++) {
+            ptg2[j] = j;
+        }
+        for (j = 1; j <= (UInt)LEN_LIST(list); j++) {
+            k = ELM_LIST(list, j);
+            if (!IS_INTOBJ(k) || INT_INTOBJ(k) < 1) {
+                ErrorQuit(
+                    "INV_LIST_TRANS: <list>[%d] must be a positive integer "
+                    "(not a %s)",
+                    (Int)j, (Int)TNAM_OBJ(k));
+            }
+            i = INT_INTOBJ(k) - 1;
+            if (i < deg) {
+                ptg2[ptf2[i]] = i;
+            }
+        }
+        return g;
     }
-    for (j = 1; j <= (UInt) LEN_LIST(list); j++) {
-      k = ELM_LIST(list, j);
-      if (!IS_INTOBJ(k) || INT_INTOBJ(k) < 1) {
-        ErrorQuit("INV_LIST_TRANS: <list>[%d] must be a positive integer "
-                  "(not a %s)", (Int) j, (Int) TNAM_OBJ(k));
-      }
-      i = INT_INTOBJ(k) - 1;
-      if (i < deg) {
-        ptg2[ptf2[i]] = i;
-      }
-    }
-    return g;
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    deg = DEG_TRANS4(f);
-    g = NEW_TRANS4(deg);
-    ptf4 = ADDR_TRANS4(f);
-    ptg4 = ADDR_TRANS4(g);
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        deg = DEG_TRANS4(f);
+        g = NEW_TRANS4(deg);
+        ptf4 = ADDR_TRANS4(f);
+        ptg4 = ADDR_TRANS4(g);
 
-    i = INT_INTOBJ(ELM_LIST(list, 1)) - 1;
-    for (j = 0; j < deg; j++) {
-      ptg4[j] = j;
+        i = INT_INTOBJ(ELM_LIST(list, 1)) - 1;
+        for (j = 0; j < deg; j++) {
+            ptg4[j] = j;
+        }
+        for (j = 1; j <= (UInt)LEN_LIST(list); j++) {
+            k = ELM_LIST(list, j);
+            if (!IS_INTOBJ(k) || INT_INTOBJ(k) < 1) {
+                ErrorQuit(
+                    "INV_LIST_TRANS: <list>[%d] must be a positive integer "
+                    "(not a %s)",
+                    (Int)j, (Int)TNAM_OBJ(k));
+            }
+            i = INT_INTOBJ(k) - 1;
+            if (i < deg) {
+                ptg4[ptf4[i]] = i;
+            }
+        }
+        return g;
     }
-    for (j = 1; j <= (UInt) LEN_LIST(list); j++) {
-      k = ELM_LIST(list, j);
-      if (!IS_INTOBJ(k) || INT_INTOBJ(k) < 1) {
-        ErrorQuit("INV_LIST_TRANS: <list>[%d] must be a positive integer "
-                  "(not a %s)", (Int) j, (Int) TNAM_OBJ(k));
-      }
-      i = INT_INTOBJ(k) - 1;
-      if (i < deg) {
-        ptg4[ptf4[i]] = i;
-      }
-    }
-    return g;
-  }
-  ErrorQuit("INV_LIST_TRANS: the second argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("INV_LIST_TRANS: the second argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 // If ker(f) = ker(g), then TRANS_IMG_CONJ returns the permutation p
@@ -3149,145 +3415,156 @@ Obj FuncINV_LIST_TRANS (Obj self, Obj list, Obj f) {
 //                         ImageListOfTransformation(g, n));
 //
 // where n = max{DegreeOfTransformation(f), DegreeOfTransformation(g)}.
-// However, this is included to avoid the overhead of producing the image lists
+// However, this is included to avoid the overhead of producing the image
+// lists
 // of f and g in the above.
 
-Obj FuncTRANS_IMG_CONJ (Obj self, Obj f, Obj g) {
-  Obj     perm;
-  UInt2   *ptf2, *ptg2;
-  UInt4   *ptsrc, *ptdst, *ptp, *ptf4, *ptg4;
-  UInt    def, deg, i, j, max, min;
+Obj FuncTRANS_IMG_CONJ(Obj self, Obj f, Obj g)
+{
+    Obj    perm;
+    UInt2 *ptf2, *ptg2;
+    UInt4 *ptsrc, *ptdst, *ptp, *ptf4, *ptg4;
+    UInt   def, deg, i, j, max, min;
 
-  if (!IS_TRANS(f) || !IS_TRANS(g)) {
-    ErrorQuit("TRANS_IMG_CONJ: the arguments must both be transformations "
-              "(not %s and %s)", (Int) TNAM_OBJ(f), (Int) TNAM_OBJ(g));
-  }
-
-  def = DEG_TRANS(f);
-  deg = DEG_TRANS(g);
-  max = MAX(def, deg);
-  min = MIN(def, deg);
-
-  // always return a T_PERM4 to reduce the amount of code in this function
-  perm = NEW_PERM4(max);
-
-  ptsrc = ResizeInitTmpTrans(2 * max);
-  ptdst = ptsrc + max;
-
-  ptp = ADDR_PERM4(perm);
-
-  if (TNUM_OBJ(f) == T_TRANS2 && TNUM_OBJ(g) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    ptg2 = ADDR_TRANS2(g);
-
-    for (i = 0; i < min; i++) {
-      ptsrc[ptf2[i]] = 1;
-      ptdst[ptg2[i]] = 1;
-      ptp[ptf2[i]] = ptg2[i];
+    if (!IS_TRANS(f) || !IS_TRANS(g)) {
+        ErrorQuit(
+            "TRANS_IMG_CONJ: the arguments must both be transformations "
+            "(not %s and %s)",
+            (Int)TNAM_OBJ(f), (Int)TNAM_OBJ(g));
     }
 
-    // if deg = min, then this isn't executed
-    for (; i < deg; i++) {
-      //ptsrc[i] = 1;
-      ptdst[ptg2[i]] = 1;
-      ptp[i] = ptg2[i];
+    def = DEG_TRANS(f);
+    deg = DEG_TRANS(g);
+    max = MAX(def, deg);
+    min = MIN(def, deg);
+
+    // always return a T_PERM4 to reduce the amount of code in this function
+    perm = NEW_PERM4(max);
+
+    ptsrc = ResizeInitTmpTrans(2 * max);
+    ptdst = ptsrc + max;
+
+    ptp = ADDR_PERM4(perm);
+
+    if (TNUM_OBJ(f) == T_TRANS2 && TNUM_OBJ(g) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        ptg2 = ADDR_TRANS2(g);
+
+        for (i = 0; i < min; i++) {
+            ptsrc[ptf2[i]] = 1;
+            ptdst[ptg2[i]] = 1;
+            ptp[ptf2[i]] = ptg2[i];
+        }
+
+        // if deg = min, then this isn't executed
+        for (; i < deg; i++) {
+            // ptsrc[i] = 1;
+            ptdst[ptg2[i]] = 1;
+            ptp[i] = ptg2[i];
+        }
+
+        // if def = min, then this isn't executed
+        for (; i < def; i++) {
+            ptsrc[ptf2[i]] = 1;
+            ptdst[i] = 1;
+            ptp[ptf2[i]] = i;
+        }
+    }
+    else if (TNUM_OBJ(f) == T_TRANS2 && TNUM_OBJ(g) == T_TRANS4) {
+        ptf2 = ADDR_TRANS2(f);
+        ptg4 = ADDR_TRANS4(g);
+
+        for (i = 0; i < min; i++) {
+            ptsrc[ptf2[i]] = 1;
+            ptdst[ptg4[i]] = 1;
+            ptp[ptf2[i]] = ptg4[i];
+        }
+
+        // if deg = min, then this isn't executed
+        for (; i < deg; i++) {
+            // ptsrc[i] = 1;
+            ptdst[ptg4[i]] = 1;
+            ptp[i] = ptg4[i];
+        }
+
+        // if def = min, then this isn't executed
+        for (; i < def; i++) {
+            // The only transformation created within this file that is of
+            // type
+            // T_TRANS4 and that does not have (internal) degree 65537 or
+            // greater
+            // is ID_TRANS4.
+            ptsrc[ptf2[i]] = 1;
+            ptdst[i] = 1;
+            ptp[ptf2[i]] = i;
+        }
+    }
+    else if (TNUM_OBJ(f) == T_TRANS4 && TNUM_OBJ(g) == T_TRANS2) {
+        ptf4 = ADDR_TRANS4(f);
+        ptg2 = ADDR_TRANS2(g);
+
+        for (i = 0; i < min; i++) {
+            ptsrc[ptf4[i]] = 1;
+            ptdst[ptg2[i]] = 1;
+            ptp[ptf4[i]] = ptg2[i];
+        }
+
+        // if deg = min, then this isn't executed
+        for (; i < deg; i++) {
+            // The only transformation created within this file that is of
+            // type
+            // T_TRANS4 and that does not have (internal) degree 65537 or
+            // greater
+            // is ID_TRANS4.
+            // ptsrc[i] = 1;
+            ptdst[ptg2[i]] = 1;
+            ptp[i] = ptg2[i];
+        }
+
+        // if def = min, then this isn't executed
+        for (; i < def; i++) {
+            ptsrc[ptf4[i]] = 1;
+            ptdst[i] = 1;
+            ptp[ptf4[i]] = i;
+        }
+    }
+    else if (TNUM_OBJ(f) == T_TRANS4 && TNUM_OBJ(g) == T_TRANS4) {
+        ptf4 = ADDR_TRANS4(f);
+        ptg4 = ADDR_TRANS4(g);
+
+        for (i = 0; i < min; i++) {
+            ptsrc[ptf4[i]] = 1;
+            ptdst[ptg4[i]] = 1;
+            ptp[ptf4[i]] = ptg4[i];
+        }
+
+        // if deg = min, then this isn't executed
+        for (; i < deg; i++) {
+            // ptsrc[i] = 1;
+            ptdst[ptg4[i]] = 1;
+            ptp[i] = ptg4[i];
+        }
+
+        // if def = min, then this isn't executed
+        for (; i < def; i++) {
+            ptsrc[ptf4[i]] = 1;
+            ptdst[i] = 1;
+            ptp[ptf4[i]] = i;
+        }
     }
 
-    // if def = min, then this isn't executed
-    for (; i < def; i++) {
-      ptsrc[ptf2[i]] = 1;
-      ptdst[i] = 1;
-      ptp[ptf2[i]] = i;
+    // complete the permutation
+    j = 0;
+    for (i = 0; i < def; i++) {
+        if (ptsrc[i] == 0) {
+            while (ptdst[j] != 0) {
+                j++;
+            }
+            ptp[i] = j;
+            j++;
+        }
     }
-  } else if (TNUM_OBJ(f) == T_TRANS2 && TNUM_OBJ(g) == T_TRANS4) {
-    ptf2 = ADDR_TRANS2(f);
-    ptg4 = ADDR_TRANS4(g);
-
-    for (i = 0; i < min; i++) {
-      ptsrc[ptf2[i]] = 1;
-      ptdst[ptg4[i]] = 1;
-      ptp[ptf2[i]] = ptg4[i];
-    }
-
-    // if deg = min, then this isn't executed
-    for (; i < deg; i++) {
-      //ptsrc[i] = 1;
-      ptdst[ptg4[i]] = 1;
-      ptp[i] = ptg4[i];
-    }
-
-    // if def = min, then this isn't executed
-    for (; i < def; i++) {
-      // The only transformation created within this file that is of type
-      // T_TRANS4 and that does not have (internal) degree 65537 or greater
-      // is ID_TRANS4.
-      ptsrc[ptf2[i]] = 1;
-      ptdst[i] = 1;
-      ptp[ptf2[i]] = i;
-    }
-  } else if (TNUM_OBJ(f) == T_TRANS4 && TNUM_OBJ(g) == T_TRANS2) {
-    ptf4 = ADDR_TRANS4(f);
-    ptg2 = ADDR_TRANS2(g);
-
-    for (i = 0; i < min; i++) {
-      ptsrc[ptf4[i]] = 1;
-      ptdst[ptg2[i]] = 1;
-      ptp[ptf4[i]] = ptg2[i];
-    }
-
-    // if deg = min, then this isn't executed
-    for (; i < deg; i++) {
-      // The only transformation created within this file that is of type
-      // T_TRANS4 and that does not have (internal) degree 65537 or greater
-      // is ID_TRANS4.
-      //ptsrc[i] = 1;
-      ptdst[ptg2[i]] = 1;
-      ptp[i] = ptg2[i];
-    }
-
-    // if def = min, then this isn't executed
-    for (; i < def; i++) {
-      ptsrc[ptf4[i]] = 1;
-      ptdst[i] = 1;
-      ptp[ptf4[i]] = i;
-    }
-  } else if (TNUM_OBJ(f) == T_TRANS4 && TNUM_OBJ(g) == T_TRANS4) {
-    ptf4 = ADDR_TRANS4(f);
-    ptg4 = ADDR_TRANS4(g);
-
-    for (i = 0; i < min; i++) {
-      ptsrc[ptf4[i]] = 1;
-      ptdst[ptg4[i]] = 1;
-      ptp[ptf4[i]] = ptg4[i];
-    }
-
-    // if deg = min, then this isn't executed
-    for (; i < deg; i++) {
-      //ptsrc[i] = 1;
-      ptdst[ptg4[i]] = 1;
-      ptp[i] = ptg4[i];
-    }
-
-    // if def = min, then this isn't executed
-    for (; i < def; i++) {
-      ptsrc[ptf4[i]] = 1;
-      ptdst[i] = 1;
-      ptp[ptf4[i]] = i;
-    }
-  }
-
-  // complete the permutation
-  j = 0;
-  for (i = 0; i < def; i++) {
-    if (ptsrc[i] == 0) {
-      while (ptdst[j] != 0) {
-        j++;
-      }
-      ptp[i] = j;
-      j++;
-    }
-  }
-  return perm;
+    return perm;
 }
 
 // Returns the flat kernel of <p> ^ -1 * f * <p> where f is any transformation
@@ -3295,106 +3572,109 @@ Obj FuncTRANS_IMG_CONJ (Obj self, Obj f, Obj g) {
 // kernel of transformation. This assumes (but doesn't check) that <p> is a
 // permutation of [1 .. Length(<ker>)] regardless of its degree.
 
-Obj FuncPOW_KER_PERM (Obj self, Obj ker, Obj p) {
-  UInt    len, rank, i, dep;
-  Obj     out;
-  UInt4   *ptcnj, *ptlkp, *ptp4;
-  UInt2   *ptp2;
+Obj FuncPOW_KER_PERM(Obj self, Obj ker, Obj p)
+{
+    UInt    len, rank, i, dep;
+    Obj     out;
+    UInt4 * ptcnj, *ptlkp, *ptp4;
+    UInt2 * ptp2;
 
-  len = LEN_LIST(ker);
+    len = LEN_LIST(ker);
 
-  if (len == 0) {
-    out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, len);
+    if (len == 0) {
+        out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, len);
+        SET_LEN_PLIST(out, len);
+        return out;
+    }
+
+    out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, len);
     SET_LEN_PLIST(out, len);
-    return out;
-  }
 
-  out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, len);
-  SET_LEN_PLIST(out, len);
+    ResizeTmpTrans(2 * len);
+    ptcnj = (UInt4 *)ADDR_OBJ(TmpTrans);
 
-  ResizeTmpTrans(2 * len);
-  ptcnj = (UInt4 *) ADDR_OBJ(TmpTrans);
+    rank = 1;
+    ptlkp = ptcnj + len;
 
-  rank  = 1;
-  ptlkp = ptcnj + len;
+    if (TNUM_OBJ(p) == T_PERM2) {
+        dep = DEG_PERM2(p);
+        ptp2 = ADDR_PERM2(p);
 
-  if (TNUM_OBJ(p) == T_PERM2) {
-    dep  = DEG_PERM2(p);
-    ptp2 = ADDR_PERM2(p);
+        if (dep <= len) {
+            // form the conjugate in ptcnj and init the lookup
+            for (i = 0; i < dep; i++) {
+                // < p ^ - 1 * g * p > then < g > with ker( < g >) = < ker >
+                ptcnj[ptp2[i]] = ptp2[INT_INTOBJ(ELM_LIST(ker, i + 1)) - 1];
+                ptlkp[i] = 0;
+            }
+            for (; i < len; i++) {
+                ptcnj[i] = IMAGE((UInt)INT_INTOBJ(ELM_LIST(ker, i + 1)) - 1,
+                                 ptp2, dep);
+                ptlkp[i] = 0;
+            }
+        }
+        else {
+            // dep > len but p fixes [1..len] setwise
 
-    if (dep <= len) {
-      // form the conjugate in ptcnj and init the lookup
-      for (i = 0; i < dep; i++) {
-        // < p ^ - 1 * g * p > then < g > with ker( < g >) = < ker >
-        ptcnj[ptp2[i]] = ptp2[INT_INTOBJ(ELM_LIST(ker, i + 1)) - 1];
-        ptlkp[i] = 0;
-      }
-      for (; i < len; i++) {
-        ptcnj[i] = IMAGE((UInt) INT_INTOBJ(ELM_LIST(ker, i + 1)) - 1,
-                         ptp2,
-                         dep);
-        ptlkp[i] = 0;
-      }
+            // form the conjugate in ptcnj and init the lookup
+            for (i = 0; i < len; i++) {
+                // < p ^ - 1 * g * p > then < g > with ker( < g >) = < ker >
+                ptcnj[ptp2[i]] = ptp2[INT_INTOBJ(ELM_LIST(ker, i + 1)) - 1];
+                ptlkp[i] = 0;
+            }
+        }
 
-    } else {
-      //dep > len but p fixes [1..len] setwise
+        // form the flat kernel
+        for (i = 0; i < len; i++) {
+            if (ptlkp[ptcnj[i]] == 0) {
+                ptlkp[ptcnj[i]] = rank++;
+            }
+            SET_ELM_PLIST(out, i + 1, INTOBJ_INT(ptlkp[ptcnj[i]]));
+        }
+        return out;
+    }
+    else if (TNUM_OBJ(p) == T_PERM4) {
+        dep = DEG_PERM4(p);
+        ptp4 = ADDR_PERM4(p);
 
-      // form the conjugate in ptcnj and init the lookup
-      for (i = 0; i < len; i++) {
-        // < p ^ - 1 * g * p > then < g > with ker( < g >) = < ker >
-        ptcnj[ptp2[i]] = ptp2[INT_INTOBJ(ELM_LIST(ker, i + 1)) - 1];
-        ptlkp[i] = 0;
-      }
+        if (dep <= len) {
+            // form the conjugate in ptcnj and init the lookup
+            for (i = 0; i < dep; i++) {
+                // < p ^ - 1 * g * p > then < g > with ker( < g >) = < ker >
+                ptcnj[ptp4[i]] = ptp4[INT_INTOBJ(ELM_LIST(ker, i + 1)) - 1];
+                ptlkp[i] = 0;
+            }
+            for (; i < len; i++) {
+                ptcnj[i] = IMAGE((UInt)INT_INTOBJ(ELM_LIST(ker, i + 1)) - 1,
+                                 ptp4, dep);
+                ptlkp[i] = 0;
+            }
+        }
+        else {
+            // dep > len but p fixes [1..len] setwise
+
+            // form the conjugate in ptcnj and init the lookup
+            for (i = 0; i < len; i++) {
+                // < p ^ - 1 * g * p > then < g > with ker( < g >) = < ker >
+                ptcnj[ptp4[i]] = ptp4[INT_INTOBJ(ELM_LIST(ker, i + 1)) - 1];
+                ptlkp[i] = 0;
+            }
+        }
+
+        // form the flat kernel
+        for (i = 0; i < len; i++) {
+            if (ptlkp[ptcnj[i]] == 0) {
+                ptlkp[ptcnj[i]] = rank++;
+            }
+            SET_ELM_PLIST(out, i + 1, INTOBJ_INT(ptlkp[ptcnj[i]]));
+        }
+        return out;
     }
 
-    // form the flat kernel
-    for (i = 0; i < len; i++) {
-      if (ptlkp[ptcnj[i]] == 0) {
-        ptlkp[ptcnj[i]] = rank++;
-      }
-      SET_ELM_PLIST(out, i + 1, INTOBJ_INT(ptlkp[ptcnj[i]]));
-    }
-    return out;
-  } else if (TNUM_OBJ(p) == T_PERM4) {
-    dep  = DEG_PERM4(p);
-    ptp4 = ADDR_PERM4(p);
-
-    if (dep <= len) {
-      // form the conjugate in ptcnj and init the lookup
-      for (i = 0; i < dep; i++) {
-        // < p ^ - 1 * g * p > then < g > with ker( < g >) = < ker >
-        ptcnj[ptp4[i]] = ptp4[INT_INTOBJ(ELM_LIST(ker, i + 1)) - 1];
-        ptlkp[i] = 0;
-      }
-      for (; i < len; i++) {
-        ptcnj[i] = IMAGE((UInt) INT_INTOBJ(ELM_LIST(ker, i + 1)) - 1, ptp4, dep);
-        ptlkp[i] = 0;
-      }
-
-    } else {
-      //dep > len but p fixes [1..len] setwise
-
-      // form the conjugate in ptcnj and init the lookup
-      for (i = 0; i < len; i++) {
-        // < p ^ - 1 * g * p > then < g > with ker( < g >) = < ker >
-        ptcnj[ptp4[i]] = ptp4[INT_INTOBJ(ELM_LIST(ker, i + 1)) - 1];
-        ptlkp[i] = 0;
-      }
-    }
-
-    // form the flat kernel
-    for (i = 0; i < len; i++) {
-      if (ptlkp[ptcnj[i]] == 0) {
-        ptlkp[ptcnj[i]] = rank++;
-      }
-      SET_ELM_PLIST(out, i + 1, INTOBJ_INT(ptlkp[ptcnj[i]]));
-    }
-    return out;
-  }
-
-  ErrorQuit("POW_KER_TRANS: the argument must be a "
-            "permutation (not a %s)", (Int) TNAM_OBJ(p), 0L);
-  return 0L;
+    ErrorQuit("POW_KER_TRANS: the argument must be a "
+              "permutation (not a %s)",
+              (Int)TNAM_OBJ(p), 0L);
+    return 0L;
 }
 
 // If <f> is a transformation and <X> is a flat kernel of a transformation,
@@ -3404,158 +3684,169 @@ Obj FuncPOW_KER_PERM (Obj self, Obj ker, Obj p) {
 // transformation g such that g<f> ^ ker(x) = ker(x) = ker(gfx) and the action
 // of g<f> on ker(x) is the identity.
 
-Obj FuncINV_KER_TRANS (Obj self, Obj X, Obj f) {
-  Obj     g;
-  UInt2 * ptf2, *ptg2;
-  UInt4 * pttmp, *ptf4, *ptg4;
-  UInt    deg, i, len;
+Obj FuncINV_KER_TRANS(Obj self, Obj X, Obj f)
+{
+    Obj    g;
+    UInt2 *ptf2, *ptg2;
+    UInt4 *pttmp, *ptf4, *ptg4;
+    UInt   deg, i, len;
 
-  len = LEN_LIST(X);
-  ResizeTmpTrans(len);
+    len = LEN_LIST(X);
+    ResizeTmpTrans(len);
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    deg = DEG_TRANS2(f);
-    if (len <= 65536) {
-      // deg(g) <= 65536 and g is T_TRANS2
-      g = NEW_TRANS2(len);
-      pttmp = ADDR_TRANS4(TmpTrans);
-      ptf2 = ADDR_TRANS2(f);
-      ptg2 = ADDR_TRANS2(g);
-      if (deg >= len) {
-        // calculate a transversal of f ^ ker(x) = ker(fx)
-        for (i = 0; i < len; i++) {
-          pttmp[INT_INTOBJ(ELM_LIST(X, ptf2[i] + 1)) - 1] = i;
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        deg = DEG_TRANS2(f);
+        if (len <= 65536) {
+            // deg(g) <= 65536 and g is T_TRANS2
+            g = NEW_TRANS2(len);
+            pttmp = ADDR_TRANS4(TmpTrans);
+            ptf2 = ADDR_TRANS2(f);
+            ptg2 = ADDR_TRANS2(g);
+            if (deg >= len) {
+                // calculate a transversal of f ^ ker(x) = ker(fx)
+                for (i = 0; i < len; i++) {
+                    pttmp[INT_INTOBJ(ELM_LIST(X, ptf2[i] + 1)) - 1] = i;
+                }
+                // install values in g
+                for (i = len; i >= 1; i--) {
+                    ptg2[i - 1] = pttmp[INT_INTOBJ(ELM_LIST(X, i)) - 1];
+                }
+            }
+            else {
+                for (i = 0; i < deg; i++) {
+                    pttmp[INT_INTOBJ(ELM_LIST(X, ptf2[i] + 1)) - 1] = i;
+                }
+                for (; i < len; i++) {
+                    pttmp[INT_INTOBJ(ELM_LIST(X, i + 1)) - 1] = i;
+                }
+                for (i = len; i >= 1; i--) {
+                    ptg2[i - 1] = pttmp[INT_INTOBJ(ELM_LIST(X, i)) - 1];
+                }
+            }
+            return g;
         }
-        // install values in g
-        for (i = len; i >= 1; i--) {
-          ptg2[i - 1] = pttmp[INT_INTOBJ(ELM_LIST(X, i)) - 1];
+        else {
+            // deg(g) = len > 65536 >= deg and g is T_TRANS4
+            g = NEW_TRANS4(len);
+            pttmp = ADDR_TRANS4(TmpTrans);
+            ptf2 = ADDR_TRANS2(f);
+            ptg4 = ADDR_TRANS4(g);
+            for (i = 0; i < deg; i++) {
+                pttmp[INT_INTOBJ(ELM_LIST(X, ptf2[i] + 1)) - 1] = i;
+            }
+            for (; i < len; i++) {
+                pttmp[INT_INTOBJ(ELM_LIST(X, i + 1)) - 1] = i;
+            }
+            for (i = len; i >= 1; i--) {
+                ptg4[i - 1] = pttmp[INT_INTOBJ(ELM_LIST(X, i)) - 1];
+            }
+            return g;
         }
-      } else {
-        for (i = 0; i < deg; i++) {
-          pttmp[INT_INTOBJ(ELM_LIST(X, ptf2[i] + 1)) - 1] = i;
-        }
-        for (; i < len; i++) {
-          pttmp[INT_INTOBJ(ELM_LIST(X, i + 1)) - 1] = i;
-        }
-        for (i = len; i >= 1; i--) {
-          ptg2[i - 1] = pttmp[INT_INTOBJ(ELM_LIST(X, i)) - 1];
-        }
-      }
-      return g;
-    } else {
-      // deg(g) = len > 65536 >= deg and g is T_TRANS4
-      g = NEW_TRANS4(len);
-      pttmp = ADDR_TRANS4(TmpTrans);
-      ptf2 = ADDR_TRANS2(f);
-      ptg4 = ADDR_TRANS4(g);
-      for (i = 0; i < deg; i++) {
-        pttmp[INT_INTOBJ(ELM_LIST(X, ptf2[i] + 1)) - 1] = i;
-      }
-      for (; i < len; i++) {
-        pttmp[INT_INTOBJ(ELM_LIST(X, i + 1)) - 1] = i;
-      }
-      for (i = len; i >= 1; i--) {
-        ptg4[i - 1] = pttmp[INT_INTOBJ(ELM_LIST(X, i)) - 1];
-      }
-      return g;
     }
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    deg = DEG_TRANS4(f);
-    if (len <= 65536) {
-      // deg(g) <= 65536 and g is T_TRANS2
-      g = NEW_TRANS2(len);
-      pttmp = ADDR_TRANS4(TmpTrans);
-      ptf4 = ADDR_TRANS4(f);
-      ptg2 = ADDR_TRANS2(g);
-      // calculate a transversal of f ^ ker(x) = ker(fx)
-      for (i = 0; i < len; i++) {
-        pttmp[INT_INTOBJ(ELM_LIST(X, ptf4[i] + 1)) - 1] = i;
-      }
-      // install values in g
-      for (i = len; i >= 1; i--) {
-        ptg2[i - 1] = pttmp[INT_INTOBJ(ELM_LIST(X, i)) - 1];
-      }
-      return g;
-    } else {
-      // deg(g) = len > 65536 >= deg and g is T_TRANS4
-      g = NEW_TRANS4(len);
-      pttmp = ADDR_TRANS4(TmpTrans);
-      ptf4 = ADDR_TRANS4(f);
-      ptg4 = ADDR_TRANS4(g);
-      for (i = 0; i < deg; i++) {
-        pttmp[INT_INTOBJ(ELM_LIST(X, ptf4[i] + 1)) - 1] = i;
-      }
-      for (; i < len; i++) {
-        pttmp[INT_INTOBJ(ELM_LIST(X, i + 1)) - 1] = i;
-      }
-      for (i = len; i >= 1; i--) {
-        ptg4[i - 1] = pttmp[INT_INTOBJ(ELM_LIST(X, i)) - 1];
-      }
-      return g;
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        deg = DEG_TRANS4(f);
+        if (len <= 65536) {
+            // deg(g) <= 65536 and g is T_TRANS2
+            g = NEW_TRANS2(len);
+            pttmp = ADDR_TRANS4(TmpTrans);
+            ptf4 = ADDR_TRANS4(f);
+            ptg2 = ADDR_TRANS2(g);
+            // calculate a transversal of f ^ ker(x) = ker(fx)
+            for (i = 0; i < len; i++) {
+                pttmp[INT_INTOBJ(ELM_LIST(X, ptf4[i] + 1)) - 1] = i;
+            }
+            // install values in g
+            for (i = len; i >= 1; i--) {
+                ptg2[i - 1] = pttmp[INT_INTOBJ(ELM_LIST(X, i)) - 1];
+            }
+            return g;
+        }
+        else {
+            // deg(g) = len > 65536 >= deg and g is T_TRANS4
+            g = NEW_TRANS4(len);
+            pttmp = ADDR_TRANS4(TmpTrans);
+            ptf4 = ADDR_TRANS4(f);
+            ptg4 = ADDR_TRANS4(g);
+            for (i = 0; i < deg; i++) {
+                pttmp[INT_INTOBJ(ELM_LIST(X, ptf4[i] + 1)) - 1] = i;
+            }
+            for (; i < len; i++) {
+                pttmp[INT_INTOBJ(ELM_LIST(X, i + 1)) - 1] = i;
+            }
+            for (i = len; i >= 1; i--) {
+                ptg4[i - 1] = pttmp[INT_INTOBJ(ELM_LIST(X, i)) - 1];
+            }
+            return g;
+        }
     }
-  }
-  ErrorQuit("INV_KER_TRANS: the argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+    ErrorQuit("INV_KER_TRANS: the argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
-// Returns the same value as OnSets(set, f) except if set = [0], when the image
+// Returns the same value as OnSets(set, f) except if set = [0], when the
+// image
 // set of <f> on [1 .. n] is returned instead. If the argument <set> is not
 // [0], then the third argument is ignored.
 
-Obj FuncOnPosIntSetsTrans (Obj self, Obj set, Obj f, Obj n) {
-  UInt2  *ptf2;
-  UInt4  *ptf4;
-  UInt   deg;
-  Obj    *ptset, *ptres, res;
-  UInt   i, k;
+Obj FuncOnPosIntSetsTrans(Obj self, Obj set, Obj f, Obj n)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    deg;
+    Obj *   ptset, *ptres, res;
+    UInt    i, k;
 
-  if (LEN_LIST(set) == 0) {
-    return set;
-  }
-
-  if (LEN_LIST(set) == 1 && INT_INTOBJ(ELM_LIST(set, 1)) == 0) {
-    return FuncIMAGE_SET_TRANS_INT(self, f, n);
-  }
-
-  PLAIN_LIST(set);
-  res = NEW_PLIST(IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT :
-                  T_PLIST_CYC_SSORT + IMMUTABLE, LEN_LIST(set));
-  ADDR_OBJ(res)[0] = ADDR_OBJ(set)[0];
-
-  ptset = ADDR_OBJ(set) + LEN_LIST(set);
-  ptres = ADDR_OBJ(res) + LEN_LIST(set);
-
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    deg = DEG_TRANS2(f);
-    for (i = LEN_LIST(set); 1 <= i; i--, ptset--, ptres--) {
-      k = INT_INTOBJ(*ptset);
-      if (k <= deg) {
-        k = ptf2[k - 1] + 1;
-      }
-      *ptres = INTOBJ_INT(k);
+    if (LEN_LIST(set) == 0) {
+        return set;
     }
-    SORT_PLIST_CYC(res);
-    REMOVE_DUPS_PLIST_CYC(res);
-    return res;
-  } else if (TNUM_OBJ(f) == T_TRANS4) {
-    ptf4 = ADDR_TRANS4(f);
-    deg = DEG_TRANS4(f);
-    for (i = LEN_LIST(set); 1 <= i; i--, ptset--, ptres--) {
-      k = INT_INTOBJ(*ptset);
-      if (k <= deg) {
-        k = ptf4[k - 1] + 1;
-      }
-      *ptres = INTOBJ_INT(k);
+
+    if (LEN_LIST(set) == 1 && INT_INTOBJ(ELM_LIST(set, 1)) == 0) {
+        return FuncIMAGE_SET_TRANS_INT(self, f, n);
     }
-    SORT_PLIST_CYC(res);
-    REMOVE_DUPS_PLIST_CYC(res);
-    return res;
-  }
-  ErrorQuit("OnPosIntSetsTrans: the argument must be a "
-            "transformation (not a %s)", (Int) TNAM_OBJ(f), 0L);
-  return 0L;
+
+    PLAIN_LIST(set);
+    res = NEW_PLIST(IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
+                                          : T_PLIST_CYC_SSORT + IMMUTABLE,
+                    LEN_LIST(set));
+    ADDR_OBJ(res)[0] = ADDR_OBJ(set)[0];
+
+    ptset = ADDR_OBJ(set) + LEN_LIST(set);
+    ptres = ADDR_OBJ(res) + LEN_LIST(set);
+
+    if (TNUM_OBJ(f) == T_TRANS2) {
+        ptf2 = ADDR_TRANS2(f);
+        deg = DEG_TRANS2(f);
+        for (i = LEN_LIST(set); 1 <= i; i--, ptset--, ptres--) {
+            k = INT_INTOBJ(*ptset);
+            if (k <= deg) {
+                k = ptf2[k - 1] + 1;
+            }
+            *ptres = INTOBJ_INT(k);
+        }
+        SORT_PLIST_CYC(res);
+        REMOVE_DUPS_PLIST_CYC(res);
+        return res;
+    }
+    else if (TNUM_OBJ(f) == T_TRANS4) {
+        ptf4 = ADDR_TRANS4(f);
+        deg = DEG_TRANS4(f);
+        for (i = LEN_LIST(set); 1 <= i; i--, ptset--, ptres--) {
+            k = INT_INTOBJ(*ptset);
+            if (k <= deg) {
+                k = ptf4[k - 1] + 1;
+            }
+            *ptres = INTOBJ_INT(k);
+        }
+        SORT_PLIST_CYC(res);
+        REMOVE_DUPS_PLIST_CYC(res);
+        return res;
+    }
+    ErrorQuit("OnPosIntSetsTrans: the argument must be a "
+              "transformation (not a %s)",
+              (Int)TNAM_OBJ(f), 0L);
+    return 0L;
 }
 
 /*******************************************************************************
@@ -3566,8 +3857,9 @@ Obj FuncOnPosIntSetsTrans (Obj self, Obj set, Obj f, Obj n) {
 
 // Returns the identity transformation.
 
-Obj OneTrans (Obj f) {
-  return IdentityTrans;
+Obj OneTrans(Obj f)
+{
+    return IdentityTrans;
 }
 
 /*******************************************************************************
@@ -3577,1262 +3869,1338 @@ Obj OneTrans (Obj f) {
 // The following function is used to check equality of both permutations and
 // transformations, it is written by Chris Jefferson in pull request #280.
 
-Int EqPermTrans22 (UInt   degL,
-                   UInt   degR,
-                   UInt2* ptLstart,
-                   UInt2* ptRstart) {
+Int EqPermTrans22(UInt degL, UInt degR, UInt2 * ptLstart, UInt2 * ptRstart)
+{
 
-  UInt2* ptL;            // pointer to the left operand
-  UInt2* ptR;            // pointer to the right operand
-  UInt   p;              // loop variable
+    UInt2 * ptL;    // pointer to the left operand
+    UInt2 * ptR;    // pointer to the right operand
+    UInt    p;      // loop variable
 
-  // if perms/trans are different sizes, check final element as an early
-  // check
+    // if perms/trans are different sizes, check final element as an early
+    // check
 
-  if (degL != degR) {
-    if (degL < degR) {
-      if (*(ptRstart + degR - 1) != (degR - 1)) {
-        return 0L;
-      }
-    } else {
-      if (*(ptLstart + degL - 1) != (degL - 1)) {
-        return 0L;
-      }
+    if (degL != degR) {
+        if (degL < degR) {
+            if (*(ptRstart + degR - 1) != (degR - 1)) {
+                return 0L;
+            }
+        }
+        else {
+            if (*(ptLstart + degL - 1) != (degL - 1)) {
+                return 0L;
+            }
+        }
     }
-  }
 
-  // search for a difference and return False if you find one
-  if (degL <= degR) {
-    ptR = ptRstart + degL;
-    for (p = degL; p < degR; p++) {
-      if (*(ptR++) != p) {
-        return 0L;
-      }
+    // search for a difference and return False if you find one
+    if (degL <= degR) {
+        ptR = ptRstart + degL;
+        for (p = degL; p < degR; p++) {
+            if (*(ptR++) != p) {
+                return 0L;
+            }
+        }
+        if (memcmp(ptLstart, ptRstart, degL * sizeof(UInt2)) != 0) {
+            return 0L;
+        }
     }
-    if (memcmp(ptLstart, ptRstart, degL * sizeof(UInt2)) != 0) {
-      return 0L;
+    else {
+        ptL = ptLstart + degR;
+        for (p = degR; p < degL; p++) {
+            if (*(ptL++) != p) {
+                return 0L;
+            }
+        }
+        if (memcmp(ptLstart, ptRstart, degR * sizeof(UInt2)) != 0) {
+            return 0L;
+        }
     }
-  }
-  else {
-    ptL = ptLstart + degR;
-    for (p = degR; p < degL; p++) {
-      if (* (ptL++) != p) {
-        return 0L;
-      }
-    }
-    if (memcmp(ptLstart, ptRstart, degR * sizeof(UInt2)) != 0) {
-      return 0L;
-    }
-  }
 
-  // otherwise they must be equal
-  return 1L;
+    // otherwise they must be equal
+    return 1L;
 }
 
-Int EqPermTrans44 (UInt   degL,
-                   UInt   degR,
-                   UInt4* ptLstart,
-                   UInt4* ptRstart) {
+Int EqPermTrans44(UInt degL, UInt degR, UInt4 * ptLstart, UInt4 * ptRstart)
+{
 
-  UInt4* ptL;            // pointer to the left operand
-  UInt4* ptR;            // pointer to the right operand
-  UInt   p;              // loop variable
+    UInt4 * ptL;    // pointer to the left operand
+    UInt4 * ptR;    // pointer to the right operand
+    UInt    p;      // loop variable
 
-  // if perms/trans are different sizes, check final element as an early
-  // check
+    // if perms/trans are different sizes, check final element as an early
+    // check
 
-  if (degL != degR) {
-    if (degL < degR) {
-      if (*(ptRstart + degR - 1) != (degR - 1)) {
-        return 0L;
-      }
-    } else {
-      if (*(ptLstart + degL - 1) != (degL - 1)) {
-        return 0L;
-      }
+    if (degL != degR) {
+        if (degL < degR) {
+            if (*(ptRstart + degR - 1) != (degR - 1)) {
+                return 0L;
+            }
+        }
+        else {
+            if (*(ptLstart + degL - 1) != (degL - 1)) {
+                return 0L;
+            }
+        }
     }
-  }
 
-  // search for a difference and return False if you find one
-  if (degL <= degR) {
-    ptR = ptRstart + degL;
-    for (p = degL; p < degR; p++) {
-      if (*(ptR++) != p) {
-        return 0L;
-      }
+    // search for a difference and return False if you find one
+    if (degL <= degR) {
+        ptR = ptRstart + degL;
+        for (p = degL; p < degR; p++) {
+            if (*(ptR++) != p) {
+                return 0L;
+            }
+        }
+        if (memcmp(ptLstart, ptRstart, degL * sizeof(UInt4)) != 0) {
+            return 0L;
+        }
     }
-    if (memcmp(ptLstart, ptRstart, degL * sizeof(UInt4)) != 0) {
-      return 0L;
+    else {
+        ptL = ptLstart + degR;
+        for (p = degR; p < degL; p++) {
+            if (*(ptL++) != p) {
+                return 0L;
+            }
+        }
+        if (memcmp(ptLstart, ptRstart, degR * sizeof(UInt4)) != 0) {
+            return 0L;
+        }
     }
-  } else {
-    ptL = ptLstart + degR;
-    for (p = degR; p < degL; p++) {
-      if (*(ptL++) != p) {
-        return 0L;
-      }
-    }
-    if (memcmp(ptLstart, ptRstart, degR * sizeof(UInt4)) != 0) {
-      return 0L;
-    }
-  }
 
-  // otherwise they must be equal
-  return 1L;
+    // otherwise they must be equal
+    return 1L;
 }
 
-Int EqTrans22 (Obj opL, Obj opR) {
-  return EqPermTrans22(DEG_TRANS2(opL),
-                       DEG_TRANS2(opR),
-                       ADDR_TRANS2(opL),
-                       ADDR_TRANS2(opR));
+Int EqTrans22(Obj opL, Obj opR)
+{
+    return EqPermTrans22(DEG_TRANS2(opL), DEG_TRANS2(opR), ADDR_TRANS2(opL),
+                         ADDR_TRANS2(opR));
 }
 
-Int EqTrans44 (Obj opL, Obj opR) {
-  return EqPermTrans44(DEG_TRANS4(opL),
-                       DEG_TRANS4(opR),
-                       ADDR_TRANS4(opL),
-                       ADDR_TRANS4(opR));
+Int EqTrans44(Obj opL, Obj opR)
+{
+    return EqPermTrans44(DEG_TRANS4(opL), DEG_TRANS4(opR), ADDR_TRANS4(opL),
+                         ADDR_TRANS4(opR));
 }
 
-Int EqTrans24 (Obj f, Obj g) {
-  UInt   i, def, deg;
-  UInt2  *ptf;
-  UInt4  *ptg;
+Int EqTrans24(Obj f, Obj g)
+{
+    UInt    i, def, deg;
+    UInt2 * ptf;
+    UInt4 * ptg;
 
-  ptf = ADDR_TRANS2(f);
-  ptg = ADDR_TRANS4(g);
-  def = DEG_TRANS2(f);
-  deg = DEG_TRANS4(g);
+    ptf = ADDR_TRANS2(f);
+    ptg = ADDR_TRANS4(g);
+    def = DEG_TRANS2(f);
+    deg = DEG_TRANS4(g);
 
-  if (def <= deg) {
-    for (i = 0; i < def; i++) {
-      if (*(ptf++) != *(ptg++)) {
-        return 0L;
-      }
+    if (def <= deg) {
+        for (i = 0; i < def; i++) {
+            if (*(ptf++) != *(ptg++)) {
+                return 0L;
+            }
+        }
+        for (; i < deg; i++) {
+            if (*(ptg++) != i) {
+                return 0L;
+            }
+        }
     }
-    for (; i < deg; i++) {
-      if (*(ptg++) != i) {
-        return 0L;
-      }
-    }
-  } else {
-    // The only transformation created within this file that is of type
-    // T_TRANS4 and that does not have (internal) degree 65537 or greater
-    // is ID_TRANS4.
+    else {
+        // The only transformation created within this file that is of type
+        // T_TRANS4 and that does not have (internal) degree 65537 or greater
+        // is ID_TRANS4.
 
-    for (i = 0; i < deg; i++) {
-      if (*(ptf++) != *(ptg++)) {
-        return 0L;
-      }
+        for (i = 0; i < deg; i++) {
+            if (*(ptf++) != *(ptg++)) {
+                return 0L;
+            }
+        }
+        for (; i < def; i++) {
+            if (*(ptf++) != i) {
+                return 0L;
+            }
+        }
     }
-    for (; i < def; i++) {
-      if (* (ptf++) != i) {
-        return 0L;
-      }
-    }
-  }
 
-  return 1L;
+    return 1L;
 }
 
-Int EqTrans42 (Obj f, Obj g) {
-  UInt   i, def, deg;
-  UInt4  *ptf;
-  UInt2  *ptg;
+Int EqTrans42(Obj f, Obj g)
+{
+    UInt    i, def, deg;
+    UInt4 * ptf;
+    UInt2 * ptg;
 
-  ptf = ADDR_TRANS4(f);
-  ptg = ADDR_TRANS2(g);
-  def = DEG_TRANS4(f);
-  deg = DEG_TRANS2(g);
+    ptf = ADDR_TRANS4(f);
+    ptg = ADDR_TRANS2(g);
+    def = DEG_TRANS4(f);
+    deg = DEG_TRANS2(g);
 
-  if (def <= deg) {
-    // The only transformation created within this file that is of type
-    // T_TRANS4 and that does not have (internal) degree 65537 or greater
-    // is ID_TRANS4.
+    if (def <= deg) {
+        // The only transformation created within this file that is of type
+        // T_TRANS4 and that does not have (internal) degree 65537 or greater
+        // is ID_TRANS4.
 
-    for (i = 0; i < def; i++) {
-      if (* (ptf++) != * (ptg++)) {
-        return 0L;
-      }
+        for (i = 0; i < def; i++) {
+            if (*(ptf++) != *(ptg++)) {
+                return 0L;
+            }
+        }
+        for (; i < deg; i++) {
+            if (*(ptg++) != i) {
+                return 0L;
+            }
+        }
     }
-    for (; i < deg; i++) {
-      if (* (ptg++) != i) {
-        return 0L;
-      }
+    else {
+        for (i = 0; i < deg; i++) {
+            if (*(ptf++) != *(ptg++)) {
+                return 0L;
+            }
+        }
+        for (; i < def; i++) {
+            if (*(ptf++) != i) {
+                return 0L;
+            }
+        }
     }
-  } else {
-    for (i = 0; i < deg; i++) {
-      if (*(ptf++) != *(ptg++)) {
-        return 0L;
-      }
-    }
-    for (; i < def; i++) {
-      if (*(ptf++) != i) {
-        return 0L;
-      }
-    }
-  }
 
-  return 1L;
+    return 1L;
 }
 
 /*******************************************************************************
 ** Less than for transformations
 *******************************************************************************/
 
-Int LtTrans22 (Obj f, Obj g) {
-  UInt   i, def, deg;
-  UInt2  *ptf, *ptg;
+Int LtTrans22(Obj f, Obj g)
+{
+    UInt   i, def, deg;
+    UInt2 *ptf, *ptg;
 
-  ptf = ADDR_TRANS2(f);
-  ptg = ADDR_TRANS2(g);
-  def = DEG_TRANS2(f);
-  deg = DEG_TRANS2(g);
+    ptf = ADDR_TRANS2(f);
+    ptg = ADDR_TRANS2(g);
+    def = DEG_TRANS2(f);
+    deg = DEG_TRANS2(g);
 
-  if (def <= deg) {
-    for (i = 0; i < def; i++) {
-      if (ptf[i] != ptg[i]) {
-        if (ptf[i] < ptg[i]) {
-          return 1L;
-        } else {
-          return 0L;
+    if (def <= deg) {
+        for (i = 0; i < def; i++) {
+            if (ptf[i] != ptg[i]) {
+                if (ptf[i] < ptg[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
-    }
-    for (; i < deg; i++) {
-      if (ptg[i] != i) {
-        if (i < ptg[i]) {
-          return 1L;
-        } else {
-          return 0L;
+        for (; i < deg; i++) {
+            if (ptg[i] != i) {
+                if (i < ptg[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
     }
-  } else {
-    //def > deg
-    for (i = 0; i < deg; i++) {
-      if (ptf[i] != ptg[i]) {
-        if (ptf[i] < ptg[i]) {
-          return 1L;
-        } else {
-          return 0L;
+    else {
+        // def > deg
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != ptg[i]) {
+                if (ptf[i] < ptg[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
-    }
-    for (; i < def; i++) {
-      if (ptf[i] != i) {
-        if (i > ptf[i]) {
-          return 1L;
-        } else {
-          return 0L;
+        for (; i < def; i++) {
+            if (ptf[i] != i) {
+                if (i > ptf[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
     }
-  }
-  return 0L;
+    return 0L;
 }
 
-Int LtTrans24 (Obj f, Obj g) {
-  UInt   i, def, deg;
-  UInt2  *ptf;
-  UInt4  *ptg;
+Int LtTrans24(Obj f, Obj g)
+{
+    UInt    i, def, deg;
+    UInt2 * ptf;
+    UInt4 * ptg;
 
-  ptf = ADDR_TRANS2(f);
-  ptg = ADDR_TRANS4(g);
-  def = DEG_TRANS2(f);
-  deg = DEG_TRANS4(g);
+    ptf = ADDR_TRANS2(f);
+    ptg = ADDR_TRANS4(g);
+    def = DEG_TRANS2(f);
+    deg = DEG_TRANS4(g);
 
-  if (def <= deg) {
-    for (i = 0; i < def; i++) {
-      if (ptf[i] != ptg[i]) {
-        if (ptf[i] < ptg[i]) {
-          return 1L;
-        } else {
-          return 0L;
+    if (def <= deg) {
+        for (i = 0; i < def; i++) {
+            if (ptf[i] != ptg[i]) {
+                if (ptf[i] < ptg[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
-    }
-    for (; i < deg; i++) {
-      if (ptg[i] != i) {
-        if (i < ptg[i]) {
-          return 1L;
-        } else {
-          return 0L;
+        for (; i < deg; i++) {
+            if (ptg[i] != i) {
+                if (i < ptg[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
     }
-  } else {
-    // The only transformation created within this file that is of type
-    // T_TRANS4 and that does not have (internal) degree 65537 or greater
-    // is ID_TRANS4.
+    else {
+        // The only transformation created within this file that is of type
+        // T_TRANS4 and that does not have (internal) degree 65537 or greater
+        // is ID_TRANS4.
 
-    for (i = 0; i < deg; i++) {
-      if (ptf[i] != ptg[i]) {
-        if (ptf[i] < ptg[i]) {
-          return 1L;
-        } else {
-          return 0L;
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != ptg[i]) {
+                if (ptf[i] < ptg[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
-    }
-    for (; i < def; i++) {
-      if (ptf[i] != i) {
-        if (i > ptf[i]) {
-          return 1L;
-        } else {
-          return 0L;
+        for (; i < def; i++) {
+            if (ptf[i] != i) {
+                if (i > ptf[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
     }
-  }
-  return 0L;
+    return 0L;
 }
 
-Int LtTrans42 (Obj f, Obj g) {
-  UInt   i, def, deg;
-  UInt4  *ptf;
-  UInt2  *ptg;
+Int LtTrans42(Obj f, Obj g)
+{
+    UInt    i, def, deg;
+    UInt4 * ptf;
+    UInt2 * ptg;
 
-  ptf = ADDR_TRANS4(f);
-  ptg = ADDR_TRANS2(g);
-  def = DEG_TRANS4(f);
-  deg = DEG_TRANS2(g);
+    ptf = ADDR_TRANS4(f);
+    ptg = ADDR_TRANS2(g);
+    def = DEG_TRANS4(f);
+    deg = DEG_TRANS2(g);
 
-  if (def <= deg) {
-    // The only transformation created within this file that is of type
-    // T_TRANS4 and that does not have (internal) degree 65537 or greater
-    // is ID_TRANS4.
+    if (def <= deg) {
+        // The only transformation created within this file that is of type
+        // T_TRANS4 and that does not have (internal) degree 65537 or greater
+        // is ID_TRANS4.
 
-    for (i = 0; i < def; i++) {
-      if (ptf[i] != ptg[i]) {
-        if (ptf[i] < ptg[i]) {
-          return 1L;
-        } else {
-          return 0L;
+        for (i = 0; i < def; i++) {
+            if (ptf[i] != ptg[i]) {
+                if (ptf[i] < ptg[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
-    }
-    for (; i < deg; i++) {
-      if (ptg[i] != i) {
-        if (i < ptg[i]) {
-          return 1L;
-        } else {
-          return 0L;
+        for (; i < deg; i++) {
+            if (ptg[i] != i) {
+                if (i < ptg[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
     }
-  } else {
-    for (i = 0; i < deg; i++) {
-      if (ptf[i] != ptg[i]) {
-        if (ptf[i] < ptg[i]) {
-          return 1L;
-        } else {
-          return 0L;
+    else {
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != ptg[i]) {
+                if (ptf[i] < ptg[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
-    }
-    for (; i < def; i++) {
-      if (ptf[i] != i) {
-        if (i > ptf[i]) {
-          return 1L;
-        } else {
-          return 0L;
+        for (; i < def; i++) {
+            if (ptf[i] != i) {
+                if (i > ptf[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
     }
-  }
-  return 0L;
+    return 0L;
 }
 
-Int LtTrans44 (Obj f, Obj g) {
-  UInt   i, def, deg;
-  UInt4  *ptf, *ptg;
+Int LtTrans44(Obj f, Obj g)
+{
+    UInt   i, def, deg;
+    UInt4 *ptf, *ptg;
 
-  ptf = ADDR_TRANS4(f);
-  ptg = ADDR_TRANS4(g);
-  def = DEG_TRANS4(f);
-  deg = DEG_TRANS4(g);
+    ptf = ADDR_TRANS4(f);
+    ptg = ADDR_TRANS4(g);
+    def = DEG_TRANS4(f);
+    deg = DEG_TRANS4(g);
 
-  if (def <= deg) {
-    for (i = 0; i < def; i++) {
-      if (ptf[i] != ptg[i]) {
-        if (ptf[i] < ptg[i]) {
-          return 1L;
-        } else {
-          return 0L;
+    if (def <= deg) {
+        for (i = 0; i < def; i++) {
+            if (ptf[i] != ptg[i]) {
+                if (ptf[i] < ptg[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
-    }
-    for (; i < deg; i++) {
-      if (ptg[i] != i) {
-        if (i < ptg[i]) {
-          return 1L;
-        } else {
-          return 0L;
+        for (; i < deg; i++) {
+            if (ptg[i] != i) {
+                if (i < ptg[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
     }
-  } else {
-    for (i = 0; i < deg; i++) {
-      if (ptf[i] != ptg[i]) {
-        if (ptf[i] < ptg[i]) {
-          return 1L;
-        } else {
-          return 0L;
+    else {
+        for (i = 0; i < deg; i++) {
+            if (ptf[i] != ptg[i]) {
+                if (ptf[i] < ptg[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
-    }
-    for (; i < def; i++) {
-      if (ptf[i] != i) {
-        if (i > ptf[i]) {
-          return 1L;
-        } else {
-          return 0L;
+        for (; i < def; i++) {
+            if (ptf[i] != i) {
+                if (i > ptf[i]) {
+                    return 1L;
+                }
+                else {
+                    return 0L;
+                }
+            }
         }
-      }
     }
-  }
-  return 0L;
+    return 0L;
 }
 
 /*******************************************************************************
 ** Products for transformations
 *******************************************************************************/
 
-Obj ProdTrans22 (Obj f, Obj g) {
-  UInt2* ptf, *ptg, *ptfg;
-  UInt   i, def, deg;
-  Obj    fg;
+Obj ProdTrans22(Obj f, Obj g)
+{
+    UInt2 *ptf, *ptg, *ptfg;
+    UInt   i, def, deg;
+    Obj    fg;
 
-  def = DEG_TRANS2(f);
-  deg = DEG_TRANS2(g);
-  fg = NEW_TRANS2(MAX(def, deg));
+    def = DEG_TRANS2(f);
+    deg = DEG_TRANS2(g);
+    fg = NEW_TRANS2(MAX(def, deg));
 
-  ptfg = ADDR_TRANS2(fg);
-  ptf = ADDR_TRANS2(f);
-  ptg = ADDR_TRANS2(g);
+    ptfg = ADDR_TRANS2(fg);
+    ptf = ADDR_TRANS2(f);
+    ptg = ADDR_TRANS2(g);
 
-  if (def <= deg) {
-    for (i = 0; i < def; i++) {
-      *(ptfg++) = ptg[*(ptf++)];
+    if (def <= deg) {
+        for (i = 0; i < def; i++) {
+            *(ptfg++) = ptg[*(ptf++)];
+        }
+        for (; i < deg; i++) {
+            *(ptfg++) = ptg[i];
+        }
     }
-    for (; i < deg; i++) {
-      *(ptfg++) = ptg[i];
+    else {
+        for (i = 0; i < def; i++) {
+            *(ptfg++) = IMAGE(ptf[i], ptg, deg);
+        }
     }
-  } else {
-    for (i = 0; i < def; i++) {
-      *(ptfg++) = IMAGE(ptf[i], ptg, deg);
-    }
-  }
-  return fg;
+    return fg;
 }
 
-Obj ProdTrans24 (Obj f, Obj g) {
-  UInt2* ptf;
-  UInt4* ptg, *ptfg;
-  UInt   i, def, deg;
-  Obj    fg;
+Obj ProdTrans24(Obj f, Obj g)
+{
+    UInt2 * ptf;
+    UInt4 * ptg, *ptfg;
+    UInt    i, def, deg;
+    Obj     fg;
 
-  def = DEG_TRANS2(f);
-  deg = DEG_TRANS4(g);
+    def = DEG_TRANS2(f);
+    deg = DEG_TRANS4(g);
 
-  fg = NEW_TRANS4(MAX(def, deg));
+    fg = NEW_TRANS4(MAX(def, deg));
 
-  ptfg = ADDR_TRANS4(fg);
-  ptf = ADDR_TRANS2(f);
-  ptg = ADDR_TRANS4(g);
+    ptfg = ADDR_TRANS4(fg);
+    ptf = ADDR_TRANS2(f);
+    ptg = ADDR_TRANS4(g);
 
-  if (def <= deg) {
-    for (i = 0; i < def; i++) {
-      *ptfg++ = ptg[*ptf++];
+    if (def <= deg) {
+        for (i = 0; i < def; i++) {
+            *ptfg++ = ptg[*ptf++];
+        }
+        for (; i < deg; i++) {
+            *ptfg++ = ptg[i];
+        }
     }
-    for (; i < deg; i++) {
-      *ptfg++ = ptg[i];
-    }
-  } else {
-    // The only transformation created within this file that is of type
-    // T_TRANS4 and that does not have (internal) degree 65537 or greater
-    // is ID_TRANS4.
+    else {
+        // The only transformation created within this file that is of type
+        // T_TRANS4 and that does not have (internal) degree 65537 or greater
+        // is ID_TRANS4.
 
-    for (i = 0; i < def; i++) {
-      *(ptfg++) = IMAGE(ptf[i], ptg, deg);
+        for (i = 0; i < def; i++) {
+            *(ptfg++) = IMAGE(ptf[i], ptg, deg);
+        }
     }
-  }
 
-  return fg;
+    return fg;
 }
 
-Obj ProdTrans42 (Obj f, Obj g) {
-  UInt4 *ptf, *ptfg;
-  UInt2 *ptg;
-  UInt  i, def, deg;
-  Obj   fg;
+Obj ProdTrans42(Obj f, Obj g)
+{
+    UInt4 * ptf, *ptfg;
+    UInt2 * ptg;
+    UInt    i, def, deg;
+    Obj     fg;
 
-  def = DEG_TRANS4(f);
-  deg = DEG_TRANS2(g);
+    def = DEG_TRANS4(f);
+    deg = DEG_TRANS2(g);
 
-  fg = NEW_TRANS4(MAX(def, deg));
+    fg = NEW_TRANS4(MAX(def, deg));
 
-  ptfg = ADDR_TRANS4(fg);
-  ptf = ADDR_TRANS4(f);
-  ptg = ADDR_TRANS2(g);
+    ptfg = ADDR_TRANS4(fg);
+    ptf = ADDR_TRANS4(f);
+    ptg = ADDR_TRANS2(g);
 
-  if (def <= deg) {
-    // The only transformation created within this file that is of type
-    // T_TRANS4 and that does not have (internal) degree 65537 or greater
-    // is ID_TRANS4.
+    if (def <= deg) {
+        // The only transformation created within this file that is of type
+        // T_TRANS4 and that does not have (internal) degree 65537 or greater
+        // is ID_TRANS4.
 
-    for (i = 0; i < def; i++) {
-      *(ptfg++) = ptg[*(ptf++)];
+        for (i = 0; i < def; i++) {
+            *(ptfg++) = ptg[*(ptf++)];
+        }
+        for (; i < deg; i++) {
+            *(ptfg++) = ptg[i];
+        }
     }
-    for (; i < deg; i++) {
-      *(ptfg++) = ptg[i];
+    else {
+        for (i = 0; i < def; i++) {
+            *(ptfg++) = IMAGE(ptf[i], ptg, deg);
+        }
     }
-  } else {
-    for (i = 0; i < def; i++) {
-      *(ptfg++) = IMAGE(ptf[i], ptg, deg);
-    }
-  }
 
-  return fg;
+    return fg;
 }
 
-Obj ProdTrans44 (Obj f, Obj g) {
-  UInt4 * ptf, *ptg, *ptfg;
-  UInt    i, def, deg;
-  Obj     fg;
+Obj ProdTrans44(Obj f, Obj g)
+{
+    UInt4 *ptf, *ptg, *ptfg;
+    UInt   i, def, deg;
+    Obj    fg;
 
-  def = DEG_TRANS4(f);
-  deg = DEG_TRANS4(g);
-  fg = NEW_TRANS4(MAX(def, deg));
+    def = DEG_TRANS4(f);
+    deg = DEG_TRANS4(g);
+    fg = NEW_TRANS4(MAX(def, deg));
 
-  ptfg = ADDR_TRANS4(fg);
-  ptf = ADDR_TRANS4(f);
-  ptg = ADDR_TRANS4(g);
+    ptfg = ADDR_TRANS4(fg);
+    ptf = ADDR_TRANS4(f);
+    ptg = ADDR_TRANS4(g);
 
-  if (def <= deg) {
-    for (i = 0; i < def; i++) {
-      *(ptfg++) = ptg[*(ptf++)];
+    if (def <= deg) {
+        for (i = 0; i < def; i++) {
+            *(ptfg++) = ptg[*(ptf++)];
+        }
+        for (; i < deg; i++) {
+            *(ptfg++) = ptg[i];
+        }
     }
-    for (; i < deg; i++) {
-      *(ptfg++) = ptg[i];
+    else {
+        for (i = 0; i < def; i++) {
+            *(ptfg++) = IMAGE(ptf[i], ptg, deg);
+        }
     }
-  } else {
-    for (i = 0; i < def; i++) {
-      *(ptfg++) = IMAGE(ptf[i], ptg, deg);
-    }
-  }
-  return fg;
+    return fg;
 }
 
 /*******************************************************************************
 ** Products for a transformation and permutation
 *******************************************************************************/
 
-Obj ProdTrans2Perm2 (Obj f, Obj p) {
-  UInt2 *ptf, *ptp, *ptfp;
-  UInt  i, def, dep;
-  Obj   fp;
+Obj ProdTrans2Perm2(Obj f, Obj p)
+{
+    UInt2 *ptf, *ptp, *ptfp;
+    UInt   i, def, dep;
+    Obj    fp;
 
-  dep = DEG_PERM2(p);
-  def = DEG_TRANS2(f);
-  fp  = NEW_TRANS2(MAX(def, dep));
+    dep = DEG_PERM2(p);
+    def = DEG_TRANS2(f);
+    fp = NEW_TRANS2(MAX(def, dep));
 
-  ptfp = ADDR_TRANS2(fp);
-  ptf = ADDR_TRANS2(f);
-  ptp = ADDR_PERM2(p);
+    ptfp = ADDR_TRANS2(fp);
+    ptf = ADDR_TRANS2(f);
+    ptp = ADDR_PERM2(p);
 
-  if (def <= dep) {
-    for (i = 0; i < def; i++) {
-      *(ptfp++) = ptp[*(ptf++)];
+    if (def <= dep) {
+        for (i = 0; i < def; i++) {
+            *(ptfp++) = ptp[*(ptf++)];
+        }
+        for (; i < dep; i++) {
+            *(ptfp++) = ptp[i];
+        }
     }
-    for (; i < dep; i++) {
-      *(ptfp++) = ptp[i];
+    else {
+        for (i = 0; i < def; i++) {
+            *(ptfp++) = IMAGE(ptf[i], ptp, dep);
+        }
     }
-  } else {
-    for(i=0;i<def;i++) {
-      *(ptfp++) = IMAGE(ptf[i], ptp, dep);
-    }
-  }
-  return fp;
+    return fp;
 }
 
-Obj ProdTrans2Perm4 (Obj f, Obj p) {
-  UInt2 *ptf;
-  UInt4 *ptp, *ptfp;
-  UInt  i, def, dep;
-  Obj   fp;
+Obj ProdTrans2Perm4(Obj f, Obj p)
+{
+    UInt2 * ptf;
+    UInt4 * ptp, *ptfp;
+    UInt    i, def, dep;
+    Obj     fp;
 
-  dep = DEG_PERM4(p);
-  def = DEG_TRANS2(f);
-  fp  = NEW_TRANS4(MAX(def, dep));
+    dep = DEG_PERM4(p);
+    def = DEG_TRANS2(f);
+    fp = NEW_TRANS4(MAX(def, dep));
 
-  ptfp = ADDR_TRANS4(fp);
-  ptf = ADDR_TRANS2(f);
-  ptp = ADDR_PERM4(p);
+    ptfp = ADDR_TRANS4(fp);
+    ptf = ADDR_TRANS2(f);
+    ptp = ADDR_PERM4(p);
 
-  if (def <= dep) {
-    for (i = 0; i < def; i++) {
-      *(ptfp++) = ptp[*(ptf++)];
+    if (def <= dep) {
+        for (i = 0; i < def; i++) {
+            *(ptfp++) = ptp[*(ptf++)];
+        }
+        for (; i < dep; i++) {
+            *(ptfp++) = ptp[i];
+        }
     }
-    for (; i < dep; i++) {
-      *(ptfp++) = ptp[i];
+    else {
+        // I don't know how to create a permutation of type T_PERM4 with
+        // (internal) degree 65536 or less, so this case isn't tested. It is
+        // included to make the code more robust.
+        for (i = 0; i < def; i++) {
+            *(ptfp++) = IMAGE(ptf[i], ptp, dep);
+        }
     }
-  } else {
-    // I don't know how to create a permutation of type T_PERM4 with
-    // (internal) degree 65536 or less, so this case isn't tested. It is
-    // included to make the code more robust.
-    for (i = 0; i < def; i++) {
-      *(ptfp++) = IMAGE(ptf[i], ptp, dep);
-    }
-  }
-  return fp;
+    return fp;
 }
 
-Obj ProdTrans4Perm2 (Obj f, Obj p) {
-  UInt4 *ptf, *ptfp;
-  UInt2 *ptp;
-  UInt  i, def, dep;
-  Obj   fp;
+Obj ProdTrans4Perm2(Obj f, Obj p)
+{
+    UInt4 * ptf, *ptfp;
+    UInt2 * ptp;
+    UInt    i, def, dep;
+    Obj     fp;
 
-  dep = DEG_PERM2(p);
-  def = DEG_TRANS4(f);
-  fp  = NEW_TRANS4(MAX(def, dep));
+    dep = DEG_PERM2(p);
+    def = DEG_TRANS4(f);
+    fp = NEW_TRANS4(MAX(def, dep));
 
-  ptfp = ADDR_TRANS4(fp);
-  ptf = ADDR_TRANS4(f);
-  ptp = ADDR_PERM2(p);
+    ptfp = ADDR_TRANS4(fp);
+    ptf = ADDR_TRANS4(f);
+    ptp = ADDR_PERM2(p);
 
-  if (def <= dep) {
-    // The only transformation created within this file that is of type
-    // T_TRANS4 and that does not have (internal) degree 65537 or greater
-    // is ID_TRANS4.
-    for (i = 0; i < def; i++) {
-      *(ptfp++) = ptp[*(ptf++)];
+    if (def <= dep) {
+        // The only transformation created within this file that is of type
+        // T_TRANS4 and that does not have (internal) degree 65537 or greater
+        // is ID_TRANS4.
+        for (i = 0; i < def; i++) {
+            *(ptfp++) = ptp[*(ptf++)];
+        }
+        for (; i < dep; i++) {
+            *(ptfp++) = ptp[i];
+        }
     }
-    for (; i < dep; i++) {
-      *(ptfp++) = ptp[i];
+    else {
+        for (i = 0; i < def; i++) {
+            *(ptfp++) = IMAGE(ptf[i], ptp, dep);
+        }
     }
-  } else {
-    for (i = 0; i < def; i++) {
-      *(ptfp++) = IMAGE(ptf[i], ptp, dep);
-    }
-  }
-  return fp;
+    return fp;
 }
 
-Obj ProdTrans4Perm4 (Obj f, Obj p) {
-  UInt4 *ptf, *ptp, *ptfp;
-  UInt  i, def, dep;
-  Obj   fp;
+Obj ProdTrans4Perm4(Obj f, Obj p)
+{
+    UInt4 *ptf, *ptp, *ptfp;
+    UInt   i, def, dep;
+    Obj    fp;
 
-  dep = DEG_PERM4(p);
-  def = DEG_TRANS4(f);
-  fp  = NEW_TRANS4(MAX(def, dep));
+    dep = DEG_PERM4(p);
+    def = DEG_TRANS4(f);
+    fp = NEW_TRANS4(MAX(def, dep));
 
-  ptfp = ADDR_TRANS4(fp);
-  ptf = ADDR_TRANS4(f);
-  ptp = ADDR_PERM4(p);
+    ptfp = ADDR_TRANS4(fp);
+    ptf = ADDR_TRANS4(f);
+    ptp = ADDR_PERM4(p);
 
-  if (def <= dep) {
-    for (i = 0; i < def; i++) {
-      *(ptfp++) = ptp[*(ptf++)];
+    if (def <= dep) {
+        for (i = 0; i < def; i++) {
+            *(ptfp++) = ptp[*(ptf++)];
+        }
+        for (; i < dep; i++) {
+            *(ptfp++) = ptp[i];
+        }
     }
-    for (; i < dep; i++) {
-      *(ptfp++) = ptp[i];
+    else {
+        for (i = 0; i < def; i++) {
+            *(ptfp++) = IMAGE(ptf[i], ptp, dep);
+        }
     }
-  } else {
-    for (i = 0; i < def; i++) {
-      *(ptfp++) = IMAGE(ptf[i], ptp, dep);
-    }
-  }
-  return fp;
+    return fp;
 }
 
 /*******************************************************************************
 ** Products for a permutation and transformation
 *******************************************************************************/
 
-Obj ProdPerm2Trans2 (Obj p, Obj f) {
-  UInt2 *ptf, *ptp, *ptpf;
-  UInt  i, def, dep;
-  Obj   pf;
+Obj ProdPerm2Trans2(Obj p, Obj f)
+{
+    UInt2 *ptf, *ptp, *ptpf;
+    UInt   i, def, dep;
+    Obj    pf;
 
-  dep = DEG_PERM2(p);
-  def = DEG_TRANS2(f);
-  pf  = NEW_TRANS2(MAX(def, dep));
+    dep = DEG_PERM2(p);
+    def = DEG_TRANS2(f);
+    pf = NEW_TRANS2(MAX(def, dep));
 
-  ptpf = ADDR_TRANS2(pf);
-  ptf = ADDR_TRANS2(f);
-  ptp = ADDR_PERM2(p);
+    ptpf = ADDR_TRANS2(pf);
+    ptf = ADDR_TRANS2(f);
+    ptp = ADDR_PERM2(p);
 
-  if (dep <= def) {
-    for (i = 0; i < dep; i++) {
-      *(ptpf++) = ptf[*(ptp++)];
+    if (dep <= def) {
+        for (i = 0; i < dep; i++) {
+            *(ptpf++) = ptf[*(ptp++)];
+        }
+        for (; i < def; i++) {
+            *(ptpf++) = ptf[i];
+        }
     }
-    for (; i < def; i++) {
-      *(ptpf++) = ptf[i];
+    else {
+        for (i = 0; i < dep; i++) {
+            *(ptpf++) = IMAGE(ptp[i], ptf, def);
+        }
     }
-  } else {
-    for (i = 0; i < dep; i++) {
-      *(ptpf++) = IMAGE(ptp[i], ptf, def);
-    }
-  }
-  return pf;
+    return pf;
 }
 
-Obj ProdPerm2Trans4 (Obj p, Obj f) {
-  UInt4 *ptf, *ptpf;
-  UInt2 *ptp;
-  UInt  i, def, dep;
-  Obj   pf;
+Obj ProdPerm2Trans4(Obj p, Obj f)
+{
+    UInt4 * ptf, *ptpf;
+    UInt2 * ptp;
+    UInt    i, def, dep;
+    Obj     pf;
 
-  dep = DEG_PERM2(p);
-  def = DEG_TRANS4(f);
-  pf  = NEW_TRANS4(MAX(def, dep));
+    dep = DEG_PERM2(p);
+    def = DEG_TRANS4(f);
+    pf = NEW_TRANS4(MAX(def, dep));
 
-  ptpf = ADDR_TRANS4(pf);
-  ptf = ADDR_TRANS4(f);
-  ptp = ADDR_PERM2(p);
+    ptpf = ADDR_TRANS4(pf);
+    ptf = ADDR_TRANS4(f);
+    ptp = ADDR_PERM2(p);
 
-  if (dep <= def) {
-    for (i = 0; i < dep; i++) {
-      *(ptpf++) = ptf[*(ptp++)];
+    if (dep <= def) {
+        for (i = 0; i < dep; i++) {
+            *(ptpf++) = ptf[*(ptp++)];
+        }
+        for (; i < def; i++) {
+            *(ptpf++) = ptf[i];
+        }
     }
-    for (; i < def; i++) {
-      *(ptpf++) = ptf[i];
+    else {
+        // The only transformation created within this file that is of type
+        // T_TRANS4 and that does not have (internal) degree 65537 or greater
+        // is ID_TRANS4.
+        for (i = 0; i < dep; i++) {
+            *(ptpf++) = IMAGE(ptp[i], ptf, def);
+        }
     }
-  } else {
-    // The only transformation created within this file that is of type
-    // T_TRANS4 and that does not have (internal) degree 65537 or greater
-    // is ID_TRANS4.
-    for (i = 0; i < dep; i++) {
-      *(ptpf++) = IMAGE(ptp[i], ptf, def);
-    }
-  }
-  return pf;
+    return pf;
 }
 
-Obj ProdPerm4Trans2 (Obj p, Obj f) {
-  UInt2   *ptf;
-  UInt4   *ptp, *ptpf;
-  UInt    i, def, dep;
-  Obj     pf;
+Obj ProdPerm4Trans2(Obj p, Obj f)
+{
+    UInt2 * ptf;
+    UInt4 * ptp, *ptpf;
+    UInt    i, def, dep;
+    Obj     pf;
 
-  dep =  DEG_PERM4(p);
-  def = DEG_TRANS2(f);
-  pf  = NEW_TRANS4(MAX(def,dep));
+    dep = DEG_PERM4(p);
+    def = DEG_TRANS2(f);
+    pf = NEW_TRANS4(MAX(def, dep));
 
-  ptpf = ADDR_TRANS4(pf);
-  ptf = ADDR_TRANS2(f);
-  ptp = ADDR_PERM4(p);
+    ptpf = ADDR_TRANS4(pf);
+    ptf = ADDR_TRANS2(f);
+    ptp = ADDR_PERM4(p);
 
-  if (dep <= def) {
-    // I don't know how to create a permutation of type T_PERM4 with
-    // (internal) degree 65536 or less, so this case isn't tested. It is
-    // included to make the code more robust.
-    for (i = 0; i < dep; i++) {
-      *(ptpf++) = ptf[*(ptp++)];
+    if (dep <= def) {
+        // I don't know how to create a permutation of type T_PERM4 with
+        // (internal) degree 65536 or less, so this case isn't tested. It is
+        // included to make the code more robust.
+        for (i = 0; i < dep; i++) {
+            *(ptpf++) = ptf[*(ptp++)];
+        }
+        for (; i < def; i++) {
+            *(ptpf++) = ptf[i];
+        }
     }
-    for (; i < def; i++) {
-      *(ptpf++) = ptf[i];
+    else {
+        for (i = 0; i < dep; i++) {
+            *(ptpf++) = IMAGE(ptp[i], ptf, def);
+        }
     }
-  } else {
-    for (i = 0; i < dep; i++) {
-      *(ptpf++) = IMAGE(ptp[i], ptf, def);
-    }
-  }
-  return pf;
+    return pf;
 }
 
-Obj ProdPerm4Trans4 (Obj p, Obj f) {
-  UInt4   *ptf, *ptp, *ptpf;
-  UInt    i, def, dep;
-  Obj     pf;
+Obj ProdPerm4Trans4(Obj p, Obj f)
+{
+    UInt4 *ptf, *ptp, *ptpf;
+    UInt   i, def, dep;
+    Obj    pf;
 
-  dep = DEG_PERM4(p);
-  def = DEG_TRANS4(f);
-  pf  = NEW_TRANS4(MAX(def, dep));
+    dep = DEG_PERM4(p);
+    def = DEG_TRANS4(f);
+    pf = NEW_TRANS4(MAX(def, dep));
 
-  ptpf = ADDR_TRANS4(pf);
-  ptf = ADDR_TRANS4(f);
-  ptp = ADDR_PERM4(p);
+    ptpf = ADDR_TRANS4(pf);
+    ptf = ADDR_TRANS4(f);
+    ptp = ADDR_PERM4(p);
 
-  if (dep <= def) {
-    for (i = 0; i < dep; i++) {
-      *(ptpf++) = ptf[*(ptp++)];
+    if (dep <= def) {
+        for (i = 0; i < dep; i++) {
+            *(ptpf++) = ptf[*(ptp++)];
+        }
+        for (; i < def; i++) {
+            *(ptpf++) = ptf[i];
+        }
     }
-    for (; i < def; i++) {
-      *(ptpf++) = ptf[i];
+    else {
+        for (i = 0; i < dep; i++) {
+            *(ptpf++) = IMAGE(ptp[i], ptf, def);
+        }
     }
-  } else {
-    for (i = 0; i < dep; i++) {
-      *(ptpf++) = IMAGE(ptp[i], ptf, def);
-    }
-  }
-  return pf;
+    return pf;
 }
 
 /*******************************************************************************
 ** Conjugate a transformation f by a permutation p: p ^ -1 * f * p
 *******************************************************************************/
 
-Obj PowTrans2Perm2 (Obj f, Obj p) {
-  UInt2 *ptf, *ptp, *ptcnj;
-  UInt  i, def, dep, decnj;
-  Obj   cnj;
+Obj PowTrans2Perm2(Obj f, Obj p)
+{
+    UInt2 *ptf, *ptp, *ptcnj;
+    UInt   i, def, dep, decnj;
+    Obj    cnj;
 
-  dep  = DEG_PERM2(p);
-  def  = DEG_TRANS2(f);
-  decnj = MAX(dep, def);
-  cnj  = NEW_TRANS2(decnj);
+    dep = DEG_PERM2(p);
+    def = DEG_TRANS2(f);
+    decnj = MAX(dep, def);
+    cnj = NEW_TRANS2(decnj);
 
-  ptcnj = ADDR_TRANS2(cnj);
-  ptf  = ADDR_TRANS2(f);
-  ptp  = ADDR_PERM2(p);
+    ptcnj = ADDR_TRANS2(cnj);
+    ptf = ADDR_TRANS2(f);
+    ptp = ADDR_PERM2(p);
 
-  if (def == dep) {
-    for (i = 0; i < decnj; i++) {
-      ptcnj[ptp[i]] = ptp[ptf[i]];
+    if (def == dep) {
+        for (i = 0; i < decnj; i++) {
+            ptcnj[ptp[i]] = ptp[ptf[i]];
+        }
     }
-  } else {
-    for (i = 0; i < decnj; i++) {
-      ptcnj[IMAGE(i, ptp, dep)] = IMAGE(IMAGE(i, ptf, def), ptp, dep);
+    else {
+        for (i = 0; i < decnj; i++) {
+            ptcnj[IMAGE(i, ptp, dep)] = IMAGE(IMAGE(i, ptf, def), ptp, dep);
+        }
     }
-  }
-  return cnj;
+    return cnj;
 }
 
-Obj PowTrans2Perm4 (Obj f, Obj p) {
-  UInt2 *ptf;
-  UInt4 *ptp, *ptcnj;
-  UInt  i, def, dep, decnj;
-  Obj   cnj;
+Obj PowTrans2Perm4(Obj f, Obj p)
+{
+    UInt2 * ptf;
+    UInt4 * ptp, *ptcnj;
+    UInt    i, def, dep, decnj;
+    Obj     cnj;
 
-  dep  = DEG_PERM4(p);
-  def  = DEG_TRANS2(f);
-  decnj = MAX(dep, def);
-  cnj  = NEW_TRANS4(decnj);
+    dep = DEG_PERM4(p);
+    def = DEG_TRANS2(f);
+    decnj = MAX(dep, def);
+    cnj = NEW_TRANS4(decnj);
 
-  ptcnj = ADDR_TRANS4(cnj);
-  ptf  = ADDR_TRANS2(f);
-  ptp  = ADDR_PERM4(p);
+    ptcnj = ADDR_TRANS4(cnj);
+    ptf = ADDR_TRANS2(f);
+    ptp = ADDR_PERM4(p);
 
-  if (def == dep) {
-    // I don't know how to create a permutation of type T_PERM4 with
-    // (internal) degree 65536 or less, so this case isn't tested. It is
-    // included to make the code more robust.
-    for (i = 0; i < decnj; i++) {
-      ptcnj[ptp[i]] = ptp[ptf[i]];
+    if (def == dep) {
+        // I don't know how to create a permutation of type T_PERM4 with
+        // (internal) degree 65536 or less, so this case isn't tested. It is
+        // included to make the code more robust.
+        for (i = 0; i < decnj; i++) {
+            ptcnj[ptp[i]] = ptp[ptf[i]];
+        }
     }
-  } else {
-    for (i = 0; i < decnj; i++) {
-      ptcnj[IMAGE(i, ptp, dep)] = IMAGE(IMAGE(i, ptf, def), ptp, dep);
+    else {
+        for (i = 0; i < decnj; i++) {
+            ptcnj[IMAGE(i, ptp, dep)] = IMAGE(IMAGE(i, ptf, def), ptp, dep);
+        }
     }
-  }
-  return cnj;
+    return cnj;
 }
 
-Obj PowTrans4Perm2 (Obj f, Obj p) {
-  UInt2 *ptp;
-  UInt4 *ptf, *ptcnj;
-  UInt  i, def, dep, decnj;
-  Obj   cnj;
+Obj PowTrans4Perm2(Obj f, Obj p)
+{
+    UInt2 * ptp;
+    UInt4 * ptf, *ptcnj;
+    UInt    i, def, dep, decnj;
+    Obj     cnj;
 
-  dep  = DEG_PERM2(p);
-  def  = DEG_TRANS4(f);
-  decnj = MAX(dep, def);
-  cnj  = NEW_TRANS4(decnj);
+    dep = DEG_PERM2(p);
+    def = DEG_TRANS4(f);
+    decnj = MAX(dep, def);
+    cnj = NEW_TRANS4(decnj);
 
-  ptcnj = ADDR_TRANS4(cnj);
-  ptf  = ADDR_TRANS4(f);
-  ptp  = ADDR_PERM2(p);
+    ptcnj = ADDR_TRANS4(cnj);
+    ptf = ADDR_TRANS4(f);
+    ptp = ADDR_PERM2(p);
 
-  if (def == dep) {
-    // The only transformation created within this file that is of type
-    // T_TRANS4 and that does not have (internal) degree 65537 or greater
-    // is ID_TRANS4.
-    for (i = 0; i < decnj; i++) {
-      ptcnj[ptp[i]] = ptp[ptf[i]];
+    if (def == dep) {
+        // The only transformation created within this file that is of type
+        // T_TRANS4 and that does not have (internal) degree 65537 or greater
+        // is ID_TRANS4.
+        for (i = 0; i < decnj; i++) {
+            ptcnj[ptp[i]] = ptp[ptf[i]];
+        }
     }
-  } else {
-    for (i = 0; i < decnj; i++) {
-      ptcnj[IMAGE(i, ptp, dep)] = IMAGE(IMAGE(i, ptf, def), ptp, dep);
+    else {
+        for (i = 0; i < decnj; i++) {
+            ptcnj[IMAGE(i, ptp, dep)] = IMAGE(IMAGE(i, ptf, def), ptp, dep);
+        }
     }
-  }
-  return cnj;
+    return cnj;
 }
 
-Obj PowTrans4Perm4 (Obj f, Obj p) {
-  UInt4 *ptf, *ptp, *ptcnj;
-  UInt  i, def, dep, decnj;
-  Obj   cnj;
+Obj PowTrans4Perm4(Obj f, Obj p)
+{
+    UInt4 *ptf, *ptp, *ptcnj;
+    UInt   i, def, dep, decnj;
+    Obj    cnj;
 
-  dep  = DEG_PERM4(p);
-  def  = DEG_TRANS4(f);
-  decnj = MAX(dep, def);
-  cnj  = NEW_TRANS4(decnj);
+    dep = DEG_PERM4(p);
+    def = DEG_TRANS4(f);
+    decnj = MAX(dep, def);
+    cnj = NEW_TRANS4(decnj);
 
-  ptcnj = ADDR_TRANS4(cnj);
-  ptf  = ADDR_TRANS4(f);
-  ptp  = ADDR_PERM4(p);
+    ptcnj = ADDR_TRANS4(cnj);
+    ptf = ADDR_TRANS4(f);
+    ptp = ADDR_PERM4(p);
 
-  if (def == dep) {
-    for (i = 0; i < decnj; i++) {
-      ptcnj[ptp[i]] = ptp[ptf[i]];
+    if (def == dep) {
+        for (i = 0; i < decnj; i++) {
+            ptcnj[ptp[i]] = ptp[ptf[i]];
+        }
     }
-  } else {
-    for (i = 0; i < decnj; i++) {
-      ptcnj[IMAGE(i, ptp, dep)] = IMAGE(IMAGE(i, ptf, def), ptp, dep);
+    else {
+        for (i = 0; i < decnj; i++) {
+            ptcnj[IMAGE(i, ptp, dep)] = IMAGE(IMAGE(i, ptf, def), ptp, dep);
+        }
     }
-  }
-  return cnj;
+    return cnj;
 }
 
 /*******************************************************************************
 ** Quotient a transformation f by a permutation p: f * p ^ -1
 *******************************************************************************/
 
-Obj QuoTrans2Perm2 (Obj f, Obj p) {
-  UInt  def, dep, i;
-  UInt2 *ptf, *ptquo, *ptp;
-  UInt4 *pttmp;
-  Obj   quo;
+Obj QuoTrans2Perm2(Obj f, Obj p)
+{
+    UInt    def, dep, i;
+    UInt2 * ptf, *ptquo, *ptp;
+    UInt4 * pttmp;
+    Obj     quo;
 
-  def = DEG_TRANS2(f);
-  dep = DEG_PERM2(p);
-  quo = NEW_TRANS2(MAX(def, dep));
-  ResizeTmpTrans(SIZE_OBJ(p));
+    def = DEG_TRANS2(f);
+    dep = DEG_PERM2(p);
+    quo = NEW_TRANS2(MAX(def, dep));
+    ResizeTmpTrans(SIZE_OBJ(p));
 
-  // invert the permutation into the buffer bag
-  pttmp = ADDR_TRANS4(TmpTrans);
-  ptp = ADDR_PERM2(p);
-  for (i = 0; i < dep; i++) {
-    pttmp[*ptp++] = i;
-  }
-
-  ptf = ADDR_TRANS2(f);
-  ptquo = ADDR_TRANS2(quo);
-
-  if (def <= dep) {
-    for (i = 0; i < def; i++) {
-      *(ptquo++) = pttmp[*(ptf++)];
+    // invert the permutation into the buffer bag
+    pttmp = ADDR_TRANS4(TmpTrans);
+    ptp = ADDR_PERM2(p);
+    for (i = 0; i < dep; i++) {
+        pttmp[*ptp++] = i;
     }
-    for (i = def; i < dep; i++) {
-      *(ptquo++) = pttmp[i];
+
+    ptf = ADDR_TRANS2(f);
+    ptquo = ADDR_TRANS2(quo);
+
+    if (def <= dep) {
+        for (i = 0; i < def; i++) {
+            *(ptquo++) = pttmp[*(ptf++)];
+        }
+        for (i = def; i < dep; i++) {
+            *(ptquo++) = pttmp[i];
+        }
     }
-  }
-  else {
-    for (i = 0; i < def; i++) {
-      *(ptquo++) = IMAGE(ptf[i], pttmp, dep);
+    else {
+        for (i = 0; i < def; i++) {
+            *(ptquo++) = IMAGE(ptf[i], pttmp, dep);
+        }
     }
-  }
-  return quo;
+    return quo;
 }
 
-Obj QuoTrans2Perm4 (Obj f, Obj p) {
-  UInt  def, dep, i;
-  UInt2 *ptf;
-  UInt4 *ptquo, *ptp, *pttmp;
-  Obj   quo;
+Obj QuoTrans2Perm4(Obj f, Obj p)
+{
+    UInt    def, dep, i;
+    UInt2 * ptf;
+    UInt4 * ptquo, *ptp, *pttmp;
+    Obj     quo;
 
-  def = DEG_TRANS2(f);
-  dep = DEG_PERM4(p);
-  quo = NEW_TRANS4( MAX(def, dep));
-  ResizeTmpTrans(SIZE_OBJ(p));
+    def = DEG_TRANS2(f);
+    dep = DEG_PERM4(p);
+    quo = NEW_TRANS4(MAX(def, dep));
+    ResizeTmpTrans(SIZE_OBJ(p));
 
-  // invert the permutation into the buffer bag
-  pttmp = ADDR_TRANS4(TmpTrans);
-  ptp = ADDR_PERM4(p);
-  for (i = 0; i < dep; i++) {
-    pttmp[*ptp++] = i;
-  }
-
-  ptf = ADDR_TRANS2(f);
-  ptquo = ADDR_TRANS4(quo);
-
-  if (def <= dep) {
-    for (i = 0; i < def; i++) {
-      *(ptquo++) = pttmp[*(ptf++)];
+    // invert the permutation into the buffer bag
+    pttmp = ADDR_TRANS4(TmpTrans);
+    ptp = ADDR_PERM4(p);
+    for (i = 0; i < dep; i++) {
+        pttmp[*ptp++] = i;
     }
-    for (i = def; i < dep; i++) {
-      *(ptquo++) = pttmp[i];
+
+    ptf = ADDR_TRANS2(f);
+    ptquo = ADDR_TRANS4(quo);
+
+    if (def <= dep) {
+        for (i = 0; i < def; i++) {
+            *(ptquo++) = pttmp[*(ptf++)];
+        }
+        for (i = def; i < dep; i++) {
+            *(ptquo++) = pttmp[i];
+        }
     }
-  } else {
-    // I don't know how to create a permutation of type T_PERM4 with
-    // (internal) degree 65536 or less, so this case isn't tested. It is
-    // included to make the code more robust.
-    for (i = 0; i < def; i++) {
-      *(ptquo++) = IMAGE(ptf[i], pttmp, dep);
+    else {
+        // I don't know how to create a permutation of type T_PERM4 with
+        // (internal) degree 65536 or less, so this case isn't tested. It is
+        // included to make the code more robust.
+        for (i = 0; i < def; i++) {
+            *(ptquo++) = IMAGE(ptf[i], pttmp, dep);
+        }
     }
-  }
-  return quo;
+    return quo;
 }
 
-Obj QuoTrans4Perm2 (Obj f, Obj p) {
-  UInt  def, dep, i;
-  UInt4 *ptf, *ptquo, *pttmp;
-  UInt2 *ptp;
-  Obj   quo;
+Obj QuoTrans4Perm2(Obj f, Obj p)
+{
+    UInt    def, dep, i;
+    UInt4 * ptf, *ptquo, *pttmp;
+    UInt2 * ptp;
+    Obj     quo;
 
-  def = DEG_TRANS4(f);
-  dep = DEG_PERM2(p);
-  quo = NEW_TRANS4(MAX(def, dep));
+    def = DEG_TRANS4(f);
+    dep = DEG_PERM2(p);
+    quo = NEW_TRANS4(MAX(def, dep));
 
-  ResizeTmpTrans(SIZE_OBJ(p));
+    ResizeTmpTrans(SIZE_OBJ(p));
 
-  // invert the permutation into the buffer bag
-  pttmp = ADDR_TRANS4(TmpTrans);
-  ptp = ADDR_PERM2(p);
-  for (i = 0; i < dep; i++) {
-    pttmp[*ptp++] = i;
-  }
-
-  ptf = ADDR_TRANS4(f);
-  ptquo = ADDR_TRANS4(quo);
-
-  if (def <= dep) {
-    // The only transformation created within this file that is of type
-    // T_TRANS4 and that does not have (internal) degree 65537 or greater
-    // is ID_TRANS4.
-    for (i = 0; i < def; i++) {
-      *(ptquo++) = pttmp[*(ptf++)];
+    // invert the permutation into the buffer bag
+    pttmp = ADDR_TRANS4(TmpTrans);
+    ptp = ADDR_PERM2(p);
+    for (i = 0; i < dep; i++) {
+        pttmp[*ptp++] = i;
     }
-    for (i = def; i < dep; i++) {
-      *(ptquo++) = pttmp[i];
+
+    ptf = ADDR_TRANS4(f);
+    ptquo = ADDR_TRANS4(quo);
+
+    if (def <= dep) {
+        // The only transformation created within this file that is of type
+        // T_TRANS4 and that does not have (internal) degree 65537 or greater
+        // is ID_TRANS4.
+        for (i = 0; i < def; i++) {
+            *(ptquo++) = pttmp[*(ptf++)];
+        }
+        for (i = def; i < dep; i++) {
+            *(ptquo++) = pttmp[i];
+        }
     }
-  } else {
-    for (i = 0; i < def; i++) {
-      *(ptquo++) = IMAGE(ptf[i], pttmp, dep);
+    else {
+        for (i = 0; i < def; i++) {
+            *(ptquo++) = IMAGE(ptf[i], pttmp, dep);
+        }
     }
-  }
-  return quo;
+    return quo;
 }
 
-Obj QuoTrans4Perm4 (Obj f, Obj p) {
-  UInt  def, dep, i;
-  UInt4 *ptf, *pttmp, *ptquo, *ptp;
-  Obj   quo;
+Obj QuoTrans4Perm4(Obj f, Obj p)
+{
+    UInt   def, dep, i;
+    UInt4 *ptf, *pttmp, *ptquo, *ptp;
+    Obj    quo;
 
-  def = DEG_TRANS4(f);
-  dep = DEG_PERM4(p);
-  quo = NEW_TRANS4(MAX(def, dep));
+    def = DEG_TRANS4(f);
+    dep = DEG_PERM4(p);
+    quo = NEW_TRANS4(MAX(def, dep));
 
-  ResizeTmpTrans(SIZE_OBJ(p));
+    ResizeTmpTrans(SIZE_OBJ(p));
 
-  // invert the permutation into the buffer bag
-  pttmp = ADDR_TRANS4(TmpTrans);
-  ptp = ADDR_PERM4(p);
-  for (i = 0; i < dep; i++) {
-    pttmp[*ptp++] = i;
-  }
-
-  ptf = ADDR_TRANS4(f);
-  ptquo = ADDR_TRANS4(quo);
-
-  if (def <= dep) {
-    for (i = 0; i < def; i++) {
-      *(ptquo++) = pttmp[ * (ptf++)];
+    // invert the permutation into the buffer bag
+    pttmp = ADDR_TRANS4(TmpTrans);
+    ptp = ADDR_PERM4(p);
+    for (i = 0; i < dep; i++) {
+        pttmp[*ptp++] = i;
     }
-    for (i = def; i < dep; i++) {
-      *(ptquo++) = pttmp[i];
+
+    ptf = ADDR_TRANS4(f);
+    ptquo = ADDR_TRANS4(quo);
+
+    if (def <= dep) {
+        for (i = 0; i < def; i++) {
+            *(ptquo++) = pttmp[*(ptf++)];
+        }
+        for (i = def; i < dep; i++) {
+            *(ptquo++) = pttmp[i];
+        }
     }
-  } else {
-    for (i = 0; i < def; i++) {
-      *(ptquo++) = IMAGE(ptf[i], pttmp, dep);
+    else {
+        for (i = 0; i < def; i++) {
+            *(ptquo++) = IMAGE(ptf[i], pttmp, dep);
+        }
     }
-  }
-  return quo;
+    return quo;
 }
 
 /*******************************************************************************
 ** Left quotient a transformation f by a permutation p: p ^ -1 * f
 *******************************************************************************/
 
-Obj LQuoPerm2Trans2 (Obj opL, Obj opR) {
-  UInt   degL, degR, degM, p;
-  Obj    mod;
-  UInt2  *ptL, *ptR, *ptM;
+Obj LQuoPerm2Trans2(Obj opL, Obj opR)
+{
+    UInt   degL, degR, degM, p;
+    Obj    mod;
+    UInt2 *ptL, *ptR, *ptM;
 
-  degL = DEG_PERM2(opL);
-  degR = DEG_TRANS2(opR);
-  degM = degL < degR ? degR : degL;
-  mod = NEW_TRANS2( degM);
+    degL = DEG_PERM2(opL);
+    degR = DEG_TRANS2(opR);
+    degM = degL < degR ? degR : degL;
+    mod = NEW_TRANS2(degM);
 
-  ptL = ADDR_PERM2(opL);
-  ptR = ADDR_TRANS2(opR);
-  ptM = ADDR_TRANS2(mod);
+    ptL = ADDR_PERM2(opL);
+    ptR = ADDR_TRANS2(opR);
+    ptM = ADDR_TRANS2(mod);
 
-  if (degL <= degR) {
-    for (p = 0; p < degL; p++) {
-      ptM[*(ptL++)] = *(ptR++);
+    if (degL <= degR) {
+        for (p = 0; p < degL; p++) {
+            ptM[*(ptL++)] = *(ptR++);
+        }
+        for (p = degL; p < degR; p++) {
+            ptM[p] = *(ptR++);
+        }
     }
-    for (p = degL; p < degR; p++) {
-      ptM[p] = *(ptR++);
+    else {
+        for (p = 0; p < degR; p++) {
+            ptM[*(ptL++)] = *(ptR++);
+        }
+        for (p = degR; p < degL; p++) {
+            ptM[*(ptL++)] = p;
+        }
     }
-  } else {
-    for (p = 0; p < degR; p++) {
-      ptM[*(ptL++) ] = *(ptR++);
-    }
-    for (p = degR; p < degL; p++) {
-      ptM[*(ptL++) ] = p;
-    }
-  }
 
-  return mod;
+    return mod;
 }
 
-Obj LQuoPerm2Trans4 (Obj opL, Obj opR) {
-  UInt   degL, degR, degM, p;
-  Obj    mod;
-  UInt2  *ptL;
-  UInt4  *ptR, *ptM;
+Obj LQuoPerm2Trans4(Obj opL, Obj opR)
+{
+    UInt    degL, degR, degM, p;
+    Obj     mod;
+    UInt2 * ptL;
+    UInt4 * ptR, *ptM;
 
-  degL = DEG_PERM2(opL);
-  degR = DEG_TRANS4(opR);
-  degM = degL < degR ? degR : degL;
-  mod = NEW_TRANS4(degM);
+    degL = DEG_PERM2(opL);
+    degR = DEG_TRANS4(opR);
+    degM = degL < degR ? degR : degL;
+    mod = NEW_TRANS4(degM);
 
-  ptL = ADDR_PERM2(opL);
-  ptR = ADDR_TRANS4(opR);
-  ptM = ADDR_TRANS4(mod);
+    ptL = ADDR_PERM2(opL);
+    ptR = ADDR_TRANS4(opR);
+    ptM = ADDR_TRANS4(mod);
 
-  if (degL <= degR) {
-    for (p = 0; p < degL; p++) {
-      ptM[*(ptL++) ] = *(ptR++);
+    if (degL <= degR) {
+        for (p = 0; p < degL; p++) {
+            ptM[*(ptL++)] = *(ptR++);
+        }
+        for (p = degL; p < degR; p++) {
+            ptM[p] = *(ptR++);
+        }
     }
-    for (p = degL; p < degR; p++) {
-      ptM[p] = *(ptR++);
+    else {
+        // The only transformation created within this file that is of type
+        // T_TRANS4 and that does not have (internal) degree 65537 or greater
+        // is ID_TRANS4.
+        for (p = 0; p < degR; p++) {
+            ptM[*(ptL++)] = *(ptR++);
+        }
+        for (p = degR; p < degL; p++) {
+            ptM[*(ptL++)] = p;
+        }
     }
-  } else {
-    // The only transformation created within this file that is of type
-    // T_TRANS4 and that does not have (internal) degree 65537 or greater
-    // is ID_TRANS4.
-    for (p = 0; p < degR; p++) {
-      ptM[*(ptL++) ] = *(ptR++);
-    }
-    for (p = degR; p < degL; p++) {
-      ptM[*(ptL++) ] = p;
-    }
-  }
 
-  return mod;
+    return mod;
 }
 
-Obj LQuoPerm4Trans2 (Obj opL, Obj opR) {
-  UInt   degL, degR, degM, p;
-  Obj    mod;
-  UInt4  *ptL, *ptM;
-  UInt2  *ptR;
+Obj LQuoPerm4Trans2(Obj opL, Obj opR)
+{
+    UInt    degL, degR, degM, p;
+    Obj     mod;
+    UInt4 * ptL, *ptM;
+    UInt2 * ptR;
 
-  degL = DEG_PERM4(opL);
-  degR = DEG_TRANS2(opR);
-  degM = degL < degR ? degR : degL;
-  mod = NEW_TRANS4( degM );
+    degL = DEG_PERM4(opL);
+    degR = DEG_TRANS2(opR);
+    degM = degL < degR ? degR : degL;
+    mod = NEW_TRANS4(degM);
 
-  ptL = ADDR_PERM4(opL);
-  ptR = ADDR_TRANS2(opR);
-  ptM = ADDR_TRANS4(mod);
+    ptL = ADDR_PERM4(opL);
+    ptR = ADDR_TRANS2(opR);
+    ptM = ADDR_TRANS4(mod);
 
-  if (degL <= degR) {
-    // I don't know how to create a permutation of type T_PERM4 with
-    // (internal) degree 65536 or less, so this case isn't tested. It is
-    // included to make the code more robust.
-    for (p = 0; p < degL; p++) {
-      ptM[*(ptL++) ] = *(ptR++);
+    if (degL <= degR) {
+        // I don't know how to create a permutation of type T_PERM4 with
+        // (internal) degree 65536 or less, so this case isn't tested. It is
+        // included to make the code more robust.
+        for (p = 0; p < degL; p++) {
+            ptM[*(ptL++)] = *(ptR++);
+        }
+        for (p = degL; p < degR; p++) {
+            ptM[p] = *(ptR++);
+        }
     }
-    for (p = degL; p < degR; p++) {
-      ptM[p] = *(ptR++);
+    else {
+        for (p = 0; p < degR; p++) {
+            ptM[*(ptL++)] = *(ptR++);
+        }
+        for (p = degR; p < degL; p++) {
+            ptM[*(ptL++)] = p;
+        }
     }
-  } else {
-    for (p = 0; p < degR; p++) {
-      ptM[*(ptL++) ] = *(ptR++);
-    }
-    for (p = degR; p < degL; p++) {
-      ptM[*(ptL++)] = p;
-    }
-  }
 
-  return mod;
+    return mod;
 }
 
-Obj LQuoPerm4Trans4 (Obj opL, Obj opR) {
-  UInt   degL, degR, degM, p;
-  Obj    mod;
-  UInt4  *ptL, *ptR, *ptM;
+Obj LQuoPerm4Trans4(Obj opL, Obj opR)
+{
+    UInt   degL, degR, degM, p;
+    Obj    mod;
+    UInt4 *ptL, *ptR, *ptM;
 
-  degL = DEG_PERM4(opL);
-  degR = DEG_TRANS4(opR);
-  degM = degL < degR ? degR : degL;
-  mod = NEW_TRANS4( degM);
+    degL = DEG_PERM4(opL);
+    degR = DEG_TRANS4(opR);
+    degM = degL < degR ? degR : degL;
+    mod = NEW_TRANS4(degM);
 
-  ptL = ADDR_PERM4(opL);
-  ptR = ADDR_TRANS4(opR);
-  ptM = ADDR_TRANS4(mod);
+    ptL = ADDR_PERM4(opL);
+    ptR = ADDR_TRANS4(opR);
+    ptM = ADDR_TRANS4(mod);
 
-  if (degL <= degR) {
-    for (p = 0; p < degL; p++) {
-      ptM[*(ptL++)] = *(ptR++);
+    if (degL <= degR) {
+        for (p = 0; p < degL; p++) {
+            ptM[*(ptL++)] = *(ptR++);
+        }
+        for (p = degL; p < degR; p++) {
+            ptM[p] = *(ptR++);
+        }
     }
-    for (p = degL; p < degR; p++) {
-      ptM[p] = *(ptR++);
+    else {
+        for (p = 0; p < degR; p++) {
+            ptM[*(ptL++)] = *(ptR++);
+        }
+        for (p = degR; p < degL; p++) {
+            ptM[*(ptL++)] = p;
+        }
     }
-  } else {
-    for (p = 0; p < degR; p++) {
-      ptM[*(ptL++) ] = *(ptR++);
-    }
-    for (p = degR; p < degL; p++) {
-      ptM[*(ptL++)] = p;
-    }
-  }
 
-  return mod;
+    return mod;
 }
 
 /*******************************************************************************
 ** Apply a transformation to a point
 *******************************************************************************/
 
-Obj PowIntTrans2 (Obj i, Obj f) {
-  Int img;
+Obj PowIntTrans2(Obj i, Obj f)
+{
+    Int img;
 
-  if (TNUM_OBJ(i) == T_INTPOS) {
-    return i;
-  }
+    if (TNUM_OBJ(i) == T_INTPOS) {
+        return i;
+    }
 
-  img = INT_INTOBJ(i);
+    img = INT_INTOBJ(i);
 
-  if (img <= 0) {
-    ErrorQuit("Tran. Operations: <point> must be a positive integer "
-              "(not %d)", (Int) img, 0L);
-  }
+    if (img <= 0) {
+        ErrorQuit("Tran. Operations: <point> must be a positive integer "
+                  "(not %d)",
+                  (Int)img, 0L);
+    }
 
-  if ((UInt) img <= DEG_TRANS2(f)) {
-    img = (ADDR_TRANS2(f))[img - 1] + 1;
-  }
+    if ((UInt)img <= DEG_TRANS2(f)) {
+        img = (ADDR_TRANS2(f))[img - 1] + 1;
+    }
 
-  return INTOBJ_INT(img);
+    return INTOBJ_INT(img);
 }
 
-Obj PowIntTrans4 (Obj i, Obj f) {
-  Int    img;
+Obj PowIntTrans4(Obj i, Obj f)
+{
+    Int img;
 
-  if (TNUM_OBJ(i) == T_INTPOS) {
-    return i;
-  }
+    if (TNUM_OBJ(i) == T_INTPOS) {
+        return i;
+    }
 
-  img = INT_INTOBJ(i);
+    img = INT_INTOBJ(i);
 
-  if (img <= 0) {
-    ErrorQuit("Tran. Operations: <point> must be a positive integer (not %d)",
-        (Int) img, 0L);
-  }
+    if (img <= 0) {
+        ErrorQuit(
+            "Tran. Operations: <point> must be a positive integer (not %d)",
+            (Int)img, 0L);
+    }
 
-  if ((UInt) img <= DEG_TRANS4(f)) {
-    img = (ADDR_TRANS4(f))[img - 1] + 1;
-  }
+    if ((UInt)img <= DEG_TRANS4(f)) {
+        img = (ADDR_TRANS4(f))[img - 1] + 1;
+    }
 
-  return INTOBJ_INT(img);
+    return INTOBJ_INT(img);
 }
 
 /*******************************************************************************
@@ -4841,151 +5209,161 @@ Obj PowIntTrans4 (Obj i, Obj f) {
 
 // OnSetsTrans for use in FuncOnSets.
 
-Obj OnSetsTrans (Obj set, Obj f){
-  UInt2  *ptf2;
-  UInt4  *ptf4;
-  UInt   deg;
-  Obj    *ptset, *ptres, tmp, res;
-  UInt   i, isint, k;
+Obj OnSetsTrans(Obj set, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    deg;
+    Obj *   ptset, *ptres, tmp, res;
+    UInt    i, isint, k;
 
-  res = NEW_PLIST(IS_MUTABLE_PLIST(set) ?
-                  T_PLIST : T_PLIST + IMMUTABLE, LEN_LIST(set));
+    res = NEW_PLIST(IS_MUTABLE_PLIST(set) ? T_PLIST : T_PLIST + IMMUTABLE,
+                    LEN_LIST(set));
 
-  ADDR_OBJ(res)[0] = ADDR_OBJ(set)[0];
+    ADDR_OBJ(res)[0] = ADDR_OBJ(set)[0];
 
-  ptset = ADDR_OBJ(set) + LEN_LIST(set);
-  ptres = ADDR_OBJ(res) + LEN_LIST(set);
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    deg = DEG_TRANS2(f);
-    // loop over the entries of the tuple
-    isint = 1;
-    for (i = LEN_LIST(set); 1 <= i; i--, ptset--, ptres--) {
-      if (IS_INTOBJ(*ptset) && 0 < INT_INTOBJ(*ptset)) {
-        k = INT_INTOBJ(*ptset);
-        if (k <= deg) {
-          k = ptf2[k - 1] + 1;
-        }
-        *ptres = INTOBJ_INT(k);
-      } else {
-        isint = 0;
-        tmp = POW(*ptset, f);
-        ptset = ADDR_OBJ(set) + i;
-        ptres = ADDR_OBJ(res) + i;
+    ptset = ADDR_OBJ(set) + LEN_LIST(set);
+    ptres = ADDR_OBJ(res) + LEN_LIST(set);
+    if (TNUM_OBJ(f) == T_TRANS2) {
         ptf2 = ADDR_TRANS2(f);
-        *ptres = tmp;
-        CHANGED_BAG(res);
-      }
-    }
-  } else {
-    ptf4 = ADDR_TRANS4(f);
-    deg = DEG_TRANS4(f);
-
-    // loop over the entries of the tuple
-    isint = 1;
-    for (i = LEN_LIST(set) ; 1 <= i; i--, ptset--, ptres--) {
-      if (IS_INTOBJ(*ptset) && 0 < INT_INTOBJ(*ptset)) {
-        k = INT_INTOBJ(*ptset);
-        if (k <= deg) {
-          k = ptf4[k - 1] + 1;
+        deg = DEG_TRANS2(f);
+        // loop over the entries of the tuple
+        isint = 1;
+        for (i = LEN_LIST(set); 1 <= i; i--, ptset--, ptres--) {
+            if (IS_INTOBJ(*ptset) && 0 < INT_INTOBJ(*ptset)) {
+                k = INT_INTOBJ(*ptset);
+                if (k <= deg) {
+                    k = ptf2[k - 1] + 1;
+                }
+                *ptres = INTOBJ_INT(k);
+            }
+            else {
+                isint = 0;
+                tmp = POW(*ptset, f);
+                ptset = ADDR_OBJ(set) + i;
+                ptres = ADDR_OBJ(res) + i;
+                ptf2 = ADDR_TRANS2(f);
+                *ptres = tmp;
+                CHANGED_BAG(res);
+            }
         }
-        *ptres = INTOBJ_INT(k);
-      } else {
-        isint = 0;
-        tmp = POW(*ptset, f);
-        ptset = ADDR_OBJ(set) + i;
-        ptres = ADDR_OBJ(res) + i;
-        ptf4 = ADDR_TRANS4(f);
-        *ptres = tmp;
-        CHANGED_BAG(res);
-      }
     }
-  }
+    else {
+        ptf4 = ADDR_TRANS4(f);
+        deg = DEG_TRANS4(f);
 
-  // sort the result and remove dups
-  if (isint) {
-    SORT_PLIST_CYC(res);
-    REMOVE_DUPS_PLIST_CYC(res);
+        // loop over the entries of the tuple
+        isint = 1;
+        for (i = LEN_LIST(set); 1 <= i; i--, ptset--, ptres--) {
+            if (IS_INTOBJ(*ptset) && 0 < INT_INTOBJ(*ptset)) {
+                k = INT_INTOBJ(*ptset);
+                if (k <= deg) {
+                    k = ptf4[k - 1] + 1;
+                }
+                *ptres = INTOBJ_INT(k);
+            }
+            else {
+                isint = 0;
+                tmp = POW(*ptset, f);
+                ptset = ADDR_OBJ(set) + i;
+                ptres = ADDR_OBJ(res) + i;
+                ptf4 = ADDR_TRANS4(f);
+                *ptres = tmp;
+                CHANGED_BAG(res);
+            }
+        }
+    }
 
-    RetypeBag(res, IS_MUTABLE_PLIST(set)
-                   ? T_PLIST_CYC_SSORT : T_PLIST_CYC_SSORT + IMMUTABLE);
+    // sort the result and remove dups
+    if (isint) {
+        SORT_PLIST_CYC(res);
+        REMOVE_DUPS_PLIST_CYC(res);
 
-  } else {
-    SortDensePlist(res);
-    RemoveDupsDensePlist(res);
-  }
+        RetypeBag(res, IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
+                                             : T_PLIST_CYC_SSORT + IMMUTABLE);
+    }
+    else {
+        SortDensePlist(res);
+        RemoveDupsDensePlist(res);
+    }
 
-  return res;
+    return res;
 }
 
 // OnTuplesTrans for use in FuncOnTuples
 
-Obj OnTuplesTrans (Obj tup, Obj f) {
-  UInt2  *ptf2;
-  UInt4  *ptf4;
-  UInt   deg, i, k;
-  Obj    *pttup, *ptres, res, tmp;
+Obj OnTuplesTrans(Obj tup, Obj f)
+{
+    UInt2 * ptf2;
+    UInt4 * ptf4;
+    UInt    deg, i, k;
+    Obj *   pttup, *ptres, res, tmp;
 
-  res = NEW_PLIST(IS_MUTABLE_PLIST(tup) ?
-                  T_PLIST : T_PLIST + IMMUTABLE, LEN_LIST(tup));
+    res = NEW_PLIST(IS_MUTABLE_PLIST(tup) ? T_PLIST : T_PLIST + IMMUTABLE,
+                    LEN_LIST(tup));
 
-  ADDR_OBJ(res)[0] = ADDR_OBJ(tup)[0];
+    ADDR_OBJ(res)[0] = ADDR_OBJ(tup)[0];
 
-  pttup = ADDR_OBJ(tup) + LEN_LIST(tup);
-  ptres = ADDR_OBJ(res) + LEN_LIST(tup);
+    pttup = ADDR_OBJ(tup) + LEN_LIST(tup);
+    ptres = ADDR_OBJ(res) + LEN_LIST(tup);
 
-  if (TNUM_OBJ(f) == T_TRANS2) {
-    ptf2 = ADDR_TRANS2(f);
-    deg = DEG_TRANS2(f);
-
-    // loop over the entries of the tuple
-    for (i = LEN_LIST(tup); 1 <= i; i--, pttup--, ptres--) {
-      if (IS_INTOBJ(*pttup) && 0 < INT_INTOBJ(*pttup)) {
-        k = INT_INTOBJ(*pttup);
-        if (k <= deg) {
-          k = ptf2[k - 1] + 1;
-        }
-        *ptres = INTOBJ_INT(k);
-      } else {
-        if (*pttup == NULL) {
-          ErrorQuit("OnTuples for transformation: list must not contain holes",
-                    0L, 0L);
-        }
-        tmp = POW(*pttup, f);
-        pttup = ADDR_OBJ(tup) + i;
-        ptres = ADDR_OBJ(res) + i;
+    if (TNUM_OBJ(f) == T_TRANS2) {
         ptf2 = ADDR_TRANS2(f);
-        *ptres = tmp;
-        CHANGED_BAG(res);
-      }
-    }
-  } else {
-    ptf4 = ADDR_TRANS4(f);
-    deg = DEG_TRANS4(f);
+        deg = DEG_TRANS2(f);
 
-    // loop over the entries of the tuple
-    for (i = LEN_LIST(tup); 1 <= i; i--, pttup--, ptres--) {
-      if (IS_INTOBJ(*pttup) && 0 < INT_INTOBJ(*pttup)) {
-        k = INT_INTOBJ(*pttup);
-        if (k <= deg) {
-          k = ptf4[k - 1] + 1;
+        // loop over the entries of the tuple
+        for (i = LEN_LIST(tup); 1 <= i; i--, pttup--, ptres--) {
+            if (IS_INTOBJ(*pttup) && 0 < INT_INTOBJ(*pttup)) {
+                k = INT_INTOBJ(*pttup);
+                if (k <= deg) {
+                    k = ptf2[k - 1] + 1;
+                }
+                *ptres = INTOBJ_INT(k);
+            }
+            else {
+                if (*pttup == NULL) {
+                    ErrorQuit("OnTuples for transformation: list must not "
+                              "contain holes",
+                              0L, 0L);
+                }
+                tmp = POW(*pttup, f);
+                pttup = ADDR_OBJ(tup) + i;
+                ptres = ADDR_OBJ(res) + i;
+                ptf2 = ADDR_TRANS2(f);
+                *ptres = tmp;
+                CHANGED_BAG(res);
+            }
         }
-        *ptres = INTOBJ_INT(k);
-      } else {
-        if (*pttup == NULL) {
-          ErrorQuit("OnTuples for transformation: list must not contain holes",
-                    0L, 0L);
-        }
-        tmp = POW(*pttup, f);
-        pttup = ADDR_OBJ(tup) + i;
-        ptres = ADDR_OBJ(res) + i;
-        ptf4 = ADDR_TRANS4(f);
-        *ptres = tmp;
-        CHANGED_BAG(res);
-      }
     }
-  }
-  return res;
+    else {
+        ptf4 = ADDR_TRANS4(f);
+        deg = DEG_TRANS4(f);
+
+        // loop over the entries of the tuple
+        for (i = LEN_LIST(tup); 1 <= i; i--, pttup--, ptres--) {
+            if (IS_INTOBJ(*pttup) && 0 < INT_INTOBJ(*pttup)) {
+                k = INT_INTOBJ(*pttup);
+                if (k <= deg) {
+                    k = ptf4[k - 1] + 1;
+                }
+                *ptres = INTOBJ_INT(k);
+            }
+            else {
+                if (*pttup == NULL) {
+                    ErrorQuit("OnTuples for transformation: list must not "
+                              "contain holes",
+                              0L, 0L);
+                }
+                tmp = POW(*pttup, f);
+                pttup = ADDR_OBJ(tup) + i;
+                ptres = ADDR_OBJ(res) + i;
+                ptf4 = ADDR_TRANS4(f);
+                *ptres = tmp;
+                CHANGED_BAG(res);
+            }
+        }
+    }
+    return res;
 }
 
 /*******************************************************************************
@@ -4993,80 +5371,90 @@ Obj OnTuplesTrans (Obj tup, Obj f) {
 *******************************************************************************/
 
 // Save and load
-void SaveTrans2 (Obj f) {
-  UInt2   *ptr;
-  UInt    len, i;
-  ptr = ADDR_TRANS2(f); // save the image list
-  len = DEG_TRANS2(f);
-  for (i = 0; i < len; i++) {
-    SaveUInt2(*ptr++);
-  }
+void SaveTrans2(Obj f)
+{
+    UInt2 * ptr;
+    UInt    len, i;
+    ptr = ADDR_TRANS2(f);    // save the image list
+    len = DEG_TRANS2(f);
+    for (i = 0; i < len; i++) {
+        SaveUInt2(*ptr++);
+    }
 }
 
-void LoadTrans2 (Obj f) {
-  UInt2   *ptr;
-  UInt    len, i;
-  len = DEG_TRANS2(f);
-  ptr = ADDR_TRANS2(f);
-  for (i = 0; i < len; i++) {
-    *ptr++ = LoadUInt2();
-  }
+void LoadTrans2(Obj f)
+{
+    UInt2 * ptr;
+    UInt    len, i;
+    len = DEG_TRANS2(f);
+    ptr = ADDR_TRANS2(f);
+    for (i = 0; i < len; i++) {
+        *ptr++ = LoadUInt2();
+    }
 }
 
-void SaveTrans4 (Obj f) {
-  UInt4   *ptr;
-  UInt    len, i;
-  ptr = ADDR_TRANS4(f); // save the image list
-  len = DEG_TRANS4(f);
-  for (i = 0; i < len; i++) {
-    SaveUInt4(*ptr++);
-  }
+void SaveTrans4(Obj f)
+{
+    UInt4 * ptr;
+    UInt    len, i;
+    ptr = ADDR_TRANS4(f);    // save the image list
+    len = DEG_TRANS4(f);
+    for (i = 0; i < len; i++) {
+        SaveUInt4(*ptr++);
+    }
 }
 
-void LoadTrans4 (Obj f) {
-  UInt4   *ptr;
-  UInt    len, i;
-  len = DEG_TRANS4(f);
-  ptr = ADDR_TRANS4(f);
-  for (i = 0; i < len; i++) {
-    *ptr++=LoadUInt4();
-  }
+void LoadTrans4(Obj f)
+{
+    UInt4 * ptr;
+    UInt    len, i;
+    len = DEG_TRANS4(f);
+    ptr = ADDR_TRANS4(f);
+    for (i = 0; i < len; i++) {
+        *ptr++ = LoadUInt4();
+    }
 }
 
 Obj TYPE_TRANS2;
 
-Obj TypeTrans2 (Obj f) {
-  return TYPE_TRANS2;
+Obj TypeTrans2(Obj f)
+{
+    return TYPE_TRANS2;
 }
 
 Obj TYPE_TRANS4;
 
-Obj TypeTrans4 (Obj f) {
-  return TYPE_TRANS4;
+Obj TypeTrans4(Obj f)
+{
+    return TYPE_TRANS4;
 }
 
 Obj IsTransFilt;
 
-Obj IsTransHandler (Obj self, Obj val) {
-  if (TNUM_OBJ(val) == T_TRANS2 || TNUM_OBJ(val) == T_TRANS4) {
-    return True;
-  } else if (TNUM_OBJ(val) < FIRST_EXTERNAL_TNUM) {
-    return False;
-  } else {
-    return DoFilter( self, val);
-  }
+Obj IsTransHandler(Obj self, Obj val)
+{
+    if (TNUM_OBJ(val) == T_TRANS2 || TNUM_OBJ(val) == T_TRANS4) {
+        return True;
+    }
+    else if (TNUM_OBJ(val) < FIRST_EXTERNAL_TNUM) {
+        return False;
+    }
+    else {
+        return DoFilter(self, val);
+    }
 }
 
-/*F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * */
+/*F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * *
+ */
 
 /****************************************************************************
 **
 *V  GVarFilts . . . . . . . . . . . . . . . . . . . list of filters to export
 */
-static StructGVarFilt GVarFilts [] = {
+static StructGVarFilt GVarFilts[] = {
 
-    { "IS_TRANS", "obj", &IsTransFilt,
-      IsTransHandler, "src/trans.c:IS_TRANS" },
+    { "IS_TRANS", "obj", &IsTransFilt, IsTransHandler,
+      "src/trans.c:IS_TRANS" },
 
     { 0, 0, 0, 0, 0 }
 
@@ -5075,317 +5463,263 @@ static StructGVarFilt GVarFilts [] = {
 /******************************************************************************
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
-static StructGVarFunc GVarFuncs [] = {
+static StructGVarFunc GVarFuncs[] = {
 
-/*  { "HAS_KER_TRANS", 1, "f",
-     FuncHAS_KER_TRANS,
-    "src/TRANS.c:FuncHAS_KER_TRANS" },
+    /*  { "HAS_KER_TRANS", 1, "f",
+         FuncHAS_KER_TRANS,
+        "src/TRANS.c:FuncHAS_KER_TRANS" },
 
-  { "HAS_IMG_TRANS", 1, "f",
-     FuncHAS_IMG_TRANS,
-    "src/TRANS.c:FuncHAS_IMG_TRANS" },
+      { "HAS_IMG_TRANS", 1, "f",
+         FuncHAS_IMG_TRANS,
+        "src/TRANS.c:FuncHAS_IMG_TRANS" },
 
-  { "INT_DEG_TRANS", 1, "f",
-     FuncINT_DEG_TRANS,
-    "src/TRANS.c:FuncINT_DEG_TRANS" },
-    */
+      { "INT_DEG_TRANS", 1, "f",
+         FuncINT_DEG_TRANS,
+        "src/TRANS.c:FuncINT_DEG_TRANS" },
+        */
 
-  { "TransformationNC", 1, "list",
-     FuncTransformationNC,
-    "src/trans.c:FuncTransformationNC" },
+    { "TransformationNC", 1, "list", FuncTransformationNC,
+      "src/trans.c:FuncTransformationNC" },
 
-  { "TransformationListListNC", 2, "src, ran",
-     FuncTransformationListListNC,
-    "src/trans.c:FuncTransformationListListNC" },
+    { "TransformationListListNC", 2, "src, ran", FuncTransformationListListNC,
+      "src/trans.c:FuncTransformationListListNC" },
 
-  { "DegreeOfTransformation", 1, "f",
-     FuncDegreeOfTransformation,
-    "src/trans.c:FuncDegreeOfTransformation" },
+    { "DegreeOfTransformation", 1, "f", FuncDegreeOfTransformation,
+      "src/trans.c:FuncDegreeOfTransformation" },
 
-  { "HASH_FUNC_FOR_TRANS", 2, "f, data",
-     FuncHASH_FUNC_FOR_TRANS,
-    "src/trans.c:FuncHASH_FUNC_FOR_TRANS" },
+    { "HASH_FUNC_FOR_TRANS", 2, "f, data", FuncHASH_FUNC_FOR_TRANS,
+      "src/trans.c:FuncHASH_FUNC_FOR_TRANS" },
 
-  { "RANK_TRANS", 1, "f",
-     FuncRANK_TRANS,
-    "src/trans.c:FuncRANK_TRANS" },
+    { "RANK_TRANS", 1, "f", FuncRANK_TRANS, "src/trans.c:FuncRANK_TRANS" },
 
-  { "RANK_TRANS_INT", 2, "f, n",
-     FuncRANK_TRANS_INT,
-    "src/trans.c:FuncRANK_TRANS_INT" },
+    { "RANK_TRANS_INT", 2, "f, n", FuncRANK_TRANS_INT,
+      "src/trans.c:FuncRANK_TRANS_INT" },
 
-  { "RANK_TRANS_LIST", 2, "f, list",
-     FuncRANK_TRANS_LIST,
-    "src/trans.c:FuncRANK_TRANS_LIST" },
+    { "RANK_TRANS_LIST", 2, "f, list", FuncRANK_TRANS_LIST,
+      "src/trans.c:FuncRANK_TRANS_LIST" },
 
-  { "LARGEST_MOVED_PT_TRANS", 1, "f",
-     FuncLARGEST_MOVED_PT_TRANS,
-    "src/trans.c:FuncLARGEST_MOVED_PT_TRANS" },
+    { "LARGEST_MOVED_PT_TRANS", 1, "f", FuncLARGEST_MOVED_PT_TRANS,
+      "src/trans.c:FuncLARGEST_MOVED_PT_TRANS" },
 
-  { "LARGEST_IMAGE_PT", 1, "f",
-     FuncLARGEST_IMAGE_PT,
-    "src/trans.c:FuncLARGEST_IMAGE_PT" },
+    { "LARGEST_IMAGE_PT", 1, "f", FuncLARGEST_IMAGE_PT,
+      "src/trans.c:FuncLARGEST_IMAGE_PT" },
 
-  { "SMALLEST_MOVED_PT_TRANS", 1, "f",
-     FuncSMALLEST_MOVED_PT_TRANS,
-    "src/trans.c:FuncSMALLEST_MOVED_PT_TRANS" },
+    { "SMALLEST_MOVED_PT_TRANS", 1, "f", FuncSMALLEST_MOVED_PT_TRANS,
+      "src/trans.c:FuncSMALLEST_MOVED_PT_TRANS" },
 
-  { "SMALLEST_IMAGE_PT", 1, "f",
-     FuncSMALLEST_IMAGE_PT,
-    "src/trans.c:FuncSMALLEST_IMAGE_PT" },
+    { "SMALLEST_IMAGE_PT", 1, "f", FuncSMALLEST_IMAGE_PT,
+      "src/trans.c:FuncSMALLEST_IMAGE_PT" },
 
-  { "NR_MOVED_PTS_TRANS", 1, "f",
-     FuncNR_MOVED_PTS_TRANS,
-    "src/trans.c:FuncNR_MOVED_PTS_TRANS" },
+    { "NR_MOVED_PTS_TRANS", 1, "f", FuncNR_MOVED_PTS_TRANS,
+      "src/trans.c:FuncNR_MOVED_PTS_TRANS" },
 
-  { "MOVED_PTS_TRANS", 1, "f",
-     FuncMOVED_PTS_TRANS,
-    "src/trans.c:FuncMOVED_PTS_TRANS" },
+    { "MOVED_PTS_TRANS", 1, "f", FuncMOVED_PTS_TRANS,
+      "src/trans.c:FuncMOVED_PTS_TRANS" },
 
-  { "IMAGE_LIST_TRANS_INT", 2, "f, n",
-     FuncIMAGE_LIST_TRANS_INT,
-    "src/trans.c:FuncIMAGE_LIST_TRANS_INT" },
+    { "IMAGE_LIST_TRANS_INT", 2, "f, n", FuncIMAGE_LIST_TRANS_INT,
+      "src/trans.c:FuncIMAGE_LIST_TRANS_INT" },
 
-  { "FLAT_KERNEL_TRANS", 1, "f",
-     FuncFLAT_KERNEL_TRANS,
-    "src/trans.c:FuncFLAT_KERNEL_TRANS" },
+    { "FLAT_KERNEL_TRANS", 1, "f", FuncFLAT_KERNEL_TRANS,
+      "src/trans.c:FuncFLAT_KERNEL_TRANS" },
 
-  { "FLAT_KERNEL_TRANS_INT", 2, "f, n",
-     FuncFLAT_KERNEL_TRANS_INT,
-    "src/trans.c:FuncFLAT_KERNEL_TRANS_INT" },
+    { "FLAT_KERNEL_TRANS_INT", 2, "f, n", FuncFLAT_KERNEL_TRANS_INT,
+      "src/trans.c:FuncFLAT_KERNEL_TRANS_INT" },
 
-  { "IMAGE_SET_TRANS", 1, "f",
-     FuncIMAGE_SET_TRANS,
-    "src/trans.c:FuncIMAGE_SET_TRANS" },
+    { "IMAGE_SET_TRANS", 1, "f", FuncIMAGE_SET_TRANS,
+      "src/trans.c:FuncIMAGE_SET_TRANS" },
 
-  { "UNSORTED_IMAGE_SET_TRANS", 1, "f",
-     FuncUNSORTED_IMAGE_SET_TRANS,
-    "src/trans.c:FuncUNSORTED_IMAGE_SET_TRANS" },
+    { "UNSORTED_IMAGE_SET_TRANS", 1, "f", FuncUNSORTED_IMAGE_SET_TRANS,
+      "src/trans.c:FuncUNSORTED_IMAGE_SET_TRANS" },
 
-  { "IMAGE_SET_TRANS_INT", 2, "f, n",
-     FuncIMAGE_SET_TRANS_INT,
-    "src/trans.c:FuncIMAGE_SET_TRANS_INT" },
+    { "IMAGE_SET_TRANS_INT", 2, "f, n", FuncIMAGE_SET_TRANS_INT,
+      "src/trans.c:FuncIMAGE_SET_TRANS_INT" },
 
-  { "KERNEL_TRANS", 2, "f, n",
-     FuncKERNEL_TRANS,
-    "src/trans.c:FuncKERNEL_TRANS" },
+    { "KERNEL_TRANS", 2, "f, n", FuncKERNEL_TRANS,
+      "src/trans.c:FuncKERNEL_TRANS" },
 
-  { "PREIMAGES_TRANS_INT", 2, "f, pt",
-     FuncPREIMAGES_TRANS_INT,
-    "src/trans.c:FuncPREIMAGES_TRANS_INT" },
+    { "PREIMAGES_TRANS_INT", 2, "f, pt", FuncPREIMAGES_TRANS_INT,
+      "src/trans.c:FuncPREIMAGES_TRANS_INT" },
 
-  { "AS_TRANS_PERM", 1, "f",
-     FuncAS_TRANS_PERM,
-    "src/trans.c:FuncAS_TRANS_PERM" },
+    { "AS_TRANS_PERM", 1, "f", FuncAS_TRANS_PERM,
+      "src/trans.c:FuncAS_TRANS_PERM" },
 
-  { "AS_TRANS_PERM_INT", 2, "f, n",
-     FuncAS_TRANS_PERM_INT,
-    "src/trans.c:FuncAS_TRANS_PERM_INT" },
+    { "AS_TRANS_PERM_INT", 2, "f, n", FuncAS_TRANS_PERM_INT,
+      "src/trans.c:FuncAS_TRANS_PERM_INT" },
 
-  { "AS_PERM_TRANS", 1, "f",
-     FuncAS_PERM_TRANS,
-    "src/trans.c:FuncAS_PERM_TRANS" },
+    { "AS_PERM_TRANS", 1, "f", FuncAS_PERM_TRANS,
+      "src/trans.c:FuncAS_PERM_TRANS" },
 
-  { "PermutationOfImage", 1, "f",
-     FuncPermutationOfImage,
-    "src/trans.c:FuncPermutationOfImage" },
+    { "PermutationOfImage", 1, "f", FuncPermutationOfImage,
+      "src/trans.c:FuncPermutationOfImage" },
 
-  { "RestrictedTransformation", 2, "f, list",
-     FuncRestrictedTransformation,
-    "src/trans.c:FuncRestrictedTransformation" },
+    { "RestrictedTransformation", 2, "f, list", FuncRestrictedTransformation,
+      "src/trans.c:FuncRestrictedTransformation" },
 
-  { "AS_TRANS_TRANS", 2, "f, m",
-     FuncAS_TRANS_TRANS,
-    "src/trans.c:FuncAS_TRANS_TRANS" },
+    { "AS_TRANS_TRANS", 2, "f, m", FuncAS_TRANS_TRANS,
+      "src/trans.c:FuncAS_TRANS_TRANS" },
 
-  { "TRIM_TRANS", 2, "f, m",
-     FuncTRIM_TRANS,
-    "src/trans.c:FuncTRIM_TRANS" },
+    { "TRIM_TRANS", 2, "f, m", FuncTRIM_TRANS, "src/trans.c:FuncTRIM_TRANS" },
 
-  { "IsInjectiveListTrans", 2, "t, l",
-     FuncIsInjectiveListTrans,
-    "src/trans.c:FuncIsInjectiveListTrans" },
+    { "IsInjectiveListTrans", 2, "t, l", FuncIsInjectiveListTrans,
+      "src/trans.c:FuncIsInjectiveListTrans" },
 
-  { "PermLeftQuoTransformationNC", 2, "f, g",
-     FuncPermLeftQuoTransformationNC,
-    "src/trans.c:FuncPermLeftQuoTransformationNC" },
+    { "PermLeftQuoTransformationNC", 2, "f, g",
+      FuncPermLeftQuoTransformationNC,
+      "src/trans.c:FuncPermLeftQuoTransformationNC" },
 
-  { "TRANS_IMG_KER_NC", 2, "img, ker",
-     FuncTRANS_IMG_KER_NC,
-    "src/trans.c:FuncTRANS_IMG_KER_NC" },
+    { "TRANS_IMG_KER_NC", 2, "img, ker", FuncTRANS_IMG_KER_NC,
+      "src/trans.c:FuncTRANS_IMG_KER_NC" },
 
-  { "IDEM_IMG_KER_NC", 2, "img, ker",
-     FuncIDEM_IMG_KER_NC,
-    "src/trans.c:FuncIDEM_IMG_KER_NC" },
+    { "IDEM_IMG_KER_NC", 2, "img, ker", FuncIDEM_IMG_KER_NC,
+      "src/trans.c:FuncIDEM_IMG_KER_NC" },
 
-  { "InverseOfTransformation", 1, "f",
-     FuncInverseOfTransformation,
-    "src/trans.c:FuncInverseOfTransformation" },
+    { "InverseOfTransformation", 1, "f", FuncInverseOfTransformation,
+      "src/trans.c:FuncInverseOfTransformation" },
 
-  { "INV_LIST_TRANS", 2, "list, f",
-     FuncINV_LIST_TRANS,
-    "src/trans.c:FuncINV_LIST_TRANS" },
+    { "INV_LIST_TRANS", 2, "list, f", FuncINV_LIST_TRANS,
+      "src/trans.c:FuncINV_LIST_TRANS" },
 
-  { "TRANS_IMG_CONJ", 2, "f, g",
-     FuncTRANS_IMG_CONJ,
-    "src/trans.c:FuncTRANS_IMG_CONJ" },
+    { "TRANS_IMG_CONJ", 2, "f, g", FuncTRANS_IMG_CONJ,
+      "src/trans.c:FuncTRANS_IMG_CONJ" },
 
-  { "IndexPeriodOfTransformation", 1, "f",
-     FuncIndexPeriodOfTransformation,
-    "src/trans.c:FuncIndexPeriodOfTransformation" },
+    { "IndexPeriodOfTransformation", 1, "f", FuncIndexPeriodOfTransformation,
+      "src/trans.c:FuncIndexPeriodOfTransformation" },
 
-  { "SMALLEST_IDEM_POW_TRANS", 1, "f",
-     FuncSMALLEST_IDEM_POW_TRANS,
-    "src/trans.c:FuncSMALLEST_IDEM_POW_TRANS" },
+    { "SMALLEST_IDEM_POW_TRANS", 1, "f", FuncSMALLEST_IDEM_POW_TRANS,
+      "src/trans.c:FuncSMALLEST_IDEM_POW_TRANS" },
 
-  { "POW_KER_PERM", 2, "ker, f",
-     FuncPOW_KER_PERM,
-    "src/trans.c:FuncPOW_KER_PERM" },
+    { "POW_KER_PERM", 2, "ker, f", FuncPOW_KER_PERM,
+      "src/trans.c:FuncPOW_KER_PERM" },
 
-  { "ON_KERNEL_ANTI_ACTION", 3, "ker, f, n",
-     FuncON_KERNEL_ANTI_ACTION,
-    "src/trans.c:FuncON_KERNEL_ANTI_ACTION" },
+    { "ON_KERNEL_ANTI_ACTION", 3, "ker, f, n", FuncON_KERNEL_ANTI_ACTION,
+      "src/trans.c:FuncON_KERNEL_ANTI_ACTION" },
 
-  { "INV_KER_TRANS", 2, "ker, f",
-     FuncINV_KER_TRANS,
-    "src/trans.c:FuncINV_KER_TRANS" },
+    { "INV_KER_TRANS", 2, "ker, f", FuncINV_KER_TRANS,
+      "src/trans.c:FuncINV_KER_TRANS" },
 
-  { "IS_IDEM_TRANS", 1, "f",
-    FuncIS_IDEM_TRANS,
-    "src/trans.c:FuncIS_IDEM_TRANS" },
+    { "IS_IDEM_TRANS", 1, "f", FuncIS_IDEM_TRANS,
+      "src/trans.c:FuncIS_IDEM_TRANS" },
 
-  { "IS_ID_TRANS", 1, "f",
-    FuncIS_ID_TRANS,
-    "src/trans.c:FuncIS_ID_TRANS" },
+    { "IS_ID_TRANS", 1, "f", FuncIS_ID_TRANS, "src/trans.c:FuncIS_ID_TRANS" },
 
-  { "COMPONENT_REPS_TRANS", 1, "f",
-    FuncCOMPONENT_REPS_TRANS,
-    "src/trans.c:FuncCOMPONENT_REPS_TRANS" },
+    { "COMPONENT_REPS_TRANS", 1, "f", FuncCOMPONENT_REPS_TRANS,
+      "src/trans.c:FuncCOMPONENT_REPS_TRANS" },
 
-  { "NR_COMPONENTS_TRANS", 1, "f",
-    FuncNR_COMPONENTS_TRANS,
-    "src/trans.c:FuncNR_COMPONENTS_TRANS" },
+    { "NR_COMPONENTS_TRANS", 1, "f", FuncNR_COMPONENTS_TRANS,
+      "src/trans.c:FuncNR_COMPONENTS_TRANS" },
 
-  { "COMPONENTS_TRANS", 1, "f",
-    FuncCOMPONENTS_TRANS,
-    "src/trans.c:FuncCOMPONENTS_TRANS" },
+    { "COMPONENTS_TRANS", 1, "f", FuncCOMPONENTS_TRANS,
+      "src/trans.c:FuncCOMPONENTS_TRANS" },
 
-  { "COMPONENT_TRANS_INT", 2, "f, pt",
-    FuncCOMPONENT_TRANS_INT,
-    "src/trans.c:FuncCOMPONENT_TRANS_INT" },
+    { "COMPONENT_TRANS_INT", 2, "f, pt", FuncCOMPONENT_TRANS_INT,
+      "src/trans.c:FuncCOMPONENT_TRANS_INT" },
 
-  { "CYCLE_TRANS_INT", 2, "f, pt",
-    FuncCYCLE_TRANS_INT,
-    "src/trans.c:FuncCYCLE_TRANS_INT" },
+    { "CYCLE_TRANS_INT", 2, "f, pt", FuncCYCLE_TRANS_INT,
+      "src/trans.c:FuncCYCLE_TRANS_INT" },
 
-  { "CYCLES_TRANS", 1, "f",
-    FuncCYCLES_TRANS,
-    "src/trans.c:FuncCYCLES_TRANS" },
+    { "CYCLES_TRANS", 1, "f", FuncCYCLES_TRANS,
+      "src/trans.c:FuncCYCLES_TRANS" },
 
-  { "CYCLES_TRANS_LIST", 2, "f, pt",
-    FuncCYCLES_TRANS_LIST,
-    "src/trans.c:FuncCYCLES_TRANS_LIST" },
+    { "CYCLES_TRANS_LIST", 2, "f, pt", FuncCYCLES_TRANS_LIST,
+      "src/trans.c:FuncCYCLES_TRANS_LIST" },
 
-  { "LEFT_ONE_TRANS", 1, "f",
-    FuncLEFT_ONE_TRANS,
-    "src/trans.c:FuncLEFT_ONE_TRANS" },
+    { "LEFT_ONE_TRANS", 1, "f", FuncLEFT_ONE_TRANS,
+      "src/trans.c:FuncLEFT_ONE_TRANS" },
 
-  { "RIGHT_ONE_TRANS", 1, "f",
-    FuncRIGHT_ONE_TRANS,
-    "src/trans.c:FuncRIGHT_ONE_TRANS" },
+    { "RIGHT_ONE_TRANS", 1, "f", FuncRIGHT_ONE_TRANS,
+      "src/trans.c:FuncRIGHT_ONE_TRANS" },
 
-  { "OnPosIntSetsTrans", 3, "set, f, n",
-    FuncOnPosIntSetsTrans,
-    "src/trans.c:FuncOnPosIntSetsTrans" },
+    { "OnPosIntSetsTrans", 3, "set, f, n", FuncOnPosIntSetsTrans,
+      "src/trans.c:FuncOnPosIntSetsTrans" },
 
-  { 0, 0, 0, 0, 0 }
+    { 0, 0, 0, 0, 0 }
 
 };
 /******************************************************************************
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
 */
-static Int InitKernel ( StructInitInfo *module )
+static Int InitKernel(StructInitInfo * module)
 {
 
     /* install the marking functions                                       */
-    InfoBags[ T_TRANS2 ].name = "transformation (small)";
-    InfoBags[ T_TRANS4 ].name = "transformation (large)";
-    InitMarkFuncBags( T_TRANS2, MarkThreeSubBags );
-    InitMarkFuncBags( T_TRANS4, MarkThreeSubBags );
+    InfoBags[T_TRANS2].name = "transformation (small)";
+    InfoBags[T_TRANS4].name = "transformation (large)";
+    InitMarkFuncBags(T_TRANS2, MarkThreeSubBags);
+    InitMarkFuncBags(T_TRANS4, MarkThreeSubBags);
 
-    MakeBagTypePublic( T_TRANS2);
-    MakeBagTypePublic( T_TRANS4);
+    MakeBagTypePublic(T_TRANS2);
+    MakeBagTypePublic(T_TRANS4);
 
     /* install the type functions                                          */
-    ImportGVarFromLibrary( "TYPE_TRANS2", &TYPE_TRANS2 );
-    ImportGVarFromLibrary( "TYPE_TRANS4", &TYPE_TRANS4 );
+    ImportGVarFromLibrary("TYPE_TRANS2", &TYPE_TRANS2);
+    ImportGVarFromLibrary("TYPE_TRANS4", &TYPE_TRANS4);
 
-    TypeObjFuncs[ T_TRANS2 ] = TypeTrans2;
-    TypeObjFuncs[ T_TRANS4 ] = TypeTrans4;
+    TypeObjFuncs[T_TRANS2] = TypeTrans2;
+    TypeObjFuncs[T_TRANS4] = TypeTrans4;
 
     /* init filters and functions                                          */
-    InitHdlrFiltsFromTable( GVarFilts );
-    InitHdlrFuncsFromTable( GVarFuncs );
+    InitHdlrFiltsFromTable(GVarFilts);
+    InitHdlrFuncsFromTable(GVarFuncs);
 
-    /* make the buffer bag                                                 */
+/* make the buffer bag                                                 */
 #ifndef HPCGAP
-     InitGlobalBag( &TmpTrans, "src/trans.c:TmpTrans" );
+    InitGlobalBag(&TmpTrans, "src/trans.c:TmpTrans");
 #endif
 
     // make the identity trans
-    InitGlobalBag( &IdentityTrans, "src/trans.c:IdentityTrans" );
+    InitGlobalBag(&IdentityTrans, "src/trans.c:IdentityTrans");
 
     /* install the saving functions */
-    SaveObjFuncs[ T_TRANS2 ] = SaveTrans2;
-    LoadObjFuncs[ T_TRANS2 ] = LoadTrans2;
-    SaveObjFuncs[ T_TRANS4 ] = SaveTrans4;
-    LoadObjFuncs[ T_TRANS4 ] = LoadTrans4;
+    SaveObjFuncs[T_TRANS2] = SaveTrans2;
+    LoadObjFuncs[T_TRANS2] = LoadTrans2;
+    SaveObjFuncs[T_TRANS4] = SaveTrans4;
+    LoadObjFuncs[T_TRANS4] = LoadTrans4;
 
     /* install the comparison methods                                      */
-    EqFuncs  [ T_TRANS2  ][ T_TRANS2  ] = EqTrans22;
-    EqFuncs  [ T_TRANS2  ][ T_TRANS4  ] = EqTrans24;
-    EqFuncs  [ T_TRANS4  ][ T_TRANS2  ] = EqTrans42;
-    EqFuncs  [ T_TRANS4  ][ T_TRANS4  ] = EqTrans44;
-    LtFuncs  [ T_TRANS2  ][ T_TRANS2  ] = LtTrans22;
-    LtFuncs  [ T_TRANS2  ][ T_TRANS4  ] = LtTrans24;
-    LtFuncs  [ T_TRANS4  ][ T_TRANS2  ] = LtTrans42;
-    LtFuncs  [ T_TRANS4  ][ T_TRANS4  ] = LtTrans44;
+    EqFuncs[T_TRANS2][T_TRANS2] = EqTrans22;
+    EqFuncs[T_TRANS2][T_TRANS4] = EqTrans24;
+    EqFuncs[T_TRANS4][T_TRANS2] = EqTrans42;
+    EqFuncs[T_TRANS4][T_TRANS4] = EqTrans44;
+    LtFuncs[T_TRANS2][T_TRANS2] = LtTrans22;
+    LtFuncs[T_TRANS2][T_TRANS4] = LtTrans24;
+    LtFuncs[T_TRANS4][T_TRANS2] = LtTrans42;
+    LtFuncs[T_TRANS4][T_TRANS4] = LtTrans44;
 
     /* install the binary operations */
-    ProdFuncs [ T_TRANS2  ][ T_TRANS2 ] = ProdTrans22;
-    ProdFuncs [ T_TRANS4  ][ T_TRANS4 ] = ProdTrans44;
-    ProdFuncs [ T_TRANS2  ][ T_TRANS4 ] = ProdTrans24;
-    ProdFuncs [ T_TRANS4  ][ T_TRANS2 ] = ProdTrans42;
-    ProdFuncs [ T_TRANS2  ][ T_PERM2 ] = ProdTrans2Perm2;
-    ProdFuncs [ T_TRANS2  ][ T_PERM4 ] = ProdTrans2Perm4;
-    ProdFuncs [ T_TRANS4  ][ T_PERM2 ] = ProdTrans4Perm2;
-    ProdFuncs [ T_TRANS4  ][ T_PERM4 ] = ProdTrans4Perm4;
-    ProdFuncs [ T_PERM2  ][ T_TRANS2 ] = ProdPerm2Trans2;
-    ProdFuncs [ T_PERM4  ][ T_TRANS2 ] = ProdPerm4Trans2;
-    ProdFuncs [ T_PERM2  ][ T_TRANS4 ] = ProdPerm2Trans4;
-    ProdFuncs [ T_PERM4  ][ T_TRANS4 ] = ProdPerm4Trans4;
-    PowFuncs  [ T_TRANS2  ][ T_PERM2 ] = PowTrans2Perm2;
-    PowFuncs  [ T_TRANS2  ][ T_PERM4 ] = PowTrans2Perm4;
-    PowFuncs  [ T_TRANS4  ][ T_PERM2 ] = PowTrans4Perm2;
-    PowFuncs  [ T_TRANS4  ][ T_PERM4 ] = PowTrans4Perm4;
-    QuoFuncs  [ T_TRANS2  ][ T_PERM2 ] = QuoTrans2Perm2;
-    QuoFuncs  [ T_TRANS2  ][ T_PERM4 ] = QuoTrans2Perm4;
-    QuoFuncs  [ T_TRANS4  ][ T_PERM2 ] = QuoTrans4Perm2;
-    QuoFuncs  [ T_TRANS4  ][ T_PERM4 ] = QuoTrans4Perm4;
-    LQuoFuncs [ T_PERM2  ][ T_TRANS2 ] = LQuoPerm2Trans2;
-    LQuoFuncs [ T_PERM4  ][ T_TRANS2 ] = LQuoPerm4Trans2;
-    LQuoFuncs [ T_PERM2  ][ T_TRANS4 ] = LQuoPerm2Trans4;
-    LQuoFuncs [ T_PERM4  ][ T_TRANS4 ] = LQuoPerm4Trans4;
-    PowFuncs  [ T_INT    ][ T_TRANS2 ] = PowIntTrans2;
-    PowFuncs  [ T_INT    ][ T_TRANS4 ] = PowIntTrans4;
-    PowFuncs  [ T_INTPOS ][ T_TRANS2 ] = PowIntTrans2;
-    PowFuncs  [ T_INTPOS ][ T_TRANS4 ] = PowIntTrans4;
+    ProdFuncs[T_TRANS2][T_TRANS2] = ProdTrans22;
+    ProdFuncs[T_TRANS4][T_TRANS4] = ProdTrans44;
+    ProdFuncs[T_TRANS2][T_TRANS4] = ProdTrans24;
+    ProdFuncs[T_TRANS4][T_TRANS2] = ProdTrans42;
+    ProdFuncs[T_TRANS2][T_PERM2] = ProdTrans2Perm2;
+    ProdFuncs[T_TRANS2][T_PERM4] = ProdTrans2Perm4;
+    ProdFuncs[T_TRANS4][T_PERM2] = ProdTrans4Perm2;
+    ProdFuncs[T_TRANS4][T_PERM4] = ProdTrans4Perm4;
+    ProdFuncs[T_PERM2][T_TRANS2] = ProdPerm2Trans2;
+    ProdFuncs[T_PERM4][T_TRANS2] = ProdPerm4Trans2;
+    ProdFuncs[T_PERM2][T_TRANS4] = ProdPerm2Trans4;
+    ProdFuncs[T_PERM4][T_TRANS4] = ProdPerm4Trans4;
+    PowFuncs[T_TRANS2][T_PERM2] = PowTrans2Perm2;
+    PowFuncs[T_TRANS2][T_PERM4] = PowTrans2Perm4;
+    PowFuncs[T_TRANS4][T_PERM2] = PowTrans4Perm2;
+    PowFuncs[T_TRANS4][T_PERM4] = PowTrans4Perm4;
+    QuoFuncs[T_TRANS2][T_PERM2] = QuoTrans2Perm2;
+    QuoFuncs[T_TRANS2][T_PERM4] = QuoTrans2Perm4;
+    QuoFuncs[T_TRANS4][T_PERM2] = QuoTrans4Perm2;
+    QuoFuncs[T_TRANS4][T_PERM4] = QuoTrans4Perm4;
+    LQuoFuncs[T_PERM2][T_TRANS2] = LQuoPerm2Trans2;
+    LQuoFuncs[T_PERM4][T_TRANS2] = LQuoPerm4Trans2;
+    LQuoFuncs[T_PERM2][T_TRANS4] = LQuoPerm2Trans4;
+    LQuoFuncs[T_PERM4][T_TRANS4] = LQuoPerm4Trans4;
+    PowFuncs[T_INT][T_TRANS2] = PowIntTrans2;
+    PowFuncs[T_INT][T_TRANS4] = PowIntTrans4;
+    PowFuncs[T_INTPOS][T_TRANS2] = PowIntTrans2;
+    PowFuncs[T_INTPOS][T_TRANS4] = PowIntTrans4;
 
     /* install the 'ONE' function for transformations */
-    OneFuncs    [ T_TRANS2 ] = OneTrans;
-    OneMutFuncs [ T_TRANS2 ] = OneTrans;
-    OneFuncs    [ T_TRANS4 ] = OneTrans;
-    OneMutFuncs [ T_TRANS4 ] = OneTrans;
+    OneFuncs[T_TRANS2] = OneTrans;
+    OneMutFuncs[T_TRANS2] = OneTrans;
+    OneFuncs[T_TRANS4] = OneTrans;
+    OneMutFuncs[T_TRANS4] = OneTrans;
 
     /* return success                                                      */
     return 0;
@@ -5394,18 +5728,19 @@ static Int InitKernel ( StructInitInfo *module )
 /******************************************************************************
 *F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
 */
-static Int InitLibrary ( StructInitInfo *module )
+static Int InitLibrary(StructInitInfo * module)
 {
     /* init filters and functions                                          */
-    InitGVarFuncsFromTable( GVarFuncs );
-    InitGVarFiltsFromTable( GVarFilts );
+    InitGVarFuncsFromTable(GVarFuncs);
+    InitGVarFiltsFromTable(GVarFilts);
     TmpTrans = 0;
     IdentityTrans = NEW_TRANS2(0);
 
     // We make the next transformation to allow testing of some parts of the
     // code which would not otherwise be accessible, since no other
     // transformation created in this file is a T_TRANS4 unless its internal
-    // degree is > 65536. Such transformation can be created by packages with a
+    // degree is > 65536. Such transformation can be created by packages with
+    // a
     // kernel module, and so we introduce the next transformation for testing
     // purposes.
     Obj ID_TRANS4 = NEW_TRANS4(0);
@@ -5421,21 +5756,21 @@ static Int InitLibrary ( StructInitInfo *module )
 *F  InitInfoTrans()  . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "trans",                            /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    MODULE_BUILTIN, /* type                           */
+    "trans",        /* name                           */
+    0,              /* revision entry of c file       */
+    0,              /* revision entry of h file       */
+    0,              /* version                        */
+    0,              /* crc                            */
+    InitKernel,     /* initKernel                     */
+    InitLibrary,    /* initLibrary                    */
+    0,              /* checkInit                      */
+    0,              /* preSave                        */
+    0,              /* postSave                       */
+    0               /* postRestore                    */
 };
 
-StructInitInfo * InitInfoTrans ( void )
+StructInitInfo * InitInfoTrans(void)
 {
     return &module;
 }

--- a/src/trans.h
+++ b/src/trans.h
@@ -29,16 +29,16 @@ extern UInt INIT_TRANS4(Obj f);
 **  'OnTuplesTrans'  returns  the  image  of  the  tuple  <tup>   under  the
 **  transformation <f>.
 */
-extern Obj OnTuplesTrans ( Obj tup, Obj f );
+extern Obj OnTuplesTrans(Obj tup, Obj f);
 
 /****************************************************************************
 **
 *F  OnSetsTrans( <set>, <f> ) . . . . . . . .  operations on sets of points
 **
-**  'OnSetsTrans' returns the  image of the  tuple <set> under the 
-**  transformation <f>. 
+**  'OnSetsTrans' returns the  image of the  tuple <set> under the
+**  transformation <f>.
 */
-extern Obj OnSetsTrans ( Obj set, Obj f );
+extern Obj OnSetsTrans(Obj set, Obj f);
 
 /****************************************************************************
 **
@@ -46,29 +46,23 @@ extern Obj OnSetsTrans ( Obj set, Obj f );
 **
 **  'IdentityTrans' is an identity transformation.
 */
-extern  Obj             IdentityTrans;
+extern Obj IdentityTrans;
 
 /****************************************************************************
 **
-*V  EqPermTrans22 . . . . . . . . . . . . . . . . .  
+*V  EqPermTrans22 . . . . . . . . . . . . . . . . .
 **
 **  The actual equality checking function for Perm2 and Trans2.
 */
-Int EqPermTrans22 (UInt                degL,
-                   UInt                degR, 
-                   UInt2 *             ptLstart,       
-                   UInt2 *             ptRstart);
+Int EqPermTrans22(UInt degL, UInt degR, UInt2 * ptLstart, UInt2 * ptRstart);
 
 /****************************************************************************
 **
-*V  EqPermTrans44 . . . . . . . . . . . . . . . . .  
+*V  EqPermTrans44 . . . . . . . . . . . . . . . . .
 **
 **  The actual equality checking function for Perm4 and Trans4.
 */
-Int EqPermTrans44 (UInt                degL,
-                   UInt                degR, 
-                   UInt4 *             ptLstart,       
-                   UInt4 *             ptRstart);
+Int EqPermTrans44(UInt degL, UInt degR, UInt4 * ptLstart, UInt4 * ptRstart);
 
 /****************************************************************************
 
@@ -79,6 +73,6 @@ Int EqPermTrans44 (UInt                degL,
 *F  InitInfoTrans()  . . . . . . . . . . . . . . . table of init functions
 */
 
-StructInitInfo * InitInfoTrans ( void );
+StructInitInfo * InitInfoTrans(void);
 
-#endif // GAP_TRANS_H
+#endif    // GAP_TRANS_H

--- a/src/trans.h
+++ b/src/trans.h
@@ -1,26 +1,75 @@
 #ifndef GAP_TRANS_H
 #define GAP_TRANS_H
 
-extern UInt INIT_TRANS2(Obj f);
-extern UInt INIT_TRANS4(Obj f);
+#include <src/plist.h>
 
-#define IMG_TRANS(f)      (ADDR_OBJ(f)[0])
-#define KER_TRANS(f)      (ADDR_OBJ(f)[1])
-#define EXT_TRANS(f)      (ADDR_OBJ(f)[2])
+static inline int IS_TRANS(Obj f)
+{
+    return (TNUM_OBJ(f) == T_TRANS2 || TNUM_OBJ(f) == T_TRANS4);
+}
 
-#define NEW_TRANS2(deg)   NewBag(T_TRANS2, deg*sizeof(UInt2)+3*sizeof(Obj))
-#define ADDR_TRANS2(f)    ((UInt2*)((Obj*)(ADDR_OBJ(f))+3))
-#define DEG_TRANS2(f)     ((UInt)(SIZE_OBJ(f)-3*sizeof(Obj))/sizeof(UInt2))
-#define RANK_TRANS2(f)    (IMG_TRANS(f)==NULL?INIT_TRANS2(f):LEN_PLIST(IMG_TRANS(f)))
+static inline Obj NEW_TRANS2(UInt deg)
+{
+    GAP_ASSERT(deg <= 65536);
+    return NewBag(T_TRANS2, deg * sizeof(UInt2) + 3 * sizeof(Obj));
+}
 
-#define NEW_TRANS4(deg)   NewBag(T_TRANS4, deg*sizeof(UInt4)+3*sizeof(Obj))
-#define ADDR_TRANS4(f)    ((UInt4*)((Obj*)(ADDR_OBJ(f))+3))
-#define DEG_TRANS4(f)     ((UInt)(SIZE_OBJ(f)-3*sizeof(Obj))/sizeof(UInt4))
-#define RANK_TRANS4(f)    (IMG_TRANS(f)==NULL?INIT_TRANS4(f):LEN_PLIST(IMG_TRANS(f)))
+static inline UInt2 * ADDR_TRANS2(Obj f)
+{
+    GAP_ASSERT(TNUM_OBJ(f) == T_TRANS2);
+    return ((UInt2 *)((Obj *)(ADDR_OBJ(f)) + 3));
+}
 
-#define IS_TRANS(f)       (TNUM_OBJ(f)==T_TRANS2||TNUM_OBJ(f)==T_TRANS4)
-#define RANK_TRANS(f)     (TNUM_OBJ(f)==T_TRANS2?RANK_TRANS2(f):RANK_TRANS4(f))
-#define DEG_TRANS(f)      (TNUM_OBJ(f)==T_TRANS2?DEG_TRANS2(f):DEG_TRANS4(f))
+static inline UInt DEG_TRANS2(Obj f)
+{
+    GAP_ASSERT(TNUM_OBJ(f) == T_TRANS2);
+    return ((UInt)(SIZE_OBJ(f) - 3 * sizeof(Obj)) / sizeof(UInt2));
+}
+
+UInt RANK_TRANS2(Obj f);
+
+static inline Obj NEW_TRANS4(UInt deg)
+{
+    // No assert here since we allow creating new T_TRANS4's when the degree
+    // is low enough to fit in a T_TRANS2.
+    return NewBag(T_TRANS4, deg * sizeof(UInt4) + 3 * sizeof(Obj));
+}
+
+static inline UInt4 * ADDR_TRANS4(Obj f)
+{
+    GAP_ASSERT(TNUM_OBJ(f) == T_TRANS4);
+    return ((UInt4 *)((Obj *)(ADDR_OBJ(f)) + 3));
+}
+
+static inline UInt DEG_TRANS4(Obj f)
+{
+    GAP_ASSERT(TNUM_OBJ(f) == T_TRANS4);
+    return ((UInt)(SIZE_OBJ(f) - 3 * sizeof(Obj)) / sizeof(UInt4));
+}
+
+UInt RANK_TRANS4(Obj f);
+
+static inline Obj NEW_TRANS(UInt deg)
+{
+    if (deg < 65536) {
+        return NEW_TRANS2(deg);
+    }
+    else {
+        return NEW_TRANS4(deg);
+    }
+}
+
+static inline UInt DEG_TRANS(Obj f)
+{
+    GAP_ASSERT(IS_TRANS(f));
+    return (TNUM_OBJ(f) == T_TRANS2 ? DEG_TRANS2(f) : DEG_TRANS4(f));
+}
+
+static inline UInt RANK_TRANS(Obj f)
+{
+    GAP_ASSERT(IS_TRANS(f));
+    return (TNUM_OBJ(f) == T_TRANS2 ? RANK_TRANS2(f) : RANK_TRANS4(f));
+}
 
 /****************************************************************************
 **


### PR DESCRIPTION
This PR removes almost all of the macros defined and used in the files trans.h/c and pperm.h/c, and replaces them with functions. It also makes it easier to create valid partial perms by not requiring that the codegree of the partial perm is set correctly when the object is created, and the functions replacing macros for partial perms are put into the header so that they can be used elsewhere. 