### PR TITLE
Load PrimGrp, SmallGrp and TransGrp packages if available

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,8 +23,9 @@ environment:
 #      HPCGAP: yes
 #      BUILDDIR: build       # HPC-GAP only supports kernel extensions for of out-of-tree builds
 
+# change to packages-stable-X.Y.tar.gz in the stable branch
 cache:
-  - bootstrap-pkg-full.tar.gz
+  - packages-master.tar.gz
 
 install:
   - '%CYG_ROOT%\setup-%CYG_ARCH%.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l %CYG_ROOT%/var/cache/setup -P libgmp-devel'

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -926,9 +926,11 @@ coverage:
 # Bootstrap rules
 ########################################################################
 
+# change PKG_BRANCH to stable-X.Y in the stable branch
+PKG_BRANCH = master
 PKG_BOOTSTRAP_URL = https://www.gap-system.org/pub/gap/gap4pkgs/
-PKG_MINIMAL = bootstrap-pkg-minimal.tar.gz
-PKG_FULL = bootstrap-pkg-full.tar.gz
+PKG_MINIMAL = packages-required-$(PKG_BRANCH).tar.gz
+PKG_FULL = packages-$(PKG_BRANCH).tar.gz
 WGET = wget -N
 
 bootstrap-pkg-minimal:

--- a/hpcgap/lib/galois.gi
+++ b/hpcgap/lib/galois.gi
@@ -550,7 +550,7 @@ local f,n,i,sh,fu,ps,pps,ind,keineu,ba,bk,j,k,a,anz,pm,
   Info(InfoPerformance,2,"Using Transitive Groups Library");
   f:=arg[1];
   f:=f/LeadingCoefficient(f);
-  if not(IsIrreducible(f)) then
+  if not IsIrreducibleRingElement(f) then
     Error("f must be irreducible");
   fi;
   n:=DegreeOfUnivariateLaurentPolynomial(f);

--- a/hpcgap/lib/package.gi
+++ b/hpcgap/lib/package.gi
@@ -1819,6 +1819,25 @@ BindGlobal( "BANNER", false );
 
     GAPInfo.delayedImplementationParts:= [];
 
+    # Ensure GAP loads PrimGrp, SmallGrp and TransGrp packages
+    # To be migrated to lib/system.g after the replacement of
+    # prim, small and trans directories by these packages
+    if TestPackageAvailability("primgrp") <> fail then
+      GAPInfo.Dependencies.NeededOtherPackages :=
+        `Concatenation( ShallowCopy(GAPInfo.Dependencies.NeededOtherPackages),
+           [ [ "primgrp", ">= 3.1.0" ] ]);
+    fi;
+    if TestPackageAvailability("smallgrp") <> fail then
+      GAPInfo.Dependencies.NeededOtherPackages :=
+        `Concatenation( ShallowCopy(GAPInfo.Dependencies.NeededOtherPackages),
+           [ [ "smallgrp", ">= 1.0" ] ]);
+    fi;
+    if TestPackageAvailability("transgrp") <> fail then
+      GAPInfo.Dependencies.NeededOtherPackages :=
+        `Concatenation( ShallowCopy(GAPInfo.Dependencies.NeededOtherPackages),
+          [ [ "transgrp", ">= 1.0" ] ]);
+    fi;
+
     # Load the needed other packages (suppressing banners)
     # that are not yet loaded.
     if ForAny( GAPInfo.Dependencies.NeededOtherPackages,

--- a/hpcgap/lib/read.g
+++ b/hpcgap/lib/read.g
@@ -28,35 +28,36 @@ fi;
 
 #############################################################################
 ##
-#X  Read transitive groups library
+#X  Checking transitive groups library
 ##
+## Assign TransitiveGroupsAvailable to a dummy function to make it
+## callable, even if the library is unavailable.
+if TestPackageAvailability("transgrp")=fail then
+  InstallGlobalFunction(TransitiveGroupsAvailable,deg->false);
+fi;
 
-# first assign TransitiveGroupsAvailable to a dummy function to make it
-# callable, even if the library is unavailable.
-InstallGlobalFunction(TransitiveGroupsAvailable,deg->false);
-
-TRANS_AVAILABLE:=ReadTrans( "trans.gd","transitive groups" );
-TRANS_AVAILABLE:= TRANS_AVAILABLE and ReadTrans( "trans.grp",
-                                        "transitive groups" );
-TRANS_AVAILABLE:= TRANS_AVAILABLE and ReadTrans( "trans.gi",
-                                        "transitive groups" );
-
-if TRANS_AVAILABLE then
-  ReadLib("galois.gd"); # the Galois group identification relies on the list
-                        # of transitive groups
-  ReadLib("galois.gi");
+# Only load component if not available as package
+# (to be removed together with the `trans` directory)
+if TestPackageAvailability("transgrp")=fail then
+  TRANS_AVAILABLE:=ReadTrans( "trans.gd","transitive groups" );
+  TRANS_AVAILABLE:= TRANS_AVAILABLE and ReadTrans( "trans.grp",
+					  "transitive groups" );
+  TRANS_AVAILABLE:= TRANS_AVAILABLE and ReadTrans( "trans.gi",
+					  "transitive groups" );
 fi;
 
 #############################################################################
 ##
-#X  Read primitive groups library
+#X  Checking primitive groups library
 ##
+## Assign PrimitiveGroupsAvailable to a dummy function to make it
+## callable, even if the library is unavailable.
+if TestPackageAvailability("primgrp")=fail then
+  InstallGlobalFunction(PrimitiveGroupsAvailable,deg->false);
+fi;
 
-# first assign PrimitiveGroupsAvailable to a dummy function to make it
-# callable, even if the library is unavailable.
-InstallGlobalFunction(PrimitiveGroupsAvailable,deg->false);
-
-# only load component if not available as package
+# Only load component if not available as package
+# (to be removed together with the `prim` directory)
 if TestPackageAvailability("primgrp")=fail then
   PRIM_AVAILABLE:=ReadPrim( "primitiv.gd","primitive groups" );
   PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "irredsol.gd","irreducible solvable groups" );

--- a/lib/galois.gi
+++ b/lib/galois.gi
@@ -550,7 +550,7 @@ local f,n,i,sh,fu,ps,pps,ind,keineu,ba,bk,j,k,a,anz,pm,
   Info(InfoPerformance,2,"Using Transitive Groups Library");
   f:=arg[1];
   f:=f/LeadingCoefficient(f);
-  if not(IsIrreducible(f)) then
+  if not IsIrreducibleRingElement(f) then
     Error("f must be irreducible");
   fi;
   n:=DegreeOfUnivariateLaurentPolynomial(f);

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1814,6 +1814,19 @@ BindGlobal( "BANNER", false );
 
     GAPInfo.delayedImplementationParts:= [];
 
+    # Ensure GAP loads PrimGrp, SmallGrp and TransGrp packages
+    # To be migrated to lib/system.g after the replacement of
+    # prim, small and trans directories by these packages
+    if TestPackageAvailability("primgrp") <> fail then
+      Add( GAPInfo.Dependencies.NeededOtherPackages, [ "primgrp", ">= 3.1.0" ] );
+    fi;
+    if TestPackageAvailability("smallgrp") <> fail then
+      Add( GAPInfo.Dependencies.NeededOtherPackages, [ "smallgrp", ">= 1.0" ] );
+    fi;
+    if TestPackageAvailability("transgrp") <> fail then
+      Add( GAPInfo.Dependencies.NeededOtherPackages, [ "transgrp", ">= 1.0" ] );
+    fi;
+
     # Load the needed other packages (suppressing banners)
     # that are not yet loaded.
     if ForAny( GAPInfo.Dependencies.NeededOtherPackages,

--- a/lib/read.g
+++ b/lib/read.g
@@ -11,11 +11,6 @@ ReadOrComplete( "lib/read8.g" ); # overloaded operations, compiler interface
 ReadLib( "colorprompt.g"  );
 
 
-# Galois group identification
-
-ReadLib("galois.gd");
-ReadLib("galois.gi");
-
 #############################################################################
 ##
 ##  Load data libraries
@@ -33,14 +28,16 @@ fi;
 
 #############################################################################
 ##
-#X  Read transitive groups library
+#X  Checking transitive groups library
 ##
+## Assign TransitiveGroupsAvailable to a dummy function to make it
+## callable, even if the library is unavailable.
+if TestPackageAvailability("transgrp")=fail then
+  InstallGlobalFunction(TransitiveGroupsAvailable,deg->false);
+fi;
 
-# first assign TransitiveGroupsAvailable to a dummy function to make it
-# callable, even if the library is unavailable.
-InstallGlobalFunction(TransitiveGroupsAvailable,deg->false);
-
-# only load component if not available as package
+# Only load component if not available as package
+# (to be removed together with the `trans` directory)
 if TestPackageAvailability("transgrp")=fail then
   TRANS_AVAILABLE:=ReadTrans( "trans.gd","transitive groups" );
   TRANS_AVAILABLE:= TRANS_AVAILABLE and ReadTrans( "trans.grp",
@@ -51,14 +48,16 @@ fi;
 
 #############################################################################
 ##
-#X  Read primitive groups library
+#X  Checking primitive groups library
 ##
+## Assign PrimitiveGroupsAvailable to a dummy function to make it
+## callable, even if the library is unavailable.
+if TestPackageAvailability("primgrp")=fail then
+  InstallGlobalFunction(PrimitiveGroupsAvailable,deg->false);
+fi;
 
-# first assign PrimitiveGroupsAvailable to a dummy function to make it
-# callable, even if the library is unavailable.
-InstallGlobalFunction(PrimitiveGroupsAvailable,deg->false);
-
-# only load component if not available as package
+# Only load component if not available as package
+# (to be removed together with the `prim` directory)
 if TestPackageAvailability("primgrp")=fail then
   PRIM_AVAILABLE:=ReadPrim( "primitiv.gd","primitive groups" );
   PRIM_AVAILABLE:=PRIM_AVAILABLE and ReadPrim( "irredsol.gd","irreducible solvable groups" );

--- a/lib/read4.g
+++ b/lib/read4.g
@@ -23,3 +23,12 @@ ReadLib( "string.gi"   ); # since StringFile is needed early
 # for dealing with test files and manual examples
 ReadLib("test.gd");
 ReadLib("test.gi");
+
+# Galois group identification relies on the list of transitive groups
+if IsBound(HPCGAP) then
+  BindGlobal("TRANSREGION", NewLibraryRegion("transitive groups region"));
+else
+  BindGlobal("TRANSREGION", fail);
+fi;
+ReadLib("galois.gd");
+ReadLib("galois.gi");

--- a/trans/trans.gd
+++ b/trans/trans.gd
@@ -73,12 +73,6 @@ DeclareGlobalFunction("NrTransitiveGroups");
 DeclareGlobalVariable( "TRANSCOMBCACHE", "combinations cache" );
 DeclareGlobalVariable( "TRANSARRCACHE", "arrangements cache" );
 
-if IsBound(HPCGAP) then
-  BindGlobal("TRANSREGION", NewLibraryRegion("transitive groups region"));
-else
-  BindGlobal("TRANSREGION", fail);
-fi;
-
 #############################################################################
 ##
 #E


### PR DESCRIPTION
This is a modification of some changes attempted in #1650.

If any of these packages is not available, GAP will read corresponding directory (`prim`, `small` or `trans`).

Dependency on `TRANSGrp` defined in the package required reading `lib/galois.g*` files in another place (in `read4.g`). In its turn, they require `IsIrreducible` which is defined in `overload.g` and delegates to `IsIrreducibleRingElement`, hence the latter was used.

Since the CI scripts are note yet using `packages-master.tar.gz`, this will now be tested for the setting in which none of the three new packages is available.

The next step would be to switch to  `packages-master.tar.gz` and run CI tests with two of the packages - PrimGrp and TransGrp.

When this will be merged, we will be able to tell developers to get the new packages in question, either installing them individually or by removing `pkg` directory and calling `make bootstrap-pkg-full` to get the latest collection of GAP packages for the master branch. 

After that, assuming that developers obtained relevant packages, we may proceed with next steps (could be done for one package at a time):
- removing prim/small/trans directories as soon and taking out of the manuals those sections which have been incorporated into packages
- replacing temporary code to ensure that GAP loads the packages by adding packages to `GAPInfo.Dependencies.NeededOtherPackages`.
