### PR TITLE
kernel: ensure uniform printing of macfloats nan, inf, -inf

### DIFF
--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -50,18 +50,39 @@ Obj TypeMacfloat (
 }
 
 
+// helper function for printing a "decimal" representation of a macfloat
+// into a buffer.
+static void PrintMacfloatToBuf(char *buf, size_t bufsize, Double val, int precision)
+{
+    // handle printing of NaN and infinities ourselves, to ensure
+    // they are printed uniformly across all platforms
+    if (isnan(val)) {
+        strcpy(buf, "nan");
+    }
+    else if (isinf(val)) {
+        if (val > 0)
+            strcpy(buf, "inf");
+        else
+            strcpy(buf, "-inf");
+    }
+    else {
+        snprintf(buf, bufsize, "%.*" PRINTFFORMAT, precision, val);
+    }
+}
+
+
 /****************************************************************************
 **
-*F  PrintMacfloat( <macfloat> ) . . . . . . . . . . . . . . . . print a macfloat value
+*F  PrintMacfloat( <macfloat> ) . . . . . . . . . . .  print a macfloat value
 **
 **  'PrintMacfloat' prints the macfloating value <macfloat>.
 */
-void PrintMacfloat (
-    Obj                 x )
+void PrintMacfloat(Obj x)
 {
-  Char buf[32];
-  snprintf(buf, sizeof(buf), "%.16" PRINTFFORMAT, (TOPRINTFFORMAT) VAL_MACFLOAT(x));
-  Pr("%s",(Int)buf, 0);
+    Char buf[32];
+    // TODO: should we use PRINTFDIGITS instead of 16?
+    PrintMacfloatToBuf(buf, sizeof(buf), VAL_MACFLOAT(x), 16);
+    Pr("%s", (Int)buf, 0);
 }
 
 
@@ -418,7 +439,7 @@ Obj FuncSTRING_DIGITS_MACFLOAT( Obj self, Obj gapprec, Obj f)
   int prec = INT_INTOBJ(gapprec);
   if (prec > 40) /* too much anyways, and would risk buffer overrun */
     prec = 40;
-  snprintf(buf, sizeof(buf), "%.*" PRINTFFORMAT, prec, (TOPRINTFFORMAT)VAL_MACFLOAT(f));
+  PrintMacfloatToBuf(buf, sizeof(buf), VAL_MACFLOAT(f), prec);
   str = MakeString(buf);
   return str;
 }

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -370,7 +370,7 @@ Obj FuncSIGN_MACFLOAT( Obj self, Obj f )
 {
   Double vf = VAL_MACFLOAT(f);
   
-  return vf == 0. ? INTOBJ_INT(0) : vf > 0. ? INTOBJ_INT(1) : INTOBJ_INT(-1);
+  return vf == 0. ? INTOBJ_INT(0) : signbit(vf) ? INTOBJ_INT(-1) : INTOBJ_INT(1);
 }
 
 Obj FuncSIGNBIT_MACFLOAT( Obj self, Obj f )

--- a/src/macfloat.h
+++ b/src/macfloat.h
@@ -17,14 +17,12 @@
 
 #ifdef VERY_LONG_DOUBLES
 typedef long double /* __float128 */ Double;
-#define TOPRINTFFORMAT long double
 #define PRINTFDIGITS 20
 #define PRINTFFORMAT "Lg"
 #define STRTOD strtold
 #define MATH(name) name##l
 #else
 typedef double Double;
-#define TOPRINTFFORMAT double
 #define PRINTFDIGITS 16
 #define PRINTFFORMAT "g"
 #define STRTOD strtod

--- a/tst/testinstall/float.tst
+++ b/tst/testinstall/float.tst
@@ -27,10 +27,26 @@ gap> Float(2/3);
 0.666667
 gap> Float("-4");
 -4.
+gap> Float("4.1");
+4.1
+gap> Float("4.1e-1");
+0.41
+gap> Float(infinity);
+inf
+gap> Float(-infinity);
+-inf
+
+#
+# input floats directly
+#
 gap> 0.6;
 0.6
 gap> -0.7;
 -0.7
+
+#
+# some arithmetic
+#
 gap> 355.0/113.0;
 3.14159
 gap> last = 355.0/113;
@@ -55,9 +71,11 @@ gap> 355/113.0 - 355.0/113;
 0.
 gap> 355/113.0 = 355.0/113;
 true
-gap> 355.0/113.0;
-3.14159
-gap> Rat(last);
+
+#
+# convert floats to other types
+#
+gap> Rat(355.0/113.0);
 355/113
 gap> Int(1.0);
 1
@@ -71,6 +89,10 @@ gap> Rat(0.5);
 1/2
 gap> Rat(0.0);
 0
+
+#
+#
+#
 gap> Sqrt(2.0);
 1.41421
 gap> MinimalPolynomial(Rationals,last);
@@ -135,16 +157,22 @@ gap> Exp(last);
 0.948683
 gap> last^2;
 0.9
+
+#
+# some tests with infinity
+#
 gap> 1.0/0.0;
 inf
 gap> -1.0/0.0;
 -inf
-gap> -Float(infinity) = Float(-infinity);
+gap> List([posinf, neginf, nan, 0.0, 1.0], IsPInfinity);
+[ true, false, false, false, false ]
+gap> List([posinf, neginf, nan, 0.0, 1.0], IsNInfinity);
+[ false, true, false, false, false ]
+gap> -posinf = neginf;
 true
-gap> posinf := Float(infinity);
-inf
-gap> neginf := Float(-infinity);
--inf
+gap> posinf = -neginf;
+true
 gap> neginf < posinf;
 true
 gap> neginf <> posinf;

--- a/tst/testinstall/float.tst
+++ b/tst/testinstall/float.tst
@@ -4,7 +4,21 @@
 ##
 ##
 gap> START_TEST("float.tst");
+
+# make sure we are testing the built-in machine floats
 gap> SetFloats(IEEE754FLOAT);
+
+# some special values we will use again later on
+gap> posinf := 1.0/0.0;
+inf
+gap> neginf := -1.0/0.0;
+-inf
+gap> nan := 0.0/0.0;
+nan
+
+#
+# Convert things to floats
+#
 gap> Float(3);
 3.
 gap> Float(-4);
@@ -145,6 +159,45 @@ gap> -MakeFloat(1.0, infinity) = neginf;
 true
 gap> MakeFloat(1.0, -infinity) = neginf;
 true
+
+#
+# test sign handling
+#
+gap> SignBit(posinf);
+false
+gap> SignFloat(posinf);
+1
+gap> SignBit(neginf);
+true
+gap> SignFloat(neginf);
+-1
+gap> SignBit(+0.0);
+false
+gap> SignFloat(+0.0);
+0
+gap> SignBit(-0.0);
+true
+gap> SignFloat(-0.0);
+0
+gap> SignBit(42.0);
+false
+gap> SignFloat(42.0);
+1
+gap> SignBit(-42.0);
+true
+gap> SignFloat(-42.0);
+-1
+
+# sign of NaN is machine specific; but we can still test whether
+# SignBit and SignFloat return consistent results
+gap> SignBit(nan) = (SignFloat(nan) = -1);
+true
+gap> SignBit(-nan) = (SignFloat(-nan) = -1);
+true
+
+#
+# test float comparison
+#
 
 #
 gap> EqFloat(1.0, 1.1);


### PR DESCRIPTION
On some platforms, NaN values might be printed as `nan`, on others as `NaN`;
on some, the sign of the Nan value may be printed, on other not so (and the
sign of a NaN is something which highly depends on the float implementation to
start with).

This made it difficult to write tests which rely on the way these values are
printed. Hence we now deal with these values explicitly and in a manner which
produces identical results across all platforms.

Fixes #2193