### PR TITLE
Let travis test all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@
 dist: trusty
 language: c
 
-branches:
-  only:
-  - master
-  - /^stable-.*$/
-  - MatrixObj2
-
 env:
   global:
     - CFLAGS="-fprofile-arcs -ftest-coverage -O2"


### PR DESCRIPTION
This is most useful in forks, where developers want their branches
to be tested before they make a PR.

I could maintain a seperate .travis.yml in my own fork, but I'd prefer not to.