### PR TITLE
Make permutations remember their inverses (cleanup of #1772)

### DIFF
--- a/doc/ref/permutat.xml
+++ b/doc/ref/permutat.xml
@@ -26,8 +26,7 @@ Permutations in &GAP; are  entered and displayed in cycle notation,
 such as <C>(1,2,3)(4,5)</C>.
 <P/>
 The preimage of the point <M>i</M> under the permutation <M>p</M> can be
-computed as <M>i</M><C>/</C><M>p</M>,
-without constructing the inverse of <M>p</M>.
+computed as <M>i</M><C>/</C><M>p</M>, see <Ref Var="PERM_INVERSE_THRESHOLD"/>.
 <P/>
 For arithmetic operations for permutations and their precedence,
 see&nbsp;<Ref Sect="Arithmetic Operations for Elements"/>.
@@ -47,6 +46,7 @@ the category test function for permutations is <Ref Func="IsPerm"/>.
 <#Include Label="IsPerm">
 <#Include Label="IsPermCollection">
 <#Include Label="PermutationsFamily">
+<#Include Label="PERM_INVERSE_THRESHOLD">
 
 </Section>
 

--- a/lib/dicthf.gi
+++ b/lib/dicthf.gi
@@ -208,7 +208,7 @@ function(d,pe)
            if IsPerm4Rep(p) then
              # is it a proper 4byte perm?
              if l>65536 then
-               return HashKeyBag(p,255,0,4*l);
+               return HashKeyBag(p,255,GAPInfo.BytesPerVariable,4*l);
              else
                # the permutation does not require 4 bytes. Trim in two
                # byte representation (we need to do this to get consistent
@@ -217,7 +217,7 @@ function(d,pe)
              fi;
             fi;
             # now we have a Perm2Rep:
-            return HashKeyBag(p,255,0,2*l);
+            return HashKeyBag(p,255,GAPInfo.BytesPerVariable,2*l);
           end;
 end);
 

--- a/lib/permutat.g
+++ b/lib/permutat.g
@@ -763,6 +763,29 @@ InstallMethod( DistancePerms, "for general permutations",
         function(x,y)
     return NrMovedPoints(x/y); end);
 
+#############################################################################
+##
+#V  PERM_INVERSE_THRESHOLD . . . . cut off for when inverses are computed
+##                                 eagerly
+##
+##  <#GAPDoc Label="PERM_INVERSE_THRESHOLD">
+##  <ManSection>
+##  <Var Name="PERM_INVERSE_THRESHOLD"/>
+##
+##  <Description>
+##  For permutations of degree up to <C>PERM_INVERSE_THRESHOLD</C> whenever
+##  the inverse image of a point under a permutations is needed, the entire
+##  inverse is computed and stored. Otherwise, if the inverse is not stored,
+##  the point is traced around the cycle it is part of to find the inverse
+##  image. This takes time when it happens, and uses memory, but saves time
+##  on a variety of subsequent computations. This threshold can be adjusted
+##  by simply assigning to the variable. The default is 10000.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+
+PERM_INVERSE_THRESHOLD := 10000;
+
 
 
 #############################################################################

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -868,10 +868,10 @@ Obj             EvalPermExpr (
 			    c, MAX_DEG_PERM4);
 
             /* if necessary resize the permutation                         */
-            if ( SIZE_OBJ(perm)/sizeof(UInt4) < c ) {
-                ResizeBag( perm, (c + 1023) / 1024 * 1024 * sizeof(UInt4) );
-                ptr4 = ADDR_PERM4( perm );
-                for ( k = m+1; k <= SIZE_OBJ(perm)/sizeof(UInt4); k++ ) {
+            if (DEG_PERM4(perm) < c) {
+                ResizeBag(perm, SIZEBAG_PERM4((c + 1023) / 1024 * 1024));
+                ptr4 = ADDR_PERM4(perm);
+                for (k = m + 1; k <= DEG_PERM4(perm); k++) {
                     ptr4[k-1] = k-1;
                 }
             }
@@ -911,12 +911,12 @@ Obj             EvalPermExpr (
             ptr2[k-1] = ptr4[k-1];
         };
         RetypeBag( perm, T_PERM2 );
-        ResizeBag( perm, m * sizeof(UInt2) );
+        ResizeBag(perm, SIZEBAG_PERM2(m));
     }
 
     /* otherwise just shorten the permutation                              */
     else {
-        ResizeBag( perm, m * sizeof(UInt4) );
+        ResizeBag(perm, SIZEBAG_PERM4(m));
     }
 
     /* return the permutation                                              */

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1984,10 +1984,10 @@ void            IntrPermCycle (
                      c, MAX_DEG_PERM4);
 
         /* if necessary resize the permutation                             */
-        if ( SIZE_OBJ(perm)/sizeof(UInt4) < c ) {
-            ResizeBag( perm, (c + 1023) / 1024 * 1024 * sizeof(UInt4) );
+        if (DEG_PERM4(perm) < c) {
+            ResizeBag(perm, SIZEBAG_PERM4((c + 1023) / 1024 * 1024));
             ptr4 = ADDR_PERM4( perm );
-            for ( k = m+1; k <= SIZE_OBJ(perm)/sizeof(UInt4); k++ ) {
+            for (k = m + 1; k <= DEG_PERM4(perm); k++) {
                 ptr4[k-1] = k-1;
             }
         }
@@ -2057,12 +2057,12 @@ void            IntrPerm (
                 ptr2[k-1] = ptr4[k-1];
             };
             RetypeBag( perm, T_PERM2 );
-            ResizeBag( perm, m * sizeof(UInt2) );
+            ResizeBag(perm, SIZEBAG_PERM2(m));
         }
 
         /* otherwise just shorten the permutation                          */
         else {
-            ResizeBag( perm, m * sizeof(UInt4) );
+            ResizeBag(perm, SIZEBAG_PERM4(m));
         }
 
     }

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -1178,7 +1178,7 @@ Obj             PowPerm2Int (
 {
     Obj                 pow;            /* handle of the power (result)    */
     UInt2 *             ptP;            /* pointer to the power            */
-    UInt2 *             ptL;            /* pointer to the permutation      */
+    const UInt2 *       ptL;            /* pointer to the permutation      */
     UInt2 *             ptKnown;        /* pointer to temporary bag        */
     UInt                deg;            /* degree of the permutation       */
     Int                 exp,  e;        /* exponent (right operand)        */
@@ -1202,7 +1202,7 @@ Obj             PowPerm2Int (
 
         /* get pointer to the permutation and the power                    */
         exp = INT_INTOBJ(opR);
-        ptL = ADDR_PERM2(opL);
+        ptL = CONST_ADDR_PERM2(opL);
         ptP = ADDR_PERM2(pow);
 
         /* loop over the points of the permutation                         */
@@ -1228,7 +1228,7 @@ Obj             PowPerm2Int (
 
         /* get pointer to the permutation and the power                    */
         exp = INT_INTOBJ(opR);
-        ptL = ADDR_PERM2(opL);
+        ptL = CONST_ADDR_PERM2(opL);
         ptP = ADDR_PERM2(pow);
 
         /* loop over all cycles                                            */
@@ -1273,7 +1273,7 @@ Obj             PowPerm2Int (
             ptKnown[p] = 0;
 
         /* get pointer to the permutation and the power                    */
-        ptL = ADDR_PERM2(opL);
+        ptL = CONST_ADDR_PERM2(opL);
         ptP = ADDR_PERM2(pow);
 
         /* loop over all cycles                                            */
@@ -1310,7 +1310,7 @@ Obj             PowPerm2Int (
     else if ( IS_INTOBJ(opR) && INT_INTOBJ(opR) == -1 ) {
 
         /* get pointer to the permutation and the power                    */
-        ptL = ADDR_PERM2(opL);
+        ptL = CONST_ADDR_PERM2(opL);
         ptP = ADDR_PERM2(pow);
 
         /* invert the permutation                                          */
@@ -1439,7 +1439,7 @@ Obj             PowPerm4Int (
 {
     Obj                 pow;            /* handle of the power (result)    */
     UInt4 *             ptP;            /* pointer to the power            */
-    UInt4 *             ptL;            /* pointer to the permutation      */
+    const UInt4 *       ptL;            /* pointer to the permutation      */
     UInt4 *             ptKnown;        /* pointer to temporary bag        */
     UInt                deg;            /* degree of the permutation       */
     Int                 exp,  e;        /* exponent (right operand)        */
@@ -1462,7 +1462,7 @@ Obj             PowPerm4Int (
 
         /* get pointer to the permutation and the power                    */
         exp = INT_INTOBJ(opR);
-        ptL = ADDR_PERM4(opL);
+        ptL = CONST_ADDR_PERM4(opL);
         ptP = ADDR_PERM4(pow);
 
         /* loop over the points of the permutation                         */
@@ -1489,7 +1489,7 @@ Obj             PowPerm4Int (
 
         /* get pointer to the permutation and the power                    */
         exp = INT_INTOBJ(opR);
-        ptL = ADDR_PERM4(opL);
+        ptL = CONST_ADDR_PERM4(opL);
         ptP = ADDR_PERM4(pow);
 
         /* loop over all cycles                                            */
@@ -1534,7 +1534,7 @@ Obj             PowPerm4Int (
             ptKnown[p] = 0;
 
         /* get pointer to the permutation and the power                    */
-        ptL = ADDR_PERM4(opL);
+        ptL = CONST_ADDR_PERM4(opL);
         ptP = ADDR_PERM4(pow);
 
         /* loop over all cycles                                            */
@@ -1571,7 +1571,7 @@ Obj             PowPerm4Int (
     else if ( IS_INTOBJ(opR) && INT_INTOBJ(opR) == -1 ) {
 
         /* get pointer to the permutation and the power                    */
-        ptL = ADDR_PERM4(opL);
+        ptL = CONST_ADDR_PERM4(opL);
         ptP = ADDR_PERM4(pow);
 
         /* invert the permutation                                          */
@@ -1586,7 +1586,7 @@ Obj             PowPerm4Int (
 
         /* get pointer to the permutation and the power                    */
         exp = -INT_INTOBJ(opR);
-        ptL = ADDR_PERM4(opL);
+        ptL = CONST_ADDR_PERM4(opL);
         ptP = ADDR_PERM4(pow);
 
         /* loop over the points                                            */
@@ -1612,7 +1612,7 @@ Obj             PowPerm4Int (
 
         /* get pointer to the permutation and the power                    */
         exp = -INT_INTOBJ(opR);
-        ptL = ADDR_PERM4(opL);
+        ptL = CONST_ADDR_PERM4(opL);
         ptP = ADDR_PERM4(pow);
 
         /* loop over all cycles                                            */
@@ -1658,7 +1658,7 @@ Obj             PowPerm4Int (
 
         /* get pointer to the permutation and the power                    */
         opR = ProdInt( INTOBJ_INT(-1), opR );
-        ptL = ADDR_PERM4(opL);
+        ptL = CONST_ADDR_PERM4(opL);
         ptP = ADDR_PERM4(pow);
 
         /* loop over all cycles                                            */
@@ -1794,7 +1794,7 @@ Obj             QuoIntPerm2 (
 {
     Int                 pre;            /* preimage (result)               */
     Int                 img;            /* image (left operand)            */
-    UInt2 *             ptR;            /* pointer to the permutation      */
+    const UInt2 *       ptR;            /* pointer to the permutation      */
 
     /* large positive integers (> 2^28-1) are fixed by any permutation     */
     if ( TNUM_OBJ(opL) == T_INTPOS )
@@ -1828,7 +1828,7 @@ Obj             QuoIntPerm4 (
 {
     Int                 pre;            /* preimage (result)               */
     Int                 img;            /* image (left operand)            */
-    UInt4 *             ptR;            /* pointer to the permutation      */
+    const UInt4 *       ptR;            /* pointer to the permutation      */
 
     /* large positive integers (> 2^28-1) are fixed by any permutation     */
     if ( TNUM_OBJ(opL) == T_INTPOS )
@@ -1873,9 +1873,9 @@ Obj             PowPerm22 (
     UInt                degC;           /* degree of the conjugation       */
     UInt2 *             ptC;            /* pointer to the conjugation      */
     UInt                degL;           /* degree of the left operand      */
-    UInt2 *             ptL;            /* pointer to the left operand     */
+    const UInt2 *       ptL;            /* pointer to the left operand     */
     UInt                degR;           /* degree of the right operand     */
-    UInt2 *             ptR;            /* pointer to the right operand    */
+    const UInt2 *       ptR;            /* pointer to the right operand    */
     UInt                p;              /* loop variable                   */
 
     /* compute the size of the result and allocate a bag                   */
@@ -1885,8 +1885,8 @@ Obj             PowPerm22 (
     cnj = NEW_PERM2( degC );
 
     /* set up the pointers                                                 */
-    ptL = ADDR_PERM2(opL);
-    ptR = ADDR_PERM2(opR);
+    ptL = CONST_ADDR_PERM2(opL);
+    ptR = CONST_ADDR_PERM2(opR);
     ptC = ADDR_PERM2(cnj);
 
     /* its faster if the both permutations have the same size              */
@@ -1913,9 +1913,9 @@ Obj             PowPerm24 (
     UInt                degC;           /* degree of the conjugation       */
     UInt4 *             ptC;            /* pointer to the conjugation      */
     UInt                degL;           /* degree of the left operand      */
-    UInt2 *             ptL;            /* pointer to the left operand     */
+    const UInt2 *       ptL;            /* pointer to the left operand     */
     UInt                degR;           /* degree of the right operand     */
-    UInt4 *             ptR;            /* pointer to the right operand    */
+    const UInt4 *       ptR;            /* pointer to the right operand    */
     UInt                p;              /* loop variable                   */
 
     /* compute the size of the result and allocate a bag                   */
@@ -1925,8 +1925,8 @@ Obj             PowPerm24 (
     cnj = NEW_PERM4( degC );
 
     /* set up the pointers                                                 */
-    ptL = ADDR_PERM2(opL);
-    ptR = ADDR_PERM4(opR);
+    ptL = CONST_ADDR_PERM2(opL);
+    ptR = CONST_ADDR_PERM4(opR);
     ptC = ADDR_PERM4(cnj);
 
     /* its faster if the both permutations have the same size              */
@@ -1953,9 +1953,9 @@ Obj             PowPerm42 (
     UInt                degC;           /* degree of the conjugation       */
     UInt4 *             ptC;            /* pointer to the conjugation      */
     UInt                degL;           /* degree of the left operand      */
-    UInt4 *             ptL;            /* pointer to the left operand     */
+    const UInt4 *       ptL;            /* pointer to the left operand     */
     UInt                degR;           /* degree of the right operand     */
-    UInt2 *             ptR;            /* pointer to the right operand    */
+    const UInt2 *       ptR;            /* pointer to the right operand    */
     UInt                p;              /* loop variable                   */
 
     /* compute the size of the result and allocate a bag                   */
@@ -1965,8 +1965,8 @@ Obj             PowPerm42 (
     cnj = NEW_PERM4( degC );
 
     /* set up the pointers                                                 */
-    ptL = ADDR_PERM4(opL);
-    ptR = ADDR_PERM2(opR);
+    ptL = CONST_ADDR_PERM4(opL);
+    ptR = CONST_ADDR_PERM2(opR);
     ptC = ADDR_PERM4(cnj);
 
     /* its faster if the both permutations have the same size              */
@@ -1993,9 +1993,9 @@ Obj             PowPerm44 (
     UInt                degC;           /* degree of the conjugation       */
     UInt4 *             ptC;            /* pointer to the conjugation      */
     UInt                degL;           /* degree of the left operand      */
-    UInt4 *             ptL;            /* pointer to the left operand     */
+    const UInt4 *       ptL;            /* pointer to the left operand     */
     UInt                degR;           /* degree of the right operand     */
-    UInt4 *             ptR;            /* pointer to the right operand    */
+    const UInt4 *       ptR;            /* pointer to the right operand    */
     UInt                p;              /* loop variable                   */
 
     /* compute the size of the result and allocate a bag                   */
@@ -2005,8 +2005,8 @@ Obj             PowPerm44 (
     cnj = NEW_PERM4( degC );
 
     /* set up the pointers                                                 */
-    ptL = ADDR_PERM4(opL);
-    ptR = ADDR_PERM4(opR);
+    ptL = CONST_ADDR_PERM4(opL);
+    ptR = CONST_ADDR_PERM4(opR);
     ptC = ADDR_PERM4(cnj);
 
     /* its faster if the both permutations have the same size              */

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -2281,7 +2281,7 @@ Obj             FuncPermList (
         degPerm = LEN_LIST( list );
 
         /* make sure that the global buffer bag is large enough for checkin*/
-	UseTmpPerm(degPerm*sizeof(UInt2)); 
+        UseTmpPerm(SIZEBAG_PERM2(degPerm));
 
         /* allocate the bag for the permutation and get pointer            */
         perm    = NEW_PERM2( degPerm );
@@ -2350,7 +2350,7 @@ Obj             FuncPermList (
 		       degPerm, MAX_DEG_PERM4);
 
         /* make sure that the global buffer bag is large enough for checkin*/
-	UseTmpPerm(degPerm*sizeof(UInt4));
+        UseTmpPerm(SIZEBAG_PERM4(degPerm));
 
         /* allocate the bag for the permutation and get pointer            */
         perm    = NEW_PERM4( degPerm );
@@ -3632,12 +3632,12 @@ Obj             FuncTRIM_PERM (
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
       rdeg = deg < DEG_PERM2(perm) ? deg : DEG_PERM2(perm);
-      ResizeBag( perm, sizeof(UInt2)*rdeg);
+      ResizeBag(perm, SIZEBAG_PERM2(rdeg));
     }
     else {
       rdeg = deg < DEG_PERM4(perm) ? deg : DEG_PERM4(perm);
       if (rdeg > 65536UL ) {
-	ResizeBag( perm, sizeof(UInt4)*rdeg);
+          ResizeBag(perm, SIZEBAG_PERM4(rdeg));
       }
       else {
 	/* Convert to 2Byte rep: move the points up */
@@ -3646,7 +3646,7 @@ Obj             FuncTRIM_PERM (
 	  ((UInt2*)addr)[i]=(UInt2)addr[i];
 	}
 	RetypeBag( perm, T_PERM2 );
-	ResizeBag( perm, sizeof(UInt2)*rdeg);
+        ResizeBag(perm, SIZEBAG_PERM2(rdeg));
       }
     }
 
@@ -4262,10 +4262,10 @@ Obj Array2Perm (
 			    c, MAX_DEG_PERM4);
 
             /* if necessary resize the permutation                         */
-            if ( SIZE_OBJ(perm)/sizeof(UInt4) < c ) {
-                ResizeBag( perm, (c + 1023) / 1024 * 1024 * sizeof(UInt4) );
+            if (DEG_PERM4(perm) < c) {
+                ResizeBag(perm, SIZEBAG_PERM4((c + 1023) / 1024 * 1024));
                 ptr4 = ADDR_PERM4( perm );
-                for ( k = m+1; k <= SIZE_OBJ(perm)/sizeof(UInt4); k++ ) {
+                for (k = m + 1; k <= DEG_PERM4(perm); k++) {
                     ptr4[k-1] = k-1;
                 }
             }
@@ -4305,12 +4305,12 @@ Obj Array2Perm (
             ptr2[k-1] = ptr4[k-1];
         };
         RetypeBag( perm, T_PERM2 );
-        ResizeBag( perm, m * sizeof(UInt2) );
+        ResizeBag(perm, SIZEBAG_PERM2(m));
     }
 
     /* otherwise just shorten the permutation                              */
     else {
-        ResizeBag( perm, m * sizeof(UInt4) );
+        ResizeBag(perm, SIZEBAG_PERM4(m));
     }
 
     /* return the permutation                                              */

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -1798,6 +1798,8 @@ Obj             PowIntPerm4 (
 **  point and so on, until we come  back to  <opL>.  The  last point  is  the
 **  preimage of <opL>.  This is faster because the cycles are  usually short.
 */
+static Obj PERM_INVERSE_THRESHOLD;
+
 Obj             QuoIntPerm2 (
     Obj                 opL,
     Obj                 opR )
@@ -1821,6 +1823,11 @@ Obj             QuoIntPerm2 (
     }
 
     Obj inv = STOREDINV_PERM(opR);
+
+    if (inv == 0 && PERM_INVERSE_THRESHOLD != 0 &&
+        IS_INTOBJ(PERM_INVERSE_THRESHOLD) &&
+        DEG_PERM2(opR) <= INT_INTOBJ(PERM_INVERSE_THRESHOLD))
+        inv = InvPerm(opR);
 
     if (inv != 0)
         return INTOBJ_INT(
@@ -1862,6 +1869,11 @@ Obj             QuoIntPerm4 (
     }
 
     Obj inv = STOREDINV_PERM(opR);
+
+    if (inv == 0 && PERM_INVERSE_THRESHOLD != 0 &&
+        IS_INTOBJ(PERM_INVERSE_THRESHOLD) &&
+        DEG_PERM2(opR) <= INT_INTOBJ(PERM_INVERSE_THRESHOLD))
+        inv = InvPerm(opR);
 
     if (inv != 0)
         return INTOBJ_INT(
@@ -4869,6 +4881,7 @@ static Int InitKernel (
     MakeBagTypePublic( T_PERM2);
     MakeBagTypePublic( T_PERM4);
 
+    ImportGVarFromLibrary("PERM_INVERSE_THRESHOLD", &PERM_INVERSE_THRESHOLD);
 
     /* install the type functions                                           */
     ImportGVarFromLibrary( "TYPE_PERM2", &TYPE_PERM2 );

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -781,197 +781,11 @@ Obj             ProdPerm44 (
 **  Unfortunatly this can not be done in <degree> steps, we need 2 * <degree>
 **  steps.
 */
-Obj             QuoPerm22 (
-    Obj                 opL,
-    Obj                 opR )
+Obj InvPerm(Obj);
+
+Obj QuoPerm(Obj opL, Obj opR)
 {
-    Obj                 quo;            /* handle of the quotient (result) */
-    UInt                degQ;           /* degree of the quotient          */
-    UInt2 *             ptQ;            /* pointer to the quotient         */
-    UInt                degL;           /* degree of the left operand      */
-    UInt2 *             ptL;            /* pointer to the left operand     */
-    UInt                degR;           /* degree of the right operand     */
-    UInt2 *             ptR;            /* pointer to the right operand    */
-    UInt2 *             ptI;            /* pointer to the inverse          */
-    UInt                p;              /* loop variable                   */
-
-    /* compute the size of the result and allocate a bag                   */
-    degL = DEG_PERM2(opL);
-    degR = DEG_PERM2(opR);
-    degQ = degL < degR ? degR : degL;
-    quo  = NEW_PERM2( degQ );
-
-    /* make sure that the buffer bag is large enough to hold the inverse   */
-    UseTmpPerm(SIZE_OBJ(opR));
-
-    /* invert the right permutation into the buffer bag                    */
-    ptI = ADDR_PERM2(TmpPerm);
-    ptR = ADDR_PERM2(opR);
-    for ( p = 0; p < degR; p++ )
-        ptI[ *ptR++ ] = p;
-
-    /* multiply the left permutation with the inverse                      */
-    ptL = ADDR_PERM2(opL);
-    ptI = ADDR_PERM2(TmpPerm);
-    ptQ = ADDR_PERM2(quo);
-    if ( degL <= degR ) {
-        for ( p = 0; p < degL; p++ )
-            *(ptQ++) = ptI[ *(ptL++) ];
-        for ( p = degL; p < degR; p++ )
-            *(ptQ++) = ptI[ p ];
-    }
-    else {
-        for ( p = 0; p < degL; p++ )
-
-            *(ptQ++) = IMAGE( ptL[ p ], ptI, degR );
-    }
-
-    /* return the result                                                   */
-    return quo;
-}
-
-Obj             QuoPerm24 (
-    Obj                 opL,
-    Obj                 opR )
-{
-    Obj                 quo;            /* handle of the quotient (result) */
-    UInt                degQ;           /* degree of the quotient          */
-    UInt4 *             ptQ;            /* pointer to the quotient         */
-    UInt                degL;           /* degree of the left operand      */
-    UInt2 *             ptL;            /* pointer to the left operand     */
-    UInt                degR;           /* degree of the right operand     */
-    UInt4 *             ptR;            /* pointer to the right operand    */
-    UInt4 *             ptI;            /* pointer to the inverse          */
-    UInt                p;              /* loop variable                   */
-
-    /* compute the size of the result and allocate a bag                   */
-    degL = DEG_PERM2(opL);
-    degR = DEG_PERM4(opR);
-    degQ = degL < degR ? degR : degL;
-    quo  = NEW_PERM4( degQ );
-
-    /* make sure that the buffer bag is large enough to hold the inverse   */
-    UseTmpPerm(SIZE_OBJ(opR));
-
-    /* invert the right permutation into the buffer bag                    */
-    ptI = ADDR_PERM4(TmpPerm);
-    ptR = ADDR_PERM4(opR);
-    for ( p = 0; p < degR; p++ )
-        ptI[ *ptR++ ] = p;
-
-    /* multiply the left permutation with the inverse                      */
-    ptL = ADDR_PERM2(opL);
-    ptI = ADDR_PERM4(TmpPerm);
-    ptQ = ADDR_PERM4(quo);
-    if ( degL <= degR ) {
-        for ( p = 0; p < degL; p++ )
-            *(ptQ++) = ptI[ *(ptL++) ];
-        for ( p = degL; p < degR; p++ )
-            *(ptQ++) = ptI[ p ];
-    }
-    else {
-        for ( p = 0; p < degL; p++ )
-            *(ptQ++) = IMAGE( ptL[ p ], ptI, degR );
-    }
-
-    /* return the result                                                   */
-    return quo;
-}
-
-Obj             QuoPerm42 (
-    Obj                 opL,
-    Obj                 opR )
-{
-    Obj                 quo;            /* handle of the quotient (result) */
-    UInt                degQ;           /* degree of the quotient          */
-    UInt4 *             ptQ;            /* pointer to the quotient         */
-    UInt                degL;           /* degree of the left operand      */
-    UInt4 *             ptL;            /* pointer to the left operand     */
-    UInt                degR;           /* degree of the right operand     */
-    UInt2 *             ptR;            /* pointer to the right operand    */
-    UInt2 *             ptI;            /* pointer to the inverse          */
-    UInt                p;              /* loop variable                   */
-
-    /* compute the size of the result and allocate a bag                   */
-    degL = DEG_PERM4(opL);
-    degR = DEG_PERM2(opR);
-    degQ = degL < degR ? degR : degL;
-    quo  = NEW_PERM4( degQ );
-
-    /* make sure that the buffer bag is large enough to hold the inverse   */
-    UseTmpPerm(SIZE_OBJ(opR));
-
-    /* invert the right permutation into the buffer bag                    */
-    ptI = ADDR_PERM2(TmpPerm);
-    ptR = ADDR_PERM2(opR);
-    for ( p = 0; p < degR; p++ )
-        ptI[ *ptR++ ] = p;
-
-    /* multiply the left permutation with the inverse                      */
-    ptL = ADDR_PERM4(opL);
-    ptI = ADDR_PERM2(TmpPerm);
-    ptQ = ADDR_PERM4(quo);
-    if ( degL <= degR ) {
-        for ( p = 0; p < degL; p++ )
-            *(ptQ++) = ptI[ *(ptL++) ];
-        for ( p = degL; p < degR; p++ )
-            *(ptQ++) = ptI[ p ];
-    }
-    else {
-        for ( p = 0; p < degL; p++ )
-            *(ptQ++) = IMAGE( ptL[ p ], ptI, degR );
-    }
-
-    /* return the result                                                   */
-    return quo;
-}
-
-Obj             QuoPerm44 (
-    Obj                 opL,
-    Obj                 opR )
-{
-    Obj                 quo;            /* handle of the quotient (result) */
-    UInt                degQ;           /* degree of the quotient          */
-    UInt4 *             ptQ;            /* pointer to the quotient         */
-    UInt                degL;           /* degree of the left operand      */
-    UInt4 *             ptL;            /* pointer to the left operand     */
-    UInt                degR;           /* degree of the right operand     */
-    UInt4 *             ptR;            /* pointer to the right operand    */
-    UInt4 *             ptI;            /* pointer to the inverse          */
-    UInt                p;              /* loop variable                   */
-
-    /* compute the size of the result and allocate a bag                   */
-    degL = DEG_PERM4(opL);
-    degR = DEG_PERM4(opR);
-    degQ = degL < degR ? degR : degL;
-    quo  = NEW_PERM4( degQ );
-
-    /* make sure that the buffer bag is large enough to hold the inverse   */
-    UseTmpPerm(SIZE_OBJ(opR));
-
-    /* invert the right permutation into the buffer bag                    */
-    ptI = ADDR_PERM4(TmpPerm);
-    ptR = ADDR_PERM4(opR);
-    for ( p = 0; p < degR; p++ )
-        ptI[ *ptR++ ] = p;
-
-    /* multiply the left permutation with the inverse                      */
-    ptL = ADDR_PERM4(opL);
-    ptI = ADDR_PERM4(TmpPerm);
-    ptQ = ADDR_PERM4(quo);
-    if ( degL <= degR ) {
-        for ( p = 0; p < degL; p++ )
-            *(ptQ++) = ptI[ *(ptL++) ];
-        for ( p = degL; p < degR; p++ )
-            *(ptQ++) = ptI[ p ];
-    }
-    else {
-        for ( p = 0; p < degL; p++ )
-            *(ptQ++) = IMAGE( ptL[ p ], ptI, degR );
-    }
-
-    /* return the result                                                   */
-    return quo;
+    return PROD(opL, InvPerm(opR));
 }
 
 
@@ -4928,10 +4742,10 @@ static Int InitKernel (
     ProdFuncs[ T_PERM2  ][ T_PERM4  ] = ProdPerm24;
     ProdFuncs[ T_PERM4  ][ T_PERM2  ] = ProdPerm42;
     ProdFuncs[ T_PERM4  ][ T_PERM4  ] = ProdPerm44;
-    QuoFuncs [ T_PERM2  ][ T_PERM2  ] = QuoPerm22;
-    QuoFuncs [ T_PERM2  ][ T_PERM4  ] = QuoPerm24;
-    QuoFuncs [ T_PERM4  ][ T_PERM2  ] = QuoPerm42;
-    QuoFuncs [ T_PERM4  ][ T_PERM4  ] = QuoPerm44;
+    QuoFuncs[T_PERM2][T_PERM2] = QuoPerm;
+    QuoFuncs[T_PERM2][T_PERM4] = QuoPerm;
+    QuoFuncs[T_PERM4][T_PERM2] = QuoPerm;
+    QuoFuncs[T_PERM4][T_PERM4] = QuoPerm;
     LQuoFuncs[ T_PERM2  ][ T_PERM2  ] = LQuoPerm22;
     LQuoFuncs[ T_PERM2  ][ T_PERM4  ] = LQuoPerm24;
     LQuoFuncs[ T_PERM4  ][ T_PERM2  ] = LQuoPerm42;

--- a/src/permutat.h
+++ b/src/permutat.h
@@ -73,6 +73,31 @@ static inline const UInt4 * CONST_ADDR_PERM4(Obj perm)
     return (const UInt4 *)(CONST_ADDR_OBJ(perm) + 1);
 }
 
+static inline Obj STOREDINV_PERM(Obj perm)
+{
+    return ADDR_OBJ(perm)[0];
+}
+
+/* SET_STOREDINV_PERM should only be used in neither perm, nor inv has
+   a stored inverse already.  It's OK (although inefficient) if perm and inv
+   are identical */
+static inline void SET_STOREDINV_PERM(Obj perm, Obj inv)
+{
+    /* check for the possibility that inv is in a different representation to
+       perm. It could be that perm actually acts on < 2^16 points but is in
+       PERM4 representation and some clever code has represented the inverse
+       as PERM2. It could be that someone introduces a new representation
+       altogether */
+    if (TNUM_OBJ(inv) == TNUM_OBJ(perm)) {
+        GAP_ASSERT(STOREDINV_PERM(perm) == 0 && STOREDINV_PERM(inv) == 0);
+        ADDR_OBJ(perm)[0] = inv;
+        CHANGED_BAG(perm);
+        ADDR_OBJ(inv)[0] = perm;
+        CHANGED_BAG(inv);
+    }
+}
+
+
 #define IMAGE(i,pt,dg)  (((i) < (dg)) ? (pt)[(i)] : (i))
 
 #ifdef SYS_IS_64_BIT

--- a/src/permutat.h
+++ b/src/permutat.h
@@ -23,12 +23,55 @@
 *F  DEG_PERM4(<perm>) . . . . . . . . . . . . . degree of (large) permutation
 *F  ADDR_PERM4(<perm>)  . . . . . . . absolute address of (large) permutation
 */
-#define NEW_PERM2(deg)          NewBag( T_PERM2, (deg) * sizeof(UInt2))
-#define DEG_PERM2(perm)         (SIZE_OBJ(perm) / sizeof(UInt2))
-#define ADDR_PERM2(perm)        ((UInt2*)ADDR_OBJ(perm))
-#define NEW_PERM4(deg)          NewBag( T_PERM4, (deg) * sizeof(UInt4))
-#define DEG_PERM4(perm)         (SIZE_OBJ(perm) / sizeof(UInt4))
-#define ADDR_PERM4(perm)        ((UInt4*)ADDR_OBJ(perm))
+static inline UInt SIZEBAG_PERM2(UInt deg)
+{
+    return sizeof(Obj) + deg * sizeof(UInt2);
+}
+
+static inline Obj NEW_PERM2(UInt deg)
+{
+    return NewBag(T_PERM2, SIZEBAG_PERM2(deg));
+}
+
+static inline UInt DEG_PERM2(Obj perm)
+{
+    return (SIZE_OBJ(perm) - sizeof(Obj)) / sizeof(UInt2);
+}
+
+static inline UInt2 * ADDR_PERM2(Obj perm)
+{
+    return (UInt2 *)(ADDR_OBJ(perm) + 1);
+}
+
+static inline const UInt2 * CONST_ADDR_PERM2(Obj perm)
+{
+    return (const UInt2 *)(CONST_ADDR_OBJ(perm) + 1);
+}
+
+static inline UInt SIZEBAG_PERM4(UInt deg)
+{
+    return sizeof(Obj) + deg * sizeof(UInt4);
+}
+
+static inline Obj NEW_PERM4(UInt deg)
+{
+    return NewBag(T_PERM4, SIZEBAG_PERM4(deg));
+}
+
+static inline UInt DEG_PERM4(Obj perm)
+{
+    return (SIZE_OBJ(perm) - sizeof(Obj)) / sizeof(UInt4);
+}
+
+static inline UInt4 * ADDR_PERM4(Obj perm)
+{
+    return (UInt4 *)(ADDR_OBJ(perm) + 1);
+}
+
+static inline const UInt4 * CONST_ADDR_PERM4(Obj perm)
+{
+    return (const UInt4 *)(CONST_ADDR_OBJ(perm) + 1);
+}
 
 #define IMAGE(i,pt,dg)  (((i) < (dg)) ? (pt)[(i)] : (i))
 

--- a/tst/testinstall/opers/MemoryUsage.tst
+++ b/tst/testinstall/opers/MemoryUsage.tst
@@ -15,7 +15,7 @@ gap> MemoryUsage(Z(2)) / GAPInfo.BytesPerVariable;
 gap> MemoryUsage(Z(3)) / GAPInfo.BytesPerVariable;
 1
 gap> g := (1,2,3);;
-gap> MemoryUsage(g) - MU_MemBagHeader - MU_MemPointer;
+gap> MemoryUsage(g) - MU_MemBagHeader - MU_MemPointer - GAPInfo.BytesPerVariable;
 6
 
 #


### PR DESCRIPTION
This PR is a cleaned up version of PR #1772: I run clang-format on the changes, and split them cleanly into self-contained commits. Otherwise, it should be identical to that PR.
