### PR TITLE
Move calling tags generation into script, add emacs tags

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -432,9 +432,12 @@ ffdata: ffgen
 ########################################################################
 
 tags:
-	cd $(abs_top_srcdir) && ctags --recurse lib hpcgap/lib src
+	cd $(abs_top_srcdir) && etc/tags.sh --recurse lib hpcgap/lib src
 
-.PHONY: tags
+etags:
+	cd $(abs_top_srcdir) && etc/tags.sh -e --recurse lib hpcgap/lib src
+
+.PHONY: tags etags
 
 
 ########################################################################
@@ -448,6 +451,7 @@ distclean: clean
 	rm -rf dev/log
 	rm -rf coverage
 	rm -rf tags
+	rm -rf TAGS
 	rmdir bin cnf dev doc src 2>/dev/null || : # remove dirs if they are now empty
 
 clean:

--- a/etc/tags.sh
+++ b/etc/tags.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -ex
+
+#
+# This little script tries guessing which executable
+# in the system is exuberant ctags. It first checks whether
+# the environment variable $GAP_CTAGS is set, and if so, executes
+# the command given by it, otherwise it first tries locating
+# `exctags`, and then `ctags`.
+#
+
+for tags in "$GAP_CTAGS" exctags ctags-exuberant ctags
+do
+    command -v "$tags" >/dev/null 2>&1 || continue
+    echo "$tags" "$@"
+    exec "$tags" "$@"
+done
+
+echo "error, exuberant ctags not found"
+exit 1


### PR DESCRIPTION
* Move calling exuberant ctags into a script. Background is that
  on different systems the executable is named differently: On
  some systems its simply ctags, on others it is exctags.

  We just take some educated guesses, and support an environment
  variable "CTAGS" with the script.

* Adjust Makefile.rules to call the script and introduce a target
  etags to generate emacs tags. The targets for ctags and etags are
  kept separately, because some filesystems in use are not case
  sensitive, yet etags are by default stored in the file TAGS, and
  ctags are by default stored in the file tags