### PR TITLE
kernel cleanup: add NUM_TYPES and T_DUMMY

### DIFF
--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -42,9 +42,7 @@
 
 
 
-enum { NTYPES = 256 };
-
-TNumInfoBags InfoBags[NTYPES];
+TNumInfoBags InfoBags[NUM_TYPES];
 
 UInt8 SizeAllBags;
 
@@ -59,7 +57,7 @@ static inline Bag * DATA(BagHeader * bag)
 *V  DSInfoBags[<type>]  . . . .  . . . . . . . . . .  region info for bags
 */
 
-static char DSInfoBags[NTYPES];
+static char DSInfoBags[NUM_TYPES];
 
 #define DSI_TL 0
 #define DSI_PUBLIC 1
@@ -101,7 +99,7 @@ Region * RegionBag(Bag bag)
 *F  InitFreeFuncBag(<type>,<free-func>)
 */
 
-TNumFreeFuncBags TabFreeFuncBags[NTYPES];
+TNumFreeFuncBags TabFreeFuncBags[NUM_TYPES];
 
 void InitFreeFuncBag(UInt type, TNumFreeFuncBags finalizer_func)
 {
@@ -291,7 +289,7 @@ void * AllocateMemoryBlock(UInt size)
     return GC_malloc(size);
 }
 
-int TabMarkTypeBags[NTYPES];
+int TabMarkTypeBags[NUM_TYPES];
 
 void InitMarkFuncBags(UInt type, TNumMarkFuncBags mark_func)
 {
@@ -320,7 +318,7 @@ void InitBags(UInt              initial_size,
     UInt i; /* loop variable                   */
 
     /* install the marking functions                                       */
-    for (i = 0; i < 255; i++) {
+    for (i = 0; i < NUM_TYPES; i++) {
         TabMarkTypeBags[i] = -1;
     }
 #ifndef DISABLE_GC

--- a/src/gap.c
+++ b/src/gap.c
@@ -914,7 +914,7 @@ again:
             Pr( "%40s ", (Int)"type",  0L          );
             Pr( "%8s %8s ",  (Int)"alive", (Int)"kbyte" );
             Pr( "%8s %8s\n",  (Int)"total", (Int)"kbyte" );
-            for ( UInt k = 0; k < 256; k++ ) {
+            for ( UInt k = 0; k < NUM_TYPES; k++ ) {
                 if ( InfoBags[k].name != 0 ) {
                     Char buf[41];
                     buf[0] = '\0';
@@ -935,7 +935,7 @@ again:
             Pr( "%40s ", (Int)"type",  0L          );
             Pr( "%8s %8s ",  (Int)"alive", (Int)"kbyte" );
             Pr( "%8s %8s\n",  (Int)"total", (Int)"kbyte" );
-            for ( UInt k = 0; k < 256; k++ ) {
+            for ( UInt k = 0; k < NUM_TYPES; k++ ) {
                 if ( InfoBags[k].name != 0 && 
                      (InfoBags[k].nrLive != 0 ||
                       InfoBags[k].sizeLive != 0 ||
@@ -957,7 +957,7 @@ again:
         /* if request display the statistics                               */
         else if ( strcmp( CSTR_STRING(cmd), "clear" ) == 0 ) {
 #ifdef COUNT_BAGS
-            for ( UInt k = 0; k < 256; k++ ) {
+            for ( UInt k = 0; k < NUM_TYPES; k++ ) {
 #ifdef GASMAN_CLEAR_TO_LIVE
                 InfoBags[k].nrAll    = InfoBags[k].nrLive;
                 InfoBags[k].sizeAll  = InfoBags[k].sizeLive;
@@ -1737,7 +1737,7 @@ StructInitInfo * InitInfoGap ( void )
 **  `PostRestore'.  This function is only used when restoring.
 */
 #ifdef USE_GASMAN
-extern TNumMarkFuncBags TabMarkFuncBags [ 256 ];
+extern TNumMarkFuncBags TabMarkFuncBags [ NUM_TYPES ];
 #endif
 
 static Obj POST_RESTORE;
@@ -1789,7 +1789,7 @@ void InitializeGap (
             Pr( "#W  %36s ", (Int)"type",  0L          );
             Pr( "%8s %8s ",  (Int)"alive", (Int)"kbyte" );
             Pr( "%8s %8s\n",  (Int)"total", (Int)"kbyte" );
-            for ( Int i = 0;  i < 256;  i++ ) {
+            for ( Int i = 0;  i < NUM_TYPES;  i++ ) {
                 if ( InfoBags[i].name != 0 && InfoBags[i].nrAll != 0 ) {
                     char    buf[41];
 

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -179,7 +179,7 @@
 **  returns the number  of words occupied  by the data  area and padding of a
 **  bag of size <size>.
 **
-**  A body in the workspace whose type byte contains the value 255 is the
+**  A body in the workspace whose type byte contains the value T_DUMMY is the
 **  remainder of a 'ResizeBag'. That is it consists either of the unused words
 **  after a bag has been shrunk, or of the old body of the bag after the
 **  contents of the body have been copied elsewhere for an extension. The
@@ -195,22 +195,24 @@
 **
 */
 
-#define SIZE_MPTR_BAGS  1
+enum {
+    SIZE_MPTR_BAGS = 1,
+
+    T_DUMMY = NUM_TYPES - 1,
+};
+
 
 static inline UInt WORDS_BAG(UInt size)
 {
     return (size + sizeof(Bag) - 1) / sizeof(Bag);
 }
 
-/* This could be 65536, but would waste memory in various tables */
-
-#define NTYPES 256
-
 
 static inline Bag *DATA(BagHeader *bag)
 {
     return (Bag *)(((char *)bag) + sizeof(BagHeader));
 }
+
 
 /****************************************************************************
 **
@@ -462,7 +464,7 @@ UInt                    NrHalfDeadBags;
 **
 *V  InfoBags[<type>]  . . . . . . . . . . . . . . . . .  information for bags
 */
-TNumInfoBags            InfoBags [ NTYPES ];
+TNumInfoBags            InfoBags [ NUM_TYPES ];
 
 /****************************************************************************
 **
@@ -505,7 +507,7 @@ void            InitMsgsFuncBags (
 *F  InitSweepFuncBags(<type>,<mark-func>)  . . . .  install sweeping function
 */
 
-static TNumSweepFuncBags TabSweepFuncBags[NTYPES];
+static TNumSweepFuncBags TabSweepFuncBags[NUM_TYPES];
 
 
 void InitSweepFuncBags (
@@ -537,7 +539,7 @@ void InitSweepFuncBags (
 **  by GASMAN as default.  This will allow to catch type clashes.
 */
 
-TNumMarkFuncBags TabMarkFuncBags [ NTYPES ];
+TNumMarkFuncBags TabMarkFuncBags [ NUM_TYPES ];
 
 void InitMarkFuncBags (
     UInt                type,
@@ -964,7 +966,7 @@ void FinishedRestoringBags( void )
 **
 **  'InitFreeFuncBag' is really too simple for an explanation.
 */
-static TNumFreeFuncBags TabFreeFuncBags[256];
+static TNumFreeFuncBags TabFreeFuncBags[NUM_TYPES];
 
 void            InitFreeFuncBag (
     UInt                type,
@@ -1182,7 +1184,7 @@ void            InitBags (
     AllocSizeBags = 256;
 
     /* install the marking functions                                       */
-    for ( i = 0; i < 255; i++ )
+    for ( i = 0; i < NUM_TYPES; i++ )
         TabMarkFuncBags[i] = MarkAllSubBagsDefault;
 
     /* Set ChangedBags to a proper initial value */
@@ -1247,6 +1249,8 @@ Bag NewBag (
     {
         Panic("cannot extend the workspace any more!!!!");
     }
+
+    GAP_ASSERT(type < T_DUMMY);
 
 #ifdef COUNT_BAGS
     /* update the statistics                                               */
@@ -1342,9 +1346,9 @@ void            RetypeBag (
 **  If  the bag  is  to be  shrunk  and at  least   one  word becomes   free,
 **  'ResizeBag'  changes  the  size word of  the bag, and stores a magic
 **  size-type word in  the first free word.  This  magic size-type  word  has
-**  type 255 and the size  is the number  of  following  free bytes, which is
-**  always divisible by 'sizeof(Bag)'.  The  type 255 allows 'CollectBags' to
-**  detect that  this body  is the remainder of a   resize operation, and the
+**  type T_DUMMY and the size is the number of following free bytes, which is
+**  always divisible by 'sizeof(Bag)'. The type T_DUMMY allows 'CollectBags'
+**  to detect that this body is the remainder of a resize operation, and the
 **  size allows  it  to know how  many  bytes  there  are  in this  body (see
 **  "Implementation of CollectBags").
 **
@@ -1369,9 +1373,9 @@ void            RetypeBag (
 **         \_____________
 **                       \
 **                        V
-**    +---------+---------+------------------------+----+---------+---------+
-**    | 10  . 7 |  <link> |         .         .    | pad|  4  .255|         |
-**    +---------+---------+------------------------+----+---------+---------+
+**    +---------+---------+------------------------+----+-------------+-----+
+**    | 10  . 7 |  <link> |         .         .    | pad| 4 . T_DUMMY |     |
+**    +---------+---------+------------------------+----+-------------+-----+
 **
 **  If the bag is to be extended and it  is that last  allocated bag, so that
 **  it  is  immediately adjacent  to the allocation  area, 'ResizeBag' simply
@@ -1382,7 +1386,7 @@ void            RetypeBag (
 **  'ResizeBag'  first allocates a  new bag  similar to 'NewBag', but without
 **  using  a new masterpointer.   Then it copies the old  contents to the new
 **  bag.  Finally it resets the masterpointer of the bag to  point to the new
-**  address.  Then it changes the type of the old body  to  255,  so that the
+**  address. Then it changes the type of the old body to T_DUMMY, so that the
 **  garbage collection can detect that this body is the remainder of a resize
 **  (see "Implementation of NewBag" and "Implementation of CollectBags").
 **
@@ -1441,9 +1445,9 @@ UInt ResizeBag (
     // memory may not be zero filled, and zeroing it out would cost us
     else if ( diff < 0 ) {
 
-        // leave magic size-type word for the sweeper, type must be 255
+        // leave magic size-type word for the sweeper, type must be T_DUMMY
         BagHeader * freeHeader = (BagHeader *)(DATA(header) + WORDS_BAG(new_size));
-        freeHeader->type = 255;
+        freeHeader->type = T_DUMMY;
         if ( diff == -1 ) {
             // if there is only one free word, avoid setting the size in
             // the header: there is no space for it on 32bit systems;
@@ -1505,8 +1509,8 @@ UInt ResizeBag (
         // update header pointer in case bag moved
         header = BAG_HEADER(bag);
 
-        // leave magic size-type word  for the sweeper, type must be 255
-        header->type = 255;
+        // leave magic size-type word  for the sweeper, type must be T_DUMMY
+        header->type = T_DUMMY;
         header->flags = 0;
         header->size = sizeof(BagHeader) + (WORDS_BAG(old_size) - 1) * sizeof(Bag);
 #if SIZEOF_VOID_P == 4
@@ -1697,9 +1701,9 @@ UInt ResizeBag (
 **  initially   point to  the   beginning  of  the   young bags area.    Then
 **  'CollectBags' looks at the body pointed to by the source pointer.
 **
-**  If this body has type 255, it is the remainder of a resize operation.  In
-**  this case 'CollectBags' simply moves the source pointer to the  next body
-**  (see "Implementation of ResizeBag").
+**  If this body has type T_DUMMY, it is the remainder of a resize operation.
+**  In this case 'CollectBags' simply moves the source pointer to the next
+**  body (see "Implementation of ResizeBag").
 **
 **
 **  Otherwise, if the  link word contains the  identifier of the bag  itself,
@@ -1993,7 +1997,7 @@ again:
         BagHeader * header = (BagHeader *)src;
 
         /* leftover of a resize of <n> bytes                               */
-        if ( header->type == 255 ) {
+        if ( header->type == T_DUMMY ) {
 
             /* advance src                                                 */
             if (header->flags == 1)

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -95,6 +95,17 @@ typedef struct {
 
 /****************************************************************************
 **
+**  'NUM_TYPES' is the maximal number of different types supported, and
+**  depends on the number of bits in the type member of struct BagHeader.
+**  It must be a power of two.
+*/
+enum {
+    NUM_TYPES = 256,
+};
+
+
+/****************************************************************************
+**
 *F  BAG_HEADER(<bag>) . . . . . . . . . . . . . . . . . . . . header of a bag
 **
 **  'BAG_HEADER' returns the header of the bag with the identifier <bag>.

--- a/src/objects.c
+++ b/src/objects.c
@@ -1503,7 +1503,7 @@ Obj FuncIS_IDENTICAL_OBJ (
 **  No saving function may allocate any bag
 */
 
-void (*SaveObjFuncs[256]) ( Obj obj );
+void (*SaveObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
 void SaveObjError( Obj obj )
 {
@@ -1528,7 +1528,7 @@ void SaveObjError( Obj obj )
 **  No loading function may allocate any bag
 */
 
-void (*LoadObjFuncs[256]) ( Obj obj );
+void (*LoadObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
 void LoadObjError( Obj obj )
 {
@@ -1872,7 +1872,7 @@ Obj FuncDEBUG_TNUM_NAMES(Obj self)
 {
     UInt indentLvl = 0;
     Char indentStr[20] = "";
-    for (UInt k = 0; k < 256; k++) {
+    for (UInt k = 0; k < NUM_TYPES; k++) {
         START_SYMBOLIC_TNUM(FIRST_REAL_TNUM);
         START_SYMBOLIC_TNUM(FIRST_CONSTANT_TNUM);
         START_SYMBOLIC_TNUM(FIRST_MULT_TNUM);

--- a/src/objects.h
+++ b/src/objects.h
@@ -591,7 +591,7 @@ extern Int IsInternallyMutableObj(Obj obj);
 **  No saving function may allocate any bag.
 */
 
-extern void (*SaveObjFuncs[256]) ( Obj obj );
+extern void (*SaveObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
 extern void SaveObjError( Obj obj );
 
@@ -611,7 +611,7 @@ extern void SaveObjError( Obj obj );
 **  No loading function may allocate any bag.
 */
 
-extern void (*LoadObjFuncs[256]) ( Obj obj );
+extern void (*LoadObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
 extern void LoadObjError( Obj obj );
 
@@ -710,7 +710,7 @@ extern Obj CopyObj (
 **  already unmarked object, it should simply return.
 */
 #if !defined(USE_THREADSAFE_COPYING)
-extern Obj (*CopyObjFuncs[LAST_REAL_TNUM+COPYING+1]) ( Obj obj, Int mut );
+extern Obj (*CopyObjFuncs[LAST_COPYING_TNUM+1]) ( Obj obj, Int mut );
 #endif
 
 
@@ -719,7 +719,7 @@ extern Obj (*CopyObjFuncs[LAST_REAL_TNUM+COPYING+1]) ( Obj obj, Int mut );
 *V  CleanObjFuncs[<type>] . . . . . . . . . . . . table of cleaning functions
 */
 #if !defined(USE_THREADSAFE_COPYING)
-extern void (*CleanObjFuncs[LAST_REAL_TNUM+COPYING+1]) ( Obj obj );
+extern void (*CleanObjFuncs[LAST_COPYING_TNUM+1]) ( Obj obj );
 #endif
 
 


### PR DESCRIPTION
Right now, we reserve 8 bit for the tnum in each "Bag". GASMAN also uses the special value `255 = 0xFF` in the tnum/type field internally, so that means TNUMs from 0 to 254 are potentially valid.

Now there are various places were this information is implicitly used. If we ever want to e.g. increase the number of TNUMs, we have to find all these places. And even if we don't change it, it can be illuminating to have these facts made explicit. This PR is a first step at doing that.