### PR TITLE
Fix USE_GVAR_BUCKETS for non-HPC-GAP

### DIFF
--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1545,11 +1545,13 @@ static Int InitKernel (
                    "src/gvars.c:CopiesGVars" );
     InitGlobalBag( &FopiesGVars,
                    "src/gvars.c:FopiesGVars"  );
+#endif
 
+#if !defined(HPCGAP)
     InitGlobalBag( &STATE(CurrNamespace),
                    "src/gvars.c:CurrNamespace" );
-
 #endif
+
     InitGlobalBag( &TableGVars,
                    "src/gvars.c:TableGVars" );
 


### PR DESCRIPTION
With this PR, it becomes possible to build GAP (without HPC) with the `USE_GVAR_BUCKETS` flag enabled. Note that this will break workspaces, though that could be fixed; everything else seems to work fine now (as in: all AppVeyor and Travis tests no using workspaces pass).