### PR TITLE
Print on startup if kernel debugging is enabled

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -526,8 +526,11 @@ BindGlobal( "ShowKernelInformation", function()
   if IsBound( GAPInfo.UseReadline ) then
     Add( libs, "readline" );
   fi;
+  if GAPInfo.KernelInfo.KernelDebug then
+    Add( libs, "KernelDebug" );
+  fi;
   if libs <> [] then
-    print_info( " Libs used:  ", libs, "\n" );
+    print_info( " Configuration:  ", libs, "\n" );
   fi;
   if GAPInfo.CommandLineOptions.L <> "" then
     Print( " Loaded workspace: ", GAPInfo.CommandLineOptions.L, "\n" );

--- a/src/gap.c
+++ b/src/gap.c
@@ -2720,6 +2720,13 @@ Obj FuncKERNEL_INFO(Obj self) {
   r = RNamName("GMP_VERSION");
   AssPRec(res, r, str);
 
+  r = RNamName("KernelDebug");
+#ifdef GAP_KERNEL_DEBUG
+  AssPRec(res, r, True);
+#else
+  AssPRec(res, r, False);
+#endif
+
   MakeImmutable(res);
   
   return res;


### PR DESCRIPTION
This adds another line to GAP's startup output which shows when `--enable-debug` was passed during configure.

I thought about merging this into the `Libs` line, but couldn't come up with a nice alternative name to replace `Libs:`.