### PR TITLE
Fix for `[Z(3)^0] in ExtendedVectors(GF(3)^0)`

### DIFF
--- a/lib/vspcrow.gi
+++ b/lib/vspcrow.gi
@@ -1729,6 +1729,10 @@ BindGlobal( "NumberElement_ExtendedVectors", function( enum, elm )
                          or elm[ enum!.len ] <> enum!.one then
       return fail;
     fi;
+    # special case for dimension 1: here, the truncated vector would be an
+    # empty list, and there are problems with trivial vector spaces over
+    # length 0 vectors (see e.g. issue #2117, PR #2125)
+    if Length( elm ) = 1 then return 1; fi;
     return Position( enum!.spaceEnumerator,
 		     elm{ [ 1 .. Length( elm ) - 1 ] } );
 end );

--- a/tst/testbugfix/2018-01-30-triv-aff-space.tst
+++ b/tst/testbugfix/2018-01-30-triv-aff-space.tst
@@ -1,0 +1,16 @@
+# Verify that enumerating "extended" vectors" over a trivial vector space
+# works as intended (this used to fail, because testing whether the empty
+# list [] is contained in the vector space V defined below, which is
+# collection, by definition always fails in GAP, even though [] is e.g. equal
+# to Zero(V). This is a major problem by itself, but difficult to resolve.
+#
+# In any case, we sidestep this larger issue, and just worry about the
+# particular case of "extended" vectors.
+gap> V:=GF(3)^0;;
+gap> A:=ExtendedVectors(V);;
+gap> [Z(3)^0] in A;
+true
+
+# test the original example from issue #2117
+gap> g:= DirectProduct( AlternatingGroup(5), SymmetricGroup(3) );;
+gap> Irr( g );;


### PR DESCRIPTION
This fixes #2117 in an hopefully minimalistic fashion. There are lots of potentially related problems, of course. See also #2121 and #2125