### PR TITLE
io: change prompt after line continuation

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -221,6 +221,13 @@ Char GET_NEXT_CHAR(void)
             // if we see a backlash without a line terminator after it, stop
             break;
         }
+
+        // if we get here, we saw a line continuation; change the prompt to a
+        // partial prompt from now on
+        if (!SyQuiet)
+            STATE(Prompt) = "> ";
+        else
+            STATE(Prompt) = "";
     }
 
     return *STATE(In);

--- a/tst/testinstall/linecontinuation.tst
+++ b/tst/testinstall/linecontinuation.tst
@@ -8,11 +8,17 @@ gap> START_TEST("linecontinuation.tst");
 gap> x:="foo\
 > bar";
 "foobar"
+gap> "foo\
+> bar";
+"foobar"
 
 # in triple quoted string
-gap> x:="""haha\
-> !""";
-"haha!"
+gap> x:="""foo\
+> bar""";
+"foobar"
+gap> """foo\
+> bar""";
+"foobar"
 
 # break keywords and operators like :=, <=, >= etc. in the middle
 gap> 1 m\
@@ -34,6 +40,19 @@ function( x... ) ... end
 gap> {x.\
 > ..}->x;
 function( x... ) ... end
+
+# inside float expressions
+gap> 1.2e\
+> 0;
+1.2
+gap> 1.1\
+> ;
+1.1
+
+# inside integer expressions
+gap> 12\
+> 3;
+123
 
 # however, in comments, you cannot use line continuations:
 gap> # 1234\


### PR DESCRIPTION
This ensures that line continuations inside of e.g. integer and float expressions properly show a line continuation prompt.

Fixes #1992

This PR is based on PR #2215, which should be merged first.
