### PR TITLE
Get rid of SyStackAlign and SYS_STACK_ALIGN

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -3236,7 +3236,7 @@ void InitializeGap (
 
     /* Initialise memory  -- have to do this here to make sure we are at top of C stack */
     InitBags( SyAllocBags, SyStorMin,
-              0, (Bag*)(((UInt)pargc/SyStackAlign)*SyStackAlign), SyStackAlign,
+              0, (Bag*)(((UInt)pargc/C_STACK_ALIGN)*C_STACK_ALIGN), C_STACK_ALIGN,
               SyAbortBags );
 #if !defined(BOEHM_GC)
     InitMsgsFuncBags( SyMsgsBags );

--- a/src/system.c
+++ b/src/system.c
@@ -100,22 +100,6 @@ const Char * SyWindowsPath = "/cygdrive/c/gap4dev";
 
 /****************************************************************************
 **
-*V  SyStackAlign  . . . . . . . . . . . . . . . . . .  alignment of the stack
-**
-**  'SyStackAlign' is  the  alignment  of items on the stack.   It  must be a
-**  divisor of  'sizof(Bag)'.  The  addresses of all identifiers on the stack
-**  must be  divisible by 'SyStackAlign'.  So if it  is 1, identifiers may be
-**  anywhere on the stack, and if it is  'sizeof(Bag)',  identifiers may only
-**  be  at addresses  divisible by  'sizeof(Bag)'.  This value is initialized
-**  from a macro passed from the makefile, because it is machine dependent.
-**
-**  This value is passed to 'InitBags'.
-*/
-UInt SyStackAlign = SYS_STACK_ALIGN;
-
-
-/****************************************************************************
-**
 *V  SyArchitecture  . . . . . . . . . . . . . . . .  name of the architecture
 */
 const Char * SyArchitecture = SYS_ARCH;

--- a/src/system.h
+++ b/src/system.h
@@ -75,9 +75,6 @@
 /* define to debug masterpointers errors                                   */
 /* #undef DEBUG_MASTERPOINTERS */
 
-/* define stack align for gasman (from "config.h")                         */
-#define SYS_STACK_ALIGN         C_STACK_ALIGN
-
 /* check if we are on a 64 bit machine                                     */
 #if SIZEOF_VOID_P == 8
 # define SYS_IS_64_BIT          1
@@ -271,21 +268,6 @@ enum { BIPEB = sizeof(UInt) * 8L, LBIPEB = (BIPEB == 64) ? 6L : 5L };
 **
 *F * * * * * * * * * * * command line settable options  * * * * * * * * * * *
 */
-
-/****************************************************************************
-**
-*V  SyStackAlign  . . . . . . . . . . . . . . . . . .  alignment of the stack
-**
-**  'SyStackAlign' is  the  alignment  of items on the stack.   It  must be a
-**  divisor of  'sizof(Bag)'.  The  addresses of all identifiers on the stack
-**  must be  divisable by 'SyStackAlign'.  So if it  is 1, identifiers may be
-**  anywhere on the stack, and if it is  'sizeof(Bag)',  identifiers may only
-**  be  at addresses  divisible by  'sizeof(Bag)'.  This value is initialized
-**  from a macro passed from the makefile, because it is machine dependent.
-**
-**  This value is passed to 'InitBags'.
-*/
-extern UInt SyStackAlign;
 
 
 /****************************************************************************


### PR DESCRIPTION
Now there is only `C_STACK_ALIGN` and `StackAlignBags` left. The former is a
constant computed by autoconf and placed into config.h. This value is then
passed to `InitBags`, which stores it into StackAlignBags.

I decided to leave these two separate, as the `InitBags` documentation
provides lots of details on how this value is used, and I felt it easiest to
leave that as it is, instead of trying to rewrite it to be correct if I had
removed the `stack_align` argument to `InitBags`.

Also, my main goal is achieved: Now it only takes one step find out where the
value in StackAlignBags comes from, instead of three (or two instead of four,
depending on how you count). Much better, in any case.

Resolves #1218