### PR TITLE
Remove InstallIsomorphismMaintenanceFunction and some HPC-GAP syncing

### DIFF
--- a/hpcgap/lib/coll.gd
+++ b/hpcgap/lib/coll.gd
@@ -354,18 +354,24 @@ end );
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL( "DeclareSynonym", function( name, value )
-    BIND_GLOBAL( name, value );
+    if ISBOUND_GLOBAL(name) and IS_IDENTICAL_OBJ(VALUE_GLOBAL(name), value) then
+        if not REREADING then
+            INFO_DEBUG( 1, "multiple declarations for synonym `", name, "'\n" );
+        fi;
+    else
+        BIND_GLOBAL( name, value );
+    fi;
 end );
 
 BIND_GLOBAL( "DeclareSynonymAttr", function( name, value )
     local nname;
-    BIND_GLOBAL( name, value );
+    DeclareSynonym( name, value );
     nname:= "Set";
     APPEND_LIST_INTR( nname, name );
-    BIND_GLOBAL( nname, Setter( value ) );
+    DeclareSynonym( nname, Setter( value ) );
     nname:= "Has";
     APPEND_LIST_INTR( nname, name );
-    BIND_GLOBAL( nname, Tester( value ) );
+    DeclareSynonym( nname, Tester( value ) );
 end );
 
 

--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -253,7 +253,7 @@ BIND_GLOBAL( "CategoryCollections", function ( elms_filter )
 
     # Construct the collections category.
     coll_filter:= NewCategory( name, super );
-    ADD_LIST( CATEGORIES_COLLECTIONS, [ elms_filter, coll_filter ] );
+    ADD_LIST( CATEGORIES_COLLECTIONS, MakeImmutable([ elms_filter, coll_filter ]) );
     return coll_filter;
 end );
 
@@ -620,16 +620,17 @@ BIND_GLOBAL( "InstallSubsetMaintenance",
       SUBSET_MAINTAINED_INFO[2][ i+1 ]:= SUBSET_MAINTAINED_INFO[2][ i ];
       i:= i-1;
     od;
-    SUBSET_MAINTAINED_INFO[2][ i+1 ]:= [ filtsopr, filtssub, rank ];
+    SUBSET_MAINTAINED_INFO[2][ i+1 ]:=
+                MakeImmutable([ filtsopr, filtssub, rank ]);
     if attrprop then
       SUBSET_MAINTAINED_INFO[1][ i+1 ]:=
-                [ filt1, filt2, operation, tester, setter ];
+                MakeImmutable([ filt1, filt2, operation, tester, setter ]);
     else
       SUBSET_MAINTAINED_INFO[1][ i+1 ]:=
-                [ filt1, filt2, operation, operation,
+                MakeImmutable([ filt1, filt2, operation, operation,
                   function( sub, val )
                       SetFeatureObj( sub, operation, val );
-                  end ];
+                  end ]);
     fi;
 
 #T missing in new implementation!
@@ -967,13 +968,13 @@ BIND_GLOBAL( "InstallFactorMaintenance",
 
     tester:= Tester( opr );
 
-    ADD_LIST( FACTOR_MAINTAINED_INFO,
+    ADD_LIST( FACTOR_MAINTAINED_INFO, MakeImmutable(
         [ IsCollection and Tester( numer_req ) and numer_req and tester,
           Tester( denom_req ) and denom_req,
           IsCollection and Tester( factor_req ) and factor_req,
           opr,
           tester,
-          Setter( opr ) ] );
+          Setter( opr ) ] ) );
 
 #T not yet available in the new implementation
 #     if     FLAGS_FILTER( opr ) <> false

--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -759,45 +759,6 @@ InstallMethod( UseIsomorphismRelation,
 
 #############################################################################
 ##
-#F  InstallIsomorphismMaintenanceFunction( <func> )
-##
-##  <ManSection>
-##  <Func Name="InstallIsomorphismMaintenanceFunction" Arg='func'/>
-##
-##  <Description>
-##  <C>InstallIsomorphismMaintenanceFunction</C> installs <A>func</A>, so that
-##  <C><A>func</A>( <A>filtsold</A>, <A>filtsnew</A>, <A>opr</A>, <A>testopr</A>, <A>settopr</A>, <A>old_req</A>,
-##  <A>new-req</A> )</C> is called for each isomorphism maintenance.
-##  More precisely, <A>func</A> is called for each entry in the global list
-##  <C>ISOMORPHISM_MAINTAINED_INFO</C>, also to those that are entered into this
-##  list after the installation of <A>func</A>.
-##  (The mechanism is the same as for attributes, which is installed in the
-##  file <C>lib/oper.g</C>.)
-##  </Description>
-##  </ManSection>
-##
-BIND_GLOBAL( "ISOM_MAINT_FUNCS", [] );
-
-BIND_GLOBAL( "InstallIsomorphismMaintenanceFunction", function( func )
-    local entry;
-    for entry in ISOMORPHISM_MAINTAINED_INFO do
-      CallFuncList( func, entry );
-    od;
-    ADD_LIST( ISOM_MAINT_FUNCS, func );
-end );
-
-BIND_GLOBAL( "RUN_ISOM_MAINT_FUNCS",
-    function( arglist )
-    local func;
-    for func in ISOM_MAINT_FUNCS do
-      CallFuncList( func, arglist );
-    od;
-    ADD_LIST( ISOMORPHISM_MAINTAINED_INFO, arglist );
-end );
-
-
-#############################################################################
-##
 #F  InstallIsomorphismMaintenance( <opr>, <old_req>, <new_req> )
 ##
 ##  <#GAPDoc Label="InstallIsomorphismMaintenance">
@@ -830,14 +791,14 @@ BIND_GLOBAL( "InstallIsomorphismMaintenance",
 
     tester:= Tester( opr );
 
-    RUN_ISOM_MAINT_FUNCS(
+    ADD_LIST( ISOMORPHISM_MAINTAINED_INFO, MakeImmutable(
         [ IsCollection and Tester( old_req ) and old_req and tester,
           IsCollection and Tester( new_req ) and new_req,
           opr,
           tester,
           Setter( opr ),
           old_req,
-          new_req ] );
+          new_req ] ) );
 end );
 
 


### PR DESCRIPTION
`InstallIsomorphismMaintenanceFunction` was added by @ThomasBreuer to support a package called `gpisotyp`. I have never heard about or seen this package. Nothing else seems to use it, and it is undocumented.

This PR removes it, and some related code, and also reduced diffs between the plain GAP and HPC-GAP versions of `lib/coll.{gi,gd}`.

It would be good to hear from @ThomasBreuer if he still needs `InstallIsomorphismMaintenanceFunction` after all?