### PR TITLE
Mark DirectProductElements as being small lists

### DIFF
--- a/lib/tuples.gd
+++ b/lib/tuples.gd
@@ -31,6 +31,7 @@ DeclareInfoClass( "InfoDirectProductElements" );
 ##  <Description>
 ##  <Ref Func="IsDirectProductElement"/> is a subcategory of the meet of
 ##  <Ref Func="IsDenseList"/>,
+##  <Ref Func="IsSmallList"/>,
 ##  <Ref Func="IsMultiplicativeElementWithInverse"/>,
 ##  <Ref Func="IsAdditiveElementWithInverse"/>,
 ##  and <Ref Func="IsCopyable"/>,
@@ -55,6 +56,7 @@ DeclareInfoClass( "InfoDirectProductElements" );
 ##
 DeclareCategory( "IsDirectProductElement",
         IsDenseList
+    and IsSmallList
     and IsCopyable
     and IsMultiplicativeElementWithInverse
     and IsAdditiveElementWithInverse );

--- a/tst/testinstall/DirectProductElement.tst
+++ b/tst/testinstall/DirectProductElement.tst
@@ -1,5 +1,7 @@
 # Embryonic test for DirectProductElement objects, could be expanded.
 gap> START_TEST("DirectProductElement.tst");
+
+#
 gap> numdpe1 := DirectProductElement([1,2]);
 DirectProductElement( [ 1, 2 ] )
 gap> numdpe2 := DirectProductElement([3,4]);
@@ -22,4 +24,11 @@ gap> PrintString(adpe);
 "DirectProductElement( [ Group( \>[ (1,2,3), (1,2) ]\<\> )\<,\<\> 1 ] )"
 gap> Display(adpe);
 DirectProductElement( [ Group( [ (1,2,3), (1,2) ] ), 1 ] )
+
+# verify bug #1824 (2) is fixed
+gap> elt := DirectProductElement([1,1]);;
+gap> IsFinite(elt);
+true
+
+#
 gap> STOP_TEST("DirectProductElement.tst");


### PR DESCRIPTION
In particular, they are finite, which resolves the 2nd part of issue #1824.

Since @stevelinton wrote this code, perhaps he has something to add.

Note that an alternative fix would be to declare `IsFinite` invalid for DPEs. But that would also require making the not be lists anymore. Which for me actually sounds attractive, *but* this may well have sever ramifications and lead to regressions. Since we are about to branch 4.9, I do not want to introduce risky changes.