### PR TITLE
Avoid some integer factoring; use PrimeDivisors

### DIFF
--- a/benchmark/transgrp/examine4
+++ b/benchmark/transgrp/examine4
@@ -2902,7 +2902,7 @@ local b,w,a,fno,cnt,normalsyl,tf,nt,tno,ntno,i,j,k,com,hom,cs,ker,nf;
   fno:=PreImage(sys.blockhom,fno); # factor normalizer
 
   # are we effectively working modulo a prime?
-  normalsyl:=Filtered(Set(Factors(Size(fno))),p->
+  normalsyl:=Filtered(PrimeDivisors(Size(fno)),p->
     (not IsInt(Index(w,b)/p)) and
     IsNormal(fno,SylowSubgroup(b,p)) );
 
@@ -3559,7 +3559,7 @@ local bls, # block size
     else
       # see, whether it's worth to use subgroups of minops
       p:=List(minops,i->Factors(Size(i)));
-      c:=Set(Factors(Size(i)));
+      c:=PrimeDivisors(Size(i));
       c:=List(p,i->Filtered(i,j->not j in c));
       p:=Minimum(List(c,Product));
       if p>1 and bla>5 and bls*bla>23 then

--- a/doc/ref/intrfc.xml
+++ b/doc/ref/intrfc.xml
@@ -335,8 +335,7 @@ operation:
 InstallMethod(PrimesDividingSize,"for finite groups",
   [IsGroup and IsFinite],
 function(G)
-  if Size(G)=1 then return [];
-  else return Set(Factors(Size(G)));fi;
+  return PrimeDivisors(Size(G));
 end);
 ]]></Log>
 <P/>

--- a/doc/ref/testconsistency.g
+++ b/doc/ref/testconsistency.g
@@ -109,7 +109,7 @@ for elt in x do
         errcount:=errcount+1;
       fi;
       if elt.name="Meth" then
-        if Length( Filtered( x, t -> t.attributes.Name=name and t.name in ["Attr","Prop","Oper"] ) ) = 0 then
+        if Number( x, t -> t.attributes.Name=name and t.name in ["Attr","Prop","Oper"] ) = 0 then
           pos:=OriginalPositionDocument(doc[2],elt.start);
           Print( pos[1], ":", pos[2], " : ", name, " uses Meth with no matching Oper/Attr/Prop\n" );
           errcount:=errcount+1;

--- a/grp/simple.gi
+++ b/grp/simple.gi
@@ -412,7 +412,7 @@ local brg,str,p,a,param,g,s,small,plus,sets;
 	SetIsSimpleGroup(g,true);
 	return g;
       elif Length(param)=1 and param[1]>7 and
-        Set(Factors(param[1]))=[2] and IsOddInt(LogInt(param[1],2)) then
+        PrimeDivisors(param[1])=[2] and IsOddInt(LogInt(param[1],2)) then
 	g:=SuzukiGroup(IsPermGroup,param[1]);
 	SetName(g,Concatenation("Sz(",String(param),")"));
 	SetIsSimpleGroup(g,true);
@@ -422,7 +422,7 @@ local brg,str,p,a,param,g,s,small,plus,sets;
       fi;
     elif str="R" or str="REE" or str="2G" then
       if Length(param)=1 and param[1]>26 and
-        Set(Factors(param[1]))=[3] and IsOddInt(LogInt(param[1],3)) then
+        PrimeDivisors(param[1])=[3] and IsOddInt(LogInt(param[1],3)) then
 	g:=ReeGroup(IsMatrixGroup,param[1]);
 	SetName(g,Concatenation("Ree(",String(param[1]),")"));
 	SetIsSimpleGroup(g,true);

--- a/hpcgap/lib/polyconw.gi
+++ b/hpcgap/lib/polyconw.gi
@@ -105,7 +105,7 @@ BindGlobal( "IsConsistentPolynomial", function( pol )
   local n, p, ps, x, null, f;
   n := DegreeOfLaurentPolynomial(pol);
   p := Characteristic(pol);
-  ps := Set(FactorsInt(n));
+  ps := PrimeDivisors(n);
   x := IndeterminateOfLaurentPolynomial(pol);
   null := 0*pol;
   f := function(k)
@@ -187,7 +187,7 @@ end);
 ##  all proper subfields.
 BindGlobal("NrCompatiblePolynomials", function(p, n)
   local ps, lcm;
-  ps := Set(Factors(n));
+  ps := PrimeDivisors(n);
   lcm := Lcm(List(ps, r-> p^(n/r)-1));
   return (p^n-1)/lcm;
 end);
@@ -320,7 +320,7 @@ InstallGlobalFunction( ConwayPol, function( p, n )
       if n > 1 then
 
         # Compute the list of all `n / l' for `l' a prime divisor of `n'
-        nfacs:= List( Set( Factors( n ) ), d -> n / d );
+        nfacs:= List( PrimeDivisors( n ), d -> n / d );
 
         if nfacs = [ 1 ] then
 
@@ -343,7 +343,7 @@ InstallGlobalFunction( ConwayPol, function( p, n )
 
         quots:= List( nfacs, x -> pp / ( p^x -1 ) );
         lencpols:= Length( cpols );
-        ppmin:= List( Set( Factors( pp ) ), d -> pp/d );
+        ppmin:= List( PrimeDivisors( pp ), d -> pp/d );
 
         found:= false;
         onelist:= [ one ];
@@ -557,7 +557,7 @@ InstallGlobalFunction( RandomPrimitivePolynomial, function(F, n, varnum...)
   FF := AlgebraicExtension(F, pol);
   one := One(FF);
   zero := Zero(FF);
-  fac:=List(Set(Factors(Size(FF)-1)), p-> (Size(FF)-1)/p);
+  fac:=List(PrimeDivisors(Size(FF)-1), p-> (Size(FF)-1)/p);
   repeat
     a := Random(FF);
   until a <> zero and ForAll(fac, d-> a^d <> one);

--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -254,7 +254,7 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
 	d:=RefinedSubnormalSeries(d,i);
       od;
     fi;
-    for i in Set(Factors(Size(r))) do
+    for i in PrimeDivisors(Size(r)) do
       u:=PCore(r,i);
       if Size(u)>1 then
 	d:=RefinedSubnormalSeries(d,u);
@@ -288,7 +288,7 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
   ser:=[TrivialSubgroup(G)];
   for i in d{[2..Length(d)]} do
     u:=ser[Length(ser)];
-    for p in Set(Factors(Size(i)/Size(u))) do
+    for p in PrimeDivisors(Size(i)/Size(u)) do
       bd:=PValuation(Size(i)/Size(u),p); # max p-exponent
       u:=ClosureSubgroup(u,SylowSubgroup(i,p));
       v:=ser[Length(ser)];

--- a/lib/clas.gi
+++ b/lib/clas.gi
@@ -761,7 +761,7 @@ local rcls, cl, mark, rep, c, o, cop, same, sub, pow, p, i, j,closure,
   rcls:=[];
   cl:=ConjugacyClasses(G);
 
-  if Length(Filtered(cl,x->Size(x)<10))<10000 then
+  if Number(cl,x->Size(x)<10)<10000 then
     # trigger for cheap element test
     for i in [1..Length(cl)] do
       if Size(cl[i])<10 then AsSSortedList(cl[i]);fi;

--- a/lib/clas.gi
+++ b/lib/clas.gi
@@ -725,7 +725,7 @@ InstallGlobalFunction( RationalClassesTry, function(  G, classes, elm  )
         Add( classes, C );
 
         # try the powers of this element that reduce the order
-        for i  in Set(FactorsInt(Order(elm)))  do
+        for i in PrimeDivisors(Order(elm)) do
             RationalClassesTry( G, classes, elm ^ i );
         od;
 

--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -353,7 +353,7 @@ InstallGlobalFunction( CompatibleConjugacyClassesDefault,
     fi;
 
     # Use power maps.
-    primes:= Set( Factors( Size( tbl ) ) );
+    primes:= PrimeDivisors( Size( tbl ) );
 
     # store power maps of the group, in order to identify the class
     # of the power only once.
@@ -1130,7 +1130,7 @@ InstallMethod( AbelianInvariants,
 
       # For all prime divisors $p$ of the size,
       # compute the element of maximal $p$ power order.
-      primes:= Set( FactorsInt( Size( tbl ) ) );
+      primes:= PrimeDivisors( Size( tbl ) );
       max:= List( primes, x -> 1 );
       pos:= [];
       orders:= OrdersClassRepresentatives( tbl );
@@ -1618,7 +1618,7 @@ InstallMethod( OrdersClassRepresentatives,
 
     # If these maps do not suffice, compute the missing power maps
     # and then try again.
-    for p in Set( Factors( Size( tbl ) ) ) do
+    for p in PrimeDivisors( Size( tbl ) ) do
       PowerMap( tbl, p );
     od;
     ord:= ElementOrdersPowerMap( ComputedPowerMaps( tbl ) );
@@ -2659,7 +2659,7 @@ InstallMethod( ClassRoots,
     orders := OrdersClassRepresentatives( tbl );
     root   := List([1..nccl], x->[]);
 
-    for p in Set( Factors( Size( tbl ) ) ) do
+    for p in PrimeDivisors( Size( tbl ) ) do
        pmap:= PowerMap( tbl, p );
        for i in [1..nccl] do
           if i <> pmap[i] and orders[i] <> orders[pmap[i]] then
@@ -3495,7 +3495,7 @@ InstallMethod( IsInternallyConsistent,
       # If the power maps of all prime divisors of the order are stored,
       # check if they are consistent with the representative orders.
       if     IsBound( orders )
-         and ForAll( Set( FactorsInt( order ) ), x -> IsBound(powermap[x]) )
+         and ForAll( PrimeDivisors( order ), x -> IsBound(powermap[x]) )
          and orders <> ElementOrdersPowerMap( powermap ) then
         Info( InfoWarning, 1,
               "IsInternallyConsistent(", tbl, "):\n",
@@ -3656,7 +3656,7 @@ InstallMethod( IsInternallyConsistent,
       # If the power maps of all prime divisors of the order are stored,
       # check if they are consistent with the representative orders.
       if     IsBound( orders )
-         and ForAll( Set( FactorsInt( order ) ), x -> IsBound(powermap[x]) )
+         and ForAll( PrimeDivisors( order ), x -> IsBound(powermap[x]) )
          and orders <> ElementOrdersPowerMap( powermap ) then
         flag:= false;
         Info( InfoWarning, 1,
@@ -3775,7 +3775,7 @@ InstallMethod( IsPSolvableCharacterTableOp,
       # \ldots and its size.
       nextsize:= Sum( classes{ nsg[i] }, 0 );
 
-      facts:= Set( FactorsInt( nextsize / size ) );
+      facts:= PrimeDivisors( nextsize / size );
       if 1 < Length( facts ) and ( p = 0 or p in facts ) then
 
         # The chief factor `nsg[i] / n' is not a prime power,
@@ -4820,7 +4820,7 @@ BindGlobal( "CharacterTableDisplayDefault", function( tbl, options )
       tbl_centralizers:= SizesCentralizers( tbl );
     elif centralizers = true then
       tbl_centralizers:= SizesCentralizers( tbl );
-      primes:= Set( FactorsInt( Size( tbl ) ) );
+      primes:= PrimeDivisors( Size( tbl ) );
       cen:= [];
       for prime in primes do
         cen[ prime ]:= [];
@@ -5650,7 +5650,7 @@ InstallMethod( CharacterTableFactorGroup,
     # Transfer necessary power maps of `tbl' to `F'.
     inverse:= ProjectionMap( factorfusion );
     maps:= ComputedPowerMaps( F );
-    for p in Set( Factors( Size( F ) ) ) do
+    for p in PrimeDivisors( Size( F ) ) do
       if not IsBound( maps[p] ) then
         maps[p]:= factorfusion{ PowerMap( tbl, p ){ inverse } };
       fi;
@@ -5923,7 +5923,7 @@ InstallOtherMethod( CharacterTableIsoclinic,
     invfusion:= InverseMap( factorfusion );
 
     # Adjust the power maps.
-    for p in Set( Factors( size ) ) do
+    for p in PrimeDivisors( size ) do
 
       map:= ShallowCopy( PowerMap( tbl, p ) );
 

--- a/lib/ctblauto.gi
+++ b/lib/ctblauto.gi
@@ -596,7 +596,7 @@ InstallMethod( TableAutomorphisms,
     nccl:= NrConjugacyClasses( tbl );
 
     # Check whether all generators commute with all power maps.
-    powermap:= List( Set( Factors( Size( tbl ) ) ),
+    powermap:= List( PrimeDivisors( Size( tbl ) ),
                      p -> PowerMap( tbl, p ) );
     admissible:= Filtered( gens, 
                            perm -> ForAll( powermap, 
@@ -1011,7 +1011,7 @@ InstallMethod( TransformingPermutationsCharacterTables,
     # - If the group orders differ then return `fail'.
     # - If irreducibles are stored in the two tables and coincide,
     #   and if the power maps are known and equal then return the identity.
-    primes:= Set( Factors( Size( tbl1 ) ) );
+    primes:= PrimeDivisors( Size( tbl1 ) );
     if Size( tbl1 ) <> Size( tbl2 ) then
       return fail;
     elif HasIrr( tbl1 ) and HasIrr( tbl2 ) and Irr( tbl1 ) = Irr( tbl2 )

--- a/lib/ctblauto.gi
+++ b/lib/ctblauto.gi
@@ -509,7 +509,7 @@ InstallMethod( MatrixAutomorphisms,
     Info( InfoMatrix, 2,
           "MatAutomorphisms: There are ", Length( permutations ),
           " families (",
-          Length( Filtered( permutations, x -> Length(x) =1 ) ),
+          Number( permutations, x -> Length(x) =1 ),
           " trivial)" );
     
     for i in [ 1 .. Length( famreps ) ] do

--- a/lib/ctblfuns.gi
+++ b/lib/ctblfuns.gi
@@ -4323,7 +4323,7 @@ InstallGlobalFunction( ReductionToFiniteField, function( value, p )
 
     if k <> 1 then
 
-      primes:= Set( Factors( m ) );
+      primes:= PrimeDivisors( m );
       sol:= fail;
 
       while not IsEmpty( primes ) do

--- a/lib/ctblmono.gi
+++ b/lib/ctblmono.gi
@@ -1105,7 +1105,7 @@ InstallMethod( TestMonomialQuick,
     # This follows from Theorem~(2D) in~\cite{Fon62}.
     if IsSolvableGroup( G ) then
 
-      pi   := Set( FactorsInt( codegree ) );
+      pi   := PrimeDivisors( codegree );
       hall := Product( Filtered( FactorsInt( factsize ), x -> x in pi ), 1 );
 
       if factsize / hall = chi[1] then
@@ -1245,7 +1245,7 @@ InstallOtherMethod( TestMonomialQuick,
         test:= rec( isMonomial := true,
                     comment    := "abelian by supersolvable group" );
 
-      elif ForAll( Set( FactorsInt( Size( ssr ) ) ),
+      elif ForAll( PrimeDivisors( Size( ssr ) ),
                    x -> IsAbelian( SylowSubgroup( ssr, x ) ) ) then
 
         # Sylow abelian by supersolvable groups are monomial.

--- a/lib/ctblpope.gi
+++ b/lib/ctblpope.gi
@@ -1494,7 +1494,7 @@ InstallGlobalFunction( PermCandidates,
 
     Info( InfoCharacterTable, 2,
           "PermCandidates: unique columns erased, there are ",
-          Length( Filtered( nonzerocol, x -> x ) ), " columns left,\n",
+          Number( nonzerocol, x -> x ), " columns left,\n",
           "#I    the number of constituents is ", Length( matrix ), "." );
 
     # step 3: collapse
@@ -2018,8 +2018,8 @@ InstallGlobalFunction( PermCandidatesFaithful,
           "PermCandidatesFaithful: There are ",
           Length( matrix ), " possible constituents,\n",
           "#I    the number of unknown values is ",
-          Length( Filtered( [ 1 .. nccl ],
-                  x -> not IsBound( faithful[x] ) ) ),
+          Number( [ 1 .. nccl ],
+                  x -> not IsBound( faithful[x] ) ),
           ";\n",
           "#I    now trying to collapse the matrix" );
 

--- a/lib/ctblpope.gi
+++ b/lib/ctblpope.gi
@@ -77,7 +77,7 @@ InstallGlobalFunction( TestPerm2, function(tbl, char)
    od;
 
    # TEST 5:
-   subfak:= Set(Factors(subord));
+   subfak:= PrimeDivisors(subord);
    for prime in subfak do
       if subord mod prime^2 <> 0 then
 
@@ -205,7 +205,7 @@ InstallGlobalFunction( TestPerm4, function( tbl, chars )
     size:= Size( tbl );
     orders:= OrdersClassRepresentatives( tbl );
 
-    for p in Set( Factors( Size( tbl ) ) ) do
+    for p in PrimeDivisors( Size( tbl ) ) do
 
       # Compute the distribution of characters to blocks.
       bl:= PrimeBlocks( tbl, p );

--- a/lib/ctblsymm.gi
+++ b/lib/ctblsymm.gi
@@ -1185,7 +1185,7 @@ InstallGlobalFunction( CharacterTableWreathSymmetric, function( sub, n )
     # \ldots, `ComputedPowerMaps', \ldots
     tbl.ComputedPowerMaps:= [];
     powermap:= tbl.ComputedPowerMaps;
-    for prime in Set( Factors( tbl.Size ) ) do
+    for prime in PrimeDivisors( tbl.Size ) do
        spm:= PowerMap( sub, prime );
        powermap[prime]:= List( [ 1 .. nccl ],
            i -> Position(parts, PowerWreath(spm, parts[i], prime)) );
@@ -1250,7 +1250,7 @@ InstallMethod( Irr,
     # Compute and store the power maps.
     pow:= ComputedPowerMaps( cG );
     fun:= gentbl.powermap[1];
-    for p in Set( Factors( Size( G ) ) ) do
+    for p in PrimeDivisors( Size( G ) ) do
       if not IsBound( pow[p] ) then
         pow[p]:= List( cp, x -> Position( cp, fun( deg, x[2], p ) ) );
       fi;

--- a/lib/cyclotom.gi
+++ b/lib/cyclotom.gi
@@ -231,7 +231,7 @@ InstallGlobalFunction( CoeffsCyc, function( z, N )
         #   and $n / s$, and hence remain in the reduced expression,
         # - all primes but the squarefree part of the rest.
 
-        factors:= Set( FactorsInt( s ) );
+        factors:= PrimeDivisors( s );
         second:= 1;
         for p in factors do
           if s mod p <> 0 or ( n / s ) mod p <> 0 then
@@ -301,7 +301,7 @@ InstallGlobalFunction( CoeffsCyc, function( z, N )
     # `E(n)^k' by $ - \sum_{j=1}^{p-1} `E(n*p)^(p*k+j*n)'$.
     if quo <> 1 then
 
-      for p in Set( FactorsInt( quo ) ) do
+      for p in PrimeDivisors( quo ) do
         if p <> 2 and n mod p <> 0 then
           nn  := n * p;
           quo := quo / p;
@@ -634,7 +634,7 @@ InstallGlobalFunction( NK, function( n, k, deriv )
       od;
     elif k in [ 3, 5, 7 ] then   # for odd primes
       if ( n mod ( k*k ) <> 0 ) and
-         ForAll( Set( FactorsInt( n ) ), p -> (p-1) mod k <> 0 ) then
+         ForAll( PrimeDivisors( n ), p -> (p-1) mod k <> 0 ) then
         return fail;
       fi;
       while true do
@@ -666,7 +666,7 @@ InstallGlobalFunction( NK, function( n, k, deriv )
     elif k = 4 then
       # An automorphism of order 4 exists if 4 divides $p-1$ for an odd
       # prime divisor $p$ of `n', or if 16 divides `n'.
-      if ForAll( Set( FactorsInt( n ) ), p -> (p-1) mod k <> 0 )
+      if ForAll( PrimeDivisors( n ), p -> (p-1) mod k <> 0 )
          and n mod 16 <> 0 then
         return fail;
       fi;
@@ -691,7 +691,7 @@ InstallGlobalFunction( NK, function( n, k, deriv )
       # An automorphism of order 6 exists if automorphisms of the orders
       # 2 and 3 exist; the former is always true.
       if ( n mod 9 <> 0 ) and
-         ForAll( Set( FactorsInt( n ) ), p -> (p-1) mod 3 <> 0 ) then
+         ForAll( PrimeDivisors( n ), p -> (p-1) mod 3 <> 0 ) then
         return fail;
       fi;
       while true do
@@ -721,7 +721,7 @@ InstallGlobalFunction( NK, function( n, k, deriv )
     elif k = 8 then
       # An automorphism of order 8 exists if 8 divides $p-1$ for an odd
       # prime divisor $p$ of `n', or if 32 divides `n'.
-      if ForAll( Set( FactorsInt( n ) ), p -> (p-1) mod k <> 0 )
+      if ForAll( PrimeDivisors( n ), p -> (p-1) mod k <> 0 )
          and n mod 32 <> 0 then
         return fail;
       fi;

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -867,7 +867,7 @@ local s,o,a,n,d,f,fn,j,b,i;
       n:=Filtered(NormalSubgroups(i),x->Size(x)>1);
       # if G is not fitting-free it has a proper normal subgroup of
       #  prime-power order
-      if ForAny(n,x->Length(Set(Factors(Size(x))))=1) then
+      if ForAny(n,x->IsPrimePowerInt(Size(x))) then
 	return fail;
       fi;
       n:=Filtered(n,IsSimpleGroup);

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -887,7 +887,7 @@ local o,C;
     Append(o,List(Orbits(C,MovedPoints(G)),Length));
   fi;
   o:=Lcm(o);
-  if Set(Factors(Size(G)))=Set(Factors(o)) then
+  if PrimeDivisors(Size(G))=PrimeDivisors(o) then
     # all primes in -- useless
     return G;
   fi;
@@ -898,7 +898,7 @@ end);
 BindGlobal("Halleen",function(arg)
 local G,gp,p,r,s,c,i,a,pp,prime,sy,k,b,dc,H,e,j,forbid;
   G:=arg[1];
-  gp:=Set(Factors(Size(G)));
+  gp:=PrimeDivisors(Size(G));
   if Length(arg)>1 then
     r:=arg[2];
     forbid:=Difference(gp,r);
@@ -1012,7 +1012,7 @@ local s,d,c,act,o,i,j,h,p,hf,img,n,prd,k,nk,map,ns,all,hl,hcomp,
     return [TrivialSubgroup(G)];
   elif false and Length(pi)=1 then
     return [SylowSubgroup(G,pi[1])];
-  elif pi=Set(Factors(Size(G))) then
+  elif pi=PrimeDivisors(Size(G)) then
     return [G];
   fi;
 

--- a/lib/gaussian.gi
+++ b/lib/gaussian.gi
@@ -279,7 +279,7 @@ InstallMethod( Factors,
 
     # loop over all factors of the norm of x
     facs := [];
-    for prm in Set( FactorsInt( EuclideanDegree( GaussianIntegers, x ) ) ) do
+    for prm in PrimeDivisors( EuclideanDegree( GaussianIntegers, x ) ) do
 
         # $p = 2$ and primes $p = 1$ mod 4 split according to $p = x^2 + y^2$
         if prm = 2  or prm mod 4 = 1  then

--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -1125,12 +1125,11 @@ local v,ma,mau,a,gens,imgs,q,k,co,aiu,aiv,primes,irrel;
     return fail;
   fi;
   # are there irrelevant primes?
-  primes:=Set(Factors(Product(aiu)*Product(aiv)));
+  primes:=Union(List(Union(aiu, aiv), PrimeDivisors));
   irrel:=Filtered(primes,x->Filtered(aiv,z->IsInt(z/x))=
                             Filtered(aiu,z->IsInt(z/x)));
 
-  Info(InfoFpGroup,1,"Larger by factor ",
-    Product(AbelianInvariants(v))/Product(AbelianInvariants(u)),"\n");
+  Info(InfoFpGroup,1,"Larger by factor ",Product(aiv)/Product(aiu),"\n");
   ma:=MaximalAbelianQuotient(v);
   mau:=MaximalAbelianQuotient(u);
   a:=Image(ma);

--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -1187,7 +1187,7 @@ syll, act, typ, sel, bas, wdom, comp, lperm, other, away, i, j,b0,opg,bp;
   Info(InfoGroup,1,"SymmAlt normalizer: orbits ",List(o,Length));
 
   if Length(o)=1 and IsAbelian(u) then
-    b:=List(Set(Factors(Size(u))),p->Omega(SylowSubgroup(u,p),p,1));
+    b:=List(PrimeDivisors(Size(u)),p->Omega(SylowSubgroup(u,p),p,1));
     if Length(b)=1 and IsTransitive(b[1],dom) then
       # elementary abelian, regular -- construct the correct AGL
       b:=b[1];

--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -608,10 +608,10 @@ InstallGlobalFunction(InnerSubdirectProducts2,function( D, U, V )
         normsU := NormalSubgroupsAbove( U, DerivedSubgroup(U),[]);
         normsV := List( ConjugacyClassesSubgroups( V ), Representative );
     else
-        div  := Set( FactorsInt( Gcd( Size( U ), Size( V ) ) ) );
+        div  := PrimeDivisors( Gcd( Size( U ), Size( V ) ) );
 
         # in U
-        fac  := Set( FactorsInt( Size( U ) ) );
+        fac  := PrimeDivisors( Size( U ) );
         fac  := Filtered( fac, x -> not x in div );
         Syl  := List( fac, x -> GeneratorsOfGroup( SylowSubgroup( U, x ) ) );
         Syl  := Concatenation( Syl );
@@ -619,7 +619,7 @@ InstallGlobalFunction(InnerSubdirectProducts2,function( D, U, V )
         normsU := NormalSubgroupsAbove( U, Syl, [] );
             
         # in V
-        fac  := Set( FactorsInt( Size( V ) ) );
+        fac  := PrimeDivisors( Size( V ) );
         fac  := Filtered( fac, x -> not x in div );
         Syl  := List( fac, x -> GeneratorsOfGroup( SylowSubgroup( V, x ) ) );
         Syl  := Concatenation( Syl );

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -52,7 +52,7 @@ InstallMethod( IsCyclic,
     # if <G> is finite, test if the <p>-th powers of the generators
     # generate a subgroup of index <p> for all prime divisors <p>
     elif IsFinite( G )  then
-        return ForAll( Set( FactorsInt( Size( G ) ) ),
+        return ForAll( PrimeDivisors( Size( G ) ),
                 p -> Index( G, SubgroupNC( G,
                                  List( GeneratorsOfGroup( G ),g->g^p)) ) = p );
 
@@ -644,7 +644,7 @@ InstallMethod( AbelianInvariants,
     inv := [];
     # the parent of this will be G
     cmm := DerivedSubgroup(G);
-    for p  in Set( FactorsInt( Size( G ) ) )  do
+    for p  in PrimeDivisors( Size( G ) )  do
         ranks := [];
         repeat
             H := cmm;
@@ -1139,7 +1139,7 @@ InstallMethod( Exponent,
 function(G)
   local exp, primes, p;
   exp := 1;
-  primes := Set(FactorsInt(Size(G)));
+  primes := PrimeDivisors(Size(G));
   for p in primes do
     exp := exp * Exponent(SylowSubgroup(G, p));
   od;
@@ -1171,7 +1171,7 @@ InstallMethod( FittingSubgroup,
     [ IsGroup and IsFinite ],
     function (G)
         if not IsTrivial( G ) then
-            G := SubgroupNC( G, Filtered(Union( List( Set( FactorsInt( Size( G ) ) ),
+            G := SubgroupNC( G, Filtered(Union( List( PrimeDivisors( Size( G ) ),
                          p -> GeneratorsOfGroup( PCore( G, p ) ) ) ),
                          p->p<>One(G)));
             Assert( 2, IsNilpotentGroup( G ) );
@@ -2621,7 +2621,7 @@ InstallMethod( IsPNilpotentOp,
 
     local primes, S;
 
-    primes:= Set( Factors( Size( G ) ) );
+    primes:= PrimeDivisors( Size( G ) );
     RemoveSet( primes, p );
     S:= HallSubgroup( G, primes );
 

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -4528,7 +4528,7 @@ function( g )
         return [ g ];
     else
         p := f[1];
-        x := Length( Filtered( f, y -> y = p ) );
+        x := Number( f, y -> y = p );
         q := p ^ x;
         r := o / q;
         gcd := Gcdex ( q, r );
@@ -4553,7 +4553,7 @@ function( g, p )
     if o = 1 then return g; fi;
 
     f := FactorsInt( o );
-    x := Length( Filtered( f, x -> x = p ) );
+    x := Number( f, x -> x = p );
     if x = 0 then return g^o; fi;
 
     q := p ^ x;

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -1513,7 +1513,6 @@ function (L)
 	    maxsz,
 	    mkk,
 	    ppow,
-	    primes,
 	    notperm,
 	    dom,
 	    orbs,
@@ -1529,7 +1528,6 @@ function (L)
       return [[]]; # trivial group
     fi;
     # relevant prime powers
-    primes:=Set(Factors(Size(grp)));
     ppow:=Collected(Factors(Size(grp)));
     ppow:=Union(List(ppow,i->List([1..i[2]],j->i[1]^j)));
 

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -2013,7 +2013,7 @@ local G,	# group
 	        
 
 		# try to catch some solvable cases that look awful
-		if Size(vs)>1000 and Length(Set(Factors(Index(j,N))))<=2
+		if Size(vs)>1000 and Length(PrimeDivisors(Index(j,N)))<=2
 		  then
 		  l:=fail;
 		else

--- a/lib/grppc.gi
+++ b/lib/grppc.gi
@@ -1335,8 +1335,8 @@ local  G,  home,  # the supergroup (of <H> and <U>), the home pcgs
   # Calculate a (central)  elementary abelian series  with all pcgs induced
   # w.r.t. <home>.
 
-  if IsPrimePowerInt( Size( G ) )  then
-    p:=FactorsInt( Size( G ) )[ 1 ];
+  if IsPGroup( G )  then
+    p:=PrimePGroup(G);
     home:=PcgsCentralSeries(G);
     eas:=CentralNormalSeriesByPcgs(home);
     cent:=ReturnTrue;
@@ -1534,8 +1534,8 @@ local G,	   # common parent
     # Calculate a (central) elementary abelian series.
 
     eas:=fail;
-    if IsPrimePowerInt( Size( G ) )  then
-        p := FactorsInt( Size( G ) )[ 1 ];
+    if IsPGroup( G ) then
+        p := PrimePGroup(G);
 	home:=PcgsPCentralSeriesPGroup(G);
 	eas:=PCentralNormalSeriesByPcgsPGroup(home);
 	if NT in eas then

--- a/lib/grppcaut.gi
+++ b/lib/grppcaut.gi
@@ -1879,7 +1879,7 @@ InstallGlobalFunction(AutomorphismGroupFrattFreeGroup,function( G )
 
     # add derivations
     Info( InfoAutGrp, 2, "add derivations ");
-    pr  := Set( FactorsInt( Size( F ) ) );
+    pr  := PrimeDivisors( Size( F ) );
     for p in pr do
 
         # create subgroup

--- a/lib/grppccom.gi
+++ b/lib/grppccom.gi
@@ -555,7 +555,7 @@ local   p, ocr;
     else
     return [rec( complement:=K, centralizer:=S )];
     fi;
-  elif IsEmpty(Intersection( Factors(Size(M)), Factors(Index(K,M))))  then
+  elif GcdInt(Size(M), Index(K,M)) = 1 then
 
     # If <K> and <M> are coprime, <K> splits.
     Info(InfoComplement,3,"CONextComplements: coprime case, <K> splits" );
@@ -880,7 +880,7 @@ local   H, E,  cor,  a,  i,  fun2,pcgs,home;
   fi;
 
   # if <G> and <N> are coprime <G> splits over <N>
-  if false and Intersection( Factors(Size(N)), Factors(Index(G,N))) = []  then
+  if false and GcdInt(Size(N), Index(G,N)) = 1  then
       Info(InfoComplement,3,"Complements: coprime case, <G> splits" );
       cor:=rec();
 
@@ -952,7 +952,7 @@ local G,N,M,keep,H,K,f,primes,p,A,S,L,hom,c,cn,nc,ncn,lnc,lncn,q,qs,qn,ser,
       A:=Core(H,A);
       if Size(A)>Size(K) then
 	# found one. Doesn't need to be elementary abelian
-	if Length(Set(Factors(Size(A)/Size(K))))>1 then
+	if not IsPrimePowerInt(Size(A)/Size(K)) then
 	  Error("multiple primes");
 	else
 	  primes:=[];

--- a/lib/grppccom.gi
+++ b/lib/grppccom.gi
@@ -940,7 +940,7 @@ local G,N,M,keep,H,K,f,primes,p,A,S,L,hom,c,cn,nc,ncn,lnc,lncn,q,qs,qn,ser,
   f:=Size(H)/Size(K);
   
   # find prime that gives normal characteristic subgroup
-  primes:=Set(Factors(f));
+  primes:=PrimeDivisors(f);
   if Length(primes)=1 then
     p:=primes[1];
     A:=H;

--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -1175,7 +1175,7 @@ local G,cl,lcl,len,comb,combc,com,a,cnt,s,alltwo;
   Info(InfoMorph,1,"FindGenerators");
   # throw out the 1-Class
   cl:=Filtered(cl,i->Length(i)>1 or Size(i[1].representative)>1);
-  alltwo:=Set(Factors(Size(G)))=[2];
+  alltwo:=PrimeDivisors(Size(G))=[2];
 
   #create just a list of ordinary classes.
   lcl:=List(cl,i->Concatenation(List(i,j->j.classes)));
@@ -1419,7 +1419,7 @@ local i,j,k,l,m,o,nl,nj,max,r,e,au,p,gens,offs;
 
   au:=[];
   # run by primes
-  p:=Set(Factors(Size(G)));
+  p:=PrimeDivisors(Size(G));
   for i in p do
     l:=Filtered(gens,j->IsInt(Order(j)/i));
     nl:=Filtered(gens,i->not i in l);

--- a/lib/numtheor.gi
+++ b/lib/numtheor.gi
@@ -33,7 +33,7 @@ InstallGlobalFunction( PrimeResidues, function ( m )
 
     # remove the multiples of all prime divisors
     residues := [1..m-1];
-    for p  in Set(FactorsInt(m))  do
+    for p in PrimeDivisors(m) do
         for i  in [1..m/p-1]  do
             residues[p*i] := 1;
         od;
@@ -64,7 +64,7 @@ InstallMethod( Phi,
 
     # compute $phi$
     phi := m;
-    for p  in Set(FactorsInt(m))  do
+    for p in PrimeDivisors(m) do
         phi := phi / p * (p-1);
     od;
 
@@ -93,7 +93,7 @@ InstallMethod( Lambda,
 
     # loop over all prime factors $p$ of $m$
     lambda := 1;
-    for p  in Set(FactorsInt(m))  do
+    for p in PrimeDivisors(m) do
 
         # compute $p^e$ and $k = (p-1) p^(e-1)$
         q := p;  k := p-1;
@@ -138,7 +138,7 @@ InstallGlobalFunction( OrderMod, function ( n, m )
     # otherwise try the divisors of $\lambda(m)$ and their divisors, etc.
     else
         o := Lambda( m );
-        for d in Set( FactorsInt( o ) )  do
+        for d in PrimeDivisors( o ) do
             while o mod d = 0  and PowerModInt(n,o/d,m) = 1  do
                 o := o / d;
             od;
@@ -185,7 +185,7 @@ InstallGlobalFunction( IsPrimitiveRootMod, function ( r, m )
     fi;
 
     # compute $pows_i := r^{{p-1}/\prod_{k=2}^{i}{facs_k}}$ ($facs_1 = 2$)
-    facs := Set( FactorsInt( p-1 ) );
+    facs := PrimeDivisors( p-1 );
     pows := [];
     pows[Length(facs)] := PowerModInt( r, 2*(p-1)/Product(facs), p );
     for i  in Reversed( [2..Length(facs)-1] )  do
@@ -357,7 +357,7 @@ InstallGlobalFunction( Legendre, function ( n, m )
     if m < 6              then return -1;  fi;
 
     # check that $n$ is a quadratic residue modulo every prime power $q$
-    for p  in Set( FactorsInt( m ) )  do
+    for p  in PrimeDivisors( m )  do
 
         # find prime power $q$ and reduce $n$
         q := p;  while m mod (q * p) = 0  do q := q * p;  od;
@@ -604,7 +604,7 @@ InstallGlobalFunction( RootMod, function ( arg )
 
     # combine the root modulo every prime power $p^l$
     r := 0;  qq := 1;
-    for p  in Set( FactorsInt( m : UseProbabilisticPrimalityTest ) ) do
+    for p  in PrimeDivisors( m : UseProbabilisticPrimalityTest ) do
 
         # find prime power $q = p^l$
         q := p;  l := 1;
@@ -849,7 +849,7 @@ InstallGlobalFunction( RootsMod, function ( arg )
 
     # combine the roots modulo every prime power $p^l$
     rr := [0];  qq := 1;
-    for p  in Set( FactorsInt( m : UseProbabilisticPrimalityTest ) )  do
+    for p  in PrimeDivisors( m : UseProbabilisticPrimalityTest )  do
 
         # find prime power $q = p^l$
         q := p;  l := 1;
@@ -998,7 +998,7 @@ InstallGlobalFunction( RootsUnityMod, function ( arg )
 
     # combine the roots modulo every prime power $p^l$
     rr := [0];  qq := 1;
-    for p  in Set( FactorsInt( m ) )  do
+    for p in PrimeDivisors( m ) do
 
         # find prime power $q = p^l$
         q := p;  l := 1;
@@ -1245,7 +1245,7 @@ InstallMethod( Sigma,
 
     # loop over all prime $p$ factors of $n$
     sigma := 1;
-    for p  in Set(FactorsInt(n))  do                                         
+    for p in PrimeDivisors(n) do
 
         # compute $p^e$ and $k = 1+p+p^2+..p^e$                              
         q := p;  k := 1 + p;
@@ -1280,7 +1280,7 @@ InstallMethod( Tau,
 
     # loop over all prime factors $p$ of $n$
     tau := 1;
-    for p  in Set(FactorsInt(n))  do                                         
+    for p in PrimeDivisors(n) do
 
         # compute $p^e$ and $k = e+1$                                        
         q := p;  k := 2;
@@ -1327,7 +1327,7 @@ InstallGlobalFunction( TwoSquares, function ( n )
     # write $n = c^2 d$, where $c$ has only  prime factors  $2$  and  $4k+3$,
     # and $d$ has at most one  $2$ and otherwise only  prime factors  $4k+1$.
     c := 1;  d := 1;
-    for p  in Set( FactorsInt( n ) )  do
+    for p in PrimeDivisors( n ) do
         q := p;  l := 1;
         while n mod (q * p) = 0  do q := q * p;  l := l + 1;  od;
         if p = 2  and l mod 2 = 0  then
@@ -1647,7 +1647,7 @@ end);
 #T     G.facts := [];
 #T     G.roots := [];
 #T     G.sizes := [];
-#T     for p  in Set( Factors( G.modulus ) )  do
+#T     for p in PrimeDivisors( G.modulus ) do
 #T         q := p;
 #T         while G.modulus mod (p*q) = 0  do q := p*q;  od;
 #T         if q mod 4 = 0  then
@@ -1809,7 +1809,7 @@ end);
 #T
 #T     # add generators for each prime power factor <q> of <m>
 #T     gens := [];
-#T     for p  in Set( Factors( m ) )  do
+#T     for p in PrimeDivisors( m ) do
 #T         q := p;
 #T         while m mod (q * p) = 0  do q := q * p;  od;
 #T

--- a/lib/oprtperm.gi
+++ b/lib/oprtperm.gi
@@ -952,7 +952,7 @@ InstallMethod( Earns, "G, ints, gens, perms, act", true,
             if not IsTrivial( G2 )  then
                 Gamma := Filtered( D, p -> ForAll( GeneratorsOfGroup( G2 ),
                                  g -> p ^ g = p ) );
-                if Set( FactorsInt( Length( Gamma ) ) ) <> [ p ]  then
+                if PrimeDivisors( Length( Gamma ) ) <> [ p ]  then
                     return fail;
                 fi;
                 C := Centralizer( G, G2 );

--- a/lib/polyconw.gi
+++ b/lib/polyconw.gi
@@ -105,7 +105,7 @@ BindGlobal( "IsConsistentPolynomial", function( pol )
   local n, p, ps, x, null, f;
   n := DegreeOfLaurentPolynomial(pol);
   p := Characteristic(pol);
-  ps := Set(FactorsInt(n));
+  ps := PrimeDivisors(n);
   x := IndeterminateOfLaurentPolynomial(pol);
   null := 0*pol;
   f := function(k)
@@ -187,7 +187,7 @@ end);
 ##  all proper subfields.
 BindGlobal("NrCompatiblePolynomials", function(p, n)
   local ps, lcm;
-  ps := Set(Factors(n));
+  ps := PrimeDivisors(n);
   lcm := Lcm(List(ps, r-> p^(n/r)-1));
   return (p^n-1)/lcm;
 end);
@@ -320,7 +320,7 @@ InstallGlobalFunction( ConwayPol, function( p, n )
       if n > 1 then
 
         # Compute the list of all `n / l' for `l' a prime divisor of `n'
-        nfacs:= List( Set( Factors( n ) ), d -> n / d );
+        nfacs:= List( PrimeDivisors( n ), d -> n / d );
 
         if nfacs = [ 1 ] then
 
@@ -343,7 +343,7 @@ InstallGlobalFunction( ConwayPol, function( p, n )
 
         quots:= List( nfacs, x -> pp / ( p^x -1 ) );
         lencpols:= Length( cpols );
-        ppmin:= List( Set( Factors( pp ) ), d -> pp/d );
+        ppmin:= List( PrimeDivisors( pp ), d -> pp/d );
 
         found:= false;
         onelist:= [ one ];
@@ -557,7 +557,7 @@ InstallGlobalFunction( RandomPrimitivePolynomial, function(F, n, varnum...)
   FF := AlgebraicExtension(F, pol);
   one := One(FF);
   zero := Zero(FF);
-  fac:=List(Set(Factors(Size(FF)-1)), p-> (Size(FF)-1)/p);
+  fac:=List(PrimeDivisors(Size(FF)-1), p-> (Size(FF)-1)/p);
   repeat
     a := Random(FF);
   until a <> zero and ForAll(fac, d-> a^d <> one);

--- a/lib/polyfinf.gi
+++ b/lib/polyfinf.gi
@@ -640,7 +640,7 @@ local   fs,  F,  L,  phi,  B,  i,  d,  pp,  a,  deg,t,pb;
       if not IsBound( L[m] )  then
 	  bad:=[];
 	  x := Characteristic(F)^m-1;
-	  primes:=Set(Factors(x)); # use the Cunningham tables, and then store the prime
+	  primes:=PrimeDivisors(x); # use the Cunningham tables, and then store the prime
 	  # factors such that they end up cached below. In fact, since we
 	  # only divide off some known primes, this factorization really
 	  # shouldn't be harder than the one below.

--- a/lib/randiso.gi
+++ b/lib/randiso.gi
@@ -18,7 +18,7 @@ FingerprintFF := function( G )
     for orb in OrbitsDomain( G, AsList( G ) ) do
         ord := Order( orb[ 1 ] );
         typ := [ ord, Length( orb ) ];
-        po := Set( FactorsInt( ord ) );
+        po := PrimeDivisors( ord );
         i := 1;
         repeat
             if not Primes[ i ] in po then

--- a/lib/randiso2.gi
+++ b/lib/randiso2.gi
@@ -195,7 +195,7 @@ CodeGenerators := function( gens, spcgs )
                sgrps[ tpos ] := GroupByGenerators( Concatenation( [ e ],
                                 pcgs{[ tpos + 1 .. first[ lay + 1 ] - 1 ]},
                                 spcgs{[ first[lay+1] .. Length(spcgs) ]} ) );
-               for p in Set( FactorsInt( Order( e ) ) ) do
+               for p in PrimeDivisors( Order( e ) ) do
                   et := e ^ p;
                   if et <> one and not et in gens then
                      Add( gens, et );

--- a/lib/randiso2.gi
+++ b/lib/randiso2.gi
@@ -155,7 +155,7 @@ SplitUpSublistsByFpFunc := function( list )
       fi;
    od;
    Info( InfoRandIso, 2, "   Iso: found ", Length(result)," classes incl. ",
-          Length( Filtered( result, IsRecord ) )," unique groups");
+          Number( result, IsRecord )," unique groups");
    return result;
 end;
 

--- a/lib/schur.gi
+++ b/lib/schur.gi
@@ -614,7 +614,7 @@ local G,pl;
   if Length(arg)>1 then
     pl:=arg[2];
   else
-    pl:=Set(Factors(Size(G)));
+    pl:=PrimeDivisors(Size(G));
   fi;
   return MulExt(G,pl);
 end;

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -30,32 +30,6 @@ BindGlobal("STBBCKT_STRING_SUBORBITS2",MakeImmutable("Suborbits2"));
 BindGlobal("STBBCKT_STRING_SUBORBITS3",MakeImmutable("Suborbits3"));
 BindGlobal("STBBCKT_STRING_TWOCLOSURE",MakeImmutable("TwoClosure"));
 
-# #############################################################################
-# ##
-# #F  YndexSymmetricGroup( <S>, <U> ) . . . . . . . . . . . yndex of <U> in <S>
-# ##
-# InstallGlobalFunction( YndexSymmetricGroup, function( S, U )
-#     local   deg,  p,  e,  i,  f,  log;
-#     
-#     deg := NrMovedPoints( S );
-#     if not IsTrivial( U )  then
-#         for p  in Collected( FactorsInt( Size( U ) ) )  do
-#             e := 0;
-#             f := deg;  log := 0;
-#             while f mod p[ 1 ] = 0  do
-#                 f := f / p[ 1 ];  log := log + 1;
-#             od;
-#             for i  in [ 1 .. log ]  do
-#                 e := e + QuoInt( deg, p[ 1 ] ^ i );
-#                 if e > p[ 2 ]  then
-#                     return p[ 1 ];
-#                 fi;
-#             od;
-#         od;
-#     fi;
-#     return 1;
-# end );
-
 #############################################################################
 ##
 #F  IsSlicedPerm( <perm> )  . . . . . . . . . . . . . . . sliced permutations

--- a/lib/tom.gi
+++ b/lib/tom.gi
@@ -1488,7 +1488,7 @@ InstallMethod( IdempotentsTom,
     marks:= MarksTom( tom );
     classes:= [ 1 .. Length( marks ) ];
 
-    for p in Set( Factors( marks[1][1] ) ) do
+    for p in PrimeDivisors( marks[1][1] ) do
       ext:= CyclicExtensionsTom( tom, p );
       for c in ext do
         for i in c do
@@ -2034,7 +2034,7 @@ InstallMethod( DerivedSubgroupTom,
       subs:=SubsTom(tom);
 
       # find normal subgroups of prime index
-      set:=Set(Factors(orders[sub]));
+      set:=PrimeDivisors(orders[sub]);
       primes:=[];
       normalsubs:=[];
       minindex:=1;
@@ -2487,7 +2487,7 @@ InstallMethod( ContainingTom,
 InstallMethod( CyclicExtensionsTom,
     "for a table of marks (classes for all prime div. of the group order)",
     [ IsTableOfMarks ],
-    tom -> CyclicExtensionsTom( tom, Set( Factors(MarksTom(tom)[1][1]) ) ) );
+    tom -> CyclicExtensionsTom( tom, PrimeDivisors(MarksTom(tom)[1][1]) ) );
 
 InstallMethod( CyclicExtensionsTom,
     "for a table of marks, and a prime",
@@ -2506,7 +2506,7 @@ InstallMethod( CyclicExtensionsTom,
       Error( "the second argument must be a list of primes" );
     fi;
 
-    factors:= Set( Factors( MarksTom( tom )[1][1] ) );
+    factors:= PrimeDivisors( MarksTom( tom )[1][1] );
     primes:= Filtered( list, x -> x in factors);
     if primes = [] then
       return List( [ 1 .. Length( MarksTom( tom ) ) ], x -> [ x ] );

--- a/lib/upoly.gi
+++ b/lib/upoly.gi
@@ -219,7 +219,7 @@ InstallMethod( IsPrimitivePolynomial,
     # \ldots and are not divisible by $x^m - 1$
     # for proper divisors $m$ of $q^d-1$.
     if size <> 1 then
-      for p in Set( Factors( size ) ) do
+      for p in PrimeDivisors( size ) do
         pmc:= PowerModCoeffs( x, size / p, coeffs );
         ShrinkRowVector( pmc );
         if pmc = [ one ] then

--- a/tst/testinstall/pgroups.tst
+++ b/tst/testinstall/pgroups.tst
@@ -191,16 +191,16 @@ true
 gap> IsPowerfulPGroup(H);
 true
 gap> myList:=AllSmallGroups(5^4);;
-gap> Length(Filtered(myList,g->IsPowerfulPGroup(g)));
+gap> Number(myList,g->IsPowerfulPGroup(g));
 9
 gap> newList:=AllSmallGroups(5^4);;
 gap> for g in newList do
 > RankPGroup(g);
 > Agemo(g,5);
 > od;
-gap> Length(Filtered(newList,g->IsPowerfulPGroup(g)));
+gap> Number(newList,g->IsPowerfulPGroup(g));
 9
 gap> myList:=AllSmallGroups(2^4);;
-gap> Length(Filtered(myList,g->IsPowerfulPGroup(g)));
+gap> Number(myList,g->IsPowerfulPGroup(g));
 6
 gap> STOP_TEST("pgroups.tst", 1);


### PR DESCRIPTION
Also remove the commented out `YndexSymmetricGroup` (it contained a call to `FactorsInt`), and replace `Length(Filtered(...))` by `Number(...)` (motivation: such code was close to code calling `FactorsInt`).

This is motivated by PR #2087. Note that `PrimeDivisors` currently calls `FactorsInt`, but now this is in a single place.