### PR TITLE
Implement StandardAssociate(Unit) for ZmodnZ, tweak documentation for IsEuclideanRing

### DIFF
--- a/hpcgap/lib/zmodnz.gi
+++ b/hpcgap/lib/zmodnz.gi
@@ -655,6 +655,39 @@ InstallMethod(ZOp,
 end);
 
 
+#############################################################################
+##
+#M  StandardAssociate( <r> )
+##
+InstallMethod( StandardAssociate,
+    "for full ring Z/nZ and an element in Z/nZ",
+    IsCollsElms,
+    [ IsZmodnZObjNonprimeCollection and IsWholeFamily and IsRing, IsZmodnZObj and IsModulusRep ],
+    function ( R, r )
+      local m, n;
+      m := ModulusOfZmodnZObj( r );
+      n := GcdInt( r![1], m );
+      return ZmodnZObj( FamilyObj( r ), n );
+    end );
+
+#############################################################################
+##
+#M  StandardAssociateUnit( <r> )
+##
+InstallMethod( StandardAssociateUnit,
+    "for full ring Z/nZ and an element in Z/nZ",
+    IsCollsElms,
+    [ IsZmodnZObjNonprimeCollection and IsWholeFamily and IsRing, IsZmodnZObj and IsModulusRep ],
+    function ( R, r )
+      local m, n;
+      m := ModulusOfZmodnZObj( r );
+      if r![1] = 0 then
+        n := 1;
+      else
+        n := QuotientMod(GcdInt( r![1], m ), r![1], m);
+      fi;
+      return ZmodnZObj( FamilyObj( r ), n );
+    end );
 
 
 #############################################################################

--- a/lib/ring.gd
+++ b/lib/ring.gd
@@ -546,7 +546,7 @@ DeclareCategory( "IsUniqueFactorizationRing", IsRing );
 ##  <Description>
 ##  A ring <M>R</M> is called a Euclidean ring if it is an integral ring and
 ##  there exists a function <M>\delta</M>, called the Euclidean degree, from
-##  <M>R-\{0_R\}</M> to the nonnegative integers,
+##  <M>R-\{0_R\}</M> into a well-ordered set (such as the the nonnegative integers),
 ##  such that for every pair <M>r \in R</M> and <M>s \in  R-\{0_R\}</M> there
 ##  exists an element <M>q</M> such that either
 ##  <M>r - q s = 0_R</M> or <M>\delta(r - q s) &lt; \delta( s )</M>.

--- a/lib/zmodnz.gi
+++ b/lib/zmodnz.gi
@@ -655,6 +655,39 @@ InstallMethod(ZOp,
 end);
 
 
+#############################################################################
+##
+#M  StandardAssociate( <r> )
+##
+InstallMethod( StandardAssociate,
+    "for full ring Z/nZ and an element in Z/nZ",
+    IsCollsElms,
+    [ IsZmodnZObjNonprimeCollection and IsWholeFamily and IsRing, IsZmodnZObj and IsModulusRep ],
+    function ( R, r )
+      local m, n;
+      m := ModulusOfZmodnZObj( r );
+      n := GcdInt( r![1], m );
+      return ZmodnZObj( FamilyObj( r ), n );
+    end );
+
+#############################################################################
+##
+#M  StandardAssociateUnit( <r> )
+##
+InstallMethod( StandardAssociateUnit,
+    "for full ring Z/nZ and an element in Z/nZ",
+    IsCollsElms,
+    [ IsZmodnZObjNonprimeCollection and IsWholeFamily and IsRing, IsZmodnZObj and IsModulusRep ],
+    function ( R, r )
+      local m, n;
+      m := ModulusOfZmodnZObj( r );
+      if r![1] = 0 then
+        n := 1;
+      else
+        n := QuotientMod(GcdInt( r![1], m ), r![1], m);
+      fi;
+      return ZmodnZObj( FamilyObj( r ), n );
+    end );
 
 
 #############################################################################

--- a/tst/testinstall/zmodnz.tst
+++ b/tst/testinstall/zmodnz.tst
@@ -467,6 +467,47 @@ ZmodnZObj( 0, 10 )
 gap> 3/y;
 fail
 
+# test StandardAssociate
+gap> checkCompatible := R -> ForAll(R, r -> StandardAssociateUnit(R,r) * r = StandardAssociate(R,r));;
+
+#
+gap> R := Integers mod 4;;
+gap> List(Elements(R), x -> Int(StandardAssociate(R, x)));
+[ 0, 1, 2, 1 ]
+gap> List(Elements(R), x -> Int(StandardAssociateUnit(R, x)));
+[ 1, 1, 1, 3 ]
+
+#
+gap> R := Integers mod 5;;
+gap> List(Elements(R), x -> Int(StandardAssociate(R, x)));
+[ 0, 1, 1, 1, 1 ]
+gap> List(Elements(R), x -> Int(StandardAssociateUnit(R, x)));
+[ 1, 1, 3, 4, 2 ]
+gap> ForAll(R, r -> StandardAssociateUnit(R,r) * r = StandardAssociate(R,r));
+true
+
+#
+gap> R := Integers mod 6;;
+gap> List(Elements(R), x -> Int(StandardAssociate(R, x)));
+[ 0, 1, 2, 3, 2, 1 ]
+gap> List(Elements(R), x -> Int(StandardAssociateUnit(R, x)));
+[ 1, 1, 1, 1, 2, 5 ]
+gap> ForAll(R, r -> StandardAssociateUnit(R,r) * r = StandardAssociate(R,r));
+true
+
+#
+gap> R := Integers mod 9;;
+gap> List(Elements(R), x -> Int(StandardAssociate(R, x)));
+[ 0, 1, 1, 3, 1, 1, 3, 1, 1 ]
+gap> List(Elements(R), x -> Int(StandardAssociateUnit(R, x)));
+[ 1, 1, 5, 1, 7, 2, 2, 4, 8 ]
+gap> ForAll(R, r -> StandardAssociateUnit(R,r) * r = StandardAssociate(R,r));
+true
+
+#
+gap> ForAll([1..100], m -> checkCompatible(Integers mod m));
+true
+
 #
 gap> STOP_TEST( "zmodnz.tst", 1);
 


### PR DESCRIPTION
Another PR coming from "spring cleaning" in my local branches. Adjusting the documentation for IsEuclideanRing is necessary because for e.g. polynomials, the euclidean degree can be `-infinity`.

Having `StandardAssociate` and `StandardAssociateUnit` for `ZmodnZ` simply is useful for writing various generic algorithms.