### PR TITLE
Handle spaces in filenames of gziped filenames

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -240,10 +240,12 @@ static void fopenMaybeCompressed(char* name, struct ProfileState* ps)
 {
 #ifdef HAVE_POPEN
   char popen_buf[4096];
-  if(endsWithgz(name) && strlen(name) < 3000)
+  // Need space for "gzip < '", ".gz'" and terminating \0.
+  if(endsWithgz(name) && strlen(name) < sizeof(popen_buf) - 8 - 4 - 1)
   {
-    strcpy(popen_buf, "gzip > ");
-    strcat(popen_buf, name);
+    strxcpy(popen_buf, "gzip > '", sizeof(popen_buf));
+    strxcat(popen_buf, name, sizeof(popen_buf));
+    strxcat(popen_buf, "'", sizeof(popen_buf));
     ps->Stream = popen(popen_buf, "w");
     ps->StreamWasPopened = 1;
     return;

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -828,12 +828,14 @@ Int SyFopen (
 
     /* set up <namegz> and <cmd> for pipe command                          */
     namegz[0] = '\0';
-    if (strlen(name) <= 1018) {
+    // Need space for "gunzip < '", ".gz'" and terminating \0.
+    if (strlen(name) <= sizeof(cmd) - 10 - 4 - 1) {
       strxcpy( namegz, name, sizeof(namegz) );
       strxcat( namegz, ".gz", sizeof(namegz) );
 
-      strxcpy( cmd, "gunzip <", sizeof(cmd) );
+      strxcpy( cmd, "gunzip < '", sizeof(cmd) );
       strxcat( cmd, namegz, sizeof(cmd) );
+      strxcat( cmd, "'", sizeof(cmd) );
     }
     if (strncmp( mode, "r", 1 ) == 0)
       flags = O_RDONLY;


### PR DESCRIPTION
Wrap filenames we pass to gzip/gunzip via shell in single quotes,
so we handle spaces and some other characters which need escaping.

This does not handle all possible filenames which could cause a
problem, but hopefully covers most which will arise in practice.

Resolves #2264