### PR TITLE
fix IsMultiplicativeElementWithOneTable documentation

### DIFF
--- a/lib/arith.gd
+++ b/lib/arith.gd
@@ -380,7 +380,7 @@ DeclareSynonym( "IsMultiplicativeElementWithOneTable",
 ##  <Description>
 ##  This is the category of elements in a family which can be the operands of 
 ##  <C>*</C> (multiplication) and the operation 
-##  <Ref Attr="MultiplicativeZero"/>.
+##  <Ref Attr="MultiplicativeZeroOp"/>.
 ##  <Example><![CDATA[
 ##  gap> S:=Semigroup(Transformation( [ 1, 1, 1 ] ));;
 ##  gap> M:=MagmaWithZeroAdjoined(S);


### PR DESCRIPTION
It referred to  MultiplicativeZero, but that is only applicable to
magmas, not elements; for the latter, one should use
MultiplicativeZeroOp. The example a bit below also correctly does that.

Resolves #1237