### PR TITLE
Fixing the interaction of signals in GAP and the IO package.

### DIFF
--- a/src/iostream.h
+++ b/src/iostream.h
@@ -13,7 +13,11 @@
 #ifndef GAP_IOSTREAM_H
 #define GAP_IOSTREAM_H
 
+// Provide a feature macro to let libraries check if GAP supports
+// CheckChildStatusChanged.
+#define GAP_HasCheckChildStatusChanged
 
+int CheckChildStatusChanged(int childPID, int status);
 
 /*F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * *
 */

--- a/tst/teststandard/processes/check.pl
+++ b/tst/teststandard/processes/check.pl
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Time::HiRes;
+
+if ( $ARGV[1] == 1 ) {
+	$SIG{INT} = 'IGNORE';
+	$SIG{TERM} = 'IGNORE';
+}
+
+Time::HiRes::sleep($ARGV[0]/1000)

--- a/tst/teststandard/processes/children.tst
+++ b/tst/teststandard/processes/children.tst
@@ -1,0 +1,18 @@
+gap> d := DirectoryCurrent();;
+gap> scriptdir := DirectoriesLibrary( "tst/teststandard/processes/" );;
+gap> checkpl := Filename(scriptdir, "check.pl");;
+
+# If IO is loaded, disable its signal handler
+gap> if IsBoundGlobal("IO_RestoreSIGCHLDHandler") then
+> ValueGlobal("IO_RestoreSIGCHLDHandler")();
+> fi;
+gap> runChild := function(ms, ignoresignals)
+>    local signal;
+>    if ignoresignals then signal := "1"; else signal := "0"; fi;
+>    return InputOutputLocalProcess(d, checkpl, [ String(time), signal]);
+>  end;;
+gap> for i in [1..200] do
+> children := List([1..20], x -> runChild(Random([1..2000]), Random([false,true])));;
+> if ForAny(children, x -> x=fail) then Print("Failed producing child\n"); fi;
+> Perform(children, CloseStream);
+> od;


### PR DESCRIPTION
This patch is part 1 of fixing the interaction of signals in GAP and the IO package.

This adds a new function (which I imagine might also be useful to anyone making GAP into a library) to pass information about dead child processes to GAP.

Once this is merged in, I have another PR for IO, which will call this function. Then I can remove the line in the test which forces IO's signal handler to be disabled (because then the test will still work even with IO's signal handler).