### PR TITLE
Add Constant Var support

### DIFF
--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -539,9 +539,36 @@ Certain special facilities are provided for manipulating global
 variables which are not available for other types of variable (such as 
 local variables or function arguments).
 <P/>
-First, such variables may be marked <E>read-only</E>. In which case
+First, such variables may be marked <E>read-only</E> using
+<Ref Func="MakeReadOnlyGlobal"/>. In which case
 attempts to change them will fail. Most of the global variables
-defined in the &GAP; library are so marked.
+defined in the &GAP; library are so marked. <E>read-only</E> variables
+can be made read-write again by calling <Ref Func="MakeReadWriteGlobal"/>.
+GAP also features <E>constant</E> variables, which are created by calling
+<Ref Func="MakeConstantGlobal"/>. Constant variables can never be changed.
+In some cases, GAP can optimise code which uses <E>constant</E> variables,
+as their value never changes. In this version GAP these optimisations can be
+observed by printing the function back out, but this behaviour may change
+in future.
+<Example><![CDATA[
+gap> globali := 1 + 2;;
+gap> globalb := true;;
+gap> MakeConstantGlobal("globali");
+gap> MakeConstantGlobal("globalb");
+gap> f := function()
+>     if globalb then
+>         return globali + 1;
+>     else
+>         return globali + 2;
+>     fi;
+> end;;
+gap> Print(f);
+function (  )
+    return 3 + 1;
+end
+]]></Example>
+
+
 <P/>
 Second, a group of functions are supplied for accessing and altering the
 values assigned to global variables. Use of these functions differs

--- a/lib/global.g
+++ b/lib/global.g
@@ -72,6 +72,16 @@ IS_READ_ONLY_GLOBAL := IsReadOnlyGVar;
 
 #############################################################################
 ##
+#F  IS_CONSTANT_GLOBAL ( <name> ) determine if a global variable is constant
+##
+##  IS_CONSTANT_GLOBAL ( <name> ) returns true if the global variable
+##  named by the string <name> is constant and false otherwise (the default)
+##
+
+IS_CONSTANT_GLOBAL := IsConstantGVar;
+
+#############################################################################
+##
 #F  MAKE_READ_ONLY_GLOBAL ( <name> ) . . . . make a global variable read-only
 ##
 ##  MAKE_READ_ONLY_GLOBAL ( <name> ) marks the global variable named
@@ -89,6 +99,16 @@ MAKE_READ_ONLY_GLOBAL := MakeReadOnlyGVar;
 ##
 
 MAKE_READ_WRITE_GLOBAL := MakeReadWriteGVar;
+
+#############################################################################
+##
+#F  MAKE_CONSTANT_GLOBAL ( <name> )
+##
+##  MAKE_CONSTANT_GLOBAL ( <name> ) marks the global variable named
+##  by the string <name> as constant
+##
+
+MAKE_CONSTANT_GLOBAL := MakeConstantGVar;
 
 #############################################################################
 ##

--- a/lib/global.gd
+++ b/lib/global.gd
@@ -115,6 +115,21 @@ DeclareGlobalFunction("UnbindGlobal");
 ##
 DeclareGlobalFunction("IsReadOnlyGlobal");
 
+#############################################################################
+##
+#F  IsConstantGlobal( <name> )  . determine if a global variable is constant
+##
+##  <ManSection>
+##  <Func Name="IsConstantGlobal" Arg='name'/>
+##
+##  <Description>
+##  IsConstantGlobal ( <A>name</A> ) returns true if the global variable
+##  named by the string <A>name</A> is constant and false otherwise (the default).
+##  </Description>
+##  </ManSection>
+##
+DeclareGlobalFunction("IsConstantGlobal");
+
 
 #############################################################################
 ##
@@ -151,6 +166,27 @@ DeclareGlobalFunction("MakeReadOnlyGlobal");
 ##  </ManSection>
 ##
 DeclareGlobalFunction("MakeReadWriteGlobal");
+
+
+#############################################################################
+##
+#F  MakeConstantGlobal( <name> )   . . . . .  make a global variable constant
+##
+##  <ManSection>
+##  <Func Name="MakeConstantGlobal" Arg='name'/>
+##
+##  <Description>
+##  MakeConstantGlobal ( <A>name</A> ) marks the global variable named
+##  by the string <A>name</A> as constant. A constant variable can never
+##  be changed or made read-write. Constant variables can only take an
+##  integer value, <C>true</C> or <C>false</C>. There is a limit on
+##  the size of allowed integers.
+##  <P/>
+##  A warning is given if <A>name</A> is already constant.
+##  </Description>
+##  </ManSection>
+##
+DeclareGlobalFunction("MakeConstantGlobal");
 
 
 #############################################################################

--- a/lib/global.gi
+++ b/lib/global.gi
@@ -147,13 +147,31 @@ InstallGlobalFunction( IsReadOnlyGlobal,
     return isro;
 end);
 
+#############################################################################
+##
+#F  IsConstantGlobal ( <name> ) . determine if a global variable is constant
+##
+##  IsConstantGlobal ( <name> ) returns true if the global variable
+##  named by the string <name> is constant and false otherwise (the default)
+##
+
+InstallGlobalFunction( IsConstantGlobal,
+        function (name)
+    local isro;
+    CheckGlobalName( name );
+    isro := IS_CONSTANT_GLOBAL(name);
+    Info( InfoGlobal, 3,
+          "IsConstantGlobal: called for ", name, " returned ", isro);
+    return isro;
+end);
+
 
 #############################################################################
 ##
 #F  MakeReadOnlyGlobal ( <name> ) . . . . .  make a global variable read-only
 ##
-##  MakeReadOnlyGlobal ( <name> ) marks the global variable named
-##  by the string <name> as read-only. 
+##  MakeReadOnlyGlobal ( <name> ) marks the global variable named by the
+##  string <name> as read-only.
 ##
 ##  A warning is given if <name> has no value bound to it or if it is
 ##  already read-only
@@ -182,10 +200,10 @@ end);
 ##
 #F  MakeReadWriteGlobal ( <name> )  . . . . make a global variable read-write
 ##
-##  MakeReadWriteGlobal ( <name> ) marks the global variable named
-##  by the string <name> as read-write
+##  MakeReadWriteGlobal ( <name> ) marks the global variable named by the
+##  string <name> as read-write
 ##
-## A warning is given if <name> is already read-write
+##  A warning is given if <name> is already read-write
 ##
 
 InstallGlobalFunction( MakeReadWriteGlobal, 
@@ -197,6 +215,27 @@ InstallGlobalFunction( MakeReadWriteGlobal,
     fi;
     Info( InfoGlobal, 2, "MakeReadWriteGlobal: called for ", name);
     MAKE_READ_WRITE_GLOBAL( name );
+end);
+
+#############################################################################
+##
+#F  MakeConstantGlobal ( <name> )  . . . . .  make a global variable constant
+##
+##  MakeConstantGlobal ( <name> ) marks the global variable named by the
+##  string <name> as constant
+##
+##  A warning is given if <name> is already constant
+##
+
+InstallGlobalFunction( MakeConstantGlobal, 
+        function (name)
+    CheckGlobalName( name );
+    if IS_CONSTANT_GLOBAL( name ) then
+        Info( InfoWarning + InfoGlobal, 1, 
+              "MakeConstantGlobal: ", name, " already constant");
+    fi;
+    Info( InfoGlobal, 2, "MakeConstantGlobal: called for ", name);
+    MAKE_CONSTANT_GLOBAL( name );
 end);
 
 

--- a/src/code.h
+++ b/src/code.h
@@ -941,6 +941,7 @@ extern  void            CodePow ( void );
 **  'CodeIntExpr' is the action to code a literal integer expression.  <str>
 **  is the integer as a (null terminated) C character string.
 */
+extern void             CodeGAPSmallInt(Obj obj);
 extern  void            CodeIntExpr (
             Char *              str );
 extern  void            CodeLongIntExpr (

--- a/src/gap.c
+++ b/src/gap.c
@@ -2998,11 +2998,19 @@ static Int InitLibrary (
     /* create windows command buffer                                       */
     WindowCmdString = NEW_STRING( 1000 );
 
+    UInt isvar = GVarName( "IsHPCGAP" );
+
 #ifdef HPCGAP
     UInt var = GVarName( "HPCGAP" );
     AssGVar( var, True );
-    MakeReadOnlyGVar( var );
+    MakeConstantGVar( var );
+
+    AssGVar( isvar, True );
+#else
+    AssGVar( isvar, False );
 #endif
+
+    MakeConstantGVar(isvar);
 
     /* return success                                                      */
     return PostRestore( module );

--- a/src/gvars.h
+++ b/src/gvars.h
@@ -165,11 +165,15 @@ extern UInt completion_gvar (
 **
 *F  MakeReadOnlyGVar( <gvar> )  . . . . . .  make a global variable read only
 *F  MakeReadWriteGVar( <gvar> ) . . . . . . make a global variable read-write
+*F  MakeConstantGVar( <gvar> ) . . . . . . make a global variable constant
 */
 extern void MakeReadOnlyGVar (
     UInt                gvar );
 
 extern void MakeReadWriteGVar (
+    UInt                gvar );
+
+extern void MakeConstantGVar (
     UInt                gvar );
 
 /****************************************************************************
@@ -184,6 +188,9 @@ extern void MakeThreadLocalVar (
 
 extern Int IsReadOnlyGVar (
     UInt                gvar );
+
+extern Int IsConstantGVar(UInt gvar);
+
 
 /****************************************************************************
 **

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2074,6 +2074,31 @@ void            IntrLongFloatExpr (
     PushObj(ConvertFloatLiteralEager(string));
 }
 
+/****************************************************************************
+**
+*F   IntrIntObjExpr()  . . . . . . .  'interpret' a GAP small integer
+**
+**  'IntrIntObjExpr' is the action to 'interpret' a existing GAP small
+**  integer. This is used for implementing constants.
+*/
+void IntrIntObjExpr(Obj val)
+{
+    /* ignore or code                                                      */
+    if (STATE(IntrReturning) > 0) {
+        return;
+    }
+    if (STATE(IntrIgnoring) > 0) {
+        return;
+    }
+    if (STATE(IntrCoding) > 0) {
+        CodeGAPSmallInt(val);
+        return;
+    }
+
+
+    /* push the value                                                      */
+    PushObj(val);
+}
 
 /****************************************************************************
 **

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -550,6 +550,8 @@ extern  void            IntrPow ( void );
 **  'IntrIntExpr' is the action  to  interpret a literal  integer expression.
 **  <str> is the integer as a (null terminated) C character string.
 */
+
+extern void             IntrIntObjExpr(Obj val);
 extern  void            IntrIntExpr (
             Char *              str );
 extern  void            IntrLongIntExpr (

--- a/src/read.c
+++ b/src/read.c
@@ -481,7 +481,22 @@ void ReadCallVarAss (
     /* Now we know this isn't a lambda function, look up the name          */
     if ( type == 'g' ) {
         var = GVarName( varname );
+
+        // Check if the variable is a constant
+        if (mode != 'i' && ValGVar(var) && IsConstantGVar(var)) {
+            Obj val = ValAutoGVar(var);
+            if (val == True)
+                IntrTrueExpr();
+            else if (val == False)
+                IntrFalseExpr();
+            else if (IS_INTOBJ(val))
+                IntrIntObjExpr(val);
+            else
+                SyntaxError("Invalid constant variable");
+            return;
+        }
     }
+
 
     /* check whether this is an unbound global variable                    */
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -1972,6 +1972,7 @@ void            PrintIf (
     Stat                stat )
 {
     UInt                i;              /* loop variable                   */
+    UInt                len;            /* length of loop                  */
 
     /* print the 'if' branch                                               */
     Pr( "if%4> ", 0L, 0L );
@@ -1980,9 +1981,11 @@ void            PrintIf (
     PrintStat( ADDR_STAT(stat)[1] );
     Pr( "%4<\n", 0L, 0L );
 
+    len = SIZE_STAT(stat) / (2 * sizeof(Stat));
     /* print the 'elif' branch                                             */
-    for ( i = 2; i <= SIZE_STAT(stat)/(2*sizeof(Stat)); i++ ) {
-        if ( TNUM_EXPR( ADDR_STAT(stat)[2*(i-1)] ) == T_TRUE_EXPR ) {
+    for (i = 2; i <= len; i++) {
+        if (i == len &&
+            TNUM_EXPR(ADDR_STAT(stat)[2 * (i - 1)]) == T_TRUE_EXPR) {
             Pr( "else%4>\n", 0L, 0L );
         }
         else {

--- a/tst/testbugfix/2017-09-07-elseif.tst
+++ b/tst/testbugfix/2017-09-07-elseif.tst
@@ -1,0 +1,24 @@
+gap> f := function() if true then return 1; elif true then return 2; else return 3; fi; end;;
+gap> Print(f, "\n");
+function (  )
+    if true then
+        return 1;
+    elif true then
+        return 2;
+    else
+        return 3;
+    fi;
+    return;
+end
+gap> f := function() if false then return 4; elif false then return 5; else return 6; fi; end;;
+gap> Print(f, "\n");
+function (  )
+    if false then
+        return 4;
+    elif false then
+        return 5;
+    else
+        return 6;
+    fi;
+    return;
+end

--- a/tst/testinstall/constant.tst
+++ b/tst/testinstall/constant.tst
@@ -1,0 +1,159 @@
+gap> testvar := 2;
+2
+gap> IsReadOnlyGlobal(testvar);
+Error, CheckGlobalName: the argument must be a string
+gap> IsReadOnlyGlobal("testvar");
+false
+gap> IsConstantGlobal("testvar");
+false
+gap> MakeReadOnlyGlobal("testvar");
+gap> IsReadOnlyGlobal("testvar");
+true
+gap> IsConstantGlobal("testvar");
+false
+gap> testvar := 3;
+Error, Variable: 'testvar' is read only
+gap> MakeReadWriteGlobal("testvar");
+gap> IsReadOnlyGlobal("testvar");
+false
+gap> IsConstantGlobal("testvar");
+false
+gap> testvar := 3;
+3
+gap> MakeConstantGlobal("testvar");
+gap> testvar := 4;
+Syntax error: ; expected in stream:1
+testvar := 4;
+         ^
+4
+gap> IsReadOnlyGlobal("testvar");
+false
+gap> IsConstantGlobal("testvar");
+true
+gap> newtestvar := fail;;
+gap> MakeConstantGlobal("newtestvar");
+Error, Variable: 'newtestvar' must be assigned a small integer, true or false
+gap> IsConstantGlobal("newtestvar");
+false
+gap> booltruevar := true;;
+gap> boolfalsevar := false;;
+gap> f := function()
+> if booltruevar then return 1; else return 2; fi;
+> if booltruevar then return 3; fi;
+> if boolfalsevar then return 4; else return 5; fi;
+> if boolfalsevar then return 6; fi;
+> if booltruevar then return 7; elif 1=2 then return 8; else return 9; fi;
+> if boolfalsevar then return 10; elif booltruevar then return 11; else return 12; fi;
+> end;;
+gap> Print(f,"\n");
+function (  )
+    if booltruevar then
+        return 1;
+    else
+        return 2;
+    fi;
+    if booltruevar then
+        return 3;
+    fi;
+    if boolfalsevar then
+        return 4;
+    else
+        return 5;
+    fi;
+    if boolfalsevar then
+        return 6;
+    fi;
+    if booltruevar then
+        return 7;
+    elif 1 = 2 then
+        return 8;
+    else
+        return 9;
+    fi;
+    if boolfalsevar then
+        return 10;
+    elif booltruevar then
+        return 11;
+    else
+        return 12;
+    fi;
+    return;
+end
+gap> MakeConstantGlobal("booltruevar");
+gap> MakeConstantGlobal("boolfalsevar");
+gap> Print(f,"\n");
+function (  )
+    if booltruevar then
+        return 1;
+    else
+        return 2;
+    fi;
+    if booltruevar then
+        return 3;
+    fi;
+    if boolfalsevar then
+        return 4;
+    else
+        return 5;
+    fi;
+    if boolfalsevar then
+        return 6;
+    fi;
+    if booltruevar then
+        return 7;
+    elif 1 = 2 then
+        return 8;
+    else
+        return 9;
+    fi;
+    if boolfalsevar then
+        return 10;
+    elif booltruevar then
+        return 11;
+    else
+        return 12;
+    fi;
+    return;
+end
+gap> f := function()
+> if booltruevar then return 1; else return 2; fi;
+> if booltruevar then return 3; fi;
+> if boolfalsevar then return 4; else return 5; fi;
+> if boolfalsevar then return 6; fi;
+> if booltruevar then return 7; elif 1=2 then return 8; else return 9; fi;
+> if boolfalsevar then return 10; elif booltruevar then return 11; else return 12; fi;
+> end;;
+gap> Print(f, "\n");
+function (  )
+    return 1;
+    return 3;
+    return 5;
+    ;
+    if true then
+        return 7;
+    elif 1 = 2 then
+        return 8;
+    else
+        return 9;
+    fi;
+    if false then
+        return 10;
+    elif true then
+        return 11;
+    else
+        return 12;
+    fi;
+    return;
+end
+gap> (function() if booltruevar then return 1; fi; return 2; end)();
+1
+gap> (function() if boolfalsevar then return 1; fi; return 2; end)();
+2
+gap> (function() if booltruevar then return 1; else return 2; fi; end)();
+1
+gap> (function() if boolfalsevar then return 1; else return 2; fi; end)();
+2
+gap> (function() if boolfalsevar then return 1; elif booltruevar then return 2; else return 3; fi; end)();
+2
+gap> (function() if boolfalsevar then return 1; elif boolfalsevar then return 2; else return 3; fi; end)();
+3


### PR DESCRIPTION
This adds to gap the concept of a constant variable. They are created with `MakeConstantVar`, and behave similarly to `MakeReadOnlyVar`, except:

* they can never be changed
* they can only be small integers, true or false
* The interpreter will inline them to optimise byte code.

The inlining is always done, and further to interpreter will inline away `if` statements of the form `if constvar then...` for a constant variable `constvar`.