### PR TITLE
Resolve issue #1652 (missing info in ErrorMayQuit)

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -1432,7 +1432,8 @@ void ErrorMayQuit (
     Int                 arg1,
     Int                 arg2)
 {
-  CallErrorInner(msg, arg1, arg2, 0, 0,0, False, 1);
+  Obj LateMsg = MakeString("type 'quit;' to quit to outer loop");
+  CallErrorInner(msg, arg1, arg2, 0, 0, 0, LateMsg, 1);
  
 }
 


### PR DESCRIPTION
This resolves Issue #1652.

Previously, `ErrorMayQuit` called `CallErrorInner` with the `LateMsg` arg set to `False`, so nothing was printed. Therefore, the user wasn't told how to exit the break loop. To fix this, I now pass the same string that is used by `ErrorNoReturn`.

I'm not sure how I'd write tests for this.