### PR TITLE
Updates in make targets for tests

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -687,11 +687,9 @@ check-manuals: all
 testinstall: all
 	$(MKDIR_P) dev/log
 	( echo 'SetUserPreference("UseColorsInTerminal",false); \
-	        ReadGapRoot( "tst/testutil.g" ); \
             ReadGapRoot( "tst/testinstall.g" );' | $(TESTGAP) | \
             tee `date -u +dev/log/testinstall1_%Y-%m-%d-%H-%M` )
-	( echo 'SetUserPreference("UseColorsInTerminal",false); \
-	        ReadGapRoot( "tst/testutil.g" ); LoadAllPackages(); \
+	( echo 'SetUserPreference("UseColorsInTerminal",false); LoadAllPackages(); \
             ReadGapRoot( "tst/testinstall.g" );' | $(TESTGAP) | \
             tee `date -u +dev/log/testinstall2_%Y-%m-%d-%H-%M` )
 
@@ -903,11 +901,9 @@ testpackagesvars: all
 teststandard: all
 	$(MKDIR_P) dev/log
 	( echo 'SetUserPreference("UseColorsInTerminal",false); \
-	        ReadGapRoot( "tst/testutil.g" ); \
           ReadGapRoot( "tst/teststandard.g" );' | $(TESTGAP) | \
             tee `date -u +dev/log/teststandard1_%Y-%m-%d-%H-%M` )
-	( echo 'SetUserPreference("UseColorsInTerminal",false); \
-	        ReadGapRoot( "tst/testutil.g" ); LoadAllPackages(); \
+	( echo 'SetUserPreference("UseColorsInTerminal",false); LoadAllPackages(); \
           ReadGapRoot( "tst/teststandard.g" );' | $(TESTGAP) | \
             tee `date -u +dev/log/teststandard2_%Y-%m-%d-%H-%M` )
 

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -911,10 +911,22 @@ teststandard: all
           ReadGapRoot( "tst/teststandard.g" );' | $(TESTGAP) | \
             tee `date -u +dev/log/teststandard2_%Y-%m-%d-%H-%M` )
 
+# run testbugfix.g twice:
+# - without packages (except needed to run GAP)
+# - with all packages loaded
+testbugfix: all
+	$(MKDIR_P) dev/log
+	( echo 'SetUserPreference("UseColorsInTerminal",false); \
+          ReadGapRoot( "tst/testbugfix.g" );' | $(TESTGAP) | \
+            tee `date -u +dev/log/testbugfix1_%Y-%m-%d-%H-%M` )
+	( echo 'SetUserPreference("UseColorsInTerminal",false); LoadAllPackages(); \
+          ReadGapRoot( "tst/testbugfix.g" );' | $(TESTGAP) | \
+            tee `date -u +dev/log/testbugfix2_%Y-%m-%d-%H-%M` )
+
 coverage:
 	gcov -o . $(SOURCES)
 
-.PHONY: testinstall testmanuals testobsoletes teststandard
+.PHONY: testinstall testmanuals testobsoletes teststandard testbugfix
 .PHONY: testpackage testpackages testpackagesload testpackagesvars
 .PHONY: coverage
 


### PR DESCRIPTION
This PR introduces `testbugfix` make target. Formerly `bugfix.tst` was run as a part of `testinstall`. This is not the case any more after it has been reorganised into multiple files in the `tst/testbugfix` directory, and as a result, it occurred to me that currently we are running tests of bugfixes with Travis, but not with Jenkins. As soon as the PR will be merged, I will create a new test.

Additionally, I've removed reading `tst/testutil.g` from two tests not requiring it.

