### PR TITLE
Add ExtraMarkFuncBags

### DIFF
--- a/src/gasman.c
+++ b/src/gasman.c
@@ -967,6 +967,8 @@ TNumAllocFuncBags       AllocFuncBags;
 
 TNumStackFuncBags       StackFuncBags;
 
+TNumExtraMarkFuncBags   ExtraMarkFuncBags;
+
 Bag *                   StackBottomBags;
 
 UInt                    StackAlignBags;
@@ -990,6 +992,7 @@ void            InitBags (
     /* install the allocator and the abort function                        */
     AllocFuncBags   = alloc_func;
     AbortFuncBags   = abort_func;
+    ExtraMarkFuncBags = 0;
 
     /* install the stack marking function and values                       */
     StackFuncBags   = stack_func;
@@ -1687,6 +1690,13 @@ again:
     for ( i = 0; i < GlobalBags.nr; i++ )
         MarkBag( *GlobalBags.addr[i] );
 
+    /* allow installing a custom marking function. This is used for integrating
+       GAP (possibly linked as a shared library) with other code bases which use
+       their own form of garbage collection. For example, with Python (for
+       SageMath) or Julia. */
+    if (ExtraMarkFuncBags) {
+        (*ExtraMarkFuncBags)();
+    }
 
     /* mark from the stack                                                 */
     if ( StackFuncBags ) {

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -1147,18 +1147,16 @@ typedef Bag *           (* TNumAllocFuncBags) (
                                 Int             size,
                                 UInt            need );
 
-typedef void            (* TNumStackFuncBags) ( void );
+typedef void (*TNumStackFuncBags)(void);
+typedef void (*TNumExtraMarkFuncBags)(void);
+typedef void (*TNumAbortFuncBags)(const Char * msg);
 
-typedef void            (* TNumAbortFuncBags) (
-                                const Char *    msg );
-
-extern  void            InitBags (
-            TNumAllocFuncBags   alloc_func,
-            UInt                initial_size,
-            TNumStackFuncBags   stack_func,
-            Bag *               stack_bottom,
-            UInt                stack_align,
-            TNumAbortFuncBags   abort_func );
+extern void InitBags(TNumAllocFuncBags alloc_func,
+                     UInt              initial_size,
+                     TNumStackFuncBags stack_func,
+                     Bag *             stack_bottom,
+                     UInt              stack_align,
+                     TNumAbortFuncBags abort_func);
 
 /****************************************************************************
 **


### PR DESCRIPTION
This allows users of gasman to use a custom bag marking function
that is called during garbage collection.

The primary reason for adding this is so that one can keep bags
alive when using GAP as a dynamic library.

There is currently no HPC-GAP support, and no tests, which is of course bad. 