### PR TITLE
Add simple check for functions containing both return; and return <obj> (DO NOT MERGE)

### DIFF
--- a/src/calls.h
+++ b/src/calls.h
@@ -96,6 +96,12 @@ typedef Obj (* ObjFunc_6ARGS) (Obj self, Obj a1, Obj a2, Obj a3, Obj a4, Obj a5,
 **  'NAMI_FUNC(<func>,<i>)' is the name of the <i>-th local variable.
 **
 **  'PROF_FUNC(<func>)' is the profiling information bag.
+**  'RETURNS_FUNC(<func>)' is space used during coding to detect
+**                      functions that contain both return and return <obj>;
+**                      it's actually the same space as PROF_FUNC since that
+**                      is never needed at coding time
+**  'FUNC_RETURNS_OBJ'  and 'FUNCS_RETURNS_VOID' are two different bits used
+**                       for this
 **
 **  'NLOC_FUNC(<func>)' is the number of local variables of  the  interpreted
 **  function <func>.
@@ -163,6 +169,11 @@ static inline Obj PROF_FUNC(Obj func)
     return FUNC_HEADER(func)->prof;
 }
 
+static inline UInt RETURNS_FUNC(Obj func)
+{
+    return (UInt)FUNC_HEADER(func)->prof;
+}
+
 static inline UInt NLOC_FUNC(Obj func)
 {
     return FUNC_HEADER(func)->nloc;
@@ -215,6 +226,11 @@ static inline void SET_PROF_FUNC(Obj func, Obj prof)
     FUNC_HEADER(func)->prof = prof;
 }
 
+static inline void SET_RETURNS_FUNC(Obj func, UInt val)
+{
+    FUNC_HEADER(func)->prof = (Obj)val;
+}
+
 static inline void SET_NLOC_FUNC(Obj func, UInt nloc)
 {
     FUNC_HEADER(func)->nloc = nloc;
@@ -245,6 +261,11 @@ static inline void SET_LCKS_FUNC(Obj func, Obj locks)
 
 
 #define SIZE_FUNC               sizeof(FunctionHeader)
+
+enum {
+    FUNC_RETURNS_OBJ       = 1L,
+    FUNC_RETURNS_VOID      = 2L,
+};
 
 #define HDLR_0ARGS(func)        ((ObjFunc_0ARGS)HDLR_FUNC(func,0))
 #define HDLR_1ARGS(func)        ((ObjFunc_1ARGS)HDLR_FUNC(func,1))

--- a/src/code.c
+++ b/src/code.c
@@ -797,6 +797,7 @@ void CodeFuncExprBegin (
     /* give it a body                                                      */
     body = NewBag( T_BODY, 1024*sizeof(Stat) );
     SET_BODY_FUNC( fexp, body );
+    SET_RETURNS_FUNC( fexp, 0 );
     CHANGED_BAG( fexp );
 
     /* record where we are reading from */
@@ -842,7 +843,13 @@ void CodeFuncExprEnd (
     /* get the function expression                                         */
     fexp = CURR_FUNC();
     assert(!STATE(LoopNesting));
-    
+
+    if ((RETURNS_FUNC(fexp) & (FUNC_RETURNS_OBJ | FUNC_RETURNS_VOID)) ==
+                              (FUNC_RETURNS_OBJ | FUNC_RETURNS_VOID)) {
+        SyntaxWarning("Function contains both 'return <obj>;' and 'return;'");
+    }
+    SET_RETURNS_FUNC(fexp, 0);
+
     /* get the body of the function                                        */
     /* push an additional return-void-statement if neccessary              */
     /* the function interpreters depend on each function ``returning''     */
@@ -1440,6 +1447,12 @@ void CodeReturnObj ( void )
     expr = PopExpr();
     ADDR_STAT(stat)[0] = expr;
 
+    // record that this function returned an object at least once, unless
+    // this is actually a 'TryNextMethod()' in disguise
+    if ( ! (TNUM_EXPR(expr) == T_REF_GVAR &&
+            ADDR_EXPR(expr)[0] == (Expr)GVarName( "TRY_NEXT_METHOD" )) )
+        SET_RETURNS_FUNC(CURR_FUNC(), RETURNS_FUNC(CURR_FUNC()) | FUNC_RETURNS_OBJ);
+
     /* push the return-statement                                           */
     PushStat( stat );
 }
@@ -1463,6 +1476,9 @@ void CodeReturnVoid ( void )
     /* allocate the return-statement                                       */
     stat = NewStat( T_RETURN_VOID, 0 * sizeof(Expr) );
 
+    // record that this function returned void at least once
+    SET_RETURNS_FUNC(CURR_FUNC(), RETURNS_FUNC(CURR_FUNC()) | FUNC_RETURNS_VOID);
+
     /* push the return-statement                                           */
     PushStat( stat );
 }
@@ -1472,8 +1488,10 @@ void CodeReturnVoidWhichIsNotProfiled ( void )
     Stat                stat;           /* return-statement, result        */
 
     /* allocate the return-statement, without profile information          */
-
     stat = NewStatWithProf( T_RETURN_VOID, 0 * sizeof(Expr), 0, 0 );
+
+    // record that this function returned void at least once
+    SET_RETURNS_FUNC(CURR_FUNC(), RETURNS_FUNC(CURR_FUNC()) | FUNC_RETURNS_VOID);
 
     /* push the return-statement                                           */
     PushStat( stat );


### PR DESCRIPTION
This is a rebased and tweaked version of PR #466. The main changes compared to that are:
* This PR also resolves most of the warnings (see also PR #1539, which contains just those changes and could be merged right away).
* It now detects `TryNextMethod()`, which internally is coded as `return TRY_NEXT_METHOD`, and does not treat it as the function returning an object; this fixes a false positive in the `ViewObj` method in `lib/teaching.g` (and probably elsewhere).
* it also modifies `CodeReturnVoidWhichIsNotProfiled` (which did not exist when #466 was created)

I found this useful, as it flagged several places in GAP and packages where I genuinely think it was a bug that a function sometimes returns a value and sometimes nothing.

However, even with all the work combined, one false (?) positive remains: `ErrorInner` in `lib/error.g` is meant to sometimes return something or not, intentionally. However, I am not sure anything ever uses its return value? There are a few `return Error(...)` in the GAP library (most of them in the meataxe code), but I think most could and should be replaced by a call to `ErrorNoReturn`. Similarly for packages.

And lots of packages produce warnings. And the code is still not doing an actual code flow analysis; so in order to avoid tons of spurious complaints about functions caused by the implicit `return;` we add to the end of function that don't end in a `return` statement, we ignore those implicit returns. This ensures we don't get a warning about this function:
```
foo := function(x)
if x = 1 then return 99;
else return 42;
fi;
end;
```
But on the other hand, it also means we don't get a warning about this function, even though we'd like to:
```
bar := function(x)
if x = 1 then return 99;
fi;
end;
```

Anyway, ultimately, we should not add this directly, but only enable it when requested -- see issue #1191. 