### PR TITLE
Parse decimal integers in only one place, not four

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -1625,65 +1625,16 @@ void CodePow ( void )
 }
 
 
-void CodeGAPSmallInt(Obj val)
-{
-    PushExpr(INTEXPR_INT(INT_INTOBJ(val)));
-}
-
 /****************************************************************************
 **
-*F  CodeIntExpr( <str> )  . . . . . . . . . . code literal integer expression
+*F  CodeIntExpr( <val> )  . . . . . . . . . . code literal integer expression
 **
-**  'CodeIntExpr' is the action to code a literal integer expression.  <str>
-**  is the integer as a (null terminated) C character string.
+**  'CodeIntExpr' is the action to code a literal integer expression.  <val>
+**  is the integer as a GAP object.
 */
-void CodeIntExpr (
-    Char *              str )
+void CodeIntExpr(Obj val)
 {
     Expr                expr;           /* expression, result              */
-    Obj                 val;            /* value = <upp> * <pow> + <low>    */
-    Obj                 upp;            /* upper part                       */
-    Int                 pow;            /* power                            */
-    Int                 low;            /* lower part                       */
-    Int                 sign;           /* is the integer negative          */
-    UInt                i;              /* loop variable                    */
-
-    /* get the signs, if any                                                */
-    sign = 1;
-    i = 0;
-    while ( str[i] == '-' ) {
-        sign = - sign;
-        i++;
-    }
-
-    /* collect the digits in groups of 8                                    */
-    low = 0;
-    pow = 1;
-    upp = INTOBJ_INT(0);
-    while ( str[i] != '\0' ) {
-        low = 10 * low + str[i] - '0';
-        pow = 10 * pow;
-        if ( pow == 100000000L ) {
-            upp = SumInt( ProdInt( upp, INTOBJ_INT(pow) ),
-                          INTOBJ_INT(sign*low) );
-            pow = 1;
-            low = 0;
-        }
-        i++;
-    }
-
-    /* compose the integer value (set <val> first to silence 'lint')       */
-    val = 0;
-    if ( upp == INTOBJ_INT(0) ) {
-        val = INTOBJ_INT(sign*low);
-    }
-    else if ( pow == 1 ) {
-        val = upp;
-    }
-    else {
-        val = SumInt( ProdInt( upp, INTOBJ_INT(pow) ),
-                      INTOBJ_INT(sign*low) );
-    }
 
     /* if it is small enough code it immediately                           */
     if ( IS_INTOBJ(val) ) {
@@ -1692,83 +1643,10 @@ void CodeIntExpr (
 
     /* otherwise stuff the value into the values list                      */
     else {
+        GAP_ASSERT(TNUM_OBJ(val) == T_INTPOS || TNUM_OBJ(val) == T_INTNEG);
         expr = NewExpr( T_INT_EXPR, sizeof(UInt) + SIZE_OBJ(val) );
         ((UInt *)ADDR_EXPR(expr))[0] = (UInt)TNUM_OBJ(val);
         memcpy(((UInt *)ADDR_EXPR(expr)+1), CONST_ADDR_OBJ(val), (size_t)SIZE_OBJ(val));
-    }
-
-    /* push the expression                                                 */
-    PushExpr( expr );
-}
-
-/****************************************************************************
-**
-*F  CodeLongIntExpr( <str> )   . . . code literal long integer expression
-**
-**  'CodeIntExpr'  is  the  action  to   code  a  long  literal  integer
-**  expression whose digits are stored in a string GAP object.
-*/
-void CodeLongIntExpr (
-    Obj              string )
-{
-    Expr                expr;           /* expression, result              */
-    Obj                 val;            /* value = <upp> * <pow> + <low>    */
-    Obj                 upp;            /* upper part                       */
-    Int                 pow;            /* power                            */
-    Int                 low;            /* lower part                       */
-    Int                 sign;           /* is the integer negative          */
-    UInt                i;              /* loop variable                    */
-    UChar *              str;
-
-    /* get the signs, if any                                                */
-    str = CHARS_STRING(string);
-    sign = 1;
-    i = 0;
-    while ( str[i] == '-' ) {
-        sign = - sign;
-        i++;
-    }
-
-    /* collect the digits in groups of 8                                    */
-    low = 0;
-    pow = 1;
-    upp = INTOBJ_INT(0);
-    while ( str[i] != '\0' ) {
-        low = 10 * low + str[i] - '0';
-        pow = 10 * pow;
-        if ( pow == 100000000L ) {
-            upp = SumInt( ProdInt( upp, INTOBJ_INT(pow) ),
-                          INTOBJ_INT(sign*low) );
-            str = CHARS_STRING(string);
-            pow = 1;
-            low = 0;
-        }
-        i++;
-    }
-
-    /* compose the integer value (set <val> first to silence 'lint')       */
-    val = 0;
-    if ( upp == INTOBJ_INT(0) ) {
-        val = INTOBJ_INT(sign*low);
-    }
-    else if ( pow == 1 ) {
-        val = upp;
-    }
-    else {
-        val = SumInt( ProdInt( upp, INTOBJ_INT(pow) ),
-                      INTOBJ_INT(sign*low) );
-    }
-
-    /* if it is small enough code it immediately                           */
-    if ( IS_INTOBJ(val) ) {
-        expr = INTEXPR_INT( INT_INTOBJ(val) );
-    }
-
-    /* otherwise stuff the value into the values list                      */
-    else {
-        expr = NewExpr( T_INT_EXPR, sizeof(UInt) + SIZE_OBJ(val) );
-        ((UInt *)ADDR_EXPR(expr))[0] = (UInt)TNUM_OBJ(val);
-        memcpy((void *)((UInt *)ADDR_EXPR(expr)+1), CONST_ADDR_OBJ(val), (size_t)SIZE_OBJ(val));
     }
 
     /* push the expression                                                 */

--- a/src/code.h
+++ b/src/code.h
@@ -966,16 +966,12 @@ extern  void            CodePow ( void );
 
 /****************************************************************************
 **
-*F  CodeIntExpr(<str>)  . . . . . . . . . . . code literal integer expression
+*F  CodeIntExpr(<val>)  . . . . . . . . . . . code literal integer expression
 **
-**  'CodeIntExpr' is the action to code a literal integer expression.  <str>
-**  is the integer as a (null terminated) C character string.
+**  'CodeIntExpr' is the action to code a literal integer expression.  <val>
+**  is the integer as a GAP object.
 */
-extern void             CodeGAPSmallInt(Obj obj);
-extern  void            CodeIntExpr (
-            Char *              str );
-extern  void            CodeLongIntExpr (
-            Obj                 string ); 
+extern void CodeIntExpr(Obj val);
 
 /****************************************************************************
 **

--- a/src/gmpints.c
+++ b/src/gmpints.c
@@ -889,6 +889,93 @@ Obj FuncSTRING_INT( Obj self, Obj integer )
 }
 
 
+Obj IntStringInternal(Obj string, const Char *str)
+{
+    Obj     val;  // value = <upp> * <pow> + <low>
+    Obj     upp;  // upper part
+    Int     pow;  // power
+    Int     low;  // lower part
+    Int     sign; // is the integer negative
+    UInt    i;    // loop variable
+
+    // if <string> is given, then we ignore <str>
+    if (string)
+        str = CSTR_STRING(string);
+
+    // get the signs, if any
+    sign = 1;
+    i = 0;
+    while (str[i] == '-') {
+        sign = -sign;
+        i++;
+    }
+
+    // reject empty string (resp. string consisting only of minus signs)
+    if (str[i] == '\0')
+        return Fail;
+
+    // collect the digits in groups of 8, for improved performance
+    // note that 2^26 < 10^8 < 2^27, so the intermediate
+    // values always fit into an immediate integer
+    low = 0;
+    pow = 1;
+    upp = INTOBJ_INT(0);
+    while (str[i] != '\0') {
+        if (str[i] < '0' || str[i] > '9') {
+            return Fail;
+        }
+        low = 10 * low + str[i] - '0';
+        pow = 10 * pow;
+        if (pow == 100000000L) {
+            upp = ProdInt(upp, INTOBJ_INT(pow));
+            upp = SumInt(upp, INTOBJ_INT(sign*low));
+            // refresh 'str', in case the arithmetic operations triggered
+            // a garbage collection
+            if (string)
+                str = CSTR_STRING(string);
+            pow = 1;
+            low = 0;
+        }
+        i++;
+    }
+
+    // compose the integer value
+    if (upp == INTOBJ_INT(0)) {
+        val = INTOBJ_INT(sign * low);
+    }
+    else if (pow == 1) {
+        val = upp;
+    }
+    else {
+        upp = ProdInt(upp, INTOBJ_INT(pow));
+        val = SumInt(upp, INTOBJ_INT(sign * low));
+    }
+
+    // return the integer value
+    return val;
+}
+
+/****************************************************************************
+**
+*F  FuncINT_STRING( <self>, <string> ) . . . .  convert a string to an integer
+**
+**  `FuncINT_STRING' returns an integer representing the string, or
+**  fail if the string is not a valid integer.
+**
+*/
+Obj FuncINT_STRING ( Obj self, Obj string )
+{
+    if( !IS_STRING(string) ) {
+        return Fail;
+    }
+
+    if( !IS_STRING_REP(string) ) {
+        string = CopyToStringRep(string);
+    }
+
+    return IntStringInternal(string, 0);
+}
+
 /****************************************************************************
 **
 *F  EqInt( <gmpL>, <gmpR> ) . . . . . . . . .  test if two integers are equal
@@ -2339,6 +2426,7 @@ static StructGVarFunc GVarFuncs [] = {
   GVAR_FUNC(IntHexString, 1, "string"),
   GVAR_FUNC(Log2Int, 1, "gmp"),
   GVAR_FUNC(STRING_INT, 1, "gmp"),
+  GVAR_FUNC(INT_STRING, 1, "string"),
   GVAR_FUNC(RandomIntegerMT, 2, "mtstr, nrbits"),
   { 0, 0, 0, 0, 0 }
 

--- a/src/gmpints.h
+++ b/src/gmpints.h
@@ -91,6 +91,16 @@ extern Obj GMP_NORMALIZE( Obj gmp );
 extern void PrintInt( Obj op );
 
 
+// Parse a string containing a decimal integer into a GAP integer
+// object. Returns 'fail' if the input is not a valid decimal.
+// This function handles signs.
+//
+// If <string> is non-NULL, then <str> is ignored, and <string>
+// must reference a GAP string object. If <string> is NULL, then
+// <str> must point to a C string.
+Obj IntStringInternal(Obj string, const Char *str);
+
+
 /****************************************************************************
 **
 *F  EqInt( <gmpL>, <gmpR> ) . . . . . test if two integers are equal

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -537,7 +537,7 @@ Int HASHKEY_WHOLE_BAG_NC(Obj obj, UInt4 seed)
     return HASHKEY_BAG_NC(obj, seed, 0, SIZE_OBJ(obj));
 }
 
-Obj IntStringInternal(Obj string)
+Obj IntStringInternal(Obj string, const Char *str)
 {
     Obj     val;  // value = <upp> * <pow> + <low>
     Obj     upp;  // upper part
@@ -545,7 +545,10 @@ Obj IntStringInternal(Obj string)
     Int     low;  // lower part
     Int     sign; // is the integer negative
     UInt    i;    // loop variable
-    UChar * str;  // temp pointer
+
+    // if <string> is given, then we ignore <str>
+    if (string)
+        str = CSTR_STRING(string);
 
     // get the signs, if any
     sign = 1;
@@ -574,9 +577,11 @@ Obj IntStringInternal(Obj string)
         pow = 10 * pow;
         if (pow == 100000000L) {
             upp = ProdInt(upp, INTOBJ_INT(pow));
-            upp = SumInt(upp, INTOBJ_INT(sign * low));
-            str = CHARS_STRING(
-                string);    // Regrab, in case garbage collection occurred
+            upp = SumInt(upp, INTOBJ_INT(sign*low));
+            // refresh 'str', in case the arithmetic operations triggered
+            // a garbage collection
+            if (string)
+                str = CSTR_STRING(string);
             pow = 1;
             low = 0;
         }
@@ -617,7 +622,7 @@ Obj FuncINT_STRING ( Obj self, Obj string )
         string = CopyToStringRep(string);
     }
 
-    return IntStringInternal(string);
+    return IntStringInternal(string, 0);
 }
 
 /****************************************************************************

--- a/src/intfuncs.h
+++ b/src/intfuncs.h
@@ -47,7 +47,14 @@ Int HASHKEY_WHOLE_BAG_NC (Obj obj, UInt4 seed);
 // Does NOT perform bounds checking
 Int HASHKEY_BAG_NC (Obj obj, UInt4 seed, Int skip, int read);
 
-Obj IntStringInternal( Obj string );
+// Parse a string containing a decimal integer into a GAP integer
+// object. Returns 'fail' if the input is not a valid decimal.
+// This function handles signs.
+//
+// If <string> is non-NULL, then <str> is ignored, and <string>
+// must reference a GAP string object. If <string> is NULL, then
+// <str> must point to a C string.
+Obj IntStringInternal(Obj string, const Char *str);
 
 /****************************************************************************
 **

--- a/src/intfuncs.h
+++ b/src/intfuncs.h
@@ -47,15 +47,6 @@ Int HASHKEY_WHOLE_BAG_NC (Obj obj, UInt4 seed);
 // Does NOT perform bounds checking
 Int HASHKEY_BAG_NC (Obj obj, UInt4 seed, Int skip, int read);
 
-// Parse a string containing a decimal integer into a GAP integer
-// object. Returns 'fail' if the input is not a valid decimal.
-// This function handles signs.
-//
-// If <string> is non-NULL, then <str> is ignored, and <string>
-// must reference a GAP string object. If <string> is NULL, then
-// <str> must point to a C string.
-Obj IntStringInternal(Obj string, const Char *str);
-
 /****************************************************************************
 **
 *F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * *

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1910,58 +1910,13 @@ void            IntrPow ( void )
 **  'IntrIntExpr' is the action  to  interpret a literal  integer expression.
 **  <str> is the integer as a (null terminated) C character string.
 */
-void            IntrIntExpr (
-    Char *              str )
+void IntrIntExpr(Char * str)
 {
-    Obj                 val;            /* value = <upp> * <pow> + <low>   */
-    Obj                 upp;            /* upper part                      */
-    Int                 pow;            /* power                           */
-    Int                 low;            /* lower part                      */
-    Int                 sign;           /* is the integer negative         */
-    UInt                i;              /* loop variable                   */
-
     /* ignore or code                                                      */
     if ( STATE(IntrReturning) > 0 ) { return; }
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
     
-    /* get the signs, if any                                                */
-    sign = 1;
-    i = 0;
-    while ( str[i] == '-' ) {
-        sign = - sign;
-        i++;
-    }
-
-    // collect the digits in groups of 8, for improved performance
-    // note that 2^26 < 10^8 < 2^27, so the intermediate
-    // values always fit into an immediate integer
-    low = 0;
-    pow = 1;
-    upp = INTOBJ_INT(0);
-    while ( str[i] != '\0' ) {
-        low = 10 * low + str[i] - '0';
-        pow = 10 * pow;
-        if ( pow == 100000000L ) {
-            upp = ProdInt(upp, INTOBJ_INT(pow));
-            upp = SumInt(upp, INTOBJ_INT(sign * low));
-
-            pow = 1;
-            low = 0;
-        }
-        i++;
-    }
-
-    // compose the integer value
-    if ( upp == INTOBJ_INT(0) ) {
-        val = INTOBJ_INT(sign*low);
-    }
-    else if ( pow == 1 ) {
-        val = upp;
-    }
-    else {
-        upp = ProdInt(upp, INTOBJ_INT(pow));
-        val = SumInt(upp, INTOBJ_INT(sign * low));
-    }
+    Obj val = IntStringInternal(0, str);
 
     if (STATE(IntrCoding) > 0) {
         CodeIntExpr(val);
@@ -1980,13 +1935,12 @@ void            IntrIntExpr (
 **  'IntrLongIntExpr' is the action to  interpret a long literal integer
 **  expression whose digits are stored in a string GAP object.
 */
-void            IntrLongIntExpr (
-    Obj               string )
+void IntrLongIntExpr(Obj string)
 {
     if ( STATE(IntrReturning) > 0 ) { return; }
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
-    Obj val = IntStringInternal(string);
+    Obj val = IntStringInternal(string, 0);
 
     if (STATE(IntrCoding) > 0) {
         CodeIntExpr(val);

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1917,6 +1917,7 @@ void IntrIntExpr(Char * str)
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
     
     Obj val = IntStringInternal(0, str);
+    GAP_ASSERT(val != Fail);
 
     if (STATE(IntrCoding) > 0) {
         CodeIntExpr(val);
@@ -1941,6 +1942,7 @@ void IntrLongIntExpr(Obj string)
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     Obj val = IntStringInternal(string, 0);
+    GAP_ASSERT(val != Fail);
 
     if (STATE(IntrCoding) > 0) {
         CodeIntExpr(val);


### PR DESCRIPTION
This adds a tiny amount of overhead to the parsing stage, as we now sometimes verify that all characters in the input are digits; but this should be negligible except for extreme cases. If we are truly worried about this, we could return to having two versions of this...