### PR TITLE
Add CONST_ADDR_OBJ, use it in some places (WIP)

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -202,7 +202,7 @@ void SaveBlist (
     UInt *              ptr;
 
     /* logical length                                                      */
-    SaveSubObj(ADDR_OBJ(bl)[0]);
+    SaveSubObj(CONST_ADDR_OBJ(bl)[0]);
     ptr = BLOCKS_BLIST(bl);
     for (i = 1; i <= NUMBER_BLOCKS_BLIST( bl ); i++ )
         SaveUInt(*ptr++);
@@ -256,10 +256,10 @@ void LoadBlist (
 **  'CleanBlist' is the function in 'CleanObjFuncs' for boolean lists.
 */
 
-Obj DoCopyBlist(Obj list, Int mut) {
-  Obj copy;
-  UInt *l;
-  UInt *c;
+Obj DoCopyBlist(Obj list, Int mut)
+{
+    Obj copy;
+
     /* make a copy                                                         */
     if ( mut ) {
       copy = NewBag( MUTABLE_TNUM(TNUM_OBJ(list)), SIZE_OBJ(list) );
@@ -268,11 +268,9 @@ Obj DoCopyBlist(Obj list, Int mut) {
       copy = NewBag( IMMUTABLE_TNUM( TNUM_OBJ(list) ), SIZE_OBJ(list) );
     }
 
-
     /* copy the subvalues                                                  */
-    l = (UInt*)(ADDR_OBJ(list));
-    c = (UInt*)(ADDR_OBJ(copy));
-    memcpy((void *)c, (void *)l, sizeof(UInt)*(1+NUMBER_BLOCKS_BLIST(list)));
+    memcpy(ADDR_OBJ(copy), CONST_ADDR_OBJ(list),
+            sizeof(UInt)*(1+NUMBER_BLOCKS_BLIST(list)));
 
     /* return the copy                                                     */
     return copy;
@@ -301,7 +299,7 @@ Obj CopyBlist (
     /* leave a forwarding pointer */
     tmp = NEW_PLIST( T_PLIST, 2 );
     SET_LEN_PLIST( tmp, 2 );
-    SET_ELM_PLIST( tmp, 1, ADDR_OBJ(list)[0] );
+    SET_ELM_PLIST( tmp, 1, CONST_ADDR_OBJ(list)[0] );
     SET_ELM_PLIST( tmp, 2, copy );
     ADDR_OBJ(list)[0] = tmp;
     CHANGED_BAG(list);
@@ -322,7 +320,7 @@ Obj ShallowCopyBlist ( Obj list)
 */
 Obj CopyBlistCopy(Obj list, Int mut)
 {
-    return ELM_PLIST(ADDR_OBJ(list)[0], 2);
+    return ELM_PLIST(CONST_ADDR_OBJ(list)[0], 2);
 }
 
 
@@ -343,7 +341,7 @@ void CleanBlist (
 void CleanBlistCopy(Obj list)
 {
     /* remove the forwarding pointer */
-    ADDR_OBJ(list)[0] = ELM_PLIST(ADDR_OBJ(list)[0], 1);
+    ADDR_OBJ(list)[0] = ELM_PLIST(CONST_ADDR_OBJ(list)[0], 1);
 
     /* now it is cleaned */
     RetypeBag(list, TNUM_OBJ(list) - COPYING);
@@ -1257,7 +1255,7 @@ Obj FuncBLIST_LIST (
     UInt                block;          /* one block of boolean list       */
     UInt                bit;            /* one bit of block                */
     Int                 lenList;        /* logical length of the list      */
-    Obj *               ptrSub;         /* pointer to the sublist          */
+    const Obj *               ptrSub;         /* pointer to the sublist          */
     UInt                lenSub;         /* logical length of sublist       */
     UInt                i, j, k = 0, l;     /* loop variables                  */
     long                s, t;           /* elements of a range             */
@@ -1316,7 +1314,7 @@ Obj FuncBLIST_LIST (
         blist = NewBag( T_BLIST, SIZE_PLEN_BLIST( lenList ) );
         ADDR_OBJ(blist)[0] = INTOBJ_INT(lenList);
         ptrBlist = BLOCKS_BLIST(blist);
-        ptrSub = ADDR_OBJ(sub);
+        ptrSub = CONST_ADDR_OBJ(sub);
 
         /* loop over <sub> and set the corresponding entries to 'true'     */
         s = INT_INTOBJ( GET_ELM_RANGE( list, 1 ) );
@@ -1368,13 +1366,13 @@ Obj FuncBLIST_LIST (
 
             /* run over the elements of <sub> and search for the elements  */
             for ( l = 1; l <= LEN_LIST(sub); l++ ) {
-                if ( ADDR_OBJ(sub)[l] != 0 ) {
+                if ( CONST_ADDR_OBJ(sub)[l] != 0 ) {
 
                     /* perform the binary search to find the position      */
                     i = 0;  k = lenList+1;
                     while ( i+1 < k ) {
                         j = (i + k) / 2;
-                        if ( LT(ADDR_OBJ(list)[j],ADDR_OBJ(sub)[l]) )
+                        if ( LT(CONST_ADDR_OBJ(list)[j],CONST_ADDR_OBJ(sub)[l]) )
                             i = j;
                         else
                             k = j;
@@ -1382,7 +1380,7 @@ Obj FuncBLIST_LIST (
 
                     /* set bit if <sub>[<l>] was found at position k       */
                     if ( k <= lenList
-                      && EQ( ADDR_OBJ(list)[k], ADDR_OBJ(sub)[l] ) )
+                      && EQ( CONST_ADDR_OBJ(list)[k], CONST_ADDR_OBJ(sub)[l] ) )
                       SET_ELM_BLIST( blist, k, True);
                 }
             }
@@ -1410,12 +1408,12 @@ Obj FuncBLIST_LIST (
 
                 /* test if <list>[<l>] is in <sub>                         */
                 while ( k <= lenSub
-                     && LT(ADDR_OBJ(sub)[k],ADDR_OBJ(list)[l]) )
+                     && LT(CONST_ADDR_OBJ(sub)[k],CONST_ADDR_OBJ(list)[l]) )
                     k++;
 
                 /* if <list>[<k>] is in <sub> set the current bit in block */
                 if ( k <= lenSub
-                  && EQ(ADDR_OBJ(sub)[k],ADDR_OBJ(list)[l]) ) {
+                  && EQ(CONST_ADDR_OBJ(sub)[k],CONST_ADDR_OBJ(list)[l]) ) {
                     block |= bit;
                     k++;
                 }
@@ -1455,16 +1453,16 @@ Obj FuncBLIST_LIST (
         for ( l = 1; l <= lenList; l++ ) {
 
             /* test if <list>[<l>] is in <sub>                             */
-            if ( l == 1 || LT(ADDR_OBJ(list)[l-1],ADDR_OBJ(list)[l]) ){
+            if ( l == 1 || LT(CONST_ADDR_OBJ(list)[l-1],CONST_ADDR_OBJ(list)[l]) ){
                 while ( k <= lenSub
-                     && LT(ADDR_OBJ(sub)[k],ADDR_OBJ(list)[l]) )
+                     && LT(CONST_ADDR_OBJ(sub)[k],CONST_ADDR_OBJ(list)[l]) )
                     k++;
             }
             else {
                 i = 0;  k = LEN_PLIST(sub) + 1;
                 while ( i+1 < k ) {
                     j = (i + k) / 2;
-                    if ( LT( ADDR_OBJ(sub)[j], ADDR_OBJ(list)[l] ) )
+                    if ( LT( CONST_ADDR_OBJ(sub)[j], CONST_ADDR_OBJ(list)[l] ) )
                         i = j;
                     else
                         k = j;
@@ -1473,7 +1471,7 @@ Obj FuncBLIST_LIST (
 
             /* if <list>[<k>] is in <sub> set the current bit in the block */
             if ( k <= lenSub
-              && EQ( ADDR_OBJ(sub)[k], ADDR_OBJ(list)[l] ) ) {
+              && EQ( CONST_ADDR_OBJ(sub)[k], CONST_ADDR_OBJ(list)[l] ) ) {
                 block |= bit;
                 k++;
             }
@@ -1801,7 +1799,7 @@ Obj FuncUNITE_BLIST_LIST (
     UInt                block;          /* one block of boolean list       */
     UInt                bit;            /* one bit of block                */
     Int                 lenList;        /* logical length of the list      */
-    Obj *               ptrSub;         /* pointer to the sublist          */
+    const Obj *         ptrSub;         /* pointer to the sublist          */
     UInt                lenSub;         /* logical length of sublist       */
     UInt                i, j, k = 0, l;     /* loop variables                  */
     long                s, t;           /* elements of a range             */
@@ -1880,7 +1878,7 @@ Obj FuncUNITE_BLIST_LIST (
 
         lenSub   = LEN_LIST( sub );
         ptrBlist = BLOCKS_BLIST(blist);
-        ptrSub = ADDR_OBJ(sub);
+        ptrSub = CONST_ADDR_OBJ(sub);
 
         /* loop over <sub> and set the corresponding entries to 'true'     */
         s = INT_INTOBJ( GET_ELM_RANGE( list, 1 ) );
@@ -1934,13 +1932,13 @@ Obj FuncUNITE_BLIST_LIST (
 
             /* run over the elements of <sub> and search for the elements  */
             for ( l = 1; l <= LEN_LIST(sub); l++ ) {
-                if ( ADDR_OBJ(sub)[l] != 0 ) {
+                if ( CONST_ADDR_OBJ(sub)[l] != 0 ) {
 
                     /* perform the binary search to find the position      */
                     i = 0;  k = lenList+1;
                     while ( i+1 < k ) {
                         j = (i + k) / 2;
-                        if ( LT(ADDR_OBJ(list)[j],ADDR_OBJ(sub)[l]) )
+                        if ( LT(CONST_ADDR_OBJ(list)[j],CONST_ADDR_OBJ(sub)[l]) )
                             i = j;
                         else
                             k = j;
@@ -1948,7 +1946,7 @@ Obj FuncUNITE_BLIST_LIST (
 
                     /* set bit if <sub>[<l>] was found at position k       */
                     if ( k <= lenList
-                      && EQ( ADDR_OBJ(list)[k], ADDR_OBJ(sub)[l] ) )
+                      && EQ( CONST_ADDR_OBJ(list)[k], CONST_ADDR_OBJ(sub)[l] ) )
                       SET_ELM_BLIST( blist, k, True);
                 }
             }
@@ -1972,12 +1970,12 @@ Obj FuncUNITE_BLIST_LIST (
 
                 /* test if <list>[<l>] is in <sub>                         */
                 while ( k <= lenSub
-                     && LT(ADDR_OBJ(sub)[k],ADDR_OBJ(list)[l]) )
+                     && LT(CONST_ADDR_OBJ(sub)[k],CONST_ADDR_OBJ(list)[l]) )
                     k++;
 
                 /* if <list>[<k>] is in <sub> set the current bit in block */
                 if ( k <= lenSub
-                  && EQ(ADDR_OBJ(sub)[k],ADDR_OBJ(list)[l]) ) {
+                  && EQ(CONST_ADDR_OBJ(sub)[k],CONST_ADDR_OBJ(list)[l]) ) {
                     block |= bit;
                     k++;
                 }
@@ -2024,16 +2022,16 @@ Obj FuncUNITE_BLIST_LIST (
         for ( l = 1; l <= lenList; l++ ) {
 
             /* test if <list>[<l>] is in <sub>                             */
-            if ( l == 1 || LT(ADDR_OBJ(list)[l-1],ADDR_OBJ(list)[l]) ){
+            if ( l == 1 || LT(CONST_ADDR_OBJ(list)[l-1],CONST_ADDR_OBJ(list)[l]) ){
                 while ( k <= lenSub
-                     && LT(ADDR_OBJ(sub)[k],ADDR_OBJ(list)[l]) )
+                     && LT(CONST_ADDR_OBJ(sub)[k],CONST_ADDR_OBJ(list)[l]) )
                     k++;
             }
             else {
                 i = 0;  k = LEN_PLIST(sub) + 1;
                 while ( i+1 < k ) {
                     j = (i + k) / 2;
-                    if ( LT( ADDR_OBJ(sub)[j], ADDR_OBJ(list)[l] ) )
+                    if ( LT( CONST_ADDR_OBJ(sub)[j], CONST_ADDR_OBJ(list)[l] ) )
                         i = j;
                     else
                         k = j;
@@ -2042,7 +2040,7 @@ Obj FuncUNITE_BLIST_LIST (
 
             /* if <list>[<k>] is in <sub> set the current bit in the block */
             if ( k <= lenSub
-              && EQ( ADDR_OBJ(sub)[k], ADDR_OBJ(list)[l] ) ) {
+              && EQ( CONST_ADDR_OBJ(sub)[k], CONST_ADDR_OBJ(list)[l] ) ) {
                 block |= bit;
                 k++;
             }

--- a/src/blister.h
+++ b/src/blister.h
@@ -90,7 +90,7 @@ static inline Int SIZE_PLEN_BLIST(Int plen)
 static inline Int LEN_BLIST(Obj list)
 {
     GAP_ASSERT(IS_BLIST_REP_WITH_COPYING(list));
-    return INT_INTOBJ(ADDR_OBJ(list)[0]);
+    return INT_INTOBJ(CONST_ADDR_OBJ(list)[0]);
 }
 
 

--- a/src/code.c
+++ b/src/code.c
@@ -1680,7 +1680,7 @@ void CodeIntExpr (
     else {
         expr = NewExpr( T_INT_EXPR, sizeof(UInt) + SIZE_OBJ(val) );
         ((UInt *)ADDR_EXPR(expr))[0] = (UInt)TNUM_OBJ(val);
-        memcpy((void *)((UInt *)ADDR_EXPR(expr)+1), (void *)ADDR_OBJ(val), (size_t)SIZE_OBJ(val));
+        memcpy(((UInt *)ADDR_EXPR(expr)+1), CONST_ADDR_OBJ(val), (size_t)SIZE_OBJ(val));
     }
 
     /* push the expression                                                 */
@@ -1754,7 +1754,7 @@ void CodeLongIntExpr (
     else {
         expr = NewExpr( T_INT_EXPR, sizeof(UInt) + SIZE_OBJ(val) );
         ((UInt *)ADDR_EXPR(expr))[0] = (UInt)TNUM_OBJ(val);
-        memcpy((void *)((UInt *)ADDR_EXPR(expr)+1), (void *)ADDR_OBJ(val), (size_t)SIZE_OBJ(val));
+        memcpy((void *)((UInt *)ADDR_EXPR(expr)+1), CONST_ADDR_OBJ(val), (size_t)SIZE_OBJ(val));
     }
 
     /* push the expression                                                 */
@@ -1955,7 +1955,7 @@ void CodeStringExpr (
     string = NewExpr( T_STRING_EXPR, SIZEBAG_STRINGLEN(GET_LEN_STRING(str)) );
 
     /* copy the string                                                     */
-    memcpy( (void *)ADDR_EXPR(string), ADDR_OBJ(str), 
+    memcpy( (void *)ADDR_EXPR(string), CONST_ADDR_OBJ(str),
                         SIZEBAG_STRINGLEN(GET_LEN_STRING(str)) );
 
     /* push the string                                                     */
@@ -3444,8 +3444,7 @@ void CodeAssertEnd3Args ( void )
 void SaveBody ( Obj body )
 {
   UInt i;
-  UInt *ptr;
-  ptr = (UInt *) ADDR_OBJ(body);
+  const UInt *ptr = (const UInt *) CONST_ADDR_OBJ(body);
   /* Save the new inforation in the body */
   for (i =0; i < sizeof(BodyHeader)/sizeof(Obj); i++)
     SaveSubObj((Obj)(*ptr++));

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -373,15 +373,7 @@ static inline Obj C_MAKE_MED_INT( Int8 value ) {
 }
 
 static inline Obj C_NORMALIZE_64BIT(Obj o) {
-  Int value =  *(Int *)ADDR_OBJ(o);
-  if (value < 0)
-    return o;
-  if (TNUM_OBJ(o) == T_INTNEG)
-    value = -value;
-  if (-(1L << 60) <= value && value < (1L << 60))
-    return INTOBJ_INT(value);
-  else
-    return o;    
+  return GMP_REDUCE(o);
 }
 
 

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -123,10 +123,41 @@
 /****************************************************************************
 **
 */
-#define SIZE_CYC(cyc)           (SIZE_OBJ(cyc) / (sizeof(Obj)+sizeof(UInt4)))
-#define COEFS_CYC(cyc)          (ADDR_OBJ(cyc))
-#define EXPOS_CYC(cyc,len)      ((UInt4*)(ADDR_OBJ(cyc)+(len)))
-#define NOF_CYC(cyc)            (COEFS_CYC(cyc)[0])
+static inline UInt SIZE_CYC(Obj cyc)
+{
+    return SIZE_OBJ(cyc) / (sizeof(Obj)+sizeof(UInt4));
+}
+
+static inline Obj * COEFS_CYC(Obj cyc)
+{
+    return ADDR_OBJ(cyc);
+}
+
+static inline const Obj * CONST_COEFS_CYC(Obj cyc)
+{
+    return CONST_ADDR_OBJ(cyc);
+}
+
+static inline UInt4 * EXPOS_CYC(Obj cyc, UInt len)
+{
+    return (UInt4 *)(ADDR_OBJ(cyc)+(len));
+}
+
+static inline const UInt4 * CONST_EXPOS_CYC(Obj cyc, UInt len)
+{
+    return (const UInt4 *)(CONST_ADDR_OBJ(cyc)+(len));
+}
+
+static inline Obj NOF_CYC(Obj cyc)
+{
+    return CONST_COEFS_CYC(cyc)[0];
+}
+
+static inline void SET_NOF_CYC(Obj cyc, Obj val)
+{
+    COEFS_CYC(cyc)[0] = val;
+}
+
 #define XXX_CYC(cyc,len)        (EXPOS_CYC(cyc,len)[0])
 
 
@@ -211,8 +242,8 @@ void            PrintCyc (
 {
     UInt                n;              /* order of the field              */
     UInt                len;            /* number of terms                 */
-    Obj *               cfs;            /* pointer to the coefficients     */
-    UInt4 *             exs;            /* pointer to the exponents        */
+    const Obj *         cfs;            /* pointer to the coefficients     */
+    const UInt4 *       exs;            /* pointer to the exponents        */
     UInt                i;              /* loop variable                   */
 
     n   = INT_INTOBJ( NOF_CYC(cyc) );
@@ -220,8 +251,8 @@ void            PrintCyc (
     Pr("%>",0L,0L);
     for ( i = 1; i < len; i++ ) {
         /* get pointers, they can change during Pr */
-        cfs = COEFS_CYC(cyc);
-        exs = EXPOS_CYC(cyc,len);
+        cfs = CONST_COEFS_CYC(cyc);
+        exs = CONST_EXPOS_CYC(cyc,len);
         if (      cfs[i]==INTOBJ_INT(1)    && exs[i]==0 )
             Pr("1",0L,0L);
         else if ( cfs[i]==INTOBJ_INT(1)    && exs[i]==1 && i==1 )
@@ -277,10 +308,10 @@ Int             EqCyc (
     Obj                 opR )
 {
     UInt                len;            /* number of terms                 */
-    Obj *               cfl;            /* ptr to coeffs of left operand   */
-    UInt4 *             exl;            /* ptr to expnts of left operand   */
-    Obj *               cfr;            /* ptr to coeffs of right operand  */
-    UInt4 *             exr;            /* ptr to expnts of right operand  */
+    const Obj *         cfl;            /* ptr to coeffs of left operand   */
+    const UInt4 *       exl;            /* ptr to expnts of left operand   */
+    const Obj *         cfr;            /* ptr to coeffs of right operand  */
+    const UInt4 *       exr;            /* ptr to expnts of right operand  */
     UInt                i;              /* loop variable                   */
 
     /* compare the order of both fields                                    */
@@ -293,10 +324,10 @@ Int             EqCyc (
 
     /* compare the cyclotomics termwise                                    */
     len = SIZE_CYC(opL);
-    cfl = COEFS_CYC(opL);
-    cfr = COEFS_CYC(opR);
-    exl = EXPOS_CYC(opL,len);
-    exr = EXPOS_CYC(opR,len);
+    cfl = CONST_COEFS_CYC(opL);
+    cfr = CONST_COEFS_CYC(opR);
+    exl = CONST_EXPOS_CYC(opL,len);
+    exr = CONST_EXPOS_CYC(opR,len);
     for ( i = 1; i < len; i++ ) {
         if ( exl[i] != exr[i] )
             return 0L;
@@ -333,11 +364,11 @@ Int             LtCyc (
     Obj                 opR )
 {
     UInt                lel;            /* nr of terms of left operand     */
-    Obj *               cfl;            /* ptr to coeffs of left operand   */
-    UInt4 *             exl;            /* ptr to expnts of left operand   */
+    const Obj *         cfl;            /* ptr to coeffs of left operand   */
+    const UInt4 *       exl;            /* ptr to expnts of left operand   */
     UInt                ler;            /* nr of terms of right operand    */
-    Obj *               cfr;            /* ptr to coeffs of right operand  */
-    UInt4 *             exr;            /* ptr to expnts of right operand  */
+    const Obj *         cfr;            /* ptr to coeffs of right operand  */
+    const UInt4 *       exr;            /* ptr to expnts of right operand  */
     UInt                i;              /* loop variable                   */
 
     /* compare the order of both fields                                    */
@@ -351,10 +382,10 @@ Int             LtCyc (
     /* compare the cyclotomics termwise                                    */
     lel = SIZE_CYC(opL);
     ler = SIZE_CYC(opR);
-    cfl = COEFS_CYC(opL);
-    cfr = COEFS_CYC(opR);
-    exl = EXPOS_CYC(opL,lel);
-    exr = EXPOS_CYC(opR,ler);
+    cfl = CONST_COEFS_CYC(opL);
+    cfr = CONST_COEFS_CYC(opR);
+    exl = CONST_EXPOS_CYC(opL,lel);
+    exr = CONST_EXPOS_CYC(opR,ler);
     for ( i = 1; i < lel && i < ler; i++ ) {
         if ( exl[i] != exr[i] )
             if ( exl[i] < exr[i] )
@@ -861,8 +892,8 @@ Obj             SumCyc (
     UInt                n;              /* order of smallest superfield    */
     UInt                ml, mr;         /* cofactors into the superfield   */
     UInt                len;            /* number of terms                 */
-    Obj *               cfs;            /* pointer to the coefficients     */
-    UInt4 *             exs;            /* pointer to the exponents        */
+    const Obj *         cfs;            /* pointer to the coefficients     */
+    const UInt4 *       exs;            /* pointer to the exponents        */
     Obj *               res;            /* pointer to the result           */
     Obj                 sum;            /* sum of two coefficients         */
     UInt                i;              /* loop variable                   */
@@ -886,8 +917,8 @@ Obj             SumCyc (
     }
     else {
         len = SIZE_CYC(opL);
-        cfs = COEFS_CYC(opL);
-        exs = EXPOS_CYC(opL,len);
+        cfs = CONST_COEFS_CYC(opL);
+        exs = CONST_EXPOS_CYC(opL,len);
         res = BASE_PTR_PLIST(STATE(ResultCyc));
         if ( ml == 1 ) {
             for ( i = 1; i < len; i++ )
@@ -910,16 +941,16 @@ Obj             SumCyc (
     }
     else {
         len = SIZE_CYC(opR);
-        cfs = COEFS_CYC(opR);
-        exs = EXPOS_CYC(opR,len);
+        cfs = CONST_COEFS_CYC(opR);
+        exs = CONST_EXPOS_CYC(opR,len);
         res = BASE_PTR_PLIST(STATE(ResultCyc));
         for ( i = 1; i < len; i++ ) {
             if ( ! ARE_INTOBJS( res[exs[i]*mr], cfs[i] )
               || ! SUM_INTOBJS( sum, res[exs[i]*mr], cfs[i] ) ) {
                 CHANGED_BAG( STATE(ResultCyc) );
                 sum = SUM( res[exs[i]*mr], cfs[i] );
-                cfs = COEFS_CYC(opR);
-                exs = EXPOS_CYC(opR,len);
+                cfs = CONST_COEFS_CYC(opR);
+                exs = CONST_EXPOS_CYC(opR,len);
                 res = BASE_PTR_PLIST(STATE(ResultCyc));
             }
             res[exs[i]*mr] = sum;
@@ -957,8 +988,8 @@ Obj             AInvCyc (
 {
     Obj                 res;            /* inverse, result                 */
     UInt                len;            /* number of terms                 */
-    Obj *               cfs;            /* ptr to coeffs of left operand   */
-    UInt4 *             exs;            /* ptr to expnts of left operand   */
+    const Obj *         cfs;            /* ptr to coeffs of left operand   */
+    const UInt4 *       exs;            /* ptr to expnts of left operand   */
     Obj *               cfp;            /* ptr to coeffs of product        */
     UInt4 *             exp;            /* ptr to expnts of product        */
     UInt                i;              /* loop variable                   */
@@ -966,20 +997,20 @@ Obj             AInvCyc (
 
     /* simply invert the coefficients                                      */
     res = NewBag( T_CYC, SIZE_CYC(op) * (sizeof(Obj)+sizeof(UInt4)) );
-    NOF_CYC(res) = NOF_CYC(op);
+    SET_NOF_CYC(res, NOF_CYC(op));
     len = SIZE_CYC(op);
-    cfs = COEFS_CYC(op);
+    cfs = CONST_COEFS_CYC(op);
+    exs = CONST_EXPOS_CYC(op,len);
     cfp = COEFS_CYC(res);
-    exs = EXPOS_CYC(op,len);
     exp = EXPOS_CYC(res,len);
     for ( i = 1; i < len; i++ ) {
         if ( ! IS_INTOBJ( cfs[i] ) || 
                cfs[i] == INTOBJ_INT(-(1L<<NR_SMALL_INT_BITS)) ) {
             CHANGED_BAG( res );
             prd = AINV( cfs[i] );
-            cfs = COEFS_CYC(op);
+            cfs = CONST_COEFS_CYC(op);
+            exs = CONST_EXPOS_CYC(op,len);
             cfp = COEFS_CYC(res);
-            exs = EXPOS_CYC(op,len);
             exp = EXPOS_CYC(res,len);
         }
         else {
@@ -1013,8 +1044,8 @@ Obj             DiffCyc (
     UInt                n;              /* order of smallest superfield    */
     UInt                ml, mr;         /* cofactors into the superfield   */
     UInt                len;            /* number of terms                 */
-    Obj *               cfs;            /* pointer to the coefficients     */
-    UInt4 *             exs;            /* pointer to the exponents        */
+    const Obj *         cfs;            /* pointer to the coefficients     */
+    const UInt4 *       exs;            /* pointer to the exponents        */
     Obj *               res;            /* pointer to the result           */
     Obj                 sum;            /* difference of two coefficients  */
     UInt                i;              /* loop variable                   */
@@ -1032,8 +1063,8 @@ Obj             DiffCyc (
     }
     else {
         len = SIZE_CYC(opL);
-        cfs = COEFS_CYC(opL);
-        exs = EXPOS_CYC(opL,len);
+        cfs = CONST_COEFS_CYC(opL);
+        exs = CONST_EXPOS_CYC(opL,len);
         res = BASE_PTR_PLIST(STATE(ResultCyc));
         if ( ml == 1 ) {
             for ( i = 1; i < len; i++ )
@@ -1056,16 +1087,16 @@ Obj             DiffCyc (
     }
     else {
         len = SIZE_CYC(opR);
-        cfs = COEFS_CYC(opR);
-        exs = EXPOS_CYC(opR,len);
+        cfs = CONST_COEFS_CYC(opR);
+        exs = CONST_EXPOS_CYC(opR,len);
         res = BASE_PTR_PLIST(STATE(ResultCyc));
         for ( i = 1; i < len; i++ ) {
             if ( ! ARE_INTOBJS( res[exs[i]*mr], cfs[i] )
               || ! DIFF_INTOBJS( sum, res[exs[i]*mr], cfs[i] ) ) {
                 CHANGED_BAG( STATE(ResultCyc) );
                 sum = DIFF( res[exs[i]*mr], cfs[i] );
-                cfs = COEFS_CYC(opR);
-                exs = EXPOS_CYC(opR,len);
+                cfs = CONST_COEFS_CYC(opR);
+                exs = CONST_EXPOS_CYC(opR,len);
                 res = BASE_PTR_PLIST(STATE(ResultCyc));
             }
             res[exs[i]*mr] = sum;
@@ -1100,8 +1131,8 @@ Obj             ProdCycInt (
 {
     Obj                 hdP;            /* product, result                 */
     UInt                len;            /* number of terms                 */
-    Obj *               cfs;            /* ptr to coeffs of left operand   */
-    UInt4 *             exs;            /* ptr to expnts of left operand   */
+    const Obj *         cfs;            /* ptr to coeffs of left operand   */
+    const UInt4 *       exs;            /* ptr to expnts of left operand   */
     Obj *               cfp;            /* ptr to coeffs of product        */
     UInt4 *             exp;            /* ptr to expnts of product        */
     UInt                i;              /* loop variable                   */
@@ -1131,20 +1162,20 @@ Obj             ProdCycInt (
     /* for $cyc * small$ use immediate multiplication if possible          */
     else if ( IS_INTOBJ(opR) ) {
         hdP = NewBag( T_CYC, SIZE_CYC(opL) * (sizeof(Obj)+sizeof(UInt4)) );
-        NOF_CYC(hdP) = NOF_CYC(opL);
+        SET_NOF_CYC(hdP, NOF_CYC(opL));
         len = SIZE_CYC(opL);
-        cfs = COEFS_CYC(opL);
+        cfs = CONST_COEFS_CYC(opL);
+        exs = CONST_EXPOS_CYC(opL,len);
         cfp = COEFS_CYC(hdP);
-        exs = EXPOS_CYC(opL,len);
         exp = EXPOS_CYC(hdP,len);
         for ( i = 1; i < len; i++ ) {
             if ( ! IS_INTOBJ( cfs[i] )
               || ! PROD_INTOBJS( prd, cfs[i], opR ) ) {
                 CHANGED_BAG( hdP );
                 prd = PROD( cfs[i], opR );
-                cfs = COEFS_CYC(opL);
+                cfs = CONST_COEFS_CYC(opL);
+                exs = CONST_EXPOS_CYC(opL,len);
                 cfp = COEFS_CYC(hdP);
-                exs = EXPOS_CYC(opL,len);
                 exp = EXPOS_CYC(hdP,len);
             }
             cfp[i] = prd;
@@ -1156,18 +1187,18 @@ Obj             ProdCycInt (
     /* otherwise multiply every coefficent                                 */
     else {
         hdP = NewBag( T_CYC, SIZE_CYC(opL) * (sizeof(Obj)+sizeof(UInt4)) );
-        NOF_CYC(hdP) = NOF_CYC(opL);
+        SET_NOF_CYC(hdP, NOF_CYC(opL));
         len = SIZE_CYC(opL);
-        cfs = COEFS_CYC(opL);
+        cfs = CONST_COEFS_CYC(opL);
+        exs = CONST_EXPOS_CYC(opL,len);
         cfp = COEFS_CYC(hdP);
-        exs = EXPOS_CYC(opL,len);
         exp = EXPOS_CYC(hdP,len);
         for ( i = 1; i < len; i++ ) {
             CHANGED_BAG( hdP );
             prd = PROD( cfs[i], opR );
-            cfs = COEFS_CYC(opL);
+            cfs = CONST_COEFS_CYC(opL);
+            exs = CONST_EXPOS_CYC(opL,len);
             cfp = COEFS_CYC(hdP);
-            exs = EXPOS_CYC(opL,len);
             exp = EXPOS_CYC(hdP,len);
             cfp[i] = prd;
             exp[i] = exs[i];
@@ -1200,8 +1231,8 @@ Obj             ProdCyc (
     Obj                 c;              /* one coefficient of the left op  */
     UInt                e;              /* one exponent of the left op     */
     UInt                len;            /* number of terms                 */
-    Obj *               cfs;            /* pointer to the coefficients     */
-    UInt4 *             exs;            /* pointer to the exponents        */
+    const Obj *         cfs;            /* pointer to the coefficients     */
+    const UInt4 *       exs;            /* pointer to the exponents        */
     Obj *               res;            /* pointer to the result           */
     Obj                 sum;            /* sum of two coefficients         */
     Obj                 prd;            /* product of two coefficients     */
@@ -1225,21 +1256,21 @@ Obj             ProdCyc (
     /* loop over the terms of the right operand                            */
     for ( k = 1; k < SIZE_CYC(opR); k++ ) {
         c = COEFS_CYC(opR)[k];
-        e = (mr * EXPOS_CYC( opR, SIZE_CYC(opR) )[k]) % n;
+        e = (mr * CONST_EXPOS_CYC( opR, SIZE_CYC(opR) )[k]) % n;
 
         /* if the coefficient is 1 just add                                */
         if ( c == INTOBJ_INT(1) ) {
             len = SIZE_CYC(opL);
-            cfs = COEFS_CYC(opL);
-            exs = EXPOS_CYC(opL,len);
+            cfs = CONST_COEFS_CYC(opL);
+            exs = CONST_EXPOS_CYC(opL,len);
             res = BASE_PTR_PLIST(STATE(ResultCyc));
             for ( i = 1; i < len; i++ ) {
                 if ( ! ARE_INTOBJS( res[(e+exs[i]*ml)%n], cfs[i] )
                   || ! SUM_INTOBJS( sum, res[(e+exs[i]*ml)%n], cfs[i] ) ) {
                     CHANGED_BAG( STATE(ResultCyc) );
                     sum = SUM( res[(e+exs[i]*ml)%n], cfs[i] );
-                    cfs = COEFS_CYC(opL);
-                    exs = EXPOS_CYC(opL,len);
+                    cfs = CONST_COEFS_CYC(opL);
+                    exs = CONST_EXPOS_CYC(opL,len);
                     res = BASE_PTR_PLIST(STATE(ResultCyc));
                 }
                 res[(e+exs[i]*ml)%n] = sum;
@@ -1250,16 +1281,16 @@ Obj             ProdCyc (
         /* if the coefficient is -1 just subtract                          */
         else if ( c == INTOBJ_INT(-1) ) {
             len = SIZE_CYC(opL);
-            cfs = COEFS_CYC(opL);
-            exs = EXPOS_CYC(opL,len);
+            cfs = CONST_COEFS_CYC(opL);
+            exs = CONST_EXPOS_CYC(opL,len);
             res = BASE_PTR_PLIST(STATE(ResultCyc));
             for ( i = 1; i < len; i++ ) {
                 if ( ! ARE_INTOBJS( res[(e+exs[i]*ml)%n], cfs[i] )
                   || ! DIFF_INTOBJS( sum, res[(e+exs[i]*ml)%n], cfs[i] ) ) {
                     CHANGED_BAG( STATE(ResultCyc) );
                     sum = DIFF( res[(e+exs[i]*ml)%n], cfs[i] );
-                    cfs = COEFS_CYC(opL);
-                    exs = EXPOS_CYC(opL,len);
+                    cfs = CONST_COEFS_CYC(opL);
+                    exs = CONST_EXPOS_CYC(opL,len);
                     res = BASE_PTR_PLIST(STATE(ResultCyc));
                 }
                 res[(e+exs[i]*ml)%n] = sum;
@@ -1270,8 +1301,8 @@ Obj             ProdCyc (
         /* if the coefficient is a small integer use immediate operations  */
         else if ( IS_INTOBJ(c) ) {
             len = SIZE_CYC(opL);
-            cfs = COEFS_CYC(opL);
-            exs = EXPOS_CYC(opL,len);
+            cfs = CONST_COEFS_CYC(opL);
+            exs = CONST_EXPOS_CYC(opL,len);
             res = BASE_PTR_PLIST(STATE(ResultCyc));
             for ( i = 1; i < len; i++ ) {
                 if ( ! ARE_INTOBJS( cfs[i], res[(e+exs[i]*ml)%n] )
@@ -1279,11 +1310,11 @@ Obj             ProdCyc (
                   || ! SUM_INTOBJS( sum, res[(e+exs[i]*ml)%n], prd ) ) {
                     CHANGED_BAG( STATE(ResultCyc) );
                     prd = PROD( cfs[i], c );
-                    exs = EXPOS_CYC(opL,len);
+                    exs = CONST_EXPOS_CYC(opL,len);
                     res = BASE_PTR_PLIST(STATE(ResultCyc));
                     sum = SUM( res[(e+exs[i]*ml)%n], prd );
-                    cfs = COEFS_CYC(opL);
-                    exs = EXPOS_CYC(opL,len);
+                    cfs = CONST_COEFS_CYC(opL);
+                    exs = CONST_EXPOS_CYC(opL,len);
                     res = BASE_PTR_PLIST(STATE(ResultCyc));
                 }
                 res[(e+exs[i]*ml)%n] = sum;
@@ -1296,12 +1327,12 @@ Obj             ProdCyc (
             len = SIZE_CYC(opL);
             for ( i = 1; i < len; i++ ) {
                 CHANGED_BAG( STATE(ResultCyc) );
-                cfs = COEFS_CYC(opL);
+                cfs = CONST_COEFS_CYC(opL);
                 prd = PROD( cfs[i], c );
-                exs = EXPOS_CYC(opL,len);
+                exs = CONST_EXPOS_CYC(opL,len);
                 res = BASE_PTR_PLIST(STATE(ResultCyc));
                 sum = SUM( res[(e+exs[i]*ml)%n], prd );
-                exs = EXPOS_CYC(opL,len);
+                exs = CONST_EXPOS_CYC(opL,len);
                 res = BASE_PTR_PLIST(STATE(ResultCyc));
                 res[(e+exs[i]*ml)%n] = sum;
             }
@@ -1351,8 +1382,8 @@ Obj             InvCyc (
     UInt                n;              /* order of the field              */
     UInt                sqr;            /* if n < sqr*sqr n is squarefree  */
     UInt                len;            /* number of terms                 */
-    Obj *               cfs;            /* pointer to the coefficients     */
-    UInt4 *             exs;            /* pointer to the exponents        */
+    const Obj *         cfs;            /* pointer to the coefficients     */
+    const UInt4 *       exs;            /* pointer to the exponents        */
     Obj *               res;            /* pointer to the result           */
     UInt                i, k;           /* loop variable                   */
     UInt                gcd, s, t;      /* gcd of i and n, temporaries     */
@@ -1372,8 +1403,8 @@ Obj             InvCyc (
         if ( gcd == 1 ) {
 
             /* permute the terms                                           */
-            cfs = COEFS_CYC(op);
-            exs = EXPOS_CYC(op,len);
+            cfs = CONST_COEFS_CYC(op);
+            exs = CONST_EXPOS_CYC(op,len);
             res = BASE_PTR_PLIST(STATE(ResultCyc));
             for ( k = 1; k < len; k++ )
                 res[(i*exs[k])%n] = cfs[k];
@@ -1440,8 +1471,8 @@ Obj             PowCyc (
     /* for $(c*e_n^i)^exp$ if $e_n^i$ belongs to the base put 1 at $i*exp$ */
     else if ( SIZE_CYC(opL) == 2 ) {
         n = INT_INTOBJ( NOF_CYC(opL) );
-        pow = POW( COEFS_CYC(opL)[1], opR );
-        i = EXPOS_CYC(opL,2)[1];
+        pow = POW( CONST_COEFS_CYC(opL)[1], opR );
+        i = CONST_EXPOS_CYC(opL,2)[1];
         exp = ((exp*(Int)i) % n + n) % n;
         SET_ELM_PLIST( STATE(ResultCyc), exp + 1, pow );
         CHANGED_BAG( STATE(ResultCyc) );
@@ -1578,7 +1609,7 @@ Obj FuncIS_CYC_INT (
     Obj                 val )
 {
     UInt                len;            /* number of terms                 */
-    Obj *               cfs;            /* pointer to the coefficients     */
+    const Obj *         cfs;            /* pointer to the coefficients     */
     UInt                i;              /* loop variable                   */
 
     /* return 'true' if <obj> is a cyclotomic integer and 'false' otherwise*/
@@ -1708,8 +1739,8 @@ Obj FuncCOEFFS_CYC (
     Obj                 list;           /* list of coefficients, result    */
     UInt                n;              /* order of field                  */
     UInt                len;            /* number of terms                 */
-    Obj *               cfs;            /* pointer to the coefficients     */
-    UInt4 *             exs;            /* pointer to the exponents        */
+    const Obj *         cfs;            /* pointer to the coefficients     */
+    const UInt4 *       exs;            /* pointer to the exponents        */
     UInt                i;              /* loop variable                   */
 
     /* do full operation                                                   */
@@ -1742,8 +1773,8 @@ Obj FuncCOEFFS_CYC (
         list = NEW_PLIST( T_PLIST, n );
         SET_LEN_PLIST( list, n );
         len = SIZE_CYC(cyc);
-        cfs = COEFS_CYC(cyc);
-        exs = EXPOS_CYC(cyc,len);
+        cfs = CONST_COEFS_CYC(cyc);
+        exs = CONST_EXPOS_CYC(cyc,len);
         for ( i = 1; i <= n; i++ )
             SET_ELM_PLIST( list, i, INTOBJ_INT(0) );
         for ( i = 1; i < len; i++ )
@@ -1785,8 +1816,8 @@ Obj FuncGALOIS_CYC (
     Int                 o;              /* galois automorphism             */
     UInt                gcd, s, t;      /* gcd of n and ord, temporaries   */
     UInt                len;            /* number of terms                 */
-    Obj *               cfs;            /* pointer to the coefficients     */
-    UInt4 *             exs;            /* pointer to the exponents        */
+    const Obj *         cfs;            /* pointer to the coefficients     */
+    const UInt4 *       exs;            /* pointer to the exponents        */
     Obj *               res;            /* pointer to the result           */
     UInt                i;              /* loop variable                   */
     UInt                tnumord, tnumcyc;
@@ -1851,15 +1882,15 @@ Obj FuncGALOIS_CYC (
     else if ( n % 2 == 0  && o == n/2 ) {
         gal = INTOBJ_INT(0);
         len = SIZE_CYC(cyc);
-        cfs = COEFS_CYC(cyc);
-        exs = EXPOS_CYC(cyc,len);
+        cfs = CONST_COEFS_CYC(cyc);
+        exs = CONST_EXPOS_CYC(cyc,len);
         for ( i = 1; i < len; i++ ) {
             if ( exs[i] % 2 == 1 ) {
                 if ( ! ARE_INTOBJS( gal, cfs[i] )
                   || ! DIFF_INTOBJS( sum, gal, cfs[i] ) ) {
                     sum = DIFF( gal, cfs[i] );
-                    cfs = COEFS_CYC(cyc);
-                    exs = EXPOS_CYC(cyc,len);
+                    cfs = CONST_COEFS_CYC(cyc);
+                    exs = CONST_EXPOS_CYC(cyc,len);
                 }
                 gal = sum;
             }
@@ -1867,8 +1898,8 @@ Obj FuncGALOIS_CYC (
                 if ( ! ARE_INTOBJS( gal, cfs[i] )
                   || ! SUM_INTOBJS( sum, gal, cfs[i] ) ) {
                     sum = SUM( gal, cfs[i] );
-                    cfs = COEFS_CYC(cyc);
-                    exs = EXPOS_CYC(cyc,len);
+                    cfs = CONST_COEFS_CYC(cyc);
+                    exs = CONST_EXPOS_CYC(cyc,len);
                 }
                 gal = sum;
             }
@@ -1880,8 +1911,8 @@ Obj FuncGALOIS_CYC (
 
         /* permute the coefficients                                        */
         len = SIZE_CYC(cyc);
-        cfs = COEFS_CYC(cyc);
-        exs = EXPOS_CYC(cyc,len);
+        cfs = CONST_COEFS_CYC(cyc);
+        exs = CONST_EXPOS_CYC(cyc,len);
         res = BASE_PTR_PLIST(STATE(ResultCyc));
         for ( i = 1; i < len; i++ ) {
             res[(UInt8)exs[i]*(UInt8)o%(UInt8)n] = cfs[i];
@@ -1904,16 +1935,16 @@ Obj FuncGALOIS_CYC (
 
         /* multiple roots may be mapped to the same root, add the coeffs   */
         len = SIZE_CYC(cyc);
-        cfs = COEFS_CYC(cyc);
-        exs = EXPOS_CYC(cyc,len);
+        cfs = CONST_COEFS_CYC(cyc);
+        exs = CONST_EXPOS_CYC(cyc,len);
         res = BASE_PTR_PLIST(STATE(ResultCyc));
         for ( i = 1; i < len; i++ ) {
             if ( ! ARE_INTOBJS( res[(UInt8)exs[i]*(UInt8)o%(UInt8)n], cfs[i] )
               || ! SUM_INTOBJS( sum, res[(UInt8)exs[i]*(UInt8)o%(UInt8)n], cfs[i] ) ) {
                 CHANGED_BAG( STATE(ResultCyc) );
                 sum = SUM( res[(UInt8)exs[i]*(UInt8)o%(UInt8)n], cfs[i] );
-                cfs = COEFS_CYC(cyc);
-                exs = EXPOS_CYC(cyc,len);
+                cfs = CONST_COEFS_CYC(cyc);
+                exs = CONST_EXPOS_CYC(cyc,len);
                 res = BASE_PTR_PLIST(STATE(ResultCyc));
             }
             res[exs[i]*o%n] = sum;
@@ -2018,13 +2049,13 @@ void MarkCycSubBags( Obj cyc )
 void  SaveCyc ( Obj cyc )
 {
   UInt len, i;
-  Obj *coefs;
-  UInt4 *expos;
+  const Obj *coefs;
+  const UInt4 *expos;
   len = SIZE_CYC(cyc);
-  coefs = COEFS_CYC(cyc);
+  coefs = CONST_COEFS_CYC(cyc);
   for (i = 0; i < len; i++)
     SaveSubObj(*coefs++);
-  expos = EXPOS_CYC(cyc,len);
+  expos = CONST_EXPOS_CYC(cyc,len);
   expos++;                      /*Skip past the XXX */
   for (i = 1; i < len; i++)
     SaveUInt4(*expos++);

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1095,9 +1095,7 @@ Obj             DoExecFuncXargs (
 
 #ifdef HPCGAP
 
-void            LockFuncArgs (
-    Obj                 func,
-    Obj *               args )
+static void LockFuncArgs(Obj func, const Obj * args)
 {
     Int nargs = NARG_FUNC(func);
     Int i;
@@ -1411,7 +1409,7 @@ Obj             DoExecFuncXargsL (
         PLAIN_LIST( args );
     }
 
-    LockFuncArgs(func, ADDR_OBJ(args) + 1);
+    LockFuncArgs(func, CONST_ADDR_OBJ(args) + 1);
 
     /* switch to a new values bag                                          */
     SWITCH_TO_NEW_LVARS( func, len, NLOC_FUNC(func), oldLvars );

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -296,6 +296,12 @@ static inline Bag *PTR_BAG(Bag bag)
     return *(Bag**)bag;
 }
 
+static inline const Bag *CONST_PTR_BAG(Bag bag)
+{
+    GAP_ASSERT(bag != 0);
+    return *(const Bag**)bag;
+}
+
 static inline void SET_PTR_BAG(Bag bag, Bag *val)
 {
     GAP_ASSERT(bag != 0);

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -108,17 +108,6 @@ static inline BagHeader * BAG_HEADER(Bag bag) {
 
 /****************************************************************************
 **
-*F  BAG_HEADER_CONTENTS(<ptr>) . . . . . . . . . . . . . . .  header of a bag
-**
-**  'BAG_HEADER' returns the header of the bag whose contents start at <ptr>.
-*/
-static inline BagHeader * BAG_HEADER_CONTENTS(void *ptr) {
-    return (((BagHeader *)ptr) - 1);
-}
-
-
-/****************************************************************************
-**
 *F  TNUM_BAG(<bag>) . . . . . . . . . . . . . . . . . . . . . . type of a bag
 **
 **  'TNUM_BAG' returns the type of the bag with the identifier <bag>.
@@ -217,8 +206,8 @@ static inline UInt SIZE_BAG(Bag bag) {
 **  atomic operations that require a memory barrier in between dereferencing
 **  the bag pointer and accessing the contents of the bag.
 */
-static inline UInt SIZE_BAG_CONTENTS(void *ptr) {
-    return BAG_HEADER_CONTENTS(ptr)->size;
+static inline UInt SIZE_BAG_CONTENTS(const void *ptr) {
+    return ((const BagHeader *)ptr)[-1].size;
 }
 
 

--- a/src/gmpints.c
+++ b/src/gmpints.c
@@ -150,7 +150,7 @@ static Obj ObjInt_UIntInv( UInt i );
 
 
 /* macros to save typing later :)  */
-#define VAL_LIMB0(obj)          (*ADDR_INT(obj))
+#define VAL_LIMB0(obj)          (*CONST_ADDR_INT(obj))
 #define SET_VAL_LIMB0(obj,val)  do { *ADDR_INT(obj) = val; } while(0)
 #define IS_INTPOS(obj)          (TNUM_OBJ(obj) == T_INTPOS)
 #define IS_INTNEG(obj)          (TNUM_OBJ(obj) == T_INTNEG)
@@ -249,10 +249,8 @@ Obj FuncIS_INT ( Obj self, Obj val )
 */
 void SaveInt( Obj gmp )
 {
-  mp_limb_t *ptr;
-  UInt i;
-  ptr = ADDR_INT(gmp);
-  for (i = 0; i < SIZE_INT(gmp); i++)
+  const mp_limb_t *ptr = CONST_ADDR_INT(gmp);
+  for (UInt i = 0; i < SIZE_INT(gmp); i++)
     SaveLimb(*ptr++);
   return;
 }
@@ -266,10 +264,8 @@ void SaveInt( Obj gmp )
 */
 void LoadInt( Obj gmp )
 {
-  mp_limb_t *ptr;
-  UInt i;
-  ptr = ADDR_INT(gmp);
-  for (i = 0; i < SIZE_INT(gmp); i++)
+  mp_limb_t *ptr = ADDR_INT(gmp);
+  for (UInt i = 0; i < SIZE_INT(gmp); i++)
     *ptr++ = LoadLimb();
   return;
 }
@@ -417,7 +413,7 @@ Obj GMP_NORMALIZE ( Obj gmp )
     return gmp;
   }
   for ( size = SIZE_INT(gmp); size != (mp_size_t)1; size-- ) {
-    if ( ADDR_INT(gmp)[(size - 1)] != 0 ) {
+    if ( CONST_ADDR_INT(gmp)[(size - 1)] != 0 ) {
       break;
     }
   }
@@ -464,7 +460,7 @@ int IS_NORMALIZED_AND_REDUCED( Obj op, const char *func, int line )
     return 0;
   }
   for ( size = SIZE_INT(op); size != (mp_size_t)1; size-- ) {
-    if ( ADDR_INT(op)[(size - 1)] != 0 ) {
+    if ( CONST_ADDR_INT(op)[(size - 1)] != 0 ) {
       break;
     }
   }
@@ -857,7 +853,7 @@ Obj FuncLog2Int( Obj self, Obj integer)
 
   if ( IS_LARGEINT(integer) ) {
     UInt len = SIZE_INT(integer) - 1;
-    UInt a = CLog2UInt( ADDR_INT(integer)[len] );
+    UInt a = CLog2UInt( CONST_ADDR_INT(integer)[len] );
 
     CHECK_INT(integer);
 
@@ -919,7 +915,7 @@ Int EqInt ( Obj gmpL, Obj gmpR )
        || SIZE_INT(gmpL) != SIZE_INT(gmpR) )
     return 0L;
 
-  if ( mpn_cmp( ADDR_INT(gmpL), ADDR_INT(gmpR), SIZE_INT(gmpL) ) == 0 ) 
+  if ( mpn_cmp( CONST_ADDR_INT(gmpL), CONST_ADDR_INT(gmpR), SIZE_INT(gmpL) ) == 0 ) 
     return 1L;
   else
     return 0L;
@@ -956,7 +952,7 @@ Int LtInt ( Obj gmpL, Obj gmpR )
   else if ( SIZE_INT(gmpL) > SIZE_INT(gmpR) )
     res = 0;
   else
-    res = mpn_cmp( ADDR_INT(gmpL), ADDR_INT(gmpR), SIZE_INT(gmpL) ) < 0;
+    res = mpn_cmp( CONST_ADDR_INT(gmpL), CONST_ADDR_INT(gmpR), SIZE_INT(gmpL) ) < 0;
 
   /* if both arguments are negative, flip the result */
   if ( IS_INTNEG(gmpL) )
@@ -1107,7 +1103,7 @@ Obj AInvInt ( Obj gmp )
       inv = NewBag( T_INTPOS, SIZE_OBJ(gmp) );
     }
 
-    memcpy( ADDR_INT(inv), ADDR_INT(gmp), SIZE_OBJ(gmp) );
+    memcpy( ADDR_INT(inv), CONST_ADDR_INT(gmp), SIZE_OBJ(gmp) );
   }
   
   /* return the inverse                                                    */
@@ -1138,7 +1134,7 @@ Obj AbsInt( Obj op )
     return op;
   } else if ( IS_INTNEG(op) ) {
     a = NewBag( T_INTPOS, SIZE_OBJ(op) );
-    memcpy( ADDR_INT(a), ADDR_INT(op), SIZE_OBJ(op) );
+    memcpy( ADDR_INT(a), CONST_ADDR_INT(op), SIZE_OBJ(op) );
     return a;
   }
   return Fail;
@@ -1322,7 +1318,7 @@ Obj ProdIntObj ( Obj n, Obj op )
     res = 0;
     for ( i = SIZE_INT(n); 0 < i; i-- ) {
       k = 8*sizeof(mp_limb_t);
-      l = ADDR_INT(n)[i-1];
+      l = CONST_ADDR_INT(n)[i-1];
       while ( 0 < k ) {
         res = (res == 0 ? res : SUM( res, res ));
         k--;
@@ -1490,7 +1486,7 @@ Obj             PowObjInt ( Obj op, Obj n )
     res = 0;
     for ( i = SIZE_INT(n); 0 < i; i-- ) {
       k = 8*sizeof(mp_limb_t);
-      l = ADDR_INT(n)[i-1];
+      l = CONST_ADDR_INT(n)[i-1];
       while ( 0 < k ) {
         res = (res == 0 ? res : PROD( res, res ));
         k--;
@@ -1593,7 +1589,7 @@ Obj ModInt ( Obj opL, Obj opR )
     
     /* otherwise use the gmp function to divide                            */
     else {
-      c = mpn_mod_1( ADDR_INT(opL), SIZE_INT(opL), (mp_limb_t)i );
+      c = mpn_mod_1( CONST_ADDR_INT(opL), SIZE_INT(opL), (mp_limb_t)i );
     }
     
     /* now c is the result, it has the same sign as the left operand       */
@@ -1633,8 +1629,8 @@ Obj ModInt ( Obj opL, Obj opR )
 
     /* and let gmp do the work                                             */
     mpn_tdiv_qr( ADDR_INT(quo), ADDR_INT(mod), 0,
-                 ADDR_INT(opL), SIZE_INT(opL),
-                 ADDR_INT(opR), SIZE_INT(opR)    );
+                 CONST_ADDR_INT(opL), SIZE_INT(opL),
+                 CONST_ADDR_INT(opR), SIZE_INT(opR)    );
       
     /* reduce to small integer if possible, otherwise shrink bag           */
     mod = GMP_NORMALIZE( mod );
@@ -1746,7 +1742,7 @@ Obj QuoInt ( Obj opL, Obj opR )
 
     /* use gmp function for dividing by a 1-limb number                    */
     mpn_divrem_1( ADDR_INT(quo), 0,
-                  ADDR_INT(opL), SIZE_INT(opL),
+                  CONST_ADDR_INT(opL), SIZE_INT(opL),
                   k );
   }
   
@@ -1769,8 +1765,8 @@ Obj QuoInt ( Obj opL, Obj opR )
                     (SIZE_INT(opL)-SIZE_INT(opR)+1)*sizeof(mp_limb_t) );
 
     mpn_tdiv_qr( ADDR_INT(quo), ADDR_INT(rem), 0,
-                 ADDR_INT(opL), SIZE_INT(opL),
-                 ADDR_INT(opR), SIZE_INT(opR) );
+                 CONST_ADDR_INT(opL), SIZE_INT(opL),
+                 CONST_ADDR_INT(opR), SIZE_INT(opR) );
   }
   
   /* normalize and return the result                                       */
@@ -1873,7 +1869,7 @@ Obj RemInt ( Obj opL, Obj opR )
     
     /* otherwise use the gmp function to divide                            */
     else {
-      c = mpn_mod_1( ADDR_INT(opL), SIZE_INT(opL), i );
+      c = mpn_mod_1( CONST_ADDR_INT(opL), SIZE_INT(opL), i );
     }
     
     /* now c is the result, it has the same sign as the left operand       */
@@ -1898,8 +1894,8 @@ Obj RemInt ( Obj opL, Obj opR )
     
     /* and let gmp do the work                                             */
     mpn_tdiv_qr( ADDR_INT(quo), ADDR_INT(rem), 0,
-                 ADDR_INT(opL), SIZE_INT(opL),
-                 ADDR_INT(opR), SIZE_INT(opR)    );
+                 CONST_ADDR_INT(opL), SIZE_INT(opL),
+                 CONST_ADDR_INT(opR), SIZE_INT(opR)    );
     
     /* reduce to small integer if possible, otherwise shrink bag           */
     rem = GMP_NORMALIZE( rem );

--- a/src/gmpints.h
+++ b/src/gmpints.h
@@ -55,6 +55,7 @@ extern "C" {
 
 
 #define ADDR_INT(obj)          ((mp_limb_t *)ADDR_OBJ(obj))
+#define CONST_ADDR_INT(obj)    ((const mp_limb_t *)CONST_ADDR_OBJ(obj))
 #define SIZE_INT(obj)          ((mp_size_t)SIZE_OBJ(obj)/sizeof(mp_limb_t))
 /* SIZE_INT gives a result in limbs                                        */
 

--- a/src/hpc/aobjects.h
+++ b/src/hpc/aobjects.h
@@ -133,7 +133,7 @@ static inline Obj ATOMIC_SET_ELM_PLIST_ONCE(Obj list, UInt index, Obj value) {
 
 static inline Obj ATOMIC_ELM_PLIST(Obj list, UInt index) {
 #ifndef WARD_ENABLED
-  Obj *contents = ADDR_OBJ(list);
+  const Obj *contents = CONST_ADDR_OBJ(list);
   Obj result;
   result = contents[index];
   MEMBAR_READ(); /* matching memory barrier. */

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -379,7 +379,7 @@ Obj DeserializeFFE(UInt tnum)
 
 void SerializeChar(Obj obj)
 {
-    UChar ch = *(char *)ADDR_OBJ(obj);
+    UChar ch = CHAR_VALUE(obj);
     WriteTNum(T_CHAR);
     WriteByte(ch);
 }

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -528,7 +528,7 @@ Int HASHKEY_MEM_NC(const void * ptr, UInt4 seed, Int read)
 
 Int HASHKEY_BAG_NC(Obj obj, UInt4 seed, Int skip, int read)
 {
-    return HASHKEY_MEM_NC((const void *)((UChar *)ADDR_OBJ(obj) + skip), seed,
+    return HASHKEY_MEM_NC((const UChar *)CONST_ADDR_OBJ(obj) + skip, seed,
                           read);
 }
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -4031,7 +4031,7 @@ void            IntrElmPosObj ( void )
          * only have read-only access, we have to be careful when accessing
          * positional objects.
          */
-        Bag *contents = PTR_BAG(list);
+        const Bag *contents = CONST_PTR_BAG(list);
         MEMBAR_READ(); /* essential memory barrier */
         if ( SIZE_BAG_CONTENTS(contents)/sizeof(Obj)-1 < p ) {
             ErrorQuit(
@@ -4204,7 +4204,7 @@ void            IntrIsbPosObj ( void )
          * only have read-only access, we have to be careful when accessing
          * positional objects.
          */
-        Bag *contents = PTR_BAG(list);
+        const Bag *contents = CONST_PTR_BAG(list);
         if (p > SIZE_BAG_CONTENTS(contents)/sizeof(Obj)-1)
           isb = False;
         else

--- a/src/macfloat.h
+++ b/src/macfloat.h
@@ -32,7 +32,7 @@ typedef double Double;
 #endif
 
 static inline Double VAL_MACFLOAT(Obj obj)
-{ Double __val; memcpy(&__val,ADDR_OBJ(obj),sizeof(Double)); return __val; }
+{ Double __val; memcpy(&__val,CONST_ADDR_OBJ(obj),sizeof(Double)); return __val; }
 static inline void SET_VAL_MACFLOAT(Obj obj, Double val)
 { Double __val = (val); memcpy(ADDR_OBJ(obj),&__val,sizeof(Double)); }
 

--- a/src/objccoll-impl.h
+++ b/src/objccoll-impl.h
@@ -55,11 +55,11 @@
 **  global exponent because the beginning of  the word might not commute with
 **  the rest.
 **/
-static void AddWordIntoExpVec( Int *v, UIntN *w, Int e, 
+static void AddWordIntoExpVec( Int *v, const UIntN *w, Int e, 
                            Int ebits, UInt expm, 
-                           Int p, Obj *pow, Int lpow ) {
+                           Int p, const Obj *pow, Int lpow ) {
 
-    UIntN *    wend = w + (INT_INTOBJ((((Obj*)(w))[-1])) - 1);
+    const UIntN * wend = w + (INT_INTOBJ((((const Obj*)(w))[-1])) - 1);
     Int        i;
     Int        ex;
 
@@ -78,11 +78,11 @@ static void AddWordIntoExpVec( Int *v, UIntN *w, Int e,
     }
 }
 
-static void AddCommIntoExpVec( Int *v, UIntN *w, Int e, 
+static void AddCommIntoExpVec( Int *v, const UIntN *w, Int e, 
                            Int ebits, UInt expm, 
-                           Int p, Obj *pow, Int lpow ) {
+                           Int p, const Obj *pow, Int lpow ) {
 
-    UIntN *    wend = w + (INT_INTOBJ((((Obj*)(w))[-1])) - 1);
+    const UIntN * wend = w + (INT_INTOBJ((((const Obj*)(w))[-1])) - 1);
     Int        i;
     Int        ex;
 
@@ -103,9 +103,9 @@ static void AddCommIntoExpVec( Int *v, UIntN *w, Int e,
     }
 }
 
-static void AddPartIntoExpVec( Int *v, UIntN *w, UIntN *wend,
+static void AddPartIntoExpVec( Int *v, const UIntN *w, const UIntN *wend,
                            Int ebits, UInt expm, 
-                           Int p, Obj *pow, Int lpow ) {
+                           Int p, const Obj *pow, Int lpow ) {
 
     Int        i;
     Int        ex;
@@ -144,18 +144,18 @@ Int CombiCollectWord ( Obj sc, Obj vv, Obj w )
 
     Obj         vpow;       /* rhs of power relations                      */
     Int         lpow;       /* length of <vpow>                            */
-    Obj *       pow;        /* address of <vpow>                           */
+    const Obj * pow;        /* address of <vpow>                           */
 
     Obj         vcnj;       /* rhs of conjugate relations                  */
     Int         lcnj;       /* length of <vcnj>                            */
-    Obj *       cnj;        /* address of <vcnj>                           */
+    const Obj * cnj;        /* address of <vcnj>                           */
 
-    Obj *       avc;        /* address of the avector                      */
-    Obj *       avc2;       /* address of the avector 2                    */
-    Obj *       wt;         /* address of the weights array                */
-    Obj *       gns;        /* address of the list of generators           */
-    Obj *       ro;         /* address of the list of relative orders      */
-    Obj *       inv;        /* address of the list of inverses             */
+    const Obj * avc;        /* address of the avector                      */
+    const Obj * avc2;       /* address of the avector 2                    */
+    const Obj * wt;         /* address of the weights array                */
+    const Obj * gns;        /* address of the list of generators           */
+    const Obj * ro;         /* address of the list of relative orders      */
+    const Obj * inv;        /* address of the list of inverses             */
 
     Int *       v;          /* address of <vv>                             */
 
@@ -242,23 +242,23 @@ Int CombiCollectWord ( Obj sc, Obj vv, Obj w )
     /* conjugates, powers, order, generators, avector, inverses            */
     vpow = SC_POWERS(sc);
     lpow = LEN_PLIST(vpow);
-    pow  = ADDR_OBJ(vpow);
+    pow  = CONST_ADDR_OBJ(vpow);
 
     vcnj = SC_CONJUGATES(sc);
     lcnj = LEN_PLIST(vcnj);
     (void) lcnj; /* please compiler -- lcnj not actually used */
-    cnj  = ADDR_OBJ(vcnj);
+    cnj  = CONST_ADDR_OBJ(vcnj);
 
-    avc = ADDR_OBJ( SC_AVECTOR(sc) );
-    gns = ADDR_OBJ( SC_RWS_GENERATORS(sc) );
+    avc = CONST_ADDR_OBJ( SC_AVECTOR(sc) );
+    gns = CONST_ADDR_OBJ( SC_RWS_GENERATORS(sc) );
 
     cl   = INT_INTOBJ( SC_CLASS(sc) );
-    wt   = ADDR_OBJ( SC_WEIGHTS(sc) );
-    avc2 = ADDR_OBJ( SC_AVECTOR2(sc) );
+    wt   = CONST_ADDR_OBJ( SC_WEIGHTS(sc) );
+    avc2 = CONST_ADDR_OBJ( SC_AVECTOR2(sc) );
 
-    ro  = ADDR_OBJ( SC_RELATIVE_ORDERS(sc) );
+    ro  = CONST_ADDR_OBJ( SC_RELATIVE_ORDERS(sc) );
     p   = INT_INTOBJ(ro[1]);
-    inv = ADDR_OBJ( SC_INVERSES(sc) );
+    inv = CONST_ADDR_OBJ( SC_INVERSES(sc) );
 
     /* initialize the stack with <w>                                        */
     sp = 0;

--- a/src/objccoll.h
+++ b/src/objccoll.h
@@ -27,13 +27,13 @@
 **
 */
 #define SC_CLASS(sc) \
-    (ADDR_OBJ(sc)[SCP_CLASS])
+    (CONST_ADDR_OBJ(sc)[SCP_CLASS])
 
 #define SC_WEIGHTS(sc) \
-    (ADDR_OBJ(sc)[SCP_WEIGHTS])
+    (CONST_ADDR_OBJ(sc)[SCP_WEIGHTS])
 
 #define SC_AVECTOR2(sc) \
-    (ADDR_OBJ(sc)[SCP_AVECTOR2])
+    (CONST_ADDR_OBJ(sc)[SCP_AVECTOR2])
 
 
 /****************************************************************************

--- a/src/objects.h
+++ b/src/objects.h
@@ -310,6 +310,11 @@ static inline Obj *ADDR_OBJ(Obj obj)
     return PTR_BAG(obj);
 }
 
+static inline const Obj *CONST_ADDR_OBJ(Obj obj)
+{
+    return CONST_PTR_BAG(obj);
+}
+
 
 /****************************************************************************
 **

--- a/src/objfgelm.h
+++ b/src/objfgelm.h
@@ -93,7 +93,7 @@
 **  pairs of <word>.
 */
 #define NPAIRS_WORD( word ) \
-    ( INT_INTOBJ( ADDR_OBJ( (word) )[1]) )
+    ( INT_INTOBJ( CONST_ADDR_OBJ( (word) )[1]) )
 
 
 /****************************************************************************

--- a/src/objscoll-impl.h
+++ b/src/objscoll-impl.h
@@ -123,7 +123,7 @@ Int VectorWord ( Obj vv, Obj v, Int num )
         return -1; \
     } \
     *++nw = (void*)DATA_WORD(word); \
-    *++lw = *nw + (INT_INTOBJ((((Obj*)(*nw))[-1])) - 1); \
+    *++lw = *nw + (INT_INTOBJ((((const Obj*)(*nw))[-1])) - 1); \
     *++pw = *nw; \
     *++ew = (**pw) & expm; \
     *++ge = exp
@@ -144,11 +144,11 @@ Int VectorWord ( Obj vv, Obj v, Int num )
 **  global exponent because the beginning of  the word might not commute with
 **  the rest.
 **/
-static Int SAddWordIntoExpVec( Int *v, UIntN *w, Int e, 
+static Int SAddWordIntoExpVec( Int *v, const UIntN *w, Int e, 
                            Int ebits, UInt expm, 
-                           Obj *ro, Obj *pow, Int lpow ) {
+                           const Obj *ro, const Obj *pow, Int lpow ) {
 
-    UIntN *    wend = w + (INT_INTOBJ((((Obj*)(w))[-1])) - 1);
+    const UIntN * wend = w + (INT_INTOBJ((((const Obj*)(w))[-1])) - 1);
     Int        i;
     Int        ex;
     Int        start = 0;
@@ -170,9 +170,9 @@ static Int SAddWordIntoExpVec( Int *v, UIntN *w, Int e,
     return start;
 }
 
-static Int SAddPartIntoExpVec( Int *v, UIntN *w, UIntN *wend,
+static Int SAddPartIntoExpVec( Int *v, const UIntN *w, const UIntN *wend,
                            Int ebits, UInt expm, 
-                           Obj* ro, Obj *pow, Int lpow ) {
+                           const Obj* ro, const Obj *pow, Int lpow ) {
 
     Int        i;
     Int        ex;
@@ -186,7 +186,7 @@ static Int SAddPartIntoExpVec( Int *v, UIntN *w, UIntN *wend,
             v[i] -= ex * INT_INTOBJ(ro[i]);
             if ( i <= lpow && pow[i] && 0 < NPAIRS_WORD(pow[i]) ) {
                 start = SAddWordIntoExpVec( 
-                    v, (UIntN*)DATA_WORD(pow[i]), ex,
+                    v, (const UIntN*)DATA_WORD(pow[i]), ex,
                     ebits, expm, ro, pow, lpow  );
             }
         }
@@ -214,16 +214,16 @@ Int SingleCollectWord ( Obj sc, Obj vv, Obj w )
 
     Obj         vpow;       /* rhs of power relations                      */
     Int         lpow;       /* length of <vpow>                            */
-    Obj *       pow;        /* address of <vpow>                           */
+    const Obj * pow;        /* address of <vpow>                           */
 
     Obj         vcnj;       /* rhs of conjugate relations                  */
     Int         lcnj;       /* length of <vcnj>                            */
-    Obj *       cnj;        /* address of <vcnj>                           */
-
-    Obj *       avc;        /* address of the avector                      */
-    Obj *       gns;        /* address of the list of generators           */
-    Obj *       ro;         /* address of the list of relative orders      */
-    Obj *       inv;        /* address of the list of inverses             */
+    const Obj * cnj;        /* address of <vcnj>                           */
+ 
+    const Obj * avc;        /* address of the avector                      */
+    const Obj * gns;        /* address of the list of generators           */
+    const Obj * ro;         /* address of the list of relative orders      */
+    const Obj * inv;        /* address of the list of inverses             */
 
     Int *       v;          /* address of <vv>                             */
 
@@ -312,18 +312,18 @@ Int SingleCollectWord ( Obj sc, Obj vv, Obj w )
     /* conjujagtes, powers, order, generators, avector, inverses           */
     vpow = SC_POWERS(sc);
     lpow = LEN_PLIST(vpow);
-    pow  = ADDR_OBJ(vpow);
+    pow  = CONST_ADDR_OBJ(vpow);
 
     vcnj = SC_CONJUGATES(sc);
     lcnj = LEN_PLIST(vcnj);
     (void) lcnj; /* please compiler -- lcnj not actually used */
-    cnj  = ADDR_OBJ(vcnj);
+    cnj  = CONST_ADDR_OBJ(vcnj);
 
-    avc = ADDR_OBJ( SC_AVECTOR(sc) );
-    gns = ADDR_OBJ( SC_RWS_GENERATORS(sc) );
+    avc = CONST_ADDR_OBJ( SC_AVECTOR(sc) );
+    gns = CONST_ADDR_OBJ( SC_RWS_GENERATORS(sc) );
 
-    ro  = ADDR_OBJ( SC_RELATIVE_ORDERS(sc) );
-    inv = ADDR_OBJ( SC_INVERSES(sc) );
+    ro  = CONST_ADDR_OBJ( SC_RELATIVE_ORDERS(sc) );
+    inv = CONST_ADDR_OBJ( SC_INVERSES(sc) );
 
     /* initialize the stack with <w>                                        */
     sp = 0;

--- a/src/opers.h
+++ b/src/opers.h
@@ -84,7 +84,7 @@ extern Obj TRY_NEXT_METHOD;
 **                                 storing is enabled (default) else false
 */
 
-#define ENABLED_ATTR(oper)                    ((UInt)(ADDR_OBJ(oper)[37])) 
+#define ENABLED_ATTR(oper)                 ((UInt)(CONST_ADDR_OBJ(oper)[37]))
 
 /****************************************************************************
 **
@@ -130,7 +130,7 @@ extern Obj TRY_NEXT_METHOD;
 **
 **  returns the list of trues of <flags> or 0 if the list is not known yet.
 */
-#define TRUES_FLAGS(flags)              (ADDR_OBJ(flags)[0])
+#define TRUES_FLAGS(flags)              (CONST_ADDR_OBJ(flags)[0])
 
 
 /****************************************************************************
@@ -144,7 +144,7 @@ extern Obj TRY_NEXT_METHOD;
 **
 *F  HASH_FLAGS( <flags> ) . . . . . . . . . . . .  hash value of <flags> or 0
 */
-#define HASH_FLAGS(flags)               (ADDR_OBJ(flags)[1])
+#define HASH_FLAGS(flags)               (CONST_ADDR_OBJ(flags)[1])
 
 
 /****************************************************************************
@@ -158,7 +158,7 @@ extern Obj TRY_NEXT_METHOD;
 **
 *F  LEN_FLAGS( <flags> )  . . . . . . . . . . . . . .  length of a flags list
 */
-#define LEN_FLAGS(list)                 (INT_INTOBJ(ADDR_OBJ(list)[2]))
+#define LEN_FLAGS(list)                 (INT_INTOBJ(CONST_ADDR_OBJ(list)[2]))
 
 
 /****************************************************************************
@@ -172,7 +172,7 @@ extern Obj TRY_NEXT_METHOD;
 **
 *F  AND_CACHE_FLAGS( <flags> )  . . . . . . . . . `and' cache of a flags list
 */
-#define AND_CACHE_FLAGS(list)           (ADDR_OBJ(list)[3])
+#define AND_CACHE_FLAGS(list)           (CONST_ADDR_OBJ(list)[3])
 
 
 /****************************************************************************

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -2261,7 +2261,7 @@ Obj             FuncPermList (
     UInt2 *             ptPerm2;        /* pointer to the permutation      */
     UInt4 *             ptPerm4;        /* pointer to the permutation      */
     UInt                degPerm;        /* degree of the permutation       */
-    Obj *               ptList;         /* pointer to the list             */
+    const Obj *         ptList;         /* pointer to the list             */
     UInt2 *             ptTmp2;         /* pointer to the buffer bag       */
     UInt4 *             ptTmp4;         /* pointer to the buffer bag       */
     Int                 i,  k;          /* loop variables                  */

--- a/src/plist.h
+++ b/src/plist.h
@@ -152,7 +152,7 @@ static inline void SET_LEN_PLIST(Obj list, Int len)
 static inline Int LEN_PLIST(Obj list)
 {
     GAP_ASSERT(IS_PLIST_OR_POSOBJ(list));
-    return ((Int)(ADDR_OBJ(list)[0]));
+    return ((Int)(CONST_ADDR_OBJ(list)[0]));
 }
 
 
@@ -187,7 +187,7 @@ static inline Obj ELM_PLIST(Obj list, Int pos)
     GAP_ASSERT(IS_PLIST_OR_POSOBJ(list));
     GAP_ASSERT(pos >= 1);
     GAP_ASSERT(pos <= CAPACITY_PLIST(list));
-    return ADDR_OBJ(list)[pos];
+    return CONST_ADDR_OBJ(list)[pos];
 }
 
 /****************************************************************************

--- a/src/precord.c
+++ b/src/precord.c
@@ -189,7 +189,7 @@ Obj CopyPRec (
     else {
         copy = NewBag( IMMUTABLE_TNUM(TNUM_OBJ(rec)), SIZE_OBJ(rec) );
     }
-    ADDR_OBJ(copy)[0] = ADDR_OBJ(rec)[0];
+    ADDR_OBJ(copy)[0] = CONST_ADDR_OBJ(rec)[0];
 
     // leave a forwarding pointer
     ADDR_OBJ(rec)[0] = copy;
@@ -229,7 +229,7 @@ void CleanPRecCopy (
     UInt                i;              /* loop variable                   */
 
     /* remove the forwarding pointer                                       */
-    ADDR_OBJ(rec)[0] = ADDR_OBJ( ADDR_OBJ(rec)[0] )[0];
+    ADDR_OBJ(rec)[0] = CONST_ADDR_OBJ( CONST_ADDR_OBJ(rec)[0] )[0];
 
     /* now it is cleaned                                               */
     RetypeBag( rec, TNUM_OBJ(rec) - COPYING );
@@ -562,7 +562,7 @@ void SortPRecRNam (
             i++; k++;
         }
         /* Finally, copy everything back to where it came from: */
-        memcpy(ADDR_OBJ(rec)+2,ADDR_OBJ(space)+2,sizeof(Obj)*2*len);
+        memcpy(ADDR_OBJ(rec)+2,CONST_ADDR_OBJ(space)+2,sizeof(Obj)*2*len);
     } else {   /* We have to work in place to avoid a garbage collection. */
         /* i == save is the cut point */
         j = 1;

--- a/src/precord.h
+++ b/src/precord.h
@@ -89,7 +89,7 @@ static inline Int CAPACITY_PREC(Obj rec)
 static inline UInt LEN_PREC(Obj rec)
 {
     GAP_ASSERT(IS_PREC_OR_COMOBJ(rec));
-    return ((UInt *)(ADDR_OBJ(rec)))[1];
+    return ((const UInt *)(CONST_ADDR_OBJ(rec)))[1];
 }
 
 
@@ -132,7 +132,7 @@ static inline UInt GET_RNAM_PREC(Obj rec, UInt i)
 {
     GAP_ASSERT(IS_PREC_OR_COMOBJ(rec));
     GAP_ASSERT(i <= CAPACITY_PREC(rec));
-    return *(UInt *)(ADDR_OBJ(rec)+2*(i));
+    return *(const UInt *)(CONST_ADDR_OBJ(rec)+2*(i));
 }
 
 
@@ -162,7 +162,7 @@ static inline Obj GET_ELM_PREC(Obj rec, UInt i)
 {
     GAP_ASSERT(IS_PREC_OR_COMOBJ(rec));
     GAP_ASSERT(i <= CAPACITY_PREC(rec));
-    return *(ADDR_OBJ(rec)+2*(i)+1);
+    return *(CONST_ADDR_OBJ(rec)+2*(i)+1);
 }
 
 

--- a/src/range.c
+++ b/src/range.c
@@ -181,7 +181,7 @@ Obj CopyRange (
     else {
         copy = NewBag( IMMUTABLE_TNUM( TNUM_OBJ(list) ), SIZE_OBJ(list) );
     }
-    ADDR_OBJ(copy)[0] = ADDR_OBJ(list)[0];
+    ADDR_OBJ(copy)[0] = CONST_ADDR_OBJ(list)[0];
 
     /* leave a forwarding pointer                                          */
     ADDR_OBJ(list)[0] = copy;
@@ -191,8 +191,8 @@ Obj CopyRange (
     RetypeBag( list, TNUM_OBJ(list) + COPYING );
 
     /* copy the subvalues                                                  */
-    ADDR_OBJ(copy)[1] = ADDR_OBJ(list)[1];
-    ADDR_OBJ(copy)[2] = ADDR_OBJ(list)[2];
+    ADDR_OBJ(copy)[1] = CONST_ADDR_OBJ(list)[1];
+    ADDR_OBJ(copy)[2] = CONST_ADDR_OBJ(list)[2];
 
     /* return the copy                                                     */
     return copy;
@@ -229,7 +229,7 @@ void CleanRangeCopy (
     Obj                 list )
 {
     /* remove the forwarding pointer                                       */
-    ADDR_OBJ(list)[0] = ADDR_OBJ( ADDR_OBJ(list)[0] )[0];
+    ADDR_OBJ(list)[0] = CONST_ADDR_OBJ( CONST_ADDR_OBJ(list)[0] )[0];
 
     /* now it is cleaned                                                   */
     RetypeBag( list, TNUM_OBJ(list) - COPYING );
@@ -867,9 +867,9 @@ Obj FuncIS_RANGE (
 
 void SaveRange( Obj range )
 {
-  SaveSubObj(ADDR_OBJ(range)[0]); /* length */
-  SaveSubObj(ADDR_OBJ(range)[1]); /* base */
-  SaveSubObj(ADDR_OBJ(range)[2]); /* increment */
+  SaveSubObj(CONST_ADDR_OBJ(range)[0]); /* length */
+  SaveSubObj(CONST_ADDR_OBJ(range)[1]); /* base */
+  SaveSubObj(CONST_ADDR_OBJ(range)[2]); /* increment */
 }
 
 /****************************************************************************

--- a/src/range.h
+++ b/src/range.h
@@ -83,7 +83,7 @@ static inline void SET_LEN_RANGE(Obj list, Int len)
 static inline Int GET_LEN_RANGE(Obj list)
 {
     GAP_ASSERT(IS_RANGE(list));
-    return INT_INTOBJ(ADDR_OBJ(list)[0]);
+    return INT_INTOBJ(CONST_ADDR_OBJ(list)[0]);
 }
 
 
@@ -111,7 +111,7 @@ static inline void SET_LOW_RANGE(Obj list, Int low)
 static inline Int GET_LOW_RANGE(Obj list)
 {
     GAP_ASSERT(IS_RANGE(list));
-    return INT_INTOBJ(ADDR_OBJ(list)[1]);
+    return INT_INTOBJ(CONST_ADDR_OBJ(list)[1]);
 }
 
 
@@ -138,7 +138,7 @@ static inline void SET_INC_RANGE(Obj list, Int inc)
 static inline Int GET_INC_RANGE(Obj list)
 {
     GAP_ASSERT(IS_RANGE(list));
-    return INT_INTOBJ(ADDR_OBJ(list)[2]);
+    return INT_INTOBJ(CONST_ADDR_OBJ(list)[2]);
 }
 
 

--- a/src/rational.c
+++ b/src/rational.c
@@ -283,8 +283,8 @@ Obj             SumRat (
     /* make the fraction or, if possible, the integer                      */
     if ( denS != INTOBJ_INT( 1L ) ) {
         sum  = NewBag( T_RAT, 2 * sizeof(Obj) );
-        NUM_RAT(sum) = numS;
-        DEN_RAT(sum) = denS;
+        SET_NUM_RAT(sum, numS);
+        SET_DEN_RAT(sum, denS);
         /* 'CHANGED_BAG' not needed, 'sum' is the youngest bag             */
     }
     else {
@@ -320,8 +320,8 @@ Obj             AInvRat (
     CHECK_RAT(op);
     res = NewBag( T_RAT, 2 * sizeof(Obj) );
     tmp = AINV( NUM_RAT(op) );
-    NUM_RAT(res) = tmp;
-    DEN_RAT(res) = DEN_RAT(op);
+    SET_NUM_RAT(res, tmp);
+    SET_DEN_RAT(res, DEN_RAT(op));
     CHANGED_BAG(res);
     CHECK_RAT(res);
     return res;
@@ -342,8 +342,8 @@ Obj AbsRat( Obj op )
         return op;
 
     res = NewBag( T_RAT, 2 * sizeof(Obj) );
-    NUM_RAT(res) = tmp;
-    DEN_RAT(res) = DEN_RAT(op);
+    SET_NUM_RAT(res, tmp);
+    SET_DEN_RAT(res, DEN_RAT(op));
     CHANGED_BAG(res);
     CHECK_RAT(res);
     return res;
@@ -441,8 +441,8 @@ Obj             DiffRat (
     /* make the fraction or, if possible, the integer                      */
     if ( denD != INTOBJ_INT( 1L ) ) {
         dif  = NewBag( T_RAT, 2 * sizeof(Obj) );
-        NUM_RAT(dif) = numD;
-        DEN_RAT(dif) = denD;
+        SET_NUM_RAT(dif, numD);
+        SET_DEN_RAT(dif, denD);
         /* 'CHANGED_BAG' not needed, 'dif' is the youngest bag             */
     }
     else {
@@ -511,8 +511,8 @@ Obj             ProdRat (
     /* make the fraction or, if possible, the integer                      */
     if ( denP != INTOBJ_INT( 1L ) ) {
         prd = NewBag( T_RAT, 2 * sizeof(Obj) );
-        NUM_RAT(prd) = numP;
-        DEN_RAT(prd) = denP;
+        SET_NUM_RAT(prd, numP);
+        SET_DEN_RAT(prd, denP);
         /* 'CHANGED_BAG' not needed, 'prd' is the youngest bag             */
     }
     else {
@@ -630,8 +630,8 @@ Obj             QuoRat (
     /* make the fraction or, if possible, the integer                      */
     if ( denQ != INTOBJ_INT( 1L ) ) {
         quo = NewBag( T_RAT, 2 * sizeof(Obj) );
-        NUM_RAT(quo) = numQ;
-        DEN_RAT(quo) = denQ;
+        SET_NUM_RAT(quo, numQ);
+        SET_DEN_RAT(quo, denQ);
         /* 'CHANGED_BAG' not needed, 'quo' is the youngest bag             */
     }
     else {
@@ -742,8 +742,8 @@ Obj             PowRat (
         numP = PowInt( NUM_RAT(opL), opR );
         denP = PowInt( DEN_RAT(opL), opR );
         pow = NewBag( T_RAT, 2 * sizeof(Obj) );
-        NUM_RAT(pow) = numP;
-        DEN_RAT(pow) = denP;
+        SET_NUM_RAT(pow, numP);
+        SET_DEN_RAT(pow, denP);
         /* 'CHANGED_BAG' not needed, 'pow' is the youngest bag             */
     }
 
@@ -766,12 +766,12 @@ Obj             PowRat (
         pow  = NewBag( T_RAT, 2 * sizeof(Obj) );
         if ( (IS_INTOBJ(denP) && 0 < INT_INTOBJ(denP))
           || TNUM_OBJ(denP) == T_INTPOS ) {
-            NUM_RAT(pow) = numP;
-            DEN_RAT(pow) = denP;
+            SET_NUM_RAT(pow, numP);
+            SET_DEN_RAT(pow, denP);
         }
         else {
-            NUM_RAT(pow) = ProdInt( INTOBJ_INT( -1L ), numP );
-            DEN_RAT(pow) = ProdInt( INTOBJ_INT( -1L ), denP );
+            SET_NUM_RAT(pow, ProdInt( INTOBJ_INT( -1L ), numP ));
+            SET_DEN_RAT(pow, ProdInt( INTOBJ_INT( -1L ), denP ));
         }
         /* 'CHANGED_BAG' not needed, 'pow' is the youngest bag             */
     }
@@ -898,8 +898,8 @@ void SaveRat(Obj rat)
 
 void LoadRat(Obj rat)
 {
-  NUM_RAT(rat) = LoadSubObj();
-  DEN_RAT(rat) = LoadSubObj();
+  SET_NUM_RAT(rat, LoadSubObj());
+  SET_DEN_RAT(rat, LoadSubObj());
 }
 
 /****************************************************************************

--- a/src/rational.h
+++ b/src/rational.h
@@ -27,8 +27,25 @@
 *F  NUM_RAT(<rat>)  . . . . . . . . . . . . . . . . . numerator of a rational
 *F  DEN_RAT(<rat>)  . . . . . . . . . . . . . . . . denominator of a rational
 */
-#define NUM_RAT(rat)    ADDR_OBJ(rat)[0]
-#define DEN_RAT(rat)    ADDR_OBJ(rat)[1]
+static inline Obj NUM_RAT(Obj rat)
+{
+    return CONST_ADDR_OBJ(rat)[0];
+}
+
+static inline Obj DEN_RAT(Obj rat)
+{
+    return CONST_ADDR_OBJ(rat)[1];
+}
+
+static inline void SET_NUM_RAT(Obj rat, Obj val)
+{
+    ADDR_OBJ(rat)[0] = val;
+}
+
+static inline void SET_DEN_RAT(Obj rat, Obj val)
+{
+    ADDR_OBJ(rat)[1] = val;
+}
 
 /****************************************************************************
 **

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -128,7 +128,7 @@ Int EqChar (
     Obj                 charL,
     Obj                 charR )
 {
-    return (*(UChar*)ADDR_OBJ(charL) == *(UChar*)ADDR_OBJ(charR));
+    return CHAR_VALUE(charL) == CHAR_VALUE(charR);
 }
 
 
@@ -143,7 +143,7 @@ Int LtChar (
     Obj                 charL,
     Obj                 charR )
 {
-    return (*(UChar*)ADDR_OBJ(charL) < *(UChar*)ADDR_OBJ(charR));
+    return CHAR_VALUE(charL) < CHAR_VALUE(charR);
 }
 
 
@@ -158,7 +158,7 @@ void PrintChar (
 {
     UChar               chr;
 
-    chr = *(UChar*)ADDR_OBJ(val);
+    chr = CHAR_VALUE(val);
     if      ( chr == '\n'  )  Pr("'\\n'",0L,0L);
     else if ( chr == '\t'  )  Pr("'\\t'",0L,0L);
     else if ( chr == '\r'  )  Pr("'\\r'",0L,0L);
@@ -189,7 +189,7 @@ void PrintChar (
 */
 void SaveChar ( Obj c )
 {
-    SaveUInt1( *(UChar *)ADDR_OBJ(c));
+    SaveUInt1( CHAR_VALUE(c));
 }
 
 
@@ -200,7 +200,7 @@ void SaveChar ( Obj c )
 */
 void LoadChar( Obj c )
 {
-    *(UChar *)ADDR_OBJ(c) = LoadUInt1();
+    SET_CHAR_VALUE(c, LoadUInt1());
 }
 
 
@@ -301,7 +301,7 @@ Obj FuncINT_CHAR (
     }
 
     /* return the character                                                */
-    return INTOBJ_INT(*(UChar*)ADDR_OBJ(val));
+    return INTOBJ_INT(CHAR_VALUE(val));
 }
 
 /****************************************************************************
@@ -352,7 +352,7 @@ Obj FuncSINT_CHAR (
   }
 
   /* return the character                                                */
-  return INTOBJ_INT(SINT_CHAR(*(UChar*)ADDR_OBJ(val)));
+  return INTOBJ_INT(SINT_CHAR(CHAR_VALUE(val)));
 }
 
 /****************************************************************************
@@ -603,7 +603,7 @@ Obj CopyString (
     else {
         copy = NewBag( IMMUTABLE_TNUM( TNUM_OBJ(list) ), SIZE_OBJ(list) );
     }
-    ADDR_OBJ(copy)[0] = ADDR_OBJ(list)[0];
+    ADDR_OBJ(copy)[0] = CONST_ADDR_OBJ(list)[0];
 
     /* leave a forwarding pointer                                          */
     ADDR_OBJ(list)[0] = copy;
@@ -613,7 +613,7 @@ Obj CopyString (
     RetypeBag( list, TNUM_OBJ(list) + COPYING );
 
     /* copy the subvalues                                                  */
-    memcpy((void*)(ADDR_OBJ(copy)+1), (void*)(ADDR_OBJ(list)+1), 
+    memcpy(ADDR_OBJ(copy)+1, CONST_ADDR_OBJ(list)+1,
            ((SIZE_OBJ(copy)+sizeof(Obj)-1)/sizeof(Obj)-1) * sizeof(Obj));
 
     /* return the copy                                                     */
@@ -628,7 +628,7 @@ Obj CopyStringCopy (
     Obj                 list,
     Int                 mut )
 {
-    return ADDR_OBJ(list)[0];
+    return CONST_ADDR_OBJ(list)[0];
 }
 
 
@@ -650,7 +650,7 @@ void CleanStringCopy (
     Obj                 list )
 {
     /* remove the forwarding pointer                                       */
-    ADDR_OBJ(list)[0] = ADDR_OBJ( ADDR_OBJ(list)[0] )[0];
+    ADDR_OBJ(list)[0] = CONST_ADDR_OBJ( CONST_ADDR_OBJ(list)[0] )[0];
 
     /* now it is cleaned                                                   */
     RetypeBag( list, TNUM_OBJ(list) - COPYING );
@@ -1095,7 +1095,7 @@ void AssString (
 
     /* now perform the assignment and return the assigned value            */
     SET_ELM_STRING( list, pos, val ); 
-    /*    CHARS_STRING(list)[pos-1] = *((UInt1*)ADDR_OBJ(val)); */
+    /*    CHARS_STRING(list)[pos-1] = CHAR_VALUE(val); */
     CHANGED_BAG( list );
   }
 }    
@@ -1247,7 +1247,7 @@ Obj PosString (
     if (TNUM_OBJ(val) != T_CHAR) return Fail;
     
     /* val as C character   */
-    valc = *(UInt1*)ADDR_OBJ(val);
+    valc = CHAR_VALUE(val);
 
     /* search entries in <list>                                     */
     p = CHARS_STRING(list);
@@ -1294,7 +1294,7 @@ void PlainString (
 	  CHANGED_BAG( list );
 	  }
     */
-    memcpy((void*)ADDR_OBJ(list), (void*)ADDR_OBJ(tmp), SIZE_OBJ(tmp));
+    memcpy(ADDR_OBJ(list), CONST_ADDR_OBJ(tmp), SIZE_OBJ(tmp));
     CHANGED_BAG(list);
 }
 
@@ -1365,13 +1365,13 @@ Obj CopyToStringRep(
     copy = NEW_STRING(lenString);
 
     if ( IS_STRING_REP(string) ) {
-        memcpy(ADDR_OBJ(copy), ADDR_OBJ(string), SIZE_OBJ(string));
+        memcpy(ADDR_OBJ(copy), CONST_ADDR_OBJ(string), SIZE_OBJ(string));
         /* XXX no error checks? */
     } else {
         /* copy the string to the string representation                     */
         for ( i = 1; i <= lenString; i++ ) {
             elm = ELMW_LIST( string, i );
-            CHARS_STRING(copy)[i-1] = *((UChar*)ADDR_OBJ(elm));
+            CHARS_STRING(copy)[i-1] = CHAR_VALUE(elm);
         } 
         CHARS_STRING(copy)[lenString] = '\0';
     }
@@ -1408,7 +1408,7 @@ void ConvString (
     /* copy the string to the string representation                     */
     for ( i = 1; i <= lenString; i++ ) {
         elm = ELMW_LIST( string, i );
-        CHARS_STRING(tmp)[i-1] = *((UChar*)ADDR_OBJ(elm));
+        CHARS_STRING(tmp)[i-1] = CHAR_VALUE(elm);
     }
     CHARS_STRING(tmp)[lenString] = '\0';
 
@@ -1416,7 +1416,7 @@ void ConvString (
     RetypeBag( string, IS_MUTABLE_OBJ(string)?T_STRING:T_STRING+IMMUTABLE );
     ResizeBag( string, SIZEBAG_STRINGLEN(lenString) );
     /* copy data area from tmp */
-    memcpy((void*)ADDR_OBJ(string), (void*)ADDR_OBJ(tmp), SIZE_OBJ(tmp));
+    memcpy(ADDR_OBJ(string), CONST_ADDR_OBJ(tmp), SIZE_OBJ(tmp));
     CHANGED_BAG(string);
 }
 
@@ -2506,7 +2506,7 @@ static Int InitLibrary (
     /* make all the character constants once and for all                   */
     for ( i = 0; i < 256; i++ ) {
         ObjsChar[i] = NewBag( T_CHAR, 1L );
-        *(UChar*)ADDR_OBJ(ObjsChar[i]) = (UChar)i;
+        SET_CHAR_VALUE(ObjsChar[i], (UChar)i);
     }
 
     /* init filters and functions                                          */

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -41,7 +41,29 @@
 **  'ObjsChar' contains all the character values.  That way we do not need to
 **  allocate new bags for new characters.
 */
-extern Obj ObjsChar [256];
+extern Obj ObjsChar[256];
+
+
+/****************************************************************************
+**
+*F  CHAR_VALUE( <charObj> )
+*/
+static inline UChar CHAR_VALUE(Obj charObj)
+{
+    GAP_ASSERT(TNUM_OBJ(charObj) == T_CHAR);
+    return *(const UChar *)CONST_ADDR_OBJ(charObj);
+}
+
+
+/****************************************************************************
+**
+*F  SET_CHAR_VALUE( <charObj>, <c> )
+*/
+static inline void SET_CHAR_VALUE(Obj charObj, UChar c)
+{
+    GAP_ASSERT(TNUM_OBJ(charObj) == T_CHAR);
+    *(UChar *)CONST_ADDR_OBJ(charObj) = c;
+}
 
 
 /****************************************************************************
@@ -106,7 +128,7 @@ static inline UChar * CHARS_STRING(Obj list)
 static inline UInt GET_LEN_STRING(Obj list)
 {
     GAP_ASSERT(IS_STRING_REP(list));
-    return *((UInt *)ADDR_OBJ(list));
+    return *((const UInt *)CONST_ADDR_OBJ(list));
 }
 
 /****************************************************************************
@@ -202,7 +224,7 @@ static inline void SET_ELM_STRING(Obj list, Int pos, Obj val)
     GAP_ASSERT(pos <= GET_LEN_STRING(list));
     GAP_ASSERT(TNUM_OBJ(val) == T_CHAR);
     UChar * ptr = CHARS_STRING(list) + (pos - 1);
-    *ptr = *(UChar *)ADDR_OBJ(val);
+    *ptr = CHAR_VALUE(val);
 }
 
 /****************************************************************************

--- a/src/trans.c
+++ b/src/trans.c
@@ -102,19 +102,19 @@ Obj FuncIMAGE_SET_TRANS(Obj self, Obj f);
 static inline Obj IMG_TRANS(Obj f)
 {
     GAP_ASSERT(IS_TRANS(f));
-    return ADDR_OBJ(f)[0];
+    return CONST_ADDR_OBJ(f)[0];
 }
 
 static inline Obj KER_TRANS(Obj f)
 {
     GAP_ASSERT(IS_TRANS(f));
-    return ADDR_OBJ(f)[1];
+    return CONST_ADDR_OBJ(f)[1];
 }
 
 static inline Obj EXT_TRANS(Obj f)
 {
     GAP_ASSERT(IS_TRANS(f));
-    return ADDR_OBJ(f)[2];
+    return CONST_ADDR_OBJ(f)[2];
 }
 
 static inline void SET_IMG_TRANS(Obj f, Obj img)
@@ -300,10 +300,10 @@ static void SORT_PLIST_CYC(Obj res)
         }
         while (0 < h) {
             for (i = h + 1; i <= len; i++) {
-                tmp = ADDR_OBJ(res)[i];
+                tmp = CONST_ADDR_OBJ(res)[i];
                 k = i;
-                while (h < k && ((Int)tmp < (Int)(ADDR_OBJ(res)[k - h]))) {
-                    ADDR_OBJ(res)[k] = ADDR_OBJ(res)[k - h];
+                while (h < k && ((Int)tmp < (Int)(CONST_ADDR_OBJ(res)[k - h]))) {
+                    ADDR_OBJ(res)[k] = CONST_ADDR_OBJ(res)[k - h];
                     k -= h;
                 }
                 ADDR_OBJ(res)[k] = tmp;
@@ -325,12 +325,12 @@ static void REMOVE_DUPS_PLIST_CYC(Obj res)
     len = LEN_PLIST(res);
 
     if (0 < len) {
-        tmp = ADDR_OBJ(res)[1];
+        tmp = CONST_ADDR_OBJ(res)[1];
         k = 1;
         for (i = 2; i <= len; i++) {
-            if (tmp != ADDR_OBJ(res)[i]) {
+            if (tmp != CONST_ADDR_OBJ(res)[i]) {
                 k++;
-                tmp = ADDR_OBJ(res)[i];
+                tmp = CONST_ADDR_OBJ(res)[i];
                 ADDR_OBJ(res)[k] = tmp;
             }
         }
@@ -935,7 +935,8 @@ Obj FuncFLAT_KERNEL_TRANS(Obj self, Obj f)
 
 Obj FuncFLAT_KERNEL_TRANS_INT(Obj self, Obj f, Obj n)
 {
-    Obj new, *ptnew, *ptker;
+    Obj new, *ptnew;
+    const Obj *ptker;
     UInt deg, m, i;
 
     if (!IS_INTOBJ(n) || INT_INTOBJ(n) < 0) {
@@ -962,7 +963,7 @@ Obj FuncFLAT_KERNEL_TRANS_INT(Obj self, Obj f, Obj n)
             new = NEW_PLIST(T_PLIST_CYC_NSORT, m);
             SET_LEN_PLIST(new, m);
 
-            ptker = ADDR_OBJ(KER_TRANS(f)) + 1;
+            ptker = CONST_ADDR_OBJ(KER_TRANS(f)) + 1;
             ptnew = ADDR_OBJ(new) + 1;
 
             // copy the kernel set up to minimum of m, deg
@@ -1003,7 +1004,7 @@ Obj FuncFLAT_KERNEL_TRANS_INT(Obj self, Obj f, Obj n)
             new = NEW_PLIST(T_PLIST_CYC_NSORT, m);
             SET_LEN_PLIST(new, m);
 
-            ptker = ADDR_OBJ(KER_TRANS(f)) + 1;
+            ptker = CONST_ADDR_OBJ(KER_TRANS(f)) + 1;
             ptnew = ADDR_OBJ(new) + 1;
 
             // copy the kernel set up to minimum of m, deg
@@ -1201,7 +1202,8 @@ Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n)
 {
     Obj     im, new;
     UInt    deg, m, len, i, j, rank;
-    Obj *   ptnew, *ptim;
+    Obj *   ptnew;
+    const Obj *ptim;
     UInt4 * pttmp, *ptf4;
     UInt2 * ptf2;
 
@@ -1268,7 +1270,7 @@ Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n)
         SET_LEN_PLIST(new, m - deg + len);
 
         ptnew = ADDR_OBJ(new) + 1;
-        ptim = ADDR_OBJ(im) + 1;
+        ptim = CONST_ADDR_OBJ(im) + 1;
 
         // copy the image set
         for (i = 0; i < len; i++) {

--- a/src/vars.c
+++ b/src/vars.c
@@ -1830,7 +1830,7 @@ Obj             EvalElmPosObj (
     /* special case for plain lists (use generic code to signal errors)    */
     if ( TNUM_OBJ(list) == T_POSOBJ ) {
 #ifdef HPCGAP
-        Bag *contents = PTR_BAG(list);
+        const Bag *contents = CONST_PTR_BAG(list);
         while ( SIZE_BAG_CONTENTS(contents)/sizeof(Obj)-1 < p ) {
             ErrorReturnVoid(
                 "PosObj Element: <PosObj>![%d] must have an assigned value",
@@ -1897,7 +1897,7 @@ Obj             EvalIsbPosObj (
     /* get the result                                                      */
     if ( TNUM_OBJ(list) == T_POSOBJ ) {
 #ifdef HPCGAP
-        Bag *contents = PTR_BAG(list);
+        const Bag *contents = CONST_PTR_BAG(list);
         if (p > SIZE_BAG_CONTENTS(contents)/sizeof(Obj)-1)
           isb = False;
         else

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -94,7 +94,7 @@ Obj IsVec8bitRep;
 **  Note that 'LEN_VEC8BIT' is a macro, so do not call it with  arguments that
 **  have side effects.
 */
-#define LEN_VEC8BIT(list)         ((Int)(ADDR_OBJ(list)[1]))
+#define LEN_VEC8BIT(list)         ((Int)(CONST_ADDR_OBJ(list)[1]))
 
 /****************************************************************************
 **
@@ -117,7 +117,7 @@ Obj IsVec8bitRep;
 **  that have side effects.
 */
 
-#define FIELD_VEC8BIT(list)         ((Int)(ADDR_OBJ(list)[2]))
+#define FIELD_VEC8BIT(list)         ((Int)(CONST_ADDR_OBJ(list)[2]))
 
 /****************************************************************************
 **
@@ -167,13 +167,13 @@ static Obj FieldInfo8Bit;
 **  Note ADD has to be last, because it is not there in characteristic 2
 */
 
-#define Q_FIELDINFO_8BIT( info ) ((UInt)(ADDR_OBJ(info)[1]))
+#define Q_FIELDINFO_8BIT( info ) ((UInt)(CONST_ADDR_OBJ(info)[1]))
 #define SET_Q_FIELDINFO_8BIT( info, q ) (ADDR_OBJ(info)[1] = (Obj)(q))
-#define P_FIELDINFO_8BIT( info ) ((UInt)(ADDR_OBJ(info)[2]))
+#define P_FIELDINFO_8BIT( info ) ((UInt)(CONST_ADDR_OBJ(info)[2]))
 #define SET_P_FIELDINFO_8BIT( info, p ) (ADDR_OBJ(info)[2] = (Obj)(p))
-#define D_FIELDINFO_8BIT( info ) ((UInt)(ADDR_OBJ(info)[3]))
+#define D_FIELDINFO_8BIT( info ) ((UInt)(CONST_ADDR_OBJ(info)[3]))
 #define SET_D_FIELDINFO_8BIT( info, d ) (ADDR_OBJ(info)[3] = (Obj)(d))
-#define ELS_BYTE_FIELDINFO_8BIT( info ) ((UInt)(ADDR_OBJ(info)[4]))
+#define ELS_BYTE_FIELDINFO_8BIT( info ) ((UInt)(CONST_ADDR_OBJ(info)[4]))
 #define SET_ELS_BYTE_FIELDINFO_8BIT( info, e ) (ADDR_OBJ(info)[4] = (Obj)(e))
 #define FFE_FELT_FIELDINFO_8BIT( info ) (ADDR_OBJ(info)+5)
 #define GAPSEQ_FELT_FIELDINFO_8BIT( info ) (ADDR_OBJ(info)+5+Q_FIELDINFO_8BIT(info))
@@ -3444,7 +3444,7 @@ Obj FuncPROD_VEC8BIT_MATRIX( Obj self, Obj vec, Obj mat)
 
 static inline Int LEN_MAT8BIT(Obj mat)
 {
-    return INT_INTOBJ(ADDR_OBJ(mat)[1]);
+    return INT_INTOBJ(CONST_ADDR_OBJ(mat)[1]);
 }
 static inline void SET_LEN_MAT8BIT(Obj mat, Int l)
 {
@@ -3457,7 +3457,7 @@ static inline Obj ELM_MAT8BIT(Obj mat, Int i)
 {
     GAP_ASSERT(i >= 1);
     GAP_ASSERT(i <= SIZE_OBJ(mat) / sizeof(Obj) - 1);
-    return ADDR_OBJ(mat)[i + 1];
+    return CONST_ADDR_OBJ(mat)[i + 1];
 }
 static inline void SET_ELM_MAT8BIT(Obj mat, Int i, Obj row)
 {
@@ -5762,7 +5762,8 @@ Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT( Obj self, Obj matl, Obj matr)
     UInt nrowl, nrowr, ncoll, ncolr, ncol, p, q, i, j, k, l, s, zero,
     mutable, elts;
     Obj mat, type, row, info, shift[5];
-    UInt1 *getelt, *setelt, *scalar, *add, *datar, *data;
+    UInt1 *getelt, *setelt, *scalar, *add, *data;
+    const UInt1 *datar;
 
     nrowl = LEN_MAT8BIT(matl);
     nrowr = LEN_MAT8BIT(matr);
@@ -5821,7 +5822,7 @@ Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT( Obj self, Obj matl, Obj matr)
                 l = 0;
                 if (s != zero) {
                     /* append s*shift[ncol%elts] to data */
-                    datar = (UInt1 *) ADDR_OBJ(shift[ncol % elts]);
+                    datar = (const UInt1 *) CONST_ADDR_OBJ(shift[ncol % elts]);
                     if (ncol % elts) {
                         if (p == 2)
                             data[-1] ^= scalar[*datar++ + 256 * s];

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -64,7 +64,7 @@ Obj             SumFFEVecFFE (
     Obj                 vecS;           /* handle of the sum               */
     Obj *               ptrS;           /* pointer into the sum            */
     FFV                 valS;           /* the value of a sum              */
-    Obj *               ptrR;           /* pointer into the right operand  */
+    const Obj *         ptrR;           /* pointer into the right operand  */
     FFV                 valR;           /* the value of an element in vecR */
     UInt                len;            /* length                          */
     UInt                i;              /* loop variable                   */
@@ -96,7 +96,7 @@ Obj             SumFFEVecFFE (
 
     /* loop over the elements and add                                      */
     valL = VAL_FFE(elmL);
-    ptrR = ADDR_OBJ(vecR);
+    ptrR = CONST_ADDR_OBJ(vecR);
     ptrS = ADDR_OBJ(vecS);
     for (i = 1; i <= len; i++) {
         valR = VAL_FFE(ptrR[i]);
@@ -126,7 +126,7 @@ Obj             SumVecFFEFFE (
 {
     Obj                 vecS;           /* handle of the sum               */
     Obj *               ptrS;           /* pointer into the sum            */
-    Obj *               ptrL;           /* pointer into the left operand   */
+    const Obj *         ptrL;           /* pointer into the left operand   */
     UInt                len;            /* length                          */
     UInt                i;              /* loop variable                   */
     FF                  fld;            /* finite field                    */
@@ -159,7 +159,7 @@ Obj             SumVecFFEFFE (
 
     /* loop over the elements and add                                      */
     valR = VAL_FFE(elmR);
-    ptrL = ADDR_OBJ(vecL);
+    ptrL = CONST_ADDR_OBJ(vecL);
     ptrS = ADDR_OBJ(vecS);
     for (i = 1; i <= len; i++) {
         valL = VAL_FFE(ptrL[i]);
@@ -189,9 +189,9 @@ Obj             SumVecFFEVecFFE (
     Obj                 vecS;           /* handle of the sum               */
     Obj *               ptrS;           /* pointer into the sum            */
     FFV                 valS;           /* one element of sum list         */
-    Obj *               ptrL;           /* pointer into the left operand   */
+    const Obj *         ptrL;           /* pointer into the left operand   */
     FFV                 valL;           /* one element of left operand     */
-    Obj *               ptrR;           /* pointer into the right operand  */
+    const Obj *         ptrR;           /* pointer into the right operand  */
     FFV                 valR;           /* one element of right operand    */
     UInt                lenL, lenR, len; /* length                          */
     UInt                lenmin;
@@ -232,8 +232,8 @@ Obj             SumVecFFEVecFFE (
     succ = SUCC_FF(fld);
 
     /* loop over the elements and add                                      */
-    ptrL = ADDR_OBJ(vecL);
-    ptrR = ADDR_OBJ(vecR);
+    ptrL = CONST_ADDR_OBJ(vecL);
+    ptrR = CONST_ADDR_OBJ(vecR);
     ptrS = ADDR_OBJ(vecS);
     for (i = 1; i <= lenmin; i++) {
         valL = VAL_FFE(ptrL[i]);
@@ -270,7 +270,7 @@ Obj             DiffFFEVecFFE (
 {
     Obj                 vecD;           /* handle of the difference        */
     Obj *               ptrD;           /* pointer into the difference     */
-    Obj *               ptrR;           /* pointer into the right operand  */
+    const Obj *         ptrR;           /* pointer into the right operand  */
     UInt                len;            /* length                          */
     UInt                i;              /* loop variable                   */
     FF                  fld;            /* finite field                    */
@@ -303,7 +303,7 @@ Obj             DiffFFEVecFFE (
 
     /* loop over the elements and subtract                                 */
     valL = VAL_FFE(elmL);
-    ptrR = ADDR_OBJ(vecR);
+    ptrR = CONST_ADDR_OBJ(vecR);
     ptrD = ADDR_OBJ(vecD);
     for (i = 1; i <= len; i++) {
         valR = VAL_FFE(ptrR[i]);
@@ -335,7 +335,7 @@ Obj             DiffVecFFEFFE (
     Obj                 vecD;           /* handle of the difference        */
     Obj *               ptrD;           /* pointer into the difference     */
     FFV                 valD;           /* the value of a difference       */
-    Obj *               ptrL;           /* pointer into the left operand   */
+    const Obj *         ptrL;           /* pointer into the left operand   */
     FFV                 valL;           /* the value of an element in vecL */
     UInt                len;            /* length                          */
     UInt                i;              /* loop variable                   */
@@ -368,7 +368,7 @@ Obj             DiffVecFFEFFE (
     /* loop over the elements and subtract                                 */
     valR = VAL_FFE(elmR);
     valR = NEG_FFV(valR, succ);
-    ptrL = ADDR_OBJ(vecL);
+    ptrL = CONST_ADDR_OBJ(vecL);
     ptrD = ADDR_OBJ(vecD);
     for (i = 1; i <= len; i++) {
         valL = VAL_FFE(ptrL[i]);
@@ -399,9 +399,9 @@ Obj             DiffVecFFEVecFFE (
     Obj                 vecD;           /* handle of the difference        */
     Obj *               ptrD;           /* pointer into the difference     */
     FFV                 valD;           /* one element of difference list  */
-    Obj *               ptrL;           /* pointer into the left operand   */
+    const Obj *         ptrL;           /* pointer into the left operand   */
     FFV                 valL;           /* one element of left operand     */
-    Obj *               ptrR;           /* pointer into the right operand  */
+    const Obj *         ptrR;           /* pointer into the right operand  */
     FFV                 valR;           /* one element of right operand    */
     UInt                len, lenL, lenR; /* length                          */
     UInt                lenmin;
@@ -442,8 +442,8 @@ Obj             DiffVecFFEVecFFE (
     succ = SUCC_FF(fld);
 
     /* loop over the elements and subtract                                 */
-    ptrL = ADDR_OBJ(vecL);
-    ptrR = ADDR_OBJ(vecR);
+    ptrL = CONST_ADDR_OBJ(vecL);
+    ptrR = CONST_ADDR_OBJ(vecR);
     ptrD = ADDR_OBJ(vecD);
     for (i = 1; i <= lenmin; i++) {
         valL = VAL_FFE(ptrL[i]);
@@ -486,7 +486,7 @@ Obj             ProdFFEVecFFE (
     Obj                 vecP;           /* handle of the product           */
     Obj *               ptrP;           /* pointer into the product        */
     FFV                 valP;           /* the value of a product          */
-    Obj *               ptrR;           /* pointer into the right operand  */
+    const Obj *         ptrR;           /* pointer into the right operand  */
     FFV                 valR;           /* the value of an element in vecR */
     UInt                len;            /* length                          */
     UInt                i;              /* loop variable                   */
@@ -518,7 +518,7 @@ Obj             ProdFFEVecFFE (
 
     /* loop over the elements and multiply                                 */
     valL = VAL_FFE(elmL);
-    ptrR = ADDR_OBJ(vecR);
+    ptrR = CONST_ADDR_OBJ(vecR);
     ptrP = ADDR_OBJ(vecP);
     for (i = 1; i <= len; i++) {
         valR = VAL_FFE(ptrR[i]);
@@ -548,7 +548,7 @@ Obj             ProdVecFFEFFE (
     Obj                 vecP;           /* handle of the product           */
     Obj *               ptrP;           /* pointer into the product        */
     FFV                 valP;           /* the value of a product          */
-    Obj *               ptrL;           /* pointer into the left operand   */
+    const Obj *         ptrL;           /* pointer into the left operand   */
     FFV                 valL;           /* the value of an element in vecL */
     UInt                len;            /* length                          */
     UInt                i;              /* loop variable                   */
@@ -580,7 +580,7 @@ Obj             ProdVecFFEFFE (
 
     /* loop over the elements and multiply                                 */
     valR = VAL_FFE(elmR);
-    ptrL = ADDR_OBJ(vecL);
+    ptrL = CONST_ADDR_OBJ(vecL);
     ptrP = ADDR_OBJ(vecP);
     for (i = 1; i <= len; i++) {
         valL = VAL_FFE(ptrL[i]);
@@ -610,9 +610,9 @@ Obj             ProdVecFFEVecFFE (
 {
     FFV                 valP;           /* one product                     */
     FFV                 valS;           /* sum of the products             */
-    Obj *               ptrL;           /* pointer into the left operand   */
+    const Obj *         ptrL;           /* pointer into the left operand   */
     FFV                 valL;           /* one element of left operand     */
-    Obj *               ptrR;           /* pointer into the right operand  */
+    const Obj *         ptrR;           /* pointer into the right operand  */
     FFV                 valR;           /* one element of right operand    */
     UInt                lenL, lenR, len; /* length                          */
     UInt                i;              /* loop variable                   */
@@ -643,7 +643,7 @@ Obj             ProdVecFFEVecFFE (
 
     /* loop over the elements and add                                      */
     valS = (FFV)0;
-    ptrL = ADDR_OBJ(vecL);
+    ptrL = CONST_ADDR_OBJ(vecL);
     ptrR = ADDR_OBJ(vecR);
     for (i = 1; i <= len; i++) {
         valL = VAL_FFE(ptrL[i]);
@@ -667,7 +667,7 @@ static Obj AddRowVectorOp;   /* BH changed to static */
 Obj FuncADD_ROWVECTOR_VECFFES_3( Obj self, Obj vecL, Obj vecR, Obj mult )
 {
     Obj *ptrL;
-    Obj *ptrR;
+    const Obj *ptrR;
     FFV  valM;
     FFV  valS;
     FFV  valL;
@@ -742,7 +742,7 @@ Obj FuncADD_ROWVECTOR_VECFFES_3( Obj self, Obj vecL, Obj vecR, Obj mult )
 
     succ = SUCC_FF(fld);
     ptrL = ADDR_OBJ(vecL);
-    ptrR = ADDR_OBJ(vecR);
+    ptrR = CONST_ADDR_OBJ(vecR);
 
     /* two versions of the loop to avoid multipling by 1 */
     if (valM == 1)
@@ -847,7 +847,7 @@ Obj FuncMULT_ROWVECTOR_VECFFES( Obj self, Obj vec, Obj mult )
 Obj FuncADD_ROWVECTOR_VECFFES_2( Obj self, Obj vecL, Obj vecR )
 {
     Obj *ptrL;
-    Obj *ptrR;
+    const Obj *ptrR;
     FFV  valS;
     FFV  valL;
     FFV  valR;
@@ -891,7 +891,7 @@ Obj FuncADD_ROWVECTOR_VECFFES_2( Obj self, Obj vecL, Obj vecR )
 
     succ = SUCC_FF(fld);
     ptrL = ADDR_OBJ(vecL);
-    ptrR = ADDR_OBJ(vecR);
+    ptrR = CONST_ADDR_OBJ(vecR);
 
     for (i = 1; i <= len; i++) {
         valL = VAL_FFE(ptrL[i]);
@@ -924,7 +924,7 @@ Obj             ProdVecFFEMatFFE (
     FFV                 valP;           /* one value of the product        */
     FFV                 valL;           /* one value of the left operand   */
     Obj                 vecR;           /* one vector of the right operand */
-    Obj *               ptrR;           /* pointer into the right vector   */
+    const Obj *         ptrR;           /* pointer into the right vector   */
     FFV                 valR;           /* one value from the right vector */
     UInt                len;            /* length                          */
     UInt                col;            /* length of the rows in matR      */

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -4513,7 +4513,8 @@ Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
   UInt nrowl, nrowr, nrowp, ncoll, ncolr, ncolp, ncol,
     i, j, k, l, mutable;
   Obj mat, type, row, shift[BIPEB];
-  UInt *datar, *data;
+  UInt *data;
+  const UInt *datar;
 
   nrowl = LEN_GF2MAT(matl);
   nrowr = LEN_GF2MAT(matr);
@@ -4572,7 +4573,7 @@ Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
 	l = 0;
 	if (BLOCK_ELM_GF2VEC(ELM_GF2MAT(matl,i),k) & MASK_POS_GF2VEC(k)) {
 	  /* append shift[ncol%BIPEB] to data */
-	  datar = (UInt *) ADDR_OBJ(shift[ncol%BIPEB]);
+	  datar = (const UInt *) CONST_ADDR_OBJ(shift[ncol%BIPEB]);
 	  if (ncol % BIPEB) {
 	    data[-1] ^= *datar++;
 	    l = BIPEB - ncol%BIPEB;

--- a/src/vecgf2.h
+++ b/src/vecgf2.h
@@ -43,7 +43,7 @@
 **  Note that 'LEN_GF2VEC' is a macro, so do not call it with  arguments that
 **  have side effects.
 */
-#define LEN_GF2VEC(list)         ((Int)(ADDR_OBJ(list)[1]))
+#define LEN_GF2VEC(list)         ((Int)(CONST_ADDR_OBJ(list)[1]))
 
 
 /****************************************************************************
@@ -136,7 +136,7 @@
 **  Note that 'LEN_GF2MAT' is a macro, so do not call it with  arguments that
 **  have side effects.
 */
-#define LEN_GF2MAT(list)         (INT_INTOBJ(ADDR_OBJ(list)[1]))
+#define LEN_GF2MAT(list)         (INT_INTOBJ(CONST_ADDR_OBJ(list)[1]))
 
 
 /****************************************************************************
@@ -163,7 +163,7 @@
 **  Note that 'ELM_GF2MAT' is a macro, so do  not call it with arguments that
 **  have side effects.
 */
-#define ELM_GF2MAT(list,pos)    (ADDR_OBJ(list)[pos+1])
+#define ELM_GF2MAT(list,pos)    (CONST_ADDR_OBJ(list)[pos+1])
 
 
 /****************************************************************************

--- a/src/vector.c
+++ b/src/vector.c
@@ -65,7 +65,7 @@ Obj             SumIntVector (
     Obj                 vecS;           /* handle of the sum               */
     Obj *               ptrS;           /* pointer into the sum            */
     Obj                 elmS;           /* one element of sum list         */
-    Obj *               ptrR;           /* pointer into the right operand  */
+    const Obj *         ptrR;           /* pointer into the right operand  */
     Obj                 elmR;           /* one element of right operand    */
     UInt                len;            /* length                          */
     UInt                i;              /* loop variable                   */
@@ -76,14 +76,14 @@ Obj             SumIntVector (
     SET_LEN_PLIST(vecS, len);
 
     /* loop over the elements and add                                      */
-    ptrR = ADDR_OBJ(vecR);
+    ptrR = CONST_ADDR_OBJ(vecR);
     ptrS = ADDR_OBJ(vecS);
     for (i = 1; i <= len; i++) {
         elmR = ptrR[i];
         if (! ARE_INTOBJS(elmL, elmR) || ! SUM_INTOBJS(elmS, elmL, elmR)) {
             CHANGED_BAG(vecS);
             elmS = SUM(elmL, elmR);
-            ptrR = ADDR_OBJ(vecR);
+            ptrR = CONST_ADDR_OBJ(vecR);
             ptrS = ADDR_OBJ(vecS);
         }
         ptrS[i] = elmS;
@@ -113,7 +113,7 @@ Obj             SumVectorInt (
     Obj                 vecS;           /* handle of the sum               */
     Obj *               ptrS;           /* pointer into the sum            */
     Obj                 elmS;           /* one element of sum list         */
-    Obj *               ptrL;           /* pointer into the left operand   */
+    const Obj *         ptrL;           /* pointer into the left operand   */
     Obj                 elmL;           /* one element of left operand     */
     UInt                len;            /* length                          */
     UInt                i;              /* loop variable                   */
@@ -124,14 +124,14 @@ Obj             SumVectorInt (
     SET_LEN_PLIST(vecS, len);
 
     /* loop over the elements and add                                      */
-    ptrL = ADDR_OBJ(vecL);
+    ptrL = CONST_ADDR_OBJ(vecL);
     ptrS = ADDR_OBJ(vecS);
     for (i = 1; i <= len; i++) {
         elmL = ptrL[i];
         if (! ARE_INTOBJS(elmL, elmR) || ! SUM_INTOBJS(elmS, elmL, elmR)) {
             CHANGED_BAG(vecS);
             elmS = SUM(elmL, elmR);
-            ptrL = ADDR_OBJ(vecL);
+            ptrL = CONST_ADDR_OBJ(vecL);
             ptrS = ADDR_OBJ(vecS);
         }
         ptrS[i] = elmS;
@@ -161,9 +161,9 @@ Obj             SumVectorVector (
     Obj                 vecS;           /* handle of the sum               */
     Obj *               ptrS;           /* pointer into the sum            */
     Obj                 elmS;           /* one element of sum list         */
-    Obj *               ptrL;           /* pointer into the left operand   */
+    const Obj *         ptrL;           /* pointer into the left operand   */
     Obj                 elmL;           /* one element of left operand     */
-    Obj *               ptrR;           /* pointer into the right operand  */
+    const Obj *         ptrR;           /* pointer into the right operand  */
     Obj                 elmR;           /* one element of right operand    */
     UInt                lenL, lenR, len, lenmin; /* lengths                          */
     UInt                i;              /* loop variable                   */
@@ -183,8 +183,8 @@ Obj             SumVectorVector (
     SET_LEN_PLIST(vecS, len);
 
     /* loop over the elements and add                                      */
-    ptrL = ADDR_OBJ(vecL);
-    ptrR = ADDR_OBJ(vecR);
+    ptrL = CONST_ADDR_OBJ(vecL);
+    ptrR = CONST_ADDR_OBJ(vecR);
     ptrS = ADDR_OBJ(vecS);
     for (i = 1; i <= lenmin; i++) {
         elmL = ptrL[i];
@@ -192,8 +192,8 @@ Obj             SumVectorVector (
         if (! ARE_INTOBJS(elmL, elmR) || ! SUM_INTOBJS(elmS, elmL, elmR)) {
             CHANGED_BAG(vecS);
             elmS = SUM(elmL, elmR);
-            ptrL = ADDR_OBJ(vecL);
-            ptrR = ADDR_OBJ(vecR);
+            ptrL = CONST_ADDR_OBJ(vecL);
+            ptrR = CONST_ADDR_OBJ(vecR);
             ptrS = ADDR_OBJ(vecS);
         }
         ptrS[i] = elmS;
@@ -230,7 +230,7 @@ Obj             DiffIntVector (
     Obj                 vecD;           /* handle of the difference        */
     Obj *               ptrD;           /* pointer into the difference     */
     Obj                 elmD;           /* one element of difference list  */
-    Obj *               ptrR;           /* pointer into the right operand  */
+    const Obj *         ptrR;           /* pointer into the right operand  */
     Obj                 elmR;           /* one element of right operand    */
     UInt                len;            /* length                          */
     UInt                i;              /* loop variable                   */
@@ -242,14 +242,14 @@ Obj             DiffIntVector (
     SET_LEN_PLIST(vecD, len);
 
     /* loop over the elements and subtract                                 */
-    ptrR = ADDR_OBJ(vecR);
+    ptrR = CONST_ADDR_OBJ(vecR);
     ptrD = ADDR_OBJ(vecD);
     for (i = 1; i <= len; i++) {
         elmR = ptrR[i];
         if (! ARE_INTOBJS(elmL, elmR) || ! DIFF_INTOBJS(elmD, elmL, elmR)) {
             CHANGED_BAG(vecD);
             elmD = DIFF(elmL, elmR);
-            ptrR = ADDR_OBJ(vecR);
+            ptrR = CONST_ADDR_OBJ(vecR);
             ptrD = ADDR_OBJ(vecD);
         }
         ptrD[i] = elmD;
@@ -279,7 +279,7 @@ Obj             DiffVectorInt (
     Obj                 vecD;           /* handle of the difference        */
     Obj *               ptrD;           /* pointer into the difference     */
     Obj                 elmD;           /* one element of difference list  */
-    Obj *               ptrL;           /* pointer into the left operand   */
+    const Obj *         ptrL;           /* pointer into the left operand   */
     Obj                 elmL;           /* one element of left operand     */
     UInt                len;            /* length                          */
     UInt                i;              /* loop variable                   */
@@ -290,14 +290,14 @@ Obj             DiffVectorInt (
     SET_LEN_PLIST(vecD, len);
 
     /* loop over the elements and subtract                                 */
-    ptrL = ADDR_OBJ(vecL);
+    ptrL = CONST_ADDR_OBJ(vecL);
     ptrD = ADDR_OBJ(vecD);
     for (i = 1; i <= len; i++) {
         elmL = ptrL[i];
         if (! ARE_INTOBJS(elmL, elmR) || ! DIFF_INTOBJS(elmD, elmL, elmR)) {
             CHANGED_BAG(vecD);
             elmD = DIFF(elmL, elmR);
-            ptrL = ADDR_OBJ(vecL);
+            ptrL = CONST_ADDR_OBJ(vecL);
             ptrD = ADDR_OBJ(vecD);
         }
         ptrD[i] = elmD;
@@ -327,9 +327,9 @@ Obj             DiffVectorVector (
     Obj                 vecD;           /* handle of the sum               */
     Obj *               ptrD;           /* pointer into the sum            */
     Obj                 elmD;           /* one element of sum list         */
-    Obj *               ptrL;           /* pointer into the left operand   */
+    const Obj *         ptrL;           /* pointer into the left operand   */
     Obj                 elmL;           /* one element of left operand     */
-    Obj *               ptrR;           /* pointer into the right operand  */
+    const Obj *         ptrR;           /* pointer into the right operand  */
     Obj                 elmR;           /* one element of right operand    */
     UInt                lenL, lenR, len, lenmin; /* lengths                          */
     UInt                i;              /* loop variable                   */
@@ -349,8 +349,8 @@ Obj             DiffVectorVector (
     SET_LEN_PLIST(vecD, len);
 
     /* loop over the elements and subtract                                   */
-    ptrL = ADDR_OBJ(vecL);
-    ptrR = ADDR_OBJ(vecR);
+    ptrL = CONST_ADDR_OBJ(vecL);
+    ptrR = CONST_ADDR_OBJ(vecR);
     ptrD = ADDR_OBJ(vecD);
     for (i = 1; i <= lenmin; i++) {
         elmL = ptrL[i];
@@ -358,8 +358,8 @@ Obj             DiffVectorVector (
         if (! ARE_INTOBJS(elmL, elmR) || ! DIFF_INTOBJS(elmD, elmL, elmR)) {
             CHANGED_BAG(vecD);
             elmD = DIFF(elmL, elmR);
-            ptrL = ADDR_OBJ(vecL);
-            ptrR = ADDR_OBJ(vecR);
+            ptrL = CONST_ADDR_OBJ(vecL);
+            ptrR = CONST_ADDR_OBJ(vecR);
             ptrD = ADDR_OBJ(vecD);
         }
         ptrD[i] = elmD;
@@ -370,7 +370,7 @@ Obj             DiffVectorVector (
             if (! IS_INTOBJ(elmR) || ! DIFF_INTOBJS(elmD, INTOBJ_INT(0), elmR)) {
                 CHANGED_BAG(vecD);
                 elmD = AINV(elmR);
-                ptrR = ADDR_OBJ(vecR);
+                ptrR = CONST_ADDR_OBJ(vecR);
                 ptrD = ADDR_OBJ(vecD);
             }
             ptrD[i] = elmD;
@@ -403,7 +403,7 @@ Obj             ProdIntVector (
     Obj                 vecP;           /* handle of the product           */
     Obj *               ptrP;           /* pointer into the product        */
     Obj                 elmP;           /* one element of product list     */
-    Obj *               ptrR;           /* pointer into the right operand  */
+    const Obj *         ptrR;           /* pointer into the right operand  */
     Obj                 elmR;           /* one element of right operand    */
     UInt                len;            /* length                          */
     UInt                i;              /* loop variable                   */
@@ -415,14 +415,14 @@ Obj             ProdIntVector (
     SET_LEN_PLIST(vecP, len);
 
     /* loop over the entries and multiply                                  */
-    ptrR = ADDR_OBJ(vecR);
+    ptrR = CONST_ADDR_OBJ(vecR);
     ptrP = ADDR_OBJ(vecP);
     for (i = 1; i <= len; i++) {
         elmR = ptrR[i];
         if (! ARE_INTOBJS(elmL, elmR) || ! PROD_INTOBJS(elmP, elmL, elmR)) {
             CHANGED_BAG(vecP);
             elmP = PROD(elmL, elmR);
-            ptrR = ADDR_OBJ(vecR);
+            ptrR = CONST_ADDR_OBJ(vecR);
             ptrP = ADDR_OBJ(vecP);
         }
         ptrP[i] = elmP;
@@ -452,7 +452,7 @@ Obj             ProdVectorInt (
     Obj                 vecP;           /* handle of the product           */
     Obj *               ptrP;           /* pointer into the product        */
     Obj                 elmP;           /* one element of product list     */
-    Obj *               ptrL;           /* pointer into the left operand   */
+    const Obj *         ptrL;           /* pointer into the left operand   */
     Obj                 elmL;           /* one element of left operand     */
     UInt                len;            /* length                          */
     UInt                i;              /* loop variable                   */
@@ -464,14 +464,14 @@ Obj             ProdVectorInt (
     SET_LEN_PLIST(vecP, len);
 
     /* loop over the entries and multiply                                  */
-    ptrL = ADDR_OBJ(vecL);
+    ptrL = CONST_ADDR_OBJ(vecL);
     ptrP = ADDR_OBJ(vecP);
     for (i = 1; i <= len; i++) {
         elmL = ptrL[i];
         if (! ARE_INTOBJS(elmL, elmR) || ! PROD_INTOBJS(elmP, elmL, elmR)) {
             CHANGED_BAG(vecP);
             elmP = PROD(elmL, elmR);
-            ptrL = ADDR_OBJ(vecL);
+            ptrL = CONST_ADDR_OBJ(vecL);
             ptrP = ADDR_OBJ(vecP);
         }
         ptrP[i] = elmP;
@@ -501,9 +501,9 @@ Obj             ProdVectorVector (
     Obj                 elmP;           /* product, result                 */
     Obj                 elmS;           /* partial sum of result           */
     Obj                 elmT;           /* one summand of result           */
-    Obj *               ptrL;           /* pointer into the left operand   */
+    const Obj *         ptrL;           /* pointer into the left operand   */
     Obj                 elmL;           /* one element of left operand     */
-    Obj *               ptrR;           /* pointer into the right operand  */
+    const Obj *         ptrR;           /* pointer into the right operand  */
     Obj                 elmR;           /* one element of right operand    */
     UInt                lenL, lenR, len; /* length                          */
     UInt                i;              /* loop variable                   */
@@ -514,14 +514,14 @@ Obj             ProdVectorVector (
     len = (lenL < lenR) ? lenL : lenR;
 
     /* loop over the entries and multiply                                  */
-    ptrL = ADDR_OBJ(vecL);
-    ptrR = ADDR_OBJ(vecR);
+    ptrL = CONST_ADDR_OBJ(vecL);
+    ptrR = CONST_ADDR_OBJ(vecR);
     elmL = ptrL[1];
     elmR = ptrR[1];
     if (! ARE_INTOBJS(elmL, elmR) || ! PROD_INTOBJS(elmT, elmL, elmR)) {
         elmT = PROD(elmL, elmR);
-        ptrL = ADDR_OBJ(vecL);
-        ptrR = ADDR_OBJ(vecR);
+        ptrL = CONST_ADDR_OBJ(vecL);
+        ptrR = CONST_ADDR_OBJ(vecR);
     }
     elmP = elmT;
     for (i = 2; i <= len; i++) {
@@ -529,13 +529,13 @@ Obj             ProdVectorVector (
         elmR = ptrR[i];
         if (! ARE_INTOBJS(elmL, elmR) || ! PROD_INTOBJS(elmT, elmL, elmR)) {
             elmT = PROD(elmL, elmR);
-            ptrL = ADDR_OBJ(vecL);
-            ptrR = ADDR_OBJ(vecR);
+            ptrL = CONST_ADDR_OBJ(vecL);
+            ptrR = CONST_ADDR_OBJ(vecR);
         }
         if (! ARE_INTOBJS(elmP, elmT) || ! SUM_INTOBJS(elmS, elmP, elmT)) {
             elmS = SUM(elmP, elmT);
-            ptrL = ADDR_OBJ(vecL);
-            ptrR = ADDR_OBJ(vecR);
+            ptrL = CONST_ADDR_OBJ(vecL);
+            ptrR = CONST_ADDR_OBJ(vecR);
         }
         elmP = elmS;
     }
@@ -571,7 +571,7 @@ Obj             ProdVectorMatrix (
     Obj                 elmT;           /* another temporary               */
     Obj                 elmL;           /* one element of left operand     */
     Obj                 vecR;           /* one vector of right operand     */
-    Obj *               ptrR;           /* pointer into the right vector   */
+    const Obj *         ptrR;           /* pointer into the right vector   */
     Obj                 elmR;           /* one element from right vector   */
     UInt                len;            /* length                          */
     UInt                col;            /* length of the rows              */
@@ -597,7 +597,7 @@ Obj             ProdVectorMatrix (
     for (i = 1; i <= len; i++) {
         elmL = ELM_PLIST(vecL, i);
         vecR = ELM_PLIST(matR, i);
-        ptrR = ADDR_OBJ(vecR);
+        ptrR = CONST_ADDR_OBJ(vecR);
         ptrP = ADDR_OBJ(vecP);
         if (elmL == INTOBJ_INT(1L)) {
             for (k = 1; k <= col; k++) {
@@ -607,7 +607,7 @@ Obj             ProdVectorMatrix (
                 || ! SUM_INTOBJS(elmS, elmP, elmT)) {
                     CHANGED_BAG(vecP);
                     elmS = SUM(elmP, elmT);
-                    ptrR = ADDR_OBJ(vecR);
+                    ptrR = CONST_ADDR_OBJ(vecR);
                     ptrP = ADDR_OBJ(vecP);
                 }
                 ptrP[k] = elmS;
@@ -620,7 +620,7 @@ Obj             ProdVectorMatrix (
                         || ! DIFF_INTOBJS(elmS, elmP, elmT)) {
                     CHANGED_BAG(vecP);
                     elmS = DIFF(elmP, elmT);
-                    ptrR = ADDR_OBJ(vecR);
+                    ptrR = CONST_ADDR_OBJ(vecR);
                     ptrP = ADDR_OBJ(vecP);
                 }
                 ptrP[k] = elmS;
@@ -634,7 +634,7 @@ Obj             ProdVectorMatrix (
                             || ! PROD_INTOBJS(elmT, elmL, elmR)) {
                         CHANGED_BAG(vecP);
                         elmT = PROD(elmL, elmR);
-                        ptrR = ADDR_OBJ(vecR);
+                        ptrR = CONST_ADDR_OBJ(vecR);
                         ptrP = ADDR_OBJ(vecP);
                     }
                     elmP = ptrP[k];
@@ -642,7 +642,7 @@ Obj             ProdVectorMatrix (
                             || ! SUM_INTOBJS(elmS, elmP, elmT)) {
                         CHANGED_BAG(vecP);
                         elmS = SUM(elmP, elmT);
-                        ptrR = ADDR_OBJ(vecR);
+                        ptrR = CONST_ADDR_OBJ(vecR);
                         ptrP = ADDR_OBJ(vecP);
                     }
                     ptrP[k] = elmS;

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -78,7 +78,7 @@
 **  an overestimate
 */
 
-#define STORED_LEN_WPOBJ(wp)                 ((Int)(ADDR_OBJ(wp)[0]))
+#define STORED_LEN_WPOBJ(wp)                 ((Int)(CONST_ADDR_OBJ(wp)[0]))
 
 /****************************************************************************
 **
@@ -582,7 +582,7 @@ Obj CopyObjWPObj (
     /* make a copy                                                         */
     if ( mut ) {
         copy = NewBag( T_WPOBJ, SIZE_OBJ(obj) );
-        ADDR_OBJ(copy)[0] = ADDR_OBJ(obj)[0];
+        ADDR_OBJ(copy)[0] = CONST_ADDR_OBJ(obj)[0];
     }
     else {
         copy = NewBag( T_PLIST+IMMUTABLE, SIZE_OBJ(obj) );
@@ -592,7 +592,7 @@ Obj CopyObjWPObj (
     /* leave a forwarding pointer                                          */
     tmp = NEW_PLIST( T_PLIST, 2 );
     SET_LEN_PLIST( tmp, 2 );
-    SET_ELM_PLIST( tmp, 1, ADDR_OBJ(obj)[0] );
+    SET_ELM_PLIST( tmp, 1, CONST_ADDR_OBJ(obj)[0] );
     SET_ELM_PLIST( tmp, 2, copy );
     ADDR_OBJ(obj)[0] = tmp;
     CHANGED_BAG(obj);
@@ -602,7 +602,7 @@ Obj CopyObjWPObj (
 
     /* copy the subvalues                                                  */
     for ( i =  SIZE_OBJ(obj)/sizeof(Obj)-1; i > 0; i-- ) {
-        elm = ADDR_OBJ(obj)[i];
+        elm = CONST_ADDR_OBJ(obj)[i];
         if ( elm != 0  && !IS_WEAK_DEAD_BAG(elm)) {
             tmp = COPY_OBJ( elm, mut );
             ADDR_OBJ(copy)[i] = tmp;
@@ -673,7 +673,7 @@ Obj CopyObjWPObjCopy (
     Obj                 obj,
     Int                 mut )
 {
-    return ELM_PLIST( ADDR_OBJ(obj)[0], 2 );
+    return ELM_PLIST( CONST_ADDR_OBJ(obj)[0], 2 );
 }
 
 
@@ -688,7 +688,7 @@ void CleanObjWPObjCopy (
     Obj                 elm;            /* subobject                       */
 
     /* remove the forwarding pointer                                       */
-    ADDR_OBJ(obj)[0] = ELM_PLIST( ADDR_OBJ(obj)[0], 1 );
+    ADDR_OBJ(obj)[0] = ELM_PLIST( CONST_ADDR_OBJ(obj)[0], 1 );
     CHANGED_BAG(obj);
 
     /* now it is cleaned                                                   */
@@ -696,7 +696,7 @@ void CleanObjWPObjCopy (
 
     /* clean the subvalues                                                 */
     for ( i = 1; i < SIZE_OBJ(obj)/sizeof(Obj); i++ ) {
-        elm = ADDR_OBJ(obj)[i];
+        elm = CONST_ADDR_OBJ(obj)[i];
         if ( elm != 0  && !IS_WEAK_DEAD_BAG(elm)) 
           CLEAN_OBJ( elm );
     }


### PR DESCRIPTION
This PR adds new macros `CONST_ADDR_OBJ` and `CONST_PTR_BAG`, which work like their counterparts without `CONST_`, but return const pointers. Then, various places in the code are changed to use them. In some places, I added new setter helpers etc.

This work is clearly incomplete, tons of more places could be changed.

As to the why: This week, Reimer discovered that ward generates almost no guards for HPC-GAP in `master`, see here: https://github.com/gap-system/ward/issues/46  -- this is of course a serious problem, caused by our recent move from macros to static inline functions.

Reimer has come up with a plan to tackle this, by essentially getting rid of `ward`. Basically, the idea is to a write guard into `PTR_BAG` and a read guard into `CONST_PTR_BAG`, and then stop using `ward` (of course more work likely is necessary, but you get the idea). For this to not be unusable due to high overhead, he came up with some clever tricks involving a C language extension supported by GCC and clang for declaring functions pure... I'll leave it to him to explain the details.

But even without this, I think there is some merit in making use of `const` here; it might enable some extra optimization opportunities.

If people think this PR is in the right direction, I'll clean up the final commit and put in some more work. Thought to get through the whole kernel, I might need some help. We'll see.