### PR TITLE
Add method for Rat with filter IsRat, document, and test

### DIFF
--- a/lib/arith.gd
+++ b/lib/arith.gd
@@ -1910,6 +1910,7 @@ DeclareAttribute( "Int", IsObject );
 ##  <M>\ldots</M>, <C>'9'</C> and <C>'-'</C> (at the first position),
 ##  <C>'/'</C> and the decimal dot <C>'.'</C> then <A>rat</A> is the rational
 ##  described by this string.
+##  If <A>elm</A> is a rational number, then <C>Rat</C> returns <A>elm</A>.
 ##  The operation <Ref Func="String"/> can be used to compute a string for
 ##  rational numbers, in fact for all cyclotomics.
 ##  <P/>

--- a/lib/rational.gi
+++ b/lib/rational.gi
@@ -445,6 +445,9 @@ InstallMethod( PadicValuation,
     return -i;
   end );
 
+# If someone tries to convert a rational into
+# a rational, just return the number.
+InstallMethod( Rat, [ IsRat ], IdFunc );
 
 InstallMethod( ViewString, "for rationals", [IsRat], function(r)
   return Concatenation(ViewString(NumeratorRat(r)), "/\>\<",

--- a/tst/testinstall/rationals.tst
+++ b/tst/testinstall/rationals.tst
@@ -1,0 +1,21 @@
+#
+gap> NumeratorRat(1/2);
+1
+gap> DenominatorRat(1/2);
+2
+gap> Rat(1/2) = 1/2;
+true
+gap> Rat(1) = 1;
+true
+gap> Rat(0.5) = 1/2;
+true
+gap> Rat("1/2");
+1/2
+gap> Rat("0.565");
+113/200
+gap> Rat("3-5");
+fail
+gap> Rat(3.7e-1);                                                  
+37/100
+
+#


### PR DESCRIPTION
There previously wasn't a method that would just return the argument if `Rat` was called with a rational, which felt a bit odd. This PR adds this method, documents that its there, and adds some small amount of tests for rationals.