### PR TITLE
`PrintString` and `ViewString` for character tables

### DIFF
--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -4479,6 +4479,74 @@ InstallMethod( PrintObj,
 
 #############################################################################
 ##
+#M  ViewString( <tbl> ) . . . . . . . . . . . . . . . . for a character table
+##
+InstallMethod( ViewString,
+    "for an ordinary table",
+    [ IsOrdinaryTable ],
+    function( tbl )
+    if HasUnderlyingGroup( tbl ) then
+      return Concatenation( "CharacterTable( ",
+                 ViewString( UnderlyingGroup( tbl ) ), " )" );
+    else
+      return Concatenation( "CharacterTable( \"", Identifier( tbl ),
+                 "\" )" );
+    fi;
+    end );
+
+InstallMethod( ViewString,
+    "for a Brauer table",
+    [ IsBrauerTable ],
+    function( tbl )
+    local ordtbl;
+    ordtbl:= OrdinaryCharacterTable( tbl );
+    if HasUnderlyingGroup( ordtbl ) then
+      return Concatenation( "BrauerTable( ",
+                 ViewString( UnderlyingGroup( ordtbl ) ), ", ",
+                 String( UnderlyingCharacteristic( tbl ) ), " )" );
+    else
+      return Concatenation( "BrauerTable( \"", Identifier( ordtbl ),
+                 "\", ", String( UnderlyingCharacteristic( tbl ) ), " )" );
+    fi;
+    end );
+
+
+#############################################################################
+##
+#M  PrintString( <tbl> )  . . . . . . . . . . . . . . . for a character table
+##
+InstallMethod( PrintString,
+    "for an ordinary table",
+    [ IsOrdinaryTable ],
+    function( tbl )
+    if HasUnderlyingGroup( tbl ) then
+      return Concatenation( "CharacterTable( \"",
+                 PrintString( UnderlyingGroup( tbl ) ), " )" );
+    else
+      return Concatenation( "CharacterTable( \"", Identifier( tbl ),
+                 "\" )" );
+    fi;
+    end );
+
+InstallMethod( PrintString,
+    "for a Brauer table",
+    [ IsBrauerTable ],
+    function( tbl )
+    local ordtbl;
+    ordtbl:= OrdinaryCharacterTable( tbl );
+    if HasUnderlyingGroup( ordtbl ) then
+      return Concatenation( "BrauerTable( ",
+                 PrintString( UnderlyingGroup( ordtbl ) ), ", ",
+                 String( UnderlyingCharacteristic( tbl ) ), " )" );
+    else
+      return Concatenation( "BrauerTable( \"", Identifier( ordtbl ),
+                 "\", ", String( UnderlyingCharacteristic( tbl ) ), " )" );
+    fi;
+    end );
+
+
+#############################################################################
+##
 #F  CharacterTableDisplayStringEntryDefault( <entry>, <data> )
 ##
 BindGlobal( "CharacterTableDisplayStringEntryDefault",

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -40,6 +40,28 @@ gap> ClassPositionsOfCentre( TrivialCharacter( t ) );
 [ 1 ]
 gap> ClassPositionsOfKernel( TrivialCharacter( t ) );
 [ 1 ]
+
+# viewing and printing of character tables with stored groups
+gap> t:= CharacterTable( DihedralGroup( 8 ) );;
+gap> View( t ); Print( "\n" );
+CharacterTable( <pc group of size 8 with 3 generators> )
+gap> Print( t, "\n" );
+CharacterTable( Group( [ f1, f2, f3 ] ) )
+gap> ViewString( t );
+"CharacterTable( <group of size 8 with 3 generators> )"
+gap> PrintString( t );
+"CharacterTable( \"Group( \>[ f1, f2, f3 ]\<\> )\< )"
+gap> t:= CharacterTable( SymmetricGroup( 5 ) );;
+gap> View( t ); Print( "\n" );
+CharacterTable( Sym( [ 1 .. 5 ] ) )
+gap> Print( t, "\n" );
+CharacterTable( SymmetricGroup( [ 1 .. 5 ] ) )
+gap> ViewString( t );
+"CharacterTable( Sym( [ 1 .. 5 ] ) )"
+gap> PrintString( t );
+"CharacterTable( \"Group( \>[ (1,2,3,4,5), (1,2) ]\<\> )\< )"
+
+##
 gap> STOP_TEST( "ctbl.tst", 1);
 
 #############################################################################


### PR DESCRIPTION
These methods are apparently needed
if one wants to use the `JupyterKernel` package.