### PR TITLE
Use RankFilter in additional places

### DIFF
--- a/doc/ref/intrfc.xml
+++ b/doc/ref/intrfc.xml
@@ -217,8 +217,8 @@ So we have &GAP; compute the extra rank of this:
 InstallMethod(Exponent,"test abelianity", [IsGroup],
   # enforced absolute rank of `IsGroup and IsAbelian' installation: Subtract
   # the rank of `IsGroup' and add the rank of `IsGroup and IsAbelian':
-  SIZE_FLAGS(FLAGS_FILTER(IsGroup and IsAbelian))
-  -SIZE_FLAGS(FLAGS_FILTER(IsGroup)),
+  RankFilter(IsGroup and IsAbelian)
+  -RankFilter(IsGroup),
 function(G)
 ]]></Log>
 the slightly complicated construction of addition and subtraction is

--- a/grp/basic.gd
+++ b/grp/basic.gd
@@ -666,9 +666,7 @@ local val, i;
   val:=0;
   # force value 0 (unless offset).
   for i in filter do
-    # when completing, `RankFilter' is redefined. Thus we must use
-    # SIZE_FLAGS.
-    val:=val-SIZE_FLAGS(WITH_HIDDEN_IMPS_FLAGS(FLAGS_FILTER(i)));
+    val:=val-RankFilter(i);
   od;
 
   InstallOtherMethod( oper,

--- a/hpcgap/lib/oper1.g
+++ b/hpcgap/lib/oper1.g
@@ -952,9 +952,7 @@ BIND_GLOBAL( "RedispatchOnCondition", function(arg)
 
     # force value 0 (unless offset).
     for i in reqs do
-      # when completing, `RankFilter' is redefined. Thus we must use
-      # SIZE_FLAGS.
-      val:=val-SIZE_FLAGS(WITH_HIDDEN_IMPS_FLAGS(FLAGS_FILTER(i)));
+      val:=val-RankFilter(i);
     od;
 
     InstallOtherMethod( oper,

--- a/hpcgap/src/c_oper1.c
+++ b/hpcgap/src/c_oper1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include <src/compiled.h>
-#define FILE_CRC  "118869904"
+#define FILE_CRC  "77349961"
 
 /* global variables used in handlers */
 static GVar G_REREADING;
@@ -52,8 +52,6 @@ static GVar G_IS__SUBSET__FLAGS;
 static Obj  GF_IS__SUBSET__FLAGS;
 static GVar G_TRUES__FLAGS;
 static Obj  GF_TRUES__FLAGS;
-static GVar G_SIZE__FLAGS;
-static Obj  GF_SIZE__FLAGS;
 static GVar G_LEN__FLAGS;
 static Obj  GF_LEN__FLAGS;
 static GVar G_ELM__FLAGS;
@@ -3541,10 +3539,6 @@ static Obj  HdlrFunc17 (
  Obj t_6 = 0;
  Obj t_7 = 0;
  Obj t_8 = 0;
- Obj t_9 = 0;
- Obj t_10 = 0;
- Obj t_11 = 0;
- Obj t_12 = 0;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
  
@@ -3656,17 +3650,11 @@ static Obj  HdlrFunc17 (
   }
   ASS_LVAR( 5, t_2 );
   
-  /* val := val - SIZE_FLAGS( WITH_HIDDEN_IMPS_FLAGS( FLAGS_FILTER( i ) ) ); */
+  /* val := val - RankFilter( i ); */
   CHECK_BOUND( l_val, "val" )
-  t_7 = GF_SIZE__FLAGS;
-  t_9 = GF_WITH__HIDDEN__IMPS__FLAGS;
-  t_11 = GF_FLAGS__FILTER;
-  t_12 = OBJ_LVAR( 5 );
-  CHECK_BOUND( t_12, "i" )
-  t_10 = CALL_1ARGS( t_11, t_12 );
-  CHECK_FUNC_RESULT( t_10 )
-  t_8 = CALL_1ARGS( t_9, t_10 );
-  CHECK_FUNC_RESULT( t_8 )
+  t_7 = GF_RankFilter;
+  t_8 = OBJ_LVAR( 5 );
+  CHECK_BOUND( t_8, "i" )
   t_6 = CALL_1ARGS( t_7, t_8 );
   CHECK_FUNC_RESULT( t_6 )
   C_DIFF_FIA( t_5, l_val, t_6 )
@@ -3697,8 +3685,8 @@ static Obj  HdlrFunc17 (
  t_4 = NewFunction( NameFunc[18], -1, 0, HdlrFunc18 );
  SET_ENVI_FUNC( t_4, STATE(CurrLVars) );
  t_5 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_5, 964);
- SET_ENDLINE_BODY(t_5, 980);
+ SET_STARTLINE_BODY(t_5, 962);
+ SET_ENDLINE_BODY(t_5, 978);
  SET_FILENAME_BODY(t_5, FileName);
  SET_BODY_FUNC(t_4, t_5);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4306,7 +4294,7 @@ static Obj  HdlrFunc1 (
           Error( "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" );
       fi;
       for i in reqs do
-          val := val - SIZE_FLAGS( WITH_HIDDEN_IMPS_FLAGS( FLAGS_FILTER( i ) ) );
+          val := val - RankFilter( i );
       od;
       InstallOtherMethod( oper, info, fampred, reqs, val, function ( arg... )
             re := false;
@@ -4328,7 +4316,7 @@ static Obj  HdlrFunc1 (
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
  SET_STARTLINE_BODY(t_4, 932);
- SET_ENDLINE_BODY(t_4, 981);
+ SET_ENDLINE_BODY(t_4, 979);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4390,7 +4378,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_WITH__HIDDEN__IMPS__FLAGS = GVarName( "WITH_HIDDEN_IMPS_FLAGS" );
  G_IS__SUBSET__FLAGS = GVarName( "IS_SUBSET_FLAGS" );
  G_TRUES__FLAGS = GVarName( "TRUES_FLAGS" );
- G_SIZE__FLAGS = GVarName( "SIZE_FLAGS" );
  G_LEN__FLAGS = GVarName( "LEN_FLAGS" );
  G_ELM__FLAGS = GVarName( "ELM_FLAGS" );
  G_FLAG1__FILTER = GVarName( "FLAG1_FILTER" );
@@ -4508,7 +4495,6 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "WITH_HIDDEN_IMPS_FLAGS", &GF_WITH__HIDDEN__IMPS__FLAGS );
  InitFopyGVar( "IS_SUBSET_FLAGS", &GF_IS__SUBSET__FLAGS );
  InitFopyGVar( "TRUES_FLAGS", &GF_TRUES__FLAGS );
- InitFopyGVar( "SIZE_FLAGS", &GF_SIZE__FLAGS );
  InitFopyGVar( "LEN_FLAGS", &GF_LEN__FLAGS );
  InitFopyGVar( "ELM_FLAGS", &GF_ELM__FLAGS );
  InitFopyGVar( "FLAG1_FILTER", &GF_FLAG1__FILTER );
@@ -4644,7 +4630,7 @@ static StructInitInfo module = {
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,
  /* version     = */ 0,
- /* crc         = */ 118869904,
+ /* crc         = */ 77349961,
  /* initKernel  = */ InitKernel,
  /* initLibrary = */ InitLibrary,
  /* checkInit   = */ 0,

--- a/lib/fitfree.gd
+++ b/lib/fitfree.gd
@@ -9,8 +9,7 @@
 ##
 
 BindGlobal("OVERRIDENICE",Maximum(NICE_FLAGS,
-	       RankFilter(WITH_HIDDEN_IMPS_FLAGS(FLAGS_FILTER(IsMatrixGroup
-	       and IsFinite)))));
+	       RankFilter(IsMatrixGroup and IsFinite)));
 
 #############################################################################
 ##

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -3096,7 +3096,7 @@ InstallMethod(LowIndexSubgroups, "FpFroups, using LowIndexSubgroupsFpGroup",
   true,
   [IsSubgroupFpGroup,IsPosInt],
   # rank higher than method for finit groups using maximal subgroups
-  SIZE_FLAGS(WITH_HIDDEN_IMPS_FLAGS(FLAGS_FILTER(IsGroup and IsFinite))),
+  RankFilter(IsGroup and IsFinite),
   LowIndexSubgroupsFpGroup );
 
 InstallOtherMethod(LowIndexSubgroupsFpGroup,

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -928,9 +928,7 @@ BIND_GLOBAL( "RedispatchOnCondition", function(arg)
 
     # force value 0 (unless offset).
     for i in reqs do
-      # when completing, `RankFilter' is redefined. Thus we must use
-      # SIZE_FLAGS.
-      val:=val-SIZE_FLAGS(WITH_HIDDEN_IMPS_FLAGS(FLAGS_FILTER(i)));
+      val:=val-RankFilter(i);
     od;
 
     InstallOtherMethod( oper,

--- a/lib/pcgs.gi
+++ b/lib/pcgs.gi
@@ -1449,7 +1449,7 @@ InstallPcgsSeriesFromIndices:=function(series,indices)
   # workaround for old code 
   InstallMethod(series,"compatibility only",true,
     [IsPcgs and HasIndicesNormalSteps],
-     -SIZE_FLAGS(WITH_HIDDEN_IMPS_FLAGS(FLAGS_FILTER(HasIndicesNormalSteps))),
+     -RankFilter(HasIndicesNormalSteps),
   function(pcgs)
   local p,l,g,h,i,ipcgs,home;
     home:=ParentPcgs(pcgs);
@@ -1471,7 +1471,7 @@ InstallPcgsSeriesFromIndices:=function(series,indices)
 
   InstallMethod(indices,"compatibility only",true,
     [IsPcgs and HasIndicesNormalSteps],
-     -SIZE_FLAGS(WITH_HIDDEN_IMPS_FLAGS(FLAGS_FILTER(HasIndicesNormalSteps))),
+     -RankFilter(HasIndicesNormalSteps),
   function(pcgs)
   local p,l,g,h,i,ipcgs,home;
     home:=ParentPcgs(pcgs);

--- a/lib/ringsc.gi
+++ b/lib/ringsc.gi
@@ -878,7 +878,7 @@ end);
 
 InstallOtherMethod(One,"for finite SC Rings",
   [IsRing],0,
-  #-SIZE_FLAGS(WITH_HIDDEN_IMPS_FLAGS(FLAGS_FILTER(IsRing))),
+  #-RankFilter(IsRing),
 function(R)
   if not (IsSubringSCRing(R) and IsFinite(R)) then
     TryNextMethod();
@@ -906,7 +906,7 @@ end);
 
 InstallOtherMethod(OneOp,"for finite SC Rings family",
   [IsSCRingObjFamily],0,
-  #-SIZE_FLAGS(WITH_HIDDEN_IMPS_FLAGS(FLAGS_FILTER(IsRing))),
+  #-RankFilter(IsRing),
 function(fam)
 local R;
   R:=fam!.fullSCRing;

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include <src/compiled.h>
-#define FILE_CRC  "46861067"
+#define FILE_CRC  "130680522"
 
 /* global variables used in handlers */
 static GVar G_REREADING;
@@ -52,8 +52,6 @@ static GVar G_IS__SUBSET__FLAGS;
 static Obj  GF_IS__SUBSET__FLAGS;
 static GVar G_TRUES__FLAGS;
 static Obj  GF_TRUES__FLAGS;
-static GVar G_SIZE__FLAGS;
-static Obj  GF_SIZE__FLAGS;
 static GVar G_LEN__FLAGS;
 static Obj  GF_LEN__FLAGS;
 static GVar G_ELM__FLAGS;
@@ -3457,10 +3455,6 @@ static Obj  HdlrFunc17 (
  Obj t_6 = 0;
  Obj t_7 = 0;
  Obj t_8 = 0;
- Obj t_9 = 0;
- Obj t_10 = 0;
- Obj t_11 = 0;
- Obj t_12 = 0;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
  
@@ -3572,17 +3566,11 @@ static Obj  HdlrFunc17 (
   }
   ASS_LVAR( 5, t_2 );
   
-  /* val := val - SIZE_FLAGS( WITH_HIDDEN_IMPS_FLAGS( FLAGS_FILTER( i ) ) ); */
+  /* val := val - RankFilter( i ); */
   CHECK_BOUND( l_val, "val" )
-  t_7 = GF_SIZE__FLAGS;
-  t_9 = GF_WITH__HIDDEN__IMPS__FLAGS;
-  t_11 = GF_FLAGS__FILTER;
-  t_12 = OBJ_LVAR( 5 );
-  CHECK_BOUND( t_12, "i" )
-  t_10 = CALL_1ARGS( t_11, t_12 );
-  CHECK_FUNC_RESULT( t_10 )
-  t_8 = CALL_1ARGS( t_9, t_10 );
-  CHECK_FUNC_RESULT( t_8 )
+  t_7 = GF_RankFilter;
+  t_8 = OBJ_LVAR( 5 );
+  CHECK_BOUND( t_8, "i" )
   t_6 = CALL_1ARGS( t_7, t_8 );
   CHECK_FUNC_RESULT( t_6 )
   C_DIFF_FIA( t_5, l_val, t_6 )
@@ -3613,8 +3601,8 @@ static Obj  HdlrFunc17 (
  t_4 = NewFunction( NameFunc[18], -1, 0, HdlrFunc18 );
  SET_ENVI_FUNC( t_4, STATE(CurrLVars) );
  t_5 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_5, 940);
- SET_ENDLINE_BODY(t_5, 956);
+ SET_STARTLINE_BODY(t_5, 938);
+ SET_ENDLINE_BODY(t_5, 954);
  SET_FILENAME_BODY(t_5, FileName);
  SET_BODY_FUNC(t_4, t_5);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4204,7 +4192,7 @@ static Obj  HdlrFunc1 (
           Error( "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" );
       fi;
       for i in reqs do
-          val := val - SIZE_FLAGS( WITH_HIDDEN_IMPS_FLAGS( FLAGS_FILTER( i ) ) );
+          val := val - RankFilter( i );
       od;
       InstallOtherMethod( oper, info, fampred, reqs, val, function ( arg... )
             re := false;
@@ -4226,7 +4214,7 @@ static Obj  HdlrFunc1 (
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
  SET_STARTLINE_BODY(t_4, 908);
- SET_ENDLINE_BODY(t_4, 957);
+ SET_ENDLINE_BODY(t_4, 955);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4288,7 +4276,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_WITH__HIDDEN__IMPS__FLAGS = GVarName( "WITH_HIDDEN_IMPS_FLAGS" );
  G_IS__SUBSET__FLAGS = GVarName( "IS_SUBSET_FLAGS" );
  G_TRUES__FLAGS = GVarName( "TRUES_FLAGS" );
- G_SIZE__FLAGS = GVarName( "SIZE_FLAGS" );
  G_LEN__FLAGS = GVarName( "LEN_FLAGS" );
  G_ELM__FLAGS = GVarName( "ELM_FLAGS" );
  G_FLAG1__FILTER = GVarName( "FLAG1_FILTER" );
@@ -4397,7 +4384,6 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "WITH_HIDDEN_IMPS_FLAGS", &GF_WITH__HIDDEN__IMPS__FLAGS );
  InitFopyGVar( "IS_SUBSET_FLAGS", &GF_IS__SUBSET__FLAGS );
  InitFopyGVar( "TRUES_FLAGS", &GF_TRUES__FLAGS );
- InitFopyGVar( "SIZE_FLAGS", &GF_SIZE__FLAGS );
  InitFopyGVar( "LEN_FLAGS", &GF_LEN__FLAGS );
  InitFopyGVar( "ELM_FLAGS", &GF_ELM__FLAGS );
  InitFopyGVar( "FLAG1_FILTER", &GF_FLAG1__FILTER );
@@ -4524,7 +4510,7 @@ static StructInitInfo module = {
  /* revision_c  = */ 0,
  /* revision_h  = */ 0,
  /* version     = */ 0,
- /* crc         = */ 46861067,
+ /* crc         = */ 130680522,
  /* initKernel  = */ InitKernel,
  /* initLibrary = */ InitLibrary,
  /* checkInit   = */ 0,


### PR DESCRIPTION
Specifically, use it to replace constructions like `SIZE_FLAGS(WITH_HIDDEN_IMPS_FLAGS(FLAGS_FILTER(i)))` which most of the time (but not always) do the same things as RankFilter, but are less clear when reading the code.