### PR TITLE
Fix broken assert

### DIFF
--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -3540,7 +3540,7 @@ Obj ProdMat8BitVec8Bit( Obj mat, Obj vec)
     len = LEN_MAT8BIT(mat);
     q = FIELD_VEC8BIT(vec);
     row1 = ELM_MAT8BIT(mat, 1);
-    assert(q = FIELD_VEC8BIT(row1));
+    assert(q == FIELD_VEC8BIT(row1));
     res = ZeroVec8Bit(q, len, IS_MUTABLE_OBJ(row1) || IS_MUTABLE_OBJ(vec));
     info = GetFieldInfo8Bit(q);
     settab = SETELT_FIELDINFO_8BIT(info);


### PR DESCRIPTION
This just fixes a typo in an assert.

I would backport it to 4.9 just because people who build GAP are likely to see it (I updated to gcc 7.3, which is when I started seeing it).