### PR TITLE
Allow Int(""), reject null bytes, clarify docs (for stable-4.9)

### DIFF
--- a/doc/ref/string.xml
+++ b/doc/ref/string.xml
@@ -458,7 +458,7 @@ see&nbsp;<Ref Sect="String Streams"/>.
 <Func Name="HexStringInt" Arg='int'/>
 
 <Description>
-returns a string which represents the integer <A>int</A> with hexa-decimal
+returns a string which represents the integer <A>int</A> with hexadecimal
 digits (using <C>A</C> to <C>F</C> as digits <C>10</C> to <C>15</C>).
 The inverse translation can be achieved with <Ref Func="IntHexString"/>.
 </Description>
@@ -607,51 +607,75 @@ gap> SIntChar(CharInt(255));
 
 <ManSection>
 <Attr Name="Int" Arg='str' Label="for strings"/>
-<Attr Name="Rat" Arg='str' Label="for strings"/>
-<Func Name="IntHexString" Arg='str'/>
 
 <Description>
 <Index Subkey="strings">evaluation</Index>
-return either an integer (<Ref Func="Int" Label="for strings"/> and
-<Ref Func="IntHexString"/>),
-or a rational (<Ref Func="Rat" Label="for strings"/>) as represented by the
-string <A>str</A>.
-<Ref Func="Int" Label="for strings"/> returns <K>fail</K> if non-digit
-characters occur in <A>str</A>.
-For <Ref Func="Rat" Label="for strings"/>, the argument string may start with
-the sign character <C>-</C>,
-followed by either a sequence of digits or by two sequences of digits
-that are separated by one of the characters <C>/</C> or <C>.</C>,
-where the latter stands for a decimal dot.
-(The methods only evaluate numbers but do <E>not</E> perform arithmetic!)
+returns an integer as represented by the string <A>str</A>.
+The argument string may optionally start with the sign character
+<C>-</C>, followed by a sequence of decimal digits.
+For any other input <K>fail</K> is returned.
 <P/>
-<Ref Func="IntHexString"/> evaluates an integer written with hexa-decimal
-digits.
-Here the letters <C>a</C>-<C>f</C> or <C>A</C>-<C>F</C> are used as
-<E>digits</E> <M>10</M> to <M>15</M>.
-An error occurs when a wrong character is found in the string.
-This function can be used (together with <Ref Func="HexStringInt"/>) for
-efficiently storing and reading large integers from respectively into &GAP;.
-Note that the translation between integers and their hexa-decimal
-representation costs linear computation time in terms of the number of
-digits, while translation from and into decimal representation needs
-substantial computations.
-If <A>str</A> is not in compact string representation then
-<Ref Func="ConvertToStringRep"/> is applied to it as side effect.
+For backwards compatibility, the empty string is accepted, in which
+case <M>0</M> is returned as result.
 <P/>
 <Example><![CDATA[
-gap> Int("12345")+1;
-12346
+gap> Int("12345");
+12345
 gap> Int("123/45");
 fail
 gap> Int("1+2");
 fail
 gap> Int("-12");
 -12
+gap> Int("");
+0
+]]></Example>
+</Description>
+</ManSection>
+
+
+<ManSection>
+<Attr Name="Rat" Arg='str' Label="for strings"/>
+
+<Description>
+<Index Subkey="strings">evaluation</Index>
+returns a rational as represented by the string <A>str</A>.
+The argument string may optionally start with the sign character
+<C>-</C>, followed by either a sequence of decimal digits or by two
+sequences of decimal digits that are separated by one of the characters
+<C>/</C> or <C>.</C>, where the latter stands for a decimal dot.
+For any other input <K>fail</K> is returned.
+<P/>
+<Example><![CDATA[
 gap> Rat("123/45");
 41/15
-gap> Rat( "123.45" );
-2469/20
+gap> Rat("-123.45");
+-2469/20
+]]></Example>
+</Description>
+</ManSection>
+
+
+<ManSection>
+<Func Name="IntHexString" Arg='str'/>
+
+<Description>
+<Index Subkey="strings">evaluation</Index>
+returns an integer as represented by the string <A>str</A>.
+The argument string may optionally start with the sign character
+<C>-</C>, followed by a sequence of hexadecimal digits. Here the letters
+<C>a</C>-<C>f</C> or <C>A</C>-<C>F</C> are used as <E>digits</E>
+<M>10</M> to <M>15</M>.
+Any other input results in an error.
+<P/>
+This function can be used (together with <Ref Func="HexStringInt"/>) for
+efficiently storing and reading large integers from respectively into &GAP;.
+Note that the translation between integers and their hexadecimal
+representation costs linear computation time in terms of the number of
+digits, while translation from and into decimal representation needs
+substantial computations.
+<P/>
+<Example><![CDATA[
 gap> IntHexString("-abcdef0123456789");
 -12379813738877118345
 gap> HexStringInt(last);

--- a/lib/arith.gd
+++ b/lib/arith.gd
@@ -1855,7 +1855,7 @@ DeclareOperationKernel( "mod", [ IsObject, IsObject ], MOD );
 ##
 ##  <Description>
 ##  <Ref Attr="Int"/> returns an integer <C>int</C> whose meaning depends
-##  on the type of <A>elm</A>.
+##  on the type of <A>elm</A>. For example:
 ##  <P/>
 ##  If <A>elm</A> is a rational number
 ##  (see Chapter&nbsp;<Ref Chap="Rational Numbers"/>) then <C>int</C> is the
@@ -1868,10 +1868,12 @@ DeclareOperationKernel( "mod", [ IsObject, IsObject ], MOD );
 ##  <C><A>elm</A> = int * One( <A>elm</A> )</C>.
 ##  <P/>
 ##  If <A>elm</A> is a string
-##  (see Chapter&nbsp;<Ref Chap="Strings and Characters"/>) consisting of
-##  digits <C>'0'</C>, <C>'1'</C>, <M>\ldots</M>, <C>'9'</C>
-##  and <C>'-'</C> (at the first position) then <C>int</C> is the integer
-##  described by this string.
+##  (see Chapter&nbsp;<Ref Chap="Strings and Characters"/>) consisting entirely
+##  of decimal digits <C>'0'</C>, <C>'1'</C>, <M>\ldots</M>, <C>'9'</C>,
+##  and optionally a sign <C>'-'</C> (at the first position), then <C>int</C> is the integer
+##  described by this string. For all other strings, <C>fail</C> is returned.
+##  See <Ref Func="Int" Label="for strings"/>.
+##  <P/>
 ##  The operation <Ref Func="String"/> can be used to compute a string for
 ##  rational integers, in fact for all cyclotomics.
 ##  <P/>

--- a/src/integer.c
+++ b/src/integer.c
@@ -1027,17 +1027,13 @@ Obj IntStringInternal(Obj string, const Char *str)
     if (string)
         str = CSTR_STRING(string);
 
-    // get the signs, if any
+    // get the sign, if any
     sign = 1;
     i = 0;
-    while (str[i] == '-') {
+    if (str[i] == '-') {
         sign = -sign;
         i++;
     }
-
-    // reject empty string (resp. string consisting only of minus signs)
-    if (str[i] == '\0')
-        return Fail;
 
     // collect the digits in groups of 8, for improved performance
     // note that 2^26 < 10^8 < 2^27, so the intermediate
@@ -1063,6 +1059,10 @@ Obj IntStringInternal(Obj string, const Char *str)
         }
         i++;
     }
+
+    // check if 0 char does not mark the end of the string
+    if (string && i < GET_LEN_STRING(string))
+        return Fail;
 
     // compose the integer value
     if (upp == INTOBJ_INT(0)) {

--- a/tst/testinstall/intarith.tst
+++ b/tst/testinstall/intarith.tst
@@ -620,17 +620,9 @@ gap> Int("0");
 0
 gap> Int("00");
 0
-gap> Int("--0");
-0
-gap> Int("---0");
-0
 gap> Int("01");
 1
 gap> Int("-01");
--1
-gap> Int("--1");
-1
-gap> Int("---1");
 -1
 gap> Int("100000000");
 100000000
@@ -645,10 +637,12 @@ gap> Int("123456789012345678901234567890");
 gap> Int("-123456789012345678901234567890");
 -123456789012345678901234567890
 gap> Int("");
-fail
+0
 gap> Int("-");
-fail
+0
 gap> Int("--");
+fail
+gap> Int("--0");
 fail
 gap> Int("+");
 fail
@@ -667,7 +661,7 @@ fail
 gap> Int(['-', '1', '2', '3']);
 -123
 gap> Int(['1', '2', '\000', '3']);
-12
+fail
 
 #
 # integer to string conversion


### PR DESCRIPTION
Strings which contain a null byte are now rejected by `Int`, instead of ignoring them and any characters after them.

Moreover, `Int("")` and `Int("-")` again returns 0 (as was the case in all previous GAP versions). I allowed both because I realized that also `Rat` accepts empty strings (i.e. `Rat("/1")` and `Rat("-/1")` both return `0`, and this way, we can write a concise uniform definition: we expect an optional sign character, followed by a sequence of decimal digits -- and that sequence can of course also be empty.

Also clarify the documentation of `Int`, `Rat` and `IntHexString` for strings: The primary reference entry for `Int` now states what happens in case of invalid input. It also now links to the secondary entry "Int for strings".

The documentation for `Int`, `Rat` and `IntHexString` for strings was previously jumbled together. Split this into three separate entries, and be more precise in documenting which inputs are accepted, and what happens for invalid inputs.

Fixes #2047
