### PR TITLE
kernel: simplify scanning of large string literals

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -61,6 +61,7 @@ typedef struct GAPState {
     UInt      CurrentGlobalForLoopDepth;
 
     /* From scanner.c */
+    Obj    ValueObj;
     Char   Value[MAX_VALUE_LEN];
     UInt   ValueLen;
     UInt   NrError;

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -63,7 +63,6 @@ typedef struct GAPState {
     /* From scanner.c */
     Obj    ValueObj;
     Char   Value[MAX_VALUE_LEN];
-    UInt   ValueLen;
     UInt   NrError;
     UInt   NrErrLine;
     UInt   Symbol;

--- a/src/read.c
+++ b/src/read.c
@@ -2566,10 +2566,8 @@ void ReadTryNext (
 
 void ReadHelp(TypSymbolSet follow)
 {
-    Obj topic;
-
-    C_NEW_STRING(topic, STATE(ValueLen), (void *)STATE(Value));
-    TRY_READ { IntrHelp(topic); };
+    TRY_READ { IntrHelp(STATE(ValueObj)); }
+    STATE(ValueObj) = 0;
 }
 
 /****************************************************************************

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -92,6 +92,33 @@ void SyntaxWarning(const Char * msg)
 
 /****************************************************************************
 **
+*F  AppendBufToString()
+**
+**  Append 'bufLen' bytes from the string buffer 'buf' to the string object
+**  'string'. If 'string' is 0, then a new string object is allocated first.
+**
+**  The string object is returned at the end, regardless of whether it was
+**  given as an argument, or created from scratch.
+**
+*/
+static Obj AppendBufToString(Obj string, const char * buf, UInt bufLen)
+{
+    if (string == 0) {
+        string = NEW_STRING(bufLen);
+        memcpy(CSTR_STRING(string), buf, bufLen);
+    }
+    else {
+        const UInt len = GET_LEN_STRING(string);
+        GROW_STRING(string, len + bufLen);
+        SET_LEN_STRING(string, len + bufLen);
+        memcpy(CSTR_STRING(string) + len, buf, bufLen);
+    }
+    return string;
+}
+
+
+/****************************************************************************
+**
 *F  Match( <symbol>, <msg>, <skipto> )  . match current symbol and fetch next
 **
 **  'Match' is the main  interface between the  scanner and the  parser.   It
@@ -645,13 +672,14 @@ static Char GetEscapedChar(void)
   return result;
 }
 
+
 /****************************************************************************
 **
 *F  GetStr()  . . . . . . . . . . . . . . . . . . . . .  get a string, local
 **
 **  'GetStr' reads  a  string from the  current input file into  the variable
-**  'STATE(Value)' and sets 'Symbol'   to  'S_STRING'.  The opening double quote '"'
-**  of the string is the current character pointed to by 'In'.
+**  'STATE(ValueObj)' and sets 'Symbol' to  'S_STRING'. The opening double
+**  quote '"' of the string is the current character pointed to by 'In'.
 **
 **  A string is a sequence of characters delimited  by double quotes '"'.  It
 **  must not include  '"' or <newline>  characters, but the  escape sequences
@@ -660,59 +688,53 @@ static Char GetEscapedChar(void)
 **
 **  An error is raised if the string includes a <newline> character or if the
 **  file ends before the closing '"'.
-**
-**  When STATE(Value) is  completely filled we have to check  if the reading of
-**  the string is  complete or not to decide  between Symbol=S_STRING or
-**  S_PARTIALSTRING.
 */
 static void GetStr(void)
 {
-  Int                 i = 0;
-  Char c = PEEK_CURR_CHAR();
+    Obj  string = 0;
+    Char buf[1024];
+    UInt i;
+    Char c = PEEK_CURR_CHAR();
 
-  /* read all characters into 'Value'                                    */
-  for ( i = 0; i < SAFE_VALUE_SIZE-1 && c != '"'
-           && c != '\n' && c != '\377'; i++ ) {
+    for (i = 0; c != '"' && c != '\n' && c != '\377'; i++) {
+        // if 'buf' is full, copy it into 'string' and then reset it
+        if (i >= sizeof(buf)) {
+            string = AppendBufToString(string, buf, i);
+            i = 0;
+        }
+        if (c == '\\') {
+            c = GetEscapedChar();
+        }
+        buf[i] = c;
 
-    /* handle escape sequences                                         */
-    if ( c == '\\' ) {
-      STATE(Value)[i] = GetEscapedChar();
+        // read the next character
+        c = GET_NEXT_CHAR();
     }
 
-    /* put normal chars into 'Value' but only if there is room         */
-    else {
-      STATE(Value)[i] = c;
-    }
+    // append any remaining data to 'string'
+    string = AppendBufToString(string, buf, i);
 
-    /* read the next character                                         */
-    c = GET_NEXT_CHAR();
+    // ensure that the string has a terminator
+    const UInt len = GET_LEN_STRING(string);
+    CSTR_STRING(string)[len] = '\0';
 
-  }
+    // check for error conditions
+    if (c == '\n')
+        SyntaxError("String must not include <newline>");
+    if (c == '\377')
+        SyntaxError("String must end with \" before end of file");
 
-  /* XXX although we have ValueLen we need trailing \000 here,
-     in gap.c, function FuncMAKE_INIT this is still used as C-string
-     and long integers and strings are not yet supported!    */
-  STATE(Value)[i] = '\0';
-
-  /* check for error conditions                                          */
-  if ( c == '\n'  )
-    SyntaxError("String must not include <newline>");
-  if ( c == '\377' )
-    SyntaxError("String must end with \" before end of file");
-
-  /* set length of string, set 'Symbol' and skip trailing '"'            */
-  STATE(ValueLen) = i;
-  if ( i < SAFE_VALUE_SIZE-1 )  {
+    STATE(ValueObj) = string;
     STATE(Symbol) = S_STRING;
-    if ( c == '"' )  c = GET_NEXT_CHAR();
-  }
-  else
-    STATE(Symbol) = S_PARTIALSTRING;
+
+    // skip trailing '"'
+    if (c == '"')
+        c = GET_NEXT_CHAR();
 }
 
 /****************************************************************************
 **
-*F  GetTripStr()  . . . . . . . . . . . . .get a triple quoted string, local
+*F  GetTripStr() . . . . . . . . . . . . .  get a triple quoted string, local
 **
 **  'GetTripStr' reads a triple-quoted string from the  current input file
 **  into  the variable 'Value' and sets 'Symbol'   to  'S_STRING'.
@@ -723,62 +745,60 @@ static void GetStr(void)
 **  by """. No escaping is performed.
 **
 **  An error is raised if the file ends before the closing """.
-**
-**  When Value is  completely filled we have to check  if the reading of
-**  the string is  complete or not to decide  between Symbol=S_STRING or
-**  S_PARTIALTRIPLESTRING.
 */
 static void GetTripStr(void)
 {
-  Int                 i = 0;
-  Char c = PEEK_CURR_CHAR();
+    Obj  string = 0;
+    Char buf[1024];
+    UInt i;
+    Char c = PEEK_CURR_CHAR();
 
-  /* print only a partial prompt while reading a triple string           */
-  if ( !SyQuiet )
-    STATE(Prompt) = "> ";
-  else
-    STATE(Prompt) = "";
-  
-  /* read all characters into 'Value'                                    */
-  for ( i = 0; i < SAFE_VALUE_SIZE-1 && c != '\377'; i++ ) {
-    // Only thing to check for is a triple quote.
-    
-    if ( c == '"') {
-        c = GET_NEXT_CHAR();
+    // print only a partial prompt while reading a triple string
+    STATE(Prompt) = SyQuiet ? "" : "> ";
+
+    for (i = 0; c != '\377'; i++) {
+        // if 'buf' is full, copy it into 'string' and then reset it;
+        // take into account that we may add up to three chars below
+        if (i + 2 >= sizeof(buf)) {
+            string = AppendBufToString(string, buf, i);
+            i = 0;
+        }
+
+        // Only thing to check for is a triple quote.
         if (c == '"') {
             c = GET_NEXT_CHAR();
-            if (c == '"' ) {
-                break;
+            if (c == '"') {
+                c = GET_NEXT_CHAR();
+                if (c == '"') {
+                    break;
+                }
+                buf[i++] = '"';
             }
-            STATE(Value)[i] = '"';
-            i++;
+            buf[i++] = '"';
         }
-        STATE(Value)[i] = '"';
-        i++;
+        buf[i] = c;
+
+        // read the next character
+        c = GET_NEXT_CHAR();
     }
-    STATE(Value)[i] = c;
 
-    /* read the next character                                         */
-    c = GET_NEXT_CHAR();
-  }
+    // append any remaining data to 'string'
+    string = AppendBufToString(string, buf, i);
 
-  /* XXX although we have ValueLen we need trailing \000 here,
-     in gap.c, function FuncMAKE_INIT this is still used as C-string
-     and long integers and strings are not yet supported!    */
-  STATE(Value)[i] = '\0';
+    // ensure that the string has a terminator
+    const UInt len = GET_LEN_STRING(string);
+    CSTR_STRING(string)[len] = '\0';
 
-  /* check for error conditions                                          */
-  if ( c == '\377' )
-    SyntaxError("String must end with \"\"\" before end of file");
+    // check for error conditions
+    if (c == '\377')
+        SyntaxError("String must end with \"\"\" before end of file");
 
-  /* set length of string, set 'Symbol' and skip trailing '"'            */
-  STATE(ValueLen) = i;
-  if ( i < SAFE_VALUE_SIZE-1 )  {
+    STATE(ValueObj) = string;
     STATE(Symbol) = S_STRING;
-    if ( c == '"' ) c = GET_NEXT_CHAR();
-  }
-  else
-    STATE(Symbol) = S_PARTIALTRIPSTRING;
+
+    // skip trailing '"'
+    if (c == '"')
+        c = GET_NEXT_CHAR();
 }
 
 /****************************************************************************
@@ -801,8 +821,7 @@ static void GetMaybeTripStr(void)
     c = GET_NEXT_CHAR();
     /* This was just an empty string! */
     if ( c != '"' ) {
-        STATE(Value)[0] = '\0';
-        STATE(ValueLen) = 0;
+        STATE(ValueObj) = NEW_STRING(0);
         STATE(Symbol) = S_STRING;
         return;
     }
@@ -890,8 +909,6 @@ void GetSymbol ( void )
 {
     /* special case if reading of a long token is not finished */
     switch (STATE(Symbol)) {
-    case S_PARTIALSTRING:     GetStr();     return;
-    case S_PARTIALTRIPSTRING: GetTripStr(); return;
     case S_PARTIALINT:        GetNumber(STATE(Value)[0] == '\0' ? 0 : 1); return;
     case S_PARTIALFLOAT1:     GetNumber(2); return;
     case S_PARTIALFLOAT2:     GetNumber(3); return;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -877,20 +877,30 @@ static void GetChar(void)
 
 static void GetHelp(void)
 {
-    Int i = 0;
+    Obj  string = 0;
+    Char buf[1024];
+    UInt i;
 
-    /* Skip the first ? */
+    // Skip the leading '?'
     Char c = GET_NEXT_CHAR();
-    while (i < SAFE_VALUE_SIZE-1 &&
-           c != '\n' &&
-           c != '\r' &&
-           c != '\377') {
-        STATE(Value)[i] = c;
-        i++;
+
+    for (i = 0; c != '\n' && c != '\r' && c != '\377'; i++) {
+        // if 'buf' is full, copy it into 'string' and then reset it
+        if (i >= sizeof(buf)) {
+            string = AppendBufToString(string, buf, i);
+            i = 0;
+        }
+        buf[i] = c;
         c = GET_NEXT_CHAR();
     }
-    STATE(Value)[i] = '\0';
-    STATE(ValueLen) = i;
+    string = AppendBufToString(string, buf, i);
+
+    // ensure that the string has a terminator
+    const UInt len = GET_LEN_STRING(string);
+    CSTR_STRING(string)[len] = '\0';
+
+    STATE(ValueObj) = string;
+    STATE(Symbol) = S_HELP;
 }
 
 /****************************************************************************
@@ -986,7 +996,7 @@ void GetSymbol ( void )
   case '^':         STATE(Symbol) = S_POW;           GET_NEXT_CHAR(); break;
 
   case '~':         STATE(Symbol) = S_TILDE;         GET_NEXT_CHAR(); break;
-  case '?':         STATE(Symbol) = S_HELP;          GetHelp(); break;
+  case '?':                                          GetHelp(); break;
   case '"':                                          GetMaybeTripStr(); break;
   case '\'':                                         GetChar(); break;
   case '\\':                                         GetIdent(0); break;

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -231,7 +231,6 @@ typedef UInt            TypSymbolSet;
 **  it hard for the scanner to carry on correctly.
 */
 /* TL: extern  Char            Value [1030]; */
-/* TL: extern  UInt            ValueLen; */
 
 #define         SAFE_VALUE_SIZE 1024
 

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -78,10 +78,8 @@ enum SCANNER_SYMBOLS {
     S_FALSE             = (1UL<<11)+1,
     S_CHAR              = (1UL<<11)+2,
     S_STRING            = (1UL<<11)+3,
-    S_PARTIALSTRING     = (1UL<<11)+4,
-    S_PARTIALTRIPSTRING = (1UL<<11)+5,
-    S_TILDE             = (1UL<<11)+6,
-    S_HELP              = (1UL<<11)+7,
+    S_TILDE             = (1UL<<11)+4,
+    S_HELP              = (1UL<<11)+5,
 
     S_REC               = (1UL<<12)+0,
 
@@ -210,22 +208,24 @@ typedef UInt            TypSymbolSet;
 
 /****************************************************************************
 **
-*V  Value . . . . . . . . . . . .  value of the identifier, integer or string
+*V  Value . . . . . . . . . . . . , value of the identifier, float or integer
+*V  ValueObj . . . . . . . . . . . . . . . . . . . . . .  value of the string
 **
-**  If 'Symbol' is 'S_IDENT', 'S_INT' or 'S_STRING' the variable 'Value' holds
-**  the name of the identifier, the digits of the integer or the value of the
-**  string constant.
+**  If 'STATE(Symbol)' is 'S_IDENT', 'S_INT' or 'S_FLOAT' the variable
+**  'STATE(Value)' holds the name of the identifier, the digits of the
+**  integer or float literal as a C string. If the symbol is 'S_STRING', then
+**  instead the variable 'STATE(ValueObj)' holds the string literal as a GAP
+**  string object.
 **
 **  Note  that  the  size  of  'Value'  limits  the  maximal  number  of
 **  significant  characters of  an identifier.  'GetIdent' truncates  an
 **  identifier after that many characters.
 **
-**  The  only other  symbols  which  may not  fit  into  Value are  long
-**  integers  or strings.  Therefore we  have  to check  in 'GetInt'  and
-**  'GetStr' if  the symbols is  not yet  completely read when  Value is
-**  filled.
+**  The only other symbols which may not fit into Value are long integers or
+**  floats. Therefore we have to check in 'GetNumber' if the symbols is not
+**  yet completely read when 'Value' is filled.
 **
-**  We only fill Value up to SAFE_VALUE_SIZE normally. The last few
+**  We only fill 'Value' up to SAFE_VALUE_SIZE normally. The last few
 **  bytes are used in the floating point parsing code to ensure that we don't
 **  stop the scan just before a non-digit (., E, +,-, etc.) which would make
 **  it hard for the scanner to carry on correctly.


### PR DESCRIPTION
This PR simplifies scanning of large string literals. As a side effect, we get rid of `STATE(ValueLen)` (this requires also tweaking the scanner code for `S_HELP`). To achieve this, we introduce `Obj STATE(ValueObj)` which is now used by the string scanning code to store its result; since the scanned data is turned into a string object later on anyway, there is no harm in this.

As an optimization, we use an intermediate (stack based) buffer in which we accumulate data, until the buffer is full resp. we are done scanning, when we transfer the data into the final string object. This way, we don't have to worry about garbage collection, and the compiler can emit better code.

Subset of PR #2371