### PR TITLE
hpcgap: get rid of MakeLiteral

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -80,12 +80,7 @@ ErrorInner := function(options, message)
     JUMP_TO_CATCH("early error");
 end;
 
-#############################################################################
-##
-#F  MakeLiteral(<obj>) . . . . . . make the argument a literal and return it.
-##
 
-MakeLiteral := MakeImmutable;
 #############################################################################
 ##
 #F  Ignore( <arg> ) . . . . . . . . . . . . ignore but evaluate the arguments

--- a/src/read.c
+++ b/src/read.c
@@ -1638,16 +1638,18 @@ void ReadLiteral (
         ReadRecExpr( follow );
         break;
 
+#ifdef HPCGAP
     /* `Literal                                                            */
     case S_BACKQUOTE:
         Match( S_BACKQUOTE, "`", follow );
         TRY_READ {
-          IntrRefGVar(GVarName("MakeLiteral"));
+          IntrRefGVar(GVarName("MakeImmutable"));
           IntrFuncCallBegin();
         }
         ReadAtom( follow, 'r' );
         TRY_READ { IntrFuncCallEnd(1, 0, 1); }
         break;
+#endif
 
     /* <Function>                                                          */
     case S_FUNCTION:
@@ -2629,7 +2631,6 @@ UInt ReadStats (
 **  read the  first symbol of the  next  input.
 **
 */
-
 
 void RecreateStackNams( Obj context )
 {

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -84,7 +84,9 @@ enum SCANNER_SYMBOLS {
     S_HELP              = (1UL<<11)+7,
 
     S_REC               = (1UL<<12)+0,
+#ifdef HPCGAP
     S_BACKQUOTE         = (1UL<<12)+1,
+#endif
 
     S_FUNCTION          = (1UL<<13),
     S_LOCAL             = (1UL<<14),


### PR DESCRIPTION
Also disable all of the S_BACKQUOTE code for non-HPC-GAP (we already
disabled it, but did not #ifdef-out all the relevant code)

This used to be part of PR #1953.