### PR TITLE
Allow profiling of memory usage

### DIFF
--- a/hpcgap/lib/system.g
+++ b/hpcgap/lib/system.g
@@ -105,6 +105,8 @@ BIND_GLOBAL( "GAPInfo", AtomicRecord(rec(
       rec( short := "z", default := "20" ),
       rec( long := "prof", default := "", arg := "<file>",
            help := [ "Run ProfileLineByLine(<filename>) on GAP start"] ),
+      rec( long := "memprof", default := "", arg := "<file>",
+           help := [ "Run ProfileLineByLine(<filename>) with recordMem := true on GAP start"] ),
       rec( long := "cover", default := "", arg := "<file>",
            help := [ "Run CoverageLineByLine(<filename>) on GAP start"] ),
           ],

--- a/lib/newprofile.g
+++ b/lib/newprofile.g
@@ -37,6 +37,12 @@
 ##             (measuring CPU-time has a higher overhead).
 ##      </Item>
 ##
+##  <Mark>recordMem</Mark>
+##      <Item> Boolean (defaults to false). Instead of recording the
+##             CPU time taken by statements, record the total size of all
+##             new objects created by each line.
+##      </Item>
+##
 ##  <Mark>resolution</Mark>
 ##      <Item> Integer (defaults to 0). By default profiling will record a trace
 ##             of all executed code. When <A>resolution</A> non-zero, GAP
@@ -57,7 +63,8 @@ BIND_GLOBAL("ProfileLineByLine",function(arg)
     fi;
 
     optRec := rec(coverage := false,
-                  wallTime := true, 
+                  wallTime := true,
+                  recordMem := false,
                   resolution := 0);
     if Length(arg) = 2 then
       if not(IsRecord(arg[2])) then
@@ -76,8 +83,8 @@ BIND_GLOBAL("ProfileLineByLine",function(arg)
        arg[1]{[Length(arg[1])-2..Length(arg[1])]} <> ".gz" then
       Info(InfoWarning, 1, "Profile filenames must end in .gz to enable compression");
     fi;
-    return ACTIVATE_PROFILING(arg[1], optRec.coverage,
-                                      optRec.wallTime, optRec.resolution);
+    return ACTIVATE_PROFILING(arg[1], optRec.coverage, optRec.wallTime,
+                                      optRec.recordMem, optRec.resolution);
 end);
 
 ##  <#GAPDoc Label="IsLineByLineProfileActive">

--- a/lib/system.g
+++ b/lib/system.g
@@ -104,6 +104,8 @@ BIND_GLOBAL( "GAPInfo", rec(
       rec( short := "z", default := "20" ),
       rec( long := "prof", default := "", arg := "<file>",
            help := [ "Run ProfileLineByLine(<filename>) on GAP start"] ),
+      rec( long := "memprof", default := "", arg := "<file>",
+           help := [ "Run ProfileLineByLine(<filename>) with recordMem := true on GAP start"] ),
       rec( long := "cover", default := "", arg := "<file>",
            help := [ "Run CoverageLineByLine(<filename>) on GAP start"] ),
           ],

--- a/src/profile.c
+++ b/src/profile.c
@@ -788,11 +788,12 @@ Obj FuncACTIVATE_COLOR_PROFILING(Obj self, Obj arg)
 */
 static StructGVarFunc GVarFuncs[] = {
 
-    GVAR_FUNC(
-        ACTIVATE_PROFILING, 5, "string,boolean,boolean,boolean,integer"),
+    GVAR_FUNC(ACTIVATE_PROFILING,
+              5,
+              "filename,coverage,wallTime,recordMem,resolution"),
     GVAR_FUNC(DEACTIVATE_PROFILING, 0, ""),
     GVAR_FUNC(IsLineByLineProfileActive, 0, ""),
-    GVAR_FUNC(ACTIVATE_COLOR_PROFILING, 1, "bool"),
+    GVAR_FUNC(ACTIVATE_COLOR_PROFILING, 1, "arg"),
     { 0, 0, 0, 0, 0 }
 };
 

--- a/src/system.c
+++ b/src/system.c
@@ -73,6 +73,7 @@
 **  of the GAP type system
 */    
 Int enableProfilingAtStartup( Char **argv, void * dummy);
+Int enableMemoryProfilingAtStartup( Char **argv, void * dummy );
 Int enableCodeCoverageAtStartup( Char **argv, void * dummy);
 
 /****************************************************************************
@@ -1735,6 +1736,7 @@ struct optInfo options[] = {
 #endif
   /* The following three options must be handled in the kernel so they happen early enough */
   { 0  , "prof", enableProfilingAtStartup, 0, 1},    /* enable profiling at startup */
+  { 0  , "memprof", enableMemoryProfilingAtStartup, 0, 1 }, /* enable memory profiling at startup */
   { 0  , "cover", enableCodeCoverageAtStartup, 0, 1}, /* enable code coverage at startup */
   { 0  , "quitonbreak", toggle, &SyQuitOnBreak, 0}, /* Quit GAP if we enter the break loop */
   { 0, "", 0, 0, 0}};


### PR DESCRIPTION
This PR adds an option to `LineByLineProfile`,  `recordMem` which allows profiling memory usage, rather than CPU usage.

It would be very simple (in the kernel) to allow profiling both time and memory at the same time, but the code in the profiling package to parse the result is quite horrible, so if someone wanted that they would have to edit both bits of code in sync.