### PR TITLE
Limit which branches Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@
 dist: trusty
 language: c
 
+branches:
+  only:
+  - master
+  - /^stable-.*$/
+  - MatrixObj2
+
 env:
   global:
     - CFLAGS="-fprofile-arcs -ftest-coverage -O2"


### PR DESCRIPTION
Main motivation is that sometimes it happens that somebody (e.g. me and @alex-konovalov , yesterday) accidentally creates a branch on `gap-system/gap` instead of their own personal repository -- in my case, it happened because I used the web editor to make a change to a file, and didn't realize the resulting branch would end up here.

Now, I'll try to be more careful about this in the future. Still, it can happen (sadly, there seems to be no way to prevent creation of new branches on a GitHub repository). With this PR, at least Travis won't build those branches twice (once the branch itself, once as part of the PR). Note that annoyingly, if one stops either of the two builds, then Travis marks the PR as "failed Travis build". 

With this PR, only master, stable-* and MatrixObj2 will get built. At least according to the Travis docs.