### PR TITLE
kernel: remove S_PARTIALFLOAT1, mark float parsing hack

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -980,11 +980,6 @@ void ReadLongNumber(
            /*      Match(S_PARTIALINT, "integer", follow);*/
            break;
 
-         case S_PARTIALFLOAT1:
-           assert(0);
-           Pr("Parsing error, this should never happen", 0L, 0L);
-           SyExit(2);
-
          case S_PARTIALFLOAT2:
          case S_PARTIALFLOAT3:
          case S_PARTIALFLOAT4:
@@ -1010,41 +1005,10 @@ void ReadLongNumber(
          }
          break;
 
-       case S_PARTIALFLOAT1:
-         switch (STATE(Symbol)) {
-         case S_INT:
-         case S_PARTIALINT:
-         case S_PARTIALFLOAT1:
-           assert(0);
-           Pr("Parsing error, this should never happen", 0L, 0L);
-           SyExit(2);
-
-
-         case S_PARTIALFLOAT2:
-         case S_PARTIALFLOAT3:
-         case S_PARTIALFLOAT4:
-           status = STATE(Symbol);
-           appendToString(string, STATE(Value));
-           /* Match(STATE(Symbol), "float", follow); */
-           break;
-
-         case S_FLOAT:
-           appendToString(string, STATE(Value));
-           Match(S_FLOAT, "float", follow);
-           TRY_READ { IntrLongFloatExpr(string); }
-           done = 1;
-           break;
-
-         default:
-           SyntaxError("Badly Formed Number");
-         }
-         break;
-
        case S_PARTIALFLOAT2:
          switch (STATE(Symbol)) {
          case S_INT:
          case S_PARTIALINT:
-         case S_PARTIALFLOAT1:
            assert(0);
            Pr("Parsing error, this should never happen", 0L, 0L);
            SyExit(2);
@@ -1080,7 +1044,6 @@ void ReadLongNumber(
          switch (STATE(Symbol)) {
          case S_INT:
          case S_PARTIALINT:
-         case S_PARTIALFLOAT1:
          case S_PARTIALFLOAT2:
          case S_PARTIALFLOAT3:
            assert(0);
@@ -1111,7 +1074,6 @@ void ReadLongNumber(
          switch (STATE(Symbol)) {
          case S_INT:
          case S_PARTIALINT:
-         case S_PARTIALFLOAT1:
          case S_PARTIALFLOAT2:
          case S_PARTIALFLOAT3:
            assert(0);
@@ -1662,6 +1624,13 @@ static void ReadLiteral (
     TypSymbolSet        follow,
     Char mode)
 {
+    if (STATE(Symbol) == S_DOT) {
+        // HACK: The only way a dot could turn up here is in a floating point
+        // literal that starts with '.'. Call back to the scanner to deal
+        // with this.
+        ScanForFloatAfterDotHACK();
+    }
+
     switch (STATE(Symbol)) {
 
     /* <Int>                                                               */
@@ -1678,7 +1647,6 @@ static void ReadLiteral (
 
     /* partial Int */
     case S_PARTIALINT:
-    case S_PARTIALFLOAT1:
     case S_PARTIALFLOAT2:
         ReadLongNumber( follow );
         break;
@@ -1730,18 +1698,6 @@ static void ReadLiteral (
     case S_FUNCTION:
     case S_ATOMIC:
         ReadFuncExpr( follow, mode );
-        break;
-
-    case S_DOT:
-        /* HACK: The only way a dot could turn up here is in a floating point
-           literal that starts with .. So, change the token to a partial float
-           of the right kind to end with a . and an associated value and dive
-           into the long float literal handler in the parser
-         */
-        STATE(Symbol) = S_PARTIALFLOAT1;
-        STATE(Value)[0] = '.';
-        STATE(Value)[1] = '\0';
-        ReadLongNumber( follow );
         break;
 
     case S_LBRACE:

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -371,6 +371,10 @@ static void GetNumber(UInt StartingStatus)
   UInt seenADigit = (StartingStatus != 0 && StartingStatus != 2);
   UInt seenExpDigit = (StartingStatus ==5);
 
+  if (StartingStatus == 2) {
+    STATE(Value)[i++] = '.';
+  }
+
   c = PEEK_CURR_CHAR();
   if (StartingStatus  <  2) {
     // read initial sequence of digits into 'Value'
@@ -584,6 +588,17 @@ static void GetNumber(UInt StartingStatus)
     SyntaxError("Badly Formed Number: need at least one digit in the exponent");
   STATE(Symbol) = S_FLOAT;
   STATE(Value)[i] = '\0';
+}
+
+
+/****************************************************************************
+**
+*F  ScanForFloatAfterDotHACK()
+**
+*/
+void ScanForFloatAfterDotHACK(void)
+{
+    GetNumber(2);
 }
 
 
@@ -930,7 +945,6 @@ static void NextSymbol(void)
     /* special case if reading of a long token is not finished */
     switch (STATE(Symbol)) {
     case S_PARTIALINT:        GetNumber(STATE(Value)[0] == '\0' ? 0 : 1); return;
-    case S_PARTIALFLOAT1:     GetNumber(2); return;
     case S_PARTIALFLOAT2:     GetNumber(3); return;
     case S_PARTIALFLOAT3:     GetNumber(4); return;
     case S_PARTIALFLOAT4:     GetNumber(5); return;

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -59,10 +59,6 @@ enum SCANNER_SYMBOLS {
     S_INT               = (1UL<<10)+1,
     S_FLOAT             = (1UL<<10)+2,
 
-    // A decimal point only, but in a context where we know it's the start of
-    // a number
-    S_PARTIALFLOAT1     = (1UL<<10)+3,
-
     // Some digits and a decimal point
     S_PARTIALFLOAT2     = (1UL<<10)+4,
 
@@ -361,6 +357,18 @@ extern void Match (
             const Char *        msg,
             TypSymbolSet        skipto );
 
+
+/****************************************************************************
+**
+*F  ScanForFloatAfterDotHACK()
+**
+**  This function is called by 'ReadLiteral' if it encounters a single dot in
+**  form the of the symbol 'S_DOT'. The only legal way this could happen is
+**  if the dot is the start of a float literal like '.123'. As the scanner
+**  cannot detect this without being context aware, we must provide this
+**  function to allow the reader to signal to the scanner about this.
+*/
+extern void ScanForFloatAfterDotHACK(void);
 
 /****************************************************************************
 **


### PR DESCRIPTION
Parsing float literals that start with a dot, like `.123`, is
implemented using a hack, where the reader tells the scanner that it
should look for a number expression (normally, the scanner never changes
the state of the reader, except for parsing long integers and float
literals).

We change the way this is done to make it stand out more. Further
benefits from the change are that we can get rid of S_PARTIALFLOAT1,
simplifying the intricate state machine for parsing. Moreover,
STATE(Symbol) now is read-only in the reader.