### PR TITLE
Use __builtin_popcntl for counting set bits in bitlists.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,7 @@ CHECK_COMPILER_BUILTIN([__builtin_smulll_overflow],[0,0,0]);
 CHECK_COMPILER_BUILTIN([__builtin_clz],[0]);
 CHECK_COMPILER_BUILTIN([__builtin_clzl],[0]);
 CHECK_COMPILER_BUILTIN([__builtin_clzll],[0]);
+CHECK_COMPILER_BUILTIN([__builtin_popcountl],[0]);
 
 dnl determine sizeof of some standard types, so that the GAP headers
 dnl can pick the correct builtins among those we just tested
@@ -215,6 +216,33 @@ AC_ARG_ENABLE([Werror],
 AC_MSG_CHECKING([whether to treat C compiler warnings as errors])
 AC_MSG_RESULT([$enable_Werror])
 
+
+AS_IF([test "x$enable_Werror" != "xno"],
+  [ax_enable_compile_warnings=error],
+  [ax_enable_compile_warnings=yes])
+
+#WARNING_CPPFLAGS=""
+AX_COMPILER_FLAGS_CFLAGS([WARNING_CPPFLAGS])
+AC_SUBST([WARNING_CPPFLAGS])
+
+dnl
+dnl User setting: Enable popcnt (on by default)
+dnl
+
+AC_ARG_ENABLE([popcnt],
+    AS_HELP_STRING([--enable-popcnt], [use __builtin_popcntl if available]),
+    [],
+    [enable_popcnt=yes])
+AC_MSG_CHECKING([whether to try and use __builtin_popcntl])
+AC_MSG_RESULT([$enable_popcnt])
+
+AS_IF([test "x$enable_popcnt" != "xno"],
+    [USE_POPCNT=1],
+    [USE_POPCNT=0])
+
+AC_DEFINE_UNQUOTED([USE_POPCNT],
+    [$USE_POPCNT],
+    [define as 1 if we should try and use the __builtin_popcntl function if available])
 
 AS_IF([test "x$enable_Werror" != "xno"],
   [ax_enable_compile_warnings=error],

--- a/src/blister.h
+++ b/src/blister.h
@@ -208,30 +208,107 @@ static inline UInt * BLOCKS_BLIST(Obj list)
 
 /****************************************************************************
 **
-*F  COUNT_TRUES_BLOCK( <block> )  . . . . . . . . . . . count number of trues
+*F COUNT_TRUES_BLOCK( <block> ) . . . . . . . . . . . count number of
+*trues
+** 
+** 'COUNT_TRUES_BLOCK( <block> )' returns the number of 1 bits in the
+**  UInt <block>. Two implementations are included below. One uses the
+**  gcc builtin __builtin_popcount which usually generates the popcntl
+**  or popcntq instruction on sufficiently recent CPUs. The other uses
+**  the algorithm described in the original comment below:
+**
+**  The sequence to compute the  number of bits in  a block is quite  clever.
+**  The idea is that after the <i>-th instruction each subblock of $2^i$ bits
+**  holds the number of   bits of this  subblock  in the original block  <m>.
+**  This is illustrated in the example below for a block of with 8 bits:
+**
+**       // a b c d e f g h
+**      m = (m & 0x55)       +  ((m >> 1) & 0x55);
+**       // . b . d . f . h  +  . a . c . e . g   =  a+b c+d e+f g+h
+**      m = (m & 0x33)       +  ((m >> 2) & 0x33);
+**       // . . c+d . . g+h  +  . . a+b . . e+f   =  a+b+c+d e+f+g+h
+**      m = (m & 0x0f)       +  ((m >> 4) & 0x0f);
+**       // . . . . e+f+g+h  +  . . . . a+b+c+d   =  a+b+c+d+e+f+g+h
+**
+**  In the actual  code  some unnecessary mask  have  been removed, improving
+**  performance quite a bit,  because masks are 32  bit immediate values  for
+**  which most RISC  processors need two  instructions to load them.  Talking
+**  about performance.  The code is  close to optimal,  it should compile  to
+**  only about  22 MIPS  or SPARC instructions.   Dividing the  block into  4
+**  bytes and looking up the number of bits  of a byte in a  table may be 10%
+**  faster, but only if the table lives in the data cache.
+**
+**  At this time (2017) the optimum choice of implementation for this
+**  function as used seems to be use the gcc builtin on all systems --
+**  but see the comments below in the documentation of
+**  'COUNT_TRUES_BLOCKS'.
+**
 */
-#ifdef SYS_IS_64_BIT
-
-#define COUNT_TRUES_BLOCK( block )                                                          \
-        do {                                                                                \
-        (block) = ((block) & 0x5555555555555555L) + (((block) >> 1) & 0x5555555555555555L); \
-        (block) = ((block) & 0x3333333333333333L) + (((block) >> 2) & 0x3333333333333333L); \
-        (block) = ((block) + ((block) >>  4)) & 0x0f0f0f0f0f0f0f0fL;                        \
-        (block) = ((block) + ((block) >>  8));                                              \
-        (block) = ((block) + ((block) >> 16));                                              \
-        (block) = ((block) + ((block) >> 32)) & 0x00000000000000ffL; } while (0)            
-
+  
+static inline UInt COUNT_TRUES_BLOCK( UInt block )  {  
+#if USE_POPCNT && defined(HAVE___BUILTIN_POPCOUNTL)  
+  return __builtin_popcountl(block);
 #else
-
-#define COUNT_TRUES_BLOCK( block )                                        \
-        do {                                                              \
-        (block) = ((block) & 0x55555555) + (((block) >> 1) & 0x55555555); \
-        (block) = ((block) & 0x33333333) + (((block) >> 2) & 0x33333333); \
-        (block) = ((block) + ((block) >>  4)) & 0x0f0f0f0f;               \
-        (block) = ((block) + ((block) >>  8));                            \
-        (block) = ((block) + ((block) >> 16)) & 0x000000ff; } while (0)   
+#ifdef SYS_IS_64_BIT
+    block =
+        (block & 0x5555555555555555L) + ((block >> 1) & 0x5555555555555555L);
+    block =
+        (block & 0x3333333333333333L) + ((block >> 2) & 0x3333333333333333L);
+    block = (block + (block >> 4)) & 0x0f0f0f0f0f0f0f0fL;
+    block = (block + (block >> 8));
+    block = (block + (block >> 16));
+    block = (block + (block >> 32)) & 0x00000000000000ffL;
+#else
+    block = (block & 0x55555555) + ((block >> 1) & 0x55555555);
+    block = (block & 0x33333333) + ((block >> 2) & 0x33333333);
+    block = (block + (block >> 4)) & 0x0f0f0f0f;
+    block = (block + (block >> 8));
+    block = (block + (block >> 16)) & 0x000000ff;
 #endif
+    return block;
+#endif
+}
 
+/****************************************************************************
+**
+*F  COUNT_TRUES_BLOCKS( <ptr>, <nblocks> ) 
+**  
+**  'COUNT_TRUES_BLOCKS( <ptr>, <nblocks> )' returns the total number of 1
+**  bits in the array of UInt values starting at <ptr> and including a total
+**  of <nblocks> UInts. The only reason this function is really needed is
+**  that, owing to hardware bugs and compiler peculiarities current in 2017,
+**  (see http://danluu.com/assembly-intrinsics/ or
+**  https://stackoverflow.com/questions/25078285?) manually unrolling this
+**  loop makes the code substantially faster on almost all CPUS.
+** 
+**  This interacts strangely with the choice of algorithm for
+**  COUNT_TRUES_BLOCK above. Without the loop unrolling, not using the gcc
+**  builtin is sometimes faster, apparently because it allows the compiler
+**  to unroll the loop and then generate SSE or AVX code to process multiple
+**  words at once. With the loop unrolling the builtin is always faster, and
+**  will itself generate AVX code when compiling for suitable processors.
+**
+*T  monitor this situation periodically. 
+*/
+
+static inline UInt COUNT_TRUES_BLOCKS(UInt * ptr, UInt nblocks)
+{
+    UInt n = 0;
+    while (nblocks >= 4) {
+        UInt n1 = COUNT_TRUES_BLOCK(*ptr++);
+        UInt n2 = COUNT_TRUES_BLOCK(*ptr++);
+        UInt n3 = COUNT_TRUES_BLOCK(*ptr++);
+        UInt n4 = COUNT_TRUES_BLOCK(*ptr++);
+        n += n1 + n2 + n3 + n4;
+        nblocks -= 4;
+    }
+    while (nblocks) {
+        n += COUNT_TRUES_BLOCK(*ptr++);
+        nblocks--;
+    }
+    // return the number of bits                                          
+    return n;
+}
 
 /****************************************************************************
 **

--- a/src/opers.c
+++ b/src/opers.c
@@ -299,7 +299,6 @@ Obj FuncTRUES_FLAGS (
     Int                 len;            /* logical length of the list      */
     UInt *              ptr;            /* pointer to flags                */
     UInt                nrb;            /* number of blocks in flags       */
-    UInt                m;              /* number of bits in a block       */
     UInt                n;              /* number of bits in flags         */
     UInt                nn;
     UInt                i;              /* loop variable                   */
@@ -317,12 +316,7 @@ Obj FuncTRUES_FLAGS (
     /* compute the number of 'true'-s just as in 'FuncSizeBlist'            */
     nrb = NRB_FLAGS(flags);
     ptr = (UInt*)BLOCKS_FLAGS(flags);
-    n = 0;
-    for ( i = 1; i <= nrb; i++ ) {
-        m = *ptr++;
-        COUNT_TRUES_BLOCK(m); 
-        n += m;
-    }
+    n = COUNT_TRUES_BLOCKS(ptr, nrb);    
 
     /* make the sublist (we now know its size exactly)                    */
     sub = NEW_PLIST( T_PLIST+IMMUTABLE, n );
@@ -358,9 +352,7 @@ Obj FuncSIZE_FLAGS (
 {
     UInt *              ptr;            /* pointer to flags                */
     UInt                nrb;            /* number of blocks in flags       */
-    UInt                m;              /* number of bits in a block       */
     UInt                n;              /* number of bits in flags         */
-    UInt                i;              /* loop variable                   */
 
     /* get and check the first argument                                    */
     while ( TNUM_OBJ(flags) != T_FLAGS ) {
@@ -376,13 +368,7 @@ Obj FuncSIZE_FLAGS (
     nrb = NRB_FLAGS(flags);
     ptr = BLOCKS_FLAGS(flags);
 
-    /* loop over the blocks, adding the number of bits of each one         */
-    n = 0;
-    for ( i = 1; i <= nrb; i++ ) {
-        m = *ptr++;
-        COUNT_TRUES_BLOCK(m);
-        n += m;
-    }
+    n = COUNT_TRUES_BLOCKS(ptr, nrb);
 
     /* return the number of bits                                           */
     return INTOBJ_INT( n );

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -3354,10 +3354,10 @@ UInt DistGF2Vecs(UInt* ptL,UInt* ptR,UInt len)
   end = ptL + ((len+BIPEB-1)/BIPEB);
   sum=0;
   /* loop over the entries */
+  /*T possibly unroll this loop */
   while ( ptL < end ) {
     m = *ptL++ ^ *ptR++; /* xor of bits, nr bits therein is difference */
-    COUNT_TRUES_BLOCK(m);
-    sum += m;
+    sum += COUNT_TRUES_BLOCK(m);
   }
   return sum;
 }


### PR DESCRIPTION
Can be disabled by --disable-popcnt at configure time, since some compilers will produce faster code from the other algorithm on Haswell for long blists. Generally this seems the better setting