### PR TITLE
HPC: Update the HPC-GAP documentation

### DIFF
--- a/doc/hpc/regions.xml
+++ b/doc/hpc/regions.xml
@@ -479,7 +479,7 @@ locking the target. I.e., for a list, it is equivalent to:
 
 <Example><![CDATA[
 AtomicIncorporateObj := function(target, index, value)
-  atomic value do
+  atomic target, value do
     target[index] := MigrateObj(value, target)
   od;
 end;

--- a/doc/hpc/tasks.xml
+++ b/doc/hpc/tasks.xml
@@ -220,6 +220,38 @@ identically to <C>WaitAnyTask(task1, ..., taskn)</C>.
         The <Ref Func="TaskResult"/> function returns the result of a task. It implicitly calls <Ref Func="WaitTask"/> if that is
         necessary. Multiple invocations of <Ref Func="TaskResult"/> with the same task argument will not do repeated waits and always
         return the same value.
+        <P/>
+        If the function executed by <A>task</A> encounters an error, <Ref Func="TaskResult"/> returns <K>fail</K>.
+        Whether <A>task</A> encountered an error can be checked via <Ref Func="TaskSuccess"/>.
+        In case of an error, the error message can be retrieved via <Ref Func="TaskError"/>.
+      </Description>
+    </ManSection>
+
+    <ManSection>
+      <Func Name="CullIdleTasks" Arg=''/>
+      <Description>
+        This function terminates unused worker threads.
+      </Description>
+    </ManSection>
+  </Section>
+
+  <Section Label="Information about tasks">
+    <Heading>Information about tasks</Heading>
+    <ManSection>
+      <Func Name="TaskSuccess" Arg='task'/>
+      <Description>
+          <Ref Func="TaskSuccess"/> waits for <A>task</A> and returns
+          <K>true</K> if the it finished without encountering an error.
+          Otherwise the function returns <K>false</K>.
+      </Description>
+    </ManSection>
+
+    <ManSection>
+      <Func Name="TaskError" Arg='task'/>
+      <Description>
+        <Ref Func="TaskError"/> waits for <A>task</A> and returns
+          its error message, if it encountered an error.
+          If it did not encounter an error, the function returns <K>fail</K>.
       </Description>
     </ManSection>
 
@@ -256,13 +288,6 @@ identically to <C>WaitAnyTask(task1, ..., taskn)</C>.
       <Func Name="TaskIsAsync" Arg='task'/>
       <Description>
         This function returns true if the task is asynchronous, true otherwise.
-      </Description>
-    </ManSection>
-
-    <ManSection>
-      <Func Name="CullIdleTasks" Arg=''/>
-      <Description>
-        This function terminates unused worker threads.
       </Description>
     </ManSection>
   </Section>

--- a/doc/hpc/tasks.xml
+++ b/doc/hpc/tasks.xml
@@ -87,8 +87,8 @@ Task arguments are generally copied so that both the task that created them and 
 data concurrently without fear of race conditions. To avoid copying, arguments should be made shared or public (see the
 relevant parts of section <Ref Sect="Migrating objects between regions"/> on migrating objects between regions); shared and public arguments will not be copied.
 <P/>
-HPC-GAP currently has multiple implementations of the task API. To enable the reference implementation, set the
-environment variable <C>GAP_STDTASKS</C> to a non-empty value before starting GAP.
+HPC-GAP currently has multiple implementations of the task API. To use an alternative implementation to the one documented here, set the
+environment variable <C>GAP_WORKSTEALING</C> to a non-empty value before starting GAP.
   </Section>
 
   <Section Label="Running tasks">

--- a/doc/hpc/tasks.xml
+++ b/doc/hpc/tasks.xml
@@ -65,18 +65,27 @@ gap> TaskResult(task);
 
 This is indistinguishable from calling the function directly, but provides the same interface as normal tasks.
 <P/>
-Sometimes it can be useful to ignore the result of a task. The <C>RunAsyncTask</C> provides the necessary functionality.
+If e.g. you want to call a function only for its side-effects, it can be useful to ignore the result of a task. <Ref Func="RunAsyncTask"/> provides the necessary functionality.
+Such a task cannot be waited for and its result (if any) is ignored.
 
 <Example><![CDATA[
 gap> RunAsyncTask(function() Print("Hello, world!\n"); end);;
-Hello, world!
+gap> !list
+--- Thread 0 [0]
+--- Thread 5 [5] (pending output)
+gap> !5
+--- Switching to thread 5
+[5] Hello, world!
+!0
+--- Switching to thread 0
+gap>
 ]]></Example>
 
-Such a task cannot be waited for and its result (if any) is ignored.
+For more information on the multi-threaded user interface, see Chapter <Ref Chap="Console User Interface"/>.
 <P/>
 Task arguments are generally copied so that both the task that created them and the task that uses them can access the
 data concurrently without fear of race conditions. To avoid copying, arguments should be made shared or public (see the
-relevant parts of the section on ); shared and public arguments will not be copied.
+relevant parts of section <Ref Sect="Migrating objects between regions"/> on migrating objects between regions); shared and public arguments will not be copied.
 <P/>
 HPC-GAP currently has multiple implementations of the task API. To enable the reference implementation, set the
 environment variable <C>GAP_STDTASKS</C> to a non-empty value before starting GAP.


### PR DESCRIPTION
The task documentation documented the old user interface. For some time
now, HPCGAP comes with a multi-threaded UI. One example needed to be
updated wrt to that point.

This commit also adds some missing references.