### PR TITLE
kernel: rename lots of functions from `FOOHandler` to `FuncFOO`

### DIFF
--- a/lib/string.gi
+++ b/lib/string.gi
@@ -515,46 +515,7 @@ InstallMethod( SplitString,
         "for three strings",
         true,
         [ IsString, IsString, IsString ], 0,
-##  function( string, seps, wspace )
-##      local   substrings,  a,  z;
-##  
-##      ##  make sets from char lists
-##      seps := Set(seps);
-##      wspace := Set(wspace);
-##  
-##      ##  store the substrings in a list.
-##      substrings := [];
-##  
-##      ##  a is the position after the last separator/white space.
-##      a := 1;
-##      z := 0;
-##  
-##      for z in [1..Length( string )] do
-##          ##  Whenever we encounter a separator or a white space, the substring
-##          ##  starting after the last separator/white space is cut out.  The
-##          ##  only difference between white spaces and separators is that white
-##          ##  spaces don't separate empty strings.  
-##          if string[z] in wspace then
-##              if a < z then
-##                  Add( substrings, string{[a..z-1]} );
-##              fi;
-##              a := z+1;
-##          elif string[z] in seps then
-##              Add( substrings, string{[a..z-1]} );
-##              a := z+1;
-##          fi;
-##      od;
-##  
-##      ##  Pick up a substring at the end of the string.  Note that a trailing
-##      ##  separator does not produce an empty string.
-##      if a <= z  then
-##          Add( substrings, string{[a..z]} );
-##      fi;
-##      return substrings;
-##  end 
-# moved to kernel
-SplitStringInternal
-);
+        SplitStringInternal );
 
 InstallMethod( SplitString,
         "for a string and two characters",

--- a/src/gmpints.h
+++ b/src/gmpints.h
@@ -74,7 +74,7 @@ extern Obj ObjInt_Int8(Int8 i);
 ** Reduce and normalize the given large integer object if necessary.
 **
 ** TODO: This is an internal implementation detail and ideally should not
-** be exported; unfortunately, FuncNUMBER_VECGF2 currently needs this.
+** be exported; unfortunately, FuncNUMBER_GF2VEC currently needs this.
 */
 extern Obj GMP_REDUCE( Obj gmp );
 extern Obj GMP_NORMALIZE( Obj gmp );

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -721,16 +721,16 @@ void MakeThreadLocalVar (
 
 /****************************************************************************
 **
-*F  MakeReadOnlyGVarHandler(<self>,<name>)   make a global variable read only
+*F  FuncMakeReadOnlyGVar(<self>,<name>)   make a global variable read only
 **
-**  'MakeReadOnlyGVarHandler' implements the function 'MakeReadOnlyGVar'.
+**  'FuncMakeReadOnlyGVar' implements the function 'MakeReadOnlyGVar'.
 **
 **  'MakeReadOnlyGVar( <name> )'
 **
 **  'MakeReadOnlyGVar' make the global  variable with the name <name>  (which
 **  must be a GAP string) read only.
 */
-Obj MakeReadOnlyGVarHandler (
+Obj FuncMakeReadOnlyGVar (
     Obj                 self,
     Obj                 name )
 {       
@@ -764,16 +764,16 @@ void MakeReadWriteGVar (
 
 /****************************************************************************
 **
-*F  MakeReadWriteGVarHandler(<self>,<name>) make a global variable read write
+*F  FuncMakeReadWriteGVar(<self>,<name>) make a global variable read write
 **
-**  'MakeReadWriteGVarHandler' implements the function 'MakeReadWriteGVar'.
+**  'FuncMakeReadWriteGVar' implements the function 'MakeReadWriteGVar'.
 **
 **  'MakeReadWriteGVar( <name> )'
 **
 **  'MakeReadWriteGVar' make the global  variable with the name <name>  (which
 **  must be a GAP string) read and writable.
 */
-Obj MakeReadWriteGVarHandler (
+Obj FuncMakeReadWriteGVar (
     Obj                 self,
     Obj                 name )
 {
@@ -828,9 +828,9 @@ static Obj FuncIsReadOnlyGVar (
 
 /****************************************************************************
 **
-*F  AUTOHandler() . . . . . . . . . . . . .   make automatic global variables
+*F  FuncAUTO() . . . . . . . . . . . . .   make automatic global variables
 **
-**  'AUTOHandler' implements the internal function 'AUTO'.
+**  'FuncAUTO' implements the internal function 'AUTO'.
 **
 **  'AUTO( <func>, <arg>, <name1>, ... )'
 **
@@ -841,7 +841,7 @@ static Obj FuncIsReadOnlyGVar (
 **  cause the execution  of an assignment to  that global variable, otherwise
 **  an error is signalled.
 */
-Obj             AUTOHandler (
+Obj             FuncAUTO (
     Obj                 self,
     Obj                 args )
 {
@@ -1478,16 +1478,10 @@ void SetGVar(GVarDescriptor *gvar, Obj obj)
 */
 static StructGVarFunc GVarFuncs [] = {
 
-    { "MakeReadOnlyGVar", 1, "name",
-      MakeReadOnlyGVarHandler, "src/gap.c:MakeReadOnlyGVar" },
-
-    { "MakeReadWriteGVar", 1, "name",
-      MakeReadWriteGVarHandler, "src/gap.c:MakeReadWriteGVar" },
-
+    GVAR_FUNC(MakeReadOnlyGVar, 1, "name"),
+    GVAR_FUNC(MakeReadWriteGVar, 1, "name"),
     GVAR_FUNC(IsReadOnlyGVar, 1, "name"),
-    { "AUTO", -1, "args",
-      AUTOHandler, "src/gap.c:AUTO" },
-               
+    GVAR_FUNC(AUTO, -1, "args"),
     GVAR_FUNC(IDENTS_GVAR, 0, ""),
     GVAR_FUNC(IDENTS_BOUND_GVARS, 0, ""),
     GVAR_FUNC(ISB_GVAR, 1, "gvar"),

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -97,7 +97,7 @@ Int             EqListList (
     return 1L;
 }
 
-Obj             EqListListHandler (
+Obj FuncEQ_LIST_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -147,7 +147,7 @@ Int             LtListList (
     return (lenL < lenR);
 }
 
-Obj             LtListListHandler (
+Obj FuncLT_LIST_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -170,7 +170,7 @@ Int             InList (
   return Fail != POS_LIST( listR, objL, INTOBJ_INT(0L) );
 }
 
-Obj             InListDefaultHandler (
+Obj FuncIN_LIST_DEFAULT (
     Obj                 self,
     Obj                 obj,
     Obj                 list )
@@ -318,7 +318,7 @@ Obj             SumListList (
     return listS;
 }
 
-Obj             SumSclListHandler (
+Obj FuncSUM_SCL_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -326,7 +326,7 @@ Obj             SumSclListHandler (
     return SumSclList( listL, listR );
 }
 
-Obj             SumListSclHandler (
+Obj FuncSUM_LIST_SCL_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -334,7 +334,7 @@ Obj             SumListSclHandler (
     return SumListScl( listL, listR );
 }
 
-Obj             SumListListHandler (
+Obj FuncSUM_LIST_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -417,7 +417,7 @@ Obj             ZeroListDefault (
     return res;
 }
 
-Obj             ZeroListDefaultHandler (
+Obj FuncZERO_LIST_DEFAULT (
     Obj                 self,
     Obj                 list )
 {
@@ -478,7 +478,7 @@ Obj             ZeroListMutDefault (
     return res;
 }
 
-Obj             ZeroListMutDefaultHandler (
+Obj FuncZERO_MUT_LIST_DEFAULT (
     Obj                 self,
     Obj                 list )
 {
@@ -493,7 +493,7 @@ Obj             ZeroListMutDefaultHandler (
    we want an immutable result, we can (a) reuse a single row of zeros
    (b) record that the result is a rectangular table */
 
-Obj ZeroAttrMat( Obj self, Obj mat )
+Obj FuncZERO_ATTR_MAT( Obj self, Obj mat )
 {
   Obj zrow;
   UInt len;
@@ -578,7 +578,7 @@ Obj AInvMutListDefault (
     return res;
 }
 
-Obj AInvMutListDefaultHandler (
+Obj FuncAINV_MUT_LIST_DEFAULT (
     Obj                 self,
     Obj                 list )
 {
@@ -642,7 +642,7 @@ Obj AInvListDefault (
     return res;
 }
 
-Obj AInvListDefaultHandler (
+Obj FuncAINV_LIST_DEFAULT (
     Obj                 self,
     Obj                 list )
 {
@@ -841,7 +841,7 @@ Obj             DiffListList (
     return listD;
 }
 
-Obj             DiffSclListHandler (
+Obj FuncDIFF_SCL_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -849,7 +849,7 @@ Obj             DiffSclListHandler (
     return DiffSclList( listL, listR );
 }
 
-Obj             DiffListSclHandler (
+Obj FuncDIFF_LIST_SCL_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -857,7 +857,7 @@ Obj             DiffListSclHandler (
     return DiffListScl( listL, listR );
 }
 
-Obj             DiffListListHandler (
+Obj FuncDIFF_LIST_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -1023,7 +1023,7 @@ Obj             ProdListList (
     return listP;
 }
 
-Obj             ProdSclListHandler (
+Obj FuncPROD_SCL_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -1031,7 +1031,7 @@ Obj             ProdSclListHandler (
     return ProdSclList( listL, listR );
 }
 
-Obj             ProdListSclHandler (
+Obj FuncPROD_LIST_SCL_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -1039,7 +1039,7 @@ Obj             ProdListSclHandler (
     return ProdListScl( listL, listR );
 }
 
-Obj             ProdListListHandler (
+Obj FuncPROD_LIST_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR,
@@ -1150,21 +1150,21 @@ Obj             OneMatrix (
     return res;
 }
 
-Obj             FuncOneMatrixImmutable (
+Obj FuncONE_MATRIX_IMMUTABLE (
     Obj                 self,
     Obj                 list )
 {
     return OneMatrix( list,0 );
 }
 
-Obj             FuncOneMatrixSameMutability (
+Obj FuncONE_MATRIX_SAME_MUTABILITY (
     Obj                 self,
     Obj                 list )
 {
     return OneMatrix( list,1 );
 }
 
-Obj             FuncOneMatrixMutable (
+Obj FuncONE_MATRIX_MUTABLE (
     Obj                 self,
     Obj                 list )
 {
@@ -2227,66 +2227,26 @@ static Obj  FuncMONOM_PROD( Obj self, Obj m1, Obj m2 ) {
 */
 static StructGVarFunc GVarFuncs [] = {
 
-    { "EQ_LIST_LIST_DEFAULT", 2, "listL, listR",
-      EqListListHandler, "src/listoper.c:EQ_LIST_LIST_DEFAULT" },
-
-    { "LT_LIST_LIST_DEFAULT", 2, "listL, listR",
-      LtListListHandler, "src/listoper.c:LT_LIST_LIST_DEFAULT" },
-
-    { "IN_LIST_DEFAULT", 2, "obj, list",
-      InListDefaultHandler, "src/listoper.c:IN_LIST_DEFAULT" },
-
-    { "SUM_SCL_LIST_DEFAULT", 2, "listL, listR",
-      SumSclListHandler, "src/listoper.c:SUM_SCL_LIST_DEFAULT" },
-
-    { "SUM_LIST_SCL_DEFAULT", 2, "listL, listR",
-      SumListSclHandler, "src/listoper.c:SUM_LIST_SCL_DEFAULT" },
-
-    { "SUM_LIST_LIST_DEFAULT", 2, "listL, listR",
-      SumListListHandler, "src/listoper.c:SUM_LIST_LIST_DEFAULT" },
-
-    { "ZERO_LIST_DEFAULT", 1, "list",
-      ZeroListDefaultHandler, "src/listoper.c:ZERO_LIST_DEFAULT" },
-
-    { "ZERO_MUT_LIST_DEFAULT", 1, "list",
-      ZeroListMutDefaultHandler, "src/listoper.c:ZERO_MUT_LIST_DEFAULT" },
-
-    { "ZERO_ATTR_MAT", 1, "mat",
-      ZeroAttrMat, "src/listoper.c:ZERO_ATTR_MAT" },
-
-    { "AINV_LIST_DEFAULT", 1, "list",
-      AInvListDefaultHandler, "src/listoper.c:AINV_LIST_DEFAULT" },
-
-    { "AINV_MUT_LIST_DEFAULT", 1, "list",
-      AInvMutListDefaultHandler, "src/listoper.c:AINV_MUT_LIST_DEFAULT" },
-
-    { "DIFF_SCL_LIST_DEFAULT", 2, "listL, listR",
-      DiffSclListHandler, "src/listoper.c:DIFF_SCL_LIST_DEFAULT" },
-
-    { "DIFF_LIST_SCL_DEFAULT", 2, "listL, listR",
-      DiffListSclHandler, "src/listoper.c:DIFF_LIST_SCL_DEFAULT" },
-
-    { "DIFF_LIST_LIST_DEFAULT", 2, "listL, listR",
-      DiffListListHandler, "src/listoper.c:DIFF_LIST_LIST_DEFAULT" },
-
-    { "PROD_SCL_LIST_DEFAULT", 2, "listL, listR",
-      ProdSclListHandler, "src/listoper.c:PROD_SCL_LIST_DEFAULT" },
-
-    { "PROD_LIST_SCL_DEFAULT", 2, "listL, listR",
-      ProdListSclHandler, "src/listoper.c:PROD_LIST_SCL_DEFAULT" },
-
-    { "PROD_LIST_LIST_DEFAULT", 3, "listL, listR, depthDiff",
-      ProdListListHandler, "src/listoper.c:PROD_LIST_LIST_DEFAULT" },
-
-    { "ONE_MATRIX_MUTABLE", 1, "list",
-      FuncOneMatrixMutable, "src/listoper.c:ONE_MATRIX_MUTABLE" },
-
-    { "ONE_MATRIX_SAME_MUTABILITY", 1, "list",
-      FuncOneMatrixSameMutability, "src/listoper.c:ONE_MATRIX_SAME_MUTABILITY" },
-
-    { "ONE_MATRIX_IMMUTABLE", 1, "list",
-      FuncOneMatrixImmutable, "src/listoper.c:ONE_MATRIX_IMMUTABLE" },
-
+    GVAR_FUNC(EQ_LIST_LIST_DEFAULT, 2, "listL, listR"),
+    GVAR_FUNC(LT_LIST_LIST_DEFAULT, 2, "listL, listR"),
+    GVAR_FUNC(IN_LIST_DEFAULT, 2, "obj, list"),
+    GVAR_FUNC(SUM_SCL_LIST_DEFAULT, 2, "listL, listR"),
+    GVAR_FUNC(SUM_LIST_SCL_DEFAULT, 2, "listL, listR"),
+    GVAR_FUNC(SUM_LIST_LIST_DEFAULT, 2, "listL, listR"),
+    GVAR_FUNC(ZERO_LIST_DEFAULT, 1, "list"),
+    GVAR_FUNC(ZERO_MUT_LIST_DEFAULT, 1, "list"),
+    GVAR_FUNC(ZERO_ATTR_MAT, 1, "mat"),
+    GVAR_FUNC(AINV_LIST_DEFAULT, 1, "list"),
+    GVAR_FUNC(AINV_MUT_LIST_DEFAULT, 1, "list"),
+    GVAR_FUNC(DIFF_SCL_LIST_DEFAULT, 2, "listL, listR"),
+    GVAR_FUNC(DIFF_LIST_SCL_DEFAULT, 2, "listL, listR"),
+    GVAR_FUNC(DIFF_LIST_LIST_DEFAULT, 2, "listL, listR"),
+    GVAR_FUNC(PROD_SCL_LIST_DEFAULT, 2, "listL, listR"),
+    GVAR_FUNC(PROD_LIST_SCL_DEFAULT, 2, "listL, listR"),
+    GVAR_FUNC(PROD_LIST_LIST_DEFAULT, 3, "listL, listR, depthDiff"),
+    GVAR_FUNC(ONE_MATRIX_MUTABLE, 1, "list"),
+    GVAR_FUNC(ONE_MATRIX_SAME_MUTABILITY, 1, "list"),
+    GVAR_FUNC(ONE_MATRIX_IMMUTABLE, 1, "list"),
     GVAR_FUNC(INV_MATRIX_MUTABLE, 1, "list"),
     GVAR_FUNC(INV_MATRIX_SAME_MUTABILITY, 1, "list"),
     GVAR_FUNC(INV_MATRIX_IMMUTABLE, 1, "list"),

--- a/src/objects.c
+++ b/src/objects.c
@@ -86,9 +86,9 @@ Int RegisterPackageTNUM( const char *name, Obj (*typeObjFunc)(Obj obj) )
 
 /****************************************************************************
 **
-*F  FamilyTypeHandler( <self>, <type> ) . . . . . . handler for 'FAMILY_TYPE'
+*F  FuncFAMILY_TYPE( <self>, <type> ) . . . . . . handler for 'FAMILY_TYPE'
 */
-Obj FamilyTypeHandler (
+Obj FuncFAMILY_TYPE (
     Obj                 self,
     Obj                 type )
 {
@@ -98,9 +98,9 @@ Obj FamilyTypeHandler (
 
 /****************************************************************************
 **
-*F  FamilyObjHandler( <self>, <obj> ) . . . . . . .  handler for 'FAMILY_OBJ'
+*F  FuncFAMILY_OBJ( <self>, <obj> ) . . . . . . .  handler for 'FAMILY_OBJ'
 */
-Obj FamilyObjHandler (
+Obj FuncFAMILY_OBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -144,10 +144,10 @@ void SetTypeObjError ( Obj obj, Obj type )
 
 /****************************************************************************
 **
-*F  TypeObjHandler( <self>, <obj> ) . . . . . . . . .  handler for 'TYPE_OBJ'
+*F  FuncTYPE_OBJ( <self>, <obj> ) . . . . . . . . .  handler for 'TYPE_OBJ'
 */
 #ifndef WARD_ENABLED
-Obj TypeObjHandler (
+Obj FuncTYPE_OBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -157,9 +157,9 @@ Obj TypeObjHandler (
 
 /****************************************************************************
 **
-*F  SetTypeObjHandler( <self>, <obj>, <type> ) . . handler for 'SET_TYPE_OBJ'
+*F  FuncSET_TYPE_OBJ( <self>, <obj>, <type> ) . . handler for 'SET_TYPE_OBJ'
 */
-Obj SetTypeObjHandler (
+Obj FuncSET_TYPE_OBJ (
     Obj                 self,
     Obj                 obj,
     Obj                 type )
@@ -770,9 +770,9 @@ void CleanObjDatObjCopy (
 
 /****************************************************************************
 **
-*F  ImmutableCopyObjHandler( <self>, <obj> )  . . . . immutable copy of <obj>
+*F  FuncIMMUTABLE_COPY_OBJ( <self>, <obj> )  . . . . immutable copy of <obj>
 */
-Obj ImmutableCopyObjHandler (
+Obj FuncIMMUTABLE_COPY_OBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -782,9 +782,9 @@ Obj ImmutableCopyObjHandler (
 
 /****************************************************************************
 **
-*F  MutableCopyObjHandler( <self>, <obj> )  . . . . . . mutable copy of <obj>
+*F  FuncDEEP_COPY_OBJ( <self>, <obj> )  . . . . . . mutable copy of <obj>
 */
-Obj MutableCopyObjHandler (
+Obj FuncDEEP_COPY_OBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -1281,9 +1281,9 @@ void SetTypeComObj( Obj obj, Obj type)
 
 /*****************************************************************************
 **
-*F  IS_COMOBJ_Handler( <self>, <obj> ) . . . . . . . . handler for 'IS_COMOBJ'
+*F  FuncIS_COMOBJ( <self>, <obj> ) . . . . . . . . handler for 'IS_COMOBJ'
 */
-Obj             IS_COMOBJ_Handler (
+Obj FuncIS_COMOBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -1303,9 +1303,9 @@ Obj             IS_COMOBJ_Handler (
 
 /****************************************************************************
 **
-*F  SET_TYPE_COMOBJ_Handler( <self>, <obj>, <type> ) . . .  'SET_TYPE_COMOBJ'
+*F  FuncSET_TYPE_COMOBJ( <self>, <obj>, <type> ) . . .  'SET_TYPE_COMOBJ'
 */
-Obj SET_TYPE_COMOBJ_Handler (
+Obj FuncSET_TYPE_COMOBJ (
     Obj                 self,
     Obj                 obj,
     Obj                 type )
@@ -1372,9 +1372,9 @@ void SetTypePosObj( Obj obj, Obj type)
 
 /****************************************************************************
 **
-*F  IS_POSOBJ_Handler( <self>, <obj> )  . . . . . . . handler for 'IS_POSOBJ'
+*F  FuncIS_POSOBJ( <self>, <obj> )  . . . . . . . handler for 'IS_POSOBJ'
 */
-Obj IS_POSOBJ_Handler (
+Obj FuncIS_POSOBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -1392,9 +1392,9 @@ Obj IS_POSOBJ_Handler (
 
 /****************************************************************************
 **
-*F  SET_TYPE_POSOBJ_Handler( <self>, <obj>, <type> )  . . .  'SET_TYPE_POSOB'
+*F  FuncSET_TYPE_POSOBJ( <self>, <obj>, <type> )  . . .  'SET_TYPE_POSOB'
 */
-Obj SET_TYPE_POSOBJ_Handler (
+Obj FuncSET_TYPE_POSOBJ (
     Obj                 self,
     Obj                 obj,
     Obj                 type )
@@ -1429,9 +1429,9 @@ Obj SET_TYPE_POSOBJ_Handler (
 
 /****************************************************************************
 **
-*F  LEN_POSOBJ_Handler( <self>, <obj> ) . . . . . .  handler for 'LEN_POSOBJ'
+*F  FuncLEN_POSOBJ( <self>, <obj> ) . . . . . .  handler for 'LEN_POSOBJ'
 */
-Obj LEN_POSOBJ_Handler (
+Obj FuncLEN_POSOBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -1475,9 +1475,9 @@ void SetTypeDatObj( Obj obj, Obj type)
 
 /*****************************************************************************
 **
-*F  IS_DATOBJ_Handler( <self>, <obj> ) . . . . . . . . handler for 'IS_DATOBJ'
+*F  FuncIS_DATOBJ( <self>, <obj> ) . . . . . . . . handler for 'IS_DATOBJ'
 */
-Obj             IS_DATOBJ_Handler (
+Obj FuncIS_DATOBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -1487,9 +1487,9 @@ Obj             IS_DATOBJ_Handler (
 
 /****************************************************************************
 **
-*F  SET_TYPE_DATOBJ_Handler( <self>, <obj>, <type> ) . . .  'SET_TYPE_DATOBJ'
+*F  FuncSET_TYPE_DATOBJ( <self>, <obj>, <type> ) . . .  'SET_TYPE_DATOBJ'
 */
-Obj SET_TYPE_DATOBJ_Handler (
+Obj FuncSET_TYPE_DATOBJ (
     Obj                 self,
     Obj                 obj,
     Obj                 type )
@@ -1509,11 +1509,11 @@ Obj SET_TYPE_DATOBJ_Handler (
 
 /****************************************************************************
 **
-*F  IsIdenticalHandler( <self>, <obj1>, <obj2> )  . . . . .  handler for '=='
+*F  FuncIS_IDENTICAL_OBJ( <self>, <obj1>, <obj2> )  . . . . .  handler for '=='
 **
-**  'IsIdenticalHandler' implements 'IsIdentical'
+**  'FuncIS_IDENTICAL_OBJ' implements 'IsIdentical'
 */
-Obj IsIdenticalHandler (
+Obj FuncIS_IDENTICAL_OBJ (
     Obj                 self,
     Obj                 obj1,
     Obj                 obj2 )
@@ -1931,48 +1931,20 @@ static StructGVarOper GVarOpers [] = {
 */
 static StructGVarFunc GVarFuncs [] = {
 
-    { "FAMILY_TYPE", 1, "type",
-      FamilyTypeHandler, "src/objects.c:FAMILY_TYPE" },
-
-    { "TYPE_OBJ", 1, "obj",
-      TypeObjHandler, "src/objects.c:TYPE_OBJ" },
-
-    { "SET_TYPE_OBJ", 2, "obj, type",
-      SetTypeObjHandler, "src/objects.c:SET_TYPE_OBJ" },
-
-    { "FAMILY_OBJ", 1, "obj",
-      FamilyObjHandler, "src/objects.c:FAMILY_OBJ" },
-
-    { "IMMUTABLE_COPY_OBJ", 1, "obj", 
-      ImmutableCopyObjHandler, "src/objects.c:IMMUTABLE_COPY_OBJ" },
-
-    { "DEEP_COPY_OBJ", 1, "obj",
-          MutableCopyObjHandler, "src/objects.c:DEEP_COPY_OBJ" },
-
-    { "IS_IDENTICAL_OBJ", 2, "obj1, obj2", 
-      IsIdenticalHandler, "src/objects.c:IS_IDENTICAL_OBJ" },
-
-    { "IS_COMOBJ", 1, "obj",
-      IS_COMOBJ_Handler, "src/objects.c:IS_COMOBJ" },
-
-    { "SET_TYPE_COMOBJ", 2, "obj, type",
-      SET_TYPE_COMOBJ_Handler, "src/objects.c:SET_TYPE_COMOBJ" },
-
-    { "IS_POSOBJ", 1, "obj",
-      IS_POSOBJ_Handler, "src/objects.c:IS_POSOBJ" },
-    
-    { "SET_TYPE_POSOBJ", 2, "obj, type",
-      SET_TYPE_POSOBJ_Handler, "src/objects.c:SET_TYPE_POSOBJ" },
-    
-    { "LEN_POSOBJ", 1, "obj",
-      LEN_POSOBJ_Handler, "src/objects.c:LEN_POSOBJ" },
-    
-    { "IS_DATOBJ", 1, "obj",
-      IS_DATOBJ_Handler, "src/objects.c:IS_DATOBJ" },
-    
-    { "SET_TYPE_DATOBJ", 2, "obj, type",
-      SET_TYPE_DATOBJ_Handler, "src/objects.c:SET_TYPE_DATOBJ" },
-
+    GVAR_FUNC(FAMILY_TYPE, 1, "type"),
+    GVAR_FUNC(TYPE_OBJ, 1, "obj"),
+    GVAR_FUNC(SET_TYPE_OBJ, 2, "obj, type"),
+    GVAR_FUNC(FAMILY_OBJ, 1, "obj"),
+    GVAR_FUNC(IMMUTABLE_COPY_OBJ, 1, "obj"),
+    GVAR_FUNC(DEEP_COPY_OBJ, 1, "obj"),
+    GVAR_FUNC(IS_IDENTICAL_OBJ, 2, "obj1, obj2"),
+    GVAR_FUNC(IS_COMOBJ, 1, "obj"),
+    GVAR_FUNC(SET_TYPE_COMOBJ, 2, "obj, type"),
+    GVAR_FUNC(IS_POSOBJ, 1, "obj"),
+    GVAR_FUNC(SET_TYPE_POSOBJ, 2, "obj, type"),
+    GVAR_FUNC(LEN_POSOBJ, 1, "obj"),
+    GVAR_FUNC(IS_DATOBJ, 1, "obj"),
+    GVAR_FUNC(SET_TYPE_DATOBJ, 2, "obj, type"),
     GVAR_FUNC(CLONE_OBJ, 2, "dst, src"),
     GVAR_FUNC(SWITCH_OBJ, 2, "obj1, obj2"),
     GVAR_FUNC(FORCE_SWITCH_OBJ, 2, "obj1, obj2"),

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -2662,7 +2662,7 @@ Obj OnePPerm(Obj f)
 }
 
 // print a partial perm in disjoint cycle and chain notation
-Obj PrintPPerm2(Obj self, Obj f)
+Obj FuncPrintPPerm2(Obj self, Obj f)
 {
     UInt    i, j, n, rank, k, deg;
     UInt4 * ptseen;
@@ -2720,7 +2720,7 @@ Obj PrintPPerm2(Obj self, Obj f)
     return 0L;
 }
 
-Obj PrintPPerm4(Obj self, Obj f)
+Obj FuncPrintPPerm4(Obj self, Obj f)
 {
     UInt   i, j, n, rank, k, deg;
     UInt4 *ptseen, *ptf4;
@@ -6429,7 +6429,7 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
     return res;
 }
 
-Obj FuncOnPosIntSetsPPerm(Obj self, Obj set, Obj f)
+Obj FuncOnPosIntSetsPartialPerm(Obj self, Obj set, Obj f)
 {
     UInt2 * ptf2;
     UInt4 * ptf4;
@@ -6645,13 +6645,9 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(ShortLexLeqPartialPerm, 2, "f, g"),
     GVAR_FUNC(HAS_DOM_PPERM, 1, "f"),
     GVAR_FUNC(HAS_IMG_PPERM, 1, "f"),
-    { "OnPosIntSetsPartialPerm", 2, "set, f", FuncOnPosIntSetsPPerm,
-      "src/pperm.c:FuncOnPosIntSetsPPerm" },
-
-    { "PrintPPerm2", 1, "f", PrintPPerm2, "src/pperm.c:PrintPPerm2" },
-
-    { "PrintPPerm4", 1, "f", PrintPPerm4, "src/pperm.c:PrintPPerm4" },
-
+    GVAR_FUNC(OnPosIntSetsPartialPerm, 2, "set, f"),
+    GVAR_FUNC(PrintPPerm2, 1, "f"),
+    GVAR_FUNC(PrintPPerm4, 1, "f"),
     { 0, 0, 0, 0, 0 }
 
 };

--- a/src/profile.c
+++ b/src/profile.c
@@ -629,7 +629,7 @@ Obj FuncDEACTIVATE_PROFILING (
   return True;
 }
 
-Obj FuncIS_PROFILE_ACTIVE (
+Obj FuncIsLineByLineProfileActive (
     Obj self)
 {
   if(profileState_Active) {
@@ -774,8 +774,7 @@ static StructGVarFunc GVarFuncs [] = {
 
     GVAR_FUNC(ACTIVATE_PROFILING, 4, "string,boolean,boolean,integer"),
     GVAR_FUNC(DEACTIVATE_PROFILING, 0, ""),
-    { "IsLineByLineProfileActive", 0, "",
-      FuncIS_PROFILE_ACTIVE, "src/profile.c:IsLineByLineProfileActive" },
+    GVAR_FUNC(IsLineByLineProfileActive, 0, ""),
     GVAR_FUNC(ACTIVATE_COLOR_PROFILING, 1, "bool"),
     { 0, 0, 0, 0, 0 }
 };

--- a/src/rational.c
+++ b/src/rational.c
@@ -818,15 +818,15 @@ Obj             IsRatHandler (
 
 /****************************************************************************
 **
-*F  FuncNumeratorRat(<self>,<rat>)  . . . . . . . . . numerator of a rational
+*F  FuncNUMERATOR_RAT(<self>,<rat>)  . . . . . . . . . numerator of a rational
 **
-**  'FuncNumeratorRat' implements the internal function 'NumeratorRat'.
+**  'FuncNUMERATOR_RAT' implements the internal function 'NumeratorRat'.
 **
 **  'NumeratorRat( <rat> )'
 **
 **  'NumeratorRat' returns the numerator of the rational <rat>.
 */
-Obj             FuncNumeratorRat (
+Obj             FuncNUMERATOR_RAT (
     Obj                 self,
     Obj                 rat )
 {
@@ -851,15 +851,15 @@ Obj             FuncNumeratorRat (
 
 /****************************************************************************
 **
-*F  FuncDenominatorRat(<self>,<rat>)  . . . . . . . denominator of a rational
+*F  FuncDENOMINATOR_RAT(<self>,<rat>)  . . . . . . . denominator of a rational
 **
-**  'FuncDenominatorRat' implements the internal function 'DenominatorRat'.
+**  'FuncDENOMINATOR_RAT' implements the internal function 'DenominatorRat'.
 **
 **  'DenominatorRat( <rat> )'
 **
 **  'DenominatorRat' returns the denominator of the rational <rat>.
 */
-Obj             FuncDenominatorRat (
+Obj             FuncDENOMINATOR_RAT (
     Obj                 self,
     Obj                 rat )
 {
@@ -930,12 +930,8 @@ static StructGVarFilt GVarFilts [] = {
 */
 static StructGVarFunc GVarFuncs [] = {
 
-    { "NUMERATOR_RAT", 1, "rat",
-      FuncNumeratorRat, "src/rational.c:NUMERATOR_RAT" },
-
-    { "DENOMINATOR_RAT", 1, "rat",
-      FuncDenominatorRat, "src/rational.c:DENOMINATOR_RAT" },
-
+    GVAR_FUNC(NUMERATOR_RAT, 1, "rat"),
+    GVAR_FUNC(DENOMINATOR_RAT, 1, "rat"),
     GVAR_FUNC(ABS_RAT, 1, "rat"),
     GVAR_FUNC(SIGN_RAT, 1, "rat"),
     { 0, 0, 0, 0, 0 }

--- a/src/records.c
+++ b/src/records.c
@@ -271,16 +271,16 @@ UInt            RNamObj (
 
 /****************************************************************************
 **
-*F  RNamObjHandler(<self>,<obj>)  . . . .  convert an object to a record name
+*F  FuncRNamObj(<self>,<obj>)  . . . .  convert an object to a record name
 **
-**  'RNamObjHandler' implements the internal function 'RNamObj'.
+**  'FuncRNamObj' implements the internal function 'RNamObj'.
 **
 **  'RNamObj( <obj> )'
 **
 **  'RNamObj' returns the record name  corresponding  to  the  object  <obj>,
 **  which currently must be a string or an integer.
 */
-Obj             RNamObjHandler (
+Obj             FuncRNamObj (
     Obj                 self,
     Obj                 obj )
 {
@@ -290,9 +290,9 @@ Obj             RNamObjHandler (
 
 /****************************************************************************
 **
-*F  NameRNamHandler(<self>,<rnam>)  . . . . convert a record name to a string
+*F  FuncNameRNam(<self>,<rnam>)  . . . . convert a record name to a string
 **
-**  'NameRNamHandler' implements the internal function 'NameRName'.
+**  'FuncNameRNam' implements the internal function 'NameRName'.
 **
 **  'NameRName( <rnam> )'
 **
@@ -300,7 +300,7 @@ Obj             RNamObjHandler (
 */
 Obj             NameRNamFunc;
 
-Obj             NameRNamHandler (
+Obj             FuncNameRNam (
     Obj                 self,
     Obj                 rnam )
 {
@@ -666,12 +666,8 @@ static StructGVarOper GVarOpers [] = {
 */
 static StructGVarFunc GVarFuncs [] = {
 
-    { "RNamObj", 1, "obj",
-      RNamObjHandler, "src/records.c:RNamObj" },
-
-    { "NameRNam", 1, "rnam",
-      NameRNamHandler, "src/records.c:NameRNam" },
-
+    GVAR_FUNC(RNamObj, 1, "obj"),
+    GVAR_FUNC(NameRNam, 1, "rnam"),
     GVAR_FUNC(ALL_RNAMES, 0, ""),
     { 0, 0, 0, 0, 0 }
 

--- a/src/sctable.c
+++ b/src/sctable.c
@@ -74,7 +74,7 @@
 */
 Obj SCTableEntryFunc;
 
-Obj SCTableEntryHandler (
+Obj FuncSC_TABLE_ENTRY (
     Obj                 self,
     Obj                 table,
     Obj                 i,
@@ -94,7 +94,7 @@ Obj SCTableEntryHandler (
             "SCTableEntry: <table> must be a small list (not a %s)",
             (Int)TNAM_OBJ(table), 0L,
             "you can replace <table> via 'return <table>;'" );
-        return SCTableEntryHandler( self, table, i, j, k );
+        return FuncSC_TABLE_ENTRY( self, table, i, j, k );
     }
     dim = LEN_LIST(table) - 2;
     if ( dim <= 0 ) {
@@ -102,7 +102,7 @@ Obj SCTableEntryHandler (
             "SCTableEntry: <table> must be a list with at least 3 elements",
             0L, 0L,
             "you can replace <table> via 'return <table>;'" );
-        return SCTableEntryHandler( self, table, i, j, k );
+        return FuncSC_TABLE_ENTRY( self, table, i, j, k );
     }
 
     /* check <i>                                                           */
@@ -111,7 +111,7 @@ Obj SCTableEntryHandler (
             "SCTableEntry: <i> must be an integer between 0 and %d",
             dim, 0L,
             "you can replace <i> via 'return <i>;'" );
-        return SCTableEntryHandler( self, table, i, j, k );
+        return FuncSC_TABLE_ENTRY( self, table, i, j, k );
     }
 
     /* get and check the relevant row                                      */
@@ -121,7 +121,7 @@ Obj SCTableEntryHandler (
             "SCTableEntry: <table>[%d] must be a list with %d elements",
             INT_INTOBJ(i), dim,
             "you can replace <table> via 'return <table>;'" );
-        return SCTableEntryHandler( self, table, i, j, k );
+        return FuncSC_TABLE_ENTRY( self, table, i, j, k );
 
     }
 
@@ -131,7 +131,7 @@ Obj SCTableEntryHandler (
             "SCTableEntry: <j> must be an integer between 0 and %d",
             dim, 0L,
             "you can replace <j> via 'return <j>;'" );
-        return SCTableEntryHandler( self, table, i, j, k );
+        return FuncSC_TABLE_ENTRY( self, table, i, j, k );
     }
 
     /* get and check the basis and coefficients list                       */
@@ -141,7 +141,7 @@ Obj SCTableEntryHandler (
             "SCTableEntry: <table>[%d][%d] must be a basis/coeffs list",
             0L, 0L,
             "you can replace <table> via 'return <table>;'" );
-        return SCTableEntryHandler( self, table, i, j, k );
+        return FuncSC_TABLE_ENTRY( self, table, i, j, k );
     }
 
     /* get and check the basis list                                        */
@@ -151,7 +151,7 @@ Obj SCTableEntryHandler (
             "SCTableEntry: <table>[%d][%d][1] must be a basis list",
             0L, 0L,
             "you can replace <table> via 'return <table>;'" );
-        return SCTableEntryHandler( self, table, i, j, k );
+        return FuncSC_TABLE_ENTRY( self, table, i, j, k );
     }
 
     /* get and check the coeffs list                                       */
@@ -161,7 +161,7 @@ Obj SCTableEntryHandler (
             "SCTableEntry: <table>[%d][%d][2] must be a coeffs list",
             0L, 0L,
             "you can replace <table> via 'return <table>;'" );
-        return SCTableEntryHandler( self, table, i, j, k );
+        return FuncSC_TABLE_ENTRY( self, table, i, j, k );
     }
 
     /* check that they have the same length                                */
@@ -171,7 +171,7 @@ Obj SCTableEntryHandler (
             "SCTableEntry: <table>[%d][%d][1], ~[2] must have equal length",
             0L, 0L,
             "you can replace <table> via 'return <table>;'" );
-        return SCTableEntryHandler( self, table, i, j, k );
+        return FuncSC_TABLE_ENTRY( self, table, i, j, k );
     }
 
     /* check <k>                                                           */
@@ -180,7 +180,7 @@ Obj SCTableEntryHandler (
             "SCTableEntry: <k> must be an integer between 0 and %d",
             dim, 0L,
             "you can replace <k> via 'return <k>;'" );
-        return SCTableEntryHandler( self, table, i, j, k );
+        return FuncSC_TABLE_ENTRY( self, table, i, j, k );
     }
 
     /* look for the (i,j,k) entry                                          */
@@ -241,7 +241,7 @@ void SCTableProdAdd (
 
 Obj SCTableProductFunc;
 
-Obj SCTableProductHandler (
+Obj FuncSC_TABLE_PRODUCT (
     Obj                 self,
     Obj                 table,
     Obj                 list1,
@@ -262,7 +262,7 @@ Obj SCTableProductHandler (
             "SCTableProduct: <table> must be a list (not a %s)",
             (Int)TNAM_OBJ(table), 0L,
             "you can replace <table> via 'return <table>;'" );
-        return SCTableProductHandler( self, table, list1, list2 );
+        return FuncSC_TABLE_PRODUCT( self, table, list1, list2 );
     }
     dim = LEN_LIST(table) - 2;
     if ( dim <= 0 ) {
@@ -270,7 +270,7 @@ Obj SCTableProductHandler (
             "SCTableProduct: <table> must be a list with at least 3 elements",
             0L, 0L,
             "you can replace <table> via 'return <table>;'" );
-        return SCTableProductHandler( self, table, list1, list2 );
+        return FuncSC_TABLE_PRODUCT( self, table, list1, list2 );
     }
     zero = ELM_LIST( table, dim+2 );
     if ( ! IS_SMALL_LIST(list1) || LEN_LIST(list1) != dim ) {
@@ -278,14 +278,14 @@ Obj SCTableProductHandler (
             "SCTableProduct: <list1> must be a list with %d elements",
             dim, 0L,
             "you can replace <list1> via 'return <list1>;'" );
-        return SCTableProductHandler( self, table, list1, list2 );
+        return FuncSC_TABLE_PRODUCT( self, table, list1, list2 );
     }
     if ( ! IS_SMALL_LIST(list2) || LEN_LIST(list2) != dim ) {
         list2 = ErrorReturnObj(
             "SCTableProduct: <list2> must be a list with %d elements",
             dim, 0L,
             "you can replace <list2> via 'return <list2>;'" );
-        return SCTableProductHandler( self, table, list1, list2 );
+        return FuncSC_TABLE_PRODUCT( self, table, list1, list2 );
     }
 
     /* make the result list                                                */
@@ -375,12 +375,8 @@ Obj SCTableProductHandler (
 */
 static StructGVarFunc GVarFuncs [] = {
 
-    { "SC_TABLE_ENTRY", 4, "table, i, j, k",
-      SCTableEntryHandler, "src/sctable.c:SC_TABLE_ENTRY" },
-
-    { "SC_TABLE_PRODUCT", 3, "table, list1, list2",
-      SCTableProductHandler, "src/sctable.c:SC_TABLE_PRODUCT" },
-
+    GVAR_FUNC(SC_TABLE_ENTRY, 4, "table, i, j, k"),
+    GVAR_FUNC(SC_TABLE_PRODUCT, 3, "table, list1, list2"),
     { 0, 0, 0, 0, 0 }
 
 };

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -662,13 +662,13 @@ Obj             ProdVecFFEVecFFE (
 
 /****************************************************************************
 **
-*F  FuncAddRowVectorVecFFEsMult( <self>, <vecL>, <vecR>, <mult> )
+*F  FuncADD_ROWVECTOR_VECFFES_3( <self>, <vecL>, <vecR>, <mult> )
 **
 */
 
 static Obj AddRowVectorOp;   /* BH changed to static */
 
-Obj FuncAddRowVectorVecFFEsMult( Obj self, Obj vecL, Obj vecR, Obj mult )
+Obj FuncADD_ROWVECTOR_VECFFES_3( Obj self, Obj vecL, Obj vecR, Obj mult )
 {
     Obj *ptrL;
     Obj *ptrR;
@@ -768,13 +768,13 @@ Obj FuncAddRowVectorVecFFEsMult( Obj self, Obj vecL, Obj vecR, Obj mult )
 }
 /****************************************************************************
 **
-*F  FuncMultRowVectorVecFFEs( <self>, <vec>, <mult> )
+*F  FuncMULT_ROWVECTOR_VECFFES( <self>, <vec>, <mult> )
 **
 */
 
 static Obj MultRowVectorOp;   /* BH changed to static */
 
-Obj FuncMultRowVectorVecFFEs( Obj self, Obj vec, Obj mult )
+Obj FuncMULT_ROWVECTOR_VECFFES( Obj self, Obj vec, Obj mult )
 {
     Obj *ptr;
     FFV  valM;
@@ -845,10 +845,10 @@ Obj FuncMultRowVectorVecFFEs( Obj self, Obj vec, Obj mult )
 
 /****************************************************************************
 **
-*F  FuncAddRowVectorVecFFEs( <self>, <vecL>, <vecR> )
+*F  FuncADD_ROWVECTOR_VECFFES_2( <self>, <vecL>, <vecR> )
 **
 */
-Obj FuncAddRowVectorVecFFEs( Obj self, Obj vecL, Obj vecR )
+Obj FuncADD_ROWVECTOR_VECFFES_2( Obj self, Obj vecL, Obj vecR )
 {
     Obj *ptrL;
     Obj *ptrR;
@@ -1119,15 +1119,9 @@ Obj FuncSMALLEST_FIELD_VECFFE( Obj self, Obj vec)
 */
 static StructGVarFunc GVarFuncs [] = {
 
-  { "ADD_ROWVECTOR_VECFFES_3", 3, "vecl, vecr, mult",
-    FuncAddRowVectorVecFFEsMult, "src/vecffe.c: ADD_ROWVECTOR_VECFFES_3" },
-
-  { "ADD_ROWVECTOR_VECFFES_2", 2, "vecl, vecr",
-    FuncAddRowVectorVecFFEs, "src/vecffe.c: ADD_ROWVECTOR_VECFFES_2" },
-
-  { "MULT_ROWVECTOR_VECFFES", 2, "vec, mult",
-    FuncMultRowVectorVecFFEs, "src/vecffe.c: MULT_ROWVECTOR_VECFFES" },
-  
+  GVAR_FUNC(ADD_ROWVECTOR_VECFFES_3, 3, "vecl, vecr, mult"),
+  GVAR_FUNC(ADD_ROWVECTOR_VECFFES_2, 2, "vecl, vecr"),
+  GVAR_FUNC(MULT_ROWVECTOR_VECFFES, 2, "vec, mult"),
   GVAR_FUNC(IS_VECFFE, 1, "vec"),
   GVAR_FUNC(COMMON_FIELD_VECFFE, 1, "vec"),
   GVAR_FUNC(SMALLEST_FIELD_VECFFE, 1, "vec"),

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1611,7 +1611,7 @@ void ConvGF2Vec (
     len   = LEN_PLIST(list);
 
     /* We may have to resize the bag now because a length 1
-       plain list is shorter than a length 1 VECGF2 */
+       plain list is shorter than a length 1 GF2VEC */
     if (SIZE_PLEN_GF2VEC(len) > SIZE_OBJ(list))
       ResizeBag( list, SIZE_PLEN_GF2VEC(len) );
 
@@ -2978,11 +2978,11 @@ Obj FuncCOPY_SECTION_GF2VECS(Obj self, Obj src, Obj dest, Obj from, Obj to, Obj 
 
 /****************************************************************************
 **
-*F  FuncAPPEND_VECGF2( <self>, <vecl>, <vecr> )
+*F  FuncAPPEND_GF2VEC( <self>, <vecl>, <vecr> )
 **
 */
 
-Obj FuncAPPEND_VECGF2( Obj self, Obj vecl, Obj vecr )
+Obj FuncAPPEND_GF2VEC( Obj self, Obj vecl, Obj vecr )
 {
   UInt lenl, lenr;
   lenl = LEN_GF2VEC(vecl);
@@ -3001,11 +3001,11 @@ Obj FuncAPPEND_VECGF2( Obj self, Obj vecl, Obj vecr )
 
 /****************************************************************************
 **
-*F  FuncSHALLOWCOPY_VECGF2( <self>, <vec> )
+*F  FuncSHALLOWCOPY_GF2VEC( <self>, <vec> )
 **
 */
 
-Obj FuncSHALLOWCOPY_VECGF2( Obj self, Obj vec)
+Obj FuncSHALLOWCOPY_GF2VEC( Obj self, Obj vec)
 {
   return ShallowCopyVecGF2(vec);
 }
@@ -3205,10 +3205,10 @@ Obj FuncTRANSPOSED_GF2MAT( Obj self, Obj mat)
 
 /****************************************************************************
 **
-*F  FuncNUMBER_VECGF2( <self>, <vect> )
+*F  FuncNUMBER_GF2VEC( <self>, <vect> )
 **
 */
-Obj FuncNUMBER_VECGF2( Obj self, Obj vec )
+Obj FuncNUMBER_GF2VEC( Obj self, Obj vec )
 {
   UInt len,nd,i;
   UInt head,a;
@@ -4726,15 +4726,9 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(POSITION_NONZERO_GF2VEC, 2, "gf2vec, zero"),
     GVAR_FUNC(POSITION_NONZERO_GF2VEC3, 3, "gf2vec, zero, from"),
     GVAR_FUNC(MULT_ROW_VECTOR_GF2VECS_2, 2, "gf2vecl, mul"),
-    { "APPEND_GF2VEC", 2, "gf2vecl, gf2vecr",
-      FuncAPPEND_VECGF2, "src/vecgf2.c:APPEND_GF2VEC" },
-
-    { "SHALLOWCOPY_GF2VEC", 1, "gf2vec",
-      FuncSHALLOWCOPY_VECGF2, "src/vecgf2.c:SHALLOWCOPY_GF2VEC" },
-
-    { "NUMBER_GF2VEC", 1, "gf2vec",
-      FuncNUMBER_VECGF2, "src/vecgf2.c:NUMBER_GF2VEC" },
-
+    GVAR_FUNC(APPEND_GF2VEC, 2, "gf2vecl, gf2vecr"),
+    GVAR_FUNC(SHALLOWCOPY_GF2VEC, 1, "gf2vec"),
+    GVAR_FUNC(NUMBER_GF2VEC, 1, "gf2vec"),
     GVAR_FUNC(TRANSPOSED_GF2MAT, 1, "gf2mat"),
     GVAR_FUNC(DIST_GF2VEC_GF2VEC, 2, "gf2vec, gf2vec"),
     { "DIST_VEC_CLOS_VEC", 3, "list, gf2vec, list",

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1063,11 +1063,11 @@ Obj ProdGF2MatGF2MatAdvanced( Obj ml, Obj mr, UInt greasesize , UInt blocksize)
 
 /****************************************************************************
 **
-*F  FuncProdGF2VecAnyMat( <self>, <v>, <m>) . . . method to handle vector*plain list
-**                                    of GF2Vectors reasonably efficiently
+*F  FuncPROD_GF2VEC_ANYMAT( <self>, <v>, <m>)
 **
+**  method to handle vector*plain list of GF2Vectors reasonably efficiently.
 */
-Obj FuncProdGF2VecAnyMat ( Obj self, Obj vec, Obj mat )
+Obj FuncPROD_GF2VEC_ANYMAT(Obj self, Obj vec, Obj mat)
 {
   Obj res;
   UInt len;
@@ -3475,7 +3475,7 @@ Int DistVecClosVec(
   return chg;
 }
 
-Obj FuncDistVecClosVec(
+Obj FuncDIST_VEC_CLOS_VEC(
   Obj		self,
   Obj		veclis, /* pointers to matrix vectors and their multiples */
   Obj		vec,    /* vector we compute distance to */
@@ -3591,7 +3591,7 @@ UInt AClosVec(
 
 
 
-Obj FuncAClosVec(
+Obj FuncA_CLOS_VEC(
   Obj		self,
   Obj		veclis, /* pointers to matrix vectors and their multiples */
   Obj		vec,    /* vector we compute distance to */
@@ -3622,7 +3622,7 @@ Obj FuncAClosVec(
   return best;
 }
 
-Obj FuncAClosVecCoords(
+Obj FuncA_CLOS_VEC_COORDS(
   Obj		self,
   Obj		veclis, /* pointers to matrix vectors and their multiples */
   Obj		vec,    /* vector we compute distance to */
@@ -4709,9 +4709,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(ZERO_GF2VEC_2, 1, "len"),
     GVAR_FUNC(INV_GF2MAT_MUTABLE, 1, "gf2mat"),
     GVAR_FUNC(INV_GF2MAT_SAME_MUTABILITY, 1, "gf2mat"),
-    { "INV_GF2MAT", 1, "gf2mat",
-      FuncINV_GF2MAT_IMMUTABLE, "src/vecgf2.c:INV_GF2MAT_IMMUTABLE" },
-
+    GVAR_FUNC(INV_GF2MAT_IMMUTABLE, 1, "gf2mat"),
     GVAR_FUNC(INV_PLIST_GF2VECS_DESTRUCTIVE, 1, "list"),
     GVAR_FUNC(SUM_GF2VEC_GF2VEC, 2, "gf2vec, gf2vec"),
     GVAR_FUNC(PROD_GF2VEC_GF2VEC, 2, "gf2vec, gf2vec"),
@@ -4731,21 +4729,13 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(NUMBER_GF2VEC, 1, "gf2vec"),
     GVAR_FUNC(TRANSPOSED_GF2MAT, 1, "gf2mat"),
     GVAR_FUNC(DIST_GF2VEC_GF2VEC, 2, "gf2vec, gf2vec"),
-    { "DIST_VEC_CLOS_VEC", 3, "list, gf2vec, list",
-      FuncDistVecClosVec, "src/vecgf2.c:DIST_VEC_CLOS_VEC" },
-
+    GVAR_FUNC(DIST_VEC_CLOS_VEC, 3, "list, gf2vec, list"),
     GVAR_FUNC(SUM_GF2MAT_GF2MAT, 2, "matl, matr"),
-    { "A_CLOS_VEC", 4, "list, gf2vec, int, int",
-      FuncAClosVec, "src/vecgf2.c:A_CLOS_VEC" },
-
-    { "A_CLOS_VEC_COORDS", 4, "list, gf2vec, int, int",
-      FuncAClosVecCoords, "src/vecgf2.c:A_CLOS_VEC_COORDS" },
-
+    GVAR_FUNC(A_CLOS_VEC, 4, "list, gf2vec, int, int"),
+    GVAR_FUNC(A_CLOS_VEC_COORDS, 4, "list, gf2vec, int, int"),
     GVAR_FUNC(COSET_LEADERS_INNER_GF2, 4, "veclis, weight, tofind, leaders"),
     GVAR_FUNC(CONV_GF2MAT, 1, "list"),
-    { "PROD_GF2VEC_ANYMAT", 2, "vec, mat",
-      FuncProdGF2VecAnyMat, "src/vecgf2.c:PROD_GF2VEC_ANYMAT" },
-    
+    GVAR_FUNC(PROD_GF2VEC_ANYMAT, 2, "vec, mat"),
     GVAR_FUNC(RIGHTMOST_NONZERO_GF2VEC, 1, "vec"),
     GVAR_FUNC(RESIZE_GF2VEC, 2, "vec, newlen"),
     GVAR_FUNC(SHIFT_LEFT_GF2VEC, 2, "vec, amount"),


### PR DESCRIPTION
Note that this PR only does this for `GVarFuncs`. For filters/operations/attributes, it actually does make some sense to use a different naming convention. This should be discussed. In any case, I did not touch them in this PR.