### PR TITLE
Cleanup module interface of io.c, move Input/Output parts of GAPState into IO module state

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -41,6 +41,7 @@
 #include <src/gap.h>
 #include <src/gvars.h>
 #include <src/integer.h>
+#include <src/io.h>
 #include <src/lists.h>
 #include <src/opers.h>
 #include <src/plist.h>

--- a/src/code.c
+++ b/src/code.c
@@ -95,24 +95,25 @@ static inline void PopLoopNesting( void ) {
   STATE(LoopNesting) = STATE(LoopStack)[--STATE(LoopStackCount)];
 }
 
-static inline void SetupGapname(TypInputFile* i)
+static inline UInt SetupGapname(void)
 {
-    if (i->gapnameid == 0) {
-        Obj filename = MakeImmString(i->name);
+    if (STATE(Input)->gapnameid == 0) {
+        Obj filename = MakeImmString(STATE(Input)->name);
 #ifdef HPCGAP
         // TODO/FIXME: adjust this code to work more like the corresponding
         // code below for GAP?!?
-        i->gapnameid = AddAList(FilenameCache, filename);
+        STATE(Input)->gapnameid = AddAList(FilenameCache, filename);
 #else
         Obj pos = POS_LIST(FilenameCache, filename, INTOBJ_INT(1));
         if (pos == Fail) {
-            i->gapnameid = PushPlist(FilenameCache, filename);
+            STATE(Input)->gapnameid = PushPlist(FilenameCache, filename);
         }
         else {
-            i->gapnameid = INT_INTOBJ(pos);
+            STATE(Input)->gapnameid = INT_INTOBJ(pos);
         }
 #endif
     }
+    return STATE(Input)->gapnameid;
 }
 
 Obj FuncGET_FILENAME_CACHE(Obj self)
@@ -243,7 +244,6 @@ Stat NewStat (
     UInt                type,
     UInt                size)
 {
-    assert(STATE(Input)->gapnameid != 0);
     return NewStatWithProf(type, size, GetInputLineNumber());
 }
 
@@ -774,8 +774,7 @@ void CodeFuncExprBegin (
     CHANGED_BAG( fexp );
 
     /* record where we are reading from */
-    SetupGapname(STATE(Input));
-    SET_GAPNAMEID_BODY(body, STATE(Input)->gapnameid);
+    SET_GAPNAMEID_BODY(body, SetupGapname());
     SET_STARTLINE_BODY(body, startLine);
     STATE(OffsBody) = sizeof(BodyHeader);
     STATE(LoopNesting) = 0;

--- a/src/code.c
+++ b/src/code.c
@@ -98,7 +98,7 @@ static inline void PopLoopNesting( void ) {
 static inline UInt SetupGapname(void)
 {
     if (STATE(Input)->gapnameid == 0) {
-        Obj filename = MakeImmString(STATE(Input)->name);
+        Obj filename = MakeImmString(GetInputFilename());
 #ifdef HPCGAP
         // TODO/FIXME: adjust this code to work more like the corresponding
         // code below for GAP?!?

--- a/src/code.c
+++ b/src/code.c
@@ -244,7 +244,7 @@ Stat NewStat (
     UInt                size)
 {
     assert(STATE(Input)->gapnameid != 0);
-    return NewStatWithProf(type, size, STATE(Input)->number);
+    return NewStatWithProf(type, size, GetInputLineNumber());
 }
 
 
@@ -777,8 +777,6 @@ void CodeFuncExprBegin (
     SetupGapname(STATE(Input));
     SET_GAPNAMEID_BODY(body, STATE(Input)->gapnameid);
     SET_STARTLINE_BODY(body, startLine);
-    /*    Pr("Coding begin at %s:%d ",(Int)(STATE(Input)->name),STATE(Input)->number);
-          Pr(" Body id %d\n",(Int)(body),0L); */
     STATE(OffsBody) = sizeof(BodyHeader);
     STATE(LoopNesting) = 0;
 
@@ -849,8 +847,7 @@ void CodeFuncExprEnd(UInt nr)
 
     /* make the body smaller                                               */
     ResizeBag( BODY_FUNC(fexp), STATE(OffsBody) );
-    SET_ENDLINE_BODY(BODY_FUNC(fexp), STATE(Input)->number);
-    /*    Pr("  finished coding %d at line %d\n",(Int)(BODY_FUNC(fexp)), STATE(Input)->number); */
+    SET_ENDLINE_BODY(BODY_FUNC(fexp), GetInputLineNumber());
 
     /* switch back to the previous function                                */
     SWITCH_TO_OLD_LVARS( ENVI_FUNC(fexp) );

--- a/src/code.c
+++ b/src/code.c
@@ -22,6 +22,7 @@
 #include <src/gapstate.h>
 #include <src/gvars.h>
 #include <src/hookintrprtr.h>
+#include <src/io.h>
 #include <src/lists.h>
 #include <src/plist.h>
 #include <src/read.h>

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -94,6 +94,7 @@
 #include <src/gap.h>
 #include <src/gapstate.h>
 #include <src/integer.h>
+#include <src/io.h>
 #include <src/lists.h>
 #include <src/opers.h>
 #include <src/plist.h>

--- a/src/gap.c
+++ b/src/gap.c
@@ -215,7 +215,7 @@ Obj Shell ( Obj context,
     STATE(Prompt) = prompt;
     ClearError();
     STATE(PrintObjDepth) = 0;
-    STATE(Output)->indent = 0;
+    ResetOutputIndent();
     SetRecursionDepth(0);
       
     /* here is a hook: */

--- a/src/gap.c
+++ b/src/gap.c
@@ -24,6 +24,7 @@
 #include <src/gapstate.h>
 #include <src/gvars.h>
 #include <src/integer.h>
+#include <src/io.h>
 #include <src/lists.h>
 #include <src/opers.h>
 #include <src/plist.h>

--- a/src/gap.c
+++ b/src/gap.c
@@ -177,7 +177,6 @@ Obj Shell ( Obj context,
   UInt status;
   Obj evalResult;
   UInt dualSemicolon;
-  UInt oldindent;
   UInt oldPrintDepth;
   Obj res;
   Obj oldShellContext;
@@ -203,8 +202,6 @@ Obj Shell ( Obj context,
   
   oldPrintDepth = STATE(PrintObjDepth);
   STATE(PrintObjDepth) = 0;
-  oldindent = STATE(Output)->indent;
-  STATE(Output)->indent = 0;
 
   while ( 1 ) {
 
@@ -303,7 +300,6 @@ Obj Shell ( Obj context,
   }
   
   STATE(PrintObjDepth) = oldPrintDepth;
-  STATE(Output)->indent = oldindent;
   CloseInput();
   CloseOutput();
   STATE(BaseShellContext) = oldBaseShellContext;

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -22,6 +22,8 @@ enum {
     STATE_MAX_HANDLERS = 256,
     STATE_SLOTS_SIZE = 32768,
 
+    MAX_OPEN_FILES = 16,
+
     MAX_VALUE_LEN = 1030,
 };
 
@@ -66,15 +68,12 @@ typedef struct GAPState {
     UInt   NrErrLine;
     UInt   Symbol;
     const Char * Prompt;
-#if defined(HPCGAP)
-    TypInputFile *  InputFiles[16];
-    TypOutputFile * OutputFiles[16];
-    int             InputFilesSP;
-    int             OutputFilesSP;
-#else
-    TypInputFile  InputFiles[16];
-    TypOutputFile OutputFiles[16];
-#endif
+
+    TypInputFile *  InputStack[MAX_OPEN_FILES];
+    TypOutputFile * OutputStack[MAX_OPEN_FILES];
+    int             InputStackPointer;
+    int             OutputStackPointer;
+
     TypInputFile *  Input;
     Char *          In;
     TypOutputFile * Output;

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -34,6 +34,7 @@
 #include <src/gap.h>
 #include <src/gapstate.h>
 #include <src/integer.h>
+#include <src/io.h>
 #include <src/lists.h>
 #include <src/plist.h>
 #include <src/stringobj.h>

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -23,6 +23,7 @@
 #include <src/gaputils.h>
 #include <src/gapstate.h>
 #include <src/gvars.h>
+#include <src/io.h>
 #include <src/lists.h>
 #include <src/objects.h>
 #include <src/plist.h>

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -18,6 +18,7 @@
 #include <src/gap.h>
 #include <src/gapstate.h>
 #include <src/gvars.h>
+#include <src/io.h>
 #include <src/lists.h>
 #include <src/objects.h>
 #include <src/plist.h>

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -882,7 +882,7 @@ void            IntrAtomicBegin ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     if (STATE(IntrCoding) == 0)
-        StartFakeFuncExpr(STATE(Input)->number);
+        StartFakeFuncExpr(GetInputLineNumber());
 
     STATE(IntrCoding)++;
 
@@ -962,7 +962,7 @@ void            IntrRepeatBegin ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     if (STATE(IntrCoding) == 0)
-        StartFakeFuncExpr(STATE(Input)->number);
+        StartFakeFuncExpr(GetInputLineNumber());
 
     STATE(IntrCoding)++;
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -27,6 +27,7 @@
 #include <src/gapstate.h>
 #include <src/gvars.h>
 #include <src/integer.h>
+#include <src/io.h>
 #include <src/lists.h>
 #include <src/opers.h>
 #include <src/permutat.h>

--- a/src/io.c
+++ b/src/io.c
@@ -42,6 +42,12 @@ static Obj PrintFormattingStatus;
 /* TODO: Eliminate race condition in HPC-GAP */
 static Char promptBuf[81];
 
+Int GetInputLineNumber(void)
+{
+    GAP_ASSERT(STATE(Input));
+    return STATE(Input)->number;
+}
+
 #ifdef HPCGAP
 #define STACK_SIZE(sp)   (STATE(sp ## FilesSP))
 #else

--- a/src/io.c
+++ b/src/io.c
@@ -185,15 +185,6 @@ UInt OpenDefaultOutput( void )
 }
 #endif
 
-TypOutputFile *GetCurrentOutput(void) {
-#ifdef HPCGAP
-  if (!STATE(Output)) {
-    OpenDefaultOutput();
-  }
-#endif
-  return STATE(Output);
-}
-
 
 /****************************************************************************
 **
@@ -1704,7 +1695,12 @@ void Pr (
          Int                 arg1,
          Int                 arg2 )
 {
-  PrTo(GetCurrentOutput(), format, arg1, arg2);
+#ifdef HPCGAP
+    if (!STATE(Output)) {
+        OpenDefaultOutput();
+    }
+#endif
+    PrTo(STATE(Output), format, arg1, arg2);
 }
 
 typedef struct {

--- a/src/io.c
+++ b/src/io.c
@@ -1754,8 +1754,9 @@ static Int InitLibrary (
 }
 
 #if !defined(HPCGAP)
-static Char Cookie[MAX_OPEN_FILES][9];
-static Char MoreCookie[MAX_OPEN_FILES][9];
+static Char OutputFilesStreamCookie[MAX_OPEN_FILES][9];
+static Char InputFilesStreamCookie[MAX_OPEN_FILES][9];
+static Char InputFilesSlineCookie[MAX_OPEN_FILES][9];
 #endif
 
 static Int InitKernel (
@@ -1787,27 +1788,17 @@ static Int InitKernel (
     // name of the current input file. For HPC-GAP we don't need the cookies
     // anymore, since the data got moved to thread-local storage.
     for (Int i = 0; i < MAX_OPEN_FILES; i++) {
-        Cookie[i][0] = 's';
-        Cookie[i][1] = 't';
-        Cookie[i][2] = 'r';
-        Cookie[i][3] = 'e';
-        Cookie[i][4] = 'a';
-        Cookie[i][5] = 'm';
-        Cookie[i][6] = ' ';
-        Cookie[i][7] = '0' + i;
-        Cookie[i][8] = '\0';
-        InitGlobalBag(&(InputFiles[i].stream), &(Cookie[i][0]));
+        strxcpy(OutputFilesStreamCookie[i], "ostream0", sizeof(OutputFilesStreamCookie[i]));
+        OutputFilesStreamCookie[i][7] = '0' + i;
+        InitGlobalBag(&(OutputFiles[i].stream), &(OutputFilesStreamCookie[i][0]));
 
-        MoreCookie[i][0] = 's';
-        MoreCookie[i][1] = 'l';
-        MoreCookie[i][2] = 'i';
-        MoreCookie[i][3] = 'n';
-        MoreCookie[i][4] = 'e';
-        MoreCookie[i][5] = ' ';
-        MoreCookie[i][6] = ' ';
-        MoreCookie[i][7] = '0' + i;
-        MoreCookie[i][8] = '\0';
-        InitGlobalBag(&(InputFiles[i].sline), &(MoreCookie[i][0]));
+        strxcpy(InputFilesStreamCookie[i], "istream0", sizeof(InputFilesStreamCookie[i]));
+        InputFilesStreamCookie[i][7] = '0' + i;
+        InitGlobalBag(&(InputFiles[i].stream), &(InputFilesStreamCookie[i][0]));
+
+        strxcpy(InputFilesSlineCookie[i], "isline 0", sizeof(InputFilesSlineCookie[i]));
+        InputFilesSlineCookie[i][7] = '0' + i;
+        InitGlobalBag(&(InputFiles[i].sline), &(InputFilesSlineCookie[i][0]));
     }
 
     /* tell GASMAN about the global bags                                   */

--- a/src/io.c
+++ b/src/io.c
@@ -1400,6 +1400,12 @@ Obj FuncPRINT_CPROMPT( Obj self, Obj prompt )
   return (Obj) 0;
 }
 
+void ResetOutputIndent(void)
+{
+    GAP_ASSERT(STATE(Output));
+    STATE(Output)->indent = 0;
+}
+
 /****************************************************************************
 **
 *F  Pr( <format>, <arg1>, <arg2> )  . . . . . . . . .  print formatted output

--- a/src/io.c
+++ b/src/io.c
@@ -1709,6 +1709,21 @@ Obj FuncSET_PRINT_FORMATTING_STDOUT(Obj self, Obj val) {
     return val;
 }
 
+Obj FuncIS_INPUT_TTY(Obj self)
+{
+    GAP_ASSERT(STATE(Input));
+    if (STATE(Input)->isstream)
+        return False;
+    return syBuf[STATE(Input)->file].isTTY ? True : False;
+}
+
+Obj FuncIS_OUTPUT_TTY(Obj self)
+{
+    GAP_ASSERT(STATE(Output));
+    if (STATE(Output)->isstream)
+        return False;
+    return syBuf[STATE(Output)->file].isTTY ? True : False;
+}
 
 static StructGVarFunc GVarFuncs [] = {
 
@@ -1718,6 +1733,8 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(INPUT_FILENAME, 0, ""),
     GVAR_FUNC(INPUT_LINENUMBER, 0, ""),
     GVAR_FUNC(SET_PRINT_FORMATTING_STDOUT, 1, "format"),
+    GVAR_FUNC(IS_INPUT_TTY, 0, ""),
+    GVAR_FUNC(IS_OUTPUT_TTY, 0, ""),
     { 0, 0, 0, 0, 0 }
 
 };

--- a/src/io.c
+++ b/src/io.c
@@ -48,6 +48,11 @@ Int GetInputLineNumber(void)
     return STATE(Input)->number;
 }
 
+void LockCurrentOutput(Int lock)
+{
+    STATE(IgnoreStdoutErrout) = lock ? STATE(Output) : NULL;
+}
+
 #ifdef HPCGAP
 #define STACK_SIZE(sp)   (STATE(sp ## FilesSP))
 #else
@@ -714,7 +719,7 @@ UInt OpenOutput (
 {
     Int                 file;
 
-    /* do nothing for stdout and errout if catched */
+    // do nothing for stdout and errout if caught
     if ( STATE(Output) != NULL && STATE(IgnoreStdoutErrout) == STATE(Output) &&
           ( strcmp( filename, "*errout*" ) == 0
            || strcmp( filename, "*stdout*" ) == 0 ) ) {
@@ -827,9 +832,9 @@ UInt OpenOutputStream (
 */
 UInt CloseOutput ( void )
 {
-    /* silently refuse to close the test output file this is probably
-         an attempt to close *errout* which is silently not opened, so
-         lets silently not close it  */
+    // silently refuse to close the test output file; this is probably an
+    // attempt to close *errout* which is silently not opened, so let's
+    // silently not close it
     if ( STATE(IgnoreStdoutErrout) == STATE(Output) )
         return 1;
 

--- a/src/io.c
+++ b/src/io.c
@@ -142,7 +142,7 @@ UInt OpenDefaultInput( void )
   Obj func, stream;
   stream = TLS(DefaultInput);
   if (stream)
-    return OpenInputStream(stream);
+      return OpenInputStream(stream, 0);
   func = GVarOptFunction(&DEFAULT_INPUT_STREAM);
   if (!func)
     return OpenInput("*stdin*");
@@ -152,7 +152,7 @@ UInt OpenDefaultInput( void )
   if (IsStringConv(stream))
     return OpenInput(CSTR_STRING(stream));
   TLS(DefaultInput) = stream;
-  return OpenInputStream(stream);
+  return OpenInputStream(stream, 0);
 }
 
 UInt OpenDefaultOutput( void )
@@ -282,13 +282,11 @@ UInt OpenInput (
 
 /****************************************************************************
 **
-*F  OpenInputStream( <stream> ) . . . . . . .  open a stream as current input
+*F  OpenInputStream( <stream>, <echo> ) . . .  open a stream as current input
 **
 **  The same as 'OpenInput' but for streams.
 */
-
-UInt OpenInputStream (
-    Obj                 stream )
+UInt OpenInputStream(Obj stream, UInt echo)
 {
     /* fail if we can not handle another open input file                   */
     if ( STACK_SIZE(Input) == ARRAY_SIZE(STATE(InputFiles)) )
@@ -323,7 +321,7 @@ UInt OpenInputStream (
         STATE(Input)->sline = 0;
     }
     STATE(Input)->file = -1;
-    STATE(Input)->echo = 0;
+    STATE(Input)->echo = echo;
     strlcpy( STATE(Input)->name, "stream", sizeof(STATE(Input)->name) );
     STATE(Input)->gapnameid = 0;
 

--- a/src/io.c
+++ b/src/io.c
@@ -264,10 +264,13 @@ UInt OpenInput (
     STATE(Input)->isstream = 0;
     STATE(Input)->file = file;
     STATE(Input)->name[0] = '\0';
-    if (strcmp("*errin*", filename) && strcmp("*stdin*", filename))
-      STATE(Input)->echo = 0;
+
+    // enable echo for stdin and errin
+    if (!strcmp("*errin*", filename) || !strcmp("*stdin*", filename))
+        STATE(Input)->echo = 1;
     else
-      STATE(Input)->echo = 1;
+        STATE(Input)->echo = 0;
+
     strlcpy( STATE(Input)->name, filename, sizeof(STATE(Input)->name) );
     STATE(Input)->gapnameid = 0;
 
@@ -1787,11 +1790,8 @@ static Int InitKernel (
     STATE(InputLog) = 0;
     STATE(OutputLog) = 0;
 
-    (void)OpenInput(  "*stdin*"  );
-    STATE(Input)->echo = 1; /* echo stdin */
-
-    (void)OpenOutput( "*stdout*" );
-
+    OpenInput("*stdin*");
+    OpenOutput("*stdout*");
 
 #ifdef HPCGAP
     /* Initialize default stream functions */

--- a/src/io.c
+++ b/src/io.c
@@ -42,12 +42,6 @@ static Obj PrintFormattingStatus;
 /* TODO: Eliminate race condition in HPC-GAP */
 static Char promptBuf[81];
 
-Int GetInputLineNumber(void)
-{
-    GAP_ASSERT(STATE(Input));
-    return STATE(Input)->number;
-}
-
 void LockCurrentOutput(Int lock)
 {
     STATE(IgnoreStdoutErrout) = lock ? STATE(Output) : NULL;
@@ -97,10 +91,28 @@ Char PEEK_CHAR(void)
 }
 
 
+const Char * GetInputFilename(void)
+{
+    GAP_ASSERT(STATE(Input));
+    return STATE(Input)->name;
+}
+
+Int GetInputLineNumber(void)
+{
+    GAP_ASSERT(STATE(Input));
+    return STATE(Input)->number;
+}
+
+const Char * GetInputLineBuffer(void)
+{
+    GAP_ASSERT(STATE(Input));
+    return STATE(Input)->line;
+}
+
 // Get current line position. In the case where we pushed back the last
 // character on the previous line we return the first character of the
 // current line, as we cannot retrieve the previous line.
-Int GetLinePosition(void)
+Int GetInputLinePosition(void)
 {
     if (STATE(In) == &STATE(Pushback)) {
         // Subtract 2 as a value was pushed back

--- a/src/io.h
+++ b/src/io.h
@@ -392,6 +392,9 @@ typedef struct {
 /* TL: extern Char *          In; */
 
 
+// get the number of the current line in the current thread's input
+extern Int GetInputLineNumber(void);
+
 /****************************************************************************
 **
 *T  TypOutputFiles  . . . . . . . . . structure of an open output file, local

--- a/src/io.h
+++ b/src/io.h
@@ -439,6 +439,10 @@ typedef struct {
 */
 extern TypOutputFile *GetCurrentOutput ( void );
 
+// Reset the indentation level of the current output to zero. The indentation
+// level can be modified via the '%>' and '%<' formats of 'Pr' resp. 'PrTo'.
+extern void ResetOutputIndent(void);
+
 // If 'lock' is non-zero, then "lock" the current output, i.e., prevent calls
 // to 'OpenOutput' or 'CloseOutput' from changing it. If 'lock' is zero, then
 // release this lock again.

--- a/src/io.h
+++ b/src/io.h
@@ -272,7 +272,8 @@ extern UInt CloseOutputLog ( void );
 **  they are just a convention between the main and the system package.
 **
 **  The function does nothing and returns success for '*stdout*' and
-**  '*errout*' when IgnoreStdoutErrout is true (useful for testing purposes).
+**  '*errout*' when 'LockCurrentOutput(1)' is in effect (used for testing
+**  purposes).
 **
 **  It is not neccessary to open the initial output file, 'InitScanner' opens
 **  '*stdout*' for that purpose.  This  file  on the other hand   can not  be
@@ -437,6 +438,14 @@ typedef struct {
 **  The same as 'OpenOutput' but for streams.
 */
 extern TypOutputFile *GetCurrentOutput ( void );
+
+// If 'lock' is non-zero, then "lock" the current output, i.e., prevent calls
+// to 'OpenOutput' or 'CloseOutput' from changing it. If 'lock' is zero, then
+// release this lock again.
+//
+// This is used to allow the 'Test' function of the GAP library to
+// consistently capture all output during testing, see 'FuncREAD_STREAM_LOOP'.
+extern void LockCurrentOutput(Int lock);
 
 /****************************************************************************
 **

--- a/src/io.h
+++ b/src/io.h
@@ -20,7 +20,7 @@
 
 #include <src/system.h>
 
-extern Int  GetLinePosition(void);
+
 extern void GET_CHAR(void);
 extern Char PEEK_CHAR(void);
 
@@ -393,8 +393,18 @@ typedef struct {
 /* TL: extern Char *          In; */
 
 
+// get the filename of the current input
+extern const Char * GetInputFilename(void);
+
 // get the number of the current line in the current thread's input
 extern Int GetInputLineNumber(void);
+
+//
+extern const Char * GetInputLineBuffer(void);
+
+//
+extern Int GetInputLinePosition(void);
+
 
 /****************************************************************************
 **

--- a/src/io.h
+++ b/src/io.h
@@ -431,14 +431,6 @@ typedef struct {
     Obj         stream;
 } TypOutputFile;
 
-/****************************************************************************
-**
-*F  GetCurrentOutput()  . . . . . . . . . . . get the current thread's output
-**
-**  The same as 'OpenOutput' but for streams.
-*/
-extern TypOutputFile *GetCurrentOutput ( void );
-
 // Reset the indentation level of the current output to zero. The indentation
 // level can be modified via the '%>' and '%<' formats of 'Pr' resp. 'PrTo'.
 extern void ResetOutputIndent(void);

--- a/src/io.h
+++ b/src/io.h
@@ -70,12 +70,11 @@ extern UInt OpenInput (
 
 /****************************************************************************
 **
-*F  OpenInputStream( <stream> ) . . . . . . .  open a stream as current input
+*F  OpenInputStream( <stream>, <echo> ) . . .  open a stream as current input
 **
 **  The same as 'OpenInput' but for streams.
 */
-extern UInt OpenInputStream (
-    Obj                 stream );
+extern UInt OpenInputStream(Obj stream, UInt echo);
 
 
 /****************************************************************************
@@ -370,7 +369,6 @@ typedef struct {
   Int         spos;
   UInt        echo;
 } TypInputFile;
-
 
 
 /****************************************************************************

--- a/src/objects.c
+++ b/src/objects.c
@@ -17,6 +17,7 @@
 #include <src/gap.h>
 #include <src/gapstate.h>
 #include <src/gvars.h>
+#include <src/io.h>
 #include <src/opers.h>
 #include <src/plist.h>
 #include <src/precord.h>

--- a/src/opers.c
+++ b/src/opers.c
@@ -21,6 +21,7 @@
 #include <src/gap.h>
 #include <src/gapstate.h>
 #include <src/gvars.h>
+#include <src/io.h>
 #include <src/lists.h>
 #include <src/plist.h>
 #include <src/precord.h>

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -45,6 +45,7 @@
 #include <src/gap.h>
 #include <src/gapstate.h>
 #include <src/integer.h>
+#include <src/io.h>
 #include <src/lists.h>
 #include <src/opers.h>
 #include <src/plist.h>

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -18,6 +18,7 @@
 #include <src/gapstate.h>
 #include <src/integer.h>
 #include <src/intfuncs.h>
+#include <src/io.h>
 #include <src/lists.h>
 #include <src/opers.h>
 #include <src/permutat.h>

--- a/src/profile.c
+++ b/src/profile.c
@@ -16,6 +16,7 @@
 #include <src/code.h>
 #include <src/gap.h>
 #include <src/hookintrprtr.h>
+#include <src/io.h>
 #include <src/plist.h>
 #include <src/stringobj.h>
 #include <src/vars.h>

--- a/src/read.c
+++ b/src/read.c
@@ -1433,7 +1433,7 @@ void ReadFuncExpr (
     volatile ArgList    args;
 
     /* begin the function               */
-    startLine = STATE(Input)->number;
+    startLine = GetInputLineNumber();
     if (STATE(Symbol) == S_ATOMIC) {
         Match(S_ATOMIC, "atomic", follow);
         is_atomic = 1;
@@ -1498,7 +1498,7 @@ void ReadFuncExprAbbrevMulti(TypSymbolSet follow)
     /* match away the '->'                                                 */
     Match(S_MAPTO, "->", follow);
 
-    ReadFuncExprBody(follow, 1, 0, args, STATE(Input)->number);
+    ReadFuncExprBody(follow, 1, 0, args, GetInputLineNumber());
 }
 
 /****************************************************************************
@@ -1529,7 +1529,7 @@ void ReadFuncExprAbbrevSingle(TypSymbolSet follow)
     /* match away the '->'                                                 */
     Match(S_MAPTO, "->", follow);
 
-    ReadFuncExprBody(follow, 1, 0, args, STATE(Input)->number);
+    ReadFuncExprBody(follow, 1, 0, args, GetInputLineNumber());
 }
 
 /****************************************************************************
@@ -2839,7 +2839,7 @@ UInt ReadEvalFile(Obj *evalResult)
     }
 
     /* fake the 'function ()'                                              */
-    IntrFuncExprBegin( 0L, nloc, nams, STATE(Input)->number );
+    IntrFuncExprBegin(0, nloc, nams, GetInputLineNumber());
 
     /* read the statements                                                 */
     nr = ReadStats( S_SEMICOLON | S_EOF );

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -25,48 +25,57 @@
 #include <src/stringobj.h>
 
 
+void SyntaxErrorOrWarning(const Char * msg, UInt error)
+{
+    // open error output
+    OpenOutput("*errout*");
+
+    // do not print a message if we found one already on the current line
+    if (STATE(NrErrLine) == 0) {
+        // print the message ...
+        if (error)
+            Pr("Syntax error: %s", (Int)msg, 0);
+        else
+            Pr("Syntax warning: %s", (Int)msg, 0);
+
+        // ... and the filename + line, unless it is '*stdin*'
+        if (strcmp("*stdin*", STATE(Input)->name) != 0)
+            Pr(" in %s:%d", (Int)STATE(Input)->name, GetInputLineNumber());
+        Pr("\n", 0, 0);
+
+        // print the current line
+        Pr("%s", (Int)STATE(Input)->line, 0);
+
+        // print a '^' pointing to the current position
+        Int pos = GetLinePosition();
+        for (Int i = 0; i < pos; i++) {
+            if (STATE(Input)->line[i] == '\t')
+                Pr("\t", 0, 0);
+            else
+                Pr(" ", 0, 0);
+        }
+        Pr("^\n", 0, 0);
+    }
+
+    if (error) {
+        // one more error
+        STATE(NrError)++;
+        STATE(NrErrLine)++;
+    }
+
+    // close error output
+    CloseOutput();
+}
+
+
 /****************************************************************************
 **
 *F  SyntaxError( <msg> )  . . . . . . . . . . . . . . .  raise a syntax error
 **
 */
-void            SyntaxError (
-    const Char *        msg )
+void SyntaxError(const Char * msg)
 {
-    Int                 i;
-
-    /* open error output                                                   */
-    OpenOutput( "*errout*" );
-
-    /* one more error                                                      */
-    STATE(NrError)++;
-    STATE(NrErrLine)++;
-
-    /* do not print a message if we found one already on the current line  */
-    if ( STATE(NrErrLine) == 1 )
-
-      {
-        /* print the message and the filename, unless it is '*stdin*'          */
-        Pr( "Syntax error: %s", (Int)msg, 0L );
-        if ( strcmp( "*stdin*", STATE(Input)->name ) != 0 )
-            Pr(" in %s:%d", (Int)STATE(Input)->name, GetInputLineNumber());
-        Pr( "\n", 0L, 0L );
-
-        /* print the current line                                              */
-        Pr( "%s", (Int)STATE(Input)->line, 0L );
-
-        /* print a '^' pointing to the current position                        */
-        Int pos = GetLinePosition();
-        for (i = 0; i < pos; i++) {
-            if (STATE(Input)->line[i] == '\t')
-                Pr("\t", 0L, 0L);
-            else
-                Pr(" ", 0L, 0L);
-        }
-        Pr( "^\n", 0L, 0L );
-      }
-    /* close error output                                                  */
-    CloseOutput();
+    SyntaxErrorOrWarning(msg, 1);
 }
 
 /****************************************************************************
@@ -74,40 +83,9 @@ void            SyntaxError (
 *F  SyntaxWarning( <msg> )  . . . . . . . . . . . . . . raise a syntax warning
 **
 */
-void            SyntaxWarning (
-    const Char *        msg )
+void SyntaxWarning(const Char * msg)
 {
-    Int                 i;
-
-    /* open error output                                                   */
-    OpenOutput( "*errout*" );
-
-
-    /* do not print a message if we found one already on the current line  */
-    if ( STATE(NrErrLine) == 0 )
-
-      {
-        /* print the message and the filename, unless it is '*stdin*'          */
-        Pr( "Syntax warning: %s", (Int)msg, 0L );
-        if ( strcmp( "*stdin*", STATE(Input)->name ) != 0 )
-            Pr(" in %s:%d", (Int)STATE(Input)->name, GetInputLineNumber());
-        Pr( "\n", 0L, 0L );
-
-        /* print the current line                                              */
-        Pr( "%s", (Int)STATE(Input)->line, 0L );
-
-        /* print a '^' pointing to the current position                        */
-        Int pos = GetLinePosition();
-        for (i = 0; i < pos; i++) {
-            if (STATE(Input)->line[i] == '\t')
-                Pr("\t", 0L, 0L);
-            else
-                Pr(" ", 0L, 0L);
-        }
-        Pr( "^\n", 0L, 0L );
-      }
-    /* close error output                                                  */
-    CloseOutput();
+    SyntaxErrorOrWarning(msg, 0);
 }
 
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -37,7 +37,6 @@ void            SyntaxError (
 
     /* open error output                                                   */
     OpenOutput( "*errout*" );
-    assert(STATE(Output));
 
     /* one more error                                                      */
     STATE(NrError)++;
@@ -67,9 +66,7 @@ void            SyntaxError (
         Pr( "^\n", 0L, 0L );
       }
     /* close error output                                                  */
-    assert(STATE(Output));
     CloseOutput();
-    assert(STATE(Output));
 }
 
 /****************************************************************************
@@ -84,7 +81,6 @@ void            SyntaxWarning (
 
     /* open error output                                                   */
     OpenOutput( "*errout*" );
-    assert(STATE(Output));
 
 
     /* do not print a message if we found one already on the current line  */
@@ -111,9 +107,7 @@ void            SyntaxWarning (
         Pr( "^\n", 0L, 0L );
       }
     /* close error output                                                  */
-    assert(STATE(Output));
     CloseOutput();
-    assert(STATE(Output));
 }
 
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -39,17 +39,18 @@ void SyntaxErrorOrWarning(const Char * msg, UInt error)
             Pr("Syntax warning: %s", (Int)msg, 0);
 
         // ... and the filename + line, unless it is '*stdin*'
-        if (strcmp("*stdin*", STATE(Input)->name) != 0)
-            Pr(" in %s:%d", (Int)STATE(Input)->name, GetInputLineNumber());
+        if (strcmp("*stdin*", GetInputFilename()) != 0)
+            Pr(" in %s:%d", (Int)GetInputFilename(), GetInputLineNumber());
         Pr("\n", 0, 0);
 
         // print the current line
-        Pr("%s", (Int)STATE(Input)->line, 0);
+        const char * line = GetInputLineBuffer();
+        Pr("%s", (Int)line, 0);
 
         // print a '^' pointing to the current position
-        Int pos = GetLinePosition();
+        Int pos = GetInputLinePosition();
         for (Int i = 0; i < pos; i++) {
-            if (STATE(Input)->line[i] == '\t')
+            if (line[i] == '\t')
                 Pr("\t", 0, 0);
             else
                 Pr(" ", 0, 0);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -49,7 +49,7 @@ void            SyntaxError (
         /* print the message and the filename, unless it is '*stdin*'          */
         Pr( "Syntax error: %s", (Int)msg, 0L );
         if ( strcmp( "*stdin*", STATE(Input)->name ) != 0 )
-          Pr( " in %s:%d", (Int)STATE(Input)->name, (Int)STATE(Input)->number );
+            Pr(" in %s:%d", (Int)STATE(Input)->name, GetInputLineNumber());
         Pr( "\n", 0L, 0L );
 
         /* print the current line                                              */
@@ -90,7 +90,7 @@ void            SyntaxWarning (
         /* print the message and the filename, unless it is '*stdin*'          */
         Pr( "Syntax warning: %s", (Int)msg, 0L );
         if ( strcmp( "*stdin*", STATE(Input)->name ) != 0 )
-          Pr( " in %s:%d", (Int)STATE(Input)->name, (Int)STATE(Input)->number );
+            Pr(" in %s:%d", (Int)STATE(Input)->name, GetInputLineNumber());
         Pr( "\n", 0L, 0L );
 
         /* print the current line                                              */

--- a/src/stats.c
+++ b/src/stats.c
@@ -24,6 +24,7 @@
 #include <src/gvars.h>
 #include <src/hookintrprtr.h>
 #include <src/intrprtr.h>
+#include <src/io.h>
 #include <src/lists.h>
 #include <src/plist.h>
 #include <src/precord.h>

--- a/src/streams.c
+++ b/src/streams.c
@@ -96,20 +96,14 @@ Obj FuncREAD_ALL_COMMANDS( Obj self, Obj stream, Obj echo )
     Obj evalResult;
 
     /* try to open the stream */
-    if (!OpenInputStream(stream) ) {
-      return Fail;
+    if (!OpenInputStream(stream, echo == True)) {
+        return Fail;
     }
 
     resultCount = 0;
     resultCapacity = 16;
     resultList = NEW_PLIST( T_PLIST, resultCapacity );
     SET_LEN_PLIST(resultList, resultCount);
-
-    if (echo == True) {
-        STATE(Input)->echo = 1;
-    } else {
-        STATE(Input)->echo = 0;
-    }
 
     do {
         ClearError();
@@ -160,14 +154,9 @@ Obj FuncREAD_COMMAND_REAL ( Obj self, Obj stream, Obj echo )
     SET_ELM_PLIST(result, 1, False);
 
     /* try to open the file                                                */
-    if ( ! OpenInputStream(stream) ) {
+    if (!OpenInputStream(stream, echo == True)) {
         return result;
     }
-
-    if (echo == True)
-      STATE(Input)->echo = 1;
-    else
-      STATE(Input)->echo = 0;
 
     status = READ_COMMAND(&evalResult);
     
@@ -1045,7 +1034,7 @@ Obj FuncREAD_STREAM (
     Obj                 stream )
 {
     /* try to open the file                                                */
-    if ( ! OpenInputStream(stream) ) {
+    if (!OpenInputStream(stream, 0)) {
         return False;
     }
 
@@ -1063,7 +1052,7 @@ Obj FuncREAD_STREAM_LOOP (
     Obj                 catcherrstdout )
 {
     /* try to open the file                                                */
-    if ( ! OpenInputStream(stream) ) {
+    if (!OpenInputStream(stream, 0)) {
         return False;
     }
     if ( catcherrstdout == True )
@@ -1116,7 +1105,7 @@ Obj FuncREAD_AS_FUNC_STREAM (
     Obj                 stream )
 {
     /* try to open the file                                                */
-    if ( ! OpenInputStream(stream) ) {
+    if (!OpenInputStream(stream, 0)) {
         return Fail;
     }
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -433,7 +433,6 @@ Int READ_GAP_ROOT ( const Char * filename )
                 (Int)filename, 0L );
         }
         if ( OpenInput(result.pathname) ) {
-          SySetBuffering(STATE(Input)->file);
             while ( 1 ) {
                 ClearError();
                 Obj evalResult;
@@ -981,8 +980,6 @@ Obj FuncREAD (
         return False;
     }
 
-    SySetBuffering(STATE(Input)->file);
-   
     /* read the test file                                                  */
     return READ() ? True : False;
 }
@@ -1013,8 +1010,6 @@ Obj FuncREAD_NORECOVERY (
         return False;
     }
 
-    SySetBuffering(STATE(Input)->file);
-   
     /* read the file */
     switch (READ_NORECOVERY()) {
     case 0: return False;
@@ -1085,8 +1080,6 @@ Obj FuncREAD_AS_FUNC (
         return Fail;
     }
 
-    SySetBuffering(STATE(Input)->file);
-    
     /* read the function                                                   */
     return READ_AS_FUNC();
 }

--- a/src/streams.c
+++ b/src/streams.c
@@ -941,22 +941,6 @@ Obj FuncSET_PREVIOUS_OUTPUT( Obj self ) {
     return 0;
 }
 
-Obj FuncIS_INPUT_TTY(Obj self)
-{
-    GAP_ASSERT(STATE(Input));
-    if (STATE(Input)->isstream)
-        return False;
-    return syBuf[STATE(Input)->file].isTTY ? True : False;
-}
-
-Obj FuncIS_OUTPUT_TTY(Obj self)
-{
-    GAP_ASSERT(STATE(Output));
-    if (STATE(Output)->isstream)
-        return False;
-    return syBuf[STATE(Output)->file].isTTY ? True : False;
-}
-
 /****************************************************************************
 **
 *F  FuncREAD( <self>, <filename> )  . . . . . . . . . . . . . . . read a file
@@ -2198,10 +2182,6 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(APPEND_TO_STREAM, -1, "args"),
     GVAR_FUNC(SET_OUTPUT, 2, "file, app"),
     GVAR_FUNC(SET_PREVIOUS_OUTPUT, 0, ""),
-
-    GVAR_FUNC(IS_INPUT_TTY, 0, ""),
-    GVAR_FUNC(IS_OUTPUT_TTY, 0, ""),
-
     GVAR_FUNC(TmpName, 0, ""),
     GVAR_FUNC(TmpDirectory, 0, ""),
     GVAR_FUNC(RemoveFile, 1, "filename"),

--- a/src/streams.c
+++ b/src/streams.c
@@ -1055,15 +1055,11 @@ Obj FuncREAD_STREAM_LOOP (
     if (!OpenInputStream(stream, 0)) {
         return False;
     }
-    if ( catcherrstdout == True )
-      STATE(IgnoreStdoutErrout) = GetCurrentOutput();
-    else
-      STATE(IgnoreStdoutErrout) = NULL;
-
 
     /* read the test file                                                  */
+    LockCurrentOutput(catcherrstdout == True);
     READ_LOOP();
-    STATE(IgnoreStdoutErrout) = NULL;
+    LockCurrentOutput(0);
     return True;
 }
 


### PR DESCRIPTION
This PR adds various accessor functions for stuff in io.c. It also unifies the handling of the "stack of input/output files" between GAP and HPC-GAP.

The end goal here is to move all `Input*` and `Output*` members of `GAPState` into a module state struct specific to `io.c`. With this PR, we are pretty close; indeed, only `STATE(Input)` is still referenced by a file other than `io.c`, namely by `code.c`, for `SetupGapname`. There are various ways to deal with that; the simplest (and so maybe most pragmatic) would be to expose the `gapnameid` field via an accessor function. But I am dissatisfied with this whole `gapnameid` thing all in all, so I'd like to think a bit more about it (e.g. we could replace with `RNams`, but I am worried about the performance impact on profiling, which is already rather slow).

Resolves #1612