### PR TITLE
Improve reproducibility in one of the examples in ctbl.gd

### DIFF
--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -4384,11 +4384,9 @@ DeclareGlobalFunction( "NormalSubgroupClasses" );
 ##    nsgclasses := [ [ 1, 3 ] ], nsgfactors := [  ] )
 ##  gap> ClassPositionsOfNormalSubgroup( tbl, kernel );
 ##  [ 1, 3 ]
-##  gap> FactorGroupNormalSubgroupClasses( tbl, [ 1, 3 ] );
-##  Group([ f1, f2 ])
-##  gap> NormalSubgroupClassesInfo( tbl );
-##  rec( nsg := [ Group([ (1,2)(3,4), (1,4)(2,3) ]) ], 
-##    nsgclasses := [ [ 1, 3 ] ], nsgfactors := [ Group([ f1, f2 ]) ] )
+##  gap> G := FactorGroupNormalSubgroupClasses( tbl, [ 1, 3 ] );;
+##  gap> NormalSubgroupClassesInfo( tbl ).nsgfactors[1] = G;
+##  true
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>


### PR DESCRIPTION
Before that, FactorGroupNormalSubgroupClasses example could
have the following diffs dependently on packages loaded:
```
########> Diff in [ "./../../lib/ctbl.gd", 4366, 4392 ]
# Input is:
FactorGroupNormalSubgroupClasses( tbl, [ 1, 3 ] );
# Expected output:
Group([ f1, f2 ])
# But found:
<pc group with 2 generators>
########
########> Diff in [ "./../../lib/ctbl.gd", 4366, 4392 ]
# Input is:
NormalSubgroupClassesInfo( tbl );
# Expected output:
rec( nsg := [ Group([ (1,2)(3,4), (1,4)(2,3) ]) ], 
  nsgclasses := [ [ 1, 3 ] ], nsgfactors := [ Group([ f1, f2 ]) ] )
# But found:
rec( nsg := [ Group([ (1,2)(3,4), (1,4)(2,3) ]) ], 
  nsgclasses := [ [ 1, 3 ] ], 
  nsgfactors := [ <pc group with 2 generators> ] )
########
```