### PR TITLE
Copy dll files built in cygwin

### DIFF
--- a/cnf/gac.in
+++ b/cnf/gac.in
@@ -114,7 +114,14 @@ c_link_dyn () {
     output_la=${1%.so}.la
     output_dir=$(dirname $1)
     ${c_dyn_linker} ${GAP_LDFLAGS} -o "$output_la" $2 ${c_addlibs} || exit 1
-    cp -r $output_dir/.libs/*.so $output_dir
+    if [ X"$SYS_IS_CYGWIN32" = X"yes" ] ; then
+        # GAP assumes shared libraries end in .so
+        for dllfile in `cd $output_dir/.libs; ls *.dll`; do
+            cp $output_dir/.libs/$dllfile $output_dir/${dllfile%.dll}.so
+        done
+    else
+        cp $output_dir/.libs/*.so $output_dir
+    fi;
 }
 
 


### PR DESCRIPTION
On cygwin, GAC builds .dll files, not .so files, so fix copying them.

I change the ending to a .so, as we do in several packages (like IO), because Windows doesn't care and this means code which assumes the ending will be .so will work fine.

Fixes #1298 