### PR TITLE
Simplify caching logic in GeneralMappingsFamily

### DIFF
--- a/hpcgap/lib/mapping.gi
+++ b/hpcgap/lib/mapping.gi
@@ -40,30 +40,20 @@ end);
 ##
 InstallGlobalFunction( GeneralMappingsFamily, function( FS, FR )
 
-    local info, i, len, entry, Fam,first,test;
+    local info, i, len, entry, Fam, freepos;
 
   atomic readwrite GENERAL_MAPPING_REGION do
     # Check whether this family was already constructed.
     info:= FamiliesOfGeneralMappingsAndRanges( FS );
     len:= LengthWPObj( info );
-    if len mod 2 = 1 then
-      len:= len - 1;
-    fi;
-    first:=fail;
-    for i in [ 2, 4 .. len ] do
-      test:=ElmWPObj( info, i-1 );
-      if test=fail and first=fail then 
-	if  ElmWPObj(info,i)=fail then
-	  first:=i-1; # note that this is a free position
-	fi;
-      elif IsIdenticalObj( test, FR ) then
-        entry:= ElmWPObj( info, i );
-        if entry <> fail then
-          return entry;
-        else
-          UnbindElmWPObj( info, i-1 );
-          break;
+    for i in [ 1.. len+1 ] do
+      entry:=ElmWPObj( info, i );
+      if entry=fail then
+        if not IsBound( freepos ) then
+          freepos:= i;
         fi;
+      elif IsIdenticalObj( FamilyRange(entry), FR ) then
+        return entry;
       fi;
     od;
 
@@ -79,15 +69,8 @@ InstallGlobalFunction( GeneralMappingsFamily, function( FS, FR )
     SetFamilyRange(  Fam, FR );
     SetFamilySource( Fam, FS );
 
-    if first<>fail then
-      # Store the family in free spot.
-      SetElmWPObj( info, first, FR  );
-      SetElmWPObj( info, first+1, Fam );
-    else
-      # no free spot -- store at end
-      SetElmWPObj( info, len+1, FR  );
-      SetElmWPObj( info, len+2, Fam );
-    fi;
+    # Store the family in free spot.
+    SetElmWPObj( info, freepos, Fam );
 
     # Return the family.
     return Fam;

--- a/lib/mapping.gi
+++ b/lib/mapping.gi
@@ -39,29 +39,19 @@ InstallMethod( FamiliesOfGeneralMappingsAndRanges,
 ##
 InstallGlobalFunction( GeneralMappingsFamily, function( FS, FR )
 
-    local info, i, len, entry, Fam,first,test;
+    local info, i, len, entry, Fam, freepos;
 
     # Check whether this family was already constructed.
     info:= FamiliesOfGeneralMappingsAndRanges( FS );
     len:= LengthWPObj( info );
-    if len mod 2 = 1 then
-      len:= len - 1;
-    fi;
-    first:=fail;
-    for i in [ 2, 4 .. len ] do
-      test:=ElmWPObj( info, i-1 );
-      if test=fail and first=fail then 
-	if  ElmWPObj(info,i)=fail then
-	  first:=i-1; # note that this is a free position
-	fi;
-      elif IsIdenticalObj( test, FR ) then
-        entry:= ElmWPObj( info, i );
-        if entry <> fail then
-          return entry;
-        else
-          UnbindElmWPObj( info, i-1 );
-          break;
+    for i in [ 1.. len+1 ] do
+      entry:=ElmWPObj( info, i );
+      if entry=fail then
+        if not IsBound( freepos ) then
+          freepos:= i;
         fi;
+      elif IsIdenticalObj( FamilyRange(entry), FR ) then
+        return entry;
       fi;
     od;
 
@@ -77,15 +67,8 @@ InstallGlobalFunction( GeneralMappingsFamily, function( FS, FR )
     SetFamilyRange(  Fam, FR );
     SetFamilySource( Fam, FS );
 
-    if first<>fail then
-      # Store the family in free spot.
-      SetElmWPObj( info, first, FR  );
-      SetElmWPObj( info, first+1, Fam );
-    else
-      # no free spot -- store at end
-      SetElmWPObj( info, len+1, FR  );
-      SetElmWPObj( info, len+2, Fam );
-    fi;
+    # Store the family in free spot.
+    SetElmWPObj( info, freepos, Fam );
 
     # Return the family.
     return Fam;


### PR DESCRIPTION
Previously, the cache consisted of a weak list with entries alternating
between "keys" (= range domain) and "values" (= the corresponding mapping
family).

But the "values" contain the keys (via FamilyRange(fam). By exploiting that,
we can simplify the caching logic. The resulting code is very similar to the
code in DirectProductElementsFamily, suggesting that we can eventually replace
both with a common abstraction.