### PR TITLE
Avoid floating point computations in Test()

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -122,7 +122,7 @@ InstallGlobalFunction(RunTests, function(arg)
     elif opts.showProgress = "some" then
       Print("\r# line ", pos[i],
             " of ", nrlines,
-            " (", Int(Round(Float(pos[i] / nrlines * 100))), "%)",
+            " (", Int(pos[i] / nrlines * 100), "%)",
             "\c");
     fi;
     s := InputTextString(inp[i]);


### PR DESCRIPTION
... for computing progress percentage. Note that the new code
intentionally always rounds down: We don't want to show 100%
if we are not on the last line. (And that last line is usually
doing STOP_TEST(), so you may never see 100%, but that's fine).

This fixes a bad interaction with the tests of the float package,
which temporarily switches GAP to different float handlers, some
of which may not implement Round().