### PR TITLE
Change HANDLE_METHOD_NOT_FOUND to never return

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -41,11 +41,10 @@ error as in the following example occurs and a break loop is entered:
 <Log><![CDATA[
 gap> IsNormal(2,2);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `IsNormal' on 2 arguments called from
-<function>( <arguments> ) called from read-eval-loop
-Entering break read-eval-print loop ...
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+Error, no 1st choice method found for `IsNormal' on 2 arguments at GAPROOT/lib/methsel2.g:250 called from
+<function "HANDLE_METHOD_NOT_FOUND">( <arguments> )
+ called from read-eval loop at *stdin*:1
+type 'quit;' to quit to outer loop
 brk> 
 ]]></Log>
 <P/>

--- a/lib/methsel2.g
+++ b/lib/methsel2.g
@@ -247,7 +247,7 @@ end;
       APPEND_LIST(no_method_found, " argument is 'fail' which might point to an earlier problem\n" );
     fi;
   od;
-  Error(no_method_found);
+  ErrorNoReturn(no_method_found);
 end;
 
 ## This is the other part of the above mentioned dirty trick:

--- a/tst/test-error/bad-add.g.out
+++ b/tst/test-error/bad-add.g.out
@@ -8,6 +8,5 @@ Error, no 1st choice method found for `+' on 2 arguments at GAPROOT/lib/methsel2
 1 + "abc" at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> QUIT;

--- a/tst/test-error/bad-array-double-1.g.out
+++ b/tst/test-error/bad-array-double-1.g.out
@@ -8,6 +8,5 @@ Error, no 1st choice method found for `[]' on 3 arguments at GAPROOT/lib/methsel
 <corrupted statement>  called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> QUIT;

--- a/tst/test-error/bad-array-int-0.g.out
+++ b/tst/test-error/bad-array-int-0.g.out
@@ -10,6 +10,5 @@ Error, no 1st choice method found for `[]' on 2 arguments at GAPROOT/lib/methsel
 l[0] at *stdin*:5 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:7
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> QUIT;

--- a/tst/test-error/bad-array-string.g.out
+++ b/tst/test-error/bad-array-string.g.out
@@ -8,6 +8,5 @@ Error, no 1st choice method found for `[]' on 2 arguments at GAPROOT/lib/methsel
 1["abc"] at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> QUIT;

--- a/tst/test-error/bad-minus.g.out
+++ b/tst/test-error/bad-minus.g.out
@@ -10,6 +10,5 @@ AdditiveInverseAttr( elm ) at GAPROOT/lib/arith.gi:213 called from
 1 - "abc" at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> QUIT;

--- a/tst/test-error/func-and-proc-call-trace.g.out
+++ b/tst/test-error/func-and-proc-call-trace.g.out
@@ -8,8 +8,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l(  ); at *stdin*:4 called from
 <function "informproc0">( <arguments> )
  called from read-eval loop at *stdin*:6
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -24,8 +23,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1 ); at *stdin*:9 called from
 <function "informproc1">( <arguments> )
  called from read-eval loop at *stdin*:11
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -40,8 +38,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1, 2 ); at *stdin*:14 called from
 <function "informproc2">( <arguments> )
  called from read-eval loop at *stdin*:16
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -56,8 +53,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1, 2, 3 ); at *stdin*:19 called from
 <function "informproc3">( <arguments> )
  called from read-eval loop at *stdin*:21
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit; 
 gap> Print("\n\n");
 
@@ -72,8 +68,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1, 2, 3, 4 ); at *stdin*:24 called from
 <function "informproc4">( <arguments> )
  called from read-eval loop at *stdin*:26
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -88,8 +83,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1, 2, 3, 4, 5 ); at *stdin*:29 called from
 <function "informproc5">( <arguments> )
  called from read-eval loop at *stdin*:31
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -104,8 +98,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1, 2, 3, 4, 5, 6 ); at *stdin*:34 called from
 <function "informproc6">( <arguments> )
  called from read-eval loop at *stdin*:36
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -120,8 +113,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1, 2, 3, 4, 5, 6, 7 ); at *stdin*:39 called from
 <function "informprocmore">( <arguments> )
  called from read-eval loop at *stdin*:41
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -136,8 +128,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l(  ) at *stdin*:44 called from
 <function "informfunc0">( <arguments> )
  called from read-eval loop at *stdin*:46
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -152,8 +143,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1 ) at *stdin*:49 called from
 <function "informfunc1">( <arguments> )
  called from read-eval loop at *stdin*:51
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -168,8 +158,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1, 2 ) at *stdin*:54 called from
 <function "informfunc2">( <arguments> )
  called from read-eval loop at *stdin*:56
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -184,8 +173,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1, 2, 3 ) at *stdin*:59 called from
 <function "informfunc3">( <arguments> )
  called from read-eval loop at *stdin*:61
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -200,8 +188,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1, 2, 3, 4 ) at *stdin*:64 called from
 <function "informfunc4">( <arguments> )
  called from read-eval loop at *stdin*:66
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -216,8 +203,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1, 2, 3, 4, 5 ) at *stdin*:69 called from
 <function "informfunc5">( <arguments> )
  called from read-eval loop at *stdin*:71
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -232,8 +218,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1, 2, 3, 4, 5, 6 ) at *stdin*:74 called from
 <function "informfunc6">( <arguments> )
  called from read-eval loop at *stdin*:76
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 
@@ -248,8 +233,7 @@ Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/l
 l( 1, 2, 3, 4, 5, 6, 7 ) at *stdin*:79 called from
 <function "informfuncmore">( <arguments> )
  called from read-eval loop at *stdin*:81
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> Print("\n\n");
 

--- a/tst/test-error/method-not-found.g.out
+++ b/tst/test-error/method-not-found.g.out
@@ -5,11 +5,7 @@ Error, no 1st choice method found for `+' on 2 arguments at GAPROOT/lib/methsel2
 a + a at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:3
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+type 'quit;' to quit to outer loop
 brk> return;
-Error, no method returned in
-  return a + a; at *stdin*:3 called from 
-<function "f">( <arguments> )
- called from read-eval loop at *stdin*:3
-gap> QUIT;
+'return' cannot be used in this read-eval-print loop
+brk> QUIT;


### PR DESCRIPTION
Using `return;` to exit a "method not found" break loop had more or less the same effect as using `quit;`

This PR contains PR #2449, but the second commit in it may be more controversial (?) than the fix in the first PR; also, only that fix should be backported to stable-4.9, not the second commit in here; hence I have put this into a separate PR.q