### PR TITLE
kernel: make GetSymbol local to scanner.c, and rename it to NextSymbol

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1418,17 +1418,17 @@ ArgList ReadFuncArgList(
     start:
         lockmode = 0;
         switch (STATE(Symbol)) {
-            case S_READWRITE:
+        case S_READWRITE:
             if (!is_atomic) {
                 SyntaxError("'readwrite' argument of non-atomic function");
-                GetSymbol();
+                Match(S_READWRITE, "readwrite", follow);
                 break;
             }
             lockmode++;
-            case S_READONLY:
+        case S_READONLY:
             if (!is_atomic) {
                 SyntaxError("'readonly' argument of non-atomic function");
-                GetSymbol();
+                Match(S_READONLY, "readonly", follow);
                 break;
             }
             lockmode++;
@@ -1437,7 +1437,10 @@ ArgList ReadFuncArgList(
             SET_LEN_STRING(locks, narg+1);
             CHARS_STRING(locks)[narg] = lockmode;
 #endif
-            GetSymbol();
+            if (STATE(Symbol) == S_READWRITE)
+                Match(S_READWRITE, "readwrite", follow);
+            else
+                Match(S_READONLY, "readonly", follow);
         }
         if (STATE(Symbol) == S_IDENT && findValueInNams(nams, 1, narg)) {
             SyntaxError("Name used for two arguments");
@@ -1453,7 +1456,7 @@ ArgList ReadFuncArgList(
         }
         if(STATE(Symbol) == S_DOTDOTDOT) {
             isvarg = 1;
-            GetSymbol();
+            Match(S_DOTDOTDOT, "...", follow);
         }
     }
     Match( symbol, symbolstr, S_LOCAL|STATBEGIN|S_END|follow );

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -25,7 +25,7 @@
 #include <src/stringobj.h>
 
 
-static void GetSymbol(void);
+static void NextSymbol(void);
 
 
 /****************************************************************************
@@ -152,7 +152,7 @@ void Match (
 
     // if 'STATE(Symbol)' is the expected symbol match it away
     if ( symbol == STATE(Symbol) ) {
-        GetSymbol();
+        NextSymbol();
     }
 
     /* else generate an error message and skip to a symbol in <skipto>     */
@@ -161,7 +161,7 @@ void Match (
         strlcat( errmsg, " expected", sizeof(errmsg) );
         SyntaxError( errmsg );
         while ( ! IS_IN( STATE(Symbol), skipto ) )
-            GetSymbol();
+            NextSymbol();
     }
 }
 
@@ -886,17 +886,17 @@ static void GetHelp(void)
 
 /****************************************************************************
 **
-*F  GetSymbol() . . . . . . . . . . . . . . . . .  get the next symbol, local
+*F  NextSymbol() . . . . . . . . . . . . . . . . . get the next symbol, local
 **
-**  'GetSymbol' reads  the  next symbol from   the  input,  storing it in the
+**  'NextSymbol' reads  the  next symbol from  the  input,  storing it in the
 **  variable 'Symbol'.  If 'Symbol' is  'S_IDENT', 'S_INT' or 'S_STRING'  the
-**  value of the symbol is stored in 'STATE(Value)'.  'GetSymbol' first
+**  value of the symbol is stored in 'STATE(Value)'.  'NextSymbol' first
 **  skips all <space>, <tab> and <newline> characters and comments.
 **
 **  After reading  a  symbol the current  character   is the first  character
 **  beyond that symbol.
 */
-static void GetSymbol(void)
+static void NextSymbol(void)
 {
     /* special case if reading of a long token is not finished */
     switch (STATE(Symbol)) {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -25,6 +25,9 @@
 #include <src/stringobj.h>
 
 
+static void GetSymbol(void);
+
+
 /****************************************************************************
 **
 *F  SyntaxErrorOrWarning( <msg> ) . . . . . . raise a syntax error or warning
@@ -887,13 +890,13 @@ static void GetHelp(void)
 **
 **  'GetSymbol' reads  the  next symbol from   the  input,  storing it in the
 **  variable 'Symbol'.  If 'Symbol' is  'S_IDENT', 'S_INT' or 'S_STRING'  the
-**  value of the symbol is stored in the variable 'STATE(Value)'.  'GetSymbol' first
+**  value of the symbol is stored in 'STATE(Value)'.  'GetSymbol' first
 **  skips all <space>, <tab> and <newline> characters and comments.
 **
 **  After reading  a  symbol the current  character   is the first  character
 **  beyond that symbol.
 */
-void GetSymbol ( void )
+static void GetSymbol(void)
 {
     /* special case if reading of a long token is not finished */
     switch (STATE(Symbol)) {

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -271,21 +271,6 @@ extern int IsKeyword(const char * str);
 
 /****************************************************************************
 **
-*F  GetSymbol() . . . . . . . . . . . . . . . . .  get the next symbol, local
-**
-**  'GetSymbol' reads  the  next symbol from   the  input,  storing it in the
-**  variable 'Symbol'.  If 'Symbol' is  'T_IDENT', 'T_INT' or 'T_STRING'  the
-**  value of the symbol is stored in the variable 'Value'.  'GetSymbol' first
-**  skips all <space>, <tab> and <newline> characters and comments.
-**
-**  After reading  a  symbol the current  character   is the first  character
-**  beyond that symbol.
-*/
-extern void GetSymbol ( void );
-
-
-/****************************************************************************
-**
 *F  SyntaxError( <msg> ) . . . . . . . . . . . . . . . . raise a syntax error
 *F  SyntaxWarning( <msg> ) . . . . . . . . . . . . . . raise a syntax warning
 **


### PR DESCRIPTION
 By not exposing `GetSymbol` to the outside, refactoring becomes easier. Also, to me `GetFOO` sounds like an idempotent operation, and I always find it confusing when this is violated. This is why I earlier renamed `GET_CHAR` to `GET_NEXT_CHAR`, and now propose to rename `GetSymbol` to `NextSymbol`.

Subset of PR #2371