### PR TITLE
Mark perm cycles as executed

### DIFF
--- a/src/exprs.c
+++ b/src/exprs.c
@@ -833,6 +833,9 @@ Obj             EvalPermExpr (
     for ( i = 1; i <= SIZE_EXPR(expr)/sizeof(Expr); i++ ) {
         cycle = ADDR_EXPR(expr)[i-1];
 
+        // Need to inform profiling this cycle expression is executed, as
+        // we never call EVAL_EXPR on it.
+        VisitStatIfHooked(cycle);
         /* loop over the entries of the cycle                              */
         c = p = l = 0;
         for ( j = SIZE_EXPR(cycle)/sizeof(Expr); 1 <= j; j-- ) {


### PR DESCRIPTION
The profiler normally detects an expression is evaluated when we
call EVAL_EXPR, but we never do this for perm cycles, which leads
to them being marked as read but never executed.

This fixes issue #50 from the profiling package.