### PR TITLE
travis: exclude packages from coverage collection

### DIFF
--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -73,6 +73,12 @@ do
       rm -rf NormalizInterface-0.9.8
     fi
 
+    # reset CFLAGS and LDFLAGS before compiling packages, to prevent
+    # them from being compiled with coverage gathering, because
+    # otherwise gcov may confuse IO's src/io.c, or anupq's src/read.c,
+    # with GAP kernel files with the same name
+    unset CFLAGS
+    unset LDFLAGS
     if ! "$SRCDIR/bin/BuildPackages.sh" --strict --with-gaproot="$BUILDDIR"
     then
         echo "Some packages failed to build:"


### PR DESCRIPTION
Specifically, reset CFLAGS and LDFLAGS before compiling packages, to prevent them from being compiled with coverage gathering, because otherwise gcov may confuse IO's src/io.c, or anupq's src/read.c, with GAP kernel files with the same name

This extends PR #2304 which already seemed to resolve the issue for `src/io.c`, but I still see garbage results on <https://codecov.io/gh/gap-system/gap/src/master/src/read.c>, which this PR hopefully will resolve. The codecov report will tell us if it worked.