### PR TITLE
Improved reproducibility of MaximalSubgroupClassReps test

### DIFF
--- a/tst/testextra/grpperm.tst
+++ b/tst/testextra/grpperm.tst
@@ -83,8 +83,8 @@ gap> g:=SemidirectProduct(GL(3,5),GF(5)^3);
 <matrix group of size 186000000 with 3 generators>
 gap> g:=Image(IsomorphismPermGroup(g));
 <permutation group of size 186000000 with 3 generators>
-gap> List(MaximalSubgroupClassReps(g),Size);
-[ 93000000, 1488000, 6000000, 6000000, 60000, 48000, 46500 ]
+gap> SortedList(List(MaximalSubgroupClassReps(g),Size));
+[ 46500, 48000, 60000, 1488000, 6000000, 6000000, 93000000 ]
 gap> g:=Image(IsomorphismPermGroup(GL(2,5)));;
 gap> w:=WreathProduct(g,SymmetricGroup(5));;
 gap> m:=MaximalSubgroupClassReps(w);;


### PR DESCRIPTION
The ordering of the result may differ dependently on packages loaded:
```
########> Diff in /data/gap-jenkins/workspace/GAP-major-release-test/GAPCOPTS/\
64build/GAPTARGET/standard/label/kovacs/gap4r9/tst/testextra/grpperm.tst:86
# Input is:
List(MaximalSubgroupClassReps(g),Size);
# Expected output:
[ 93000000, 1488000, 6000000, 6000000, 60000, 48000, 46500 ]
# But found:
[ 93000000, 1488000, 6000000, 6000000, 48000, 46500, 60000 ]
########
```
This PR sorts the output to ensure that the ordering is always the same.
