### PR TITLE
Add kernel implementation of Binomial()

### DIFF
--- a/lib/combinat.gi
+++ b/lib/combinat.gi
@@ -60,32 +60,7 @@ end);
 ##
 #F  Binomial( <n>, <k> )  . . . . . . . . .  binomial coefficient of integers
 ##
-InstallGlobalFunction(Binomial,function ( n, k )
-    local   bin, i, j;
-    if   k < 0  then
-        bin := 0;
-    elif k = 0  then
-        bin := 1;
-    elif n < 0  then
-        bin := (-1)^k * Binomial( -n+k-1, k );
-    elif n < k  then
-        bin := 0;
-    elif n = k  then
-        bin := 1;
-    elif n-k < k  then
-        bin := Binomial( n, n-k );
-    else
-        bin := 1;  j := 1;
-        # note that all intermediate results are binomial coefficients itself
-        # hence integers!
-        # slight improvement by Frank and Max.
-        for i  in [0..k-1]  do
-            bin := bin * (n-i) / j;
-            j := j + 1;
-        od;
-    fi;
-    return bin;
-end);
+InstallGlobalFunction(Binomial, BINOMIAL_INT);
 
 
 #############################################################################

--- a/tst/testinstall/opers/Binomial.tst
+++ b/tst/testinstall/opers/Binomial.tst
@@ -1,0 +1,34 @@
+gap> START_TEST("Binomial.tst");
+
+#
+gap> Binomial_GAP := function ( n, k )
+>     local   bin, i, j;
+>     if   k < 0  then
+>         bin := 0;
+>     elif k = 0  then
+>         bin := 1;
+>     elif n < 0  then
+>         bin := (-1)^k * Binomial_GAP( -n+k-1, k );
+>     elif n < k  then
+>         bin := 0;
+>     elif n = k  then
+>         bin := 1;
+>     elif n-k < k  then
+>         bin := Binomial_GAP( n, n-k );
+>     else
+>         bin := 1;  j := 1;
+>         for i  in [0..k-1]  do
+>             bin := bin * (n-i) / j;
+>             j := j + 1;
+>         od;
+>     fi;
+>     return bin;
+> end;;
+
+# compared C Binomial against GAP version
+gap> ForAll([-100..100], n->ForAll([-1..100],
+>       k->Binomial_GAP(n,k) = BINOMIAL_INT(n,k)));
+true
+
+#
+gap> STOP_TEST("Binomial.tst", 1);


### PR DESCRIPTION
This example illustrates the speedup:
```
gap> n:=2^14;; a:=BINOMIAL_INT(2*n,n);; time; b:=Binomial_GAP(2*n,n);; time; a=b;
0
51
true
gap> n:=2^16;; a:=BINOMIAL_INT(2*n,n);; time; b:=Binomial_GAP(2*n,n);; time; a=b;
2
719
true
gap> n:=2^18;; a:=BINOMIAL_INT(2*n,n);; time; b:=Binomial_GAP(2*n,n);; time; a=b;
8
11470
true
gap> n:=2^19;; a:=BINOMIAL_INT(2*n,n);; time; b:=Binomial_GAP(2*n,n);; time; a=b;
14
51386
gap> n:=2^20;; a:=BINOMIAL_INT(2*n,n);; time; b:=Binomial_GAP(2*n,n);; time; a=b;
33
190444
```

Note that on 32bit systems, some previously "supported" combinations (n,k) are no longer supported. But those values are effectively out of reach for the old code, too: if I extrapolate the results above in various ways, I get an estimate of about 30 days to compute the smallest binomial coefficient (for n=2^28) not supported. Granted, this is on my laptop, and your super computer might get to it quicker. But at that point you might also just use the 64 bit version of GAP, which gets  the result on my laptop in less than 30 *seconds*:
```gap
gap> n:=2^28;; a:=BINOMIAL_INT(2*n,n);; time;
26180
gap> MemoryUsage(a);
67108888
gap> StringOfMemoryAmount(last);
"64.0MB"
```