### PR TITLE
Change MAX_VALUE_LEN back to 1030

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -15,18 +15,21 @@
 
 #include <src/system.h>
 #include <src/gasman.h>
-#include <src/io.h> // for TypInputFile and friends
-#include <src/scanner.h> // for MAX_VALUE_LEN
+#include <src/io.h>    // for TypInputFile and friends
 
 #if defined(HPCGAP)
 #include <src/hpc/serialize.h>
 #include <src/hpc/tls.h>
 #endif
 
-enum { STATE_MAX_HANDLERS = 256,
-       STATE_SLOTS_SIZE = 32768 };
+enum {
+    STATE_MAX_HANDLERS = 256,
+    STATE_SLOTS_SIZE = 32768,
 
-#define MAXPRINTDEPTH 1024L
+    MAX_VALUE_LEN = 1030,
+
+    MAXPRINTDEPTH = 1024,
+};
 
 typedef struct GAPState {
 #ifdef HPCGAP

--- a/src/io.c
+++ b/src/io.c
@@ -24,6 +24,7 @@
 #include <src/bool.h>
 #include <src/stringobj.h>
 #include <src/read.h>
+#include <src/scanner.h>
 
 #include <src/sysfiles.h>               /* file input/output */
 

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -234,7 +234,6 @@ typedef UInt            TypSymbolSet;
 /* TL: extern  UInt            ValueLen; */
 
 #define         SAFE_VALUE_SIZE 1024
-#define MAX_VALUE_LEN 1025
 
 /****************************************************************************
 **


### PR DESCRIPTION
Also move it from scanner.h to gapstate.h, which allows us to stop

The change to 1030 is apparently necessary to deal with some corner
cases in the floating point case, and was accidentally lost when we
merged HPC-GAP.

Perhaps @stevelinton has some additional remarks on this; he introduced the value 1030 in a commit dated 2011-03-31.