### PR TITLE
Fix PositionProperty with from < 1

### DIFF
--- a/lib/list.gi
+++ b/lib/list.gi
@@ -1525,8 +1525,8 @@ InstallMethod( PositionProperty,
     function( list, func, from )
     local i;
 
-    if from < 1 then
-      from:= 1;
+    if from < 0 then
+      from:= 0;
     fi;
     for i in [ from+1 .. Length( list ) ] do
       if IsBound( list[i] ) then
@@ -1557,8 +1557,8 @@ InstallMethod( PositionProperty,
     function( list, func, from )
     local i;
 
-    if from < 1 then
-      from:= 1;
+    if from < 0 then
+      from:= 0;
     fi;
     for i in [ from+1 .. Length( list ) ] do
       if func( list[i] ) then

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -209,5 +209,25 @@ gap> PositionsProperty( ll, ReturnTrue );
 gap> PositionsProperty( ll, IsInt );
 [ 1, 2, 3 ]
 
+# PositionProperty
+gap> ll := [ 1, , "s" ];;
+gap> PositionProperty( ll, ReturnTrue, 0);
+1
+gap> PositionProperty( ll, ReturnTrue, 1);
+3
+gap> PositionProperty( ll, IsInt, 0);
+1
+gap> PositionProperty( ll, IsInt, 1);
+fail
+gap> ll := [ 1, 2, 3 ];;
+gap> PositionProperty( ll, ReturnTrue, 0);
+1
+gap> PositionProperty( ll, ReturnTrue, 1);
+2
+gap> PositionProperty( ll, ReturnTrue, 2);
+3
+gap> PositionProperty( ll, ReturnTrue, 3);
+fail
+
 #
 gap> STOP_TEST("list.tst");


### PR DESCRIPTION
This PR fixes a bug in `PositionProperty(list, func, 0)` which previously only started trying to find an item in `list` for which `func` returns `true` from `list[2]` onwards. This contradicts both the documentation and is not consistent with how `Position` behaves.  
  