### PR TITLE
Remove T_INV expression

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -1473,7 +1473,6 @@ void CodeReturnVoidWhichIsNotProfiled ( void )
 *F  CodeAInv()  . . . . . . . . . . . . . . . . . . . code unary --expression
 *F  CodeDiff()  . . . . . . . . . . . . . . . . . . . . . . code --expression
 *F  CodeProd()  . . . . . . . . . . . . . . . . . . . . . . code *-expression
-*F  CodeInv() . . . . . . . . . . . . . . . . . . . . . . code ^-1-expression
 *F  CodeQuo() . . . . . . . . . . . . . . . . . . . . . . . code /-expression
 *F  CodeMod() . . . . . . . . . . . . . . . . . . . . . . code mod-expression
 *F  CodePow() . . . . . . . . . . . . . . . . . . . . . . . code ^-expression
@@ -1570,11 +1569,6 @@ void CodeDiff ( void )
 void CodeProd ( void )
 {
     PushBinaryOp( T_PROD );
-}
-
-void CodeInv ( void )
-{
-    PushUnaryOp( T_INV );
 }
 
 void CodeQuo ( void )

--- a/src/code.h
+++ b/src/code.h
@@ -390,7 +390,6 @@ enum EXPR_TNUM {
     T_AINV,
     T_DIFF,
     T_PROD,
-    T_INV,
     T_QUO,
     T_MOD,
     T_POW,
@@ -917,7 +916,6 @@ extern  void            CodeReturnVoidWhichIsNotProfiled ( void );
 *F  CodeAInv()  . . . . . . . . . . . . . . . . . . . code unary --expression
 *F  CodeDiff()  . . . . . . . . . . . . . . . . . . . . . . code --expression
 *F  CodeProd()  . . . . . . . . . . . . . . . . . . . . . . code *-expression
-*F  CodeInv() . . . . . . . . . . . . . . . . . . . . . . code ^-1-expression
 *F  CodeQuo() . . . . . . . . . . . . . . . . . . . . . . . code /-expression
 *F  CodeMod() . . . . . . . . . . . . . . . . . . . . . . code mod-expression
 *F  CodePow() . . . . . . . . . . . . . . . . . . . . . . . code ^-expression
@@ -958,8 +956,6 @@ extern  void            CodeAInv ( void );
 extern  void            CodeDiff ( void );
 
 extern  void            CodeProd ( void );
-
-extern  void            CodeInv ( void );
 
 extern  void            CodeQuo ( void );
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2166,39 +2166,6 @@ CVar CompProd (
 
 /****************************************************************************
 **
-*F  CompInv( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_INV
-**
-** C_INV is not defined, so I guess this never gets called SL
-**
-*/
-CVar CompInv (
-    Expr                expr )
-{
-    CVar                val;            /* result                          */
-    CVar                left;           /* left operand                    */
-
-    /* allocate a new temporary for the result                             */
-    val = CVAR_TEMP( NewTemp( "val" ) );
-
-    /* compile the operands                                                */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-
-    /* emit the code                                                       */
-    Emit( "C_INV( %c, %c )\n", val, left );
-
-    /* set the information for the result                                  */
-    SetInfoCVar( val, W_BOUND );
-
-    /* free the temporaries                                                */
-    if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
-
-    /* return the result                                                   */
-    return val;
-}
-
-
-/****************************************************************************
-**
 *F  CompQuo( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_QUO
 */
 CVar CompQuo (
@@ -5935,7 +5902,6 @@ static Int InitKernel (
     CompExprFuncs[ T_AINV            ] = CompAInv;
     CompExprFuncs[ T_DIFF            ] = CompDiff;
     CompExprFuncs[ T_PROD            ] = CompProd;
-    CompExprFuncs[ T_INV             ] = CompInv;
     CompExprFuncs[ T_QUO             ] = CompQuo;
     CompExprFuncs[ T_MOD             ] = CompMod;
     CompExprFuncs[ T_POW             ] = CompPow;

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -725,36 +725,6 @@ Obj             EvalProd (
 
 /****************************************************************************
 **
-*F  EvalInv(<expr>) . . . . . . . . . . . . evaluate a multiplicative inverse
-**
-**  'EvalInv' evaluates the multiplicative inverse-expression and returns its
-**  value,  i.e., the multiplicative inverse  of  the operand.  'EvalInv' is
-**  called from 'EVAL_EXPR' to evaluate expressions of type 'T_INV'.
-**
-**  'EvalInv' evaluates the operand and then calls the 'INV' macro.
-*/
-Obj             EvalInv (
-    Expr                expr )
-{
-    Obj                 val;            /* value, result                   */
-    Obj                 opL;            /* evaluated left  operand         */
-    Expr                tmp;            /* temporary expression            */
-
-    /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
-    opL = EVAL_EXPR( tmp );
-
-    /* compute the multiplicative inverse                                  */
-    SET_BRK_CALL_TO(expr);     /* Note possible call for FuncWhere */
-    val = INV_MUT( opL );
-
-    /* return the value                                                    */
-    return val;
-}
-
-
-/****************************************************************************
-**
 *F  EvalQuo(<expr>) . . . . . . . . . . . . . . . . . . . evaluate a quotient
 **
 **  'EvalQuo' evaluates the quotient-expression <expr> and returns its value,
@@ -1674,19 +1644,6 @@ void            PrintAInv (
     PrintPrecedence = oldPrec;
 }
 
-void            PrintInv (
-    Expr                expr )
-{
-    UInt                oldPrec;
-
-    oldPrec = PrintPrecedence;
-    PrintPrecedence = 14;
-    Pr("%> ",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
-    Pr("%<^-1",0L,0L);
-    PrintPrecedence = oldPrec;
-}
-
 void            PrintBinop (
     Expr                expr )
 {
@@ -2061,7 +2018,6 @@ static Int InitKernel (
     InstallEvalExprFunc( T_AINV           , EvalAInv);
     InstallEvalExprFunc( T_DIFF           , EvalDiff);
     InstallEvalExprFunc( T_PROD           , EvalProd);
-    InstallEvalExprFunc( T_INV            , EvalInv);
     InstallEvalExprFunc( T_QUO            , EvalQuo);
     InstallEvalExprFunc( T_MOD            , EvalMod);
     InstallEvalExprFunc( T_POW            , EvalPow);
@@ -2108,7 +2064,6 @@ static Int InitKernel (
     InstallPrintExprFunc( T_AINV           , PrintAInv);
     InstallPrintExprFunc( T_DIFF           , PrintBinop);
     InstallPrintExprFunc( T_PROD           , PrintBinop);
-    InstallPrintExprFunc( T_INV            , PrintInv);
     InstallPrintExprFunc( T_QUO            , PrintBinop);
     InstallPrintExprFunc( T_MOD            , PrintBinop);
     InstallPrintExprFunc( T_POW            , PrintBinop);

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1833,27 +1833,6 @@ void            IntrProd ( void )
     PushObj( val );
 }
 
-void            IntrInv ( void )
-{
-    Obj                 val;            /* value, result                   */
-    Obj                 opL;            /* left operand                    */
-
-    /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
-    if ( STATE(IntrCoding)    > 0 ) { CodeInv(); return; }
-
-
-    /* get the operand                                                     */
-    opL = PopObj();
-
-    /* compute the multiplicative inverse                                  */
-    val = INV_MUT( opL );
-
-    /* push the result                                                     */
-    PushObj( val );
-}
-
 void            IntrQuo ( void )
 {
     Obj                 val;            /* value, result                   */


### PR DESCRIPTION
There was no way of creating one from the parser.

Alternatives include actually parsing `x^-1` as `T_INV` expression.
If anyone sees a point in that I can look at adjusting the parser accordingly.