### PR TITLE
Make GAP_KERNEL_* into macros

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -847,13 +847,15 @@ extern void SyAbortBags(const Char * msg) NORETURN;
 ** functionality is added. The major version should be incremented when
 ** a backwards-incompatible change is made.
 **
+** The kernel version is a macro so it can be used by packages
+** to optionally compile support for new functionality.
+**
 */
 
-enum {
-    GAP_KERNEL_MAJOR_VERSION = 1,
-    GAP_KERNEL_MINOR_VERSION = 1,
-    GAP_KERNEL_API_VERSION = GAP_KERNEL_MAJOR_VERSION * 1000 + GAP_KERNEL_MINOR_VERSION
-};
+#define GAP_KERNEL_MAJOR_VERSION 1
+#define GAP_KERNEL_MINOR_VERSION 1
+#define GAP_KERNEL_API_VERSION                                               \
+    ((GAP_KERNEL_MAJOR_VERSION)*1000 + (GAP_KERNEL_MINOR_VERSION))
 
 enum {
     /** builtin module */


### PR DESCRIPTION
This makes the `GAP_KERNEL` enums into macros, so packages can test them.

We should also remember to increase these whenever we break a kernel interface (I will try to start reminding people to do so).