### PR TITLE
Speed up IsPrimePowerInt in a few more cases, and fix a IsNilpotenGroup method

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -405,6 +405,9 @@ InstallMethod( IsNilpotentGroup,
         SetIsPGroup( G, true );
         SetPrimePGroup( G, SmallestRootInt( s ) );
         return true;
+    elif s = 1 then
+        SetIsPGroup( G, true );
+        return true;
     else
         SetIsPGroup( G, false );
     fi;

--- a/lib/integer.gi
+++ b/lib/integer.gi
@@ -951,7 +951,16 @@ InstallGlobalFunction( IsPrimePowerInt, function(n)
             i := i + 1;
             k := Primes[i];
         else
+            # need more primes...
             k := NextPrimeInt( k );
+            # since we are now beyond the primes in Primes, for which we
+            # checked whether they divide n, we might now just as well
+            # test if k divides n, too
+            r := PVALUATION_INT(n, k);
+            if r > 0 then
+                if s = -1 and IsEvenInt(r) then return false; fi;
+                return n = k^r;
+            fi;
         fi;
     od;
 


### PR DESCRIPTION
Note: the bug fix for the IsNilpotentGroup method normally is not necessary, because of immediate methods; but if immediate methods are turned off, the issue becomes apparent (already with our existing test suite, hence I am not adding a new tests for this).