### PR TITLE
Make the memory printing in TestDirectory more robust

### DIFF
--- a/lib/string.gi
+++ b/lib/string.gi
@@ -1210,6 +1210,9 @@ end);
 
 InstallGlobalFunction(StringOfMemoryAmount, function(m)
     local  whole, frac, shift, s, units;
+    if not IsInt(m) or m < 0 then
+        Error("StringOfMemoryAmount: amount must be a non-negative integer number of bytes");
+    fi;
     whole := m;
     frac := 0;
     shift := 0;

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -572,7 +572,6 @@ InstallGlobalFunction( "TestDirectory", function(arg)
       g := GASMAN_STATS();    
       return g[1][8] + g[2][8];    
   end;
-        
   STOP_TEST_CPY := STOP_TEST;
   STOP_TEST := function(arg) end;
   

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -50,7 +50,7 @@ enum { NTYPES = 256 };
 
 TNumInfoBags InfoBags[NTYPES];
 
-UInt SizeAllBags;
+UInt8 SizeAllBags;
 
 static inline Bag * DATA(BagHeader * bag)
 {

--- a/src/calls.c
+++ b/src/calls.c
@@ -456,7 +456,7 @@ UInt TimeDone;
 **  'StorDone' is the amount of storage spent for all function call that have
 **  already been completed.
 */
-UInt StorDone;
+UInt8 StorDone;
 
 
 /****************************************************************************
@@ -476,8 +476,8 @@ Obj DoProf0args (
     Obj                 prof;           /* profiling bag                   */
     UInt                timeElse;       /* time    spent elsewhere         */
     UInt                timeCurr;       /* time    spent in current funcs. */
-    UInt                storElse;       /* storage spent elsewhere         */
-    UInt                storCurr;       /* storage spent in current funcs. */ 
+    UInt8               storElse;       /* storage spent elsewhere         */
+    UInt8               storCurr;       /* storage spent in current funcs. */ 
 
     /* get the profiling bag                                               */
     prof = PROF_FUNC( PROF_FUNC( self ) );
@@ -525,8 +525,8 @@ Obj DoProf1args (
     Obj                 prof;           /* profiling bag                   */
     UInt                timeElse;       /* time    spent elsewhere         */
     UInt                timeCurr;       /* time    spent in current funcs. */
-    UInt                storElse;       /* storage spent elsewhere         */
-    UInt                storCurr;       /* storage spent in current funcs. */ 
+    UInt8               storElse;       /* storage spent elsewhere         */
+    UInt8               storCurr;       /* storage spent in current funcs. */ 
 
     /* get the profiling bag                                               */
     prof = PROF_FUNC( PROF_FUNC( self ) );
@@ -575,8 +575,8 @@ Obj DoProf2args (
     Obj                 prof;           /* profiling bag                   */
     UInt                timeElse;       /* time    spent elsewhere         */
     UInt                timeCurr;       /* time    spent in current funcs. */
-    UInt                storElse;       /* storage spent elsewhere         */
-    UInt                storCurr;       /* storage spent in current funcs. */ 
+    UInt8               storElse;       /* storage spent elsewhere         */
+    UInt8               storCurr;       /* storage spent in current funcs. */ 
 
     /* get the profiling bag                                               */
     prof = PROF_FUNC( PROF_FUNC( self ) );
@@ -626,8 +626,8 @@ Obj DoProf3args (
     Obj                 prof;           /* profiling bag                   */
     UInt                timeElse;       /* time    spent elsewhere         */
     UInt                timeCurr;       /* time    spent in current funcs. */
-    UInt                storElse;       /* storage spent elsewhere         */
-    UInt                storCurr;       /* storage spent in current funcs. */ 
+    UInt8               storElse;       /* storage spent elsewhere         */
+    UInt8               storCurr;       /* storage spent in current funcs. */ 
 
     /* get the profiling bag                                               */
     prof = PROF_FUNC( PROF_FUNC( self ) );
@@ -678,8 +678,8 @@ Obj DoProf4args (
     Obj                 prof;           /* profiling bag                   */
     UInt                timeElse;       /* time    spent elsewhere         */
     UInt                timeCurr;       /* time    spent in current funcs. */
-    UInt                storElse;       /* storage spent elsewhere         */
-    UInt                storCurr;       /* storage spent in current funcs. */ 
+    UInt8               storElse;       /* storage spent elsewhere         */
+    UInt8               storCurr;       /* storage spent in current funcs. */ 
 
     /* get the profiling bag                                               */
     prof = PROF_FUNC( PROF_FUNC( self ) );
@@ -731,8 +731,8 @@ Obj DoProf5args (
     Obj                 prof;           /* profiling bag                   */
     UInt                timeElse;       /* time    spent elsewhere         */
     UInt                timeCurr;       /* time    spent in current funcs. */
-    UInt                storElse;       /* storage spent elsewhere         */
-    UInt                storCurr;       /* storage spent in current funcs. */ 
+    UInt8               storElse;       /* storage spent elsewhere         */
+    UInt8               storCurr;       /* storage spent in current funcs. */ 
 
     /* get the profiling bag                                               */
     prof = PROF_FUNC( PROF_FUNC( self ) );
@@ -785,8 +785,8 @@ Obj DoProf6args (
     Obj                 prof;           /* profiling bag                   */
     UInt                timeElse;       /* time    spent elsewhere         */
     UInt                timeCurr;       /* time    spent in current funcs. */
-    UInt                storElse;       /* storage spent elsewhere         */
-    UInt                storCurr;       /* storage spent in current funcs. */ 
+    UInt8               storElse;       /* storage spent elsewhere         */
+    UInt8               storCurr;       /* storage spent in current funcs. */ 
 
     /* get the profiling bag                                               */
     prof = PROF_FUNC( PROF_FUNC( self ) );
@@ -834,8 +834,8 @@ Obj DoProfXargs (
     Obj                 prof;           /* profiling bag                   */
     UInt                timeElse;       /* time    spent elsewhere         */
     UInt                timeCurr;       /* time    spent in current funcs. */
-    UInt                storElse;       /* storage spent elsewhere         */
-    UInt                storCurr;       /* storage spent in current funcs. */ 
+    UInt8               storElse;       /* storage spent elsewhere         */
+    UInt8               storCurr;       /* storage spent in current funcs. */ 
 
     /* get the profiling bag                                               */
     prof = PROF_FUNC( PROF_FUNC( self ) );

--- a/src/calls.h
+++ b/src/calls.h
@@ -48,6 +48,7 @@
 #include <src/gap.h>
 #include <src/gaputils.h>
 #include <src/lists.h>
+#include <src/integer.h>
 
 
 /****************************************************************************
@@ -378,14 +379,24 @@ extern Obj NargError(Obj func, Int actual);
 #define COUNT_PROF(prof)            (INT_INTOBJ(ELM_PLIST(prof,1)))
 #define TIME_WITH_PROF(prof)        (INT_INTOBJ(ELM_PLIST(prof,2)))
 #define TIME_WOUT_PROF(prof)        (INT_INTOBJ(ELM_PLIST(prof,3)))
-#define STOR_WITH_PROF(prof)        (INT_INTOBJ(ELM_PLIST(prof,4)))
-#define STOR_WOUT_PROF(prof)        (INT_INTOBJ(ELM_PLIST(prof,5)))
+#define STOR_WITH_PROF(prof)        (UInt8_ObjInt(ELM_PLIST(prof,4)))
+#define STOR_WOUT_PROF(prof)        (UInt8_ObjInt(ELM_PLIST(prof,5)))
 
 #define SET_COUNT_PROF(prof,n)      SET_ELM_PLIST(prof,1,INTOBJ_INT(n))
 #define SET_TIME_WITH_PROF(prof,n)  SET_ELM_PLIST(prof,2,INTOBJ_INT(n))
 #define SET_TIME_WOUT_PROF(prof,n)  SET_ELM_PLIST(prof,3,INTOBJ_INT(n))
-#define SET_STOR_WITH_PROF(prof,n)  SET_ELM_PLIST(prof,4,INTOBJ_INT(n))
-#define SET_STOR_WOUT_PROF(prof,n)  SET_ELM_PLIST(prof,5,INTOBJ_INT(n))
+
+static inline void SET_STOR_WITH_PROF(Obj prof, UInt8 n)
+{
+    SET_ELM_PLIST(prof,4,ObjInt_Int8(n));
+    CHANGED_BAG(prof);
+}
+
+static inline void SET_STOR_WOUT_PROF(Obj prof, UInt8 n)
+{
+    SET_ELM_PLIST(prof,5,ObjInt_Int8(n));
+    CHANGED_BAG(prof);
+}
 
 #define LEN_PROF                    5
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -236,7 +236,7 @@ Obj Shell ( Obj context,
             Char *outFile)
 {
   UInt time = 0;
-  UInt mem = 0;
+  UInt8 mem = 0;
   UInt status;
   Obj evalResult;
   UInt dualSemicolon;
@@ -354,11 +354,7 @@ Obj Shell ( Obj context,
     /* stop the stopwatch                                          */
     if (setTime) {
       AssGVar( Time, INTOBJ_INT( SyTime() - time ) );
-      /* This should be correct for small allocated totals at least, 
-         even on 32 bits, but this functionality will never be very useful
-         on 32 bits */         
-      AssGVar(MemoryAllocated,
-              INTOBJ_INT((SizeAllBags - mem) % (1L << NR_SMALL_INT_BITS)));
+      AssGVar(MemoryAllocated, ObjInt_Int8(SizeAllBags - mem));
     }
 
     if (STATE(UserHasQuit))
@@ -1986,7 +1982,7 @@ Obj FuncSHALLOW_SIZE (
 */
 
 Obj FuncTotalMemoryAllocated( Obj self ) {
-    return INTOBJ_INT(SizeAllBags);
+    return ObjInt_UInt8(SizeAllBags);
 }
 
 /****************************************************************************

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -422,11 +422,11 @@ Bag                     MarkedBags;
 **                            but may still be weakly pointed to
 */
 UInt                    NrAllBags;
-UInt                    SizeAllBags;
+UInt8                   SizeAllBags;
 UInt                    NrLiveBags;
 UInt                    SizeLiveBags;
 UInt                    NrDeadBags;
-UInt                    SizeDeadBags;
+UInt8                   SizeDeadBags;
 UInt                    NrHalfDeadBags;
 
 

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -599,11 +599,11 @@ extern void SwapMasterPoint (
 */
 
 extern  UInt                    NrAllBags;
-extern  UInt                    SizeAllBags;
+extern  UInt8                   SizeAllBags;
 extern  UInt                    NrLiveBags;
 extern  UInt                    SizeLiveBags;
 extern  UInt                    NrDeadBags;
-extern  UInt                    SizeDeadBags;
+extern  UInt8                   SizeDeadBags;
 extern  UInt                    NrHalfDeadBags;
 
 

--- a/src/gmpints.h
+++ b/src/gmpints.h
@@ -69,7 +69,19 @@ extern "C" {
 extern Obj ObjInt_Int(Int i);
 extern Obj ObjInt_UInt(UInt i);
 extern Obj ObjInt_Int8(Int8 i);
+extern Obj ObjInt_UInt8(UInt8 i);
 
+/**************************************************************************
+**
+** The following functions convert a GAP integer into an Int, UInt,
+** Int8 or UInt8 if it is in range. Otherwise it gives an error.
+*/
+extern Int Int_ObjInt(Obj i);    
+extern UInt UInt_ObjInt(Obj i);    
+extern Int8 Int8_ObjInt(Obj i);    
+extern UInt8 UInt8_ObjInt(Obj i);    
+
+    
 /****************************************************************************
 **
 ** Reduce and normalize the given large integer object if necessary.


### PR DESCRIPTION
On 32 bit systems the memory count can easily overflow. This at
least avoid attempting to print negative amounts, although it
can still fail to detect if it has overflowed and wrapped round,
giving a result wrong by some multiple of 4GB.