### PR TITLE
Deal with Random changing attributes of object

### DIFF
--- a/tst/testrandom.g
+++ b/tst/testrandom.g
@@ -6,6 +6,10 @@ randomTest := function(collection, method, checkin...)
         checkmethod := checkin[1];
     fi;
 
+    # We do a single call first, to deal with calling Random causing extra attributes
+    # of 'collection' to be set, changing the dispatch
+    method(collection);
+
     # Firstly, we will generate a base list
     Init(GlobalMersenneTwister, 6);
     test1 := List([1..1000], x -> method(collection));


### PR DESCRIPTION
This changes the tester to add one initial call to `Random` when testing random generation. This deals with the problem where the first call to `Random` adds attributes, which changes which `Random` method gets called. Therefore calling `Random` twice, even if we reset `GlobalMersenneTwister`, produces different values.

The other alternative (why I marked this discussion) is that we could say this is a bug, and different overloads must provide the same sequence of random values.