### PR TITLE
Add more tests, fix assertion triggered by `IsBound(x->x)`

### DIFF
--- a/grp/basicprm.gi
+++ b/grp/basicprm.gi
@@ -225,7 +225,7 @@ InstallMethod( DihedralGroupCons,
     elif 2n = 4 then
       D := GroupByGenerators( [ (1,2), (3,4) ] );
     elif 2n mod 2 = 1 then
-      Error( "<2n> must be an even integer" );
+      TryNextMethod();
     else
       g:= PermList( Concatenation( [ 2 .. 2n/2 ], [ 1 ] ) );
       h:= PermList( Concatenation( [ 1 ], Reversed( [ 2 .. 2n/2 ] ) ) );

--- a/grp/glzmodmz.gi
+++ b/grp/glzmodmz.gi
@@ -127,12 +127,9 @@ local f,M2,o,e,MM,i;
 end);
 
 BindGlobal("SPRingGeneric",function(n,ring)
-local t,geni,m,slmats,gens,f,rels,i,j,k,l,mat,mat1,mats,id,nh,g;
+local geni,m,slmats,gens,f,rels,i,j,k,l,mat,mat1,mats,id,nh,g;
   nh:=n;
   n:=2*n;
-  t:=function(i,j)
-    return slmats[geni[i][j]];
-  end;
   geni:=List([1..n],x->[]);
   mats:=[];
   slmats:=[];

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -35,6 +35,7 @@ extern "C" {
 #include <src/integer.h>
 #include <src/intrprtr.h>
 #include <src/io.h>
+#include <src/iostream.h>
 #include <src/listfunc.h>
 #include <src/listoper.h>
 #include <src/lists.h>

--- a/src/read.c
+++ b/src/read.c
@@ -941,25 +941,28 @@ void ReadPerm (
 **
 */
 
-static UInt appendToString(Obj string, UInt len)
+static void appendToString(Obj string, const char * val)
 {
-       UInt len1 = strlen(STATE(Value));
-       GROW_STRING(string, len+len1+1);
-       memcpy(CHARS_STRING(string) + len, STATE(Value), len1+1);
-       SET_LEN_STRING(string, len+len1);
-       return len + len1;
+    const UInt len = GET_LEN_STRING(string);
+    const UInt len1 = strlen(val);
+
+    // ensure enough memory is allocated (GROW_STRING automatically
+    // reserves extra space for the terminating zero byte)
+    GROW_STRING(string, len + len1);
+    SET_LEN_STRING(string, len + len1);
+
+    // copy the data, including the terminator byte
+    memcpy(CHARS_STRING(string) + len, val, len1 + 1);
 }
 
 void ReadLongNumber(
       TypSymbolSet        follow )
 {
      Obj  string;
-     UInt len;
      UInt status;
      UInt done;
 
      /* string in which to accumulate number */
-     len = strlen(STATE(Value));
      string = MakeString(STATE(Value));
      done = 0;
 
@@ -973,14 +976,14 @@ void ReadLongNumber(
        case S_PARTIALINT:
          switch (STATE(Symbol)) {
          case S_INT:
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            Match(S_INT, "integer", follow);
            IntrLongIntExpr(string);
            done = 1;
            break;
 
          case S_PARTIALINT:
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            /*      Match(S_PARTIALINT, "integer", follow);*/
            break;
 
@@ -993,12 +996,12 @@ void ReadLongNumber(
          case S_PARTIALFLOAT3:
          case S_PARTIALFLOAT4:
            status = STATE(Symbol);
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            /* Match(STATE(Symbol), "float", follow); */
            break;
 
          case S_FLOAT:
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            Match(S_FLOAT, "float", follow);
            IntrLongFloatExpr(string);
            done = 1;
@@ -1008,7 +1011,7 @@ void ReadLongNumber(
            SyntaxError("Identifier over 1024 characters");
 
          default:
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            IntrLongIntExpr(string);
            done = 1;
          }
@@ -1028,12 +1031,12 @@ void ReadLongNumber(
          case S_PARTIALFLOAT3:
          case S_PARTIALFLOAT4:
            status = STATE(Symbol);
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            /* Match(STATE(Symbol), "float", follow); */
            break;
 
          case S_FLOAT:
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            Match(S_FLOAT, "float", follow);
            IntrLongFloatExpr(string);
            done = 1;
@@ -1058,12 +1061,12 @@ void ReadLongNumber(
          case S_PARTIALFLOAT3:
          case S_PARTIALFLOAT4:
            status = STATE(Symbol);
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            /* Match(STATE(Symbol), "float", follow); */
            break;
 
          case S_FLOAT:
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            Match(S_FLOAT, "float", follow);
            IntrLongFloatExpr(string);
            done = 1;
@@ -1074,7 +1077,7 @@ void ReadLongNumber(
            SyntaxError("Badly Formed Number");
 
          default:
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            IntrLongFloatExpr(string);
            done = 1;
          }
@@ -1094,12 +1097,12 @@ void ReadLongNumber(
 
          case S_PARTIALFLOAT4:
            status = STATE(Symbol);
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            /* Match(STATE(Symbol), "float", follow); */
            break;
 
          case S_FLOAT:
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            Match(S_FLOAT, "float", follow);
            IntrLongFloatExpr(string);
            done = 1;
@@ -1125,12 +1128,12 @@ void ReadLongNumber(
 
          case S_PARTIALFLOAT4:
            status = STATE(Symbol);
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            /* Match(STATE(Symbol), "float", follow); */
            break;
 
          case S_FLOAT:
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            Match(S_FLOAT, "float", follow);
            IntrLongFloatExpr(string);
            done = 1;
@@ -1140,7 +1143,7 @@ void ReadLongNumber(
            SyntaxError("Badly Formed Number");
 
          default:
-           len = appendToString(string, len);
+           appendToString(string, STATE(Value));
            IntrLongFloatExpr(string);
            done = 1;
 

--- a/src/read.c
+++ b/src/read.c
@@ -763,16 +763,14 @@ void ReadCallVarAss(TypSymbolSet follow, Char mode)
     if (ref.type == R_INVALID)
         return;
 
-    /* if this was actually the beginning of a function literal            */
-    /* then we are in the wrong function                                   */
-    if ( STATE(Symbol) == S_MAPTO ) {
-      if (mode == 'r' || mode == 'x')
-        {
-          ReadFuncExprAbbrevSingle( follow );
-          return;
-        }
-      else
-        SyntaxError("Function literal in impossible context");
+    // if this was actually the beginning of a function literal, then we are
+    // in the wrong function
+    if (STATE(Symbol) == S_MAPTO) {
+        if (mode == 'r' || mode == 'x')
+            ReadFuncExprAbbrevSingle(follow);
+        else
+            SyntaxError("Function literal in impossible context");
+        return;
     }
 
     // Check if the variable is a constant

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -35,11 +35,35 @@ gap> AbelianGroup(IsFpGroup,[2,3]);
 <fp group of size 6 on the generators [ f1, f2 ]>
 
 #
+gap> AbelianGroup([2,0]);
+<fp group on the generators [ f1, f2 ]>
+gap> AbelianGroup([2,infinity]);
+<fp group on the generators [ f1, f2 ]>
+gap> AbelianGroup(IsPcGroup,[2,0]);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `AbelianGroupCons' on 2 arguments
+gap> AbelianGroup(IsPermGroup,[2,0]);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `AbelianGroupCons' on 2 arguments
+gap> AbelianGroup(IsFpGroup,[2,0]);
+<fp group on the generators [ f1, f2 ]>
+
+#
 gap> AbelianGroup(2,3);
 Error, usage: AbelianGroup( [<filter>, ]<ints> )
 gap> AbelianGroup(IsRing,[2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `AbelianGroupCons' on 2 arguments
+
+#
+gap> AbelianGroup("bad");
+Error, <ints> must be a list of integers
+gap> AbelianGroup(IsPcGroup, "bad");
+Error, <ints> must be a list of integers
+gap> AbelianGroup(IsPermGroup, "bad");
+Error, <ints> must be a list of integers
+gap> AbelianGroup(IsFpGroup, "bad");
+Error, <ints> must be a list of integers
 
 #
 # alternating groups
@@ -50,11 +74,34 @@ gap> AlternatingGroup(IsPcGroup,4);
 <pc group of size 12 with 3 generators>
 gap> AlternatingGroup(IsPermGroup,4);
 Alt( [ 1 .. 4 ] )
-
-# not (yet?) supported
-gap> AlternatingGroup(IsFpGroup,4);
+gap> AlternatingGroup(IsFpGroup,4); # not (yet?) supported
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `AlternatingGroupCons' on 2 arguments
+
+#
+gap> AlternatingGroup(5);
+Alt( [ 1 .. 5 ] )
+gap> AlternatingGroup(IsPcGroup,5);
+Error, <deg> must be at most 4
+gap> AlternatingGroup(IsPermGroup,5);
+Alt( [ 1 .. 5 ] )
+gap> AlternatingGroup(IsFpGroup,5); # not (yet?) supported
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `AlternatingGroupCons' on 2 arguments
+
+#
+gap> AlternatingGroup([2,4,17]);
+Alt( [ 2, 4, 17 ] )
+
+#
+gap> AlternatingGroup( IsRegular, 3 );
+Group([ (1,2,3) ])
+gap> AlternatingGroup( IsRegular, 4 );
+Group([ (1,5,7)(2,4,8)(3,6,9)(10,11,12), (1,2,3)(4,7,10)(5,9,11)(6,8,12) ])
+gap> AlternatingGroup( IsRegular, [2,4,6] );
+Group([ (1,2,3) ])
+gap> AlternatingGroup( IsRegular, [2,4,6,7] );
+Group([ (1,5,7)(2,4,8)(3,6,9)(10,11,12), (1,2,3)(4,7,10)(5,9,11)(6,8,12) ])
 
 #
 gap> AlternatingGroup(2,3);
@@ -65,6 +112,21 @@ Error, no 1st choice method found for `AlternatingGroupCons' on 2 arguments
 
 #
 # cyclic groups
+#
+gap> CyclicGroup(1);
+<pc group of size 1 with 0 generators>
+gap> CyclicGroup(IsPcGroup,1);
+<pc group of size 1 with 0 generators>
+gap> CyclicGroup(IsPermGroup,1);
+Group(())
+gap> CyclicGroup(IsFpGroup,1);
+<fp group of size 1 on the generators [ a ]>
+gap> G:=CyclicGroup(IsMatrixGroup, GF(2), 1);
+Group([ <an immutable 1x1 matrix over GF2> ])
+gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
+GF(2)
+1
+
 #
 gap> CyclicGroup(4);
 <pc group of size 4 with 2 generators>
@@ -90,6 +152,26 @@ Error, no 1st choice method found for `CyclicGroupCons' on 2 arguments
 #
 # dihedral groups
 #
+gap> DihedralGroup(2);
+<pc group of size 2 with 1 generators>
+gap> DihedralGroup(IsPcGroup,2);
+<pc group of size 2 with 1 generators>
+gap> DihedralGroup(IsPermGroup,2);
+Group([ (1,2) ])
+gap> DihedralGroup(IsFpGroup,2);
+<fp group of size 2 on the generators [ a ]>
+
+#
+gap> DihedralGroup(4);
+<pc group of size 4 with 2 generators>
+gap> DihedralGroup(IsPcGroup,4);
+<pc group of size 4 with 2 generators>
+gap> DihedralGroup(IsPermGroup,4);
+Group([ (1,2), (3,4) ])
+gap> DihedralGroup(IsFpGroup,4);
+<fp group of size 4 on the generators [ r, s ]>
+
+#
 gap> DihedralGroup(8);
 <pc group of size 8 with 3 generators>
 gap> DihedralGroup(IsPcGroup,8);
@@ -105,6 +187,20 @@ Error, usage: DihedralGroup( [<filter>, ]<size> )
 gap> DihedralGroup(IsRing,3);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `DihedralGroupCons' on 2 arguments
+
+#
+gap> DihedralGroup(7);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `DihedralGroupCons' on 2 arguments
+gap> DihedralGroup(IsPcGroup,7);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `DihedralGroupCons' on 2 arguments
+gap> DihedralGroup(IsPermGroup,7);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `DihedralGroupCons' on 2 arguments
+gap> DihedralGroup(IsFpGroup,7);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `DihedralGroupCons' on 2 arguments
 
 #
 # quaternion groups
@@ -148,12 +244,32 @@ gap> ElementaryAbelianGroup(IsFpGroup,8);
 <fp group of size 8 on the generators [ f1, f2, f3 ]>
 
 #
+gap> ElementaryAbelianGroup(1);
+<pc group of size 1 with 0 generators>
+gap> ElementaryAbelianGroup(IsPcGroup,1);
+<pc group of size 1 with 0 generators>
+gap> ElementaryAbelianGroup(IsPermGroup,1);
+Group(())
+gap> ElementaryAbelianGroup(IsFpGroup,1);
+<fp group of size 1 on the generators [ a ]>
+
+#
 gap> ElementaryAbelianGroup(2,3);
 Error, usage: ElementaryAbelianGroup( [<filter>, ]<size> )
 gap> ElementaryAbelianGroup(IsRing,3);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `ElementaryAbelianGroupCons' on 2 argume\
 nts
+
+#
+gap> ElementaryAbelianGroup(6);
+Error, <n> must be a prime power
+gap> ElementaryAbelianGroup(IsPcGroup,6);
+Error, <n> must be a prime power
+gap> ElementaryAbelianGroup(IsPermGroup,6);
+Error, <n> must be a prime power
+gap> ElementaryAbelianGroup(IsFpGroup,6);
+Error, <n> must be a prime power
 
 #
 # free abelian groups
@@ -173,14 +289,35 @@ Error, no 1st choice method found for `FreeAbelianGroupCons' on 2 arguments
 #
 # extra special groups
 #
-gap> ExtraspecialGroup(27, 3);
-<pc group of size 27 with 3 generators>
-gap> ExtraspecialGroup(27, '+');
-<pc group of size 27 with 3 generators>
+gap> ExtraspecialGroup(8, "+");
+<pc group of size 8 with 3 generators>
 gap> ExtraspecialGroup(8, "-");
 <pc group of size 8 with 3 generators>
-gap> ExtraspecialGroup(IsPcGroup, 125, 25);
+
+#
+gap> ExtraspecialGroup(27, 3); Exponent(last);
+<pc group of size 27 with 3 generators>
+3
+gap> ExtraspecialGroup(27, 9); Exponent(last);
+<pc group of size 27 with 3 generators>
+9
+gap> ExtraspecialGroup(27, '+'); Exponent(last);
+<pc group of size 27 with 3 generators>
+3
+gap> ExtraspecialGroup(27, '-'); Exponent(last);
+<pc group of size 27 with 3 generators>
+9
+
+#
+gap> ExtraspecialGroup(32, "+");
+<pc group of size 32 with 5 generators>
+gap> ExtraspecialGroup(32, "-");
+<pc group of size 32 with 5 generators>
+
+#
+gap> ExtraspecialGroup(IsPcGroup, 125, 25); Exponent(last);
 <pc group of size 125 with 3 generators>
+25
 
 #
 gap> ExtraspecialGroup(8,3);
@@ -248,11 +385,30 @@ gap> SymmetricGroup(IsPcGroup,3);
 <pc group of size 6 with 2 generators>
 gap> SymmetricGroup(IsPermGroup,3);
 Sym( [ 1 .. 3 ] )
-
-# not (yet?) supported
-gap> SymmetricGroup(IsFpGroup,4);
+gap> SymmetricGroup(IsFpGroup,3); # not (yet?) supported
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `SymmetricGroupCons' on 2 arguments
+
+#
+gap> SymmetricGroup(5);
+Sym( [ 1 .. 5 ] )
+gap> SymmetricGroup(IsPcGroup,5);
+Error, <deg> must be at most 4
+gap> SymmetricGroup(IsPermGroup,5);
+Sym( [ 1 .. 5 ] )
+gap> SymmetricGroup(IsFpGroup,5); # not (yet?) supported
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `SymmetricGroupCons' on 2 arguments
+
+#
+gap> SymmetricGroup([2,4,17]);
+Sym( [ 2, 4, 17 ] )
+
+#
+gap> SymmetricGroup( IsRegular, 3 );
+Group([ (1,4,5)(2,3,6), (1,3)(2,4)(5,6) ])
+gap> SymmetricGroup( IsRegular, [2,4,6] );
+Group([ (1,4,5)(2,3,6), (1,3)(2,4)(5,6) ])
 
 #
 gap> SymmetricGroup(2,3);

--- a/tst/testinstall/grp/glzmodmz.tst
+++ b/tst/testinstall/grp/glzmodmz.tst
@@ -42,10 +42,14 @@ gap> G:=GL(4,Integers mod 4);
 GL(4,Z/4Z)
 gap> CheckGeneratorsInvertible(G);
 true
+
+#
 gap> H:=SL(4,Integers mod 4);
 SL(4,Z/4Z)
 gap> CheckGeneratorsSpecial(H);
 true
+
+#
 gap> K:=Sp(4,Integers mod 4);
 Sp(4,Z/4Z)
 gap> CheckGeneratorsSpecial(K) and CheckBilinearForm(K);
@@ -68,6 +72,25 @@ gap> Size(G); Size(H); Size(K);
 660602880
 737280
 
+# test over non-prime-power rings
+gap> GL(4,Integers mod 6); CheckGeneratorsInvertible(last);
+GL(4,Z/6Z)
+true
+gap> SL(4,Integers mod 6); CheckGeneratorsSpecial(last);
+SL(4,Z/6Z)
+true
+gap> Sp(4,Integers mod 6);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `SymplecticGroupCons' on 3 arguments
+gap> GO(3,Integers mod 6);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `GeneralOrthogonalGroupCons' on 4 argume\
+nts
+gap> SO(3,Integers mod 6);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `SpecialOrthogonalGroupCons' on 4 argume\
+nts
+
 #
 gap> K:=Sp(4,Integers mod 9);
 Sp(4,Z/9Z)
@@ -79,6 +102,10 @@ gap> CheckGeneratorsSpecial(K) and CheckBilinearForm(K);
 true
 
 #
+gap> K:=GO(3,Integers mod 4);  # not (yet?) supported
+fail
+gap> K:=GO(3,Integers mod 25); # use separate code path 'transpose'
+GO(3,Z/25Z)
 gap> K:=GO(3,Integers mod 9);
 GO(3,Z/9Z)
 gap> CheckGeneratorsInvertible(K) and CheckBilinearForm(K);

--- a/tst/testinstall/kernel/read.tst
+++ b/tst/testinstall/kernel/read.tst
@@ -1,0 +1,64 @@
+#
+# Tests for functions defined in src/read.c
+#
+
+#
+# ReadFuncCallOption
+#
+gap> IsInt(1 : "a");
+Syntax error: Identifier expected in stream:1
+IsInt(1 : "a");
+            ^
+
+#
+# ReadSelector
+#
+gap> r:=rec(a:=1);;
+gap> r."a";
+Syntax error: Record component name expected in stream:1
+r."a";
+    ^
+gap> r!."a";
+Syntax error: Record component name expected in stream:1
+r!."a";
+     ^
+
+#
+# ReadVar
+#
+gap> IsBound("a");
+Syntax error: Identifier expected in stream:1
+IsBound("a");
+          ^
+
+#
+# ReadCallVarAss
+#
+gap> IsBound(x->x);
+Syntax error: Function literal in impossible context in stream:1
+IsBound(x->x);
+          ^
+
+#
+# ReadListExpr
+#
+gap> [,2..5];
+Syntax error: Must have no unbound entries in range in stream:1
+[,2..5];
+    ^
+gap> [1,2,3..5];
+Syntax error: Must have at most 2 entries before '..' in stream:1
+[1,2,3..5];
+       ^
+gap> [1..~];
+Syntax error: Sorry, '~' not allowed in range in stream:1
+[1..~];
+     ^
+
+#
+# ReadRecExpr
+#
+gap> rec("a":=1);
+Syntax error: Identifier expected in stream:1
+rec("a":=1);
+      ^

--- a/tst/testinstall/opers/SimpleGroup.tst
+++ b/tst/testinstall/opers/SimpleGroup.tst
@@ -1,13 +1,10 @@
 gap> START_TEST("SimpleGroup.tst");
 
 #
-gap> SimpleGroup("Alt(5)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
+gap> SimpleGroup("Alt(5)"); Size(last); IsAlternatingGroup(last2);
 A5
 60
-rec( 
-  name := "A(5) ~ A(1,4) = L(2,4) ~ B(1,4) = O(3,4) ~ C(1,4) = S(2,4) ~ 2A(1,4\
-) = U(2,4) ~ A(1,5) = L(2,5) ~ B(1,5) = O(3,5) ~ C(1,5) = S(2,5) ~ 2A(1,5) = U\
-(2,5)", parameter := 5, series := "A", shortname := "A5" )
+true
 gap> SimpleGroup("A6"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 A6
 360
@@ -133,13 +130,10 @@ gap> SimpleGroup("L(2,2)");
 Error, illegal parameter for linear groups
 gap> SimpleGroup("L(2,3)");
 Error, illegal parameter for linear groups
-gap> SimpleGroup("L(2,4)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
+gap> SimpleGroup("L(2,4)"); Size(last); IsAlternatingGroup(last2);
 PSL(2,4)
 60
-rec( 
-  name := "A(5) ~ A(1,4) = L(2,4) ~ B(1,4) = O(3,4) ~ C(1,4) = S(2,4) ~ 2A(1,4\
-) = U(2,4) ~ A(1,5) = L(2,5) ~ B(1,5) = O(3,5) ~ C(1,5) = S(2,5) ~ 2A(1,5) = U\
-(2,5)", parameter := 5, series := "A", shortname := "A5" )
+true
 gap> SimpleGroup("L(3,2)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 PSL(3,2)
 168
@@ -176,13 +170,10 @@ gap> SimpleGroup("Sp(2,2)");
 Error, illegal parameter for symplectic groups
 gap> SimpleGroup("S(2,3)");
 Error, illegal parameter for symplectic groups
-gap> SimpleGroup("PSp(2,4)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
+gap> SimpleGroup("PSp(2,4)"); Size(last); IsAlternatingGroup(last2);
 PSp(2,4)
 60
-rec( 
-  name := "A(5) ~ A(1,4) = L(2,4) ~ B(1,4) = O(3,4) ~ C(1,4) = S(2,4) ~ 2A(1,4\
-) = U(2,4) ~ A(1,5) = L(2,5) ~ B(1,5) = O(3,5) ~ C(1,5) = S(2,5) ~ 2A(1,5) = U\
-(2,5)", parameter := 5, series := "A", shortname := "A5" )
+true
 gap> SimpleGroup("S(3,2)");
 Error, the dimension <d> must be even
 gap> SimpleGroup("Sp(4,2)");
@@ -197,15 +188,29 @@ rec(
 #
 # orthogonal groups
 #
+
+# test input validation: sign does not match parity of dimension
 gap> SimpleGroup("O-(5,2)");
 Error, wrong dimension/parity for O
 gap> SimpleGroup("O(+,5,2)");
 Error, wrong dimension/parity for O
 gap> SimpleGroup("O(8,2)");
 Error, wrong dimension/parity for O
-gap> SimpleGroup("O+(2,23)");
+
+# odd dimension
+gap> SimpleGroup("O(1,23)");
 Error, illegal parameter for orthogonal groups
-gap> SimpleGroup("O-(2,29)");
+gap> SimpleGroup("O(3,2)");
+Error, illegal parameter for orthogonal groups
+gap> SimpleGroup("O(3,3)");
+Error, illegal parameter for orthogonal groups
+gap> SimpleGroup("O(3,5)"); Size(last); IsAlternatingGroup(last2);
+O(3,5)
+60
+true
+
+# even dimension, plus type
+gap> SimpleGroup("O+(2,23)");
 Error, illegal parameter for orthogonal groups
 gap> SimpleGroup("O(+,4,17)");
 Error, illegal parameter for orthogonal groups
@@ -214,15 +219,31 @@ O+(6,2)
 20160
 rec( name := "A(8) ~ A(3,2) = L(4,2) ~ D(3,2) = O+(6,2)", parameter := 8, 
   series := "A", shortname := "A8" )
-gap> SimpleGroup("O(-,4,2)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
+gap> SimpleGroup("O(1,8,3)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
+O+(8,3)
+4952179814400
+rec( name := "D(4,3) = O+(8,3)", parameter := [ 4, 3 ], series := "D", 
+  shortname := "O8+(3)" )
+
+# even dimension, minus type
+gap> SimpleGroup("O-(2,29)");
+Error, illegal parameter for orthogonal groups
+gap> SimpleGroup("O(-,4,2)"); Size(last); IsAlternatingGroup(last2);
 O-(4,2)
 60
-rec( 
-  name := "A(5) ~ A(1,4) = L(2,4) ~ B(1,4) = O(3,4) ~ C(1,4) = S(2,4) ~ 2A(1,4\
-) = U(2,4) ~ A(1,5) = L(2,5) ~ B(1,5) = O(3,5) ~ C(1,5) = S(2,5) ~ 2A(1,5) = U\
-(2,5)", parameter := 5, series := "A", shortname := "A5" )
+true
 gap> SimpleGroup("O-(4,2)");
 O-(4,2)
+gap> SimpleGroup("O-(6,5)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
+O-(6,5)
+14742000000
+rec( name := "2A(3,5) = U(4,5) ~ 2D(3,5) = O-(6,5)", parameter := [ 3, 5 ], 
+  series := "2A", shortname := "U4(5)" )
+gap> SimpleGroup("O-(8,2)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
+O-(8,2)
+197406720
+rec( name := "2D(4,2) = O-(8,2)", parameter := [ 4, 2 ], series := "2D", 
+  shortname := "O8-(2)" )
 
 #
 # exceptional groups


### PR DESCRIPTION
Note: the assertion triggered by `IsBound(x->x)` is because we access element 0 of a plist. In this particular case, it is actual harmless, i.e., if assertions are off, GAP works just fine. Hence this is not really a bug relevant for the release notes.

I am also sneaking in the addition of `#include iostream.h` in `compiled.h`, which is needed so that a future version of the IO package does not have to include `iostream.h` directly anymore. I thought I had done that change a year ago, ouch. If nobody objects, I'd like to backport that single commit to stable-4.9.