### PR TITLE
Refactor parts of the scanner

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -622,7 +622,7 @@ static inline Char CharHexDigit( Char c )
 static Char GetEscapedChar(void)
 {
   Char result = 0;
-  Char c = PEEK_CURR_CHAR();
+  Char c = GET_NEXT_CHAR();
 
   if ( c == 'n'  )       result = '\n';
   else if ( c == 't'  )  result = '\t';
@@ -695,7 +695,6 @@ static void GetStr(void)
 
     /* handle escape sequences                                         */
     if ( c == '\\' ) {
-      c = GET_NEXT_CHAR();
       STATE(Value)[i] = GetEscapedChar();
     }
 
@@ -858,7 +857,6 @@ static void GetChar(void)
     SyntaxError("Character literal must not include <newline>");
   } else {
     if ( c == '\\' ) {
-      c = GET_NEXT_CHAR();
       STATE(Value)[0] = GetEscapedChar();
     } else {
       /* put normal chars into 'STATE(Value)' */

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -921,10 +921,10 @@ void GetSymbol ( void )
 
     Char c = PEEK_CURR_CHAR();
 
-  /* if no character is available then get one                           */
-  if ( c == '\0' )
-    { STATE(In)--;
-      c = GET_NEXT_CHAR();
+    // if no character is available then get one
+    if ( c == '\0' ) {
+        STATE(In)--;
+        c = GET_NEXT_CHAR();
     }
 
   /* skip over <spaces>, <tabs>, <newlines> and comments                 */
@@ -934,74 +934,73 @@ void GetSymbol ( void )
     c = GET_NEXT_CHAR();
   }
 
-  /* switch according to the character                                   */
-  switch ( c ) {
+  // switch according to the character
+  if (IsAlpha(c)) {
+      GetIdent();
+      return;
+  }
 
-  case '.':   STATE(Symbol) = S_DOT;                         c = GET_NEXT_CHAR();
-    if ( c == '.' ) { 
-            STATE(Symbol) = S_DOTDOT; c = GET_NEXT_CHAR();
-            if ( c == '.') {
-                    STATE(Symbol) = S_DOTDOTDOT; c = GET_NEXT_CHAR();
-            }
+  switch (c) {
+  case '.':         STATE(Symbol) = S_DOT;       c = GET_NEXT_CHAR();
+    if (c == '.') { STATE(Symbol) = S_DOTDOT;    c = GET_NEXT_CHAR();
+        if (c == '.') { STATE(Symbol) = S_DOTDOTDOT;
+                                                 c = GET_NEXT_CHAR();
+        }
     }
     break;
 
-  case '!':   STATE(Symbol) = S_ILLEGAL;                     c = GET_NEXT_CHAR();
-    if ( c == '.' ) { STATE(Symbol) = S_BDOT;    GET_NEXT_CHAR();  break; }
-    if ( c == '[' ) { STATE(Symbol) = S_BLBRACK; GET_NEXT_CHAR();  break; }
-    if ( c == '{' ) { STATE(Symbol) = S_BLBRACE; GET_NEXT_CHAR();  break; }
+  case '!':         STATE(Symbol) = S_ILLEGAL;   c = GET_NEXT_CHAR();
+    if (c == '.') { STATE(Symbol) = S_BDOT;          GET_NEXT_CHAR(); break; }
+    if (c == '[') { STATE(Symbol) = S_BLBRACK;       GET_NEXT_CHAR(); break; }
+    if (c == '{') { STATE(Symbol) = S_BLBRACE;       GET_NEXT_CHAR(); break; }
     break;
-  case '[':   STATE(Symbol) = S_LBRACK;                      GET_NEXT_CHAR();  break;
-  case ']':   STATE(Symbol) = S_RBRACK;                      GET_NEXT_CHAR();  break;
-  case '{':   STATE(Symbol) = S_LBRACE;                      GET_NEXT_CHAR();  break;
-  case '}':   STATE(Symbol) = S_RBRACE;                      GET_NEXT_CHAR();  break;
-  case '(':   STATE(Symbol) = S_LPAREN;                      GET_NEXT_CHAR();  break;
-  case ')':   STATE(Symbol) = S_RPAREN;                      GET_NEXT_CHAR();  break;
-  case ',':   STATE(Symbol) = S_COMMA;                       GET_NEXT_CHAR();  break;
+  case '[':         STATE(Symbol) = S_LBRACK;        GET_NEXT_CHAR(); break;
+  case ']':         STATE(Symbol) = S_RBRACK;        GET_NEXT_CHAR(); break;
+  case '{':         STATE(Symbol) = S_LBRACE;        GET_NEXT_CHAR(); break;
+  case '}':         STATE(Symbol) = S_RBRACE;        GET_NEXT_CHAR(); break;
+  case '(':         STATE(Symbol) = S_LPAREN;        GET_NEXT_CHAR(); break;
+  case ')':         STATE(Symbol) = S_RPAREN;        GET_NEXT_CHAR(); break;
+  case ',':         STATE(Symbol) = S_COMMA;         GET_NEXT_CHAR(); break;
 
-  case ':':   STATE(Symbol) = S_COLON;                       c = GET_NEXT_CHAR();
-    if ( c == '=' ) { STATE(Symbol) = S_ASSIGN;  c = GET_NEXT_CHAR(); break; }
-    break;
-
-  case ';':   STATE(Symbol) = S_SEMICOLON;                   c = GET_NEXT_CHAR();
-    if ( c == ';' ) {
-        STATE(Symbol) = S_DUALSEMICOLON; c = GET_NEXT_CHAR();
-    }
+  case ':':         STATE(Symbol) = S_COLON;     c = GET_NEXT_CHAR();
+    if (c == '=') { STATE(Symbol) = S_ASSIGN;        GET_NEXT_CHAR(); break; }
     break;
 
-  case '=':   STATE(Symbol) = S_EQ;                          GET_NEXT_CHAR();  break;
-  case '<':   STATE(Symbol) = S_LT;                          c = GET_NEXT_CHAR();
-    if ( c == '=' ) { STATE(Symbol) = S_LE;      c = GET_NEXT_CHAR();  break; }
-    if ( c == '>' ) { STATE(Symbol) = S_NE;      c = GET_NEXT_CHAR();  break; }
-    break;
-  case '>':   STATE(Symbol) = S_GT;                          c = GET_NEXT_CHAR();
-    if ( c == '=' ) { STATE(Symbol) = S_GE;      c = GET_NEXT_CHAR();  break; }
+  case ';':         STATE(Symbol) = S_SEMICOLON; c = GET_NEXT_CHAR();
+    if (c == ';') { STATE(Symbol) = S_DUALSEMICOLON; GET_NEXT_CHAR(); break; }
     break;
 
-  case '+':   STATE(Symbol) = S_PLUS;                        GET_NEXT_CHAR();  break;
-  case '-':   STATE(Symbol) = S_MINUS;                       c = GET_NEXT_CHAR();
-    if ( c == '>' ) { STATE(Symbol)=S_MAPTO;     c = GET_NEXT_CHAR();  break; }
+  case '=':         STATE(Symbol) = S_EQ;            GET_NEXT_CHAR(); break;
+  case '<':         STATE(Symbol) = S_LT;        c = GET_NEXT_CHAR();
+    if (c == '=') { STATE(Symbol) = S_LE;            GET_NEXT_CHAR(); break; }
+    if (c == '>') { STATE(Symbol) = S_NE;            GET_NEXT_CHAR(); break; }
     break;
-  case '*':   STATE(Symbol) = S_MULT;                        GET_NEXT_CHAR();  break;
-  case '/':   STATE(Symbol) = S_DIV;                         GET_NEXT_CHAR();  break;
-  case '^':   STATE(Symbol) = S_POW;                         GET_NEXT_CHAR();  break;
+  case '>':         STATE(Symbol) = S_GT;        c = GET_NEXT_CHAR();
+    if (c == '=') { STATE(Symbol) = S_GE;            GET_NEXT_CHAR(); break; }
+    break;
 
-  case '"':                                           GetMaybeTripStr();  break;
-  case '\'':                                          GetChar();   break;
-  case '\\':                                          GetIdent();  break;
-  case '_':                                           GetIdent();  break;
-  case '@':                                           GetIdent();  break;
-  case '~':   STATE(Symbol) = S_TILDE;                GET_NEXT_CHAR();  break;
-  case '?':   STATE(Symbol) = S_HELP;                 GetHelp();   break;
+  case '+':         STATE(Symbol) = S_PLUS;          GET_NEXT_CHAR(); break;
+  case '-':         STATE(Symbol) = S_MINUS;     c = GET_NEXT_CHAR();
+    if (c == '>') { STATE(Symbol) = S_MAPTO;         GET_NEXT_CHAR(); break; }
+    break;
+  case '*':         STATE(Symbol) = S_MULT;          GET_NEXT_CHAR(); break;
+  case '/':         STATE(Symbol) = S_DIV;           GET_NEXT_CHAR(); break;
+  case '^':         STATE(Symbol) = S_POW;           GET_NEXT_CHAR(); break;
+
+  case '~':         STATE(Symbol) = S_TILDE;         GET_NEXT_CHAR(); break;
+  case '?':         STATE(Symbol) = S_HELP;          GetHelp(); break;
+  case '"':                                          GetMaybeTripStr(); break;
+  case '\'':                                         GetChar(); break;
+  case '\\':                                         GetIdent(); break;
+  case '_':                                          GetIdent(); break;
+  case '@':                                          GetIdent(); break;
 
   case '0': case '1': case '2': case '3': case '4':
-  case '5': case '6': case '7': case '8': case '9':
-    GetNumber(0);    break;
+  case '5': case '6': case '7': case '8': case '9':  GetNumber(0); break;
 
-  case '\377': STATE(Symbol) = S_EOF;                        *STATE(In) = '\0';  break;
+  case '\377':      STATE(Symbol) = S_EOF;           *STATE(In) = '\0'; break;
 
-  default :   if ( IsAlpha(c) )                   { GetIdent();  break; }
-    STATE(Symbol) = S_ILLEGAL;                     GET_NEXT_CHAR();  break;
+  default:          STATE(Symbol) = S_ILLEGAL;       GET_NEXT_CHAR(); break;
   }
 }
 


### PR DESCRIPTION
Removing the line continuation logic from the scanner enables several ways to simplify the code.

Also, I reformatted `GetSymbol` to restore the manual whitespace alignment it used to have. I know some people prefer to just run `git clang-format`, but IMHO, this much more compact version of the code makes it much easier to see very quickly what's going on, so I think it's worth keeping it. In any case, the current formatting is messed up, so I think this is arguably an improvement either way, and `git clang-format` could still be run in the future if that's really what we want...