### PR TITLE
Some tweaks to p-groups code

### DIFF
--- a/grp/basicmat.gi
+++ b/grp/basicmat.gi
@@ -402,7 +402,8 @@ MaximalUnipotentSubgroupOfNaturalGL := function( gl )
     )
   );
   SetSize( u, Size(q)^Binomial(n,2) );
-  IsPGroup( u );
+  SetIsPGroup( u, true );
+  SetPrimePGroup( u, Characteristic(q) );
   return u;
 end;
 

--- a/hpcgap/lib/grppc.gi
+++ b/hpcgap/lib/grppc.gi
@@ -223,7 +223,7 @@ end);
 ##
 #M  Pcgs( <G> )
 ##
-InstallMethod( Pcgs, "fail if insolvable", true,
+InstallMethod( Pcgs, "fail if not solvable", true,
         [ HasIsSolvableGroup ], 
 	SUM_FLAGS, # for groups for which we know that they are not solvable
 	           # this is the best we can do.

--- a/hpcgap/lib/grppc.gi
+++ b/hpcgap/lib/grppc.gi
@@ -2509,8 +2509,8 @@ function(G,bound)
         return monic(LGLayers(pcgs),PrimePGroup(G),a->Order(PcElementByExponents(pcgs,a)));
 end);
 
-InstallMethod( Exponent,"solvable group",
-  true,[IsGroup and IsSolvableGroup],0,
+InstallMethod( Exponent,"finite solvable group",
+  true,[IsGroup and IsSolvableGroup and IsFinite],0,
 function(G)
 local exp, primes, p;
   if IsPGroup(G) then 

--- a/hpcgap/small/small11/smlgp11.g
+++ b/hpcgap/small/small11/smlgp11.g
@@ -257,6 +257,7 @@ SMALL_GROUP_FUNCS[ 26 ] := function( size, i, inforec )
 
     g := GroupByRwsNC( c );
     SetIsPGroup( g, true );
+    SetPrimePGroup( g, p );
     return g;
 end;
 

--- a/hpcgap/small/small9/smlgp9.g
+++ b/hpcgap/small/small9/smlgp9.g
@@ -128,6 +128,7 @@ SMALL_GROUP_FUNCS[ 19 ] := function( size, i, inforec )
 
     g := GroupByRwsNC( c );
     SetIsPGroup( g, true );
+    SetPrimePGroup( g, p );
     return g;
 end;
 
@@ -509,6 +510,7 @@ SMALL_GROUP_FUNCS[ 20 ] := function( size, i, inforec )
 
     g := GroupByRwsNC( c );
     SetIsPGroup( g, true );
+    SetPrimePGroup( g, p );
     return g;
 end;
 

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -444,12 +444,12 @@ InstallTrueMethod( IsPGroup, IsGroup and IsElementaryAbelian );
 ##  <Prop Name="IsPowerfulPGroup" Arg='G'/>
 ##
 ##  <Description>
-##  <Index Key="PowerfulPGroup">Powerful <M> p</M>-group</Index>
-##  A finite p-group <A>G</A> is said to be a Powerful <M>p</M>-group if the 
-##  commutator subgroup <M>[<A>G</A>,<A>G</A>]</M> is contained in
+##  <Index Key="PowerfulPGroup">Powerful <M>p</M>-group</Index>
+##  A finite p-group <A>G</A> is said to be a <E>powerful <M>p</M>-group</E>
+##  if the commutator subgroup <M>[<A>G</A>,<A>G</A>]</M> is contained in
 ##  <M><A>G</A>^{p}</M> if the prime <M>p</M> is odd, or if
 ##  <M>[<A>G</A>,<A>G</A>]</M> is contained in <M><A>G</A>^{4}</M> 
-##  if<M> p = 2</M>. The subgroup <M><A>G</A>^{p}</M> is called the first 
+##  if <M>p = 2</M>. The subgroup <M><A>G</A>^{p}</M> is called the first 
 ##  Agemo subgroup, (see&nbsp;<Ref Func="Agemo"/>).
 ##  <Ref Prop="IsPowerfulPGroup"/> returns <K>true</K> if <A>G</A> is a 
 ##  powerful <M>p</M>-group, and <K>false</K> otherwise. 

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -465,7 +465,8 @@ DeclareProperty( "IsPowerfulPGroup", IsGroup );
 InstallFactorMaintenance( IsPowerfulPGroup,
     IsPowerfulPGroup, IsGroup, IsGroup );
 #abelian p-groups are powerful
-InstallTrueMethod( IsPowerfulPGroup, IsPGroup and IsAbelian );
+InstallTrueMethod( IsPowerfulPGroup, IsFinite and IsPGroup and IsAbelian );
+InstallTrueMethod( IsPGroup, IsPowerfulPGroup );
 
 #############################################################################
 ##
@@ -567,7 +568,7 @@ InstallFactorMaintenance( IsNilpotentGroup,
 
 InstallTrueMethod( IsNilpotentGroup, IsGroup and IsCommutative );
 
-InstallTrueMethod( IsNilpotentGroup, IsGroup and IsPGroup );
+InstallTrueMethod( IsNilpotentGroup, IsGroup and IsPGroup and IsFinite );
 
 
 #############################################################################

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -83,7 +83,7 @@ function(G)
   TryNextMethod();
 end);
 
-InstallMethod( MinimalGeneratingSet,"cyclic groups",true,
+InstallMethod( MinimalGeneratingSet,"finite cyclic groups",true,
     [ IsGroup and IsCyclic and IsFinite ],
     RankFilter(IsFinite and IsPcGroup),
 function ( G )
@@ -251,13 +251,15 @@ InstallMethod( IsPGroup,
     # known *and* the group knows to be nilpotent or is abelian;
     # thus an `IsAbelian' test may be forced (which can be done via comparing
     # products of generators) but *not* an `IsNilpotent' test.
-    if     ( not HasSize( G ) )
-       and (    ( HasIsNilpotentGroup( G ) and IsNilpotentGroup( G ) )
-             or IsAbelian( G ) ) then
+    if HasSize( G ) and IsFinite( G ) then
+      return IS_PGROUP_FROM_SIZE( G );
+    elif ( HasIsNilpotentGroup( G ) and IsNilpotentGroup( G ) )
+             or IsAbelian( G ) then
       return IS_PGROUP_FOR_NILPOTENT( G );
-    else
+    elif IsFinite( G ) then
       return IS_PGROUP_FROM_SIZE( G );
     fi;
+    TryNextMethod();
     end );
 
 InstallMethod( IsPGroup,
@@ -266,7 +268,7 @@ InstallMethod( IsPGroup,
     function( G )
     local s, gen, ord;
 
-    if HasSize( G ) then
+    if HasSize( G ) and IsFinite( G ) then
       return IS_PGROUP_FROM_SIZE( G );
     else
       return IS_PGROUP_FOR_NILPOTENT( G );
@@ -1072,7 +1074,7 @@ InstallOtherMethod( ElementaryAbelianSeries,
     end );
 
 InstallMethod( ElementaryAbelianSeries,
-    "generic method for groups",
+    "generic method for finite groups",
     [ IsGroup and IsFinite],
     function( G )
     local f;
@@ -1132,8 +1134,8 @@ InstallOtherMethod( ElementaryAbelianSeriesLargeSteps,
 #M  Exponent( <G> ) . . . . . . . . . . . . . . . . . . . . . exponent of <G>
 ##
 InstallMethod( Exponent,
-    "generic method for groups",
-    [ IsGroup ],
+    "generic method for finite groups",
+    [ IsGroup and IsFinite ],
 function(G)
   local exp, primes, p;
   exp := 1;
@@ -1145,17 +1147,17 @@ function(G)
 end);
 
 InstallMethod( Exponent,
-    "method for abelian groups with generators",
-    [ IsGroup and IsAbelian and HasGeneratorsOfGroup],
+    "method for finite abelian groups with generators",
+    [ IsGroup and IsAbelian and HasGeneratorsOfGroup and IsFinite ],
     function( G )
     G:= GeneratorsOfGroup( G );
     if IsEmpty( G ) then
       return 1;
-    else
-      return Lcm( List( G, Order ) );
     fi;
+    return Lcm( List( G, Order ) );
     end );
 
+RedispatchOnCondition( Exponent, true, [IsGroup], [IsFinite], 0);
 
 #############################################################################
 ##
@@ -1165,7 +1167,7 @@ InstallMethod( FittingSubgroup, "for nilpotent group",
     [ IsGroup and IsNilpotentGroup ], SUM_FLAGS, IdFunc );
 
 InstallMethod( FittingSubgroup,
-    "generic method for groups",
+    "generic method for finite groups",
     [ IsGroup and IsFinite ],
     function (G)
         if not IsTrivial( G ) then

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -348,7 +348,7 @@ local gen, s;
       break;
     fi;
   od;
-  return Factors( s )[1];
+  return SmallestRootInt( s );
 end );
 
 InstallMethod( PrimePGroup,
@@ -365,7 +365,7 @@ local s;
   if s = 1 then
     return fail;
   fi;
-  return Factors( s )[1];
+  return SmallestRootInt( s );
 end );
 
 RedispatchOnCondition (PrimePGroup, true,
@@ -399,7 +399,7 @@ InstallMethod( IsNilpotentGroup,
     s := Size ( G );
     if IsInt( s ) and IsPrimePowerInt( s ) then
         SetIsPGroup( G, true );
-        SetPrimePGroup( G, Factors( s )[1] );
+        SetPrimePGroup( G, SmallestRootInt( s ) );
         return true;
     else
         SetIsPGroup( G, false );
@@ -1025,7 +1025,7 @@ InstallMethod( DimensionsLoewyFactors,
     fi;
 
     # get the prime and the Jennings series
-    p := FactorsInt( Size( G ) )[1];
+    p := PrimePGroup( G );
     J := JenningsSeries( G );
 
     # construct the Jennings polynomial over the rationals
@@ -1268,7 +1268,7 @@ InstallMethod( JenningsSeries,
     fi;
 
     # get the prime
-    p := FactorsInt(Size(G))[1];
+    p := PrimePGroup( G );
 
     # and compute the series
     # (this is a new variant thanks to Laurent Bartholdi)
@@ -1381,7 +1381,7 @@ local ind, pcgs, primes, pos, p, i, e, f, a, j;
     pos:=[];
     for i in ind do
       Assert(1, IsPrimePowerInt(Order(i)));
-      p:=Factors(Order(i))[1];
+      p:=SmallestRootInt(Order(i));
       Add(primes,p);
       Add(pos,Length(pcgs)+1);
       while not IsOne(i) do

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -182,52 +182,62 @@ InstallMethod( IsElementaryAbelian,
 ##
 #M  IsPGroup( <G> ) . . . . . . . . . . . . . . . . .  is a group a p-group ?
 ##
+
+# The following helper function makes use of the fact that for any given prime
+# p, any (possibly infinite) nilpotent group G is a p-group if and only if any
+# generating set of G consists of p-elements (i.e. elements whose order is a
+# power of p). For finite G this is well-known. The general case follows from
+# e.g. 5.2.6 in "A Course in the Theory of Groups" by Derek J.S. Robinson,
+# since it holds in the case were G is abelian, and since being a p-group is
+# a property inherited by quotients and extensions.
 BindGlobal( "IS_PGROUP_FOR_NILPOTENT",
-
     function( G )
-    local s, gen, ord;
+    local p, gen, ord;
 
-    s:= [];
+    p := fail;
     for gen in GeneratorsOfGroup( G ) do
-      ord:= Order( gen );
+      ord := Order( gen );
       if ord = infinity then
         return false;
-      elif 1 < ord then
-        if not IsPrimePowerInt( ord ) then
-          return false;
+      elif ord > 1 then
+        if p = fail then
+          p := SmallestRootInt( ord );
+          if not IsPrimeInt( p ) then
+            return false;
+          fi;
         else
-          AddSet( s, Factors( ord )[1] );
-          if 1 < Length( s ) then
+          if ord <> p^PValuation( ord, p ) then
             return false;
           fi;
         fi;
       fi;
     od;
-    if IsEmpty( s ) then
+    if p = fail then
       return true;
     fi;
 
-    SetPrimePGroup( G, s[1] );
+    SetPrimePGroup( G, p );
     return true;
     end);
 
+# The following helper function uses the well-known fact that a finite group
+# is a p-group if and only if its order is a prime power.
 BindGlobal( "IS_PGROUP_FROM_SIZE",
-
     function( G )
-    local s;
+    local s, p;
 
     s:= Size( G );
     if s = 1 then
       return true;
     elif s = infinity then
+      return fail; # cannot say anything about infinite groups
+    fi;
+    p := SmallestRootInt( s );
+    if not IsPrimeInt( p ) then
       return false;
-    elif not IsPrimePowerInt( s ) then
-      return false;
-    else
-      s:= Factors( s );
     fi;
 
-    SetPrimePGroup( G, s[1] );
+    SetPrimePGroup( G, p );
     return true;
     end);
 
@@ -262,6 +272,8 @@ InstallMethod( IsPGroup,
       return IS_PGROUP_FOR_NILPOTENT( G );
     fi;
     end );
+
+
 #############################################################################
 ##
 #M  IsPowerfulPGroup( <G> ) . . . . . . . . . . is a group a powerful p-group ?

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -187,6 +187,7 @@ local hom,gp,f;
     f:=Factors(Size(gp));
     if Length(Set(f))=1 then
       SetIsPGroup(gp,true);
+      SetPrimePGroup(gp,f[1]);
     elif Length(Set(f))=2 then
       SetIsSolvableGroup(gp,true);
     fi;

--- a/lib/grppc.gi
+++ b/lib/grppc.gi
@@ -2508,8 +2508,8 @@ function(G,bound)
         return monic(LGLayers(pcgs),PrimePGroup(G),a->Order(PcElementByExponents(pcgs,a)));
 end);
 
-InstallMethod( Exponent,"solvable group",
-  true,[IsGroup and IsSolvableGroup],0,
+InstallMethod( Exponent,"finite solvable group",
+  true,[IsGroup and IsSolvableGroup and IsFinite],0,
 function(G)
 local exp, primes, p;
   if IsPGroup(G) then 

--- a/lib/grppc.gi
+++ b/lib/grppc.gi
@@ -222,7 +222,7 @@ end);
 ##
 #M  Pcgs( <G> )
 ##
-InstallMethod( Pcgs, "fail if insolvable", true,
+InstallMethod( Pcgs, "fail if not solvable", true,
         [ HasIsSolvableGroup ], 
 	SUM_FLAGS, # for groups for which we know that they are not solvable
 	           # this is the best we can do.

--- a/lib/pcgs.gi
+++ b/lib/pcgs.gi
@@ -59,7 +59,7 @@ end);
 ##
 ##  `HasPcgs' implies  `CanEasilyComputePcgs',  which implies `IsSolvable',
 ##  so a  pcgs cannot be set for insoluble permutation groups.
-##  As Pcgs may return 'fail' for insolvable permutation groups, this method
+##  As Pcgs may return 'fail' for non-solvable permutation groups, this method
 ##  is necessary.
 ##
 InstallMethod( SetPcgs, true, [ IsGroup, IsBool ], 0,

--- a/lib/pcgsmodu.gd
+++ b/lib/pcgsmodu.gd
@@ -72,7 +72,7 @@ DeclareGlobalFunction( "ModuloTailPcgsByList" );
 ##
 ##  <Description>
 ##  returns a modulo pcgs for the factor <M><A>G</A>/<A>N</A></M> which must
-##  be solvable, which <A>N</A> may be insolvable.
+##  be solvable, while <A>N</A> may be non-solvable.
 ##  <Ref Func="ModuloPcgs"/> will return <E>a</E> pcgs for the factor,
 ##  there is no guarantee that it will be <Q>compatible</Q> with any other
 ##  pcgs.

--- a/lib/pquot.gi
+++ b/lib/pquot.gi
@@ -1793,6 +1793,7 @@ InstallMethod(EpimorphismQuotientSystem,
 
     H := GroupByQuotientSystem( qs );
     SetIsPGroup( H, true );
+    SetPrimePGroup( H, qs!.prime );
 
     # now we write the images of the generators of G in H from qs:
     l := List(qs!.images,x->ObjByExtRep(FamilyObj(One(H)),ExtRepOfObj(x)));

--- a/small/small11/smlgp11.g
+++ b/small/small11/smlgp11.g
@@ -251,6 +251,7 @@ SMALL_GROUP_FUNCS[ 26 ] := function( size, i, inforec )
 
     g := GroupByRwsNC( c );
     SetIsPGroup( g, true );
+    SetPrimePGroup( g, p );
     return g;
 end;
 

--- a/small/small9/smlgp9.g
+++ b/small/small9/smlgp9.g
@@ -128,6 +128,7 @@ SMALL_GROUP_FUNCS[ 19 ] := function( size, i, inforec )
 
     g := GroupByRwsNC( c );
     SetIsPGroup( g, true );
+    SetPrimePGroup( g, p );
     return g;
 end;
 
@@ -509,6 +510,7 @@ SMALL_GROUP_FUNCS[ 20 ] := function( size, i, inforec )
 
     g := GroupByRwsNC( c );
     SetIsPGroup( g, true );
+    SetPrimePGroup( g, p );
     return g;
 end;
 


### PR DESCRIPTION
This PR is an hopefully uncontroversial subset of PR #1545. This PR...
* ... ensures we always call `SetPrimePGroup` after `SetIsPGroup`;
* ... optimizes `IS_PGROUP_FOR_NILPOTENT` and `IS_PGROUP_FROM_SIZE`;
* ... avoids several calls to `Factors` resp. `FactorsInt` (by using `PrimePGroup` and `SmallestRootInt` suitably);
* ... improves / corrects some comments;
* ... tweaks some code which explicitly require *finite* p-groups to check for finiteness, instead of assuming that `IsPGroup` implies `IsFinite`. Note that technically, our documentation currently suggests that this is case; my desire to change that is the controversial bit in PR #1545. However, I think this change is fine even if we leave `IsPGroup` to imply finiteness, as then the check we add is free anyway.