### PR TITLE
Allow additional data to be stored for operations, and add documentation for OPERATIONS and OPER_FLAGS

### DIFF
--- a/hpcgap/lib/oper.g
+++ b/hpcgap/lib/oper.g
@@ -155,18 +155,18 @@ BIND_GLOBAL( "NUMBERS_PROPERTY_GETTERS", [] );
 ##
 OPERATIONS_REGION := ShareSpecialObj("OPERATIONS_REGION");  # FIXME: remove
 BIND_GLOBAL( "OPERATIONS", MakeStrictWriteOnceAtomic([]) );
-BIND_GLOBAL( "OPER_FLAGS", MakeStrictWriteOnceAtomic(rec()) );
-BIND_GLOBAL( "STORE_OPER_FLAGS",
+BIND_GLOBAL( "OPER_DATA", MakeStrictWriteOnceAtomic(rec()) );
+BIND_GLOBAL( "STORE_OPER_DATA",
 function(oper, flags)
   local nr, info;
   nr := MASTER_POINTER_NUMBER(oper);
-  if not IsBound(OPER_FLAGS.(nr)) then
+  if not IsBound(OPER_DATA.(nr)) then
     # we need a back link to oper for the post-restore function
     OPER_FLAGS.(nr) := FixedAtomicList([oper,
         MakeWriteOnceAtomic([]), MakeWriteOnceAtomic([])]);
     ADD_LIST(OPERATIONS, oper);
   fi;
-  info := OPER_FLAGS.(nr);
+  info := OPER_DATA.(nr);
   ADD_LIST(info[2], MakeImmutable(flags));
   ADD_LIST(info[3], MakeImmutable([INPUT_FILENAME(), INPUT_LINENUMBER()]));
 end);
@@ -174,30 +174,30 @@ end);
 BIND_GLOBAL( "GET_OPER_FLAGS", function(oper)
   local nr;
   nr := MASTER_POINTER_NUMBER(oper);
-  if not IsBound(OPER_FLAGS.(nr)) then
+  if not IsBound(OPER_DATA.(nr)) then
     return fail;
   fi;
-  return OPER_FLAGS.(nr)[2];
+  return OPER_DATA.(nr)[2];
 end);
 BIND_GLOBAL( "GET_DECLARATION_LOCATIONS", function(oper)
   local nr;
   nr := MASTER_POINTER_NUMBER(oper);
-  if not IsBound(OPER_FLAGS.(nr)) then
+  if not IsBound(OPER_DATA.(nr)) then
     return fail;
   fi;
-  return OPER_FLAGS.(nr)[3];
+  return OPER_DATA.(nr)[3];
 end);
 
 # the object handles change after loading a workspace
 ADD_LIST(GAPInfo.PostRestoreFuncs, function()
   local tmp, a;
   tmp := [];
-  for a in REC_NAMES(OPER_FLAGS) do
-    ADD_LIST(tmp, OPER_FLAGS.(a));
-    Unbind(OPER_FLAGS.(a));
+  for a in REC_NAMES(OPER_DATA) do
+    ADD_LIST(tmp, OPER_DATA.(a));
+    Unbind(OPER_DATA.(a));
   od;
   for a in tmp do
-    OPER_FLAGS.(MASTER_POINTER_NUMBER(a[1])) := a;
+    OPER_DATA.(MASTER_POINTER_NUMBER(a[1])) := a;
   od;
 end);
 
@@ -630,7 +630,7 @@ BIND_GLOBAL( "NewOperation", function ( name, filters )
         fi;
         ADD_LIST( filt, FLAGS_FILTER( filter ) );
     od;
-    STORE_OPER_FLAGS(oper, filt);
+    STORE_OPER_DATA(oper, filt);
     return oper;
 end );
 
@@ -758,7 +758,7 @@ BIND_GLOBAL( "NewConstructor", function ( name, filters )
     atomic readwrite CONSTRUCTORS do
     ADD_LIST( CONSTRUCTORS, oper );
     od;
-    STORE_OPER_FLAGS(oper, filt);
+    STORE_OPER_DATA(oper, filt);
     return oper;
 end );
 
@@ -847,7 +847,7 @@ BIND_GLOBAL( "DeclareOperation", function ( name, filters )
               "for operation `", name, "'\n" );
         fi;
       else
-        STORE_OPER_FLAGS( gvar, filt );
+        STORE_OPER_DATA( gvar, filt );
       fi;
 
     else
@@ -892,7 +892,7 @@ BIND_GLOBAL( "DeclareOperationKernel", function ( name, filters, oper )
         ADD_LIST( filt, FLAGS_FILTER( filter ) );
     od;
 
-    STORE_OPER_FLAGS(oper, filt);
+    STORE_OPER_DATA(oper, filt);
 end );
 
 
@@ -947,7 +947,7 @@ BIND_GLOBAL( "DeclareConstructor", function ( name, filters )
         ADD_LIST( filt, FLAGS_FILTER( filter ) );
       od;
 
-      STORE_OPER_FLAGS( gvar, filt );
+      STORE_OPER_DATA( gvar, filt );
 
     else
 
@@ -994,7 +994,7 @@ BIND_GLOBAL( "DeclareConstructorKernel", function ( name, filters, oper )
     atomic readwrite CONSTRUCTORS do
     ADD_LIST( CONSTRUCTORS, oper );
     od;
-    STORE_OPER_FLAGS(oper, filt);
+    STORE_OPER_DATA(oper, filt);
 end );
 
 
@@ -1061,9 +1061,9 @@ BIND_GLOBAL( "DeclareAttributeKernel", function ( name, filter, getter )
     tester := TESTER_FILTER( getter );
 
     # add getter, setter and tester to the list of operations
-    STORE_OPER_FLAGS(getter, [ FLAGS_FILTER(filter) ]);
-    STORE_OPER_FLAGS(setter, [ FLAGS_FILTER(filter), FLAGS_FILTER(IS_OBJECT) ]);
-    STORE_OPER_FLAGS(tester, [ FLAGS_FILTER(filter) ]);
+    STORE_OPER_DATA(getter, [ FLAGS_FILTER(filter) ]);
+    STORE_OPER_DATA(setter, [ FLAGS_FILTER(filter), FLAGS_FILTER(IS_OBJECT) ]);
+    STORE_OPER_DATA(tester, [ FLAGS_FILTER(filter) ]);
 
     # store the information about the filter
     atomic FILTER_REGION do
@@ -1157,8 +1157,8 @@ BIND_GLOBAL( "OPER_SetupAttribute", function(getter, flags, mutflag, filter, ran
           setter := SETTER_FILTER( getter );
           tester := TESTER_FILTER( getter );
 
-          STORE_OPER_FLAGS(setter, [ flags, FLAGS_FILTER( IS_OBJECT ) ]);
-          STORE_OPER_FLAGS(tester, [ flags ]);
+          STORE_OPER_DATA(setter, [ flags, FLAGS_FILTER( IS_OBJECT ) ]);
+          STORE_OPER_DATA(tester, [ flags ]);
 
           # install the default functions
           FILTERS[ FLAG2_FILTER( tester ) ] := tester;
@@ -1206,7 +1206,7 @@ BIND_GLOBAL( "NewAttribute", function ( arg )
     else
         rank := 1;
     fi;
-    STORE_OPER_FLAGS(getter, [ flags ]);
+    STORE_OPER_DATA(getter, [ flags ]);
 
     atomic FILTER_REGION do
     OPER_SetupAttribute(getter, flags, mutflag, filter, rank, name);
@@ -1281,7 +1281,7 @@ BIND_GLOBAL( "DeclareAttribute", function ( arg )
           fi;
           
           flags := FLAGS_FILTER(filter);
-          STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
+          STORE_OPER_DATA( gvar, [ FLAGS_FILTER( filter ) ] );
           
           # kernel magic for the conversion
           if mutflag then
@@ -1314,11 +1314,11 @@ BIND_GLOBAL( "DeclareAttribute", function ( arg )
       if not IS_OPERATION( filter ) then
         Error( "<filter> must be an operation" );
       fi;
-      STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
+      STORE_OPER_DATA( gvar, [ FLAGS_FILTER( filter ) ] );
 
       # also set the extended range for the setter
       req := GET_OPER_FLAGS( Setter(gvar) );
-      STORE_OPER_FLAGS( Setter(gvar), [ FLAGS_FILTER( filter), req[1][2] ] );
+      STORE_OPER_DATA( Setter(gvar), [ FLAGS_FILTER( filter), req[1][2] ] );
 
       od;
     else
@@ -1383,9 +1383,9 @@ BIND_GLOBAL( "DeclarePropertyKernel", function ( name, filter, getter )
     ADD_LIST( NUMBERS_PROPERTY_GETTERS, FLAG1_FILTER( getter ) );
 
     # add getter, setter and tester to the list of operations
-    STORE_OPER_FLAGS(getter, [ FLAGS_FILTER(filter) ]);
-    STORE_OPER_FLAGS(setter, [ FLAGS_FILTER(filter), FLAGS_FILTER(IS_BOOL) ]);
-    STORE_OPER_FLAGS(tester, [ FLAGS_FILTER(filter) ]);
+    STORE_OPER_DATA(getter, [ FLAGS_FILTER(filter) ]);
+    STORE_OPER_DATA(setter, [ FLAGS_FILTER(filter), FLAGS_FILTER(IS_BOOL) ]);
+    STORE_OPER_DATA(tester, [ FLAGS_FILTER(filter) ]);
 
     # install the default functions
     FILTERS[ FLAG1_FILTER( getter ) ]:= getter;
@@ -1455,9 +1455,9 @@ BIND_GLOBAL( "NewProperty", function ( arg )
     tester := TESTER_FILTER( getter );
 
     # add getter, setter and tester to the list of operations
-    STORE_OPER_FLAGS(getter, [ flags ]);
-    STORE_OPER_FLAGS(setter, [ flags, FLAGS_FILTER(IS_BOOL) ]);
-    STORE_OPER_FLAGS(tester, [ flags ]);
+    STORE_OPER_DATA(getter, [ flags ]);
+    STORE_OPER_DATA(setter, [ flags, FLAGS_FILTER(IS_BOOL) ]);
+    STORE_OPER_DATA(tester, [ flags ]);
 
     # store the property getters
     ADD_LIST( NUMBERS_PROPERTY_GETTERS, FLAG1_FILTER( getter ) );
@@ -1548,7 +1548,7 @@ BIND_GLOBAL( "DeclareProperty", function ( arg )
         Error( "<filter> must be an operation" );
       fi;
 
-      STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
+      STORE_OPER_DATA( gvar, [ FLAGS_FILTER( filter ) ] );
 
     else
 

--- a/hpcgap/lib/oper.g
+++ b/hpcgap/lib/oper.g
@@ -157,7 +157,7 @@ BIND_GLOBAL( "NUMBERS_PROPERTY_GETTERS", [] );
 ##  information.
 ##
 ##  <Ref Func="STORE_OPER_DATA"/> is used to store the flags and source
-##  locations of calls to <Ref Func="NewOperation"/> ord
+##  locations of calls to <Ref Func="NewOperation"/> or
 ##  <Ref Func="DeclareOperation"/>
 ##
 ##  More precisely, if for the operation <C>op</C>, which has been declared by
@@ -184,36 +184,33 @@ OPERATIONS_REGION := ShareSpecialObj("OPERATIONS_REGION");  # FIXME: remove
 BIND_GLOBAL( "OPERATIONS", MakeStrictWriteOnceAtomic([]) );
 BIND_GLOBAL( "OPER_DATA", MakeStrictWriteOnceAtomic(rec()) );
 BIND_GLOBAL( "STORE_OPER_DATA",
-function(oper, flags)
+function(oper, flags, opt...)
   local nr, info;
   nr := MASTER_POINTER_NUMBER(oper);
   if not IsBound(OPER_DATA.(nr)) then
     # we need a back link to oper for the post-restore function
     OPER_FLAGS.(nr) := FixedAtomicList([oper,
-        MakeWriteOnceAtomic([]), MakeWriteOnceAtomic([])]);
+        MakeWriteOnceAtomic([]), MakeWriteOnceAtomic([]), MakeWriteOnceAtomic([])]);
     ADD_LIST(OPERATIONS, oper);
   fi;
   info := OPER_DATA.(nr);
   ADD_LIST(info[2], MakeImmutable(flags));
   ADD_LIST(info[3], MakeImmutable([INPUT_FILENAME(), INPUT_LINENUMBER()]));
+  ADD_LIST(info[4], MakeImmutable(opt));
 end);
 
-BIND_GLOBAL( "GET_OPER_FLAGS", function(oper)
+BIND_GLOBAL( "GET_OPER_DATA", function(oper)
   local nr;
   nr := MASTER_POINTER_NUMBER(oper);
   if not IsBound(OPER_DATA.(nr)) then
     return fail;
   fi;
-  return OPER_DATA.(nr)[2];
+  return OPER_DATA.(nr);
 end);
-BIND_GLOBAL( "GET_DECLARATION_LOCATIONS", function(oper)
-  local nr;
-  nr := MASTER_POINTER_NUMBER(oper);
-  if not IsBound(OPER_DATA.(nr)) then
-    return fail;
-  fi;
-  return OPER_DATA.(nr)[3];
-end);
+BIND_GLOBAL( "GET_OPER_FLAGS",
+             oper -> GET_OPER_DATA(oper)[2] );
+BIND_GLOBAL( "GET_DECLARATION_LOCATIONS",
+             oper -> GET_OPER_DATA(oper)[3] );
 
 # the object handles change after loading a workspace
 ADD_LIST(GAPInfo.PostRestoreFuncs, function()

--- a/hpcgap/lib/oper.g
+++ b/hpcgap/lib/oper.g
@@ -133,23 +133,50 @@ BIND_GLOBAL( "IMMEDIATE_METHODS", AtomicList([]) );
 ##
 BIND_GLOBAL( "NUMBERS_PROPERTY_GETTERS", [] );
 
-
 #############################################################################
 ##
 #V  OPERATIONS
+#V  OPER_DATA
 ##
 ##  <ManSection>
 ##  <Var Name="OPERATIONS"/>
+##  <Var Name="OPER_DATA"/>
+##  <Func Name="STORE_OPER_DATA"/>
+##  <Func Name="GET_OPER_FLAGS"/>
+##  <Func Name="GET_DECLARATION_LOCATIONS"/>
+##
 ##
 ##  <Description>
-##  is a list that stores all &GAP; operations at the odd positions,
-##  and the corresponding list of requirements at the even positions.
-##  More precisely, if the operation <C>OPERATIONS[<A>n</A>]</C> has been declared
-##  by several calls of <C>DeclareOperation</C>,
-##  with second arguments <A>req1</A>, <A>req2</A>, \ldots,
-##  each being a list of filters, then <C>OPERATIONS[ <A>n</A>+1 ]</C> is the list
-##  <C>[</C> <A>flags1</A>, <A>flags2</A>, <M>\ldots</M>, <C>]</C>,
-##  where <A>flagsi</A> is the list of flags of the filters in <A>reqi</A>.
+##  <Ref Var="OPERATIONS"/> is a list that stores all &GAP; operations, and
+##  <Ref Var="OPER_DATA"/> is a record that stores additional information
+##  about operations, such lists of required filters and source locations
+##  where <Ref Func="DeclareOperation"> was called.
+##
+##  The functions <Ref Func="GET_OPER_FLAGS"/> and
+##  <Ref Func="GET_DECLARATION_LOCATIONS"/> are provided to obtain stored
+##  information.
+##
+##  <Ref Func="STORE_OPER_DATA"/> is used to store the flags and source
+##  locations of calls to <Ref Func="NewOperation"/> ord
+##  <Ref Func="DeclareOperation"/>
+##
+##  More precisely, if for the operation <C>op</C>, which has been declared by
+##  by several calls of <Ref Func="DeclareOperation"/> , each with second
+##  arguments <A>req1</A>, <A>req2</A>, \ldots, then calling
+##  <Ref Func="GET_OPER_FLAGS"/>  with argument <A>op</A> returns the list
+##  <C>[ flags1, flags2, \ldots ]</C>, where <C>flagsi</C> is the list offset
+##  flags of the filters in <C>reqi</C>.
+##
+##  Calling <Ref Func="GET_DECLARATION_LOCATIONS"/> with argument <A>op</A>
+##  returns a list of source locations where <Ref Func="NewOperation"/> or 
+##  <Ref Func="DeclareOperation"/> was called.
+##
+##  Note that <Ref Func="DeclareAttribute"/>, <Ref Func="NewAttribute"/>,
+##  <Ref Func="DeclareProperty"/>, <Ref Func="NewProperty"/>, and others, call
+##  <Ref Func="NewOperation"/> or <Ref Func="DeclareOperation">.
+##
+##  A <E>source location on</E> is a pair <C>[ f, n ]</C> where <C>f</C> is a
+##  filename and <C>l</C> is a line number in the file.
 ##  </Description>
 ##  </ManSection>
 ##

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -148,17 +148,17 @@ BIND_GLOBAL( "NUMBERS_PROPERTY_GETTERS", [] );
 ##  </ManSection>
 ##
 BIND_GLOBAL( "OPERATIONS", [] );
-BIND_GLOBAL( "OPER_FLAGS", rec() );
-BIND_GLOBAL( "STORE_OPER_FLAGS",
+BIND_GLOBAL( "OPER_DATA", rec() );
+BIND_GLOBAL( "STORE_OPER_DATA",
 function(oper, flags)
   local nr, info;
   nr := MASTER_POINTER_NUMBER(oper);
-  if not IsBound(OPER_FLAGS.(nr)) then
+  if not IsBound(OPER_DATA.(nr)) then
     # we need a back link to oper for the post-restore function
-    OPER_FLAGS.(nr) := [oper, [], []];
+    OPER_DATA.(nr) := [oper, [], []];
     ADD_LIST(OPERATIONS, oper);
   fi;
-  info := OPER_FLAGS.(nr);
+  info := OPER_DATA.(nr);
   ADD_LIST(info[2], MakeImmutable(flags));
   ADD_LIST(info[3], MakeImmutable([INPUT_FILENAME(), INPUT_LINENUMBER()]));
 end);
@@ -166,30 +166,30 @@ end);
 BIND_GLOBAL( "GET_OPER_FLAGS", function(oper)
   local nr;
   nr := MASTER_POINTER_NUMBER(oper);
-  if not IsBound(OPER_FLAGS.(nr)) then
+  if not IsBound(OPER_DATA.(nr)) then
     return fail;
   fi;
-  return OPER_FLAGS.(nr)[2];
+  return OPER_DATA.(nr)[2];
 end);
 BIND_GLOBAL( "GET_DECLARATION_LOCATIONS", function(oper)
   local nr;
   nr := MASTER_POINTER_NUMBER(oper);
-  if not IsBound(OPER_FLAGS.(nr)) then
+  if not IsBound(OPER_DATA.(nr)) then
     return fail;
   fi;
-  return OPER_FLAGS.(nr)[3];
+  return OPER_DATA.(nr)[3];
 end);
 
 # the object handles change after loading a workspace
 ADD_LIST(GAPInfo.PostRestoreFuncs, function()
   local tmp, a;
   tmp := [];
-  for a in REC_NAMES(OPER_FLAGS) do
-    ADD_LIST(tmp, OPER_FLAGS.(a));
-    Unbind(OPER_FLAGS.(a));
+  for a in REC_NAMES(OPER_DATA) do
+    ADD_LIST(tmp, OPER_DATA.(a));
+    Unbind(OPER_DATA.(a));
   od;
   for a in tmp do
-    OPER_FLAGS.(MASTER_POINTER_NUMBER(a[1])) := a;
+    OPER_DATA.(MASTER_POINTER_NUMBER(a[1])) := a;
   od;
 end);
 
@@ -612,7 +612,7 @@ BIND_GLOBAL( "NewOperation", function ( name, filters )
         fi;
         ADD_LIST( filt, FLAGS_FILTER( filter ) );
     od;
-    STORE_OPER_FLAGS(oper, filt);
+    STORE_OPER_DATA(oper, filt);
     return oper;
 end );
 
@@ -738,7 +738,7 @@ BIND_GLOBAL( "NewConstructor", function ( name, filters )
         ADD_LIST( filt, FLAGS_FILTER( filter ) );
     od;
     ADD_LIST( CONSTRUCTORS, oper );
-    STORE_OPER_FLAGS(oper, filt);
+    STORE_OPER_DATA(oper, filt);
     return oper;
 end );
 
@@ -822,7 +822,7 @@ BIND_GLOBAL( "DeclareOperation", function ( name, filters )
               "for operation `", name, "'\n" );
         fi;
       else
-        STORE_OPER_FLAGS( gvar, filt );
+        STORE_OPER_DATA( gvar, filt );
       fi;
 
     else
@@ -867,7 +867,7 @@ BIND_GLOBAL( "DeclareOperationKernel", function ( name, filters, oper )
         ADD_LIST( filt, FLAGS_FILTER( filter ) );
     od;
 
-    STORE_OPER_FLAGS(oper, filt);
+    STORE_OPER_DATA(oper, filt);
 end );
 
 
@@ -922,7 +922,7 @@ BIND_GLOBAL( "DeclareConstructor", function ( name, filters )
         ADD_LIST( filt, FLAGS_FILTER( filter ) );
       od;
 
-      STORE_OPER_FLAGS( gvar, filt );
+      STORE_OPER_DATA( gvar, filt );
 
     else
 
@@ -967,7 +967,7 @@ BIND_GLOBAL( "DeclareConstructorKernel", function ( name, filters, oper )
     od;
 
     ADD_LIST( CONSTRUCTORS, oper );
-    STORE_OPER_FLAGS(oper, filt);
+    STORE_OPER_DATA(oper, filt);
 end );
 
 
@@ -1034,9 +1034,9 @@ BIND_GLOBAL( "DeclareAttributeKernel", function ( name, filter, getter )
     tester := TESTER_FILTER( getter );
 
     # add getter, setter and tester to the list of operations
-    STORE_OPER_FLAGS(getter, [ FLAGS_FILTER(filter) ]);
-    STORE_OPER_FLAGS(setter, [ FLAGS_FILTER(filter), FLAGS_FILTER(IS_OBJECT) ]);
-    STORE_OPER_FLAGS(tester, [ FLAGS_FILTER(filter) ]);
+    STORE_OPER_DATA(getter, [ FLAGS_FILTER(filter) ]);
+    STORE_OPER_DATA(setter, [ FLAGS_FILTER(filter), FLAGS_FILTER(IS_OBJECT) ]);
+    STORE_OPER_DATA(tester, [ FLAGS_FILTER(filter) ]);
 
     # store the information about the filter
     FILTERS[ FLAG2_FILTER( tester ) ] := tester;
@@ -1126,8 +1126,8 @@ BIND_GLOBAL( "OPER_SetupAttribute", function(getter, flags, mutflag, filter, ran
           setter := SETTER_FILTER( getter );
           tester := TESTER_FILTER( getter );
 
-          STORE_OPER_FLAGS(setter, [ flags, FLAGS_FILTER( IS_OBJECT ) ]);
-          STORE_OPER_FLAGS(tester, [ flags ]);
+          STORE_OPER_DATA(setter, [ flags, FLAGS_FILTER( IS_OBJECT ) ]);
+          STORE_OPER_DATA(tester, [ flags ]);
 
           # install the default functions
           FILTERS[ FLAG2_FILTER( tester ) ] := tester;
@@ -1175,7 +1175,7 @@ BIND_GLOBAL( "NewAttribute", function ( arg )
     else
         rank := 1;
     fi;
-    STORE_OPER_FLAGS(getter, [ flags ]);
+    STORE_OPER_DATA(getter, [ flags ]);
 
     OPER_SetupAttribute(getter, flags, mutflag, filter, rank, name);
 
@@ -1247,7 +1247,7 @@ BIND_GLOBAL( "DeclareAttribute", function ( arg )
           fi;
           
           flags := FLAGS_FILTER(filter);
-          STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
+          STORE_OPER_DATA( gvar, [ FLAGS_FILTER( filter ) ] );
           
           # kernel magic for the conversion
           if mutflag then
@@ -1280,11 +1280,11 @@ BIND_GLOBAL( "DeclareAttribute", function ( arg )
       if not IS_OPERATION( filter ) then
         Error( "<filter> must be an operation" );
       fi;
-      STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
+      STORE_OPER_DATA( gvar, [ FLAGS_FILTER( filter ) ] );
 
       # also set the extended range for the setter
       req := GET_OPER_FLAGS( Setter(gvar) );
-      STORE_OPER_FLAGS( Setter(gvar), [ FLAGS_FILTER( filter), req[1][2] ] );
+      STORE_OPER_DATA( Setter(gvar), [ FLAGS_FILTER( filter), req[1][2] ] );
 
     else
 
@@ -1348,9 +1348,9 @@ BIND_GLOBAL( "DeclarePropertyKernel", function ( name, filter, getter )
     ADD_LIST( NUMBERS_PROPERTY_GETTERS, FLAG1_FILTER( getter ) );
 
     # add getter, setter and tester to the list of operations
-    STORE_OPER_FLAGS(getter, [ FLAGS_FILTER(filter) ]);
-    STORE_OPER_FLAGS(setter, [ FLAGS_FILTER(filter), FLAGS_FILTER(IS_BOOL) ]);
-    STORE_OPER_FLAGS(tester, [ FLAGS_FILTER(filter) ]);
+    STORE_OPER_DATA(getter, [ FLAGS_FILTER(filter) ]);
+    STORE_OPER_DATA(setter, [ FLAGS_FILTER(filter), FLAGS_FILTER(IS_BOOL) ]);
+    STORE_OPER_DATA(tester, [ FLAGS_FILTER(filter) ]);
 
     # install the default functions
     FILTERS[ FLAG1_FILTER( getter ) ]:= getter;
@@ -1420,9 +1420,9 @@ BIND_GLOBAL( "NewProperty", function ( arg )
     tester := TESTER_FILTER( getter );
 
     # add getter, setter and tester to the list of operations
-    STORE_OPER_FLAGS(getter, [ flags ]);
-    STORE_OPER_FLAGS(setter, [ flags, FLAGS_FILTER(IS_BOOL) ]);
-    STORE_OPER_FLAGS(tester, [ flags ]);
+    STORE_OPER_DATA(getter, [ flags ]);
+    STORE_OPER_DATA(setter, [ flags, FLAGS_FILTER(IS_BOOL) ]);
+    STORE_OPER_DATA(tester, [ flags ]);
 
     # store the property getters
     ADD_LIST( NUMBERS_PROPERTY_GETTERS, FLAG1_FILTER( getter ) );
@@ -1509,7 +1509,7 @@ BIND_GLOBAL( "DeclareProperty", function ( arg )
         Error( "<filter> must be an operation" );
       fi;
 
-      STORE_OPER_FLAGS( gvar, [ FLAGS_FILTER( filter ) ] );
+      STORE_OPER_DATA( gvar, [ FLAGS_FILTER( filter ) ] );
 
     else
 

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -131,19 +131,43 @@ BIND_GLOBAL( "NUMBERS_PROPERTY_GETTERS", [] );
 #############################################################################
 ##
 #V  OPERATIONS
+#V  OPER_DATA
 ##
 ##  <ManSection>
 ##  <Var Name="OPERATIONS"/>
+##  <Var Name="OPER_DATA"/>
+##  <Func Name="STORE_OPER_DATA"/>
+##  <Func Name="GET_OPER_FLAGS"/>
+##  <Func Name="GET_DECLARATION_LOCATIONS"/>
+##
 ##
 ##  <Description>
-##  is a list that stores all &GAP; operations at the odd positions,
-##  and the corresponding list of requirements at the even positions.
-##  More precisely, if the operation <C>OPERATIONS[<A>n</A>]</C> has been declared
-##  by several calls of <C>DeclareOperation</C>,
-##  with second arguments <A>req1</A>, <A>req2</A>, \ldots,
-##  each being a list of filters, then <C>OPERATIONS[ <A>n</A>+1 ]</C> is the list
-##  <C>[</C> <A>flags1</A>, <A>flags2</A>, <M>\ldots</M>, <C>]</C>,
-##  where <A>flagsi</A> is the list of flags of the filters in <A>reqi</A>.
+##  <Ref Var="OPERATIONS"/> is a list that stores all &GAP; operations, and
+##  <Ref Var="OPER_DATA"/> is a record that stores additional information
+##  about operations, such lists of required filters and source locations
+##  where <Ref Func="DeclareOperation"> was called.
+##
+##  The functions <Ref Func="GET_OPER_FLAGS"/> and
+##  <Ref Func="GET_DECLARATION_LOCATIONS"/> are provided to obtain stored
+##  information.
+##
+##  <Ref Func="STORE_OPER_DATA"/> is used to store the flags and source
+##  locations of calls to <Ref Func="NewOperation"/> ord
+##  <Ref Func="DeclareOperation"/>
+##
+##  More precisely, if for the operation <C>op</C>, which has been declared by
+##  by several calls of <Ref Func="DeclareOperation"/> , each with second
+##  arguments <A>req1</A>, <A>req2</A>, \ldots, then calling
+##  <Ref Func="GET_OPER_FLAGS"/>  with argument <A>op</A> returns the list
+##  <C>[ flags1, flags2, \ldots ]</C>, where <C>flagsi</C> is the list offset
+##  flags of the filters in <C>reqi</C>.
+##
+##  Calling <Ref Func="GET_DECLARATION_LOCATIONS"/> with argument <A>op</A>
+##  returns a list of source locations where <Ref Func="NewOperation"/> or 
+##  <Ref Func="DeclareOperation"/> was called.
+##
+##  A <E>source location on</E> is a pair <C>[ f, n ]</C> where <C>f</C> is a
+##  filename and <C>l</C> is a line number in the file.
 ##  </Description>
 ##  </ManSection>
 ##


### PR DESCRIPTION
This PR first renames `OPER_FLAGS` to `OPER_DATA`. This is because I would like to store additional information about operations at a later stage (such as mutability for attributes), and `OPER_DATA` seems a more fitting name.

It then introduces an optional argument to `STORE_OPER_DATA` which is stored alongside the flags and the location info.

I debated multiple slightly different options for this storage, as currently of course the optional argument is always the empty list, and hence only adds storage overhead.

I tried storing all information as a list of records (this makes startup times quite slow), but storing just the additional information (location plus optional information) as a list of records, not binding the component for the optional argument might work better than what there is now. Of course providing an API to these structures makes it easy to hide these details from the user (being the GAP systems programmer in this case).

This PR also makes an attempt to update the documentation for `OPERATIONS` and `OPER_DATA` as well as the functions that access these lists.