### PR TITLE
Rename GET_CHAR to GET_NEXT_CHAR and add a return value to it; some more scanner+io refactoring

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -215,6 +215,10 @@ Char PEEK_NEXT_CHAR(void)
     return *IO()->RealIn;
 }
 
+Char PEEK_CURR_CHAR(void)
+{
+    return *STATE(In);
+}
 
 const Char * GetInputFilename(void)
 {

--- a/src/io.c
+++ b/src/io.c
@@ -188,7 +188,7 @@ static inline Int IS_CHAR_PUSHBACK_EMPTY(void)
     return STATE(In) != &IO()->Pushback;
 }
 
-void GET_NEXT_CHAR(void)
+Char GET_NEXT_CHAR(void)
 {
     if (STATE(In) == &IO()->Pushback) {
         STATE(In) = IO()->RealIn;
@@ -197,6 +197,7 @@ void GET_NEXT_CHAR(void)
         STATE(In)++;
     if (!*STATE(In))
         GetLine();
+    return *STATE(In);
 }
 
 Char PEEK_NEXT_CHAR(void)

--- a/src/io.c
+++ b/src/io.c
@@ -176,12 +176,10 @@ void LockCurrentOutput(Int lock)
 
 /****************************************************************************
 **
-*F  GET_CHAR()  . . . . . . . . . . . . . . . . get the next character, local
+*F  GET_NEXT_CHAR()  . . . . . . . . . . . . .  get the next character, local
 **
-**  'GET_CHAR' returns the next character from  the current input file.  This
-**  character is afterwards also available as '*In'.
-**
-**  'GET_CHAR' supports a single character pushback (via 'UNGET_CHAR').
+**  'GET_NEXT_CHAR' returns the next character from  the current input file.
+**  This character is afterwards also available as '*In'.
 */
 
 
@@ -190,7 +188,7 @@ static inline Int IS_CHAR_PUSHBACK_EMPTY(void)
     return STATE(In) != &IO()->Pushback;
 }
 
-void GET_CHAR(void)
+void GET_NEXT_CHAR(void)
 {
     if (STATE(In) == &IO()->Pushback) {
         STATE(In) = IO()->RealIn;
@@ -201,14 +199,14 @@ void GET_CHAR(void)
         GetLine();
 }
 
-Char PEEK_CHAR(void)
+Char PEEK_NEXT_CHAR(void)
 {
     assert(IS_CHAR_PUSHBACK_EMPTY());
     // store the current character
     IO()->Pushback = *STATE(In);
 
     // read next character
-    GET_CHAR();
+    GET_NEXT_CHAR();
 
     // fake insert the previous character
     IO()->RealIn = STATE(In);

--- a/src/io.c
+++ b/src/io.c
@@ -1052,39 +1052,37 @@ static Int GetLine2 (
         if ( input->sline == Fail || ! IS_STRING(input->sline) ) {
             return 0;
         }
-        else {
-            ConvString(input->sline);
-            /* we now allow that input->sline actually contains several lines,
-               e.g., it can be a  string from a string stream  */
-            {
-                /***  probably this can be a bit more optimized  ***/
-                register Char * ptr, * bptr;
-                register UInt count, len, max, cbuf;
-                /* start position in buffer */
-                for(cbuf = 0; buffer[cbuf]; cbuf++);
-                /* copy piece of input->sline into buffer and adjust counters */
-                for(count = input->spos,
-                    ptr = (Char *)CHARS_STRING(input->sline) + count,
-                    len = GET_LEN_STRING(input->sline),
-                    max = length-2,
-                    bptr = buffer + cbuf;
-                    cbuf < max && count < len
-                                  && *ptr != '\n' && *ptr != '\r';
-                    *bptr = *ptr, cbuf++, ptr++, bptr++, count++);
-                /* we also copy an end of line if there is one */
-                if (*ptr == '\n' || *ptr == '\r') {
-                    buffer[cbuf] = *ptr;
-                    cbuf++;
-                    count++;
-                }
-                buffer[cbuf] = '\0';
-                input->spos = count;
-                /* if input->stream is a string stream, we have to adjust the
-                   position counter in the stream object as well */
-                if (input->isstringstream) {
-                    ADDR_OBJ(input->stream)[1] = INTOBJ_INT(count);
-                }
-            }
+
+        ConvString(input->sline);
+        /* we now allow that input->sline actually contains several lines,
+           e.g., it can be a  string from a string stream  */
+
+        /* start position in buffer */
+        Char *bptr = buffer;
+        while (*bptr)
+            bptr++;
+
+        /* copy piece of input->sline into buffer and adjust counters */
+        UInt count = input->spos;
+        Char *ptr = (Char *)CHARS_STRING(input->sline) + count;
+        UInt len = GET_LEN_STRING(input->sline);
+        Char *bend = buffer + length - 2;
+        while (bptr < bend && count < len && *ptr != '\n' && *ptr != '\r') {
+            *bptr++ = *ptr++;
+            count++;
+        }
+        /* we also copy an end of line if there is one */
+        if (*ptr == '\n' || *ptr == '\r') {
+            *bptr++ = *ptr++;
+            count++;
+        }
+        *bptr = '\0';
+        input->spos = count;
+
+        /* if input->stream is a string stream, we have to adjust the
+           position counter in the stream object as well */
+        if (input->isstringstream) {
+            ADDR_OBJ(input->stream)[1] = INTOBJ_INT(count);
         }
     }
     else {

--- a/src/io.h
+++ b/src/io.h
@@ -21,7 +21,7 @@
 #include <src/system.h>
 
 
-extern void GET_NEXT_CHAR(void);
+extern Char GET_NEXT_CHAR(void);
 extern Char PEEK_NEXT_CHAR(void);
 
 

--- a/src/io.h
+++ b/src/io.h
@@ -23,6 +23,7 @@
 
 extern Char GET_NEXT_CHAR(void);
 extern Char PEEK_NEXT_CHAR(void);
+extern Char PEEK_CURR_CHAR(void);
 
 
 /****************************************************************************

--- a/src/io.h
+++ b/src/io.h
@@ -21,8 +21,8 @@
 #include <src/system.h>
 
 
-extern void GET_CHAR(void);
-extern Char PEEK_CHAR(void);
+extern void GET_NEXT_CHAR(void);
+extern Char PEEK_NEXT_CHAR(void);
 
 
 /****************************************************************************

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -198,7 +198,7 @@ void GetIdent ( void )
     isQuoted = 0;
 
     /* read all characters into 'STATE(Value)'                                    */
-    Char c = *STATE(In);
+    Char c = PEEK_CURR_CHAR();
     for ( i=0; IsIdent(c) || IsDigit(c) || c=='\\'; i++ ) {
 
         fetch = 1;
@@ -368,7 +368,7 @@ void GetNumber ( UInt StartingStatus )
   UInt seenADigit = (StartingStatus != 0 && StartingStatus != 2);
   UInt seenExpDigit = (StartingStatus ==5);
 
-  c = *STATE(In);
+  c = PEEK_CURR_CHAR();
   if (StartingStatus  <  2) {
     /* read initial sequence of digits into 'Value'             */
     for (i = 0; !wasEscaped && IsDigit(c) && i < SAFE_VALUE_SIZE-1; i++) {
@@ -606,7 +606,7 @@ void GetNumber ( UInt StartingStatus )
 static inline Char GetOctalDigits( void )
 {
     Char result;
-    Char c = *STATE(In);
+    Char c = PEEK_CURR_CHAR();
     if ( c < '0' || c > '7' )
         SyntaxError("Expecting octal digit");
     result = 8 * (c - '0');
@@ -642,7 +642,7 @@ static inline Char CharHexDigit( Char c )
 Char GetEscapedChar( void )
 {
   Char result = 0;
-  Char c = *STATE(In);
+  Char c = PEEK_CURR_CHAR();
 
   if ( c == 'n'  )       result = '\n';
   else if ( c == 't'  )  result = '\t';
@@ -707,7 +707,7 @@ Char GetEscapedChar( void )
 void GetStr ( void )
 {
   Int                 i = 0, fetch;
-  Char c = *STATE(In);
+  Char c = PEEK_CURR_CHAR();
 
   /* read all characters into 'Value'                                    */
   for ( i = 0; i < SAFE_VALUE_SIZE-1 && c != '"'
@@ -784,7 +784,7 @@ void GetStr ( void )
 void GetTripStr ( void )
 {
   Int                 i = 0;
-  Char c = *STATE(In);
+  Char c = PEEK_CURR_CHAR();
 
   /* print only a partial prompt while reading a triple string           */
   if ( !SyQuiet )
@@ -954,7 +954,7 @@ void GetSymbol ( void )
     }
 
 
-    Char c = *STATE(In);
+    Char c = PEEK_CURR_CHAR();
 
   /* if no character is available then get one                           */
   if ( c == '\0' )

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -624,13 +624,18 @@ static inline Char GetOctalDigits( void )
 *F  CharHexDigit( <ch> ) . . . . . . . . .  turn a single hex digit into Char
 **
 */
-static inline Char CharHexDigit( const Char ch ) {
-    if (ch >= 'a') {
-        return (ch - 'a' + 10);
-    } else if (ch >= 'A') {
-        return (ch - 'A' + 10);
+static inline Char CharHexDigit( Char c )
+{
+    c = GET_NEXT_CHAR();
+    if (!IsHexDigit(c)) {
+        SyntaxError("Expecting hexadecimal digit");
+    }
+    if (c >= 'a') {
+        return (c - 'a' + 10);
+    } else if (c >= 'A') {
+        return (c - 'A' + 10);
     } else {
-        return (ch - '0');
+        return (c - '0');
     }
 }
 
@@ -654,15 +659,7 @@ Char GetEscapedChar( void )
        octal numbers */
     c = GET_NEXT_CHAR();
     if (c == 'x') {
-        c = GET_NEXT_CHAR();
-        if (!IsHexDigit(c)) {
-            SyntaxError("Expecting hexadecimal digit");
-        }
         result = 16 * CharHexDigit(c);
-        c = GET_NEXT_CHAR();
-        if (!IsHexDigit(c)) {
-            SyntaxError("Expecting hexadecimal digit");
-        }
         result += CharHexDigit(c);
     } else if (c >= '0' && c <= '7' ) {
         result += GetOctalDigits();


### PR DESCRIPTION
This PR contains some tweaks to the io and scanner code:
* change `GET_CHAR` (now: `GET_NEXT_CHAR`) to also return the new char value
* it renames `GET_CHAR` and `PEEK_CHAR` to `GET_NEXT_CHAR` and `PEEK_NEXT_CHAR`; at least for me, this was very helpful to remember what these functions really do, resp. how they relate to each other. An alternative might be to call them `READ_NEXT_CHAR_AND_ADVANCE` and `READ_NEXT_CHAR` or so... but that feels a bit clumsy. Perhaps somebody has another idea?
* use this to avoid accessing `STATE(In)` in the scanner; the number of lines referencing `STATE(In)` decreases from 108 down to 9.
* add `PEEK_CURR_CHAR` helper, which further reduces the places in `scanner.c` using `STATE(In)` to two, both of which *write* to it:
```
$ git grep -n -F "STATE(In)" src/scanner.c
src/scanner.c:961:    { STATE(In)--;
src/scanner.c:1054:  case '\377': STATE(Symbol) = S_EOF;                        *STATE(In) = '\0';  break;
```

Somewhat unrelated from this, I also cleaned up some code in `GetLine2`, and slightly refactored `CharHexDigit`.


@markuspf does this interfere with unpublished IO work of yours?