### PR TITLE
kernel: replace UNGET_CHAR by PEEK_CHAR

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -76,13 +76,21 @@ void GET_CHAR(void)
         GetLine();
 }
 
-void UNGET_CHAR(Char c)
+Char PEEK_CHAR(void)
 {
     assert(IS_CHAR_PUSHBACK_EMPTY());
-    STATE(Pushback) = c;
+    // store the current character
+    STATE(Pushback) = *STATE(In);
+
+    // read next character
+    GET_CHAR();
+
+    // fake insert the previous character
     STATE(RealIn) = STATE(In);
     STATE(In) = &STATE(Pushback);
+    return *STATE(RealIn);
 }
+
 
 // Get current line position. In the case where we pushed back the last
 // character on the previous line we return the first character of the

--- a/src/io.h
+++ b/src/io.h
@@ -21,8 +21,8 @@
 #include <src/system.h>
 
 extern Int  GetLinePosition(void);
-extern void GET_CHAR();
-extern void UNGET_CHAR(Char c);
+extern void GET_CHAR(void);
+extern Char PEEK_CHAR(void);
 
 
 /****************************************************************************


### PR DESCRIPTION
`UNGET_CHAR` was easy to use incorrectly. Indeed, I claim that three of the four use cases were formally incorrect. Specifically, we did `UNGET_CHAR(*STATE(In))`, but that puts the currently visible character back -- it should put the one before that back! In one case, this did not matter, as both of those were equal to '.'. This leaves two cases in which I think we put back the wrong character, both are inside the floating point code. It would be interesting to figure out if there is an input where this leads to an incorrect reaction by GAP (I only briefly tried to find some, but all I constructed ended up being inputs which leads to errors either way).

To fix this and avoid future problems, I replaced `UNGET_CHAR` by a new function `PEEK_CHAR`. This has the added advantage that we know we'll never need to put back things twice in a row. I.e. you could `PEEK_CHAR` multiple times in a row without problems.

Also, this opens up a chance for future refactoring: with some extra effort and rearranging, we may be able to get rid of `Pushback` and `RealIn` now, if we assume that we never peek beyond the end of a line (which I think is true right now, and could be added to the API). In that case, for long lines, we just would need to make sure that `GetLine()` carries over the last character of the previous line buffer as first character of the new line buffer. 

But that's a lot more work, and for a future PR, which then should also investigate whether we really need a 32kb line buffer (which adds up to 512kb for our 16 `InputFiles`; in theory, just 1kb should be plenty for most cases. But I wonder whether we really handle such long lines correctly right now (some comments and code suggest it should, others suggest it won't...). So for experiments, I am tempted to reduce it to something very small, like 32 or so, and debug the hell out of it ;-).