### PR TITLE
InstallImmediateMethod: make rank optional, tweak docs

### DIFF
--- a/hpcgap/src/c_oper1.c
+++ b/hpcgap/src/c_oper1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include <src/compiled.h>
-#define FILE_CRC  "25918424"
+#define FILE_CRC  "452946"
 
 /* global variables used in handlers */
 static GVar G_REREADING;
@@ -1383,13 +1383,20 @@ static Obj  HdlrFunc6 (
  }
  /* fi */
  
- /* if IS_STRING_REP( arglist[2] ) then */
- t_3 = GF_IS__STRING__REP;
- C_ELM_LIST_FPL( t_4, a_arglist, INTOBJ_INT(2) )
- t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
- t_1 = (Obj)(UInt)(t_2 != False);
+ /* if IS_STRING_REP( arglist[2] ) or arglist[2] = false then */
+ t_4 = GF_IS__STRING__REP;
+ C_ELM_LIST_FPL( t_5, a_arglist, INTOBJ_INT(2) )
+ t_3 = CALL_1ARGS( t_4, t_5 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
+ t_2 = (Obj)(UInt)(t_3 != False);
+ t_1 = t_2;
+ if ( ! t_1 ) {
+  C_ELM_LIST_FPL( t_4, a_arglist, INTOBJ_INT(2) )
+  t_5 = False;
+  t_3 = (Obj)(UInt)(EQ( t_4, t_5 ));
+  t_1 = t_3;
+ }
  if ( t_1 ) {
   
   /* info := arglist[2]; */
@@ -4012,7 +4019,7 @@ static Obj  HdlrFunc1 (
       if not IS_OPERATION( opr ) then
           Error( "<opr> is not an operation" );
       fi;
-      if IS_STRING_REP( arglist[2] ) then
+      if IS_STRING_REP( arglist[2] ) or arglist[2] = false then
           info := arglist[2];
           pos := 3;
       else
@@ -4695,7 +4702,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "GAPROOT/lib/oper1.g",
- .crc         = 25918424,
+ .crc         = 452946,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -421,7 +421,7 @@ end );
 
 #############################################################################
 ##
-#F  InstallImmediateMethod( <opr>[, <info>], <filter>, <rank>, <method> )
+#F  InstallImmediateMethod( <opr>[, <info>], <filter>[, <rank>], <method> )
 ##
 ##  <#GAPDoc Label="InstallImmediateMethod">
 ##  <ManSection>
@@ -431,7 +431,8 @@ end );
 ##  <Description>
 ##  <Ref Func="InstallImmediateMethod"/> installs <A>method</A> as an
 ##  immediate method for <A>opr</A>, which must be an attribute or a
-##  property, with requirement <A>filter</A> and rank <A>rank</A>.
+##  property, with requirement <A>filter</A> and rank <A>rank</A>
+##  (the rank can be omitted, in which case 0 is used as rank).
 ##  The rank must be an integer value that measures the priority of
 ##  <A>method</A> among the immediate methods for <A>opr</A>.
 ##  If supplied, <A>info</A> should be a short but informative string
@@ -489,25 +490,52 @@ end );
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL( "InstallImmediateMethod", function( arg )
+    local pos, opr, info, filter, rank, method;
 
-    if     LEN_LIST( arg ) = 4
-       and IS_OPERATION( arg[1] )
-       and IsFilter( arg[2] )
-       and IS_RAT( arg[3] )
-       and IS_FUNCTION( arg[4] ) then
-        INSTALL_IMMEDIATE_METHOD( arg[1], false, arg[2], arg[3], arg[4] );
-        INSTALL_METHOD( [ arg[1], [ arg[2] ], arg[4] ], false );
-    elif   LEN_LIST( arg ) = 5
-       and IS_OPERATION( arg[1] )
-       and IS_STRING( arg[2] )
-       and IsFilter( arg[3] )
-       and IS_RAT( arg[4] )
-       and IS_FUNCTION( arg[5] ) then
-        INSTALL_IMMEDIATE_METHOD( arg[1], arg[2], arg[3], arg[4], arg[5] );
-        INSTALL_METHOD( [ arg[1], arg[2], [ arg[3] ], arg[5] ], false );
+    pos := 1;
+
+    if pos <= LEN_LIST( arg ) and IS_OPERATION( arg[pos] ) then
+        opr := arg[pos];
+        pos := pos + 1;
     else
-      Error("usage: InstallImmediateMethod(<opr>,<filter>,<rank>,<method>)");
+        pos := -1;
     fi;
+
+    if pos <= LEN_LIST( arg ) and IS_STRING( arg[pos] ) then
+        info := arg[pos];
+        pos := pos + 1;
+    else
+        info := false;
+    fi;
+
+    if pos <= LEN_LIST( arg ) and IsFilter( arg[pos] ) then
+        filter := arg[pos];
+        pos := pos + 1;
+    else
+        pos := -1;
+    fi;
+
+    if pos <= LEN_LIST( arg ) and IS_RAT( arg[pos] ) then
+        rank := arg[pos];
+        pos := pos + 1;
+    else
+        rank := 0;
+    fi;
+
+    if pos <= LEN_LIST( arg ) and IS_FUNCTION( arg[pos] ) then
+        method := arg[pos];
+        pos := pos + 1;
+    else
+        pos := -1;
+    fi;
+
+    if pos = LEN_LIST( arg ) + 1 then
+        INSTALL_IMMEDIATE_METHOD( opr, info, filter, rank, method );
+        INSTALL_METHOD( [ opr, info, [ filter ], method ], false );
+    else
+        Error("usage: InstallImmediateMethod( <opr>[, <info>], <filter>, <rank>, <method> )");
+    fi;
+
 end );
 
 

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -381,7 +381,7 @@ BIND_GLOBAL( "INSTALL_METHOD",
 
     # Check whether an info string is given,
     # or whether the list of argument filters is given by a list of strings.
-    if IS_STRING_REP( arglist[2] ) then
+    if IS_STRING_REP( arglist[2] ) or arglist[2] = false then
       info:= arglist[2];
       pos:= 3;
     else

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include <src/compiled.h>
-#define FILE_CRC  "25918424"
+#define FILE_CRC  "452946"
 
 /* global variables used in handlers */
 static GVar G_REREADING;
@@ -1336,13 +1336,20 @@ static Obj  HdlrFunc6 (
  }
  /* fi */
  
- /* if IS_STRING_REP( arglist[2] ) then */
- t_3 = GF_IS__STRING__REP;
- C_ELM_LIST_FPL( t_4, a_arglist, INTOBJ_INT(2) )
- t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
- t_1 = (Obj)(UInt)(t_2 != False);
+ /* if IS_STRING_REP( arglist[2] ) or arglist[2] = false then */
+ t_4 = GF_IS__STRING__REP;
+ C_ELM_LIST_FPL( t_5, a_arglist, INTOBJ_INT(2) )
+ t_3 = CALL_1ARGS( t_4, t_5 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
+ t_2 = (Obj)(UInt)(t_3 != False);
+ t_1 = t_2;
+ if ( ! t_1 ) {
+  C_ELM_LIST_FPL( t_4, a_arglist, INTOBJ_INT(2) )
+  t_5 = False;
+  t_3 = (Obj)(UInt)(EQ( t_4, t_5 ));
+  t_1 = t_3;
+ }
  if ( t_1 ) {
   
   /* info := arglist[2]; */
@@ -3927,7 +3934,7 @@ static Obj  HdlrFunc1 (
       if not IS_OPERATION( opr ) then
           Error( "<opr> is not an operation" );
       fi;
-      if IS_STRING_REP( arglist[2] ) then
+      if IS_STRING_REP( arglist[2] ) or arglist[2] = false then
           info := arglist[2];
           pos := 3;
       else
@@ -4594,7 +4601,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "GAPROOT/lib/oper1.g",
- .crc         = 25918424,
+ .crc         = 452946,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,


### PR DESCRIPTION
Clarify in the InstallImmediateMethod documentation that <info> is
an optional argument. Moreover, make the <rank> optional, too
(if omitted, 0 is used as default value).