### PR TITLE
Get rid of NEW_WORD_READ_WRITE

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -206,7 +206,6 @@ VoidFunc debug_func_pointers[] = {
     (VoidFunc)RANK_PPERM,
     (VoidFunc)RANK_TRANS,
     (VoidFunc)RegisterStatWithHook,
-    (VoidFunc)RESIZE_WORD,
     (VoidFunc)SET_BODY_FUNC,
     (VoidFunc)SET_CHAR_VALUE,
     (VoidFunc)SET_DEN_RAT,

--- a/src/objfgelm.h
+++ b/src/objfgelm.h
@@ -122,36 +122,22 @@
 */
 static inline Obj NewWord(Obj type, UInt npairs) {
   Obj word;
+#ifdef HPCGAP
+  ReadGuard(type);
+#endif
   word = NewBag(T_DATOBJ,2*sizeof(Obj)+npairs*BITS_WORDTYPE(type)/8L);
-  (ADDR_OBJ(word)[1] = INTOBJ_INT(npairs));
+  ADDR_OBJ(word)[1] = INTOBJ_INT(npairs);
   SetTypeDatObj(word, type);
+#ifdef HPCGAP
+  MakeBagReadOnly( word );
+#endif
   return word;
 }
-
-#define NEW_WORD_READ_WRITE(word, type, npairs) \
-  do { \
-    ReadGuard(type); \
-    (word) = NewWord((type), (npairs)); \
-  } while(0)
 
 #define NEW_WORD(word, type, npairs) \
   do { \
-    NEW_WORD_READ_WRITE(word, type, npairs); \
-    MakeBagReadOnly( word ); \
+    (word) = NewWord((type), (npairs)); \
   } while(0)
-
-
-/****************************************************************************
-**
-*F  RESIZE_WORD( <word>, <npairs> )
-*/
-static inline Obj RESIZE_WORD( Obj word, UInt npairs )
-{
-  WriteGuard(word);
-  ResizeBag( (word), 2*sizeof(Obj)+((npairs)*BITS_WORD((word))/8L));
-  (ADDR_OBJ((word))[1] = INTOBJ_INT((npairs)));
-  return word;
-}
 
 
 /****************************************************************************

--- a/src/objscoll-impl.h
+++ b/src/objscoll-impl.h
@@ -19,7 +19,7 @@ Obj WordVectorAndClear ( Obj type, Obj vv, Int num )
     expm = (1UL << ebits) - 1;
 
     /* construct a new object                                              */
-    NEW_WORD_READ_WRITE( obj, type, num );
+    NEW_WORD( obj, type, num );
 
     /* clear <vv>                                                          */
     ptr = (UIntN*)DATA_WORD(obj);
@@ -33,9 +33,8 @@ Obj WordVectorAndClear ( Obj type, Obj vv, Int num )
     }
 
     /* correct the size of <obj>                                           */
-    (void) RESIZE_WORD( obj, j );
-
-    MakeBagReadOnly( obj );
+    ResizeBag( obj, 2*sizeof(Obj) + j * BITS_WORD(obj)/8 );
+    ADDR_OBJ(obj)[1] = INTOBJ_INT(j);
 
     return obj;
 }


### PR DESCRIPTION
Just use NEW_WORD. Yes, this means we move the bag "too early" into the
read-only region; however, it is not world visible yet; plus, in many of the
places we already are using NEW_WORD, we are doing the same anyway.

This only affects HPC-GAP.

This used to be part of PR #1953.