### PR TITLE
Speed up some of the slowest teststandard tests

### DIFF
--- a/tst/teststandard/arithlst.g
+++ b/tst/teststandard/arithlst.g
@@ -16,6 +16,14 @@ error:= Print;;
 
 #############################################################################
 ##
+##  How many times to repeat the same tests? Large values result in longer
+##  test runs, but with a higher probability of finding bugs
+##
+ARITH_LST_REPS := 5;
+
+
+#############################################################################
+##
 ##  Define auxiliary functions.
 ##
 RandomSquareArray := function( dim, D )
@@ -519,14 +527,14 @@ TestOfAdditiveListArithmetic := function( R, dim )
   if IsGeneralizedRowVector( r ) then
 
     # tests of kind 1.
-    for i in [ 1 .. 10 ] do
+    for i in [ 1 .. ARITH_LST_REPS ] do
       RunTest( ZeroTest, Random( R ) );
       RunTest( AdditiveInverseTest, Random( R ) );
       RunTest( AdditionTest, Random( R ), Random( R ) );
     od;
 
     # tests of kind 2.
-    for i in [ 1 .. 10 ] do
+    for i in [ 1 .. ARITH_LST_REPS ] do
       RunTest( AdditionTest, Random( R ), [] );
       RunTest( AdditionTest, [], Random( R ) );
       r:= Random( R );
@@ -542,7 +550,7 @@ TestOfAdditiveListArithmetic := function( R, dim )
   fi;
 
   # tests of kind 3.
-  for i in [ 1 .. 10 ] do
+  for i in [ 1 .. ARITH_LST_REPS ] do
 
     vec1:= List( [ 1 .. dim ], x -> Random( R ) );
     vec2:= List( [ 1 .. dim ], x -> Random( R ) );
@@ -628,14 +636,14 @@ TestOfMultiplicativeListArithmetic := function( R, dim )
   if IsMultiplicativeGeneralizedRowVector( r ) then
 
     # tests of kind 1.
-    for i in [ 1 .. 10 ] do
+    for i in [ 1 .. ARITH_LST_REPS ] do
       RunTest( OneTest, Random( R ) );
       RunTest( InverseTest, Random( R ) );
       RunTest( MultiplicationTest, Random( R ), Random( R ) );
     od;
 
     # tests of kind 2.
-    for i in [ 1 .. 10 ] do
+    for i in [ 1 .. ARITH_LST_REPS ] do
       r:= Random( R );
       intlist:= List( [ 1 .. Length( r ) + Random( [ -1 .. 1 ] ) ],
                       x -> Random( Integers ) );
@@ -649,7 +657,7 @@ TestOfMultiplicativeListArithmetic := function( R, dim )
   fi;
 
   # tests of kind 3.
-  for i in [ 1 .. 10 ] do
+  for i in [ 1 .. ARITH_LST_REPS ] do
 
     vec1:= List( [ 1 .. dim ], x -> Random( R ) );
     vec2:= List( [ 1 .. dim ], x -> Random( R ) );

--- a/tst/teststandard/hash2.tst
+++ b/tst/teststandard/hash2.tst
@@ -9,9 +9,9 @@
 ##  Exclude from testinstall.g as it takes considerable time.
 ##
 gap> START_TEST("hash2.tst");
-gap> g:=GL(20,2);;
+gap> g:=GL(18,2);;
 gap> Length(Orbit(g,g.1[1],OnRight));
-1048575
+262143
 gap> g:=GL(8,2);;
 gap> Length(Orbit(g,g.1,OnPoints));
 32385

--- a/tst/teststandard/sort.tst
+++ b/tst/teststandard/sort.tst
@@ -60,7 +60,7 @@ gap> for i in [0..500] do CheckSort([1..i],[1..i]); od;
 gap> for i in [0..500] do CheckSort(List([1..i],x->x),[1..i]); od;
 gap> for i in [0..500] do CheckSort([-i..i],[-i..i]); od;
 gap> for i in [0..500] do CheckSort([i,i-1..-i],[-i..i]); od;
-gap> for i in [0..500] do
+gap> for i in [0..50] do
 >      for j in [0..10] do
 >        CheckSort(Shuffle([1..i]), [1..i]);
 >        CheckFilters([1..i], true, true, i <= 1, i <= 1);
@@ -77,7 +77,7 @@ gap> for i in [0..100] do
 >    od;
 
 # Need to test something which are not plists. Strings are a good choice.
-gap> for i in [0..100] do
+gap> for i in [0..50] do
 >      for j in [0..10] do
 >        l := "";
 >        for a in [1..j] do for b in [1..i] do
@@ -94,7 +94,7 @@ gap> for i in [0..100] do
 >    od;
 
 # Let test bool lists too!
-gap> for i in [0..100] do
+gap> for i in [0..50] do
 >      for j in [0..10] do
 >        l := BlistList([1..i+j],[1..i]);
 >        l2 := Shuffle(List(l));

--- a/tst/teststandard/stabchain.tst
+++ b/tst/teststandard/stabchain.tst
@@ -6,20 +6,22 @@
 ##  Test orbit algorithms, which use hashing
 ##  Also a few direct tests of SCRSift, since I have been working on it.
 ##     SL
-##  Exclude from testinstall.g: why?
+##  Exclude from testinstall.g as it takes considerable time.
 ##
 gap> START_TEST("stabchain.tst");
-gap> G := SymmetricGroup(10);;
+
+#
+gap> G := SymmetricGroup(9);;
 gap> Size(G);
-3628800
-gap> S := StabChain(G, [1,2,3,4,5,6,7,8,9]);;
+362880
+gap> S := StabChain(G, [1,2,3,4,5,6,7,8]);;
 gap> it := IteratorStabChain(S);;
 gap> NextIterator(it);
 ()
 gap> NextIterator(it);
-(9,10)
+(8,9)
 gap> NextIterator(it);
-(8,10)
+(7,9)
 gap> it2 := ShallowCopy(it);;
 gap> NextIterator(it2);; b := NextIterator(it2);;
 gap> NextIterator(it);; a := NextIterator(it);;
@@ -28,13 +30,17 @@ true
 gap> while not IsDoneIterator(it) do NextIterator(it); od;;
 gap> l := List(it2);;
 gap> Length(l);
-3628795
+362875
 gap> SCRSift(S,(1,2));
 ()
 gap> SCRSift(S,(1,11));
 (1,11)
 gap> SCRSift(S,(1,10));
+(1,10)
+gap> SCRSift(S,(1,9));
 ()
+
+#
 gap> m := MathieuGroup(24);;
 gap> S := StabChain(m,[1..24]);
 <stabilizer chain record, Base [ 1, 2, 3, 4, 5, 6, 7 ], Orbit length 

--- a/tst/teststandard/stablesort.tst
+++ b/tst/teststandard/stablesort.tst
@@ -79,7 +79,7 @@ gap> for i in [0..500] do CheckSort([1..i],[1..i]); od;
 gap> for i in [0..500] do CheckSort(List([1..i],x->x),[1..i]); od;
 gap> for i in [0..500] do CheckSort([-i..i],[-i..i]); od;
 gap> for i in [0..500] do CheckSort([i,i-1..-i],[-i..i]); od;
-gap> for i in [0..500] do
+gap> for i in [0..50] do
 >      for j in [0..10] do
 >        CheckSort(Shuffle([1..i]), [1..i]);
 >      od;
@@ -93,7 +93,7 @@ gap> for i in [0..100] do
 >    od;
 
 # Need to test something which are not plists. Strings are a good choice.
-gap> for i in [0..100] do
+gap> for i in [0..50] do
 >      for j in [0..10] do
 >        l := "";
 >        for a in [1..j] do for b in [1..i] do
@@ -108,7 +108,7 @@ gap> for i in [0..100] do
 >    od;
 
 # Let test bool lists too!
-gap> for i in [0..100] do
+gap> for i in [0..50] do
 >      for j in [0..10] do
 >        l := BlistList([1..i+j],[1..i]);
 >        l2 := Shuffle(List(l));


### PR DESCRIPTION
This mainly reduces the number of repetition in tests, or replaces input groups with a smaller ones.

Motivation is of course to reduce the Travis run times.

I think these reductions don't really take away from our coverage, but I think they will save a few minutes on the two `testtravis` jobs.