### PR TITLE
Compare tty identity using fstat, not ttyname (and remove one embarrassing nonsense usage of ttyname)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -541,7 +541,7 @@ AS_IF([test "x$ac_cv_search_openpty" = xno],[
 
 dnl check for input/output functions
 AC_CHECK_HEADERS([signal.h])
-AC_CHECK_FUNCS([ttyname select])
+AC_CHECK_FUNCS([select])
 
 dnl various functions to deal with child processes
 AC_HEADER_SYS_WAIT

--- a/src/iostream.c
+++ b/src/iostream.c
@@ -211,7 +211,6 @@ static UInt OpenPty(int * master, int * slave)
         goto error;
     }
 
-    ttyname = ;
     *slave = open(ptsname(*master), O_RDWR, 0);
     if (*slave < 0) {
         Pr("OpenPty: opening slave tty failed\n", 0L, 0L);


### PR DESCRIPTION
On many (most? all?) POSIX compliant systems, `strcmp( ttyname(fileno(stdin)), ttyname(fileno(stderr)) )` will always return 0, as `ttyname` returns a pointer to a fixed buffer, so we
end up always comparing a string against itself.

Instead, use `fstat` to compare whether the stdin/stdout/stderr reference the same terminals or not: the POSIX standard guarantees that st_dev and st_ino uniquely identify any device.

Also add some comments that explain what is going on in that code in the first place.

Note that this also drops a configure check for `ttyname`, as I think this is available on all systems we support. If not, we can add it back, but then use it more fine-grained -- previously, we completely failed to initialize `syBuf[0]` to `syBuf[3]` if `ttyname` was missing, so I am guessing GAP was broken on such systems anyway.

Also note that we are now always using `fstat`, and in one other place we use `fstat`, there is a comment saying "fstat seems completely broken under CYGWIN", added by @frankluebeck  in 2002. But I am not sure why exactly, resp. what about it is broken. I am hoping that even if it is broken in some way, it won't affect us here... AppVeyor will tell us, I guess.

Fixes #998