### PR TITLE
Fix initialisation of CopyObjFuncs for String Objects

### DIFF
--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -2563,7 +2563,7 @@ static Int InitKernel (
     }
 
     /* install the copy method                                             */
-    for ( t1 = T_STRING; t1 <= T_STRING_SSORT; t1++ ) {
+    for ( t1 = T_STRING; t1 <= T_STRING_SSORT; t1 += 2 ) {
         CopyObjFuncs [ t1                     ] = CopyString;
         CopyObjFuncs [ t1          +IMMUTABLE ] = CopyString;
         CleanObjFuncs[ t1                     ] = CleanString;


### PR DESCRIPTION
This was part of #1520 and we should at least not forget about it.