### PR TITLE
split manual 76.2.1 into two subsections

### DIFF
--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -4,10 +4,10 @@
 <Index>package</Index>
 The  functionality  of  &GAP;  can  be  extended  by  loading  &GAP;
 packages. 
-&GAP; distribution already contains all currently redistributed with 
-&GAP; packages in the <F>&GAPDIRNAME;/pkg</F> directory.
+The &GAP; distribution contains, in the <F>&GAPDIRNAME;/pkg</F> 
+directory, all currently available &GAP; packages.
 <P/>
-&GAP; packages are written by (groups  of) &GAP; users which may not
+&GAP; packages are written by (groups  of) &GAP; users who may not
 be  members  of the  &GAP;  developer  team. The  responsibility  and
 copyright of a &GAP; package remains with the original author(s).
 <P/>
@@ -17,14 +17,14 @@ integrated into the &GAP; help system.
 All  &GAP;  users   who  develop  new  code  are   invited  to  share
 the  results  of their  efforts  with  other  &GAP; users  by  making
 the  code  and its  documentation  available  in  form of  a  package.
-Information how  to do  this is  available from  the &GAP; website
+Guidance on how  to do  this is  available from  the &GAP; website
 (<URL>https://www.gap-system.org</URL>)
 and in the &GAP; package <Package>Example</Package>
 (see <URL>https://www.gap-system.org/Packages/example.html</URL>).
 <P/>
-There  are  possibilities  to get  a  package  distributed together  with
-&GAP;  and it  is possible  to submit  a package  to a formal refereeing
-process.
+The &GAP; development team will assist in making any new package 
+suitable for distribution with &GAP;.   
+It is possible to submit a package to a formal refereeing process.
 <P/>
 In this chapter we first describe how to use existing packages,
 and then provide guidelines for writing a &GAP; package.
@@ -34,37 +34,41 @@ and then provide guidelines for writing a &GAP; package.
 <Section Label="Installing a GAP Package">
 <Heading>Installing a GAP Package</Heading>
 
-Before a  package can be  used it must  be installed. A standard installation
-of &GAP; already contains all &GAP; packages currently redistributed with 
-&GAP;. This set of packages is checked for compatibility
-with the system and other packages during release preparation. Most of
-the packages can be used immediately, but some of them may require further
-installation steps such as compilation or installing additional software
-to satisfy their dependencies. Most of the packages that require compilation
-can be compiled in a single step by changing to the <F>pkg</F> directory of
-your &GAP; installation and calling the <C>../bin/BuildPackages.sh</C> script.
+Before a  package can be  used it must  be installed. 
+A standard distribution of &GAP; already contains all the packages 
+currently available with &GAP;. 
+This set of packages has been checked for compatibility
+with the system and with each other during release preparation.  
+Most of the packages can be used immediately, but some of them may require further installation steps (see below). 
 <P/>
 Also, since &GAP; packages are released independently of the main &GAP; system,
-sometimes it may be useful to upgrade or install new packages between
+it may sometimes be useful to upgrade or install new packages between
 upgrades of your &GAP; installation, e.g. if a new version of a package adds
 new capabilities or bug fixes that you need.
 <P/>
 A package consists of a collection  of files within a single directory
 that must  be a subdirectory of  the <F>pkg</F>  directory   in one  of the
-&GAP; root directories, see <Ref Sect="GAP Root Directories"/>. (If you don't
-have access  to the <F>pkg</F>  directory in your main  &GAP; installation
-you can add private root directories as explained in that section.)
+&GAP; root directories (see <Ref Sect="GAP Root Directories"/>). 
+If you don't have access  to the <F>pkg</F>  directory in your main  &GAP; installation you can add private root directories as explained in that section. 
 <P/>
-Whenever  you  get from  somewhere  an  archive  of a  &GAP;  package
-it  should be  accompanied  with  a <F>README</F>  file  that explains  its
-installation.  Some packages  just  consist  of  &GAP;  code and  the
-installation  is  done  by  unpacking   the  archive  in  one  of  the
-places  described above.  There are  also packages  that need  further
-installation steps,  there may be  for example some  external programs
-which  have  to  be  compiled  (this is  often  done  by  just  saying
-<C>./configure; make</C>  inside the unpacked package  directory, but check
-the individual <F>README</F> files). Note that if you use Windows you may not 
-be able to use some or all external binaries.
+Whenever you download an  archive  of a  &GAP;  package, it will contain a 
+<F>README</F>  file  that explains how it should be installed.  
+Some packages just consist of &GAP; code and the installation is done by 
+unpacking the archive in one of the places described above.  
+There are  also packages  that need  further installation steps,  
+such as compilation or installing additional software
+to satisfy their dependencies. 
+If there are some  external programs which have to be compiled, 
+this is often done by executing <C>./configure; make</C> 
+inside the unpacked package directory 
+(but check the individual <F>README</F> files). 
+<P/> 
+Most of the packages that require compilation can be compiled 
+in a single step by changing to the <F>pkg</F> directory of your &GAP; 
+installation and calling the <C>../bin/BuildPackages.sh</C> script.
+<P/> 
+Note that if you use Windows you may not be able to use some or all 
+external binaries.
 </Section>
 
 
@@ -72,30 +76,24 @@ be able to use some or all external binaries.
 <Section Label="Loading a GAP Package">
 <Heading>Loading a GAP Package</Heading>
 
-<Index>automatic loading of GAP packages</Index>
-<Index>disable automatic loading</Index>
-If a package is not loaded, it may be loaded using 
+If a package is not already loaded, it may be loaded using 
 the function <Ref Func="LoadPackage"/>.
 <P/>
-Some &GAP; packages are loaded automatically with &GAP;. Those belong to
-two categories: packages which are needed to start &GAP; (as of this writing,
-the only such package is &GAPDoc;; their list is contained in 
-<C>GAPInfo.Dependencies.NeededOtherPackages</C>), and packages which are
-loaded during &GAP; startup by default. The latter list may be obtained by
-calling <C>UserPreference("PackagesToLoad")</C> and is customisable as
-described in Section <Ref BookName="ref" Sect="Configuring User preferences"/>.
-<P/>
-While &GAP; will not start if any of the packages from the former group is
-missing, loading of the packages from the latter group may be suppressed by
-using the <C>-A</C> command line option (see <Ref Sect="Command Line Options" />).
+Some &GAP; packages are prepared for automatic loading, 
+that is they will be loaded automatically when &GAP; starts 
+(see <Ref Subsect="LoadPackageAutomatic"/>).  
 
 <#Include Label="LoadPackage">
+
+<Index>automatic loading of GAP packages</Index>
+<Index>disable automatic loading</Index>
+<#Include Label="LoadPackageAutomatic">
+
 <#Include Label="SetPackagePath">
 <#Include Label="ExtendRootDirectories">
 <#Include Label="DisplayPackageLoadingLog">
 
 </Section>
-
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <Section Label="Functions for GAP Packages">

--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -4,15 +4,18 @@
 <Index>package</Index>
 The  functionality  of  &GAP;  can  be  extended  by  loading  &GAP;
 packages. 
-The &GAP; distribution contains, in the <F>&GAPDIRNAME;/pkg</F> 
-directory, all currently available &GAP; packages.
+The &GAP; distribution already contains all currently redistributed 
+&GAP; packages in the <F>&GAPDIRNAME;/pkg</F> directory.
 <P/>
-&GAP; packages are written by (groups  of) &GAP; users who may not
-be  members  of the  &GAP;  developer  team. The  responsibility  and
-copyright of a &GAP; package remains with the original author(s).
+&GAP; packages are written by (groups of) &GAP; users who may not
+necessarily be  members of the  &GAP; developer team. 
+The responsibility and copyright of a &GAP; package remains 
+with the original author(s).
 <P/>
 &GAP;  packages  have  their  own  documentation  which  is  smoothly
-integrated into the &GAP; help system.
+integrated into the &GAP; help system. 
+(When &GAP; is started, <C>LoadPackageDocumentation</C> is called 
+for all packages.) 
 <P/>
 All  &GAP;  users   who  develop  new  code  are   invited  to  share
 the  results  of their  efforts  with  other  &GAP; users  by  making
@@ -24,7 +27,7 @@ and in the &GAP; package <Package>Example</Package>
 <P/>
 The &GAP; development team will assist in making any new package 
 suitable for distribution with &GAP;.   
-It is possible to submit a package to a formal refereeing process.
+It is also possible to submit a package to a formal refereeing process.
 <P/>
 In this chapter we first describe how to use existing packages,
 and then provide guidelines for writing a &GAP; package.
@@ -36,7 +39,7 @@ and then provide guidelines for writing a &GAP; package.
 
 Before a  package can be  used it must  be installed. 
 A standard distribution of &GAP; already contains all the packages 
-currently available with &GAP;. 
+currently redistributed with &GAP;. 
 This set of packages has been checked for compatibility
 with the system and with each other during release preparation.  
 Most of the packages can be used immediately, but some of them may require further installation steps (see below). 
@@ -49,10 +52,12 @@ new capabilities or bug fixes that you need.
 A package consists of a collection  of files within a single directory
 that must  be a subdirectory of  the <F>pkg</F>  directory   in one  of the
 &GAP; root directories (see <Ref Sect="GAP Root Directories"/>). 
-If you don't have access  to the <F>pkg</F>  directory in your main  &GAP; installation you can add private root directories as explained in that section. 
+If you don't have access  to the <F>pkg</F>  directory in your main  &GAP; installation you can add private root directories as explained in section 
+<Ref Sect="GAP Root Directories"/>. 
 <P/>
-Whenever you download an  archive  of a  &GAP;  package, it will contain a 
-<F>README</F>  file  that explains how it should be installed.  
+Whenever you download or clone an archive of a &GAP; package, 
+it will contain a <F>README</F> file (or <F>README.md</F> etc.) 
+that explains how it should be installed.  
 Some packages just consist of &GAP; code and the installation is done by 
 unpacking the archive in one of the places described above.  
 There are  also packages  that need  further installation steps,  

--- a/lib/package.gd
+++ b/lib/package.gd
@@ -702,21 +702,24 @@ DeclareGlobalFunction( "LoadPackageDocumentation" );
 ##  true
 ##  ]]></Log>
 ##  <P/>
-##  The package name may be appropriately abbreviated. For example, at the time
-##  of writing, <C>LoadPackage("semi");</C> will load the 
-##  <Package>Semigroups</Package> package, and <C>LoadPackage("j");</C> will
-##  load the <Package>json</Package> package. If the abbreviation can not be
-##  uniquely completed, further suggestions will be offered.
+##  The package name is case insensitive and may be appropriately abbreviated. 
+##  At the time of writing, for example, <C>LoadPackage("semi");</C> 
+##  will load the <Package>Semigroups</Package> package, and 
+##  <C>LoadPackage("j");</C> will load the <Package>json</Package> package. 
+##  If the abbreviation cannot be uniquely completed, 
+##  a list of available completions will be offered, 
+##  and <Ref Func="LoadPackage"/> returns <K>fail</K>.
+##  Thus the names of <E>all</E> installed packages can be shown by calling
+##  <C>LoadPackage("");</C>.
 ##  <P/>
-##  If the optional version string <A>version</A> is given,
-##  the package will only be loaded in a version number at least as large as
-##  <A>version</A>,
-##  or equal to <A>version</A> if its first character is <C>=</C>
+##  When the optional argument string <A>version</A> is present,
+##  the package will only be loaded in a version number 
+##  equal to or greater than <A>version</A> 
 ##  (see&nbsp;<Ref Func="CompareVersionNumbers"/>).
-##  The argument <A>name</A> is case insensitive.
+##  If the first character is <C>=</C> then only that version will be loaded. 
 ##  <P/>
 ##  <Ref Func="LoadPackage"/> will return <K>true</K> if the package has been
-##  successfully loaded
+##  successfully loaded, 
 ##  and will return <K>fail</K> if the package could not be loaded.
 ##  The latter may be the case if the package is not installed, if necessary
 ##  binaries have not been compiled, or if the version number of the
@@ -724,48 +727,55 @@ DeclareGlobalFunction( "LoadPackageDocumentation" );
 ##  If the package cannot be loaded, <Ref Func="TestPackageAvailability"/>
 ##  can be used to find the reasons. Also,
 ##  <Ref Func="DisplayPackageLoadingLog"/> can be used to find out more
-##  about the failure reasons. To see the problems directly, one can
+##  about the failure. To see the problems directly, one can
 ##  change the verbosity using the user preference
 ##  <C>InfoPackageLoadingLevel</C>, see <Ref InfoClass="InfoPackageLoading"/>
 ##  for details.
 ##  <P/>
 ##  If the package <A>name</A> has already been loaded in a version number
-##  at least or equal to <A>version</A>, respectively,
-##  <Ref Func="LoadPackage"/> returns <K>true</K> without doing anything
-##  else.
-##  <P/>
-##  The argument <A>name</A> may be the prefix of a package name.
-##  If no package with name <A>name</A> is installed,
-##  the behaviour is as follows.
-##  If <A>name</A> is the prefix of exactly one name of an installed package
-##  then <Ref Func="LoadPackage"/> is called with this name;
-##  if the names of several installed packages start with <A>name</A> then
-##  the these names are printed, and <Ref Func="LoadPackage"/> returns
-##  <K>fail</K>.
-##  Thus the names of <E>all</E> installed packages can be shown by calling
-##  <Ref Func="LoadPackage"/> with an empty string.
+##  equal to or greater than <A>version</A>,  <Ref Func="LoadPackage"/> 
+##  returns <K>true</K> without doing anything else.
 ##  <P/>
 ##  If the optional argument <A>banner</A> is present then it must be either
 ##  <K>true</K> or <K>false</K>;
 ##  in the latter case, the effect is that no package banner is printed.
 ##  <P/>
-##  After a package has been loaded its code and documentation should be
-##  available as other parts of the &GAP; library are.
+##  After a package has been loaded, all its code and documentation becomes 
+##  available to use with the rest of the &GAP; library.
 ##  <P/>
-##  When &GAP; is started then some packages are loaded automatically.
-##  These are the packages listed in
-##  <C>GAPInfo.Dependencies.NeededOtherPackages</C> and
-##  (if this is not disabled, see below)
-##  <C>UserPreference( "PackagesToLoad" )</C>.
 ##  <P/>
-##  A &GAP; package may also install only its documentation automatically
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+DeclareGlobalFunction( "LoadPackage" );
+
+##  <#GAPDoc Label="LoadPackageAutomatic">
+##  <Subsection Label="LoadPackageAutomatic">
+##  <Heading>Automatic loading of &GAP; packages</Heading> 
+##  When &GAP; is started some packages are loaded automatically,  
+##  and these belong to two categories. 
+##  The first are those packages which are needed to start &GAP; 
+##  (at the present time, the only such package is &GAPDoc;).  
+##  Their list is contained in 
+##  <C>GAPInfo.Dependencies.NeededOtherPackages</C>. 
+##  The second are packages which are loaded during &GAP; startup by default. 
+##  The latter list may be obtained by calling 
+##  <C>UserPreference("PackagesToLoad")</C> and is customisable as described 
+##  in Section <Ref BookName="ref" Sect="Configuring User preferences"/>.
+##  <P/>
+##  While &GAP; will not start if any of the packages from the former group 
+##  is missing, loading of the packages from the latter group may be 
+##  suppressed by using the <C>-A</C> command line option 
+##  (see <Ref Sect="Command Line Options" />).
+##  <P/>
+##  A &GAP; package may also automatically install just its documentation, 
 ##  but still need loading by <Ref Func="LoadPackage"/>.
 ##  In this situation the online
 ##  help displays <C>(not loaded)</C> in the header lines of the manual
 ##  pages belonging to this &GAP; package.
 ##  <P/>
 ##  If for some reason you don't want certain packages to be automatically
-##  loaded, &GAP; provides three levels for disabling autoloading:
+##  loaded, &GAP; provides three levels for disabling autoloading. 
 ##  <P/>
 ##  <Index Key="NOAUTO"><C>NOAUTO</C></Index>
 ##  The autoloading of specific packages can be overwritten <E>for the whole
@@ -779,25 +789,23 @@ DeclareGlobalFunction( "LoadPackageDocumentation" );
 ##  for example in the user's <F>gap.ini</F> file
 ##  (see&nbsp;<Ref Subsect="subsect:gap.ini file"/>).
 ##  <P/>
-##  Using the <C>-A</C> command line option when starting up &GAP;
+##  Using the <C>-A</C> command line option when starting &GAP;
 ##  (see&nbsp;<Ref Sect="Command Line Options"/>),
 ##  automatic loading of packages is switched off
 ##  <E>for this &GAP; session</E>.
 ##  <P/>
 ##  In any of the above three cases, the packages listed in
 ##  <C>GAPInfo.Dependencies.NeededOtherPackages</C> are still loaded
-##  automatically, and an error is signalled if not all of these packages
-##  are available.
+##  automatically, and an error is signalled if any of these packages
+##  is unavailable.
 ##  <P/>
-##  See <Ref Func="SetPackagePath"/> for a possibility to force that a
-##  prescribed package version will be loaded.
-##  See also <Ref Func="ExtendRootDirectories"/> for a possibility to
-##  add directories containing packages after &GAP; has been started.
-##  </Description>
-##  </ManSection>
+##  See <Ref Func="SetPackagePath"/> for a way to force the loading of a
+##  prescribed package version.
+##  See also <Ref Func="ExtendRootDirectories"/> for a method of adding 
+##  directories containing packages <E>after</E> &GAP; has been started.
+##  </Subsection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "LoadPackage" );
 
 
 #############################################################################
@@ -825,6 +833,9 @@ DeclareGlobalFunction( "LoadAllPackages" );
 ##  <Func Name="SetPackagePath" Arg='pkgname, pkgpath'/>
 ##
 ##  <Description>
+##  This function can be used to force &GAP; to load a particular version of
+##  a package, even though newer versions of the package are available.
+##  <P/>
 ##  Let <A>pkgname</A> and <A>pkgpath</A> be strings denoting the name of a
 ##  &GAP; package and the path to a directory where a version of this package
 ##  can be found (i.&nbsp;e., calling <Ref Func="Directory"/> with the
@@ -840,9 +851,6 @@ DeclareGlobalFunction( "LoadAllPackages" );
 ##  contained in the <F>PackageInfo.g</F> file at <A>pkgpath</A> instead,
 ##  such that only the version installed at <A>pkgpath</A> can be loaded
 ##  with <Ref Func="LoadPackage"/>.
-##  <P/>
-##  This function can be used to force &GAP; to load a particular version of
-##  a package, although newer versions of the package might be available.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/package.gd
+++ b/lib/package.gd
@@ -716,7 +716,8 @@ DeclareGlobalFunction( "LoadPackageDocumentation" );
 ##  the package will only be loaded in a version number 
 ##  equal to or greater than <A>version</A> 
 ##  (see&nbsp;<Ref Func="CompareVersionNumbers"/>).
-##  If the first character is <C>=</C> then only that version will be loaded. 
+##  If the first character of <A>version</A> is <C>=</C> 
+##  then only that version will be loaded. 
 ##  <P/>
 ##  <Ref Func="LoadPackage"/> will return <K>true</K> if the package has been
 ##  successfully loaded, 
@@ -740,7 +741,7 @@ DeclareGlobalFunction( "LoadPackageDocumentation" );
 ##  <K>true</K> or <K>false</K>;
 ##  in the latter case, the effect is that no package banner is printed.
 ##  <P/>
-##  After a package has been loaded, all its code and documentation becomes 
+##  After a package has been loaded, all its code becomes 
 ##  available to use with the rest of the &GAP; library.
 ##  <P/>
 ##  <P/>
@@ -767,12 +768,6 @@ DeclareGlobalFunction( "LoadPackage" );
 ##  is missing, loading of the packages from the latter group may be 
 ##  suppressed by using the <C>-A</C> command line option 
 ##  (see <Ref Sect="Command Line Options" />).
-##  <P/>
-##  A &GAP; package may also automatically install just its documentation, 
-##  but still need loading by <Ref Func="LoadPackage"/>.
-##  In this situation the online
-##  help displays <C>(not loaded)</C> in the header lines of the manual
-##  pages belonging to this &GAP; package.
 ##  <P/>
 ##  If for some reason you don't want certain packages to be automatically
 ##  loaded, &GAP; provides three levels for disabling autoloading. 


### PR DESCRIPTION
This PR started out as a comment on #484 (adding guidelines for package authors from Example package).  It replaces the attempt which went badly wrong yesterday.  It makes changes to sections 76.1 and 76.2 of the reference manual: (a) splitting the LoadPackage section in two, with a separate subsection on automatic loading; (b) removes some duplication; (c) rephrases some passages.