### PR TITLE
Modify READ_ALL_COMMANDS to copy results

### DIFF
--- a/tst/testinstall/read.tst
+++ b/tst/testinstall/read.tst
@@ -96,4 +96,7 @@ gap> p;
   [ true, 6 ], [ true, 7 ], [ true, 8 ], [ true, 9 ], [ true, 10 ], 
   [ true, 11 ], [ true, 12 ], [ true, 13 ], [ true, 14 ], [ true, 15 ], 
   [ true, 16 ], [ true, 17 ], [ true, 18 ] ]
+gap> READ_ALL_COMMANDS(InputTextString("""a:=[1,"a"]; b:=a; b[2]:=3;  a;"""), false);
+[ [ true, [ 1, "a" ] ], [ true, [ 1, "a" ] ], [ true, 3 ], [ true, [ 1, 3 ] ] \
+]
 gap> STOP_TEST( "read.tst", 1);


### PR DESCRIPTION
this is done to cater for the following situation: In Jupyter a user
wants to execute the following code in a single cell:
```
a:=[1,"a"];
b:=a;
b[2]:=3;
a;
```

Before this patch, the result is

```
[ [ true, [ 1, 3 ] ], [ true, [ 1, 3 ] ], [ true, 3 ], [ true, [ 1, 3 ] ] ]
```

after it is

```
[ [ true, [ 1, "a" ] ], [ true, [ 1, "a" ] ], [ true, 3 ], [ true, [ 1, 3 ] ] ]
```

and yields the output the user expects.

Note that copying the results of expressions is potentially expensive, but this
problem needs to be addressed by making the scanner/parser/interpreter capable
of partially reading an input stream and not forgetting its (remaining) contents.