### PR TITLE
Reduce memory usage of tests

### DIFF
--- a/tst/testinstall/grpmat.tst
+++ b/tst/testinstall/grpmat.tst
@@ -50,6 +50,10 @@ gap> iso:= IsomorphismPermGroup( g );;
 gap> img:=Image( iso );;
 gap> Size(img);
 67010895544320000
+
+# Unbind variables so we can GC memory
+gap> Unbind(img); Unbind(iso); Unbind(g); Unbind(hom); Unbind(u);
+gap> Unbind(g); Unbind(gd); Unbind(G); Unbind(cl); Unbind(pcgs);
 gap> STOP_TEST( "grpmat.tst", 1);
 
 #############################################################################

--- a/tst/teststandard/algext.tst
+++ b/tst/teststandard/algext.tst
@@ -25,4 +25,9 @@ gap> ll := AlgebraicExtension(l, x^5-2, "beta");;
 gap> b := RootOfDefiningPolynomial(ll);;
 gap> (a+b)^5-(a-b)^5;
 20*alpha^2*beta^3+(10*alpha^2-10)*beta+!4
+
+# Unbind variables so we can GC memory
+gap> Unbind(f0); Unbind(p1); Unbind(f1); Unbind(p2); Unbind(f2);
+gap> Unbind(p3); Unbind(f3); Unbind(p4); Unbind(f4);
+gap> Unbind(x); Unbind(l); Unbind(a); Unbind(ll); Unbind(b);
 gap> STOP_TEST("algext.tst",1);

--- a/tst/teststandard/direct_factors.tst
+++ b/tst/teststandard/direct_factors.tst
@@ -121,4 +121,7 @@ true
 gap> G := DirectProduct(DihedralGroup(12), SymmetricGroup(4));;
 gap> SortedList(List(DirectFactorsOfGroup(G),IdGroup));
 [ [ 2, 1 ], [ 6, 1 ], [ 24, 12 ] ]
+
+# Unbind variables so we can GC memory
+gap> Unbind(G); Unbind(F); Unbind(Q); Unbind(D); Unbind(Df); Unbind(U); Unbind(V);
 gap> STOP_TEST("direct_factors.tst", 1);

--- a/tst/teststandard/innerfunc.tst
+++ b/tst/teststandard/innerfunc.tst
@@ -61,4 +61,7 @@ true
 gap> y := List(list2, z -> z()());;
 gap> y = [len+1..len*2];
 true
+
+# Unbind variables so we can GC memory
+gap> Unbind(list1); Unbind(list2); Unbind(list3); Unbind(y);
 gap> STOP_TEST("info.tst", 1);

--- a/tst/teststandard/opers/ComplementClassesRepresentatives.tst
+++ b/tst/teststandard/opers/ComplementClassesRepresentatives.tst
@@ -30,4 +30,7 @@ true
 gap> G := SymmetricGroup(6);; N := AlternatingGroup(6);;
 gap> Set(ComplementClassesRepresentatives(G, N), H -> H^G)=Set([ Group([ (1,2) ])^G, Group([ (1,2)(3,4)(5,6) ])^G ]);
 true
+
+# Unbind variables so we can GC memory
+gap> Unbind(G); Unbind(N);
 gap> STOP_TEST("ComplementClassesRepresentatives.tst", 1);

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -26,6 +26,9 @@ gap> p:=Image(IsomorphismPermGroup(g));;
 gap> s:=SylowSubgroup(p,7);;
 gap> Length(IntermediateSubgroups(p,s).subgroups);
 71
+
+# Unbind variables so we can GC memory
+gap> Unbind(g); Unbind(dc); Unbind(ac); Unbind(g); Unbind(p); Unbind(s);
 gap> STOP_TEST( "permgrp.tst", 1);
 
 #############################################################################

--- a/tst/teststandard/stabchain.tst
+++ b/tst/teststandard/stabchain.tst
@@ -43,6 +43,9 @@ gap> SCRSift(S,(1,2));
 (8,11)(9,21)(12,23)(14,16)(17,22)(18,24)(19,20)
 gap> SCRSift(S,GeneratorsOfGroup(m)[1]);
 ()
+
+# Unbind variables so we can GC memory
+gap> Unbind(G); Unbind(S); Unbind(it); Unbind(it2); Unbind(l); Unbind(m);
 gap> STOP_TEST( "stabchain.tst", 1);
 
 #############################################################################


### PR DESCRIPTION
This patch unbinds variables in some tests which use a lot of memory.

I built this by running each test and measuring memory usage before and after, and unbinding in the worst ones. Long term, #1633 would fix this general problem, but that really needs some care before merging (in particular, if someone wants to figure out a better way of making a bag of local variables other than my horrible eval method).