### PR TITLE
Fix cross-references to old location of package guidance

### DIFF
--- a/doc/changes/changes44.xml
+++ b/doc/changes/changes44.xml
@@ -18,7 +18,7 @@ subsequent update releases of &GAP; 4.4.
   updates independent of main &GAP; releases. Packages require a
   file <F>PackageInfo.g</F> now. The new <F>PackageInfo.g</F> files are 
   available for all packages with the new version of GAP
-  (see <Ref BookName="Example" Label="PackageInfo.g"/>).
+  (see <Ref BookName="ref" Label="PackageInfo.g"/>).
 </Item>
 <Item>
   <Ref Oper="IsSimpleGroup" BookName="ref"/> returns false now for the trivial group.
@@ -270,7 +270,7 @@ saved workspaces have been introduced. (S. Linton and B. Höfling)
 <Item>
   There is a new mechanism for loading packages available.
               Packages need a file <F>PackageInfo.g</F> now. (T. Breuer and
-              F. Lübeck; see <Ref BookName="Example" Label="PackageInfo.g"/>).
+              F. Lübeck; see <Ref BookName="ref" Label="PackageInfo.g"/>).
 </Item>
 </List>
 <P/>

--- a/doc/changes/changes45.xml
+++ b/doc/changes/changes45.xml
@@ -654,8 +654,9 @@ library, see <Ref Sect="Namespaces for GAP packages" BookName="ref"/>.
 
 All guidance on how to <E>develop</E> a &GAP; package has been consolidated 
 in the <Package>Example</Package> package which also contains a checklist 
-for upgrading a &GAP; package to &GAP;&nbsp;4.5, see 
-<Ref Appendix="Guidelines for Writing a GAP Package" BookName="Example"/>.
+for upgrading a &GAP; package to &GAP;&nbsp;4.5 (the guidance has been
+transferred to <Ref Chap="Using and Developing GAP Packages" BookName="ref"/>
+in &GAP;&nbsp;4.9).
 <P/> 
 
 </Subsection>
@@ -800,8 +801,9 @@ computation.
  
 <Item>
 <Package>Example</Package> package by W. Nickel, G. Gamble and A. Konovalov
-has a more detailed and up-to-date guidance on developing a &GAP; package,
-see <Ref Appendix="Guidelines for Writing a GAP Package" BookName="Example"/>.
+has a more detailed and up-to-date guidance on developing a &GAP; package
+(transferred to <Ref Chap="Using and Developing GAP Packages" BookName="ref"/>
+in &GAP;&nbsp;4.9).
 </Item>
 
 <Item>

--- a/doc/dev/testing.xml
+++ b/doc/dev/testing.xml
@@ -229,7 +229,7 @@ It consists of
     the tests of packages loading with
     <Ref BookName="ref" Func="LoadPackage"/> 
     and
-    <Ref BookName="Example" Func="LoadAllPackages"/>
+    <Ref BookName="ref" Func="LoadAllPackages"/>
   </Item>
 </List>
 
@@ -282,7 +282,7 @@ Then proceed as follows in the &GAP; root directory.
   <Item>
     Call <C>make testpackagesloading</C>.
     This loads each accepted or deposited package in a new &GAP; session,
-    then starts a new &GAP; session and calls <Ref BookName="Example" Func="LoadAllPackages"/>
+    then starts a new &GAP; session and calls <Ref BookName="ref" Func="LoadAllPackages"/>
     to check that all packages may be loaded simultaneosuly.
     It require just a few minutes.
   </Item>  

--- a/lib/package.gd
+++ b/lib/package.gd
@@ -1199,7 +1199,7 @@ DeclareGlobalFunction( "Cite" );
 ##  (For that, &GAP; actually loads the package.)
 ##  <P/>
 ##  If a version number <A>version</A> is given
-##  (see Section&nbsp;<Ref Sect="Version Numbers" BookName="Example"/>)
+##  (see Section&nbsp;<Ref Sect="Version Numbers" BookName="ref"/>)
 ##  then this version of the package is considered.
 ##  <P/>
 ##  An error message is printed if (the given version of) the package


### PR DESCRIPTION
Appendix from the manual of the Example package has been moved to the Reference manual.