### PR TITLE
Reduce immutable/mutable diffs (UPDATE: now ready for merge)

### DIFF
--- a/doc/ref/create.xml
+++ b/doc/ref/create.xml
@@ -1026,7 +1026,7 @@ gap> l := [1,2,4];
 gap> MakeImmutable(l);
 [ 1, 2, 4 ]
 gap> l[3] := 5;
-Error, Lists Assignment: <list> must be a mutable list
+Error, List Assignment: <list> must be a mutable list
 ]]></Example>
 <P/>
 For external objects, the situation is different. An external object which

--- a/doc/tut/lists.xml
+++ b/doc/tut/lists.xml
@@ -342,7 +342,7 @@ gap> list[3][5] := 'w';; list; copy;
 [ 1, 2, "threw", [ 4 ] ]
 [ 1, 2, "three", [ 4 ] ]
 gap> copy[3][5] := 'w';
-Lists Assignment: <list> must be a mutable list
+List Assignment: <list> must be a mutable list
 not in any function
 Entering break read-eval-print loop ...
 you can 'quit;' to quit to outer loop, or

--- a/src/blister.c
+++ b/src/blister.c
@@ -105,69 +105,39 @@ Obj TYPE_BLIST_SSORT_IMM;
 Obj TYPE_BLIST_EMPTY_MUT;
 Obj TYPE_BLIST_EMPTY_IMM;
 
-Obj TypeBlistMut (
-    Obj                 list )
+Obj TypeBlist(Obj list)
 {
     /* special case for the empty blist                                    */
     if ( LEN_BLIST(list) == 0 ) {
-        return TYPE_BLIST_EMPTY_MUT;
+        return IS_MUTABLE_PLAIN_OBJ(list) ? TYPE_BLIST_EMPTY_MUT
+                                          : TYPE_BLIST_EMPTY_IMM;
     } else {
-        return TYPE_BLIST_MUT;
+        return IS_MUTABLE_PLAIN_OBJ(list) ? TYPE_BLIST_MUT
+                                          : TYPE_BLIST_IMM;
     }
 }
 
-Obj TypeBlistImm (
-    Obj                 list )
+Obj TypeBlistNSort(Obj list)
 {
     /* special case for the empty blist                                    */
     if ( LEN_BLIST(list) == 0 ) {
-        return TYPE_BLIST_EMPTY_IMM;
+        return IS_MUTABLE_PLAIN_OBJ(list) ? TYPE_BLIST_EMPTY_MUT
+                                          : TYPE_BLIST_EMPTY_IMM;
     } else {
-        return TYPE_BLIST_IMM;
+        return IS_MUTABLE_PLAIN_OBJ(list) ? TYPE_BLIST_NSORT_MUT
+                                          : TYPE_BLIST_NSORT_IMM;
     }
 }
 
-Obj TypeBlistNSortMut (
-    Obj                 list )
+Obj TypeBlistSSort(Obj list)
 {
     /* special case for the empty blist                                    */
     if ( LEN_BLIST(list) == 0 ) {
-        return TYPE_BLIST_EMPTY_MUT;
+        return IS_MUTABLE_PLAIN_OBJ(list) ? TYPE_BLIST_EMPTY_MUT
+                                          : TYPE_BLIST_EMPTY_IMM;
     } else {
-        return TYPE_BLIST_NSORT_MUT;
-    }
-}
-
-Obj TypeBlistNSortImm (
-    Obj                 list )
-{
-    /* special case for the empty blist                                    */
-    if ( LEN_BLIST(list) == 0 ) {
-        return TYPE_BLIST_EMPTY_IMM;
-    } else {
-        return TYPE_BLIST_NSORT_IMM;
-    }
-}
-
-Obj TypeBlistSSortMut (
-    Obj                 list )
-{
-    /* special case for the empty blist                                    */
-    if ( LEN_BLIST(list) == 0 ) {
-        return TYPE_BLIST_EMPTY_MUT;
-    } else {
-        return TYPE_BLIST_SSORT_MUT;
-    }
-}
-
-Obj TypeBlistSSortImm (
-    Obj                 list )
-{
-    /* special case for the empty blist                                    */
-    if ( LEN_BLIST(list) == 0 ) {
-        return TYPE_BLIST_EMPTY_IMM;
-    } else {
-        return TYPE_BLIST_SSORT_IMM;
+        return IS_MUTABLE_PLAIN_OBJ(list) ? TYPE_BLIST_SSORT_MUT
+                                          : TYPE_BLIST_SSORT_IMM;
     }
 }
 
@@ -2452,12 +2422,12 @@ static Int InitKernel (
     }
 
     /* install the type methods                                            */
-    TypeObjFuncs[ T_BLIST ] = TypeBlistMut;
-    TypeObjFuncs[ T_BLIST +IMMUTABLE ] = TypeBlistImm;
-    TypeObjFuncs[ T_BLIST_NSORT ] = TypeBlistNSortMut;
-    TypeObjFuncs[ T_BLIST_NSORT +IMMUTABLE ] = TypeBlistNSortImm;
-    TypeObjFuncs[ T_BLIST_SSORT ] = TypeBlistSSortMut;
-    TypeObjFuncs[ T_BLIST_SSORT +IMMUTABLE ] = TypeBlistSSortImm;
+    TypeObjFuncs[ T_BLIST            ] = TypeBlist;
+    TypeObjFuncs[ T_BLIST +IMMUTABLE ] = TypeBlist;
+    TypeObjFuncs[ T_BLIST_NSORT            ] = TypeBlistNSort;
+    TypeObjFuncs[ T_BLIST_NSORT +IMMUTABLE ] = TypeBlistNSort;
+    TypeObjFuncs[ T_BLIST_SSORT            ] = TypeBlistSSort;
+    TypeObjFuncs[ T_BLIST_SSORT +IMMUTABLE ] = TypeBlistSSort;
 
     /* initialise list tables                                              */
     InitClearFiltsTNumsFromTable   ( ClearFiltsTab );

--- a/src/blister.c
+++ b/src/blister.c
@@ -231,12 +231,6 @@ Obj DoCopyBlist(Obj list, Int mut)
 
 #if !defined(USE_THREADSAFE_COPYING)
 
-Obj CopyBlistImm(Obj list, Int mut)
-{
-    GAP_ASSERT(!IS_MUTABLE_OBJ(list));
-    return list;
-}
-
 Obj CopyBlist (
     Obj                 list,
     Int                 mut )
@@ -244,10 +238,9 @@ Obj CopyBlist (
     Obj copy;
     Obj tmp;
 
-    /* immutable objects should never end up here, because
-     * they have their own handler defined above
-     */
-    GAP_ASSERT(IS_MUTABLE_OBJ(list));
+    if (!IS_MUTABLE_OBJ(list)) {
+        return list;
+    }
 
     copy = DoCopyBlist(list, mut);
     /* leave a forwarding pointer */
@@ -2447,7 +2440,7 @@ static Int InitKernel (
     for ( t1 = T_BLIST; t1 <= T_BLIST_SSORT; t1 += 2 ) {
 #if !defined(USE_THREADSAFE_COPYING)
         CopyObjFuncs [ t1                     ] = CopyBlist;
-        CopyObjFuncs [ t1 +IMMUTABLE          ] = CopyBlistImm;
+        CopyObjFuncs [ t1 +IMMUTABLE          ] = CopyBlist;
         CopyObjFuncs [ t1            +COPYING ] = CopyBlistCopy;
         CopyObjFuncs [ t1 +IMMUTABLE +COPYING ] = CopyBlistCopy;
         CleanObjFuncs[ t1                     ] = CleanBlist;

--- a/src/blister.c
+++ b/src/blister.c
@@ -654,22 +654,6 @@ void AssBlist (
 
 /****************************************************************************
 **
-*F  AssBlistImm( <list>, <pos>, <val> ) . assign to an immutable boolean list
-*/
-void AssBlistImm (
-    Obj                 list,
-    Int                 pos,
-    Obj                 val )
-{
-    ErrorReturnVoid(
-        "Lists Assignment: <list> must be a mutable list",
-        0L, 0L,
-        "you can 'return;' and ignore the assignment" );
-}
-
-
-/****************************************************************************
-**
 *F  AsssBlist( <list>, <poss>, <vals> ) .  assign several elements to a blist
 **
 **  'AsssBlist' assignes the values  from  the list  <vals> at the  positions
@@ -698,22 +682,6 @@ void AsssBlist (     /*  currently not used */
       val = ELMW_LIST(vals, i);
       ASS_LIST( list, pos, val);
     }
-}
-
-
-/****************************************************************************
-**
-*F  AsssBlistImm( <list>, <poss>, <vals> )  . .  assign to an immutable blist
-*/
-void AsssBlistImm (
-    Obj                 list,
-    Obj                 poss,
-    Obj                 val )
-{
-    ErrorReturnVoid(
-        "Lists Assignments: <list> must be a mutable list",
-        0L, 0L,
-        "you can 'return;' and ignore the assignment" );
 }
 
 
@@ -2478,9 +2446,7 @@ static Int InitKernel (
         ElmsListFuncs   [ t1            ] = ElmsBlist;
         ElmsListFuncs   [ t1 +IMMUTABLE ] = ElmsBlist;
         AssListFuncs    [ t1            ] = AssBlist;
-        AssListFuncs    [ t1 +IMMUTABLE ] = AssBlistImm;
         AsssListFuncs   [ t1            ] = AsssListDefault;
-        AsssListFuncs   [ t1 +IMMUTABLE ] = AsssBlistImm;
         IsDenseListFuncs[ t1            ] = AlwaysYes;
         IsDenseListFuncs[ t1 +IMMUTABLE ] = AlwaysYes;
         IsHomogListFuncs[ t1            ] = IsHomogBlist;

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -85,7 +85,7 @@ void            AddPlist3 (
 
     if ( ! IS_MUTABLE_PLIST(list) ) {
         list = ErrorReturnObj(
-                "Lists Assignment: <list> must be a mutable list",
+                "List Assignment: <list> must be a mutable list",
                 0L, 0L,
                 "you may replace <list> via 'return <list>;'" );
         FuncADD_LIST( 0, list, obj );

--- a/src/lists.c
+++ b/src/lists.c
@@ -2613,10 +2613,8 @@ static Int InitKernel (
     }
 
 
-    /* install the generic mutability test function                        */
+    /* install tests for being copyable                                    */
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type += 2 ) {
-        IsMutableObjFuncs[  type           ] = AlwaysYes;
-        IsMutableObjFuncs[  type+IMMUTABLE ] = AlwaysNo;
         IsCopyableObjFuncs[ type           ] = AlwaysYes;
         IsCopyableObjFuncs[ type+IMMUTABLE ] = AlwaysYes;
     }

--- a/src/lists.h
+++ b/src/lists.h
@@ -18,6 +18,7 @@
 #ifndef GAP_LISTS_H
 #define GAP_LISTS_H
 
+#include <src/error.h>
 #include <src/objects.h>
 
 /****************************************************************************
@@ -510,6 +511,12 @@ static inline void ASS_LIST(Obj list, Int pos, Obj obj)
 {
     GAP_ASSERT(pos > 0);
     GAP_ASSERT(obj != 0);
+    UInt tnum = TNUM_OBJ(list);
+    if (FIRST_LIST_TNUM <= tnum && tnum <= LAST_IMM_MUT_TNUM &&
+        (tnum & IMMUTABLE)) {
+        ErrorReturnVoid("List Assignment: <list> must be a mutable list", 0,
+                        0, "you can 'return;' and ignore the assignment");
+    }
     (*AssListFuncs[TNUM_OBJ(list)])(list, pos, obj);
 }
 
@@ -556,6 +563,12 @@ static inline void ASSS_LIST(Obj list, Obj poss, Obj objs)
     GAP_ASSERT(IS_POSS_LIST(poss));
     GAP_ASSERT(IS_DENSE_LIST(objs));
     GAP_ASSERT(LEN_LIST(poss) == LEN_LIST(objs));
+    UInt tnum = TNUM_OBJ(list);
+    if (FIRST_LIST_TNUM <= tnum && tnum <= LAST_IMM_MUT_TNUM &&
+        (tnum & IMMUTABLE)) {
+        ErrorReturnVoid("List Assignments: <list> must be a mutable list", 0,
+                        0, "you can 'return;' and ignore the assignment");
+    }
     (*AsssListFuncs[TNUM_OBJ(list)])(list, poss, objs);
 }
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -518,10 +518,17 @@ extern void CheckedMakeImmutable( Obj obj );
 **  'IS_MUTABLE_OBJ' returns   1 if the object  <obj> is mutable   (i.e., can
 **  change due to assignments), and 0 otherwise.
 */
-#define IS_MUTABLE_OBJ(obj) \
-                        ((*IsMutableObjFuncs[ TNUM_OBJ(obj) ])( obj ))
-
 extern Int (*IsMutableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
+static inline Int IS_MUTABLE_OBJ(Obj obj)
+{
+    UInt tnum = TNUM_OBJ(obj);
+    if (/*FIRST_CONSTANT_TNUM <= tnum &&*/ tnum <= LAST_CONSTANT_TNUM)
+        return 0;
+    if (FIRST_IMM_MUT_TNUM <= tnum && tnum <= LAST_IMM_MUT_TNUM)
+        return !(tnum & IMMUTABLE);
+    return ((*IsMutableObjFuncs[tnum])(obj));
+}
+
 
 /****************************************************************************
 **

--- a/src/objects.h
+++ b/src/objects.h
@@ -532,6 +532,22 @@ static inline Int IS_MUTABLE_OBJ(Obj obj)
 
 /****************************************************************************
 **
+*F  IS_MUTABLE_PLAIN_OBJ( <obj> ) . . . . . .  is an object plain and mutable
+**
+**  'IS_MUTABLE_PLAIN_OBJ' returns 1 if the object <obj> is a plain object
+**  (i.e., built into GAP), and mutable (i.e., can change due to assignments),
+**  and 0 otherwise.
+*/
+static inline Int IS_MUTABLE_PLAIN_OBJ(Obj obj)
+{
+    UInt type = TNUM_OBJ(obj);
+    return (FIRST_IMM_MUT_TNUM <= type) && (type <= LAST_IMM_MUT_TNUM)
+            && !(type & IMMUTABLE);
+}
+
+
+/****************************************************************************
+**
 *F  IsInternallyMutableObj( <obj> ) . . . does an object have a mutable state
 **
 **  This function returns   1 if the object  <obj> has a mutable state, i.e.

--- a/src/objset.c
+++ b/src/objset.c
@@ -1037,11 +1037,6 @@ static Int InitKernel (
   PrintObjFuncs[ T_OBJSET+IMMUTABLE ] = PrintObjSet;
   PrintObjFuncs[ T_OBJMAP           ] = PrintObjMap;
   PrintObjFuncs[ T_OBJMAP+IMMUTABLE ] = PrintObjMap;
-  /* install mutability functions */
-  IsMutableObjFuncs [ T_OBJSET           ] = AlwaysYes;
-  IsMutableObjFuncs [ T_OBJSET+IMMUTABLE ] = AlwaysNo;
-  IsMutableObjFuncs [ T_OBJMAP           ] = AlwaysYes;
-  IsMutableObjFuncs [ T_OBJMAP+IMMUTABLE ] = AlwaysNo;
 
 #ifdef USE_THREADSAFE_COPYING
   SetTraversalMethod(T_OBJSET, TRAVERSE_BY_FUNCTION, TraverseObjSet, CopyObjSet);

--- a/src/plist.c
+++ b/src/plist.c
@@ -1878,18 +1878,6 @@ void AssPlistHomog (
 }
 
 
-void            AssPlistImm (
-    Obj                 list,
-    Int                 pos,
-    Obj                 val )
-{
-    ErrorReturnVoid(
-        "Lists Assignment: <list> must be a mutable list",
-        0L, 0L,
-        "you can 'return;' and ignore the assignment" );
-}
-
-
 /****************************************************************************
 **
 *F  AssPlistEmpty( <list>, <pos>, <val> ) . . . . .  assignment to empty list
@@ -2063,17 +2051,6 @@ void            AsssPlistXXX (
 
     /* and delegate                                                        */
     AsssPlist( list, poss, vals );
-}
-
-void            AsssPlistImm (
-    Obj                 list,
-    Obj                 poss,
-    Obj                 val )
-{
-    ErrorReturnVoid(
-        "Lists Assignments: <list> must be a mutable list",
-        0L, 0L,
-        "you can 'return;' and ignore the assignment" );
 }
 
 
@@ -3886,40 +3863,28 @@ static Int InitKernel (
 
     /* install the list assignment methods                                 */
     AssListFuncs    [ T_PLIST           ] = AssPlist;
-    AssListFuncs    [ T_PLIST+IMMUTABLE ] = AssPlistImm;
     AssListFuncs    [ T_PLIST_NDENSE           ] = AssPlistXXX;
-    AssListFuncs    [ T_PLIST_NDENSE+IMMUTABLE ] = AssPlistImm;
     AssListFuncs    [ T_PLIST_DENSE           ] = AssPlistDense;
-    AssListFuncs    [ T_PLIST_DENSE+IMMUTABLE ] = AssPlistImm;
     AssListFuncs    [ T_PLIST_DENSE_NHOM           ] = AssPlistDense;
-    AssListFuncs    [ T_PLIST_DENSE_NHOM+IMMUTABLE ] = AssPlistImm;
     AssListFuncs    [ T_PLIST_DENSE_NHOM_SSORT           ] = AssPlistDense;
-    AssListFuncs    [ T_PLIST_DENSE_NHOM_SSORT+IMMUTABLE ] = AssPlistImm;
     AssListFuncs    [ T_PLIST_DENSE_NHOM_NSORT           ] = AssPlistDense;
-    AssListFuncs    [ T_PLIST_DENSE_NHOM_NSORT+IMMUTABLE ] = AssPlistImm;
     AssListFuncs    [ T_PLIST_EMPTY           ] = AssPlistEmpty;
-    AssListFuncs    [ T_PLIST_EMPTY+IMMUTABLE ] = AssPlistImm;
     
     
     for ( t1 = T_PLIST_HOM; t1 < T_PLIST_CYC; t1 += 2 ) {
       AssListFuncs[ t1                ] = AssPlistHomog;
-      AssListFuncs[ t1+IMMUTABLE      ] = AssPlistImm;
     }
 
     for ( t1 = T_PLIST_CYC; t1 <= T_PLIST_CYC_SSORT; t1 += 2 ) {
       AssListFuncs[ t1                ] = AssPlistCyc;
-      AssListFuncs[ t1+IMMUTABLE      ] = AssPlistImm;
     }
 
     AssListFuncs[ T_PLIST_FFE           ] = AssPlistFfe;
-    AssListFuncs[ T_PLIST_FFE+IMMUTABLE ] = AssPlistImm;
 
     /* install the list assignments methods                                */
     AsssListFuncs   [ T_PLIST            ] = AsssPlist;
-    AsssListFuncs   [ T_PLIST +IMMUTABLE ] = AsssPlistImm;
     for ( t1 = T_PLIST_NDENSE; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
         AsssListFuncs   [ t1             ] = AsssPlistXXX;
-        AsssListFuncs   [ t1 +IMMUTABLE  ] = AsssPlistImm;
     }
 
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -142,12 +142,12 @@ Int             GrowPlist (
 **
 **  There are 10 functions entered in TypeObjFuncs:
 **      1. TypePlist
-**      2. TypePlistNDenseMut/Imm
-**      3. TypePlistDenseMut/Imm
-**      4. TypePlistDenseNHomMut/Imm
-**      5. TypePlistDenseNHomSSortMut/Imm
-**      6. TypePlistDenseNHomNSortMut/Imm
-**      7. TypePlistEmptyMut/Imm
+**      2. TypePlistNDense
+**      3. TypePlistDense
+**      4. TypePlistDenseNHom
+**      5. TypePlistDenseNHomSSort
+**      6. TypePlistDenseNHomNSort
+**      7. TypePlistEmpty
 **      8. TypePlistHom     -- also handles Tab and RectTab
 **      9. TypePlistCyc
 **      10.TypePlistFfe
@@ -688,65 +688,46 @@ static Obj TypePlistWithKTNum (
 #endif
 }
 
-Obj TypePlistNDenseMut (
-    Obj                 list )
+Obj TypePlistNDense(Obj list)
 {
-    return TYPE_LIST_NDENSE_MUTABLE;
+    if (IS_MUTABLE_PLAIN_OBJ(list))
+        return TYPE_LIST_NDENSE_MUTABLE;
+    else
+        return TYPE_LIST_NDENSE_IMMUTABLE;
 }
 
-Obj TypePlistNDenseImm (
-    Obj                 list )
+#define         TypePlistDense       TypePlist
+
+Obj TypePlistDenseNHom(Obj list)
 {
-    return TYPE_LIST_NDENSE_IMMUTABLE;
+    if (IS_MUTABLE_PLAIN_OBJ(list))
+        return TYPE_LIST_DENSE_NHOM_MUTABLE;
+    else
+        return TYPE_LIST_DENSE_NHOM_IMMUTABLE;
 }
 
-#define         TypePlistDenseMut       TypePlist
-#define         TypePlistDenseImm       TypePlist
-
-Obj TypePlistDenseNHomMut (
-    Obj                 list )
+Obj TypePlistDenseNHomSSort(Obj list)
 {
-    return TYPE_LIST_DENSE_NHOM_MUTABLE;
+    if (IS_MUTABLE_PLAIN_OBJ(list))
+        return TYPE_LIST_DENSE_NHOM_SSORT_MUTABLE;
+    else
+        return TYPE_LIST_DENSE_NHOM_SSORT_IMMUTABLE;
 }
 
-Obj TypePlistDenseNHomImm (
-    Obj                 list )
+Obj TypePlistDenseNHomNSort(Obj list)
 {
-    return TYPE_LIST_DENSE_NHOM_IMMUTABLE;
-}
-Obj TypePlistDenseNHomSSortMut (
-    Obj                 list )
-{
-    return TYPE_LIST_DENSE_NHOM_SSORT_MUTABLE;
+    if (IS_MUTABLE_PLAIN_OBJ(list))
+        return TYPE_LIST_DENSE_NHOM_NSORT_MUTABLE;
+    else
+        return TYPE_LIST_DENSE_NHOM_NSORT_IMMUTABLE;
 }
 
-Obj TypePlistDenseNHomSSortImm (
-    Obj                 list )
+Obj TypePlistEmpty(Obj list)
 {
-    return TYPE_LIST_DENSE_NHOM_SSORT_IMMUTABLE;
-}
-Obj TypePlistDenseNHomNSortMut (
-    Obj                 list )
-{
-    return TYPE_LIST_DENSE_NHOM_NSORT_MUTABLE;
-}
-
-Obj TypePlistDenseNHomNSortImm (
-    Obj                 list )
-{
-    return TYPE_LIST_DENSE_NHOM_NSORT_IMMUTABLE;
-}
-
-Obj TypePlistEmptyMut (
-    Obj                 list )
-{
-    return TYPE_LIST_EMPTY_MUTABLE;
-}
-
-Obj TypePlistEmptyImm (
-    Obj                 list )
-{
-    return TYPE_LIST_EMPTY_IMMUTABLE;
+    if (IS_MUTABLE_PLAIN_OBJ(list))
+        return TYPE_LIST_EMPTY_MUTABLE;
+    else
+        return TYPE_LIST_EMPTY_IMMUTABLE;
 }
 
 Obj TypePlistHom(Obj list)
@@ -3753,18 +3734,18 @@ static Int InitKernel (
     /* install the type methods                                            */
     TypeObjFuncs[ T_PLIST                       ] = TypePlist;
     TypeObjFuncs[ T_PLIST            +IMMUTABLE ] = TypePlist;
-    TypeObjFuncs[ T_PLIST_NDENSE                ] = TypePlistNDenseMut;
-    TypeObjFuncs[ T_PLIST_NDENSE     +IMMUTABLE ] = TypePlistNDenseImm;
-    TypeObjFuncs[ T_PLIST_DENSE                 ] = TypePlistDenseMut;
-    TypeObjFuncs[ T_PLIST_DENSE      +IMMUTABLE ] = TypePlistDenseImm;
-    TypeObjFuncs[ T_PLIST_DENSE_NHOM            ] = TypePlistDenseNHomMut;
-    TypeObjFuncs[ T_PLIST_DENSE_NHOM +IMMUTABLE ] = TypePlistDenseNHomImm;
-    TypeObjFuncs[ T_PLIST_DENSE_NHOM_SSORT      ] = TypePlistDenseNHomSSortMut;
-    TypeObjFuncs[ T_PLIST_DENSE_NHOM_SSORT+IMMUTABLE ] = TypePlistDenseNHomSSortImm;
-    TypeObjFuncs[ T_PLIST_DENSE_NHOM_NSORT      ] = TypePlistDenseNHomNSortMut;
-    TypeObjFuncs[ T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE ] = TypePlistDenseNHomNSortImm;
-    TypeObjFuncs[ T_PLIST_EMPTY                 ] = TypePlistEmptyMut;
-    TypeObjFuncs[ T_PLIST_EMPTY      +IMMUTABLE ] = TypePlistEmptyImm;
+    TypeObjFuncs[ T_PLIST_NDENSE                ] = TypePlistNDense;
+    TypeObjFuncs[ T_PLIST_NDENSE     +IMMUTABLE ] = TypePlistNDense;
+    TypeObjFuncs[ T_PLIST_DENSE                 ] = TypePlistDense;
+    TypeObjFuncs[ T_PLIST_DENSE      +IMMUTABLE ] = TypePlistDense;
+    TypeObjFuncs[ T_PLIST_DENSE_NHOM            ] = TypePlistDenseNHom;
+    TypeObjFuncs[ T_PLIST_DENSE_NHOM +IMMUTABLE ] = TypePlistDenseNHom;
+    TypeObjFuncs[ T_PLIST_DENSE_NHOM_SSORT            ] = TypePlistDenseNHomSSort;
+    TypeObjFuncs[ T_PLIST_DENSE_NHOM_SSORT +IMMUTABLE ] = TypePlistDenseNHomSSort;
+    TypeObjFuncs[ T_PLIST_DENSE_NHOM_NSORT            ] = TypePlistDenseNHomNSort;
+    TypeObjFuncs[ T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE ] = TypePlistDenseNHomNSort;
+    TypeObjFuncs[ T_PLIST_EMPTY                 ] = TypePlistEmpty;
+    TypeObjFuncs[ T_PLIST_EMPTY      +IMMUTABLE ] = TypePlistEmpty;
 
     for ( t1 = T_PLIST;  t1 <= LAST_PLIST_TNUM;  t1 += 2 ) {
         SetTypeObjFuncs[ t1 ] = SetTypePlistToPosObj;

--- a/src/precord.c
+++ b/src/precord.c
@@ -356,7 +356,7 @@ Obj ElmPRec (
         return GET_ELM_PREC( rec, i );
     else {
         ErrorReturnVoid(
-            "Record: '<rec>.%g' must have an assigned value",
+            "Record Element: '<rec>.%g' must have an assigned value",
             (Int)NAME_RNAM(rnam), 0L,
             "you can 'return;' after assigning a value" );
         return ELM_REC( rec, rnam );
@@ -424,7 +424,7 @@ void AssPRec (
     // Accept T_PREC and T_COMOBJ, reject T_PREC+IMMUTABLE
     if (TNUM_OBJ(rec) == T_PREC+IMMUTABLE) {
         ErrorReturnVoid(
-            "Records Assignment: <rec> must be a mutable record",
+            "Record Assignment: <rec> must be a mutable record",
             0L, 0L,
             "you can 'return;' and ignore the assignment" );
     }

--- a/src/precord.c
+++ b/src/precord.c
@@ -915,9 +915,7 @@ static Int InitKernel (
     UnbRecFuncs[ T_PREC            ] = UnbPRec;
     UnbRecFuncs[ T_PREC +IMMUTABLE ] = UnbPRecImm;
 
-    /* install mutability test                                             */
-    IsMutableObjFuncs[  T_PREC            ] = AlwaysYes;
-    IsMutableObjFuncs[  T_PREC +IMMUTABLE ] = AlwaysNo;
+    /* install tests for being copyable                                    */
     IsCopyableObjFuncs[ T_PREC            ] = AlwaysYes;
     IsCopyableObjFuncs[ T_PREC +IMMUTABLE ] = AlwaysYes;
 

--- a/src/precord.c
+++ b/src/precord.c
@@ -378,6 +378,14 @@ void UnbPRec (
     UInt                len;            /* length of <rec>                 */
     UInt                i;              /* loop variable                   */
 
+    // Accept T_PREC and T_COMOBJ, reject T_PREC+IMMUTABLE
+    if (TNUM_OBJ(rec) == T_PREC+IMMUTABLE) {
+        ErrorReturnVoid(
+            "Record Unbind: <rec> must be a mutable record",
+            0L, 0L,
+            "you can 'return;' and ignore the unbind" );
+    }
+
     if (FindPRec( rec, rnam, &i, 1 )) {
         /* otherwise move everything forward                               */
         len = LEN_PREC( rec );
@@ -397,16 +405,6 @@ void UnbPRec (
         return;
 }
 
-void            UnbPRecImm (
-    Obj                 rec,
-    UInt                rnam )
-{
-    ErrorReturnVoid(
-        "Record Unbind: <rec> must be a mutable record",
-        0L, 0L,
-        "you can 'return;' and ignore the unbind" );
-}
-
 
 /****************************************************************************
 **
@@ -422,6 +420,14 @@ void AssPRec (
 {
     UInt                len;            /* length of <rec>                 */
     UInt                i;              /* loop variable                   */
+
+    // Accept T_PREC and T_COMOBJ, reject T_PREC+IMMUTABLE
+    if (TNUM_OBJ(rec) == T_PREC+IMMUTABLE) {
+        ErrorReturnVoid(
+            "Records Assignment: <rec> must be a mutable record",
+            0L, 0L,
+            "you can 'return;' and ignore the assignment" );
+    }
 
     /* get the length of the record                                        */
     len = LEN_PREC( rec );
@@ -442,17 +448,6 @@ void AssPRec (
     /* assign the value to the component                                   */
     SET_ELM_PREC( rec, i, val );
     CHANGED_BAG( rec );
-}
-
-void            AssPRecImm (
-    Obj                 rec,
-    UInt                rnam,
-    Obj                 val )
-{
-    ErrorReturnVoid(
-        "Records Assignment: <rec> must be a mutable record",
-        0L, 0L,
-        "you can 'return;' and ignore the assignment" );
 }
 
 /****************************************************************************
@@ -902,9 +897,9 @@ static Int InitKernel (
     IsbRecFuncs[ T_PREC            ] = IsbPRec;
     IsbRecFuncs[ T_PREC +IMMUTABLE ] = IsbPRec;
     AssRecFuncs[ T_PREC            ] = AssPRec;
-    AssRecFuncs[ T_PREC +IMMUTABLE ] = AssPRecImm;
+    AssRecFuncs[ T_PREC +IMMUTABLE ] = AssPRec;
     UnbRecFuncs[ T_PREC            ] = UnbPRec;
-    UnbRecFuncs[ T_PREC +IMMUTABLE ] = UnbPRecImm;
+    UnbRecFuncs[ T_PREC +IMMUTABLE ] = UnbPRec;
 
     /* install tests for being copyable                                    */
     IsCopyableObjFuncs[ T_PREC            ] = AlwaysYes;

--- a/src/precord.c
+++ b/src/precord.c
@@ -61,20 +61,11 @@
 **  'TypePRec' is the function in 'TypeObjFuncs' for plain records.
 */
 Obj TYPE_PREC_MUTABLE;
-
-Obj TypePRecMut (
-    Obj                 prec )
-{
-    return TYPE_PREC_MUTABLE;
-}
-
-
 Obj TYPE_PREC_IMMUTABLE;
 
-Obj TypePRecImm (
-    Obj                 prec )
+Obj TypePRec(Obj prec)
 {
-    return TYPE_PREC_IMMUTABLE;
+    return IS_MUTABLE_PLAIN_OBJ(prec) ? TYPE_PREC_MUTABLE : TYPE_PREC_IMMUTABLE;
 }
 
 /****************************************************************************
@@ -944,8 +935,8 @@ static Int InitKernel (
     ImportGVarFromLibrary( "TYPE_PREC_MUTABLE",   &TYPE_PREC_MUTABLE   );
     ImportGVarFromLibrary( "TYPE_PREC_IMMUTABLE", &TYPE_PREC_IMMUTABLE );
 
-    TypeObjFuncs[ T_PREC            ] = TypePRecMut;
-    TypeObjFuncs[ T_PREC +IMMUTABLE ] = TypePRecImm;
+    TypeObjFuncs[ T_PREC            ] = TypePRec;
+    TypeObjFuncs[ T_PREC +IMMUTABLE ] = TypePRec;
 
     SetTypeObjFuncs[ T_PREC ] = SetTypePRecToComObj;
 

--- a/src/range.c
+++ b/src/range.c
@@ -511,17 +511,6 @@ void            AssRange (
     CHANGED_BAG( list );
 }
 
-void            AssRangeImm (
-    Obj                 list,
-    Int                 pos,
-    Obj                 val )
-{
-    ErrorReturnVoid(
-        "Lists Assignment: <list> must be a mutable list",
-        0L, 0L,
-        "you can 'return;' and ignore the assignment" );
-}
-
 
 /****************************************************************************
 **
@@ -550,17 +539,6 @@ void            AsssRange (
 
     /* and delegate                                                        */
     ASSS_LIST( list, poss, vals );
-}
-
-void            AsssRangeImm (
-    Obj                 list,
-    Obj                 poss,
-    Obj                 val )
-{
-    ErrorReturnVoid(
-        "Lists Assignments: <list> must be a mutable list",
-        0L, 0L,
-        "you can 'return;' and ignore the assignment" );
 }
 
 
@@ -1376,13 +1354,9 @@ static Int InitKernel (
     ElmsListFuncs   [ T_RANGE_SSORT            ] = ElmsRange;
     ElmsListFuncs   [ T_RANGE_SSORT +IMMUTABLE ] = ElmsRange;
     AssListFuncs    [ T_RANGE_NSORT            ] = AssRange;
-    AssListFuncs    [ T_RANGE_NSORT +IMMUTABLE ] = AssRangeImm;
     AssListFuncs    [ T_RANGE_SSORT            ] = AssRange;
-    AssListFuncs    [ T_RANGE_SSORT +IMMUTABLE ] = AssRangeImm;
     AsssListFuncs   [ T_RANGE_NSORT            ] = AsssRange;
-    AsssListFuncs   [ T_RANGE_NSORT +IMMUTABLE ] = AsssRangeImm;
     AsssListFuncs   [ T_RANGE_SSORT            ] = AsssRange;
-    AsssListFuncs   [ T_RANGE_SSORT +IMMUTABLE ] = AsssRangeImm;
     IsDenseListFuncs[ T_RANGE_NSORT            ] = AlwaysYes;
     IsDenseListFuncs[ T_RANGE_NSORT +IMMUTABLE ] = AlwaysYes;
     IsDenseListFuncs[ T_RANGE_SSORT            ] = AlwaysYes;

--- a/src/range.c
+++ b/src/range.c
@@ -66,65 +66,38 @@
 
 /****************************************************************************
 **
-*F  TypeRangeNSortImmutable( <range> )  . . . . . . . . . . . type of a range
+*F  TypeRangeNSort( <range> ) . . . . . . . . . . . . . . . . type of a range
 **
-**  'TypeRangeNSortMutable' is the   function in 'TypeObjFuncs' for immutable
-**  ranges which are not strictly sorted.
+**  'TypeRangeNSort' is the  function in 'TypeObjFuncs' for ranges which are
+**  not strictly sorted.
 */
 Obj TYPE_RANGE_NSORT_IMMUTABLE;
-
-Obj TypeRangeNSortImmutable (
-    Obj                 list )
-{
-    return TYPE_RANGE_NSORT_IMMUTABLE;
-}
-    
-/****************************************************************************
-**
-*F  TypeRangeNSortMutable( <range> )  . . . . . . . . . . . . type of a range
-**
-**  'TypeRangeNSortMutable' is the   function in 'TypeObjFuncs' for   mutable
-**  ranges which are not strictly sorted.
-*/
 Obj TYPE_RANGE_NSORT_MUTABLE;
 
-Obj TypeRangeNSortMutable (
-    Obj                 list )
+Obj TypeRangeNSort(Obj list)
 {
-    return TYPE_RANGE_NSORT_MUTABLE;
+    return IS_MUTABLE_PLAIN_OBJ(list) ? TYPE_RANGE_NSORT_MUTABLE
+                                      : TYPE_RANGE_NSORT_IMMUTABLE;
 }
+
     
 /****************************************************************************
 **
-*F  TypeRangeSSortImmutable( <range> )  . . . . . . . . . . . type of a range
+*F  TypeRangeSSort( <range> ) . . . . . . . . . . . . . . . . type of a range
 **
-**  'TypeRangeNSortMutable' is the   function in 'TypeObjFuncs' for immutable
-**  ranges which are strictly sorted.
+**  'TypeRangeSSort' is the function in 'TypeObjFuncs' for ranges which are
+**  strictly sorted.
 */
 Obj TYPE_RANGE_SSORT_IMMUTABLE;
-
-Obj TypeRangeSSortImmutable (
-    Obj                 list )
-{
-    return TYPE_RANGE_SSORT_IMMUTABLE;
-}
-
-
-/****************************************************************************
-**
-*F  TypeRangeSSortMutable( <range> )  . . . . . . . . . . . . type of a range
-**
-**  'TypeRangeNSortMutable' is the   function in 'TypeObjFuncs' for   mutable
-**  ranges which are strictly sorted.
-*/
 Obj TYPE_RANGE_SSORT_MUTABLE;
 
-Obj TypeRangeSSortMutable (
-    Obj                 list )
+Obj TypeRangeSSort(Obj list)
 {
-    return TYPE_RANGE_SSORT_MUTABLE;
+    return IS_MUTABLE_PLAIN_OBJ(list) ? TYPE_RANGE_SSORT_MUTABLE
+                                      : TYPE_RANGE_SSORT_IMMUTABLE;
 }
-    
+
+
 #if !defined(USE_THREADSAFE_COPYING)
 
 /****************************************************************************
@@ -1304,10 +1277,10 @@ static Int InitKernel (
     ImportGVarFromLibrary( "TYPE_RANGE_SSORT_IMMUTABLE",
                            &TYPE_RANGE_SSORT_IMMUTABLE );
 
-    TypeObjFuncs[ T_RANGE_NSORT            ] = TypeRangeNSortMutable;
-    TypeObjFuncs[ T_RANGE_NSORT +IMMUTABLE ] = TypeRangeNSortImmutable;
-    TypeObjFuncs[ T_RANGE_SSORT            ] = TypeRangeSSortMutable;
-    TypeObjFuncs[ T_RANGE_SSORT +IMMUTABLE ] = TypeRangeSSortImmutable;
+    TypeObjFuncs[ T_RANGE_NSORT            ] = TypeRangeNSort;
+    TypeObjFuncs[ T_RANGE_NSORT +IMMUTABLE ] = TypeRangeNSort;
+    TypeObjFuncs[ T_RANGE_SSORT            ] = TypeRangeSSort;
+    TypeObjFuncs[ T_RANGE_SSORT +IMMUTABLE ] = TypeRangeSSort;
 
     /* init filters and functions                                          */
     InitHdlrFiltsFromTable( GVarFilts );

--- a/src/records.c
+++ b/src/records.c
@@ -414,7 +414,7 @@ Int             IsbRecError (
     UInt                rnam )
 {
     rec = ErrorReturnObj(
-        "IsBound: <rec> must be a record (not a %s)",
+        "Record IsBound: <rec> must be a record (not a %s)",
         (Int)TNAM_OBJ(rec), 0L,
         "you can replace <rec> via 'return <rec>;'" );
     return ISB_REC( rec, rnam );
@@ -509,7 +509,7 @@ void            UnbRecError (
     UInt                rnam )
 {
     rec = ErrorReturnObj(
-        "Unbind: <rec> must be a record (not a %s)",
+        "Record Unbind: <rec> must be a record (not a %s)",
         (Int)TNAM_OBJ(rec), 0L,
         "you can replace <rec> via 'return <rec>;'" );
     UNB_REC( rec, rnam );

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -1072,17 +1072,6 @@ void AssString (
   }
 }    
 
-void AssStringImm (
-    Obj                 list,
-    Int                 pos,
-    Obj                 val )
-{
-    ErrorReturnVoid(
-        "Lists Assignment: <list> must be a mutable list",
-        0L, 0L,
-        "you can 'return;' and ignore the assignment" );
-}
-
 
 /****************************************************************************
 **
@@ -1109,17 +1098,6 @@ void AsssString (
   for (i = 1; i <= len; i++) {
     ASS_LIST(list, INT_INTOBJ(ELM_LIST(poss, i)), ELM_LIST(vals, i));
   }
-}
-
-void AsssStringImm (
-    Obj                 list,
-    Obj                 poss,
-    Obj                 val )
-{
-    ErrorReturnVoid(
-        "Lists Assignments: <list> must be a mutable list",
-        0L, 0L,
-        "you can 'return;' and ignore the assignment" );
 }
 
 
@@ -2402,9 +2380,7 @@ static Int InitKernel (
         ElmsListFuncs   [ t1            ] = ElmsString;
         ElmsListFuncs   [ t1 +IMMUTABLE ] = ElmsString;
         AssListFuncs    [ t1            ] = AssString;
-        AssListFuncs    [ t1 +IMMUTABLE ] = AssStringImm;
         AsssListFuncs   [ t1            ] = AsssString;
-        AsssListFuncs   [ t1 +IMMUTABLE ] = AsssStringImm;
         IsDenseListFuncs[ t1            ] = AlwaysYes;
         IsDenseListFuncs[ t1 +IMMUTABLE ] = AlwaysYes;
         IsHomogListFuncs[ t1            ] = IsHomogString;

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -2971,7 +2971,7 @@ Obj FuncASS_VEC8BIT (
     /* check that <list> is mutable                                        */
     if (! IS_MUTABLE_OBJ(list)) {
         ErrorReturnVoid(
-            "Lists Assignment: <list> must be a mutable list",
+            "List Assignment: <list> must be a mutable list",
             0L, 0L,
             "you can 'return;' and ignore the assignment");
         return 0;
@@ -3081,9 +3081,9 @@ Obj FuncUNB_VEC8BIT (
     /* check that <list> is mutable                                        */
     if (! IS_MUTABLE_OBJ(list)) {
         ErrorReturnVoid(
-            "Lists Assignment: <list> must be a mutable list",
+            "List Unbind: <list> must be a mutable list",
             0L, 0L,
-            "you can 'return;' and ignore the assignment");
+            "you can 'return;' and ignore the unbind");
         return 0;
     }
     if (True == DoFilter(IsLockedRepresentationVector, list)) {

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1933,7 +1933,7 @@ Obj FuncASS_GF2VEC (
     /* check that <list> is mutable                                        */
     if ( ! IS_MUTABLE_OBJ(list) ) {
         ErrorReturnVoid(
-            "Lists Assignment: <list> must be a mutable list",
+            "List Assignment: <list> must be a mutable list",
             0L, 0L,
             "you can 'return;' and ignore the assignment" );
         return 0;
@@ -2016,7 +2016,7 @@ Obj FuncASS_GF2MAT (
     /* check that <list> is mutable                                        */
     if ( ! IS_MUTABLE_OBJ(list) ) {
         ErrorReturnVoid(
-            "Lists Assignment: <list> must be a mutable list",
+            "List Assignment: <list> must be a mutable list",
             0L, 0L,
             "you can 'return;' and ignore the assignment" );
         return 0;
@@ -2098,9 +2098,9 @@ Obj FuncUNB_GF2VEC (
     /* check that <list> is mutable                                        */
     if ( ! IS_MUTABLE_OBJ(list) ) {
         ErrorReturnVoid(
-            "Unbind: <list> must be a mutable list",
+            "List Unbind: <list> must be a mutable list",
             0L, 0L,
-            "you can 'return;' and ignore the operation" );
+            "you can 'return;' and ignore the unbind" );
         return 0;
     }
 
@@ -2153,9 +2153,9 @@ Obj FuncUNB_GF2MAT (
     /* check that <list> is mutable                                        */
     if ( ! IS_MUTABLE_OBJ(list) ) {
         ErrorReturnVoid(
-            "Lists Assignment: <list> must be a mutable list",
+            "List Unbind: <list> must be a mutable list",
             0L, 0L,
-            "you can 'return;' and ignore the assignment" );
+            "you can 'return;' and ignore the unbind" );
         return 0;
     }
 

--- a/tst/testinstall/function.tst
+++ b/tst/testinstall/function.tst
@@ -91,7 +91,7 @@ gap> Info(InfoWarning, 1000, f());
 gap> r.(f());
 Error, Function call: <func> must return a value
 gap> r.(g());
-Error, Record: '<rec>.2' must have an assigned value
+Error, Record Element: '<rec>.2' must have an assigned value
 gap> (function() end)();
 gap> (function() return 2; end)();
 2

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -272,7 +272,7 @@ gap> l[2,1];
 Error, List Element: <list>[2] must have an assigned value
 gap> MakeImmutable(l[1]);;
 gap> l[1,1] := 2;;
-Error, Lists Assignment: <list> must be a mutable list
+Error, List Assignment: <list> must be a mutable list
 gap> l;
 [ [ 3, 4 ] ]
 

--- a/tst/testinstall/matblock.tst
+++ b/tst/testinstall/matblock.tst
@@ -34,7 +34,7 @@ gap> Length( z );  DimensionsMat( z );
 gap> m1[3];
 [ 0, 0, 0, 1, 0, 0, 0, 0 ]
 gap> m1[3][4] := 4;
-Error, Lists Assignment: <list> must be a mutable list
+Error, List Assignment: <list> must be a mutable list
 gap> m1[3];
 [ 0, 0, 0, 1, 0, 0, 0, 0 ]
 gap> z[2];

--- a/tst/testinstall/range.tst
+++ b/tst/testinstall/range.tst
@@ -80,7 +80,7 @@ Error, List Elements: <list>[7] must have an assigned value
 gap> [-5,-3..5]{[1..6]};
 [ -5, -3 .. 5 ]
 gap> Immutable([-5,-3..5])[3] := 2;
-Error, Lists Assignment: <list> must be a mutable list
+Error, List Assignment: <list> must be a mutable list
 gap> x := [-5,-3..5];
 [ -5, -3 .. 5 ]
 gap> x[2] := 7;
@@ -88,7 +88,7 @@ gap> x[2] := 7;
 gap> x;
 [ -5, 7, -1, 1, 3, 5 ]
 gap> Immutable([-5,-3..5]){[2,4]} := [2..3];
-Error, Lists Assignments: <list> must be a mutable list
+Error, List Assignments: <list> must be a mutable list
 gap> x := [-5,-3..5];
 [ -5, -3 .. 5 ]
 gap> x{[2,5,3]};
@@ -100,7 +100,7 @@ gap> x;
 gap> x{[2,4]} := [2..4];
 Error, List Assignment: <rhss> must have the same length as <positions> (2)
 gap> Immutable([-5,-3..5]){[2..3]} := [2..3];
-Error, Lists Assignments: <list> must be a mutable list
+Error, List Assignments: <list> must be a mutable list
 gap> x := [-5,-3..5];
 [ -5, -3 .. 5 ]
 gap> x{[2..3]};

--- a/tst/testinstall/recordname.tst
+++ b/tst/testinstall/recordname.tst
@@ -10,9 +10,9 @@ rec( x := 2 )
 gap> Unbind(x.x);
 Error, Record Unbind: <rec> must be a mutable record
 gap> x.y := 2;
-Error, Records Assignment: <rec> must be a mutable record
+Error, Record Assignment: <rec> must be a mutable record
 gap> x.x := 2;
-Error, Records Assignment: <rec> must be a mutable record
+Error, Record Assignment: <rec> must be a mutable record
 gap> r := rec(x := 2, y := 3);
 rec( x := 2, y := 3 )
 gap> r.x;


### PR DESCRIPTION
UPDATE: I believe this could be merged now. Also, I submitted issue #2325 for the general (im)mutability plan.

This PR builds extends PR #1570, and again is motivated by PR #1563: It unifies some code to reduce difference between mutable and immutable cases. The number of word occurrences of `IMMUTABLE`, as counted by `git grep -w IMMUTABLE src | wc -l` goes slightly down from 1328 to 565. But once one runs the script below, it goes down to 309, i.e. a quarter of what we started with.

This now makes it much easier to decide how to deal with the rest. Some immediate observations on those:
* [x] adding a `NEW_IMM_PLIST` function (possibly with a different name) would take care of quite a few of those occurences (and this function could immediately set the new `OBJ_FLAG_IMMUTABLE`)
* [ ] a lot of code deals with creating a new object with mutability identical to another object; could have a function for that, too
* [ ] but in a few cases, the mutability depends on a more complex logic... also, there are a bunch of `RetypeBag` calls to change immutability... it might be useful to have a faster variant of `MakeImmutable`, which is only useful for builtin lists and record, and directly modifies the TNUM (now) resp. object flag (with PR #1563)
* [ ] for HPC-GAP, `MakeBagTypePublic` cannot be used to automatically migrate immutable list and record bags to the public region. No big deal, though (and I actually like that we can thus remove some logic from `RetypeBag`)
* [ ] `IsMutableObjFuncs` likely can and should be removed once we get rid of the `IMMUTABLE` bit in the TNUM

Here is the script I mentioned above:

```gap
files:=[];
for dir in [ "src", "src/hpc" ] do
    dir:=Directory(dir);
    fs:=DirectoryContents(dir);
    fs:=Filtered(fs, f->EndsWith(f,".c"));
    Append(files, List(fs, f -> Filename(dir,f)));
od;


for f in files do
    Print("Processing ", f, "\n");
    data:=StringFile(f);
    lines:=SplitString(data,"\n");
    i := 2;
    while i <= Length(lines) do
        if PositionSublist(lines[i], "IMMUTABLE") = fail then
            i := i + 1;
            continue;
        fi;
        str := ReplacedString(lines[i], "+IMMUTABLE", "          ");
        if str = lines[i-1] then
            Remove(lines, i);
        fi;
        i := i + 1;
    od;
    out:=JoinStringsWithSeparator(lines, "\n");
    Add(out,'\n');
    FileString(f,out);
od;
```