### PR TITLE
Add rewriteToFile to TestDirectory

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -541,6 +541,10 @@ end);
 ##  <Item>suppress displaying status messages <C>#I  Errors detected while testing</C> and
 ##  <C>#I  No errors detected while testing</C> after the test (defaults to <K>false</K>).
 ##  </Item>
+##  <Mark><C>rewriteToFile</C></Mark>
+##  <Item>If <K>true</K>, then rewrite each test file to disc, with the output substituted
+##  by the results of running the test (defaults to <K>false</K>).
+##  </Item>
 ##  <Mark><C>exitGAP</C></Mark>
 ##  <Item>Rather than returning <K>true</K> or <K>false</K>, exit GAP with the return value
 ##  of GAP set to success or fail, depending on if all tests passed (defaults to <K>false</K>).
@@ -589,6 +593,7 @@ InstallGlobalFunction( "TestDirectory", function(arg)
     earlyStop := false,
     showProgress := true,
     suppressStatusMessage := false,
+    rewriteToFile := false,
     exitGAP := false,
   );
   
@@ -655,7 +660,11 @@ InstallGlobalFunction( "TestDirectory", function(arg)
     
     startTime := Runtime();
     startMem := TotalMemoryAllocated();    
-    startGcTime := GcTime();    
+    startGcTime := GcTime();
+
+    if opts.rewriteToFile then
+      opts.testOptions.rewriteToFile := files[i].name;
+    fi;
     testResult := Test(files[i].name, opts.testOptions);
     if not(testResult) and opts.earlyStop then
       STOP_TEST := STOP_TEST_CPY;

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -527,7 +527,7 @@ end);
 ##  If the optional argument <Arg>optrec</Arg> is given it must be a record.
 ##  The following components of <Arg>optrec</Arg> are recognized and can change
 ##  the default behaviour of <Ref Func="TestDirectory" />:
-##  <List >
+##  <List>
 ##  <Mark><C>testOptions</C></Mark>
 ##  <Item>A record which will be passed on as the second argument of <Ref Func="Test" />
 ##  if present.</Item>
@@ -550,22 +550,6 @@ end);
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
-
-###################################
-##
-## TestDirectory(<files> [, <options> ])
-## <files>: A directory (or filename) or list of filenames and directories
-## <options>: Optional record of options (with defaults)
-## 
-##    testOptions := rec()   : Options to pass on to Test
-##    earlyStop := false     : Stop once one test fails
-##    showProgress := "some" : Show some progress
-##    suppressStatusMessage := false: do not print status messages after the test
-##    recursive := true      : Search through directories recursively
-##    exitGAP := false       : Exit GAP, setting exit value depending on if tests succeeded
-##
-##
-
 InstallGlobalFunction( "TestDirectory", function(arg)
     local  testTotal, totalTime, totalMem, STOP_TEST_CPY, 
            basedirs, nopts, opts, testOptions, earlyStop, 


### PR DESCRIPTION
This adds an option `rewriteToFile` to `TestDirectory`. This just provides an easy-to-use access to `rewriteToFile` from `Test`.

This lets you run `TestDirectory(".", rec(rewriteToFile := true))` in a directory, which will run all the tests and replace all outputs with GAP's current outputs. This will hopefully make fixing tests faster. 