### PR TITLE
Get rid of FN_IS_EMPTY

### DIFF
--- a/dev/lists.txt
+++ b/dev/lists.txt
@@ -424,7 +424,6 @@ check if filter <fnum> is known for <list>
 
 filter numbers
 --------------
-FN_IS_EMPTY:            empty list
 FN_IS_SSORT:            strictly sorted
 FN_IS_NSORT:            not strictly sorted
 FN_IS_DENSE:            dense

--- a/src/blister.c
+++ b/src/blister.c
@@ -2285,7 +2285,6 @@ static Int ClearFiltsTab [] = {
 static Int HasFiltTab [] = {
 
     /* mutable boolean list                                                */
-    T_BLIST,                    FN_IS_EMPTY,    0,
     T_BLIST,                    FN_IS_DENSE,    1,
     T_BLIST,                    FN_IS_NDENSE,   0,
     T_BLIST,                    FN_IS_HOMOG,    1,
@@ -2295,7 +2294,6 @@ static Int HasFiltTab [] = {
     T_BLIST,                    FN_IS_NSORT,    0,
 
     /* nsort mutable boolean list                                          */
-    T_BLIST_NSORT,              FN_IS_EMPTY,    0,
     T_BLIST_NSORT,              FN_IS_DENSE,    1,
     T_BLIST_NSORT,              FN_IS_NDENSE,   0,
     T_BLIST_NSORT,              FN_IS_HOMOG,    1,
@@ -2305,7 +2303,6 @@ static Int HasFiltTab [] = {
     T_BLIST_NSORT,              FN_IS_NSORT,    1,
 
     /* ssort mutable boolean list                                          */
-    T_BLIST_SSORT,              FN_IS_EMPTY,    0,
     T_BLIST_SSORT,              FN_IS_DENSE,    1,
     T_BLIST_SSORT,              FN_IS_NDENSE,   0,
     T_BLIST_SSORT,              FN_IS_HOMOG,    1,
@@ -2325,7 +2322,6 @@ static Int HasFiltTab [] = {
 static Int SetFiltTab [] = {
 
     /* mutable boolean list                                                */
-    T_BLIST,                    FN_IS_EMPTY,    T_BLIST_SSORT,
     T_BLIST,                    FN_IS_DENSE,    T_BLIST,
     T_BLIST,                    FN_IS_NDENSE,   -1,
     T_BLIST,                    FN_IS_HOMOG,    T_BLIST,
@@ -2335,7 +2331,6 @@ static Int SetFiltTab [] = {
     T_BLIST,                    FN_IS_NSORT,    T_BLIST_NSORT,
 
     /* nsort mutable boolean list                                          */
-    T_BLIST_NSORT,              FN_IS_EMPTY,    -1,
     T_BLIST_NSORT,              FN_IS_DENSE,    T_BLIST_NSORT,
     T_BLIST_NSORT,              FN_IS_NDENSE,   -1,
     T_BLIST_NSORT,              FN_IS_HOMOG,    T_BLIST_NSORT,
@@ -2345,7 +2340,6 @@ static Int SetFiltTab [] = {
     T_BLIST_NSORT,              FN_IS_NSORT,    T_BLIST_NSORT,
 
     /* ssort mutable boolean list                                          */
-    T_BLIST_SSORT,              FN_IS_EMPTY,    T_BLIST_SSORT,
     T_BLIST_SSORT,              FN_IS_DENSE,    T_BLIST_SSORT,
     T_BLIST_SSORT,              FN_IS_NDENSE,   -1,
     T_BLIST_SSORT,              FN_IS_HOMOG,    T_BLIST_SSORT,
@@ -2366,7 +2360,6 @@ static Int SetFiltTab [] = {
 static Int ResetFiltTab [] = {
 
     /* mutable boolean list                                                */
-    T_BLIST,                    FN_IS_EMPTY,    T_BLIST,
     T_BLIST,                    FN_IS_DENSE,    T_BLIST,
     T_BLIST,                    FN_IS_NDENSE,   T_BLIST,
     T_BLIST,                    FN_IS_HOMOG,    T_BLIST,
@@ -2376,7 +2369,6 @@ static Int ResetFiltTab [] = {
     T_BLIST,                    FN_IS_NSORT,    T_BLIST,
 
     /* nsort mutable boolean list                                          */
-    T_BLIST_NSORT,              FN_IS_EMPTY,    T_BLIST_NSORT,
     T_BLIST_NSORT,              FN_IS_DENSE,    T_BLIST_NSORT,
     T_BLIST_NSORT,              FN_IS_NDENSE,   T_BLIST_NSORT,
     T_BLIST_NSORT,              FN_IS_HOMOG,    T_BLIST_NSORT,
@@ -2386,7 +2378,6 @@ static Int ResetFiltTab [] = {
     T_BLIST_NSORT,              FN_IS_NSORT,    T_BLIST,
 
     /* ssort mutable boolean list                                          */
-    T_BLIST_SSORT,              FN_IS_EMPTY,    T_BLIST_SSORT,
     T_BLIST_SSORT,              FN_IS_DENSE,    T_BLIST_SSORT,
     T_BLIST_SSORT,              FN_IS_NDENSE,   T_BLIST_SSORT,
     T_BLIST_SSORT,              FN_IS_HOMOG,    T_BLIST_SSORT,

--- a/src/gap.h
+++ b/src/gap.h
@@ -238,9 +238,6 @@ extern UInt SystemErrorCode;
 */
 
 enum {
-    /** filter number for `IsEmpty' */
-    FN_IS_EMPTY,
-
     /** filter number for `IsSSortedList' */
     FN_IS_SSORT,
 

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1241,7 +1241,7 @@ Obj             FuncOnTuples (
     }
 
     /* special case for the empty list */
-    if ( HAS_FILT_LIST( tuple, FN_IS_EMPTY )) {
+    if ( LEN_LIST(tuple) == 0 ) {
       if (IS_MUTABLE_OBJ(tuple)) {
         img = NEW_PLIST(T_PLIST_EMPTY, 0);
         SET_LEN_PLIST(img,0);
@@ -1313,10 +1313,10 @@ Obj             FuncOnSets (
     }
 
     /* special case for the empty list */
-    if ( HAS_FILT_LIST( set, FN_IS_EMPTY )) {
+    if ( LEN_LIST(set) == 0 ) {
       if (IS_MUTABLE_OBJ(set)) {
         img = NEW_PLIST(T_PLIST_EMPTY, 0);
-        SET_LEN_PLIST(img,0);
+        SET_LEN_PLIST(img, 0);
         return img;
       } else {
         return set;

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -381,7 +381,7 @@ Obj             ZeroListDefault (
     /* Now adjust the result TNUM info */
 
     if (len == 0)
-      SET_FILT_LIST( res, FN_IS_EMPTY );
+      RetypeBag(res, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
     else if (IS_PLIST( list ))
       {
         if (TNUM_OBJ(list) == T_PLIST_FFE ||
@@ -447,7 +447,7 @@ Obj             ZeroListMutDefault (
     /* Now adjust the result TNUM info */
 
     if (len == 0)
-      SET_FILT_LIST( res, FN_IS_EMPTY );
+      RetypeBag(res, T_PLIST_EMPTY);
     else if (IS_PLIST( list ))
       {
         if (TNUM_OBJ(list) == T_PLIST_FFE ||
@@ -545,9 +545,8 @@ Obj AInvMutListDefault (
     }
 
     /* Now adjust the result TNUM info */
-
     if (len == 0)
-      SET_FILT_LIST( res, FN_IS_EMPTY );
+      RetypeBag(res, T_PLIST_EMPTY);
     else if (IS_PLIST( list ))
       {
         if (TNUM_OBJ(list) == T_PLIST_FFE ||
@@ -604,9 +603,8 @@ Obj AInvListDefault (
     }
 
     /* Now adjust the result TNUM info */
-
     if (len == 0)
-      SET_FILT_LIST( res, FN_IS_EMPTY );
+      RetypeBag(res, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
     else if (IS_PLIST( list ))
       {
         if (TNUM_OBJ(list) == T_PLIST_FFE ||
@@ -697,9 +695,8 @@ Obj             DiffSclList (
     }
 
     /* Now adjust the result TNUM info */
-
     if (len == 0)
-      SET_FILT_LIST( listD, FN_IS_EMPTY );
+      RetypeBag(listD, IS_MUTABLE_OBJ(listD) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
     else if (IS_PLIST( listR ))
       {
          if (HAS_FILT_LIST(listR, FN_IS_DENSE))
@@ -740,9 +737,8 @@ Obj             DiffListScl (
     }
 
     /* Now adjust the result TNUM info */
-
     if (len == 0)
-      SET_FILT_LIST( listD, FN_IS_EMPTY );
+      RetypeBag(listD, IS_MUTABLE_OBJ(listD) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
     else if (IS_PLIST( listL ))
       {
          if (HAS_FILT_LIST(listL, FN_IS_DENSE))
@@ -826,7 +822,7 @@ Obj             DiffListList (
        can say here with total reliability */
 
     if (lenD == 0)
-      SET_FILT_LIST( listD, FN_IS_EMPTY );
+      RetypeBag(listD, IS_MUTABLE_OBJ(listD) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
     else if (IS_PLIST( listR ) && IS_PLIST(listL) &&
              HAS_FILT_LIST(listR, FN_IS_DENSE) &&
              HAS_FILT_LIST(listL, FN_IS_DENSE))
@@ -917,7 +913,7 @@ Obj             ProdSclList (
           }
     }
     if (len == 0)
-      SET_FILT_LIST( listP, FN_IS_EMPTY );
+      RetypeBag(listP, IS_MUTABLE_OBJ(listP) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
     else if (IS_PLIST( listR ))
       {
          if (HAS_FILT_LIST(listR, FN_IS_DENSE))
@@ -957,7 +953,7 @@ Obj             ProdListScl (
     }
 
     if (len == 0)
-      SET_FILT_LIST( listP, FN_IS_EMPTY );
+      RetypeBag(listP, IS_MUTABLE_OBJ(listP) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
     else if (IS_PLIST( listL ))
       {
          if (HAS_FILT_LIST(listL, FN_IS_DENSE))

--- a/src/lists.c
+++ b/src/lists.c
@@ -2747,12 +2747,14 @@ static Int CheckInit (
     Int         j;              /* loop variable                           */
     Int         success = 1;
 
-    Int         fnums[] = { FN_IS_EMPTY, FN_IS_DENSE,
-                            FN_IS_NDENSE, FN_IS_HOMOG, FN_IS_NHOMOG,
-                            FN_IS_TABLE, FN_IS_SSORT, FN_IS_NSORT };
-    const Char *fnams[] = { "empty", "dense", "ndense",
-                            "homog", "nhomog", "table", "ssort",
-                            "nsort" };
+    Int         fnums[] = { FN_IS_DENSE, FN_IS_NDENSE,
+                            FN_IS_HOMOG, FN_IS_NHOMOG,
+                            FN_IS_TABLE,
+                            FN_IS_SSORT, FN_IS_NSORT };
+    const Char *fnams[] = { "dense", "ndense",
+                            "homog", "nhomog",
+                            "table",
+                            "ssort", "nsort" };
 
 
     /* fix unknown list types                                              */
@@ -2882,7 +2884,7 @@ static Int CheckInit (
             }
         }
 
-        if ( HasFiltListTNums[i][FN_IS_EMPTY] ) {
+        if ( i == T_PLIST_EMPTY || i == T_PLIST_EMPTY+IMMUTABLE ) {
             if ( ! HasFiltListTNums[i][FN_IS_DENSE] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ empty -> dense ] missing\n",

--- a/src/plist.c
+++ b/src/plist.c
@@ -260,7 +260,7 @@ Int KTNumPlist (
 
     /* special case for empty list                                         */
     if ( lenList == 0 ) {
-        SET_FILT_LIST( list, FN_IS_EMPTY );
+        RetypeBag(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
         res = TNUM_OBJ(list);
 	if (famfirst != (Obj *) 0)
 	  *famfirst = (Obj) 0;
@@ -1655,7 +1655,7 @@ void UnbPlist (
         while ( 1 <= pos && ELM_PLIST( list, pos ) == 0 ) { pos--; }
         SET_LEN_PLIST( list, pos );
 	if (LEN_PLIST( list) == 0)
-	  SET_FILT_LIST(list, FN_IS_EMPTY);
+	  RetypeBag(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
     }
 }
 
@@ -2150,7 +2150,7 @@ Int             IsDensePlist (
 
     /* special case for empty list                                         */
     if ( lenList == 0 ) {
-        SET_FILT_LIST( list, FN_IS_EMPTY );
+        RetypeBag(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
         return 1L;
     }
 
@@ -2231,7 +2231,7 @@ Int             IsSSortPlist (
 
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
-        SET_FILT_LIST( list, FN_IS_EMPTY );
+        RetypeBag(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
         return 2L;
     }
 
@@ -2318,7 +2318,7 @@ Int             IsSSortPlistDense (
 
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
-        SET_FILT_LIST( list, FN_IS_EMPTY );
+        RetypeBag(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
         return 2L;
     }
 
@@ -2386,7 +2386,7 @@ Int             IsSSortPlistHom (
 
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
-        SET_FILT_LIST( list, FN_IS_EMPTY );
+        RetypeBag(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
         return 2L;
     }
 
@@ -2965,7 +2965,6 @@ static Int ClearFiltsTab [] = {
 static Int HasFiltTab [] = {
 
     // plain lists
-    T_PLIST,                      FN_IS_EMPTY,    0,
     T_PLIST,                      FN_IS_DENSE,    0,
     T_PLIST,                      FN_IS_NDENSE,   0,
     T_PLIST,                      FN_IS_HOMOG,    0,
@@ -2976,7 +2975,6 @@ static Int HasFiltTab [] = {
     T_PLIST,                      FN_IS_NSORT,    0,
 
     // empty list
-    T_PLIST_EMPTY,                FN_IS_EMPTY,    1,
     T_PLIST_EMPTY,                FN_IS_DENSE,    1,
     T_PLIST_EMPTY,                FN_IS_NDENSE,   0,
     T_PLIST_EMPTY,                FN_IS_HOMOG,    1,
@@ -2987,7 +2985,6 @@ static Int HasFiltTab [] = {
     T_PLIST_EMPTY,                FN_IS_NSORT,    0,
 
     // dense list
-    T_PLIST_DENSE,                FN_IS_EMPTY,    0,
     T_PLIST_DENSE,                FN_IS_DENSE,    1,
     T_PLIST_DENSE,                FN_IS_NDENSE,   0,
     T_PLIST_DENSE,                FN_IS_HOMOG,    0,
@@ -2998,7 +2995,6 @@ static Int HasFiltTab [] = {
     T_PLIST_DENSE,                FN_IS_NSORT,    0,
 
     // dense list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM,           FN_IS_EMPTY,    0,
     T_PLIST_DENSE_NHOM,           FN_IS_DENSE,    1,
     T_PLIST_DENSE_NHOM,           FN_IS_NDENSE,   0,
     T_PLIST_DENSE_NHOM,           FN_IS_HOMOG,    0,
@@ -3009,7 +3005,6 @@ static Int HasFiltTab [] = {
     T_PLIST_DENSE_NHOM,           FN_IS_NSORT,    0,
 
     // dense ssorted list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM_SSORT,      FN_IS_EMPTY,    0,
     T_PLIST_DENSE_NHOM_SSORT,      FN_IS_DENSE,    1,
     T_PLIST_DENSE_NHOM_SSORT,      FN_IS_NDENSE,   0,
     T_PLIST_DENSE_NHOM_SSORT,      FN_IS_HOMOG,    0,
@@ -3020,7 +3015,6 @@ static Int HasFiltTab [] = {
     T_PLIST_DENSE_NHOM_SSORT,      FN_IS_NSORT,    0,
 
     // dense nsorted list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM_NSORT,           FN_IS_EMPTY,    0,
     T_PLIST_DENSE_NHOM_NSORT,           FN_IS_DENSE,    1,
     T_PLIST_DENSE_NHOM_NSORT,           FN_IS_NDENSE,   0,
     T_PLIST_DENSE_NHOM_NSORT,           FN_IS_HOMOG,    0,
@@ -3031,7 +3025,6 @@ static Int HasFiltTab [] = {
     T_PLIST_DENSE_NHOM_NSORT,           FN_IS_NSORT,    1,
 
     // a mutable list with holes
-    T_PLIST_NDENSE,               FN_IS_EMPTY,    0,
     T_PLIST_NDENSE,               FN_IS_DENSE,    0,
     T_PLIST_NDENSE,               FN_IS_NDENSE,   1,
     T_PLIST_NDENSE,               FN_IS_HOMOG,    0,
@@ -3042,7 +3035,6 @@ static Int HasFiltTab [] = {
     T_PLIST_NDENSE,               FN_IS_NSORT,    0,
 
     // dense list, which conts imms, is homogeneous, not a table
-    T_PLIST_HOM,                  FN_IS_EMPTY,    0,
     T_PLIST_HOM,                  FN_IS_DENSE,    1,
     T_PLIST_HOM,                  FN_IS_NDENSE,   0,
     T_PLIST_HOM,                  FN_IS_HOMOG,    1,
@@ -3053,7 +3045,6 @@ static Int HasFiltTab [] = {
     T_PLIST_HOM,                  FN_IS_NSORT,    0,
 
     // ssort dense list, which conts imms, is homog, not a table
-    T_PLIST_HOM_SSORT,            FN_IS_EMPTY,    0,
     T_PLIST_HOM_SSORT,            FN_IS_DENSE,    1,
     T_PLIST_HOM_SSORT,            FN_IS_NDENSE,   0,
     T_PLIST_HOM_SSORT,            FN_IS_HOMOG,    1,
@@ -3064,7 +3055,6 @@ static Int HasFiltTab [] = {
     T_PLIST_HOM_SSORT,            FN_IS_NSORT,    0,
 
     // nsort dense list, which conts imms, is homog, not a table
-    T_PLIST_HOM_NSORT,            FN_IS_EMPTY,    0,
     T_PLIST_HOM_NSORT,            FN_IS_DENSE,    1,
     T_PLIST_HOM_NSORT,            FN_IS_NDENSE,   0,
     T_PLIST_HOM_NSORT,            FN_IS_HOMOG,    1,
@@ -3075,7 +3065,6 @@ static Int HasFiltTab [] = {
     T_PLIST_HOM_NSORT,            FN_IS_NSORT,    1,
 
     // dense list, which is immutable, homog, non-empty, table
-    T_PLIST_TAB,                  FN_IS_EMPTY,    0,
     T_PLIST_TAB,                  FN_IS_DENSE,    1,
     T_PLIST_TAB,                  FN_IS_NDENSE,   0,
     T_PLIST_TAB,                  FN_IS_HOMOG,    1,
@@ -3086,7 +3075,6 @@ static Int HasFiltTab [] = {
     T_PLIST_TAB,                  FN_IS_NSORT,    0,
 
     // ssort, dense list, which is imm, homog, non-empty, table
-    T_PLIST_TAB_SSORT,            FN_IS_EMPTY,    0,
     T_PLIST_TAB_SSORT,            FN_IS_DENSE,    1,
     T_PLIST_TAB_SSORT,            FN_IS_NDENSE,   0,
     T_PLIST_TAB_SSORT,            FN_IS_HOMOG,    1,
@@ -3097,7 +3085,6 @@ static Int HasFiltTab [] = {
     T_PLIST_TAB_SSORT,            FN_IS_NSORT,    0,
 
     // nsort, dense list, which is imm, homog, non-empty, table
-    T_PLIST_TAB_NSORT,            FN_IS_EMPTY,    0,
     T_PLIST_TAB_NSORT,            FN_IS_DENSE,    1,
     T_PLIST_TAB_NSORT,            FN_IS_NDENSE,   0,
     T_PLIST_TAB_NSORT,            FN_IS_HOMOG,    1,
@@ -3108,7 +3095,6 @@ static Int HasFiltTab [] = {
     T_PLIST_TAB_NSORT,            FN_IS_NSORT,    1,
 
     // dense list, which is immutable, homog, non-empty, rect table
-    T_PLIST_TAB_RECT,                  FN_IS_EMPTY,    0,
     T_PLIST_TAB_RECT,                  FN_IS_DENSE,    1,
     T_PLIST_TAB_RECT,                  FN_IS_NDENSE,   0,
     T_PLIST_TAB_RECT,                  FN_IS_HOMOG,    1,
@@ -3119,7 +3105,6 @@ static Int HasFiltTab [] = {
     T_PLIST_TAB_RECT,                  FN_IS_NSORT,    0,
 
     // ssort, dense list, which is imm, homog, non-empty, rect table
-    T_PLIST_TAB_RECT_SSORT,            FN_IS_EMPTY,    0,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_DENSE,    1,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_NDENSE,   0,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_HOMOG,    1,
@@ -3130,7 +3115,6 @@ static Int HasFiltTab [] = {
     T_PLIST_TAB_RECT_SSORT,            FN_IS_NSORT,    0,
 
     // nsort, dense list, which is imm, homog, non-empty, rect table
-    T_PLIST_TAB_RECT_NSORT,            FN_IS_EMPTY,    0,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_DENSE,    1,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_NDENSE,   0,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_HOMOG,    1,
@@ -3141,7 +3125,6 @@ static Int HasFiltTab [] = {
     T_PLIST_TAB_RECT_NSORT,            FN_IS_NSORT,    1,
 
     // dense list, which only contains objects of type <= T_CYC
-    T_PLIST_CYC,                  FN_IS_EMPTY,    0,
     T_PLIST_CYC,                  FN_IS_DENSE,    1,
     T_PLIST_CYC,                  FN_IS_NDENSE,   0,
     T_PLIST_CYC,                  FN_IS_HOMOG,    1,
@@ -3152,7 +3135,6 @@ static Int HasFiltTab [] = {
     T_PLIST_CYC,                  FN_IS_NSORT,    0,
 
     // ssort dense list, which only contains objs of type <= T_CYC
-    T_PLIST_CYC_SSORT,            FN_IS_EMPTY,    0,
     T_PLIST_CYC_SSORT,            FN_IS_DENSE,    1,
     T_PLIST_CYC_SSORT,            FN_IS_NDENSE,   0,
     T_PLIST_CYC_SSORT,            FN_IS_HOMOG,    1,
@@ -3163,7 +3145,6 @@ static Int HasFiltTab [] = {
     T_PLIST_CYC_SSORT,            FN_IS_NSORT,    0,
 
     // nsort dense list, which only contains objs of type <= T_CYC
-    T_PLIST_CYC_NSORT,            FN_IS_EMPTY,    0,
     T_PLIST_CYC_NSORT,            FN_IS_DENSE,    1,
     T_PLIST_CYC_NSORT,            FN_IS_NDENSE,   0,
     T_PLIST_CYC_NSORT,            FN_IS_HOMOG,    1,
@@ -3175,7 +3156,6 @@ static Int HasFiltTab [] = {
 
     // dense list, which only contains objects of type T_FFE
     // all written over the same field
-    T_PLIST_FFE,            FN_IS_EMPTY,    0,
     T_PLIST_FFE,            FN_IS_DENSE,    1,
     T_PLIST_FFE,            FN_IS_NDENSE,   0,
     T_PLIST_FFE,            FN_IS_HOMOG,    1,
@@ -3196,7 +3176,6 @@ static Int HasFiltTab [] = {
 static Int SetFiltTab [] = {
 
     // plain lists
-    T_PLIST,                      FN_IS_EMPTY,   T_PLIST_EMPTY,
     T_PLIST,                      FN_IS_DENSE,   T_PLIST_DENSE,
     T_PLIST,                      FN_IS_NDENSE,  T_PLIST_NDENSE,
     T_PLIST,                      FN_IS_HOMOG,   T_PLIST_HOM,
@@ -3207,7 +3186,6 @@ static Int SetFiltTab [] = {
     T_PLIST,                      FN_IS_NSORT,   T_PLIST,
 
     // empty list
-    T_PLIST_EMPTY,                FN_IS_EMPTY,   T_PLIST_EMPTY,
     T_PLIST_EMPTY,                FN_IS_DENSE,   T_PLIST_EMPTY,
     T_PLIST_EMPTY,                FN_IS_NDENSE,  -1,
     T_PLIST_EMPTY,                FN_IS_HOMOG,   T_PLIST_EMPTY,
@@ -3218,7 +3196,6 @@ static Int SetFiltTab [] = {
     T_PLIST_EMPTY,                FN_IS_NSORT,   -1,
 
     // dense list
-    T_PLIST_DENSE,                FN_IS_EMPTY,   T_PLIST_EMPTY,
     T_PLIST_DENSE,                FN_IS_DENSE,   T_PLIST_DENSE,
     T_PLIST_DENSE,                FN_IS_NDENSE,  -1,
     T_PLIST_DENSE,                FN_IS_HOMOG,   T_PLIST_HOM,
@@ -3229,7 +3206,6 @@ static Int SetFiltTab [] = {
     T_PLIST_DENSE,                FN_IS_NSORT,   T_PLIST_DENSE,
 
     // dense list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM,           FN_IS_EMPTY,   -1,
     T_PLIST_DENSE_NHOM,           FN_IS_DENSE,   T_PLIST_DENSE_NHOM,
     T_PLIST_DENSE_NHOM,           FN_IS_NDENSE,  -1,
     T_PLIST_DENSE_NHOM,           FN_IS_HOMOG,   -1,
@@ -3240,7 +3216,6 @@ static Int SetFiltTab [] = {
     T_PLIST_DENSE_NHOM,           FN_IS_NSORT,   T_PLIST_DENSE_NHOM_NSORT,
 
     // dense ssorted list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM_SSORT,     FN_IS_EMPTY,   -1,
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_DENSE,   T_PLIST_DENSE_NHOM_SSORT,
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_NDENSE,  -1,
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_HOMOG,   -1,
@@ -3251,7 +3226,6 @@ static Int SetFiltTab [] = {
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_NSORT,   -1,
 
     // dense nsorted list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM_NSORT,     FN_IS_EMPTY,   -1,
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_DENSE,   T_PLIST_DENSE_NHOM_NSORT,
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_NDENSE,  -1,
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_HOMOG,   -1,
@@ -3262,7 +3236,6 @@ static Int SetFiltTab [] = {
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_NSORT,   T_PLIST_DENSE_NHOM_NSORT,
 
     // a mutable list with holes
-    T_PLIST_NDENSE,               FN_IS_EMPTY,   -1,
     T_PLIST_NDENSE,               FN_IS_DENSE,   -1,
     T_PLIST_NDENSE,               FN_IS_NDENSE,  T_PLIST_NDENSE,
     T_PLIST_NDENSE,               FN_IS_HOMOG,   -1,
@@ -3273,7 +3246,6 @@ static Int SetFiltTab [] = {
     T_PLIST_NDENSE,               FN_IS_NSORT,   T_PLIST_NDENSE,
 
     // dense list, which conts imms, is homogeneous, not a table
-    T_PLIST_HOM,                  FN_IS_EMPTY,   T_PLIST_EMPTY,
     T_PLIST_HOM,                  FN_IS_DENSE,   T_PLIST_HOM,
     T_PLIST_HOM,                  FN_IS_NDENSE,  -1,
     T_PLIST_HOM,                  FN_IS_HOMOG,   T_PLIST_HOM,
@@ -3284,7 +3256,6 @@ static Int SetFiltTab [] = {
     T_PLIST_HOM,                  FN_IS_NSORT,   T_PLIST_HOM_NSORT,
 
     // ssort dense list, which conts imms, is homog, not a table
-    T_PLIST_HOM_SSORT,            FN_IS_EMPTY,   T_PLIST_EMPTY,
     T_PLIST_HOM_SSORT,            FN_IS_DENSE,   T_PLIST_HOM_SSORT,
     T_PLIST_HOM_SSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_HOM_SSORT,            FN_IS_HOMOG,   T_PLIST_HOM_SSORT,
@@ -3295,7 +3266,6 @@ static Int SetFiltTab [] = {
     T_PLIST_HOM_SSORT,            FN_IS_NSORT,   -1,
 
     // nsort dense list, which conts imms, is homog, not a table
-    T_PLIST_HOM_NSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_HOM_NSORT,            FN_IS_DENSE,   T_PLIST_HOM_NSORT,
     T_PLIST_HOM_NSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_HOM_NSORT,            FN_IS_HOMOG,   T_PLIST_HOM_NSORT,
@@ -3306,7 +3276,6 @@ static Int SetFiltTab [] = {
     T_PLIST_HOM_NSORT,            FN_IS_NSORT,   T_PLIST_HOM_NSORT,
 
     // dense list, which is immutable, homog, non-empty, table
-    T_PLIST_TAB,                  FN_IS_EMPTY,   -1,
     T_PLIST_TAB,                  FN_IS_DENSE,   T_PLIST_TAB,
     T_PLIST_TAB,                  FN_IS_NDENSE,  -1,
     T_PLIST_TAB,                  FN_IS_HOMOG,   T_PLIST_TAB,
@@ -3317,7 +3286,6 @@ static Int SetFiltTab [] = {
     T_PLIST_TAB,                  FN_IS_NSORT,   T_PLIST_TAB_NSORT,
 
     // ssort, dense list, which is imm, homog, non-empty, table
-    T_PLIST_TAB_SSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_TAB_SSORT,            FN_IS_DENSE,   T_PLIST_TAB_SSORT,
     T_PLIST_TAB_SSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_TAB_SSORT,            FN_IS_HOMOG,   T_PLIST_TAB_SSORT,
@@ -3328,7 +3296,6 @@ static Int SetFiltTab [] = {
     T_PLIST_TAB_SSORT,            FN_IS_NSORT,   -1,
 
     // nsort, dense list, which is imm, homog, non-empty, table
-    T_PLIST_TAB_NSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_TAB_NSORT,            FN_IS_DENSE,   T_PLIST_TAB_NSORT,
     T_PLIST_TAB_NSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_TAB_NSORT,            FN_IS_HOMOG,   T_PLIST_TAB_NSORT,
@@ -3339,7 +3306,6 @@ static Int SetFiltTab [] = {
     T_PLIST_TAB_NSORT,            FN_IS_NSORT,   T_PLIST_TAB_NSORT,
 
     // dense list, which is immutable, homog, non-empty, rect table
-    T_PLIST_TAB_RECT,                  FN_IS_EMPTY,   -1,
     T_PLIST_TAB_RECT,                  FN_IS_DENSE,   T_PLIST_TAB_RECT,
     T_PLIST_TAB_RECT,                  FN_IS_NDENSE,  -1,
     T_PLIST_TAB_RECT,                  FN_IS_HOMOG,   T_PLIST_TAB_RECT,
@@ -3350,7 +3316,6 @@ static Int SetFiltTab [] = {
     T_PLIST_TAB_RECT,                  FN_IS_NSORT,   T_PLIST_TAB_RECT_NSORT,
 
     // ssort, dense list, which is imm, homog, non-empty, rect table
-    T_PLIST_TAB_RECT_SSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_DENSE,   T_PLIST_TAB_RECT_SSORT,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_HOMOG,   T_PLIST_TAB_RECT_SSORT,
@@ -3361,7 +3326,6 @@ static Int SetFiltTab [] = {
     T_PLIST_TAB_RECT_SSORT,            FN_IS_NSORT,   -1,
 
     // nsort, dense list, which is imm, homog, non-empty, rect table
-    T_PLIST_TAB_RECT_NSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_DENSE,   T_PLIST_TAB_RECT_NSORT,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_HOMOG,   T_PLIST_TAB_RECT_NSORT,
@@ -3372,7 +3336,6 @@ static Int SetFiltTab [] = {
     T_PLIST_TAB_RECT_NSORT,            FN_IS_NSORT,   T_PLIST_TAB_RECT_NSORT,
 
     // dense list, which only contains objects of type <= T_CYC
-    T_PLIST_CYC,                  FN_IS_EMPTY,   -1,
     T_PLIST_CYC,                  FN_IS_DENSE,   T_PLIST_CYC,
     T_PLIST_CYC,                  FN_IS_NDENSE,  -1,
     T_PLIST_CYC,                  FN_IS_HOMOG,   T_PLIST_CYC,
@@ -3383,7 +3346,6 @@ static Int SetFiltTab [] = {
     T_PLIST_CYC,                  FN_IS_NSORT,   T_PLIST_CYC_NSORT,
 
     // ssort dense list, which only contains objs of type <= T_CYC
-    T_PLIST_CYC_SSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_CYC_SSORT,            FN_IS_DENSE,   T_PLIST_CYC_SSORT,
     T_PLIST_CYC_SSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_CYC_SSORT,            FN_IS_HOMOG,   T_PLIST_CYC_SSORT,
@@ -3394,7 +3356,6 @@ static Int SetFiltTab [] = {
     T_PLIST_CYC_SSORT,            FN_IS_NSORT,   -1,
 
     // nsort dense list, which only contains objs of type <= T_CYC
-    T_PLIST_CYC_NSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_CYC_NSORT,            FN_IS_DENSE,   T_PLIST_CYC_NSORT,
     T_PLIST_CYC_NSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_CYC_NSORT,            FN_IS_HOMOG,   T_PLIST_CYC_NSORT,
@@ -3405,7 +3366,6 @@ static Int SetFiltTab [] = {
     T_PLIST_CYC_NSORT,            FN_IS_NSORT,   T_PLIST_CYC_NSORT,
 
     // dense list, which only contains objects of type T_FFE
-    T_PLIST_FFE,            FN_IS_EMPTY,   -1,
     T_PLIST_FFE,            FN_IS_DENSE,   T_PLIST_FFE,
     T_PLIST_FFE,            FN_IS_NDENSE,  -1,
     T_PLIST_FFE,            FN_IS_HOMOG,   T_PLIST_FFE,
@@ -3426,7 +3386,6 @@ static Int SetFiltTab [] = {
 static Int ResetFiltTab [] = {
 
     // plain lists
-    T_PLIST,                      FN_IS_EMPTY,   T_PLIST,
     T_PLIST,                      FN_IS_DENSE,   T_PLIST,
     T_PLIST,                      FN_IS_NDENSE,  T_PLIST,
     T_PLIST,                      FN_IS_HOMOG,   T_PLIST,
@@ -3437,7 +3396,6 @@ static Int ResetFiltTab [] = {
     T_PLIST,                      FN_IS_NSORT,   T_PLIST,
 
     // empty list
-    T_PLIST_EMPTY,                FN_IS_EMPTY,   T_PLIST,
     T_PLIST_EMPTY,                FN_IS_DENSE,   T_PLIST,
     T_PLIST_EMPTY,                FN_IS_NDENSE,  T_PLIST_EMPTY,
     T_PLIST_EMPTY,                FN_IS_HOMOG,   T_PLIST,
@@ -3448,7 +3406,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_EMPTY,                FN_IS_NSORT,   T_PLIST_EMPTY,
 
     // dense list
-    T_PLIST_DENSE,                FN_IS_EMPTY,   T_PLIST_DENSE,
     T_PLIST_DENSE,                FN_IS_DENSE,   T_PLIST,
     T_PLIST_DENSE,                FN_IS_NDENSE,  T_PLIST_DENSE,
     T_PLIST_DENSE,                FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3459,7 +3416,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_DENSE,                FN_IS_NSORT,   T_PLIST_DENSE,
 
     // dense list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM,           FN_IS_EMPTY,   T_PLIST_DENSE_NHOM,
     T_PLIST_DENSE_NHOM,           FN_IS_DENSE,   T_PLIST,
     T_PLIST_DENSE_NHOM,           FN_IS_NDENSE,  T_PLIST_DENSE_NHOM,
     T_PLIST_DENSE_NHOM,           FN_IS_HOMOG,   T_PLIST_DENSE_NHOM,
@@ -3470,7 +3426,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_DENSE_NHOM,           FN_IS_NSORT,   T_PLIST_DENSE_NHOM,
 
     // dense ssorted list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM_SSORT,     FN_IS_EMPTY,   T_PLIST_DENSE_NHOM_SSORT,
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_DENSE,   T_PLIST,
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_NDENSE,  T_PLIST_DENSE_NHOM_SSORT,
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_HOMOG,   T_PLIST_DENSE_NHOM_SSORT,
@@ -3481,7 +3436,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_NSORT,   T_PLIST_DENSE_NHOM_SSORT,
 
     // dense nsorted list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM_NSORT,     FN_IS_EMPTY,   T_PLIST_DENSE_NHOM_NSORT,
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_DENSE,   T_PLIST,
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_NDENSE,  T_PLIST_DENSE_NHOM_NSORT,
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_HOMOG,   T_PLIST_DENSE_NHOM_NSORT,
@@ -3492,7 +3446,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_NSORT,   T_PLIST_DENSE_NHOM,
 
     // a mutable list with holes
-    T_PLIST_NDENSE,               FN_IS_EMPTY,   T_PLIST_NDENSE,
     T_PLIST_NDENSE,               FN_IS_DENSE,   T_PLIST_NDENSE,
     T_PLIST_NDENSE,               FN_IS_NDENSE,  T_PLIST,
     T_PLIST_NDENSE,               FN_IS_HOMOG,   T_PLIST_NDENSE,
@@ -3503,7 +3456,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_NDENSE,               FN_IS_NSORT,   T_PLIST_NDENSE,
 
     // dense list, which conts imms, is homogeneous, not a table
-    T_PLIST_HOM,                  FN_IS_EMPTY,   T_PLIST_HOM,
     T_PLIST_HOM,                  FN_IS_DENSE,   T_PLIST,
     T_PLIST_HOM,                  FN_IS_NDENSE,  T_PLIST_HOM,
     T_PLIST_HOM,                  FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3514,7 +3466,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_HOM,                  FN_IS_NSORT,   T_PLIST_HOM,
 
     // ssort dense list, which conts imms, is homog, not a table
-    T_PLIST_HOM_SSORT,            FN_IS_EMPTY,   T_PLIST_HOM_SSORT,
     T_PLIST_HOM_SSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_HOM_SSORT,            FN_IS_NDENSE,  T_PLIST_HOM_SSORT,
     T_PLIST_HOM_SSORT,            FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3525,7 +3476,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_HOM_SSORT,            FN_IS_NSORT,   T_PLIST_HOM_SSORT,
 
     // nsort dense list, which conts imms, is homog, not a table
-    T_PLIST_HOM_NSORT,            FN_IS_EMPTY,   T_PLIST_HOM_NSORT,
     T_PLIST_HOM_NSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_HOM_NSORT,            FN_IS_NDENSE,  T_PLIST_HOM_NSORT,
     T_PLIST_HOM_NSORT,            FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3536,7 +3486,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_HOM_NSORT,            FN_IS_NSORT,   T_PLIST_HOM,
 
     // dense list, which is immutable, homog, non-empty, table
-    T_PLIST_TAB,                  FN_IS_EMPTY,   T_PLIST_TAB,
     T_PLIST_TAB,                  FN_IS_DENSE,   T_PLIST,
     T_PLIST_TAB,                  FN_IS_NDENSE,  T_PLIST_TAB,
     T_PLIST_TAB,                  FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3547,7 +3496,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_TAB,                  FN_IS_NSORT,   T_PLIST_TAB,
 
     // ssort, dense list, which is imm, homog, non-empty, table
-    T_PLIST_TAB_SSORT,            FN_IS_EMPTY,   T_PLIST_TAB_SSORT,
     T_PLIST_TAB_SSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_TAB_SSORT,            FN_IS_NDENSE,  T_PLIST_TAB_SSORT,
     T_PLIST_TAB_SSORT,            FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3558,7 +3506,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_TAB_SSORT,            FN_IS_NSORT,   T_PLIST_TAB_SSORT,
 
     // nsort, dense list, which is imm, homog, non-empty, table
-    T_PLIST_TAB_NSORT,            FN_IS_EMPTY,   T_PLIST_TAB_NSORT,
     T_PLIST_TAB_NSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_TAB_NSORT,            FN_IS_NDENSE,  T_PLIST_TAB_NSORT,
     T_PLIST_TAB_NSORT,            FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3569,7 +3516,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_TAB_NSORT,            FN_IS_NSORT,   T_PLIST_TAB,
 
     // dense list, which is immutable, homog, non-empty, rect table
-    T_PLIST_TAB_RECT,                  FN_IS_EMPTY,   T_PLIST_TAB_RECT,
     T_PLIST_TAB_RECT,                  FN_IS_DENSE,   T_PLIST,
     T_PLIST_TAB_RECT,                  FN_IS_NDENSE,  T_PLIST_TAB_RECT,
     T_PLIST_TAB_RECT,                  FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3580,7 +3526,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_TAB_RECT,                  FN_IS_NSORT,   T_PLIST_TAB_RECT,
 
     // ssort, dense list, which is imm, homog, non-empty, rect table
-    T_PLIST_TAB_RECT_SSORT,            FN_IS_EMPTY,   T_PLIST_TAB_RECT_SSORT,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_NDENSE,  T_PLIST_TAB_RECT_SSORT,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3591,7 +3536,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_TAB_RECT_SSORT,            FN_IS_NSORT,   T_PLIST_TAB_RECT_SSORT,
 
     // loop variables
-    T_PLIST_TAB_RECT_NSORT,            FN_IS_EMPTY,   T_PLIST_TAB_RECT_NSORT,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_NDENSE,  T_PLIST_TAB_RECT_NSORT,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3602,7 +3546,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_TAB_RECT_NSORT,            FN_IS_NSORT,   T_PLIST_TAB_RECT,
 
     // dense list, which only contains objects of type <= T_CYC
-    T_PLIST_CYC,                  FN_IS_EMPTY,   T_PLIST_CYC,
     T_PLIST_CYC,                  FN_IS_DENSE,   T_PLIST,
     T_PLIST_CYC,                  FN_IS_NDENSE,  T_PLIST_CYC,
     T_PLIST_CYC,                  FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3613,7 +3556,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_CYC,                  FN_IS_NSORT,   T_PLIST_CYC,
 
     // ssort dense list, which only contains objs of type <= T_CYC
-    T_PLIST_CYC_SSORT,            FN_IS_EMPTY,   T_PLIST_CYC_SSORT,
     T_PLIST_CYC_SSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_CYC_SSORT,            FN_IS_NDENSE,  T_PLIST_CYC_SSORT,
     T_PLIST_CYC_SSORT,            FN_IS_HOMOG,   T_PLIST,
@@ -3624,7 +3566,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_CYC_SSORT,            FN_IS_NSORT,   T_PLIST_CYC_SSORT,
 
     // nsort dense list, which only contains objs of type <= T_CYC
-    T_PLIST_CYC_NSORT,            FN_IS_EMPTY,   T_PLIST_CYC_NSORT,
     T_PLIST_CYC_NSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_CYC_NSORT,            FN_IS_NDENSE,  T_PLIST_CYC_NSORT,
     T_PLIST_CYC_NSORT,            FN_IS_HOMOG,   T_PLIST,
@@ -3635,7 +3576,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_CYC_NSORT,            FN_IS_NSORT,   T_PLIST_CYC,
 
     // dense list, which only contains objects of type T_FFE
-    T_PLIST_FFE,            FN_IS_EMPTY,   T_PLIST_FFE,
     T_PLIST_FFE,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_FFE,            FN_IS_NDENSE,  T_PLIST_FFE,
     T_PLIST_FFE,            FN_IS_HOMOG,   T_PLIST,

--- a/src/range.c
+++ b/src/range.c
@@ -1169,7 +1169,6 @@ static Int ClearFiltsTab [] = {
 static Int HasFiltTab [] = {
 
     // nsort range
-    T_RANGE_NSORT,              FN_IS_EMPTY,    0,
     T_RANGE_NSORT,              FN_IS_DENSE,    1,
     T_RANGE_NSORT,              FN_IS_NDENSE,   0,
     T_RANGE_NSORT,              FN_IS_HOMOG,    1,
@@ -1180,7 +1179,6 @@ static Int HasFiltTab [] = {
     T_RANGE_NSORT,              FN_IS_NSORT,    1,
 
     // ssort range
-    T_RANGE_SSORT,              FN_IS_EMPTY,    0,
     T_RANGE_SSORT,              FN_IS_DENSE,    1,
     T_RANGE_SSORT,              FN_IS_NDENSE,   0,
     T_RANGE_SSORT,              FN_IS_HOMOG,    1,
@@ -1201,7 +1199,6 @@ static Int HasFiltTab [] = {
 static Int SetFiltTab [] = {
 
     // nsort range
-    T_RANGE_NSORT,              FN_IS_EMPTY,    -1,
     T_RANGE_NSORT,              FN_IS_DENSE,    T_RANGE_NSORT,
     T_RANGE_NSORT,              FN_IS_NDENSE,   -1,
     T_RANGE_NSORT,              FN_IS_HOMOG,    T_RANGE_NSORT,
@@ -1212,7 +1209,6 @@ static Int SetFiltTab [] = {
     T_RANGE_NSORT,              FN_IS_NSORT,    T_RANGE_NSORT,
 
     // ssort range
-    T_RANGE_SSORT,              FN_IS_EMPTY,    T_RANGE_SSORT,
     T_RANGE_SSORT,              FN_IS_DENSE,    T_RANGE_SSORT,
     T_RANGE_SSORT,              FN_IS_NDENSE,   -1,
     T_RANGE_SSORT,              FN_IS_HOMOG,    T_RANGE_SSORT,
@@ -1234,7 +1230,6 @@ static Int SetFiltTab [] = {
 static Int ResetFiltTab [] = {
 
     // nsort range
-    T_RANGE_NSORT,              FN_IS_EMPTY,    T_RANGE_NSORT,
     T_RANGE_NSORT,              FN_IS_DENSE,    T_RANGE_NSORT,
     T_RANGE_NSORT,              FN_IS_NDENSE,   T_RANGE_NSORT,
     T_RANGE_NSORT,              FN_IS_HOMOG,    T_RANGE_NSORT,
@@ -1245,7 +1240,6 @@ static Int ResetFiltTab [] = {
     T_RANGE_NSORT,              FN_IS_NSORT,    T_RANGE_NSORT,
 
     // ssort range
-    T_RANGE_SSORT,              FN_IS_EMPTY,    T_RANGE_SSORT,
     T_RANGE_SSORT,              FN_IS_DENSE,    T_RANGE_SSORT,
     T_RANGE_SSORT,              FN_IS_NDENSE,   T_RANGE_SSORT,
     T_RANGE_SSORT,              FN_IS_HOMOG,    T_RANGE_SSORT,

--- a/src/set.c
+++ b/src/set.c
@@ -77,7 +77,7 @@ Int IsSet (
 
         /* if <list> is the empty list, its a set (:-)                     */
         if ( LEN_PLIST(list) == 0 ) {
-            SET_FILT_LIST( list, FN_IS_EMPTY );
+            RetypeBag(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
             isSet = 1;
         }
 
@@ -99,7 +99,7 @@ Int IsSet (
         /* if <list> is the empty list, its a set (:-)                     */
         if ( LEN_LIST(list) == 0 ) {
             PLAIN_LIST( list );
-            SET_FILT_LIST( list, FN_IS_EMPTY );
+            RetypeBag(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
             isSet = 1;
         }
 
@@ -597,8 +597,7 @@ Obj FuncREM_SET (
 
         /* fix up the type of the result                                   */
         if ( len-1 == 0 ) {
-            CLEAR_FILTS_LIST(set);
-            SET_FILT_LIST( set, FN_IS_EMPTY );
+            RetypeBag(set, IS_MUTABLE_OBJ(set) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
         }
     }
 
@@ -880,8 +879,7 @@ Obj FuncINTER_SET (
 
     /* fix up the type of the result                                       */
     if ( lenr == 0 ) {
-      CLEAR_FILTS_LIST(set1);
-      SET_FILT_LIST( set1, FN_IS_EMPTY );
+      RetypeBag(set1, IS_MUTABLE_OBJ(set1) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
     }
     else if ( lenr == 1) {
       if (TNUM_OBJ(ELM_PLIST(set1,1)) <= T_CYC)
@@ -1041,8 +1039,7 @@ Obj FuncSUBTR_SET (
 
     /* fix up the type of the result                                       */
     if ( lenr == 0 ) {
-        CLEAR_FILTS_LIST(set1);
-        SET_FILT_LIST( set1, FN_IS_EMPTY );
+        RetypeBag(set1, IS_MUTABLE_OBJ(set1) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
     }
     else if ( lenr == 1) {
       if (TNUM_OBJ(ELM_PLIST(set1,1)) <= T_CYC)

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -2140,7 +2140,6 @@ static Int ClearFiltsTab [] = {
 static Int HasFiltTab [] = {
 
     // string
-    T_STRING,                  FN_IS_EMPTY,   0,
     T_STRING,                  FN_IS_DENSE,   1,
     T_STRING,                  FN_IS_NDENSE,  0,
     T_STRING,                  FN_IS_HOMOG,   1,
@@ -2151,7 +2150,6 @@ static Int HasFiltTab [] = {
     T_STRING,                  FN_IS_NSORT,   0,
 
     // ssort string
-    T_STRING_SSORT,            FN_IS_EMPTY,   0,
     T_STRING_SSORT,            FN_IS_DENSE,   1,
     T_STRING_SSORT,            FN_IS_NDENSE,  0,
     T_STRING_SSORT,            FN_IS_HOMOG,   1,
@@ -2162,7 +2160,6 @@ static Int HasFiltTab [] = {
     T_STRING_SSORT,            FN_IS_NSORT,   0,
 
     // nsort string
-    T_STRING_NSORT,            FN_IS_EMPTY,   0,
     T_STRING_NSORT,            FN_IS_DENSE,   1,
     T_STRING_NSORT,            FN_IS_NDENSE,  0,
     T_STRING_NSORT,            FN_IS_HOMOG,   1,
@@ -2183,7 +2180,6 @@ static Int HasFiltTab [] = {
 static Int SetFiltTab [] = {
 
     // string
-    T_STRING,                  FN_IS_EMPTY,   T_STRING_SSORT,
     T_STRING,                  FN_IS_DENSE,   T_STRING,
     T_STRING,                  FN_IS_NDENSE,  -1,
     T_STRING,                  FN_IS_HOMOG,   T_STRING,
@@ -2194,7 +2190,6 @@ static Int SetFiltTab [] = {
     T_STRING,                  FN_IS_NSORT,   T_STRING_NSORT,
 
     // ssort string
-    T_STRING_SSORT,            FN_IS_EMPTY,   T_STRING_SSORT,
     T_STRING_SSORT,            FN_IS_DENSE,   T_STRING_SSORT,
     T_STRING_SSORT,            FN_IS_NDENSE,  -1,
     T_STRING_SSORT,            FN_IS_HOMOG,   T_STRING_SSORT,
@@ -2205,7 +2200,6 @@ static Int SetFiltTab [] = {
     T_STRING_SSORT,            FN_IS_NSORT,   -1,
 
     // nsort string
-    T_STRING_NSORT,            FN_IS_EMPTY,   -1,
     T_STRING_NSORT,            FN_IS_DENSE,   T_STRING_NSORT,
     T_STRING_NSORT,            FN_IS_NDENSE,  -1,
     T_STRING_NSORT,            FN_IS_HOMOG,   T_STRING_NSORT,
@@ -2227,7 +2221,6 @@ static Int SetFiltTab [] = {
 static Int ResetFiltTab [] = {
 
     // string
-    T_STRING,                  FN_IS_EMPTY,   T_STRING,
     T_STRING,                  FN_IS_DENSE,   T_STRING,
     T_STRING,                  FN_IS_NDENSE,  T_STRING,
     T_STRING,                  FN_IS_HOMOG,   T_STRING,
@@ -2238,7 +2231,6 @@ static Int ResetFiltTab [] = {
     T_STRING,                  FN_IS_NSORT,   T_STRING,
 
     // ssort string
-    T_STRING_SSORT,            FN_IS_EMPTY,   T_STRING_SSORT,
     T_STRING_SSORT,            FN_IS_DENSE,   T_STRING_SSORT,
     T_STRING_SSORT,            FN_IS_NDENSE,  T_STRING_SSORT,
     T_STRING_SSORT,            FN_IS_HOMOG,   T_STRING_SSORT,
@@ -2249,7 +2241,6 @@ static Int ResetFiltTab [] = {
     T_STRING_SSORT,            FN_IS_NSORT,   T_STRING_SSORT,
 
     // nsort string
-    T_STRING_NSORT,            FN_IS_EMPTY,   T_STRING_NSORT,
     T_STRING_NSORT,            FN_IS_DENSE,   T_STRING_NSORT,
     T_STRING_NSORT,            FN_IS_NDENSE,  T_STRING_NSORT,
     T_STRING_NSORT,            FN_IS_HOMOG,   T_STRING_NSORT,


### PR DESCRIPTION
I am not really sure whether this is a good thing or not -- but I had this branch sitting around for a loong time now, so I decided I should just push it out now, and we either merge it, or I can discard it for good. (I've been doing some spring cleaning on the 50+ branches I locally have ;-)

One argument for this is IMHO that it reduces complexity in the kernel and makes it ever so slightly easier to understand what's going on. The whole `CLEAR_FILTS_LIST` and `SET_FILT_LIST` always felt a bit like black magic to me.

On the other hand, that code has been around for ages and seems to work, so no strong reason to change it.
