### PR TITLE
Remove threadExit from GAPState

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -2868,7 +2868,7 @@ void ThreadedInterpreter(void *funcargs) {
 
   TRY_READ {
     Obj init, exit;
-    if (sySetjmp(STATE(threadExit)))
+    if (sySetjmp(TLS(threadExit)))
       return;
     init = GVarOptFunction(&GVarTHREAD_INIT);
     if (init) CALL_0ARGS(init);

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -55,9 +55,6 @@ typedef struct GAPState {
 
     /* From read.c */
     syJmp_buf ReadJmpError;
-#if defined(HPCGAP)
-    syJmp_buf threadExit;
-#endif
     Obj       StackNams;
     UInt      ReadTop;
     UInt      ReadTilde;


### PR DESCRIPTION
This actually fixes a bug: We had both STATE(threadExit) and TLS(threadExit),
and used the former in one place, the latter in two other places.