### PR TITLE
Add system headers required for cygwin

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -32,7 +32,14 @@
 
 #include <dirent.h>
 #include <errno.h>
+#include <time.h>
 #include <unistd.h>
+
+#ifdef HAVE_SELECT
+// For FuncUNIXSelect
+#include <sys/time.h>
+#endif
+
 
 
 /****************************************************************************


### PR DESCRIPTION
This (hopefully) adds some headers required by some systems, in particular older versions of cygwin.

The documentation for the time related functions does mention time.h and sys/time.h. I decided to include them both to be safe. They are included in other files (with sys/time.h guarded as appropriate), so I don't see how this could cause any problems.