### PR TITLE
Increase stack size on cygwin (the default is too small)

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -391,6 +391,9 @@ bin/cygwin-version.txt:
 
 GAP_CPPFLAGS += "-DCOMPILECYGWINDLL"
 
+# increase stack size, the default is too small (see issue #1522)
+GAP_LDFLAGS += -Wl,--stack,16777216
+
 # Special build rules for CYGWIN / Windows: In order to allow kernel
 # extensions, we employ a trick: GAP itself is compiled into DLL, in which 
 # GAP's standard main function is renamed. And gap.exe is a tiny binary which


### PR DESCRIPTION
Closes #1522.