### PR TITLE
Refactor plist types handling

### DIFF
--- a/hpcgap/lib/variable.g
+++ b/hpcgap/lib/variable.g
@@ -172,6 +172,8 @@ if IsHPCGAP then
 BIND_GLOBAL( "FLUSHABLE_VALUE_REGION", NewSpecialRegion("FLUSHABLE_VALUE_REGION"));
 fi;
 
+BIND_GLOBAL( "UNCLONEABLE_TNUMS", MakeImmutable([T_INT,T_FFE,T_BOOL]) );
+
 BIND_GLOBAL( "InstallValue", function ( gvar, value )
     if (not IsBound(REREADING) or REREADING = false) and not
        IsToBeDefinedObj( gvar ) then
@@ -182,9 +184,7 @@ BIND_GLOBAL( "InstallValue", function ( gvar, value )
           "please use `BindGlobal' for the family object ",
           value!.NAME, ", not `InstallValue'" );
     fi;
-    if TNUM_OBJ(value) <= LAST_CONSTANT_TNUM
-        and (TNUM_OBJ(value) = TNUM_OBJ(0)
-             or IS_FFE(value) or IS_BOOL(value)) then
+    if TNUM_OBJ(value) in UNCLONEABLE_TNUMS then
        Error("InstallValue: <value> cannot be immediate, boolean or character");
     fi;
     if IsPublic(value) then

--- a/lib/list.g
+++ b/lib/list.g
@@ -282,205 +282,41 @@ BIND_GLOBAL( "TYPE_BLIST_EMPTY_IMM",
 
 #############################################################################
 ##
-#F  TYPE_LIST_HOM( <family>, <kernel_number> )	. . return the type of a list
+#F  TYPE_LIST_HOM( <family>, <isMutable>, <sort>, <table> )
 ##
 ##  <ManSection>
-##  <Func Name="TYPE_LIST_HOM" Arg='family, kernel_number'/>
+##  <Func Name="TYPE_LIST_HOM" Arg='family, isMutable, sort, table'/>
 ##
 ##  <Description>
-##  For <A>kernel_number</A> see <F>objects.h</F> and <F>plist.c</F>:
-##  <P/>
-##   1: T_PLIST_HOM
-##   2: T_PLIST_HOM       + IMMUTABLE
-##   3: T_PLIST_HOM_NSORT
-##   4: T_PLIST_HOM_NSORT + IMMUTABLE
-##   5: T_PLIST_HOM_SSORT
-##   6: T_PLIST_HOM_SSORT + IMMUTABLE
-##   7: T_PLIST_TAB
-##   8: T_PLIST_TAB       + IMMUTABLE
-##   9: T_PLIST_TAB_NSORT
-##  10: T_PLIST_TAB_NSORT + IMMUTABLE
-##  11: T_PLIST_TAB_SSORT
-##  12: T_PLIST_TAB_SSORT + IMMUTABLE
-##  13: T_PLIST_TAB_RECT
-##  14: T_PLIST_TAB_RECT       + IMMUTABLE
-##  15: T_PLIST_TAB_RECT_NSORT
-##  16: T_PLIST_TAB_RECT_NSORT + IMMUTABLE
-##  17: T_PLIST_TAB_RECT_SSORT
-##  18: T_PLIST_TAB_RECT_SSORT + IMMUTABLE
-##  19: T_PLIST_CYC
-##  20: T_PLIST_CYC       + IMMUTABLE
-##  21: T_PLIST_CYC_NSORT
-##  22: T_PLIST_CYC_NSORT + IMMUTABLE
-##  23: T_PLIST_CYC_SSORT
-##  24: T_PLIST_CYC_SSORT + IMMUTABLE
-##  25: T_PLIST_FFE
-##  26: T_PLIST_FFE + IMMUTABLE
+##  Return the type of a homogenous list whose elements are in <family>, with
+##  additional properties indicated by <isMutable>, <sort> and <table>.
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, knr )
-    local   colls;
+BIND_GLOBAL( "TYPE_LIST_HOM", function ( family, isMutable, sort, table )
+    local   colls, filter;
 
     colls := CollectionsFamily( family );
+    filter := IsPlistRep and IsList and IsDenseList and
+              IsHomogeneousList and IsCollection;
+    if isMutable then
+        filter := filter and IsMutable;
+    fi;
 
-    # The Cyclotomic types behave just like the corresponding
-    # homogenous types
-
-    if knr > 18 then 
-        if knr < 25 then
-            knr := knr -18;
-        # The FFE types behave just like the corresponding
-        # homogenous types
-        else
-            knr := knr -24;
+    if sort <> fail then
+        filter := filter and Tester(IsSSortedList);
+        if sort then
+            filter := filter and IsSSortedList;
         fi;
     fi;
 
-    # T_PLIST_HOM
-    if   knr = 1  then
-        return NewType( colls,
-                        IsMutable and IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        IsPlistRep );
-
-    # T_PLIST_HOM + IMMUTABLE
-    elif knr = 2  then
-        return NewType( colls,
-                        IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        IsPlistRep );
-
-    # T_PLIST_HOM_NSORT
-    elif knr = 3  then
-        return NewType( colls,
-                        IsMutable and IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        Tester(IsSSortedList) and
-                        IsPlistRep );
-
-    # T_PLIST_HOM_NSORT + IMMUTABLE
-    elif knr = 4  then
-        return NewType( colls,
-                        IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        Tester(IsSSortedList) and
-                        IsPlistRep );
-
-    # T_PLIST_HOM_SSORT
-    elif knr = 5  then
-        return NewType( colls,
-                        IsMutable and IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        Tester(IsSSortedList) and
-                        IsSSortedList and
-                        IsPlistRep );
-
-    # T_PLIST_HOM_SSORT + IMMUTABLE
-    elif knr = 6  then
-        return NewType( colls,
-                        IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        Tester(IsSSortedList) and
-                        IsSSortedList and
-                        IsPlistRep );
-
-    # T_PLIST_TAB
-    elif knr = 7  then
-        return NewType( colls,
-                        IsMutable and IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        IsTable and IsPlistRep );
-
-    # T_PLIST_TAB + IMMUTABLE
-    elif knr = 8  then
-        return NewType( colls,
-                        IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        IsTable and IsPlistRep );
-
-    # T_PLIST_TAB_NSORT
-    elif knr = 9  then
-        return NewType( colls,
-                        IsMutable and IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        Tester(IsSSortedList) and IsTable
-                        and IsPlistRep );
-
-    # T_PLIST_TAB_NSORT + IMMUTABLE
-    elif knr = 10  then
-        return NewType( colls,
-                        IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        Tester(IsSSortedList) and IsTable
-                        and IsPlistRep );
-
-    # T_PLIST_TAB_SSORT
-    elif knr = 11  then
-        return NewType( colls,
-                        IsMutable and IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        Tester(IsSSortedList) and
-                        IsSSortedList and IsTable and IsPlistRep );
-
-    # T_PLIST_TAB_SSORT + IMMUTABLE
-    elif knr = 12  then
-        return NewType( colls,
-                        IsList and IsDenseList and IsHomogeneousList
-                        and Tester(IsSSortedList)
-                        and IsCollection and IsSSortedList and IsTable
-                        and IsPlistRep );
-
-    # T_PLIST_TAB_RECT
-    elif knr = 13  then
-        return NewType( colls,
-                        IsMutable and IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        IsTable and HasIsRectangularTable and IsRectangularTable and IsPlistRep );
-
-    # T_PLIST_TAB_RECT + IMMUTABLE
-    elif knr = 14  then
-        return NewType( colls,
-                        IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        IsTable and HasIsRectangularTable and IsRectangularTable and IsPlistRep );
-
-    # T_PLIST_TAB_RECT_NSORT
-    elif knr = 15  then
-        return NewType( colls,
-                        IsMutable and IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        Tester(IsSSortedList) and IsTable and HasIsRectangularTable and IsRectangularTable
-                        and IsPlistRep );
-
-    # T_PLIST_TAB_RECT_NSORT + IMMUTABLE
-    elif knr = 16  then
-        return NewType( colls,
-                        IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        Tester(IsSSortedList) and IsTable and HasIsRectangularTable and IsRectangularTable
-                        and IsPlistRep );
-
-    # T_PLIST_TAB_RECT_SSORT
-    elif knr = 17  then
-        return NewType( colls,
-                        IsMutable and IsList and IsDenseList and
-                        IsHomogeneousList and IsCollection and
-                        Tester(IsSSortedList) and
-                        IsSSortedList and IsTable and HasIsRectangularTable and IsRectangularTable and IsPlistRep );
-
-    # T_PLIST_TAB_RECT_SSORT + IMMUTABLE
-    elif knr = 18  then
-        return NewType( colls,
-                        IsList and IsDenseList and IsHomogeneousList
-                        and Tester(IsSSortedList)
-                       and IsCollection and IsSSortedList and IsTable and HasIsRectangularTable 
-                       and IsRectangularTable
-                        and IsPlistRep );
-
-    else
-        Error( "what?  Unknown kernel number ", knr );
+    if table = 1 then
+        filter := filter and IsTable;
+    elif table = 2 then
+        filter := filter and IsTable and IsRectangularTable;
     fi;
+
+    return NewType(colls, filter);
 end );
 
 

--- a/lib/variable.g
+++ b/lib/variable.g
@@ -172,6 +172,8 @@ if IsHPCGAP then
 BIND_GLOBAL( "FLUSHABLE_VALUE_REGION", NewSpecialRegion("FLUSHABLE_VALUE_REGION"));
 fi;
 
+BIND_GLOBAL( "UNCLONEABLE_TNUMS", MakeImmutable([T_INT,T_FFE,T_BOOL]) );
+
 BIND_GLOBAL( "InstallValue", function ( gvar, value )
     if (not IsBound(REREADING) or REREADING = false) and not
        IsToBeDefinedObj( gvar ) then
@@ -182,9 +184,7 @@ BIND_GLOBAL( "InstallValue", function ( gvar, value )
           "please use `BindGlobal' for the family object ",
           value!.NAME, ", not `InstallValue'" );
     fi;
-    if TNUM_OBJ(value) <= LAST_CONSTANT_TNUM
-        and (TNUM_OBJ(value) = TNUM_OBJ(0)
-             or IS_FFE(value) or IS_BOOL(value)) then
+    if TNUM_OBJ(value) in UNCLONEABLE_TNUMS then
        Error("InstallValue: <value> cannot be immediate, boolean or character");
     fi;
     CLONE_OBJ (gvar, value);

--- a/src/plist.c
+++ b/src/plist.c
@@ -597,7 +597,9 @@ static Obj TypePlistHomHelper(Obj family, UInt tnum, UInt knr, Obj list)
         type = CALL_4ARGS(TYPE_LIST_HOM, family, isMutable, sort, table);
         ASS_LIST(types, knr, type);
 #ifdef HPCGAP
-        // read back element before returning it, in case another thread raced us
+        // read back element before returning it, in case another thread raced
+        // us (this works because <TYPES_LIST_FAM> returns an atomic list in
+        // HPC-GAP)
         type = ELM0_LIST(types, knr);
 #endif
     }

--- a/src/plist.c
+++ b/src/plist.c
@@ -647,10 +647,7 @@ static Obj TypePlistWithKTNum (
 
     /* handle homogeneous list                                             */
     if ( family && HasFiltListTNums[tnum][FN_IS_HOMOG] ) {
-#ifdef HPCGAP
-        if (CheckWriteAccess(TYPES_LIST_FAM(family)))
-#endif
-            return TypePlistHomHelper(family, tnum-T_PLIST_HOM+1);
+        return TypePlistHomHelper(family, tnum - T_PLIST_HOM + 1);
     }
 
 #ifdef HPCGAP


### PR DESCRIPTION
Right now, the types of homogeneous plists are computed via the library function TYPE_LIST_HOM, which hard codes information about plist TNUMs but in a way that is not easy to find if one does not know about it. In particular, it encodes assumptions about the order of various TNUMs relative to each other; and also the assumption that (im)mutability can be determined from the parity of the TNUM. Since some of us are working towards getting rid of the latter, it seems prudent to get rid of this assumption from the library, which this PR does.

In addition, a HPC-GAP check for writeability to `TYPES_LIST_FAM` is removed. I assume that once made sense, but `TYPES_LIST_FAM` now always is a strict write-once atomic list, and we take care of potential races in the new `TypePlistHomHelper`.

Finally, an unrelated change reintroduces `UNCLONEABLE_TNUMS` -- now that we export the TNUMs as constants to GAP, IMHO the intent of the code is easier to understand with the use of `UNCLONEABLE_TNUMS`.