### PR TITLE
Fix list error messages for too large indices; add some more tests

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -504,7 +504,17 @@ Obj ElmsBlist (
         for ( i = 1; i <= lenPoss; i++ ) {
 
             /* get <position>                                              */
-            pos = INT_INTOBJ( ELMW_LIST( poss, (Int)i ) );
+            Obj p = ELMW_LIST(poss, i);
+            while (!IS_INTOBJ(p)) {
+                p = ErrorReturnObj("List Elements: position is too large for "
+                                   "this type of list",
+                                   0L, 0L,
+                                   "you can supply a new position <pos> via "
+                                   "'return <pos>;'");
+            }
+            pos = INT_INTOBJ(p);
+
+            /* select the element                                          */
             if ( lenList < pos ) {
                 ErrorReturnVoid(
                     "List Elements: <list>[%d] must have an assigned value",

--- a/src/error.c
+++ b/src/error.c
@@ -543,6 +543,33 @@ void CheckIsPossList(const Char * desc, Obj poss)
 
 /****************************************************************************
 **
+*F  CheckIsDenseList( <desc>, <listName>, <list> ) . . . check for dense list
+*/
+void CheckIsDenseList(const Char * desc, const Char * listName, Obj list)
+{
+    if (!IS_DENSE_LIST(list)) {
+        ErrorQuit("%s: <%s> must be a dense list", (Int)desc, (Int)listName);
+    }
+}
+
+/****************************************************************************
+**
+*F  CheckSameLength
+*/
+void CheckSameLength(const Char * desc, const Char *leftName, const Char *rightName, Obj left, Obj right)
+{
+    UInt ll = LEN_LIST(left);
+    UInt lr = LEN_LIST(right);
+    if ( ll != lr ) {
+        Char message[1024];
+        snprintf(message, sizeof(message), "%s: <%s> must have the same length as <%s> (not %d and %d)",
+            desc, leftName, rightName, (int)ll, (int)lr);
+        ErrorQuit(message, 0, 0);
+    }
+}
+
+/****************************************************************************
+**
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
 static StructGVarFunc GVarFuncs[] = {

--- a/src/error.c
+++ b/src/error.c
@@ -529,6 +529,17 @@ void ErrorMayQuit(const Char * msg, Int arg1, Int arg2)
     SyExit(1);
 }
 
+/****************************************************************************
+**
+*F  CheckIsPossList( <desc>, <poss> ) . . . . . . . . . . check for poss list
+*/
+void CheckIsPossList(const Char * desc, Obj poss)
+{
+    if ( ! IS_POSS_LIST( poss ) ) {
+        ErrorQuit("%s: <positions> must be a dense list of positive integers",
+            (Int)desc, 0 );
+    }
+}
 
 /****************************************************************************
 **

--- a/src/error.h
+++ b/src/error.h
@@ -129,6 +129,13 @@ ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2);
 
 /****************************************************************************
 **
+*F  CheckIsPossList( <desc>, <poss> ) . . . . . . . . . . check for poss list
+*/
+void CheckIsPossList(const Char * desc, Obj poss);
+
+
+/****************************************************************************
+**
 *F * * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * *
 */
 

--- a/src/error.h
+++ b/src/error.h
@@ -136,6 +136,20 @@ void CheckIsPossList(const Char * desc, Obj poss);
 
 /****************************************************************************
 **
+*F  CheckIsDenseList( <desc>, <listName>, <list> ) . . . check for dense list
+*/
+void CheckIsDenseList(const Char * desc, const Char * listName, Obj list);
+
+
+/****************************************************************************
+**
+*F  CheckSameLength
+*/
+void CheckSameLength(const Char * desc, const Char *leftName, const Char *rightName, Obj left, Obj right);
+
+
+/****************************************************************************
+**
 *F * * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * *
 */
 

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -1362,9 +1362,7 @@ Obj FuncMultiSendChannel(Obj self, Obj channel, Obj list)
     if (!IsChannel(channel))
         return ArgumentError(
             "MultiSendChannel: First argument must be a channel");
-    if (!IS_DENSE_LIST(list))
-        return ArgumentError(
-            "MultiSendChannel: Second argument must be a dense list");
+    CheckIsDenseList("MultiSendChannel", "list", list);
     MultiSendChannel(ObjPtr(channel), list, 1);
     return (Obj)0;
 }
@@ -1374,9 +1372,7 @@ Obj FuncMultiTransmitChannel(Obj self, Obj channel, Obj list)
     if (!IsChannel(channel))
         return ArgumentError(
             "MultiTransmitChannel: First argument must be a channel");
-    if (!IS_DENSE_LIST(list))
-        return ArgumentError(
-            "MultiTransmitChannel: Second argument must be a dense list");
+    CheckIsDenseList("MultiTransmitChannel", "list", list);
     MultiSendChannel(ObjPtr(channel), list, 0);
     return (Obj)0;
 }
@@ -1386,9 +1382,7 @@ Obj FuncTryMultiSendChannel(Obj self, Obj channel, Obj list)
     if (!IsChannel(channel))
         return ArgumentError(
             "TryMultiSendChannel: First argument must be a channel");
-    if (!IS_DENSE_LIST(list))
-        return ArgumentError(
-            "TryMultiSendChannel: Second argument must be a dense list");
+    CheckIsDenseList("TryMultiSendChannel", "list", list);
     return INTOBJ_INT(TryMultiSendChannel(ObjPtr(channel), list, 1));
 }
 
@@ -1398,9 +1392,7 @@ Obj FuncTryMultiTransmitChannel(Obj self, Obj channel, Obj list)
     if (!IsChannel(channel))
         return ArgumentError(
             "TryMultiTransmitChannel: First argument must be a channel");
-    if (!IS_DENSE_LIST(list))
-        return ArgumentError(
-            "TryMultiTransmitChannel: Second argument must be a dense list");
+    CheckIsDenseList("TryMultiTransmitChannel", "list", list);
     return INTOBJ_INT(TryMultiSendChannel(ObjPtr(channel), list, 0));
 }
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -3006,11 +3006,7 @@ void            IntrAsssList ( void )
 
     /* get and check the positions                                         */
     poss = PopObj();
-    if ( ! IS_POSS_LIST( poss ) ) {
-        ErrorQuit(
-    "List Assignment: <positions> must be a dense list of positive integers",
-               0L, 0L );
-    }
+    CheckIsPossList("List Assignment", poss);
     if ( LEN_LIST( poss ) != LEN_LIST( rhss ) ) {
         ErrorQuit(
      "List Assignment: <rhss> must have the same length as <positions> (%d)",
@@ -3083,11 +3079,7 @@ void            IntrAsssListLevel (
 
     /* get and check the positions                                         */
     poss = PopObj();
-    if ( ! IS_POSS_LIST( poss ) ) {
-        ErrorQuit(
-    "List Assignment: <positions> must be a dense list of positive integers",
-            0L, 0L );
-    }
+    CheckIsPossList("List Assignment", poss);
 
     /* get lists (if this works, then <lists> is nested <level> deep,      */
     /* checking it is nested <level>+1 deep is done by 'AsssListLevel')    */
@@ -3201,11 +3193,7 @@ void            IntrElmsList ( void )
 
     /* get and check the positions                                         */
     poss = PopObj();
-    if ( ! IS_POSS_LIST( poss ) ) {
-        ErrorQuit(
-      "List Elements: <positions> must be a dense list of positive integers",
-            0L, 0L );
-    }
+    CheckIsPossList("List Elements", poss);
 
     /* get the list (checking is done by 'ELMS_LIST')                      */
     list = PopObj();
@@ -3272,11 +3260,7 @@ void            IntrElmsListLevel (
 
     /* get and check the positions                                         */
     poss = PopObj();
-    if ( ! IS_POSS_LIST( poss ) ) {
-        ErrorQuit(
-      "List Elements: <positions> must be a dense list of positive integers",
-            0L, 0L );
-    }
+    CheckIsPossList("List Elements", poss);
 
     /* get lists (if this works, then <lists> is nested <level> deep,      */
     /* checking it is nested <level>+1 deep is done by 'ElmsListLevel')    */
@@ -3619,11 +3603,7 @@ void            IntrAsssPosObj ( void )
 
     /* get and check the positions                                         */
     poss = PopObj();
-    if ( ! IS_POSS_LIST( poss ) ) {
-        ErrorQuit(
-    "PosObj Assignment: <positions> must be a dense list of positive integers",
-               0L, 0L );
-    }
+    CheckIsPossList("PosObj Assignment", poss);
     if ( LEN_LIST( poss ) != LEN_LIST( rhss ) ) {
         ErrorQuit(
      "PosObj Assignment: <rhss> must have the same length as <positions> (%d)",
@@ -3698,11 +3678,7 @@ void            IntrAsssPosObjLevel (
 
     /* get and check the positions                                         */
     poss = PopObj();
-    if ( ! IS_POSS_LIST( poss ) ) {
-        ErrorQuit(
-    "PosObj Assignment: <positions> must be a dense list of positive integers",
-            0L, 0L );
-    }
+    CheckIsPossList("PosObj Assignment", poss);
 
     /* assign the right hand sides to several elements of several lists    */
     ErrorQuit(
@@ -3852,11 +3828,7 @@ void            IntrElmsPosObj ( void )
 
     /* get and check the positions                                         */
     poss = PopObj();
-    if ( ! IS_POSS_LIST( poss ) ) {
-        ErrorQuit(
-      "PosObj Elements: <positions> must be a dense list of positive integers",
-            0L, 0L );
-    }
+    CheckIsPossList("PosObj Elements", poss);
 
     /* get the list (checking is done by 'ELMS_LIST')                      */
     list = PopObj();
@@ -3925,11 +3897,7 @@ void            IntrElmsPosObjLevel (
 
     /* get and check the positions                                         */
     poss = PopObj();
-    if ( ! IS_POSS_LIST( poss ) ) {
-        ErrorQuit(
-      "PosObj Elements: <positions> must be a dense list of positive integers",
-            0L, 0L );
-    }
+    CheckIsPossList("PosObj Elements", poss);
 
     /* get lists (if this works, then <lists> is nested <level> deep,      */
     /* checking it is nested <level>+1 deep is done by 'ElmsPosObjLevel')    */

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2998,20 +2998,12 @@ void            IntrAsssList ( void )
 
     /* get the right hand sides                                            */
     rhss = PopObj();
-    if ( ! IS_DENSE_LIST( rhss ) ) {
-        ErrorQuit(
-            "List Assignment: <rhss> must be a dense list",
-            0L, 0L );
-    }
+    CheckIsDenseList("List Assignment", "rhss", rhss);
 
     /* get and check the positions                                         */
     poss = PopObj();
     CheckIsPossList("List Assignment", poss);
-    if ( LEN_LIST( poss ) != LEN_LIST( rhss ) ) {
-        ErrorQuit(
-     "List Assignment: <rhss> must have the same length as <positions> (%d)",
-            (Int)LEN_LIST(poss), 0L );
-    }
+    CheckSameLength("List Assignment", "rhss", "positions", rhss, poss);
 
     /* get the list (checking is done by 'ASSS_LIST')                      */
     list = PopObj();
@@ -3595,20 +3587,12 @@ void            IntrAsssPosObj ( void )
 
     /* get the right hand sides                                            */
     rhss = PopObj();
-    if ( ! IS_DENSE_LIST( rhss ) ) {
-        ErrorQuit(
-            "PosObj Assignment: <rhss> must be a dense list",
-            0L, 0L );
-    }
+    CheckIsDenseList("PosObj Assignment", "rhss", rhss);
 
     /* get and check the positions                                         */
     poss = PopObj();
     CheckIsPossList("PosObj Assignment", poss);
-    if ( LEN_LIST( poss ) != LEN_LIST( rhss ) ) {
-        ErrorQuit(
-     "PosObj Assignment: <rhss> must have the same length as <positions> (%d)",
-            (Int)LEN_LIST(poss), 0L );
-    }
+    CheckSameLength("List Assignment", "rhss", "positions", rhss, poss);
 
     /* get the list (checking is done by 'ASSS_LIST')                      */
     list = PopObj();

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1017,13 +1017,7 @@ Obj FuncSORT_PARA_LIST (
     /* check the first two arguments                                       */
     CheckIsSmallList(list, "SORT_PARA_LIST");
     CheckIsSmallList(shadow, "SORT_PARA_LIST");
-
-    if( LEN_LIST( list ) != LEN_LIST( shadow ) ) {
-        ErrorMayQuit( 
-            "SORT_PARA_LIST: lists must have the same length (not %d and %d)",
-            (Int)LEN_LIST( list ),
-            (Int)LEN_LIST( shadow ));
-    }
+    CheckSameLength("SORT_PARA_LIST", "list", "shadow", list, shadow);
 
     /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) && IS_DENSE_PLIST(shadow) ) {
@@ -1046,13 +1040,7 @@ Obj FuncSTABLE_SORT_PARA_LIST (
     /* check the first two arguments                                       */
     CheckIsSmallList(list, "STABLE_SORT_PARA_LIST");
     CheckIsSmallList(shadow, "STABLE_SORT_PARA_LIST");
-
-    if( LEN_LIST( list ) != LEN_LIST( shadow ) ) {
-        ErrorMayQuit( 
-            "STABLE_SORT_PARA_LIST: lists must have the same length (not %d and %d)",
-            (Int)LEN_LIST( list ),
-            (Int)LEN_LIST( shadow ));
-    }
+    CheckSameLength("STABLE_SORT_PARA_LIST", "list", "shadow", list, shadow);
 
     /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) && IS_DENSE_PLIST(shadow) ) {
@@ -1081,13 +1069,7 @@ Obj FuncSORT_PARA_LIST_COMP (
     /* check the first two arguments                                       */
     CheckIsSmallList(list, "SORT_PARA_LIST_COMP");
     CheckIsSmallList(shadow, "SORT_PARA_LIST_COMP");
-
-    if( LEN_LIST( list ) != LEN_LIST( shadow ) ) {
-        ErrorMayQuit( 
-            "SORT_PARA_LIST_COMP: lists must have the same length (not %d and %d)",
-            (Int)LEN_LIST( list ),
-            (Int)LEN_LIST( shadow ));
-    }
+    CheckSameLength("SORT_PARA_LIST_COMP", "list", "shadow", list, shadow);
 
     /* check the third argument                                            */
     CheckIsFunction(func, "SORT_PARA_LIST_COMP");
@@ -1113,13 +1095,7 @@ Obj FuncSTABLE_SORT_PARA_LIST_COMP (
     /* check the first two arguments                                       */
     CheckIsSmallList(list, "SORT_PARA_LIST_COMP");
     CheckIsSmallList(shadow, "SORT_PARA_LIST_COMP");
-
-    if( LEN_LIST( list ) != LEN_LIST( shadow ) ) {
-        ErrorMayQuit( 
-            "SORT_PARA_LIST_COMP: lists must have the same length (not %d and %d)",
-            (Int)LEN_LIST( list ),
-            (Int)LEN_LIST( shadow ));
-    }
+    CheckSameLength("SORT_PARA_LIST_COMP", "list", "shadow", list, shadow);
 
     /* check the third argument                                            */
     CheckIsFunction(func, "SORT_PARA_LIST_COMP");

--- a/src/lists.c
+++ b/src/lists.c
@@ -824,11 +824,7 @@ Obj ElmsListCheck (
     Obj                 list,
     Obj                 poss )
 {
-    if ( ! IS_POSS_LIST(poss) ) {
-        ErrorQuit(
-      "List Elements: <positions> must be a dense list of positive integers",
-            0L, 0L );
-    }
+    CheckIsPossList("List Elements", poss);
     return ELMS_LIST( list, poss );
 }
 
@@ -845,11 +841,7 @@ void ElmsListLevelCheck (
     Obj                 poss,
     Int                 level )
 {
-    if ( ! IS_POSS_LIST(poss) ) {
-        ErrorQuit(
-      "List Elements: <positions> must be a dense list of positive integers",
-            0L, 0L );
-    }
+    CheckIsPossList("List Elements", poss);
     ElmsListLevel( lists, poss, level );
 }
 
@@ -2162,11 +2154,7 @@ void AsssListCheck (
     Obj                 poss,
     Obj                 rhss )
 {
-    if ( ! IS_POSS_LIST(poss) ) {
-        ErrorQuit(
-    "List Assignment: <positions> must be a dense list of positive integers",
-            0L, 0L );
-    }
+    CheckIsPossList("List Assignment", poss);
     if ( ! IS_DENSE_LIST(rhss) ) {
         ErrorQuit(
             "List Assignment: <rhss> must be a dense list",
@@ -2190,11 +2178,7 @@ void AsssPosObjCheck (
     Obj                 poss,
     Obj                 rhss )
 {
-    if ( ! IS_POSS_LIST(poss) ) {
-        ErrorQuit(
-    "List Assignment: <positions> must be a dense list of positive integers",
-            0L, 0L );
-    }
+    CheckIsPossList("List Assignment", poss);
     if ( ! IS_DENSE_LIST(rhss) ) {
         ErrorQuit(
             "List Assignment: <rhss> must be a dense list",
@@ -2224,11 +2208,7 @@ void AsssListLevelCheck (
     Obj                 rhss,
     Int                 level )
 {
-    if ( ! IS_POSS_LIST(poss) ) {
-        ErrorQuit(
-    "List Assignment: <positions> must be a dense list of positive integers",
-            0L, 0L );
-    }
+    CheckIsPossList("List Assignment", poss);
     AsssListLevel( lists, poss, rhss, level );
 }
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -1752,20 +1752,8 @@ void            AssListLevel (
     Obj pos,pos1,pos2;
 
     /* check <objs>                                                        */
-    while ( ! IS_DENSE_LIST(objs) || LEN_LIST(lists) != LEN_LIST(objs) ) {
-        if ( ! IS_DENSE_LIST(objs) ) {
-            objs = ErrorReturnObj(
-                "List Assignment: <objs> must be a dense list (not a %s)",
-                (Int)TNAM_OBJ(objs), 0L,
-                "you can replace <objs> via 'return <objs>;'" );
-        }
-        if ( LEN_LIST(lists) != LEN_LIST(objs) ) {
-            objs = ErrorReturnObj(
-         "List Assignment: <objs> must have the same length as <lists> (%d)",
-                LEN_LIST(lists), 0L,
-                "you can replace <objs> via 'return <objs>;'" );
-        }
-    }
+    CheckIsDenseList("List Assignment", "objs", objs);
+    CheckSameLength("List Assignment", "objs", "lists", objs, lists);
 
     /* if <level> is one, perform the assignments                          */
     if ( level == 1 ) {
@@ -1847,20 +1835,8 @@ void            AsssListLevel (
     Int                 i;              /* loop variable                   */
 
     /* check <objs>                                                        */
-    while ( ! IS_DENSE_LIST(objs) || LEN_LIST(lists) != LEN_LIST(objs) ) {
-        if ( ! IS_DENSE_LIST(objs) ) {
-            objs = ErrorReturnObj(
-                "List Assignment: <objs> must be a dense list (not a %s)",
-                (Int)TNAM_OBJ(objs), 0L,
-                "you can replace <objs> via 'return <objs>;'" );
-        }
-        if ( LEN_LIST(lists) != LEN_LIST(objs) ) {
-            objs = ErrorReturnObj(
-         "List Assignment: <objs> must have the same length as <lists> (%d)",
-                LEN_LIST(lists), 0L,
-                "you can replace <objs> via 'return <objs>;'" );
-        }
-    }
+    CheckIsDenseList("List Assignment", "objs", objs);
+    CheckSameLength("List Assignment", "objs", "lists", objs, lists);
 
     /* if <lev> is one, loop over all the lists and assign the value       */
     if ( lev == 1 ) {
@@ -1874,21 +1850,8 @@ void            AsssListLevel (
 
             /* select the elements to assign                               */
             obj = ELMW_LIST( objs, i );
-            while ( ! IS_DENSE_LIST( obj )
-                 || LEN_LIST( poss ) != LEN_LIST( obj ) ) {
-                if ( ! IS_DENSE_LIST( obj ) ) {
-                    obj = ErrorReturnObj(
-                  "List Assignments: <objs> must be a dense list (not a %s)",
-                        (Int)TNAM_OBJ(obj), 0L,
-                        "you can replace <objs> via 'return <objs>;'" );
-                }
-                if ( LEN_LIST( poss ) != LEN_LIST( obj ) ) {
-                    obj = ErrorReturnObj(
-     "List Assignments: <objs> must have the same length as <positions> (%d)",
-                        LEN_LIST( poss ), 0L,
-                        "you can replace <objs> via 'return <objs>;'" );
-                }
-            }
+            CheckIsDenseList("List Assignments", "objs", obj);
+            CheckSameLength("List Assignments", "objs", "positions", obj, poss);
 
             /* assign the elements                                         */
             ASSS_LIST( list, poss, obj );
@@ -2155,16 +2118,8 @@ void AsssListCheck (
     Obj                 rhss )
 {
     CheckIsPossList("List Assignment", poss);
-    if ( ! IS_DENSE_LIST(rhss) ) {
-        ErrorQuit(
-            "List Assignment: <rhss> must be a dense list",
-            0L, 0L );
-    }
-    if ( LEN_LIST( poss ) != LEN_LIST( rhss ) ) {
-        ErrorQuit(
-     "List Assignment: <rhss> must have the same length as <positions> (%d)",
-            (Int)LEN_LIST(poss), 0L );
-    }
+    CheckIsDenseList("List Assignment", "rhss", rhss);
+    CheckSameLength("List Assignment", "rhss", "positions", rhss, poss);
     ASSS_LIST( list, poss, rhss );
 }
 
@@ -2179,16 +2134,8 @@ void AsssPosObjCheck (
     Obj                 rhss )
 {
     CheckIsPossList("List Assignment", poss);
-    if ( ! IS_DENSE_LIST(rhss) ) {
-        ErrorQuit(
-            "List Assignment: <rhss> must be a dense list",
-            0L, 0L );
-    }
-    if ( LEN_LIST( poss ) != LEN_LIST( rhss ) ) {
-        ErrorQuit(
-     "List Assignment: <rhss> must have the same length as <positions> (%d)",
-            (Int)LEN_LIST(poss), 0L );
-    }
+    CheckIsDenseList("List Assignment", "rhss", rhss);
+    CheckSameLength("List Assignment", "rhss", "positions", rhss, poss);
     if ( TNUM_OBJ(list) == T_POSOBJ ) {
         ErrorQuit( "sorry: <posobj>!{<poss>} not yet implemented", 0L, 0L );
     }

--- a/src/lists.c
+++ b/src/lists.c
@@ -692,7 +692,6 @@ Obj ElmsListDefault (
     Int                 pos;            /* <position> as integer           */
     Int                 inc;            /* increment in a range            */
     Int                 i;              /* loop variable                   */
-    Obj                 p;
 
     /* general code                                                        */
     if ( ! IS_RANGE(poss) ) {
@@ -712,14 +711,15 @@ Obj ElmsListDefault (
         for ( i = 1; i <= lenPoss; i++ ) {
 
             /* get <position>                                              */
-          p = ELMW_LIST( poss, i);
-          while (!IS_INTOBJ(p))
-            {
-              p = ErrorReturnObj("List Elements: position is too large for this type of list",
-                                 0L, 0L, 
-                                 "you can supply a new position <pos> via 'return <pos>;'" );
+            Obj p = ELMW_LIST(poss, i);
+            while (!IS_INTOBJ(p)) {
+                p = ErrorReturnObj("List Elements: position is too large for "
+                                   "this type of list",
+                                   0L, 0L,
+                                   "you can supply a new position <pos> via "
+                                   "'return <pos>;'");
             }
-            pos = INT_INTOBJ( p );
+            pos = INT_INTOBJ(p);
 
             /* select the element                                          */
             elm = ELM0_LIST( list, pos );

--- a/src/lists.c
+++ b/src/lists.c
@@ -671,7 +671,7 @@ Obj FuncELMS_LIST (
     Obj                 list,
     Obj                 poss )
 {
-    return ELMS_LIST( list, poss );
+    return ElmsListCheck( list, poss );
 }
 
 
@@ -1022,7 +1022,7 @@ Obj             FuncASSS_LIST (
     Obj                 poss,
     Obj                 objs )
 {
-    ASSS_LIST( list, poss, objs );
+    AsssListCheck( list, poss, objs );
     return 0;
 }
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -1050,6 +1050,10 @@ void            AsssListDefault (
     Obj                 obj;            /* one element from <objs>         */
     Int                 i;              /* loop variable                   */
 
+    CheckIsPossList("List Assignment", poss);
+    CheckIsDenseList("List Assignment", "rhss", objs);
+    CheckSameLength("List Assignment", "rhss", "positions", objs, poss);
+
     /* general code                                                        */
     if ( ! IS_RANGE(poss) ) {
 

--- a/src/lists.h
+++ b/src/lists.h
@@ -512,7 +512,7 @@ static inline void ASS_LIST(Obj list, Int pos, Obj obj)
     GAP_ASSERT(pos > 0);
     GAP_ASSERT(obj != 0);
     UInt tnum = TNUM_OBJ(list);
-    if (FIRST_LIST_TNUM <= tnum && tnum <= LAST_IMM_MUT_TNUM &&
+    if (FIRST_LIST_TNUM <= tnum && tnum <= LAST_LIST_TNUM &&
         (tnum & IMMUTABLE)) {
         ErrorReturnVoid("List Assignment: <list> must be a mutable list", 0,
                         0, "you can 'return;' and ignore the assignment");
@@ -564,7 +564,7 @@ static inline void ASSS_LIST(Obj list, Obj poss, Obj objs)
     GAP_ASSERT(IS_DENSE_LIST(objs));
     GAP_ASSERT(LEN_LIST(poss) == LEN_LIST(objs));
     UInt tnum = TNUM_OBJ(list);
-    if (FIRST_LIST_TNUM <= tnum && tnum <= LAST_IMM_MUT_TNUM &&
+    if (FIRST_LIST_TNUM <= tnum && tnum <= LAST_LIST_TNUM &&
         (tnum & IMMUTABLE)) {
         ErrorReturnVoid("List Assignments: <list> must be a mutable list", 0,
                         0, "you can 'return;' and ignore the assignment");

--- a/src/plist.c
+++ b/src/plist.c
@@ -1477,7 +1477,17 @@ Obj             ElmsPlistDense (
         for ( i = 1; i <= lenPoss; i++ ) {
 
             /* get <position>                                              */
-            pos = INT_INTOBJ( ELMW_LIST( poss, i ) );
+            Obj p = ELMW_LIST(poss, i);
+            while (!IS_INTOBJ(p)) {
+                p = ErrorReturnObj("List Elements: position is too large for "
+                                   "this type of list",
+                                   0L, 0L,
+                                   "you can supply a new position <pos> via "
+                                   "'return <pos>;'");
+            }
+            pos = INT_INTOBJ(p);
+
+            /* select the element                                          */
             if ( lenList < pos ) {
                 ErrorReturnVoid(
                     "List Elements: <list>[%d] must have an assigned value",

--- a/src/range.c
+++ b/src/range.c
@@ -415,7 +415,17 @@ Obj             ElmsRange (
         for ( i = 1; i <= lenPoss; i++ ) {
 
             /* get <position>                                              */
-            pos = INT_INTOBJ( ELMW_LIST( poss, i ) );
+            Obj p = ELMW_LIST(poss, i);
+            while (!IS_INTOBJ(p)) {
+                p = ErrorReturnObj("List Elements: position is too large for "
+                                   "this type of list",
+                                   0L, 0L,
+                                   "you can supply a new position <pos> via "
+                                   "'return <pos>;'");
+            }
+            pos = INT_INTOBJ(p);
+
+            /* select the element                                          */
             if ( lenList < pos ) {
                 ErrorReturnVoid(
                     "List Elements: <list>[%d] must have an assigned value",

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -947,7 +947,6 @@ Obj ElmsString (
     Int                 pos;            /* <position> as integer           */
     Int                 inc;            /* increment in a range            */
     Int                 i;              /* loop variable                   */
-    UInt1               *p, *pn;        /* loop pointer                    */
 
     /* general code                                                        */
     if ( ! IS_RANGE(poss) ) {
@@ -965,7 +964,17 @@ Obj ElmsString (
         for ( i = 1; i <= lenPoss; i++ ) {
 
             /* get <position>                                              */
-            pos = INT_INTOBJ( ELMW_LIST( poss, i ) );
+            Obj p = ELMW_LIST(poss, i);
+            while (!IS_INTOBJ(p)) {
+                p = ErrorReturnObj("List Elements: position is too large for "
+                                   "this type of list",
+                                   0L, 0L,
+                                   "you can supply a new position <pos> via "
+                                   "'return <pos>;'");
+            }
+            pos = INT_INTOBJ(p);
+
+            /* select the element                                          */
             if ( lenList < pos ) {
                 ErrorReturnVoid(
                     "List Elements: <list>[%d] must have an assigned value",
@@ -1015,10 +1024,10 @@ Obj ElmsString (
         elms = NEW_STRING( lenPoss );
 
         /* loop over the entries of <positions> and select                 */
-	p = CHARS_STRING(list);
-	pn = CHARS_STRING(elms);
+        UInt1 * p = CHARS_STRING(list);
+        UInt1 * pn = CHARS_STRING(elms);
         for ( i = 1; i <= lenPoss; i++, pos += inc ) {
-	  pn[i-1] = p[pos-1];
+            pn[i - 1] = p[pos - 1];
         }
 
     }

--- a/src/vars.c
+++ b/src/vars.c
@@ -682,12 +682,7 @@ UInt            ExecAsssList (
 
     /* evaluate and check the positions                                    */
     poss = EVAL_EXPR( ADDR_STAT(stat)[1] );
-    while ( ! IS_POSS_LIST( poss ) ) {
-        poss = ErrorReturnObj(
-    "List Assignment: <positions> must be a dense list of positive integers",
-            0L, 0L,
-        "you can replace <positions> via 'return <positions>;'" );
-    }
+    CheckIsPossList("List Assignment", poss);
 
     /* evaluate and check right hand sides                                 */
     rhss = EVAL_EXPR( ADDR_STAT(stat)[2] );
@@ -795,12 +790,7 @@ UInt            ExecAsssListLevel (
 
     /* evaluate and check the positions                                    */
     poss = EVAL_EXPR( ADDR_EXPR(stat)[1] );
-    while ( ! IS_POSS_LIST( poss ) ) {
-        poss = ErrorReturnObj(
-    "List Assignment: <positions> must be a dense list of positive integers",
-            0L, 0L,
-        "you can replace <positions> via 'return <positions>;'" );
-    }
+    CheckIsPossList("List Assignment", poss);
 
     /* evaluate right hand sides (checking is done by 'AsssListLevel')     */
     rhss = EVAL_EXPR( ADDR_STAT(stat)[2] );
@@ -995,12 +985,7 @@ Obj             EvalElmsList (
 
     /* evaluate and check the positions                                    */
     poss = EVAL_EXPR( ADDR_EXPR(expr)[1] );
-    while ( ! IS_POSS_LIST( poss ) ) {
-        poss = ErrorReturnObj(
-      "List Elements: <positions> must be a dense list of positive integers",
-            0L, 0L,
-        "you can replace <positions> via 'return <positions>;'" );
-    }
+    CheckIsPossList("List Elements", poss);
 
     /* select several elements from the list                               */
     elms = ELMS_LIST( list, poss );
@@ -1082,12 +1067,7 @@ Obj             EvalElmsListLevel (
 
     /* evaluate and check the positions                                    */
     poss = EVAL_EXPR( ADDR_EXPR(expr)[1] );
-    while ( ! IS_POSS_LIST( poss ) ) {
-        poss = ErrorReturnObj(
-      "List Elements: <positions> must be a dense list of positive integers",
-            0L, 0L,
-        "you can replace <positions> via 'return <positions>;'" );
-    }
+    CheckIsPossList("List Elements", poss);
 
     /* get the level                                                       */
     level = (Int)(ADDR_EXPR(expr)[2]);

--- a/src/vars.c
+++ b/src/vars.c
@@ -686,21 +686,8 @@ UInt            ExecAsssList (
 
     /* evaluate and check right hand sides                                 */
     rhss = EVAL_EXPR( ADDR_STAT(stat)[2] );
-    while ( ! IS_DENSE_LIST( rhss )
-         || LEN_LIST( poss ) != LEN_LIST( rhss ) ) {
-        if ( ! IS_DENSE_LIST( rhss ) ) {
-            rhss = ErrorReturnObj(
-                "List Assignment: <rhss> must be a dense list (not a %s)",
-                (Int)TNAM_OBJ(rhss), 0L,
-                "you can replace <rhss> via 'return <rhss>;'" );
-        }
-        else /* if ( LEN_LIST( poss ) != LEN_LIST( rhss ) ) */ {
-            rhss = ErrorReturnObj(
-     "List Assignment: <rhss> must be a list with the same length as <positions> (%d)",
-                (Int)LEN_LIST( poss ), 0L,
-                "you can replace <rhss> via 'return <rhss>;'" );
-        }
-    }
+    CheckIsDenseList("List Assignment", "rhss", rhss);
+    CheckSameLength("List Assignment", "rhss", "positions", rhss, poss);
 
     /* assign the right hand sides to several elements of the list         */
     ASSS_LIST( list, poss, rhss );

--- a/tst/testinstall/kernel/lists.tst
+++ b/tst/testinstall/kernel/lists.tst
@@ -18,4 +18,112 @@ gap> SET_FILTER_LIST(fail,fail);
 Error, <oper> must be an operation
 
 #
+gap> enum:=Enumerator(Integers);
+<enumerator of Integers>
+gap> IsList(enum);
+true
+gap> Length(enum);
+infinity
+gap> IsSmallList(enum);
+false
+
+#
+gap> ISB_LIST(1,2);
+Error, IsBound: <list> must be a list (not a integer)
+gap> ISB_LIST([1],1);
+true
+gap> ISB_LIST([1],2);
+false
+gap> ISB_LIST([1],[1,2]);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `IsBound[]' on 2 arguments
+gap> ISB_LIST([[1,2],[3,4]],[1,2]);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `IsBound[]' on 2 arguments
+
+#
+gap> UNB_LIST(1,2);
+Error, Unbind: <list> must be a list (not a integer)
+gap> UNB_LIST([1],1);
+gap> UNB_LIST([1],2);
+
+#
+gap> ELM0_LIST([1],1);
+1
+gap> ELM0_LIST([1],2);
+fail
+gap> ELM0_LIST(1,2);
+Error, List Element: <list> must be a list (not a integer)
+
+#
+gap> ELM_LIST([1],1);
+1
+gap> ELM_LIST([1],2);
+Error, List Element: <list>[2] must have an assigned value
+gap> ELM_LIST(1,2);
+Error, List Element: <list> must be a list (not a integer)
+
+#
+gap> ELMS_LIST(1,1);
+Error, List Elements: <positions> must be a dense list of positive integers
+gap> ELMS_LIST([1],1);
+Error, List Elements: <positions> must be a dense list of positive integers
+gap> ELMS_LIST([1],[2]);
+Error, List Elements: <list>[2] must have an assigned value
+gap> ELMS_LIST([1,2,3],[1,3]);
+[ 1, 3 ]
+gap> ELMS_LIST([1],[1,2^100,3]);
+Error, List Elements: position is too large for this type of list
+gap> ELMS_LIST([1,2,3],[1..4]);
+Error, List Elements: <list>[4] must have an assigned value
+gap> ELMS_LIST([1,2,3],[4..5]);
+Error, List Elements: <list>[4] must have an assigned value
+gap> ELMS_LIST([1,2,3],[1..2]);
+[ 1, 2 ]
+
+#
+gap> ELMS_LIST_DEFAULT(1,1);
+Error, Length: <list> must be a list (not a integer)
+gap> ELMS_LIST_DEFAULT([1],1);
+Error, Length: <list> must be a list (not a integer)
+gap> ELMS_LIST_DEFAULT([1],[2]);
+Error, List Elements: <list>[2] must have an assigned value
+gap> ELMS_LIST_DEFAULT([1,2,3],[1,3]);
+[ 1, 3 ]
+gap> ELMS_LIST_DEFAULT([1],[1,2^100,3]);
+Error, List Elements: position is too large for this type of list
+gap> ELMS_LIST_DEFAULT([1,2,3],[1..4]);
+Error, List Elements: <list>[4] must have an assigned value
+gap> ELMS_LIST_DEFAULT([1,2,3],[4..5]);
+Error, List Elements: <list>[4] must have an assigned value
+gap> ELMS_LIST_DEFAULT([1,2,3],[1..2]);
+[ 1, 2 ]
+
+#
+gap> ASS_LIST(1,1,1);
+Error, List Assignment: <list> must be a list (not a integer)
+gap> l:=[];; ASS_LIST(l,1,1); l;
+[ 1 ]
+
+#
+gap> ASSS_LIST([1],[1],1);
+Error, List Assignment: <rhss> must be a dense list
+gap> ASSS_LIST([1],1,[1]);
+Error, List Assignment: <positions> must be a dense list of positive integers
+gap> ASSS_LIST(1,[1],[1]);
+Error, List Assignments: <list> must be a list (not a integer)
+gap> l:=[];; ASSS_LIST(l,[1],[1]); l;
+[ 1 ]
+
+#
+gap> ASSS_LIST_DEFAULT([1],[1],1);
+Error, List Assignment: <rhss> must be a dense list
+gap> ASSS_LIST_DEFAULT([1],1,[1]);
+Error, List Assignment: <positions> must be a dense list of positive integers
+gap> ASSS_LIST_DEFAULT(1,[1],[1]);
+Error, List Assignment: <list> must be a list (not a integer)
+gap> l:=[];; ASSS_LIST_DEFAULT(l,[1],[1]); l;
+[ 1 ]
+
+#
 gap> STOP_TEST("kernel/lists.tst", 1);

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -59,9 +59,9 @@ Error, List Assignment: <positions> must be a dense list of positive integers
 
 #
 gap> a{[1]}{[1]}[1] := 42;
-Error, List Assignment: <objs> must be a dense list (not a integer)
+Error, List Assignment: <objs> must be a dense list
 gap> a{[1]}{[1]}[1] := [ 42 ];
-Error, List Assignment: <objs> must be a dense list (not a integer)
+Error, List Assignment: <objs> must be a dense list
 gap> a{[1]}{[1]}![1] := [ [ 42 ] ];
 Error, sorry: <lists>{<poss>}![<pos>] not yet implemented
 gap> a{[1]}{[1]}[1] := [ [ 42 ] ];
@@ -71,11 +71,13 @@ gap> a;
 
 #
 gap> a{[1]}{[1]} := 19;
-Error, List Assignment: <objs> must be a dense list (not a integer)
+Error, List Assignment: <objs> must be a dense list
 gap> a{[1]}{[1]} := [ 18, 19 ];
-Error, List Assignment: <objs> must have the same length as <lists> (1)
+Error, List Assignment: <objs> must have the same length as <lists> (not 2 and\
+ 1)
 gap> a{[1]}{[1]} := [ [ 18, 19 ] ] ;
-Error, List Assignments: <objs> must have the same length as <positions> (1)
+Error, List Assignments: <objs> must have the same length as <positions> (not \
+2 and 1)
 gap> a{[1]}{[1,,3]} := [ [ [ 18, 19 ] ] ];
 Error, List Assignment: <positions> must be a dense list of positive integers
 gap> a{[1]}{[1]} := [ [ [ 18, 19 ] ] ];

--- a/tst/testinstall/range.tst
+++ b/tst/testinstall/range.tst
@@ -98,7 +98,8 @@ gap> x{[2,5,3]} := [7,8,9];
 gap> x;
 [ -5, 7, 9, 1, 8, 5 ]
 gap> x{[2,4]} := [2..4];
-Error, List Assignment: <rhss> must have the same length as <positions> (2)
+Error, List Assignment: <rhss> must have the same length as <positions> (not 3\
+ and 2)
 gap> Immutable([-5,-3..5]){[2..3]} := [2..3];
 Error, List Assignments: <list> must be a mutable list
 gap> x := [-5,-3..5];


### PR DESCRIPTION
We called INT_INTOBJ on indices without verifying that given value actually *is* an immediate integer.

Also add more content to `tst/testinstall/kernel/lists.tst` which tests the above issue, and more