### PR TITLE
Avoid holding reference to a GAP bag when NewBag is called.

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -1177,7 +1177,10 @@ Obj CallErrorInner (
     Obj                 lateMessage,
     UInt                printThisStatement)
 {
-  Obj EarlyMsg;
+  // Must do this before creating any other GAP objects,
+  // as one of the args could be a pointer into a Bag.
+  Obj EarlyMsg = ErrorMessageToGAPString(msg, arg1, arg2);
+
   Obj r = NEW_PREC(0);
   Obj l;
   Int i;
@@ -1186,7 +1189,6 @@ Obj CallErrorInner (
   Region *savedRegion = TLS(currentRegion);
   TLS(currentRegion) = TLS(threadRegion);
 #endif
-  EarlyMsg = ErrorMessageToGAPString(msg, arg1, arg2);
   AssPRec(r, RNamName("context"), STATE(CurrLVars));
   AssPRec(r, RNamName("justQuit"), justQuit? True : False);
   AssPRec(r, RNamName("mayReturnObj"), mayReturnObj? True : False);


### PR DESCRIPTION
    In some calls to CallErrorInner, one or more of the arguments
    is a C pointer to a string stored in a GAP bag.
    In that case we must call ErrorMessageToGAPString before NEW_PREC,
    which could cause a GC which would move the string.

This can be observed using the memory checker in #2293 , type:

```
gap> GASMAN_MEM_CHECK(1);
gap> FASJKLFJSKLA; # Or any other invalid variable name
```