### PR TITLE
Experiment: Reimplement MemoizePosIntFunction using BindOnceExpr (DO NOT MERGE)

### DIFF
--- a/lib/hpc/thread1.g
+++ b/lib/hpc/thread1.g
@@ -214,3 +214,56 @@ end);
 BIND_GLOBAL("UNBIND_ATOMIC_RECORD", function(record, field)
   Unbind(record.(field));
 end);
+
+
+BIND_GLOBAL("BindOnce", function(obj, index, val)
+  if TNUM_OBJ(obj) = T_POSOBJ then
+    if not IsBound(obj![index]) then
+      obj![index]:= val;
+    fi;
+    return obj![index];
+  elif IS_LIST(obj) then
+    if not IsBound(obj[index]) then
+      obj[index]:= val;
+    fi;
+    return obj[index];
+  elif TNUM_OBJ(obj) = T_COMOBJ then
+    if not IsBound(obj!.(index)) then
+      obj!.(index):= val;
+    fi;
+    return obj!.(index);
+  elif IS_REC(obj) then
+    if not IsBound(obj.(index)) then
+      obj.(index):= val;
+    fi;
+    return obj.(index);
+  else
+    Error("<obj> is not supported");
+  fi;
+end);
+
+BIND_GLOBAL("BindOnceExpr", function(obj, index, expr)
+  if TNUM_OBJ(obj) = T_POSOBJ then
+    if not IsBound(obj![index]) then
+      return BindOnce(obj, index, expr());
+    fi;
+    return obj![index];
+  elif IS_LIST(obj) then
+    if not IsBound(obj[index]) then
+      return BindOnce(obj, index, expr());
+    fi;
+    return obj[index];
+  elif TNUM_OBJ(obj) = T_COMOBJ then
+    if not IsBound(obj!.(index)) then
+      return BindOnce(obj, index, expr());
+    fi;
+    return obj!.(index);
+  elif IS_REC(obj) then
+    if not IsBound(obj.(index)) then
+      return BindOnce(obj, index, expr());
+    fi;
+    return obj.(index);
+  else
+    Error("<obj> is not supported");
+  fi;
+end);

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -1818,9 +1818,12 @@ Obj BindOnceAComObj(Obj obj, Obj index, Obj *new, int eval, const char *currFunc
 
 
 Obj BindOnce(Obj obj, Obj index, Obj *new, int eval, const char *currFuncName) {
+  if (IS_PLIST(obj))
+    return BindOncePosObj(obj, index, new, eval, currFuncName);
   switch (TNUM_OBJ(obj)) {
     case T_POSOBJ:
       return BindOncePosObj(obj, index, new, eval, currFuncName);
+    case T_FIXALIST:
     case T_APOSOBJ:
       return BindOnceAPosObj(obj, index, new, eval, currFuncName);
     case T_COMOBJ:


### PR DESCRIPTION
This is an experimental PR which reimplements `MemoizePosIntFunction` using `BindOnceExpr`. IMHO the resulting code is easier to read; it is also shorter.

Drawback: To adapt it to (atomic) records, we'll have to implement `BindOnceExpr` for (atomic) records. Of course for starters, we could just adapt the naive GAP implementation of `BindOnceExpr` also added in this PR.

This PR relies on a hack to enable `BindOnceExpr` for plists. That hack is not 100% safe, as it may leave a PLIST with a "bad" tnum (such as `T_PLIST_EMPTY`). As long as `boundvals` cannot be referenced from anywhere else, this doesn't matter, but we should still fix it; a simple fix is to always force the TNUM in this case to be `T_PLIST`. But I am slightly worried about this (changing the TNUM) leading to race conditions again.

So what I'd prefer instead is to go back to using an atomic list again, by adding an implementation of `BindOnceExpr`. But before I invest time and energy looking into that, I figured it's best to get some feedback on this approach.