### PR TITLE
Some fp group tweaks

### DIFF
--- a/doc/ref/grpfp.xml
+++ b/doc/ref/grpfp.xml
@@ -24,9 +24,15 @@ accordingly.
 <P/>
 So to create a finitely presented group you first have to generate a free
 group (see&nbsp;<Ref Func="FreeGroup" Label="for given rank"/> for details).
-Then a list of relators is constructed as words in the generators of the
-free group and is factored out to obtain the finitely presented group.
-Its generators <E>are</E> the images of the free generators.
+
+There are two ways to specify a quotient of the free group: either by giving
+a list of relators or by giving a list of equations.
+
+Relators are just words in the generators of the free group. Equations are 
+represented as pairs of words in the generators of the free group. 
+
+In either case the generators of the quotient are <E>the images</E> of the free
+generators under the canonical homomorphism from the free group onto the quotient.
 So for example to create the group
 <Display Mode="M">
 \langle a, b \mid a^2, b^3, (a b)^5 \rangle
@@ -35,6 +41,8 @@ you can use the following commands:
 <Example><![CDATA[
 gap> f := FreeGroup( "a", "b" );;
 gap> g := f / [ f.1^2, f.2^3, (f.1*f.2)^5 ];
+<fp group on the generators [ a, b ]>
+gap> h := f / [ [f.1^2, f.1^0], [f.2^3, f.1^0], [(f.1*f.2)^4, f.2^-1*f.1^-1] ];
 <fp group on the generators [ a, b ]>
 ]]></Example>
 <P/>
@@ -119,16 +127,20 @@ See also <Ref Func="SetReducedMultiplication"/>.
 <ManSection>
 <Meth Name="\/" Arg="F, rels"
  Label="for a free group and a list of elements"/>
+<Meth Name="\/" Arg="F, eqns"
+ Label="for a free group and a list of pairs of elements"/>
 
 <Description>
 <Index Subkey="for finitely presented groups">quotient</Index>
 creates a finitely presented group given by the presentation
-<M>\langle gens \mid <A>rels</A> \rangle</M>
+<M>\langle gens \mid <A>rels</A> \rangle</M> or
+<M>\langle gens \mid <A>eqns</A> \rangle</M>, respectively
 where <M>gens</M> are the free generators of the free group <A>F</A>.
-Note that relations are entered as <E>relators</E>, i.e., as words in the
-generators of the free group.  To enter an equation use the quotient
-operator, i.e., for the relation <M>a^b = ab</M> one has to enter
-<M>a^b / (a b)</M>.
+Relations can be entered either as words or
+as pairs of words in the generators of <A>F</A>. In the former case
+we refer to the words given as <E>relators</E>, in the latter we
+refer to the pairs of words as <E>equations</E>.
+The two methods can currently not be mixed.
 <P/>
 The same result is obtained with the infix operator <C>/</C>,
 i.e., as <A>F</A> <C>/</C> <A>rels</A>.
@@ -136,6 +148,8 @@ i.e., as <A>F</A> <C>/</C> <A>rels</A>.
 <Example><![CDATA[
 gap> f := FreeGroup( 3 );;
 gap> f / [ f.1^4, f.2^3, f.3^5, f.1*f.2*f.3 ];
+<fp group on the generators [ f1, f2, f3 ]>
+gap> f / [ [ f.1^4, f.1^0 ], [ f.2^3, f.1^0 ], [ f.1, f.2^-1*f.3^-1 ] ];
 <fp group on the generators [ f1, f2, f3 ]>
 ]]></Example>
 </Description>

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -1582,6 +1582,26 @@ InstallOtherMethod( \/,
     0,
     FactorFreeGroupByRelators );
 
+InstallOtherMethod( \/,
+    "for fp groups and relators",
+    IsIdenticalObj,
+    [ IsFpGroup, IsCollection ],
+    0,
+    FactorGroupFpGroupByRels );
+
+InstallOtherMethod( \/,
+    "for free groups and a list of equations",
+    IsElmsColls,
+    [ IsFreeGroup, IsCollection ],
+    0,
+    {F, rels} -> FactorFreeGroupByRelators(F, List(rels, r -> r[1] / r[2]))); 
+
+InstallOtherMethod( \/,
+    "for fp groups and a list of equations",
+    IsElmsColls,
+    [ IsFpGroup, IsCollection ],
+    0,
+    {F, rels} -> FactorGroupFpGroupByRels(F, List(rels, r -> r[1] / r[2]))); 
 
 #############################################################################
 ##
@@ -1593,7 +1613,6 @@ InstallOtherMethod( \/,
     [ IsFreeGroup, IsEmpty ],
     0,
     FactorFreeGroupByRelators );
-
 
 #############################################################################
 ##

--- a/lib/semiquo.gi
+++ b/lib/semiquo.gi
@@ -51,10 +51,22 @@ function(cong)
     SetOne(Q, One(S)^QuotientSemigroupHomomorphism(Q));
   fi;
 
-  if HasGeneratorsOfSemigroup(S) then
-    Qgens:= List( GeneratorsOfSemigroup( S ),
-     s -> s^QuotientSemigroupHomomorphism(Q));
-    SetGeneratorsOfSemigroup( Q, Qgens );
+  # Set the semigroup generators of the quotient if possible.
+  #
+  # It is not sufficient to check HasGeneratorsOfSemigroup
+  # by itself, because groups for example only have
+  # GeneratorsOfMagmaWithInverses.
+  #
+  # The code below is safe, because GeneratorsOfSemigroup
+  # is synonymous with GeneratorsOfMagma, and there is a
+  # method for GeneratorsOfMagma, if we know
+  # GeneratorsOfMagmaWithInverses.
+  if HasGeneratorsOfMagma(S) or
+     HasGeneratorsOfMagmaWithInverses(S) or 
+     HasGeneratorsOfSemigroup(S) then
+      Qgens := List( GeneratorsOfSemigroup(S),
+                     s -> s^QuotientSemigroupHomomorphism(Q));
+      SetGeneratorsOfSemigroup( Q, Qgens );
   fi;
 
   return QuotientSemigroupHomomorphism(Q);

--- a/tst/testinstall/grpfree.tst
+++ b/tst/testinstall/grpfree.tst
@@ -58,6 +58,24 @@ gap> ForAll([0,1,2,3], n -> (n < 2) = IsSolvableGroup(DerivedSubgroup(FreeGroup(
 true
 
 #
+gap> F := FreeGroup(2);;
+gap> G := F / [ [ F.1^2, F.2^2 ] ];
+<fp group of size infinity on the generators [ f1, f2 ]>
+gap> H := G / [ G.1 ];
+<fp group on the generators [ f1, f2 ]>
+gap> rho := SemigroupCongruenceByGeneratingPairs(F, [[F.1, F.2]]);;
+gap> IsSemigroupCongruence(rho);
+true
+gap> Length(GeneratingPairsOfSemigroupCongruence(rho));
+1
+gap> G := F / rho;;
+gap> IsQuotientSemigroup(G);
+true
+gap> H / rho;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `FactorSemigroup' on 2 arguments
+
+#
 gap> STOP_TEST( "grpfree.tst", 1);
 
 #############################################################################


### PR DESCRIPTION
While addressing the immediate problem with #405, I stumbled across some more things that I added.

The immediate problem in #405 is that the quotient did not know it had `GeneratorsOfSemigroup`, so now the `RecursionDepthTrap` problem does not occur anymore (when taking the quotient of a group by a semigroup congruence). This was fixed by making the quotient aware of the presence of semigroup generators.

Using the code pasted in #405 now produces the following behaviour:

```
gap> f:=FreeGroup(2);;
gap> g := f / [[f.1^2, f.2^2]];
<fp group of size infinity on the generators [ f1, f2 ]>
```

This is because this PR installs a method to handle quotients of free groups by lists of equations, by delegating to quotients of free groups by relators, rewriting the equations `[u,v]` to the relators `uv^{-1}`.

Additionally this PR installs a method to take quotients of *finitely presented* groups by relators (and pairs of equations), as these were not previously installed.

Closes #405 .