### PR TITLE
Add IsCentral methods where second argument is an element

### DIFF
--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -3280,6 +3280,28 @@ InstallMethod( IsCentral,
     IsCentralFromGenerators( GeneratorsOfAlgebraWithOne,
                              GeneratorsOfAlgebraWithOne ) );
 
+#############################################################################
+##
+#O  IsCentral( <A>, <x> )  . . . . . . . .  test if <x> is centralized by <A>
+##
+InstallMethod( IsCentral,
+    "for an FLMLOR and an element",
+    IsCollsElms,
+    [ IsFLMLOR, IsObject ],
+    IsCentralElementFromGenerators( GeneratorsOfLeftModule ) );
+
+InstallMethod( IsCentral,
+    "for an associative FLMLOR and an element",
+    IsCollsElms,
+    [ IsFLMLOR and IsAssociative, IsObject ],
+    IsCentralElementFromGenerators( GeneratorsOfAlgebra ) );
+
+InstallMethod( IsCentral,
+    "for an associative FLMLOs-with-one and an element",
+    IsCollsElms,
+    [ IsFLMLORWithOne and IsAssociative, IsObject ],
+    IsCentralElementFromGenerators( GeneratorsOfAlgebraWithOne ) );
+
 
 #############################################################################
 ##

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -3315,27 +3315,8 @@ InstallMethod( \=,
 InstallMethod( IsCentral,
     "generic method for two groups",
     IsIdenticalObj, [ IsGroup, IsGroup ],
-    function ( G, U )
-    local   Ggens,      # group generators of `G'
-            one,        # identity of `U'
-            g,          # one generator of <G>
-            u;          # one generator of <U>
-
-    # test if all generators of <U> are fixed by the generators of <G>
-    Ggens:= GeneratorsOfGroup( G );
-    one:= One( U );
-    for u  in GeneratorsOfGroup( U ) do
-        for g  in Ggens  do
-            if Comm( u, g ) <> one then
-                return false;
-            fi;
-        od;
-    od;
-
-    # all generators of <U> are fixed, return `true'
-    return true;
-    end );
-#T compare method in `mgmgen.g'!
+    IsCentralFromGenerators( GeneratorsOfGroup,
+                             GeneratorsOfGroup ) );
 
 #############################################################################
 ##

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -3320,6 +3320,15 @@ InstallMethod( IsCentral,
 
 #############################################################################
 ##
+#M  IsCentral( <G>, <g> ) . . . . . . . is an element centralized by a group?
+##
+InstallMethod( IsCentral,
+    "for a group and an element",
+    IsCollsElms, [ IsGroup, IsMultiplicativeElementWithInverse ],
+    IsCentralElementFromGenerators( GeneratorsOfGroup ) );
+
+#############################################################################
+##
 #M  IsSubset( <G>, <H> ) . . . . . . . . . . . . .  test for subset of groups
 ##
 InstallMethod( IsSubset,

--- a/lib/magma.gd
+++ b/lib/magma.gd
@@ -894,9 +894,9 @@ end );
 ##  <Func Name="IsCentralFromGenerators" Arg='GeneratorsStruct1, GeneratorsStruct2'/>
 ##
 ##  <Description>
-##  is a function that takes two domain arguments <A>D1</A>, <A>D2</A> and checks
-##  whether <C><A>GeneratorsStruct1</A>( <A>D1</A> )</C> and <C><A>GeneratorsStruct2</A>( <A>D2</A> )</C>
-##  commute.
+##  is a function which returns a function that takes two domain arguments <A>D1</A>,
+##  <A>D2</A> and checks whether <C><A>GeneratorsStruct1</A>( <A>D1</A> )</C>
+##  and <C><A>GeneratorsStruct2</A>( <A>D2</A> )</C> commute.
 ##  </Description>
 ##  </ManSection>
 ##
@@ -910,6 +910,34 @@ BindGlobal( "IsCentralFromGenerators",
           return false;
         fi;
       od;
+    od;
+    return true;
+    end;
+end );
+
+
+#############################################################################
+##
+#F  IsCentralElementFromGenerators( <GeneratorsStruct> )
+##
+##  <ManSection>
+##  <Func Name="IsCentralElementFromGenerators" Arg='GeneratorsStruct'/>
+##
+##  <Description>
+##  is a function which returns a function that takes a domain argument
+##  <A>D</A>  and an object <A>obj</A> and checks whether
+##  <C><A>GeneratorsStruct</A>( <A>D</A> )</C> and <A>obj</A> commute.
+##  </Description>
+##  </ManSection>
+##
+BindGlobal( "IsCentralElementFromGenerators",
+    function( GeneratorsStruct )
+    return function( D, obj )
+    local g;
+    for g in GeneratorsStruct( D ) do
+      if g * obj <> obj * g then
+        return false;
+      fi;
     od;
     return true;
     end;

--- a/lib/magma.gi
+++ b/lib/magma.gi
@@ -1100,9 +1100,10 @@ InstallMethod( Enumerator,
     [ IsMagma and IsAttributeStoringRep ], 0,
     EnumeratorOfMagma );
 
+
 #############################################################################
 ##
-#M  IsCentral( <M>, <N> ) . . . . . . . . . . . . . . . . . .  for two magmas
+#M  IsCentral( <M>, <N> )
 ##
 InstallMethod( IsCentral,
     "for two magmas",
@@ -1110,11 +1111,6 @@ InstallMethod( IsCentral,
     [ IsMagma, IsMagma ], 0,
     IsCentralFromGenerators( GeneratorsOfMagma, GeneratorsOfMagma ) );
 
-
-#############################################################################
-##
-#M  IsCentral( <M>, <N> ) . . . . . . . . . . . . . . for two magmas with one
-##
 InstallMethod( IsCentral,
     "for two magmas-with-one",
     IsIdenticalObj,
@@ -1122,17 +1118,34 @@ InstallMethod( IsCentral,
     IsCentralFromGenerators( GeneratorsOfMagmaWithOne,
                              GeneratorsOfMagmaWithOne ) );
 
-
-#############################################################################
-##
-#M  IsCentral( <M>, <N> ) . . . . . . . . . . .  for two magmas with inverses
-##
 InstallMethod( IsCentral,
     "for two magmas-with-inverses",
     IsIdenticalObj,
     [ IsMagmaWithInverses, IsMagmaWithInverses ], 0,
     IsCentralFromGenerators( GeneratorsOfMagmaWithInverses,
                              GeneratorsOfMagmaWithInverses ) );
+
+#############################################################################
+##
+#M  IsCentral( <M>, <elm> )
+##
+InstallMethod( IsCentral,
+    "for a magma and an element",
+    IsCollsElms,
+    [ IsMagma, IsObject ], 0,
+    IsCentralElementFromGenerators( GeneratorsOfMagma ) );
+
+InstallMethod( IsCentral,
+    "for a magma-with-one and an element",
+    IsCollsElms,
+    [ IsMagmaWithOne, IsObject ], 0,
+    IsCentralElementFromGenerators( GeneratorsOfMagmaWithOne ) );
+
+InstallMethod( IsCentral,
+    "for a magma-with-inverses and an element",
+    IsCollsElms,
+    [ IsMagmaWithInverses, IsObject ], 0,
+    IsCentralElementFromGenerators( GeneratorsOfMagmaWithInverses ) );
 
 
 #############################################################################

--- a/lib/ring.gi
+++ b/lib/ring.gi
@@ -189,16 +189,32 @@ InstallImmediateMethod( IsZeroMultiplicationRing,
 InstallMethod( IsCentral,
     "for two associative rings",
     IsIdenticalObj,
-    [ IsRing and IsAssociative, IsRing and IsAssociative ], 0,
+    [ IsRing and IsAssociative, IsRing and IsAssociative ],
     IsCentralFromGenerators( GeneratorsOfRing, GeneratorsOfRing ) );
 
 InstallMethod( IsCentral,
     "for two associative rings-with-one",
     IsIdenticalObj,
     [ IsRingWithOne and IsAssociative,
-      IsRingWithOne and IsAssociative ], 0,
+      IsRingWithOne and IsAssociative ],
     IsCentralFromGenerators( GeneratorsOfRingWithOne,
                              GeneratorsOfRingWithOne ) );
+
+#############################################################################
+##
+#M  IsCentral( <R>, <x> )  . . . . . . . .  test if <x> is centralized by <R>
+##
+InstallMethod( IsCentral,
+    "for an associative ring and an element",
+    IsCollsElms,
+    [ IsRing and IsAssociative, IsObject ],
+    IsCentralElementFromGenerators( GeneratorsOfRing ) );
+
+InstallMethod( IsCentral,
+    "for an associative ring-with-one and an element",
+    IsCollsElms,
+    [ IsRingWithOne and IsAssociative, IsObject ],
+    IsCentralElementFromGenerators( GeneratorsOfRingWithOne ) );
 
 
 #############################################################################

--- a/tst/testinstall/opers/IsCentral.tst
+++ b/tst/testinstall/opers/IsCentral.tst
@@ -1,0 +1,92 @@
+gap> START_TEST("IsCentral.tst");
+
+#
+# for groups
+#
+gap> G:=SymmetricGroup(3);;
+
+# a group and an element
+gap> List(AsSet(G), g -> [g, IsCentral(G,g)]);
+[ [ (), true ], [ (2,3), false ], [ (1,2), false ], [ (1,2,3), false ], 
+  [ (1,3,2), false ], [ (1,3), false ] ]
+
+# a group and a subgroup
+gap> G:=SymmetricGroup(3);;
+gap> List(Set(AllSubgroups(G)), H -> [H, IsCentral(G, H)]);
+[ [ Group(()), true ], [ Group([ (2,3) ]), false ], 
+  [ Group([ (1,2,3), (2,3) ]), false ], [ Group([ (1,2) ]), false ], 
+  [ Group([ (1,2,3) ]), false ], [ Group([ (1,3) ]), false ] ]
+
+#
+# a set of matrices for the other tests
+#
+gap> gens := [ DiagonalMat([1,0]), [[0,1],[0,0]], DiagonalMat([1,1]) ];;
+
+#
+# for a magma
+#
+gap> M:=Magma(gens);
+<magma with 3 generators>
+gap> List(AsSet(M), x->IsCentral(M,x));
+[ true, false, false, true ]
+gap> IsCentral(M, Submagma(M, []));
+true
+gap> List(AsSet(M), x->IsCentral(M,Submagma(M,[x])));
+[ true, false, false, true ]
+
+#
+# for a magma with one
+#
+gap> M:=MagmaWithOne(gens);
+<magma-with-one with 3 generators>
+gap> List(AsSet(M), x->IsCentral(M,x));
+[ true, false, false, true ]
+gap> IsCentral(M, Submagma(M, []));
+true
+gap> List(AsSet(M), x->IsCentral(M,Submagma(M,[x])));
+[ true, false, false, true ]
+
+#
+# for an algebra
+#
+gap> A:=Algebra(Rationals, gens);
+<algebra over Rationals, with 3 generators>
+gap> List(GeneratorsOfAlgebra(A), x->IsCentral(A,x));
+[ false, false, true ]
+gap> List(GeneratorsOfAlgebra(A), x->IsCentral(A,Subalgebra(A,[x])));
+[ false, false, true ]
+
+#
+# for an algebra with one
+#
+gap> A:=AlgebraWithOne(Rationals, gens);
+<algebra-with-one over Rationals, with 3 generators>
+gap> List(GeneratorsOfAlgebraWithOne(A), x->IsCentral(A,x));
+[ false, false, true ]
+gap> List(GeneratorsOfAlgebraWithOne(A), x->IsCentral(A,Subalgebra(A,[x])));
+[ false, false, true ]
+
+#
+# for a ring
+#
+gap> R:=Ring(gens);
+<free left module over Integers, and ring, with 3 generators>
+gap> SetIsAssociative(R,true);
+gap> List(GeneratorsOfLeftOperatorRing(R), x->IsCentral(R,x));
+[ false, false, true ]
+gap> List(GeneratorsOfLeftOperatorRing(R), x->IsCentral(R,SubringNC(R,[x])));
+[ false, false, true ]
+
+#
+# for a ring with one
+#
+gap> R:=RingWithOne(gens);
+<free left module over Integers, and ring-with-one, with 3 generators>
+gap> SetIsAssociative(R,true);
+gap> List(GeneratorsOfLeftOperatorRingWithOne(R), x->IsCentral(R,x));
+[ false, false, true ]
+gap> List(GeneratorsOfLeftOperatorRingWithOne(R), x->IsCentral(R,SubringNC(R,[x])));
+[ false, false, true ]
+
+#
+gap> STOP_TEST("IsCentral.tst", 10000);


### PR DESCRIPTION
The documentation for `IsCentral` already claims these methods exist, but they never did. Add them in a systematic fashion.

Resolves #1795