### PR TITLE
kernel: track LoopNesting in the reader, not coder

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -59,6 +59,7 @@ typedef struct GAPState {
     UInt      CurrLHSGVar;
     UInt      CurrentGlobalForLoopVariables[100];
     UInt      CurrentGlobalForLoopDepth;
+    UInt      LoopNesting;
 
     /* From scanner.c */
     Obj    ValueObj;
@@ -81,9 +82,6 @@ typedef struct GAPState {
     Stat   OffsBody;
     Stat * OffsBodyStack;
     UInt   OffsBodyCount;
-    UInt   LoopNesting;
-    UInt * LoopStack;
-    UInt   LoopStackCount;
 
     Obj CodeResult;
     Bag StackStat;

--- a/tst/testinstall/break.tst
+++ b/tst/testinstall/break.tst
@@ -1,16 +1,50 @@
 gap> START_TEST("break.tst");
+
+#
 gap> break;
-Error, 'break' statement can only appear inside a loop
-gap> continue;
-Error, 'continue' statement can only appear inside a loop
+Syntax error: 'break' statement not enclosed in a loop in stream:1
+break;
+    ^
+gap> if true then break; fi;
+Syntax error: 'break' statement not enclosed in a loop in stream:1
+if true then break; fi;
+                 ^
+gap> if false then break; fi;
+Syntax error: 'break' statement not enclosed in a loop in stream:1
+if false then break; fi;
+                  ^
 gap> f := function() break; end;
 Syntax error: 'break' statement not enclosed in a loop in stream:1
 f := function() break; end;
+                    ^
+gap> for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
+Syntax error: 'break' statement not enclosed in a loop in stream:1
+for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
+                                                ^
+
+#
+gap> continue;
+Syntax error: 'continue' statement not enclosed in a loop in stream:1
+continue;
+       ^
+gap> if true then continue; fi;
+Syntax error: 'continue' statement not enclosed in a loop in stream:1
+if true then continue; fi;
+                    ^
+gap> if false then continue; fi;
+Syntax error: 'continue' statement not enclosed in a loop in stream:1
+if false then continue; fi;
                      ^
 gap> f := function() continue; end;
 Syntax error: 'continue' statement not enclosed in a loop in stream:1
 f := function() continue; end;
-                        ^
+                       ^
+gap> for i in [1..5] do List([1..5], function(x) continue; return 1; end); od;
+Syntax error: 'continue' statement not enclosed in a loop in stream:1
+for i in [1..5] do List([1..5], function(x) continue; return 1; end); od;
+                                                   ^
+
+#
 gap> f := function() local i; for i in [1..5] do continue; od; end;;
 gap> f();
 gap> f := function() local i; for i in [1..5] do break; od; end;;
@@ -23,16 +57,6 @@ gap> f := function() local i; i := 1; repeat i := i + 1; continue; until i in [1
 gap> f();
 gap> f := function() local i; i := 1; repeat i := i + 1; break; until i in [1..5]; end;;
 gap> f();
-gap> for i in [1..5] do List([1..5], function(x) continue; return 1; end); od;
-Syntax error: 'continue' statement not enclosed in a loop in stream:1
-for i in [1..5] do List([1..5], function(x) continue; return 1; end); od;
-                                                    ^
-gap> for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
-Syntax error: 'break' statement not enclosed in a loop in stream:1
-for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
-                                                 ^
-gap> for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
-Syntax error: 'break' statement not enclosed in a loop in stream:1
-for i in [1..5] do List([1..5], function(x) break; return 1; end); od;
-                                                 ^
+
+#
 gap> STOP_TEST("break.tst", 1);


### PR DESCRIPTION
These constitute syntax errors, so it makes sense to report then before
coding. This also yields uniform error handling, including when using
break/continue outside of coding (which is always illegal).

As an added bonus, we get rid of LoopStack and LoopStackCount.

I also think that the new code is much easier to understand, verify and debug, but I may be biased ;-).

(The end game here is that I want to move all `SyntaxError` calls to either `read.c` or `scanner.c`; right now we also have some in `code.c` and `intrprt.c`. This PR gets rid of those in the coder. I have more coming up which get rid of some of those in the interpreter.