### PR TITLE
Introduce TYPE_KERNEL_OBJECT as a general type for T_DATOBJ objects that

### DIFF
--- a/hpcgap/lib/object.gi
+++ b/hpcgap/lib/object.gi
@@ -686,6 +686,29 @@ function( obj,str )
   TryNextMethod();
 end );
 
+#############################################################################
+##
+#V  TYPE_KERNEL_OBJECT  
+##
+##
+##
+##  TYPE_KERNEL_OBJECT is the type of data objects used internally in the 
+##  kernel which have no significant &GAP; callable methods and should not
+##  normally be seen at &GAP; level. These are typically lookup tables or
+##  buffers created and used within the kernel and containing binary data only
+##
+
+
+DeclareRepresentation( "IsKernelDataObjectRep", IsDataObjectRep, []);
+
+
+BIND_GLOBAL( "TYPE_KERNEL_OBJECT",
+          NewType(NewFamily("KernelObjectFamily", IsObject),
+          IsObject and IsKernelDataObjectRep));
+
+
+InstallMethod( String, [IsKernelDataObjectRep], o->MakeImmutable("<kernel object>"));
+
 
 #############################################################################
 ##

--- a/lib/object.gi
+++ b/lib/object.gi
@@ -676,6 +676,25 @@ function( obj,str )
   TryNextMethod();
 end );
 
+#############################################################################
+##
+#V  TYPE_KERNEL_OBJECT  
+##
+##
+##
+##  TYPE_KERNEL_OBJECT is the type of data objects used internally in the 
+##  kernel which have no significant &GAP; callable methods and should not
+##  normally be seen at &GAP; level. These are typically lookup tables or
+##  buffers created and used within the kernel and containing binary data only
+##
+
+DeclareRepresentation( "IsKernelDataObjectRep", IsDataObjectRep, []);
+
+BIND_GLOBAL( "TYPE_KERNEL_OBJECT",
+          NewType(NewFamily("KernelObjectFamily", IsObject),
+          IsObject and IsKernelDataObjectRep));
+
+InstallMethod( String, [IsKernelDataObjectRep], o->MakeImmutable("<kernel object>"));
 
 #############################################################################
 ##

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -78,9 +78,9 @@ end);
 ##  doesn't really say anything, because there are no applicable operations.
 ##
 
-InstallValue( TYPE_FIELDINFO_8BIT,
-  NewType(NewFamily("FieldInfo8BitFamily", IsObject),
-          IsObject and IsDataObjectRep));
+
+InstallValue( TYPE_FIELDINFO_8BIT, TYPE_KERNEL_OBJECT);
+
 
 #############################################################################
 ##

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -144,36 +144,9 @@ typedef UInt2       FF;
 */
 
 
-/****************************************************************************
-**
-*F  SUCC_FF(<ff>) . . . . . . . . . . . successor table of small finite field
-**
-**  'SUCC_FF' returns a pointer to the successor table of  the  small  finite
-**  field <ff>.
-**
-**  Note that 'SUCC_FF' is a macro, so do not call  it  with  arguments  that
-**  side effects.
-**
-**  'SUCC_FF' is defined in the declaration part of this package as follows
-**
-#define SUCC_FF(ff)             ((FFV*)ADDR_OBJ( ELM_PLIST( SuccFF, ff ) ))
-*/
 Obj             SuccFF;
 
 
-/****************************************************************************
-**
-*F  TYPE_FF(<ff>) . . . . . . . . . . . . . . .  type of a small finite field
-**
-**  'TYPE_FF' returns the type of elements of the small finite field <ff>.
-**
-**  Note that  'TYPE_FF' is a macro, so  do not call  it  with arguments that
-**  have side effects.
-**
-**  'TYPE_FF' is defined in the declaration part of this package as follows
-**
-#define TYPE_FF(ff)             (ELM_PLIST( TypeFF, ff ))
-*/
 Obj             TypeFF;
 Obj             TypeFF0;
 
@@ -500,6 +473,9 @@ unsigned long   PolsFF [] = {
 };
 
 
+// used for successor bags
+static Obj TYPE_KERNEL_OBJECT;
+
 /****************************************************************************
 **
 *F  FiniteField(<p>,<d>)  . . . make the small finite field with <q> elements
@@ -569,10 +545,12 @@ FF              FiniteField (
 #endif
 
     /* allocate a bag for the finite field and one for a temporary         */
-    bag1  = NewBag( T_PERM2, q * sizeof(FFV) );
-    bag2  = NewBag( T_PERM2, q * sizeof(FFV) );
-    indx = (FFV*)ADDR_OBJ( bag1 );
-    succ = (FFV*)ADDR_OBJ( bag2 );
+    bag1  = NewBag( T_DATOBJ, sizeof(Obj) + q * sizeof(FFV) );
+    SET_TYPE_DATOBJ(bag1, TYPE_KERNEL_OBJECT );
+    bag2  = NewBag( T_DATOBJ, sizeof(Obj) + q * sizeof(FFV) );
+    SET_TYPE_DATOBJ(bag2, TYPE_KERNEL_OBJECT );
+    indx = (FFV*)(1+ADDR_OBJ( bag1 ));
+    succ = (FFV*)(1+ADDR_OBJ( bag2 ));
 
     /* if q is a prime find the smallest primitive root $e$, use $x - e$   */
     /*N 1990/02/04 mschoene this is likely to explode if 'FFV' is 'UInt4'  */
@@ -2036,6 +2014,8 @@ static Int InitKernel (
     ImportFuncFromLibrary( "QUO_FFE_LARGE",  &QUO_FFE_LARGE  );
     ImportFuncFromLibrary( "LOG_FFE_LARGE",  &LOG_FFE_LARGE  );
 
+    ImportGVarFromLibrary( "TYPE_KERNEL_OBJECT", &TYPE_KERNEL_OBJECT );
+    
     /* init filters and functions                                          */
     InitHdlrFiltsFromTable( GVarFilts );
     InitHdlrFuncsFromTable( GVarFuncs );

--- a/src/finfield.h
+++ b/src/finfield.h
@@ -116,7 +116,7 @@ typedef UInt2       FF;
 **  Note that 'SUCC_FF' is a macro, so do not call  it  with  arguments  that
 **  side effects.
 */
-#define SUCC_FF(ff)             ((FFV*)ADDR_OBJ( ELM_PLIST( SuccFF, ff ) ))
+#define SUCC_FF(ff)             ((FFV*)(1+ADDR_OBJ( ELM_PLIST( SuccFF, ff ) )))
 
 extern  Obj             SuccFF;
 


### PR DESCRIPTION
have no GAP-level semantics (mainly kernel lookup tables).
Use for finite fields and compressed vectors. 

Should solve test failure in #1772 