### PR TITLE
kernel: remove precords code in ariths.c

### DIFF
--- a/lib/record.gi
+++ b/lib/record.gi
@@ -135,18 +135,6 @@ InstallMethod( ViewObj,
     Print(" \<\<\<\<)");
 end);
 
-InstallMethod( \=,
-               "record = record",
-               IsIdenticalObj,
-               [ IsRecord, IsRecord ],
-               EQ_PREC );
-
-InstallMethod( \<,
-               "record < record",
-               IsIdenticalObj,
-               [ IsRecord, IsRecord ],
-               LT_PREC );
-
 
 # methods to catch error cases
 

--- a/src/ariths.c
+++ b/src/ariths.c
@@ -80,8 +80,6 @@ void InstallZeroObject ( Int verb )
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
         ZeroFuncs[t1] = func;
     }
-    ZeroFuncs[ T_PREC            ] = func;
-    ZeroFuncs[ T_PREC +IMMUTABLE ] = func;
 }
 
 
@@ -152,8 +150,6 @@ void InstallZeroMutObject ( Int verb )
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
         ZeroMutFuncs[t1] = func;
     }
-    ZeroMutFuncs[ T_PREC            ] = func;
-    ZeroMutFuncs[ T_PREC +IMMUTABLE ] = func;
 }
 
 
@@ -226,8 +222,6 @@ void InstallAinvObject ( Int verb )
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
         AInvFuncs[t1] = func;
     }
-    AInvFuncs[ T_PREC            ] = func;
-    AInvFuncs[ T_PREC +IMMUTABLE ] = func;
 }
 
 
@@ -289,8 +283,6 @@ void InstallAinvMutObject ( Int verb )
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
         AInvMutFuncs[t1] = func;
     }
-    AInvMutFuncs[ T_PREC            ] = func;
-    AInvMutFuncs[ T_PREC +IMMUTABLE ] = func;
 }
 
 
@@ -360,8 +352,6 @@ void InstallOneObject ( Int verb )
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
         OneFuncs[t1] = func;
     }
-    OneFuncs[ T_PREC            ] = func;
-    OneFuncs[ T_PREC +IMMUTABLE ] = func;
 }
 
 
@@ -430,8 +420,6 @@ void InstallOneMutObject ( Int verb )
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
         OneMutFuncs[t1] = func;
     }
-    OneMutFuncs[ T_PREC            ] = func;
-    OneMutFuncs[ T_PREC +IMMUTABLE ] = func;
 }
 
 
@@ -501,8 +489,6 @@ void InstallInvObject ( Int verb )
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
         InvFuncs[t1] = func;
     }
-    InvFuncs[ T_PREC            ] = func;
-    InvFuncs[ T_PREC +IMMUTABLE ] = func;
 }
 
 
@@ -572,8 +558,6 @@ void InstallInvMutObject ( Int verb )
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
         InvMutFuncs[t1] = func;
     }
-    InvMutFuncs[ T_PREC            ] = func;
-    InvMutFuncs[ T_PREC +IMMUTABLE ] = func;
 }
 
 
@@ -656,13 +640,6 @@ void InstallEqObject ( Int verb )
             EqFuncs[t2][t1] = func;
         }
     }
-    for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-
-        EqFuncs[ t2 ][ T_PREC            ] = func;
-        EqFuncs[ t2 ][ T_PREC +IMMUTABLE ] = func;
-        EqFuncs[ T_PREC            ][ t2 ] = func;
-        EqFuncs[ T_PREC +IMMUTABLE ][ t2 ] = func;
-    }
 }
 
 
@@ -735,13 +712,6 @@ void InstallLtObject ( Int verb )
             LtFuncs[t1][t2] = func;
             LtFuncs[t2][t1] = func;
         }
-    }
-    for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-
-        LtFuncs[ t2 ][ T_PREC            ] = func;
-        LtFuncs[ t2 ][ T_PREC +IMMUTABLE ] = func;
-        LtFuncs[ T_PREC            ][ t2 ] = func;
-        LtFuncs[ T_PREC +IMMUTABLE ][ t2 ] = func;
     }
 }
 
@@ -825,11 +795,6 @@ void InstallInObject ( Int verb )
             InFuncs[t2][t1] = func;
         }
     }
-    for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-
-        InFuncs[ t2 ][ T_PREC            ] = func;
-        InFuncs[ t2 ][ T_PREC +IMMUTABLE ] = func;
-    }
 }
 
 
@@ -910,13 +875,6 @@ void InstallSumObject ( Int verb )
             SumFuncs[t1][t2] = func;
             SumFuncs[t2][t1] = func;
         }
-    }
-    for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM; t2++ ) {
-
-        SumFuncs[ t2 ][ T_PREC            ] = func;
-        SumFuncs[ t2 ][ T_PREC +IMMUTABLE ] = func;
-        SumFuncs[ T_PREC            ][ t2 ] = func;
-        SumFuncs[ T_PREC +IMMUTABLE ][ t2 ] = func;
     }
 }
 
@@ -1009,13 +967,6 @@ void InstallDiffObject ( Int verb )
             DiffFuncs[t2][t1] = func;
         }
     }
-    for ( t2 = FIRST_REAL_TNUM; t2 <= LAST_REAL_TNUM; t2++ ) {
-
-        DiffFuncs[ t2 ][ T_PREC            ] = func;
-        DiffFuncs[ t2 ][ T_PREC +IMMUTABLE ] = func;
-        DiffFuncs[ T_PREC            ][ t2 ] = func;
-        DiffFuncs[ T_PREC +IMMUTABLE ][ t2 ] = func;
-    }
 }
 
 
@@ -1107,13 +1058,6 @@ void InstallProdObject ( Int verb )
             ProdFuncs[t2][t1] = func;
         }
     }
-    for ( t2 = FIRST_REAL_TNUM; t2 <= LAST_REAL_TNUM; t2++ ) {
-
-        ProdFuncs[ t2 ][ T_PREC            ] = func;
-        ProdFuncs[ t2 ][ T_PREC +IMMUTABLE ] = func;
-        ProdFuncs[ T_PREC            ][ t2 ] = func;
-        ProdFuncs[ T_PREC +IMMUTABLE ][ t2 ] = func;
-    }
 }
 
 
@@ -1203,13 +1147,6 @@ void InstallQuoObject ( Int verb )
             QuoFuncs[t1][t2] = func;
             QuoFuncs[t2][t1] = func;
         }
-    }
-    for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-
-        QuoFuncs[ t2 ][ T_PREC            ] = func;
-        QuoFuncs[ t2 ][ T_PREC +IMMUTABLE ] = func;
-        QuoFuncs[ T_PREC            ][ t2 ] = func;
-        QuoFuncs[ T_PREC +IMMUTABLE ][ t2 ] = func;
     }
 }
 
@@ -1316,12 +1253,6 @@ void InstallLQuoObject ( Int verb )
             LQuoFuncs[t2][t1] = func;
         }
     }
-    for ( t2 = FIRST_REAL_TNUM; t2 <= LAST_REAL_TNUM; t2++ ) {
-        LQuoFuncs[ t2 ][ T_PREC            ] = func;
-        LQuoFuncs[ t2 ][ T_PREC +IMMUTABLE ] = func;
-        LQuoFuncs[ T_PREC            ][ t2 ] = func;
-        LQuoFuncs[ T_PREC +IMMUTABLE ][ t2 ] = func;
-    }
 }
 
 
@@ -1427,13 +1358,6 @@ void InstallPowObject ( Int verb )
             PowFuncs[t1][t2] = func;
             PowFuncs[t2][t1] = func;
         }
-    }
-    for ( t2 = FIRST_REAL_TNUM; t2 <= LAST_REAL_TNUM; t2++ ) {
-
-        PowFuncs[ t2 ][ T_PREC            ] = func;
-        PowFuncs[ t2 ][ T_PREC +IMMUTABLE ] = func;
-        PowFuncs[ T_PREC            ][ t2 ] = func;
-        PowFuncs[ T_PREC +IMMUTABLE ][ t2 ] = func;
     }
 }
 
@@ -1542,13 +1466,6 @@ void InstallCommObject ( Int verb )
             CommFuncs[t2][t1] = func;
         }
     }
-    for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-
-        CommFuncs[ t2 ][ T_PREC            ] = func;
-        CommFuncs[ t2 ][ T_PREC +IMMUTABLE ] = func;
-        CommFuncs[ T_PREC            ][ t2 ] = func;
-        CommFuncs[ T_PREC +IMMUTABLE ][ t2 ] = func;
-    }
 }
 
 
@@ -1640,13 +1557,6 @@ void InstallModObject ( Int verb )
             ModFuncs[t1][t2] = func;
             ModFuncs[t2][t1] = func;
         }
-    }
-    for ( t2 = FIRST_REAL_TNUM; t2 <= LAST_REAL_TNUM; t2++ ) {
-
-        ModFuncs[ t2 ][ T_PREC            ] = func;
-        ModFuncs[ t2 ][ T_PREC +IMMUTABLE ] = func;
-        ModFuncs[ T_PREC            ][ t2 ] = func;
-        ModFuncs[ T_PREC +IMMUTABLE ][ t2 ] = func;
     }
 }
 

--- a/src/precord.c
+++ b/src/precord.c
@@ -683,7 +683,6 @@ Obj FuncREC_NAMES_COMOBJ (
 /****************************************************************************
 **
 *F  EqPRec( <self>, <left>, <right> ) . . . . . . . comparison of two records
-*F  FuncEQ_PREC( <self>, <left>, <right> )  . . . . comparison of two records
 **
 **  'EqPRec' returns '1L'  if the two  operands <left> and <right> are equal
 **  and '0L' otherwise.  At least one operand must be a plain record.
@@ -728,16 +727,9 @@ Int EqPRec(Obj left, Obj right)
 }
 
 
-Obj FuncEQ_PREC(Obj self, Obj left, Obj right)
-{
-    return EqPRec(left, right) ? True : False;
-}
-
-
 /****************************************************************************
 **
 *F  LtPRec( <self>, <left>, <right> ) . . . . . . . comparison of two records
-*F  FuncLT_PREC( <self>, <left>, <right> )  . . . . comparison of two records
 **
 **  'LtPRec' returns '1L'  if the operand  <left> is  less than the  operand
 **  <right>, and '0L'  otherwise.  At least  one operand  must be a  plain
@@ -790,12 +782,6 @@ Int LtPRec(Obj left, Obj right)
     /* the records are equal or the right is a prefix of the left          */
     DecRecursionDepth();
     return res;
-}
-
-
-Obj FuncLT_PREC(Obj self, Obj left, Obj right)
-{
-    return LtPRec(left, right) ? True : False;
 }
 
 
@@ -863,8 +849,6 @@ static StructGVarFunc GVarFuncs [] = {
 
     GVAR_FUNC(REC_NAMES, 1, "rec"),
     GVAR_FUNC(REC_NAMES_COMOBJ, 1, "rec"),
-    GVAR_FUNC(EQ_PREC, 2, "left, right"),
-    GVAR_FUNC(LT_PREC, 2, "left, right"),
     { 0, 0, 0, 0, 0 }
 
 };

--- a/tst/testinstall/recordname.tst
+++ b/tst/testinstall/recordname.tst
@@ -46,14 +46,6 @@ gap> REC_NAMES( () );
 Error, RecNames: <rec> must be a record (not a permutation (small))
 gap> REC_NAMES_COMOBJ( () );
 Error, RecNames: <rec> must be a component object (not a permutation (small))
-gap> EQ_PREC( rec(), () );
-false
-gap> EQ_PREC( (), rec() );
-false
-gap> LT_PREC( rec(), () );
-false
-gap> LT_PREC( (), rec() );
-true
 gap> rec() < rec(x := 1);
 true
 gap> rec(x := 1) = rec(x := 2);


### PR DESCRIPTION
The functions `InstallOneObject`, `InstallSumObject`, etc. are meant to
switch between normal and verbose operations for arithmetic operations
on external objects (i.e. positional and component objects, as well as
datobjs, weakpointer objects and possibly those provided by kernel
extensions in packages).

But for some reason, they also did that for precords. My guess is that
this was for backwards compatibility for GAP3 code, but AFAIK we removed
most of that elsewhere, so this code in ariths.c doesn't seem to serve a
purpose anymore; hence we remove it.

Note that even if my understanding is flawed, the impact of this change
should be harmless: It only affects tracing of such methods, but not
their actual use.

Nevertheless, I'd be grateful if people who've been around back then (Steve, Frank, Thomas) could have a look and possibly comment. Thanks!

For context, I just dug out the commit adding these lines:
```
Author: Frank Celler
Date:   1997-05-30 11:32:30 +0000

    started to rewritte record to allow method selection
```
