### PR TITLE
Add missing space in error message

### DIFF
--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1500,7 +1500,7 @@ BIND_GLOBAL( "DeclareProperty", function ( arg )
 
         # `gvar' is not a property (tester).
         Error( "operation `", name, "' was not created as a property,",
-               " use`DeclareOperation'" );
+               " use `DeclareOperation'" );
 
       fi;
 

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -662,7 +662,7 @@ static inline UInt OFFSET_BITFIELD_FUNC(Obj func)
 
 static inline void SET_OFFFSET_BITFIELD_FUNC(Obj func, UInt offset)
 {
-  return SET_FEXS_FUNC(func, INTOBJ_INT(offset));		    
+  SET_FEXS_FUNC(func, INTOBJ_INT(offset));
 }
 
 static Obj DoFieldGetter(Obj self, Obj data)

--- a/src/lists.h
+++ b/src/lists.h
@@ -461,7 +461,7 @@ extern void UnbListDefault( Obj list, Int  pos );
 static inline void UNB_LIST(Obj list, Int pos)
 {
     GAP_ASSERT(pos > 0);
-    return (*UnbListFuncs[TNUM_OBJ(list)])(list, pos);
+    (*UnbListFuncs[TNUM_OBJ(list)])(list, pos);
 }
 
 extern void UNB2_LIST(Obj list, Obj pos1, Obj pos2);


### PR DESCRIPTION
This pull request adds a missing space in an error message, and removes a `return` from a `void` function in `lists.h`