### PR TITLE
Reduce number of functions and macros which return pointers into GAP objects

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -57,9 +57,9 @@ void SET_NAME_FUNC(Obj func, Obj name)
     FUNC(func)->name = name;
 }
 
-Char * NAMI_FUNC(Obj func, Int i)
+Obj NAMI_FUNC(Obj func, Int i)
 {
-    return CSTR_STRING(ELM_LIST(NAMS_FUNC(func),i));
+    return ELM_LIST(NAMS_FUNC(func),i);
 }
 
 
@@ -1364,7 +1364,7 @@ void PrintFunction (
         }
 #endif
         if ( NAMS_FUNC(func) != 0 )
-            Pr( "%I", (Int)NAMI_FUNC( func, (Int)i ), 0L );
+            Pr( "%H", (Int)NAMI_FUNC( func, (Int)i ), 0L );
         else
             Pr( "<<arg-%d>>", (Int)i, 0L );
         if(isvarg && i == narg) {
@@ -1382,7 +1382,7 @@ void PrintFunction (
             Pr("%>local ",0L,0L);
             for ( i = 1; i <= nloc; i++ ) {
                 if ( NAMS_FUNC(func) != 0 )
-                    Pr( "%I", (Int)NAMI_FUNC( func, (Int)(narg+i) ), 0L );
+                    Pr( "%H", (Int)NAMI_FUNC( func, (Int)(narg+i) ), 0L );
                 else
                     Pr( "<<loc-%d>>", (Int)i, 0L );
                 if ( i != nloc )  Pr("%<, %>",0L,0L);

--- a/src/calls.h
+++ b/src/calls.h
@@ -154,7 +154,7 @@ static inline Obj NAMS_FUNC(Obj func)
     return CONST_FUNC(func)->namesOfLocals;
 }
 
-extern Char * NAMI_FUNC(Obj func, Int i);
+extern Obj NAMI_FUNC(Obj func, Int i);
 
 static inline Obj PROF_FUNC(Obj func)
 {

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -694,22 +694,18 @@ void            Emit (
                 Pr( "%d", dint, 0L );
             }
 
-            /* emit a string                                               */
-            else if ( *p == 's' ) {
+            // emit a C string
+            else if ( *p == 's' || *p == 'S' || *p == 'C' ) {
+                const Char f[] = { '%', *p, 0 };
                 string = va_arg( ap, Char* );
-                Pr( "%s", (Int)string, 0L );
+                Pr( f, (Int)string, 0L );
             }
 
-            /* emit a string                                               */
-            else if ( *p == 'S' ) {
-                string = va_arg( ap, Char* );
-                Pr( "%S", (Int)string, 0L );
-            }
-
-            /* emit a string                                               */
-            else if ( *p == 'C' ) {
-                string = va_arg( ap, Char* );
-                Pr( "%C", (Int)string, 0L );
+            // emit a GAP string
+            else if ( *p == 'g' || *p == 'G' ) { 
+                const Char f[] = { '%', *p, 0 };
+                Obj str = va_arg( ap, Obj );
+                Pr( f, (Int)str, 0L );
             }
 
             /* emit a name                                                 */
@@ -819,7 +815,7 @@ void CompCheckBound (
 {
     if ( ! HasInfoCVar( obj, W_BOUND ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_BOUND( %c, \"%s\" )\n", obj, CSTR_STRING(name) );
+            Emit( "CHECK_BOUND( %c, \"%g\" )\n", obj, name );
         }
         SetInfoCVar( obj, W_BOUND );
     }
@@ -5618,22 +5614,22 @@ Int CompileFunc (
     Emit( "\n/* global variables used in handlers */\n" );
     for ( i = 1; i < SIZE_OBJ(CompInfoGVar)/sizeof(UInt); i++ ) {
         if ( CompGetUseGVar( i ) ) {
-            Emit( "G_%n = GVarName( \"%s\" );\n",
-                   NameGVarObj(i), NameGVar(i) );
+            Emit( "G_%n = GVarName( \"%g\" );\n",
+                   NameGVarObj(i), NameGVarObj(i) );
         }
     }
     Emit( "\n/* record names used in handlers */\n" );
     for ( i = 1; i < SIZE_OBJ(CompInfoRNam)/sizeof(UInt); i++ ) {
         if ( CompGetUseRNam( i ) ) {
-            Emit( "R_%n = RNamName( \"%s\" );\n",
-                  NAME_OBJ_RNAM(i), NAME_RNAM(i) );
+            Emit( "R_%n = RNamName( \"%g\" );\n",
+                  NAME_OBJ_RNAM(i), NAME_OBJ_RNAM(i) );
         }
     }
     Emit( "\n/* information for the functions */\n" );
     for ( i = 1; i <= compFunctionsNr; i++ ) {
         n = NAME_FUNC(ELM_PLIST(CompFunctions,i));
         if ( n != 0 && IsStringConv(n) ) {
-            Emit( "NameFunc[%d] = MakeImmString(\"%S\");\n", i, CSTR_STRING(n) );
+            Emit( "NameFunc[%d] = MakeImmString(\"%G\");\n", i, n );
         }
         else {
             Emit( "NameFunc[%d] = 0;\n", i );
@@ -5651,12 +5647,12 @@ Int CompileFunc (
     Emit( "\n/* global variables used in handlers */\n" );
     for ( i = 1; i < SIZE_OBJ(CompInfoGVar)/sizeof(UInt); i++ ) {
         if ( CompGetUseGVar( i ) & COMP_USE_GVAR_COPY ) {
-            Emit( "InitCopyGVar( \"%s\", &GC_%n );\n",
-                  NameGVar(i), NameGVarObj(i) );
+            Emit( "InitCopyGVar( \"%g\", &GC_%n );\n",
+                  NameGVarObj(i), NameGVarObj(i) );
         }
         if ( CompGetUseGVar( i ) & COMP_USE_GVAR_FOPY ) {
-            Emit( "InitFopyGVar( \"%s\", &GF_%n );\n",
-                  NameGVar(i), NameGVarObj(i) );
+            Emit( "InitFopyGVar( \"%g\", &GF_%n );\n",
+                  NameGVarObj(i), NameGVarObj(i) );
         }
     }
     Emit( "\n/* information for the functions */\n" );

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -129,7 +129,7 @@ static Int compilerMagic1;
 **
 *V  compilerMagic2  . . . . . . . . . . . . . . . . . . . . .  current magic2
 */
-static Char * compilerMagic2;
+static Obj compilerMagic2;
 
 
 /****************************************************************************
@@ -5533,11 +5533,11 @@ void CompFunc (
 *F  CompileFunc( <output>, <func>, <name>, <magic1>, <magic2> ) . . . compile
 */
 Int CompileFunc (
-    Char *              output,
+    Obj                 output,
     Obj                 func,
-    Char *              name,
+    Obj                 name,
     Int                 magic1,
-    Char *              magic2 )
+    Obj                 magic2 )
 {
     Int                 i;              /* loop variable                   */
     Obj                 n;              /* temporary                       */
@@ -5545,7 +5545,7 @@ Int CompileFunc (
     UInt                compFunctionsNr;
 
     /* open the output file                                                */
-    if ( ! OpenOutput( output ) ) {
+    if ( ! OpenOutput( CSTR_STRING(output) ) ) {
         return 0;
     }
     col = SyNrCols;
@@ -5656,12 +5656,12 @@ Int CompileFunc (
         }
     }
     Emit( "\n/* information for the functions */\n" );
-    Emit( "InitGlobalBag( &FileName, \"%s:FileName(\"FILE_CRC\")\" );\n",
+    Emit( "InitGlobalBag( &FileName, \"%g:FileName(\"FILE_CRC\")\" );\n",
           magic2 );
     for ( i = 1; i <= compFunctionsNr; i++ ) {
-        Emit( "InitHandlerFunc( HdlrFunc%d, \"%s:HdlrFunc%d(\"FILE_CRC\")\" );\n",
+        Emit( "InitHandlerFunc( HdlrFunc%d, \"%g:HdlrFunc%d(\"FILE_CRC\")\" );\n",
               i, compilerMagic2, i );
-        Emit( "InitGlobalBag( &(NameFunc[%d]), \"%s:NameFunc[%d](\"FILE_CRC\")\" );\n", 
+        Emit( "InitGlobalBag( &(NameFunc[%d]), \"%g:NameFunc[%d](\"FILE_CRC\")\" );\n", 
                i, magic2, i );
         n = NAME_FUNC(ELM_PLIST(CompFunctions,i));
     }
@@ -5677,7 +5677,7 @@ Int CompileFunc (
     Emit( "Obj body1;\n" );
     Emit( "\n/* Complete Copy/Fopy registration */\n" );
     Emit( "UpdateCopyFopyInfo();\n" );
-    Emit( "FileName = MakeImmString( \"%s\" );\n", magic2 );
+    Emit( "FileName = MakeImmString( \"%g\" );\n", magic2 );
     Emit( "PostRestore(module);\n" );
     Emit( "\n/* create all the functions defined in this module */\n" );
     Emit( "func1 = NewFunction(NameFunc[1],%d,0,HdlrFunc1);\n", NARG_FUNC(ELM_PLIST(CompFunctions,1)) );
@@ -5694,20 +5694,20 @@ Int CompileFunc (
     /* emit the initialization code                                        */
     Emit( "\n/* <name> returns the description of this module */\n" );
     Emit( "static StructInitInfo module = {\n" );
-    if ( ! strcmp( "Init_Dynamic", name ) ) {
+    if ( ! strcmp( "Init_Dynamic", CSTR_STRING(name) ) ) {
         Emit( ".type        = MODULE_DYNAMIC,\n" );
     }
     else {
         Emit( ".type        = MODULE_STATIC,\n" );
     }
-    Emit( ".name        = \"%C\",\n", magic2 );
+    Emit( ".name        = \"%g\",\n", magic2 );
     Emit( ".crc         = %d,\n",     magic1 );
     Emit( ".initKernel  = InitKernel,\n" );
     Emit( ".initLibrary = InitLibrary,\n" );
     Emit( ".postRestore = PostRestore,\n" );
     Emit( "};\n" );
     Emit( "\n" );
-    Emit( "StructInitInfo * %n ( void )\n", MakeImmString(name) );
+    Emit( "StructInitInfo * %n ( void )\n", name );
     Emit( "{\n" );
     Emit( "return &module;\n" );
     Emit( "}\n" );
@@ -5797,8 +5797,8 @@ Obj FuncCOMPILE_FUNC (
     
     /* compile the function                                                */
     nr = CompileFunc(
-        CSTR_STRING(output), func, CSTR_STRING(name),
-        INT_INTOBJ(magic1), CSTR_STRING(magic2) );
+        output, func, name,
+        INT_INTOBJ(magic1), magic2 );
 
 
     /* return the result                                                   */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -743,10 +743,10 @@ void            Emit (
                     Pr( "t_%d", TEMP_CVAR(cvar), 0L );
                 }
                 else if ( LVAR_CVAR(cvar) <= narg ) {
-                    Emit( "a_%n", NAME_LVAR( LVAR_CVAR(cvar) ) );
+                    Emit( "a_%n", CSTR_STRING( NAME_LVAR( LVAR_CVAR(cvar) ) ) );
                 }
                 else {
-                    Emit( "l_%n", NAME_LVAR( LVAR_CVAR(cvar) ) );
+                    Emit( "l_%n", CSTR_STRING( NAME_LVAR( LVAR_CVAR(cvar) ) ) );
                 }
             }
 
@@ -760,10 +760,10 @@ void            Emit (
                     Pr( "INT_INTOBJ(t_%d)", TEMP_CVAR(cvar), 0L );
                 }
                 else if ( LVAR_CVAR(cvar) <= narg ) {
-                    Emit( "INT_INTOBJ(a_%n)", NAME_LVAR( LVAR_CVAR(cvar) ) );
+                    Emit( "INT_INTOBJ(a_%n)", CSTR_STRING( NAME_LVAR( LVAR_CVAR(cvar) ) ) );
                 }
                 else {
-                    Emit( "INT_INTOBJ(l_%n)", NAME_LVAR( LVAR_CVAR(cvar) ) );
+                    Emit( "INT_INTOBJ(l_%n)", CSTR_STRING( NAME_LVAR( LVAR_CVAR(cvar) ) ) );
                 }
             }
 
@@ -814,11 +814,11 @@ void            Emit (
 */
 void CompCheckBound (
     CVar                obj,
-    Char *              name )
+    Obj                 name )
 {
     if ( ! HasInfoCVar( obj, W_BOUND ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_BOUND( %c, \"%s\" )\n", obj, name );
+            Emit( "CHECK_BOUND( %c, \"%s\" )\n", obj, CSTR_STRING(name) );
         }
         SetInfoCVar( obj, W_BOUND );
     }
@@ -2996,7 +2996,7 @@ CVar CompRefGVar (
     Emit( "%c = GC_%n;\n", val, NameGVar(gvar) );
 
     /* emit the code to check that the variable has a value                */
-    CompCheckBound( val, NameGVar(gvar) );
+    CompCheckBound( val, NameGVarObj(gvar) );
 
     /* return the value                                                    */
     return val;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2787,7 +2787,7 @@ void            CompRecExpr2 (
         if ( IS_INTEXPR(tmp) ) {
             CompSetUseRNam( (UInt)INT_INTEXPR(tmp), COMP_USE_RNAM_ID );
             Emit( "%c = (Obj)R_%n;\n",
-                  rnam, NAME_OBJ_RNAM((UInt)INT_INTEXPR(tmp)) );
+                  rnam, NAME_RNAM((UInt)INT_INTEXPR(tmp)) );
         }
         else {
             sub = CompExpr( tmp );
@@ -3267,7 +3267,7 @@ CVar CompElmRecName (
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code to select the element of the record                   */
-    Emit( "%c = ELM_REC( %c, R_%n );\n", elm, record, NAME_OBJ_RNAM(rnam) );
+    Emit( "%c = ELM_REC( %c, R_%n );\n", elm, record, NAME_RNAM(rnam) );
 
     /* we know that we have a value                                        */
     SetInfoCVar( elm, W_BOUND );
@@ -3338,7 +3338,7 @@ CVar CompIsbRecName (
 
     /* emit the code to test the element                                   */
     Emit( "%c = (ISB_REC( %c, R_%n ) ? True : False);\n",
-          isb, record, NAME_OBJ_RNAM(rnam) );
+          isb, record, NAME_RNAM(rnam) );
 
     /* we know that the result is boolean                                  */
     SetInfoCVar( isb, W_BOOL );
@@ -3532,13 +3532,13 @@ CVar CompElmComObjName (
 
     /* emit the code to select the element of the record                   */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
-    Emit( "%c = ElmPRec( %c, R_%n );\n", elm, record, NAME_OBJ_RNAM(rnam) );
+    Emit( "%c = ElmPRec( %c, R_%n );\n", elm, record, NAME_RNAM(rnam) );
     Emit( "#ifdef HPCGAP\n" );
     Emit( "} else if ( TNUM_OBJ(%c) == T_ACOMOBJ) {\n", record );
-    Emit( "%c = ElmARecord( %c, R_%n );\n", elm, record, NAME_OBJ_RNAM(rnam) );
+    Emit( "%c = ElmARecord( %c, R_%n );\n", elm, record, NAME_RNAM(rnam) );
     Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
-    Emit( "%c = ELM_REC( %c, R_%n );\n", elm, record, NAME_OBJ_RNAM(rnam) );
+    Emit( "%c = ELM_REC( %c, R_%n );\n", elm, record, NAME_RNAM(rnam) );
     Emit( "}\n" );
 
     /* we know that we have a value                                        */
@@ -3620,15 +3620,15 @@ CVar CompIsbComObjName (
     /* emit the code to test the element                                   */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
     Emit( "%c = (IsbPRec( %c, R_%n ) ? True : False);\n",
-          isb, record, NAME_OBJ_RNAM(rnam) );
+          isb, record, NAME_RNAM(rnam) );
     Emit( "#ifdef HPCGAP\n" );
     Emit( "} else if ( TNUM_OBJ(%c) == T_ACOMOBJ ) {\n", record );
     Emit( "%c = (IsbARecord( %c, R_%n ) ? True : False);\n",
-                isb, record, NAME_OBJ_RNAM(rnam) );
+                isb, record, NAME_RNAM(rnam) );
     Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
     Emit( "%c = (ISB_REC( %c, R_%n ) ? True : False);\n",
-          isb, record, NAME_OBJ_RNAM(rnam) );
+          isb, record, NAME_RNAM(rnam) );
     Emit( "}\n" );
 
     /* we know that the result is boolean                                  */
@@ -4835,7 +4835,7 @@ void CompAssRecName (
     rhs = CompExpr( ADDR_STAT(stat)[2] );
 
     /* emit the code for the assignment                                    */
-    Emit( "ASS_REC( %c, R_%n, %c );\n", record, NAME_OBJ_RNAM(rnam), rhs );
+    Emit( "ASS_REC( %c, R_%n, %c );\n", record, NAME_RNAM(rnam), rhs );
 
     /* free the temporaries                                                */
     if ( IS_TEMP_CVAR( rhs    ) )  FreeTemp( TEMP_CVAR( rhs    ) );
@@ -4901,7 +4901,7 @@ void CompUnbRecName (
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code for the assignment                                    */
-    Emit( "UNB_REC( %c, R_%n );\n", record, NAME_OBJ_RNAM(rnam) );
+    Emit( "UNB_REC( %c, R_%n );\n", record, NAME_RNAM(rnam) );
 
     /* free the temporaries                                                */
     if ( IS_TEMP_CVAR( record ) )  FreeTemp( TEMP_CVAR( record ) );
@@ -5102,13 +5102,13 @@ void CompAssComObjName (
 
     /* emit the code for the assignment                                    */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
-    Emit( "AssPRec( %c, R_%n, %c );\n", record, NAME_OBJ_RNAM(rnam), rhs );
+    Emit( "AssPRec( %c, R_%n, %c );\n", record, NAME_RNAM(rnam), rhs );
     Emit( "#ifdef HPCGAP\n" );
     Emit( "} else if ( TNUM_OBJ(%c) == T_ACOMOBJ ) {\n", record );
-    Emit( "AssARecord( %c, R_%n, %c );\n", record, NAME_OBJ_RNAM(rnam), rhs );
+    Emit( "AssARecord( %c, R_%n, %c );\n", record, NAME_RNAM(rnam), rhs );
     Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
-    Emit( "ASS_REC( %c, R_%n, %c );\n", record, NAME_OBJ_RNAM(rnam), rhs );
+    Emit( "ASS_REC( %c, R_%n, %c );\n", record, NAME_RNAM(rnam), rhs );
     Emit( "}\n" );
 
     /* free the temporaries                                                */
@@ -5184,13 +5184,13 @@ void CompUnbComObjName (
 
     /* emit the code for the assignment                                    */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
-    Emit( "UnbPRec( %c, R_%n );\n", record, NAME_OBJ_RNAM(rnam) );
+    Emit( "UnbPRec( %c, R_%n );\n", record, NAME_RNAM(rnam) );
     Emit( "#ifdef HPCGAP\n" );
     Emit( "} else if ( TNUM_OBJ(%c) == T_ACOMOBJ ) {\n", record );
-    Emit( "UnbARecord( %c, R_%n );\n", record, NAME_OBJ_RNAM(rnam) );
+    Emit( "UnbARecord( %c, R_%n );\n", record, NAME_RNAM(rnam) );
     Emit( "#endif\n" );
     Emit( "}\nelse {\n" );
-    Emit( "UNB_REC( %c, R_%n );\n", record, NAME_OBJ_RNAM(rnam) );
+    Emit( "UNB_REC( %c, R_%n );\n", record, NAME_RNAM(rnam) );
     Emit( "}\n" );
 
     /* free the temporaries                                                */
@@ -5594,7 +5594,7 @@ Int CompileFunc (
     Emit( "\n/* record names used in handlers */\n" );
     for ( i = 1; i < SIZE_OBJ(CompInfoRNam)/sizeof(UInt); i++ ) {
         if ( CompGetUseRNam( i ) ) {
-            Emit( "static RNam R_%n;\n", NAME_OBJ_RNAM(i) );
+            Emit( "static RNam R_%n;\n", NAME_RNAM(i) );
         }
     }
 
@@ -5622,7 +5622,7 @@ Int CompileFunc (
     for ( i = 1; i < SIZE_OBJ(CompInfoRNam)/sizeof(UInt); i++ ) {
         if ( CompGetUseRNam( i ) ) {
             Emit( "R_%n = RNamName( \"%g\" );\n",
-                  NAME_OBJ_RNAM(i), NAME_OBJ_RNAM(i) );
+                  NAME_RNAM(i), NAME_RNAM(i) );
         }
     }
     Emit( "\n/* information for the functions */\n" );

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2990,10 +2990,10 @@ CVar CompRefGVar (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* emit the code to get the value                                      */
-    Emit( "%c = GC_%n;\n", val, NameGVarObj(gvar) );
+    Emit( "%c = GC_%n;\n", val, NameGVar(gvar) );
 
     /* emit the code to check that the variable has a value                */
-    CompCheckBound( val, NameGVarObj(gvar) );
+    CompCheckBound( val, NameGVar(gvar) );
 
     /* return the value                                                    */
     return val;
@@ -3018,7 +3018,7 @@ CVar CompRefGVarFopy (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* emit the code to get the value                                      */
-    Emit( "%c = GF_%n;\n", val, NameGVarObj(gvar) );
+    Emit( "%c = GF_%n;\n", val, NameGVar(gvar) );
 
     /* we know that the object in a function copy is a function            */
     SetInfoCVar( val, W_FUNC );
@@ -3048,7 +3048,7 @@ CVar CompIsbGVar (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* emit the code to get the value                                      */
-    Emit( "%c = GC_%n;\n", val, NameGVarObj(gvar) );
+    Emit( "%c = GC_%n;\n", val, NameGVar(gvar) );
 
     /* emit the code to check that the variable has a value                */
     Emit( "%c = ((%c != 0) ? True : False);\n", isb, val );
@@ -4229,7 +4229,7 @@ void CompFor (
         }
         else if ( vart == 'g' ) {
             Emit( "AssGVar( G_%n, %c );\n",
-                  NameGVarObj(var), elm );
+                  NameGVar(var), elm );
         }
 
         /* set what we know about the loop variable                        */
@@ -4588,7 +4588,7 @@ void CompAssGVar (
     /* emit the code for the assignment                                    */
     gvar = (GVar)(ADDR_STAT(stat)[0]);
     CompSetUseGVar( gvar, COMP_USE_GVAR_ID );
-    Emit( "AssGVar( G_%n, %c );\n", NameGVarObj(gvar), rhs );
+    Emit( "AssGVar( G_%n, %c );\n", NameGVar(gvar), rhs );
 
     /* free the temporary                                                  */
     if ( IS_TEMP_CVAR( rhs ) )  FreeTemp( TEMP_CVAR( rhs ) );
@@ -4612,7 +4612,7 @@ void            CompUnbGVar (
     /* emit the code for the assignment                                    */
     gvar = (GVar)(ADDR_STAT(stat)[0]);
     CompSetUseGVar( gvar, COMP_USE_GVAR_ID );
-    Emit( "AssGVar( G_%n, 0 );\n", NameGVarObj(gvar) );
+    Emit( "AssGVar( G_%n, 0 );\n", NameGVar(gvar) );
 }
 
 
@@ -5580,13 +5580,13 @@ Int CompileFunc (
     Emit( "\n/* global variables used in handlers */\n" );
     for ( i = 1; i < SIZE_OBJ(CompInfoGVar)/sizeof(UInt); i++ ) {
         if ( CompGetUseGVar( i ) ) {
-            Emit( "static GVar G_%n;\n", NameGVarObj(i) );
+            Emit( "static GVar G_%n;\n", NameGVar(i) );
         }
         if ( CompGetUseGVar( i ) & COMP_USE_GVAR_COPY ) {
-            Emit( "static Obj  GC_%n;\n", NameGVarObj(i) );
+            Emit( "static Obj  GC_%n;\n", NameGVar(i) );
         }
         if ( CompGetUseGVar( i ) & COMP_USE_GVAR_FOPY ) {
-            Emit( "static Obj  GF_%n;\n", NameGVarObj(i) );
+            Emit( "static Obj  GF_%n;\n", NameGVar(i) );
         }
     }
 
@@ -5615,7 +5615,7 @@ Int CompileFunc (
     for ( i = 1; i < SIZE_OBJ(CompInfoGVar)/sizeof(UInt); i++ ) {
         if ( CompGetUseGVar( i ) ) {
             Emit( "G_%n = GVarName( \"%g\" );\n",
-                   NameGVarObj(i), NameGVarObj(i) );
+                   NameGVar(i), NameGVar(i) );
         }
     }
     Emit( "\n/* record names used in handlers */\n" );
@@ -5648,11 +5648,11 @@ Int CompileFunc (
     for ( i = 1; i < SIZE_OBJ(CompInfoGVar)/sizeof(UInt); i++ ) {
         if ( CompGetUseGVar( i ) & COMP_USE_GVAR_COPY ) {
             Emit( "InitCopyGVar( \"%g\", &GC_%n );\n",
-                  NameGVarObj(i), NameGVarObj(i) );
+                  NameGVar(i), NameGVar(i) );
         }
         if ( CompGetUseGVar( i ) & COMP_USE_GVAR_FOPY ) {
             Emit( "InitFopyGVar( \"%g\", &GF_%n );\n",
-                  NameGVarObj(i), NameGVarObj(i) );
+                  NameGVar(i), NameGVar(i) );
         }
     }
     Emit( "\n/* information for the functions */\n" );

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -21,11 +21,11 @@
 *F  CompileFunc(<output>,<func>,<name>,<magic1>,<magic2>) . . . . . . compile
 */
 extern Int CompileFunc (
-            Char *              output,
+            Obj                 output,
             Obj                 func,
-            Char *              name,
+            Obj                 name,
             Int                 magic1,
-            Char *              magic2 );
+            Obj                 magic2 );
 
 
 /****************************************************************************

--- a/src/error.c
+++ b/src/error.c
@@ -181,11 +181,11 @@ Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj context)
     Obj filename = GET_FILENAME_BODY(body);
     if (FIRST_STAT_TNUM <= type && type <= LAST_STAT_TNUM) {
         PrintStat(call);
-        Pr(" at %s:%d", (UInt)CSTR_STRING(filename), LINE_STAT(call));
+        Pr(" at %g:%d", (Int)filename, LINE_STAT(call));
     }
     else if (FIRST_EXPR_TNUM <= type && type <= LAST_EXPR_TNUM) {
         PrintExpr(call);
-        Pr(" at %s:%d", (UInt)CSTR_STRING(filename), LINE_STAT(call));
+        Pr(" at %g:%d", (Int)filename, LINE_STAT(call));
     }
     SWITCH_TO_OLD_LVARS(currLVars);
     return 0;

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1791,7 +1791,7 @@ void            PrintRecExpr1 (
         /* print an ordinary record name                                   */
         tmp = ADDR_EXPR(expr)[2*i-2];
         if ( IS_INTEXPR(tmp) ) {
-            Pr( "%H", (Int)NAME_OBJ_RNAM( INT_INTEXPR(tmp) ), 0L );
+            Pr( "%H", (Int)NAME_RNAM( INT_INTEXPR(tmp) ), 0L );
         }
 
         /* print an evaluating record name                                 */

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1791,7 +1791,7 @@ void            PrintRecExpr1 (
         /* print an ordinary record name                                   */
         tmp = ADDR_EXPR(expr)[2*i-2];
         if ( IS_INTEXPR(tmp) ) {
-            Pr( "%I", (Int)NAME_RNAM( INT_INTEXPR(tmp) ), 0L );
+            Pr( "%H", (Int)NAME_OBJ_RNAM( INT_INTEXPR(tmp) ), 0L );
         }
 
         /* print an evaluating record name                                 */

--- a/src/gap.c
+++ b/src/gap.c
@@ -438,11 +438,11 @@ int realmain( int argc, char * argv[], char * environ[] )
       func = READ_AS_FUNC();
       crc  = SyGAPCRC(SyCompileInput);
       type = CompileFunc(
-                         SyCompileOutput,
+                         MakeImmString(SyCompileOutput),
                          func,
-                         SyCompileName,
+                         MakeImmString(SyCompileName),
                          crc,
-                         SyCompileMagic1 );
+                         MakeImmString(SyCompileMagic1) );
       if ( type == 0 )
         SyExit( 1 );
       SyExit( 0 );

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -440,8 +440,8 @@ Obj             ValAutoGVar (
         /* if this is still an automatic variable, this is an error        */
         while ( (val = ValGVar(gvar)) == 0 ) {
             ErrorReturnVoid(
-       "Variable: automatic variable '%s' must get a value by function call",
-                (Int)NameGVar(gvar), 0L,
+       "Variable: automatic variable '%g' must get a value by function call",
+                (Int)NameGVarObj(gvar), 0L,
                 "you can 'return;' after assigning a value" );
         }
 

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -320,7 +320,7 @@ void            AssGVar (
 
     // Make certain variable is not constant
     if (writeval == INTOBJ_INT(-1)) {
-        ErrorMayQuit("Variable: '%g' is constant", (Int)NameGVarObj(gvar), 0L);
+        ErrorMayQuit("Variable: '%g' is constant", (Int)NameGVar(gvar), 0L);
     }
 
     /* make certain that the variable is not read only                     */
@@ -328,7 +328,7 @@ void            AssGVar (
             (ELM_GVAR_LIST( WriteGVars, gvar ) == INTOBJ_INT(0)) ) {
         ErrorReturnVoid(
             "Variable: '%g' is read only",
-            (Int)NameGVarObj(gvar), 0L,
+            (Int)NameGVar(gvar), 0L,
             "you can 'return;' after making it writable" );
     }
 
@@ -394,7 +394,7 @@ void            AssGVar (
     if (IS_BAG_REF(val) && REGION(val) == 0) { /* public region? */
 #endif
     if ( val != 0 && TNUM_OBJ(val) == T_FUNCTION && NAME_FUNC(val) == 0 ) {
-        onam = CopyToStringRep(NameGVarObj(gvar));
+        onam = CopyToStringRep(NameGVar(gvar));
         MakeImmutableString(onam);
         SET_NAME_FUNC(val, onam);
         CHANGED_BAG(val);
@@ -441,7 +441,7 @@ Obj             ValAutoGVar (
         while ( (val = ValGVar(gvar)) == 0 ) {
             ErrorReturnVoid(
        "Variable: automatic variable '%g' must get a value by function call",
-                (Int)NameGVarObj(gvar), 0L,
+                (Int)NameGVar(gvar), 0L,
                 "you can 'return;' after assigning a value" );
         }
 
@@ -502,7 +502,7 @@ Obj NewGVarBucket(void) {
 }
 #endif
 
-Obj NameGVarObj ( UInt gvar )
+Obj NameGVar ( UInt gvar )
 {
     return ELM_GVAR_LIST( NameGVars, gvar );
 }
@@ -578,7 +578,7 @@ UInt GVarName (
     sizeGVars = LEN_PLIST(TableGVars);
     pos = (hash % sizeGVars) + 1;
     while ( (gvar = ELM_PLIST( TableGVars, pos )) != 0
-         && strncmp( CSTR_STRING( NameGVarObj( INT_INTOBJ(gvar) ) ), name, 1023 ) ) {
+         && strncmp( CSTR_STRING( NameGVar( INT_INTOBJ(gvar) ) ), name, 1023 ) ) {
         pos = (pos % sizeGVars) + 1;
     }
 
@@ -592,7 +592,7 @@ UInt GVarName (
         sizeGVars = LEN_PLIST(TableGVars);
         pos = (hash % sizeGVars) + 1;
         while ( (gvar = ELM_PLIST( TableGVars, pos )) != 0
-             && strncmp( CSTR_STRING( NameGVarObj( INT_INTOBJ(gvar) ) ), name, 1023 ) ) {
+             && strncmp( CSTR_STRING( NameGVar( INT_INTOBJ(gvar) ) ), name, 1023 ) ) {
             pos = (pos % sizeGVars) + 1;
         }
     }
@@ -655,7 +655,7 @@ UInt GVarName (
             for ( i = 1; i <= (sizeGVars-1)/2; i++ ) {
                 gvar2 = ELM_PLIST( table, i );
                 if ( gvar2 == 0 )  continue;
-                pos = HashString( CSTR_STRING( NameGVarObj( INT_INTOBJ(gvar2) ) ) );
+                pos = HashString( CSTR_STRING( NameGVar( INT_INTOBJ(gvar2) ) ) );
                 pos = (pos % sizeGVars) + 1;
                 while ( ELM_PLIST( TableGVars, pos ) != 0 ) {
                     pos = (pos % sizeGVars) + 1;
@@ -682,7 +682,7 @@ void MakeReadOnlyGVar (
     UInt                gvar )
 {
     if (ELM_GVAR_LIST(WriteGVars, gvar) == INTOBJ_INT(-1)) {
-        ErrorMayQuit("Variable: '%g' is constant", (Int)NameGVarObj(gvar), 0L);
+        ErrorMayQuit("Variable: '%g' is constant", (Int)NameGVar(gvar), 0L);
     }
     SET_ELM_GVAR_LIST( WriteGVars, gvar, INTOBJ_INT(0) );
     CHANGED_GVAR_LIST( WriteGVars, gvar );
@@ -698,7 +698,7 @@ void MakeConstantGVar(UInt gvar)
     if (!IS_INTOBJ(val) && val != True && val != False) {
         ErrorMayQuit(
             "Variable: '%g' must be assigned a small integer, true or false",
-            (Int)NameGVarObj(gvar), 0L);
+            (Int)NameGVar(gvar), 0L);
     }
     SET_ELM_GVAR_LIST(WriteGVars, gvar, INTOBJ_INT(-1));
     CHANGED_GVAR_LIST(WriteGVars, gvar);
@@ -791,7 +791,7 @@ void MakeReadWriteGVar (
     UInt                gvar )
 {
     if (ELM_GVAR_LIST(WriteGVars, gvar) == INTOBJ_INT(-1)) {
-        ErrorMayQuit("Variable: '%g' is constant", (Int)NameGVarObj(gvar), 0L);
+        ErrorMayQuit("Variable: '%g' is constant", (Int)NameGVar(gvar), 0L);
     }
     SET_ELM_GVAR_LIST( WriteGVars, gvar, INTOBJ_INT(1) );
     CHANGED_GVAR_LIST( WriteGVars, gvar );
@@ -976,7 +976,7 @@ UInt            iscomplete_gvar (
 
     numGVars = INT_INTOBJ(CountGVars);
     for ( i = 1; i <= numGVars; i++ ) {
-        curr = CSTR_STRING( NameGVarObj( i ) );
+        curr = CSTR_STRING( NameGVar( i ) );
         for ( k = 0; name[k] != 0 && curr[k] == name[k]; k++ ) ;
         if ( k == len && curr[k] == '\0' )  return 1;
     }
@@ -997,7 +997,7 @@ UInt            completion_gvar (
     for ( i = 1; i <= numGVars; i++ ) {
         /* consider only variables which are currently bound for completion */
         if ( VAL_GVAR_INTERN( i ) || ELM_GVAR_LIST( ExprGVars, i )) {
-            curr = CSTR_STRING( NameGVarObj( i ) );
+            curr = CSTR_STRING( NameGVar( i ) );
             for ( k = 0; name[k] != 0 && curr[k] == name[k]; k++ ) ;
             if ( k < len || curr[k] <= name[k] )  continue;
             if ( next != 0 ) {
@@ -1042,7 +1042,7 @@ Obj FuncIDENTS_GVAR (
     for ( i = 1;  i <= numGVars;  i++ ) {
         /* Copy the string here, because we do not want members of NameGVars
          * accessible to users, as these strings must not be changed */
-        strcopy = CopyToStringRep( NameGVarObj( i ) );
+        strcopy = CopyToStringRep( NameGVar( i ) );
         SET_ELM_PLIST( copy, i, strcopy );
         CHANGED_BAG( copy );
     }
@@ -1072,7 +1072,7 @@ Obj FuncIDENTS_BOUND_GVARS (
            /* Copy the string here, because we do not want members of
             * NameGVars accessible to users, as these strings must not be
             * changed */
-           strcopy = CopyToStringRep( NameGVarObj( i ) );
+           strcopy = CopyToStringRep( NameGVar( i ) );
            SET_ELM_PLIST( copy, j, strcopy );
            CHANGED_BAG( copy );
            j++;

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -491,18 +491,6 @@ Obj FuncIsThreadLocalGVar( Obj self, Obj name) {
 #endif
 
 
-/****************************************************************************
-**
-*F  NameGVar(<gvar>)  . . . . . . . . . . . . . . . name of a global variable
-**
-**  'NameGVar' returns the name of the global variable <gvar> as a C string.
-*/
-Char *          NameGVar (
-    UInt                gvar )
-{
-    return CSTR_STRING( ELM_GVAR_LIST( NameGVars, gvar ) );
-}
-
 #ifdef USE_GVAR_BUCKETS
 Obj NewGVarBucket(void) {
     Obj result = NEW_PLIST(T_PLIST, GVAR_BUCKET_SIZE);
@@ -590,7 +578,7 @@ UInt GVarName (
     sizeGVars = LEN_PLIST(TableGVars);
     pos = (hash % sizeGVars) + 1;
     while ( (gvar = ELM_PLIST( TableGVars, pos )) != 0
-         && strncmp( NameGVar( INT_INTOBJ(gvar) ), name, 1023 ) ) {
+         && strncmp( CSTR_STRING( NameGVarObj( INT_INTOBJ(gvar) ) ), name, 1023 ) ) {
         pos = (pos % sizeGVars) + 1;
     }
 
@@ -604,7 +592,7 @@ UInt GVarName (
         sizeGVars = LEN_PLIST(TableGVars);
         pos = (hash % sizeGVars) + 1;
         while ( (gvar = ELM_PLIST( TableGVars, pos )) != 0
-             && strncmp( NameGVar( INT_INTOBJ(gvar) ), name, 1023 ) ) {
+             && strncmp( CSTR_STRING( NameGVarObj( INT_INTOBJ(gvar) ) ), name, 1023 ) ) {
             pos = (pos % sizeGVars) + 1;
         }
     }
@@ -667,7 +655,7 @@ UInt GVarName (
             for ( i = 1; i <= (sizeGVars-1)/2; i++ ) {
                 gvar2 = ELM_PLIST( table, i );
                 if ( gvar2 == 0 )  continue;
-                pos = HashString( NameGVar( INT_INTOBJ(gvar2) ) );
+                pos = HashString( CSTR_STRING( NameGVarObj( INT_INTOBJ(gvar2) ) ) );
                 pos = (pos % sizeGVars) + 1;
                 while ( ELM_PLIST( TableGVars, pos ) != 0 ) {
                     pos = (pos % sizeGVars) + 1;
@@ -988,7 +976,7 @@ UInt            iscomplete_gvar (
 
     numGVars = INT_INTOBJ(CountGVars);
     for ( i = 1; i <= numGVars; i++ ) {
-        curr = NameGVar( i );
+        curr = CSTR_STRING( NameGVarObj( i ) );
         for ( k = 0; name[k] != 0 && curr[k] == name[k]; k++ ) ;
         if ( k == len && curr[k] == '\0' )  return 1;
     }
@@ -1009,7 +997,7 @@ UInt            completion_gvar (
     for ( i = 1; i <= numGVars; i++ ) {
         /* consider only variables which are currently bound for completion */
         if ( VAL_GVAR_INTERN( i ) || ELM_GVAR_LIST( ExprGVars, i )) {
-            curr = NameGVar( i );
+            curr = CSTR_STRING( NameGVarObj( i ) );
             for ( k = 0; name[k] != 0 && curr[k] == name[k]; k++ ) ;
             if ( k < len || curr[k] <= name[k] )  continue;
             if ( next != 0 ) {

--- a/src/gvars.h
+++ b/src/gvars.h
@@ -105,16 +105,6 @@ extern  Obj             ValGVarTL (
 
 /****************************************************************************
 **
-*F  NameGVar(<gvar>)  . . . . . . . . . . . . . . . name of a global variable
-**
-**  'NameGVar' returns the name of the global variable <gvar> as a C string.
-*/
-extern  Char *          NameGVar (
-            UInt                gvar );
-
-
-/****************************************************************************
-**
 *F  NameGVarObj(<gvar>)  . . . . . . . . . . . . .  name of a global variable
 **
 **  'NameGVarObj' returns the name of the global variable <gvar> as a GAP

--- a/src/gvars.h
+++ b/src/gvars.h
@@ -105,12 +105,12 @@ extern  Obj             ValGVarTL (
 
 /****************************************************************************
 **
-*F  NameGVarObj(<gvar>)  . . . . . . . . . . . . .  name of a global variable
+*F  NameGVar(<gvar>)  . . . . . . . . . . . . . . . name of a global variable
 **
-**  'NameGVarObj' returns the name of the global variable <gvar> as a GAP
+**  'NameGVar' returns the name of the global variable <gvar> as a GAP
 **  string.
 */
-extern  Obj            NameGVarObj (
+extern  Obj            NameGVar (
             UInt                gvar );
 
 

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -585,7 +585,7 @@ static void PrintTLRecord(Obj obj)
   if (record) {
     for (i = 1; i <= LEN_PREC(record); i++) {
       Obj val = GET_ELM_PREC(record, i);
-      Pr("%I", (Int)NAME_RNAM(labs((Int)GET_RNAM_PREC(record, i))), 0L);
+      Pr("%H", (Int)NAME_OBJ_RNAM(labs((Int)GET_RNAM_PREC(record, i))), 0L);
       Pr ("%< := %>", 0L, 0L);
       if (val)
 	PrintObj(val);
@@ -606,7 +606,7 @@ static void PrintTLRecord(Obj obj)
     if (key && (!record || !FindPRec(record, key, &dummy, 0))) {
       if (comma)
 	Pr("%2<, %2>", 0L, 0L);
-      Pr("%I", (Int)(NAME_RNAM(key)), 0L);
+      Pr("%H", (Int)(NAME_OBJ_RNAM(key)), 0L);
       Pr ("%< := %>", 0L, 0L);
       PrintObj(CopyTraversed(value));
       comma = 1;

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -585,7 +585,7 @@ static void PrintTLRecord(Obj obj)
   if (record) {
     for (i = 1; i <= LEN_PREC(record); i++) {
       Obj val = GET_ELM_PREC(record, i);
-      Pr("%H", (Int)NAME_OBJ_RNAM(labs((Int)GET_RNAM_PREC(record, i))), 0L);
+      Pr("%H", (Int)NAME_RNAM(labs((Int)GET_RNAM_PREC(record, i))), 0L);
       Pr ("%< := %>", 0L, 0L);
       if (val)
 	PrintObj(val);
@@ -606,7 +606,7 @@ static void PrintTLRecord(Obj obj)
     if (key && (!record || !FindPRec(record, key, &dummy, 0))) {
       if (comma)
 	Pr("%2<, %2>", 0L, 0L);
-      Pr("%H", (Int)(NAME_OBJ_RNAM(key)), 0L);
+      Pr("%H", (Int)(NAME_RNAM(key)), 0L);
       Pr ("%< := %>", 0L, 0L);
       PrintObj(CopyTraversed(value));
       comma = 1;
@@ -926,7 +926,7 @@ Obj ElmARecord(Obj record, UInt rnam)
     if (result)
       return result;
     ErrorReturnVoid("Record: '<atomic record>.%g' must have an assigned value",
-      (UInt)NAME_OBJ_RNAM(rnam), 0L,
+      (UInt)NAME_RNAM(rnam), 0L,
       "you can 'return;' after assigning a value" );
   }
 }
@@ -936,7 +936,7 @@ void AssARecord(Obj record, UInt rnam, Obj value)
    Obj result = SetARecordField(record, rnam, value);
    if (!result)
      ErrorReturnVoid("Record: '<atomic record>.%g' already has an assigned value",
-       (UInt)NAME_OBJ_RNAM(rnam), 0L,
+       (UInt)NAME_RNAM(rnam), 0L,
        "you can 'return';");
 
 }
@@ -1071,7 +1071,7 @@ Obj ElmTLRecord(Obj record, UInt rnam)
     if (result)
       return result;
     ErrorReturnVoid("Record: '<thread-local record>.%g' must have an assigned value",
-      (UInt)NAME_OBJ_RNAM(rnam), 0L,
+      (UInt)NAME_RNAM(rnam), 0L,
       "you can 'return;' after assigning a value" );
   }
 }

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -925,8 +925,8 @@ Obj ElmARecord(Obj record, UInt rnam)
     result = GetARecordField(record, rnam);
     if (result)
       return result;
-    ErrorReturnVoid("Record: '<atomic record>.%s' must have an assigned value",
-      (UInt)NAME_RNAM(rnam), 0L,
+    ErrorReturnVoid("Record: '<atomic record>.%g' must have an assigned value",
+      (UInt)NAME_OBJ_RNAM(rnam), 0L,
       "you can 'return;' after assigning a value" );
   }
 }
@@ -935,8 +935,8 @@ void AssARecord(Obj record, UInt rnam, Obj value)
 {
    Obj result = SetARecordField(record, rnam, value);
    if (!result)
-     ErrorReturnVoid("Record: '<atomic record>.%s' already has an assigned value",
-       (UInt)NAME_RNAM(rnam), 0L,
+     ErrorReturnVoid("Record: '<atomic record>.%g' already has an assigned value",
+       (UInt)NAME_OBJ_RNAM(rnam), 0L,
        "you can 'return';");
 
 }
@@ -1070,8 +1070,8 @@ Obj ElmTLRecord(Obj record, UInt rnam)
     result = GetTLRecordField(record, rnam);
     if (result)
       return result;
-    ErrorReturnVoid("Record: '<thread-local record>.%s' must have an assigned value",
-      (UInt)NAME_RNAM(rnam), 0L,
+    ErrorReturnVoid("Record: '<thread-local record>.%g' must have an assigned value",
+      (UInt)NAME_OBJ_RNAM(rnam), 0L,
       "you can 'return;' after assigning a value" );
   }
 }

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -571,7 +571,7 @@ void SerializeRecord(Obj obj)
     WriteImmediateObj(INTOBJ_INT(len));
     for (i = 1; i <= len; i++) {
         UInt rnam = GET_RNAM_PREC(obj, i);
-        Obj  rnams = NAME_OBJ_RNAM(rnam);
+        Obj  rnams = NAME_RNAM(rnam);
         WriteByteBlock(rnams, sizeof(UInt), GET_LEN_STRING(rnams));
     }
     for (i = 1; i <= len; i++) {

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -2324,7 +2324,7 @@ Obj FuncMakeThreadLocal(Obj self, Obj var)
             "MakeThreadLocal: Argument must be a variable name");
     name = CSTR_STRING(var);
     gvar = GVarName(name);
-    name = NameGVar(gvar); /* to apply namespace scopes where needed. */
+    name = CSTR_STRING(NameGVarObj(gvar)); /* to apply namespace scopes where needed. */
     MakeThreadLocalVar(gvar, RNamName(name));
     return (Obj)0;
 }

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -2324,7 +2324,7 @@ Obj FuncMakeThreadLocal(Obj self, Obj var)
             "MakeThreadLocal: Argument must be a variable name");
     name = CSTR_STRING(var);
     gvar = GVarName(name);
-    name = CSTR_STRING(NameGVarObj(gvar)); /* to apply namespace scopes where needed. */
+    name = CSTR_STRING(NameGVar(gvar)); /* to apply namespace scopes where needed. */
     MakeThreadLocalVar(gvar, RNamName(name));
     return (Obj)0;
 }

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -1950,7 +1950,7 @@ static void PrintRegion(Obj obj)
     Obj      name = GetRegionName(region);
 
     if (name) {
-        Pr("<region: %s", (Int)(CSTR_STRING(name)), 0L);
+        Pr("<region: %g", (Int)name, 0L);
     }
     else {
         snprintf(buffer, 32, "<region %p", (void *)GetRegionOf(obj));

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2609,7 +2609,7 @@ void            IntrRefLVar (
     else {
         while ((val = OBJ_LVAR(lvar))==0) {
             ErrorReturnVoid(
-                            "Variable: '%s' must have an assigned value",
+                            "Variable: '%g' must have an assigned value",
                             (Int)NAME_LVAR( (UInt)( lvar )), 0L,
                             "you can 'return;' after assigning a value" );
 
@@ -2696,7 +2696,7 @@ void            IntrRefHVar (
     else {
         while ((val = OBJ_HVAR(hvar))==0) {
             ErrorReturnVoid(
-                            "Variable: '%s' must have an assigned value",
+                            "Variable: '%g' must have an assigned value",
                             (Int)NAME_HVAR( (UInt)( hvar )), 0L,
                             "you can 'return;' after assigning a value" );
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2908,7 +2908,7 @@ void            IntrRefGVar (
     if ( (val = ValAutoGVar( gvar )) == 0 ) {
         ErrorQuit(
             "Variable: '%g' must have a value",
-            (Int)NameGVarObj(gvar), 0L );
+            (Int)NameGVar(gvar), 0L );
     }
 
     /* push the value                                                      */

--- a/src/modules.c
+++ b/src/modules.c
@@ -468,7 +468,7 @@ void InitGVarFiltsFromTable(const StructGVarFilt * tab)
 
     for (i = 0; tab[i].name != 0; i++) {
         UInt gvar = GVarName(tab[i].name);
-        Obj  name = NameGVarObj(gvar);
+        Obj  name = NameGVar(gvar);
         Obj  args = ValidatedArgList(tab[i].name, 1, tab[i].argument);
         AssReadOnlyGVar(gvar, NewFilter(name, 1, args, tab[i].handler));
     }
@@ -485,7 +485,7 @@ void InitGVarAttrsFromTable(const StructGVarAttr * tab)
 
     for (i = 0; tab[i].name != 0; i++) {
         UInt gvar = GVarName(tab[i].name);
-        Obj  name = NameGVarObj(gvar);
+        Obj  name = NameGVar(gvar);
         Obj  args = ValidatedArgList(tab[i].name, 1, tab[i].argument);
         AssReadOnlyGVar(gvar, NewAttribute(name, 1, args, tab[i].handler));
     }
@@ -501,7 +501,7 @@ void InitGVarPropsFromTable(const StructGVarProp * tab)
 
     for (i = 0; tab[i].name != 0; i++) {
         UInt gvar = GVarName(tab[i].name);
-        Obj  name = NameGVarObj(gvar);
+        Obj  name = NameGVar(gvar);
         Obj  args = ValidatedArgList(tab[i].name, 1, tab[i].argument);
         AssReadOnlyGVar(gvar, NewProperty(name, 1, args, tab[i].handler));
     }
@@ -518,7 +518,7 @@ void InitGVarOpersFromTable(const StructGVarOper * tab)
 
     for (i = 0; tab[i].name != 0; i++) {
         UInt gvar = GVarName(tab[i].name);
-        Obj  name = NameGVarObj(gvar);
+        Obj  name = NameGVar(gvar);
         Obj  args = ValidatedArgList(tab[i].name, tab[i].nargs, tab[i].args);
         AssReadOnlyGVar(
             gvar, NewOperation(name, tab[i].nargs, args, tab[i].handler));
@@ -569,7 +569,7 @@ void InitGVarFuncsFromTable(const StructGVarFunc * tab)
 
     for (i = 0; tab[i].name != 0; i++) {
         UInt gvar = GVarName(tab[i].name);
-        Obj  name = NameGVarObj(gvar);
+        Obj  name = NameGVar(gvar);
         Obj  args = ValidatedArgList(tab[i].name, tab[i].nargs, tab[i].args);
         Obj  func = NewFunction(name, tab[i].nargs, args, tab[i].handler);
         SetupFuncInfo(func, tab[i].cookie);

--- a/src/precord.c
+++ b/src/precord.c
@@ -608,7 +608,7 @@ void PrintPathPRec (
     Obj                 rec,
     Int                 indx )
 {
-    Pr( ".%I", (Int)NAME_RNAM( labs((Int)(GET_RNAM_PREC(rec,indx))) ), 0L );
+    Pr( ".%H", (Int)NAME_OBJ_RNAM( labs((Int)(GET_RNAM_PREC(rec,indx))) ), 0L );
 }
 
 /****************************************************************************

--- a/src/precord.c
+++ b/src/precord.c
@@ -785,8 +785,8 @@ Obj FuncLT_PREC (
         /* The sense of this comparison is determined by the rule that
            unbound entries compare less than bound ones                    */
         if ( GET_RNAM_PREC(left,i) != GET_RNAM_PREC(right,i) ) {
-            res = ( strcmp( NAME_RNAM( labs((Int)(GET_RNAM_PREC(left,i))) ),
-                   NAME_RNAM( labs((Int)(GET_RNAM_PREC(right,i))) ) ) > 0 );
+            res = !LT( NAME_OBJ_RNAM( labs((Int)(GET_RNAM_PREC(left,i))) ),
+                   NAME_OBJ_RNAM( labs((Int)(GET_RNAM_PREC(right,i))) ) );
             break;
         }
 

--- a/src/precord.c
+++ b/src/precord.c
@@ -365,7 +365,7 @@ Obj ElmPRec (
     else {
         ErrorReturnVoid(
             "Record: '<rec>.%g' must have an assigned value",
-            (Int)NAME_OBJ_RNAM(rnam), 0L,
+            (Int)NAME_RNAM(rnam), 0L,
             "you can 'return;' after assigning a value" );
         return ELM_REC( rec, rnam );
     }
@@ -608,7 +608,7 @@ void PrintPathPRec (
     Obj                 rec,
     Int                 indx )
 {
-    Pr( ".%H", (Int)NAME_OBJ_RNAM( labs((Int)(GET_RNAM_PREC(rec,indx))) ), 0L );
+    Pr( ".%H", (Int)NAME_RNAM( labs((Int)(GET_RNAM_PREC(rec,indx))) ), 0L );
 }
 
 /****************************************************************************
@@ -639,7 +639,7 @@ Obj InnerRecNames( Obj rec )
     for ( i = 1; i <= LEN_PREC(rec); i++ ) {
         rnam = -(Int)(GET_RNAM_PREC( rec, i ));
         /* could have been moved by garbage collection */
-        name = NAME_OBJ_RNAM( rnam );
+        name = NAME_RNAM( rnam );
         string = CopyToStringRep( name );
         SET_ELM_PLIST( list, i, string );
         CHANGED_BAG( list );
@@ -785,8 +785,8 @@ Obj FuncLT_PREC (
         /* The sense of this comparison is determined by the rule that
            unbound entries compare less than bound ones                    */
         if ( GET_RNAM_PREC(left,i) != GET_RNAM_PREC(right,i) ) {
-            res = !LT( NAME_OBJ_RNAM( labs((Int)(GET_RNAM_PREC(left,i))) ),
-                   NAME_OBJ_RNAM( labs((Int)(GET_RNAM_PREC(right,i))) ) );
+            res = !LT( NAME_RNAM( labs((Int)(GET_RNAM_PREC(left,i))) ),
+                   NAME_RNAM( labs((Int)(GET_RNAM_PREC(right,i))) ) );
             break;
         }
 

--- a/src/records.c
+++ b/src/records.c
@@ -32,11 +32,6 @@ static Obj HashRNam;
 
 static Obj NamesRNam;
 
-inline const Char *NAME_RNAM(UInt rnam)
-{
-    return CSTR_STRING(ELM_PLIST(NamesRNam, rnam));
-}
-
 inline extern Obj NAME_OBJ_RNAM(UInt rnam)
 {
     return ELM_PLIST(NamesRNam, rnam);
@@ -117,7 +112,7 @@ UInt            RNamName (
     sizeRNam = LEN_PLIST(HashRNam);
     pos = (hash % sizeRNam) + 1;
     while ( (rnam = ELM_PLIST( HashRNam, pos )) != 0
-         && strncmp( NAME_RNAM( INT_INTOBJ(rnam) ), name, 1023 ) ) {
+         && strncmp( CSTR_STRING( NAME_OBJ_RNAM( INT_INTOBJ(rnam) ) ), name, 1023 ) ) {
         pos = (pos % sizeRNam) + 1;
     }
     if (rnam != 0) {
@@ -134,7 +129,7 @@ UInt            RNamName (
       sizeRNam = LEN_PLIST(HashRNam);
       pos = (hash % sizeRNam) + 1;
       while ( (rnam = ELM_PLIST( HashRNam, pos )) != 0
-           && strncmp( NAME_RNAM( INT_INTOBJ(rnam) ), name, 1023 ) ) {
+           && strncmp( CSTR_STRING( NAME_OBJ_RNAM( INT_INTOBJ(rnam) ) ), name, 1023 ) ) {
           pos = (pos % sizeRNam) + 1;
       }
     }
@@ -168,7 +163,7 @@ UInt            RNamName (
         for ( i = 1; i <= (sizeRNam-1)/2; i++ ) {
             rnam2 = ELM_PLIST( table, i );
             if ( rnam2 == 0 )  continue;
-            pos = HashString( NAME_RNAM( INT_INTOBJ(rnam2) ) );
+            pos = HashString( CSTR_STRING( NAME_OBJ_RNAM( INT_INTOBJ(rnam2) ) ) );
             pos = (pos % sizeRNam) + 1;
             while ( ELM_PLIST( HashRNam, pos ) != 0 ) {
                 pos = (pos % sizeRNam) + 1;
@@ -541,7 +536,7 @@ UInt            iscomplete_rnam (
     const UInt          countRNam = LEN_PLIST(NamesRNam);
 
     for ( i = 1; i <= countRNam; i++ ) {
-        curr = NAME_RNAM( i );
+        curr = CSTR_STRING( NAME_OBJ_RNAM( i ) );
         for ( k = 0; name[k] != 0 && curr[k] == name[k]; k++ ) ;
         if ( k == len && curr[k] == '\0' )  return 1;
     }
@@ -559,7 +554,7 @@ UInt            completion_rnam (
 
     next = 0;
     for ( i = 1; i <= countRNam; i++ ) {
-        curr = NAME_RNAM( i );
+        curr = CSTR_STRING( NAME_OBJ_RNAM( i ) );
         for ( k = 0; name[k] != 0 && curr[k] == name[k]; k++ ) ;
         if ( k < len || curr[k] <= name[k] )  continue;
         if ( next != 0 ) {

--- a/src/records.c
+++ b/src/records.c
@@ -32,7 +32,7 @@ static Obj HashRNam;
 
 static Obj NamesRNam;
 
-inline extern Obj NAME_OBJ_RNAM(UInt rnam)
+inline extern Obj NAME_RNAM(UInt rnam)
 {
     return ELM_PLIST(NamesRNam, rnam);
 }
@@ -112,7 +112,7 @@ UInt            RNamName (
     sizeRNam = LEN_PLIST(HashRNam);
     pos = (hash % sizeRNam) + 1;
     while ( (rnam = ELM_PLIST( HashRNam, pos )) != 0
-         && strncmp( CSTR_STRING( NAME_OBJ_RNAM( INT_INTOBJ(rnam) ) ), name, 1023 ) ) {
+         && strncmp( CSTR_STRING( NAME_RNAM( INT_INTOBJ(rnam) ) ), name, 1023 ) ) {
         pos = (pos % sizeRNam) + 1;
     }
     if (rnam != 0) {
@@ -129,7 +129,7 @@ UInt            RNamName (
       sizeRNam = LEN_PLIST(HashRNam);
       pos = (hash % sizeRNam) + 1;
       while ( (rnam = ELM_PLIST( HashRNam, pos )) != 0
-           && strncmp( CSTR_STRING( NAME_OBJ_RNAM( INT_INTOBJ(rnam) ) ), name, 1023 ) ) {
+           && strncmp( CSTR_STRING( NAME_RNAM( INT_INTOBJ(rnam) ) ), name, 1023 ) ) {
           pos = (pos % sizeRNam) + 1;
       }
     }
@@ -163,7 +163,7 @@ UInt            RNamName (
         for ( i = 1; i <= (sizeRNam-1)/2; i++ ) {
             rnam2 = ELM_PLIST( table, i );
             if ( rnam2 == 0 )  continue;
-            pos = HashString( CSTR_STRING( NAME_OBJ_RNAM( INT_INTOBJ(rnam2) ) ) );
+            pos = HashString( CSTR_STRING( NAME_RNAM( INT_INTOBJ(rnam2) ) ) );
             pos = (pos % sizeRNam) + 1;
             while ( ELM_PLIST( HashRNam, pos ) != 0 ) {
                 pos = (pos % sizeRNam) + 1;
@@ -288,7 +288,7 @@ Obj             FuncNameRNam (
             (Int)TNAM_OBJ(rnam), 0L,
             "you can replace <rnam> via 'return <rnam>;'" );
     }
-    oname = NAME_OBJ_RNAM( INT_INTOBJ(rnam) );
+    oname = NAME_RNAM( INT_INTOBJ(rnam) );
     name = CopyToStringRep(oname);
     return name;
 }
@@ -536,7 +536,7 @@ UInt            iscomplete_rnam (
     const UInt          countRNam = LEN_PLIST(NamesRNam);
 
     for ( i = 1; i <= countRNam; i++ ) {
-        curr = CSTR_STRING( NAME_OBJ_RNAM( i ) );
+        curr = CSTR_STRING( NAME_RNAM( i ) );
         for ( k = 0; name[k] != 0 && curr[k] == name[k]; k++ ) ;
         if ( k == len && curr[k] == '\0' )  return 1;
     }
@@ -554,7 +554,7 @@ UInt            completion_rnam (
 
     next = 0;
     for ( i = 1; i <= countRNam; i++ ) {
-        curr = CSTR_STRING( NAME_OBJ_RNAM( i ) );
+        curr = CSTR_STRING( NAME_RNAM( i ) );
         for ( k = 0; name[k] != 0 && curr[k] == name[k]; k++ ) ;
         if ( k < len || curr[k] <= name[k] )  continue;
         if ( next != 0 ) {
@@ -583,7 +583,7 @@ Obj FuncALL_RNAMES (
 
     copy = NEW_PLIST_IMM( T_PLIST, countRNam );
     for ( i = 1;  i <= countRNam;  i++ ) {
-        name = NAME_OBJ_RNAM( i );
+        name = NAME_RNAM( i );
         s = CopyToStringRep(name);
         SET_ELM_PLIST( copy, i, s );
     }

--- a/src/records.h
+++ b/src/records.h
@@ -20,13 +20,10 @@
 
 /****************************************************************************
 **
-*F  NAME_RNAM(<rnam>) . . . . . . . . . .  name for a record name as C string
 *F  NAME_OBJ_RNAM(<rnam>) . . . . . . . . .  name for a record name as an Obj
 **
-**  'NAME_RNAM' returns the name (as a C string) for the record name <rnam>.
 **  'NAME_OBJ_RNAM' returns the name (as an Obj) for the record name <rnam>.
 */
-extern const Char *NAME_RNAM(UInt rnam);
 extern Obj NAME_OBJ_RNAM(UInt rnam);
 
 

--- a/src/records.h
+++ b/src/records.h
@@ -20,11 +20,11 @@
 
 /****************************************************************************
 **
-*F  NAME_OBJ_RNAM(<rnam>) . . . . . . . . .  name for a record name as an Obj
+*F  NAME_RNAM(<rnam>) . . . . . . . . . . .  name for a record name as an Obj
 **
-**  'NAME_OBJ_RNAM' returns the name (as an Obj) for the record name <rnam>.
+**  'NAME_RNAM' returns the name (as an Obj) for the record name <rnam>.
 */
-extern Obj NAME_OBJ_RNAM(UInt rnam);
+extern Obj NAME_RNAM(UInt rnam);
 
 
 /****************************************************************************

--- a/src/vars.c
+++ b/src/vars.c
@@ -476,7 +476,7 @@ void            PrintAssGVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
-    Pr( "%I", (Int)NameGVar( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr( "%H", (Int)NameGVarObj( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
     Pr( "%< %>:= ", 0L, 0L );
     PrintExpr( ADDR_EXPR(stat)[1] );
     Pr( "%2<;", 0L, 0L );
@@ -486,7 +486,7 @@ void            PrintUnbGVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
-    Pr( "%I", (Int)NameGVar( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr( "%H", (Int)NameGVarObj( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
     Pr( " );", 0L, 0L );
 }
 
@@ -500,14 +500,14 @@ void            PrintUnbGVar (
 void            PrintRefGVar (
     Expr                expr )
 {
-    Pr( "%I", (Int)NameGVar( (UInt)(ADDR_STAT(expr)[0]) ), 0L );
+    Pr( "%H", (Int)NameGVarObj( (UInt)(ADDR_STAT(expr)[0]) ), 0L );
 }
 
 void            PrintIsbGVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr( "%I", (Int)NameGVar( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
+    Pr( "%H", (Int)NameGVarObj( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
     Pr( " )", 0L, 0L );
 }
 
@@ -1550,7 +1550,7 @@ void            PrintAssRecName (
     Pr("%4>",0L,0L);
     PrintExpr( ADDR_EXPR(stat)[0] );
     Pr("%<.",0L,0L);
-    Pr("%I",(Int)NAME_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
+    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
     Pr("%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
     PrintExpr( ADDR_EXPR(stat)[2] );
@@ -1564,7 +1564,7 @@ void            PrintUnbRecName (
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(stat)[0] );
     Pr("%<.",0L,0L);
-    Pr("%I",(Int)NAME_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
+    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
     Pr("%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -1616,7 +1616,7 @@ void            PrintElmRecName (
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(expr)[0] );
     Pr("%<.",0L,0L);
-    Pr("%I",(Int)NAME_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
+    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
     Pr("%<",0L,0L);
 }
 
@@ -1627,7 +1627,7 @@ void            PrintIsbRecName (
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(expr)[0] );
     Pr("%<.",0L,0L);
-    Pr("%I",(Int)NAME_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
+    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
     Pr("%<",0L,0L);
     Pr( " )", 0L, 0L );
 }
@@ -2308,7 +2308,7 @@ void            PrintAssComObjName (
     Pr("%4>",0L,0L);
     PrintExpr( ADDR_EXPR(stat)[0] );
     Pr("%<!.",0L,0L);
-    Pr("%I",(Int)NAME_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
+    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
     Pr("%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
     PrintExpr( ADDR_EXPR(stat)[2] );
@@ -2322,7 +2322,7 @@ void            PrintUnbComObjName (
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(stat)[0] );
     Pr("%<!.",0L,0L);
-    Pr("%I",(Int)NAME_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
+    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
     Pr("%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -2374,7 +2374,7 @@ void            PrintElmComObjName (
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(expr)[0] );
     Pr("%<!.",0L,0L);
-    Pr("%I",(Int)NAME_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
+    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
     Pr("%<",0L,0L);
 }
 
@@ -2385,7 +2385,7 @@ void            PrintIsbComObjName (
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(expr)[0] );
     Pr("%<!.",0L,0L);
-    Pr("%I",(Int)NAME_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
+    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
     Pr("%<",0L,0L);
     Pr( " )", 0L, 0L );
 }

--- a/src/vars.c
+++ b/src/vars.c
@@ -445,7 +445,7 @@ Obj             EvalRefGVar (
     while ( (val = ValAutoGVar( (UInt)(ADDR_EXPR(expr)[0]) )) == 0 ) {
         ErrorReturnVoid(
             "Variable: '%g' must have an assigned value",
-            (Int)NameGVarObj( (UInt)(ADDR_EXPR(expr)[0]) ), 0L,
+            (Int)NameGVar( (UInt)(ADDR_EXPR(expr)[0]) ), 0L,
             "you can 'return;' after assigning a value" );
     }
 
@@ -476,7 +476,7 @@ void            PrintAssGVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
-    Pr( "%H", (Int)NameGVarObj( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr( "%H", (Int)NameGVar( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
     Pr( "%< %>:= ", 0L, 0L );
     PrintExpr( ADDR_EXPR(stat)[1] );
     Pr( "%2<;", 0L, 0L );
@@ -486,7 +486,7 @@ void            PrintUnbGVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
-    Pr( "%H", (Int)NameGVarObj( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr( "%H", (Int)NameGVar( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
     Pr( " );", 0L, 0L );
 }
 
@@ -500,14 +500,14 @@ void            PrintUnbGVar (
 void            PrintRefGVar (
     Expr                expr )
 {
-    Pr( "%H", (Int)NameGVarObj( (UInt)(ADDR_STAT(expr)[0]) ), 0L );
+    Pr( "%H", (Int)NameGVar( (UInt)(ADDR_STAT(expr)[0]) ), 0L );
 }
 
 void            PrintIsbGVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr( "%H", (Int)NameGVarObj( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
+    Pr( "%H", (Int)NameGVar( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
     Pr( " )", 0L, 0L );
 }
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -1989,10 +1989,11 @@ UInt            ExecAssComObjName (
       case T_ACOMOBJ:
 #ifdef CHECK_TL_ASSIGNS
         if (GetRegionOf(rhs) == STATE(threadRegion)) {
-            if (strcmp(NAME_RNAM(rnam), "buffer") != 0
-             && strcmp(NAME_RNAM(rnam), "state") != 0) {
+            Obj name = NAME_OBJ_RNAM(rnam);
+            if (strcmp(CSTR_STRING(name)), "buffer") != 0
+             && strcmp(CSTR_STRING(name)), "state") != 0) {
                 ErrorReturnObj("Warning: thread local assignment of '%g'",
-                               (Int)NAME_OBJ_RNAM(rnam), 0L,
+                               (Int)name, 0L,
                                "type 'return <value>; to continue'");
             }
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -1550,7 +1550,7 @@ void            PrintAssRecName (
     Pr("%4>",0L,0L);
     PrintExpr( ADDR_EXPR(stat)[0] );
     Pr("%<.",0L,0L);
-    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
+    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
     Pr("%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
     PrintExpr( ADDR_EXPR(stat)[2] );
@@ -1564,7 +1564,7 @@ void            PrintUnbRecName (
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(stat)[0] );
     Pr("%<.",0L,0L);
-    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
+    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
     Pr("%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -1616,7 +1616,7 @@ void            PrintElmRecName (
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(expr)[0] );
     Pr("%<.",0L,0L);
-    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
+    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
     Pr("%<",0L,0L);
 }
 
@@ -1627,7 +1627,7 @@ void            PrintIsbRecName (
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(expr)[0] );
     Pr("%<.",0L,0L);
-    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
+    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
     Pr("%<",0L,0L);
     Pr( " )", 0L, 0L );
 }
@@ -1989,7 +1989,7 @@ UInt            ExecAssComObjName (
       case T_ACOMOBJ:
 #ifdef CHECK_TL_ASSIGNS
         if (GetRegionOf(rhs) == STATE(threadRegion)) {
-            Obj name = NAME_OBJ_RNAM(rnam);
+            Obj name = NAME_RNAM(rnam);
             if (strcmp(CSTR_STRING(name)), "buffer") != 0
              && strcmp(CSTR_STRING(name)), "state") != 0) {
                 ErrorReturnObj("Warning: thread local assignment of '%g'",
@@ -2309,7 +2309,7 @@ void            PrintAssComObjName (
     Pr("%4>",0L,0L);
     PrintExpr( ADDR_EXPR(stat)[0] );
     Pr("%<!.",0L,0L);
-    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
+    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
     Pr("%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
     PrintExpr( ADDR_EXPR(stat)[2] );
@@ -2323,7 +2323,7 @@ void            PrintUnbComObjName (
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(stat)[0] );
     Pr("%<!.",0L,0L);
-    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
+    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
     Pr("%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -2375,7 +2375,7 @@ void            PrintElmComObjName (
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(expr)[0] );
     Pr("%<!.",0L,0L);
-    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
+    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
     Pr("%<",0L,0L);
 }
 
@@ -2386,7 +2386,7 @@ void            PrintIsbComObjName (
     Pr("%2>",0L,0L);
     PrintExpr( ADDR_EXPR(expr)[0] );
     Pr("%<!.",0L,0L);
-    Pr("%H",(Int)NAME_OBJ_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
+    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
     Pr("%<",0L,0L);
     Pr( " )", 0L, 0L );
 }

--- a/src/vars.c
+++ b/src/vars.c
@@ -94,7 +94,7 @@ Obj             ObjLVar (
     Obj                 val;            /* value result                    */
     while ( (val = OBJ_LVAR(lvar)) == 0 ) {
         ErrorReturnVoid(
-            "Variable: '%s' must have an assigned value",
+            "Variable: '%g' must have an assigned value",
             (Int)NAME_LVAR( lvar ), 0L,
             "you can 'return;' after assigning a value" );
     }
@@ -179,7 +179,7 @@ void            PrintAssLVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
-    Pr( "%I", (Int)NAME_LVAR( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr( "%H", (Int)NAME_LVAR( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
     Pr( "%< %>:= ", 0L, 0L );
     PrintExpr( ADDR_EXPR(stat)[1] );
     Pr( "%2<;", 0L, 0L );
@@ -189,7 +189,7 @@ void            PrintUnbLVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
-    Pr( "%I", (Int)NAME_LVAR( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr( "%H", (Int)NAME_LVAR( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
     Pr( " );", 0L, 0L );
 }
 
@@ -203,14 +203,14 @@ void            PrintUnbLVar (
 void            PrintRefLVar (
     Expr                expr )
 {
-    Pr( "%I", (Int)NAME_LVAR( LVAR_REFLVAR(expr) ), 0L );
+    Pr( "%H", (Int)NAME_LVAR( LVAR_REFLVAR(expr) ), 0L );
 }
 
 void            PrintIsbLVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr( "%I", (Int)NAME_LVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
+    Pr( "%H", (Int)NAME_LVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
     Pr( " )", 0L, 0L );
 }
 
@@ -225,7 +225,7 @@ void            PrintIsbLVar (
 **
 **  'OBJ_HVAR' returns the value of the higher variable <hvar>.
 **
-**  'NAME_HVAR' returns the name of the higher variable <hvar> as a C string.
+**  'NAME_HVAR' returns the name of the higher variable <hvar>.
 */
 void ASS_HVAR(UInt hvar, Obj val)
 {
@@ -237,7 +237,7 @@ Obj OBJ_HVAR(UInt hvar)
     return OBJ_HVAR_WITH_CONTEXT(STATE(CurrLVars), hvar);
 }
 
-Char * NAME_HVAR(UInt hvar)
+Obj NAME_HVAR(UInt hvar)
 {
     return NAME_HVAR_WITH_CONTEXT(STATE(CurrLVars), hvar);
 }
@@ -268,7 +268,7 @@ Obj OBJ_HVAR_WITH_CONTEXT(Obj context, UInt hvar)
     return val;
 }
 
-Char * NAME_HVAR_WITH_CONTEXT(Obj context, UInt hvar)
+Obj NAME_HVAR_WITH_CONTEXT(Obj context, UInt hvar)
 {
     // walk up the environment chain to the correct values bag
     for (UInt i = 1; i <= (hvar >> 16); i++) {
@@ -276,10 +276,7 @@ Char * NAME_HVAR_WITH_CONTEXT(Obj context, UInt hvar)
     }
 
     // get the name
-    Char * name = NAME_LVAR_WITH_CONTEXT(context, hvar & 0xFFFF);
-
-    // return the name
-    return name;
+    return NAME_LVAR_WITH_CONTEXT(context, hvar & 0xFFFF);
 }
 
 
@@ -331,7 +328,7 @@ Obj             EvalRefHVar (
     if ( (val = OBJ_HVAR( (UInt)(ADDR_EXPR(expr)[0]) )) == 0 ) {
         while ( (val = OBJ_HVAR( (UInt)(ADDR_EXPR(expr)[0]) )) == 0 ) {
             ErrorReturnVoid(
-                "Variable: '%s' must have an assigned value",
+                "Variable: '%g' must have an assigned value",
                 (Int)NAME_HVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L,
                 "you can 'return;' after assigning a value" );
         }
@@ -364,7 +361,7 @@ void            PrintAssHVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
-    Pr( "%I", (Int)NAME_HVAR( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr( "%H", (Int)NAME_HVAR( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
     Pr( "%< %>:= ", 0L, 0L );
     PrintExpr( ADDR_EXPR(stat)[1] );
     Pr( "%2<;", 0L, 0L );
@@ -374,7 +371,7 @@ void            PrintUnbHVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
-    Pr( "%I", (Int)NAME_HVAR( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr( "%H", (Int)NAME_HVAR( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
     Pr( " );", 0L, 0L );
 }
 
@@ -388,14 +385,14 @@ void            PrintUnbHVar (
 void            PrintRefHVar (
     Expr                expr )
 {
-    Pr( "%I", (Int)NAME_HVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
+    Pr( "%H", (Int)NAME_HVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
 }
 
 void            PrintIsbHVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr( "%I", (Int)NAME_HVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
+    Pr( "%H", (Int)NAME_HVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
     Pr( " )", 0L, 0L );
 }
 

--- a/src/vars.h
+++ b/src/vars.h
@@ -296,7 +296,7 @@ static inline void SwitchToOldLVarsAndFree(Obj old, const char *file, int line)
 **
 *F  NAME_LVAR( <lvar> ) . . . . . . . . . . . . . . .  name of local variable
 **
-**  'NAME_LVAR' returns the name of the local variable <lvar> as a C string.
+**  'NAME_LVAR' returns the name of the local variable <lvar>.
 */
 #define NAME_LVAR(lvar)         NAMI_FUNC( CURR_FUNC(), lvar )
 #define NAME_LVAR_WITH_CONTEXT(context,lvar)         NAMI_FUNC( FUNC_LVARS(context), lvar )
@@ -322,15 +322,15 @@ extern  Obj             ObjLVar (
 **
 **  'OBJ_HVAR' returns the value of the higher variable <hvar>.
 **
-**  'NAME_HVAR' returns the name of the higher variable <hvar> as a C string.
+**  'NAME_HVAR' returns the name of the higher variable <hvar>.
 */
-extern void   ASS_HVAR(UInt hvar, Obj val);
-extern Obj    OBJ_HVAR(UInt hvar);
-extern Char * NAME_HVAR(UInt hvar);
+extern void ASS_HVAR(UInt hvar, Obj val);
+extern Obj  OBJ_HVAR(UInt hvar);
+extern Obj  NAME_HVAR(UInt hvar);
 
-extern void   ASS_HVAR_WITH_CONTEXT(Obj context, UInt hvar, Obj val);
-extern Obj    OBJ_HVAR_WITH_CONTEXT(Obj context, UInt hvar);
-extern Char * NAME_HVAR_WITH_CONTEXT(Obj context, UInt hvar);
+extern void ASS_HVAR_WITH_CONTEXT(Obj context, UInt hvar, Obj val);
+extern Obj  OBJ_HVAR_WITH_CONTEXT(Obj context, UInt hvar);
+extern Obj  NAME_HVAR_WITH_CONTEXT(Obj context, UInt hvar);
 
 
 /****************************************************************************


### PR DESCRIPTION
More specifically, avoid returning `CSTR_STRING(foo)` for GAP strings `foo`, as this is very prone to introduce bugs triggered by a garbage collection in the wrong moment.

Some thoughts:
* the new `%H` added to `Pr()` actually replaced *all* instances of `%I`, so we could drop the old `%I` and rename `%H` to `%I`, thus reducing the final diff in this PR quite a bit.
* I checked carefully that none of the functions changed and/or renamed by this PR are used by any packages (with a tiny exception for ParGAP, which wraps NAME_LVAR, but only to aid debuggers like GDB/LLDB; this is trivial to fix, but I consider ParGAP unmaintained at this point and thus don't care about breaking it further).

Closes #2337
