### PR TITLE
Add PopPlist helper, use it to set removed StackNams entries to zero

### DIFF
--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -81,9 +81,9 @@
 **
 **  If 'IntrReturning' is  non-zero, the interpreter is currently  returning.
 **  The interpreter switches  to this mode when  it finds a return-statement.
-**  If it interpretes a return-value-statement, it sets 'IntrReturning' to 1.
-**  If it interpretes a return-void-statement,  it sets 'IntrReturning' to 2.
-**  If it interpretes a quit-statement, it sets 'IntrReturning' to 8.
+**  If it interprets a return-value-statement, it sets 'IntrReturning' to 1.
+**  If it interprets a return-void-statement,  it sets 'IntrReturning' to 2.
+**  If it interprets a quit-statement, it sets 'IntrReturning' to 8.
 */
 /* TL: UInt IntrReturning; */
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -144,14 +144,9 @@
 
 /* TL: Obj             StackObj; */
 
-void            PushObj (
-    Obj                 val )
+static void PushObj(Obj val)
 {
-    /* there must be a stack, it must not be underfull or overfull         */
-    assert( STATE(StackObj) != 0 );
     assert( val != 0 );
-
-    // put the value onto the stack
     PushPlist( STATE(StackObj), val );
 }
 
@@ -162,70 +157,43 @@ void            PushObj (
  * The only place other than these methods which access the stack is
  * the permutation reader, but it only directly accesses values it wrote,
  * so it will not see this magic value. */
-Obj VoidReturnMarker;
+static Obj VoidReturnMarker;
 
-void            PushFunctionVoidReturn ( void )
+static void PushFunctionVoidReturn(void)
 {
-    /* there must be a stack, it must not be underfull or overfull         */
-    assert( STATE(StackObj) != 0 );
-
-    // put the value onto the stack
     PushPlist( STATE(StackObj), (Obj)&VoidReturnMarker );
 }
 
-void            PushVoidObj ( void )
+void PushVoidObj(void)
 {
-    /* there must be a stack, it must not be underfull or overfull         */
-    assert( STATE(StackObj) != 0 );
-
-    // put the value onto the stack
     PushPlist( STATE(StackObj), (Obj)0 );
 }
 
-Obj             PopObj ( void )
+static Obj PopObj(void)
 {
-    Obj                 val;
+    Obj val = PopPlist( STATE(StackObj) );
 
-    /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( STATE(StackObj) != 0 );
-    UInt countObj = LEN_LIST(STATE(StackObj));
-    assert( 1 <= countObj );
-
-    /* get the top element from the stack and count down                   */
-    val = ELM_PLIST( STATE(StackObj), countObj );
-    SET_ELM_PLIST( STATE(StackObj), countObj, 0 );
-    SET_LEN_PLIST( STATE(StackObj), countObj - 1 );
-
-    if(val == (Obj)&VoidReturnMarker) {
+    if (val == (Obj)&VoidReturnMarker) {
         ErrorQuit(
             "Function call: <func> must return a value",
             0L, 0L );
     }
-    /* return the popped value (which must be non-void)                    */
+
+    // return the popped value (which must be non-void)
     assert( val != 0 );
     return val;
 }
 
-Obj             PopVoidObj ( void )
+static Obj PopVoidObj(void)
 {
-    Obj                 val;
+    Obj val = PopPlist( STATE(StackObj) );
 
-    /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( STATE(StackObj) != 0 );
-    UInt countObj = LEN_LIST(STATE(StackObj));
-    assert( 1 <= countObj );
-
-    /* get the top element from the stack and count down                   */
-    val = ELM_PLIST( STATE(StackObj), countObj );
-    SET_ELM_PLIST( STATE(StackObj), countObj, 0 );
-    SET_LEN_PLIST( STATE(StackObj), countObj - 1 );
-
-    /* Treat a function which returned no value the same as 'void'         */
-    if(val == (Obj)&VoidReturnMarker) {
+    // Treat a function which returned no value the same as 'void'
+    if (val == (Obj)&VoidReturnMarker) {
         val = 0;
     }
 
-    /* return the popped value (which may be void)                         */
+    // return the popped value (which may be void)
     return val;
 }
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -783,7 +783,7 @@ void IntrForEnd ( void )
        variable names list to get the counts right. Remove it */
     const UInt len = LEN_PLIST(STATE(StackNams));
     if (len > 0)
-      SET_LEN_PLIST(STATE(StackNams), len - 1);
+        PopPlist(STATE(StackNams));
 
     func = STATE(CodeResult);
 
@@ -904,7 +904,7 @@ void            IntrWhileEnd ( void )
        variable names list to get the counts right. Remove it */
     const UInt len = LEN_PLIST(STATE(StackNams));
     if (len > 0)
-      SET_LEN_PLIST(STATE(StackNams), len - 1);
+        PopPlist(STATE(StackNams));
 
     func = STATE(CodeResult);
 
@@ -1030,7 +1030,7 @@ void            IntrAtomicEndBody (
        variable names list to get the counts right. Remove it */
       const UInt len = LEN_PLIST(STATE(StackNams));
       if (len > 0)
-        SET_LEN_PLIST(STATE(StackNams), len - 1);
+          PopPlist(STATE(StackNams));
 
       /* Code the body as a function expression */
       CodeFuncExprEnd( nrstats, 0UL );
@@ -1240,7 +1240,7 @@ void            IntrRepeatEnd ( void )
        variable names list to get the counts right. Remove it */
     const UInt len = LEN_PLIST(STATE(StackNams));
     if (len > 0)
-      SET_LEN_PLIST(STATE(StackNams), len - 1);
+        PopPlist(STATE(StackNams));
 
     func = STATE(CodeResult);
 

--- a/src/plist.h
+++ b/src/plist.h
@@ -259,6 +259,24 @@ static inline UInt PushPlist(Obj list, Obj val)
 
 /****************************************************************************
 **
+*F  PopPlist( <list> ) . . . . . . . . .  remove last element of a plain list
+**
+**  Also returns the removed element. Caller is responsible for ensuring that
+**  the list is non-empty. Otherwise, an assertion may be raised, or the plist
+**  be left in an invalid state.
+**
+*/
+static inline Obj PopPlist(Obj list)
+{
+    const UInt pos = LEN_PLIST(list);
+    Obj val = ELM_PLIST(list, pos);
+    SET_LEN_PLIST(list, pos - 1);
+    SET_ELM_PLIST(list, pos, 0);
+    return val;
+}
+
+/****************************************************************************
+**
 *F  AssPlistEmpty( <list>, <pos>, <val> ) . . . . .  assignment to empty list
 *F  UnbPlistImm( <list>, <pos> ) . . . .  unbind an element from a plain list
 */

--- a/src/read.c
+++ b/src/read.c
@@ -1517,9 +1517,7 @@ void ReadFuncExpr (
     }
 
     /* pop the new local variables list                                    */
-    const UInt len = LEN_PLIST(STATE(StackNams));
-    assert(len > 0);
-    SET_LEN_PLIST(STATE(StackNams), len - 1);
+    PopPlist(STATE(StackNams));
 
     /* 'end'                                                               */
     if (is_block)
@@ -1578,9 +1576,7 @@ static void ReadFuncExprBody (
     }
 
     /* pop the new local variables list                                    */
-    const UInt len = LEN_PLIST(STATE(StackNams));
-    assert(len > 0);
-    SET_LEN_PLIST(STATE(StackNams), len - 1);
+    PopPlist(STATE(StackNams));
 }
 
 /****************************************************************************


### PR DESCRIPTION
This does what we discussed on a previous PR, and also cleans up PushObj and PopObj in the interpreter -- all those asserts in there are made redundant by `GAP_ASSERT`s in `PopPlist` resp. in the functions it uses.