### PR TITLE
Fix some referencing issues in HPC-GAP documentation

### DIFF
--- a/doc/changes/changes48.xml
+++ b/doc/changes/changes48.xml
@@ -61,11 +61,10 @@ and is now equivalent to <C>function( arg... )</C>, so no changes in the
 existing code are required.
 </Item>
 <Item>
-Introduced <Ref Func="CallWithTimeout" BookName="ref"/> and
-<Ref Func="CallWithTimeoutList" BookName="ref"/> to call a function with
-a limit on the CPU time it can consume. This functionality may not be
-available on all systems and you should check <C>GAPInfo.TimeoutsSupported</C>
-before using this functionality.
+Introduced <C>CallWithTimeout</C> and <C>CallWithTimeoutList</C> to call a
+function with a limit on the CPU time it can consume. This functionality may
+not be available on all systems and you should check
+<C>GAPInfo.TimeoutsSupported</C> before using this functionality.
 </Item>
 <Item>
 &GAP; now displays the filename and line numbers of statements in backtraces

--- a/doc/changes/changes48.xml
+++ b/doc/changes/changes48.xml
@@ -65,6 +65,8 @@ Introduced <C>CallWithTimeout</C> and <C>CallWithTimeoutList</C> to call a
 function with a limit on the CPU time it can consume. This functionality may
 not be available on all systems and you should check
 <C>GAPInfo.TimeoutsSupported</C> before using this functionality.
+<!-- https://github.com/gap-system/gap/pull/1324 -->
+(These functions were withdrawn in &GAP; 4.9.)
 </Item>
 <Item>
 &GAP; now displays the filename and line numbers of statements in backtraces

--- a/doc/hpc/mpi.xml
+++ b/doc/hpc/mpi.xml
@@ -91,7 +91,7 @@ and <C>InstallGlobalFunction</C>. In the case when pickling is used for object m
 <C>listOfArguments</C> can also be a function.
 
     </Subsection>
-    <Subsection Label="ExecuteTask">
+    <Subsection Label="ExecuteTask:MPI">
       <Heading>ExecuteTask(task)</Heading>
 
 <C>ExecuteTask</C> puts <C>task</C> into the task queue of the node where it was created.
@@ -101,7 +101,7 @@ node. All of the arguments are copied to the remote node. One or more arguments 
 case, only the handles (and not the underlying objects) are copied to the remote node.
 
     </Subsection>
-    <Subsection Label="RunTask">
+    <Subsection Label="RunTask:MPI">
       <Heading>RunTask(f,arg1,arg2,...,argN)</Heading>
 
 <C>RunTask</C> creates a task, with the function (or function name, depending on the method for marshalling, see

--- a/doc/hpc/regions.xml
+++ b/doc/hpc/regions.xml
@@ -116,7 +116,7 @@ these semantics, either a &quot;write guard error&quot; (for a failed write acce
 caused such an error.
 
 One exception is that threads can modify objects in regions that they have only read access (but not write access) to
-using write-once functions (<Ref Func="write-once"/>).
+using write-once functions - see section <Ref Sect="Write-once functionality"/>.
 
 To inspect objects whose contents lie in other regions (and therefore cannot be displayed by <C>PrintObj</C> or
 <C>ViewObj</C>, the functions <Ref Func="ViewShared"/> and <Ref Func="UNSAFE_VIEW"/> can be used.

--- a/doc/hpc/tasks.xml
+++ b/doc/hpc/tasks.xml
@@ -168,6 +168,7 @@ gap> TaskResult(t);
     <ManSection>
       <Func Name="WaitTask" Arg='task1,...,taskn'/>
       <Func Name="WaitTask" Arg='condition'/>
+      <Func Name="WaitTask" Arg='condition' Label="with a condition" />
       <Func Name="WaitTasks" Arg='task1,...,taskn'/>
 
       <Description>


### PR DESCRIPTION
This resolves some of the problems discussed in #1568 — all except the LaTeX warnings about `UNSAFEVIEW`, `MAXINTERRUPT` and `SWITCHOBJ`. 

These seem to stem from an issue in GAPDoc's LaTeX generator itself: when the section for e.g. `UNSAFE_VIEW` starts, it defines the label as `\label{UNSAFE_VIEW}`, but when referencing the section later, it strips the underscore, using `\ref{UNSAFEVIEW}`. (Normally in text, it becomes `UNSAFE{\textunderscore}VIEW`.)

Elsewhere in the GAP manual, variables with underscores are described using `<Var Name="..."/>` definitions, rather than ordinary `<Section Label="...">` tags, so perhaps GAPDoc handles this case there. It seems inconsistent to use this form for just these three functions, however.