### PR TITLE
Store declaration filters of operations in record

### DIFF
--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -344,36 +344,81 @@ end);
 ##
 ##  <#GAPDoc Label="PageSource">
 ##  <ManSection>
-##  <Func Name="PageSource" Arg='func'/>
+##  <Func Name="PageSource" Arg='func[, nr]'/>
 ##
 ##  <Description>
 ##  This shows the file containing the source code of the function or method
 ##  <A>func</A> in a pager (see <Ref Func="Pager"/>). The display starts at 
 ##  a line shortly before the code of <A>func</A>.<P/>
 ##  
-##  This function works if <C>FilenameFunc(<A>func</A>)</C> returns the name of
-##  a proper file. In that case this filename and the position of the 
-##  function definition are also printed.
-##  Otherwise the function indicates that the source is not available 
-##  (for example this happens for functions which are implemented in 
-##  the &GAP; C-kernel).<P/>
+##  For operations <A>func</A> the function shows the source code of the
+##  declaration of <A>func</A>. Operations can have several declarations, use
+##  the optional second argument to specify which one should be shown (in the
+##  order the declarations were read); the default is to show the first.<P/>
 ##  
+##  For kernel functions the function tries to show the C source code.<P/>
+##  
+##  If GAP cannot find a file containing the source code this will be indicated.
+##  <P/>
 ##  Usage examples:<Br/>
 ##  <C>met := ApplicableMethod(\^, [(1,2),2743527]); PageSource(met);</C><Br/>
 ##  <C>PageSource(Combinations);</C><Br/>
-##  <C>ct:=CharacterTable(Group((1,2,3))); </C><Br/>
+##  <C>PageSource(SORT_LIST); </C><Br/>
+##  <C>PageSource(Size, 2);</C><Br/>
+##  <C>ct := CharacterTable(Group((1,2,3))); </C><Br/>
 ##  <C>met := ApplicableMethod(Size,[ct]); PageSource(met); </C>
 ##  <P/>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
-BIND_GLOBAL("PageSource", function ( fun )
-    local f, l;
+BIND_GLOBAL("PageSource", function ( fun, nr... )
+    local f, n, l, s, ss, locs;
+
+    if Length(nr) > 0 and IsPosInt(nr[1]) then
+      n := nr[1];
+    else
+      n := 1;
+    fi;
+    l := fail;
     f := FILENAME_FUNC( fun );
+    if IsString(f) and Length(f)>0 and f[1] <> '/' then
+      if Length(f) > 7 and f{[1..8]} = "GAPROOT/" then
+        f := f{[9..Length(f)]};
+      fi;
+      f := Filename(List(GAPInfo.RootPaths, Directory), f);
+    fi;
+    if f = fail and fun in OPERATIONS then
+      # for operations we show the location(s) of their operation
+      locs := GET_DECLARATION_LOCATIONS(fun);
+      if n > Length(locs) then
+        Print("Operation ", NameFunction(fun), " has only ",
+              Length(locs), " declarations.\n");
+        return;
+      else
+        if Length(locs) > 1 then
+          Print("Operation ", NameFunction(fun), " has ",
+                Length(locs), " declarations, showing number ", n, ".\n");
+        fi;
+        f := locs[n][1];
+        l := locs[n][2];
+      fi;
+    fi;
     if f <> fail then
-        l := STARTLINE_FUNC( fun );
-        if l <> fail then
-            l := Maximum(l-5, 1);
+        if l = fail then
+          l := STARTLINE_FUNC( fun );
+          if l <> fail then
+              l := Maximum(l-5, 1);
+          elif IsKernelFunction(fun) then
+              # page correct C source file and try to find line in C 
+              # source starting `Obj Func<fun>`
+              s := String(fun);
+              ss:=SplitString(s,""," <>");
+              s := First(ss, a-> ':' in a);
+              if s <> fail then
+                ss := SplitString(s,":","");
+                l := Concatenation("/Obj *Func", ss[2]);
+              fi;
+          fi;
         fi;
     fi;
     if f = fail or l = fail then
@@ -387,7 +432,6 @@ BIND_GLOBAL("PageSource", function ( fun )
         Print( "Cannot access code from file \"",f,"\".\n");
     else
         Print( "Showing source in ", f, " (from line ", l, ")\n" );
-        # Exec( Concatenation( "view +", String( l ), " ", f ) );
         Pager(rec(lines := StringFile(f), formatted := true, start := l));
     fi;
 end);

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -148,7 +148,54 @@ BIND_GLOBAL( "NUMBERS_PROPERTY_GETTERS", [] );
 ##  </ManSection>
 ##
 BIND_GLOBAL( "OPERATIONS", [] );
+BIND_GLOBAL( "OPER_FLAGS", rec() );
+BIND_GLOBAL( "STORE_OPER_FLAGS",
+function(oper, flags)
+  local nr, flist, locs;
+  nr := MASTER_POINTER_NUMBER(oper);
+  if IsBound(OPER_FLAGS.(nr)) then
+    flist := OPER_FLAGS.(nr)[2];
+    locs := OPER_FLAGS.(nr)[3];
+  else
+    ADD_LIST(OPERATIONS, oper);
+    flist := [];
+    locs := [];
+  fi;
+  ADD_LIST(flist, flags);
+  ADD_LIST(locs, [INPUT_FILENAME(), INPUT_LINENUMBER()]);
+  # we need a back link to oper for the post-restore function
+  OPER_FLAGS.(nr) := [oper, flist, locs];
+end);
 
+BIND_GLOBAL( "GET_OPER_FLAGS", function(oper)
+  local nr;
+  nr := MASTER_POINTER_NUMBER(oper);
+  if not IsBound(OPER_FLAGS.(nr)) then
+    return fail;
+  fi;
+  return OPER_FLAGS.(nr)[2];
+end);
+BIND_GLOBAL( "GET_DECLARATION_LOCATIONS", function(oper)
+  local nr;
+  nr := MASTER_POINTER_NUMBER(oper);
+  if not IsBound(OPER_FLAGS.(nr)) then
+    return fail;
+  fi;
+  return OPER_FLAGS.(nr)[3];
+end);
+
+# the object handles change after loading a workspace
+ADD_LIST(GAPInfo.PostRestoreFuncs, function()
+  local tmp, a;
+  tmp := [];
+  for a in REC_NAMES(OPER_FLAGS) do
+    ADD_LIST(tmp, OPER_FLAGS.(a));
+    Unbind(OPER_FLAGS.(a));
+  od;
+  for a in tmp do 
+    OPER_FLAGS.(MASTER_POINTER_NUMBER(a[1])) := a;
+  od;
+end);
 
 #############################################################################
 ##
@@ -567,8 +614,7 @@ BIND_GLOBAL( "NewOperation", function ( name, filters )
         fi;
         ADD_LIST( filt, FLAGS_FILTER( filter ) );
     od;
-    ADD_LIST( OPERATIONS, oper );
-    ADD_LIST( OPERATIONS, [ filt ] );
+    STORE_OPER_FLAGS(oper, filt);
     return oper;
 end );
 
@@ -694,8 +740,7 @@ BIND_GLOBAL( "NewConstructor", function ( name, filters )
         ADD_LIST( filt, FLAGS_FILTER( filter ) );
     od;
     ADD_LIST( CONSTRUCTORS, oper );
-    ADD_LIST( OPERATIONS,   oper );
-    ADD_LIST( OPERATIONS,   [ filt ] );
+    STORE_OPER_FLAGS(oper, filt);
     return oper;
 end );
 
@@ -716,7 +761,7 @@ end );
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL( "DeclareOperation", function ( name, filters )
-    local gvar, pos, filt, filter;
+    local gvar, pos, req, filt, filter;
 
     if   GAPInfo.MaxNrArgsMethod < LEN_LIST( filters ) then
       Error( "methods can have at most ", GAPInfo.MaxNrArgsMethod,
@@ -772,14 +817,14 @@ BIND_GLOBAL( "DeclareOperation", function ( name, filters )
         ADD_LIST( filt, FLAGS_FILTER( filter ) );
       od;
       
-      pos:= POS_LIST_DEFAULT( OPERATIONS, gvar, 0 );
-      if filt in OPERATIONS[ pos+1 ] then
+      req := GET_OPER_FLAGS(gvar);
+      if filt in req then
         if not REREADING then
           INFO_DEBUG( 1, "equal requirements in multiple declarations ",
               "for operation `", name, "'\n" );
         fi;
       else
-        ADD_LIST( OPERATIONS[ pos+1 ], filt );
+        STORE_OPER_FLAGS( gvar, filt );
       fi;
 
     else
@@ -824,8 +869,7 @@ BIND_GLOBAL( "DeclareOperationKernel", function ( name, filters, oper )
         ADD_LIST( filt, FLAGS_FILTER( filter ) );
     od;
 
-    ADD_LIST( OPERATIONS, oper );
-    ADD_LIST( OPERATIONS, [ filt ] );
+    STORE_OPER_FLAGS(oper, filt);
 end );
 
 
@@ -850,7 +894,7 @@ end );
 ##
 BIND_GLOBAL( "DeclareConstructor", function ( name, filters )
 
-    local gvar, pos, filt, filter;
+    local gvar, req, filt, filter;
 
     if GAPInfo.MaxNrArgsMethod < LEN_LIST( filters ) then
       Error( "methods can have at most ", GAPInfo.MaxNrArgsMethod,
@@ -880,8 +924,7 @@ BIND_GLOBAL( "DeclareConstructor", function ( name, filters )
         ADD_LIST( filt, FLAGS_FILTER( filter ) );
       od;
 
-      pos:= POS_LIST_DEFAULT( OPERATIONS, gvar, 0 );
-      ADD_LIST( OPERATIONS[ pos+1 ], filt );
+      STORE_OPER_FLAGS( gvar, filt );
 
     else
 
@@ -926,8 +969,7 @@ BIND_GLOBAL( "DeclareConstructorKernel", function ( name, filters, oper )
     od;
 
     ADD_LIST( CONSTRUCTORS, oper );
-    ADD_LIST( OPERATIONS,   oper );
-    ADD_LIST( OPERATIONS,   [ filt ] );
+    STORE_OPER_FLAGS(oper, filt);
 end );
 
 
@@ -993,13 +1035,9 @@ BIND_GLOBAL( "DeclareAttributeKernel", function ( name, filter, getter )
     tester := TESTER_FILTER( getter );
 
     # add getter, setter and tester to the list of operations
-    ADD_LIST( OPERATIONS, getter );
-    ADD_LIST( OPERATIONS, [ [ FLAGS_FILTER(filter) ] ] );
-    ADD_LIST( OPERATIONS, setter );
-    ADD_LIST( OPERATIONS,
-              [ [ FLAGS_FILTER( filter ), FLAGS_FILTER( IS_OBJECT ) ] ] );
-    ADD_LIST( OPERATIONS, tester );
-    ADD_LIST( OPERATIONS, [ [ FLAGS_FILTER(filter) ] ] );
+    STORE_OPER_FLAGS(getter, [ FLAGS_FILTER(filter) ]);
+    STORE_OPER_FLAGS(setter, [ FLAGS_FILTER(filter), FLAGS_FILTER(IS_OBJECT) ]);
+    STORE_OPER_FLAGS(tester, [ FLAGS_FILTER(filter) ]);
 
     # store the information about the filter
     FILTERS[ FLAG2_FILTER( tester ) ] := tester;
@@ -1089,10 +1127,8 @@ BIND_GLOBAL( "OPER_SetupAttribute", function(getter, flags, mutflag, filter, ran
           setter := SETTER_FILTER( getter );
           tester := TESTER_FILTER( getter );
 
-          ADD_LIST( OPERATIONS, setter );
-          ADD_LIST( OPERATIONS, [ [ flags, FLAGS_FILTER( IS_OBJECT ) ] ] );
-          ADD_LIST( OPERATIONS, tester );
-          ADD_LIST( OPERATIONS, [ [ flags ] ] );
+          STORE_OPER_FLAGS(setter, [ flags, FLAGS_FILTER( IS_OBJECT ) ]);
+          STORE_OPER_FLAGS(tester, [ flags ]);
 
           # install the default functions
           FILTERS[ FLAG2_FILTER( tester ) ] := tester;
@@ -1140,8 +1176,8 @@ BIND_GLOBAL( "NewAttribute", function ( arg )
     else
         rank := 1;
     fi;
-    ADD_LIST(OPERATIONS,getter);
-    ADD_LIST(OPERATIONS, [ [ flags ] ]);
+    STORE_OPER_FLAGS(getter, [ flags ]);
+
     OPER_SetupAttribute(getter, flags, mutflag, filter, rank, name);
     # store the information about the filtera
     # And return the getter
@@ -1170,7 +1206,7 @@ end );
 ##
 
 BIND_GLOBAL( "DeclareAttribute", function ( arg )
-    local   name,  gvar,  pos,  reqs,  filter,  setter,  tester,  
+    local   name,  gvar,  req,  reqs,  filter,  setter,  tester,  
               attr,  nname, mutflag, flags, rank;
 
     name:= arg[1];
@@ -1196,8 +1232,8 @@ BIND_GLOBAL( "DeclareAttribute", function ( arg )
           
           # if `gvar' has no one argument declarations we can turn it into 
           # an attribute
-          pos:= POS_LIST_DEFAULT( OPERATIONS, gvar, 0 );
-          for reqs in OPERATIONS[pos+1] do
+          req := GET_OPER_FLAGS(gvar);
+          for reqs in req do
               if LENGTH(reqs)  = 1 then
                   Error( "operation `", name, "' has been declared as a one ",
                          "argument Operation and cannot also be an Attribute");
@@ -1212,8 +1248,7 @@ BIND_GLOBAL( "DeclareAttribute", function ( arg )
           fi;
           
           flags := FLAGS_FILTER(filter);
-          pos:= POS_LIST_DEFAULT( OPERATIONS, gvar, 0 );
-          ADD_LIST( OPERATIONS[ pos+1 ], [ FLAGS_FILTER( filter ) ] );
+          STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
           
           # kernel magic for the conversion
           if mutflag then
@@ -1246,13 +1281,11 @@ BIND_GLOBAL( "DeclareAttribute", function ( arg )
       if not IS_OPERATION( filter ) then
         Error( "<filter> must be an operation" );
       fi;
-      pos:= POS_LIST_DEFAULT( OPERATIONS, gvar, 0 );
-      ADD_LIST( OPERATIONS[ pos+1 ], [ FLAGS_FILTER( filter ) ] );
+      STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
 
       # also set the extended range for the setter
-      pos:= POS_LIST_DEFAULT( OPERATIONS, Setter(gvar), pos );
-      ADD_LIST( OPERATIONS[ pos+1 ],
-                [ FLAGS_FILTER( filter),OPERATIONS[pos+1][1][2] ] );
+      req := GET_OPER_FLAGS( Setter(gvar) );
+      STORE_OPER_FLAGS( Setter(gvar), [ FLAGS_FILTER( filter), req[1][2] ] );
 
     else
 
@@ -1316,13 +1349,9 @@ BIND_GLOBAL( "DeclarePropertyKernel", function ( name, filter, getter )
     ADD_LIST( NUMBERS_PROPERTY_GETTERS, FLAG1_FILTER( getter ) );
 
     # add getter, setter and tester to the list of operations
-    ADD_LIST( OPERATIONS, getter );
-    ADD_LIST( OPERATIONS, [ [ FLAGS_FILTER(filter) ] ] );
-    ADD_LIST( OPERATIONS, setter );
-    ADD_LIST( OPERATIONS,
-              [ [ FLAGS_FILTER( filter ), FLAGS_FILTER( IS_BOOL ) ] ] );
-    ADD_LIST( OPERATIONS, tester );
-    ADD_LIST( OPERATIONS, [ [ FLAGS_FILTER(filter) ] ] );
+    STORE_OPER_FLAGS(getter, [ FLAGS_FILTER(filter) ]);
+    STORE_OPER_FLAGS(setter, [ FLAGS_FILTER(filter), FLAGS_FILTER(IS_BOOL) ]);
+    STORE_OPER_FLAGS(tester, [ FLAGS_FILTER(filter) ]);
 
     # install the default functions
     FILTERS[ FLAG1_FILTER( getter ) ]:= getter;
@@ -1392,12 +1421,9 @@ BIND_GLOBAL( "NewProperty", function ( arg )
     tester := TESTER_FILTER( getter );
 
     # add getter, setter and tester to the list of operations
-    ADD_LIST( OPERATIONS, getter );
-    ADD_LIST( OPERATIONS, [ [ flags ] ] );
-    ADD_LIST( OPERATIONS, setter );
-    ADD_LIST( OPERATIONS, [ [ flags, FLAGS_FILTER( IS_BOOL ) ] ] );
-    ADD_LIST( OPERATIONS, tester );
-    ADD_LIST( OPERATIONS, [ [ flags ] ] );
+    STORE_OPER_FLAGS(getter, [ flags ]);
+    STORE_OPER_FLAGS(setter, [ flags, FLAGS_FILTER(IS_BOOL) ]);
+    STORE_OPER_FLAGS(tester, [ flags ]);
 
     # store the property getters
     ADD_LIST( NUMBERS_PROPERTY_GETTERS, FLAG1_FILTER( getter ) );
@@ -1452,7 +1478,7 @@ end );
 ##
 BIND_GLOBAL( "DeclareProperty", function ( arg )
 
-    local prop, name, nname, gvar, pos, filter;
+    local prop, name, nname, gvar, req, filter;
 
     name:= arg[1];
 
@@ -1484,8 +1510,7 @@ BIND_GLOBAL( "DeclareProperty", function ( arg )
         Error( "<filter> must be an operation" );
       fi;
 
-      pos:= POS_LIST_DEFAULT( OPERATIONS, gvar, 0 );
-      ADD_LIST( OPERATIONS[ pos+1 ], [ FLAGS_FILTER( filter ) ] );
+      STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
 
     else
 
@@ -1640,7 +1665,7 @@ end );
 ##
 BIND_GLOBAL( "TraceAllMethods", function( arg )
     local   fun;
-    TraceMethods(OPERATIONS{[ 1, 3 .. LEN_LIST(OPERATIONS)-1 ]});
+    TraceMethods(OPERATIONS);
 end );
 
 
@@ -1702,7 +1727,7 @@ end );
 ##
 BIND_GLOBAL( "UntraceAllMethods", function( arg )
     local   fun;
-    UntraceMethods(OPERATIONS{[ 1, 3 .. LEN_LIST(OPERATIONS)-1 ]});
+    UntraceMethods(OPERATIONS);
 end );
 
 #############################################################################
@@ -1795,10 +1820,10 @@ end );
 
 
 BIND_GLOBAL( "FLUSH_ALL_METHOD_CACHES", function()
-    local i,j;
-    for i in [1,3..LEN_LIST(OPERATIONS)-1] do
+    local oper,j;
+    for oper in OPERATIONS do
         for j in [1..6] do
-            CHANGED_METHODS_OPERATION(OPERATIONS[i],j);
+            CHANGED_METHODS_OPERATION(oper,j);
         od;
     od;
 end);

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -444,13 +444,7 @@ BIND_GLOBAL( "INSTALL_METHOD",
       fi;
 
       # find the operation
-      req := false;
-      for i  in [ 1, 3 .. LEN_LIST(OPERATIONS)-1 ]  do
-        if IS_IDENTICAL_OBJ( OPERATIONS[i], opr )  then
-          req := OPERATIONS[i+1];
-          break;
-        fi;
-      od;
+      req := GET_OPER_FLAGS(opr);
       if req = false  then
         Error( "unknown operation ", NAME_FUNC(opr) );
       fi;

--- a/lib/pager.gi
+++ b/lib/pager.gi
@@ -111,7 +111,7 @@ BindGlobal("PAGER_BUILTIN", function( lines )
     if IsBound(lines.formatted) then
       formatted := lines.formatted;
     fi;
-    if IsBound(lines.start) then
+    if IsBound(lines.start) and IsInt(lines.start) then
       linepos := lines.start;
     fi;
     if IsBound( lines.exitAtEnd ) then

--- a/lib/profile.g
+++ b/lib/profile.g
@@ -759,7 +759,7 @@ BIND_GLOBAL("ProfileOperationsOn",function()
     local   prof;
 
     # Note that the list of operations may have grown since the last call.
-    prof := OPERATIONS{[ 1, 3 .. Length(OPERATIONS)-1 ]};
+    prof := OPERATIONS;
     PROFILED_OPERATIONS := prof;
     UnprofileMethods(prof);
     ProfileFunctions( prof );
@@ -818,7 +818,7 @@ end);
 BIND_GLOBAL("ProfileOperationsAndMethodsOn",function()
     local   prof;
 
-    prof := OPERATIONS{[ 1, 3 .. Length(OPERATIONS)-1 ]};
+    prof := OPERATIONS;
     PROFILED_OPERATIONS := prof;
     ProfileFunctions( prof );
     ProfileMethods(prof);

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include <src/compiled.h>
-#define FILE_CRC  "-40042667"
+#define FILE_CRC  "119111818"
 
 /* global variables used in handlers */
 static GVar G_REREADING;
@@ -114,8 +114,8 @@ static GVar G_WRAPPER__OPERATIONS;
 static Obj  GC_WRAPPER__OPERATIONS;
 static GVar G_INFO__DEBUG;
 static Obj  GF_INFO__DEBUG;
-static GVar G_OPERATIONS;
-static Obj  GC_OPERATIONS;
+static GVar G_GET__OPER__FLAGS;
+static Obj  GF_GET__OPER__FLAGS;
 static GVar G_NamesFilter;
 static Obj  GF_NamesFilter;
 static GVar G_Ordinal;
@@ -1725,67 +1725,11 @@ static Obj  HdlrFunc6 (
   }
   /* fi */
   
-  /* req := false; */
-  t_1 = False;
+  /* req := GET_OPER_FLAGS( opr ); */
+  t_2 = GF_GET__OPER__FLAGS;
+  t_1 = CALL_1ARGS( t_2, l_opr );
+  CHECK_FUNC_RESULT( t_1 )
   l_req = t_1;
-  
-  /* for i in [ 1, 3 .. LEN_LIST( OPERATIONS ) - 1 ] do */
-  t_7 = GF_LEN__LIST;
-  t_8 = GC_OPERATIONS;
-  CHECK_BOUND( t_8, "OPERATIONS" )
-  t_6 = CALL_1ARGS( t_7, t_8 );
-  CHECK_FUNC_RESULT( t_6 )
-  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
-  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(3), t_5 );
-  if ( IS_SMALL_LIST(t_4) ) {
-   t_3 = (Obj)(UInt)1;
-   t_1 = INTOBJ_INT(1);
-  }
-  else {
-   t_3 = (Obj)(UInt)0;
-   t_1 = CALL_1ARGS( GF_ITERATOR, t_4 );
-  }
-  while ( 1 ) {
-   if ( t_3 ) {
-    if ( LEN_LIST(t_4) < INT_INTOBJ(t_1) )  break;
-    t_2 = ELMV0_LIST( t_4, INT_INTOBJ(t_1) );
-    t_1 = (Obj)(((UInt)t_1)+4);
-    if ( t_2 == 0 )  continue;
-   }
-   else {
-    if ( CALL_1ARGS( GF_IS_DONE_ITER, t_1 ) != False )  break;
-    t_2 = CALL_1ARGS( GF_NEXT_ITER, t_1 );
-   }
-   l_i = t_2;
-   
-   /* if IS_IDENTICAL_OBJ( OPERATIONS[i], opr ) then */
-   t_7 = GF_IS__IDENTICAL__OBJ;
-   t_9 = GC_OPERATIONS;
-   CHECK_BOUND( t_9, "OPERATIONS" )
-   CHECK_INT_POS( l_i )
-   C_ELM_LIST_FPL( t_8, t_9, l_i )
-   t_6 = CALL_2ARGS( t_7, t_8, l_opr );
-   CHECK_FUNC_RESULT( t_6 )
-   CHECK_BOOL( t_6 )
-   t_5 = (Obj)(UInt)(t_6 != False);
-   if ( t_5 ) {
-    
-    /* req := OPERATIONS[i + 1]; */
-    t_6 = GC_OPERATIONS;
-    CHECK_BOUND( t_6, "OPERATIONS" )
-    C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) )
-    CHECK_INT_POS( t_7 )
-    C_ELM_LIST_FPL( t_5, t_6, t_7 )
-    l_req = t_5;
-    
-    /* break; */
-    break;
-    
-   }
-   /* fi */
-   
-  }
-  /* od */
   
   /* if req = false then */
   t_2 = False;
@@ -2435,8 +2379,8 @@ static Obj  HdlrFunc7 (
    t_6 = NewFunction( NameFunc[8], 1, 0, HdlrFunc8 );
    SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
    t_7 = NewBag( T_BODY, sizeof(BodyHeader) );
-   SET_STARTLINE_BODY(t_7, 580);
-   SET_ENDLINE_BODY(t_7, 598);
+   SET_STARTLINE_BODY(t_7, 574);
+   SET_ENDLINE_BODY(t_7, 592);
    SET_FILENAME_BODY(t_7, FileName);
    SET_BODY_FUNC(t_6, t_7);
    CHANGED_BAG( STATE(CurrLVars) );
@@ -3026,8 +2970,8 @@ static Obj  HdlrFunc11 (
   t_1 = NewFunction( NameFunc[12], 1, 0, HdlrFunc12 );
   SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
   t_2 = NewBag( T_BODY, sizeof(BodyHeader) );
-  SET_STARTLINE_BODY(t_2, 777);
-  SET_ENDLINE_BODY(t_2, 781);
+  SET_STARTLINE_BODY(t_2, 771);
+  SET_ENDLINE_BODY(t_2, 775);
   SET_FILENAME_BODY(t_2, FileName);
   SET_BODY_FUNC(t_1, t_2);
   CHANGED_BAG( STATE(CurrLVars) );
@@ -3106,8 +3050,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[13], 1, 0, HdlrFunc13 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_7, 798);
- SET_ENDLINE_BODY(t_7, 798);
+ SET_STARTLINE_BODY(t_7, 792);
+ SET_ENDLINE_BODY(t_7, 792);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3169,8 +3113,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[14], 2, 0, HdlrFunc14 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_7, 811);
- SET_ENDLINE_BODY(t_7, 834);
+ SET_STARTLINE_BODY(t_7, 805);
+ SET_ENDLINE_BODY(t_7, 828);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3218,8 +3162,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[15], 2, 0, HdlrFunc15 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_7, 844);
- SET_ENDLINE_BODY(t_7, 852);
+ SET_STARTLINE_BODY(t_7, 838);
+ SET_ENDLINE_BODY(t_7, 846);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3280,8 +3224,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[16], 3, 0, HdlrFunc16 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_7, 861);
- SET_ENDLINE_BODY(t_7, 874);
+ SET_STARTLINE_BODY(t_7, 855);
+ SET_ENDLINE_BODY(t_7, 868);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3661,8 +3605,8 @@ static Obj  HdlrFunc17 (
  t_4 = NewFunction( NameFunc[18], -1, 0, HdlrFunc18 );
  SET_ENVI_FUNC( t_4, STATE(CurrLVars) );
  t_5 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_5, 942);
- SET_ENDLINE_BODY(t_5, 958);
+ SET_STARTLINE_BODY(t_5, 936);
+ SET_ENDLINE_BODY(t_5, 952);
  SET_FILENAME_BODY(t_5, FileName);
  SET_BODY_FUNC(t_4, t_5);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3975,13 +3919,7 @@ static Obj  HdlrFunc1 (
           if opr in WRAPPER_OPERATIONS then
               INFO_DEBUG( 1, "a method is installed for the wrapper operation ", NAME_FUNC( opr ), "\n", "#I  probably it should be installed for (one of) its\n", "#I  underlying operation(s)" );
           fi;
-          req := false;
-          for i in [ 1, 3 .. LEN_LIST( OPERATIONS ) - 1 ] do
-              if IS_IDENTICAL_OBJ( OPERATIONS[i], opr ) then
-                  req := OPERATIONS[i + 1];
-                  break;
-              fi;
-          od;
+          req := GET_OPER_FLAGS( opr );
           if req = false then
               Error( "unknown operation ", NAME_FUNC( opr ) );
           fi;
@@ -4043,7 +3981,7 @@ static Obj  HdlrFunc1 (
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
  SET_STARTLINE_BODY(t_4, 322);
- SET_ENDLINE_BODY(t_4, 529);
+ SET_ENDLINE_BODY(t_4, 523);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4099,8 +4037,8 @@ static Obj  HdlrFunc1 (
  t_2 = NewFunction( NameFunc[7], 6, 0, HdlrFunc7 );
  SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
  t_3 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_3, 548);
- SET_ENDLINE_BODY(t_3, 602);
+ SET_STARTLINE_BODY(t_3, 542);
+ SET_ENDLINE_BODY(t_3, 596);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4114,8 +4052,8 @@ static Obj  HdlrFunc1 (
  t_2 = NewFunction( NameFunc[9], 6, 0, HdlrFunc9 );
  SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
  t_3 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_3, 605);
- SET_ENDLINE_BODY(t_3, 611);
+ SET_STARTLINE_BODY(t_3, 599);
+ SET_ENDLINE_BODY(t_3, 605);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4143,8 +4081,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[10], 2, 0, HdlrFunc10 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 624);
- SET_ENDLINE_BODY(t_4, 648);
+ SET_STARTLINE_BODY(t_4, 618);
+ SET_ENDLINE_BODY(t_4, 642);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4226,8 +4164,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[11], 4, 0, HdlrFunc11 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 773);
- SET_ENDLINE_BODY(t_4, 875);
+ SET_STARTLINE_BODY(t_4, 767);
+ SET_ENDLINE_BODY(t_4, 869);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4278,8 +4216,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[17], -1, 0, HdlrFunc17 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 910);
- SET_ENDLINE_BODY(t_4, 959);
+ SET_STARTLINE_BODY(t_4, 904);
+ SET_ENDLINE_BODY(t_4, 953);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4372,7 +4310,7 @@ static Int PostRestore ( StructInitInfo * module )
  G_EvalString = GVarName( "EvalString" );
  G_WRAPPER__OPERATIONS = GVarName( "WRAPPER_OPERATIONS" );
  G_INFO__DEBUG = GVarName( "INFO_DEBUG" );
- G_OPERATIONS = GVarName( "OPERATIONS" );
+ G_GET__OPER__FLAGS = GVarName( "GET_OPER_FLAGS" );
  G_NamesFilter = GVarName( "NamesFilter" );
  G_Ordinal = GVarName( "Ordinal" );
  G_INSTALL__METHOD__FLAGS = GVarName( "INSTALL_METHOD_FLAGS" );
@@ -4480,7 +4418,7 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "EvalString", &GF_EvalString );
  InitCopyGVar( "WRAPPER_OPERATIONS", &GC_WRAPPER__OPERATIONS );
  InitFopyGVar( "INFO_DEBUG", &GF_INFO__DEBUG );
- InitCopyGVar( "OPERATIONS", &GC_OPERATIONS );
+ InitFopyGVar( "GET_OPER_FLAGS", &GF_GET__OPER__FLAGS );
  InitFopyGVar( "NamesFilter", &GF_NamesFilter );
  InitFopyGVar( "Ordinal", &GF_Ordinal );
  InitFopyGVar( "INSTALL_METHOD_FLAGS", &GF_INSTALL__METHOD__FLAGS );
@@ -4575,7 +4513,7 @@ static StructInitInfo module = {
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,
  /* version     = */ 0,
- /* crc         = */ -40042667,
+ /* crc         = */ 119111818,
  /* initKernel  = */ InitKernel,
  /* initLibrary = */ InitLibrary,
  /* checkInit   = */ 0,


### PR DESCRIPTION
This substitutes a list OPERATIONS containing operations in odd positions
and corresponding lists of flag lists from declarations in the following
positions by:
- a list OPERATIONS, containing only the operations themselves and
- a record OPER_FLAGS containing the lists of flag lists.

More precisely, a pair [oper,flaglists] is stored in component
HANDLE_OBJ(oper) of OPER_FLAGS.
We need a backpointer to oper here because HANDLE_OBJ(oper) will
change after reloading a workspace. With the backpointer we can
clean this up in a post-restore function.

On my computer the startup time of GAP is reduced from about 1460msec
to 1260msec.