### PR TITLE
added the implication `IsMatrix` => `IsMatrixObj` ...

### DIFF
--- a/dev/TODO_matobj.txt
+++ b/dev/TODO_matobj.txt
@@ -3,6 +3,7 @@ Tasks for MatrixObj
 
 Design Decisions
 ===================
+
 - Decide the relation between 'IsMatrix' and 'IsMatrixObj'.
 
   (September 08th)
@@ -38,18 +39,53 @@ Design Decisions
   and say that special vector representations may support more general
   cases.)
   
+- Attributes for 'IsMatrixObj' objects:
+
+  *Storing* rank, determinant, etc. makes sense only for immutable objects;
+  it would be dangerous/wrong to store such information in mutable matrices.
+  We can still declare 'RankMat', 'DeterminantMat', etc. as attributes,
+  since the feature to *store* attributes is deactivated unless one sets
+  the filter 'IsAttributeStoringRep' or installs special setter methods.
+  Thus we could document that we recommend to implement new kinds of matrix
+  objects in one of the following ways:
+
+  1. As always *immutable* objects,
+     with the possibility to set the filter 'IsAttributeStoringRep' or to
+     install special attribute setter methods,
+
+  2. as copyable objects (that is, with the possibility to create mutable
+     matrices);
+     here the filter 'IsAttributeStoringRep' should not be set,
+     and special attribute setter methods should better not be installed.
+
+  Note that 'IsMatrixObj' does currently imply 'IsCopyable'.
+  We could drop 'IsCopyable' from the general 'IsMatrixObj' definition,
+  and set it whenever mutable versions shall be supported.
+  (For example, if the objects returned by 'BlockMatrix' would not be lists
+  then one could think about removing 'IsCopyable' from their type.
+  Currently 'IsCopyable' is set, and 'ShallowCopy' is defined to return
+  a deep copy represented via plists.)
+
 
 Changes to IsMatrixObj
 ===================
 
-- define 'DefaultRing' for the entries as default 'BaseDomain'
-  of Plist vectors and matrices
-  (Cheaper methods may be installed for special cases,
-  for example 'Cyclotomics' should be good enough for plists of (plists of)
-  cyclotomics, without computing conductors;
-  analogous objects for finite characteristic seem not to be available.)
-
-- introduce 'ZeroOfBaseDomain' (done)
+- If the identity of the 'BaseDomain's of two matrices is a necessary
+  condition for the applicability of (generic) methods,
+  for example for 'KroneckerProduct',
+  then the 'BaseDomain' for plists of plists must be as large as possible,
+  in order to make these methods.
+  For plists of plists of cyclotomics, 'Cyclotomics' would be suitable.
+  For plists of plists of FFE elements, we do not have analogous objects
+  (one for each positive characteristic), but we could create them,
+  and for matrices of polynomials etc., things are getting complicated.
+  Alternatively, we could take the *family of the matrix entries* as the
+  'BaseDomain':
+  'One', 'Zero', 'Characteristic' work in principle,
+  'IsFinite', 'Size', '\in' could be provided.
+  (With this choice, computing the 'BaseDomain' would be cheap, as required.)
+  
+- introduce 'OneOfBaseDomain', 'ZeroOfBaseDomain' (done)
 
 - Define and implement 'EmptyMatrix' as IsMatrixObj
 

--- a/lib/liefam.gi
+++ b/lib/liefam.gi
@@ -368,28 +368,24 @@ InstallMethod( AdditiveInverseOp,
 #M  IsBound\[\]( <mat>, <i> )
 #M  Position( <mat>, <obj> )
 ##
-InstallMethod( \[\],
+InstallOtherMethod( \[\],
     "for Lie matrix in default representation, and positive integer",
-    true,
-    [ IsLieMatrix and IsPackedElementDefaultRep, IsPosInt ], 0,
+    [ IsLieMatrix and IsPackedElementDefaultRep, IsPosInt ],
     function( mat, i ) return mat![1][i]; end );
 
-InstallMethod( Length,
+InstallOtherMethod( Length,
     "for Lie matrix in default representation",
-    true,
-    [ IsLieMatrix and IsPackedElementDefaultRep ], 0,
-    mat -> Length( mat![1] ) );
+    [ IsLieMatrix and IsPackedElementDefaultRep ],
+    mat -> NumberRows( mat![1] ) );
 
 InstallMethod( IsBound\[\],
     "for Lie matrix in default representation, and integer",
-    true,
-    [ IsLieMatrix and IsPackedElementDefaultRep, IsPosInt ], 0,
+    [ IsLieMatrix and IsPackedElementDefaultRep, IsPosInt ],
     function( mat, i ) return IsBound( mat![1][i] ); end );
 
 InstallMethod( Position,
     "for Lie matrix in default representation, row vector, and integer",
-    true,
-    [ IsLieMatrix and IsPackedElementDefaultRep, IsRowVector, IsInt ], 0,
+    [ IsLieMatrix and IsPackedElementDefaultRep, IsRowVector, IsInt ],
     function( mat, v, pos ) return Position( mat![1], v, pos ); end );
 
 

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -1047,11 +1047,9 @@ InstallMethod(DeterminantMatDestructive,
 ##
 
 
-InstallMethod(RankMatDestructive,
+InstallOtherMethod(RankMatDestructive,
         "kernel method for plain list of GF2 vectors",
-        true,
         [IsMatrix and IsPlistRep and IsFFECollColl and IsMutable],
-        0, 
         RANK_LIST_VEC8BITS);
   
 InstallMethod(NestingDepthM, [Is8BitMatrixRep], m->2);

--- a/lib/matblock.gi
+++ b/lib/matblock.gi
@@ -132,7 +132,7 @@ end );
 ##
 #M  Length( <blockmat> )  . . . . . . . . . . . . . . . .  for a block matrix
 ##
-InstallMethod( Length,
+InstallOtherMethod( Length,
     "for an ordinary block matrix",
     [ IsOrdinaryMatrix and IsBlockMatrixRep ],
     blockmat -> blockmat!.nrb * blockmat!.rpb );
@@ -142,7 +142,7 @@ InstallMethod( Length,
 ##
 #M  \[\]( <blockmat>, <n> ) . . . . . . . . . . . . . . .  for a block matrix
 ##
-InstallMethod( \[\],
+InstallOtherMethod( \[\],
     "for an ordinary block matrix and a positive integer",
     [ IsOrdinaryMatrix and IsBlockMatrixRep, IsPosInt ],
     function( blockmat, n )
@@ -195,7 +195,7 @@ InstallOtherMethod( \[\],
 ##
 #M  TransposedMat( <blockmat> ) . . . . . . . . . . . . .  for a block matrix
 ##
-InstallMethod( TransposedMat,
+InstallOtherMethod( TransposedMat,
     "for an ordinary block matrix",
     [ IsOrdinaryMatrix and IsBlockMatrixRep ],
     m -> BlockMatrix( List( m!.blocks, i -> [ i[2], i[1],
@@ -668,7 +668,7 @@ InstallMethod( PrintObj,
 ##
 #M  DimensionsMat( <blockmat> ) . . . . . . . . . . . . .  for a block matrix
 ##
-InstallMethod( DimensionsMat,
+InstallOtherMethod( DimensionsMat,
     "for an ordinary block matrix",
     [ IsOrdinaryMatrix and IsBlockMatrixRep ],
     m -> [ m!.nrb * m!.rpb, m!.ncb * m!.cpb ] );

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -323,9 +323,8 @@ InstallMethod( Fold, "for a vector, a positive int, and a matrix",
 InstallMethod( CompanionMatrix, "for a polynomial and a matrix",
   [ IsUnivariatePolynomial, IsMatrixObj ],
   function( po, m )
-    local l, n, q, ll, i, bd, one;
-    bd := BaseDomain(m);
-    one := One(bd);
+    local l, n, q, ll, i, one;
+    one := OneOfBaseDomain( m );
     l := CoefficientsOfUnivariatePolynomial(po);
     n := Length(l)-1;
     if not IsOne(l[n+1]) then
@@ -428,13 +427,12 @@ InstallMethod( ExtractSubVector, "generic method",
 InstallOtherMethod( ScalarProduct, "generic method",
   [ IsVectorObj, IsVectorObj ],
   function( v, w )
-    local bd,i,s;
-    bd := BaseDomain(v);
-    s := Zero(bd);
+    local i,s;
     if Length(v) <> Length(w) then
         Error("vectors must have equal length");
         return fail;
     fi;
+    s:= ZeroOfBaseDomain( v );
     for i in [1..Length(v)] do
         s := s + v[i]*w[i];
     od;
@@ -444,15 +442,14 @@ InstallOtherMethod( ScalarProduct, "generic method",
 InstallMethod( TraceMat, "generic method",
   [ IsMatrixObj ],
   function( m )
-    local bd,i,s;
-    bd := BaseDomain(m);
-    s := Zero(bd);
+    local i,s;
     if NumberRows(m) <> NumberColumns(m) then
         Error("matrix must be square");
         return fail;
     fi;
+    s := ZeroOfBaseDomain( m );
     for i in [1..NumberRows(m)] do
-        s := s + MatElm(m,i,i);
+        s := s + m[ i, i ];
     od;
     return s;
   end );
@@ -467,6 +464,8 @@ InstallMethod(PositionNonZero,
   od;
   return i+1;
 end);
+#T superfluous?
+
 
 InstallMethod(PositionNonZero,
   "generic method for a vector object",

--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -36,24 +36,40 @@ DeclareSynonym( "IsRowVectorObj", IsVectorObj );
 # We should eventually remove this synonym.
 
 
-# There are one main category for matrices and two disjoint sub-categories:
+# There are one main category for matrices and one subcategory:
 
 DeclareCategory( "IsMatrixObj", IsVector and IsScalar and IsCopyable );
 # All the arithmetical filters come from IsVector and IsScalar.
 # In particular, matrices are in "IsMultiplicativeElement" which defines
 # powering with a positive integer by the (kernel) method for POW_OBJ_INT.
 # Note that this is at least strange for non-associative base domains.
+# The filter 'IsMatrixObj' for an object does *not* imply that the
+# multiplication for this object is the usual matrix multiplication,
+# one can specify this multiplication via the filter 'IsOrdinaryMatrix'.
+# Also the associativity of the multiplication of matrices does not follow
+# from 'IsMatrixObj' and the associativity of the base domain,
+# one needs also 'IsOrdinaryMatrix' for this implication.
+# Note that elements of matrix Lie algebras lie in 'IsMatrixObj' but not in
+# 'IsOrdinaryMatrix'.
 # Matrices are no longer necessarily lists, since they do not promise all list
 # operations! Of course, in specific implementations the objects may
 # still be lists.
 # The family of an object in IsMatrixObj is the collections family of
 # the family of its base domain.
 
-InstallTrueMethod(IsAssociativeElement,
-	 IsMatrixObj and IsAssociativeElementCollColl);
+InstallTrueMethod( IsMatrixObj, IsMatrix );
+# We want that those matrices that are plain lists of plain lists
+# are also in 'IsMatrixObj', in order to be able to install a method for
+# all representations of matrices with the same requirements.
+# (With the current distribution of declarations to files,
+# we cannot put the implication into the declaration of 'IsMatrix':
+# Both 'IsVector' and 'IsMatrix' are declared in 'lib/arith.gd',
+# and 'IsMatrixObj' --which shall be in the middle-- is declared in
+# 'lib/matobj1.gd'.)
 
 DeclareCategory( "IsRowListMatrix", IsMatrixObj );
 # The category of matrices behaving like lists of rows which are GAP objects.
 # Different matrices in this category can share rows and the same row can
 # occur more than once in a matrix. Row access just gives a reference
 # to the row object.
+

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -236,31 +236,6 @@ DeclareAttribute( "DefaultFieldOfMatrix", IsMatrix );
 
 #############################################################################
 ##
-#A  BaseDomain( <v> )
-#A  BaseDomain( <mat> )
-##
-##  <ManSection>
-##  <Attr Name="BaseDomain" Arg='v'/>
-##  <Attr Name="BaseDomain" Arg='mat'/>
-##
-##  <Description>
-##  For a row vector <A>v</A> that is a (necessarily nonempty) plain list,
-##  the default <Ref Attr="BaseDomain"/> method returns the default ring
-##  of <A>v</A>,
-##  see <Ref Attr="DefaultRing" Label="for ring elements"/>.
-##  <P/>
-##  For a matrix <A>mat</A> that is a (necessarily nonempty) plain list,
-##  the default <Ref Attr="BaseDomain"/> method returns the value
-##  for the first row of <A>mat</A>.
-##  </Description>
-##  </ManSection>
-##
-DeclareAttribute( "BaseDomain", IsRowVector );
-DeclareAttribute( "BaseDomain", IsMatrix );
-
-
-#############################################################################
-##
 #A  DepthOfUpperTriangularMatrix( <mat> )
 ##
 ##  <#GAPDoc Label="DepthOfUpperTriangularMatrix">

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -32,6 +32,11 @@ InstallOtherMethod( \[\]\:\=, [ IsMatrix and IsMutable, IsPosInt, IsPosInt, IsOb
     -RankFilter(IsMatrix),
     function (m,i,j,o) m[i][j]:=o; end );
 
+InstallOtherMethod( Unpack,
+    [ IsMatrix ],
+    ShallowCopy );
+
+
 #############################################################################
 ##
 #F  PrintArray( <array> ) . . . . . . . . . . . . . . . . pretty print matrix
@@ -159,7 +164,7 @@ InstallMethod( IsGeneralizedCartanMatrix,
 ##
 #M  IsDiagonalMat(<mat>)
 ##
-InstallMethod( IsDiagonalMat,
+InstallOtherMethod( IsDiagonalMat,
     "for a matrix",
     [ IsMatrix ],
     function( mat )
@@ -183,7 +188,7 @@ InstallOtherMethod( IsDiagonalMat, [ IsEmpty ], ReturnTrue );
 ##
 #M  IsUpperTriangularMat(<mat>)
 ##
-InstallMethod( IsUpperTriangularMat,
+InstallOtherMethod( IsUpperTriangularMat,
     "for a matrix",
     [ IsMatrix ],
     function( mat )
@@ -204,7 +209,7 @@ InstallMethod( IsUpperTriangularMat,
 ##
 #M  IsLowerTriangularMat(<mat>)
 ##
-InstallMethod( IsLowerTriangularMat,
+InstallOtherMethod( IsLowerTriangularMat,
     "for a matrix",
     [ IsMatrix ],
     function( mat )
@@ -251,7 +256,7 @@ DeclareRepresentation( "IsNullMapMatrix", IsMatrix, [  ] );
 BindGlobal( "NullMapMatrix",
     Objectify( NewType( ListsFamily, IsNullMapMatrix ), MakeImmutable([  ]) ) );
 
-InstallMethod( Length,
+InstallOtherMethod( Length,
     "for null map matrix",
     [ IsNullMapMatrix ],
     null -> 0 );
@@ -1230,7 +1235,7 @@ InstallOtherMethod( ZeroOfBaseDomain,
     [ IsRowVector ],
     v -> Zero( v[1] ) );
 
-InstallMethod( BaseDomain,
+InstallOtherMethod( BaseDomain,
     "generic method for a matrix that is a plain list",
     [ IsMatrix and IsPlistRep ],
     mat -> BaseDomain( mat[1] ) );
@@ -1607,7 +1612,7 @@ InstallMethod( DeterminantMatDivFree,
 ##
 #M  DimensionsMat( <mat> )
 ##
-InstallMethod( DimensionsMat,
+InstallOtherMethod( DimensionsMat,
     [ IsMatrix ],
     function( A )
     if IsRectangularTable(A) then
@@ -1929,7 +1934,7 @@ InstallMethod( MutableCopyMat, "generic method", [IsList],
 ##
 #M  MutableTransposedMat( <mat> ) . . . . . . . . . .  transposed of a matrix
 ##
-InstallMethod( MutableTransposedMat,
+InstallOtherMethod( MutableTransposedMat,
     "generic method",
     [ IsRectangularTable and IsMatrix ],
     function( mat )
@@ -2239,7 +2244,7 @@ end );
 ##
 #M  RankMat( <mat> )  . . . . . . . . . . . . . . . . . . .  rank of a matrix
 ##
-InstallMethod( RankMatDestructive,
+InstallOtherMethod( RankMatDestructive,
     "generic method for mutable matrices",
     [ IsMatrix and IsMutable ],
     function( mat )
@@ -2250,7 +2255,7 @@ InstallMethod( RankMatDestructive,
     return mat;
     end );
 
-InstallMethod( RankMat,
+InstallOtherMethod( RankMat,
     "generic method for matrices",
     [ IsMatrix ],
     mat -> RankMatDestructive( MutableCopyMat( mat ) ) );
@@ -2642,7 +2647,7 @@ end );
 ##
 #M  KroneckerProduct( <mat1>, <mat2> )
 ##
-InstallMethod( KroneckerProduct,
+InstallOtherMethod( KroneckerProduct,
     "generic method for matrices",
     IsIdenticalObj,
     [ IsMatrix, IsMatrix ],

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -1220,7 +1220,7 @@ end );
 ##  Since the rows are homogeneous and nonempty,
 ##  one can also access the first entry in the first row.
 ##
-InstallMethod( BaseDomain,
+InstallOtherMethod( BaseDomain,
     "generic method for a row vector",
     [ IsRowVector ],
     DefaultRing );

--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -364,17 +364,17 @@ InstallOtherMethod(CycleStructurePerm,
 
 # Matrix methods:
 
-InstallMethod( DimensionsMat, "for a matrix with memory",true,
-  [ IsMatrix and IsObjWithMemory ], 0,
+InstallOtherMethod( DimensionsMat, "for a matrix with memory",
+  [ IsMatrix and IsObjWithMemory ],
   function(M)
     return DimensionsMat(M!.el);
   end);
 
-InstallMethod( Length, "for a matrix with memory",
+InstallOtherMethod( Length, "for a matrix with memory",
   [ IsMatrix and IsObjWithMemory ], M -> Length(M!.el) ) ;
 
-InstallMethod( ELM_LIST, "for a matrix with memory",true,
-  [ IsMatrix and IsObjWithMemory, IsPosInt ], 0,
+InstallOtherMethod( ELM_LIST, "for a matrix with memory",
+  [ IsMatrix and IsObjWithMemory, IsPosInt ],
   function(M,i)
     return M!.el[i];
   end);

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2092,9 +2092,8 @@ InstallMethod(DeterminantMatDestructive,
 ##
 
 
-InstallMethod(RankMatDestructive,
+InstallOtherMethod(RankMatDestructive,
         "kernel method for plain list of GF2 vectors",
-        true,
         [IsMatrix and IsPlistRep and IsFFECollColl and IsMutable],
         GF2_AHEAD_OF_8BIT_RANK, 
         RANK_LIST_GF2VECS);


### PR DESCRIPTION
... and dealt with some side-effects:

- changed calls of `MatElm(m,i,j)` to `m[i,j]`
  where `MatElm` methods for plain lists of plain lists
  are missing

- changed those method installations from
  `InstallMethod` to `InstallOtherMethod`
  that currently cause a warning about matching
  multiple declarations;
  in a later step, some of these declarations
  will get merged

- changed calls of `BaseDomain` to calls of
  `OneOfBaseDomain` or `ZeroOfBaseDomain`
  where only the one or zero element are needed

- added comments to `dev/TODO_matobj.txt`
  and to `lib/matobj1.gd`