### PR TITLE
lib/list.gd: restrict [], []:=, IsBound, Unbind to pos int indices

### DIFF
--- a/lib/list.gd
+++ b/lib/list.gd
@@ -170,7 +170,7 @@ InstallTrueMethod(HasLength,IsPlistRep);
 ##  <#/GAPDoc>
 ##
 DeclareOperationKernel( "IsBound[]",
-    [ IsList, IsObject ],
+    [ IsList, IS_INT ],
     ISB_LIST );
 
 
@@ -179,7 +179,7 @@ DeclareOperationKernel( "IsBound[]",
 #o  <list>[<pos>] . . . . . . . . . . . . . . . select an element from a list
 ##
 DeclareOperationKernel( "[]",
-    [ IsList, IsObject ],
+    [ IsList, IS_INT ],
     ELM_LIST );
 
 
@@ -243,7 +243,7 @@ DeclareOperationKernel( "Elm0List",
 ##  <#/GAPDoc>
 ##
 DeclareOperationKernel( "Unbind[]",
-    [ IsList and IsMutable, IsObject ],
+    [ IsList and IsMutable, IS_INT ],
     UNB_LIST );
 
 
@@ -252,7 +252,7 @@ DeclareOperationKernel( "Unbind[]",
 #o  <list>[<pos>] := <obj>
 ##
 DeclareOperationKernel( "[]:=",
-    [ IsList and IsMutable, IsObject, IsObject ],
+    [ IsList and IsMutable, IS_INT, IsObject ],
     ASS_LIST );
 
 

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -8,16 +8,16 @@
 gap> START_TEST("listindex.tst");
 gap> r := NewCategory("ListTestObject",IsList and HasLength and HasIsFinite);
 <Category "ListTestObject">
-gap> InstallMethod(\[\],[r,IsObject],function(l,ix) 
+gap> InstallOtherMethod(\[\],[r,IsObject],function(l,ix) 
 >     return ix;
 > end);
-gap> InstallMethod(\[\]\:\=,[r and IsMutable,IsObject, IsObject],function(l,ix,x) 
+gap> InstallOtherMethod(\[\]\:\=,[r and IsMutable,IsObject, IsObject],function(l,ix,x) 
 >     Print ("Assign ",ix," ",x,"\n");
 > end);
-gap> InstallMethod(Unbind\[\],[r and IsMutable,IsObject],function(l,ix) 
+gap> InstallOtherMethod(Unbind\[\],[r and IsMutable,IsObject],function(l,ix) 
 >     Print ("Unbind ",ix,"\n");
 > end);
-gap> InstallMethod(IsBound\[\],[r and IsMutable,IsObject],function(l,ix) 
+gap> InstallOtherMethod(IsBound\[\],[r and IsMutable,IsObject],function(l,ix) 
 >     Print ("IsBound ",ix,"\n");
 >     return false;
 > end);


### PR DESCRIPTION
This is how it always was before we made it more generous in 2015 to
allow for fancy index operations (like `matrix[1,2]`, or `dict["key"]`).
We still support that, but code which wants to do it should either
use `InstallOtherMethod` (like the tests), or use `DeclareOperation` to
explicitly declare the supported index types.

This way, incorrectly using `InstallMethod` by accident at least triggers
a GAP warning / error.