### PR TITLE
Fix crash when exiting HPC-GAP

### DIFF
--- a/src/vars.c
+++ b/src/vars.c
@@ -2785,14 +2785,14 @@ static void InitModuleState(ModuleStateOffset offset)
 {
     Obj tmpFunc, tmpBody;
 
-    STATE(CurrLVars) = (Bag)0;
-
     STATE(BottomLVars) = NewBag(T_HVARS, 3 * sizeof(Obj));
     tmpFunc = NewFunctionC( "bottom", 0, "", 0 );
     FUNC_LVARS( STATE(BottomLVars) ) = tmpFunc;
     PARENT_LVARS(STATE(BottomLVars)) = Fail;
     tmpBody = NewBag( T_BODY, sizeof(BodyHeader) );
     SET_BODY_FUNC( tmpFunc, tmpBody );
+
+    STATE(CurrLVars) = STATE(BottomLVars);
 }
 
 


### PR DESCRIPTION
... by initializing STATE(CurrLVars) to STATE(BottomLVars)

This fixes a regression introduced by me in e51e35d0c73886d1bfc7e86acbd537ac56a8c153
