### PR TITLE
kernel: get rid of multiple global variables

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -2777,7 +2777,6 @@ void ThreadedInterpreter(void *funcargs) {
 
   /* intialize everything and begin an interpreter                       */
   STATE(StackNams)   = NEW_PLIST( T_PLIST, 16 );
-  STATE(CountNams)   = 0;
   STATE(ReadTop)     = 0;
   STATE(ReadTilde)   = 0;
   STATE(CurrLHSGVar) = 0;
@@ -3216,7 +3215,6 @@ void InitializeGap (
 #endif
 
     STATE(StackNams)    = NEW_PLIST( T_PLIST, 16 );
-    STATE(CountNams)    = 0;
     STATE(ReadTop)      = 0;
     STATE(ReadTilde)    = 0;
     STATE(CurrLHSGVar)  = 0;

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -48,7 +48,6 @@ typedef struct GAPState {
     syJmp_buf ReadJmpError;
     syJmp_buf threadExit;
     Obj       StackNams;
-    UInt      CountNams;
     UInt      ReadTop;
     UInt      ReadTilde;
     UInt      CurrLHSGVar;

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -31,7 +31,6 @@ typedef struct GAPState {
     UInt IntrCoding;
     Obj  IntrState;
     Obj  StackObj;
-    Int  CountObj;
     Obj  Tilde;
 
     /* From gvar.c */

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -712,10 +712,8 @@ void IntrForBegin ( void )
 
        If we are not in a break loop, then this would be a waste of time and effort */
 
-    if (STATE(CountNams) > 0) {
-        GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
-        SET_ELM_PLIST(STATE(StackNams), STATE(CountNams), nams);
-        SET_LEN_PLIST(STATE(StackNams), STATE(CountNams));
+    if (LEN_PLIST(STATE(StackNams)) > 0) {
+        PushPlist(STATE(StackNams), nams);
     }
 
     CodeFuncExprBegin( 0, 0, nams, 0 );
@@ -780,10 +778,12 @@ void IntrForEnd ( void )
     /* switch back to immediate mode, get the function                     */
     STATE(IntrCoding) = 0;
     CodeEnd( 0 );
+
     /* If we are in a break loop, then we will have created a "dummy" local
        variable names list to get the counts right. Remove it */
-    if (STATE(CountNams) > 0)
-      STATE(CountNams)--;
+    const UInt len = LEN_PLIST(STATE(StackNams));
+    if (len > 0)
+      SET_LEN_PLIST(STATE(StackNams), len - 1);
 
     func = STATE(CodeResult);
 
@@ -845,10 +845,8 @@ void            IntrWhileBegin ( void )
 
        If we are not in a break loop, then this would be a waste of time and effort */
 
-    if (STATE(CountNams) > 0) {
-        GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
-        SET_ELM_PLIST(STATE(StackNams), STATE(CountNams), nams);
-        SET_LEN_PLIST(STATE(StackNams), STATE(CountNams));
+    if (LEN_PLIST(STATE(StackNams)) > 0) {
+        PushPlist(STATE(StackNams), nams);
     }
 
     CodeFuncExprBegin( 0, 0, nams, 0 );
@@ -898,18 +896,17 @@ void            IntrWhileEnd ( void )
     /* code a function expression (with one statement in the body)         */
     CodeFuncExprEnd( 1UL, 0UL );
 
-
     /* switch back to immediate mode, get the function                     */
     STATE(IntrCoding) = 0;
     CodeEnd( 0 );
 
     /* If we are in a break loop, then we will have created a "dummy" local
        variable names list to get the counts right. Remove it */
-    if (STATE(CountNams) > 0)
-      STATE(CountNams)--;
+    const UInt len = LEN_PLIST(STATE(StackNams));
+    if (len > 0)
+      SET_LEN_PLIST(STATE(StackNams), len - 1);
 
     func = STATE(CodeResult);
-
 
     /* call the function                                                   */
     CALL_0ARGS( func );
@@ -1009,10 +1006,8 @@ void            IntrAtomicBeginBody ( UInt nrexprs )
        
        If we are not in a break loop, then this would be a waste of time and effort */
     
-    if (STATE(CountNams) > 0) {
-        GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
-        SET_ELM_PLIST(STATE(StackNams), STATE(CountNams), nams);
-        SET_LEN_PLIST(STATE(StackNams), STATE(CountNams));
+    if (LEN_PLIST(STATE(StackNams)) > 0) {
+        PushPlist(STATE(StackNams), nams);
     }
     
     CodeFuncExprBegin( 0, 0, nams, STATE(Input)->number );
@@ -1033,8 +1028,9 @@ void            IntrAtomicEndBody (
 
     /* If we are in a break loop, then we will have created a "dummy" local
        variable names list to get the counts right. Remove it */
-      if (STATE(CountNams) > 0)
-        STATE(CountNams)--;
+      const UInt len = LEN_PLIST(STATE(StackNams));
+      if (len > 0)
+        SET_LEN_PLIST(STATE(StackNams), len - 1);
 
       /* Code the body as a function expression */
       CodeFuncExprEnd( nrstats, 0UL );
@@ -1185,10 +1181,8 @@ void            IntrRepeatBegin ( void )
 
        If we are not in a break loop, then this would be a waste of time and effort */
 
-    if (STATE(CountNams) > 0) {
-        GROW_PLIST(STATE(StackNams), ++STATE(CountNams));
-        SET_ELM_PLIST(STATE(StackNams), STATE(CountNams), nams);
-        SET_LEN_PLIST(STATE(StackNams), STATE(CountNams));
+    if (LEN_PLIST(STATE(StackNams)) > 0) {
+        PushPlist(STATE(StackNams), nams);
     }
 
     CodeFuncExprBegin( 0, 0, nams, STATE(Input)->number );
@@ -1241,10 +1235,13 @@ void            IntrRepeatEnd ( void )
     /* switch back to immediate mode, get the function                     */
     STATE(IntrCoding) = 0;
     CodeEnd( 0 );
+
     /* If we are in a break loop, then we will have created a "dummy" local
        variable names list to get the counts right. Remove it */
-    if (STATE(CountNams) > 0)
-      STATE(CountNams)--;
+    const UInt len = LEN_PLIST(STATE(StackNams));
+    if (len > 0)
+      SET_LEN_PLIST(STATE(StackNams), len - 1);
+
     func = STATE(CodeResult);
 
     /* call the function                                                   */

--- a/src/read.h
+++ b/src/read.h
@@ -110,14 +110,13 @@ extern void ReadEvalError ( void ) NORETURN;
 
 /****************************************************************************
 **
-*V  StackNams, CountNames . . . . . .stack of lists of local variable names
+*V  StackNams . . . . . . . . . . . .  stack of lists of local variable names
 **
-**  This is exported to support a rather nasty hack in intrprtr.c todo with
+**  This is exported to support a rather nasty hack in intrprtr.c related to
 **  while loops and the break loop
 */
 
 /* TL: extern Obj StackNams; */
-/* TL: extern UInt CountNams; */
 
 
 extern void PushGlobalForLoopVariable( UInt var);


### PR DESCRIPTION
We are using plists as stacks in various places in the code. Strangely enough, we then also usually keep a separate stack pointer -- even in cases were the length of the plist is exactly equal to the value of the stack pointer. This seems pointless, and is a potential source of bugs, if the two values get out of sync by accident. It also increases the complexity of the code, making it slightly harder to understand ("hmm, it seems this variable is supposed to always contain the length of that plist -- but I can't be sure, so I'll now have to check the whole kernel to verify").

This PR builds upon PR #1605, which therefore should be merged first. (And afterwards, I could split this PR into several PRs which are easier to review; let me know if you would prefer that).
