### PR TITLE
WIP: tests: pass CFLAGS and LDFLAGS to gac

### DIFF
--- a/tst/test-compile/run_compiled_dynamic.sh
+++ b/tst/test-compile/run_compiled_dynamic.sh
@@ -20,7 +20,7 @@ rm -rf .libs "$gfile.comp"*
 
 "$gac" "$gfile" -d -C -o "$gfile.dynamic.c" 2>&1 >/dev/null
 
-"$gac" "$gfile" -d -o "$gfile.comp" 2>&1 >/dev/null
+"$gac" "$gfile" -p "$CFLAGS" -P "$LDFLAGS" -d -o "$gfile.comp" 2>&1 >/dev/null
 
 echo "LoadDynamicModule(\"./$gfile.comp.so\"); runtest();" |
     "$gap" -r -A -q -b -x 200 2>&1 |

--- a/tst/test-compile/run_compiled_static.sh
+++ b/tst/test-compile/run_compiled_static.sh
@@ -19,7 +19,7 @@ rm -rf .libs "$gfile.comp"*
 
 "$gac" "$gfile" -C -o "$gfile.static.c" 2>&1 >/dev/null
 
-"$gac" "$gfile" -o "$gfile.comp" 2>&1 >/dev/null
+"$gac" "$gfile" -p "$CFLAGS" -P "$LDFLAGS" -o "$gfile.comp" 2>&1 >/dev/null
 
 echo "LOAD_STAT(\"$gfile\",false);; runtest();" |
     "./$gfile.comp" -l "$GAPROOT" -r -A -q -b -x 200 2>&1 |


### PR DESCRIPTION
... so that on Travis, we pass `-fprofile-arcs -ftest-coverage` to gac, and thus get coverage data for the compiled test code.

At least that's the theory, let's see if it works...