### PR TITLE
Restrict CallbackForAllBags to builds using GASMAN

### DIFF
--- a/hpcgap/src/c_type1.c
+++ b/hpcgap/src/c_type1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include <src/compiled.h>
-#define FILE_CRC  "92266133"
+#define FILE_CRC  "-114907653"
 
 /* global variables used in handlers */
 static GVar G_NAME__FUNC;
@@ -83,8 +83,6 @@ static GVar G_SET__FILTER__LIST;
 static Obj  GF_SET__FILTER__LIST;
 static GVar G_RESET__FILTER__LIST;
 static Obj  GF_RESET__FILTER__LIST;
-static GVar G_GASMAN;
-static Obj  GF_GASMAN;
 static GVar G_WRITE__LOCK;
 static Obj  GF_WRITE__LOCK;
 static GVar G_READ__LOCK;
@@ -160,10 +158,6 @@ static GVar G_NEW__TYPE__NEXT__ID;
 static Obj  GC_NEW__TYPE__NEXT__ID;
 static GVar G_NEW__TYPE__ID__LIMIT;
 static Obj  GC_NEW__TYPE__ID__LIMIT;
-static GVar G_FLUSH__ALL__METHOD__CACHES;
-static Obj  GF_FLUSH__ALL__METHOD__CACHES;
-static GVar G_COMPACT__TYPE__IDS;
-static Obj  GF_COMPACT__TYPE__IDS;
 static GVar G_POS__NUMB__TYPE;
 static Obj  GC_POS__NUMB__TYPE;
 static GVar G_NEW__TYPE;
@@ -1381,20 +1375,10 @@ static Obj  HdlrFunc11 (
  t_1 = (Obj)(UInt)(! LT( t_2, t_3 ));
  if ( t_1 ) {
   
-  /* GASMAN( "collect" ); */
-  t_1 = GF_GASMAN;
-  t_2 = MakeString( "collect" );
+  /* Error( "No more type ids available" ); */
+  t_1 = GF_Error;
+  t_2 = MakeString( "No more type ids available" );
   CALL_1ARGS( t_1, t_2 );
-  
-  /* FLUSH_ALL_METHOD_CACHES(  ); */
-  t_1 = GF_FLUSH__ALL__METHOD__CACHES;
-  CALL_0ARGS( t_1 );
-  
-  /* NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS(  ); */
-  t_2 = GF_COMPACT__TYPE__IDS;
-  t_1 = CALL_0ARGS( t_2 );
-  CHECK_FUNC_RESULT( t_1 )
-  AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
   
  }
  /* fi */
@@ -3808,9 +3792,7 @@ static Obj  HdlrFunc1 (
       fi;
       NEW_TYPE_NEXT_ID := NEW_TYPE_NEXT_ID + 1;
       if NEW_TYPE_NEXT_ID >= NEW_TYPE_ID_LIMIT then
-          GASMAN( "collect" );
-          FLUSH_ALL_METHOD_CACHES(  );
-          NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS(  );
+          Error( "No more type ids available" );
       fi;
       type := [ family, flags ];
       data := MakeReadOnlyObj( data );
@@ -3848,7 +3830,7 @@ static Obj  HdlrFunc1 (
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
  SET_STARTLINE_BODY(t_4, 229);
- SET_ENDLINE_BODY(t_4, 346);
+ SET_ENDLINE_BODY(t_4, 353);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3862,8 +3844,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[12], 3, 0, HdlrFunc12 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 350);
- SET_ENDLINE_BODY(t_4, 357);
+ SET_STARTLINE_BODY(t_4, 357);
+ SET_ENDLINE_BODY(t_4, 364);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3877,8 +3859,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[13], 4, 0, HdlrFunc13 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 360);
- SET_ENDLINE_BODY(t_4, 367);
+ SET_STARTLINE_BODY(t_4, 367);
+ SET_ENDLINE_BODY(t_4, 374);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3903,8 +3885,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[14], -1, 0, HdlrFunc14 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 370);
- SET_ENDLINE_BODY(t_4, 394);
+ SET_STARTLINE_BODY(t_4, 377);
+ SET_ENDLINE_BODY(t_4, 401);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3918,8 +3900,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[15], 2, 0, HdlrFunc15 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 407);
- SET_ENDLINE_BODY(t_4, 414);
+ SET_STARTLINE_BODY(t_4, 414);
+ SET_ENDLINE_BODY(t_4, 421);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3933,8 +3915,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[16], 3, 0, HdlrFunc16 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 417);
- SET_ENDLINE_BODY(t_4, 424);
+ SET_STARTLINE_BODY(t_4, 424);
+ SET_ENDLINE_BODY(t_4, 431);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3962,8 +3944,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[17], -1, 0, HdlrFunc17 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 428);
- SET_ENDLINE_BODY(t_4, 450);
+ SET_STARTLINE_BODY(t_4, 435);
+ SET_ENDLINE_BODY(t_4, 457);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3977,8 +3959,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[18], 2, 0, HdlrFunc18 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 464);
- SET_ENDLINE_BODY(t_4, 471);
+ SET_STARTLINE_BODY(t_4, 471);
+ SET_ENDLINE_BODY(t_4, 478);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3992,8 +3974,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[19], 3, 0, HdlrFunc19 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 474);
- SET_ENDLINE_BODY(t_4, 481);
+ SET_STARTLINE_BODY(t_4, 481);
+ SET_ENDLINE_BODY(t_4, 488);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4015,8 +3997,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[20], -1, 0, HdlrFunc20 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 484);
- SET_ENDLINE_BODY(t_4, 498);
+ SET_STARTLINE_BODY(t_4, 491);
+ SET_ENDLINE_BODY(t_4, 505);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4030,8 +4012,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[21], 1, 0, HdlrFunc21 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 512);
- SET_ENDLINE_BODY(t_4, 512);
+ SET_STARTLINE_BODY(t_4, 519);
+ SET_ENDLINE_BODY(t_4, 519);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4045,8 +4027,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[22], 1, 0, HdlrFunc22 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 526);
- SET_ENDLINE_BODY(t_4, 526);
+ SET_STARTLINE_BODY(t_4, 533);
+ SET_ENDLINE_BODY(t_4, 533);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4060,8 +4042,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[23], 1, 0, HdlrFunc23 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 542);
- SET_ENDLINE_BODY(t_4, 542);
+ SET_STARTLINE_BODY(t_4, 549);
+ SET_ENDLINE_BODY(t_4, 549);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4076,8 +4058,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[24], 2, 0, HdlrFunc24 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 544);
- SET_ENDLINE_BODY(t_4, 550);
+ SET_STARTLINE_BODY(t_4, 551);
+ SET_ENDLINE_BODY(t_4, 557);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4105,8 +4087,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[25], 1, 0, HdlrFunc25 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 649);
- SET_ENDLINE_BODY(t_4, 649);
+ SET_STARTLINE_BODY(t_4, 656);
+ SET_ENDLINE_BODY(t_4, 656);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4120,8 +4102,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[26], 1, 0, HdlrFunc26 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 663);
- SET_ENDLINE_BODY(t_4, 663);
+ SET_STARTLINE_BODY(t_4, 670);
+ SET_ENDLINE_BODY(t_4, 670);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4194,8 +4176,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[27], 2, 0, HdlrFunc27 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 684);
- SET_ENDLINE_BODY(t_4, 719);
+ SET_STARTLINE_BODY(t_4, 691);
+ SET_ENDLINE_BODY(t_4, 726);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4245,8 +4227,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[28], 2, 0, HdlrFunc28 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 741);
- SET_ENDLINE_BODY(t_4, 779);
+ SET_STARTLINE_BODY(t_4, 748);
+ SET_ENDLINE_BODY(t_4, 786);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4287,8 +4269,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[29], 2, 0, HdlrFunc29 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 801);
- SET_ENDLINE_BODY(t_4, 823);
+ SET_STARTLINE_BODY(t_4, 808);
+ SET_ENDLINE_BODY(t_4, 830);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4314,8 +4296,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[30], 3, 0, HdlrFunc30 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 839);
- SET_ENDLINE_BODY(t_4, 845);
+ SET_STARTLINE_BODY(t_4, 846);
+ SET_ENDLINE_BODY(t_4, 852);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4393,8 +4375,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[31], -1, 0, HdlrFunc31 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 893);
- SET_ENDLINE_BODY(t_4, 959);
+ SET_STARTLINE_BODY(t_4, 900);
+ SET_ENDLINE_BODY(t_4, 966);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4455,7 +4437,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_LEN__LIST = GVarName( "LEN_LIST" );
  G_SET__FILTER__LIST = GVarName( "SET_FILTER_LIST" );
  G_RESET__FILTER__LIST = GVarName( "RESET_FILTER_LIST" );
- G_GASMAN = GVarName( "GASMAN" );
  G_WRITE__LOCK = GVarName( "WRITE_LOCK" );
  G_READ__LOCK = GVarName( "READ_LOCK" );
  G_UNLOCK = GVarName( "UNLOCK" );
@@ -4493,8 +4474,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_POS__FIRST__FREE__TYPE = GVarName( "POS_FIRST_FREE_TYPE" );
  G_NEW__TYPE__NEXT__ID = GVarName( "NEW_TYPE_NEXT_ID" );
  G_NEW__TYPE__ID__LIMIT = GVarName( "NEW_TYPE_ID_LIMIT" );
- G_FLUSH__ALL__METHOD__CACHES = GVarName( "FLUSH_ALL_METHOD_CACHES" );
- G_COMPACT__TYPE__IDS = GVarName( "COMPACT_TYPE_IDS" );
  G_POS__NUMB__TYPE = GVarName( "POS_NUMB_TYPE" );
  G_NEW__TYPE = GVarName( "NEW_TYPE" );
  G_IsFamily = GVarName( "IsFamily" );
@@ -4620,7 +4599,6 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "LEN_LIST", &GF_LEN__LIST );
  InitFopyGVar( "SET_FILTER_LIST", &GF_SET__FILTER__LIST );
  InitFopyGVar( "RESET_FILTER_LIST", &GF_RESET__FILTER__LIST );
- InitFopyGVar( "GASMAN", &GF_GASMAN );
  InitFopyGVar( "WRITE_LOCK", &GF_WRITE__LOCK );
  InitFopyGVar( "READ_LOCK", &GF_READ__LOCK );
  InitFopyGVar( "UNLOCK", &GF_UNLOCK );
@@ -4659,8 +4637,6 @@ static Int InitKernel ( StructInitInfo * module )
  InitCopyGVar( "POS_FIRST_FREE_TYPE", &GC_POS__FIRST__FREE__TYPE );
  InitCopyGVar( "NEW_TYPE_NEXT_ID", &GC_NEW__TYPE__NEXT__ID );
  InitCopyGVar( "NEW_TYPE_ID_LIMIT", &GC_NEW__TYPE__ID__LIMIT );
- InitFopyGVar( "FLUSH_ALL_METHOD_CACHES", &GF_FLUSH__ALL__METHOD__CACHES );
- InitFopyGVar( "COMPACT_TYPE_IDS", &GF_COMPACT__TYPE__IDS );
  InitCopyGVar( "POS_NUMB_TYPE", &GC_POS__NUMB__TYPE );
  InitFopyGVar( "NEW_TYPE", &GF_NEW__TYPE );
  InitFopyGVar( "IsFamily", &GF_IsFamily );
@@ -4794,7 +4770,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "GAPROOT/lib/type1.g",
- .crc         = 92266133,
+ .crc         = -114907653,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/hpcgap/src/c_type1.c
+++ b/hpcgap/src/c_type1.c
@@ -6,10 +6,6 @@
 /* global variables used in handlers */
 static GVar G_NAME__FUNC;
 static Obj  GF_NAME__FUNC;
-static GVar G_IsType;
-static Obj  GF_IsType;
-static GVar G_FLUSH__ALL__METHOD__CACHES;
-static Obj  GF_FLUSH__ALL__METHOD__CACHES;
 static GVar G_IS__REC;
 static Obj  GF_IS__REC;
 static GVar G_IS__LIST;
@@ -79,8 +75,6 @@ static GVar G_GETTER__FUNCTION;
 static Obj  GF_GETTER__FUNCTION;
 static GVar G_IS__AND__FILTER;
 static Obj  GF_IS__AND__FILTER;
-static GVar G_COMPACT__TYPE__IDS;
-static Obj  GF_COMPACT__TYPE__IDS;
 static GVar G_fail;
 static Obj  GC_fail;
 static GVar G_LEN__LIST;
@@ -166,6 +160,10 @@ static GVar G_NEW__TYPE__NEXT__ID;
 static Obj  GC_NEW__TYPE__NEXT__ID;
 static GVar G_NEW__TYPE__ID__LIMIT;
 static Obj  GC_NEW__TYPE__ID__LIMIT;
+static GVar G_FLUSH__ALL__METHOD__CACHES;
+static Obj  GF_FLUSH__ALL__METHOD__CACHES;
+static GVar G_COMPACT__TYPE__IDS;
+static Obj  GF_COMPACT__TYPE__IDS;
 static GVar G_POS__NUMB__TYPE;
 static Obj  GC_POS__NUMB__TYPE;
 static GVar G_NEW__TYPE;
@@ -178,6 +176,8 @@ static GVar G_TypeOfTypes;
 static Obj  GC_TypeOfTypes;
 static GVar G_NewType4;
 static Obj  GF_NewType4;
+static GVar G_IsType;
+static Obj  GF_IsType;
 static GVar G_Subtype2;
 static Obj  GF_Subtype2;
 static GVar G_Subtype3;
@@ -4417,8 +4417,6 @@ static Int PostRestore ( StructInitInfo * module )
  
  /* global variables used in handlers */
  G_NAME__FUNC = GVarName( "NAME_FUNC" );
- G_IsType = GVarName( "IsType" );
- G_FLUSH__ALL__METHOD__CACHES = GVarName( "FLUSH_ALL_METHOD_CACHES" );
  G_IS__REC = GVarName( "IS_REC" );
  G_IS__LIST = GVarName( "IS_LIST" );
  G_ADD__LIST = GVarName( "ADD_LIST" );
@@ -4453,7 +4451,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_SETTER__FUNCTION = GVarName( "SETTER_FUNCTION" );
  G_GETTER__FUNCTION = GVarName( "GETTER_FUNCTION" );
  G_IS__AND__FILTER = GVarName( "IS_AND_FILTER" );
- G_COMPACT__TYPE__IDS = GVarName( "COMPACT_TYPE_IDS" );
  G_fail = GVarName( "fail" );
  G_LEN__LIST = GVarName( "LEN_LIST" );
  G_SET__FILTER__LIST = GVarName( "SET_FILTER_LIST" );
@@ -4496,12 +4493,15 @@ static Int PostRestore ( StructInitInfo * module )
  G_POS__FIRST__FREE__TYPE = GVarName( "POS_FIRST_FREE_TYPE" );
  G_NEW__TYPE__NEXT__ID = GVarName( "NEW_TYPE_NEXT_ID" );
  G_NEW__TYPE__ID__LIMIT = GVarName( "NEW_TYPE_ID_LIMIT" );
+ G_FLUSH__ALL__METHOD__CACHES = GVarName( "FLUSH_ALL_METHOD_CACHES" );
+ G_COMPACT__TYPE__IDS = GVarName( "COMPACT_TYPE_IDS" );
  G_POS__NUMB__TYPE = GVarName( "POS_NUMB_TYPE" );
  G_NEW__TYPE = GVarName( "NEW_TYPE" );
  G_IsFamily = GVarName( "IsFamily" );
  G_NewType3 = GVarName( "NewType3" );
  G_TypeOfTypes = GVarName( "TypeOfTypes" );
  G_NewType4 = GVarName( "NewType4" );
+ G_IsType = GVarName( "IsType" );
  G_Subtype2 = GVarName( "Subtype2" );
  G_Subtype3 = GVarName( "Subtype3" );
  G_SupType2 = GVarName( "SupType2" );
@@ -4581,8 +4581,6 @@ static Int InitKernel ( StructInitInfo * module )
  
  /* global variables used in handlers */
  InitFopyGVar( "NAME_FUNC", &GF_NAME__FUNC );
- InitFopyGVar( "IsType", &GF_IsType );
- InitFopyGVar( "FLUSH_ALL_METHOD_CACHES", &GF_FLUSH__ALL__METHOD__CACHES );
  InitFopyGVar( "IS_REC", &GF_IS__REC );
  InitFopyGVar( "IS_LIST", &GF_IS__LIST );
  InitFopyGVar( "ADD_LIST", &GF_ADD__LIST );
@@ -4618,7 +4616,6 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "SETTER_FUNCTION", &GF_SETTER__FUNCTION );
  InitFopyGVar( "GETTER_FUNCTION", &GF_GETTER__FUNCTION );
  InitFopyGVar( "IS_AND_FILTER", &GF_IS__AND__FILTER );
- InitFopyGVar( "COMPACT_TYPE_IDS", &GF_COMPACT__TYPE__IDS );
  InitCopyGVar( "fail", &GC_fail );
  InitFopyGVar( "LEN_LIST", &GF_LEN__LIST );
  InitFopyGVar( "SET_FILTER_LIST", &GF_SET__FILTER__LIST );
@@ -4662,12 +4659,15 @@ static Int InitKernel ( StructInitInfo * module )
  InitCopyGVar( "POS_FIRST_FREE_TYPE", &GC_POS__FIRST__FREE__TYPE );
  InitCopyGVar( "NEW_TYPE_NEXT_ID", &GC_NEW__TYPE__NEXT__ID );
  InitCopyGVar( "NEW_TYPE_ID_LIMIT", &GC_NEW__TYPE__ID__LIMIT );
+ InitFopyGVar( "FLUSH_ALL_METHOD_CACHES", &GF_FLUSH__ALL__METHOD__CACHES );
+ InitFopyGVar( "COMPACT_TYPE_IDS", &GF_COMPACT__TYPE__IDS );
  InitCopyGVar( "POS_NUMB_TYPE", &GC_POS__NUMB__TYPE );
  InitFopyGVar( "NEW_TYPE", &GF_NEW__TYPE );
  InitFopyGVar( "IsFamily", &GF_IsFamily );
  InitFopyGVar( "NewType3", &GF_NewType3 );
  InitCopyGVar( "TypeOfTypes", &GC_TypeOfTypes );
  InitFopyGVar( "NewType4", &GF_NewType4 );
+ InitFopyGVar( "IsType", &GF_IsType );
  InitFopyGVar( "Subtype2", &GF_Subtype2 );
  InitFopyGVar( "Subtype3", &GF_Subtype3 );
  InitFopyGVar( "SupType2", &GF_SupType2 );

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1898,6 +1898,7 @@ BIND_GLOBAL( "InstallGlobalFunction", function( arg )
     od;
 end );
 
+if not IsHPCGAP then
 
 BIND_GLOBAL( "FLUSH_ALL_METHOD_CACHES", function()
     local oper,j;
@@ -1907,7 +1908,8 @@ BIND_GLOBAL( "FLUSH_ALL_METHOD_CACHES", function()
         od;
     od;
 end);
-        
+
+fi;
 
 #############################################################################
 ##

--- a/lib/type1.g
+++ b/lib/type1.g
@@ -294,10 +294,17 @@ BIND_GLOBAL( "NEW_TYPE", function ( typeOfTypes, family, flags, data, parent )
     # get next type id
     NEW_TYPE_NEXT_ID := NEW_TYPE_NEXT_ID + 1;
     if NEW_TYPE_NEXT_ID >= NEW_TYPE_ID_LIMIT then
-        GASMAN("collect");
-        FLUSH_ALL_METHOD_CACHES();
-        NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS();
-        #Print("#I Compacting type IDs: ",NEW_TYPE_NEXT_ID+2^28," in use\n");
+        if IsHPCGAP then
+            # We cannot renumber types in HPC-GAP. However, HPC-GAP is
+            # only supported in 64bit mode, so we should not really run
+            # out of them anyway.
+            Error("No more type ids available");
+        else
+            GASMAN("collect");
+            FLUSH_ALL_METHOD_CACHES();
+            NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS();
+            #Print("#I Compacting type IDs: ",NEW_TYPE_NEXT_ID+2^28," in use\n");
+        fi;
     fi;
 
     # make the new type

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -587,10 +587,6 @@ void InitGlobalBag(Bag * addr, const Char * cookie)
 {
 }
 
-void CallbackForAllBags(void (*func)(Bag))
-{
-}
-
 void InitCollectFuncBags(TNumCollectFuncBags before_func,
                          TNumCollectFuncBags after_func)
 {

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include <src/compiled.h>
-#define FILE_CRC  "92266133"
+#define FILE_CRC  "-114907653"
 
 /* global variables used in handlers */
 static GVar G_NAME__FUNC;
@@ -3610,7 +3610,7 @@ static Obj  HdlrFunc1 (
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
  SET_STARTLINE_BODY(t_4, 229);
- SET_ENDLINE_BODY(t_4, 346);
+ SET_ENDLINE_BODY(t_4, 353);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3624,8 +3624,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[12], 3, 0, HdlrFunc12 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 350);
- SET_ENDLINE_BODY(t_4, 357);
+ SET_STARTLINE_BODY(t_4, 357);
+ SET_ENDLINE_BODY(t_4, 364);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3639,8 +3639,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[13], 4, 0, HdlrFunc13 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 360);
- SET_ENDLINE_BODY(t_4, 367);
+ SET_STARTLINE_BODY(t_4, 367);
+ SET_ENDLINE_BODY(t_4, 374);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3665,8 +3665,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[14], -1, 0, HdlrFunc14 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 370);
- SET_ENDLINE_BODY(t_4, 394);
+ SET_STARTLINE_BODY(t_4, 377);
+ SET_ENDLINE_BODY(t_4, 401);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3680,8 +3680,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[15], 2, 0, HdlrFunc15 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 407);
- SET_ENDLINE_BODY(t_4, 414);
+ SET_STARTLINE_BODY(t_4, 414);
+ SET_ENDLINE_BODY(t_4, 421);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3695,8 +3695,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[16], 3, 0, HdlrFunc16 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 417);
- SET_ENDLINE_BODY(t_4, 424);
+ SET_STARTLINE_BODY(t_4, 424);
+ SET_ENDLINE_BODY(t_4, 431);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3724,8 +3724,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[17], -1, 0, HdlrFunc17 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 428);
- SET_ENDLINE_BODY(t_4, 450);
+ SET_STARTLINE_BODY(t_4, 435);
+ SET_ENDLINE_BODY(t_4, 457);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3739,8 +3739,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[18], 2, 0, HdlrFunc18 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 464);
- SET_ENDLINE_BODY(t_4, 471);
+ SET_STARTLINE_BODY(t_4, 471);
+ SET_ENDLINE_BODY(t_4, 478);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3754,8 +3754,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[19], 3, 0, HdlrFunc19 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 474);
- SET_ENDLINE_BODY(t_4, 481);
+ SET_STARTLINE_BODY(t_4, 481);
+ SET_ENDLINE_BODY(t_4, 488);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3777,8 +3777,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[20], -1, 0, HdlrFunc20 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 484);
- SET_ENDLINE_BODY(t_4, 498);
+ SET_STARTLINE_BODY(t_4, 491);
+ SET_ENDLINE_BODY(t_4, 505);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3792,8 +3792,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[21], 1, 0, HdlrFunc21 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 512);
- SET_ENDLINE_BODY(t_4, 512);
+ SET_STARTLINE_BODY(t_4, 519);
+ SET_ENDLINE_BODY(t_4, 519);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3807,8 +3807,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[22], 1, 0, HdlrFunc22 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 526);
- SET_ENDLINE_BODY(t_4, 526);
+ SET_STARTLINE_BODY(t_4, 533);
+ SET_ENDLINE_BODY(t_4, 533);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3822,8 +3822,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[23], 1, 0, HdlrFunc23 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 542);
- SET_ENDLINE_BODY(t_4, 542);
+ SET_STARTLINE_BODY(t_4, 549);
+ SET_ENDLINE_BODY(t_4, 549);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3838,8 +3838,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[24], 2, 0, HdlrFunc24 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 544);
- SET_ENDLINE_BODY(t_4, 550);
+ SET_STARTLINE_BODY(t_4, 551);
+ SET_ENDLINE_BODY(t_4, 557);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3867,8 +3867,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[25], 1, 0, HdlrFunc25 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 649);
- SET_ENDLINE_BODY(t_4, 649);
+ SET_STARTLINE_BODY(t_4, 656);
+ SET_ENDLINE_BODY(t_4, 656);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3882,8 +3882,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[26], 1, 0, HdlrFunc26 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 663);
- SET_ENDLINE_BODY(t_4, 663);
+ SET_STARTLINE_BODY(t_4, 670);
+ SET_ENDLINE_BODY(t_4, 670);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3941,8 +3941,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[27], 2, 0, HdlrFunc27 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 684);
- SET_ENDLINE_BODY(t_4, 719);
+ SET_STARTLINE_BODY(t_4, 691);
+ SET_ENDLINE_BODY(t_4, 726);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3992,8 +3992,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[28], 2, 0, HdlrFunc28 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 741);
- SET_ENDLINE_BODY(t_4, 779);
+ SET_STARTLINE_BODY(t_4, 748);
+ SET_ENDLINE_BODY(t_4, 786);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4034,8 +4034,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[29], 2, 0, HdlrFunc29 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 801);
- SET_ENDLINE_BODY(t_4, 823);
+ SET_STARTLINE_BODY(t_4, 808);
+ SET_ENDLINE_BODY(t_4, 830);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4061,8 +4061,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[30], 3, 0, HdlrFunc30 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 839);
- SET_ENDLINE_BODY(t_4, 845);
+ SET_STARTLINE_BODY(t_4, 846);
+ SET_ENDLINE_BODY(t_4, 852);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4140,8 +4140,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[31], -1, 0, HdlrFunc31 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 893);
- SET_ENDLINE_BODY(t_4, 959);
+ SET_STARTLINE_BODY(t_4, 900);
+ SET_ENDLINE_BODY(t_4, 966);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4502,7 +4502,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "GAPROOT/lib/type1.g",
- .crc         = 92266133,
+ .crc         = -114907653,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/src/calls.h
+++ b/src/calls.h
@@ -361,6 +361,8 @@ extern void InitHandlerFunc (
      ObjFunc            hdlr,
      const Char *       cookie );
 
+#ifdef USE_GASMAN
+
 extern const Char * CookieOfHandler(
      ObjFunc            hdlr );
 
@@ -371,6 +373,7 @@ extern void SortHandlers( UInt byWhat );
 
 extern void CheckAllHandlers(void);
 
+#endif
 
 /****************************************************************************
 **

--- a/src/gap.c
+++ b/src/gap.c
@@ -3169,7 +3169,9 @@ void InitializeGap (
 
     /* otherwise call library initialisation                               */
     else {
+#ifdef USE_GASMAN
         CheckAllHandlers();
+#endif
 
         SyInitializing = 1;    
         for ( i = 0;  i < NrBuiltinModules;  i++ ) {

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -1135,9 +1135,9 @@ extern void FinishBags( void );
 ** collection, by simply  walking the masterpointer area. Not terribly safe
 ** 
 */
-
-extern void CallbackForAllBags(
-     void (*func)(Bag) );
+#ifdef USE_GASMAN
+extern void CallbackForAllBags( void (*func)(Bag) );
+#endif
 
 
 #if !defined(USE_GASMAN)

--- a/src/opers.c
+++ b/src/opers.c
@@ -1799,7 +1799,7 @@ Obj CallHandleMethodNotFound( Obj oper,
 **
 */
 
-#ifdef USE_GASMAN
+#if !defined(HPCGAP)
 
 static Obj FLUSH_ALL_METHOD_CACHES;
 
@@ -4146,7 +4146,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(DO_NOTHING_SETTER, 2, "obj, val"),
     GVAR_FUNC(IS_AND_FILTER, 1, "filter"),
     GVAR_FUNC(IS_CONSTRUCTOR, 1, "x"),
-#ifdef USE_GASMAN
+#if !defined(HPCGAP)
     GVAR_FUNC(COMPACT_TYPE_IDS, 0, ""),
 #endif
     GVAR_FUNC(OPER_TO_ATTRIBUTE, 1, "oper"),
@@ -4339,7 +4339,7 @@ static Int InitKernel (
     
     ImportFuncFromLibrary( "HANDLE_METHOD_NOT_FOUND", &HandleMethodNotFound );
 
-#ifdef USE_GASMAN
+#if !defined(HPCGAP)
     ImportGVarFromLibrary( "IsType", &IsType );
     ImportFuncFromLibrary( "FLUSH_ALL_METHOD_CACHES", &FLUSH_ALL_METHOD_CACHES );
 #endif

--- a/src/opers.c
+++ b/src/opers.c
@@ -1799,6 +1799,8 @@ Obj CallHandleMethodNotFound( Obj oper,
 **
 */
 
+#ifdef USE_GASMAN
+
 static Obj FLUSH_ALL_METHOD_CACHES;
 
 static Int NextTypeID;
@@ -1821,6 +1823,8 @@ Obj FuncCOMPACT_TYPE_IDS( Obj self )
   CALL_0ARGS(FLUSH_ALL_METHOD_CACHES);
   return INTOBJ_INT(NextTypeID);
 }
+
+#endif
 
 /****************************************************************************
 **
@@ -4142,7 +4146,9 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(DO_NOTHING_SETTER, 2, "obj, val"),
     GVAR_FUNC(IS_AND_FILTER, 1, "filter"),
     GVAR_FUNC(IS_CONSTRUCTOR, 1, "x"),
+#ifdef USE_GASMAN
     GVAR_FUNC(COMPACT_TYPE_IDS, 0, ""),
+#endif
     GVAR_FUNC(OPER_TO_ATTRIBUTE, 1, "oper"),
     GVAR_FUNC(OPER_TO_MUTABLE_ATTRIBUTE, 1, "oper"),
     { 0, 0, 0, 0, 0 }
@@ -4158,7 +4164,6 @@ static Int InitKernel (
     StructInitInfo *    module )
 {
 
-    NextTypeID = 0;
     CountFlags = 0;
 
     InitGlobalBag( &StringFilterSetter, "src/opers.c:StringFilterSetter" );
@@ -4333,9 +4338,11 @@ static Int InitKernel (
     ImportFuncFromLibrary( "RESET_FILTER_OBJ", &RESET_FILTER_OBJ );
     
     ImportFuncFromLibrary( "HANDLE_METHOD_NOT_FOUND", &HandleMethodNotFound );
-    ImportGVarFromLibrary( "IsType", &IsType );
 
+#ifdef USE_GASMAN
+    ImportGVarFromLibrary( "IsType", &IsType );
     ImportFuncFromLibrary( "FLUSH_ALL_METHOD_CACHES", &FLUSH_ALL_METHOD_CACHES );
+#endif
 
     /* init filters and functions                                          */
     InitHdlrFiltsFromTable( GVarFilts );

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -341,34 +341,6 @@ Obj LoadSubObj( void )
 #endif
 }
 
-void SaveHandler( ObjFunc hdlr )
-{
-  const Char * cookie;
-  if (hdlr == (ObjFunc)0)
-    SaveCStr("");
-  else
-    {
-      cookie = CookieOfHandler(hdlr);
-      if (!cookie)
-	{
-	  Pr("No cookie for Handler -- workspace will be corrupt\n",0,0);
-	  SaveCStr("");
-	}
-      SaveCStr(cookie);
-    }
-}
-
-
-ObjFunc LoadHandler( void )
-{
-  Char buf[256];
-  LoadCStr(buf, 256);
-  if (buf[0] == '\0')
-    return (ObjFunc) 0;
-  else
-    return HandlerOfCookie(buf);
-}
-
 
 /***************************************************************************
 **
@@ -475,6 +447,8 @@ static void CheckEndiannessMarker( void )
 **  FuncBagStats
 */
 
+#ifdef USE_GASMAN
+
 static FILE *file;
 
 static void report( Bag bag)
@@ -490,6 +464,9 @@ Obj FuncBagStats(Obj self, Obj filename)
   return (Obj) 0;
 }
 
+#endif
+
+
 /***************************************************************************
 **
 **  Find Bags -- a useful debugging tool -- scan for a bag of specified
@@ -498,6 +475,7 @@ Obj FuncBagStats(Obj self, Obj filename)
 **  a functions body.
 */
 
+#ifdef USE_GASMAN
 
 static UInt fb_minsize, fb_maxsize, fb_tnum;
 static Bag hit;
@@ -520,6 +498,8 @@ Obj FuncFindBag( Obj self, Obj minsize, Obj maxsize, Obj tnum )
   CallbackForAllBags(ScanBag);
   return (hit != (Bag) 0) ? hit : Fail;
 }
+
+#endif
 
 
 /***************************************************************************
@@ -942,8 +922,10 @@ static StructGVarFunc GVarFuncs [] = {
 
     GVAR_FUNC(SaveWorkspace, 1, "fname"),
     GVAR_FUNC(DumpWorkspace, 1, "fname"),
+#ifdef USE_GASMAN
     GVAR_FUNC(FindBag, 3, "minsize, maxsize, tnum"),
     GVAR_FUNC(BagStats, 1, "filename"),
+#endif
     { 0, 0, 0, 0, 0 }
 
 };

--- a/src/saveload.h
+++ b/src/saveload.h
@@ -46,7 +46,6 @@ extern void SaveCStr(const Char *s);
 extern void SaveString(Obj string);
 extern void LoadString(Obj string);
 extern void SaveSubObj(Obj o);
-extern void SaveHandler(ObjFunc hdlr);
 
 extern UInt1 LoadUInt1( void );
 extern UInt2 LoadUInt2( void );
@@ -57,7 +56,6 @@ extern UInt8 LoadUInt8( void);
 #endif
 extern void LoadCStr(Char *buf, UInt maxlen );
 extern Obj LoadSubObj( void );
-extern ObjFunc LoadHandler();
 
 
 


### PR DESCRIPTION
This function is not available in Boehm GC -- we did provide an
empty stub for it, but that's a dangerous illusion, so we are better
off removing it.