### PR TITLE
Record mutability

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -1328,8 +1328,14 @@ Obj SET_TYPE_COMOBJ_Handler (
         RetypeBag( obj, T_ACOMOBJ );
         CHANGED_BAG( obj );
         break;
+      default:
+        ErrorMayQuit("You can't make component object from a %s.",
+                     (Int)TNAM_OBJ(obj), 0L);
     }
 #else
+    if (TNUM_OBJ(obj) == T_PREC+IMMUTABLE)
+      ErrorMayQuit("You can't make a component object from an immutable object",
+		   0L, 0L);
     TYPE_COMOBJ( obj ) = type;
     RetypeBag( obj, T_COMOBJ );
     CHANGED_BAG( obj );

--- a/src/precord.c
+++ b/src/precord.c
@@ -296,6 +296,11 @@ void MakeImmutablePRec( Obj rec)
   len = LEN_PREC( rec );
   for ( i = 1; i <= len; i++ )
     MakeImmutable(GET_ELM_PREC(rec,i));
+  
+  /* Sort the record at this point.
+     This can never hurt, unless the record will never be accessed again anyway
+     for HPCGAP it's essential so that immutable records are actually binary unchanging */
+  SortPRecRNam(rec, 1); 
   RetypeBag(rec, IMMUTABLE_TNUM(TNUM_OBJ(rec)));
 }
 


### PR DESCRIPTION
This PR makes two small changes which avoid potential problems in HPCGAP and should do no harm in GAP. 

1. Sort all plain records while making them immutable.  Then immutable plain records are bitwise immutable

2. Check for attempts to make component objects from immutable records, which doesn't really make sense. 