### PR TITLE
Removed function for ValueGlobal

### DIFF
--- a/lib/global.gi
+++ b/lib/global.gi
@@ -74,14 +74,7 @@ end;
 ##  is currently bound
 ##
 
-InstallGlobalFunction( ValueGlobal, 
-        function (name)
-    local val;
-    CheckGlobalName( name );
-    val := VALUE_GLOBAL(name);
-    Info( InfoGlobal, 3, "ValueGlobal: access to ",name," returned ",val); 
-    return val;
-end);
+InstallGlobalFunction( ValueGlobal, VALUE_GLOBAL );
 
 
 #############################################################################


### PR DESCRIPTION
and made it a synonym of `VALUE_GLOBAL`.

The check if the argument of `ValueGlobal` is a string is done by `VALUE_GLOBAL`, too, so this check is not necessary.

The fact if all characters in the argument string are in `IdentifierLetters` does not cause an error, just an info. Furthermore, variables with different characters in their identifier, e.g., `\ `, can still be written to and accessed.