### PR TITLE
Fix DisplaySemigroup for transformation semigroups

### DIFF
--- a/doc/ref/semigrp.xml
+++ b/doc/ref/semigrp.xml
@@ -206,6 +206,7 @@ The following functions deal with quotient semigroups in &GAP;.
 <#Include Label="GroupHClassOfGreensDClass">
 <#Include Label="IsGroupHClass">
 <#Include Label="IsRegularDClass">
+<#Include Label="DisplaySemigroup">
 
 </Section>
 

--- a/lib/semigrp.gd
+++ b/lib/semigrp.gd
@@ -537,24 +537,26 @@ DeclareProperty("IsInverseSemigroup", IsSemigroup);
 ##
 #O  DisplaySemigroup( <S> )
 ##
+##  <#GAPDoc Label="DisplaySemigroup">
 ##  <ManSection>
 ##  <Oper Name="DisplaySemigroup" Arg='S'/>
 ##
 ##  <Description>
-##  Produces a convenient display of a semigroup's DClass
-##  structure.   Let <A>S</A> have degree <M>n</M>.   Then for each <M>r\leq n</M>, we
-##  show all D classes of rank <M>n</M>.   
+##  Produces a convenient display of a transformation semigroup's D-Class
+##  structure.   Let <A>S</A> be a transformation semigroup of degree
+##  <M>n</M>. Then for each <M>r\leq n</M>, we show all D-classes of
+##  rank <M>r</M>.   
 ##  <P/>
-##  A regular D class with a single H class of size 120 appears as
-##  <Example><![CDATA[
-##  *[H size = 120, 1 L classes, 1 R classes] 
-##  ]]></Example>
+##  A regular D-class with a single H-class of size 120 appears as
+##  <Log><![CDATA[
+##  *[H size = 120, 1 L-class, 1 R-class] 
+##  ]]></Log>
 ##  (the <C>*</C> denoting regularity).
 ##  </Description>
 ##  </ManSection>
+##  <#/GAPDoc>
 ##
-DeclareOperation("DisplaySemigroup", 
-    [IsSemigroup]);
+DeclareOperation("DisplaySemigroup", [IsSemigroup]);
 
 # Everything from here...
 

--- a/lib/semigrp.gi
+++ b/lib/semigrp.gi
@@ -422,20 +422,29 @@ InstallMethod(DisplaySemigroup, "for finite semigroups",
     [IsTransformationSemigroup],
 function(S)
 
-    local dc, i, len, sh, D, layer, displayDClass;
+    local dc, i, len, sh, D, layer, displayDClass, n;
 
     displayDClass:= function(D)
-        local h, sh;
+        local h, nrL, nrR;
         h:= GreensHClassOfElement(AssociatedSemigroup(D),Representative(D));
         if IsRegularDClass(D) then
             Print("*");
+        else
+            Print(" ");
         fi;
-        Print("[H size = ", Size(h),", ",
-        Size(GreensRClassOfElement(AssociatedSemigroup(D),
-            Representative(h)))/Size(h), " L classes, ",
-        Size(GreensLClassOfElement(AssociatedSemigroup(D),
-            Representative(h)))/Size(h)," R classes]");
-        Print("\n");
+        nrL := Size(GreensRClassOfElement(AssociatedSemigroup(D),
+                                          Representative(h))) / Size(h);
+        nrR := Size(GreensLClassOfElement(AssociatedSemigroup(D),
+                                          Representative(h))) / Size(h);
+        Print("[H size = ", Size(h), ", ", nrL, " L-class");
+        if nrL > 1 then
+            Print("es");
+        fi;
+        Print(", ", nrR, " R-class");
+        if nrR > 1 then
+            Print("es");
+        fi;
+        Print("]\n");
     end;
 
     #########################################################################
@@ -446,13 +455,22 @@ function(S)
 
     # check finiteness
     if not IsFinite(S) then
-      TryNextMethod();
+        TryNextMethod();
     fi;
 
     # determine D classes and sort according to rank.
-    layer:= List([1..DegreeOfTransformationSemigroup(S)], x->[]);
+    n := DegreeOfTransformationSemigroup(S);
+
+    if n = 0 then
+        # special case for the full transformation monoid on one point
+        Print("Rank 0: ");
+        displayDClass(GreensDClasses(S)[1]);
+        return;
+    fi;
+
+    layer:= List([1 .. n], x->[]);
     for D in GreensDClasses(S) do
-        Add(layer[RankOfTransformation(Representative(D))], D);
+        Add(layer[RankOfTransformation(Representative(D), n)], D);
     od;
 
     # loop over the layers.

--- a/tst/testinstall/semigrp.tst
+++ b/tst/testinstall/semigrp.tst
@@ -481,6 +481,24 @@ s3*s1
 gap> Random(GlobalRandomSource, S);
 s3*s2^2
 
+#T# Test DisplaySemigroup
+gap> DisplaySemigroup(FullTransformationSemigroup(1));
+Rank 0: *[H size = 1, 1 L-class, 1 R-class]
+gap> DisplaySemigroup(FullTransformationSemigroup(2));
+Rank 2: *[H size = 2, 1 L-class, 1 R-class]
+Rank 1: *[H size = 1, 2 L-classes, 1 R-class]
+gap> DisplaySemigroup(FullTransformationSemigroup(3));
+Rank 3: *[H size = 6, 1 L-class, 1 R-class]
+Rank 2: *[H size = 2, 3 L-classes, 3 R-classes]
+Rank 1: *[H size = 1, 3 L-classes, 1 R-class]
+gap> S := Semigroup([
+>  Transformation([1, 1, 1, 2]),
+>  Transformation([1, 1, 2, 1])]);;
+gap> DisplaySemigroup(S);
+Rank 2:  [H size = 1, 1 L-class, 1 R-class]
+Rank 2:  [H size = 1, 1 L-class, 1 R-class]
+Rank 1: *[H size = 1, 1 L-class, 1 R-class]
+
 #
 gap> STOP_TEST( "semigrp.tst", 1);
 


### PR DESCRIPTION
`DisplaySemigroup` is supposed to give a summary of the Green's structure of a transformation semigroup.

* The documentation for `DisplaySemigroup` was not linked into the documentation system. I have now linked this, and reworded the documentation slightly.

* I have changed the code of `DisplaySemigroup` so that the output is more readable (and correctly pluralises the word "class").

* Furthermore, there was an unexpected error for certain types of transformation semigroup when using `DisplaySemigroup`. This was because the method did not take into account the degree of the semigroup when trying to calculate the rank of an element. For example, in any monoid of transformations of degree `n`, the `IdentityTransformation` has rank `n`. So you need to know the degree of the semigroup in order to get the rank of any element.