### PR TITLE
kernel: rename funcs handling GAP "global functions"

### DIFF
--- a/hpcgap/lib/oper.g
+++ b/hpcgap/lib/oper.g
@@ -1790,7 +1790,7 @@ BIND_GLOBAL( "DeclareGlobalFunction", function( arg )
     atomic GLOBAL_FUNCTION_NAMES do
     ADD_SET( GLOBAL_FUNCTION_NAMES, IMMUTABLE_COPY_OBJ(name) );
     od;
-    BIND_GLOBAL( name, NEW_OPERATION_ARGS( name ) );
+    BIND_GLOBAL( name, NEW_GLOBAL_FUNCTION( name ) );
 end );
 
 BIND_GLOBAL( "InstallGlobalFunction", function( arg )
@@ -1812,7 +1812,7 @@ BIND_GLOBAL( "InstallGlobalFunction", function( arg )
       Error("you cannot install a global function for another global ",
             "function,\nuse `DeclareSynonym' instead!");
     fi;
-    INSTALL_METHOD_ARGS( oper, func );
+    INSTALL_GLOBAL_FUNCTION( oper, func );
     od;
 end );
 

--- a/lib/debug.g
+++ b/lib/debug.g
@@ -99,9 +99,9 @@ Debug := function(arg)
   MakeReadWriteGVar("REREADING");
   REREADING := true;
   if i > Length(DEBUG.LIST) then
-    INSTALL_METHOD_ARGS(oldversion,f);     # save the old version
+    INSTALL_GLOBAL_FUNCTION(oldversion,f);     # save the old version
   fi;
-  INSTALL_METHOD_ARGS(f,DEBUG.FUNCTION);
+  INSTALL_GLOBAL_FUNCTION(f,DEBUG.FUNCTION);
   REREADING := false;
   MakeReadOnlyGVar("REREADING");
 
@@ -154,7 +154,7 @@ UnDebug := function(f)
   # Copy the old version into the function:
   MakeReadWriteGVar("REREADING");
   REREADING := true;
-  INSTALL_METHOD_ARGS(DEBUG.LIST[nr].func,DEBUG.LIST[nr].old);
+  INSTALL_GLOBAL_FUNCTION(DEBUG.LIST[nr].func,DEBUG.LIST[nr].old);
   REREADING := false;
   MakeReadOnlyGVar("REREADING");
   Unbind(DEBUG.LIST[nr]);

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1766,7 +1766,7 @@ BIND_GLOBAL( "DeclareGlobalFunction", function( arg )
 
     name := arg[1];
     ADD_SET( GLOBAL_FUNCTION_NAMES, IMMUTABLE_COPY_OBJ(name) );
-    BIND_GLOBAL( name, NEW_OPERATION_ARGS( name ) );
+    BIND_GLOBAL( name, NEW_GLOBAL_FUNCTION( name ) );
 end );
 
 BIND_GLOBAL( "InstallGlobalFunction", function( arg )
@@ -1787,7 +1787,7 @@ BIND_GLOBAL( "InstallGlobalFunction", function( arg )
       Error("you cannot install a global function for another global ",
             "function,\nuse `DeclareSynonym' instead!");
     fi;
-    INSTALL_METHOD_ARGS( oper, func );
+    INSTALL_GLOBAL_FUNCTION( oper, func );
 end );
 
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1720,10 +1720,9 @@ Obj             MakeFunction (
     else /* NARG_FUNC(fexp) < -1 */    hdlr = DoPartialUnWrapFunc;
 
     /* make the function                                                   */
-    func = NewFunctionT( T_FUNCTION, SIZE_FUNC,
-                         NAME_FUNC( fexp ),
-                         NARG_FUNC( fexp ), NAMS_FUNC( fexp ),
-                         hdlr );
+    func = NewFunction( NAME_FUNC( fexp ),
+                        NARG_FUNC( fexp ), NAMS_FUNC( fexp ),
+                        hdlr );
 
     /* install the things an interpreted function needs                    */
     SET_NLOC_FUNC( func, NLOC_FUNC( fexp ) );

--- a/src/opers.c
+++ b/src/opers.c
@@ -5287,8 +5287,7 @@ Obj NewGlobalFunction (
     Obj                 namobj;
 
     /* create the function                                                 */
-    func = NewFunctionT( T_FUNCTION, SIZE_FUNC, name, narg, nams, 
-                         DoUninstalledGlobalFunction );
+    func = NewFunction( name, narg, nams, DoUninstalledGlobalFunction );
 
     /* check the number of args                                            */
     if ( narg == -1 ) {
@@ -5814,8 +5813,7 @@ Obj FuncSETTER_FUNCTION (
     Obj                 tmp;
 
     fname = WRAP_NAME(name, "SetterFunc");
-    func = NewFunctionT( T_FUNCTION, SIZE_FUNC, fname, 2,
-                         ArglistObjVal, DoSetterFunction );
+    func = NewFunction( fname, 2, ArglistObjVal, DoSetterFunction );
     tmp = NEW_PLIST( T_PLIST+IMMUTABLE, 2 );
     SET_LEN_PLIST( tmp, 2 );
     SET_ELM_PLIST( tmp, 1, INTOBJ_INT( RNamObj(name) ) );
@@ -5857,8 +5855,7 @@ Obj FuncGETTER_FUNCTION (
     Obj                 fname;
 
     fname = WRAP_NAME(name, "GetterFunc");
-    func = NewFunctionT( T_FUNCTION, SIZE_FUNC, fname, 1,
-                         ArglistObj, DoGetterFunction );
+    func = NewFunction( fname, 1, ArglistObj, DoGetterFunction );
     SET_ENVI_FUNC(func, INTOBJ_INT( RNamObj(name) ));
     return func;
 }

--- a/src/opers.c
+++ b/src/opers.c
@@ -5256,15 +5256,15 @@ Obj NewProperty (
 
 /****************************************************************************
 **
-*F  DoOperationArgs( <name> ) . . . . . . . . . . . make a new operation args
+*F  DoGlobalFunction( <name> ) . . . . . . . . . . make a new global function
 */
 
 
 /****************************************************************************
 **
-**  DoUninstalledOperationArgs( <oper>, <args> )
+**  DoUninstalledGlobalFunction( <oper>, <args> )
 */
-Obj DoUninstalledOperationArgs (
+Obj DoUninstalledGlobalFunction (
     Obj                 oper,
     Obj                 args )
 {
@@ -5276,9 +5276,9 @@ Obj DoUninstalledOperationArgs (
 
 /****************************************************************************
 **
-*F  NewOperationArgs( <name>, <nargs>, <nams> )
+*F  NewGlobalFunction( <name>, <nargs>, <nams> )
 */
-Obj NewOperationArgs (
+Obj NewGlobalFunction (
     Obj                 name,
     Int                 narg,
     Obj                 nams )
@@ -5288,21 +5288,21 @@ Obj NewOperationArgs (
 
     /* create the function                                                 */
     func = NewFunctionT( T_FUNCTION, SIZE_FUNC, name, narg, nams, 
-                         DoUninstalledOperationArgs );
+                         DoUninstalledGlobalFunction );
 
     /* check the number of args                                            */
     if ( narg == -1 ) {
-        SET_HDLR_FUNC(func, 0, DoUninstalledOperationArgs);
-        SET_HDLR_FUNC(func, 1, DoUninstalledOperationArgs);
-        SET_HDLR_FUNC(func, 2, DoUninstalledOperationArgs);
-        SET_HDLR_FUNC(func, 3, DoUninstalledOperationArgs);
-        SET_HDLR_FUNC(func, 4, DoUninstalledOperationArgs);
-        SET_HDLR_FUNC(func, 5, DoUninstalledOperationArgs);
-        SET_HDLR_FUNC(func, 6, DoUninstalledOperationArgs);
-        SET_HDLR_FUNC(func, 7, DoUninstalledOperationArgs);
+        SET_HDLR_FUNC(func, 0, DoUninstalledGlobalFunction);
+        SET_HDLR_FUNC(func, 1, DoUninstalledGlobalFunction);
+        SET_HDLR_FUNC(func, 2, DoUninstalledGlobalFunction);
+        SET_HDLR_FUNC(func, 3, DoUninstalledGlobalFunction);
+        SET_HDLR_FUNC(func, 4, DoUninstalledGlobalFunction);
+        SET_HDLR_FUNC(func, 5, DoUninstalledGlobalFunction);
+        SET_HDLR_FUNC(func, 6, DoUninstalledGlobalFunction);
+        SET_HDLR_FUNC(func, 7, DoUninstalledGlobalFunction);
     }
     else {
-        ErrorQuit("number of args must be -1 in `NewOperationArgs'",0L,0L);
+        ErrorQuit("number of args must be -1 in `NewGlobalFunction'",0L,0L);
         return 0;
     }
 
@@ -5318,13 +5318,13 @@ Obj NewOperationArgs (
 
 /****************************************************************************
 **
-*F  InstallMethodArgs( <oper>, <func> ) . . . . . . . . . . .  clone function
+*F  InstallGlobalFunction( <oper>, <func> ) . . . . . . . . .  clone function
 **
 **  There is a problem  with uncompleted functions: if  they are  cloned then
 **  only   the orignal and not  the  clone will be  completed.  Therefore the
 **  clone must postpone the real cloning.
 */
-void InstallMethodArgs (
+void InstallGlobalFunction (
     Obj                 oper,
     Obj                 func )
 {
@@ -5555,9 +5555,9 @@ Obj FuncNEW_PROPERTY (
 
 /****************************************************************************
 **
-*F  FuncNEW_OPERATION_ARGS( <self>, <name> )  . . . . . .  new operation args
+*F  FuncNEW_GLOBAL_FUNCTION( <self>, <name> ) . . . . . . new global function
 */
-Obj FuncNEW_OPERATION_ARGS (
+Obj FuncNEW_GLOBAL_FUNCTION (
     Obj                 self,
     Obj                 name )
 {
@@ -5566,7 +5566,7 @@ Obj FuncNEW_OPERATION_ARGS (
 
     /* check the argument                                                  */
     if ( ! IsStringConv(name) ) {
-        ErrorQuit( "usage: NewOperationArgs( <name> )", 0L, 0L );
+        ErrorQuit( "usage: NewGlobalFunction( <name> )", 0L, 0L );
         return 0;
     }
 
@@ -5576,17 +5576,17 @@ Obj FuncNEW_OPERATION_ARGS (
     SET_LEN_PLIST( list, 1 );
     SET_ELM_PLIST( list, 1, args );
     CHANGED_BAG( list );
-    return NewOperationArgs( name, -1, list );
+    return NewGlobalFunction( name, -1, list );
 }
 
 
 /****************************************************************************
 **
-*F  FuncINSTALL_METHOD_ARGS( <self>, <oper>, <func> ) . . install method args
+*F  FuncINSTALL_GLOBAL_FUNCTION( <self>, <oper>, <func> )
 */
 static Obj REREADING;
 
-Obj FuncINSTALL_METHOD_ARGS (
+Obj FuncINSTALL_GLOBAL_FUNCTION (
     Obj                 self,
     Obj                 oper,
     Obj                 func )
@@ -5597,7 +5597,7 @@ Obj FuncINSTALL_METHOD_ARGS (
                    (Int)TNAM_OBJ(oper), 0L );
     }
     if ( (REREADING != True) &&
-         (HDLR_FUNC(oper,0) != (ObjFunc)DoUninstalledOperationArgs) ) {
+         (HDLR_FUNC(oper,0) != (ObjFunc)DoUninstalledGlobalFunction) ) {
         ErrorQuit( "operation already installed",
                    0L, 0L );
         return 0;
@@ -5613,7 +5613,7 @@ Obj FuncINSTALL_METHOD_ARGS (
     }
 
     /* install the new method                                              */
-    InstallMethodArgs( oper, func );
+    InstallGlobalFunction( oper, func );
     return 0;
 }
 
@@ -6125,8 +6125,8 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(NEW_PROPERTY, 1, "name"),
     GVAR_FUNC(SETTER_FUNCTION, 2, "name, filter"),
     GVAR_FUNC(GETTER_FUNCTION, 1, "name"),
-    GVAR_FUNC(NEW_OPERATION_ARGS, 1, "name"),
-    GVAR_FUNC(INSTALL_METHOD_ARGS, 2, "oper, func"),
+    GVAR_FUNC(NEW_GLOBAL_FUNCTION, 1, "name"),
+    GVAR_FUNC(INSTALL_GLOBAL_FUNCTION, 2, "oper, func"),
     GVAR_FUNC(TRACE_METHODS, 1, "oper"),
     GVAR_FUNC(UNTRACE_METHODS, 1, "oper"),
     GVAR_FUNC(OPERS_CACHE_INFO, 0, ""),
@@ -6232,7 +6232,7 @@ static Int InitKernel (
     InitHandlerFunc( DoVerboseConstructor6Args, "src/opers.c:DoVerboseConstructor6Args" );
     InitHandlerFunc( DoVerboseConstructorXArgs, "src/opers.c:DoVerboseConstructorXArgs" );
 
-    InitHandlerFunc( DoUninstalledOperationArgs, "src/opers.c:DoUninstalledOperationArgs" );
+    InitHandlerFunc( DoUninstalledGlobalFunction, "src/opers.c:DoUninstalledGlobalFunction" );
 
     /* install the type function                                           */
     ImportGVarFromLibrary( "TYPE_FLAGS", &TYPE_FLAGS );

--- a/src/opers.c
+++ b/src/opers.c
@@ -5752,7 +5752,7 @@ Obj FuncSET_METHODS_OPERATION (
 
 /****************************************************************************
 **
-*F  FuncSETTER_FUNCTION( <self>, <name> ) . . . . . . default attribut setter
+*F  FuncSETTER_FUNCTION( <self>, <name> ) . . . . .  default attribute setter
 */
 Obj DoSetterFunction (
     Obj                 self,
@@ -5827,7 +5827,7 @@ Obj FuncSETTER_FUNCTION (
 
 /****************************************************************************
 **
-*F  FuncGETTER_FUNCTION( <self>, <name> ) . . . . . . default attribut getter
+*F  FuncGETTER_FUNCTION( <self>, <name> ) . . . . .  default attribute getter
 */
 Obj DoGetterFunction (
     Obj                 self,


### PR DESCRIPTION
Looking at the C code, I never knew what these functions were about. So I figured it's best to rename the kernel functions to mach their GAP level counterparts.

Also replaced some calls to `NewFunctionT` by calls to `NewFunction`, and fixed typos in comments.