### PR TITLE
Fix sparse pperm

### DIFF
--- a/lib/pperm.gd
+++ b/lib/pperm.gd
@@ -8,14 +8,13 @@
 ##############################################################################
 ###
 
-
 DeclareUserPreference(rec(
-  name:=["PartialPermDisplayLimit", "NotationForPartialPerms"],
-  description:=["options for the display of partial perms"],
-  default:=[100, "component"],
-  check:=function(a, b) 
-  return IsPosInt(a) 
-  or (IsString(b) and b in ["component", "domainimage", "input"]); 
+  name := ["PartialPermDisplayLimit", "NotationForPartialPerms"],
+  description := ["options for the display of partial perms"],
+  default := [100, "component"],
+  check := function(a, b)
+    return IsPosInt(a)
+           or (IsString(b) and b in ["component", "domainimage", "input"]);
   end));
 
 DeclareGlobalFunction("ComponentStringOfPartialPerm");
@@ -52,7 +51,7 @@ DeclareAttribute("SmallestImageOfMovedPoint", IsPartialPerm);
 DeclareAttribute("SmallestImageOfMovedPoint", IsPartialPermCollection);
 
 # operations
-DeclareOperation("PreImagePartialPerm",[IsPartialPerm, IsPosInt]);
+DeclareOperation("PreImagePartialPerm", [IsPartialPerm, IsPosInt]);
 DeclareOperation("ComponentPartialPermInt", [IsPartialPerm, IsPosInt]);
 DeclareOperation("AsPartialPerm", [IsAssociativeElement, IsList]);
 DeclareOperation("AsPartialPerm", [IsAssociativeElement]);

--- a/lib/pperm.gi
+++ b/lib/pperm.gi
@@ -545,12 +545,13 @@ function(arg)
     fi;
   elif Length(arg)=2 then  
     if IsSSortedList(arg[1]) and ForAll(arg[1], IsPosInt) and
-     IsDuplicateFreeList(arg[2]) and ForAll(arg[2], IsPosInt) then 
+     IsDuplicateFreeList(arg[2]) and ForAll(arg[2], IsPosInt) and
+     Length(arg[1]) = Length(arg[2]) then 
       return SparsePartialPermNC(arg[1], arg[2]); 
     else
       ErrorNoReturn("usage: the 1st argument must be a set of positive integers ",
       "and the 2nd argument must be a duplicate-free list of positive ",
-      "integers");
+      "integers of equal length to the first");
     fi;
   fi; 
  

--- a/lib/pperm.gi
+++ b/lib/pperm.gi
@@ -11,8 +11,13 @@
 InstallMethod(IsGeneratorsOfMagmaWithInverses,
  "for a partial perm collection",
 [IsPartialPermCollection],
-coll-> ForAll(coll, x-> DomainOfPartialPerm(x)=DomainOfPartialPerm(coll[1]) and
-ImageSetOfPartialPerm(x)=DomainOfPartialPerm(coll[1])));
+function(coll)
+  return ForAll(coll, x -> DomainOfPartialPerm(x)
+                           = DomainOfPartialPerm(coll[1])
+                           and
+                           ImageSetOfPartialPerm(x)
+                           = DomainOfPartialPerm(coll[1]));
+end);
 
 # attributes
 
@@ -40,51 +45,53 @@ InstallMethod(NrComponentsOfPartialPerm, "for a partial perm",
 InstallMethod(ComponentsOfPartialPerm, "for a partial perm",
 [IsPartialPerm], COMPONENTS_PPERM);
 
-InstallMethod(IsIdempotent, "for a partial perm", 
+InstallMethod(IsIdempotent, "for a partial perm",
 [IsPartialPerm], IS_IDEM_PPERM);
 
-InstallMethod(IsOne, "for a partial perm", 
+InstallMethod(IsOne, "for a partial perm",
 [IsPartialPerm], IS_IDEM_PPERM);
 
-InstallMethod(FixedPointsOfPartialPerm, "for a partial perm", 
+InstallMethod(FixedPointsOfPartialPerm, "for a partial perm",
 [IsPartialPerm], FIXED_PTS_PPERM);
 
-InstallMethod(NrFixedPoints, "for a partial perm", 
+InstallMethod(NrFixedPoints, "for a partial perm",
 [IsPartialPerm], NR_FIXED_PTS_PPERM);
 
-InstallMethod(MovedPoints, "for a partial perm", 
+InstallMethod(MovedPoints, "for a partial perm",
 [IsPartialPerm], MOVED_PTS_PPERM);
 
-InstallMethod(NrMovedPoints, "for a partial perm", 
+InstallMethod(NrMovedPoints, "for a partial perm",
 [IsPartialPerm], NR_MOVED_PTS_PPERM);
 
-InstallMethod(LargestMovedPoint, "for a partial perm", 
+InstallMethod(LargestMovedPoint, "for a partial perm",
 [IsPartialPerm], LARGEST_MOVED_PT_PPERM);
 
 InstallMethod(LargestImageOfMovedPoint, "for a partial perm",
 [IsPartialPerm],
 function(f)
   local max, i;
-  
-  if IsOne(f) then 
+
+  if IsOne(f) then
     return 0;
   fi;
-  
-  max:=0;
-  for i in [SmallestMovedPoint(f)..LargestMovedPoint(f)] do 
-    if i^f>max then max:=i^f; fi;
+
+  max := 0;
+  for i in [SmallestMovedPoint(f) .. LargestMovedPoint(f)] do
+    if i ^ f > max then
+      max := i ^ f;
+    fi;
   od;
   return max;
 end);
 
-InstallMethod(SmallestMovedPoint, "for a partial perm", 
-[IsPartialPerm], 
+InstallMethod(SmallestMovedPoint, "for a partial perm",
+[IsPartialPerm],
 function(f)
   local m;
   m := SMALLEST_MOVED_PT_PPERM(f);
-  if m = fail then 
+  if m = fail then
     return infinity;
-  else 
+  else
     return m;
   fi;
 end);
@@ -93,23 +100,25 @@ InstallMethod(SmallestImageOfMovedPoint, "for a partial perm",
 [IsPartialPerm],
 function(f)
   local min, j, i;
- 
-  if IsOne(f) then 
+
+  if IsOne(f) then
     return infinity;
   fi;
 
-  min:=CoDegreeOfPartialPerm(f);
-  for i in [SmallestMovedPoint(f)..LargestMovedPoint(f)] do
-    j:=i^f;
-    if j>0 and j<min then min:=j; fi;
+  min := CoDegreeOfPartialPerm(f);
+  for i in [SmallestMovedPoint(f) .. LargestMovedPoint(f)] do
+    j := i ^ f;
+    if j > 0 and j < min then
+      min := j;
+    fi;
   od;
   return min;
 end);
 
-InstallMethod(LeftOne, "for a partial perm", 
+InstallMethod(LeftOne, "for a partial perm",
 [IsPartialPerm], LEFT_ONE_PPERM);
 
-InstallMethod(RightOne, "for a partial perm", 
+InstallMethod(RightOne, "for a partial perm",
 [IsPartialPerm], RIGHT_ONE_PPERM);
 
 # operations
@@ -118,65 +127,62 @@ InstallMethod(PreImagePartialPerm,
 "for a partial perm and positive integer",
 [IsPartialPerm, IsPosInt and IsSmallIntRep], PREIMAGE_PPERM_INT);
 
-#
-
 InstallMethod(ComponentPartialPermInt,
 "for a partial perm and positive integer",
 [IsPartialPerm, IsPosInt and IsSmallIntRep], COMPONENT_PPERM_INT);
 
-#
-
-InstallGlobalFunction(JoinOfPartialPerms, 
+InstallGlobalFunction(JoinOfPartialPerms,
 function(arg)
   local join, i;
 
-  if IsPartialPermCollection(arg[1]) then 
+  if IsPartialPermCollection(arg[1]) then
     return CallFuncList(JoinOfPartialPerms, arg[1]);
-  elif not IsPartialPermCollection(arg) then 
-    ErrorNoReturn("usage: the argument should be a collection of partial perms,");
+  elif not IsPartialPermCollection(arg) then
+    ErrorNoReturn("usage: the argument should be a collection of partial ",
+                  "perms,");
   fi;
 
-  join:=arg[1]; i:=1;
-  while i<Length(arg) and join<>fail do
-    i:=i+1;
-    join:=JOIN_PPERMS(join, arg[i]);
-   od; 
+  join := arg[1];
+  i := 1;
+  while i < Length(arg) and join <> fail do
+    i := i + 1;
+    join := JOIN_PPERMS(join, arg[i]);
+   od;
   return join;
 end);
 
-#
-
-InstallGlobalFunction(JoinOfIdempotentPartialPermsNC, 
+InstallGlobalFunction(JoinOfIdempotentPartialPermsNC,
 function(arg)
   local join, i;
 
-  if IsPartialPermCollection(arg[1]) then 
+  if IsPartialPermCollection(arg[1]) then
     return CallFuncList(JoinOfIdempotentPartialPermsNC, arg[1]);
-  elif not IsPartialPermCollection(arg) then 
-    ErrorNoReturn("usage: the argument should be a collection of partial perms,");
+  elif not IsPartialPermCollection(arg) then
+    ErrorNoReturn("usage: the argument should be a collection of partial ",
+                  "perms,");
   fi;
 
-  join:=arg[1]; i:=1;
-  while i<Length(arg) do
-    i:=i+1;
-    join:=JOIN_IDEM_PPERMS(join, arg[i]);
-   od; 
+  join := arg[1];
+  i := 1;
+  while i < Length(arg) do
+    i := i + 1;
+    join := JOIN_IDEM_PPERMS(join, arg[i]);
+   od;
   return join;
 end);
 
-#
-
-InstallGlobalFunction(MeetOfPartialPerms, 
+InstallGlobalFunction(MeetOfPartialPerms,
 function(arg)
   local meet, i, empty;
-  
-  if Length(arg) = 1 and IsPartialPermCollection(arg[1]) then 
+
+  if Length(arg) = 1 and IsPartialPermCollection(arg[1]) then
     return CallFuncList(MeetOfPartialPerms, AsList(arg[1]));
-  elif not IsPartialPermCollection(arg) then 
-    ErrorNoReturn("usage: the argument should be a collection of partial perms, ");
+  elif not IsPartialPermCollection(arg) then
+    ErrorNoReturn("usage: the argument should be a collection of ",
+                  "partial perms,");
   fi;
 
-  meet := arg[1]; 
+  meet := arg[1];
   i := 1;
   empty := EmptyPartialPerm();
 
@@ -184,41 +190,34 @@ function(arg)
     i := i + 1;
     meet := MEET_PPERMS(meet, arg[i]);
   od;
-    
+
   return meet;
 end);
 
-#
-
-InstallMethod(AsPartialPerm, "for a perm and a list", 
-[IsPerm, IsList], 
+InstallMethod(AsPartialPerm, "for a perm and a list",
+[IsPerm, IsList],
 function(p, list)
-  
-  if not IsSSortedList(list) 
-      or not ForAll(list, x -> IsSmallIntRep(x) and IsPosInt(x)) then 
-    ErrorNoReturn("usage: the second argument must be a set of positive integers,");
+
+  if not IsSSortedList(list)
+      or not ForAll(list, x -> IsSmallIntRep(x) and IsPosInt(x)) then
+    ErrorNoReturn("usage: the second argument must be a set of positive ",
+                  "integers,");
   fi;
 
   return AS_PPERM_PERM(p, list);
 end);
 
-#
-
 InstallMethod(AsPartialPerm, "for a perm",
-[IsPerm], p-> AS_PPERM_PERM(p, [1..LargestMovedPoint(p)]));
-
-#
+[IsPerm], p -> AS_PPERM_PERM(p, [1 .. LargestMovedPoint(p)]));
 
 InstallMethod(AsPartialPerm, "for a perm and pos int",
-[IsPerm, IsPosInt and IsSmallIntRep], 
+[IsPerm, IsPosInt and IsSmallIntRep],
 function(p, n)
-  return AS_PPERM_PERM(p, [1..n]);
+  return AS_PPERM_PERM(p, [1 .. n]);
 end);
 
-#
-
 InstallMethod(AsPartialPerm, "for a perm and zero",
-[IsPerm, IsZeroCyc], 
+[IsPerm, IsZeroCyc],
 function(p, n)
   return PartialPerm([]);
 end);
@@ -226,287 +225,260 @@ end);
 # c method? JDM
 
 InstallMethod(AsPartialPerm, "for a transformation and list",
-[IsTransformation, IsList], 
+[IsTransformation, IsList],
 function(f, list)
-  
+
   if not IsSSortedList(list)
-      or not ForAll(list, x -> IsSmallIntRep(x) and IsPosInt(x)) then 
+      or not ForAll(list, x -> IsSmallIntRep(x) and IsPosInt(x)) then
     ErrorNoReturn("usage: the second argument must be a set of positive ",
-                  "integers,"); 
-  elif not IsInjectiveListTrans(list, f) then 
+                  "integers,");
+  elif not IsInjectiveListTrans(list, f) then
     ErrorNoReturn("usage: the first argument must be injective on the ",
                   "second,");
   fi;
-  return PartialPermNC(list, OnTuples(list, f)); 
+  return PartialPermNC(list, OnTuples(list, f));
 end);
-
-#
 
 InstallMethod(AsPartialPerm, "for a transformation and positive int",
-[IsTransformation, IsPosInt and IsSmallIntRep], 
+[IsTransformation, IsPosInt and IsSmallIntRep],
 function(f, n)
-  return AsPartialPerm(f, [1..n]);
+  return AsPartialPerm(f, [1 .. n]);
 end);
 
-# n is image of undefined points 
+# n is image of undefined points
 InstallMethod(AsTransformation, "for a partial perm and positive integer",
 [IsPartialPerm, IsPosInt and IsSmallIntRep],
 function(f, n)
   local deg, out, i;
-  
-  if n<DegreeOfPartialPerm(f) and n^f<>0 and n^f<>n then 
-    ErrorNoReturn("usage: the 2nd argument must not be a moved point of the 1st ", 
-    "argument,");
+
+  if n < DegreeOfPartialPerm(f) and n ^ f <> 0 and n ^ f <> n then
+    ErrorNoReturn("usage: the 2nd argument must not be a moved ",
+                  "point of the 1st argument,");
   fi;
-  deg:=Maximum(n, LargestMovedPoint(f)+1, LargestImageOfMovedPoint(f)+1); 
-  out:=ListWithIdenticalEntries(deg, n);
+  deg := Maximum(n, LargestMovedPoint(f) + 1, LargestImageOfMovedPoint(f) + 1);
+  out := ListWithIdenticalEntries(deg, n);
   for i in DomainOfPartialPerm(f) do
-    out[i]:=i^f;
+    out[i] := i ^ f;
   od;
 
   return Transformation(out);
 end);
 
-# c method? JDM
-
 InstallMethod(AsTransformation, "for a partial perm",
 [IsPartialPerm],
 function(f)
-  return AsTransformation(f, Maximum(LargestImageOfMovedPoint(f),
-   LargestMovedPoint(f))+1);
+  return AsTransformation(f,
+                          Maximum(LargestImageOfMovedPoint(f),
+                          LargestMovedPoint(f)) + 1);
 end);
-
-#
 
 InstallMethod(RestrictedPartialPerm, "for a partial perm",
 [IsPartialPerm, IsList],
 function(f, list)
 
   if not IsSSortedList(list)
-      or not ForAll(list, x -> IsSmallIntRep(x) and IsPosInt(x)) then 
-    ErrorNoReturn("usage: the second argument must be a set of positive integers,");
+      or not ForAll(list, x -> IsSmallIntRep(x) and IsPosInt(x)) then
+    ErrorNoReturn("usage: the second argument must be a set of positive ",
+                  "integers,");
   fi;
 
   return RESTRICTED_PPERM(f, list);
 end);
 
-#
-
 InstallMethod(AsPermutation, "for a partial perm",
 [IsPartialPerm], AS_PERM_PPERM);
-
-#
 
 InstallMethod(PermLeftQuoPartialPermNC, "for a partial perm and partial perm",
 [IsPartialPerm, IsPartialPerm], PERM_LEFT_QUO_PPERM_NC);
 
-#
-
 InstallMethod(PermLeftQuoPartialPerm, "for a partial perm and partial perm",
-[IsPartialPerm, IsPartialPerm], 
+[IsPartialPerm, IsPartialPerm],
 function(f, g)
-  
-  if ImageSetOfPartialPerm(f)<>ImageSetOfPartialPerm(g) then 
-    ErrorNoReturn("usage: the arguments must be partial perms with equal image sets,");
+
+  if ImageSetOfPartialPerm(f) <> ImageSetOfPartialPerm(g) then
+    ErrorNoReturn("usage: the arguments must be partial perms with equal ",
+                  "image sets,");
   fi;
 
   return PERM_LEFT_QUO_PPERM_NC(f, g);
 end);
 
-#
-
 InstallMethod(TrimPartialPerm, "for a partial perm",
 [IsPartialPerm], TRIM_PPERM);
-
-#
 
 InstallMethod(PartialPermOp, "for object, list, function",
 [IsObject, IsList, IsFunction],
 function(f, D, act)
   local perm, out, seen, i, j, pnt, new;
 
-  perm:=(); 
+  perm := ();
 
-  if IsPlistRep(D) and Length(D)>2 and CanEasilySortElements(D[1]) then 
-    if not IsSSortedList(D) then 
-      D:=ShallowCopy(D);
-      perm:=Sortex(D);
-      D:=Immutable(D);
+  if IsPlistRep(D) and Length(D) > 2 and CanEasilySortElements(D[1]) then
+    if not IsSSortedList(D) then
+      D := ShallowCopy(D);
+      perm := Sortex(D);
+      D := Immutable(D);
     fi;
   fi;
-  
-  out:=EmptyPlist(Length(D));
-  seen:=EmptyPlist(Length(D));
-  i:=0; j:=Length(D);
-  
-  for pnt in D do 
-    pnt:=act(pnt, f);
-    new:=PositionCanonical(D, pnt);
-    if not pnt in seen then 
+
+  out := EmptyPlist(Length(D));
+  seen := EmptyPlist(Length(D));
+  i := 0;
+  j := Length(D);
+
+  for pnt in D do
+    pnt := act(pnt, f);
+    new := PositionCanonical(D, pnt);
+    if not pnt in seen then
       AddSet(seen, pnt);
-      if new<>fail then 
-        i:=i+1;
-        out[i]:=new;
+      if new <> fail then
+        i := i + 1;
+        out[i] := new;
       else
-        i:=i+1;
-        j:=j+1;
-        out[i]:=j;
+        i := i + 1;
+        j := j + 1;
+        out[i] := j;
       fi;
-    else 
+    else
       return fail;
     fi;
   od;
 
-  out:=PartialPerm([1..Length(D)], out);
-  
-  if not IsOne(perm) then 
-    out:=out^perm;
+  out := PartialPerm([1 .. Length(D)], out);
+
+  if not IsOne(perm) then
+    out := out ^ perm;
   fi;
 
   return out;
 end);
 
-#
-
 InstallMethod(PartialPermOp, "for an obj and list",
-[IsObject, IsList], 
-function(obj, list) 
+[IsObject, IsList],
+function(obj, list)
   return PartialPermOp(obj, list, OnPoints);
 end);
 
-#
-
 InstallMethod(PartialPermOp, "for an obj and domain",
-[IsObject, IsDomain], 
-function(obj, D) 
+[IsObject, IsDomain],
+function(obj, D)
   return PartialPermOp(obj, Enumerator(D), OnPoints);
 end);
 
-#
-
 InstallMethod(PartialPermOp, "for an obj, domain, and function",
-[IsObject, IsDomain, IsFunction], 
-function(obj, D, func) 
+[IsObject, IsDomain, IsFunction],
+function(obj, D, func)
   return PartialPermOp(obj, Enumerator(D), func);
 end);
-
-#
 
 InstallMethod(PartialPermOpNC, "for object, list, function",
 [IsObject, IsList, IsFunction],
 function(f, D, act)
   local perm, out, i, j, pnt, new;
 
-  perm:=(); 
+  perm := ();
 
-  if IsPlistRep(D) and Length(D)>2 and CanEasilySortElements(D[1]) then 
-    if not IsSSortedList(D) then 
-      D:=ShallowCopy(D);
-      perm:=Sortex(D);
-      D:=Immutable(D);
+  if IsPlistRep(D) and Length(D) > 2 and CanEasilySortElements(D[1]) then
+    if not IsSSortedList(D) then
+      D := ShallowCopy(D);
+      perm := Sortex(D);
+      D := Immutable(D);
     fi;
   fi;
-  
-  out:=EmptyPlist(Length(D));
-  i:=0; j:=Length(D);
-  
-  for pnt in D do 
-    pnt:=act(pnt, f);
-    new:=PositionCanonical(D, pnt);
-    if new<>fail then 
-      i:=i+1;
-      out[i]:=new;
+
+  out := EmptyPlist(Length(D));
+  i := 0;
+  j := Length(D);
+
+  for pnt in D do
+    pnt := act(pnt, f);
+    new := PositionCanonical(D, pnt);
+    if new <> fail then
+      i := i + 1;
+      out[i] := new;
     else
-      i:=i+1;
-      j:=j+1;
-      out[i]:=j;
+      i := i + 1;
+      j := j + 1;
+      out[i] := j;
     fi;
   od;
 
-  out:=PartialPermNC([1..Length(D)], out);
-  
-  if not IsOne(perm) then 
-    out:=out^perm;
+  out := PartialPermNC([1 .. Length(D)], out);
+
+  if not IsOne(perm) then
+    out := out ^ perm;
   fi;
 
   return out;
 end);
 
-#
-
 InstallMethod(PartialPermOpNC, "for an obj and list",
-[IsObject, IsList], 
-function(obj, list) 
+[IsObject, IsList],
+function(obj, list)
   return PartialPermOpNC(obj, list, OnPoints);
 end);
 
-#
-
 InstallMethod(PartialPermOpNC, "for an obj and domain",
-[IsObject, IsDomain], 
-function(obj, D) 
+[IsObject, IsDomain],
+function(obj, D)
   return PartialPermOpNC(obj, Enumerator(D), OnPoints);
 end);
 
-#
-
 InstallMethod(PartialPermOpNC, "for an obj, domain, and function",
-[IsObject, IsDomain, IsFunction], 
-function(obj, D, func) 
+[IsObject, IsDomain, IsFunction],
+function(obj, D, func)
   return PartialPermOpNC(obj, Enumerator(D), func);
 end);
 
-
-#
-
-# creating partial perms
+# Creating partial perms
 
 InstallGlobalFunction(RandomPartialPerm,
 function(arg)
   local source, min, max, n, out, seen, j, dom, img, out1, out2, i;
 
-  if Length(arg)=1 then 
-    if IsSmallIntRep(arg[1]) and IsPosInt(arg[1]) then 
-      source:=[1..arg[1]];
-      min:=0;
-      max:=arg[1];
-    elif IsCyclotomicCollection(arg[1]) and IsSSortedList(arg[1]) 
-        and ForAll(arg[1], x -> IsSmallIntRep(x) and IsPosInt(x)) then 
-      source:=arg[1];
-      n:=Length(source);
-      min:=Minimum(source)-1;
-      max:=Maximum(source);
+  if Length(arg) = 1 then
+    if IsSmallIntRep(arg[1]) and IsPosInt(arg[1]) then
+      source := [1 .. arg[1]];
+      min := 0;
+      max := arg[1];
+    elif IsCyclotomicCollection(arg[1]) and IsSSortedList(arg[1])
+        and ForAll(arg[1], x -> IsSmallIntRep(x) and IsPosInt(x)) then
+      source := arg[1];
+      n := Length(source);
+      min := Minimum(source) - 1;
+      max := Maximum(source);
     else
       ErrorNoReturn("usage: the argument must be a positive integer, a set, ",
-      "or 2 sets, of positive integers,");
+      "or 2 sets, of positive integers, ");
     fi;
 
-    out:=List([1..max], x-> 0);
-    seen:=BlistList([1..max], []);
+    out := List([1 .. max], x -> 0);
+    seen := BlistList([1 .. max], []);
 
     for i in source do
-      j:=Random(source);
-      if not seen[j-min] then
-        seen[j-min]:=true;
-        out[i]:=j;
+      j := Random(source);
+      if not seen[j - min] then
+        seen[j - min] := true;
+        out[i] := j;
       fi;
     od;
     return DensePartialPermNC(out);
   # for a domain and image
-  elif Length(arg)=2 and IsCyclotomicCollColl(arg) 
+  elif Length(arg) = 2 and IsCyclotomicCollColl(arg)
       and ForAll(arg, IsSSortedList)
-      and ForAll(arg[1], x -> IsSmallIntRep(x) and IsPosInt(x)) 
-      and ForAll(arg[2], x -> IsSmallIntRep(x) and IsPosInt(x)) then 
-    
-    dom:=arg[1]; img:=arg[2];
-    out1:=EmptyPlist(Length(dom));
-    out2:=EmptyPlist(Length(dom));
-    seen:=BlistList([1..Maximum(img)], []);
-    
-    for i in dom do 
-      j:=Random(img);
-      if not seen[j] then 
-        seen[j]:=true;
+      and ForAll(arg[1], x -> IsSmallIntRep(x) and IsPosInt(x))
+      and ForAll(arg[2], x -> IsSmallIntRep(x) and IsPosInt(x)) then
+
+    dom := arg[1];
+    img := arg[2];
+    out1 := EmptyPlist(Length(dom));
+    out2 := EmptyPlist(Length(dom));
+    seen := BlistList([1 .. Maximum(img)], []);
+
+    for i in dom do
+      j := Random(img);
+      if not seen[j] then
+        seen[j] := true;
         Add(out1, i);
         Add(out2, j);
       fi;
@@ -514,167 +486,163 @@ function(arg)
       ShrinkAllocationPlist(out2);
     od;
     return SparsePartialPermNC(out1, out2);
-  else 
+  else
     ErrorNoReturn("usage: the argument must be a positive integer, a set, ",
-     "or 2 sets, of positive integers,");
+                  "or 2 sets, of positive integers, ");
   fi;
 
 end);
 
-#
-
 InstallGlobalFunction(PartialPermNC,
-function(arg) 
-   
-  if Length(arg)=1 then  
-    return DensePartialPermNC(arg[1]); 
-  elif Length(arg)=2 then  
-    return SparsePartialPermNC(arg[1], arg[2]); 
-  fi; 
- 
-  ErrorNoReturn("usage: there should be one or two arguments,");
-end); 
+function(arg)
 
-#
+  if Length(arg) = 1 then
+    return DensePartialPermNC(arg[1]);
+  elif Length(arg) = 2 then
+    return SparsePartialPermNC(arg[1], arg[2]);
+  fi;
+
+  ErrorNoReturn("usage: there should be one or two arguments,");
+end);
 
 InstallGlobalFunction(PartialPerm,
-function(arg) 
-   
-  if Length(arg)=1 then  
-    if ForAll(arg[1], i -> IsSmallIntRep(i) and i >= 0) and 
-      IsDuplicateFreeList(Filtered(arg[1], x-> x<>0)) then 
+function(arg)
+
+  if Length(arg) = 1 then
+    if ForAll(arg[1], i -> IsSmallIntRep(i) and i >= 0)
+        and IsDuplicateFreeList(Filtered(arg[1], x -> x <> 0)) then
       return DensePartialPermNC(arg[1]);
     else
-      ErrorNoReturn("usage: the argument must be a list of non-negative integers ",
-      "and the non-zero elements must be duplicate-free,");
+      ErrorNoReturn("usage: the argument must be a list of non-negative ",
+                    "integers and the non-zero elements must be ",
+                    "duplicate-free,");
     fi;
-  elif Length(arg)=2 then  
-    if IsSSortedList(arg[1]) and ForAll(arg[1], IsSmallIntRep) and
-     IsDuplicateFreeList(arg[2]) and ForAll(arg[2], IsSmallIntRep) and
-     Length(arg[1]) = Length(arg[2]) then 
-      return SparsePartialPermNC(arg[1], arg[2]); 
+  elif Length(arg) = 2 then
+    if IsSSortedList(arg[1]) and ForAll(arg[1], IsSmallIntRep)
+        and IsDuplicateFreeList(arg[2]) and ForAll(arg[2], IsSmallIntRep)
+        and Length(arg[1]) = Length(arg[2]) then
+      return SparsePartialPermNC(arg[1], arg[2]);
     else
-      ErrorNoReturn("usage: the 1st argument must be a set of positive integers ",
-      "and the 2nd argument must be a duplicate-free list of positive ",
-      "integers of equal length to the first");
+      ErrorNoReturn("usage: the 1st argument must be a set of positive ",
+                    "integers and the 2nd argument must be a duplicate-free ",
+                    "list of positive integers of equal length to the first");
     fi;
-  fi; 
- 
-  ErrorNoReturn("usage: there should be one or two arguments,");
-end); 
+  fi;
+
+  ErrorNoReturn("usage: there should be one or two arguments, ");
+end);
 
 # printing, viewing, displaying...
 
-InstallMethod(String, "for a partial perm", 
-[IsPartialPerm], 
+InstallMethod(String, "for a partial perm",
+[IsPartialPerm],
 function(f)
   return STRINGIFY("PartialPerm( ", DomainOfPartialPerm(f), ", ",
    ImageListOfPartialPerm(f), " )");
 end);
 
-#
-
 InstallMethod(PrintString, "for a partial perm",
-[IsPartialPerm], 
+[IsPartialPerm],
 function(f)
   return PRINT_STRINGIFY("PartialPerm( ",
     Concatenation(PrintString(DomainOfPartialPerm(f)), ", "),
      ImageListOfPartialPerm(f), " )");
 end);
 
-#
-
 InstallMethod(PrintObj, "for a partial perm",
-[IsPartialPerm], 
+[IsPartialPerm],
 function(f)
   Print("PartialPerm(\>\> ", DomainOfPartialPerm(f), "\<, \>",
      ImageListOfPartialPerm(f), "\<\< )");
 end);
 
-#
-
 InstallMethod(ViewString, "for a partial perm",
 [IsPartialPerm],
 function(f)
 
-  if DegreeOfPartialPerm(f)=0 then
+  if DegreeOfPartialPerm(f) = 0 then
     return "<empty partial perm>";
   fi;
 
-  if RankOfPartialPerm(f)<UserPreference("PartialPermDisplayLimit") then 
-    if UserPreference("NotationForPartialPerms")="component" then 
-      if DomainOfPartialPerm(f)<>ImageListOfPartialPerm(f) then 
+  if RankOfPartialPerm(f) < UserPreference("PartialPermDisplayLimit") then
+    if UserPreference("NotationForPartialPerms") = "component" then
+      if DomainOfPartialPerm(f) <> ImageListOfPartialPerm(f) then
         return ComponentStringOfPartialPerm(f);
       else
-        return PRINT_STRINGIFY("<identity partial perm on ", 
-         DomainOfPartialPerm(f), ">");
+        return PRINT_STRINGIFY("<identity partial perm on ",
+                               DomainOfPartialPerm(f),
+                               ">");
       fi;
-    elif UserPreference("NotationForPartialPerms")="domainimage" then 
-      if DomainOfPartialPerm(f)<>ImageListOfPartialPerm(f) then 
-        return PRINT_STRINGIFY(DomainOfPartialPerm(f), " -> ",
-         ImageListOfPartialPerm(f));
+    elif UserPreference("NotationForPartialPerms") = "domainimage" then
+      if DomainOfPartialPerm(f) <> ImageListOfPartialPerm(f) then
+        return PRINT_STRINGIFY(DomainOfPartialPerm(f),
+                               " -> ",
+                               ImageListOfPartialPerm(f));
       else
-        return PRINT_STRINGIFY("<identity partial perm on ", 
-         DomainOfPartialPerm(f), ">");
+        return PRINT_STRINGIFY("<identity partial perm on ",
+                               DomainOfPartialPerm(f),
+                               ">");
       fi;
-    elif UserPreference("NotationForPartialPerms")="input" then 
+    elif UserPreference("NotationForPartialPerms") = "input" then
       return PrintString(f);
     fi;
   fi;
-  
-  return STRINGIFY("<partial perm on ", RankOfPartialPerm(f), 
-   " pts with degree ", DegreeOfPartialPerm(f), ", codegree ",
-   CoDegreeOfPartialPerm(f), ">");
+
+  return STRINGIFY("<partial perm on ",
+                   RankOfPartialPerm(f),
+                   " pts with degree ",
+                   DegreeOfPartialPerm(f),
+                   ", codegree ",
+                   CoDegreeOfPartialPerm(f),
+                   ">");
 end);
 
-#
-
-InstallGlobalFunction(ComponentStringOfPartialPerm, 
+InstallGlobalFunction(ComponentStringOfPartialPerm,
 function(f)
   local n, seen, str, i, j;
 
-  n:=Maximum(DegreeOfPartialPerm(f), CoDegreeOfPartialPerm(f));
-  seen:=List([1..n], x-> 0);
-  
-  #find the image 
-  for i in ImageSetOfPartialPerm(f) do 
-    seen[i]:=1;
+  n := Maximum(DegreeOfPartialPerm(f), CoDegreeOfPartialPerm(f));
+  seen := List([1 .. n], x -> 0);
+
+  #find the image
+  for i in ImageSetOfPartialPerm(f) do
+    seen[i] := 1;
   od;
-  
-  str:="";
+
+  str := "";
 
   #find chains
   for i in DomainOfPartialPerm(f) do
-    if seen[i]=0 then 
+    if seen[i] = 0 then
       Append(str, "\>[\>");
       Append(str, String(i));
       Append(str, "\<");
-      seen[i]:=2; 
-      i:=i^f;
-      while i<>0 do 
+      seen[i] := 2;
+      i := i ^ f;
+      while i <> 0 do
         Append(str, ",\>");
         Append(str, String(i));
         Append(str, "\<");
-        seen[i]:=2;
-        i:=i^f;
+        seen[i] := 2;
+        i := i ^ f;
       od;
       Append(str, "\<]");
     fi;
   od;
 
   #find cycles
-  for i in DomainOfPartialPerm(f) do 
-    if seen[i]=1 then 
+  for i in DomainOfPartialPerm(f) do
+    if seen[i] = 1 then
       Append(str, "\>(\>");
       Append(str, String(i));
-      Append(str, "\<"); 
-      j:=i^f;
-      while j<>i do 
+      Append(str, "\<");
+      j := i ^ f;
+      while j <> i do
         Append(str, ",\>");
         Append(str, String(j));
         Append(str, "\<");
-        seen[j]:=2;
-        j:=j^f;
+        seen[j] := 2;
+        j := j ^ f;
       od;
       Append(str, "\<)");
     fi;
@@ -684,57 +652,57 @@ end);
 
 #collections
 
-InstallMethod(DegreeOfPartialPermCollection, 
+InstallMethod(DegreeOfPartialPermCollection,
 "for a partial perm collection",
-[IsPartialPermCollection], coll-> Maximum(List(coll, DegreeOfPartialPerm)));
+[IsPartialPermCollection], coll -> Maximum(List(coll, DegreeOfPartialPerm)));
 
-InstallMethod(CodegreeOfPartialPermCollection, 
+InstallMethod(CodegreeOfPartialPermCollection,
 "for a partial perm collection",
-[IsPartialPermCollection], coll-> Maximum(List(coll, CodegreeOfPartialPerm)));
+[IsPartialPermCollection], coll -> Maximum(List(coll, CodegreeOfPartialPerm)));
 
 InstallMethod(RankOfPartialPermCollection,
 "for a partial perm collection",
-[IsPartialPermCollection], coll-> Length(DomainOfPartialPermCollection(coll)));
+[IsPartialPermCollection], coll -> Length(DomainOfPartialPermCollection(coll)));
 
 InstallMethod(DomainOfPartialPermCollection, "for a partial perm coll",
-[IsPartialPermCollection], coll-> Union(List(coll, DomainOfPartialPerm)));
+[IsPartialPermCollection], coll -> Union(List(coll, DomainOfPartialPerm)));
 
 InstallMethod(ImageOfPartialPermCollection, "for a partial perm coll",
-[IsPartialPermCollection], coll-> Union(List(coll, ImageSetOfPartialPerm)));
+[IsPartialPermCollection], coll -> Union(List(coll, ImageSetOfPartialPerm)));
 
 InstallMethod(FixedPointsOfPartialPerm, "for a partial perm coll",
-[IsPartialPermCollection], coll-> Union(List(coll, FixedPointsOfPartialPerm)));
+[IsPartialPermCollection], coll -> Union(List(coll, FixedPointsOfPartialPerm)));
 
 InstallMethod(MovedPoints, "for a partial perm coll",
-[IsPartialPermCollection], coll-> Union(List(coll, MovedPoints)));
+[IsPartialPermCollection], coll -> Union(List(coll, MovedPoints)));
 
 InstallMethod(NrFixedPoints, "for a partial perm coll",
-[IsPartialPermCollection], coll-> Length(FixedPointsOfPartialPerm(coll)));
+[IsPartialPermCollection], coll -> Length(FixedPointsOfPartialPerm(coll)));
 
 InstallMethod(NrMovedPoints, "for a partial perm coll",
-[IsPartialPermCollection], coll-> Length(MovedPoints(coll)));
+[IsPartialPermCollection], coll -> Length(MovedPoints(coll)));
 
 InstallMethod(LargestMovedPoint, "for a partial perm collection",
-[IsPartialPermCollection], coll-> Maximum(List(coll, LargestMovedPoint)));
+[IsPartialPermCollection], coll -> Maximum(List(coll, LargestMovedPoint)));
 
 InstallMethod(LargestImageOfMovedPoint, "for a partial perm collection",
-[IsPartialPermCollection], 
-coll-> Maximum(List(coll, LargestImageOfMovedPoint)));
+[IsPartialPermCollection],
+coll -> Maximum(List(coll, LargestImageOfMovedPoint)));
 
 InstallMethod(SmallestMovedPoint, "for a partial perm collection",
-[IsPartialPermCollection], coll-> Minimum(List(coll, SmallestMovedPoint)));
+[IsPartialPermCollection], coll -> Minimum(List(coll, SmallestMovedPoint)));
 
 InstallMethod(SmallestImageOfMovedPoint, "for a partial perm collection",
-[IsPartialPermCollection], 
-coll-> Minimum(List(coll, SmallestImageOfMovedPoint)));
+[IsPartialPermCollection],
+coll -> Minimum(List(coll, SmallestImageOfMovedPoint)));
 
-InstallMethod(OneImmutable, "for a partial perm coll", 
-[IsPartialPermCollection], 
+InstallMethod(OneImmutable, "for a partial perm coll",
+[IsPartialPermCollection],
 function(x)
-  return JoinOfIdempotentPartialPermsNC(List(x, OneImmutable)); 
+  return JoinOfIdempotentPartialPermsNC(List(x, OneImmutable));
 end);
 
-InstallMethod(OneMutable, "for a partial perm coll", 
+InstallMethod(OneMutable, "for a partial perm coll",
 [IsPartialPermCollection], OneImmutable);
 
 InstallMethod(MultiplicativeZeroOp, "for a partial perm",

--- a/lib/pperm.gi
+++ b/lib/pperm.gi
@@ -80,10 +80,13 @@ end);
 InstallMethod(SmallestMovedPoint, "for a partial perm", 
 [IsPartialPerm], 
 function(f)
-  if IsOne(f) then
+  local m;
+  m := SMALLEST_MOVED_PT_PPERM(f);
+  if m = fail then 
     return infinity;
+  else 
+    return m;
   fi;
-  return SMALLEST_MOVED_PT_PPERM(f);
 end);
 
 InstallMethod(SmallestImageOfMovedPoint, "for a partial perm",
@@ -329,7 +332,6 @@ function(f, D, act)
       D:=ShallowCopy(D);
       perm:=Sortex(D);
       D:=Immutable(D);
-      SetIsSSortedList(D, true);
     fi;
   fi;
   
@@ -402,7 +404,6 @@ function(f, D, act)
       D:=ShallowCopy(D);
       perm:=Sortex(D);
       D:=Immutable(D);
-      SetIsSSortedList(D, true);
     fi;
   fi;
   
@@ -567,7 +568,7 @@ end);
 InstallMethod(String, "for a partial perm", 
 [IsPartialPerm], 
 function(f)
-  return STRINGIFY("PartialPermNC( ", DomainOfPartialPerm(f), ", ",
+  return STRINGIFY("PartialPerm( ", DomainOfPartialPerm(f), ", ",
    ImageListOfPartialPerm(f), " )");
 end);
 
@@ -576,7 +577,7 @@ end);
 InstallMethod(PrintString, "for a partial perm",
 [IsPartialPerm], 
 function(f)
-  return PRINT_STRINGIFY("PartialPermNC( ",
+  return PRINT_STRINGIFY("PartialPerm( ",
     Concatenation(PrintString(DomainOfPartialPerm(f)), ", "),
      ImageListOfPartialPerm(f), " )");
 end);

--- a/lib/pperm.gi
+++ b/lib/pperm.gi
@@ -113,13 +113,13 @@ InstallMethod(RightOne, "for a partial perm",
 
 InstallMethod(PreImagePartialPerm,
 "for a partial perm and positive integer",
-[IsPartialPerm, IsPosInt], PREIMAGE_PPERM_INT);
+[IsPartialPerm, IsPosInt and IsSmallIntRep], PREIMAGE_PPERM_INT);
 
 #
 
 InstallMethod(ComponentPartialPermInt,
 "for a partial perm and positive integer",
-[IsPartialPerm, IsPosInt], COMPONENT_PPERM_INT);
+[IsPartialPerm, IsPosInt and IsSmallIntRep], COMPONENT_PPERM_INT);
 
 #
 
@@ -191,7 +191,8 @@ InstallMethod(AsPartialPerm, "for a perm and a list",
 [IsPerm, IsList], 
 function(p, list)
   
-  if not IsSSortedList(list) or not ForAll(list, IsPosInt) then 
+  if not IsSSortedList(list) 
+      or not ForAll(list, x -> IsSmallIntRep(x) and IsPosInt(x)) then 
     ErrorNoReturn("usage: the second argument must be a set of positive integers,");
   fi;
 
@@ -206,7 +207,7 @@ InstallMethod(AsPartialPerm, "for a perm",
 #
 
 InstallMethod(AsPartialPerm, "for a perm and pos int",
-[IsPerm, IsPosInt], 
+[IsPerm, IsPosInt and IsSmallIntRep], 
 function(p, n)
   return AS_PPERM_PERM(p, [1..n]);
 end);
@@ -225,7 +226,8 @@ InstallMethod(AsPartialPerm, "for a transformation and list",
 [IsTransformation, IsList], 
 function(f, list)
   
-  if not IsSSortedList(list) or not ForAll(list, IsPosInt) then 
+  if not IsSSortedList(list)
+      or not ForAll(list, x -> IsSmallIntRep(x) and IsPosInt(x)) then 
     ErrorNoReturn("usage: the second argument must be a set of positive ",
                   "integers,"); 
   elif not IsInjectiveListTrans(list, f) then 
@@ -238,14 +240,14 @@ end);
 #
 
 InstallMethod(AsPartialPerm, "for a transformation and positive int",
-[IsTransformation, IsPosInt], 
+[IsTransformation, IsPosInt and IsSmallIntRep], 
 function(f, n)
   return AsPartialPerm(f, [1..n]);
 end);
 
 # n is image of undefined points 
 InstallMethod(AsTransformation, "for a partial perm and positive integer",
-[IsPartialPerm, IsPosInt],
+[IsPartialPerm, IsPosInt and IsSmallIntRep],
 function(f, n)
   local deg, out, i;
   
@@ -277,7 +279,8 @@ InstallMethod(RestrictedPartialPerm, "for a partial perm",
 [IsPartialPerm, IsList],
 function(f, list)
 
-  if not IsSSortedList(list) or not ForAll(list, IsPosInt) then 
+  if not IsSSortedList(list)
+      or not ForAll(list, x -> IsSmallIntRep(x) and IsPosInt(x)) then 
     ErrorNoReturn("usage: the second argument must be a set of positive integers,");
   fi;
 
@@ -462,12 +465,12 @@ function(arg)
   local source, min, max, n, out, seen, j, dom, img, out1, out2, i;
 
   if Length(arg)=1 then 
-    if IsPosInt(arg[1]) then 
+    if IsSmallIntRep(arg[1]) and IsPosInt(arg[1]) then 
       source:=[1..arg[1]];
       min:=0;
       max:=arg[1];
-    elif IsCyclotomicCollection(arg[1]) and IsSSortedList(arg[1]) and
-     ForAll(arg[1], IsPosInt) then 
+    elif IsCyclotomicCollection(arg[1]) and IsSSortedList(arg[1]) 
+        and ForAll(arg[1], x -> IsSmallIntRep(x) and IsPosInt(x)) then 
       source:=arg[1];
       n:=Length(source);
       min:=Minimum(source)-1;
@@ -490,8 +493,9 @@ function(arg)
     return DensePartialPermNC(out);
   # for a domain and image
   elif Length(arg)=2 and IsCyclotomicCollColl(arg) 
-   and ForAll(arg, IsSSortedList) and ForAll(arg[1], IsPosInt) 
-   and ForAll(arg[2], IsPosInt) then 
+      and ForAll(arg, IsSSortedList)
+      and ForAll(arg[1], x -> IsSmallIntRep(x) and IsPosInt(x)) 
+      and ForAll(arg[2], x -> IsSmallIntRep(x) and IsPosInt(x)) then 
     
     dom:=arg[1]; img:=arg[2];
     out1:=EmptyPlist(Length(dom));
@@ -536,7 +540,7 @@ InstallGlobalFunction(PartialPerm,
 function(arg) 
    
   if Length(arg)=1 then  
-    if ForAll(arg[1], i-> i=0 or IsPosInt(i)) and 
+    if ForAll(arg[1], i -> IsSmallIntRep(i) and i >= 0) and 
       IsDuplicateFreeList(Filtered(arg[1], x-> x<>0)) then 
       return DensePartialPermNC(arg[1]);
     else
@@ -544,8 +548,8 @@ function(arg)
       "and the non-zero elements must be duplicate-free,");
     fi;
   elif Length(arg)=2 then  
-    if IsSSortedList(arg[1]) and ForAll(arg[1], IsPosInt) and
-     IsDuplicateFreeList(arg[2]) and ForAll(arg[2], IsPosInt) and
+    if IsSSortedList(arg[1]) and ForAll(arg[1], IsSmallIntRep) and
+     IsDuplicateFreeList(arg[2]) and ForAll(arg[2], IsSmallIntRep) and
      Length(arg[1]) = Length(arg[2]) then 
       return SparsePartialPermNC(arg[1], arg[2]); 
     else

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -1,14 +1,14 @@
 /*****************************************************************************
-*
-* A partial perm is of the form:
-*
-* [image set, domain, codegree, entries of image list]
-*
-* An element of the internal rep of a partial perm in T_PPERM2 must be
-* at most 65535 and be of UInt2. The <codegree> is just the degree of
-* the inverse or equivalently the maximum element of the image.
-*
-*****************************************************************************/
+ *
+ * A partial perm is of the form:
+ *
+ * [image set, domain, codegree, entries of image list]
+ *
+ * An element of the internal rep of a partial perm in T_PPERM2 must be
+ * at most 65535 and be of UInt2. The <codegree> is just the degree of
+ * the inverse or equivalently the maximum element of the image.
+ *
+ *****************************************************************************/
 
 #include <src/pperm.h>
 
@@ -40,19 +40,19 @@ static ModuleStateOffset PPermStateOffset = -1;
 
 typedef struct {
 
-/**************************************************************************
-*
-*V TmpPPerm . . . . . . . handle of the buffer bag of the pperm package
-*
-* 'TmpPPerm' is the handle of a bag of type 'T_PPERM4', which is
-* created at initialization time of this package.  Functions in this
-* package can use this bag for  whatever purpose they want.  They have
-* to make sure of course that it is large enough.
-*
-* The buffer is *not* guaranteed to have any particular value, routines
-* that require a zero-initialization need to do this at the start.
-*/
-Obj TmpPPerm;
+    /**************************************************************************
+     *
+     *V TmpPPerm . . . . . . . handle of the buffer bag of the pperm package
+     *
+     * 'TmpPPerm' is the handle of a bag of type 'T_PPERM4', which is
+     * created at initialization time of this package.  Functions in this
+     * package can use this bag for  whatever purpose they want.  They have
+     * to make sure of course that it is large enough.
+     *
+     * The buffer is *not* guaranteed to have any particular value, routines
+     * that require a zero-initialization need to do this at the start.
+     */
+    Obj TmpPPerm;
 
 } PPermModuleState;
 
@@ -72,8 +72,8 @@ static inline void ResizeTmpPPerm(UInt len)
 }
 
 /*****************************************************************************
-* Static functions for partial perms
-*****************************************************************************/
+ * Static functions for partial perms
+ *****************************************************************************/
 
 static inline UInt GET_CODEG_PPERM2(Obj f)
 {
@@ -91,16 +91,16 @@ UInt CODEG_PPERM2(Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     if (GET_CODEG_PPERM2(f) != 0) {
-      return GET_CODEG_PPERM2(f);
+        return GET_CODEG_PPERM2(f);
     }
     // The following is only ever entered by the EmptyPartialPerm.
-    UInt codeg = 0;
-    UInt i;
-    UInt2* ptf = ADDR_PPERM2(f);
+    UInt    codeg = 0;
+    UInt    i;
+    UInt2 * ptf = ADDR_PPERM2(f);
     for (i = 0; i < DEG_PPERM2(f); i++) {
-      if (ptf[i] > codeg) {
-        codeg = ptf[i];
-      }
+        if (ptf[i] > codeg) {
+            codeg = ptf[i];
+        }
     }
     SET_CODEG_PPERM2(f, codeg);
     return codeg;
@@ -122,16 +122,16 @@ UInt CODEG_PPERM4(Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     if (GET_CODEG_PPERM4(f) != 0) {
-      return GET_CODEG_PPERM4(f);
+        return GET_CODEG_PPERM4(f);
     }
     // The following is only ever entered by the EmptyPartialPerm.
-    UInt codeg = 0;
-    UInt i;
-    UInt4* ptf = ADDR_PPERM4(f);
+    UInt    codeg = 0;
+    UInt    i;
+    UInt4 * ptf = ADDR_PPERM4(f);
     for (i = 0; i < DEG_PPERM4(f); i++) {
-      if (ptf[i] > codeg) {
-        codeg = ptf[i];
-      }
+        if (ptf[i] > codeg) {
+            codeg = ptf[i];
+        }
     }
     SET_CODEG_PPERM4(f, codeg);
     return codeg;
@@ -216,7 +216,7 @@ static UInt INIT_PPERM2(Obj f)
             SET_ELM_PLIST(img, rank, INTOBJ_INT(ptf[i]));
         }
     }
-    GAP_ASSERT(rank != 0); // rank = 0 => deg = 0, so this is not allowed
+    GAP_ASSERT(rank != 0);    // rank = 0 => deg = 0, so this is not allowed
 
     SHRINK_PLIST(img, (Int)rank);
     SET_LEN_PLIST(img, (Int)rank);
@@ -261,7 +261,7 @@ static UInt INIT_PPERM4(Obj f)
             SET_ELM_PLIST(img, rank, INTOBJ_INT(ptf[i]));
         }
     }
-    GAP_ASSERT(rank != 0); // rank = 0 => deg = 0, so this is not allowed
+    GAP_ASSERT(rank != 0);    // rank = 0 => deg = 0, so this is not allowed
 
     SHRINK_PLIST(img, (Int)rank);
     SET_LEN_PLIST(img, (Int)rank);
@@ -333,8 +333,8 @@ static Obj PreImagePPermInt(Obj pt, Obj f)
 }
 
 /*****************************************************************************
-* GAP functions for partial perms
-*****************************************************************************/
+ * GAP functions for partial perms
+ *****************************************************************************/
 
 Obj FuncEmptyPartialPerm(Obj self)
 {
@@ -613,7 +613,7 @@ static UInt4 * FindImg(UInt n, UInt rank, Obj img)
 {
     GAP_ASSERT(IS_PLIST(img));
 
-    UInt i;
+    UInt    i;
     UInt4 * ptseen;
 
     ResizeTmpPPerm(n);
@@ -905,8 +905,8 @@ Obj FuncCOMPONENTS_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
-    UInt    i, j, n, rank, k, deg, nr, len;
-    Obj     dom, img, out;
+    UInt i, j, n, rank, k, deg, nr, len;
+    Obj  dom, img, out;
 
     n = MAX(DEG_PPERM(f), CODEG_PPERM(f));
 
@@ -1437,7 +1437,8 @@ Int HashFuncForPPerm(Obj f)
                           (int)2 * DEG_PPERM2(f));
 }
 
-Obj FuncHASH_FUNC_FOR_PPERM(Obj self, Obj f, Obj data) {
+Obj FuncHASH_FUNC_FOR_PPERM(Obj self, Obj f, Obj data)
+{
     return INTOBJ_INT(HashFuncForPPerm(f) % INT_INTOBJ(data) + 1);
 }
 
@@ -2217,8 +2218,8 @@ Obj FuncRESTRICTED_PPERM(Obj self, Obj f, Obj set)
     return Fail;
 }
 
-// convert a permutation <p> to a partial perm on <set>, which is assumed to be
-// a set of positive integers
+// convert a permutation <p> to a partial perm on <set>, which is assumed to
+// be a set of positive integers
 Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
 {
     GAP_ASSERT(IS_PERM2(p) || IS_PERM4(p));
@@ -6176,12 +6177,12 @@ Obj LQuoPPerm44(Obj f, Obj g)
 */
 Obj OnSetsPPerm(Obj set, Obj f)
 {
-    UInt2 * ptf2;
-    UInt4 * ptf4;
-    UInt    deg;
+    UInt2 *     ptf2;
+    UInt4 *     ptf4;
+    UInt        deg;
     const Obj * ptset;
-    Obj *   ptres, tmp, res;
-    UInt    i, isint, k, reslen;
+    Obj *       ptres, tmp, res;
+    UInt        i, isint, k, reslen;
 
     GAP_ASSERT(IS_PLIST(set));
     GAP_ASSERT(LEN_PLIST(set) > 0);
@@ -6280,12 +6281,12 @@ Obj OnSetsPPerm(Obj set, Obj f)
 */
 Obj OnTuplesPPerm(Obj tup, Obj f)
 {
-    UInt2 * ptf2;
-    UInt4 * ptf4;
-    UInt    deg;
+    UInt2 *     ptf2;
+    UInt4 *     ptf4;
+    UInt        deg;
     const Obj * pttup;
-    Obj *   ptres, res;
-    UInt    i, k, reslen;
+    Obj *       ptres, res;
+    UInt        i, k, reslen;
 
     GAP_ASSERT(IS_PLIST(tup));
     GAP_ASSERT(LEN_PLIST(tup) > 0);
@@ -6357,12 +6358,12 @@ Obj FuncOnPosIntSetsPartialPerm(Obj self, Obj set, Obj f)
     GAP_ASSERT(IS_LIST(set));
     GAP_ASSERT(IS_PPERM(f));
 
-    UInt2 * ptf2;
-    UInt4 * ptf4;
-    UInt    deg;
+    UInt2 *     ptf2;
+    UInt4 *     ptf4;
+    UInt        deg;
     const Obj * ptset;
-    Obj *   ptres, tmp, res;
-    UInt    i, k, reslen;
+    Obj *       ptres, tmp, res;
+    UInt        i, k, reslen;
 
     if (LEN_LIST(set) == 0)
         return set;
@@ -6525,8 +6526,8 @@ static StructGVarFilt GVarFilts[] = {
 };
 
 /****************************************************************************
-*V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
-*/
+ *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
+ */
 static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC(EmptyPartialPerm, 0, ""),
@@ -6574,8 +6575,8 @@ static StructGVarFunc GVarFuncs[] = {
 
 
 /****************************************************************************
-*F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
-*/
+ *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
+ */
 static Int InitKernel(StructInitInfo * module)
 {
 

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -182,6 +182,8 @@ static inline void SET_DOM_PPERM(Obj f, Obj dom)
 
 static UInt INIT_PPERM2(Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+
     UInt    deg, rank, i;
     UInt2 * ptf;
     Obj     img, dom;
@@ -230,6 +232,8 @@ static UInt INIT_PPERM2(Obj f)
 
 static UInt INIT_PPERM4(Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+
     UInt    deg, rank, i;
     UInt4 * ptf;
     Obj     img, dom;
@@ -289,6 +293,7 @@ UInt RANK_PPERM4(Obj f)
 
 static Obj SORT_PLIST_INTOBJ(Obj res)
 {
+    GAP_ASSERT(IS_PLIST(res));
     if (LEN_PLIST(res) == 0)
         return res;
 
@@ -299,6 +304,9 @@ static Obj SORT_PLIST_INTOBJ(Obj res)
 
 static Obj PreImagePPermInt(Obj pt, Obj f)
 {
+    GAP_ASSERT(IS_INTOBJ(pt));
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt2 * ptf2;
     UInt4 * ptf4;
     UInt    i, cpt, deg;
@@ -342,6 +350,8 @@ Obj FuncEmptyPartialPerm(Obj self)
 /* method for creating a partial perm */
 Obj FuncDensePartialPermNC(Obj self, Obj img)
 {
+    GAP_ASSERT(IS_LIST(img));
+
     UInt    deg, i, j, codeg;
     UInt2 * ptf2;
     UInt4 * ptf4;
@@ -392,6 +402,10 @@ Obj FuncDensePartialPermNC(Obj self, Obj img)
 /* assumes that dom is a set and that img is duplicatefree */
 Obj FuncSparsePartialPermNC(Obj self, Obj dom, Obj img)
 {
+    GAP_ASSERT(IS_LIST(dom));
+    GAP_ASSERT(IS_LIST(img));
+    GAP_ASSERT(LEN_LIST(dom) == LEN_LIST(img));
+
     UInt    rank, deg, i, j, codeg;
     Obj     f;
     UInt2 * ptf2;
@@ -494,6 +508,8 @@ Obj FuncRankOfPartialPerm(Obj self, Obj f)
 /* domain of a partial perm */
 Obj FuncDOMAIN_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     if (DOM_PPERM(f) == NULL) {
         if (TNUM_OBJ(f) == T_PPERM2) {
             INIT_PPERM2(f);
@@ -508,6 +524,8 @@ Obj FuncDOMAIN_PPERM(Obj self, Obj f)
 /* image list of pperm */
 Obj FuncIMAGE_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt2 * ptf2;
     UInt4 * ptf4;
     UInt    i, rank;
@@ -599,6 +617,8 @@ Obj FuncPREIMAGE_PPERM_INT(Obj self, Obj f, Obj pt)
 // find img(f)
 static UInt4 * FindImg(UInt n, UInt rank, Obj img)
 {
+    GAP_ASSERT(IS_PLIST(img));
+
     UInt i;
     UInt4 * ptseen;
 
@@ -615,6 +635,8 @@ static UInt4 * FindImg(UInt n, UInt rank, Obj img)
 // the least m, r such that f^m=f^m+r
 Obj FuncINDEX_PERIOD_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt    i, len, j, pow, rank, k, deg, n;
     UInt2 * ptf2;
     UInt4 * ptseen, *ptf4;
@@ -712,6 +734,8 @@ Obj FuncINDEX_PERIOD_PPERM(Obj self, Obj f)
 // the least power of <f> which is an idempotent
 Obj FuncSMALLEST_IDEM_POW_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     Obj x, ind, per, pow;
 
     x = FuncINDEX_PERIOD_PPERM(self, f);
@@ -727,6 +751,8 @@ Obj FuncSMALLEST_IDEM_POW_PPERM(Obj self, Obj f)
  * there exists <j> in <out> and a pos int <k> such that <j^(f^k)=i>. */
 Obj FuncCOMPONENT_REPS_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt    i, j, rank, k, deg, nr, n;
     UInt2 * ptf2;
     UInt4 * ptseen, *ptf4;
@@ -809,6 +835,8 @@ Obj FuncCOMPONENT_REPS_PPERM(Obj self, Obj f)
 /* the number of components of a partial perm (as a functional digraph) */
 Obj FuncNR_COMPONENTS_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt    i, j, n, rank, k, deg, nr;
     UInt2 * ptf2;
     UInt4 * ptseen, *ptf4;
@@ -881,6 +909,8 @@ Obj FuncNR_COMPONENTS_PPERM(Obj self, Obj f)
 /* the components of a partial perm (as a functional digraph) */
 Obj FuncCOMPONENTS_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt    i, j, n, rank, k, deg, nr, len;
     Obj     dom, img, out;
 
@@ -992,6 +1022,9 @@ Obj FuncCOMPONENTS_PPERM(Obj self, Obj f)
 // the points that can be obtained from <pt> by successively applying <f>.
 Obj FuncCOMPONENT_PPERM_INT(Obj self, Obj f, Obj pt)
 {
+    GAP_ASSERT(IS_PPERM(f));
+    GAP_ASSERT(IS_INTOBJ(pt));
+
     UInt i, j, deg, len;
     Obj  out;
 
@@ -1041,6 +1074,8 @@ Obj FuncCOMPONENT_PPERM_INT(Obj self, Obj f, Obj pt)
 // the fixed points of a partial perm
 Obj FuncFIXED_PTS_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt    len, i, j, deg, rank;
     Obj     out, dom;
     UInt2 * ptf2;
@@ -1106,6 +1141,8 @@ Obj FuncFIXED_PTS_PPERM(Obj self, Obj f)
 
 Obj FuncNR_FIXED_PTS_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt    nr, i, j, deg, rank;
     Obj     dom;
     UInt2 * ptf2;
@@ -1154,6 +1191,8 @@ Obj FuncNR_FIXED_PTS_PPERM(Obj self, Obj f)
 // the moved points of a partial perm
 Obj FuncMOVED_PTS_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt    len, i, j, deg, rank;
     Obj     out, dom;
     UInt2 * ptf2;
@@ -1217,6 +1256,8 @@ Obj FuncMOVED_PTS_PPERM(Obj self, Obj f)
 
 Obj FuncNR_MOVED_PTS_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt    nr, i, j, deg, rank;
     Obj     dom;
     UInt2 * ptf2;
@@ -1264,6 +1305,8 @@ Obj FuncNR_MOVED_PTS_PPERM(Obj self, Obj f)
 
 Obj FuncLARGEST_MOVED_PT_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt    i, j, deg;
     Obj     dom;
     UInt2 * ptf2;
@@ -1310,6 +1353,8 @@ Obj FuncLARGEST_MOVED_PT_PPERM(Obj self, Obj f)
 
 Obj FuncSMALLEST_MOVED_PT_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt    i, j, deg, rank;
     Obj     dom;
     UInt2 * ptf2;
@@ -1359,6 +1404,8 @@ Obj FuncSMALLEST_MOVED_PT_PPERM(Obj self, Obj f)
 // convert a T_PPERM4 with codeg<65536 to a T_PPERM2
 Obj FuncTRIM_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt    deg, i;
     UInt4 * ptf;
 
@@ -1403,6 +1450,8 @@ Obj FuncHASH_FUNC_FOR_PPERM(Obj self, Obj f, Obj data) {
 // test if a partial perm is an idempotent
 Obj FuncIS_IDEM_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt2 * ptf2;
     UInt4 * ptf4;
     UInt    deg, i, j, rank;
@@ -1452,6 +1501,8 @@ Obj FuncIS_IDEM_PPERM(Obj self, Obj f)
 /* an idempotent partial perm <e> with ker(e)=ker(f) */
 Obj FuncLEFT_ONE_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     Obj     dom, g;
     UInt    deg, i, j, rank;
     UInt2 * ptg2;
@@ -1497,6 +1548,8 @@ Obj FuncLEFT_ONE_PPERM(Obj self, Obj f)
 // an idempotent partial perm <e> with im(e)=im(f)
 Obj FuncRIGHT_ONE_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     Obj     g, img;
     UInt    i, j, codeg, rank;
     UInt2 * ptg2;
@@ -1546,6 +1599,9 @@ Obj FuncRIGHT_ONE_PPERM(Obj self, Obj f)
 // f<=g if and only if f is a restriction of g
 Obj FuncNaturalLeqPartialPerm(Obj self, Obj f, Obj g)
 {
+    GAP_ASSERT(IS_PPERM(f));
+    GAP_ASSERT(IS_PPERM(g));
+
     UInt   def, deg, i, j, rank;
     UInt2 *ptf2, *ptg2;
     UInt4 *ptf4, *ptg4;
@@ -1656,6 +1712,9 @@ Obj FuncNaturalLeqPartialPerm(Obj self, Obj f, Obj g)
 // could add use of rank to improve things here. JDM
 Obj FuncJOIN_IDEM_PPERMS(Obj self, Obj f, Obj g)
 {
+    GAP_ASSERT(IS_PPERM(f));
+    GAP_ASSERT(IS_PPERM(g));
+
     UInt   def, deg, dej, i;
     Obj    join;
     UInt2 *ptjoin2, *ptf2, *ptg2;
@@ -1765,6 +1824,9 @@ Obj FuncJOIN_IDEM_PPERMS(Obj self, Obj f, Obj g)
 // the union of f and g where this defines an injective function
 Obj FuncJOIN_PPERMS(Obj self, Obj f, Obj g)
 {
+    GAP_ASSERT(IS_PPERM(f));
+    GAP_ASSERT(IS_PPERM(g));
+
     UInt   deg, i, j, degf, degg, codeg, rank;
     UInt2 *ptf2, *ptg2, *ptjoin2;
     UInt4 *ptf4, *ptg4, *ptjoin4, *ptseen;
@@ -2028,6 +2090,9 @@ Obj FuncJOIN_PPERMS(Obj self, Obj f, Obj g)
 
 Obj FuncMEET_PPERMS(Obj self, Obj f, Obj g)
 {
+    GAP_ASSERT(IS_PPERM(f));
+    GAP_ASSERT(IS_PPERM(g));
+
     UInt   deg, i, j, degf, degg, codeg;
     UInt2 *ptf2, *ptg2, *ptmeet2;
     UInt4 *ptf4, *ptg4, *ptmeet4;
@@ -2152,6 +2217,9 @@ Obj FuncMEET_PPERMS(Obj self, Obj f, Obj g)
 // restricted partial perm where set is assumed to be a set of positive ints
 Obj FuncRESTRICTED_PPERM(Obj self, Obj f, Obj set)
 {
+    GAP_ASSERT(IS_PPERM(f));
+    GAP_ASSERT(IS_LIST(set));
+
     UInt   i, j, n, codeg, deg;
     UInt2 *ptf2, *ptg2;
     UInt4 *ptf4, *ptg4;
@@ -2217,6 +2285,9 @@ Obj FuncRESTRICTED_PPERM(Obj self, Obj f, Obj set)
 // a set of positive integers
 Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
 {
+    GAP_ASSERT(IS_PERM2(p) || IS_PERM4(p));
+    GAP_ASSERT(IS_LIST(set));
+
     UInt   i, j, n, deg, codeg, dep;
     UInt2 *ptf2, *ptp2;
     UInt4 *ptf4, *ptp4;
@@ -2323,6 +2394,8 @@ Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
 // for a partial perm with equal dom and img
 Obj FuncAS_PERM_PPERM(Obj self, Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt2 *ptf2, *ptp2;
     UInt4 *ptf4, *ptp4;
     UInt   deg, i, j, rank;
@@ -2369,6 +2442,9 @@ Obj FuncAS_PERM_PPERM(Obj self, Obj f)
 // and dom(f)=dom(g), no checking
 Obj FuncPERM_LEFT_QUO_PPERM_NC(Obj self, Obj f, Obj g)
 {
+    GAP_ASSERT(IS_PPERM(f));
+    GAP_ASSERT(IS_PPERM(g));
+
     UInt   deg, i, j, rank;
     Obj    perm, dom;
     UInt2 *ptf2, *ptp2, *ptg2;
@@ -2552,6 +2628,8 @@ Obj FuncHAS_IMG_PPERM(Obj self, Obj f)
 // an idempotent partial perm on the union of the domain and image
 Obj OnePPerm(Obj f)
 {
+    GAP_ASSERT(IS_PPERM(f));
+
     Obj     g, img, dom;
     UInt    i, j, deg, rank;
     UInt2 * ptg2;
@@ -2598,6 +2676,9 @@ Obj OnePPerm(Obj f)
 /* equality for partial perms */
 Int EqPPerm22(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+
     UInt2 * ptf = ADDR_PPERM2(f);
     UInt2 * ptg = ADDR_PPERM2(g);
     UInt    deg = DEG_PPERM2(f);
@@ -2630,6 +2711,9 @@ Int EqPPerm22(Obj f, Obj g)
 
 Int EqPPerm24(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
+
     UInt2 * ptf = ADDR_PPERM2(f);
     UInt4 * ptg = ADDR_PPERM4(g);
     UInt    deg = DEG_PPERM2(f);
@@ -2666,6 +2750,9 @@ Int EqPPerm42(Obj f, Obj g)
 
 Int EqPPerm44(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
+
     UInt4 * ptf = ADDR_PPERM4(f);
     UInt4 * ptg = ADDR_PPERM4(g);
     UInt    i, j, rank;
@@ -2699,6 +2786,9 @@ Int EqPPerm44(Obj f, Obj g)
 // beware this is different than it used to be...
 Int LtPPerm22(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+
     UInt2 * ptf = ADDR_PPERM2(f);
     UInt2 * ptg = ADDR_PPERM2(g);
     UInt    deg, i;
@@ -2726,6 +2816,9 @@ Int LtPPerm22(Obj f, Obj g)
 
 Int LtPPerm24(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
+
     UInt2 * ptf = ADDR_PPERM2(f);
     UInt4 * ptg = ADDR_PPERM4(g);
     UInt    deg, i;
@@ -2753,6 +2846,9 @@ Int LtPPerm24(Obj f, Obj g)
 
 Int LtPPerm42(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+
     UInt4 * ptf = ADDR_PPERM4(f);
     UInt2 * ptg = ADDR_PPERM2(g);
     UInt    deg, i;
@@ -2780,6 +2876,9 @@ Int LtPPerm42(Obj f, Obj g)
 
 Int LtPPerm44(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
+
     UInt4 * ptf = ADDR_PPERM4(f);
     UInt4 * ptg = ADDR_PPERM4(g);
     UInt    deg, i;
@@ -2808,6 +2907,9 @@ Int LtPPerm44(Obj f, Obj g)
 /* product of partial perm and partial perm */
 Obj ProdPPerm22(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+
     UInt   deg, degg, i, j, rank;
     UInt2 *ptf, *ptg, *ptfg, codeg;
     Obj    fg, dom;
@@ -2865,6 +2967,9 @@ Obj ProdPPerm22(Obj f, Obj g)
 // the product is always pperm2
 Obj ProdPPerm42(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+
     UInt    deg, degg, i, j, rank;
     UInt4 * ptf;
     UInt2 * ptg, *ptfg, codeg;
@@ -2921,6 +3026,9 @@ Obj ProdPPerm42(Obj f, Obj g)
 // it is possible that f*g could be represented as a PPERM2
 Obj ProdPPerm44(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
+
     UInt   deg, degg, codeg, i, j, rank;
     UInt4 *ptf, *ptg, *ptfg;
     Obj    fg, dom;
@@ -2982,6 +3090,9 @@ Obj ProdPPerm44(Obj f, Obj g)
 // it is possible that f*g could be represented as a PPERM2
 Obj ProdPPerm24(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
+
     UInt    deg, degg, i, j, codeg, rank;
     UInt2 * ptf;
     UInt4 * ptg, *ptfg;
@@ -3046,6 +3157,9 @@ Obj ProdPPerm24(Obj f, Obj g)
 // compose partial perms and perms
 Obj ProdPPerm2Perm2(Obj f, Obj p)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
+
     UInt2 * ptf, *ptp, *ptfp2;
     UInt4 * ptfp4;
     Obj     fp, dom;
@@ -3143,6 +3257,9 @@ Obj ProdPPerm2Perm2(Obj f, Obj p)
 
 Obj ProdPPerm4Perm4(Obj f, Obj p)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
+
     UInt4 *ptf, *ptp, *ptfp;
     Obj    fp, dom;
     UInt   codeg, dep, deg, i, j, rank;
@@ -3206,6 +3323,9 @@ Obj ProdPPerm4Perm4(Obj f, Obj p)
 
 Obj ProdPPerm2Perm4(Obj f, Obj p)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
+
     UInt2 * ptf;
     UInt4 * ptp, *ptfp;
     Obj     fp, dom;
@@ -3243,6 +3363,9 @@ Obj ProdPPerm2Perm4(Obj f, Obj p)
 
 Obj ProdPPerm4Perm2(Obj f, Obj p)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
+
     UInt4 *ptf, *ptfp;
     UInt2 *ptp, dep;
     Obj    fp, dom;
@@ -3282,6 +3405,9 @@ Obj ProdPPerm4Perm2(Obj f, Obj p)
 // product of a perm and a partial perm
 Obj ProdPerm2PPerm2(Obj p, Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+
     UInt2 deg, *ptp, *ptf, *ptpf;
     UInt  degf, i;
     Obj   pf;
@@ -3324,6 +3450,9 @@ Obj ProdPerm2PPerm2(Obj p, Obj f)
 
 Obj ProdPerm4PPerm4(Obj p, Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+
     UInt4 deg, *ptp, *ptf, *ptpf;
     UInt  degf, i;
     Obj   pf;
@@ -3366,6 +3495,9 @@ Obj ProdPerm4PPerm4(Obj p, Obj f)
 
 Obj ProdPerm4PPerm2(Obj p, Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+
     UInt4  deg, *ptp;
     UInt2 *ptf, *ptpf;
     UInt   degf, i;
@@ -3409,6 +3541,9 @@ Obj ProdPerm4PPerm2(Obj p, Obj f)
 
 Obj ProdPerm2PPerm4(Obj p, Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+
     UInt2 * ptp;
     UInt4 * ptf, *ptpf;
     UInt    deg, degf, i;
@@ -3453,6 +3588,8 @@ Obj ProdPerm2PPerm4(Obj p, Obj f)
 // the inverse of a partial perm
 Obj InvPPerm2(Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+
     UInt    deg, codeg, i, j, rank;
     UInt2 * ptf, *ptinv2;
     UInt4 * ptinv4;
@@ -3504,6 +3641,8 @@ Obj InvPPerm2(Obj f)
 
 Obj InvPPerm4(Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+
     UInt    deg, codeg, i, j, rank;
     UInt2 * ptinv2;
     UInt4 * ptf, *ptinv4;
@@ -3558,6 +3697,9 @@ Obj InvPPerm4(Obj f)
 // JDM
 Obj PowPPerm2Perm2(Obj f, Obj p)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
+
     UInt   deg, rank, degconj, i, j, k, codeg;
     UInt2 *ptf, *ptp, *ptconj, dep;
     Obj    conj, dom;
@@ -3614,6 +3756,9 @@ Obj PowPPerm2Perm2(Obj f, Obj p)
 
 Obj PowPPerm2Perm4(Obj f, Obj p)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
+
     UInt    deg, rank, degconj, i, j, k, codeg;
     UInt2 * ptf;
     UInt4 * ptp, *ptconj, dep;
@@ -3660,6 +3805,9 @@ Obj PowPPerm2Perm4(Obj f, Obj p)
 
 Obj PowPPerm4Perm2(Obj f, Obj p)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
+
     UInt    deg, rank, degconj, i, j, k, codeg;
     UInt4 * ptf, *ptconj, dep;
     UInt2 * ptp;
@@ -3716,6 +3864,9 @@ Obj PowPPerm4Perm2(Obj f, Obj p)
 
 Obj PowPPerm4Perm4(Obj f, Obj p)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
+
     UInt   deg, rank, degconj, i, j, k, codeg;
     UInt4 *ptf, *ptp, *ptconj, dep;
     Obj    conj, dom;
@@ -3775,6 +3926,9 @@ Obj PowPPerm4Perm4(Obj f, Obj p)
 // JDM not sure this is worth it...
 Obj PowPPerm22(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+
     UInt2 *ptg, *ptf, *ptconj, img;
     UInt   i, j, def, deg, dec, codeg, codec, min, len;
     Obj    dom, conj;
@@ -3993,6 +4147,9 @@ Obj PowPPerm22(Obj f, Obj g)
 
 Obj PowPPerm24(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
+
     UInt4 * ptg, *ptconj;
     UInt2 * ptf;
     UInt    i, j, def, deg, dec, codeg, codec, min, img, len;
@@ -4212,6 +4369,9 @@ Obj PowPPerm24(Obj f, Obj g)
 
 Obj PowPPerm42(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+
     UInt4 * ptf, *ptconj;
     UInt2 * ptg;
     UInt    i, j, def, deg, dec, codeg, codec, min, img, len;
@@ -4431,6 +4591,9 @@ Obj PowPPerm42(Obj f, Obj g)
 
 Obj PowPPerm44(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
+
     UInt4 *ptg, *ptf, *ptconj, img;
     UInt   i, j, def, deg, dec, codeg, codec, min, len;
     Obj    dom, conj;
@@ -4650,6 +4813,9 @@ Obj PowPPerm44(Obj f, Obj g)
 // f*p^-1
 Obj QuoPPerm2Perm2(Obj f, Obj p)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
+
     UInt2 *ptf, *ptp, *ptquo2;
     UInt4 *ptquo4, *pttmp;
     Obj    quo, dom;
@@ -4763,6 +4929,9 @@ Obj QuoPPerm2Perm2(Obj f, Obj p)
 
 Obj QuoPPerm4Perm4(Obj f, Obj p)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
+
     UInt4 *ptf, *ptp, *ptquo, *pttmp;
     Obj    quo, dom;
     UInt   codeg, lmp, deg, i, j, rank;
@@ -4845,6 +5014,9 @@ Obj QuoPPerm4Perm4(Obj f, Obj p)
 
 Obj QuoPPerm2Perm4(Obj f, Obj p)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
+
     UInt4 * ptp, *ptquo, *pttmp;
     UInt2 * ptf;
     Obj     quo, dom;
@@ -4904,6 +5076,9 @@ Obj QuoPPerm2Perm4(Obj f, Obj p)
 
 Obj QuoPPerm4Perm2(Obj f, Obj p)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
+
     UInt4 * ptf, *ptquo, *pttmp;
     UInt2 * ptp;
     Obj     quo, dom;
@@ -4961,6 +5136,9 @@ Obj QuoPPerm4Perm2(Obj f, Obj p)
 // f*g^-1 for partial perms
 Obj QuoPPerm22(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+
     UInt   deg, i, j, deginv, codeg, rank;
     UInt2 *ptf, *ptg;
     UInt4 *ptquo, *pttmp;
@@ -5039,6 +5217,9 @@ Obj QuoPPerm22(Obj f, Obj g)
 
 Obj QuoPPerm24(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
+
     UInt    deg, i, j, deginv, codeg, rank;
     UInt2 * ptf;
     UInt4 * ptg, *ptquo, *pttmp;
@@ -5124,6 +5305,9 @@ Obj QuoPPerm24(Obj f, Obj g)
 
 Obj QuoPPerm42(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+
     UInt    deg, i, j, deginv, codeg, rank;
     UInt2 * ptg;
     UInt4 * ptf, *ptquo, *pttmp;
@@ -5209,6 +5393,9 @@ Obj QuoPPerm42(Obj f, Obj g)
 
 Obj QuoPPerm44(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
+
     UInt   deg, i, j, deginv, codeg, rank;
     UInt4 *ptf, *ptg, *ptquo, *pttmp;
     Obj    quo, dom;
@@ -5287,6 +5474,7 @@ Obj QuoPPerm44(Obj f, Obj g)
 // i^f
 Obj PowIntPPerm2(Obj i, Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
 
     if (!IS_INTOBJ(i) || INT_INTOBJ(i) <= 0) {
         ErrorQuit("usage: the first argument should be a positive integer,",
@@ -5299,6 +5487,7 @@ Obj PowIntPPerm2(Obj i, Obj f)
 
 Obj PowIntPPerm4(Obj i, Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
 
     if (!IS_INTOBJ(i) || INT_INTOBJ(i) <= 0) {
         ErrorQuit("usage: the first argument should be a positive integer,",
@@ -5312,6 +5501,9 @@ Obj PowIntPPerm4(Obj i, Obj f)
 // p^-1*f
 Obj LQuoPerm2PPerm2(Obj p, Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+
     UInt2 *ptp, *ptf, *ptlquo, dep;
     UInt   def, i, j, del, len;
     Obj    dom, lquo;
@@ -5393,6 +5585,9 @@ Obj LQuoPerm2PPerm2(Obj p, Obj f)
 
 Obj LQuoPerm2PPerm4(Obj p, Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+
     UInt2 *ptp, dep;
     UInt4 *ptf, *ptlquo;
     UInt   def, i, j, del, len;
@@ -5474,6 +5669,9 @@ Obj LQuoPerm2PPerm4(Obj p, Obj f)
 
 Obj LQuoPerm4PPerm2(Obj p, Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+
     UInt4 *ptp, dep;
     UInt2 *ptf, *ptlquo;
     UInt   def, i, j, del, len;
@@ -5556,6 +5754,9 @@ Obj LQuoPerm4PPerm2(Obj p, Obj f)
 
 Obj LQuoPerm4PPerm4(Obj p, Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+
     UInt4 *ptp, *ptf, *ptlquo, dep;
     UInt   def, i, j, del, len;
     Obj    dom, lquo;
@@ -5638,6 +5839,9 @@ Obj LQuoPerm4PPerm4(Obj p, Obj f)
 // f^-1*g
 Obj LQuoPPerm22(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+
     UInt2 *ptg, *ptf, *ptlquo;
     UInt   i, j, def, deg, del, codef, codel, min, len;
     Obj    dom, lquo;
@@ -5744,6 +5948,9 @@ Obj LQuoPPerm22(Obj f, Obj g)
 
 Obj LQuoPPerm24(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
+
     UInt4 * ptg, *ptlquo;
     UInt2 * ptf;
     UInt    i, j, def, deg, del, codef, codel, min, len;
@@ -5851,6 +6058,9 @@ Obj LQuoPPerm24(Obj f, Obj g)
 
 Obj LQuoPPerm42(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+
     UInt2 * ptg, *ptlquo;
     UInt4 * ptf;
     UInt    i, j, def, deg, del, codef, codel, min, len;
@@ -5958,6 +6168,9 @@ Obj LQuoPPerm42(Obj f, Obj g)
 
 Obj LQuoPPerm44(Obj f, Obj g)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
+
     UInt4 *ptg, *ptf, *ptlquo;
     UInt   i, j, def, deg, del, codef, codel, min, len;
     Obj    dom, lquo;
@@ -6083,6 +6296,7 @@ Obj OnSetsPPerm(Obj set, Obj f)
 
     GAP_ASSERT(IS_PLIST(set));
     GAP_ASSERT(LEN_PLIST(set) > 0);
+    GAP_ASSERT(IS_PPERM(f));
 
     const UInt len = LEN_PLIST(set);
 
@@ -6178,6 +6392,7 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
 
     GAP_ASSERT(IS_PLIST(tup));
     GAP_ASSERT(LEN_PLIST(tup) > 0);
+    GAP_ASSERT(IS_PPERM(f));
 
     const UInt len = LEN_PLIST(tup);
 
@@ -6232,6 +6447,9 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
 
 Obj FuncOnPosIntSetsPartialPerm(Obj self, Obj set, Obj f)
 {
+    GAP_ASSERT(IS_LIST(set));
+    GAP_ASSERT(IS_PPERM(f));
+
     UInt2 * ptf2;
     UInt4 * ptf4;
     UInt    deg;
@@ -6304,6 +6522,8 @@ Obj FuncOnPosIntSetsPartialPerm(Obj self, Obj set, Obj f)
 /* Save and load */
 void SavePPerm2(Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+
     UInt2 * ptr;
     UInt    len, i;
     len = DEG_PPERM2(f);
@@ -6314,6 +6534,8 @@ void SavePPerm2(Obj f)
 
 void LoadPPerm2(Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+
     UInt2 * ptr;
     UInt    len, i;
     len = DEG_PPERM2(f);
@@ -6324,6 +6546,8 @@ void LoadPPerm2(Obj f)
 
 void SavePPerm4(Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+
     UInt4 * ptr;
     UInt    len, i;
     len = DEG_PPERM4(f);
@@ -6334,6 +6558,8 @@ void SavePPerm4(Obj f)
 
 void LoadPPerm4(Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
+
     UInt4 * ptr;
     UInt    len, i;
     len = DEG_PPERM4(f);
@@ -6346,6 +6572,7 @@ Obj TYPE_PPERM2;
 
 Obj TypePPerm2(Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     return TYPE_PPERM2;
 }
 
@@ -6353,6 +6580,7 @@ Obj TYPE_PPERM4;
 
 Obj TypePPerm4(Obj f)
 {
+    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     return TYPE_PPERM4;
 }
 

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -316,17 +316,17 @@ static Obj PreImagePPermInt(Obj pt, Obj f)
     if (TNUM_OBJ(f) == T_PPERM2) {
         ptf2 = ADDR_PPERM2(f);
         deg = DEG_PPERM2(f);
-        while (ptf2[i] != cpt && i < deg)
+        while (i < deg && ptf2[i] != cpt)
             i++;
-        if (ptf2[i] != cpt)
+        if (i == deg || ptf2[i] != cpt)
             return Fail;
     }
     else {
         ptf4 = ADDR_PPERM4(f);
         deg = DEG_PPERM4(f);
-        while (ptf4[i] != cpt && i < deg)
+        while (i < deg && ptf4[i] != cpt)
             i++;
-        if (ptf4[i] != cpt)
+        if (i == deg || ptf4[i] != cpt)
             return Fail;
     }
     return INTOBJ_INT(i + 1);

--- a/tst/testinstall/invsgp.tst
+++ b/tst/testinstall/invsgp.tst
@@ -5,7 +5,6 @@
 ##
 #Y  Copyright (C) 2016
 ##
-
 gap> START_TEST("invsgp.tst");
 
 # Test String method for inverse semigroup with generators as a semigroup
@@ -43,16 +42,16 @@ true
 # Test string method for inverse monoid with inverse monoid generators
 gap> S := InverseMonoid(PartialPerm([1, 2, 3]), PartialPerm([1], [2]));;
 gap> String(S);
-"InverseMonoid( [ PartialPermNC( [ 1, 2, 3 ], [ 1, 2, 3 ] ), PartialPermNC( [ \
-1 ], [ 2 ] ) ] )"
+"InverseMonoid( [ PartialPerm( [ 1, 2, 3 ], [ 1, 2, 3 ] ), PartialPerm( [ 1 ],\
+ [ 2 ] ) ] )"
 gap> S = EvalString(String(S));
 true
 
 # Test string method for inverse semigroup with inverse semigroup generators
 gap> S := InverseSemigroup(PartialPerm([1, 2, 3]), PartialPerm([1], [2]));;
 gap> String(S);
-"InverseMonoid( [ PartialPermNC( [ 1, 2, 3 ], [ 1, 2, 3 ] ), PartialPermNC( [ \
-1 ], [ 2 ] ) ] )"
+"InverseMonoid( [ PartialPerm( [ 1, 2, 3 ], [ 1, 2, 3 ] ), PartialPerm( [ 1 ],\
+ [ 2 ] ) ] )"
 gap> S = EvalString(String(S));
 true
 

--- a/tst/testinstall/pperm.tst
+++ b/tst/testinstall/pperm.tst
@@ -38,6 +38,8 @@ gap> ImageSetOfPartialPerm(f);
 [  ]
 gap> ImageListOfPartialPerm(f);
 [  ]
+gap> IMAGE_SET_PPERM(fail);
+Error, usage: the argument must be a partial perm,
 
 # test input validation
 gap> DegreeOfPartialPerm(fail);
@@ -120,6 +122,12 @@ gap> IndexPeriodOfPartialPerm(f);
 [ 2, 15 ]
 gap> IsIdempotent(f);
 false
+gap> IndexPeriodOfPartialPerm(PartialPerm([1, 2, 10 ^ 5], [2, 10 ^ 5, 1]));
+[ 1, 3 ]
+gap> IsIdempotent(PartialPerm([2,3,1,5,6,7,8,4,10]));
+false
+gap> IsIdempotent(PartialPermNC([1 .. 70000] + 1));
+false
 
 # ComponentsOfPartialPerm, NrComponentsOfPartialPerm, 
 # ComponentRepsOfPartialPerm and ComponentPartialPermInt
@@ -157,6 +165,24 @@ gap> ComponentRepsOfPartialPerm(f);
 [ 9, 1, 4 ]
 gap> NrComponentsOfPartialPerm(f);
 3
+gap> ComponentRepsOfPartialPerm(PartialPerm([1, 2, 10 ^ 5], [2, 10 ^ 5, 1]));
+[ 1 ]
+gap> NrComponentsOfPartialPerm(PartialPerm([1, 2, 10 ^ 5], [2, 10 ^ 5, 1]));
+1
+gap> ComponentsOfPartialPerm(PartialPerm([1, 2, 10 ^ 5], [2, 10 ^ 5, 1]));
+[ [ 1, 2, 100000 ] ]
+gap> ComponentPartialPermInt(PartialPerm([1, 2, 10 ^ 5], [2, 10 ^ 5, 1]),
+>                              100000);
+[ 100000, 1, 2 ]
+gap> ComponentPartialPermInt(PartialPerm([1, 2, 10 ^ 5], [2, 10 ^ 5, 1]),
+>                              1000);
+[  ]
+gap> ComponentPartialPermInt(PartialPerm([1, 3], [3, 1]),
+>                              1000);
+[  ]
+gap> ComponentPartialPermInt(PartialPerm([1, 2], [2, 1]),
+>                              2);
+[ 2, 1 ]
 
 # FixedPointsOfPartialPerm, MovedPoints, 
 # NrFixedPoints, NrMovedPoints
@@ -179,6 +205,8 @@ gap> DomainOfPartialPerm(f);;
 gap> FixedPointsOfPartialPerm(f)=
 > Filtered([1..DegreeOfPartialPerm(f)], i-> i^f=i);
 true
+gap> NrFixedPoints(f);
+0
 gap> f:=PartialPerm([1, 100000], [100000, 2]);;
 gap> NrMovedPoints(f)+NrFixedPoints(f)=
 > RankOfPartialPerm(f);
@@ -196,6 +224,89 @@ gap> Union(MovedPoints(f), FixedPointsOfPartialPerm(f))=
 > DomainOfPartialPerm(f);
 true
 gap> Intersection(MovedPoints(f), FixedPointsOfPartialPerm(f));
+[  ]
+gap> f := PartialPerm(List([69950 .. 70000], function(x) 
+>   if IsEvenInt(x) then 
+>     return 0;
+>   else
+>     return x;
+>   fi;
+> end));;
+gap> FixedPointsOfPartialPerm(f);
+[  ]
+gap> NrFixedPoints(f);
+0
+gap> MovedPoints(f);
+[ 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 
+  42, 44, 46, 48, 50 ]
+gap> NrMovedPoints(f);
+25
+gap> im := ListWithIdenticalEntries(70000, 0);;
+gap> im[65536] := 65536;
+65536
+gap> f := PartialPerm(im);;
+gap> FixedPointsOfPartialPerm(f);
+[ 65536 ]
+gap> NrFixedPoints(f);
+1
+gap> MovedPoints(f);
+[  ]
+gap> NrMovedPoints(f);
+0
+gap> f := PartialPerm(List([7950 .. 8000], function(x) 
+>   if IsEvenInt(x) then 
+>     return 0;
+>   else
+>     return x;
+>   fi;
+> end));;
+gap> FixedPointsOfPartialPerm(f);
+[  ]
+gap> NrFixedPoints(f);
+0
+gap> MovedPoints(f);
+[ 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 
+  42, 44, 46, 48, 50 ]
+gap> NrMovedPoints(f);
+25
+gap> f := PartialPerm(List([1 .. 100], function(x) 
+>   if IsEvenInt(x) then 
+>     return 0;
+>   else
+>     return x;
+>   fi;
+> end));;
+gap> FixedPointsOfPartialPerm(f);
+[ 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 
+  41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 
+  79, 81, 83, 85, 87, 89, 91, 93, 95, 97, 99 ]
+gap> NrFixedPoints(f);
+50
+gap> MovedPoints(f);
+[  ]
+gap> NrMovedPoints(f);
+0
+gap> f := PartialPerm([1, 3 .. 99], [1, 3 .. 99]);;
+gap> FixedPointsOfPartialPerm(f);
+[ 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 
+  41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 
+  79, 81, 83, 85, 87, 89, 91, 93, 95, 97, 99 ]
+gap> NrFixedPoints(f);
+50
+gap> MovedPoints(f);
+[  ]
+gap> NrMovedPoints(f);
+0
+gap> f := PartialPerm([70001, 70003 .. 70099], [70001, 70003 .. 70099]);;
+gap> FixedPointsOfPartialPerm(f);
+[ 70001, 70003, 70005, 70007, 70009, 70011, 70013, 70015, 70017, 70019, 
+  70021, 70023, 70025, 70027, 70029, 70031, 70033, 70035, 70037, 70039, 
+  70041, 70043, 70045, 70047, 70049, 70051, 70053, 70055, 70057, 70059, 
+  70061, 70063, 70065, 70067, 70069, 70071, 70073, 70075, 70077, 70079, 
+  70081, 70083, 70085, 70087, 70089, 70091, 70093, 70095, 70097, 70099 ]
+gap> NrFixedPoints(f);
+50
+gap> MovedPoints(f);
 [  ]
 
 # LargestMovedPoint, SmallestMovedPoint
@@ -275,13 +386,24 @@ gap> SmallestMovedPoint(f);
 gap> f:=PartialPermNC(Concatenation([100001], [2..100000]));;
 gap> SmallestMovedPoint(f);
 1
-gap> f:=PartialPermNC([1..100000]);                          
-<partial perm on 100000 pts with degree 100000, codegree 100000>
+gap> f:=PartialPermNC([1..70000]);;
 gap> SmallestMovedPoint(f);
+infinity
+gap> LargestMovedPoint(f);
+0
+gap> f := PartialPermNC([1 .. 10]);;
+gap> SmallestMovedPoint(f);
+infinity
+gap> f := PartialPermNC([1 .. 10], [1 .. 10]);;
+gap> SmallestMovedPoint(f);
+infinity
+gap> SmallestMovedPoint(PartialPerm([69999, 70001], [69999, 70001]));
 infinity
 
 # TRIM_PPERM
 gap> f:=PartialPermNC([65536]); 
+[1,65536]
+gap> TRIM_PPERM(f);
 [1,65536]
 gap> g:=PartialPermNC([2,65536], [70000,1]);           
 [2,70000][65536,1]
@@ -301,8 +423,34 @@ gap> TRIM_PPERM(h); h;
 gap> IsPPerm2Rep(h);
 true
 
+# HashFuncForPPerm and HASH_FUNC_FOR_PPERM
+gap> f := PartialPerm([65536]);;
+gap> HASH_FUNC_FOR_PPERM(f, 10 ^ 6);
+260581
+gap> f := PartialPermNC([65535]);;
+gap> HASH_FUNC_FOR_PPERM(f, 10 ^ 6);
+354405
+gap> f := PartialPermNC([65535]);;
+gap> HASH_FUNC_FOR_PPERM(f, 10 ^ 6);
+354405
+gap> f := PartialPerm([1, 2, 3, 4, 5, 6, 7, 9, 11, 12, 15, 16, 19],
+> [2, 4, 11, 1, 20, 10, 15, 16, 5, 3, 6, 12, 9]);;
+gap> HASH_FUNC_FOR_PPERM(f, 10 ^ 6);
+773594
+gap> f := PartialPermNC([65536]);;
+gap> g := PartialPermNC([2, 65536], [70000, 1]);;
+gap> h := f * g;
+<identity partial perm on [ 1 ]>
+gap> IsPPerm4Rep(h);
+true
+gap> HASH_FUNC_FOR_PPERM(h, 10 ^ 6);
+567548
+gap> IsPPerm2Rep(h);
+true
+
 # LeftOne
-gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );; DomainOfPartialPerm(f);;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );;
+> DomainOfPartialPerm(f);;
 gap> e:=LeftOne(f);;
 gap> IsIdempotent(e);
 true
@@ -543,6 +691,10 @@ true
 gap> g:=PartialPerm( [ 1, 3 ], [ 3, 1 ] );;     
 gap> NaturalLeqPartialPerm(f,g);
 false
+gap> NaturalLeqPartialPerm(fail, f);
+Error, usage: the arguments must be partial perms,
+gap> NaturalLeqPartialPerm(EmptyPartialPerm(), f);
+true
 
 # AsPartialPerm
 gap> p:=(1,2,7,5)(3,9)(6,10,8);;
@@ -577,6 +729,22 @@ gap> AsPartialPerm(p,9);
 gap> p:=(1,9)(10,100000);;
 gap> AsPartialPerm(p,9);
 (1,9)(2)(3)(4)(5)(6)(7)(8)
+gap> AsPartialPerm((1,2), [1, 2, 2 ^ 61]);
+Error, usage: the second argument must be a set of positive integers,
+gap> AsPartialPerm((1,2), [1, 3, 2]);
+Error, usage: the second argument must be a set of positive integers,
+gap> AsPartialPerm((1,2), [1, "a", 2]);
+Error, usage: the second argument must be a set of positive integers,
+gap> AsPartialPerm((1,2), 0);
+<empty partial perm>
+gap> AsPartialPerm(Transformation([10, 8, 4, 6, 4, 5, 3, 8, 8, 2]), [1 .. 4]);
+[1,10][2,8][3,4,6]
+gap> AsPartialPerm(Transformation([10, 8, 4, 6, 4, 5, 3, 8, 8, 2]), [1 .. 5]);
+Error, usage: the first argument must be injective on the second,
+gap> AsPartialPerm(Transformation([10, 8, 4, 6, 4, 5, 3, 8, 8, 2]), [1, 2, 2, 3]);
+Error, usage: the second argument must be a set of positive integers,
+gap> AsPartialPerm(Transformation([10, 8, 4, 6, 4, 5, 3, 8, 8, 2]), 4);
+[1,10][2,8][3,4,6]
 
 # JoinOfPartialPerms
 gap> f:=PartialPermNC([1],[2]);;
@@ -622,6 +790,10 @@ gap> g:=PartialPermNC([0,100000]);
 [2,100000]
 gap> JoinOfPartialPerms(f,g);
 [1,2,100000]
+gap> JoinOfPartialPerms([f, g]);
+[1,2,100000]
+gap> JoinOfPartialPerms(1, 2);
+Error, usage: the argument should be a collection of partial perms,
 gap> JoinOfPartialPerms(last, PartialPermNC([100000],[1]));
 (1,2,100000)
 gap> g:=PartialPermNC([0,100000]);;
@@ -674,6 +846,24 @@ gap> g:=PartialPermNC([8],[100000]);
 [8,100000]
 gap> JoinOfPartialPerms(f, g);
 [6,1,5,3][8,100000](4,7)
+
+# JOIN_IDEM_PPERMS
+gap> JOIN_IDEM_PPERMS(PartialPerm([1 .. 5]), 
+>                     PartialPerm([3 .. 10], [3 .. 10]));
+<identity partial perm on [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]>
+gap> JOIN_IDEM_PPERMS(PartialPerm([3 .. 10], [3 .. 10]),
+>                     PartialPerm([1 .. 5]));
+<identity partial perm on [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]>
+gap> JOIN_IDEM_PPERMS(PartialPerm([3 .. 10], [3 .. 10]),
+>                     PartialPerm([65536 .. 65538], [65536 .. 65538]));
+<identity partial perm on [ 3, 4, 5, 6, 7, 8, 9, 10, 65536, 65537, 65538 ]>
+gap> JOIN_IDEM_PPERMS(PartialPerm([70000 .. 70010], [70000 .. 70010]),
+>                     PartialPerm([65536 .. 65538], [65536 .. 65538]));
+<identity partial perm on 
+[ 65536, 65537, 65538, 70000, 70001, 70002, 70003, 70004, 70005, 70006, 70007,\
+ 70008, 70009, 70010 ]>
+gap> JoinOfIdempotentPartialPermsNC(1, 2);
+Error, usage: the argument should be a collection of partial perms,
 
 # MeetOfPartialPerms
 gap> f:=PartialPermNC([2]);;
@@ -739,6 +929,10 @@ gap> g:=RestrictedPartialPerm(f, [10]);
 <empty partial perm>
 gap> g:=RestrictedPartialPerm(f, [5]); 
 <identity partial perm on [ 5 ]>
+gap> RestrictedPartialPerm(f, [2, 1, 3]);
+Error, usage: the second argument must be a set of positive integers,
+gap> RestrictedPartialPerm(f, [1, 2, 2 ^ 61]);
+Error, usage: the second argument must be a set of positive integers,
 
 # AsPermutation
 gap> f:=PartialPermNC([10,2,3,4,5]);      
@@ -812,6 +1006,8 @@ gap> PermLeftQuoPartialPerm(f, g);
 (1,2)
 gap> PermLeftQuoPartialPerm(g, f);
 (1,2)
+gap> PermLeftQuoPartialPerm(PartialPerm([1]), PartialPerm([2]));
+Error, usage: the arguments must be partial perms with equal image sets,
 
 # Kernel level functions
 #
@@ -2337,6 +2533,10 @@ gap> AsTransformation(f);
 <transformation: 9,11,10,5,7,2,11,11,8,11>
 gap> AsTransformation(f);
 <transformation: 9,11,10,5,7,2,11,11,8,11>
+gap> AsTransformation(PartialPerm([1, 2, 3, 5, 6, 9, 10],
+>                                 [3, 5, 8, 4, 1, 9, 7]), 
+>                     3);
+Error, usage: the 2nd argument must not be a moved point of the 1st argument,
 gap> OnTuples([1..DegreeOfPartialPerm(f)], f);
 [ 9, 10, 5, 7, 2, 8 ]
 gap> g:=PartialPermNC([ 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 19 ],
@@ -2462,6 +2662,182 @@ gap> PartialPerm([1,2,8],[3,4,1,2]);
 Error, usage: the 1st argument must be a set of positive integers and the 2nd \
 argument must be a duplicate-free list of positive integers of equal length to\
  the first
+
+# New tests
+gap> x := PartialPerm([0, 0, 0]);
+<empty partial perm>
+
+# PreImagePPermInt
+gap> 1 / EmptyPartialPerm();
+fail
+gap> 1 / PartialPerm([1, 2, 4, 7, 9], [5, 3, 7, 4, 9]);
+fail
+gap> 3 / PartialPerm([1, 2, 4, 7, 9], [5, 3, 7, 4, 9]);
+2
+gap> 3 / PartialPerm([10 ^ 5], [3]);
+100000
+gap> 1 / PartialPerm([10 ^ 5], [3]);
+fail
+gap> 3 / PartialPerm([10 ^ 5], [10 ^ 5 + 1]);
+fail
+gap> (10 ^ 5 + 1) / PartialPerm([10 ^ 5], [10 ^ 5 + 1]);
+100000
+gap> PreImagePartialPerm(PartialPerm([1, 2, 4, 7, 9], [5, 3, 7, 4, 9]), 1);
+fail
+gap> PreImagePartialPerm(PartialPerm([10 ^ 5], [3]), 3);
+100000
+
+# IsGeneratorsOfMagmaWithInverses
+gap> IsGeneratorsOfMagmaWithInverses([PartialPerm([2]), PartialPerm([1])]);
+false
+gap> IsGeneratorsOfMagmaWithInverses([PartialPerm([2, 1]), PartialPerm([1])]);
+false
+gap> IsGeneratorsOfMagmaWithInverses([PartialPerm([2, 1]), PartialPerm([1, 2])]);
+true
+
+# LargestImageOfMovedPoint
+gap> LargestImageOfMovedPoint(EmptyPartialPerm());
+0
+
+# SmallestImageOfMovedPoint
+gap> SmallestImageOfMovedPoint(EmptyPartialPerm());
+infinity
+gap> SmallestImageOfMovedPoint(PartialPerm([1, 2, 4, 7, 9], [1, 2, 7, 4, 9]));
+4
+
+# PartialPermOp/NC
+gap> f := Transformation([9, 10, 4, 2, 10, 5, 9, 10, 9, 6]);;
+gap> PartialPermOp(f, [6 .. 8], OnPoints);
+[1,4][2,5][3,6]
+gap> f := Transformation([9, 10, 4, 2, 10, 5, 9, 10, 9, 6]);;
+gap> PartialPermOp(f, [8, 6, 7], OnPoints);
+[1,5][2,6][3,4]
+gap> PartialPermOp(f, [8, 6, 7, 6], OnPoints);
+fail
+gap> PartialPermOp(f, [7, 9], OnPoints);
+fail
+gap> PartialPermOp(f, [10, 11, 12], OnPoints);
+[1,4](2)(3)
+gap> PartialPermOp(f, [10, 11, 12]);
+[1,4](2)(3)
+gap> PartialPermOp(f, [10, 11, 12], function(x, f)
+> if x > 10 then return 100; else return x ^ f; fi; end);
+fail
+gap> PartialPermOp(PartialPerm([1]), SymmetricInverseMonoid(2), OnRight);
+fail
+gap> PartialPermOp(PartialPerm([1]), SymmetricInverseMonoid(1), OnRight);
+<identity partial perm on [ 1, 2 ]>
+gap> PartialPermOp(PartialPerm([1]), SymmetricInverseMonoid(1));
+<identity partial perm on [ 1, 2 ]>
+gap> f := Transformation([9, 10, 4, 2, 10, 5, 9, 10, 9, 6]);;
+gap> PartialPermOpNC(f, [6 .. 8], OnPoints);
+[1,4][2,5][3,6]
+gap> f := Transformation([9, 10, 4, 2, 10, 5, 9, 10, 9, 6]);;
+gap> PartialPermOpNC(f, [8, 6, 7], OnPoints);
+[1,5][2,6][3,4]
+gap> PartialPermOpNC(f, [10, 11, 12], OnPoints);
+[1,4](2)(3)
+gap> PartialPermOpNC(f, [10, 11, 12]);
+[1,4](2)(3)
+gap> PartialPermOpNC(f, [10, 11, 12], function(x, f)
+> if x > 10 then return 100; else return x ^ f; fi; end);
+[1,4][2,5][3,6]
+gap> PartialPermOpNC(PartialPerm([1]), SymmetricInverseMonoid(1), OnRight);
+<identity partial perm on [ 1, 2 ]>
+gap> PartialPermOpNC(PartialPerm([1]), SymmetricInverseMonoid(1));
+<identity partial perm on [ 1, 2 ]>
+
+# RandomPartialPerm
+gap> RandomPartialPerm(4);;
+gap> RandomPartialPerm(2 ^ 60);
+Error, usage: the argument must be a positive integer, a set, or 2 sets, of po\
+sitive integers,
+gap> f := RandomPartialPerm([4 .. 10]);;
+gap> IsSubset([4 .. 10], DomainOfPartialPerm(f));
+true
+gap> IsSubset([4 .. 10], ImageSetOfPartialPerm(f));
+true
+gap> f := RandomPartialPerm([6 .. 10], [1 .. 5]);;
+gap> IsSubset([6 .. 10], DomainOfPartialPerm(f));
+true
+gap> IsSubset([1 .. 5], ImageSetOfPartialPerm(f));
+true
+gap> f := RandomPartialPerm([1, 2 ^ 60]);
+Error, usage: the argument must be a positive integer, a set, or 2 sets, of po\
+sitive integers,
+gap> f := RandomPartialPerm([3, 1, 2]);
+Error, usage: the argument must be a positive integer, a set, or 2 sets, of po\
+sitive integers,
+gap> f := RandomPartialPerm([1 .. 3], [3, 1, 2]);
+Error, usage: the argument must be a positive integer, a set, or 2 sets, of po\
+sitive integers,
+gap> f := RandomPartialPerm([3, 1, 2], [1 .. 3]);
+Error, usage: the argument must be a positive integer, a set, or 2 sets, of po\
+sitive integers,
+gap> f := RandomPartialPerm([3, 1, 2], [1, 3, 2 ^ 60]);
+Error, usage: the argument must be a positive integer, a set, or 2 sets, of po\
+sitive integers,
+
+# PartialPermNC
+gap> PartialPermNC(1, 2, 3);
+Error, usage: there should be one or two arguments,
+gap> PartialPerm(1, 2, 3);
+Error, usage: there should be one or two arguments,
+gap> PartialPerm([1, 2, 2 ^ 60]);
+Error, usage: the argument must be a list of non-negative integers and the non\
+-zero elements must be duplicate-free,
+gap> PartialPerm([1, 2, 2]);
+Error, usage: the argument must be a list of non-negative integers and the non\
+-zero elements must be duplicate-free,
+
+# String etc
+gap> EvalString(String(PartialPerm([1, 2, 4, 7, 9], [5, 3, 7, 4, 9]))) 
+> = PartialPerm([1, 2, 4, 7, 9], [5, 3, 7, 4, 9]);
+true
+gap> PrintString(PartialPerm([1, 2, 4, 7, 9], [5, 3, 7, 4, 9]));
+"PartialPerm( \>[ 1, 2, 4, 7, 9 ], \<\>[ 5, 3, 7, 4, 9 ]\<\> )\<"
+gap> PrintObj(PartialPerm([1, 2, 4, 7, 9], [5, 3, 7, 4, 9])); 
+> "this string allows us to test the PrintObj method";
+PartialPerm( [ 1, 2, 4, 7, 9 ], [ 5, 3, 7, 4, 9 ]
+  )"this string allows us to test the PrintObj method"
+gap> SetUserPreference("NotationForPartialPerms", "domainimage");;
+gap> PartialPerm( [ 1, 2, 4, 7, 9 ], [ 5, 3, 7, 4, 9 ]);
+[ 1, 2, 4, 7, 9 ] -> [ 5, 3, 7, 4, 9 ]
+gap> PartialPerm([1, 2, 3]);
+<identity partial perm on [ 1, 2, 3 ]>
+gap> SetUserPreference("NotationForPartialPerms", notationpp);;
+gap> SetUserPreference("NotationForPartialPerms", "input");;
+gap> PartialPerm( [ 1, 2, 4, 7, 9 ], [ 5, 3, 7, 4, 9 ]);
+PartialPerm( [ 1, 2, 4, 7, 9 ], [ 5, 3, 7, 4, 9 ] )
+gap> SetUserPreference("NotationForPartialPerms", notationpp);;
+
+# Collections
+gap> coll := [PartialPerm([1, 2, 4, 7, 9], [5, 3, 7, 4, 9]), 
+>             PartialPerm([1, 2, 4, 5, 6, 7], [1, 8, 9, 7, 5, 3])];;
+gap> DegreeOfPartialPermCollection(coll);
+9
+gap> CodegreeOfPartialPermCollection(coll);
+9
+gap> RankOfPartialPermCollection(coll);
+7
+gap> ImageOfPartialPermCollection(coll);
+[ 1, 3, 4, 5, 7, 8, 9 ]
+gap> FixedPointsOfPartialPerm(coll);
+[ 1, 9 ]
+gap> MovedPoints(coll);
+[ 1, 2, 4, 5, 6, 7 ]
+gap> NrFixedPoints(coll);
+2
+gap> NrMovedPoints(coll);
+6
+gap> LargestMovedPoint(coll);
+7
+gap> LargestImageOfMovedPoint(coll);
+9
+gap> SmallestMovedPoint(coll);
+1
+gap> SmallestImageOfMovedPoint(coll);
+3
 
 #
 gap> SetUserPreference("PartialPermDisplayLimit", display);;

--- a/tst/testinstall/pperm.tst
+++ b/tst/testinstall/pperm.tst
@@ -49,7 +49,7 @@ Error, usage: the argument should be a partial perm,
 gap> 
 
 # SmallestIdempotentPower, IndexPeriodOfPartialPerm, IsIdempotent
-gap> f:=RandomPartialPerm(100000);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
 gap> IsIdempotent(f^SmallestIdempotentPower(f));
 true
 gap> x:=IndexPeriodOfPartialPerm(f);;
@@ -57,7 +57,7 @@ gap> f^x[1]=f^(x[1]+x[2]);
 true
 gap> RankOfPartialPerm(f^(x[1]-1))>RankOfPartialPerm(f^x[1]);
 true
-gap> f:=RandomPartialPerm(100000);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
 gap> IsIdempotent(f^SmallestIdempotentPower(f));
 true
 gap> x:=IndexPeriodOfPartialPerm(f);;
@@ -65,7 +65,7 @@ gap> f^x[1]=f^(x[1]+x[2]);
 true
 gap> RankOfPartialPerm(f^(x[1]-1))>RankOfPartialPerm(f^x[1]);
 true
-gap> f:=RandomPartialPerm(1000);;
+gap> f:=PartialPerm([1, 1000], [1000, 2]);;
 gap> IsIdempotent(f^SmallestIdempotentPower(f));
 true
 gap> x:=IndexPeriodOfPartialPerm(f);;
@@ -123,7 +123,7 @@ false
 
 # ComponentsOfPartialPerm, NrComponentsOfPartialPerm, 
 # ComponentRepsOfPartialPerm and ComponentPartialPermInt
-gap> f:=RandomPartialPerm(100000);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
 gap> NrComponentsOfPartialPerm(f)=Length(ComponentsOfPartialPerm(f));
 true
 gap> Union(ComponentsOfPartialPerm(f))=Union(DomainOfPartialPerm(f), 
@@ -132,7 +132,7 @@ true
 gap> List(ComponentRepsOfPartialPerm(f), i-> ComponentPartialPermInt(f, i))
 > =ComponentsOfPartialPerm(f);
 true
-gap> f:=RandomPartialPerm(100);;
+gap> f:=PartialPerm([1, 100], [100, 2]);;
 gap> NrComponentsOfPartialPerm(f)=Length(ComponentsOfPartialPerm(f));
 true
 gap> Union(ComponentsOfPartialPerm(f))=Union(DomainOfPartialPerm(f), 
@@ -160,7 +160,7 @@ gap> NrComponentsOfPartialPerm(f);
 
 # FixedPointsOfPartialPerm, MovedPoints, 
 # NrFixedPoints, NrMovedPoints
-gap> f:=RandomPartialPerm(100000);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
 gap> FixedPointsOfPartialPerm(f)=
 > Filtered([1..DegreeOfPartialPerm(f)], i-> i^f=i);
 true
@@ -168,16 +168,18 @@ gap> f:=PartialPermNC([1..100000]);
 <partial perm on 100000 pts with degree 100000, codegree 100000>
 gap> FixedPointsOfPartialPerm(f)=[1..100000];
 true
-gap> f:=RandomPartialPerm(20);;
+gap> f:=PartialPerm( [ 1, 2, 3, 4, 5, 6, 7, 9, 11, 12, 15, 16, 19 ],
+> [ 2, 4, 11, 1, 20, 10, 15, 16, 5, 3, 6, 12, 9 ] );;
 gap> FixedPointsOfPartialPerm(f)=
 > Filtered([1..DegreeOfPartialPerm(f)], i-> i^f=i);
 true
-gap> f:=RandomPartialPerm(20);;
+gap> f:=PartialPerm( [ 1, 2, 3, 4, 5, 6, 7, 9, 11, 12, 15, 16, 19 ],
+> [ 2, 4, 11, 1, 20, 10, 15, 16, 5, 3, 6, 12, 9 ] );;
 gap> DomainOfPartialPerm(f);;
 gap> FixedPointsOfPartialPerm(f)=
 > Filtered([1..DegreeOfPartialPerm(f)], i-> i^f=i);
 true
-gap> f:=RandomPartialPerm(100000);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
 gap> NrMovedPoints(f)+NrFixedPoints(f)=
 > RankOfPartialPerm(f);
 true
@@ -186,7 +188,7 @@ gap> Union(MovedPoints(f), FixedPointsOfPartialPerm(f))=
 true
 gap> Intersection(MovedPoints(f), FixedPointsOfPartialPerm(f));
 [  ]
-gap> f:=RandomPartialPerm(100);;
+gap> f:=PartialPerm([1, 100], [100, 2]);;
 gap> NrMovedPoints(f)+NrFixedPoints(f)=
 > RankOfPartialPerm(f);
 true
@@ -197,19 +199,19 @@ gap> Intersection(MovedPoints(f), FixedPointsOfPartialPerm(f));
 [  ]
 
 # LargestMovedPoint, SmallestMovedPoint
-gap> f:=RandomPartialPerm(100000);; DomainOfPartialPerm(f);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);; DomainOfPartialPerm(f);;
 gap> i:=LargestMovedPoint(f);;
 gap> i^f<>i;
 true
-gap> f:=RandomPartialPerm(100000);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
 gap> i:=LargestMovedPoint(f);;
 gap> i^f<>i;
 true
-gap> f:=RandomPartialPerm(100);;   DomainOfPartialPerm(f);;
+gap> f:=PartialPerm([1, 100], [100, 2]);;   DomainOfPartialPerm(f);;
 gap> i:=LargestMovedPoint(f);;
 gap> i^f<>i;
 true
-gap> f:=RandomPartialPerm(100);;
+gap> f:=PartialPerm([1, 100], [100, 2]);;
 gap> i:=LargestMovedPoint(f);;
 gap> i^f<>i;
 true
@@ -237,19 +239,19 @@ gap> f:=PartialPermNC([1..100000]);
 <partial perm on 100000 pts with degree 100000, codegree 100000>
 gap> LargestMovedPoint(f);
 0
-gap> f:=RandomPartialPerm(100000);; DomainOfPartialPerm(f);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);; DomainOfPartialPerm(f);;
 gap> i:=SmallestMovedPoint(f);;
 gap> i^f<>i;
 true
-gap> f:=RandomPartialPerm(100000);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
 gap> i:=SmallestMovedPoint(f);;
 gap> i^f<>i;
 true
-gap> f:=RandomPartialPerm(100);;   DomainOfPartialPerm(f);;
+gap> f:=PartialPerm([1, 100], [100, 2]);;   DomainOfPartialPerm(f);;
 gap> i:=SmallestMovedPoint(f);;
 gap> i^f<>i;
 true
-gap> f:=RandomPartialPerm(100);;
+gap> f:=PartialPerm([1, 100], [100, 2]);;
 gap> i:=SmallestMovedPoint(f);;
 gap> i^f<>i;
 true
@@ -300,7 +302,7 @@ gap> IsPPerm2Rep(h);
 true
 
 # LeftOne
-gap> f:=RandomPartialPerm(10);; DomainOfPartialPerm(f);;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );; DomainOfPartialPerm(f);;
 gap> e:=LeftOne(f);;
 gap> IsIdempotent(e);
 true
@@ -310,7 +312,7 @@ gap> DomainOfPartialPerm(e)=DomainOfPartialPerm(f);
 true
 gap> ImageListOfPartialPerm(e)=DomainOfPartialPerm(f);
 true
-gap> f:=RandomPartialPerm(10);;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );;
 gap> e:=LeftOne(f);;
 gap> IsIdempotent(e);
 true
@@ -320,7 +322,7 @@ gap> DomainOfPartialPerm(e)=DomainOfPartialPerm(f);
 true
 gap> ImageListOfPartialPerm(e)=DomainOfPartialPerm(f);
 true
-gap> f:=RandomPartialPerm(100000);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
 gap> e:=LeftOne(f);;
 gap> IsIdempotent(e);
 true
@@ -330,7 +332,7 @@ gap> DomainOfPartialPerm(e)=DomainOfPartialPerm(f);
 true
 gap> ImageListOfPartialPerm(e)=DomainOfPartialPerm(f);
 true
-gap> f:=RandomPartialPerm(100000);; DomainOfPartialPerm(f);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);; DomainOfPartialPerm(f);;
 gap> e:=LeftOne(f);;
 gap> IsIdempotent(e);
 true
@@ -354,7 +356,7 @@ gap> e*f=f;
 true
 
 #RightOne
-gap> f:=RandomPartialPerm(10);; ImageSetOfPartialPerm(f);;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );; ImageSetOfPartialPerm(f);;
 gap> e:=RightOne(f);;
 gap> IsIdempotent(e);
 true
@@ -364,7 +366,7 @@ gap> ImageListOfPartialPerm(e)=ImageSetOfPartialPerm(f);
 true
 gap> DomainOfPartialPerm(e)=ImageSetOfPartialPerm(f);
 true
-gap> f:=RandomPartialPerm(10);; 
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );; 
 gap> e:=RightOne(f);;
 gap> IsIdempotent(e);
 true
@@ -374,7 +376,7 @@ gap> ImageListOfPartialPerm(e)=ImageSetOfPartialPerm(f);
 true
 gap> DomainOfPartialPerm(e)=ImageSetOfPartialPerm(f);
 true
-gap> f:=RandomPartialPerm(100000);; ImageSetOfPartialPerm(f);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);; ImageSetOfPartialPerm(f);;
 gap> e:=RightOne(f);;
 gap> IsIdempotent(e);
 true
@@ -384,7 +386,7 @@ gap> ImageListOfPartialPerm(e)=ImageSetOfPartialPerm(f);
 true
 gap> DomainOfPartialPerm(e)=ImageSetOfPartialPerm(f);
 true
-gap> f:=RandomPartialPerm(100000);; 
+gap> f:=PartialPerm([1, 100000], [100000, 2]);; 
 gap> e:=RightOne(f);;
 gap> IsIdempotent(e);
 true
@@ -682,14 +684,14 @@ gap> f:=PartialPermNC( [ 1, 2, 3, 4, 5, 8, 10 ], [ 7, 1, 4, 3, 2, 6, 5 ] );;
 gap> g:=PartialPermNC( [ 1, 2, 3, 4, 5, 8, 10 ], [ 3, 1, 4, 2, 5, 6, 7 ] );;
 gap> MeetOfPartialPerms(f,g);
 [2,1][3,4][8,6]
-gap> f:=RandomPartialPerm(1000);;
+gap> f:=PartialPerm([1, 1000], [1000, 2]);;
 gap> g:=JoinOfPartialPerms(f, PartialPermNC([1001..2000], [1001..2000]));;
 gap> f=MeetOfPartialPerms(f, g);
 true
 gap> g:=JoinOfPartialPerms(f, PartialPermNC([1001..100000], [1001..100000]));;
 gap> f=MeetOfPartialPerms(f, g);
 true
-gap> g:=RandomPartialPerm(1000);;
+gap> g:=PartialPerm([1, 1000], [1000, 2]);;
 gap> f:=JoinOfPartialPerms(g, PartialPermNC([1001..100000], [1001..100000]));;
 gap> g=MeetOfPartialPerms(f, g);
 true
@@ -747,13 +749,13 @@ gap> f:=RestrictedPartialPerm(f, [2..10]);
 <identity partial perm on [ 2, 3, 4, 5 ]>
 gap> AsPermutation(f);
 ()
-gap> f:=RandomPartialPerm(1000);;
+gap> f:=PartialPerm([1, 1000], [1000, 2]);;
 gap> x:=IndexPeriodOfPartialPerm(f);;
 gap> g:=f^x[1];;
 gap> OnTuples(DomainOfPartialPerm(g),AsPermutation(g))=
 > OnTuples(DomainOfPartialPerm(g), g);
 true
-gap> f:=RandomPartialPerm(100000);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
 gap> x:=IndexPeriodOfPartialPerm(f);;
 gap> g:=f^x[1];;
 gap> OnTuples(DomainOfPartialPerm(g),AsPermutation(g))=
@@ -763,12 +765,13 @@ gap> AsPermutation(f);
 fail
 
 # PermLeftQuoPartialPerm
-gap> f:=RandomPartialPerm(100);;
-gap> p:=Random(SymmetricGroup(ImageSetOfPartialPerm(f)));;
+gap> f := PartialPerm([1, 100], [100, 2]);;
+gap> p := (2, 100);;
 gap> g:=f*p;;
 gap> PermLeftQuoPartialPerm(f, g)=p;
 true
-gap> h:=RandomPartialPerm([101..100000]);;
+gap> h := PartialPerm([200, 300, 400, 1900, 10 ^ 6], 
+>                     [101, 113, 131, 450, 10 ^ 6]);;
 gap> h:=JoinOfPartialPerms(h, PartialPermNC([1..100], [1..100]));;
 gap> g=g*h;
 true
@@ -813,7 +816,7 @@ gap> PermLeftQuoPartialPerm(g, f);
 # Kernel level functions
 #
 # OnePPerm
-gap> f:=RandomPartialPerm(100000);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
 gap> e:=One(f);;
 gap> e*f=f;
 true
@@ -825,7 +828,7 @@ true
 gap> Union(DomainOfPartialPerm(f), ImageSetOfPartialPerm(f))=
 > ImageSetOfPartialPerm(e);
 true
-gap> f:=RandomPartialPerm(10000);;
+gap> f:=PartialPerm([1, 10000], [10000, 2]);;
 gap> e:=One(f);;
 gap> e*f=f;    
 true
@@ -862,8 +865,8 @@ gap> f=f*p;
 true
 
 # ProdPPerm2Perm2, Case 1 of 6: codeg(f)<=deg(p), domain known
-gap> f:=RandomPartialPerm(10);; DomainOfPartialPerm(f);;
-gap> p:=Random(SymmetricGroup(100));;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );; DomainOfPartialPerm(f);;
+gap> p:=(7, 100);;
 gap> g:=f*p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
@@ -873,8 +876,8 @@ gap> CodegreeOfPartialPerm(g)=Maximum(ImageSetOfPartialPerm(g));
 true
 
 # QuoPPerm2Perm2, Case 1 of 6: codeg(f)<=deg(p), domain known
-gap> f:=RandomPartialPerm(10);; DomainOfPartialPerm(f);;
-gap> p:=Random(SymmetricGroup(100));;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );; DomainOfPartialPerm(f);;
+gap> p:=(7, 100);;
 gap> g:=f/p;;
 gap> OnTuples(ImageListOfPartialPerm(f), p^-1)=ImageListOfPartialPerm(g);
 true
@@ -884,15 +887,15 @@ gap> f/p=f*p^-1;
 true
 
 # ProdPPerm2Perm2, Case 2 of 6: codeg(f)<=deg(p), domain not known
-gap> f:=RandomPartialPerm(10);;
-gap> p:=Random(SymmetricGroup(100));;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );;
+gap> p:=(7, 100);;
 gap> g:=f*p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
 gap> OnTuples(ImageListOfPartialPerm(f), p)=ImageListOfPartialPerm(g);
 true
-gap> f:=RandomPartialPerm(10);;
-gap> p:=Random(SymmetricGroup(100));;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );;
+gap> p:=(7, 100);;
 gap> g:=f*p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
@@ -902,8 +905,8 @@ gap> CodegreeOfPartialPerm(g)=Maximum(ImageSetOfPartialPerm(g));
 true
 
 # QuoPPerm2Perm2, Case 2 of 6: codeg(f)<=deg(p), domain not known
-gap> f:=RandomPartialPerm(10);;
-gap> p:=Random(SymmetricGroup(100));;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );;
+gap> p:=(7, 100);;
 gap> g:=f/p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
@@ -911,8 +914,8 @@ gap> OnTuples(ImageListOfPartialPerm(f), p^-1)=ImageListOfPartialPerm(g);
 true
 gap> f/p=f*p^-1;
 true
-gap> f:=RandomPartialPerm(10);;
-gap> p:=Random(SymmetricGroup(100));;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );;
+gap> p:=(7, 100);;
 gap> g:=f/p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
@@ -924,8 +927,8 @@ gap> f/p=f*p^-1;
 true
 
 # ProdPPerm2Perm2, Case 3 of 6: codeg(f)>deg(p), domain known
-gap> f:=RandomPartialPerm(100);; DomainOfPartialPerm(f);;
-gap> p:=Random(SymmetricGroup(10));;
+gap> f:=PartialPerm([1, 100], [100, 2]);; DomainOfPartialPerm(f);;
+gap> p:=(7, 10);;
 gap> g:=f*p;;
 gap> OnTuples(ImageListOfPartialPerm(f), p)=ImageListOfPartialPerm(g);
 true
@@ -933,8 +936,8 @@ gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
 gap> CodegreeOfPartialPerm(g)=Maximum(ImageSetOfPartialPerm(g));
 true
-gap> f:=RandomPartialPerm(65535);;
-gap> p:=Random(SymmetricGroup(10000));;
+gap> f:=PartialPerm([1, 65535], [65535, 2]);;
+gap> p:=(17, 10000);;
 gap> g:=f*p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
@@ -944,8 +947,8 @@ gap> CodegreeOfPartialPerm(g)=Maximum(ImageSetOfPartialPerm(g));
 true
 
 # QuoPPerm2Perm2, Case 3 of 6: codeg(f)>deg(p), domain known
-gap> f:=RandomPartialPerm(100);; DomainOfPartialPerm(f);;
-gap> p:=Random(SymmetricGroup(10));;
+gap> f:=PartialPerm([1, 100], [100, 2]);; DomainOfPartialPerm(f);;
+gap> p:=(7, 10);;
 gap> g:=f/p;;
 gap> OnTuples(ImageListOfPartialPerm(f), p^-1)=ImageListOfPartialPerm(g);
 true
@@ -955,8 +958,8 @@ gap> CodegreeOfPartialPerm(g)=Maximum(ImageSetOfPartialPerm(g));
 true
 gap> f/p=f*p^-1;
 true
-gap> f:=RandomPartialPerm(65535);;
-gap> p:=Random(SymmetricGroup(10000));;
+gap> f:=PartialPerm([1, 65535], [65535, 2]);;
+gap> p:=(17, 10000);;
 gap> g:=f/p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
@@ -968,8 +971,8 @@ gap> f/p=f*p^-1;
 true
 
 # ProdPPerm2Perm2, Case 4 of 6: codeg(f)>deg(p), domain not known
-gap> f:=RandomPartialPerm(100);;
-gap> p:=Random(SymmetricGroup(10));;   
+gap> f:=PartialPerm([1, 100], [100, 2]);;
+gap> p:=(7, 10);;   
 gap> g:=f*p;;                       
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
@@ -977,8 +980,8 @@ gap> OnTuples(ImageListOfPartialPerm(f), p)=ImageListOfPartialPerm(g);
 true
 gap> CodegreeOfPartialPerm(g)=Maximum(ImageSetOfPartialPerm(g));
 true
-gap> f:=RandomPartialPerm(10000);;
-gap> p:=Random(SymmetricGroup(1000));; 
+gap> f:=PartialPerm([1, 10000], [10000, 2]);;
+gap> p:=(13, 1000);; 
 gap> g:=f*p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
@@ -988,8 +991,8 @@ gap> CodegreeOfPartialPerm(g)=Maximum(ImageSetOfPartialPerm(g));
 true
 
 # QuoPPerm2Perm2, Case 4 of 6: codeg(f)>deg(p), domain not known
-gap> f:=RandomPartialPerm(100);;
-gap> p:=Random(SymmetricGroup(10));;   
+gap> f:=PartialPerm([1, 100], [100, 2]);;
+gap> p:=(7, 10);;   
 gap> g:=f/p;;                       
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
@@ -999,8 +1002,8 @@ gap> CodegreeOfPartialPerm(g)=Maximum(ImageSetOfPartialPerm(g));
 true
 gap> f/p=f*p^-1;
 true
-gap> f:=RandomPartialPerm(10000);;
-gap> p:=Random(SymmetricGroup(1000));; 
+gap> f:=PartialPerm([1, 10000], [10000, 2]);;
+gap> p:=(13, 1000);; 
 gap> g:=f/p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
@@ -1013,7 +1016,7 @@ true
 
 # ProdPPerm2Perm2, Case 5 of 6: deg(p)=65536, domain not known
 gap> p:=(1,65536);;
-gap> f:=RandomPartialPerm(10000);;
+gap> f:=PartialPerm([1, 10000], [10000, 2]);;
 gap> g:=f*p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
@@ -1024,7 +1027,7 @@ true
 
 # QuoPPerm2Perm2, Case 5 of 6: deg(p)=65536, domain not known
 gap> p:=(1,65536,123);;
-gap> f:=RandomPartialPerm(10000);;
+gap> f:=PartialPerm([1, 10000], [10000, 2]);;
 gap> g:=f/p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
@@ -1036,7 +1039,7 @@ gap> f/p=f*p^-1;
 true
 
 # ProdPPerm2Perm2, Case 6 of 6: deg(p)=65536, domain known
-gap> f:=RandomPartialPerm(10000);; DomainOfPartialPerm(f);;
+gap> f:=PartialPerm([1, 10000], [10000, 2]);; DomainOfPartialPerm(f);;
 gap> p:=(1,65536);;
 gap> g:=f*p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
@@ -1047,7 +1050,7 @@ gap> CodegreeOfPartialPerm(g)=Maximum(ImageSetOfPartialPerm(g));
 true
 
 # QuoPPerm2Perm2, Case 6 of 6: deg(p)=65536, domain known
-gap> f:=RandomPartialPerm(10000);; DomainOfPartialPerm(f);;
+gap> f:=PartialPerm([1, 10000], [10000, 2]);; DomainOfPartialPerm(f);;
 gap> p:=(1,65536,123);;
 gap> g:=f/p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
@@ -1060,7 +1063,7 @@ gap> f/p=f*p^-1;
 true
 
 # ProdPPerm2Perm4, Case 1 of 2: domain known
-gap> f:=RandomPartialPerm(10);; DomainOfPartialPerm(f);;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );; DomainOfPartialPerm(f);;
 gap> p:=(1,100000);;
 gap> g:=f*p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
@@ -1071,7 +1074,7 @@ gap> CodegreeOfPartialPerm(g)=Maximum(ImageSetOfPartialPerm(g));
 true
 
 # QuoPPerm2Perm4, Case 1 of 2: domain known
-gap> f:=RandomPartialPerm(10);; DomainOfPartialPerm(f);;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );; DomainOfPartialPerm(f);;
 gap> p:=(1,100000,123);;
 gap> g:=f/p;;
 gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
@@ -1084,7 +1087,7 @@ gap> f/p=f*p^-1;
 true
 
 # ProdPPerm2Perm4, Case 2 of 2: domain not known
-gap> f:=RandomPartialPerm(1000);;
+gap> f:=PartialPerm([1, 1000], [1000, 2]);;
 gap> p:=(1,100000);;
 gap> g:=f*p;;
 gap> OnTuples(ImageListOfPartialPerm(f), p)=ImageListOfPartialPerm(g);
@@ -1095,7 +1098,7 @@ gap> DomainOfPartialPerm(g)=DomainOfPartialPerm(f);
 true
 
 # QuoPPerm2Perm4, Case 2 of 2: domain not known
-gap> f:=RandomPartialPerm(1000);;
+gap> f:=PartialPerm([1, 1000], [1000, 2]);;
 gap> p:=(1,100000,123);;
 gap> g:=f/p;;
 gap> OnTuples(ImageListOfPartialPerm(f), p^-1)=ImageListOfPartialPerm(g);
@@ -1283,8 +1286,8 @@ gap> CodegreeOfPartialPerm(g)=Maximum(ImageSetOfPartialPerm(g));
 true
 gap> ImageSetOfPartialPerm(f)=ImageSetOfPartialPerm(g);
 true
-gap> f:=RandomPartialPerm(10000);;
-gap> p:=Random(SymmetricGroup(9000));;
+gap> f:=PartialPerm([1, 10000], [10000, 2]);;
+gap> p:=(13, 9000);;
 gap> g:=p*f;;
 gap> OnSets(DomainOfPartialPerm(f), p^-1)=DomainOfPartialPerm(g);
 true
@@ -1313,8 +1316,8 @@ gap> CodegreeOfPartialPerm(g)=Maximum(ImageSetOfPartialPerm(g));
 true
 gap> ImageSetOfPartialPerm(f)=ImageSetOfPartialPerm(g);
 true
-gap> f:=RandomPartialPerm(1000);;
-gap> p:=Random(SymmetricGroup(2000));;
+gap> f:=PartialPerm([1, 1000], [1000, 2]);;
+gap> p:=(13, 2000);;
 gap> g:=p*f;;
 gap> OnSets(DomainOfPartialPerm(f), p^-1)=DomainOfPartialPerm(g);
 true
@@ -1521,13 +1524,13 @@ gap> f:=PartialPermNC([100000], [1]);
 [100000,1]
 gap> IsPPerm2Rep(f);
 true
-gap> p:=Random(SymmetricGroup(100000));;
+gap> p := (17, 100000);;
 gap> f^p=p^-1*f*p;
 true
 
 # PowPPerm2Perm4, Case 2 of 2, deg(f)<=deg(p) and codeg(f)<=deg(p)
-gap> f:=PartialPermNC( [ 1, 2, 3, 4, 5, 6 ], [ 2, 5, 8, 1, 3, 4 ] );;
-gap> p:=Random(SymmetricGroup(100000));;
+gap> f := PartialPermNC([1, 2, 3, 4, 5, 6], [2, 5, 8, 1, 3, 4]);;
+gap> p := (17, 100000);;
 gap> f^p=p^-1*f*p;               
 true
 
@@ -1537,15 +1540,14 @@ gap> f:=PartialPermNC([100000], [100000]);
 gap> p:=(1,3,2,10)(5,7)(6,9,8);;
 gap> f^p;
 <identity partial perm on [ 100000 ]>
-gap> f:=RandomPartialPerm(100000);;        
-gap> p:=Random(SymmetricGroup(50000));;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;        
+gap> p:=(17, 50000);;
 gap> f^p=p^-1*f*p;
 true
 
 # PowPPerm4Perm2, Case 2 of 4, deg(f)>deg(p) and codeg(f)<=deg(p)
 gap> f:=PartialPermNC([100000], [1]);     
 [100000,1]
-gap> p:=Random(SymmetricGroup(10));;   
 gap> p:=(1,10)(3,8)(4,7,5,9);;
 gap> f^p;
 [100000,10]
@@ -1589,8 +1591,8 @@ gap> p^-1*f*p;
 [1,3,4,5](6,10)
 
 # PowPPerm4Perm4, Case 1 of 4, deg(f)>deg(p) and codeg(f)>deg(p)
-gap> f:=RandomPartialPerm(100000);; 
-gap> p:=Random(SymmetricGroup(65538));;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);; 
+gap> p:=(17, 65538);;
 gap> IsPPerm4Rep(f); IsPerm4Rep(p);
 true
 true
@@ -1599,7 +1601,7 @@ true
 
 # PowPPerm4Perm4, Case 2 of 4, deg(f)>deg(p) and codeg(f)<=deg(p)
 gap> f:=PartialPermNC([100000], [65536]);;
-gap> p:=Random(SymmetricGroup(70000));;
+gap> p:=(17, 70000);;
 gap> f^p=p^-1*f*p;
 true
 
@@ -1610,8 +1612,8 @@ gap> f^p=p^-1*f*p;
 true
 
 # PowPPerm4Perm4, Case 4 of 4, deg(f)<=deg(p) and codeg(f)<=deg(p)
-gap> f:=RandomPartialPerm(66000);; 
-gap> p:=Random(SymmetricGroup(70000));;
+gap> f:=PartialPerm([1, 66000], [66000, 2]);; 
+gap> p:=(17, 70000);;
 gap> f^p=p^-1*f*p;
 true
 
@@ -1626,8 +1628,8 @@ gap> f*g^-1;
 [4,2,3][5,1](9)(10)
 gap> f*g^-1=f/g;
 true
-gap> f:=RandomPartialPerm(10000);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(10000);; DomainOfPartialPerm(g);;
+gap> f:=PartialPerm([1, 10000], [10000, 2]);; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm([1, 10000], [10000, 2]);; DomainOfPartialPerm(g);;
 gap> f/g=f*g^-1;
 true
 gap> f:=PartialPermNC([100000], [1]);
@@ -1645,8 +1647,8 @@ gap> f*g^-1;
 [4,10,3,5](6)(7)
 gap> f/g=f*g^-1;
 true
-gap> f:=RandomPartialPerm(10000);;
-gap> g:=RandomPartialPerm(10000);; DomainOfPartialPerm(g);;
+gap> f:=PartialPerm([1, 10000], [10000, 2]);;
+gap> g:=PartialPerm([1, 10000], [10000, 2]);; DomainOfPartialPerm(g);;
 gap> f/g=f*g^-1;
 true
 
@@ -1658,8 +1660,8 @@ gap> f/g;
 [5,3,10,4](6)(7)
 gap> f*g^-1;
 [5,3,10,4](6)(7)
-gap> f:=RandomPartialPerm(10000);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(10000);;
+gap> f:=PartialPerm([1, 10000], [10000, 2]);; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm([1, 10000], [10000, 2]);;
 gap> f/g=f*g^-1;
 true
 
@@ -1668,80 +1670,88 @@ gap> f:=PartialPermNC([ 1, 8, 10, 0, 4, 3, 7, 0, 0, 2 ]);;
 gap> g:=PartialPermNC([5,9,4,2,0,3,7,6,0,10]);;
 gap> f/g=f*g^-1;
 true
-gap> f:=RandomPartialPerm(10000);;                          
-gap> g:=RandomPartialPerm(10000);;
+gap> f:=PartialPerm([1, 10000], [10000, 2]);;                          
+gap> g:=PartialPerm([1, 10000], [10000, 2]);;
 gap> f/g=f*g^-1;
 true
 
 # QuoPPerm24, Case 1 of 4, dom(f) known,   dom(g) known
-gap> f:=RandomPartialPerm(20);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(100000);; DomainOfPartialPerm(g);;
+gap> f:=PartialPerm( [ 1, 2, 3, 4, 5, 6, 7, 9, 11, 12, 15, 16, 19 ],
+> [ 2, 4, 11, 1, 20, 10, 15, 16, 5, 3, 6, 12, 9 ] );; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm([1, 100000], [100000, 2]);; DomainOfPartialPerm(g);;
 gap> f/g=f*g^-1;
 true
 
 # QuoPPerm24, Case 2 of 4, dom(f) known,   dom(g) unknown
-gap> f:=RandomPartialPerm(20);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(100000);;                         
+gap> f:=PartialPerm( [ 1, 2, 3, 4, 5, 6, 7, 9, 11, 12, 15, 16, 19 ],
+> [ 2, 4, 11, 1, 20, 10, 15, 16, 5, 3, 6, 12, 9 ] );; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm([1, 100000], [100000, 2]);;                         
 gap> f/g=f*g^-1;
 true
 
 # QuoPPerm24, Case 3 of 4, dom(f) unknown, dom(g) known
-gap> f:=RandomPartialPerm(20);;                         
-gap> g:=RandomPartialPerm(100000);; DomainOfPartialPerm(g);;
+gap> f:=PartialPerm( [ 1, 2, 3, 4, 5, 6, 7, 9, 11, 12, 15, 16, 19 ],
+> [ 2, 4, 11, 1, 20, 10, 15, 16, 5, 3, 6, 12, 9 ] );;                         
+gap> g:=PartialPerm([1, 100000], [100000, 2]);; DomainOfPartialPerm(g);;
 gap> f/g=f*g^-1;
 true
 
 # QuoPPerm24, Case 4 of 4, dom(f) unknown, dom(g) unknown
-gap> f:=RandomPartialPerm(20);;                             
-gap> g:=RandomPartialPerm(100000);;                         
+gap> f:=PartialPerm( [ 1, 2, 3, 4, 5, 6, 7, 9, 11, 12, 15, 16, 19 ],
+> [ 2, 4, 11, 1, 20, 10, 15, 16, 5, 3, 6, 12, 9 ] );;                             
+gap> g:=PartialPerm([1, 100000], [100000, 2]);;                         
 gap> f/g=f*g^-1;
 true
 
 # QuoPPerm42, Case 1 of 4, dom(f) known,   dom(g) known
-gap> f:=RandomPartialPerm(100000);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(20);; DomainOfPartialPerm(g);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm( [ 1, 2, 3, 4, 5, 6, 7, 9, 11, 12, 15, 16, 19 ],
+> [ 2, 4, 11, 1, 20, 10, 15, 16, 5, 3, 6, 12, 9 ] );; DomainOfPartialPerm(g);;
 gap> f/g=f*g^-1;
 true
 
 # QuoPPerm42, Case 2 of 4, dom(f) known,   dom(g) unknown
-gap> f:=RandomPartialPerm(100000);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(20);; 
+gap> f:=PartialPerm([1, 100000], [100000, 2]);; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm( [ 1, 2, 3, 4, 5, 6, 7, 9, 11, 12, 15, 16, 19 ],
+> [ 2, 4, 11, 1, 20, 10, 15, 16, 5, 3, 6, 12, 9 ] );; 
 gap> f/g=f*g^-1;
 true
 
 # QuoPPerm42, Case 3 of 4, dom(f) unknown, dom(g) known
-gap> f:=RandomPartialPerm(100000);;
-gap> g:=RandomPartialPerm(20);; DomainOfPartialPerm(g);;                     
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
+gap> g:=PartialPerm( [ 1, 2, 3, 4, 5, 6, 7, 9, 11, 12, 15, 16, 19 ],
+> [ 2, 4, 11, 1, 20, 10, 15, 16, 5, 3, 6, 12, 9 ] );; DomainOfPartialPerm(g);;                     
 gap> f/g=f*g^-1;
 true
 
 # QuoPPerm42, Case 4 of 4, dom(f) unknown, dom(g) unknown
-gap> f:=RandomPartialPerm(100000);;                         
-gap> g:=RandomPartialPerm(20);;                             
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;                         
+gap> g:=PartialPerm( [ 1, 2, 3, 4, 5, 6, 7, 9, 11, 12, 15, 16, 19 ],
+> [ 2, 4, 11, 1, 20, 10, 15, 16, 5, 3, 6, 12, 9 ] );;                             
 gap> f/g=f*g^-1;
 true
 
 # QuoPPerm44, Case 1 of 4, dom(f) known,   dom(g) known
-gap> f:=RandomPartialPerm(100000);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(100000);; DomainOfPartialPerm(g);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm([1, 100000], [100000, 2]);; DomainOfPartialPerm(g);;
 gap> f/g=f*g^-1;
 true
 
 # QuoPPerm44, Case 2 of 4, dom(f) known,   dom(g) unknown
-gap> f:=RandomPartialPerm(100000);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(100000);; 
+gap> f:=PartialPerm([1, 100000], [100000, 2]);; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm([1, 100000], [100000, 2]);; 
 gap> f/g=f*g^-1;
 true
 
 # QuoPPerm44, Case 3 of 4, dom(f) unknown, dom(g) known
-gap> f:=RandomPartialPerm(100000);;
-gap> g:=RandomPartialPerm(100000);; DomainOfPartialPerm(g);;                     
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
+gap> g:=PartialPerm([1, 100000], [100000, 2]);; DomainOfPartialPerm(g);;                     
 gap> f/g=f*g^-1;
 true
 
 # QuoPPerm44, Case 4 of 4, dom(f) unknown, dom(g) unknown
-gap> f:=RandomPartialPerm(100000);;                         
-gap> g:=RandomPartialPerm(100000);;                             
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;                         
+gap> g:=PartialPerm([1, 100000], [100000, 2]);;                             
 gap> f/g=f*g^-1;
 true
 
@@ -1787,32 +1797,32 @@ gap> p^-1*f;
 [5,8][7,10][13,2][16,3][17,1](4,6,9)
 gap> last=last2;
 true
-gap> f:=RandomPartialPerm(65535);;
-gap> p:=Random(SymmetricGroup(65536));;
+gap> f:=PartialPerm([1, 65535], [65535, 2]);;
+gap> p:=(17, 65536);;
 gap> LQUO(p, f)=p^-1*f;
 true
 
 # LQuoPerm2PPerm4, Case 1 of 4, deg(p)<deg(f),  dom(f) unknown
-gap> f:=RandomPartialPerm(65536);;
-gap> p:=Random(SymmetricGroup(60000));;
+gap> f:=PartialPerm([1, 65536], [65536, 2]);;
+gap> p:=(17, 60000);;
 gap> LQUO(p, f)=p^-1*f; 
 true
 
 # LQuoPerm2PPerm4, Case 2 of 4, deg(p)<deg(f),  dom(f) known
-gap> f:=RandomPartialPerm(65536);; DomainOfPartialPerm(f);;
-gap> p:=Random(SymmetricGroup(60000));;
+gap> f:=PartialPerm([1, 65536], [65536, 2]);; DomainOfPartialPerm(f);;
+gap> p:=(17, 60000);;
 gap> LQUO(p, f)=p^-1*f; 
 true
 
 # LQuoPerm2PPerm4, Case 3 of 4, deg(p)>=deg(f), dom(f) unknown
-gap> f:=RandomPartialPerm(65536);;                         
-gap> p:=Random(SymmetricGroup(70000));;
+gap> f:=PartialPerm([1, 65536], [65536, 2]);;                         
+gap> p:=(17, 70000);;
 gap> LQUO(p, f)=p^-1*f;
 true
 
 # LQuoPerm2PPerm4, Case 4 of 4, deg(p)>=deg(f), dom(f) known
-gap> f:=RandomPartialPerm(65536);; DomainOfPartialPerm(f);;
-gap> p:=Random(SymmetricGroup(60000));;
+gap> f:=PartialPerm([1, 65536], [65536, 2]);; DomainOfPartialPerm(f);;
+gap> p:=(17, 60000);;
 gap> LQUO(p, f)=p^-1*f;
 true
 
@@ -1820,7 +1830,7 @@ true
 gap> f:=PartialPermNC( [ 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 14, 15, 17, 19 ], 
 > [ 19, 7, 17, 14, 8, 5, 3, 18, 15, 13, 2, 12, 10, 20 ] );;
 gap> f:=JoinOfPartialPerms(f, PartialPermNC([100000], [1]));;
-gap> p:=Random(SymmetricGroup(70000));;
+gap> p:=(17, 70000);;
 gap> LQUO(p, f)=p^-1*f;
 true
 
@@ -1829,7 +1839,7 @@ gap> f:=PartialPermNC( [ 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 14, 15, 17, 19 ],
 > [ 19, 7, 17, 14, 8, 5, 3, 18, 15, 13, 2, 12, 10, 20 ] );;
 gap> f:=JoinOfPartialPerms(f, PartialPermNC([100000], [1]));;
 gap> DomainOfPartialPerm(f);;
-gap> p:=Random(SymmetricGroup(70000));;
+gap> p:=(17, 70000);;
 gap> LQUO(p, f)=p^-1*f;
 true
 
@@ -1837,7 +1847,7 @@ true
 gap> f:=PartialPermNC( [ 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 14, 15, 17, 19 ], 
 > [ 19, 7, 17, 14, 8, 5, 3, 18, 15, 13, 2, 12, 10, 20 ] );;
 gap> f:=JoinOfPartialPerms(f, PartialPermNC([10000], [1]));;
-gap> p:=Random(SymmetricGroup(70000));;
+gap> p:=(17, 70000);;
 gap> LQUO(p, f)=p^-1*f;
 true
 
@@ -1846,33 +1856,33 @@ gap> f:=PartialPermNC( [ 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 14, 15, 17, 19 ],
 > [ 19, 7, 17, 14, 8, 5, 3, 18, 15, 13, 2, 12, 10, 20 ] );;
 gap> f:=JoinOfPartialPerms(f, PartialPermNC([10000], [1]));;
 gap> DomainOfPartialPerm(f);;
-gap> p:=Random(SymmetricGroup(70000));;
+gap> p:=(17, 70000);;
 gap> LQUO(p, f)=p^-1*f;
 true
 
 # LQuoPerm4PPerm4, Case 1 of 4, deg(p)<deg(f),  dom(f) unknown
-gap> f:=RandomPartialPerm(70000);;
-gap> p:=Random(SymmetricGroup(66000));;
+gap> f:=PartialPerm([1, 70000], [70000, 2]);;
+gap> p:=(17, 66000);;
 gap> LQUO(p, f)=p^-1*f;
 true
 
 # LQuoPerm4PPerm4, Case 2 of 4, deg(p)<deg(f),  dom(f) known
-gap> f:=RandomPartialPerm(70000);;
+gap> f:=PartialPerm([1, 70000], [70000, 2]);;
 gap> DomainOfPartialPerm(f);;
-gap> p:=Random(SymmetricGroup(66000));;
+gap> p:=(17, 66000);;
 gap> LQUO(p, f)=p^-1*f;
 true
 
 # LQuoPerm4PPerm4, Case 3 of 4, deg(p)>=deg(f), dom(f) unknown
-gap> f:=RandomPartialPerm(66000);;
-gap> p:=Random(SymmetricGroup(70000));;
+gap> f:=PartialPerm([1, 66000], [66000, 2]);;
+gap> p:=(17, 70000);;
 gap> LQUO(p, f)=p^-1*f;
 true
 
 # LQuoPerm4PPerm4, Case 4 of 4, deg(p)>=deg(f), dom(f) known
-gap> f:=RandomPartialPerm(66000);;
+gap> f:=PartialPerm([1, 66000], [66000, 2]);;
 gap> DomainOfPartialPerm(f);;
-gap> p:=Random(SymmetricGroup(70000));;
+gap> p:=(17, 70000);;
 gap> LQUO(p, f)=p^-1*f;
 true
 
@@ -1887,8 +1897,8 @@ gap> f^-1*g;
 [2,11,4,5][10,7][12,1][15,20][19,3,13](8,18,14)(9)
 gap> last=last2;
 true
-gap> f:=RandomPartialPerm(10000);;                             
-gap> g:=RandomPartialPerm(9000);; 
+gap> f:=PartialPerm([1, 10000], [10000, 2]);;                             
+gap> g:=PartialPerm([1, 9000], [9000, 2]);; 
 gap> LQUO(f, g)=f^-1*g;
 true
 
@@ -1901,72 +1911,72 @@ gap> LQUO(f, g)=f^-1*g;
 true
 gap> LQUO(f, g);
 [8,12][16,2][18,1,9,5][19,11,10][20,7]
-gap> f:=RandomPartialPerm(9000);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(10000);; DomainOfPartialPerm(g);;
+gap> f:=PartialPerm([1, 9000], [9000, 2]);; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm([1, 10000], [10000, 2]);; DomainOfPartialPerm(g);;
 gap> LQUO(f, g)=f^-1*g;
 true
 
 # LQuoPPerm22, Case 3 of 3, dom(g) known, deg(g)<=deg(f)
-gap> f:=RandomPartialPerm(10000);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(9000);; DomainOfPartialPerm(g);;
+gap> f:=PartialPerm([1, 10000], [10000, 2]);; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm([1, 9000], [9000, 2]);; DomainOfPartialPerm(g);;
 gap> LQUO(f, g)=f^-1*g; 
 true
 
 # LQuoPPerm24, Case 1 of 3, dom(g) unknown
-gap> f:=RandomPartialPerm(100);;
-gap> g:=RandomPartialPerm(100000);;
+gap> f:=PartialPerm([1, 100], [100, 2]);;
+gap> g:=PartialPerm([1, 100000], [100000, 2]);;
 gap> LQUO(f, g)=f^-1*g;
 true
 
 # LQuoPPerm24, Case 2 of 3, dom(g) known, deg(g)>deg(f)
-gap> f:=RandomPartialPerm(100);;
-gap> g:=RandomPartialPerm(100000);; DomainOfPartialPerm(g);;
+gap> f:=PartialPerm([1, 100], [100, 2]);;
+gap> g:=PartialPerm([1, 100000], [100000, 2]);; DomainOfPartialPerm(g);;
 gap> LQUO(f, g)=f^-1*g;
 true
 
 # LQuoPPerm24, Case 3 of 3, dom(g) known, deg(g)<=deg(f)
-gap> f:=RandomPartialPerm(9000);;
-gap> g:=RandomPartialPerm(100);;  
+gap> f:=PartialPerm([1, 9000], [9000, 2]);;
+gap> g:=PartialPerm([1, 100], [100, 2]);;  
 gap> g:=JoinOfPartialPerms(g, PartialPermNC([101], [100000]));;
 gap> DomainOfPartialPerm(g);;
 gap> LQUO(f, g)=f^-1*g;
 true
 
 # LQuoPPerm42, Case 1 of 3, dom(g) unknown
-gap> f:=RandomPartialPerm(100000);;
-gap> g:=RandomPartialPerm(100);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
+gap> g:=PartialPerm([1, 100], [100, 2]);;
 gap> LQUO(f, g)=f^-1*g;
 true
 
 # LQuoPPerm42, Case 2 of 3, dom(g) known, deg(g)>deg(f)
-gap> f:=RandomPartialPerm(100000);;
-gap> g:=RandomPartialPerm(100);; 
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
+gap> g:=PartialPerm([1, 100], [100, 2]);; 
 gap> g:=JoinOfPartialPerms(g, PartialPermNC([100001],[101]));;
 gap> DomainOfPartialPerm(g);;
 gap> LQUO(f, g)=f^-1*g;
 true
 
 # LQuoPPerm42, Case 3 of 3, dom(g) known, deg(g)<=deg(f)
-gap> f:=RandomPartialPerm(100000);;
-gap> g:=RandomPartialPerm(100);; DomainOfPartialPerm(g);;
+gap> f:=PartialPerm([1, 100000], [100000, 2]);;
+gap> g:=PartialPerm([1, 100], [100, 2]);; DomainOfPartialPerm(g);;
 gap> LQUO(f, g)=f^-1*g;
 true
 
 # LQuoPPerm44, Case 1 of 3, dom(g) unknown
-gap> f:=RandomPartialPerm(65536);;
-gap> g:=RandomPartialPerm(65536);;
+gap> f:=PartialPerm([1, 65536], [65536, 2]);;
+gap> g:=PartialPerm([1, 65536], [65536, 2]);;
 gap> LQUO(f, g)=f^-1*g;
 true
 
 # LQuoPPerm44, Case 2 of 3, dom(g) known, deg(g)>deg(f)
-gap> f:=RandomPartialPerm(65536);;
-gap> g:=RandomPartialPerm(66000);; DomainOfPartialPerm(g);;
+gap> f:=PartialPerm([1, 65536], [65536, 2]);;
+gap> g:=PartialPerm([1, 66000], [66000, 2]);; DomainOfPartialPerm(g);;
 gap> LQUO(f, g)=f^-1*g;
 true
 
 # LQuoPPerm44, Case 3 of 3, dom(g) known, deg(g)<=deg(f)
-gap> f:=RandomPartialPerm(66000);;
-gap> g:=RandomPartialPerm(66553);; DomainOfPartialPerm(g);;
+gap> f:=PartialPerm([1, 66000], [66000, 2]);;
+gap> g:=PartialPerm([1, 66553], [66553, 2]);; DomainOfPartialPerm(g);;
 gap> LQUO(f, g)=f^-1*g;
 true
 
@@ -1981,8 +1991,8 @@ gap> f^g;
 [1,12][4,2,11][13,8,21](5,25)(22)(24)
 gap> g^-1*f*g;
 [1,12][4,2,11][13,8,21](5,25)(22)(24)
-gap> f:=RandomPartialPerm(20000);; 
-gap> g:=RandomPartialPerm(30000);;
+gap> f:=PartialPerm([1, 20000], [20000, 2]);; 
+gap> g:=PartialPerm([1, 30000], [30000, 2]);;
 gap> f^g=g^-1*f*g;
 true
 
@@ -2022,8 +2032,8 @@ gap> g^-1*f*g;
 [18,9][20,8](11)(14)
 gap> last=last2;
 true
-gap> f:=RandomPartialPerm(50000);;
-gap> g:=RandomPartialPerm(40000);;
+gap> f:=PartialPerm([1, 50000], [50000, 2]);;
+gap> g:=PartialPerm([1, 40000], [40000, 2]);;
 gap> f^g=g^-1*f*g;
 true
 
@@ -2051,16 +2061,18 @@ gap> g^-1*f*g;
 [4,6][10,1][17,13](19)
 
 # PowPPerm24, Case 1 of 6, dom(f) not known, codeg(f)<=deg(g)
-gap> f:=RandomPartialPerm(10);;                           
-gap> g:=RandomPartialPerm(65536);;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );;                           
+gap> g:=PartialPerm([1, 65536], [65536, 2]);;
 gap> f^g=g^-1*f*g;
 true
 
 # PowPPerm24, Case 2 of 6, dom(f) not known, codeg(f)> deg(g)
-gap> f:=RandomPartialPerm(10);;
+gap> f:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );;
 gap> f:=JoinOfPartialPerms(f, PartialPermNC([11], [100]));;
 gap> g:=PartialPermNC([10], [65536]);;
-gap> g:=JoinOfPartialPerms(g, RandomPartialPerm(9));;
+gap> g:=JoinOfPartialPerms(g, 
+>                          PartialPerm([1, 2, 3, 4, 5, 6, 7], 
+>                                      [8, 3, 6, 1, 5, 7, 2]));;
 gap> f^g=g^-1*f*g;
 true
 
@@ -2069,7 +2081,7 @@ gap> f:=PartialPerm( [ 1, 2, 4, 6, 7 ], [ 6, 9, 8, 5, 7 ] );;
 gap> f:=JoinOfPartialPerms(f, PartialPermNC([11], [100]));;
 gap> f:=f^-1;; DomainOfPartialPerm(f);;
 gap> g:=PartialPermNC([20], [65536]);;              
-gap> g:=JoinOfPartialPerms(g, RandomPartialPerm(9));;
+gap> g:=JoinOfPartialPerms(g, PartialPerm( [ 1, 2, 3, 4, 5, 6, 7 ], [ 8, 3, 6, 1, 5, 7, 2 ] ));;
 gap> DegreeOfPartialPerm(f)>DegreeOfPartialPerm(g);
 true
 gap> CodegreeOfPartialPerm(f)<=DegreeOfPartialPerm(g);
@@ -2078,7 +2090,10 @@ gap> f^g = g^-1*f*g;
 true
 
 # PowPPerm24, Case 4 of 6, dom(f)     known, deg(f)>deg(g),   codeg(f)> deg(g)
-gap> f:=RandomPartialPerm(30);; DomainOfPartialPerm(f);;
+gap> f:=PartialPerm(
+> [ 1, 2, 3, 4, 5, 6, 8, 9, 14, 15, 16, 17, 18, 19, 21, 24, 25, 26, 27 ],
+> [ 14, 11, 12, 22, 18, 8, 4, 5, 1, 23, 29, 6, 17, 21, 30, 9, 15, 2, 7 ] );;
+> DomainOfPartialPerm(f);;
 gap> DegreeOfPartialPerm(f)>DegreeOfPartialPerm(g);
 true
 gap> CoDegreeOfPartialPerm(f)>DegreeOfPartialPerm(g);
@@ -2087,8 +2102,10 @@ gap> f^g=g^-1*f*g;
 true
 
 # PowPPerm24, Case 5 of 6, dom(f)     known, deg(f)<=deg(g),  codeg(f)<=deg(g)
-gap> f:=RandomPartialPerm(30);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(65536);;                  
+gap> f:=PartialPerm(
+> [ 1, 2, 3, 4, 5, 6, 8, 9, 14, 15, 16, 17, 18, 19, 21, 24, 25, 26, 27 ],
+> [ 14, 11, 12, 22, 18, 8, 4, 5, 1, 23, 29, 6, 17, 21, 30, 9, 15, 2, 7 ] );; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm([1, 65536], [65536, 2]);;                  
 gap> f^g=g^-1*f*g;
 true
 
@@ -2139,15 +2156,15 @@ gap> g^-1*f*g=last;
 true
 
 # PowPPerm42, Case 4 of 6, dom(f)     known, deg(f)>deg(g),   codeg(f)> deg(g)
-gap> f:=RandomPartialPerm(70000);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(10);;                                                
+gap> f:=PartialPerm([1, 70000], [70000, 2]);; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm( [ 1, 2, 3, 6, 10 ], [ 2, 7, 8, 10, 6 ] );;                                                
 gap> f^g=g^-1*f*g;
 true
 
 # PowPPerm42, Case 5 of 6, dom(f)     known, deg(f)<=deg(g),  codeg(f)<=deg(g)
 gap> g:=PartialPermNC( [ 1, 2, 3, 4, 5, 9, 100000 ],
 > [ 9, 3, 8, 2, 10, 7, 11 ] );;
-gap> f:=RandomPartialPerm(70000);; DomainOfPartialPerm(f);;
+gap> f:=PartialPerm([1, 70000], [70000, 2]);; DomainOfPartialPerm(f);;
 gap> f^g=g^-1*f*g;
 true
 
@@ -2198,15 +2215,15 @@ gap> g^-1*f*g=last;
 true
 
 # PowPPerm44, Case 4 of 6, dom(f)     known, deg(f)>deg(g),   codeg(f)> deg(g)
-gap> f:=RandomPartialPerm(70000);;                                             
+gap> f:=PartialPerm([1, 70000], [70000, 2]);;                                             
 gap> DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(66000);;
+gap> g:=PartialPerm([1, 66000], [66000, 2]);;
 gap> f^g=g^-1*f*g;
 true
 
 # PowPPerm44, Case 5 of 6, dom(f)     known, deg(f)<=deg(g),  codeg(f)<=deg(g)
-gap> f:=RandomPartialPerm(66000);; DomainOfPartialPerm(f);;
-gap> g:=RandomPartialPerm(70000);;
+gap> f:=PartialPerm([1, 66000], [66000, 2]);; DomainOfPartialPerm(f);;
+gap> g:=PartialPerm([1, 70000], [70000, 2]);;
 gap> f^g=g^-1*f*g;
 true
 
@@ -2275,7 +2292,7 @@ gap> f[4]^10;
 gap> f[4]^-4; 
 [8,3](2)(7)
 gap> 
-gap> f:=RandomPartialPerm(10000);;
+gap> f:=PartialPerm([1, 10000], [10000, 2]);;
 gap> g:=f^-1;;
 gap> ForAll(DomainOfPartialPerm(f), i-> (i^f)^g=i);
 true

--- a/tst/testinstall/pperm.tst
+++ b/tst/testinstall/pperm.tst
@@ -2440,6 +2440,12 @@ gap> MultiplicativeZeroOp(x);
 gap> MultiplicativeZero(x);
 <empty partial perm>
 
+# Test PartialPerm (for sparse incorrect arg)
+gap> PartialPerm([1,2,8],[3,4,1,2]);
+Error, usage: the 1st argument must be a set of positive integers and the 2nd \
+argument must be a duplicate-free list of positive integers of equal length to\
+ the first
+
 #
 gap> SetUserPreference("PartialPermDisplayLimit", display);;
 gap> SetUserPreference("NotationForPartialPerm", notationpp);;


### PR DESCRIPTION
This PR resolves Issue #2301 by checking that the arguments to `PartialPerm` are of equal length, if there are more than two of them.

And increases the code coverage of the tests to ~97%, removes unnecessary randomness from the test file, fixes some bugs in the c, and GAP code, and reformats the GAP code. 