### PR TITLE
Fix two bugs related to empty magmas

### DIFF
--- a/lib/addmagma.gi
+++ b/lib/addmagma.gi
@@ -175,7 +175,7 @@ InstallGlobalFunction( SubadditiveMagmaNC, function( M, gens )
     if IsEmpty( gens ) then
       K:= NewType( FamilyObj(M),
                        IsAdditiveMagma
-                   and IsTrivial
+                   and IsEmpty
                    and IsAttributeStoringRep );
       S:= Objectify( K, rec() );
       SetGeneratorsOfAdditiveMagma( S, [] );

--- a/lib/magma.gd
+++ b/lib/magma.gd
@@ -129,8 +129,13 @@ DeclareCategory( "IsMagmaWithInverses",
         IsMagmaWithInversesIfNonzero
     and IsMultiplicativeElementWithInverseCollection );
 
+# FIXME: this is wrong for empty magmas
+# InstallTrueMethod( IsMagmaWithInverses,
+#     IsFiniteOrderElementCollection and IsMagma );
+
 InstallTrueMethod( IsMagmaWithInverses,
-    IsFiniteOrderElementCollection and IsMagma );
+    IsFiniteOrderElementCollection and IsMagmaWithOne );
+
 
 #############################################################################
 ##

--- a/tst/testbugfix/2018-05-09-submagma.tst
+++ b/tst/testbugfix/2018-05-09-submagma.tst
@@ -1,0 +1,54 @@
+#
+# There was a bug where we marked a sub additive magma
+# with empty generator list as trivial, even though it is empty.
+#
+# There was also a wrong implication, from "IsFiniteOrderElementCollection and
+# IsMagma" to IsMagmaWithInverses. But a collection with the former filters may
+# be empty, and then it isn't a IsMagmaWithInverses.
+#
+gap> amgm:=AdditiveMagma([0]);
+<additive magma with 1 generators>
+gap> Size(amgm);
+1
+gap> IsTrivial(amgm);
+true
+gap> IsEmpty(amgm);
+false
+gap> IsMagmaWithInverses(amgm);
+false
+
+#
+gap> asub:=SubadditiveMagma(amgm, []);
+<additive magma with 0 generators>
+gap> Size(asub);
+0
+gap> IsTrivial(asub);
+false
+gap> IsEmpty(asub);
+true
+gap> IsMagmaWithInverses(asub);
+false
+
+#
+gap> mgm:=Magma( () );
+<commutative semigroup with 1 generator>
+gap> Size(mgm);
+1
+gap> IsTrivial(mgm);
+true
+gap> IsEmpty(mgm);
+false
+gap> IsMagmaWithInverses(mgm);
+false
+
+#
+gap> sub:=Submagma(mgm,[]);
+<commutative semigroup with 0 generators>
+gap> Size(sub);
+0
+gap> IsTrivial(sub);
+false
+gap> IsEmpty(sub);
+true
+gap> IsMagmaWithInverses(sub);
+false


### PR DESCRIPTION
First, SubadditiveMagma(a,[]) computes an empty magma, but we erroneously set
IsTrivial for it, which implies size 1. This was changed to IsEmpty.

Secondly, there was an implication from "IsFiniteOrderElementCollection and
IsMagma" to IsMagmaWithInverses. But such a collection may be empty, hence the
implication is invalid as given. This PR just removes it (instead of trying to do something clever),
which seems to have no negative consequences -- if anybody is aware of any, please let me know.

Fixes #2400 
Closes #2429