### PR TITLE
kernel: some cleanup; unify user interrupt handling between GAP and HPC-GAP

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -1389,7 +1389,7 @@ void PrintFunction (
         else {
             SWITCH_TO_NEW_LVARS( func, narg, NLOC_FUNC(func),
                                  oldLVars );
-            PrintStat( FIRST_STAT_CURR_FUNC );
+            PrintStat( OFFSET_FIRST_STAT );
             SWITCH_TO_OLD_LVARS( oldLVars );
         }
         Pr("%4<\n",0L,0L);

--- a/src/code.c
+++ b/src/code.c
@@ -289,30 +289,7 @@ Expr            NewExpr (
     UInt                type,
     UInt                size )
 {
-    Expr                expr;           /* result                          */
-
-    /* this is where the new expression goes                               */
-    expr = STATE(OffsBody) + sizeof(StatHeader);
-
-    /* increase the offset                                                 */
-    STATE(OffsBody) = expr + ((size+sizeof(Expr)-1) / sizeof(Expr)) * sizeof(Expr);
-
-    /* make certain that the current body bag is large enough              */
-    Obj body = BODY_FUNC(CURR_FUNC());
-    UInt bodySize = SIZE_BAG(body);
-    if (bodySize == 0)
-        bodySize = STATE(OffsBody);
-    while (bodySize < STATE(OffsBody))
-        bodySize *= 2;
-    ResizeBag(body, bodySize);
-    STATE(PtrBody) = (Stat*)PTR_BAG(body);
-
-    /* enter type and size                                                 */
-    *STAT_HEADER(expr) = fillFilenameLine(STATE(Input)->gapnameid,
-                                           STATE(Input)->number, size, type);
-    RegisterStatWithHook(expr);
-    /* return the new expression                                           */
-    return expr;
+    return NewStat(type, size);
 }
 
 

--- a/src/code.c
+++ b/src/code.c
@@ -802,7 +802,7 @@ void CodeFuncExprBegin (
 
     /* allocate the top level statement sequence                           */
     stat1 = NewStat( T_SEQ_STAT, 8*sizeof(Stat) );
-    assert( stat1 == FIRST_STAT_CURR_FUNC );
+    assert( stat1 == OFFSET_FIRST_STAT );
 }
 
 void CodeFuncExprEnd (
@@ -847,15 +847,15 @@ void CodeFuncExprEnd (
 
     /* stuff the first statements into the first statement sequence       */
     /* Making sure to preserve the line number and file name              */
-    *STAT_HEADER(FIRST_STAT_CURR_FUNC)
+    *STAT_HEADER(OFFSET_FIRST_STAT)
         = fillFilenameLine(
-            FILENAMEID_STAT(FIRST_STAT_CURR_FUNC),
-            LINE_STAT(FIRST_STAT_CURR_FUNC),
+            FILENAMEID_STAT(OFFSET_FIRST_STAT),
+            LINE_STAT(OFFSET_FIRST_STAT),
             nr*sizeof(Stat),
             T_SEQ_STAT+nr-1);
     for ( i = 1; i <= nr; i++ ) {
         stat1 = PopStat();
-        ADDR_STAT(FIRST_STAT_CURR_FUNC)[nr-i] = stat1;
+        ADDR_STAT(OFFSET_FIRST_STAT)[nr-i] = stat1;
     }
 
     /* make the body smaller                                               */

--- a/src/code.h
+++ b/src/code.h
@@ -116,88 +116,108 @@ enum {
 enum STAT_TNUMS {
     START_ENUM_RANGE(FIRST_STAT_TNUM),
 
-    T_PROCCALL_0ARGS,
-    T_PROCCALL_1ARGS,
-    T_PROCCALL_2ARGS,
-    T_PROCCALL_3ARGS,
-    T_PROCCALL_4ARGS,
-    T_PROCCALL_5ARGS,
-    T_PROCCALL_6ARGS,
-    T_PROCCALL_XARGS,
+        T_PROCCALL_0ARGS,
+        T_PROCCALL_1ARGS,
+        T_PROCCALL_2ARGS,
+        T_PROCCALL_3ARGS,
+        T_PROCCALL_4ARGS,
+        T_PROCCALL_5ARGS,
+        T_PROCCALL_6ARGS,
+        T_PROCCALL_XARGS,
 
-    // The statement types between FIRST_NON_INTERRUPT_STAT
-    // and LAST_NON_INTERRUPT_STAT will not be interrupted (which may happen for two reasons:
-    // the user interrupted, e.g. via ctrl-c; or memory run full).
-    // They are all statement types which either contain sub-statements
-    // (and hence are not easy to interpret in backtraces), or else are
-    // ephemeral (break, continue, return)
-    // TODO: what about T_EMPTY and T_ATOMIC ?
-    START_ENUM_RANGE(FIRST_NON_INTERRUPT_STAT),
+        // The statement types between FIRST_NON_INTERRUPT_STAT
+        // and LAST_NON_INTERRUPT_STAT will not be interrupted (which may happen for two reasons:
+        // the user interrupted, e.g. via ctrl-c; or memory run full).
+        // They are all statement types which either contain sub-statements
+        // (and hence are not easy to interpret in backtraces), or else are
+        // ephemeral (break, continue, return)
+        // TODO: what about T_EMPTY and T_ATOMIC ?
+        START_ENUM_RANGE(FIRST_NON_INTERRUPT_STAT),
 
-    T_SEQ_STAT,
-    T_SEQ_STAT2,
-    T_SEQ_STAT3,
-    T_SEQ_STAT4,
-    T_SEQ_STAT5,
-    T_SEQ_STAT6,
-    T_SEQ_STAT7,
-    T_IF,
-    T_IF_ELSE,
-    T_IF_ELIF,
-    T_IF_ELIF_ELSE,
-    T_FOR,
-    T_FOR2,
-    T_FOR3,
-    T_FOR_RANGE,
-    T_FOR_RANGE2,
-    T_FOR_RANGE3,
-    T_WHILE,
-    T_WHILE2,
-    T_WHILE3,
-    T_REPEAT,
-    T_REPEAT2,
-    T_REPEAT3,
-    T_BREAK,
-    T_CONTINUE,
-    T_RETURN_OBJ,
-    T_RETURN_VOID,
+            START_ENUM_RANGE(FIRST_COMPOUND_STAT),
 
-    END_ENUM_RANGE(LAST_NON_INTERRUPT_STAT),
+            T_SEQ_STAT,
+            T_SEQ_STAT2,
+            T_SEQ_STAT3,
+            T_SEQ_STAT4,
+            T_SEQ_STAT5,
+            T_SEQ_STAT6,
+            T_SEQ_STAT7,
 
-    T_ASS_LVAR,
-    T_UNB_LVAR,
-    T_ASS_HVAR,
-    T_UNB_HVAR,
-    T_ASS_GVAR,
-    T_UNB_GVAR,
-    T_ASS_LIST,
-    T_ASSS_LIST,
-    T_ASS_LIST_LEV,
-    T_ASSS_LIST_LEV,
-    T_UNB_LIST,
-    T_ASS_REC_NAME,
-    T_ASS_REC_EXPR,
-    T_UNB_REC_NAME,
-    T_UNB_REC_EXPR,
-    T_ASS_POSOBJ,
-    T_ASSS_POSOBJ,
-    T_ASS_POSOBJ_LEV,
-    T_ASSS_POSOBJ_LEV,
-    T_UNB_POSOBJ,
-    T_ASS_COMOBJ_NAME,
-    T_ASS_COMOBJ_EXPR,
-    T_UNB_COMOBJ_NAME,
-    T_UNB_COMOBJ_EXPR,
+            T_IF,
+            T_IF_ELSE,
+            T_IF_ELIF,
+            T_IF_ELIF_ELSE,
 
-    T_INFO,
-    T_ASSERT_2ARGS,
-    T_ASSERT_3ARGS,
+            T_FOR,
+            T_FOR2,
+            T_FOR3,
 
-    T_EMPTY,
+            T_FOR_RANGE,
+            T_FOR_RANGE2,
+            T_FOR_RANGE3,
 
-    T_PROCCALL_OPTS,
+            T_WHILE,
+            T_WHILE2,
+            T_WHILE3,
 
-    T_ATOMIC,
+            T_REPEAT,
+            T_REPEAT2,
+            T_REPEAT3,
+
+            END_ENUM_RANGE(LAST_COMPOUND_STAT),
+
+            START_ENUM_RANGE(FIRST_CONTROL_FLOW_STAT),
+
+            T_BREAK,
+            T_CONTINUE,
+            T_RETURN_OBJ,
+            T_RETURN_VOID,
+
+            END_ENUM_RANGE(LAST_CONTROL_FLOW_STAT),
+
+        END_ENUM_RANGE(LAST_NON_INTERRUPT_STAT),
+
+        T_ASS_LVAR,
+        T_UNB_LVAR,
+
+        T_ASS_HVAR,
+        T_UNB_HVAR,
+
+        T_ASS_GVAR,
+        T_UNB_GVAR,
+
+        T_ASS_LIST,
+        T_ASSS_LIST,
+        T_ASS_LIST_LEV,
+        T_ASSS_LIST_LEV,
+        T_UNB_LIST,
+
+        T_ASS_REC_NAME,
+        T_ASS_REC_EXPR,
+        T_UNB_REC_NAME,
+        T_UNB_REC_EXPR,
+
+        T_ASS_POSOBJ,
+        T_ASSS_POSOBJ,
+        T_ASS_POSOBJ_LEV,
+        T_ASSS_POSOBJ_LEV,
+        T_UNB_POSOBJ,
+
+        T_ASS_COMOBJ_NAME,
+        T_ASS_COMOBJ_EXPR,
+        T_UNB_COMOBJ_NAME,
+        T_UNB_COMOBJ_EXPR,
+
+        T_INFO,
+        T_ASSERT_2ARGS,
+        T_ASSERT_3ARGS,
+
+        T_EMPTY,
+
+        T_PROCCALL_OPTS,
+
+        T_ATOMIC,
 
     END_ENUM_RANGE(LAST_STAT_TNUM),
 };

--- a/src/code.h
+++ b/src/code.h
@@ -93,12 +93,16 @@ void SET_ENDLINE_BODY(Obj body, UInt val);
 
 /****************************************************************************
 **
-*V  FIRST_STAT_CURR_FUNC  . . . . . . . .  index of first statement in a body
+*V  OFFSET_FIRST_STAT . . . . . . . . . . offset of first statement in a body
 **
-**  'FIRST_STAT_CURR_FUNC' is the index of the first statement in a body.
+**  'OFFSET_FIRST_STAT' is the offset of the first statement in a body.
 */
 
-#define FIRST_STAT_CURR_FUNC    (sizeof(StatHeader)+sizeof(BodyHeader))
+enum {
+    OFFSET_FIRST_STAT = sizeof(StatHeader)+sizeof(BodyHeader)
+};
+
+
 
 /****************************************************************************
 **

--- a/src/code.h
+++ b/src/code.h
@@ -136,6 +136,7 @@ enum STAT_TNUMS {
 
             START_ENUM_RANGE(FIRST_COMPOUND_STAT),
 
+            T_EMPTY,        // may also be considered to be "T_SEQ_STAT0"
             T_SEQ_STAT,
             T_SEQ_STAT2,
             T_SEQ_STAT3,
@@ -164,6 +165,8 @@ enum STAT_TNUMS {
             T_REPEAT,
             T_REPEAT2,
             T_REPEAT3,
+
+            T_ATOMIC,
 
             END_ENUM_RANGE(LAST_COMPOUND_STAT),
 
@@ -213,11 +216,7 @@ enum STAT_TNUMS {
         T_ASSERT_2ARGS,
         T_ASSERT_3ARGS,
 
-        T_EMPTY,
-
         T_PROCCALL_OPTS,
-
-        T_ATOMIC,
 
     END_ENUM_RANGE(LAST_STAT_TNUM),
 };

--- a/src/code.h
+++ b/src/code.h
@@ -125,6 +125,15 @@ enum STAT_TNUMS {
     T_PROCCALL_6ARGS,
     T_PROCCALL_XARGS,
 
+    // The statement types between FIRST_NON_INTERRUPT_STAT
+    // and LAST_NON_INTERRUPT_STAT will not be interrupted (which may happen for two reasons:
+    // the user interrupted, e.g. via ctrl-c; or memory run full).
+    // They are all statement types which either contain sub-statements
+    // (and hence are not easy to interpret in backtraces), or else are
+    // ephemeral (break, continue, return)
+    // TODO: what about T_EMPTY and T_ATOMIC ?
+    START_ENUM_RANGE(FIRST_NON_INTERRUPT_STAT),
+
     T_SEQ_STAT,
     T_SEQ_STAT2,
     T_SEQ_STAT3,
@@ -152,6 +161,8 @@ enum STAT_TNUMS {
     T_CONTINUE,
     T_RETURN_OBJ,
     T_RETURN_VOID,
+
+    END_ENUM_RANGE(LAST_NON_INTERRUPT_STAT),
 
     T_ASS_LVAR,
     T_UNB_LVAR,

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5565,7 +5565,7 @@ void CompFunc (
     }
 
     /* compile the body                                                    */
-    CompStat( FIRST_STAT_CURR_FUNC );
+    CompStat( OFFSET_FIRST_STAT );
 
     /* emit the code to switch back to the old frame and return            */
     Emit( "\n/* return; */\n" );

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -817,7 +817,7 @@ static void ExecFuncHelper(void)
 
     // execute the statement sequence
     REM_BRK_CURR_STAT();
-    EXEC_STAT( FIRST_STAT_CURR_FUNC );
+    EXEC_STAT( OFFSET_FIRST_STAT );
     RES_BRK_CURR_STAT();
 }
 

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -93,9 +93,7 @@ typedef struct GAPState {
     /* From stats.c */
     Stat CurrStat;
     Obj  ReturnObjStat;
-#if defined(HPCGAP)
     UInt (**CurrExecStatFuncs)(Stat);
-#endif
 
     /* From code.c */
     Stat * PtrBody;

--- a/src/stats.h
+++ b/src/stats.h
@@ -51,16 +51,9 @@ extern  UInt            (* ExecStatFuncs[256]) ( Stat stat );
 static inline UInt EXEC_STAT(Stat stat)
 {
     UInt tnum = TNUM_STAT(stat);
-#ifdef HPCGAP
     return (*STATE(CurrExecStatFuncs)[ tnum ]) ( stat );
-#else
-    return ( (*ExecStatFuncs[ tnum ]) ( stat ) );
-#endif
 }
 
-
-
-#ifdef HPCGAP
 
 /****************************************************************************
 **
@@ -73,8 +66,6 @@ static inline UInt EXEC_STAT(Stat stat)
 */
 
 extern  UInt 		(* IntrExecStatFuncs[256]) ( Stat stat );
-
-#endif
 
 
 /****************************************************************************

--- a/src/vars.h
+++ b/src/vars.h
@@ -84,6 +84,15 @@ static inline int IS_LVARS_OR_HVARS(Obj obj)
 
 /****************************************************************************
 **
+*F  STAT_LVARS . . . . . . . current statement in function of the given lvars
+**
+*/
+#define STAT_LVARS_PTR(lvars_ptr)   (lvars_ptr[1])
+#define STAT_LVARS(lvars_obj)       STAT_LVARS_PTR(ADDR_OBJ(lvars_obj))
+
+
+/****************************************************************************
+**
 *F  PARENT_LVARS . . . . . . . . . . . . . .  parent lvars of the given lvars
 **
 */
@@ -115,25 +124,23 @@ static inline Obj CURR_FUNC(void)
 */
 
 #ifdef TRACEFRAMES
-
 extern Obj STEVES_TRACING;
 extern Obj True;
 #include <stdio.h>
+#endif
 
 static inline void SetBrkCallTo( Expr expr, const char * file, int line ) {
+#ifdef TRACEFRAMES
   if (STEVES_TRACING == True) {
     fprintf(stderr,"SBCT: %i %x %s %i\n",
             (int)expr, (int)STATE(CurrLVars), file, line);
   }
-  (STATE(PtrLVars)[1] = (Obj)(Int)(expr));
+#endif
+  STAT_LVARS_PTR(STATE(PtrLVars)) = (Obj)expr;
 }
 
-#else
-#define SetBrkCallTo(expr, file, line)  (STATE(PtrLVars)[1] = (Obj)(Int)(expr))
-#endif
-
 #ifndef NO_BRK_CALLS
-#define BRK_CALL_TO()                   ((Expr)(Int)(STATE(PtrLVars)[1]))
+#define BRK_CALL_TO()                   ((Expr)STAT_LVARS_PTR(STATE(PtrLVars)))
 #define SET_BRK_CALL_TO(expr)           SetBrkCallTo(expr, __FILE__, __LINE__)
 #else
 #define BRK_CALL_TO()                   /* do nothing */

--- a/src/vars.h
+++ b/src/vars.h
@@ -192,10 +192,6 @@ static void SET_CURR_LVARS(Obj lvars)
 **  variables.  The old local variables bag is saved in <old>.
 */
 
-extern Obj STEVES_TRACING;
-
-#include <stdio.h>
-
 static inline Obj SwitchToNewLvars(Obj func, UInt narg, UInt nloc
 #ifdef TRACEFRAMES
 , const char * file, int line
@@ -238,11 +234,7 @@ static inline Obj SwitchToNewLvars(Obj func, UInt narg, UInt nloc
 **  'SWITCH_TO_OLD_LVARS' switches back to the old local variables bag <old>.
 */
 
-static inline void SwitchToOldLVars( Obj old
-#ifdef TRACEFRAMES
-, const char *file, int line
-#endif
-)
+static inline void SwitchToOldLVars(Obj old, const char *file, int line)
 {
 #ifdef TRACEFRAMES
   if (STEVES_TRACING == True) {
@@ -254,11 +246,7 @@ static inline void SwitchToOldLVars( Obj old
   SET_CURR_LVARS(old);
 }
 
-static inline void SwitchToOldLVarsAndFree( Obj old
-#ifdef TRACEFRAMES
-, const char *file, int line
-#endif
-)
+static inline void SwitchToOldLVarsAndFree(Obj old, const char *file, int line)
 {
 #ifdef TRACEFRAMES
   if (STEVES_TRACING == True) {
@@ -277,17 +265,8 @@ static inline void SwitchToOldLVarsAndFree( Obj old
 }
 
 
-#ifdef TRACEFRAMES
 #define SWITCH_TO_OLD_LVARS(old) SwitchToOldLVars((old), __FILE__,__LINE__)
-#else
-#define SWITCH_TO_OLD_LVARS(old) SwitchToOldLVars((old))
-#endif
-
-#ifdef TRACEFRAMES
 #define SWITCH_TO_OLD_LVARS_AND_FREE(old) SwitchToOldLVarsAndFree((old), __FILE__,__LINE__)
-#else
-#define SWITCH_TO_OLD_LVARS_AND_FREE(old) SwitchToOldLVarsAndFree((old))
-#endif
 
 
 /****************************************************************************


### PR DESCRIPTION
Some assorted cleanup.

Major change is the addition of `FIRST_NON_INTERRUPT_STAT` and `LAST_NON_INTERRUPT_STAT` and the comment preceding them, which tries to rationalize the (to me) previously completely unmotivated and confusing way `InterruptExecStat` treated some stat types differently than others.

I wonder if @stevelinton can confirm or else correct this guess?

Also note that with that PR, I actually changed how user interrupts affect `T_RETURN_VOID`. It felt more logical that way, and I wonder if the original code treated it differently for actual reasons, or just by accident? Also, I think in reality it will virtually never make a user visible difference, but perhaps I am missing something?

We might also want to consider moving `T_EMPTY` and/or `T_ATOMIC` into that `*_NON_INTERRUPT_STAT` range... Not sure.