### PR TITLE
Add TRANSDEGREES to obsoletes (used by CTblLib)

### DIFF
--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -207,6 +207,25 @@ BindGlobal( "Revision", rec() );
 
 #############################################################################
 ##
+#V  TRANSDEGREES - used by CTblLib (11/2017)
+##
+##  This variable was used by the GAP Transitive Groups Library before it
+##  became a separate TransGrp package. It denoted the maximal degree of
+##  transitive permutation groups provided by that library.
+##
+##  In the TransGrp package, this information is provided by the boolean
+##  list TRANSAVAILABLE, which indicates availability for each possible
+##  degree (this is necessary because the data for some degrees may have
+##  to be downloaded separately).
+##
+##  At the time of writing this comment, the TransGrp package contained
+##  representatives for all transitive permutation groups of degree at
+##  most 47, with degree 32 needing to be downloaded separately.
+##
+BindGlobal( "TRANSDEGREES", 30 );
+
+#############################################################################
+##
 #A  NormedVectors( <V> )
 ##
 ##  Moved to obsoletes in May 2003. 


### PR DESCRIPTION
This is extracted from #1650, since it can be merged independently and fix tests that use CTblLib.

I've discovered that TransGrp breaks CTblLib, because @hulpke replaced TRANSDEGREES with the boolean list TRANSAVAILABLE. What is completely sensible, of course, since there is no more continuous availability of degrees, due to degree 32 requiring a separate download.

I've added TRANSDEGREES to obsolete.gd and explained the situation in the comment there. I will notify @ThomasBreuer subject to passing tests and merging this, so that he can eventually adjust CTblLib for the new TransGrp package.