### PR TITLE
fixed an error in the default method for PositionNot

### DIFF
--- a/lib/kernel.g
+++ b/lib/kernel.g
@@ -168,8 +168,11 @@ POSITION_NOT := function( arg )
                 return i;
             fi;
         od;
-        return LENGTH(arg[1]) + 1;
-
+        if LENGTH( arg[1] ) <= arg[3] then
+          return arg[3] + 1;
+        else
+          return LENGTH(arg[1]) + 1;
+        fi;
     else
       Error( "usage: PositionNot( <list>, <val>[, <from>] )" );
     fi;

--- a/tst/testinstall/listgen.tst
+++ b/tst/testinstall/listgen.tst
@@ -46,6 +46,22 @@ gap> PositionBound( [ ,,,, 1 ] );
 5
 gap> PositionBound( [] );
 fail
+gap> PositionNot( [ 2, 1 ], 1 );
+1
+gap> PositionNot( [ 1, 2 ], 1 );
+2
+gap> PositionNot( [ 1, 1 ], 1 );
+3
+gap> PositionNot( [ 1, 1 ], 1, 3 );
+4
+gap> PositionNonZero( [ 1, 1 ] );
+1
+gap> PositionNonZero( [ 0, 1 ] );
+2
+gap> PositionNonZero( [ 0, 0 ] );
+3
+gap> PositionNonZero( [ 0, 0 ], 3 );
+4
 gap> l:= [ 1 .. 10 ];;
 gap> SortParallel( [ 2, 3, 4, 1, 5, 10, 9, 7, 8, 6 ], l );
 gap> l;


### PR DESCRIPTION
fixed an error in the default method for PositionNot (and PositionNonZero),
in the case that the given 'from' value is larger than the length of the list