### PR TITLE
kernel: move definition of BIPEB to system.h

### DIFF
--- a/src/blister.h
+++ b/src/blister.h
@@ -20,16 +20,7 @@
 #ifndef GAP_BLISTER_H
 #define GAP_BLISTER_H
 
-
-/****************************************************************************
-**
-*V  BIPEB . . . . . . . . . . . . . . . . . . . . . . . . . .  bits per block
-**
-**  'BIPEB' is the  number of bits  per  block, where a  block  fills a UInt,
-**  which must be the same size as a bag identifier.
-**
-*/
-#define BIPEB   (sizeof(UInt) * 8L)
+#include <src/system.h>
 
 /****************************************************************************
 **

--- a/src/opers.h
+++ b/src/opers.h
@@ -14,6 +14,7 @@
 #ifndef GAP_OPERS_H
 #define GAP_OPERS_H
 
+#include <src/system.h>
 
 /****************************************************************************
 **

--- a/src/system.h
+++ b/src/system.h
@@ -166,6 +166,19 @@ typedef Bag Obj;
 
 /****************************************************************************
 **
+*V  BIPEB . . . . . . . . . . . . . . . . . . . . . . . . . .  bits per block
+**
+**  'BIPEB' is the  number of bits  per  block, where a  block  fills a UInt,
+**  which must be the same size as a bag identifier.
+**
+*/
+enum {
+    BIPEB =  sizeof(UInt) * 8L
+};
+
+
+/****************************************************************************
+**
 *F * * * * * * * * * * * command line settable options  * * * * * * * * * * *
 */
 

--- a/src/vecgf2.h
+++ b/src/vecgf2.h
@@ -11,6 +11,8 @@
 #ifndef GAP_VECGF2_H
 #define GAP_VECGF2_H
 
+#include <src/system.h>
+
 /****************************************************************************
 **
 *F  IS_GF2VEC_REP( <obj> )  . . . . . . check that <obj> is in GF2 vector rep


### PR DESCRIPTION
It was previously defined in blister.h, but actually also used in
opers.h and vecgf2.h for things that had nothing to do with blists.