### PR TITLE
Turn NAME_RNAM and NAME_OBJ_RNAM into functions

### DIFF
--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -565,7 +565,7 @@ void SerializeRecord(Obj obj)
     WriteImmediateObj(INTOBJ_INT(len));
     for (i = 1; i <= len; i++) {
         UInt rnam = GET_RNAM_PREC(obj, i);
-        Obj  rnams = ELM_PLIST(NamesRNam, rnam);
+        Obj  rnams = NAME_OBJ_RNAM(rnam);
         WriteByteBlock(rnams, sizeof(UInt), GET_LEN_STRING(rnams));
     }
     for (i = 1; i <= len; i++) {

--- a/src/records.c
+++ b/src/records.c
@@ -43,20 +43,18 @@
 #include <src/gaputils.h>
 
 
-/****************************************************************************
-**
-*F  NAME_RNAM(<rnam>) . . . . . . . . . . . . . . . .  name for a record name
-**
-**  'NAME_RNAM' returns the name (as a C string) for the record name <rnam>.
-**
-**  Note that 'NAME_RNAM' is a  macro, so do not call  it with arguments that
-**  have side effects.
-**
-**  'NAME_RNAM' is defined in the declaration part of this package as follows
-**
-#define NAME_RNAM(rnam) CSTR_STRING( ELM_PLIST( NamesRNam, rnam ) )
-*/
-Obj             NamesRNam;
+
+static Obj NamesRNam;
+
+inline const Char *NAME_RNAM(UInt rnam)
+{
+    return CSTR_STRING(ELM_PLIST(NamesRNam, rnam));
+}
+
+inline extern Obj NAME_OBJ_RNAM(UInt rnam)
+{
+    return ELM_PLIST(NamesRNam, rnam);
+}
 
 
 #ifdef HPCGAP
@@ -555,7 +553,7 @@ UInt            iscomplete_rnam (
     Char *              name,
     UInt                len )
 {
-    Char *              curr;
+    const Char *        curr;
     UInt                i, k;
     const UInt          countRNam = LEN_PLIST(NamesRNam);
 
@@ -571,8 +569,8 @@ UInt            completion_rnam (
     Char *              name,
     UInt                len )
 {
-    Char *              curr;
-    Char *              next;
+    const Char *        curr;
+    const Char *        next;
     UInt                i, k;
     const UInt          countRNam = LEN_PLIST(NamesRNam);
 

--- a/src/records.h
+++ b/src/records.h
@@ -19,19 +19,14 @@
 
 /****************************************************************************
 **
-*F  NAME_RNAM(<rnam>) . . . . . . . . . . .name for a record name as C string
-*F  NAME_OBJ_RNAM(<rnam>) . . . . . . . . .name for a record name as an Obj
+*F  NAME_RNAM(<rnam>) . . . . . . . . . .  name for a record name as C string
+*F  NAME_OBJ_RNAM(<rnam>) . . . . . . . . .  name for a record name as an Obj
 **
 **  'NAME_RNAM' returns the name (as a C string) for the record name <rnam>.
 **  'NAME_OBJ_RNAM' returns the name (as an Obj) for the record name <rnam>.
-**
-**  Note that 'NAME_RNAM' and 'NAME_OBJ_RNAM' are macros, so do not call them
-**  with arguments that have side effects.
 */
-#define NAME_RNAM(rnam) CSTR_STRING( ELM_PLIST( NamesRNam, rnam ) )
-#define NAME_OBJ_RNAM(rnam) ELM_PLIST( NamesRNam, rnam )
-
-extern  Obj             NamesRNam;
+extern const Char *NAME_RNAM(UInt rnam);
+extern Obj NAME_OBJ_RNAM(UInt rnam);
 
 
 /****************************************************************************


### PR DESCRIPTION
This means these functions are not inlined in several cases, but these are all not speed critical. The only places I found where it might be speed critical is inside `RNamName`, but that's inside of `records.c`, and thus sees the implementations of the two functions, and so the compiler actually still can inline them.

This used to be part of PR #1953.