### PR TITLE
kernel: don't use ProdIntObj as ProdFunc; use PowObjInt less

### DIFF
--- a/lib/arith.gi
+++ b/lib/arith.gi
@@ -535,7 +535,7 @@ InstallOtherMethod( \*,
 
 InstallOtherMethod( \*,
     "negative integer * additive element with inverse",
-    [ IsInt and IsNegRat, IsNearAdditiveElementWithInverse ],
+    [ IsNegInt, IsNearAdditiveElementWithInverse ],
     PROD_INT_OBJ );
 
 
@@ -559,7 +559,7 @@ end);
 
 InstallOtherMethod( \*,
     "additive element with inverse * negative integer",
-    [ IsNearAdditiveElementWithInverse, IsInt and IsNegRat ],
+    [ IsNearAdditiveElementWithInverse, IsNegInt ],
 function(a,b)
   return PROD_INT_OBJ(b,a);
 end);
@@ -584,7 +584,7 @@ InstallMethod( \^,
 
 InstallMethod( \^,
     "for mult. element-with-inverse, and negative integer",
-    [ IsMultiplicativeElementWithInverse, IsInt and IsNegRat ],
+    [ IsMultiplicativeElementWithInverse, IsNegInt ],
     POW_OBJ_INT );
 
 InstallMethod( \^, "catch wrong root taking",

--- a/src/integer.c
+++ b/src/integer.c
@@ -2829,20 +2829,16 @@ static Int InitKernel ( StructInitInfo * module )
     OneMutFuncs [ t1 ] = OneInt;
   }    
 
-    /* install the default product and power methods                       */
+    /* install the default power methods                                   */
   for ( t1 = T_INT; t1 <= T_INTNEG; t1++ ) {
-    for ( t2 = FIRST_CONSTANT_TNUM;  t2 <= LAST_CONSTANT_TNUM;  t2++ ) {
-      ProdFuncs[ t1 ][ t2 ] = ProdIntObj;
+    for ( t2 = FIRST_MULT_TNUM; t2 <= LAST_MULT_TNUM; t2++ ) {
       PowFuncs [ t2 ][ t1 ] = PowObjInt;
     }
-    for ( t2 = FIRST_RECORD_TNUM;  t2 <= LAST_RECORD_TNUM;  t2++ ) {
-      ProdFuncs[ t1 ][ t2 ] = ProdIntObj;
+    for ( t2 = FIRST_PLIST_TNUM; t2 <= LAST_PLIST_TNUM; t2++ ) {
       PowFuncs [ t2 ][ t1 ] = PowObjInt;
     }
-    for ( t2 = FIRST_LIST_TNUM;    t2 <= LAST_LIST_TNUM;    t2++ ) {
-      ProdFuncs[ t1 ][ t2 ] = ProdIntObj;
-      PowFuncs [ t2 ][ t1 ] = PowObjInt;
-    }
+    PowFuncs [ T_RANGE_NSORT ][ t1 ] = PowObjInt;
+    PowFuncs [ T_RANGE_SSORT ][ t1 ] = PowObjInt;
   }
 
   /* install the binary arithmetic methods                                 */

--- a/src/objects.c
+++ b/src/objects.c
@@ -1874,6 +1874,7 @@ Obj FuncDEBUG_TNUM_NAMES(Obj self)
     for (UInt k = 0; k < 256; k++) {
         START_SYMBOLIC_TNUM(FIRST_REAL_TNUM);
         START_SYMBOLIC_TNUM(FIRST_CONSTANT_TNUM);
+        START_SYMBOLIC_TNUM(FIRST_MULT_TNUM);
         START_SYMBOLIC_TNUM(FIRST_IMM_MUT_TNUM);
         START_SYMBOLIC_TNUM(FIRST_RECORD_TNUM);
         START_SYMBOLIC_TNUM(FIRST_LIST_TNUM);
@@ -1891,6 +1892,7 @@ Obj FuncDEBUG_TNUM_NAMES(Obj self)
         const char *name = InfoBags[k].name;
         Pr("%3d: %s", k, (Int)indentStr);
         Pr("%s%s\n", (Int)indentStr, (Int)(name ? name : "."));
+        STOP_SYMBOLIC_TNUM(LAST_MULT_TNUM);
         STOP_SYMBOLIC_TNUM(LAST_CONSTANT_TNUM);
         STOP_SYMBOLIC_TNUM(LAST_RECORD_TNUM);
         STOP_SYMBOLIC_TNUM(LAST_PLIST_TNUM);
@@ -2175,6 +2177,9 @@ static Int InitLibrary (
 
     ExportAsConstantGVar(FIRST_CONSTANT_TNUM);
     ExportAsConstantGVar(LAST_CONSTANT_TNUM);
+
+    ExportAsConstantGVar(FIRST_MULT_TNUM);
+    ExportAsConstantGVar(LAST_MULT_TNUM);
 
     ExportAsConstantGVar(FIRST_IMM_MUT_TNUM);
     ExportAsConstantGVar(LAST_IMM_MUT_TNUM);

--- a/src/objects.h
+++ b/src/objects.h
@@ -139,24 +139,31 @@ enum TNUM {
     START_ENUM_RANGE(FIRST_REAL_TNUM),
 
     START_ENUM_RANGE(FIRST_CONSTANT_TNUM),
-        T_INT,      // immediate
-        T_INTPOS,
-        T_INTNEG,
-        T_RAT,
-        T_CYC,
-        T_FFE,      // immediate
-        T_PERM2,
-        T_PERM4,
-        T_TRANS2,
-        T_TRANS4,
-        T_PPERM2,
-        T_PPERM4,
+
+        // The next range contains all constant TNUMs for which multiplication
+        // with an integer resp. powering by an integer makes sense
+        START_ENUM_RANGE(FIRST_MULT_TNUM),
+            T_INT,      // immediate
+            T_INTPOS,
+            T_INTNEG,
+            T_RAT,
+            T_CYC,
+            T_FFE,      // immediate
+            T_MACFLOAT,
+            T_PERM2,
+            T_PERM4,
+            T_TRANS2,
+            T_TRANS4,
+            T_PPERM2,
+            T_PPERM4,
+        END_ENUM_RANGE(LAST_MULT_TNUM),
+
         T_BOOL,
         T_CHAR,
+
         T_FUNCTION,
         T_BODY,     // the type of function body bags
         T_FLAGS,
-        T_MACFLOAT,
         T_LVARS,
         T_HVARS,
     END_ENUM_RANGE(LAST_CONSTANT_TNUM),

--- a/tst/testbugfix/2018-02-21-int-mul-pow.tst
+++ b/tst/testbugfix/2018-02-21-int-mul-pow.tst
@@ -1,0 +1,71 @@
+# in the past, the kernel functions IsNegInt ProdIntObj and PowObjInt were
+# applicable to almost arbitrary objects, which lead to some strange
+# expressions being evaluated by GAP. Here we verify that these now produce
+# errors instead.
+gap> f:=x->x;;
+
+#
+gap> rec() ^ 1;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `^' on 2 arguments
+gap> 'x' ^ 1;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `^' on 2 arguments
+gap> "x" ^ 1;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `^' on 2 arguments
+gap> f ^ 1;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `^' on 2 arguments
+
+#
+gap> 1 * Immutable(rec());
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `*' on 2 arguments
+gap> 1 * 'x';
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `*' on 2 arguments
+gap> 1 * "x";
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `*' on 2 arguments
+gap> 1 * f;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `*' on 2 arguments
+
+# the following always gave errors, but let's check them for completeness
+gap> Immutable(rec()) * 1;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `*' on 2 arguments
+gap> 'x' * 1;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `*' on 2 arguments
+gap> "x" * 1;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `*' on 2 arguments
+gap> f * 1;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `*' on 2 arguments
+
+# in contrast, one can still power vectors by a positive integer, with the
+# understanding that vec^1=vec, and vec^2 is the standard scalar product of
+# the vector with itself, and larger powers are derived from this.
+gap> [1..3]^1;
+[ 1 .. 3 ]
+gap> [1..3]^2;
+14
+gap> [1..3]^3;
+[ 14, 28, 42 ]
+gap> [1..3]^4;
+196
+gap> [1..3]^0;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 3rd choice method found for `OneSameMutability' on 1 arguments
+gap> [1..3]^-1;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `InverseSameMutability' on 1 arguments
+
+# multiplication of int*float and float*int used to behave inconsistently
+gap> 10^400 * 10.^-300; # used to return 1.e+100
+inf
+gap> 10.^-300 * 10^400;
+inf


### PR DESCRIPTION
We used to install ProdIntObj and PowObjInt for a large variety of TNUMs,
including precords, functions, strings etc., where they never made sense:

And for those TNUMs where it did make sense (e.g. T_RAT), often later modules
would install more specialized functions anyway. For ProdIntObj, this meant
that the only sensible place it was used was for T_MACFLOAT. This PR removes
even that, though, since it was only used for `int * float`, but not for
`float * int`, which resulted in the two behaving differently:

    gap> 10^400 * 10.^-300;
    1.e+100
    gap> 10.^-300 * 10^400;
    inf

Hence, we stop using ProdIntObj as kernel level ProdFunc completely, even for
machine floats, and instead,rely on library functions for multiplying integers
and floats.

Note that ProdIntObj can still be invoked from the library via PROD_INT_OBJ,
and this is used to install default multiplication functions for integers with
IsNearAdditiveElementWithInverse elements (and these method installations are
also provided symmetrically, i.e. int*obj as well as obj*int). While this is
very slightly slower, it is at least guaranteed to be symmetric and
mathematically well-defined.

For PowObjInt, the asymmetry is natural, so less of a problem. Also, it turns
out that it is actually used in a few more cases, e.g. to power
transformations and partial permutations. Still, doing f^1 for a function or
'x'^1 or true^1 are all surprising. To resolve this, we restrict for which
TNUMs we install PowObjInt as PowFunc substantially: We don't use it on all
constant TNUMs anymore, but rather only on those were multiplication by an
integer makes some sense, using the new TNUM range FIRST_MULT_TNUM till
LAST_MULT_TNUM. We also don't install it for records anymore, and also not for
blists and strings. It is kept for ranges and other plists, as there it has a
chance of a well-defined behavior (if the list describes a vector,
possibly a matrix).