### PR TITLE
Clean up ListWithIdenticalEntries, and add some list tests

### DIFF
--- a/lib/list.gi
+++ b/lib/list.gi
@@ -3672,21 +3672,8 @@ end );
 ##
 #F  ListWithIdenticalEntries( <n>, <obj> )
 ##
-InstallGlobalFunction( ListWithIdenticalEntries, function( n, obj )
-    local list, i;
-    if IsChar(obj) then
-      list := "";
-      for i in [ 1 .. n ] do
-        list[i]:= obj;
-      od;
-    else
-      list:= [];
-      for i in [ n, n-1 .. 1 ] do
-        list[i]:= obj;
-      od;
-    fi;
-    return list;
-end );
+InstallGlobalFunction( ListWithIdenticalEntries,
+LIST_WITH_IDENTICAL_ENTRIES );
 
 
 #############################################################################

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -19,6 +19,12 @@ false
 gap> [] = l;
 false
 
+# ListWithIdenticalEntries: errors
+gap> ListWithIdenticalEntries(fail, true);
+Error, <n> must be a non-negative integer (not a boolean or fail)
+gap> ListWithIdenticalEntries(-1, fail);
+Error, <n> must be a non-negative integer (not a integer)
+
 # ListWithIdenticalEntries: 0 length
 gap> l := ListWithIdenticalEntries(0, 'w');
 ""
@@ -27,7 +33,7 @@ true
 gap> l := ListWithIdenticalEntries(0, true);
 [  ]
 gap> IsBlistRep(l);
-false
+true
 gap> l := ListWithIdenticalEntries(0, fail);
 [  ]
 gap> IsPlistRep(l);
@@ -55,11 +61,11 @@ true
 gap> l := ListWithIdenticalEntries(2, true);
 [ true, true ]
 gap> IsBlistRep(l);
-false
+true
 gap> l := ListWithIdenticalEntries(3, true);
 [ true, true, true ]
 gap> IsBlistRep(l);
-false
+true
 gap> ForAll([1 .. 100],
 >           i -> ForAll(ListWithIdenticalEntries(i, true), x -> x));
 true
@@ -70,11 +76,11 @@ true
 gap> l := ListWithIdenticalEntries(2, false);
 [ false, false ]
 gap> IsBlistRep(l);
-false
+true
 gap> l := ListWithIdenticalEntries(3, false);
 [ false, false, false ]
 gap> IsBlistRep(l);
-false
+true
 gap> ForAny([1 .. 100],
 >           i -> ForAny(ListWithIdenticalEntries(i, false), x -> x));
 false
@@ -88,11 +94,11 @@ gap> IsIdenticalObj(l[1], l[2]);
 true
 gap> l := ListWithIdenticalEntries(10, "GAP");;
 gap> TNUM_OBJ(l)[2];
-"list (plain)"
+"list (plain,hom)"
 gap> l;
 [ "GAP", "GAP", "GAP", "GAP", "GAP", "GAP", "GAP", "GAP", "GAP", "GAP" ]
 gap> TNUM_OBJ(l)[2];
-"list (plain,dense)"
+"list (plain,table)"
 gap> l := ListWithIdenticalEntries(10, PrimitiveRoot(GF(5)));
 [ Z(5), Z(5), Z(5), Z(5), Z(5), Z(5), Z(5), Z(5), Z(5), Z(5) ]
 gap> TNUM_OBJ(l)[2];
@@ -119,18 +125,18 @@ gap> TNUM_OBJ(l)[2];
 "list (plain,hom)"
 gap> l := ListWithIdenticalEntries(4, []);;
 gap> TNUM_OBJ(l)[2];
-"list (plain)"
+"list (plain,hom)"
 gap> l;
 [ [  ], [  ], [  ], [  ] ]
 gap> TNUM_OBJ(l)[2];
-"list (plain,dense)"
+"list (plain,rect table)"
 gap> l := ListWithIdenticalEntries(4, [5]);;
 gap> TNUM_OBJ(l)[2];
-"list (plain)"
+"list (plain,hom)"
 gap> l;
 [ [ 5 ], [ 5 ], [ 5 ], [ 5 ] ]
 gap> TNUM_OBJ(l)[2];
-"list (plain,dense)"
+"list (plain,rect table)"
 
 # String, for a range
 gap> l := [5 .. 10];

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -1,0 +1,195 @@
+gap> START_TEST("list.tst");
+
+# EQ: for two small lists, 1
+gap> [1] = [2];
+false
+gap> [1] = [1];
+true
+gap> [2, 1] = [2];
+false
+gap> [4] = [4, 5];
+false
+
+# EQ: for two lists, the first or second being empty
+gap> l := [0];;
+gap> HasIsEmpty(l);
+false
+gap> l = [];
+false
+gap> [] = l;
+false
+
+# ListWithIdenticalEntries: 0 length
+gap> l := ListWithIdenticalEntries(0, 'w');
+""
+gap> IsStringRep(l);
+true
+gap> l := ListWithIdenticalEntries(0, true);
+[  ]
+gap> IsBlistRep(l);
+false
+gap> l := ListWithIdenticalEntries(0, fail);
+[  ]
+gap> IsPlistRep(l);
+true
+
+# ListWithIdenticalEntries: strings
+gap> l := ListWithIdenticalEntries(1, 'y');
+"y"
+gap> IsStringRep(l);
+true
+gap> l := ListWithIdenticalEntries(2, 'z');
+"zz"
+gap> IsStringRep(l);
+true
+gap> l := ListWithIdenticalEntries(76, '#');
+"############################################################################"
+gap> IsStringRep(l);
+true
+
+# ListWithIdenticalEntries: blists
+gap> l := ListWithIdenticalEntries(1, true);
+[ true ]
+gap> IsBlistRep(l);
+true
+gap> l := ListWithIdenticalEntries(2, true);
+[ true, true ]
+gap> IsBlistRep(l);
+false
+gap> l := ListWithIdenticalEntries(3, true);
+[ true, true, true ]
+gap> IsBlistRep(l);
+false
+gap> ForAll([1 .. 100],
+>           i -> ForAll(ListWithIdenticalEntries(i, true), x -> x));
+true
+gap> l := ListWithIdenticalEntries(1, false);
+[ false ]
+gap> IsBlistRep(l);
+true
+gap> l := ListWithIdenticalEntries(2, false);
+[ false, false ]
+gap> IsBlistRep(l);
+false
+gap> l := ListWithIdenticalEntries(3, false);
+[ false, false, false ]
+gap> IsBlistRep(l);
+false
+gap> ForAny([1 .. 100],
+>           i -> ForAny(ListWithIdenticalEntries(i, false), x -> x));
+false
+
+# ListWithIdenticalEntries: other
+gap> l := ListWithIdenticalEntries(2, Group(()));
+[ Group(()), Group(()) ]
+gap> IsPlistRep(l);
+true
+gap> IsIdenticalObj(l[1], l[2]);
+true
+gap> l := ListWithIdenticalEntries(10, "GAP");;
+gap> TNUM_OBJ(l)[2];
+"list (plain)"
+gap> l;
+[ "GAP", "GAP", "GAP", "GAP", "GAP", "GAP", "GAP", "GAP", "GAP", "GAP" ]
+gap> TNUM_OBJ(l)[2];
+"list (plain,dense)"
+gap> l := ListWithIdenticalEntries(10, PrimitiveRoot(GF(5)));
+[ Z(5), Z(5), Z(5), Z(5), Z(5), Z(5), Z(5), Z(5), Z(5), Z(5) ]
+gap> TNUM_OBJ(l)[2];
+"list (sml fin fld elms)"
+gap> l := ListWithIdenticalEntries(10, 5 / 7);
+[ 5/7, 5/7, 5/7, 5/7, 5/7, 5/7, 5/7, 5/7, 5/7, 5/7 ]
+gap> TNUM_OBJ(l)[2];
+"list (plain,cyc)"
+gap> l := ListWithIdenticalEntries(5, -1);
+[ -1, -1, -1, -1, -1 ]
+gap> TNUM_OBJ(l)[2];
+"list (plain,cyc)"
+gap> l := ListWithIdenticalEntries(5, 8);
+[ 8, 8, 8, 8, 8 ]
+gap> TNUM_OBJ(l)[2];
+"list (plain,cyc)"
+gap> l := ListWithIdenticalEntries(5, 0);
+[ 0, 0, 0, 0, 0 ]
+gap> TNUM_OBJ(l)[2];
+"list (plain,cyc)"
+gap> l := ListWithIdenticalEntries(5, infinity);
+[ infinity, infinity, infinity, infinity, infinity ]
+gap> TNUM_OBJ(l)[2];
+"list (plain,hom)"
+gap> l := ListWithIdenticalEntries(4, []);;
+gap> TNUM_OBJ(l)[2];
+"list (plain)"
+gap> l;
+[ [  ], [  ], [  ], [  ] ]
+gap> TNUM_OBJ(l)[2];
+"list (plain,dense)"
+gap> l := ListWithIdenticalEntries(4, [5]);;
+gap> TNUM_OBJ(l)[2];
+"list (plain)"
+gap> l;
+[ [ 5 ], [ 5 ], [ 5 ], [ 5 ] ]
+gap> TNUM_OBJ(l)[2];
+"list (plain,dense)"
+
+# String, for a range
+gap> l := [5 .. 10];
+[ 5 .. 10 ]
+gap> String(l);
+"[ 5 .. 10 ]"
+gap> l := [21, 23, 25];
+[ 21, 23, 25 ]
+gap> IsRange(l);
+true
+gap> String(l);
+"[ 21, 23 .. 25 ]"
+gap> l := [10, 20];
+[ 10, 20 ]
+gap> IsRange(l);
+true
+gap> String(l);
+"[ 10, 20 .. 20 ]"
+gap> l := [2, 10, 18, 26, 34, 42];
+[ 2, 10, 18, 26, 34, 42 ]
+gap> IsRange(l);
+true
+gap> String(l);
+"[ 2, 10 .. 42 ]"
+gap> l := [50, 40, 30, 20, 10, 0, -10];
+[ 50, 40, 30, 20, 10, 0, -10 ]
+gap> IsRange(l);
+true
+gap> String(l);
+"[ 50, 40 .. -10 ]"
+gap> EvalString(String(l)) = l;
+true
+
+# Representative, for two lists
+gap> l := Filtered([1 .. 20], IsPrimeInt);;
+gap> Representative(l);
+2
+gap> Representative([]);
+Error, <list> must be nonempty to have a representative
+gap> Representative(EmptyPlist(0));
+Error, <list> must be nonempty to have a representative
+gap> l := EmptyPlist(4);;
+gap> l[3] := 5;;
+gap> Representative(l);
+5
+
+# RepresentativeSmallest, for an empty list
+gap> RepresentativeSmallest(EmptyPlist(0));
+Error, <C> must be nonempty to have a representative
+
+# RepresentativeSmallest, for a strictly sorted list
+gap> l := [12 .. 40];;
+gap> RepresentativeSmallest(l);
+12
+
+# RepresentativeSmallest, for a list
+gap> l := [40, 39 .. 10];;
+gap> RepresentativeSmallest(l);
+10
+
+#
+gap> STOP_TEST("list.tst");


### PR DESCRIPTION
I've made some changes to `ListWithIdenticalEntries`, which overall are very minor. I've also made a test file `testinstall/list.tst` to test `ListWithIdenticalEntries`, and whilst I was at it I added tests for some other methods in `lib/list.gi`, in the hopes of increasing the code coverage.

Most significantly, we now check that the first argument given to `ListWithIdenticalEntries` is a non-negative integer.

Also, in my opinion, the code is now more logical: previously a string was filled in start-to-end, whilst a list was filled in end-to-start. I presume this was done for memory-allocation reasons, but it seemed weird to read this. I think my solution is as efficient, but easier to read/maintain.

Old:
```
    if IsChar(obj) then
      list := "";
      for i in [ 1 .. n ] do
        list[i]:= obj;
      od;
    else
      list:= [];
      for i in [ n, n-1 .. 1 ] do
        list[i]:= obj;
      od;
    fi;
    return list;
```
New:
```
    if not IsInt(n) or n < 0 then
      ErrorNoReturn("the first argument <n> must be a non-negative integer");
    elif IsChar(obj) then
      list := EmptyString(n);
    else
      list := EmptyPlist(n);
    fi;
    for i in [1 .. n] do
      list[i] := obj;
    od;
    return list;
```