### PR TITLE
Change all StructInitInfo instances to C99 init

### DIFF
--- a/hpcgap/src/c_oper1.c
+++ b/hpcgap/src/c_oper1.c
@@ -4625,18 +4625,12 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ MODULE_STATIC,
- /* name        = */ "GAPROOT/lib/oper1.g",
- /* revision_c  = */ 0,
- /* revision_h  = */ 0,
- /* version     = */ 0,
- /* crc         = */ 81317498,
- /* initKernel  = */ InitKernel,
- /* initLibrary = */ InitLibrary,
- /* checkInit   = */ 0,
- /* preSave     = */ 0,
- /* postSave    = */ 0,
- /* postRestore = */ PostRestore
+ .type        = MODULE_STATIC,
+ .name        = "GAPROOT/lib/oper1.g",
+ .crc         = 81317498,
+ .initKernel  = InitKernel,
+ .initLibrary = InitLibrary,
+ .postRestore = PostRestore,
 };
 
 StructInitInfo * Init__oper1 ( void )

--- a/hpcgap/src/c_type1.c
+++ b/hpcgap/src/c_type1.c
@@ -4732,18 +4732,12 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ MODULE_STATIC,
- /* name        = */ "GAPROOT/lib/type1.g",
- /* revision_c  = */ 0,
- /* revision_h  = */ 0,
- /* version     = */ 0,
- /* crc         = */ -108827285,
- /* initKernel  = */ InitKernel,
- /* initLibrary = */ InitLibrary,
- /* checkInit   = */ 0,
- /* preSave     = */ 0,
- /* postSave    = */ 0,
- /* postRestore = */ PostRestore
+ .type        = MODULE_STATIC,
+ .name        = "GAPROOT/lib/type1.g",
+ .crc         = -108827285,
+ .initKernel  = InitKernel,
+ .initLibrary = InitLibrary,
+ .postRestore = PostRestore,
 };
 
 StructInitInfo * Init__type1 ( void )

--- a/src/ariths.c
+++ b/src/ariths.c
@@ -1927,18 +1927,12 @@ static Int InitLibrary (
 *F  InitInfoAriths()  . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "ariths",                           /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "ariths",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoAriths ( void )

--- a/src/blister.c
+++ b/src/blister.c
@@ -2590,18 +2590,12 @@ static Int InitLibrary (
 *F  InitInfoBlist() . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "blister",                          /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "blister",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoBlist ( void )

--- a/src/bool.c
+++ b/src/bool.c
@@ -466,18 +466,12 @@ static Int InitLibrary (
 *F  InitInfoBool()  . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "bool",                             /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "bool",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoBool ( void )

--- a/src/c_methsel1.c
+++ b/src/c_methsel1.c
@@ -5594,18 +5594,12 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ MODULE_STATIC,
- /* name        = */ "GAPROOT/lib/methsel1.g",
- /* revision_c  = */ 0,
- /* revision_h  = */ 0,
- /* version     = */ 0,
- /* crc         = */ 102657344,
- /* initKernel  = */ InitKernel,
- /* initLibrary = */ InitLibrary,
- /* checkInit   = */ 0,
- /* preSave     = */ 0,
- /* postSave    = */ 0,
- /* postRestore = */ PostRestore
+ .type        = MODULE_STATIC,
+ .name        = "GAPROOT/lib/methsel1.g",
+ .crc         = 102657344,
+ .initKernel  = InitKernel,
+ .initLibrary = InitLibrary,
+ .postRestore = PostRestore,
 };
 
 StructInitInfo * Init__methsel1 ( void )

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -4505,18 +4505,12 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ MODULE_STATIC,
- /* name        = */ "GAPROOT/lib/oper1.g",
- /* revision_c  = */ 0,
- /* revision_h  = */ 0,
- /* version     = */ 0,
- /* crc         = */ 130680522,
- /* initKernel  = */ InitKernel,
- /* initLibrary = */ InitLibrary,
- /* checkInit   = */ 0,
- /* preSave     = */ 0,
- /* postSave    = */ 0,
- /* postRestore = */ PostRestore
+ .type        = MODULE_STATIC,
+ .name        = "GAPROOT/lib/oper1.g",
+ .crc         = 130680522,
+ .initKernel  = InitKernel,
+ .initLibrary = InitLibrary,
+ .postRestore = PostRestore,
 };
 
 StructInitInfo * Init__oper1 ( void )

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -4457,18 +4457,12 @@ static Int InitLibrary ( StructInitInfo * module )
 
 /* <name> returns the description of this module */
 static StructInitInfo module = {
- /* type        = */ MODULE_STATIC,
- /* name        = */ "GAPROOT/lib/type1.g",
- /* revision_c  = */ 0,
- /* revision_h  = */ 0,
- /* version     = */ 0,
- /* crc         = */ 38895215,
- /* initKernel  = */ InitKernel,
- /* initLibrary = */ InitLibrary,
- /* checkInit   = */ 0,
- /* preSave     = */ 0,
- /* postSave    = */ 0,
- /* postRestore = */ PostRestore
+ .type        = MODULE_STATIC,
+ .name        = "GAPROOT/lib/type1.g",
+ .crc         = 38895215,
+ .initKernel  = InitKernel,
+ .initLibrary = InitLibrary,
+ .postRestore = PostRestore,
 };
 
 StructInitInfo * Init__type1 ( void )

--- a/src/calls.c
+++ b/src/calls.c
@@ -2156,18 +2156,12 @@ static Int InitLibrary (
 *F  InitInfoCalls() . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "calls",                            /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "calls",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoCalls ( void )

--- a/src/code.c
+++ b/src/code.c
@@ -3462,18 +3462,14 @@ static void InitModuleState(ModuleStateOffset offset)
 *F  InitInfoCode()  . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "code",                             /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                        /* checkInit                      */
-    PreSave,                            /* preSave                        */
-    0,                                  /* postSave                       */
-    PostRestore                        /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "code",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .preSave = PreSave,
+    .postRestore = PostRestore
 };
 
 StructInitInfo * InitInfoCode ( void )

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5713,22 +5713,16 @@ Int CompileFunc (
     Emit( "\n/* <name> returns the description of this module */\n" );
     Emit( "static StructInitInfo module = {\n" );
     if ( ! strcmp( "Init_Dynamic", name ) ) {
-        Emit( "/* type        = */ MODULE_DYNAMIC,\n" );
+        Emit( ".type        = MODULE_DYNAMIC,\n" );
     }
     else {
-        Emit( "/* type        = */ MODULE_STATIC,\n" );
+        Emit( ".type        = MODULE_STATIC,\n" );
     }
-    Emit( "/* name        = */ \"%C\",\n", magic2 );
-    Emit( "/* revision_c  = */ %d,\n",     0 );
-    Emit( "/* revision_h  = */ %d,\n",     0 );
-    Emit( "/* version     = */ %d,\n",     0 );
-    Emit( "/* crc         = */ %d,\n",     magic1 );
-    Emit( "/* initKernel  = */ InitKernel,\n" );
-    Emit( "/* initLibrary = */ InitLibrary,\n" );
-    Emit( "/* checkInit   = */ 0,\n" );
-    Emit( "/* preSave     = */ 0,\n" );
-    Emit( "/* postSave    = */ 0,\n" );
-    Emit( "/* postRestore = */ PostRestore\n" );
+    Emit( ".name        = \"%C\",\n", magic2 );
+    Emit( ".crc         = %d,\n",     magic1 );
+    Emit( ".initKernel  = InitKernel,\n" );
+    Emit( ".initLibrary = InitLibrary,\n" );
+    Emit( ".postRestore = PostRestore,\n" );
     Emit( "};\n" );
     Emit( "\n" );
     Emit( "StructInitInfo * %n ( void )\n", name );

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -6076,18 +6076,13 @@ static Int InitLibrary (
 *F  InitInfoCompiler() . . . . . . . . . . . . . . .  table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "compiler",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    PostRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "compiler",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = PostRestore
 };
 
 StructInitInfo * InitInfoCompiler ( void )

--- a/src/costab.c
+++ b/src/costab.c
@@ -2489,18 +2489,12 @@ static Int InitLibrary (
 *F  InitInfoCosetTable()  . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "costab",                           /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "costab",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoCosetTable ( void )

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -2266,18 +2266,12 @@ static void InitModuleState(ModuleStateOffset offset)
 *F  InitInfoCyc() . . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "cyclotom",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "cyclotom",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoCyc ( void )

--- a/src/dt.c
+++ b/src/dt.c
@@ -1817,18 +1817,12 @@ static Int InitLibrary (
 *F  InitInfoDeepThought() . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "dt",                               /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "dt",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoDeepThought ( void )

--- a/src/dteval.c
+++ b/src/dteval.c
@@ -1077,18 +1077,13 @@ static Int InitLibrary (
 *F  InitInfoDTEvaluation()  . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "dteval",                           /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    PostRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "dteval",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = PostRestore
 };
 
 StructInitInfo * InitInfoDTEvaluation ( void )

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -2016,18 +2016,13 @@ static Int InitLibrary(StructInitInfo * module)
 *F  InitInfoExprs() . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "exprs",                            /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    InitLibrary                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "exprs",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = InitLibrary
 };
 
 StructInitInfo * InitInfoExprs ( void )

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -2096,18 +2096,12 @@ static Int InitLibrary (
 *F  InitInfoFinfield()  . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "finfield",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "finfield",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoFinfield ( void )

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1905,18 +1905,12 @@ static void InitModuleState(ModuleStateOffset offset)
 *F  InitInfoFuncs() . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "funcs",                            /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "funcs",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoFuncs ( void )

--- a/src/gap.c
+++ b/src/gap.c
@@ -3020,18 +3020,13 @@ static Int InitLibrary (
 *F  InitInfoGap() . . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "gap",                              /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    PostRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "gap",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = PostRestore
 };
 
 StructInitInfo * InitInfoGap ( void )

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1796,18 +1796,16 @@ static void InitModuleState(ModuleStateOffset offset)
 *F  InitInfoGVars() . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "gvars",                            /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    CheckInit,                          /* checkInit                      */
-    PreSave,                            /* preSave                        */
-    PostSave,                            /* postSave                       */
-    PostRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "gvars",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .checkInit = CheckInit,
+    .preSave = PreSave,
+    .postSave = PostSave,
+    .postRestore = PostRestore
 };
 
 StructInitInfo * InitInfoGVars ( void )

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -286,18 +286,12 @@ static Int InitKernel(StructInitInfo * module)
 *F  InitInfoHookIntrptr() . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN, /* type                           */
-    "hookintrprtr", /* name                           */
-    0,              /* revision entry of c file       */
-    0,              /* revision entry of h file       */
-    0,              /* version                        */
-    0,              /* crc                            */
-    InitKernel,     /* initKernel                     */
-    InitLibrary,    /* initLibrary                    */
-    0,              /* checkInit                      */
-    0,              /* preSave                        */
-    0,              /* postSave                       */
-    0               /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "hookintrprtr",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoHookIntrprtr(void)

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -2097,18 +2097,12 @@ static Int InitLibrary (
 *F  InitInfoAObjects() . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "aobjects",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                         		/* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "aobjects",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoAObjects ( void )

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -1189,18 +1189,12 @@ static Int InitLibrary(StructInitInfo * module)
 *F  InitInfoObjSet() . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN, /* type                           */
-    "serialize",    /* name                           */
-    0,              /* revision entry of c file       */
-    0,              /* revision entry of h file       */
-    0,              /* version                        */
-    0,              /* crc                            */
-    InitKernel,     /* initKernel                     */
-    InitLibrary,    /* initLibrary                    */
-    0,              /* checkInit                      */
-    0,              /* preSave                        */
-    0,              /* postSave                       */
-    0               /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "serialize",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoSerialize(void)

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -2854,18 +2854,12 @@ static Int InitLibrary(StructInitInfo * module)
 *F  InitInfoThreadAPI() . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN, /* type                           */
-    "threadapi",    /* name                           */
-    0,              /* revision entry of c file       */
-    0,              /* revision entry of h file       */
-    0,              /* version                        */
-    0,              /* crc                            */
-    InitKernel,     /* initKernel                     */
-    InitLibrary,    /* initLibrary                    */
-    0,              /* checkInit                      */
-    0,              /* preSave                        */
-    0,              /* postSave                       */
-    0               /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "threadapi",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoThreadAPI(void)

--- a/src/integer.c
+++ b/src/integer.c
@@ -2809,18 +2809,12 @@ static Int InitLibrary ( StructInitInfo *    module )
 *F  InitInfoInt() . . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-  MODULE_BUILTIN,                        /* type                           */
-  "integer",                             /* name                           */
-  0,                                     /* revision entry of c file       */
-  0,                                     /* revision entry of h file       */
-  0,                                     /* version                        */
-  0,                                     /* crc                            */
-  InitKernel,                            /* initKernel                     */
-  InitLibrary,                           /* initLibrary                    */
-  0,                                     /* checkInit                      */
-  0,                                     /* preSave                        */
-  0,                                     /* postSave                       */
-  0                                      /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "integer",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoInt ( void )

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -800,18 +800,12 @@ static Int InitLibrary (
 *F  InitInfoIntFuncs() . . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "intfuncs",                          /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "intfuncs",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoIntFuncs ( void )

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -4638,18 +4638,12 @@ static Int InitLibrary (
 *F  InitInfoIntrprtr()  . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "intrprtr",                          /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "intrprtr",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoIntrprtr ( void )

--- a/src/io.c
+++ b/src/io.c
@@ -1834,18 +1834,12 @@ static void InitModuleState(ModuleStateOffset offset)
  *F  InitInfoScanner() . . . . . . . . . . . . . . . . table of init functions
  */
 static StructInitInfo module = {
-  MODULE_BUILTIN,                     /* type                           */
-  "scanner",                          /* name                           */
-  0,                                  /* revision entry of c file       */
-  0,                                  /* revision entry of h file       */
-  0,                                  /* version                        */
-  0,                                  /* crc                            */
-  InitKernel,                         /* initKernel                     */
-  InitLibrary,                        /* initLibrary                    */
-  0,                                  /* checkInit                      */
-  0,                                  /* preSave                        */
-  0,                                  /* postSave                       */
-  0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "scanner",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoIO ( void )

--- a/src/iostream.c
+++ b/src/iostream.c
@@ -746,18 +746,13 @@ static Int InitLibrary(StructInitInfo * module)
 *F  InitInfoSysFiles()  . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "iostream",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    postRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "iostream",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = postRestore
 };
 
 StructInitInfo * InitInfoIOStream(void)

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1895,18 +1895,12 @@ static Int InitLibrary (
 *F  InitInfoListFunc()  . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "listfunc",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "listfunc",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoListFunc ( void )

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -2412,18 +2412,12 @@ static Int InitLibrary (
 *F  InitInfoListOper()  . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "listoper",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "listoper",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoListOper ( void )

--- a/src/lists.c
+++ b/src/lists.c
@@ -3016,18 +3016,14 @@ static Int CheckInit (
 *F  InitInfoLists() . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "lists",                            /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    CheckInit,                          /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    PostRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "lists",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .checkInit = CheckInit,
+    .postRestore = PostRestore
 };
 
 StructInitInfo * InitInfoLists ( void )

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -599,18 +599,12 @@ static Int InitLibrary (
 *F  InitInfoMacfloat()  . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "macfloat",                             /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "macfloat",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoMacfloat ( void )

--- a/src/objccoll.c
+++ b/src/objccoll.c
@@ -80,18 +80,10 @@
 **
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "objccoll",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    0,                                  /* initKernel                     */
-    0,                                  /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "objccoll",
 };
 
 StructInitInfo * InitInfoCombiCollector ( void )

--- a/src/objcftl.c
+++ b/src/objcftl.c
@@ -415,18 +415,13 @@ static Int InitLibrary (
 *F  InitInfoPcc() . . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "objcftl",                          /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    PostRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "objcftl",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = PostRestore
 };
 
 StructInitInfo * InitInfoPcc ( void )

--- a/src/objects.c
+++ b/src/objects.c
@@ -2305,18 +2305,12 @@ static Int InitLibrary (
 *F  InitInfoObjects() . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "objects",                          /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "objects",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoObjects ( void )

--- a/src/objfgelm.c
+++ b/src/objfgelm.c
@@ -3359,18 +3359,12 @@ static Int InitLibrary (
 *F  InitInfoFreeGroupElements() . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "objfgelm",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "objfgelm",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoFreeGroupElements ( void )

--- a/src/objpcgel.c
+++ b/src/objpcgel.c
@@ -645,18 +645,12 @@ static Int InitLibrary (
 *F  InitInfoPcElements()  . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "objpcgel",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "objpcgel",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoPcElements ( void )

--- a/src/objscoll.c
+++ b/src/objscoll.c
@@ -841,18 +841,12 @@ static void InitModuleState(ModuleStateOffset offset)
 *F  InitInfoSingleCollector() . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "objscoll",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "objscoll",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoSingleCollector ( void )

--- a/src/objset.c
+++ b/src/objset.c
@@ -1043,18 +1043,12 @@ static Int InitLibrary (
 *F  InitInfoObjSet() . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "objset",                           /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "objset",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoObjSets ( void )

--- a/src/opers.c
+++ b/src/opers.c
@@ -4448,18 +4448,13 @@ static void InitModuleState(ModuleStateOffset offset)
 *F  InitInfoOpers() . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "opers",                            /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    postRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "opers",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = postRestore
 };
 
 StructInitInfo * InitInfoOpers ( void )

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -4788,18 +4788,12 @@ static void InitModuleState(ModuleStateOffset offset)
 *F  InitInfoPermutat()  . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "permutat",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "permutat",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoPermutat ( void )

--- a/src/plist.c
+++ b/src/plist.c
@@ -4163,18 +4163,12 @@ static Int InitLibrary (
 *F  InitInfoPlist() . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "plist",                            /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "plist",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoPlist ( void )

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -6795,18 +6795,12 @@ static void InitModuleState(ModuleStateOffset offset)
  *F InitInfoPPerm()   . . . . . . . . . . . . . . . table of init functions
  */
 static StructInitInfo module = {
-    MODULE_BUILTIN, /* type                           */
-    "pperm",        /* name                           */
-    0,              /* revision entry of c file       */
-    0,              /* revision entry of h file       */
-    0,              /* version                        */
-    0,              /* crc                            */
-    InitKernel,     /* initKernel                     */
-    InitLibrary,    /* initLibrary                    */
-    0,              /* checkInit                      */
-    0,              /* preSave                        */
-    0,              /* postSave                       */
-    0               /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "pperm",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoPPerm(void)

--- a/src/precord.c
+++ b/src/precord.c
@@ -976,18 +976,12 @@ static Int InitLibrary (
 *F  InitInfoPRecord() . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "precord",                          /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "precord",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoPRecord ( void )

--- a/src/profile.c
+++ b/src/profile.c
@@ -836,18 +836,13 @@ static Int PostRestore ( StructInitInfo * module )
 *F  InitInfoStats() . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "stats",                            /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    PostRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "stats",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = PostRestore
 };
 
 StructInitInfo * InitInfoProfile ( void )

--- a/src/range.c
+++ b/src/range.c
@@ -1485,18 +1485,12 @@ static Int InitLibrary (
 *F  InitInfoRange() . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "range",                            /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "range",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoRange ( void )

--- a/src/rational.c
+++ b/src/rational.c
@@ -1053,18 +1053,12 @@ static Int InitLibrary (
 *F  InitInfoRat() . . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "rational",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "rational",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoRat ( void )

--- a/src/read.c
+++ b/src/read.c
@@ -3094,18 +3094,11 @@ static void InitModuleState(ModuleStateOffset offset)
 *F  InitInfoRead()  . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "read",                             /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    0,                                  /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "read",
+    .initKernel = InitKernel,
 };
 
 StructInitInfo * InitInfoRead ( void )

--- a/src/records.c
+++ b/src/records.c
@@ -778,18 +778,12 @@ static Int InitLibrary (
 *F  InitInfoRecords() . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "records",                          /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "records",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoRecords ( void )

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -1053,18 +1053,12 @@ static Int InitLibrary (
 *F  InitInfoSaveLoad()  . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "saveload",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "saveload",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoSaveLoad ( void )

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1196,18 +1196,12 @@ static void InitModuleState(ModuleStateOffset offset)
  *F  InitInfoScanner() . . . . . . . . . . . . . . . . table of init functions
  */
 static StructInitInfo module = {
-  MODULE_BUILTIN,                     /* type                           */
-  "scanner",                          /* name                           */
-  0,                                  /* revision entry of c file       */
-  0,                                  /* revision entry of h file       */
-  0,                                  /* version                        */
-  0,                                  /* crc                            */
-  InitKernel,                         /* initKernel                     */
-  InitLibrary,                        /* initLibrary                    */
-  0,                                  /* checkInit                      */
-  0,                                  /* preSave                        */
-  0,                                  /* postSave                       */
-  0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "scanner",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoScanner ( void )

--- a/src/sctable.c
+++ b/src/sctable.c
@@ -412,18 +412,12 @@ static Int InitLibrary (
 *F  InitInfoSCTable() . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "sctable",                          /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "sctable",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoSCTable ( void )

--- a/src/set.c
+++ b/src/set.c
@@ -1124,18 +1124,12 @@ static Int InitLibrary (
 *F  InitInfoSet() . . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "set",                              /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "set",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoSet ( void )

--- a/src/stats.c
+++ b/src/stats.c
@@ -2336,18 +2336,12 @@ static void InitModuleState(ModuleStateOffset offset)
 *F  InitInfoStats() . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "stats",                            /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "stats",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoStats ( void )

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -2532,18 +2532,12 @@ static Int InitLibrary (
 *F  InitInfoString()  . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "string",                           /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "string",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoString ( void )

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -3594,18 +3594,13 @@ static Int InitLibrary(
 *F  InitInfoSysFiles()  . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "sysfiles",                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    postRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "sysfiles",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = postRestore
 };
 
 StructInitInfo * InitInfoSysFiles ( void )

--- a/src/tietze.c
+++ b/src/tietze.c
@@ -1744,18 +1744,12 @@ static Int InitLibrary (
 *F  InitInfoTietze()  . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "tietze",                           /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "tietze",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoTietze ( void )

--- a/src/trans.c
+++ b/src/trans.c
@@ -5768,18 +5768,12 @@ static void InitModuleState(ModuleStateOffset offset)
 *F  InitInfoTrans()  . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN, /* type                           */
-    "trans",        /* name                           */
-    0,              /* revision entry of c file       */
-    0,              /* revision entry of h file       */
-    0,              /* version                        */
-    0,              /* crc                            */
-    InitKernel,     /* initKernel                     */
-    InitLibrary,    /* initLibrary                    */
-    0,              /* checkInit                      */
-    0,              /* preSave                        */
-    0,              /* postSave                       */
-    0               /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "trans",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoTrans(void)

--- a/src/vars.c
+++ b/src/vars.c
@@ -2801,18 +2801,13 @@ static void InitModuleState(ModuleStateOffset offset)
 *F  InitInfoVars()  . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "vars",                             /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    PostRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "vars",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = PostRestore
 };
 
 StructInitInfo * InitInfoVars ( void )

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -5978,18 +5978,13 @@ static Int InitLibrary (
 *F  InitInfoVec8bit()  . . . . . . . . . . . . . . .  table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "vec8bit",                          /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    PreSave,                            /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "vec8bit",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .preSave = PreSave,
 };
 
 StructInitInfo * InitInfoVec8bit ( void )

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -1183,18 +1183,12 @@ static Int InitLibrary (
 *F  InitInfoVecFFE()  . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "vecffe",                           /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "vecffe",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoVecFFE ( void )

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -4595,18 +4595,12 @@ static Int InitLibrary (
 *F  InitInfoGF2Vec()  . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "vecgf2",                           /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "vecgf2",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoGF2Vec ( void )

--- a/src/vector.c
+++ b/src/vector.c
@@ -772,18 +772,12 @@ static Int InitLibrary (
 *F  InitInfoVector()  . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "vector",                           /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "vector",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoVector ( void )

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -905,18 +905,12 @@ static Int InitLibrary (
 *F  InitInfoWeakPtr() . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "weakptr",                          /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    0                                   /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "weakptr",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 StructInitInfo * InitInfoWeakPtr ( void )


### PR DESCRIPTION
Doing this here and also in packages opens up the possibility for us to remove and add entries in the future (e.g. to remove revision_c, revision_h, version, and instead add e.g. initModuleState).

It is also IMHO easier to read and get right, thus avoids errors. Indeed, people already used comments to make it clear which field each line was corresponding to, we just formalize this.

The changes were made with a regex, so if this conflicts with a PR (e.g. with PR #1994), it's easy enough to update this.

Also, I have applied similar changes to all packages with kernel extensions I have access to. I hope we can migrate them all to use this, too.