### PR TITLE
Teach GAP executable to find itself (replaces PR #802)

### DIFF
--- a/doc/dev/updates.xml
+++ b/doc/dev/updates.xml
@@ -337,7 +337,7 @@ Version numbers must be adjusted in the following files:
 <C>NeedKernelVersion</C>
 </Item>
 <Item>
-<F>src/system.c</F>, see <C>SyKernelVersion</C> and <C>SyWindowsPath</C>
+<F>src/system.c</F>, see <C>SyKernelVersion</C>
 </Item>
 <Item>
 <F>doc/versiondata</F>, see <C>VERSIONNUMBER</C>,

--- a/src/gap.c
+++ b/src/gap.c
@@ -440,6 +440,8 @@ int realmain( int argc, char * argv[], char * environ[] )
   Obj                 func;                   /* function (compiler)     */
   Int4                crc;                    /* crc of file to compile  */
 
+  SetupGAPLocation(argc, argv);
+
   /* initialize everything and read init.g which runs the GAP session */
   InitializeGap( &argc, argv, environ );
   if (!STATE(UserHasQUIT)) {         /* maybe the user QUIT from the initial

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -78,6 +78,21 @@ extern Int SyLoadModule( const Char * name, InitInfoFunc * func );
 
 /****************************************************************************
 **
+*F * * * * * * * * * * finding location of executable * * * * * * * * * * * *
+*/
+
+// 'GAPExecLocation' is the path to the directory containing the running GAP
+// executable, terminated by a slash, or contains the empty string is it could
+// not be detect.
+extern char GAPExecLocation[GAP_PATH_MAX];
+
+// Fills in GAPExecLocation. Is called straight after 'main' starts.
+void SetupGAPLocation(int argc, char ** argv);
+
+
+/****************************************************************************
+**
+
 *F * * * * * * * * * * * * * * * window handler * * * * * * * * * * * * * * *
 */
 

--- a/src/system.c
+++ b/src/system.c
@@ -77,13 +77,6 @@ Int enableCodeCoverageAtStartup( Char **argv, void * dummy);
 const Char * SyKernelVersion = "4.dev";
 
 /****************************************************************************
- *V  SyWindowsPath  . . . . . . . . . . . . . . . . . default path for Windows
- ** do not edit the following line. Occurrences of `gap4dev'
- ** will be replaced by string matching by distribution wrapping scripts.
- */
-const Char * SyWindowsPath = "/cygdrive/c/gap4dev";
-
-/****************************************************************************
 **
 *F * * * * * * * * * * * command line settable options  * * * * * * * * * * *
 */
@@ -1847,9 +1840,7 @@ void InitSystem (
     
     SyInstallAnswerIntr();
 
-#ifdef SYS_IS_CYGWIN32
-    SySetGapRootPath(SyWindowsPath);
-#elif defined(SYS_DEFAULT_PATHS)
+#if defined(SYS_DEFAULT_PATHS)
     SySetGapRootPath( SYS_DEFAULT_PATHS );
 #else
     SySetInitialGapRootPaths();


### PR DESCRIPTION
This is a revised version of PR #802. I fixed the main commit of that PR (i.e.: fixed typo in its commit message, and addressed most of the comments I made on PR #802, plus some few extra issues, e.g. I added ` /proc` access for FreeBSD and DragonFly BSD). I rewrote `find_yourself` in a separate new commit. The old version contained at least one bug, and used unnecessary buffers, and was IMHO needlessly hard to read.