### PR TITLE
Include random.gd before coll.gi

### DIFF
--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -246,11 +246,6 @@ InstallMethod( RepresentativeSmallest,
 ##  an enumerator of <C> and selects a random element of this list using the
 ##  function `RandomList', which is a pseudo random number generator.
 ##
-if IsHPCGAP then
-    MakeThreadLocal( "GlobalMersenneTwister" );
-else
-    DeclareGlobalVariable( "GlobalMersenneTwister" );
-fi;
 InstallGlobalFunction( RandomList, function(list)
   return list[Random(GlobalMersenneTwister, 1, Length(list))];
 end );

--- a/lib/read1.g
+++ b/lib/read1.g
@@ -36,6 +36,8 @@ ReadLib( "set.gd"      );
 
 ReadLib( "record.gd"   );
 
+ReadLib( "random.gd"   );
+
 ReadLib( "cache.gi"    );
 ReadLib( "coll.gi"     );
 
@@ -69,8 +71,6 @@ ReadLib( "global.gd"   );
 ReadLib( "info.gi"     );
 ReadLib( "assert.gi"   );
 ReadLib( "global.gi"   );
-
-ReadLib( "random.gd"   );
 
 ReadLib( "options.gd"  );
 ReadLib( "options.gi"  );


### PR DESCRIPTION
This way, we can move the definition of GlobalMersenneTwister from
coll.gi to random.gd, and will be able to use InstallMethodWithRandomSource
inside of coll.gi

This implements a change I suggested on #2204 -- if @ChrisJefferson likes it, also feel free to cherry-pick this into your PR, and then we just test and merge your PR and we close this. Or we merge this first. Or we discard this PR if people hate it, and do something completely different ;-).