### PR TITLE
Refactor src/hpc/traverse.c

### DIFF
--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -231,8 +231,6 @@ void RunThreadedMain(int (*mainFunction)(int, char **, char **),
     RunThreadedMain2(mainFunction, argc, argv, environ);
 }
 
-extern void InitTraversalModule();
-
 static void RunThreadedMain2(int (*mainFunction)(int, char **, char **),
                              int     argc,
                              char ** argv,
@@ -266,9 +264,6 @@ static void RunThreadedMain2(int (*mainFunction)(int, char **, char **),
     InitSignals();
     if (sySetjmp(TLS(threadExit)))
         exit(0);
-    /* Traversal functionality may be needed during the initialization
-     * of some modules, so we set it up now. */
-    InitTraversalModule();
     exit((*mainFunction)(argc, argv, environ));
 }
 

--- a/src/hpc/traverse.c
+++ b/src/hpc/traverse.c
@@ -202,32 +202,6 @@ void SetTraversalMethod(UInt tnum,
     TraversalCopyFunc[tnum] = cf;
 }
 
-void InitTraversalModule(void)
-{
-    int i;
-    for (i = FIRST_REAL_TNUM; i <= LAST_REAL_TNUM; i++) {
-        assert(TraversalMethod[i] == 0);
-        TraversalMethod[i] = TRAVERSE_NONE;
-    }
-    SetTraversalMethod(T_PREC,            TRAVERSE_BY_FUNCTION, TraversePRecord, CopyPRecord);
-    SetTraversalMethod(T_PREC +IMMUTABLE, TRAVERSE_BY_FUNCTION, TraversePRecord, CopyPRecord);
-    for (i = FIRST_PLIST_TNUM; i <= LAST_PLIST_TNUM; i++) {
-        SetTraversalMethod(i, TRAVERSE_BY_FUNCTION, TraversePList, CopyPList);
-    }
-    for (i = T_PLIST_CYC; i <= T_PLIST_FFE+IMMUTABLE; i++) {
-        SetTraversalMethod(i, TRAVERSE_NONE, 0, 0);
-    }
-
-    SetTraversalMethod(T_OBJSET, TRAVERSE_BY_FUNCTION, TraverseObjSet, CopyObjSet);
-    SetTraversalMethod(T_OBJMAP, TRAVERSE_BY_FUNCTION, TraverseObjMap, CopyObjMap);
-
-    SetTraversalMethod(T_POSOBJ, TRAVERSE_ALL_BUT_FIRST, 0, 0);
-    SetTraversalMethod(T_COMOBJ, TRAVERSE_BY_FUNCTION, TraversePRecord, CopyPRecord);
-    SetTraversalMethod(T_DATOBJ, TRAVERSE_NONE, 0, 0);
-
-    SetTraversalMethod(T_WPOBJ, TRAVERSE_BY_FUNCTION, TraverseWPObj, CopyWPObj);
-}
-
 static void BeginTraversal(TraversalState * traversal)
 {
     traversal->hashTable = NewList(16);
@@ -556,6 +530,57 @@ Obj CopyTraversed(Obj traversedList)
         CopyBag(copies[i], traversed[i]);
     EndTraversal();
     return copies[1];
+}
+
+
+/****************************************************************************
+**
+*F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
+*/
+static Int InitKernel ( StructInitInfo * module )
+{
+    int i;
+    for (i = FIRST_REAL_TNUM; i <= LAST_REAL_TNUM; i++) {
+        assert(TraversalMethod[i] == 0);
+        TraversalMethod[i] = TRAVERSE_NONE;
+    }
+    SetTraversalMethod(T_PREC,            TRAVERSE_BY_FUNCTION, TraversePRecord, CopyPRecord);
+    SetTraversalMethod(T_PREC +IMMUTABLE, TRAVERSE_BY_FUNCTION, TraversePRecord, CopyPRecord);
+    for (i = FIRST_PLIST_TNUM; i <= LAST_PLIST_TNUM; i++) {
+        SetTraversalMethod(i, TRAVERSE_BY_FUNCTION, TraversePList, CopyPList);
+    }
+    for (i = T_PLIST_CYC; i <= T_PLIST_FFE+IMMUTABLE; i++) {
+        SetTraversalMethod(i, TRAVERSE_NONE, 0, 0);
+    }
+
+    SetTraversalMethod(T_OBJSET, TRAVERSE_BY_FUNCTION, TraverseObjSet, CopyObjSet);
+    SetTraversalMethod(T_OBJMAP, TRAVERSE_BY_FUNCTION, TraverseObjMap, CopyObjMap);
+
+    SetTraversalMethod(T_POSOBJ, TRAVERSE_ALL_BUT_FIRST, 0, 0);
+    SetTraversalMethod(T_COMOBJ, TRAVERSE_BY_FUNCTION, TraversePRecord, CopyPRecord);
+    SetTraversalMethod(T_DATOBJ, TRAVERSE_NONE, 0, 0);
+
+    SetTraversalMethod(T_WPOBJ, TRAVERSE_BY_FUNCTION, TraverseWPObj, CopyWPObj);
+
+    return 0;
+}
+
+
+/****************************************************************************
+**
+*F  InitInfoGVars() . . . . . . . . . . . . . . . . . table of init functions
+*/
+static StructInitInfo module = {
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "traverse",
+    .initKernel = InitKernel,
+};
+
+StructInitInfo * InitInfoTraverse ( void )
+{
+    return &module;
 }
 
 #endif

--- a/src/hpc/traverse.h
+++ b/src/hpc/traverse.h
@@ -38,4 +38,17 @@ Obj CopyTraversed(Obj traversed);
 int PreMakeImmutableCheck(Obj obj);
 
 
+/****************************************************************************
+**
+*F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * *
+*/
+
+
+/****************************************************************************
+**
+*F  InitInfoTraverse() . . . . . . . . . . . . . . .  table of init functions
+*/
+StructInitInfo * InitInfoTraverse( void );
+
+
 #endif // GAP_TRAVERSE_H

--- a/src/hpc/traverse.h
+++ b/src/hpc/traverse.h
@@ -8,12 +8,34 @@
  */
 
 typedef void (*TraversalFunction)(Obj);
+typedef void (*TraversalCopyFunction)(Obj copy, Obj original);
 
-extern TraversalFunction TraversalFunc[];
+typedef enum {
+    TRAVERSE_NONE,
+    TRAVERSE_BY_FUNCTION,
+    TRAVERSE_ALL,
+    TRAVERSE_ALL_BUT_FIRST,
+} TraversalMethodEnum;
+
+// set the traversal method (and optionally, helper functions)
+// for all objects with the specified tnum.
+extern void SetTraversalMethod(UInt tnum,
+                               TraversalMethodEnum meth,
+                               TraversalFunction tf,
+                               TraversalCopyFunction cf);
+
+
+// helper to be called from traverse functions
+extern void QueueForTraversal(Obj obj);
+
+// helper to be called from copy functions
+extern Obj ReplaceByCopy(Obj obj);
+
 
 Obj ReachableObjectsFrom(Obj obj);
 Obj CopyReachableObjectsFrom(Obj obj, int delimited, int asList, int imm);
 Obj CopyTraversed(Obj traversed);
 int PreMakeImmutableCheck(Obj obj);
+
 
 #endif // GAP_TRAVERSE_H

--- a/src/modules-builtin.c
+++ b/src/modules-builtin.c
@@ -14,6 +14,7 @@
 #include <src/hpc/aobjects.h>
 #include <src/hpc/serialize.h>
 #include <src/hpc/threadapi.h>
+#include <src/hpc/traverse.h>
 #endif
 
 extern StructInitInfo * InitInfoGap ( void );
@@ -23,6 +24,12 @@ extern StructInitInfo * InitInfoGap ( void );
 *V  InitFuncsBuiltinModules . . . . .  list of builtin modules init functions
 */
 const InitInfoFunc InitFuncsBuiltinModules[] = {
+
+#ifdef HPCGAP
+    // Traversal functionality may be needed during the initialization
+    // of some modules, so set it up as early as possible
+    InitInfoTraverse,
+#endif
 
     /* global variables                                                    */
     InitInfoGVars,

--- a/src/objects.c
+++ b/src/objects.c
@@ -29,6 +29,7 @@
 #include <src/hpc/aobjects.h>
 #include <src/hpc/guards.h>
 #include <src/hpc/thread.h>
+#include <src/hpc/traverse.h>
 #endif
 
 #if defined(USE_THREADSAFE_COPYING)
@@ -2077,8 +2078,12 @@ static Int InitKernel (
     for ( t = FIRST_EXTERNAL_TNUM; t <= LAST_EXTERNAL_TNUM; t++ )
         ShallowCopyObjFuncs[ t ] = ShallowCopyObjObject;
 
+#ifdef USE_THREADSAFE_COPYING
+    SetTraversalMethod(T_POSOBJ, TRAVERSE_ALL_BUT_FIRST, 0, 0);
+    SetTraversalMethod(T_COMOBJ, TRAVERSE_BY_FUNCTION, TraversePRecord, CopyPRecord);
+    SetTraversalMethod(T_DATOBJ, TRAVERSE_NONE, 0, 0);
+#else
     /* make and install the 'COPY_OBJ' function                            */
-#if !defined(USE_THREADSAFE_COPYING)
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ ) {
         assert(CopyObjFuncs [ t ] == 0);
         CopyObjFuncs [ t ] = CopyObjError;

--- a/src/precord.h
+++ b/src/precord.h
@@ -253,6 +253,12 @@ extern  void            SortPRecRNam (
             int                 inplace );
 
 
+#ifdef USE_THREADSAFE_COPYING
+extern void TraversePRecord(Obj obj);
+extern void CopyPRecord(Obj copy, Obj original);
+#endif
+
+
 /****************************************************************************
 **
 *F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * *

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -566,7 +566,7 @@ void TraverseWPObj(Obj obj)
     while (len) {
         volatile Obj tmp = *ptr;
         MEMBAR_READ();
-        if (tmp && *ptr)
+        if (IS_BAG_REF(tmp) && IS_BAG_REF(*ptr))
             QueueForTraversal(*ptr);
         ptr++;
         len--;
@@ -578,12 +578,13 @@ void CopyWPObj(Obj copy, Obj original)
     UInt  len = STORED_LEN_WPOBJ(original);
     const Obj * ptr = CONST_ADDR_OBJ(original) + 1;
     Obj * copyptr = ADDR_OBJ(copy) + 1;
-    while (len) {
+    while (len--) {
         volatile Obj tmp = *ptr;
         MEMBAR_READ();
-        if (tmp && *ptr)
+        if (IS_BAG_REF(tmp) && IS_BAG_REF(*ptr)) {
             *copyptr = ReplaceByCopy(tmp);
-        REGISTER_WP(copyptr, tmp);
+            REGISTER_WP(copyptr, tmp);
+        }
         ptr++;
         copyptr++;
     }

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -561,11 +561,7 @@ static void SweepWeakPointerObj( Bag *src, Bag *dst, UInt len)
 #ifdef USE_THREADSAFE_COPYING
 void TraverseWPObj(Obj obj)
 {
-    /* This is a hack, we rely on weak pointer objects
-     * having the same layout as plain lists, so we don't
-     * have to replicate the macro here.
-     */
-    UInt  len = LEN_PLIST(obj);
+    UInt  len = STORED_LEN_WPOBJ(obj);
     const Obj * ptr = CONST_ADDR_OBJ(obj) + 1;
     while (len) {
         volatile Obj tmp = *ptr;
@@ -579,11 +575,7 @@ void TraverseWPObj(Obj obj)
 
 void CopyWPObj(Obj copy, Obj original)
 {
-    /* This is a hack, we rely on weak pointer objects
-     * having the same layout as plain lists, so we don't
-     * have to replicate the macro here.
-     */
-    UInt  len = LEN_PLIST(original);
+    UInt  len = STORED_LEN_WPOBJ(original);
     const Obj * ptr = CONST_ADDR_OBJ(original) + 1;
     Obj * copyptr = ADDR_OBJ(copy) + 1;
     while (len) {

--- a/tst/testinstall/weakptr.tst
+++ b/tst/testinstall/weakptr.tst
@@ -5,7 +5,6 @@
 ##
 #Y  Copyright (C)  1997, 
 ##
-##  Exclude from testinstall.g: too sensitive to compiler idiosyncracies SL
 ##
 gap> START_TEST("weakptr.tst");
 


### PR DESCRIPTION
One motivation was to remove the need for putting knowledge about how weak pointer objects work in there, which poses a (minor) complication for PR #2092 

It also correct some quirks in the traverse code (e.g. the traversal for *immutable* lists of cyclotomics and FFEs was not being set before, leading to suboptimal performance), and opens it up for use by kernel extensions.

This code might at some point become interesting for GAP, too. In particular, I'd be curious to test performance for copying objects with it vs. with our current copying code. Of course I expect the current copying code to be faster, but by how much? If it is not too much, I'd investigate switching GAP to this alternate copying code, simply because it is much simpler (and would allow us to get rid of the `COPYING` tnum trick).