### PR TITLE
Remove GASMAN's 'dirty mode'

### DIFF
--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -310,7 +310,6 @@ void            InitBags (
     TNumStackFuncBags   stack_func,
     Bag *               stack_bottom,
     UInt                stack_align,
-    UInt                dirty,
     TNumAbortFuncBags   abort_func )
 {
     UInt                i;              /* loop variable                   */

--- a/src/gap.c
+++ b/src/gap.c
@@ -3268,7 +3268,7 @@ void InitializeGap (
     /* Initialise memory  -- have to do this here to make sure we are at top of C stack */
     InitBags( SyAllocBags, SyStorMin,
               0, (Bag*)(((UInt)pargc/SyStackAlign)*SyStackAlign), SyStackAlign,
-              0, SyAbortBags );
+              SyAbortBags );
 #if !defined(BOEHM_GC)
     InitMsgsFuncBags( SyMsgsBags );
 #endif

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -964,10 +964,9 @@ void FinishBags( void )
 **
 *F  InitBags(...) . . . . . . . . . . . . . . . . . . . . . initialize Gasman
 **
-**  'InitBags'   remembers   <alloc-func>,  <stack-func>,     <stack-bottom>,
-**  <stack-align>, <dirty>,    and   <abort-func>  in   global
-**  variables.   It also  allocates  the initial workspace,   and sets up the
-**  linked list of available masterpointer.
+**  'InitBags' remembers <alloc-func>, <stack-func>, <stack-bottom>,
+**  <stack-align> and <abort-func> in global variables. It also allocates the
+**  initial workspace, and sets up the linked list of available masterpointer.
 */
 TNumAllocFuncBags       AllocFuncBags;
 
@@ -977,8 +976,6 @@ Bag *                   StackBottomBags;
 
 UInt                    StackAlignBags;
 
-UInt                    DirtyBags;
-
 TNumAbortFuncBags       AbortFuncBags;
 
 void            InitBags (
@@ -987,7 +984,6 @@ void            InitBags (
     TNumStackFuncBags   stack_func,
     Bag *               stack_bottom,
     UInt                stack_align,
-    UInt                dirty,
     TNumAbortFuncBags   abort_func )
 {
     Bag *               p;              /* loop variable                   */
@@ -1031,9 +1027,6 @@ void            InitBags (
 
     AllocSizeBags = 256;
 
-    /* remember whether bags should be clean                               */
-    DirtyBags = dirty;
-
     /* install the marking functions                                       */
     for ( i = 0; i < 255; i++ )
         TabMarkFuncBags[i] = MarkAllSubBagsDefault;
@@ -1068,10 +1061,7 @@ void            InitBags (
 **
 **  Finally it returns the identifier of the new bag.
 **
-**  Note that 'NewBag' never  initializes the new bag  to contain only 0.  If
-**  this is desired because  the initialization flag <dirty> (see "InitBags")
-**  was  0, it is the job  of 'CollectBags'  to initialize the new free space
-**  after a garbage collection.
+**  All entries of  the new bag will be initialized to 0.
 **
 **  If {\Gasman} was compiled with the option 'COUNT_BAGS' then 'NewBag' also
 **  updates the information in 'InfoBags' (see "InfoBags").
@@ -1894,8 +1884,7 @@ again:
     AllocBags = YoungBags = dst;
 
     /* clear the new free area                                             */
-    if (!DirtyBags)
-      memset((void *)dst, 0, ((Char *)src)-((Char *)dst));
+    memset((void *)dst, 0, ((Char *)src)-((Char *)dst));
 
     /* information after the sweep phase                                   */
     NrDeadBags += nrDeadBags;

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -395,9 +395,7 @@ extern void CHANGED_BAG_IMPL(Bag b);
 **  The application can find the size of a bag with 'SIZE_BAG' and change  it
 **  with 'ResizeBag' (see "SIZE_BAG" and "ResizeBag").
 **
-**  If the initialization flag <dirty> is 0, all entries of  the new bag will
-**  be initialized to 0; otherwise the  entries  of the  new bag will contain
-**  random values (see "InitBags").
+**  All entries of  the new bag will be initialized to 0.
 **
 **  What  happens if {\Gasman}  cannot  get  enough  storage  to perform   an
 **  allocation     depends on  the  behavior    of   the allocation  function
@@ -469,9 +467,7 @@ extern  void            RetypeBagIfWritable (
 **  new size.  If the new size  <new> is larger than  the old size, {\Gasman}
 **  extends the bag.
 **
-**  If the initialization flag <dirty> is 0, all entries of an extension will
-**  be initialized to 0; otherwise the  entries of an  extension will contain
-**  random values (see "InitBags").
+**  All entries of an extension will be initialized to 0.
 **
 **  What happens  if {\Gasman} cannot   get   enough storage to  perform   an
 **  extension depends   on   the   behavior   of the   allocation    function
@@ -1075,7 +1071,7 @@ extern void CheckMasterPointers( void );
 **
 **  InitBags( <alloc-func>, <initial-size>,
 **            <stack-func>, <stack-start>, <stack-align>,
-**            <dirty>, <abort-func> )
+**            <abort-func> )
 **
 **  'InitBags'  initializes {\Gasman}.  It  must be called from a application
 **  using {\Gasman} before any bags can be allocated.
@@ -1136,12 +1132,6 @@ extern void CheckMasterPointers( void );
 **  on  the   machine,  the  operating system,   and   the compiler.   If the
 **  application provides another <stack-func>, <stack-align> is ignored.
 **
-**  The initialization  flag  <dirty> determines  whether  bags allocated  by
-**  'NewBag' are initialized to contain only 0 or not.   If <dirty> is 0, the
-**  bags are  initialized to  contain only 0.    If  <dirty> is  1, the  bags
-**  initially contain  random values.  Note that {\Gasman}  will be  a little
-**  bit faster if bags need not be initialized.
-**
 **  <abort-func> should be a function that {\Gasman} should call in case that
 **  something goes  wrong, e.g.,     if it  cannot allocation    the  initial
 **  workspace.  <abort-func> should be a function of one string argument, and
@@ -1163,7 +1153,6 @@ extern  void            InitBags (
             TNumStackFuncBags   stack_func,
             Bag *               stack_bottom,
             UInt                stack_align,
-            UInt                dirty,
             TNumAbortFuncBags   abort_func );
 
 /****************************************************************************


### PR DESCRIPTION
NewBag now always returned zeroed bags, and promises so in its
documentation. Rationale: Quite some code implicitly relies on this
behaviour by now. So if we wanted to change it, we'd have to do more
than just flip on "dirty mode" (resp. remove the relevant memset in the
GASMAN collector code). We'd then have to review all code making
allocations as to whether it relies on the zeroing behaviour or not (and
that can be quite tricky to refute). The existing "dirty mode" would not
help with that in any serious way, so we may just as well remove it now.