### PR TITLE
Simplify handling of GAPState for non HPC-GAP

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -494,10 +494,6 @@ int realmain( int argc, char * argv[], char * environ[] )
   // and 255 is reserved for internal use by GASMAN.
   assert(LAST_COPYING_TNUM <= 253);
 
-#if !defined(HPCGAP)
-  InitMainGAPState();
-#endif
-
   /* initialize everything and read init.g which runs the GAP session */
   InitializeGap( &argc, argv, environ );
   if (!STATE(UserHasQUIT)) {         /* maybe the user QUIT from the initial
@@ -3271,7 +3267,7 @@ void InitializeGap (
     InitMainThread();
     InitTLS();
 #else
-    InitGAPState(MainGAPState);
+    InitGAPState(&MainGAPState);
 #endif
 
     InitGlobalBag(&POST_RESTORE, "gap.c: POST_RESTORE");

--- a/src/gapstate.c
+++ b/src/gapstate.c
@@ -11,16 +11,7 @@
 #include <src/system.h>
 #include <src/gapstate.h>
 
-static GAPState _MainGAPState;
-
-GAPState * MainGAPState = 0;
-
-void InitMainGAPState(void)
-{
-    // with GASMAN mallocing this struct could
-    // lead to unwanted effects.
-    MainGAPState = &_MainGAPState;
-}
+GAPState MainGAPState;
 
 void InitGAPState(GAPState * state)
 {

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -192,8 +192,8 @@ typedef struct GAPState {
 
 #else
 
-extern GAPState * MainGAPState;
-#define STATE(x) (MainGAPState->x)
+extern GAPState MainGAPState;
+#define STATE(x) (MainGAPState.x)
 
 #endif
 


### PR DESCRIPTION
I don't think there is a good reason to do the pointer-handstand-to-a-global-variable.