### PR TITLE
Move SET_BRK_CALL_TO()s in funcs.c to resolve issue #917

### DIFF
--- a/src/funcs.c
+++ b/src/funcs.c
@@ -98,7 +98,9 @@ UInt ExecProccallOpts(
 **
 **  'ExecProccall<i>args'  executes  a  procedure   call   to the    function
 **  'FUNC_CALL(<call>)'   with   the   arguments   'ARGI_CALL(<call>,1)'   to
-**  'ARGI_CALL(<call>,<i>)'.  It returns the value returned by the function.
+**  'ARGI_CALL(<call>,<i>)'.  It discards the value returned by the function
+**  and returns the statement execution status (as per EXEC_STAT, q.v.)
+**  resulting from the procedure call, which in fact is always 0.
 */
 
 static Obj DispatchFuncCall( Obj func, Int nargs, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5, Obj arg6)
@@ -168,10 +170,10 @@ UInt            ExecProccall1args (
     arg1 = EVAL_EXPR( ARGI_CALL( call, 1 ) );
  
     /* call the function                                                   */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION)
       DispatchFuncCall(func, 1, (Obj) arg1,  (Obj) 0L,  (Obj) 0L,  (Obj) 0L,  (Obj) 0L,  (Obj) 0L);
     else {
-      SET_BRK_CALL_TO( call );
       CALL_1ARGS( func, arg1 );
     } 
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
@@ -198,10 +200,10 @@ UInt            ExecProccall2args (
     arg2 = EVAL_EXPR( ARGI_CALL( call, 2 ) );
 
     /* call the function                                                   */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION)
       DispatchFuncCall(func, 2, (Obj) arg1,  (Obj) arg2,  (Obj) 0L,  (Obj) 0L,  (Obj) 0L,  (Obj) 0L);
     else {
-      SET_BRK_CALL_TO( call );
       CALL_2ARGS( func, arg1, arg2 );
     }
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
@@ -230,10 +232,10 @@ UInt            ExecProccall3args (
     arg3 = EVAL_EXPR( ARGI_CALL( call, 3 ) );
 
     /* call the function                                                   */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION)
       DispatchFuncCall(func, 3, (Obj) arg1,  (Obj) arg2,  (Obj) arg3,  (Obj) 0L,  (Obj) 0L,  (Obj) 0L);
     else {
-      SET_BRK_CALL_TO( call );
       CALL_3ARGS( func, arg1, arg2, arg3 );
     }
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
@@ -264,10 +266,10 @@ UInt            ExecProccall4args (
     arg4 = EVAL_EXPR( ARGI_CALL( call, 4 ) );
 
     /* call the function                                                   */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION)
       DispatchFuncCall(func, 4, (Obj) arg1,  (Obj) arg2,  (Obj) arg3,  (Obj) arg4,  (Obj) 0,  (Obj) 0);
     else {
-      SET_BRK_CALL_TO( call );
       CALL_4ARGS( func, arg1, arg2, arg3, arg4 );
     }
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
@@ -300,10 +302,10 @@ UInt            ExecProccall5args (
     arg5 = EVAL_EXPR( ARGI_CALL( call, 5 ) );
 
     /* call the function                                                   */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION)
       DispatchFuncCall(func, 5, (Obj) arg1,  (Obj) arg2,  (Obj) arg3,  (Obj) arg4,  (Obj) arg5,  (Obj) 0L);
     else {
-      SET_BRK_CALL_TO( call );
       CALL_5ARGS( func, arg1, arg2, arg3, arg4, arg5 );
     }
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
@@ -338,10 +340,10 @@ UInt            ExecProccall6args (
     arg6 = EVAL_EXPR( ARGI_CALL( call, 6 ) );
 
     /* call the function                                                   */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION)
       DispatchFuncCall(func, 6, (Obj) arg1,  (Obj) arg2,  (Obj) arg3,  (Obj) arg4,  (Obj) arg5,  (Obj) arg6);
     else {
-      SET_BRK_CALL_TO( call );
       CALL_6ARGS( func, arg1, arg2, arg3, arg4, arg5, arg6 );
     }
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
@@ -375,10 +377,10 @@ UInt            ExecProccallXargs (
     }
 
     /* call the function                                                   */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
       DoOperation2Args(CallFuncListOper, func, args);
     } else {
-      SET_BRK_CALL_TO( call );
       CALL_XARGS( func, args );
     }
 
@@ -441,12 +443,12 @@ Obj             EvalFunccall0args (
     /* evaluate the function                                               */
     func = EVAL_EXPR( FUNC_CALL( call ) );
 
+    /* call the function and return the result                             */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
       return DispatchFuncCall(func, 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0 );
     }
 
-    /* call the function and return the result                             */
-    SET_BRK_CALL_TO( call );
     result = CALL_0ARGS( func );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
@@ -473,12 +475,12 @@ Obj             EvalFunccall1args (
       /* evaluate the arguments                                              */
     arg1 = EVAL_EXPR( ARGI_CALL( call, 1 ) );
 
+    /* call the function and return the result                             */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
       return DispatchFuncCall(func, 1, (Obj) arg1, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0 );
     }
 
-    /* call the function and return the result                             */
-    SET_BRK_CALL_TO( call );
     result = CALL_1ARGS( func, arg1 );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
@@ -508,12 +510,12 @@ Obj             EvalFunccall2args (
     arg1 = EVAL_EXPR( ARGI_CALL( call, 1 ) );
     arg2 = EVAL_EXPR( ARGI_CALL( call, 2 ) );
 
+    /* call the function and return the result                             */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
       return DispatchFuncCall(func, 2, (Obj) arg1, (Obj) arg2, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0 );
     }
 
-    /* call the function and return the result                             */
-    SET_BRK_CALL_TO( call );
     result = CALL_2ARGS( func, arg1, arg2 );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
@@ -545,12 +547,12 @@ Obj             EvalFunccall3args (
     arg2 = EVAL_EXPR( ARGI_CALL( call, 2 ) );
     arg3 = EVAL_EXPR( ARGI_CALL( call, 3 ) );
 
+    /* call the function and return the result                             */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
       return DispatchFuncCall(func, 3, (Obj) arg1, (Obj) arg2, (Obj) arg3, (Obj) 0, (Obj) 0, (Obj) 0 );
     }
 
-    /* call the function and return the result                             */
-    SET_BRK_CALL_TO( call );
     result = CALL_3ARGS( func, arg1, arg2, arg3 );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
@@ -583,12 +585,12 @@ Obj             EvalFunccall4args (
     arg3 = EVAL_EXPR( ARGI_CALL( call, 3 ) );
     arg4 = EVAL_EXPR( ARGI_CALL( call, 4 ) );
 
+    /* call the function and return the result                             */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
       return DispatchFuncCall(func, 4, (Obj) arg1, (Obj) arg2, (Obj) arg3, (Obj) arg4, (Obj) 0, (Obj) 0 );
     }
 
-    /* call the function and return the result                             */
-    SET_BRK_CALL_TO( call );
     result = CALL_4ARGS( func, arg1, arg2, arg3, arg4 );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
@@ -624,12 +626,12 @@ Obj             EvalFunccall5args (
     arg4 = EVAL_EXPR( ARGI_CALL( call, 4 ) );
     arg5 = EVAL_EXPR( ARGI_CALL( call, 5 ) );
 
+    /* call the function and return the result                             */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
       return DispatchFuncCall(func, 5, (Obj) arg1, (Obj) arg2, (Obj) arg3, (Obj) arg4, (Obj) arg5, (Obj) 0 );
     }
 
-    /* call the function and return the result                             */
-    SET_BRK_CALL_TO( call );
     result = CALL_5ARGS( func, arg1, arg2, arg3, arg4, arg5 );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
@@ -667,12 +669,12 @@ Obj             EvalFunccall6args (
     arg5 = EVAL_EXPR( ARGI_CALL( call, 5 ) );
     arg6 = EVAL_EXPR( ARGI_CALL( call, 6 ) );
 
+    /* call the function and return the result                             */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
       return DispatchFuncCall(func, 6, (Obj) arg1, (Obj) arg2, (Obj) arg3, (Obj) arg4, (Obj) arg5, (Obj) arg6 );
     }
 
-    /* call the function and return the result                             */
-    SET_BRK_CALL_TO( call );
     result = CALL_6ARGS( func, arg1, arg2, arg3, arg4, arg5, arg6 );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
@@ -708,12 +710,12 @@ Obj             EvalFunccallXargs (
         CHANGED_BAG( args );
     }
 
+    /* call the function and return the result                             */
+    SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
       return DispatchFuncCall(func, -1, (Obj) args, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0 );
     }
 
-    /* call the function and return the result                             */
-    SET_BRK_CALL_TO( call );
     result = CALL_XARGS( func, args );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -446,10 +446,10 @@ Obj             EvalFunccall0args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
-      return DispatchFuncCall(func, 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0 );
+      result = DispatchFuncCall(func, 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0 );
+    } else {
+      result = CALL_0ARGS( func );
     }
-
-    result = CALL_0ARGS( func );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
@@ -478,10 +478,10 @@ Obj             EvalFunccall1args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
-      return DispatchFuncCall(func, 1, (Obj) arg1, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0 );
+      result = DispatchFuncCall(func, 1, (Obj) arg1, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0 );
+    } else {
+      result = CALL_1ARGS( func, arg1 );
     }
-
-    result = CALL_1ARGS( func, arg1 );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
@@ -513,10 +513,10 @@ Obj             EvalFunccall2args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
-      return DispatchFuncCall(func, 2, (Obj) arg1, (Obj) arg2, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0 );
+      result = DispatchFuncCall(func, 2, (Obj) arg1, (Obj) arg2, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0 );
+    } else {
+      result = CALL_2ARGS( func, arg1, arg2 );
     }
-
-    result = CALL_2ARGS( func, arg1, arg2 );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
@@ -550,10 +550,10 @@ Obj             EvalFunccall3args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
-      return DispatchFuncCall(func, 3, (Obj) arg1, (Obj) arg2, (Obj) arg3, (Obj) 0, (Obj) 0, (Obj) 0 );
+      result = DispatchFuncCall(func, 3, (Obj) arg1, (Obj) arg2, (Obj) arg3, (Obj) 0, (Obj) 0, (Obj) 0 );
+    } else {
+      result = CALL_3ARGS( func, arg1, arg2, arg3 );
     }
-
-    result = CALL_3ARGS( func, arg1, arg2, arg3 );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
@@ -588,10 +588,10 @@ Obj             EvalFunccall4args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
-      return DispatchFuncCall(func, 4, (Obj) arg1, (Obj) arg2, (Obj) arg3, (Obj) arg4, (Obj) 0, (Obj) 0 );
+      result = DispatchFuncCall(func, 4, (Obj) arg1, (Obj) arg2, (Obj) arg3, (Obj) arg4, (Obj) 0, (Obj) 0 );
+    } else {
+      result = CALL_4ARGS( func, arg1, arg2, arg3, arg4 );
     }
-
-    result = CALL_4ARGS( func, arg1, arg2, arg3, arg4 );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
@@ -629,10 +629,10 @@ Obj             EvalFunccall5args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
-      return DispatchFuncCall(func, 5, (Obj) arg1, (Obj) arg2, (Obj) arg3, (Obj) arg4, (Obj) arg5, (Obj) 0 );
+      result = DispatchFuncCall(func, 5, (Obj) arg1, (Obj) arg2, (Obj) arg3, (Obj) arg4, (Obj) arg5, (Obj) 0 );
+    } else {
+      result = CALL_5ARGS( func, arg1, arg2, arg3, arg4, arg5 );
     }
-
-    result = CALL_5ARGS( func, arg1, arg2, arg3, arg4, arg5 );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
@@ -672,10 +672,10 @@ Obj             EvalFunccall6args (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
-      return DispatchFuncCall(func, 6, (Obj) arg1, (Obj) arg2, (Obj) arg3, (Obj) arg4, (Obj) arg5, (Obj) arg6 );
+      result = DispatchFuncCall(func, 6, (Obj) arg1, (Obj) arg2, (Obj) arg3, (Obj) arg4, (Obj) arg5, (Obj) arg6 );
+    } else {
+      result = CALL_6ARGS( func, arg1, arg2, arg3, arg4, arg5, arg6 );
     }
-
-    result = CALL_6ARGS( func, arg1, arg2, arg3, arg4, arg5, arg6 );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */
@@ -713,10 +713,10 @@ Obj             EvalFunccallXargs (
     /* call the function and return the result                             */
     SET_BRK_CALL_TO( call );
     if (TNUM_OBJ(func) != T_FUNCTION) {
-      return DispatchFuncCall(func, -1, (Obj) args, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0 );
+      result = DispatchFuncCall(func, -1, (Obj) args, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0, (Obj) 0 );
+    } else {
+      result = CALL_XARGS( func, args );
     }
-
-    result = CALL_XARGS( func, args );
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) /* the procedure must have called
                                        READ() and the user quit from a break
                                        loop inside it */

--- a/tst/test-error/func-and-proc-call-trace.g
+++ b/tst/test-error/func-and-proc-call-trace.g
@@ -1,0 +1,112 @@
+informproc0 := function(l)
+Add(l,1);
+l();
+end;;
+informproc0([]);
+quit;
+Print("\n\n");
+informproc1 := function(l)
+Add(l,1);
+l(1);
+end;;
+informproc1([]);
+quit;
+Print("\n\n");
+informproc2 := function(l)
+Add(l,1);
+l(1,2);
+end;;
+informproc2([]);
+quit;
+Print("\n\n");
+informproc3 := function(l)
+Add(l,1);
+l(1,2,3);
+end;;
+informproc3([]);
+quit; 
+Print("\n\n");
+informproc4 := function(l)
+Add(l,1);
+l(1,2,3,4);
+end;;
+informproc4([]);
+quit;
+Print("\n\n");
+informproc5 := function(l)
+Add(l,1);
+l(1,2,3,4,5);
+end;;
+informproc5([]);
+quit;
+Print("\n\n");
+informproc6 := function(l)
+Add(l,1);
+l(1,2,3,4,5,6);
+end;;
+informproc6([]);
+quit;
+Print("\n\n");
+informprocmore := function(l)
+Add(l,1);
+l(1,2,3,4,5,6,7);
+end;;
+informprocmore([]);
+quit;
+Print("\n\n");
+informfunc0 := function(l)
+Add(l,1);
+Print(l());
+end;;
+informfunc0([]);
+quit;
+Print("\n\n");
+informfunc1 := function(l)
+Add(l,1);
+Print(l(1));
+end;;
+informfunc1([]);
+quit;
+Print("\n\n");
+informfunc2 := function(l)
+Add(l,1);
+Print(l(1,2));
+end;;
+informfunc2([]);
+quit;
+Print("\n\n");
+informfunc3 := function(l)
+Add(l,1);
+Print(l(1,2,3));
+end;;
+informfunc3([]);
+quit;
+Print("\n\n");
+informfunc4 := function(l)
+Add(l,1);
+Print(l(1,2,3,4));
+end;;
+informfunc4([]);
+quit;
+Print("\n\n");
+informfunc5 := function(l)
+Add(l,1);
+Print(l(1,2,3,4,5));
+end;;
+informfunc5([]);
+quit;
+Print("\n\n");
+informfunc6 := function(l)
+Add(l,1);
+Print(l(1,2,3,4,5,6));
+end;;
+informfunc6([]);
+quit;
+Print("\n\n");
+informfuncmore := function(l)
+Add(l,1);
+Print(l(1,2,3,4,5,6,7));
+end;;
+informfuncmore([]);
+quit;
+Print("\n\n");

--- a/tst/test-error/func-and-proc-call-trace.g.out
+++ b/tst/test-error/func-and-proc-call-trace.g.out
@@ -1,0 +1,144 @@
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l(  ); at *stdin*:3 called from
+<function "informproc0">( <arguments> )
+ called from read-eval loop at *stdin*:5
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1 ); at *stdin*:8 called from
+<function "informproc1">( <arguments> )
+ called from read-eval loop at *stdin*:10
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1, 2 ); at *stdin*:13 called from
+<function "informproc2">( <arguments> )
+ called from read-eval loop at *stdin*:15
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1, 2, 3 ); at *stdin*:18 called from
+<function "informproc3">( <arguments> )
+ called from read-eval loop at *stdin*:20
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1, 2, 3, 4 ); at *stdin*:23 called from
+<function "informproc4">( <arguments> )
+ called from read-eval loop at *stdin*:25
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1, 2, 3, 4, 5 ); at *stdin*:28 called from
+<function "informproc5">( <arguments> )
+ called from read-eval loop at *stdin*:30
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1, 2, 3, 4, 5, 6 ); at *stdin*:33 called from
+<function "informproc6">( <arguments> )
+ called from read-eval loop at *stdin*:35
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1, 2, 3, 4, 5, 6, 7 ); at *stdin*:38 called from
+<function "informprocmore">( <arguments> )
+ called from read-eval loop at *stdin*:40
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l(  ) at *stdin*:43 called from
+<function "informfunc0">( <arguments> )
+ called from read-eval loop at *stdin*:45
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1 ) at *stdin*:48 called from
+<function "informfunc1">( <arguments> )
+ called from read-eval loop at *stdin*:50
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1, 2 ) at *stdin*:53 called from
+<function "informfunc2">( <arguments> )
+ called from read-eval loop at *stdin*:55
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1, 2, 3 ) at *stdin*:58 called from
+<function "informfunc3">( <arguments> )
+ called from read-eval loop at *stdin*:60
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1, 2, 3, 4 ) at *stdin*:63 called from
+<function "informfunc4">( <arguments> )
+ called from read-eval loop at *stdin*:65
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1, 2, 3, 4, 5 ) at *stdin*:68 called from
+<function "informfunc5">( <arguments> )
+ called from read-eval loop at *stdin*:70
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1, 2, 3, 4, 5, 6 ) at *stdin*:73 called from
+<function "informfunc6">( <arguments> )
+ called from read-eval loop at *stdin*:75
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:241 called from
+l( 1, 2, 3, 4, 5, 6, 7 ) at *stdin*:78 called from
+<function "informfuncmore">( <arguments> )
+ called from read-eval loop at *stdin*:80
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> 
+

--- a/tst/testinstall/callfunc.tst
+++ b/tst/testinstall/callfunc.tst
@@ -102,5 +102,27 @@ gap> CALL_FUNC_LIST(o, [1,2,3,4,5,6]);
 gap> CALL_FUNC_LIST(o, [1,2,3,4,5,6,7]);
 [ 1, 2, 3, 4, 5, 6, 7 ]
 
-#
+# test overloading CallFuncList with a procedure call
+gap> cat2 := NewCategory("IsXYZ2",IsObject);;
+gap> type2 := NewType(fam, cat2 and IsPositionalObjectRep);;
+gap> InstallMethod(CallFuncList,[cat2,IsList],function(func,args) result:=args; end);
+gap> o2 := Objectify(type2,[]);;
+
+# test edge case: expecting a func call, but doing a proc call
+gap> f := function() return o2(); end;; f();
+Error, Function Calls: <func> must return a value
+gap> f := function() return o2(1); end;; f();
+Error, Function Calls: <func> must return a value
+gap> f := function() return o2(1,2); end;; f();
+Error, Function Calls: <func> must return a value
+gap> f := function() return o2(1,2,3); end;; f();
+Error, Function Calls: <func> must return a value
+gap> f := function() return o2(1,2,3,4); end;; f();
+Error, Function Calls: <func> must return a value
+gap> f := function() return o2(1,2,3,4,5); end;; f();
+Error, Function Calls: <func> must return a value
+gap> f := function() return o2(1,2,3,4,6,7); end;; f();
+Error, Function Calls: <func> must return a value
+gap> f := function() return o2(1,2,3,4,5,6,7); end;; f();
+Error, Function Calls: <func> must return a value
 gap> STOP_TEST( "callfunc.tst", 1);


### PR DESCRIPTION
Consider the following interaction with a freshly-compiled gap from master; it is essentially the same phenomenon as the first example in #917, albeit with the offending bit of code as a procedure call rather than a function:
```
 ┌───────┐   GAP 4.8.8-4439-gbeeebb0 of today
 │  GAP  │   https://www.gap-system.org
 └───────┘   Architecture: x86_64-pc-linux-gnu-gcc-default64
 Configuration:  gmp 6.1.2, readline
 Loading the library and packages ...
 Packages:   GAPDoc 1.6, PrimGrp 3.1.2, smallgrp 1.2, transgrp 2.0
 Try '??help' for help. See also '?copyright', '?cite' and '?authors'
gap> mislead := function(l)
> Add(l,1);
> l(1);
> return; end;
function( l ) ... end
gap> mislead([]);
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 1st choice method found for `CallFuncList' on 2 arguments at /home/gwhitney/code/dev/gap/lib/methsel2.g:241 called from
Add( l, 1 ); at *stdin*:2 called from
<function "mislead">( <arguments> )
 called from read-eval loop at *stdin*:5
you can 'quit;' to quit to outer loop, or
you can 'return;' to continue
brk> quit;
gap> quit;
```
I included the opening banner so that you can easily count the lines in *stdin* and see that the backtrace is misreporting the expression in which the error (namely that there is no method for the function-call syntax with the function object being a list) occurs and the line on which it occurred. But now contrast that session with the following one:
```
 ┌───────┐   GAP 4.8.8-4439-gbeeebb0 of today
 │  GAP  │   https://www.gap-system.org
 └───────┘   Architecture: x86_64-pc-linux-gnu-gcc-default64
 Configuration:  gmp 6.1.2, readline
 Loading the library and packages ...
 Packages:   GAPDoc 1.6, PrimGrp 3.1.2, smallgrp 1.2, transgrp 2.0
 Try '??help' for help. See also '?copyright', '?cite' and '?authors'
gap> inform := function(l)
> Add(l,1);
> l();
> return; end;
function( l ) ... end
gap> inform([]);
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 1st choice method found for `CallFuncList' on 2 arguments at /home/gwhitney/code/dev/gap/lib/methsel2.g:241 called from
l(  ); at *stdin*:3 called from
<function "inform">( <arguments> )
 called from read-eval loop at *stdin*:5
you can 'quit;' to quit to outer loop, or
you can 'return;' to continue
brk> quit;
gap> quit;
```
Now the error message is corretly showing that the offending code was at line 3, and it lies in "l( )" (there's still no method for the function call of a list object). The difference might be mysterious until you look at code in funcs.c and compare ExecProccall0args, in which SET_BRK_CALL_TO() occurs **before** the DispatchFuncCall, with ExecProccall1args, in which SET_BRK_CALL_TO() occurs **after** the DispatchFuncCall. Examining the remaining ExecProc... and EvalFunc... functions suggests that similar bad behavior will occur in all of those corresponding cases, and sure enough, I have attached a transcript of the remaining 12 cases displaying misleading information.

It appears that when the code to allow arbitrary objects to implement the function call syntax was added, in almost all (but thankfully not all, otherwise I would have been very unlikely to find this) cases the DispatchFuncCall was added "too early" in the various ExecProc... and EvalFunc... functions. This pull request moves the SET_BRK_CALL_TO()s uniformly before the DispatchFuncCall, and the other attachment shows a transcript of all 14 cases suppling more informative messages.

I will update the pull request with a test based on the latter transcript as soon as I figure out how the extended testing for the full backtrace added in pull request #918 works.
[issue_917_examples.txt](https://github.com/gap-system/gap/files/1418307/issue_917_examples.txt)
 
[issue_917_corrected.txt](https://github.com/gap-system/gap/files/1418308/issue_917_corrected.txt)

Resolves #917.