### PR TITLE
Fix IsomorphismPartialPermSemigroup and Monoid for perm groups with 0 generators

### DIFF
--- a/lib/semipperm.gi
+++ b/lib/semipperm.gi
@@ -356,7 +356,11 @@ function(G)
   local dom, S;
 
   dom := MovedPoints(G);
-  S := InverseMonoid(List(GeneratorsOfGroup(G), p -> AsPartialPerm(p, dom)));
+  if IsEmpty(GeneratorsOfGroup(G)) then
+    S := InverseMonoid(EmptyPartialPerm());
+  else
+    S := InverseMonoid(List(GeneratorsOfGroup(G), p -> AsPartialPerm(p, dom)));
+  fi;
   UseIsomorphismRelation(G, S);
   SetIsGroupAsSemigroup(S, true);
 
@@ -373,8 +377,12 @@ function(G)
   local dom, S;
 
   dom := MovedPoints(G);
-  S := InverseSemigroup(List(GeneratorsOfGroup(G), 
-                             p -> AsPartialPerm(p, dom)));
+  if IsEmpty(GeneratorsOfGroup(G)) then
+    S := InverseSemigroup(EmptyPartialPerm());
+  else
+    S := InverseSemigroup(List(GeneratorsOfGroup(G),
+                               p -> AsPartialPerm(p, dom)));
+  fi;
   UseIsomorphismRelation(G, S);
   SetIsGroupAsSemigroup(S, true);
 

--- a/tst/testbugfix/2017-10-19-IsomorphismPartialPermSemigroup.tst
+++ b/tst/testbugfix/2017-10-19-IsomorphismPartialPermSemigroup.tst
@@ -1,0 +1,27 @@
+# Issue related to IsomorphismPartialPermSemigroup and
+# IsomorphismPartialPermMonoid for a trivial perm group with 0 generators
+# Examples reported on issue #1783 on github.com/gap-system/gap
+gap> iso := [];;
+gap> iso[1] := IsomorphismPartialPermSemigroup(SymmetricGroup(1));
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
+  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+gap> iso[2] := IsomorphismPartialPermSemigroup(Group([()]));
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
+  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+gap> iso[3] := IsomorphismPartialPermSemigroup(Group([], ()));
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
+  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+gap> iso[4] := IsomorphismPartialPermMonoid(SymmetricGroup(1));
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
+  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+gap> iso[5] := IsomorphismPartialPermMonoid(Group([()]));
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
+  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+gap> iso[6] := IsomorphismPartialPermMonoid(Group([], ()));
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
+  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+gap> ForAll(iso, map -> () ^ map = EmptyPartialPerm());
+true
+gap> inv := List(iso, InverseGeneralMapping);;
+gap> ForAll(inv, map -> EmptyPartialPerm() ^ map = ());
+true

--- a/tst/testinstall/semipperm.tst
+++ b/tst/testinstall/semipperm.tst
@@ -333,8 +333,36 @@ gap> BruteForceIsoCheck(last);
 true
 gap> BruteForceInverseCheck(last2);
 true
+gap> IsomorphismPartialPermSemigroup(Group([()]));
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
+  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+gap> BruteForceIsoCheck(last);
+true
+gap> BruteForceInverseCheck(last2);
+true
+gap> IsomorphismPartialPermSemigroup(Group([], ()));
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
+  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+gap> BruteForceIsoCheck(last);
+true
+gap> BruteForceInverseCheck(last2);
+true
 gap> IsomorphismPartialPermMonoid(Group((1,2,3)));
 MappingByFunction( Group([ (1,2,3) ]), <partial perm group of rank 3 with
+  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+gap> BruteForceIsoCheck(last);
+true
+gap> BruteForceInverseCheck(last2);
+true
+gap> IsomorphismPartialPermMonoid(Group([()]));
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
+  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+gap> BruteForceIsoCheck(last);
+true
+gap> BruteForceInverseCheck(last2);
+true
+gap> IsomorphismPartialPermMonoid(Group([], ()));
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
   1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> BruteForceIsoCheck(last);
 true


### PR DESCRIPTION
This resolves #1783. Previously, these methods encountered unexpected errors for perm groups with 0 generators. This adds a special case for such groups.