### PR TITLE
Reduce kernel #includes, split some headers, assorted cleanup

### DIFF
--- a/src/ariths.c
+++ b/src/ariths.c
@@ -36,7 +36,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 
 

--- a/src/ariths.c
+++ b/src/ariths.c
@@ -35,7 +35,6 @@
 #include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 
 

--- a/src/ariths.c
+++ b/src/ariths.c
@@ -11,7 +11,6 @@
 **  This file contains the functions of the  arithmetic  operations  package.
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/ariths.c
+++ b/src/ariths.c
@@ -31,7 +31,6 @@
 #include <src/precord.h>                /* plain records */
 
 #include <src/lists.h>                  /* generic lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
 

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -1,5 +1,4 @@
 #include <src/system.h>
-#include <src/gapstate.h>
 
 #if defined(HAVE_BACKTRACE) && defined(PRINT_BACKTRACE)
 #include <execinfo.h>

--- a/src/blister.c
+++ b/src/blister.c
@@ -100,6 +100,7 @@
 #include <src/saveload.h>               /* saving and loading */
 
 #include <src/code.h>                   /* coder */
+#include <src/hpc/guards.h>
 
 #include <src/gaputils.h>
 

--- a/src/blister.c
+++ b/src/blister.c
@@ -94,7 +94,6 @@
 #include <src/set.h>                    /* plain sets */
 #include <src/blister.h>                /* boolean lists */
 #include <src/range.h>                  /* ranges */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/saveload.h>               /* saving and loading */
 

--- a/src/blister.c
+++ b/src/blister.c
@@ -100,7 +100,6 @@
 #include <src/saveload.h>               /* saving and loading */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 #include <src/gaputils.h>
 

--- a/src/blister.c
+++ b/src/blister.c
@@ -101,7 +101,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/gaputils.h>
 

--- a/src/blister.c
+++ b/src/blister.c
@@ -70,7 +70,6 @@
 *N  1992/12/16 martin should have 'LtBlist'
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -39,7 +39,6 @@
 #include <src/code.h>                   /* coder */
 #include <src/hpc/misc.h>
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 #ifdef TRACK_CREATOR
 /* Need CURR_FUNC and NAME_FUNC() */
 #include <src/calls.h>                  /* calls */

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -39,6 +39,7 @@
 #include <src/code.h>                   /* coder */
 #include <src/hpc/misc.h>
 #include <src/hpc/thread.h>             /* threads */
+#include <src/hpc/guards.h>
 #ifdef TRACK_CREATOR
 /* Need CURR_FUNC and NAME_FUNC() */
 #include <src/calls.h>                  /* calls */

--- a/src/bool.c
+++ b/src/bool.c
@@ -39,7 +39,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 
 /****************************************************************************

--- a/src/bool.c
+++ b/src/bool.c
@@ -38,7 +38,6 @@
 #include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 
 /****************************************************************************

--- a/src/bool.c
+++ b/src/bool.c
@@ -14,7 +14,6 @@
 **  True and Fail.
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/bool.c
+++ b/src/bool.c
@@ -34,7 +34,6 @@
 #include <src/precord.h>                /* plain records */
 
 #include <src/lists.h>                  /* generic lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
 

--- a/src/calls.c
+++ b/src/calls.c
@@ -65,7 +65,6 @@
 #include <src/stats.h>                  /* statements */
 
 #include <src/saveload.h>               /* saving and loading */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/vars.h>                   /* variables */
 

--- a/src/calls.c
+++ b/src/calls.c
@@ -34,7 +34,6 @@
 **  ...what the other components are...
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 

--- a/src/calls.c
+++ b/src/calls.c
@@ -69,6 +69,22 @@
 
 #include <assert.h>
 
+
+void SET_NAME_FUNC(Obj func, Obj name)
+{
+    GAP_ASSERT(name == 0 || IS_STRING_REP(name));
+    FUNC_HEADER(func)->name = name;
+}
+
+Char * NAMI_FUNC(Obj func, Int i)
+{
+    return CSTR_STRING(ELM_LIST(NAMS_FUNC(func),i));
+}
+
+
+Obj FuncIsKernelFunction(Obj self, Obj func);
+
+
 /****************************************************************************
 **
 *F * * * * wrapper for functions with variable number of arguments  * * * * *
@@ -1863,6 +1879,14 @@ Obj FuncUNPROFILE_FUNC(
     return (Obj)0;
 }
 
+/****************************************************************************
+*
+*F  FuncIsKernelFunction( <self>, <func> ) . . . . . . . .  print a function
+**
+**  'FuncIsKernelFunction' returns Fail if <func> is not a function, True if
+**  <func> is a function, and is installed as a kernel function, and False
+**  otherwise.
+*/
 Obj FuncIsKernelFunction(Obj self, Obj func) {
   if (!IS_FUNC(func))
     return Fail;

--- a/src/calls.h
+++ b/src/calls.h
@@ -47,7 +47,6 @@
 
 #include <src/gap.h>
 #include <src/gaputils.h>
-#include <src/stringobj.h>
 #include <src/lists.h>
 
 
@@ -157,10 +156,7 @@ static inline Obj NAMS_FUNC(Obj func)
     return FUNC_HEADER(func)->namesOfLocals;
 }
 
-static inline Char * NAMI_FUNC(Obj func, Int i)
-{
-    return CSTR_STRING(ELM_LIST(NAMS_FUNC(func),i));
-}
+extern Char * NAMI_FUNC(Obj func, Int i);
 
 static inline Obj PROF_FUNC(Obj func)
 {
@@ -202,11 +198,7 @@ static inline void SET_HDLR_FUNC(Obj func, Int i, ObjFunc hdlr)
     header->handlers[i] = hdlr;
 }
 
-static inline void SET_NAME_FUNC(Obj func, Obj name)
-{
-    GAP_ASSERT(name == 0 || IS_STRING_REP(name));
-    FUNC_HEADER(func)->name = name;
-}
+extern void SET_NAME_FUNC(Obj func, Obj name);
 
 static inline void SET_NARG_FUNC(Obj func, Int nargs)
 {
@@ -510,18 +502,6 @@ extern Obj ArgStringToList(const Char *nams_c);
 extern void PrintFunction (
     Obj                 func );
 
-
-/****************************************************************************
-*
-*F  FuncIsKernelFunction( <self>, <func> ) . . . . . . . .  print a function
-**
-**  'FuncIsKernelFunction' returns Fail if <func> is not a function, True if
-**  <func> is a function, and is installed as a kernel function, and False
-**  otherwise.
-*/
-extern Obj FuncIsKernelFunction(
-                        Obj self,
-                        Obj func);
 
 /****************************************************************************
 **

--- a/src/code.c
+++ b/src/code.c
@@ -49,7 +49,6 @@
 #include <src/read.h>                   /* to access stack of for loop globals */
 #include <src/gvars.h>
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 #include <src/hpc/aobjects.h>           /* atomic objects */
 
 #include <src/vars.h>                   /* variables */

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -55,7 +55,6 @@ extern "C" {
 #include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/objfgelm.h>               /* objects of free groups */
 #include <src/objpcgel.h>               /* objects of polycyclic groups */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -48,6 +48,7 @@
 
 #include <src/compiler.h>               /* compiler */
 
+#include <src/hpc/guards.h>
 
 #include <src/vars.h>                   /* variables */
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -48,7 +48,6 @@
 
 #include <src/compiler.h>               /* compiler */
 
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/vars.h>                   /* variables */
 

--- a/src/compstat.c
+++ b/src/compstat.c
@@ -8,7 +8,6 @@
 *Y  Copyright (C) 2002 The GAP Group
 */
 #include <src/system.h>
-#include <src/gapstate.h>
 #include <src/compstat.h>               /* statically linked modules */
 
 // #define AVOID_PRECOMPILED

--- a/src/costab.c
+++ b/src/costab.c
@@ -13,7 +13,6 @@
 **  This file contains the functions of for coset tables.
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/costab.c
+++ b/src/costab.c
@@ -33,7 +33,6 @@
 
 #include <src/lists.h>                  /* generic lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/costab.h>                 /* coset table */
 

--- a/src/costab.c
+++ b/src/costab.c
@@ -40,7 +40,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 
 /****************************************************************************

--- a/src/costab.c
+++ b/src/costab.c
@@ -39,7 +39,6 @@
 #include <src/costab.h>                 /* coset table */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 
 /****************************************************************************

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -119,6 +119,7 @@
 #include <src/saveload.h>               /* saving and loading */
 
 #include <src/code.h>
+#include <src/hpc/guards.h>
 
 /****************************************************************************
 **

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -119,7 +119,6 @@
 #include <src/saveload.h>               /* saving and loading */
 
 #include <src/code.h>
-#include <src/hpc/tls.h>
 
 /****************************************************************************
 **

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -114,7 +114,6 @@
 
 #include <src/lists.h>                  /* generic lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/saveload.h>               /* saving and loading */
 

--- a/src/dt.c
+++ b/src/dt.c
@@ -77,7 +77,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 
 /****************************************************************************

--- a/src/dt.c
+++ b/src/dt.c
@@ -72,7 +72,6 @@
 #include <src/lists.h>                  /* generic lists */
 #include <src/listfunc.h>               /* functions for generic lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
 

--- a/src/dt.c
+++ b/src/dt.c
@@ -52,7 +52,6 @@
 **  for pos( <b> ) for all trees <b> which are represented by <a>.
 */
 #include <src/system.h>
-#include <src/gapstate.h>
 
 
 

--- a/src/dt.c
+++ b/src/dt.c
@@ -76,7 +76,6 @@
 #include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 
 /****************************************************************************

--- a/src/dteval.c
+++ b/src/dteval.c
@@ -49,7 +49,6 @@
 #include <src/lists.h>                  /* generic lists */
 #include <src/listfunc.h>               /* functions for generic lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/guards.h>

--- a/src/dteval.c
+++ b/src/dteval.c
@@ -53,7 +53,7 @@
 #include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
-
+#include <src/hpc/guards.h>
 
 static int             evlist, evlistvec;
 

--- a/src/dteval.c
+++ b/src/dteval.c
@@ -54,7 +54,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 
 static int             evlist, evlistvec;

--- a/src/dteval.c
+++ b/src/dteval.c
@@ -53,7 +53,6 @@
 #include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 
 static int             evlist, evlistvec;

--- a/src/dteval.c
+++ b/src/dteval.c
@@ -24,7 +24,6 @@
 **  is 0 if also the polynomials f_{m1},...,f_{mn} for (m > i) are trivial .
 */
 #include <src/system.h>
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -49,7 +49,6 @@
 
 #include <src/exprs.h>                  /* expressions */
 
-#include <src/hpc/tls.h>                /* thread-local storage */
 #include <src/hookintrprtr.h>
 #include <src/hpc/aobjects.h>           /* atomic objects */
 

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -2146,7 +2146,6 @@ static Int InitLibrary (
 
 void InitExprState(GAPState * state)
 {
-    state->CurrEvalExprFuncs = EvalExprFuncs;
 }
 
 void DestroyExprState(GAPState * state)

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -83,7 +83,6 @@
 
 #include <src/hpc/aobjects.h>           /* atomic access to plists */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 
 /****************************************************************************

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -76,7 +76,6 @@
 
 #include <src/lists.h>                  /* generic lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
 

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -82,7 +82,6 @@
 #include <src/code.h>                   /* coder */
 
 #include <src/hpc/aobjects.h>           /* atomic access to plists */
-#include <src/hpc/thread.h>             /* threads */
 
 
 /****************************************************************************

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -50,7 +50,6 @@
 **  order of the finite field minus one.
 */
 #include <src/system.h>                 /* Ints, UInts */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -51,7 +51,6 @@
 #include <src/opers.h>                  /* generic operations */
 #include <src/gvars.h>
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/vars.h>                   /* variables */
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -51,6 +51,7 @@
 #include <src/opers.h>                  /* generic operations */
 #include <src/gvars.h>
 #include <src/hpc/thread.h>             /* threads */
+#include <src/hpc/guards.h>
 
 #include <src/vars.h>                   /* variables */
 

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -19,11 +19,6 @@
 
 #include <src/gapstate.h>
 
-#ifdef HPCGAP
-/* HACK: need to include this for STATE() below in CheckRecursionBefore */
-#include "src/hpc/tls.h"
-#endif
-
 /****************************************************************************
 **
 *F  MakeFunction(<fexp>)  . . . . . . . . . . . . . . . . . . make a function

--- a/src/gap.c
+++ b/src/gap.c
@@ -101,7 +101,6 @@
 
 #ifdef HPCGAP
 #include <src/hpc/thread.h>
-#include <src/hpc/tls.h>
 #include <src/hpc/aobjects.h>
 #include <src/hpc/misc.h>
 #include <src/hpc/threadapi.h>

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -90,9 +90,6 @@ typedef struct GAPState {
     UInt            TheCount;
     UInt            TheLimit;
 
-    /* From exprs.c */
-    Obj (**CurrEvalExprFuncs)(Expr);
-
     /* From stats.c */
     Stat CurrStat;
     Obj  ReturnObjStat;

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -112,7 +112,6 @@
 */
 #include <string.h>
 #include <src/system.h>                 /* Ints, UInts */
-#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -39,9 +39,6 @@
 #include <src/system.h>
 #include <src/debug.h>
 
-#include <src/hpc/atomic.h>
-
-
 
 /****************************************************************************
 **
@@ -1187,44 +1184,6 @@ extern void FinishBags( void );
 
 extern void CallbackForAllBags(
      void (*func)(Bag) );
-
-#ifdef HPCGAP
-
-typedef struct
-{
-    void *lock;       /* void * so that we don't have to include pthread.h always */
-    Bag obj;          /* references a unique T_REGION object per region */
-    Bag name;         /* name of the region, or a null pointer */
-    Int prec;         /* locking precedence */
-    int fixed_owner;
-    void *owner;      /* opaque thread descriptor */
-    void *alt_owner;  /* for paused threads */
-    int count_active; /* whether we counts number of (contended) locks */
-    AtomicUInt locks_acquired;    /* number of times the lock was acquired successfully */
-    AtomicUInt locks_contended;   /* number of failed attempts at acuiring the lock */
-    unsigned char readers[];     /* this field extends with number of threads
-                                     don't add any fields after it */
-} Region;
-
-/****************************************************************************
-**
-*F  NewRegion() . . . . . . . . . . . . . . . . allocate a new region
-*/
-
-Region *NewRegion(void);
-
-/****************************************************************************
-**
-*F  REGION(<bag>)  . . . . . . . .  return the region containing the bag
-*F  RegionBag(<bag>)   . . . . . .  return the region containing the bag
-**
-**  RegionBag() also contains a memory barrier.
-*/
-#define REGION(bag) (((Region **)(bag))[1])
-
-Region *RegionBag(Bag bag);
-
-#endif // HPCGAP
 
 
 #ifdef BOEHM_GC

--- a/src/gmpints.c
+++ b/src/gmpints.c
@@ -66,7 +66,6 @@
 **  GMP_NORMALIZE and GMP_REDUCE can be used to ensure this.
 */
 #include <src/system.h>                 /* Ints, UInts */
-#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -53,7 +53,6 @@
 
 #include <src/bool.h>                   /* booleans */
 
-#include <src/hpc/tls.h>                /* thread-local storage */
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/aobjects.h>           /* atomic objects */
 

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -53,6 +53,7 @@
 
 #include <src/bool.h>                   /* booleans */
 
+#include <src/hpc/guards.h>
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/aobjects.h>           /* atomic objects */
 

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -10,7 +10,6 @@
 */
 
 #include <src/system.h>
-#include <src/gapstate.h>
 #include <src/sysfiles.h>
 
 #include <src/gasman.h>

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -27,7 +27,6 @@
 
 #include <src/lists.h>
 #include <src/plist.h>
-#include <src/stringobj.h>
 
 #include <src/bool.h>
 

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -47,7 +47,6 @@
 #include <src/hookintrprtr.h>
 
 #include <src/hpc/thread.h>
-#include <src/hpc/tls.h>
 
 #include <src/gaputils.h>
 

--- a/src/hookintrprtr.h
+++ b/src/hookintrprtr.h
@@ -13,7 +13,6 @@
 #define GAP_HOOKINTRPRTR_H
 
 #include <src/exprs.h>
-#include <src/gapstate.h>
 
 void InstallEvalBoolFunc(Int, Obj (*)(Expr));
 void InstallEvalExprFunc(Int, Obj (*)(Expr));

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -52,7 +52,6 @@
 
 #include <src/hpc/thread.h>
 #include <src/hpc/traverse.h>
-#include <src/hpc/tls.h>
 #include <src/vars.h>                   /* variables */
 
 #include <src/hpc/aobjects.h>

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -52,6 +52,7 @@
 
 #include <src/hpc/thread.h>
 #include <src/hpc/traverse.h>
+#include <src/hpc/guards.h>
 #include <src/vars.h>                   /* variables */
 
 #include <src/hpc/aobjects.h>

--- a/src/hpc/aobjects.h
+++ b/src/hpc/aobjects.h
@@ -9,6 +9,8 @@
 
 #else
 
+#include <src/hpc/atomic.h>
+
 StructInitInfo *InitInfoAObjects(void);
 Obj NewAtomicRecord(UInt capacity);
 Obj SetARecordField(Obj record, UInt field, Obj obj);

--- a/src/hpc/guards.h
+++ b/src/hpc/guards.h
@@ -1,0 +1,122 @@
+#ifndef GAP_HPC_GUARD_H
+#define GAP_HPC_GUARD_H
+
+#if !defined(HPCGAP)
+
+/*
+ * HPC-GAP stubs.
+ */
+
+#define ReadGuard(bag) ((void) 0)
+#define WriteGuard(bag) ((void) 0)
+
+static inline Bag ImpliedWriteGuard(Bag bag)
+{
+  return bag;
+}
+
+#else
+
+#include <src/hpc/tls.h>
+
+#ifdef VERBOSE_GUARDS
+void WriteGuardError(Bag bag,
+    const char *file, unsigned line, const char *func, const char *expr);
+void ReadGuardError(Bag bag,
+    const char *file, unsigned line, const char *func, const char *expr);
+#else
+void WriteGuardError(Bag bag);
+void ReadGuardError(Bag bag);
+#endif
+
+#ifdef VERBOSE_GUARDS
+#define WriteGuard(bag) WriteGuardFull(bag, __FILE__, __LINE__, __FUNCTION__, #bag)
+static ALWAYS_INLINE Bag WriteGuardFull(Bag bag,
+  const char *file, unsigned line, const char *func, const char *expr)
+#else
+static ALWAYS_INLINE Bag WriteGuard(Bag bag)
+#endif
+{
+  Region *region;
+  if (!IS_BAG_REF(bag))
+    return bag;
+  region = REGION(bag);
+  if (region && region->owner != realTLS && region->alt_owner != realTLS)
+    WriteGuardError(bag
+#ifdef VERBOSE_GUARDS
+    , file, line, func, expr
+#endif
+    );
+  return bag;
+}
+
+static inline Bag ImpliedWriteGuard(Bag bag)
+{
+  return bag;
+}
+
+static inline int CheckWriteAccess(Bag bag)
+{
+  Region *region;
+  if (!IS_BAG_REF(bag))
+    return 1;
+  region = REGION(bag);
+  return !(region && region->owner != realTLS && region->alt_owner != realTLS)
+    || TLS(DisableGuards) >= 2;
+}
+
+static inline int CheckExclusiveWriteAccess(Bag bag)
+{
+  Region *region;
+  if (!IS_BAG_REF(bag))
+    return 1;
+  region = REGION(bag);
+  if (!region)
+    return 0;
+  return region->owner == realTLS || region->alt_owner == realTLS
+    || TLS(DisableGuards) >= 2;
+}
+
+#ifdef VERBOSE_GUARDS
+#define ReadGuard(bag) ReadGuardFull(bag, __FILE__, __LINE__, __FUNCTION__, #bag)
+static ALWAYS_INLINE Bag ReadGuardFull(Bag bag,
+  const char *file, unsigned line, const char *func, const char *expr)
+#else
+static ALWAYS_INLINE Bag ReadGuard(Bag bag)
+#endif
+{
+  Region *region;
+  if (!IS_BAG_REF(bag))
+    return bag;
+  region = REGION(bag);
+  if (region && region->owner != realTLS &&
+      !region->readers[TLS(threadID)] && region->alt_owner != realTLS)
+    ReadGuardError(bag
+#ifdef VERBOSE_GUARDS
+    , file, line, func, expr
+#endif
+    );
+  return bag;
+}
+
+
+static ALWAYS_INLINE Bag ImpliedReadGuard(Bag bag)
+{
+  return bag;
+}
+
+
+static ALWAYS_INLINE int CheckReadAccess(Bag bag)
+{
+  Region *region;
+  if (!IS_BAG_REF(bag))
+    return 1;
+  region = REGION(bag);
+  return !(region && region->owner != realTLS &&
+    !region->readers[TLS(threadID)] && region->alt_owner != realTLS)
+    || TLS(DisableGuards) >= 2;
+}
+
+#endif // HPCGAP
+
+#endif // GAP_HPC_GUARD_H

--- a/src/hpc/guards.h
+++ b/src/hpc/guards.h
@@ -17,6 +17,7 @@ static inline Bag ImpliedWriteGuard(Bag bag)
 
 #else
 
+#include <src/hpc/region.h>
 #include <src/hpc/tls.h>
 
 #ifdef VERBOSE_GUARDS

--- a/src/hpc/region.h
+++ b/src/hpc/region.h
@@ -1,0 +1,44 @@
+#ifndef GAP_REGION_H
+#define GAP_REGION_H
+
+#if defined(HPCGAP)
+
+#include <src/hpc/atomic.h>
+
+typedef struct
+{
+    void *lock;       /* void * so that we don't have to include pthread.h always */
+    Bag obj;          /* references a unique T_REGION object per region */
+    Bag name;         /* name of the region, or a null pointer */
+    Int prec;         /* locking precedence */
+    int fixed_owner;
+    void *owner;      /* opaque thread descriptor */
+    void *alt_owner;  /* for paused threads */
+    int count_active; /* whether we counts number of (contended) locks */
+    AtomicUInt locks_acquired;    /* number of times the lock was acquired successfully */
+    AtomicUInt locks_contended;   /* number of failed attempts at acuiring the lock */
+    unsigned char readers[];     /* this field extends with number of threads
+                                     don't add any fields after it */
+} Region;
+
+/****************************************************************************
+**
+*F  NewRegion() . . . . . . . . . . . . . . . . allocate a new region
+*/
+
+Region *NewRegion(void);
+
+/****************************************************************************
+**
+*F  REGION(<bag>)  . . . . . . . .  return the region containing the bag
+*F  RegionBag(<bag>)   . . . . . .  return the region containing the bag
+**
+**  RegionBag() also contains a memory barrier.
+*/
+#define REGION(bag) (((Region **)(bag))[1])
+
+Region *RegionBag(Bag bag);
+
+#endif // HPCGAP
+
+#endif // GAP_REGION_H

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -14,7 +14,6 @@
 #include <src/gap.h>
 #include <src/lists.h>
 #include <src/hpc/aobjects.h>
-#include <src/hpc/tls.h>
 #include <src/hpc/serialize.h>
 #include <src/objset.h>
 

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -13,7 +13,6 @@
 #include <src/stats.h>
 #include <src/gap.h>
 #include <src/hpc/misc.h>
-#include <src/hpc/tls.h>
 #include <src/hpc/thread.h>
 #include <src/hpc/threadapi.h>
 #include <src/fibhash.h>

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -13,6 +13,7 @@
 #include <src/stats.h>
 #include <src/gap.h>
 #include <src/hpc/misc.h>
+#include <src/hpc/guards.h>
 #include <src/hpc/thread.h>
 #include <src/hpc/threadapi.h>
 #include <src/fibhash.h>

--- a/src/hpc/thread.h
+++ b/src/hpc/thread.h
@@ -14,6 +14,8 @@
 
 #else
 
+#include <src/hpc/region.h>
+
 /* Maximum number of threads excluding the main thread */
 #define MAX_THREADS 1023
 

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -56,7 +56,6 @@
 #include <src/hpc/misc.h>
 #include <src/hpc/thread.h>
 #include <src/hpc/traverse.h>
-#include <src/hpc/tls.h>
 #include <src/hpc/threadapi.h>
 
 #include <src/vars.h>                   /* variables */

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -56,6 +56,7 @@
 #include <src/hpc/misc.h>
 #include <src/hpc/thread.h>
 #include <src/hpc/traverse.h>
+#include <src/hpc/guards.h>
 #include <src/hpc/threadapi.h>
 
 #include <src/vars.h>                   /* variables */

--- a/src/hpc/tls.c
+++ b/src/hpc/tls.c
@@ -1,5 +1,4 @@
 #include <src/system.h>
-#include <src/gapstate.h>
 #include <src/gasman.h>
 #include <src/objects.h>
 #include <src/scanner.h>

--- a/src/hpc/tls.h
+++ b/src/hpc/tls.h
@@ -1,21 +1,7 @@
 #ifndef GAP_TLS_H
 #define GAP_TLS_H
 
-#if !defined(HPCGAP)
-
-/*
- * HPC-GAP stubs.
- */
-
-#define ReadGuard(bag) ((void) 0)
-#define WriteGuard(bag) ((void) 0)
-
-static inline Bag ImpliedWriteGuard(Bag bag)
-{
-  return bag;
-}
-
-#else
+#ifdef HPCGAP
 
 #include <stdint.h>
 #include <src/gapstate.h>
@@ -118,109 +104,6 @@ static ALWAYS_INLINE ThreadLocalStorage *GetTLS(void)
 
 #define TLS(x) realTLS->x
 #define STATE(x) TLS(state).x
-
-#ifdef VERBOSE_GUARDS
-
-#define ReadGuard(bag) ReadGuardFull(bag, __FILE__, __LINE__, __FUNCTION__, #bag)
-#define WriteGuard(bag) WriteGuardFull(bag, __FILE__, __LINE__, __FUNCTION__, #bag)
-
-#endif
-
-#ifdef VERBOSE_GUARDS
-void WriteGuardError(Bag bag,
-    const char *file, unsigned line, const char *func, const char *expr);
-void ReadGuardError(Bag bag,
-    const char *file, unsigned line, const char *func, const char *expr);
-#else
-void WriteGuardError(Bag bag);
-void ReadGuardError(Bag bag);
-#endif
-
-#ifdef VERBOSE_GUARDS
-static ALWAYS_INLINE Bag WriteGuardFull(Bag bag,
-  const char *file, unsigned line, const char *func, const char *expr)
-#else
-static ALWAYS_INLINE Bag WriteGuard(Bag bag)
-#endif
-{
-  Region *region;
-  if (!IS_BAG_REF(bag))
-    return bag;
-  region = REGION(bag);
-  if (region && region->owner != realTLS && region->alt_owner != realTLS)
-    WriteGuardError(bag
-#ifdef VERBOSE_GUARDS
-    , file, line, func, expr
-#endif
-    );
-  return bag;
-}
-
-static inline Bag ImpliedWriteGuard(Bag bag)
-{
-  return bag;
-}
-
-static inline int CheckWriteAccess(Bag bag)
-{
-  Region *region;
-  if (!IS_BAG_REF(bag))
-    return 1;
-  region = REGION(bag);
-  return !(region && region->owner != realTLS && region->alt_owner != realTLS)
-    || TLS(DisableGuards) >= 2;
-}
-
-static inline int CheckExclusiveWriteAccess(Bag bag)
-{
-  Region *region;
-  if (!IS_BAG_REF(bag))
-    return 1;
-  region = REGION(bag);
-  if (!region)
-    return 0;
-  return region->owner == realTLS || region->alt_owner == realTLS
-    || TLS(DisableGuards) >= 2;
-}
-
-#ifdef VERBOSE_GUARDS
-static ALWAYS_INLINE Bag ReadGuardFull(Bag bag,
-  const char *file, unsigned line, const char *func, const char *expr)
-#else
-static ALWAYS_INLINE Bag ReadGuard(Bag bag)
-#endif
-{
-  Region *region;
-  if (!IS_BAG_REF(bag))
-    return bag;
-  region = REGION(bag);
-  if (region && region->owner != realTLS &&
-      !region->readers[TLS(threadID)] && region->alt_owner != realTLS)
-    ReadGuardError(bag
-#ifdef VERBOSE_GUARDS
-    , file, line, func, expr
-#endif
-    );
-  return bag;
-}
-
-
-static ALWAYS_INLINE Bag ImpliedReadGuard(Bag bag)
-{
-  return bag;
-}
-
-
-static ALWAYS_INLINE int CheckReadAccess(Bag bag)
-{
-  Region *region;
-  if (!IS_BAG_REF(bag))
-    return 1;
-  region = REGION(bag);
-  return !(region && region->owner != realTLS &&
-    !region->readers[TLS(threadID)] && region->alt_owner != realTLS)
-    || TLS(DisableGuards) >= 2;
-}
 
 static inline int IsMainThread(void)
 {

--- a/src/hpc/traverse.c
+++ b/src/hpc/traverse.c
@@ -14,6 +14,7 @@
 #include <src/precord.h>
 #include <src/stats.h>
 #include <src/gap.h>
+#include <src/hpc/guards.h>
 #include <src/hpc/thread.h>
 #include <src/hpc/traverse.h>
 #include <src/fibhash.h>

--- a/src/hpc/traverse.c
+++ b/src/hpc/traverse.c
@@ -2,7 +2,6 @@
  * Functionality to traverse nested object structures.
  */
 #include <src/system.h>
-#include <src/gapstate.h>
 #include <src/gasman.h>
 #include <src/objects.h>
 #include <src/bool.h>

--- a/src/hpc/traverse.c
+++ b/src/hpc/traverse.c
@@ -14,7 +14,6 @@
 #include <src/precord.h>
 #include <src/stats.h>
 #include <src/gap.h>
-#include <src/hpc/tls.h>
 #include <src/hpc/thread.h>
 #include <src/hpc/traverse.h>
 #include <src/fibhash.h>

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -46,7 +46,6 @@
 #include <src/saveload.h>               /* saving and loading */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 
 #include <stdio.h>

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -47,7 +47,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 
 #include <stdio.h>

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -15,7 +15,6 @@
 
 
 #include <src/system.h>                 /* Ints, UInts */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -56,6 +56,7 @@
 #include <src/intrprtr.h>               /* interpreter */
 #include <src/intfuncs.h>
 
+#include <src/hpc/guards.h>
 #include <src/hpc/thread.h>
 #include <src/hpc/aobjects.h>           /* atomic objects */
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -56,7 +56,6 @@
 #include <src/intrprtr.h>               /* interpreter */
 #include <src/intfuncs.h>
 
-#include <src/hpc/tls.h>
 #include <src/hpc/thread.h>
 #include <src/hpc/aobjects.h>           /* atomic objects */
 

--- a/src/iostream.c
+++ b/src/iostream.c
@@ -22,7 +22,6 @@
 */
 
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 #include <src/iostream.h>               /* file input/output */
 

--- a/src/iostream.c
+++ b/src/iostream.c
@@ -45,7 +45,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <stdio.h>                      /* standard input/output functions */
 #include <stdlib.h>

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -43,7 +43,6 @@
 
 #include <src/plist.h>                  /* plain lists */
 #include <src/set.h>                    /* plain sets */
-#include <src/range.h>                  /* ranges */
 #include <src/code.h>
 #include <src/gmpints.h>
 

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -48,7 +48,6 @@
 #include <src/code.h>
 #include <src/gmpints.h>
 
-#include <src/hpc/thread.h>
 #include <src/hpc/aobjects.h>           /* atomic objects */
 
 #include <string.h>

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -10,7 +10,6 @@
 **  This file contains the functions for generic lists.
 */
 #include <src/system.h>                 /* Ints, UInts */
-#include <src/gapstate.h>
 
 
 

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -48,6 +48,7 @@
 #include <src/code.h>
 #include <src/gmpints.h>
 
+#include <src/hpc/guards.h>
 #include <src/hpc/aobjects.h>           /* atomic objects */
 
 #include <string.h>

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -49,7 +49,6 @@
 #include <src/gmpints.h>
 
 #include <src/hpc/thread.h>
-#include <src/hpc/tls.h>
 #include <src/hpc/aobjects.h>           /* atomic objects */
 
 #include <string.h>

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -44,7 +44,6 @@
 #include <src/range.h>                  /* Ranges */
 #include <src/code.h>                   /* Coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 
 #ifndef HPCGAP

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -11,7 +11,6 @@
 **  generic lists.
 */
 #include <src/system.h>                 /* Ints, UInts */
-#include <src/gapstate.h>
 
 
 #include <src/sysfiles.h>               /* file input/output */

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -38,7 +38,6 @@
 #include <src/listoper.h>               /* operations for generic lists */
 #include <src/listfunc.h>               /* functions for generic lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/stringobj.h>              /* strings */
 #include <src/opers.h>                  /* TRY_NEXT_METHOD */
 #include <src/range.h>                  /* Ranges */
 #include <src/code.h>                   /* Coder */

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -43,7 +43,6 @@
 #include <src/opers.h>                  /* TRY_NEXT_METHOD */
 #include <src/range.h>                  /* Ranges */
 #include <src/code.h>                   /* Coder */
-#include <src/hpc/thread.h>             /* threads */
 
 
 #ifndef HPCGAP

--- a/src/lists.c
+++ b/src/lists.c
@@ -52,7 +52,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/gaputils.h>
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -51,7 +51,6 @@
 #include <src/hpc/aobjects.h>           /* atomic objects */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 #include <src/gaputils.h>
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -51,6 +51,7 @@
 #include <src/hpc/aobjects.h>           /* atomic objects */
 
 #include <src/code.h>                   /* coder */
+#include <src/hpc/guards.h>
 
 #include <src/gaputils.h>
 

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -44,7 +44,6 @@
 #include <assert.h>
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 /* the following two declarations would belong in `saveload.h', but then all
  * files get macfloat dependencies */

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -45,7 +45,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 /* the following two declarations would belong in `saveload.h', but then all
  * files get macfloat dependencies */

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -23,7 +23,6 @@
 
 
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/objccoll.c
+++ b/src/objccoll.c
@@ -34,7 +34,6 @@
 #include <src/precord.h>                /* plain records */
 
 #include <src/plist.h>                  /* plain lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
 

--- a/src/objccoll.c
+++ b/src/objccoll.c
@@ -37,7 +37,6 @@
 #include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 #include <src/objfgelm.h>               /* objects of free groups */
 

--- a/src/objccoll.c
+++ b/src/objccoll.c
@@ -23,7 +23,6 @@
 
 #include <src/gvars.h>                  /* global variables */
 #include <src/gap.h>                    /* error handling, initialisation */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/calls.h>                  /* generic call mechanism */
 
@@ -39,7 +38,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/objfgelm.h>               /* objects of free groups */
 

--- a/src/objcftl.c
+++ b/src/objcftl.c
@@ -15,7 +15,6 @@
 **  code here.                                                                    
 */
 #include <src/system.h>
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/objcftl.c
+++ b/src/objcftl.c
@@ -40,6 +40,7 @@
 #include <src/objcftl.h>                /* from the left collect */
 
 #include <src/code.h>
+#include <src/hpc/guards.h>
 
 
 #define IS_INT_ZERO( n )  ((n) == INTOBJ_INT(0))

--- a/src/objcftl.c
+++ b/src/objcftl.c
@@ -41,7 +41,6 @@
 
 #include <src/code.h>
 #include <src/hpc/thread.h>
-#include <src/hpc/tls.h>
 
 
 #define IS_INT_ZERO( n )  ((n) == INTOBJ_INT(0))

--- a/src/objcftl.c
+++ b/src/objcftl.c
@@ -32,7 +32,6 @@
 
 #include <src/lists.h>                  /* generic lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/dt.h>                     /* deep thought */
 

--- a/src/objcftl.c
+++ b/src/objcftl.c
@@ -40,7 +40,6 @@
 #include <src/objcftl.h>                /* from the left collect */
 
 #include <src/code.h>
-#include <src/hpc/thread.h>
 
 
 #define IS_INT_ZERO( n )  ((n) == INTOBJ_INT(0))

--- a/src/objects.c
+++ b/src/objects.c
@@ -45,7 +45,6 @@
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/traverse.h>           /* object traversal */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/gaputils.h>
 
@@ -1482,7 +1481,9 @@ Obj FuncSET_TYPE_DATOBJ (
     Obj                 type )
 {
 #ifndef WARD_ENABLED
+#ifdef HPCGAP
     ReadGuard( obj );
+#endif
     TYPE_DATOBJ( obj ) = type;
 #ifdef HPCGAP
     if (TNUM_OBJ(obj) != T_DATOBJ)

--- a/src/objects.c
+++ b/src/objects.c
@@ -45,6 +45,7 @@
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/traverse.h>           /* object traversal */
+#include <src/hpc/guards.h>
 
 #include <src/gaputils.h>
 

--- a/src/objfgelm.c
+++ b/src/objfgelm.c
@@ -98,7 +98,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/objfgelm.h>               /* objects of free groups */
 

--- a/src/objfgelm.c
+++ b/src/objfgelm.c
@@ -97,7 +97,6 @@
 #include <src/bool.h>                   /* booleans */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 #include <src/objfgelm.h>               /* objects of free groups */
 

--- a/src/objfgelm.c
+++ b/src/objfgelm.c
@@ -73,7 +73,6 @@
 */
 #include <assert.h>                     /* assert */
 #include <src/system.h>                 /* Ints, UInts */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/objfgelm.h
+++ b/src/objfgelm.h
@@ -11,7 +11,7 @@
 #ifndef GAP_OBJFGELM_H
 #define GAP_OBJFGELM_H
 
-#include <src/hpc/tls.h>
+#include <src/hpc/guards.h>
 
 /****************************************************************************
 **

--- a/src/objpcgel.c
+++ b/src/objpcgel.c
@@ -31,13 +31,11 @@
 #include <src/bool.h>                   /* booleans */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/tls.h>                /* thread-local storage */
 #include <src/objfgelm.h>               /* objects of free groups */
 #include <src/objscoll.h>               /* single collector */
 
 #include <src/objpcgel.h>               /* objects of polycyclic groups */
 
-#include <src/hpc/tls.h>                /* thread-local storage */
 #include <src/hpc/thread.h>             /* threads */
 
 

--- a/src/objpcgel.c
+++ b/src/objpcgel.c
@@ -24,7 +24,6 @@
 
 #include <src/lists.h>                  /* generic lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/ariths.h>                 /* basic arithmetic */
 #include <src/bool.h>                   /* booleans */

--- a/src/objpcgel.c
+++ b/src/objpcgel.c
@@ -36,7 +36,6 @@
 
 #include <src/objpcgel.h>               /* objects of polycyclic groups */
 
-#include <src/hpc/thread.h>             /* threads */
 
 
 /****************************************************************************

--- a/src/objpcgel.c
+++ b/src/objpcgel.c
@@ -8,7 +8,6 @@
 *Y  Copyright (C) 2002 The GAP Group
 */
 #include <src/system.h>                 /* Ints, UInts */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/objscoll.c
+++ b/src/objscoll.c
@@ -46,7 +46,6 @@
 
 #include <src/code.h>                   /* coder */
 
-#include <src/hpc/tls.h>                /* thread-local storage */
 #include <src/objfgelm.h>               /* objects of free groups */
 
 #include <src/objscoll.h>               /* single collector */

--- a/src/objscoll.c
+++ b/src/objscoll.c
@@ -51,7 +51,6 @@
 #include <src/objscoll.h>               /* single collector */
 
 #include <src/objccoll.h>               /* combinatorial collector */
-#include <src/hpc/thread.h>
 
 /****************************************************************************
 **

--- a/src/objset.c
+++ b/src/objset.c
@@ -30,6 +30,7 @@
 
 #include <src/scanner.h>
 
+#include <src/hpc/guards.h>
 
 #include <src/gaputils.h>
 

--- a/src/objset.c
+++ b/src/objset.c
@@ -13,7 +13,6 @@
 #include <stdlib.h>
 
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 #include <src/gasman.h>                 /* garbage collector */
 #include <src/objects.h>                /* objects */

--- a/src/objset.c
+++ b/src/objset.c
@@ -30,7 +30,6 @@
 
 #include <src/scanner.h>
 
-#include <src/hpc/tls.h>
 
 #include <src/gaputils.h>
 

--- a/src/opers.c
+++ b/src/opers.c
@@ -50,7 +50,6 @@
 #include <src/gmpints.h>   
 
 #ifdef HPCGAP
-#include <src/hpc/tls.h>                /* thread-local storage */
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/aobjects.h>           /* atomic objects */
 

--- a/src/opers.c
+++ b/src/opers.c
@@ -50,6 +50,7 @@
 #include <src/gmpints.h>   
 
 #ifdef HPCGAP
+#include <src/hpc/guards.h>
 #include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/aobjects.h>           /* atomic objects */
 

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -71,6 +71,7 @@
 #include <src/code.h>                   /* coder */
 
 #include <src/saveload.h>               /* saving and loading */
+#include <src/hpc/guards.h>
 
 #include <src/trans.h>
 #include <assert.h>

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -71,7 +71,6 @@
 #include <src/code.h>                   /* coder */
 
 #include <src/saveload.h>               /* saving and loading */
-#include <src/hpc/tls.h>
 
 #include <src/trans.h>
 #include <assert.h>

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -66,7 +66,6 @@
 #include <src/lists.h>                  /* generic lists */
 #include <src/plist.h>                  /* plain lists */
 #include <src/range.h>                  /* ranges */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -67,7 +67,6 @@
 
 #include <src/saveload.h>               /* saving and loading */
 #include <src/code.h>
-#include <src/hpc/thread.h>
 
 #include <src/gaputils.h>
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -62,7 +62,6 @@
 #include <src/lists.h>                  /* generic lists */
 #include <src/plist.h>                  /* plain lists */
 #include <src/range.h>                  /* ranges */
-#include <src/stringobj.h>              /* strings */
 #include <src/blister.h>                /* boolean lists */
 
 #include <src/saveload.h>               /* saving and loading */

--- a/src/plist.c
+++ b/src/plist.c
@@ -67,6 +67,7 @@
 
 #include <src/saveload.h>               /* saving and loading */
 #include <src/code.h>
+#include <src/hpc/guards.h>
 
 #include <src/gaputils.h>
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -68,7 +68,6 @@
 #include <src/saveload.h>               /* saving and loading */
 #include <src/code.h>
 #include <src/hpc/thread.h>
-#include <src/hpc/tls.h>
 
 #include <src/gaputils.h>
 

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -39,7 +39,6 @@
 #include <src/lists.h>                  /* generic lists */
 #include <src/plist.h>                  /* plain lists */
 #include <src/range.h>                  /* ranges */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/saveload.h>               /* saving and loading */
 

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -47,7 +47,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/pperm.h>                  /* same header applies */
 

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -46,7 +46,6 @@
 #include <src/set.h>                    /* sets */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 #include <src/pperm.h>                  /* same header applies */
 

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -38,7 +38,6 @@
 
 #include <src/lists.h>                  /* generic lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/range.h>                  /* ranges */
 
 #include <src/saveload.h>               /* saving and loading */
 

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -46,6 +46,7 @@
 #include <src/set.h>                    /* sets */
 
 #include <src/code.h>                   /* coder */
+#include <src/hpc/guards.h>
 
 #include <src/pperm.h>                  /* same header applies */
 

--- a/src/precord.c
+++ b/src/precord.c
@@ -58,7 +58,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 #include <src/hpc/aobjects.h>           /* thread-local storage */
 
 #include <src/gaputils.h>

--- a/src/precord.c
+++ b/src/precord.c
@@ -57,7 +57,6 @@
 #include <src/saveload.h>               /* saving and loading */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 #include <src/hpc/aobjects.h>           /* thread-local storage */
 
 #include <src/gaputils.h>

--- a/src/precord.c
+++ b/src/precord.c
@@ -57,6 +57,7 @@
 #include <src/saveload.h>               /* saving and loading */
 
 #include <src/code.h>                   /* coder */
+#include <src/hpc/guards.h>
 #include <src/hpc/aobjects.h>           /* thread-local storage */
 
 #include <src/gaputils.h>

--- a/src/profile.c
+++ b/src/profile.c
@@ -48,7 +48,6 @@
 #include <src/profile.h>
 #include <src/hookintrprtr.h>
 
-#include <src/hpc/tls.h>
 #include <src/hpc/thread.h>
 
 #include <src/calls.h>                  /* function filename, line number */

--- a/src/profile.c
+++ b/src/profile.c
@@ -9,7 +9,6 @@
 **
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/sysfiles.h>               /* file input/output */

--- a/src/range.c
+++ b/src/range.c
@@ -79,7 +79,6 @@
 #include <src/saveload.h>               /* saving and loading */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 #include <src/gaputils.h>
 

--- a/src/range.c
+++ b/src/range.c
@@ -80,7 +80,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/gaputils.h>
 

--- a/src/range.c
+++ b/src/range.c
@@ -79,6 +79,7 @@
 #include <src/saveload.h>               /* saving and loading */
 
 #include <src/code.h>                   /* coder */
+#include <src/hpc/guards.h>
 
 #include <src/gaputils.h>
 

--- a/src/range.c
+++ b/src/range.c
@@ -50,7 +50,6 @@
 **  The  third part consists  ...
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/range.c
+++ b/src/range.c
@@ -73,7 +73,6 @@
 #include <src/lists.h>                  /* generic lists */
 #include <src/plist.h>                  /* plain lists */
 #include <src/range.h>                  /* ranges */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/saveload.h>               /* saving and loading */
 

--- a/src/rational.c
+++ b/src/rational.c
@@ -43,7 +43,6 @@
 **  'SumInt', 'ProdInt' or 'GcdInt'.
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/rational.c
+++ b/src/rational.c
@@ -72,6 +72,7 @@
 
 #include <src/saveload.h>               /* saving and loading */
 #include <src/code.h>
+#include <src/hpc/guards.h>
 
 
 #if defined(DEBUG_RATIONALS)

--- a/src/rational.c
+++ b/src/rational.c
@@ -73,7 +73,6 @@
 #include <src/saveload.h>               /* saving and loading */
 #include <src/code.h>
 #include <src/hpc/thread.h>
-#include <src/hpc/tls.h>
 
 
 #if defined(DEBUG_RATIONALS)

--- a/src/rational.c
+++ b/src/rational.c
@@ -72,7 +72,6 @@
 
 #include <src/saveload.h>               /* saving and loading */
 #include <src/code.h>
-#include <src/hpc/thread.h>
 
 
 #if defined(DEBUG_RATIONALS)

--- a/src/rational.c
+++ b/src/rational.c
@@ -67,7 +67,6 @@
 #include <src/precord.h>                /* plain records */
 
 #include <src/lists.h>                  /* generic lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/saveload.h>               /* saving and loading */
 #include <src/code.h>

--- a/src/read.c
+++ b/src/read.c
@@ -37,7 +37,6 @@
 
 #include <src/read.h>                   /* reader */
 
-#include <src/hpc/tls.h>
 #include <src/hpc/thread.h>
 
 #include <src/vars.h>                   /* variables */

--- a/src/records.c
+++ b/src/records.c
@@ -39,7 +39,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/hpc/systhread.h>          /* system thread primitives */
 

--- a/src/records.c
+++ b/src/records.c
@@ -13,7 +13,6 @@
 **  records and the elements for the other packages in the GAP kernel.
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -36,7 +36,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/gaputils.h>
 

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -12,7 +12,6 @@
 **  throughout the kernel
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <unistd.h>                     /* write, read */

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -35,7 +35,6 @@
 #include <src/saveload.h>               /* saving and loading */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 #include <src/gaputils.h>
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -62,7 +62,6 @@
 #include <src/opers.h>                  /* DoFilter... */
 #include <src/read.h>                   /* Call0ArgsInNewReader */
 
-#include <src/hpc/tls.h>
 #include <src/hpc/thread.h>
 
 #include <src/gaputils.h>

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -62,7 +62,6 @@
 #include <src/opers.h>                  /* DoFilter... */
 #include <src/read.h>                   /* Call0ArgsInNewReader */
 
-#include <src/hpc/thread.h>
 
 #include <src/gaputils.h>
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -62,6 +62,7 @@
 #include <src/opers.h>                  /* DoFilter... */
 #include <src/read.h>                   /* Call0ArgsInNewReader */
 
+#include <src/hpc/guards.h>
 
 #include <src/gaputils.h>
 

--- a/src/sctable.c
+++ b/src/sctable.c
@@ -37,7 +37,6 @@
 **        can fool around with SCTables as s/he likes. 
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/sctable.c
+++ b/src/sctable.c
@@ -62,7 +62,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 
 /****************************************************************************

--- a/src/sctable.c
+++ b/src/sctable.c
@@ -55,7 +55,6 @@
 
 #include <src/lists.h>                  /* generic lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/sctable.h>                /* structure constant table */
 

--- a/src/sctable.c
+++ b/src/sctable.c
@@ -61,7 +61,6 @@
 #include <src/sctable.h>                /* structure constant table */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 
 /****************************************************************************

--- a/src/set.c
+++ b/src/set.c
@@ -50,7 +50,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 
 /****************************************************************************

--- a/src/set.c
+++ b/src/set.c
@@ -49,7 +49,6 @@
 #include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 
 /****************************************************************************

--- a/src/set.c
+++ b/src/set.c
@@ -21,7 +21,6 @@
 */
 #include <assert.h>                     /* assert */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/set.c
+++ b/src/set.c
@@ -45,7 +45,6 @@
 #include <src/listfunc.h>               /* functions for generic lists */
 #include <src/plist.h>                  /* plain lists */
 #include <src/set.h>                    /* plain sets */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/code.h>                   /* coder */
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -50,7 +50,6 @@
 
 #include <assert.h>
 
-#include <src/hpc/tls.h>
 #include <src/hpc/thread.h>
 
 #include <src/vars.h>                   /* variables */

--- a/src/streams.c
+++ b/src/streams.c
@@ -54,7 +54,6 @@
 
 #include <src/code.h>
 
-#include <src/hpc/tls.h>
 
 #include <src/vars.h>                   /* STATE(BottomLVars) for execution contexts */
 

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -79,6 +79,7 @@
 #include <src/stringobj.h>              /* strings */
 
 #include <src/saveload.h>               /* saving and loading */
+#include <src/hpc/guards.h>
 
 #include <src/gaputils.h>
 

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -51,7 +51,6 @@
 **  string, and if so converts it into the above format.
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -79,7 +79,6 @@
 #include <src/stringobj.h>              /* strings */
 
 #include <src/saveload.h>               /* saving and loading */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/gaputils.h>
 

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -41,7 +41,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/read.h>                   /* reader */
 

--- a/src/system.c
+++ b/src/system.c
@@ -20,7 +20,6 @@
 */
 
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 #include <src/gap.h>                    /* get UserHasQUIT */
 

--- a/src/system.h
+++ b/src/system.h
@@ -29,6 +29,7 @@
 /* include C library stdlib.h to ensure size_t etc. is defined. */
 #include <stdlib.h>
 
+#include <string.h>     // memcpy etc.
 
 
 /****************************************************************************

--- a/src/tietze.c
+++ b/src/tietze.c
@@ -37,7 +37,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 
 /****************************************************************************

--- a/src/tietze.c
+++ b/src/tietze.c
@@ -36,6 +36,7 @@
 #include <src/tietze.h>                 /* tietze helper functions */
 
 #include <src/code.h>                   /* coder */
+#include <src/hpc/guards.h>
 
 
 /****************************************************************************

--- a/src/tietze.c
+++ b/src/tietze.c
@@ -11,7 +11,6 @@
 **  This file contains the functions for computing with finite presentations.
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 #include <src/code.h>
 #include <src/stats.h>                  /* for TakeInterrupt */
 

--- a/src/tietze.c
+++ b/src/tietze.c
@@ -36,7 +36,6 @@
 #include <src/tietze.h>                 /* tietze helper functions */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 
 /****************************************************************************

--- a/src/trans.c
+++ b/src/trans.c
@@ -70,7 +70,6 @@
 #include <src/listfunc.h>               /* functions for lists */
 #include <src/plist.h>                  /* plain lists */
 #include <src/range.h>                  /* ranges */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/saveload.h>               /* saving and loading */
 

--- a/src/trans.c
+++ b/src/trans.c
@@ -77,6 +77,7 @@
 #include <src/set.h>                    /* sets */
 
 #include <src/code.h>                   /* coder */
+#include <src/hpc/guards.h>
 
 #include <src/trans.h>                  /* transformations */
 #include <assert.h>

--- a/src/trans.c
+++ b/src/trans.c
@@ -69,7 +69,6 @@
 #include <src/lists.h>                  /* generic lists */
 #include <src/listfunc.h>               /* functions for lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/range.h>                  /* ranges */
 
 #include <src/saveload.h>               /* saving and loading */
 

--- a/src/trans.c
+++ b/src/trans.c
@@ -78,7 +78,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/trans.h>                  /* transformations */
 #include <assert.h>

--- a/src/trans.c
+++ b/src/trans.c
@@ -77,7 +77,6 @@
 #include <src/set.h>                    /* sets */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 #include <src/trans.h>                  /* transformations */
 #include <assert.h>

--- a/src/vars.c
+++ b/src/vars.c
@@ -50,7 +50,6 @@
 #include <src/saveload.h>               /* saving and loading */
 
 #include <src/hpc/aobjects.h>           /* atomic objects */
-#include <src/hpc/thread.h>             /* threads */
 
 #include <src/hookintrprtr.h>           /* installing methods */
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -51,7 +51,6 @@
 
 #include <src/hpc/aobjects.h>           /* atomic objects */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <src/hookintrprtr.h>           /* installing methods */
 
@@ -1730,7 +1729,9 @@ UInt            ExecAssPosObj (
 
     /* special case for plain list                                         */
     if ( TNUM_OBJ(list) == T_POSOBJ ) {
+#ifdef HPCGAP
         WriteGuard(list);
+#endif
         if ( SIZE_OBJ(list)/sizeof(Obj)-1 < p ) {
             ResizeBag( list, (p+1) * sizeof(Obj) );
         }
@@ -1779,7 +1780,9 @@ UInt            ExecUnbPosObj (
 
     /* unbind the element                                                  */
     if ( TNUM_OBJ(list) == T_POSOBJ ) {
+#ifdef HPCGAP
         WriteGuard(list);
+#endif
         if ( p <= SIZE_OBJ(list)/sizeof(Obj)-1 ) {
             SET_ELM_PLIST( list, p, 0 );
         }

--- a/src/vars.c
+++ b/src/vars.c
@@ -50,6 +50,7 @@
 #include <src/saveload.h>               /* saving and loading */
 
 #include <src/hpc/aobjects.h>           /* atomic objects */
+#include <src/hpc/guards.h>
 
 #include <src/hookintrprtr.h>           /* installing methods */
 

--- a/src/vars.h
+++ b/src/vars.h
@@ -20,6 +20,7 @@
 #ifndef GAP_VARS_H
 #define GAP_VARS_H
 
+#include <src/gapstate.h>   // for STATE
 
 /****************************************************************************
 **

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -43,7 +43,6 @@
 
 #include <src/hpc/aobjects.h>           /* atomic objects */
 #include <src/hpc/thread.h>
-#include <src/hpc/tls.h>
 
 #ifndef DEBUG
 #ifndef NDEBUG

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -23,7 +23,6 @@
 #include <src/plist.h>                  /* plain lists */
 #include <src/range.h>                  /* ranges */
 #include <src/blister.h>                /* boolean lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/vector.h>                 /* vectors */
 #include <src/listoper.h>               /* default list ops */

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -42,7 +42,6 @@
 #include <src/stats.h> 
 
 #include <src/hpc/aobjects.h>           /* atomic objects */
-#include <src/hpc/thread.h>
 
 #ifndef DEBUG
 #ifndef NDEBUG

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -42,6 +42,7 @@
 #include <src/stats.h> 
 
 #include <src/hpc/aobjects.h>           /* atomic objects */
+#include <src/hpc/guards.h>
 
 #ifndef DEBUG
 #ifndef NDEBUG

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -1,5 +1,4 @@
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -45,7 +45,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <assert.h>
 

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -9,7 +9,6 @@
 **
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -33,7 +33,6 @@
 #include <src/lists.h>                  /* generic lists */
 #include <src/listoper.h>               /* operations for generic lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/vecffe.h>                 /* functions for fin field vectors */
 

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -44,7 +44,6 @@
 #include <src/opers.h>                  /* for TRY_NEXT_METHOD */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 #include <assert.h>
 

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -37,6 +37,7 @@
 #include <src/code.h>                   /* Needed for TakeInterrupt */
 #include <src/stats.h>
 
+#include <src/hpc/guards.h>
 
 #include <assert.h>
 

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -2144,8 +2144,6 @@ Obj FuncELMS_GF2VEC (
 **  and that <elm> is not 0.
 */
 
-static Obj ConvertToVectorRep;	/* BH: changed to static */
-
 Obj FuncASS_GF2VEC (
     Obj                 self,
     Obj                 list,
@@ -4783,7 +4781,6 @@ static Int InitKernel (
     /* init filters and functions                                          */
     InitHdlrFuncsFromTable( GVarFuncs );
 
-    InitFopyGVar("ConvertToVectorRep", &ConvertToVectorRep);
     InitFopyGVar("IsLockedRepresentationVector", &IsLockedRepresentationVector);
 
     /* return success                                                      */

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -38,7 +38,6 @@
 #include <src/stats.h>
 
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <assert.h>
 

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -37,7 +37,6 @@
 #include <src/code.h>                   /* Needed for TakeInterrupt */
 #include <src/stats.h>
 
-#include <src/hpc/thread.h>             /* threads */
 
 #include <assert.h>
 

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1,5 +1,4 @@
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -23,7 +23,6 @@
 #include <src/plist.h>                  /* plain lists */
 #include <src/range.h>                  /* ranges */
 #include <src/blister.h>                /* boolean lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/vecgf2.h>                 /* GF2 vectors */
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -46,7 +46,6 @@
 #include <src/range.h>                  /* ranges */
 
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 #include <assert.h>
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -17,7 +17,6 @@
 **  vector flag and the compact representation of vectors over finite fields.
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/vector.c
+++ b/src/vector.c
@@ -41,8 +41,6 @@
 
 #include <src/vector.h>                 /* functions for plain vectors */
 
-#include <src/range.h>                  /* ranges */
-
 #include <src/code.h>                   /* coder */
 
 #include <assert.h>

--- a/src/vector.c
+++ b/src/vector.c
@@ -38,7 +38,6 @@
 #include <src/lists.h>                  /* generic lists */
 #include <src/listoper.h>               /* operations for generic lists */
 #include <src/plist.h>                  /* plain lists */
-#include <src/stringobj.h>              /* strings */
 
 #include <src/vector.h>                 /* functions for plain vectors */
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -47,7 +47,6 @@
 
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #include <assert.h>
 

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -16,7 +16,6 @@
 **  in some other kind of object). 
 */
 #include <src/system.h>                 /* system dependent part */
-#include <src/gapstate.h>
 
 
 #include <src/gasman.h>                 /* garbage collector */

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -40,7 +40,6 @@
 #include <src/scanner.h>                /* scanner */
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
-#include <src/hpc/tls.h>                /* thread-local storage */
 
 #ifdef BOEHM_GC
 # ifdef HPCGAP

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -39,6 +39,7 @@
 
 #include <src/scanner.h>                /* scanner */
 #include <src/code.h>                   /* coder */
+#include <src/hpc/guards.h>
 
 #ifdef BOEHM_GC
 # ifdef HPCGAP

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -39,7 +39,6 @@
 
 #include <src/scanner.h>                /* scanner */
 #include <src/code.h>                   /* coder */
-#include <src/hpc/thread.h>             /* threads */
 
 #ifdef BOEHM_GC
 # ifdef HPCGAP


### PR DESCRIPTION
My goal is to get rid of as many pointless includes as possible, so that if one changes a header file, as few C files as possible need to be recompiled.

For example, gapstate.h goes from 66 to 37 C files including it. Computed with the following command (run it in the build dir):
```bash
find obj -name "*.d" | xargs cat | fgrep .h: | fgrep -v extern | sort | uniq -c
```