### PR TITLE
Add line continuation tests; move a kernel comment to right spot; make some scanner functions static

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -597,10 +597,7 @@ void GetNumber ( UInt StartingStatus )
 
 /****************************************************************************
 **
-*F  GetEscapedChar() . . . . . . . . . . . . . . . . get an escaped character
-**
-**  'GetEscapedChar' reads an escape sequence from the current input file
-**  into the variable *dst.
+*F  GetOctalDigits()
 **
 */
 static inline Char GetOctalDigits( void )
@@ -639,6 +636,15 @@ static inline Char CharHexDigit( Char c )
     }
 }
 
+
+/****************************************************************************
+**
+*F  GetEscapedChar() . . . . . . . . . . . . . . . . get an escaped character
+**
+**  'GetEscapedChar' reads an escape sequence from the current input file
+**  into the variable *dst.
+**
+*/
 Char GetEscapedChar( void )
 {
   Char result = 0;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -189,7 +189,7 @@ void Match (
 **  'GetIdent' can decide with one string comparison if 'STATE(Value)' holds
 **  a keyword or not.
 */
-void GetIdent ( void )
+static void GetIdent(void)
 {
     Int                 i, fetch;
     Int                 isQuoted;
@@ -359,7 +359,7 @@ static Char GetCleanedChar( UInt *wasEscaped ) {
 }
 
 
-void GetNumber ( UInt StartingStatus )
+static void GetNumber(UInt StartingStatus)
 {
   Int                 i=0;
   Char                c;
@@ -645,7 +645,7 @@ static inline Char CharHexDigit( Char c )
 **  into the variable *dst.
 **
 */
-Char GetEscapedChar( void )
+static Char GetEscapedChar(void)
 {
   Char result = 0;
   Char c = PEEK_CURR_CHAR();
@@ -710,7 +710,7 @@ Char GetEscapedChar( void )
 **  the string is  complete or not to decide  between Symbol=S_STRING or
 **  S_PARTIALSTRING.
 */
-void GetStr ( void )
+static void GetStr(void)
 {
   Int                 i = 0, fetch;
   Char c = PEEK_CURR_CHAR();
@@ -787,7 +787,7 @@ void GetStr ( void )
 **  the string is  complete or not to decide  between Symbol=S_STRING or
 **  S_PARTIALTRIPLESTRING.
 */
-void GetTripStr ( void )
+static void GetTripStr(void)
 {
   Int                 i = 0;
   Char c = PEEK_CURR_CHAR();
@@ -847,7 +847,7 @@ void GetTripStr ( void )
 **  'GetMaybeTripStr' decides if we are reading a single quoted string,
 **  or a triple quoted string.
 */
-void GetMaybeTripStr ( void )
+static void GetMaybeTripStr(void)
 {
     Char c = GET_NEXT_CHAR();
 
@@ -884,7 +884,7 @@ void GetMaybeTripStr ( void )
 **  must not  be '\'' or <newline>, but  the escape  sequences '\\\'' or '\n'
 **  can be used instead.
 */
-void GetChar ( void )
+static void GetChar(void)
 {
   /* skip '\''                                                           */
   Char c = GET_NEXT_CHAR();
@@ -916,7 +916,7 @@ void GetChar ( void )
   }
 }
 
-void GetHelp( void )
+static void GetHelp(void)
 {
     Int i = 0;
 

--- a/tst/testinstall/linecontinuation.tst
+++ b/tst/testinstall/linecontinuation.tst
@@ -1,0 +1,32 @@
+#
+# This file tests line continuations, i.e., GAP commands which span multiple
+# lines with help of a backslash just before the new line, inside various
+# kinds of GAP expressions
+gap> START_TEST("linecontinuation.tst");
+
+# in strings
+gap> x:="foo\
+> bar";
+"foobar"
+
+# in triple quoted string
+gap> x:="""haha\
+> !""";
+"haha\\\n!"
+
+# break keywords and operators like :=, <=, >= etc. in the middle
+gap> 1 m\
+> od 5;
+1
+gap> x :\
+> =1;
+1
+
+# however, in comments, you cannot use line continuations:
+gap> # 1234\
+gap> 5;
+5
+
+#
+gap> STOP_TEST("linecontinuation.tst", 1);
+


### PR DESCRIPTION
This is a subset of PR #2215. I hope we can merge this quickly, then I can simplify that PR. Also, by merging this first, we have assurance that the line continuations tests really work before the change to line continuation processing.