### PR TITLE
Allow disabling SIGCHLD

### DIFF
--- a/src/iostream.h
+++ b/src/iostream.h
@@ -13,7 +13,7 @@
 #ifndef GAP_IOSTREAM_H
 #define GAP_IOSTREAM_H
 
-
+extern Int SIGCHLDHandlerDisabled;
 
 /*F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * *
 */


### PR DESCRIPTION
For using GAP as a shared library, it is necessary to disable signal handlers. This PR is currently incomplete.