### PR TITLE
Not all finitely generated magmas are groups (alternative to PR #2276)

### DIFF
--- a/lib/magma.gi
+++ b/lib/magma.gi
@@ -657,13 +657,15 @@ local M;
     family!.defaultMagmaWithInversesByGeneratorsType :=
       NewType( FamilyObj( gens ),
                 IsMagmaWithInverses and IsAttributeStoringRep 
-                and HasGeneratorsOfMagmaWithInverses 
-                and IsFinitelyGeneratedGroup);
+                and HasGeneratorsOfMagmaWithInverses);
   fi;
 
   M:=rec();
   ObjectifyWithAttributes( M,family!.defaultMagmaWithInversesByGeneratorsType,
     GeneratorsOfMagmaWithInverses, AsList( gens ) );
+  if HasIsAssociative( M ) and IsAssociative( M ) then
+    SetIsFinitelyGeneratedGroup( M, true );
+  fi;
   return M;
 end;
 

--- a/tst/testbugfix/2018-03-21-MagmaWithInversesByGenerators.tst
+++ b/tst/testbugfix/2018-03-21-MagmaWithInversesByGenerators.tst
@@ -1,0 +1,12 @@
+# GAP used to set the IsFinitelyGeneratedGroup property for every finitely
+# generated magma-with-inverses, even those which are not groups.
+gap> A:=[[1,2,3,4],[2,1,4,2],[3,4,1,3],[4,2,3,1]];
+[ [ 1, 2, 3, 4 ], [ 2, 1, 4, 2 ], [ 3, 4, 1, 3 ], [ 4, 2, 3, 1 ] ]
+gap> M:=MagmaWithInversesByMultiplicationTable(A);
+<magma-with-inverses with 4 generators>
+gap> IsFinitelyGeneratedGroup(M);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `IsFinitelyGeneratedGroup' on 1 argument\
+s
+gap> IsGroup(M);
+false


### PR DESCRIPTION
... hence we should not set IsFinitelyGeneratedGroup for them.
Instead, only set IsFinitelyGeneratedGroup if the final magma
is actually a group (i.e., associative).

This is an alternative to PR #2276 
Fixes #2252, closes #2276