### PR TITLE
Add GetWithDefault

### DIFF
--- a/doc/ref/lists.xml
+++ b/doc/ref/lists.xml
@@ -440,6 +440,7 @@ the operations <Ref Func="Add"/> and <Ref Func="Remove"/>.
 <Heading>IsBound and Unbind for Lists</Heading>
 
 <#Include Label="IsBound_list">
+<#Include Label="GetWithDefault_list">
 <#Include Label="Unbind_list">
 
 </Section>

--- a/lib/hpc/thread1.g
+++ b/lib/hpc/thread1.g
@@ -161,15 +161,6 @@ BIND_GLOBAL("CopyToRegion", {x,y} -> x);
 BIND_GLOBAL("SetTLDefault", BindThreadLocal);
 BIND_GLOBAL("SetTLConstructor", BindThreadLocalConstructor);
 
-
-BIND_GLOBAL("CHECKED_GET_ATOMIC_LIST", function(l, pos, default)
-    if IsBound(l[pos]) then
-        return l[pos];
-    else
-        return default;
-    fi;
-end);
-
 BIND_GLOBAL("COMPARE_AND_SWAP", function(l, pos, old, new)
     if IsBound(l[pos]) and IS_IDENTICAL_OBJ(l[pos], old) then
         l[pos] := new;

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -178,6 +178,51 @@ DeclareOperationKernel( "[]",
     [ IsList, IS_INT ],
     ELM_LIST );
 
+#############################################################################
+##
+##  <#GAPDoc Label="GetWithDefault_list">
+##  <ManSection>
+##  <Oper Name="GetWithDefault" Arg='list, n, default'/>
+##
+##  <Description>
+##  <Ref Func="GetWithDefault"/> returns the <A>n</A>th element of the list
+##  <A>list</A>, if <A>list</A> has a value at index <A>n</A>, and
+##  <A>default</A> otherwise.
+##  <P/>
+##  While this method can be used on any list, it is particularly useful
+##  for Weak Pointer lists <Ref Sect="Weak Pointer Objects"/> where the
+##  value of the list can change.
+##  <P/>
+##  To distinguish between the <A>n</A>th element being unbound, or
+##  <A>default</A> being in <A>list</A>, users can create a new mutable
+##  object, such as a string. <Ref Func="IsIdenticalObj"/> returns
+##  <K>false</K> for different mutable strings, even if their contents are
+##  the same.
+##
+##  <Example><![CDATA[
+##  gap> l := [1,2,,"a"];
+##  [ 1, 2,, "a" ]
+##  gap> newobj := "a";
+##  "a"
+##  gap> GetWithDefault(l, 2, newobj);
+##  2
+##  gap> GetWithDefault(l, 3, newobj);
+##  "a"
+##  gap> GetWithDefault(l, 4, newobj);
+##  "a"
+##  gap> IsIdenticalObj(GetWithDefault(l, 3, newobj), newobj);
+##  true
+##  gap> IsIdenticalObj(GetWithDefault(l, 4, newobj), newobj);
+##  false
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperationKernel( "GetWithDefault",
+    [ IsList, IS_INT, IsObject ],
+    ELM_DEFAULT_LIST );
+
 
 #############################################################################
 ##

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -351,20 +351,17 @@ static Obj FuncGET_ATOMIC_LIST(Obj self, Obj list, Obj index)
 // The reason this function exists is that it is not thread-safe to
 // check if an index in a list is bound before reading it, as it
 // could be unbound before the actual reading is performed.
-static Obj FuncCHECKED_GET_ATOMIC_LIST(Obj self, Obj list, Obj index, Obj value)
+static Obj ElmDefAList(Obj list, Int n, Obj value)
 {
-    UInt        n;
     UInt        len;
     AtomicObj * addr;
     Obj         val;
-    if (TNUM_OBJ(list) != T_ALIST && TNUM_OBJ(list) != T_FIXALIST)
-        ArgumentError(
-            "CHECKED_GET_ATOMIC_LIST: First argument must be an atomic list");
+
+    GAP_ASSERT(TNUM_OBJ(list) == T_ALIST || TNUM_OBJ(list) == T_FIXALIST);
+    GAP_ASSERT(n > 0);
     addr = ADDR_ATOM(list);
     len = ALIST_LEN((UInt)addr[0].atom);
-    if (!IS_INTOBJ(index))
-        ArgumentError("CHECKED_GET_ATOMIC_LIST: Second argument must be an integer");
-    n = INT_INTOBJ(index);
+
     if (n <= 0 || n > len) {
         val = 0;
     }
@@ -1882,7 +1879,6 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(FromAtomicList, 1, "list"),
     GVAR_FUNC(AddAtomicList, 2, "list, obj"),
     GVAR_FUNC(GET_ATOMIC_LIST, 2, "list, index"),
-    GVAR_FUNC(CHECKED_GET_ATOMIC_LIST, 3, "list, index, default"),
     GVAR_FUNC(SET_ATOMIC_LIST, 3, "list, index, value"),
     GVAR_FUNC(COMPARE_AND_SWAP, 4, "list, index, old, new"),
     GVAR_FUNC(ATOMIC_BIND, 3, "list, index, new"),
@@ -1988,6 +1984,7 @@ static Int InitKernel (
   LenListFuncs[T_FIXALIST] = LenListAList;
   LengthFuncs[T_FIXALIST] = LengthAList;
   Elm0ListFuncs[T_FIXALIST] = Elm0AList;
+  ElmDefListFuncs[T_FIXALIST] = ElmDefAList;
   Elm0vListFuncs[T_FIXALIST] = Elm0AList;
   ElmListFuncs[T_FIXALIST] = ElmAList;
   ElmvListFuncs[T_FIXALIST] = ElmAList;
@@ -2002,6 +1999,7 @@ static Int InitKernel (
   LenListFuncs[T_ALIST] = LenListAList;
   LengthFuncs[T_ALIST] = LengthAList;
   Elm0ListFuncs[T_ALIST] = Elm0AList;
+  ElmDefListFuncs[T_ALIST] = ElmDefAList;
   Elm0vListFuncs[T_ALIST] = Elm0AList;
   ElmListFuncs[T_ALIST] = ElmAList;
   ElmvListFuncs[T_ALIST] = ElmAList;

--- a/src/lists.h
+++ b/src/lists.h
@@ -236,6 +236,31 @@ static inline Obj ELM0_LIST(Obj list, Int pos)
     return (*Elm0ListFuncs[TNUM_OBJ(list)])(list, pos);
 }
 
+/****************************************************************************
+**
+*V  ElmDefListFuncs[ <type> ] . . . . . . . . .  table of selection functions
+**
+**  A package implementing a list type <type> can provide a function for
+**  'ELM_DEFAULT_LIST' and install it in 'ElmDefListFuncs[<type>]', otherwise
+**  a default implementation is provided.
+*/
+extern Obj (*ElmDefListFuncs[LAST_REAL_TNUM + 1])(Obj list, Int pos, Obj def);
+
+
+/****************************************************************************
+**
+*F  ELM_DEFAULT_LIST( <list>, <pos>, <default> )select an element from a list
+**
+**  'ELM_DEFAULT_LIST' returns the element at the position <pos> in the list
+**  <list>, or <default> if <list> has no assigned object at position <pos>.
+**  An error is signalled if <list> is not a list. It is the responsibility
+**  of the caller to ensure that <pos> is a positive integer.
+*/
+static inline Obj ELM_DEFAULT_LIST(Obj list, Int pos, Obj def)
+{
+    return (*ElmDefListFuncs[TNUM_OBJ(list)])(list, pos, def);
+}
+
 
 /****************************************************************************
 **

--- a/tst/testinstall/atomic_list.tst
+++ b/tst/testinstall/atomic_list.tst
@@ -60,14 +60,14 @@ gap> IsBound(a[3]);
 false
 gap> IsBound(a[9]);
 false
-gap> CHECKED_GET_ATOMIC_LIST(a, 2, -1);
+gap> GetWithDefault(a, 2, -1);
 7
-gap> CHECKED_GET_ATOMIC_LIST(a, 3, -1);
+gap> GetWithDefault(a, 3, -1);
 -1
-gap> CHECKED_GET_ATOMIC_LIST(a, 10, -1);
+gap> GetWithDefault(a, 10, -1);
 -1
 gap> s := "";;
-gap> IsIdenticalObj(CHECKED_GET_ATOMIC_LIST(a, 10, s), s);
+gap> IsIdenticalObj(GetWithDefault(a, 10, s), s);
 true
 gap> COMPARE_AND_SWAP(a, 2, 6, 5);
 false
@@ -141,14 +141,14 @@ gap> IsBound(a[3]);
 false
 gap> IsBound(a[9]);
 false
-gap> CHECKED_GET_ATOMIC_LIST(a, 2, -1);
+gap> GetWithDefault(a, 2, -1);
 7
-gap> CHECKED_GET_ATOMIC_LIST(a, 3, -1);
+gap> GetWithDefault(a, 3, -1);
 -1
-gap> CHECKED_GET_ATOMIC_LIST(a, 10, -1);
+gap> GetWithDefault(a, 10, -1);
 -1
 gap> s := "";;
-gap> IsIdenticalObj(CHECKED_GET_ATOMIC_LIST(a, 10, s), s);
+gap> IsIdenticalObj(GetWithDefault(a, 10, s), s);
 true
 gap> COMPARE_AND_SWAP(a, 2, 6, 5);
 false

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -23,6 +23,10 @@ gap> InstallOtherMethod(IsBound\[\],[r and IsMutable,IsObject],function(l,ix)
 >     Print ("IsBound ",ix,"\n");
 >     return false;
 > end);
+gap> InstallOtherMethod(GetWithDefault, [r and IsMutable, IsInt, IsObject], function(a,ix,d)
+>     Print("GetWithDefault ", ix, ":", d, "\n");
+>     return d;
+> end);
 
 #
 gap> InstallOtherMethod(\[\],[r,IsPosInt,IsPosInt],function(l,i,j) 
@@ -98,6 +102,9 @@ false
 gap> IsBound(o["abc"]);
 IsBound abc
 false
+gap> GetWithDefault(o, 2, "abc");
+GetWithDefault 2:abc
+"abc"
 gap> foo := function(a)
 >     return[ a[1,2,3],
 >             a[4,5],
@@ -138,6 +145,24 @@ gap> s;
 gap> s := [];; Add(s, 0, -1);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Add' on 3 arguments
+gap> s := [];; GetWithDefault(s, 0, -1);
+Error, GetWithDefault: <pos> must be >= 0
+gap> s := [];; GetWithDefault(s, "cheese", -1);
+Error, GetWithDefault: <pos> must be an integer (not a list (string))
+gap> t := [];; GetWithDefault(t, 1, -1);
+-1
+gap> t := [6];; GetWithDefault(t, 1, -1);
+6
+gap> t := [6];; GetWithDefault(t, 2, -1);
+-1
+gap> t := "cheese";; GetWithDefault(t, 2, -1);
+'h'
+gap> t := "cheese";; GetWithDefault(t, 7, -1);
+-1
+gap> t := BlistList([1..5], [2]);; GetWithDefault(t, 2, -1);
+true
+gap> t := BlistList([1..5], [2]);; GetWithDefault(t, 6, -1);
+-1
 gap> l := [];; Append(l, [1]); l;
 [ 1 ]
 gap> l := [];; Append(l, "cheese"); l;

--- a/tst/teststandard/weakptr.tst
+++ b/tst/teststandard/weakptr.tst
@@ -18,6 +18,13 @@ WeakPointerObj( [ 1, , 10995116277760000000000, Z(17),
 [ 2, 3, 4 ], fail, SymmetricGroup( [ 1 .. 5 ] ) ] )
 gap> LengthWPObj(w);
 7
+gap> val := "cheese";;
+gap> GetWithDefault(w, 1, "cheese");
+1
+gap> IsIdenticalObj(val, GetWithDefault(w, 2, val));
+true
+gap> IsIdenticalObj(val, GetWithDefault(w, 8, val));
+true
 gap> List([1..7],x->IsBoundElmWPObj(w,x));
 [ true, false, true, true, true, true, true ]
 gap> List([1..7],x->ElmWPObj(w,x)); 
@@ -55,6 +62,14 @@ gap> LengthWPObj(w);
 6
 gap> Print(ShallowCopy(w),"\n");
 WeakPointerObj( [ 1, , , , , fail ] )
+gap> List([1..8], x -> GetWithDefault(w, x, -1));
+[ 1, -1, -1, -1, -1, fail, -1, -1 ]
+gap> GetWithDefault(w, 1, "cheese");
+1
+gap> IsIdenticalObj(val, GetWithDefault(w, 2, val));
+true
+gap> IsIdenticalObj(val, GetWithDefault(w, 8, val));
+true
 
 #
 # Access as lists


### PR DESCRIPTION
GetWithDefault provides a way of checking if an index in a list
is bound, and the value if the index is bound, as one function call.

It is particularly useful in weak pointer lists and atomic lists,
where there is a race condition between checking if an element is
bound, and then reading it's value.

This removes the very recently added method `CHECKED_GET_ATOMIC_LIST`, as it is now subsumed into this general method.