### PR TITLE
Fix test diffs when the Semigroups package is loaded

### DIFF
--- a/doc/ref/pperm.xml
+++ b/doc/ref/pperm.xml
@@ -1724,6 +1724,8 @@ gap> S := InverseSemigroup(
 > PartialPerm( [ 1, 2, 4, 5 ], [ 3, 1, 4, 2 ] ) );;
 gap> IsMonoid(S); 
 false
+gap> Size(S);
+508
 gap> iso := IsomorphismPartialPermMonoid(S);
 MappingByFunction( <inverse partial perm semigroup of size 508, 
  rank 5 with 2 generators>, <inverse partial perm monoid of size 508, 

--- a/doc/ref/trans.xml
+++ b/doc/ref/trans.xml
@@ -971,7 +971,7 @@ gap> S := FullTransformationSemigroup( 5 );
 gap> SmallestMovedPoint( S );              
 1
 gap> S := Semigroup( IdentityTransformation );
-<trivial transformation monoid of degree 0 with 1 generator>
+<trivial transformation group of degree 0 with 1 generator>
 gap> SmallestMovedPoint( S );
 infinity
 gap> f := Transformation( [ 1, 2, 3, 6, 6, 6 ] );;
@@ -1007,7 +1007,7 @@ gap> S := FullTransformationSemigroup( 5 );
 gap> LargestMovedPoint( S );
 5
 gap> S := Semigroup( IdentityTransformation );
-<trivial transformation monoid of degree 0 with 1 generator>
+<trivial transformation group of degree 0 with 1 generator>
 gap> LargestMovedPoint( S );
 0
 gap> f := Transformation( [ 1, 2, 3, 6, 6, 6 ] );;
@@ -1043,7 +1043,7 @@ gap> S := FullTransformationSemigroup( 5 );
 gap> SmallestImageOfMovedPoint( S );              
 1
 gap> S := Semigroup( IdentityTransformation );
-<trivial transformation monoid of degree 0 with 1 generator>
+<trivial transformation group of degree 0 with 1 generator>
 gap> SmallestImageOfMovedPoint( S );
 infinity
 gap> f := Transformation( [ 1, 2, 3, 6, 6, 6 ] );;

--- a/lib/semigrp.gd
+++ b/lib/semigrp.gd
@@ -584,7 +584,7 @@ DeclareProperty("IsZeroSemigroup", IsSemigroup);
 InstallTrueMethod(IsMonoidAsSemigroup, IsMagmaWithOne and IsSemigroup);
 InstallTrueMethod(IsGroupAsSemigroup, IsMagmaWithInverses and IsSemigroup);
 InstallTrueMethod(IsGroupAsSemigroup, IsInverseSemigroup and IsSimpleSemigroup and IsFinite);
-InstallTrueMethod(IsGroupAsSemigroup, IsCommutativeSemigroup and IsSimpleSemigroup);
+InstallTrueMethod(IsGroupAsSemigroup, IsCommutative and IsSimpleSemigroup);
 InstallTrueMethod(IsBand, IsSemilattice);
 InstallTrueMethod(IsBrandtSemigroup, IsInverseSemigroup and IsZeroSimpleSemigroup);
 InstallTrueMethod(IsCliffordSemigroup, IsSemilattice);

--- a/tst/testinstall/semigrp.tst
+++ b/tst/testinstall/semigrp.tst
@@ -286,7 +286,7 @@ gap>
 #T# Checking for correct non-removal of one from generating sets in
 # SemigroupByGenerators JDM
 gap> S := Semigroup(PartialPerm([1]));
-<trivial partial perm monoid of rank 1 with 1 generator>
+<trivial partial perm group of rank 1 with 1 generator>
 gap> GeneratorsOfSemigroup(S);
 [ <identity partial perm on [ 1 ]> ]
 gap> GeneratorsOfMonoid(S);
@@ -296,7 +296,7 @@ gap> GeneratorsOfInverseSemigroup(S);
 gap> GeneratorsOfInverseMonoid(S);
 [ <identity partial perm on [ 1 ]> ]
 gap> S := Semigroup(IdentityTransformation);
-<trivial transformation monoid of degree 0 with 1 generator>
+<trivial transformation group of degree 0 with 1 generator>
 gap> GeneratorsOfSemigroup(S);
 [ IdentityTransformation ]
 gap> GeneratorsOfMonoid(S);
@@ -305,15 +305,13 @@ gap> GeneratorsOfMonoid(S);
 #T# Checking for correct non-removal of one from generating sets in
 # MonoidByGenerators JDM
 gap> S := Monoid(PartialPerm([1]));
-<trivial partial perm monoid of rank 1 with 1 generator>
-gap> S := Monoid(PartialPerm([1]));
-<trivial partial perm monoid of rank 1 with 1 generator>
+<trivial partial perm group of rank 1 with 1 generator>
 gap> GeneratorsOfSemigroup(S);
 [ <identity partial perm on [ 1 ]> ]
 gap> GeneratorsOfMonoid(S);
 [ <identity partial perm on [ 1 ]> ]
 gap> S := Monoid(IdentityTransformation);
-<trivial transformation monoid of degree 0 with 1 generator>
+<trivial transformation group of degree 0 with 1 generator>
 gap> GeneratorsOfSemigroup(S);
 [ IdentityTransformation ]
 gap> GeneratorsOfMonoid(S);
@@ -362,8 +360,11 @@ gap> GeneratorsOfInverseMonoid(S);
 [ IdentityTransformation ]
 
 #T# Checking GroupByGenerators
-gap> S := Group(PartialPerm([1]));
-<partial perm group of rank 1 with 1 generator>
+gap> S := Group(PartialPerm([1]));;
+gap> IsTrivial(S);
+true
+gap> S;
+<trivial partial perm group of rank 1 with 1 generator>
 gap> GeneratorsOfSemigroup(S);
 [ <identity partial perm on [ 1 ]> ]
 gap> GeneratorsOfMonoid(S);

--- a/tst/testinstall/semitran.tst
+++ b/tst/testinstall/semitran.tst
@@ -51,7 +51,7 @@ true
 # gap> Print(Semigroup(IdentityTransformation));
 # Test SemigroupViewStringPrefix
 gap> S := Semigroup(IdentityTransformation);
-<trivial transformation monoid of degree 0 with 1 generator>
+<trivial transformation group of degree 0 with 1 generator>
 
 # Test < 
 gap> T := Semigroup(Transformation([2, 3, 1]));
@@ -145,7 +145,7 @@ gap> S := Group(IdentityTransformation);
 gap> GeneratorsOfGroup(S);
 [ IdentityTransformation ]
 gap> S := Semigroup(IdentityTransformation);
-<trivial transformation monoid of degree 0 with 1 generator>
+<trivial transformation group of degree 0 with 1 generator>
 
 # Test IsomorphismPermGroup for an H-class
 gap> S := FullTransformationMonoid(4);;
@@ -169,7 +169,7 @@ gap> S := Semigroup(GeneratorsOfSemigroup(FullTransformationMonoid(3)));
 gap> IsFullTransformationSemigroup(S);
 true
 gap> S := Semigroup(IdentityTransformation);
-<trivial transformation monoid of degree 0 with 1 generator>
+<trivial transformation group of degree 0 with 1 generator>
 gap> IsFullTransformationSemigroup(S);
 true
 gap> S := Semigroup(GeneratorsOfSemigroup(FullTransformationMonoid(3)));


### PR DESCRIPTION
In the test files `tst/testinstall/semigrp.tst` and `semitran.tst`, there are some diffs when the Semigroups package is loaded. In these tests, there are semigroups that happen to be groups. When the Semigroups package is loaded, there are additional methods that realise this information, and so the ViewString is different, causing the diffs.

I have changed an ImmediateMethod to `lib/semigrp.gd` so that these semigroups know that they are groups, even when the Semigroups package is not loaded.

In the future, we will be running the `GAP` test files in the continuous integration for the Semigroups package, and so diffs like this should be caught immediately.

There still remains one diff in `tst/testinstall/semigrp.tst` when the Semigroups package is loaded. This is an actual bug in Semigroups, and is being sorted out by @james-d-mitchell in the Semigroups repo.