### PR TITLE
Touch gmp.info so GMP does not try to rebuild it

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -539,8 +539,11 @@ EXTERN_FILES += $(GMP_FILES)
 # Note: we pass the ABI flag to gmp, and also --enable-shared ; the latter
 # is there for the benefit of cygwin builds, where GMP otherwise defaults
 # to building only a static library.
+# We touch gmp.info so GMP does not think it is out of date and rebuilds it,
+# because that requires makeinfo
 gmp: $(GMP_FILES)
 $(GMP_FILES):
+	touch "$(abs_srcdir)/extern/gmp/doc/gmp.info"
 	MAKE=$(MAKE) $(srcdir)/cnf/build-extern.sh gmp "$(abs_srcdir)/extern/gmp" ABI=$(ABI) --disable-static --enable-shared
 
 .PHONY: gmp


### PR DESCRIPTION
This just stops GMP trying to rebuild it's documentation.

There doesn't seem to be a way to make GMP without it trying to build documentation, so we just touch a file to update it's timestamp so it won't try.

Resolves #2084 