### PR TITLE
Restrict capacity of plists to 2^28 resp. 2^60 (revision of #2039)

### DIFF
--- a/lib/memusage.gi
+++ b/lib/memusage.gi
@@ -39,7 +39,7 @@ InstallGlobalFunction( MemoryUsage, function( o )
             continue;
         fi;
 
-        mem := mem + SHALLOW_SIZE(o) + MU_MemBagHeader + MU_MemPointer;
+        mem := mem + SIZE_OBJ(o) + MU_MemBagHeader + MU_MemPointer;
         if IsRat(o) then
             visit(NumeratorRat(o));
             visit(DenominatorRat(o));

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -592,5 +592,17 @@ DeclareObsoleteSynonym( "RecFields", "RecNames" );
 
 #############################################################################
 ##
-#E
+#F  SHALLOW_SIZE
+##
+##  'SHALLOW_SIZE' is an alias for the kernel function 'SIZE_OBJ'. Note that
+##  in the past, SIZE_OBJ was buggy for immediate inputs (i.e. small integers
+##  or finite field elements), hence packages using either of these
+##  UNDOCUMENTED kernel functions may wish to keep using SHALLOW_SIZE until
+##  they can adjust their minimal GAP version requirements.
+##
+## still used by cvec, datastructures, orb, recog
+DeclareObsoleteSynonym( "SHALLOW_SIZE", "SIZE_OBJ" );
 
+#############################################################################
+##
+#E

--- a/src/code.c
+++ b/src/code.c
@@ -1517,7 +1517,7 @@ void CodeAInv ( void )
     Int                 i;
 
     expr = PopExpr();
-    if ( IS_INTEXPR(expr) && INT_INTEXPR(expr) != -(1L<<NR_SMALL_INT_BITS) ) {
+    if ( IS_INTEXPR(expr) && INT_INTEXPR(expr) != INT_INTOBJ_MIN ) {
         i = INT_INTEXPR(expr);
         PushExpr( INTEXPR_INT( -i ) );
     }

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -722,7 +722,7 @@ Obj             Cyclotomic (
                 for ( i = 0; i < n; i += p ) {
                     cof = res[(i+n/p)%n];
                     if ( ! IS_INTOBJ(cof)
-                      || (cof == INTOBJ_INT(-(1L<<NR_SMALL_INT_BITS))) ) {
+                      || (cof == INTOBJ_MIN) ) {
                         CHANGED_BAG( ResultCyc );
                         cof = DIFF( INTOBJ_INT(0), cof );
                         res = BASE_PTR_PLIST(ResultCyc);
@@ -813,7 +813,7 @@ static UInt FindCommonField(UInt nl, UInt nr, UInt *ml, UInt *mr)
   /* Compute the result (lcm) in 64 bit */
   n8 = (UInt8)nl * ((UInt8)*ml);  
   /* Check if it is too large for a small int */
-  if (n8 > ((UInt8)(1) << NR_SMALL_INT_BITS))
+  if (n8 > INT_INTOBJ_MAX)
     ErrorMayQuit("This computation would require a cyclotomic field too large to be handled",0L, 0L);
 
   /* Switch to UInt now we know we can*/
@@ -1000,8 +1000,7 @@ Obj             AInvCyc (
     cfp = COEFS_CYC(res);
     exp = EXPOS_CYC(res,len);
     for ( i = 1; i < len; i++ ) {
-        if ( ! IS_INTOBJ( cfs[i] ) || 
-               cfs[i] == INTOBJ_INT(-(1L<<NR_SMALL_INT_BITS)) ) {
+        if ( ! IS_INTOBJ( cfs[i] ) || cfs[i] == INTOBJ_MIN ) {
             CHANGED_BAG( res );
             prd = AINV( cfs[i] );
             cfs = CONST_COEFS_CYC(op);

--- a/src/gap.c
+++ b/src/gap.c
@@ -1891,25 +1891,27 @@ Obj FuncGASMAN_LIMITS( Obj self )
 
 /****************************************************************************
 **
-*F  FuncSHALLOW_SIZE( <self>, <obj> ) . . . .  expert function 'SHALLOW_SIZE'
+*F  FuncTotalMemoryAllocated( <self> ) .expert function 'TotalMemoryAllocated'
 */
-Obj FuncSHALLOW_SIZE (
-    Obj                 self,
-    Obj                 obj )
+
+Obj FuncTotalMemoryAllocated( Obj self )
 {
-  if (IS_INTOBJ(obj) || IS_FFE(obj))
-    return INTOBJ_INT(0);
-  else
-    return ObjInt_UInt( SIZE_BAG( obj ) );
+    return ObjInt_UInt8(SizeAllBags);
 }
 
 /****************************************************************************
 **
-*F  FuncTotalMemoryAllocated( <self> ) .expert function 'TotalMemoryAllocated'
+*F  FuncSIZE_OBJ( <self>, <obj> ) . . . .  expert function 'SIZE_OBJ'
+**
+**  'SIZE_OBJ( <obj> )' returns 0 for immediate objects, and otherwise
+**  returns the bag size of the object. This does not include the size of
+**  sub-objects.
 */
-
-Obj FuncTotalMemoryAllocated( Obj self ) {
-    return ObjInt_UInt8(SizeAllBags);
+Obj FuncSIZE_OBJ(Obj self, Obj obj)
+{
+    if (IS_INTOBJ(obj) || IS_FFE(obj))
+        return INTOBJ_INT(0);
+    return ObjInt_UInt(SIZE_OBJ(obj));
 }
 
 /****************************************************************************
@@ -2022,7 +2024,7 @@ Obj FuncFUNC_BODY_SIZE(Obj self, Obj f)
     if (TNUM_OBJ(f) != T_FUNCTION) return Fail;
     body = BODY_FUNC(f);
     if (body == 0) return INTOBJ_INT(0);
-    else return INTOBJ_INT( SIZE_BAG( body ) );
+    else return ObjInt_UInt( SIZE_BAG( body ) );
 }
 
 /****************************************************************************
@@ -2810,8 +2812,8 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(GASMAN_STATS, 0, ""),
     GVAR_FUNC(GASMAN_MESSAGE_STATUS, 0, ""),
     GVAR_FUNC(GASMAN_LIMITS, 0, ""),
-    GVAR_FUNC(SHALLOW_SIZE, 1, "object"),
     GVAR_FUNC(TotalMemoryAllocated, 0, ""),
+    GVAR_FUNC(SIZE_OBJ, 1, "object"),
     GVAR_FUNC(TNUM_OBJ, 1, "object"),
     GVAR_FUNC(TNAM_OBJ, 1, "object"),
     GVAR_FUNC(OBJ_HANDLE, 1, "object"),

--- a/src/gap.c
+++ b/src/gap.c
@@ -1844,7 +1844,6 @@ Obj FuncGASMAN_STATS(Obj self)
 {
   Obj res;
   Obj row;
-  Obj entry;
   UInt i,j;
   Int x;
   res = NEW_PLIST(T_PLIST_TAB_RECT + IMMUTABLE, 2);
@@ -1858,15 +1857,7 @@ Obj FuncGASMAN_STATS(Obj self)
       for (j = 1; j <= 8; j++)
         {
           x = SyGasmanNumbers[i-1][j];
-
-          /* convert x to GAP integer. x may be too big to be a small int */
-          if (x < (1L << NR_SMALL_INT_BITS))
-            entry = INTOBJ_INT(x);
-          else
-            entry = SUM( PROD(INTOBJ_INT(x >> (NR_SMALL_INT_BITS/2)),
-                              INTOBJ_INT(1 << (NR_SMALL_INT_BITS/2))),
-                         INTOBJ_INT( x % ( 1 << (NR_SMALL_INT_BITS/2))));
-          SET_ELM_PLIST(row, j, entry);
+          SET_ELM_PLIST(row, j, ObjInt_Int(x));
         }
       SET_ELM_PLIST(row, 9, INTOBJ_INT(SyGasmanNumbers[i-1][0]));       
     }

--- a/src/integer.c
+++ b/src/integer.c
@@ -431,9 +431,8 @@ Obj GMP_REDUCE( Obj gmp )
     return gmp;
   }
   if ( SIZE_INT(gmp) == 1) {
-    if ( ( VAL_LIMB0(gmp) < ((1L<<NR_SMALL_INT_BITS)) ) ||
-         ( IS_INTNEG(gmp) &&
-           ( VAL_LIMB0(gmp) == (1L<<NR_SMALL_INT_BITS) ) ) ) {
+    if ( ( VAL_LIMB0(gmp) <= INT_INTOBJ_MAX ) ||
+         ( IS_INTNEG(gmp) && VAL_LIMB0(gmp) == -INT_INTOBJ_MIN ) ) {
       if ( IS_INTNEG(gmp) ) {
         return INTOBJ_INT( -(Int)VAL_LIMB0(gmp) );
       }
@@ -470,9 +469,8 @@ int IS_NORMALIZED_AND_REDUCED( Obj op, const char *func, int line )
     Pr("WARNING: non-normalized gmp value (%s:%d)\n",(Int)func,line);
   }
   if ( SIZE_INT(op) == 1) {
-    if ( ( VAL_LIMB0(op) < ((1L<<NR_SMALL_INT_BITS)) ) ||
-         ( IS_INTNEG(op) &&
-           ( VAL_LIMB0(op) == (1L<<NR_SMALL_INT_BITS) ) ) ) {
+    if ( ( VAL_LIMB0(op) <= INT_INTOBJ_MAX ) ||
+         ( IS_INTNEG(op) && VAL_LIMB0(op) == -INT_INTOBJ_MIN ) ) {
       if ( IS_INTNEG(op) ) {
         Pr("WARNING: non-reduced negative gmp value (%s:%d)\n",(Int)func,line);
         return 0;
@@ -499,7 +497,7 @@ Obj ObjInt_Int( Int i )
 {
   Obj gmp;
 
-  if ( (-(1L<<NR_SMALL_INT_BITS) <= i) && (i < 1L<<NR_SMALL_INT_BITS )) {
+  if (INT_INTOBJ_MIN <= i && i <= INT_INTOBJ_MAX) {
     return INTOBJ_INT(i);
   }
   else if (i < 0 ) {
@@ -516,9 +514,7 @@ Obj ObjInt_Int( Int i )
 Obj ObjInt_UInt( UInt i )
 {
   Obj gmp;
-  UInt bound = 1UL << NR_SMALL_INT_BITS;
-
-  if (i < bound) {
+  if (i <= INT_INTOBJ_MAX) {
     return INTOBJ_INT(i);
   }
   else {
@@ -532,9 +528,9 @@ Obj ObjInt_UInt( UInt i )
 Obj ObjInt_UIntInv( UInt i )
 {
   Obj gmp;
-  UInt bound = 1UL << NR_SMALL_INT_BITS;
-
-  if (i <= bound) {
+  // we need INT_INTOBJ_MIN <= -i; to express this with unsigned values, we
+  // must evaluate all negative terms, which leads to this equivalent check:
+  if (i <= -INT_INTOBJ_MIN) {
     return INTOBJ_INT(-i);
   }
   else {
@@ -1287,9 +1283,9 @@ Obj AInvInt ( Obj gmp )
   if ( IS_INTOBJ( gmp ) ) {
     
     /* special case (ugh)                                              */
-    if ( gmp == INTOBJ_INT( -(1L<<NR_SMALL_INT_BITS) ) ) {
+    if ( gmp == INTOBJ_MIN ) {
       inv = NewBag( T_INTPOS, sizeof(mp_limb_t) );
-      SET_VAL_LIMB0( inv, 1L<<NR_SMALL_INT_BITS );
+      SET_VAL_LIMB0( inv, -INT_INTOBJ_MIN );
     }
     
     /* general case                                                    */
@@ -1302,9 +1298,8 @@ Obj AInvInt ( Obj gmp )
   else {
     if ( IS_INTPOS(gmp) ) {
       /* special case                                                        */
-      if ( ( SIZE_INT(gmp) == 1 ) 
-           && ( VAL_LIMB0(gmp) == (1L<<NR_SMALL_INT_BITS) ) ) {
-        return INTOBJ_INT( -(Int) (1L<<NR_SMALL_INT_BITS) );
+      if ( SIZE_INT(gmp) == 1 && VAL_LIMB0(gmp) == -INT_INTOBJ_MIN ) {
+        return INTOBJ_MIN;
       }
       else {
         inv = NewBag( T_INTNEG, SIZE_OBJ(gmp) );
@@ -1334,9 +1329,9 @@ Obj AbsInt( Obj op )
   if ( IS_INTOBJ(op) ) {
     if ( ((Int)op) > 0 ) /* non-negative? */
       return op;
-    else if ( op == INTOBJ_INT(-(1L << NR_SMALL_INT_BITS)) ) {
+    else if ( op == INTOBJ_MIN ) {
       a = NewBag( T_INTPOS, sizeof(mp_limb_t) );
-      SET_VAL_LIMB0( a, (1L << NR_SMALL_INT_BITS) );
+      SET_VAL_LIMB0( a, -INT_INTOBJ_MIN );
       return a;
     } else
       return (Obj)( 2 - (Int)op );
@@ -1515,15 +1510,15 @@ Obj ProdIntObj ( Obj n, Obj op )
   /* <res> = 0 means that <res> is the neutral element                     */
   else if ( IS_INTOBJ(n) && INT_INTOBJ(n) >   1 ) {
     res = 0;
-    k = 1L << (NR_SMALL_INT_BITS+1);
+    k = 1L << NR_SMALL_INT_BITS;
     l = INT_INTOBJ(n);
-    while ( 1 < k ) {
+    while ( 0 < k ) {
       res = (res == 0 ? res : SUM( res, res ));
-      k = k / 2;
       if ( k <= l ) {
         res = (res == 0 ? op : SUM( res, op ));
         l = l - k;
       }
+      k = k / 2;
     }
   }
   
@@ -1683,15 +1678,15 @@ Obj             PowObjInt ( Obj op, Obj n )
   /* <res> = 0 means that <res> is the neutral element                   */
   else if ( IS_INTOBJ(n) && INT_INTOBJ(n) >   0 ) {
     res = 0;
-    k = 1L << (NR_SMALL_INT_BITS+1);
+    k = 1L << NR_SMALL_INT_BITS;
     l = INT_INTOBJ(n);
-    while ( 1 < k ) {
+    while ( 0 < k ) {
       res = (res == 0 ? res : PROD( res, res ));
-      k = k / 2;
       if ( k <= l ) {
         res = (res == 0 ? op : PROD( res, op ));
         l = l - k;
       }
+      k = k / 2;
     }
   }
   
@@ -1775,10 +1770,10 @@ Obj ModInt ( Obj opL, Obj opR )
   else if ( IS_INTOBJ(opL) ) {
     
     /* the small int -(1<<28) mod the large int (1<<28) is 0               */
-    if ( opL == INTOBJ_INT(-(Int)(1L<<NR_SMALL_INT_BITS) )
+    if ( opL == INTOBJ_MIN
          && ( IS_INTPOS(opR) )
          && ( SIZE_INT(opR) == 1 )
-         && ( VAL_LIMB0(opR) == (mp_limb_t)(1L<<NR_SMALL_INT_BITS) ) )
+         && ( VAL_LIMB0(opR) == -INT_INTOBJ_MIN ) )
       mod = INTOBJ_INT(0);
     
     /* in all other cases the remainder is equal the left operand          */
@@ -1797,13 +1792,13 @@ Obj ModInt ( Obj opL, Obj opR )
     i = INT_INTOBJ(opR);  if ( i < 0 )  i = -i;
     
     /* check whether right operand is a small power of 2                   */
-    if ( i <= (1L<<NR_SMALL_INT_BITS) && !(i & (i-1)) ) {
+    if ( !(i & (i-1)) ) {
       c = VAL_LIMB0(opL) & (i-1);
     }
     
     /* otherwise use the gmp function to divide                            */
     else {
-      c = mpn_mod_1( CONST_ADDR_INT(opL), SIZE_INT(opL), (mp_limb_t)i );
+      c = mpn_mod_1( CONST_ADDR_INT(opL), SIZE_INT(opL), i );
     }
     
     /* now c is the result, it has the same sign as the left operand       */
@@ -1906,10 +1901,9 @@ Obj QuoInt ( Obj opL, Obj opR )
   if ( ARE_INTOBJS( opL, opR ) ) {
     
     /* the small int -(1<<28) divided by -1 is the large int (1<<28)       */
-    if ( opL == INTOBJ_INT(-(Int)(1L<<NR_SMALL_INT_BITS)) 
-         && opR == INTOBJ_INT(-1) ) {
+    if ( opL == INTOBJ_MIN && opR == INTOBJ_INT(-1) ) {
       quo = NewBag( T_INTPOS, sizeof(mp_limb_t) );
-      SET_VAL_LIMB0( quo, 1L<<NR_SMALL_INT_BITS );
+      SET_VAL_LIMB0( quo, -INT_INTOBJ_MIN );
       return quo;
     }
     
@@ -1930,9 +1924,9 @@ Obj QuoInt ( Obj opL, Obj opR )
   else if ( IS_INTOBJ(opL) ) {
     
     /* the small int -(1<<28) divided by the large int (1<<28) is -1       */
-    if ( opL == INTOBJ_INT(-(Int)(1L<<NR_SMALL_INT_BITS))
+    if ( opL == INTOBJ_MIN
          && IS_INTPOS(opR) && SIZE_INT(opR) == 1
-         && VAL_LIMB0(opR) == 1L<<NR_SMALL_INT_BITS )
+         && VAL_LIMB0(opR) == -INT_INTOBJ_MIN )
       quo = INTOBJ_INT(-1);
     
     /* in all other cases the quotient is of course zero                   */
@@ -2060,9 +2054,9 @@ Obj RemInt ( Obj opL, Obj opR )
   else if ( IS_INTOBJ(opL) ) {
     
     /* the small int -(1<<28) rem the large int (1<<28) is 0               */
-    if ( opL == INTOBJ_INT(-(Int)(1L<<NR_SMALL_INT_BITS))
+    if ( opL == INTOBJ_MIN
          && IS_INTPOS(opR) && SIZE_INT(opR) == 1
-         && VAL_LIMB0(opR) == 1L<<NR_SMALL_INT_BITS )
+         && VAL_LIMB0(opR) == -INT_INTOBJ_MIN )
       rem = INTOBJ_INT(0);
     
     /* in all other cases the remainder is equal the left operand          */
@@ -2077,7 +2071,7 @@ Obj RemInt ( Obj opL, Obj opR )
     i = INT_INTOBJ(opR);  if ( i < 0 )  i = -i;
 
     /* check whether right operand is a small power of 2                   */
-    if ( i <= (1L<<NR_SMALL_INT_BITS) && !(i & (i-1)) ) {
+    if ( !(i & (i-1)) ) {
       c = VAL_LIMB0(opL) & (i-1);
     }
     

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -27,21 +27,6 @@
 
 /****************************************************************************
 **
-*F  FuncSIZE_OBJ(<self>,<obj>)
-**
-**  'SIZE_OBJ( <obj> )' returns the size of a nonimmediate object. It can be
-**  used to debug memory use.
-*/
-Obj             FuncSIZE_OBJ (
-    Obj                 self,
-    Obj                 a)
-{
-  return INTOBJ_INT(SIZE_OBJ(a));
-}
-
-
-/****************************************************************************
-**
 ** * * * * * * * "Mersenne twister" random numbers  * * * * * * * * * * * * *
 **
 **  Part of this code for fast generation of 32 bit pseudo random numbers with
@@ -727,7 +712,6 @@ static StructGVarFunc GVarFuncs [] = {
 
 
     GVAR_FUNC(HASHKEY_BAG, 4, "obj, int,int,int"),
-    GVAR_FUNC(SIZE_OBJ, 1, "obj"),
     GVAR_FUNC(InitRandomMT, 1, "initstr"),
     GVAR_FUNC(MAKE_BITFIELDS, -1, "widths"),
     GVAR_FUNC(BUILD_BITFIELDS, -2, "widths, vals"),

--- a/src/intobj.h
+++ b/src/intobj.h
@@ -41,6 +41,15 @@ a
 #define NR_SMALL_INT_BITS  (32 - 4)
 #endif
 
+// the minimal / maximal possible values of an immediate integer object:
+#define INT_INTOBJ_MIN  (-(1L << NR_SMALL_INT_BITS))
+#define INT_INTOBJ_MAX  ((1L << NR_SMALL_INT_BITS) - 1)
+
+// the minimal / maximal possible immediate integer objects:
+#define INTOBJ_MIN  INTOBJ_INT(INT_INTOBJ_MIN)
+#define INTOBJ_MAX  INTOBJ_INT(INT_INTOBJ_MAX)
+
+
 /****************************************************************************
 **
 *F  IS_INTOBJ( <o> )  . . . . . . . .  test if an object is an integer object
@@ -121,6 +130,7 @@ static inline Int INT_INTOBJ(Obj o)
 static inline Obj INTOBJ_INT(Int i)
 {
     Obj o;
+    GAP_ASSERT(INT_INTOBJ_MIN <= i && i <= INT_INTOBJ_MAX);
     o = (Obj)(((UInt)i << 2) + 0x01);
     GAP_ASSERT(INT_INTOBJ(o) == i);
     return o;

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2258,7 +2258,7 @@ void            IntrListExprEnd (
         /* else make the range                                             */
         else {
             /* length must be a small integer as well */
-            if ((high-low) / inc + 1 >= (1L<<NR_SMALL_INT_BITS)) {
+            if ((high-low) / inc >= INT_INTOBJ_MAX) {
                 ErrorQuit("Range: the length of a range must be less than 2^%d",
                            NR_SMALL_INT_BITS, 0L);
             }

--- a/src/opers.c
+++ b/src/opers.c
@@ -1800,7 +1800,7 @@ static void FixTypeIDs( Bag b ) {
 
 Obj FuncCOMPACT_TYPE_IDS( Obj self )
 {
-  NextTypeID = -(1L << NR_SMALL_INT_BITS);
+  NextTypeID = INT_INTOBJ_MIN;
   CallbackForAllBags( FixTypeIDs );
   CALL_0ARGS(FLUSH_ALL_METHOD_CACHES);
   return INTOBJ_INT(NextTypeID);

--- a/src/plist.c
+++ b/src/plist.c
@@ -67,8 +67,13 @@ Int             GrowPlist (
     UInt                plen;           /* new physical length             */
     UInt                good;           /* good new physical length        */
 
+    if (need > INT_INTOBJ_MAX)
+        ErrorMayQuit("GrowPlist: List size too large", 0, 0);
+
     /* find out how large the plain list should become                     */
     good = 5 * (SIZE_OBJ(list)/sizeof(Obj)-1) / 4 + 4;
+    if (good > INT_INTOBJ_MAX)
+        good = INT_INTOBJ_MAX;
 
     /* but maybe we need more                                              */
     if ( need < good ) { plen = good; }

--- a/src/plist.h
+++ b/src/plist.h
@@ -40,6 +40,7 @@
 static inline Obj NEW_PLIST(UInt type, Int plen)
 {
     GAP_ASSERT(plen >= 0);
+    GAP_ASSERT(plen <= INT_INTOBJ_MAX);
     return NewBag(type, (plen + 1) * sizeof(Obj));
 }
 

--- a/tst/testbugfix/2007-08-31-t00192.tst
+++ b/tst/testbugfix/2007-08-31-t00192.tst
@@ -1,8 +1,8 @@
 # 2007/08/31 (FL)
 gap> # Quotient to yield the same on 32- and 64-bit systems
-gap> SHALLOW_SIZE([1])/GAPInfo.BytesPerVariable;
+gap> SIZE_OBJ([1])/GAPInfo.BytesPerVariable;
 2
-gap> SHALLOW_SIZE(List([1..160],i->i^2))/GAPInfo.BytesPerVariable;
+gap> SIZE_OBJ(List([1..160],i->i^2))/GAPInfo.BytesPerVariable;
 161
 gap> [ShrinkAllocationPlist, ShrinkAllocationString];;
 gap> [EmptyPlist, EmptyString];;                                               

--- a/tst/testinstall/opers/MemoryUsage.tst
+++ b/tst/testinstall/opers/MemoryUsage.tst
@@ -61,7 +61,7 @@ gap> (MemoryUsage([1..100]) - MU_MemBagHeader) / GAPInfo.BytesPerVariable;
 # test component objects
 #
 gap> G := Group(g);;
-gap> MemoryUsage(G) = SHALLOW_SIZE(G) + MU_MemBagHeader + MU_MemPointer
+gap> MemoryUsage(G) = SIZE_OBJ(G) + MU_MemBagHeader + MU_MemPointer
 > + Sum(NamesOfComponents(G), n -> MemoryUsage(G!.(n)));
 true
 
@@ -84,21 +84,21 @@ gap> F := FreeGroup(3);;
 gap> w := One(F);;
 gap> w:=Product(GeneratorsOfGroup(F))^3;
 (f1*f2*f3)^3
-gap> MemoryUsage(w![1]) = SHALLOW_SIZE(w![1]) + MU_MemBagHeader + MU_MemPointer;
+gap> MemoryUsage(w![1]) = SIZE_OBJ(w![1]) + MU_MemBagHeader + MU_MemPointer;
 true
-gap> MemoryUsage(w) = SHALLOW_SIZE(w) + MU_MemBagHeader + MU_MemPointer + MemoryUsage(w![1]);
+gap> MemoryUsage(w) = SIZE_OBJ(w) + MU_MemBagHeader + MU_MemPointer + MemoryUsage(w![1]);
 true
 gap> o := ExtRepOfObj(w);
 [ 1, 1, 2, 1, 3, 1, 1, 1, 2, 1, 3, 1, 1, 1, 2, 1, 3, 1 ]
-gap> MemoryUsage(o) = SHALLOW_SIZE(o) + MU_MemBagHeader + MU_MemPointer;
+gap> MemoryUsage(o) = SIZE_OBJ(o) + MU_MemBagHeader + MU_MemPointer;
 true
 
 #
 # test functions
 #
-gap> f:=x->x;; MemoryUsage(f) - SHALLOW_SIZE(f) in [160, 96];
+gap> f:=x->x;; MemoryUsage(f) - SIZE_OBJ(f) in [160, 96];
 true
-gap> f:=x->x+1;; MemoryUsage(f) - SHALLOW_SIZE(f) in [184, 112];
+gap> f:=x->x+1;; MemoryUsage(f) - SIZE_OBJ(f) in [184, 112];
 true
 gap> MemoryUsage(f) = MemoryUsage(f);
 true


### PR DESCRIPTION
This is a rebased version of PR #2039, with the fixup commit squashed, and a new size restriction assert added to `NEW_PLIST`. As such, it addresses parts of issue #1479 (but does not fully resolve it; at least one overflow bug in GASMAN needs to be fixed, as well a bug in one of the GNU libc `memmove` implementations).

I also provided a new, extensive commit message for the second commit, and since that now makes the majority of the work in that commit, took the liberty of changing authorship of that commit to myself. Here is the new commit message:


By adding bounds checks to GrowPlist and NEW_PLIST, we restrict the capacity
of plain lists to the maximum value of an immediate integer, i.e. 2^28 on a
32 bit system and 2^60 on a 64 bit system. The check in GrowPlist triggers
an error, as it can be triggered by the user. The check in NEW_PLIST is a
run-time assertion, and should never be triggered by user actions, only by
buggy kernel code.

This restriction fixes overflows and other problems, which can lead to
crashes, corrupt data or nonsense computations.

It poses no actual limitation in practice, for the following reasons:

First off, many other places already effectively limited the length of a
plist they can interact with to the maximum value of an immediate integer.
E.g. such limitations exist for sublist access via l{poss}, EmptyPlist(),
ASS_PLIST_DEFAULT, and more.

Secondly, with this change,  the effective size (in bytes) of a plist of
this maximal length would be 2^30 resp. 2^63. The latter certainly poses no
actual limitation. The former corresponds to 1 GB. Conceivably, GAP could
support slightly larger bags on a 32bit system (the GASMAN heap can grow up
to 3GB if the host system supports it). However, there is not much you can
do with GAP if most of its heap is filled with a single gigantic plist, so
this restriction seems acceptable.