### PR TITLE
hpcgap: get rid of backquote alias for MakeImmutable

### DIFF
--- a/hpcgap/lib/cmdleditx.g
+++ b/hpcgap/lib/cmdleditx.g
@@ -135,14 +135,14 @@ BindGlobal("CommandLineHistoryHandler", function(l)
       for i in [2..Length(hist)-1] do
         hist[i] := hist[i+1];
       od;
-      hist[Length(hist)] := `l[1];
+      hist[Length(hist)] := MakeImmutable(l[1]);
       if hist[1] > 2 then
         hist[1] := hist[1]-1;
       else
         hist[1] := Length(hist)+1;
       fi;
     else
-      Add(hist, `l[1]);
+      Add(hist, MakeImmutable(l[1]));
     fi;
     LastPosCLH := hist[1];
     hist[1] := Length(hist)+1;
@@ -280,7 +280,7 @@ BindGlobal("ReadCommandLineHistory", function(arg)
       s := s{[Length(s)-n+1..Length(s)]};
     fi;
     hist{[Length(s)+2..Length(s)+Length(hist)]} := hist{[2..Length(hist)]};
-    hist{[2..Length(s)+1]} := `s;
+    hist{[2..Length(s)+1]} := MakeImmutable(s);
   fi;
   hist[1] := Length(hist) + 1;
 

--- a/hpcgap/lib/fldabnum.gi
+++ b/hpcgap/lib/fldabnum.gi
@@ -1255,8 +1255,8 @@ InstallMethod( CanonicalBasis,
       # Fill in additional components.
       SetBasisVectors( B, List( lenst,
                                 x -> Sum( List( x, y -> E(N)^y ) ) ) );
-      B!.coeffslist  := `List( lenst, x -> x[1] + 1 );
-      B!.lenstrabase := `lenst;
+      B!.coeffslist  := MakeImmutable(List( lenst, x -> x[1] + 1 ));
+      B!.lenstrabase := MakeImmutable(lenst);
       B!.conductor   := N;
 #T better compute basis vectors only if necessary
 #T (in the case of a normal basis the vectors are of course known ...)
@@ -1518,7 +1518,7 @@ InstallMethod( CanonicalBasis,
       SetIsIntegralBasis( B, true );
 
       # Construct the Zumbroich basis.
-      B!.zumbroichbase := `ZumbroichBase( n, Conductor( subfield ) );
+      B!.zumbroichbase := MakeImmutable(ZumbroichBase( n, Conductor( subfield ) ));
 
     else
 
@@ -1563,8 +1563,8 @@ InstallMethod( CanonicalBasis,
       SetBasisVectors( B, vectors );
       SetIsNormalBasis( B, true );
 
-      B!.zumbroichbase := `(zumb - 1);
-      B!.coeffsmat     := `coeffsmat;
+      B!.zumbroichbase := MakeImmutable(zumb - 1);
+      B!.coeffsmat     := MakeImmutable(coeffsmat);
 
     fi;
 

--- a/hpcgap/lib/package.gi
+++ b/hpcgap/lib/package.gi
@@ -277,7 +277,7 @@ InstallGlobalFunction( InitializePackagesInfoRecords, function( arg )
                   elif IsRecord( record.PackageDoc ) then
                     record.PackageDoc:= [ record.PackageDoc ];
                   fi;
-                  Add( GAPInfo.PackagesInfo, `record );
+                  Add( GAPInfo.PackagesInfo, MakeImmutable(record) );
                 fi;
               fi;
             fi;
@@ -294,11 +294,11 @@ InstallGlobalFunction( InitializePackagesInfoRecords, function( arg )
     # Turn the lists into records.
     record:= rec();
     for r in GAPInfo.PackagesInfo do
-      name:= `LowercaseString( r.PackageName );
+      name:= MakeImmutable( LowercaseString( r.PackageName ) );
       if IsBound( record.( name ) ) then
-        record.( name ) := `Concatenation( record.( name ), [ r ] );
+        record.( name ) := MakeImmutable( Concatenation( record.( name ), [ r ] ) );
       else
-        record.( name ):= `[ r ];
+        record.( name ):= MakeImmutable( [ r ] );
       fi;
     od;
     GAPInfo.PackagesInfo:= AtomicRecord(record);
@@ -2315,7 +2315,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
 ##  </ManSection>
 ##
 GAPInfo.PackagesRestrictions := AtomicRecord(rec(
-  anupq := `rec(
+  anupq := MakeImmutable(rec(
     OnInitialization := function( pkginfo )
         if CompareVersionNumbers( pkginfo.Version, "1.3" ) = false then
           return false;
@@ -2333,9 +2333,9 @@ GAPInfo.PackagesRestrictions := AtomicRecord(rec(
               "most recent version, see URL\n",
               "      http://www.math.rwth-aachen.de/~Greg.Gamble/ANUPQ\n" );
         fi;
-        end ),
+        end )),
 
-  autpgrp := `rec(
+  autpgrp := MakeImmutable(rec(
     OnInitialization := function( pkginfo )
         return true;
         end,
@@ -2350,7 +2350,7 @@ GAPInfo.PackagesRestrictions := AtomicRecord(rec(
               "most recent version, see URL\n",
               "      https://www.gap-system.org/Packages/autpgrp.html\n" );
         fi;
-        end ) ));
+        end )) ));
 
 
 #############################################################################

--- a/hpcgap/lib/variable.g
+++ b/hpcgap/lib/variable.g
@@ -172,6 +172,8 @@ if IsHPCGAP then
 BIND_GLOBAL( "FLUSHABLE_VALUE_REGION", NewSpecialRegion("FLUSHABLE_VALUE_REGION"));
 fi;
 
+BIND_GLOBAL( "UNCLONEABLE_TNUMS", MakeImmutable([T_INT,T_FFE,T_BOOL]) );
+
 BIND_GLOBAL( "InstallValue", function ( gvar, value )
     if (not IsBound(REREADING) or REREADING = false) and not
        IsToBeDefinedObj( gvar ) then
@@ -182,9 +184,7 @@ BIND_GLOBAL( "InstallValue", function ( gvar, value )
           "please use `BindGlobal' for the family object ",
           value!.NAME, ", not `InstallValue'" );
     fi;
-    if TNUM_OBJ(value) <= LAST_CONSTANT_TNUM
-        and (TNUM_OBJ(value) = TNUM_OBJ(0)
-             or IS_FFE(value) or IS_BOOL(value)) then
+    if TNUM_OBJ(value) in UNCLONEABLE_TNUMS then
        Error("InstallValue: <value> cannot be immediate, boolean or character");
     fi;
     if IsPublic(value) then

--- a/hpcgap/lib/wordrep.gi
+++ b/hpcgap/lib/wordrep.gi
@@ -1013,10 +1013,10 @@ InstallGlobalFunction( StoreInfoFreeMagma, function( F, names, req )
     MakeImmutable(expB);
     F!.expBits := expB;
 
-    F!.expBitsInfo := `[ 2^( F!.expBits[1] - 1 ),
+    F!.expBitsInfo := MakeImmutable([ 2^( F!.expBits[1] - 1 ),
                          2^( F!.expBits[2] - 1 ),
                          2^( F!.expBits[3] - 1 ),
-                         infinity          ];
+                         infinity          ]);
 
     # Store the internal types.
     K:= NewType( F, Is8BitsAssocWord and req );

--- a/src/read.c
+++ b/src/read.c
@@ -1737,19 +1737,6 @@ void ReadLiteral (
         ReadRecExpr( follow );
         break;
 
-#ifdef HPCGAP
-    /* `Literal                                                            */
-    case S_BACKQUOTE:
-        Match( S_BACKQUOTE, "`", follow );
-        TRY_READ {
-          IntrRefGVar(GVarName("MakeImmutable"));
-          IntrFuncCallBegin();
-        }
-        ReadAtom( follow, 'r' );
-        TRY_READ { IntrFuncCallEnd(1, 0, 1); }
-        break;
-#endif
-
     /* <Function>                                                          */
     case S_FUNCTION:
     case S_ATOMIC:

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1035,9 +1035,6 @@ void GetSymbol ( void )
   case '*':   STATE(Symbol) = S_MULT;                        GET_NEXT_CHAR();  break;
   case '/':   STATE(Symbol) = S_DIV;                         GET_NEXT_CHAR();  break;
   case '^':   STATE(Symbol) = S_POW;                         GET_NEXT_CHAR();  break;
-#ifdef HPCGAP
-  case '`':   STATE(Symbol) = S_BACKQUOTE;                   GET_NEXT_CHAR();  break;
-#endif
 
   case '"':                                           GetMaybeTripStr();  break;
   case '\'':                                          GetChar();   break;

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -84,9 +84,6 @@ enum SCANNER_SYMBOLS {
     S_HELP              = (1UL<<11)+7,
 
     S_REC               = (1UL<<12)+0,
-#ifdef HPCGAP
-    S_BACKQUOTE         = (1UL<<12)+1,
-#endif
 
     S_FUNCTION          = (1UL<<13),
     S_LOCAL             = (1UL<<14),


### PR DESCRIPTION
The backquote / backtick syntax always was controversial, and with the whole unification project, we already got rid of most of its uses. This PR removes the last few remaining uses, and the implementation.