### PR TITLE
Remove profiling limit on files with <= 2^16 lines

### DIFF
--- a/src/code.h
+++ b/src/code.h
@@ -27,8 +27,7 @@
 */
 typedef struct {
     unsigned int visited : 1;
-    unsigned int fileid : 15;
-    unsigned int line : 16;
+    unsigned int line : 31;
     unsigned int size : 24;
     unsigned int type : 8;
 } StatHeader;
@@ -45,7 +44,7 @@ typedef struct {
 
 /****************************************************************************
 **
-** Function headers
+** Function body headers
 **
 ** 'FILENAME_BODY' is a string containing the file of a function
 ** 'STARTLINE_BODY' is the line number where a function starts.
@@ -61,11 +60,19 @@ typedef struct {
 */
 
 typedef struct {
-    Obj filename;
-    union {
-        Obj startline;
-        Obj location;
-    };
+    // if non-zero, this is either a string containing the name of the
+    // file of a function, or an immediate integer containing the index
+    // of the filename inside FilenameCache
+    Obj filename_or_id;
+
+    // if non-zero, this is either an immediate integer encoding the
+    // line number where a function starts, or string describing the
+    // location of a function. Typically this will be the name of a C
+    // function implementing it.
+    Obj startline_or_location;
+
+    // if non-zero, this is an immediate integer encoding the line
+    // number where a function ends
     Obj endline;
 } BodyHeader;
 
@@ -77,6 +84,10 @@ static inline BodyHeader *BODY_HEADER(Obj body)
 
 Obj GET_FILENAME_BODY(Obj body);
 void SET_FILENAME_BODY(Obj body, Obj val);
+
+UInt GET_GAPNAMEID_BODY(Obj body);
+void SET_GAPNAMEID_BODY(Obj body, UInt val);
+
 Obj GET_LOCATION_BODY(Obj body);
 void SET_LOCATION_BODY(Obj body, Obj val);
 
@@ -248,24 +259,6 @@ enum STAT_TNUM {
 **  'LINE_STAT' returns the line number of the statement <stat>.
 */
 #define LINE_STAT(stat) (STAT_HEADER(stat)->line)
-
-/****************************************************************************
-**
-*F  FILENAMEID_STAT(<stat>) . . . . . . . . . . . . file name of a statement
-**
-**  'FILENAMEID_STAT' returns the file the statement <stat> was read from.
-**  This should be looked up in the FilenameCache variable
-*/
-#define FILENAMEID_STAT(stat) (STAT_HEADER(stat)->fileid)
-
-/****************************************************************************
-**
-*F  FILENAME_STAT(<stat>) . . . . . . . . . . . . .  file name of a statement
-**
-**  'FILENAME_STAT' returns a gap string containing the file where the statement
-**  <stat> was read from.
-*/
-Obj FILENAME_STAT(Stat stat);
 
 /****************************************************************************
 **

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -57,9 +57,6 @@ static Int HookActiveCount;
 /* If a print hook is current active */
 static Int PrintHookActive;
 
-/* Forward declaration */
-void CheckPrintOverflowWarnings(void);
-
 /****************************************************************************
 **
 ** Store the true values of each function we wrap for hooking. These always
@@ -166,8 +163,6 @@ Int ActivateHooks(struct InterpreterHooks * hook)
 {
     Int i;
 
-    CheckPrintOverflowWarnings();
-
     if (HookActiveCount == HookCount) {
         return 0;
     }
@@ -220,68 +215,6 @@ Int DeactivateHooks(struct InterpreterHooks * hook)
     return 1;
 }
 
-/****************************************************************************
-**
-** These variables store if we have overflowed either 2^16 lines, or files.
-** In this case GAP will stop marking the line and file of statements.
-** We print a warning to tell users that this happens, either immediately
-** (if hooking is active) or when hooking is next activated if not.
-**/
-
-static Int HaveReportedLineProfileOverflow;
-static Int ShouldReportLineProfileOverflow;
-
-static Int HaveReportedFileProfileOverflow;
-static Int ShouldReportFileProfileOverflow;
-
-// This function only exists to allow testing of these overflow checks
-Obj FuncCLEAR_PROFILE_OVERFLOW_CHECKS(Obj self)
-{
-    HaveReportedLineProfileOverflow = 0;
-    ShouldReportLineProfileOverflow = 0;
-
-    HaveReportedFileProfileOverflow = 0;
-    ShouldReportFileProfileOverflow = 0;
-
-    return 0;
-}
-
-void CheckPrintOverflowWarnings(void)
-{
-    if (!HaveReportedLineProfileOverflow && ShouldReportLineProfileOverflow) {
-        HaveReportedLineProfileOverflow = 1;
-        Pr("#I Interpreter hooking only works on the first 65,535 lines\n"
-           "#I of each file (this warning will only appear once).\n"
-           "#I This will effect profiling and debugging.\n",
-           0L, 0L);
-    }
-
-    if (!HaveReportedFileProfileOverflow && ShouldReportFileProfileOverflow) {
-        HaveReportedFileProfileOverflow = 1;
-        Pr("#I Interpreter hooking only works on the first 65,535 read files\n"
-           "#I of each file (this warning will only appear once).\n"
-           "#I This will effect profiling and debugging.\n",
-           0L, 0L);
-    }
-}
-
-void ReportLineNumberOverflowOccured(void)
-{
-    ShouldReportLineProfileOverflow = 1;
-    if (HookActiveCount) {
-        CheckPrintOverflowWarnings();
-    }
-}
-
-void ReportFileNumberOverflowOccured(void)
-{
-    ShouldReportFileProfileOverflow = 1;
-    if (HookActiveCount) {
-        CheckPrintOverflowWarnings();
-    }
-}
-
-
 void ActivatePrintHooks(struct PrintHooks * hook)
 {
     Int i;
@@ -320,7 +253,6 @@ void DeactivatePrintHooks(struct PrintHooks * hook)
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
 static StructGVarFunc GVarFuncs[] = {
-    GVAR_FUNC(CLEAR_PROFILE_OVERFLOW_CHECKS, 0, ""),
     { 0, 0, 0, 0, 0 }
 };
 

--- a/src/hookintrprtr.h
+++ b/src/hookintrprtr.h
@@ -108,18 +108,6 @@ void DeactivatePrintHooks(struct PrintHooks * hook);
 
 /****************************************************************************
 **
-** We can only store a fixed number of files, and files, in statements.
-**
-** Whenever an overflow occurs we do not mark that statement with its line
-** or file, and call these functions to record the fact information is
-** missing, so we can inform users later.
-*/
-
-void ReportLineNumberOverflowOccured();
-void ReportFileNumberOverflowOccured();
-
-/****************************************************************************
-**
 ** We need the functions in the next three functions to be in the header,
 ** so they can be inlined away. The only functionality here which should
 ** be publicly used is 'VisitStatIfHooked',

--- a/src/profile.c
+++ b/src/profile.c
@@ -282,7 +282,9 @@ static void fcloseMaybeCompressed(struct ProfileState* ps)
 // This function checks if we have ever printed out the id of stat
 static inline UInt getFilenameId(Stat stat)
 {
-  UInt id = FILENAMEID_STAT(stat);
+  Obj func = CURR_FUNC();
+  Obj body = BODY_FUNC(func);
+  UInt id = GET_GAPNAMEID_BODY(body);
   if (id == 0) {
     return 0;
   }
@@ -290,7 +292,7 @@ static inline UInt getFilenameId(Stat stat)
       ELM_PLIST(OutputtedFilenameList, id) != True) {
     AssPlist(OutputtedFilenameList, id, True);
     fprintf(profileState.Stream, "{\"Type\":\"S\",\"File\":\"%s\",\"FileId\":%d}\n",
-                                  CSTR_STRING(FILENAME_STAT(stat)), (int)id);
+                                  CSTR_STRING(GET_FILENAME_BODY(body)), (int)id);
   }
   return id;
 }
@@ -335,25 +337,24 @@ static inline void outputStat(Stat stat, int exec, int visited)
   // Explicitly skip these two cases, as they are often specially handled
   // and also aren't really interesting statements (something else will
   // be executed whenever they are).
-  if(TNUM_STAT(stat) == T_TRUE_EXPR || TNUM_STAT(stat) == T_FALSE_EXPR) {
+  if (TNUM_STAT(stat) == T_TRUE_EXPR || TNUM_STAT(stat) == T_FALSE_EXPR) {
     return;
   }
 
   // Catch the case we arrive here and profiling is already disabled
-  if(!profileState_Active) {
+  if (!profileState_Active) {
     return;
   }
 
   nameid = getFilenameId(stat);
 
   // Statement not attached to a file
-  if(nameid == 0)
-  {
+  if (nameid == 0) {
     return;
   }
 
   line = LINE_STAT(stat);
-  if(profileState.lastOutputted.line != line ||
+  if (profileState.lastOutputted.line != line ||
      profileState.lastOutputted.fileID != nameid ||
      profileState.lastOutputtedExec != exec)
   {

--- a/tst/testprofiling/prof.tst
+++ b/tst/testprofiling/prof.tst
@@ -4,7 +4,6 @@ gap> START_TEST("prof.tst");
 gap> tempdir := DirectoryTemporary();;
 gap> prof := IsLineByLineProfileActive();;
 gap> if prof then Print("prof.tst will produce failures if run with profiling"); fi;
-gap> CLEAR_PROFILE_OVERFLOW_CHECKS();
 gap> longFile := function(l)
 >      return Concatenation( [ ListWithIdenticalEntries(l - 1, '\n'),
 >                              "f := function(x) return x + ", String(l), "; end;\n" ] );
@@ -25,26 +24,12 @@ gap> IsLineByLineProfileActive();
 false
 gap> if not prof then ProfileLineByLine(Filename(tempdir, "profout")); fi;
 #I  Profile filenames must end in .gz to enable compression
-#I Interpreter hooking only works on the first 65,535 lines
-#I of each file (this warning will only appear once).
-#I This will effect profiling and debugging.
-gap> IsLineByLineProfileActive();
-true
-gap> if not prof then UnprofileLineByLine(); fi;
-gap> IsLineByLineProfileActive();
-false
-gap> CLEAR_PROFILE_OVERFLOW_CHECKS();
-gap> if not prof then ProfileLineByLine(Filename(tempdir, "profout")); fi;
-#I  Profile filenames must end in .gz to enable compression
 gap> IsLineByLineProfileActive();
 true
 gap> Read(Filename(tempdir, "line-65535.g"));;
 gap> f(0);
 65535
 gap> Read(Filename(tempdir, "line-65536.g"));;
-#I Interpreter hooking only works on the first 65,535 lines
-#I of each file (this warning will only appear once).
-#I This will effect profiling and debugging.
 gap> f(0);
 65536
 gap> Read(Filename(tempdir, "line-65536.g"));;
@@ -53,14 +38,11 @@ gap> f(0);
 gap> Read(Filename(tempdir, "line-65537.g"));;
 gap> f(0);
 65537
-gap> if prof then lim := 10; else lim := 66000; fi;
-gap> for i in [1..lim] do
+gap> for i in [1..10] do
 > f := fail;
 > Read(Filename(tempdir, "line-65536.g"));
 > if f(0) <> 65536 then Print("bad"); fi;
 > od;
-#I Profiling only works for the first 65,535 read files
-#I (this warning will only appear once).
 gap> f(0);
 65536
 gap> for i in [1..10] do


### PR DESCRIPTION
The new limit is 2^31, which should be sufficient for everybody (TM).

It exploits the fact that all statements in a `T_BODY` come from the same file, and that file is being recored in the `T_BODY` bag anyway.

Previously, the filename was stored as a string object in the `T_BODY`. This still is supported (and used by some code), but for regular GAP functions, we now instead store an immediate integer indexing into the `filecache`. This is so that profiling code does not have to be modified to heavily.
