### PR TITLE
Change default test options in HPCGAP

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -371,6 +371,14 @@ InstallGlobalFunction("Test", function(arg)
            end,
            subsWindowsLineBreaks := true,
          );
+
+  if IsBound(HPCGAP) then
+    # HPCGAP's window size varies in different threads
+    opts.compareFunction := "uptowhitespace";
+    # HPCGAP's output is not compatible with changing lines
+    opts.showProgress := false;
+  fi;
+
   for c in RecNames(nopts) do
     opts.(c) := nopts.(c);
   od;


### PR DESCRIPTION
At the moment testing in HPCGAP is very painful, for two reasons:

1) The default `"some"` output method produces huge amounts of input.

2) The use of `[ 5 ]` at the start of lines to denote the thread messes up formatting, so tests always fail off the main thread.

This patch changes the default behaviour of testing in HPC-GAP to produce minimal output, and to use `uptowhitespace`.