### PR TITLE
kernel: use C99 init for streams' StructInitInfo

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -2247,18 +2247,13 @@ static Int InitLibrary (
 *F  InitInfoStreams() . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    MODULE_BUILTIN,                     /* type                           */
-    "streams" ,                         /* name                           */
-    0,                                  /* revision entry of c file       */
-    0,                                  /* revision entry of h file       */
-    0,                                  /* version                        */
-    0,                                  /* crc                            */
-    InitKernel,                         /* initKernel                     */
-    InitLibrary,                        /* initLibrary                    */
-    0,                                  /* checkInit                      */
-    0,                                  /* preSave                        */
-    0,                                  /* postSave                       */
-    PostRestore                         /* postRestore                    */
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "streams",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = PostRestore,
 };
 
 StructInitInfo * InitInfoStreams ( void )


### PR DESCRIPTION
Not sure how I missed this one back when I converted all the others.