### PR TITLE
Remove TypInputFile::gapname

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -109,24 +109,22 @@ static inline void PopLoopNesting( void ) {
 
 static inline void SetupGapname(TypInputFile* i)
 {
-  if (!i->gapname) {
-    i->gapname = MakeImmString(i->name);
+    if (i->gapnameid == 0) {
+        Obj filename = MakeImmString(i->name);
 #ifdef HPCGAP
-    i->gapnameid = AddAList(FilenameCache, i->gapname);
-    // TODO/FIXME: adjust this code to work more like the corresponding
-    // code below for GAP?!?
+        // TODO/FIXME: adjust this code to work more like the corresponding
+        // code below for GAP?!?
+        i->gapnameid = AddAList(FilenameCache, filename);
 #else
-    Obj pos = POS_LIST( FilenameCache, i->gapname, INTOBJ_INT(1) );
-    if (pos == Fail) {
-        i->gapnameid = PushPlist(FilenameCache, i->gapname);;
-    }
-    else {
-        i->gapnameid = INT_INTOBJ(pos);
-        // Use string from FilenameCache as we know it will not get GCed
-        i->gapname = ELM_LIST( FilenameCache, i->gapnameid );
-    }
+        Obj pos = POS_LIST(FilenameCache, filename, INTOBJ_INT(1));
+        if (pos == Fail) {
+            i->gapnameid = PushPlist(FilenameCache, filename);
+        }
+        else {
+            i->gapnameid = INT_INTOBJ(pos);
+        }
 #endif
-  }
+    }
 }
 
 Obj FuncGET_FILENAME_CACHE(Obj self)
@@ -793,7 +791,8 @@ void CodeFuncExprBegin (
 
     /* record where we are reading from */
     SetupGapname(STATE(Input));
-    SET_FILENAME_BODY(body, STATE(Input)->gapname);
+    Obj filename = ELM_LIST(FilenameCache, STATE(Input)->gapnameid);
+    SET_FILENAME_BODY(body, filename);
     SET_STARTLINE_BODY(body, startLine);
     /*    Pr("Coding begin at %s:%d ",(Int)(STATE(Input)->name),STATE(Input)->number);
           Pr(" Body id %d\n",(Int)(body),0L); */

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -411,7 +411,7 @@ UInt OpenInput (
     else
       STATE(Input)->echo = 1;
     strlcpy( STATE(Input)->name, filename, sizeof(STATE(Input)->name) );
-    STATE(Input)->gapname = (Obj) 0;
+    STATE(Input)->gapnameid = 0;
 
     /* start with an empty line and no symbol                              */
     STATE(In) = STATE(Input)->line;
@@ -469,6 +469,7 @@ UInt OpenInputStream (
     STATE(Input)->file = -1;
     STATE(Input)->echo = 0;
     strlcpy( STATE(Input)->name, "stream", sizeof(STATE(Input)->name) );
+    STATE(Input)->gapnameid = 0;
 
     /* start with an empty line and no symbol                              */
     STATE(In) = STATE(Input)->line;
@@ -508,8 +509,7 @@ UInt CloseInput ( void )
     }
 
     /* don't keep GAP objects alive unnecessarily */
-    STATE(Input)->gapname = 0;
-    STATE(Input)->sline = 0;
+    memset(STATE(Input), 0, sizeof(TypInputFile));
 
     /* revert to last file                                                 */
 #ifdef HPCGAP
@@ -3001,7 +3001,6 @@ static Int InitLibrary (
 #if !defined(HPCGAP)
 static Char Cookie[ARRAY_SIZE(STATE(InputFiles))][9];
 static Char MoreCookie[ARRAY_SIZE(STATE(InputFiles))][9];
-static Char StillMoreCookie[ARRAY_SIZE(STATE(InputFiles))][9];
 #endif
 
 static Int InitKernel (
@@ -3040,12 +3039,6 @@ static Int InitKernel (
       MoreCookie[i][6] = ' ';  MoreCookie[i][7] = '0'+i;
       MoreCookie[i][8] = '\0';
       InitGlobalBag(&(STATE(InputFiles)[i].sline), &(MoreCookie[i][0]));
-
-      StillMoreCookie[i][0] = 'g';  StillMoreCookie[i][1] = 'a';  StillMoreCookie[i][2] = 'p';
-      StillMoreCookie[i][3] = 'n';  StillMoreCookie[i][4] = 'a';  StillMoreCookie[i][5] = 'm';
-      StillMoreCookie[i][6] = 'e';  StillMoreCookie[i][7] = '0'+i;
-      StillMoreCookie[i][8] = '\0';
-      InitGlobalBag(&(STATE(InputFiles)[i].gapname), &(StillMoreCookie[i][0]));
     }
 
     /* tell GASMAN about the global bags                                   */

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -715,7 +715,6 @@ typedef struct {
   UInt        isstream;
   Int         file;
   Char        name [256];
-  Obj         gapname;
   UInt        gapnameid;
   Char        line [32768];
   Char *      ptr;


### PR DESCRIPTION
This commit used to be part of PR #1826. I tried to address all of the (very valuable, thanks!) comments by @ChrisJefferson.