### PR TITLE
kernel: remove SET_OUTPUT, SET_PREVIOUS_OUTPUT

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -131,14 +131,13 @@ InstallGlobalFunction(RunTests, function(arg)
     s := InputTextString(inp[i]);
     res := "";
     fres := OutputTextString(res, false);
-    SET_OUTPUT(fres, true);
     t := Runtime();
-    READ_STREAM_LOOP(s, true);
-    SET_PREVIOUS_OUTPUT();
+    READ_STREAM_LOOP(s, fres);
+    t := Runtime() - t;
     CloseStream(fres);
     CloseStream(s);
     Add(cmp, res);
-    Add(times, Runtime()-t);
+    Add(times, t);
   od;
   if opts.showProgress = "some" then
     Print("\r                                    \c\r"); # clear the line


### PR DESCRIPTION
These needlessly exposed deep internals of GAP, namely the stack of
output streams. Instead, we merge them into READ_STREAM_LOOP, and also
merge READ_LOOP into READ_STREAM_LOOP (the latter was the only place
calling the former). Also shuffle some more bits and pieces around.

All this should make it easier to refactor this code in the future.