### PR TITLE
.gitignore: add doc/*/*.out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ doc/*/*.css
 doc/*/*.js
 doc/*/*.idx
 doc/*/*.tex
+/doc/*/*.out
 doc/gapmacrodoc.example-1.tst
 doc/gapmacrodoc.idx
 


### PR DESCRIPTION
Such files are generated by `make doc`