### PR TITLE
travis: suppress banners when testing manual chapters; use stock version of io & profiling if possible

### DIFF
--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -83,28 +83,19 @@ then
   # reports; and also the IO package, as the profiling package depends on it.
   pushd "$SRCDIR/pkg"
 
-  # HACK: io 4.4.6 (shipped with GAP 4.8.6) directly accesses some GAP internals
-  # (for GASMAN), which we will remove in GAP 4.9. To ensure it works,
-  # we simply grab the latest version from git.
-  # TODO: go back to using the io release on 4.5.0 is out
-  rm -rf io*
-  git clone https://github.com/gap-packages/io
-  cd io
-  # invoke autogen if configure does not exist or is not executable
-  [[ -x configure ]] || ./autogen.sh
-  ./configure $CONFIGFLAGS --with-gaproot=$BUILDDIR
-  make V=1
-  cd ..
+  # On OS X, we only install a minimal set of packages, so clone missing
+  # packages directly from their repositories
+  if [[ ! -d io* ]]
+  then
+    time git clone https://github.com/gap-packages/io
+  fi
+  if [[ ! -d profiling* ]]
+  then
+    time git clone https://github.com/gap-packages/profiling
+  fi
 
-  # HACK: grab the latest profiling version.
-  rm -rf profiling*
-  git clone https://github.com/gap-packages/profiling
-  cd profiling
-  # invoke autogen if configure does not exist or is not executable
-  [[ -x configure ]] || ./autogen.sh
-  ./configure $CONFIGFLAGS --with-gaproot=$BUILDDIR
-  make V=1
-  cd ..
+  # Compile io and profiling packages
+  "$SRCDIR/bin/BuildPackages.sh" --strict --with-gaproot="$BUILDDIR" io* profiling*
 
   popd
 

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -116,7 +116,7 @@ GAPInput
     TESTMANUALSPASS=yes
     for ch in $SRCDIR/tst/testmanuals/*.tst
     do
-        $GAP -L testmanuals.wsp --cover $COVDIR/$(basename $ch).coverage <<GAPInput || TESTMANUALSPASS=no
+        $GAP -b -L testmanuals.wsp --cover $COVDIR/$(basename $ch).coverage <<GAPInput || TESTMANUALSPASS=no
         TestManualChapter("$ch");
         QUIT_GAP(0);
 GAPInput

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -75,8 +75,7 @@ do
       rm -rf NormalizInterface-0.9.8
     fi
 
-    $SRCDIR/bin/BuildPackages.sh --with-gaproot=$BUILDDIR
-    if [[ "$(wc -l < log/fail.log)" -ge 3 ]]
+    if ! "$SRCDIR/bin/BuildPackages.sh" --strict --with-gaproot="$BUILDDIR"
     then
         echo "Some packages failed to build:"
         cat "log/fail.log"


### PR DESCRIPTION
This makes it slightly more convenient to visually scan the Travis logs for `testmanuals` for errors.  