### PR TITLE
WIP: Fixes for vector spaces with DimensionOfVectors(V) = 0 (DO NOT MERGE)

### DIFF
--- a/hpcgap/lib/basis.gi
+++ b/hpcgap/lib/basis.gi
@@ -1403,6 +1403,17 @@ InstallMethod( Coefficients,
     fi;
     end );
 
+InstallOtherMethod( Coefficients,
+    "for empty basis and empty list",
+    [ IsBasis and IsEmpty, IsEmpty and IsList ], SUM_FLAGS,
+    function( B, v )
+    if v = Zero( UnderlyingLeftModule( B ) ) then
+      return [];
+    else
+      return fail;
+    fi;
+    end );
+
 InstallMethod( LinearCombination,
     "for empty basis and empty list",
     [ IsBasis and IsEmpty, IsList and IsEmpty ], SUM_FLAGS,

--- a/lib/basis.gi
+++ b/lib/basis.gi
@@ -1398,6 +1398,17 @@ InstallMethod( Coefficients,
     fi;
     end );
 
+InstallOtherMethod( Coefficients,
+    "for empty basis and empty list",
+    [ IsBasis and IsEmpty, IsEmpty and IsList ], SUM_FLAGS,
+    function( B, v )
+    if v = Zero( UnderlyingLeftModule( B ) ) then
+      return [];
+    else
+      return fail;
+    fi;
+    end );
+
 InstallMethod( LinearCombination,
     "for empty basis and empty list",
     [ IsBasis and IsEmpty, IsList and IsEmpty ], SUM_FLAGS,

--- a/lib/modulrow.gi
+++ b/lib/modulrow.gi
@@ -209,6 +209,15 @@ InstallMethod( \in,
            and IsSubset( LeftActingDomain( M ), v );
     end );
 
+# TODO: HACK: properly document this
+InstallMethod( \in,
+    "for empty list and vector space with length 0 vector",
+    [ IsEmpty and IsList, IsFreeLeftModule and IsFullRowModule ],
+    SUM_FLAGS, # can't do better
+    function( v, M )
+    return DimensionOfVectors(M) = 0;
+    end );
+
 
 #############################################################################
 ##
@@ -535,7 +544,8 @@ InstallMethod( EnumeratorByBasis,
                  zerovector    := Zero( V ),
                  dimension     := Dimension( V ) ) );
 
-      if IsField( F ) and Size( F ) < 256 and IsInternalRep( One( F ) ) then
+      if IsField( F ) and Size( F ) < 256 and Dimension( V ) > 0 and
+            IsInternalRep( One( F ) ) then
         # Use a more efficient method for `Position'.
         enum!.NumberElement:= PosVecEnumFF;
         SetFilterObj( enum, IsQuickPositionList );

--- a/tst/testbugfix/2018-01-29-empty-list-in-vecspace.tst
+++ b/tst/testbugfix/2018-01-29-empty-list-in-vecspace.tst
@@ -1,0 +1,17 @@
+#
+# See <https://github.com/gap-system/gap/issues/2117>
+#
+gap> V := GF(5)^0;;
+gap> e := Enumerator(V);;
+gap> Position(e, Zero(V));
+1
+gap> Coefficients(Basis(V), Zero(V));
+[  ]
+
+#
+gap> V := GF(257)^0;;
+gap> e := Enumerator(V);;
+gap> Position(e, Zero(V));
+1
+gap> Coefficients(Basis(V), Zero(V));
+[  ]


### PR DESCRIPTION
[This is motivated by #2117 resp #2121; in particular, it fixes #2117)
Given a vector space V with DimensionOfVectors(V) = 0, e.g. V:=GF(5)^0, we currently
have Zero(V) = []. This commit makes the following snippets work:

* Coefficients(Basis(V), [])
* Position(Enumerator(V), [])
* [] in V

Especially the last point requires a rather nasty hack: By definition, "[a] collection in GAP consists of elements in the same family"; and any vector space `V` in GAP is such a collection, yet its only element, the empty list `[]`, is not in the correct family. This already is strictly speaking a bug, and forcing `\in` to work regardless could equally be described as a "fix" or as "making things even worse".

So all in all I am conflicted about merging this... But what is the alternative? For vectors over small fields, we could realize #2121 and make empty compressed vectors safe to use, but that doesn't solve e.g. the case of `Rationals^0`.