### PR TITLE
Fix some comparison of different types of integer compiler warnings

### DIFF
--- a/src/precord.h
+++ b/src/precord.h
@@ -74,7 +74,7 @@ static inline Int IS_PREC_OR_COMOBJ(Obj rec)
 **  'CAPACITY_PREC' returns the maximum capacity of a PREC.
 **
 */
-static inline Int CAPACITY_PREC(Obj rec)
+static inline UInt CAPACITY_PREC(Obj rec)
 {
     return SIZE_OBJ(rec) / (2 * sizeof(Obj)) - 1;
 }

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -206,7 +206,7 @@ static inline Obj GET_ELM_STRING(Obj list, Int pos)
 {
     GAP_ASSERT(IS_STRING_REP(list));
     GAP_ASSERT(pos > 0);
-    GAP_ASSERT(pos <= GET_LEN_STRING(list));
+    GAP_ASSERT((UInt) pos <= GET_LEN_STRING(list));
     UChar c = CHARS_STRING(list)[pos - 1];
     return ObjsChar[c];
 }
@@ -222,7 +222,7 @@ static inline void SET_ELM_STRING(Obj list, Int pos, Obj val)
 {
     GAP_ASSERT(IS_STRING_REP(list));
     GAP_ASSERT(pos > 0);
-    GAP_ASSERT(pos <= GET_LEN_STRING(list));
+    GAP_ASSERT((UInt) pos <= GET_LEN_STRING(list));
     GAP_ASSERT(TNUM_OBJ(val) == T_CHAR);
     UChar * ptr = CHARS_STRING(list) + (pos - 1);
     *ptr = CHAR_VALUE(val);


### PR DESCRIPTION
This PR fixes some compiler warnings, arising from `CAPACITY_PREC` and `GET_LEN_STRING`.