### PR TITLE
Just use the generic list access code in ASS2_LIST

### DIFF
--- a/src/lists.c
+++ b/src/lists.c
@@ -994,13 +994,6 @@ void ASS2_LIST(Obj list, Obj pos1, Obj pos2, Obj obj)
             Obj row = ELM_PLIST( list, p1 );
             Int p2 = INT_INTOBJ(pos2);
 
-            if ( IS_PLIST( row ) ) {
-                AssPlist( row, p2, obj );
-                return;
-            }
-
-            // fallback to generic list access code (also triggers error if
-            // row isn't a list)
             ASS_LIST( row, p2, obj );
             return;
         }

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -213,6 +213,18 @@ Error, COPY_LIST_ENTRIES: list indices must be positive integers
 gap> CopyListEntries(s,1,1,l,0,1,2);
 Error, COPY_LIST_ENTRIES: list indices must be positive integers
 
+# Indexing into plain lists
+gap> l := [[]];;
+gap> l[1,2] := 4;
+4
+gap> l;
+[ [ , 4 ] ]
+gap> l[1,1] := 3;;
+gap> l;
+[ [ 3, 4 ] ]
+gap> l[2,1];
+Error, List Element: <list>[2] must have an assigned value
+
 # that's all, folks
 gap> STOP_TEST( "listgen.tst", 1);
 


### PR DESCRIPTION
The original code lead to the following error

```
gap> l := [[]];
[ [  ] ]
gap> l[1,2] := 4;
4
gap> l;
[ [  ] ]
```

This is caused by the list l[1] being empty, and the optimised code
in ASS2_LIST calling AssPlist on this list, not retyping it correctly.

Just deleting the optimisation the code behave safely (albeit maybe
slightly slower).

An alternative fix would be to add a check whether the list is
empty and call the appropriate assignment functions, or edit
AssPlist to correctly assign to the empty list.