### PR TITLE
More informative error for ReadAndCheckFunc

### DIFF
--- a/hpcgap/lib/init.g
+++ b/hpcgap/lib/init.g
@@ -330,6 +330,7 @@ BIND_GLOBAL("ReadAndCheckFunc",function( arg )
         local  name,  ext,  libname, error;
 
         name := arg[1];
+
         # create a filename from <path> and <name>
         libname := SHALLOW_COPY_OBJ(path);
         APPEND_LIST_INTR( libname, "/" );
@@ -339,7 +340,7 @@ BIND_GLOBAL("ReadAndCheckFunc",function( arg )
 
         if error then
           if LEN_LIST( arg )=1 then
-            Error( "the library file '", name, "' must exist and ",
+            Error( "the library file '", libname, "' must exist and ",
                    "be readable");
           else
             return false;

--- a/lib/init.g
+++ b/lib/init.g
@@ -311,6 +311,7 @@ BIND_GLOBAL("ReadAndCheckFunc",function( arg )
         local  name,  ext,  libname, error;
 
         name := arg[1];
+
         # create a filename from <path> and <name>
         libname := SHALLOW_COPY_OBJ(path);
         APPEND_LIST_INTR( libname, "/" );
@@ -320,7 +321,7 @@ BIND_GLOBAL("ReadAndCheckFunc",function( arg )
 
         if error then
           if LEN_LIST( arg )=1 then
-            Error( "the library file '", name, "' must exist and ",
+            Error( "the library file '", libname, "' must exist and ",
                    "be readable");
           else
             return false;


### PR DESCRIPTION
If `ReadAndCheckFunc` cannot find a library file it now displays the full
path where it looked.