### PR TITLE
Fixed bug when exterior power is 0-dimensional

### DIFF
--- a/lib/algrep.gi
+++ b/lib/algrep.gi
@@ -2343,11 +2343,7 @@ InstallMethod( ExteriorPower,
 
     combs:= Combinations( [1..Dimension(V)], n );
     gens:= List( combs, x -> Basis(V){x} );
-    if gens = [ ]  then
-        gens[1] :=  ObjByExtRep( fam, [ [] , Zero(F) ] );
-    else
-        gens:= List( gens, x -> ObjByExtRep( fam, [ x , One(F) ] ) );
-    fi;
+    gens:= List( gens, x -> ObjByExtRep( fam, [ x , One(F) ] ) );
     
     for i in [1..Length(gens)] do
         gens[i]![2]:= true;
@@ -2357,7 +2353,11 @@ InstallMethod( ExteriorPower,
     
     # we know a basis of VT:
     
-    VT:= VectorSpace( F, gens );
+    if gens = [ ]  then
+        VT := VectorSpace( F, [ ObjByExtRep( fam, [] ) ] );
+    else
+        VT:= VectorSpace( F, gens );
+    fi;
     BT:= BasisOfMonomialSpace( VT, gens );
     BT!.echelonBasis:= gens;
     BT!.baseChange:= List( [ 1..Length(gens)], x -> [ [ x, One(F) ] ] );

--- a/tst/testbugfix/2017-11-08-ExteriorPower.tst
+++ b/tst/testbugfix/2017-11-08-ExteriorPower.tst
@@ -1,0 +1,6 @@
+# if ExteriorPower(V,n) is called with n > Dimension(V), the space returned is marked
+# as 1-dimensional rather than 0-dimensional.
+
+gap> wedge := ExteriorPower(Rationals^10,11);;
+gap> Dimension(wedge);
+0


### PR DESCRIPTION
There's a bug with ExteriorPower:
```
gap> wedge := ExteriorPower(Rationals^10,11);;
gap> Dimension(wedge);
1
```
when it should be 0.