### PR TITLE
Remove leftovers from the restart code

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -884,10 +884,10 @@ typedef struct {
 }
 TypeHandlerInfo;
 
-static UInt HandlerSortingStatus;
+static UInt HandlerSortingStatus = 0;
 
 static TypeHandlerInfo HandlerFuncs[MAX_HANDLERS];
-static UInt NHandlerFuncs;
+static UInt NHandlerFuncs = 0;
  
 void InitHandlerFunc (
     ObjFunc             hdlr,
@@ -917,16 +917,6 @@ void InitHandlerFunc (
 **
 *f  CheckHandlersBag( <bag> ) . . . . . . check that handlers are initialised
 */
-
-void InitHandlerRegistration( void )
-{
-  /* initialize these here rather than statically to allow for restart */
-  /* can't do them in InitKernel of this module because it's called too late
-     so make it a function and call it from an earlier InitKernel */
-  HandlerSortingStatus = 0;
-  NHandlerFuncs = 0;
-
-}
 
 #ifdef DEBUG_HANDLER_REGISTRATION
 

--- a/src/calls.h
+++ b/src/calls.h
@@ -297,8 +297,6 @@ Obj FuncENDLINE_FUNC(Obj self, Obj func);
 **  handler
 */
 
-extern void InitHandlerRegistration( void );
-
 extern void InitHandlerFunc (
      ObjFunc            hdlr,
      const Char *       cookie );

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1529,8 +1529,6 @@ static StructGVarFunc GVarFuncs [] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
-    InitHandlerRegistration();
-
     /* init global bags and handler                                        */
     InitGlobalBag( &ErrorMustEvalToFuncFunc,
                    "src/gvars.c:ErrorMustEvalToFuncFunc" );

--- a/src/system.c
+++ b/src/system.c
@@ -1755,8 +1755,7 @@ void InitSystem (
     UInt                i;             /* loop variable                   */
     Int res;                       /* return from option processing function */
 
-    /* Initialize global and static variables. Do it here rather than
-       with initializers to allow for restart */
+    /* Initialize global and static variables */
     SyCTRD = 1;             
     SyCompilePlease = 0;
     SyDebugLoading = 0;


### PR DESCRIPTION
There used to be an incomplete code path in GAP for "restarting"
GAP without actually existing. This was removed a few years ago,
but some traces were left in by accident.