### PR TITLE
Catch overflows in Gasman

### DIFF
--- a/src/gasman.c
+++ b/src/gasman.c
@@ -2089,7 +2089,7 @@ again:
     /* information after the check phase                                   */
     if ( MsgsFuncBags )
       (*MsgsFuncBags)( FullBags, 5,
-                       SpaceBetweenPointers(EndBags, stopBags)/(1024/sizeof(Bag)));
+                       (EndBags - stopBags)/(1024/sizeof(Bag)));
     if ( MsgsFuncBags )
         (*MsgsFuncBags)( FullBags, 6,
                          SizeWorkspace/(1024/sizeof(Bag)));


### PR DESCRIPTION
The main purpose of this patch is to catch a couple of pointer overflows in gasman. I also add some tests to make future problems easier to catch.

I suspect there may be other overflows, particularly is the memory space gets very close to 4GB, but this fixes some problems I know about, and my prefered solution to fixing other problems would be instead to limit the size of the memory space, so (for example) the GAP workspace stops at least 1GB from the end of the memory space, and we limit largest object to 1GB.