### PR TITLE
When printing function, reproduce TryNextMethod() correctly

### DIFF
--- a/hpcgap/src/c_oper1.c
+++ b/hpcgap/src/c_oper1.c
@@ -2253,7 +2253,7 @@ static Obj  HdlrFunc8 (
    t_5 = (Obj)(UInt)( ! ((Int)t_6) );
    if ( t_5 ) {
     
-    /* return TRY_NEXT_METHOD; */
+    /* TryNextMethod(); */
     t_5 = GC_TRY__NEXT__METHOD;
     CHECK_BOUND( t_5, "TRY_NEXT_METHOD" )
     RES_BRK_CURR_STAT();
@@ -2288,7 +2288,7 @@ static Obj  HdlrFunc8 (
  /* else */
  else {
   
-  /* return TRY_NEXT_METHOD; */
+  /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
   CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
   RES_BRK_CURR_STAT();
@@ -2490,14 +2490,14 @@ static Obj  HdlrFunc7 (
           if not Tester( prop )( obj )  then
               found := true;
               if not (prop( obj ) and Tester( prop )( obj ))  then
-                  return TRY_NEXT_METHOD;
+                  TryNextMethod();
               fi;
           fi;
       od;
       if found  then
           return getter( obj );
       else
-          return TRY_NEXT_METHOD;
+          TryNextMethod();
       fi;
       return;
   end ); */
@@ -3559,7 +3559,7 @@ static Obj  HdlrFunc18 (
  /* else */
  else {
   
-  /* return TRY_NEXT_METHOD; */
+  /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
   CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
   RES_BRK_CURR_STAT();
@@ -3738,7 +3738,7 @@ static Obj  HdlrFunc17 (
       if re  then
           return CallFuncList( oper, arg );
       else
-          return TRY_NEXT_METHOD;
+          TryNextMethod();
       fi;
       return;
   end ); */
@@ -4188,14 +4188,14 @@ static Obj  HdlrFunc1 (
                         if not Tester( prop )( obj )  then
                             found := true;
                             if not (prop( obj ) and Tester( prop )( obj ))  then
-                                return TRY_NEXT_METHOD;
+                                TryNextMethod();
                             fi;
                         fi;
                     od;
                     if found  then
                         return getter( obj );
                     else
-                        return TRY_NEXT_METHOD;
+                        TryNextMethod();
                     fi;
                     return;
                 end );
@@ -4377,7 +4377,7 @@ static Obj  HdlrFunc1 (
             if re  then
                 return CallFuncList( oper, arg );
             else
-                return TRY_NEXT_METHOD;
+                TryNextMethod();
             fi;
             return;
         end );

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -2196,7 +2196,7 @@ static Obj  HdlrFunc8 (
    t_5 = (Obj)(UInt)( ! ((Int)t_6) );
    if ( t_5 ) {
     
-    /* return TRY_NEXT_METHOD; */
+    /* TryNextMethod(); */
     t_5 = GC_TRY__NEXT__METHOD;
     CHECK_BOUND( t_5, "TRY_NEXT_METHOD" )
     RES_BRK_CURR_STAT();
@@ -2231,7 +2231,7 @@ static Obj  HdlrFunc8 (
  /* else */
  else {
   
-  /* return TRY_NEXT_METHOD; */
+  /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
   CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
   RES_BRK_CURR_STAT();
@@ -2411,14 +2411,14 @@ static Obj  HdlrFunc7 (
           if not Tester( prop )( obj )  then
               found := true;
               if not (prop( obj ) and Tester( prop )( obj ))  then
-                  return TRY_NEXT_METHOD;
+                  TryNextMethod();
               fi;
           fi;
       od;
       if found  then
           return getter( obj );
       else
-          return TRY_NEXT_METHOD;
+          TryNextMethod();
       fi;
       return;
   end ); */
@@ -3467,7 +3467,7 @@ static Obj  HdlrFunc18 (
  /* else */
  else {
   
-  /* return TRY_NEXT_METHOD; */
+  /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
   CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
   RES_BRK_CURR_STAT();
@@ -3646,7 +3646,7 @@ static Obj  HdlrFunc17 (
       if re  then
           return CallFuncList( oper, arg );
       else
-          return TRY_NEXT_METHOD;
+          TryNextMethod();
       fi;
       return;
   end ); */
@@ -4079,14 +4079,14 @@ static Obj  HdlrFunc1 (
                         if not Tester( prop )( obj )  then
                             found := true;
                             if not (prop( obj ) and Tester( prop )( obj ))  then
-                                return TRY_NEXT_METHOD;
+                                TryNextMethod();
                             fi;
                         fi;
                     od;
                     if found  then
                         return getter( obj );
                     else
-                        return TRY_NEXT_METHOD;
+                        TryNextMethod();
                     fi;
                     return;
                 end );
@@ -4266,7 +4266,7 @@ static Obj  HdlrFunc1 (
             if re  then
                 return CallFuncList( oper, arg );
             else
-                return TRY_NEXT_METHOD;
+                TryNextMethod();
             fi;
             return;
         end );

--- a/src/stats.c
+++ b/src/stats.c
@@ -2241,9 +2241,16 @@ void            PrintAssert3Args (
 void            PrintReturnObj (
     Stat                stat )
 {
-    Pr( "%2>return%< %>", 0L, 0L );
-    PrintExpr( ADDR_STAT(stat)[0] );
-    Pr( "%2<;", 0L, 0L );
+    Expr expr = ADDR_STAT(stat)[0];
+    if ( TNUM_EXPR(expr) == T_REF_GVAR &&
+         (UInt)(ADDR_STAT(expr)[0]) == GVarName( "TRY_NEXT_METHOD" ) ) {
+        Pr( "TryNextMethod();", 0L, 0L );
+    }
+    else {
+        Pr( "%2>return%< %>", 0L, 0L );
+        PrintExpr( expr );
+        Pr( "%2<;", 0L, 0L );
+    }
 }
 
 

--- a/tst/testinstall/function.tst
+++ b/tst/testinstall/function.tst
@@ -176,4 +176,12 @@ gap> Display(x->x);
 function ( x )
     return x;
 end
+
+#
+gap> Display(function() TryNextMethod(); end);
+function (  )
+    TryNextMethod();
+end
+
+#
 gap> STOP_TEST("function.tst", 1);


### PR DESCRIPTION
Before:
```
gap> Display(function() TryNextMethod(); end);
function (  )
    return TRY_NEXT_METHOD;
end
```
After:
```
gap> Display(function() TryNextMethod(); end);
function (  )
    TryNextMethod();
end
```