### PR TITLE
Bitfields

### DIFF
--- a/doc/ref/integers.xml
+++ b/doc/ref/integers.xml
@@ -174,5 +174,20 @@ random integers and random choices from lists.
 <#Include Label="RandomSource">
 
 </Section>
+<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
+<Section Label="Bitfields">
+  <Heading>Bitfields</Heading>
+Bitfields are a low-level feature intended to support efficient 
+subdivision of immediate integers into bitfields of various widths.
+This is typically useful in implementing space-efficient and/or
+cache-efficient data structures. This feature should be used with care
+because (<E>inter alia</E>) it has different limitations on 32-bit and 64-bit
+architectures.
+
+<#Include Label="MakeBitfields">
+<#Include Label="BuildBitfields">
+
+</Section>
+
 </Chapter>
 

--- a/doc/ref/makedocreldata.g
+++ b/doc/ref/makedocreldata.g
@@ -28,6 +28,7 @@ GAPInfo.ManualDataRef:= rec(
     "../../lib/attr.gd",
     "../../lib/basis.gd",
     "../../lib/basismut.gd",
+    "../../lib/bitfields.gd",
     "../../lib/boolean.g",
     "../../lib/clas.gd",
     "../../lib/cmdledit.g",

--- a/lib/bitfields.gd
+++ b/lib/bitfields.gd
@@ -1,0 +1,119 @@
+#############################################################################
+##
+#W  bitfields.gd                  GAP library                   Steve Linton
+##
+##
+#Y  Copyright (C) 2017 The GAP Group
+##
+##  This file declares the operations for bitfields
+##
+
+
+#############################################################################
+##
+#F  MakeBitfields(<width>[, <width>[, <width>...]]])
+##  <#GAPDoc Label="MakeBitfields">
+##  <ManSection>
+##  <Func Name="MakeBitfields" Arg='width....'/>
+##
+##  <Description>
+##
+##  This function sets up the machinery for a set of bitfields of the given
+##  widths. All bitfield values are treated as unsigned. 
+##  The total of the widths must not exceed 60 bits on 64-bit architecture
+##  or 28 bits on a 32-bit architecture. For performance 
+##  reasons some checks that one might wish to do are ommitted. In particular, 
+##  the builder and setter functions do not check if the value[s] passed to them are 
+##  negative or too large (unless &GAP; is specially compiled for debugging).
+##  Behaviour when such arguments are passed is undefined.
+##
+##  You can tell which type of architecture you are running on by acccessing 
+##  <C>GAPInfo.BytesPerVariable</C> which is 8 on 64-bits and 4 on 32. 
+##
+##
+##  The return value  when <M>n</M> widths are given is a record whose fields are 
+##  <List>
+##  <Mark><C>widths</C></Mark> <Item>a copy of the arguments, for convenience,</Item>
+##  <Mark><C>getters</C></Mark> <Item> a list of <M>n</M> functions of one
+##  argument each of which extracts one of the fields from an immediate integer</Item>
+##  <Mark><C>setters</C></Mark> <Item> a list of <M>n</M> functions each taking
+##  two arguments: a packed value and a new value for one of its fields and
+##  returning a new packed value. The
+##  <M>i</M>th function returned the new packed value in which the <M>i</M>th
+##  field has been replaced by the new value.
+##   Note that this does NOT modify the original packed value.</Item>
+##
+##  </List>
+## 
+##  Two additional fields may be present if any of the field widths is
+##  one. Each is a list and only has entried bound in the positions
+##  corresponding to the width 1 fields.
+##  <List> <Mark><C>booleanGetters</C></Mark> <Item>if the <M>i</M>th position of
+##  this list is set, it contains a function which extracts the <M>i</M>th
+##  field (which will have width one) and returns <C>true</C> if it contains 1
+##  and <C>false</C> if it contains 0</Item>
+##  <Mark><C>booleanSetters</C></Mark> <Item>if the <M>i</M>th position of
+##  this list is set, it contains a function of two arguments. The first
+##  argument is a packed value, the second is <C>true</C> or <C>false</C>. It returns a
+##  new packed value in which the <M>i</M>th field is set to 1 if the second
+##  argument was <C>true</C> and 0 if it was <C>false</C>. Behaviour for any
+##  other value is undefined.</Item></List>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+
+DeclareGlobalFunction( "MakeBitfields" ); 
+
+##  
+#############################################################################
+##
+#F  BuildBitfields( <widths>[, <val1>, [<val2>...]])
+##  <#GAPDoc Label="BuildBitfields">
+##  <ManSection>
+##  <Func Name="BuildBitfields" Arg='widths,....'/>
+##  <Description>
+##
+##  This function takes one or more argument. It's first argument is a list
+##  of field widths, as found in the <C>widths</C> entry of a record returned
+##  by <C>MakeBitfields</C>. The remaining arguments are unsigned integer
+##  values, equal in number to the entries of the list of field widths. It returns
+##  a small integer in which those entries are packed into bitfields of the
+##  given widths. The first entry occupies the least significant bits. 
+##
+##  
+
+DeclareGlobalFunction("BuildBitfields");
+
+##  
+##  <Example><![CDATA[
+##  gap> bf := MakeBitfields(1,2,3);
+##  rec( booleanGetters := [ function( data ) ... end ], 
+##    booleanSetters := [ function( data, val ) ... end ], 
+##    getters := [ function( data ) ... end, function( data ) ... end, 
+##        function( data ) ... end ], 
+##    setters := [ function( data, val ) ... end, function( data, val ) ... end, 
+##        function( data, val ) ... end ], widths := [ 1, 2, 3 ] )
+##  gap> x := BuildBitfields(bf.widths,0,3,5);
+##  46
+##  gap> bf.getters[3](x);
+##  5
+##  gap> y := bf.setters[1](x,1);
+##  47  
+##  gap> x;
+##  46
+##  gap> bf.booleanGetters[1](x);
+##  false
+##  gap> bf.booleanGetters[1](y);
+##  true
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+
+
+
+#############################################################################
+##
+#E
+

--- a/lib/bitfields.gi
+++ b/lib/bitfields.gi
@@ -1,0 +1,2 @@
+InstallGlobalFunction(MakeBitfields, MAKE_BITFIELDS);
+InstallGlobalFunction(BuildBitfields, BUILD_BITFIELDS);

--- a/lib/read3.g
+++ b/lib/read3.g
@@ -12,6 +12,7 @@ ReadLib( "extrset.gd"  );
 ReadLib( "extuset.gd"  );
 
 ReadLib( "dict.gd"     );
+ReadLib( "bitfields.gd" );
 
 ReadLib( "mapping.gd"  );
 ReadLib( "mapphomo.gd" );

--- a/lib/read5.g
+++ b/lib/read5.g
@@ -149,6 +149,7 @@ ReadLib( "grppcatr.gi" );
 ReadLib( "grppcnrm.gi" );
 
 # files dealing with trees and hash tables
+ReadLib( "bitfields.gi" );
 ReadLib( "dict.gi"  );
 ReadLib( "dicthf.gi"  );
 

--- a/tst/testinstall/bitfields.tst
+++ b/tst/testinstall/bitfields.tst
@@ -1,0 +1,47 @@
+gap> START_TEST("bitfields.tst");
+
+# Test correct behaviour for a variety of numbers of fields
+# and all getters and setters. 
+gap> for i in [1..2+GAPInfo.BytesPerVariable] do
+> bf := CallFuncList(MakeBitfields,[1..i]);
+> vals := List([1..i], j -> Random(0,2^j-1));
+> Add(vals, [1..i], 1);
+> x := CallFuncList(BuildBitfields,vals);
+> for j in [1..i] do
+> if bf.getters[j](x) <> vals[j+1] then
+> Print("Bad return from getter",i," ",j," ",x,"\n");
+> fi; od;
+> if bf.booleanGetters[1](x) <> (vals[2] = 1) then
+> Print("Bad return from boolean getter");
+> fi;
+> vals := List([1..i], j -> Random(0,2^j-1));
+> for j in [1..i] do
+> y := bf.setters[j](x, vals[j]);
+> if bf.getters[j](y) <> vals[j] then
+> Print("Bad return from getter and setter\n");
+> fi; od;
+> y := bf.booleanSetters[1](x,true);
+> z := bf.booleanSetters[1](x,false);
+> if (not bf.booleanGetters[1](y))  or bf.booleanGetters[1](z) then
+> Print("Bad results from boolean setter\n");
+> fi; od;
+
+#
+# Now test various error and extreme conditions
+#<
+gap> bf := MakeBitfields(1);
+rec( booleanGetters := [ function( data ) ... end ], 
+  booleanSetters := [ function( data, val ) ... end ], 
+  getters := [ function( data ) ... end ], 
+  setters := [ function( data, val ) ... end ], widths := [ 1 ] )
+gap> bf.getters[1](Z(5));
+Error, Field getter: argument must be small integer
+gap> bf.setters[1](1, (1,2));
+Error, Field Setter: both arguments must be small integers
+gap> bf.setters[1]([],1);
+Error, Field Setter: both arguments must be small integers
+gap> BuildBitfields([1],Z(5));
+Error, Fields builder: values must be small integers
+gap> MakeBitfields(100);
+Error, MAKE_BITFIELDS: total widths too large
+gap> STOP_TEST("bitfields.tst", 1);


### PR DESCRIPTION
This is work in progress on an implementation of fast access to bitfields within small integers. 
It seems to work, but is not thoroughly tested. As currently committed it needs a CPU with BEXTR (Haswell or later). I'll set up autoconf for that, of course.

Performance seems pretty decent. My laptop does a loop with 200 million gets in about 1.8s and 200 million sets in about 2.5s. 

Relates to issue #1611 