### PR TITLE
Parse dual semicolons in READ_ALL_COMMANDS

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -80,11 +80,18 @@ static Int READ_COMMAND(Obj *evalResult)
 
 /*
  * This function reads all code from the stream and returns either `fail` if the stream
- * cannot be opened, or a list of lists of length at most two, where the first entry is
- * either `true` or `false` depending on whether the statement was successfuly executed
- * and the second entry is the result of the statement if there was one.
+ * cannot be opened, or executes all statements in the stream and returns a list of lists,
+ * each entry of which reflects the result of the execution of one statement.
  *
- * This function is curently used in interactive tools such as the GAP Jupyter kernel to
+ * The results are returned as lists with at most three bound positions.
+ *
+ * If the first entry is `true`, then the second entry is bound to the result of
+ * the statement if there was one, and unbound otherwise, and the third entry
+ * reflects whether the statement ended in a dual semicolon,
+ * if the first entry is `false', an error occurred during the execution of a statement,
+ * and no other positions of the list are bound.
+ *
+ * This function is currently used in interactive tools such as the GAP Jupyter kernel to
  * execute cells and is likely to be replaced by a function that can read a single command
  * from a stream without losing the rest of its content.
  */
@@ -92,6 +99,7 @@ Obj FuncREAD_ALL_COMMANDS( Obj self, Obj stream, Obj echo )
 {
     ExecStatus status;
     Int resultCount, resultCapacity;
+    UInt dualSemicolon;
     Obj result, resultList;
     Obj evalResult;
 
@@ -107,7 +115,7 @@ Obj FuncREAD_ALL_COMMANDS( Obj self, Obj stream, Obj echo )
 
     do {
         ClearError();
-        status = ReadEvalCommand(STATE(BottomLVars), &evalResult, 0);
+        status = ReadEvalCommand(STATE(BottomLVars), &evalResult, &dualSemicolon);
 
         if(!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT))) {
             resultCount++;
@@ -115,16 +123,18 @@ Obj FuncREAD_ALL_COMMANDS( Obj self, Obj stream, Obj echo )
                 resultCapacity += 16;
                 GROW_PLIST(resultList, resultCapacity);
             }
-            result = NEW_PLIST( T_PLIST, 2 );
+            result = NEW_PLIST( T_PLIST, 3 );
             SET_LEN_PLIST(result, 1);
             SET_ELM_PLIST(result, 1, False);
             SET_ELM_PLIST(resultList, resultCount, result );
             SET_LEN_PLIST(resultList, resultCount );
 
             if(!(status & STATUS_ERROR)) {
+                SET_LEN_PLIST(result, 3);
                 SET_ELM_PLIST(result, 1, True);
+                SET_ELM_PLIST(result, 3, dualSemicolon ? True : False);
+
                 if (evalResult) {
-                    SET_LEN_PLIST(result, 2);
                     SET_ELM_PLIST(result, 2, evalResult);
                 }
             }

--- a/tst/testinstall/read.tst
+++ b/tst/testinstall/read.tst
@@ -86,14 +86,16 @@ true
 gap> READ_ALL_COMMANDS(InputTextString(""), false);
 [  ]
 gap> READ_ALL_COMMANDS(InputTextString("a := (3,7,1); y := a^(-1);"), false);
-[ [ true, (1,3,7) ], [ true, (1,7,3) ] ]
+[ [ true, (1,3,7), false ], [ true, (1,7,3), false ] ]
 gap> READ_ALL_COMMANDS(InputTextString("Unbind(x); z := x;"), false);
 Error, Variable: 'x' must have a value
-[ [ true ], [ false ] ]
-gap> p := READ_ALL_COMMANDS(InputTextString("1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16;17;18;"), false);;
+[ [ true,, false ], [ false ] ]
+gap> p := READ_ALL_COMMANDS(InputTextString("1;;2;3;;4;5;6;7;8;9;10;11;12;13;14;;15;16;17;18;"), false);;
 gap> p;
-[ [ true, 1 ], [ true, 2 ], [ true, 3 ], [ true, 4 ], [ true, 5 ], 
-  [ true, 6 ], [ true, 7 ], [ true, 8 ], [ true, 9 ], [ true, 10 ], 
-  [ true, 11 ], [ true, 12 ], [ true, 13 ], [ true, 14 ], [ true, 15 ], 
-  [ true, 16 ], [ true, 17 ], [ true, 18 ] ]
+[ [ true, 1, true ], [ true, 2, false ], [ true, 3, true ], 
+  [ true, 4, false ], [ true, 5, false ], [ true, 6, false ], 
+  [ true, 7, false ], [ true, 8, false ], [ true, 9, false ], 
+  [ true, 10, false ], [ true, 11, false ], [ true, 12, false ], 
+  [ true, 13, false ], [ true, 14, true ], [ true, 15, false ], 
+  [ true, 16, false ], [ true, 17, false ], [ true, 18, false ] ]
 gap> STOP_TEST( "read.tst", 1);


### PR DESCRIPTION
This is required to allow suppressing output in https://github.com/gap-packages/JupyterKernel (and similar tools)