### PR TITLE
Adjustments to some semigroups-related documentation

### DIFF
--- a/doc/ref/semigrp.xml
+++ b/doc/ref/semigrp.xml
@@ -21,25 +21,7 @@ and determining information about them.
 <#Include Label="IsSemigroup">
 <#Include Label="Semigroup">
 <#Include Label="Subsemigroup">
-
-<ManSection>
-  <Oper Name="IsSubsemigroup"  Arg="S, T"/>
-  <Returns><K>true</K> or <K>false</K>.</Returns>
-  <Description>
-    This operation returns <K>true</K> if the semigroup <A>T</A> is a
-    subsemigroup of the semigroup <A>S</A> and <K>false</K> if it is not. 
-    <Example>
-gap> f:=Transformation( [ 5, 6, 7, 1, 4, 3, 2, 7 ] );
-Transformation( [ 5, 6, 7, 1, 4, 3, 2, 7 ] )
-gap> T:=Semigroup(f);;
-gap> IsSubsemigroup(FullTransformationSemigroup(4), T);
-false
-gap> S:=Semigroup(f);; T:=Semigroup(f^2);;
-gap> IsSubsemigroup(S, T);                             
-true</Example>
-</Description>
-</ManSection>
- 
+<#Include Label="IsSubsemigroup">
 <#Include Label="SemigroupByGenerators">
 <#Include Label="AsSemigroup">
 <#Include Label="AsSubsemigroup">
@@ -81,66 +63,12 @@ about semigroups.
 
 <#Include Label="IsRegularSemigroup">
 <#Include Label="IsRegularSemigroupElement">
-
-<ManSection>
-  <Oper Name="InversesOfSemigroupElement" Arg="S, x"/>
-  <Returns>The inverses of an element of a semigroup.</Returns>
-  <Description>
-    <C>InversesOfSemigroupElement</C> returns a list of the inverses of the 
-    element <A>x</A> in the semigroup <A>S</A>.<P/>
-     
-    An element <A>y</A> in <A>S</A> is an <E>inverse</E> of <A>x</A> if      
-    <C><A>x</A>*y*<A>x</A>=<A>x</A></C> and <C>y*<A>x</A>*y=y</C>.
-    The element <A>x</A> has an inverse if and only if <A>x</A> is a regular  
-    element of <A>S</A>.
-    <Example>
-gap> S:=Semigroup([ Transformation( [ 3, 1, 4, 2, 5, 2, 1, 6, 1 ] ), 
->  Transformation( [ 5, 7, 8, 8, 7, 5, 9, 1, 9 ] ), 
->  Transformation( [ 7, 6, 2, 8, 4, 7, 5, 8, 3 ] ) ]);;
-gap> x:=Transformation( [ 3, 1, 4, 2, 5, 2, 1, 6, 1 ] );;
-gap> InversesOfSemigroupElement(S, x);
-[  ]
-gap> IsRegularSemigroupElement(S, x);
-false
-gap> x:=Transformation( [ 1, 9, 7, 5, 5, 1, 9, 5, 1 ] );;
-gap> Set(InversesOfSemigroupElement(S, x));
-[ Transformation( [ 1, 2, 3, 5, 5, 1, 3, 5, 2 ] ), 
-  Transformation( [ 1, 5, 1, 1, 5, 1, 3, 1, 2 ] ), 
-  Transformation( [ 1, 5, 1, 2, 5, 1, 3, 2, 2 ] ) ]
-gap> IsRegularSemigroupElement(S, x);
-true
-gap> S:=ReesZeroMatrixSemigroup(Group((1,2,3)), 
-> [ [ (), () ], [ (), 0 ], [ (), (1,2,3) ] ]);;
-gap> x:=ReesZeroMatrixSemigroupElement(S, 2, (1,2,3), 3);;
-gap> InversesOfSemigroupElement(S, x);
-[ (1,(1,2,3),3), (1,(1,3,2),1), (2,(),3), (2,(1,2,3),1) ]</Example>
-  </Description>
-</ManSection>
-
+<#Include Label="InversesOfSemigroupElement">
 <#Include Label="IsSimpleSemigroup">
 <#Include Label="IsZeroSimpleSemigroup">
 <#Include Label="IsZeroGroup">
 <#Include Label="IsReesCongruenceSemigroup">
-
-<ManSection>
-  <Prop Name="IsInverseSemigroup" Arg="S"/>
-  <Filt Name="IsInverseMonoid" Arg="S" Type="Category"/>
-  <Returns><K>true</K> or <K>false</K>.</Returns>
-  <Description>
-    A semigroup is an <E>inverse semigroup</E> if every element
-    <C>x</C> has a unique semigroup inverse, that is, a unique
-    element <C>y</C> such that <C>x*y*x=x</C> and <C>y*x*y=y</C>.<P/>
-
-    A monoid that happens to be an inverse semigroup is called an <E>inverse
-      monoid</E>. 
-    <Example>
-gap> S:=Semigroup( Transformation( [ 1, 2, 4, 5, 6, 3, 7, 8 ] ),
-> Transformation( [ 3, 3, 4, 5, 6, 2, 7, 8 ] ),
-> Transformation( [ 1, 2, 5, 3, 6, 8, 4, 4 ] ) );;
-gap> IsInverseSemigroup(S);
-true</Example>
-  </Description>
-</ManSection>
+<#Include Label="IsInverseSemigroup">
 
 </Section>
 

--- a/lib/invsgp.gd
+++ b/lib/invsgp.gd
@@ -9,6 +9,7 @@
 ##  This file contains the declaration of operations for inverse semigroups.
 ##
 
+# IsInverseMonoid is documented with IsInverseSemigroup in semigrp.gd
 DeclareSynonym("IsInverseMonoid", IsMonoid and IsInverseSemigroup);
 
 DeclareOperation("IsInverseSubsemigroup", [IsSemigroup, IsSemigroup]);
@@ -25,14 +26,10 @@ DeclareAttribute("GeneratorsOfInverseSemigroup", IsInverseSemigroup);
 DeclareOperation("InverseMonoidByGenerators", [IsCollection]);
 DeclareOperation("InverseSemigroupByGenerators", [IsCollection]);
 
-DeclareOperation("InverseSubsemigroup",
-[IsInverseSemigroup, IsCollection]);
-DeclareOperation("InverseSubsemigroupNC",
-[IsInverseSemigroup, IsCollection]);
-DeclareOperation("InverseSubmonoid",
-[IsInverseMonoid, IsCollection]);
-DeclareOperation("InverseSubmonoidNC",
-[IsInverseMonoid, IsCollection]);
+DeclareOperation("InverseSubsemigroup", [IsInverseSemigroup, IsCollection]);
+DeclareOperation("InverseSubsemigroupNC", [IsInverseSemigroup, IsCollection]);
+DeclareOperation("InverseSubmonoid", [IsInverseMonoid, IsCollection]);
+DeclareOperation("InverseSubmonoidNC", [IsInverseMonoid, IsCollection]);
 
 DeclareAttribute("AsInverseSemigroup", IsCollection);
 DeclareAttribute("AsInverseMonoid", IsCollection);

--- a/lib/semigrp.gd
+++ b/lib/semigrp.gd
@@ -29,6 +29,49 @@
 ##
 DeclareSynonymAttr( "IsSemigroup", IsMagma and IsAssociative );
 
+##############################################################################
+##
+#O  InversesOfSemigroupElement( <S>, <x> )
+##
+##  <#GAPDoc Label="InversesOfSemigroupElement">
+##  <ManSection>
+##    <Oper Name="InversesOfSemigroupElement" Arg="S, x"/>
+##    <Returns>A list of the inverses of an element of a semigroup.</Returns>
+##    <Description>
+##      <C>InversesOfSemigroupElement</C> returns a list of the inverses of
+##      the element <A>x</A> in the semigroup <A>S</A>.<P/>
+##       
+##      An element <A>y</A> in <A>S</A> is an <E>inverse</E> of <A>x</A> if
+##      <C><A>x</A>*y*<A>x</A>=<A>x</A></C> and <C>y*<A>x</A>*y=y</C>.
+##      The element <A>x</A> has an inverse if and only if <A>x</A> is a
+##      regular element of <A>S</A>.
+##      <Example><![CDATA[
+##  gap> S := Semigroup([
+##  >  Transformation([3, 1, 4, 2, 5, 2, 1, 6, 1]), 
+##  >  Transformation([5, 7, 8, 8, 7, 5, 9, 1, 9]), 
+##  >  Transformation([7, 6, 2, 8, 4, 7, 5, 8, 3])]);
+##  <transformation semigroup of degree 9 with 3 generators>
+##  gap> x := Transformation([3, 1, 4, 2, 5, 2, 1, 6, 1]);;
+##  gap> InversesOfSemigroupElement(S, x);
+##  [  ]
+##  gap> IsRegularSemigroupElement(S, x);
+##  false
+##  gap> x := Transformation([1, 9, 7, 5, 5, 1, 9, 5, 1]);;
+##  gap> Set(InversesOfSemigroupElement(S, x));
+##  [ Transformation( [ 1, 2, 3, 5, 5, 1, 3, 5, 2 ] ), 
+##    Transformation( [ 1, 5, 1, 1, 5, 1, 3, 1, 2 ] ), 
+##    Transformation( [ 1, 5, 1, 2, 5, 1, 3, 2, 2 ] ) ]
+##  gap> IsRegularSemigroupElement(S, x);
+##  true
+##  gap> S := ReesZeroMatrixSemigroup(Group((1,2,3)),
+##  >  [[(), ()], [(), 0], [(), (1,2,3)]]);;
+##  gap> x := ReesZeroMatrixSemigroupElement(S, 2, (1,2,3), 3);;
+##  gap> InversesOfSemigroupElement(S, x);
+##  [ (1,(1,2,3),3), (1,(1,3,2),1), (2,(),3), (2,(1,2,3),1) ]]]></Example>
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
 DeclareOperation("InversesOfSemigroupElement", 
 [IsSemigroup, IsMultiplicativeElement]);
 
@@ -521,14 +564,29 @@ DeclareProperty("IsRegularSemigroup", IsSemigroup);
 ##
 #P  IsInverseSemigroup( <S> )
 ##
+##  <#GAPDoc Label="IsInverseSemigroup">
 ##  <ManSection>
-##  <Prop Name="IsInverseSemigroup" Arg='S'/>
-##
-##  <Description>
-##  returns <K>true</K> if <A>S</A> is an inverse semigroup, i.e.,
-##  if every element of <A>S</A> has a unique (semigroup) inverse.
-##  </Description>
+##    <Prop Name="IsInverseSemigroup" Arg="S"/>
+##    <Filt Name="IsInverseMonoid" Arg="S" Type="Category"/>
+##    <Returns><K>true</K> or <K>false</K>.</Returns>
+##    <Description>
+##      A semigroup <A>S</A> is an <E>inverse semigroup</E> if every element
+##      <C>x</C> in <A>S</A> has a unique semigroup inverse, that is, a unique
+##      element <C>y</C> in <A>S</A> such that <C>x*y*x=x</C> and
+##      <C>y*x*y=y</C>.<P/>
+##  
+##      A monoid that happens to be an inverse semigroup is called an
+##      <E>inverse monoid</E>; see <Ref Filt="IsMonoid"/>.
+##      <Example>
+##  gap> S := Semigroup([
+##  >  Transformation([1, 2, 4, 5, 6, 3, 7, 8]),
+##  >  Transformation([3, 3, 4, 5, 6, 2, 7, 8]),
+##  >  Transformation([1, 2, 5, 3, 6, 8, 4, 4])]);;
+##  gap> IsInverseSemigroup(S);
+##  true</Example>
+##    </Description>
 ##  </ManSection>
+##  <#/GAPDoc>
 ##
 DeclareProperty("IsInverseSemigroup", IsSemigroup);
 
@@ -560,6 +618,32 @@ DeclareOperation("DisplaySemigroup",
 
 DeclareAttribute("NilpotencyDegree", IsSemigroup);
 
+##############################################################################
+##
+#O IsSubsemigroup( <S>, <T> )
+##
+## <#GAPDoc Label="IsSubsemigroup">
+## <ManSection>
+##   <Oper Name="IsSubsemigroup"  Arg="S, T"/>
+##   <Returns><K>true</K> or <K>false</K>.</Returns>
+##   <Description>
+##
+##     This operation returns <K>true</K> if the semigroup <A>T</A> is a
+##     subsemigroup of the semigroup <A>S</A> and <K>false</K> if it is not.
+##     <Example>
+## gap> f := Transformation([5, 6, 7, 1, 4, 3, 2, 7]);
+## Transformation( [ 5, 6, 7, 1, 4, 3, 2, 7 ] )
+## gap> T := Semigroup(f);;
+## gap> IsSubsemigroup(FullTransformationSemigroup(4), T);
+## false
+## gap> S := Semigroup(f);;
+## gap> T := Semigroup(f ^ 2);;
+## gap> IsSubsemigroup(S, T);
+## true</Example>
+##   </Description>
+## </ManSection>
+## <#/GAPDoc>
+##
 DeclareOperation("IsSubsemigroup", [IsSemigroup, IsSemigroup]);
 
 DeclareProperty("IsBand", IsSemigroup);


### PR DESCRIPTION
At GAP Days Fall 2017, @ChrisJefferson was telling me about ways to improve the documentation in the library. Some pieces of documentation in `gd` files are not linked, and bits of documentation sometimes appear in the "wrong" place.

Seeing as I know about semigroups, I decided to look at the related library code. In this PR, I move some chunks of documentation around, and give them labels and include them, for consistency with the rest of the file. These are very minor changes; I've not changed the content of any of the documentation.

This effort also led to PR #1785.