### PR TITLE
Clarify documentation for Triangulized(Integer)Mat

### DIFF
--- a/lib/matint.gd
+++ b/lib/matint.gd
@@ -35,7 +35,7 @@ DeclareInfoClass( "InfoMatInt" );
 ##
 ##  <Description>
 ##  Computes an upper triangular form of a matrix with integer entries.
-##  It returns a immutable matrix in upper triangular form.
+##  It returns a mutable matrix in upper triangular form.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -1172,7 +1172,7 @@ DeclareOperation( "SumIntersectionMat", [ IsMatrix, IsMatrix ] );
 ##
 ##  <Description>
 ##  Computes an upper triangular form of the matrix <A>mat</A> via
-##  the Gaussian Algorithm. It returns a immutable matrix in upper triangular form.
+##  the Gaussian Algorithm. It returns a mutable matrix in upper triangular form.
 ##  This is sometimes also  called <Q>Hermite normal form</Q> or <Q>Reduced Row Echelon
 ##  Form</Q>.
 ##  <C>RREF</C> is a synonym for <C>TriangulizedMat</C>.


### PR DESCRIPTION
The documentation said the result of these functions was immutable, but it
really was mutable. Since it is likely that code relies on this, we change the
documentation to reflect reality.

Resolves #1030