### PR TITLE
Avoid GC problem in PowPerm2Int/PowPerm4Int

### DIFF
--- a/src/permutat.c
+++ b/src/permutat.c
@@ -1135,6 +1135,8 @@ Obj             PowPerm2Int (
 
     /* compute the power by raising the cycles individually for large exps */
     else if ( TNUM_OBJ(opR) == T_INTNEG ) {
+        /* do negation first as it can cause a garbage collection          */
+        opR = AInvInt(opR);
 
         /* make sure that the buffer bag is large enough                   */
         UseTmpPerm(SIZE_OBJ(opL));
@@ -1145,7 +1147,6 @@ Obj             PowPerm2Int (
             ptKnown[p] = 0;
 
         /* get pointer to the permutation and the power                    */
-        opR = AInvInt(opR);
         ptL = CONST_ADDR_PERM2(opL);
         ptP = ADDR_PERM2(pow);
 
@@ -1397,6 +1398,8 @@ Obj             PowPerm4Int (
 
     /* compute the power by raising the cycles individually for large exps */
     else if ( TNUM_OBJ(opR) == T_INTNEG ) {
+        /* do negation first as it can cause a garbage collection          */
+        opR = AInvInt(opR);
 
         /* make sure that the buffer bag is large enough                   */
         UseTmpPerm(SIZE_OBJ(opL));
@@ -1407,7 +1410,6 @@ Obj             PowPerm4Int (
             ptKnown[p] = 0;
 
         /* get pointer to the permutation and the power                    */
-        opR = AInvInt(opR);
         ptL = CONST_ADDR_PERM4(opL);
         ptP = ADDR_PERM4(pow);
 


### PR DESCRIPTION
AInvInt can cause a garbage collection, which moves the memory that ptKnown points to, so calculate the negation first.