### PR TITLE
Some more reader refactoring

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -420,7 +420,7 @@ void ReadCallVarAss (
             break;
         }
 #endif
-        nams = ELM_LIST(STATE(StackNams), countNams - nest);
+        nams = ELM_PLIST(STATE(StackNams), countNams - nest);
         indx = findValueInNams(nams, 1, LEN_PLIST(nams));
         if (indx != 0) {
             type = (nest == 0) ? 'l' : 'h';
@@ -1357,7 +1357,7 @@ ArgList ReadFuncArgList(
     Match( symbol, symbolstr, S_LOCAL|STATBEGIN|S_END|follow );
 
     // Special case for function(arg)
-    if ( narg == 1 && ! strcmp( "arg", CSTR_STRING( ELM_LIST(nams, narg) ) )) {
+    if ( narg == 1 && ! strcmp( "arg", CSTR_STRING( ELM_PLIST(nams, narg) ) )) {
         isvarg = 1;
     }
 

--- a/src/read.c
+++ b/src/read.c
@@ -154,29 +154,6 @@ static void MatchSemicolon(TypSymbolSet skipto)
 */
 
 
-/****************************************************************************
-**
-*F  ReadCallVarAss( <follow>, <mode> )  . . . . . . . . . . . read a variable
-**
-**  'ReadCallVarAss' reads  a variable.  In  case  of an  error it skips  all
-**  symbols up to one contained in  <follow>.  The <mode>  must be one of the
-**  following:
-**
-**  'i':        check if variable, record component, list entry is bound
-**  'r':        reference to a variable
-**  's':        assignment via ':='
-**  'u':        unbind a variable
-**  'x':        either 'r' or 's' depending on <Symbol>
-**
-**  <Ident> :=  a|b|..|z|A|B|..|Z { a|b|..|z|A|B|..|Z|0|..|9|_ }
-**
-**  <Var> := <Ident>
-**        |  <Var> '[' <Expr> [,<Expr>]* ']'
-**        |  <Var> '{' <Expr> '}'
-**        |  <Var> '.' <Ident>
-**        |  <Var> '(' [ <Expr> { ',' <Expr> } ] [':' [ <options> ]] ')'
-*/
-
 /* This function reads the options part at the end of a function call
    The syntax is
 
@@ -369,6 +346,29 @@ void ReadReferenceModifiers( TypSymbolSet follow )
     } /* end TRY_READ */
   }
 }
+
+/****************************************************************************
+**
+*F  ReadCallVarAss( <follow>, <mode> )  . . . . . . . . . . . read a variable
+**
+**  'ReadCallVarAss' reads  a variable.  In  case  of an  error it skips  all
+**  symbols up to one contained in  <follow>.  The <mode>  must be one of the
+**  following:
+**
+**  'i':        check if variable, record component, list entry is bound
+**  'r':        reference to a variable
+**  's':        assignment via ':='
+**  'u':        unbind a variable
+**  'x':        either 'r' or 's' depending on <Symbol>
+**
+**  <Ident> :=  a|b|..|z|A|B|..|Z { a|b|..|z|A|B|..|Z|0|..|9|_ }
+**
+**  <Var> := <Ident>
+**        |  <Var> '[' <Expr> [,<Expr>]* ']'
+**        |  <Var> '{' <Expr> '}'
+**        |  <Var> '.' <Ident>
+**        |  <Var> '(' [ <Expr> { ',' <Expr> } ] [':' [ <options> ]] ')'
+*/
 
 void ReadCallVarAss (
     TypSymbolSet        follow,

--- a/src/read.c
+++ b/src/read.c
@@ -1317,7 +1317,6 @@ ArgList ReadFuncArgList(
     narg = 0;
     nams = NEW_PLIST(T_PLIST, 0);
     SET_LEN_PLIST(nams, 0);
-    PushPlist( STATE(StackNams), nams );
     if ( STATE(Symbol) != symbol ) {
         goto start;
     }
@@ -1394,6 +1393,9 @@ static void ReadFuncExprBody(
     // remember the current variables in case of an error
     currLVars = STATE(CurrLVars);
     nrError = STATE(NrError);
+
+    // push the new local variables list
+    PushPlist(STATE(StackNams), args.nams);
 
     // begin interpreting the function expression (with 1 argument)
     TRY_READ {
@@ -1539,8 +1541,6 @@ void ReadFuncExprAbbrevSingle(TypSymbolSet follow)
     Obj nams = NEW_PLIST(T_PLIST, 1);
     SET_LEN_PLIST( nams, 0 );
     PushPlist(nams, MakeImmString(STATE(Value)));
-
-    PushPlist( STATE(StackNams), nams );
 
     ArgList args;
     args.narg = 1;

--- a/src/read.c
+++ b/src/read.c
@@ -148,6 +148,20 @@ static void MatchSemicolon(TypSymbolSet skipto)
           ";", skipto);
 }
 
+// Search the plist 'nams' for a string equal to STATE(Value) between and
+// including index 'start' and 'end' and return its index; return 0 if not
+// found.
+static UInt findValueInNams(Obj nams, UInt start, UInt end)
+{
+    for (UInt i = start; i <= end; i++) {
+        if (strcmp(CSTR_STRING(ELM_PLIST(nams, i)), STATE(Value)) == 0) {
+            return i;
+        }
+    }
+    // not found
+    return 0;
+}
+
 /****************************************************************************
 **
 *F * * * * * * * * * * read symbols and call interpreter  * * * * * * * * * *
@@ -1260,19 +1274,6 @@ typedef struct {
     Obj        locks;          /* locks of the function (HPC-GAP) */
 #endif
 } ArgList;
-
-// Search 'nams' for a string equal to STATE(Value) between (and including)
-// index 'start' and 'end' and return its index; return 0 if not found.
-static UInt findValueInNams(Obj nams, UInt start, UInt end)
-{
-    for (UInt i = start; i <= end; i++) {
-        if (strcmp(CSTR_STRING(ELM_LIST(nams, i)), STATE(Value)) == 0) {
-            return i;
-        }
-    }
-    // not found
-    return 0;
-}
 
 /****************************************************************************
 **


### PR DESCRIPTION
This moves the documentation comment for `ReadCallVarAss` to the right place; and moves up the definition of `findValueInNams`, so that we can use it inside `ReadCallVarAss`.