### PR TITLE
Fix tests when 'ToolsForHomalg' is loaded

### DIFF
--- a/tst/testinstall/opers/LocationFunc.tst
+++ b/tst/testinstall/opers/LocationFunc.tst
@@ -6,8 +6,8 @@ gap> LocationFunc(f);
 "stream:1"
 
 # GAP function which was compiled to C code by gac
-gap> LocationFunc(RunImmediateMethods);
-"GAPROOT/lib/oper1.g:26"
+gap> LocationFunc(INSTALL_METHOD_FLAGS);
+"GAPROOT/lib/oper1.g:137"
 
 # proper kernel function
 gap> LocationFunc(APPEND_LIST_INTR);

--- a/tst/testinstall/varargs.tst
+++ b/tst/testinstall/varargs.tst
@@ -81,9 +81,9 @@ gap> Display(RETURN_FIRST);
 function ( object... )
     <<kernel code from src/gap.c:RETURN_FIRST>>
 end
-gap> Print(RunImmediateMethods,"\n");
-function ( <<arg-1>>, <<arg-2>> )
-    <<compiled GAP code from GAPROOT/lib/oper1.g:26>>
+gap> Print(INSTALL_METHOD_FLAGS,"\n");
+function ( <<arg-1>>, <<arg-2>>, <<arg-3>>, <<arg-4>>, <<arg-5>>, <<arg-6>> )
+    <<compiled GAP code from GAPROOT/lib/oper1.g:137>>
 end
 gap> Display(InstallMethod);
 function ( <<arg-1>>... )


### PR DESCRIPTION
`ToolsForHomalg ` by @sebasguts replaces `RunImmediateMethods` with a custom function, which throws of the test output. Fixed by using another function to test the printing of compiled functions.