### PR TITLE
Refactor and fix `DeclareAttribute`

### DIFF
--- a/hpcgap/lib/oper.g
+++ b/hpcgap/lib/oper.g
@@ -1104,7 +1104,7 @@ end );
 
 #############################################################################
 ##
-#F  NewAttribute( <name>, <filter>[, "mutable"][, <rank>] ) . . new attribute
+#F  NewAttribute( <name>, <filter>[, <mutable>][, <rank>] ) . . new attribute
 ##
 ##  <#GAPDoc Label="NewAttribute">
 ##  <ManSection>
@@ -1126,16 +1126,20 @@ end );
 ##  applicable to a character table,
 ##  which is neither a list nor a collection.
 ##  <P/>
-##  If the optional third argument is given then there are two possibilities.
-##  Either it is an integer <A>rank</A>,
-##  then the attribute tester has this incremental rank
-##  (see&nbsp;<Ref Sect="Filters"/>).
-##  Or it is the string <C>"mutable"</C>,
-##  then the values of the attribute shall be mutable;
-##  more precisely, when a value of such a mutable attribute is set
-##  then this value itself is stored, not an immutable copy of it.
-##  (So it is the user's responsibility to set an object that is in fact
-##  mutable.)
+##  For the optional third and fourth arguments, there are the following
+##  possibilities.
+##  <List>
+##  <Item> The integer argument <A>rank</A> causes the attribute tester to have
+##  this incremental rank (see&nbsp;<Ref Sect="Filters"/>),
+##  <Item> If the argument <A>mutable</A> is the string <C>"mutable"</C> or
+##  the boolean <C>true</C>, then the values of the attribute are mutable.
+##  <Item> If the argument <A>mutable</A> is the boolean <C>false</C>, then
+##  the values of the attribute are immutable.
+##  </List>
+##  <P/>
+##  When a value of such mutable attribute is set
+##  then this value itself is stored, not an immutable copy of it, 
+##  and it is the user's responsibility to set an object that is mutable.
 ##  This is useful for an attribute whose value is some partial information
 ##  that may be completed later.
 ##  For example, there is an attribute <C>ComputedSylowSubgroups</C>
@@ -1148,7 +1152,7 @@ end );
 ##  <!-- attributes; is this really intended?-->
 ##  <!-- if yes then it should be documented!-->
 ##  <P/>
-##  If no third argument is given then the rank of the tester is 1.
+##  If no argument for <A>rank</A> is given, then the rank of the tester is 1.
 ##  <P/>
 ##  Each method for the new attribute that does <E>not</E> require
 ##  its argument to lie in <A>filter</A> must be installed using

--- a/hpcgap/lib/oper.g
+++ b/hpcgap/lib/oper.g
@@ -1012,9 +1012,19 @@ end );
 ##  </Description>
 ##  </ManSection>
 ##
+
+# FIXME: Find out and document how exactly ATTRIBUTES and RUN_ATTR_FUNCS is
+#        used
 BIND_GLOBAL( "ATTRIBUTES", MakeStrictWriteOnceAtomic([]) );
 
 BIND_GLOBAL( "ATTR_FUNCS", MakeStrictWriteOnceAtomic([]) );
+
+BIND_GLOBAL( "REGISTER_ATTRIBUTE_WITH_FILTER",
+function(name, filter, getter, setter, tester, mutable)
+    ADD_LIST( ATTRIBUTES,
+              MakeImmutable( [ name, filter, getter, setter, tester, mutable ] ) );
+end);
+
 
 BIND_GLOBAL( "InstallAttributeFunction", function ( func )
     local   attr;
@@ -1031,8 +1041,7 @@ BIND_GLOBAL( "RUN_ATTR_FUNCS",
     for func in ATTR_FUNCS do
         func( name, filter, getter, setter, tester, mutflag );
     od;
-    ADD_LIST( ATTRIBUTES,
-        MakeImmutable( [ name, filter, getter, setter, tester, mutflag ] ) );
+    REGISTER_ATTRIBUTE_WITH_FILTER(name, filter, getter, setter, tester, mutflag);
 end );
 
 
@@ -1179,32 +1188,29 @@ BIND_GLOBAL( "OPER_SetupAttribute", function(getter, flags, mutflag, filter, ran
           return;
       end);
 
+# construct getter, setter and tester
+BIND_GLOBAL( "NewAttribute", function ( name, filter, args... )
+    local  flags, mutflag, getter, rank;
 
-BIND_GLOBAL( "NewAttribute", function ( arg )
-    local   name, filter, flags, mutflag, getter, rank;
-
-    # construct getter, setter and tester
-    name   := arg[1];
-    filter := arg[2];
+    mutflag := LEN_LIST(args) >= 1 and (args[1] = "mutable" or args[1] = true);
+    if LEN_LIST(args) = 1 and IS_INT(args[1]) then
+        rank := args[2];
+    elif LEN_LIST(args) = 2 and IS_INT(args[2]) then
+        rank := args[2];
+    else
+        rank := 1;
+    fi;
 
     if not IS_OPERATION( filter ) then
       Error( "<filter> must be an operation" );
     fi;
     flags:= FLAGS_FILTER( filter );
 
-    # the mutability flags is the third one (which can also be the rank)
-    mutflag := LEN_LIST(arg) = 3 and arg[3] = "mutable";
-
     # construct a new attribute
     if mutflag then
         getter := NEW_MUTABLE_ATTRIBUTE( name );
     else
         getter := NEW_ATTRIBUTE( name );
-    fi;
-    if LEN_LIST(arg) = 3 and IS_INT(arg[3]) then
-        rank := arg[3];
-    else
-        rank := 1;
     fi;
     STORE_OPER_FLAGS(getter, [ flags ]);
 
@@ -1237,102 +1243,93 @@ end );
 ##  <#/GAPDoc>
 ##
 
-BIND_GLOBAL( "DeclareAttribute", function ( arg )
-    local   name,  gvar,  req,  reqs,  filter,  setter,  tester,  
-              attr,  nname, mutflag, flags, rank;
+BIND_GLOBAL( "ConvertToAttribute",
+function(name, op, filter, rank, mutable)
+    local req, reqs, flags, nname;
+    # `op' is not an attribute (tester) and not a property (tester),
+    # or `op' is a filter; in any case, `op' is not an attribute.
 
-    name:= arg[1];
+    # if `op' has no one argument declarations we can turn it into 
+    # an attribute
+    req := GET_OPER_FLAGS(op);
+    for reqs in req do
+        if LENGTH(reqs)  = 1 then
+            Error( "operation `", name, "' has been declared as a one ",
+                   "argument Operation and cannot also be an Attribute");
+        fi;
+    od;
+
+    flags := FLAGS_FILTER(filter);
+    STORE_OPER_FLAGS( op, [ FLAGS_FILTER( filter ) ] );
+
+    # kernel magic for the conversion
+    if mutable then
+        OPER_TO_MUTABLE_ATTRIBUTE(op);
+    else
+        OPER_TO_ATTRIBUTE(op);
+    fi;
+
+    OPER_SetupAttribute(op, flags, mutable, filter, rank, name);
+
+    # and make the remaining assignments
+    nname:= "Set"; APPEND_LIST_INTR( nname, name );
+    BIND_GLOBAL( nname, SETTER_FILTER(op) );
+    nname:= "Has"; APPEND_LIST_INTR( nname, name );
+    BIND_GLOBAL( nname, TESTER_FILTER(op) );
+end);
+
+BIND_GLOBAL( "DeclareAttribute", function ( name, filter, args... )
+    local gvar, req, reqs, setter, tester,
+              attr, nname, mutflag, flags, rank;
+
+    mutflag := LEN_LIST(args) >= 1 and (args[1] = "mutable" or args[1] = true);
+
+    if LEN_LIST(args) = 1 and IS_INT(args[1]) then
+        rank := args[2];
+    elif LEN_LIST(args) = 2 and IS_INT(args[2]) then
+        rank := args[2];
+    else
+        rank := 1;
+    fi;
 
     if ISB_GVAR( name ) then
+        if not IS_OPERATION( filter ) then
+            Error( "<filter> must be an operation" );
+        fi;
 
-      atomic FILTER_REGION do
-      # The variable exists already.
-      gvar:= VALUE_GLOBAL( name );
+        atomic FILTER_REGION do
+            # The variable exists already.
+            gvar := VALUE_GLOBAL( name );
 
-      # Check that the variable is in fact bound to an operation.
-      if not IS_OPERATION( gvar ) then
-        Error( "variable `", name, "' is not bound to an operation" );
-      fi;
+            # Check that the variable is in fact bound to an operation.
+            if not IS_OPERATION( gvar ) then
+                Error( "variable `", name, "' is not bound to an operation" );
+            fi;
 
-      # The attribute has already been declared.
-      # If it was not created as an attribute
-      # then we may be able to convert it
-      if FLAG2_FILTER( gvar ) = 0 or gvar in FILTERS then
+            # The attribute has already been declared.
+            # If it was not created as an attribute
+            # then we may be able to convert it
+            if FLAG2_FILTER( gvar ) = 0 or gvar in FILTERS then
+                ConvertToAttribute(name, gvar, filter, rank, mutflag);
+            else
+                STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
 
-          # `gvar' is not an attribute (tester) and not a property (tester),
-          # or `gvar' is a filter;
-          # in any case, `gvar' is not an attribute.
-          
-          # if `gvar' has no one argument declarations we can turn it into 
-          # an attribute
-          req := GET_OPER_FLAGS(gvar);
-          for reqs in req do
-              if LENGTH(reqs)  = 1 then
-                  Error( "operation `", name, "' has been declared as a one ",
-                         "argument Operation and cannot also be an Attribute");
-              fi;
-          od;
-          mutflag := LEN_LIST(arg) = 3 and arg[3] = "mutable";
-          
-          # add the new set of requirements 
-          filter:= arg[2];
-          if not IS_OPERATION( filter ) then
-              Error( "<filter> must be an operation" );
-          fi;
-          
-          flags := FLAGS_FILTER(filter);
-          STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
-          
-          # kernel magic for the conversion
-          if mutflag then
-              OPER_TO_MUTABLE_ATTRIBUTE(gvar);
-          else
-              OPER_TO_ATTRIBUTE(gvar);
-          fi;
-          
-          # now we have to adjust the data structures
-          
-          if LEN_LIST(arg) = 3 and IS_INT(arg[3]) then
-              rank := arg[3];
-          else
-              rank := 1;
-          fi;
-          OPER_SetupAttribute(gvar, flags, mutflag, filter, rank, name);         
-          # and make the remaining assignments
-          nname:= "Set"; APPEND_LIST_INTR( nname, name );
-          BIND_GLOBAL( nname, SETTER_FILTER(gvar) );
-          nname:= "Has"; APPEND_LIST_INTR( nname, name );
-          BIND_GLOBAL( nname, TESTER_FILTER(gvar) );
-          
-          return;      
-    
-              
-      fi;
-
-      # Add the new requirements.
-      filter:= arg[2];
-      if not IS_OPERATION( filter ) then
-        Error( "<filter> must be an operation" );
-      fi;
-      STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
-
-      # also set the extended range for the setter
-      req := GET_OPER_FLAGS( Setter(gvar) );
-      STORE_OPER_FLAGS( Setter(gvar), [ FLAGS_FILTER( filter), req[1][2] ] );
-
-      od;
+                # also set the extended range for the setter
+                req := GET_OPER_FLAGS( Setter(gvar) );
+                STORE_OPER_FLAGS( Setter(gvar), [ FLAGS_FILTER( filter), req[1][2] ] );
+                REGISTER_ATTRIBUTE_WITH_FILTER(name, filter, gvar, Setter(gvar), Tester(gvar), mutflag);
+            fi;
+        od;
     else
+        # The attribute is new.
+        attr := NewAttribute(name, filter, mutflag, rank);
+        BIND_GLOBAL( name, attr );
 
-      # The attribute is new.
-      attr:= CALL_FUNC_LIST( NewAttribute, arg );
-      BIND_GLOBAL( name, attr );
-      
-      # and make the remaining assignments
-      nname:= "Set"; APPEND_LIST_INTR( nname, name );
-      BIND_GLOBAL( nname, SETTER_FILTER(attr) );
-      nname:= "Has"; APPEND_LIST_INTR( nname, name );
-      BIND_GLOBAL( nname, TESTER_FILTER( attr ) );
-
+        # and make the remaining assignments
+        nname := "Set"; APPEND_LIST_INTR( nname, name );
+        BIND_GLOBAL( nname, SETTER_FILTER(attr) );
+        nname := "Has"; APPEND_LIST_INTR( nname, name );
+        BIND_GLOBAL( nname, TESTER_FILTER( attr ) );
     fi;
 end );
 

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -985,9 +985,19 @@ end );
 ##  </Description>
 ##  </ManSection>
 ##
+
+# FIXME: Find out and document how exactly ATTRIBUTES and RUN_ATTR_FUNCS is
+#        used
 BIND_GLOBAL( "ATTRIBUTES", [] );
 
 BIND_GLOBAL( "ATTR_FUNCS", [] );
+
+BIND_GLOBAL( "REGISTER_ATTRIBUTE_WITH_FILTER",
+function(name, filter, getter, setter, tester, mutable)
+    ADD_LIST( ATTRIBUTES,
+              MakeImmutable( [ name, filter, getter, setter, tester, mutable ] ) );
+end);
+
 
 BIND_GLOBAL( "InstallAttributeFunction", function ( func )
     local   attr;
@@ -1004,8 +1014,7 @@ BIND_GLOBAL( "RUN_ATTR_FUNCS",
     for func in ATTR_FUNCS do
         func( name, filter, getter, setter, tester, mutflag );
     od;
-    ADD_LIST( ATTRIBUTES,
-        MakeImmutable( [ name, filter, getter, setter, tester, mutflag ] ) );
+    REGISTER_ATTRIBUTE_WITH_FILTER(name, filter, getter, setter, tester, mutflag);
 end );
 
 
@@ -1274,6 +1283,7 @@ BIND_GLOBAL( "DeclareAttribute", function ( name, filter, args... )
             # also set the extended range for the setter
             req := GET_OPER_FLAGS( Setter(gvar) );
             STORE_OPER_FLAGS( Setter(gvar), [ FLAGS_FILTER( filter), req[1][2] ] );
+            REGISTER_ATTRIBUTE_WITH_FILTER(name, filter, gvar, Setter(gvar), Tester(gvar), mutflag);
         fi;
     else
         # The attribute is new.

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1073,7 +1073,7 @@ end );
 
 #############################################################################
 ##
-#F  NewAttribute( <name>, <filter>[, "mutable"][, <rank>] ) . . new attribute
+#F  NewAttribute( <name>, <filter>[, <mutable>][, <rank>] ) . . new attribute
 ##
 ##  <#GAPDoc Label="NewAttribute">
 ##  <ManSection>
@@ -1095,16 +1095,20 @@ end );
 ##  applicable to a character table,
 ##  which is neither a list nor a collection.
 ##  <P/>
-##  If the optional third argument is given then there are two possibilities.
-##  Either it is an integer <A>rank</A>,
-##  then the attribute tester has this incremental rank
-##  (see&nbsp;<Ref Sect="Filters"/>).
-##  Or it is the string <C>"mutable"</C>,
-##  then the values of the attribute shall be mutable;
-##  more precisely, when a value of such a mutable attribute is set
-##  then this value itself is stored, not an immutable copy of it.
-##  (So it is the user's responsibility to set an object that is in fact
-##  mutable.)
+##  For the optional third and fourth arguments, there are the following
+##  possibilities.
+##  <List>
+##  <Item> The integer argument <A>rank</A> causes the attribute tester to have
+##  this incremental rank (see&nbsp;<Ref Sect="Filters"/>),
+##  <Item> If the argument <A>mutable</A> is the string <C>"mutable"</C> or
+##  the boolean <C>true</C>, then the values of the attribute are mutable.
+##  <Item> If the argument <A>mutable</A> is the boolean <C>false</C>, then
+##  the values of the attribute are immutable.
+##  </List>
+##  <P/>
+##  When a value of such mutable attribute is set
+##  then this value itself is stored, not an immutable copy of it, 
+##  and it is the user's responsibility to set an object that is mutable.
 ##  This is useful for an attribute whose value is some partial information
 ##  that may be completed later.
 ##  For example, there is an attribute <C>ComputedSylowSubgroups</C>
@@ -1117,7 +1121,7 @@ end );
 ##  <!-- attributes; is this really intended?-->
 ##  <!-- if yes then it should be documented!-->
 ##  <P/>
-##  If no third argument is given then the rank of the tester is 1.
+##  If no argument for <A>rank</A> is given, then the rank of the tester is 1.
 ##  <P/>
 ##  Each method for the new attribute that does <E>not</E> require
 ##  its argument to lie in <A>filter</A> must be installed using

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1148,32 +1148,29 @@ BIND_GLOBAL( "OPER_SetupAttribute", function(getter, flags, mutflag, filter, ran
           return;
       end);
 
+# construct getter, setter and tester
+BIND_GLOBAL( "NewAttribute", function ( name, filter, args... )
+    local  flags, mutflag, getter, rank;
 
-BIND_GLOBAL( "NewAttribute", function ( arg )
-    local   name, filter, flags, mutflag, getter, rank;
-
-    # construct getter, setter and tester
-    name   := arg[1];
-    filter := arg[2];
+    mutflag := LEN_LIST(args) >= 1 and (args[1] = "mutable" or args[1] = true);
+    if LEN_LIST(args) = 1 and IS_INT(args[1]) then
+        rank := args[2];
+    elif LEN_LIST(args) = 2 and IS_INT(args[2]) then
+        rank := args[2];
+    else
+        rank := 1;
+    fi;
 
     if not IS_OPERATION( filter ) then
       Error( "<filter> must be an operation" );
     fi;
     flags:= FLAGS_FILTER( filter );
 
-    # the mutability flags is the third one (which can also be the rank)
-    mutflag := LEN_LIST(arg) = 3 and arg[3] = "mutable";
-
     # construct a new attribute
     if mutflag then
         getter := NEW_MUTABLE_ATTRIBUTE( name );
     else
         getter := NEW_ATTRIBUTE( name );
-    fi;
-    if LEN_LIST(arg) = 3 and IS_INT(arg[3]) then
-        rank := arg[3];
-    else
-        rank := 1;
     fi;
     STORE_OPER_FLAGS(getter, [ flags ]);
 
@@ -1204,100 +1201,90 @@ end );
 ##  <#/GAPDoc>
 ##
 
-BIND_GLOBAL( "DeclareAttribute", function ( arg )
-    local   name,  gvar,  req,  reqs,  filter,  setter,  tester,  
-              attr,  nname, mutflag, flags, rank;
+BIND_GLOBAL( "ConvertToAttribute",
+function(name, op, filter, rank, mutable)
+    local req, reqs, flags, nname;
+    # `op' is not an attribute (tester) and not a property (tester),
+    # or `op' is a filter; in any case, `op' is not an attribute.
 
-    name:= arg[1];
+    # if `op' has no one argument declarations we can turn it into 
+    # an attribute
+    req := GET_OPER_FLAGS(op);
+    for reqs in req do
+        if LENGTH(reqs)  = 1 then
+            Error( "operation `", name, "' has been declared as a one ",
+                   "argument Operation and cannot also be an Attribute");
+        fi;
+    od;
+
+    flags := FLAGS_FILTER(filter);
+    STORE_OPER_FLAGS( op, [ FLAGS_FILTER( filter ) ] );
+
+    # kernel magic for the conversion
+    if mutable then
+        OPER_TO_MUTABLE_ATTRIBUTE(op);
+    else
+        OPER_TO_ATTRIBUTE(op);
+    fi;
+
+    OPER_SetupAttribute(op, flags, mutable, filter, rank, name);
+
+    # and make the remaining assignments
+    nname:= "Set"; APPEND_LIST_INTR( nname, name );
+    BIND_GLOBAL( nname, SETTER_FILTER(op) );
+    nname:= "Has"; APPEND_LIST_INTR( nname, name );
+    BIND_GLOBAL( nname, TESTER_FILTER(op) );
+end);
+
+BIND_GLOBAL( "DeclareAttribute", function ( name, filter, args... )
+    local gvar, req, reqs, setter, tester,
+              attr, nname, mutflag, flags, rank;
+
+    mutflag := LEN_LIST(args) >= 1 and (args[1] = "mutable" or args[1] = true);
+
+    if LEN_LIST(args) = 1 and IS_INT(args[1]) then
+        rank := args[2];
+    elif LEN_LIST(args) = 2 and IS_INT(args[2]) then
+        rank := args[2];
+    else
+        rank := 1;
+    fi;
 
     if ISB_GVAR( name ) then
+        if not IS_OPERATION( filter ) then
+            Error( "<filter> must be an operation" );
+        fi;
 
-      # The variable exists already.
-      gvar:= VALUE_GLOBAL( name );
+        # The variable exists already.
+        gvar := VALUE_GLOBAL( name );
 
-      # Check that the variable is in fact bound to an operation.
-      if not IS_OPERATION( gvar ) then
-        Error( "variable `", name, "' is not bound to an operation" );
-      fi;
+        # Check that the variable is in fact bound to an operation.
+        if not IS_OPERATION( gvar ) then
+            Error( "variable `", name, "' is not bound to an operation" );
+        fi;
 
-      # The attribute has already been declared.
-      # If it was not created as an attribute
-      # then we may be able to convert it
-      if FLAG2_FILTER( gvar ) = 0 or gvar in FILTERS then
+        # The attribute has already been declared.
+        # If it was not created as an attribute
+        # then we may be able to convert it
+        if FLAG2_FILTER( gvar ) = 0 or gvar in FILTERS then
+            ConvertToAttribute(name, gvar, filter, rank, mutflag);
+        else
+            STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
 
-          # `gvar' is not an attribute (tester) and not a property (tester),
-          # or `gvar' is a filter;
-          # in any case, `gvar' is not an attribute.
-          
-          # if `gvar' has no one argument declarations we can turn it into 
-          # an attribute
-          req := GET_OPER_FLAGS(gvar);
-          for reqs in req do
-              if LENGTH(reqs)  = 1 then
-                  Error( "operation `", name, "' has been declared as a one ",
-                         "argument Operation and cannot also be an Attribute");
-              fi;
-          od;
-          mutflag := LEN_LIST(arg) = 3 and arg[3] = "mutable";
-          
-          # add the new set of requirements 
-          filter:= arg[2];
-          if not IS_OPERATION( filter ) then
-              Error( "<filter> must be an operation" );
-          fi;
-          
-          flags := FLAGS_FILTER(filter);
-          STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
-          
-          # kernel magic for the conversion
-          if mutflag then
-              OPER_TO_MUTABLE_ATTRIBUTE(gvar);
-          else
-              OPER_TO_ATTRIBUTE(gvar);
-          fi;
-          
-          # now we have to adjust the data structures
-          
-          if LEN_LIST(arg) = 3 and IS_INT(arg[3]) then
-              rank := arg[3];
-          else
-              rank := 1;
-          fi;
-          OPER_SetupAttribute(gvar, flags, mutflag, filter, rank, name);         
-          # and make the remaining assignments
-          nname:= "Set"; APPEND_LIST_INTR( nname, name );
-          BIND_GLOBAL( nname, SETTER_FILTER(gvar) );
-          nname:= "Has"; APPEND_LIST_INTR( nname, name );
-          BIND_GLOBAL( nname, TESTER_FILTER(gvar) );
-          
-          return;      
-    
-              
-      fi;
-
-      # Add the new requirements.
-      filter:= arg[2];
-      if not IS_OPERATION( filter ) then
-        Error( "<filter> must be an operation" );
-      fi;
-      STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
-
-      # also set the extended range for the setter
-      req := GET_OPER_FLAGS( Setter(gvar) );
-      STORE_OPER_FLAGS( Setter(gvar), [ FLAGS_FILTER( filter), req[1][2] ] );
-
+            # also set the extended range for the setter
+            req := GET_OPER_FLAGS( Setter(gvar) );
+            STORE_OPER_FLAGS( Setter(gvar), [ FLAGS_FILTER( filter), req[1][2] ] );
+        fi;
     else
+        # The attribute is new.
+        attr := NewAttribute(name, filter, mutflag, rank);
+        BIND_GLOBAL( name, attr );
 
-      # The attribute is new.
-      attr:= CALL_FUNC_LIST( NewAttribute, arg );
-      BIND_GLOBAL( name, attr );
-      
-      # and make the remaining assignments
-      nname:= "Set"; APPEND_LIST_INTR( nname, name );
-      BIND_GLOBAL( nname, SETTER_FILTER(attr) );
-      nname:= "Has"; APPEND_LIST_INTR( nname, name );
-      BIND_GLOBAL( nname, TESTER_FILTER( attr ) );
-
+        # and make the remaining assignments
+        nname := "Set"; APPEND_LIST_INTR( nname, name );
+        BIND_GLOBAL( nname, SETTER_FILTER(attr) );
+        nname := "Has"; APPEND_LIST_INTR( nname, name );
+        BIND_GLOBAL( nname, TESTER_FILTER( attr ) );
     fi;
 end );
 


### PR DESCRIPTION
This is a result of trying to fix a bug in `DeclareAttribute`, namely if a user did the following

```
gap> DeclareAttribute("PlaceHolder", IsGroup);
gap> DeclareAttribute("PlaceHolder", IsMultiplicativeElement);
```

Then the second instance of `PlaceHolder` would not be stored in the global array `ATTRIBUTES`.

In the process this PR also fixes a bug with argument parsing in `DeclareAttribute` and `NewAttribute`, where if one gave `"mutable"` as third argument, the argument for rank would be ignored.

We now allow passing `true` or `false` as well as the string "mutable" as mutability flag.  