### PR TITLE
Flush input line after early syntax error; some minor reader/scanner tweaks

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -511,7 +511,7 @@ static LHSRef ReadSelector(TypSymbolSet follow, UInt level)
             ref.narg++;
         }
         if (ref.narg > 2) {
-          SyntaxError("[] only supports 1 or 2 indices");
+          SyntaxError("'[]' only supports 1 or 2 indices");
         }
         Match(S_RBRACK, "]", follow);
         ref.type = R_ELM_LIST;
@@ -2362,7 +2362,7 @@ static void ReadAtomic (
       nexprs ++;
 #ifdef HPCGAP
       if (nexprs > MAX_ATOMIC_OBJS) {
-        SyntaxError("atomic statement can have at most 256 objects to lock");
+        SyntaxError("'atomic' statement can have at most 256 objects to lock");
         return;
       }
 #endif

--- a/src/read.c
+++ b/src/read.c
@@ -2713,8 +2713,9 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     /* get the first symbol from the input                                 */
     Match( STATE(Symbol), "", 0UL );
 
-    /* using TRY_READ sets the jump buffer and mucks up the interpreter    */
+    // if scanning the first symbol produced a syntax error, abort
     if (STATE(NrError)) {
+        FlushRestOfInputLine();
         return STATUS_ERROR;
     }
 

--- a/src/read.c
+++ b/src/read.c
@@ -2733,6 +2733,7 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     readTilde   = STATE(ReadTilde);
     tilde       = STATE(Tilde);
     currLHSGVar = STATE(CurrLHSGVar);
+    errorLVars  = STATE(ErrorLVars);
     memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
 
     // initialize everything and begin an interpreter
@@ -2741,9 +2742,8 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     STATE(ReadTilde)   = 0;
     STATE(Tilde)       = 0;
     STATE(CurrLHSGVar) = 0;
+    STATE(ErrorLVars)  = context;
     RecreateStackNams(context);
-    errorLVars = STATE(ErrorLVars);
-    STATE(ErrorLVars) = context;
 #ifdef HPCGAP
     lockSP = RegionLockSP();
 #endif
@@ -2812,7 +2812,7 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     STATE(ReadTilde)   = readTilde;
     STATE(Tilde)       = tilde;
     STATE(CurrLHSGVar) = currLHSGVar;
-    STATE(ErrorLVars) = errorLVars;
+    STATE(ErrorLVars)  = errorLVars;
 
     /* copy the result (if any)                                            */
     *evalResult = STATE(IntrResult);

--- a/tst/testinstall/kernel/read.tst
+++ b/tst/testinstall/kernel/read.tst
@@ -65,4 +65,70 @@ rec("a":=1);
       ^
 
 #
+# ReadEvalCommand
+#
+# See also https://github.com/gap-system/gap/issues/995
+#
+
+# some inputs which immediately trigger an error in ReadEvalCommand,
+# even before an interpreter has been started
+gap> '
+Syntax error: Character literal must not include <newline> in stream:1
+'
+^
+gap> 'x
+Syntax error: Missing single quote in character constant in stream:1
+'x
+ ^
+gap> "
+Syntax error: String must not include <newline> in stream:1
+"
+^
+gap> "x
+Syntax error: String must not include <newline> in stream:1
+"x
+ ^
+
+# similar inputs to the above, but here the error is triggered a bit
+# later, after the interpreter has already started
+gap> s := '
+Syntax error: Character literal must not include <newline> in stream:1
+s := '
+     ^
+Syntax error: ; expected in stream:2
+^
+gap> s := 'x
+Syntax error: Missing single quote in character constant in stream:1
+s := 'x
+      ^
+Syntax error: ; expected in stream:2
+^
+gap> s := "
+Syntax error: String must not include <newline> in stream:1
+s := "
+     ^
+Syntax error: ; expected in stream:2
+^
+gap> s := "x
+Syntax error: String must not include <newline> in stream:1
+s := "x
+      ^
+Syntax error: ; expected in stream:2
+^
+
+# errors in the middle of parsing a float literal
+gap> 12.34\56;
+Syntax error: Badly formed number in stream:1
+12.34\56;
+     ^
+gap> 12.34\a56;
+Syntax error: Badly formed number in stream:1
+12.34\a56;
+     ^
+gap> 12.34\56a;
+Syntax error: Badly formed number in stream:1
+12.34\56a;
+     ^
+
+#
 gap> STOP_TEST("kernel/read.tst", 1);

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -29,7 +29,7 @@ gap> a[1];
 gap> a[1,1];
 [ 1 ]
 gap> a[1,1,1];
-Syntax error: [] only supports 1 or 2 indices in stream:1
+Syntax error: '[]' only supports 1 or 2 indices in stream:1
 a[1,1,1];
        ^
 
@@ -95,15 +95,15 @@ gap> a[1] := [ [ 42 ] ];
 gap> a[1,1] := [ 43 ];
 [ 43 ]
 gap> a[1,1,1] := 44;
-Syntax error: [] only supports 1 or 2 indices in stream:1
+Syntax error: '[]' only supports 1 or 2 indices in stream:1
 a[1,1,1] := 44;
        ^
 gap> IsBound(a[1,1,1]);
-Syntax error: [] only supports 1 or 2 indices in stream:1
+Syntax error: '[]' only supports 1 or 2 indices in stream:1
 IsBound(a[1,1,1]);
                ^
 gap> Unbind(a[1,1,1]);
-Syntax error: [] only supports 1 or 2 indices in stream:1
+Syntax error: '[]' only supports 1 or 2 indices in stream:1
 Unbind(a[1,1,1]);
               ^
 


### PR DESCRIPTION
This fixes a mild regression introduce by PR #1015, which in turn attempted to fix parts of issue #995. With GAP 4.8 and also with this fix:

    gap> 1.2\3;
    Syntax error: Badly formed number
    1.2\3;
       ^

In GAP 4.9:

    gap> 1.2\3;
    Syntax error: Badly formed number
    1.2\3;
       ^
    3

Also added some tests for the other issues in #995, tweak two syntax error messages, and reorder some core for clarity.