### PR TITLE
More IMPLICATIONS changes (second half of PR #1729)

### DIFF
--- a/hpcgap/lib/filter.g
+++ b/hpcgap/lib/filter.g
@@ -76,7 +76,6 @@ IMM_FLAGS := FLAGS_FILTER( IS_OBJECT );
 
 #############################################################################
 ##
-
 #F  Setter( <filter> )  . . . . . . . . . . . . . . . .  setter of a <filter>
 ##
 BIND_GLOBAL( "Setter", SETTER_FILTER );
@@ -89,17 +88,16 @@ BIND_GLOBAL( "Setter", SETTER_FILTER );
 BIND_GLOBAL( "Tester", TESTER_FILTER );
 
 
-
 #############################################################################
 ##
-#F  InstallTrueMethodNewFilter( <to>, <from> )
+#F  InstallTrueMethodNewFilter( <tofilt>, <from> )
 ##
 ##  If <from> is a new filter then  it cannot occur in  the cache.  Therefore
 ##  we do not flush the cache.  <from> should a basic  filter not an `and' of
 ##  from. This should only be used in the file "type.g".
 ##
 BIND_GLOBAL( "InstallTrueMethodNewFilter", function ( tofilt, from )
-    local   imp;
+    local   imp, found, imp2;
 
     # Check that no filter implies `IsMutable'.
     # (If this would be allowed then `Immutable' would be able
@@ -110,12 +108,34 @@ BIND_GLOBAL( "InstallTrueMethodNewFilter", function ( tofilt, from )
       Error( "filter <from> must not imply `IsMutable'" );
     fi;
 
-    atomic IMPLICATIONS do
+    # If 'tofilt' equals 'IsObject' then do nothing.
+    if IS_IDENTICAL_OBJ( tofilt, IS_OBJECT ) then
+      return;
+    fi;
+
+    # Apply the available implications from 'tofilt and from' to 'tofilt'.
     imp := [];
-    imp[1] := FLAGS_FILTER( tofilt );
+    imp[1] := WITH_IMPS_FLAGS( AND_FLAGS( FLAGS_FILTER( tofilt ),
+                                          FLAGS_FILTER( from ) ) );
     imp[2] := FLAGS_FILTER( from );
-    MIGRATE_RAW(imp, IMPLICATIONS);
-    ADD_LIST( IMPLICATIONS, imp );
+
+    atomic IMPLICATIONS do
+    # Extend available implications by the new one if applicable.
+    found:= false;
+    for imp2 in IMPLICATIONS do
+      if IS_SUBSET_FLAGS( imp2[2], imp[2] ) then
+        imp2[1]:= AND_FLAGS( imp2[1], imp[1] );
+        if IS_EQUAL_FLAGS( imp2[2], imp[2] ) then
+          found:= true;
+        fi;
+      fi;
+    od;
+
+    if not found then
+      # Extend the list of implications.
+      MIGRATE_RAW(imp, IMPLICATIONS);
+      ADD_LIST( IMPLICATIONS, imp );
+    fi;
     od;
     InstallHiddenTrueMethod( tofilt, from );
 end );

--- a/hpcgap/lib/type.g
+++ b/hpcgap/lib/type.g
@@ -109,7 +109,6 @@ BIND_GLOBAL( "NewCategory", function ( arg )
 
     # Create the filter.
     cat:= NEW_FILTER( arg[1] );
-    InstallTrueMethodNewFilter( arg[2], cat );
 
     # Do some administrational work.
     atomic readwrite CATS_AND_REPS do
@@ -126,6 +125,9 @@ BIND_GLOBAL( "NewCategory", function ( arg )
     fi;
     INFO_FILTERS[ FLAG1_FILTER( cat ) ] := 2;
     od;
+
+    # Do not call this before adding 'cat' to 'FILTERS'.
+    InstallTrueMethodNewFilter( arg[2], cat );
 
     # Return the filter.
     return cat;
@@ -281,7 +283,6 @@ BIND_GLOBAL( "NewRepresentation", function ( arg )
     else
         Error("usage:NewRepresentation(<name>,<super>,<slots>[,<req>])");
     fi;
-    InstallTrueMethodNewFilter( arg[2], rep );
 
     # Do some administrational work.
     atomic readwrite CATS_AND_REPS, FILTER_REGION do
@@ -291,6 +292,9 @@ BIND_GLOBAL( "NewRepresentation", function ( arg )
     RANK_FILTERS[ FLAG1_FILTER( rep ) ] := 1;
     INFO_FILTERS[ FLAG1_FILTER( rep ) ] := 4;
     od;
+
+    # Do not call this before adding 'rep' to 'FILTERS'.
+    InstallTrueMethodNewFilter( arg[2], rep );
 
     # Return the filter.
     return rep;

--- a/lib/filter.g
+++ b/lib/filter.g
@@ -76,7 +76,6 @@ IMM_FLAGS := FLAGS_FILTER( IS_OBJECT );
 
 #############################################################################
 ##
-
 #F  Setter( <filter> )  . . . . . . . . . . . . . . . .  setter of a <filter>
 ##
 BIND_GLOBAL( "Setter", SETTER_FILTER );
@@ -89,17 +88,16 @@ BIND_GLOBAL( "Setter", SETTER_FILTER );
 BIND_GLOBAL( "Tester", TESTER_FILTER );
 
 
-
 #############################################################################
 ##
-#F  InstallTrueMethodNewFilter( <to>, <from> )
+#F  InstallTrueMethodNewFilter( <tofilt>, <from> )
 ##
 ##  If <from> is a new filter then  it cannot occur in  the cache.  Therefore
 ##  we do not flush the cache.  <from> should a basic  filter not an `and' of
 ##  from. This should only be used in the file "type.g".
 ##
 BIND_GLOBAL( "InstallTrueMethodNewFilter", function ( tofilt, from )
-    local   imp;
+    local   imp, found, imp2;
 
     # Check that no filter implies `IsMutable'.
     # (If this would be allowed then `Immutable' would be able
@@ -110,10 +108,32 @@ BIND_GLOBAL( "InstallTrueMethodNewFilter", function ( tofilt, from )
       Error( "filter <from> must not imply `IsMutable'" );
     fi;
 
+    # If 'tofilt' equals 'IsObject' then do nothing.
+    if IS_IDENTICAL_OBJ( tofilt, IS_OBJECT ) then
+      return;
+    fi;
+
+    # Apply the available implications from 'tofilt and from' to 'tofilt'.
     imp := [];
-    imp[1] := FLAGS_FILTER( tofilt );
+    imp[1] := WITH_IMPS_FLAGS( AND_FLAGS( FLAGS_FILTER( tofilt ),
+                                          FLAGS_FILTER( from ) ) );
     imp[2] := FLAGS_FILTER( from );
-    ADD_LIST( IMPLICATIONS, imp );
+
+    # Extend available implications by the new one if applicable.
+    found:= false;
+    for imp2 in IMPLICATIONS do
+      if IS_SUBSET_FLAGS( imp2[2], imp[2] ) then
+        imp2[1]:= AND_FLAGS( imp2[1], imp[1] );
+        if IS_EQUAL_FLAGS( imp2[2], imp[2] ) then
+          found:= true;
+        fi;
+      fi;
+    od;
+
+    if not found then
+      # Extend the list of implications.
+      ADD_LIST( IMPLICATIONS, imp );
+    fi;
     InstallHiddenTrueMethod( tofilt, from );
 end );
 

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -271,31 +271,40 @@ end);
 ##  <Func Name="ShowImpliedFilters" Arg='filter'/>
 ##
 ##  <Description>
-##  Displays information about the filters that may be implied by 
-##  <A>filter</A>. They are given by their names. <C>ShowImpliedFilters</C> first
-##  displays the names of all filters that are unconditionally implied by
-##  <A>filter</A>. It then displays implications that require further filters to
-##  be present (indicating by <C>+</C> the required further filters).
-##  The function displays only first-level implications, implications that
-##  follow in turn are not displayed (though &GAP; will do these).
+##  Displays information about the filters that may be
+##  implied by <A>filter</A>. They are given by their names.
+##  <C>ShowImpliedFilters</C> first displays the names of all filters
+##  that are unconditionally implied by <A>filter</A>. It then displays
+##  implications that require further filters to be present (indicating
+##  by <C>+</C> the required further filters).
 ##  <Example><![CDATA[
-##  gap> ShowImpliedFilters(IsMatrix);
+##  gap> ShowImpliedFilters(IsNilpotentGroup);
 ##  Implies:
-##     IsNearAdditiveElementWithInverse
-##     IsAdditiveElement
-##     IsMultiplicativeElement
-##     IsGeneralizedRowVector
+##     IsNilpotentGroup
+##     HasIsNilpotentGroup
+##     IsSupersolvableGroup
+##     HasIsSupersolvableGroup
+##     IsSolvableGroup
+##     HasIsSolvableGroup
+##     IsNilpotentByFinite
+##     HasIsNilpotentByFinite
 ##  
 ##  
 ##  May imply with:
-##  +IsInternalRep
-##     IsOrdinaryMatrix
-##  
-##  +CategoryCollections(CategoryCollections(IsAdditivelyCommutativeElement))
-##     IsAdditivelyCommutativeElement
-##  
-##  +IsGF2MatrixRep
-##     IsOrdinaryMatrix
+##  +IsFinitelyGeneratedGroup
+##  +HasIsFinitelyGeneratedGroup
+##     IsFinitelyGeneratedGroup
+##     HasIsFinitelyGeneratedGroup
+##     IsNilpotentGroup
+##     HasIsNilpotentGroup
+##     IsSupersolvableGroup
+##     HasIsSupersolvableGroup
+##     IsSolvableGroup
+##     HasIsSolvableGroup
+##     IsPolycyclicGroup
+##     HasIsPolycyclicGroup
+##     IsNilpotentByFinite
+##     HasIsNilpotentByFinite
 ##  
 ##  ]]></Example>
 ##  </Description>

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -305,8 +305,9 @@ end);
 BIND_GLOBAL("ShowImpliedFilters",function(fil)
 local flags,f,i,j,l,m,n;
   flags:=FLAGS_FILTER(fil);
-  atomic readonly IMPLICATIONS do
-    f:=Filtered(IMPLICATIONS,x->IS_SUBSET_FLAGS(x[2],flags));
+  atomic readonly IMPLICATIONS_SIMPLE do
+    f:=Filtered(IMPLICATIONS_SIMPLE, x->IS_SUBSET_FLAGS(x[2],flags));
+    Append(f, Filtered(IMPLICATIONS_COMPOSED, x->IS_SUBSET_FLAGS(x[2],flags)));
     l:=[];
     m:=[];
     for i in f do

--- a/lib/type.g
+++ b/lib/type.g
@@ -107,7 +107,6 @@ BIND_GLOBAL( "NewCategory", function ( arg )
 
     # Create the filter.
     cat:= NEW_FILTER( arg[1] );
-    InstallTrueMethodNewFilter( arg[2], cat );
 
     # Do some administrational work.
     ADD_LIST( CATS_AND_REPS, FLAG1_FILTER( cat ) );
@@ -120,6 +119,9 @@ BIND_GLOBAL( "NewCategory", function ( arg )
       RANK_FILTERS[ FLAG1_FILTER( cat ) ]:= 1;
     fi;
     INFO_FILTERS[ FLAG1_FILTER( cat ) ] := 2;
+
+    # Do not call this before adding 'cat' to 'FILTERS'.
+    InstallTrueMethodNewFilter( arg[2], cat );
 
     # Return the filter.
     return cat;
@@ -260,7 +262,6 @@ BIND_GLOBAL( "NewRepresentation", function ( arg )
     else
         Error("usage:NewRepresentation(<name>,<super>,<slots>[,<req>])");
     fi;
-    InstallTrueMethodNewFilter( arg[2], rep );
 
     # Do some administrational work.
     ADD_LIST( CATS_AND_REPS, FLAG1_FILTER( rep ) );
@@ -268,6 +269,9 @@ BIND_GLOBAL( "NewRepresentation", function ( arg )
     IMM_FLAGS:= AND_FLAGS( IMM_FLAGS, FLAGS_FILTER( rep ) );
     RANK_FILTERS[ FLAG1_FILTER( rep ) ] := 1;
     INFO_FILTERS[ FLAG1_FILTER( rep ) ] := 4;
+
+    # Do not call this before adding 'rep' to 'FILTERS'.
+    InstallTrueMethodNewFilter( arg[2], rep );
 
     # Return the filter.
     return rep;

--- a/src/opers.c
+++ b/src/opers.c
@@ -951,7 +951,9 @@ Obj FuncWITH_HIDDEN_IMPS_FLAGS(Obj self, Obj flags)
     return with;
 }
 
-static Obj IMPLICATIONS;
+
+static Obj IMPLICATIONS_SIMPLE;
+static Obj IMPLICATIONS_COMPOSED;
 static Obj WITH_IMPS_FLAGS_CACHE;
 enum { IMPS_CACHE_LENGTH = 11001 };
 
@@ -963,7 +965,7 @@ Obj FuncCLEAR_IMP_CACHE(Obj self)
 {
   Int i;
 #ifdef HPCGAP
-  RegionWriteLock(REGION(IMPLICATIONS));
+  RegionWriteLock(REGION(IMPLICATIONS_SIMPLE));
 #endif
   for(i = 1; i < IMPS_CACHE_LENGTH * 2 - 1; i += 2)
   {
@@ -971,7 +973,7 @@ Obj FuncCLEAR_IMP_CACHE(Obj self)
     SET_ELM_PLIST(WITH_IMPS_FLAGS_CACHE, i + 1, 0);
   }
 #ifdef HPCGAP
-  RegionWriteUnlock(REGION(IMPLICATIONS));
+  RegionWriteUnlock(REGION(IMPLICATIONS_SIMPLE));
 #endif
   return 0;
 }
@@ -986,9 +988,7 @@ static Int WITH_IMPS_FLAGS_HIT=0;
 #endif
 Obj FuncWITH_IMPS_FLAGS(Obj self, Obj flags)
 {
-    Int changed, lastand, i;
-    Int stop;
-    Int imps_length;
+    Int changed, lastand, i, j, stop, imps_length;
     Int base_hash = INT_INTOBJ(FuncHASH_FLAGS(0, flags)) % IMPS_CACHE_LENGTH;
     Int hash = base_hash;
     Int hash_loop = 0;
@@ -997,6 +997,7 @@ Obj FuncWITH_IMPS_FLAGS(Obj self, Obj flags)
     Int old_moving;
     Obj with = flags;
     Obj imp;
+    Obj trues;
     
     /* do some trivial checks - we have to do this so we can use
      * UncheckedIS_SUBSET_FLAGS                                              */
@@ -1006,7 +1007,7 @@ Obj FuncWITH_IMPS_FLAGS(Obj self, Obj flags)
             "you can replace <flags> via 'return <flags>;'" );
     }
 #ifdef HPCGAP
-    RegionWriteLock(REGION(IMPLICATIONS));
+    RegionWriteLock(REGION(IMPLICATIONS_SIMPLE));
 #endif
     for(hash_loop = 0; hash_loop < 3; ++hash_loop)
     {
@@ -1014,7 +1015,7 @@ Obj FuncWITH_IMPS_FLAGS(Obj self, Obj flags)
       if(cacheval && cacheval == flags) {
         Obj ret = ELM_PLIST(WITH_IMPS_FLAGS_CACHE, hash*2+2);
 #ifdef HPCGAP
-        RegionWriteUnlock(REGION(IMPLICATIONS));
+        RegionWriteUnlock(REGION(IMPLICATIONS_SIMPLE));
 #endif
 #ifdef COUNT_OPERS
         WITH_IMPS_FLAGS_HIT++;
@@ -1027,15 +1028,31 @@ Obj FuncWITH_IMPS_FLAGS(Obj self, Obj flags)
 #ifdef COUNT_OPERS
     WITH_IMPS_FLAGS_MISS++;
 #endif
+    /* first implications from simple filters (need only be checked once) */
+    trues = FuncTRUES_FLAGS(0, flags);
+    for (i=1; i<=LEN_PLIST(trues); i++) {
+        j = INT_INTOBJ(ELM_PLIST(trues, i));
+        if (j <= LEN_PLIST(IMPLICATIONS_SIMPLE)
+            && ELM_PLIST(IMPLICATIONS_SIMPLE, j)) {
+           imp = ELM_PLIST(IMPLICATIONS_SIMPLE, j);
+           if( UncheckedIS_SUBSET_FLAGS(with, ELM_PLIST(imp, 2)) == True &&
+              UncheckedIS_SUBSET_FLAGS(with, ELM_PLIST(imp, 1)) != True )
+           {
+             with = FuncAND_FLAGS(0, with, ELM_PLIST(imp, 1));
+           }
+        }
+    }
+
+    /* the other implications have to be considered in a loop */
+    imps_length = LEN_PLIST(IMPLICATIONS_COMPOSED);
     changed = 1;
-    imps_length = LEN_PLIST(IMPLICATIONS);
     lastand = imps_length+1;
     while(changed)
     {
       changed = 0;
       for (i = 1, stop = lastand; i < stop; i++)
       {
-        imp = ELM_PLIST(IMPLICATIONS, i);
+        imp = ELM_PLIST(IMPLICATIONS_COMPOSED, i);
         if( UncheckedIS_SUBSET_FLAGS(with, ELM_PLIST(imp, 2)) == True &&
            UncheckedIS_SUBSET_FLAGS(with, ELM_PLIST(imp, 1)) != True )
         {
@@ -1076,7 +1093,7 @@ Obj FuncWITH_IMPS_FLAGS(Obj self, Obj flags)
     }
     
 #ifdef HPCGAP
-    RegionWriteUnlock(REGION(IMPLICATIONS));
+    RegionWriteUnlock(REGION(IMPLICATIONS_SIMPLE));
 #endif
     return with;
 }
@@ -4259,7 +4276,8 @@ static Int InitKernel (
     
     /* set up implications                                                 */
     InitGlobalBag( &WITH_IMPS_FLAGS_CACHE, "src/opers.c:WITH_IMPS_FLAGS_CACHE");
-    InitGlobalBag( &IMPLICATIONS, "src/opers.c:IMPLICATIONS");
+    InitGlobalBag( &IMPLICATIONS_SIMPLE, "src/opers.c:IMPLICATIONS_SIMPLE");
+    InitGlobalBag( &IMPLICATIONS_COMPOSED, "src/opers.c:IMPLICATIONS_COMPOSED");
     
     /* make the 'true' operation                                           */  
     InitGlobalBag( &ReturnTrueFilter, "src/opers.c:ReturnTrueFilter" );
@@ -4405,15 +4423,19 @@ static Int InitLibrary (
     REGION(WITH_HIDDEN_IMPS_FLAGS_CACHE) = REGION(HIDDEN_IMPS);
 #endif
 
-    IMPLICATIONS = NEW_PLIST(T_PLIST, 0);
-    SET_LEN_PLIST(IMPLICATIONS, 0);
+    IMPLICATIONS_SIMPLE = NEW_PLIST(T_PLIST, 0);
+    SET_LEN_PLIST(IMPLICATIONS_SIMPLE, 0);
+    IMPLICATIONS_COMPOSED = NEW_PLIST(T_PLIST, 0);
+    SET_LEN_PLIST(IMPLICATIONS_COMPOSED, 0);
     WITH_IMPS_FLAGS_CACHE = NEW_PLIST(T_PLIST, IMPS_CACHE_LENGTH * 2);
     SET_LEN_PLIST(WITH_IMPS_FLAGS_CACHE, IMPS_CACHE_LENGTH * 2);
-    AssGVar(GVarName("IMPLICATIONS"), IMPLICATIONS);
+    AssGVar(GVarName("IMPLICATIONS_SIMPLE"), IMPLICATIONS_SIMPLE);
+    AssGVar(GVarName("IMPLICATIONS_COMPOSED"), IMPLICATIONS_COMPOSED);
 
 #ifdef HPCGAP
-    REGION(IMPLICATIONS) = NewRegion();
-    REGION(WITH_IMPS_FLAGS_CACHE) = REGION(IMPLICATIONS);
+    REGION(IMPLICATIONS_SIMPLE) = NewRegion();
+    REGION(IMPLICATIONS_COMPOSED) = REGION(IMPLICATIONS_SIMPLE);
+    REGION(WITH_IMPS_FLAGS_CACHE) = REGION(IMPLICATIONS_SIMPLE);
 #endif
 
     /* make the 'true' operation                                           */  

--- a/tst/testbugfix/2005-07-18-t00082.tst
+++ b/tst/testbugfix/2005-07-18-t00082.tst
@@ -1,2 +1,0 @@
-# 2005/07/18 (FL)
-gap> TypeObj(IMPLICATIONS);;


### PR DESCRIPTION
This PR adds the remaining changes from PR #1729, with the exception of the C version of `RankFilter`, which @frankluebeck said did not provide a measurable speed gain, so I left it out for simplicity.

UPDATE: this PR should be working ready for review now. I am leaving the old text below, even though it mostly doesn't apply anymore.


This PR is not done, but I thought it best to submit it here, lest it gets forgotten.

One problem is that HPC-GAP is not working right now (basically because the C code is careless about locking a region already locked by the active thread, which cause an abort via `assert`. That's easy to fix, but I first want to understand the exact execution sequence leading to that, which simply requires some time I don't have right now).

The first two commits are also in PR #1834 and I expect that to be merged first, so they can be ignored for review of this PR.

The next commit then is "Store only ranks different from 1 in RANK_FILTERS"; that change was nestled in another bigger commit in the old PR, and last time around was controversial. As it is, I don't see any benefit of that commit (in particular, no memory is saved), and it could be trivially dropped from this PR. In fact, unless somebody explains why it is beneficial, that's exactly what I plan to do at a later point.

The last two commits are pretty much trivial, though I actually think they ought to be squash into the "Split IMPLICATIONS" commit.

This leaves two actual commits worthy of review in this PR -- but it might be easier to wait with a review until PR #1834 has been merged and this PR has been rebased.