### PR TITLE
GASMAN and kernel tweaks

### DIFF
--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -630,6 +630,6 @@ void MarkAllSubBags(Bag bag)
 {
 }
 
-void MarkArrayOfBags(Bag array[], int count)
+void MarkArrayOfBags(const Bag array[], UInt count)
 {
 }

--- a/src/calls.c
+++ b/src/calls.c
@@ -944,14 +944,11 @@ void InitHandlerFunc (
         Pr( "No room left for function handler\n", 0L, 0L );
         SyExit(1);
     }
-#ifdef DEBUG_HANDLER_REGISTRATION
-    {
-      UInt i;
-      for (i = 0; i < NHandlerFuncs; i++)
+
+    for (UInt i = 0; i < NHandlerFuncs; i++)
         if (!strcmp(HandlerFuncs[i].cookie, cookie))
-          Pr("Duplicate cookie %s\n", (Int)cookie, 0L);
-    }
-#endif
+            Pr("Duplicate cookie %s\n", (Int)cookie, 0L);
+
     HandlerFuncs[NHandlerFuncs].hdlr   = hdlr;
     HandlerFuncs[NHandlerFuncs].cookie = cookie;
     HandlerSortingStatus = 0; /* no longer sorted by handler or cookie */
@@ -964,9 +961,6 @@ void InitHandlerFunc (
 **
 *f  CheckHandlersBag( <bag> ) . . . . . . check that handlers are initialised
 */
-
-#ifdef DEBUG_HANDLER_REGISTRATION
-
 static void CheckHandlersBag(
     Bag         bag )
 {
@@ -994,13 +988,10 @@ static void CheckHandlersBag(
     }
 }
 
-void CheckAllHandlers(
-       void )
+void CheckAllHandlers(void)
 {
-  CallbackForAllBags( CheckHandlersBag);
+    CallbackForAllBags(CheckHandlersBag);
 }
-
-#endif
 
 static int IsLessHandlerInfo (
     TypeHandlerInfo *           h1, 

--- a/src/calls.h
+++ b/src/calls.h
@@ -362,6 +362,9 @@ extern ObjFunc HandlerOfCookie (
 
 extern void SortHandlers( UInt byWhat );
 
+extern void CheckAllHandlers(void);
+
+
 /****************************************************************************
 **
 *F  NewFunction( <name>, <narg>, <nams>, <hdlr> )  . . .  make a new function

--- a/src/gap.c
+++ b/src/gap.c
@@ -3191,9 +3191,7 @@ void InitializeGap (
 #       if !defined(BOEHM_GC)
             WarnInitGlobalBag = 1;
 #       endif
-#       ifdef DEBUG_HANDLER_REGISTRATION
-            CheckAllHandlers();
-#       endif
+        CheckAllHandlers();
 
         SyInitializing = 1;    
         for ( i = 0;  i < NrBuiltinModules;  i++ ) {

--- a/src/gap.c
+++ b/src/gap.c
@@ -3088,11 +3088,11 @@ void InitializeGap (
         }
         info = InitFuncsBuiltinModules[i]();
         Modules[NrModules++].info = info;
-#       ifdef DEBUG_LOADING
+        if (SyDebugLoading) {
             FPUTS_TO_STDERR( "#I  InitInfo(builtin " );
             FPUTS_TO_STDERR( info->name );
             FPUTS_TO_STDERR( ")\n" );
-#       endif
+        }
     }
     NrBuiltinModules = NrModules;
 
@@ -3100,11 +3100,11 @@ void InitializeGap (
     for ( i = 0;  i < NrBuiltinModules;  i++ ) {
         info = Modules[i].info;
         if ( info->initKernel ) {
-#           ifdef DEBUG_LOADING
+            if (SyDebugLoading) {
                 FPUTS_TO_STDERR( "#I  InitKernel(builtin " );
                 FPUTS_TO_STDERR( info->name );
                 FPUTS_TO_STDERR( ")\n" );
-#           endif
+            }
             ret =info->initKernel( info );
             if ( ret ) {
                 FPUTS_TO_STDERR( "#I  InitKernel(builtin " );
@@ -3123,7 +3123,7 @@ void InitializeGap (
     InitFopyGVar( "POST_RESTORE", &POST_RESTORE);
 
 #ifdef COUNT_BAGS
-#   ifdef DEBUG_LOADING
+    if (SyDebugLoading) {
         if ( SyRestoring ) {
             Pr( "#W  after setup\n", 0L, 0L );
             Pr( "#W  %36s ", (Int)"type",  0L          );
@@ -3143,7 +3143,7 @@ void InitializeGap (
                 }
             }
         }
-#   endif
+    }
 #endif
 
 #ifndef BOEHM_GC
@@ -3160,11 +3160,11 @@ void InitializeGap (
         for ( i = 0;  i < NrModules;  i++ ) {
             info = Modules[i].info;
             if ( info->postRestore ) {
-#               ifdef DEBUG_LOADING
+                if (SyDebugLoading) {
                     FPUTS_TO_STDERR( "#I  PostRestore(builtin " );
                     FPUTS_TO_STDERR( info->name );
                     FPUTS_TO_STDERR( ")\n" );
-#               endif
+                }
                 ret = info->postRestore( info );
                 if ( ret ) {
                     FPUTS_TO_STDERR( "#I  PostRestore(builtin " );
@@ -3197,11 +3197,11 @@ void InitializeGap (
         for ( i = 0;  i < NrBuiltinModules;  i++ ) {
             info = Modules[i].info;
             if ( info->initLibrary ) {
-#               ifdef DEBUG_LOADING
+                if (SyDebugLoading) {
                     FPUTS_TO_STDERR( "#I  InitLibrary(builtin " );
                     FPUTS_TO_STDERR( info->name );
                     FPUTS_TO_STDERR( ")\n" );
-#               endif
+                }
                 ret = info->initLibrary( info );
                 if ( ret ) {
                     FPUTS_TO_STDERR( "#I  InitLibrary(builtin " );
@@ -3219,11 +3219,11 @@ void InitializeGap (
     for ( i = 0;  i < NrModules;  i++ ) {
         info = Modules[i].info;
         if ( info->checkInit ) {
-#           ifdef DEBUG_LOADING
+            if (SyDebugLoading) {
                 FPUTS_TO_STDERR( "#I  CheckInit(builtin " );
                 FPUTS_TO_STDERR( info->name );
                 FPUTS_TO_STDERR( ")\n" );
-#           endif
+            }
             ret = info->checkInit( info );
             if ( ret ) {
                 FPUTS_TO_STDERR( "#I  CheckInit(builtin " );

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -440,14 +440,12 @@ TNumInfoBags            InfoBags [ NTYPES ];
 
 /****************************************************************************
 **
-*F  IS_BAG -- check if a value looks like a masterpointer reference.
+*F  IS_BAG_ID -- check if a value looks like a masterpointer id
 */
-static inline UInt IS_BAG (
-    UInt                bid )
+static inline UInt IS_BAG_ID(void * ptr)
 {
-    return (((UInt)MptrBags <= bid)
-         && (bid < (UInt)OldBags)
-         && (bid & (sizeof(Bag)-1)) == 0);
+    return (((void *)MptrBags <= ptr) && (ptr < (void *)OldBags) &&
+            ((UInt)ptr & (sizeof(Bag) - 1)) == 0);
 }
 
 /****************************************************************************
@@ -648,9 +646,7 @@ void MarkAllSubBagsDefault( Bag bag )
 // to start with).
 inline void MarkBag( Bag bag )
 {
-  if ( (((UInt)bag) & (sizeof(Bag)-1)) == 0 /* really looks like a pointer */
-       && (Bag)MptrBags <= bag              /* in plausible range */
-       && bag < (Bag)OldBags                /*  "    "       "    */
+  if ( IS_BAG_ID(bag)
        && YoungBags < PTR_BAG(bag)          /*  points to a young bag */
        && PTR_BAG(bag) <= AllocBags         /*    "     " "  "     "  */
        && (IS_MARKED_DEAD(bag) || IS_MARKED_HALFDEAD(bag)) )
@@ -662,9 +658,7 @@ inline void MarkBag( Bag bag )
 
 void MarkBagWeakly( Bag bag )
 {
-  if ( (((UInt)bag) & (sizeof(Bag)-1)) == 0 /* really looks like a pointer */
-       && (Bag)MptrBags <= bag              /* in plausible range */
-       && bag < (Bag)OldBags                /*  "    "       "    */
+  if ( IS_BAG_ID(bag)
        && YoungBags < PTR_BAG(bag)          /*  points to a young bag */
        && PTR_BAG(bag) <= AllocBags         /*    "     " "  "     "  */
        && IS_MARKED_DEAD(bag) )             /*  and not marked already */
@@ -2016,8 +2010,7 @@ again:
           Bag *mptr = (Bag *)*p;
           if ( mptr == OldWeakDeadBagMarker)
             NrHalfDeadBags--;
-          if ( mptr == OldWeakDeadBagMarker || IS_BAG((UInt)mptr) || mptr == 0)
-            {
+          if (mptr == OldWeakDeadBagMarker || IS_BAG_ID(mptr) || mptr == 0) {
               *p = FreeMptrBags;
               FreeMptrBags = (Bag)p;
             }
@@ -2250,7 +2243,7 @@ UInt BID( Bag bag )
 Bag BAG (
     UInt                bid )
 {
-    if ( IS_BAG(bid) )
+    if (IS_BAG_ID(bid))
         return (Bag) bid;
     else
         return (Bag) 0;

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -478,20 +478,10 @@ void InitSweepFuncBags (
     UInt                type,
     TNumSweepFuncBags    sweep_func )
 {
-#ifdef CHECK_FOR_CLASH_IN_INIT_SWEEP_FUNC
-    char                str[256];
-
     if ( TabSweepFuncBags[type] != 0 ) {
-        str[0] = 0;
-        strncat( str, "warning: sweep function for type ", 33 );
-        str[33] = '0' + ((type/100) % 10);
-        str[34] = '0' + ((type/ 10) % 10);
-        str[35] = '0' + ((type/  1) % 10);
-        str[36] = 0;
-        strncat( str, " already installed\n", 19 );
-        SyFputs( str, 0 );
+        Pr("warning: sweep function for type %d already installed\n", type, 0);
     }
-#endif
+
     TabSweepFuncBags[type] = sweep_func;
 }
 
@@ -519,20 +509,10 @@ void InitMarkFuncBags (
     UInt                type,
     TNumMarkFuncBags    mark_func )
 {
-#ifdef CHECK_FOR_CLASH_IN_INIT_MARK_FUNC
-    char                str[256];
-
     if ( TabMarkFuncBags[type] != MarkAllSubBagsDefault ) {
-        str[0] = 0;
-        strncat( str, "warning: mark function for type ", 32 );
-        str[32] = '0' + ((type/100) % 10);
-        str[33] = '0' + ((type/ 10) % 10);
-        str[34] = '0' + ((type/  1) % 10);
-        str[35] = 0;
-        strncat( str, " already installed\n", 19 );
-        SyFputs( str, 0 );
+        Pr("warning: mark function for type %d already installed\n", type, 0);
     }
-#endif
+
     TabMarkFuncBags[type] = mark_func;
 }
 
@@ -757,18 +737,18 @@ void InitGlobalBag (
         (*AbortFuncBags)(
             "Panic: Gasman cannot handle so many global variables" );
     }
-#ifdef DEBUG_GLOBAL_BAGS
-    {
-      UInt i;
-      if (cookie != (Char *)0)
-        for (i = 0; i < GlobalBags.nr; i++)
-          if ( 0 == strcmp(GlobalBags.cookie[i], cookie) )
-            if (GlobalBags.addr[i] == addr)
-              Pr("Duplicate global bag entry %s\n", (Int)cookie, 0L);
-            else
-              Pr("Duplicate global bag cookie %s\n", (Int)cookie, 0L);
+
+    if (cookie != 0) {
+        for (UInt i = 0; i < GlobalBags.nr; i++) {
+            if (0 == strcmp(GlobalBags.cookie[i], cookie)) {
+                if (GlobalBags.addr[i] == addr)
+                    Pr("Duplicate global bag entry %s\n", (Int)cookie, 0L);
+                else
+                    Pr("Duplicate global bag cookie %s\n", (Int)cookie, 0L);
+            }
+        }
     }
-#endif
+
     if ( WarnInitGlobalBag ) {
         Pr( "#W  global bag '%s' initialized\n", (Int)cookie, 0L );
     }
@@ -777,7 +757,6 @@ void InitGlobalBag (
     GlobalBags.nr++;
     GlobalSortingStatus = 0;
 }
-
 
 
 static Int IsLessGlobal (
@@ -919,18 +898,16 @@ Bag NextBagRestoring( UInt type, UInt flags, UInt size )
   header->size = size;
   header->link = NextMptrRestoring;
   NextMptrRestoring++;
-#ifdef DEBUG_LOADING
+
   if ((Bag *)NextMptrRestoring >= OldBags)
     (*AbortFuncBags)("Overran Masterpointer area");
-#endif
 
   for (i = 0; i < WORDS_BAG(size); i++)
     *AllocBags++ = (Bag)0;
 
-#ifdef DEBUG_LOADING
   if (AllocBags > EndBags)
     (*AbortFuncBags)("Overran data area");
-#endif
+
 #ifdef COUNT_BAGS
   InfoBags[type].nrLive   += 1;
   InfoBags[type].nrAll    += 1;

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -672,15 +672,13 @@ void MarkBagWeakly(Bag bag)
 **  walking the masterpointer area. Not terribly safe.
 **
 */
-void CallbackForAllBags(
-     void (*func)(Bag) )
+void CallbackForAllBags(void (*func)(Bag))
 {
-  Bag ptr;
-  for (ptr = (Bag)MptrBags; ptr < (Bag)OldBags; ptr ++)
-    if (*ptr != 0 && !IS_WEAK_DEAD_BAG(ptr) && (Bag)(*ptr) >= (Bag)OldBags)
-      {
-        (*func)(ptr);
-      }
+    for (Bag bag = (Bag)MptrBags; bag < (Bag)OldBags; bag++) {
+        if (IS_BAG_BODY(*bag)) {
+            (*func)(bag);
+        }
+    }
 }
 
 

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -2257,77 +2257,25 @@ void SwapMasterPoint(Bag bag1, Bag bag2)
 
 /****************************************************************************
 **
-*F  BID(<bag>)  . . . . . . . . . . . .  bag identifier (as unsigned integer)
-*F  IS_BAG(<bid>) . . . . . .  test whether a bag identifier identifies a bag
 *F  BAG(<bid>)  . . . . . . . . . . . . . . . . . . bag (from bag identifier)
-*F  TNUM_BAG(<bag>) . . . . . . . . . . . . . . . . . . . . . . type of a bag
-*F  SIZE_BAG(<bag>) . . . . . . . . . . . . . . . . . . . . . . size of a bag
-*F  PTR_BAG(<bag>)  . . . . . . . . . . . . . . . . . . . .  pointer to a bag
 *F  ELM_BAG(<bag>,<i>)  . . . . . . . . . . . . . . . <i>-th element of a bag
 *F  SET_ELM_BAG(<bag>,<i>,<elm>)  . . . . . . . . set <i>-th element of a bag
 **
-**  'BID', 'IS_BAG', 'BAG', 'TNUM_BAG', 'TNAM_BAG', 'PTR_BAG', 'ELM_BAG', and
-**  'SET_ELM_BAG' are functions to support  debugging.  They are not intended
-**  to be used  in an application  using {\Gasman}.  Note  that the functions
-**  'TNUM_BAG', 'SIZE_BAG', and 'PTR_BAG' shadow the macros of the same name,
-**  which are usually not available in a debugger.
+**  'BAG', 'ELM_BAG', and 'SET_ELM_BAG' are functions to support  debugging.
+**  They are not intended to be used in an application using {\Gasman}.
 */
-
-#ifdef  DEBUG_FUNCTIONS_BAGS
-
-#undef  TNUM_BAG
-#undef  SIZE_BAG
-#undef  PTR_BAG
-
-UInt BID( Bag bag )
+Bag BAG(UInt bid)
 {
-    return (UInt) bag;
+    return IS_BAG_ID((Bag)bid) ? (Bag)bid : 0;
 }
 
-
-Bag BAG (
-    UInt                bid )
-{
-    if (IS_BAG_ID(bid))
-        return (Bag) bid;
-    else
-        return (Bag) 0;
-}
-
-UInt TNUM_BAG( Bag bag )
-{
-    return BAG_HEADER(bag)->type;
-}
-
-const Char * TNAM_BAG( Bag bag )
-{
-    return InfoBags[ BAG_HEADER(bag)->type ].name;
-}
-
-UInt SIZE_BAG( Bag bag )
-{
-    return BAG_HEADER(bag)->size;
-}
-
-Bag * PTR_BAG( Bag bag )
-{
-    return (*(Bag**)(bag));
-}
-
-UInt ELM_BAG (
-    Bag                 bag,
-    UInt                i )
+UInt ELM_BAG(Bag bag, UInt i)
 {
     return (UInt) ((*(Bag**)(bag))[i]);
 }
 
-UInt SET_ELM_BAG (
-    Bag                 bag,
-    UInt                i,
-    UInt                elm )
+UInt SET_ELM_BAG(Bag bag, UInt i, UInt elm)
 {
-    (*(Bag**)(bag))[i] = (Bag) elm;
+    (*(Bag **)(bag))[i] = (Bag)elm;
     return elm;
 }
-
-#endif

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -636,7 +636,7 @@ extern  UInt                    NrHalfDeadBags;
 **  <type> that have been allocated.
 **
 **  This  information is only  kept if {\Gasman} is  compiled with the option
-**  '-DCOUNT_BAGS', e.g., with 'make <target> COPTS=-DCOUNT_BAGS'.
+**  'COUNT_BAGS' defined.
 */
 typedef struct  {
     const Char *            name;
@@ -970,7 +970,7 @@ extern TNumGlobalBags GlobalBags;
 **  There is a limit on the number of calls to 'InitGlobalBag', which is 20000
 **  by default.   If the application has  more global variables that may hold
 **  bag  identifier, you  have to  compile  {\Gasman} with a  higher value of
-**  'NR_GLOBAL_BAGS', i.e., with 'make COPTS=-DNR_GLOBAL_BAGS=<nr>'.
+**  'NR_GLOBAL_BAGS'.
 **
 **  <cookie> is a C string, which should uniquely identify this global
 **  bag from all others.  It is used  in reconstructing  the Workspace

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -370,7 +370,7 @@ extern Bag * YoungBags;
 extern Bag   ChangedBags;
 static inline void CHANGED_BAG(Bag bag)
 {
-    if (PTR_BAG(bag) <= YoungBags && LINK_BAG(bag) == bag) {
+    if (CONST_PTR_BAG(bag) <= YoungBags && LINK_BAG(bag) == bag) {
         LINK_BAG(bag) = ChangedBags;
         ChangedBags = bag;
     }
@@ -866,9 +866,7 @@ extern void MarkBagWeakly( Bag bag );
 **  'MarkArrayOfBags' iterates over <count> all bags in the given array,
 **  and marks each bag using MarkBag.
 */
-extern void MarkArrayOfBags( Bag array[], int count );
-
-
+extern void MarkArrayOfBags(const Bag array[], UInt count);
 
 
 /****************************************************************************

--- a/src/integer.c
+++ b/src/integer.c
@@ -626,7 +626,7 @@ Int Int_ObjInt(Obj i)
 UInt UInt_ObjInt(Obj i)
 {
     if (IS_NEG_INT(i))
-        ErrorMayQuit("Conversion: negative integer into unsigned type", 0, 0);
+        ErrorMayQuit("Conversion error, cannot convert negative integer to unsigned type", 0, 0);
     if (IS_INTOBJ(i))
         return (UInt)INT_INTOBJ(i);
     if (TNUM_BAG(i) != T_INTPOS)
@@ -645,10 +645,10 @@ Int8 Int8_ObjInt(Obj i)
     // in this case Int8 is Int
     return Int_ObjInt(i);
 #else
-    UInt sign = 0;
     if (IS_INTOBJ(i))
         return (Int8)INT_INTOBJ(i);
-    // must be at most two limbs
+
+    UInt sign = 0;
     if (TNUM_BAG(i) == T_INTPOS)
         sign = 0;
     else if (TNUM_BAG(i) == T_INTNEG)
@@ -657,6 +657,7 @@ Int8 Int8_ObjInt(Obj i)
         ErrorMayQuit("Conversion error, expecting an integer, not a %s",
                      (Int)TNAM_OBJ(i), 0);
 
+    // must be at most two limbs
     if (SIZE_INT(i) > 2)
         ErrorMayQuit("Conversion error, integer too large", 0L, 0L);
     UInt  vall = ADDR_INT(i)[0];
@@ -679,7 +680,7 @@ UInt8 UInt8_ObjInt(Obj i)
     return UInt_ObjInt(i);
 #else
     if (IS_NEG_INT(i))
-        ErrorMayQuit("Conversion: negative integer into unsigned type", 0, 0);
+        ErrorMayQuit("Conversion error, cannot convert negative integer to unsigned type", 0, 0);
     if (IS_INTOBJ(i))
         return (UInt8)INT_INTOBJ(i);
     if (TNUM_BAG(i) != T_INTPOS)
@@ -1725,8 +1726,8 @@ Obj FuncPOW_OBJ_INT ( Obj self, Obj opL, Obj opR )
 **
 *F  ModInt( <intL>, <intR> )  . representative of residue class of an integer
 **
-**  'ModInt' returns the smallest positive representant of the residue  class
-**  of the  integer  <intL>  modulo  the  integer  <intR>.  'ModInt'  handles
+**  'ModInt' returns the smallest positive representative of the residue
+**  class of the integer <intL> modulo the integer <intR>. 'ModInt' handles
 **  operands of type 'T_INT', 'T_INTPOS', 'T_INTNEG'.
 **
 **  It can also be used in the cases that both operands  are  small  integers

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -165,10 +165,10 @@ Obj FuncADD_LIST (
 
 /****************************************************************************
 **
-*F  RemList(<list>) . . . . . . . .  add an object to the end of a list
+*F  RemList(<list>) . . . . . . . .  remove an object from the end of a list
 **
-**  'RemList' removes the last object <obj> from the end  of  the  list  
-** <list>,  and returns it.
+**  'RemList' removes the last object <obj> from the end of the list <list>,
+**  and returns it.
 */
 Obj            RemList (
     Obj                 list)

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -447,16 +447,11 @@ static void LoadBagData ( void )
   flags = LoadUInt1();
   size = LoadUInt();
 
-#ifdef DEBUG_LOADING
-  {
     if (InfoBags[type].name == NULL)
       {
         Pr("Bad type %d, size %d\n",type,size);
         exit(1);
       }
-  }
-  
-#endif  
 
   /* Get GASMAN to set up the bag for me */
   bag = NextBagRestoring( type, flags, size );

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -885,9 +885,8 @@ void LoadWorkspace( Char * fname )
           SyExit(1);
         }
       *glob = LoadSubObj();
-#ifdef DEBUG_LOADING
-      Pr("Restored global %s\n",(Int)buf,0L);
-#endif
+      if (SyDebugLoading)
+          Pr("Restored global %s\n", (Int)buf, 0L);
     }
 
   LoadCStr(buf,256);

--- a/src/system.h
+++ b/src/system.h
@@ -59,12 +59,6 @@
 /* define to get information while restoring                               */
 /* #undef DEBUG_LOADING */
 
-/* define to debug registering of global bags                              */
-/* #undef DEBUG_GLOBAL_BAGS */
-
-/* define to debug registering of function handlers                        */
-/* #undef DEBUG_HANDLER_REGISTRATION */
-
 
 /* * * * * * * * * * * * * debugging GASMAN  * * * * * * * * * * * * * * * */
 

--- a/src/system.h
+++ b/src/system.h
@@ -54,11 +54,6 @@
 *D  debug flags (user edit-able)
 */
 
-/* * * * * * * * * *  saving/loading the workspace * * * * * * * * * * * * */
-
-/* define to get information while restoring                               */
-/* #undef DEBUG_LOADING */
-
 
 /* * * * * * * * * * * * * debugging GASMAN  * * * * * * * * * * * * * * * */
 


### PR DESCRIPTION
While looking into issue #1479 and the memory corruption in GASMAN, I enabled and enhanced various debug options, corrected comments, turned macros into functions etc. The resulting cleanup work is in this PR.

This already revealed a bug in the IO package (where a function cookie was incorrectly used twice).