### PR TITLE
Reduce TypOutputFile STATE members for logging from 6 to 2

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -75,12 +75,8 @@ typedef struct GAPState {
     TypOutputFile * InputLog;
     TypOutputFile * OutputLog;
     TypOutputFile * IgnoreStdoutErrout;
-    TypOutputFile   LogFile;
-    TypOutputFile   LogStream;
-    TypOutputFile   InputLogFile;
-    TypOutputFile   InputLogStream;
-    TypOutputFile   OutputLogFile;
-    TypOutputFile   OutputLogStream;
+    TypOutputFile   InputLogFileOrStream;
+    TypOutputFile   OutputLogFileOrStream;
     Int             HELPSubsOn;
     Int             NoSplitLine;
     KOutputStream   TheStream;


### PR DESCRIPTION
This may interfere with @markuspf so let's not merge this before he had a chance to check (probably delay till after PR #1767 has been merged in any case).

Note that this is somewhat orthogonal to the decoupling efforts in PR #1767: the `STATE` members touched by this PR here all naturally "belong" to `scanner.c`, and thus should be in its `MODULE_STATE`; but regardless of that, it's beneficial to remove redundant state members.

Esp. since each `TypOutputFile` takes up 6560 bytes on a 64 bit system, so his PR shaves 25kb of the `STATE`. Note that `sizeof(GAPState)` is 693512 in GAP and 42656 on the master branch. So for HPC-GAP, this more than halves the size of each `STATE`, down to 16416 bytes (less than 16k), which may have beneficial performance implications. For GAP, the bulk of the space is taken up by these two arrays:
```
    TypInputFile  InputFiles[16];
    TypOutputFile OutputFiles[16];
```

The one concern I have about this PR is that I feel the whole logging code is not very well tested by our test suite. So perhaps we should look at the coverage for the affected functions in `scanner.c`, and add additional tests for them (which would involve "testing" the log file, I guess).

Meta question @ChrisJefferson actually, couldn't we use `LogTo` to get much nicer to read `.out` files in `tst/test-error/`? I just entered this into a GAP session:
```
LogTo("foo.log");
1/0;
quit;
0^0;
```
and afterwards got this log:
```
gap> 1/0;
Error, Rational operations: <divisor> must not be zero
not in any function at *stdin*:2
you can replace <divisor> via 'return <divisor>;'
brk> quit;
gap> 0^0;
1
gap> 
```
which IMHO is much more helpful than the current `.out` files.