### PR TITLE
Add HASHKEY_MEM_NC and add hashing comments

### DIFF
--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -516,18 +516,23 @@ Obj FuncHASHKEY_BAG(Obj self, Obj obj, Obj opSeed, Obj opOffset, Obj opMaxLen)
   return INTOBJ_INT(HASHKEY_BAG_NC( obj, (UInt4)INT_INTOBJ(opSeed), offs, (int) n));
 }
 
-Int HASHKEY_BAG_NC (Obj obj, UInt4 seed, Int skip, int maxread){
-  #ifdef SYS_IS_64_BIT
+Int HASHKEY_MEM_NC(const void * ptr, UInt4 seed, Int read)
+{
+#ifdef SYS_IS_64_BIT
     UInt8 hashout[2];
-    MurmurHash3_x64_128 ( (const void *)((UChar *)ADDR_OBJ(obj)+skip), 
-                           maxread, seed, (void *) hashout);
+    MurmurHash3_x64_128(ptr, read, seed, (void *)hashout);
     return hashout[0] % (1UL << 60);
-  #else
+#else
     UInt4 hashout;
-    MurmurHash3_x86_32 ( (const void *)((UChar *)ADDR_OBJ(obj)+skip), 
-                          maxread, seed, (void *) &hashout);
+    MurmurHash3_x86_32(ptr, read, seed, (void *)&hashout);
     return hashout % (1UL << 28);
-  #endif
+#endif
+}
+
+Int HASHKEY_BAG_NC(Obj obj, UInt4 seed, Int skip, int read)
+{
+    return HASHKEY_MEM_NC((const void *)((UChar *)ADDR_OBJ(obj) + skip), seed,
+                          read);
 }
 
 Int HASHKEY_WHOLE_BAG_NC(Obj obj, UInt4 seed)

--- a/src/intfuncs.h
+++ b/src/intfuncs.h
@@ -29,8 +29,23 @@ extern void MurmurHash3_x86_32 ( const void * key, int len,
 extern void MurmurHash3_x64_128 ( const void * key, const int len,
                            const UInt4 seed, void * out );
 
-extern Int HASHKEY_BAG_NC(Obj obj, UInt4 factor, Int skip, int maxread);
-extern Int HASHKEY_WHOLE_BAG_NC(Obj obj, UInt4 seed);
+// These three functions provide an wrappers around MurmurHash3
+// for common use cases.
+// In particular, they deal with taking the output of MurmurHash3,
+// and transforming it into an Int which fits into a GAP
+// immediate integer.
+// The 'seed' parameter sets the initial seed of the hash, different
+// values (should) produce different hash values.
+
+// Hash a block of memory
+Int HASHKEY_MEM_NC (const void* ptr, UInt4 seed, Int read);
+
+// Hash an entire bag
+Int HASHKEY_WHOLE_BAG_NC (Obj obj, UInt4 seed);
+
+// Hash a bag starting at position 'skip', reading 'read' bytes.
+// Does NOT perform bounds checking
+Int HASHKEY_BAG_NC (Obj obj, UInt4 seed, Int skip, int read);
 
 Obj IntStringInternal( Obj string );
 


### PR DESCRIPTION
This PR adds a new function to the HASHKEY family which hashes a simple block of memory (for use in datastructures) and adds some basic comments to the header.