### PR TITLE
Change (SET_){DAT,POS,COM}OBJ_TYPE to static inline

### DIFF
--- a/src/costab.c
+++ b/src/costab.c
@@ -2322,9 +2322,8 @@ Obj FuncLOWINDEX_PREPARE_RELS (
       for (k=1;k<=l;k++) 
         rp[k]=INT_INTOBJ((Obj)rp[k]); /* convert relator entries to C-integers */
       /* change type */
-      TYPE_DATOBJ(rel) = TYPE_LOWINDEX_DATA;
       RetypeBag(rel,T_DATOBJ);
-
+      SET_TYPE_DATOBJ(rel, TYPE_LOWINDEX_DATA);
     }
    }
    return (Obj) 0;

--- a/src/objects.c
+++ b/src/objects.c
@@ -340,7 +340,7 @@ Obj ShallowCopyObjDefault (
     Obj                 obj )
 {
     Obj                 new;
-    Obj *               o;
+    const Obj *         o;
     Obj *               n;
     UInt                len;
     UInt                i;
@@ -348,7 +348,7 @@ Obj ShallowCopyObjDefault (
     /* make the new object and copy the contents                           */
     len = (SIZE_OBJ( obj ) + sizeof(Obj)-1) / sizeof(Obj);
     new = NewBag( MUTABLE_TNUM(TNUM_OBJ(obj)), SIZE_OBJ(obj) );
-    o = ADDR_OBJ( obj );
+    o = CONST_ADDR_OBJ(obj);
     n = ADDR_OBJ( new );
     for ( i = 0; i < len; i++ ) {
         *n++ = *o++;
@@ -489,7 +489,7 @@ Obj CopyObjPosObj (
 
     /* make a copy                                                         */
     copy = NewBag( TNUM_OBJ(obj), SIZE_OBJ(obj) );
-    ADDR_OBJ(copy)[0] = ADDR_OBJ(obj)[0];
+    ADDR_OBJ(copy)[0] = CONST_ADDR_OBJ(obj)[0];
     if ( !mut ) {
         CALL_2ARGS( RESET_FILTER_OBJ, copy, IsMutableObjFilt );
     }
@@ -497,7 +497,7 @@ Obj CopyObjPosObj (
     /* leave a forwarding pointer                                          */
     tmp = NEW_PLIST( T_PLIST, 2 );
     SET_LEN_PLIST( tmp, 2 );
-    SET_ELM_PLIST( tmp, 1, ADDR_OBJ(obj)[0] );
+    SET_ELM_PLIST(tmp, 1, CONST_ADDR_OBJ(obj)[0]);
     SET_ELM_PLIST( tmp, 2, copy );
     ADDR_OBJ(obj)[0] = tmp;
     CHANGED_BAG(obj);
@@ -507,8 +507,8 @@ Obj CopyObjPosObj (
 
     /* copy the subvalues                                                  */
     for ( i = 1; i < SIZE_OBJ(obj)/sizeof(Obj); i++ ) {
-        if ( ADDR_OBJ(obj)[i] != 0 ) {
-            tmp = COPY_OBJ( ADDR_OBJ(obj)[i], mut );
+        if (CONST_ADDR_OBJ(obj)[i] != 0) {
+            tmp = COPY_OBJ(CONST_ADDR_OBJ(obj)[i], mut);
             ADDR_OBJ(copy)[i] = tmp;
             CHANGED_BAG( copy );
         }
@@ -537,7 +537,7 @@ Obj CopyObjPosObjCopy (
     Obj                 obj,
     Int                 mut )
 {
-    return ELM_PLIST( ADDR_OBJ(obj)[0], 2 );
+    return ELM_PLIST(CONST_ADDR_OBJ(obj)[0], 2);
 }
 
 
@@ -551,7 +551,7 @@ void CleanObjPosObjCopy (
     UInt                i;              /* loop variable                   */
 
     /* remove the forwarding pointer                                       */
-    ADDR_OBJ(obj)[0] = ELM_PLIST( ADDR_OBJ(obj)[0], 1 );
+    ADDR_OBJ(obj)[0] = ELM_PLIST(CONST_ADDR_OBJ(obj)[0], 1);
     CHANGED_BAG(obj);
 
     /* now it is cleaned                                                   */
@@ -559,8 +559,8 @@ void CleanObjPosObjCopy (
 
     /* clean the subvalues                                                 */
     for ( i = 1; i < SIZE_OBJ(obj)/sizeof(Obj); i++ ) {
-        if ( ADDR_OBJ(obj)[i] != 0 )
-            CLEAN_OBJ( ADDR_OBJ(obj)[i] );
+        if (CONST_ADDR_OBJ(obj)[i] != 0)
+            CLEAN_OBJ(CONST_ADDR_OBJ(obj)[i]);
     }
 
 }
@@ -591,7 +591,7 @@ Obj CopyObjComObj (
 
     /* make a copy                                                         */
     copy = NewBag( TNUM_OBJ(obj), SIZE_OBJ(obj) );
-    ADDR_OBJ(copy)[0] = ADDR_OBJ(obj)[0];
+    ADDR_OBJ(copy)[0] = CONST_ADDR_OBJ(obj)[0];
     SET_LEN_PREC(copy,LEN_PREC(obj));
     if ( !mut ) {
         CALL_2ARGS( RESET_FILTER_OBJ, copy, IsMutableObjFilt );
@@ -600,7 +600,7 @@ Obj CopyObjComObj (
     /* leave a forwarding pointer                                          */
     tmp = NEW_PLIST( T_PLIST, 2 );
     SET_LEN_PLIST( tmp, 2 );
-    SET_ELM_PLIST( tmp, 1, ADDR_OBJ(obj)[0] );
+    SET_ELM_PLIST(tmp, 1, CONST_ADDR_OBJ(obj)[0]);
     SET_ELM_PLIST( tmp, 2, copy );
     ADDR_OBJ(obj)[0] = tmp;
     CHANGED_BAG(obj);
@@ -639,7 +639,7 @@ Obj CopyObjComObjCopy (
     Obj                 obj,
     Int                 mut )
 {
-    return ELM_PLIST( ADDR_OBJ(obj)[0], 2 );
+    return ELM_PLIST(CONST_ADDR_OBJ(obj)[0], 2);
 }
 
 
@@ -653,7 +653,7 @@ void CleanObjComObjCopy (
     UInt                i;              /* loop variable                   */
 
     /* remove the forwarding pointer                                       */
-    ADDR_OBJ(obj)[0] = ELM_PLIST( ADDR_OBJ(obj)[0], 1 );
+    ADDR_OBJ(obj)[0] = ELM_PLIST(CONST_ADDR_OBJ(obj)[0], 1);
     CHANGED_BAG(obj);
 
     /* now it is cleaned                                                   */
@@ -678,7 +678,7 @@ Obj CopyObjDatObj (
     Obj                 copy;           /* copy, result                    */
     Obj                 tmp;            /* temporary variable              */
     UInt                i;              /* loop variable                   */
-    Int               * src;
+    const Int *         src;
     Int               * dst;
 
     /* don't change immutable objects                                      */
@@ -694,7 +694,7 @@ Obj CopyObjDatObj (
 
     /* make a copy                                                         */
     copy = NewBag( TNUM_OBJ(obj), SIZE_OBJ(obj) );
-    ADDR_OBJ(copy)[0] = ADDR_OBJ(obj)[0];
+    ADDR_OBJ(copy)[0] = CONST_ADDR_OBJ(obj)[0];
     if ( !mut ) {
         CALL_2ARGS( RESET_FILTER_OBJ, copy, IsMutableObjFilt );
     }
@@ -702,7 +702,7 @@ Obj CopyObjDatObj (
     /* leave a forwarding pointer                                          */
     tmp = NEW_PLIST( T_PLIST, 2 );
     SET_LEN_PLIST( tmp, 2 );
-    SET_ELM_PLIST( tmp, 1, ADDR_OBJ(obj)[0] );
+    SET_ELM_PLIST(tmp, 1, CONST_ADDR_OBJ(obj)[0]);
     SET_ELM_PLIST( tmp, 2, copy );
     ADDR_OBJ(obj)[0] = tmp;
     CHANGED_BAG(obj);
@@ -711,8 +711,8 @@ Obj CopyObjDatObj (
     RetypeBag( obj, TNUM_OBJ(obj) + COPYING );
 
     /* copy the subvalues                                                  */
-    src = (Int*)( ADDR_OBJ(obj) + 1 );
-    dst = (Int*)( ADDR_OBJ(copy) + 1 );
+    src = (const Int *)(CONST_ADDR_OBJ(obj) + 1);
+    dst = (Int *)(ADDR_OBJ(copy) + 1);
     i   = (SIZE_OBJ(obj)-sizeof(Obj)+sizeof(Int)-1) / sizeof(Int);
     for ( ;  0 < i;  i--, src++, dst++ ) {
         *dst = *src;
@@ -742,7 +742,7 @@ Obj CopyObjDatObjCopy (
     Obj                 obj,
     Int                 mut )
 {
-    return ELM_PLIST( ADDR_OBJ(obj)[0], 2 );
+    return ELM_PLIST(CONST_ADDR_OBJ(obj)[0], 2);
 }
 
 
@@ -754,7 +754,7 @@ void CleanObjDatObjCopy (
     Obj                 obj )
 {
     /* remove the forwarding pointer                                       */
-    ADDR_OBJ(obj)[0] = ELM_PLIST( ADDR_OBJ(obj)[0], 1 );
+    ADDR_OBJ(obj)[0] = ELM_PLIST(CONST_ADDR_OBJ(obj)[0], 1);
     CHANGED_BAG(obj);
 
     /* now it is cleaned                                                   */
@@ -1234,7 +1234,7 @@ void SetTypeComObj( Obj obj, Obj type)
     ReadGuard(obj);
     MEMBAR_WRITE();
 #endif
-    TYPE_COMOBJ(obj) = type;
+    SET_TYPE_COMOBJ(obj, type);
     CHANGED_BAG(obj);
 }
 #endif
@@ -1275,7 +1275,7 @@ Obj FuncSET_TYPE_COMOBJ (
     switch (TNUM_OBJ(obj)) {
       case T_PREC:
         MEMBAR_WRITE();
-        TYPE_COMOBJ( obj ) = type;
+        SET_TYPE_COMOBJ(obj, type);
         RetypeBag( obj, T_COMOBJ );
         CHANGED_BAG( obj );
         break;
@@ -1294,9 +1294,10 @@ Obj FuncSET_TYPE_COMOBJ (
     }
 #else
     if (TNUM_OBJ(obj) == T_PREC+IMMUTABLE)
-      ErrorMayQuit("You can't make a component object from an immutable object",
-                   0L, 0L);
-    TYPE_COMOBJ( obj ) = type;
+        ErrorMayQuit(
+            "You can't make a component object from an immutable object", 0L,
+            0L);
+    SET_TYPE_COMOBJ(obj, type);
     RetypeBag( obj, T_COMOBJ );
     CHANGED_BAG( obj );
 #endif
@@ -1325,7 +1326,7 @@ void SetTypePosObj( Obj obj, Obj type)
     ReadGuard(obj);
     MEMBAR_WRITE();
 #endif
-    TYPE_POSOBJ(obj) = type;
+    SET_TYPE_POSOBJ(obj, type);
     CHANGED_BAG(obj);
 }
 #endif
@@ -1374,14 +1375,14 @@ Obj FuncSET_TYPE_POSOBJ (
         break;
       default:
         MEMBAR_WRITE();
-        TYPE_POSOBJ( obj ) = type;
+        SET_TYPE_POSOBJ(obj, type);
         RetypeBag( obj, T_POSOBJ );
         CHANGED_BAG( obj );
         break;
     }
 #else
-    TYPE_POSOBJ( obj ) = type;
     RetypeBag( obj, T_POSOBJ );
+    SET_TYPE_POSOBJ(obj, type);
     CHANGED_BAG( obj );
 #endif
     return obj;
@@ -1420,7 +1421,7 @@ Obj             TypeDatObj (
 
 void SetTypeDatObj( Obj obj, Obj type)
 {
-    TYPE_DATOBJ(obj) = type;
+    SET_TYPE_DATOBJ(obj, type);
 #ifdef HPCGAP
     if (TNUM_OBJ(obj) == T_DATOBJ &&
         !IsMutableObjObject(obj) && !IsInternallyMutableObj(obj)) {
@@ -1459,7 +1460,7 @@ Obj FuncSET_TYPE_DATOBJ (
 #ifdef HPCGAP
     ReadGuard( obj );
 #endif
-    TYPE_DATOBJ( obj ) = type;
+    SET_TYPE_DATOBJ(obj, type);
 #ifdef HPCGAP
     if (TNUM_OBJ(obj) != T_DATOBJ)
 #endif
@@ -1565,7 +1566,7 @@ void SavePosObj( Obj posobj)
   len = (SIZE_OBJ(posobj)/sizeof(Obj) - 1);
   for (i = 1; i <= len; i++)
     {
-      SaveSubObj(ADDR_OBJ(posobj)[i]);
+      SaveSubObj(CONST_ADDR_OBJ(posobj)[i]);
     }
 }
 
@@ -1580,10 +1581,10 @@ void SavePosObj( Obj posobj)
 void SaveDatObj( Obj datobj)
 {
   UInt len,i;
-  UInt *ptr;
+  const UInt * ptr;
   SaveSubObj(TYPE_DATOBJ( datobj ));
   len = ((SIZE_OBJ(datobj)+sizeof(UInt)-1)/sizeof(UInt) - 1);
-  ptr = (UInt *)ADDR_OBJ(datobj)+1;
+  ptr = (const UInt *)CONST_ADDR_OBJ(datobj) + 1;
   for (i = 1; i <= len; i++)
     {
       SaveUInt(*ptr++);
@@ -1599,7 +1600,7 @@ void SaveDatObj( Obj datobj)
 void LoadComObj( Obj comobj)
 {
   UInt len,i;
-  TYPE_COMOBJ( comobj) = LoadSubObj( );
+  SET_TYPE_COMOBJ(comobj, LoadSubObj());
   len = LoadUInt();
   SET_LEN_PREC(comobj,len);
   for (i = 1; i <= len; i++)
@@ -1618,7 +1619,7 @@ void LoadComObj( Obj comobj)
 void LoadPosObj( Obj posobj)
 {
   UInt len,i;
-  TYPE_POSOBJ( posobj ) = LoadSubObj();
+  SET_TYPE_POSOBJ(posobj, LoadSubObj());
   len = (SIZE_OBJ(posobj)/sizeof(Obj) - 1);
   for (i = 1; i <= len; i++)
     {
@@ -1638,7 +1639,7 @@ void LoadDatObj( Obj datobj)
 {
   UInt len,i;
   UInt *ptr;
-  TYPE_DATOBJ( datobj ) = LoadSubObj();
+  SET_TYPE_DATOBJ(datobj, LoadSubObj());
   len = ((SIZE_OBJ(datobj)+sizeof(UInt)-1)/sizeof(UInt) - 1);
   ptr = (UInt *)ADDR_OBJ(datobj)+1;
   for (i = 1; i <= len; i++)
@@ -1677,7 +1678,7 @@ Obj FuncCLONE_OBJ (
     Obj             dst,
     Obj             src )
 {
-    Obj *           psrc;
+    const Obj *     psrc;
     Obj *           pdst;
     Int             i;
 
@@ -1740,7 +1741,7 @@ Obj FuncCLONE_OBJ (
     RetypeBag( dst, TNUM_OBJ(src) );
     pdst = ADDR_OBJ(dst);
 #endif
-    psrc = ADDR_OBJ(src);
+    psrc = CONST_ADDR_OBJ(src);
     for ( i = (SIZE_OBJ(src)+sizeof(Obj) - 1)/sizeof(Obj);  0 < i;  i-- ) {
         *pdst++ = *psrc++;
     }

--- a/src/objects.h
+++ b/src/objects.h
@@ -739,56 +739,80 @@ extern void (* PrintPathFuncs[LAST_REAL_TNUM+1]) (
 **
 *F  IS_COMOBJ( <obj> )  . . . . . . . . . . . is an object a component object
 */
-#define IS_COMOBJ(obj)            (TNUM_OBJ(obj) == T_COMOBJ)
+static inline Int IS_COMOBJ(Obj obj)
+{
+    return TNUM_OBJ(obj) == T_COMOBJ;
+}
 
 
 /****************************************************************************
 **
 *F  TYPE_COMOBJ( <obj> )  . . . . . . . . . . . .  type of a component object
 */
-#define TYPE_COMOBJ(obj)          ADDR_OBJ(obj)[0]
+static inline Obj TYPE_COMOBJ(Obj obj)
+{
+    return CONST_ADDR_OBJ(obj)[0];
+}
 
 
 /****************************************************************************
 **
 *F  SET_TYPE_COMOBJ( <obj>, <val> ) . . .  set the type of a component object
 */
-#define SET_TYPE_COMOBJ(obj,val)  (ADDR_OBJ(obj)[0] = (val))
+static inline void SET_TYPE_COMOBJ(Obj obj, Obj val)
+{
+    ADDR_OBJ(obj)[0] = val;
+}
 
 
 /****************************************************************************
 **
 *F  IS_POSOBJ( <obj> )  . . . . . . . . . .  is an object a positional object
 */
-#define IS_POSOBJ(obj)            (TNUM_OBJ(obj) == T_POSOBJ)
+static inline Int IS_POSOBJ(Obj obj)
+{
+    return TNUM_OBJ(obj) == T_POSOBJ;
+}
 
 
 /****************************************************************************
 **
 *F  TYPE_POSOBJ( <obj> )  . . . . . . . . . . . . type of a positional object
 */
-#define TYPE_POSOBJ(obj)          ADDR_OBJ(obj)[0]
+static inline Obj TYPE_POSOBJ(Obj obj)
+{
+    return CONST_ADDR_OBJ(obj)[0];
+}
 
 
 /****************************************************************************
 **
 *F  SET_TYPE_POSOBJ( <obj>, <val> ) . . . set the type of a positional object
 */
-#define SET_TYPE_POSOBJ(obj,val)  (ADDR_OBJ(obj)[0] = (val))
+static inline void SET_TYPE_POSOBJ(Obj obj, Obj val)
+{
+    ADDR_OBJ(obj)[0] = val;
+}
 
 
 /****************************************************************************
 **
 *F  IS_DATOBJ( <obj> )  . . . . . . . . . . . . .  is an object a data object
 */
-#define IS_DATOBJ(obj)            (TNUM_OBJ(obj) == T_DATOBJ)
+static inline Int IS_DATOBJ(Obj obj)
+{
+    return TNUM_OBJ(obj) == T_DATOBJ;
+}
 
 
 /****************************************************************************
 **
 *F  TYPE_DATOBJ( <obj> )  . . . . . . . . . . . . . . . type of a data object
 */
-#define TYPE_DATOBJ(obj)          ADDR_OBJ(obj)[0]
+static inline Obj TYPE_DATOBJ(Obj obj)
+{
+    return CONST_ADDR_OBJ(obj)[0];
+}
 
 
 /****************************************************************************
@@ -797,9 +821,12 @@ extern void (* PrintPathFuncs[LAST_REAL_TNUM+1]) (
 **
 **  'SetTypeDatobj' sets the kind <kind> of the data object <obj>.
 */
-extern void SetTypeDatObj( Obj obj, Obj type );
+static inline void SET_TYPE_DATOBJ(Obj obj, Obj val)
+{
+    ADDR_OBJ(obj)[0] = val;
+}
 
-#define SET_TYPE_DATOBJ(obj, type)  SetTypeDatObj(obj, type)
+extern void SetTypeDatObj(Obj obj, Obj type);
 
 
 /****************************************************************************

--- a/src/plist.c
+++ b/src/plist.c
@@ -834,8 +834,8 @@ Obj TypePlistFfe (
 */
 void SetTypePlistToPosObj(Obj list, Obj kind)
 {
-    TYPE_POSOBJ(list) = kind;
     RetypeBag(list, T_POSOBJ);
+    SET_TYPE_POSOBJ(list, kind);
     CHANGED_BAG(list);
 }
 

--- a/src/precord.c
+++ b/src/precord.c
@@ -82,8 +82,8 @@ Obj TypePRecImm (
 */
 void SetTypePRecToComObj( Obj rec, Obj kind )
 {
-    TYPE_COMOBJ(rec) = kind;
     RetypeBag(rec, T_COMOBJ);
+    SET_TYPE_COMOBJ(rec, kind);
     CHANGED_BAG(rec);
 }
 

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -3408,7 +3408,7 @@ Obj FuncCONV_MAT8BIT( Obj self, Obj list, Obj q )
     SET_LEN_MAT8BIT(list, len);
     RetypeBag(list, T_POSOBJ);
     type = TypeMat8Bit(INT_INTOBJ(q), mut);
-    TYPE_POSOBJ(list) = type;
+    SET_TYPE_POSOBJ(list, type);
     return 0;
 }
 
@@ -3621,7 +3621,7 @@ Obj ProdMat8BitMat8Bit( Obj matl, Obj matr)
     prod = NewBag(T_POSOBJ, sizeof(Obj) * (len + 2));
     SET_LEN_MAT8BIT(prod, len);
     type = TypeMat8Bit(q, IS_MUTABLE_OBJ(matl) || IS_MUTABLE_OBJ(matr));
-    TYPE_POSOBJ(prod) = type;
+    SET_TYPE_POSOBJ(prod, type);
     locked_type  = TypeVec8BitLocked(q, IS_MUTABLE_OBJ(ELM_MAT8BIT(matl, 1)) || IS_MUTABLE_OBJ(ELM_MAT8BIT(matr, 1)));
     for (i = 1; i <= len; i++) {
         row = ProdVec8BitMat8Bit(ELM_MAT8BIT(matl, i), matr);
@@ -3718,7 +3718,7 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
         CHANGED_BAG(inv);
         RetypeBag(inv, T_POSOBJ);
         type = TypeMat8Bit(q, mut == 2 || (mut == 1 && IS_MUTABLE_OBJ(mat)));
-        TYPE_POSOBJ(inv) = type;
+        SET_TYPE_POSOBJ(inv, type);
         SET_LEN_MAT8BIT(inv, 1);
         return inv;
     }
@@ -3805,7 +3805,7 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
     }
     RetypeBag(inv, T_POSOBJ);
     type = TypeMat8Bit(q, mut == 2 || (mut == 1 && IS_MUTABLE_OBJ(mat)));
-    TYPE_POSOBJ(inv) = type;
+    SET_TYPE_POSOBJ(inv, type);
     CHANGED_BAG(inv);
     return inv;
 }
@@ -3906,7 +3906,8 @@ Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj p, Obj obj)
             q = FIELD_VEC8BIT(obj);
             goto cando;
         } else {
-            TYPE_POSOBJ(mat) = IS_MUTABLE_OBJ(mat) ? TYPE_LIST_GF2MAT : TYPE_LIST_GF2MAT_IMM;
+            SET_TYPE_POSOBJ(mat, IS_MUTABLE_OBJ(mat) ? TYPE_LIST_GF2MAT
+                                                     : TYPE_LIST_GF2MAT_IMM);
             SetTypeDatObj(obj, IS_MUTABLE_OBJ(obj) ? TYPE_LIST_GF2VEC_LOCKED : TYPE_LIST_GF2VEC_IMM_LOCKED);
             SET_ELM_GF2MAT(mat, 1, obj);
             return (Obj) 0;
@@ -4028,7 +4029,7 @@ Obj SumMat8BitMat8Bit( Obj ml, Obj mr)
     q = FIELD_VEC8BIT(ELM_MAT8BIT(ml, 1));
     sum = NewBag(T_POSOBJ, sizeof(Obj) * (ls + 2));
     type = TypeMat8Bit(q, IS_MUTABLE_OBJ(ml) || IS_MUTABLE_OBJ(mr));
-    TYPE_POSOBJ(sum) = type;
+    SET_TYPE_POSOBJ(sum, type);
     SET_LEN_MAT8BIT(sum, ls);
 
     type = TypeVec8BitLocked(q, IS_MUTABLE_OBJ(ELM_MAT8BIT(ml, 1)) || IS_MUTABLE_OBJ(ELM_MAT8BIT(mr, 1)));
@@ -4110,7 +4111,7 @@ Obj DiffMat8BitMat8Bit( Obj ml, Obj mr)
 
     diff = NewBag(T_POSOBJ, sizeof(Obj) * (ld + 2));
     type = TypeMat8Bit(q, IS_MUTABLE_OBJ(ml) || IS_MUTABLE_OBJ(mr));
-    TYPE_POSOBJ(diff) = type;
+    SET_TYPE_POSOBJ(diff, type);
     SET_LEN_MAT8BIT(diff, ld);
     type = TypeVec8BitLocked(q, IS_MUTABLE_OBJ(ELM_MAT8BIT(ml, 1)) || IS_MUTABLE_OBJ(ELM_MAT8BIT(mr, 1)));
     info = GetFieldInfo8Bit(q);
@@ -5566,7 +5567,7 @@ Obj FuncTRANSPOSED_MAT8BIT( Obj self, Obj mat)
     tra = NewBag(T_POSOBJ, sizeof(Obj) * (w + 2));
     q = FIELD_VEC8BIT(r1);
     type = TypeMat8Bit(q, 1);
-    TYPE_POSOBJ(tra) = type;
+    SET_TYPE_POSOBJ(tra, type);
 
     SET_LEN_MAT8BIT(tra, w);
 
@@ -5664,7 +5665,7 @@ Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT( Obj self, Obj matl, Obj matr)
     /* create a matrix */
     mat = NewBag(T_POSOBJ, sizeof(Obj) * (nrowl*nrowr + 2));
     SET_LEN_MAT8BIT(mat, nrowl*nrowr);
-    TYPE_POSOBJ(mat) = TypeMat8Bit(q, mutable);
+    SET_TYPE_POSOBJ(mat, TypeMat8Bit(q, mutable));
     type = TypeVec8BitLocked(q, mutable);
 
     /* allocate 0 matrix */

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -509,7 +509,7 @@ Obj ProdGF2MatGF2MatSimple( Obj ml, Obj mr )
   SET_LEN_GF2MAT(prod,len);
   if (IS_MUTABLE_OBJ(ml) || IS_MUTABLE_OBJ(mr))
     {
-      TYPE_POSOBJ(prod) = TYPE_LIST_GF2MAT;
+      SET_TYPE_POSOBJ(prod, TYPE_LIST_GF2MAT);
       if (IS_MUTABLE_OBJ(ELM_GF2MAT(ml,1)) || IS_MUTABLE_OBJ(ELM_GF2MAT(mr,1)))
 	rtype = TYPE_LIST_GF2VEC_LOCKED;
       else
@@ -517,7 +517,7 @@ Obj ProdGF2MatGF2MatSimple( Obj ml, Obj mr )
     }
   else
     {
-      TYPE_POSOBJ(prod) = TYPE_LIST_GF2MAT_IMM;
+      SET_TYPE_POSOBJ(prod, TYPE_LIST_GF2MAT_IMM);
       rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
     }
   for (i = 1; i <= len; i++)
@@ -661,7 +661,7 @@ Obj ProdGF2MatGF2MatAdvanced( Obj ml, Obj mr, UInt greasesize , UInt blocksize)
   SET_LEN_GF2MAT(prod,len);
   if (IS_MUTABLE_OBJ(ml) || IS_MUTABLE_OBJ(mr))
     {
-     TYPE_POSOBJ(prod) = TYPE_LIST_GF2MAT;
+      SET_TYPE_POSOBJ(prod, TYPE_LIST_GF2MAT);
       if (IS_MUTABLE_OBJ(ELM_GF2MAT(ml,1)) || IS_MUTABLE_OBJ(ELM_GF2MAT(mr,1)))
 	rtype = TYPE_LIST_GF2VEC_LOCKED;
       else
@@ -669,7 +669,7 @@ Obj ProdGF2MatGF2MatAdvanced( Obj ml, Obj mr, UInt greasesize , UInt blocksize)
     }
   else
     {
-      TYPE_POSOBJ(prod) = TYPE_LIST_GF2MAT_IMM;
+      SET_TYPE_POSOBJ(prod, TYPE_LIST_GF2MAT_IMM);
       rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
     }
 
@@ -1041,8 +1041,9 @@ Obj InverseGF2Mat (
     }
     SET_LEN_GF2MAT( inv, len );
     RetypeBag( inv, T_POSOBJ );
-    TYPE_POSOBJ( inv ) = (mut == 2 || (mut == 1 && IS_MUTABLE_OBJ(mat)))
-      ? TYPE_LIST_GF2MAT : TYPE_LIST_GF2MAT_IMM;
+    SET_TYPE_POSOBJ(inv, (mut == 2 || (mut == 1 && IS_MUTABLE_OBJ(mat)))
+                             ? TYPE_LIST_GF2MAT
+                             : TYPE_LIST_GF2MAT_IMM);
     return inv;
 }
 
@@ -2373,8 +2374,8 @@ Obj FuncSUM_GF2VEC_GF2VEC (
       }
 
     if (!IS_MUTABLE_OBJ(vl) && !IS_MUTABLE_OBJ(vr))
-      TYPE_POSOBJ(sum) = TYPE_LIST_GF2VEC_IMM;
-    
+        SET_TYPE_POSOBJ(sum, TYPE_LIST_GF2VEC_IMM);
+
     return sum;
 }
 
@@ -2828,7 +2829,7 @@ Obj FuncSUM_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
   sum = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT( ls ));
   if (IS_MUTABLE_OBJ(matl) || IS_MUTABLE_OBJ(matr))
     {
-      TYPE_POSOBJ(sum) = TYPE_LIST_GF2MAT;
+      SET_TYPE_POSOBJ(sum, TYPE_LIST_GF2MAT);
       if (IS_MUTABLE_OBJ(ELM_GF2MAT(matl,1)) || IS_MUTABLE_OBJ(ELM_GF2MAT(matr,1)))
 	rtype = TYPE_LIST_GF2VEC_LOCKED;
       else
@@ -2836,7 +2837,7 @@ Obj FuncSUM_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
     }
   else
     {
-      TYPE_POSOBJ(sum) = TYPE_LIST_GF2MAT_IMM;
+      SET_TYPE_POSOBJ(sum, TYPE_LIST_GF2MAT_IMM);
       rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
     }
   
@@ -2915,8 +2916,8 @@ Obj FuncTRANSPOSED_GF2MAT( Obj self, Obj mat)
   nrb=NUMBER_BLOCKS_GF2VEC(r1);
 
   tra = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT( w ));
-  TYPE_POSOBJ(tra) = typ;
-  
+  SET_TYPE_POSOBJ(tra, typ);
+
   /* type for rows */
   typ = TYPE_LIST_GF2VEC_LOCKED;
   
@@ -4304,11 +4305,11 @@ Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
   mat = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT(nrowp));
   SET_LEN_GF2MAT(mat,nrowp);
   if (mutable) {
-    TYPE_POSOBJ(mat) = TYPE_LIST_GF2MAT;
-    type = TYPE_LIST_GF2VEC_LOCKED;
+      SET_TYPE_POSOBJ(mat, TYPE_LIST_GF2MAT);
+      type = TYPE_LIST_GF2VEC_LOCKED;
   } else {
-    TYPE_POSOBJ(mat) = TYPE_LIST_GF2MAT_IMM;
-    type = TYPE_LIST_GF2VEC_IMM_LOCKED;
+      SET_TYPE_POSOBJ(mat, TYPE_LIST_GF2MAT_IMM);
+      type = TYPE_LIST_GF2VEC_IMM_LOCKED;
   }
 
   /* allocate 0 matrix */


### PR DESCRIPTION
Also revert SET_TYPE_DATOBJ to the old pre-HPC-GAP-merge behavior.
I.e. do not make it an alias for SetTypeDatObj. Instead, code which
"needs" SetTypeDatObj should call it explicitly.

Finally, use CONST_ADDR_OBJ instead of ADDR_OBJ in a bunch of places

[ Had this branch sitting around since October, no idea why I didn't submit it earlier. No need to merge this before `stable-4.9` is created).