### PR TITLE
Minimal fix for Algebraic Extensions over finite fields of order > 256.

### DIFF
--- a/lib/algfld.gi
+++ b/lib/algfld.gi
@@ -105,7 +105,7 @@ local fam,i,cof,red,rchar,impattr,deg;
   fam!.deg:=deg;
   i:=List([1..DegreeOfLaurentPolynomial(p)],i->fam!.zeroCoefficient);
   i[2]:=fam!.oneCoefficient;
-  i:=ImmutableVector(rchar,i,true);
+  i:=ImmutableVector(Size(f),i,true);
   fam!.primitiveElm:=MakeImmutable(ObjByExtRep(fam,i));
   fam!.indeterminateName:=MakeImmutable("a");
 

--- a/tst/testbugfix/2017-08-05-algfld.tst
+++ b/tst/testbugfix/2017-08-05-algfld.tst
@@ -1,0 +1,14 @@
+#
+# AlgebraicExtension used to fail for finite fields of size over 256
+#
+gap> algexttest := function(q, i1, i2)
+>    local f,x,pol;    
+>    f := GF(q);
+>    x :=Indeterminate(f,"x");
+>    pol := x^2+Z(q)^i1*x+Z(q)^i2;
+>    AlgebraicExtension(f,pol);
+> end;;
+gap> algexttest(1009,108,864); # from bug report
+gap> algexttest(1024,1023,5);  # prime under 256, field size over
+gap> algexttest(65537,1,1);    # prime over 2^16
+gap> algexttest(3^11,1,6);     # prime under 2^16, field over


### PR DESCRIPTION
Code really needs rewriting, as does the whole issue of mechanisms to
construct/convert a vector in/to the most efficient form.