### PR TITLE
Memmove fix

### DIFF
--- a/src/gasman.c
+++ b/src/gasman.c
@@ -115,6 +115,7 @@
 
 #include <src/gaputils.h>
 #include <src/io.h>
+#include <src/sysfiles.h>
 
 
 /****************************************************************************
@@ -1362,7 +1363,7 @@ UInt ResizeBag (
         SET_PTR_BAG(bag, dst);
 
         /* copy the contents of the bag                                    */
-        memmove((void *)dst, (void *)DATA(header),
+        SyMemmove((void *)dst, (void *)DATA(header),
                 sizeof(Obj) * WORDS_BAG(old_size));
     }
 
@@ -1884,7 +1885,7 @@ again:
 
             /* Otherwise do the default thing */
             else if ( dst != DATA(header) ) {
-                memmove(dst, DATA(header), (end - DATA(header))*sizeof(Bag));
+                SyMemmove(dst, DATA(header), (end - DATA(header))*sizeof(Bag));
                 dst += end - DATA(header);
             }
             else {
@@ -2024,7 +2025,7 @@ again:
             i = SpaceBetweenPointers(EndBags,stopBags)/7 - (SizeMptrsArea-NrLiveBags);
 
             /* move the bags area                                          */
-            memmove(OldBags+i, OldBags, SizeAllBagsArea*sizeof(*OldBags));
+            SyMemmove(OldBags+i, OldBags, SizeAllBagsArea*sizeof(*OldBags));
 
             /* update the masterpointers                                   */
             for ( p = MptrBags; p < OldBags; p++ ) {

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -25,6 +25,7 @@
 #include <src/pperm.h>
 #include <src/set.h>
 #include <src/stringobj.h>
+#include <src/sysfiles.h>
 #include <src/trans.h>
 
 #ifdef HPCGAP
@@ -100,7 +101,7 @@ void            AddPlist3 (
     if (pos <= len) {
       GROW_PLIST(list, len+1);
       SET_LEN_PLIST(list, len+1);
-      memmove(ADDR_OBJ(list) + pos+1,
+      SyMemmove(ADDR_OBJ(list) + pos+1,
               CONST_ADDR_OBJ(list) + pos,
               (size_t)(sizeof(Obj)*(len - pos + 1)));
     }
@@ -288,7 +289,7 @@ Obj             FuncAPPEND_LIST_INTR (
         GROW_STRING(list1, len1 + len2);
         SET_LEN_STRING(list1, len1 + len2);
         CLEAR_FILTS_LIST(list1);
-        memmove( CHARS_STRING(list1) + len1, CHARS_STRING(list2), len2 + 1);
+        SyMemmove( CHARS_STRING(list1) + len1, CHARS_STRING(list2), len2 + 1);
         /* ensure trailing zero */
         *(CHARS_STRING(list1) + len1 + len2) = 0;    
         return (Obj) 0;
@@ -1623,7 +1624,7 @@ Obj FuncCOPY_LIST_ENTRIES( Obj self, Obj args )
   GROW_PLIST(srclist, srcmax);
   if (srcinc == 1 && dstinc == 1)
     {
-      memmove(ADDR_OBJ(dstlist) + dststart,
+      SyMemmove(ADDR_OBJ(dstlist) + dststart,
               CONST_ADDR_OBJ(srclist) + srcstart,
               (size_t) number*sizeof(Obj));
     }

--- a/src/opers.c
+++ b/src/opers.c
@@ -28,6 +28,7 @@
 #include <src/records.h>
 #include <src/saveload.h>
 #include <src/stringobj.h>
+#include <src/sysfiles.h>
 
 #ifdef HPCGAP
 #include <src/hpc/aobjects.h>
@@ -1991,7 +1992,7 @@ static ALWAYS_INLINE Obj GetMethodCached(Obj  oper,
                         Obj buf[cacheEntrySize];
                         memcpy(buf, cache + i,
                                sizeof(Obj) * cacheEntrySize);
-                        memmove(cache + target + cacheEntrySize,
+                        SyMemmove(cache + target + cacheEntrySize,
                                 cache + target,
                                 sizeof(Obj) * (i - target));
                         memcpy(cache + target, buf,
@@ -2017,7 +2018,7 @@ CacheMethod(Obj oper, UInt n, Int prec, Obj * ids, Obj method)
     UInt  cacheEntrySize = n + 2;
     Bag   cacheBag = GET_METHOD_CACHE(oper, n);
     Obj * cache = 1 + prec * cacheEntrySize + ADDR_OBJ(cacheBag);
-    memmove(cache + cacheEntrySize, cache,
+    SyMemmove(cache + cacheEntrySize, cache,
             sizeof(Obj) * (CACHE_SIZE - prec - 1) * cacheEntrySize);
     cache[0] = method;
     cache[1] = INTOBJ_INT(prec);

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -52,6 +52,7 @@
 #include <src/range.h>
 #include <src/records.h>
 #include <src/saveload.h>
+#include <src/sysfiles.h>
 #include <src/trans.h>
 
 /****************************************************************************
@@ -4443,12 +4444,12 @@ Obj FuncSCR_SIFT_HELPER(Obj self, Obj S, Obj g, Obj n)
   /* Copy g into the buffer */
   if (IS_PERM2(g) && useP2) {
     UInt2 * ptR = ADDR_PERM2(result);
-    memmove(ptR, CONST_ADDR_PERM2(g),2*dg);
+    SyMemmove(ptR, CONST_ADDR_PERM2(g),2*dg);
     for ( i = dg; i < nn; i++)
       ptR[i] = (UInt2)i;
   } else if (IS_PERM4(g) && !useP2) {
     UInt4 *ptR = ADDR_PERM4(result);
-    memmove(ptR,CONST_ADDR_PERM4(g),4*dg);    
+    SyMemmove(ptR,CONST_ADDR_PERM4(g),4*dg);
     for ( i = dg; i <nn; i++)
       ptR[i] = (UInt4)i;
   } else if (IS_PERM2(g) && !useP2) {

--- a/src/set.c
+++ b/src/set.c
@@ -29,6 +29,7 @@
 #include <src/listfunc.h>
 #include <src/lists.h>
 #include <src/plist.h>
+#include <src/sysfiles.h>
 
 
 /****************************************************************************
@@ -449,7 +450,7 @@ Obj FuncADD_SET (
     {
       Obj *ptr;
       ptr = PTR_BAG(set);
-      memmove(ptr + pos+1, ptr+pos, sizeof(Obj)*(len+1-pos));
+      SyMemmove(ptr + pos+1, ptr+pos, sizeof(Obj)*(len+1-pos));
     }
     SET_ELM_PLIST( set, pos, obj );
     CHANGED_BAG( set );

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -577,6 +577,7 @@ extern Char * SyTmpname ( void );
 */
 extern Char * SyTmpdir ( const Char * hint );
 
+
 /****************************************************************************
 **
 *F  void getwindowsize( void )  . probe the OS for the window size and
@@ -611,6 +612,9 @@ extern Char *SyFgetsSemiBlock (
 extern Obj SyReadStringFid(Int fid);
 extern Obj SyReadStringFile(Int fid);
 extern Obj SyReadStringFileGeneric(Int fid);
+
+// Internal implementation of memmove, to avoid issues with glibc
+void *SyMemmove(void *dst, const void* src, UInt size);
 
 /****************************************************************************
 **

--- a/src/system.c
+++ b/src/system.c
@@ -2006,7 +2006,7 @@ void InitSystem (
             const UInt pathlen = strlen(SyGapRootPaths[i]);
             if (SyGapRootPaths[i][0] == '~' &&
                 userhomelen + pathlen < sizeof(SyGapRootPaths[i])) {
-                memmove(SyGapRootPaths[i] + userhomelen,
+                SyMemmove(SyGapRootPaths[i] + userhomelen,
                         /* don't copy the ~ but the trailing '\0' */
                         SyGapRootPaths[i] + 1, pathlen);
                 memcpy(SyGapRootPaths[i], userhome, userhomelen);


### PR DESCRIPTION
This is an attempt to fix the bug in 32-bit memove, identified by Max Horn.

I have checked and up to date clang and gcc seem unable to convert SyMemmove to memmove.

I decided to just always use my function for 32-bit GAP, as it seems only about 25% slower than the built-in, and I have never seen memmove occur as a significant part of any GAP profile.