### PR TITLE
Warning about missing TestFile in ValidatePackageInfo

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -2270,6 +2270,14 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
     TestOption( record, "BannerString", IsString, "a string" );
     TestOption( record, "TestFile", IsFilename,
                 "a string denoting a relative path to a readable file" );
+    if not IsBound( record.TestFile ) then
+      Print(
+        "#W  ************************************************************\n",
+        "#W  No 'TestFile' is given but is highly recommended. Package\n",
+        "#W  tests are run for deposited packages as part of the standard\n",
+        "#W  GAP test suite. See '?TestPackage' for more information.\n",
+        "#W  ************************************************************\n" );
+    fi;
     TestOption( record, "PreloadFile", IsFilename,
                 "a string denoting a relative path to a readable file" );
     TestOption( record, "Keywords", IsStringList, "a list of strings" );

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -141,6 +141,11 @@ ps:// or ftp://
  https:// or ftp://
 #E  component `PackageDoc' must be bound to a record or a list of records
 #E  component `AvailabilityTest' must be bound to a function
+#W  ************************************************************
+#W  No 'TestFile' is given but is highly recommended. Package
+#W  tests are run for deposited packages as part of the standard
+#W  GAP test suite. See '?TestPackage' for more information.
+#W  ************************************************************
 false
 gap> info := rec(
 >     PackageName := "pkg",
@@ -168,6 +173,11 @@ a readable file
 #E  component `SixFile' must be bound to a string denoting a relative path to \
 a readable file
 #E  component `LongTitle' must be bound to a string
+#W  ************************************************************
+#W  No 'TestFile' is given but is highly recommended. Package
+#W  tests are run for deposited packages as part of the standard
+#W  GAP test suite. See '?TestPackage' for more information.
+#W  ************************************************************
 false
 gap> info.PackageDoc := rec(
 >     BookName := "",
@@ -177,6 +187,7 @@ gap> info.PackageDoc := rec(
 >     SixFile := Filename(DirectoriesLibrary(), "init.g"),
 >     LongTitle := "",
 >   );;
+> info.TestFile:="tst/testall.g";;
 gap> ValidatePackageInfo(info);
 true
 


### PR DESCRIPTION
This PR will add a warning like this:
```
gap>  ValidatePackageInfo("pkg/Convex/PackageInfo.g");
#W  ******************************************************
#W  There is no 'TestFile' component. It is recommended to
#W  specify a short test (to run for no more than several minutes)
#W  which may be used to check that a package works as expected.
#W  For deposited packages, these tests are run regularly
#W  as a part of the standard GAP test suite.
#W  See '?TestPackage', '?Tests files for a GAP package'
#W  and also '?TestDirectory' for more information
#W  ******************************************************
true
```
