### PR TITLE
Add a fast-path in LtFFE for common case.

### DIFF
--- a/src/finfield.c
+++ b/src/finfield.c
@@ -884,12 +884,18 @@ Int             LtFFE (
     if ( vL == 0 || vR == 0 ) {
         return (vL == 0 && vR != 0);
     }
+    
+    /* get the sizes of the fields over which the elements are written */
+    qL = SIZE_FF( fL );
+    qR = SIZE_FF( fR );
+
+    /* Deal quickly with the case where both elements are written over the ground field */
+    if (qL ==pL &&  qR == pR)
+      return vL < vR;
 
     /* compute the sizes of the minimal fields in which the elements lie   */
-    qL = SIZE_FF( fL );
     mL = pL;
     while ( (qL-1) % (mL-1) != 0 || (vL-1) % ((qL-1)/(mL-1)) != 0 ) mL *= pL;
-    qR = SIZE_FF( fR );
     mR = pR;
     while ( (qR-1) % (mR-1) != 0 || (vR-1) % ((qR-1)/(mR-1)) != 0 ) mR *= pR;
 


### PR DESCRIPTION
I noticed that testinstall was spending quite a large proportion of its time in LtFFE. I don't know whether this is typical of any real code, but I spotted this very simple change which speeds things up a lot. Essentially we avoid doing the minimal fields calculation if both FFEs are written over the same field to start with, which they usually will be.