### PR TITLE
Fix RepresentativeAction for symmetric and alternating groups (for stable branch)

### DIFF
--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -1538,6 +1538,10 @@ local dom,n,sortfun,max,cd,ce,p1,p2;
       return fail;
     fi;
     if IsSubset(dom,Set(d)) and IsSubset(dom,Set(e)) then
+      if dom <> [1..n] then
+        p1 := MappingPermListList(dom,[1..n]);
+        return p1*MappingPermListList(OnTuples(d,p1),OnTuples(e,p1))/p1;
+      fi;
       return MappingPermListList(d,e);
     fi;
   fi;

--- a/tst/testbugfix/2017-07-27.tst
+++ b/tst/testbugfix/2017-07-27.tst
@@ -1,0 +1,12 @@
+# RepresentativeAction used to produce incorrect answers for both
+# symmetric and alternating groups, with both OnTuples and OnSets, by
+# producing elements outside the group.
+# This bug was originally reported by Mun See Chang.
+gap> RepresentativeAction(SymmetricGroup([5,7,11,15]),[7,11],[5,15],OnTuples);
+(5,7)(11,15)
+gap> RepresentativeAction(AlternatingGroup([5,7,11,15]),[7,11],[5,15],OnTuples);
+(5,7)(11,15)
+gap> RepresentativeAction(SymmetricGroup([5,7,11,15]),[7,11],[5,15],OnSets);
+(5,7)(11,15)
+gap> RepresentativeAction(AlternatingGroup([5,7,11,15]),[7,11],[5,15],OnSets);
+(5,7)(11,15)


### PR DESCRIPTION
Specifically, do not rely on MappingPermListList not moving additional
points. Fixes #1431 

This PR supersedes PR #1453, on which it is based; but I turned it into a truly minimal patch, and also added a test case.