### PR TITLE
Fixed documentation for MakeConstantGlobal and memory_allocated

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -424,13 +424,12 @@ should be treated as an estimate.
 
 <ManSection>
   <Var Name="time"/>
-  <Var Name="memory_allocated"/>
 
 <Description>
 In the read-eval-print loop,
 <Ref Var="time"/> stores the number of milliseconds the last command
-took. and <Ref Var="memory_allocated"/> stored the number of bytes of
-memory it allocated.
+took (see also <Ref Var="memory_allocated"/> for the number of bytes of
+memory it allocated).
 </Description>
 </ManSection>
 
@@ -457,15 +456,14 @@ in nanoseconds.
     in bytes allocated by the &GAP; memory manager since &GAP; started.
     </Description>
   </ManSection>
+  
   <ManSection>
-  <Var Name="memory_allocated"/>
-
-<Description>
-In the read-eval-print loop,
-<Ref Var="memory_allocated"/> stores the number of bytes of
-memoryallocated by the last completed statement.
-</Description>
-</ManSection>
+    <Var Name="memory_allocated"/>
+    <Description> In the read-eval-print loop, <Ref Var="memory_allocated"/>
+    stores the number of bytes of memory allocated by the last completed statement
+    (see also <Ref Var="time"/> for the number of milliseconds it took).
+  </Description>
+  </ManSection>
 
 </Section>
 

--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -643,6 +643,7 @@ false
 </Description>
 </ManSection>
 
+<#Include Label="MakeConstantGlobal">
 
 <ManSection>
 <Func Name="ValueGlobal" Arg='name'/>

--- a/lib/global.gd
+++ b/lib/global.gd
@@ -172,6 +172,7 @@ DeclareGlobalFunction("MakeReadWriteGlobal");
 ##
 #F  MakeConstantGlobal( <name> )   . . . . .  make a global variable constant
 ##
+##  <#GAPDoc Label="MakeConstantGlobal">
 ##  <ManSection>
 ##  <Func Name="MakeConstantGlobal" Arg='name'/>
 ##
@@ -185,6 +186,7 @@ DeclareGlobalFunction("MakeReadWriteGlobal");
 ##  A warning is given if <A>name</A> is already constant.
 ##  </Description>
 ##  </ManSection>
+##  <#/GAPDoc>
 ##
 DeclareGlobalFunction("MakeConstantGlobal");
 


### PR DESCRIPTION
This is a fix of the problem that triggered #1796. This PR links `MakeConstantGlobal` ManSection given as a comment in the source code, to the GAP reference manual. It also ensures that `memory_allocated` has only one ManSection, to avoid report about a duplicated label. Also fixed a typo.

