### PR TITLE
Add Travis CI badge for gap-docker-master-testsuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/gap-system/gap.svg?branch=master)](https://travis-ci.org/gap-system/gap) [![Code Coverage](https://codecov.io/github/gap-system/gap/coverage.svg?branch=master&token=)](https://codecov.io/gh/gap-system/gap)
+[![Build Status](https://travis-ci.org/gap-system/gap.svg?branch=master)](https://travis-ci.org/gap-system/gap) [![Build Status](https://travis-ci.org/gap-system/gap-docker-master-testsuite.svg?branch=master)](https://travis-ci.org/gap-system/gap-docker-master-testsuite) [![Code Coverage](https://codecov.io/github/gap-system/gap/coverage.svg?branch=master&token=)](https://codecov.io/gh/gap-system/gap)
 
 # What is GAP?
 


### PR DESCRIPTION
This PR adds new Travis CI badge which points to the Travis build at https://travis-ci.org/gap-system/gap-docker-master-testsuite. 

This build allows everyone (not only to those who can access Jenkins instance in St Andrews) to see how tests from `testinstall`, `teststandard` and `testbugfix` directories behave in three scenarios: with no packages, with default packages, and with all packages loaded. 

This build is a Travis CI cron job, scheduled to run daily, and it uses the GAP Docker container for the master branch (https://hub.docker.com/r/gapsystem/gap-docker-master/), which is also built daily, with packages from the http://www.gap-system.org/pub/gap/gap4pkgs/packages-master.tar.gz archive, which is updated periodically when package updates pass some internal checks in Jenkins.

Adding this badge will allow others to see the current status of the test and easily find test logs.

At the moment, tests which are failing are those reported in #1849 and #1860.

