### PR TITLE
 Introduce S_DUALSEMICOLON to scanner

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1098,7 +1098,11 @@ void GetSymbol ( void )
     if ( *STATE(In) == '=' ) { STATE(Symbol) = S_ASSIGN;  GET_CHAR(); break; }
     break;
 
-  case ';':   STATE(Symbol) = S_SEMICOLON;                   GET_CHAR();  break;
+  case ';':   STATE(Symbol) = S_SEMICOLON;                   GET_CHAR();
+    if ( *STATE(In) == ';' ) {
+        STATE(Symbol) = S_DUALSEMICOLON; GET_CHAR();
+    }
+    break;
 
   case '=':   STATE(Symbol) = S_EQ;                          GET_CHAR();  break;
   case '<':   STATE(Symbol) = S_LT;                          GET_CHAR();

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -144,7 +144,8 @@ enum {
     S_QQUIT             = (1UL<<29)+3,
     S_CONTINUE          = (1UL<<29)+4,
 
-    S_SEMICOLON         = (1UL<<30),
+    S_SEMICOLON         = (1UL<<30)+0,
+    S_DUALSEMICOLON     = (1UL<<30)+1,
 
     S_EOF               = (1UL<<31),
 };


### PR DESCRIPTION
This gets rid of a hack in `read.c` where it peaks into `STATE(In)`, bypassing the scanner.

However, this PR arguably contains a hack of its own (namely reseting `STATE(Symbol)` to `S_SEMICOLON`, so i am not sure we really want to go that way.

An alternative would be to add a function that allows code to peek at the next `In` value. But for just one use case? Hm.