### PR TITLE
FIX/ENHANCE: ImageKernelBlockHomomorphism memory and performance

### DIFF
--- a/lib/ghomperm.gi
+++ b/lib/ghomperm.gi
@@ -702,9 +702,9 @@ InstallOtherMethod( StabChainMutable, "perm mapping by images",  true,
     BuildOrb:=function(genimg)
     local a,orb,dict,orbf,T,elm,img,i,n;
       if Length(genimg[1])>0 then
-	a:=genimg[1][1];
+        a:=genimg[1][1];
       else
-	a:=One(Source(hom));
+        a:=One(Source(hom));
       fi;
       dict:=NewDictionary(a,false);
       a:=One(Source(hom));
@@ -1633,7 +1633,7 @@ InstallGlobalFunction( ImageKernelBlocksHomomorphism, function( hom, H,par )
               while j<=Length(orb) do
                 for k in S.generators do
                   img:=D[orb[j]][1]^k;
-		  p:=hom!.reps[img];
+                  p:=hom!.reps[img];
                   if not p in orb then
                     Add(orb,p);
                     Add(rep,rep[j]*k);
@@ -2056,23 +2056,23 @@ function( hom )
           fix:=First(oimgs[i],p->ForAll(GeneratorsOfGroup(E),
                       gen -> p ^ gen = p ) );
   
-	  # parallel orbit algorithm
-	  mapi:=MappingGeneratorsImages(hom);
-	  Add(dom,bpt);
-	  Add(idom,fix);
-	  pos:=Length(dom);
-	  doms:=[bpt];
-	  while pos<=Length(dom) do
-	    for gn in [1..Length(mapi[1])] do
-	      bpt:=dom[pos]^mapi[1][gn];
-	      if not bpt in doms then
-	        Add(dom,bpt);
-		AddSet(doms,bpt);
-		Add(idom,idom[pos]^mapi[2][gn]);
-	      fi;
-	    od;
-	    pos:=pos+1;
-	  od;
+          # parallel orbit algorithm
+          mapi:=MappingGeneratorsImages(hom);
+          Add(dom,bpt);
+          Add(idom,fix);
+          pos:=Length(dom);
+          doms:=[bpt];
+          while pos<=Length(dom) do
+            for gn in [1..Length(mapi[1])] do
+              bpt:=dom[pos]^mapi[1][gn];
+              if not bpt in doms then
+                Add(dom,bpt);
+                AddSet(doms,bpt);
+                Add(idom,idom[pos]^mapi[2][gn]);
+              fi;
+            od;
+            pos:=pos+1;
+          od;
 
           # # we could try to use stabilizer chains, but the homomorphism does
           # # not necessarily have one which acts in every orbit. So we use the
@@ -2088,32 +2088,32 @@ function( hom )
       else
         # we got multiple orbits
 
-	# does it matter? (can we do per orbit?)
-	orb:=List(Orbits(s,dom),Set);
-	rep:=[];
-	i:=1;
-	while i<=Length(orb) do
-	  sym:=ActionHomomorphism(s,orb[i],"surjective");
-	  pi:=InducedAutomorphism(sym,hom);
-	  if IsConjugatorIsomorphism(pi) then
-	    rep[i]:=ConjugatorOfConjugatorIsomorphism(pi);
-	  else
-	    rep:=fail;
-	    i:=Length(orb);
-	  fi;
-	  i:=i+1;
-	od;
-	if rep<>fail then
-	  pi:=List([1..Length(orb)],x->MappingPermListList(Permuted(orb[x],rep[x]),orb[x]));
-	  rep:=Product(pi);
+        # does it matter? (can we do per orbit?)
+        orb:=List(Orbits(s,dom),Set);
+        rep:=[];
+        i:=1;
+        while i<=Length(orb) do
+          sym:=ActionHomomorphism(s,orb[i],"surjective");
+          pi:=InducedAutomorphism(sym,hom);
+          if IsConjugatorIsomorphism(pi) then
+            rep[i]:=ConjugatorOfConjugatorIsomorphism(pi);
+          else
+            rep:=fail;
+            i:=Length(orb);
+          fi;
+          i:=i+1;
+        od;
+        if rep<>fail then
+          pi:=List([1..Length(orb)],x->MappingPermListList(Permuted(orb[x],rep[x]),orb[x]));
+          rep:=Product(pi);
           Assert(1,ForAll(genss,i->ImagesRepresentative(hom,i)=i^rep));
-	  SetConjugatorOfConjugatorIsomorphism( hom, rep );
-	  return true;
-	fi;
+          SetConjugatorOfConjugatorIsomorphism( hom, rep );
+          return true;
+        fi;
 
-	if ValueOption("cheap")=true then
-	  return false;
-	fi;
+        if ValueOption("cheap")=true then
+          return false;
+        fi;
         rep:=RepresentativeAction(OrbitStabilizingParentGroup(s),
               genss,
               List( genss, i -> ImagesRepresentative( hom, i ) ), OnTuples );

--- a/tst/testextra/grpperm.tst
+++ b/tst/testextra/grpperm.tst
@@ -229,6 +229,32 @@ gap> gpcopy:=function(G)local s,r;s:=Size(G); # new conjugate group
 > G:=Group(List(GeneratorsOfGroup(G),x->x^r));SetSize(G,s);return G;end;;
 gap> First(rr,x->ONanScottType(gpcopy(PrimitiveGroup(x[1],x[2])))<>x[3]);
 fail
+
+# test of block homomorphism kernels -- observed by Thomas 12/15/17. The test
+# is to ensure that the `SmallerDegree` runs through in plausible memory and
+# time use. Takes about 4 minutes on my Laptop. AH
+gap> a:=[[0,-1,0,1,0,-1,1,0],[0,0,-1,0,1,-1,0,0],[0,0,0,-1,1,0,0,0],
+> [0,0,0,-1,0,0,0,0],[0,0,1,-1,0,0,0,0],[0,-1,1,0,-1,0,0,0],
+> [1,-1,0,1,0,-1,0,0],[2,1,0,0,0,1,4,1]];;
+gap> b:=[[-1,0,1,0,-1,1,0,0],[0,-1,0,1,-1,0,0,0],[0,0,-1,1,0,0,0,0],
+> [0,0,-1,0,0,0,0,0],[0,1,-1,0,0,0,0,0],[-1,1,0,-1,0,0,0,0],
+> [-1,0,1,0,-1,0,1,0],[2,0,0,0,0,0,0,1]];;
+gap> c:=[[1,0,0,0,0,0,0,0],[0,1,0,0,0,0,0,0],[0,0,1,0,0,0,0,0],
+> [0,0,0,1,0,0,0,0],[0,0,0,0,1,0,0,0],[0,0,0,0,0,1,0,0],
+> [0,0,0,0,0,0,1,0],[6,0,0,0,0,0,0,1]];;
+gap> elm:=a*b;;
+gap> one:=elm^0;;
+gap> fixed:=NullspaceMat(elm-one);;
+gap> fun:=function(v,g)return List(v*g,x->x mod 18);end;;
+gap> seed:=fun(fixed[2],one);;
+gap> sgens:=[a,b,c];;
+gap> orb:=Orbit(Group(sgens),seed,fun);;
+gap> permgens:=List(sgens,x->Permutation(x,orb,fun));;
+gap> sm:=SmallerDegreePermutationRepresentation(Group(permgens));;
+gap> NrMovedPoints(Source(sm));
+157464
+gap> NrMovedPoints(Range(sm))<200;
+true
 gap> STOP_TEST( "grpperm.tst", 1);
 
 #############################################################################


### PR DESCRIPTION
in ImageKernelBlockHomomorphism do not add superfluous generators.
This otherwise can cause bad memory problems in large degrees with few
blocks (observed by Thomas).
Also if there are few large blocks, use orbit on blocks, together with test for redundant Schreier generators, rather than running through all points in block.