### PR TITLE
kernel: change GetNumber to call GetIdent if needed; cleanup GetIdent a bit

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -167,16 +167,15 @@ void Match (
 **  If the characters make up a keyword 'GetIdent' will set 'Symbol' to the
 **  corresponding value. The parser will ignore 'STATE(Value)' in this case.
 **
-**  An  identifier consists of a letter  followed by more letters, digits and
-**  underscores '_'.  An identifier is terminated by the first  character not
-**  in this  class.  The escape sequence '\<newline>'  is ignored,  making it
-**  possible to split  long identifiers  over multiple lines.  The  backslash
-**  '\' can be used  to include special characters like  '('  in identifiers.
-**  For example 'G\(2\,5\)' is an identifier not a call to a function 'G'.
+**  An identifier consists of a letter followed by more letters, digits and
+**  underscores '_'. An identifier is terminated by the first character not
+**  in this class. The backslash '\' can be used to include special
+**  characters like '(' in identifiers. For example 'G\(2\,5\)' is an
+**  identifier not a call to a function 'G'.
 **
 **  The size of 'STATE(Value)' limits the number of significant characters in
-**  an identifier. If an identifier has more characters 'GetIdent' will
-**  silently truncate it.
+**  an identifier. If an identifier has more characters 'GetIdent' truncates
+**  it and signal a syntax error.
 **
 **  After reading the identifier 'GetIdent'  looks at the  first and the last
 **  character of 'STATE(Value)' to see if it could possibly be a keyword. For

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -198,10 +198,7 @@ static void GetIdent(Int i)
     Char c = PEEK_CURR_CHAR();
     for ( ; IsIdent(c) || IsDigit(c) || c=='\\'; i++ ) {
 
-        /* handle escape sequences                                         */
-        /* we ignore '\ newline' by decrementing i, except at the
-           very start of the identifier, when we cannot do that
-           so we recurse instead                                           */
+        // handle escape sequences
         if ( c == '\\' ) {
             c = GET_NEXT_CHAR();
             switch(c) {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -194,12 +194,12 @@ static void GetIdent(Int i)
     // initially it could be a keyword
     Int isQuoted = 0;
 
-    /* read all characters into 'STATE(Value)'                                    */
+    // read all characters into 'STATE(Value)'
     Char c = PEEK_CURR_CHAR();
-    for ( ; IsIdent(c) || IsDigit(c) || c=='\\'; i++ ) {
+    for (; IsIdent(c) || IsDigit(c) || c == '\\'; i++) {
 
         // handle escape sequences
-        if ( c == '\\' ) {
+        if (c == '\\') {
             c = GET_NEXT_CHAR();
             switch(c) {
             case 'n': c = '\n'; break;
@@ -215,12 +215,11 @@ static void GetIdent(Int i)
         if (i < SAFE_VALUE_SIZE - 1)
             STATE(Value)[i] = c;
 
-        /* read the next character                                         */
+        // read the next character
         c = GET_NEXT_CHAR();
-
     }
 
-    /* terminate the identifier and lets assume that it is not a keyword   */
+    // terminate the identifier and lets assume that it is not a keyword
     if (i >= SAFE_VALUE_SIZE-1) {
         SyntaxError("Identifiers in GAP must consist of less than 1023 characters.");
         i = SAFE_VALUE_SIZE-1;
@@ -232,7 +231,7 @@ static void GetIdent(Int i)
     if (isQuoted)
         return;
 
-    /* now check if 'STATE(Value)' holds a keyword                                */
+    // now check if 'STATE(Value)' holds a keyword
     switch ( 256*STATE(Value)[0]+STATE(Value)[i-1] ) {
     case 256*'a'+'d': if(!strcmp(STATE(Value),"and"))     STATE(Symbol)=S_AND;     break;
     case 256*'a'+'c': if(!strcmp(STATE(Value),"atomic"))  STATE(Symbol)=S_ATOMIC;  break;


### PR DESCRIPTION
This contains more refactoring of the scanner, enabled by moving the line continuation code from the scanner into io.

`GetNumber` actually replicated a considerable part of `GetIdent`, but in a slightly inconsistent way. Luckily, this inconsistency only concerned "weird" identifiers which contains non-printable characters `\< = \001`, `\> = \002` and `\c = \003`. So I am confident it doesn't affect regular code (and if you use these chars in your identifiers, I am *happy* if this PR makes you suffer ;-).

Also update some comments in `GetIdent` and reformat it a bit.