### PR TITLE
Convert assert calls to GAP_ASSERT

### DIFF
--- a/src/ariths.c
+++ b/src/ariths.c
@@ -1641,56 +1641,56 @@ static Int InitKernel (
 
     /* make and install the 'ZERO' arithmetic operation                    */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
-        assert(ZeroFuncs[t1] == 0);
+        GAP_ASSERT(ZeroFuncs[t1] == 0);
         ZeroFuncs[t1] = ZeroObject;
     }
     InstallZeroObject(0);
 
     /* make and install the 'ZERO_MUT' arithmetic operation                */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
-        assert(ZeroMutFuncs[t1] == 0);
+        GAP_ASSERT(ZeroMutFuncs[t1] == 0);
         ZeroMutFuncs[t1] = ZeroMutObject;
     }
     InstallZeroMutObject(0);
 
     /* make and install the 'AINV' arithmetic operation                    */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
-        assert(AInvFuncs[t1] == 0);
+        GAP_ASSERT(AInvFuncs[t1] == 0);
         AInvFuncs[t1] = AInvObject;
     }
     InstallAinvObject(0);
 
     /* make and install the 'AINV_MUT' arithmetic operation                */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
-        assert(AInvMutFuncs[t1] == 0);
+        GAP_ASSERT(AInvMutFuncs[t1] == 0);
         AInvMutFuncs[t1] = AInvMutObject;
     }
     InstallAinvMutObject(0);
 
     /* make and install the 'ONE' arithmetic operation                     */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
-        assert(OneFuncs[t1] == 0);
+        GAP_ASSERT(OneFuncs[t1] == 0);
         OneFuncs[t1] = OneObject;
     }
     InstallOneObject(0);
 
     /* make and install the 'ONE' arithmetic operation                     */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
-        assert(OneMutFuncs[t1] == 0);
+        GAP_ASSERT(OneMutFuncs[t1] == 0);
         OneMutFuncs[t1] = OneMutObject;
     }
     InstallOneMutObject(0);
 
     /* make and install the 'INV' arithmetic operation                     */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
-        assert(InvFuncs[t1] == 0);
+        GAP_ASSERT(InvFuncs[t1] == 0);
         InvFuncs[t1] = InvObject;
     }
     InstallInvObject(0);
 
     /* make and install the 'INV' arithmetic operation                     */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
-        assert(InvMutFuncs[t1] == 0);
+        GAP_ASSERT(InvMutFuncs[t1] == 0);
         InvMutFuncs[t1] = InvMutObject;
     }
     InstallInvMutObject(0);
@@ -1698,7 +1698,7 @@ static Int InitKernel (
     /* make and install the 'EQ' comparison operation                      */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
         for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-            assert(EqFuncs[t1][t2] == 0);
+            GAP_ASSERT(EqFuncs[t1][t2] == 0);
             EqFuncs[t1][t2] = EqNot;
         }
     }
@@ -1707,7 +1707,7 @@ static Int InitKernel (
     /* make and install the 'LT' comparison operation                      */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
         for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-            assert(LtFuncs[t1][t2] == 0);
+            GAP_ASSERT(LtFuncs[t1][t2] == 0);
             LtFuncs[t1][t2] = LtObject;
         }
     }
@@ -1716,7 +1716,7 @@ static Int InitKernel (
     /* make and install the 'IN' comparison operation                      */
     for ( t1 = FIRST_REAL_TNUM; t1 <= LAST_REAL_TNUM; t1++ ) {
         for ( t2 = FIRST_REAL_TNUM; t2 <= LAST_REAL_TNUM; t2++ ) {
-            assert(InFuncs[t1][t2] == 0);
+            GAP_ASSERT(InFuncs[t1][t2] == 0);
             InFuncs[t1][t2] = InUndefined;
         }
     }
@@ -1725,7 +1725,7 @@ static Int InitKernel (
     /* make and install the 'SUM' arithmetic operation                     */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
         for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-            assert(SumFuncs[t1][t2] == 0);
+            GAP_ASSERT(SumFuncs[t1][t2] == 0);
             SumFuncs[t1][t2] = SumObject;
         }
     }
@@ -1734,7 +1734,7 @@ static Int InitKernel (
     /* make and install the 'DIFF' arithmetic operation                    */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
         for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-            assert(DiffFuncs[t1][t2] == 0);
+            GAP_ASSERT(DiffFuncs[t1][t2] == 0);
             DiffFuncs[t1][t2] = DiffDefault;
         }
     }
@@ -1743,7 +1743,7 @@ static Int InitKernel (
     /* make and install the 'PROD' arithmetic operation                    */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
         for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-            assert(ProdFuncs[t1][t2] == 0);
+            GAP_ASSERT(ProdFuncs[t1][t2] == 0);
             ProdFuncs[t1][t2] = ProdObject;
         }
     }
@@ -1752,7 +1752,7 @@ static Int InitKernel (
     /* make and install the 'QUO' arithmetic operation                     */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
         for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-            assert(QuoFuncs[t1][t2] == 0);
+            GAP_ASSERT(QuoFuncs[t1][t2] == 0);
             QuoFuncs[t1][t2] = QuoDefault;
         }
     }
@@ -1761,7 +1761,7 @@ static Int InitKernel (
     /* make and install the 'LQUO' arithmetic operation                    */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
         for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-            assert(LQuoFuncs[t1][t2] == 0);
+            GAP_ASSERT(LQuoFuncs[t1][t2] == 0);
             LQuoFuncs[t1][t2] = LQuoDefault;
         }
     }
@@ -1770,7 +1770,7 @@ static Int InitKernel (
     /* make and install the 'POW' arithmetic operation                     */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
         for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-            assert(PowFuncs[t1][t2] == 0);
+            GAP_ASSERT(PowFuncs[t1][t2] == 0);
             PowFuncs[t1][t2] = PowObject;
         }
     }
@@ -1779,7 +1779,7 @@ static Int InitKernel (
     /* make and install the 'COMM' arithmetic operation                    */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
         for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-            assert(CommFuncs[t1][t2] == 0);
+            GAP_ASSERT(CommFuncs[t1][t2] == 0);
             CommFuncs[t1][t2] = CommDefault;
         }
     }
@@ -1788,7 +1788,7 @@ static Int InitKernel (
     /* make and install the 'MOD' arithmetic operation                     */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
         for ( t2 = FIRST_REAL_TNUM;  t2 <= LAST_REAL_TNUM;  t2++ ) {
-            assert(ModFuncs[t1][t2] == 0);
+            GAP_ASSERT(ModFuncs[t1][t2] == 0);
             ModFuncs[t1][t2] = ModObject;
         }
     }

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -225,7 +225,7 @@ static void TLAllocatorInit(void)
 **/
 void * AllocateBagMemory(int gc_type, int type, UInt size)
 {
-    assert(gc_type >= -1);
+    GAP_ASSERT(gc_type >= -1);
     void * result = NULL;
     if (size <= TL_GC_SIZE) {
         UInt alloc_seg, alloc_size;

--- a/src/calls.c
+++ b/src/calls.c
@@ -337,13 +337,13 @@ Obj NargError(Obj func, Int actual)
   Int narg = NARG_FUNC(func);
 
   if (narg >= 0) {
-    assert(narg != actual);
+    GAP_ASSERT(narg != actual);
     return ErrorReturnObj(
 			  "Function: number of arguments must be %d (not %d)",
 			  narg, actual,
 			  "you can replace the argument list <args> via 'return <args>;'" );
   } else {
-    assert(-narg-1 > actual);
+    GAP_ASSERT(-narg-1 > actual);
     return ErrorReturnObj(
         "Function: number of arguments must be at least %d (not %d)",
         -narg-1, actual,

--- a/src/code.c
+++ b/src/code.c
@@ -76,12 +76,12 @@ Obj FilenameCache;
 /* TL: UInt OffsBodyCount = 0; */
 
 static inline void PushOffsBody( void ) {
-  assert(STATE(OffsBodyCount) <= MAX_FUNC_EXPR_NESTING-1);
+  GAP_ASSERT(STATE(OffsBodyCount) <= MAX_FUNC_EXPR_NESTING-1);
   STATE(OffsBodyStack)[STATE(OffsBodyCount)++] = STATE(OffsBody);
 }
 
 static inline void PopOffsBody( void ) {
-  assert(STATE(OffsBodyCount));
+  GAP_ASSERT(STATE(OffsBodyCount));
   STATE(OffsBody) = STATE(OffsBodyStack)[--STATE(OffsBodyCount)];
 }
 
@@ -292,10 +292,10 @@ static void PushStat (
     Stat                stat )
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( STATE(StackStat) != 0 );
-    assert( 0 <= STATE(CountStat) );
-    assert( STATE(CountStat) <= CapacityStatStack() );
-    assert( stat != 0 );
+    GAP_ASSERT( STATE(StackStat) != 0 );
+    GAP_ASSERT( 0 <= STATE(CountStat) );
+    GAP_ASSERT( STATE(CountStat) <= CapacityStatStack() );
+    GAP_ASSERT( stat != 0 );
 
     // count up and put the statement onto the stack
     if ( STATE(CountStat) == CapacityStatStack() ) {
@@ -313,9 +313,9 @@ static Stat PopStat ( void )
     Stat                stat;
 
     /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( STATE(StackStat) != 0 );
-    assert( 1 <= STATE(CountStat) );
-    assert( STATE(CountStat) <= CapacityStatStack() );
+    GAP_ASSERT( STATE(StackStat) != 0 );
+    GAP_ASSERT( 1 <= STATE(CountStat) );
+    GAP_ASSERT( STATE(CountStat) <= CapacityStatStack() );
 
     /* get the top statement from the stack, and count down                */
     STATE(CountStat)--;
@@ -417,10 +417,10 @@ static inline UInt CapacityStackExpr(void)
 static void PushExpr(Expr expr)
 {
     /* there must be a stack, it must not be underfull or overfull         */
-    assert( STATE(StackExpr) != 0 );
-    assert( 0 <= STATE(CountExpr) );
-    assert( STATE(CountExpr) <= CapacityStackExpr() );
-    assert( expr != 0 );
+    GAP_ASSERT( STATE(StackExpr) != 0 );
+    GAP_ASSERT( 0 <= STATE(CountExpr) );
+    GAP_ASSERT( STATE(CountExpr) <= CapacityStackExpr() );
+    GAP_ASSERT( expr != 0 );
 
     /* count up and put the expression onto the stack                      */
     if ( STATE(CountExpr) == CapacityStackExpr() ) {
@@ -437,9 +437,9 @@ static Expr PopExpr(void)
     Expr                expr;
 
     /* there must be a stack, it must not be underfull/empty or overfull   */
-    assert( STATE(StackExpr) != 0 );
-    assert( 1 <= STATE(CountExpr) );
-    assert( STATE(CountExpr) <= CapacityStackExpr() );
+    GAP_ASSERT( STATE(StackExpr) != 0 );
+    GAP_ASSERT( 1 <= STATE(CountExpr) );
+    GAP_ASSERT( STATE(CountExpr) <= CapacityStackExpr() );
 
     /* get the top expression from the stack, and count down               */
     STATE(CountExpr)--;
@@ -597,8 +597,8 @@ void            CodeFuncCallOptionsEnd ( UInt nr )
 void CodeBegin ( void )
 {
     /* the stacks must be empty                                            */
-    assert( STATE(CountStat) == 0 );
-    assert( STATE(CountExpr) == 0 );
+    GAP_ASSERT( STATE(CountStat) == 0 );
+    GAP_ASSERT( STATE(CountExpr) == 0 );
 
     /* remember the current frame                                          */
     STATE(CodeLVars) = STATE(CurrLVars);
@@ -614,11 +614,11 @@ UInt CodeEnd (
     if ( ! error ) {
 
         /* the stacks must be empty                                        */
-        assert( STATE(CountStat) == 0 );
-        assert( STATE(CountExpr) == 0 );
+        GAP_ASSERT( STATE(CountStat) == 0 );
+        GAP_ASSERT( STATE(CountExpr) == 0 );
 
         /* we must be back to 'STATE(CurrLVars)'                                  */
-        assert( STATE(CurrLVars) == STATE(CodeLVars) );
+        GAP_ASSERT( STATE(CurrLVars) == STATE(CodeLVars) );
 
         /* 'CodeFuncExprEnd' left the function already in 'STATE(CodeResult)'     */
     }
@@ -786,7 +786,11 @@ void CodeFuncExprBegin (
 
     /* allocate the top level statement sequence                           */
     stat1 = NewStat( T_SEQ_STAT, 8*sizeof(Stat) );
-    assert( stat1 == OFFSET_FIRST_STAT );
+
+    /* Cast to void to avoid warning when asserts are disabled             */
+    (void)stat1;
+
+    GAP_ASSERT( stat1 == OFFSET_FIRST_STAT );
 }
 
 void CodeFuncExprEnd(UInt nr)
@@ -800,6 +804,7 @@ void CodeFuncExprEnd(UInt nr)
 
     /* get the function expression                                         */
     fexp = CURR_FUNC();
+    GAP_ASSERT(!STATE(LoopNesting));
     
     /* get the body of the function                                        */
     /* push an additional return-void-statement if neccessary              */
@@ -1791,7 +1796,7 @@ static UInt getNextFloatExprNumber(void)
 {
     UInt next;
     HashLock(&NextFloatExprNumber);
-    assert(NextFloatExprNumber < MAX_FLOAT_INDEX);
+    GAP_ASSERT(NextFloatExprNumber < MAX_FLOAT_INDEX);
     next = NextFloatExprNumber++;
     HashUnlock(&NextFloatExprNumber);
     return next;
@@ -1826,7 +1831,7 @@ static UInt CheckForCommonFloat(Char * str)
     if (IsDigit(*str))
         return 0;
     /* must now be an exponent character */
-    assert(IsAlpha(*str));
+    GAP_ASSERT(IsAlpha(*str));
     /* skip it */
     str++;
     /*skip + and - in exponent */
@@ -1869,12 +1874,12 @@ static void CodeEagerFloatExpr(Obj str, Char mark)
     Expr fl = NewExpr(T_FLOAT_EXPR_EAGER, sizeof(UInt) * 3 + l + 1);
     Obj v = CALL_2ARGS(CONVERT_FLOAT_LITERAL_EAGER, str, ObjsChar[(Int)mark]);
     UInt ix;
-    assert(EAGER_FLOAT_LITERAL_CACHE);
+    GAP_ASSERT(EAGER_FLOAT_LITERAL_CACHE);
 #ifdef HPCGAP
-    assert(TNUM_OBJ(EAGER_FLOAT_LITERAL_CACHE) == T_ALIST);
+    GAP_ASSERT(TNUM_OBJ(EAGER_FLOAT_LITERAL_CACHE) == T_ALIST);
     ix = AddAList(EAGER_FLOAT_LITERAL_CACHE, v);
 #else
-    assert(IS_PLIST(EAGER_FLOAT_LITERAL_CACHE));
+    GAP_ASSERT(IS_PLIST(EAGER_FLOAT_LITERAL_CACHE));
     ix = PushPlist(EAGER_FLOAT_LITERAL_CACHE, v);
 #endif
     ADDR_EXPR(fl)[0] = ix;

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1218,7 +1218,7 @@ Obj             EvalFloatExprLazy (
                MAX_FLOAT_LITERAL_CACHE_SIZE == INTOBJ_INT(0) ||
                ix <= INT_INTOBJ(MAX_FLOAT_LITERAL_CACHE_SIZE))) {
       cache = FLOAT_LITERAL_CACHE;
-      assert(cache);
+      GAP_ASSERT(cache);
       fl = ELM0_LIST(cache, ix);
       if (fl)
         return fl;

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1014,7 +1014,7 @@ void            ExecEnd (
     if ( ! error ) {
 
         /* the state must be primal again                                  */
-        assert( STATE(CurrStat)  == 0 );
+        GAP_ASSERT( STATE(CurrStat)  == 0 );
 
     }
 

--- a/src/gapstate.c
+++ b/src/gapstate.c
@@ -38,11 +38,11 @@ Int RegisterModuleState(UInt size, ModuleConstructor constructor, ModuleDestruct
 
     // if not at least one of the three arguments is non-zero, it doesn't make
     // sense to call this function
-    assert(size || constructor || destructor);
+    GAP_ASSERT(size || constructor || destructor);
 
     // check that we have enough free space
-    assert((STATE_SLOTS_SIZE - StateNextFreeOffset) >= size);
-    assert(StateDescriptorCount < STATE_MAX_HANDLERS);
+    GAP_ASSERT((STATE_SLOTS_SIZE - StateNextFreeOffset) >= size);
+    GAP_ASSERT(StateDescriptorCount < STATE_MAX_HANDLERS);
 
     handler = StateDescriptors + StateDescriptorCount++;
     handler->size = size;

--- a/src/hpc/misc.c
+++ b/src/hpc/misc.c
@@ -75,7 +75,7 @@ static void MergeSortRecurse(char * data,
                              int (*lessThan)(const void * a, const void *))
 {
     UInt nleft, nright;
-    /* assert(count > 1); */
+    /* GAP_ASSERT(count > 1); */
     if (count == 2) {
         if (!lessThan(data, data + width)) {
             memcpy(aux, data, width);

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -489,7 +489,7 @@ void HashUnlockShared(void * object)
 void RegionWriteLock(Region * region)
 {
     int result = 0;
-    assert(region->owner != GetTLS());
+    GAP_ASSERT(region->owner != GetTLS());
 
     if (region->count_active || TLS(CountActive)) {
         result = !pthread_rwlock_trywrlock(region->lock);
@@ -518,7 +518,7 @@ void RegionWriteLock(Region * region)
 int RegionTryWriteLock(Region * region)
 {
     int result;
-    assert(region->owner != GetTLS());
+    GAP_ASSERT(region->owner != GetTLS());
     result = !pthread_rwlock_trywrlock(region->lock);
 
     if (result) {
@@ -539,7 +539,7 @@ int RegionTryWriteLock(Region * region)
 
 void RegionWriteUnlock(Region * region)
 {
-    assert(region->owner == GetTLS());
+    GAP_ASSERT(region->owner == GetTLS());
     region->owner = NULL;
     pthread_rwlock_unlock(region->lock);
 }
@@ -547,8 +547,8 @@ void RegionWriteUnlock(Region * region)
 void RegionReadLock(Region * region)
 {
     int result = 0;
-    assert(region->owner != GetTLS());
-    assert(region->readers[TLS(threadID)] == 0);
+    GAP_ASSERT(region->owner != GetTLS());
+    GAP_ASSERT(region->readers[TLS(threadID)] == 0);
 
     if (region->count_active || TLS(CountActive)) {
         result = !pthread_rwlock_rdlock(region->lock);
@@ -576,8 +576,8 @@ void RegionReadLock(Region * region)
 int RegionTryReadLock(Region * region)
 {
     int result = !pthread_rwlock_rdlock(region->lock);
-    assert(region->owner != GetTLS());
-    assert(region->readers[TLS(threadID)] == 0);
+    GAP_ASSERT(region->owner != GetTLS());
+    GAP_ASSERT(region->readers[TLS(threadID)] == 0);
 
     if (result) {
         if (region->count_active)
@@ -597,14 +597,14 @@ int RegionTryReadLock(Region * region)
 
 void RegionReadUnlock(Region * region)
 {
-    assert(region->readers[TLS(threadID)]);
+    GAP_ASSERT(region->readers[TLS(threadID)]);
     region->readers[TLS(threadID)] = 0;
     pthread_rwlock_unlock(region->lock);
 }
 
 void RegionUnlock(Region * region)
 {
-    assert(region->owner == GetTLS() || region->readers[TLS(threadID)]);
+    GAP_ASSERT(region->owner == GetTLS() || region->readers[TLS(threadID)]);
     if (region->owner == GetTLS())
         region->owner = NULL;
     region->readers[TLS(threadID)] = 0;

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -241,7 +241,7 @@ static int MonitorsAreSorted(UInt count, Monitor ** monitors)
 void LockMonitors(UInt count, Monitor ** monitors)
 {
     UInt i;
-    assert(MonitorsAreSorted(count, monitors));
+    GAP_ASSERT(MonitorsAreSorted(count, monitors));
     for (i = 0; i < count; i++)
         LockMonitor(monitors[i]);
 }
@@ -277,7 +277,7 @@ UInt WaitForAnyMonitor(UInt count, Monitor ** monitors)
     Monitor *         monitor;
     UInt              i;
     Int               result;
-    assert(MonitorsAreSorted(count, monitors));
+    GAP_ASSERT(MonitorsAreSorted(count, monitors));
     nodes = alloca(sizeof(struct WaitList) * count);
     for (i = 0; i < count; i++)
         nodes[i].thread = GetTLS();

--- a/src/hpc/threadapi.h
+++ b/src/hpc/threadapi.h
@@ -33,7 +33,7 @@ StructInitInfo *InitInfoThreadAPI(void);
 
 static inline Monitor *MonitorPtr(Obj obj)
 {
-  assert(TNUM_OBJ(obj) == T_MONITOR);
+  GAP_ASSERT(TNUM_OBJ(obj) == T_MONITOR);
   return (Monitor *)(PTR_BAG(obj));
 }
 Obj NewMonitor(void);

--- a/src/hpc/traverse.c
+++ b/src/hpc/traverse.c
@@ -420,7 +420,7 @@ static Int InitKernel ( StructInitInfo * module )
 {
     int i;
     for (i = FIRST_REAL_TNUM; i <= LAST_REAL_TNUM; i++) {
-        assert(TraversalMethod[i] == 0);
+        GAP_ASSERT(TraversalMethod[i] == 0);
         TraversalMethod[i] = TRAVERSE_NONE;
     }
 

--- a/src/integer.c
+++ b/src/integer.c
@@ -386,7 +386,7 @@ static inline void UPDATE_FAKEMPZ( fake_mpz_t fake )
 /* some extra debugging tools for FAKMPZ objects */
 #if DEBUG_GMP
 #define CHECK_FAKEMPZ(fake) \
-    assert( ((fake)->v->_mp_d == ((fake)->obj ? ADDR_INT((fake)->obj) : &(fake)->tmp )) \
+    GAP_ASSERT( ((fake)->v->_mp_d == ((fake)->obj ? ADDR_INT((fake)->obj) : &(fake)->tmp )) \
         &&  (fake->v->_mp_alloc == ((fake)->obj ? SIZE_INT((fake)->obj) : 1 )) )
 #else
 #define CHECK_FAKEMPZ(fake)  do { } while(0);
@@ -545,7 +545,7 @@ Obj ObjInt_Int8( Int8 i )
   }
 
   /* we need two limbs to store this integer */
-  assert( sizeof(mp_limb_t) == 4 );
+  GAP_ASSERT( sizeof(mp_limb_t) == 4 );
   Obj gmp;
   if (i >= 0) {
      gmp = NewBag( T_INTPOS, 2 * sizeof(mp_limb_t) );
@@ -571,7 +571,7 @@ Obj ObjInt_UInt8( UInt8 i )
   }
 
   /* we need two limbs to store this integer */
-  assert( sizeof(mp_limb_t) == 4 );
+  GAP_ASSERT( sizeof(mp_limb_t) == 4 );
   Obj gmp = NewBag( T_INTPOS, 2 * sizeof(mp_limb_t) );
   mp_limb_t *ptr = ADDR_INT(gmp);
   ptr[0] = (UInt4)i;
@@ -1808,7 +1808,7 @@ Obj ModInt(Obj opL, Obj opR)
       else
         mod = SumOrDiffInt( opL, opR, -1 );
 #if DEBUG_GMP
-      assert( !IS_NEG_INT(mod) );
+      GAP_ASSERT( !IS_NEG_INT(mod) );
 #endif
       CHECK_INT(mod);
       return mod;
@@ -1840,7 +1840,7 @@ Obj ModInt(Obj opL, Obj opR)
   
   /* return the result                                                     */
 #if DEBUG_GMP
-  assert( !IS_NEG_INT(mod) );
+  GAP_ASSERT( !IS_NEG_INT(mod) );
 #endif
   CHECK_INT(mod);
   return mod;

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -128,7 +128,7 @@
 
 static void PushObj(Obj val)
 {
-    assert( val != 0 );
+    GAP_ASSERT( val != 0 );
     PushPlist( STATE(StackObj), val );
 }
 
@@ -162,7 +162,7 @@ static Obj PopObj(void)
     }
 
     // return the popped value (which must be non-void)
-    assert( val != 0 );
+    GAP_ASSERT( val != 0 );
     return val;
 }
 
@@ -181,7 +181,7 @@ static Obj PopVoidObj(void)
 
 static inline void StartFakeFuncExpr(Int startLine)
 {
-    assert(STATE(IntrCoding) == 0);
+    GAP_ASSERT(STATE(IntrCoding) == 0);
 
     // switch to coding mode now
     CodeBegin();
@@ -205,7 +205,7 @@ static inline void StartFakeFuncExpr(Int startLine)
 
 static inline void FinishAndCallFakeFuncExpr(void)
 {
-    assert(STATE(IntrCoding) == 0);
+    GAP_ASSERT(STATE(IntrCoding) == 0);
 
     // code a function expression (with one statement in the body)
     CodeFuncExprEnd(1);
@@ -265,8 +265,8 @@ void IntrBegin ( Obj frame )
     SET_LEN_PLIST( STATE(StackObj), 0 );
 
     /* must be in immediate (non-ignoring, non-coding) mode                */
-    assert( STATE(IntrIgnoring) == 0 );
-    assert( STATE(IntrCoding)   == 0 );
+    GAP_ASSERT( STATE(IntrIgnoring) == 0 );
+    GAP_ASSERT( STATE(IntrCoding)   == 0 );
 
     /* no return-statement was yet interpreted                             */
     STATE(IntrReturning) = 0;
@@ -291,11 +291,11 @@ ExecStatus IntrEnd (
         STATE(IntrReturning) = 0;
 
         /* must be back in immediate (non-ignoring, non-coding) mode       */
-        assert( STATE(IntrIgnoring) == 0 );
-        assert( STATE(IntrCoding)   == 0 );
+        GAP_ASSERT( STATE(IntrIgnoring) == 0 );
+        GAP_ASSERT( STATE(IntrCoding)   == 0 );
 
         /* and the stack must contain the result value (which may be void) */
-        assert( LEN_PLIST(STATE(StackObj)) == 1 );
+        GAP_ASSERT( LEN_PLIST(STATE(StackObj)) == 1 );
         STATE(IntrResult) = PopVoidObj();
 
     }
@@ -494,7 +494,7 @@ void IntrFuncExprEnd(UInt nr)
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert(STATE(IntrCoding) > 0);
+    GAP_ASSERT(STATE(IntrCoding) > 0);
 
     STATE(IntrCoding)--;
     CodeFuncExprEnd(nr);
@@ -697,7 +697,7 @@ void IntrForIn ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( STATE(IntrCoding) > 0 );
+    GAP_ASSERT( STATE(IntrCoding) > 0 );
     CodeForIn();
 }
 
@@ -708,7 +708,7 @@ void IntrForBeginBody ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( STATE(IntrCoding) > 0 );
+    GAP_ASSERT( STATE(IntrCoding) > 0 );
     CodeForBeginBody();
 }
 
@@ -720,7 +720,7 @@ void IntrForEndBody (
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert(STATE(IntrCoding) > 0);
+    GAP_ASSERT(STATE(IntrCoding) > 0);
     CodeForEndBody(nr);
 }
 
@@ -731,7 +731,7 @@ void IntrForEnd ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( STATE(IntrCoding) > 0 );
+    GAP_ASSERT( STATE(IntrCoding) > 0 );
 
     STATE(IntrCoding)--;
     CodeForEnd();
@@ -789,7 +789,7 @@ void            IntrWhileBeginBody ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( STATE(IntrCoding) > 0 );
+    GAP_ASSERT( STATE(IntrCoding) > 0 );
     CodeWhileBeginBody();
 }
 
@@ -801,7 +801,7 @@ void            IntrWhileEndBody (
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( STATE(IntrCoding) > 0 );
+    GAP_ASSERT( STATE(IntrCoding) > 0 );
     CodeWhileEndBody( nr );
 }
 
@@ -812,7 +812,7 @@ void            IntrWhileEnd ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( STATE(IntrCoding) > 0 );
+    GAP_ASSERT( STATE(IntrCoding) > 0 );
 
     STATE(IntrCoding)--;
     CodeWhileEnd();
@@ -896,7 +896,7 @@ void            IntrAtomicBeginBody ( UInt nrexprs )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert(STATE(IntrCoding) > 0);
+    GAP_ASSERT(STATE(IntrCoding) > 0);
     CodeAtomicBeginBody(nrexprs);
 }
 
@@ -908,7 +908,7 @@ void            IntrAtomicEndBody (
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     // must be coding
-    assert(STATE(IntrCoding) > 0);
+    GAP_ASSERT(STATE(IntrCoding) > 0);
     CodeAtomicEndBody(nrstats);
 }
 
@@ -919,7 +919,7 @@ void            IntrAtomicEnd ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert(STATE(IntrCoding) > 0);
+    GAP_ASSERT(STATE(IntrCoding) > 0);
 
     STATE(IntrCoding)--;
     CodeAtomicEnd();
@@ -977,7 +977,7 @@ void            IntrRepeatBeginBody ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( STATE(IntrCoding) > 0 );
+    GAP_ASSERT( STATE(IntrCoding) > 0 );
     CodeRepeatBeginBody();
 }
 
@@ -989,7 +989,7 @@ void            IntrRepeatEndBody (
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( STATE(IntrCoding) > 0 );
+    GAP_ASSERT( STATE(IntrCoding) > 0 );
     CodeRepeatEndBody( nr );
 }
 
@@ -1000,7 +1000,7 @@ void            IntrRepeatEnd ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* otherwise must be coding                                            */
-    assert( STATE(IntrCoding) > 0 );
+    GAP_ASSERT( STATE(IntrCoding) > 0 );
 
     STATE(IntrCoding)--;
     CodeRepeatEnd();
@@ -1124,7 +1124,7 @@ void            IntrQuit ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* 'quit' is not allowed in functions (by the reader)                  */
-    /* assert( STATE(IntrCoding) == 0 ); */
+    /* GAP_ASSERT( STATE(IntrCoding) == 0 ); */
     if ( STATE(IntrCoding) > 0 ) {
       SyntaxError("'quit;' cannot be used in this context");
     }
@@ -1152,7 +1152,7 @@ void            IntrQUIT ( void )
     if ( STATE(IntrIgnoring)  > 0 ) { return; }
 
     /* 'quit' is not allowed in functions (by the reader)                  */
-    assert( STATE(IntrCoding) == 0 );
+    GAP_ASSERT( STATE(IntrCoding) == 0 );
 
     /* empty the values stack and push the void value                      */
     SET_LEN_PLIST( STATE(StackObj), 0 );

--- a/src/io.c
+++ b/src/io.c
@@ -246,7 +246,7 @@ static Char GET_NEXT_CHAR_NO_LC(void)
 
 Char PEEK_NEXT_CHAR(void)
 {
-    assert(IS_CHAR_PUSHBACK_EMPTY());
+    GAP_ASSERT(IS_CHAR_PUSHBACK_EMPTY());
 
     // store the current character
     IO()->Pushback = *STATE(In);

--- a/src/iostream.c
+++ b/src/iostream.c
@@ -245,7 +245,7 @@ static void ChildStatusChanged(int whichsig)
     UInt i;
     int  status;
     int  retcode;
-    assert(whichsig == SIGCHLD);
+    GAP_ASSERT(whichsig == SIGCHLD);
     HashLock(PtyIOStreams);
     for (i = 0; i < MAX_PTYS; i++) {
         if (PtyIOStreams[i].inuse) {

--- a/src/lists.c
+++ b/src/lists.c
@@ -2351,7 +2351,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_LIST' filter                               */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(IsListFuncs[ type ] == 0);
+        GAP_ASSERT(IsListFuncs[ type ] == 0);
         IsListFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
@@ -2364,7 +2364,7 @@ static Int InitKernel (
     /* make and install the 'IS_SMALL_LIST' filter                   */
     /* non-lists are not small lists */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(IsSmallListFuncs[ type ] == 0);
+        GAP_ASSERT(IsSmallListFuncs[ type ] == 0);
         IsSmallListFuncs[ type ] = AlwaysNo;
     }
     /* internal lists ARE small lists */
@@ -2379,7 +2379,7 @@ static Int InitKernel (
 
     /* make and install the 'LEN_LIST' function                            */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(LenListFuncs[ type ] == 0);
+        GAP_ASSERT(LenListFuncs[ type ] == 0);
         LenListFuncs[ type ] = LenListError;
     }
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
@@ -2388,7 +2388,7 @@ static Int InitKernel (
 
     /* make and install the 'LENGTH' function                            */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(LengthFuncs[ type ] == 0);
+        GAP_ASSERT(LengthFuncs[ type ] == 0);
         LengthFuncs[ type ] = LengthError;
     }
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
@@ -2409,9 +2409,9 @@ static Int InitKernel (
 
     /* make and install the 'ELM0_LIST' operation                          */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(Elm0ListFuncs[  type ] == 0);
+        GAP_ASSERT(Elm0ListFuncs[  type ] == 0);
         Elm0ListFuncs[  type ] = Elm0ListError;
-        assert(Elm0vListFuncs[ type ] == 0);
+        GAP_ASSERT(Elm0vListFuncs[ type ] == 0);
         Elm0vListFuncs[ type ] = Elm0ListError;
     }
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
@@ -2432,11 +2432,11 @@ static Int InitKernel (
 
     /* make and install the 'ELM_LIST' operation                           */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(ElmListFuncs[  type ] == 0);
+        GAP_ASSERT(ElmListFuncs[  type ] == 0);
         ElmListFuncs[  type ] = ElmListError;
-        assert(ElmvListFuncs[ type ] == 0);
+        GAP_ASSERT(ElmvListFuncs[ type ] == 0);
         ElmvListFuncs[ type ] = ElmListError;
-        assert(ElmwListFuncs[ type ] == 0);
+        GAP_ASSERT(ElmwListFuncs[ type ] == 0);
         ElmwListFuncs[ type ] = ElmListError;
     }
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
@@ -2448,7 +2448,7 @@ static Int InitKernel (
 
     /* make and install the 'ELMS_LIST' operation                          */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(ElmsListFuncs[ type ] == 0);
+        GAP_ASSERT(ElmsListFuncs[ type ] == 0);
         ElmsListFuncs[ type ] = ElmsListError;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
@@ -2461,7 +2461,7 @@ static Int InitKernel (
 
     /* make and install the 'UNB_LIST' operation                           */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(UnbListFuncs[ type ] == 0);
+        GAP_ASSERT(UnbListFuncs[ type ] == 0);
         UnbListFuncs[ type ] = UnbListError;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
@@ -2474,7 +2474,7 @@ static Int InitKernel (
 
     /* make and install the 'ASS_LIST' operation                           */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(AssListFuncs[ type ] == 0);
+        GAP_ASSERT(AssListFuncs[ type ] == 0);
         AssListFuncs[ type ] = AssListError;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
@@ -2487,7 +2487,7 @@ static Int InitKernel (
 
     /* make and install the 'ASSS_LIST' operation                          */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(AsssListFuncs[ type ] == 0);
+        GAP_ASSERT(AsssListFuncs[ type ] == 0);
         AsssListFuncs[ type ] = AsssListError;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
@@ -2500,7 +2500,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_DENSE_LIST' filter                         */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(IsDenseListFuncs[ type ] == 0);
+        GAP_ASSERT(IsDenseListFuncs[ type ] == 0);
         IsDenseListFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
@@ -2513,7 +2513,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_HOMOG_LIST' filter                         */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(IsHomogListFuncs[ type ] == 0);
+        GAP_ASSERT(IsHomogListFuncs[ type ] == 0);
         IsHomogListFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
@@ -2526,7 +2526,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_TABLE_LIST' filter                         */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(IsTableListFuncs[ type ] == 0);
+        GAP_ASSERT(IsTableListFuncs[ type ] == 0);
         IsTableListFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
@@ -2539,7 +2539,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_SSORT_LIST' property                       */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(IsSSortListFuncs[ type ] == 0);
+        GAP_ASSERT(IsSSortListFuncs[ type ] == 0);
         IsSSortListFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
@@ -2552,7 +2552,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_POSS_LIST' property                        */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(IsPossListFuncs[ type ] == 0);
+        GAP_ASSERT(IsPossListFuncs[ type ] == 0);
         IsPossListFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
@@ -2565,7 +2565,7 @@ static Int InitKernel (
 
     /* make and install the 'POS_LIST' operation                           */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(PosListFuncs[ type ] == 0);
+        GAP_ASSERT(PosListFuncs[ type ] == 0);
         PosListFuncs[ type ] = PosListError;
     }
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
@@ -2578,7 +2578,7 @@ static Int InitKernel (
 
     /* install the error functions into the other tables                   */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(PlainListFuncs [ type ] == 0);
+        GAP_ASSERT(PlainListFuncs [ type ] == 0);
         PlainListFuncs [ type ] = PlainListError;
     }
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -1855,14 +1855,14 @@ Obj FuncFORCE_SWITCH_OBJ(Obj self, Obj obj1, Obj obj2) {
     if (k == name) {                                                         \
         Pr("%3d: %s", k, (Int)indentStr);                                    \
         Pr("%s" #name "\n", (Int)indentStr, 0);                              \
-        assert(indentLvl + 1 < sizeof(indentStr));                           \
+        GAP_ASSERT(indentLvl + 1 < sizeof(indentStr));                           \
         indentStr[indentLvl++] = ' ';                                        \
         indentStr[indentLvl] = 0;                                            \
     }
 
 #define STOP_SYMBOLIC_TNUM(name)                                             \
     if (k == name) {                                                         \
-        assert(indentLvl > 0);                                               \
+        GAP_ASSERT(indentLvl > 0);                                               \
         indentStr[--indentLvl] = 0;                                          \
         Pr("%3d: %s", k, (Int)indentStr);                                    \
         Pr("%s" #name "\n", (Int)indentStr, 0);                              \
@@ -2024,7 +2024,7 @@ static Int InitKernel (
 #endif
 
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ ) {
-        assert(TypeObjFuncs[ t ] == 0);
+        GAP_ASSERT(TypeObjFuncs[ t ] == 0);
         TypeObjFuncs[ t ] = TypeObjError;
         SetTypeObjFuncs [ t] = SetTypeObjError;
     }
@@ -2049,7 +2049,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_MUTABLE_OBJ' filter                        */
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ ) {
-        assert(IsMutableObjFuncs[ t ] == 0);
+        GAP_ASSERT(IsMutableObjFuncs[ t ] == 0);
         IsMutableObjFuncs[ t ] = IsMutableObjError;
     }
     for ( t = FIRST_CONSTANT_TNUM; t <= LAST_CONSTANT_TNUM; t++ )
@@ -2059,7 +2059,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_COPYABLE_OBJ' filter                       */
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ ) {
-        assert(IsCopyableObjFuncs[ t ] == 0);
+        GAP_ASSERT(IsCopyableObjFuncs[ t ] == 0);
         IsCopyableObjFuncs[ t ] = IsCopyableObjError;
     }
     for ( t = FIRST_CONSTANT_TNUM; t <= LAST_CONSTANT_TNUM; t++ )
@@ -2069,7 +2069,7 @@ static Int InitKernel (
 
     /* make and install the 'SHALLOW_COPY_OBJ' operation                   */
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ ) {
-        assert(ShallowCopyObjFuncs[ t ] == 0);
+        GAP_ASSERT(ShallowCopyObjFuncs[ t ] == 0);
         ShallowCopyObjFuncs[ t ] = ShallowCopyObjError;
     }
     for ( t = FIRST_CONSTANT_TNUM; t <= LAST_CONSTANT_TNUM; t++ )
@@ -2088,9 +2088,9 @@ static Int InitKernel (
 #else
     /* make and install the 'COPY_OBJ' function                            */
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ ) {
-        assert(CopyObjFuncs [ t ] == 0);
+        GAP_ASSERT(CopyObjFuncs [ t ] == 0);
         CopyObjFuncs [ t ] = CopyObjError;
-        assert(CleanObjFuncs[ t ] == 0);
+        GAP_ASSERT(CleanObjFuncs[ t ] == 0);
         CleanObjFuncs[ t ] = CleanObjError;
     }
     for ( t = FIRST_CONSTANT_TNUM; t <= LAST_CONSTANT_TNUM; t++ ) {
@@ -2113,21 +2113,21 @@ static Int InitKernel (
 
     /* make and install the 'PRINT_OBJ' operation                          */
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ ) {
-        assert(PrintObjFuncs[ t ] == 0);
+        GAP_ASSERT(PrintObjFuncs[ t ] == 0);
         PrintObjFuncs[ t ] = PrintObjObject;
     }
 
     /* enter 'PrintUnknownObj' in the dispatching tables                   */
     for ( t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ ) {
-        assert(PrintPathFuncs[ t ] == 0);
+        GAP_ASSERT(PrintPathFuncs[ t ] == 0);
         PrintPathFuncs[ t ] = PrintPathError;
     }
 
     /* enter 'SaveObjError' and 'LoadObjError' for all types initially     */
     for ( t = FIRST_REAL_TNUM;  t <= LAST_REAL_TNUM;  t++ ) {
-        assert(SaveObjFuncs[ t ] == 0);
+        GAP_ASSERT(SaveObjFuncs[ t ] == 0);
         SaveObjFuncs[ t ] = SaveObjError;
-        assert(LoadObjFuncs[ t ] == 0);
+        GAP_ASSERT(LoadObjFuncs[ t ] == 0);
         LoadObjFuncs[ t ] = LoadObjError;
     }
   
@@ -2142,7 +2142,7 @@ static Int InitKernel (
     LoadObjFuncs[ T_DATOBJ ] = LoadDatObj;
 
     for (t = FIRST_REAL_TNUM; t <= LAST_REAL_TNUM; t++ ) {
-        assert(MakeImmutableObjFuncs[ t ] == 0);
+        GAP_ASSERT(MakeImmutableObjFuncs[ t ] == 0);
         MakeImmutableObjFuncs[t] = MakeImmutableError;
     }
     

--- a/src/objfgelm.c
+++ b/src/objfgelm.c
@@ -193,7 +193,7 @@ Obj Func8Bits_ExponentSums3 (
             /* this will not cause a garbage collection                    */
             exp = exp + (Int) ELM_PLIST( sums, pos-start+1 );
             SET_ELM_PLIST( sums, pos-start+1, (Obj) exp );
-            assert( ptr == (UInt1*)DATA_WORD(obj) + (i-1) );
+            GAP_ASSERT( ptr == (UInt1*)DATA_WORD(obj) + (i-1) );
         }
     }
 
@@ -304,7 +304,7 @@ Obj Func8Bits_ExtRepOfObj (
             SET_ELM_PLIST( lst, 2*i, INTOBJ_INT(((*ptr)&expm)-exps) );
         else
             SET_ELM_PLIST( lst, 2*i, INTOBJ_INT((*ptr)&expm) );
-        assert( ptr == (UInt1*)DATA_WORD(obj) + (i-1) );
+        GAP_ASSERT( ptr == (UInt1*)DATA_WORD(obj) + (i-1) );
     }
     CHANGED_BAG(lst);
 
@@ -564,7 +564,7 @@ Obj Func8Bits_AssocWord (
         }
         nexp = INT_INTOBJ(vexp) & expm;
         *ptr = ((ngen-1) << ebits) | nexp;
-        assert( ptr == (UInt1*)DATA_WORD(obj) + (i-1) );
+        GAP_ASSERT( ptr == (UInt1*)DATA_WORD(obj) + (i-1) );
     }
     CHANGED_BAG(obj);
 
@@ -625,7 +625,7 @@ Obj Func8Bits_ObjByVector (
         vexp = ELMW_LIST( data, j );
         nexp = INT_INTOBJ(vexp) & expm;
         *ptr = ((j-1) << ebits) | nexp;
-        assert( ptr == (UInt1*)DATA_WORD(obj) + (i-1) );
+        GAP_ASSERT( ptr == (UInt1*)DATA_WORD(obj) + (i-1) );
     }
     CHANGED_BAG(obj);
 
@@ -1172,7 +1172,7 @@ Obj Func16Bits_ExponentSums3 (
             /* this will not cause a garbage collection                    */
             exp = exp + (Int) ELM_PLIST( sums, pos-start+1 );
             SET_ELM_PLIST( sums, pos-start+1, (Obj) exp );
-            assert( ptr == (UInt2*)DATA_WORD(obj) + (i-1) );
+            GAP_ASSERT( ptr == (UInt2*)DATA_WORD(obj) + (i-1) );
         }
     }
 
@@ -1283,7 +1283,7 @@ Obj Func16Bits_ExtRepOfObj (
             SET_ELM_PLIST( lst, 2*i, INTOBJ_INT(((*ptr)&expm)-exps) );
         else
             SET_ELM_PLIST( lst, 2*i, INTOBJ_INT((*ptr)&expm) );
-        assert( ptr == (UInt2*)DATA_WORD(obj) + (i-1) );
+        GAP_ASSERT( ptr == (UInt2*)DATA_WORD(obj) + (i-1) );
     }
     CHANGED_BAG(lst);
 
@@ -1522,7 +1522,7 @@ Obj Func16Bits_AssocWord (
         }
         nexp = INT_INTOBJ(vexp) & expm;
         *ptr = ((ngen-1) << ebits) | nexp;
-        assert( ptr == (UInt2*)DATA_WORD(obj) + (i-1) );
+        GAP_ASSERT( ptr == (UInt2*)DATA_WORD(obj) + (i-1) );
     }
     CHANGED_BAG(obj);
 
@@ -1583,7 +1583,7 @@ Obj Func16Bits_ObjByVector (
         vexp = ELMW_LIST( data, j );
         nexp = INT_INTOBJ(vexp) & expm;
         *ptr = ((j-1) << ebits) | nexp;
-        assert( ptr == (UInt2*)DATA_WORD(obj) + (i-1) );
+        GAP_ASSERT( ptr == (UInt2*)DATA_WORD(obj) + (i-1) );
     }
     CHANGED_BAG(obj);
 
@@ -2130,7 +2130,7 @@ Obj Func32Bits_ExponentSums3 (
             /* this will not cause a garbage collection                    */
             exp = exp + (Int) ELM_PLIST( sums, pos-start+1 );
             SET_ELM_PLIST( sums, pos-start+1, (Obj) exp );
-            assert( ptr == (UInt4*)DATA_WORD(obj) + (i-1) );
+            GAP_ASSERT( ptr == (UInt4*)DATA_WORD(obj) + (i-1) );
         }
     }
 
@@ -2241,7 +2241,7 @@ Obj Func32Bits_ExtRepOfObj (
             SET_ELM_PLIST( lst, 2*i, INTOBJ_INT(((*ptr)&expm)-exps) );
         else
             SET_ELM_PLIST( lst, 2*i, INTOBJ_INT((*ptr)&expm) );
-        assert( ptr == (UInt4*)DATA_WORD(obj) + (i-1) );
+        GAP_ASSERT( ptr == (UInt4*)DATA_WORD(obj) + (i-1) );
     }
     CHANGED_BAG(lst);
 
@@ -2480,7 +2480,7 @@ Obj Func32Bits_AssocWord (
         }
         nexp = INT_INTOBJ(vexp) & expm;
         *ptr = ((ngen-1) << ebits) | nexp;
-        assert( ptr == (UInt4*)DATA_WORD(obj) + (i-1) );
+        GAP_ASSERT( ptr == (UInt4*)DATA_WORD(obj) + (i-1) );
     }
     CHANGED_BAG(obj);
 
@@ -2541,7 +2541,7 @@ Obj Func32Bits_ObjByVector (
         vexp = ELMW_LIST( data, j );
         nexp = INT_INTOBJ(vexp) & expm;
         *ptr = ((j-1) << ebits) | nexp;
-        assert( ptr == (UInt4*)DATA_WORD(obj) + (i-1) );
+        GAP_ASSERT( ptr == (UInt4*)DATA_WORD(obj) + (i-1) );
     }
     CHANGED_BAG(obj);
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -466,12 +466,12 @@ Int KTNumHomPlist (
     lenList = LEN_PLIST(list);
 
     /* special case for empty list                                         */
-    assert(lenList);
+    GAP_ASSERT(lenList);
 
     /* look at the first element                                           */
     elm = ELM_PLIST( list, 1 );
-    assert(elm);
-    assert(!TEST_OBJ_FLAG(elm, TESTING));
+    GAP_ASSERT(elm);
+    GAP_ASSERT(!TEST_OBJ_FLAG(elm, TESTING));
 
     isSSort = HAS_FILT_LIST(list, FN_IS_SSORT );
     isNSort = HAS_FILT_LIST(list, FN_IS_NSORT );
@@ -527,8 +527,8 @@ Int KTNumHomPlist (
 	/* loop over the list */
 	for ( i = 2; isTable && i <= lenList; i++ ) {
 	  elm = ELM_PLIST( list, i );
-	  assert(elm);
-          assert(!TEST_OBJ_FLAG(elm, TESTING));
+	  GAP_ASSERT(elm);
+          GAP_ASSERT(!TEST_OBJ_FLAG(elm, TESTING));
           isTable = isTable && IS_LIST(elm); /* (isTable && IS_SMALL_LIST(elm) && LEN_LIST(elm) == len);*/
 	  isRect = isRect && IS_PLIST(elm) && LEN_PLIST(elm) == len;
 	}
@@ -2467,7 +2467,7 @@ Obj             PosPlistDense (
 
         /* select one element from <list>                                  */
         elm = ELM_PLIST( list, i );
-        assert(elm);
+        GAP_ASSERT(elm);
 
         /* compare with <val>                                              */
         if ( EQ( elm, val ) )
@@ -2672,9 +2672,9 @@ Obj FuncIsRectangularTablePlist( Obj self, Obj plist)
   UInt hasMut = 0;
   Obj elm;
   
-  assert(!HAS_FILT_LIST(plist, FN_IS_RECT));
+  GAP_ASSERT(!HAS_FILT_LIST(plist, FN_IS_RECT));
   lenlist = LEN_PLIST(plist);
-  assert(lenlist);
+  GAP_ASSERT(lenlist);
   if (lenlist == 1)
     {
       if (!IS_MUTABLE_OBJ(ELM_PLIST(plist,1)))

--- a/src/read.c
+++ b/src/read.c
@@ -107,7 +107,7 @@ void PushGlobalForLoopVariable( UInt var)
 
 void PopGlobalForLoopVariable( void )
 {
-  assert(STATE(CurrentGlobalForLoopDepth));
+  GAP_ASSERT(STATE(CurrentGlobalForLoopDepth));
   STATE(CurrentGlobalForLoopDepth)--;
 }
 

--- a/src/records.c
+++ b/src/records.c
@@ -670,7 +670,7 @@ static Int InitKernel (
 
     /* make and install the 'IS_REC' filter                                */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(IsRecFuncs[ type ] == 0);
+        GAP_ASSERT(IsRecFuncs[ type ] == 0);
         IsRecFuncs[ type ] = AlwaysNo;
     }
     for ( type = FIRST_RECORD_TNUM; type <= LAST_RECORD_TNUM; type++ ) {
@@ -683,7 +683,7 @@ static Int InitKernel (
 
     /* make and install the 'ELM_REC' operations                           */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(ElmRecFuncs[ type ] == 0);
+        GAP_ASSERT(ElmRecFuncs[ type ] == 0);
         ElmRecFuncs[ type ] = ElmRecError;
     }
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
@@ -693,7 +693,7 @@ static Int InitKernel (
 
     /* make and install the 'ISB_REC' operation                            */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(IsbRecFuncs[ type ] == 0);
+        GAP_ASSERT(IsbRecFuncs[ type ] == 0);
         IsbRecFuncs[ type ] = IsbRecError;
     }
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
@@ -703,7 +703,7 @@ static Int InitKernel (
 
     /* make and install the 'ASS_REC' operation                            */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(AssRecFuncs[ type ] == 0);
+        GAP_ASSERT(AssRecFuncs[ type ] == 0);
         AssRecFuncs[ type ] = AssRecError;
     }
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {
@@ -713,7 +713,7 @@ static Int InitKernel (
 
     /* make and install the 'UNB_REC' operation                            */
     for ( type = FIRST_REAL_TNUM; type <= LAST_REAL_TNUM; type++ ) {
-        assert(UnbRecFuncs[ type ] == 0);
+        GAP_ASSERT(UnbRecFuncs[ type ] == 0);
         UnbRecFuncs[ type ] = UnbRecError;
     }
     for ( type = FIRST_EXTERNAL_TNUM; type <= LAST_EXTERNAL_TNUM; type++ ) {

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -254,7 +254,7 @@ void LoadCStr( Char *buf, UInt maxsize)
 {
   UInt nread = 0;
   UInt1 c = 1;
-  assert(maxsize > 0);
+  GAP_ASSERT(maxsize > 0);
   while (c != '\0' && nread < maxsize )
     {
       c = LOAD_BYTE();

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -390,7 +390,7 @@ static void GetNumber(UInt StartingStatus)
 
     /* Or maybe we just ran out of space */
     if (IsDigit(c)) {
-      assert(i >= SAFE_VALUE_SIZE-1);
+      GAP_ASSERT(i >= SAFE_VALUE_SIZE-1);
       STATE(Symbol) = S_PARTIALINT;
       STATE(Value)[SAFE_VALUE_SIZE-1] = '\0';
       return;

--- a/src/stats.c
+++ b/src/stats.c
@@ -1651,7 +1651,7 @@ static inline Int BreakLoopPending(void)
 
 static void UnInterruptExecStat(void)
 {
-    assert(STATE(CurrExecStatFuncs) != ExecStatFuncs);
+    GAP_ASSERT(STATE(CurrExecStatFuncs) != ExecStatFuncs);
     STATE(CurrExecStatFuncs) = ExecStatFuncs;
 }
 

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -2410,7 +2410,7 @@ static Int InitKernel (
 
     /* install the `IsString' functions                                    */
     for ( t1 = FIRST_REAL_TNUM; t1 <= LAST_REAL_TNUM; t1++ ) {
-        assert(IsStringFuncs[ t1 ] == 0);
+        GAP_ASSERT(IsStringFuncs[ t1 ] == 0);
         IsStringFuncs[ t1 ] = AlwaysNo;
     }
 

--- a/src/system.c
+++ b/src/system.c
@@ -20,6 +20,7 @@
 */
 
 #include <src/system.h>
+#include <src/debug.h>
 
 #include <src/gaputils.h>
 #ifdef GAP_MEM_CHECK
@@ -477,7 +478,7 @@ size_t strxcpy (
     size_t len)
 {
     size_t res = strlcpy(dst, src, len);
-    assert(res < len);
+    GAP_ASSERT(res < len);
     return res;
 }
 
@@ -487,7 +488,7 @@ size_t strxcat (
     size_t len)
 {
     size_t res = strlcat(dst, src, len);
-    assert(res < len);
+    GAP_ASSERT(res < len);
     return res;
 }
 
@@ -498,7 +499,7 @@ size_t strxncat (
     size_t n)
 {
     size_t res = strlncat(dst, src, len, n);
-    assert(res < len);
+    GAP_ASSERT(res < len);
     return res;
 }
 

--- a/src/trans.c
+++ b/src/trans.c
@@ -1025,7 +1025,7 @@ Obj FuncKERNEL_TRANS(Obj self, Obj f, Obj n)
     pttmp = ResizeInitTmpTrans(nr);
 
     // RANK_TRANS(f) should install KER_TRANS(f)
-    assert(KER_TRANS(f) != NULL);
+    GAP_ASSERT(KER_TRANS(f) != NULL);
 
     nr = 0;
     // read off flat kernel
@@ -1697,8 +1697,8 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n)
     UInt    deg, i, j, rank, len;
     Obj     out;
 
-    assert(IS_LIST(ker));
-    assert(IS_INTOBJ(n));
+    GAP_ASSERT(IS_LIST(ker));
+    GAP_ASSERT(IS_INTOBJ(n));
 
     len = LEN_LIST(ker);
     if (len == 1 && INT_INTOBJ(ELM_LIST(ker, 1)) == 0) {
@@ -1873,7 +1873,7 @@ Obj FuncAS_TRANS_PERM_INT(Obj self, Obj p, Obj deg)
     else {    // dep >= def > 65536
         f = NEW_TRANS4(def);
         ptf4 = ADDR_TRANS4(f);
-        assert(TNUM_OBJ(p) == T_PERM4);
+        GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
         ptp4 = CONST_ADDR_PERM4(p);
         for (i = 0; i < min; i++) {
             ptf4[i] = ptp4[i];
@@ -2003,7 +2003,7 @@ Obj FuncPermutationOfImage(Obj self, Obj f)
 
         ptf2 = CONST_ADDR_TRANS2(f);
         img = IMG_TRANS(f);
-        assert(img != NULL);    // should be installed by RANK_TRANS2
+        GAP_ASSERT(img != NULL);    // should be installed by RANK_TRANS2
 
         for (i = 0; i < rank; i++) {
             j = INT_INTOBJ(ELM_PLIST(img, i + 1)) - 1;
@@ -2031,7 +2031,7 @@ Obj FuncPermutationOfImage(Obj self, Obj f)
 
         ptf4 = CONST_ADDR_TRANS4(f);
         img = IMG_TRANS(f);
-        assert(img != NULL);    // should be installed by RANK_TRANS2
+        GAP_ASSERT(img != NULL);    // should be installed by RANK_TRANS2
 
         for (i = 0; i < rank; i++) {
             j = INT_INTOBJ(ELM_PLIST(img, i + 1)) - 1;

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -491,7 +491,7 @@ void MakeFieldInfo8Bit( UInt q)
 Obj GetFieldInfo8Bit( UInt q)
 {
     Obj info;
-    assert(2 < q && q <= 256);
+    GAP_ASSERT(2 < q && q <= 256);
 #ifdef HPCGAP
     info = ATOMIC_ELM_PLIST(FieldInfo8Bit, q);
     if (info == 0) {
@@ -538,7 +538,7 @@ void RewriteVec8Bit( Obj vec, UInt q)
 
     if (q1 == q)
         return;
-    assert(q > q1);
+    GAP_ASSERT(q > q1);
 
     if (DoFilter(IsLockedRepresentationVector, vec) == True) {
         ErrorMayQuit("You cannot convert a locked vector compressed over GF(%i) to GF(%i)",
@@ -550,8 +550,8 @@ void RewriteVec8Bit( Obj vec, UInt q)
     len = LEN_VEC8BIT(vec);
     info = GetFieldInfo8Bit(q);
     info1 = GetFieldInfo8Bit(q1);
-    assert(P_FIELDINFO_8BIT(info) == P_FIELDINFO_8BIT(info1));
-    assert(!(D_FIELDINFO_8BIT(info) % D_FIELDINFO_8BIT(info1)));
+    GAP_ASSERT(P_FIELDINFO_8BIT(info) == P_FIELDINFO_8BIT(info1));
+    GAP_ASSERT(!(D_FIELDINFO_8BIT(info) % D_FIELDINFO_8BIT(info1)));
     els = ELS_BYTE_FIELDINFO_8BIT(info);
     els1 = ELS_BYTE_FIELDINFO_8BIT(info1);
 
@@ -573,7 +573,7 @@ void RewriteVec8Bit( Obj vec, UInt q)
     byte = 0;
     i = len - 1;
 
-    assert(((q - 1) % (q1 - 1)) == 0);
+    GAP_ASSERT(((q - 1) % (q1 - 1)) == 0);
     mult = (q - 1) / (q1 - 1);
     while (i >= 0) {
         val = VAL_FFE(convtab1[ gettab1[byte1 + 256 * (i % els1)]]);
@@ -614,7 +614,7 @@ void RewriteGF2Vec( Obj vec, UInt q )
     Int i;
     Obj type;
 
-    assert(q % 2 == 0);
+    GAP_ASSERT(q % 2 == 0);
 
     if (DoFilter(IsLockedRepresentationVector, vec) == True) {
         ErrorMayQuit("You cannot convert a locked vector compressed over GF(2) to GF(%i)",
@@ -737,8 +737,8 @@ void ConvVec8Bit (
     ptr = BYTES_VEC8BIT(list);
     for (i = 1;  i <= len;  i++) {
         elt = (i <= 3) ? firstthree[i - 1] : ELM_LIST(list, i);
-        assert(CHAR_FF(FLD_FFE(elt)) == p);
-        assert(d % DegreeFFE(elt) == 0);
+        GAP_ASSERT(CHAR_FF(FLD_FFE(elt)) == p);
+        GAP_ASSERT(d % DegreeFFE(elt) == 0);
         val = VAL_FFE(elt);
         if (val != 0 && FLD_FFE(elt) != f) {
             val = 1 + (val - 1) * (q - 1) / (SIZE_FF(FLD_FFE(elt)) - 1);
@@ -907,8 +907,8 @@ Obj NewVec8Bit (
     ptr = BYTES_VEC8BIT(res);
     for ( i = 1;  i <= len;  i++ ) {
       elt = ELM_LIST(list,i);
-      assert(CHAR_FF(FLD_FFE(elt)) == p);
-      assert( d % DegreeFFE(elt) == 0);
+      GAP_ASSERT(CHAR_FF(FLD_FFE(elt)) == p);
+      GAP_ASSERT( d % DegreeFFE(elt) == 0);
       val = VAL_FFE(elt);
       if (val != 0 && FLD_FFE(elt) != f)
 	{
@@ -1130,11 +1130,11 @@ void  AddVec8BitVec8BitInner( Obj sum,
     if (!stop)
         return;
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(sum));
-    assert(Q_FIELDINFO_8BIT(info) == FIELD_VEC8BIT(vl));
-    assert(Q_FIELDINFO_8BIT(info) == FIELD_VEC8BIT(vr));
-    assert(LEN_VEC8BIT(sum) >= stop);
-    assert(LEN_VEC8BIT(vl) >= stop);
-    assert(LEN_VEC8BIT(vr) >= stop);
+    GAP_ASSERT(Q_FIELDINFO_8BIT(info) == FIELD_VEC8BIT(vl));
+    GAP_ASSERT(Q_FIELDINFO_8BIT(info) == FIELD_VEC8BIT(vr));
+    GAP_ASSERT(LEN_VEC8BIT(sum) >= stop);
+    GAP_ASSERT(LEN_VEC8BIT(vl) >= stop);
+    GAP_ASSERT(LEN_VEC8BIT(vr) >= stop);
     p = P_FIELDINFO_8BIT(info);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     /* Convert from 1 based to zero based addressing */
@@ -1252,7 +1252,7 @@ Obj FuncSUM_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
         UInt p, newq;
         UInt i;
         p = P_FIELDINFO_8BIT(infol);
-        assert(p == P_FIELDINFO_8BIT(infor));
+        GAP_ASSERT(p == P_FIELDINFO_8BIT(infor));
         newq = 1;
         for (i = 0; i < newd; i++)
             newq *= p;
@@ -1320,10 +1320,10 @@ void MultVec8BitFFEInner( Obj prod,
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(prod));
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
-    assert(Q_FIELDINFO_8BIT(info) == FIELD_VEC8BIT(vec));
-    assert(LEN_VEC8BIT(prod) >= stop);
-    assert(LEN_VEC8BIT(vec) >= stop);
-    assert(Q_FIELDINFO_8BIT(info) == SIZE_FF(FLD_FFE(scal)));
+    GAP_ASSERT(Q_FIELDINFO_8BIT(info) == FIELD_VEC8BIT(vec));
+    GAP_ASSERT(LEN_VEC8BIT(prod) >= stop);
+    GAP_ASSERT(LEN_VEC8BIT(vec) >= stop);
+    GAP_ASSERT(Q_FIELDINFO_8BIT(info) == SIZE_FF(FLD_FFE(scal)));
 
 
     /* convert to 0 based addressing */
@@ -1429,7 +1429,7 @@ Obj FuncPROD_VEC8BIT_FFE( Obj self, Obj vec, Obj ffe)
     d = D_FIELDINFO_8BIT(info);
 
     /* family predicate should have handled this */
-    assert(CHAR_FF(FLD_FFE(ffe)) == P_FIELDINFO_8BIT(info));
+    GAP_ASSERT(CHAR_FF(FLD_FFE(ffe)) == P_FIELDINFO_8BIT(info));
 
     /* check for field compatibility */
     if (d % DEGR_FF(FLD_FFE(ffe))) {
@@ -1715,8 +1715,8 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_5( Obj self, Obj vl, Obj vr, Obj mul, Obj from, O
         d0 = LcmDegree(d, d1);
         d0 = LcmDegree(d0, d2);
         p = P_FIELDINFO_8BIT(info);
-        assert(p == P_FIELDINFO_8BIT(info1));
-        assert(p == CHAR_FF(FLD_FFE(mul)));
+        GAP_ASSERT(p == P_FIELDINFO_8BIT(info1));
+        GAP_ASSERT(p == CHAR_FF(FLD_FFE(mul)));
         q0 = 1;
         for (i = 0; i < d0; i++)
             q0 *= p;
@@ -1777,8 +1777,8 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_3( Obj self, Obj vl, Obj vr, Obj mul)
         d0 = LcmDegree(d, d1);
         d0 = LcmDegree(d0, d2);
         p = P_FIELDINFO_8BIT(info);
-        assert(p == P_FIELDINFO_8BIT(info1));
-        assert(p == CHAR_FF(FLD_FFE(mul)));
+        GAP_ASSERT(p == P_FIELDINFO_8BIT(info1));
+        GAP_ASSERT(p == CHAR_FF(FLD_FFE(mul)));
         q0 = 1;
         for (i = 0; i < d0; i++)
             q0 *= p;
@@ -1835,7 +1835,7 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_2( Obj self, Obj vl, Obj vr)
         d1 = D_FIELDINFO_8BIT(info1);
         d0 = LcmDegree(d, d1);
         p = P_FIELDINFO_8BIT(info);
-        assert(p == P_FIELDINFO_8BIT(info1));
+        GAP_ASSERT(p == P_FIELDINFO_8BIT(info1));
         q0 = 1;
         for (i = 0; i < d0; i++)
             q0 *= p;
@@ -1954,7 +1954,7 @@ Obj FuncDIFF_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
         UInt p, newq;
         UInt i;
         p = P_FIELDINFO_8BIT(infol);
-        assert(p == P_FIELDINFO_8BIT(infor));
+        GAP_ASSERT(p == P_FIELDINFO_8BIT(infor));
         newq = 1;
         for (i = 0; i < newd; i++)
             newq *= p;
@@ -1999,7 +1999,7 @@ Int CmpVec8BitVec8Bit( Obj vl, Obj vr )
     UInt1 *gettab;
     Obj *ffe_elt;
     UInt len;
-    assert(FIELD_VEC8BIT(vl) == FIELD_VEC8BIT(vr));
+    GAP_ASSERT(FIELD_VEC8BIT(vl) == FIELD_VEC8BIT(vr));
     q = FIELD_VEC8BIT(vl);
     info = GetFieldInfo8Bit(q);
     lenl = LEN_VEC8BIT(vl);
@@ -2090,7 +2090,7 @@ Obj ScalarProductVec8Bits( Obj vl, Obj vr )
     if (len > LEN_VEC8BIT(vr))
         len = LEN_VEC8BIT(vr);
     q = FIELD_VEC8BIT(vl);
-    assert(q == FIELD_VEC8BIT(vr));
+    GAP_ASSERT(q == FIELD_VEC8BIT(vr));
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
@@ -2152,8 +2152,8 @@ UInt DistanceVec8Bits( Obj vl, Obj vr )
 
     len = LEN_VEC8BIT(vl);
     q = FIELD_VEC8BIT(vl);
-    assert(q == FIELD_VEC8BIT(vr));
-    assert(len == LEN_VEC8BIT(vr));
+    GAP_ASSERT(q == FIELD_VEC8BIT(vr));
+    GAP_ASSERT(len == LEN_VEC8BIT(vr));
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
@@ -3034,7 +3034,7 @@ Obj FuncASS_VEC8BIT (
             /* may need to promote the element to a bigger field
                or restrict it to a smaller one */
             if (v != 0 && q != SIZE_FF(FLD_FFE(elm))) {
-                assert(((v - 1) * (q - 1)) % (SIZE_FF(FLD_FFE(elm)) - 1) == 0);
+                GAP_ASSERT(((v - 1) * (q - 1)) % (SIZE_FF(FLD_FFE(elm)) - 1) == 0);
                 v = 1 + (v - 1) * (q - 1) / (SIZE_FF(FLD_FFE(elm)) - 1);
             }
 
@@ -3443,7 +3443,7 @@ Obj ProdVec8BitMat8Bit( Obj vec, Obj mat )
     len = LEN_VEC8BIT(vec);
     lenm = LEN_MAT8BIT(mat);
     row1 = ELM_MAT8BIT(mat, 1);
-    assert(q == FIELD_VEC8BIT(row1));
+    GAP_ASSERT(q == FIELD_VEC8BIT(row1));
     len1 = LEN_VEC8BIT(row1);
     res = ZeroVec8Bit(q, len1, IS_MUTABLE_OBJ(vec) || IS_MUTABLE_OBJ(row1));
 
@@ -3540,7 +3540,7 @@ Obj ProdMat8BitVec8Bit( Obj mat, Obj vec)
     len = LEN_MAT8BIT(mat);
     q = FIELD_VEC8BIT(vec);
     row1 = ELM_MAT8BIT(mat, 1);
-    assert(q = FIELD_VEC8BIT(row1));
+    GAP_ASSERT(q = FIELD_VEC8BIT(row1));
     res = ZeroVec8Bit(q, len, IS_MUTABLE_OBJ(row1) || IS_MUTABLE_OBJ(vec));
     info = GetFieldInfo8Bit(q);
     settab = SETELT_FIELDINFO_8BIT(info);
@@ -3619,8 +3619,8 @@ Obj ProdMat8BitMat8Bit( Obj matl, Obj matr)
     len = LEN_MAT8BIT(matl);
     q = FIELD_VEC8BIT(ELM_MAT8BIT(matl, 1));
 
-    assert(q == FIELD_VEC8BIT(ELM_MAT8BIT(matr, 1)));
-    assert(LEN_MAT8BIT(matr) == LEN_VEC8BIT(ELM_MAT8BIT(matl, 1)));
+    GAP_ASSERT(q == FIELD_VEC8BIT(ELM_MAT8BIT(matr, 1)));
+    GAP_ASSERT(LEN_MAT8BIT(matr) == LEN_VEC8BIT(ELM_MAT8BIT(matl, 1)));
 
     prod = NewBag(T_POSOBJ, sizeof(Obj) * (len + 2));
     SET_LEN_MAT8BIT(prod, len);
@@ -3697,7 +3697,7 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
     row = ELM_MAT8BIT(mat, 1);
     q = FIELD_VEC8BIT(row);
     len = LEN_MAT8BIT(mat);
-    assert(len == LEN_VEC8BIT(row));
+    GAP_ASSERT(len == LEN_VEC8BIT(row));
     inv = NEW_PLIST(T_PLIST, len + 1);
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
@@ -4024,10 +4024,10 @@ Obj SumMat8BitMat8Bit( Obj ml, Obj mr)
     /* Now sort out the size of the result */
     if (ll > lr) {
         ls = ll;
-        assert(wl > wr);
+        GAP_ASSERT(wl > wr);
     } else {
         ls = lr;
-        assert(wr >= wl);
+        GAP_ASSERT(wr >= wl);
     }
 
     q = FIELD_VEC8BIT(ELM_MAT8BIT(ml, 1));
@@ -4103,10 +4103,10 @@ Obj DiffMat8BitMat8Bit( Obj ml, Obj mr)
     /* Now sort out the size of the result */
     if (ll > lr) {
         ld = ll;
-        assert(wl > wr);
+        GAP_ASSERT(wl > wr);
     } else {
         ld = lr;
-        assert(wr >= wl);
+        GAP_ASSERT(wr >= wl);
     }
     q = FIELD_VEC8BIT(ELM_MAT8BIT(ml, 1));
 
@@ -4434,8 +4434,8 @@ Obj FuncADD_COEFFS_VEC8BIT_3( Obj self, Obj vec1, Obj vec2, Obj mult )
         d0 = LcmDegree(d, d1);
         d0 = LcmDegree(d0, d2);
         p = P_FIELDINFO_8BIT(info);
-        assert(p == P_FIELDINFO_8BIT(info1));
-        assert(p == CHAR_FF(FLD_FFE(mult)));
+        GAP_ASSERT(p == P_FIELDINFO_8BIT(info1));
+        GAP_ASSERT(p == CHAR_FF(FLD_FFE(mult)));
         q0 = 1;
         for (i = 0; i < d0; i++)
             q0 *= p;
@@ -4493,7 +4493,7 @@ Obj FuncADD_COEFFS_VEC8BIT_2( Obj self, Obj vec1, Obj vec2 )
         d1 = D_FIELDINFO_8BIT(info1);
         d0 = LcmDegree(d, d1);
         p = P_FIELDINFO_8BIT(info);
-        assert(p == P_FIELDINFO_8BIT(info1));
+        GAP_ASSERT(p == P_FIELDINFO_8BIT(info1));
         q0 = 1;
         for (i = 0; i < d0; i++)
             q0 *= p;
@@ -4522,7 +4522,7 @@ Obj FuncADD_COEFFS_VEC8BIT_2( Obj self, Obj vec1, Obj vec2 )
 Obj FuncSHIFT_VEC8BIT_LEFT( Obj self, Obj vec, Obj amount)
 {
     /* should be checked in method selection */
-    assert(IS_MUTABLE_OBJ(vec));
+    GAP_ASSERT(IS_MUTABLE_OBJ(vec));
     while (!IS_INTOBJ(amount) || INT_INTOBJ(amount) < 0) {
         amount = ErrorReturnObj("SHIFT_VEC8BIT_LEFT: <amount> must be a non-negative small integer",
                                 0, 0,
@@ -4540,7 +4540,7 @@ Obj FuncSHIFT_VEC8BIT_LEFT( Obj self, Obj vec, Obj amount)
 
 Obj FuncSHIFT_VEC8BIT_RIGHT( Obj self, Obj vec, Obj amount, Obj zero)
 {
-    assert(IS_MUTABLE_OBJ(vec));
+    GAP_ASSERT(IS_MUTABLE_OBJ(vec));
     while (!IS_INTOBJ(amount) || INT_INTOBJ(amount) < 0) {
         amount = ErrorReturnObj("SHIFT_VEC8BIT_RIGHT: <amount> must be a non-negative small integer",
                                 0, 0,
@@ -4603,11 +4603,11 @@ void ProdCoeffsVec8Bit ( Obj res, Obj vl, UInt ll, Obj vr, UInt lr )
     UInt1 * gettab, *settab;
     UInt1 partl = 0, partr = 0;
     q = FIELD_VEC8BIT(vl);
-    assert(q == FIELD_VEC8BIT(vr));
-    assert(q == FIELD_VEC8BIT(res));
-    assert(ll <= LEN_VEC8BIT(vl));
-    assert(lr <= LEN_VEC8BIT(vr));
-    assert(ll + lr - 1 <= LEN_VEC8BIT(res));
+    GAP_ASSERT(q == FIELD_VEC8BIT(vr));
+    GAP_ASSERT(q == FIELD_VEC8BIT(res));
+    GAP_ASSERT(ll <= LEN_VEC8BIT(vl));
+    GAP_ASSERT(lr <= LEN_VEC8BIT(vr));
+    GAP_ASSERT(ll + lr - 1 <= LEN_VEC8BIT(res));
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     p = P_FIELDINFO_8BIT(info);
@@ -4763,7 +4763,7 @@ Obj FuncPROD_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vr, Obj lr  )
         d1 = D_FIELDINFO_8BIT(info1);
         d0 = LcmDegree(d, d1);
         p = P_FIELDINFO_8BIT(info);
-        assert(p == P_FIELDINFO_8BIT(info1));
+        GAP_ASSERT(p == P_FIELDINFO_8BIT(info1));
         q0 = 1;
         for (i = 0; i < d0; i++)
             q0 *= p;
@@ -4827,7 +4827,7 @@ Obj MakeShiftedVecs( Obj v, UInt len)
     Obj type;
 
     q = FIELD_VEC8BIT(v);
-    assert(len <= LEN_VEC8BIT(v));
+    GAP_ASSERT(len <= LEN_VEC8BIT(v));
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
@@ -4848,7 +4848,7 @@ Obj MakeShiftedVecs( Obj v, UInt len)
     ffefelt = FFE_FELT_FIELDINFO_8BIT(info);
 
     x = gettab[BYTES_VEC8BIT(vn)[(len - 1) / elts] + 256 * ((len - 1) % elts)];
-    assert(x != 0);
+    GAP_ASSERT(x != 0);
     xi = INV(ffefelt[x]);
     MultVec8BitFFEInner(vn, vn,  xi , 1, len);
     type = TypeVec8Bit(q, 0);
@@ -4957,7 +4957,7 @@ void ReduceCoeffsVec8Bit ( Obj vl, Obj vrshifted, Obj quot )
                 ptrl1--;
                 ptrr--;
             }
-            assert(! gettab[ptrl[i / elts] + 256 * (i % elts)]);
+            GAP_ASSERT(! gettab[ptrl[i / elts] + 256 * (i % elts)]);
         }
     }
     if (quot) {

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -989,10 +989,10 @@ Obj ZeroMutVecFFE( Obj vec )
     UInt i, len;
     Obj res;
     Obj z;
-    assert(TNUM_OBJ(vec) >= T_PLIST_FFE && \
+    GAP_ASSERT(TNUM_OBJ(vec) >= T_PLIST_FFE && \
     TNUM_OBJ(vec) <= T_PLIST_FFE + IMMUTABLE);
     len = LEN_PLIST(vec);
-    assert(len);
+    GAP_ASSERT(len);
     res  = NEW_PLIST(T_PLIST_FFE, len);
     SET_LEN_PLIST(res, len);
     z = ZERO(ELM_PLIST(vec, 1));
@@ -1006,10 +1006,10 @@ Obj ZeroVecFFE( Obj vec )
     UInt i, len;
     Obj res;
     Obj z;
-    assert(TNUM_OBJ(vec) >= T_PLIST_FFE && \
+    GAP_ASSERT(TNUM_OBJ(vec) >= T_PLIST_FFE && \
     TNUM_OBJ(vec) <= T_PLIST_FFE + IMMUTABLE);
     len = LEN_PLIST(vec);
-    assert(len);
+    GAP_ASSERT(len);
     res  = NEW_PLIST(TNUM_OBJ(vec), len);
     SET_LEN_PLIST(res, len);
     z = ZERO(ELM_PLIST(vec, 1));

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -3853,7 +3853,7 @@ void AddShiftedVecGF2VecGF2( Obj vec1, Obj vec2, UInt len2, UInt off )
 	  *ptr1++ ^= block << shift1;
 	  if (len2 % BIPEB + off % BIPEB > BIPEB)
 	    {
-	      assert(ptr1 < BLOCKS_GF2VEC(vec1) + (LEN_GF2VEC(vec1) + BIPEB -1)/BIPEB);
+	      GAP_ASSERT(ptr1 < BLOCKS_GF2VEC(vec1) + (LEN_GF2VEC(vec1) + BIPEB -1)/BIPEB);
 	      *ptr1 ^= block >> shift2;
 	    }
 	}
@@ -3994,7 +3994,7 @@ void ReduceCoeffsGF2Vec( Obj vec1, Obj vec2, UInt len2, Obj quotient )
 	  if (qptr)
 	    qptr[(j-1)/BIPEB] |= MASK_POS_GF2VEC(j);
 	}
-      assert(!(*ptr & ((UInt)1<<e)));
+      GAP_ASSERT(!(*ptr & ((UInt)1<<e)));
       if (e == 0)
 	{
 	  e = BIPEB -1;

--- a/src/vector.c
+++ b/src/vector.c
@@ -649,7 +649,7 @@ Obj ZeroVector( Obj vec )
 {
     UInt i, len;
     Obj res;
-    assert(TNUM_OBJ(vec) >= T_PLIST_CYC && \
+    GAP_ASSERT(TNUM_OBJ(vec) >= T_PLIST_CYC && \
     TNUM_OBJ(vec) <= T_PLIST_CYC_SSORT + IMMUTABLE);
     len = LEN_PLIST(vec);
     res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(vec), T_PLIST_CYC, len);
@@ -663,7 +663,7 @@ Obj ZeroMutVector( Obj vec )
 {
     UInt i, len;
     Obj res;
-    assert(TNUM_OBJ(vec) >= T_PLIST_CYC && \
+    GAP_ASSERT(TNUM_OBJ(vec) >= T_PLIST_CYC && \
     TNUM_OBJ(vec) <= T_PLIST_CYC_SSORT + IMMUTABLE);
     len = LEN_PLIST(vec);
     res = NEW_PLIST(T_PLIST_CYC, len);


### PR DESCRIPTION
This changes most of the asserts in GAP into GAP_ASSERTS.

This is the kind of PR which could end up causing a whole bunch of conflicts, so I don't mind waiting until we seem to be at a "quiet period", even waiting until near the 4.10 branch.

I left the `assert(0)` calls.

This does reduce the executable, and startup time, by about 1% for me (there is in practice a couple of asserts which hit often during startup).