### PR TITLE
kernel: add NEW_PLIST_IMM and NEW_PLIST_MUT helpers

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -1528,7 +1528,7 @@ Obj FuncLIST_BLIST (
     n = SizeBlist(blist);
 
     /* make the sublist (we now know its size exactly)                    */
-    sub = NEW_PLIST( IS_MUTABLE_OBJ(list) ? T_PLIST : T_PLIST+IMMUTABLE, n );
+    sub = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(list), T_PLIST, n );
     SET_LEN_PLIST( sub, n );
 
     /* loop over the boolean list and stuff elements into <sub>            */

--- a/src/calls.c
+++ b/src/calls.c
@@ -1548,7 +1548,7 @@ Obj FuncCALL_FUNC_LIST_WRAP (
 
     if (retval == 0)
     {
-        retlist = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        retlist = NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
     }
     else
     {

--- a/src/code.c
+++ b/src/code.c
@@ -3375,7 +3375,7 @@ static Int InitLibrary (
 #ifdef HPCGAP
     cache = NewAtomicList(T_ALIST, 1);
 #else
-    cache = NEW_PLIST(T_PLIST+IMMUTABLE, 1000L);
+    cache = NEW_PLIST_IMM(T_PLIST, 1000L);
     SET_LEN_PLIST(cache,0);
 #endif
     EAGER_FLOAT_LITERAL_CACHE = cache;

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -1781,7 +1781,7 @@ Obj INT_FF (
     if ( LEN_PLIST(IntFF) < ff || ELM_PLIST(IntFF,ff) == 0 ) {
         q = SIZE_FF( ff );
         p = CHAR_FF( ff );
-        conv = NEW_PLIST( T_PLIST+IMMUTABLE, p-1 );
+        conv = NEW_PLIST_IMM( T_PLIST, p-1 );
         succ = SUCC_FF( ff );
         SET_LEN_PLIST( conv, p-1 );
         z = 1;

--- a/src/gap.c
+++ b/src/gap.c
@@ -1061,7 +1061,7 @@ Obj FuncCALL_WITH_CATCH( Obj self, Obj func, volatile Obj args )
     currStat = STATE(CurrStat);
     recursionDepth = GetRecursionDepth();
     tilde = STATE(Tilde);
-    res = NEW_PLIST(T_PLIST_DENSE+IMMUTABLE,2);
+    res = NEW_PLIST_IMM(T_PLIST_DENSE,2);
 #ifdef HPCGAP
     int lockSP = RegionLockSP();
     Region *savedRegion = TLS(currentRegion);
@@ -1193,7 +1193,7 @@ Obj CallErrorInner (
   AssPRec(r, RNamName("mayReturnVoid"), mayReturnVoid? True : False);
   AssPRec(r, RNamName("printThisStatement"), printThisStatement? True : False);
   AssPRec(r, RNamName("lateMessage"), lateMessage);
-  l = NEW_PLIST(T_PLIST_HOM+IMMUTABLE, 1);
+  l = NEW_PLIST_IMM(T_PLIST_HOM, 1);
   SET_ELM_PLIST(l,1,EarlyMsg);
   SET_LEN_PLIST(l,1);
   SET_BRK_CALL_TO(STATE(CurrStat));
@@ -1846,11 +1846,11 @@ Obj FuncGASMAN_STATS(Obj self)
   Obj row;
   UInt i,j;
   Int x;
-  res = NEW_PLIST(T_PLIST_TAB_RECT + IMMUTABLE, 2);
+  res = NEW_PLIST_IMM(T_PLIST_TAB_RECT, 2);
   SET_LEN_PLIST(res, 2);
   for (i = 1; i <= 2; i++)
     {
-      row = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, 9);
+      row = NEW_PLIST_IMM(T_PLIST_CYC, 9);
       SET_ELM_PLIST(res, i, row);
       CHANGED_BAG(res);
       SET_LEN_PLIST(row, 9);
@@ -1872,7 +1872,7 @@ Obj FuncGASMAN_MESSAGE_STATUS( Obj self )
 Obj FuncGASMAN_LIMITS( Obj self )
 {
   Obj list;
-  list = NEW_PLIST(T_PLIST_CYC+IMMUTABLE, 3);
+  list = NEW_PLIST_IMM(T_PLIST_CYC, 3);
   SET_LEN_PLIST(list,3);
   SET_ELM_PLIST(list, 1, INTOBJ_INT(SyStorMin));
   SET_ELM_PLIST(list, 2, INTOBJ_INT(SyStorMax));
@@ -2596,7 +2596,7 @@ Obj FuncKERNEL_INFO(Obj self) {
   /* GAP_ROOT_PATH                                                       */
   /* do we need this. Could we rebuild it from the command line in GAP
      if so, should we                                                    */
-  list = NEW_PLIST( T_PLIST+IMMUTABLE, MAX_GAP_DIRS );
+  list = NEW_PLIST_IMM( T_PLIST, MAX_GAP_DIRS );
   for ( i = 0, j = 1;  i < MAX_GAP_DIRS;  i++ ) {
     if ( SyGapRootPaths[i][0] ) {
       tmp = MakeImmString( SyGapRootPaths[i] );
@@ -2616,7 +2616,7 @@ Obj FuncKERNEL_INFO(Obj self) {
     
   /* make command line and environment available to GAP level       */
   for (lenvec=0; SyOriginalArgv[lenvec]; lenvec++);
-  tmp = NEW_PLIST( T_PLIST+IMMUTABLE, lenvec );
+  tmp = NEW_PLIST_IMM( T_PLIST, lenvec );
   SET_LEN_PLIST( tmp, lenvec );
   for (i = 0; i<lenvec; i++) {
     str = MakeImmString( SyOriginalArgv[i] );

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1050,7 +1050,7 @@ Obj FuncIDENTS_GVAR (
     numGVars = INT_INTOBJ(CountGVars);
 #endif
 
-    copy = NEW_PLIST( T_PLIST+IMMUTABLE, numGVars );
+    copy = NEW_PLIST_IMM( T_PLIST, numGVars );
     for ( i = 1;  i <= numGVars;  i++ ) {
         /* Copy the string here, because we do not want members of NameGVars
          * accessible to users, as these strings must not be changed */
@@ -1078,7 +1078,7 @@ Obj FuncIDENTS_BOUND_GVARS (
     numGVars = INT_INTOBJ(CountGVars);
 #endif
 
-    copy = NEW_PLIST( T_PLIST+IMMUTABLE, numGVars );
+    copy = NEW_PLIST_IMM( T_PLIST, numGVars );
     for ( i = 1, j = 1;  i <= numGVars;  i++ ) {
         if ( VAL_GVAR_INTERN( i ) || ELM_GVAR_LIST( ExprGVars, i ) ) {
            /* Copy the string here, because we do not want members of

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -821,7 +821,7 @@ Obj FuncHASH_SYNCHRONIZED_SHARED(Obj self, Obj target, Obj function)
 Obj FuncCREATOR_OF(Obj self, Obj obj)
 {
 #ifdef TRACK_CREATOR
-    Obj result = NEW_PLIST(T_PLIST + IMMUTABLE, 2);
+    Obj result = NEW_PLIST_IMM(T_PLIST, 2);
     SET_LEN_PLIST(result, 2);
     if (!IS_BAG_REF(obj)) {
         SET_ELM_PLIST(result, 1, Fail);

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -645,11 +645,11 @@ Obj FuncMAKE_BITFIELDS(Obj self, Obj widths)
     if (starts[nfields] > 8 * sizeof(UInt))
         ErrorMayQuit("MAKE_BITFIELDS: total widths too large", 0, 0);
 
-    Obj  setters = NEW_PLIST(T_PLIST_DENSE + IMMUTABLE, nfields);
-    Obj  getters = NEW_PLIST(T_PLIST_DENSE + IMMUTABLE, nfields);
-    Obj  bsetters = NEW_PLIST(T_PLIST + IMMUTABLE, nfields);
+    Obj  setters = NEW_PLIST_IMM(T_PLIST_DENSE, nfields);
+    Obj  getters = NEW_PLIST_IMM(T_PLIST_DENSE, nfields);
+    Obj  bsetters = NEW_PLIST_IMM(T_PLIST, nfields);
     UInt bslen = 0;
-    Obj  bgetters = NEW_PLIST(T_PLIST + IMMUTABLE, nfields);
+    Obj  bgetters = NEW_PLIST_IMM(T_PLIST, nfields);
     for (UInt i = 1; i <= nfields; i++) {
         UInt mask = (1L << starts[i]) - (1L << starts[i - 1]);
         Obj s = NewFunctionC("<field setter>", 2, "data, val", DoFieldSetter);

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1185,7 +1185,7 @@ Obj             FuncOnPairs (
     }
 
     /* create a new bag for the result                                     */
-    img = NEW_PLIST( IS_MUTABLE_OBJ(pair) ? T_PLIST : T_PLIST+IMMUTABLE, 2 );
+    img = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(pair), T_PLIST, 2 );
     SET_LEN_PLIST( img, 2 );
 
     /* and enter the images of the points into the result bag              */
@@ -1259,7 +1259,7 @@ Obj             FuncOnTuples (
     }
 
     /* create a new bag for the result                                     */
-    img = NEW_PLIST( IS_MUTABLE_OBJ(tuple) ? T_PLIST : T_PLIST+IMMUTABLE, LEN_LIST(tuple) );
+    img = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(tuple), T_PLIST, LEN_LIST(tuple) );
     SET_LEN_PLIST( img, LEN_LIST(tuple) );
 
     /* and enter the images of the points into the result bag              */

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -195,8 +195,8 @@ Obj             SumSclList (
 
     /* make the result list                                                */
     len = LEN_LIST( listR );
-    listS = NEW_PLIST( IS_MUTABLE_OBJ(listL) ||  IS_MUTABLE_OBJ(listR) ?
-                       T_PLIST : (T_PLIST + IMMUTABLE), len );
+    listS = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listL) ||  IS_MUTABLE_OBJ(listR),
+                           T_PLIST, len );
     SET_LEN_PLIST( listS, len );
 
     /* loop over the entries and add                                       */
@@ -226,8 +226,8 @@ Obj             SumListScl (
 
     /* make the result list                                                */
     len = LEN_LIST( listL );
-    listS = NEW_PLIST( IS_MUTABLE_OBJ(listR) || IS_MUTABLE_OBJ(listL) ?
-                       T_PLIST : T_PLIST+IMMUTABLE, len );
+    listS = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listR) || IS_MUTABLE_OBJ(listL),
+                           T_PLIST, len );
     SET_LEN_PLIST( listS, len );
 
     /* loop over the entries and add                                       */
@@ -261,8 +261,8 @@ Obj             SumListList (
     lenL = LEN_LIST( listL );
     lenR = LEN_LIST( listR );
     lenS = (lenR > lenL) ? lenR : lenL;
-    listS = NEW_PLIST( (IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR)) ?
-                       T_PLIST : T_PLIST+IMMUTABLE, lenS );
+    listS = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR),
+                           T_PLIST, lenS );
     SET_LEN_PLIST( listS, lenS );
 
     /* Sort out mutability */
@@ -348,7 +348,7 @@ Obj             ZeroListDefault (
 
     /* make the result list -- same mutability as argument */
     len = LEN_LIST( list );
-    res = NEW_PLIST( IS_MUTABLE_OBJ(list) ? T_PLIST : T_PLIST+IMMUTABLE, len );
+    res = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(list), T_PLIST, len );
     SET_LEN_PLIST( res, len );
 
     /* enter zeroes everywhere                                             */
@@ -574,7 +574,7 @@ Obj AInvListDefault (
 
     /* make the result list -- same mutability as input */
     len = LEN_LIST( list );
-    res = NEW_PLIST( IS_MUTABLE_OBJ(list) ? T_PLIST : T_PLIST+IMMUTABLE , len );
+    res = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(list), T_PLIST, len );
     SET_LEN_PLIST( res, len );
 
     /* enter the additive inverses everywhere                              */
@@ -665,8 +665,8 @@ Obj             DiffSclList (
 
     /* make the result list                                                */
     len = LEN_LIST( listR );
-    listD = NEW_PLIST(IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR) ? T_PLIST :
-                      T_PLIST+IMMUTABLE, len );
+    listD = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR),
+                           T_PLIST, len );
     SET_LEN_PLIST( listD, len );
 
     /* loop over the entries and subtract                                  */
@@ -707,8 +707,8 @@ Obj             DiffListScl (
 
     /* make the result list                                                */
     len = LEN_LIST( listL );
-    listD = NEW_PLIST( IS_MUTABLE_OBJ(listL)|| IS_MUTABLE_OBJ(listR) ? T_PLIST :
-                       T_PLIST+IMMUTABLE, len );
+    listD = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listL)|| IS_MUTABLE_OBJ(listR),
+                           T_PLIST, len );
     SET_LEN_PLIST( listD, len );
 
     /* loop over the entries and subtract                                  */
@@ -754,8 +754,8 @@ Obj             DiffListList (
     lenL = LEN_LIST( listL );
     lenR = LEN_LIST( listR );
     lenD = (lenR > lenL) ? lenR : lenL;
-    listD = NEW_PLIST( (IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR)) ?
-                       T_PLIST : T_PLIST+IMMUTABLE, lenD );
+    listD = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR),
+                           T_PLIST, lenD );
     SET_LEN_PLIST( listD, lenD );
 
     /* Sort out mutability */
@@ -886,8 +886,8 @@ Obj             ProdSclList (
 
     /* make the result list                                                */
     len = LEN_LIST( listR );
-    listP = NEW_PLIST( IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR) ?
-                       T_PLIST :T_PLIST+IMMUTABLE, len );
+    listP = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR),
+                           T_PLIST, len );
     SET_LEN_PLIST( listP, len );
 
     /* loop over the entries and multiply                                  */
@@ -926,8 +926,8 @@ Obj             ProdListScl (
 
     /* make the result list                                                */
     len = LEN_LIST( listL );
-    listP = NEW_PLIST( (IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR))
-                       ? T_PLIST :T_PLIST+IMMUTABLE, len );
+    listP = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR),
+                           T_PLIST, len );
     SET_LEN_PLIST( listP, len );
 
     /* loop over the entries and multiply                                  */

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -480,10 +480,10 @@ Obj FuncZERO_ATTR_MAT( Obj self, Obj mat )
   Obj res;
   len = LEN_LIST(mat);
   if (len == 0)
-    return NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+    return NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
   zrow = ZERO(ELM_LIST(mat,1));
   CheckedMakeImmutable(zrow);
-  res = NEW_PLIST(T_PLIST_TAB_RECT+IMMUTABLE, len);
+  res = NEW_PLIST_IMM(T_PLIST_TAB_RECT, len);
   SET_LEN_PLIST(res,len);
   for (i = 1; i <= len; i++)
     SET_ELM_PLIST(res,i,zrow);

--- a/src/objscoll-impl.h
+++ b/src/objscoll-impl.h
@@ -58,14 +58,9 @@ Int VectorWord ( Obj vv, Obj v, Int num )
 
     /* <vv> must be a string                                               */
     if ( TNUM_OBJ(vv) != T_STRING ) {
-        if ( TNUM_OBJ(vv) == IMMUTABLE_TNUM(T_STRING) ) {
-            RetypeBag( vv, T_STRING );
-        }
-        else {
-            ErrorQuit( "collect vector must be a string not a %s", 
-                       (Int)TNAM_OBJ(vv), 0L );
-            return -1;
-        }
+        ErrorQuit( "collect vector must be a mutable string not a %s",
+                   (Int)TNAM_OBJ(vv), 0L );
+        return -1;
     }
 
     /* fix the length                                                      */
@@ -500,14 +495,9 @@ Int Solution(
 
     /* <ww> must be a string                                               */
     if ( TNUM_OBJ(ww) != T_STRING ) {
-        if ( TNUM_OBJ(ww) == IMMUTABLE_TNUM(T_STRING) ) {
-            RetypeBag( ww, T_STRING );
-        }
-        else {
-            ErrorQuit( "collect vector must be a string not a %s", 
-                       (Int)TNAM_OBJ(ww), 0L );
-            return -1;
-        }
+        ErrorQuit( "collect vector must be a mutable string not a %s",
+                   (Int)TNAM_OBJ(ww), 0L );
+        return -1;
     }
 
     /* fix the length                                                      */
@@ -521,14 +511,9 @@ Int Solution(
 
     /* <uu> must be a string                                               */
     if ( TNUM_OBJ(uu) != T_STRING ) {
-        if ( TNUM_OBJ(uu) == IMMUTABLE_TNUM(T_STRING) ) {
-            RetypeBag( uu, T_STRING );
-        }
-        else {
-            ErrorQuit( "collect vector must be a string not a %s", 
-                       (Int)TNAM_OBJ(uu), 0L );
-            return -1;
-        }
+        ErrorQuit( "collect vector must be a mutable string not a %s",
+                   (Int)TNAM_OBJ(uu), 0L );
+        return -1;
     }
 
     /* fix the length                                                      */

--- a/src/opers.c
+++ b/src/opers.c
@@ -299,7 +299,7 @@ Obj FuncTRUES_FLAGS (
     n = COUNT_TRUES_BLOCKS(ptr, nrb);    
 
     /* make the sublist (we now know its size exactly)                    */
-    sub = NEW_PLIST( T_PLIST+IMMUTABLE, n );
+    sub = NEW_PLIST_IMM( T_PLIST, n );
     SET_LEN_PLIST( sub, n );
 
     /* loop over the boolean list and stuff elements into <sub>            */
@@ -1776,8 +1776,7 @@ Obj CallHandleMethodNotFound( Obj oper,
       RNamPrecedence = RNamName("Precedence");
     }
   AssPRec(r,RNamOperation,oper);
-  arglist = NEW_PLIST(nargs ? T_PLIST_DENSE+IMMUTABLE:
-                      T_PLIST_EMPTY+IMMUTABLE, nargs);
+  arglist = NEW_PLIST_IMM(nargs ? T_PLIST_DENSE : T_PLIST_EMPTY, nargs);
   SET_LEN_PLIST(arglist,nargs);
   for (i = 0; i < nargs; i++)
     SET_ELM_PLIST( arglist, i+1, args[i]);
@@ -3775,7 +3774,7 @@ Obj FuncSETTER_FUNCTION (
 
     fname = WRAP_NAME(name, "SetterFunc");
     func = NewFunction( fname, 2, ArglistObjVal, DoSetterFunction );
-    tmp = NEW_PLIST( T_PLIST+IMMUTABLE, 2 );
+    tmp = NEW_PLIST_IMM( T_PLIST, 2 );
     SET_LEN_PLIST( tmp, 2 );
     SET_ELM_PLIST( tmp, 1, INTOBJ_INT( RNamObj(name) ) );
     SET_ELM_PLIST( tmp, 2, filter );
@@ -3832,7 +3831,7 @@ Obj FuncOPERS_CACHE_INFO (
     Obj                 list;
     Int                 i;
 
-    list = NEW_PLIST(IMMUTABLE_TNUM(T_PLIST), 15);
+    list = NEW_PLIST_IMM(T_PLIST, 15);
     SET_LEN_PLIST(list, 15);
 #ifdef COUNT_OPERS
     SET_ELM_PLIST(list, 1, INTOBJ_INT(AndFlagsCacheHit));
@@ -3852,15 +3851,15 @@ Obj FuncOPERS_CACHE_INFO (
     /* Now we need to convert the 3d matrix of cache hit counts (by
        precedence, location found and number of arguments) into a three
        dimensional GAP matrix (tensor) */
-    Obj tensor = NEW_PLIST(IMMUTABLE_TNUM(T_PLIST), CACHE_SIZE);
+    Obj tensor = NEW_PLIST_IMM(T_PLIST, CACHE_SIZE);
     SET_LEN_PLIST(tensor, CACHE_SIZE);
     for (i = 1; i <= CACHE_SIZE; i++) {
-        Obj mat = NEW_PLIST(IMMUTABLE_TNUM(T_PLIST), CACHE_SIZE);
+        Obj mat = NEW_PLIST_IMM(T_PLIST, CACHE_SIZE);
         SET_LEN_PLIST(mat, CACHE_SIZE);
         SET_ELM_PLIST(tensor, i, mat);
         CHANGED_BAG(tensor);
         for (Int j = 1; j <= CACHE_SIZE; j++) {
-            Obj vec = NEW_PLIST(IMMUTABLE_TNUM(T_PLIST), 7);
+            Obj vec = NEW_PLIST_IMM(T_PLIST, 7);
             SET_LEN_PLIST(vec, 7);
             SET_ELM_PLIST(mat, j, vec);
             CHANGED_BAG(mat);
@@ -3875,10 +3874,10 @@ Obj FuncOPERS_CACHE_INFO (
 
     /* and similarly the 2D matrix of cache miss information (by
        precedence and number of arguments) */
-    Obj mat = NEW_PLIST(IMMUTABLE_TNUM(T_PLIST), CACHE_SIZE + 1);
+    Obj mat = NEW_PLIST_IMM(T_PLIST, CACHE_SIZE + 1);
     SET_LEN_PLIST(mat, CACHE_SIZE + 1);
     for (Int j = 1; j <= CACHE_SIZE + 1; j++) {
-        Obj vec = NEW_PLIST(IMMUTABLE_TNUM(T_PLIST), 7);
+        Obj vec = NEW_PLIST_IMM(T_PLIST, 7);
         SET_LEN_PLIST(vec, 7);
         SET_ELM_PLIST(mat, j, vec);
         CHANGED_BAG(mat);
@@ -4169,12 +4168,12 @@ static Int InitKernel (
     /* share between uncompleted functions                                 */
     StringFilterSetter = MakeImmString("<<filter-setter>>");
 
-    ArglistObj = NEW_PLIST( T_PLIST+IMMUTABLE, 1 );
+    ArglistObj = NEW_PLIST_IMM( T_PLIST, 1 );
     SET_LEN_PLIST( ArglistObj, 1 );
     SET_ELM_PLIST( ArglistObj, 1, MakeImmString("obj") );
     CHANGED_BAG( ArglistObj );
 
-    ArglistObjVal = NEW_PLIST( T_PLIST+IMMUTABLE, 2 );
+    ArglistObjVal = NEW_PLIST_IMM( T_PLIST, 2 );
     SET_LEN_PLIST( ArglistObjVal, 2 );
     SET_ELM_PLIST( ArglistObjVal, 1, MakeImmString("obj") );
     CHANGED_BAG( ArglistObjVal );

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -3576,8 +3576,7 @@ Obj             OnTuplesPerm (
     const UInt len = LEN_PLIST(tup);
 
     /* make a bag for the result and initialize pointers                   */
-    res = NEW_PLIST( IS_MUTABLE_PLIST(tup) ? T_PLIST : T_PLIST + IMMUTABLE,
-		     len );
+    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(tup), T_PLIST, len);
     SET_LEN_PLIST(res, len);
 
     /* handle small permutations                                           */
@@ -3685,8 +3684,7 @@ Obj             OnSetsPerm (
     const UInt len = LEN_PLIST(set);
 
     /* make a bag for the result and initialize pointers                   */
-    res = NEW_PLIST( IS_MUTABLE_PLIST(set) ? T_PLIST : T_PLIST + IMMUTABLE,
-                     len );
+    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(set), T_PLIST, len);
     SET_LEN_PLIST(res, len);
 
     /* handle small permutations                                           */

--- a/src/plist.h
+++ b/src/plist.h
@@ -33,15 +33,21 @@
 **
 *F  NEW_PLIST(<type>,<plen>)  . . . . . . . . . . . allocate a new plain list
 **
-**  'NEW_PLIST'  allocates    a new plain   list  of  type <type> ('T_PLIST',
-**  'T_SET', 'T_VECTOR') that has room for at least <plen> elements.
+**  'NEW_PLIST'  allocates a new plain list of type <type> that has room for
+**  at least <plen> elements.
 **
 */
 static inline Obj NEW_PLIST(UInt type, Int plen)
 {
     GAP_ASSERT(plen >= 0);
     GAP_ASSERT(plen <= INT_INTOBJ_MAX);
+    GAP_ASSERT(FIRST_PLIST_TNUM <= type && type <= LAST_PLIST_TNUM);
     return NewBag(type, (plen + 1) * sizeof(Obj));
+}
+
+static inline Obj NEW_PLIST_IMM(UInt type, Int plen)
+{
+    return NEW_PLIST(type | IMMUTABLE, plen);
 }
 
 /****************************************************************************

--- a/src/plist.h
+++ b/src/plist.h
@@ -50,6 +50,13 @@ static inline Obj NEW_PLIST_IMM(UInt type, Int plen)
     return NEW_PLIST(type | IMMUTABLE, plen);
 }
 
+static inline Obj NEW_PLIST_WITH_MUTABILITY(Int mut, UInt type, Int plen)
+{
+    if (!mut)
+        type |= IMMUTABLE;
+    return NEW_PLIST(type, plen);
+}
+
 /****************************************************************************
 **
 *F  IS_PLIST( <list> )  . . . . . . . . . . . check if <list> is a plain list

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -6086,8 +6086,7 @@ Obj OnSetsPPerm(Obj set, Obj f)
 
     const UInt len = LEN_PLIST(set);
 
-    res = NEW_PLIST(IS_MUTABLE_PLIST(set) ? T_PLIST : T_PLIST + IMMUTABLE,
-                    len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(set), T_PLIST, len);
 
     /* get the pointer                                                 */
     ptset = CONST_ADDR_OBJ(set) + len;
@@ -6182,9 +6181,7 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
 
     const UInt len = LEN_PLIST(tup);
 
-    res = NEW_PLIST(IS_MUTABLE_PLIST(tup) ? T_PLIST_CYC
-                                          : T_PLIST_CYC + IMMUTABLE,
-                    len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(tup), T_PLIST_CYC, len);
 
     /* get the pointer                                                 */
     pttup = CONST_ADDR_OBJ(tup) + 1;
@@ -6250,9 +6247,7 @@ Obj FuncOnPosIntSetsPartialPerm(Obj self, Obj set, Obj f)
     }
 
     PLAIN_LIST(set);
-    res = NEW_PLIST(IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
-                                          : T_PLIST_CYC_SSORT + IMMUTABLE,
-                    LEN_LIST(set));
+    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(set), T_PLIST_CYC_SSORT, LEN_LIST(set));
 
     /* get the pointer                                                 */
     ptset = CONST_ADDR_OBJ(set) + LEN_LIST(set);

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -189,7 +189,7 @@ static UInt INIT_PPERM2(Obj f)
     deg = DEG_PPERM2(f);
 
     if (deg == 0) {
-        dom = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        dom = NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
         SET_LEN_PLIST(dom, 0);
         SET_DOM_PPERM(f, dom);
         SET_IMG_PPERM(f, dom);
@@ -197,8 +197,8 @@ static UInt INIT_PPERM2(Obj f)
         return deg;
     }
 
-    dom = NEW_PLIST(T_PLIST_CYC_SSORT + IMMUTABLE, deg);
-    img = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, deg);
+    dom = NEW_PLIST_IMM(T_PLIST_CYC_SSORT, deg);
+    img = NEW_PLIST_IMM(T_PLIST_CYC, deg);
 
     /* renew the ptr in case of garbage collection */
     ptf = ADDR_PPERM2(f);
@@ -237,7 +237,7 @@ static UInt INIT_PPERM4(Obj f)
     deg = DEG_PPERM4(f);
 
     if (deg == 0) {
-        dom = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        dom = NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
         SET_LEN_PLIST(dom, 0);
         SET_DOM_PPERM(f, dom);
         SET_IMG_PPERM(f, dom);
@@ -245,8 +245,8 @@ static UInt INIT_PPERM4(Obj f)
         return deg;
     }
 
-    dom = NEW_PLIST(T_PLIST_CYC_SSORT + IMMUTABLE, deg);
-    img = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, deg);
+    dom = NEW_PLIST_IMM(T_PLIST_CYC_SSORT, deg);
+    img = NEW_PLIST_IMM(T_PLIST_CYC, deg);
 
     ptf = ADDR_PPERM4(f);
 
@@ -522,11 +522,11 @@ Obj FuncIMAGE_PPERM(Obj self, Obj f)
         }
         rank = RANK_PPERM2(f);
         if (rank == 0) {
-            out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+            out = NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
             SET_LEN_PLIST(out, 0);
             return out;
         }
-        out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, rank);
+        out = NEW_PLIST_IMM(T_PLIST_CYC, rank);
         SET_LEN_PLIST(out, rank);
         ptf2 = ADDR_PPERM2(f);
         dom = DOM_PPERM(f);
@@ -545,11 +545,11 @@ Obj FuncIMAGE_PPERM(Obj self, Obj f)
         }
         rank = RANK_PPERM4(f);
         if (rank == 0) {
-            out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+            out = NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
             SET_LEN_PLIST(out, 0);
             return out;
         }
-        out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, rank);
+        out = NEW_PLIST_IMM(T_PLIST_CYC, rank);
         SET_LEN_PLIST(out, rank);
         ptf4 = ADDR_PPERM4(f);
         dom = DOM_PPERM(f);

--- a/src/records.c
+++ b/src/records.c
@@ -586,7 +586,7 @@ Obj FuncALL_RNAMES (
     Obj                 name;
     const UInt          countRNam = LEN_PLIST(NamesRNam);
 
-    copy = NEW_PLIST( T_PLIST+IMMUTABLE, countRNam );
+    copy = NEW_PLIST_IMM( T_PLIST, countRNam );
     for ( i = 1;  i <= countRNam;  i++ ) {
         name = NAME_OBJ_RNAM( i );
         s = CopyToStringRep(name);

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -1262,7 +1262,7 @@ void PlainString (
 
     /* find the length and allocate a temporary copy                       */
     lenList = GET_LEN_STRING( list );
-    tmp = NEW_PLIST( IS_MUTABLE_OBJ(list) ? T_PLIST : T_PLIST+IMMUTABLE, lenList );
+    tmp = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(list), T_PLIST, lenList);
     SET_LEN_PLIST( tmp, lenList );
 
     /* copy the characters                                                 */

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -560,9 +560,8 @@ Obj TypeString (
 **
 **  If <list> has not  yet  been copied, it makes   a copy, leaves  a forward
 **  pointer to the copy in  the first entry of  the string, where the size of
-**  the string usually resides,  and copies  all the  entries.  If  the plain
-**  list  has already  been copied, it   returns the value of the  forwarding
-**  pointer.
+**  the string usually resides,  and copies  all the  entries.  If the string
+**  has already been copied, it returns the value of the forwarding pointer.
 **
 **  'CopyString' is the function in 'CopyObjFuncs' for strings.
 **
@@ -1275,13 +1274,6 @@ void PlainString (
     ResizeBag( list, SIZE_OBJ(tmp) );
     RetypeBag( list, TNUM_OBJ(tmp) );
 
-    /*    Why not just copying the data area ? (FL)
-	  SET_LEN_PLIST( list, lenList );
-	  for ( i = 1; i <= lenList; i++ ) {
-	  SET_ELM_PLIST( list, i, ELM_PLIST( tmp, i ) );
-	  CHANGED_BAG( list );
-	  }
-    */
     memcpy(ADDR_OBJ(list), CONST_ADDR_OBJ(tmp), SIZE_OBJ(tmp));
     CHANGED_BAG(list);
 }

--- a/src/trans.c
+++ b/src/trans.c
@@ -165,7 +165,7 @@ UInt INIT_TRANS2(Obj f)
 
     if (deg == 0) {
         // special case for degree 0
-        img = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        img = NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
         SET_LEN_PLIST(img, 0);
         SET_IMG_TRANS(f, img);
         SET_KER_TRANS(f, img);
@@ -173,8 +173,8 @@ UInt INIT_TRANS2(Obj f)
         return 0;
     }
 
-    img = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, deg);
-    ker = NEW_PLIST(T_PLIST_CYC_NSORT + IMMUTABLE, deg);
+    img = NEW_PLIST_IMM(T_PLIST_CYC, deg);
+    ker = NEW_PLIST_IMM(T_PLIST_CYC_NSORT, deg);
     SET_LEN_PLIST(ker, (Int)deg);
 
     pttmp = ResizeInitTmpTrans(deg);
@@ -218,7 +218,7 @@ UInt INIT_TRANS4(Obj f)
         // T_TRANS4 and that does not have (internal) degree 65537 or greater
         // is ID_TRANS4.
 
-        img = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        img = NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
         SET_LEN_PLIST(img, 0);
         SET_IMG_TRANS(f, img);
         SET_KER_TRANS(f, img);
@@ -226,8 +226,8 @@ UInt INIT_TRANS4(Obj f)
         return 0;
     }
 
-    img = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, deg);
-    ker = NEW_PLIST(T_PLIST_CYC_NSORT + IMMUTABLE, deg);
+    img = NEW_PLIST_IMM(T_PLIST_CYC, deg);
+    ker = NEW_PLIST_IMM(T_PLIST_CYC_NSORT, deg);
     SET_LEN_PLIST(ker, (Int)deg);
 
     pttmp = ResizeInitTmpTrans(deg);
@@ -1179,13 +1179,13 @@ Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n)
         return FuncIMAGE_SET_TRANS(self, f);
     }
     else if (m == 0) {
-        new = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        new = NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
         SET_LEN_PLIST(new, 0);
         return new;
     }
     else if (m < deg) {
         pttmp = ResizeInitTmpTrans(deg);
-        new = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, m);
+        new = NEW_PLIST_IMM(T_PLIST_CYC, m);
         pttmp = ADDR_TRANS4(TmpTrans);
 
         if (TNUM_OBJ(f) == T_TRANS2) {
@@ -1260,12 +1260,12 @@ Obj FuncIMAGE_LIST_TRANS_INT(Obj self, Obj f, Obj n)
     m = INT_INTOBJ(n);
 
     if (m == 0) {
-        out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+        out = NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
         SET_LEN_PLIST(out, 0);
         return out;
     }
 
-    out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, m);
+    out = NEW_PLIST_IMM(T_PLIST_CYC, m);
 
     if (TNUM_OBJ(f) == T_TRANS2) {
         ptf2 = CONST_ADDR_TRANS2(f);
@@ -1711,11 +1711,11 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n)
         deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
         if (len >= deg) {
             if (len == 0) {
-                out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+                out = NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
                 SET_LEN_PLIST(out, 0);
                 return out;
             }
-            out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, len);
+            out = NEW_PLIST_IMM(T_PLIST_CYC, len);
             SET_LEN_PLIST(out, len);
             pttmp = ResizeInitTmpTrans(len);
             ptf2 = CONST_ADDR_TRANS2(f);
@@ -1747,11 +1747,11 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n)
         deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
         if (len >= deg) {
             if (len == 0) {
-                out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
+                out = NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
                 SET_LEN_PLIST(out, 0);
                 return out;
             }
-            out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, len);
+            out = NEW_PLIST_IMM(T_PLIST_CYC, len);
             SET_LEN_PLIST(out, len);
             pttmp = ResizeInitTmpTrans(len);
             ptf4 = CONST_ADDR_TRANS4(f);
@@ -3606,12 +3606,12 @@ Obj FuncPOW_KER_PERM(Obj self, Obj ker, Obj p)
     len = LEN_LIST(ker);
 
     if (len == 0) {
-        out = NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, len);
+        out = NEW_PLIST_IMM(T_PLIST_EMPTY, len);
         SET_LEN_PLIST(out, len);
         return out;
     }
 
-    out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, len);
+    out = NEW_PLIST_IMM(T_PLIST_CYC, len);
     SET_LEN_PLIST(out, len);
 
     ResizeTmpTrans(2 * len);

--- a/src/trans.c
+++ b/src/trans.c
@@ -3837,9 +3837,7 @@ Obj FuncOnPosIntSetsTrans(Obj self, Obj set, Obj f, Obj n)
 
     const UInt len = LEN_PLIST(set);
 
-    res = NEW_PLIST(IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
-                                          : T_PLIST_CYC_SSORT + IMMUTABLE,
-                    len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(set), T_PLIST_CYC_SSORT, len);
     SET_LEN_PLIST(res, len);
 
     ptset = CONST_ADDR_OBJ(set) + len;
@@ -5245,8 +5243,7 @@ Obj OnSetsTrans(Obj set, Obj f)
 
     const UInt len = LEN_PLIST(set);
 
-    res = NEW_PLIST(IS_MUTABLE_PLIST(set) ? T_PLIST : T_PLIST + IMMUTABLE,
-                    len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(set), T_PLIST, len);
     SET_LEN_PLIST(res, len);
 
     ptset = CONST_ADDR_OBJ(set) + len;
@@ -5340,8 +5337,7 @@ Obj OnTuplesTrans(Obj tup, Obj f)
 
     const UInt len = LEN_PLIST(tup);
 
-    res = NEW_PLIST(IS_MUTABLE_PLIST(tup) ? T_PLIST : T_PLIST + IMMUTABLE,
-                    len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(tup), T_PLIST, len);
     SET_LEN_PLIST(res, len);
 
     pttup = CONST_ADDR_OBJ(tup) + len;

--- a/src/vars.c
+++ b/src/vars.c
@@ -2464,7 +2464,7 @@ Obj FuncContentsLVars (Obj self, Obj lvars )
   Obj func = FUNC_LVARS(lvars);
   Obj nams = NAMS_FUNC(func);
   UInt len = (SIZE_BAG(lvars) - 2*sizeof(Obj) - sizeof(UInt))/sizeof(Obj);
-  Obj values = NEW_PLIST(T_PLIST+IMMUTABLE, len);
+  Obj values = NEW_PLIST_IMM(T_PLIST, len);
   if (lvars == STATE(BottomLVars))
     return False;
   AssPRec(contents, RNamName("func"), func);

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -4854,7 +4854,7 @@ Obj MakeShiftedVecs( Obj v, UInt len)
     SetTypeDatObj(vn, type);
 
     /* Now we start to build up the result */
-    shifts = NEW_PLIST(T_PLIST_TAB + IMMUTABLE, elts + 2);
+    shifts = NEW_PLIST_IMM(T_PLIST_TAB, elts + 2);
     SET_ELM_PLIST(shifts, elts + 1, INTOBJ_INT(len));
     SET_ELM_PLIST(shifts, elts + 2, xi);
     SET_LEN_PLIST(shifts, elts + 2);

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -62,8 +62,7 @@ Obj             SumFFEVecFFE (
 
     /* make the result list                                                */
     len = LEN_PLIST(vecR);
-    vecS = NEW_PLIST(IS_MUTABLE_OBJ(vecR) ?
-                T_PLIST_FFE : T_PLIST_FFE + IMMUTABLE, len);
+    vecS = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vecR), T_PLIST_FFE, len);
     SET_LEN_PLIST(vecS, len);
 
     /* to add we need the successor table                                  */
@@ -125,8 +124,7 @@ Obj             SumVecFFEFFE (
 
     /* make the result list                                                */
     len = LEN_PLIST(vecL);
-    vecS = NEW_PLIST(IS_MUTABLE_OBJ(vecL) ?
-                T_PLIST_FFE : T_PLIST_FFE + IMMUTABLE, len);
+    vecS = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vecL), T_PLIST_FFE, len);
     SET_LEN_PLIST(vecS, len);
 
     /* to add we need the successor table                                  */
@@ -199,8 +197,8 @@ Obj             SumVecFFEVecFFE (
     }
 
     /* make the result list                                                */
-    vecS = NEW_PLIST((IS_MUTABLE_OBJ(vecL) || IS_MUTABLE_OBJ(vecR)) ?
-                T_PLIST_FFE : T_PLIST_FFE + IMMUTABLE, len);
+    vecS = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vecL) || IS_MUTABLE_OBJ(vecR),
+                         T_PLIST_FFE, len);
     SET_LEN_PLIST(vecS, len);
 
     /* to add we need the successor table                                  */
@@ -269,8 +267,7 @@ Obj             DiffFFEVecFFE (
 
     /* make the result list                                                */
     len = LEN_PLIST(vecR);
-    vecD = NEW_PLIST(IS_MUTABLE_OBJ(vecR) ?
-                T_PLIST_FFE : T_PLIST_FFE + IMMUTABLE, len);
+    vecD = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vecR), T_PLIST_FFE, len);
     SET_LEN_PLIST(vecD, len);
 
     /* to subtract we need the successor table                             */
@@ -333,8 +330,7 @@ Obj             DiffVecFFEFFE (
 
     /* make the result list                                                */
     len = LEN_PLIST(vecL);
-    vecD = NEW_PLIST(IS_MUTABLE_OBJ(vecL) ?
-                T_PLIST_FFE : T_PLIST_FFE + IMMUTABLE, len);
+    vecD = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vecL), T_PLIST_FFE, len);
     SET_LEN_PLIST(vecD, len);
 
     /* to subtract we need the successor table                             */
@@ -409,8 +405,8 @@ Obj             DiffVecFFEVecFFE (
     }
 
     /* make the result list                                                */
-    vecD = NEW_PLIST((IS_MUTABLE_OBJ(vecL) || IS_MUTABLE_OBJ(vecR)) ?
-                T_PLIST_FFE : T_PLIST_FFE + IMMUTABLE, len);
+    vecD = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vecL) || IS_MUTABLE_OBJ(vecR),
+                         T_PLIST_FFE, len);
     SET_LEN_PLIST(vecD, len);
 
     /* to subtract we need the successor table                             */
@@ -484,8 +480,7 @@ Obj             ProdFFEVecFFE (
 
     /* make the result list                                                */
     len = LEN_PLIST(vecR);
-    vecP = NEW_PLIST(IS_MUTABLE_OBJ(vecR) ?
-                T_PLIST_FFE : T_PLIST_FFE + IMMUTABLE, len);
+    vecP = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vecR), T_PLIST_FFE, len);
     SET_LEN_PLIST(vecP, len);
 
     /* to multiply we need the successor table                             */
@@ -546,8 +541,7 @@ Obj             ProdVecFFEFFE (
 
     /* make the result list                                                */
     len = LEN_PLIST(vecL);
-    vecP = NEW_PLIST(IS_MUTABLE_OBJ(vecL) ?
-                    T_PLIST_FFE : T_PLIST_FFE + IMMUTABLE, len);
+    vecP = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vecL), T_PLIST_FFE, len);
     SET_LEN_PLIST(vecP, len);
 
     /* to multiply we need the successor table                             */

--- a/src/vector.c
+++ b/src/vector.c
@@ -215,8 +215,7 @@ Obj             DiffIntVector (
 
     /* make the result list                                                */
     len = LEN_PLIST(vecR);
-    vecD = NEW_PLIST(IS_MUTABLE_OBJ(vecR) ?
-                     T_PLIST_CYC : T_PLIST_CYC + IMMUTABLE, len);
+    vecD = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vecR), T_PLIST_CYC, len);
     SET_LEN_PLIST(vecD, len);
 
     /* loop over the elements and subtract                                 */
@@ -388,8 +387,7 @@ Obj             ProdIntVector (
 
     /* make the result list                                                */
     len = LEN_PLIST(vecR);
-    vecP = NEW_PLIST(IS_MUTABLE_OBJ(vecR) ?
-                     T_PLIST_CYC : T_PLIST_CYC + IMMUTABLE, len);
+    vecP = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vecR), T_PLIST_CYC, len);
     SET_LEN_PLIST(vecP, len);
 
     /* loop over the entries and multiply                                  */
@@ -437,8 +435,7 @@ Obj             ProdVectorInt (
 
     /* make the result list                                                */
     len = LEN_PLIST(vecL);
-    vecP = NEW_PLIST(IS_MUTABLE_OBJ(vecL) ?
-                     T_PLIST_CYC : T_PLIST_CYC + IMMUTABLE, len);
+    vecP = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vecL), T_PLIST_CYC, len);
     SET_LEN_PLIST(vecP, len);
 
     /* loop over the entries and multiply                                  */
@@ -563,9 +560,8 @@ Obj             ProdVectorMatrix (
 
     /* make the result list */
 
-    vecP = NEW_PLIST((IS_MUTABLE_OBJ(vecL) || IS_MUTABLE_OBJ(ELM_PLIST(matR, 1))) ?
-                     T_PLIST_CYC : T_PLIST_CYC + IMMUTABLE,
-    col);
+    vecP = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vecL) || IS_MUTABLE_OBJ(ELM_PLIST(matR, 1)),
+                         T_PLIST_CYC, col);
     SET_LEN_PLIST(vecP, col);
     for (i = 1; i <= col; i++)
         SET_ELM_PLIST(vecP, i, INTOBJ_INT(0));
@@ -656,7 +652,7 @@ Obj ZeroVector( Obj vec )
     assert(TNUM_OBJ(vec) >= T_PLIST_CYC && \
     TNUM_OBJ(vec) <= T_PLIST_CYC_SSORT + IMMUTABLE);
     len = LEN_PLIST(vec);
-    res = NEW_PLIST(IS_MUTABLE_OBJ(vec) ? T_PLIST_CYC : T_PLIST_CYC + IMMUTABLE, len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vec), T_PLIST_CYC, len);
     SET_LEN_PLIST(res, len);
     for (i = 1; i <= len; i++)
         SET_ELM_PLIST(res, i, INTOBJ_INT(0));


### PR DESCRIPTION
This PR adds two `NEW_PLIST` wrapper functions: `NEW_PLIST_IMM` has the same signature as `NEW_PLIST`, but ensures that the resulting plist is immutable, currently by adjusting the TNUM (i.e. OR-ing it with `IMMUTABLE`), in the future it might instead set or clear a suitable object flag.

The second helper, `NEW_PLIST_MUT`, takes an additional boolean (0 or 1) as its first argument `mut`, which indicates whether the resulting plist should be mutable (`mut=1`) or immutable (`mut=0`). This is used in code where a new plist is created whose mutability depends on some external factors, e.g. it should match that of another object.

(Oh yeah: This PR contains some code from PR #1571)

One obvious bad thing about this PR is that the naming of the two helpers is somewhat in conflict: Based on the names, one could rightfully expect the second helper `NEW_PLIST_MUT` to be just like the first, except that it always forces a mutable plist, but it isn't. I don't expect us to merge the PR with this conflict, though; but there are several ways to resolve them, and I though I'd solicit some feedback before wasting time on implementing one of them:

1. We could rename the second helper to e.g. `NEW_PLIST_WITH_MUTABILITY` -- but I'd kind of prefer to keep a short name.
2. We could get rid of the first helper, and replace  `NEW_PLIST_IMM(tnum, len)` invocations by `NEW_PLIST_MUT(0, tnum, len)`. Does this have drawbacks? (perhaps that one might not immediately be able to guess that the second code is creating an immutable plist; also, one could accidentally permute the arguments, a possible source of errors -- and one of the reasons why I really would have liked to introduce a `BOOL` type, see #1883, but it seems nobody either likes or cares about this approach).
3. Rename the first helper, to... ?
4. Others?

I am kind of tempted to just go with approach 2, it is trivial to implement with a quick `sed` invocation. The main reason I did not yet do it is that reverting it again *would* be work, so I'd rather first get feedback.