### PR TITLE
kernel: optimize LcmInt for small inputs

### DIFF
--- a/src/integer.c
+++ b/src/integer.c
@@ -2199,6 +2199,15 @@ Obj LcmInt(Obj opL, Obj opR)
     if (opL == INTOBJ_INT(0) || opR == INTOBJ_INT(0))
         return INTOBJ_INT(0);
 
+    if (IS_INTOBJ(opL) || IS_INTOBJ(opR)) {
+        if (!IS_INTOBJ(opR)) {
+            SWAP(Obj, opL, opR);
+        }
+        Obj gcd = GcdInt(opL, opR);
+        opR = QuoInt(opR, gcd);
+        return AbsInt(ProdInt(opL, opR));
+    }
+
     sizeL = SIZE_INT_OR_INTOBJ(opL);
     sizeR = SIZE_INT_OR_INTOBJ(opR);
 


### PR DESCRIPTION
Motivated by PR #2154 (which made me realize that `LcmInt(100, 1)` will allocate a temporary `T_INTPOS` object only to immediately discard it again), this PR gives a tiny speed boost, but more importantly, avoids unnecessary allocation of temporary memory.

Before:
```
gap> for i in [1..10000000] do LcmInt(2^50*13, 2^50*17); od; time;
2655
gap> for i in [1..10000000] do LcmInt(2^60*13, 2^60*17); od; time;
4450
gap> for i in [1..10000000] do LcmInt(2^70*13, 2^70*17); od; time;
5831
```
After:
```
gap> for i in [1..10000000] do LcmInt(2^50*13, 2^50*17); od; time;
2381
gap> for i in [1..10000000] do LcmInt(2^60*13, 2^60*17); od; time;
4505
gap> for i in [1..10000000] do LcmInt(2^70*13, 2^70*17); od; time;
5854
```