### PR TITLE
Fix incorrect IsFinitelyGeneratedMonoid method

### DIFF
--- a/lib/monofree.gi
+++ b/lib/monofree.gi
@@ -260,6 +260,7 @@ InstallGlobalFunction( FreeMonoid, function( arg )
       SetIsTrivial( M, false );
       SetIsFinite( M, false );
       SetIsCommutative(M, false );
+      SetIsFinitelyGeneratedMonoid(M, false);
     fi;
 
     SetIsFreeMonoid( M, true);

--- a/lib/monoid.gi
+++ b/lib/monoid.gi
@@ -304,7 +304,10 @@ end);
 InstallMethod( IsFinitelyGeneratedMonoid, "for a monoid",
                [ IsMonoid and HasGeneratorsOfMonoid ],
 function(M)
-    return IsFinite(GeneratorsOfMonoid(M));
+    if IsFinite(GeneratorsOfMonoid(M)) then
+      return true;
+    fi;
+    TryNextMethod();
 end);
 
 


### PR DESCRIPTION
Turns out we also have `IsFinitelyGeneratedMonoid` (which I did not realize), and we also have an invalid method for that (see PR #2275).