### PR TITLE
Refactor ReadCallVarAss and ReadReferenceModifiers

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -251,11 +251,16 @@ enum REFTYPE {
 typedef struct {
     enum REFTYPE type;
 
-    UInt var;
-    UInt narg;
-    UInt rnam;
-    UInt nest0;
-    UInt level;
+    union {
+        UInt var;
+        UInt narg;
+        UInt rnam;
+    };
+
+    union {
+        UInt nest0;
+        UInt level;
+    };
 } LHSRef;
 
 

--- a/src/read.c
+++ b/src/read.c
@@ -271,7 +271,7 @@ UInt EvalRef(const LHSRef ref, Int needExpr)
 {
     TRY_READ
     {
-        switch ((UInt)ref.type) {
+        switch (ref.type) {
         case R_LVAR:
             IntrRefLVar(ref.var);
             break;
@@ -326,6 +326,7 @@ UInt EvalRef(const LHSRef ref, Int needExpr)
         case R_FUNCCALL_OPTS:
             IntrFuncCallEnd(needExpr, 1, ref.narg);
             break;
+        case R_INVALID:
         default:
             // This should never be reached
             SyntaxError("Parse error in EvalRef");
@@ -338,7 +339,7 @@ void AssignRef(const LHSRef ref)
 {
     TRY_READ
     {
-        switch ((UInt)ref.type) {
+        switch (ref.type) {
         case R_LVAR:
             IntrAssLVar(ref.var);
             break;
@@ -393,6 +394,7 @@ void AssignRef(const LHSRef ref)
         case R_FUNCCALL_OPTS:
             IntrFuncCallEnd(0, 1, ref.narg);
             break;
+        case R_INVALID:
         default:
             // This should never be reached
             SyntaxError("Parse error in AssignRef");
@@ -408,7 +410,7 @@ void UnbindRef(const LHSRef ref)
 
     TRY_READ
     {
-        switch ((UInt)type) {
+        switch (type) {
         case R_LVAR:
             IntrUnbLVar(ref.var);
             break;
@@ -439,6 +441,11 @@ void UnbindRef(const LHSRef ref)
         case R_ELM_COMOBJ_EXPR:
             IntrUnbComObjExpr();
             break;
+        case R_INVALID:
+        case R_ELMS_LIST:
+        case R_ELMS_POSOBJ:
+        case R_FUNCCALL:
+        case R_FUNCCALL_OPTS:
         default:
             SyntaxError("Illegal operand for 'Unbind'");
         }
@@ -453,7 +460,7 @@ void IsBoundRef(const LHSRef ref)
 
     TRY_READ
     {
-        switch ((UInt)type) {
+        switch (type) {
         case R_LVAR:
             IntrIsbLVar(ref.var);
             break;
@@ -484,6 +491,11 @@ void IsBoundRef(const LHSRef ref)
         case R_ELM_COMOBJ_EXPR:
             IntrIsbComObjExpr();
             break;
+        case R_INVALID:
+        case R_ELMS_LIST:
+        case R_ELMS_POSOBJ:
+        case R_FUNCCALL:
+        case R_FUNCCALL_OPTS:
         default:
             SyntaxError("Illegal operand for 'IsBound'");
         }

--- a/src/read.c
+++ b/src/read.c
@@ -374,8 +374,8 @@ void ReadReferenceModifiers( TypSymbolSet follow )
     else if ( type == ':' ) { IntrElmRecExpr();             level=0; }
     else if ( type == '!' ) { IntrElmComObjName( rnam );    level=0; }
     else if ( type == '|' ) { IntrElmComObjExpr();          level=0; }
-    else if ( type == 'c' || type == 'C' )
-    { IntrFuncCallEnd( 1UL, type == 'C', narg ); level=0; }
+    else if ( type == 'c' ) { IntrFuncCallEnd(1, 0, narg);  level=0; }
+    else if ( type == 'C' ) { IntrFuncCallEnd(1, 1, narg);  level=0; }
     else
       SyntaxError("Parse error in modifiers"); // This should never be reached
     } /* end TRY_READ */
@@ -593,9 +593,10 @@ void ReadCallVarAss (
         else if ( type == ':' ) { IntrElmRecExpr();             level=0; }
         else if ( type == '!' ) { IntrElmComObjName( rnam );    level=0; }
         else if ( type == '|' ) { IntrElmComObjExpr();          level=0; }
-        else if ( type == 'c' || type == 'C' )
-          { IntrFuncCallEnd( 1UL, type == 'C', narg ); level=0; }
+        else if ( type == 'c' ) { IntrFuncCallEnd(1, 0, narg);  level=0; }
+        else if ( type == 'C' ) { IntrFuncCallEnd(1, 1, narg);  level=0; }
         } /* end TRY_READ */
+
         /* <Var> '[' <Expr> ']'  list selector                             */
         if ( STATE(Symbol) == S_LBRACK ) {
             Match( S_LBRACK, "[", follow );
@@ -704,6 +705,7 @@ void ReadCallVarAss (
 
     /* if we need a reference                                              */
     if ( mode == 'r' || (mode == 'x' && STATE(Symbol) != S_ASSIGN) ) {
+        Int needExpr = mode == 'r' || !IS_IN(STATE(Symbol), S_SEMICOLON);
       TRY_READ {
              if ( type == 'l' ) { IntrRefLVar( ref.var );             }
         else if ( type == 'h' ) { IntrRefHVar( ref.var );             }
@@ -721,14 +723,8 @@ void ReadCallVarAss (
         else if ( type == ':' ) { IntrElmRecExpr();               }
         else if ( type == '!' ) { IntrElmComObjName( rnam );      }
         else if ( type == '|' ) { IntrElmComObjExpr();            }
-        else if ( type == 'c' || type == 'C') {
-            if (mode == 'x' && IS_IN(STATE(Symbol), S_SEMICOLON)) {
-                IntrFuncCallEnd( 0UL, type == 'C', narg );
-            }
-            else {
-                IntrFuncCallEnd( 1UL, type == 'C', narg );
-            }
-        }
+        else if ( type == 'c' ) { IntrFuncCallEnd(needExpr, 0, narg); }
+        else if ( type == 'C' ) { IntrFuncCallEnd(needExpr, 1, narg); }
       } /* end TRY_READ */
     }
 
@@ -758,8 +754,8 @@ void ReadCallVarAss (
         else if ( type == ':' ) { IntrAssRecExpr();               }
         else if ( type == '!' ) { IntrAssComObjName( rnam );      }
         else if ( type == '|' ) { IntrAssComObjExpr();            }
-        else if ( type == 'c' || type == 'C' )
-          { IntrFuncCallEnd( 0UL, type == 'C', narg ); }
+        else if ( type == 'c' ) { IntrFuncCallEnd(0, 0, narg); }
+        else if ( type == 'C' ) { IntrFuncCallEnd(0, 1, narg); }
       } /* end TRY_READ */
     }
 


### PR DESCRIPTION
This PR resolves the code duplication between `ReadReferenceModifiers` and `ReadCallVarAss`, and also inside of `ReadCallVarAss`, by refactoring the code. Key to do this is a new struct `LHSRef` (suggestions for a better name are welcome :-).

Besides the obvious motivation of reducing code duplication, and making `ReadCallVarAss` easier to understand (IMHO), this also lays ground work for implementing the ideas in issue #40: with the refactored code, it becomes much easier to implement support for multiple "lvalues".

(To give a rough idea for the latter: Essentially, in `ReadCallVarAss`, after the loop which invokes `ReadSelector`, we would insert a check for `S_COMMA`. If we see that, we expect to see a "multi assignment" resp. "list unpacking" as described in #40, e.g. `a[1], b, b{poss}[2] := EXPRESSION`. So we parsed `a[1],` at this point; on the object stack (if we are interpreting, similar for coding) is the object stored in variable `a`, and the `LHSRef ref` indicates that we want to assign to `a[1]`. We have to now push `ref` onto a stack (or pop `a` from the stack, combine it with `ref` into an `T_LVALUE` or so, and push that back). Now we just start another `ReadSelector` loop, etc., until we don't get `S_COMMA` anymore, but rather `S_ASSIGN` (anything else will be an error).

Now we have multiple `T_LVALUE`, and we can finally evaluate the RHS expression. We do that, and check that it is a list (else: error) of the right length (else: error). Then start assigning to the lvalues, from left to right.

The hardest part then seems to be coding the list of `T_LVALUE`s and the assignment to them, esp. if we don't want to end up duplicating TONS of code. To this end, we could change the existing assign statements to also use `T_LVALUE`. If done right, that should allow avoid major code duplication for the most part. I.e. `T_ASS_LVAR`, `T_ASS_HVAR`, `T_ASS_GVAR`, etc. would be turned into a `T_LVALUE` encoding the lvar/hvar/gvar/..., followed by a `T_ASSIGN` which references the LHS as a `T_LVALUE`, and the RHS just like now as an arbitrary expression. The function which assigns (the value of) an expression to (the variable/entry reference by) an `T_LVALUE` could then also be called by the `ExecStatFunc` function which deals with the `multi assignment` resp. list unpacking. 

Once all of that is done, it should be very easy to also support minor extensions like `head, *tail := list;` or `a, , c := [1,2,3]` etc. 

Also, we could then start thinking about adding operators `+=`, `-=`, `*=` etc. (also `mod=`, `and=`, ... ??? :). For `LHS += RHS`, the logic would be: "record `T_LVALUE` for the LHS; deref it, then evaluate RHS; perform addition; assign result by using the retained `T_LVALUE`.

It would even be possible to combine this to do  `a, b += [1, 2]` (not saying this is a good idea, just that it'd be not much extra work once the other things are in place).


Anyway: the above sketch may be flawed, or for other reasons never be implemented; but even then, I think the changes in this PR are valuable.