### PR TITLE
Slightly extend `MinimalGeneratingSet` for groups

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -124,7 +124,7 @@ function(G)
     Error(
   "`MinimalGeneratingSet' currently assumes that the group must be solvable.\n",
   "In general, try `SmallGeneratingSet' instead, which returns a generating\n",
-  "set that is small but not of guarateed smallest cardinality");
+  "set that is small but not of guaranteed smallest cardinality");
   fi;
 end);
 

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -103,6 +103,10 @@ InstallMethod(MinimalGeneratingSet,"solvable group via pc",true,
 function(G)
 local i;
   if not IsSolvableGroup(G) then
+    if IsGroup(G) and HasGeneratorsOfGroup(G)
+        and Length(GeneratorsOfGroup(G)) = 2 then
+      return GeneratorsOfGroup(G);
+    fi;
     TryNextMethod();
   fi;
   i:=IsomorphismPcGroup(G);
@@ -122,7 +126,8 @@ function(G)
     TryNextMethod();
   else
     Error(
-  "`MinimalGeneratingSet' currently assumes that the group must be solvable.\n",
+  "`MinimalGeneratingSet' currently assumes that the group is solvable, or\n",
+  "already possesses a generating set of size 2.\n",
   "In general, try `SmallGeneratingSet' instead, which returns a generating\n",
   "set that is small but not of guaranteed smallest cardinality");
   fi;

--- a/tst/testinstall/grpperm.tst
+++ b/tst/testinstall/grpperm.tst
@@ -72,4 +72,9 @@ gap> Length(MaximalSubgroupClassReps(g));
 gap> g:=PSL(8,2);;
 gap> Length(MaximalSubgroupClassReps(g));
 10
+gap> G := SymmetricGroup(6);;
+gap> IsSolvable(G);
+false
+gap> Length(MinimalGeneratingSet(G));
+2
 gap> STOP_TEST( "grpperm.tst", 1);


### PR DESCRIPTION
Currently, `MinimalGeneratingSet` only supports soluble groups. Cyclic groups are soluble, and so a group that is not soluble requires at least two generators.  Therefore, in `MinimalGeneratingSet`, we can add a special case for groups that aren't soluable but already a generating set of size two.

So this behaviour:
```
gap> MinimalGeneratingSet(SymmetricGroup(5));
Error, `MinimalGeneratingSet' currently assumes that the group must be solvable.
In general, try `SmallGeneratingSet' instead, which returns a generating
set that is small but not of guarateed smallest cardinality
```
now becomes:
```
gap> MinimalGeneratingSet(SymmetricGroup(5));
[ (1,2,3,4,5), (1,2) ]
```
I'm wondering, do people think this is worth doing? And if so, have I gone about it the right way?