### PR TITLE
Improved documentation, moved to float.gd, added IsRealFloat filter, …

### DIFF
--- a/doc/ref/floats.xml
+++ b/doc/ref/floats.xml
@@ -162,85 +162,7 @@ false
 ]]></Example>
 <P/>
 
-<ManSection>
-  <Heading>Mathematical operations</Heading>
-  <Attr Name="Cos" Arg="x"/>
-  <Attr Name="Sin" Arg="x"/>
-  <Attr Name="SinCos" Arg="x"/>
-  <Attr Name="Tan" Arg="x"/>
-  <Attr Name="Sec" Arg="x"/>
-  <Attr Name="Csc" Arg="x"/>
-  <Attr Name="Cot" Arg="x"/>
-  <Attr Name="Asin" Arg="x"/>
-  <Attr Name="Acos" Arg="x"/>
-  <Attr Name="Atan" Arg="x"/>
-  <Oper Name="Atan2" Arg="y x"/>
-  <Attr Name="Cosh" Arg="x"/>
-  <Attr Name="Sinh" Arg="x"/>
-  <Attr Name="Tanh" Arg="x"/>
-  <Attr Name="Sech" Arg="x"/>
-  <Attr Name="Csch" Arg="x"/>
-  <Attr Name="Coth" Arg="x"/>
-  <Attr Name="Asinh" Arg="x"/>
-  <Attr Name="Acosh" Arg="x"/>
-  <Attr Name="Atanh" Arg="x"/>
-  <Oper Name="Log" Arg="x"/>
-  <Attr Name="Log2" Arg="x"/>
-  <Attr Name="Log10" Arg="x"/>
-  <Attr Name="Log1p" Arg="x"/>
-  <Attr Name="Exp" Arg="x"/>
-  <Attr Name="Exp2" Arg="x"/>
-  <Attr Name="Exp10" Arg="x"/>
-  <Attr Name="Expm1" Arg="x"/>
-  <Attr Name="CubeRoot" Arg="x"/>
-  <Attr Name="Square" Arg="x"/>
-  <Oper Name="Hypothenuse" Arg="x y"/>
-  <Attr Name="Ceil" Arg="x"/>
-  <Attr Name="Floor" Arg="x"/>
-  <Attr Name="Round" Arg="x"/>
-  <Attr Name="Trunc" Arg="x"/>
-  <Attr Name="Frac" Arg="x"/>
-  <Attr Name="SignFloat" Arg="x"/>
-  <Attr Name="Erf" Arg="x"/>
-  <Attr Name="Zeta" Arg="x"/>
-  <Attr Name="Gamma" Arg="x"/>
-  <Description>
-    Usual mathematical functions.
-  </Description>
-</ManSection>
-
-<ManSection>
-  <Oper Name="EqFloat" Arg="x y"/>
-  <Returns>Whether the floateans <A>x</A> and <A>y</A> are equal</Returns>
-  <Description>
-    This function compares two floating-point numbers, and returns
-    <K>true</K> if they are equal, and <K>false</K> otherwise; with the
-    exception that <K>NaN</K> is always considered to be different from
-    itself.
-  </Description>
-</ManSection>
-
-<ManSection>
-  <Attr Name="PrecisionFloat" Arg="x"/>
-  <Returns>The precision of <A>x</A></Returns>
-  <Description>
-    This function returns the precision, counted in number of binary digits,
-    of the floating-point number <A>x</A>.
-  </Description>
-</ManSection>
-
-<ManSection>
-  <Prop Name="IsPInfinity" Arg="x"/>
-  <Prop Name="IsNInfinity" Arg="x"/>
-  <Prop Name="IsXInfinity" Arg="x"/>
-  <Prop Name="IsFinite" Arg="x" Label="float"/>
-  <Prop Name="IsNaN" Arg="x"/>
-  <Description>
-    Returns <K>true</K> if the floating-point number <A>x</A> is
-    respectively <M>+\infty</M>, <M>-\infty</M>, <M>\pm\infty</M>,
-    finite, or `not a number', such as the result of <C>0.0/0.0</C>.
-  </Description>
-</ManSection>
+<#Include Label="Float">
 
 <ManSection>
   <Var Name="FLOAT" Label="constants"/>
@@ -267,7 +189,9 @@ false
   </Description>
 </ManSection>
 
-<#Include Label="Float">
+<#Include Label="Float-Extra">
+<#Include Label="Float-Infinities">
+<#Include Label="Float-Math-Commands">
 
 </Section>
 
@@ -307,30 +231,18 @@ optional second argument requesting a precision in binary digits.
 
 <Section><Heading>Complex arithmetic</Heading>
 
-Complex arithmetic may be implemented in packages, and is present
-in <Package>float</Package>. Complex numbers are treated as usual
-numbers; they may be input with an extra "i" as in <C>-0.5+0.866i</C>.
+Complex arithmetic may be implemented in packages, and is present in
+<Package>float</Package>. Complex numbers are treated as usual
+numbers; they may be input with an extra "i" as in
+<C>-0.5+0.866i</C>. They may also be created using <Ref
+Oper="NewFloat"/> with three arguments: the float filter, the real
+part, and the imaginary part.
 <P/>
 
 Methods should then be implemented for <C>Norm</C>, <C>RealPart</C>,
 <C>ImaginaryPart</C>, <C>ComplexConjugate</C>, ...
 
-<ManSection>
-  <Attr Name="ComplexI" Arg="x"/>
-  <Description>
-    Returns a floatean with the same precision and representation,
-    whose value equals the imaginary unit <C>i</C>.
-  </Description>
-</ManSection>
-
-<ManSection>
-  <Attr Name="Argument" Arg="z" Label="for complex numbers" />
-  <Description>
-    Returns the argument of the complex number <A>z</A>.
-    <!-- Define what the argument is? -->
-  </Description>
-</ManSection>
-
+<#Include Label="Float-Complex">
 
 </Section>
 
@@ -348,77 +260,7 @@ Note the usual convention that intervals are compared as
 in <M>[a,b]\le[c,d]</M> if and only if <M>a\le c</M> and <M>b\le
 d</M>.
 
-<ManSection>
-  <Attr Name="Sup" Arg="interval"/>
-  <Description>
-    Returns the supremum of the interval.
-  </Description>
-</ManSection>
-<ManSection>
-  <Attr Name="Inf" Arg="interval"/>
-  <Description>
-    Returns the infimum of the interval.
-  </Description>
-</ManSection>
-<ManSection>
-  <Attr Name="Mid" Arg="interval"/>
-  <Description>
-    Returns the midpoint of the interval.
-  </Description>
-</ManSection>
-<ManSection>
-  <Attr Name="AbsoluteDiameter" Arg="interval"/>
-  <Description>
-    Returns the absolute diameter of the interval.
-    <!-- FIXME: what does that mean? -->
-  </Description>
-</ManSection>
-<ManSection>
-  <Attr Name="RelativeDiameter" Arg="interval"/>
-  <Description>
-    Returns the relative diameter of the interval.
-    <!-- FIXME: what does that mean? -->
-  </Description>
-</ManSection>
-<ManSection>
-  <Oper Name="Overlaps" Arg="interval1 interval2"/>
-  <Description>
-    Returns <K>true</K> if the two intervals overlap.
-    <!-- FIXME: is that correct? -->
-  </Description>
-</ManSection>
-<ManSection>
-  <Oper Name="IsDisjoint" Arg="interval1 interval2"/>
-  <Description>
-    Returns <K>true</K> if the two intervals are disjoint.
-  </Description>
-</ManSection>
-<ManSection>
-  <Oper Name="IsSubset" Arg="interval1 interval2" Label="for floatean intervals"/>
-  <Description>
-    Returns <K>true</K> if the first interval contains the second.
-  </Description>
-</ManSection>
-<ManSection>
-  <Oper Name="IncreaseInterval" Arg="interval delta"/>
-  <Description>
-    Returns an interval with same midpoint but absolute diameter increased by
-    <A>delta</A>.
-  </Description>
-</ManSection>
-<ManSection>
-  <Oper Name="BlowupInterval" Arg="interval ratio"/>
-  <Description>
-    Returns an interval with same midpoint but relative diameter increased by
-    <A>ratio</A>.
-  </Description>
-</ManSection>
-<ManSection>
-  <Oper Name="BisectInterval" Arg="interval"/>
-  <Description>
-    Returns a list of two intervals whose union equals <A>interval</A>.
-  </Description>
-</ManSection>
+<#Include Label="Float-Intervals">
 
 </Section>
 

--- a/lib/float.gd
+++ b/lib/float.gd
@@ -92,7 +92,7 @@ end);
 ##   <Oper Name="Zeta" Arg="f"/>
 ##   <Oper Name="Gamma" Arg="f"/>
 ##   <Description>
-##     These are all standard math functions, directly copied from the standard math library; see <C>man 3 math</C> for their list.
+##     Standard math functions.
 ##   </Description>
 ## </ManSection>
 ## <#/GAPDoc>

--- a/lib/float.gd
+++ b/lib/float.gd
@@ -83,8 +83,8 @@ end);
 ##   <Oper Name="Atan2" Arg="y x"/>
 ##   <Oper Name="FrExp" Arg="f"/>
 ##   <Oper Name="LdExp" Arg="f exp"/>
-##   <Oper Name="AbsoluteValue" Arg="f"/>
-##   <Oper Name="Norm" Arg="f"/>
+##   <Oper Name="AbsoluteValue" Arg="f" Label="for floats"/>
+##   <Oper Name="Norm" Arg="f" Label="for floats"/>
 ##   <Oper Name="Hypothenuse" Arg="x y"/>
 ##   <Oper Name="Frac" Arg="f"/>
 ##   <Oper Name="SinCos" Arg="f"/>
@@ -133,14 +133,13 @@ DeclareOperation("Atan2", [IsFloat, IsFloat]);
 DeclareAttribute("FrExp", IsFloat);
 DeclareOperation("LdExp", [IsFloat, IsInt]);
 DeclareAttribute("AbsoluteValue", IsFloat);
-#DeclareAttribute("Norm", IsFloat); #already defined
+#DeclareAttribute("Norm", IsFloat); # already defined
 DeclareOperation("Hypothenuse", [IsFloat, IsFloat]);
 DeclareAttribute("Frac", IsFloat);
 DeclareAttribute("SinCos", IsFloat);
 DeclareAttribute("Erf", IsFloat);
 DeclareAttribute("Zeta", IsFloat);
 DeclareAttribute("Gamma", IsFloat);
-#DeclareAttribute("ComplexI", IsFloat); #obsolete
 
 ################################################################
 ## <#GAPDoc Label="Float-Extra">
@@ -165,17 +164,24 @@ DeclareAttribute("Gamma", IsFloat);
 ## </ManSection>
 ## 
 ## <ManSection>
+##   <Attr Name="SignBit" Arg="x"/>
 ##   <Attr Name="SignFloat" Arg="x"/>
-##   <Returns>The sign of <A>x</A>, as an integer</Returns>
+##   <Returns>The sign of <A>x</A>.</Returns>
 ##   <Description>
-##       This function returns the sign of the floating-point number <A >x</A>,
-##       as a &GAP; integer.
+##       The first function <C>SignBit</C> returns the sign bit of the
+##       floating-point number <A>x</A>: <K>true</K> if <A>x</A> is negative
+##       (including <C>-0.</C>) and <K>false</K> otherwise.
+##
+##       <P/> The second function <C>SignFloat</C> returns the integer
+##       <K>-1</K> if <A>x&lt;0</A>, <K>0</K> if <A>x=0</A> and <K>1</K>
+##       if <A>x&gt;0</A>.
 ##   </Description>
 ## </ManSection>
 ## <#/GAPDoc>
 ##
 DeclareOperation("EqFloat", [IsFloat, IsFloat]);
 DeclareAttribute("PrecisionFloat", IsFloat);
+DeclareAttribute("SignBit", IsFloat);
 DeclareAttribute("SignFloat", IsFloat);
 ################################################################
 
@@ -187,7 +193,7 @@ DeclareAttribute("SignFloat", IsFloat);
 ##   <Prop Name="IsPInfinity" Arg="x"/>
 ##   <Prop Name="IsNInfinity" Arg="x"/>
 ##   <Prop Name="IsXInfinity" Arg="x"/>
-##   <Prop Name="IsFinite" Arg="x" Label="float"/>
+##   <Prop Name="IsFinite" Arg="x" Label="for floats"/>
 ##   <Prop Name="IsNaN" Arg="x"/>
 ##   <Description>
 ##     Returns <K>true</K> if the floating-point number <A>x</A> is
@@ -208,7 +214,7 @@ DeclareProperty("IsNaN", IsFloat);
 ##
 ## <#GAPDoc Label="Float-Complex">
 ## <ManSection>
-##   <Attr Name="Argument" Arg="z" Label="for complex numbers" />
+##   <Attr Name="Argument" Arg="z" Label="for complex floats"/>
 ##   <Description>
 ##     Returns the argument of the complex number <A>z</A>, namely the value
 ##     <C>Atan2(ImaginaryPart(z),RealPart(z))</C>.
@@ -217,6 +223,28 @@ DeclareProperty("IsNaN", IsFloat);
 ## <#/GAPDoc>
 ##
 DeclareAttribute("Argument", IsComplexFloat);
+################################################################
+
+################################################################
+##
+## <#GAPDoc Label="Float-Roots">
+## <ManSection>
+##   <Func Name="RootsFloat" Arg="p" Label="for a polynomial"/>
+##   <Func Name="RootsFloat" Arg="list" Label="for coefficients"/>
+##   <Description>
+##     Returns the roots of the polynomial <A>p</A>, or of the polynomial
+##     given by the list <A>list</A> of its coefficients, with <C>list[i]</C>
+##     the coefficient of degree <C>i-1</C>.
+##
+##    <P/>There is no default implementation of <C>RootsFloat</C> in the
+##    &GAP; kernel; these are supplied by packages such as
+##    <Package>float</Package>.
+##   </Description>
+## </ManSection>
+## <#/GAPDoc>
+##
+DeclareOperation("RootsFloatOp", [IsList,IsFloat]);
+DeclareGlobalFunction("RootsFloat");
 ################################################################
 
 ################################################################
@@ -242,6 +270,7 @@ DeclareAttribute("Argument", IsComplexFloat);
 ## </ManSection>
 ## <ManSection>
 ##   <Attr Name="AbsoluteDiameter" Arg="x"/>
+##   <Attr Name="Diameter" Arg="x"/>
 ##   <Description>
 ##     Returns the absolute diameter of the interval <A>x</A>, namely
 ##     the difference <C>Sup(x)-Inf(x)</C>.
@@ -262,7 +291,7 @@ DeclareAttribute("Argument", IsComplexFloat);
 ##   </Description>
 ## </ManSection>
 ## <ManSection>
-##   <Oper Name="IsSubset" Arg="x1 x2" Label="for floatean intervals"/>
+##   <Oper Name="IsSubset" Arg="x1 x2" Label="for interval floats"/>
 ##   <Description>
 ##     Returns <K>true</K> if the interval <A>x1</A> contains <A>x2</A>.
 ##   </Description>
@@ -294,11 +323,11 @@ DeclareAttribute("Inf", IsFloatInterval);
 DeclareAttribute("Mid", IsFloatInterval);
 DeclareAttribute("AbsoluteDiameter", IsFloatInterval);
 DeclareAttribute("RelativeDiameter", IsFloatInterval);
-#DeclareOperation("Diameter", IsFloat);
+DeclareOperation("Diameter", [IsFloat]);
 DeclareOperation("IsDisjoint", [IsFloatInterval, IsFloatInterval]);
-DeclareOperation("IncreaseInterval", [IsFloatInterval, IsFloatInterval]);
-DeclareOperation("BlowupInterval", [IsFloatInterval, IsFloatInterval]);
-DeclareOperation("BisectInterval", [IsFloatInterval, IsFloatInterval]);
+DeclareOperation("IncreaseInterval", [IsFloatInterval, IsFloat]);
+DeclareOperation("BlowupInterval", [IsFloatInterval, IsFloat]);
+DeclareOperation("BisectInterval", [IsFloatInterval]);
 ################################################################
 
 #############################################################################

--- a/lib/float.gd
+++ b/lib/float.gd
@@ -13,14 +13,15 @@
 #C  Floateans
 ##
 DeclareCategory("IsFloat", IsScalar and IsCommutativeElement and IsZDFRE);
+DeclareCategory("IsRealFloat", IsFloat);
 DeclareCategory("IsFloatInterval", IsFloat and IsCollection);
 DeclareCategory("IsComplexFloat", IsFloat);
 DeclareCategory("IsComplexFloatInterval", IsComplexFloat and IsFloatInterval);
 DeclareCategoryFamily("IsFloat");
 DeclareCategoryCollections("IsFloat");
 DeclareCategoryCollections("IsFloatCollection");
-DeclareConstructor("NewFloat",[IsFloat,IsObject]);
-DeclareOperation("MakeFloat",[IsFloat,IsObject]);
+DeclareConstructor("NewFloat", [IsFloat,IsObject]);
+DeclareOperation("MakeFloat", [IsFloat,IsObject]);
 #############################################################################
 
 BindGlobal("DECLAREFLOATCREATOR", function(arg)
@@ -44,80 +45,261 @@ end);
 ##
 #O Unary operations
 ##
-DeclareAttribute("Cos",IsFloat);
-DeclareAttribute("Sin",IsFloat);
-DeclareAttribute("Tan",IsFloat);
-DeclareAttribute("Sec",IsFloat);
-DeclareAttribute("Csc",IsFloat);
-DeclareAttribute("Cot",IsFloat);
-DeclareAttribute("Asin",IsFloat);
-DeclareAttribute("Acos",IsFloat);
-DeclareAttribute("Atan",IsFloat);
-DeclareAttribute("Cosh",IsFloat);
-DeclareAttribute("Sinh",IsFloat);
-DeclareAttribute("Tanh",IsFloat);
-DeclareAttribute("Sech",IsFloat);
-DeclareAttribute("Csch",IsFloat);
-DeclareAttribute("Coth",IsFloat);
-DeclareAttribute("Asinh",IsFloat);
-DeclareAttribute("Acosh",IsFloat);
-DeclareAttribute("Atanh",IsFloat);
-DeclareOperation("Log",[IsFloat]);
-DeclareAttribute("Log2",IsFloat);
-DeclareAttribute("Log10",IsFloat);
-DeclareAttribute("Log1p",IsFloat);
-DeclareAttribute("Exp",IsFloat);
-DeclareAttribute("Exp2",IsFloat);
-DeclareAttribute("Exp10",IsFloat);
-DeclareAttribute("Expm1",IsFloat);
-DeclareAttribute("CubeRoot",IsFloat);
-DeclareAttribute("Square",IsFloat);
-DeclareAttribute("Ceil",IsFloat);
-DeclareAttribute("Floor",IsFloat);
-DeclareAttribute("Round",IsFloat);
-DeclareAttribute("Trunc",IsFloat);
-DeclareOperation("Atan2", [IsFloat,IsFloat]);
+## <#GAPDoc Label="Float-Math-Commands">
+## <ManSection>
+##   <Heading>Standard mathematical operations</Heading>
+##   <Oper Name="Cos" Arg="f"/>
+##   <Oper Name="Sin" Arg="f"/>
+##   <Oper Name="Tan" Arg="f"/>
+##   <Oper Name="Sec" Arg="f"/>
+##   <Oper Name="Csc" Arg="f"/>
+##   <Oper Name="Cot" Arg="f"/>
+##   <Oper Name="Asin" Arg="f"/>
+##   <Oper Name="Acos" Arg="f"/>
+##   <Oper Name="Atan" Arg="f"/>
+##   <Oper Name="Cosh" Arg="f"/>
+##   <Oper Name="Sinh" Arg="f"/>
+##   <Oper Name="Tanh" Arg="f"/>
+##   <Oper Name="Sech" Arg="f"/>
+##   <Oper Name="Csch" Arg="f"/>
+##   <Oper Name="Coth" Arg="f"/>
+##   <Oper Name="Asinh" Arg="f"/>
+##   <Oper Name="Acosh" Arg="f"/>
+##   <Oper Name="Atanh" Arg="f"/>
+##   <Oper Name="Log" Arg="f"/>
+##   <Oper Name="Log2" Arg="f"/>
+##   <Oper Name="Log10" Arg="f"/>
+##   <Oper Name="Log1p" Arg="f"/>
+##   <Oper Name="Exp" Arg="f"/>
+##   <Oper Name="Exp2" Arg="f"/>
+##   <Oper Name="Exp10" Arg="f"/>
+##   <Oper Name="Expm1" Arg="f"/>
+##   <Oper Name="CubeRoot" Arg="f"/>
+##   <Oper Name="Square" Arg="f"/>
+##   <Oper Name="Ceil" Arg="f"/>
+##   <Oper Name="Floor" Arg="f"/>
+##   <Oper Name="Round" Arg="f"/>
+##   <Oper Name="Trunc" Arg="f"/>
+##   <Oper Name="Atan2" Arg="y x"/>
+##   <Oper Name="FrExp" Arg="f"/>
+##   <Oper Name="LdExp" Arg="f exp"/>
+##   <Oper Name="AbsoluteValue" Arg="f"/>
+##   <Oper Name="Norm" Arg="f"/>
+##   <Oper Name="Hypothenuse" Arg="x y"/>
+##   <Oper Name="Frac" Arg="f"/>
+##   <Oper Name="SinCos" Arg="f"/>
+##   <Oper Name="Erf" Arg="f"/>
+##   <Oper Name="Zeta" Arg="f"/>
+##   <Oper Name="Gamma" Arg="f"/>
+##   <Description>
+##     These are all standard math functions, directly copied from the standard math library; see <C>man 3 math</C> for their list.
+##   </Description>
+## </ManSection>
+## <#/GAPDoc>
+##
+DeclareAttribute("Cos", IsFloat);
+DeclareAttribute("Sin", IsFloat);
+DeclareAttribute("Tan", IsFloat);
+DeclareAttribute("Sec", IsFloat);
+DeclareAttribute("Csc", IsFloat);
+DeclareAttribute("Cot", IsFloat);
+DeclareAttribute("Asin", IsFloat);
+DeclareAttribute("Acos", IsFloat);
+DeclareAttribute("Atan", IsFloat);
+DeclareAttribute("Cosh", IsFloat);
+DeclareAttribute("Sinh", IsFloat);
+DeclareAttribute("Tanh", IsFloat);
+DeclareAttribute("Sech", IsFloat);
+DeclareAttribute("Csch", IsFloat);
+DeclareAttribute("Coth", IsFloat);
+DeclareAttribute("Asinh", IsFloat);
+DeclareAttribute("Acosh", IsFloat);
+DeclareAttribute("Atanh", IsFloat);
+DeclareOperation("Log", [IsFloat]);
+DeclareAttribute("Log2", IsFloat);
+DeclareAttribute("Log10", IsFloat);
+DeclareAttribute("Log1p", IsFloat);
+DeclareAttribute("Exp", IsFloat);
+DeclareAttribute("Exp2", IsFloat);
+DeclareAttribute("Exp10", IsFloat);
+DeclareAttribute("Expm1", IsFloat);
+DeclareAttribute("CubeRoot", IsFloat);
+DeclareAttribute("Square", IsFloat);
+DeclareAttribute("Ceil", IsFloat);
+DeclareAttribute("Floor", IsFloat);
+DeclareAttribute("Round", IsFloat);
+DeclareAttribute("Trunc", IsFloat);
+DeclareOperation("Atan2", [IsFloat, IsFloat]);
 DeclareAttribute("FrExp", IsFloat);
-DeclareOperation("LdExp", [IsFloat,IsInt]);
-DeclareAttribute("Argument", IsFloat);
+DeclareOperation("LdExp", [IsFloat, IsInt]);
 DeclareAttribute("AbsoluteValue", IsFloat);
 #DeclareAttribute("Norm", IsFloat); #already defined
-DeclareOperation("Hypothenuse", [IsFloat,IsFloat]);
-DeclareAttribute("Frac",IsFloat);
-DeclareAttribute("SinCos",IsFloat);
-DeclareAttribute("Erf",IsFloat);
-DeclareAttribute("Zeta",IsFloat);
-DeclareAttribute("Gamma",IsFloat);
-DeclareAttribute("ComplexI",IsFloat);
+DeclareOperation("Hypothenuse", [IsFloat, IsFloat]);
+DeclareAttribute("Frac", IsFloat);
+DeclareAttribute("SinCos", IsFloat);
+DeclareAttribute("Erf", IsFloat);
+DeclareAttribute("Zeta", IsFloat);
+DeclareAttribute("Gamma", IsFloat);
+#DeclareAttribute("ComplexI", IsFloat); #obsolete
 
-DeclareAttribute("PrecisionFloat",IsFloat);
-DeclareAttribute("SignFloat",IsFloat);
+################################################################
+## <#GAPDoc Label="Float-Extra">
+## <ManSection>
+##   <Oper Name="EqFloat" Arg="x y"/>
+##   <Returns>Whether the floateans <A>x</A> and <A>y</A> are equal</Returns>
+##   <Description>
+##     This function compares two floating-point numbers, and returns
+##     <K>true</K> if they are equal, and <K>false</K> otherwise; with the
+##     exception that <K>NaN</K> is always considered to be different from
+##     itself.
+##   </Description>
+## </ManSection>
+## 
+## <ManSection>
+##   <Attr Name="PrecisionFloat" Arg="x"/>
+##   <Returns>The precision of <A>x</A></Returns>
+##   <Description>
+##     This function returns the precision, counted in number of binary digits,
+##     of the floating-point number <A>x</A>.
+##   </Description>
+## </ManSection>
+## 
+## <ManSection>
+##   <Attr Name="SignFloat" Arg="x"/>
+##   <Returns>The sign of <A>x</A>, as an integer</Returns>
+##   <Description>
+##       This function returns the sign of the floating-point number <A >x</A>,
+##       as a &GAP; integer.
+##   </Description>
+## </ManSection>
+## <#/GAPDoc>
+##
+DeclareOperation("EqFloat", [IsFloat, IsFloat]);
+DeclareAttribute("PrecisionFloat", IsFloat);
+DeclareAttribute("SignFloat", IsFloat);
+################################################################
 
-DeclareAttribute("Sup", IsFloat);
-DeclareAttribute("Inf", IsFloat);
-DeclareAttribute("Mid", IsFloat);
-DeclareAttribute("AbsoluteDiameter", IsFloat);
-DeclareAttribute("RelativeDiameter", IsFloat);
-#DeclareOperation("Diameter", IsFloat);
-DeclareOperation("Overlaps", [IsFloat,IsFloat]);
-DeclareOperation("IsDisjoint", [IsFloat,IsFloat]);
-DeclareOperation("EqFloat", [IsFloat,IsFloat]);
-DeclareOperation("IncreaseInterval", [IsFloat,IsFloat]);
-DeclareOperation("BlowupInterval", [IsFloat,IsFloat]);
-DeclareOperation("BisectInterval", [IsFloat,IsFloat]);
-
+################################################################
+##
+## <#GAPDoc Label="Float-Infinities">
+## <ManSection>
+##   <Heading>Infinity testers</Heading>
+##   <Prop Name="IsPInfinity" Arg="x"/>
+##   <Prop Name="IsNInfinity" Arg="x"/>
+##   <Prop Name="IsXInfinity" Arg="x"/>
+##   <Prop Name="IsFinite" Arg="x" Label="float"/>
+##   <Prop Name="IsNaN" Arg="x"/>
+##   <Description>
+##     Returns <K>true</K> if the floating-point number <A>x</A> is
+##     respectively <M>+\infty</M>, <M>-\infty</M>, <M>\pm\infty</M>,
+##     finite, or `not a number', such as the result of <C>0.0/0.0</C>.
+##   </Description>
+## </ManSection>
+## <#/GAPDoc>
+##
 DeclareProperty("IsPInfinity", IsFloat);
 DeclareProperty("IsNInfinity", IsFloat);
 DeclareProperty("IsXInfinity", IsFloat);
 DeclareProperty("IsFinite", IsFloat);
 DeclareProperty("IsNaN", IsFloat);
-#############################################################################
+################################################################
 
-#############################################################################
-# roots
-#############################################################################
-#! document (LB)
-#############################################################################
+################################################################
+##
+## <#GAPDoc Label="Float-Complex">
+## <ManSection>
+##   <Attr Name="Argument" Arg="z" Label="for complex numbers" />
+##   <Description>
+##     Returns the argument of the complex number <A>z</A>, namely the value
+##     <C>Atan2(ImaginaryPart(z),RealPart(z))</C>.
+##   </Description>
+## </ManSection>
+## <#/GAPDoc>
+##
+DeclareAttribute("Argument", IsComplexFloat);
+################################################################
+
+################################################################
+##
+## <#GAPDoc Label="Float-Intervals">
+## <ManSection>
+##   <Attr Name="Sup" Arg="x"/>
+##   <Description>
+##     Returns the supremum of the interval <A>x</A>.
+##   </Description>
+## </ManSection>
+## <ManSection>
+##   <Attr Name="Inf" Arg="x"/>
+##   <Description>
+##     Returns the infimum of the interval <A>x</A>.
+##   </Description>
+## </ManSection>
+## <ManSection>
+##   <Attr Name="Mid" Arg="x"/>
+##   <Description>
+##     Returns the midpoint of the interval <A>x</A>.
+##   </Description>
+## </ManSection>
+## <ManSection>
+##   <Attr Name="AbsoluteDiameter" Arg="x"/>
+##   <Description>
+##     Returns the absolute diameter of the interval <A>x</A>, namely
+##     the difference <C>Sup(x)-Inf(x)</C>.
+##   </Description>
+## </ManSection>
+## <ManSection>
+##   <Attr Name="RelativeDiameter" Arg="x"/>
+##   <Description>
+##     Returns the relative diameter of the interval <A>x</A>, namely
+##     <C>(Sup(x)-Inf(x))/AbsoluteValue(Min(x))</C>.
+##   </Description>
+## </ManSection>
+## <ManSection>
+##   <Oper Name="IsDisjoint" Arg="x1 x2"/>
+##   <Description>
+##     Returns <K>true</K> if the two intervals <A>x1</A>, <A>x2</A>
+##     are disjoint.
+##   </Description>
+## </ManSection>
+## <ManSection>
+##   <Oper Name="IsSubset" Arg="x1 x2" Label="for floatean intervals"/>
+##   <Description>
+##     Returns <K>true</K> if the interval <A>x1</A> contains <A>x2</A>.
+##   </Description>
+## </ManSection>
+## <ManSection>
+##   <Oper Name="IncreaseInterval" Arg="x delta"/>
+##   <Description>
+##     Returns an interval with same midpoint as <A>x</A> but absolute diameter increased by
+##     <A>delta</A>.
+##   </Description>
+## </ManSection>
+## <ManSection>
+##   <Oper Name="BlowupInterval" Arg="x ratio"/>
+##   <Description>
+##     Returns an interval with same midpoint as <A>x</A> but relative diameter increased by
+##     <A>ratio</A>.
+##   </Description>
+## </ManSection>
+## <ManSection>
+##   <Oper Name="BisectInterval" Arg="x"/>
+##   <Description>
+##     Returns a list of two intervals whose union equals the interval <A>x</A>.
+##   </Description>
+## </ManSection>
+## <#/GAPDoc>
+##
+DeclareAttribute("Sup", IsFloatInterval);
+DeclareAttribute("Inf", IsFloatInterval);
+DeclareAttribute("Mid", IsFloatInterval);
+DeclareAttribute("AbsoluteDiameter", IsFloatInterval);
+DeclareAttribute("RelativeDiameter", IsFloatInterval);
+#DeclareOperation("Diameter", IsFloat);
+DeclareOperation("IsDisjoint", [IsFloatInterval, IsFloatInterval]);
+DeclareOperation("IncreaseInterval", [IsFloatInterval, IsFloatInterval]);
+DeclareOperation("BlowupInterval", [IsFloatInterval, IsFloatInterval]);
+DeclareOperation("BisectInterval", [IsFloatInterval, IsFloatInterval]);
+################################################################
 
 #############################################################################
 ##
@@ -125,6 +307,7 @@ DeclareProperty("IsNaN", IsFloat);
 ##
 ## <#GAPDoc Label="Float">
 ## <ManSection>
+##   <Heading>Float creators</Heading>
 ##   <Func Name="Float" Arg="obj"/>
 ##   <Oper Name="NewFloat" Arg="filter, obj"/>
 ##   <Oper Name="MakeFloat" Arg="sample obj, obj"/>
@@ -173,6 +356,21 @@ DeclareProperty("IsNaN", IsFloat);
 ## </ManSection>
 ##
 ## <ManSection>
+##   <Attr Name="Cyc" Arg="f [degree]" Label="for floats"/>
+##   <Returns>A cyclotomic approximation to <A>f</A></Returns>
+##   <Description>
+##     This command constructs a cyclotomic approximation to the
+##     floating-point number <A>f</A>. Of course, it is not guaranteed to
+##     return the original rational number <A>f</A> was created from, though
+##     it returns the most `reasonable' one given the precision of
+##     <A>f</A>. An optional argument <A>degree</A> specifies the maximal
+##     degree of the cyclotomic to be constructed.
+##
+##     <P/> The method used is LLL lattice reduction.
+##   </Description>
+## </ManSection>
+##
+## <ManSection>
 ##   <Func Name="SetFloats" Arg="rec [bits] [install]"/>
 ##   <Description>
 ##     Installs a new interface to floating-point numbers in &GAP;, optionally
@@ -186,10 +384,9 @@ DeclareProperty("IsNaN", IsFloat);
 ##
 DeclareGlobalFunction("Float");
 DeclareGlobalFunction("SetFloats");
-#############################################################################
-
 DeclareOperation("Cyc", [IsFloat, IsPosInt]);
 DeclareOperation("Cyc", [IsFloat]);
+#############################################################################
 
 # these variables are read-write
 FLOAT := fail; # record holding all float information

--- a/lib/float.gi
+++ b/lib/float.gi
@@ -20,8 +20,6 @@ DeclareCategory("IsFloatPseudoField", IsAlgebra);
 DeclareCategory("IsFloatRationalFunction", IsRationalFunction);
 DeclareSynonym("IsFloatPolynomial", IsFloatRationalFunction and IsPolynomial);
 DeclareSynonym("IsFloatUnivariatePolynomial", IsFloatRationalFunction and IsUnivariatePolynomial);
-DeclareOperation("RootsFloatOp", [IsList,IsFloat]);
-DeclareGlobalFunction("RootsFloat");
 DeclareOperation("Value", [IsFloatRationalFunction,IsFloat]);
 DeclareOperation("ValueInterval", [IsFloatRationalFunction,IsFloat]);
 #############################################################################
@@ -256,6 +254,9 @@ end);
 ## These methods have priority -1, because they are inefficient.
 ## Hopefully every float implementation implements them better.
 #############################################################################
+InstallMethod( Diameter, "for a float interval", [ IsFloatInterval ],
+        AbsoluteDiameter );
+
 InstallMethod( AbsoluteValue, "for real floats", [ IsRealFloat ], -1,
         function ( x )
     if x < Zero(x) then return -x; else return x; fi;
@@ -268,9 +269,15 @@ end );
 
 InstallMethod( SignFloat, "for real floats", [ IsRealFloat ], -1,
         function ( x )
-    if x < Zero(x) then return -1; elif IsZero(x) then return 0; else return 1; fi;
+    if IsZero( x ) then
+        return 0;
+    elif x < Zero( x ) then
+        return -1;
+    else
+        return 1;
+    fi;
 end );
-
+    
 InstallMethod( Exp2, "for floats", [ IsFloat ], -1,
         function ( x )
     return Exp(Log(MakeFloat(x,2))*x);
@@ -285,7 +292,6 @@ InstallMethod( Expm1, "for floats", [ IsFloat ], -1,
         function ( x )
     return Exp(x)-MakeFloat(x,1);
 end );
-
 
 InstallMethod( Log2, "for floats", [ IsFloat ], -1,
         function ( x )

--- a/lib/float.gi
+++ b/lib/float.gi
@@ -252,23 +252,21 @@ end);
 
 #############################################################################
 ## Default methods
+##
+## These methods have priority -1, because they are inefficient.
+## Hopefully every float implementation implements them better.
 #############################################################################
-InstallMethod( AbsoluteValue, "for floats", [ IsFloat ], -1,
+InstallMethod( AbsoluteValue, "for real floats", [ IsRealFloat ], -1,
         function ( x )
     if x < Zero(x) then return -x; else return x; fi;
 end );
 
-InstallMethod( Norm, "for floats", [ IsFloat ], -1,
+InstallMethod( Norm, "for real floats", [ IsRealFloat ], -1,
         function ( x )
     return x*x;
 end );
 
-InstallMethod( Argument, "for floats", [ IsFloat ], -1,
-        function ( x )
-    return Zero(x);
-end );
-
-InstallMethod( SignFloat, "for floats", [ IsFloat ], -1,
+InstallMethod( SignFloat, "for real floats", [ IsRealFloat ], -1,
         function ( x )
     if x < Zero(x) then return -1; elif IsZero(x) then return 0; else return 1; fi;
 end );
@@ -355,17 +353,18 @@ InstallMethod( Hypothenuse, "for floats", [ IsFloat, IsFloat ], -1,
     return Sqrt(x*x+y*y);
 end );
 
-InstallMethod( Ceil, "for floats", [ IsFloat ], -1,
+InstallMethod( Ceil, "for real floats", [ IsRealFloat ], -1,
         function ( x )
     return -Floor(-x);
 end );
 
-InstallMethod( Round, "for floats", [ IsFloat ], -1,
-        function ( x )
-    return Floor(x+MakeFloat(x,1/2));
-end );
+# this is disabled because it's so bad... it loses an ulp in fringe cases.
+#InstallMethod( Round, "for floats", [ IsFloat ], -1,
+#        function ( x )
+#    return Floor(x+MakeFloat(x,1/2));
+#end );
 
-InstallMethod( Trunc, "for floats", [ IsFloat ], -1,
+InstallMethod( Trunc, "for real floats", [ IsRealFloat ], -1,
         function ( x )
     if x>Zero(x) then
         return Floor(x);

--- a/lib/ieee754.g
+++ b/lib/ieee754.g
@@ -106,6 +106,8 @@ InstallMethod( Round, "for macfloats", [ IsIEEE754FloatRep ], RINT_MACFLOAT );
 InstallMethod( Floor, "for macfloats", [ IsIEEE754FloatRep ], FLOOR_MACFLOAT );
 InstallMethod( Ceil, "for macfloats", [ IsIEEE754FloatRep ], CEIL_MACFLOAT );
 InstallMethod( AbsoluteValue, "for macfloats", [ IsIEEE754FloatRep ], ABS_MACFLOAT );
+InstallMethod( SignFloat, "for macfloats", [ IsIEEE754FloatRep ], SIGN_MACFLOAT );
+InstallMethod( SignBit, "for macfloats", [ IsIEEE754FloatRep ], SIGNBIT_MACFLOAT );
 InstallMethod( Hypothenuse, "for macfloats", [ IsIEEE754FloatRep, IsIEEE754FloatRep ], HYPOT_MACFLOAT );
 InstallMethod( LdExp, "for macfloat,int", [ IsIEEE754FloatRep, IsInt ], LDEXP_MACFLOAT );
 InstallMethod( FrExp, "for macfloat", [ IsIEEE754FloatRep ], FREXP_MACFLOAT );

--- a/lib/macfloat.g
+++ b/lib/macfloat.g
@@ -13,7 +13,7 @@
 ##
 
 #############################################################################
-DeclareRepresentation("IsIEEE754FloatRep", IsFloat and IsInternalRep 
+DeclareRepresentation("IsIEEE754FloatRep", IsRealFloat and IsInternalRep 
         #and IS_MACFLOAT
         ,[]);
 

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -371,6 +371,19 @@ MAKEMATHPRIMITIVE(ABS,fabs)
 MAKEMATHPRIMITIVE2(ATAN2,atan2)
 MAKEMATHPRIMITIVE2(HYPOT,hypot)
 
+Obj FuncSIGN_MACFLOAT( Obj self, Obj f )
+{
+  Double vf = VAL_MACFLOAT(f);
+  
+  return vf == 0. ? INTOBJ_INT(0) : vf > 0. ? INTOBJ_INT(1) : INTOBJ_INT(-1);
+}
+
+Obj FuncSIGNBIT_MACFLOAT( Obj self, Obj f )
+{
+  return signbit(VAL_MACFLOAT(f)) ? True : False;
+}
+
+
 extern Obj FuncIntHexString(Obj,Obj);
 
 Obj FuncINTFLOOR_MACFLOAT( Obj self, Obj obj )
@@ -487,6 +500,8 @@ static StructGVarFunc GVarFuncs [] = {
   GVAR_FUNC(FLOOR_MACFLOAT, 1, "macfloat"),
   GVAR_FUNC(CEIL_MACFLOAT, 1, "macfloat"),
   GVAR_FUNC(ABS_MACFLOAT, 1, "macfloat"),
+  GVAR_FUNC(SIGN_MACFLOAT, 1, "macfloat"),
+  GVAR_FUNC(SIGNBIT_MACFLOAT, 1, "macfloat"),
   GVAR_FUNC(STRING_MACFLOAT, 1, "macfloat"),
 
   GVAR_FUNC(STRING_DIGITS_MACFLOAT, 2, "digits, macfloat"),


### PR DESCRIPTION
Improved float documentation and interface

This commit overhauls the documentation of the floateans in GAP, and adds and removes some commands from the interface:
* ComplexI is removed, it can be replaced by "MakeFloat(filter, 0, 1)"
* Overlaps is removed, it can be replaced by "not IsDisjoint(interval1, interval1)"
* filters IsRealFloat, IsComplexFloat, IsFloatInterval are used more systematically
* SignFloat, which does not permit to distinguish 0 and -0 and is not part of IEEE754, is supplemented by SignBit, which returns True if and only if its argument has the sign bit set
* the default method for Round is removed, because it can lead to precision loss
* RootsFloat, Cyc, and interval operations are now documented.