### PR TITLE
kernel: overhaul OnSets & OnTuples for perms, pperms, trans

### DIFF
--- a/src/permutat.c
+++ b/src/permutat.c
@@ -46,6 +46,7 @@
 #include <src/gapstate.h>
 #include <src/integer.h>
 #include <src/io.h>
+#include <src/listfunc.h>
 #include <src/lists.h>
 #include <src/opers.h>
 #include <src/plist.h>
@@ -3552,6 +3553,9 @@ Obj             FuncSMALLEST_IMG_TUP_PERM (
 **
 **  'OnTuplesPerm'  returns  the  image  of  the  tuple  <tup>   under  the
 **  permutation <perm>.  It is called from 'FuncOnTuples'.
+**
+**  The input <tup> must be a non-empty and dense plain list. This is is not
+**  verified.
 */
 Obj             OnTuplesPerm (
     Obj                 tup,
@@ -3566,22 +3570,27 @@ Obj             OnTuplesPerm (
     UInt                lmp;            /* largest moved point             */
     UInt                i, k;           /* loop variables                  */
 
+    GAP_ASSERT(IS_PLIST(tup));
+    GAP_ASSERT(LEN_PLIST(tup) > 0);
+
+    const UInt len = LEN_PLIST(tup);
+
     /* make a bag for the result and initialize pointers                   */
     res = NEW_PLIST( IS_MUTABLE_PLIST(tup) ? T_PLIST : T_PLIST + IMMUTABLE,
-		     LEN_LIST(tup) );
-    ADDR_OBJ(res)[0] = CONST_ADDR_OBJ(tup)[0];
+		     len );
+    SET_LEN_PLIST(res, len);
 
     /* handle small permutations                                           */
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
 
         /* get the pointer                                                 */
-        ptTup = CONST_ADDR_OBJ(tup) + LEN_LIST(tup);
-        ptRes = ADDR_OBJ(res) + LEN_LIST(tup);
+        ptTup = CONST_ADDR_OBJ(tup) + len;
+        ptRes = ADDR_OBJ(res) + len;
         ptPrm2 = CONST_ADDR_PERM2(perm);
         lmp = DEG_PERM2(perm);
 
         /* loop over the entries of the tuple                              */
-        for ( i = LEN_LIST(tup); 1 <= i; i--, ptTup--, ptRes-- ) {
+        for ( i = len; 1 <= i; i--, ptTup--, ptRes-- ) {
             if (IS_INTOBJ(*ptTup) && (0 < INT_INTOBJ(*ptTup))) {
                 k = INT_INTOBJ( *ptTup );
                 if (k > lmp) {
@@ -3610,13 +3619,13 @@ Obj             OnTuplesPerm (
     else {
 
         /* get the pointer                                                 */
-        ptTup = CONST_ADDR_OBJ(tup) + LEN_LIST(tup);
-        ptRes = ADDR_OBJ(res) + LEN_LIST(tup);
+        ptTup = CONST_ADDR_OBJ(tup) + len;
+        ptRes = ADDR_OBJ(res) + len;
         ptPrm4 = CONST_ADDR_PERM4(perm);
         lmp = DEG_PERM4(perm);
 
         /* loop over the entries of the tuple                              */
-        for ( i = LEN_LIST(tup); 1 <= i; i--, ptTup--, ptRes-- ) {
+        for ( i = len; 1 <= i; i--, ptTup--, ptRes-- ) {
             if (IS_INTOBJ(*ptTup) && (0 < INT_INTOBJ(*ptTup))) {
                 k = INT_INTOBJ( *ptTup );
                 if (k > lmp) {
@@ -3653,8 +3662,8 @@ Obj             OnTuplesPerm (
 **  'OnSetsPerm' returns the  image of the  tuple <set> under the permutation
 **  <perm>.  It is called from 'FuncOnSets'.
 **
-**  The input <set> must be a set, i.e., dense and strictly sorted. This is
-**  is not verified.
+**  The input <set> must be a non-empty set, i.e., plain, dense and strictly
+**  sorted. This is is not verified.
 */
 Obj             OnSetsPerm (
     Obj                 set,
@@ -3668,26 +3677,30 @@ Obj             OnSetsPerm (
     Obj                 tmp;            /* temporary handle                */
     UInt                lmp;            /* largest moved point             */
     UInt                isint;          /* <set> only holds integers       */
-    UInt                len;            /* logical length of the list      */
-    UInt                h;              /* gap width in the shellsort      */
     UInt                i, k;           /* loop variables                  */
 
+    GAP_ASSERT(IS_PLIST(set));
+    GAP_ASSERT(LEN_PLIST(set) > 0);
+
+    const UInt len = LEN_PLIST(set);
+
     /* make a bag for the result and initialize pointers                   */
-    res = NEW_PLIST(  IS_MUTABLE_PLIST(set) ? T_PLIST : T_PLIST + IMMUTABLE , LEN_LIST(set) );
-    ADDR_OBJ(res)[0] = CONST_ADDR_OBJ(set)[0];
+    res = NEW_PLIST( IS_MUTABLE_PLIST(set) ? T_PLIST : T_PLIST + IMMUTABLE,
+                     len );
+    SET_LEN_PLIST(res, len);
 
     /* handle small permutations                                           */
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
 
         /* get the pointer                                                 */
-        ptTup = CONST_ADDR_OBJ(set) + LEN_LIST(set);
-        ptRes = ADDR_OBJ(res) + LEN_LIST(set);
+        ptTup = CONST_ADDR_OBJ(set) + len;
+        ptRes = ADDR_OBJ(res) + len;
         ptPrm2 = CONST_ADDR_PERM2(perm);
         lmp = DEG_PERM2(perm);
 
         /* loop over the entries of the tuple                              */
         isint = 1;
-        for ( i = LEN_LIST(set); 1 <= i; i--, ptTup--, ptRes-- ) {
+        for ( i = len; 1 <= i; i--, ptTup--, ptRes-- ) {
             if ( IS_INTOBJ( *ptTup ) && 0 < INT_INTOBJ( *ptTup ) ) {
                 k = INT_INTOBJ( *ptTup );
                 if ( k <= lmp )
@@ -3713,14 +3726,14 @@ Obj             OnSetsPerm (
     else {
 
         /* get the pointer                                                 */
-        ptTup = CONST_ADDR_OBJ(set) + LEN_LIST(set);
-        ptRes = ADDR_OBJ(res) + LEN_LIST(set);
+        ptTup = CONST_ADDR_OBJ(set) + len;
+        ptRes = ADDR_OBJ(res) + len;
         ptPrm4 = CONST_ADDR_PERM4(perm);
         lmp = DEG_PERM4(perm);
 
         /* loop over the entries of the tuple                              */
         isint = 1;
-        for ( i = LEN_LIST(set); 1 <= i; i--, ptTup--, ptRes-- ) {
+        for ( i = len; 1 <= i; i--, ptTup--, ptRes-- ) {
             if ( IS_INTOBJ( *ptTup ) && 0 < INT_INTOBJ( *ptTup ) ) {
                 k = INT_INTOBJ( *ptTup );
                 if ( k <= lmp )
@@ -3742,44 +3755,14 @@ Obj             OnSetsPerm (
 
     }
 
-    /* special case if the result only holds integers                      */
-    if ( isint ) {
-
-        /* sort the set with a shellsort                                   */
-        len = LEN_LIST(res);
-        h = 1;  while ( 9*h + 4 < len )  h = 3*h + 1;
-        while ( 0 < h ) {
-            for ( i = h+1; i <= len; i++ ) {
-                tmp = CONST_ADDR_OBJ(res)[i];  k = i;
-                while ( h < k && ((Int)tmp < (Int)(CONST_ADDR_OBJ(res)[k-h])) ) {
-                    ADDR_OBJ(res)[k] = CONST_ADDR_OBJ(res)[k-h];
-                    k -= h;
-                }
-                ADDR_OBJ(res)[k] = tmp;
-            }
-            h = h / 3;
-        }
-        RetypeBag( res, IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT : T_PLIST_CYC_SSORT + IMMUTABLE );
+    // sort the result
+    if (isint) {
+        SortPlistByRawObj(res);
+        RetypeBag(res, IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
+                                             : T_PLIST_CYC_SSORT + IMMUTABLE);
     }
-
-    /* general case                                                        */
     else {
-
-        /* sort the set with a shellsort                                   */
-        len = LEN_LIST(res);
-        h = 1;  while ( 9*h + 4 < len )  h = 3*h + 1;
-        while ( 0 < h ) {
-            for ( i = h+1; i <= len; i++ ) {
-                tmp = CONST_ADDR_OBJ(res)[i];  k = i;
-                while ( h < k && LT( tmp, CONST_ADDR_OBJ(res)[k-h] ) ) {
-                    ADDR_OBJ(res)[k] = CONST_ADDR_OBJ(res)[k-h];
-                    k -= h;
-                }
-                ADDR_OBJ(res)[k] = tmp;
-            }
-            h = h / 3;
-        }
-
+        SortDensePlist(res);
     }
 
     /* return the result                                                   */

--- a/src/trans.c
+++ b/src/trans.c
@@ -3832,18 +3832,21 @@ Obj FuncOnPosIntSetsTrans(Obj self, Obj set, Obj f, Obj n)
     }
 
     PLAIN_LIST(set);
+
+    const UInt len = LEN_PLIST(set);
+
     res = NEW_PLIST(IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
                                           : T_PLIST_CYC_SSORT + IMMUTABLE,
-                    LEN_LIST(set));
-    ADDR_OBJ(res)[0] = CONST_ADDR_OBJ(set)[0];
+                    len);
+    SET_LEN_PLIST(res, len);
 
-    ptset = CONST_ADDR_OBJ(set) + LEN_LIST(set);
-    ptres = ADDR_OBJ(res) + LEN_LIST(set);
+    ptset = CONST_ADDR_OBJ(set) + len;
+    ptres = ADDR_OBJ(res) + len;
 
     if (TNUM_OBJ(f) == T_TRANS2) {
         ptf2 = CONST_ADDR_TRANS2(f);
         deg = DEG_TRANS2(f);
-        for (i = LEN_LIST(set); 1 <= i; i--, ptset--, ptres--) {
+        for (i = len; 1 <= i; i--, ptset--, ptres--) {
             k = INT_INTOBJ(*ptset);
             if (k <= deg) {
                 k = ptf2[k - 1] + 1;
@@ -3857,7 +3860,7 @@ Obj FuncOnPosIntSetsTrans(Obj self, Obj set, Obj f, Obj n)
     else if (TNUM_OBJ(f) == T_TRANS4) {
         ptf4 = CONST_ADDR_TRANS4(f);
         deg = DEG_TRANS4(f);
-        for (i = LEN_LIST(set); 1 <= i; i--, ptset--, ptres--) {
+        for (i = len; 1 <= i; i--, ptset--, ptres--) {
             k = INT_INTOBJ(*ptset);
             if (k <= deg) {
                 k = ptf4[k - 1] + 1;
@@ -5216,12 +5219,16 @@ Obj PowIntTrans4(Obj i, Obj f)
     return INTOBJ_INT(img);
 }
 
-/*******************************************************************************
-** Apply a transformation to a set or tuple
-*******************************************************************************/
-
-// OnSetsTrans for use in FuncOnSets.
-
+/****************************************************************************
+**
+*F  OnSetsTrans( <set>, <f> ) . . . . . . . . .  operations on sets of points
+**
+**  'OnSetsTrans' returns the  image of the tuple <set> under the
+**  transformation <f>.  It is called from 'FuncOnSets'.
+**
+**  The input <set> must be a non-empty set, i.e., plain, dense and strictly
+**  sorted. This is is not verified.
+*/
 Obj OnSetsTrans(Obj set, Obj f)
 {
     const UInt2 * ptf2;
@@ -5231,19 +5238,23 @@ Obj OnSetsTrans(Obj set, Obj f)
     Obj *   ptres, tmp, res;
     UInt    i, isint, k;
 
+    GAP_ASSERT(IS_PLIST(set));
+    GAP_ASSERT(LEN_PLIST(set) > 0);
+
+    const UInt len = LEN_PLIST(set);
+
     res = NEW_PLIST(IS_MUTABLE_PLIST(set) ? T_PLIST : T_PLIST + IMMUTABLE,
-                    LEN_LIST(set));
+                    len);
+    SET_LEN_PLIST(res, len);
 
-    ADDR_OBJ(res)[0] = CONST_ADDR_OBJ(set)[0];
-
-    ptset = CONST_ADDR_OBJ(set) + LEN_LIST(set);
-    ptres = ADDR_OBJ(res) + LEN_LIST(set);
+    ptset = CONST_ADDR_OBJ(set) + len;
+    ptres = ADDR_OBJ(res) + len;
     if (TNUM_OBJ(f) == T_TRANS2) {
         ptf2 = CONST_ADDR_TRANS2(f);
         deg = DEG_TRANS2(f);
         // loop over the entries of the tuple
         isint = 1;
-        for (i = LEN_LIST(set); 1 <= i; i--, ptset--, ptres--) {
+        for (i = len; 1 <= i; i--, ptset--, ptres--) {
             if (IS_INTOBJ(*ptset) && 0 < INT_INTOBJ(*ptset)) {
                 k = INT_INTOBJ(*ptset);
                 if (k <= deg) {
@@ -5268,7 +5279,7 @@ Obj OnSetsTrans(Obj set, Obj f)
 
         // loop over the entries of the tuple
         isint = 1;
-        for (i = LEN_LIST(set); 1 <= i; i--, ptset--, ptres--) {
+        for (i = len; 1 <= i; i--, ptset--, ptres--) {
             if (IS_INTOBJ(*ptset) && 0 < INT_INTOBJ(*ptset)) {
                 k = INT_INTOBJ(*ptset);
                 if (k <= deg) {
@@ -5304,8 +5315,16 @@ Obj OnSetsTrans(Obj set, Obj f)
     return res;
 }
 
-// OnTuplesTrans for use in FuncOnTuples
-
+/****************************************************************************
+**
+*F  OnTuplesTrans( <tup>, <f> ) . . . . . . .  operations on tuples of points
+**
+**  'OnTuplesTrans'  returns  the  image  of  the  tuple  <tup>   under  the
+**  transformation <f>.  It is called from 'FuncOnTuples'.
+**
+**  The input <tup> must be a non-empty and dense plain list. This is is not
+**  verified.
+*/
 Obj OnTuplesTrans(Obj tup, Obj f)
 {
     const UInt2 * ptf2;
@@ -5314,20 +5333,24 @@ Obj OnTuplesTrans(Obj tup, Obj f)
     const Obj *   pttup;
     Obj *   ptres, res, tmp;
 
+    GAP_ASSERT(IS_PLIST(tup));
+    GAP_ASSERT(LEN_PLIST(tup) > 0);
+
+    const UInt len = LEN_PLIST(tup);
+
     res = NEW_PLIST(IS_MUTABLE_PLIST(tup) ? T_PLIST : T_PLIST + IMMUTABLE,
-                    LEN_LIST(tup));
+                    len);
+    SET_LEN_PLIST(res, len);
 
-    ADDR_OBJ(res)[0] = CONST_ADDR_OBJ(tup)[0];
-
-    pttup = CONST_ADDR_OBJ(tup) + LEN_LIST(tup);
-    ptres = ADDR_OBJ(res) + LEN_LIST(tup);
+    pttup = CONST_ADDR_OBJ(tup) + len;
+    ptres = ADDR_OBJ(res) + len;
 
     if (TNUM_OBJ(f) == T_TRANS2) {
         ptf2 = CONST_ADDR_TRANS2(f);
         deg = DEG_TRANS2(f);
 
         // loop over the entries of the tuple
-        for (i = LEN_LIST(tup); 1 <= i; i--, pttup--, ptres--) {
+        for (i = len; 1 <= i; i--, pttup--, ptres--) {
             if (IS_INTOBJ(*pttup) && 0 < INT_INTOBJ(*pttup)) {
                 k = INT_INTOBJ(*pttup);
                 if (k <= deg) {
@@ -5355,7 +5378,7 @@ Obj OnTuplesTrans(Obj tup, Obj f)
         deg = DEG_TRANS4(f);
 
         // loop over the entries of the tuple
-        for (i = LEN_LIST(tup); 1 <= i; i--, pttup--, ptres--) {
+        for (i = len; 1 <= i; i--, pttup--, ptres--) {
             if (IS_INTOBJ(*pttup) && 0 < INT_INTOBJ(*pttup)) {
                 k = INT_INTOBJ(*pttup);
                 if (k <= deg) {

--- a/src/trans.c
+++ b/src/trans.c
@@ -267,21 +267,23 @@ UInt RANK_TRANS4(Obj f)
 // Retyping is the responsibility of the caller, this should only be called
 // after a call to SortPlistByRawObj.
 
-static void REMOVE_DUPS_PLIST_CYC(Obj res)
+static void REMOVE_DUPS_PLIST_INTOBJ(Obj res)
 {
     Obj  tmp;
     UInt i, k, len;
+    Obj  *data;
 
     len = LEN_PLIST(res);
 
     if (0 < len) {
-        tmp = CONST_ADDR_OBJ(res)[1];
+        data = ADDR_OBJ(res);
+        tmp = data[1];
         k = 1;
         for (i = 2; i <= len; i++) {
-            if (tmp != CONST_ADDR_OBJ(res)[i]) {
+            if (tmp != data[i]) {
                 k++;
-                tmp = CONST_ADDR_OBJ(res)[i];
-                ADDR_OBJ(res)[k] = tmp;
+                tmp = data[i];
+                data[k] = tmp;
             }
         }
         if (k < len) {
@@ -3854,7 +3856,7 @@ Obj FuncOnPosIntSetsTrans(Obj self, Obj set, Obj f, Obj n)
             *ptres = INTOBJ_INT(k);
         }
         SortPlistByRawObj(res);
-        REMOVE_DUPS_PLIST_CYC(res);
+        REMOVE_DUPS_PLIST_INTOBJ(res);
         return res;
     }
     else if (TNUM_OBJ(f) == T_TRANS4) {
@@ -3868,7 +3870,7 @@ Obj FuncOnPosIntSetsTrans(Obj self, Obj set, Obj f, Obj n)
             *ptres = INTOBJ_INT(k);
         }
         SortPlistByRawObj(res);
-        REMOVE_DUPS_PLIST_CYC(res);
+        REMOVE_DUPS_PLIST_INTOBJ(res);
         return res;
     }
     ErrorQuit("OnPosIntSetsTrans: the argument must be a "
@@ -5302,7 +5304,7 @@ Obj OnSetsTrans(Obj set, Obj f)
     // sort the result and remove dups
     if (isint) {
         SortPlistByRawObj(res);
-        REMOVE_DUPS_PLIST_CYC(res);
+        REMOVE_DUPS_PLIST_INTOBJ(res);
 
         RetypeBag(res, IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
                                              : T_PLIST_CYC_SSORT + IMMUTABLE);


### PR DESCRIPTION
The code for these functions used LEN_LIST but elsewhere was written in such
a way that it was only corrected it the input list were non-empty plain (and
possibly having other properties). Luckily, the only callers for the six
involved functions already enforced that.

Documented this requirement, and then changed the code to explicitly use
plist accessor functions. Also use SortPlistByRawObj resp. SortDensePlist
where it (now) makes sense.