### PR TITLE
Modernise random number generation

### DIFF
--- a/lib/random.gd
+++ b/lib/random.gd
@@ -107,7 +107,14 @@ DeclareOperation( "Random", [IsRandomSource, IsInt, IsInt] );
 ##  data which are needed. Optionally, it should allow one to specify a 
 ##  <A>seed</A> for the initial state, as explained for <Ref Oper="Reset"/>.
 ##  <P/>
-##  Most methods for <Ref Oper="Random" Label="for a list or collection"/> 
+##  Random sources should also implement <Ref Oper="Random"
+##  Label="for random source and two integers"/> for a random source and two integers.
+##  All other implementations
+##  of <Ref Oper="Random" BookName="ref"/> call other overloads of
+##  <Ref Oper="Random" BookName="ref"/>, or
+##  <Ref Oper="Random" Label="for random source and two integers"/> for a random source
+##  and two integers.
+##  <P/>
 ##  in the &GAP; library use the 
 ##  <Ref Var="GlobalMersenneTwister"/> as random source. It can be reset 
 ##  into a known state as in the following example.

--- a/lib/random.gi
+++ b/lib/random.gi
@@ -54,9 +54,6 @@ InstallMethod(Random, [IsRandomSource, IsInt, IsInt], function(rs, a, b)
   fi;
 end);
 
-InstallMethod(Random, [IsRandomSource, IsList], function(rs, list)
-  return list[Random(rs, 1, Length(list))];
-end);
 
 # A print method.
 InstallMethod(PrintObj, [IsRandomSource], function(rs)
@@ -231,13 +228,6 @@ else
 InstallValue(GlobalMersenneTwister, RandomSource(IsMersenneTwister, "1"));
 fi;
 
-# default random method for lists and pairs of integers using the Mersenne
-# twister
-InstallMethod( Random, "for an internal list",
-    [ IsList and IsInternalRep ], 100, function(l) 
-  return l[Random(GlobalMersenneTwister, 1, Length(l))]; 
-end );
-
 InstallMethod( Random,
     "for two integers",
     IsIdenticalObj,
@@ -318,3 +308,8 @@ InstallMethodWithRandomSource( Random, "for a random source and a (finite) colle
     [ IsRandomSource, IsCollection and IsFinite ],
     {} -> -RankFilter(IsCollection and IsFinite),
     {rs, C} -> RandomList(rs, Enumerator( C ) ) );
+
+InstallMethodWithRandomSource( Random,
+    "for a random source and a list",
+    [ IsRandomSource, IsList ],
+    {rs, C} -> C[Random(rs,1,Length(C))]);


### PR DESCRIPTION
This cleanups up some random number generation.

The main change here is that random number generators only implement `Random(RandomSource, IsInt, isInt)`. This helps with overloading resolution.

I also add tests for the different generators contained in GAP.