### PR TITLE
Factor out common logic in interpreter and coder; simplify the code interpreting atomic statements

### DIFF
--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1637,7 +1637,6 @@ void            IntrIn ( void )
 *F  IntrAInv()  . . . . . . . . . . . . . . . .  interpret unary --expression
 *F  IntrDiff()  . . . . . . . . . . . . . . . . . . .  interpret --expression
 *F  IntrProd()  . . . . . . . . . . . . . . . . . . .  interpret *-expression
-*F  IntrInv() . . . . . . . . . . . . . . . . . . .  interpret ^-1-expression
 *F  IntrQuo() . . . . . . . . . . . . . . . . . . . .  interpret /-expression
 *F  IntrMod()   . . . . . . . . . . . . . . . . . .  interpret mod-expression
 *F  IntrPow() . . . . . . . . . . . . . . . . . . . .  interpret ^-expression

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -517,7 +517,6 @@ extern  void            IntrIn ( void );
 *F  IntrAInv()  . . . . . . . . . . . . . . . .  interpret unary --expression
 *F  IntrDiff()  . . . . . . . . . . . . . . . . . . .  interpret --expression
 *F  IntrProd()  . . . . . . . . . . . . . . . . . . .  interpret *-expression
-*F  IntrInv() . . . . . . . . . . . . . . . . . . .  interpret ^-1-expression
 *F  IntrQuo() . . . . . . . . . . . . . . . . . . . .  interpret /-expression
 *F  IntrMod()   . . . . . . . . . . . . . . . . . .  interpret mod-expression
 *F  IntrPow() . . . . . . . . . . . . . . . . . . . .  interpret ^-expression
@@ -533,8 +532,6 @@ extern  void            IntrAInv ( void );
 extern  void            IntrDiff ( void );
 
 extern  void            IntrProd ( void );
-
-extern  void            IntrInv ( void );
 
 extern  void            IntrQuo ( void );
 

--- a/src/read.c
+++ b/src/read.c
@@ -2402,9 +2402,7 @@ void ReadAtomic (
       return; }
 
     /* 'atomic' <QualifiedExpression> {',' <QualifiedExpression> } 'do'    */
-#ifdef HPCGAP
     TRY_READ { IntrAtomicBegin(); }
-#endif
 
     ReadQualifiedExpr( S_DO|S_OD|follow, 'r' );
     nexprs = 1;


### PR DESCRIPTION
Motivation for this patch was a desire to understand how `atomic` works (e.g. so that we can eventually implement support for it in the compiler). This then lead me to wonder why it is handled differently from loops; and also why there are some subtle differences in how loops are handled.

The result is this PR, which removes quite some code duplication, which for me personally was quite helpful in understanding the modified code.