### PR TITLE
Fix PrimePGroup for direct products of trivial groups

### DIFF
--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -263,10 +263,15 @@ end );
 InstallMethod( PrimePGroup, "for direct products",
                [IsPGroup and HasDirectProductInfo],
 function( D )
-    local groups, p;
+    local groups, p, H;
     groups := DirectProductInfo(D).groups;
     Assert(1, ForAll(groups, IsPGroup));
-    p := PrimePGroup(First(groups, G -> PrimePGroup(G) <> fail));
+    H := First(groups, G -> PrimePGroup(G) <> fail);
+    if H = fail then
+      SetIsTrivial(D, true);
+      return fail;
+    fi;
+    p := PrimePGroup(H);
     Assert(1, ForAll(groups, G -> PrimePGroup(G) in [fail, p]));
     return p;
 end );

--- a/tst/testbugfix/2017-09-29-PrimePGroup.tst
+++ b/tst/testbugfix/2017-09-29-PrimePGroup.tst
@@ -1,0 +1,14 @@
+# Issue related to PrimePGroup for a direct product of trivial groups
+#
+gap> G := DirectProduct(TrivialGroup(IsPcGroup), TrivialGroup(IsPcGroup));
+<pc group of size 1 with 0 generators>
+gap> PrimePGroup(G);
+fail
+gap> A := Group(Transformation([1, 2, 3]));;
+gap> B := DirectProduct(A, A);;
+gap> IsPGroup(B);
+true
+gap> HasDirectProductInfo(B);
+true
+gap> PrimePGroup(B);
+fail


### PR DESCRIPTION
In PR #1722, I resolved issue #1719: there was a bug in an `Assert` in `PrimePGroup` for a direct product of groups.

I have discovered a further problem in `PrimePGroup` for a direct product of groups, which was present both before and after my earlier PR. In particular, `PrimePGroup` for trivial group should return `fail`, however for a direct product of trivial groups, `PrimePGroup` triggers an error. I don't think I fully appreciated before that a trivial group is a p-group in GAP.

This PR resolves the problem.

This is an example of the problem:
```
gap> G := DirectProduct(TrivialGroup(IsPcGroup), TrivialGroup(IsPcGroup));
<pc group of size 1 with 0 generators>
gap> PrimePGroup(G);
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
The 1st argument is 'fail' which might point to an earlier problem
Error, no 1st choice method found for `IsPGroup' on 1 arguments at /Users/Wilf/GAP/lib/methsel2.g:241 called from
<compiled or corrupted statement>  called from
PrimePGroup( First( groups, function ( G )
        return PrimePGroup( G ) <> fail;
    end ) ) at /Users/Wilf/GAP/lib/gprd.gi:269 called from
<function "unknown">( <arguments> )
```
This is now fixed:
```
gap> G := DirectProduct(TrivialGroup(IsPcGroup), TrivialGroup(IsPcGroup));
<pc group of size 1 with 0 generators>
gap> PrimePGroup(G);
fail
```