### PR TITLE
Provide String() and PrintString() methods for DirectProductElements

### DIFF
--- a/hpcgap/lib/tuples.gi
+++ b/hpcgap/lib/tuples.gi
@@ -145,25 +145,48 @@ InstallOtherMethod( DirectProductElement,
     return DirectProductElementNC( fam, objlist );
     end );
 
-
 #############################################################################
 ##
-#M  PrintObj( <dpelm> )  . . . . . . . . . . . print a direct product element
+#M  String( <dpelm> )  . . . . . . convert a direct product element to string
 ##
-InstallMethod( PrintObj,
+InstallMethod( String,
     "for a direct product element",
     [ IsDirectProductElement ],
     function( dpelm )
-    local i;
-    Print( "DirectProductElement( [ " );
-    for i in [ 1 .. Length( dpelm )-1 ] do
-      Print( dpelm[i], ", " );
-    od;
-    if Length( dpelm ) <> 0 then
-      Print( dpelm[ Length( dpelm ) ] );
+    local i, str;
+    str := "DirectProductElement( [ ";
+    if Length( dpelm ) > 0 then
+      Append( str, String( dpelm[1] ) );
     fi;
-    Print(" ] )");
+    for i in [ 2 .. Length( dpelm ) ] do
+      Append( str, ", " );
+      Append( str, String( dpelm[i] ) );
+    od;
+    Append( str, " ] )" );
+    return str;
     end );
+
+#############################################################################
+##
+#M  PrintString( <dpelm> ) . convert a direct product element to print string
+##
+InstallMethod( PrintString,
+    "for a direct product element",
+    [ IsDirectProductElement ],
+    function( dpelm )
+    local i, str;
+    str := "DirectProductElement( [ ";
+    if Length( dpelm ) > 0 then
+      Append( str, PrintString( dpelm[1] ) );
+    fi;
+    for i in [ 2 .. Length( dpelm ) ] do
+      Append( str, ",\<\> " );
+      Append( str, PrintString( dpelm[i] ) );
+    od;
+    Append( str, " ] )" );
+    return str;
+    end );
+
 
 #############################################################################
 ##

--- a/lib/tuples.gi
+++ b/lib/tuples.gi
@@ -139,25 +139,48 @@ InstallOtherMethod( DirectProductElement,
     return DirectProductElementNC( fam, objlist );
     end );
 
-
 #############################################################################
 ##
-#M  PrintObj( <dpelm> )  . . . . . . . . . . . print a direct product element
+#M  String( <dpelm> )  . . . . . . convert a direct product element to string
 ##
-InstallMethod( PrintObj,
+InstallMethod( String,
     "for a direct product element",
     [ IsDirectProductElement ],
     function( dpelm )
-    local i;
-    Print( "DirectProductElement( [ " );
-    for i in [ 1 .. Length( dpelm )-1 ] do
-      Print( dpelm[i], ", " );
-    od;
-    if Length( dpelm ) <> 0 then
-      Print( dpelm[ Length( dpelm ) ] );
+    local i, str;
+    str := "DirectProductElement( [ ";
+    if Length( dpelm ) > 0 then
+      Append( str, String( dpelm[1] ) );
     fi;
-    Print(" ] )");
+    for i in [ 2 .. Length( dpelm ) ] do
+      Append( str, ", " );
+      Append( str, String( dpelm[i] ) );
+    od;
+    Append( str, " ] )" );
+    return str;
     end );
+
+#############################################################################
+##
+#M  PrintString( <dpelm> ) . convert a direct product element to print string
+##
+InstallMethod( PrintString,
+    "for a direct product element",
+    [ IsDirectProductElement ],
+    function( dpelm )
+    local i, str;
+    str := "DirectProductElement( [ ";
+    if Length( dpelm ) > 0 then
+      Append( str, PrintString( dpelm[1] ) );
+    fi;
+    for i in [ 2 .. Length( dpelm ) ] do
+      Append( str, ",\<\> " );
+      Append( str, PrintString( dpelm[i] ) );
+    od;
+    Append( str, " ] )" );
+    return str;
+    end );
+
 
 #############################################################################
 ##

--- a/tst/testinstall/DirectProductElement.tst
+++ b/tst/testinstall/DirectProductElement.tst
@@ -1,0 +1,25 @@
+# Embryonic test for DirectProductElement objects, could be expanded.
+gap> START_TEST("DirectProductElement.tst");
+gap> numdpe1 := DirectProductElement([1,2]);
+DirectProductElement( [ 1, 2 ] )
+gap> numdpe2 := DirectProductElement([3,4]);
+DirectProductElement( [ 3, 4 ] )
+gap> numdpe1 + numdpe2;
+DirectProductElement( [ 4, 6 ] )
+gap> numdpe1 / 3;
+DirectProductElement( [ 1/3, 2/3 ] )
+gap> numdpe1 * [2, 3];
+[ DirectProductElement( [ 2, 4 ] ), DirectProductElement( [ 3, 6 ] ) ]
+gap> numdpe1 + [numdpe1, numdpe2];
+[ DirectProductElement( [ 2, 4 ] ), DirectProductElement( [ 4, 6 ] ) ]
+
+# Using SymmetricGroup below specifically because its String() and
+# PrintString() are different.
+gap> adpe := DirectProductElement([SymmetricGroup(3), 1]);;
+gap> String(adpe);
+"DirectProductElement( [ SymmetricGroup( [ 1 .. 3 ] ), 1 ] )"
+gap> PrintString(adpe);
+"DirectProductElement( [ Group( \>[ (1,2,3), (1,2) ]\<\> )\<,\<\> 1 ] )"
+gap> Display(adpe);
+DirectProductElement( [ Group( [ (1,2,3), (1,2) ] ), 1 ] )
+gap> STOP_TEST("DirectProductElement.tst");

--- a/tst/testinstall/mapping.tst
+++ b/tst/testinstall/mapping.tst
@@ -10,13 +10,12 @@ gap> M:= GF(3);
 GF(3)
 gap> tuples:= List( Tuples( AsList( M ), 2 ), DirectProductElement );;
 gap> Print(tuples,"\n");
-[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), DirectProductElement( [ 0*Z(3), 
+[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), DirectProductElement( [ 0*Z(3),
     Z(3)^0 ] ), DirectProductElement( [ 0*Z(3), Z(3) ] ), 
-  DirectProductElement( [ Z(3)^0, 0*Z(3) ] ), DirectProductElement( [ Z(3)^0, 
+  DirectProductElement( [ Z(3)^0, 0*Z(3) ] ), DirectProductElement( [ Z(3)^0,
     Z(3)^0 ] ), DirectProductElement( [ Z(3)^0, Z(3) ] ), 
-  DirectProductElement( [ Z(3), 0*Z(3) ] ), 
-  DirectProductElement( [ Z(3), Z(3)^0 ] ), 
-  DirectProductElement( [ Z(3), Z(3) ] ) ]
+  DirectProductElement( [ Z(3), 0*Z(3) ] ), DirectProductElement( [ Z(3),
+    Z(3)^0 ] ), DirectProductElement( [ Z(3), Z(3) ] ) ]
 gap> map:= GeneralMappingByElements( M, M, [] );
 <general mapping: GF(3) -> GF(3) >
 gap> IsInjective( map );
@@ -40,7 +39,7 @@ true
 gap> inv:= InverseGeneralMapping( map );
 InverseGeneralMapping( <general mapping: GF(3) -> GF(3) > )
 gap> Print(AsList( UnderlyingRelation( inv ) ),"\n");
-[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), DirectProductElement( [ 0*Z(3), 
+[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), DirectProductElement( [ 0*Z(3),
     Z(3)^0 ] ), DirectProductElement( [ 0*Z(3), Z(3) ] ), 
   DirectProductElement( [ Z(3)^0, 0*Z(3) ] ) ]
 gap> IsInjective( inv );
@@ -56,13 +55,12 @@ CompositionMapping(
 InverseGeneralMapping( <general mapping: GF(3) -> GF(3) > ),
  <general mapping: GF(3) -> GF(3) > )
 gap> Print(AsList( UnderlyingRelation( comp ) ),"\n");
-[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), DirectProductElement( [ 0*Z(3), 
+[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), DirectProductElement( [ 0*Z(3),
     Z(3)^0 ] ), DirectProductElement( [ 0*Z(3), Z(3) ] ), 
-  DirectProductElement( [ Z(3)^0, 0*Z(3) ] ), DirectProductElement( [ Z(3)^0, 
+  DirectProductElement( [ Z(3)^0, 0*Z(3) ] ), DirectProductElement( [ Z(3)^0,
     Z(3)^0 ] ), DirectProductElement( [ Z(3)^0, Z(3) ] ), 
-  DirectProductElement( [ Z(3), 0*Z(3) ] ), 
-  DirectProductElement( [ Z(3), Z(3)^0 ] ), 
-  DirectProductElement( [ Z(3), Z(3) ] ) ]
+  DirectProductElement( [ Z(3), 0*Z(3) ] ), DirectProductElement( [ Z(3),
+    Z(3)^0 ] ), DirectProductElement( [ Z(3), Z(3) ] ) ]
 gap> IsInjective( comp );
 false
 gap> IsSingleValued( comp );
@@ -75,7 +73,7 @@ gap> anticomp:= CompositionMapping( map, inv );
 CompositionMapping( <general mapping: GF(3) -> GF(3) >,
  InverseGeneralMapping( <general mapping: GF(3) -> GF(3) > ) )
 gap> Print(AsList( UnderlyingRelation( anticomp ) ),"\n");
-[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), DirectProductElement( [ 0*Z(3), 
+[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), DirectProductElement( [ 0*Z(3),
     Z(3)^0 ] ), DirectProductElement( [ Z(3)^0, 0*Z(3) ] ), 
   DirectProductElement( [ Z(3)^0, Z(3)^0 ] ) ]
 gap> IsInjective( anticomp );
@@ -201,7 +199,7 @@ gap> (0*Z(3)) ^ map;
 gap> map:= InverseGeneralMapping( map );
 InverseGeneralMapping( <mapping: GF(3) -> GF(3) > )
 gap> Print(AsList( UnderlyingRelation( map ) ),"\n");
-[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), DirectProductElement( [ 0*Z(3), 
+[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), DirectProductElement( [ 0*Z(3),
     Z(3)^0 ] ), DirectProductElement( [ Z(3)^0, Z(3) ] ) ]
 gap> IsInjective( map );
 true
@@ -244,7 +242,7 @@ gap> ImagesRepresentative( map, Z(3) );
 gap> map:= InverseGeneralMapping( map );
 InverseGeneralMapping( <mapping: GF(3) -> GF(3) > )
 gap> Print(AsList( UnderlyingRelation( map ) ),"\n");
-[ DirectProductElement( [ 0*Z(3), Z(3) ] ), DirectProductElement( [ Z(3)^0, 
+[ DirectProductElement( [ 0*Z(3), Z(3) ] ), DirectProductElement( [ Z(3)^0,
     0*Z(3) ] ), DirectProductElement( [ Z(3), Z(3)^0 ] ) ]
 gap> IsInjective( map );
 true


### PR DESCRIPTION
This pull request fixes part (1A) of issue #1824 which IMHO is a bug. I could not reproduce the exact identical linebreaks and spaces at the end of lines in the results of "mapping.tst", so I added a PrintString() method for DirectProductElements to get very close, and then updated mapping.tst to reflect the remaining slight differences.
