### PR TITLE
Document LowIndexSubgroups, add LowLayerSubgroups, some fixes (partial rebase of #2035)

### DIFF
--- a/doc/ref/groups.xml
+++ b/doc/ref/groups.xml
@@ -449,8 +449,9 @@ the series without destroying the properties of the series.
 <#Include Label="IsConjugacyClassSubgroupsRep">
 <#Include Label="ConjugacyClassesSubgroups">
 <#Include Label="ConjugacyClassesMaximalSubgroups">
-<#Include Label="AllSubgroups">
 <#Include Label="MaximalSubgroupClassReps">
+<#Include Label="LowIndexSubgroups">
+<#Include Label="AllSubgroups">
 <#Include Label="MaximalSubgroups">
 <#Include Label="NormalSubgroups">
 <#Include Label="MaximalNormalSubgroups">

--- a/lib/clas.gd
+++ b/lib/clas.gd
@@ -320,8 +320,10 @@ DeclareGlobalFunction( "GeneralStepClEANS" );
 ##  <Mark><C>candidates</C></Mark>
 ##  <Item>
 ##  is a list of elements for which canonical representatives
-##  are to be computed or for which a conjugacy test is performed. They must
-##  be given in mode 4. In mode 0 a list of classes corresponding to
+##  are to be computed or for which a conjugacy test is performed. Both
+##  elements must lie in <A>G</A>, but this is not tested. In mode 4 these
+##  elements must be given.
+##  In mode 0 a list of classes corresponding to
 ##  <C>candidates</C> is returned (which may contain duplicates). The
 ##  <C>representative</C>s chosen are canonical with respect to <C>pcgs</C>.
 ##  The records returned also contain components <C>operator</C>

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -4495,27 +4495,26 @@ DeclareGlobalFunction("GroupEnumeratorByClosure");
 ##
 ##  <#GAPDoc Label="LowIndexSubgroups">
 ##  <ManSection>
-##  <Oper Name="LowIndexSubgroups"
-##   Arg='G, index'/>
 ##  <Oper Name="LowIndexSubgroups" Arg='G, index'/>
 ##
 ##  <Description>
-##  These operations computes representatives of the conjugacy classes of
-##  subgroups of the group <A>G</A> that 
-##  index less than or equal to
-##  <A>index</A>.
+##  The operation <Ref Oper="LowIndexSubgroups"/> computes representatives of
+##  the conjugacy classes of subgroups of the group <A>G</A> that index less
+##  than or equal to <A>index</A>.
 ##  <P/>
 ##  For finitely presented groups this operation simply defaults to
-##  <C>LowIndexSubgroupsFpGroup</C>. In other cases, it uses repeated
+##  <Ref Oper="LowIndexSubgroupsFpGroup"/>. In other cases, it uses repeated
 ##  calculation of maximal subgroups.
 ##  <P/>
+##  The function <Ref Func="LowLayerSubgroups"/> works similar but does not
+##  bound the index, but instead considers up to <A>layer</A>-th maximal
+##  subgroups.
 ##  <Example><![CDATA[
 ##  gap> g:=TransitiveGroup(18,950);;
 ##  gap> l:=LowIndexSubgroups(g,20);;Collected(List(l,x->Index(g,x)));
 ##  [ [ 1, 1 ], [ 2, 1 ], [ 5, 1 ], [ 6, 1 ], [ 10, 2 ], [ 12, 3 ], [ 15, 1 ], 
 ##    [ 16, 2 ], [ 18, 1 ], [ 20, 9 ] ]
 ##  ]]></Example>
-##  <P/>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/grpffmat.gi
+++ b/lib/grpffmat.gi
@@ -79,6 +79,13 @@ if Length(l)=0 then Error("list must be nonempty");fi;
   return GF(char^deg);
 end);
 
+BindGlobal("NonemptyGeneratorsOfGroup",function(grp)
+local l;
+   l:=GeneratorsOfGroup(grp);
+   if Length(l)=0 then l:=[One(grp)]; fi;
+   return l;
+end);
+
 #############################################################################
 ##
 #M  IsNaturalGL( <ffe-mat-grp> )
@@ -91,7 +98,7 @@ InstallMethod( IsNaturalGL,
 
 function( grp )
   return MTX.IsAbsolutelyIrreducible(
-    GModuleByMats(GeneratorsOfGroup(grp),DefaultFieldOfMatrixGroup(grp))) and
+    GModuleByMats(NonemptyGeneratorsOfGroup(grp),DefaultFieldOfMatrixGroup(grp))) and
    Size( grp ) = Size( GL( DimensionOfMatrixGroup( grp ),
 		  Size( FieldOfMatrixGroup( grp ) ) ) );
 end );
@@ -108,7 +115,7 @@ local gen, d, f;
   d := DimensionOfMatrixGroup( grp );
   gen := GeneratorsOfGroup( grp );
   return MTX.IsAbsolutelyIrreducible(
-    GModuleByMats(GeneratorsOfGroup(grp),DefaultFieldOfMatrixGroup(grp))) and
+    GModuleByMats(NonemptyGeneratorsOfGroup(grp),DefaultFieldOfMatrixGroup(grp))) and
     ForAll(gen, x-> DeterminantMat(x) = One(f)) 
 	    and Size(grp) = Size(SL(d, Size(f)));
 end );

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -3053,6 +3053,23 @@ local recog,m,len;
   return m;
 end);
 
+InstallMethod(LowIndexSubgroups,"finite groups, using iterated maximals",
+  true,[IsGroup and IsFinite,IsPosInt],0,
+function(G,n)
+local m,all,m2;
+  m:=[G];
+  all:=[G];
+  while Length(m)>0 do
+    m2:=Concatenation(List(m,MaximalSubgroupClassReps));
+    m2:=Unique(Filtered(m2,x->Index(G,x)<=n));
+    m2:=List(SubgroupsOrbitsAndNormalizers(G,m2,false),x->x.representative);
+    m2:=Filtered(m2,x->ForAll(all,y->RepresentativeAction(G,x,y)=fail));
+    Append(all,m2);
+    m:=Filtered(m2,x->Index(G,x)<=n/2); # otherwise subgroups will have too large index
+  od;
+  return all;
+end);
+
 #############################################################################
 ##
 #F  LowLayerSubgroups( [<act>,] <G>, <lim> [,<cond> [,<dosub>]] )

--- a/tst/testinstall/grpmat.tst
+++ b/tst/testinstall/grpmat.tst
@@ -50,6 +50,8 @@ gap> iso:= IsomorphismPermGroup( g );;
 gap> img:=Image( iso );;
 gap> Size(img);
 67010895544320000
+gap> IsNaturalGL( TrivialSubgroup( GL(2,2) ) );
+false
 
 # Unbind variables so we can GC memory
 gap> Unbind(img); Unbind(iso); Unbind(g); Unbind(hom); Unbind(u);


### PR DESCRIPTION
This is a rebased version of some changes in PR #2035. For an explanation, see there. My hope is that we can merge this ASAP into `master`, then immediately after cherry-pick it into master. 

The changes in this branch should be cherry-picked into stable-4.9.