### PR TITLE
Use MODULE_STATE in more files

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -3374,9 +3374,6 @@ static Int InitLibrary (
     UInt gv;
     Obj cache;
 
-    /* allocate the statements and expressions stacks                      */
-    STATE(StackStat) = NewBag( T_BODY, 64*sizeof(Stat) );
-    STATE(StackExpr) = NewBag( T_BODY, 64*sizeof(Expr) );
 #ifdef HPCGAP
     FilenameCache = NewAtomicList(0);
 #else
@@ -3444,6 +3441,8 @@ static void InitModuleState(ModuleStateOffset offset)
     STATE(OffsBodyCount) = 0;
     STATE(LoopNesting) = 0;
     STATE(LoopStackCount) = 0;
+
+    /* allocate the statements and expressions stacks                      */
     STATE(StackStat) = NewBag( T_BODY, 64*sizeof(Stat) );
     STATE(StackExpr) = NewBag( T_BODY, 64*sizeof(Expr) );
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -57,20 +57,20 @@
 
 #include <src/hookintrprtr.h>
 
-static ModuleStateOffset funcsStateOffset;
+static ModuleStateOffset FuncsStateOffset;
 typedef struct {
     Int RecursionDepth;
     Obj ExecState;
-} funcsModuleState;
+} FuncsModuleState;
 
 void IncRecursionDepth(void)
 {
-    MODULE_STATE(funcs, RecursionDepth)++;
+    MODULE_STATE(Funcs, RecursionDepth)++;
 }
 
 void DecRecursionDepth(void)
 {
-    MODULE_STATE(funcs, RecursionDepth)--;
+    MODULE_STATE(Funcs, RecursionDepth)--;
     /* FIXME: According to a comment in the function
               RecursionDepthTrap below, RecursionDepth
               can become "slightly" negative. This
@@ -81,13 +81,13 @@ void DecRecursionDepth(void)
 
 Int GetRecursionDepth(void)
 {
-    return MODULE_STATE(funcs, RecursionDepth);
+    return MODULE_STATE(Funcs, RecursionDepth);
 }
 
 void SetRecursionDepth(Int depth)
 {
     GAP_ASSERT(depth >= 0);
-    MODULE_STATE(funcs, RecursionDepth) = depth;
+    MODULE_STATE(Funcs, RecursionDepth) = depth;
 }
 
 /****************************************************************************
@@ -1707,12 +1707,12 @@ void            ExecBegin ( Obj frame )
     /* remember the old execution state                                    */
     execState = NEW_PLIST(T_PLIST, 3);
     SET_LEN_PLIST(execState, 3);
-    SET_ELM_PLIST(execState, 1, MODULE_STATE(funcs, ExecState));
+    SET_ELM_PLIST(execState, 1, MODULE_STATE(Funcs, ExecState));
     SET_ELM_PLIST(execState, 2, STATE(CurrLVars));
     /* the 'CHANGED_BAG(STATE(CurrLVars))' is needed because it is delayed        */
     CHANGED_BAG( STATE(CurrLVars) );
     SET_ELM_PLIST(execState, 3, INTOBJ_INT((Int)STATE(CurrStat)));
-    MODULE_STATE(funcs, ExecState) = execState;
+    MODULE_STATE(Funcs, ExecState) = execState;
 
     /* set up new state                                                    */
     SWITCH_TO_OLD_LVARS( frame );
@@ -1731,9 +1731,9 @@ void            ExecEnd (
     }
 
     /* switch back to the old state                                    */
-    SET_BRK_CURR_STAT((Stat)INT_INTOBJ(ELM_PLIST(MODULE_STATE(funcs, ExecState), 3)));
-    SWITCH_TO_OLD_LVARS( ELM_PLIST(MODULE_STATE(funcs, ExecState), 2) );
-    MODULE_STATE(funcs, ExecState) = ELM_PLIST(MODULE_STATE(funcs, ExecState), 1);
+    SET_BRK_CURR_STAT((Stat)INT_INTOBJ(ELM_PLIST(MODULE_STATE(Funcs, ExecState), 3)));
+    SWITCH_TO_OLD_LVARS( ELM_PLIST(MODULE_STATE(Funcs, ExecState), 2) );
+    MODULE_STATE(Funcs, ExecState) = ELM_PLIST(MODULE_STATE(Funcs, ExecState), 1);
 }
 
 /****************************************************************************
@@ -1806,7 +1806,7 @@ static Int InitKernel (
 
 #if !defined(HPCGAP)
     /* make the global variable known to Gasman                            */
-    InitGlobalBag( &MODULE_STATE(funcs, ExecState), "src/funcs.c:ExecState" );
+    InitGlobalBag( &MODULE_STATE(Funcs, ExecState), "src/funcs.c:ExecState" );
 #endif
 
     /* Register the handler for our exported function                      */
@@ -1890,8 +1890,8 @@ static Int InitKernel (
 
 static void InitModuleState(ModuleStateOffset offset)
 {
-    MODULE_STATE(funcs, ExecState) = 0;
-    MODULE_STATE(funcs, RecursionDepth) = 0;
+    MODULE_STATE(Funcs, ExecState) = 0;
+    MODULE_STATE(Funcs, RecursionDepth) = 0;
 }
 
 /****************************************************************************
@@ -1915,6 +1915,6 @@ static StructInitInfo module = {
 
 StructInitInfo * InitInfoFuncs ( void )
 {
-    funcsStateOffset = RegisterModuleState(sizeof(funcsModuleState), InitModuleState, 0);
+    FuncsStateOffset = RegisterModuleState(sizeof(FuncsModuleState), InitModuleState, 0);
     return &module;
 }

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -57,7 +57,8 @@
 
 #include <src/hookintrprtr.h>
 
-static ModuleStateOffset FuncsStateOffset;
+static ModuleStateOffset FuncsStateOffset = -1;
+
 typedef struct {
     Int RecursionDepth;
     Obj ExecState;
@@ -65,12 +66,12 @@ typedef struct {
 
 void IncRecursionDepth(void)
 {
-    MODULE_STATE(Funcs, RecursionDepth)++;
+    MODULE_STATE(Funcs).RecursionDepth++;
 }
 
 void DecRecursionDepth(void)
 {
-    MODULE_STATE(Funcs, RecursionDepth)--;
+    MODULE_STATE(Funcs).RecursionDepth--;
     /* FIXME: According to a comment in the function
               RecursionDepthTrap below, RecursionDepth
               can become "slightly" negative. This
@@ -81,13 +82,13 @@ void DecRecursionDepth(void)
 
 Int GetRecursionDepth(void)
 {
-    return MODULE_STATE(Funcs, RecursionDepth);
+    return MODULE_STATE(Funcs).RecursionDepth;
 }
 
 void SetRecursionDepth(Int depth)
 {
     GAP_ASSERT(depth >= 0);
-    MODULE_STATE(Funcs, RecursionDepth) = depth;
+    MODULE_STATE(Funcs).RecursionDepth = depth;
 }
 
 /****************************************************************************
@@ -1707,12 +1708,12 @@ void            ExecBegin ( Obj frame )
     /* remember the old execution state                                    */
     execState = NEW_PLIST(T_PLIST, 3);
     SET_LEN_PLIST(execState, 3);
-    SET_ELM_PLIST(execState, 1, MODULE_STATE(Funcs, ExecState));
+    SET_ELM_PLIST(execState, 1, MODULE_STATE(Funcs).ExecState);
     SET_ELM_PLIST(execState, 2, STATE(CurrLVars));
     /* the 'CHANGED_BAG(STATE(CurrLVars))' is needed because it is delayed        */
     CHANGED_BAG( STATE(CurrLVars) );
     SET_ELM_PLIST(execState, 3, INTOBJ_INT((Int)STATE(CurrStat)));
-    MODULE_STATE(Funcs, ExecState) = execState;
+    MODULE_STATE(Funcs).ExecState = execState;
 
     /* set up new state                                                    */
     SWITCH_TO_OLD_LVARS( frame );
@@ -1731,9 +1732,9 @@ void            ExecEnd (
     }
 
     /* switch back to the old state                                    */
-    SET_BRK_CURR_STAT((Stat)INT_INTOBJ(ELM_PLIST(MODULE_STATE(Funcs, ExecState), 3)));
-    SWITCH_TO_OLD_LVARS( ELM_PLIST(MODULE_STATE(Funcs, ExecState), 2) );
-    MODULE_STATE(Funcs, ExecState) = ELM_PLIST(MODULE_STATE(Funcs, ExecState), 1);
+    SET_BRK_CURR_STAT((Stat)INT_INTOBJ(ELM_PLIST(MODULE_STATE(Funcs).ExecState, 3)));
+    SWITCH_TO_OLD_LVARS( ELM_PLIST(MODULE_STATE(Funcs).ExecState, 2) );
+    MODULE_STATE(Funcs).ExecState = ELM_PLIST(MODULE_STATE(Funcs).ExecState, 1);
 }
 
 /****************************************************************************
@@ -1806,7 +1807,7 @@ static Int InitKernel (
 
 #if !defined(HPCGAP)
     /* make the global variable known to Gasman                            */
-    InitGlobalBag( &MODULE_STATE(Funcs, ExecState), "src/funcs.c:ExecState" );
+    InitGlobalBag( &MODULE_STATE(Funcs).ExecState, "src/funcs.c:ExecState" );
 #endif
 
     /* Register the handler for our exported function                      */
@@ -1890,8 +1891,8 @@ static Int InitKernel (
 
 static void InitModuleState(ModuleStateOffset offset)
 {
-    MODULE_STATE(Funcs, ExecState) = 0;
-    MODULE_STATE(Funcs, RecursionDepth) = 0;
+    MODULE_STATE(Funcs).ExecState = 0;
+    MODULE_STATE(Funcs).RecursionDepth = 0;
 }
 
 /****************************************************************************

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -19,11 +19,6 @@
 
 #include <src/gapstate.h>
 
-void IncRecursionDepth(void);
-void DecRecursionDepth(void);
-Int GetRecursionDepth(void);
-void SetRecursionDepth(Int depth);
-
 /****************************************************************************
 **
 *F  MakeFunction(<fexp>)  . . . . . . . . . . . . . . . . . . make a function
@@ -42,7 +37,19 @@ extern Obj MakeFunction(Obj fexp);
 extern void ExecBegin(Obj frame);
 extern void ExecEnd(UInt error);
 
-/* TL: extern Int RecursionDepth; */
+
+/****************************************************************************
+**
+**  Functions for tracking the recursion depth, and detecting if it exceeds
+**  some threshold. This is used to abort recursion beyond a certain depth,
+**  to protect against stack overflows and the resulting crashes.
+*/
+
+void IncRecursionDepth(void);
+void DecRecursionDepth(void);
+Int GetRecursionDepth(void);
+void SetRecursionDepth(Int depth);
+
 extern UInt RecursionTrapInterval;
 extern void RecursionDepthTrap( void );
 
@@ -55,6 +62,16 @@ static inline void CheckRecursionBefore( void )
 }
 
 
+/****************************************************************************
+**
+*F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * *
+*/
+
+
+/****************************************************************************
+**
+*F  InitInfoFuncs() . . . . . . . . . . . . . . . . . table of init functions
+*/
 StructInitInfo * InitInfoFuncs ( void );
 
 #endif // GAP_FUNCS_H

--- a/src/gap.c
+++ b/src/gap.c
@@ -2831,24 +2831,14 @@ GVarDescriptor GVarTHREAD_INIT;
 GVarDescriptor GVarTHREAD_EXIT;
 
 void ThreadedInterpreter(void *funcargs) {
-  Obj tmp, func, body;
+  Obj tmp, func;
   int i;
 
-  /* intialize everything and begin an interpreter                       */
-  STATE(StackNams)   = NEW_PLIST( T_PLIST, 16 );
-  STATE(ReadTop)     = 0;
-  STATE(ReadTilde)   = 0;
-  STATE(CurrLHSGVar) = 0;
+  /* initialize everything and begin an interpreter                       */
   STATE(IntrCoding) = 0;
   STATE(IntrIgnoring) = 0;
   STATE(NrError) = 0;
   STATE(ThrownObject) = 0;
-  STATE(BottomLVars) = NewBag( T_HVARS, 3*sizeof(Obj) );
-  func = NewFunctionC( "bottom", 0, "", 0 );
-  FUNC_LVARS(STATE(BottomLVars)) = func;
-  body = NewBag( T_BODY, sizeof(BodyHeader) );
-  SET_BODY_FUNC( func, body );
-  STATE(CurrLVars) = STATE(BottomLVars);
 
   IntrBegin( STATE(BottomLVars) );
   tmp = KEPTALIVE(funcargs);
@@ -3269,10 +3259,6 @@ void InitializeGap (
     InitMsgsFuncBags( SyMsgsBags );
 #endif
 
-    STATE(StackNams)    = NEW_PLIST( T_PLIST, 16 );
-    STATE(ReadTop)      = 0;
-    STATE(ReadTilde)    = 0;
-    STATE(CurrLHSGVar)  = 0;
     STATE(IntrCoding)   = 0;
     STATE(IntrIgnoring) = 0;
     STATE(NrError)      = 0;

--- a/src/gapstate.c
+++ b/src/gapstate.c
@@ -35,9 +35,11 @@ Int RegisterModuleState(UInt size, ModuleConstructor constructor, ModuleDestruct
 {
     StateDescriptor * handler;
 
-    if (!constructor && !destructor)
-        return -1;
+    // if not at least one of the three arguments is non-zero, it doesn't make
+    // sense to call this function
+    assert(size || constructor || destructor);
 
+    // check that we have enough free space
     assert((STATE_SLOTS_SIZE - StateNextFreeOffset) >= size);
     assert(StateDescriptorCount < STATE_MAX_HANDLERS);
 

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -122,11 +122,6 @@ typedef struct GAPState {
 #endif
     UInt  CacheIndex;
 
-    /* From cyclotom.c */
-    Obj  ResultCyc;
-    Obj  LastECyc;
-    UInt LastNCyc;
-
     /* From permutat.c */
     Obj TmpPerm;
 

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -203,15 +203,21 @@ static inline GAPState * ActiveGAPState(void)
 
 #define STATE(x) (ActiveGAPState()->x)
 
-/* Access a module's registered state */
-#define MODULE_STATE(module, var) \
-    (((module ## ModuleState *)(&STATE(StateSlots)[module ## StateOffset]))->var)
-
 
 // Offset into StateSlots
 typedef Int ModuleStateOffset;
 typedef void (*ModuleConstructor)(ModuleStateOffset offset);
 typedef void (*ModuleDestructor)();
+
+static inline void *StateSlotsAtOffset(ModuleStateOffset offset)
+{
+    GAP_ASSERT(0 <= offset && offset < STATE_SLOTS_SIZE);
+    return &STATE(StateSlots)[offset];
+}
+
+/* Access a module's registered state */
+#define MODULE_STATE(module) \
+    (*(module ## ModuleState *)StateSlotsAtOffset(module ## StateOffset))
 
 /*
  * Register global state for a module.

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -26,8 +26,6 @@ enum {
     STATE_SLOTS_SIZE = 32768,
 
     MAX_VALUE_LEN = 1030,
-
-    MAXPRINTDEPTH = 1024,
 };
 
 typedef struct GAPState {
@@ -131,18 +129,8 @@ typedef struct GAPState {
     Int  ErrorLLevel;       // record where on the stack ErrorLVars is relative to the top, i.e. BaseShellContext
 
     /* From objects.c */
-    Obj PrintObjThis;
     Int PrintObjIndex;
     Int PrintObjDepth;
-#if defined(HPCGAP)
-    Obj   PrintObjThissObj;
-    Obj * PrintObjThiss;
-    Obj   PrintObjIndicesObj;
-    Int * PrintObjIndices;
-#else
-    Obj           PrintObjThiss[MAXPRINTDEPTH];
-    Int           PrintObjIndices[MAXPRINTDEPTH];
-#endif
 
     /* For objscoll*, objccoll* */
     Obj  SC_NW_STACK;

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -122,15 +122,6 @@ typedef struct GAPState {
 #endif
     UInt  CacheIndex;
 
-    /* From permutat.c */
-    Obj TmpPerm;
-
-    /* From trans.c */
-    Obj TmpTrans;
-
-    /* From pperm.c */
-    Obj TmpPPerm;
-
     /* From gap.c */
     Obj  ThrownObject;
     UInt UserHasQuit;

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -18,7 +18,6 @@
 #include <src/io.h>    // for TypInputFile and friends
 
 #if defined(HPCGAP)
-#include <src/hpc/serialize.h>
 #include <src/hpc/tls.h>
 #endif
 
@@ -143,11 +142,6 @@ typedef struct GAPState {
 #else
     Obj           PrintObjThiss[MAXPRINTDEPTH];
     Int           PrintObjIndices[MAXPRINTDEPTH];
-#endif
-
-#if defined(HPCGAP)
-    /* For serializer.c */
-    SerializationState Serialization;
 #endif
 
     /* For objscoll*, objccoll* */

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1753,10 +1753,6 @@ static Int InitLibrary (
     MakeBagPublic(TableGVars);
 #endif
 
-    /* Create the current namespace: */
-    STATE(CurrNamespace) = NEW_STRING(0);
-    SET_LEN_STRING(STATE(CurrNamespace),0);
-    
     /* fix C vars                                                          */
     PostRestore( module );
 
@@ -1787,6 +1783,14 @@ static Int CheckInit (
 }
 
 
+static void InitModuleState(ModuleStateOffset offset)
+{
+    /* Create the current namespace: */
+    STATE(CurrNamespace) = NEW_STRING(0);
+    SET_LEN_STRING(STATE(CurrNamespace), 0);
+}
+
+
 /****************************************************************************
 **
 *F  InitInfoGVars() . . . . . . . . . . . . . . . . . table of init functions
@@ -1808,5 +1812,6 @@ static StructInitInfo module = {
 
 StructInitInfo * InitInfoGVars ( void )
 {
+    RegisterModuleState(0, InitModuleState, 0);
     return &module;
 }

--- a/src/hpc/serialize.h
+++ b/src/hpc/serialize.h
@@ -1,14 +1,6 @@
 #ifndef GAP_SERIALIZE_H
 #define GAP_SERIALIZE_H
 
-typedef struct SerializationState {
-    Obj    obj;
-    UInt   index;
-    void * dispatcher;
-    Obj    registry;
-    Obj    stack;
-} SerializationState;
-
 typedef void (*SerializationFunction)(Obj obj);
 typedef Obj (*DeserializationFunction)(UInt tnum);
 

--- a/src/io.c
+++ b/src/io.c
@@ -1771,13 +1771,15 @@ static Int InitKernel (
     StructInitInfo *    module )
 {
     STATE(Input) = 0;
+    STATE(Output) = 0;
+    STATE(InputLog) = 0;
+    STATE(OutputLog) = 0;
+
     (void)OpenInput(  "*stdin*"  );
     STATE(Input)->echo = 1; /* echo stdin */
 
-    STATE(Output) = 0;
     (void)OpenOutput( "*stdout*" );
 
-    STATE(InputLog)  = 0;  STATE(OutputLog)  = 0;
 
 #ifdef HPCGAP
     /* Initialize default stream functions */

--- a/src/objscoll.c
+++ b/src/objscoll.c
@@ -761,22 +761,6 @@ static inline Obj NewPlist( UInt tnum, UInt len, UInt reserved )
     return obj;
 }
 
-/*
- * Setup the collector stacks etc.
- */
-static void SetupCollectorStacks(void)
-{
-    const UInt maxStackSize = 256;
-    STATE(SC_NW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    STATE(SC_LW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    STATE(SC_PW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    STATE(SC_EW_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    STATE(SC_GE_STACK) = NewPlist( T_PLIST_EMPTY, 0, maxStackSize );
-    STATE(SC_CW_VECTOR) = NEW_STRING( 0 );
-    STATE(SC_CW2_VECTOR) = NEW_STRING( 0 );
-    STATE(SC_MAX_STACK_SIZE) = maxStackSize;
-}
-
 
 /****************************************************************************
 **
@@ -816,10 +800,6 @@ static Int InitLibrary (
     ExportAsConstantGVar(SCP_CLASS);
     ExportAsConstantGVar(SCP_AVECTOR2);
 
-#ifndef HPCGAP
-    SetupCollectorStacks();
-#endif
-
     /* export collector number                                             */
     AssConstantGVar( GVarName( "8Bits_SingleCollector" ),
              INTOBJ_INT(C8Bits_SingleCollectorNo) );
@@ -844,9 +824,17 @@ static Int InitLibrary (
 
 static void InitModuleState(ModuleStateOffset offset)
 {
-#ifdef HPCGAP
-    SetupCollectorStacks();
-#else
+    const UInt maxStackSize = 256;
+    STATE(SC_NW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
+    STATE(SC_LW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
+    STATE(SC_PW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
+    STATE(SC_EW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
+    STATE(SC_GE_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
+    STATE(SC_CW_VECTOR) = NEW_STRING(0);
+    STATE(SC_CW2_VECTOR) = NEW_STRING(0);
+    STATE(SC_MAX_STACK_SIZE) = maxStackSize;
+
+#ifndef HPCGAP
     InitGlobalBag( &STATE(SC_NW_STACK), "SC_NW_STACK" );
     InitGlobalBag( &STATE(SC_LW_STACK), "SC_LW_STACK" );
     InitGlobalBag( &STATE(SC_PW_STACK), "SC_PW_STACK" );

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -105,6 +105,11 @@
 Obj             IdentityPerm;
 
 
+
+static ModuleStateOffset PermutatStateOffset = -1;
+
+typedef struct {
+
 /****************************************************************************
 **
 *V  TmpPerm . . . . . . . handle of the buffer bag of the permutation package
@@ -119,7 +124,12 @@ Obj             IdentityPerm;
 **  costs (particularly when starting new threads).
 **  Use the UseTmpPerm(<size>) utility function to ensure it is constructed!
 */
-#define  TmpPerm STATE(TmpPerm)
+Obj TmpPerm;
+
+} PermutatModuleState;
+
+#define  TmpPerm MODULE_STATE(Permutat).TmpPerm
+
 
 static void UseTmpPerm(UInt size)
 {
@@ -4757,14 +4767,19 @@ static Int InitLibrary (
     /* init filters and functions                                          */
     InitGVarFiltsFromTable( GVarFilts );
     InitGVarFuncsFromTable( GVarFuncs );
-    /* make the buffer bag                                                 */
-    TmpPerm = 0;
 
     /* make the identity permutation                                       */
     IdentityPerm = NEW_PERM2(0);
 
     /* return success                                                      */
     return 0;
+}
+
+
+static void InitModuleState(ModuleStateOffset offset)
+{
+    /* make the buffer bag                                                 */
+    TmpPerm = 0;
 }
 
 
@@ -4789,5 +4804,6 @@ static StructInitInfo module = {
 
 StructInitInfo * InitInfoPermutat ( void )
 {
+    PermutatStateOffset = RegisterModuleState(sizeof(PermutatModuleState), InitModuleState, 0);
     return &module;
 }

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -54,6 +54,11 @@
 
 Obj EmptyPartialPerm;
 
+
+static ModuleStateOffset PPermStateOffset = -1;
+
+typedef struct {
+
 /**************************************************************************
 *
 *V TmpPPerm . . . . . . . handle of the buffer bag of the pperm package
@@ -66,8 +71,12 @@ Obj EmptyPartialPerm;
 * The buffer is *not* guaranteed to have any particular value, routines
 * that require a zero-initialization need to do this at the start.
 */
-/* TL: Obj TmpPPerm; */
-#define TmpPPerm STATE(TmpPPerm)
+Obj TmpPPerm;
+
+} PPermModuleState;
+
+
+#define TmpPPerm MODULE_STATE(PPerm).TmpPPerm
 
 static inline void ResizeTmpPPerm(UInt len)
 {
@@ -6767,13 +6776,19 @@ static Int InitLibrary(StructInitInfo * module)
     /* init filters and functions                                          */
     InitGVarFuncsFromTable(GVarFuncs);
     InitGVarFiltsFromTable(GVarFilts);
-    TmpPPerm = 0;
 
     EmptyPartialPerm = NEW_PPERM2(0);
 
     /* return success                                                      */
     return 0;
 }
+
+
+static void InitModuleState(ModuleStateOffset offset)
+{
+    TmpPPerm = 0;
+}
+
 
 /**************************************************************************
  **
@@ -6796,5 +6811,6 @@ static StructInitInfo module = {
 
 StructInitInfo * InitInfoPPerm(void)
 {
+    PPermStateOffset = RegisterModuleState(sizeof(PPermModuleState), InitModuleState, 0);
     return &module;
 }

--- a/src/read.c
+++ b/src/read.c
@@ -3076,14 +3076,23 @@ Obj Call1ArgsInNewReader(Obj f,Obj a)
 static Int InitKernel (
     StructInitInfo *    module )
 {
-    STATE(ErrorLVars) = (UInt **)0;
-    STATE(CurrentGlobalForLoopDepth) = 0;
 #if !defined(HPCGAP)
     InitGlobalBag( &STATE(StackNams),      "src/read.c:StackNams"      );
 #endif
     InitCopyGVar( "GAPInfo", &GAPInfo);
     /* return success                                                      */
     return 0;
+}
+
+
+static void InitModuleState(ModuleStateOffset offset)
+{
+    STATE(ErrorLVars) = (UInt **)0;
+    STATE(StackNams) = NEW_PLIST(T_PLIST, 16);
+    STATE(ReadTop) = 0;
+    STATE(ReadTilde) = 0;
+    STATE(CurrLHSGVar) = 0;
+    STATE(CurrentGlobalForLoopDepth) = 0;
 }
 
 
@@ -3108,5 +3117,6 @@ static StructInitInfo module = {
 
 StructInitInfo * InitInfoRead ( void )
 {
+    RegisterModuleState(0, InitModuleState, 0);
     return &module;
 }

--- a/src/trans.c
+++ b/src/trans.c
@@ -82,8 +82,15 @@
 #define MIN(a, b) (a < b ? a : b)
 #define MAX(a, b) (a < b ? b : a)
 
+
+static ModuleStateOffset TransStateOffset = -1;
+
+typedef struct {
+    Obj TmpTrans;
+} TransModuleState;
+
 // TmpTrans is the same as TmpPerm
-#define TmpTrans STATE(TmpTrans)
+#define TmpTrans MODULE_STATE(Trans).TmpTrans
 
 /* mp this will become a ReadOnly object? */
 Obj IdentityTrans;
@@ -5735,7 +5742,6 @@ static Int InitLibrary(StructInitInfo * module)
     /* init filters and functions                                          */
     InitGVarFuncsFromTable(GVarFuncs);
     InitGVarFiltsFromTable(GVarFilts);
-    TmpTrans = 0;
     IdentityTrans = NEW_TRANS2(0);
 
     // We make the next transformation to allow testing of some parts of the
@@ -5750,6 +5756,11 @@ static Int InitLibrary(StructInitInfo * module)
 
     /* return success                                                      */
     return 0;
+}
+
+static void InitModuleState(ModuleStateOffset offset)
+{
+    TmpTrans = 0;
 }
 
 /****************************************************************************
@@ -5773,5 +5784,6 @@ static StructInitInfo module = {
 
 StructInitInfo * InitInfoTrans(void)
 {
+    TransStateOffset = RegisterModuleState(sizeof(TransModuleState), InitModuleState, 0);
     return &module;
 }

--- a/src/vars.c
+++ b/src/vars.c
@@ -2591,8 +2591,6 @@ static StructGVarFunc GVarFuncs [] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
-    STATE(CurrLVars) = (Bag) 0;
-
 #if !defined(HPCGAP)
     /* make 'CurrLVars' known to Gasman                                    */
     InitGlobalBag( &STATE(CurrLVars),   "src/vars.c:CurrLVars"   );
@@ -2775,20 +2773,26 @@ static Int PostRestore (
 static Int InitLibrary (
     StructInitInfo *    module )
 {
-    Obj tmpFunc, tmpBody;
-
-    STATE(BottomLVars) = NewBag( T_LVARS, 3*sizeof(Obj) );
-    tmpFunc = NewFunctionC( "bottom", 0, "", 0 );
-    FUNC_LVARS( STATE(BottomLVars) ) = tmpFunc;
-    PARENT_LVARS(STATE(BottomLVars)) = Fail;
-    tmpBody = NewBag( T_BODY, sizeof(BodyHeader) );
-    SET_BODY_FUNC( tmpFunc, tmpBody );
-
     /* init filters and functions                                          */
     InitGVarFuncsFromTable( GVarFuncs );
 
     /* return success                                                      */
     return PostRestore( module );
+}
+
+
+static void InitModuleState(ModuleStateOffset offset)
+{
+    Obj tmpFunc, tmpBody;
+
+    STATE(CurrLVars) = (Bag)0;
+
+    STATE(BottomLVars) = NewBag(T_HVARS, 3 * sizeof(Obj));
+    tmpFunc = NewFunctionC( "bottom", 0, "", 0 );
+    FUNC_LVARS( STATE(BottomLVars) ) = tmpFunc;
+    PARENT_LVARS(STATE(BottomLVars)) = Fail;
+    tmpBody = NewBag( T_BODY, sizeof(BodyHeader) );
+    SET_BODY_FUNC( tmpFunc, tmpBody );
 }
 
 
@@ -2813,5 +2817,6 @@ static StructInitInfo module = {
 
 StructInitInfo * InitInfoVars ( void )
 {
+    RegisterModuleState(0, InitModuleState, 0);
     return &module;
 }


### PR DESCRIPTION
This PR moves more members of `GAPState` into module states. In addition, it changes the way `MODULE_STATE` work. Instead of `MODULE_STATE(modulename, var)` one now writes `MODULE_STATE(modulename).var`. The main advantage is that it becomes possible to easily access the whole module state struct, which is exploited by `hpc/serialize.c`