### PR TITLE
hpcgap: allow (Fixed)AtomicList with no arguments

### DIFF
--- a/lib/hpc/thread1.g
+++ b/lib/hpc/thread1.g
@@ -26,10 +26,13 @@ BIND_GLOBAL("IsReadOnlyObj", RETURN_FALSE);
 
 BIND_GLOBAL("AtomicList", function(arg)
   local l, i;
-  if LEN_LIST(arg) = 0 or LEN_LIST(arg) > 2 then
+  if LEN_LIST(arg) > 2 then
     Error("Invalid AtomicList arguments");
   fi;
 
+  if LEN_LIST(arg) = 0 then
+    return [];
+  fi;
   if LEN_LIST(arg) = 1 and IS_LIST(arg[1]) then
     l := [];
     for i in [1..LEN_LIST(arg[1])] do
@@ -39,16 +42,10 @@ BIND_GLOBAL("AtomicList", function(arg)
     od;
     return l;
   fi;
-
   if LEN_LIST(arg) = 1 then
-    # For plists, we can't set a capacity
-    return [];
+    return EmptyPlist(arg[1]);
   else
-    l := [];
-    for i in [1..arg[1]] do
-        l[i] := arg[2];
-    od;
-    return l;
+    return LIST_WITH_IDENTICAL_ENTRIES(arg[1], arg[2]);
   fi;
 end);
 

--- a/src/code.c
+++ b/src/code.c
@@ -3378,7 +3378,7 @@ static Int InitLibrary (
     STATE(StackStat) = NewBag( T_BODY, 64*sizeof(Stat) );
     STATE(StackExpr) = NewBag( T_BODY, 64*sizeof(Expr) );
 #ifdef HPCGAP
-    FilenameCache = NewAtomicList(0);
+    FilenameCache = NewAtomicList(T_ALIST, 0);
 #else
     FilenameCache = NEW_PLIST(T_PLIST, 0);
 #endif
@@ -3387,7 +3387,7 @@ static Int InitLibrary (
     
     gv = GVarName("EAGER_FLOAT_LITERAL_CACHE");
 #ifdef HPCGAP
-    cache = NewAtomicList(1);
+    cache = NewAtomicList(T_ALIST, 1);
 #else
     cache = NEW_PLIST(T_PLIST+IMMUTABLE, 1000L);
     SET_LEN_PLIST(cache,0);

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1235,7 +1235,7 @@ Obj             EvalFloatExprLazy (
       cache = FLOAT_LITERAL_CACHE;
 #ifdef HPCGAP
       if (!cache) {
-          cache = NewAtomicList(ix);
+          cache = NewAtomicList(T_ALIST, ix);
           AssGVar(GVAR_FLOAT_LITERAL_CACHE, cache);
       }
       else

--- a/src/hpc/aobjects.h
+++ b/src/hpc/aobjects.h
@@ -17,19 +17,21 @@ Obj SetARecordField(Obj record, UInt field, Obj obj);
 Obj GetARecordField(Obj record, UInt field);
 Obj ElmARecord(Obj record, UInt rnam);
 void AssARecord(Obj record, UInt rnam, Obj value);
+void UnbARecord(Obj record, UInt rnam);
+
 void AssTLRecord(Obj record, UInt field, Obj obj);
 Obj GetTLRecordField(Obj record, UInt field);
 Obj FromAtomicRecord(Obj record);
 void SetTLDefault(Obj record, UInt rnam, Obj value);
 void SetTLConstructor(Obj record, UInt rnam, Obj func);
-Obj NewAtomicList(UInt length);
+
+Obj NewAtomicList(UInt tnum, UInt capacity);
 Obj FromAtomicList(Obj list);
 UInt AddAList(Obj list, Obj obj);
 void AssAList(Obj list, Int pos, Obj obj);
 Obj ElmAList(Obj list, Int pos);
 Obj Elm0AList(Obj list, Int pos);
 Obj LengthAList(Obj list);
-void UnbARecord(Obj record, UInt rnam);
 
 void InitAObjectsState();
 void DestroyAObjectsState();

--- a/tst/testinstall/atomic_list.tst
+++ b/tst/testinstall/atomic_list.tst
@@ -34,7 +34,7 @@ gap> EqualLists := function(l1, l2)
 >  return true;
 > end;;
 
-# variable sized list
+# variable sized atomic list
 gap> l:=AtomicList([1,2,3]);
 [ 1, 2, 3 ]
 gap> Length(l);
@@ -49,7 +49,11 @@ gap> l[4] := 23;
 23
 gap> l;
 [ 42, 2, 3, 23 ]
-gap> a := FixedAtomicList(5);;
+gap> EqualLists(AtomicList(), []);
+true
+gap> EqualLists(AtomicList(0), []);
+true
+gap> a := AtomicList(5);;
 gap> EqualLists(a, []);
 true
 gap> a[2] := 7;
@@ -119,7 +123,7 @@ false
 gap> EqualLists(a, []);
 true
 
-# fixed sized list
+# fixed sized atomic list
 gap> l:=FixedAtomicList([1,2,3]);
 [ 1, 2, 3 ]
 gap> Length(l);
@@ -130,6 +134,10 @@ gap> l[1]; l[2]; l[3];
 3
 gap> l[1] := 42;; l;
 [ 42, 2, 3 ]
+gap> EqualLists(FixedAtomicList(), []);
+true
+gap> EqualLists(FixedAtomicList(0), []);
+true
 gap> a := FixedAtomicList(5);;
 gap> EqualLists(a, []);
 true


### PR DESCRIPTION
Also allow AtomicList(0) and FixedAtomicList(0). Both do the same as
AtomicList([]). Moreover, reduce code duplication for creating atomic lists.