### PR TITLE
Remove bin/@GAPARCH@/ from path to gap.exe in bat-files templates

### DIFF
--- a/cnf/cygwin/gap.bat.in
+++ b/cnf/cygwin/gap.bat.in
@@ -4,6 +4,6 @@ set LANG=en_US.UTF-8
 set HOME=%HOMEDRIVE%%HOMEPATH%
 set PATH=@wincygbin@;%PATH%
 cd %HOME%
-start "GAP" @wincygbin@\mintty.exe -s 120,40 @gapdir@/bin/@GAPARCH@/gap.exe -l @gapdir@ %*
+start "GAP" @wincygbin@\mintty.exe -s 120,40 @gapdir@/gap.exe -l @gapdir@ %*
 if NOT ["%errorlevel%"]==["0"] timeout 15
 exit

--- a/cnf/cygwin/gapcmd.bat.in
+++ b/cnf/cygwin/gapcmd.bat.in
@@ -4,6 +4,6 @@ set LANG=en_US.UTF-8
 set HOME=%HOMEDRIVE%%HOMEPATH%
 set PATH=@wincygbin@;%PATH%
 cd %HOME%
-@wingapdir@\bin\@GAPARCH@\gap.exe -l @gapdir@ %*
+@wingapdir@\gap.exe -l @gapdir@ %*
 if NOT ["%errorlevel%"]==["0"] timeout 15
 exit

--- a/cnf/cygwin/gaprxvt.bat.in
+++ b/cnf/cygwin/gaprxvt.bat.in
@@ -4,6 +4,6 @@ set LANG=en_US.ISO-8859-1
 set HOME=%HOMEDRIVE%%HOMEPATH%
 set PATH=@wincygbin@;%PATH%
 cd %HOME%
-start "GAP" @wincygbin@\rxvt.exe -fn fixedsys -sl 1000 -e @gapdir@/bin/@GAPARCH@/gap.exe -l @gapdir@ %*
+start "GAP" @wincygbin@\rxvt.exe -fn fixedsys -sl 1000 -e @gapdir@/gap.exe -l @gapdir@ %*
 if NOT ["%errorlevel%"]==["0"] timeout 15
 exit


### PR DESCRIPTION
This is one the tasks identified in #1820.