### PR TITLE
Change blockmat[i][j]:=k to produce an error

### DIFF
--- a/lib/matblock.gi
+++ b/lib/matblock.gi
@@ -164,7 +164,7 @@ InstallMethod( \[\],
       fi;
     od;
 
-    return row;
+    return MakeImmutable(row);
     end );
 
 #############################################################################

--- a/tst/testinstall/matblock.tst
+++ b/tst/testinstall/matblock.tst
@@ -33,6 +33,10 @@ gap> Length( z );  DimensionsMat( z );
 [ 6, 6 ]
 gap> m1[3];
 [ 0, 0, 0, 1, 0, 0, 0, 0 ]
+gap> m1[3][4] := 4;
+Error, Lists Assignment: <list> must be a mutable list
+gap> m1[3];
+[ 0, 0, 0, 1, 0, 0, 0, 0 ]
 gap> z[2];
 [ 0, 0, 0, 0, 0, 0 ]
 gap> m2 = m3;


### PR DESCRIPTION
Previously, this was silently accepted, but did not modify the (immutable!)
block matrix. An explicit error is better than a silent failure in this case.