### PR TITLE
Change definition of IsPGroup to *not* require finiteness

### DIFF
--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -415,11 +415,18 @@ DeclareOperation( "KnowsHowToDecompose", [ IsGroup, IsList ] );
 ##
 ##  <Description>
 ##  <Index Key="p-group"><M>p</M>-group</Index>
-##  A <E><M>p</M>-group</E> is a finite group whose order
-##  (see&nbsp;<Ref Func="Size"/>) is of the form <M>p^n</M> for a prime
-##  integer <M>p</M> and a nonnegative integer <M>n</M>.
+##  A <E><M>p</M>-group</E> is a group in which the order
+##  (see&nbsp;<Ref Func="Order"/>) of every element is of the form <M>p^n</M>
+##  for a prime integer <M>p</M> and a nonnegative integer <M>n</M>.
 ##  <Ref Prop="IsPGroup"/> returns <K>true</K> if <A>G</A> is a
 ##  <M>p</M>-group, and <K>false</K> otherwise.
+##  <P/>
+##  Finite <M>p</M>-groups are precisely those groups whose order
+##  (see&nbsp;<Ref Func="Size"/>) is a prime power, and are always
+##  nilpotent.
+##  <P/>
+##  Note that <M>p</M>-groups can also be infinite, and in that case,
+##  need not be nilpotent.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>


### PR DESCRIPTION
This is kind of the opposite of PR #483 which changes the *implementation* (i.e. the actual filter) of `IsPGroup` to imply `IsFinite`, matching its documentation. This PR instead adjusts the documentation to also include infinite p-groups.

That means of course that `IsPGroup` should no longer imply `IsNilpotent` -- instead, `IsFinite and IsPGroup` is needed.

We discussed this briefly a few years ago, and IIRC the thought was that it's too risky to change this, as code might implicitly rely on `IsPGroup` "implying" `IsFinite`. Well, I audited all distributed packages and the GAP library, and surprisingly little code does. And virtually all of it just would run into an error if used on an infinite p-group.

The main reason to adjust code to explicitly check for `IsFinite` thus would be to get more helpful error messages... I performed various adjustments in this direction, which were merged as part of PR #1578. I also submitted patches to a few packages which improved code that seemed to implicitly rely on p-groups being finite, but in all cases, the only effect an infinite p-group should have would be a plain error, or perhaps a non-terminating program (e.g. trying to get an infinite generating set).

In the end, all that is left for this PR is to adjust the documentation!