### PR TITLE
More tests for group constructors; fix docs for Omega group constructor

### DIFF
--- a/grp/classic.gd
+++ b/grp/classic.gd
@@ -635,8 +635,8 @@ DeclareConstructor( "OmegaCons", [ IsGroup, IsInt, IsPosInt, IsPosInt ] );
 ##  (see&nbsp;<Ref Func="InvariantQuadraticForm"/>) specified by <A>e</A>,
 ##  and that have square spinor norm in odd characteristic
 ##  or Dickson invariant <M>0</M> in even characteristic, respectively,
-##  in the category given by the filter <A>filt</A>.
-##  This group has always index two in the corresponding special orthogonal group,
+##  in the category given by the filter <A>filt</A>. For odd <A>q</A>,
+##  this group has always index two in the corresponding special orthogonal group,
 ##  which will be conjugate in <M>GL(d,q)</M> to the group returned by SO( <A>e</A>, <A>d</A>, <A>q</A> ),
 ##  see <Ref Func="SpecialOrthogonalGroup"/>, but may fix a different form (see <Ref Sect="Classical Groups"/>).
 ##  <P/>

--- a/grp/classic.gi
+++ b/grp/classic.gi
@@ -79,8 +79,8 @@ InstallMethod( SymplecticGroupCons,
             fi;
         fi;
 
-	mat1:=ImmutableMatrix(f,mat1,true);
-	mat2:=ImmutableMatrix(f,mat2,true);
+        mat1:=ImmutableMatrix(f,mat1,true);
+        mat2:=ImmutableMatrix(f,mat2,true);
         # avoid to call 'Group' because this would check invertibility ...
         g := GroupWithGenerators( [ mat1, mat2 ] );
         SetName( g, Concatenation("Sp(",String(d),",",String(q),")") );
@@ -600,9 +600,9 @@ BindGlobal( "OpmOdd", function( s, d, q )
         g := GroupWithGenerators( [
                     [[1,0,0,0],[0,1,2,1],[2,0,2,0],[1,0,0,1]]*One( f ),
                     [[0,2,2,2],[0,1,1,2],[1,0,2,0],[1,2,2,0]]*One( f ) ] );
-	SetInvariantBilinearForm( g, rec( matrix:= ImmutableMatrix( f,
+        SetInvariantBilinearForm( g, rec( matrix:= ImmutableMatrix( f,
           [[0,1,0,0],[1,0,0,0],[0,0,1,0],[0,0,0,2]]*One( f ), true ) ) );
-	SetInvariantQuadraticForm( g, rec( matrix:= ImmutableMatrix( f,
+        SetInvariantQuadraticForm( g, rec( matrix:= ImmutableMatrix( f,
           [[0,1,0,0],[0,0,0,0],[0,0,2,0],[0,0,0,1]]*One( f ), true ) ) );
         SetSize( g, 1152 );
         return g;
@@ -610,9 +610,9 @@ BindGlobal( "OpmOdd", function( s, d, q )
         g := GroupWithGenerators( [
                     [[0,2,0,0],[2,1,0,1],[0,2,0,1],[0,0,1,0]]*One( f ),
                     [[2,0,0,0],[1,2,0,2],[1,0,0,1],[0,0,1,0]]*One( f ) ] );
-	SetInvariantBilinearForm( g, rec( matrix:= ImmutableMatrix( f,
+        SetInvariantBilinearForm( g, rec( matrix:= ImmutableMatrix( f,
           [[0,1,0,0],[1,0,0,0],[0,0,2,0],[0,0,0,2]]*One( f ), true ) ) );
-	SetInvariantQuadraticForm( g, rec( matrix:= ImmutableMatrix( f,
+        SetInvariantQuadraticForm( g, rec( matrix:= ImmutableMatrix( f,
           [[0,1,0,0],[0,0,0,0],[0,0,1,0],[0,0,0,1]]*One( f ), true ) ) );
         SetSize( g, 1440 );
         return g;

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -31,8 +31,12 @@ gap> AbelianGroup(IsPcGroup,[2,3]);
 <pc group of size 6 with 2 generators>
 gap> AbelianGroup(IsPermGroup,[2,3]);
 Group([ (1,2), (3,4,5) ])
-gap> AbelianGroup(IsFpGroup,[2,3]);
+gap> A:=AbelianGroup(IsFpGroup,[2,3]);
 <fp group of size 6 on the generators [ f1, f2 ]>
+gap> A.1^-1;
+f1
+gap> A.2^-1;
+f2^2
 
 #
 gap> AbelianGroup([2,0]);
@@ -45,8 +49,10 @@ Error, no 2nd choice method found for `AbelianGroupCons' on 2 arguments
 gap> AbelianGroup(IsPermGroup,[2,0]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 2nd choice method found for `AbelianGroupCons' on 2 arguments
-gap> AbelianGroup(IsFpGroup,[2,0]);
+gap> A:=AbelianGroup(IsFpGroup,[2,0]);
 <fp group of size infinity on the generators [ f1, f2 ]>
+gap> A.1*A.2^-3*A.1*A.2^4;
+f2
 
 #
 gap> AbelianGroup(2,3);
@@ -121,6 +127,11 @@ gap> CyclicGroup(IsPermGroup,1);
 Group(())
 gap> CyclicGroup(IsFpGroup,1);
 <fp group of size 1 on the generators [ a ]>
+gap> G:=CyclicGroup(IsMatrixGroup, 1);
+Group([ [ [ 1 ] ] ])
+gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
+Rationals
+1
 gap> G:=CyclicGroup(IsMatrixGroup, GF(2), 1);
 Group([ <an immutable 1x1 matrix over GF2> ])
 gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
@@ -136,11 +147,16 @@ gap> CyclicGroup(IsPermGroup,4);
 Group([ (1,2,3,4) ])
 gap> CyclicGroup(IsFpGroup,4);
 <fp group of size 4 on the generators [ a ]>
-gap> G:=CyclicGroup(IsMatrixGroup, GF(2), 12);
-<matrix group of size 12 with 1 generators>
+gap> G:=CyclicGroup(IsMatrixGroup, 6);
+<matrix group of size 6 with 1 generators>
+gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
+Rationals
+6
+gap> G:=CyclicGroup(IsMatrixGroup, GF(2), 6);
+<matrix group of size 6 with 1 generators>
 gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
 GF(2)
-12
+6
 
 #
 gap> CyclicGroup(2,3);
@@ -148,6 +164,12 @@ Error, usage: CyclicGroup( [<filter>, ]<size> )
 gap> CyclicGroup(IsRing,3);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CyclicGroupCons' on 2 arguments
+gap> CyclicGroup(0);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CyclicGroupCons' on 2 arguments
+gap> CyclicGroup(IsFpGroup,0);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `CyclicGroupCons' on 2 arguments
 
 #
 # dihedral groups
@@ -205,6 +227,10 @@ Error, no 2nd choice method found for `DihedralGroupCons' on 2 arguments
 #
 # quaternion groups
 #
+gap> IdGroup(QuaternionGroup(4));
+[ 4, 1 ]
+gap> IdGroup(QuaternionGroup(IsFpGroup,4));
+[ 4, 1 ]
 gap> QuaternionGroup(8);
 <pc group of size 8 with 3 generators>
 gap> QuaternionGroup(IsPcGroup,8);
@@ -218,10 +244,21 @@ gap> G:=QuaternionGroup(IsMatrixGroup, 8);
 gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
 Rationals
 4
+gap> G:=QuaternionGroup(IsMatrixGroup, GF(2), 8);
+<matrix group of size 8 with 2 generators>
+gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
+GF(2)
+8
 gap> G:=QuaternionGroup(IsMatrixGroup, GF(3), 8);
 <matrix group of size 8 with 2 generators>
 gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
 GF(3)
+4
+gap> F:=FunctionField(GF(3),["t"]);
+FunctionField(...,[ t ])
+gap> G:=QuaternionGroup(IsMatrixGroup, F, 8);
+<matrix group of size 8 with 2 generators>
+gap> DimensionOfMatrixGroup(G);
 4
 
 #
@@ -230,6 +267,15 @@ Error, usage: QuaternionGroup( [<filter>, ]<size> )
 gap> QuaternionGroup(IsRing,3);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `QuaternionGroupCons' on 2 arguments
+gap> QuaternionGroup(0);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `QuaternionGroupCons' on 2 arguments
+gap> QuaternionGroup(1);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `QuaternionGroupCons' on 2 arguments
+gap> QuaternionGroup(IsFpGroup,1);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `QuaternionGroupCons' on 2 arguments
 
 #
 # elementary abelian groups

--- a/tst/testinstall/grp/classic-G.tst
+++ b/tst/testinstall/grp/classic-G.tst
@@ -34,6 +34,21 @@ gap> G:=GL(5,3);; List([2,3,5,11,13], p-> Size(SylowSubgroup(G,p)));
 gap> G:=GL(5,4);; List([2,3,5,11,13], p-> Size(SylowSubgroup(G,p)));
 [ 1048576, 729, 25, 11, 1 ]
 
+# special case: DefaultFieldOfMatrixGroup <> FieldOfMatrixGroup
+gap> G:=GL(2,9);
+GL(2,9)
+gap> H:=Subgroup(G,[G.1^4,G.2]);;
+gap> G := GL(2,3);
+GL(2,3)
+gap> IsNaturalGL(H) and (G=H);
+true
+gap> DefaultFieldOfMatrixGroup(H);
+GF(3^2)
+gap> FieldOfMatrixGroup(H);
+GF(3)
+gap> ForAll([2,3,5], p -> IsConjugate(G, SylowSubgroup(G,2), SylowSubgroup(H,2)));
+true
+
 #
 gap> G := GO(3,5);
 GO(0,3,5)
@@ -97,20 +112,70 @@ gap> GammaL(2,5);
 GL(2,5)
 gap> GammaL(3,5);
 GL(3,5)
-gap> GammaL(1,9);
+gap> GammaL(1,9); Size(last) = SizeGL(1,9) * 2;
 GammaL(1,9)
-gap> GammaL(2,9);
+true
+gap> GammaL(2,9); Size(last) = SizeGL(2,9) * 2;
 GammaL(2,9)
-gap> GammaL(3,9);
+true
+gap> GammaL(3,9); Size(last) = SizeGL(3,9) * 2;
 GammaL(3,9)
-gap> GammaL(IsPermGroup,3,9);
+true
+gap> GammaL(IsPermGroup,3,9); Size(last) = SizeGL(3,9) * 2;
 Perm_GammaL(3,9)
-gap> Size(last) / Size(GL(3,9));
-2
+true
 gap> GammaL(3);
 Error, usage: GeneralSemilinearGroup( [<filter>, ]<d>, <q> )
 gap> GammaL(3,6);
 Error, <subfield> must be a prime or a finite field
+
+#
+gap> Omega(3,2);
+Omega(0,3,2)
+gap> Omega(3,3);
+Omega(0,3,3)
+gap> Omega(5,2);
+GO(0,5,2)
+gap> Omega(5,3);
+Omega(0,5,3)
+
+#
+gap> Omega(+1,2,2);
+Omega(+1,2,2)
+gap> Omega(+1,2,3);
+Omega(+1,2,3)
+gap> Omega(+1,4,2);
+Omega(+1,4,2)
+gap> Omega(+1,4,3);
+Omega(+1,4,3)
+
+#
+gap> Omega(-1,4,2);
+Omega(-1,4,2)
+gap> Omega(-1,4,3);
+Omega(-1,4,3)
+
+#
+gap> Omega(0,2);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `Omega' on 2 arguments
+gap> Omega(-1,0,2);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `Omega' on 3 arguments
+gap> Omega(IsPermGroup,3,2);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `OmegaCons' on 4 arguments
+gap> Omega(IsPermGroup,0,3,2);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `OmegaCons' on 4 arguments
+
+#
+gap> Omega(1,2);
+Error, <d> must be at least 3
+gap> Omega(2,2);
+Error, sign <e> = 0 but dimension <d> is even
+gap> Omega(-1,2,2);
+Error, <d> = 2 is not supported
 
 #
 gap> STOP_TEST("classic-G.tst", 1);

--- a/tst/testinstall/grp/classic-S.tst
+++ b/tst/testinstall/grp/classic-S.tst
@@ -4,6 +4,13 @@
 gap> START_TEST("classic-S.tst");
 
 #
+gap> SL(0,5);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `SpecialLinearGroupCons' on 3 arguments
+gap> SL(1,5);
+SL(1,5)
+gap> ForAll([2,3,4,5,7,9,11], q -> IsTrivial(SL(1,q)));
+true
 gap> SL(2,5);
 SL(2,5)
 gap> last = SL(2,GF(5));

--- a/tst/testinstall/grp/classic-forms.tst
+++ b/tst/testinstall/grp/classic-forms.tst
@@ -19,6 +19,12 @@ gap> CheckBilinearForm := function(G)
 >   return ForAll(GeneratorsOfGroup(G),
 >               g -> g*M*TransposedMat(g) = M);
 > end;;
+gap> CheckQuadraticForm := function(G)
+>   local M, Q;
+>   M := InvariantBilinearForm(G).matrix;
+>   Q := InvariantQuadraticForm(G).matrix;
+>   return Q+TransposedMat(Q) = M;
+> end;;
 gap> frob := function(g,aut)
 >   return List(g,row->List(row,x->x^aut));
 > end;;
@@ -43,6 +49,8 @@ gap> ForAll(grps, CheckGeneratorsInvertible);
 true
 gap> ForAll(grps, CheckBilinearForm);
 true
+gap> ForAll(grps, CheckQuadraticForm);
+true
 
 # even-dimensional general orthogonal groups
 gap> grps:=[];;
@@ -56,6 +64,8 @@ gap> ForAll(grps, CheckGeneratorsInvertible);
 true
 gap> ForAll(grps, CheckBilinearForm);
 true
+gap> ForAll(grps, CheckQuadraticForm);
+true
 
 # odd-dimensional special orthogonal groups
 gap> grps:=[];;
@@ -67,6 +77,8 @@ gap> for d in [3,5,7] do
 gap> ForAll(grps, CheckGeneratorsSpecial);
 true
 gap> ForAll(grps, CheckBilinearForm);
+true
+gap> ForAll(grps, CheckQuadraticForm);
 true
 
 # even-dimensional special orthogonal groups
@@ -81,7 +93,44 @@ gap> ForAll(grps, CheckGeneratorsSpecial);
 true
 gap> ForAll(grps, CheckBilinearForm);
 true
+gap> ForAll(grps, CheckQuadraticForm);
+true
 
+#
+# Omega subgroups of special orthogonal groups
+#
+# TODO: add forms to Omega, check them here
+
+# odd-dimensional
+gap> grps:=[];;
+gap> for d in [3,5,7] do
+>   for q in [2,3,4,5,7,8,9] do
+>     Add(grps, Omega(d,q));
+>   od;
+> od;
+gap> ForAll(grps, CheckGeneratorsSpecial);
+true
+
+#gap> ForAll(grps, CheckBilinearForm);
+#true
+#gap> ForAll(grps, CheckQuadraticForm);
+#true
+
+# even-dimensional
+gap> grps:=[];;
+gap> for d in [2,4,6,8] do
+>   for q in [2,3,4,5,7,8,9] do
+>     Add(grps, Omega(+1,d,q));
+>     if d <> 2 then Add(grps, Omega(-1,d,q)); fi;
+>   od;
+> od;
+gap> ForAll(grps, CheckGeneratorsSpecial);
+true
+
+#gap> ForAll(grps, CheckBilinearForm);
+#true
+#gap> ForAll(grps, CheckQuadraticForm);
+#true
 #
 # unitary groups
 #
@@ -108,6 +157,20 @@ gap> for d in [1..6] do
 gap> ForAll(grps, CheckGeneratorsInvertible);
 true
 gap> ForAll(grps, CheckSesquilinearForm);
+true
+
+#
+# symplectic groups
+#
+gap> grps:=[];;
+gap> for d in [2,4,6,8] do
+>   for q in [2,3,4,5,7,8,9] do
+>     Add(grps, Sp(d,q));
+>   od;
+> od;
+gap> ForAll(grps, CheckGeneratorsSpecial);
+true
+gap> ForAll(grps, CheckBilinearForm);
 true
 
 #


### PR DESCRIPTION
The documentation for `Omega` claimed that the returned group always has index in the corresponding special orthogonal group. But that's not true in characteristic 2, where they are equal.