### PR TITLE
kernel: do not code `atomic` statements in plain GAP

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -1140,6 +1140,7 @@ void CodeAtomicBeginBody ( UInt nrexprs )
 void CodeAtomicEndBody (
     UInt                nrstats )
 {
+#ifdef HPCGAP
     Stat                stat;           /* atomic-statement, result         */
     Stat                stat1;          /* single statement of body        */
     UInt                i;              /* loop variable                   */
@@ -1167,6 +1168,15 @@ void CodeAtomicEndBody (
 
     /* push the atomic-statement                                            */
     PushStat( stat );
+#else
+    Stat stat  = PopSeqStat( nrstats );
+    UInt nrexprs = INT_INTEXPR(PopExpr());
+    while (nrexprs--) {
+        PopExpr();
+        PopExpr();
+    }
+    PushStat( stat );
+#endif
 }
 
 void CodeAtomicEnd ( void )

--- a/tst/testinstall/atomic_basic.tst
+++ b/tst/testinstall/atomic_basic.tst
@@ -28,34 +28,22 @@ gap> f(1);
 2
 gap> Print(f,"\n");
 function ( x )
-    atomic L do
-        return x + 1;
-    od;
-    return;
+    return x + 1;
 end
 gap> g := function(x) atomic readwrite L do return x+1; od; end;;
 gap> Print(g,"\n");
 function ( x )
-    atomic readwrite L do
-        return x + 1;
-    od;
-    return;
+    return x + 1;
 end
 gap> h := function(x) atomic readonly L do return x+1; od; end;;
 gap> Print(h,"\n");
 function ( x )
-    atomic readonly L do
-        return x + 1;
-    od;
-    return;
+    return x + 1;
 end
 gap> h2 := function(x) atomic readonly L,M do return x+1; od; end;;
 gap> Print(h2,"\n");
 function ( x )
-    atomic readonly L, M do
-        return x + 1;
-    od;
-    return;
+    return x + 1;
 end
 gap> h3 := atomic function(x) end;;
 gap> # We do not preserve atomic functions in non-HPC gap, just want them to parse


### PR DESCRIPTION
That is, when coding
```gap
  function(x) atomic x do return x; od; end;
```
then in GAP (instead of HPC-GAP), the resulting function is
identical to
```gap
  function(x) return x; end;
```
Thus, `atomic` statements have zero run-time overhead in GAP.