### PR TITLE
kernel: remove `SyntaxError` calls from interpreter, forbid `quit`, `QUIT` and `?` uniformly outside of REPLs

### DIFF
--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2953,9 +2953,7 @@ void            IntrAssList ( Int narg )
     Obj                 pos;            /* position                        */
     Obj                 rhs;            /* right hand side                 */
 
-    if (narg != 1 && narg != 2) {
-      SyntaxError("[]:= only supports 1 or 2 indices");
-    }
+    GAP_ASSERT(narg == 1 || narg == 2);
 
     /* ignore or code                                                      */
     if ( STATE(IntrReturning) > 0 ) { return; }
@@ -3114,9 +3112,7 @@ void            IntrUnbList ( Int narg )
     Obj                 list;           /* list                            */
     Obj                 pos;            /* position                        */
 
-    if (narg != 1 && narg != 2) {
-      SyntaxError("Unbind[] only supports 1 or 2 indices");
-    }
+    GAP_ASSERT(narg == 1 || narg == 2);
 
     /* ignore or code                                                      */
     if ( STATE(IntrReturning) > 0 ) { return; }
@@ -3164,9 +3160,7 @@ void            IntrElmList ( Int narg )
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, right operand         */
 
-    if (narg != 1 && narg != 2) {
-      SyntaxError("[] only supports 1 or 2 indices");
-    }
+    GAP_ASSERT(narg == 1 || narg == 2);
 
     /* ignore or code                                                      */
     if ( STATE(IntrReturning) > 0 ) { return; }
@@ -3308,9 +3302,7 @@ void            IntrIsbList ( Int narg )
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, right operand         */
 
-    if (narg != 1 && narg != 2) {
-      SyntaxError("IsBound[] only supports 1 or 2 indices");
-    }
+    GAP_ASSERT(narg == 1 || narg == 2);
 
     /* ignore or code                                                      */
     if ( STATE(IntrReturning) > 0 ) { return; }

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -37,7 +37,6 @@
 #include <src/range.h>
 #include <src/read.h>
 #include <src/records.h>
-#include <src/scanner.h>
 #include <src/stringobj.h>
 #include <src/vars.h>
 
@@ -1124,15 +1123,11 @@ void            IntrQuit ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* 'quit' is not allowed in functions (by the reader)                  */
-    /* assert( STATE(IntrCoding) == 0 ); */
-    if ( STATE(IntrCoding) > 0 ) {
-      SyntaxError("'quit;' cannot be used in this context");
-    }
+    assert( STATE(IntrCoding) == 0 );
 
     /* empty the values stack and push the void value                      */
     SET_LEN_PLIST( STATE(StackObj), 0 );
     PushVoidObj();
-
 
     /* indicate that a quit-statement was interpreted                      */
     STATE(IntrReturning) = STATUS_QUIT;
@@ -1151,15 +1146,14 @@ void            IntrQUIT ( void )
     if ( STATE(IntrReturning) > 0 ) { return; }
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
-    /* 'quit' is not allowed in functions (by the reader)                  */
+    /* 'QUIT' is not allowed in functions (by the reader)                  */
     assert( STATE(IntrCoding) == 0 );
 
     /* empty the values stack and push the void value                      */
     SET_LEN_PLIST( STATE(StackObj), 0 );
     PushVoidObj();
 
-
-    /* indicate that a quit-statement was interpreted                      */
+    /* indicate that a QUIT-statement was interpreted                      */
     STATE(IntrReturning) = STATUS_QQUIT;
 }
 
@@ -1181,10 +1175,9 @@ void IntrHelp(Obj topic)
     if (STATE(IntrIgnoring) > 0) {
         return;
     }
-    if (STATE(IntrCoding) > 0) {
-        SyntaxError("'?' cannot be used in this context");
-        return;
-    }
+
+    // '?' is not allowed in functions (by the reader)
+    assert( STATE(IntrCoding) == 0 );
 
     /* FIXME: Hard coded function name */
     hgvar = GVarName("HELP");

--- a/src/read.c
+++ b/src/read.c
@@ -510,6 +510,9 @@ static LHSRef ReadSelector(TypSymbolSet follow, UInt level)
             ReadExpr(S_COMMA | S_RBRACK | follow, 'r');
             ref.narg++;
         }
+        if (ref.narg > 2) {
+          SyntaxError("[] only supports 1 or 2 indices");
+        }
         Match(S_RBRACK, "]", follow);
         ref.type = R_ELM_LIST;
         ref.level = level;

--- a/src/read.c
+++ b/src/read.c
@@ -2669,22 +2669,25 @@ static UInt ReadStats (
     while ( IS_IN( STATE(Symbol), STATBEGIN|S_SEMICOLON ) ) {
 
         /* read a statement                                                */
-        if      ( STATE(Symbol) == S_IDENT  ) ReadCallVarAss(follow,'s');
-        else if ( STATE(Symbol) == S_UNBIND ) ReadUnbind(    follow    );
-        else if ( STATE(Symbol) == S_INFO   ) ReadInfo(      follow    );
-        else if ( STATE(Symbol) == S_ASSERT ) ReadAssert(    follow    );
-        else if ( STATE(Symbol) == S_IF     ) ReadIf(        follow    );
-        else if ( STATE(Symbol) == S_FOR    ) ReadFor(       follow    );
-        else if ( STATE(Symbol) == S_WHILE  ) ReadWhile(     follow    );
-        else if ( STATE(Symbol) == S_REPEAT ) ReadRepeat(    follow    );
-        else if ( STATE(Symbol) == S_BREAK  ) ReadBreak(     follow    );
-        else if ( STATE(Symbol) == S_CONTINUE) ReadContinue(     follow    );
-        else if ( STATE(Symbol) == S_RETURN ) ReadReturn(    follow    );
-        else if ( STATE(Symbol) == S_TRYNEXT) ReadTryNext(   follow    );
-        else if ( STATE(Symbol) == S_QUIT   ) ReadQuit(      follow    );
-        else if ( STATE(Symbol) == S_ATOMIC ) ReadAtomic(    follow    );
-        else if ( STATE(Symbol) == S_HELP   ) ReadHelp(      follow    );
-        else                           ReadEmpty(     follow    );
+        switch (STATE(Symbol)) {
+        case S_IDENT:     ReadCallVarAss(follow,'s'); break;
+        case S_UNBIND:    ReadUnbind(    follow    ); break;
+        case S_INFO:      ReadInfo(      follow    ); break;
+        case S_ASSERT:    ReadAssert(    follow    ); break;
+        case S_IF:        ReadIf(        follow    ); break;
+        case S_FOR:       ReadFor(       follow    ); break;
+        case S_WHILE:     ReadWhile(     follow    ); break;
+        case S_REPEAT:    ReadRepeat(    follow    ); break;
+        case S_BREAK:     ReadBreak(     follow    ); break;
+        case S_CONTINUE:  ReadContinue(  follow    ); break;
+        case S_RETURN:    ReadReturn(    follow    ); break;
+        case S_TRYNEXT:   ReadTryNext(   follow    ); break;
+        case S_ATOMIC:    ReadAtomic(    follow    ); break;
+        case S_SEMICOLON: ReadEmpty(     follow    ); break;
+        case S_QUIT:      ReadQuit(      follow    ); break;
+        case S_HELP:      ReadHelp(      follow    ); break;
+        default:          ReadEmpty(     follow    ); break;
+        }
         nr++;
         MatchSemicolon(follow);
     }
@@ -2791,29 +2794,31 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
 
     IntrBegin( context );
 
+    switch (STATE(Symbol)) {
     /* read an expression or an assignment or a procedure call             */
-    if      (STATE(Symbol) == S_IDENT   ) { ReadExpr(    S_SEMICOLON|S_EOF, 'x' ); }
+    case S_IDENT:     ReadExpr(    S_SEMICOLON|S_EOF, 'x' ); break;
 
     /* otherwise read a statement                                          */
-    else if (STATE(Symbol)==S_UNBIND    ) { ReadUnbind(  S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_INFO      ) { ReadInfo(    S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_ASSERT    ) { ReadAssert(  S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_IF        ) { ReadIf(      S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_FOR       ) { ReadFor(     S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_WHILE     ) { ReadWhile(   S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_REPEAT    ) { ReadRepeat(  S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_BREAK     ) { ReadBreak(   S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_CONTINUE  ) { ReadContinue(S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_RETURN    ) { ReadReturn(  S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_TRYNEXT   ) { ReadTryNext( S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_QUIT      ) { ReadQuit(    S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_QQUIT     ) { ReadQUIT(    S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_SEMICOLON ) { ReadEmpty(   S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_ATOMIC    ) { ReadAtomic(  S_SEMICOLON|S_EOF      ); }
-    else if (STATE(Symbol)==S_HELP      ) { ReadHelp(    S_SEMICOLON|S_EOF      ); }
+    case S_UNBIND:    ReadUnbind(  S_SEMICOLON|S_EOF      ); break;
+    case S_INFO:      ReadInfo(    S_SEMICOLON|S_EOF      ); break;
+    case S_ASSERT:    ReadAssert(  S_SEMICOLON|S_EOF      ); break;
+    case S_IF:        ReadIf(      S_SEMICOLON|S_EOF      ); break;
+    case S_FOR:       ReadFor(     S_SEMICOLON|S_EOF      ); break;
+    case S_WHILE:     ReadWhile(   S_SEMICOLON|S_EOF      ); break;
+    case S_REPEAT:    ReadRepeat(  S_SEMICOLON|S_EOF      ); break;
+    case S_BREAK:     ReadBreak(   S_SEMICOLON|S_EOF      ); break;
+    case S_CONTINUE:  ReadContinue(S_SEMICOLON|S_EOF      ); break;
+    case S_RETURN:    ReadReturn(  S_SEMICOLON|S_EOF      ); break;
+    case S_TRYNEXT:   ReadTryNext( S_SEMICOLON|S_EOF      ); break;
+    case S_ATOMIC:    ReadAtomic(  S_SEMICOLON|S_EOF      ); break;
+    case S_SEMICOLON: ReadEmpty(   S_SEMICOLON|S_EOF      ); break;
+    case S_QUIT:      ReadQuit(    S_SEMICOLON|S_EOF      ); break;
+    case S_QQUIT:     ReadQUIT(    S_SEMICOLON|S_EOF      ); break;
+    case S_HELP:      ReadHelp(    S_SEMICOLON|S_EOF      ); break;
     /* otherwise try to read an expression                                 */
     /* Unless the statement is empty, in which case do nothing             */
-    else                           { ReadExpr(    S_SEMICOLON|S_EOF, 'r' ); }
+    default:          ReadExpr(    S_SEMICOLON|S_EOF, 'r' ); break;
+    }
 
     /* every statement must be terminated by a semicolon                  */
     if (!IS_IN(STATE(Symbol), S_SEMICOLON) && STATE(Symbol) != S_HELP) {

--- a/src/read.c
+++ b/src/read.c
@@ -2687,8 +2687,9 @@ static UInt ReadStats (
         case S_TRYNEXT:   ReadTryNext(   follow    ); break;
         case S_ATOMIC:    ReadAtomic(    follow    ); break;
         case S_SEMICOLON: ReadEmpty(     follow    ); break;
-        case S_QUIT:      ReadQuit(      follow    ); break;
-        case S_HELP:      ReadHelp(      follow    ); break;
+        case S_QUIT:      SyntaxError("'quit;' cannot be used in this context"); break;
+        case S_QQUIT:     SyntaxError("'QUIT;' cannot be used in this context"); break;
+        case S_HELP:      SyntaxError("'?' cannot be used in this context"); break;
         default:          ReadEmpty(     follow    ); break;
         }
         nr++;

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -302,6 +302,9 @@ extern int IsKeyword(const char * str);
 **  so execution continues as normal. Thus you must make sure that subsequent
 **  code can safely recover from the indicated error.
 **
+**  Both functions should only be called from the scanner or reader, but not
+**  from e.g. the interpreter or coder, let alone any other parts of GAP.
+**
 */
 extern  void            SyntaxError (
             const Char *        msg );

--- a/tst/testinstall/break.tst
+++ b/tst/testinstall/break.tst
@@ -45,6 +45,43 @@ for i in [1..5] do List([1..5], function(x) continue; return 1; end); od;
                                                    ^
 
 #
+#
+gap> if true then quit; fi;
+Syntax error: 'quit;' cannot be used in this context in stream:1
+if true then quit; fi;
+                ^
+gap> if false then quit; fi;
+Syntax error: 'quit;' cannot be used in this context in stream:1
+if false then quit; fi;
+                 ^
+gap> f := function() quit; end;
+Syntax error: 'quit;' cannot be used in this context in stream:1
+f := function() quit; end;
+                   ^
+gap> for i in [1..5] do quit; od;
+Syntax error: 'quit;' cannot be used in this context in stream:1
+for i in [1..5] do quit; od;
+                      ^
+
+#
+gap> if true then QUIT; fi;
+Syntax error: 'QUIT;' cannot be used in this context in stream:1
+if true then QUIT; fi;
+                ^
+gap> if false then QUIT; fi;
+Syntax error: 'QUIT;' cannot be used in this context in stream:1
+if false then QUIT; fi;
+                 ^
+gap> f := function() QUIT; end;
+Syntax error: 'QUIT;' cannot be used in this context in stream:1
+f := function() QUIT; end;
+                   ^
+gap> for i in [1..5] do QUIT; od;
+Syntax error: 'QUIT;' cannot be used in this context in stream:1
+for i in [1..5] do QUIT; od;
+                      ^
+
+#
 gap> f := function() local i; for i in [1..5] do continue; od; end;;
 gap> f();
 gap> f := function() local i; for i in [1..5] do break; od; end;;

--- a/tst/testinstall/help.tst
+++ b/tst/testinstall/help.tst
@@ -1,4 +1,22 @@
 # Test help
+
+#
+gap> if true then ?what fi;
+Syntax error: '?' cannot be used in this context in stream:1
+if true then ?what fi;
+                     ^
+Syntax error: fi expected in stream:2
+^
+
+#
+gap> if false then ?what fi;
+Syntax error: '?' cannot be used in this context in stream:1
+if false then ?what fi;
+                      ^
+Syntax error: fi expected in stream:2
+^
+
+#
 gap> f := function()
 > ?help
 Syntax error: '?' cannot be used in this context in stream:2

--- a/tst/testinstall/interpreter.tst
+++ b/tst/testinstall/interpreter.tst
@@ -17,7 +17,7 @@ Error, <expr> must be 'true' or 'false' (not a integer)
 gap> function() quit; end;
 Syntax error: 'quit;' cannot be used in this context in stream:1
 function() quit; end;
-               ^
+              ^
 
 #
 # return is not allowed in interpreter

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -31,9 +31,7 @@ gap> a[1,1];
 gap> a[1,1,1];
 Syntax error: [] only supports 1 or 2 indices in stream:1
 a[1,1,1];
-        ^
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[]' on 3 arguments
+       ^
 
 #
 gap> a := [ [ [1, 2], [3, 4] ], [ [5, 6], [7, 8] ] ];
@@ -97,8 +95,16 @@ gap> a[1] := [ [ 42 ] ];
 gap> a[1,1] := [ 43 ];
 [ 43 ]
 gap> a[1,1,1] := 44;
-Syntax error: []:= only supports 1 or 2 indices in stream:1
+Syntax error: [] only supports 1 or 2 indices in stream:1
 a[1,1,1] := 44;
+       ^
+gap> IsBound(a[1,1,1]);
+Syntax error: [] only supports 1 or 2 indices in stream:1
+IsBound(a[1,1,1]);
+               ^
+gap> Unbind(a[1,1,1]);
+Syntax error: [] only supports 1 or 2 indices in stream:1
+Unbind(a[1,1,1]);
               ^
 
 # ListWithIdenticalEntries: errors


### PR DESCRIPTION
With this change, all calls to `SyntaxError` are in either `read.c` or `scanner.c`. The documentation of `SyntaxError` is also changed to state that it should only be called from there.