### PR TITLE
Implement PositionsBound.

### DIFF
--- a/doc/ref/lists.xml
+++ b/doc/ref/lists.xml
@@ -1410,6 +1410,7 @@ The latter can be done also using <Ref Func="ListWithIdenticalEntries"/>.
 <#Include Label="PositionProperty">
 <#Include Label="PositionsProperty">
 <#Include Label="PositionBound">
+<#Include Label="PositionsBound">
 <#Include Label="PositionNot">
 <#Include Label="PositionNonZero">
 <#Include Label="PositionSublist">

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -985,7 +985,7 @@ DeclareOperation( "PositionsProperty", [ IsList, IsFunction ] );
 ##  <Oper Name="PositionBound" Arg='list'/>
 ##
 ##  <Description>
-##  returns the first index for which an element is bound in the list
+##  returns the first bound position of the list
 ##  <A>list</A>.
 ##  For the empty list it returns <K>fail</K>.
 ##  <P/>
@@ -1000,6 +1000,34 @@ DeclareOperation( "PositionsProperty", [ IsList, IsFunction ] );
 ##  <#/GAPDoc>
 ##
 DeclareOperation( "PositionBound", [ IsList ] );
+
+
+#############################################################################
+##
+#O  PositionsBound( <list> ) . . . . . . . . . positions of all bound entries
+##
+##  <#GAPDoc Label="PositionsBound">
+##  <ManSection>
+##  <Oper Name="PositionsBound" Arg='list'/>
+##
+##  <Description>
+##  returns the set of all bound positions in the list
+##  <A>list</A>.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> PositionsBound([1,2,3]);
+##  [ 1 .. 3 ]
+##  gap> PositionsBound([,1,,3]);
+##  [ 2, 4 ]
+##  gap> PositionsBound([]);
+##  []
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction( "PositionsBound", [IsList] );
+
 
 
 #############################################################################

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -1694,6 +1694,28 @@ InstallMethod( PositionBound,
 
 #############################################################################
 ##
+#M  PositionsBound( <list> ) . . . . . . . . . positions of all bound entries
+##
+InstallGlobalFunction( PositionsBound, function( list )
+    local i, bound;
+
+    if IsDenseList( list ) then
+        return [ 1 .. Length( list ) ];
+    fi;
+
+    bound := [];
+    for i in [ 1 .. Length( list ) ] do
+        if IsBound( list[i] )  then
+            Add( bound, i );
+        fi;
+    od;
+
+    return bound;
+end );
+
+
+#############################################################################
+##
 #M  PositionSublist( <list>,<sub>[,<ind>] )
 ##
 InstallMethod( PositionSublist,


### PR DESCRIPTION
Currently there is no library method to return the set of all bound
entries of a list. This commit implements this functionality in an
efficient manner.

To see the effect consider the following time difference:
```
gap> t := 10^7;
10000000
gap> L := [];
[  ]
gap> L[t] := t;;
gap> Filtered( [1..Length(L)], i -> IsBound(L[i]) ); time;
[ 10000000 ]
637
gap> R := Runtime();
2198
gap> res := [];;
gap> pos := 1;;
gap> for i in [1..Length(L)] do
> if IsBound(L[i]) then
> res[pos] := i;
> pos := pos+1;
> fi;
> od;
gap> res;
[ 10000000 ]
gap> Runtime() - R;
239
gap>
```