### PR TITLE
Add ability for FormatOutput to print GAP strings directly

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -1397,14 +1397,14 @@ void PrintFunction (
                 Obj body = BODY_FUNC(func);
                 if ( GET_FILENAME_BODY(body) ) {
                     if ( GET_LOCATION_BODY(body) ) {
-                        Pr("<<kernel code from %s:%s>>",
-                            (Int)CSTR_STRING(GET_FILENAME_BODY(body)),
-                            (Int)CSTR_STRING(GET_LOCATION_BODY(body)));
+                        Pr("<<kernel code from %g:%g>>",
+                            (Int)GET_FILENAME_BODY(body),
+                            (Int)GET_LOCATION_BODY(body));
                             outputtedfunc = 1;
                     }
                     else if ( GET_STARTLINE_BODY(body) ) {
-                        Pr("<<compiled GAP code from %s:%d>>",
-                            (Int)CSTR_STRING(GET_FILENAME_BODY(body)),
+                        Pr("<<compiled GAP code from %g:%d>>",
+                            (Int)GET_FILENAME_BODY(body),
                             GET_STARTLINE_BODY(body));
                             outputtedfunc = 1;
                     }

--- a/src/gap.c
+++ b/src/gap.c
@@ -1455,7 +1455,7 @@ Obj FuncLOAD_DYN (
     /* try to read the module                                              */
     res = SyLoadModule( CSTR_STRING(filename), &init );
     if ( res == 1 )
-        ErrorQuit( "module '%s' not found", (Int)CSTR_STRING(filename), 0L );
+        ErrorQuit( "module '%g' not found", (Int)filename, 0L );
     else if ( res == 3 )
         ErrorQuit( "symbol 'Init_Dynamic' not found", 0L, 0L );
     else if ( res == 5 )
@@ -1560,8 +1560,8 @@ Obj FuncLOAD_STAT (
     }
     if ( CompInitFuncs[k] == 0 ) {
         if ( SyDebugLoading ) {
-            Pr( "#I  LOAD_STAT: no module named '%s' found\n",
-                (Int)CSTR_STRING(filename), 0L );
+            Pr( "#I  LOAD_STAT: no module named '%g' found\n",
+                (Int)filename, 0L );
         }
         return False;
     }

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -320,15 +320,15 @@ void            AssGVar (
 
     // Make certain variable is not constant
     if (writeval == INTOBJ_INT(-1)) {
-        ErrorMayQuit("Variable: '%s' is constant", (Int)NameGVar(gvar), 0L);
+        ErrorMayQuit("Variable: '%g' is constant", (Int)NameGVarObj(gvar), 0L);
     }
 
     /* make certain that the variable is not read only                     */
     while ( (REREADING != True) &&
             (ELM_GVAR_LIST( WriteGVars, gvar ) == INTOBJ_INT(0)) ) {
         ErrorReturnVoid(
-            "Variable: '%s' is read only",
-            (Int)NameGVar(gvar), 0L,
+            "Variable: '%g' is read only",
+            (Int)NameGVarObj(gvar), 0L,
             "you can 'return;' after making it writable" );
     }
 
@@ -694,7 +694,7 @@ void MakeReadOnlyGVar (
     UInt                gvar )
 {
     if (ELM_GVAR_LIST(WriteGVars, gvar) == INTOBJ_INT(-1)) {
-        ErrorMayQuit("Variable: '%s' is constant", (Int)NameGVar(gvar), 0L);
+        ErrorMayQuit("Variable: '%g' is constant", (Int)NameGVarObj(gvar), 0L);
     }
     SET_ELM_GVAR_LIST( WriteGVars, gvar, INTOBJ_INT(0) );
     CHANGED_GVAR_LIST( WriteGVars, gvar );
@@ -709,8 +709,8 @@ void MakeConstantGVar(UInt gvar)
     Obj val = ValGVar(gvar);
     if (!IS_INTOBJ(val) && val != True && val != False) {
         ErrorMayQuit(
-            "Variable: '%s' must be assigned a small integer, true or false",
-            (Int)NameGVar(gvar), 0L);
+            "Variable: '%g' must be assigned a small integer, true or false",
+            (Int)NameGVarObj(gvar), 0L);
     }
     SET_ELM_GVAR_LIST(WriteGVars, gvar, INTOBJ_INT(-1));
     CHANGED_GVAR_LIST(WriteGVars, gvar);
@@ -803,7 +803,7 @@ void MakeReadWriteGVar (
     UInt                gvar )
 {
     if (ELM_GVAR_LIST(WriteGVars, gvar) == INTOBJ_INT(-1)) {
-        ErrorMayQuit("Variable: '%s' is constant", (Int)NameGVar(gvar), 0L);
+        ErrorMayQuit("Variable: '%g' is constant", (Int)NameGVarObj(gvar), 0L);
     }
     SET_ELM_GVAR_LIST( WriteGVars, gvar, INTOBJ_INT(1) );
     CHANGED_GVAR_LIST( WriteGVars, gvar );

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1170,8 +1170,8 @@ Obj FuncVAL_GVAR (
     val = ValAutoGVar( GVarName( CSTR_STRING(gvar) ) );
 
     while (val == (Obj) 0)
-      val = ErrorReturnObj("VAL_GVAR: No value bound to %s",
-                           (Int)CSTR_STRING(gvar), (Int) 0,
+      val = ErrorReturnObj("VAL_GVAR: No value bound to %g",
+                           (Int)gvar, (Int) 0,
                            "you can return a value" );
     return val;
 }

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2907,8 +2907,8 @@ void            IntrRefGVar (
     /* get and check the value                                             */
     if ( (val = ValAutoGVar( gvar )) == 0 ) {
         ErrorQuit(
-            "Variable: '%s' must have a value",
-            (Int)NameGVar(gvar), 0L );
+            "Variable: '%g' must have a value",
+            (Int)NameGVarObj(gvar), 0L );
     }
 
     /* push the value                                                      */

--- a/src/io.c
+++ b/src/io.c
@@ -1551,7 +1551,6 @@ static inline void FormatOutput(
     void *state, const Char *format, Int arg1, Int arg2 )
 {
   const Char *        p;
-  Char *              q;
   Int                 prec,  n;
   Char                fill;
 
@@ -1617,7 +1616,7 @@ static inline void FormatOutput(
     else if ( *p == 's' ) {
 
       /* compute how many characters this identifier requires    */
-      for ( q = (Char*)arg1; *q != '\0' && prec > 0; q++ ) {
+      for ( Char * q = (Char *)arg1; *q != '\0' && prec > 0; q++ ) {
         prec--;
       }
 
@@ -1627,7 +1626,7 @@ static inline void FormatOutput(
       /* print the string                                        */
       /* must be careful that line breaks don't go inside
          escaped sequences \n or \123 or similar */
-      for ( q = (Char*)arg1; *q != '\0'; q++ ) {
+      for ( Char * q = (Char *)arg1; *q != '\0'; q++ ) {
           if (*q == '\\' && IO()->NoSplitLine == 0) {
               if (*(q + 1) < '8' && *(q + 1) >= '0')
                   IO()->NoSplitLine = 3;
@@ -1647,7 +1646,7 @@ static inline void FormatOutput(
     else if ( *p == 'S' ) {
 
       /* compute how many characters this identifier requires    */
-      for ( q = (Char*)arg1; *q != '\0' && prec > 0; q++ ) {
+      for ( Char * q = (Char *)arg1; *q != '\0' && prec > 0; q++ ) {
         if      ( *q == '\n'  ) { prec -= 2; }
         else if ( *q == '\t'  ) { prec -= 2; }
         else if ( *q == '\r'  ) { prec -= 2; }
@@ -1664,7 +1663,7 @@ static inline void FormatOutput(
       while ( prec-- > 0 )  put_a_char(state, ' ');
 
       /* print the string                                        */
-      for ( q = (Char*)arg1; *q != '\0'; q++ ) {
+      for ( Char * q = (Char *)arg1; *q != '\0'; q++ ) {
         if      ( *q == '\n'  ) { put_a_char(state, '\\'); put_a_char(state, 'n');  }
         else if ( *q == '\t'  ) { put_a_char(state, '\\'); put_a_char(state, 't');  }
         else if ( *q == '\r'  ) { put_a_char(state, '\\'); put_a_char(state, 'r');  }
@@ -1685,7 +1684,7 @@ static inline void FormatOutput(
     else if ( *p == 'C' ) {
 
       /* compute how many characters this identifier requires    */
-      for ( q = (Char*)arg1; *q != '\0' && prec > 0; q++ ) {
+      for ( Char * q = (Char *)arg1; *q != '\0' && prec > 0; q++ ) {
         if      ( *q == '\n'  ) { prec -= 2; }
         else if ( *q == '\t'  ) { prec -= 2; }
         else if ( *q == '\r'  ) { prec -= 2; }
@@ -1702,7 +1701,7 @@ static inline void FormatOutput(
       while ( prec-- > 0 )  put_a_char(state, ' ');
 
       /* print the string                                        */
-      for ( q = (Char*)arg1; *q != '\0'; q++ ) {
+      for ( Char * q = (Char *)arg1; *q != '\0'; q++ ) {
         if      ( *q == '\n'  ) { put_a_char(state, '\\'); put_a_char(state, 'n');  }
         else if ( *q == '\t'  ) { put_a_char(state, '\\'); put_a_char(state, 't');  }
         else if ( *q == '\r'  ) { put_a_char(state, '\\'); put_a_char(state, 'r');  }
@@ -1727,14 +1726,13 @@ static inline void FormatOutput(
       int found_keyword = 0;
 
       /* check if q matches a keyword    */
-      q = (Char*)arg1;
-      found_keyword = IsKeyword(q);
+      found_keyword = IsKeyword((Char *)arg1);
 
       /* compute how many characters this identifier requires    */
       if (found_keyword) {
         prec--;
       }
-      for ( q = (Char*)arg1; *q != '\0'; q++ ) {
+      for ( Char * q = (Char *)arg1; *q != '\0'; q++ ) {
         if ( !IsIdent(*q) && !IsDigit(*q) ) {
           prec--;
         }
@@ -1748,7 +1746,7 @@ static inline void FormatOutput(
       if ( found_keyword ) {
         put_a_char(state, '\\');
       }
-      for ( q = (Char*)arg1; *q != '\0'; q++ ) {
+      for ( Char * q = (Char *)arg1; *q != '\0'; q++ ) {
         if ( !IsIdent(*q) && !IsDigit(*q) ) {
           put_a_char(state, '\\');
         }

--- a/src/opers.c
+++ b/src/opers.c
@@ -3237,8 +3237,8 @@ Obj DoUninstalledGlobalFunction (
     Obj                 oper,
     Obj                 args )
 {
-    ErrorQuit( "%s: function is not yet defined",
-               (Int)CSTR_STRING(NAME_FUNC(oper)), 0L );
+    ErrorQuit( "%g: function is not yet defined",
+               (Int)NAME_FUNC(oper), 0L );
     return 0;
 }
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -521,8 +521,8 @@ Obj FuncLOG_TO (
             "you can replace <filename> via 'return <filename>;'" );
     }
     if ( ! OpenLog( CSTR_STRING(filename) ) ) {
-        ErrorReturnVoid( "LogTo: cannot log to %s",
-                         (Int)CSTR_STRING(filename), 0L,
+        ErrorReturnVoid( "LogTo: cannot log to %g",
+                         (Int)filename, 0L,
                          "you can 'return;'" );
         return False;
     }
@@ -593,8 +593,8 @@ Obj FuncINPUT_LOG_TO (
             "you can replace <filename> via 'return <filename>;'" );
     }
     if ( ! OpenInputLog( CSTR_STRING(filename) ) ) {
-        ErrorReturnVoid( "InputLogTo: cannot log to %s",
-                         (Int)CSTR_STRING(filename), 0L,
+        ErrorReturnVoid( "InputLogTo: cannot log to %g",
+                         (Int)filename, 0L,
                          "you can 'return;'" );
         return False;
     }
@@ -665,8 +665,8 @@ Obj FuncOUTPUT_LOG_TO (
             "you can replace <filename> via 'return <filename>;'" );
     }
     if ( ! OpenOutputLog( CSTR_STRING(filename) ) ) {
-        ErrorReturnVoid( "OutputLogTo: cannot log to %s",
-                         (Int)CSTR_STRING(filename), 0L,
+        ErrorReturnVoid( "OutputLogTo: cannot log to %g",
+                         (Int)filename, 0L,
                          "you can 'return;'" );
         return False;
     }
@@ -754,8 +754,8 @@ static Obj PRINT_OR_APPEND_TO(Obj args, int append)
     i = append ? OpenAppend( CSTR_STRING(filename) )
                : OpenOutput( CSTR_STRING(filename) );
     if ( ! i ) {
-        ErrorQuit( "%s: cannot open '%s' for output",
-                   (Int)funcname, (Int)CSTR_STRING(filename) );
+        ErrorQuit( "%s: cannot open '%g' for output",
+                   (Int)funcname, (Int)filename );
         return 0;
     }
 
@@ -914,15 +914,15 @@ Obj FuncSET_OUTPUT (
     if ( IsStringConv(file) ) {
         if ( append != False ) {
           if ( ! OpenAppend( CSTR_STRING(file) ) ) {
-             ErrorQuit( "SET_OUTPUT: cannot open '%s' for appending",
-                                  (Int)CSTR_STRING(file), 0L );
+             ErrorQuit( "SET_OUTPUT: cannot open '%g' for appending",
+                                  (Int)file, 0L );
           } else {
              return 0;
           }
         } else {
           if ( ! OpenOutput( CSTR_STRING(file) ) ) {
-             ErrorQuit( "SET_OUTPUT: cannot open '%s' for output",
-                                  (Int)CSTR_STRING(file), 0L );
+             ErrorQuit( "SET_OUTPUT: cannot open '%g' for output",
+                                  (Int)file, 0L );
           } else {
             return 0;
           }

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -754,23 +754,7 @@ void PrintString (
 void PrintString1 (
     Obj                 list )
 {
-  char PrStrBuf[10007];	/* 7 for a \c\123 at the end */
-  UInt len = GET_LEN_STRING(list);
-  UInt scanout, off = 0;
-  UInt1  *p;
-
-  while (off < len)    {
-    for (p = CHARS_STRING(list), scanout=0; 
-         p[off] && off<len && scanout<10000; 
-         off++, scanout++) {
-      PrStrBuf[scanout] = p[off];
-    }
-    PrStrBuf[scanout] = '\0';
-    Pr( "%s", (Int)PrStrBuf, 0L );
-    for (; off<len && CHARS_STRING(list)[off]==0; off++) {
-      Pr("%c", 0L, 0L);
-    }
-  }
+  Pr("%g", (Int)list, 0L);
 }
 
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -447,8 +447,8 @@ Obj             EvalRefGVar (
     /* get and check the value of the global variable                      */
     while ( (val = ValAutoGVar( (UInt)(ADDR_EXPR(expr)[0]) )) == 0 ) {
         ErrorReturnVoid(
-            "Variable: '%s' must have an assigned value",
-            (Int)NameGVar( (UInt)(ADDR_EXPR(expr)[0]) ), 0L,
+            "Variable: '%g' must have an assigned value",
+            (Int)NameGVarObj( (UInt)(ADDR_EXPR(expr)[0]) ), 0L,
             "you can 'return;' after assigning a value" );
     }
 


### PR DESCRIPTION
This adds '%g' and '%G' to GAP's FormatOutput, to allow print GAP strings directly. This replaces many places where we pass a C pointer to a GAP string around, in some cases leading to problems with strings getting GCed.

Resolves #2317