### PR TITLE
Correctly restore Tilde when returning from ReadAsFunction

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2738,6 +2738,7 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     volatile Obj                 stackNams;
     volatile UInt                readTop;
     volatile UInt                readTilde;
+    volatile Obj                 tilde;
     volatile UInt                currLHSGVar;
     volatile Obj                 errorLVars;
     syJmp_buf           readJmpError;
@@ -2766,6 +2767,7 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     stackNams   = STATE(StackNams);
     readTop     = STATE(ReadTop);
     readTilde   = STATE(ReadTilde);
+    tilde       = STATE(Tilde);
     currLHSGVar = STATE(CurrLHSGVar);
     memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
 
@@ -2773,6 +2775,7 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     STATE(StackNams)   = NEW_PLIST( T_PLIST, 16 );
     STATE(ReadTop)     = 0;
     STATE(ReadTilde)   = 0;
+    STATE(Tilde)       = 0;
     STATE(CurrLHSGVar) = 0;
     RecreateStackNams(context);
     errorLVars = STATE(ErrorLVars);
@@ -2842,6 +2845,7 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     STATE(StackNams)   = stackNams;
     STATE(ReadTop)     = readTop;
     STATE(ReadTilde)   = readTilde;
+    STATE(Tilde)       = tilde;
     STATE(CurrLHSGVar) = currLHSGVar;
     STATE(ErrorLVars) = errorLVars;
 
@@ -2868,6 +2872,7 @@ UInt ReadEvalFile(Obj *evalResult)
     volatile Obj        stackNams;
     volatile UInt       readTop;
     volatile UInt       readTilde;
+    volatile Obj        tilde;
     volatile UInt       currLHSGVar;
     syJmp_buf           readJmpError;
     volatile UInt       nr;
@@ -2895,6 +2900,7 @@ UInt ReadEvalFile(Obj *evalResult)
     stackNams   = STATE(StackNams);
     readTop     = STATE(ReadTop);
     readTilde   = STATE(ReadTilde);
+    tilde       = STATE(Tilde);
     currLHSGVar = STATE(CurrLHSGVar);
 #ifdef HPCGAP
     lockSP      = RegionLockSP();
@@ -2905,6 +2911,7 @@ UInt ReadEvalFile(Obj *evalResult)
     STATE(StackNams)   = NEW_PLIST( T_PLIST, 16 );
     STATE(ReadTop)     = 0;
     STATE(ReadTilde)   = 0;
+    STATE(Tilde)       = 0;
     STATE(CurrLHSGVar) = 0;
     IntrBegin(STATE(BottomLVars));
 
@@ -2977,6 +2984,7 @@ UInt ReadEvalFile(Obj *evalResult)
     STATE(StackNams)   = stackNams;
     STATE(ReadTop)     = readTop;
     STATE(ReadTilde)   = readTilde;
+    STATE(Tilde)       = tilde;
     STATE(CurrLHSGVar) = currLHSGVar;
 
     /* copy the result (if any)                                            */

--- a/tst/testinstall/tilde.tst
+++ b/tst/testinstall/tilde.tst
@@ -82,4 +82,7 @@ true
 gap> bool := (rec1 < rec2);;
 gap> ForAll([1..10000], q -> ( (rec1 < rec2) = bool) );
 true
+gap> i := InputTextString( "local a; a := 10; return rec(a := a*10, b := ~);" );;
+gap> r := rec(a := ~, b := ReadAsFunction(i)(), c := ~.b.a);
+rec( a := ~, b := rec( a := 100, b := ~.b ), c := 100 )
 gap> STOP_TEST( "tilde.tst", 1);


### PR DESCRIPTION
This ensures when we call `ReadAsFunction` we correctly save and restore the value of `~`. Fixes #1924.