### PR TITLE
Refactor opers

### DIFF
--- a/hpcgap/src/c_type1.c
+++ b/hpcgap/src/c_type1.c
@@ -8,6 +8,8 @@ static GVar G_NAME__FUNC;
 static Obj  GF_NAME__FUNC;
 static GVar G_IsType;
 static Obj  GF_IsType;
+static GVar G_FLUSH__ALL__METHOD__CACHES;
+static Obj  GF_FLUSH__ALL__METHOD__CACHES;
 static GVar G_IS__REC;
 static Obj  GF_IS__REC;
 static GVar G_IS__LIST;
@@ -164,8 +166,6 @@ static GVar G_NEW__TYPE__NEXT__ID;
 static Obj  GC_NEW__TYPE__NEXT__ID;
 static GVar G_NEW__TYPE__ID__LIMIT;
 static Obj  GC_NEW__TYPE__ID__LIMIT;
-static GVar G_FLUSH__ALL__METHOD__CACHES;
-static Obj  GF_FLUSH__ALL__METHOD__CACHES;
 static GVar G_POS__NUMB__TYPE;
 static Obj  GC_POS__NUMB__TYPE;
 static GVar G_NEW__TYPE;
@@ -4358,6 +4358,7 @@ static Int PostRestore ( StructInitInfo * module )
  /* global variables used in handlers */
  G_NAME__FUNC = GVarName( "NAME_FUNC" );
  G_IsType = GVarName( "IsType" );
+ G_FLUSH__ALL__METHOD__CACHES = GVarName( "FLUSH_ALL_METHOD_CACHES" );
  G_IS__REC = GVarName( "IS_REC" );
  G_IS__LIST = GVarName( "IS_LIST" );
  G_ADD__LIST = GVarName( "ADD_LIST" );
@@ -4435,7 +4436,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_POS__FIRST__FREE__TYPE = GVarName( "POS_FIRST_FREE_TYPE" );
  G_NEW__TYPE__NEXT__ID = GVarName( "NEW_TYPE_NEXT_ID" );
  G_NEW__TYPE__ID__LIMIT = GVarName( "NEW_TYPE_ID_LIMIT" );
- G_FLUSH__ALL__METHOD__CACHES = GVarName( "FLUSH_ALL_METHOD_CACHES" );
  G_POS__NUMB__TYPE = GVarName( "POS_NUMB_TYPE" );
  G_NEW__TYPE = GVarName( "NEW_TYPE" );
  G_IsFamily = GVarName( "IsFamily" );
@@ -4522,6 +4522,7 @@ static Int InitKernel ( StructInitInfo * module )
  /* global variables used in handlers */
  InitFopyGVar( "NAME_FUNC", &GF_NAME__FUNC );
  InitFopyGVar( "IsType", &GF_IsType );
+ InitFopyGVar( "FLUSH_ALL_METHOD_CACHES", &GF_FLUSH__ALL__METHOD__CACHES );
  InitFopyGVar( "IS_REC", &GF_IS__REC );
  InitFopyGVar( "IS_LIST", &GF_IS__LIST );
  InitFopyGVar( "ADD_LIST", &GF_ADD__LIST );
@@ -4601,7 +4602,6 @@ static Int InitKernel ( StructInitInfo * module )
  InitCopyGVar( "POS_FIRST_FREE_TYPE", &GC_POS__FIRST__FREE__TYPE );
  InitCopyGVar( "NEW_TYPE_NEXT_ID", &GC_NEW__TYPE__NEXT__ID );
  InitCopyGVar( "NEW_TYPE_ID_LIMIT", &GC_NEW__TYPE__ID__LIMIT );
- InitFopyGVar( "FLUSH_ALL_METHOD_CACHES", &GF_FLUSH__ALL__METHOD__CACHES );
  InitCopyGVar( "POS_NUMB_TYPE", &GC_POS__NUMB__TYPE );
  InitFopyGVar( "NEW_TYPE", &GF_NEW__TYPE );
  InitFopyGVar( "IsFamily", &GF_IsFamily );

--- a/src/c_methsel1.c
+++ b/src/c_methsel1.c
@@ -11,7 +11,6 @@ static GVar G_METHOD__3ARGS;
 static GVar G_METHOD__4ARGS;
 static GVar G_METHOD__5ARGS;
 static GVar G_METHOD__6ARGS;
-static GVar G_METHOD__XARGS;
 static GVar G_NEXT__METHOD__0ARGS;
 static GVar G_NEXT__METHOD__1ARGS;
 static GVar G_NEXT__METHOD__2ARGS;
@@ -19,7 +18,6 @@ static GVar G_NEXT__METHOD__3ARGS;
 static GVar G_NEXT__METHOD__4ARGS;
 static GVar G_NEXT__METHOD__5ARGS;
 static GVar G_NEXT__METHOD__6ARGS;
-static GVar G_NEXT__METHOD__XARGS;
 static GVar G_CONSTRUCTOR__0ARGS;
 static GVar G_CONSTRUCTOR__1ARGS;
 static GVar G_CONSTRUCTOR__2ARGS;
@@ -27,7 +25,6 @@ static GVar G_CONSTRUCTOR__3ARGS;
 static GVar G_CONSTRUCTOR__4ARGS;
 static GVar G_CONSTRUCTOR__5ARGS;
 static GVar G_CONSTRUCTOR__6ARGS;
-static GVar G_CONSTRUCTOR__XARGS;
 static GVar G_NEXT__CONSTRUCTOR__0ARGS;
 static GVar G_NEXT__CONSTRUCTOR__1ARGS;
 static GVar G_NEXT__CONSTRUCTOR__2ARGS;
@@ -35,7 +32,6 @@ static GVar G_NEXT__CONSTRUCTOR__3ARGS;
 static GVar G_NEXT__CONSTRUCTOR__4ARGS;
 static GVar G_NEXT__CONSTRUCTOR__5ARGS;
 static GVar G_NEXT__CONSTRUCTOR__6ARGS;
-static GVar G_NEXT__CONSTRUCTOR__XARGS;
 static GVar G_Error;
 static Obj  GF_Error;
 static GVar G_IS__IDENTICAL__OBJ;
@@ -50,11 +46,15 @@ static GVar G_fail;
 static Obj  GC_fail;
 static GVar G_LEN__LIST;
 static Obj  GF_LEN__LIST;
+static GVar G_METHOD__XARGS;
+static GVar G_NEXT__METHOD__XARGS;
 static GVar G_AttributeValueNotSet;
 static GVar G_TypeObj;
 static Obj  GF_TypeObj;
 static GVar G_FamilyObj;
 static Obj  GF_FamilyObj;
+static GVar G_CONSTRUCTOR__XARGS;
+static GVar G_NEXT__CONSTRUCTOR__XARGS;
 
 /* record names used in handlers */
 
@@ -5396,7 +5396,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_METHOD__4ARGS = GVarName( "METHOD_4ARGS" );
  G_METHOD__5ARGS = GVarName( "METHOD_5ARGS" );
  G_METHOD__6ARGS = GVarName( "METHOD_6ARGS" );
- G_METHOD__XARGS = GVarName( "METHOD_XARGS" );
  G_NEXT__METHOD__0ARGS = GVarName( "NEXT_METHOD_0ARGS" );
  G_NEXT__METHOD__1ARGS = GVarName( "NEXT_METHOD_1ARGS" );
  G_NEXT__METHOD__2ARGS = GVarName( "NEXT_METHOD_2ARGS" );
@@ -5404,7 +5403,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_NEXT__METHOD__4ARGS = GVarName( "NEXT_METHOD_4ARGS" );
  G_NEXT__METHOD__5ARGS = GVarName( "NEXT_METHOD_5ARGS" );
  G_NEXT__METHOD__6ARGS = GVarName( "NEXT_METHOD_6ARGS" );
- G_NEXT__METHOD__XARGS = GVarName( "NEXT_METHOD_XARGS" );
  G_CONSTRUCTOR__0ARGS = GVarName( "CONSTRUCTOR_0ARGS" );
  G_CONSTRUCTOR__1ARGS = GVarName( "CONSTRUCTOR_1ARGS" );
  G_CONSTRUCTOR__2ARGS = GVarName( "CONSTRUCTOR_2ARGS" );
@@ -5412,7 +5410,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_CONSTRUCTOR__4ARGS = GVarName( "CONSTRUCTOR_4ARGS" );
  G_CONSTRUCTOR__5ARGS = GVarName( "CONSTRUCTOR_5ARGS" );
  G_CONSTRUCTOR__6ARGS = GVarName( "CONSTRUCTOR_6ARGS" );
- G_CONSTRUCTOR__XARGS = GVarName( "CONSTRUCTOR_XARGS" );
  G_NEXT__CONSTRUCTOR__0ARGS = GVarName( "NEXT_CONSTRUCTOR_0ARGS" );
  G_NEXT__CONSTRUCTOR__1ARGS = GVarName( "NEXT_CONSTRUCTOR_1ARGS" );
  G_NEXT__CONSTRUCTOR__2ARGS = GVarName( "NEXT_CONSTRUCTOR_2ARGS" );
@@ -5420,7 +5417,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_NEXT__CONSTRUCTOR__4ARGS = GVarName( "NEXT_CONSTRUCTOR_4ARGS" );
  G_NEXT__CONSTRUCTOR__5ARGS = GVarName( "NEXT_CONSTRUCTOR_5ARGS" );
  G_NEXT__CONSTRUCTOR__6ARGS = GVarName( "NEXT_CONSTRUCTOR_6ARGS" );
- G_NEXT__CONSTRUCTOR__XARGS = GVarName( "NEXT_CONSTRUCTOR_XARGS" );
  G_Error = GVarName( "Error" );
  G_IS__IDENTICAL__OBJ = GVarName( "IS_IDENTICAL_OBJ" );
  G_TRY__NEXT__METHOD = GVarName( "TRY_NEXT_METHOD" );
@@ -5428,9 +5424,13 @@ static Int PostRestore ( StructInitInfo * module )
  G_METHODS__OPERATION = GVarName( "METHODS_OPERATION" );
  G_fail = GVarName( "fail" );
  G_LEN__LIST = GVarName( "LEN_LIST" );
+ G_METHOD__XARGS = GVarName( "METHOD_XARGS" );
+ G_NEXT__METHOD__XARGS = GVarName( "NEXT_METHOD_XARGS" );
  G_AttributeValueNotSet = GVarName( "AttributeValueNotSet" );
  G_TypeObj = GVarName( "TypeObj" );
  G_FamilyObj = GVarName( "FamilyObj" );
+ G_CONSTRUCTOR__XARGS = GVarName( "CONSTRUCTOR_XARGS" );
+ G_NEXT__CONSTRUCTOR__XARGS = GVarName( "NEXT_CONSTRUCTOR_XARGS" );
  
  /* record names used in handlers */
  

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -8,6 +8,8 @@ static GVar G_NAME__FUNC;
 static Obj  GF_NAME__FUNC;
 static GVar G_IsType;
 static Obj  GF_IsType;
+static GVar G_FLUSH__ALL__METHOD__CACHES;
+static Obj  GF_FLUSH__ALL__METHOD__CACHES;
 static GVar G_IS__REC;
 static Obj  GF_IS__REC;
 static GVar G_IS__LIST;
@@ -130,8 +132,6 @@ static GVar G_NEW__TYPE__NEXT__ID;
 static Obj  GC_NEW__TYPE__NEXT__ID;
 static GVar G_NEW__TYPE__ID__LIMIT;
 static Obj  GC_NEW__TYPE__ID__LIMIT;
-static GVar G_FLUSH__ALL__METHOD__CACHES;
-static Obj  GF_FLUSH__ALL__METHOD__CACHES;
 static GVar G_POS__NUMB__TYPE;
 static Obj  GC_POS__NUMB__TYPE;
 static GVar G_NEW__TYPE;
@@ -4122,6 +4122,7 @@ static Int PostRestore ( StructInitInfo * module )
  /* global variables used in handlers */
  G_NAME__FUNC = GVarName( "NAME_FUNC" );
  G_IsType = GVarName( "IsType" );
+ G_FLUSH__ALL__METHOD__CACHES = GVarName( "FLUSH_ALL_METHOD_CACHES" );
  G_IS__REC = GVarName( "IS_REC" );
  G_IS__LIST = GVarName( "IS_LIST" );
  G_ADD__LIST = GVarName( "ADD_LIST" );
@@ -4182,7 +4183,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_POS__FIRST__FREE__TYPE = GVarName( "POS_FIRST_FREE_TYPE" );
  G_NEW__TYPE__NEXT__ID = GVarName( "NEW_TYPE_NEXT_ID" );
  G_NEW__TYPE__ID__LIMIT = GVarName( "NEW_TYPE_ID_LIMIT" );
- G_FLUSH__ALL__METHOD__CACHES = GVarName( "FLUSH_ALL_METHOD_CACHES" );
  G_POS__NUMB__TYPE = GVarName( "POS_NUMB_TYPE" );
  G_NEW__TYPE = GVarName( "NEW_TYPE" );
  G_IsFamily = GVarName( "IsFamily" );
@@ -4267,6 +4267,7 @@ static Int InitKernel ( StructInitInfo * module )
  /* global variables used in handlers */
  InitFopyGVar( "NAME_FUNC", &GF_NAME__FUNC );
  InitFopyGVar( "IsType", &GF_IsType );
+ InitFopyGVar( "FLUSH_ALL_METHOD_CACHES", &GF_FLUSH__ALL__METHOD__CACHES );
  InitFopyGVar( "IS_REC", &GF_IS__REC );
  InitFopyGVar( "IS_LIST", &GF_IS__LIST );
  InitFopyGVar( "ADD_LIST", &GF_ADD__LIST );
@@ -4329,7 +4330,6 @@ static Int InitKernel ( StructInitInfo * module )
  InitCopyGVar( "POS_FIRST_FREE_TYPE", &GC_POS__FIRST__FREE__TYPE );
  InitCopyGVar( "NEW_TYPE_NEXT_ID", &GC_NEW__TYPE__NEXT__ID );
  InitCopyGVar( "NEW_TYPE_ID_LIMIT", &GC_NEW__TYPE__ID__LIMIT );
- InitFopyGVar( "FLUSH_ALL_METHOD_CACHES", &GF_FLUSH__ALL__METHOD__CACHES );
  InitCopyGVar( "POS_NUMB_TYPE", &GC_POS__NUMB__TYPE );
  InitFopyGVar( "NEW_TYPE", &GF_NEW__TYPE );
  InitFopyGVar( "IsFamily", &GF_IsFamily );

--- a/src/opers.c
+++ b/src/opers.c
@@ -449,48 +449,46 @@ static Int IsSubsetFlagsCalls2;
 *F  UncheckedIS_SUBSET_FLAGS( <flags1>, <flags2> ) subset test with
 *F                                                         no safety check
 */
-static Obj UncheckedIS_SUBSET_FLAGS (
-    Obj                 flags1,
-    Obj                 flags2 )
+static Obj UncheckedIS_SUBSET_FLAGS(Obj flags1, Obj flags2)
 {
-    Int                 len1;
-    Int                 len2;
-    UInt *              ptr1;
-    UInt *              ptr2;
-    Int                 i;
-    Obj                 trues;
+    Int    len1;
+    Int    len2;
+    UInt * ptr1;
+    UInt * ptr2;
+    Int    i;
+    Obj    trues;
 
-    /* do the real work                                                    */
+/* do the real work                                                    */
 #ifdef COUNT_OPERS
     IsSubsetFlagsCalls++;
 #endif
 
     /* first check the trues                                               */
     trues = TRUES_FLAGS(flags2);
-    if ( trues != 0 ) {
+    if (trues != 0) {
         len2 = LEN_PLIST(trues);
-	        if ( TRUES_FLAGS(flags1) != 0 ) {
-            if ( LEN_PLIST(TRUES_FLAGS(flags1)) < len2 ) {
+        if (TRUES_FLAGS(flags1) != 0) {
+            if (LEN_PLIST(TRUES_FLAGS(flags1)) < len2) {
 #ifdef COUNT_OPERS
                 IsSubsetFlagsCalls1++;
 #endif
                 return False;
             }
-	    } 
-        if ( len2 == 0 ) {
+        }
+        if (len2 == 0) {
             return True;
         }
-        if ( len2 < 3 ) {
+        if (len2 < 16) {
 #ifdef COUNT_OPERS
             IsSubsetFlagsCalls2++;
 #endif
-            if ( LEN_FLAGS(flags1) < INT_INTOBJ(ELM_PLIST(trues,len2)) ) {
+            if (LEN_FLAGS(flags1) < INT_INTOBJ(ELM_PLIST(trues, len2))) {
                 return False;
             }
-            for ( i = len2;  0 < i;  i-- ) {
-               if (ELM_FLAGS(flags1,INT_INTOBJ(ELM_PLIST(trues,i)))==False) {
-                   return False;
-               }
+            for (i = len2; 0 < i; i--) {
+                if (!C_ELM_FLAGS(flags1, INT_INTOBJ(ELM_PLIST(trues, i)))) {
+                    return False;
+                }
             }
             return True;
         }
@@ -502,22 +500,22 @@ static Obj UncheckedIS_SUBSET_FLAGS (
     ptr1 = BLOCKS_FLAGS(flags1);
     ptr2 = BLOCKS_FLAGS(flags2);
     if (len1 < len2) {
-      for (i = len2-1; i >= len1; i--) {
-	if (ptr2[i] != 0)
-	  return False;
-      }
-      for (i = len1-1; i >= 0; i--) {
-	UInt x = ptr2[i];
-	if ((x & ptr1[i]) != x)
-	  return False;
-      }
+        for (i = len2 - 1; i >= len1; i--) {
+            if (ptr2[i] != 0)
+                return False;
+        }
+        for (i = len1 - 1; i >= 0; i--) {
+            UInt x = ptr2[i];
+            if ((x & ptr1[i]) != x)
+                return False;
+        }
     }
     else {
-      for (i = len2-1; i >= 0; i--) {
-	UInt x = ptr2[i];
-	if ((x & ptr1[i]) != x)
-	  return False;
-      }
+        for (i = len2 - 1; i >= 0; i--) {
+            UInt x = ptr2[i];
+            if ((x & ptr1[i]) != x)
+                return False;
+        }
     }
     return True;
 }
@@ -1874,7 +1872,7 @@ static inline Obj TYPE_OBJ_FEO (
 #ifdef HPCGAP
 
 static pthread_mutex_t CacheLock;
-static UInt CacheSize;
+static UInt            CacheSize;
 
 static void LockCache(void)
 {
@@ -1890,25 +1888,23 @@ static void UnlockCache(void)
 
 #endif
 
-static inline Obj CacheOper (
-    Obj                 oper,
-    UInt                i )
+static inline Obj CacheOper(Obj oper, UInt i)
 {
-    Obj cache = CACHE_OPER( oper, i );
+    Obj  cache = CACHE_OPER(oper, i);
     UInt len;
 
 #ifdef HPCGAP
     UInt cacheIndex;
 
-    if ( cache == 0 ) {
+    if (cache == 0) {
         /* This is a safe form of double-checked locking, because
          * the cache value is not a reference. */
         LockCache();
-        cache = CACHE_OPER( oper, i );
-        if (cache == 0 ) {
+        cache = CACHE_OPER(oper, i);
+        if (cache == 0) {
             CacheSize++;
             cacheIndex = CacheSize;
-            CACHE_OPER( oper, i ) = INTOBJ_INT(cacheIndex);
+            CACHE_OPER(oper, i) = INTOBJ_INT(cacheIndex);
         }
         else
             cacheIndex = INT_INTOBJ(cache);
@@ -1931,17 +1927,17 @@ static inline Obj CacheOper (
     cache = ELM_PLIST(STATE(MethodCache), cacheIndex);
 #endif
 
-    if ( cache == 0 ) {
-        len = (i < 7 ? CACHE_SIZE * (i+2) : CACHE_SIZE * (1+2));
-        cache = NEW_PLIST( T_PLIST, len);
-        SET_LEN_PLIST( cache, len ); 
-#       ifdef HPCGAP
-            SET_ELM_PLIST( STATE(MethodCache), cacheIndex, cache );
-            CHANGED_BAG( STATE(MethodCache) );
-#       else
-            CACHE_OPER( oper, i ) = cache;
-            CHANGED_BAG( oper );
-#       endif
+    if (cache == 0) {
+        len = (i < 7 ? CACHE_SIZE * (i + 2) : CACHE_SIZE * (1 + 2));
+        cache = NEW_PLIST(T_PLIST, len);
+        SET_LEN_PLIST(cache, len);
+#ifdef HPCGAP
+        SET_ELM_PLIST(STATE(MethodCache), cacheIndex, cache);
+        CHANGED_BAG(STATE(MethodCache));
+#else
+        CACHE_OPER(oper, i) = cache;
+        CHANGED_BAG(oper);
+#endif
     }
 
     return cache;
@@ -1950,19 +1946,18 @@ static inline Obj CacheOper (
 
 #ifdef HPCGAP
 
-#define GET_METHOD_CACHE( oper, i ) \
-  ( STATE(MethodCacheItems)[INT_INTOBJ( CACHE_OPER ( oper, i ))] )
+#define GET_METHOD_CACHE(oper, i)                                            \
+    (STATE(MethodCacheItems)[INT_INTOBJ(CACHE_OPER(oper, i))])
 
 #else
 
-#define GET_METHOD_CACHE( oper, i ) \
-    CACHE_OPER( oper, i )
+#define GET_METHOD_CACHE(oper, i) CACHE_OPER(oper, i)
 
 #endif
 
-/* This function actually searches the cache. Normally it should be called with 
+/* This function actually searches the cache. Normally it should be called
+   with
    n a compile-time constant to allow the optimiser to tidy things up */
-
 
 
 static inline Obj __attribute__((always_inline))
@@ -2019,7 +2014,7 @@ CacheMethod(Obj oper, UInt n, Obj prec, Obj * ids, Obj method)
 
 /* These will contain the GAP method selection functions */
 static Obj MethodSelectors[2][7];
-static Obj VerboseMethodSelectors[2][7];					
+static Obj VerboseMethodSelectors[2][7];
 
 static inline Obj __attribute__((always_inline))
 GetMethodUncached(UInt n, Obj oper, Obj prec, Obj types[], Obj selectors[][7])
@@ -2039,15 +2034,15 @@ GetMethodUncached(UInt n, Obj oper, Obj prec, Obj types[], Obj selectors[][7])
             method = CALL_3ARGS(selectors[0][2], oper, types[0], types[1]);
             break;
         case 3:
-            method =
-                CALL_4ARGS(selectors[0][3], oper, types[0], types[1], types[2]);
+            method = CALL_4ARGS(selectors[0][3], oper, types[0], types[1],
+                                types[2]);
             break;
         case 4:
             method = CALL_5ARGS(selectors[0][4], oper, types[0], types[1],
                                 types[2], types[3]);
             break;
         case 5:
-	  method = CALL_6ARGS(selectors[0][5], oper, types[0], types[1],
+            method = CALL_6ARGS(selectors[0][5], oper, types[0], types[1],
                                 types[2], types[3], types[4]);
             break;
         case 6:
@@ -2079,7 +2074,7 @@ GetMethodUncached(UInt n, Obj oper, Obj prec, Obj types[], Obj selectors[][7])
                                 types[1], types[2]);
             break;
         case 4:
-	  method = CALL_6ARGS(selectors[1][4], oper, prec, types[0],
+            method = CALL_6ARGS(selectors[1][4], oper, prec, types[0],
                                 types[1], types[2], types[3]);
             break;
         case 5:
@@ -2091,8 +2086,7 @@ GetMethodUncached(UInt n, Obj oper, Obj prec, Obj types[], Obj selectors[][7])
             for (i = 0; i < n; i++)
                 SET_ELM_PLIST(margs, 3 + i, types[i]);
             SET_LEN_PLIST(margs, n + 2);
-            method =
-                CALL_XARGS(selectors[1][n], margs);
+            method = CALL_XARGS(selectors[1][n], margs);
             break;
         default:
             GAP_ASSERT(0);
@@ -2108,17 +2102,18 @@ static Int OperationNext;
 #endif
 
 
-static inline Obj __attribute__((always_inline)) DoOperationNArgs(Obj  oper,
-                                                                  UInt n,
-								  Obj  selectors[2][7],
-								  UInt verbose,
-								  UInt constructor,
-                                                                  Obj  arg1,
-                                                                  Obj  arg2,
-                                                                  Obj  arg3,
-                                                                  Obj  arg4,
-                                                                  Obj  arg5,
-                                                                  Obj  arg6)
+static inline Obj __attribute__((always_inline))
+DoOperationNArgs(Obj  oper,
+                 UInt n,
+                 Obj  selectors[2][7],
+                 UInt verbose,
+                 UInt constructor,
+                 Obj  arg1,
+                 Obj  arg2,
+                 Obj  arg3,
+                 Obj  arg4,
+                 Obj  arg5,
+                 Obj  arg6)
 {
     Obj types[n];
     Obj ids[n];
@@ -2140,18 +2135,19 @@ static inline Obj __attribute__((always_inline)) DoOperationNArgs(Obj  oper,
     case 2:
         types[1] = TYPE_OBJ_FEO(arg2);
     case 1:
-      if (constructor) {
-	while (!IS_OPERATION(arg1))
-	  {
-	    arg1 = ErrorReturnObj(
-				  "Constructor: the first argument must be a filter not a %s",
-				  (Int)TNAM_OBJ(arg1), 0L, 
-				  "you can replace the first argument <arg1> via 'return <arg1>;'");
-	  }
-	
-	types[0] = FLAGS_FILT( arg1 );
-      } else
-        types[0] = TYPE_OBJ_FEO(arg1);
+        if (constructor) {
+            while (!IS_OPERATION(arg1)) {
+                arg1 = ErrorReturnObj("Constructor: the first argument must "
+                                      "be a filter not a %s",
+                                      (Int)TNAM_OBJ(arg1), 0L,
+                                      "you can replace the first argument "
+                                      "<arg1> via 'return <arg1>;'");
+            }
+
+            types[0] = FLAGS_FILT(arg1);
+        }
+        else
+            types[0] = TYPE_OBJ_FEO(arg1);
     case 0:
         break;
     default:
@@ -2159,12 +2155,12 @@ static inline Obj __attribute__((always_inline)) DoOperationNArgs(Obj  oper,
     }
 
     if (n > 0) {
-      if (constructor)
-	ids[0] = types[0];
-      else
-	ids[0] = ID_TYPE(types[0]);
+        if (constructor)
+            ids[0] = types[0];
+        else
+            ids[0] = ID_TYPE(types[0]);
     }
-    
+
     for (UInt i = 1; i < n; i++)
         ids[i] = ID_TYPE(types[i]);
 
@@ -2174,22 +2170,22 @@ static inline Obj __attribute__((always_inline)) DoOperationNArgs(Obj  oper,
         prec = INTOBJ_INT(INT_INTOBJ(prec) + 1);
         /* Is there a method in the cache */
         method = verbose ? 0 : GetMethodCached(oper, n, prec, ids);
-	
+
 #ifdef COUNT_OPERS
-	if (method)
-	  OperationHit++;
-	else 
-	  OperationMiss++;
+        if (method)
+            OperationHit++;
+        else
+            OperationMiss++;
 #endif
 
         /* otherwise try to find one in the list of methods */
         if (!method) {
-	  method = GetMethodUncached(n, oper, prec, types, selectors);
-	          /* update the cache */
-	  if (!verbose && method)
-	    CacheMethod(oper, n, prec, ids, method);
-	}
-	
+            method = GetMethodUncached(n, oper, prec, types, selectors);
+            /* update the cache */
+            if (!verbose && method)
+                CacheMethod(oper, n, prec, ids, method);
+        }
+
         if (!method) {
             ErrorQuit("no method returned", 0L, 0L);
         }
@@ -2220,8 +2216,8 @@ static inline Obj __attribute__((always_inline)) DoOperationNArgs(Obj  oper,
                 GAP_ASSERT(0);
             }
             while (method == Fail)
-                method = CallHandleMethodNotFound(oper, n, (Obj *)args, verbose, constructor,
-                                                  prec);
+                method = CallHandleMethodNotFound(oper, n, (Obj *)args,
+                                                  verbose, constructor, prec);
         }
 
         /* call this method */
@@ -2257,52 +2253,55 @@ static inline Obj __attribute__((always_inline)) DoOperationNArgs(Obj  oper,
 
 Obj DoOperation0Args(Obj oper)
 {
-  return DoOperationNArgs(oper, 0, MethodSelectors, 0, 0, 0, 0, 0, 0, 0, 0);
+    return DoOperationNArgs(oper, 0, MethodSelectors, 0, 0, 0, 0, 0, 0, 0, 0);
 }
 
 Obj DoOperation1Args(Obj oper, Obj arg1)
 {
-    return DoOperationNArgs(oper, 1, MethodSelectors, 0, 0, arg1, 0, 0, 0, 0, 0);
+    return DoOperationNArgs(oper, 1, MethodSelectors, 0, 0, arg1, 0, 0, 0, 0,
+                            0);
 }
 
 Obj DoOperation2Args(Obj oper, Obj arg1, Obj arg2)
 {
-    return DoOperationNArgs(oper, 2, MethodSelectors, 0, 0, arg1, arg2, 0, 0, 0, 0);
+    return DoOperationNArgs(oper, 2, MethodSelectors, 0, 0, arg1, arg2, 0, 0,
+                            0, 0);
 }
 
 Obj DoOperation3Args(Obj oper, Obj arg1, Obj arg2, Obj arg3)
 {
-    return DoOperationNArgs(oper, 3, MethodSelectors, 0, 0, arg1, arg2, arg3, 0, 0, 0);
+    return DoOperationNArgs(oper, 3, MethodSelectors, 0, 0, arg1, arg2, arg3,
+                            0, 0, 0);
 }
 
 Obj DoOperation4Args(Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
 {
-    return DoOperationNArgs(oper, 4, MethodSelectors, 0, 0, arg1, arg2, arg3, arg4, 0, 0);
+    return DoOperationNArgs(oper, 4, MethodSelectors, 0, 0, arg1, arg2, arg3,
+                            arg4, 0, 0);
 }
 
 Obj DoOperation5Args(
     Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5)
 {
-    return DoOperationNArgs(oper, 5, MethodSelectors, 0, 0, arg1, arg2, arg3, arg4, arg5, 0);
+    return DoOperationNArgs(oper, 5, MethodSelectors, 0, 0, arg1, arg2, arg3,
+                            arg4, arg5, 0);
 }
 
 Obj DoOperation6Args(
     Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5, Obj arg6)
 {
-    return DoOperationNArgs(oper, 6, MethodSelectors, 0, 0, arg1, arg2, arg3, arg4, arg5, arg6);
+    return DoOperationNArgs(oper, 6, MethodSelectors, 0, 0, arg1, arg2, arg3,
+                            arg4, arg5, arg6);
 }
-
 
 
 /****************************************************************************
 **
 **  DoOperationXArgs( <oper>, ... )
 */
-Obj DoOperationXArgs (
-    Obj                 self,
-    Obj                 args )
+Obj DoOperationXArgs(Obj self, Obj args)
 {
-    ErrorQuit("sorry: cannot yet have X argument operations",0L,0L);
+    ErrorQuit("sorry: cannot yet have X argument operations", 0L, 0L);
     return 0;
 }
 
@@ -2311,82 +2310,58 @@ Obj DoOperationXArgs (
 **
 **  DoVerboseOperation0Args( <oper> )
 */
-Obj DoVerboseOperation0Args (
-    Obj                 oper )
+Obj DoVerboseOperation0Args(Obj oper)
 {
-  return DoOperationNArgs( oper, 0, VerboseMethodSelectors, 1, 0, 0, 0, 0, 0, 0, 0);
+    return DoOperationNArgs(oper, 0, VerboseMethodSelectors, 1, 0, 0, 0, 0, 0,
+                            0, 0);
 }
 
-Obj DoVerboseOperation1Args (
-			     Obj                 oper,
-			     Obj arg1)
+Obj DoVerboseOperation1Args(Obj oper, Obj arg1)
 {
-  return DoOperationNArgs( oper, 1, VerboseMethodSelectors, 1, 0, arg1, 0, 0, 0, 0, 0);
+    return DoOperationNArgs(oper, 1, VerboseMethodSelectors, 1, 0, arg1, 0, 0,
+                            0, 0, 0);
 }
 
-Obj DoVerboseOperation2Args (
-			     Obj                 oper,
-			     Obj arg1,
-			     Obj arg2)
+Obj DoVerboseOperation2Args(Obj oper, Obj arg1, Obj arg2)
 {
-  return DoOperationNArgs( oper, 2, VerboseMethodSelectors, 1, 0, arg1, arg2, 0, 0, 0, 0);
+    return DoOperationNArgs(oper, 2, VerboseMethodSelectors, 1, 0, arg1, arg2,
+                            0, 0, 0, 0);
 }
 
-Obj DoVerboseOperation3Args (
-			     Obj                 oper,
-			     Obj arg1,
-			     Obj arg2,
-			     Obj arg3
-			     )
+Obj DoVerboseOperation3Args(Obj oper, Obj arg1, Obj arg2, Obj arg3)
 {
-  return DoOperationNArgs( oper, 3, VerboseMethodSelectors, 1, 0, arg1, arg2, arg3, 0, 0, 0);
+    return DoOperationNArgs(oper, 3, VerboseMethodSelectors, 1, 0, arg1, arg2,
+                            arg3, 0, 0, 0);
 }
 
-Obj DoVerboseOperation4Args (
-			     Obj                 oper,
-			     Obj arg1,
-			     Obj arg2,
-			     Obj arg3,
-			     Obj arg4
-			    )
+Obj DoVerboseOperation4Args(Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
 {
-  return DoOperationNArgs( oper, 4, VerboseMethodSelectors, 1, 0, arg1, arg2, arg3, arg4, 0, 0);
+    return DoOperationNArgs(oper, 4, VerboseMethodSelectors, 1, 0, arg1, arg2,
+                            arg3, arg4, 0, 0);
 }
 
-Obj DoVerboseOperation5Args (
-			     Obj                 oper,
-			     Obj arg1,
-			     Obj arg2,
-			     Obj arg3,
-			     Obj arg4,
-			     Obj arg5
-			     )
+Obj DoVerboseOperation5Args(
+    Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5)
 {
-  return DoOperationNArgs( oper, 5, VerboseMethodSelectors, 1, 0, arg1, arg2, arg3, arg4, arg5, 0);
+    return DoOperationNArgs(oper, 5, VerboseMethodSelectors, 1, 0, arg1, arg2,
+                            arg3, arg4, arg5, 0);
 }
 
-Obj DoVerboseOperation6Args (Obj oper,
-			     Obj arg1,
-			     Obj arg2,
-			     Obj arg3,
-			     Obj arg4,
-			     Obj arg5,
-			     Obj arg6)
+Obj DoVerboseOperation6Args(
+    Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5, Obj arg6)
 {
-  return DoOperationNArgs( oper, 6, VerboseMethodSelectors, 1, 0, arg1, arg2, arg3, arg4, arg5, arg6);
+    return DoOperationNArgs(oper, 6, VerboseMethodSelectors, 1, 0, arg1, arg2,
+                            arg3, arg4, arg5, arg6);
 }
-
 
 
 /****************************************************************************
 **
 **  DoVerboseOperationXArgs( <oper>, ... )
 */
-Obj DoVerboseOperationXArgs (
-    Obj                 self,
-    Obj                 args )
+Obj DoVerboseOperationXArgs(Obj self, Obj args)
 {
-    ErrorQuit("sorry: cannot yet have X argument operations",0L,0L);
+    ErrorQuit("sorry: cannot yet have X argument operations", 0L, 0L);
     return 0;
 }
 
@@ -2395,16 +2370,12 @@ Obj DoVerboseOperationXArgs (
 **
 *F  NewOperation( <name>, <narg>, <nams>, <hdlr> )
 */
-Obj NewOperation (
-    Obj                 name,
-    Int                 narg,
-    Obj                 nams,
-    ObjFunc             hdlr )
+Obj NewOperation(Obj name, Int narg, Obj nams, ObjFunc hdlr)
 {
-    Obj                 oper;
+    Obj oper;
 
     /* create the function                                                 */
-    oper = NewFunctionT( T_FUNCTION, SIZE_OPER, name, narg, nams, hdlr );
+    oper = NewFunctionT(T_FUNCTION, SIZE_OPER, name, narg, nams, hdlr);
 
     /* enter the handlers                                                  */
     SET_HDLR_FUNC(oper, 0, DoOperation0Args);
@@ -2418,7 +2389,7 @@ Obj NewOperation (
 
     /* reenter the given handler */
     if (narg != -1)
-      SET_HDLR_FUNC(oper, narg, hdlr);
+        SET_HDLR_FUNC(oper, narg, hdlr);
 
     /*N 1996/06/06 mschoene this should not be done here                   */
     FLAG1_FILT(oper) = INTOBJ_INT(0);
@@ -2426,7 +2397,7 @@ Obj NewOperation (
     FLAGS_FILT(oper) = False;
     SETTR_FILT(oper) = False;
     TESTR_FILT(oper) = False;
-    
+
     /* This isn't an attribute (yet) */
     SET_ENABLED_ATTR(oper, 0);
 
@@ -2451,85 +2422,58 @@ Obj VerboseConstructorSelectors[2][7];
 */
 
 
-
-Obj DoConstructor0Args (
-    Obj                 oper )
+Obj DoConstructor0Args(Obj oper)
 {
-  return DoOperationNArgs(oper, 0, ConstructorSelectors, 0, 1, 0, 0, 0, 0, 0, 0);
+    return DoOperationNArgs(oper, 0, ConstructorSelectors, 0, 1, 0, 0, 0, 0,
+                            0, 0);
 }
 
-Obj DoConstructor1Args (
-			Obj                 oper,
-			Obj arg1 )
+Obj DoConstructor1Args(Obj oper, Obj arg1)
 {
-  return DoOperationNArgs(oper, 1, ConstructorSelectors, 0, 1, arg1, 0, 0, 0, 0, 0);
+    return DoOperationNArgs(oper, 1, ConstructorSelectors, 0, 1, arg1, 0, 0,
+                            0, 0, 0);
 }
 
-Obj DoConstructor2Args (
-			Obj                 oper,
-			Obj arg1,
-			Obj arg2 )
+Obj DoConstructor2Args(Obj oper, Obj arg1, Obj arg2)
 {
-  return DoOperationNArgs(oper, 2, ConstructorSelectors, 0, 1, arg1, arg2, 0, 0, 0, 0);
+    return DoOperationNArgs(oper, 2, ConstructorSelectors, 0, 1, arg1, arg2,
+                            0, 0, 0, 0);
 }
 
-Obj DoConstructor3Args (
-			Obj                 oper,
-			Obj arg1,
-			Obj arg2,
-			Obj arg3
-			)
+Obj DoConstructor3Args(Obj oper, Obj arg1, Obj arg2, Obj arg3)
 {
-  return DoOperationNArgs(oper, 3, ConstructorSelectors, 0, 1, arg1, arg2, arg3, 0, 0, 0);
+    return DoOperationNArgs(oper, 3, ConstructorSelectors, 0, 1, arg1, arg2,
+                            arg3, 0, 0, 0);
 }
 
-Obj DoConstructor4Args (
-			Obj                 oper,
-			Obj arg1,
-			Obj arg2,
-			Obj arg3,
-			Obj arg4
-			)
+Obj DoConstructor4Args(Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
 {
-  return DoOperationNArgs(oper, 4, ConstructorSelectors, 0, 1, arg1, arg2, arg3, arg4, 0, 0);
+    return DoOperationNArgs(oper, 4, ConstructorSelectors, 0, 1, arg1, arg2,
+                            arg3, arg4, 0, 0);
 }
 
-Obj DoConstructor5Args (
-			Obj                 oper,
-			Obj arg1,
-			Obj arg2,
-			Obj arg3,
-			Obj arg4,
-			Obj arg5
-			)
+Obj DoConstructor5Args(
+    Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5)
 {
-  return DoOperationNArgs(oper, 5, ConstructorSelectors, 0, 1, arg1, arg2, arg3, arg4, arg5, 0);
+    return DoOperationNArgs(oper, 5, ConstructorSelectors, 0, 1, arg1, arg2,
+                            arg3, arg4, arg5, 0);
 }
 
-Obj DoConstructor6Args (
-			Obj                 oper,
-			Obj arg1,
-			Obj arg2,
-			Obj arg3,
-			Obj arg4,
-			Obj arg5,
-			Obj arg6
-			)
+Obj DoConstructor6Args(
+    Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5, Obj arg6)
 {
-  return DoOperationNArgs(oper, 6, ConstructorSelectors, 0, 1, arg1, arg2, arg3, arg4, arg5, arg6);
+    return DoOperationNArgs(oper, 6, ConstructorSelectors, 0, 1, arg1, arg2,
+                            arg3, arg4, arg5, arg6);
 }
-
 
 
 /****************************************************************************
 **
 **  DoConstructorXArgs( <oper>, ... )
 */
-Obj DoConstructorXArgs (
-    Obj                 self,
-    Obj                 args )
+Obj DoConstructorXArgs(Obj self, Obj args)
 {
-    ErrorQuit("sorry: cannot yet have X argument constructors",0L,0L);
+    ErrorQuit("sorry: cannot yet have X argument constructors", 0L, 0L);
     return 0;
 }
 
@@ -2538,84 +2482,59 @@ Obj DoConstructorXArgs (
 **  DoVerboseConstructor0Args( <oper> )
 */
 
-Obj DoVerboseConstructor0Args (
-    Obj                 oper )
+Obj DoVerboseConstructor0Args(Obj oper)
 {
-  return DoOperationNArgs(oper, 0, VerboseConstructorSelectors, 1, 1, 0, 0, 0, 0, 0, 0);
+    return DoOperationNArgs(oper, 0, VerboseConstructorSelectors, 1, 1, 0, 0,
+                            0, 0, 0, 0);
 }
 
-Obj DoVerboseConstructor1Args (
-			Obj                 oper,
-			Obj arg1 )
+Obj DoVerboseConstructor1Args(Obj oper, Obj arg1)
 {
-  return DoOperationNArgs(oper, 1, VerboseConstructorSelectors, 1, 1, arg1, 0, 0, 0, 0, 0);
+    return DoOperationNArgs(oper, 1, VerboseConstructorSelectors, 1, 1, arg1,
+                            0, 0, 0, 0, 0);
 }
 
-Obj DoVerboseConstructor2Args (
-			Obj                 oper,
-			Obj arg1,
-			Obj arg2 )
+Obj DoVerboseConstructor2Args(Obj oper, Obj arg1, Obj arg2)
 {
-  return DoOperationNArgs(oper, 2, VerboseConstructorSelectors, 1, 1, arg1, arg2, 0, 0, 0, 0);
+    return DoOperationNArgs(oper, 2, VerboseConstructorSelectors, 1, 1, arg1,
+                            arg2, 0, 0, 0, 0);
 }
 
-Obj DoVerboseConstructor3Args (
-			Obj                 oper,
-			Obj arg1,
-			Obj arg2,
-			Obj arg3
-			)
+Obj DoVerboseConstructor3Args(Obj oper, Obj arg1, Obj arg2, Obj arg3)
 {
-  return DoOperationNArgs(oper, 3, VerboseConstructorSelectors, 1, 1, arg1, arg2, arg3, 0, 0, 0);
+    return DoOperationNArgs(oper, 3, VerboseConstructorSelectors, 1, 1, arg1,
+                            arg2, arg3, 0, 0, 0);
 }
 
-Obj DoVerboseConstructor4Args (
-			Obj                 oper,
-			Obj arg1,
-			Obj arg2,
-			Obj arg3,
-			Obj arg4
-			)
+Obj DoVerboseConstructor4Args(
+    Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
 {
-  return DoOperationNArgs(oper, 4, VerboseConstructorSelectors, 1, 1, arg1, arg2, arg3, arg4, 0, 0);
+    return DoOperationNArgs(oper, 4, VerboseConstructorSelectors, 1, 1, arg1,
+                            arg2, arg3, arg4, 0, 0);
 }
 
-Obj DoVerboseConstructor5Args (
-			Obj                 oper,
-			Obj arg1,
-			Obj arg2,
-			Obj arg3,
-			Obj arg4,
-			Obj arg5
-			)
+Obj DoVerboseConstructor5Args(
+    Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5)
 {
-  return DoOperationNArgs(oper, 5, VerboseConstructorSelectors, 1, 1, arg1, arg2, arg3, arg4, arg5, 0);
+    return DoOperationNArgs(oper, 5, VerboseConstructorSelectors, 1, 1, arg1,
+                            arg2, arg3, arg4, arg5, 0);
 }
 
-Obj DoVerboseConstructor6Args (
-			Obj                 oper,
-			Obj arg1,
-			Obj arg2,
-			Obj arg3,
-			Obj arg4,
-			Obj arg5,
-			Obj arg6
-			)
+Obj DoVerboseConstructor6Args(
+    Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5, Obj arg6)
 {
-  return DoOperationNArgs(oper, 6, VerboseConstructorSelectors, 1, 1, arg1, arg2, arg3, arg4, arg5, arg6);
+    return DoOperationNArgs(oper, 6, VerboseConstructorSelectors, 1, 1, arg1,
+                            arg2, arg3, arg4, arg5, arg6);
 }
-
 
 
 /****************************************************************************
 **
 **  DoVerboseConstructorXArgs( <oper>, ... )
 */
-Obj DoVerboseConstructorXArgs (
-    Obj                 self,
-    Obj                 args )
+Obj DoVerboseConstructorXArgs(Obj self, Obj args)
 {
-    ErrorQuit("sorry: cannot yet have X argument constructors",0L,0L);
+    ErrorQuit("sorry: cannot yet have X argument constructors", 0L, 0L);
     return 0;
 }
 

--- a/src/opers.h
+++ b/src/opers.h
@@ -120,7 +120,7 @@ extern Obj TRY_NEXT_METHOD;
 *F  SIZE_PLEN_FLAGS( <plen> ) . .  size for a flags list with physical length
 */
 #define SIZE_PLEN_FLAGS(plen) \
-  (4*sizeof(Obj)+((plen)+BIPEB-1)/BIPEB*sizeof(Obj))
+  (4*sizeof(Obj)+(((plen)+BIPEB-1) >> LBIPEB)*sizeof(Obj))
 
 
 
@@ -186,7 +186,7 @@ extern Obj TRY_NEXT_METHOD;
 **
 *F  NRB_FLAGS( <flags> )  . . . . . .  number of basic blocks of a flags lits
 */
-#define NRB_FLAGS(flags)                ((LEN_FLAGS(flags)+BIPEB-1)/BIPEB)
+#define NRB_FLAGS(flags)                ((LEN_FLAGS(flags)+BIPEB-1) >> LBIPEB)
 
 
 
@@ -209,7 +209,7 @@ extern Obj TRY_NEXT_METHOD;
 **  Note that 'BLOCK_ELM_FLAGS' is a macro, so do not call it  with arguments
 **  that have side effects.
 */
-#define BLOCK_ELM_FLAGS(list, pos)      (BLOCKS_FLAGS(list)[((pos)-1)/BIPEB])
+#define BLOCK_ELM_FLAGS(list, pos)      (BLOCKS_FLAGS(list)[((pos)-1) >> LBIPEB])
 
 
 /****************************************************************************
@@ -222,7 +222,7 @@ extern Obj TRY_NEXT_METHOD;
 **  Note that 'MASK_POS_FLAGS'  is a macro, so  do not call it with arguments
 **  that have side effects.
 */
-#define MASK_POS_FLAGS(pos)             (((UInt) 1)<<((pos)-1)%BIPEB)
+#define MASK_POS_FLAGS(pos)             (((UInt) 1)<<(((pos)-1) & (BIPEB-1)))
 
 
 /****************************************************************************
@@ -235,9 +235,14 @@ extern Obj TRY_NEXT_METHOD;
 **
 **  Note that 'ELM_FLAGS' is a macro, so do not call it  with arguments  that
 **  have side effects.
+**
+**  C_ELM_FLAGS returns a result more convenient for use inside the kernel
+**  since the C compiler can't know that True != False.
 */
-#define ELM_FLAGS(list,pos) \
-  ((BLOCK_ELM_FLAGS(list,pos) & MASK_POS_FLAGS(pos)) ?  True : False)
+#define C_ELM_FLAGS(list, pos)                                               \
+    ((BLOCK_ELM_FLAGS(list, pos) & MASK_POS_FLAGS(pos)) ? 1 : 0)
+
+#define ELM_FLAGS(list, pos) (C_ELM_FLAGS(list, pos) ? True : False)
 
 
 /****************************************************************************

--- a/src/opers.h
+++ b/src/opers.h
@@ -236,8 +236,9 @@ extern Obj TRY_NEXT_METHOD;
 **  Note that 'ELM_FLAGS' is a macro, so do not call it  with arguments  that
 **  have side effects.
 **
-**  C_ELM_FLAGS returns a result more convenient for use inside the kernel
-**  since the C compiler can't know that True != False.
+**  C_ELM_FLAGS returns a result which it is better to use inside the kernel
+**  since the C compiler can't know that True != False. Using C_ELM_FLAGS
+**  gives slightly nicer C code and potential for a little more optimisation.
 */
 #define C_ELM_FLAGS(list, pos)                                               \
     ((BLOCK_ELM_FLAGS(list, pos) & MASK_POS_FLAGS(pos)) ? 1 : 0)

--- a/src/system.h
+++ b/src/system.h
@@ -211,11 +211,10 @@ typedef Bag Obj;
 **
 **  'BIPEB' is the  number of bits  per  block, where a  block  fills a UInt,
 **  which must be the same size as a bag identifier.
+**  'LBIPEB' is the log to the base 2 of BIPEB
 **
 */
-enum {
-    BIPEB =  sizeof(UInt) * 8L
-};
+enum { BIPEB = sizeof(UInt) * 8L, LBIPEB = (BIPEB == 64) ? 6L : 5L };
 
 
 /****************************************************************************


### PR DESCRIPTION
This PR refactors a lot of code in opers.c and makes some small changes that improve performance (especially in IS_SUBSET_FLAGS). The main aim is to reduce code duplication and allow the compiler to do the work instead. It depends for performance on a C compiler that will inline and do a LOT of contstant folding.

A major goal was to get all the logic for method selection including the cache in just one place, without repetition, which is now achieved. This should make it easier to experiment with alternative cache layouts and algorithms.