### PR TITLE
Fix issues in NUMBER_GF2VEC and NUMBER_VEC8BIT

### DIFF
--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -2470,6 +2470,9 @@ Obj FuncNUMBER_VEC8BIT (Obj self, Obj vec)
     res = INTOBJ_INT(0);
     f = INTOBJ_INT(FIELD_VEC8BIT(vec)); /* Field size as GAP integer */
 
+    if (len == 0)
+      return INTOBJ_INT(1);
+
     for (i = 0; i < len; i++) {
         elt = convtab[gettab[ptrS[i / elts] + 256 * (i % elts)]];
         res = ProdInt(res, f); /* ``shift'' */

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -2988,6 +2988,8 @@ Obj FuncNUMBER_GF2VEC( Obj self, Obj vec )
   UInt *num;
   mp_limb_t *vp;
   len = LEN_GF2VEC(vec);
+  if (len == 0)
+    return INTOBJ_INT(1);
   num = BLOCKS_GF2VEC(vec) + (len-1)/BIPEB;
   off = (len -1) % BIPEB + 1; /* number of significant bits in last word */
   off2 = BIPEB - off;         /* number of insignificant bits in last word */

--- a/tst/testbugfix/2018-01-29-NUMBER_VEC.tst
+++ b/tst/testbugfix/2018-01-29-NUMBER_VEC.tst
@@ -1,0 +1,12 @@
+# Fix NUMBER_GF2VEC crash if input is empty vector
+# See https://github.com/gap-system/gap/issues/2121
+gap> v:=[];; CONV_GF2VEC(v); v;
+<a GF2 vector of length 0>
+gap> NUMBER_GF2VEC(v);
+1
+
+# Fix NUMBER_VEC8BIT to return correct result for empty vector
+gap> v:=[];; CONV_VEC8BIT(v,5); v;
+< mutable compressed vector length 0 over GF(5) >
+gap> NUMBER_VEC8BIT(v);
+1


### PR DESCRIPTION
This PR fixes a crash mentioned in #2117 resp. #2121. It also makes `NUMBER_VEC8BIT` return a correct result for empty vectors (1, not 0).