### PR TITLE
make last2 and last3 available in a break loop

### DIFF
--- a/lib/error.g
+++ b/lib/error.g
@@ -237,7 +237,7 @@ BIND_GLOBAL("ErrorInner",
         prompt := "brk> ";
     fi;
     if not justQuit then
-        res := SHELL(context,mayReturnVoid,mayReturnObj,1,false,prompt,false,"*errin*","*errout*",false);
+        res := SHELL(context,mayReturnVoid,mayReturnObj,3,false,prompt,false,"*errin*","*errout*",false);
     else
         res := fail;
     fi;


### PR DESCRIPTION
This PR addresses issue #2374. 
I came upon this by accident - it is not a feature that I particularly wish to use. 
Only 'last' is currently available inside a break loop because LastDepth=1 is set there. 
The fix suggested by @ChrisJefferson is to change '1' to '3' in lib/error.g line 240. 
Alternatively we could add "(Note that last2 and last3 are not available inside a break loop.)" to the reference manual. 
The additional suggestion by @stevelinton, "Would it be nicer if the old values of last* were reset on return from the break loop?", has not been addressed. 