### PR TITLE
Remove DEBUG_LOADING, InfoRead1, and InfoRead2

### DIFF
--- a/lib/files.gi
+++ b/lib/files.gi
@@ -202,23 +202,23 @@ InstallMethod( Read,
     "string",
     [ IsString ],
 function ( name )
-    local   readIndent,  found;
+    local readIndent;
 
-    name := UserHomeExpand(name);
-
-    readIndent := SHALLOW_COPY_OBJ( READ_INDENT );
-    APPEND_LIST_INTR( READ_INDENT, "  " );
     if GAPInfo.CommandLineOptions.D then
-    	Print( "#I", READ_INDENT, "Read( \"", name, "\" )\n" );
+        readIndent := SHALLOW_COPY_OBJ( READ_INDENT );
+        APPEND_LIST_INTR( READ_INDENT, "  " );
+        Print( "#I", READ_INDENT, "Read( \"", name, "\" )\n" );
     fi;
-    found := (IsReadableFile(name)=true) and READ(name);
-    READ_INDENT := readIndent;
-    if GAPInfo.CommandLineOptions.D and
-       found and READ_INDENT = ""  then
-        Print( "#I  Read( \"", name, "\" ) done\n" );
-    fi;
-    if not found  then
+
+    if not READ(UserHomeExpand(name)) then
         Error( "file \"", name, "\" must exist and be readable" );
+    fi;
+
+    if GAPInfo.CommandLineOptions.D then
+        READ_INDENT := readIndent;
+        if READ_INDENT = "" then
+            Print( "#I  Read( \"", name, "\" ) done\n" );
+        fi;
     fi;
 end );
 

--- a/lib/files.gi
+++ b/lib/files.gi
@@ -208,11 +208,14 @@ function ( name )
 
     readIndent := SHALLOW_COPY_OBJ( READ_INDENT );
     APPEND_LIST_INTR( READ_INDENT, "  " );
-    InfoRead1( "#I", READ_INDENT, "Read( \"", name, "\" )\n" );
+    if GAPInfo.CommandLineOptions.D then
+    	Print( "#I", READ_INDENT, "Read( \"", name, "\" )\n" );
+    fi;
     found := (IsReadableFile(name)=true) and READ(name);
     READ_INDENT := readIndent;
-    if found and READ_INDENT = ""  then
-        InfoRead1( "#I  Read( \"", name, "\" ) done\n" );
+    if GAPInfo.CommandLineOptions.D and
+       found and READ_INDENT = ""  then
+        Print( "#I  Read( \"", name, "\" ) done\n" );
     fi;
     if not found  then
         Error( "file \"", name, "\" must exist and be readable" );

--- a/lib/init.g
+++ b/lib/init.g
@@ -142,15 +142,6 @@ end;
 
 #############################################################################
 ##
-#V  InfoRead? . . . . . . . . . . . . . . . . . . . . print what file is read
-##
-if DEBUG_LOADING           then InfoRead1 := Print;   fi;
-if not IsBound(InfoRead1)  then InfoRead1 := Ignore;  fi;
-if not IsBound(InfoRead2)  then InfoRead2 := Ignore;  fi;
-
-
-#############################################################################
-##
 #V  CHECK_INSTALL_METHOD  . . . . . .  check requirements in `INSTALL_METHOD'
 ##
 CHECK_INSTALL_METHOD := true;
@@ -234,20 +225,11 @@ fi;
 
 #############################################################################
 ##
-##  - Unbind `DEBUG_LOADING', since later the `-D' option can be checked.
 ##  - Set or disable break loop according to the `-T' option.
 ##  - Set whether traceback may be suppressed (e.g. by `-T') according to the
 ##    `--alwaystrace' option.
 ##
 CallAndInstallPostRestore( function()
-    if DEBUG_LOADING then
-      InfoRead1:= Print;
-    else
-      InfoRead1:= Ignore;
-    fi;
-    MAKE_READ_WRITE_GLOBAL( "DEBUG_LOADING" );
-    UNBIND_GLOBAL( "DEBUG_LOADING" );
-
     if IsHPCGAP then
       # In HPC-GAP we want to decide how to handle errors on a per thread
       # basis. E.g. the break loop can be disabled in a worker thread that
@@ -269,7 +251,9 @@ CallAndInstallPostRestore( function()
 end);
 
 ReadOrComplete := function(name)
-    InfoRead1( "#I  reading ", name, "\n" );
+    if GAPInfo.CommandLineOptions.D then
+        Print( "#I  reading ", name, "\n" );
+    fi;
     if not READ_GAP_ROOT( name ) then
         Error( "cannot read file ", name );
     fi;

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -681,6 +681,17 @@ DeclareObsoleteSynonym( "RecFields", "RecNames" );
 ##  Not used in any redistributed package (11/2018)
 #DeclareObsoleteSynonym( "SHALLOW_SIZE", "SIZE_OBJ" );
 
+
+#############################################################################
+##
+#V  InfoRead? 
+##
+##  InfoRead used to be used to print when a file is read using `Read()`
+##  
+if GAPInfo.CommandLineOptions.D then InfoRead1 := Print; fi;
+if not IsBound(InfoRead1) then InfoRead1 := Ignore; fi;
+if not IsBound(InfoRead2) then InfoRead2 := Ignore; fi;
+
 #############################################################################
 ##
 #E

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -224,7 +224,6 @@ DeclareObsoleteSynonym( "ReadPkg", "ReadPackage" );
 #BindGlobal( "VERSION", GAPInfo.Version );
 BindGlobal( "GAP_ARCHITECTURE", GAPInfo.Architecture );
 #BindGlobal( "GAP_ROOT_PATHS", GAPInfo.RootPaths );
-BindGlobal( "DEBUG_LOADING", GAPInfo.CommandLineOptions.D );
 BindGlobal( "BANNER", not GAPInfo.CommandLineOptions.b );
 BindGlobal( "QUIET", GAPInfo.CommandLineOptions.q );
 #BindGlobal( "LOADED_PACKAGES", GAPInfo.PackagesLoaded );

--- a/lib/system.g
+++ b/lib/system.g
@@ -409,11 +409,6 @@ CallAndInstallPostRestore( function()
     GAPInfo.CommandLineOptions:= CommandLineOptions;
     GAPInfo.InitFiles:= InitFiles;
 
-    # Switch on debugging (`-D' option) when GAP is started with a workspace.
-    if GAPInfo.CommandLineOptions.D then
-      InfoRead1:= Print;
-    fi;
-
     padspace := function(strlen, len)
       local i;
       for i in [strlen+1..len] do

--- a/src/gap.c
+++ b/src/gap.c
@@ -1635,14 +1635,6 @@ static Int InitKernel (
 static Int PostRestore (
     StructInitInfo *    module )
 {
-      UInt var;
-
-    /* library name and other stuff                                        */
-    var = GVarName( "DEBUG_LOADING" );
-    MakeReadWriteGVar(var);
-    AssGVar( var, (SyDebugLoading ? True : False) );
-    MakeReadOnlyGVar(var);
-
     /* construct the `ViewObj' variable                                    */
     ViewObjGVar = GVarName( "ViewObj" ); 
 


### PR DESCRIPTION
They are a leftover of a legacy debugging mechanism. `InfoRead1` and `InfoRead2` are moved into `obsoletes.gd`.

Unfortunately the following packages still refer to `InfoRead1` or `InfoRead2`:

- [ ] atlasrep (uses `InfoRead1` for info output, should be replaced by `Info()`)
- [ ] gbnp (only saves and restores state in tests)
- [x] guava (only saves and restores state) done in https://github.com/gap-packages/guava/pull/33 
- [x] hecke (spurious misuse of `InfoRead1`): TODO https://github.com/gap-packages/hecke/issues/5
- [x] xgap: TODO https://github.com/gap-packages/xgap/issues/7

These packages will break with this PR if GAP is started without obsoletes.