### PR TITLE
fix inconsistent comment format in src/*.h files

### DIFF
--- a/src/blister.h
+++ b/src/blister.h
@@ -164,8 +164,9 @@ static inline const UInt * CONST_BLOCK_ELM_BLIST_PTR(Obj list, UInt pos)
 **
 *F  MASK_POS_BLIST( <pos> )  . . . .  bit mask for position of a Boolean list
 **
-**  MASK_POS_BLIST(<pos>) returns a UInt with   a single set bit in  position
-**  (pos-1) % BIPEB, useful for accessing the pos'th element of a blist
+**  'MASK_POS_BLIST(<pos>)' returns a UInt with a single set bit in  position
+**  '(<pos>-1) % BIPEB',
+**  useful for accessing the <pos>-th element of a blist.
 */
 static inline UInt MASK_POS_BLIST(UInt pos)
 {
@@ -221,7 +222,7 @@ static inline void CLEAR_BIT_BLIST(Obj list, UInt pos)
 **
 *F  COUNT_TRUES_BLOCK( <block> ) . . . . . . . . . . .  count number of trues
 **
-** 'COUNT_TRUES_BLOCK( <block> )' returns the number of 1 bits in the
+**  'COUNT_TRUES_BLOCK( <block> )' returns the number of 1 bits in the
 **  UInt <block>. Two implementations are included below. One uses the
 **  gcc builtin __builtin_popcount which usually generates the popcntl
 **  or popcntq instruction on sufficiently recent CPUs. The other uses
@@ -353,7 +354,7 @@ extern void AssBlist (
 **
 *F  ConvBlist( <list> ) . . . . . . . . .  convert a list into a boolean list
 **
-**  `ConvBlist' changes the representation of boolean  lists into the compact
+**  'ConvBlist' changes the representation of boolean  lists into the compact
 **  representation of type 'T_BLIST' described above.
 */
 extern void ConvBlist (
@@ -365,7 +366,7 @@ extern void ConvBlist (
 *F  CopyBits( <fromblock>, <from-starting-bit>, <toblock>, <to-starting-bit>,
 **            <numbits> )
 **
-**  `CopyBits' copies <numbits> bits (numbering bits within a UInt
+**  'CopyBits' copies <numbits> bits (numbering bits within a UInt
 **   from the least significant to the most significant) starting with
 **   bit number <from-starting-bit> of UInt *<fromblock> to a destination
 **   starting at bit <to-starting-bit> of *<toblock>. The source and 

--- a/src/calls.h
+++ b/src/calls.h
@@ -432,9 +432,9 @@ extern Obj NewFunctionCT (
 **
 *F  ArgStringToList( <nams_c> )
 **
-** 'ArgStringToList' takes a C string <nams_c> containing a list of comma
-** separated argument names, and turns it into a plist of strings, ready
-** to be passed to 'NewFunction' as <nams>.
+**  'ArgStringToList' takes a C string <nams_c> containing a list of comma
+**  separated argument names, and turns it into a plist of strings, ready
+**  to be passed to 'NewFunction' as <nams>.
 */
 extern Obj ArgStringToList(const Char *nams_c);
 

--- a/src/code.h
+++ b/src/code.h
@@ -43,12 +43,12 @@ typedef struct {
 
 /****************************************************************************
 **
-** Function body headers
+**  Function body headers
 **
-** 'FILENAME_BODY' is a string containing the file of a function
-** 'STARTLINE_BODY' is the line number where a function starts.
-** 'ENDLINE_BODY' is the line number where a function ends.
-** 'LOCATION_BODY' is a string describing the location of a function.
+**  'FILENAME_BODY' is a string containing the file of a function.
+**  'STARTLINE_BODY' is the line number where a function starts.
+**  'ENDLINE_BODY' is the line number where a function ends.
+**  'LOCATION_BODY' is a string describing the location of a function.
 **  Typically this will be the name of a C function implementing it.
 **
 **  These each have a 'GET' and a 'SET' variant, to read or set the value.

--- a/src/gap.h
+++ b/src/gap.h
@@ -67,14 +67,14 @@ extern void ViewObjHandler ( Obj obj );
 
 /****************************************************************************
 **
-*F RegisterBreakloopObserver( <func> )
+*F  RegisterBreakloopObserver( <func> )
 **
-** Register a function which will be called when the break loop is entered
-** and left. Function should take a single Int argument which will be 1 when
-** break loop is entered, 0 when leaving.
+**  Register a function which will be called when the break loop is entered
+**  and left. Function should take a single Int argument which will be 1 when
+**  break loop is entered, 0 when leaving.
 **
-** Note that it is also possible to leave the break loop (or any GAP code)
-** by longjmping. This should be tracked with RegisterSyLongjmpObserver.
+**  Note that it is also possible to leave the break loop (or any GAP code)
+**  by longjmping. This should be tracked with RegisterSyLongjmpObserver.
 */
 
 typedef void (*intfunc)(Int);

--- a/src/gaputils.h
+++ b/src/gaputils.h
@@ -21,7 +21,7 @@
 
 /****************************************************************************
 **
-** Compute the number of elements of a given C array.
+**  Compute the number of elements of a given C array.
 **/
 #define ARRAY_SIZE(arr)     ( sizeof(arr) / sizeof((arr)[0]) )
 

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -142,12 +142,12 @@ static inline UInt TNUM_BAG(Bag bag) {
 **  To test that all of them are set, compare the result to the original
 **  flags, e.g.
 **
-** 	if (TEST_BAG_FLAG(obj, FLAG1 | FLAG2 ) == (FLAG1 | FLAG2)) ...
+**  	if (TEST_BAG_FLAG(obj, FLAG1 | FLAG2 ) == (FLAG1 | FLAG2)) ...
 **
 **  Similary, if you wish to test that FLAG1 is set and FLAG2 is not set,
 **  use:
 **
-** 	if (TEST_BAG_FLAG(obj, FLAG1 | FLAG2 ) == FLAG1) ...
+**  	if (TEST_BAG_FLAG(obj, FLAG1 | FLAG2 ) == FLAG1) ...
 **
 **  Each flag must be a an integer with exactly one bit set, e.g. a value
 **  of the form (1 << i). Currently, 'i' must be in the range from 0 to
@@ -1053,9 +1053,9 @@ extern  void            InitCollectFuncBags (
 
 /****************************************************************************
 **
-*F  CheckMasterPointers() . . . . . . . . . . . . .do some consistency checks
+*F  CheckMasterPointers() . . . . . . . . . . . .  do some consistency checks
 **
-**  'CheckMasterPointers()' tests for masterpoinetrs which are not one of the
+**  'CheckMasterPointers' tests for masterpointers which are not one of the
 **  following:
 **
 **  0                       denoting the end of the free chain
@@ -1130,9 +1130,9 @@ extern void FinishBags( void );
 **
 *F  CallbackForAllBags( <func> ) call a C function on all non-zero mptrs
 **
-** This calls a   C  function on every    bag, including ones  that  are  not
-** reachable from    the root, and    will  be deleted  at the   next garbage
-** collection, by simply  walking the masterpointer area. Not terribly safe
+**  This calls a   C  function on every   bag, including ones  that  are  not
+**  reachable from    the root, and   will  be deleted  at the   next garbage
+**  collection, by simply  walking the masterpointer area. Not terribly safe.
 ** 
 */
 #ifdef USE_GASMAN

--- a/src/gvars.h
+++ b/src/gvars.h
@@ -51,7 +51,7 @@ extern Obj ValGVar(UInt gvar);
 *V  ErrorMustEvalToFuncFunc . . . . . . . . .  function that signals an error
 **
 **  'ErrorMustEvalToFuncFunc' is a (variable number of  args)  function  that
-**  signals the error ``Function: <func> be a function''.
+**  signals the error ``Function Calls: <func> must be a function''.
 */
 extern Obj ErrorMustEvalToFuncFunc;
 

--- a/src/integer.h
+++ b/src/integer.h
@@ -97,7 +97,7 @@ static inline const mp_limb_t * CONST_ADDR_INT(Obj obj)
 
 /**************************************************************************
 **
-**  'SIZE_INT returns the number of limbs in a large integer object.
+**  'SIZE_INT' returns the number of limbs in a large integer object.
 */
 static inline UInt SIZE_INT(Obj obj)
 {
@@ -108,7 +108,7 @@ static inline UInt SIZE_INT(Obj obj)
 
 /**************************************************************************
 **
-**  IS_NEG_INT' returns 1 if 'obj' is a negative large or immediate
+**  'IS_NEG_INT' returns 1 if 'obj' is a negative large or immediate
 **  integer object, and 0 for all other kinds of objects.
 */
 static inline Int IS_NEG_INT(Obj obj)
@@ -156,9 +156,9 @@ static inline Int IS_EVEN_INT(Obj obj)
 
 /**************************************************************************
 **
-** The following functions convert Int, UInt or Int8 respectively into
-** a GAP integer, either an immediate, small integer if possible or 
-** otherwise a new GAP bag with TNUM T_INTPOS or T_INTNEG.
+**  The following functions convert Int, UInt or Int8 respectively into
+**  a GAP integer, either an immediate, small integer if possible or 
+**  otherwise a new GAP bag with TNUM T_INTPOS or T_INTNEG.
 */
 extern Obj ObjInt_Int(Int i);
 extern Obj ObjInt_UInt(UInt i);
@@ -167,8 +167,8 @@ extern Obj ObjInt_UInt8(UInt8 i);
 
 /**************************************************************************
 **
-** The following functions convert a GAP integer into an Int, UInt,
-** Int8 or UInt8 if it is in range. Otherwise it gives an error.
+**  The following functions convert a GAP integer into an Int, UInt,
+**  Int8 or UInt8 if it is in range. Otherwise it gives an error.
 */
 extern Int Int_ObjInt(Obj i);    
 extern UInt UInt_ObjInt(Obj i);    
@@ -178,10 +178,10 @@ extern UInt8 UInt8_ObjInt(Obj i);
     
 /****************************************************************************
 **
-** Reduce and normalize the given large integer object if necessary.
+**  Reduce and normalize the given large integer object if necessary.
 **
-** TODO: This is an internal implementation detail and ideally should not
-** be exported; unfortunately, FuncNUMBER_GF2VEC currently needs this.
+**  TODO: This is an internal implementation detail and ideally should not
+**  be exported; unfortunately, FuncNUMBER_GF2VEC currently needs this.
 */
 extern Obj GMP_REDUCE( Obj gmp );
 extern Obj GMP_NORMALIZE( Obj gmp );
@@ -353,8 +353,8 @@ extern Obj InverseModInt(Obj base, Obj mod);
 
 /****************************************************************************
 **
-** Compute log2 of the absolute value of an Int, i.e. the index of the highest
-** set bit. For input 0, return -1.
+**  Compute log2 of the absolute value of an Int, i.e. the index of the highest
+**  set bit. For input 0, return -1.
 */
 extern Int CLog2Int( Int intnum );
 

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -347,7 +347,7 @@ enum {
 *F  IntrRepeatEndBody(<nr>) . . . . . interpret repeat-statement, end of body
 *F  IntrRepeatEnd() . . . . . .  interpret repeat-statement, end of statement
 **
-**  'IntrRepeatBegin"  is an action to interpret  a  repeat-statement.  It is
+**  'IntrRepeatBegin'  is an action to interpret  a  repeat-statement.  It is
 **  called when the read encounters the 'repeat'.
 **
 **  'IntrRepeatBeginBody' is an action  to interpret a  repeat-statement.  It
@@ -918,7 +918,7 @@ extern void             IntrEmpty ( void );
 *F  IntrInfoBegin() . . . . . . . . .  start interpretation of Info statement
 *F  IntrInfoMiddle() . . . . . . .  shift to interpreting printable arguments
 *F  IntrInfoEnd( <narg> ) . . Info statement complete, <narg> things to print
-*V  InfoCheckLevel(<selectors>,<level>) . . . . . check if Info should output
+*F  InfoCheckLevel( <selectors>, <level> )  . . . check if Info should output
 */
 
 extern void             IntrInfoBegin ( void );

--- a/src/io.h
+++ b/src/io.h
@@ -200,8 +200,8 @@ extern UInt CloseInputLog ( void );
  *V  EndLineHook . . . . . . . . . . . function called at end of command line
  **  
  **  These functions can be set on GAP-level. If they are not bound  the 
- **  default is: Instead of `PrintPromptHook' the `Prompt' is printed and
- **  instead of `EndLineHook' nothing is done.
+ **  default is: Instead of 'PrintPromptHook' the 'Prompt' is printed and
+ **  instead of 'EndLineHook' nothing is done.
  */
 /* TL: extern Obj  PrintPromptHook; */
 extern Obj  EndLineHook;

--- a/src/lists.h
+++ b/src/lists.h
@@ -262,9 +262,9 @@ static inline Obj ELM_DEFAULT_LIST(Obj list, Int pos, Obj def)
 *V  Elmv0ListFuncs[ <type> ]  . . . . . . . . .  table of selection functions
 **
 **  A package implementing  a lists type  <type> must provide a function  for
-**  'ELMV0_LIST' and install it  in 'Elmv0ListFuncs[<type>]'.   This function
-**  need not test   whether <pos> is less  than   or equal to  the  length of
-**  <list>.
+**  'ELMV0_LIST( <list>, <pos> )' and install it in 'Elmv0ListFuncs[<type>]'.
+**  This function need not test whether <pos> is less than or equal to the
+**  length of <list>.
 */
 extern  Obj (*Elm0vListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
@@ -290,9 +290,9 @@ static inline Obj ELMV0_LIST(Obj list, Int pos)
 *V  ElmListFuncs[ <type> ]  . . . . . . . . . .  table of selection functions
 **
 **  A package implementing a  list  type <type> must  provide a  function for
-**  'ELM_LIST' and install it  in 'ElmListFuncs[<type>]'.  This function must
-**  signal an error if <pos> is larger than the length of <list> or if <list>
-**  has no assigned object at <pos>.
+**  'ELM_LIST( <list>, <pos> )' and install it in 'ElmListFuncs[<type>]'.
+**  This function must signal an error if <pos> is larger than the length of
+**  <list> or if <list> has no assigned object at <pos>.
 */
 extern Obj (*ElmListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
@@ -308,8 +308,8 @@ extern Obj (*ElmListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 **  is the responsibility  of the caller to  ensure that <pos>  is a positive
 **  integer.
 **
-**  The difference between ELM_LIST and ELMB_LIST is that ELMB_LIST accepts
-**  an object as the second argument
+**  The difference between 'ELM_LIST' and 'ELMB_LIST' is that 'ELMB_LIST'
+**  accepts an object as the second argument.
 **  It is intended as an interface for access to elements of large external
 **  lists, on the rare occasions when the kernel needs to do this.
 */
@@ -431,7 +431,7 @@ static inline Obj ELMS_LIST(Obj list, Obj poss)
 
 /****************************************************************************
 **
-*F  ElmsListDefault( <list>, <poss> ) . . .  default function for `ELMS_LIST'
+*F  ElmsListDefault( <list>, <poss> ) . . .  default function for 'ELMS_LIST'
 */
 extern Obj ElmsListDefault (
             Obj                 list,
@@ -440,7 +440,7 @@ extern Obj ElmsListDefault (
 
 /****************************************************************************
 **
-*F  ElmsListCheck( <list>, <poss> ) . . . . . . . . .  `ELMS_LIST' with check
+*F  ElmsListCheck( <list>, <poss> ) . . . . . . . . .  'ELMS_LIST' with check
 */
 extern Obj ElmsListCheck (
     Obj                 list,
@@ -449,7 +449,7 @@ extern Obj ElmsListCheck (
 
 /****************************************************************************
 **
-*F  ElmsListLevelCheck( <lists>, <poss>, <level> ) `ElmsListLevel' with check
+*F  ElmsListLevelCheck( <lists>, <poss>, <level> ) 'ElmsListLevel' with check
 */
 extern void ElmsListLevelCheck (
     Obj                 lists,
@@ -807,31 +807,31 @@ extern  Obj             TYPES_LIST_FAM (
 */
 
 enum {
-    /** filter number for `IsEmpty' */
+    /** filter number for 'IsEmpty' */
     FN_IS_EMPTY,
 
-    /** filter number for `IsSSortedList' */
+    /** filter number for 'IsSSortedList' */
     FN_IS_SSORT,
 
-    /** filter number for `IsNSortedList' */
+    /** filter number for 'IsNSortedList' */
     FN_IS_NSORT,
 
-    /** filter number for `IsDenseList' */
+    /** filter number for 'IsDenseList' */
     FN_IS_DENSE,
 
-    /** filter number for `IsNDenseList' */
+    /** filter number for 'IsNDenseList' */
     FN_IS_NDENSE,
 
-    /** filter number for `IsHomogeneousList' */
+    /** filter number for 'IsHomogeneousList' */
     FN_IS_HOMOG,
 
-    /** filter number for `IsNonHomogeneousList' */
+    /** filter number for 'IsNonHomogeneousList' */
     FN_IS_NHOMOG,
 
-    /** filter number for `IsTable' */
+    /** filter number for 'IsTable' */
     FN_IS_TABLE,
 
-    /** filter number for `IsRectangularTable' */
+    /** filter number for 'IsRectangularTable' */
     FN_IS_RECT,
 
     LAST_FN = FN_IS_RECT
@@ -845,9 +845,9 @@ enum {
 **  If a list  with type number <tnum>  gains  the filter  with filter number
 **  <fnum>, then the new type number is stored in:
 **
-**  `SetFiltListTNums[<tnum>][<fnum>]'
+**  'SetFiltListTNums[<tnum>][<fnum>]'
 **
-**  The macro  `SET_FILT_LIST' is  used  to  set  the filter  for a  list  by
+**  The macro  'SET_FILT_LIST' is  used  to  set  the filter  for a  list  by
 **  changing its type number.
 */
 extern UInt SetFiltListTNums [ LAST_REAL_TNUM ] [ LAST_FN + 1 ];
@@ -882,9 +882,9 @@ extern Obj FuncSET_FILTER_LIST ( Obj self, Obj list, Obj filter );
 **  If a list  with type number <tnum>  loses  the filter  with filter number
 **  <fnum>, then the new type number is stored in:
 **
-**  `ResetFiltListTNums[<tnum>][<fnum>]'
+**  'ResetFiltListTNums[<tnum>][<fnum>]'
 **
-**  The macro `RESET_FILT_LIST' is used  to  set  the filter  for a  list  by
+**  The macro 'RESET_FILT_LIST' is used  to  set  the filter  for a  list  by
 **  changing its type number.
 */
 extern UInt ResetFiltListTNums [ LAST_REAL_TNUM ] [ LAST_FN + 1 ];
@@ -928,9 +928,9 @@ extern Int HasFiltListTNums [ LAST_REAL_TNUM ] [ LAST_FN + 1 ];
 **  The type  number without any  known properties  of a  list of type number
 **  <tnum> is stored in:
 **
-**  `ClearPropsTNums[<tnum>]'
+**  'ClearPropsTNums[<tnum>]'
 **
-**  The macro `CLEAR_PROPS_LIST' is used to clear all properties of a list.
+**  The macro 'CLEAR_PROPS_LIST' is used to clear all properties of a list.
 */
 extern UInt ClearFiltsTNums [ LAST_REAL_TNUM ];
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -28,7 +28,7 @@
 
 /****************************************************************************
 **
-*T  Obj . . . . . . . . . . . . . . . . . . . . . . . . . . . type of objects
+*t  Obj . . . . . . . . . . . . . . . . . . . . . . . . . . . type of objects
 **
 **  'Obj' is the type of objects.
 **
@@ -337,7 +337,7 @@ static inline void CLEAR_OBJ_FLAG(Obj obj, uint8_t flag)
 
 /****************************************************************************
 **
-** Object flags for use with SET_OBJ_FLAG() etc.
+**  Object flags for use with SET_OBJ_FLAG() etc.
 **
 */
 enum {
@@ -539,17 +539,17 @@ extern Int IsInternallyMutableObj(Obj obj);
 
 /****************************************************************************
 **
-*V  SaveObjFuncs (<type>) . . . . . . . . . . . . . functions to save objects
+*V  SaveObjFuncs[ <type> ]  . . . . . . . . . . . . functions to save objects
 **
-** 'SaveObjFuncs' is the dispatch table that  contains, for every type
+**  'SaveObjFuncs' is the dispatch table that  contains, for every type
 **  of  objects, a pointer to the saving function for objects of that type
 **  These should not handle the file directly, but should work via the
 **  functions 'SaveObjRef', 'SaveUInt<n>' (<n> = 1,2,4 or 8), and others
 **  to be determined. Their role is to identify the C types of the various
 **  parts of the bag, and perhaps to leave out some information that does
 **  not need to be saved. By the time this function is called, the bag
-**  size and type have already been saved
-**  No saving function may allocate any bag
+**  size and type have already been saved.
+**  No saving function may allocate any bag.
 */
 
 extern void (*SaveObjFuncs[256]) ( Obj obj );
@@ -559,17 +559,17 @@ extern void SaveObjError( Obj obj );
 
 /****************************************************************************
 **
-*V  LoadObjFuncs (<type>) . . . . . . . . . . . . . functions to load objects
+*V  LoadObjFuncs[ <type> ]  . . . . . . . . . . . . functions to load objects
 **
-** 'LoadObjFuncs' is the dispatch table that  contains, for every type
+**  'LoadObjFuncs' is the dispatch table that  contains, for every type
 **  of  objects, a pointer to the loading function for objects of that type
 **  These should not handle the file directly, but should work via the
 **  functions 'LoadObjRef', 'LoadUInt<n>' (<n> = 1,2,4 or 8), and others
 **  to be determined. Their role is to reinstall the information in the bag
 **  and reconstruct anything that was left out. By the time this function is
 **  called, the bag size and type have already been loaded and the bag argument
-**  contains the bag in question
-**  No loading function may allocate any bag
+**  contains the bag in question.
+**  No loading function may allocate any bag.
 */
 
 extern void (*LoadObjFuncs[256]) ( Obj obj );

--- a/src/objpcgel.h
+++ b/src/objpcgel.h
@@ -44,7 +44,7 @@
 
 /****************************************************************************
 **
-*V  COLLECTOR_PCWORD( <obj> ) . . . . . . . . . . . . . .  collector of <obj>
+*F  COLLECTOR_PCWORD( <obj> ) . . . . . . . . . . . . . .  collector of <obj>
 */
 #define COLLECTOR_PCWORD(obj) \
     ( ELM_PLIST( TYPE_DATOBJ(obj), PCWP_COLLECTOR ) )

--- a/src/opers.h
+++ b/src/opers.h
@@ -26,10 +26,10 @@ typedef struct {
     // an operation is a T_FUNCTION with additional data
     FuncBag func;
 
-    // flag 1 list of an `and' filter
+    // flag 1 list of an 'and' filter
     Obj flag1;
 
-    // flag 2 list of an `and' filter
+    // flag 2 list of an 'and' filter
     Obj flag2;
 
     // flags of a filter
@@ -54,7 +54,7 @@ typedef struct {
 
 /****************************************************************************
 **
-*V  TRY_NEXT_METHOD . . . . . . . . . . . . . . . . . `TRY_NEXT_MESSAGE' flag
+*V  TRY_NEXT_METHOD . . . . . . . . . . . . . . . . .  'TRY_NEXT_METHOD' flag
 */
 extern Obj TRY_NEXT_METHOD;
 
@@ -88,7 +88,7 @@ static inline const OperBag * CONST_OPER(Obj oper)
 
 /****************************************************************************
 **
-*F  FLAG1_FILT( <oper> )  . . . . . . . . . .  flag 1 list of an `and' filter
+*F  FLAG1_FILT( <oper> )  . . . . . . . . . .  flag 1 list of an 'and' filter
 */
 static inline Obj FLAG1_FILT(Obj oper)
 {
@@ -103,7 +103,7 @@ static inline void SET_FLAG1_FILT(Obj oper, Obj x)
 
 /****************************************************************************
 **
-*F  FLAG2_FILT( <oper> )  . . . . . . . . . .  flag 2 list of an `and' filter
+*F  FLAG2_FILT( <oper> )  . . . . . . . . . .  flag 2 list of an 'and' filter
 */
 static inline Obj FLAG2_FILT(Obj oper)
 {
@@ -287,14 +287,14 @@ static inline void SET_ENABLED_ATTR(Obj oper, Int x)
 
 /****************************************************************************
 **
-*F  AND_CACHE_FLAGS( <flags> )  . . . . . . . . . `and' cache of a flags list
+*F  AND_CACHE_FLAGS( <flags> )  . . . . . . . . . 'and' cache of a flags list
 */
 #define AND_CACHE_FLAGS(list)           (CONST_ADDR_OBJ(list)[3])
 
 
 /****************************************************************************
 **
-*F  SET_AND_CACHE_FLAGS( <flags>, <len> ) set the `and' cache of a flags list
+*F  SET_AND_CACHE_FLAGS( <flags>, <len> ) set the 'and' cache of a flags list
 */
 #define SET_AND_CACHE_FLAGS(flags,andc)  (ADDR_OBJ(flags)[3]=(andc))
 
@@ -333,8 +333,9 @@ static inline void SET_ENABLED_ATTR(Obj oper, Int x)
 **
 *F  MASK_POS_FLAGS( <pos> ) . . .  . .  bit mask for position of a flags list
 **
-**  MASK_POS_FLAGS(<pos>) returns  a UInt with a  single set  bit in position
-**  (pos-1) % BIPEB, useful for accessing the pos'th element of a FLAGS
+**  'MASK_POS_FLAGS(<pos>)' returns a UInt with a single set  bit in position
+**  '(<pos>-1) % BIPEB',
+**  useful for accessing the <pos>-th element of a 'FLAGS' list.
 **
 **  Note that 'MASK_POS_FLAGS'  is a macro, so  do not call it with arguments
 **  that have side effects.
@@ -353,7 +354,7 @@ static inline void SET_ENABLED_ATTR(Obj oper, Int x)
 **  Note that 'ELM_FLAGS' is a macro, so do not call it  with arguments  that
 **  have side effects.
 **
-**  C_ELM_FLAGS returns a result which it is better to use inside the kernel
+**  'C_ELM_FLAGS' returns a result which it is better to use inside the kernel
 **  since the C compiler can't know that True != False. Using C_ELM_FLAGS
 **  gives slightly nicer C code and potential for a little more optimisation.
 */

--- a/src/plist.h
+++ b/src/plist.h
@@ -225,10 +225,10 @@ static inline Obj * BASE_PTR_PLIST(Obj list)
 **
 *F  IS_DENSE_PLIST( <list> )  . . . . . check if <list> is a dense plain list
 **
-** Note that this only checks for plists that are known to be dense.  This is
-** very fast.  If you want  to also handle plists  for which it  is now known
-** whether they  are dense or not  (i.e. of type T_PLIST),  use IS_DENSE_LIST
-** instead.
+**  Note that this only checks for plists that are known to be dense. This is
+**  very fast.  If you want  to also handle plists  for which it is now known
+**  whether they are dense or not (i.e. of type 'T_PLIST'),
+**  use 'IS_DENSE_LIST' instead.
 */
 static inline Int IS_DENSE_PLIST(Obj list)
 {

--- a/src/pperm.h
+++ b/src/pperm.h
@@ -96,9 +96,9 @@ extern Obj OnSetsPPerm(Obj set, Obj f);
 
 /****************************************************************************
 **
-*F HashFuncForPPerm( <f>) . . . hash pperm
+*F  HashFuncForPPerm( <f> ) . . . hash pperm
 **
-** Returns a hash value for a partial permutation
+**  Returns a hash value for a partial permutation
 */
 
 Int HashFuncForPPerm(Obj f);

--- a/src/precord.h
+++ b/src/precord.h
@@ -173,13 +173,14 @@ static inline Obj GET_ELM_PREC(Obj rec, UInt i)
 
 /****************************************************************************
 **
-*F FindPRec( <rec>, <rnam>, <pos>, <cleanup> )
-**   . . . . . . . . . . . . . . . . . find a component name by binary search
+*F  FindPRec( <rec>, <rnam>, <pos>, <cleanup> )
+*F   . . . . . . . . . . . . . . . . . find a component name by binary search
 **
-** Searches rnam in rec, sets pos to the position where it is found (return
-** value 1) or where it should be inserted if it is not found (return val 0).
-** If cleanup is nonzero, a dirty record is automatically cleaned up.
-** If cleanup is 0, this does not happen.
+**  Searches <rnam> in <rec>, sets <pos> to the position where it is found
+**  (return value 1) or where it should be inserted if it is not found
+**  (return value 0).
+**  If <cleanup> is nonzero, a dirty record is automatically cleaned up.
+**  If <cleanup> is 0, this does not happen.
 **/
 
 extern UInt FindPRec( Obj rec, UInt rnam, UInt *pos, int cleanup );

--- a/src/profile.h
+++ b/src/profile.h
@@ -22,7 +22,7 @@
 
 /****************************************************************************
 **
-*F  InitInfoStats() . . . . . . . . . . . . . . . . . table of init functions
+*F  InitInfoProfile() . . . . . . . . . . . . . . . . table of init functions
 */
 StructInitInfo * InitInfoProfile ( void );
 

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -15,9 +15,9 @@
 **  and the compact representation of strings.
 **
 **  Strings in compact representation  can be accessed and handled through
-**  the  macros     'NEW_STRING',   `CHARS_STRING'  (and   'CSTR_STRING'),
-**  'GET_LEN_STRING',   `SET_LEN_STRING', `GROW_STRING',  'GET_ELM_STRING'
-**  and `SET_ELM_STRING'.
+**  the  macros     'NEW_STRING',   'CHARS_STRING'  (and   'CSTR_STRING'),
+**  'GET_LEN_STRING',   'SET_LEN_STRING', 'GROW_STRING',  'GET_ELM_STRING'
+**  and 'SET_ELM_STRING'.
 **  
 **  This  package also contains the   list  function  for ranges, which   are
 **  installed in the appropriate tables by 'InitString'.
@@ -251,7 +251,8 @@ static inline void COPY_CHARS(Obj str, UChar * pnt, Int n)
 **  'PrintString' prints the string with the handle <list>.
 **
 **  No  linebreaks are allowed,  if one must be  inserted  anyhow, it must be
-** escaped by a backslash '\', which is done in 'Pr'.  */
+**  escaped by a backslash '\', which is done in 'Pr'.
+*/
 extern void PrintString (
     Obj                 list );
 
@@ -377,11 +378,12 @@ Obj ConvImmString(Obj str);
 **
 *F  C_NEW_STRING_DYN( <string>, <cstring> ) . . . . . . . . create GAP string
 **
-** The cstring is assumed to be allocated on the heap, hence its length
-** is dynamic and must be computed during runtime using strlen.
+**  The cstring is assumed to be allocated on the heap, hence its length
+**  is dynamic and must be computed during runtime using strlen.
 **
-** This macro is provided for backwards compatibility of packages.
-** MakeString and MakeImmString are as efficient and should be used instead.
+**  This macro is provided for backwards compatibility of packages.
+**  'MakeString' and 'MakeImmString' are as efficient and should be used
+**  instead.
 */
 #define C_NEW_STRING_DYN(string,cstr) \
   C_NEW_STRING(string, strlen(cstr), cstr)

--- a/src/system.h
+++ b/src/system.h
@@ -203,7 +203,9 @@ typedef UInt4    UInt;
 
 /****************************************************************************
 **
-*T  Bag . . . . . . . . . . . . . . . . . . . type of the identifier of a bag
+*t  Bag . . . . . . . . . . . . . . . . . . . type of the identifier of a bag
+**
+**  (The documentation of 'Bag' is contained in 'gasman.h'.)
 */
 typedef UInt * *        Bag;
 
@@ -280,7 +282,7 @@ extern const Char * SyArchitecture;
 *V  SyBuildVersion . . . . . . . . . . . . . . . . .  kernel version number
 *V  SyBuildDateTime  . . . . . . . . . . . . . . . .  kernel build time
 **
-** SyBuildVersion will replace SyKernelVersion
+**  'SyBuildVersion' will replace 'SyKernelVersion'.
 */
 extern const Char * SyKernelVersion;
 extern const Char * SyBuildVersion;
@@ -463,7 +465,7 @@ extern UInt SyQuitOnBreak;
 **
 *V  SyRestoring . . . . . . . . . . . . . . . . . . . . restoring a workspace
 **
-**  `SyRestoring' determines whether GAP is restoring a workspace or not.  If
+**  'SyRestoring' determines whether GAP is restoring a workspace or not.  If
 **  it is zero no restoring should take place otherwise it holds the filename
 **  of a workspace to restore.
 **
@@ -474,7 +476,7 @@ extern Char * SyRestoring;
 **
 *V  SyInitializing                               set to 1 during library init
 **
-**  `SyInitializing' is set to 1 during the library intialization phase of
+**  'SyInitializing' is set to 1 during the library intialization phase of
 **  startup. It supresses some behaviours that may not be possible so early
 **  such as homogeneity tests in the plist code.
 */
@@ -631,15 +633,16 @@ extern UInt SyTimeChildrenSys ( void );
 **
 *F  strlcpy( <dst>, <src>, <len> )
 **
-** Copy src to buffer dst of size len.  At most len-1 characters will be
-** copied. Afterwards, dst is always NUL terminated (unless len == 0).
+**  Copy <src> to buffer <dst> of size <len>. At most <len>-1 characters will
+**  be copied. Afterwards, <dst> is always 'NUL' terminated
+**  (unless <len> == 0).
 **
-** Returns strlen(src); hence if the return value is greater or equal
-** than len, truncation occurred.
+**  Returns 'strlen( <src> )'; hence if the return value is greater or equal
+**  than <len>, truncation occurred.
 **
-** This function is provided by some systems (e.g. OpenBSD, Mac OS X),
-** but not by all, so we provide a fallback implementation for those
-** systems that lack it.
+**  This function is provided by some systems (e.g. OpenBSD, Mac OS X),
+**  but not by all, so we provide a fallback implementation for those
+**  systems that lack it.
 */
 #ifndef HAVE_STRLCPY
 size_t strlcpy (
@@ -652,16 +655,17 @@ size_t strlcpy (
 **
 *F  strlcat( <dst>, <src>, <len> )
 **
-** Appends src to buffer dst of size len (unlike strncat, len is the full
-** size of dst, not space left). At most len-1 characters will be copied.
-** Afterwards, dst is always NUL terminated (unless len == 0).
+**  Appends <src> to buffer <dst> of size <len> (unlike 'strncat', <len> is
+**  the full size of <dst>, not space left).
+**  At most <len>-1 characters will be copied.
+**  Afterwards, <dst> is always 'NUL' terminated (unless <len> == 0).
 **
-** Returns initial length of dst plus strlen(src); hence if the return value
-** is greater or equal than len, truncation occurred.
+**  Returns initial length of <dst> plus 'strlen(<src>)'; hence if the return
+**  value is greater or equal than <len>, truncation occurred.
 **
-** This function is provided by some systems (e.g. OpenBSD, Mac OS X),
-** but not by all, so we provide a fallback implementation for those
-** systems that lack it.
+**  This function is provided by some systems (e.g. OpenBSD, Mac OS X),
+**  but not by all, so we provide a fallback implementation for those
+**  systems that lack it.
 */
 #ifndef HAVE_STRLCAT
 size_t strlcat (
@@ -674,12 +678,13 @@ size_t strlcat (
 **
 *F  strlncat( <dst>, <src>, <len>, <n> )
 **
-** Append at most n characters from src to buffer dst of size len. At most
-** len-1 characters will be copied. Afterwards, dst is always NUL terminated
-** (unless len == 0).
+**  Append at most <n> characters from <src> to buffer <dst> of size <len>.
+**  At most <len>-1 characters will be copied.
+**  Afterwards, <dst> is always 'NUL' terminated (unless <len> == 0).
 **
-** Returns initial length of dst plus the minimum of n and strlen(src); hence
-** if the return value is greater or equal than len, truncation occurred.
+**  Returns initial length of <dst> plus the minimum of <n> and
+**  'strlen(<src>)'; hence if the return value is greater or equal than
+**  <len>, truncation occurred.
 */
 size_t strlncat (
     char *dst,
@@ -691,11 +696,11 @@ size_t strlncat (
 **
 *F  strxcpy( <dst>, <src>, <len> )
 **
-** Copy src to buffer dst of size len. If an overflow would occur, trigger
-** an assertion.
+**  Copy <src> to buffer <dst> of size <len>.
+**  If an overflow would occur, trigger an assertion.
 **
-** This should be used with caution; in general, proper error handling is
-** preferable.
+**  This should be used with caution; in general, proper error handling is
+**  preferable.
 **/
 size_t strxcpy (
     char *dst,
@@ -706,11 +711,11 @@ size_t strxcpy (
 **
 *F  strxcat( <dst>, <src>, <len> )
 **
-** Append src to buffer dst of size len. If an overflow would occur, trigger
-** an assertion.
+**  Append <src> to buffer <dst> of size <len>.
+**  If an overflow would occur, trigger an assertion.
 **
-** This should be used with caution; in general, proper error handling is
-** preferable.
+**  This should be used with caution; in general, proper error handling is
+**  preferable.
 **/
 size_t strxcat (
     char *dst,
@@ -721,11 +726,12 @@ size_t strxcat (
 **
 *F  strxncat( <dst>, <src>, <len>, <n> )
 **
-** Append not more than n characters from src to buffer dst of size len.
-** If an overflow would occur, trigger an assertion.
+**  Append not more than <n> characters from <src> to buffer <dst> of size
+**  <len>.
+**  If an overflow would occur, trigger an assertion.
 **
-** This should be used with caution; in general, proper error handling is
-** preferable.
+**  This should be used with caution; in general, proper error handling is
+**  preferable.
 **/
 size_t strxncat (
     char *dst,
@@ -811,24 +817,31 @@ extern void SyAbortBags(const Char * msg) NORETURN;
 **
 *F * * * * * * * * * * * * * loading of modules * * * * * * * * * * * * * * *
 **
-** GAP_KERNEL_API_VERSION gives the version of the GAP kernel. This value
-** is used to check if kernel modules were built with a compatible kernel.
-** This version is not the same as, and not connected to, the GAP version.
+*/
+
+/****************************************************************************
 **
-** This is stored as GAP_KERNEL_MAJOR_VERSION*1000 + GAP_KERNEL_MINOR_VERSION
+*V  GAP_KERNEL_API_VERSION
 **
-** The algorithm used is the following:
+**  'GAP_KERNEL_API_VERSION' gives the version of the GAP kernel. This value
+**  is used to check if kernel modules were built with a compatible kernel.
+**  This version is not the same as, and not connected to, the GAP version.
 **
-** The kernel will not load a module compiled for a newer kernel.
+**  This is stored as
+**  'GAP_KERNEL_MAJOR_VERSION*1000 + GAP_KERNEL_MINOR_VERSION'.
 **
-** The kernel will not load a module compiled for a different major version.
+**  The algorithm used is the following:
 **
-** The minor version should be incremented when new backwards-compatible
-** functionality is added. The major version should be incremented when
-** a backwards-incompatible change is made.
+**  The kernel will not load a module compiled for a newer kernel.
 **
-** The kernel version is a macro so it can be used by packages
-** to optionally compile support for new functionality.
+**  The kernel will not load a module compiled for a different major version.
+**
+**  The minor version should be incremented when new backwards-compatible
+**  functionality is added. The major version should be incremented when
+**  a backwards-incompatible change is made.
+**
+**  The kernel version is a macro so it can be used by packages
+**  to optionally compile support for new functionality.
 **
 */
 
@@ -1065,12 +1078,12 @@ extern void SySleep( UInt secs );
 extern void SyUSleep( UInt msecs );
 
 /****************************************************************************
- **
- *F    sySetjmp( <jump buffer> )
- *F    syLongjmp( <jump buffer>, <value>)
- ** 
- **   macros and functions, defining our selected longjump mechanism
- */
+**
+*F  sySetjmp( <jump buffer> )
+*F  syLongjmp( <jump buffer>, <value> )
+** 
+**  macros and functions, defining our selected longjump mechanism
+*/
 
 #if defined(HAVE_SIGSETJMP)
 #define sySetjmp( buff ) (sigsetjmp( (buff), 0))
@@ -1090,8 +1103,9 @@ void syLongjmp(syJmp_buf* buf, int val) NORETURN;
 
 /****************************************************************************
 **
-*F RegisterSyLongjmpObserver : register a function to be called before
-**                   longjmp is called.
+*F  RegisterSyLongjmpObserver( <func> )
+**
+**  register a function to be called before longjmp is called.
 */
 
 typedef void (*voidfunc)(void);

--- a/src/trans.h
+++ b/src/trans.h
@@ -127,9 +127,9 @@ Int EqPermTrans44(UInt degL, UInt degR, const UInt4 * ptLstart, const UInt4 * pt
 
 /****************************************************************************
 **
-*F HashFuncForTrans( <f>) . . . hash transformation
+*F  HashFuncForTrans( <f> ) . . . hash transformation
 **
-** Returns a hash value for a transformation
+**  Returns a hash value for a transformation
 */
 
 Int HashFuncForTrans(Obj f);

--- a/src/vecgf2.h
+++ b/src/vecgf2.h
@@ -103,7 +103,8 @@
 *F  MASK_POS_GF2VEC( <pos> )  . . . . bit mask for position of a Boolean list
 **
 **  MASK_POS_GF2VEC(<pos>) returns a UInt with  a single set bit in  position
-**  (pos-1) % BIPEB, useful for accessing the pos'th element of a blist
+**  '(<pos>-1) % BIPEB',
+**  useful for accessing the <pos>-th element of a blist.
 **
 **  Note that 'MASK_POS_GF2VEC' is a  macro, so do not call it with arguments
 **  that have side effects.


### PR DESCRIPTION
This makes it easier to deal programmatically with the comments.
The most relevant changes concern '*V' vs. '*F',
round and square brackets in '*V' and '*T' lines,
and the analogue of GAPDoc's <C> element.
Besides that, I have fixed some obvious typos.