### PR TITLE
Move Input/Output parts of GAPState into IO module state

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -98,23 +98,25 @@ static inline void PopLoopNesting( void ) {
 
 static inline UInt SetupGapname(void)
 {
-    if (STATE(Input)->gapnameid == 0) {
+    UInt gapnameid = GetInputFilenameID();
+    if (gapnameid == 0) {
         Obj filename = MakeImmString(GetInputFilename());
 #ifdef HPCGAP
         // TODO/FIXME: adjust this code to work more like the corresponding
         // code below for GAP?!?
-        STATE(Input)->gapnameid = AddAList(FilenameCache, filename);
+        gapnameid = AddAList(FilenameCache, filename);
 #else
         Obj pos = POS_LIST(FilenameCache, filename, INTOBJ_INT(1));
         if (pos == Fail) {
-            STATE(Input)->gapnameid = PushPlist(FilenameCache, filename);
+            gapnameid = PushPlist(FilenameCache, filename);
         }
         else {
-            STATE(Input)->gapnameid = INT_INTOBJ(pos);
+            gapnameid = INT_INTOBJ(pos);
         }
 #endif
+        SetInputFilenameID(gapnameid);
     }
-    return STATE(Input)->gapnameid;
+    return gapnameid;
 }
 
 Obj FuncGET_FILENAME_CACHE(Obj self)

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -12,7 +12,6 @@
 #define GAP_GAPSTATE_H
 
 #include <src/debug.h>
-#include <src/io.h>
 
 #if defined(HPCGAP)
 #include <src/hpc/tls.h>
@@ -67,24 +66,10 @@ typedef struct GAPState {
     UInt   NrError;
     UInt   NrErrLine;
     UInt   Symbol;
+
     const Char * Prompt;
 
-    TypInputFile *  InputStack[MAX_OPEN_FILES];
-    TypOutputFile * OutputStack[MAX_OPEN_FILES];
-    int             InputStackPointer;
-    int             OutputStackPointer;
-
-    TypInputFile *  Input;
-    Char *          In;
-    TypOutputFile * Output;
-    TypOutputFile * InputLog;
-    TypOutputFile * OutputLog;
-    TypOutputFile * IgnoreStdoutErrout;
-    TypOutputFile   InputLogFileOrStream;
-    TypOutputFile   OutputLogFileOrStream;
-    Int             NoSplitLine;
-    Char            Pushback;
-    Char *          RealIn;
+    Char * In;
 
     /* From stats.c */
     Stat CurrStat;

--- a/src/io.c
+++ b/src/io.c
@@ -29,6 +29,77 @@
 #include <src/sysfiles.h>
 
 
+/****************************************************************************
+**
+*T  TypInputFile  . . . . . . . . . .  structure of an open input file, local
+**
+**  'TypInputFile' describes the  information stored  for  open input  files:
+**
+**  'isstream' is 'true' if input come from a stream.
+**
+**  'file'  holds the  file identifier  which  is received from 'SyFopen' and
+**  which is passed to 'SyFgets' and 'SyFclose' to identify this file.
+**
+**  'name' is the name of the file, this is only used in error messages.
+**
+**  'line' is a  buffer that holds the  current input  line.  This is  always
+**  terminated by the character '\0'.  Because 'line' holds  only part of the
+**  line for very long lines the last character need not be a <newline>.
+**
+**  'ptr' points to the current character within that line.  This is not used
+**  for the current input file, where 'In' points to the  current  character.
+**
+**  'number' is the number of the current line, is used in error messages.
+**
+**  'stream' is none zero if the input points to a stream.
+**
+**  'sline' contains the next line from the stream as GAP string.
+**
+*/
+typedef struct {
+    UInt   isstream;
+    Int    file;
+    Char   name[256];
+    UInt   gapnameid;
+    Char   line[32768];
+    Char * ptr;
+    UInt   symbol;
+    Int    number;
+    Obj    stream;
+    UInt   isstringstream;
+    Obj    sline;
+    Int    spos;
+    UInt   echo;
+} TypInputFile;
+
+
+/****************************************************************************
+**
+*T  TypOutputFiles  . . . . . . . . . structure of an open output file, local
+**
+**  'TypOutputFile' describes the information stored for open  output  files:
+**  'file' holds the file identifier which is  received  from  'SyFopen'  and
+**  which is passed to  'SyFputs'  and  'SyFclose'  to  identify  this  file.
+**  'line' is a buffer that holds the current output line.
+**  'pos' is the position of the current character on that line.
+*/
+/* the maximal number of used line break hints */
+#define MAXHINTS 100
+typedef struct {
+    UInt isstream;
+    UInt isstringstream;
+    Int  file;
+    Char line[MAXLENOUTPUTLINE];
+    Int  pos;
+    Int  format;
+    Int  indent;
+
+    /* each hint is a tripel (position, value, indent) */
+    Int hints[3 * MAXHINTS + 1];
+    Obj stream;
+} TypOutputFile;
+
+
 static Char GetLine(void);
 static void PutLine2(TypOutputFile * output, const Char * line, UInt len);
 
@@ -1727,7 +1798,8 @@ static void putToTheStream(void *state, Char c) {
     PutChrTo((TypOutputFile *)state, c);
 }
 
-void PrTo(TypOutputFile * stream, const Char * format, Int arg1, Int arg2)
+static void
+PrTo(TypOutputFile * stream, const Char * format, Int arg1, Int arg2)
 {
   FormatOutput( putToTheStream, stream, format, arg1, arg2);
 }

--- a/src/io.c
+++ b/src/io.c
@@ -126,6 +126,18 @@ Int GetInputLinePosition(void)
     }
 }
 
+UInt GetInputFilenameID(void)
+{
+    GAP_ASSERT(STATE(Input));
+    return STATE(Input)->gapnameid;
+}
+
+void SetInputFilenameID(UInt id)
+{
+    GAP_ASSERT(STATE(Input));
+    STATE(Input)->gapnameid = id;
+}
+
 
 /****************************************************************************
 **

--- a/src/io.h
+++ b/src/io.h
@@ -330,50 +330,6 @@ extern UInt OpenAppend (
 
 /****************************************************************************
 **
-*T  TypInputFile  . . . . . . . . . .  structure of an open input file, local
-**
-**  'TypInputFile' describes the  information stored  for  open input  files:
-**
-**  'isstream' is 'true' if input come from a stream.
-**
-**  'file'  holds the  file identifier  which  is received from 'SyFopen' and
-**  which is passed to 'SyFgets' and 'SyFclose' to identify this file.
-**
-**  'name' is the name of the file, this is only used in error messages.
-**
-**  'line' is a  buffer that holds the  current input  line.  This is  always
-**  terminated by the character '\0'.  Because 'line' holds  only part of the
-**  line for very long lines the last character need not be a <newline>.
-**
-**  'ptr' points to the current character within that line.  This is not used
-**  for the current input file, where 'In' points to the  current  character.
-**
-**  'number' is the number of the current line, is used in error messages.
-**
-**  'stream' is none zero if the input points to a stream.
-**
-**  'sline' contains the next line from the stream as GAP string.
-**
-*/
-typedef struct {
-  UInt        isstream;
-  Int         file;
-  Char        name [256];
-  UInt        gapnameid;
-  Char        line [32768];
-  Char *      ptr;
-  UInt        symbol;
-  Int         number;
-  Obj         stream;
-  UInt        isstringstream;
-  Obj         sline;
-  Int         spos;
-  UInt        echo;
-} TypInputFile;
-
-
-/****************************************************************************
-**
 *V  In  . . . . . . . . . . . . . . . . . pointer to current character, local
 **
 **  'In' is a  pointer to  the current  input character, i.e.,  '*In' is  the
@@ -400,32 +356,9 @@ extern UInt GetInputFilenameID(void);
 extern void SetInputFilenameID(UInt id);
 
 
-/****************************************************************************
-**
-*T  TypOutputFiles  . . . . . . . . . structure of an open output file, local
-**
-**  'TypOutputFile' describes the information stored for open  output  files:
-**  'file' holds the file identifier which is  received  from  'SyFopen'  and
-**  which is passed to  'SyFputs'  and  'SyFclose'  to  identify  this  file.
-**  'line' is a buffer that holds the current output line.
-**  'pos' is the position of the current character on that line.
-*/
 /* the widest allowed screen width */
 #define MAXLENOUTPUTLINE  4096
-/* the maximal number of used line break hints */ 
-#define MAXHINTS 100
-typedef struct {
-    UInt        isstream;
-    UInt        isstringstream;
-    Int         file;
-    Char        line [MAXLENOUTPUTLINE];
-    Int         pos;
-    Int         format;
-    Int         indent;
-    /* each hint is a tripel (position, value, indent) */
-    Int         hints[3*MAXHINTS+1];
-    Obj         stream;
-} TypOutputFile;
+
 
 // Reset the indentation level of the current output to zero. The indentation
 // level can be modified via the '%>' and '%<' formats of 'Pr' resp. 'PrTo'.
@@ -473,12 +406,6 @@ extern  void            Pr (
             Int                 arg1,
             Int                 arg2 );
 
-
-extern  void            PrTo (
-            TypOutputFile *   stream,
-            const Char *    format,
-            Int                 arg1,
-            Int                 arg2 );
 
 extern  void            SPrTo (
 			       Char * buffer,

--- a/src/io.h
+++ b/src/io.h
@@ -374,22 +374,12 @@ typedef struct {
 
 /****************************************************************************
 **
-*V  InputFiles[]  . . . . . . . . . . . . .  stack of open input files, local
-*V  Input . . . . . . . . . . . . . . .  pointer to current input file, local
 *V  In  . . . . . . . . . . . . . . . . . pointer to current character, local
-**
-**  'InputFiles' is the stack of the open input  files.  It is represented as
-**  an array of structures of type 'TypInputFile'.
-**
-**  'Input' is a pointer to the current input file.   It points to the top of
-**  the stack 'InputFiles'.
 **
 **  'In' is a  pointer to  the current  input character, i.e.,  '*In' is  the
 **  current input character.  It points into the buffer 'Input->line'.
 */
 
-/* TL: extern TypInputFile    InputFiles [16]; */
-/* TL: extern TypInputFile *  Input; */
 /* TL: extern Char *          In; */
 
 
@@ -413,20 +403,12 @@ extern void SetInputFilenameID(UInt id);
 /****************************************************************************
 **
 *T  TypOutputFiles  . . . . . . . . . structure of an open output file, local
-*V  OutputFiles . . . . . . . . . . . . . . stack of open output files, local
-*V  Output  . . . . . . . . . . . . . . pointer to current output file, local
 **
 **  'TypOutputFile' describes the information stored for open  output  files:
 **  'file' holds the file identifier which is  received  from  'SyFopen'  and
 **  which is passed to  'SyFputs'  and  'SyFclose'  to  identify  this  file.
 **  'line' is a buffer that holds the current output line.
 **  'pos' is the position of the current character on that line.
-**
-**  'OutputFiles' is the stack of open output files.  It  is  represented  as
-**  an array of structures of type 'TypOutputFile'.
-**
-**  'Output' is a pointer to the current output file.  It points to  the  top
-**  of the stack 'OutputFiles'.
 */
 /* the widest allowed screen width */
 #define MAXLENOUTPUTLINE  4096
@@ -505,28 +487,6 @@ extern  void            SPrTo (
             Int                 arg1,
             Int                 arg2 );
 
-
-
-/****************************************************************************
-**
-*V  InputLog  . . . . . . . . . . . . . . . file identifier of logfile, local
-**
-**  'InputLog' is the file identifier of the current input logfile.  If it is
-**  not 0  the    scanner echoes all input   from  the files  '*stdin*'   and
-**  '*errin*' to this file.
-*/
-/* TL: extern TypOutputFile * InputLog; */
-
-
-/****************************************************************************
-**
-*V  OutputLog . . . . . . . . . . . . . . . file identifier of logfile, local
-**
-**  'OutputLog' is the file identifier of  the current output logfile.  If it
-**  is  not  0  the  scanner echoes  all output  to  the files '*stdout*' and
-**  '*errout*' to this file.
-*/
-/* TL: extern TypOutputFile * OutputLog; */
 
 
 /****************************************************************************

--- a/src/io.h
+++ b/src/io.h
@@ -405,6 +405,10 @@ extern const Char * GetInputLineBuffer(void);
 //
 extern Int GetInputLinePosition(void);
 
+// get or set the filenameid (if any) of the current input
+extern UInt GetInputFilenameID(void);
+extern void SetInputFilenameID(UInt id);
+
 
 /****************************************************************************
 **


### PR DESCRIPTION
This contains the parts of PR #2031 which rely on the "RNam" hack that was deemed problematic in that PR. Hence this should not (yet) be merged before that is resolved.

One way to do that would be simply keep the `gapnameid` as it is right now, but add another global accessor function to query it. Like `GetFilenameIdOfCurrentInput()` or so.

OTOH, computing the filenameid from a filename string is not *that* expensive, and only has to be done once for each function which gets coded, of which there are only a few 10,000 when loading GAP. So, it would be perfectly reasonable to have recompute it each time in `SetupGapname()`. That would allow completely decoupling the io module from the code mapping filenames to ids.

That code then in turn could either be implemented as it is right now (with a linear search), plus some improvements to get the HPC-GAP version in sync with the GAP version (that could be achieved via some simple locking, I think; as we load the library in a single thread, that shouldn't be problematic at all).

Or we could use a simply hash table. In fact, we already have two (very similar) hash tables mapping strings to something: in `src/gvars.c` and in `src/records.c`. I already thought about factoring that out before; if that was done, then the filename cache could be a third place it is used.