### PR TITLE
Fix bug in DeclareObsoleteSynonym

### DIFF
--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -82,7 +82,7 @@ BIND_GLOBAL( "DeclareObsoleteSynonym", function( name_obsolete, name_current )
         Error("Each argument of DeclareObsoleteSynonym must be a string\n");
     fi;
     value := EvalString( name_current );
-    if IsFunction( value ) then
+    if IsFunction( value ) and not IsOperation( value ) then
         orig_value := value;
         value := function (arg)
             local res;


### PR DESCRIPTION
Calling DeclareObsoleteSynonym("ObsOp", "NewOp") with "NewOp" the name of an
operation defined "ObsOp" as a function.
This caused method installations into "ObsOp" to fail.
See issue #1717