### PR TITLE
Add BindConstant, BIND_CONSTANT and use them

### DIFF
--- a/hpcgap/lib/type.g
+++ b/hpcgap/lib/type.g
@@ -29,9 +29,9 @@
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "POS_DATA_TYPE", 3 );
-BIND_GLOBAL( "POS_NUMB_TYPE", 4 );
-BIND_GLOBAL( "POS_FIRST_FREE_TYPE", 5 );
+BIND_CONSTANT( "POS_DATA_TYPE", 3 );
+BIND_CONSTANT( "POS_NUMB_TYPE", 4 );
+BIND_CONSTANT( "POS_FIRST_FREE_TYPE", 5 );
 
 
 #############################################################################
@@ -47,11 +47,10 @@ BIND_GLOBAL( "POS_FIRST_FREE_TYPE", 5 );
 ##
 if TNUM_OBJ(2^30) = 0 then
     NEW_TYPE_NEXT_ID := -(2^60);
-    NEW_TYPE_ID_LIMIT:= 2^60-1;
+    NEW_TYPE_ID_LIMIT := 2^60-1;
 else
     NEW_TYPE_NEXT_ID := -(2^28);
     NEW_TYPE_ID_LIMIT := 2^28-1;
-#    NEW_TYPE_ID_LIMIT := NEW_TYPE_NEXT_ID + 1000000;
 fi;
 
 

--- a/lib/global.g
+++ b/lib/global.g
@@ -145,6 +145,22 @@ BIND_GLOBAL := function( name, val)
 end;
 MAKE_READ_ONLY_GLOBAL("BIND_GLOBAL");
 
+BIND_CONSTANT := function( name, val)
+    # Ignore attempts to reassign an identical value, to simplify
+    # rereading files
+    if ISBOUND_GLOBAL( name ) and 
+       IS_IDENTICAL_OBJ( val, VAL_GVAR( name ) ) then
+       return;
+    fi;
+
+    # Even when REREADING we do not allow constants to be changed, as
+    # they are substituted in at parsing time
+    ASS_GVAR(name, val);
+    MAKE_CONSTANT_GLOBAL(name);
+    return val;
+end;
+MAKE_READ_ONLY_GLOBAL("BIND_CONSTANT");
+
 #############################################################################
 ##
 #E  global.g . . . . . . . . . . . . . . . . . . . . . . . . . . . ends here

--- a/lib/global.gd
+++ b/lib/global.gd
@@ -196,18 +196,21 @@ DeclareGlobalFunction("MakeConstantGlobal");
 ##  <#GAPDoc Label="BindGlobal">
 ##  <ManSection>
 ##  <Func Name="BindGlobal" Arg='name, val'/>
+##  <Func Name="BindConstant" Arg='name, val'/>
 ##
 ##  <Description>
-##  sets the global variable named by the string <A>name</A> to the value
-##  <A>val</A>, provided it is writable, and makes it read-only.
+##  <Ref Func="BindGlobal"/> and <Ref Func="BindConstant"/> set the global
+##  variable named by the string <A>name</A> to the value <A>val</A>,
+##  provided that variable is writable. <Ref Func="BindGlobal"/> makes
+##  the resulting variable read-only, while <Ref Func="BindConstant"/> makes
+##  it constant.
 ##  If <A>name</A> already had a value, a warning message is printed.
 ##  <P/>
 ##  This is intended to be the normal way to create and set <Q>official</Q>
-##  global variables (such as operations and filters).
+##  global variables (such as operations, filters and constants).
 ##  <P/>
 ##  Caution should be exercised in using these functions, especially
-##  <Ref Func="BindGlobal"/> and <Ref Func="UnbindGlobal"/>
-##  as unexpected changes
+##  <Ref Func="UnbindGlobal"/> as unexpected changes
 ##  in global variables can be very confusing for the user.
 ##  <P/>
 ##  <Example><![CDATA[
@@ -233,7 +236,7 @@ DeclareGlobalFunction("MakeConstantGlobal");
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction("BindGlobal");
-
+DeclareGlobalFunction("BindConstant");
 
 #############################################################################
 ##

--- a/lib/global.gi
+++ b/lib/global.gi
@@ -259,6 +259,14 @@ InstallGlobalFunction( BindGlobal,
     BIND_GLOBAL( name, value );
 end);
 
+
+InstallGlobalFunction( BindConstant, 
+        function (name, value)
+    CheckGlobalName( name );
+    Info( InfoGlobal, 2, "BindConstant: called to set ", name, " to ", value);
+    BIND_CONSTANT( name, value );
+end);
+
 #############################################################################
 ##
 #F  TemporaryGlobalVarName( [<prefix>] )   name of an unbound global variable

--- a/lib/type.g
+++ b/lib/type.g
@@ -29,9 +29,9 @@
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "POS_DATA_TYPE", 3 );
-BIND_GLOBAL( "POS_NUMB_TYPE", 4 );
-BIND_GLOBAL( "POS_FIRST_FREE_TYPE", 5 );
+BIND_CONSTANT( "POS_DATA_TYPE", 3 );
+BIND_CONSTANT( "POS_NUMB_TYPE", 4 );
+BIND_CONSTANT( "POS_FIRST_FREE_TYPE", 5 );
 
 
 #############################################################################
@@ -47,11 +47,10 @@ BIND_GLOBAL( "POS_FIRST_FREE_TYPE", 5 );
 ##
 if TNUM_OBJ(2^30) = 0 then
     NEW_TYPE_NEXT_ID := -(2^60);
-    NEW_TYPE_ID_LIMIT:= 2^60-1;
+    NEW_TYPE_ID_LIMIT := 2^60-1;
 else
     NEW_TYPE_NEXT_ID := -(2^28);
     NEW_TYPE_ID_LIMIT := 2^28-1;
-#    NEW_TYPE_ID_LIMIT := NEW_TYPE_NEXT_ID + 1000000;
 fi;
 
 

--- a/tst/testinstall/constant.tst
+++ b/tst/testinstall/constant.tst
@@ -169,3 +169,21 @@ gap> (function() if boolfalsevar then return 1; elif booltruevar then return 2; 
 2
 gap> (function() if boolfalsevar then return 1; elif boolfalsevar then return 2; else return 3; fi; end)();
 3
+gap> BindConstant("constx", 3);
+gap> constx;
+3
+gap> BindConstant("constx", 3);
+gap> BindConstant("constx", 4);
+Error, Variable: 'constx' is constant
+gap> BindConstant("constx", true);
+Error, Variable: 'constx' is constant
+gap> BindConstant("consty", true);
+gap> consty;
+true
+gap> BindConstant("constz", false);
+gap> constz;
+false
+gap> BindConstant(23, 3);
+Error, CheckGlobalName: the argument must be a string
+gap> BindConstant( (1,2), 3);
+Error, CheckGlobalName: the argument must be a string


### PR DESCRIPTION
This contains a rebased version of the first commit of #1770, with a small improvement to one of the documentation comments; and also a second commit which uses `BIND_CONSTANT` for a few things.

Motivation: #1770 currently does not merge, and contains a second, more controversial change. It makes no sense to delay `BIND_CONSTANT` further, better to merge this now and then rebase #1770.