### PR TITLE
Fix FroidurePinExtendedAlg for partial perm monoids

### DIFF
--- a/lib/semirel.gi
+++ b/lib/semirel.gi
@@ -959,7 +959,7 @@ function(m)
   local gens, k, free, freegens, actualelts, fpelts, rules, i, u, v, Last,
         currentlength, b, s, r, newelt, j, p, new, length, newword, first,
         final, prefix, suffix, next, postmult, reducedflags, premult, fpsemi,
-        old, sortedelts, pos, semi, perm, free2;
+        old, sortedelts, pos, semi, perm, free2, one;
 
   if not IsFinite(m) then 
     return fail;
@@ -972,13 +972,14 @@ function(m)
   fi;
 
   #gens:=Set(GeneratorsOfMonoid(semi));
-  gens:=Set(Filtered(GeneratorsOfMonoid(semi), x-> not IsOne(x)));
+  one:=One(semi);
+  gens:=Set(Filtered(GeneratorsOfMonoid(semi), x -> x <> one));
   k:=Length(gens);
   free:=FreeMonoid(k);
   freegens:=GeneratorsOfMonoid(free);
-  actualelts:=Concatenation([One(semi)], gens);
+  actualelts:=Concatenation([one], gens);
   fpelts:=Concatenation([One(free)], freegens);
-  sortedelts:=List(Concatenation([One(semi)], gens));
+  sortedelts:=List(Concatenation([one], gens));
 
   #output
 

--- a/tst/testbugfix/2017-09-07-FroidurePinExtendedAlg.tst
+++ b/tst/testbugfix/2017-09-07-FroidurePinExtendedAlg.tst
@@ -1,0 +1,48 @@
+# Issue related to FroidurePinExtendedAlg
+# Examples reported on issue #1674 on github.com/gap-system/gap
+#
+gap> sort := function(x, y)
+> local rx, ry;
+> rx := RankOfPartialPerm(Representative(x));
+> ry := RankOfPartialPerm(Representative(y));
+> return rx < ry;
+> end;;
+gap> x := PartialPerm([1]);
+<identity partial perm on [ 1 ]>
+gap> y := PartialPerm([0]);
+<empty partial perm>
+gap> S := Semigroup(x, y);
+<partial perm monoid of rank 1 with 2 generators>
+gap> D := ShallowCopy(GreensDClasses(S));;
+gap> Sort(D, sort);
+gap> D;
+[ <Green's D-class: <empty partial perm>>, 
+  <Green's D-class: <identity partial perm on [ 1 ]>> ]
+gap> Elements(S);
+[ <empty partial perm>, <identity partial perm on [ 1 ]> ]
+gap> S := Semigroup(x, y);
+<partial perm monoid of rank 1 with 2 generators>
+gap> Elements(S);
+[ <empty partial perm>, <identity partial perm on [ 1 ]> ]
+gap> D := ShallowCopy(GreensDClasses(S));;
+gap> Sort(D, sort);
+gap> D;
+[ <Green's D-class: <empty partial perm>>, 
+  <Green's D-class: <identity partial perm on [ 1 ]>> ]
+
+#
+gap> SymmetricInverseMonoid(2);
+<symmetric inverse monoid of degree 2>
+gap> D := ShallowCopy(GreensDClasses(last));;
+gap> Sort(D, sort);
+gap> D;
+[ <Green's D-class: <empty partial perm>>, 
+  <Green's D-class: <identity partial perm on [ 1 ]>>, 
+  <Green's D-class: <identity partial perm on [ 1, 2 ]>> ]
+
+#
+gap> S := Semigroup(x, y);
+<partial perm monoid of rank 1 with 2 generators>
+gap> FroidurePinExtendedAlg(S);
+gap> LeftCayleyGraphSemigroup(S);
+[ [ 1 ], [ 1 ] ]


### PR DESCRIPTION
In #1674 I gave an example of a monoid of partial perms, on which `GreensDClasses` gave an incorrect result. This PR resolves #1674. 

@markuspf tracked the cause down to a line in `FroidurePinExtendedAlg`. The problem is that a line in this method assumed that the `One` of any element of a monoid is the same as the `One` of the monoid. This is the documented behaviour of how `One` works in a magma-with-one, but this is not how monoids of partial perms behave. I will open an issue in the hope of addressing the disparity between behaviour and documentation.