### PR TITLE
Partial fix and workaround for #2400

### DIFF
--- a/lib/addmagma.gi
+++ b/lib/addmagma.gi
@@ -175,7 +175,7 @@ InstallGlobalFunction( SubadditiveMagmaNC, function( M, gens )
     if IsEmpty( gens ) then
       K:= NewType( FamilyObj(M),
                        IsAdditiveMagma
-                   and IsTrivial
+                   and IsEmpty
                    and IsAttributeStoringRep );
       S:= Objectify( K, rec() );
       SetGeneratorsOfAdditiveMagma( S, [] );

--- a/lib/magma.gi
+++ b/lib/magma.gi
@@ -1209,6 +1209,9 @@ InstallMethod( AsMagma,
     D := AsSSortedList( D );
     L := ShallowCopy( D );
     M := Submagma( MagmaByGenerators( D ), [] );
+    if IsGroup(M) then
+      M:=Submagma(MagmaByGenerators(D),[One(ElementsFamily(FamilyObj(D)))]);
+    fi;
     SubtractSet( L, AsSSortedList( M ) );
     while not IsEmpty(L)  do
         M := ClosureMagmaDefault( M, L[1] );

--- a/lib/magma.gi
+++ b/lib/magma.gi
@@ -1209,6 +1209,11 @@ InstallMethod( AsMagma,
     D := AsSSortedList( D );
     L := ShallowCopy( D );
     M := Submagma( MagmaByGenerators( D ), [] );
+    # the following is a workaround for a bug in the magma code: If the
+    # elements family of $M$ is associative, what is returned is not the
+    # empty magma, but the trivial magma.
+    # If this is the case (which is indicated by M being a group) rather
+    # create this trivial magma properly.
     if IsGroup(M) then
       M:=Submagma(MagmaByGenerators(D),[One(ElementsFamily(FamilyObj(D)))]);
     fi;


### PR DESCRIPTION
As requested made this a PR of its own. It avoids creating magmas from group elements that have the wrong order.

Tests for this are already in the tst files (therefore no extra test provided here) but will be triggered only once the new method for SetSize in #2387 has been merged.