### PR TITLE
Fix QuaternionGroup for non-abelian number fields, tests

### DIFF
--- a/grp/basicmat.gi
+++ b/grp/basicmat.gi
@@ -101,7 +101,7 @@ function( filter, fld, n )
     cyc := E( n / 2 );
     bas := CanonicalBasis( Field( fld, [ cyc ]  ) );
     one := 1;
-  elif 0 = n mod Characteristic( fld )
+  elif Characteristic( fld ) = 0 or (0 = n mod Characteristic( fld ))
   then # XXX: regular rep is not minimal
     grp := QuaternionGroup( IsPermGroup, n );
     grp := Group( List( GeneratorsOfGroup( grp ), prm -> PermutationMat( prm, NrMovedPoints( grp ), fld ) ) );
@@ -115,11 +115,6 @@ function( filter, fld, n )
     bas := CanonicalBasis( GF( Size( fld ), OrderMod( Size( fld ), n/2 ) ) );
     cyc := Z( Size( Field( bas ) ) )^( ( Size( Field( bas ) ) - 1 ) / (n/2) );
     one := One( fld );
-  elif Characteristic( fld ) = 0
-  then
-    bas := CanonicalBasis( CF( n / 2 ) );
-    cyc := E( n / 2 );
-    one := 1;
   else
     bas := CanonicalBasis( GF( Characteristic( fld ), OrderMod( Characteristic( fld ), n/2 ) ) );
     cyc := Z( Size( Field( bas ) ) )^( ( Size( Field( bas ) ) - 1 ) / (n/2) );
@@ -352,7 +347,6 @@ CallFuncList( function()
   local 
     SylowSubgroupOfWreathProduct,
     MaximalUnipotentSubgroupOfNaturalGL,
-    TorusOfNaturalGL,
     SylowSubgroupOfTorusOfNaturalGL,
     SylowSubgroupOfNaturalGL;
 
@@ -405,33 +399,6 @@ MaximalUnipotentSubgroupOfNaturalGL := function( gl )
   SetIsPGroup( u, true );
   SetPrimePGroup( u, Characteristic(q) );
   return u;
-end;
-
-# The conjugacy classes of maximal tori of GL are indexed by conjugacy classes
-# of Weyl group elements.  For a given permutation, return a corresponding
-# torus.
-TorusOfNaturalGL := function( gl, pi )
-  local n, q, gfq, one, orbs, gens, sub;
-  n := DimensionOfMatrixGroup( gl );
-  q := Size( DefaultFieldOfMatrixGroup( gl ) );
-  if SizeGL( n, q ) <> Size( gl ) then
-    q := Size( FieldOfMatrixGroup( gl ) );
-  fi;
-  gfq := GF(q);
-  one := IdentityMat( n, gfq );
-  orbs := Cycles( pi, [1..n] );
-  gens := List( orbs, function( orb )
-    local mat;
-    mat := MutableCopyMat( one );
-    # XXX: Asks GAP to compute ConwayPolynomial, but could make do with much less
-    mat{orb}{orb} := CompanionMat( MinimalPolynomial( gfq, Z(q^Size(orb)) ) );
-    return ImmutableMatrix( gfq, mat, true );
-  end );
-  sub := Subgroup( gl, gens );
-  SetIsAbelian( sub, true );
-  SetAbelianInvariants( sub, AbelianInvariantsOfList( List( orbs, orb -> q^Size(orb)-1 ) ) );
-  SetSize( sub, Product( AbelianInvariants( sub ) ) );
-  return sub;
 end;
 
 # The Sylow p-subgroup of a direct product of cyclic groups is quite easy to

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -117,6 +117,11 @@ gap> QuaternionGroup(IsPermGroup,8);
 Group([ (1,5,3,7)(2,8,4,6), (1,2,3,4)(5,6,7,8) ])
 gap> QuaternionGroup(IsFpGroup,8);
 <fp group of size 8 on the generators [ r, s ]>
+gap> G:=QuaternionGroup(IsMatrixGroup, 8);
+<matrix group of size 8 with 2 generators>
+gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
+Rationals
+4
 gap> G:=QuaternionGroup(IsMatrixGroup, GF(3), 8);
 <matrix group of size 8 with 2 generators>
 gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);

--- a/tst/testinstall/grp/classic-G.tst
+++ b/tst/testinstall/grp/classic-G.tst
@@ -4,6 +4,9 @@
 gap> START_TEST("classic-G.tst");
 
 #
+gap> GL(1,5); Size(last);
+GL(1,5)
+4
 gap> GL(2,5);
 GL(2,5)
 gap> last = GL(2,GF(5));
@@ -16,6 +19,20 @@ gap> GL(3);
 Error, usage: GeneralLinearGroup( [<filter>, ]<d>, <R> )
 gap> GL(3,6);
 Error, usage: GeneralLinearGroup( [<filter>, ]<d>, <R> )
+
+#
+gap> G:=GL(4,3);; List([2,3,5,11,13], p-> Size(SylowSubgroup(G,p)));
+[ 512, 729, 5, 1, 13 ]
+gap> G:=GL(4,4);; List([2,3,5,11,13], p-> Size(SylowSubgroup(G,p)));
+[ 4096, 243, 25, 1, 1 ]
+gap> G:=GL(4,5);; List([2,3,5,11,13], p-> Size(SylowSubgroup(G,p)));
+[ 2048, 9, 15625, 1, 13 ]
+gap> G:=GL(4,7);; List([2,3,5,11,13], p-> Size(SylowSubgroup(G,p)));
+[ 2048, 243, 25, 1, 1 ]
+gap> G:=GL(5,3);; List([2,3,5,11,13], p-> Size(SylowSubgroup(G,p)));
+[ 1024, 59049, 5, 121, 13 ]
+gap> G:=GL(5,4);; List([2,3,5,11,13], p-> Size(SylowSubgroup(G,p)));
+[ 1048576, 729, 25, 11, 1 ]
 
 #
 gap> G := GO(3,5);
@@ -74,8 +91,16 @@ gap> GU(3,6);
 Error, <subfield> must be a prime or a finite field
 
 #
+gap> GammaL(1,5);
+GL(1,5)
+gap> GammaL(2,5);
+GL(2,5)
 gap> GammaL(3,5);
 GL(3,5)
+gap> GammaL(1,9);
+GammaL(1,9)
+gap> GammaL(2,9);
+GammaL(2,9)
 gap> GammaL(3,9);
 GammaL(3,9)
 gap> GammaL(IsPermGroup,3,9);


### PR DESCRIPTION
* fix QuaternionGroupCons for matrix groups over non-abelian
  number fields
* remove unused TorusOfNaturalGL
* add more tests

I did not add a test for the bug fix, because the only way I know how to get a non-abelian number field in GAP is to use `AlgebraicExtension` and that doesn't work very well; I had to use all kinds of trickery to get one that triggered the (obvious) bug in the code, and then the resulting group is not very pleasant to work with. So, not test, but the fix is IMHO clearly correct.