### PR TITLE
kernel: reduce code duplication in function dispatchers

### DIFF
--- a/tst/test-error/trace.g
+++ b/tst/test-error/trace.g
@@ -1,14 +1,93 @@
-m:=ImmutableMatrix(GF(2),IdentityMat(2,GF(2)));;
+#
+# tracing of operations
+#
 
-InverseMutable(m);
-TraceMethods(InverseMutable);
-InverseMutable(m);
+# create a dummy operation
+o:=NewOperation("dummy",[]);
+InstallOtherMethod(o,[],{}->[]);
+InstallOtherMethod(o,[IsInt],{arg...}->arg);
+InstallOtherMethod(o,[IsInt,IsInt],{arg...}->arg);
+InstallOtherMethod(o,[IsInt,IsInt],{arg...}->arg);
+InstallOtherMethod(o,[IsInt,IsInt,IsInt],{arg...}->arg);
+InstallOtherMethod(o,[IsInt,IsInt,IsInt,IsInt],{arg...}->arg);
+InstallOtherMethod(o,[IsInt,IsInt,IsInt,IsInt,IsInt],{arg...}->arg);
+InstallOtherMethod(o,[IsInt,IsInt,IsInt,IsInt,IsInt,IsInt],{arg...}->arg);
 
-AdditiveInverseMutable(m);
-TraceMethods(AdditiveInverseMutable);
-AdditiveInverseMutable(m);
+# without tracing
+o();
+o(1);
+o(1,2);
+o(1,2,3);
+o(1,2,3,4);
+o(1,2,3,4,5);
+o(1,2,3,4,5,6);
+o(1,2,3,4,5,6,7); # not (yet?) supported
 
-g:= Group( (1,2,3), (1,2) );;  Size( g );
-TraceMethods( [ Size ] );
-Size(g);
-UntraceMethods( [ Size ] );
+# with tracing
+TraceMethods( o );
+o();
+o(1);
+o(1,2);
+o(1,2,3);
+o(1,2,3,4);
+o(1,2,3,4,5);
+o(1,2,3,4,5,6);
+o(1,2,3,4,5,6,7);
+UntraceMethods( o ); # not (yet?) supported
+
+# again without tracing
+o();
+o(1);
+o(1,2);
+o(1,2,3);
+o(1,2,3,4);
+o(1,2,3,4,5);
+o(1,2,3,4,5,6);
+o(1,2,3,4,5,6,7); # not (yet?) supported
+
+#
+# tracing of constructors
+#
+
+# create a dummy constructor
+o:=NewConstructor("foobar",[]);
+InstallOtherMethod(o,[],{}->[]);
+InstallOtherMethod(o,[IsInt],{arg...}->arg);
+InstallOtherMethod(o,[IsInt,IsInt],{arg...}->arg);
+InstallOtherMethod(o,[IsInt,IsInt],{arg...}->arg);
+InstallOtherMethod(o,[IsInt,IsInt,IsInt],{arg...}->arg);
+InstallOtherMethod(o,[IsInt,IsInt,IsInt,IsInt],{arg...}->arg);
+InstallOtherMethod(o,[IsInt,IsInt,IsInt,IsInt,IsInt],{arg...}->arg);
+InstallOtherMethod(o,[IsInt,IsInt,IsInt,IsInt,IsInt,IsInt],{arg...}->arg);
+
+# without tracing
+#o(); # ???
+o(IsInt);
+o(IsInt,2);
+o(IsInt,2,3);
+o(IsInt,2,3,4);
+o(IsInt,2,3,4,5);
+o(IsInt,2,3,4,5,6);
+o(IsInt,2,3,4,5,6,7); # not (yet?) supported
+
+# with tracing
+TraceMethods( o );
+#o(); # ???
+o(IsInt);
+o(IsInt,2);
+o(IsInt,2,3);
+o(IsInt,2,3,4);
+o(IsInt,2,3,4,5);
+o(IsInt,2,3,4,5,6);
+o(IsInt,2,3,4,5,6,7); # not (yet?) supported
+UntraceMethods( o );
+
+# again without tracing
+#o(); # ???
+o(IsInt);
+o(IsInt,2);
+o(IsInt,2,3);
+o(IsInt,2,3,4);
+o(IsInt,2,3,4,5);
+o(IsInt,2,3,4,5,6);
+o(IsInt,2,3,4,5,6,7); # not (yet?) supported

--- a/tst/test-error/trace.g.out
+++ b/tst/test-error/trace.g.out
@@ -1,24 +1,160 @@
-gap> m:=ImmutableMatrix(GF(2),IdentityMat(2,GF(2)));;
+gap> #
+gap> # tracing of operations
+gap> #
 gap> 
-gap> InverseMutable(m);
-<a 2x2 matrix over GF2>
-gap> TraceMethods(InverseMutable);
-gap> InverseMutable(m);
-#I  InverseMutable: for GF2 matrix at GAPROOT/lib/vecmat.gi:832
-<a 2x2 matrix over GF2>
+gap> # create a dummy operation
+gap> o:=NewOperation("dummy",[]);
+<Operation "dummy">
+gap> InstallOtherMethod(o,[],{}->[]);
+gap> InstallOtherMethod(o,[IsInt],{arg...}->arg);
+gap> InstallOtherMethod(o,[IsInt,IsInt],{arg...}->arg);
+gap> InstallOtherMethod(o,[IsInt,IsInt],{arg...}->arg);
+gap> InstallOtherMethod(o,[IsInt,IsInt,IsInt],{arg...}->arg);
+gap> InstallOtherMethod(o,[IsInt,IsInt,IsInt,IsInt],{arg...}->arg);
+gap> InstallOtherMethod(o,[IsInt,IsInt,IsInt,IsInt,IsInt],{arg...}->arg);
+gap> InstallOtherMethod(o,[IsInt,IsInt,IsInt,IsInt,IsInt,IsInt],{arg...}->arg);
 gap> 
-gap> AdditiveInverseMutable(m);
-<a 2x2 matrix over GF2>
-gap> TraceMethods(AdditiveInverseMutable);
-gap> AdditiveInverseMutable(m);
-#I  AdditiveInverseMutable: for GF2 matrix at GAPROOT/lib/vecmat.gi:774
-<a 2x2 matrix over GF2>
+gap> # without tracing
+gap> o();
+[  ]
+gap> o(1);
+[ 1 ]
+gap> o(1,2);
+[ 1, 2 ]
+gap> o(1,2,3);
+[ 1, 2, 3 ]
+gap> o(1,2,3,4);
+[ 1, 2, 3, 4 ]
+gap> o(1,2,3,4,5);
+[ 1, 2, 3, 4, 5 ]
+gap> o(1,2,3,4,5,6);
+[ 1, 2, 3, 4, 5, 6 ]
+gap> o(1,2,3,4,5,6,7); # not (yet?) supported
+Error, sorry: cannot yet have X argument operations
+not in any function at *stdin*:25
 gap> 
-gap> g:= Group( (1,2,3), (1,2) );;  Size( g );
-6
-gap> TraceMethods( [ Size ] );
-gap> Size(g);
-#I  Size: system getter at GAPROOT/lib/coll.gd:1473
-6
-gap> UntraceMethods( [ Size ] );
+gap> # with tracing
+gap> TraceMethods( o );
+gap> o();
+#I  dummy at *stdin*:8
+[  ]
+gap> o(1);
+#I  dummy at *stdin*:9
+[ 1 ]
+gap> o(1,2);
+#I  dummy at *stdin*:11
+[ 1, 2 ]
+gap> o(1,2,3);
+#I  dummy at *stdin*:12
+[ 1, 2, 3 ]
+gap> o(1,2,3,4);
+#I  dummy at *stdin*:13
+[ 1, 2, 3, 4 ]
+gap> o(1,2,3,4,5);
+#I  dummy at *stdin*:14
+[ 1, 2, 3, 4, 5 ]
+gap> o(1,2,3,4,5,6);
+#I  dummy at *stdin*:15
+[ 1, 2, 3, 4, 5, 6 ]
+gap> o(1,2,3,4,5,6,7);
+Error, sorry: cannot yet have X argument operations
+not in any function at *stdin*:36
+gap> UntraceMethods( o ); # not (yet?) supported
+gap> 
+gap> # again without tracing
+gap> o();
+[  ]
+gap> o(1);
+[ 1 ]
+gap> o(1,2);
+[ 1, 2 ]
+gap> o(1,2,3);
+[ 1, 2, 3 ]
+gap> o(1,2,3,4);
+[ 1, 2, 3, 4 ]
+gap> o(1,2,3,4,5);
+[ 1, 2, 3, 4, 5 ]
+gap> o(1,2,3,4,5,6);
+[ 1, 2, 3, 4, 5, 6 ]
+gap> o(1,2,3,4,5,6,7); # not (yet?) supported
+Error, sorry: cannot yet have X argument operations
+not in any function at *stdin*:47
+gap> 
+gap> #
+gap> # tracing of constructors
+gap> #
+gap> 
+gap> # create a dummy constructor
+gap> o:=NewConstructor("foobar",[]);
+<Constructor "foobar">
+gap> InstallOtherMethod(o,[],{}->[]);
+gap> InstallOtherMethod(o,[IsInt],{arg...}->arg);
+gap> InstallOtherMethod(o,[IsInt,IsInt],{arg...}->arg);
+gap> InstallOtherMethod(o,[IsInt,IsInt],{arg...}->arg);
+gap> InstallOtherMethod(o,[IsInt,IsInt,IsInt],{arg...}->arg);
+gap> InstallOtherMethod(o,[IsInt,IsInt,IsInt,IsInt],{arg...}->arg);
+gap> InstallOtherMethod(o,[IsInt,IsInt,IsInt,IsInt,IsInt],{arg...}->arg);
+gap> InstallOtherMethod(o,[IsInt,IsInt,IsInt,IsInt,IsInt,IsInt],{arg...}->arg);
+gap> 
+gap> # without tracing
+gap> #o(); # ???
+gap> o(IsInt);
+[ <Category "IsInt"> ]
+gap> o(IsInt,2);
+[ <Category "IsInt">, 2 ]
+gap> o(IsInt,2,3);
+[ <Category "IsInt">, 2, 3 ]
+gap> o(IsInt,2,3,4);
+[ <Category "IsInt">, 2, 3, 4 ]
+gap> o(IsInt,2,3,4,5);
+[ <Category "IsInt">, 2, 3, 4, 5 ]
+gap> o(IsInt,2,3,4,5,6);
+[ <Category "IsInt">, 2, 3, 4, 5, 6 ]
+gap> o(IsInt,2,3,4,5,6,7); # not (yet?) supported
+Error, sorry: cannot yet have X argument constructors
+not in any function at *stdin*:72
+gap> 
+gap> # with tracing
+gap> TraceMethods( o );
+gap> #o(); # ???
+gap> o(IsInt);
+#I  foobar at *stdin*:56
+[ <Category "IsInt"> ]
+gap> o(IsInt,2);
+#I  foobar at *stdin*:58
+[ <Category "IsInt">, 2 ]
+gap> o(IsInt,2,3);
+#I  foobar at *stdin*:59
+[ <Category "IsInt">, 2, 3 ]
+gap> o(IsInt,2,3,4);
+#I  foobar at *stdin*:60
+[ <Category "IsInt">, 2, 3, 4 ]
+gap> o(IsInt,2,3,4,5);
+#I  foobar at *stdin*:61
+[ <Category "IsInt">, 2, 3, 4, 5 ]
+gap> o(IsInt,2,3,4,5,6);
+#I  foobar at *stdin*:62
+[ <Category "IsInt">, 2, 3, 4, 5, 6 ]
+gap> o(IsInt,2,3,4,5,6,7); # not (yet?) supported
+Error, sorry: cannot yet have X argument constructors
+not in any function at *stdin*:83
+gap> UntraceMethods( o );
+gap> 
+gap> # again without tracing
+gap> #o(); # ???
+gap> o(IsInt);
+[ <Category "IsInt"> ]
+gap> o(IsInt,2);
+[ <Category "IsInt">, 2 ]
+gap> o(IsInt,2,3);
+[ <Category "IsInt">, 2, 3 ]
+gap> o(IsInt,2,3,4);
+[ <Category "IsInt">, 2, 3, 4 ]
+gap> o(IsInt,2,3,4,5);
+[ <Category "IsInt">, 2, 3, 4, 5 ]
+gap> o(IsInt,2,3,4,5,6);
+[ <Category "IsInt">, 2, 3, 4, 5, 6 ]
+gap> o(IsInt,2,3,4,5,6,7); # not (yet?) supported
+Error, sorry: cannot yet have X argument constructors
+not in any function at *stdin*:94
 gap> QUIT;

--- a/tst/testinstall/callfunc.tst
+++ b/tst/testinstall/callfunc.tst
@@ -54,7 +54,7 @@ gap> o(1,2,3,4,5,6);
 gap> o(1,2,3,4,5,6,7);
 [ 1, 2, 3, 4, 5, 6, 7 ]
 
-# test dispatch through executor / DispatchFuncCall, as function call
+# test dispatch through executor / EvalOrExecCall, as function call
 gap> f := function() return o(); end;; f();
 [  ]
 gap> f := function() return o(1); end;; f();
@@ -72,7 +72,7 @@ gap> f := function() return o(1,2,3,4,5,6); end;; f();
 gap> f := function() return o(1,2,3,4,5,6,7); end;; f();
 [ 1, 2, 3, 4, 5, 6, 7 ]
 
-# test dispatch through executor / DispatchFuncCall, as procedure call
+# test dispatch through executor / EvalOrExecCall, as procedure call
 gap> f := function() o(); return result; end;; f();
 [  ]
 gap> f := function() o(1); return result; end;; f();

--- a/tst/testinstall/kernel/calls.tst
+++ b/tst/testinstall/kernel/calls.tst
@@ -3,7 +3,26 @@
 #
 gap> START_TEST("kernel/calls.tst");
 
-# test error for wrong number of arguments
+# test DoWrap0args, DoWrap1args, ...
+gap> o:={l...} -> l;;
+gap> o();
+[  ]
+gap> o(1);
+[ 1 ]
+gap> o(1,2);
+[ 1, 2 ]
+gap> o(1,2,3);
+[ 1, 2, 3 ]
+gap> o(1,2,3,4);
+[ 1, 2, 3, 4 ]
+gap> o(1,2,3,4,5);
+[ 1, 2, 3, 4, 5 ]
+gap> o(1,2,3,4,5,6);
+[ 1, 2, 3, 4, 5, 6 ]
+gap> o(1,2,3,4,5,6,7);
+[ 1, 2, 3, 4, 5, 6, 7 ]
+
+# test DoFail0args, DoFail1args, ...
 gap> f:={}->1;;
 gap> f(1);
 Error, Function: number of arguments must be 0 (not 1)
@@ -25,6 +44,27 @@ Error, Function: number of arguments must be 1 (not 0)
 gap> f:={x,y,z...}->x;;
 gap> f();
 Error, Function: number of arguments must be at least 2 (not 0)
+
+# test DoProf0args, DoProf1args, ...
+gap> o:={l...} -> l;;
+gap> ProfileFunctions([o]);
+gap> o();
+[  ]
+gap> o(1);
+[ 1 ]
+gap> o(1,2);
+[ 1, 2 ]
+gap> o(1,2,3);
+[ 1, 2, 3 ]
+gap> o(1,2,3,4);
+[ 1, 2, 3, 4 ]
+gap> o(1,2,3,4,5);
+[ 1, 2, 3, 4, 5 ]
+gap> o(1,2,3,4,5,6);
+[ 1, 2, 3, 4, 5, 6 ]
+gap> o(1,2,3,4,5,6,7);
+[ 1, 2, 3, 4, 5, 6, 7 ]
+gap> UnprofileFunctions([o]);
 
 #
 gap> PROF_FUNC(1);

--- a/tst/testinstall/kernel/opers.tst
+++ b/tst/testinstall/kernel/opers.tst
@@ -198,26 +198,12 @@ Error, <oper> must be an operation
 gap> if not IsHPCGAP then COMPACT_TYPE_IDS(); fi;
 
 #
-# ensure at least some of the "verbose" profiling code path is hit
 #
-gap> opers:=[IsAbelian,Size,SylowSubgroup,NthRootsInGroup,AbelianGroupCons];;
-gap> ProfileFunctions(opers);
-gap> G := Group( (1,2,3), (4,5,6));;
-gap> Size(G);
-9
-gap> SylowSubgroup(G, 3) = G;
-true
-gap> NthRootsInGroup(G, G.1, 3);
-[  ]
-gap> IsAbelian(G);
-true
-gap> G = AbelianGroupCons(IsPermGroup, [3,3]);
-true
-gap> UnprofileFunctions(opers);
+#
 
-#
-#
-#
+# DoOperationNArgs
+gap> SymmetricGroupCons(1,2);
+Error, Constructor: the first argument must be a filter not a integer
 
 #
 gap> NEW_OPERATION(fail);


### PR DESCRIPTION
... by putting the duplicate code into `static ALWAYS_INLINE` functions and then relying on the compiler to optimize the code. Which it does, in my tests with clang and gcc.