### PR TITLE
Add #define USE_THREADSAFE_COPYING, disable old COPYING code in HPC-GAP

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -2258,16 +2258,18 @@ void MakeImmutableBlist( Obj blist )
 static StructBagNames BagNames[] = {
   { T_BLIST,                           "list (boolean)"                  },
   { T_BLIST       +IMMUTABLE,          "list (boolean,imm)"              },
-  { T_BLIST                  +COPYING, "list (boolean,copied)"           },
-  { T_BLIST       +IMMUTABLE +COPYING, "list (boolean,imm,copied)"       },
   { T_BLIST_NSORT,                     "list (boolean,nsort)"            },
   { T_BLIST_NSORT +IMMUTABLE,          "list (boolean,nsort,imm)"        },
-  { T_BLIST_NSORT            +COPYING, "list (boolean,nsort,copied)"     },
-  { T_BLIST_NSORT +IMMUTABLE +COPYING, "list (boolean,nsort,imm,copied)" },
   { T_BLIST_SSORT,                     "list (boolean,ssort)"            },
   { T_BLIST_SSORT +IMMUTABLE,          "list (boolean,ssort,imm)"        },
+#if !defined(USE_THREADSAFE_COPYING)
+  { T_BLIST                  +COPYING, "list (boolean,copied)"           },
+  { T_BLIST       +IMMUTABLE +COPYING, "list (boolean,imm,copied)"       },
+  { T_BLIST_NSORT            +COPYING, "list (boolean,nsort,copied)"     },
+  { T_BLIST_NSORT +IMMUTABLE +COPYING, "list (boolean,nsort,imm,copied)" },
   { T_BLIST_SSORT            +COPYING, "list (boolean,ssort,copied)"     },
   { T_BLIST_SSORT +IMMUTABLE +COPYING, "list (boolean,ssort,imm,copied)" },
+#endif
   { -1,                                ""                                }
 };
 
@@ -2463,8 +2465,10 @@ static Int InitKernel (
     for ( t1 = T_BLIST;  t1 <= T_BLIST_SSORT;  t1 += 2 ) {
         InitMarkFuncBags( t1                     , MarkNoSubBags  );
         InitMarkFuncBags( t1 +IMMUTABLE          , MarkNoSubBags  );
+#if !defined(USE_THREADSAFE_COPYING)
         InitMarkFuncBags( t1            +COPYING , MarkOneSubBags );
         InitMarkFuncBags( t1 +IMMUTABLE +COPYING , MarkOneSubBags );
+#endif
     }
 
     /* Make immutable blists public					   */

--- a/src/blister.c
+++ b/src/blister.c
@@ -277,6 +277,8 @@ Obj DoCopyBlist(Obj list, Int mut)
   
 }
 
+#if !defined(USE_THREADSAFE_COPYING)
+
 Obj CopyBlistImm(Obj list, Int mut)
 {
     GAP_ASSERT(!IS_MUTABLE_OBJ(list));
@@ -307,12 +309,16 @@ Obj CopyBlist (
     return copy;
 }
 
+#endif // !defined(USE_THREADSAFE_COPYING)
+
+
 Obj ShallowCopyBlist ( Obj list)
 {
   return DoCopyBlist(list, 1);
 }
 
 
+#if !defined(USE_THREADSAFE_COPYING)
 
 /****************************************************************************
 **
@@ -346,6 +352,8 @@ void CleanBlistCopy(Obj list)
     /* now it is cleaned */
     RetypeBag(list, TNUM_OBJ(list) - COPYING);
 }
+
+#endif // !defined(USE_THREADSAFE_COPYING)
 
 
 /****************************************************************************
@@ -2488,6 +2496,7 @@ static Int InitKernel (
 
     /* install the copy functions                                          */
     for ( t1 = T_BLIST; t1 <= T_BLIST_SSORT; t1 += 2 ) {
+#if !defined(USE_THREADSAFE_COPYING)
         CopyObjFuncs [ t1                     ] = CopyBlist;
         CopyObjFuncs [ t1 +IMMUTABLE          ] = CopyBlistImm;
         CopyObjFuncs [ t1            +COPYING ] = CopyBlistCopy;
@@ -2496,6 +2505,7 @@ static Int InitKernel (
         CleanObjFuncs[ t1 +IMMUTABLE          ] = CleanBlist;
         CleanObjFuncs[ t1            +COPYING ] = CleanBlistCopy;
         CleanObjFuncs[ t1 +IMMUTABLE +COPYING ] = CleanBlistCopy;
+#endif
         ShallowCopyObjFuncs[ t1               ] = ShallowCopyBlist;
         ShallowCopyObjFuncs[ t1 +IMMUTABLE    ] = ShallowCopyBlist;
     }

--- a/src/blister.h
+++ b/src/blister.h
@@ -44,8 +44,10 @@ static inline Int IS_BLIST_REP(Obj list)
 static inline Int IS_BLIST_REP_WITH_COPYING(Obj list)
 {
     UInt tnum = TNUM_OBJ(list);
+#if !defined(USE_THREADSAFE_COPYING)
     if (tnum > COPYING)
         tnum -= COPYING;
+#endif
     return T_BLIST <= tnum && tnum <= T_BLIST_SSORT + IMMUTABLE;
 }
 

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -1032,6 +1032,8 @@ Obj ShallowCopyARecord(Obj obj)
   return copy;
 }
 
+#if !defined(USE_THREADSAFE_COPYING)
+
 Obj CopyARecord(Obj obj, Int mutable)
 {
   return obj;
@@ -1049,6 +1051,9 @@ void CleanARecord(Obj obj)
 void CleanAList(Obj obj)
 {
 }
+
+#endif // !defined(USE_THREADSAFE_COPYING)
+
 
 static void UpdateThreadRecord(Obj record, Obj tlrecord)
 {
@@ -2021,8 +2026,10 @@ static Int InitKernel (
       ElmwListFuncs[type] = ElmAList;
       UnbListFuncs[type] = UnbAList;
       IsbListFuncs[type] = IsbAList;
+#if !defined(USE_THREADSAFE_COPYING)
       CopyObjFuncs[type] = CopyAList;
       CleanObjFuncs[type] = CleanAList;
+#endif
   }
 
   AssListFuncs[T_FIXALIST] = AssFixAList;
@@ -2034,13 +2041,17 @@ static Int InitKernel (
   ElmRecFuncs[ T_AREC ] = ElmARecord;
   IsbRecFuncs[ T_AREC ] = IsbARecord;
   AssRecFuncs[ T_AREC ] = AssARecord;
-  CopyObjFuncs[ T_AREC ] = CopyARecord;
   ShallowCopyObjFuncs[ T_AREC ] = ShallowCopyARecord;
+#if !defined(USE_THREADSAFE_COPYING)
+  CopyObjFuncs[ T_AREC ] = CopyARecord;
   CleanObjFuncs[ T_AREC ] = CleanARecord;
+#endif // !defined(USE_THREADSAFE_COPYING)
   IsRecFuncs[ T_AREC ] = AlwaysYes;
   UnbRecFuncs[ T_AREC ] = UnbARecord;
+#if !defined(USE_THREADSAFE_COPYING)
   CopyObjFuncs[ T_ACOMOBJ ] = CopyARecord;
   CleanObjFuncs[ T_ACOMOBJ ] = CleanARecord;
+#endif // !defined(USE_THREADSAFE_COPYING)
   IsRecFuncs[ T_ACOMOBJ ] = AlwaysNo;
   ElmRecFuncs[ T_TLREC ] = ElmTLRecord;
   IsbRecFuncs[ T_TLREC ] = IsbTLRecord;
@@ -2054,8 +2065,10 @@ static Int InitKernel (
   // Ensure that atomic objects cannot be copied
   for (UInt type = FIRST_ATOMIC_TNUM; type <= LAST_ATOMIC_TNUM; type++) {
       ShallowCopyObjFuncs[type] = AtomicErrorNoShallowCopy;
+#if !defined(USE_THREADSAFE_COPYING)
       CopyObjFuncs[type] = AtomicErrorNoCopy;
       // Do not error on CleanObj, just leave it as a no-op
+#endif // !defined(USE_THREADSAFE_COPYING)
   }
 
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -1898,8 +1898,10 @@ Obj FuncDEBUG_TNUM_NAMES(Obj self)
 #ifdef HPCGAP
         START_SYMBOLIC_TNUM(FIRST_SHARED_TNUM);
 #endif
+#if !defined(USE_THREADSAFE_COPYING)
         START_SYMBOLIC_TNUM(FIRST_COPYING_TNUM);
         START_SYMBOLIC_TNUM(FIRST_PACKAGE_TNUM + COPYING);
+#endif
         if (InfoBags[k].name != 0) {
             Pr("%3d: %s", k, (Int)indentStr);
             Pr("%s%s\n", (Int)indentStr, (Int)InfoBags[k].name);
@@ -1916,8 +1918,10 @@ Obj FuncDEBUG_TNUM_NAMES(Obj self)
         STOP_SYMBOLIC_TNUM(LAST_SHARED_TNUM);
 #endif
         STOP_SYMBOLIC_TNUM(LAST_REAL_TNUM);
+#if !defined(USE_THREADSAFE_COPYING)
         STOP_SYMBOLIC_TNUM(LAST_PACKAGE_TNUM + COPYING);
         STOP_SYMBOLIC_TNUM(LAST_COPYING_TNUM);
+#endif
     }
     return 0;
 }
@@ -2018,16 +2022,18 @@ static Int InitKernel (
     /* install the marking methods                                         */
     InfoBags[         T_COMOBJ          ].name = "object (component)";
     InitMarkFuncBags( T_COMOBJ          , MarkAllSubBags  );
-    InfoBags[         T_COMOBJ +COPYING ].name = "object (component,copied)";
-    InitMarkFuncBags( T_COMOBJ +COPYING , MarkAllSubBags  );
     InfoBags[         T_POSOBJ          ].name = "object (positional)";
     InitMarkFuncBags( T_POSOBJ          , MarkAllSubBags  );
-    InfoBags[         T_POSOBJ +COPYING ].name = "object (positional,copied)";
-    InitMarkFuncBags( T_POSOBJ +COPYING , MarkAllSubBags  );
     InfoBags[         T_DATOBJ          ].name = "object (data)";
     InitMarkFuncBags( T_DATOBJ          , MarkOneSubBags  );
+#if !defined(USE_THREADSAFE_COPYING)
+    InfoBags[         T_COMOBJ +COPYING ].name = "object (component,copied)";
+    InitMarkFuncBags( T_COMOBJ +COPYING , MarkAllSubBags  );
+    InfoBags[         T_POSOBJ +COPYING ].name = "object (positional,copied)";
+    InitMarkFuncBags( T_POSOBJ +COPYING , MarkAllSubBags  );
     InfoBags[         T_DATOBJ +COPYING ].name = "object (data,copied)";
     InitMarkFuncBags( T_DATOBJ +COPYING , MarkOneSubBags  );
+#endif
 
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ ) {
         assert(TypeObjFuncs[ t ] == 0);
@@ -2207,8 +2213,10 @@ static Int InitLibrary (
     ExportAsConstantGVar(LAST_SHARED_TNUM);
 #endif
 
+#if !defined(USE_THREADSAFE_COPYING)
     ExportAsConstantGVar(FIRST_COPYING_TNUM);
     ExportAsConstantGVar(LAST_COPYING_TNUM);
+#endif
 
     ExportAsConstantGVar(T_INT);
     ExportAsConstantGVar(T_INTPOS);

--- a/src/objects.c
+++ b/src/objects.c
@@ -44,7 +44,9 @@
 #include <src/hpc/aobjects.h>           /* atomic objects */
 #include <src/code.h>                   /* coder */
 #include <src/hpc/thread.h>             /* threads */
+#if defined(USE_THREADSAFE_COPYING)
 #include <src/hpc/traverse.h>           /* object traversal */
+#endif
 #include <src/hpc/guards.h>
 
 #include <src/gaputils.h>
@@ -376,7 +378,7 @@ Obj CopyObj (
     Obj                 obj,
     Int                 mut )
 {
-#ifdef HPCGAP
+#ifdef USE_THREADSAFE_COPYING
     return CopyReachableObjectsFrom(obj, 0, 0, !mut);
 #else
     Obj                 new;            /* copy of <obj>                   */
@@ -392,6 +394,8 @@ Obj CopyObj (
 #endif
 }
 
+
+#if !defined(USE_THREADSAFE_COPYING)
 
 /****************************************************************************
 **
@@ -754,6 +758,7 @@ void CleanObjDatObjCopy (
     RetypeBag( obj, TNUM_OBJ(obj) - COPYING );
 }
 
+#endif // !defined(USE_THREADSAFE_COPYING)
 
 /****************************************************************************
 **
@@ -2083,6 +2088,7 @@ static Int InitKernel (
         ShallowCopyObjFuncs[ t ] = ShallowCopyObjObject;
 
     /* make and install the 'COPY_OBJ' function                            */
+#if !defined(USE_THREADSAFE_COPYING)
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ ) {
         assert(CopyObjFuncs [ t ] == 0);
         CopyObjFuncs [ t ] = CopyObjError;
@@ -2105,6 +2111,7 @@ static Int InitKernel (
     CopyObjFuncs[  T_DATOBJ + COPYING ] = CopyObjDatObjCopy;
     CleanObjFuncs[ T_DATOBJ           ] = CleanObjDatObj;
     CleanObjFuncs[ T_DATOBJ + COPYING ] = CleanObjDatObjCopy;
+#endif
 
     /* make and install the 'PRINT_OBJ' operation                          */
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ ) {

--- a/src/objects.c
+++ b/src/objects.c
@@ -1902,10 +1902,9 @@ Obj FuncDEBUG_TNUM_NAMES(Obj self)
         START_SYMBOLIC_TNUM(FIRST_COPYING_TNUM);
         START_SYMBOLIC_TNUM(FIRST_PACKAGE_TNUM + COPYING);
 #endif
-        if (InfoBags[k].name != 0) {
-            Pr("%3d: %s", k, (Int)indentStr);
-            Pr("%s%s\n", (Int)indentStr, (Int)InfoBags[k].name);
-        }
+        const char *name = InfoBags[k].name;
+        Pr("%3d: %s", k, (Int)indentStr);
+        Pr("%s%s\n", (Int)indentStr, (Int)(name ? name : "."));
         STOP_SYMBOLIC_TNUM(LAST_CONSTANT_TNUM);
         STOP_SYMBOLIC_TNUM(LAST_RECORD_TNUM);
         STOP_SYMBOLIC_TNUM(LAST_PLIST_TNUM);

--- a/src/objects.h
+++ b/src/objects.h
@@ -268,15 +268,21 @@ enum TNUM {
 
     END_ENUM_RANGE(LAST_REAL_TNUM),
 
+#if !defined(USE_THREADSAFE_COPYING)
     // virtual TNUMs for copying objects
     START_ENUM_RANGE_EVEN(FIRST_COPYING_TNUM),
         COPYING             = FIRST_COPYING_TNUM - FIRST_IMM_MUT_TNUM,
         // we use LAST_EXTERNAL_TNUM+1 instead of LAST_REAL_TNUM to
         // skip over the shared TNUMs in HPC-GAP
     LAST_COPYING_TNUM       = LAST_EXTERNAL_TNUM + COPYING,
+#endif
 };
 
+#if defined(USE_THREADSAFE_COPYING)
+GAP_STATIC_ASSERT(LAST_REAL_TNUM <= 254, "LAST_REAL_TNUM is too large");
+#else
 GAP_STATIC_ASSERT(LAST_COPYING_TNUM <= 254, "LAST_COPYING_TNUM is too large");
+#endif
 
 /****************************************************************************
 **

--- a/src/objects.h
+++ b/src/objects.h
@@ -20,6 +20,11 @@
 #include <src/debug.h>
 #include <src/intobj.h>
 
+#ifdef HPCGAP
+#define USE_THREADSAFE_COPYING
+#endif
+
+
 /****************************************************************************
 **
 *T  Obj . . . . . . . . . . . . . . . . . . . . . . . . . . . type of objects
@@ -566,8 +571,10 @@ extern Obj CopyObj (
 **  Note that 'COPY_OBJ' and 'CLEAN_OBJ' are macros, so do not call them with
 **  arguments that have side effects.
 */
+#if !defined(USE_THREADSAFE_COPYING)
 #define COPY_OBJ(obj,mut) \
                         ((*CopyObjFuncs[ TNUM_OBJ(obj) ])( obj, mut ))
+#endif
 
 
 /****************************************************************************
@@ -580,9 +587,10 @@ extern Obj CopyObj (
 **  Note that 'COPY_OBJ' and 'CLEAN_OBJ' are macros, so do not call them with
 **  arguments that have side effects.
 */
+#if !defined(USE_THREADSAFE_COPYING)
 #define CLEAN_OBJ(obj) \
                         ((*CleanObjFuncs[ TNUM_OBJ(obj) ])( obj ))
-
+#endif
 
 
 /****************************************************************************
@@ -605,15 +613,18 @@ extern Obj CopyObj (
 **  then call 'CLEAN_OBJ'  for all subobjects recursively.  If called for an
 **  already unmarked object, it should simply return.
 */
+#if !defined(USE_THREADSAFE_COPYING)
 extern Obj (*CopyObjFuncs[LAST_REAL_TNUM+COPYING+1]) ( Obj obj, Int mut );
-
+#endif
 
 
 /****************************************************************************
 **
 *V  CleanObjFuncs[<type>] . . . . . . . . . . . . table of cleaning functions
 */
+#if !defined(USE_THREADSAFE_COPYING)
 extern void (*CleanObjFuncs[LAST_REAL_TNUM+COPYING+1]) ( Obj obj );
+#endif
 
 
 extern void (*MakeImmutableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );

--- a/src/objects.h
+++ b/src/objects.h
@@ -228,11 +228,20 @@ enum TNUM {
 #endif
 
         // package TNUMs, for use by kernel extensions
-        // note that LAST_COPYING_TNUM must not exceed 253, which restricts
-        // the value for LAST_PACKAGE_TNUM indirectly
+        //
+        // The largest TNUM (which, depending on USE_THREADSAFE_COPYING, is
+        // either LAST_REAL_TNUM or LAST_COPYING_TNUM) must not exceed 253.
+        // This restricts the value for LAST_PACKAGE_TNUM indirectly. It is
+        // difficult to describe the largest possible value with a formula, as
+        // LAST_COPYING_TNUM itself changes depending LAST_PACKAGE_TNUM, and
+        // the fact that some TNUMs are forced to be even causes additional
+        // jumps; so increasing LAST_PACKAGE_TNUM by 1 can lead to
+        // LAST_COPYING_TNUM growing by 2, 3 or even 4. So we simply hand-pick
+        // LAST_PACKAGE_TNUM as the largest value that does not trigger the
+        // GAP_STATIC_ASSERT following this enum.
         FIRST_PACKAGE_TNUM,
 #ifdef HPCGAP
-        LAST_PACKAGE_TNUM   = FIRST_PACKAGE_TNUM + 41,
+        LAST_PACKAGE_TNUM   = FIRST_PACKAGE_TNUM + 153,
 #else
         LAST_PACKAGE_TNUM   = FIRST_PACKAGE_TNUM + 50,
 #endif

--- a/src/plist.c
+++ b/src/plist.c
@@ -949,6 +949,8 @@ Obj FuncIS_PLIST_REP (
 }
 
 
+#if !defined(USE_THREADSAFE_COPYING)
+
 /****************************************************************************
 **
 *F  CopyPlist( <list>, <mut> )  . . . . . . . . . . . . . . copy a plain list
@@ -1056,6 +1058,9 @@ void CleanPlistCopy (
     }
 
 }
+
+
+#endif // !defined(USE_THREADSAFE_COPYING)
 
 
 /****************************************************************************
@@ -3790,7 +3795,7 @@ static Int InitKernel (
         ShallowCopyObjFuncs[ t1 +IMMUTABLE ] = ShallowCopyPlist;
     }
 
-
+#if !defined(USE_THREADSAFE_COPYING)
     /* install the copy list methods                                       */
     for ( t1 = T_PLIST; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
         CopyObjFuncs [ t1                     ] = CopyPlist;
@@ -3802,7 +3807,7 @@ static Int InitKernel (
         CleanObjFuncs[ t1            +COPYING ] = CleanPlistCopy;
         CleanObjFuncs[ t1 +IMMUTABLE +COPYING ] = CleanPlistCopy;
     }
-
+#endif
 
     /* install the comparison methods                                      */
     for ( t1 = T_PLIST; t1 <= LAST_PLIST_TNUM; t1++ ) {

--- a/src/plist.c
+++ b/src/plist.c
@@ -2791,103 +2791,143 @@ Obj FuncIsRectangularTablePlist( Obj self, Obj plist)
 static StructBagNames BagNames[] = {
   { T_PLIST,                                "list (plain)" },
   { T_PLIST            +IMMUTABLE,          "list (plain,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST                       +COPYING, "list (plain,copied)" },
   { T_PLIST            +IMMUTABLE +COPYING, "list (plain,imm,copied)" },
+#endif
 
   { T_PLIST_NDENSE,                         "list (plain,ndense)" },
   { T_PLIST_NDENSE     +IMMUTABLE,          "list (plain,ndense,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_NDENSE                +COPYING, "list (plain,ndense,copied)" },
   { T_PLIST_NDENSE     +IMMUTABLE +COPYING, "list (plain,ndense,imm,copied)" },
+#endif
 
   { T_PLIST_DENSE,                          "list (plain,dense)" },
   { T_PLIST_DENSE      +IMMUTABLE,          "list (plain,dense,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_DENSE                 +COPYING, "list (plain,dense,copied)" },
   { T_PLIST_DENSE      +IMMUTABLE +COPYING, "list (plain,dense,imm,copied)" },
+#endif
 
   { T_PLIST_DENSE_NHOM,                     "list (plain,dense,nhom)" },
   { T_PLIST_DENSE_NHOM +IMMUTABLE,          "list (plain,dense,nhom,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_DENSE_NHOM            +COPYING, "list (plain,dense,nhom,copied)" },
   { T_PLIST_DENSE_NHOM +IMMUTABLE +COPYING, "list (plain,dense,nhom,imm,copied)" },
+#endif
 
   { T_PLIST_DENSE_NHOM_SSORT,                     "list (plain,dense,nhom,ssort)" },
   { T_PLIST_DENSE_NHOM_SSORT +IMMUTABLE,          "list (plain,dense,nhom,ssort,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_DENSE_NHOM_SSORT            +COPYING, "list (plain,dense,nhom,ssort,copied)" },
   { T_PLIST_DENSE_NHOM_SSORT +IMMUTABLE +COPYING, "list (plain,dense,nhom,ssort,imm,copied)" },
+#endif
 
   { T_PLIST_DENSE_NHOM_NSORT,                     "list (plain,dense,nhom,nsort)" },
   { T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE,          "list (plain,dense,nhom,nsort,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_DENSE_NHOM_NSORT            +COPYING, "list (plain,dense,nhom,nsort,copied)" },
   { T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE +COPYING, "list (plain,dense,nhom,nsort,imm,copied)" },
+#endif
 
   { T_PLIST_EMPTY,                          "list (plain,empty)" },
   { T_PLIST_EMPTY      +IMMUTABLE,          "list (plain,empty,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_EMPTY                 +COPYING, "list (plain,empty,copied)" },
   { T_PLIST_EMPTY      +IMMUTABLE +COPYING, "list (plain,empty,imm,copied)" },
+#endif
 
   { T_PLIST_HOM,                            "list (plain,hom)" },
   { T_PLIST_HOM        +IMMUTABLE,          "list (plain,hom,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_HOM                   +COPYING, "list (plain,hom,copied)" },
   { T_PLIST_HOM        +IMMUTABLE +COPYING, "list (plain,hom,imm,copied)" },
+#endif
 
   { T_PLIST_HOM_NSORT,                      "list (plain,hom,nsort)" },
   { T_PLIST_HOM_NSORT  +IMMUTABLE,          "list (plain,hom,nsort,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_HOM_NSORT             +COPYING, "list (plain,hom,nsort,copied)" },
   { T_PLIST_HOM_NSORT  +IMMUTABLE +COPYING, "list (plain,hom,nsort,imm,copied)" },
+#endif
 
   { T_PLIST_HOM_SSORT,                      "list (plain,hom,ssort)" },
   { T_PLIST_HOM_SSORT +IMMUTABLE,           "list (plain,hom,ssort,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_HOM_SSORT            +COPYING,  "list (plain,hom,ssort,copied)" },
   { T_PLIST_HOM_SSORT +IMMUTABLE +COPYING,  "list (plain,hom,ssort,imm,copied)" },
+#endif
 
   { T_PLIST_TAB,                            "list (plain,table)" },
   { T_PLIST_TAB       +IMMUTABLE,           "list (plain,table,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_TAB                  +COPYING,  "list (plain,table,copied)" },
   { T_PLIST_TAB       +IMMUTABLE +COPYING,  "list (plain,table,imm,copied)" },
+#endif
 
   { T_PLIST_TAB_NSORT,                      "list (plain,table,nsort)" },
   { T_PLIST_TAB_NSORT +IMMUTABLE,           "list (plain,table,nsort,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_TAB_NSORT            +COPYING,  "list (plain,table,nsort,copied)" },
   { T_PLIST_TAB_NSORT +IMMUTABLE +COPYING,  "list (plain,table,nsort,imm,copied)" },
+#endif
 
   { T_PLIST_TAB_SSORT,                      "list (plain,table,ssort)" },
   { T_PLIST_TAB_SSORT +IMMUTABLE,           "list (plain,table,ssort,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_TAB_SSORT            +COPYING,  "list (plain,table,ssort,copied)" },
   { T_PLIST_TAB_SSORT +IMMUTABLE +COPYING,  "list (plain,table,ssort,imm,copied)" },
+#endif
 
   { T_PLIST_TAB_RECT,                            "list (plain,rect table)" },
   { T_PLIST_TAB_RECT       +IMMUTABLE,           "list (plain,rect table,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_TAB_RECT                  +COPYING,  "list (plain,rect table,copied)" },
   { T_PLIST_TAB_RECT       +IMMUTABLE +COPYING,  "list (plain,rect table,imm,copied)" },
+#endif
 
   { T_PLIST_TAB_RECT_NSORT,                      "list (plain,rect table,nsort)" },
   { T_PLIST_TAB_RECT_NSORT +IMMUTABLE,           "list (plain,rect table,nsort,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_TAB_RECT_NSORT            +COPYING,  "list (plain,rect table,nsort,copied)" },
   { T_PLIST_TAB_RECT_NSORT +IMMUTABLE +COPYING,  "list (plain,rect table,nsort,imm,copied)" },
+#endif
 
   { T_PLIST_TAB_RECT_SSORT,                      "list (plain,rect table,ssort)" },
   { T_PLIST_TAB_RECT_SSORT +IMMUTABLE,           "list (plain,rect table,ssort,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_TAB_RECT_SSORT            +COPYING,  "list (plain,rect table,ssort,copied)" },
   { T_PLIST_TAB_RECT_SSORT +IMMUTABLE +COPYING,  "list (plain,rect table,ssort,imm,copied)" },
+#endif
 
   { T_PLIST_CYC,                            "list (plain,cyc)" },
   { T_PLIST_CYC       +IMMUTABLE,           "list (plain,cyc,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_CYC                  +COPYING,  "list (plain,cyc,copied)" },
   { T_PLIST_CYC       +IMMUTABLE +COPYING,  "list (plain,cyc,imm,copied)" },
+#endif
 
   { T_PLIST_CYC_NSORT,                      "list (plain,cyc,nsort)" },
   { T_PLIST_CYC_NSORT +IMMUTABLE,           "list (plain,cyc,nsort,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_CYC_NSORT            +COPYING,  "list (plain,cyc,nsort,copied)" },
   { T_PLIST_CYC_NSORT +IMMUTABLE +COPYING,  "list (plain,cyc,nsort,imm,copied)" },
+#endif
 
   { T_PLIST_CYC_SSORT,                      "list (plain,cyc,ssort)" },
   { T_PLIST_CYC_SSORT +IMMUTABLE,           "list (plain,cyc,ssort,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_CYC_SSORT            +COPYING,  "list (plain,cyc,ssort,copied)" },
   { T_PLIST_CYC_SSORT +IMMUTABLE +COPYING,  "list (plain,cyc,ssort,imm,copied)" },
+#endif
 
   { T_PLIST_FFE,                     "list (sml fin fld elms)" },
   { T_PLIST_FFE +IMMUTABLE,          "list (sml fin fld elms,imm)" },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PLIST_FFE            +COPYING, "list (sml fin fld elms,copied)" },
   { T_PLIST_FFE +IMMUTABLE +COPYING, "list (sml fin fld elms,imm,copied)" },
+#endif
 
   { -1,                                     "" }
 };
@@ -3687,14 +3727,18 @@ static Int InitKernel (
     for ( t1 = T_PLIST;  t1 < T_PLIST_FFE ;  t1 += 2 ) {
         InitMarkFuncBags( t1                     , MarkAllSubBags );
         InitMarkFuncBags( t1 +IMMUTABLE          , MarkAllSubBags );
+#if !defined(USE_THREADSAFE_COPYING)
         InitMarkFuncBags( t1            +COPYING , MarkAllSubBags );
         InitMarkFuncBags( t1 +IMMUTABLE +COPYING , MarkAllSubBags );
+#endif
     }
 
     InitMarkFuncBags( T_PLIST_FFE                     , MarkNoSubBags );
     InitMarkFuncBags( T_PLIST_FFE +IMMUTABLE          , MarkNoSubBags );
+#if !defined(USE_THREADSAFE_COPYING)
     InitMarkFuncBags( T_PLIST_FFE            +COPYING , MarkNoSubBags );
     InitMarkFuncBags( T_PLIST_FFE +IMMUTABLE +COPYING , MarkNoSubBags );
+#endif
 
 #ifdef CHECK_NDENSE_BAGS
     InitSweepFuncBags( T_PLIST_NDENSE, SweepAndCheckNonDensePlist);

--- a/src/plist.h
+++ b/src/plist.h
@@ -68,8 +68,10 @@ static inline Int IS_PLIST(Obj list)
 static inline Int IS_PLIST_OR_POSOBJ(Obj list)
 {
     UInt tnum = TNUM_OBJ(list);
+#if !defined(USE_THREADSAFE_COPYING)
     if (tnum > COPYING)
         tnum -= COPYING;
+#endif
     return (FIRST_PLIST_TNUM <= tnum && tnum <= LAST_PLIST_TNUM) ||
            tnum == T_POSOBJ;
 }

--- a/src/precord.c
+++ b/src/precord.c
@@ -149,6 +149,9 @@ Int             GrowPRec (
     return 1L;
 }
 
+
+#if !defined(USE_THREADSAFE_COPYING)
+
 /****************************************************************************
 **
 *F  CopyPRec( <rec> ) . . . . . . . . . . . . . . . . . . copy a plain record
@@ -239,6 +242,9 @@ void CleanPRecCopy (
         CLEAN_OBJ( GET_ELM_PREC( rec, i ) );
     }
 }
+
+#endif //!defined(USE_THREADSAFE_COPYING)
+
 
 /****************************************************************************
 **
@@ -913,6 +919,7 @@ static Int InitKernel (
     IsCopyableObjFuncs[ T_PREC            ] = AlwaysYes;
     IsCopyableObjFuncs[ T_PREC +IMMUTABLE ] = AlwaysYes;
 
+#if !defined(USE_THREADSAFE_COPYING)
     /* install into copy function tables                                  */
     CopyObjFuncs [ T_PREC                     ] = CopyPRec;
     CopyObjFuncs [ T_PREC +IMMUTABLE          ] = CopyPRec;
@@ -922,6 +929,7 @@ static Int InitKernel (
     CleanObjFuncs[ T_PREC +IMMUTABLE          ] = CleanPRec;
     CleanObjFuncs[ T_PREC            +COPYING ] = CleanPRecCopy;
     CleanObjFuncs[ T_PREC +IMMUTABLE +COPYING ] = CleanPRecCopy;
+#endif // !defined(USE_THREADSAFE_COPYING)
 
     /* install printer                                                     */
     PrintObjFuncs[  T_PREC            ] = PrintPRec;

--- a/src/precord.c
+++ b/src/precord.c
@@ -855,8 +855,10 @@ void LoadPRec( Obj prec )
 static StructBagNames BagNames[] = {
   { T_PREC,                     "record (plain)"            },
   { T_PREC +IMMUTABLE,          "record (plain,imm)"        },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_PREC            +COPYING, "record (plain,copied)"     },
   { T_PREC +IMMUTABLE +COPYING, "record (plain,imm,copied)" },
+#endif
   { -1,                         ""                          }
 };
 
@@ -888,8 +890,10 @@ static Int InitKernel (
 
     InitMarkFuncBags( T_PREC                     , MarkAllSubBags );
     InitMarkFuncBags( T_PREC +IMMUTABLE          , MarkAllSubBags );
+#if !defined(USE_THREADSAFE_COPYING)
     InitMarkFuncBags( T_PREC            +COPYING , MarkAllSubBags );
     InitMarkFuncBags( T_PREC +IMMUTABLE +COPYING , MarkAllSubBags );
+#endif
 
     /* Immutable records are public                                        */
     MakeBagTypePublic( T_PREC +IMMUTABLE );

--- a/src/precord.h
+++ b/src/precord.h
@@ -61,8 +61,10 @@ static inline Int IS_PREC(Obj rec)
 static inline Int IS_PREC_OR_COMOBJ(Obj rec)
 {
     UInt tnum = TNUM_OBJ(rec);
+#if !defined(USE_THREADSAFE_COPYING)
     if (tnum > COPYING)
         tnum -= COPYING;
+#endif
     return tnum == T_PREC || tnum == T_PREC+IMMUTABLE || tnum == T_COMOBJ;
 }
 

--- a/src/range.c
+++ b/src/range.c
@@ -144,6 +144,8 @@ Obj TypeRangeSSortMutable (
     return TYPE_RANGE_SSORT_MUTABLE;
 }
     
+#if !defined(USE_THREADSAFE_COPYING)
+
 /****************************************************************************
 **
 *F  CopyRange( <list>, <mut> )  . . . . . . . . . . . . . . . .  copy a range
@@ -234,6 +236,8 @@ void CleanRangeCopy (
     /* now it is cleaned                                                   */
     RetypeBag( list, TNUM_OBJ(list) - COPYING );
 }
+
+#endif // !defined(USE_THREADSAFE_COPYING)
 
 
 /****************************************************************************
@@ -1334,6 +1338,7 @@ static Int InitKernel (
     LoadObjFuncs[T_RANGE_SSORT            ] = LoadRange;
     LoadObjFuncs[T_RANGE_SSORT +IMMUTABLE ] = LoadRange;
 
+#if !defined(USE_THREADSAFE_COPYING)
     /* install the copy methods                                            */
     CopyObjFuncs [ T_RANGE_NSORT                     ] = CopyRange;
     CopyObjFuncs [ T_RANGE_NSORT +IMMUTABLE          ] = CopyRange;
@@ -1351,6 +1356,7 @@ static Int InitKernel (
     CleanObjFuncs[ T_RANGE_SSORT +IMMUTABLE          ] = CleanRange;
     CleanObjFuncs[ T_RANGE_SSORT            +COPYING ] = CleanRangeCopy;
     CleanObjFuncs[ T_RANGE_SSORT +IMMUTABLE +COPYING ] = CleanRangeCopy;
+#endif
 
     /* Make immutable methods */
     MakeImmutableObjFuncs[ T_RANGE_NSORT ] = MakeImmutableRange;

--- a/src/range.c
+++ b/src/range.c
@@ -1142,10 +1142,12 @@ static StructBagNames BagNames[] = {
   { T_RANGE_NSORT +IMMUTABLE,          "list (range,nsort,imm)"        },
   { T_RANGE_SSORT,                     "list (range,ssort)"            },
   { T_RANGE_SSORT +IMMUTABLE,          "list (range,ssort,imm)"        },
+#if !defined(USE_THREADSAFE_COPYING)
   { T_RANGE_NSORT            +COPYING, "list (range,nsort,copied)"     },
   { T_RANGE_NSORT +IMMUTABLE +COPYING, "list (range,nsort,imm,copied)" },
   { T_RANGE_SSORT            +COPYING, "list (range,ssort,copied)"     },
   { T_RANGE_SSORT +IMMUTABLE +COPYING, "list (range,ssort,imm,copied)" },
+#endif
   { -1,                                ""                              }
 };
 
@@ -1297,10 +1299,12 @@ static Int InitKernel (
     InitMarkFuncBags(   T_RANGE_NSORT +IMMUTABLE          , MarkAllSubBags );
     InitMarkFuncBags(   T_RANGE_SSORT                     , MarkAllSubBags );
     InitMarkFuncBags(   T_RANGE_SSORT +IMMUTABLE          , MarkAllSubBags );
+#if !defined(USE_THREADSAFE_COPYING)
     InitMarkFuncBags(   T_RANGE_NSORT            +COPYING , MarkAllSubBags );
     InitMarkFuncBags(   T_RANGE_NSORT +IMMUTABLE +COPYING , MarkAllSubBags );
     InitMarkFuncBags(   T_RANGE_SSORT            +COPYING , MarkAllSubBags );
     InitMarkFuncBags(   T_RANGE_SSORT +IMMUTABLE +COPYING , MarkAllSubBags );
+#endif
 
     /* Make immutable bags public                                          */
     MakeBagTypePublic( T_RANGE_NSORT + IMMUTABLE );

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -2106,16 +2106,18 @@ static StructBagNames BagNames[] = {
   { T_CHAR,                           "character"                      },
   { T_STRING,                         "list (string)"                  },
   { T_STRING              +IMMUTABLE, "list (string,imm)"              },
-  { T_STRING      +COPYING,           "list (string,copied)"           },
-  { T_STRING      +COPYING+IMMUTABLE, "list (string,imm,copied)"       },
   { T_STRING_SSORT,                   "list (string,ssort)"            },
   { T_STRING_SSORT        +IMMUTABLE, "list (string,ssort,imm)"        },
-  { T_STRING_SSORT+COPYING,           "list (string,ssort,copied)"     },
-  { T_STRING_SSORT+COPYING+IMMUTABLE, "list (string,ssort,imm,copied)" },
   { T_STRING_NSORT,                   "list (string,nsort)"            },
   { T_STRING_NSORT        +IMMUTABLE, "list (string,nsort,imm)"        },
+#if !defined(USE_THREADSAFE_COPYING)
+  { T_STRING      +COPYING,           "list (string,copied)"           },
+  { T_STRING      +COPYING+IMMUTABLE, "list (string,imm,copied)"       },
+  { T_STRING_SSORT+COPYING,           "list (string,ssort,copied)"     },
+  { T_STRING_SSORT+COPYING+IMMUTABLE, "list (string,ssort,imm,copied)" },
   { T_STRING_NSORT+COPYING,           "list (string,nsort,copied)"     },
   { T_STRING_NSORT+COPYING+IMMUTABLE, "list (string,nsort,imm,copied)" },
+#endif
   { -1,                               ""                               }
 };
 
@@ -2331,8 +2333,10 @@ static Int InitKernel (
     for ( t1 = T_STRING; t1 <= T_STRING_SSORT; t1 += 2 ) {
         InitMarkFuncBags( t1                     , MarkNoSubBags );
         InitMarkFuncBags( t1          +IMMUTABLE , MarkNoSubBags );
+#if !defined(USE_THREADSAFE_COPYING)
         InitMarkFuncBags( t1 +COPYING            , MarkNoSubBags );
         InitMarkFuncBags( t1 +COPYING +IMMUTABLE , MarkNoSubBags );
+#endif
     }
     for ( t1 = T_STRING; t1 <= T_STRING_SSORT; t1 += 2 ) {
       MakeBagTypePublic( t1 + IMMUTABLE );

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -565,6 +565,8 @@ Obj TypeString (
 *F * * * * * * * * * * * * * * copy functions * * * * * * * * * * * * * * * *
 */
 
+#if !defined(USE_THREADSAFE_COPYING)
+
 /****************************************************************************
 **
 *F  CopyString( <list>, <mut> ) . . . . . . . . . . . . . . . . copy a string
@@ -655,6 +657,8 @@ void CleanStringCopy (
     /* now it is cleaned                                                   */
     RetypeBag( list, TNUM_OBJ(list) - COPYING );
 }
+
+#endif //!defined(USE_THREADSAFE_COPYING)
 
 
 /****************************************************************************
@@ -2386,6 +2390,7 @@ static Int InitKernel (
         LoadObjFuncs[ t1 +IMMUTABLE ] = LoadString;
     }
 
+#if !defined(USE_THREADSAFE_COPYING)
     /* install the copy method                                             */
     for ( t1 = T_STRING; t1 <= T_STRING_SSORT; t1 += 2 ) {
         CopyObjFuncs [ t1                     ] = CopyString;
@@ -2397,6 +2402,7 @@ static Int InitKernel (
         CleanObjFuncs[ t1 +COPYING            ] = CleanStringCopy;
         CleanObjFuncs[ t1 +COPYING +IMMUTABLE ] = CleanStringCopy;
     }
+#endif
 
     /* install the print method                                            */
     for ( t1 = T_STRING; t1 <= T_STRING_SSORT; t1 += 2 ) {

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -833,17 +833,23 @@ static Int InitKernel (
 {
     /* install the marking and sweeping methods                            */
     InfoBags[ T_WPOBJ          ].name = "object (weakptr)";
+#if !defined(USE_THREADSAFE_COPYING)
     InfoBags[ T_WPOBJ +COPYING ].name = "object (weakptr, copied)";
+#endif
 
 #ifdef BOEHM_GC
     /* force atomic allocation of these pointers */
     InitMarkFuncBags ( T_WPOBJ,          MarkNoSubBags   );
+  #if !defined(USE_THREADSAFE_COPYING)
     InitMarkFuncBags ( T_WPOBJ +COPYING, MarkNoSubBags   );
+  #endif
 #else
     InitMarkFuncBags ( T_WPOBJ,          MarkWeakPointerObj   );
     InitSweepFuncBags( T_WPOBJ,          SweepWeakPointerObj  );
+  #if !defined(USE_THREADSAFE_COPYING)
     InitMarkFuncBags ( T_WPOBJ +COPYING, MarkWeakPointerObj   );
     InitSweepFuncBags( T_WPOBJ +COPYING, SweepWeakPointerObj  );
+  #endif
   #ifdef HPCGAP
     InitFreeFuncBag( T_WPOBJ, FinalizeWeakPointerObj );
     InitFreeFuncBag( T_WPOBJ+COPYING, FinalizeWeakPointerObj );

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -569,6 +569,8 @@ static void SweepWeakPointerObj( Bag *src, Bag *dst, UInt len)
 #endif
 
 
+#if !defined(USE_THREADSAFE_COPYING)
+
 /****************************************************************************
 **
 *F  CopyObjWPObj( <obj>, <mut> ) . . . . . . . . .  copy a positional object
@@ -624,6 +626,9 @@ Obj CopyObjWPObj (
     return copy;
 }
 
+#endif // !defined(USE_THREADSAFE_COPYING)
+
+
 /****************************************************************************
 **
 *F  MakeImmutableWPObj( <obj> ) . . . . . . . . . . make immutable in place
@@ -664,6 +669,8 @@ void MakeImmutableWPObj( Obj obj )
   SET_PTR_BAG(obj, PTR_BAG(copy));
 #endif
 }
+
+#if !defined(USE_THREADSAFE_COPYING)
 
 /****************************************************************************
 **
@@ -712,6 +719,9 @@ void CleanObjWPObjCopy (
     }
 
 }
+
+#endif //!defined(USE_THREADSAFE_COPYING)
+
 
 /****************************************************************************
 **
@@ -855,11 +865,13 @@ static Int InitKernel (
     // List functions
     ElmDefListFuncs[T_WPOBJ] = ElmDefWPList;
 
+#if !defined(USE_THREADSAFE_COPYING)
     /* copying functions                                                   */
     CopyObjFuncs[  T_WPOBJ           ] = CopyObjWPObj;
     CopyObjFuncs[  T_WPOBJ + COPYING ] = CopyObjWPObjCopy;
     CleanObjFuncs[ T_WPOBJ           ] = CleanObjWPObj;
     CleanObjFuncs[ T_WPOBJ + COPYING ] = CleanObjWPObjCopy;
+#endif
 
     MakeImmutableObjFuncs[ T_WPOBJ ] = MakeImmutableWPObj;
     /* return success                                                      */


### PR DESCRIPTION
This PR mainly is helpful (for me, at least) when trying to understand the differences in object copying between GAP and HPC-GAP, by making it easier to grep for the relevant parts; it also isolates the code using `COPYING` from the rest.

As such, this is mainly refactoring work which is pointless in itself, but should hopefully enable future improvements.