### PR TITLE
Start using bool,true,false from C99's stdbool.h

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -404,9 +404,7 @@ Int LenBlist (
 **
 **  'IsbBlist' is the function in 'IsbListFuncs' for boolean lists.
 */
-Int IsbBlist (
-    Obj                 list,
-    Int                 pos )
+BOOL IsbBlist(Obj list, Int pos)
 {
     return (pos <= LEN_BLIST(list));
 }
@@ -903,8 +901,7 @@ void PlainBlist (
 **  'IsPossBlist' returns  1 if  <list> is  empty, and 0 otherwise, since a
 **  boolean list is a positions list if and only if it is empty.
 */
-Int IsPossBlist (
-    Obj                 list )
+BOOL IsPossBlist(Obj list)
 {
     return LEN_BLIST(list) == 0;
 }
@@ -914,8 +911,7 @@ Int IsPossBlist (
 **
 *F  IsHomogBlist( <list> )  . . . . . . . . . . check if <list> is homogenous
 */
-Int IsHomogBlist (
-    Obj                 list )
+BOOL IsHomogBlist(Obj list)
 {
     return (0 < LEN_BLIST(list));
 }
@@ -925,8 +921,7 @@ Int IsHomogBlist (
 **
 *F  IsSSortBlist( <list> )  . . . . . . .  check if <list> is strictly sorted
 */
-Int IsSSortBlist (
-    Obj                 list )
+BOOL IsSSortBlist(Obj list)
 {
     Int                 isSort;
 
@@ -993,8 +988,7 @@ void ConvBlist (
 **  list that   has no holes  and contains  only  'true' and  'false',  and 0
 **  otherwise.
 */
-Int IsBlist (
-    Obj                 list )
+BOOL IsBlist(Obj list)
 {
     UInt                isBlist;        /* result of the test              */
     Int                 len;            /* logical length of the list      */
@@ -1041,8 +1035,7 @@ Int IsBlist (
 **  boolean lists into the compact representation of type 'T_BLIST' described
 **  above.
 */
-Int IsBlistConv (
-    Obj                 list )
+BOOL IsBlistConv(Obj list)
 {
     UInt                isBlist;        /* result of the test              */
     Int                 len;            /* logical length of the list      */

--- a/src/blister.h
+++ b/src/blister.h
@@ -27,7 +27,7 @@
 **
 *F  IS_BLIST_REP( <list> )  . . . . .  check if <list> is in boolean list rep
 */
-static inline Int IS_BLIST_REP(Obj list)
+static inline BOOL IS_BLIST_REP(Obj list)
 {
     return T_BLIST <= TNUM_OBJ(list) &&
            TNUM_OBJ(list) <= T_BLIST_SSORT + IMMUTABLE;
@@ -42,7 +42,7 @@ static inline Int IS_BLIST_REP(Obj list)
 **  a (little) slower.
 */
 
-static inline Int IS_BLIST_REP_WITH_COPYING(Obj list)
+static inline BOOL IS_BLIST_REP_WITH_COPYING(Obj list)
 {
     UInt tnum = TNUM_OBJ(list);
 #if !defined(USE_THREADSAFE_COPYING)

--- a/src/bool.c
+++ b/src/bool.c
@@ -86,19 +86,18 @@ Obj TypeBool (
 **
 **  'PrintBool' prints the boolean value <bool>.
 */
-void PrintBool (
-    Obj                 bool )
+void PrintBool(Obj val)
 {
-    if ( bool == True ) {
+    if (val == True) {
         Pr( "true", 0L, 0L );
     }
-    else if ( bool == False ) {
+    else if (val == False) {
         Pr( "false", 0L, 0L );
     }
-    else if ( bool == Fail ) {
+    else if (val == Fail) {
         Pr( "fail", 0L, 0L );
     }
-    else if ( bool == Undefined ) {
+    else if (val == Undefined) {
         Pr( "Undefined", 0L, 0L );
     }
     else {

--- a/src/calls.c
+++ b/src/calls.c
@@ -1916,7 +1916,7 @@ Obj FuncIsKernelFunction(Obj self, Obj func)
     return IsKernelFunction(func) ? True : False;
 }
 
-Int IsKernelFunction(Obj func)
+BOOL IsKernelFunction(Obj func)
 {
     GAP_ASSERT(IS_FUNC(func));
     return (BODY_FUNC(func) == 0) ||

--- a/src/calls.h
+++ b/src/calls.h
@@ -247,7 +247,7 @@ static inline void SET_LCKS_FUNC(Obj func, Obj locks)
 **  'IsKernelFunction' returns 1 if <func> is a kernel function (i.e.
 **  compiled from C code), and 0 otherwise.
 */
-extern Int IsKernelFunction(Obj func);
+extern BOOL IsKernelFunction(Obj func);
 
 
 #define HDLR_0ARGS(func)        ((ObjFunc_0ARGS)HDLR_FUNC(func,0))

--- a/src/gaputils.h
+++ b/src/gaputils.h
@@ -26,7 +26,14 @@
 #define ARRAY_SIZE(arr)     ( sizeof(arr) / sizeof((arr)[0]) )
 
 
-static inline Int AlwaysYes(Obj obj) { return 1; }
-static inline Int AlwaysNo(Obj obj) { return 0; }
+static inline BOOL AlwaysYes(Obj obj)
+{
+    return 1;
+}
+
+static inline BOOL AlwaysNo(Obj obj)
+{
+    return 0;
+}
 
 #endif // GAP_UTILS_H

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -843,8 +843,7 @@ Obj FuncMakeReadWriteGVar (
 **
 *F  IsReadOnlyGVar( <gvar> ) . . . . . . return status of a global variable
 */
-Int IsReadOnlyGVar (
-    UInt                gvar )
+BOOL IsReadOnlyGVar(UInt gvar)
 {
     return ELM_GVAR_LIST(WriteGVars, gvar) == INTOBJ_INT(0);
 }
@@ -875,7 +874,7 @@ static Obj FuncIsReadOnlyGVar (
 **
 *F  IsConstantGVar( <gvar> ) . . . . . . return if a variable is a constant
 */
-Int IsConstantGVar(UInt gvar)
+BOOL IsConstantGVar(UInt gvar)
 {
     return INT_INTOBJ(ELM_GVAR_LIST(WriteGVars, gvar)) == -1;
 }

--- a/src/gvars.h
+++ b/src/gvars.h
@@ -187,10 +187,9 @@ extern void MakeThreadLocalVar (
     UInt		rnam );
 #endif
 
-extern Int IsReadOnlyGVar (
-    UInt                gvar );
+extern BOOL IsReadOnlyGVar(UInt gvar);
 
-extern Int IsConstantGVar(UInt gvar);
+extern BOOL IsConstantGVar(UInt gvar);
 
 
 /****************************************************************************

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -944,7 +944,7 @@ void UnbARecord(Obj record, UInt rnam) {
    SetARecordField(record, rnam, Undefined);
 }
 
-Int IsbARecord(Obj record, UInt rnam)
+BOOL IsbARecord(Obj record, UInt rnam)
 {
   return GetARecordField(record, rnam) != (Obj) 0;
 }
@@ -1106,7 +1106,7 @@ void UnbTLRecord(Obj record, UInt rnam)
 }
 
 
-Int IsbTLRecord(Obj record, UInt rnam)
+BOOL IsbTLRecord(Obj record, UInt rnam)
 {
   return GetTLRecordField(record, rnam) != (Obj) 0;
 }
@@ -1335,7 +1335,8 @@ Obj ElmAList(Obj list, Int pos)
   }
 }
 
-Int IsbAList(Obj list, Int pos) {
+BOOL IsbAList(Obj list, Int pos)
+{
   AtomicObj *addr = ADDR_ATOM(list);
   UInt len;
   MEMBAR_READ();

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -250,7 +250,7 @@ static Obj DeserializeBinary(UInt tnum)
     return result;
 }
 
-static inline int IsBasicObj(Obj obj)
+static inline BOOL IsBasicObj(Obj obj)
 {
     // FIXME: hard coding T_MACFLOAT like this seems like a bad idea
     return !obj || TNUM_OBJ(obj) <= T_MACFLOAT;

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -1389,7 +1389,7 @@ Obj FuncCreateChannel(Obj self, Obj args)
     return CreateChannel(capacity);
 }
 
-static int IsChannel(Obj obj)
+static BOOL IsChannel(Obj obj)
 {
     return obj && TNUM_OBJ(obj) == T_CHANNEL;
 }
@@ -1497,7 +1497,7 @@ Obj FuncReceiveChannel(Obj self, Obj channel)
     return ReceiveChannel(ObjPtr(channel));
 }
 
-int IsChannelList(Obj list)
+BOOL IsChannelList(Obj list)
 {
     int len = LEN_PLIST(list);
     int i;
@@ -1718,7 +1718,7 @@ Obj FuncDestroyBarrier(Obj self, Obj barrier)
     return (Obj)0;
 }
 
-int IsBarrier(Obj obj)
+BOOL IsBarrier(Obj obj)
 {
     return obj && TNUM_OBJ(obj) == T_BARRIER;
 }
@@ -1803,7 +1803,7 @@ Obj SyncIsBound(SyncVar * var)
     return var->value ? True : False;
 }
 
-int IsSyncVar(Obj var)
+BOOL IsSyncVar(Obj var)
 {
     return var && TNUM_OBJ(var) == T_SYNCVAR;
 }

--- a/src/hpc/traverse.c
+++ b/src/hpc/traverse.c
@@ -392,21 +392,17 @@ void TraverseRegionFrom(TraversalState * traversal,
     SET_LEN_PLIST(traversal->list, traversal->listSize);
 }
 
-// static int IsReadable(Obj obj) {
-//   return CheckReadAccess(obj);
-// }
-
-static int IsSameRegion(Obj obj)
+static BOOL IsSameRegion(Obj obj)
 {
     return REGION(obj) == currentTraversal()->region;
 }
 
-static int IsMutable(Obj obj)
+static BOOL IsMutable(Obj obj)
 {
     return CheckReadAccess(obj) && IS_MUTABLE_OBJ(obj);
 }
 
-static int IsWritableOrImmutable(Obj obj)
+static BOOL IsWritableOrImmutable(Obj obj)
 {
     int writable = CheckExclusiveWriteAccess(obj);
     if (!writable && IS_MUTABLE_OBJ(obj)) {

--- a/src/integer.h
+++ b/src/integer.h
@@ -59,7 +59,7 @@ extern "C" {
 **  'IS_LARGEINT' returns 1 if 'obj' is large positive or negative integer
 **  object, and 0 for all other kinds of objects.
 */
-static inline Int IS_LARGEINT(Obj obj)
+static inline BOOL IS_LARGEINT(Obj obj)
 {
     UInt tnum = TNUM_OBJ(obj);
     return tnum == T_INTPOS || tnum == T_INTNEG;
@@ -71,7 +71,7 @@ static inline Int IS_LARGEINT(Obj obj)
 **  'IS_INT' returns 1 if 'obj' is either a large or an immediate integer
 **  object, and 0 for all other kinds of objects.
 */
-static inline Int IS_INT(Obj obj)
+static inline BOOL IS_INT(Obj obj)
 {
     return IS_INTOBJ(obj) || IS_LARGEINT(obj);
 }
@@ -111,7 +111,7 @@ static inline UInt SIZE_INT(Obj obj)
 **  IS_NEG_INT' returns 1 if 'obj' is a negative large or immediate
 **  integer object, and 0 for all other kinds of objects.
 */
-static inline Int IS_NEG_INT(Obj obj)
+static inline BOOL IS_NEG_INT(Obj obj)
 {
     if (IS_INTOBJ(obj))
         return (Int)obj < (Int)INTOBJ_INT(0);
@@ -123,7 +123,7 @@ static inline Int IS_NEG_INT(Obj obj)
 **  'IS_POS_INT' returns 1 if 'obj' is a positive large or immediate
 **  integer object, and 0 for all other kinds of objects.
 */
-static inline Int IS_POS_INT(Obj obj)
+static inline BOOL IS_POS_INT(Obj obj)
 {
     if (IS_INTOBJ(obj))
         return (Int)obj > (Int)INTOBJ_INT(0);
@@ -135,7 +135,7 @@ static inline Int IS_POS_INT(Obj obj)
 **  'IS_ODD_INT' returns 1 if 'obj' is an odd large or immediate integer
 **  object, and 0 for all other kinds of objects.
 */
-static inline Int IS_ODD_INT(Obj obj)
+static inline BOOL IS_ODD_INT(Obj obj)
 {
     if (IS_INTOBJ(obj))
         return ((Int)obj & 4) != 0;
@@ -148,7 +148,7 @@ static inline Int IS_ODD_INT(Obj obj)
 **  'IS_EVEN_INT' returns 1 if 'obj' is an even large or immediate integer
 **  object, and 0 for all other kinds of objects.
 */
-static inline Int IS_EVEN_INT(Obj obj)
+static inline BOOL IS_EVEN_INT(Obj obj)
 {
     return !IS_ODD_INT(obj);
 }

--- a/src/intobj.h
+++ b/src/intobj.h
@@ -48,7 +48,7 @@ a
 **  'IS_INTOBJ' returns 1 if the object <o> is an (immediate) integer object,
 **  and 0 otherwise.
 */
-static inline Int IS_INTOBJ(Obj o)
+static inline BOOL IS_INTOBJ(Obj o)
 {
     return (Int)o & 0x01;
 }
@@ -61,7 +61,7 @@ static inline Int IS_INTOBJ(Obj o)
 **  'IS_POS_INTOBJ' returns 1 if the object <o> is an (immediate) integer
 **  object encoding a positive integer, and 0 otherwise.
 */
-static inline Int IS_POS_INTOBJ(Obj o)
+static inline BOOL IS_POS_INTOBJ(Obj o)
 {
     return ((Int)o & 0x01) && ((Int)o > 0x01);
 }
@@ -73,7 +73,7 @@ static inline Int IS_POS_INTOBJ(Obj o)
 **  'IS_NONNEG_INTOBJ' returns 1 if the object <o> is an (immediate) integer
 **  object encoding a non-negative integer, and 0 otherwise.
 */
-static inline Int IS_NONNEG_INTOBJ(Obj o)
+static inline BOOL IS_NONNEG_INTOBJ(Obj o)
 {
     return ((Int)o & 0x01) && ((Int)o > 0);
 }

--- a/src/io.c
+++ b/src/io.c
@@ -60,7 +60,7 @@ static Char promptBuf[81];
 */
 
 
-static inline Int IS_CHAR_PUSHBACK_EMPTY(void)
+static inline BOOL IS_CHAR_PUSHBACK_EMPTY(void)
 {
     return STATE(In) != &STATE(Pushback);
 }

--- a/src/lists.c
+++ b/src/lists.c
@@ -54,7 +54,7 @@
 **
 #define IS_LIST(obj)    (*IsListFuncs[ TNUM_OBJ( (obj) ) ])( obj )
 */
-Int             (*IsListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
+BOOL (*IsListFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 Obj             IsListFilt;
 
@@ -65,8 +65,7 @@ Obj             FuncIS_LIST (
     return (IS_LIST( obj ) ? True : False);
 }
 
-Int             IsListObject (
-    Obj                 obj )
+BOOL IsListObject(Obj obj)
 {
     return (DoFilter( IsListFilt, obj ) == True);
 }
@@ -87,15 +86,14 @@ Int             IsListObject (
 ** 
 #define IS_SMALL_LIST(obj)    (*IsSmallListFuncs[ TNUM_OBJ( (obj) ) ])( obj )
 */
-Int             (*IsSmallListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
+BOOL (*IsSmallListFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 Obj             IsSmallListFilt;
 Obj             HasIsSmallListFilt;
 Obj             LengthAttr;
 Obj             SetIsSmallList;
 
-Int             IsSmallListObject (
-    Obj                 obj )
+BOOL IsSmallListObject(Obj obj)
 {
   Obj len;
   if (DoFilter(IsListFilt, obj) != True)
@@ -301,7 +299,7 @@ Obj LengthInternal (
 #define ISB_LIST(list,pos) \
                         ((*IsbListFuncs[TNUM_OBJ(list)])(list,pos))
 */
-Int             (*IsbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
+BOOL (*IsbListFuncs[LAST_REAL_TNUM + 1])(Obj list, Int pos);
 
 static Obj             IsbListOper;
 
@@ -316,9 +314,7 @@ Obj             FuncISB_LIST (
         return ISBB_LIST( list, pos ) ? True : False;
 }
 
-Int             IsbListError (
-    Obj                 list,
-    Int                 pos )
+BOOL IsbListError(Obj list, Int pos)
 {
     list = ErrorReturnObj(
         "IsBound: <list> must be a list (not a %s)",
@@ -327,21 +323,17 @@ Int             IsbListError (
     return ISB_LIST( list, pos );
 }
 
-Int             IsbListObject (
-    Obj                 list,
-    Int                 pos )
+BOOL IsbListObject(Obj list, Int pos)
 {
     return DoOperation2Args( IsbListOper, list, INTOBJ_INT(pos) ) == True;
 }
 
-Int             ISBB_LIST (
-    Obj                 list,
-    Obj                 pos )
+BOOL ISBB_LIST(Obj list, Obj pos)
 {
     return DoOperation2Args( IsbListOper, list, pos ) == True;
 }
 
-Int ISB2_LIST(Obj list, Obj pos1, Obj pos2)
+BOOL ISB2_LIST(Obj list, Obj pos1, Obj pos2)
 {
     return DoOperation3Args( IsbListOper, list, pos1, pos2 ) == True;
 }
@@ -1174,7 +1166,7 @@ Obj FuncASSS_LIST_DEFAULT (
 #define IS_DENSE_LIST(list) \
                         ((*IsDenseListFuncs[TNUM_OBJ(list)])(list))
 */
-Int             (*IsDenseListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+BOOL (*IsDenseListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
 Obj             IsDenseListFilt;
 
@@ -1185,8 +1177,7 @@ Obj             FuncIS_DENSE_LIST (
     return (IS_DENSE_LIST( obj ) ? True : False);
 }
 
-Int             IsDenseListDefault (
-    Obj                 list )
+BOOL IsDenseListDefault(Obj list)
 {
     Int                 lenList;        /* length of <list>                */
     Int                 i;              /* loop variable                   */
@@ -1210,8 +1201,7 @@ Int             IsDenseListDefault (
     return 1L;
 }
 
-Int             IsDenseListObject (
-    Obj                 obj )
+BOOL IsDenseListObject(Obj obj)
 {
     return (DoFilter( IsDenseListFilt, obj ) == True);
 }
@@ -1233,7 +1223,7 @@ Int             IsDenseListObject (
 #define IS_HOMOG_LIST(list) \
                         ((*IsHomogListFuncs[TNUM_OBJ(list)])(list))
 */
-Int             (*IsHomogListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+BOOL (*IsHomogListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
 Obj             IsHomogListFilt;
 
@@ -1244,8 +1234,7 @@ Obj             FuncIS_HOMOG_LIST (
     return (IS_HOMOG_LIST( obj ) ? True : False);
 }
 
-Int             IsHomogListDefault (
-    Obj                 list )
+BOOL IsHomogListDefault(Obj list)
 {
     Int                 lenList;        /* length of <list>                */
     Obj                 elm;            /* one element of <list>           */
@@ -1279,8 +1268,7 @@ Int             IsHomogListDefault (
     return 1L;
 }
 
-Int             IsHomogListObject (
-    Obj                 obj )
+BOOL IsHomogListObject(Obj obj)
 {
     return (DoFilter( IsHomogListFilt, obj ) == True);
 }
@@ -1302,7 +1290,7 @@ Int             IsHomogListObject (
 #define IS_TABLE_LIST(list) \
                         ((*IsTableListFuncs[TNUM_OBJ(list)])(list))
 */
-Int             (*IsTableListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+BOOL (*IsTableListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
 Obj             IsTableListFilt;
 
@@ -1313,8 +1301,7 @@ Obj             FuncIS_TABLE_LIST (
     return (IS_TABLE_LIST( obj ) ? True : False);
 }
 
-Int             IsTableListDefault (
-    Obj                 list )
+BOOL IsTableListDefault(Obj list)
 {
     Int                 lenList;        /* length of <list>                */
     Obj                 elm;            /* one element of <list>           */
@@ -1356,8 +1343,7 @@ Int             IsTableListDefault (
     return 1L;
 }
 
-Int             IsTableListObject (
-    Obj                 obj )
+BOOL IsTableListObject(Obj obj)
 {
     return (DoFilter( IsTableListFilt, obj ) == True);
 }
@@ -1379,7 +1365,7 @@ Int             IsTableListObject (
 #define IS_SSORTED_LIST(list) \
                         ((*IsSSortListFuncs[TNUM_OBJ(list)])(list))
 */
-Int (*IsSSortListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+BOOL (*IsSSortListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
 Obj IsSSortListProp;
 
@@ -1390,8 +1376,7 @@ Obj FuncIS_SSORT_LIST (
     return (IS_SSORT_LIST( obj ) ? True : False);
 }
 
-Int IsSSortListDefault (
-    Obj                 list )
+BOOL IsSSortListDefault(Obj list)
 {
     Int                 lenList;
     Obj                 elm1;
@@ -1427,8 +1412,7 @@ Int IsSSortListDefault (
     return 2L;
 }
 
-Int             IsSSortListObject (
-    Obj                 obj )
+BOOL IsSSortListObject(Obj obj)
 {
     return (DoProperty( IsSSortListProp, obj ) == True);
 }
@@ -1473,7 +1457,7 @@ Obj FuncIS_NSORT_LIST (
 #define IS_POSS_LIST(list) \
                         ((*IsPossListFuncs[TNUM_OBJ(list)])(list))
 */
-Int             (*IsPossListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+BOOL (*IsPossListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
 Obj             IsPossListProp;
 
@@ -1484,8 +1468,7 @@ Obj             FuncIS_POSS_LIST (
     return (IS_POSS_LIST(obj) ? True : False);
 }
 
-Int             IsPossListDefault (
-    Obj                 list )
+BOOL IsPossListDefault(Obj list)
 {
     Int                 lenList;        /* length of <list>                */
     Obj                 elm;            /* one element of <list>           */
@@ -1518,8 +1501,7 @@ Int             IsPossListDefault (
     return 1L;
 }
 
-Int             IsPossListObject (
-    Obj                 obj )
+BOOL IsPossListObject(Obj obj)
 {
     return (DoProperty( IsPossListProp, obj ) == True);
 }

--- a/src/lists.h
+++ b/src/lists.h
@@ -33,9 +33,9 @@
 **  vector type must set  it to '2'.  A  package implementing a matrix  type
 **  must set it to '3'.
 */
-extern  Int             (*IsListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
+extern BOOL (*IsListFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
-static inline Int IS_LIST(Obj obj)
+static inline BOOL IS_LIST(Obj obj)
 {
     return (*IsListFuncs[TNUM_OBJ(obj)])(obj);
 }
@@ -55,9 +55,9 @@ static inline Int IS_LIST(Obj obj)
 **  instead it will check if the object HasIsSmallList and IsSmallList, or
 **  HasLength in which case Length will be checked
 */
-extern Int (*IsSmallListFuncs[LAST_REAL_TNUM + 1])(Obj obj);
+extern BOOL (*IsSmallListFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
-static inline Int IS_SMALL_LIST(Obj obj)
+static inline BOOL IS_SMALL_LIST(Obj obj)
 {
     return (*IsSmallListFuncs[TNUM_OBJ(obj)])(obj);
 }
@@ -76,11 +76,11 @@ static inline Int IS_SMALL_LIST(Obj obj)
 **  already that the list is dense (e.g. for sets).
 */
 
-extern Int (*IsDenseListFuncs[LAST_REAL_TNUM + 1])(Obj list);
+extern BOOL (*IsDenseListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
-extern Int IsDenseListDefault(Obj list);
+extern BOOL IsDenseListDefault(Obj list);
 
-static inline Int IS_DENSE_LIST(Obj list)
+static inline BOOL IS_DENSE_LIST(Obj list)
 {
     return (*IsDenseListFuncs[TNUM_OBJ(list)])(list);
 }
@@ -101,11 +101,11 @@ static inline Int IS_DENSE_LIST(Obj list)
 **  homogeneous (e.g. for sets).
 */
 
-extern Int (*IsHomogListFuncs[LAST_REAL_TNUM + 1])(Obj list);
+extern BOOL (*IsHomogListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
-extern Int IsHomogListDefault(Obj list);
+extern BOOL IsHomogListDefault(Obj list);
 
-static inline Int IS_HOMOG_LIST(Obj list)
+static inline BOOL IS_HOMOG_LIST(Obj list)
 {
     return (*IsHomogListFuncs[TNUM_OBJ(list)])(list);
 }
@@ -127,11 +127,11 @@ static inline Int IS_HOMOG_LIST(Obj list)
 **  acceptable (e.g. a range with positive <low> and <high> values).
 */
 
-extern Int (*IsPossListFuncs[LAST_REAL_TNUM + 1])(Obj list);
+extern BOOL (*IsPossListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
-extern Int IsPossListDefault(Obj list);
+extern BOOL IsPossListDefault(Obj list);
 
-static inline Int IS_POSS_LIST(Obj list)
+static inline BOOL IS_POSS_LIST(Obj list)
 {
     return (*IsPossListFuncs[TNUM_OBJ(list)])(list);
 }
@@ -189,16 +189,16 @@ static inline Obj LENGTH(Obj list)
 **
 */
 
-extern  Int             (*IsbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
+extern BOOL (*IsbListFuncs[LAST_REAL_TNUM + 1])(Obj list, Int pos);
 
-static inline Int ISB_LIST(Obj list, Int pos)
+static inline BOOL ISB_LIST(Obj list, Int pos)
 {
     return (*IsbListFuncs[TNUM_OBJ(list)])(list, pos);
 }
 
-extern Int ISBB_LIST( Obj list, Obj pos );
+extern BOOL ISBB_LIST(Obj list, Obj pos);
 
-extern Int ISB2_LIST(Obj list, Obj pos1, Obj pos2);
+extern BOOL ISB2_LIST(Obj list, Obj pos1, Obj pos2);
 
 
 /****************************************************************************
@@ -587,12 +587,11 @@ extern void AssListObject (
 **  guarantees already that the list has this property.
 */
 
-extern  Int             (*IsTableListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+extern BOOL (*IsTableListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
-extern  Int             IsTableListDefault (
-            Obj                 list );
+extern BOOL IsTableListDefault(Obj list);
 
-static inline Int IS_TABLE_LIST(Obj list)
+static inline BOOL IS_TABLE_LIST(Obj list)
 {
     return (*IsTableListFuncs[TNUM_OBJ(list)])(list);
 }
@@ -612,12 +611,11 @@ static inline Int IS_TABLE_LIST(Obj list)
 **  of the list guarantees already that the list is strictly sorted.
 */
 
-extern  Int             (*IsSSortListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+extern BOOL (*IsSSortListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
-extern  Int             IsSSortListDefault (
-            Obj                 list );
+extern BOOL IsSSortListDefault(Obj list);
 
-static inline Int IS_SSORT_LIST(Obj list)
+static inline BOOL IS_SSORT_LIST(Obj list)
 {
     return (*IsSSortListFuncs[TNUM_OBJ(list)])(list);
 }

--- a/src/macfloat.h
+++ b/src/macfloat.h
@@ -43,7 +43,7 @@ static inline void SET_VAL_MACFLOAT(Obj obj, Double val)
     memcpy(ADDR_OBJ(obj), &val, sizeof(Double));
 }
 
-static inline  Int IS_MACFLOAT(Obj obj)
+static inline BOOL IS_MACFLOAT(Obj obj)
 {
     return TNUM_OBJ(obj) == T_MACFLOAT;
 }

--- a/src/objects.c
+++ b/src/objects.c
@@ -184,12 +184,11 @@ Obj FuncSET_TYPE_OBJ (
 **
 **  'IS_MUTABLE_OBJ' is defined in the declaration part of this package.
 */
-Int (*IsMutableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
+BOOL (*IsMutableObjFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 Obj IsMutableObjFilt;
 
-Int IsMutableObjError (
-    Obj                 obj )
+BOOL IsMutableObjError(Obj obj)
 {
     ErrorQuit(
         "Panic: tried to test mutability of unsupported type '%s'",
@@ -197,8 +196,7 @@ Int IsMutableObjError (
     return 0;
 }
 
-Int IsMutableObjObject (
-    Obj                 obj )
+BOOL IsMutableObjObject(Obj obj)
 {
 #ifdef HPCGAP
     if (RegionBag(obj) == ReadOnlyRegion)
@@ -237,7 +235,8 @@ Obj IsInternallyMutableObjHandler (
       DoFilter( IsInternallyMutableObjFilt, obj) == True) ? True : False;
 }
 
-Int IsInternallyMutableObj(Obj obj) {
+BOOL IsInternallyMutableObj(Obj obj)
+{
     return TNUM_OBJ(obj) == T_DATOBJ &&
       RegionBag(obj) != ReadOnlyRegion &&
       DoFilter( IsInternallyMutableObjFilt, obj) == True;
@@ -255,12 +254,11 @@ Int IsInternallyMutableObj(Obj obj) {
 **
 **  'IS_COPYABLE_OBJ' is defined in the declaration part of this package.
 */
-Int (*IsCopyableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
+BOOL (*IsCopyableObjFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 Obj IsCopyableObjFilt;
 
-Int IsCopyableObjError (
-    Obj                 obj )
+BOOL IsCopyableObjError(Obj obj)
 {
     ErrorQuit(
         "Panic: tried to test copyability of unsupported type '%s'",
@@ -268,8 +266,7 @@ Int IsCopyableObjError (
     return 0L;
 }
 
-Int IsCopyableObjObject (
-    Obj                 obj )
+BOOL IsCopyableObjObject(Obj obj)
 {
     return (DoFilter( IsCopyableObjFilt, obj ) == True);
 }
@@ -894,16 +891,16 @@ Obj FuncMakeImmutable( Obj self, Obj obj)
 
 // This function is used to keep track of which objects are already
 // being printed or viewed to trigger the use of ~ when needed.
-static inline UInt IS_ON_PRINT_STACK( Obj obj )
+static inline BOOL IS_ON_PRINT_STACK(Obj obj)
 {
   UInt i;
   if (!(FIRST_RECORD_TNUM <= TNUM_OBJ(obj)
         && TNUM_OBJ(obj) <= LAST_LIST_TNUM))
-    return 0;
+      return FALSE;
   for (i = 0; i < STATE(PrintObjDepth)-1; i++)
     if (MODULE_STATE(Objects).PrintObjThiss[i] == obj)
-      return 1;
-  return 0;
+        return TRUE;
+  return FALSE;
 }
 
 #ifdef HPCGAP

--- a/src/objects.h
+++ b/src/objects.h
@@ -45,7 +45,7 @@
 **  'IS_FFE'  returns 1  if the  object <o>  is  an  (immediate) finite field
 **  element and 0 otherwise.
 */
-static inline Int IS_FFE(Obj o)
+static inline BOOL IS_FFE(Obj o)
 {
     return (Int)o & 0x02;
 }
@@ -514,7 +514,7 @@ extern void CheckedMakeImmutable( Obj obj );
 #define IS_MUTABLE_OBJ(obj) \
                         ((*IsMutableObjFuncs[ TNUM_OBJ(obj) ])( obj ))
 
-extern Int (*IsMutableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
+extern BOOL (*IsMutableObjFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 /****************************************************************************
 **
@@ -527,7 +527,7 @@ extern Int (*IsMutableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 */
 
 #ifdef HPCGAP
-extern Int IsInternallyMutableObj(Obj obj);
+extern BOOL IsInternallyMutableObj(Obj obj);
 #endif
 
 /****************************************************************************
@@ -579,7 +579,7 @@ extern void LoadObjError( Obj obj );
 #define IS_COPYABLE_OBJ(obj) \
                         ((IsCopyableObjFuncs[ TNUM_OBJ(obj) ])( obj ))
 
-extern Int (*IsCopyableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
+extern BOOL (*IsCopyableObjFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 
 /****************************************************************************

--- a/src/plist.c
+++ b/src/plist.c
@@ -1165,16 +1165,12 @@ Int             LenPlistEmpty (
 **  and 0 otherwise.  It is the responsibility of the caller to  ensure  that
 **  <pos> is a positive integer.
 */
-Int             IsbPlist (
-    Obj                 list,
-    Int                 pos )
+BOOL IsbPlist(Obj list, Int pos)
 {
     return (pos <= LEN_PLIST( list ) && ELM_PLIST( list, pos ) != 0);
 }
 
-Int             IsbPlistDense (
-    Obj                 list,
-    Int                 pos )
+BOOL IsbPlistDense(Obj list, Int pos)
 {
     return (pos <= LEN_PLIST( list ));
 }
@@ -2122,8 +2118,7 @@ void            AsssPlistImm (
 **
 **  'IsDensePlist' is the function in 'IsDenseListFuncs' for plain lists.
 */
-Int             IsDensePlist (
-    Obj                 list )
+BOOL IsDensePlist(Obj list)
 {
     Int                 lenList;        /* length of <list>                */
     Int                 i;              /* loop variable                   */
@@ -2160,8 +2155,7 @@ Int             IsDensePlist (
 **
 **  'IsHomogPlist' is the function in 'IsHomogListFuncs' for plain lists.
 */
-Int             IsHomogPlist (
-    Obj                 list )
+BOOL IsHomogPlist(Obj list)
 {
     Int                 tnum;
     tnum = KTNumPlist( list, (Obj *)0 );
@@ -2178,8 +2172,7 @@ Int             IsHomogPlist (
 **
 **  'IsTablePlist' is the function in 'IsTableListFuncs' for plain lists.
 */
-Int             IsTablePlist (
-    Obj                 list )
+BOOL IsTablePlist(Obj list)
 {
     Int                 tnum;
     tnum = KTNumPlist( list, (Obj *)0 );
@@ -2197,8 +2190,7 @@ Int             IsTablePlist (
 **  'IsSSortPlist' is the function in 'IsSSortListFuncs' for plain lists.
 */
 
-Int             IsSSortPlist (
-    Obj                 list )
+BOOL IsSSortPlist(Obj list)
 {
     Int                 lenList;
     Obj elm1;
@@ -2285,8 +2277,7 @@ Int             IsSSortPlist (
     return 0L;
 }
 
-Int             IsSSortPlistDense (
-    Obj                 list )
+BOOL IsSSortPlistDense(Obj list)
 {
     Int                 lenList;
     Obj elm1;
@@ -2356,8 +2347,7 @@ Int             IsSSortPlistDense (
 
 }
 
-Int             IsSSortPlistHom (
-    Obj                 list )
+BOOL IsSSortPlistHom(Obj list)
 {
     Int                 lenList;
     Obj elm1;
@@ -2421,8 +2411,7 @@ Obj FuncSET_IS_SSORTED_PLIST(Obj self, Obj list)
 **
 **  'IsPossPlist' is the function in 'IsPossListFuncs' for plain lists.
 */
-Int             IsPossPlist (
-    Obj                 list )
+BOOL IsPossPlist(Obj list)
 {
     Int                 lenList;        /* length of <list>                */
     Obj                 elm;            /* one element of <list>           */

--- a/src/plist.h
+++ b/src/plist.h
@@ -47,7 +47,7 @@ static inline Obj NEW_PLIST(UInt type, Int plen)
 **
 *F  IS_PLIST( <list> )  . . . . . . . . . . . check if <list> is a plain list
 */
-static inline Int IS_PLIST(Obj list)
+static inline BOOL IS_PLIST(Obj list)
 {
     return FIRST_PLIST_TNUM <= TNUM_OBJ(list) &&
            TNUM_OBJ(list) <= LAST_PLIST_TNUM;
@@ -66,7 +66,7 @@ static inline Int IS_PLIST(Obj list)
 **  (which have the same memory layout as plists), as the plist APIs using it
 **  for assertion checks are in practice invoked on such objects, too.
 */
-static inline Int IS_PLIST_OR_POSOBJ(Obj list)
+static inline BOOL IS_PLIST_OR_POSOBJ(Obj list)
 {
     UInt tnum = TNUM_OBJ(list);
 #if !defined(USE_THREADSAFE_COPYING)
@@ -216,7 +216,7 @@ static inline Obj * BASE_PTR_PLIST(Obj list)
 ** whether they  are dense or not  (i.e. of type T_PLIST),  use IS_DENSE_LIST
 ** instead.
 */
-static inline Int IS_DENSE_PLIST(Obj list)
+static inline BOOL IS_DENSE_PLIST(Obj list)
 {
     return T_PLIST_DENSE <= TNUM_OBJ(list) &&
            TNUM_OBJ(list) <= LAST_PLIST_TNUM;
@@ -226,7 +226,7 @@ static inline Int IS_DENSE_PLIST(Obj list)
 **
 *F  IS_MUTABLE_PLIST( <list> )  . . . . . . . . . . . is a plain list mutable
 */
-static inline Int IS_MUTABLE_PLIST(Obj list)
+static inline BOOL IS_MUTABLE_PLIST(Obj list)
 {
     return !((TNUM_OBJ(list) - T_PLIST) % 2);
 }

--- a/src/pperm.h
+++ b/src/pperm.h
@@ -3,7 +3,7 @@
 
 #include <src/objects.h>
 
-static inline int IS_PPERM(Obj f)
+static inline BOOL IS_PPERM(Obj f)
 {
     return (TNUM_OBJ(f) == T_PPERM2 || TNUM_OBJ(f) == T_PPERM4);
 }

--- a/src/precord.c
+++ b/src/precord.c
@@ -320,9 +320,7 @@ UInt FindPRec( Obj rec, UInt rnam, UInt *pos, int cleanup )
 **  'IsbPRec' returns 1 if the record <rec> has a component with  the  record
 **  name <rnam>, and 0 otherwise.
 */
-Int IsbPRec (
-    Obj                 rec,
-    UInt                rnam )
+BOOL IsbPRec(Obj rec, UInt rnam)
 {
     UInt                i;              /* loop variable                   */
 

--- a/src/precord.h
+++ b/src/precord.h
@@ -36,7 +36,7 @@ extern Obj NEW_PREC(UInt len);
 **
 *F  IS_PREC( <rec> ) . . . . . . . . .  check if <rec> is in plain record rep
 */
-static inline Int IS_PREC(Obj rec)
+static inline BOOL IS_PREC(Obj rec)
 {
     UInt tnum = TNUM_OBJ(rec);
     return tnum == T_PREC || tnum == T_PREC+IMMUTABLE;
@@ -56,7 +56,7 @@ static inline Int IS_PREC(Obj rec)
 **  (which have the same memory layout as precs), as the precs APIs using it
 **  for assertion checks are in practice invoked on such objects, too.
 */
-static inline Int IS_PREC_OR_COMOBJ(Obj rec)
+static inline BOOL IS_PREC_OR_COMOBJ(Obj rec)
 {
     UInt tnum = TNUM_OBJ(rec);
 #if !defined(USE_THREADSAFE_COPYING)
@@ -205,9 +205,7 @@ extern  Obj             ElmPRec (
 **  'IsbPRec' returns 1 if the record <rec> has a component with  the  record
 **  name <rnam>, and 0 otherwise.
 */
-extern  Int             IsbPRec (
-            Obj                 rec,
-            UInt                rnam );
+extern BOOL IsbPRec(Obj rec, UInt rnam);
 
 
 /****************************************************************************

--- a/src/range.c
+++ b/src/range.c
@@ -318,9 +318,7 @@ Int             LenRange (
 **
 **  'IsbRange' is the function in 'IsbListFuncs' for ranges.
 */
-Int             IsbRange (
-    Obj                 list,
-    Int                 pos )
+BOOL IsbRange(Obj list, Int pos)
 {
     return (pos <= GET_LEN_RANGE(list));
 }
@@ -599,8 +597,7 @@ void            AsssRangeImm (
 **
 **  'IsPossRange' is the function in 'IsPossListFuncs' for ranges.
 */
-Int             IsPossRange (
-    Obj                 list )
+BOOL IsPossRange(Obj list)
 {
     /* test if the first element is positive                               */
     if ( GET_LOW_RANGE( list ) <= 0 )
@@ -739,8 +736,7 @@ void            PlainRange (
 */
 Obj IsRangeFilt;
 
-Int             IsRange (
-    Obj                 list )
+BOOL IsRange(Obj list)
 {
     Int                 isRange;        /* result of the test              */
     Int                 len;            /* logical length of list          */

--- a/src/range.h
+++ b/src/range.h
@@ -53,7 +53,7 @@ static inline Obj NEW_RANGE_SSORT(void)
 **  a range, but  the kernel does not know  this yet.  Use  'IsRange' to test
 **  whether a list is a range.
 */
-static inline Int IS_RANGE(Obj val)
+static inline BOOL IS_RANGE(Obj val)
 {
     return TNUM_OBJ(val) >= T_RANGE_NSORT &&
            TNUM_OBJ(val) <= T_RANGE_SSORT + IMMUTABLE;

--- a/src/records.c
+++ b/src/records.c
@@ -314,7 +314,7 @@ Obj             FuncNameRNam (
 **
 #define IS_REC(obj)     ((*IsRecFuncs[ TNUM_OBJ(obj) ])( obj ))
 */
-Int             (*IsRecFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
+BOOL (*IsRecFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 Obj             IsRecFilt;
 
@@ -325,8 +325,7 @@ Obj             IsRecHandler (
     return (IS_REC(obj) ? True : False);
 }
 
-Int             IsRecObject (
-    Obj                 obj )
+BOOL IsRecObject(Obj obj)
 {
     return (DoFilter( IsRecFilt, obj ) == True);
 }
@@ -401,7 +400,7 @@ Obj             ElmRecObject (
 #define ISB_REC(rec,rnam) \
                         ((*IsbRecFuncs[ TNUM_OBJ(rec) ])( rec, rnam ))
 */
-Int             (*IsbRecFuncs[LAST_REAL_TNUM+1]) ( Obj rec, UInt rnam );
+BOOL (*IsbRecFuncs[LAST_REAL_TNUM + 1])(Obj rec, UInt rnam);
 
 Obj             IsbRecOper;
 
@@ -413,9 +412,7 @@ Obj             IsbRecHandler (
     return (ISB_REC( rec, INT_INTOBJ(rnam) ) ? True : False);
 }
 
-Int             IsbRecError (
-    Obj                 rec,
-    UInt                rnam )
+BOOL IsbRecError(Obj rec, UInt rnam)
 {
     rec = ErrorReturnObj(
         "IsBound: <rec> must be a record (not a %s)",
@@ -424,9 +421,7 @@ Int             IsbRecError (
     return ISB_REC( rec, rnam );
 }
 
-Int             IsbRecObject (
-    Obj                 obj,
-    UInt                rnam )
+BOOL IsbRecObject(Obj obj, UInt rnam)
 {
     return (DoOperation2Args( IsbRecOper, obj, INTOBJ_INT(rnam) ) == True);
 }

--- a/src/records.h
+++ b/src/records.h
@@ -75,7 +75,7 @@ extern  UInt            RNamObj (
 */
 #define IS_REC(obj)     ((*IsRecFuncs[ TNUM_OBJ(obj) ])( obj ))
 
-extern  Int             (*IsRecFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
+extern BOOL (*IsRecFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 
 /****************************************************************************
@@ -109,7 +109,7 @@ extern  Obj             (*ElmRecFuncs[LAST_REAL_TNUM+1]) ( Obj rec, UInt rnam );
 #define ISB_REC(rec,rnam) \
                         ((*IsbRecFuncs[ TNUM_OBJ(rec) ])( rec, rnam ))
 
-extern  Int             (*IsbRecFuncs[LAST_REAL_TNUM+1]) ( Obj rec, UInt rnam );
+extern BOOL (*IsbRecFuncs[LAST_REAL_TNUM + 1])(Obj rec, UInt rnam);
 
 
 /****************************************************************************

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1095,7 +1095,7 @@ static const char * AllKeywords[] = {
     "IsBound", "Unbind",   "TryNextMethod", "Info",     "Assert",
 };
 
-int IsKeyword(const char * str)
+BOOL IsKeyword(const char * str)
 {
     for (UInt i = 0; i < ARRAY_SIZE(AllKeywords); i++) {
         if (strcmp(str, AllKeywords[i]) == 0) {

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -264,12 +264,12 @@ typedef UInt            TypSymbolSet;
 /* TL: extern  UInt            NrErrLine; */
 
 
-static inline int IsIdent(char c)
+static inline BOOL IsIdent(char c)
 {
     return IsAlpha(c) || c == '_' || c == '@';
 }
 
-extern int IsKeyword(const char * str);
+extern BOOL IsKeyword(const char * str);
 
 
 /****************************************************************************

--- a/src/set.c
+++ b/src/set.c
@@ -50,8 +50,7 @@
 ** 
 */
 
-Int IsSet ( 
-    Obj                 list )
+BOOL IsSet(Obj list)
 {
     Int                 isSet;          /* result                          */
 

--- a/src/set.h
+++ b/src/set.h
@@ -49,8 +49,7 @@ extern  Obj             SetList (
 **  to 'T_SET'.  If  it is not  then 'SetList' is  called to  make a copy  of
 **  'list', remove the holes, sort the copy, and remove the duplicates.
 */
-extern  Int             IsSet ( 
-            Obj                 list );
+extern BOOL IsSet(Obj list);
 
 
 /****************************************************************************

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -847,9 +847,7 @@ Int LenString (
 **
 **  'IsbString'  is the function in 'IsbListFuncs'  for strings.
 */
-Int IsbString (
-    Obj                 list,
-    Int                 pos )
+BOOL IsbString(Obj list, Int pos)
 {
     /* since strings are dense, this must only test for the length         */
     return (pos <= GET_LEN_STRING(list));
@@ -1148,8 +1146,7 @@ void AsssStringImm (
 **
 **  'IsHomogString' is the function in 'IsHomogListFuncs' for strings.
 */
-Int IsHomogString (
-    Obj                 list )
+BOOL IsHomogString(Obj list)
 {
     return (0 < GET_LEN_STRING(list));
 }
@@ -1164,8 +1161,7 @@ Int IsHomogString (
 **
 **  'IsSSortString' is the function in 'IsSSortListFuncs' for strings.
 */
-Int IsSSortString (
-    Obj                 list )
+BOOL IsSSortString(Obj list)
 {
     Int                 len;
     Int                 i;
@@ -1193,8 +1189,7 @@ Int IsSSortString (
 **
 **  'IsPossString' is the function in 'TabIsPossList' for strings.
 */
-Int IsPossString (
-    Obj                 list )
+BOOL IsPossString(Obj list)
 {
     return GET_LEN_STRING( list ) == 0;
 }
@@ -1294,12 +1289,11 @@ void PlainString (
 **  'IS_STRING' returns 1  if the object <obj>  is a string  and 0 otherwise.
 **  It does not change the representation of <obj>.
 */
-Int (*IsStringFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
+BOOL (*IsStringFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 Obj IsStringFilt;
 
-Int IsStringList (
-    Obj                 list )
+BOOL IsStringList(Obj list)
 {
     Int                 lenList;
     Obj                 elm;
@@ -1321,14 +1315,12 @@ Int IsStringList (
     return (lenList < i);
 }
 
-Int IsStringListHom (
-    Obj                 list )
+BOOL IsStringListHom(Obj list)
 {
     return (TNUM_OBJ( ELM_LIST(list,1) ) == T_CHAR);
 }
 
-Int IsStringObject (
-    Obj                 obj )
+BOOL IsStringObject(Obj obj)
 {
     return (DoFilter( IsStringFilt, obj ) != False);
 }
@@ -1420,8 +1412,7 @@ void ConvString (
 */
 Obj IsStringConvFilt;
 
-Int IsStringConv (
-    Obj                 obj )
+BOOL IsStringConv(Obj obj)
 {
     Int                 res;
 

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -76,7 +76,7 @@ static inline void SET_CHAR_VALUE(Obj charObj, UChar c)
 **
 *F  IS_STRING_REP( <list> ) . . . . . . . .  check if <list> is in string rep
 */
-static inline Int IS_STRING_REP(Obj list)
+static inline BOOL IS_STRING_REP(Obj list)
 {
     return (T_STRING <= TNUM_OBJ(list) &&
             TNUM_OBJ(list) <= T_STRING_SSORT + IMMUTABLE);
@@ -274,9 +274,9 @@ extern void PrintString1 (
 **  'IS_STRING' returns 1  if the object <obj>  is a string  and 0 otherwise.
 **  It does not change the representation of <obj>.
 */
-extern  Int             (*IsStringFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
+extern BOOL (*IsStringFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
-static inline Int IS_STRING(Obj obj)
+static inline BOOL IS_STRING(Obj obj)
 {
     return (*IsStringFuncs[TNUM_OBJ(obj)])(obj);
 }
@@ -289,8 +289,7 @@ static inline Int IS_STRING(Obj obj)
 **  'IsString' returns 1 if the object <obj> is a string and 0 otherwise.  It
 **  does not change the representation of <obj>.
 */
-extern Int IsString (
-            Obj                 obj );
+extern BOOL IsString(Obj obj);
 
 
 /****************************************************************************
@@ -322,8 +321,7 @@ extern void ConvString (
 **  otherwise.   If <obj> is a  string it  changes  its representation to the
 **  string representation.
 */
-extern Int IsStringConv (
-            Obj                 obj );
+extern BOOL IsStringConv(Obj obj);
 
 
 /****************************************************************************

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -81,7 +81,7 @@ typedef void sig_handler_t ( int );
 #endif
 
 #ifdef SYS_IS_DARWIN
-#include <mach-o/dyld.h>
+// #include <mach-o/dyld.h>
 #endif
 
 

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -81,7 +81,10 @@ typedef void sig_handler_t ( int );
 #endif
 
 #ifdef SYS_IS_DARWIN
-// #include <mach-o/dyld.h>
+// Workaround for the fact that TRUE / FALSE area also
+// defined by OS X mach-o headers
+#define ENUM_DYLD_BOOL
+#include <mach-o/dyld.h>
 #endif
 
 

--- a/src/system.h
+++ b/src/system.h
@@ -172,6 +172,9 @@ typedef Int4     Int;
 typedef UInt4    UInt;
 #endif
 
+typedef UChar BOOL;
+enum { FALSE = 0, TRUE = 1 };
+
 /****************************************************************************
 **
 **  'START_ENUM_RANGE' and 'END_ENUM_RANGE' simplify creating "ranges" of
@@ -848,17 +851,17 @@ enum {
     MODULE_DYNAMIC = GAP_KERNEL_API_VERSION * 10 + 2,
 };
 
-static inline Int IS_MODULE_BUILTIN(UInt type)
+static inline BOOL IS_MODULE_BUILTIN(UInt type)
 {
     return type % 10 == 0;
 }
 
-static inline Int IS_MODULE_STATIC(UInt type)
+static inline BOOL IS_MODULE_STATIC(UInt type)
 {
     return type % 10 == 1;
 }
 
-static inline Int IS_MODULE_DYNAMIC(UInt type)
+static inline BOOL IS_MODULE_DYNAMIC(UInt type)
 {
     return type % 10 == 2;
 }

--- a/src/trans.h
+++ b/src/trans.h
@@ -3,7 +3,7 @@
 
 #include <src/objects.h>
 
-static inline int IS_TRANS(Obj f)
+static inline BOOL IS_TRANS(Obj f)
 {
     return (TNUM_OBJ(f) == T_TRANS2 || TNUM_OBJ(f) == T_TRANS4);
 }

--- a/src/vars.h
+++ b/src/vars.h
@@ -69,7 +69,7 @@
 *F  IS_LVARS_OR_HVARS()
 **
 */
-static inline int IS_LVARS_OR_HVARS(Obj obj)
+static inline BOOL IS_LVARS_OR_HVARS(Obj obj)
 {
     UInt tnum = TNUM_OBJ(obj);
     return tnum == T_LVARS || tnum == T_HVARS;

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -1023,7 +1023,7 @@ Obj ZeroVecFFE( Obj vec )
     return res;
 }
 
-UInt IsVecFFE(Obj vec)
+BOOL IsVecFFE(Obj vec)
 {
     UInt tn;
     tn = TNUM_OBJ(vec);

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -315,7 +315,7 @@ Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 ** */
 
 
-Int IsBoundElmWPObj( Obj wp, Obj pos)
+BOOL IsBoundElmWPObj(Obj wp, Obj pos)
 {
   if (TNUM_OBJ(wp) != T_WPOBJ)
     {


### PR DESCRIPTION
I think it makes code more readable to explicitly use type `bool` and values `true`/`false` instead of generic `int` resp. `Int`, and `1`/`0` as return values. This PR is a first step towards this.

It can certainly wait till until GAP 4.9 has been branched. It should also wait till after superfail is removed, as that will conflict with this PR (in a trivial, easy to resolve way, so I am happy to do it here).

The main reason I am putting this out now is that I thought about this on multiple occasions (most recently when looking at `CHAR_PUSHBACK_EMPTY` in PR #1882), and I wanted to get it out here for discussion, to see what others think about that change.

If we merge it, there are tons of other places that could use `bool` (and which we could gradually and over time adapt to it). If we reject it, then I don't need to waste more time thinking about this possibility :-).