### PR TITLE
Removed SmallGroup call from HPC-GAP test

### DIFF
--- a/tst/testinstall/hpc/task.tst
+++ b/tst/testinstall/hpc/task.tst
@@ -52,8 +52,6 @@ gap> enum:= Enumerator( g );;
 gap> first50:=List( [ 1 .. 50 ], x -> enum[x] );;
 gap> CallAsTask( Position, enum, first50[1]);
 1
-gap> CallAsTask(SmallGroup,256,1);
-<pc group of size 256 with 8 generators>
 gap> CallAsTask(QuaternionAlgebra,Rationals);
 <algebra-with-one of dimension 4 over Rationals>
 gap> A := CallAsTask( FreeAlgebraWithOne, Rationals, 2);


### PR DESCRIPTION
Otherwise, it will fail after the switch to the SmallGrp package as it is not yet HPC-GAP ready.

I suggest to do this to allow to pick up SmallGrp package and cleanly merge #1714 - latter work on updating SmallGrp to work in HPC-GAP will not require pull requests as it will be picked up via package updates. 