### PR TITLE
Some Input/Output cleanup

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -736,6 +736,17 @@ static Obj PRINT_OR_APPEND_TO(Obj args, int append)
     i = append ? OpenAppend( CSTR_STRING(filename) )
                : OpenOutput( CSTR_STRING(filename) );
     if ( ! i ) {
+        if (strcmp(CSTR_STRING(filename), "*errout*")) {
+            // When trying to print an error opening *errout* failed,
+            // We exit GAP after trying to print an error.
+            // First try printing an error to stderr
+            int ret = fputs("gap: panic, could not open *errout*!\n", stderr);
+            // If that failed, try printing to stdout
+            if(ret == EOF) {
+                fputs("gap: panic, could not open *errout*!\n", stdout);
+            }
+            SyExit(1);
+        }
         ErrorQuit( "%s: cannot open '%g' for output",
                    (Int)funcname, (Int)filename );
         return 0;

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -87,12 +87,13 @@ typedef void sig_handler_t ( int );
 
 
 /* utility to check return value of 'write'  */
-ssize_t writeandcheck(int fd, const char *buf, size_t count) {
+ssize_t echoandcheck(int fid, const char *buf, size_t count) {
   int ret;
-  ret = write(fd, buf, count);
+
+  ret = write(syBuf[fid].echo, buf, count);
   if (ret < 0)
     ErrorQuit("Cannot write to file descriptor %d, see 'LastSystemError();'\n",
-               fd, 0L);
+               fid, 0L);
   return ret;
 }
 
@@ -588,7 +589,6 @@ void syWinPut (
     const Char *        cmd,
     const Char *        str )
 {
-    Int                 fd;             /* file descriptor                 */
     Char                tmp [130];      /* temporary buffer                */
     const Char *        s;              /* pointer into the string         */
     Char *              t;              /* pointer into the temporary      */
@@ -597,12 +597,8 @@ void syWinPut (
     if ( ! SyWindow || 4 <= fid )
         return;
 
-    /* get the file descriptor                                             */
-    if ( fid == 0 || fid == 2 )  fd = syBuf[fid].echo;
-    else                         fd = syBuf[fid].fp;
-
     /* print the cmd                                                       */
-    writeandcheck( fd, cmd, strlen(cmd) );
+    echoandcheck( fid, cmd, strlen(cmd) );
 
     /* print the output line, duplicate '@' and handle <ctr>-<chr>         */
     s = str;  t = tmp;
@@ -617,12 +613,12 @@ void syWinPut (
             *t++ = *s++;
         }
         if ( 128 <= t-tmp ) {
-            writeandcheck( fd, tmp, t-tmp );
+            echoandcheck( fid, tmp, t-tmp );
             t = tmp;
         }
     }
     if ( 0 < t-tmp ) {
-        writeandcheck( fd, tmp, t-tmp );
+        echoandcheck( fid, tmp, t-tmp );
     }
 }
 
@@ -1301,12 +1297,12 @@ void syEchoch (
 
     /* write the character to the associate echo output device             */
     ch2 = ch;
-    writeandcheck( syBuf[fid].echo, (char*)&ch2, 1 );
+    echoandcheck( fid, (char*)&ch2, 1 );
 
     /* if running under a window handler, duplicate '@'                    */
     if ( SyWindow && ch == '@' ) {
         ch2 = ch;
-        writeandcheck( syBuf[fid].echo, (char*)&ch2, 1 );
+        echoandcheck( fid, (char*)&ch2, 1 );
     }
 }
 
@@ -1351,7 +1347,7 @@ void syEchos (
 
     /* otherwise, write it to the associate echo output device             */
     else
-        writeandcheck( syBuf[fid].echo, str, strlen(str) );
+        echoandcheck(fid, str, strlen(str) );
 }
 
 
@@ -1398,7 +1394,7 @@ void SyFputs (
 
     /* otherwise, write it to the output file                              */
     else
-        writeandcheck( syBuf[fid].fp, line, i );
+        echoandcheck( fid, line, i );
 }
 
 

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -173,6 +173,10 @@ extern SYS_SY_BUFFER syBuffers[32];
 
 extern UInt SySetBuffering( UInt fid );
 
+extern void SyMarkBufUnused(Int i);
+
+extern Int SyBufInUse(Int i);
+
 /****************************************************************************
 **
 *F  SyFileno( <fid> ) . . . . . . . . . . . . . . get operating system fileno

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -142,8 +142,10 @@ extern const Char * SyWinCmd (
 **  otherwise confuse Gasman.
 */
 typedef struct {
-  int         fp;          /* file descriptor for this file */
-  int         echo;        /* file descriptor for the echo */
+  int         fp;          /* file descriptor for this file. This is used
+                              for input */
+  int         echo;        /* file descriptor for the echo. This is used
+                              for output. Is set to 0 if read-only file */
   UInt        pipe;        /* file is really a pipe */
   FILE       *pipehandle;  /* for pipes we need to remember the file handle */
   UInt        ateof;       /* set to 1 by any read operation that hits eof

--- a/src/system.c
+++ b/src/system.c
@@ -1174,7 +1174,7 @@ void InitSystem (
     setbuf(stderr, (char *)0);
 
     for (i = 4; i < ARRAY_SIZE(syBuf); i++)
-        syBuf[i].fp = -1;
+        SyMarkBufUnused(i);
 
     for (i = 0; i < ARRAY_SIZE(syBuffers); i++)
         syBuffers[i].inuse = 0;

--- a/src/system.c
+++ b/src/system.c
@@ -1165,7 +1165,7 @@ void InitSystem (
     }
 
     // set up errout
-    syBuf[3].fp = fileno(stderr);
+    syBuf[3].echo = syBuf[3].fp = fileno(stderr);
     syBuf[3].bufno = -1;
 
     // turn off buffering


### PR DESCRIPTION
These two commits are some cleanups I wrote while adding zlib support. I decided to seperate them out as to make review easier.

The first basically simplifies how we handle `.echo` and `.fp`, to consistently always write to `.echo`. In practice this rarely make a difference because except for descriptors 0 and 2, for any descriptor we can write to `.echo` and `.fp` are always the same value.

The second makes it clearer when we are checking if a descriptor is currently in use.

Both of these patches will make the later gzip support much easier to read and smaller, because now I only have to change writing, and checking if streams are in use, in one place.