### PR TITLE
two small fixes concerning `InfoWarning`

### DIFF
--- a/lib/attr.gd
+++ b/lib/attr.gd
@@ -16,7 +16,8 @@
 ##  value the setter of the attribute is called, to (possibly) store the
 ##  computed value. In special circumstances, this behaviour can be altered
 ##  dynamically on an attribute-by-attribute basis, using the functions
-##  <C>DisableAttributeValueStoring</C> and <C>EnableAttributeValueStoring</C>.
+##  <Ref Func="DisableAttributeValueStoring"/> and
+##  <Ref Func="EnableAttributeValueStoring"/>.
 ##  <P/>
 ##  In general, the code in the library assumes, for efficiency, but not for
 ##  correctness, that attribute values <E>will</E> be stored (in suitable
@@ -34,7 +35,7 @@
 ##  <InfoClass Name="InfoAttributes"/>
 ##
 ##  <Description>
-##  This info class (together with <Ref Func="InfoWarning"/> is  used
+##  This info class (together with <Ref InfoClass="InfoWarning"/> is used
 ##  for messages about attribute storing  being  disabled  (at  level  2)  or
 ##  enabled (level 3). It may be  used  in  the  future  for  other  messages
 ##  concerning changes to attribute behaviour.
@@ -56,7 +57,8 @@ DeclareInfoClass("InfoAttributes");
 ##  <Description>
 ##  enables the usual call of <C>Setter( <A>attr</A> )</C> when  a  method  for  <A>attr</A>
 ##  returns a value. In consequence the  values  may  be  stored.  This  will
-##  usually  have  no  effect   unless   <C>DisableAttributeValueStoring</C>   has
+##  usually have no effect unless
+##  <Ref Func="DisableAttributeValueStoring"/> has
 ##  previously been used for <A>attr</A>. Note that <A>attr</A> must  be  an  attribute
 ##  and <E>not</E> a property.
 ##  <Example><![CDATA[

--- a/lib/cyclotom.gi
+++ b/lib/cyclotom.gi
@@ -1540,7 +1540,8 @@ InstallMethod( GaloisMat,
         for j in [ i+1 .. ncha ] do
           if mat[j] = X then
             galoisfams[j]:= Unknown();
-            InfoWarning( 1, "GaloisMat: row ", i, " is equal to row ", j );
+            Info( InfoWarning, 1,
+                  "GaloisMat: row ", i, " is equal to row ", j );
           fi;
         od;
 

--- a/tst/testinstall/cyclotom.tst
+++ b/tst/testinstall/cyclotom.tst
@@ -224,6 +224,8 @@ rec( galoisfams := [ [ [ 1, 5 ], [ 1, 10321 ] ], [ [ 2, 6 ], [ 1, 9031 ] ],
 gap> Print(RationalizedMat( gm.mat ),"\n");
 [ [ 2666, -1, -2, 0, 0 ], [ 519550080, 0, 0, 0, 0 ], 
   [ 1770515712, 0, -2, 0, 0 ], [ 4337827830, 0, 0, 0, -1 ] ]
+gap> GaloisMat( [ [ E(3) ], [ E(3) ] ] );;
+#I  GaloisMat: row 1 is equal to row 2
 gap> a := -E(4)*2^(8*GAPInfo.BytesPerVariable-4);;
 gap> TNUM_OBJ(COEFFS_CYC(-a)[2]) = T_INTPOS;
 true


### PR DESCRIPTION
two small fixes concerning `InfoWarning`

- fix of wrong GAP syntax (calling `InfoWarning` as a function,
  which causes an error --apparently this was never executed in GAP 4);
  I have now added a test for this piece of code

- fix of a wrong GAPDoc reference to the info class

    TB