### PR TITLE
Reformat some kernel comments (e.g. to use <= 78 chars per line)

### DIFF
--- a/src/integer.c
+++ b/src/integer.c
@@ -18,8 +18,8 @@
 **  In the following, let 'N' be the number of bits in an mp_limb_t (so 32 or
 **  64, depending on the system). 'T_INT' is the type of those integers small
 **  enough to fit into N-3 bits. Therefore the value range of this small
-**  integers is $-2^{N-4}...2^{N-4}-1$. Only these small integers can be used as
-**  index expression into sequences.
+**  integers is $-2^{N-4}...2^{N-4}-1$. Only these small integers can be used
+**  as index expression into sequences.
 **
 **  Small integers are represented by an immediate integer handle, containing
 **  the value instead of pointing to it, which has the following form:
@@ -31,22 +31,22 @@
 **
 **  Immediate integers handles carry the tag 'T_INT', i.e. the last bit is 1.
 **  This distinguishes immediate integers from other handles which point to
-**  structures aligned on even boundaries and therefore have last bit zero. (The
-**  second bit is reserved as tag to allow extensions of this scheme.) Using
-**  immediates as pointers and dereferencing them gives address errors.
+**  structures aligned on even boundaries and therefore have last bit zero.
+**  (The second bit is reserved as tag to allow extensions of this scheme.)
+**  Using immediates as pointers and dereferencing them gives address errors.
 **
 **  To aid overflow check the most significant two bits must always be equal,
 **  that is to say that the sign bit of immediate integers has a guard bit.
 **
-**  The macros 'INTOBJ_INT' and 'INT_INTOBJ' should be used to convert between a
-**  small integer value and its representation as immediate integer handle.
+**  The macros 'INTOBJ_INT' and 'INT_INTOBJ' should be used to convert between
+**  a small integer value and its representation as immediate integer handle.
 **
-**  'T_INTPOS' and 'T_INTNEG' are the types of positive (respectively, negative)
+**  'T_INTPOS' and 'T_INTNEG' are the types of positive respectively negative
 **  integer values that can not be represented by immediate integers.
 **
-**  This large integers values are represented as low-level GMP integer objects,
-**  that is, in base 2^N. That means that the bag of a large integer has the
-**  following form:
+**  These large integers values are represented as low-level GMP integer
+**  objects, that is, in base 2^N. That means that the bag of a large integer
+**  has the following form:
 **
 **      +-------+-------+-------+-------+- - - -+-------+-------+-------+
 **      | digit | digit | digit | digit |       | digit | digit | digit |
@@ -54,14 +54,14 @@
 **      +-------+-------+-------+-------+- - - -+-------+-------+-------+
 **
 **  The value of this is: $d0 + d1 2^N + d2 (2^N)^2 + ... + d_n (2^N)^n$,
-**  respectively the negative of this if the type of this object is 'T_INTNEG'.
+**  respectively the negative of this if the object type is 'T_INTNEG'.
 **
 **  Each digit is of course stored as a N bit wide unsigned integer.
 **
 **  Note that we require that all large integers be normalized (that is, they
 **  must not contain leading zero limbs) and reduced (they do not fit into a
-**  small integer). Internally, it is possible that a large integer temporarily
-**  is not normalized or not reduced, but all kernel functions must make sure
+**  small integer). Internally, a large integer may temporarily not be
+**  normalized or not be reduced, but all kernel functions must make sure
 **  that they eventually return normalized and reduced values. The function
 **  GMP_NORMALIZE and GMP_REDUCE can be used to ensure this.
 */
@@ -264,7 +264,7 @@ typedef struct {
 **
 *F  NEW_FAKEMPZ( <fake>, <size> )
 **
-**  Setup a fake mpz_t object for capturing the output of a GMP mpz_* function,
+**  Setup a fake mpz_t object for capturing the output of a GMP mpz_ function,
 **  with space for up to <size> limbs allocated.
 */
 static void NEW_FAKEMPZ( fake_mpz_t fake, UInt size )
@@ -913,7 +913,8 @@ Obj FuncIntHexString( Obj self,  Obj str )
 **  Implementation of Log2Int for C integers.
 **
 **  When available, we try to use GCC builtins. Otherwise, fall back to code
-**  based on https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogLookup.
+**  based on
+**   https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogLookup
 **  On a test machine with x86 64bit, the builtins are about 4 times faster
 **  than the generic code.
 **
@@ -1409,9 +1410,11 @@ Obj FuncSIGN_INT(Obj self, Obj op)
 **
 **  It can also be used in the cases that both operands  are  small  integers
 **  and the result is a small integer too,  i.e., that  no  overflow  occurs.
-**  This case is usually already handled in 'EvalProd' for a better efficiency.
+**  This case is usually already handled in 'EvalProd' for a better
+**  efficiency.
 **
-**  Is called from the 'EvalProd' binop so both operands are already evaluated.
+**  Is called from the 'EvalProd' binop so both operands are already
+*   evaluated.
 */
 Obj ProdInt ( Obj gmpL, Obj gmpR )
 {
@@ -1569,9 +1572,9 @@ Obj OneInt ( Obj op )
 **
 **  It can also be used in the cases that both operands  are  small  integers
 **  and the result is a small integer too,  i.e., that  no  overflow  occurs.
-**  This case is usually already handled in 'EvalPow' for a better  efficiency.
+**  This case is usually already handled in 'EvalPow' for a better efficiency.
 **
-**  Is called from the 'EvalPow'  binop so both operands are already evaluated.
+**  Is called from the 'EvalPow' binop so both operands are already evaluated.
 */
 Obj PowInt ( Obj gmpL, Obj gmpR )
 {
@@ -1729,8 +1732,8 @@ Obj FuncPOW_OBJ_INT ( Obj self, Obj opL, Obj opR )
 **  It can also be used in the cases that both operands  are  small  integers
 **  and the result is a small integer too,  i.e., that  no  overflow  occurs.
 **  This case is usually already handled in 'EvalMod' for a better efficiency.
-p**
-**  Is called from the 'EvalMod'  binop so both operands are already evaluated.
+**
+**  Is called from the 'EvalMod' binop so both operands are already evaluated.
 */
 Obj ModInt ( Obj opL, Obj opR )
 {
@@ -1876,9 +1879,9 @@ Obj ModInt ( Obj opL, Obj opR )
 **  It can also be used in the cases that both operands  are  small  integers
 **  and the result is a small integer too,  i.e., that  no  overflow  occurs.
 **
-**  Note that this routine is not called from 'EvalQuo', the  division  of  two
-**  integers yields  a  rational  and  is  therefor  performed  in  'QuoRat'.
-**  This operation is however available through the internal function 'Quo'.
+**  Note that this routine is not called from 'EvalQuo', the  division of two
+**  integers yields a rational and is therefor performed in 'QuoRat'. This
+**  operation is however available through the internal function 'Quo'.
 */
 Obj QuoInt ( Obj opL, Obj opR )
 {
@@ -2539,9 +2542,9 @@ Obj FuncIS_PROBAB_PRIME_INT(Obj self, Obj n, Obj reps)
 **
 ** * * * * * * * "Mersenne twister" random numbers  * * * * * * * * * * * * *
 **
-**  Part of this code for fast generation of 32 bit pseudo random numbers with 
-**  a period of length 2^19937-1 and a 623-dimensional equidistribution is 
-**  taken from:
+**  Part of this code for fast generation of 32 bit pseudo random numbers
+**  with a period of length 2^19937-1 and a 623-dimensional equidistribution
+**  is taken from:
 **          http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
 **  (Also look in Wikipedia for "Mersenne twister".)
 */

--- a/src/io.c
+++ b/src/io.c
@@ -1054,21 +1054,19 @@ Char GetLine ( void )
 
 
 /****************************************************************************
- **
-
- *F * * * * * * * * * * * * *  output functions  * * * * * * * * * * * * * * *
- */
+**
+*F * * * * * * * * * * * * *  output functions  * * * * * * * * * * * * * * *
+*/
 
 
 /****************************************************************************
- **
- *F  PutLine2( <output>, <line>, <len> )  . . . . . . . . . print a line, local
- **
- **  Introduced  <len> argument. Actually in all cases where this is called one
- **  knows the length of <line>, so it is not necessary to compute it again
- **  with the inefficient C- strlen.  (FL)
- */
-
+**
+*F  PutLine2( <output>, <line>, <len> )  . . . . . . . . .print a line, local
+**
+**  Introduced <len> argument. Actually in all cases where this is called one
+**  knows the length of <line>, so it is not necessary to compute it again
+**  with the inefficient C- strlen.  (FL)
+*/
 
 void PutLine2(
         TypOutputFile *         output,
@@ -1103,17 +1101,17 @@ void PutLine2(
 
 
 /****************************************************************************
- **
- *F  PutLineTo ( stream, len ) . . . . . . . . . . . . . . print a line, local
- **
- **  'PutLineTo'  prints the first len characters of the current output
- **  line   'stream->line' to <stream>
- **  It  is  called from 'PutChrTo'.
- **
- **  'PutLineTo'  also echoes the  output  line  to the  logfile 'OutputLog' if
- **  'OutputLog' is not 0 and the output file is '*stdout*' or '*errout*'.
- **
- */
+**
+*F  PutLineTo ( stream, len ) . . . . . . . . . . . . . . print a line, local
+**
+**  'PutLineTo'  prints the first len characters of the current output
+**  line   'stream->line' to <stream>
+**  It  is  called from 'PutChrTo'.
+**
+**  'PutLineTo' also echoes the output line to the logfile 'OutputLog' if
+**  'OutputLog' is not 0 and the output file is '*stdout*' or '*errout*'.
+**
+*/
 void PutLineTo(TypOutputFile * stream, UInt len)
 {
   PutLine2( stream, stream->line, len );
@@ -1128,17 +1126,18 @@ void PutLineTo(TypOutputFile * stream, UInt len)
 
 
 /****************************************************************************
- **
- *F  PutChrTo( <stream>, <ch> )  . . . . . . . . . print character <ch>, local
- **
- **  'PutChrTo' prints the single character <ch> to the stream <stream>
- **
- **  'PutChrTo' buffers the  output characters until  either <ch> is  <newline>,
- **  <ch> is '\03' (<flush>) or the buffer fills up.
- **
- **  In the later case 'PutChrTo' has to decide where to  split the output line.
- **  It takes the point at which $linelength - pos + 8 * indent$ is minimal.
- */
+**
+*F  PutChrTo( <stream>, <ch> )  . . . . . . . . . print character <ch>, local
+**
+**  'PutChrTo' prints the single character <ch> to the stream <stream>
+**
+**  'PutChrTo' buffers the output characters until either <ch> is <newline>,
+**  <ch> is '\03' (<flush>) or the buffer fills up.
+**
+**  In the later case 'PutChrTo' has to decide where to split the output
+**  line. It takes the point at which $linelength - pos + 8 * indent$ is
+**  minimal.
+*/
 
 /* helper function to add a hint about a possible line break;
    a triple (pos, value, indent), such that the minimal (value-pos) wins */
@@ -1347,9 +1346,9 @@ void PutChrTo(TypOutputFile * stream, Char ch)
 }
 
 /****************************************************************************
- **
- *F  FuncToggleEcho( )
- **
+**
+*F  FuncToggleEcho( )
+**
 */
 
 Obj FuncToggleEcho( Obj self)
@@ -1359,11 +1358,11 @@ Obj FuncToggleEcho( Obj self)
 }
 
 /****************************************************************************
- **
- *F  FuncCPROMPT( )
- **
- **  returns the current `Prompt' as GAP string.
- */
+**
+*F  FuncCPROMPT( )
+**
+**  returns the current `Prompt' as GAP string.
+*/
 Obj FuncCPROMPT( Obj self)
 {
   Obj p;
@@ -1372,13 +1371,13 @@ Obj FuncCPROMPT( Obj self)
 }
 
 /****************************************************************************
- **
- *F  FuncPRINT_CPROMPT( <prompt> )
- **
- **  prints current `Prompt' if argument <prompt> is not in StringRep, otherwise
- **  uses the content of <prompt> as `Prompt' (at most 80 characters).
- **  (important is the flush character without resetting the cursor column)
- */
+**
+*F  FuncPRINT_CPROMPT( <prompt> )
+**
+**  prints current `Prompt' if argument <prompt> is not in StringRep, otherwise
+**  uses the content of <prompt> as `Prompt' (at most 80 characters).
+**  (important is the flush character without resetting the cursor column)
+*/
 
 Obj FuncPRINT_CPROMPT( Obj self, Obj prompt )
 {
@@ -1393,41 +1392,40 @@ Obj FuncPRINT_CPROMPT( Obj self, Obj prompt )
 }
 
 /****************************************************************************
- **
- *F  Pr( <format>, <arg1>, <arg2> )  . . . . . . . . .  print formatted output
- *F  PrTo( <stream>, <format>, <arg1>, <arg2> )  . . .  print formatted output
- **
- **  'Pr' is the output function. The first argument is a 'printf' like format
- **  string containing   up   to 2  '%'  format   fields,   specifing  how the
- **  corresponding arguments are to be  printed.  The two arguments are passed
- **  as  'Int'   integers.   This  is possible  since every  C object  ('int',
- **  'char', pointers) except 'float' or 'double', which are not used  in GAP,
- **  can be converted to a 'Int' without loss of information.
- **
- **  The function 'Pr' currently support the following '%' format  fields:
- **  '%c'    the corresponding argument represents a character,  usually it is
- **          its ASCII or EBCDIC code, and this character is printed.
- **  '%s'    the corresponding argument is the address of  a  null  terminated
- **          character string which is printed.
- **  '%S'    the corresponding argument is the address of  a  null  terminated
- **          character string which is printed with escapes.
- **  '%C'    the corresponding argument is the address of  a  null  terminated
- **          character string which is printed with C escapes.
- **  '%d'    the corresponding argument is a signed integer, which is printed.
- **          Between the '%' and the 'd' an integer might be used  to  specify
- **          the width of a field in which the integer is right justified.  If
- **          the first character is '0' 'Pr' pads with '0' instead of <space>.
- **  '%i'    is a synonym of %d, in line with recent C library developements
- **  '%I'    print an identifier
- **  '%>'    increment the indentation level.
- **  '%<'    decrement the indentation level.
- **  '%%'    can be used to print a single '%' character. No argument is used.
- **
- **  You must always  cast the arguments to  '(Int)'  to avoid  problems  with
- **  those compilers with a default integer size of 16 instead of 32 bit.  You
- **  must pass 0L if you don't make use of an argument to please lint.
- */
-
+**
+*F  Pr( <format>, <arg1>, <arg2> )  . . . . . . . . .  print formatted output
+*F  PrTo( <stream>, <format>, <arg1>, <arg2> )  . . .  print formatted output
+**
+**  'Pr' is the output function. The first argument is a 'printf' like format
+**  string containing   up   to 2  '%'  format   fields,   specifing  how the
+**  corresponding arguments are to be  printed.  The two arguments are passed
+**  as  'Int'   integers.   This  is possible  since every  C object  ('int',
+**  'char', pointers) except 'float' or 'double', which are not used  in GAP,
+**  can be converted to a 'Int' without loss of information.
+**
+**  The function 'Pr' currently support the following '%' format  fields:
+**  '%c'    the corresponding argument represents a character,  usually it is
+**          its ASCII or EBCDIC code, and this character is printed.
+**  '%s'    the corresponding argument is the address of  a  null  terminated
+**          character string which is printed.
+**  '%S'    the corresponding argument is the address of  a  null  terminated
+**          character string which is printed with escapes.
+**  '%C'    the corresponding argument is the address of  a  null  terminated
+**          character string which is printed with C escapes.
+**  '%d'    the corresponding argument is a signed integer, which is printed.
+**          Between the '%' and the 'd' an integer might be used  to  specify
+**          the width of a field in which the integer is right justified.  If
+**          the first character is '0' 'Pr' pads with '0' instead of <space>.
+**  '%i'    is a synonym of %d, in line with recent C library developements
+**  '%I'    print an identifier
+**  '%>'    increment the indentation level.
+**  '%<'    decrement the indentation level.
+**  '%%'    can be used to print a single '%' character. No argument is used.
+**
+**  You must always  cast the arguments to  '(Int)'  to avoid  problems  with
+**  those compilers with a default integer size of 16 instead of 32 bit.  You
+**  must pass 0L if you don't make use of an argument to please lint.
+*/
 static inline void FormatOutput(
     void (*put_a_char)(void *state, Char c),
     void *state, const Char *format, Int arg1, Int arg2 )
@@ -1475,7 +1473,7 @@ static inline void FormatOutput(
       int is_neg = (arg1 < 0);
       if ( is_neg ) {
         arg1 = -arg1;
-        prec--; /* we loose one digit of output precision for the minus sign */
+        prec--; // we loose one digit of output precision for the minus sign
       }
 
       /* compute how many characters this number requires    */
@@ -1752,9 +1750,9 @@ static StructGVarFunc GVarFuncs [] = {
 };
 
 /****************************************************************************
- **
- *F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
- */
+**
+*F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
+*/
 static Int InitLibrary (
     StructInitInfo *    module )
 {
@@ -1790,11 +1788,10 @@ static Int InitKernel (
     DeclareGVar(&DEFAULT_OUTPUT_STREAM, "DEFAULT_OUTPUT_STREAM");
 
 #else
-    /* initialize cookies for streams                                      */
-    /* also initialize the cookies for the GAP strings which hold the
-       latest lines read from the streams  and the name of the current input file*/
-    /* For HPC-GAP we don't need the cookies anymore, since the data got moved to thread-local
-     * storage. */
+    // Initialize cookies for streams. Also initialize the cookies for the
+    // GAP strings which hold the latest lines read from the streams  and the
+    // name of the current input file. For HPC-GAP we don't need the cookies
+    // anymore, since the data got moved to thread-local storage.
     Int i;
     for ( i = 0;  i < ARRAY_SIZE(STATE(InputFiles));  i++ ) {
       Cookie[i][0] = 's';  Cookie[i][1] = 't';  Cookie[i][2] = 'r';
@@ -1833,9 +1830,9 @@ static void InitModuleState(ModuleStateOffset offset)
 }
 
 /****************************************************************************
- **
- *F  InitInfoScanner() . . . . . . . . . . . . . . . . table of init functions
- */
+**
+*F  InitInfoIO() . . . . . . . . . . . . . . . . table of init functions
+*/
 static StructInitInfo module = {
     // init struct using C99 designated initializers; for a full list of
     // fields, please refer to the definition of StructInitInfo

--- a/src/io.h
+++ b/src/io.h
@@ -184,20 +184,20 @@ extern UInt CloseInputLog ( void );
 
 /****************************************************************************
  **
- *V  Prompt  . . . . . . . . . . . . . . . . . . . . . .  prompt to be printed
+ *V  Prompt  . . . . . . . . . . . . . . . . . . . . . . prompt to be printed
  **
- **  'Prompt' holds the string that is to be printed if a  new  line  is  read
+ **  'Prompt' holds the string that is to be printed if a  new  line  is read
  **  from the interactive files '*stdin*' or '*errin*'.
  **
- **  It is set to 'gap> ' or 'brk> ' in the  read-eval-print loops and changed
+ **  It is set to 'gap> ' or 'brk> ' in the read-eval-print loops and changed
  **  to the partial prompt '> ' in 'Read' after the first symbol is read.
  */
 /* TL: extern  const Char *    Prompt; */
 
-/***************************************************************************** 
+/****************************************************************************
  **
- *V  PrintPromptHook . . . . . . . . . . . . . .  function for printing prompt
- *V  EndLineHook . . . . . . . . . . .  function called at end of command line
+ *V  PrintPromptHook . . . . . . . . . . . . . . function for printing prompt
+ *V  EndLineHook . . . . . . . . . . . function called at end of command line
  **  
  **  These functions can be set on GAP-level. If they are not bound  the 
  **  default is: Instead of `PrintPromptHook' the `Prompt' is printed and
@@ -271,8 +271,9 @@ extern UInt CloseOutputLog ( void );
 **  which is the terminal  even   if '*stdout*'  is  redirected to   a  file.
 **  'OpenOutput' passes  those  file names to 'SyFopen'  like any other name,
 **  they are just a convention between the main and the system package.
-**  The function does nothing and returns success for '*stdout*' and '*errout*'
-**  when IgnoreStdoutErrout is true (useful for testing purposes).
+**
+**  The function does nothing and returns success for '*stdout*' and
+**  '*errout*' when IgnoreStdoutErrout is true (useful for testing purposes).
 **
 **  It is not neccessary to open the initial output file, 'InitScanner' opens
 **  '*stdout*' for that purpose.  This  file  on the other hand   can not  be

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -154,7 +154,7 @@ void            SyntaxWarning (
 **  'else' or 'fi' symbol, or a symbol that is  contained in the set <follow>
 **  which is passed to 'ReadIf' and contains all symbols allowing  one of the
 **  calling functions  to resynchronize,  for example 'S_OD' if 'ReadIf'  has
-**  been called from 'ReadFor'.  <follow> always contain 'S_EOF', which 'Read'
+**  been called from 'ReadFor'. <follow> always contain 'S_EOF', which 'Read'
 **  uses to resynchronise.
 **
 **  If 'Match' needs to  read a  new line from  '*stdin*' or '*errin*' to get
@@ -167,7 +167,7 @@ void Match (
 {
     Char                errmsg [256];
 
-    /* if 'STATE(Symbol)' is the expected symbol match it away                    */
+    // if 'STATE(Symbol)' is the expected symbol match it away
     if ( symbol == STATE(Symbol) ) {
         GetSymbol();
     }
@@ -189,10 +189,10 @@ void Match (
 *F  GetIdent()  . . . . . . . . . . . . . get an identifier or keyword, local
 **
 **  'GetIdent' reads   an identifier from  the current  input  file  into the
-**  variable 'STATE(Value)' and sets 'Symbol' to 'S_IDENT'.   The first character of
-**  the   identifier  is  the current character  pointed to  by 'In'.  If the
-**  characters make  up   a  keyword 'GetIdent'  will  set   'Symbol'  to the
-**  corresponding value.  The parser will ignore 'STATE(Value)' in this case.
+**  variable 'STATE(Value)' and sets 'Symbol' to 'S_IDENT'. The first
+**  character of the identifier is the current character pointed to by 'In'.
+**  If the characters make up a keyword 'GetIdent' will set 'Symbol' to the
+**  corresponding value. The parser will ignore 'STATE(Value)' in this case.
 **
 **  An  identifier consists of a letter  followed by more letters, digits and
 **  underscores '_'.  An identifier is terminated by the first  character not
@@ -201,22 +201,21 @@ void Match (
 **  '\' can be used  to include special characters like  '('  in identifiers.
 **  For example 'G\(2\,5\)' is an identifier not a call to a function 'G'.
 **
-**  The size  of 'STATE(Value)' limits the  number  of significant characters  in an
-**  identifier.   If  an  identifier   has more characters    'GetIdent' will
+**  The size of 'STATE(Value)' limits the number of significant characters in
+**  an identifier. If an identifier has more characters 'GetIdent' will
 **  silently truncate it.
 **
 **  After reading the identifier 'GetIdent'  looks at the  first and the last
-**  character  of  'STATE(Value)' to see if  it  could possibly  be  a keyword.  For
+**  character of 'STATE(Value)' to see if it could possibly be a keyword. For
 **  example 'test'  could  not be  a  keyword  because there  is  no  keyword
 **  starting and ending with a 't'.  After that  test either 'GetIdent' knows
-**  that 'STATE(Value)' is not a keyword, or there is a unique possible keyword that
-**  could match, because   no two  keywords  have  identical  first and  last
-**  characters.  For example if 'STATE(Value)' starts with 'f' and ends with 'n' the
-**  only possible keyword  is 'function'.   Thus in this case  'GetIdent' can
-**  decide with one string comparison if 'STATE(Value)' holds a keyword or not.
+**  that 'STATE(Value)' is not a keyword, or there is a unique possible
+**  keyword that could match, because no two keywords have identical first
+**  and last characters. For example if 'STATE(Value)' starts with 'f' and
+**  ends with 'n' the only possible keyword is 'function'. Thus in this case
+**  'GetIdent' can decide with one string comparison if 'STATE(Value)' holds
+**  a keyword or not.
 */
-
-
 void GetIdent ( void )
 {
     Int                 i, fetch;
@@ -325,30 +324,33 @@ void GetIdent ( void )
 }
 
 
-/******************************************************************************
+/****************************************************************************
+**
 *F  GetNumber()  . . . . . . . . . . . . . .  get an integer or float literal
 **
-**  'GetNumber' reads  a number from  the  current  input file into the
-**  variable  'STATE(Value)' and sets  'Symbol' to 'S_INT', 'S_PARTIALINT',
-**  'S_FLOAT' or 'S_PARTIALFLOAT'.   The first character of
-**  the number is the current character pointed to by 'In'.
+**  'GetNumber' reads a number from the current input file into the variable
+**  'STATE(Value)' and sets 'Symbol' to 'S_INT', 'S_PARTIALINT', 'S_FLOAT' or
+**  'S_PARTIALFLOAT'. The first character of the number is the current
+**  character pointed to by 'In'.
 **
-**  If the sequence contains characters which do not match the regular expression
-**  [0-9]+.?[0-9]*([edqEDQ][+-]?[0-9]+)? 'GetNumber'  will
+**  If the sequence contains characters which do not match the regular
+**  expression [0-9]+.?[0-9]*([edqEDQ][+-]?[0-9]+)? 'GetNumber'  will
 **  interpret the sequence as an identifier and set 'Symbol' to 'S_IDENT'.
 **
-**  As we read, we keep track of whether we have seen a . or exponent notation
-**  and so whether we will return S_[PARTIAL]INT or S_[PARTIAL]FLOAT.
+**  As we read, we keep track of whether we have seen a . or exponent
+**  notation and so whether we will return S_[PARTIAL]INT or
+**  S_[PARTIAL]FLOAT.
 **
-**  When STATE(Value) is  completely filled we have to check  if the reading of
-**  the number  is complete  or not to  decide whether to return a PARTIAL type.
+**  When STATE(Value) is completely filled we have to check if the reading of
+**  the number is complete or not to decide whether to return a PARTIAL type.
 **
-**  The argument reflects how far we are through reading a possibly very long number
-**  literal. 0 indicates that nothing has been read. 1 that at least one digit has been
-**  read, but no decimal point. 2 that a decimal point has been read with no digits before
-**  or after it. 3 a decimal point and at least one digit, but no exponential indicator
-**  4 an exponential indicator  but no exponent digits and 5 an exponential indicator and
-**  at least one exponent digit.
+**  The argument reflects how far we are through reading a possibly very long
+**  number literal. 0 indicates that nothing has been read. 1 that at least
+**  one digit has been read, but no decimal point. 2 that a decimal point has
+**  been read with no digits before or after it. 3 a decimal point and at
+**  least one digit, but no exponential indicator 4 an exponential indicator
+**  but no exponent digits and 5 an exponential indicator and at least one
+**  exponent digit.
 **
 */
 static Char GetCleanedChar( UInt *wasEscaped ) {
@@ -619,14 +621,14 @@ void GetNumber ( UInt StartingStatus )
 }
 
 
-/*******************************************************************************
- **
- *F  GetEscapedChar()   . . . . . . . . . . . . . . . . get an escaped character
- **
- **  'GetEscapedChar' reads an escape sequence from the current input file into
- **  the variable *dst.
- **
- */
+/****************************************************************************
+**
+*F  GetEscapedChar() . . . . . . . . . . . . . . . . get an escaped character
+**
+**  'GetEscapedChar' reads an escape sequence from the current input file
+**  into the variable *dst.
+**
+*/
 static inline Char GetOctalDigits( void )
 {
     Char c;
@@ -644,10 +646,10 @@ static inline Char GetOctalDigits( void )
 
 
 /****************************************************************************
- **
- *F  CharHexDigit( <ch> ) . . . . . . . . . turn a single hex digit into Char
- **
- */
+**
+*F  CharHexDigit( <ch> ) . . . . . . . . .  turn a single hex digit into Char
+**
+*/
 static inline Char CharHexDigit( const Char ch ) {
     if (ch >= 'a') {
         return (ch - 'a' + 10);
@@ -713,28 +715,29 @@ Char GetEscapedChar( void )
 }
 
 /****************************************************************************
- **
- *F  GetStr()  . . . . . . . . . . . . . . . . . . . . . . get a string, local
- **
- **  'GetStr' reads  a  string from the  current input file into  the variable
- **  'STATE(Value)' and sets 'Symbol'   to  'S_STRING'.  The opening double quote '"'
- **  of the string is the current character pointed to by 'In'.
- **
- **  A string is a sequence of characters delimited  by double quotes '"'.  It
- **  must not include  '"' or <newline>  characters, but the  escape sequences
- **  '\"' or '\n' can  be used instead.  The  escape sequence  '\<newline>' is
- **  ignored, making it possible to split long strings over multiple lines.
- **
- **  An error is raised if the string includes a <newline> character or if the
- **  file ends before the closing '"'.
- **
- **  When STATE(Value) is  completely filled we have to check  if the reading of
- **  the string is  complete or not to decide  between Symbol=S_STRING or
- **  S_PARTIALSTRING.
- */
+**
+*F  GetStr()  . . . . . . . . . . . . . . . . . . . . .  get a string, local
+**
+**  'GetStr' reads  a  string from the  current input file into  the variable
+**  'STATE(Value)' and sets 'Symbol'   to  'S_STRING'.  The opening double quote '"'
+**  of the string is the current character pointed to by 'In'.
+**
+**  A string is a sequence of characters delimited  by double quotes '"'.  It
+**  must not include  '"' or <newline>  characters, but the  escape sequences
+**  '\"' or '\n' can  be used instead.  The  escape sequence  '\<newline>' is
+**  ignored, making it possible to split long strings over multiple lines.
+**
+**  An error is raised if the string includes a <newline> character or if the
+**  file ends before the closing '"'.
+**
+**  When STATE(Value) is  completely filled we have to check  if the reading of
+**  the string is  complete or not to decide  between Symbol=S_STRING or
+**  S_PARTIALSTRING.
+*/
 void GetStr ( void )
 {
   Int                 i = 0, fetch;
+
 
   /* read all characters into 'Value'                                    */
   for ( i = 0; i < SAFE_VALUE_SIZE-1 && *STATE(In) != '"'
@@ -791,23 +794,23 @@ void GetStr ( void )
 }
 
 /****************************************************************************
- **
- *F  GetTripStr()  . . . . . . . . . . . . .get a triple quoted string, local
- **
- **  'GetTripStr' reads a triple-quoted string from the  current input file
- **  into  the variable 'Value' and sets 'Symbol'   to  'S_STRING'.
- **  The last member of the opening triple quote '"'
- **  of the string is the current character pointed to by 'In'.
- **
- **  A triple quoted string is any sequence of characters which is terminated
- **  by """. No escaping is performed.
- **
- **  An error is raised if the file ends before the closing """.
- **
- **  When Value is  completely filled we have to check  if the reading of
- **  the string is  complete or not to decide  between Symbol=S_STRING or
- **  S_PARTIALTRIPLESTRING.
- */
+**
+*F  GetTripStr()  . . . . . . . . . . . . .get a triple quoted string, local
+**
+**  'GetTripStr' reads a triple-quoted string from the  current input file
+**  into  the variable 'Value' and sets 'Symbol'   to  'S_STRING'.
+**  The last member of the opening triple quote '"'
+**  of the string is the current character pointed to by 'In'.
+**
+**  A triple quoted string is any sequence of characters which is terminated
+**  by """. No escaping is performed.
+**
+**  An error is raised if the file ends before the closing """.
+**
+**  When Value is  completely filled we have to check  if the reading of
+**  the string is  complete or not to decide  between Symbol=S_STRING or
+**  S_PARTIALTRIPLESTRING.
+*/
 void GetTripStr ( void )
 {
   Int                 i = 0;
@@ -862,13 +865,12 @@ void GetTripStr ( void )
 }
 
 /****************************************************************************
- **
- *F  GetMaybeTripStr()  . . . . . . . . . . . . . . . . . get a string, local
- **
- **  'GetMaybeTripStr' decides if we are reading a single quoted string,
- **  or a triple quoted string.
- */
-
+**
+*F  GetMaybeTripStr()  . . . . . . . . . . . . . . . . . get a string, local
+**
+**  'GetMaybeTripStr' decides if we are reading a single quoted string,
+**  or a triple quoted string.
+*/
 void GetMaybeTripStr ( void )
 {
     /* This is just a normal string! */
@@ -893,17 +895,17 @@ void GetMaybeTripStr ( void )
 
 
 /****************************************************************************
- **
- *F  GetChar() . . . . . . . . . . . . . . . . . get a single character, local
- **
- **  'GetChar' reads the next  character from the current input file  into the
- **  variable 'STATE(Value)' and sets 'Symbol' to 'S_CHAR'.  The opening single quote
- **  '\'' of the character is the current character pointed to by 'In'.
- **
- **  A  character is  a  single character delimited by single quotes '\''.  It
- **  must not  be '\'' or <newline>, but  the escape  sequences '\\\'' or '\n'
- **  can be used instead.
- */
+**
+*F  GetChar() . . . . . . . . . . . . . . . . . get a single character, local
+**
+**  'GetChar' reads the next  character from the current input file  into the
+**  variable 'STATE(Value)' and sets 'Symbol' to 'S_CHAR'.  The opening single quote
+**  '\'' of the character is the current character pointed to by 'In'.
+**
+**  A  character is  a  single character delimited by single quotes '\''.  It
+**  must not  be '\'' or <newline>, but  the escape  sequences '\\\'' or '\n'
+**  can be used instead.
+*/
 void GetChar ( void )
 {
   /* skip '\''                                                           */
@@ -955,17 +957,17 @@ void GetHelp( void )
 }
 
 /****************************************************************************
- **
- *F  GetSymbol() . . . . . . . . . . . . . . . . .  get the next symbol, local
- **
- **  'GetSymbol' reads  the  next symbol from   the  input,  storing it in the
- **  variable 'Symbol'.  If 'Symbol' is  'S_IDENT', 'S_INT' or 'S_STRING'  the
- **  value of the symbol is stored in the variable 'STATE(Value)'.  'GetSymbol' first
- **  skips all <space>, <tab> and <newline> characters and comments.
- **
- **  After reading  a  symbol the current  character   is the first  character
- **  beyond that symbol.
- */
+**
+*F  GetSymbol() . . . . . . . . . . . . . . . . .  get the next symbol, local
+**
+**  'GetSymbol' reads  the  next symbol from   the  input,  storing it in the
+**  variable 'Symbol'.  If 'Symbol' is  'S_IDENT', 'S_INT' or 'S_STRING'  the
+**  value of the symbol is stored in the variable 'STATE(Value)'.  'GetSymbol' first
+**  skips all <space>, <tab> and <newline> characters and comments.
+**
+**  After reading  a  symbol the current  character   is the first  character
+**  beyond that symbol.
+*/
 void GetSymbol ( void )
 {
     /* special case if reading of a long token is not finished */
@@ -1123,13 +1125,13 @@ static StructGVarFunc GVarFuncs [] = {
 };
 
 /****************************************************************************
- **
- *F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * *
- */
+**
+*F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * *
+*/
 
 /****************************************************************************
- **
- *F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
+**
+*F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
  */
 static Int InitLibrary (
                         StructInitInfo *    module )
@@ -1139,9 +1141,9 @@ static Int InitLibrary (
 }
 
 /****************************************************************************
- **
- *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
- */
+**
+*F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
+*/
 static Int InitKernel (
     StructInitInfo *    module )
 {
@@ -1154,9 +1156,9 @@ static void InitModuleState(ModuleStateOffset offset)
 }
 
 /****************************************************************************
- **
- *F  InitInfoScanner() . . . . . . . . . . . . . . . . table of init functions
- */
+**
+*F  InitInfoScanner() . . . . . . . . . . . . . . . . table of init functions
+*/
 static StructInitInfo module = {
     // init struct using C99 designated initializers; for a full list of
     // fields, please refer to the definition of StructInitInfo


### PR DESCRIPTION
This PR only changes comments, no actual code.

It fixes various instances of comments exceeding the chars per line limit, which seems to be 78 in most files. It also adjust a bunch of comments in io.c which were formatted differently from how that's done in virtually all other GAP kernel source files.