### PR TITLE
Memory canary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -238,6 +238,14 @@ AC_ARG_ENABLE([debug],
 AC_MSG_CHECKING([whether to enable debug mode])
 AC_MSG_RESULT([$enable_debug])
 
+AC_ARG_ENABLE([memory-checking],
+    [AS_HELP_STRING([--enable-memory-checking], [enable memory checking])],
+    [AC_DEFINE([GAP_MEM_CHECK], [1], [define if building with memory checking])],
+    [enable_memory_checking=no]
+    )
+AC_MSG_CHECKING([whether to enable memory checking])
+AC_MSG_RESULT([$enable_memory_checking])
+
 dnl
 dnl User setting: Enable -Werror (off by default)
 dnl

--- a/lib/init.g
+++ b/lib/init.g
@@ -560,6 +560,9 @@ BindGlobal( "ShowKernelInformation", function()
   if GAPInfo.KernelInfo.KernelDebug then
     Add( config, "KernelDebug" );
   fi;
+  if GAPInfo.KernelInfo.MemCheck then
+    Add(config, "MemCheck");
+  fi;
   if config <> [] then
     print_info( " Configuration:  ", config, "\n" );
   fi;

--- a/lib/system.g
+++ b/lib/system.g
@@ -110,7 +110,8 @@ BIND_GLOBAL( "GAPInfo", rec(
            help := [ "Run ProfileLineByLine(<filename>) with recordMem := true on GAP start"] ),
       rec( long := "cover", default := "", arg := "<file>",
            help := [ "Run CoverageLineByLine(<filename>) on GAP start"] ),
-          ],
+      rec( long := "enableMemCheck", default := false)
+    ],
     ) );
 
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -1985,7 +1985,7 @@ Obj FuncMASTER_POINTER_NUMBER(Obj self, Obj o)
         return INTOBJ_INT(0);
     }
 #ifdef USE_GASMAN
-    if ((void **) o >= (void **) MptrBags && (void **) o < (void **) OldBags) {
+    if ((void **) o >= (void **) MptrBags && (void **) o < (void **) MptrEndBags) {
         return INTOBJ_INT( ((void **) o - (void **) MptrBags) + 1 );
     } else {
         return INTOBJ_INT( 0 );

--- a/src/gap.c
+++ b/src/gap.c
@@ -1882,6 +1882,18 @@ Obj FuncGASMAN_LIMITS( Obj self )
   return list;
 }
 
+#ifdef GAP_MEM_CHECK
+
+extern Int EnableMemCheck;
+
+Obj FuncGASMAN_MEM_CHECK(Obj self, Obj newval)
+{
+    EnableMemCheck = INT_INTOBJ(newval);
+    return 0;
+}
+
+#endif
+
 /****************************************************************************
 **
 *F  FuncTotalMemoryAllocated( <self> ) .expert function 'TotalMemoryAllocated'
@@ -2674,6 +2686,13 @@ Obj FuncKERNEL_INFO(Obj self) {
   AssPRec(res, r, False);
 #endif
 
+  r = RNamName("MemCheck");
+#ifdef GAP_MEM_CHECK
+  AssPRec(res, r, True);
+#else
+  AssPRec(res, r, False);
+#endif
+
   MakeImmutable(res);
   
   return res;
@@ -2769,7 +2788,7 @@ void ThreadedInterpreter(void *funcargs) {
 **
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
-static StructGVarFunc GVarFuncs [] = {
+static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC(Runtime, 0, ""),
     GVAR_FUNC(RUNTIMES, 0, ""),
@@ -2790,6 +2809,9 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(GASMAN_STATS, 0, ""),
     GVAR_FUNC(GASMAN_MESSAGE_STATUS, 0, ""),
     GVAR_FUNC(GASMAN_LIMITS, 0, ""),
+#ifdef GAP_MEM_CHECK
+    GVAR_FUNC(GASMAN_MEM_CHECK, 1, "int"),
+#endif
     GVAR_FUNC(TotalMemoryAllocated, 0, ""),
     GVAR_FUNC(SIZE_OBJ, 1, "object"),
     GVAR_FUNC(TNUM_OBJ, 1, "object"),
@@ -2804,7 +2826,8 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(QUIT_GAP, -1, "args"),
     GVAR_FUNC(FORCE_QUIT_GAP, -1, "args"),
     GVAR_FUNC(SHOULD_QUIT_ON_BREAK, 0, ""),
-    GVAR_FUNC(SHELL, -1, "context, canReturnVoid, canReturnObj, lastDepth, setTime, prompt, promptHook, infile, outfile"),
+    GVAR_FUNC(SHELL, -1, "context, canReturnVoid, canReturnObj, lastDepth, "
+                         "setTime, prompt, promptHook, infile, outfile"),
     GVAR_FUNC(CALL_WITH_CATCH, 2, "func, args"),
     GVAR_FUNC(JUMP_TO_CATCH, 1, "payload"),
     GVAR_FUNC(KERNEL_INFO, 0, ""),

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -1144,4 +1144,9 @@ extern void CallbackForAllBags( void (*func)(Bag) );
 void *AllocateMemoryBlock(UInt size);
 #endif
 
+
+#ifdef GAP_MEM_CHECK
+Int enableMemCheck(Char ** argv, void * dummy);
+#endif
+
 #endif // GAP_GASMAN_H

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -877,12 +877,12 @@ extern void MarkArrayOfBags(const Bag array[], UInt count);
 #ifdef USE_GASMAN
 
 extern  Bag *                   MptrBags;
-extern  Bag *                   OldBags;
+extern  Bag *                   MptrEndBags;
 extern  Bag *                   AllocBags;
 
 #define IS_WEAK_DEAD_BAG(bag) ( (((UInt)bag & (sizeof(Bag)-1)) == 0) && \
                                 (Bag)MptrBags <= (bag)    &&          \
-                                (bag) < (Bag)OldBags  &&              \
+                                (bag) < (Bag)MptrEndBags  &&              \
                                 (((UInt)*bag) & (sizeof(Bag)-1)) == 1)
 
 #elif defined(USE_BOEHM_GC)

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -314,8 +314,8 @@ void SaveSubObj( Obj subobj )
     SaveUInt((UInt) subobj);
   else if ((((UInt)subobj & 3) != 0) || 
            subobj < (Bag)MptrBags || 
-           subobj > (Bag)OldBags ||
-           (Bag *)PTR_BAG(subobj) < OldBags)
+           subobj > (Bag)MptrEndBags ||
+           (Bag *)PTR_BAG(subobj) < MptrEndBags)
     {
       Pr("#W bad bag id %d found, 0 saved\n", (Int)subobj, 0L);
       SaveUInt(0);
@@ -553,7 +553,7 @@ static void WriteSaveHeader( void )
       globalcount++;
   SaveUInt(globalcount);
   SaveUInt(NextSaveIndex-1);
-  SaveUInt(AllocBags - OldBags);
+  SaveUInt(AllocBags - MptrEndBags);
   
   SaveCStr("Loaded Modules");
 

--- a/src/system.h
+++ b/src/system.h
@@ -739,6 +739,11 @@ size_t strxncat (
 *F * * * * * * * * * * * * * * gasman interface * * * * * * * * * * * * * * *
 */
 
+#ifdef GAP_MEM_CHECK
+UInt   GetMembufCount(void);
+void * GetMembuf(UInt i);
+UInt GetMembufSize(void);
+#endif
 
 /****************************************************************************
 **


### PR DESCRIPTION
This is an old piece of code I had, simplified and resurrected.

This PR is split into two pieces:

The first, bigger but simpler commit, introduces to GASMAN the concept of `MptrEndBags`, which denotes the end of the master pointers. Previously, the start of bag memory (called `OldBags`) was also the end of the master pointers. This lets the two move independantly. This is useful for part 2, but also might be useful for other things (I know I, and others, have considered changing GASMAN to rearrange objects for locality as it GCs. That would be much easier after this PR).

The second, crazier but more self contained part, adds a configure-time switch ( `--enable-memory-checking`), which adds to GAP the ability to find places where pointers into bag data are incorrectly accessed after a call to GASMAN.

The easiest way to see this in action is using the 3rd commit (which I will remove before merging!) which adds a simple but extremely hard to track down bug (if you didn't know where it was) in GASMAN_LIMITS(), where we try to write to a bag location after making a new plist (note the code also catches invalid reads as well as writes).

Do:
```
gap> GASMAN_LIMITS();
[ 131072, 2097152, 0 ]
gap> GASMAN_MEM_CHECK(1); # Enables checks
true
gap> GASMAN_LIMITS();
Segmentation fault
```

If you run GAP in a debugger, it will drop you onto the bad line.

You can start checks at startup by running GAP with `--enableMemCheck`. Note that GAP will take a LONG time to start (I'm talking a couple of days).

While this code has some slightly crazy memory things, I've tried to keep them tightly defined within `#ifdef GAP_MEM_CHECK`. I've also tried to keep the code short (there are a number of things one could do more cleverly, but the code is already quite scary).