### PR TITLE
Check version of kernel for package versions

### DIFF
--- a/hpcgap/src/c_filter1.c
+++ b/hpcgap/src/c_filter1.c
@@ -781,7 +781,7 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ 2,
+ /* type        = */ MODULE_STATIC,
  /* name        = */ "GAPROOT/lib/filter1.g",
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,

--- a/hpcgap/src/c_methsel1.c
+++ b/hpcgap/src/c_methsel1.c
@@ -5593,7 +5593,7 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ 2,
+ /* type        = */ MODULE_STATIC,
  /* name        = */ "GAPROOT/lib/methsel1.g",
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,

--- a/hpcgap/src/c_oper1.c
+++ b/hpcgap/src/c_oper1.c
@@ -4700,7 +4700,7 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ 2,
+ /* type        = */ MODULE_STATIC,
  /* name        = */ "GAPROOT/lib/oper1.g",
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,

--- a/hpcgap/src/c_type1.c
+++ b/hpcgap/src/c_type1.c
@@ -5451,7 +5451,7 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ 2,
+ /* type        = */ MODULE_STATIC,
  /* name        = */ "GAPROOT/lib/type1.g",
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,

--- a/src/c_filter1.c
+++ b/src/c_filter1.c
@@ -686,7 +686,7 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ 2,
+ /* type        = */ MODULE_STATIC,
  /* name        = */ "GAPROOT/lib/filter1.g",
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,

--- a/src/c_methsel1.c
+++ b/src/c_methsel1.c
@@ -5593,7 +5593,7 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ 2,
+ /* type        = */ MODULE_STATIC,
  /* name        = */ "GAPROOT/lib/methsel1.g",
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -4569,7 +4569,7 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ 2,
+ /* type        = */ MODULE_STATIC,
  /* name        = */ "GAPROOT/lib/oper1.g",
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -5061,7 +5061,7 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ 2,
+ /* type        = */ MODULE_STATIC,
  /* name        = */ "GAPROOT/lib/type1.g",
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5745,10 +5745,10 @@ Int CompileFunc (
     Emit( "\n/* <name> returns the description of this module */\n" );
     Emit( "static StructInitInfo module = {\n" );
     if ( ! strcmp( "Init_Dynamic", name ) ) {
-        Emit( "/* type        = */ %d,\n",     MODULE_DYNAMIC ); 
+        Emit( "/* type        = */ MODULE_DYNAMIC,\n" );
     }
     else {
-        Emit( "/* type        = */ %d,\n",     MODULE_STATIC ); 
+        Emit( "/* type        = */ MODULE_STATIC,\n" );
     }
     Emit( "/* name        = */ \"%C\",\n", magic2 );
     Emit( "/* revision_c  = */ %d,\n",     0 );

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -823,22 +823,22 @@ void LoadWorkspace( Char * fname )
 	{
 	  StructInitInfo *info = NULL;
  	  /* Search for user module static case first */
-	  if (type == MODULE_STATIC) { 
-	    UInt k;
-	    for ( k = 0;  CompInitFuncs[k];  k++ ) {
-	      info = (*(CompInitFuncs[k]))();
-	      if ( info == 0 ) {
-		continue;
-	      }
-	      if ( ! strcmp( buf, info->name ) ) {
-		break;
-	      }
-	    }
-	    if ( CompInitFuncs[k] == 0 ) {
-	      Pr( "Static module %s not found in loading kernel\n",
-		  (Int)buf, 0L );
-	      SyExit(1);
-	    }
+          if (IS_MODULE_STATIC(type)) {
+              UInt k;
+              for (k = 0; CompInitFuncs[k]; k++) {
+                  info = (*(CompInitFuncs[k]))();
+                  if (info == 0) {
+                      continue;
+                  }
+                  if (!strcmp(buf, info->name)) {
+                      break;
+                  }
+              }
+              if (CompInitFuncs[k] == 0) {
+                  Pr("Static module %s not found in loading kernel\n",
+                     (Int)buf, 0L);
+                  SyExit(1);
+              }
 	
 	  } else {
 	    /* and dynamic case */

--- a/src/system.h
+++ b/src/system.h
@@ -783,18 +783,56 @@ extern void SyAbortBags(const Char * msg) NORETURN;
 /****************************************************************************
 **
 *F * * * * * * * * * * * * * loading of modules * * * * * * * * * * * * * * *
+**
+** GAP_KERNEL_API_VERSION gives the version of the GAP kernel. This value
+** is used to check if kernel modules were built with a compatible kernel.
+** This version is not the same as, and not connected to, the GAP version.
+**
+** This is stored as GAP_KERNEL_MAJOR_VERSION*1000 + GAP_KERNEL_MINOR_VERSION
+**
+** The algorithm used is the following:
+**
+** The kernel will not load a module compiled for a newer kernel.
+**
+** The kernel will not load a module compiled for a different major version.
+**
+** The minor version should be incremented when new backwards-compatible
+** functionality is added. The major version should be incremented when
+** a backwards-incompatible change is made.
+**
 */
 
 enum {
+    GAP_KERNEL_MAJOR_VERSION = 1,
+    GAP_KERNEL_MINOR_VERSION = 1,
+    GAP_KERNEL_API_VERSION = GAP_KERNEL_MAJOR_VERSION * 1000 + GAP_KERNEL_MINOR_VERSION
+};
+
+enum {
     /** builtin module */
-    MODULE_BUILTIN = 1,
+    MODULE_BUILTIN = GAP_KERNEL_API_VERSION * 10,
 
     /** statically loaded compiled module */
-    MODULE_STATIC  = 2,
+    MODULE_STATIC = GAP_KERNEL_API_VERSION * 10 + 1,
 
     /** dynamically loaded compiled module */
-    MODULE_DYNAMIC = 3,
+    MODULE_DYNAMIC = GAP_KERNEL_API_VERSION * 10 + 2,
 };
+
+static inline Int IS_MODULE_BUILTIN(UInt type)
+{
+    return type % 10 == 0;
+}
+
+static inline Int IS_MODULE_STATIC(UInt type)
+{
+    return type % 10 == 1;
+}
+
+static inline Int IS_MODULE_DYNAMIC(UInt type)
+{
+    return type % 10 == 2;
+}
 
 
 /****************************************************************************


### PR DESCRIPTION
This adds a way of checking if GAP packages with kernel modules were compiled with a compatible version of the GAP kernel.

I wouldn't do it this way if I was doing it from scratch, but this has the advantage it works with all packages (I think), without any need for changes.