### PR TITLE
Add configure option to select GC; introduce USE_GASMAN macro

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -21,6 +21,9 @@ ABI_CFLAGS = @ABI_CFLAGS@
 HPCGAP = @HPCGAP@
 ADDGUARDS2 = @ADDGUARDS2@
 
+# garbage collector source files
+GC_SOURCES = @GC_SOURCES@
+
 # compatibility mode
 COMPAT_MODE = @COMPAT_MODE@
 GAPARCH = @GAPARCH@

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -100,12 +100,7 @@ SOURCES += src/vecgf2.c
 SOURCES += src/vector.c
 SOURCES += src/weakptr.c
 
-# TODO: Change the following to check for a new USE_BOEHM flag
-ifeq ($(HPCGAP),yes)
-  SOURCES += src/boehm_gc.c
-else
-  SOURCES += src/gasman.c
-endif
+SOURCES += $(GC_SOURCES)
 
 ifeq ($(GAPMPI),yes)
   SOURCES += src/hpc/gapmpi.c

--- a/configure.ac
+++ b/configure.ac
@@ -216,11 +216,12 @@ AS_CASE([$with_gc],
     [boehm],    [AS_IF([test "x$enable_hpcgap" = xno],
                     [AC_MSG_ERROR([Boehm GC can only be used with HPC-GAP])])
                  AC_SUBST([GC_SOURCES], [src/boehm_gc.c])
-                 AC_DEFINE([BOEHM_GC],  [1], [define as 1 if Boehm GC is used])
+                 AC_DEFINE([USE_BOEHM_GC],  [1], [define as 1 if Boehm GC is used])
                 ],
     [gasman],   [AS_IF([test "x$enable_hpcgap" = xyes],
                     [AC_MSG_ERROR([GASMAN can not be used with HPC-GAP])])
                  AC_SUBST([GC_SOURCES], [src/gasman.c])
+                 AC_DEFINE([USE_GASMAN],    [1], [define as 1 if GASMAN is used])
                 ],
     [*],        [AC_MSG_ERROR([Invalid gc method '$with_gc', use default|none|gasman|boehm])],
     )

--- a/configure.ac
+++ b/configure.ac
@@ -183,18 +183,48 @@ dnl If on, build an HPCGAP executable instead of standard GAP.
 dnl
 AC_ARG_ENABLE([hpcgap],
     [AS_HELP_STRING([--enable-hpcgap], [enable HPC-GAP])],
-    [AC_DEFINE([HPCGAP], [1], [define if building HPC-GAP])],
-    [enable_hpcgap=no]
-    )
+    [],
+    [enable_hpcgap=no])
 AC_MSG_CHECKING([whether to enable HPC-GAP])
 AC_MSG_RESULT([$enable_hpcgap])
 
 AC_SUBST([HPCGAP], [$enable_hpcgap])
 AS_IF([test "x$enable_hpcgap" = xyes],
     [
-    # HACK (see issue #9)
+    AC_DEFINE([HPCGAP], [1], [define if building HPC-GAP])
+
+    # HACK, see https://github.com/fingolfin/gap/issues/9
     AC_DEFINE([MAX_GC_THREADS], [4], [maximum number of GC threads])
     ])
+
+dnl
+dnl User setting: garbage collector to use
+dnl
+AC_ARG_WITH([gc],
+    [AS_HELP_STRING([--with-gc@<:@=default|gasman|boehm@:>@],
+      [specify which garbage collector to use (default: gasman; for HPC-GAP: boehm)])],
+    [],
+    [with_gc=default])
+AC_MSG_CHECKING([which garbage collector to use])
+AS_IF([test "x$with_gc" = xyes], [with_gc=default])
+AS_IF([test "x$with_gc" = xdefault],
+    [
+    AS_IF([test "x$enable_hpcgap" = xyes], [with_gc=boehm], [with_gc=gasman])
+    ])
+AS_CASE([$with_gc],
+    [none|no],  [AC_MSG_ERROR([cannot run GAP without a garbage collector])],
+    [boehm],    [AS_IF([test "x$enable_hpcgap" = xno],
+                    [AC_MSG_ERROR([Boehm GC can only be used with HPC-GAP])])
+                 AC_SUBST([GC_SOURCES], [src/boehm_gc.c])
+                 AC_DEFINE([BOEHM_GC],  [1], [define as 1 if Boehm GC is used])
+                ],
+    [gasman],   [AS_IF([test "x$enable_hpcgap" = xyes],
+                    [AC_MSG_ERROR([GASMAN can not be used with HPC-GAP])])
+                 AC_SUBST([GC_SOURCES], [src/gasman.c])
+                ],
+    [*],        [AC_MSG_ERROR([Invalid gc method '$with_gc', use default|none|gasman|boehm])],
+    )
+AC_MSG_RESULT([$with_gc])
 
 dnl
 dnl User setting: Debug mode (off by default)
@@ -393,8 +423,11 @@ AS_IF([test "x$enable_hpcgap" = xyes],
 
   ATOMIC_OPS_CFLAGS=$LIBATOMIC_OPS_CPPFLAGS
   ATOMIC_OPS_LIBS=$LIBATOMIC_OPS_LDFLAGS
+  ]
+)
 
-  AC_DEFINE([BOEHM_GC], [1], [Use Boehm garbage collector])
+AS_IF([test "x$with_gc" = xboehm],
+  [
   BUILD_BOEHM_GC=yes
   BOEHM_GC_CPPFLAGS='-I${abs_builddir}/extern/install/gc/include'
   BOEHM_GC_LDFLAGS='${abs_builddir}/extern/install/gc/lib/libgc.la'

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -22,7 +22,7 @@
 #include <src/vars.h>
 #endif
 
-#ifndef BOEHM_GC
+#ifndef USE_BOEHM_GC
 #error This file can only be used when the Boehm GC collector is enabled
 #endif
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -1727,7 +1727,7 @@ again:
                "you can replace <cmd> via 'return <cmd>;'" );
        }
 
-#ifdef BOEHM_GC
+#if !defined(USE_GASMAN)
         if ( strcmp( CSTR_STRING(cmd), "collect" ) == 0 ) {
             CollectBags(0,1);
         }
@@ -1738,7 +1738,7 @@ again:
             goto again;
         }
 
-#else // BOEHM_GC
+#else
 
         /* if request display the statistics                               */
         if ( strcmp( CSTR_STRING(cmd), "display" ) == 0 ) {
@@ -1835,7 +1835,7 @@ again:
                 "you can replace <cmd> via 'return <cmd>;'" );
             goto again;
         }
-#endif // ! BOEHM_GC
+#endif // USE_GASMAN
     }
 
     /* return nothing, this function is a procedure                        */
@@ -1984,14 +1984,14 @@ Obj FuncMASTER_POINTER_NUMBER(Obj self, Obj o)
     if (IS_INTOBJ(o) || IS_FFE(o)) {
         return INTOBJ_INT(0);
     }
-#ifdef HPCGAP
-    return ObjInt_UInt((UInt)o / sizeof(Obj));
-#else
+#ifdef USE_GASMAN
     if ((void **) o >= (void **) MptrBags && (void **) o < (void **) OldBags) {
         return INTOBJ_INT( ((void **) o - (void **) MptrBags) + 1 );
     } else {
         return INTOBJ_INT( 0 );
     }
+#else
+    return ObjInt_UInt((UInt)o / sizeof(Obj));
 #endif
 }
 
@@ -3020,7 +3020,7 @@ void RecordLoadedModule (
 **  general    `InitLibrary'  will  create    all objects    and  then  calls
 **  `PostRestore'.  This function is only used when restoring.
 */
-#ifndef BOEHM_GC
+#ifdef USE_GASMAN
 extern TNumMarkFuncBags TabMarkFuncBags [ 256 ];
 #endif
 
@@ -3042,7 +3042,7 @@ void InitializeGap (
     /* Initialise memory  -- have to do this here to make sure we are at top of C stack */
     InitBags( SyStorMin,
               0, (Bag*)(((UInt)pargc/C_STACK_ALIGN)*C_STACK_ALIGN), C_STACK_ALIGN );
-#if !defined(BOEHM_GC)
+#ifdef USE_GASMAN
     InitMsgsFuncBags( SyMsgsBags );
 #endif
 
@@ -3127,7 +3127,7 @@ void InitializeGap (
     }
 #endif
 
-#ifndef BOEHM_GC
+#ifdef USE_GASMAN
     /* and now for a special hack                                          */
     for ( i = LAST_CONSTANT_TNUM+1; i <= LAST_REAL_TNUM; i++ ) {
       if (TabMarkFuncBags[i + COPYING] == MarkAllSubBagsDefault)

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -129,7 +129,7 @@ typedef struct GAPState {
     UInt1 StateSlots[STATE_SLOTS_SIZE];
 
 /* Allocation */
-#ifdef BOEHM_GC
+#if !defined(USE_GASMAN)
 #define MAX_GC_PREFIX_DESC 4
     void ** FreeList[MAX_GC_PREFIX_DESC + 2];
 #endif

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -88,7 +88,7 @@ typedef struct {
     uint16_t reserved : 16;
     uint32_t size : 32;
 #endif
-#if !defined(BOEHM_GC)
+#ifdef USE_GASMAN
     Bag link;
 #endif
 } BagHeader;
@@ -342,7 +342,7 @@ static inline void SET_PTR_BAG(Bag bag, Bag *val)
 **  have side effects.
 */
 
-#ifdef BOEHM_GC
+#if !defined(USE_GASMAN)
 
 static inline void CHANGED_BAG(Bag bag)
 {
@@ -726,7 +726,7 @@ Bag MakeBagReadOnly(Bag bag);
 **  34+3016 is the  number  of bags allocated  between  the last two  garbage
 **  collections, using 978 KByte and the other two numbers are as above.
 */
-#if !defined(BOEHM_GC)
+#ifdef USE_GASMAN
 typedef void            (* TNumMsgsFuncBags) (
             UInt                full,
             UInt                phase,
@@ -826,7 +826,7 @@ extern void MarkAllSubBagsDefault ( Bag );
 **  identifier.
 
 */
-#if !defined(BOEHM_GC)
+#ifdef USE_GASMAN
 extern void MarkBag( Bag bag );
 #else
 static inline void MarkBag( Bag bag ) {}
@@ -854,7 +854,7 @@ static inline void MarkBag( Bag bag ) {}
 **  "IS_WEAK_DEAD_BAG". Which should  always be   checked before copying   or
 **  using such an identifier.
 */
-#if !defined(BOEHM_GC)
+#if !defined(USE_BOEHM_GC)
 extern void MarkBagWeakly( Bag bag );
 #endif
 
@@ -874,7 +874,7 @@ extern void MarkArrayOfBags(const Bag array[], UInt count);
 *F
 */
 
-#if !defined(BOEHM_GC)
+#ifdef USE_GASMAN
 
 extern  Bag *                   MptrBags;
 extern  Bag *                   OldBags;
@@ -885,7 +885,7 @@ extern  Bag *                   AllocBags;
                                 (bag) < (Bag)OldBags  &&              \
                                 (((UInt)*bag) & (sizeof(Bag)-1)) == 1)
 
-#else
+#elif defined(USE_BOEHM_GC)
 
 #define IS_WEAK_DEAD_BAG(bag) (!(bag))
 #define REGISTER_WP(loc, obj) \
@@ -933,7 +933,7 @@ extern  void            InitSweepFuncBags (
 **
 *V  GlobalBags  . . . . . . . . . . . . . . . . . . . . . list of global bags
 */
-#if !defined(BOEHM_GC)
+#ifdef USE_GASMAN
 
 #ifndef NR_GLOBAL_BAGS
 #define NR_GLOBAL_BAGS  20000L
@@ -979,7 +979,7 @@ extern void InitGlobalBag (
             Bag *               addr,
             const Char *        cookie );
 
-#if !defined(BOEHM_GC)
+#ifdef USE_GASMAN
 
 extern void SortGlobals( UInt byWhat );
 
@@ -1140,7 +1140,7 @@ extern void CallbackForAllBags(
      void (*func)(Bag) );
 
 
-#ifdef BOEHM_GC
+#if !defined(USE_GASMAN)
 void *AllocateMemoryBlock(UInt size);
 #endif
 

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -19,7 +19,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-#ifdef BOEHM_GC
+#ifdef USE_BOEHM_GC
 # ifdef HPCGAP
 #  define GC_THREADS
 # endif

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -919,7 +919,7 @@ Obj TypeRegion(Obj obj)
     return TYPE_REGION;
 }
 
-#ifndef BOEHM_GC
+#ifdef USE_GASMAN
 static void MarkSemaphoreBag(Bag);
 static void MarkChannelBag(Bag);
 static void MarkBarrierBag(Bag);
@@ -943,7 +943,7 @@ static UInt RNAM_SIGVTALRM;
 static UInt RNAM_SIGWINCH;
 #endif
 
-#ifndef BOEHM_GC
+#ifdef USE_GASMAN
 static void MarkSemaphoreBag(Bag bag)
 {
     Semaphore * sem = (Semaphore *)(PTR_BAG(bag));
@@ -2757,7 +2757,7 @@ static Int InitKernel(StructInitInfo * module)
     InitMarkFuncBags(T_THREAD, MarkNoSubBags);
     InitMarkFuncBags(T_MONITOR, MarkNoSubBags);
     InitMarkFuncBags(T_REGION, MarkAllSubBags);
-#ifndef BOEHM_GC
+#ifdef USE_GASMAN
     InitMarkFuncBags(T_SEMAPHORE, MarkSemaphoreBag);
     InitMarkFuncBags(T_CHANNEL, MarkChannelBag);
     InitMarkFuncBags(T_BARRIER, MarkBarrierBag);

--- a/src/rational.c
+++ b/src/rational.c
@@ -885,7 +885,7 @@ static Int InitKernel (
      * more space-efficient for the Boehm GC and does not incur a
      * speed penalty.
      */
-#ifndef BOEHM_GC
+#ifdef USE_GASMAN
     InitMarkFuncBags( T_RAT, MarkTwoSubBags );
 #else
     InitMarkFuncBags( T_RAT, MarkAllSubBags );

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -42,7 +42,7 @@ static UInt1* LBPointer;
 static UInt1* LBEnd;
 static Obj userHomeExpand;
 
-#if !defined(BOEHM_GC)
+#ifdef USE_GASMAN
 
 static Int OpenForSave( Obj fname ) 
 {
@@ -302,7 +302,7 @@ void LoadString ( Obj string )
 
 void SaveSubObj( Obj subobj )
 {
-#ifdef BOEHM_GC
+#ifndef USE_GASMAN
   // FIXME: HACK
   assert(0);
 #else
@@ -327,7 +327,7 @@ void SaveSubObj( Obj subobj )
 
 Obj LoadSubObj( void )
 {
-#ifdef BOEHM_GC
+#ifndef USE_GASMAN
   // FIXME: HACK
   assert(0);
 #else
@@ -375,7 +375,7 @@ ObjFunc LoadHandler( void )
 **  Bag level saving routines
 */
 
-#if !defined(BOEHM_GC)
+#ifdef USE_GASMAN
 
 static void SaveBagData (Bag bag )
 {
@@ -422,7 +422,7 @@ static void LoadBagData ( void )
 **
 */
 
-#if !defined(BOEHM_GC)
+#ifdef USE_GASMAN
 
 static void WriteEndiannessMarker( void )
 {
@@ -536,7 +536,7 @@ Obj FuncFindBag( Obj self, Obj minsize, Obj maxsize, Obj tnum )
 **  The return value is either True or Fail
 */
 
-#if !defined(BOEHM_GC)
+#ifdef USE_GASMAN
 
 static UInt NextSaveIndex = 1;
 
@@ -598,8 +598,8 @@ static void WriteSaveHeader( void )
 
 Obj SaveWorkspace( Obj fname )
 {
-#ifdef BOEHM_GC
-  Pr("SaveWorkspace is not currently supported when Boehm GC is in use",0,0);
+#ifndef USE_GASMAN
+  Pr("SaveWorkspace is only supported when GASMAN is in use",0,0);
   return Fail;
 
 #else
@@ -678,8 +678,8 @@ Obj FuncSaveWorkspace(Obj self, Obj filename )
 
 void LoadWorkspace( Char * fname )
 {
-#ifdef BOEHM_GC
-  Pr("LoadWorkspace is not currently supported when Boehm GC is in use",0,0);
+#ifndef USE_GASMAN
+  Pr("LoadWorkspace is only supported when GASMAN is in use",0,0);
   return;
 
 #else

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -29,7 +29,7 @@
 #include <src/hpc/traverse.h>
 #endif
 
-#ifdef BOEHM_GC
+#ifdef USE_BOEHM_GC
 # ifdef HPCGAP
 #  define GC_THREADS
 # endif
@@ -116,7 +116,7 @@ Int GrowWPObj (
     if ( need < good ) { plen = good; }
     else               { plen = need; }
 
-#ifndef BOEHM_GC
+#ifndef USE_BOEHM_GC
     /* resize the plain list                                               */
     ResizeBag( wp, ((plen)+1)*sizeof(Obj) );
 #else
@@ -154,7 +154,7 @@ Obj FuncWeakPointerObj( Obj self, Obj list ) {
   Obj wp; 
   Int i;
   Int len; 
-#ifdef BOEHM_GC
+#ifdef USE_BOEHM_GC
   /* We need to make sure that the list stays live until
    * after REGISTER_WP(); on architectures that pass
    * arguments in registers (x86_64, SPARC, etc), the
@@ -169,7 +169,7 @@ Obj FuncWeakPointerObj( Obj self, Obj list ) {
   STORE_LEN_WPOBJ(wp,len); 
   for (i = 1; i <= len ; i++) 
     { 
-#ifdef BOEHM_GC
+#ifdef USE_BOEHM_GC
       Obj tmp = ELM0_LIST(list2, i);
       ELM_WPOBJ(wp,i) = tmp;
       if (IS_BAG_REF(tmp))
@@ -208,7 +208,7 @@ Int LengthWPObj(Obj wp)
     return len;
 #endif
 
-#ifndef BOEHM_GC
+#ifndef USE_BOEHM_GC
   Obj elm;
   while (len > 0 && 
          (!(elm = ELM_WPOBJ(wp,len)) ||
@@ -279,7 +279,7 @@ Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
       ErrorMayQuit("SetElmWPObj: Position must be a positive integer",0L,0L);
     }
 
-#ifdef BOEHM_GC
+#ifdef USE_BOEHM_GC
   /* Ensure reference remains visible to GC in case val is
    * stored in a register and the register is reused before
    * REGISTER_WP() is called.
@@ -291,7 +291,7 @@ Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
       GROW_WPOBJ(wp, ipos);
       STORE_LEN_WPOBJ(wp,ipos);
     }
-#ifdef BOEHM_GC
+#ifdef USE_BOEHM_GC
   volatile Obj tmp = ELM_WPOBJ(wp, ipos);
   MEMBAR_READ();
   if (IS_BAG_REF(tmp) && ELM_WPOBJ(wp, ipos))
@@ -336,7 +336,7 @@ Int IsBoundElmWPObj( Obj wp, Obj pos)
       ErrorMayQuit("IsBoundElmWPObj: Position must be a positive integer",0L,0L);
     }
 
-#ifdef BOEHM_GC
+#ifdef USE_BOEHM_GC
   volatile
 #endif
   Obj elm;
@@ -345,7 +345,7 @@ Int IsBoundElmWPObj( Obj wp, Obj pos)
       return 0;
     }
   elm = ELM_WPOBJ(wp,ipos);
-#ifdef BOEHM_GC
+#ifdef USE_BOEHM_GC
   MEMBAR_READ();
   if (elm == 0 || ELM_WPOBJ(wp, ipos) == 0)
       return 0;
@@ -405,7 +405,7 @@ Obj FuncUnbindElmWPObj( Obj self, Obj wp, Obj pos)
 
   Int len = LengthWPObj(wp);
   if ( ipos <= len ) {
-#ifndef BOEHM_GC
+#ifndef USE_BOEHM_GC
     ELM_WPOBJ( wp, ipos) =  0;
 #else
     /* Ensure the result is visible on the stack in case a garbage
@@ -454,11 +454,11 @@ Obj ElmDefWPList(Obj wp, Int ipos, Obj def)
       return def;
 #endif
 
-#ifdef BOEHM_GC
+#ifdef USE_BOEHM_GC
   volatile
 #endif
   Obj elm = ELM_WPOBJ(wp,ipos);
-#ifdef BOEHM_GC
+#ifdef USE_BOEHM_GC
   MEMBAR_READ();
   if (elm == 0 || ELM_WPOBJ(wp, ipos) == 0)
       return def;
@@ -534,7 +534,7 @@ Obj FuncIsWPObj( Obj self, Obj wp)
 **  pointers can be reclaimed.  
 */
 
-#if !defined(BOEHM_GC)
+#if !defined(USE_BOEHM_GC)
 
 static void MarkWeakPointerObj( Obj wp) 
 {
@@ -661,7 +661,7 @@ void MakeImmutableWPObj( Obj obj )
 {
   UInt i;
   
-#ifndef BOEHM_GC
+#ifndef USE_BOEHM_GC
   /* remove any weak dead bags */
   for (i = 1; i <= STORED_LEN_WPOBJ(obj); i++)
     {
@@ -750,7 +750,7 @@ void CleanObjWPObjCopy (
 *F  FinalizeWeapPointerObj( <wpobj> )
 */
 
-#if defined(HPCGAP) && !defined(BOEHM_GC)
+#if defined(HPCGAP) && !defined(USE_BOEHM_GC)
 void FinalizeWeakPointerObj( Obj wpobj )
 {
     volatile Obj keep = wpobj;
@@ -859,7 +859,7 @@ static Int InitKernel (
     InfoBags[ T_WPOBJ +COPYING ].name = "object (weakptr, copied)";
 #endif
 
-#ifdef BOEHM_GC
+#ifdef USE_BOEHM_GC
     /* force atomic allocation of these pointers */
     InitMarkFuncBags ( T_WPOBJ,          MarkNoSubBags   );
   #if !defined(USE_THREADSAFE_COPYING)


### PR DESCRIPTION
Also rename `BOEHM_GC` to `USE_BOEHM_GC`, for uniformity. Also change the code to use `USE_GASMAN` and `USE_BOEHM_GC` more consistently; e.g. don't assume that HPC-GAP uses Boehm and non-HPC-GAP uses GASMAN.

This is part of #2092 (I wrote this code for @rbehrends but since that work currently doesn't seem to go anywhere, I think it's best to merge this now, instead of letting it bitrot).

Resolves #1470