### PR TITLE
Refactor some LVARS related code

### DIFF
--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -422,7 +422,7 @@ Bag NewBag (
 #else
     bag = GC_malloc(4*sizeof(Bag *));
     if (STATE(PtrLVars)) {
-      bag[2] = (void *)(CURR_FUNC);
+      bag[2] = (void *)CURR_FUNC();
       if (STATE(CurrLVars) != STATE(BottomLVars)) {
         Obj plvars = PARENT_LVARS(STATE(CurrLVars));
         bag[3] = (void *) (FUNC_LVARS(plvars));

--- a/src/code.c
+++ b/src/code.c
@@ -253,13 +253,14 @@ static Stat NewStatWithProf (
     STATE(OffsBody) = stat + ((size+sizeof(Stat)-1) / sizeof(Stat)) * sizeof(Stat);
 
     /* make certain that the current body bag is large enough              */
-    UInt bodySize = SIZE_BAG(BODY_FUNC(CURR_FUNC));
+    Obj body = BODY_FUNC(CURR_FUNC());
+    UInt bodySize = SIZE_BAG(body);
     if (bodySize == 0)
         bodySize = STATE(OffsBody);
     while (bodySize < STATE(OffsBody))
         bodySize *= 2;
-    ResizeBag(BODY_FUNC(CURR_FUNC), bodySize);
-    STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+    ResizeBag(body, bodySize);
+    STATE(PtrBody) = (Stat*)PTR_BAG(body);
 
     /* enter type and size                                                 */
     *STAT_HEADER(stat) = fillFilenameLine(file, line, size, type);
@@ -297,13 +298,14 @@ Expr            NewExpr (
     STATE(OffsBody) = expr + ((size+sizeof(Expr)-1) / sizeof(Expr)) * sizeof(Expr);
 
     /* make certain that the current body bag is large enough              */
-    UInt bodySize = SIZE_BAG(BODY_FUNC(CURR_FUNC));
+    Obj body = BODY_FUNC(CURR_FUNC());
+    UInt bodySize = SIZE_BAG(body);
     if (bodySize == 0)
         bodySize = STATE(OffsBody);
     while (bodySize < STATE(OffsBody))
         bodySize *= 2;
-    ResizeBag(BODY_FUNC(CURR_FUNC), bodySize);
-    STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+    ResizeBag(body, bodySize);
+    STATE(PtrBody) = (Stat*)PTR_BAG(body);
 
     /* enter type and size                                                 */
     *STAT_HEADER(expr) = fillFilenameLine(STATE(Input)->gapnameid,
@@ -838,7 +840,7 @@ void CodeFuncExprEnd (
     UInt                i;              /* loop variable                   */
 
     /* get the function expression                                         */
-    fexp = CURR_FUNC;
+    fexp = CURR_FUNC();
     assert(!STATE(LoopNesting));
     
     /* get the body of the function                                        */
@@ -897,7 +899,7 @@ void CodeFuncExprEnd (
     /* if this was inside another function definition, make the expression */
     /* and store it in the function expression list of the outer function  */
     if ( STATE(CurrLVars) != STATE(CodeLVars) ) {
-        fexs = FEXS_FUNC( CURR_FUNC );
+        fexs = FEXS_FUNC( CURR_FUNC() );
         len = PushPlist( fexs, fexp );
         expr = NewExpr( T_FUNC_EXPR, sizeof(Expr) );
         ADDR_EXPR(expr)[0] = (Expr)len;

--- a/src/code.h
+++ b/src/code.h
@@ -29,7 +29,7 @@
 **  If 'Stat' is different  from 'Expr', then  a lot of things will  probably
 **  break.
 */
-typedef UInt8 Stat;
+typedef UInt Stat;
 
 typedef struct {
     unsigned int visited : 1;

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -134,13 +134,13 @@ typedef UInt    RNam;
 #define SWITCH_TO_OLD_FRAME     SWITCH_TO_OLD_LVARS
 
 #define CURR_FRAME              STATE(CurrLVars)
-#define CURR_FRAME_1UP          ENVI_FUNC( PTR_BAG( CURR_FRAME     )[0] )
-#define CURR_FRAME_2UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_1UP )[0] )
-#define CURR_FRAME_3UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_2UP )[0] )
-#define CURR_FRAME_4UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_3UP )[0] )
-#define CURR_FRAME_5UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_4UP )[0] )
-#define CURR_FRAME_6UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_5UP )[0] )
-#define CURR_FRAME_7UP          ENVI_FUNC( PTR_BAG( CURR_FRAME_6UP )[0] )
+#define CURR_FRAME_1UP          ENVI_FUNC( FUNC_LVARS( CURR_FRAME     ) )
+#define CURR_FRAME_2UP          ENVI_FUNC( FUNC_LVARS( CURR_FRAME_1UP ) )
+#define CURR_FRAME_3UP          ENVI_FUNC( FUNC_LVARS( CURR_FRAME_2UP ) )
+#define CURR_FRAME_4UP          ENVI_FUNC( FUNC_LVARS( CURR_FRAME_3UP ) )
+#define CURR_FRAME_5UP          ENVI_FUNC( FUNC_LVARS( CURR_FRAME_4UP ) )
+#define CURR_FRAME_6UP          ENVI_FUNC( FUNC_LVARS( CURR_FRAME_5UP ) )
+#define CURR_FRAME_7UP          ENVI_FUNC( FUNC_LVARS( CURR_FRAME_6UP ) )
 
 /* #define OBJ_LVAR(lvar)  STATE(PtrLVars)[(lvar)+2] */
 #define OBJ_LVAR_0UP(lvar) \

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -261,7 +261,7 @@ void            SetInfoCVar (
     Bag                 info;           /* its info bag                    */
 
     /* get the information bag                                             */
-    info = INFO_FEXP( CURR_FUNC );
+    info = INFO_FEXP( CURR_FUNC() );
 
     /* set the type of a temporary                                         */
     if ( IS_TEMP_CVAR(cvar) ) {
@@ -281,7 +281,7 @@ Int             GetInfoCVar (
     Bag                 info;           /* its info bag                    */
 
     /* get the information bag                                             */
-    info = INFO_FEXP( CURR_FUNC );
+    info = INFO_FEXP( CURR_FUNC() );
 
     /* get the type of an integer                                          */
     if ( IS_INTG_CVAR(cvar) ) {
@@ -316,7 +316,7 @@ Bag             NewInfoCVars ( void )
 {
     Bag                 old;
     Bag                 new;
-    old = INFO_FEXP( CURR_FUNC );
+    old = INFO_FEXP( CURR_FUNC() );
     new = NewBag( TNUM_BAG(old), SIZE_BAG(old) );
     return new;
 }
@@ -402,7 +402,7 @@ Temp            NewTemp (
     Bag                 info;           /* information bag                 */
 
     /* get the information bag                                             */
-    info = INFO_FEXP( CURR_FUNC );
+    info = INFO_FEXP( CURR_FUNC() );
 
     /* take the next available temporary                                   */
     CTEMP_INFO( info )++;
@@ -427,7 +427,7 @@ void            FreeTemp (
     Bag                 info;           /* information bag                 */
 
     /* get the information bag                                             */
-    info = INFO_FEXP( CURR_FUNC );
+    info = INFO_FEXP( CURR_FUNC() );
 
     /* check that deallocations happens in the correct order               */
     if ( temp != CTEMP_INFO( info ) && CompPass == 2 ) {
@@ -478,7 +478,7 @@ void            CompSetUseHVar (
     if ( CompPass != 1 )  return;
 
     /* walk up                                                             */
-    info = INFO_FEXP( CURR_FUNC );
+    info = INFO_FEXP( CURR_FUNC() );
     for ( i = 1; i <= (hvar >> 16); i++ ) {
         info = NEXT_INFO( info );
     }
@@ -498,7 +498,7 @@ Int             CompGetUseHVar (
     Int                 i;              /* loop variable                   */
 
     /* walk up                                                             */
-    info = INFO_FEXP( CURR_FUNC );
+    info = INFO_FEXP( CURR_FUNC() );
     for ( i = 1; i <= (hvar >> 16); i++ ) {
         info = NEXT_INFO( info );
     }
@@ -516,7 +516,7 @@ UInt            GetLevlHVar (
 
     /* walk up                                                             */
     levl = 0;
-    info = INFO_FEXP( CURR_FUNC );
+    info = INFO_FEXP( CURR_FUNC() );
     levl++;
     for ( i = 1; i <= (hvar >> 16); i++ ) {
         info = NEXT_INFO( info );
@@ -535,7 +535,7 @@ UInt            GetIndxHVar (
     Int                 i;              /* loop variable                   */
 
     /* walk up                                                             */
-    info = INFO_FEXP( CURR_FUNC );
+    info = INFO_FEXP( CURR_FUNC() );
     for ( i = 1; i <= (hvar >> 16); i++ ) {
         info = NEXT_INFO( info );
     }
@@ -690,7 +690,7 @@ void            Emit (
     if ( CompPass != 2 )  return;
 
     /* get the information bag                                             */
-    narg = NARG_FUNC( CURR_FUNC );
+    narg = NARG_FUNC( CURR_FUNC() );
     if (narg < 0) {
         narg = -narg;
     }
@@ -1195,7 +1195,7 @@ CVar CompFuncExpr (
     Int                 nr;             /* number of the function          */
 
     /* get the number of the function                                      */
-    fexs = FEXS_FUNC( CURR_FUNC );
+    fexs = FEXS_FUNC( CURR_FUNC() );
     fexp = ELM_PLIST( fexs, ((Int*)ADDR_EXPR(expr))[0] );
     nr   = NR_INFO( INFO_FEXP( fexp ) );
 
@@ -1246,7 +1246,7 @@ CVar CompOr (
     Emit( "%c = (%c ? True : False);\n", val, left );
     Emit( "if ( %c == False ) {\n", val );
     only_left = NewInfoCVars();
-    CopyInfoCVars( only_left, INFO_FEXP(CURR_FUNC) );
+    CopyInfoCVars( only_left, INFO_FEXP(CURR_FUNC()) );
 
     /* compile the right expression                                        */
     right = CompBoolExpr( ADDR_EXPR(expr)[1] );
@@ -1254,7 +1254,7 @@ CVar CompOr (
     Emit( "}\n" );
 
     /* we know that the result is boolean                                  */
-    MergeInfoCVars( INFO_FEXP(CURR_FUNC), only_left );
+    MergeInfoCVars( INFO_FEXP(CURR_FUNC()), only_left );
     SetInfoCVar( val, W_BOOL );
 
     /* free the temporaries                                                */
@@ -1286,7 +1286,7 @@ CVar CompOrBool (
     Emit( "%c = %c;\n", val, left );
     Emit( "if ( ! %c ) {\n", val );
     only_left = NewInfoCVars();
-    CopyInfoCVars( only_left, INFO_FEXP(CURR_FUNC) );
+    CopyInfoCVars( only_left, INFO_FEXP(CURR_FUNC()) );
 
     /* compile the right expression                                        */
     right = CompBoolExpr( ADDR_EXPR(expr)[1] );
@@ -1294,7 +1294,7 @@ CVar CompOrBool (
     Emit( "}\n" );
 
     /* we know that the result is boolean (should be 'W_CBOOL')            */
-    MergeInfoCVars( INFO_FEXP(CURR_FUNC), only_left );
+    MergeInfoCVars( INFO_FEXP(CURR_FUNC()), only_left );
     SetInfoCVar( val, W_BOOL );
 
     /* free the temporaries                                                */
@@ -1325,7 +1325,7 @@ CVar CompAnd (
     /* compile the left expression                                         */
     left = CompExpr( ADDR_EXPR(expr)[0] );
     only_left = NewInfoCVars();
-    CopyInfoCVars( only_left, INFO_FEXP(CURR_FUNC) );
+    CopyInfoCVars( only_left, INFO_FEXP(CURR_FUNC()) );
 
     /* emit the code for the case that the left value is 'false'           */
     Emit( "if ( %c == False ) {\n", left );
@@ -1348,7 +1348,7 @@ CVar CompAnd (
     Emit( "}\n" );
 
     /* we know precious little about the result                            */
-    MergeInfoCVars( INFO_FEXP(CURR_FUNC), only_left );
+    MergeInfoCVars( INFO_FEXP(CURR_FUNC()), only_left );
     SetInfoCVar( val, W_BOUND );
 
     /* free the temporaries                                                */
@@ -1381,7 +1381,7 @@ CVar CompAndBool (
     Emit( "%c = %c;\n", val, left );
     Emit( "if ( %c ) {\n", val );
     only_left = NewInfoCVars();
-    CopyInfoCVars( only_left, INFO_FEXP(CURR_FUNC) );
+    CopyInfoCVars( only_left, INFO_FEXP(CURR_FUNC()) );
 
     /* compile the right expression                                        */
     right = CompBoolExpr( ADDR_EXPR(expr)[1] );
@@ -1389,7 +1389,7 @@ CVar CompAndBool (
     Emit( "}\n" );
 
     /* we know that the result is boolean (should be 'W_CBOOL')            */
-    MergeInfoCVars( INFO_FEXP(CURR_FUNC), only_left );
+    MergeInfoCVars( INFO_FEXP(CURR_FUNC()), only_left );
     SetInfoCVar( val, W_BOOL );
 
     /* free the temporaries                                                */
@@ -3970,14 +3970,14 @@ void CompIf (
 
     /* remember what we know after evaluating the first condition          */
     info_in = NewInfoCVars();
-    CopyInfoCVars( info_in, INFO_FEXP(CURR_FUNC) );
+    CopyInfoCVars( info_in, INFO_FEXP(CURR_FUNC()) );
 
     /* compile the body                                                    */
     CompStat( ADDR_STAT( stat )[1] );
 
     /* remember what we know after executing the first body                */
     info_out = NewInfoCVars();
-    CopyInfoCVars( info_out, INFO_FEXP(CURR_FUNC) );
+    CopyInfoCVars( info_out, INFO_FEXP(CURR_FUNC()) );
 
     /* emit the rest code                                                  */
     Emit( "\n}\n" );
@@ -4000,7 +4000,7 @@ void CompIf (
         Emit( "else {\n" );
 
         /* this is what we know if we enter this branch                    */
-        CopyInfoCVars( INFO_FEXP(CURR_FUNC), info_in );
+        CopyInfoCVars( INFO_FEXP(CURR_FUNC()), info_in );
 
         /* compile the expression                                          */
         cond = CompBoolExpr( ADDR_STAT( stat )[2*(i-1)] );
@@ -4010,13 +4010,13 @@ void CompIf (
         if ( IS_TEMP_CVAR( cond ) )  FreeTemp( TEMP_CVAR( cond ) );
 
         /* remember what we know after evaluating all previous conditions  */
-        CopyInfoCVars( info_in, INFO_FEXP(CURR_FUNC) );
+        CopyInfoCVars( info_in, INFO_FEXP(CURR_FUNC()) );
 
         /* compile the body                                                */
         CompStat( ADDR_STAT( stat )[2*(i-1)+1] );
 
         /* remember what we know after executing one of the previous bodies*/
-        MergeInfoCVars( info_out, INFO_FEXP(CURR_FUNC) );
+        MergeInfoCVars( info_out, INFO_FEXP(CURR_FUNC()) );
 
         /* emit the rest code                                              */
         Emit( "\n}\n" );
@@ -4035,13 +4035,13 @@ void CompIf (
         Emit( "else {\n" );
 
         /* this is what we know if we enter this branch                    */
-        CopyInfoCVars( INFO_FEXP(CURR_FUNC), info_in );
+        CopyInfoCVars( INFO_FEXP(CURR_FUNC()), info_in );
 
         /* compile the body                                                */
         CompStat( ADDR_STAT( stat )[2*(i-1)+1] );
 
         /* remember what we know after executing one of the previous bodies*/
-        MergeInfoCVars( info_out, INFO_FEXP(CURR_FUNC) );
+        MergeInfoCVars( info_out, INFO_FEXP(CURR_FUNC()) );
 
         /* emit the rest code                                              */
         Emit( "\n}\n" );
@@ -4052,10 +4052,10 @@ void CompIf (
     else {
 
         /* this is what we know if we enter this branch                    */
-        CopyInfoCVars( INFO_FEXP(CURR_FUNC), info_in );
+        CopyInfoCVars( INFO_FEXP(CURR_FUNC()), info_in );
 
         /* remember what we know after executing one of the previous bodies*/
-        MergeInfoCVars( info_out, INFO_FEXP(CURR_FUNC) );
+        MergeInfoCVars( info_out, INFO_FEXP(CURR_FUNC()) );
 
     }
 
@@ -4068,7 +4068,7 @@ void CompIf (
     Emit( "/* fi */\n" );
 
     /* put what we know into the current info                              */
-    CopyInfoCVars( INFO_FEXP(CURR_FUNC), info_out );
+    CopyInfoCVars( INFO_FEXP(CURR_FUNC()), info_out );
 
 }
 
@@ -4134,7 +4134,7 @@ void CompFor (
         CompPass = 99;
         prev = NewInfoCVars();
         do {
-            CopyInfoCVars( prev, INFO_FEXP(CURR_FUNC) );
+            CopyInfoCVars( prev, INFO_FEXP(CURR_FUNC()) );
             if ( HasInfoCVar( first, W_INT_SMALL_POS ) ) {
                 SetInfoCVar( CVAR_LVAR(var), W_INT_SMALL_POS );
             }
@@ -4144,8 +4144,8 @@ void CompFor (
             for ( i = 2; i < SIZE_STAT(stat)/sizeof(Stat); i++ ) {
                 CompStat( ADDR_STAT(stat)[i] );
             }
-            MergeInfoCVars( INFO_FEXP(CURR_FUNC), prev );
-        } while ( ! IsEqInfoCVars( INFO_FEXP(CURR_FUNC), prev ) );
+            MergeInfoCVars( INFO_FEXP(CURR_FUNC()), prev );
+        } while ( ! IsEqInfoCVars( INFO_FEXP(CURR_FUNC()), prev ) );
         CompPass = pass;
 
         /* emit the code for the loop                                      */
@@ -4236,15 +4236,15 @@ void CompFor (
         CompPass = 99;
         prev = NewInfoCVars();
         do {
-            CopyInfoCVars( prev, INFO_FEXP(CURR_FUNC) );
+            CopyInfoCVars( prev, INFO_FEXP(CURR_FUNC()) );
             if ( vart == 'l' ) {
                 SetInfoCVar( CVAR_LVAR(var), W_BOUND );
             }
             for ( i = 2; i < SIZE_STAT(stat)/sizeof(Stat); i++ ) {
                 CompStat( ADDR_STAT(stat)[i] );
             }
-            MergeInfoCVars( INFO_FEXP(CURR_FUNC), prev );
-        } while ( ! IsEqInfoCVars( INFO_FEXP(CURR_FUNC), prev ) );
+            MergeInfoCVars( INFO_FEXP(CURR_FUNC()), prev );
+        } while ( ! IsEqInfoCVars( INFO_FEXP(CURR_FUNC()), prev ) );
         CompPass = pass;
 
         /* emit the code for the loop                                      */
@@ -4332,15 +4332,15 @@ void CompWhile (
     Emit( "while ( 1 ) {\n" );
     prev = NewInfoCVars();
     do {
-        CopyInfoCVars( prev, INFO_FEXP(CURR_FUNC) );
+        CopyInfoCVars( prev, INFO_FEXP(CURR_FUNC()) );
         cond = CompBoolExpr( ADDR_STAT(stat)[0] );
         Emit( "if ( ! %c ) break;\n", cond );
         if ( IS_TEMP_CVAR( cond ) )  FreeTemp( TEMP_CVAR( cond ) );
         for ( i = 1; i < SIZE_STAT(stat)/sizeof(Stat); i++ ) {
             CompStat( ADDR_STAT(stat)[i] );
         }
-        MergeInfoCVars( INFO_FEXP(CURR_FUNC), prev );
-    } while ( ! IsEqInfoCVars( INFO_FEXP(CURR_FUNC), prev ) );
+        MergeInfoCVars( INFO_FEXP(CURR_FUNC()), prev );
+    } while ( ! IsEqInfoCVars( INFO_FEXP(CURR_FUNC()), prev ) );
     Emit( "}\n" );
     CompPass = pass;
 
@@ -4390,15 +4390,15 @@ void CompRepeat (
     Emit( "do {\n" );
     prev = NewInfoCVars();
     do {
-        CopyInfoCVars( prev, INFO_FEXP(CURR_FUNC) );
+        CopyInfoCVars( prev, INFO_FEXP(CURR_FUNC()) );
         for ( i = 1; i < SIZE_STAT(stat)/sizeof(Stat); i++ ) {
             CompStat( ADDR_STAT(stat)[i] );
         }
         cond = CompBoolExpr( ADDR_STAT(stat)[0] );
         Emit( "if ( %c ) break;\n", cond );
         if ( IS_TEMP_CVAR( cond ) )  FreeTemp( TEMP_CVAR( cond ) );
-        MergeInfoCVars( INFO_FEXP(CURR_FUNC), prev );
-    } while ( ! IsEqInfoCVars( INFO_FEXP(CURR_FUNC), prev ) );
+        MergeInfoCVars( INFO_FEXP(CURR_FUNC()), prev );
+    } while ( ! IsEqInfoCVars( INFO_FEXP(CURR_FUNC()), prev ) );
     Emit( "} while ( 1 );\n" );
     CompPass = pass;
 
@@ -5443,7 +5443,7 @@ void CompFunc (
         UInt nr = PushPlist( CompFunctions, func );
 
         info = NewBag( T_STRING, SIZE_INFO(narg+nloc,8) );
-        NEXT_INFO(info)  = INFO_FEXP( CURR_FUNC );
+        NEXT_INFO(info)  = INFO_FEXP( CURR_FUNC() );
         NR_INFO(info)    = nr;
         NLVAR_INFO(info) = narg + nloc;
         NHVAR_INFO(info) = 0;
@@ -5459,7 +5459,7 @@ void CompFunc (
     SWITCH_TO_NEW_LVARS( func, narg, nloc, oldFrame );
 
     /* get the info bag                                                    */
-    info = INFO_FEXP( CURR_FUNC );
+    info = INFO_FEXP( CURR_FUNC() );
 
     /* compile the innner functions                                        */
     fexs = FEXS_FUNC(func);

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1557,7 +1557,7 @@ Obj             EvalFuncExpr (
     Obj                 fexp;           /* function expression bag         */
 
     /* get the function expression bag                                     */
-    fexs = FEXS_FUNC( CURR_FUNC );
+    fexs = FEXS_FUNC( CURR_FUNC() );
     fexp = ELM_PLIST( fexs, (Int)(ADDR_EXPR(expr)[0]) );
 
     /* and make the function                                               */
@@ -1578,7 +1578,7 @@ void            PrintFuncExpr (
     Obj                 fexp;           /* function expression bag         */
 
     /* get the function expression bag                                     */
-    fexs = FEXS_FUNC( CURR_FUNC );
+    fexs = FEXS_FUNC( CURR_FUNC() );
     fexp = ELM_PLIST( fexs, (Int)(ADDR_EXPR(expr)[0]) );
     PrintFunction( fexp );
     /* Pr("function ... end",0L,0L); */

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1672,13 +1672,13 @@ void            ExecBegin ( Obj frame )
     Obj                 execState;      /* old execution state             */
 
     /* remember the old execution state                                    */
-    execState = NewBag( T_PLIST, 4*sizeof(Obj) );
-    ADDR_OBJ(execState)[0] = (Obj)3;
-    ADDR_OBJ(execState)[1] = STATE(ExecState);
-    ADDR_OBJ(execState)[2] = STATE(CurrLVars);
+    execState = NEW_PLIST(T_PLIST, 3);
+    SET_LEN_PLIST(execState, 3);
+    SET_ELM_PLIST(execState, 1, STATE(ExecState));
+    SET_ELM_PLIST(execState, 2, STATE(CurrLVars));
     /* the 'CHANGED_BAG(STATE(CurrLVars))' is needed because it is delayed        */
     CHANGED_BAG( STATE(CurrLVars) );
-    ADDR_OBJ(execState)[3] = INTOBJ_INT((Int)STATE(CurrStat));
+    SET_ELM_PLIST(execState, 3, INTOBJ_INT((Int)STATE(CurrStat)));
     STATE(ExecState) = execState;
 
     /* set up new state                                                    */
@@ -1698,9 +1698,9 @@ void            ExecEnd (
     }
 
     /* switch back to the old state                                    */
-    SET_BRK_CURR_STAT( (Stat)INT_INTOBJ((ADDR_OBJ(STATE(ExecState))[3]) ));
-    SWITCH_TO_OLD_LVARS( ADDR_OBJ(STATE(ExecState))[2] );
-    STATE(ExecState) = ADDR_OBJ(STATE(ExecState))[1];
+    SET_BRK_CURR_STAT((Stat)INT_INTOBJ(ELM_PLIST(STATE(ExecState), 3)));
+    SWITCH_TO_OLD_LVARS( ELM_PLIST(STATE(ExecState), 2) );
+    STATE(ExecState) = ELM_PLIST(STATE(ExecState), 1);
 }
 
 /****************************************************************************

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -819,10 +819,6 @@ static void ExecFuncHelper(void)
     REM_BRK_CURR_STAT();
     EXEC_STAT( FIRST_STAT_CURR_FUNC );
     RES_BRK_CURR_STAT();
-
-    // remove the link to the calling function, in case this values bag stays
-    // alive due to higher variable reference
-    SET_BRK_CALL_FROM( ((Obj) 0));
 }
 
 static Obj PopReturnObjStat(void)

--- a/src/gap.c
+++ b/src/gap.c
@@ -1106,9 +1106,7 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, volatile Obj args )
       SET_ELM_PLIST(res,2,STATE(ThrownObject));
       CHANGED_BAG(res);
       STATE(ThrownObject) = 0;
-      STATE(CurrLVars) = currLVars;
-      STATE(PtrLVars) = PTR_BAG(STATE(CurrLVars));
-      STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+      SET_CURR_LVARS(currLVars);
       STATE(CurrStat) = currStat;
       STATE(RecursionDepth) = recursionDepth;
 #ifdef HPCGAP

--- a/src/gap.c
+++ b/src/gap.c
@@ -410,7 +410,7 @@ Obj FuncSHELL (Obj self, Obj args)
     ErrorMayQuit("SHELL takes 10 arguments",0,0);
   
   context = ELM_PLIST(args,1);
-  if (TNUM_OBJ(context) != T_LVARS && TNUM_OBJ(context) != T_HVARS)
+  if (!IS_LVARS_OR_HVARS(context))
     ErrorMayQuit("SHELL: 1st argument should be a local variables bag",0,0);
   
   if (ELM_PLIST(args,2) == True)

--- a/src/read.c
+++ b/src/read.c
@@ -1495,7 +1495,7 @@ void ReadFuncExpr (
     /* now finally begin the function                                      */
     TRY_READ { IntrFuncExprBegin( isvarg ? -narg : narg, nloc, nams, startLine ); }
 #ifdef HPCGAP
-    if ( nrError == 0) SET_LCKS_FUNC(CURR_FUNC, locks);
+    if ( nrError == 0) SET_LCKS_FUNC(CURR_FUNC(), locks);
 #endif
 
     /* <Statments>                                                         */
@@ -2957,7 +2957,7 @@ UInt ReadEvalFile ( void )
         Obj fexp;
         CodeEnd(1);
         STATE(IntrCoding)--;
-        fexp = CURR_FUNC;
+        fexp = CURR_FUNC();
         if (fexp && ENVI_FUNC(fexp))  SWITCH_TO_OLD_LVARS(ENVI_FUNC(fexp));
     }
 
@@ -2996,7 +2996,7 @@ UInt ReadEvalFile ( void )
 */
 void            ReadEvalError ( void )
 {
-    STATE(PtrBody)  = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+    STATE(PtrBody)  = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC()));
     STATE(PtrLVars) = PTR_BAG(STATE(CurrLVars));
     syLongjmp( &(STATE(ReadJmpError)), 1 );
 }

--- a/src/read.c
+++ b/src/read.c
@@ -1510,9 +1510,7 @@ void ReadFuncExpr (
     else if ( nrError == 0 && STATE(IntrCoding) ) {
         CodeEnd(1);
         STATE(IntrCoding)--;
-        STATE(CurrLVars) = currLVars;
-        STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
-        STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+        SET_CURR_LVARS(currLVars);
     }
 
     /* pop the new local variables list                                    */
@@ -1569,9 +1567,7 @@ static void ReadFuncExprBody (
     else if ( nrError == 0  && STATE(IntrCoding) ) {
         CodeEnd(1);
         STATE(IntrCoding)--;
-        STATE(CurrLVars) = currLVars;
-        STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
-        STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+        SET_CURR_LVARS(currLVars);
     }
 
     /* pop the new local variables list                                    */
@@ -2303,9 +2299,7 @@ void ReadFor (
         if ( nrError == 0 && STATE(IntrCoding) ) {
             CodeEnd(1);
             STATE(IntrCoding)--;
-            STATE(CurrLVars) = currLVars;
-            STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
-            STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+            SET_CURR_LVARS(currLVars);
         }
     }
 }
@@ -2357,9 +2351,7 @@ void ReadWhile (
         if ( nrError == 0 && STATE(IntrCoding) ) {
             CodeEnd(1);
             STATE(IntrCoding)--;
-            STATE(CurrLVars) = currLVars;
-            STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
-            STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+            SET_CURR_LVARS(currLVars);
         }
     }
 }
@@ -2439,9 +2431,7 @@ void ReadAtomic (
         if ( nrError == 0 && STATE(IntrCoding) ) {
             CodeEnd(1);
             STATE(IntrCoding)--;
-            STATE(CurrLVars) = currLVars;
-            STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
-            STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+            SET_CURR_LVARS(currLVars);
         }
     }
 #ifdef HPCGAP
@@ -2497,9 +2487,7 @@ void ReadRepeat (
         if ( nrError == 0 && STATE(IntrCoding) ) {
             CodeEnd(1);
             STATE(IntrCoding)--;
-            STATE(CurrLVars) = currLVars;
-            STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
-            STATE(PtrBody)   = (Stat*) PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+            SET_CURR_LVARS(currLVars);
         }
     }
 }

--- a/src/vars.c
+++ b/src/vars.c
@@ -2478,7 +2478,7 @@ Obj FuncGetBottomLVars( Obj self )
 
 Obj FuncParentLVars( Obj self, Obj lvars )
 {
-  if (TNUM_OBJ(lvars) != T_LVARS && TNUM_OBJ(lvars) != T_HVARS) {
+  if (!IS_LVARS_OR_HVARS(lvars)) {
     ErrorQuit( "<lvars> must be an lvars (not a %s)",
                (Int)TNAM_OBJ(lvars), 0L );
     return 0;

--- a/src/vars.c
+++ b/src/vars.c
@@ -254,7 +254,7 @@ void            ASS_HVAR (
     /* walk up the environment chain to the correct values bag             */
     currLVars = STATE(CurrLVars);
     for ( i = 1; i <= (hvar >> 16); i++ ) {
-        SWITCH_TO_OLD_LVARS( ENVI_FUNC( CURR_FUNC ) );
+        SWITCH_TO_OLD_LVARS( ENVI_FUNC( CURR_FUNC() ) );
     }
 
     /* assign the value                                                    */
@@ -275,7 +275,7 @@ Obj             OBJ_HVAR (
     /* walk up the environment chain to the correct values bag             */
     currLVars = STATE(CurrLVars);
     for ( i = 1; i <= (hvar >> 16); i++ ) {
-        SWITCH_TO_OLD_LVARS( ENVI_FUNC( CURR_FUNC ) );
+        SWITCH_TO_OLD_LVARS( ENVI_FUNC( CURR_FUNC() ) );
     }
 
     /* get the value                                                       */
@@ -298,7 +298,7 @@ Char *          NAME_HVAR (
     /* walk up the environment chain to the correct values bag             */
     currLVars = STATE(CurrLVars);
     for ( i = 1; i <= (hvar >> 16); i++ ) {
-        SWITCH_TO_OLD_LVARS( ENVI_FUNC( CURR_FUNC ) );
+        SWITCH_TO_OLD_LVARS( ENVI_FUNC( CURR_FUNC() ) );
     }
 
     /* get the name                                                        */
@@ -2523,7 +2523,7 @@ void VarsAfterCollectBags ( void )
   if (STATE(CurrLVars))
     {
       STATE(PtrLVars) = PTR_BAG( STATE(CurrLVars) );
-      STATE(PtrBody)  = (Stat*)PTR_BAG( BODY_FUNC( CURR_FUNC ) );
+      STATE(PtrBody)  = (Stat*)PTR_BAG( BODY_FUNC( CURR_FUNC() ) );
     }
   GVarsAfterCollectBags();
 }

--- a/src/vars.h
+++ b/src/vars.h
@@ -190,13 +190,17 @@ static inline Obj SwitchToNewLvars(Obj func, UInt narg, UInt nloc
 #endif
 )
 {
+  // make sure old lvars are not garbage collected
   Obj old = STATE(CurrLVars);
   CHANGED_BAG( old );
-  STATE(CurrLVars) = NewLVarsBag( narg+nloc );
-  STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
-  CURR_FUNC = func;
-  STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
-  PARENT_LVARS_PTR(STATE(PtrLVars)) = old;
+
+  // create new lvars (may cause garbage collection)
+  Obj new_lvars = NewLVarsBag( narg+nloc );
+  FUNC_LVARS(new_lvars) = func;
+  PARENT_LVARS(new_lvars) = old;
+
+  // switch to new lvars
+  SET_CURR_LVARS(new_lvars);
 #ifdef TRACEFRAMES
   if (STEVES_TRACING == True) {
     Obj n = NAME_FUNC(func);

--- a/src/vars.h
+++ b/src/vars.h
@@ -100,7 +100,12 @@ static inline int IS_LVARS_OR_HVARS(Obj obj)
 **  This  is  in this package,  because  it is stored   along  with the local
 **  variables in the local variables bag.
 */
-#define CURR_FUNC       FUNC_LVARS_PTR(STATE(PtrLVars))
+static inline Obj CURR_FUNC(void)
+{
+    GAP_ASSERT(IS_LVARS_OR_HVARS(STATE(CurrLVars)));
+    GAP_ASSERT(STATE(PtrLVars) == PTR_BAG(STATE(CurrLVars)));
+    return FUNC_LVARS_PTR(STATE(PtrLVars));
+}
 
 
 /****************************************************************************
@@ -167,7 +172,7 @@ static void SET_CURR_LVARS(Obj lvars)
     GAP_ASSERT(IS_LVARS_OR_HVARS(lvars));
     STATE(CurrLVars) = lvars;
     STATE(PtrLVars) = PTR_BAG(lvars);
-    STATE(PtrBody) = (Stat *)PTR_BAG(BODY_FUNC(CURR_FUNC));
+    STATE(PtrBody) = (Stat *)PTR_BAG(BODY_FUNC(CURR_FUNC()));
 }
 
 
@@ -302,7 +307,7 @@ static inline void SwitchToOldLVarsAndFree( Obj old
 **
 **  'NAME_LVAR' returns the name of the local variable <lvar> as a C string.
 */
-#define NAME_LVAR(lvar)         NAMI_FUNC( CURR_FUNC, lvar )
+#define NAME_LVAR(lvar)         NAMI_FUNC( CURR_FUNC(), lvar )
 
 
 /****************************************************************************

--- a/src/vars.h
+++ b/src/vars.h
@@ -24,15 +24,6 @@
 
 /****************************************************************************
 **
-*S  T_LVARS . . . . . . . . . . . . . . . .  symbolic name for lvars bag type
-**
-**  'T_LVARS' is the type of bags used to store values of local variables.
-
-#define T_LVARS                 174
-*/
-
-/****************************************************************************
-**
 *V  CurrLVars   . . . . . . . . . . . . . . . . . . . . . local variables bag
 **
 **  'CurrLVars'  is the bag containing the  values  of the local variables of

--- a/src/vars.h
+++ b/src/vars.h
@@ -63,6 +63,18 @@
 
 /****************************************************************************
 **
+*F  IS_LVARS_OR_HVARS()
+**
+*/
+static inline int IS_LVARS_OR_HVARS(Obj obj)
+{
+    UInt tnum = TNUM_OBJ(obj);
+    return tnum == T_LVARS || tnum == T_HVARS;
+}
+
+
+/****************************************************************************
+**
 *F  FUNC_LVARS . . . . . . . . . . . function to which the given lvars belong
 **
 */

--- a/src/vars.h
+++ b/src/vars.h
@@ -120,7 +120,7 @@ extern Obj STEVES_TRACING;
 extern Obj True;
 #include <stdio.h>
 
-static inline void SetBrkCallTo( Expr expr, char * file, int line ) {
+static inline void SetBrkCallTo( Expr expr, const char * file, int line ) {
   if (STEVES_TRACING == True) {
     fprintf(stderr,"SBCT: %i %x %s %i\n",
             (int)expr, (int)STATE(CurrLVars), file, line);
@@ -191,7 +191,7 @@ extern Obj STEVES_TRACING;
 
 static inline Obj SwitchToNewLvars(Obj func, UInt narg, UInt nloc
 #ifdef TRACEFRAMES
-, char * file, int line
+, const char * file, int line
 #endif
 )
 {
@@ -233,7 +233,7 @@ static inline Obj SwitchToNewLvars(Obj func, UInt narg, UInt nloc
 
 static inline void SwitchToOldLVars( Obj old
 #ifdef TRACEFRAMES
-, char *file, int line
+, const char *file, int line
 #endif
 )
 {
@@ -249,7 +249,7 @@ static inline void SwitchToOldLVars( Obj old
 
 static inline void SwitchToOldLVarsAndFree( Obj old
 #ifdef TRACEFRAMES
-, char *file, int line
+, const char *file, int line
 #endif
 )
 {

--- a/src/vars.h
+++ b/src/vars.h
@@ -158,6 +158,18 @@ static inline void MakeHighVars( Bag bag ) {
 }
 
 
+/****************************************************************************
+**
+*F  SET_CURR_LVARS
+*/
+static void SET_CURR_LVARS(Obj lvars)
+{
+    GAP_ASSERT(IS_LVARS_OR_HVARS(lvars));
+    STATE(CurrLVars) = lvars;
+    STATE(PtrLVars) = PTR_BAG(lvars);
+    STATE(PtrBody) = (Stat *)PTR_BAG(BODY_FUNC(CURR_FUNC));
+}
+
 
 /****************************************************************************
 **
@@ -223,9 +235,7 @@ static inline void SwitchToOldLVars( Obj old
   }
 #endif
   CHANGED_BAG( STATE(CurrLVars) );
-  STATE(CurrLVars) = (old);
-  STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
-  STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+  SET_CURR_LVARS(old);
 }
 
 static inline void SwitchToOldLVarsAndFree( Obj old
@@ -247,9 +257,7 @@ static inline void SwitchToOldLVarsAndFree( Obj old
   CHANGED_BAG( STATE(CurrLVars) );
   if (STATE(CurrLVars) != old && TNUM_OBJ(STATE(CurrLVars)) == T_LVARS)
     FreeLVarsBag(STATE(CurrLVars));
-  STATE(CurrLVars) = (old);
-  STATE(PtrLVars)  = PTR_BAG( STATE(CurrLVars) );
-  STATE(PtrBody) = (Stat*)PTR_BAG(BODY_FUNC(CURR_FUNC));
+  SET_CURR_LVARS(old);
 }
 
 

--- a/tst/test-error/regenerate_error_tests.sh
+++ b/tst/test-error/regenerate_error_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
+gap="../../bin/gap.sh"
 for gfile in *.g; do
-    ./run_gap.sh "../../bin/gap.sh" "${gfile}" > "${gfile}.out"
+    ./run_gap.sh "${gap}" "${gfile}" > "${gfile}.out"
 done
-

--- a/tst/test-error/run_error_tests.sh
+++ b/tst/test-error/run_error_tests.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 retvalue=0
+gap="../../bin/gap.sh"
 for gfile in *.g; do
-    if ! diff -b "${gfile}.out" <(./run_gap.sh "../../bin/gap.sh" "${gfile}"); then
+    if ! diff -b "${gfile}.out" <(./run_gap.sh "${gap}" "${gfile}"); then
         echo "${gfile}" failed
         retvalue=1
     fi;

--- a/tst/testinstall/opers/MemoryUsage.tst
+++ b/tst/testinstall/opers/MemoryUsage.tst
@@ -96,9 +96,9 @@ true
 #
 # test functions
 #
-gap> f:=x->x;; MemoryUsage(f) - SHALLOW_SIZE(f) in [160, 132];
+gap> f:=x->x;; MemoryUsage(f) - SHALLOW_SIZE(f) in [160, 96];
 true
-gap> f:=x->x+1;; MemoryUsage(f) - SHALLOW_SIZE(f) in [184, 156];
+gap> f:=x->x+1;; MemoryUsage(f) - SHALLOW_SIZE(f) in [184, 112];
 true
 gap> MemoryUsage(f) = MemoryUsage(f);
 true


### PR DESCRIPTION
This is part of an ongoing effort to untangle code in the interpreter/executor/coder/lvars etc. handling, one of the eventual goals being to fix various issue related to break loop and error handling.

Turning `CURR_FUNC` into a function with assert's might also help track down the HPC-GAP issues @markuspf (or his student) observed.

The (from my POV) crucial improvement in this PR is that it untangles `SwitchToNewLvars` -- I feel that for the first time, I can just look at that function, and immediately understand what is going on there.