### PR TITLE
Remove CALL_FUNC operation

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -1416,94 +1416,6 @@ Obj FuncIS_FUNCTION (
 
 /****************************************************************************
 **
-*F  FuncCALL_FUNC( <self>, <args> ) . . . . . . . . . . . . . call a function
-**
-**  'FuncCALL_FUNC' implements the internal function 'CallFunction'.
-**
-**  'CallFunction( <func>, <arg1>... )'
-**
-**  'CallFunction' calls the  function <func> with the  arguments  <arg1>...,
-**  i.e., it is equivalent to '<func>( <arg1>, <arg2>... )'.
-*/
-Obj CallFunctionOper;
-
-
-
-Obj FuncCALL_FUNC (
-    Obj                 self,
-    Obj                 args )
-{
-    Obj                 result;         /* result                          */
-    Obj                 func;           /* function                        */
-    Obj                 list2;          /* list of arguments               */
-    Obj                 arg;            /* one argument                    */
-    UInt                i;              /* loop variable                   */
-
-    /* the first argument is the function                                  */
-    if ( LEN_LIST( args ) == 0 ) {
-        func = ErrorReturnObj(
-            "usage: CallFunction( <func>, <arg1>... )",
-            0L, 0L,
-            "you can replace function <func> via 'return <func>;'" );
-    }
-    else {
-        func = ELMV_LIST( args, 1 );
-    }    
-
-    /* check that the first argument is a function                         */
-    /*N 1996/06/26 mschoene this should be done by 'CALL_<i>ARGS'          */
-    while ( TNUM_OBJ( func ) != T_FUNCTION ) {
-        func = ErrorReturnObj(
-            "CallFunction: <func> must be a function",
-            0L, 0L,
-            "you can replace function <func> via 'return <func>;'" );
-    }
-
-    /* call the function                                                   */
-    if      ( LEN_LIST(args) == 1 ) {
-        result = CALL_0ARGS( func );
-    }
-    else if ( LEN_LIST(args) == 2 ) {
-        result = CALL_1ARGS( func, ELMV_LIST(args,2) );
-    }
-    else if ( LEN_LIST(args) == 3 ) {
-        result = CALL_2ARGS( func, ELMV_LIST(args,2), ELMV_LIST(args,3) );
-    }
-    else if ( LEN_LIST(args) == 4 ) {
-        result = CALL_3ARGS( func, ELMV_LIST(args,2), ELMV_LIST(args,3),
-                                   ELMV_LIST(args,4) );
-    }
-    else if ( LEN_LIST(args) == 5 ) {
-        result = CALL_4ARGS( func, ELMV_LIST(args,2), ELMV_LIST(args,3),
-                                   ELMV_LIST(args,4), ELMV_LIST(args,5) );
-    }
-    else if ( LEN_LIST(args) == 6 ) {
-        result = CALL_5ARGS( func, ELMV_LIST(args,2), ELMV_LIST(args,3),
-                                   ELMV_LIST(args,4), ELMV_LIST(args,5),
-                                   ELMV_LIST(args,6) );
-    }
-    else if ( LEN_LIST(args) == 7 ) {
-        result = CALL_6ARGS( func, ELMV_LIST(args,2), ELMV_LIST(args,3),
-                                   ELMV_LIST(args,4), ELMV_LIST(args,5),
-                                   ELMV_LIST(args,6), ELMV_LIST(args,7) );
-    }
-    else {
-        list2 = NEW_PLIST( T_PLIST, LEN_LIST(args)-1 );
-        SET_LEN_PLIST( list2, LEN_LIST(args)-1 );
-        for ( i = 1; i <= LEN_LIST(args)-1; i++ ) {
-            arg = ELMV_LIST( args, (Int)(i+1) );
-            SET_ELM_PLIST( list2, i, arg );
-        }
-        result = CALL_XARGS( func, list2 );
-    }
-
-    /* return the result                                                   */
-    return result;
-}
-
-
-/****************************************************************************
-**
 *F  FuncCALL_FUNC_LIST( <self>, <func>, <list> )  . . . . . . call a function
 **
 **  'FuncCALL_FUNC_LIST' implements the internal function 'CallFuncList'.
@@ -2054,7 +1966,6 @@ static StructGVarFilt GVarFilts [] = {
 */
 static StructGVarOper GVarOpers [] = {
 
-    GVAR_OPER(CALL_FUNC, -1, "args", &CallFunctionOper),
     GVAR_OPER(CALL_FUNC_LIST, 2, "func, list", &CallFuncListOper),
     GVAR_OPER(CALL_FUNC_LIST_WRAP, 2, "func, list", &CallFuncListWrapOper),
     GVAR_OPER(NAME_FUNC, 1, "func", &NAME_FUNC_Oper),


### PR DESCRIPTION
This operation was declared as taking an arbitrary argument count, which
we do not actually support. Hence, it was impossible to actually use it.
It has been like this since at least 1997. The code also has no obvious
benefit compared to CALL_FUNC_LIST{_WRAP} resp. CallFuncList{Wrap}.