### PR TITLE
Fix dummy implementation of CopyToRegion in GAP

### DIFF
--- a/lib/hpc/thread1.g
+++ b/lib/hpc/thread1.g
@@ -157,7 +157,7 @@ end);
 BIND_GLOBAL("AtomicIncorporateObj", IncorporateObj);
 
 BIND_GLOBAL("CopyFromRegion", ID_FUNC);
-BIND_GLOBAL("CopyToRegion", ID_FUNC);
+BIND_GLOBAL("CopyToRegion", {x,y} -> x);
 
 
 ###########################


### PR DESCRIPTION
This function takes two arguments, not one. The new implementation
still is not 100% convincing, because it does not actually copy anything,
which might lead to unexpected results.