### PR TITLE
Fix crash when returning from "method not found" break loop

### DIFF
--- a/src/opers.c
+++ b/src/opers.c
@@ -2115,10 +2115,6 @@ static ALWAYS_INLINE Obj DoOperationNArgs(Obj  oper,
                 CacheMethod(oper, n, prec, ids, method);
         }
 
-        if (!method) {
-            ErrorQuit("no method returned", 0L, 0L);
-        }
-
         /* If there was no method found, then pass the information needed
            for the error reporting. This function rarely returns */
         if (method == Fail) {
@@ -2147,6 +2143,10 @@ static ALWAYS_INLINE Obj DoOperationNArgs(Obj  oper,
             while (method == Fail)
                 method = CallHandleMethodNotFound(oper, n, (Obj *)args,
                                                   verbose, constructor, INTOBJ_INT(prec));
+        }
+
+        if (!method) {
+            ErrorQuit("no method returned", 0L, 0L);
         }
 
         /* call this method */

--- a/tst/test-error/method-not-found.g
+++ b/tst/test-error/method-not-found.g
@@ -1,0 +1,3 @@
+# test returning from a 'method not found' error
+f:=a->a+a;; f(());
+return;

--- a/tst/test-error/method-not-found.g.out
+++ b/tst/test-error/method-not-found.g.out
@@ -1,0 +1,15 @@
+gap> # test returning from a 'method not found' error
+gap> f:=a->a+a;; f(());
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `+' on 2 arguments at GAPROOT/lib/methsel2.g:250 called from
+a + a at *stdin*:3 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:3
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> return;
+Error, no method returned in
+  return a + a; at *stdin*:3 called from 
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:3
+gap> QUIT;


### PR DESCRIPTION
Fixes #2447 

This should be backported to stable-4.9. I am not sure how far the 4.9.1 release process is -- if there is still time, we might even want to squeeze it in there. If not, then it should go into GAP 4.9.2, and we should consider documenting this as a "known regression" in GAP 4.9.1.