### PR TITLE
kernel: speed up IS_SUBSET_FLAGS

### DIFF
--- a/lib/profile.g
+++ b/lib/profile.g
@@ -981,8 +981,6 @@ BIND_GLOBAL("DisplayCacheStats",function()
         "Operation TryNextMethod",
         "Operation cache misses",
         "IS_SUBSET_FLAGS calls",
-        "IS_SUBSET_FLAGS less trues",
-        "IS_SUBSET_FLAGS few trues",
         "WITH_HIDDEN_IMPS hits",
         "WITH_HIDDEN_IMPS misses",
         "WITH_IMPS hits",

--- a/src/opers.c
+++ b/src/opers.c
@@ -437,8 +437,6 @@ Obj FuncIS_EQUAL_FLAGS (
 
 #ifdef COUNT_OPERS
 static Int IsSubsetFlagsCalls;
-static Int IsSubsetFlagsCalls1;
-static Int IsSubsetFlagsCalls2;
 #endif
 
 /****************************************************************************
@@ -452,49 +450,10 @@ static Int IS_SUBSET_FLAGS(Obj flags1, Obj flags2)
     UInt * ptr1;
     UInt * ptr2;
     Int    i;
-    Obj    trues;
 
-/* do the real work                                                    */
 #ifdef COUNT_OPERS
     IsSubsetFlagsCalls++;
 #endif
-
-    /* first check the trues                                               */
-    trues = TRUES_FLAGS(flags2);
-    if (trues != 0) {
-        len2 = LEN_PLIST(trues);
-        if (TRUES_FLAGS(flags1) != 0) {
-            if (LEN_PLIST(TRUES_FLAGS(flags1)) < len2) {
-#ifdef COUNT_OPERS
-                IsSubsetFlagsCalls1++;
-#endif
-                return 0;
-            }
-        }
-        if (len2 == 0) {
-            return 1;
-        }
-
-        /* If flags2 has only a "few" set bits then the best way is to
-           simply check if those bits are set in flags1. The optimal
-           value of "few" depends on compilers, hardware and the
-           length of flags1. Experiments in 2017 suggest that it is
-           somewhere between 10 and 20 for current setups. */
-        if (len2 < 16) {
-#ifdef COUNT_OPERS
-            IsSubsetFlagsCalls2++;
-#endif
-            if (LEN_FLAGS(flags1) < INT_INTOBJ(ELM_PLIST(trues, len2))) {
-                return 0;
-            }
-            for (i = len2; 0 < i; i--) {
-                if (!C_ELM_FLAGS(flags1, INT_INTOBJ(ELM_PLIST(trues, i)))) {
-                    return 0;
-                }
-            }
-            return 1;
-        }
-    }
 
     /* compare the bit lists                                               */
     len1 = NRB_FLAGS(flags1);
@@ -3808,8 +3767,8 @@ Obj FuncOPERS_CACHE_INFO (
     Obj                 list;
     Int                 i;
 
-    list = NEW_PLIST_IMM(T_PLIST, 15);
-    SET_LEN_PLIST(list, 15);
+    list = NEW_PLIST_IMM(T_PLIST, 13);
+    SET_LEN_PLIST(list, 13);
 #ifdef COUNT_OPERS
     SET_ELM_PLIST(list, 1, INTOBJ_INT(AndFlagsCacheHit));
     SET_ELM_PLIST(list, 2, INTOBJ_INT(AndFlagsCacheMiss));
@@ -3818,12 +3777,10 @@ Obj FuncOPERS_CACHE_INFO (
     SET_ELM_PLIST(list, 5, INTOBJ_INT(OperationNext));
     SET_ELM_PLIST(list, 6, INTOBJ_INT(OperationMiss));
     SET_ELM_PLIST(list, 7, INTOBJ_INT(IsSubsetFlagsCalls));
-    SET_ELM_PLIST(list, 8, INTOBJ_INT(IsSubsetFlagsCalls1));
-    SET_ELM_PLIST(list, 9, INTOBJ_INT(IsSubsetFlagsCalls2));
-    SET_ELM_PLIST(list, 10, INTOBJ_INT(WITH_HIDDEN_IMPS_HIT));
-    SET_ELM_PLIST(list, 11, INTOBJ_INT(WITH_HIDDEN_IMPS_MISS));
-    SET_ELM_PLIST(list, 12, INTOBJ_INT(WITH_IMPS_FLAGS_HIT));
-    SET_ELM_PLIST(list, 13, INTOBJ_INT(WITH_IMPS_FLAGS_MISS));
+    SET_ELM_PLIST(list, 8, INTOBJ_INT(WITH_HIDDEN_IMPS_HIT));
+    SET_ELM_PLIST(list, 9, INTOBJ_INT(WITH_HIDDEN_IMPS_MISS));
+    SET_ELM_PLIST(list, 10, INTOBJ_INT(WITH_IMPS_FLAGS_HIT));
+    SET_ELM_PLIST(list, 11, INTOBJ_INT(WITH_IMPS_FLAGS_MISS));
     
     /* Now we need to convert the 3d matrix of cache hit counts (by
        precedence, location found and number of arguments) into a three
@@ -3846,7 +3803,7 @@ Obj FuncOPERS_CACHE_INFO (
                     INTOBJ_INT(CacheHitStatistics[i - 1][j - 1][k]));
         }
     }
-    SET_ELM_PLIST(list, 14, tensor);
+    SET_ELM_PLIST(list, 12, tensor);
     CHANGED_BAG(list);
 
     /* and similarly the 2D matrix of cache miss information (by
@@ -3862,10 +3819,10 @@ Obj FuncOPERS_CACHE_INFO (
             SET_ELM_PLIST(vec, k + 1,
                           INTOBJ_INT(CacheMissStatistics[j - 1][k]));
     }
-    SET_ELM_PLIST(list, 15, mat);
+    SET_ELM_PLIST(list, 13, mat);
     CHANGED_BAG(list);
 #else
-    for (i = 1; i <= 15; i++)
+    for (i = 1; i <= 13; i++)
         SET_ELM_PLIST(list, i, INTOBJ_INT(0));
 #endif
     return list;
@@ -3886,8 +3843,6 @@ Obj FuncCLEAR_CACHE_INFO (
     OperationHit = 0;
     OperationMiss = 0;
     IsSubsetFlagsCalls = 0;
-    IsSubsetFlagsCalls1 = 0;
-    IsSubsetFlagsCalls2 = 0;
     OperationNext = 0;
     WITH_HIDDEN_IMPS_HIT = 0;
     WITH_HIDDEN_IMPS_MISS = 0;

--- a/tst/testinstall/kernel/opers.tst
+++ b/tst/testinstall/kernel/opers.tst
@@ -272,7 +272,7 @@ Error, <obj> must be a component object
 #
 gap> CLEAR_CACHE_INFO();
 gap> OPERS_CACHE_INFO();
-[ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+[ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
 
 #
 # method tracing


### PR DESCRIPTION
I investigated `IS_SUBSET_FLAGS` because callgrind shows that it is #1 in terms of instructions during GAP startup (followed by `GET_NEXT_CHAR`, `FuncWITH_HIDDEN_IMPS_FLAGS`, `strcmp` and `NextSymbol`):
```
3,617,597,065  PROGRAM TOTALS
360,902,963  src/opers.c:IS_SUBSET_FLAGS.isra.45 [/home/horn/Projekte/GAP/gap.github/gap]
299,271,263  src/io.c:GET_NEXT_CHAR [/home/horn/Projekte/GAP/gap.github/gap]
194,587,622  src/opers.c:FuncWITH_HIDDEN_IMPS_FLAGS [/home/horn/Projekte/GAP/gap.github/gap]
112,844,582  /build/glibc-Cl5G7W/glibc-2.23/string/../sysdeps/x86_64/multiarch/strcmp-sse2-unaligned.S:__strcmp_sse2_unaligned [/lib/x86_64-linux-gnu/libc-2.23.so]
 99,232,409  src/scanner.c:NextSymbol [/home/horn/Projekte/GAP/gap.github/gap]
...
```
Moreover, cachegrind indicated a huge amount of L1 read misspredictions. With this PR, it actually still has a lot, but overall timings improve.

Accessing TRUES_FLAGS requires a pointer dereference, and often leads to
a cache miss, eating up all advantage to be gained from using it; so
drop it.

To verify, I run

    echo "QUIT;" > quit.g
    perf stat -r 10 -d ./gap -A -q quit.g

on a Linux test machine, which measures the startup performance of GAP
10 times (I also verified that there was an improvement on macOS, but
less rigorously).

Before this change:

    Performance counter stats for './gap.master -A -q quit.g' (10 runs):

     760.858383      task-clock (msec)         #    0.999 CPUs utilized            ( +-  1.22% )
              7      context-switches          #    0.009 K/sec                    ( +- 12.04% )
              0      cpu-migrations            #    0.000 K/sec
            355      page-faults               #    0.467 K/sec                    ( +-  0.09% )
     2834967239      cycles                    #    3.726 GHz                      ( +-  0.38% )  (39.57%)
     1384871452      stalled-cycles-frontend   #   48.85% frontend cycles idle     ( +-  0.26% )  (39.68%)
      835157974      stalled-cycles-backend    #   29.46% backend  cycles idle     ( +-  0.26% )  (40.12%)
     3588976596      instructions              #    1.27  insns per cycle
                                               #    0.39  stalled cycles per insn  ( +-  0.42% )  (50.64%)
      834750192      branches                  # 1097.116 M/sec                    ( +-  0.32% )  (50.91%)
       15136518      branch-misses             #    1.81% of all branches          ( +-  0.57% )  (51.05%)
     1003981324      L1-dcache-loads           # 1319.538 M/sec                    ( +-  0.38% )  (49.19%)
       75716887      L1-dcache-load-misses     #    7.54% of all L1-dcache hits    ( +-  0.40% )  (20.19%)
       60158560      LLC-loads                 #   79.067 M/sec                    ( +-  1.44% )  (19.90%)
        1873602      LLC-load-misses           #    3.11% of all LL-cache hits     ( +- 10.08% )  (29.63%)

    0.761377984 seconds time elapsed                                          ( +-  1.22% )

After this change:

    Performance counter stats for './gap -A -q quit.g' (10 runs):

     718.481321      task-clock (msec)         #    0.999 CPUs utilized            ( +-  1.24% )
              8      context-switches          #    0.011 K/sec                    ( +- 11.44% )
              0      cpu-migrations            #    0.000 K/sec
            355      page-faults               #    0.494 K/sec                    ( +-  0.10% )
     2670255520      cycles                    #    3.717 GHz                      ( +-  0.11% )  (39.23%)
     1273776668      stalled-cycles-frontend   #   47.70% frontend cycles idle     ( +-  0.19% )  (39.36%)
      773319911      stalled-cycles-backend    #   28.96% backend  cycles idle     ( +-  0.45% )  (40.15%)
     3532240401      instructions              #    1.32  insns per cycle
                                               #    0.36  stalled cycles per insn  ( +-  0.10% )  (50.85%)
      809874472      branches                  # 1127.203 M/sec                    ( +-  0.18% )  (51.10%)
       12333874      branch-misses             #    1.52% of all branches          ( +-  0.29% )  (51.18%)
      960149151      L1-dcache-loads           # 1336.359 M/sec                    ( +-  0.14% )  (49.34%)
       65644690      L1-dcache-load-misses     #    6.84% of all L1-dcache hits    ( +-  0.73% )  (20.23%)
       50626980      LLC-loads                 #   70.464 M/sec                    ( +-  1.37% )  (19.81%)
        3477462      LLC-load-misses           #    6.87% of all LL-cache hits     ( +-  1.50% )  (29.43%)

    0.719034384 seconds time elapsed                                          ( +-  1.24% )

So we go from ~0.76 seconds to ~0.72 seconds startup time on average on this machine.

I also checked the testinstall testsuite, but less thoroughly, using

    perf stat -r 5 -d ./gap -A -q tst/testinstall.g

Before: ~56.408 (+- 0.15%) seconds time elapsed
After: ~56.280 (+- 0.15%) seconds time elapsed

Here it provides not much of an advantage; but it also doesn't cause a slow down.


I suspect we could speed flags up quite a bit more by making use of the fact that they are usually very sparse. E.g. I looked at the flag lists used for implications, and while they were up to ~2200 entries long or beyond, they had at most 90 bits set to true; but on average only 7.82, median 3.
```
gap> printStats:=function(vals)
>     Print("min ", Minimum(vals), " - avg ", Int(100*Average(vals))/100.,
>           " - med ", Median(vals), " - max ", Maximum(vals), "\n");
> end;;
gap> filters:=Concatenation(Flat(IMPLICATIONS_SIMPLE),Flat(IMPLICATIONS_COMPOSED));;
gap> printStats(List(filters, SIZE_FLAGS));
min 1 - avg 7.82 - med 3 - max 90
gap> printStats(List(filters, LEN_FLAGS));
min 1 - avg 1024.97 - med 1017 - max 2210
gap> printStats(List(filters, SIZE_OBJ));
min 40 - avg 164.15 - med 160 - max 312
```
Also note how the average flag object takes 160 bytes, so multiple flags together will quickly exceed the L1 cache.  Thus, perhaps with a more clever encoding (even a simple RLE scheme), we could gain a lot more, simply by virtue of it leading to much smaller flags objects which better fit into the cache. 


BTW, I also tried reversing the order we loop over memory in `IS_SUBSET_FLAGS`, thinking that it might help the CPU in predicting the memory access better, but this actually caused a slowdown. I have not yet investigate why, but I think part of the reason is that the flags we compare often are identical in the first few blocks.