### PR TITLE
HPC-GAP manual cleanup

### DIFF
--- a/doc/hpc/aobjects.xml
+++ b/doc/hpc/aobjects.xml
@@ -42,12 +42,13 @@ list may be non-deterministic.
 
 It is faster to write to fixed atomic lists than to a resizable atomic list.
 
-    <Subsection Label="AtomicList">
-      <Heading>AtomicList(list | count, obj)</Heading>
-
-<C>AtomicList</C> is used to create a new atomic list. It takes either a plain list as an argument, in which case it
+<ManSection>
+    <Func Name="AtomicList" Arg='list'/>
+    <Func Name="AtomicList" Arg='count, obj' Label="for a count and an object"/>
+<Description>
+<Ref Func="AtomicList"/> is used to create a new atomic list. It takes either a plain list as an argument, in which case it
 will create a new atomic list of the same size, populated by the same elements; or it takes a count and an object
-argument. In that case, it creates an atomic list with <C>count</C> elements, each set to the value of <C>obj</C>.
+argument. In that case, it creates an atomic list with <A>count</A> elements, each set to the value of <A>obj</A>.
 
 <Example><![CDATA[
 gap> al := AtomicList([3, 1, 4]);
@@ -62,18 +63,24 @@ gap> WaitTask(RunTask(function() al[3] := `"beta"; end));
 gap> al[3];
 "beta"
 ]]></Example>
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="FixedAtomicList">
-      <Heading>FixedAtomicList(list | count, obj)</Heading>
+<ManSection>
+    <Func Name="FixedAtomicList" Arg='list'/>
+    <Func Name="FixedAtomicList" Arg='count, obj' Label="for a count and an object"/>
 
-<C>FixedAtomicList</C> works like <Ref Func="AtomicList"/> except that the resulting list cannot be resized.
+<Description>
+<Ref Func="FixedAtomicList"/> works like <Ref Func="AtomicList"/> except that the resulting list cannot be resized.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="MakeFixedAtomicList">
-      <Heading>MakeFixedAtomicList(list)</Heading>
+<ManSection>
+    <Func Name="MakeFixedAtomicList"
+      Arg='list'/>
 
-<C>MakeFixedAtomicList</C> turns a resizable atomic list into a fixed atomic list.
+<Description>
+<Ref Func="MakeFixedAtomicList"/> turns a resizable atomic list into a fixed atomic list.
 
 <Example><![CDATA[
 gap> a := AtomicList([99]);
@@ -85,12 +92,15 @@ gap> MakeFixedAtomicList(a);
 gap> a[3] := 101;
 Error, Atomic List Element: <pos>=3 is an invalid index for <list>
 ]]></Example>
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="FromAtomicList">
-      <Heading>FromAtomicList(atomic_list)</Heading>
+<ManSection>
+    <Func Name="FromAtomicList"
+      Arg='atomic_list'/>
 
-<C>FromAtomicList</C> returns a plain list containing the same elements as <C>atomic_list</C> at the time of the call.
+<Description>
+<Ref Func="FromAtomicList"/> returns a plain list containing the same elements as <A>atomic_list</A> at the time of the call.
 Because other threads can write concurrently to that list, the result is not guaranteed to be deterministic.
 
 <Example><![CDATA[
@@ -99,13 +109,16 @@ gap> WaitTask(RunTask(function() al[2] := 40; end));
 gap> FromAtomicList(al);
 [ 10, 40, 30 ]
 ]]></Example>
-    </Subsection>
-  </Section>
-  <Section Label="ATOMIC_ADDITION">
-    <Heading>ATOMIC_ADDITION(atomic_list, index, value)</Heading>
+</Description>
+</ManSection>
+     
+<ManSection>
+    <Func Name="ATOMIC_ADDITION"
+      Arg='atomic_list, index, value'/>
 
-<C>ATOMIC_ADDITION</C> is a low-level operation that atomically adds <C>value</C> to <C>atomic_list[index]</C>. It
-returns the value of atomic_list[index] after the addition has been performed.
+<Description>
+<Ref Func="ATOMIC_ADDITION"/> is a low-level operation that atomically adds <A>value</A> to <A>atomic_list[index]</A>. It
+returns the value of <A>atomic_list[index]</A> after the addition has been performed.
 
 <Example><![CDATA[
 gap> al := FixedAtomicList([4,5,6]);;
@@ -114,36 +127,44 @@ gap> ATOMIC_ADDITION(al, 2, 7);
 gap> FromAtomicList(al);
 [ 4, 12, 6 ]
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="COMPARE_AND_SWAP">
-    <Heading>COMPARE_AND_SWAP(atomic_list, index, old, new)</Heading>
+<ManSection>
+    <Func Name="COMPARE_AND_SWAP"
+      Arg='atomic_list, index, old, new'/>
 
-<C>COMPARE_AND_SWAP</C> is an atomic operation. It atomically compares <C>atomic_list[index]</C> to <C>old</C> and, if
-they are identical,  replaces the value (in the same atomic step) with <C>new</C>. It returns true if the replacement
+<Description>
+<Ref Func="COMPARE_AND_SWAP"/> is an atomic operation. It atomically compares <A>atomic_list[index]</A> to <A>old</A> and, if
+they are identical,  replaces the value (in the same atomic step) with <A>new</A>. It returns true if the replacement
 took place, false otherwise.
-
-The primary use of <C>COMPARE_AND_SWAP</C> is to implement certain concurrency primitives; most programmers will not
+<P/>
+The primary use of <Ref Func="COMPARE_AND_SWAP"/> is to implement certain concurrency primitives; most programmers will not
 need to use it.
+</Description>
+</ManSection>
 
   </Section>
+
   <Section Label="Atomic records and component objects">
     <Heading>Atomic records and component objects</Heading>
 
 Atomic records are atomic counterparts to plain records. They support assignment to individual record fields, and
 conversion to and from plain records.
-
+<P/>
 Assignment semantics can be specified on a per-record basis if the assigned record field is already populated, allowing
 either an overwrite, keeping the existing value, or raising an error.
-
+<P/>
 It is not possible to unbind atomic record elements.
-
+<P/>
 Like plain records, atomic records can be converted to component objects using <C>Objectify</C>.
 
-    <Subsection Label="AtomicRecord">
-      <Heading>AtomicRecord([capacity|record])</Heading>
+<ManSection>
+    <Func Name="AtomicRecord" Arg='capacity'/>
+    <Func Name="AtomicRecord" Arg='record' Label="for a record"/>
 
-<C>AtomicRecord</C> is used to create a new atomic record. Its single optional argument is either a positive integer,
+<Description>
+<Ref Func="AtomicRecord"/> is used to create a new atomic record. Its single optional argument is either a positive integer,
 denoting the intended capacity (i.e., number of elements to be held) of the record, in which case a new empty atomic
 record with that initial capacity will be created. Alternatively, the caller can provide a plain record with which to
 initially populate the atomic record.
@@ -161,13 +182,16 @@ gap> [ r.x, r.y ];
 
 Any atomic record can later grow beyond its initial capacity. There is no limit to the number of elements it can hold
 other than available memory.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="FromAtomicRecord">
-      <Heading>FromAtomicRecord(record)</Heading>
+<ManSection>
+    <Func Name="FromAtomicRecord"
+      Arg='record'/>
 
-<C>FromAtomicRecord</C> returns a plain record copy of the atomic record <C>record</C>. This copy is shallow; elements
-of <C>record</C> will not also be copied.
+<Description>
+<Ref Func="FromAtomicRecord"/> returns a plain record copy of the atomic record <A>record</A>. This copy is shallow; elements
+of <A>record</A> will not also be copied.
 
 <Example><![CDATA[
 gap> r := AtomicRecord();;
@@ -176,39 +200,52 @@ gap> FromAtomicRecord(r);
 rec( x := 1, y := 2, z := 3 )
 ]]></Example>
 
-    </Subsection>
+</Description>
+</ManSection>
+
   </Section>
   <Section Label="Replacement policy functions">
     <Heading>Replacement policy functions</Heading>
 
 There are three functions that set the replacement policy of an atomic object. All three can also be used with plain
 lists and records, in which case an atomic version of the list or record is first created. This allows programmers to
-elide <C>AtomicList</C> and <C>AtomicRecord</C> calls when the next step is to change their policy.
+elide <Ref Func="AtomicList"/> and <Ref Func="AtomicRecord"/> calls when the next step is to change their policy.
 
-    <Subsection Label="MakeWriteOnceAtomic">
-      <Heading>MakeWriteOnceAtomic(obj)</Heading>
+<ManSection>
+    <Func Name="MakeWriteOnceAtomic"
+      Arg='obj'/>
 
-<C>MakeWriteOnceAtomic</C> takes a list, record, atomic list, atomic record, atomic positional object, or atomic
+<Description>
+<Ref Func="MakeWriteOnceAtomic"/> takes a list, record, atomic list, atomic record, atomic positional object, or atomic
 component object as its argument. If the argument is a non-atomic list or record, then the function first creates an
 atomic copy of the argument. The function then changes the replacement policy of the object to write-once: if an element
 of the object is already bound, then further attempts to assign to it will be ignored.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="MakeStrictWriteOnceAtomic">
-      <Heading>MakeStrictWriteOnceAtomic(obj)</Heading>
+<ManSection>
+    <Func Name="MakeStrictWriteOnceAtomic"
+      Arg='obj'/>
 
-<C>MakeStrictWriteOnceAtomic</C> works like <C>MakeWriteOnceAtomic</C>, except that the replacement policy is being
+<Description>
+<Ref Func="MakeStrictWriteOnceAtomic"/> works like <Ref Func="MakeWriteOnceAtomic"/>, except that the replacement policy is being
 changed to being strict write-once: if an element is already bound, then further attempts to assign to it will raise an
 error.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="MakeReadWriteAtomic">
-      <Heading>MakeReadWriteAtomic(obj)</Heading>
+<ManSection>
+    <Func Name="MakeReadWriteAtomic"
+      Arg='obj'/>
 
-<C>MakeReadWriteAtomic</C> is the inverse of <C>MakeWriteOnceAtomic</C> and <C>MakeStrictWriteOnceAtomic</C> in that the
+<Description>
+<Ref Func="MakeReadWriteAtomic"/> is the inverse of <Ref Func="MakeWriteOnceAtomic"/> 
+and <Ref Func="MakeStrictWriteOnceAtomic"/> in that the
 replacement policy is being changed to being rewritable: Elements can be replaced even if they are already bound.
-    </Subsection>
+</Description>
+</ManSection>
   </Section>
+
   <Section Label="Thread-local records">
     <Heading>Thread-local records</Heading>
 
@@ -230,10 +267,12 @@ gap> r.x;
 As can be seen above, even though <C>r.x</C> is overwritten in the second thread, it does not affect the value of
 <C>r.x| in the first thread</C>
 
-    <Subsection Label="ThreadLocalRecord">
-      <Heading>ThreadLocalRecord([defaults [, constructors]])</Heading>
+<ManSection>
+    <Func Name="ThreadLocalRecord"
+      Arg='[defaults [, constructors]]'/>
 
-<C>ThreadLocalRecord</C> creates a new thread-local record. It accepts up to two initial arguments. The <C>defaults</C>
+<Description>
+<Ref Func="ThreadLocalRecord"/> creates a new thread-local record. It accepts up to two initial arguments. The <A>defaults</A>
 argument is a record of default values with which each thread-local copy is initially populated (this happens on demand,
 so values are not actually read until needed).
 
@@ -253,13 +292,16 @@ gap> TaskResult(RunTask(function() return r.x; end));
 gap> TaskResult(RunTask(function() return r.y; end));
 101
 ]]></Example>
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="SetTLDefault">
-      <Heading>SetTLDefault(record, name, value)</Heading>
+<ManSection>
+    <Func Name="SetTLDefault"
+      Arg='record, name, value'/>
 
-<C>SetTLDefault</C> can be used to set the default value of a record field after its creation. Here, <C>record</C> is an
-atomic record, <C>name</C> is the string of the field name, and <C>value</C> is the value.
+<Description>
+<Ref Func="SetTLDefault"/> can be used to set the default value of a record field after its creation. Here, <A>record</A> is an
+atomic record, <A>name</A> is the string of the field name, and <A>value</A> is the value.
 
 <Example><![CDATA[
 gap> r := ThreadLocalRecord();;
@@ -269,13 +311,16 @@ gap> r.x;
 gap> TaskResult(RunTask(function() return r.x; end));
 314
 ]]></Example>
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="SetTLConstructor">
-      <Heading>SetTLConstructor(record, name, func)</Heading>
+<ManSection>
+    <Func Name="SetTLConstructor"
+      Arg='record, name, func'/>
 
-<C>SetTLConstructor</C> can be used to set the constructor of a thread-local record field after its creation, similar to
-<C>SetTLDefault</C>.
+<Description>
+<Ref Func="SetTLConstructor"/> can be used to set the constructor of a thread-local record field after its creation, similar to
+<Ref Func="SetTLDefault"/>.
 
 <Example><![CDATA[
 gap> r := ThreadLocalRecord();;
@@ -285,6 +330,8 @@ gap> r.x;
 gap> TaskResult(RunTask(function() return r.x; end));
 2718
 ]]></Example>
-    </Subsection>
+</Description>
+</ManSection>
+
   </Section>
   </Chapter>

--- a/doc/hpc/channels.xml
+++ b/doc/hpc/channels.xml
@@ -1,15 +1,20 @@
 <Chapter Label="Channels">
   <Heading>Channels</Heading>
 
+<Section Label="section:Channels">
+  <Heading>Channels</Heading>
+  
   Channels are FIFO queues that threads can use to coordinate their activities.
 
-  <Section Label="CreateChannel">
-    <Heading>CreateChannel([capacity])</Heading>
+<ManSection>
+    <Func Name="CreateChannel"
+      Arg='[capacity]'/>
 
-CreateChannel() returns a FIFO communication channel that can be used to exchange information between threads. Its
+<Description>
+<Ref Func="CreateChannel"/> returns a FIFO communication channel that can be used to exchange information between threads. Its
 optional argument is a capacity (positive integer). If insufficient resources are available to create a channel, it
 returns -1. If the capacity is not a positive integer, an error will be raised.
-
+<P/>
 If a capacity is not provided, by default the channel can hold an indefinite number of objects. Otherwise, attempts to
 store objects in the channel beyond its capacity will block.
 
@@ -19,20 +24,23 @@ gap> ch1:=CreateChannel();
 gap> ch2:=CreateChannel(5);
 <channel 0x460324c: 0/5 elements, 0 waiting>
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="SendChannel">
-    <Heading>SendChannel(channel, obj)</Heading>
+<ManSection>
+    <Func Name="SendChannel"
+      Arg='channel, obj'/>
 
-<C>SendChannel</C> accepts two arguments, a channel object returned by <C>CreateChannel</C>, and an arbitrary GAP
-object. It stores <C>obj</C> in <C>channel</C>. If <C>channel</C> has a finite capacity and is currently full, then
-<C>SendChannel</C> will block until at least one element has been removed from the channel, e.g. using <Ref
+<Description>
+<Ref Func="SendChannel"/> accepts two arguments, a channel object returned by <Ref Func="CreateChannel"/>, and an arbitrary GAP
+object. It stores <A>obj</A> in <A>channel</A>. If <A>channel</A> has a finite capacity and is currently full, then
+<Ref Func="SendChannel"/> will block until at least one element has been removed from the channel, e.g. using <Ref
 Func="ReceiveChannel"/>.
-
-<C>SendChannel</C> performs automatic region migration for thread-local objects. If <C>obj</C> is thread-local for the
+<P/>
+<Ref Func="SendChannel"/> performs automatic region migration for thread-local objects. If <A>obj</A> is thread-local for the
 current thread, it will be migrated (along with all subobjects contained in the same region) to the receiving
-thread&#39;s thread-local data space. In between sending and receiving, <C>obj</C> cannot be accessed by either thread.
-
+thread&#39;s thread-local data space. In between sending and receiving, <A>obj</A> cannot be accessed by either thread.
+<P/>
 This example demonstrates sending messages across a channel.
 
 <Example><![CDATA[
@@ -69,12 +77,17 @@ gap> ReceiveChannel(ch3); # the thread is blocked until we read from ch3
 Thread finished
 gap> WaitThread(t);
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="TransmitChannel">
-    <Heading>TransmitChannel(channel, obj)</Heading>
 
-<C>TransmitChannel</C> is identical to <C>SendChannel</C>, except that it does not perform automatic region migration of
+<ManSection>
+    <Func Name="TransmitChannel"
+      Arg='channel, obj'/>
+
+<Description>
+<Ref Func="TransmitChannel"/> is identical to <Ref Func="SendChannel"/>,
+except that it does not perform automatic region migration of
 thread-local objects.
 
 <Example><![CDATA[
@@ -96,12 +109,17 @@ gap> WaitThread(CreateThread(function()
 >    end));
 true
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="TrySendChannel">
-    <Heading>TrySendChannel(channel, obj)</Heading>
 
-<C>TrySendChannel</C> is identical to <C>SendChannel</C>, except that it returns if the channel is full instead of
+<ManSection>
+    <Func Name="TrySendChannel"
+      Arg='channel, obj'/>
+
+<Description>
+<Ref Func="TrySendChannel"/> is identical to <Ref Func="SendChannel"/>,
+except that it returns if the channel is full instead of
 blocking. It returns true if the send was successful and false otherwise.
 
 <Example><![CDATA[
@@ -111,29 +129,43 @@ true
 gap> TrySendChannel(ch, 99);
 false
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="TryTransmitChannel">
-    <Heading>TryTransmitChannel(channel, obj)</Heading>
 
-<C>TryTransmitChannel</C> is identical to <C>TrySendChannel</C>, except that it does not perform automatic region
-migration of thread-local objects.
+<ManSection>
+    <Func Name="TryTransmitChannel"
+      Arg='channel, obj'/>
 
-  </Section>
-  <Section Label="ReceiveChannel">
-    <Heading>ReceiveChannel(channel)</Heading>
+<Description>
+<Ref Func="TryTransmitChannel"/> is identical to <Ref Func="TrySendChannel"/>,
+except that it does not perform automatic region migration of thread-local objects.
+</Description>
+</ManSection>
 
-<C>ReceiveChannel</C> is used to retrieve elements from a channel. If <C>channel</C> is empty, the call will block until
-an element has been added to the channel via <C>SendChannel</C> or a similar primitive.
 
+<ManSection>
+    <Func Name="ReceiveChannel"
+      Arg='channel'/>
+
+<Description>
+<Ref Func="ReceiveChannel"/> is used to retrieve elements from a channel.
+If <A>channel</A> is empty, the call will block until an element has been
+added to the channel via <Ref Func="SendChannel"/> or a similar primitive.
+<P/>
 See <Ref Func="SendChannel"/> for an example.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="TryReceiveChannel">
-    <Heading>TryReceiveChannel(channel, default)</Heading>
 
-<C>TryReceiveChannel</C>, like <C>ReceiveChannel</C>, attempts to retrieve an object from <C>channel</C>. If it does not
-succeed, however, it will return <C>default</C> rather than blocking.
+<ManSection>
+    <Func Name="TryReceiveChannel"
+      Arg='channel, default'/>
+
+<Description>
+<Ref Func="TryReceiveChannel"/>, like <Ref Func="ReceiveChannel"/>,
+attempts to retrieve an object from <A>channel</A>. If it does not
+succeed, however, it will return <A>default</A> rather than blocking.
 
 <Example><![CDATA[
 gap> ch := CreateChannel();;
@@ -143,37 +175,53 @@ gap> TryReceiveChannel(ch, fail);
 gap> TryReceiveChannel(ch, fail);
 fail
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="MultiSendChannel">
-    <Heading>MultiSendChannel(channel, list)</Heading>
 
-<C>MultiSendChannel</C> allows the sending of all the objects contained in the list <C>list</C> to <C>channel</C> as a
+<ManSection>
+    <Func Name="MultiSendChannel"
+      Arg='channel, list'/>
+
+<Description>
+<Ref Func="MultiSendChannel"/> allows the sending of all the objects contained in the list <A>list</A> to <A>channel</A> as a
 single operation. The list must be dense and is not modified by the call. The function will send elements starting at
 index 1 until all elements have been sent. If a channel with finite capacity is full, then the operation will block
 until all elements can be sent.
-
-The operation is designed to be more efficient than sending all elements individually via <C>SendChannel</C> by
+<P/>
+The operation is designed to be more efficient than sending all elements individually via <Ref Func="SendChannel"/> by
 minimizing potentially expensive concurrency operations.
-
+<P/>
 See <Ref Func="MultiReceiveChannel"/> for an example.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="TryMultiSendChannel">
-    <Heading>TryMultiSendChannel(channel, list)</Heading>
 
-<C>TryMultiSendChannel</C> operates like <C>MultiSendChannel</C>, except that it returns rather than blocking if it
-cannot send any more elements if the channel is full. It returns the number of elements it has sent. If <C>channel</C>
-does not have finite capacity, <C>TryMultiSendChannel</C> will always send all elements in the list.
+<ManSection>
+    <Func Name="TryMultiSendChannel"
+      Arg='channel, list'/>
 
-  </Section>
-  <Section Label="MultiReceiveChannel">
-    <Heading>MultiReceiveChannel(channel, amount)</Heading>
+<Description>
+<Ref Func="TryMultiSendChannel"/> operates like <Ref Func="MultiSendChannel"/>,
+except that it returns rather than blocking if it
+cannot send any more elements if the channel is full. 
+It returns the number of elements it has sent. If <A>channel</A>
+does not have finite capacity, <Ref Func="TryMultiSendChannel"/>
+will always send all elements in the list.
+</Description>
+</ManSection>
 
-<C>MultiReceiveChannel</C> is the receiving counterpart to <C>MultiSendChannel</C>. It will try to receive up to
-<C>amount</C> objects from <C>channel</C>. If the channel contains less than <C>amount</C> objects, it will return
-rather than blocking.
 
+<ManSection>
+    <Func Name="MultiReceiveChannel"
+      Arg='channel, amount'/>
+
+<Description>
+<Ref Func="MultiReceiveChannel"/> is the receiving counterpart to
+<Ref Func="MultiSendChannel"/>.It will try to receive up to
+<A>amount</A> objects from <A>channel</A>. If the channel contains less
+than <A>amount</A> objects, it will return rather than blocking.
+<P/>
 The function returns a list of all the objects received.
 
 <Example><![CDATA[
@@ -186,13 +234,17 @@ gap> MultiReceiveChannel(ch,7);
 gap> MultiReceiveChannel(ch,7);
 [  ]
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="ReceiveAnyChannel">
-    <Heading>ReceiveAnyChannel(channel_1, ..., channel_n | channel_list)</Heading>
 
-<C>ReceiveAnyChannel</C> is a multiplexing variant of <C>ReceiveChannel</C>. It blocks until at least one of the
-channels provided contains an object. It will then retrieve that object from the channel and return it.
+<ManSection>
+    <Func Name="ReceiveAnyChannel" Arg='channel_1, ..., channel_n'/>
+    <Func Name="ReceiveAnyChannel" Arg='channel_list' Label="for a list of channels"/>
+<Description>
+<Ref Func="ReceiveAnyChannel"/> is a multiplexing variant of<Ref Func="ReceiveChannel"/>.
+It blocks until at least one of the channels provided contains an object.
+It will then retrieve that object from the channel and return it.
 
 <Example><![CDATA[
 gap> ch1 := CreateChannel();;
@@ -201,14 +253,18 @@ gap> SendChannel(ch2, [1, 2, 3]);;
 gap> ReceiveAnyChannel(ch1, ch2);
 [ 1, 2, 3 ]
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="ReceiveAnyChannelWithIndex">
-    <Heading>ReceiveAnyChannelWithIndex(channel_1, ..., channel_n | channel_list)</Heading>
 
-<C>ReceiveAnyChannelWithIndex</C> works like <C>ReceiveAnyChannel</C>, except that it returns a list with two elements,
-the first being the object being received, the second being the number of the channel from which the object has been
-retrieved.
+<ManSection>
+    <Func Name="ReceiveAnyChannelWithIndex" Arg='channel_1, ..., channel_n'/>
+    <Func Name="ReceiveAnyChannelWithIndex" Arg='channel_list' Label="for a list of channels"/>
+<Description>
+<Ref Func="ReceiveAnyChannelWithIndex"/> works like <Ref Func="ReceiveAnyChannel"/>,
+except that it returns a list with two elements, the first being the object
+being received, the second being the number of the channel from which the
+object has been retrieved.
 
 <Example><![CDATA[
 gap> ch1 := CreateChannel();;
@@ -217,12 +273,16 @@ gap> SendChannel(ch2, [1, 2, 3]);;
 gap> ReceiveAnyChannelWithIndex(ch1, ch2);
 [ [ 1, 2, 3 ], 2 ]
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="TallyChannel">
-    <Heading>TallyChannel(channel)</Heading>
 
-<C>TallyChannel</C> returns the number of objects that a channel contains. This number can increase or decrease, as data
+<ManSection>
+    <Func Name="TallyChannel"
+      Arg='channel'/>
+
+<Description>
+<Ref Func="TallyChannel"/> returns the number of objects that a channel contains. This number can increase or decrease, as data
 is sent to or received from this channel. Send operations will only ever increase and receive operations will only ever
 decrease this count. Thus, if there is only one thread receiving data from the channel, it can use the result as a lower
 bound for the number of elements that will be available in the channel.
@@ -235,12 +295,16 @@ gap> SendChannel(ch, 5);
 gap> TallyChannel(ch);
 3
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="InspectChannel">
-    <Heading>InspectChannel(channel)</Heading>
 
-<C>InspectChannel</C> returns a list of the objects that a channel contains. Note that objects that are not in the
+<ManSection>
+    <Func Name="InspectChannel"
+      Arg='channel'/>
+
+<Description>
+<Ref Func="InspectChannel"/> returns a list of the objects that a channel contains. Note that objects that are not in the
 shared, public, or read-only region will be temporarily stored in the so-called limbo region while in transit and will
 be inaccessible through normal means until they have been received.
 
@@ -254,5 +318,7 @@ gap> InspectChannel(ch);
 ]]></Example>
 
 This function is primarly intended for debugging purposes.
+</Description>
+</ManSection>
   </Section>
 </Chapter>

--- a/doc/hpc/lowlevel.xml
+++ b/doc/hpc/lowlevel.xml
@@ -3,49 +3,60 @@
 
 The functionality described in this section should only be used by experts, and even by those only with caution
 (especially the parts that relate to the memory model).
-
+<P/>
 Not only is it possible to crash or hang the GAP kernel, it can happen in ways that are very difficult to reproduce,
 leading to software defects that are discovered only long after deployment of a package and then become difficult to
 correct.
-
+<P/>
 The performance benefit of using these primitives is generally minimal; while concurrency can induce some overhead, the
 benefit from micromanaging concurrency in an interpreted language such as GAP is likely to be small.
-
+<P/>
 These low-level primitives exist primarily for the benefit of kernel programmers; it allows them to prototype new kernel
 functionality in GAP before implementing it in C.
 
   <Section Label="Explicit lock and unlock primitives">
     <Heading>Explicit lock and unlock primitives</Heading>
 
-The <C>LOCK</C> operation combined with <C>UNLOCK</C> is a low-level interface for the functionality of the  statement.
+The <Ref Func="LOCK"/> operation combined with <Ref Func="UNLOCK"/>
+is a low-level interface for the functionality of the  statement.
 
-  <Subsection Label="LOCK">
-    <Heading>LOCK([arg_1, ..., arg_n])</Heading>
+<ManSection>
+    <Func Name="LOCK"
+      Arg='[arg_1, ..., arg_n]'/>
 
-<C>LOCK</C> takes zero or more pairs of parameters, where each is either an object or a boolean value. If an argument is
-an object, the region containing it will be locked. If an argument is the boolean value <C>false</C>, all subsequent
-locks will be read locks; if it is the boolean value <C>true</C>, all subsequent locks will be write locks. If the first
+<Description>
+<Ref Func="LOCK"/> takes zero or more pairs of parameters, where each is either an object or a boolean value. If an argument is
+an object, the region containing it will be locked. If an argument is the boolean value <K>false</K>, all subsequent
+locks will be read locks; if it is the boolean value <K>true</K>, all subsequent locks will be write locks. If the first
 argument is not a boolean value, all locks until the first boolean value will be write locks.
+<P/>
+Locks are managed internally as a stack of locked regions; <Ref Func="LOCK"/> returns an integer indicating a pointer to the
+top of the stack; this integer is used later by the <Ref Func="UNLOCK"/> operation to unlock locks on the stack up to that
+position. If <Ref Func="LOCK"/> should fail for some reason, it will return <K>fail</K>.
+<P/>
+Calling <Ref Func="LOCK"/> with no parameters returns the current lock stack pointer.
+</Description>
+</ManSection>
 
-Locks are managed internally as a stack of locked regions; <C>LOCK</C> returns an integer indicating a pointer to the
-top of the stack; this integer is used later by the <C>UNLOCK</C> operation to unlock locks on the stack up to that
-position. If <C>LOCK</C> should fail for some reason, it will return <C>fail</C>.
+<ManSection>
+    <Func Name="TRYLOCK"
+      Arg='[arg_1, ..., arg_n]'/>
 
-Calling <C>LOCK()</C> with no parameters returns the current lock stack pointer.
+<Description>
+<Ref Func="TRYLOCK"/> works similarly to <Ref Func="LOCK"/>. If it cannot acquire
+all region locks, it returns <K>fail</K> and does not lock any regions. Otherwise,
+its semantics are identical to <Ref Func="LOCK"/>.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="TRYLOCK">
-    <Heading>TRYLOCK([arg_1, ..., arg_n])</Heading>
 
-<C>TRYLOCK</C> works similarly to <C>LOCK</C>. If it cannot acquire all region locks, it returns <C>fail</C> and does
-not lock any regions. Otherwise, its semantics are identical to <C>LOCK</C>.
+<ManSection>
+    <Func Name="UNLOCK"
+      Arg='stackpos'/>
 
-  </Subsection>
-  <Subsection Label="UNLOCK">
-    <Heading>UNLOCK(stackpos)</Heading>
-
-<C>UNLOCK</C> unlocks all regions on the stack at <C>stackpos</C> or higher and sets the stack pointer to
-<C>stackpos</C>.
+<Description>
+<Ref Func="UNLOCK"/> unlocks all regions on the stack at <A>stackpos</A>
+or higher and sets the stack pointer to <A>stackpos</A>.
 
 <Example><![CDATA[
 gap> l1 := ShareObj([1,2,3]);;
@@ -58,7 +69,9 @@ gap> UNLOCK(p); # unlock both RegionOf(l1) and RegionOf(l2)
 gap> LOCK(); # current stack pointer
 0
 ]]></Example>
-  </Subsection>
+</Description>
+</ManSection>
+
   </Section>
   <Section Label="Hash locks">
     <Heading>Hash locks</Heading>
@@ -78,71 +91,95 @@ gap> HASH_UNLOCK(l); # unlock 'l'
 
 Hash locks should only be used for very short operations, since there is a chance that two concurrently locked objects
 map to the same hash value, leading to unnecessary contention.
+<P/>
+Hash locks are unrelated to the locks used by the <C>atomic</C> statements and
+the <Ref Func="LOCK"/> and <Ref Func="UNLOCK"/> primitives.
 
-Hash locks are unrelated to the locks used by the <C>atomic</C> statements and the <C>LOCK</C> and <C>UNLOCK</C>
-primitives.
+<ManSection>
+    <Func Name="HASH_LOCK"
+      Arg='obj'/>
 
-    <Subsection Label="HASH_LOCK">
-      <Heading>HASH_LOCK(obj)</Heading>
+<Description>
+<Ref Func="HASH_LOCK"/> obtains the read-write lock for the hash value associated with <C>obj</C>.
+</Description>
+</ManSection>
 
-<C>HASH_LOCK</C> obtains the read-write lock for the hash value associated with <C>obj</C>.
+<ManSection>
+    <Func Name="HASH_UNLOCK"
+      Arg='obj'/>
 
-    </Subsection>
-    <Subsection Label="HASH_UNLOCK">
-      <Heading>HASH_UNLOCK(obj)</Heading>
+<Description>
+<Ref Func="HASH_UNLOCK"/> releases the read-write lock for the hash value associated with <C>obj</C>.
+</Description>
+</ManSection>
 
-<C>HASH_UNLOCK</C> releases the read-write lock for the hash value associated with <C>obj</C>.
+<ManSection>
+    <Func Name="HASH_LOCK_SHARED"
+      Arg='obj'/>
 
-    </Subsection>
-    <Subsection Label="HASH_LOCK_SHARED">
-      <Heading>HASH_LOCK_SHARED(obj)</Heading>
+<Description>
+<Ref Func="HASH_LOCK_SHARED"/> obtains the read-only lock for the hash value associated with <C>obj</C>.
+</Description>
+</ManSection>
 
-<C>HASH_LOCK_SHARED</C> obtains the read-only lock for the hash value associated with <C>obj</C>.
+<ManSection>
+    <Func Name="HASH_UNLOCK_SHARED"
+      Arg='obj'/>
 
-    </Subsection>
-    <Subsection Label="HASH_UNLOCK_SHARED">
-      <Heading>HASH_UNLOCK_SHARED(obj)</Heading>
+<Description>
+<Ref Func="HASH_UNLOCK_SHARED"/> releases the read-only lock for the hash value associated with <C>obj</C>.
+</Description>
+</ManSection>
 
-<C>HASH_UNLOCK_SHARED</C> releases the read-only lock for the hash value associated with <C>obj</C>.
-    </Subsection>
   </Section>
+  
   <Section Label="Migration to the public region">
     <Heading>Migration to the public region</Heading>
 
 HPC-GAP allows migration of arbitrary objects to the public region. This functionality is potentially dangerous; for
 example, if two threads try resize a plain list simultaneously, this can result in memory corruption.
-
+<P/>
 Accordingly, such data should never be accessed except through operations that protect accesses through locks, memory
 barriers, or other mechanisms.
 
-    <Subsection Label="MAKE_PUBLIC">
-      <Heading>MAKE_PUBLIC(obj)</Heading>
+<ManSection>
+    <Func Name="MAKE_PUBLIC"
+      Arg='obj'/>
 
-<C>MAKE_PUBLIC</C> makes <C>obj</C> and all its subobjects members of the public region.
+<Description>
+<Ref Func="MAKE_PUBLIC"/> makes <A>obj</A> and all its subobjects members of the public region.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="MAKE_PUBLIC_NORECURSE">
-      <Heading>MAKE_PUBLIC_NORECURSE(obj)</Heading>
 
-<C>MAKE_PUBLIC_NORECURSE</C> makes <C>obj</C>, but not any of its subobjects members of the public region.
-    </Subsection>
+<ManSection>
+    <Func Name="MAKE_PUBLIC_NORECURSE"
+      Arg='obj'/>
+
+<Description>
+<Ref Func="MAKE_PUBLIC_NORECURSE"/> makes <A>obj</A>, but not any of its subobjects members of the public region.
+</Description>
+</ManSection>
   </Section>
+  
   <Section Label="Memory barriers">
     <Heading>Memory barriers</Heading>
 
 The memory models of some processors do no guarantee that read and writes reflect accesses to main memory in the same
-order in which the processor performed them; for example, code may write variable v1 first, and v2 second; but the cache
-line containing v2 is flushed to main memory first so that other processors see the change to v2 before the change to
-v1.
-
+order in which the processor performed them; for example, code may write variable <C>v1</C> first, and <C>v2</C> second; but the cache
+line containing <C>v2</C> is flushed to main memory first so that other processors see the change to <C>v2</C> before the change to
+<C>v1</C>.
+<P/>
 Memory barriers can be used to prevent such counter-intuitive reordering of memory accesses.
 
-    <Subsection Label="ORDERED_WRITE">
-      <Heading>ORDERED_WRITE(expr)</Heading>
+<ManSection>
+    <Func Name="ORDERED_WRITE"
+      Arg='expr'/>
 
-The <C>ORDERED_WRITE</C> function guarantees that all writes that occur prior to its execution or during the evaluation
-of <C>expr</C> become visible to other processors before any of the code executed after.
-
+<Description>
+The <Ref Func="ORDERED_WRITE"/> function guarantees that all writes that occur prior to its execution or during the evaluation
+of <A>expr</A> become visible to other processors before any of the code executed after.
+<P/>
 Example:
 
 <Example><![CDATA[
@@ -153,7 +190,7 @@ gap> x := ORDERED_WRITE(f());
 
 Here, the write barrier ensure that the assignment to <C>y</C> that occurs during the call of <C>f()</C> becomes visible
 to other processors before or at the same time as the assignment to <C>x</C>.
-
+<P/>
 This can also be done differently, with the same semantics:
 
 <Example><![CDATA[
@@ -163,24 +200,35 @@ gap> x := t;
 2
 ]]></Example>
 
-    </Subsection>
-    <Subsection Label="ORDERED_READ">
-      <Heading>ORDERED_READ(expr)</Heading>
+</Description>
+</ManSection>
 
-Conversely, the <C>ORDERED_READ</C> function ensures that reads that occur before its call or during the evaluation of
-<C>expr</C> are not reordered with respects to memory reads occurring after it.
-    </Subsection>
+
+<ManSection>
+    <Func Name="ORDERED_READ"
+      Arg='expr'/>
+
+<Description>
+Conversely, the <Ref Func="ORDERED_READ"/> function ensures that reads that occur before its call or during the evaluation of
+<A>expr</A> are not reordered with respects to memory reads occurring after it.
+</Description>
+</ManSection>
   </Section>
+  
+  
+  
   <Section Label="Object manipulation">
     <Heading>Object manipulation</Heading>
 
 There are two new functions to exchange a pair of objects.
 
-    <Subsection Label="SWITCH_OBJ">
-      <Heading>SWITCH_OBJ(obj1, obj2)</Heading>
+<ManSection>
+    <Func Name="SWITCH_OBJ"
+      Arg='obj1, obj2'/>
 
-<C>SWITCH_OBJ</C> exchanges its two arguments. All variables currently referencing <C>obj1</C> will reference
-<C>obj2</C> instead after the operation completes, and vice versa. Both objects stay within their previous regions.
+<Description>
+<Ref Func="SWITCH_OBJ"/> exchanges its two arguments. All variables currently referencing <A>obj1</A> will reference
+<A>obj2</A> instead after the operation completes, and vice versa. Both objects stay within their previous regions.
 
 <Example><![CDATA[
 gap> a := [ 1, 2, 3];;
@@ -204,11 +252,15 @@ gap> atomic readonly b do Display(b); od;
 [ 1, 2, 3 ]
 ]]></Example>
 
-    </Subsection>
-    <Subsection Label="FORCE_SWITCH_OBJ">
-      <Heading>FORCE_SWITCH_OBJ(obj1, obj2)</Heading>
+</Description>
+</ManSection>
 
-<C>FORCE_SWITCH_OBJ</C> works like <Ref Func="SWITCH_OBJ"/>, except that it can also exchange objects in the public
+<ManSection>
+    <Func Name="FORCE_SWITCH_OBJ"
+      Arg='obj1, obj2'/>
+
+<Description>
+<Ref Func="FORCE_SWITCH_OBJ"/> works like <Ref Func="SWITCH_OBJ"/>, except that it can also exchange objects in the public
 region:
 
 <Example><![CDATA[
@@ -223,6 +275,7 @@ This function should be used with extreme caution and only with public objects f
 reference. Otherwise, undefined behavior and crashes can result from other threads accessing the public object
 concurrently.
 
-    </Subsection>
+</Description>
+</ManSection>
   </Section>
 </Chapter>

--- a/doc/hpc/regions.xml
+++ b/doc/hpc/regions.xml
@@ -11,7 +11,7 @@ modified by another.
 
 Each thread has an associated thread-local region. When a thread implicitly or explicitly creates a new object, that
 object initially belongs to the thread&#39;s thread-local region.
-
+<P/>
 Only the thread can read or modify objects in its thread-local region. For other threads to access an object, that
 object has to be migrated into a different region first.
 
@@ -22,7 +22,7 @@ object has to be migrated into a different region first.
 Shared regions are explicitly created through the <Ref Func="ShareObj"/> and <Ref Func="ShareSingleObj"/> primitives
 (see below). Multiple threads can access them concurrently, but accessing them requires that a thread uses an
 <C>atomic</C> statement to acquire a read or write lock beforehand.
-
+<P/>
 See the section on <C>atomic</C> statements (<Ref Sect="The atomic statement."/>) for details.
 
   </Section>
@@ -32,10 +32,10 @@ See the section on <C>atomic</C> statements (<Ref Sect="The atomic statement."/>
 Shared regions are by default ordered; each shared region has an associated numeric precedence level. Regions can
 generally only be locked in order of descending precedence. The purpose of this mechanism is to avoid accidental
 deadlocks.
-
+<P/>
 The ordering requirement can be overridden in two ways: regions with a negative precedence are excluded from it. This
 exception should be used with care, as it can lead to deadlocks.
-
+<P/>
 Alternatively, two or more regions can be locked simultaneously via the <C>atomic</C> statement. In this case, the
 ordering of these regions relative to each other can be arbitrary.
 
@@ -45,7 +45,7 @@ ordering of these regions relative to each other can be arbitrary.
 
 A special public region contains objects that only permit atomic operations. These include, in particular, all immutable
 objects (immutable in the sense that their in-memory representation cannot change).
-
+<P/>
 All threads can access objects in the public region at all times without needing to acquire a read- or write-lock
 beforehand.
 
@@ -64,31 +64,31 @@ Func="CopyRegion"/> primitive can be used.
 Objects can be migrated between regions using a number of functions. In order to migrate an object, the current thread
 must have exclusive access to that object; the object must be in its thread-local region or it must be in a shared
 region for which the current thread holds a write lock.
-
+<P/>
 The <Ref Func="ShareObj"/> and <Ref Func="ShareSingleObj"/> functions create a new shared region and migrate their
 respective argument to that region; <C>ShareObj</C> will also migrate all subobjects that are within the same region,
 while <C>ShareSingleObj</C> will leave the subobjects unaffected.
-
+<P/>
 The <Ref Func="MigrateObj"/> and <Ref Func="MigrateSingleObj"/> functions migrate objects to an existing region. The
 first argument of either function is the object to be migrated; the second is either a region (as returned by the <Ref
 Func="RegionOf"/> function) or an object whose containing region the first argument is to be migrated to.
-
+<P/>
 The current thread needs exclusive access to the target region (denoted by the second argument) for the operation to
 succeed. If successful, the first argument will be in the same region as the second argument afterwards. In the case of
-<C>MigrateObj</C>, all subobjects within the same region as the first argument will also be migrated to the target
+<Ref Func="MigrateObj"/>, all subobjects within the same region as the first argument will also be migrated to the target
 region.
-
-Finally, <Ref Func="AdoptObj"/> and <Ref Func="AdoptSingleObj"/> are special cases of <C>MigrateObj</C> and
-<C>MigrateSingleObj</C>, where the target region is the thread-local region of the current thread.
-
+<P/>
+Finally, <Ref Func="AdoptObj"/> and <Ref Func="AdoptSingleObj"/> are special cases of <Ref Func="MigrateObj"/> and
+<Ref Func="MigrateSingleObj"/>, where the target region is the thread-local region of the current thread.
+<P/>
 To migrate objects to the read-only region, one can use <Ref Func="MakeReadOnly"/> and <Ref Func="MakeReadOnlyObj"/>.
 The first migrates its argument and all its subjobjects that are within the same region to the read-only region; the
 second migrates only the argument itself, but not its subobjects.
-
+<P/>
 It is generally not possible to migrate objects explicitly to the public region; only objects with purely atomic
 operations can be made public and that is done automatically when they are created.
-
-The exception are immutable objects. When <C>MakeImmutable</C> is used, its argument is automatically moved to the
+<P/>
+The exception are immutable objects. When <Ref BookName="ref" Func="MakeImmutable"/> is used, its argument is automatically moved to the
 public region.
 
 <Example><![CDATA[
@@ -103,7 +103,7 @@ gap> RegionOf(MakeImmutable([1,2,3]));
 Regions can be given names, either explicitly via <Ref Func="SetRegionName"/> or when they are created via <Ref
 Func="ShareObj"/> and <Ref Func="ShareSingleObj"/>. Thread-local regions, the public, and the readonly region are given
 names by default.
-
+<P/>
 Multiple regions can have the same name.
 
   </Section>
@@ -114,73 +114,97 @@ If either GAP code or a kernel primitive attempts to access an object that it is
 these semantics, either a &quot;write guard error&quot; (for a failed write access) or a &quot;read guard error&quot;
 (for a failed read access) will be raised. The global variable <C>LastInaccessible</C> will contain the object that
 caused such an error.
-
+<P/>
 One exception is that threads can modify objects in regions that they have only read access (but not write access) to
 using write-once functions - see section <Ref Sect="Write-once functionality"/>.
-
-To inspect objects whose contents lie in other regions (and therefore cannot be displayed by <C>PrintObj</C> or
-<C>ViewObj</C>, the functions <Ref Func="ViewShared"/> and <Ref Func="UNSAFE_VIEW"/> can be used.
+<P/>
+To inspect objects whose contents lie in other regions (and therefore cannot be displayed by
+<Ref BookName="ref" Func="PrintObj"/> or <Ref BookName="ref" Func="ViewObj"/>,
+the functions <Ref Func="ViewShared"/> and <Ref Func="UNSAFE_VIEW"/> can be used.
 
   </Section>
   <Section Label="Functions relating to regions">
     <Heading>Functions relating to regions</Heading>
 
-    <Subsection Label="NewRegion">
-      <Heading>NewRegion(name|prec|name,prec)</Heading>
+<ManSection>
+    <Func Name="NewRegion"
+      Arg='[name, ] prec'/>
 
-The function <C>NewRegion</C> creates a new shared region. If the optional argument <C>name</C> is provided, then the
-name of the new region will be set to <C>name</C>.
+<Description>
+The function <Ref Func="NewRegion"/> creates a new shared region.
+If the optional argument <A>name</A> is provided, then the
+name of the new region will be set to <A>name</A>.
 
 <Example><![CDATA[
 gap> NewRegion("example region");
 <region: example region>
 ]]></Example>
 
-<C>NewRegion</C> will create a region with a high precedence level. It is intended to be called by user code. The exact
-precedence level can be adjusted with <C>prec</C>, which must be an integer in the range <C>[-1000..1000]</C>;
-<C>prec</C> will be added to the normal precedence level.
+<Ref Func="NewRegion"/> will create a region with a high precedence level. It is intended to be called by user code. The exact
+precedence level can be adjusted with <A>prec</A>, which must be an integer in the range <C>[-1000..1000]</C>;
+<A>prec</A> will be added to the normal precedence level.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="NewLibraryRegion">
-    <Heading>NewLibraryRegion(name|prec|name,prec)</Heading>
+<ManSection>
+    <Func Name="NewLibraryRegion"
+      Arg='[name, ] prec'/>
 
-<C>NewLibraryRegion</C> functions like <C>NewRegion</C>, except that the precedence of the region it creates is below
-that of <C>NewRegion</C>. It is intended to be used by user libraries and GAP packages.
+<Description>
+<Ref Func="NewLibraryRegion"/> functions like <Ref Func="NewRegion"/>,
+except that the precedence of the region it creates is below
+that of <Ref Func="NewRegion"/>. It is intended to be used by user libraries and GAP packages.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="NewSystemRegion">
-    <Heading>NewSystemRegion(name|prec|name,prec)</Heading>
+<ManSection>
+    <Func Name="NewSystemRegion"
+      Arg='[name, ] prec'/>
 
-<C>NewSystemRegion</C> functions like <C>NewRegion</C>, except that the precedence of the region it creates is below
-that of <C>NewLibraryRegion</C>. It is intended to be used by the standard GAP library.
+<Description>
+<Ref Func="NewSystemRegion"/> functions like <Ref Func="NewRegion"/>,
+except that the precedence of the region it creates is below
+that of <Ref Func="NewLibraryRegion"/>. It is intended to be used by the standard GAP library.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="NewKernelRegion">
-    <Heading>NewKernelRegion(name|prec|name,prec)</Heading>
+<ManSection>
+    <Func Name="NewKernelRegion"
+      Arg='[name, ] prec'/>
 
-<C>NewKernelRegion</C> functions like <C>NewRegion</C>, except that the precedence of the region it creates is below
-that of <C>NewSystemRegion</C>. It is intended to be used by the GAP kernel, and GAP library code that interacts closely
+<Description>
+<Ref Func="NewKernelRegion"/> functions like <Ref Func="NewRegion"/>, except that the precedence of the region it creates is below
+that of <Ref Func="NewSystemRegion"/>. It is intended to be used by the GAP kernel, and GAP library code that interacts closely
 with the kernel.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="NewInternalRegion">
-    <Heading>NewInternalRegion([name])</Heading>
+<ManSection>
+    <Func Name="NewInternalRegion"
+      Arg='[name]'/>
 
-<C>NewInternalRegion</C> functions like <C>NewRegion</C>, except that the precedence of the region it creates is the
+<Description>
+<Ref Func="NewInternalRegion"/> functions like <Ref Func="NewRegion"/>, except that the precedence of the region it creates is the
 lowest available. It is intended to be used for regions that are self-contained; i.e. no function that uses such a
 region may lock another region while accessing it. The precedence level of an internal region cannot be adjusted.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="NewSpecialRegion">
-    <Heading>NewSpecialRegion([name])</Heading>
+<ManSection>
+    <Func Name="NewSpecialRegion"
+      Arg='[name]'/>
 
-<C>NewLibraryRegion</C> functions like <C>NewRegion</C>, except that the precedence of the region it creates is
+<Description>
+<Ref Func="NewLibraryRegion"/> functions like <Ref Func="NewRegion"/>, except that the precedence of the region it creates is
 negative. It is thus exempt from normal ordering and deadlock checks.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="RegionOf">
-    <Heading>RegionOf(obj)</Heading>
+<ManSection>
+    <Func Name="RegionOf"
+      Arg='obj'/>
 
+<Description>
 <Example><![CDATA[
 gap> RegionOf(1/2);
 <public region>
@@ -205,12 +229,15 @@ true
 ]]></Example>
 
 The result in this example is true because both lists are in the same thread-local region.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="RegionPrecedence">
-    <Heading>RegionPrecedence(obj)</Heading>
+<ManSection>
+    <Func Name="RegionPrecedence"
+      Arg='obj'/>
 
-<C>RegionPrecedence</C> will return the precedence of the region of <C>obj</C>.
+<Description>
+<Ref Func="RegionPrecedence"/> will return the precedence of the region of <A>obj</A>.
 
 <Example><![CDATA[
 gap> RegionPrecedence(NewRegion("Test"));
@@ -220,60 +247,81 @@ gap> RegionPrecedence(NewRegion("Test2", 1));
 gap> RegionPrecedence(NewLibraryRegion("LibTest", -1));
 19999
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="ShareObj">
-    <Heading>ShareObj(obj[, name|, prec|, name, prec])</Heading>
+<ManSection>
+    <Func Name="ShareObj"
+      Arg='obj [, [ name, ] prec]'/>
 
-The <C>ShareObj</C> function creates a new shared region and migrates the object and all its subobjects to that region.
-If the optional argument <C>name</C> is provided, then the name of the new region is set to <C>name</C>.
+<Description>
+The <Ref Func="ShareObj"/> function creates a new shared region and migrates the object and all its subobjects to that region.
+If the optional argument <A>name</A> is provided, then the name of the new region is set to <A>name</A>.
+<P/>
+<Ref Func="ShareObj"/> will create a region with a high precedence level. It is intended to be called by user code. The actual
+precedence level can be adjusted by the optional <A>prec</A> argument in the same way as for <Ref Func="NewRegion"/>.
+</Description>
+</ManSection>
 
-<C>ShareObj</C> will create a region with a high precedence level. It is intended to be called by user code. The actual
-precedence level can be adjusted by the optional <C>prec</C> argument in the same way as for <C>NewRegion</C>.
+<ManSection>
+    <Func Name="ShareLibraryObj"
+      Arg='obj [, [ name, ] prec]'/>
 
-  </Subsection>
-  <Subsection Label="ShareLibraryObj">
-    <Heading>ShareLibraryObj(obj[, name|, prec|, name, prec])</Heading>
+<Description>
+<Ref Func="ShareLibraryObj"/> functions like <Ref Func="ShareObj"/>, except that the precedence of the region it creates is below that
+of <Ref Func="ShareObj"/>. It is intended to be used by user libraries and GAP packages.
+</Description>
+</ManSection>
 
-<C>ShareLibraryObj</C> functions like <C>ShareObj</C>, except that the precedence of the region it creates is below that
-of <C>ShareObj</C>. It is intended to be used by user libraries and GAP packages.
+<ManSection>
+    <Func Name="ShareSystemObj"
+      Arg='obj [, [ name, ] prec]'/>
 
-  </Subsection>
-  <Subsection Label="ShareSystemObj">
-    <Heading>ShareSystemObj(obj[, name|, prec|, name, prec])</Heading>
+<Description>
+<Ref Func="ShareSystemObj"/> functions like <Ref Func="ShareObj"/>, except that the precedence of the region it creates is below that
+of <Ref Func="ShareLibraryObj"/>. It is intended to be used by the standard GAP library.
+</Description>
+</ManSection>
 
-<C>ShareSystemObj</C> functions like <C>ShareObj</C>, except that the precedence of the region it creates is below that
-of <C>ShareLibraryObj</C>. It is intended to be used by the standard GAP library.
+<ManSection>
+    <Func Name="ShareKernelObj"
+      Arg='obj [, [ name, ] prec]'/>
 
-  </Subsection>
-  <Subsection Label="ShareKernelObj">
-    <Heading>ShareKernelObj(obj[, name|, prec|, name, prec])</Heading>
-
-<C>ShareKernelObj</C> functions like <C>ShareObj</C>, except that the precedence of the region it creates is below that
-of <C>ShareSystemObj</C>. It is intended to be used by the GAP kernel, and GAP library code that interacts closely with
+<Description>
+<Ref Func="ShareKernelObj"/> functions like <Ref Func="ShareObj"/>, except that the precedence of the region it creates is below that
+of <Ref Func="ShareSystemObj"/>. It is intended to be used by the GAP kernel, and GAP library code that interacts closely with
 the kernel.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="ShareInternalObj">
-    <Heading>ShareInternalObj(obj[, name])</Heading>
+<ManSection>
+    <Func Name="ShareInternalObj"
+      Arg='obj[, name]'/>
 
-<C>ShareInternalObj</C> functions like <C>ShareObj</C>, except that the precedence of the region it creates is the
+<Description>
+<Ref Func="ShareInternalObj"/> functions like <Ref Func="ShareObj"/>, except that the precedence of the region it creates is the
 lowest available. It is intended to be used for regions that are self-contained; i.e. no function that uses such a
 region may lock another region while accessing it.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="ShareSpecialObj">
-    <Heading>ShareSpecialObj(obj[, name])</Heading>
+<ManSection>
+    <Func Name="ShareSpecialObj"
+      Arg='obj[, name]'/>
 
-<C>ShareLibraryObj</C> functions like <C>ShareObj</C>, except that the precedence of the region it creates is negative.
+<Description>
+<Ref Func="ShareLibraryObj"/> functions like <Ref Func="ShareObj"/>, except that the precedence of the region it creates is negative.
 It is thus exempt from normal ordering and deadlock checks.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="ShareSingleObj">
-    <Heading>ShareSingleObj(obj[, name|, prec|, name, prec])</Heading>
+<ManSection>
+    <Func Name="ShareSingleObj"
+      Arg='obj [, [ name, ] prec]'/>
 
-The <C>ShareSingleObj</C> function creates a new shared region and migrates the object, but not its subobjects, to that
-region. If the optional argument <C>name</C> is provided, then the name of the new region is set to <C>name</C>.
+<Description>
+The <Ref Func="ShareSingleObj"/> function creates a new shared region and migrates the object, but not its subobjects, to that
+region. If the optional argument <A>name</A> is provided, then the name of the new region is set to <A>name</A>.
 
 <Example><![CDATA[
 gap> m := [ [1, 2], [3, 4] ];;
@@ -284,78 +332,105 @@ gap> atomic readonly m do
 [ true, false, false ]
 ]]></Example>
 
-<C>ShareSingleObj</C> will create a region with a high precedence level. It is intended to be called by user code. The
-actual precedence level can be adjusted by the optional <C>prec</C> argument in the same way as for <C>NewRegion</C>.
+<Ref Func="ShareSingleObj"/> will create a region with a high precedence level. It is intended to be called by user code. The
+actual precedence level can be adjusted by the optional <A>prec</A> argument in the same way as for <Ref Func="NewRegion"/>.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="ShareSingleLibraryObj">
-    <Heading>ShareSingleLibraryObj(obj[, name|, prec|, name, prec])</Heading>
+<ManSection>
+    <Func Name="ShareSingleLibraryObj"
+      Arg='obj [, [ name, ] prec]'/>
 
-<C>ShareSingleLibraryObj</C> functions like <C>ShareSingleObj</C>, except that the precedence of the region it creates
-is below that of <C>ShareSingleObj</C>. It is intended to be used by user libraries and GAP packages.
+<Description>
+<Ref Func="ShareSingleLibraryObj"/> functions like <Ref Func="ShareSingleObj"/>, except that the precedence of the region it creates
+is below that of <Ref Func="ShareSingleObj"/>. It is intended to be used by user libraries and GAP packages.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="ShareSingleSystemObj">
-    <Heading>ShareSingleSystemObj(obj[, name|, prec|, name, prec])</Heading>
+<ManSection>
+    <Func Name="ShareSingleSystemObj"
+      Arg='obj [, [ name, ] prec]'/>
 
-<C>ShareSingleSystemObj</C> functions like <C>ShareSingleObj</C>, except that the precedence of the region it creates is
-below that of <C>ShareSingleLibraryObj</C>. It is intended to be used by the standard GAP library.
+<Description>
+<Ref Func="ShareSingleSystemObj"/> functions like <Ref Func="ShareSingleObj"/>, except that the precedence of the region it creates is
+below that of <Ref Func="ShareSingleLibraryObj"/>. It is intended to be used by the standard GAP library.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="ShareSingleKernelObj">
-    <Heading>ShareSingleKernelObj(obj[, name|, prec|, name, prec])</Heading>
+<ManSection>
+    <Func Name="ShareSingleKernelObj"
+      Arg='obj [, [ name, ] prec]'/>
 
-<C>ShareSingleKernelObj</C> functions like <C>ShareSingleObj</C>, except that the precedence of the region it creates is
-below that of <C>ShareSingleSystemObj</C>. It is intended to be used by the GAP kernel, and GAP library code that
+<Description>
+<Ref Func="ShareSingleKernelObj"/> functions like <Ref Func="ShareSingleObj"/>, except that the precedence of the region it creates is
+below that of <Ref Func="ShareSingleSystemObj"/>. It is intended to be used by the GAP kernel, and GAP library code that
 interacts closely with the kernel.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="ShareSingleInternalObj">
-    <Heading>ShareSingleInternalObj(obj[, name])</Heading>
+<ManSection>
+    <Func Name="ShareSingleInternalObj"
+      Arg='obj[, name]'/>
 
-<C>ShareSingleInternalObj</C> functions like <C>ShareSingleObj</C>, except that the precedence of the region it creates
+<Description>
+<Ref Func="ShareSingleInternalObj"/> functions like <Ref Func="ShareSingleObj"/>, except that the precedence of the region it creates
 is the lowest available. It is intended to be used for regions that are self-contained; i.e. no function that uses such
 a region may lock another region while accessing it.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="ShareSingleSpecialObj">
-    <Heading>ShareSingleSpecialObj(obj[, name])</Heading>
+<ManSection>
+    <Func Name="ShareSingleSpecialObj"
+      Arg='obj[, name]'/>
 
-<C>ShareSingleLibraryObj</C> functions like <C>ShareSingleObj</C>, except that the precedence of the region it creates
+<Description>
+<Ref Func="ShareSingleLibraryObj"/> functions like <Ref Func="ShareSingleObj"/>, except that the precedence of the region it creates
 is negative. It is thus exempt from normal ordering and deadlock checks.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="MigrateObj">
-    <Heading>MigrateObj(obj, target)</Heading>
+<ManSection>
+    <Func Name="MigrateObj"
+      Arg='obj, target'/>
 
-The <C>MigrateObj</C> function migrates <C>obj</C> (and all subobjects contained within the same region) to the region
-denoted by the <C>target</C> argument. Here, <C>target</C> can either be a region object returned by <C>RegionOf</C> or
-a normal gap object. If <C>target</C> is a normal gap object, <C>obj</C> will be migrated to the region containing
+<Description>
+The <Ref Func="MigrateObj"/> function migrates <A>obj</A> (and all subobjects contained within the same region) to the region
+denoted by the <A>target</A> argument. Here, <A>target</A> can either be a region object returned by <Ref Func="RegionOf"/> or
+a normal gap object. If <A>target</A> is a normal gap object, <A>obj</A> will be migrated to the region containing
 <C>target</C>.
-
+<P/>
 For the operation to succeed, the current thread must have exclusive access to the target region and the object being
 migrated.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="MigrateSingleObj">
-    <Heading>MigrateSingleObj(obj, target)</Heading>
+<ManSection>
+    <Func Name="MigrateSingleObj"
+      Arg='obj, target'/>
 
-The <C>MigrateSingleObj</C> function works like <Ref Func="MigrateObj"/>, except that it does not migrate the subobjects
+<Description>
+The <Ref Func="MigrateSingleObj"/> function works like <Ref Func="MigrateObj"/>, except that it does not migrate the subobjects
 of <C>obj</C>.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="LockAndMigrateObj">
-    <Heading>LockAndMigrateObj(obj, target)</Heading>
+<ManSection>
+    <Func Name="LockAndMigrateObj"
+      Arg='obj, target'/>
 
-The <C>LockAndMigrateObj</C> function works like <Ref Func="MigrateObj"/>, except that it will automatically try to
-acquire a lock for the region containing <C>target</C> if it does not have one already.
+<Description>
+The <Ref Func="LockAndMigrateObj"/> function works like <Ref Func="MigrateObj"/>, except that it will automatically try to
+acquire a lock for the region containing <A>target</A> if it does not have one already.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="IncorporateObj">
-    <Heading>IncorporateObj(target, index, value)</Heading>
+<ManSection>
+    <Func Name="IncorporateObj"
+      Arg='target, index, value'/>
 
-The <C>IncorporateObj</C> function allows convenient migration to a shared list or record. If <C>target</C> is a list,
-then <C>IncorporateObj</C> is equivalent to:
+<Description>
+The <Ref Func="IncorporateObj"/> function allows convenient migration to a shared list or record. If <A>target</A> is a list,
+then <Ref Func="IncorporateObj"/> is equivalent to:
 
 <Example><![CDATA[
 IncorporateObj := function(target, index, value)
@@ -365,7 +440,7 @@ IncorporateObj := function(target, index, value)
 end;
 ]]></Example>
 
-If <C>target</C> is a record, then it is equivalent to:
+If <A>target</A> is a record, then it is equivalent to:
 
 <Example><![CDATA[
 IncorporateObj := function(target, index, value)
@@ -391,13 +466,16 @@ gap> ViewShared(list);
 ]]></Example>
 
 Using plain assignment would leave the newly created lists in the thread-local region.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="AtomicIncorporateObj">
-    <Heading>AtomicIncorporateObj(target, index, value)</Heading>
+<ManSection>
+    <Func Name="AtomicIncorporateObj"
+      Arg='target, index, value'/>
 
-<C>AtomicIncorporateObj</C> extends <C>IncorporateObj</C> by also locking the target. I.e., for a list, it is equivalent
-to:
+<Description>
+<Ref Func="AtomicIncorporateObj"/> extends <Ref Func="IncorporateObj"/> by also
+locking the target. I.e., for a list, it is equivalent to:
 
 <Example><![CDATA[
 AtomicIncorporateObj := function(target, index, value)
@@ -416,13 +494,16 @@ AtomicIncorporateObj := function(target, index, value)
   od;
 end;
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="AdoptObj">
-    <Heading>AdoptObj(obj)</Heading>
+<ManSection>
+    <Func Name="AdoptObj"
+      Arg='obj'/>
 
-The <C>AdoptObj</C> function migrates <C>obj</C> (and all its subobjects contained within the same region) to the
-thread&#39;s current region. It requires exclusive access to <C>obj</C>.
+<Description>
+The <Ref Func="AdoptObj"/> function migrates <A>obj</A> (and all its subobjects contained within the same region) to the
+thread&#39;s current region. It requires exclusive access to <A>obj</A>.
 
 <Example><![CDATA[
 gap> l := ShareObj([1,2,3]);;
@@ -432,26 +513,35 @@ gap> atomic l do AdoptObj(l); od;
 gap> IsThreadLocal(l);
 true
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="AdoptSingleObj">
-    <Heading>AdoptSingleObj(obj)</Heading>
+<ManSection>
+    <Func Name="AdoptSingleObj"
+      Arg='obj'/>
 
-The <C>AdoptSingleObj</C> function works like <Ref Func="AdoptObj"/>, except that it does not migrate the subobjects of
-<C>obj</C>.
+<Description>
+The <Ref Func="AdoptSingleObj"/> function works like <Ref Func="AdoptObj"/>, except that it does not migrate the subobjects of
+<A>obj</A>.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="LockAndAdoptObj">
-    <Heading>LockAndAdoptObj(obj)</Heading>
+<ManSection>
+    <Func Name="LockAndAdoptObj"
+      Arg='obj'/>
 
-The <C>LockAndAdoptObj</C> function works like <Ref Func="AdoptObj"/>, except that it will attempt acquire an exclusive
-lock for the region containing <C>obj</C> if it does not have one already.
+<Description>
+The <Ref Func="LockAndAdoptObj"/> function works like <Ref Func="AdoptObj"/>, except that it will attempt acquire an exclusive
+lock for the region containing <A>obj</A> if it does not have one already.
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="CopyRegion">
-    <Heading>CopyRegion(obj)</Heading>
+<ManSection>
+    <Func Name="CopyRegion"
+      Arg='obj'/>
 
-The <C>CopyRegion</C> function performs a structural copy of <C>obj</C>. The resulting objects will be located in the
+<Description>
+The <Ref Func="CopyRegion"/> function performs a structural copy of <A>obj</A>. The resulting objects will be located in the
 current thread&#39;s thread-local region. The function returns the copy as its result.
 
 <Example><![CDATA[
@@ -466,12 +556,15 @@ false
 gap> l = l2;
 true
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Subsection>
-  <Subsection Label="IsPublic">
-    <Heading>IsPublic(obj)</Heading>
+<ManSection>
+    <Func Name="IsPublic"
+      Arg='obj'/>
 
-The <C>IsPublic</C> function returns true if its argument is an object in the public region, false otherwise.
+<Description>
+The <Ref Func="IsPublic"/> function returns true if its argument is an object in the public region, false otherwise.
 
 <Example><![CDATA[
 gap> IsPublic(1/2);
@@ -483,12 +576,15 @@ false
 gap> IsPublic(MakeImmutable([1,2,3]));
 true
 ]]></Example>
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="IsThreadLocal">
-      <Heading>IsThreadLocal(obj)</Heading>
+<ManSection>
+    <Func Name="IsThreadLocal"
+      Arg='obj'/>
 
-The <C>IsThreadLocal</C> function returns true if its argument is an object in the current thread&#39;s thread-local
+<Description>
+The <Ref Func="IsThreadLocal"/> function returns true if its argument is an object in the current thread&#39;s thread-local
 region, false otherwise.
 
 <Example><![CDATA[
@@ -501,21 +597,27 @@ false
 gap> RegionOf(1/2);
 <public region>
 ]]></Example>
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="IsShared">
-      <Heading>IsShared(obj)</Heading>
+<ManSection>
+    <Func Name="IsShared"
+      Arg='obj'/>
 
-The <C>IsShared</C> function returns true if its argument is an object in a shared region. Note that if the current
-thread does not hold a lock on that shared region, another thread can migrate <C>obj</C> to a different region before
+<Description>
+The <Ref Func="IsShared"/> function returns true if its argument is an object in a shared region. Note that if the current
+thread does not hold a lock on that shared region, another thread can migrate <A>obj</A> to a different region before
 the result is being evaluated; this can lead to race conditions. The function is intended primarily for debugging, not
 to build actual program logic around.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="HaveReadAccess">
-      <Heading>HaveReadAccess(obj)</Heading>
+<ManSection>
+    <Func Name="HaveReadAccess"
+      Arg='obj'/>
 
-The <C>HaveReadAccess</C> function returns true if the current thread has read access to <C>obj</C>.
+<Description>
+The <Ref Func="HaveReadAccess"/> function returns true if the current thread has read access to <A>obj</A>.
 
 <Example><![CDATA[
 gap> HaveReadAccess([1,2,3]);
@@ -526,12 +628,15 @@ false
 gap> atomic readonly l do t := HaveReadAccess(l); od;; t;
 true
 ]]></Example>
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="HaveWriteAccess">
-      <Heading>HaveWriteAccess(obj)</Heading>
+<ManSection>
+    <Func Name="HaveWriteAccess"
+      Arg='obj'/>
 
-The <C>HaveWriteAccess</C> function returns true if the current thread has write access to <C>obj</C>.
+<Description>
+The <Ref Func="HaveWriteAccess"/> function returns true if the current thread has write access to <A>obj</A>.
 
 <Example><![CDATA[
 gap> HaveWriteAccess([1,2,3]);
@@ -542,26 +647,35 @@ false
 gap> atomic readwrite l do t := HaveWriteAccess(l); od;; t;
 true
 ]]></Example>
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="MakeReadOnly">
-      <Heading>MakeReadOnly(obj)</Heading>
+<ManSection>
+    <Func Name="MakeReadOnly"
+      Arg='obj'/>
 
-The <C>MakeReadOnly</C> function migrates <C>obj</C> and all its subobjects that are within the same region as
-<C>obj</C> to the read-only region. It returns <C>obj</C>.
+<Description>
+The <Ref Func="MakeReadOnly"/> function migrates <A>obj</A> and all its subobjects that are within the same region as
+<A>obj</A> to the read-only region. It returns <A>obj</A>.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="MakeReadOnlyObj">
-      <Heading>MakeReadOnlyObj(obj)</Heading>
+<ManSection>
+    <Func Name="MakeReadOnlyObj"
+      Arg='obj'/>
 
-The <C>MakeReadOnlyObj</C> function migrates <C>obj</C>, but not any of its subobjects, to the read-only region. It
-returns <C>obj</C>.
+<Description>
+The <Ref Func="MakeReadOnlyObj"/> function migrates <A>obj</A>, but not any of its subobjects, to the read-only region. It
+returns <A>obj</A>.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="IsReadOnly">
-      <Heading>IsReadOnly(obj)</Heading>
+<ManSection>
+    <Func Name="IsReadOnly"
+      Arg='obj'/>
 
-The <C>IsReadOnly</C> function returns true if <C>obj</C> is in the read-only region, false otherwise.
+<Description>
+The <Ref Func="IsReadOnly"/> function returns <K>true</K> if <A>obj</A> is in the read-only region, <K>false</K> otherwise.
 
 <Example><![CDATA[
 gap> IsReadOnly([1,2,3]);
@@ -571,48 +685,64 @@ false
 gap> IsReadOnly(MakeReadOnly([1,2,3]));
 true
 ]]></Example>
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="SetRegionName">
-      <Heading>SetRegionName(obj, name)</Heading>
+<ManSection>
+    <Func Name="SetRegionName"
+      Arg='obj, name'/>
 
-The <C>SetRegionName</C> function sets the name of the region of <C>obj</C> to <C>name</C>.
+<Description>
+The <Ref Func="SetRegionName"/> function sets the name of the region of <A>obj</A> to <A>name</A>.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="ClearRegionName">
-      <Heading>ClearRegionName(obj)</Heading>
+<ManSection>
+    <Func Name="ClearRegionName"
+      Arg='obj'/>
 
-The <C>ClearRegionName</C> function clears the name of the region of <C>obj</C> to <C>name</C>.
+<Description>
+The <Ref Func="ClearRegionName"/> function clears the name of the region of <A>obj</A> to <A>name</A>.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="RegionName">
-      <Heading>RegionName(obj)</Heading>
+<ManSection>
+    <Func Name="RegionName"
+      Arg='obj'/>
 
-The <C>RegionName</C> function returns the name of the region of <C>obj</C>. If that region does not have a name,
-<C>fail</C> will be returned.
+<Description>
+The <Ref Func="RegionName"/> function returns the name of the region of <A>obj</A>. If that region does not have a name,
+<K>fail</K> will be returned.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="ViewShared">
-      <Heading>ViewShared(obj)</Heading>
+<ManSection>
+    <Func Name="ViewShared"
+      Arg='obj'/>
 
-The <C>ViewShared</C> function allows the inspection of objects in shared regions. It will try to lock the region and
+<Description>
+The <Ref Func="ViewShared"/> function allows the inspection of objects in shared regions. It will try to lock the region and
 then call <C>ViewObj(obj)</C>. If it cannot acquire a lock for the region, it will simply display the normal description
 of the object.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="UNSAFE_VIEW">
-      <Heading>UNSAFE_VIEW(obj)</Heading>
+<ManSection>
+    <Func Name="UNSAFE_VIEW"
+      Arg='obj'/>
 
-The <C>UNSAFE_VIEW</C> function allows the inspection of any object in the system, regardless of whether the current
+<Description>
+The <Ref Func="UNSAFE_VIEW"/> function allows the inspection of any object in the system, regardless of whether the current
 thread has access to the region containing it. It should be used with care: If the object inspected is being modified by
 another thread concurrently, the resulting behavior is undefined.
-
+<P/>
 Moreover, the function works by temporarily disabling read and write guards for regions, so other threads may corrupt
 memory rather than producing errors.
-
+<P/>
 It is generally safe to use if all threads but the current one are paused.
+</Description>
+</ManSection>
 
-    </Subsection>
     <Subsection Label="The atomic statement.">
       <Heading>The <C>atomic</C> statement.</Heading>
 
@@ -678,41 +808,48 @@ gap> AddAtomic := atomic function(readwrite list, readonly item)
 There is an exception to the rule that objects can only be modified if a thread has write access to a region. A limited
 sets of objects can be modified using the &quot;bind once&quot; family of functions. These allow the modifications of
 objects to which a thread has read access in a limited fashion.
-
+<P/>
 For reasons of implementation symmetry, these functions can also be used on the atomic versions of these objects.
-
+<P/>
 Implementation note: The functionality is not currently available for component objects.
 
-  </Section>
-  <Section Label="BindOnce">
-    <Heading>BindOnce(obj, index, value)</Heading>
+<ManSection>
+    <Func Name="BindOnce"
+      Arg='obj, index, value'/>
 
-<C>BindOnce</C> modifies <C>obj</C>, which can be a positional object, atomic positional object, component object, or
+<Description>
+<Ref Func="BindOnce"/> modifies <A>obj</A>, which can be a positional object, atomic positional object, component object, or
 atomic component object. It inspects <C>obj![index]</C> for the positional versions or <C>obj!.(index)</C> for the
-component versions. If the respective element is not yet bound, <C>value</C> is assigned to that element. Otherwise, no
+component versions. If the respective element is not yet bound, <A>value</A> is assigned to that element. Otherwise, no
 modification happens. The test and modification occur as one atomic step. The function returns the value of the element;
-i.e. the old value if the element was bound and <C>value</C> if it was unbound.
-
+i.e. the old value if the element was bound and <A>value</A> if it was unbound.
+<P/>
 The intent of this function is to allow concurrent initialization of objects, where multiple threads may attempt to set
-a value concurrently. Only one will succeed; all threads can then use the return value of <C>BindOnce</C> as the
+a value concurrently. Only one will succeed; all threads can then use the return value of <Ref Func="BindOnce"/> as the
 definitive value of the element. It also allows for the lazy initialization of objects in the read-only region.
+<P/>
+The current thread needs to have at least read access to <A>obj</A>, but does not require write access.
+</Description>
+</ManSection>
 
-The current thread needs to have at least read access to <C>obj</C>, but does not require write access.
+<ManSection>
+    <Func Name="TestBindOnce"
+      Arg='obj, index, value'/>
 
-  </Section>
-  <Section Label="TestBindOnce">
-    <Heading>TestBindOnce(obj, index, value)</Heading>
+<Description>
+<Ref Func="TestBindOnce"/> works like <Ref Func="BindOnce"/>, except that it returns <K>true</K> if the value could be bound and
+<K>false</K> otherwise.
+</Description>
+</ManSection>
 
-<C>TestBindOnce</C> works like <C>BindOnce</C>, except that it returns <C>true</C> if the value could be bound and
-<C>false</C> otherwise.
+<ManSection>
+    <Func Name="BindOnceExpr"
+      Arg='obj, index, expr'/>
 
-  </Section>
-  <Section Label="BindOnceExpr">
-    <Heading>BindOnceExpr(obj, index, expr)</Heading>
-
-<C>BindOnceExpr</C> works like <C>BindOnce</C>, except that it evaluates the parameterless function <C>expr</C> to
-determine the value. It will only evaluate <C>expr</C> if the element is not bound.
-
+<Description>
+<Ref Func="BindOnceExpr"/> works like <Ref Func="BindOnce"/>, except that it evaluates the parameterless function <A>expr</A> to
+determine the value. It will only evaluate <A>expr</A> if the element is not bound.
+<P/>
 For positional objects, the implementation works as follows:
 
 <Example><![CDATA[
@@ -726,24 +863,32 @@ end;
 ]]></Example>
 
 The implementation for component objects works analogously.
-
+<P/>
 The intent is to avoid unnecessary computations if the value is already bound. Note that this cannot be avoided
-entirely, because <C>obj![index]</C> or <C>obj!.(index)</C> can be bound while <C>expr</C> is evaluated, but it can
+entirely, because <C>obj![index]</C> or <C>obj!.(index)</C> can be bound while <A>expr</A> is evaluated, but it can
 minimize such occurrences.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="TestBindOnceExpr">
-    <Heading>TestBindOnceExpr(obj, index, expr)</Heading>
+<ManSection>
+    <Func Name="TestBindOnceExpr"
+      Arg='obj, index, expr'/>
 
-<C>TestBindOnceExpr</C> works like <C>BindOnceExpr</C>, except that it returns <C>true</C> if the value could be bound
-and <C>false</C> otherwise.
+<Description>
+<Ref Func="TestBindOnceExpr"/> works like <Ref Func="BindOnceExpr"/>, except that it returns <K>true</K> if the value could be bound
+and <K>false</K> otherwise.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="StrictBindOnce">
-    <Heading>StrictBindOnce(obj, index, expr)</Heading>
+<ManSection>
+    <Func Name="StrictBindOnce"
+      Arg='obj, index, expr'/>
 
-<C>StrictBindOnce</C> works like <C>BindOnce</C>, except that it raises an error if the element is already bound. This
+<Description>
+<Ref Func="StrictBindOnce"/> works like <Ref Func="BindOnce"/>, except that it raises an error if the element is already bound. This
 is intended for cases where a read-only object is initialized, but where another thread trying to initialize it
 concurrently would be an error.
+</Description>
+</ManSection>
   </Section>
 </Chapter>

--- a/doc/hpc/semaphores.xml
+++ b/doc/hpc/semaphores.xml
@@ -1,26 +1,33 @@
 <Chapter Label="Semaphores">
   <Heading>Semaphores</Heading>
 
+<Section Label="section:Semaphores">
+  <Heading>Semaphores</Heading>
   Semaphores are synchronized counters; they can also be used to simulate locks.
 
-  <Section Label="CreateSemaphore">
-    <Heading>CreateSemaphore([value])</Heading>
+<ManSection>
+    <Func Name="CreateSemaphore"
+      Arg='[value]'/>
 
-The function <C>CreateSemaphore</C> takes an optional argument, which defaults to zero. It is the counter with which the
+<Description>
+The function <Ref Func="CreateSemaphore"/> takes an optional argument, which defaults to zero. It is the counter with which the
 semaphore is initialized.
 
 <Example><![CDATA[
 gap> sem := CreateSemaphore(1);
 <semaphore 0x1108e81c0: count = 1>
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="WaitSemaphore">
-    <Heading>WaitSemaphore(sem);</Heading>
+<ManSection>
+    <Func Name="WaitSemaphore"
+      Arg='sem'/>
 
-<C>WaitSemaphore</C> receives a previously created semaphore as its argument. If the semaphore&#39;s counter is greater
+<Description>
+<Ref Func="WaitSemaphore"/> receives a previously created semaphore as its argument. If the semaphore&#39;s counter is greater
 than zero, it decrements the counter and returns; if the counter is zero, it waits until another thread increases it via
-<C>SignalSemaphore</C>, then decrements the counter and returns.
+<Ref Func="SignalSemaphore"/>, then decrements the counter and returns.
 
 <Example><![CDATA[
 gap> sem := CreateSemaphore(1);
@@ -29,12 +36,15 @@ gap> WaitSemaphore(sem);
 gap> sem;
 <semaphore 0x1108e81c0: count = 0>
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="SignalSemaphore">
-    <Heading>SignalSemaphore(sem)</Heading>
+<ManSection>
+    <Func Name="SignalSemaphore"
+      Arg='sem'/>
 
-<C>SignalSemaphore</C> receives a previously created semaphore as its argument. It increments the semaphore&#39;s
+<Description>
+<Ref Func="SignalSemaphore"/> receives a previously created semaphore as its argument. It increments the semaphore&#39;s
 counter and returns.
 
 <Example><![CDATA[
@@ -47,12 +57,14 @@ gap> SignalSemaphore(sem);
 gap> sem;
 <semaphore 0x1108e81c0: count = 1>
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="Simulating locks">
+  <Subsection Label="Simulating locks">
     <Heading>Simulating locks</Heading>
 
-In order to use semaphores to simulate locks, create a semaphore with an initial value of 1. <C>WaitSemaphore</C> is
-then equivalent to a lock operation, <C>SignalSemaphore</C> is equivalent to an unlock operation.
+In order to use semaphores to simulate locks, create a semaphore with an initial value of 1. <Ref Func="WaitSemaphore"/> is
+then equivalent to a lock operation, <Ref Func="SignalSemaphore"/> is equivalent to an unlock operation.
+  </Subsection>
   </Section>
 </Chapter>

--- a/doc/hpc/serialize.xml
+++ b/doc/hpc/serialize.xml
@@ -1,68 +1,81 @@
 <Chapter Label="Serialization support">
   <Heading>Serialization support</Heading>
 
+<Section Label="section:Serialization support">
+  <Heading>Serialization support</Heading>
 
 HPC-GAP has support to serialize most GAP data. While functions in particular cannot be serialized, it is possible to
 serialize all primitive types (booleans, integers, cyclotomics, permutations, floats, etc.) as well as all lists and
 records.
-
+<P/>
 Custom serialization support can be written for data objects, positional objects, and component objects; serialization
 of compressed vectors is already supported by the standard library.
 
-  <Section Label="SerializeToNativeString">
-    <Heading>SerializeToNativeString(obj)</Heading>
+<ManSection>
+    <Func Name="SerializeToNativeString"
+      Arg='obj'/>
 
-<C>SerializeToNativeString</C> takes the object passed as an argument and turns it into a string, from which a copy of
-the original can be extracted using <C>DeserializeNativeString</C>.
+<Description>
+<Ref Func="SerializeToNativeString"/> takes the object passed as an argument and turns it into a string, from which a copy of
+the original can be extracted using <Ref Func="DeserializeNativeString"/>.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="DeserializeNativeString">
-    <Heading>DeserializeNativeString(str)</Heading>
+<ManSection>
+    <Func Name="DeserializeNativeString"
+      Arg='str'/>
 
-<C>DeserializeNativeString</C> reverts the serialization process.
-
+<Description>
+<Ref Func="DeserializeNativeString"/> reverts the serialization process.
+<P/>
 Example:
 
 <Example><![CDATA[
 gap> DeserializeNativeString(SerializeToNativeString([1,2,3]));
 [ 1, 2, 3 ]
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="InstallTypeSerializationTag">
-    <Heading>InstallTypeSerializationTag(type, tag)</Heading>
+<ManSection>
+    <Func Name="InstallTypeSerializationTag"
+      Arg='type, tag'/>
 
-<C>InstallTypeSerializationTag</C> allows the serialization of data objects, positional objects, and component objects.
-The value of <C>tag</C> must be unique for each type; it can be a string or integer. Non-negative integers are reserved
+<Description>
+<Ref Func="InstallTypeSerializationTag"/> allows the serialization of data objects, positional objects, and component objects.
+The value of <A>tag</A> must be unique for each type; it can be a string or integer. Non-negative integers are reserved
 for use by the standard library; users should use negative integers or strings instead.
-
+<P/>
 Objects of such a type are serialized in a straightforward way: During serialization, data objects are converted into
 byte streams, positional objects into lists, and component objects into records. These objects are then serialized along
-with their tags; deserialization uses the type corresponding to the tag in conjunction with <C>Objectify</C> to
+with their tags; deserialization uses the type corresponding to the tag in conjunction with <Ref BookName="ref" Func="Objectify"/> to
 reconstruct a copy of the original object.
-
+<P/>
 Note that this functionality may be inadequate for objects that have complex data structures attached that are not meant
 to be replicated. The following alternative is meant for such objects.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="InstallSerializer">
-    <Heading>InstallSerializer(description, filters, method)</Heading>
+<ManSection>
+    <Func Name="InstallSerializer"
+      Arg='description, filters, method'/>
 
-The more general <C>InstallSerializer</C> allows for arbitarily complex serialization code. It installs <C>method</C> as
-the method to serialize objects matching <C>filters</C>; <C>description</C> has the same role as for
-<C>InstallMethod</C>.
-
+<Description>
+The more general <Ref Func="InstallSerializer"/> allows for arbitarily complex serialization code. It installs <A>method</A> as
+the method to serialize objects matching <A>filters</A>; <A>description</A> has the same role as for
+<Ref BookName="ref" Func="InstallMethod"/>.
+<P/>
 The method must return a plain list matching a specific format. The first element must be a non-negative integer, the
 second must be a string descriptor that is unique to the serializer; these can then be followed by an arbitrary number
 of arguments.
-
+<P/>
 As many of the arguments (starting with the third element of the list) as specified by the first element of the list
 will be converted from their object representation into a serializable representation. Data objects will be converted
 into untyped data objects, positional objects will be converted into plain lists, and component objects into records.
 Conversion will not modify the objects in place, but work on copies. The remaining arguments will remain untouched.
-
+<P/>
 Upon deserialization, these arguments will be passed to a function specified by the second element of the list.
-
+<P/>
 Example:
 
 <Example><![CDATA[
@@ -73,15 +86,18 @@ end);
 
 Here, <C>obj</C> will be converted into its underlying representation, while the remaining arguments are left alone.
 <C>"Vec8Bit"</C> is the name that is used to look up the deserializer function.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="InstallDeserializer">
-    <Heading>InstallDeserializer(descriptor, func)</Heading>
+<ManSection>
+    <Func Name="InstallDeserializer"
+      Arg='descriptor, func'/>
 
-The <C>descriptor</C> value must be the same as the second element of the list returned by the serializer; <C>func</C>
+<Description>
+The <A>descriptor</A> value must be the same as the second element of the list returned by the serializer; <A>func</A>
 must be a function that takes as many arguments as there were arguments after the second element of that list. For
 deserialization, this function is invoked and needs to return the deserialized object constructed from the arguments.
-
+<P/>
 Example:
 
 <Example><![CDATA[
@@ -93,6 +109,7 @@ end);
 
 Here, the untyped <C>obj</C> that was passed to the deserializer needs to be given the correct type, which is calculated
 from <C>q</C> and <C>mut</C>.
-
+</Description>
+</ManSection>
   </Section>
 </Chapter>

--- a/doc/hpc/syncvars.xml
+++ b/doc/hpc/syncvars.xml
@@ -1,9 +1,12 @@
 <Chapter Label="Synchronization variables">
   <Heading>Synchronization variables</Heading>
 
+<Section Label="section:Synchronization variables">
+  <Heading>Synchronization variables</Heading>
+  
 Synchronization variables (also often called dataflow variables in the literature) are variables that can be written
 only once; attempts to read the variable block until it has been written to.
-
+<P/>
 Synchronization variables are created with <Ref Func="CreateSyncVar"/>, written with <Ref Func="SyncWrite"/> and read
 with <Ref Func="SyncRead"/>.
 
@@ -17,29 +20,37 @@ gap> SyncRead(sv);
 [ 1, 2, 3 ]
 ]]></Example>
 
-  <Section Label="CreateSyncVar">
-    <Heading>CreateSyncVar()</Heading>
+<ManSection>
+    <Func Name="CreateSyncVar"
+      Arg=''/>
 
-The function <C>CreateSyncVar</C> takes no arguments. It returns a new synchronization variable. There is no need to
+<Description>
+The function <Ref Func="CreateSyncVar"/> takes no arguments. It returns a new synchronization variable. There is no need to
 deallocate it; the garbage collector will free the memory and all related resources when it is no longer accessible.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="SyncWrite">
-    <Heading>SyncWrite(syncvar, obj)</Heading>
+<ManSection>
+    <Func Name="SyncWrite"
+      Arg='syncvar, obj'/>
 
-<C>SyncWrite</C> attempts to assign the value <C>obj</C> to <C>syncvar</C>. If <C>syncvar</C> has been previously
-assigned a value, the call will fail with a runtime error; otherwise, <C>obj</C> will be assigned to <C>syncvar</C>.
-
-In order to make sure that the recipient can read the result, the <C>obj</C> argument should not be a thread-local
+<Description>
+<Ref Func="SyncWrite"/> attempts to assign the value <A>obj</A> to <A>syncvar</A>. If <A>syncvar</A> has been previously
+assigned a value, the call will fail with a runtime error; otherwise, <A>obj</A> will be assigned to <A>syncvar</A>.
+<P/>
+In order to make sure that the recipient can read the result, the <A>obj</A> argument should not be a thread-local
 object; it should be public, read-only, or shared.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="SyncRead">
-    <Heading>SyncRead(syncvar)</Heading>
+<ManSection>
+    <Func Name="SyncRead"
+      Arg='syncvar'/>
 
-<C>SyncRead</C> reads the value previously assigned to <C>syncvar</C> with <C>SyncWrite</C>. If no value has been
+<Description>
+<Ref Func="SyncRead"/> reads the value previously assigned to <A>syncvar</A> with <Ref Func="SyncWrite"/>. If no value has been
 assigned yet, it blocks. It returns the assigned value.
-
-
+</Description>
+</ManSection>
   </Section>
 </Chapter>

--- a/doc/hpc/tasks.xml
+++ b/doc/hpc/tasks.xml
@@ -6,7 +6,7 @@
     Tasks provide mid- to high-level functionality for programmers to describe asynchronous workflows. A task is an
     asynchronously or synchronously executing job; functions exist to create tasks that are executed concurrently, on
     demand, or in the current thread; to wait for their completion, check their status, and retrieve any results.
-
+    <P/>
     Here is a simple example of sorting a list in the background:
 
 <Example><![CDATA[
@@ -19,7 +19,7 @@ gap> TaskResult(task);
 <Ref Func="RunTask"/> dispatches a task to run in the background; a task is described by a function and zero or more
 arguments that are passed to <Ref Func="RunTask"/>. <Ref Func="WaitTask"/> waits for the task to complete; and
 <C>TaskResult</C> returns the result of the task.
-
+<P/>
 <Ref Func="TaskResult"/> does an implicit <Ref Func="WaitTask"/>, so the second line above can actually be omitted:
 
 <Example><![CDATA[
@@ -50,10 +50,10 @@ true
 
 Note that <Ref Func="WaitTask"/> is used here to start execution of both tasks; otherwise, <C>task2</C> would not be
 started until <C>TaskResult(task1)</C> has been evaluated.
-
+<P/>
 To start execution of a delayed task, you can also use <C>ExecuteTask</C>. This has no effect if a task has already been
 running.
-
+<P/>
 For convenience, you can also use <Ref Func="ImmediateTask"/> to execute a task synchronously (i.e., the task is started
 immediately and the call does not return until the task has completed).
 
@@ -64,7 +64,7 @@ gap> TaskResult(task);
 ]]></Example>
 
 This is indistinguishable from calling the function directly, but provides the same interface as normal tasks.
-
+<P/>
 Sometimes it can be useful to ignore the result of a task. The <C>RunAsyncTask</C> provides the necessary functionality.
 
 <Example><![CDATA[
@@ -73,11 +73,11 @@ Hello, world!
 ]]></Example>
 
 Such a task cannot be waited for and its result (if any) is ignored.
-
+<P/>
 Task arguments are generally copied so that both the task that created them and the task that uses them can access the
 data concurrently without fear of race conditions. To avoid copying, arguments should be made shared or public (see the
 relevant parts of the section on ); shared and public arguments will not be copied.
-
+<P/>
 HPC-GAP currently has multiple implementations of the task API. To enable the reference implementation, set the
 environment variable <C>GAP_STDTASKS</C> to a non-empty value before starting GAP.
   </Section>
@@ -167,7 +167,6 @@ gap> TaskResult(t);
 
     <ManSection>
       <Func Name="WaitTask" Arg='task1,...,taskn'/>
-      <Func Name="WaitTask" Arg='condition'/>
       <Func Name="WaitTask" Arg='condition' Label="with a condition" />
       <Func Name="WaitTasks" Arg='task1,...,taskn'/>
 

--- a/doc/hpc/threads.xml
+++ b/doc/hpc/threads.xml
@@ -5,37 +5,51 @@ HPC-GAP has low-level functionality to support explicit creation of threads. In 
 higher-level functionality, such as tasks, to describe concurrency. The thread functions described here exist to
 facilitate the construction of higher level libraries and are not meant to be used directly.
 
-  <Section Label="CreateThread">
-    <Heading>CreateThread(func [, arg1, ..., argn])</Heading>
+<Section Label="section:Thread functions">
+  <Heading>Thread functions</Heading>
+  
+<ManSection>
+    <Func Name="CreateThread"
+      Arg='func [, arg1, ..., argn]'/>
 
-New threads are created with the function <C>CreateThread</C>. The thread takes at least one function as its argument
+<Description>
+New threads are created with the function <Ref Func="CreateThread"/>. The thread takes at least one function as its argument
 that it will call in the newly created thread; it also accepts zero or more parameters that will be passed to that
 function.
-
+<P/>
 The function returns a thread object describing the thread.
-
+<P/>
 Only a finite number of threads can be active at a time (that limit is system-dependent). To reclaim the resources
 occupied by one thread, use the <Ref Func="WaitThread"/> function.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="WaitThread">
-    <Heading>WaitThread</Heading>
+<ManSection>
+    <Func Name="WaitThread"
+      Arg='threadID'/>
 
-The <C>WaitThread</C> function waits for the thread identified by <C>threadID</C> to finish; it does not return any
+<Description>
+The <Ref Func="WaitThread"/> function waits for the thread identified by <A>threadID</A> to finish; it does not return any
 value. When it returns, it returns all resources occupied by the thread it waited for, such as thread-local memory and
 operating system structures, to the system.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="CurrentThread">
-    <Heading>CurrentThread()</Heading>
+<ManSection>
+    <Func Name="CurrentThread"
+      Arg=''/>
 
-The <C>CurrentThread</C> function returns the thread object for the current thread.
+<Description>
+The <Ref Func="CurrentThread"/> function returns the thread object for the current thread.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="ThreadID">
-    <Heading>ThreadID(thread)</Heading>
+<ManSection>
+    <Func Name="ThreadID"
+      Arg='thread'/>
 
-The <C>ThreadID</C> function returns a numeric thread id for the given thread. The thread id of the main thread is
+<Description>
+The <Ref Func="ThreadID"/> function returns a numeric thread id for the given thread. The thread id of the main thread is
 always 0.
 
 <Example><![CDATA[
@@ -44,33 +58,39 @@ gap> CurrentThread();
 gap> ThreadID(CurrentThread());
 0
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="KillThread">
-    <Heading>KillThread(thread)</Heading>
+<ManSection>
+    <Func Name="KillThread"
+      Arg='thread'/>
 
-The <C>KillThread</C> function terminates the given thread. Any region locks that the thread currently holds will be
+<Description>
+The <Ref Func="KillThread"/> function terminates the given thread. Any region locks that the thread currently holds will be
 unlocked. The thread can be specified as a thread object or via its numeric id.
-
-The implementation for <C>KillThread</C> is dependent on the interpreter actually executing statements. Threads
+<P/>
+The implementation for <Ref Func="KillThread"/> is dependent on the interpreter actually executing statements. Threads
 performing system calls, for example, will not be terminated until the system call returns. Similarly, long-running
 kernel functions will delay termination until the kernel function returns.
-
+<P/>
 Use of <C>CALL_WITH_CATCH</C> will not prevent a thread from being terminated. If you wish to make sure that catch
-handlers will be visited, use <Ref Func="InterruptThread"/> instead. <C>KillThread</C> should be used for threads that
+handlers will be visited, use <Ref Func="InterruptThread"/> instead. <Ref Func="KillThread"/> should be used for threads that
 cannot be controlled anymore in any other way but still eat system resources.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="PauseThread">
-    <Heading>PauseThread(thread)</Heading>
+<ManSection>
+    <Func Name="PauseThread"
+      Arg='thread'/>
 
-The <C>PauseThread</C> function suspends execution for the given thread. The thread can be specified as a thread object
+<Description>
+The <Ref Func="PauseThread"/> function suspends execution for the given thread. The thread can be specified as a thread object
 or via its numeric id.
-
-The implementation for <C>PauseThread()</C> is dependent on the interpreter actually executing statements. Threads
+<P/>
+The implementation for <Ref Func="PauseThread"/> is dependent on the interpreter actually executing statements. Threads
 performing system calls, for example, will not pause until the system call returns. Similarly, long-running kernel
 functions will not pause until the kernel function returns.
-
+<P/>
 While a thread is paused, the thread that initiated the pause can access the paused thread&#39;s thread-local region.
 
 <Example><![CDATA[
@@ -81,44 +101,56 @@ gap> PauseThread(th);
 gap> x;
 [ 1, 2, 3 ]
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="ResumeThread">
-    <Heading>ResumeThread(thread)</Heading>
+<ManSection>
+    <Func Name="ResumeThread"
+      Arg='thread'/>
 
-The <C>ResumeThread</C> function resumes execution for the given thread that was paused with <C>PauseThread</C>. The
+<Description>
+The <Ref Func="ResumeThread"/> function resumes execution for the given thread that was paused with <Ref Func="PauseThread"/>. The
 thread can be specified as a thread object or via its numeric id.
+<P/>
+If the thread isn&#39;t paused, <Ref Func="ResumeThread"/> is a no-op.
+</Description>
+</ManSection>
 
-If the thread isn&#39;t paused, <C>ResumeThread</C> is a no-op.
+<ManSection>
+    <Func Name="InterruptThread"
+      Arg='thread, interrupt'/>
 
-  </Section>
-  <Section Label="InterruptThread">
-    <Heading>InterruptThread(thread, interrupt)</Heading>
-
-The <C>InterruptThread</C> function calls an interrupt handler for the given thread. The thread can be specified as a
+<Description>
+The <Ref Func="InterruptThread"/> function calls an interrupt handler for the given thread. The thread can be specified as a
 thread object or via its numeric id. The interrupt is specified as an integer between 0 and <Ref Func="MAX_INTERRUPT"/>.
-
+<P/>
 An interrupt number of zero (or an interrupt number for which no interrupt handler has been set up with <Ref
 Func="SetInterruptHandler"/> will cause the thread to enter a break loop. Otherwise, the respective interrupt handler
 that has been created with <Ref Func="SetInterruptHandler"/> will be called.
-
-The implementation for <C>InterruptThread</C> is dependent on the interpreter actually executing statements. Threads
+<P/>
+The implementation for <Ref Func="InterruptThread"/> is dependent on the interpreter actually executing statements. Threads
 performing system calls, for example, will not call interrupt handlers until the system call returns. Similarly,
 long-running kernel functions will delay invocation of the interrupt handler until the kernel function returns.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="SetInterruptHandler">
-    <Heading>SetInterruptHandler(interrupt, handler)</Heading>
+<ManSection>
+    <Func Name="SetInterruptHandler"
+      Arg='interrupt, handler'/>
 
-The <C>SetInterruptHandler</C> function allows the programmer to set up interrupt handlers for the current thread. The
+<Description>
+The <Ref Func="SetInterruptHandler"/> function allows the programmer to set up interrupt handlers for the current thread. The
 interrupt number must be in the range from 1 to <Ref Func="MAX_INTERRUPT"/> (inclusive); the handler must be a
-parameterless function (or <C>fail</C> to remove a handler).
+parameterless function (or <K>fail</K> to remove a handler).
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="NewInterruptID">
-    <Heading>NewInterruptID()</Heading>
+<ManSection>
+    <Func Name="NewInterruptID"
+      Arg=''/>
 
-The <C>NewInterruptID</C> function returns a previously unused number (starting at 1). These numbers can be used to
+<Description>
+The <Ref Func="NewInterruptID"/> function returns a previously unused number (starting at 1). These numbers can be used to
 globally coordinate interrupt numbers.
 
 <Example><![CDATA[
@@ -126,12 +158,16 @@ gap> StopTaskInterrupt := NewInterruptID();
 1
 gap> SetInterruptHandler(StopTaskInterrupt, StopTaskHandler);
 ]]></Example>
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="MAX_INTERRUPT">
-    <Heading>MAX_INTERRUPT</Heading>
+<ManSection>
+    <Var Name="MAX_INTERRUPT"/>
 
-The global variable <C>MAX_INTERRUPT</C> is an integer containing the maximum value for the interrupt arguments to <Ref
+<Description>
+The global variable <Ref Var="MAX_INTERRUPT"/> is an integer containing the maximum value for the interrupt arguments to <Ref
 Func="InterruptThread"/> and <Ref Func="SetInterruptHandler"/>.
+</Description>
+</ManSection>
   </Section>
 </Chapter>

--- a/doc/hpc/ui.xml
+++ b/doc/hpc/ui.xml
@@ -10,7 +10,7 @@ the <C>-S</C> option.
 
 The console user interface provides the user with the option to control threads by commands prefixed with an exclamation
 mark (&quot;!&quot;). Those commands are listed below.
-
+<P/>
 For ease of use, users only need to type as many letters of each commands so that it can be unambiguously selected.
 Thus, the shell will recognize <C>!l</C> as an abbreviation for <C>!list</C>.
 
@@ -188,67 +188,92 @@ Calls the function with name <C>function</C>, passing it the single argument <C>
 
 There are several functions to access the basic functionality of the shell user interface. Other than <Ref
 Func="TextUIRegisterCommand"/>, they can only be called from within a registered command.
-
+<P/>
 Threads can be specified either by their numerical identifier or by their name (as a string). The empty string can be
 used to specify the current foreground thread.
 
-    <Subsection Label="TextUIRegisterCommand">
-      <Heading>TextUIRegisterCommand(name, func)</Heading>
+<ManSection>
+    <Func Name="TextUIRegisterCommand"
+      Arg='name, func'/>
 
+<Description>
 Registers the command <C>!name</C> with the shell UI. It will call &lt;func&gt; with the rest of the command line passed
 as a string argument when typed.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="TextUIForegroundThread">
-      <Heading>TextUIForegroundThread()</Heading>
+<ManSection>
+    <Func Name="TextUIForegroundThread"
+      Arg=''/>
 
+<Description>
 Returns the numerical identifier of the current foreground thread.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="TextUIForegroundThreadName">
-      <Heading>TextUIForegroundThreadName()</Heading>
+<ManSection>
+    <Func Name="TextUIForegroundThreadName"
+      Arg=''/>
 
-Returns the name of the current foreground thread or <C>fail</C> if the current foreground thread has no name.
+<Description>
+Returns the name of the current foreground thread or <K>fail</K> if the current foreground thread has no name.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="TextUISelectThread">
-      <Heading>TextUISelectThread(id)</Heading>
+<ManSection>
+    <Func Name="TextUISelectThread"
+      Arg='id'/>
 
-Makes <C>id</C> the current foreground thread. Returns <C>true</C> or <C>false</C> to indicate success.
+<Description>
+Makes <A>id</A> the current foreground thread. Returns <K>true</K> or <K>false</K> to indicate success.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="TextUIOutputHistory">
-      <Heading>TextUIOutputHistory(id, count)</Heading>
+<ManSection>
+    <Func Name="TextUIOutputHistory" Arg='id, count'/>
 
-Returns the last <C>count</C> lines of the thread specified by <C>id</C> (which can be a numerical identifier or a
-name). Returns <C>fail</C> if there is no such thread.
+<Description>
+Returns the last <A>count</A> lines of the thread specified by <A>id</A> (which can be a numerical identifier or a
+name). Returns <K>fail</K> if there is no such thread.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="TextUISetOutputHistoryLength">
-      <Heading>TextUISetOutputHistoryLength(length)</Heading>
+<ManSection>
+    <Func Name="TextUISetOutputHistoryLength"
+      Arg='length'/>
 
-By default, retain <C>length</C> lines of output history from each thread.
+<Description>
+By default, retain <A>length</A> lines of output history from each thread.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="TextUINewSession">
-      <Heading>TextUINewSession(foreground, name)</Heading>
+<ManSection>
+    <Func Name="TextUINewSession"
+      Arg='foreground, name'/>
 
-Creates a new shell thread. Here, <C>foreground</C> is a boolean variable specifying whether it should be made the new
-foreground thread and <C>name</C> is the name of the thread. The empty string can be used to leave the thread without a
+<Description>
+Creates a new shell thread. Here, <A>foreground</A> is a boolean variable specifying whether it should be made the new
+foreground thread and <A>name</A> is the name of the thread. The empty string can be used to leave the thread without a
 name.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="TextUIRunCommand">
-      <Heading>TextUIRunCommand(command)</Heading>
+<ManSection>
+    <Func Name="TextUIRunCommand"
+      Arg='command'/>
 
-Run the command denoted by <C>command</C> as though a user had typed it. The command must not contain a newline
+<Description>
+Run the command denoted by <A>command</A> as though a user had typed it. The command must not contain a newline
 character.
+</Description>
+</ManSection>
 
-    </Subsection>
-    <Subsection Label="TextUIWritePrompt">
-      <Heading>TextUIWritePrompt()</Heading>
+<ManSection>
+    <Func Name="TextUIWritePrompt" Arg=''/>
 
+<Description>
 Display a prompt for the current thread.
-    </Subsection>
+</Description>
+</ManSection>
   </Section>
 </Chapter>

--- a/doc/hpc/vars.xml
+++ b/doc/hpc/vars.xml
@@ -31,39 +31,49 @@ gap> x;
 As can be seen here, the assignment to <C>x</C> in a separate thread does not overwrite the value of <C>x</C> in the
 main thread.
 
-  </Section>
-  <Section Label="MakeThreadLocal">
-    <Heading>MakeThreadLocal(name)</Heading>
+<ManSection>
+    <Func Name="MakeThreadLocal"
+      Arg='name'/>
 
-<C>MakeThreadLocal</C> makes the variable described by the string <C>name</C> a thread-local variable. It normally does
+<Description>
+<Ref Func="MakeThreadLocal"/> makes the variable described by the string <A>name</A> a thread-local variable. It normally does
 not give it an initial value; either explicit per-thread assignment or a call to <Ref Func="BindThreadLocal"/> or <Ref
 Func="BindThreadLocalConstructor"/> to provide a default value is necessary.
-
+<P/>
 If a global variable with the same name exists and is bound at the time of the call, its value will be used as the
 default value as though <Ref Func="BindThreadLocal"/> had been called with that value as its second argument.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="BindThreadLocal">
-    <Heading>BindThreadLocal(name, obj)</Heading>
+<ManSection>
+    <Func Name="BindThreadLocal"
+      Arg='name, obj'/>
 
-<C>BindThreadLocal</C> gives the thread-local variable described by the string <C>name</C> the default value <C>obj</C>.
-The first time the thread-local variable is accessed in a thread thereafter, it will yield <C>obj</C> as its value if it
+<Description>
+<Ref Func="BindThreadLocal"/> gives the thread-local variable described by the string <A>name</A> the default value <A>obj</A>.
+The first time the thread-local variable is accessed in a thread thereafter, it will yield <A>obj</A> as its value if it
 hasn&#39;t been assigned a specific value yet.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="BindThreadLocalConstructor">
-    <Heading>BindThreadLocalConstructor(name, func)</Heading>
+<ManSection>
+    <Func Name="BindThreadLocalConstructor"
+      Arg='name, func'/>
 
-<C>BindThreadLocal</C> gives the thread-local variable described by the string <C>name</C> the constructor <C>func</C>.
-The first time the thread-local variable is accessed in a thread thereafter, it will yield <C>func()</C> as its value if
+<Description>
+<Ref Func="BindThreadLocal"/> gives the thread-local variable described by the string <A>name</A> the constructor <A>func</A>.
+The first time the thread-local variable is accessed in a thread thereafter, it will yield <A>func()</A> as its value if
 it hasn&#39;t been assigned a specific value yet.
+</Description>
+</ManSection>
 
-  </Section>
-  <Section Label="ThreadVar">
-    <Heading>ThreadVar</Heading>
+<ManSection>
+    <Var Name="ThreadVar"/>
 
-All thread-local variables are stored in the thread-local record <C>ThreadVar</C>. Thus, if <C>x</C> is a thread-local
+<Description>
+All thread-local variables are stored in the thread-local record <Ref Var="ThreadVar"/>. Thus, if <C>x</C> is a thread-local
 variable, using <C>ThreadVar.x</C> is the same as using <C>x</C>.
-
+</Description>
+</ManSection>
   </Section>
 </Chapter>


### PR DESCRIPTION
Convert many sections and subsections to proper ManSections and
assorted improvements of GAPDoc markup use. Fix issues with cross-
references. Resolves #1568. Resolves #1215.