### PR TITLE
WIP: refactor scanner and reader

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -1956,6 +1956,7 @@ void CodeLongFloatExpr(Obj s)
         CodeEagerFloatExpr(s, mark);
     }
     else {
+        // FIXME: this is not GC safe
         CodeLazyFloatExpr(str, l);
     }
 }

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1737,13 +1737,13 @@ void            IntrPow ( void )
 **  'IntrIntExpr' is the action  to  interpret a literal  integer expression.
 **  <str> is the integer as a (null terminated) C character string.
 */
-void IntrIntExpr(Char * str)
+void IntrIntExpr(Obj string, Char * str)
 {
     /* ignore or code                                                      */
     if ( STATE(IntrReturning) > 0 ) { return; }
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
     
-    Obj val = IntStringInternal(0, str);
+    Obj val = IntStringInternal(string, str);
     GAP_ASSERT(val != Fail);
 
     if (STATE(IntrCoding) > 0) {
@@ -1755,30 +1755,6 @@ void IntrIntExpr(Char * str)
     }
 }
 
-
-/****************************************************************************
-**
-*F  IntrLongIntExpr(<str>)   .  .  interpret literal long integer expression
-**
-**  'IntrLongIntExpr' is the action to  interpret a long literal integer
-**  expression whose digits are stored in a string GAP object.
-*/
-void IntrLongIntExpr(Obj string)
-{
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
-
-    Obj val = IntStringInternal(string, 0);
-    GAP_ASSERT(val != Fail);
-
-    if (STATE(IntrCoding) > 0) {
-        CodeIntExpr(val);
-    }
-    else {
-        // push the integer value
-        PushObj(val);
-    }
-}
 
 /****************************************************************************
 **
@@ -1810,38 +1786,24 @@ static Obj ConvertFloatLiteralEager(Obj str)
     return res;
 }
 
-void            IntrFloatExpr (
-    Char *              str )
-{
-    Obj                 val;
-
-    /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
-    if ( STATE(IntrCoding)    > 0 ) {  CodeFloatExpr( str );   return; }
-
-    val = MakeString(str);
-    PushObj(ConvertFloatLiteralEager(val));
-}
-
-
-/****************************************************************************
-**
-*F  IntrLongFloatExpr(<str>)   .  .  interpret literal long float expression
-**
-**  'IntrLongFloatExpr' is the action to  interpret a long literal float
-**  expression whose digits are stored in a string GAP object.
-*/
-void            IntrLongFloatExpr (
-    Obj               string )
+void IntrFloatExpr(Obj string, Char * str)
 {
     /* ignore or code                                                      */
     if ( STATE(IntrReturning) > 0 ) { return; }
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
-    if ( STATE(IntrCoding)    > 0 ) { CodeLongFloatExpr( string );  return; }
+    if ( STATE(IntrCoding)    > 0 ) {
+        if (string)
+            CodeLongFloatExpr(string);
+        else
+            CodeFloatExpr( str );
+        return;
+    }
 
+    if (string == 0)
+        string = MakeString(str);
     PushObj(ConvertFloatLiteralEager(string));
 }
+
 
 /****************************************************************************
 **

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -542,17 +542,20 @@ extern  void            IntrPow ( void );
 
 /****************************************************************************
 **
+*F  IntrIntObjExpr(<val>)
+*/
+extern void IntrIntObjExpr(Obj val);
+
+
+/****************************************************************************
+**
 *F  IntrIntExpr(<str>)  . . . . . . . .  interpret literal integer expression
 **
 **  'IntrIntExpr' is the action  to  interpret a literal  integer expression.
 **  <str> is the integer as a (null terminated) C character string.
 */
+extern void IntrIntExpr(Obj string, Char * str);
 
-extern void             IntrIntObjExpr(Obj val);
-extern  void            IntrIntExpr (
-            Char *              str );
-extern  void            IntrLongIntExpr (
-            Obj                 string );
 
 /****************************************************************************
 **
@@ -561,10 +564,8 @@ extern  void            IntrLongIntExpr (
 **  'IntrFloatExpr' is the action  to  interpret a literal  float expression.
 **  <str> is the float as a (null terminated) C character string.
 */
-extern  void            IntrFloatExpr (
-            Char *              str );
-extern  void            IntrLongFloatExpr (
-            Obj                 string );
+extern void IntrFloatExpr(Obj string, Char * str);
+
 
 /****************************************************************************
 **

--- a/src/io.c
+++ b/src/io.c
@@ -218,10 +218,7 @@ Char GET_NEXT_CHAR(void)
 
         // if we get here, we saw a line continuation; change the prompt to a
         // partial prompt from now on
-        if (!SyQuiet)
-            STATE(Prompt) = "> ";
-        else
-            STATE(Prompt) = "";
+        STATE(Prompt) = SyQuiet ? "" : "> ";
     }
 
     return *STATE(In);

--- a/src/read.c
+++ b/src/read.c
@@ -2499,6 +2499,8 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     int                 lockSP;
 #endif
 
+    STATE(NrError) = 0;
+
     /* get the first symbol from the input                                 */
     Match( STATE(Symbol), "", 0UL );
 
@@ -2624,6 +2626,8 @@ UInt ReadEvalFile(Obj *evalResult)
 #ifdef HPCGAP
     volatile int        lockSP;
 #endif
+
+    STATE(NrError) = 0;
 
     /* get the first symbol from the input                                 */
     Match( STATE(Symbol), "", 0UL );

--- a/src/read.c
+++ b/src/read.c
@@ -2511,10 +2511,7 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     if ( STATE(Symbol) == S_EOF )  { return STATUS_EOF; }
 
     /* print only a partial prompt from now on                             */
-    if ( !SyQuiet )
-      STATE(Prompt) = "> ";
-    else
-      STATE(Prompt) = "";
+    STATE(Prompt) = SyQuiet ? "" : "> ";
 
     /* remember the old reader context                                     */
     stackNams   = STATE(StackNams);
@@ -2635,10 +2632,7 @@ UInt ReadEvalFile(Obj *evalResult)
     if ( STATE(Symbol) == S_EOF )  { return STATUS_EOF; }
 
     /* print only a partial prompt from now on                             */
-    if ( !SyQuiet )
-      STATE(Prompt) = "> ";
-    else
-      STATE(Prompt) = "";
+    STATE(Prompt) = SyQuiet ? "" : "> ";
 
     /* remember the old reader context                                     */
     stackNams   = STATE(StackNams);

--- a/src/read.c
+++ b/src/read.c
@@ -1321,7 +1321,7 @@ void ReadRecExpr (
 **  ArgList represents the return value of ReadFuncArgList
 */
 typedef struct {
-    Int        narg;           /* number of arguments             */
+    UInt       narg;           /* number of arguments             */
     Obj        nams;           /* list of local variables names   */
     UInt       isvarg;         /* does function have varargs?     */
 #ifdef HPCGAP
@@ -1501,6 +1501,40 @@ static void ReadFuncExprBody(
 
 /****************************************************************************
 **
+*F  ReadLocals( <follow> )
+*/
+static UInt ReadLocals(TypSymbolSet follow, Obj nams, UInt narg)
+{
+    UInt nloc = 0;
+
+    Match( S_LOCAL, "local", follow );
+    goto start;
+    while ( STATE(Symbol) == S_COMMA ) {
+        /* init to avoid strange message in case of empty string */
+        STATE(Value)[0] = '\0';
+        Match( S_COMMA, ",", follow );
+        if (findValueInNams(nams, narg + 1, narg + nloc)) {
+            SyntaxError("Name used for two locals");
+        }
+    start:
+        if (STATE(Symbol) == S_IDENT &&
+            findValueInNams(nams, 1, narg)) {
+            SyntaxError("Name used for argument and local");
+        }
+        nloc += 1;
+        PushPlist(nams, MakeImmString(STATE(Value)));
+        if (LEN_PLIST(nams) >= 65536) {
+            SyntaxError("Too many function arguments and locals");
+        }
+        Match( S_IDENT, "identifier", STATBEGIN|S_END|follow );
+    }
+    MatchSemicolon(STATBEGIN | S_END | follow);
+
+    return nloc;
+}
+
+/****************************************************************************
+**
 *F  ReadFuncExpr( <follow> )  . . . . . . . . . .  read a function definition
 **
 **  'ReadFuncExpr' reads a function literal expression.  In  case of an error
@@ -1515,10 +1549,10 @@ void ReadFuncExpr (
     TypSymbolSet        follow,
     Char mode)
 {
-    volatile Int        startLine;      /* line number of function keyword */
-    volatile int        is_atomic = 0;  /* is this an atomic function?      */
-    volatile UInt       nloc = 0;       /* number of locals                */
-    volatile ArgList    args;
+    Int        startLine;      /* line number of function keyword */
+    int        is_atomic = 0;  /* is this an atomic function?      */
+    UInt       nloc = 0;       /* number of locals                */
+    ArgList    args;
 
     /* begin the function               */
     startLine = GetInputLineNumber();
@@ -1536,28 +1570,7 @@ void ReadFuncExpr (
     args = ReadFuncArgList(follow, is_atomic, S_RPAREN, ")");
 
     if ( STATE(Symbol) == S_LOCAL ) {
-        Match( S_LOCAL, "local", follow );
-        goto start;
-        while ( STATE(Symbol) == S_COMMA ) {
-            /* init to avoid strange message in case of empty string */
-            STATE(Value)[0] = '\0';
-            Match( S_COMMA, ",", follow );
-            if (findValueInNams(args.nams, args.narg + 1, args.narg + nloc)) {
-                SyntaxError("Name used for two locals");
-            }
-        start:
-            if (STATE(Symbol) == S_IDENT &&
-                findValueInNams(args.nams, 1, args.narg)) {
-                SyntaxError("Name used for argument and local");
-            }
-            nloc += 1;
-            PushPlist(args.nams, MakeImmString(STATE(Value)));
-            if (LEN_PLIST(args.nams) >= 65536) {
-                SyntaxError("Too many function arguments and locals");
-            }
-            Match( S_IDENT, "identifier", STATBEGIN|S_END|follow );
-        }
-        MatchSemicolon(STATBEGIN | S_END | follow);
+        nloc = ReadLocals(follow, args.nams, args.narg);
     }
 
     ReadFuncExprBody(follow, 0, nloc, args, startLine);
@@ -2889,24 +2902,7 @@ UInt ReadEvalFile(Obj *evalResult)
     PushPlist( STATE(StackNams), nams );
     nloc = 0;
     if ( STATE(Symbol) == S_LOCAL ) {
-        Match( S_LOCAL, "local", 0L );
-        nloc += 1;
-        PushPlist(nams, MakeImmString(STATE(Value)));
-        Match( S_IDENT, "identifier", STATBEGIN|S_END );
-        while ( STATE(Symbol) == S_COMMA ) {
-            STATE(Value)[0] = '\0';
-            Match( S_COMMA, ",", 0L );
-            if (findValueInNams(nams, 1, nloc)) {
-                SyntaxError("Name used for two locals");
-            }
-            nloc += 1;
-            PushPlist(nams, MakeImmString(STATE(Value)));
-            if (LEN_PLIST(nams) >= 65536) {
-                SyntaxError("Too many locals");
-            }
-            Match( S_IDENT, "identifier", STATBEGIN|S_END );
-        }
-        MatchSemicolon(STATBEGIN | S_END);
+        nloc = ReadLocals(0, nams, 0);
     }
 
     /* fake the 'function ()'                                              */

--- a/src/read.c
+++ b/src/read.c
@@ -1446,23 +1446,13 @@ static void ReadLiteral (
 
     /* <Int>                                                               */
     case S_INT:
-        TRY_READ {
-            if (STATE(ValueObj))
-                IntrLongIntExpr(STATE(ValueObj));
-            else
-                IntrIntExpr(STATE(Value));
-        }
+        TRY_READ { IntrIntExpr(STATE(ValueObj), STATE(Value)); }
         Match( S_INT, "integer", follow );
         break;
 
     /* <Float> */
     case S_FLOAT:
-        TRY_READ {
-            if (STATE(ValueObj))
-                IntrLongFloatExpr(STATE(ValueObj));
-            else
-                IntrFloatExpr(STATE(Value));
-        }
+        TRY_READ { IntrFloatExpr(STATE(ValueObj), STATE(Value)); }
         Match( S_FLOAT, "float", follow );
         break;
 

--- a/src/read.c
+++ b/src/read.c
@@ -1513,18 +1513,19 @@ static UInt ReadLocals(TypSymbolSet follow, Obj nams, UInt narg)
         /* init to avoid strange message in case of empty string */
         STATE(Value)[0] = '\0';
         Match( S_COMMA, ",", follow );
-        if (findValueInNams(nams, narg + 1, narg + nloc)) {
-            SyntaxError("Name used for two locals");
-        }
+        if (STATE(Symbol) == S_IDENT) {
+            if (findValueInNams(nams, narg + 1, narg + nloc)) {
+                SyntaxError("Name used for two locals");
+            }
     start:
-        if (STATE(Symbol) == S_IDENT &&
-            findValueInNams(nams, 1, narg)) {
-            SyntaxError("Name used for argument and local");
-        }
-        nloc += 1;
-        PushPlist(nams, MakeImmString(STATE(Value)));
-        if (LEN_PLIST(nams) >= 65536) {
-            SyntaxError("Too many function arguments and locals");
+            if (findValueInNams(nams, 1, narg)) {
+                SyntaxError("Name used for argument and local");
+            }
+            nloc += 1;
+            PushPlist(nams, MakeImmString(STATE(Value)));
+            if (LEN_PLIST(nams) >= 65536) {
+                SyntaxError("Too many function arguments and locals");
+            }
         }
         Match( S_IDENT, "identifier", STATBEGIN|S_END|follow );
     }

--- a/src/read.c
+++ b/src/read.c
@@ -81,17 +81,17 @@
 **  is <Statements>. The functions 'ReadExpr' and 'ReadStats' must therefore
 **  be declared forward.
 */
-void            ReadExpr (
+static void            ReadExpr (
     TypSymbolSet        follow,
     Char                mode );
 
-UInt            ReadStats (
+static UInt            ReadStats (
     TypSymbolSet        follow );
 
-void            ReadFuncExprAbbrevSingle (
+static void            ReadFuncExprAbbrevSingle (
     TypSymbolSet        follow );
 
-void ReadAtom (
+static void ReadAtom (
     TypSymbolSet        follow,
     Char                mode );
 
@@ -111,7 +111,7 @@ void PopGlobalForLoopVariable( void )
   STATE(CurrentGlobalForLoopDepth)--;
 }
 
-UInt GlobalComesFromEnclosingForLoop (UInt var)
+static UInt GlobalComesFromEnclosingForLoop (UInt var)
 {
   UInt i;
   for (i = 0; i < STATE(CurrentGlobalForLoopDepth); i++)
@@ -161,7 +161,7 @@ static UInt findValueInNams(Obj nams, UInt start, UInt end)
 
    empty options lists are handled further up
 */
-void ReadFuncCallOption( TypSymbolSet follow )
+static void ReadFuncCallOption( TypSymbolSet follow )
 {
   volatile UInt       rnam;           /* record component name           */
   if ( STATE(Symbol) == S_IDENT ) {
@@ -190,7 +190,7 @@ void ReadFuncCallOption( TypSymbolSet follow )
     }
 }
 
-void ReadFuncCallOptions( TypSymbolSet follow )
+static void ReadFuncCallOptions( TypSymbolSet follow )
 {
   volatile UInt nr;
   TRY_READ { IntrFuncCallOptionsBegin( ); }
@@ -267,7 +267,7 @@ typedef struct {
 /****************************************************************************
 **
 */
-UInt EvalRef(const LHSRef ref, Int needExpr)
+static UInt EvalRef(const LHSRef ref, Int needExpr)
 {
     TRY_READ
     {
@@ -335,7 +335,7 @@ UInt EvalRef(const LHSRef ref, Int needExpr)
     return 0;
 }
 
-void AssignRef(const LHSRef ref)
+static void AssignRef(const LHSRef ref)
 {
     TRY_READ
     {
@@ -398,7 +398,7 @@ void AssignRef(const LHSRef ref)
     }
 }
 
-void UnbindRef(const LHSRef ref)
+static void UnbindRef(const LHSRef ref)
 {
     volatile enum REFTYPE type = ref.type;
     if (type != R_DVAR && ref.level > 0)
@@ -448,7 +448,7 @@ void UnbindRef(const LHSRef ref)
     }
 }
 
-void IsBoundRef(const LHSRef ref)
+static void IsBoundRef(const LHSRef ref)
 {
     volatile enum REFTYPE type = ref.type;
     if (type != R_DVAR && ref.level > 0)
@@ -502,7 +502,7 @@ void IsBoundRef(const LHSRef ref)
 /****************************************************************************
 **
 */
-LHSRef ReadSelector(TypSymbolSet follow, UInt level)
+static LHSRef ReadSelector(TypSymbolSet follow, UInt level)
 {
     volatile LHSRef ref;
 
@@ -621,7 +621,7 @@ LHSRef ReadSelector(TypSymbolSet follow, UInt level)
     return ref;
 }
 
-void ReadReferenceModifiers(TypSymbolSet follow)
+static void ReadReferenceModifiers(TypSymbolSet follow)
 {
     UInt level = 0;
 
@@ -641,7 +641,7 @@ void ReadReferenceModifiers(TypSymbolSet follow)
 **
 **  <Ident> :=  a|b|..|z|A|B|..|Z { a|b|..|z|A|B|..|Z|0|..|9|_ }
 */
-LHSRef ReadVar(TypSymbolSet follow)
+static LHSRef ReadVar(TypSymbolSet follow)
 {
     LHSRef ref = { .type = R_INVALID, .var = 0, .nest0 = 0 };
 
@@ -757,7 +757,7 @@ LHSRef ReadVar(TypSymbolSet follow)
 **        |  <Var> '.' <Ident>
 **        |  <Var> '(' [ <Expr> { ',' <Expr> } ] [':' [ <options> ]] ')'
 */
-void ReadCallVarAss(TypSymbolSet follow, Char mode)
+static void ReadCallVarAss(TypSymbolSet follow, Char mode)
 {
     volatile LHSRef ref = ReadVar(follow);
     if (ref.type == R_INVALID)
@@ -871,7 +871,7 @@ void ReadCallVarAss(TypSymbolSet follow, Char mode)
 **
 **  <Atom> := 'IsBound' '(' <Var> ')'
 */
-void            ReadIsBound (
+static void            ReadIsBound (
     TypSymbolSet        follow )
 {
     Match( S_ISBOUND, "IsBound", follow );
@@ -895,7 +895,7 @@ void            ReadIsBound (
 **  <Perm> :=  ( <Expr> {, <Expr>} ) { ( <Expr> {, <Expr>} ) }
 **
 */
-void ReadPerm (
+static void ReadPerm (
     TypSymbolSet        follow )
 {
     volatile UInt       nrc;            /* number of cycles                */
@@ -1167,7 +1167,7 @@ void ReadLongNumber(
 **  <List> := '[' [ <Expr> ] {',' [ <Expr> ] } ']'
 **         |  '[' <Expr> [',' <Expr>] '..' <Expr> ']'
 */
-void ReadListExpr (
+static void ReadListExpr (
     TypSymbolSet        follow )
 {
     volatile UInt       pos;            /* actual position of element      */
@@ -1253,7 +1253,7 @@ void ReadListExpr (
 **
 **  <Record> := 'rec( [ <Ident>:=<Expr> {, <Ident>:=<Expr> } ] )'
 */
-void ReadRecExpr (
+static void ReadRecExpr (
     TypSymbolSet        follow )
 {
     volatile UInt       rnam;           /* record component name           */
@@ -1349,7 +1349,7 @@ typedef struct {
 **  responsible for reading the closing bracket.
 */
 
-ArgList ReadFuncArgList(
+static ArgList ReadFuncArgList(
     TypSymbolSet        follow,
     Int is_atomic,
     UInt symbol,
@@ -1546,7 +1546,7 @@ static UInt ReadLocals(TypSymbolSet follow, Obj nams, UInt narg)
 **                             <Statements>
 **                'end'
 */
-void ReadFuncExpr (
+static void ReadFuncExpr (
     TypSymbolSet        follow,
     Char mode)
 {
@@ -1591,7 +1591,7 @@ void ReadFuncExpr (
 **
 **      <Function>      := '{' <ArgList> '}' '->' <Expr>
 */
-void ReadFuncExprAbbrevMulti(TypSymbolSet follow)
+static void ReadFuncExprAbbrevMulti(TypSymbolSet follow)
 {
     Match( S_LBRACE, "{", follow );
 
@@ -1613,7 +1613,7 @@ void ReadFuncExprAbbrevMulti(TypSymbolSet follow)
 **
 **      <Function>      := <Var> '->' <Expr>
 */
-void ReadFuncExprAbbrevSingle(TypSymbolSet follow)
+static void ReadFuncExprAbbrevSingle(TypSymbolSet follow)
 {
     /* make and push the new local variables list                          */
     Obj nams = NEW_PLIST(T_PLIST, 1);
@@ -1657,7 +1657,7 @@ void ReadFuncExprAbbrevSingle(TypSymbolSet follow)
 **
 **  <String>  := " { <any character> } "
 */
-void ReadLiteral (
+static void ReadLiteral (
     TypSymbolSet        follow,
     Char mode)
 {
@@ -1771,7 +1771,7 @@ static const UInt LiteralExprStateMask =
                           S_TILDE|S_REC|S_FUNCTION|
                           S_ATOMIC|S_FLOAT|S_DOT|S_MAPTO;
 
-void ReadAtom (
+static void ReadAtom (
     TypSymbolSet        follow,
     Char                mode )
 {
@@ -1823,7 +1823,7 @@ void ReadAtom (
 **
 **  <Factor> := {'+'|'-'} <Atom> [ '^' {'+'|'-'} <Atom> ]
 */
-void ReadFactor (
+static void ReadFactor (
     TypSymbolSet        follow,
     Char                mode )
 {
@@ -1887,7 +1887,7 @@ void ReadFactor (
 **
 **  <Term> := <Factor> { '*'|'/'|'mod' <Factor> }
 */
-void ReadTerm (
+static void ReadTerm (
     TypSymbolSet        follow,
     Char                mode )
 {
@@ -1920,7 +1920,7 @@ void ReadTerm (
 **
 **  <Arith> := <Term> { '+'|'-' <Term> }
 */
-void ReadAri (
+static void ReadAri (
     TypSymbolSet        follow,
     Char                mode )
 {
@@ -1951,7 +1951,7 @@ void ReadAri (
 **
 **  <Rel> := { 'not' } <Arith> { '=|<>|<|>|<=|>=|in' <Arith> }
 */
-void ReadRel (
+static void ReadRel (
     TypSymbolSet        follow,
     Char                mode )
 {
@@ -2000,7 +2000,7 @@ void ReadRel (
 **
 **  <And> := <Rel> { 'and' <Rel> }
 */
-void ReadAnd (
+static void ReadAnd (
     TypSymbolSet        follow,
     Char                mode )
 {
@@ -2030,7 +2030,7 @@ void ReadAnd (
 **  These functions only do something meaningful inside HPC-GAP; in plain GAP,
 **  they are simply placeholders.
 */
-void ReadQualifiedExpr (
+static void ReadQualifiedExpr (
     TypSymbolSet        follow,
     Char                mode )
 {
@@ -2072,7 +2072,7 @@ void ReadQualifiedExpr (
 **
 **
 */
-void ReadExpr (
+static void ReadExpr (
     TypSymbolSet        follow,
     Char                mode )
 {
@@ -2098,7 +2098,7 @@ void ReadExpr (
 **
 **  <Statement> := 'Unbind' '(' <Var> ')' ';'
 */
-void ReadUnbind (
+static void ReadUnbind (
     TypSymbolSet        follow )
 {
     Match( S_UNBIND, "Unbind", follow );
@@ -2116,7 +2116,7 @@ void ReadUnbind (
 **
 **  <Statement> :=  ';'
 */
-void ReadEmpty (
+static void ReadEmpty (
     TypSymbolSet        follow )
 {
   IntrEmpty();
@@ -2131,7 +2131,7 @@ void ReadEmpty (
 **
 **  <Statement> := 'Info' '(' <Expr> ',' <Expr> { ',' <Expr> } ')' ';'
 */
-void ReadInfo (
+static void ReadInfo (
     TypSymbolSet        follow )
 {
     volatile UInt       narg;     /* number of arguments to print (or not)  */
@@ -2163,7 +2163,7 @@ void ReadInfo (
 **
 **  <Statement> := 'Assert' '(' <Expr> ',' <Expr> [ ',' <Expr> ]  ')' ';'
 */
-void ReadAssert (
+static void ReadAssert (
     TypSymbolSet        follow )
 {
     TRY_READ { IntrAssertBegin(); }
@@ -2200,7 +2200,7 @@ void ReadAssert (
 **                 [ 'else'               <Statements> ]
 **                 'fi' ';'
 */
-void ReadIf (
+static void ReadIf (
     TypSymbolSet        follow )
 {
     volatile UInt       nrb;            /* number of branches              */
@@ -2255,7 +2255,7 @@ void ReadIf (
 */
 
 
-void ReadFor (
+static void ReadFor (
     TypSymbolSet        follow )
 {
     volatile UInt       nrs;            /* number of statements in body    */
@@ -2314,7 +2314,7 @@ void ReadFor (
 **                     <Statements>
 **                 'od' ';'
 */
-void ReadWhile (
+static void ReadWhile (
     TypSymbolSet        follow )
 {
     volatile UInt       nrs;            /* number of statements in body    */
@@ -2366,7 +2366,7 @@ void ReadWhile (
 **  These functions only do something meaningful inside HPC-GAP; in plain GAP,
 **  they are simply placeholders.
 */
-void ReadAtomic (
+static void ReadAtomic (
     TypSymbolSet        follow )
 {
     volatile UInt       nrs;            /* number of statements in body    */
@@ -2449,7 +2449,7 @@ void ReadAtomic (
 **                    <Statements>
 **                'until' <Expr> ';'
 */
-void ReadRepeat (
+static void ReadRepeat (
     TypSymbolSet        follow )
 {
     volatile UInt       nrs;            /* number of statements in body    */
@@ -2498,7 +2498,7 @@ void ReadRepeat (
 **
 **  <Statement> := 'break' ';'
 */
-void ReadBreak (
+static void ReadBreak (
     TypSymbolSet        follow )
 {
     /* skip the break symbol                                               */
@@ -2517,7 +2517,7 @@ void ReadBreak (
 **
 **  <Statement> := 'continue' ';'
 */
-void ReadContinue (
+static void ReadContinue (
     TypSymbolSet        follow )
 {
     /* skip the continue symbol                                               */
@@ -2541,7 +2541,7 @@ void ReadContinue (
 **  It is still legal to use parenthesis but they  are  no  longer  required,
 **  a return statement is not a function call and should not look  like  one.
 */
-void ReadReturn (
+static void ReadReturn (
     TypSymbolSet        follow )
 {
     /* skip the return symbol                                              */
@@ -2569,7 +2569,7 @@ void ReadReturn (
 **
 **  <Statement> := 'TryNextMethod' '(' ')' ';'
 */
-void ReadTryNext (
+static void ReadTryNext (
     TypSymbolSet        follow )
 {
     Match( S_TRYNEXT, "TryNextMethod", follow );
@@ -2581,7 +2581,7 @@ void ReadTryNext (
     }
 }
 
-void ReadHelp(TypSymbolSet follow)
+static void ReadHelp(TypSymbolSet follow)
 {
     TRY_READ { IntrHelp(STATE(ValueObj)); }
     STATE(ValueObj) = 0;
@@ -2596,7 +2596,7 @@ void ReadHelp(TypSymbolSet follow)
 **
 **  <Statement> := 'quit' ';'
 */
-void            ReadQuit (
+static void            ReadQuit (
     TypSymbolSet        follow )
 {
     /* skip the quit symbol                                                */
@@ -2615,7 +2615,7 @@ void            ReadQuit (
 **
 **  <Statement> := 'QUIT' ';'
 */
-void            ReadQUIT (
+static void            ReadQUIT (
     TypSymbolSet        follow )
 {
     /* skip the quit symbol                                                */
@@ -2649,7 +2649,7 @@ void            ReadQUIT (
 **              |  'atomic' <QualifiedExpression> { ',' <QualifiedExpression> } 'do' <Statements> 'od' ';'
 **              |  ';'
 */
-UInt ReadStats (
+static UInt ReadStats (
     TypSymbolSet        follow )
 {
     UInt               nr;            /* number of statements            */
@@ -2701,7 +2701,7 @@ UInt ReadStats (
 **
 */
 
-void RecreateStackNams( Obj context )
+static void RecreateStackNams( Obj context )
 {
     Obj lvars = context;
     while (lvars != STATE(BottomLVars) && lvars != (Obj)0)  {

--- a/src/read.c
+++ b/src/read.c
@@ -933,194 +933,6 @@ static void ReadPerm (
 
 /****************************************************************************
 **
-*F  ReadLongNumber( <follow> )  . . . . . . . . . . . . . . . read a long integer
-**
-**  A `long integer' here means one whose digits don't fit into `STATE(Value)',
-**  see scanner.c.  This function copies repeatedly  digits from `STATE(Value)'
-**  into a GAP string until the full integer is read.
-**
-*/
-
-static void appendToString(Obj string, const char * val)
-{
-    const UInt len = GET_LEN_STRING(string);
-    const UInt len1 = strlen(val);
-
-    // ensure enough memory is allocated (GROW_STRING automatically
-    // reserves extra space for the terminating zero byte)
-    GROW_STRING(string, len + len1);
-    SET_LEN_STRING(string, len + len1);
-
-    // copy the data, including the terminator byte
-    memcpy(CHARS_STRING(string) + len, val, len1 + 1);
-}
-
-void ReadLongNumber(
-      TypSymbolSet        follow )
-{
-     Obj  string;
-     UInt status;
-     UInt done;
-
-     /* string in which to accumulate number */
-     string = MakeString(STATE(Value));
-     done = 0;
-
-     while (!done) {
-       /* remember the current symbol and get the next one */
-       status = STATE(Symbol);
-       Match(STATE(Symbol), "partial number", follow);
-
-       /* Now there are just lots of cases */
-       switch (status) {
-       case S_PARTIALINT:
-         switch (STATE(Symbol)) {
-         case S_INT:
-           appendToString(string, STATE(Value));
-           Match(S_INT, "integer", follow);
-           TRY_READ { IntrLongIntExpr(string); }
-           done = 1;
-           break;
-
-         case S_PARTIALINT:
-           appendToString(string, STATE(Value));
-           /*      Match(S_PARTIALINT, "integer", follow);*/
-           break;
-
-         case S_PARTIALFLOAT2:
-         case S_PARTIALFLOAT3:
-         case S_PARTIALFLOAT4:
-           status = STATE(Symbol);
-           appendToString(string, STATE(Value));
-           /* Match(STATE(Symbol), "float", follow); */
-           break;
-
-         case S_FLOAT:
-           appendToString(string, STATE(Value));
-           Match(S_FLOAT, "float", follow);
-           TRY_READ { IntrLongFloatExpr(string); }
-           done = 1;
-           break;
-
-         case S_IDENT:
-           SyntaxError("Identifier over 1024 characters");
-
-         default:
-           appendToString(string, STATE(Value));
-           TRY_READ { IntrLongIntExpr(string); }
-           done = 1;
-         }
-         break;
-
-       case S_PARTIALFLOAT2:
-         switch (STATE(Symbol)) {
-         case S_INT:
-         case S_PARTIALINT:
-           assert(0);
-           Pr("Parsing error, this should never happen", 0L, 0L);
-           SyExit(2);
-
-
-         case S_PARTIALFLOAT2:
-         case S_PARTIALFLOAT3:
-         case S_PARTIALFLOAT4:
-           status = STATE(Symbol);
-           appendToString(string, STATE(Value));
-           /* Match(STATE(Symbol), "float", follow); */
-           break;
-
-         case S_FLOAT:
-           appendToString(string, STATE(Value));
-           Match(S_FLOAT, "float", follow);
-           TRY_READ { IntrLongFloatExpr(string); }
-           done = 1;
-           break;
-
-
-         case S_IDENT:
-           SyntaxError("Badly Formed Number");
-
-         default:
-           appendToString(string, STATE(Value));
-           TRY_READ { IntrLongFloatExpr(string); }
-           done = 1;
-         }
-         break;
-
-       case S_PARTIALFLOAT3:
-         switch (STATE(Symbol)) {
-         case S_INT:
-         case S_PARTIALINT:
-         case S_PARTIALFLOAT2:
-         case S_PARTIALFLOAT3:
-           assert(0);
-           Pr("Parsing error, this should never happen", 0L, 0L);
-           SyExit(2);
-
-
-         case S_PARTIALFLOAT4:
-           status = STATE(Symbol);
-           appendToString(string, STATE(Value));
-           /* Match(STATE(Symbol), "float", follow); */
-           break;
-
-         case S_FLOAT:
-           appendToString(string, STATE(Value));
-           Match(S_FLOAT, "float", follow);
-           TRY_READ { IntrLongFloatExpr(string); }
-           done = 1;
-           break;
-
-
-         default:
-           SyntaxError("Badly Formed Number");
-
-         }
-         break;
-       case S_PARTIALFLOAT4:
-         switch (STATE(Symbol)) {
-         case S_INT:
-         case S_PARTIALINT:
-         case S_PARTIALFLOAT2:
-         case S_PARTIALFLOAT3:
-           assert(0);
-           Pr("Parsing error, this should never happen", 0L, 0L);
-           SyExit(2);
-
-
-         case S_PARTIALFLOAT4:
-           status = STATE(Symbol);
-           appendToString(string, STATE(Value));
-           /* Match(STATE(Symbol), "float", follow); */
-           break;
-
-         case S_FLOAT:
-           appendToString(string, STATE(Value));
-           Match(S_FLOAT, "float", follow);
-           TRY_READ { IntrLongFloatExpr(string); }
-           done = 1;
-           break;
-
-         case S_IDENT:
-           SyntaxError("Badly Formed Number");
-
-         default:
-           appendToString(string, STATE(Value));
-           TRY_READ { IntrLongFloatExpr(string); }
-           done = 1;
-
-         }
-         break;
-       default:
-         assert(0);
-         Pr("Parsing error, this should never happen", 0L, 0L);
-         SyExit(2);
-       }
-     }
-}
-
-/****************************************************************************
-**
 *F  ReadListExpr( <follow> )  . . . . . . . . . . . . . . . . . . read a list
 **
 **  'ReadListExpr'  reads a list literal expression.   In case of an error it
@@ -1634,20 +1446,24 @@ static void ReadLiteral (
 
     /* <Int>                                                               */
     case S_INT:
-        TRY_READ { IntrIntExpr( STATE(Value) ); }
+        TRY_READ {
+            if (STATE(ValueObj))
+                IntrLongIntExpr(STATE(ValueObj));
+            else
+                IntrIntExpr(STATE(Value));
+        }
         Match( S_INT, "integer", follow );
         break;
 
     /* <Float> */
     case S_FLOAT:
-        TRY_READ { IntrFloatExpr( STATE(Value) ); }
+        TRY_READ {
+            if (STATE(ValueObj))
+                IntrLongFloatExpr(STATE(ValueObj));
+            else
+                IntrFloatExpr(STATE(Value));
+        }
         Match( S_FLOAT, "float", follow );
-        break;
-
-    /* partial Int */
-    case S_PARTIALINT:
-    case S_PARTIALFLOAT2:
-        ReadLongNumber( follow );
         break;
 
     /* 'true'                                                              */

--- a/src/read.h
+++ b/src/read.h
@@ -123,8 +123,6 @@ extern void PushGlobalForLoopVariable( UInt var);
 
 extern void PopGlobalForLoopVariable( void );
 
-extern UInt GlobalComesFromEnclosingForLoop (UInt var);
-
 
 /****************************************************************************
 **

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -346,6 +346,10 @@ static void GetNumber(const UInt StartingStatus)
   Char                c;
   UInt seenADigit = (StartingStatus != 0 && StartingStatus != 2);
 
+  if (StartingStatus == 2) {
+    STATE(Value)[i++] = '.';
+  }
+
   c = PEEK_CURR_CHAR();
   if (StartingStatus  <  2) {
     // read initial sequence of digits into 'Value'
@@ -562,6 +566,12 @@ static void GetNumber(const UInt StartingStatus)
   STATE(Value)[i] = '\0';
 }
 
+void ScanForFloatAfterDotHACK(void)
+{
+    // A decimal point only, but in a context where we know it's the start of
+    // a number
+    GetNumber(2);
+}
 
 /****************************************************************************
 **
@@ -906,7 +916,6 @@ static void NextSymbol(void)
     /* special case if reading of a long token is not finished */
     switch (STATE(Symbol)) {
     case S_PARTIALINT:        GetNumber(STATE(Value)[0] == '\0' ? 0 : 1); return;
-    case S_PARTIALFLOAT1:     GetNumber(2); return;
     case S_PARTIALFLOAT2:     GetNumber(3); return;
     case S_PARTIALFLOAT3:     GetNumber(4); return;
     case S_PARTIALFLOAT4:     GetNumber(5); return;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -316,42 +316,47 @@ static void GetIdent(Int i)
 *F  GetNumber()  . . . . . . . . . . . . . .  get an integer or float literal
 **
 **  'GetNumber' reads a number from the current input file into the variable
-**  'STATE(Value)' and sets 'Symbol' to 'S_INT', 'S_PARTIALINT', 'S_FLOAT' or
-**  'S_PARTIALFLOAT'. The first character of the number is the current
-**  character pointed to by 'In'.
+**  'STATE(Value)' or 'STATE(ValueObj)' and sets 'STATE(Symbol)' to 'S_INT' or
+**  'S_FLOAT'. The first character of the number is the current character
+**  pointed to by 'In'.
 **
 **  If the sequence contains characters which do not match the regular
 **  expression [0-9]+.?[0-9]*([edqEDQ][+-]?[0-9]+)? 'GetNumber'  will
-**  interpret the sequence as an identifier and set 'Symbol' to 'S_IDENT'.
+**  interpret the sequence as an identifier by delegating to 'GetIdent'.
 **
 **  As we read, we keep track of whether we have seen a . or exponent
-**  notation and so whether we will return S_[PARTIAL]INT or
-**  S_[PARTIAL]FLOAT.
+**  notation and so whether we will return 'S_INT' or 'S_FLOAT'.
 **
-**  When STATE(Value) is completely filled we have to check if the reading of
-**  the number is complete or not to decide whether to return a PARTIAL type.
+**  When 'STATE(Value)' is completely filled, then a GAP string object is
+**  created in 'STATE(ValueObj)' and all data is stored there.
 **
-**  The argument reflects how far we are through reading a possibly very long
-**  number literal. 0 indicates that nothing has been read. 1 that at least
-**  one digit has been read, but no decimal point. 2 that a decimal point has
-**  been read with no digits before or after it. 3 a decimal point and at
-**  least one digit, but no exponential indicator 4 an exponential indicator
-**  but no exponent digits and 5 an exponential indicator and at least one
-**  exponent digit.
+**  The argument is used to signal if a decimal point was already read,
+**  or whether we are starting from scratch..
 **
 */
-static void GetNumber(const UInt StartingStatus)
+static UInt AddCharToValue(UInt i, Char c)
 {
-  Int                 i=0;
-  Char                c;
-  UInt seenADigit = (StartingStatus != 0 && StartingStatus != 2);
+    if (i >= SAFE_VALUE_SIZE - 1) {
+        STATE(ValueObj) = AppendBufToString(STATE(ValueObj), STATE(Value), i);
+        i = 0;
+    }
+    STATE(Value)[i++] = c;
+    return i;
+}
 
-  if (StartingStatus == 2) {
-    STATE(Value)[i++] = '.';
-  }
+static void GetNumber(const Int readDecimalPoint)
+{
+  UInt i = 0;
+  Char c;
+  UInt seenADigit = 0;
+
+  STATE(ValueObj) = 0;
 
   c = PEEK_CURR_CHAR();
-  if (StartingStatus  <  2) {
+  if (readDecimalPoint) {
+    STATE(Value)[i++] = '.';
+  }
+  else {
     // read initial sequence of digits into 'Value'
     while (IsDigit(c) && i < SAFE_VALUE_SIZE-1) {
       STATE(Value)[i++] = c;
@@ -369,208 +374,194 @@ static void GetNumber(const UInt StartingStatus)
 
     /* Or maybe we just ran out of space */
     if (IsDigit(c)) {
-      assert(i >= SAFE_VALUE_SIZE-1);
-      STATE(Symbol) = S_PARTIALINT;
-      STATE(Value)[SAFE_VALUE_SIZE-1] = '\0';
-      return;
+      GAP_ASSERT(i >= SAFE_VALUE_SIZE-1);
+      GAP_ASSERT(seenADigit);
+      while (IsDigit(c)) {
+        i = AddCharToValue(i, c);
+        c = GET_NEXT_CHAR();
+      }
     }
 
-    /* Or maybe we saw a . which could indicate one of two things:
-       a float literal or .. */
+    // Or maybe we saw a '.' which could indicate one of two things: a
+    // float literal or S_DOT, i.e., '.' used to access a record entry.
     if (c == '.') {
-      /* If the symbol before this integer was S_DOT then 
-         we must be in a nested record element expression, so don't 
-         look for a float.
+      GAP_ASSERT(i < SAFE_VALUE_SIZE - 1);
 
-      This is a bit fragile  */
+      // If the symbol before this integer was S_DOT then we must be in
+      // a nested record element expression, so don't look for a float.
+      // This is a bit fragile
       if (STATE(Symbol) == S_DOT || STATE(Symbol) == S_BDOT) {
-        STATE(Value)[i]  = '\0';
         STATE(Symbol) = S_INT;
-        return;
-      }
-      
-      /* peek ahead to decide which */
-      if (PEEK_NEXT_CHAR() == '.') {
-        /* It was .. */
-        STATE(Symbol) = S_INT;
-        STATE(Value)[i] = '\0';
-        return;
+        goto finish;
       }
 
-      /* Now the . must be part of our number
-         store it and move on */
-      STATE(Value)[i++] = '.';
+      // peek ahead to decide which
+      if (PEEK_NEXT_CHAR() == '.') {
+        // It was '.', so this looks like '..' and we are probably
+        // inside a range expression.
+        STATE(Symbol) = S_INT;
+        goto finish;
+      }
+
+      // Now the '.' must be part of our number; store it and move on
+      i = AddCharToValue(i, '.');
       c = GET_NEXT_CHAR();
     }
 
     else {
-      /* Anything else we see tells us that the token is done */
-      STATE(Value)[i]  = '\0';
+      // Anything else we see tells us that the token is done
       STATE(Symbol) = S_INT;
-      return;
+      goto finish;
     }
   }
 
 
+  // When we get here we have read possibly some digits, a . and possibly
+  // some more digits, but not an e,E,d,D,q or Q
 
-  /* The only case in which we fall through to here is when
-     we have read zero or more digits, followed by . which is not part of a .. token
-     or we were called with StartingStatus >= 2 so we read at least that much in
-     a previous token */
-
-
-  if (StartingStatus< 4) {
-    /* When we get here we have read (either in this token or a previous S_PARTIALFLOAT*)
-       possibly some digits, a . and possibly some more digits, but not an e,E,d,D,q or Q */
-
-    /* read digits */
-    while (IsDigit(c) && i < SAFE_VALUE_SIZE-1) {
-      STATE(Value)[i++] = c;
+    // read digits
+    while (IsDigit(c)) {
+      i = AddCharToValue(i, c);
       seenADigit = 1;
       c = GET_NEXT_CHAR();
     }
     if (!seenADigit)
-      SyntaxError("Badly formed number: need a digit before or after the decimal point");
+      SyntaxError("Badly formed number: need a digit before or after the "
+                  "decimal point");
     if (c == '\\')
       SyntaxError("Badly Formed Number");
-    /* If we found an identifier type character in this context could be an error
-      or the start of one of the allowed trailing marker sequences */
-    if (IsIdent(c) && c != 'e' && c != 'E' && c != 'd' && c != 'D' && c != 'q' && c != 'Q') {
 
-       // Allow one letter on the end of the numbers -- could be an i, C99 style
-       if (IsAlpha(c)) {
-         STATE(Value)[i++] = c;
-         c = GET_NEXT_CHAR();
-       }
-       /* independently of that, we allow an _ signalling immediate conversion */
-       if (c == '_') {
-         STATE(Value)[i++] = c;
-         c = GET_NEXT_CHAR();
-         /* After which there may be one character signifying the conversion style */
-         if (IsAlpha(c)) {
-           STATE(Value)[i++] = c;
-           c = GET_NEXT_CHAR();
-         }
-       }
-       /* Now if the next character is alphanumerical, or an identifier type symbol then we
-          really do have an error, otherwise we return a result */
-       if (IsIdent(c) || IsDigit(c)) {
-         SyntaxError("Badly formed number");
-       }
-       else {
-         STATE(Value)[i] = '\0';
-         STATE(Symbol) = S_FLOAT;
-         return;
-       }
+    // If we found an identifier type character in this context could be an
+    // error or the start of one of the allowed trailing marker sequences
+    if (IsIdent(c) && c != 'e' && c != 'E' && c != 'd' && c != 'D' &&
+        c != 'q' && c != 'Q') {
+
+      // Allow one letter on the end of the numbers -- could be an i, C99
+      // style
+      if (IsAlpha(c)) {
+        i = AddCharToValue(i, c);
+        c = GET_NEXT_CHAR();
+      }
+      // independently of that, we allow an _ signalling immediate conversion
+      if (c == '_') {
+        i = AddCharToValue(i, c);
+        c = GET_NEXT_CHAR();
+        // After which there may be one character signifying the
+        // conversion style
+        if (IsAlpha(c)) {
+          i = AddCharToValue(i, c);
+          c = GET_NEXT_CHAR();
+        }
+      }
+      // Now if the next character is alphanumerical, or an identifier type
+      // symbol then we really do have an error, otherwise we return a result
+      if (IsIdent(c) || IsDigit(c)) {
+        SyntaxError("Badly formed number");
+      }
+      else {
+        STATE(Symbol) = S_FLOAT;
+        goto finish;
+      }
     }
 
-    /* If the next thing is the start of the exponential notation,
-       read it now -- we have left enough space at the end of the buffer even if we
-       left the previous loop because of overflow */
+    // If the next thing is the start of the exponential notation, read it now.
     UInt seenExp = 0;
     if (IsAlpha(c)) {
-        if (!seenADigit)
-          SyntaxError("Badly formed number: need a digit before or after the decimal point");
-        seenExp = 1;
-        STATE(Value)[i++] = c;
+      if (!seenADigit)
+        SyntaxError("Badly formed number: need a digit before or after "
+                    "the decimal point");
+      seenExp = 1;
+      i = AddCharToValue(i, c);
+      c = GET_NEXT_CHAR();
+      if (c == '+' || c == '-') {
+        i = AddCharToValue(i, c);
         c = GET_NEXT_CHAR();
-        if (c == '+' || c == '-') {
-            STATE(Value)[i++] = c;
-            c = GET_NEXT_CHAR();
-        }
+      }
     }
 
-    /* Now deal with full buffer case */
-    if (i >= SAFE_VALUE_SIZE -1) {
-      STATE(Symbol) = seenExp ? S_PARTIALFLOAT3 : S_PARTIALFLOAT2;
-      STATE(Value)[i] = '\0';
-      return;
-    }
-
-    /* Either we saw an exponent indicator, or we hit end of token
-       deal with the end of token case */
+    // Either we saw an exponent indicator, or we hit end of token deal with
+    // the end of token case
     if (!seenExp) {
       if (!seenADigit)
-        SyntaxError("Badly formed number: need a digit before or after the decimal point");
-      /* Might be a conversion marker */
-        if (IsAlpha(c) && c != 'e' && c != 'E' && c != 'd' && c != 'D' && c != 'q' && c != 'Q') {
-          STATE(Value)[i++] = c;
-          c = GET_NEXT_CHAR();
-        }
-        /* independently of that, we allow an _ signalling immediate conversion */
-        if (c == '_') {
-          STATE(Value)[i++] = c;
-          c = GET_NEXT_CHAR();
-          /* After which there may be one character signifying the conversion style */
-          if (IsAlpha(c))
-            STATE(Value)[i++] = c;
-          c = GET_NEXT_CHAR();
-        }
-        /* Now if the next character is alphanumerical, or an identifier type symbol then we
-           really do have an error, otherwise we return a result */
-        if (!IsIdent(c) && !IsDigit(c)) {
-          STATE(Value)[i] = '\0';
-          STATE(Symbol) = S_FLOAT;
-          return;
-        }
+        SyntaxError("Badly formed number: need a digit before or after "
+                    "the decimal point");
+      // Might be a conversion marker
+      if (IsAlpha(c) && c != 'e' && c != 'E' && c != 'd' && c != 'D' &&
+          c != 'q' && c != 'Q') {
+        i = AddCharToValue(i, c);
+        c = GET_NEXT_CHAR();
+      }
+      // independently of that, we allow an _ signalling immediate conversion
+      if (c == '_') {
+        i = AddCharToValue(i, c);
+        c = GET_NEXT_CHAR();
+        // After which there may be one character signifying the
+        // conversion style
+        if (IsAlpha(c))
+          i = AddCharToValue(i, c);
+        c = GET_NEXT_CHAR();
+      }
+      // Now if the next character is alphanumerical, or an identifier type
+      // symbol then we really do have an error, otherwise we return a result
+      if (!IsIdent(c) && !IsDigit(c)) {
+        STATE(Symbol) = S_FLOAT;
+        goto finish;
+      }
       SyntaxError("Badly Formed Number");
     }
 
-  }
+  // Here we are into the unsigned exponent of a number in scientific
+  // notation, so we just read digits
+  UInt seenExpDigit = 0;
 
-  /* Here we are into the unsigned exponent of a number
-     in scientific notation, so we just read digits */
-  UInt seenExpDigit = (StartingStatus == 5);
-
-  while (IsDigit(c) && i < SAFE_VALUE_SIZE-1) {
-    STATE(Value)[i++] = c;
+  while (IsDigit(c)) {
+    i = AddCharToValue(i, c);
     seenExpDigit = 1;
     c = GET_NEXT_CHAR();
   }
 
-  /* Look out for a single alphabetic character on the end
-     which could be a conversion marker */
+  // Look out for a single alphabetic character on the end
+  // which could be a conversion marker
   if (seenExpDigit) {
     if (IsAlpha(c)) {
-      STATE(Value)[i] = c;
+      i = AddCharToValue(i, c);
       c = GET_NEXT_CHAR();
-      STATE(Value)[i+1] = '\0';
       STATE(Symbol) = S_FLOAT;
-      return;
+      goto finish;
     }
     if (c == '_') {
-      STATE(Value)[i++] = c;
+      i = AddCharToValue(i, c);
       c = GET_NEXT_CHAR();
-      /* After which there may be one character signifying the conversion style */
+      // After which there may be one character signifying the
+      // conversion style
       if (IsAlpha(c)) {
-        STATE(Value)[i++] = c;
+        i = AddCharToValue(i, c);
         c = GET_NEXT_CHAR();
       }
-      STATE(Value)[i] = '\0';
       STATE(Symbol) = S_FLOAT;
-      return;
+      goto finish;
     }
   }
 
-  /* If we ran off the end */
-  if (i >= SAFE_VALUE_SIZE -1) {
-    STATE(Symbol) = seenExpDigit ? S_PARTIALFLOAT4 : S_PARTIALFLOAT3;
-    STATE(Value)[i] = '\0';
-    return;
-  }
-
-  /* Otherwise this is the end of the token */
+  // Otherwise this is the end of the token
   if (!seenExpDigit)
-    SyntaxError("Badly Formed Number: need at least one digit in the exponent");
+    SyntaxError(
+        "Badly Formed Number: need at least one digit in the exponent");
   STATE(Symbol) = S_FLOAT;
-  STATE(Value)[i] = '\0';
+
+finish:
+  i = AddCharToValue(i, '\0');
+  if (STATE(ValueObj)) {
+    // flush buffer
+    AppendBufToString(STATE(ValueObj), STATE(Value), i - 1);
+  }
 }
 
 void ScanForFloatAfterDotHACK(void)
 {
     // A decimal point only, but in a context where we know it's the start of
     // a number
-    GetNumber(2);
+    GetNumber(1);
 }
 
 /****************************************************************************
@@ -913,15 +904,6 @@ static void GetHelp(void)
 */
 static void NextSymbol(void)
 {
-    /* special case if reading of a long token is not finished */
-    switch (STATE(Symbol)) {
-    case S_PARTIALINT:        GetNumber(STATE(Value)[0] == '\0' ? 0 : 1); return;
-    case S_PARTIALFLOAT2:     GetNumber(3); return;
-    case S_PARTIALFLOAT3:     GetNumber(4); return;
-    case S_PARTIALFLOAT4:     GetNumber(5); return;
-    }
-
-
     Char c = PEEK_CURR_CHAR();
 
     // if no character is available then get one

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -232,6 +232,7 @@ static void GetIdent(Int i)
 
     // read all characters into 'STATE(Value)'
     Char c = PEEK_CURR_CHAR();
+    Char * buf = STATE(Value);
     for (; IsIdent(c) || IsDigit(c) || c == '\\'; i++) {
 
         // handle escape sequences
@@ -249,7 +250,7 @@ static void GetIdent(Int i)
 
         /// put char into 'STATE(Value)' but only if there is room
         if (i < SAFE_VALUE_SIZE - 1)
-            STATE(Value)[i] = c;
+            buf[i] = c;
 
         // read the next character
         c = GET_NEXT_CHAR();
@@ -260,7 +261,7 @@ static void GetIdent(Int i)
         SyntaxError("Identifiers in GAP must consist of less than 1023 characters.");
         i = SAFE_VALUE_SIZE-1;
     }
-    STATE(Value)[i] = '\0';
+    buf[i] = '\0';
     STATE(Symbol) = S_IDENT;
 
     // if it is quoted then it is an identifier
@@ -268,44 +269,42 @@ static void GetIdent(Int i)
         return;
 
     // now check if 'STATE(Value)' holds a keyword
-    switch ( 256*STATE(Value)[0]+STATE(Value)[i-1] ) {
-    case 256*'a'+'d': if(!strcmp(STATE(Value),"and"))     STATE(Symbol)=S_AND;     break;
-    case 256*'a'+'c': if(!strcmp(STATE(Value),"atomic"))  STATE(Symbol)=S_ATOMIC;  break;
-    case 256*'b'+'k': if(!strcmp(STATE(Value),"break"))   STATE(Symbol)=S_BREAK;   break;
-    case 256*'c'+'e': if(!strcmp(STATE(Value),"continue"))   STATE(Symbol)=S_CONTINUE;   break;
-    case 256*'d'+'o': if(!strcmp(STATE(Value),"do"))      STATE(Symbol)=S_DO;      break;
-    case 256*'e'+'f': if(!strcmp(STATE(Value),"elif"))    STATE(Symbol)=S_ELIF;    break;
-    case 256*'e'+'e': if(!strcmp(STATE(Value),"else"))    STATE(Symbol)=S_ELSE;    break;
-    case 256*'e'+'d': if(!strcmp(STATE(Value),"end"))     STATE(Symbol)=S_END;     break;
-    case 256*'f'+'e': if(!strcmp(STATE(Value),"false"))   STATE(Symbol)=S_FALSE;   break;
-    case 256*'f'+'i': if(!strcmp(STATE(Value),"fi"))      STATE(Symbol)=S_FI;      break;
-    case 256*'f'+'r': if(!strcmp(STATE(Value),"for"))     STATE(Symbol)=S_FOR;     break;
-    case 256*'f'+'n': if(!strcmp(STATE(Value),"function"))STATE(Symbol)=S_FUNCTION;break;
-    case 256*'i'+'f': if(!strcmp(STATE(Value),"if"))      STATE(Symbol)=S_IF;      break;
-    case 256*'i'+'n': if(!strcmp(STATE(Value),"in"))      STATE(Symbol)=S_IN;      break;
-    case 256*'l'+'l': if(!strcmp(STATE(Value),"local"))   STATE(Symbol)=S_LOCAL;   break;
-    case 256*'m'+'d': if(!strcmp(STATE(Value),"mod"))     STATE(Symbol)=S_MOD;     break;
-    case 256*'n'+'t': if(!strcmp(STATE(Value),"not"))     STATE(Symbol)=S_NOT;     break;
-    case 256*'o'+'d': if(!strcmp(STATE(Value),"od"))      STATE(Symbol)=S_OD;      break;
-    case 256*'o'+'r': if(!strcmp(STATE(Value),"or"))      STATE(Symbol)=S_OR;      break;
-    case 256*'r'+'e': if(!strcmp(STATE(Value),"readwrite")) STATE(Symbol)=S_READWRITE;     break;
-    case 256*'r'+'y': if(!strcmp(STATE(Value),"readonly"))  STATE(Symbol)=S_READONLY;     break;
-    case 256*'r'+'c': if(!strcmp(STATE(Value),"rec"))     STATE(Symbol)=S_REC;     break;
-    case 256*'r'+'t': if(!strcmp(STATE(Value),"repeat"))  STATE(Symbol)=S_REPEAT;  break;
-    case 256*'r'+'n': if(!strcmp(STATE(Value),"return"))  STATE(Symbol)=S_RETURN;  break;
-    case 256*'t'+'n': if(!strcmp(STATE(Value),"then"))    STATE(Symbol)=S_THEN;    break;
-    case 256*'t'+'e': if(!strcmp(STATE(Value),"true"))    STATE(Symbol)=S_TRUE;    break;
-    case 256*'u'+'l': if(!strcmp(STATE(Value),"until"))   STATE(Symbol)=S_UNTIL;   break;
-    case 256*'w'+'e': if(!strcmp(STATE(Value),"while"))   STATE(Symbol)=S_WHILE;   break;
-    case 256*'q'+'t': if(!strcmp(STATE(Value),"quit"))    STATE(Symbol)=S_QUIT;    break;
-    case 256*'Q'+'T': if(!strcmp(STATE(Value),"QUIT"))    STATE(Symbol)=S_QQUIT;   break;
-
-    case 256*'I'+'d': if(!strcmp(STATE(Value),"IsBound")) STATE(Symbol)=S_ISBOUND; break;
-    case 256*'U'+'d': if(!strcmp(STATE(Value),"Unbind"))  STATE(Symbol)=S_UNBIND;  break;
-    case 256*'T'+'d': if(!strcmp(STATE(Value),"TryNextMethod"))
-                                                     STATE(Symbol)=S_TRYNEXT; break;
-    case 256*'I'+'o': if(!strcmp(STATE(Value),"Info"))    STATE(Symbol)=S_INFO;    break;
-    case 256*'A'+'t': if(!strcmp(STATE(Value),"Assert"))  STATE(Symbol)=S_ASSERT;  break;
+    switch ( 256*buf[0]+buf[i-1] ) {
+    case 256*'a'+'d': if(!strcmp(buf,"and"))           STATE(Symbol)=S_AND;       break;
+    case 256*'a'+'c': if(!strcmp(buf,"atomic"))        STATE(Symbol)=S_ATOMIC;    break;
+    case 256*'b'+'k': if(!strcmp(buf,"break"))         STATE(Symbol)=S_BREAK;     break;
+    case 256*'c'+'e': if(!strcmp(buf,"continue"))      STATE(Symbol)=S_CONTINUE;  break;
+    case 256*'d'+'o': if(!strcmp(buf,"do"))            STATE(Symbol)=S_DO;        break;
+    case 256*'e'+'f': if(!strcmp(buf,"elif"))          STATE(Symbol)=S_ELIF;      break;
+    case 256*'e'+'e': if(!strcmp(buf,"else"))          STATE(Symbol)=S_ELSE;      break;
+    case 256*'e'+'d': if(!strcmp(buf,"end"))           STATE(Symbol)=S_END;       break;
+    case 256*'f'+'e': if(!strcmp(buf,"false"))         STATE(Symbol)=S_FALSE;     break;
+    case 256*'f'+'i': if(!strcmp(buf,"fi"))            STATE(Symbol)=S_FI;        break;
+    case 256*'f'+'r': if(!strcmp(buf,"for"))           STATE(Symbol)=S_FOR;       break;
+    case 256*'f'+'n': if(!strcmp(buf,"function"))      STATE(Symbol)=S_FUNCTION;  break;
+    case 256*'i'+'f': if(!strcmp(buf,"if"))            STATE(Symbol)=S_IF;        break;
+    case 256*'i'+'n': if(!strcmp(buf,"in"))            STATE(Symbol)=S_IN;        break;
+    case 256*'l'+'l': if(!strcmp(buf,"local"))         STATE(Symbol)=S_LOCAL;     break;
+    case 256*'m'+'d': if(!strcmp(buf,"mod"))           STATE(Symbol)=S_MOD;       break;
+    case 256*'n'+'t': if(!strcmp(buf,"not"))           STATE(Symbol)=S_NOT;       break;
+    case 256*'o'+'d': if(!strcmp(buf,"od"))            STATE(Symbol)=S_OD;        break;
+    case 256*'o'+'r': if(!strcmp(buf,"or"))            STATE(Symbol)=S_OR;        break;
+    case 256*'r'+'e': if(!strcmp(buf,"readwrite"))     STATE(Symbol)=S_READWRITE; break;
+    case 256*'r'+'y': if(!strcmp(buf,"readonly"))      STATE(Symbol)=S_READONLY;  break;
+    case 256*'r'+'c': if(!strcmp(buf,"rec"))           STATE(Symbol)=S_REC;       break;
+    case 256*'r'+'t': if(!strcmp(buf,"repeat"))        STATE(Symbol)=S_REPEAT;    break;
+    case 256*'r'+'n': if(!strcmp(buf,"return"))        STATE(Symbol)=S_RETURN;    break;
+    case 256*'t'+'n': if(!strcmp(buf,"then"))          STATE(Symbol)=S_THEN;      break;
+    case 256*'t'+'e': if(!strcmp(buf,"true"))          STATE(Symbol)=S_TRUE;      break;
+    case 256*'u'+'l': if(!strcmp(buf,"until"))         STATE(Symbol)=S_UNTIL;     break;
+    case 256*'w'+'e': if(!strcmp(buf,"while"))         STATE(Symbol)=S_WHILE;     break;
+    case 256*'q'+'t': if(!strcmp(buf,"quit"))          STATE(Symbol)=S_QUIT;      break;
+    case 256*'Q'+'T': if(!strcmp(buf,"QUIT"))          STATE(Symbol)=S_QQUIT;     break;
+    case 256*'I'+'d': if(!strcmp(buf,"IsBound"))       STATE(Symbol)=S_ISBOUND;   break;
+    case 256*'U'+'d': if(!strcmp(buf,"Unbind"))        STATE(Symbol)=S_UNBIND;    break;
+    case 256*'T'+'d': if(!strcmp(buf,"TryNextMethod")) STATE(Symbol)=S_TRYNEXT;   break;
+    case 256*'I'+'o': if(!strcmp(buf,"Info"))          STATE(Symbol)=S_INFO;      break;
+    case 256*'A'+'t': if(!strcmp(buf,"Assert"))        STATE(Symbol)=S_ASSERT;    break;
 
     default: ;
     }

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -59,10 +59,6 @@ enum SCANNER_SYMBOLS {
     S_INT               = (1UL<<10)+1,
     S_FLOAT             = (1UL<<10)+2,
 
-    // A decimal point only, but in a context where we know it's the start of
-    // a number
-    S_PARTIALFLOAT1     = (1UL<<10)+3,
-
     // Some digits and a decimal point
     S_PARTIALFLOAT2     = (1UL<<10)+4,
 
@@ -358,6 +354,13 @@ extern void Match (
             const Char *        msg,
             TypSymbolSet        skipto );
 
+
+/****************************************************************************
+**
+*F  ScanForFloatAfterDotHACK()
+**
+*/
+extern void ScanForFloatAfterDotHACK(void);
 
 /****************************************************************************
 **

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -55,20 +55,8 @@ enum SCANNER_SYMBOLS {
     S_READONLY          = (1UL<< 9)+4,
     S_DOTDOTDOT         = (1UL<< 9)+5,
 
-    S_PARTIALINT        = (1UL<<10)+0, // Some digits
-    S_INT               = (1UL<<10)+1,
-    S_FLOAT             = (1UL<<10)+2,
-
-    // Some digits and a decimal point
-    S_PARTIALFLOAT2     = (1UL<<10)+4,
-
-    // Some digits and a decimal point and an exponent indicator and maybe a
-    // sign, but no digits
-    S_PARTIALFLOAT3     = (1UL<<10)+5,
-
-    // Some digits and a decimal point and an exponent indicator and maybe a
-    // sign, and at least one digit
-    S_PARTIALFLOAT4     = (1UL<<10)+6,
+    S_INT               = (1UL<<10)+0,
+    S_FLOAT             = (1UL<<10)+1,
 
     S_TRUE              = (1UL<<11)+0,
     S_FALSE             = (1UL<<11)+1,

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -299,7 +299,7 @@ extern  void            SyntaxWarning (
 *F  Match( <symbol>, <msg>, <skipto> )  . match current symbol and fetch next
 **
 **  'Match' is the main  interface between the  scanner and the  parser.   It
-**  performs the  4 most common actions in  the scanner  with  just one call.
+**  performs the four most common actions in the scanner with  just one call.
 **  First it checks that  the current symbol stored  in the variable 'Symbol'
 **  is the expected symbol  as passed in the  argument <symbol>.  If  it  is,
 **  'Match' reads the next symbol from input  and returns.  Otherwise 'Match'
@@ -331,7 +331,7 @@ extern  void            SyntaxWarning (
 **  'else' or 'fi' symbol, or a symbol that is  contained in the set <follow>
 **  which is passed to 'ReadIf' and contains all symbols allowing  one of the
 **  calling functions  to resynchronize,  for example 'S_OD' if 'ReadIf'  has
-**  been called from 'ReadFor'.  <follow> always contain 'S_EOF', which 'Read'
+**  been called from 'ReadFor'. <follow> always contain 'S_EOF', which 'Read'
 **  uses to resynchronise.
 **
 **  If 'Match' needs to  read a  new line from  '*stdin*' or '*errin*' to get

--- a/src/stats.c
+++ b/src/stats.c
@@ -1769,9 +1769,6 @@ void ClearError ( void )
           Pr("the maximum is now enlarged to %d kB.\n", (Int)SyStorMax, 0L);
         }
     }
-
-    /* reset <STATE(NrError)>                                                */
-    STATE(NrError) = 0;
 }
 
 /****************************************************************************

--- a/src/stats.h
+++ b/src/stats.h
@@ -148,9 +148,6 @@ extern  void            (* PrintStatFuncs[256] ) ( Stat stat );
  **
  *F  ClearError()  . . . . . . . . . . . . . .  reset execution and error flag
  *
- * FIXME: This function accesses NrError which is state of the scanner, so
- *        scanner should have an API for this.
- * 
  */
 
 extern void ClearError ( void );

--- a/src/streams.c
+++ b/src/streams.c
@@ -307,7 +307,13 @@ Obj READ_AS_FUNC ( void )
 }
 
 
-static void READ_TEST_OR_LOOP(void)
+/****************************************************************************
+**
+*F  READ_LOOP() . . . . . . . . . .  read current input as read-eval-view loop
+**
+**  Read the current input as read-eval-view loop and close the input stream.
+*/
+static void READ_LOOP ( void )
 {
     UInt                type;
     UInt                oldtime;
@@ -356,18 +362,6 @@ static void READ_TEST_OR_LOOP(void)
         // FIXME: what about other types? e.g. STATUS_ERROR and STATUS_QQUIT
 
     }
-}
-
-
-/****************************************************************************
-**
-*F  READ_LOOP() . . . . . . . . . .  read current input as read-eval-view loop
-**
-**  Read the current input as read-eval-view loop and close the input stream.
-*/
-static void READ_LOOP ( void )
-{
-    READ_TEST_OR_LOOP();
 
     /* close the input file again, and return 'true'                       */
     if ( ! CloseInput() ) {

--- a/src/streams.c
+++ b/src/streams.c
@@ -222,8 +222,8 @@ static Int READ_INNER ( UInt UseUHQ )
         ClearError();
         Obj evalResult;
         ExecStatus status = ReadEvalCommand(STATE(BottomLVars), &evalResult, 0);
-	if (STATE(UserHasQuit) || STATE(UserHasQUIT))
-	  break;
+        if (STATE(UserHasQuit) || STATE(UserHasQUIT))
+          break;
         /* handle return-value or return-void command                      */
         if ( status & (STATUS_RETURN_VAL | STATUS_RETURN_VOID) ) {
             Pr(
@@ -1702,9 +1702,9 @@ Obj FuncREAD_ALL_FILE (
 
     while ( ! IS_INTOBJ(limit) ) {
       limit = ErrorReturnObj(
-			     "<limit> must be a small integer (not a %s)",
-			     (Int)TNAM_OBJ(limit), 0L,
-			     "you can replace limit via 'return <limit>;'" );
+                             "<limit> must be a small integer (not a %s)",
+                             (Int)TNAM_OBJ(limit), 0L,
+                             "you can replace limit via 'return <limit>;'" );
     }
     ilim = INT_INTOBJ(limit);
 
@@ -1717,55 +1717,55 @@ Obj FuncREAD_ALL_FILE (
 
     if (syBuf[ifid].bufno >= 0)
       {
-	UInt bufno = syBuf[ifid].bufno;
+        UInt bufno = syBuf[ifid].bufno;
 
-	/* first drain the buffer */
-	lstr = syBuffers[bufno].buflen - syBuffers[bufno].bufstart;
-	if (ilim != -1)
-	  {
-	    if (lstr > ilim)
-	      lstr = ilim;
-	    ilim -= lstr;
-	  }
-	GROW_STRING(str, lstr);
-	memcpy(CHARS_STRING(str), syBuffers[bufno].buf + syBuffers[bufno].bufstart, lstr);
-	len = lstr;
-	SET_LEN_STRING(str, len);
-	syBuffers[bufno].bufstart += lstr;
+        /* first drain the buffer */
+        lstr = syBuffers[bufno].buflen - syBuffers[bufno].bufstart;
+        if (ilim != -1)
+          {
+            if (lstr > ilim)
+              lstr = ilim;
+            ilim -= lstr;
+          }
+        GROW_STRING(str, lstr);
+        memcpy(CHARS_STRING(str), syBuffers[bufno].buf + syBuffers[bufno].bufstart, lstr);
+        len = lstr;
+        SET_LEN_STRING(str, len);
+        syBuffers[bufno].bufstart += lstr;
       }
 #ifdef SYS_IS_CYGWIN32
  getmore:
 #endif
     while (ilim == -1 || len < ilim ) {
       if ( len > 0 && !HasAvailableBytes(ifid))
-	break;
+        break;
       if (syBuf[ifid].isTTY)
-	{
-	  if (ilim == -1)
-	    {
-	      Pr("#W Warning -- reading to  end of input tty will never end\n",0,0);
-	      csize = 20000;
-	    }
-	  else
-	      csize = ((ilim- len) > 20000) ? 20000 : ilim - len;
-	    
-	  if (SyFgetsSemiBlock(buf, csize, ifid))
-	    lstr = strlen(buf);
-	  else  
-	    lstr = 0;
-	}
+        {
+          if (ilim == -1)
+            {
+              Pr("#W Warning -- reading to  end of input tty will never end\n",0,0);
+              csize = 20000;
+            }
+          else
+              csize = ((ilim- len) > 20000) ? 20000 : ilim - len;
+            
+          if (SyFgetsSemiBlock(buf, csize, ifid))
+            lstr = strlen(buf);
+          else  
+            lstr = 0;
+        }
       else
-	{
-	  do {
-	    csize = (ilim == -1 || (ilim- len) > 20000) ? 20000 : ilim - len;
-	    lstr = read(syBuf[ifid].fp, buf, csize);
-	  } while (lstr == -1 && errno == EAGAIN);
-	}
+        {
+          do {
+            csize = (ilim == -1 || (ilim- len) > 20000) ? 20000 : ilim - len;
+            lstr = read(syBuf[ifid].fp, buf, csize);
+          } while (lstr == -1 && errno == EAGAIN);
+        }
       if (lstr <= 0)
-	{
-	  syBuf[ifid].ateof = 1;
-	  break;
-	}
+        {
+          syBuf[ifid].ateof = 1;
+          break;
+        }
       GROW_STRING( str, len+lstr );
       memcpy(CHARS_STRING(str)+len, buf, lstr);
       len += lstr;
@@ -1779,23 +1779,23 @@ Obj FuncREAD_ALL_FILE (
     {
       UInt i = 0,j = 0;
       while ( i < len )
-	{
-	  if (CHARS_STRING(str)[i] == '\r')
-	    {
-	      if (i < len -1 && CHARS_STRING(str)[i+1] == '\n')
-		{
-		  i++;
-		  continue;
-		}
-	      else
-		CHARS_STRING(str)[i] = '\n';
-	    }
-	  CHARS_STRING(str)[j++] = CHARS_STRING(str)[i++];
-	}
+        {
+          if (CHARS_STRING(str)[i] == '\r')
+            {
+              if (i < len -1 && CHARS_STRING(str)[i+1] == '\n')
+                {
+                  i++;
+                  continue;
+                }
+              else
+                CHARS_STRING(str)[i] = '\n';
+            }
+          CHARS_STRING(str)[j++] = CHARS_STRING(str)[i++];
+        }
       len = j;
       SET_LEN_STRING(str, len);
       if (ilim != -1 && len < ilim)
-	goto getmore;
+        goto getmore;
       
     }
 #endif

--- a/src/streams.c
+++ b/src/streams.c
@@ -2281,18 +2281,13 @@ static Int InitLibrary (
 *F  InitInfoStreams() . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "streams" ,                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    PostRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "streams",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = PostRestore,
 };
 
 StructInitInfo * InitInfoStreams ( void )


### PR DESCRIPTION
This is currently based on #2040, so that PR should be merged first.

Also, I have not yet fully rewritten the float and integer literal scanning (to avoid the `S_PARTIAL*` states); or rather, I had changes for that, but decided to start from scratch with this PR, in an attempt to make the change more incremental, and hence easier to review, at least when looking at it commit-by-commit.

However, I wanted to get this out now, to (a) see what the full test suite makes of it, and (b) to give people an early chance to spot issues and leave comments (though of course most likely nobody will have time to do that ;-).

One thing on which everybody can comment:The commit "scanner: remove GetCleanedChar" is a bit experimental, as it changes user visible behaviour; what do people think about this in terms of how "bad" it is? To illustrate, before the change, you might see this:
```
gap> 12.34\56;
Syntax error: Badly formed number
12.34\56;
     ^
```
after:
```
gap> 12.34\56;
Syntax error: Badly Formed Number
12.34\56;
    ^
Error, Variable: '56' must have a value
not in any function at *stdin*:1
```

To me, this is acceptable if this allow us to gain substantially simpler code, *but* I wonder if there are other reasons for the existence and use of `GetCleanedChar` in the float parser that I missed? Perhaps @stevelinton has some thought on this?