### PR TITLE
Fix workspaces when using USE_GVAR_BUCKETS in plain GAP

### DIFF
--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1356,18 +1356,18 @@ static void RemoveCopyFopyInfo( void )
 /****************************************************************************
 **
 */
-void GVarsAfterCollectBags ( void )
+void GVarsAfterCollectBags(void)
 {
 #ifdef USE_GVAR_BUCKETS
-  int i;
-  for (i=0; i<GVAR_BUCKETS; i++)
+  for (int i = 0; i < GVAR_BUCKETS; i++) {
     if (ValGVars[i])
-      PtrGVars[i] = ADDR_OBJ( ValGVars[i] )+1;
+      PtrGVars[i] = ADDR_OBJ( ValGVars[i] ) + 1;
     else
       break;
+  }
 #else
   if (ValGVars)
-    PtrGVars = PTR_BAG( ValGVars );
+    PtrGVars = ADDR_OBJ( ValGVars );
 #endif
 }
 
@@ -1591,8 +1591,9 @@ static Int PostRestore (
     /* TODO: Implement with buckets. */
 #else
     CountGVars = LEN_PLIST( ValGVars );
-    PtrGVars   = ADDR_OBJ( ValGVars );
 #endif
+    // restore PtrGVars
+    GVarsAfterCollectBags();
 
     /* update fopies and copies                                            */
     UpdateCopyFopyInfo();


### PR DESCRIPTION
With this PR, the test suite passes when `USE_GVAR_BUCKETS` is set in plain GAP.

To demonstrate this, I added a commit to this PR which does just that. Let's see if Travis agrees with my local tests. If so, I'll remove that commit again, and we can then afterwards merge it.

UPDATE: the test worked, so I now removed the experimental final commit. One day, we may wish to revisit the bucket approach and see whether to enable it in plain GAP, too.