### PR TITLE
Add NumberColumns and NumberRows to MatrixObj interface

### DIFF
--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1032,8 +1032,10 @@ InstallMethod( BaseDomain, "for an 8bit vector",
   [ Is8BitVectorRep ], function( v ) return GF(Q_VEC8BIT(v)); end );
 InstallMethod( BaseDomain, "for an 8bit matrix",
   [ Is8BitMatrixRep ], function( m ) return GF(Q_VEC8BIT(m[1])); end );
+InstallMethod( NumberRows, "for an 8bit matrix",
+  [ Is8BitMatrixRep ], m -> m![1]);
 # FIXME: this breaks down for matrices with 0 rows
-InstallMethod( RowLength, "for an 8bit matrix",
+InstallMethod( NumberColumns, "for an 8bit matrix",
   [ Is8BitMatrixRep ], function( m ) return Length(m[1]); end );
 # FIXME: this breaks down for matrices with 0 rows
 InstallMethod( Vector, "for a plist of finite field elements and an 8bitvector",

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2331,7 +2331,9 @@ InstallMethod( BaseDomain, "for a gf2 vector",
   [ IsGF2VectorRep ], function( v ) return GF(2); end );
 InstallMethod( BaseDomain, "for a gf2 matrix",
   [ IsGF2MatrixRep ], function( m ) return GF(2); end );
-InstallMethod( RowLength, "for a gf2 matrix",
+InstallMethod( NumberRows, "for a gf2 matrix",
+  [ IsGF2MatrixRep ], m -> m![1]);
+InstallMethod( NumberColumns, "for a gf2 matrix",
   [ IsGF2MatrixRep ], function( m ) return Length(m[1]); end );
 # FIXME: this breaks down for matrices with 0 rows
 InstallMethod( Vector, "for a list of gf2 elements and a gf2 vector",

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -61,7 +61,7 @@ InstallMethod( Unfold, "for a matrix object, and a vector object",
     if Length(m) = 0 then
         return ZeroVector(0,w);
     else
-        l := RowLength(m);
+        l := NumberColumns(m);
         v := ZeroVector(Length(m)*l,w);
         for i in [1..Length(m)] do
             CopySubVector( m[i], v, [1..l], [(i-1)*l+1..i*l] );
@@ -114,10 +114,10 @@ InstallMethod( KroneckerProduct, "for two matrices",
         ErrorNoReturn("KroneckerProduct: Matrices not over same base domain");
     fi;
 
-    rowsA := Length(A);
-    colsA := RowLength(A);
-    rowsB := Length(B);
-    colsB := RowLength(B);
+    rowsA := NumberRows(A);
+    colsA := NumberColumns(A);
+    rowsB := NumberRows(B);
+    colsB := NumberColumns(B);
 
     AxB := ZeroMatrix( rowsA * rowsB, colsA * colsB, A );
 
@@ -239,13 +239,20 @@ InstallMethod( TraceMat, "generic method",
     local bd,i,s;
     bd := BaseDomain(m);
     s := Zero(bd);
-    if Length(m) <> RowLength(m) then
+    if NumberRows(m) <> NumberColumns(m) then
         Error("matrix must be square");
         return fail;
     fi;
-    for i in [1..Length(m)] do
+    for i in [1..NumberRows(m)] do
         s := s + MatElm(m,i,i);
     od;
     return s;
   end );
 
+#
+# Compatibility code: Install MatrixObj methods for IsMatrix.
+#
+InstallOtherMethod( NumberRows, "for a plist matrix",
+  [ IsMatrix ], Length);
+InstallOtherMethod( NumberColumns, "for a plist matrix",
+  [ IsMatrix ], m -> Length(m[1]) );

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -373,12 +373,16 @@ DeclareAttribute( "BaseDomain", IsMatrixObj );
 # nor associative. For non-associative base domains, the behavior of
 # powering matrices is undefined.
 
-DeclareAttribute( "Length", IsMatrixObj );
-# We have to declare this since matrix objects need not be lists.
-# We have to use InstallOtherMethod for those matrix types that are
-# lists.
+DeclareAttribute( "NumberRows", IsMatrixObj );
+DeclareAttribute( "NumberColumns", IsMatrixObj );
+DeclareSynonym( "NrRows", NumberRows );
+DeclareSynonym( "NrCols", NumberColumns );
 
-DeclareAttribute( "RowLength", IsMatrixObj );
+# HACK: Length and RowLength were in the old version of MatrixObj. We want
+# to get rid of them, but for now, keep thm to allow the few packages
+# already using this to continue working.
+DeclareAttribute( "Length", IsMatrixObj ); # ????
+DeclareSynonym( "RowLength", NumberColumns );
 
 DeclareAttribute( "DimensionsMat", IsMatrixObj );   # returns [rows,cols]
 

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -729,13 +729,13 @@ InstallMethod( BaseDomain, "for a plist matrix",
     return m![BDPOS];
   end );
 
-InstallMethod( Length, "for a plist matrix",
+InstallMethod( NumberRows, "for a plist matrix",
   [ IsPlistMatrixRep ],
   function( m )
     return Length(m![ROWSPOS]);
   end );
 
-InstallMethod( RowLength, "for a plist matrix",
+InstallMethod( NumberColumns, "for a plist matrix",
   [ IsPlistMatrixRep ],
   function( m )
     return m![RLPOS];
@@ -1218,7 +1218,7 @@ InstallMethod( PrintObj, "for a plist matrix", [ IsPlistMatrixRep ],
     else
         Print(",",String(m![BDPOS]),",");
     fi;
-    Print(RowLength(m),",",Unpack(m),")");
+    Print(NumberColumns(m),",",Unpack(m),")");
   end );
 
 InstallMethod( Display, "for a plist matrix", [ IsPlistMatrixRep ],
@@ -1255,7 +1255,7 @@ InstallMethod( String, "for plist matrix", [ IsPlistMatrixRep ],
         Append(st,String(m![BDPOS]));
         Append(st,",");
     fi;
-    Append(st,String(RowLength(m)));
+    Append(st,String(NumberColumns(m)));
     Add(st,',');
     Append(st,String(Unpack(m)));
     Add(st,')');
@@ -1783,21 +1783,21 @@ InstallMethod( ChangedBaseDomain, "for a checking plist vector, and a domain",
 InstallMethod( ChangedBaseDomain, "for a plist matrix, and a domain",
   [ IsPlistMatrixRep, IsRing ],
   function( m, r )
-    return NewMatrix(IsPlistMatrixRep, r, RowLength(m),
+    return NewMatrix(IsPlistMatrixRep, r, NumberColumns(m),
                      List(m![ROWSPOS], x-> x![ELSPOS]));
   end );
 
 InstallMethod( ChangedBaseDomain, "for a checking plist matrix, and a domain",
   [ IsPlistMatrixRep and IsCheckingMatrix, IsRing ],
   function( m, r )
-    return NewMatrix(IsPlistMatrixRep and IsCheckingMatrix, r, RowLength(m),
+    return NewMatrix(IsPlistMatrixRep and IsCheckingMatrix, r, NumberColumns(m),
                      List(m![ROWSPOS], x-> x![ELSPOS]));
   end );
 
 InstallMethod( CompatibleVector, "for a plist matrix",
   [ IsPlistMatrixRep ],
   function( v )
-    return NewZeroVector(IsPlistVectorRep,BaseDomain(v),Length(v));
+    return NewZeroVector(IsPlistVectorRep,BaseDomain(v),NumberRows(v));
   end );
 
 InstallMethod( NewCompanionMatrix,

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -989,8 +989,10 @@ InstallMethod( BaseDomain, "for an 8bit vector",
   [ Is8BitVectorRep ], function( v ) return GF(Q_VEC8BIT(v)); end );
 InstallMethod( BaseDomain, "for an 8bit matrix",
   [ Is8BitMatrixRep ], function( m ) return GF(Q_VEC8BIT(m[1])); end );
+InstallMethod( NumberRows, "for an 8bit matrix",
+  [ Is8BitMatrixRep ], m -> m![1]);
 # FIXME: this breaks down for matrices with 0 rows
-InstallMethod( RowLength, "for an 8bit matrix",
+InstallMethod( NumberColumns, "for an 8bit matrix",
   [ Is8BitMatrixRep ], function( m ) return Length(m[1]); end );
 # FIXME: this breaks down for matrices with 0 rows
 InstallMethod( Vector, "for a plist of finite field elements and an 8bitvector",

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2126,7 +2126,9 @@ InstallMethod( BaseDomain, "for a gf2 vector",
   [ IsGF2VectorRep ], function( v ) return GF(2); end );
 InstallMethod( BaseDomain, "for a gf2 matrix",
   [ IsGF2MatrixRep ], function( m ) return GF(2); end );
-InstallMethod( RowLength, "for a gf2 matrix",
+InstallMethod( NumberRows, "for a gf2 matrix",
+  [ IsGF2MatrixRep ], m -> m![1]);
+InstallMethod( NumberColumns, "for a gf2 matrix",
   [ IsGF2MatrixRep ], function( m ) return Length(m[1]); end );
 # FIXME: this breaks down for matrices with 0 rows
 InstallMethod( Vector, "for a list of gf2 elements and a gf2 vector",


### PR DESCRIPTION
These are meant to be used instead of Length and RowLength.
We retain RowLength for now, to keep existing code (and packages!)
working, but the plan is to remove this eventually.

Also provide default implementations of both for IsMatrix.
