### PR TITLE
Fix displaying help in HPCGAP

### DIFF
--- a/lib/pager.gi
+++ b/lib/pager.gi
@@ -85,7 +85,12 @@ leave the 'Pager' and 'PagerOptions' preferences empty."
         return [ pager, options ];
       fi;
     fi;
-    return [ "builtin", [] ];
+    # The builtin pager does not work in HPCGAP
+    if IsHPCGAP then
+      return [ "less" , ["-f","-r","-a","-i","-M","-j2"] ];
+    else
+      return [ "builtin", [] ];
+    fi;
   end,
   ) );
 ## HACKUSERPREF  temporary until all packages are adjusted


### PR DESCRIPTION
One of the (to me) most annoying bugs in HPCGAP is that you can't read help ( #1673 ).

This is basically because the multithreaded UI and pager fight over keypresses.

This fixes this problem, by:

* Always using the external viewer `less` to show help.
* Add a global variable `FreezeStdin`, which when can be used to stop HPCGAP from accessing stdin. In normal GAP you don't have to worry about this, because while you are `wait`ing for an external process, of course you cannot also be reading from stdin!

Fixing the built-in viewer will (I believe) basically a from-scratch rewrite of how the HPCGAP UI does IO, because it is fundamentally line based.

This patch does assume that the user has the `select` function. Assuming this is accepted I plan on then enabling `SELECT` in all cases, but thought that might be too big a diff.

The reason for only enabling the select hook in `HPCGAP` is a comment in the GAP release notes which says in readline 6.2, this select hook code produces substantial slowdowns when pasting code in. I can't reproduce that on my machine in readline 7.