### PR TITLE
Fix MigrateObjects for empty list of objects

### DIFF
--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -2160,7 +2160,7 @@ static int
 MigrateObjects(int count, Obj * objects, Region * target, int retype)
 {
     int i;
-    if (retype && IS_BAG_REF(objects[0]) &&
+    if (count && retype && IS_BAG_REF(objects[0]) &&
         REGION(objects[0])->owner == realTLS && AutoRetyping) {
         for (i = 0; i < count; i++)
             if (REGION(objects[i])->owner == realTLS)


### PR DESCRIPTION
If MigrateObjects was passed an empty list of objects this lead
to it trying to access the region of something that isn't an object,
leading to a segfault.

Reported-By: Alasdair Macindoe <agm24@st-andrews.ac.uk>