### PR TITLE
Random source for additive cosets, grpnice and external orbits

### DIFF
--- a/lib/addcoset.gi
+++ b/lib/addcoset.gi
@@ -142,11 +142,11 @@ InstallMethod( IsFinite,
 ##
 #M  Random( <A> ) . . . . . . . . . . . . . . . . . . . . for additive cosets
 ##
-InstallMethod( Random,
-    "for an additive coset",
+InstallMethodWithRandomSource( Random,
+    "for a random source and an additive coset",
     true,
-    [ IsAdditiveCoset ], 0,
-    A -> Representative( A ) + Random( AdditivelyActingDomain( A ) ) );
+    [ IsRandomSource, IsAdditiveCoset ], 0,
+    {rs, A} -> Representative( A ) + Random( rs, AdditivelyActingDomain( A ) ) );
 
 
 #############################################################################

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -267,7 +267,7 @@ end );
 
 
 RedispatchOnCondition(Random,true,[IsCollection],[IsFinite],0);
-RedispatchOnCondition(Random,true,[IsRandomSource,IsCollection],[IsFinite],0);
+RedispatchOnCondition(Random,true,[IsRandomSource,IsCollection],[,IsFinite],0);
 
 #############################################################################
 ##

--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -783,7 +783,7 @@ SubgroupMethodByNiceMonomorphism( RadicalGroup,
 ##
 #M  Random( <G> )
 ##
-InstallMethod( Random,
+InstallMethodWithRandomSource( Random,
     "for a random source and a group handled by nice monomorphism",
     [ IsRandomSource, IsGroup and IsHandledByNiceMonomorphism ], 0,
     {rs, G} -> PreImagesRepresentative( NiceMonomorphism( G ),

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -294,15 +294,16 @@ function( xset )
   return Orbit(xset,Representative(xset));
 end);
 
-InstallMethod( Random,"for external orbit: via acting domain", true,
-  [ IsExternalOrbit ], 0,
-function( xset )
+InstallMethodWithRandomSource( Random,
+	"for a random source and for an external orbit: via acting domain", true,
+  [ IsRandomSource, IsExternalOrbit ], 0,
+function( rs, xset )
   if HasHomeEnumerator(xset) and not IsPlistRep(HomeEnumerator(xset)) then
     TryNextMethod(); # can't do orbit because the home enumerator might
     # imply a different `PositionCanonical' (and thus equivalence of objects)
     # method.
   fi;
-  return FunctionAction(xset)(Representative(xset),Random(ActingDomain(xset)));
+  return FunctionAction(xset)(Representative(xset),Random(rs, ActingDomain(xset)));
 end);
 
 #############################################################################

--- a/tst/testinstall/random.tst
+++ b/tst/testinstall/random.tst
@@ -119,6 +119,21 @@ gap> rm:= FreeMagmaRing( GF(2), a );;
 gap> randomTest(AdditiveCoset(rm, rm.1), Random);
 
 #
+# external orbits
+#
+gap> g:=DihedralGroup(8);; orbs:=ExternalOrbits(g,AsList(g));;
+gap> for orb in orbs do
+> randomTest(orb,Random);
+> od;
+
+#
+gap> g:=SymmetricGroup(4);;
+gap> orbs:=ExternalOrbits(g,[1..4]);;
+gap> for orb in orbs do
+> randomTest(orb,Random);
+> od;
+
+#
 # other stuff
 #
 

--- a/tst/testinstall/random.tst
+++ b/tst/testinstall/random.tst
@@ -106,6 +106,19 @@ gap> randomTest(GL(2,2), Random);
 gap> randomTest(GL(3,3), Random);
 
 #
+# additive cosets
+#
+gap> randomTest(AdditiveCoset(ZmodnZ(1),Identity(ZmodnZ(1))),Random);
+gap> randomTest(AdditiveCoset(Integers,2),Random);
+gap> randomTest(AdditiveCoset(CF(5),-2/3*E(5)-1/2*E(5)^2+1/3*E(5)^4),Random);
+gap> randomTest(AdditiveCoset(GF(17),Z(17)^9),Random);
+gap> R := SmallRing(10,2);;
+gap> randomTest(AdditiveCoset(R,5*R.1),Random);
+gap> a:= Algebra( GF(2), [ [ [ Z(2) ] ] ] );;
+gap> rm:= FreeMagmaRing( GF(2), a );;
+gap> randomTest(AdditiveCoset(rm, rm.1), Random);
+
+#
 # other stuff
 #
 


### PR DESCRIPTION
This begins to address some of the points raised in issue #1098 .
In particular we:
- Change Random for Additive Cosets to use InstallWithRandomSource.
- Add tests for Random on Additive Cosets into random.tst .
- Add a missing comma in coll.gi.
