### PR TITLE
kernel: use more accurate marking

### DIFF
--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -625,6 +625,10 @@ void MarkAllSubBags(Bag bag)
 {
 }
 
+void MarkAllButFirstSubBags(Bag bag)
+{
+}
+
 void MarkArrayOfBags(const Bag array[], UInt count)
 {
 }

--- a/src/calls.h
+++ b/src/calls.h
@@ -107,10 +107,10 @@ typedef Obj (* ObjFunc_6ARGS) (Obj self, Obj a1, Obj a2, Obj a3, Obj a4, Obj a5,
 typedef struct {
     ObjFunc handlers[8];
     Obj name;
-    Int nargs;
+    Obj nargs;
     Obj namesOfLocals;
     Obj prof;
-    UInt nloc;
+    Obj nloc;
     Obj body;
     Obj envi;
     Obj fexs;
@@ -146,7 +146,7 @@ static inline Obj NAME_FUNC(Obj func)
 
 static inline Int NARG_FUNC(Obj func)
 {
-    return CONST_FUNC(func)->nargs;
+    return INT_INTOBJ(CONST_FUNC(func)->nargs);
 }
 
 static inline Obj NAMS_FUNC(Obj func)
@@ -163,7 +163,7 @@ static inline Obj PROF_FUNC(Obj func)
 
 static inline UInt NLOC_FUNC(Obj func)
 {
-    return CONST_FUNC(func)->nloc;
+    return INT_INTOBJ(CONST_FUNC(func)->nloc);
 }
 
 static inline Obj BODY_FUNC(Obj func)
@@ -199,7 +199,7 @@ extern void SET_NAME_FUNC(Obj func, Obj name);
 
 static inline void SET_NARG_FUNC(Obj func, Int nargs)
 {
-    FUNC(func)->nargs = nargs;
+    FUNC(func)->nargs = INTOBJ_INT(nargs);
 }
 
 static inline void SET_NAMS_FUNC(Obj func, Obj namesOfLocals)
@@ -214,7 +214,7 @@ static inline void SET_PROF_FUNC(Obj func, Obj prof)
 
 static inline void SET_NLOC_FUNC(Obj func, UInt nloc)
 {
-    FUNC(func)->nloc = nloc;
+    FUNC(func)->nloc = INTOBJ_INT(nloc);
 }
 
 static inline void SET_BODY_FUNC(Obj func, Obj body)

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -660,6 +660,12 @@ void MarkAllSubBagsDefault(Bag bag)
     MarkArrayOfBags(CONST_PTR_BAG(bag), SIZE_BAG(bag) / sizeof(Bag));
 }
 
+#ifdef DEBUG_GASMAN_MARKING
+UInt BadMarksCounter = 0;
+Int DisableMarkBagValidation = 0;
+#endif
+
+
 // We define MarkBag as a inline function here so that
 // the compiler can optimize the marking functions using it in the
 // "current translation unit", i.e. inside gasman.c.
@@ -676,6 +682,13 @@ inline void MarkBag(Bag bag)
         LINK_BAG(bag) = MarkedBags;
         MarkedBags = bag;
     }
+#ifdef DEBUG_GASMAN_MARKING
+    else if (!DisableMarkBagValidation) {
+        if (bag != 0 && !((UInt)bag & 3) && !IS_BAG_ID(bag)) {
+            BadMarksCounter++;
+        }
+    }
+#endif
 }
 
 void MarkBagWeakly(Bag bag)
@@ -1755,6 +1768,10 @@ void GenStackFuncBags ( void )
     Bag *               p;              /* loop variable                   */
     UInt                i;              /* loop variable                   */
 
+#ifdef DEBUG_GASMAN_MARKING
+    DisableMarkBagValidation = 1;
+#endif
+
     top = (Bag*)((void*)&top);
     if ( StackBottomBags < top ) {
         for ( i = 0; i < sizeof(Bag*); i += StackAlignBags ) {
@@ -1775,6 +1792,9 @@ void GenStackFuncBags ( void )
           p++ )
         MarkBag( *p );
 
+#ifdef DEBUG_GASMAN_MARKING
+    DisableMarkBagValidation = 0;
+#endif
 }
 
 UInt FullBags;

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -649,6 +649,11 @@ void MarkAllSubBags(Bag bag)
     MarkArrayOfBags(CONST_PTR_BAG(bag), SIZE_BAG(bag) / sizeof(Bag));
 }
 
+void MarkAllButFirstSubBags(Bag bag)
+{
+    MarkArrayOfBags(CONST_PTR_BAG(bag) + 1, SIZE_BAG(bag) / sizeof(Bag) - 1);
+}
+
 void MarkAllSubBagsDefault(Bag bag)
 {
     MarkArrayOfBags(CONST_PTR_BAG(bag), SIZE_BAG(bag) / sizeof(Bag));

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -613,41 +613,35 @@ static inline Bag UNMARKED_HALFDEAD(Bag x)
 }
 
 
+inline void MarkArrayOfBags(const Bag array[], UInt count)
+{
+    for (UInt i = 0; i < count; i++) {
+        MarkBag(array[i]);
+    }
+}
+
 void MarkNoSubBags(Bag bag)
 {
 }
 
 void MarkOneSubBags(Bag bag)
 {
-    MarkBag(CONST_PTR_BAG(bag)[0]);
+    MarkArrayOfBags(CONST_PTR_BAG(bag), 1);
 }
 
 void MarkTwoSubBags(Bag bag)
 {
-    MarkBag(CONST_PTR_BAG(bag)[0]);
-    MarkBag(CONST_PTR_BAG(bag)[1]);
+    MarkArrayOfBags(CONST_PTR_BAG(bag), 2);
 }
 
 void MarkThreeSubBags(Bag bag)
 {
-    MarkBag(CONST_PTR_BAG(bag)[0]);
-    MarkBag(CONST_PTR_BAG(bag)[1]);
-    MarkBag(CONST_PTR_BAG(bag)[2]);
+    MarkArrayOfBags(CONST_PTR_BAG(bag), 3);
 }
 
 void MarkFourSubBags(Bag bag)
 {
-    MarkBag(CONST_PTR_BAG(bag)[0]);
-    MarkBag(CONST_PTR_BAG(bag)[1]);
-    MarkBag(CONST_PTR_BAG(bag)[2]);
-    MarkBag(CONST_PTR_BAG(bag)[3]);
-}
-
-inline void MarkArrayOfBags(const Bag array[], UInt count)
-{
-    for (UInt i = 0; i < count; i++) {
-        MarkBag(array[i]);
-    }
+    MarkArrayOfBags(CONST_PTR_BAG(bag), 4);
 }
 
 void MarkAllSubBags(Bag bag)

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -806,6 +806,8 @@ extern void MarkAllSubBags( Bag bag );
 
 extern void MarkAllSubBagsDefault ( Bag );
 
+extern void MarkAllButFirstSubBags( Bag bag );
+
 /****************************************************************************
 **
 *F  MarkBag(<bag>) . . . . . . . . . . . . . . . . . . .  mark a bag as live

--- a/src/objects.c
+++ b/src/objects.c
@@ -2009,14 +2009,14 @@ static Int InitKernel (
 
     /* install the marking methods                                         */
     InfoBags[         T_COMOBJ          ].name = "object (component)";
-    InitMarkFuncBags( T_COMOBJ          , MarkAllSubBags  );
+    InitMarkFuncBags( T_COMOBJ          , MarkPRecSubBags );
     InfoBags[         T_POSOBJ          ].name = "object (positional)";
     InitMarkFuncBags( T_POSOBJ          , MarkAllSubBags  );
     InfoBags[         T_DATOBJ          ].name = "object (data)";
     InitMarkFuncBags( T_DATOBJ          , MarkOneSubBags  );
 #if !defined(USE_THREADSAFE_COPYING)
     InfoBags[         T_COMOBJ +COPYING ].name = "object (component,copied)";
-    InitMarkFuncBags( T_COMOBJ +COPYING , MarkAllSubBags  );
+    InitMarkFuncBags( T_COMOBJ +COPYING , MarkPRecSubBags );
     InfoBags[         T_POSOBJ +COPYING ].name = "object (positional,copied)";
     InitMarkFuncBags( T_POSOBJ +COPYING , MarkAllSubBags  );
     InfoBags[         T_DATOBJ +COPYING ].name = "object (data,copied)";

--- a/src/opers.c
+++ b/src/opers.c
@@ -3313,22 +3313,22 @@ void InstallGlobalFunction (
 void SaveOperationExtras (
     Obj         oper )
 {
-    UInt        i;
+    const OperBag * header = CONST_OPER(oper);
 
-    SaveSubObj(FLAG1_FILT(oper));
-    SaveSubObj(FLAG2_FILT(oper));
-    SaveSubObj(FLAGS_FILT(oper));
-    SaveSubObj(SETTR_FILT(oper));
-    SaveSubObj(TESTR_FILT(oper));
-    SaveUInt(ENABLED_ATTR(oper));
-    for (i = 0; i <= 7; i++)
-        SaveSubObj(METHS_OPER(oper,i));
+    SaveSubObj(header->flag1);
+    SaveSubObj(header->flag2);
+    SaveSubObj(header->flags);
+    SaveSubObj(header->setter);
+    SaveSubObj(header->tester);
+    SaveSubObj(header->enabled);
+    for (UInt i = 0; i <= 7; i++)
+        SaveSubObj(header->methods[i]);
 #ifdef HPCGAP
     // FIXME: We probably don't want to save/restore the cache?
     // (and that would include "normal" GAP, too...)
 #else
-    for (i = 0; i <= 7; i++)
-        SaveSubObj(CACHE_OPER(oper,i));
+    for (UInt i = 0; i <= 7; i++)
+        SaveSubObj(header->cache[i]);
 #endif
 }
 
@@ -3344,23 +3344,22 @@ void SaveOperationExtras (
 void LoadOperationExtras (
     Obj         oper )
 {
-    UInt        i;
+    OperBag * header = OPER(oper);
 
-    SET_FLAG1_FILT(oper, LoadSubObj());
-    SET_FLAG2_FILT(oper, LoadSubObj());
-    SET_FLAGS_FILT(oper, LoadSubObj());
-    SET_SETTR_FILT(oper, LoadSubObj());
-    SET_TESTR_FILT(oper, LoadSubObj());
-    i = LoadUInt();
-    SET_ENABLED_ATTR(oper,i);
-    for (i = 0; i <= 7; i++)
-        SET_METHS_OPER(oper, i, LoadSubObj());
+    header->flag1 = LoadSubObj();
+    header->flag2 = LoadSubObj();
+    header->flags = LoadSubObj();
+    header->setter = LoadSubObj();
+    header->tester = LoadSubObj();
+    header->enabled = LoadSubObj();
+    for (UInt i = 0; i <= 7; i++)
+        header->methods[i] = LoadSubObj();
 #ifdef HPCGAP
     // FIXME: We probably don't want to save/restore the cache?
     // (and that would include "normal" GAP, too...)
 #else
-    for (i = 0; i <= 7; i++)
-        SET_CACHE_OPER(oper, i, LoadSubObj());
+    for (UInt i = 0; i <= 7; i++)
+        header->cache[i] = LoadSubObj();
 #endif
 }
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -3644,8 +3644,8 @@ static Int InitKernel (
     InitBagNamesFromTable( BagNames );
 
     for ( t1 = T_PLIST;  t1 < T_PLIST_FFE ;  t1 += 2 ) {
-        InitMarkFuncBags( t1                     , MarkAllSubBags );
-        InitMarkFuncBags( t1 +IMMUTABLE          , MarkAllSubBags );
+        InitMarkFuncBags( t1                     , MarkAllButFirstSubBags );
+        InitMarkFuncBags( t1 +IMMUTABLE          , MarkAllButFirstSubBags );
 #if !defined(USE_THREADSAFE_COPYING)
         InitMarkFuncBags( t1            +COPYING , MarkAllSubBags );
         InitMarkFuncBags( t1 +IMMUTABLE +COPYING , MarkAllSubBags );

--- a/src/precord.c
+++ b/src/precord.c
@@ -823,6 +823,29 @@ void LoadPRec( Obj prec )
 
 /****************************************************************************
 **
+*F  MarkPRecSubBags( <bag> ) . . . . marking function for precs and com. objs
+**
+**  'MarkPRecSubBags' is the marking function for bags of type 'T_PREC' or
+**  'T_COMOBJ'.
+*/
+void MarkPRecSubBags(Obj bag)
+{
+    const Bag * data = CONST_PTR_BAG(bag);
+    const UInt count = SIZE_BAG(bag) / sizeof(Bag);
+
+    // while data[0] is unused for regular precords, it used during copying
+    // to store a pointer to the copy; moreover, this mark function is also
+    // used for component objects, which store their type in slot 0
+    MarkBag(data[0]);
+
+    for (UInt i = 3; i < count; i += 2) {
+        MarkBag(data[i]);
+    }
+}
+
+
+/****************************************************************************
+**
 *F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
 */
 
@@ -864,11 +887,11 @@ static Int InitKernel (
     /* GASMAN marking functions and GASMAN names                           */
     InitBagNamesFromTable( BagNames );
 
-    InitMarkFuncBags( T_PREC                     , MarkAllSubBags );
-    InitMarkFuncBags( T_PREC +IMMUTABLE          , MarkAllSubBags );
+    InitMarkFuncBags( T_PREC                     , MarkPRecSubBags );
+    InitMarkFuncBags( T_PREC +IMMUTABLE          , MarkPRecSubBags );
 #if !defined(USE_THREADSAFE_COPYING)
-    InitMarkFuncBags( T_PREC            +COPYING , MarkAllSubBags );
-    InitMarkFuncBags( T_PREC +IMMUTABLE +COPYING , MarkAllSubBags );
+    InitMarkFuncBags( T_PREC            +COPYING , MarkPRecSubBags );
+    InitMarkFuncBags( T_PREC +IMMUTABLE +COPYING , MarkPRecSubBags );
 #endif
 
     /* Immutable records are public                                        */

--- a/src/precord.h
+++ b/src/precord.h
@@ -260,6 +260,10 @@ extern void CopyPRecord(Obj copy, Obj original);
 #endif
 
 
+
+extern void MarkPRecSubBags(Obj bag);
+
+
 /****************************************************************************
 **
 *F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *

--- a/src/vars.h
+++ b/src/vars.h
@@ -77,8 +77,8 @@ static inline int IS_LVARS_OR_HVARS(Obj obj)
 
 
 typedef struct {
-    Obj func;
     Expr stat;
+    Obj func;
     Obj parent;
 } LVarsHeader;
 


### PR DESCRIPTION
This PR how we mark-for-garbage-collection in various bag types with GASMAN. This is motivated by @rbehrends' work on integrating Julia GC, see PR #2092 

Specifically, when marking bags during garbage collection, we were very liberal in what we passed on to `MarkBag` (directly or indirectly). This is no big deal with GASMAN, as GASMAN can easily decide whether a given pointer is a master pointer or not (it has to be in a certain range), and ignore all other values passed to it. For other GCs, this is not quite as easy, as master pointers typically are not allocated from a fixed pool (though one could think about doing that... with the provision that one may have to maintain multiple such pools...)

This PR resolves most of these issues:

* we abused `T_BODY` bags in `code.c` to maintain two stacks of statements resp. expressions, which are not bags. But in a `T_BODY`, the first three slots are expected to be bag refs. This wasn't the case for these stacks. So now we use a `T_DATOBJ` for them (and make sure to leave its type slot intact)
* we marked all slots in plists via `MarkAllSubBags`; but the first slot contains the length of the list; fixed via new marking function `MarkAllButFirstSubBags`
* we marked all slots in precords and component objects via `MarkAllSubBags`; but only slot 0 (for component objects), and the odd slots starting with slot 3, contain bag refs. Fixed with a custom marking function `MarkPRecSubBags`
* we marked all slots in `T_FUNCTION` objects via `MarkAllSubBags`; but we store pointers to C functions in the first 8 slots, and also stored raw `UInt` values in two other slots. The latter were replaced by immediate integer objects; and a custom marking function `MarkFunctionSubBags` was added, which skips the first 8 slots, and only marks the rest.
* I also added a debug `#define DEBUG_GASMAN_MARKING` which enables code that tests if `MarkBag` is called on something that is neither a valid bag ref, a valid immediate object (integer or FFE), nor a null pointer. This can be used to track down more instances of the problem type described here, which is much easier than trying to do so while also hooking up a new GC at the same time ;-).
* For LVars and HVars, there is an `Expr` in slot 1 which should not marked. I moved it from slot 1 into slot 0, and then made it use `MarkAllButFirstSubBags`. This also required tweaking the LVars pool code, which I did (it is now also documented and more readable).