### PR TITLE
Introduce ? syntax to access help, get rid of HELPSubs hack

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -89,7 +89,6 @@ typedef struct GAPState {
     TypOutputFile * IgnoreStdoutErrout;
     TypOutputFile   InputLogFileOrStream;
     TypOutputFile   OutputLogFileOrStream;
-    Int             HELPSubsOn;
     Int             NoSplitLine;
     Char            Pushback;
     Char *          RealIn;

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1183,6 +1183,45 @@ void            IntrQUIT ( void )
     STATE(IntrReturning) = STATUS_QQUIT;
 }
 
+/****************************************************************************
+ **
+ *F  IntrHelp()
+ **
+ **  'IntrHelp' is the action to interpret a help statement.
+ **
+ */
+void IntrHelp(Obj topic)
+{
+    UInt hgvar;
+    Obj  help;
+
+    if (STATE(IntrReturning) > 0) {
+        return;
+    }
+    if (STATE(IntrIgnoring) > 0) {
+        return;
+    }
+    if (STATE(IntrCoding) > 0) {
+        SyntaxError("'?' cannot be used in this context");
+        return;
+    }
+
+    /* FIXME: Hard coded function name */
+    hgvar = GVarName("HELP");
+    if (hgvar == 0) {
+        ErrorQuit( "Global function \"HELP\" is not declared. Cannot access help.",
+                   0L, 0L );
+    }
+    help = ValGVar(hgvar);
+    if (!help) {
+        ErrorQuit( "Global function \"HELP\" is not defined. Cannot access help.",
+                   0L, 0L );
+    }
+
+    CALL_1ARGS(help, topic);
+    PushVoidObj();
+}
+
 
 /****************************************************************************
 **

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -589,6 +589,8 @@ extern  void            IntrFalseExpr ( void );
 */
 extern  void            IntrTildeExpr ( void );
 
+extern void IntrHelp( Obj topic );
+
 /****************************************************************************
 **
 *F  IntrCharExpr(<chr>) . . . . . . .  interpret literal character expression

--- a/src/io.c
+++ b/src/io.c
@@ -1000,10 +1000,6 @@ static Int GetLine2 (
 */
 Char GetLine ( void )
 {
-    Char            buf[200];
-    Char *          p;
-    Char *          q;
-
     /* if file is '*stdin*' or '*errin*' print the prompt and flush it     */
     /* if the GAP function `PrintPromptHook' is defined then it is called  */
     /* for printing the prompt, see also `EndLineHook'                     */
@@ -1041,28 +1037,6 @@ Char GetLine ( void )
     /* try to read a line                                              */
     if ( ! GetLine2( STATE(Input), STATE(Input)->line, sizeof(STATE(Input)->line) ) ) {
         STATE(In)[0] = '\377';  STATE(In)[1] = '\0';
-    }
-
-
-    /* convert '?' at the beginning into 'HELP'
-       (if not inside reading long string which may have line
-       or chunk from GetLine starting with '?')                        */
-
-    if ( STATE(In)[0] == '?' && STATE(HELPSubsOn) == 1) {
-        strlcpy( buf, STATE(In)+1, sizeof(buf) );
-        strcpy( STATE(In), "HELP(\"" );
-        for ( p = STATE(In)+6,  q = buf;  *q;  q++ ) {
-            if ( *q != '"' && *q != '\n' ) {
-                *p++ = *q;
-            }
-            else if ( *q == '"' ) {
-                *p++ = '\\';
-                *p++ = *q;
-            }
-        }
-        *p = '\0';
-        /* FIXME: We should do bounds checking, but don't know what 'In' points to */
-        strcat( STATE(In), "\");\n" );
     }
 
     /* if necessary echo the line to the logfile                      */
@@ -1850,7 +1824,6 @@ static Int InitKernel (
 
 static void InitModuleState(ModuleStateOffset offset)
 {
-    STATE(HELPSubsOn) = 1;
 }
 
 /****************************************************************************

--- a/src/read.c
+++ b/src/read.c
@@ -2516,6 +2516,13 @@ void ReadTryNext (
     }
 }
 
+void ReadHelp(TypSymbolSet follow)
+{
+    Obj topic;
+
+    C_NEW_STRING(topic, STATE(ValueLen), (void *)STATE(Value));
+    TRY_READ { IntrHelp(topic); };
+}
 
 /****************************************************************************
 **
@@ -2603,6 +2610,7 @@ UInt ReadStats (
         else if ( STATE(Symbol) == S_TRYNEXT) ReadTryNext(   follow    );
         else if ( STATE(Symbol) == S_QUIT   ) ReadQuit(      follow    );
         else if ( STATE(Symbol) == S_ATOMIC ) ReadAtomic(    follow    );
+        else if ( STATE(Symbol) == S_HELP   ) ReadHelp(      follow    );
         else                           ReadEmpty(     follow    );
         nr++;
         MatchSemicolon(follow);
@@ -2652,7 +2660,6 @@ void RecreateStackNams( Obj context )
         SET_ELM_PLIST(STATE(StackNams), j, tmpA);
     }
 }
-
 
 ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
 {
@@ -2727,13 +2734,13 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     else if (STATE(Symbol)==S_QQUIT     ) { ReadQUIT(    S_SEMICOLON|S_EOF      ); }
     else if (STATE(Symbol)==S_SEMICOLON ) { ReadEmpty(   S_SEMICOLON|S_EOF      ); }
     else if (STATE(Symbol)==S_ATOMIC    ) { ReadAtomic(  S_SEMICOLON|S_EOF      ); }
-
+    else if (STATE(Symbol)==S_HELP      ) { ReadHelp(    S_SEMICOLON|S_EOF      ); }
     /* otherwise try to read an expression                                 */
     /* Unless the statement is empty, in which case do nothing             */
     else                           { ReadExpr(    S_SEMICOLON|S_EOF, 'r' ); }
 
     /* every statement must be terminated by a semicolon                  */
-    if (!IS_IN(STATE(Symbol), S_SEMICOLON)) {
+    if (!IS_IN(STATE(Symbol), S_SEMICOLON) && STATE(Symbol) != S_HELP) {
         SyntaxError( "; expected");
     }
 

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -81,6 +81,7 @@ enum SCANNER_SYMBOLS {
     S_PARTIALSTRING     = (1UL<<11)+4,
     S_PARTIALTRIPSTRING = (1UL<<11)+5,
     S_TILDE             = (1UL<<11)+6,
+    S_HELP              = (1UL<<11)+7,
 
     S_REC               = (1UL<<12)+0,
     S_BACKQUOTE         = (1UL<<12)+1,
@@ -205,7 +206,7 @@ typedef UInt            TypSymbolSet;
                     |S_PLUS|S_MINUS|S_NOT|S_LPAREN)
 
 #define STATBEGIN  (S_IDENT|S_UNBIND|S_IF|S_FOR|S_WHILE|S_REPEAT \
-                    |S_BREAK|S_RETURN|S_QUIT)
+                    |S_BREAK|S_RETURN|S_HELP|S_QUIT)
 
 
 /****************************************************************************

--- a/tst/testinstall/help.tst
+++ b/tst/testinstall/help.tst
@@ -1,0 +1,9 @@
+# Test help
+
+gap> f := function()
+> ?help
+Syntax error: '?' cannot be used in this context in stream:2
+?help
+    ^
+Syntax error: end expected in stream:3
+^


### PR DESCRIPTION
 * We introduce a symbol S_HELP which is parsed starting from a
   '?' and ends at the end of a line.
 * Remove the inline replacement (inside the scanner!) of '?'
   at the beginning of a line by HELP("...");
 * In the long term we should have two scanner/parser modes, or
   separate parsers for REPL mode code and for GAP code (where the
   GAP Parser is a sub-parser of the REPL mode parser).
 * With '?' we can potentially interpret expressions after '?'
 * ? by itself wasn't valid syntax (as part of a identifier or otherwise) before