### PR TITLE
Improvements to reesmat code and new tests

### DIFF
--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -77,15 +77,21 @@ end);
 InstallMethod(IsIdempotent, "for a Rees 0-matrix semigroup element",
 [IsReesZeroMatrixSemigroupElement], 
 function(x)
-  local R;
+  local matrix_entry, g;
 
-  R:=ReesMatrixSemigroupOfFamily(FamilyObj(x));
-  if IsGroup(UnderlyingSemigroup(R)) then 
-    # only for RZMS over groups!
-    return x![1]=0 or x![2]^-1=x![4][x![3]][x![1]];
-  else 
-    return x ^ 2 = x;
+  if x![1] = 0 then
+    # <x> is the 0 element of the family
+    return true;
   fi;
+
+  matrix_entry := x![4][x![3]][x![1]];
+
+  if matrix_entry = 0 then
+    return false;
+  fi;
+
+  g := UnderlyingElementOfReesZeroMatrixSemigroupElement(x);
+  return g * matrix_entry * g = g;
 end);
 
 #

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -201,11 +201,11 @@ function(R)
     return false; #Rees 0-matrix semigroups always contain the 0.
   fi;
   
-  gens:=GeneratorsOfSemigroup(R);
+  gens := Unique(GeneratorsOfSemigroup(R));
   pos:=Position(gens, MultiplicativeZero(R));
   if pos<>fail then 
     if Size(gens) = 1 then
-      return Size(ParentAttr(R)) = 1;
+      return false;
     fi;
     gens:=ShallowCopy(gens);
     Remove(gens, pos);

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -33,7 +33,11 @@
 InstallImmediateMethod(IsFinite, IsReesZeroMatrixSubsemigroup, 0,
 function(R)
   if IsBound(ElementsFamily(FamilyObj(R))!.IsFinite) then
-    return ElementsFamily(FamilyObj(R))!.IsFinite;
+    if HasIsWholeFamily(R) and IsWholeFamily(R) then
+      return ElementsFamily(FamilyObj(R))!.IsFinite;
+    elif ElementsFamily(FamilyObj(R))!.IsFinite then
+      return true;
+    fi;
   fi;
   TryNextMethod();
 end);
@@ -41,16 +45,11 @@ end);
 InstallImmediateMethod(IsFinite, IsReesMatrixSubsemigroup, 0,
 function(R)
   if IsBound(ElementsFamily(FamilyObj(R))!.IsFinite) then
-    return ElementsFamily(FamilyObj(R))!.IsFinite;
-  fi;
-  TryNextMethod();
-end);
-
-InstallMethod(IsFinite, "for a Rees matrix subsemigroup",
-[IsReesMatrixSubsemigroup], 
-function(R)
-  if (not IsIdenticalObj(R, ParentAttr(R))) and HasIsFinite(ParentAttr(R)) then 
-    return IsFinite(ParentAttr(R));
+    if HasIsWholeFamily(R) and IsWholeFamily(R) then
+      return ElementsFamily(FamilyObj(R))!.IsFinite;
+    elif ElementsFamily(FamilyObj(R))!.IsFinite then
+      return true;
+    fi;
   fi;
   TryNextMethod();
 end);
@@ -58,8 +57,17 @@ end);
 InstallMethod(IsFinite, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup], 
 function(R)
-  if (not IsIdenticalObj(R, ParentAttr(R))) and HasIsFinite(ParentAttr(R)) then 
-    return IsFinite(ParentAttr(R));
+  if HasIsFinite(ParentAttr(R)) and IsFinite(ParentAttr(R))then 
+    return true;
+  fi;
+  TryNextMethod();
+end);
+
+InstallMethod(IsFinite, "for a Rees matrix subsemigroup",
+[IsReesMatrixSubsemigroup], 
+function(R)
+  if HasIsFinite(ParentAttr(R)) and IsFinite(ParentAttr(R)) then 
+    return true;
   fi;
   TryNextMethod();
 end);

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -742,7 +742,12 @@ x-> x![1]);
 
 InstallMethod(RowOfReesZeroMatrixSemigroupElement, 
 "for a Rees 0-matrix semigroup element", [IsReesZeroMatrixSemigroupElement], 
-x-> x![1]);
+function(x)
+  if x![1] = 0 then
+    return fail;
+  fi;
+  return x![1];
+end);
 
 #
 
@@ -754,7 +759,12 @@ x-> x![2]);
 
 InstallMethod(UnderlyingElementOfReesZeroMatrixSemigroupElement, 
 "for a Rees 0-matrix semigroup element", [IsReesZeroMatrixSemigroupElement], 
-x-> x![2]);
+function(x)
+  if x![1] = 0 then
+    return fail;
+  fi;
+  return x![2];
+end);
 
 #
 
@@ -766,7 +776,12 @@ x-> x![3]);
 
 InstallMethod(ColumnOfReesZeroMatrixSemigroupElement, 
 "for a Rees 0-matrix semigroup element", [IsReesZeroMatrixSemigroupElement], 
-x-> x![3]);
+function(x)
+  if x![1] = 0 then
+    return fail;
+  fi;
+  return x![3];
+end);
 
 #
 
@@ -819,7 +834,7 @@ InstallMethod(ELM_LIST, "for a Rees matrix semigroup element",
 [IsReesMatrixSemigroupElement, IsPosInt], 
 function(x, i)
   if i > 3 then 
-    ErrorNoReturn("the second argument must equal 1, 2, or 3");
+    ErrorNoReturn("the second argument must be 1, 2, or 3");
   fi;
   return x![i];
 end);

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -129,20 +129,13 @@ R-> IsSimpleSemigroup(UnderlyingSemigroup(R)));
 InstallMethod(IsZeroSimpleSemigroup, "for a Rees 0-matrix semigroup", 
 [IsReesZeroMatrixSemigroup],
 function(R)
-  local i;
+  local i, mat;
 
-  for i in Columns(R) do 
-    if ForAll(Rows(R), j-> Matrix(R)[i][j]=0) then 
-      return false;
-    fi;
-  od;
-  
-  for i in Rows(R) do 
-    if ForAll(Columns(R), j-> Matrix(R)[j][i]=0) then 
-      return false;
-    fi;
-  od;
-  
+  mat := Matrix(R);
+  if ForAny(Columns(R), j -> ForAll(Rows(R), i -> mat[j][i] = 0))
+      or ForAny(Rows(R), i -> ForAll(Columns(R), j -> mat[j][i] = 0)) then 
+    return false;
+  fi;
   return IsSimpleSemigroup(UnderlyingSemigroup(R));
 end);
 

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -276,9 +276,10 @@ InstallMethod(ReesZeroMatrixSemigroup, "for a semigroup and a dense list",
 function(S, mat)
   local fam, R, type, x;
 
-  if not ForAll(mat, x -> IsDenseList(x) and Length(x) = Length(mat[1])) then
-    ErrorNoReturn("the entries of the second argument (a list) must be ",
-                  "lists of equal length");
+  if IsEmpty(mat) or not ForAll(mat, x -> IsDenseList(x) and not IsEmpty(x)
+                                          and Length(x) = Length(mat[1])) then
+    ErrorNoReturn("the second argument must be a non-empty list, whose ",
+                  "entries are non-empty lists of equal length");
   fi;
 
   for x in mat do

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -479,6 +479,9 @@ function( R )
        Enumerator(UnderlyingSemigroup(R)), Columns(R), [Matrix(R)]),
     
     NumberElement:=function(enum, x)
+      if FamilyObj(x) <> ElementsFamily(FamilyObj(R)) then
+        return fail;
+      fi;
       return Position(enum!.enum, [x![1], x![2], x![3], x![4]]);
     end,
     
@@ -507,7 +510,10 @@ function( R )
     
     NumberElement:=function(enum, x)
       local pos;
-      if IsMultiplicativeZero(R, x) then 
+
+      if FamilyObj(x) <> ElementsFamily(FamilyObj(R)) then
+        return fail;
+      elif IsMultiplicativeZero(R, x) then 
         return 1;
       fi;
       

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -90,40 +90,6 @@ end);
 
 #
 
-InstallMethod(IsOne, "for a Rees matrix semigroup element", 
-[IsReesMatrixSemigroupElement],
-function(x)
-  local R;
-  R:=ReesMatrixSemigroupOfFamily(FamilyObj(x));
-  if IsIdempotent(x) then 
-    if Length(Rows(R))=1 and Length(Columns(R))=1 then 
-      return true;
-    else 
-      return ForAll(GeneratorsOfSemigroup(R), y-> x*y=y and y*x=y);
-    fi;
-  fi;
-  return false;
-end);
-
-#
-
-InstallMethod(IsOne, "for a Rees 0-matrix semigroup element", 
-[IsReesZeroMatrixSemigroupElement],
-function(x)
-  local R;
-  R:=ReesMatrixSemigroupOfFamily(FamilyObj(x));
-  if IsIdempotent(x) then 
-    if Length(Rows(R))=1 and Length(Columns(R))=1 then 
-      return true;
-    else 
-      return ForAll(GeneratorsOfSemigroup(R), y-> x*y=y and y*x=y);
-    fi;
-  fi;
-  return false;
-end);
-
-#
-
 InstallTrueMethod(IsRegularSemigroup, 
 IsReesMatrixSemigroup and IsSimpleSemigroup);
 

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -104,9 +104,13 @@ IsReesMatrixSemigroup and IsSimpleSemigroup);
 InstallMethod(IsRegularSemigroup, "for a Rees 0-matrix semigroup",
 [IsReesZeroMatrixSemigroup], 
 function(R)
-  if IsGroup(UnderlyingSemigroup(R)) then 
-    return ForAll(Rows(R), i-> ForAny(Columns(R), j-> Matrix(R)[j][i]<>0))
-     and ForAll(Columns(R), j-> ForAny(Rows(R), i-> Matrix(R)[j][i]<>0));
+  local mat;
+
+  mat := Matrix(R);
+  if HasIsGroupAsSemigroup(UnderlyingSemigroup(R))
+      and IsGroupAsSemigroup(UnderlyingSemigroup(R)) then 
+    return ForAll(Rows(R), i -> ForAny(Columns(R), j -> mat[j][i]<>0))
+      and ForAll(Columns(R), j -> ForAny(Rows(R), i -> mat[j][i]<>0));
   else
     TryNextMethod();
   fi;

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -153,9 +153,6 @@ function(R)
   
   if IsWholeFamily(R) then 
     return true;
-  elif IsSimpleSemigroup(UnderlyingSemigroup(ParentAttr(R))) 
-   and not IsSimpleSemigroup(R) then 
-    return false;
   fi;
   
   # it is still possible that <R> is a Rees matrix semigroup, if, for example,

--- a/tst/testbugfix/2017-09-06-reesmat.tst
+++ b/tst/testbugfix/2017-09-06-reesmat.tst
@@ -1,0 +1,35 @@
+# Bug in IsFinite
+# Example reported on issue #1659 on github.com/gap-system/gap
+gap> F := FreeSemigroup(1);;
+gap> R := ReesZeroMatrixSemigroup(F, [[F.1]]);;
+gap> S := Semigroup(MultiplicativeZero(R));;
+gap> IsFinite(S);
+true
+gap> A := ReesMatrixSemigroup(R, [[MultiplicativeZero(R)]]);;
+gap> B := Semigroup(RMSElement(A, 1, MultiplicativeZero(R), 1));;
+gap> IsFinite(B);
+true
+
+# Bug in IsReesZeroMatrixSemigroup
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
+gap> T := Semigroup(MultiplicativeZero(R), MultiplicativeZero(R));;
+gap> IsReesZeroMatrixSemigroup(T);
+false
+
+# Bug in Enumerator for a RMS
+gap> R := ReesMatrixSemigroup(Group(()), [[()]]);;
+gap> S := ReesMatrixSemigroup(SymmetricGroup(2), [[()]]);;
+gap> x := RMSElement(S, 1, (), 1);;
+gap> x in R;
+false
+gap> Position(Enumerator(R), x);
+fail
+
+# Bug in Enumerator for a RZMS
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
+gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(2), [[()]]);;
+gap> x := RMSElement(S, 1, (), 1);;
+gap> x in R;
+false
+gap> Position(Enumerator(R), x);
+fail

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -262,5 +262,22 @@ gap> S := Semigroup(RMSElement(R, 1, (), 1), MultiplicativeZero(R));
 gap> IsReesZeroMatrixSemigroup(S);
 true
 
+# ReesZeroMatrixSemigroup: for a semigroup and a dense list
+gap> ReesZeroMatrixSemigroup(Group(()), []);
+Error, the second argument must be a non-empty list, whose entries are non-emp\
+ty lists of equal length
+gap> ReesZeroMatrixSemigroup(Group(()), [[]]);
+Error, the second argument must be a non-empty list, whose entries are non-emp\
+ty lists of equal length
+gap> ReesZeroMatrixSemigroup(Group(()), [[1, 2], []]);
+Error, the second argument must be a non-empty list, whose entries are non-emp\
+ty lists of equal length
+gap> ReesZeroMatrixSemigroup(Group(()), [[1, 2, 3], [1, 2, 3], [1,, 3]]);
+Error, the second argument must be a non-empty list, whose entries are non-emp\
+ty lists of equal length
+gap> ReesZeroMatrixSemigroup(Group(()), [[1]]);
+Error, the entries of the second argument must be 0 or belong to the first arg\
+ument (a semigroup)
+
 #
 gap> STOP_TEST("reesmat.tst");

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -226,6 +226,25 @@ gap> R := ReesZeroMatrixSemigroup(S, [[One(S)]]);
 gap> IsRegularSemigroup(R);
 true
 
+# IsSimpleSemigroup: for a Rees matrix subsemigroup with an underlying semigroup
+gap> S := FullTransformationMonoid(2);
+<full transformation monoid of degree 2>
+gap> R := ReesMatrixSemigroup(S, [[One(S)]]);
+<Rees matrix semigroup 1x1 over <full transformation monoid of degree 2>>
+gap> IsSimpleSemigroup(R);
+false
+gap> S := Semigroup([Transformation([1, 1]), Transformation([2, 2])]);
+<transformation semigroup of degree 2 with 2 generators>
+gap> R := ReesMatrixSemigroup(S, [[S.1, S.2]]);
+<Rees matrix semigroup 2x1 over <transformation semigroup of degree 2 with 2 
+  generators>>
+gap> IsSimpleSemigroup(R);
+true
+gap> T := Semigroup(RMSElement(R, 2, S.1, 1));
+<subsemigroup of 2x1 Rees matrix semigroup with 1 generator>
+gap> IsSimpleSemigroup(T);
+true
+
 # IsZeroSimpleSemigroup: for a Rees 0-matrix semigroup
 gap> S := Semigroup([Transformation([1, 1]), Transformation([2, 2])]);
 <transformation semigroup of degree 2 with 2 generators>
@@ -311,6 +330,11 @@ gap> S := Semigroup(RMSElement(R, 1, (), 1), MultiplicativeZero(R));
 gap> IsReesZeroMatrixSemigroup(S);
 true
 
+# ReesMatrixSemigroup: for a semigroup and a rectangular table, 1
+gap> ReesMatrixSemigroup(SymmetricGroup(2), [[PartialPerm([0])]]);
+Error, the entries of the second argument (a rectangular table) must belong to\
+ the first argument (a semigroup)
+
 # ReesZeroMatrixSemigroup: for a semigroup and a dense list
 gap> ReesZeroMatrixSemigroup(Group(()), []);
 Error, the second argument must be a non-empty list, whose entries are non-emp\
@@ -327,6 +351,52 @@ ty lists of equal length
 gap> ReesZeroMatrixSemigroup(Group(()), [[1]]);
 Error, the entries of the second argument must be 0 or belong to the first arg\
 ument (a semigroup)
+
+# PrintObj: for a Rees matrix semigroup
+gap> R := ReesMatrixSemigroup(Group(()), [[()]]);
+<Rees matrix semigroup 1x1 over Group(())>
+gap> PrintObj(R); Print("\n");
+ReesMatrixSemigroup( Group( [ () ] ), [ [ () ] ] )
+
+# PrintObj: for a Rees 0-matrix semigroup
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);
+<Rees 0-matrix semigroup 1x1 over Group(())>
+gap> PrintObj(R); Print("\n");
+ReesZeroMatrixSemigroup( Group( [ () ] ), [ [ () ] ] )
+
+# Size: for a Rees matrix semigroup
+gap> Size(ReesMatrixSemigroup(SymmetricGroup(3), [[()], [()]]));
+12
+gap> F := FreeSemigroup(1);;
+gap> Size(ReesMatrixSemigroup(F, [[F.1]]));
+infinity
+gap> F := FreeSemigroup(2);;
+gap> S := F / [[F.1, F.1], [F.1, F.1]];
+<fp semigroup on the generators [ s1, s2 ]>
+gap> R := ReesMatrixSemigroup(S, [[S.1]]);
+<Rees matrix semigroup 1x1 over <fp semigroup on the generators [ s1, s2 ]>>
+gap> HasIsFinite(S);
+false
+gap> SetIsFinite(S, false);
+gap> Size(R);
+infinity
+
+# Size: for a Rees 0-matrix semigroup
+gap> Size(ReesZeroMatrixSemigroup(SymmetricGroup(3), [[()], [()]]));
+13
+gap> F := FreeSemigroup(1);;
+gap> Size(ReesZeroMatrixSemigroup(F, [[F.1]]));
+infinity
+gap> F := FreeSemigroup(2);;
+gap> S := F / [[F.1, F.1], [F.1, F.1]];
+<fp semigroup on the generators [ s1, s2 ]>
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1]]);
+<Rees 0-matrix semigroup 1x1 over <fp semigroup on the generators [ s1, s2 ]>>
+gap> HasIsFinite(S);
+false
+gap> SetIsFinite(S, false);
+gap> Size(R);
+infinity
 
 # Enumerator: for a Rees matrix semigroup
 gap> R := ReesMatrixSemigroup(SymmetricGroup(2), [[()]]);
@@ -371,6 +441,475 @@ gap> SetUnderlyingSemigroup(T, Group(()));
 gap> enum := Enumerator(T);;
 gap> Position(enum, RMSElement(R, 1, (1,2), 1));
 fail
+
+# Matrix, Rows, Columns, UnderlyingSemigroup:
+# for a Rees 0-matrix subsemigroup with generators
+gap> R := ReesMatrixSemigroup(Group((1,2)), [[(1,2), ()]]);;
+gap> T := Semigroup(RMSElement(R, 2, (), 1));
+<subsemigroup of 2x1 Rees matrix semigroup with 1 generator>
+gap> Matrix(T);
+[ [ (1,2), () ] ]
+gap> Rows(T);
+[ 2 ]
+gap> Columns(T);
+[ 1 ]
+gap> UnderlyingSemigroup(T);
+Group(())
+gap> T := Semigroup(RMSElement(R, 2, (), 1), RMSElement(R, 2, (1,2), 1));
+<subsemigroup of 2x1 Rees matrix semigroup with 2 generators>
+gap> UnderlyingSemigroup(T);
+Group([ (1,2) ])
+gap> S := Semigroup(RMSElement(R, 1, (1,2), 1));
+<subsemigroup of 2x1 Rees matrix semigroup with 1 generator>
+gap> Matrix(S);
+fail
+gap> Rows(S);
+fail
+gap> Columns(S);
+fail
+gap> UnderlyingSemigroup(S);
+fail
+gap> R := ReesMatrixSemigroup(FullTransformationMonoid(2),
+>                             [[IdentityTransformation]]);;
+gap> T := Semigroup(RMSElement(R, 1, Transformation([2, 2]), 1),
+>                   RMSElement(R, 1, Transformation([1, 1]), 1));
+<subsemigroup of 1x1 Rees matrix semigroup with 2 generators>
+gap> UnderlyingSemigroup(T);
+<simple transformation semigroup of degree 2 with 2 generators>
+
+# Matrix, Rows, Columns, UnderlyingSemigroup:
+# for a Rees matrix subsemigroup with generators
+gap> R := ReesZeroMatrixSemigroup(Group((1,2)), [[(1,2), 0]]);;
+gap> T := Semigroup(RMSElement(R, 2, (), 1), MultiplicativeZero(R));
+<subsemigroup of 2x1 Rees 0-matrix semigroup with 2 generators>
+gap> Matrix(T);
+[ [ (1,2), 0 ] ]
+gap> Rows(T);
+[ 2 ]
+gap> Columns(T);
+[ 1 ]
+gap> UnderlyingSemigroup(T);
+Group(())
+gap> T := Semigroup(RMSElement(R, 2, (), 1), RMSElement(R, 2, (1,2), 1));
+<subsemigroup of 2x1 Rees 0-matrix semigroup with 2 generators>
+gap> UnderlyingSemigroup(T);
+Group([ (1,2) ])
+gap> S := Semigroup(RMSElement(R, 1, (1,2), 1), MultiplicativeZero(R));
+<subsemigroup of 2x1 Rees 0-matrix semigroup with 2 generators>
+gap> Matrix(S);
+fail
+gap> Rows(S);
+fail
+gap> Columns(S);
+fail
+gap> UnderlyingSemigroup(S);
+fail
+gap> R := ReesZeroMatrixSemigroup(FullTransformationMonoid(2),
+>                                 [[IdentityTransformation]]);;
+gap> T := Semigroup(RMSElement(R, 1, Transformation([2, 2]), 1),
+>                   RMSElement(R, 1, Transformation([1, 1]), 1),
+>                   MultiplicativeZero(R));
+<subsemigroup of 1x1 Rees 0-matrix semigroup with 3 generators>
+gap> UnderlyingSemigroup(T);
+<transformation semigroup of degree 2 with 2 generators>
+
+# TypeReesMatrixSemigroupElements: for a Rees (0-)matrix semigroup
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
+gap> TypeReesMatrixSemigroupElements(Semigroup(Representative(R)));
+<Type: (ReesZeroMatrixSemigroupElementsFamily, [ IsExtLElement, IsExtRElement,\
+ IsMultiplicativeElement, ... ]), data: fail,>
+gap> R := ReesMatrixSemigroup(Group(()), [[()]]);;
+gap> TypeReesMatrixSemigroupElements(Semigroup(Representative(R)));
+<Type: (ReesMatrixSemigroupElementsFamily, [ IsExtLElement, IsExtRElement, IsM\
+ultiplicativeElement, ... ]), data: fail,>
+
+# RMSElement global function
+gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(2), [[(1,2), 0], [0, ()]]);;
+gap> T := Semigroup(RMSElement(R, 2, (1,2), 1),
+>                   RMSElement(R, 2, (), 1));
+<subsemigroup of 2x2 Rees 0-matrix semigroup with 2 generators>
+gap> RMSElement(SymmetricGroup(2), fail, fail, fail);
+Error, the first argument must be a Rees matrix semigroup or Rees 0-matrix sem\
+igroup
+gap> RMSElement(T, 2, (), 2);
+Error, the arguments do not describe an element of the first argument (a Rees \
+(0-)matrix semigroup)
+gap> RMSElement(T, 2, (), 1);
+(2,(),1)
+gap> IsReesZeroMatrixSemigroup(T);
+true
+gap> RMSElement(T, 1, (), 1);
+Error, the second argument (a positive integer) does not belong to the rows of\
+ the first argument (a Rees (0-)matrix semigroup)
+gap> RMSElement(T, 2, (), 2);
+Error, the fourth argument (a positive integer) does not belong to the columns\
+ of the first argument (a Rees (0-)matrix semigroup)
+gap> RMSElement(T, 2, (1,2,3), 1);
+Error, the second argument does not belong to theunderlying semigroup of the f\
+irst argument (a Rees (0-)matrix semgiroup)
+gap> RMSElement(T, 2, (1,2), 1);
+(2,(1,2),1)
+
+# (Row/Column/UnderlyingElement)OfReesMatrixSemigroupElement
+gap> R := ReesMatrixSemigroup(Group(()), [[()]]);;
+gap> x := Elements(R)[1];
+(1,(),1)
+gap> RowOfReesMatrixSemigroupElement(x);
+1
+gap> ColumnOfReesMatrixSemigroupElement(x);
+1
+gap> UnderlyingElementOfReesMatrixSemigroupElement(x);
+()
+
+# (Row/Column/UnderlyingElement)OfReesZeroMatrixSemigroupElement
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
+gap> x := RMSElement(R, 1, (), 1);
+(1,(),1)
+gap> RowOfReesZeroMatrixSemigroupElement(x);
+1
+gap> ColumnOfReesZeroMatrixSemigroupElement(x);
+1
+gap> UnderlyingElementOfReesZeroMatrixSemigroupElement(x);
+()
+gap> x := MultiplicativeZero(R);
+0
+gap> RowOfReesZeroMatrixSemigroupElement(x);
+fail
+gap> ColumnOfReesZeroMatrixSemigroupElement(x);
+fail
+gap> UnderlyingElementOfReesZeroMatrixSemigroupElement(x);
+fail
+
+# PrintObj: for Rees (0-)matrix semigroup elements
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[0]]);;
+gap> x := RMSElement(R, 1, (), 1);;
+gap> PrintObj(x); Print("\n");
+RMSElement(ReesZeroMatrixSemigroup( Group( [ () ] ), [ [ 0 ] ] ), 1, (), 1)
+gap> PrintObj(MultiplicativeZero(R)); Print("\n");
+MultiplicativeZero(ReesZeroMatrixSemigroup( Group( [ () ] ), [ [ 0 ] ] ))
+gap> R := ReesMatrixSemigroup(Group(()), [[()]]);;
+gap> x := RMSElement(R, 1, (), 1);;
+gap> PrintObj(x); Print("\n");
+RMSElement(ReesMatrixSemigroup( Group( [ () ] ), [ [ () ] ] ), 1, (), 1)
+
+# ELM_LIST: for a Rees (0-)matrix semigroup element
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[0]]);;
+gap> x := RMSElement(R, 1, (), 1);
+(1,(),1)
+gap> x[1];
+1
+gap> x[2];
+()
+gap> x[3];
+1
+gap> x[4];
+Error, the second argument must be 1, 2, or 3
+gap> x := MultiplicativeZero(R);
+0
+gap> x[1];
+Error, the first argument (an element of a Rees 0-matrix semigroup) must be no\
+n-zero
+gap> x[2];
+Error, the first argument (an element of a Rees 0-matrix semigroup) must be no\
+n-zero
+gap> x[3];
+Error, the first argument (an element of a Rees 0-matrix semigroup) must be no\
+n-zero
+gap> x[4];
+Error, the first argument (an element of a Rees 0-matrix semigroup) must be no\
+n-zero
+gap> R := ReesMatrixSemigroup(Group(()), [[()]]);;
+gap> x := RMSElement(R, 1, (), 1);
+(1,(),1)
+gap> x[1];
+1
+gap> x[2];
+()
+gap> x[3];
+1
+gap> x[4];
+Error, the second argument must be 1, 2, or 3
+
+# GeneratorsOfReesMatrixSemigroupNC global function
+gap> R := ReesMatrixSemigroup(SymmetricGroup(5), [[(1,2), (), (3,4,5)],
+>                                                 [(), (), ()]]);
+<Rees matrix semigroup 3x2 over Sym( [ 1 .. 5 ] )>
+gap> GeneratorsOfReesMatrixSemigroupNC(R, [1, 2], Group((1,2)(3,4)), [1]);
+[ (1,(3,4),1), (2,(),1) ]
+gap> Size(Semigroup(last));
+4
+gap> GeneratorsOfReesMatrixSemigroupNC(R, [2], Group(()), [1]);
+[ (2,(),1) ]
+gap> Size(Semigroup(last));
+1
+gap> GeneratorsOfReesMatrixSemigroupNC(R, [1, 2, 3], Group([(1,2), (3,4,5)]),
+>                                      [1, 2]);
+[ (1,(),1), (1,(1,2)(3,4,5),1), (2,(),2), (3,(),1) ]
+gap> Size(Semigroup(last));
+36
+gap> R := ReesMatrixSemigroup(SymmetricGroup(5), TransposedMat(Matrix(R)));
+<Rees matrix semigroup 2x3 over Sym( [ 1 .. 5 ] )>
+gap> GeneratorsOfReesMatrixSemigroupNC(R, [1, 2], Group([(1,2), (3,4,5)]),
+>                                      [1, 2, 3]);
+[ (1,(),1), (1,(1,2)(3,4,5),1), (2,(),2), (1,(),3) ]
+gap> Size(Semigroup(last));
+36
+gap> ReesMatrixSubsemigroupNC(R, [2], Group(()), [2]);
+<subsemigroup of 2x3 Rees matrix semigroup with 1 generator>
+
+# GeneratorsOfReesZeroMatrixSemigroupNC global function
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[(), 0], [0, ()]]);;
+gap> ReesZeroMatrixSubsemigroupNC(R, [1], Group(()), [1, 2]);
+<Rees 0-matrix semigroup 1x2 over Group(())>
+gap> Size(Semigroup(last));
+3
+
+# (GeneratorsOf)ReesMatrixS(ubs)emigroup and GeneratorsOfSemigroup
+gap> R := ReesMatrixSemigroup(Group((1,2)), [[(1,2)]]);
+<Rees matrix semigroup 1x1 over Group([ (1,2) ])>
+gap> T := Semigroup(RMSElement(R, 1, (1,2), 1));
+<subsemigroup of 1x1 Rees matrix semigroup with 1 generator>
+gap> ReesMatrixSubsemigroup(T, [1], Group(()), [1]);
+Error, the first argument must be a Rees matrix semigroup
+gap> GeneratorsOfReesMatrixSemigroup(T, [1], Group(()), [1]);
+Error, the first argument must be a Rees matrix semigroup
+gap> ReesMatrixSubsemigroup(R, [], Group(()), [1]);
+Error, the second argument must be a non-empty subset of the rows of the first\
+ argument (a Rees matrix semigroup)
+gap> GeneratorsOfReesMatrixSemigroup(R, [], Group(()), [1]);
+Error, the second argument must be a non-empty subset of the rows of the first\
+ argument (a Rees matrix semigroup)
+gap> ReesMatrixSubsemigroup(R, [2], Group(()), [1]);
+Error, the second argument must be a non-empty subset of the rows of the first\
+ argument (a Rees matrix semigroup)
+gap> GeneratorsOfReesMatrixSemigroup(R, [2], Group(()), [1]);
+Error, the second argument must be a non-empty subset of the rows of the first\
+ argument (a Rees matrix semigroup)
+gap> ReesMatrixSubsemigroup(R, [1], Group(()), []);
+Error, the fourth argument must be a non-empty subset of the columns of the fi\
+rst argument (a Rees matrix semigroup)
+gap> GeneratorsOfReesMatrixSemigroup(R, [1], Group(()), []);
+Error, the fourth argument must be a non-empty subset of the columns of the fi\
+rst argument (a Rees matrix semigroup)
+gap> ReesMatrixSubsemigroup(R, [1], Group(()), [2]);
+Error, the fourth argument must be a non-empty subset of the columns of the fi\
+rst argument (a Rees matrix semigroup)
+gap> GeneratorsOfReesMatrixSemigroup(R, [1], Group(()), [2]);
+Error, the fourth argument must be a non-empty subset of the columns of the fi\
+rst argument (a Rees matrix semigroup)
+gap> ReesMatrixSubsemigroup(R, [1], Group((1,3)), [1]);
+Error, the third argument must be a subsemigroup of the underlying semigroup o\
+f the first argument (a Rees matrix semigroup)
+gap> GeneratorsOfReesMatrixSemigroup(R, [1], Group((1,3)), [1]);
+Error, the third argument must be a subsemigroup of the underlying semigroup o\
+f the first argument (a Rees matrix semigroup)
+gap> ReesMatrixSubsemigroup(R, [1], Group((1,2)), [1]);
+<Rees matrix semigroup 1x1 over Group([ (1,2) ])>
+gap> GeneratorsOfReesMatrixSemigroup(R, [1], Group((1,2)), [1]);
+[ (1,(),1) ]
+gap> Semigroup(last) = last2;
+true
+gap> GeneratorsOfSemigroup(R);
+[ (1,(),1) ]
+
+# (GeneratorsOf)ReesZeroMatrixS(ubs)emigroup and GeneratorsOfSemigroup
+gap> R := ReesZeroMatrixSemigroup(Group((1,2)), [[(1,2)]]);
+<Rees 0-matrix semigroup 1x1 over Group([ (1,2) ])>
+gap> T := Semigroup(RMSElement(R, 1, (1,2), 1));
+<subsemigroup of 1x1 Rees 0-matrix semigroup with 1 generator>
+gap> ReesZeroMatrixSubsemigroup(T, [1], Group(()), [1]);
+Error, the first argument must be a Rees 0-matrix semigroup
+gap> GeneratorsOfReesZeroMatrixSemigroup(T, [1], Group(()), [1]);
+Error, the first argument must be a Rees 0-matrix semigroup
+gap> ReesZeroMatrixSubsemigroup(R, [], Group(()), [1]);
+Error, the second argument must be a non-empty subset of the rows of the first\
+ argument (a Rees 0-matrix semigroup)
+gap> GeneratorsOfReesZeroMatrixSemigroup(R, [], Group(()), [1]);
+Error, the second argument must be a non-empty subset of the rows of the first\
+ argument (a Rees 0-matrix semigroup)
+gap> ReesZeroMatrixSubsemigroup(R, [2], Group(()), [1]);
+Error, the second argument must be a non-empty subset of the rows of the first\
+ argument (a Rees 0-matrix semigroup)
+gap> GeneratorsOfReesZeroMatrixSemigroup(R, [2], Group(()), [1]);
+Error, the second argument must be a non-empty subset of the rows of the first\
+ argument (a Rees 0-matrix semigroup)
+gap> ReesZeroMatrixSubsemigroup(R, [1], Group(()), []);
+Error, the fourth argument must be a non-empty subset of the columns of the fi\
+rst argument (a Rees 0-matrix semigroup)
+gap> GeneratorsOfReesZeroMatrixSemigroup(R, [1], Group(()), []);
+Error, the fourth argument must be a non-empty subset of the columns of the fi\
+rst argument (a Rees 0-matrix semigroup)
+gap> ReesZeroMatrixSubsemigroup(R, [1], Group(()), [2]);
+Error, the fourth argument must be a non-empty subset of the columns of the fi\
+rst argument (a Rees 0-matrix semigroup)
+gap> GeneratorsOfReesZeroMatrixSemigroup(R, [1], Group(()), [2]);
+Error, the fourth argument must be a non-empty subset of the columns of the fi\
+rst argument (a Rees 0-matrix semigroup)
+gap> ReesZeroMatrixSubsemigroup(R, [1], Group((1,3)), [1]);
+Error, the third argument must be a subsemigroup of the underlying semigroup o\
+f the first argument (a Rees 0-matrix semigroup)
+gap> GeneratorsOfReesZeroMatrixSemigroup(R, [1], Group((1,3)), [1]);
+Error, the third argument must be a subsemigroup of the underlying semigroup o\
+f the first argument (a Rees 0-matrix semigroup)
+gap> ReesZeroMatrixSubsemigroup(R, [1], Group((1,2)), [1]);
+<subsemigroup of 1x1 Rees 0-matrix semigroup with 1 generator>
+gap> GeneratorsOfReesZeroMatrixSemigroup(R, [1], Group((1,2)), [1]);
+[ (1,(),1) ]
+gap> Semigroup(last) = last2;
+true
+gap> GeneratorsOfSemigroup(R);
+[ (1,(),1), 0 ]
+
+# IsomorphismReesMatrixSemigroup: for a D-class
+gap> S := FullTransformationMonoid(3);
+<full transformation monoid of degree 3>
+gap> D := GreensDClassOfElement(S, Transformation([1, 2, 2]));
+<Green's D-class: Transformation( [ 1, 2, 2 ] )>
+
+#gap> IsomorphismReesMatrixSemigroup(D);
+#Error, the argument (a Green's D-class) is not a subsemigroup
+gap> D := GreensDClassOfElement(S, Transformation([1, 1, 1]));
+<Green's D-class: Transformation( [ 1, 1, 1 ] )>
+gap> iso := IsomorphismReesMatrixSemigroup(D);
+MappingByFunction( <Green's D-class: Transformation( [ 1, 1, 1 ] )>, 
+<Rees matrix semigroup 1x3 over Group(())>
+ , function( x ) ... end, function( x ) ... end )
+gap> inv := InverseGeneralMapping(iso);
+MappingByFunction( <Rees matrix semigroup 1x3 over Group(())>, 
+<Green's D-class: Transformation( [ 1, 1, 1 ] )>
+ , function( x ) ... end, function( x ) ... end )
+gap> R := Range(iso);
+<Rees matrix semigroup 1x3 over Group(())>
+gap> ForAll(D, d -> (d ^ iso) ^ inv = d);
+true
+gap> IdentityTransformation ^ iso;
+fail
+gap> S := Semigroup([
+>  Transformation([1, 2, 1, 4, 4]),
+>  Transformation([1, 2, 2, 5, 5])]);
+<transformation semigroup of degree 5 with 2 generators>
+gap> D := GreensDClassOfElement(S, S.1);
+<Green's D-class: Transformation( [ 1, 2, 1, 4, 4 ] )>
+gap> iso := IsomorphismReesMatrixSemigroup(D);
+MappingByFunction( <Green's D-class: Transformation( [ 1, 2, 1, 4, 4 ] )>, 
+<Rees matrix semigroup 2x2 over Group(())>
+ , function( x ) ... end, function( x ) ... end )
+
+# IsomorphismReesMatrixSemigroup: for a finite simple semigroup
+#gap> IsomorphismReesMatrixSemigroup(FullTransformationMonoid(2));
+#Error, the argument must be a finite simple semigroup
+gap> S := Semigroup([
+>  Transformation([1, 2, 1, 4, 4]),
+>  Transformation([1, 2, 2, 5, 5])]);
+<transformation semigroup of degree 5 with 2 generators>
+gap> iso := IsomorphismReesMatrixSemigroup(S);;
+gap> inv := InverseGeneralMapping(iso);;
+gap> ForAll(S, s -> (s ^ iso) ^ inv = s);
+true
+
+# IsomorphismReesZeroMatrixSemigroup: for a finite 0-simple semigroup
+#gap> IsomorphismReesZeroMatrixSemigroup(FullTransformationMonoid(2));
+#Error, the argument must be a finite 0-simple semigroup
+gap> S := Semigroup(Transformation([1, 2, 2]), Transformation([1, 1, 1]));
+<transformation semigroup of degree 3 with 2 generators>
+gap> iso := IsomorphismReesZeroMatrixSemigroup(S);;
+gap> inv := InverseGeneralMapping(iso);;
+gap> ForAll(S, s -> (s ^ iso) ^ inv = s);
+true
+gap> MultiplicativeZero(Range(iso)) ^ inv;
+Transformation( [ 1, 1, 1 ] )
+gap> S := Semigroup([
+>  Transformation([1, 2, 1, 4, 1, 2]),
+>  Transformation([1, 3, 1, 5, 1, 3]),
+>  Transformation([1, 1, 2, 1, 4, 4])]);
+<transformation semigroup of degree 6 with 3 generators>
+gap> iso := IsomorphismReesZeroMatrixSemigroup(S);;
+gap> inv := InverseGeneralMapping(iso);;
+gap> ForAll(S, s -> (s ^ iso) ^ inv = s);
+true
+gap> D := GreensDClassOfElement(S, S.1);;
+gap> iso := _InjectionPrincipalFactor(D, ReesZeroMatrixSemigroup);;
+gap> inv := InverseGeneralMapping(iso);;
+gap> MultiplicativeZero(Range(iso)) ^ inv;
+fail
+
+# AssociatedReesMatrixSemigroupOfDClass: for a D-class of a finite semigroup
+gap> S := Semigroup([
+> Transformation([1, 1, 1, 1]),
+> Transformation([2, 2, 2, 2]),
+> Transformation([1, 2, 2, 3])]);
+<transformation semigroup of degree 4 with 3 generators>
+gap> D := GreensDClassOfElement(S, S.1);;
+gap> R := AssociatedReesMatrixSemigroupOfDClass(D);
+<Rees matrix semigroup 1x2 over Group(())>
+gap> D := GreensDClassOfElement(S, S.2);;
+gap> R := AssociatedReesMatrixSemigroupOfDClass(D);
+<Rees matrix semigroup 1x2 over Group(())>
+gap> D := GreensDClassOfElement(S, S.3);;
+gap> R := AssociatedReesMatrixSemigroupOfDClass(D);
+Error, the argument should be a regular D-class
+gap> S := Semigroup([
+>  Transformation([1, 2, 1, 4, 1, 2]),
+>  Transformation([1, 3, 1, 5, 1, 3]),
+>  Transformation([1, 1, 2, 1, 4, 4])]);
+<transformation semigroup of degree 6 with 3 generators>
+gap> AssociatedReesMatrixSemigroupOfDClass(GreensDClassOfElement(S, S.1));
+<Rees 0-matrix semigroup 2x2 over Group(())>
+
+# MonoidByAdjoiningIdentity: for a Rees matrix subsemigroup
+gap> R := ReesMatrixSemigroup(Group(()), [[()]]);;
+gap> S := MonoidByAdjoiningIdentity(R);
+<commutative monoid with 1 generator>
+gap> IsZeroSimpleSemigroup(S);
+true
+gap> Size(S);
+2
+gap> R = UnderlyingSemigroupOfMonoidByAdjoiningIdentity(S);
+true
+
+# IsomorphismReesZeroMatrixSemigroup: for a Rees 0-matrix subsemigroup
+gap> R := ReesZeroMatrixSemigroup(Group((1,2)), [[(1,2), ()]]);
+<Rees 0-matrix semigroup 2x1 over Group([ (1,2) ])>
+gap> U := Semigroup(RMSElement(R, 1, (), 1));
+<subsemigroup of 2x1 Rees 0-matrix semigroup with 1 generator>
+
+#gap> IsomorphismReesZeroMatrixSemigroup(U);
+#Error, the argument must be a finite 0-simple semigroup
+gap> U := Semigroup(Elements(R));
+<subsemigroup of 2x1 Rees 0-matrix semigroup with 5 generators>
+gap> HasIsWholeFamily(U);
+false
+gap> iso := IsomorphismReesZeroMatrixSemigroup(U);;
+gap> inv := InverseGeneralMapping(iso);;
+gap> ForAll(U, u -> (u ^ iso) ^ inv = u);
+true
+gap> U := Semigroup(RMSElement(R, 1, (), 1), MultiplicativeZero(R));
+<subsemigroup of 2x1 Rees 0-matrix semigroup with 2 generators>
+gap> iso := IsomorphismReesZeroMatrixSemigroup(U);;
+gap> inv := InverseGeneralMapping(iso);;
+gap> ForAll(U, u -> (u ^ iso) ^ inv = u);
+true
+
+# IsomorphismReesMatrixSemigroup: for a Rees matrix subsemigroup
+gap> R := ReesMatrixSemigroup(Group((1,2)), [[(1,2), ()]]);
+<Rees matrix semigroup 2x1 over Group([ (1,2) ])>
+gap> U := Semigroup(RMSElement(R, 1, (1,2), 1));
+<subsemigroup of 2x1 Rees matrix semigroup with 1 generator>
+gap> iso := IsomorphismReesMatrixSemigroup(U);;
+gap> U := Semigroup(Elements(R));
+<subsemigroup of 2x1 Rees matrix semigroup with 4 generators>
+gap> HasIsWholeFamily(U);
+false
+gap> iso := IsomorphismReesMatrixSemigroup(U);;
+gap> inv := InverseGeneralMapping(iso);;
+gap> ForAll(U, u -> (u ^ iso) ^ inv = u);
+true
+gap> U := Semigroup(RMSElement(R, 2, (), 1));
+<subsemigroup of 2x1 Rees matrix semigroup with 1 generator>
+gap> iso := IsomorphismReesMatrixSemigroup(U);;
+gap> inv := InverseGeneralMapping(iso);;
+gap> ForAll(U, u -> (u ^ iso) ^ inv = u);
+true
 
 #
 gap> STOP_TEST("reesmat.tst");

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -328,5 +328,49 @@ gap> ReesZeroMatrixSemigroup(Group(()), [[1]]);
 Error, the entries of the second argument must be 0 or belong to the first arg\
 ument (a semigroup)
 
+# Enumerator: for a Rees matrix semigroup
+gap> R := ReesMatrixSemigroup(SymmetricGroup(2), [[()]]);
+<Rees matrix semigroup 1x1 over Sym( [ 1 .. 2 ] )>
+gap> enum := Enumerator(R);
+<enumerator of Rees matrix semigroup>
+gap> enum[1];
+(1,(),1)
+gap> Position(enum, enum[1]);
+1
+gap> enum[2];
+(1,(1,2),1)
+gap> Position(enum, enum[2]);
+2
+gap> S := ReesZeroMatrixSemigroup(Group(()), [[(), ()]]);;
+gap> Position(enum, RMSElement(S, 2, (), 1));
+fail
+gap> S := ReesMatrixSemigroup(SymmetricGroup(2), [[()]]);;
+gap> Position(enum, RMSElement(S, 1, (), 1));
+fail
+
+# Enumerator: for a Rees 0-matrix semigroup
+gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(2), [[()]]);
+<Rees 0-matrix semigroup 1x1 over Sym( [ 1 .. 2 ] )>
+gap> enum := Enumerator(R);;
+gap> enum[Position(enum, enum[1])] = enum[1];
+true
+gap> enum[Position(enum, enum[2])] = enum[2];
+true
+gap> enum[Position(enum, enum[3])] = enum[3];
+true
+gap> S := ReesZeroMatrixSemigroup(Group(()), [[(), ()]]);;
+gap> Position(enum, RMSElement(S, 2, (), 1));
+fail
+gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(2), [[()]]);;
+gap> Position(enum, RMSElement(S, 1, (), 1));
+fail
+gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(2), [[(), 0]]);;
+gap> T := ReesZeroMatrixSubsemigroup(R, [1, 2], Group(()), [1]);;
+gap> SetIsReesZeroMatrixSemigroup(T, true);
+gap> SetUnderlyingSemigroup(T, Group(()));
+gap> enum := Enumerator(T);;
+gap> Position(enum, RMSElement(R, 1, (1,2), 1));
+fail
+
 #
 gap> STOP_TEST("reesmat.tst");

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -243,6 +243,38 @@ gap> R := ReesZeroMatrixSemigroup(FullTransformationMonoid(2),
 gap> IsZeroSimpleSemigroup(R);
 false
 
+# IsReesMatrixSemigroup: for a semigroup
+gap> IsReesMatrixSemigroup(FullTransformationMonoid(2));
+false
+
+# IsReesMatrixSemigroup: for a Rees matrix subsemigroup with generators, 1
+gap> R := ReesMatrixSemigroup(SymmetricGroup(2), [[(1,2)]]);
+<Rees matrix semigroup 1x1 over Sym( [ 1 .. 2 ] )>
+gap> IsReesMatrixSemigroup(R);
+true
+gap> S := Semigroup(Elements(R));
+<subsemigroup of 1x1 Rees matrix semigroup with 2 generators>
+gap> IsReesMatrixSemigroup(S);
+true
+
+# IsReesMatrixSemigroup: for a Rees matrix subsemigroup with generators, 2
+gap> S := SymmetricInverseMonoid(2);
+<symmetric inverse monoid of degree 2>
+gap> z := PartialPerm([0]);
+<empty partial perm>
+gap> R := ReesMatrixSemigroup(S, [[One(S), One(S)], [One(S), z]]);
+<Rees matrix semigroup 2x2 over <symmetric inverse monoid of degree 2>>
+gap> T := Semigroup(RMSElement(R, 1, One(S), 1), RMSElement(R, 2, One(S), 2));
+<subsemigroup of 2x2 Rees matrix semigroup with 2 generators>
+gap> IsReesMatrixSemigroup(T);
+true
+gap> R := ReesMatrixSemigroup(S, [[One(S), z], [z, z]]);
+<Rees matrix semigroup 2x2 over <symmetric inverse monoid of degree 2>>
+gap> T := Semigroup(RMSElement(R, 1, One(S), 1), RMSElement(R, 2, One(S), 2));
+<subsemigroup of 2x2 Rees matrix semigroup with 2 generators>
+gap> IsReesMatrixSemigroup(T);
+false
+
 # IsReesZeroMatrixSemigroup: for a semigroup
 gap> IsReesZeroMatrixSemigroup(FullTransformationMonoid(2));
 false

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -226,6 +226,23 @@ gap> R := ReesZeroMatrixSemigroup(S, [[One(S)]]);
 gap> IsRegularSemigroup(R);
 true
 
+# IsZeroSimpleSemigroup: for a Rees 0-matrix semigroup
+gap> S := Semigroup([Transformation([1, 1]), Transformation([2, 2])]);
+<transformation semigroup of degree 2 with 2 generators>
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1, 0, 0], [0, S.1, 0]]);;
+gap> IsZeroSimpleSemigroup(R);
+false
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1, S.1, S.1], [0, 0, 0]]);;
+gap> IsZeroSimpleSemigroup(R);
+false
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1, 0, S.2], [0, S.1, 0]]);;
+gap> IsZeroSimpleSemigroup(R);
+true
+gap> R := ReesZeroMatrixSemigroup(FullTransformationMonoid(2),
+>                                 [[IdentityTransformation]]);;
+gap> IsZeroSimpleSemigroup(R);
+false
+
 # IsReesZeroMatrixSemigroup: for a semigroup
 gap> IsReesZeroMatrixSemigroup(FullTransformationMonoid(2));
 false

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -201,5 +201,30 @@ gap> x := Filtered(R, IsIdempotent);;
 gap> x = Filtered(R, s -> s * s = s);
 true
 
+# IsRegularSemigroup: for a Rees matrix semigroup, 1
+gap> R := ReesMatrixSemigroup(SymmetricGroup(3), [[(1, 3)], [()]]);
+<Rees matrix semigroup 1x2 over Sym( [ 1 .. 3 ] )>
+gap> IsRegularSemigroup(R);
+true
+
+# IsRegularSemigroup: for a Rees 0-matrix semigroup, 1
+gap> S := InverseMonoid(PartialPerm([1]));
+<trivial partial perm group of rank 1 with 1 generator>
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1, S.1], [0, 0]]);;
+gap> IsRegularSemigroup(R);
+false
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1, 0], [S.1, 0]]);;
+gap> IsRegularSemigroup(R);
+false
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1, 0], [0, S.1]]);;
+gap> IsRegularSemigroup(R);
+true
+gap> S := FullTransformationMonoid(2);
+<full transformation monoid of degree 2>
+gap> R := ReesZeroMatrixSemigroup(S, [[One(S)]]);
+<Rees 0-matrix semigroup 1x1 over <full transformation monoid of degree 2>>
+gap> IsRegularSemigroup(R);
+true
+
 #
 gap> STOP_TEST("reesmat.tst");

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -182,5 +182,24 @@ false
 gap> IsFinite(U);
 true
 
+# IsIdempotent: for a Rees 0-matrix semigroup element, 1
+gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(3), [[(1,2,3), 0]]);
+<Rees 0-matrix semigroup 2x1 over Sym( [ 1 .. 3 ] )>
+gap> IsIdempotent(MultiplicativeZero(R));
+true
+gap> Number(R, IsIdempotent);
+2
+gap> Set(Filtered(R, IsIdempotent));
+[ 0, (1,(1,3,2),1) ]
+
+# IsIdempotent: for a Rees 0-matrix semigroup element, 1
+gap> S := FullTransformationSemigroup(2);
+<full transformation monoid of degree 2>
+gap> R := ReesZeroMatrixSemigroup(S, [[IdentityTransformation, 0]]);
+<Rees 0-matrix semigroup 2x1 over <full transformation monoid of degree 2>>
+gap> x := Filtered(R, IsIdempotent);;
+gap> x = Filtered(R, s -> s * s = s);
+true
+
 #
 gap> STOP_TEST("reesmat.tst");

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -1,0 +1,186 @@
+#############################################################################
+##
+#W  reesmat.tst                GAP library                Wilf A. Wilson
+##
+##
+#Y  Copyright (C)  2017, The GAP Group
+##
+gap> START_TEST("reesmat.tst");
+
+# IsFinite: ImmediateMethod, for IsReesZeroMatrixSubsemigroup, 1
+gap> F := FreeSemigroup(2);
+<free semigroup on the generators [ s1, s2 ]>
+gap> S := F / [[F.1 ^ 2, F.1], [F.2, F.1]];
+<fp semigroup on the generators [ s1, s2 ]>
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1, 0]]);
+<Rees 0-matrix semigroup 2x1 over <fp semigroup on the generators [ s1, s2 ]>>
+gap> HasIsFinite(R);
+false
+gap> U := Semigroup(RMSElement(R, 1, S.1, 1));
+<subsemigroup of 2x1 Rees 0-matrix semigroup with 1 generator>
+gap> HasIsFinite(U);
+false
+gap> IsFinite(S);
+true
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1, 0]]);
+<Rees 0-matrix semigroup 2x1 over <fp semigroup on the generators [ s1, s2 ]>>
+gap> HasIsFinite(R) and IsFinite(R);
+true
+gap> U := Semigroup(RMSElement(R, 1, S.1, 1));
+<subsemigroup of 2x1 Rees 0-matrix semigroup with 1 generator>
+gap> HasIsFinite(U) and IsFinite(U);
+true
+
+# IsFinite: ImmediateMethod, for IsReesZeroMatrixSubsemigroup, 2
+gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(3), [[(), 0]]);
+<Rees 0-matrix semigroup 2x1 over Sym( [ 1 .. 3 ] )>
+gap> HasIsFinite(R) and IsFinite(R);
+true
+gap> U := Semigroup(RMSElement(R, 1, (), 1));
+<subsemigroup of 2x1 Rees 0-matrix semigroup with 1 generator>
+gap> HasIsFinite(U) and IsFinite(U);
+true
+
+# IsFinite: ImmediateMethod, for IsReesZeroMatrixSubsemigroup, 3
+gap> F := FreeSemigroup(1);;
+gap> R := ReesZeroMatrixSemigroup(F, [[F.1]]);;
+gap> HasIsFinite(R);
+true
+gap> IsFinite(R);
+false
+gap> U := Semigroup(MultiplicativeZero(R));
+<subsemigroup of 1x1 Rees 0-matrix semigroup with 1 generator>
+gap> HasIsFinite(U);
+false
+
+# IsFinite: ImmediateMethod, for IsReesMatrixSubsemigroup, 1
+gap> F := FreeSemigroup(2);
+<free semigroup on the generators [ s1, s2 ]>
+gap> S := F / [[F.1 ^ 2, F.1], [F.2, F.1]];
+<fp semigroup on the generators [ s1, s2 ]>
+gap> R := ReesMatrixSemigroup(S, [[S.1, S.2]]);
+<Rees matrix semigroup 2x1 over <fp semigroup on the generators [ s1, s2 ]>>
+gap> HasIsFinite(R);
+false
+gap> U := Semigroup(RMSElement(R, 1, S.1, 1));
+<subsemigroup of 2x1 Rees matrix semigroup with 1 generator>
+gap> HasIsFinite(U);
+false
+gap> IsFinite(S);
+true
+gap> R := ReesMatrixSemigroup(S, [[S.1, S.2]]);
+<Rees matrix semigroup 2x1 over <fp semigroup on the generators [ s1, s2 ]>>
+gap> HasIsFinite(R) and IsFinite(R);
+true
+gap> U := Semigroup(RMSElement(R, 1, S.1, 1));
+<subsemigroup of 2x1 Rees matrix semigroup with 1 generator>
+gap> HasIsFinite(U) and IsFinite(U);
+true
+
+# IsFinite: ImmediateMethod, for IsZeroMatrixSubsemigroup, 2
+gap> R := ReesMatrixSemigroup(SymmetricGroup(3), [[(), (1,2,3)]]);
+<Rees matrix semigroup 2x1 over Sym( [ 1 .. 3 ] )>
+gap> HasIsFinite(R) and IsFinite(R);
+true
+gap> U := Semigroup(RMSElement(R, 1, (), 1));
+<subsemigroup of 2x1 Rees matrix semigroup with 1 generator>
+gap> HasIsFinite(U) and IsFinite(U);
+true
+
+# IsFinite: ImmediateMethod, for IsZeroMatrixSubsemigroup, 3
+gap> F := FreeMonoid(1);;
+gap> R := ReesMatrixSemigroup(F, [[F.1]]);;
+gap> HasIsFinite(R);
+true
+gap> IsFinite(R);
+false
+gap> U := Semigroup(RMSElement(R, 1, One(F), 1));
+<subsemigroup of 1x1 Rees matrix semigroup with 1 generator>
+gap> HasIsFinite(U);
+false
+
+# IsFinite: for a Rees 0-matrix subsemigroup, 1
+gap> F := FreeSemigroup(1);;
+gap> R := ReesZeroMatrixSemigroup(F, [[F.1]]);
+<Rees 0-matrix semigroup 1x1 over <free semigroup on the generators [ s1 ]>>
+gap> S := Semigroup(MultiplicativeZero(R));
+<subsemigroup of 1x1 Rees 0-matrix semigroup with 1 generator>
+gap> HasIsFinite(S);
+false
+gap> IsFinite(S);
+true
+
+# IsFinite: for a Rees 0-matrix subsemigroup, 2
+gap> F := FreeSemigroup(2);
+<free semigroup on the generators [ s1, s2 ]>
+gap> S := F / [[F.1 ^ 2, F.1], [F.2, F.1]];
+<fp semigroup on the generators [ s1, s2 ]>
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1, 0]]);
+<Rees 0-matrix semigroup 2x1 over <fp semigroup on the generators [ s1, s2 ]>>
+gap> U := Semigroup(RMSElement(R, 1, S.1, 1));
+<subsemigroup of 2x1 Rees 0-matrix semigroup with 1 generator>
+gap> HasIsFinite(U);
+false
+gap> IsFinite(R);
+true
+gap> IsFinite(U);
+true
+
+# IsFinite: for a Rees 0-matrix subsemigroup, 3
+gap> F := FreeSemigroup(2);
+<free semigroup on the generators [ s1, s2 ]>
+gap> S := F / [[F.1 ^ 2, F.1], [F.2, F.1]];
+<fp semigroup on the generators [ s1, s2 ]>
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1, 0]]);
+<Rees 0-matrix semigroup 2x1 over <fp semigroup on the generators [ s1, s2 ]>>
+gap> U := Semigroup(RMSElement(R, 1, S.1, 1));
+<subsemigroup of 2x1 Rees 0-matrix semigroup with 1 generator>
+gap> HasIsFinite(U);
+false
+gap> IsFinite(U);
+true
+
+# IsFinite: for a Rees matrix subsemigroup, 1
+gap> F := FreeMonoid(1);
+<free monoid on the generators [ m1 ]>
+gap> R := ReesMatrixSemigroup(F, [[One(F)]]);
+<Rees matrix semigroup 1x1 over <free monoid on the generators [ m1 ]>>
+gap> S := Semigroup(RMSElement(R, 1, One(F), 1));
+<subsemigroup of 1x1 Rees matrix semigroup with 1 generator>
+gap> HasIsFinite(S);
+false
+gap> IsFinite(S);
+true
+
+# IsFinite: for a Rees matrix subsemigroup, 2
+gap> F := FreeSemigroup(2);
+<free semigroup on the generators [ s1, s2 ]>
+gap> S := F / [[F.1 ^ 2, F.1], [F.2, F.1]];
+<fp semigroup on the generators [ s1, s2 ]>
+gap> R := ReesMatrixSemigroup(S, [[S.1, S.2]]);
+<Rees matrix semigroup 2x1 over <fp semigroup on the generators [ s1, s2 ]>>
+gap> U := Semigroup(RMSElement(R, 1, S.1, 1));
+<subsemigroup of 2x1 Rees matrix semigroup with 1 generator>
+gap> HasIsFinite(U);
+false
+gap> IsFinite(R);
+true
+gap> IsFinite(U);
+true
+
+# IsFinite: for a Rees matrix subsemigroup, 3
+gap> F := FreeSemigroup(2);
+<free semigroup on the generators [ s1, s2 ]>
+gap> S := F / [[F.1 ^ 2, F.1], [F.2, F.1]];
+<fp semigroup on the generators [ s1, s2 ]>
+gap> R := ReesMatrixSemigroup(S, [[S.1, S.2]]);
+<Rees matrix semigroup 2x1 over <fp semigroup on the generators [ s1, s2 ]>>
+gap> U := Semigroup(RMSElement(R, 1, S.1, 1));
+<subsemigroup of 2x1 Rees matrix semigroup with 1 generator>
+gap> HasIsFinite(U);
+false
+gap> IsFinite(U);
+true
+
+#
+gap> STOP_TEST("reesmat.tst");

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -226,5 +226,41 @@ gap> R := ReesZeroMatrixSemigroup(S, [[One(S)]]);
 gap> IsRegularSemigroup(R);
 true
 
+# IsReesZeroMatrixSemigroup: for a semigroup
+gap> IsReesZeroMatrixSemigroup(FullTransformationMonoid(2));
+false
+
+# IsReesZeroMatrixSemigroup: for a Rees matrix subsemigroup with generators, 1
+gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(2), [[(1,2)]]);
+<Rees 0-matrix semigroup 1x1 over Sym( [ 1 .. 2 ] )>
+gap> IsReesZeroMatrixSemigroup(R);
+true
+gap> S := Semigroup(Elements(R));
+<subsemigroup of 1x1 Rees 0-matrix semigroup with 3 generators>
+gap> IsReesZeroMatrixSemigroup(S);
+true
+gap> S := Semigroup(RMSElement(R, 1, (1,2), 1));
+<subsemigroup of 1x1 Rees 0-matrix semigroup with 1 generator>
+gap> IsReesZeroMatrixSemigroup(S);
+false
+gap> S := Semigroup(MultiplicativeZero(R), MultiplicativeZero(R));
+<subsemigroup of 1x1 Rees 0-matrix semigroup with 2 generators>
+gap> IsReesZeroMatrixSemigroup(S);
+false
+
+# IsReesZeroMatrixSemigroup: for a Rees matrix subsemigroup with generators, 1
+gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(2), [[(1,2)]]);
+<Rees 0-matrix semigroup 1x1 over Sym( [ 1 .. 2 ] )>
+gap> S := Semigroup(RMSElement(R, 1, (1,2), 1), MultiplicativeZero(R));
+<subsemigroup of 1x1 Rees 0-matrix semigroup with 2 generators>
+gap> IsReesZeroMatrixSemigroup(S);
+false
+gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(2), [[()]]);
+<Rees 0-matrix semigroup 1x1 over Sym( [ 1 .. 2 ] )>
+gap> S := Semigroup(RMSElement(R, 1, (), 1), MultiplicativeZero(R));
+<subsemigroup of 1x1 Rees 0-matrix semigroup with 2 generators>
+gap> IsReesZeroMatrixSemigroup(S);
+true
+
 #
 gap> STOP_TEST("reesmat.tst");

--- a/tst/teststandard/reesmat.tst
+++ b/tst/teststandard/reesmat.tst
@@ -879,11 +879,11 @@ gap> IsomorphismReesZeroMatrixSemigroup(V);;
 
 #over semigroups not groups!
 gap> ReesZeroMatrixSemigroup(FullTransformationSemigroup(3), [[,0],[0,0]]);
-Error, the entries of the second argument (a list) must be lists of equal leng\
-th
+Error, the second argument must be a non-empty list, whose entries are non-emp\
+ty lists of equal length
 gap> ReesZeroMatrixSemigroup(FullTransformationSemigroup(3), [[0],[0,0]]);
-Error, the entries of the second argument (a list) must be lists of equal leng\
-th
+Error, the second argument must be a non-empty list, whose entries are non-emp\
+ty lists of equal length
 gap> mat:=List([1..3], x-> List([1..4], x->
 > Random(FullTransformationSemigroup(4))));;
 gap> ReesZeroMatrixSemigroup(FullTransformationSemigroup(3), mat);

--- a/tst/teststandard/reesmat.tst
+++ b/tst/teststandard/reesmat.tst
@@ -550,7 +550,7 @@ gap> f[3];
 gap> f[2]=x;
 true
 gap> f[4];
-Error, the second argument must equal 1, 2, or 3
+Error, the second argument must be 1, 2, or 3
 
 # more general tests
 gap> mat:=[ [ 0, 0, 0, (), (), (), () ], [ 0, (), (), 0, 0, (), () ], 


### PR DESCRIPTION
This PR resolves issues #1659 and #1661, as well as a couple of other small bugs I detected and fixed whilst working on this PR.

My purpose with this PR was to increase my confidence in the library's Rees (0-)matrix semigroup code, since I'd never really looked at it before. I was concerned with making sure that the code correct rather than more efficient, and I was writing test coverage as a way of achieving this confidence.

@james-d-mitchell already had good coverage of `lib/reesmat.gi` with his test file `tst/teststandard/reesmat.tst`, which contains more complicated tests than the ones I have added in this PR. I have put my new tests into `tst/testinstall/reesmat.tst`, which on its own gives 98% coverage of `lib/reesmat.gi`. I started my new file so that I could approach the problem fresh.

In doing so, I found several instances where methods either returned wrong answers, or unnecessarily led to break loops. I have fixed these problems, and re-written some very small parts of the code for either improved readability or consistency. More detail on the specific changes is given in the relevant commit messages. In summary, there were problems with

* `IsFinite`
* `IsOne`
* `Enumerator`
* `IsReesMatrixSemigroup`
* `IsReesZeroMatrixSemigroup`

This PR increases the code coverage of `lib/reesmat.gi` almost as far as I can without running into technical difficulties (having test coverage of some errors, for instance, will mean that the tests will fail when the Semigroups package is loaded, since Semigroups replaces some of the relevant methods, and uses different error messages). I make no claim that `lib/reesmat.gi` is perfect now, but I think this PR is a good start.

I apologise for this being a large number of changes in one PR; however most of the lines are simply new tests. The changes to `lib/reesmat.gi` themselves are quite small and I think it makes sense to bundle them together.