### PR TITLE
MatrixObj: Remove test diffs due to ws/line breaks

### DIFF
--- a/tst/test-matobj/ConcatenationOfVectors.tst
+++ b/tst/test-matobj/ConcatenationOfVectors.tst
@@ -18,5 +18,6 @@ gap> v4 := Vector(GF(5), l2*One(GF(5)));
 gap> vv := ConcatenationOfVectors( [ v3, v4, v3 ] );
 < mutable compressed vector length 18 over GF(5) >
 gap> Unpack( vv );
-[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5)^2, 0*Z(5), Z(5)^0, Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5)^2, 
+  0*Z(5), Z(5)^0, Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
 gap> STOP_TEST("ConcatenationOfVectors.tst",1);

--- a/tst/test-matobj/WeightOfVector.tst
+++ b/tst/test-matobj/WeightOfVector.tst
@@ -14,17 +14,17 @@ gap> WeightOfVector( v2 );
 gap> l3 := [0,0,0,0,0,0];
 [ 0, 0, 0, 0, 0, 0 ]
 gap> v3 := Vector(IsPlistVectorRep, Rationals, l3);
-<plist vector over Rationals of length 6> 
+<plist vector over Rationals of length 6>
 gap> WeightOfVector( v3 );
-0 
+0
 gap> v4 := Vector(GF(5), l1*One(GF(5)));
 [ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
 gap> WeightOfVector( v4 );
-5 
+5
 gap> v5 := Vector(GF(5), l2*One(GF(5)));
 [ 0*Z(5), Z(5), Z(5)^3, 0*Z(5), 0*Z(5), Z(5)^0 ]
 gap> WeightOfVector( v5 );
-3 
+3
 gap> v6 := Vector(GF(5), l3*One(GF(5)));
 [ 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5) ]
 gap> WeightOfVector( v6 );

--- a/tst/test-matobj/ZeroVector.tst
+++ b/tst/test-matobj/ZeroVector.tst
@@ -12,5 +12,6 @@ gap> v3 := Vector(GF(5), l1*One(GF(5)));
 gap> v0 := ZeroVector( 12, v3 );
 < mutable compressed vector length 12 over GF(5) >
 gap> Unpack( v0 );
-[ 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5) ]
+[ 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 0*Z(5), 
+  0*Z(5), 0*Z(5), 0*Z(5) ]
 gap> STOP_TEST("ZeroVector.tst",1);


### PR DESCRIPTION
I don't have write access to the MatrixObj2 branch so here is another pull request. :)