### PR TITLE
Don't expose (EAGER_)FLOAT_LITERAL_CACHE to the user; cleanup some float related kernel code

### DIFF
--- a/lib/float.gi
+++ b/lib/float.gi
@@ -79,7 +79,7 @@ InstallGlobalFunction(SetFloats, function(arg)
         EAGER_FLOAT_LITERAL_CONVERTERS.([r.eager]) := r.creator;
     fi;
     
-    UNBIND_GLOBAL("FLOAT_LITERAL_CACHE");
+    FLUSH_FLOAT_LITERAL_CACHE();
 
     if prec<>fail then
         r.constants.MANT_DIG := prec;

--- a/src/code.c
+++ b/src/code.c
@@ -1793,10 +1793,6 @@ void CodeStringExpr (
 static UInt GVAR_SAVED_FLOAT_INDEX;
 static UInt NextFloatExprNumber = 3;
 
-#if !defined(HPCGAP)
-static UInt NextEagerFloatLiteralNumber = 1;
-#endif
-
 static Obj EAGER_FLOAT_LITERAL_CACHE = 0;
 static Obj CONVERT_FLOAT_LITERAL_EAGER;
 
@@ -1890,8 +1886,7 @@ static void CodeEagerFloatExpr( Obj str, Char mark ) {
   ix = AddAList(EAGER_FLOAT_LITERAL_CACHE, v);
 #else
   assert(IS_PLIST(EAGER_FLOAT_LITERAL_CACHE));
-  AssPlist(EAGER_FLOAT_LITERAL_CACHE, NextEagerFloatLiteralNumber, v);
-  ix = NextEagerFloatLiteralNumber++;
+  ix = PushPlist(EAGER_FLOAT_LITERAL_CACHE, v);
 #endif
   ADDR_EXPR(fl)[0] = ix;
   ADDR_EXPR(fl)[1] = l;

--- a/src/code.c
+++ b/src/code.c
@@ -3334,7 +3334,7 @@ static Int InitKernel (
     InitGlobalBag( &STATE(StackExpr), "STATE(StackExpr)" );
 
     /* some functions and globals needed for float conversion */
-    InitCopyGVar( "EAGER_FLOAT_LITERAL_CACHE", &EAGER_FLOAT_LITERAL_CACHE);
+    InitGlobalBag( &EAGER_FLOAT_LITERAL_CACHE, "EAGER_FLOAT_LITERAL_CACHE" );
     InitFopyGVar( "CONVERT_FLOAT_LITERAL_EAGER", &CONVERT_FLOAT_LITERAL_EAGER);
 
     InitHdlrFuncsFromTable( GVarFuncs );
@@ -3351,7 +3351,6 @@ static Int InitKernel (
 static Int InitLibrary (
     StructInitInfo *    module )
 {
-    UInt gv;
     Obj cache;
 
 #ifdef HPCGAP
@@ -3362,14 +3361,13 @@ static Int InitLibrary (
 
     GVAR_SAVED_FLOAT_INDEX = GVarName("SavedFloatIndex");
     
-    gv = GVarName("EAGER_FLOAT_LITERAL_CACHE");
 #ifdef HPCGAP
     cache = NewAtomicList(T_ALIST, 1);
 #else
     cache = NEW_PLIST(T_PLIST+IMMUTABLE, 1000L);
     SET_LEN_PLIST(cache,0);
 #endif
-    AssGVar(gv, cache);
+    EAGER_FLOAT_LITERAL_CACHE = cache;
 
     /* init filters and functions                                          */
     InitGVarFuncsFromTable( GVarFuncs );

--- a/src/code.c
+++ b/src/code.c
@@ -1786,24 +1786,22 @@ void CodeStringExpr (
 **
 *F  CodeFloatExpr( <str> ) . . . . . . . .  code literal float expression
 */
-#define FLOAT_0_INDEX 1
-#define FLOAT_1_INDEX 2
-#define MAX_FLOAT_INDEX ((1L<<NR_SMALL_INT_BITS)-2)
-
+enum {
+    FLOAT_0_INDEX = 1,  // reserved for constant 0.0
+    FLOAT_1_INDEX = 2,  // reserved for constant 1.0
+    MAX_FLOAT_INDEX = ((1L<<NR_SMALL_INT_BITS)-2)
+};
 static UInt NextFloatExprNumber = 3;
 
-static Obj EAGER_FLOAT_LITERAL_CACHE = 0;
+Obj EAGER_FLOAT_LITERAL_CACHE = 0;
 static Obj CONVERT_FLOAT_LITERAL_EAGER;
 
 
 static UInt getNextFloatExprNumber( void ) {
   UInt next;
   HashLock(&NextFloatExprNumber);
-  if (NextFloatExprNumber > MAX_FLOAT_INDEX)
-    next = 0;
-  else {
-    next = NextFloatExprNumber++;
-  }
+  assert(NextFloatExprNumber < MAX_FLOAT_INDEX);
+  next = NextFloatExprNumber++;
   HashUnlock(&NextFloatExprNumber);
   return next;
 }
@@ -1923,7 +1921,7 @@ void CodeFloatExpr (
 
 /****************************************************************************
 **
-*F  CodeLongFloatExpr( <str> ) . . . . . . .code long literal float expression
+*F  CodeLongFloatExpr( <str> ) . . . . . . code long literal float expression
 */
 
 void CodeLongFloatExpr (

--- a/src/code.c
+++ b/src/code.c
@@ -1790,7 +1790,6 @@ void CodeStringExpr (
 #define FLOAT_1_INDEX 2
 #define MAX_FLOAT_INDEX ((1L<<NR_SMALL_INT_BITS)-2)
 
-static UInt GVAR_SAVED_FLOAT_INDEX;
 static UInt NextFloatExprNumber = 3;
 
 static Obj EAGER_FLOAT_LITERAL_CACHE = 0;
@@ -3359,8 +3358,6 @@ static Int InitLibrary (
     FilenameCache = NEW_PLIST(T_PLIST, 0);
 #endif
 
-    GVAR_SAVED_FLOAT_INDEX = GVarName("SavedFloatIndex");
-    
 #ifdef HPCGAP
     cache = NewAtomicList(T_ALIST, 1);
 #else
@@ -3383,8 +3380,7 @@ static Int InitLibrary (
 static Int PostRestore (
     StructInitInfo *    module )
 {
-  GVAR_SAVED_FLOAT_INDEX = GVarName("SavedFloatIndex");
-  NextFloatExprNumber = INT_INTOBJ(ValGVar(GVAR_SAVED_FLOAT_INDEX));
+  NextFloatExprNumber = INT_INTOBJ(ValGVar(GVarName("SavedFloatIndex")));
   return 0;
 }
 
@@ -3403,7 +3399,7 @@ static Int PreSave (
     return 1;
 
   /* push the FP cache index out into a GAP Variable */
-  AssGVar(GVAR_SAVED_FLOAT_INDEX, INTOBJ_INT(NextFloatExprNumber));
+  AssGVar(GVarName("SavedFloatIndex"), INTOBJ_INT(NextFloatExprNumber));
 
   /* clean any old data out of the statement and expression stacks */
   for (i = 0; i < SIZE_BAG(STATE(StackStat))/sizeof(UInt); i++)

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1215,22 +1215,15 @@ Obj             EvalFloatExprLazy (
                MAX_FLOAT_LITERAL_CACHE_SIZE == INTOBJ_INT(0) ||
                ix <= INT_INTOBJ(MAX_FLOAT_LITERAL_CACHE_SIZE))) {
       cache = FLOAT_LITERAL_CACHE;
+      if (!cache) {
 #ifdef HPCGAP
-      if (!cache) {
           cache = NewAtomicList(T_ALIST, ix);
-          AssGVar(GVAR_FLOAT_LITERAL_CACHE, cache);
-      }
-      else
-        assert(TNUM_OBJ(cache) == T_ALIST);
-      fl = Elm0AList(cache,ix);
 #else
-      if (!cache) {
           cache = NEW_PLIST(T_PLIST,ix);
+#endif
           AssGVar(GVAR_FLOAT_LITERAL_CACHE, cache);
       }
-      GROW_PLIST(cache,ix);
-      fl = ELM_PLIST(cache,ix);
-#endif
+      fl = ELM0_LIST(cache, ix);
       if (fl)
         return fl;
     }
@@ -1241,11 +1234,7 @@ Obj             EvalFloatExprLazy (
            len );
     fl = CALL_1ARGS(CONVERT_FLOAT_LITERAL, string);
     if (cache) {
-#ifdef HPCGAP
-      AssAList(cache, ix, fl);
-#else
-      AssPlist(cache, ix, fl);
-#endif
+      ASS_LIST(cache, ix, fl);
     }
 
     return fl;
@@ -1260,23 +1249,10 @@ Obj             EvalFloatExprLazy (
 */
 static Obj EAGER_FLOAT_LITERAL_CACHE;
 
-Obj             EvalFloatExprEager (
-    Expr                expr )
+Obj EvalFloatExprEager(Expr expr)
 {
-    UInt                 ix;
-    Obj cache= 0;
-    Obj fl;
-    
-    ix = ((UInt *)ADDR_EXPR(expr))[0];
-    cache = EAGER_FLOAT_LITERAL_CACHE;
-#ifdef HPCGAP
-    assert(TNUM_OBJ(cache) == T_ALIST);
-    fl = Elm0AList(cache,ix);
-#else
-    assert(IS_PLIST(cache));
-    fl = ELM_PLIST(cache,ix);
-#endif
-    assert(fl);
+    UInt ix = ((UInt *)ADDR_EXPR(expr))[0];
+    Obj fl = ELM_LIST(EAGER_FLOAT_LITERAL_CACHE, ix);
     return fl;
 }
 

--- a/tst/testinstall/float.tst
+++ b/tst/testinstall/float.tst
@@ -157,6 +157,34 @@ gap> EqFloat(0.0,0.0/0.0);
 false
 
 #
+# float literal expressions in functions
+#
+
+# eager literal
+gap> f := {} -> 0.0_;; f();
+0.
+gap> f := {} -> 1.0_;; f();
+1.
+gap> f := {} -> 42.0_;; f();
+42.
+gap> Display(f);
+function (  )
+    return 42.0_;
+end
+
+# lazy literal
+gap> g := {} -> 0.0;; g();
+0.
+gap> g := {} -> 1.0;; g();
+1.
+gap> g := {} -> 23.0;; g();
+23.
+gap> Display(g);
+function (  )
+    return 23.0;
+end
+
+#
 gap> STOP_TEST( "float.tst", 1);
 
 #############################################################################


### PR DESCRIPTION
This PR partially addresses issue #1993.

I apologize for the last commit which run `clang-format` on some of the code, but it really helped me a lot in understanding and comparing some of that code, so I thought I'd try to "sneak it in" anyway.