### PR TITLE
Test/TestDirectory: default to `showProgress:=false` if stdout isn't a tty (for stable-4.9)

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -91,6 +91,9 @@ InstallGlobalFunction(RunTests, function(arg)
   # don't enter break loop in case of error during test
   tests := arg[1];
   opts := rec( breakOnError := false, showProgress := "some" );
+  if not IS_OUTPUT_TTY() then
+    opts.showProgress := false;
+  fi;
   if Length(arg) > 1 and IsRecord(arg[2]) then
     for f in RecNames(arg[2]) do
       opts.(f) := arg[2].(f);
@@ -263,7 +266,8 @@ end;
 ##  and the input line before it is processed; if set to <C>"some"</C>,
 ##  then GAP shows the current line number of the test being processed;
 ##  if set to <K>false</K>, no progress updates are displayed
-##  (default is <C>"some"</C>).</Item>
+##  (default is <C>"some"</C> if GAP's output goes to a terminal, otherwise
+##  <K>false</K>). </Item>
 ##  <Mark><C>subsWindowsLineBreaks</C></Mark>
 ##  <Item>If this is <K>true</K> then &GAP; substitutes DOS/Windows style
 ##  line breaks "\r\n" by UNIX style line breaks "\n" after reading the test
@@ -371,6 +375,9 @@ InstallGlobalFunction("Test", function(arg)
            end,
            subsWindowsLineBreaks := true,
          );
+  if not IS_OUTPUT_TTY() then
+    opts.showProgress := false;
+  fi;
 
   if IsHPCGAP then
     # HPCGAP's window size varies in different threads
@@ -535,7 +542,8 @@ end);
 ##  <Item>If <K>true</K>, stop as soon as any <Ref Func="Test" /> fails (defaults to <K>false</K>).
 ##  </Item>
 ##  <Mark><C>showProgress</C></Mark>
-##  <Item>Print information about how tests are progressing (defaults to <K>"some"</K>).
+##  <Item>Print information about how tests are progressing (defaults to <C>"some"</C>
+##  if GAP's output goes to a terminal, otherwise <K>false</K>).
 ##  </Item>
 ##  <Mark><C>suppressStatusMessage</C></Mark>
 ##  <Item>suppress displaying status messages <C>#I  Errors detected while testing</C> and

--- a/src/streams.c
+++ b/src/streams.c
@@ -952,7 +952,23 @@ Obj FuncSET_PREVIOUS_OUTPUT( Obj self ) {
     }
     return 0;
 }
-     
+
+Obj FuncIS_INPUT_TTY(Obj self)
+{
+    GAP_ASSERT(STATE(Input));
+    if (STATE(Input)->isstream)
+        return False;
+    return syBuf[STATE(Input)->file].isTTY ? True : False;
+}
+
+Obj FuncIS_OUTPUT_TTY(Obj self)
+{
+    GAP_ASSERT(STATE(Output));
+    if (STATE(Output)->isstream)
+        return False;
+    return syBuf[STATE(Output)->file].isTTY ? True : False;
+}
+
 /****************************************************************************
 **
 *F  FuncREAD( <self>, <filename> )  . . . . . . . . . . . . . . . read a file
@@ -2177,7 +2193,7 @@ Obj FuncExecuteProcess (
 **
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
-static StructGVarFunc GVarFuncs [] = {
+static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC(READ, 1, "filename"),
     GVAR_FUNC(READ_NORECOVERY, 1, "filename"),
@@ -2204,6 +2220,10 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(APPEND_TO_STREAM, -1, "args"),
     GVAR_FUNC(SET_OUTPUT, 2, "file, app"),
     GVAR_FUNC(SET_PREVIOUS_OUTPUT, 0, ""),
+
+    GVAR_FUNC(IS_INPUT_TTY, 0, ""),
+    GVAR_FUNC(IS_OUTPUT_TTY, 0, ""),
+
     GVAR_FUNC(TmpName, 0, ""),
     GVAR_FUNC(TmpDirectory, 0, ""),
     GVAR_FUNC(RemoveFile, 1, "filename"),

--- a/src/system.c
+++ b/src/system.c
@@ -1806,6 +1806,7 @@ void InitSystem (
     // set up stdout
     syBuf[1].echo = syBuf[1].fp = fileno(stdout); 
     syBuf[1].bufno = -1;
+    syBuf[1].isTTY = isatty(fileno(stdout));
 
     // set up errin (defaults to stdin, unless stderr is on a terminal)
     syBuf[2].fp = fileno(stdin);


### PR DESCRIPTION
Thus if you pipe the output of Test or TestDirectory into a file, no progress output is generated.

Note that only the default setting is changed; you can still manually override the `showProgress` setting.

Should resolve #2049 -- curious to hear what @ThomasBreuer thinks.
