### PR TITLE
Fix assertion in PrimePGroup for direct products of p-groups

### DIFF
--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -263,11 +263,12 @@ end );
 InstallMethod( PrimePGroup, "for direct products",
                [IsPGroup and HasDirectProductInfo],
 function( D )
-    local p;
-    Assert (1, ForAll (DirectProductInfo( D ).groups, IsPGroup));    
-    p := First (DirectProductInfo( D ).groups, G -> PrimePGroup (G) <> fail);
-    Assert (1, ForAll (DirectProductInfo( D ).groups, G -> PrimePGroup (G) in [fail, p]));
-    return PrimePGroup(p);
+    local groups, p;
+    groups := DirectProductInfo(D).groups;
+    Assert(1, ForAll(groups, IsPGroup));
+    p := PrimePGroup(First(groups, G -> PrimePGroup(G) <> fail));
+    Assert(1, ForAll(groups, G -> PrimePGroup(G) in [fail, p]));
+    return p;
 end );
 
 #############################################################################

--- a/tst/testbugfix/2017-09-13-PrimePGroup.tst
+++ b/tst/testbugfix/2017-09-13-PrimePGroup.tst
@@ -1,0 +1,11 @@
+# Issue related to PrimePGroup for filter IsPGroup and HasDirectProductInfo
+# Examples reported on issue #1719 on github.com/gap-system/gap
+#
+gap> level := AssertionLevel();;
+gap> SetAssertionLevel(1);
+gap> G := CyclicGroup(IsPcGroup, 5);;
+gap> H := Range(IsomorphismPermGroup(G));
+Group([ (1,2,3,4,5) ])
+gap> PrimePGroup(H);
+5
+gap> SetAssertionLevel(level);;


### PR DESCRIPTION
This fixes  #1719: the problem is described on that issue. The assertion incorrectly assumed that `p` was a prime rather than a group.