### PR TITLE
Forbid 3 argument Add for atomic lists

### DIFF
--- a/hpcgap/tst/testinstall/atomic_list_hpc.tst
+++ b/hpcgap/tst/testinstall/atomic_list_hpc.tst
@@ -31,6 +31,12 @@ gap> IsAtomicList(l);
 true
 gap> l[4];
 Error, Atomic List Element: <pos>=4 is an invalid index for <list>
+gap> Add(l, 7);
+gap> l;
+[ 1, 2, 3, 7 ]
+gap> Add(l, 7, 5);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `Add' on 3 arguments
 gap> a := FixedAtomicList(5);
 [ ,,,, ]
 gap> EqualLists(a, []);
@@ -57,6 +63,12 @@ Error, COMPARE_AND_SWAP: Index out of range
 gap> a := FixedAtomicList(5);;
 gap> COMPARE_AND_SWAP(a, 10, 1, 2);
 Error, COMPARE_AND_SWAP: Index out of range
+gap> Add(l, 7);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `Add' on 2 arguments
+gap> Add(l, 7, 5);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `Add' on 3 arguments
 
 #
 gap> STOP_TEST("atomic_list.tst");

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -160,7 +160,8 @@ Obj FuncADD_LIST3 (
   } else if ( TNUM_OBJ( list ) < FIRST_EXTERNAL_TNUM ) {
     AddList3( list, obj, ipos );
 #ifdef HPCGAP
-  } else if ( TNUM_OBJ(list) == T_ALIST ) {
+  // Only support adding to end of atomic lists
+  } else if ( TNUM_OBJ(list) == T_ALIST && pos == (Obj)0 ) {
     AddAList( list, obj );
 #endif
   } else {


### PR DESCRIPTION
This fixes #1918, by forbidding 3 argument Add on atomic lists.

This is (slightly) non-trivial, because we still want 2-argument Add to work, and we implement 2 argument add by calling 3-argument add and passing (Obj)0.