### PR TITLE
Update example for TraceImmediateMethods

### DIFF
--- a/lib/oper.g
+++ b/lib/oper.g
@@ -521,8 +521,6 @@ end );
 ##  #I  immediate: IsPerfectGroup
 ##  #I  immediate: IsNonTrivial
 ##  #I  immediate: Size
-##  #I  immediate: IsFreeAbelian
-##  #I  immediate: IsTorsionFree
 ##  #I  immediate: IsNonTrivial
 ##  #I  immediate: IsPerfectGroup
 ##  #I  immediate: GeneralizedPcgs


### PR DESCRIPTION
After the recent update of Polycyclic package, immediate methods for IsFreeAbelian and IsTorsionFree are no longer triggered. The example is updated to match the actual output when GAP is started with the default set of packages loaded.

This PR is submitted to stable-4.9 branch and is needed for GAP 4.9.1. In the master branch, the old  example with IsFreeAbelian and IsTorsionFree is still valid.