### PR TITLE
Prevent Z(p,d), p non-prime, from breaking the type system

### DIFF
--- a/src/finfield.c
+++ b/src/finfield.c
@@ -544,6 +544,8 @@ FF              FiniteField (
     }
     if (ff < 1 || ff > NUM_SHORT_FINITE_FIELDS)
       return 0;
+    if (CharFF[ff] != p)
+      return 0;
     if (SizeFF[ff] != q)
       return 0;
 #ifdef HPCGAP
@@ -1700,7 +1702,6 @@ Obj FuncIS_FFE (
 **  with respect to the root <r> which must lie in the same field like <z>.
 */
 Obj LOG_FFE_LARGE;
-#include <stdio.h>
 
 Obj FuncLOG_FFE_DEFAULT (
     Obj                 self,

--- a/tst/testbugfix/2017-08-07-FFE-bad-char.tst
+++ b/tst/testbugfix/2017-08-07-FFE-bad-char.tst
@@ -1,0 +1,13 @@
+# Invoking Z(p,d) with p not a prime used to crash gap, which we fixed.
+# However, invocations like `Z(4,5)` still would erroneously trigger the
+# creation of a type object for fields of size p^d (in the example: 1024),
+# with the non-prime value p set as characteristic. This could then corrupt
+# subsequent computations.
+gap> Z(4,5);
+Error, Z: <p> must be a prime
+gap> FieldByGenerators(GF(2), [ Z(1024) ]);
+GF(2^10)
+gap> Characteristic(Z(1024));
+2
+gap> Characteristic(FamilyObj(Z(1024)));
+2


### PR DESCRIPTION
Invoking Z(p,d) with p not a prime used to crash gap, which we fixed.
However, invocations like `Z(4,5)` still would erroneously trigger the
creation of a type object for fields of size p^d (in the example: 1024),
with the non-prime value p set as characteristic. This could then corrupt
subsequent computations.

Also get rid of a stray #include.


This should resolve the error in PR #1569 