### PR TITLE
Substitute for CONFIGNAME in old build system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -413,6 +413,10 @@ dnl
 AS_IF([test "x$enable_hpcgap" = xyes],
   [GAPARCH="$host-hpcgap${ABI}"],
   [GAPARCH="$host-default${ABI}"])
+AS_IF([test "x$ARCHEXT" != "x"],
+  [GAPARCH="$GAPARCH-$ARCHEXT"])
+AS_IF([test "x$ARCH" != "x"],
+  [GAPARCH="$ARCH"])
 
 AC_DEFINE_UNQUOTED([SYS_ARCH], ["$GAPARCH"], [for backwards compatibility])
 AC_SUBST([GAPARCH])


### PR DESCRIPTION
There are various scenarios where users want to build GAP with different
configurations (for different machines/ architectures, with different
optimizations or libraries, for several branches of a repository, ...).

In GAPs old build system an environment variable `CONFIGNAME` was
introduced for two reasons:
  (1) to allow for building GAP with several configurations within
      the main GAP directory
  (2) to allow for building packages with kernel code for several
      configurations within the same copy of the package

In the new build system (1) can be addressed differently, namely with
"out-of-tree builds": go to any directory $BUILDDIR and call the `configure`
script in your GAP source directory from there.

But I don't see how (2) could work. GAP searches the kernel modules of a
package in a subdirectory of the package `bin/$GAParch`, where the content
of `GAParch` is stored in GAP in `GAPInfo.Architecture` and the variable is
set in the `sysinfo.gap` file in any `$BUILDDIR` directory (and it is shown
in GAPs startup banner). Unfortunately, many possible configurations of
GAP will produce the same `$GAParch` which leads to conflicts when building
packages for several configurations.

This patch introduces environment variables which affect the value of
`$GAParch` during `configure` of GAP. Examples:

 cd /dir1; /gapdir/configure ARCHEXT=ForMyMachine ...more options ; make

 cd /dir2; /gapdir/configure ARCH=MyArchDescription ...other options ; make

Now I can build my package multiple times by
 cd /gapdir/pkg/MyPkg
 ./configure /dir1; make
 ./configure /dir2; make
Then `MyPkg/bin` will contain directories like
   bin/x86_64-pc-linux-gnu-default64-ForMyMachine
   bin/MyArchDescription
without any conflict.