### PR TITLE
Check list length in GrowPlist

### DIFF
--- a/src/intobj.h
+++ b/src/intobj.h
@@ -111,6 +111,26 @@ static inline Int INT_INTOBJ(Obj o)
 #endif
 }
 
+/****************************************************************************
+**
+*F  INT_FITS_IN_INTOBJ( <i> ) . check if a C integer fits in an immediate
+**  integer.
+*/
+static inline Int INT_FITS_IN_INTOBJ(Int i)
+{
+    return (-(((Int)1) << NR_SMALL_INT_BITS) <= i) &&
+           (i < ((Int)1) << NR_SMALL_INT_BITS);
+}
+
+/****************************************************************************
+**
+*F  UINT_FITS_IN_INTOBJ( <i> ) . check if a C unsigned integer fits in an
+**  immediate integer.
+*/
+static inline Int UINT_FITS_IN_INTOBJ(UInt i)
+{
+    return i < ((UInt)1) << NR_SMALL_INT_BITS;
+}
 
 /****************************************************************************
 **
@@ -121,6 +141,7 @@ static inline Int INT_INTOBJ(Obj o)
 static inline Obj INTOBJ_INT(Int i)
 {
     Obj o;
+    GAP_ASSERT(INT_FITS_IN_INTOBJ(i));
     o = (Obj)(((UInt)i << 2) + 0x01);
     GAP_ASSERT(INT_INTOBJ(o) == i);
     return o;

--- a/src/plist.c
+++ b/src/plist.c
@@ -71,13 +71,14 @@ Int             GrowPlist (
         ErrorMayQuit("GrowPlist: List size too large", 0, 0);
     }
 
-
     /* find out how large the plain list should become                     */
     good = 5 * (SIZE_OBJ(list)/sizeof(Obj)-1) / 4 + 4;
 
     /* but maybe we need more                                              */
-    if ( need < good ) { plen = good; }
-    else               { plen = need; }
+    if (need < good && UINT_FITS_IN_INTOBJ(good))
+        plen = good;
+    else
+        plen = need;
 
     /* resize the plain list                                               */
     ResizeBag( list, ((plen)+1)*sizeof(Obj) );

--- a/src/plist.c
+++ b/src/plist.c
@@ -67,6 +67,11 @@ Int             GrowPlist (
     UInt                plen;           /* new physical length             */
     UInt                good;           /* good new physical length        */
 
+    if (!UINT_FITS_IN_INTOBJ(need)) {
+        ErrorMayQuit("GrowPlist: List size too large", 0, 0);
+    }
+
+
     /* find out how large the plain list should become                     */
     good = 5 * (SIZE_OBJ(list)/sizeof(Obj)-1) / 4 + 4;
 


### PR DESCRIPTION
This ensures GrowPlist checks the size we are growing the list to is a valid list size. This stops us then overflowing in ResizeBag later.

I hope this fixes #1479, but I had trouble reproducing the error originally, so it is hard for me to check.

This also adds two explicit functions to check if a C signed or unsigned integer can be turned into an immediate integer. These functions can be used more widely, but I leave that for another PR (or at least until this one is checked to see if people like them).