### PR TITLE
Fix TriangulizedMat([])

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -2949,6 +2949,9 @@ local m;
   return m;
 end);
 
+InstallOtherMethod( TriangulizedMat, "for an empty list", [ IsList and IsEmpty ],
+mat -> []);
+
 #############################################################################
 ##
 #M  UpperSubdiagonal( <mat>, <pos> )

--- a/tst/testinstall/opers/TriangulizedMat.tst
+++ b/tst/testinstall/opers/TriangulizedMat.tst
@@ -1,0 +1,33 @@
+gap> START_TEST("TriangulizedMat.tst");
+
+#
+gap> a:=[];;
+gap> b:=TriangulizedMat(a);
+[  ]
+gap> a = [];
+true
+gap> IsIdenticalObj(a, b);
+false
+
+#
+gap> a:=[[42]];;
+gap> b:=TriangulizedMat(a);
+[ [ 1 ] ]
+gap> a = [[42]];
+true
+
+#
+gap> a:=[[Z(7)]];;
+gap> b:=TriangulizedMat(a);
+[ [ Z(7)^0 ] ]
+gap> a = [[Z(7)]];
+true
+
+#
+gap> TriangulizedMat([[1,2],[3,4]]);
+[ [ 1, 0 ], [ 0, 1 ] ]
+gap> TriangulizedMat([[1,2],[3,6]]);
+[ [ 1, 2 ], [ 0, 0 ] ]
+
+#
+gap> STOP_TEST("TriangulizedMat.tst", 1);


### PR DESCRIPTION
This PR ensures that `TriangulizedMat([])` returns an empty list / matrix, instead of triggering an error.

This in turn fixes a regression in the modisom package in GAP 4.9 (compared to GAP 4.8 and before), see https://github.com/gap-packages/modisom/issues/2

This change should be cherry-picked to stable-4.9