### PR TITLE
Don't set modulus as DataType for ZmodnZobj

### DIFF
--- a/hpcgap/lib/ffe.gi
+++ b/hpcgap/lib/ffe.gi
@@ -198,7 +198,6 @@ InstallGlobalFunction( FFEFamily, function( p )
         # via residues.
         F!.typeOfZmodnZObj:= NewType( F, IsZmodpZObjLarge 
           and IsModulusRep and IsZDFRE);
-        SetDataType( F!.typeOfZmodnZObj, p );   # TODO: remove once no package uses this
 
         SetOne(  F, ZmodnZObj( F, 1 ) );
         SetZero( F, ZmodnZObj( F, 0 ) );

--- a/hpcgap/lib/zmodnz.gi
+++ b/hpcgap/lib/zmodnz.gi
@@ -85,7 +85,6 @@ InstallOtherMethod( ZmodnZObj,
       # via residues.
       Fam!.typeOfZmodnZObj:= NewType( Fam,
                                  IsZmodpZObjSmall and IsModulusRep );
-      SetDataType( Fam!.typeOfZmodnZObj, p );   # TODO: remove once no package uses this
 
     fi;
     return Objectify( Fam!.typeOfZmodnZObj, [ residue mod p ] );
@@ -992,7 +991,6 @@ InstallGlobalFunction( ZmodnZ, function( n )
 
     # Store the objects type.
     F!.typeOfZmodnZObj:= NewType( F, IsZmodnZObjNonprime and IsModulusRep );
-    SetDataType( F!.typeOfZmodnZObj, n ); # TODO: remove once no package uses this
 
     # as n is no prime, the family is no UFD
     SetIsUFDFamily(F,false);

--- a/lib/ffe.gi
+++ b/lib/ffe.gi
@@ -198,7 +198,6 @@ InstallGlobalFunction( FFEFamily, function( p )
         # via residues.
         F!.typeOfZmodnZObj:= NewType( F, IsZmodpZObjLarge 
           and IsModulusRep and IsZDFRE);
-        SetDataType( F!.typeOfZmodnZObj, p );   # TODO: remove once no package uses this
 
         SetOne(  F, ZmodnZObj( F, 1 ) );
         SetZero( F, ZmodnZObj( F, 0 ) );

--- a/lib/zmodnz.gi
+++ b/lib/zmodnz.gi
@@ -85,7 +85,6 @@ InstallOtherMethod( ZmodnZObj,
       # via residues.
       Fam!.typeOfZmodnZObj:= NewType( Fam,
                                  IsZmodpZObjSmall and IsModulusRep );
-      SetDataType( Fam!.typeOfZmodnZObj, p );   # TODO: remove once no package uses this
 
     fi;
     return Objectify( Fam!.typeOfZmodnZObj, [ residue mod p ] );
@@ -983,7 +982,6 @@ InstallGlobalFunction( ZmodnZ, function( n )
       # Store the objects type.
       F!.typeOfZmodnZObj:= NewType( F,     IsZmodnZObjNonprime
                                        and IsModulusRep );
-      SetDataType( F!.typeOfZmodnZObj, n );   # TODO: remove once no package uses this
 
       # as n is no prime, the family is no UFD
       SetIsUFDFamily(F,false);


### PR DESCRIPTION
This code was left in for compatibility with Browse 1.8.6. Since Browse
1.8.7 does not need these anymore, we can remove them once Browse 1.8.7
is part of the GAP distribution.

DO NOT MERGE before that happens.