### PR TITLE
Get rid of Imm and MakeImm (before GAP 4.9!)

### DIFF
--- a/doc/ref/objects.xml
+++ b/doc/ref/objects.xml
@@ -185,7 +185,6 @@ can assign values to components of a mutable record, or unbind them.
 
 <ManSection>
 <Func Name="MakeImmutable" Arg='obj'/>
-<Func Name="MakeImm" Arg='obj'/>
 
 <Description>
 One can turn the (mutable or immutable) object <A>obj</A> into an immutable
@@ -194,7 +193,6 @@ note that this also makes all subobjects of <A>obj</A> immutable,
 so one should call <Ref Func="MakeImmutable"/> only if <A>obj</A> and
 its mutable subobjects are newly created.
 If one is not sure about this, <Ref Func="Immutable"/> should be used.
-<Ref Func="MakeImm"/> provides a shorthand for <Ref Func="MakeImmutable"/>.
 <P/>
 Note that it is <E>not</E> possible to turn an immutable object into a
 mutable one;

--- a/hpcgap/lib/object.gd
+++ b/hpcgap/lib/object.gd
@@ -252,7 +252,6 @@ InstallTrueMethod( IsCopyable, IsMutable);
 ##  <#GAPDoc Label="Immutable">
 ##  <ManSection>
 ##  <Func Name="Immutable" Arg='obj'/>
-##  <Func Name="Imm" Arg='obj'/>
 ##
 ##  <Description>
 ##  returns an immutable structural copy
@@ -264,15 +263,11 @@ InstallTrueMethod( IsCopyable, IsMutable);
 ##  <P/>
 ##  &GAP; will complain with an error if one tries to change an
 ##  immutable object.
-##  <P/>
-##  <Ref Func="Imm"/> povides a shorthand for <Ref Func="Immutable"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL( "Immutable", IMMUTABLE_COPY_OBJ );
-BIND_GLOBAL( "Imm", IMMUTABLE_COPY_OBJ );
-BIND_GLOBAL( "MakeImm", MakeImmutable );
 
 #############################################################################
 ##

--- a/hpcgap/tst/testinstall/immutable.tst
+++ b/hpcgap/tst/testinstall/immutable.tst
@@ -7,21 +7,13 @@
 ##
 ##
 gap> START_TEST("immutable.tst");
-gap> IS_IDENTICAL_OBJ(Immutable, Imm);
-true
-gap> IS_IDENTICAL_OBJ(MakeImmutable, MakeImm);
-true
 gap> IS_IDENTICAL_OBJ(Immutable, MakeImmutable);
 false
 gap> IsMutable(1);
 false
 gap> IS_IDENTICAL_OBJ(1,Immutable(1));
 true
-gap> IS_IDENTICAL_OBJ(1,Imm(1));
-true
 gap> IS_IDENTICAL_OBJ(1,MakeImmutable(1));
-true
-gap> IS_IDENTICAL_OBJ(1,MakeImm(1));
 true
 gap> x := [1,2,3];
 [ 1, 2, 3 ]
@@ -31,11 +23,7 @@ gap> IsMutable(Immutable(x));
 false
 gap> x = Immutable(x);
 true
-gap> IsMutable(Imm(x));
-false
-gap> x = Imm(x);
-true
-gap> IS_IDENTICAL_OBJ(x, Imm(x));
+gap> IS_IDENTICAL_OBJ(x, Immutable(x));
 false
 gap> IsMutable(x);
 true

--- a/lib/alglie.gi
+++ b/lib/alglie.gi
@@ -3591,9 +3591,9 @@ InstallHandlingByNiceBasis( "IsSpaceOfUEAElements", rec(
 
       # For the zero row vector, catch the case of empty `monomials' list.
       if IsEmpty( monomials ) then
-        info.zerovector := MakeImm([ zero ]);
+        info.zerovector := MakeImmutable([ zero ]);
       else
-        info.zerovector := MakeImm(ListWithIdenticalEntries( Length( monomials ),
+        info.zerovector := MakeImmutable(ListWithIdenticalEntries( Length( monomials ),
                                                              zero ) );
       fi;
 

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -440,7 +440,7 @@ function(g,str,N)
     SetKernelOfMultiplicativeGeneralMapping(hom,N);
   fi;
 
-  hom!.decompinfo:=MakeImm(di);
+  hom!.decompinfo:=MakeImmutable(di);
   SetIsWordDecompHomomorphism(hom,true);
   return hom;
 end);
@@ -593,7 +593,7 @@ local fpq, qgens, qreps, fpqg, rels, pcgs, p, f, qimg, idx, nimg, decomp,
     di.dec:=[elm->MappedWord(Image(hom,elm),fpqg,qimg),decomp];
   fi;
 
-  hom2!.decompinfo:=MakeImm(di);
+  hom2!.decompinfo:=MakeImmutable(di);
   SetIsWordDecompHomomorphism(hom2,true);
 
   SetIsSurjective(hom2,true);
@@ -615,7 +615,7 @@ local di, hom;
       # this homomorphism is just to store decomposition information and is
       # not declared total, so an assertion test will fail
       hom:=GroupHomomorphismByImagesNC(k,di.fp,cgens,GeneratorsOfGroup(di.fp):noassert);
-      hom!.decompinfo:=MakeImm(di);
+      hom!.decompinfo:=MakeImmutable(di);
       if HasIsSurjective(h) and IsSurjective(h) 
 	and HasKernelOfMultiplicativeGeneralMapping(h)
 	and m=KernelOfMultiplicativeGeneralMapping(h) then

--- a/lib/groebner.gi
+++ b/lib/groebner.gi
@@ -226,7 +226,7 @@ InstallMonomialOrdering(MonomialLexOrdering,
       min:=am; # will increase until no variable in a left
     until false;
   end,
-  MakeImm("lp"));
+  MakeImmutable("lp"));
 
 #############################################################################
 ##
@@ -371,7 +371,7 @@ InstallMonomialOrdering(MonomialGrlexOrdering,
       min:=am; # will increase until no variable in a left
     until false;
   end,
-  MakeImm("Dp"));
+  MakeImmutable("Dp"));
 
 #############################################################################
 ##
@@ -432,7 +432,7 @@ InstallMonomialOrdering(MonomialGrevlexOrdering,
   function(a,b,idx)
     Error("indexed grevlex not yet implemented");
   end,
-  MakeImm("dp"));
+  MakeImmutable("dp"));
 
 #############################################################################
 ##

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -1681,8 +1681,8 @@ end;
 
 SMTX.BasisModuleEndomorphisms:=SMTX_BasisModuleEndomorphisms;
 
-SMTX.SetBasisEndomorphismsRadical:=SMTX.Setter(MakeImm("basisEndoRad"));
-SMTX.BasisEndomorphismsRadical:=SMTX.Getter(MakeImm("basisEndoRad"));
+SMTX.SetBasisEndomorphismsRadical:=SMTX.Setter("basisEndoRad");
+SMTX.BasisEndomorphismsRadical:=SMTX.Getter("basisEndoRad");
 
-SMTX.SetEndAlgResidue:=SMTX.Setter(MakeImm("endAlgResidue"));
-SMTX.EndAlgResidue:=SMTX.Getter(MakeImm("endAlgResidue"));
+SMTX.SetEndAlgResidue:=SMTX.Setter("endAlgResidue");
+SMTX.EndAlgResidue:=SMTX.Getter("endAlgResidue");

--- a/lib/meataxe.gd
+++ b/lib/meataxe.gd
@@ -88,6 +88,7 @@ SMTX:=rec(name:="The Smash MeatAxe");
 MTX:=SMTX;
 
 SMTX.Getter := function(string)
+  MakeImmutable(string);
   return function(module)
     if not (IsBound(module.smashMeataxe) and 
             IsBound(module.smashMeataxe.(string))) then

--- a/lib/meataxe.gi
+++ b/lib/meataxe.gi
@@ -198,6 +198,7 @@ InstallGlobalFunction(WedgeGModule,function( module)
 end);
 
 SMTX.Setter:=function(string)
+  MakeImmutable(string);
   return function(module,obj)
     if not IsBound(module.smashMeataxe) then
       module.smashMeataxe:=rec();
@@ -262,33 +263,33 @@ SMTX.HasIsAbsolutelyIrreducible:=function(module)
   return IsBound(module.IsAbsolutelyIrreducible);
 end;
 
-SMTX.SetSmashRecord:=SMTX.Setter(MakeImm("dummy"));
-SMTX.Subbasis:=SMTX.Getter(MakeImm("subbasis"));
-SMTX.SetSubbasis:=SMTX.Setter(MakeImm("subbasis"));
-SMTX.AlgEl:=SMTX.Getter(MakeImm("algebraElement"));
-SMTX.SetAlgEl:=SMTX.Setter(MakeImm("algebraElement"));
-SMTX.AlgElMat:=SMTX.Getter(MakeImm("algebraElementMatrix"));
-SMTX.SetAlgElMat:=SMTX.Setter(MakeImm("algebraElementMatrix"));
-SMTX.AlgElCharPol:=SMTX.Getter(MakeImm("characteristicPolynomial"));
-SMTX.SetAlgElCharPol:=SMTX.Setter(MakeImm("characteristicPolynomial"));
-SMTX.AlgElCharPolFac:=SMTX.Getter(MakeImm("charpolFactors"));
-SMTX.SetAlgElCharPolFac:=SMTX.Setter(MakeImm("charpolFactors"));
-SMTX.AlgElNullspaceVec:=SMTX.Getter(MakeImm("nullspaceVector"));
-SMTX.SetAlgElNullspaceVec:=SMTX.Setter(MakeImm("nullspaceVector"));
-SMTX.AlgElNullspaceDimension:=SMTX.Getter(MakeImm("ndimFlag"));
-SMTX.SetAlgElNullspaceDimension:=SMTX.Setter(MakeImm("ndimFlag"));
+SMTX.SetSmashRecord:=SMTX.Setter("dummy");
+SMTX.Subbasis:=SMTX.Getter("subbasis");
+SMTX.SetSubbasis:=SMTX.Setter("subbasis");
+SMTX.AlgEl:=SMTX.Getter("algebraElement");
+SMTX.SetAlgEl:=SMTX.Setter("algebraElement");
+SMTX.AlgElMat:=SMTX.Getter("algebraElementMatrix");
+SMTX.SetAlgElMat:=SMTX.Setter("algebraElementMatrix");
+SMTX.AlgElCharPol:=SMTX.Getter("characteristicPolynomial");
+SMTX.SetAlgElCharPol:=SMTX.Setter("characteristicPolynomial");
+SMTX.AlgElCharPolFac:=SMTX.Getter("charpolFactors");
+SMTX.SetAlgElCharPolFac:=SMTX.Setter("charpolFactors");
+SMTX.AlgElNullspaceVec:=SMTX.Getter("nullspaceVector");
+SMTX.SetAlgElNullspaceVec:=SMTX.Setter("nullspaceVector");
+SMTX.AlgElNullspaceDimension:=SMTX.Getter("ndimFlag");
+SMTX.SetAlgElNullspaceDimension:=SMTX.Setter("ndimFlag");
 
-SMTX.CentMat:=SMTX.Getter(MakeImm("centMat"));
-SMTX.SetCentMat:=SMTX.Setter(MakeImm("centMat"));
-SMTX.CentMatMinPoly:=SMTX.Getter(MakeImm("centMatMinPoly"));
-SMTX.SetCentMatMinPoly:=SMTX.Setter(MakeImm("centMatMinPoly"));
+SMTX.CentMat:=SMTX.Getter("centMat");
+SMTX.SetCentMat:=SMTX.Setter("centMat");
+SMTX.CentMatMinPoly:=SMTX.Getter("centMatMinPoly");
+SMTX.SetCentMatMinPoly:=SMTX.Setter("centMatMinPoly");
 
-SMTX.FGCentMat:=SMTX.Getter(MakeImm("fieldGenCentMat"));
-SMTX.SetFGCentMat:=SMTX.Setter(MakeImm("fieldGenCentMat"));
-SMTX.FGCentMatMinPoly:=SMTX.Getter(MakeImm("fieldGenCentMatMinPoly"));
-SMTX.SetFGCentMatMinPoly:=SMTX.Setter(MakeImm("fieldGenCentMatMinPoly"));
+SMTX.FGCentMat:=SMTX.Getter("fieldGenCentMat");
+SMTX.SetFGCentMat:=SMTX.Setter("fieldGenCentMat");
+SMTX.FGCentMatMinPoly:=SMTX.Getter("fieldGenCentMatMinPoly");
+SMTX.SetFGCentMatMinPoly:=SMTX.Setter("fieldGenCentMatMinPoly");
 
-SMTX.SetDegreeFieldExt:=SMTX.Setter(MakeImm("degreeFieldExt"));
+SMTX.SetDegreeFieldExt:=SMTX.Setter("degreeFieldExt");
 
 
 #############################################################################

--- a/lib/mgmring.gi
+++ b/lib/mgmring.gi
@@ -639,7 +639,7 @@ InstallMethod( OneOp,
       return fail;
     fi;
     z:= ZeroCoefficient( elm );
-    return Objectify( F!.defaultType, MakeImm([ z, [ F!.oneMagma, One( z ) ] ]) );
+    return Objectify( F!.defaultType, MakeImmutable([ z, [ F!.oneMagma, One( z ) ] ]) );
     end );
 
 

--- a/lib/object.gd
+++ b/lib/object.gd
@@ -226,7 +226,6 @@ InstallTrueMethod( IsCopyable, IsMutable);
 ##  <#GAPDoc Label="Immutable">
 ##  <ManSection>
 ##  <Func Name="Immutable" Arg='obj'/>
-##  <Func Name="Imm" Arg='obj'/>
 ##
 ##  <Description>
 ##  returns an immutable structural copy
@@ -238,15 +237,11 @@ InstallTrueMethod( IsCopyable, IsMutable);
 ##  <P/>
 ##  &GAP; will complain with an error if one tries to change an
 ##  immutable object.
-##  <P/>
-##  <Ref Func="Imm"/> povides a shorthand for <Ref Func="Immutable"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL( "Immutable", IMMUTABLE_COPY_OBJ );
-BIND_GLOBAL( "Imm", IMMUTABLE_COPY_OBJ );
-BIND_GLOBAL( "MakeImm", MakeImmutable );
 
 #############################################################################
 ##

--- a/lib/string.gd
+++ b/lib/string.gd
@@ -832,7 +832,7 @@ DeclareGlobalFunction("PrintCSV");
 ##
 DeclareGlobalFunction("LaTeXTable");
 
-BindGlobal("BHINT", MakeImm("\>\<"));
+BindGlobal("BHINT", MakeImmutable("\>\<"));
 
 #############################################################################
 ##

--- a/tst/testinstall/immutable.tst
+++ b/tst/testinstall/immutable.tst
@@ -7,21 +7,13 @@
 ##
 ##
 gap> START_TEST("immutable.tst");
-gap> IS_IDENTICAL_OBJ(Immutable, Imm);
-true
-gap> IS_IDENTICAL_OBJ(MakeImmutable, MakeImm);
-true
 gap> IS_IDENTICAL_OBJ(Immutable, MakeImmutable);
 false
 gap> IsMutable(1);
 false
 gap> IS_IDENTICAL_OBJ(1,Immutable(1));
 true
-gap> IS_IDENTICAL_OBJ(1,Imm(1));
-true
 gap> IS_IDENTICAL_OBJ(1,MakeImmutable(1));
-true
-gap> IS_IDENTICAL_OBJ(1,MakeImm(1));
 true
 gap> x := [1,2,3];
 [ 1, 2, 3 ]
@@ -31,11 +23,7 @@ gap> IsMutable(Immutable(x));
 false
 gap> x = Immutable(x);
 true
-gap> IsMutable(Imm(x));
-false
-gap> x = Imm(x);
-true
-gap> IS_IDENTICAL_OBJ(x, Imm(x));
+gap> IS_IDENTICAL_OBJ(x, Immutable(x));
 false
 gap> IsMutable(x);
 true


### PR DESCRIPTION
These were introduced as convenience aliases for Immutable and
MakeImmutable. In practice, they are not that convenient, but instead
just add more complexity.

Luckily, they were never in a released GAP version, so let's remove them
before GAP 4.9 is released. I.e. assuming we all agree on this, we'll merge this PR and then cherry-pick it into the stable-4.9 branch.

As far as I know, no packages uses `Imm` or `MakeImm` (I just checked this in a package archive I downloaded last week). Also, in the GAP commit history, only a handful commits, all by @ChrisJefferson , ever used it. So I think this is fairly safe.