### PR TITLE
correction of `IsMonomial`, mainly for reducible characters

### DIFF
--- a/lib/ctblmono.gd
+++ b/lib/ctblmono.gd
@@ -545,7 +545,9 @@ DeclareProperty( "IsMonomialNumber", IsPosInt );
 ##  whether the irreducible character <A>chi</A> or the group <A>G</A>,
 ##  respectively, is monomial.
 ##  Here <Q>cheap</Q> means in particular that no computations of character
-##  tables are involved.
+##  tables are involved,
+##  and it is <E>not</E> checked whether <A>chi</A> is a character and
+##  irreducible.
 ##  The return value is a record with components
 ##  <List>
 ##  <Mark><C>isMonomial</C></Mark>
@@ -572,7 +574,7 @@ DeclareProperty( "IsMonomialNumber", IsPosInt );
 ##  it is linear, or if its codegree is a prime power,
 ##  or if its group knows to be monomial,
 ##  or if the factor group modulo the kernel can be proved to be monomial by
-##  <Ref Attr="TestMonomialQuick" Label="for a character"/>.
+##  <Ref Attr="TestMonomialQuick" Label="for a group"/>.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> TestMonomialQuick( Irr( S4 )[3] );
@@ -699,9 +701,9 @@ TestMonomialUseLattice := 1000;
 ##  <Prop Name="IsSubnormallyMonomial" Arg='chi' Label="for a character"/>
 ##
 ##  <Description>
-##  A character of the group <M>G</M> is called <E>subnormally monomial</E>
-##  (SM for short) if it is induced from a linear character of a subnormal
-##  subgroup of <M>G</M>.
+##  An irreducible character of the group <M>G</M> is called
+##  <E>subnormally monomial</E> (<E>SM</E> for short) if it is induced
+##  from a linear character of a subnormal subgroup of <M>G</M>.
 ##  A group <M>G</M> is called SM if all its irreducible characters are SM.
 ##  <P/>
 ##  <Ref Attr="TestSubnormallyMonomial" Label="for a group"/> returns

--- a/tst/testinstall/ctblmono.tst
+++ b/tst/testinstall/ctblmono.tst
@@ -7,8 +7,12 @@
 #Y  Copyright (C)  1998,  Lehrstuhl D für Mathematik,  RWTH Aachen,  Germany
 ##
 gap> START_TEST("ctblmono.tst");
+
+##
 gap> S4:= SymmetricGroup( 4 );;  SetName( S4, "S4");
 gap> Sl23:= SL( 2, 3 );;
+
+##
 gap> Alpha( Sl23 );
 [ 1, 3, 3 ]
 gap> Alpha( S4 );
@@ -25,9 +29,11 @@ gap> List( Irr( Sl23 ), IsBergerCondition );
 [ true, true, true, false, false, false, true ]
 gap> List( Irr( Sl23 ), Degree );
 [ 1, 1, 1, 2, 2, 2, 3 ]
-gap> n:= DerivedSubgroup( Sl23 );;      
+
+##
 gap> chi:= Irr( Sl23 )[7];
 Character( CharacterTable( SL(2,3) ), [ 3, 0, 0, 3, 0, 0, -1 ] )
+gap> n:= DerivedSubgroup( Sl23 );;
 gap> test:= TestHomogeneous( chi, n );;
 gap> test.isHomogeneous;  test.comment;  test.multiplicity;
 false
@@ -39,6 +45,8 @@ gap> cln:= ClassPositionsOfNormalSubgroup( CharacterTable( Sl23 ), n );
 [ 1, 4, 7 ]
 gap> TestHomogeneous( chi, cln );
 rec( comment := "restricts irreducibly", isHomogeneous := true )
+
+##
 gap> chi:= Irr( Sl23 )[4];;
 gap> TestQuasiPrimitive( chi );
 rec( comment := "all restrictions checked", isQuasiPrimitive := true )
@@ -51,6 +59,8 @@ gap> IsPrimitive( Irr( Sl23 )[4] );
 true
 gap> IsPrimitive( Irr( Sl23 )[7] );
 false
+
+##
 gap> List( Irr( Sl23 ), IsInducedFromNormalSubgroup );
 [ false, false, false, false, false, false, true ]
 gap> List( Irr( S4 ){ [ 1, 3, 4 ] },
@@ -61,18 +71,216 @@ gap> List( Irr( S4 ){ [ 1, 3, 4 ] },
       comment := "induced from component '.character'", isInduced := true ), 
   rec( comment := "all maximal normal subgroups checked", isInduced := false 
      ) ]
-gap> TestMonomial( S4 );
-rec( comment := "abelian by supersolvable group", isMonomial := true )
-gap> TestMonomial( Sl23 );
-rec( comment := "list Delta( G ) contains entry > 1", isMonomial := false )
-gap> Filtered( [ 1 .. 111 ], x -> not IsMonomial( x ) );
-[ 24, 48, 72, 96, 108 ]
-gap> TestMonomialQuick( Irr( S4 )[3] );
+
+##
+gap> Filtered( [ 1 .. 200 ], i -> not IsMonomial( i ) );
+[ 24, 48, 72, 96, 108, 120, 144, 160, 168, 192 ]
+
+##
+gap> irr:= Irr( SymmetricGroup( 4 ) );;
+gap> SetIsMonomialCharacter( irr[1], true );
+gap> TestMonomialQuick( irr[1] );
+rec( comment := "was already stored", isMonomial := true )
+gap> TestMonomial( irr[1] );
+rec( comment := "was already stored", isMonomial := true )
+gap> IsMonomial( irr[1] );
+true
+gap> TestMonomialQuick( irr[5] );
+rec( comment := "linear character", isMonomial := true )
+gap> TestMonomial( irr[5] );
+rec( comment := "linear character", isMonomial := true )
+gap> IsMonomial( irr[5] );
+true
+gap> TestMonomial( 5 * irr[1] );
+rec( comment := "degree does not divide group order", isMonomial := false )
+gap> IsMonomial( 5 * irr[5] );
+false
+gap> TestMonomialQuick( irr[2] );
 rec( comment := "whole group is monomial", isMonomial := true )
+gap> TestMonomial( irr[2] );
+rec( comment := "whole group is monomial", isMonomial := true )
+gap> IsMonomial( irr[2] );
+true
+gap> irr:= Irr( SL(2,3) );;
+gap> chi:= First( irr, x -> x[1] = 3 );;
+gap> TestMonomialQuick( chi );
+rec( comment := "codegree is prime power", isMonomial := true )
+gap> TestMonomial( chi );
+rec( comment := "codegree is prime power", isMonomial := true )
+gap> IsMonomial( chi );
+true
+gap> irr:= Irr( SmallGroup( 120, 15 ) );;
+gap> chi:= First( irr, x -> x[1] = 3 and
+>                           Length( ClassPositionsOfKernel( x ) ) = 2 );;
+gap> TestMonomialQuick( chi );
+rec( comment := "degree is index of Hall subgroup", isMonomial := true )
+gap> TestMonomial( chi );
+rec( comment := "degree is index of Hall subgroup", isMonomial := true )
+gap> IsMonomial( chi );
+true
+gap> irr:= Irr( SmallGroup( 240, 109 ) );;
+gap> chi:= First( irr, x -> x[1] = 6 );;
+gap> TestMonomialQuick( chi );
+rec( comment := "induced from monomial Hall subgroup", isMonomial := true )
+gap> TestMonomial( chi );
+rec( comment := "induced from monomial Hall subgroup", isMonomial := true )
+gap> IsMonomial( chi );
+true
+gap> g:= DirectProduct( AlternatingGroup(5), SymmetricGroup(3),
+>                       SymmetricGroup(3) );;
+gap> chi:= First( Irr( g ), x -> x[1] = 2 and
+>                           Length( ClassPositionsOfKernel( x ) ) = 10 );;
+gap> TestMonomialQuick( chi );
+rec( comment := "kernel factor group is supersolvable", isMonomial := true )
+gap> TestMonomial( chi );
+rec( comment := "kernel factor group is supersolvable", isMonomial := true )
+gap> IsMonomial( chi );
+true
+gap> irr:= Irr( SmallGroup( 144, 31 ) );;
+gap> chi:= First( irr, x -> x[1] = 6 );;
+gap> TestMonomialQuick( chi );
+rec( comment := "kernel factor group is monomial", isMonomial := true )
+gap> TestMonomial( chi );
+rec( comment := "kernel factor group is monomial", isMonomial := true )
+gap> IsMonomial( chi );
+true
+gap> irr:= Irr( SL(2,3) );;
+gap> chi:= First( irr, x -> x[1] = 2 );;
+gap> TestMonomialQuick( chi );
+rec( comment := "no decision by cheap tests", isMonomial := "?" )
+gap> TestMonomial( chi );
+rec( comment := "quasiprimitive character", isMonomial := false )
+gap> IsMonomial( chi );
+false
+gap> irr:= Irr( AlternatingGroup( 5 ) );;
+gap> chi:= First( irr, x -> x[1] = 5 );;
+gap> TestMonomialQuick( chi );
+rec( comment := "no decision by cheap tests", isMonomial := "?" )
+gap> TestMonomial( chi ).comment;
+"induced from 'character'"
+gap> IsMonomial( chi );
+true
+gap> TestMonomialUseLattice_Orig:= TestMonomialUseLattice;;
+gap> TestMonomialUseLattice:= 20;;
+gap> chi:= First( irr, x -> x[1] = 4 );;
+gap> TestMonomialQuick( chi );
+rec( comment := "no decision by cheap tests", isMonomial := "?" )
+gap> TestMonomial( chi ).comment;
+"no criterion for nonsolvable group"
+gap> TestMonomial( chi, true ).comment;
+"lattice checked"
+gap> IsMonomial( chi );
+false
+gap> irr:= Irr( SmallGroup( 96, 204 ) );;
+gap> chi:= First( irr, x -> x[1] = 4 );;
+gap> TestMonomialQuick( chi );
+rec( comment := "no decision by cheap tests", isMonomial := "?" )
+gap> TestMonomial( chi ).comment;
+"induced from 'character'"
+gap> IsMonomial( chi );
+true
+gap> chi:= First( Irr( SmallGroup( 144, 31 ) ), x -> x[1] = 4 );;
+gap> TestMonomialQuick( chi );
+rec( comment := "no decision by cheap tests", isMonomial := "?" )
+gap> TestMonomial( chi ).comment;
+"all inertia subgroups checked, no result"
+gap> TestMonomial( chi, true ).comment;
+"induced from 'character'"
+gap> IsMonomial( chi );
+true
+gap> chi:= 0 * [ 1 .. NrConjugacyClasses( S4 ) ];;
+gap> chi[1]:= Size( S4 );;
+gap> chi:= ClassFunction( S4, chi );;
+gap> TestMonomial( chi ).comment;
+"no criterion for reducible character"
+gap> TestMonomial( chi, true ).comment;
+"induced from 'character'"
+gap> IsMonomial( chi );
+true
+gap> TestMonomialUseLattice:= TestMonomialUseLattice_Orig;;
+gap> chi:= First( Irr( SmallGroup( 48, 28 ) ), x -> x[1] = 4 );;
+gap> TestMonomialQuick( chi );
+rec( comment := "no decision by cheap tests", isMonomial := "?" )
+gap> TestMonomial( chi ).comment;
+"induced from 'character'"
+gap> IsMonomial( chi );
+true
+
+##
 gap> TestMonomialQuick( S4 );
 rec( comment := "abelian by supersolvable group", isMonomial := true )
+gap> TestMonomial( S4 );
+rec( comment := "abelian by supersolvable group", isMonomial := true )
+gap> IsMonomial( S4 );
+true
 gap> TestMonomialQuick( Sl23 );
 rec( comment := "no decision by cheap tests", isMonomial := "?" )
+gap> TestMonomial( Sl23 );
+rec( comment := "list Delta( G ) contains entry > 1", isMonomial := false )
+gap> IsMonomial( Sl23 );
+false
+gap> g:= SmallGroup( 96, 204 );;
+gap> TestMonomialQuick( g );
+rec( comment := "no decision by cheap tests", isMonomial := "?" )
+gap> TestMonomial( g );
+rec( comment := "all characters checked", isMonomial := true )
+gap> IsMonomial( g );
+true
+gap> TestMonomialUseLattice_Orig:= TestMonomialUseLattice;;
+gap> TestMonomialUseLattice:= 50;;
+gap> test:= TestMonomial( SmallGroup( 96, 190 ) );;
+gap> test.isMonomial;  test.comment;
+"?"
+"(possibly) nonmon. characters found"
+gap> test:= TestMonomial( SmallGroup( 96, 190 ), true );;
+gap> test.isMonomial;  test.comment;
+false
+"nonmonomial character found"
+gap> TestMonomialUseLattice:= TestMonomialUseLattice_Orig;;
+gap> g:= SmallGroup( 16, 3 );;
+gap> TestMonomialQuick( g );  # implication
+rec( comment := "was already stored", isMonomial := true )
+gap> TestMonomial( g );
+rec( comment := "was already stored", isMonomial := true )
+gap> IsMonomial( g );
+true
+gap> g:= AlternatingGroup( 5 );;
+gap> TestMonomialQuick( g );
+rec( comment := "non-solvable group", isMonomial := false )
+gap> TestMonomial( g );
+rec( comment := "non-solvable group", isMonomial := false )
+gap> IsMonomial( g );
+false
+gap> g:= SmallGroup( 56, 10 );;
+gap> TestMonomialQuick( g );
+rec( comment := "group order is monomial", isMonomial := true )
+gap> TestMonomial( g );
+rec( comment := "group order is monomial", isMonomial := true )
+gap> IsMonomial( g );
+true
+gap> g:= SmallGroup( 24, 10 );;
+gap> TestMonomialQuick( g );
+rec( comment := "nilpotent group", isMonomial := true )
+gap> TestMonomial( g );
+rec( comment := "nilpotent group", isMonomial := true )
+gap> IsMonomial( g );
+true
+gap> g:= SmallGroup( 24, 4 );;
+gap> TestMonomialQuick( g );
+rec( comment := "supersolvable group", isMonomial := true )
+gap> TestMonomial( g );
+rec( comment := "supersolvable group", isMonomial := true )
+gap> IsMonomial( g );
+true
+gap> g:= SmallGroup( 324, 160 );;
+gap> TestMonomialQuick( g );
+rec( comment := "Sylow abelian by supersolvable group", isMonomial := true )
+gap> TestMonomial( g );
+rec( comment := "Sylow abelian by supersolvable group", isMonomial := true )
+gap> IsMonomial( g );
+true
+
+##
 gap> TestSubnormallyMonomial( S4 );
 rec( character := Character( CharacterTable( S4 ), [ 3, -1, -1, 0, 1 ] ), 
   comment := "found non-SM character", isSubnormallyMonomial := false )
@@ -83,27 +291,52 @@ gap> TestSubnormallyMonomial( DerivedSubgroup( S4 ) );
 rec( comment := "all irreducibles checked", isSubnormallyMonomial := true )
 gap> IsSubnormallyMonomial( DerivedSubgroup( S4 ) );
 true
+
+##
 gap> TestRelativelySM( DerivedSubgroup( S4 ) );
 rec( comment := "normal subgroups are abelian or have nilpotent factor group",
   isRelativelySM := true )
-gap> IsMinimalNonmonomial( Sl23 );                  
+
+##
+gap> g1:= MinimalNonmonomialGroup(  2,  3 ); # the group SL(2,3)
+2^(1+2):3
+gap> g2:= MinimalNonmonomialGroup(  3,  4 );
+3^(1+2):4
+gap> g3:= MinimalNonmonomialGroup(  5,  8 );
+5^(1+2):Q8
+gap> g4:= MinimalNonmonomialGroup( 13, 12 );
+13^(1+2):2.D6
+gap> g5:= MinimalNonmonomialGroup(  1, 14 );
+2^(1+6):D14
+gap> g6:= MinimalNonmonomialGroup(  2, 14 );
+(2^(1+6)Y4):D14
+gap> MinimalNonmonomialGroup(  3,  3 );
+fail
+gap> MinimalNonmonomialGroup(  2,  4 );
+fail
+gap> MinimalNonmonomialGroup(  2,  8 );
+fail
+gap> MinimalNonmonomialGroup(  1, 10 );
+fail
+gap> MinimalNonmonomialGroup(  5,  9 );
+fail
+
+##
+gap> IsMinimalNonmonomial( Sl23 );
 true
+gap> for g in [ g1, g2, g3, g4, g5, g6 ] do
+>      # Make sure that the value is not yet stored.
+>      if not IsMinimalNonmonomial( Group( GeneratorsOfGroup( g ) ) ) then
+>        Error( "wrong result of IsMinimalNonmonomial" );
+>      fi;
+>    od;
 gap> IsMinimalNonmonomial( S4 );
 false
-gap> MinimalNonmonomialGroup(  2,  3 ); # the group SL(2,3)
-2^(1+2):3
-gap> MinimalNonmonomialGroup(  3,  4 );
-3^(1+2):4
-gap> MinimalNonmonomialGroup(  5,  8 );
-5^(1+2):Q8
-gap> MinimalNonmonomialGroup( 13, 12 );                              
-13^(1+2):2.D6
-gap> MinimalNonmonomialGroup(  1, 14 );
-2^(1+6):D14
-gap> MinimalNonmonomialGroup(  2, 14 );
-(2^(1+6)Y4):D14
+
+##
 gap> STOP_TEST( "ctblmono.tst", 1);
 
 #############################################################################
 ##
 #E
+


### PR DESCRIPTION
correction of `IsMonomial`, mainly for reducible characters

- change the `TestMonomialQuick` and `TestMonomial` methods
  for characters such that also reducible characters are handled correctly

- restrict the `IsPrimitiveCharacter` method that relies on
  quasi-primitivity to irreducible characters

- define `IsSubnormallyMonomial` only for irreducible characters

- add tests