### PR TITLE
kernel: move FilenameCache to io.c, use for INPUT_FILENAME

### DIFF
--- a/src/code.h
+++ b/src/code.h
@@ -1356,14 +1356,6 @@ extern  void            CodeAssertEnd3Args ( void );
 /*  CodeContinue() .  . . . . . . . . . . . .  code continue-statement */
 extern  void            CodeContinue ( void );
 
-/****************************************************************************
-**
-*V  FilenameCache . . . . . . . . . . . . . . . . . . list of filenames
-**
-**  'FilenameCache' is a list of previously opened filenames.
-*/
-extern Obj FilenameCache;
-
 
 /****************************************************************************
 **

--- a/src/io.h
+++ b/src/io.h
@@ -355,9 +355,11 @@ extern const Char * GetInputLineBuffer(void);
 //
 extern Int GetInputLinePosition(void);
 
-// get or set the filenameid (if any) of the current input
+// get the filenameid (if any) of the current input
 extern UInt GetInputFilenameID(void);
-extern void SetInputFilenameID(UInt id);
+
+// get the filename (as GAP string object) with the given id
+extern Obj GetCachedFilename(UInt id);
 
 
 /* the widest allowed screen width */

--- a/src/profile.c
+++ b/src/profile.c
@@ -161,7 +161,7 @@ static inline void outputFilenameIdIfRequired(UInt id)
         AssPlist(OutputtedFilenameList, id, True);
         fprintf(profileState.Stream,
                 "{\"Type\":\"S\",\"File\":\"%s\",\"FileId\":%d}\n",
-                CSTR_STRING(ELM_LIST(FilenameCache, id)), (int)id);
+                CSTR_STRING(GetCachedFilename(id)), (int)id);
     }
 }
 


### PR DESCRIPTION
Previously, `INPUT_FILENAME()` returned a new (mutable) string object each time it was called. Now, we always return the same (immutable) string object from the cache of input filenames we keep anyway (for profiling, amongst other things). Note that this string is used for tracking the locations where we declare operations or install methods, so the memory used for the duplicate strings could add up considerably before this patch.

Resolves #2397