### PR TITLE
Slightly nicer Error message for InstallGlobalFunction

### DIFF
--- a/hpcgap/lib/oper.g
+++ b/hpcgap/lib/oper.g
@@ -1805,6 +1805,10 @@ BIND_GLOBAL( "InstallGlobalFunction", function( arg )
         func := arg[2];
     fi;
     if IS_STRING( oper ) then
+      # Can't use IsBoundGlobal yet in early loading
+      if not ISBOUND_GLOBAL(oper) then
+        Error("global function `", oper, "' is not declared yet");
+      fi;
       oper:= VALUE_GLOBAL( oper );
     fi;
     atomic readonly GLOBAL_FUNCTION_NAMES do

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1781,6 +1781,9 @@ BIND_GLOBAL( "InstallGlobalFunction", function( arg )
         func := arg[2];
     fi;
     if IS_STRING( oper ) then
+      if not ISBOUND_GLOBAL(oper) then
+        Error("global function `", oper, "' is not declared yet");
+      fi;
       oper:= VALUE_GLOBAL( oper );
     fi;
     if NAME_FUNC(func) in GLOBAL_FUNCTION_NAMES then

--- a/tst/testinstall/function.tst
+++ b/tst/testinstall/function.tst
@@ -184,4 +184,8 @@ function (  )
 end
 
 #
+gap> InstallGlobalFunction("CheeseCakeFunction123123", function() end);
+Error, global function `CheeseCakeFunction123123' is not declared yet
+
+#
 gap> STOP_TEST("function.tst", 1);


### PR DESCRIPTION
If `InstallGlobalFunction` is called with a string as
the function name, we display a slightly more helpful
error message if the function name has not been declared
yet.