### PR TITLE
WIP: Reformat Flags Lists

### DIFF
--- a/lib/filter.g
+++ b/lib/filter.g
@@ -310,23 +310,16 @@ end );
 ##
 #F  NamesFilter( <flags> )  . . . . . list of names of the filters in <flags>
 ##
+
 BIND_GLOBAL( "NamesFilter", function( flags )
     local  bn,  i;
-
-    if IS_FUNCTION(flags)  then
-        flags := FLAGS_FILTER(flags);
-    fi;
-    if IS_LIST(flags)  then
-        bn := SHALLOW_COPY_OBJ(flags);
-    else
-        bn := SHALLOW_COPY_OBJ(TRUES_FLAGS(flags));
-    fi;
+    bn := [];    
     atomic readonly FILTER_REGION do
-      for i  in  [ 1 .. LEN_LIST(bn) ]  do
-          if not IsBound(FILTERS[ bn[i] ])  then
-              bn[i] := STRING_INT( bn[i] );
+      for i  in  [ 1 .. LEN_LIST(flags) ]  do
+          if not IsBound(FILTERS[ flags[i] ])  then
+              bn[i] := STRING_INT( flags[i] );
           else
-              bn[i] := NAME_FUNC(FILTERS[ bn[i] ]);
+              bn[i] := NAME_FUNC(FILTERS[ flags[i] ]);
           fi;
       od;
     od;

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -35,6 +35,7 @@ BIND_GLOBAL( "RunImmediateMethods", function ( obj, flags )
             meth,
             res,        # result of an immediate method
             loc,
+            flag,
             newflags;   # newly  found filters
 
     # Avoid recursive calls from inside a setter,
@@ -47,7 +48,10 @@ BIND_GLOBAL( "RunImmediateMethods", function ( obj, flags )
     if IS_SUBSET_FLAGS( IMM_FLAGS, flags ) then return; fi;
     flags := SUB_FLAGS( flags, IMM_FLAGS );
 
-    flagspos := SHALLOW_COPY_OBJ(TRUES_FLAGS(flags));
+    flagspos := [];
+    for flag in flags do
+        ADD_LIST(flagspos,flag);
+    od;    
     tried    := [];
     type     := TYPE_OBJ( obj );
     flags    := type![2];
@@ -111,9 +115,9 @@ BIND_GLOBAL( "RunImmediateMethods", function ( obj, flags )
 
                           newflags := SUB_FLAGS( type![2], IMM_FLAGS );
                           newflags := SUB_FLAGS( newflags, flags );
-                          APPEND_LIST_INTR( flagspos,
-                                            TRUES_FLAGS( newflags ) );
-
+                          for flag in newflags do
+                              ADD_LIST(flagspos, flag);
+                          od;
                           flags := type![2];
 
                         fi;

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include <src/compiled.h>
-#define FILE_CRC  "-110560148"
+#define FILE_CRC  "-3672617"
 
 /* global variables used in handlers */
 static GVar G_REREADING;
@@ -183,6 +183,7 @@ static Obj  HdlrFunc2 (
  Obj l_meth = 0;
  Obj l_res = 0;
  Obj l_loc = 0;
+ Obj l_flag = 0;
  Obj l_newflags = 0;
  Obj t_1 = 0;
  Obj t_2 = 0;
@@ -210,6 +211,7 @@ static Obj  HdlrFunc2 (
  (void)l_meth;
  (void)l_res;
  (void)l_loc;
+ (void)l_flag;
  (void)l_newflags;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
@@ -260,14 +262,40 @@ static Obj  HdlrFunc2 (
  CHECK_FUNC_RESULT( t_1 )
  a_flags = t_1;
  
- /* flagspos := SHALLOW_COPY_OBJ( TRUES_FLAGS( flags ) ); */
- t_2 = GF_SHALLOW__COPY__OBJ;
- t_4 = GF_TRUES__FLAGS;
- t_3 = CALL_1ARGS( t_4, a_flags );
- CHECK_FUNC_RESULT( t_3 )
- t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ /* flagspos := [  ]; */
+ t_1 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_1, 0 );
  l_flagspos = t_1;
+ 
+ /* for flag in flags do */
+ t_4 = a_flags;
+ if ( IS_SMALL_LIST(t_4) ) {
+  t_3 = (Obj)(UInt)1;
+  t_1 = INTOBJ_INT(1);
+ }
+ else {
+  t_3 = (Obj)(UInt)0;
+  t_1 = CALL_1ARGS( GF_ITERATOR, t_4 );
+ }
+ while ( 1 ) {
+  if ( t_3 ) {
+   if ( LEN_LIST(t_4) < INT_INTOBJ(t_1) )  break;
+   t_2 = ELMV0_LIST( t_4, INT_INTOBJ(t_1) );
+   t_1 = (Obj)(((UInt)t_1)+4);
+   if ( t_2 == 0 )  continue;
+  }
+  else {
+   if ( CALL_1ARGS( GF_IS_DONE_ITER, t_1 ) != False )  break;
+   t_2 = CALL_1ARGS( GF_NEXT_ITER, t_1 );
+  }
+  l_flag = t_2;
+  
+  /* ADD_LIST( flagspos, flag ); */
+  t_5 = GF_ADD__LIST;
+  CALL_2ARGS( t_5, l_flagspos, l_flag );
+  
+ }
+ /* od */
  
  /* tried := [  ]; */
  t_1 = NEW_PLIST( T_PLIST, 0 );
@@ -550,12 +578,35 @@ static Obj  HdlrFunc2 (
        CHECK_FUNC_RESULT( t_9 )
        l_newflags = t_9;
        
-       /* APPEND_LIST_INTR( flagspos, TRUES_FLAGS( newflags ) ); */
-       t_9 = GF_APPEND__LIST__INTR;
-       t_11 = GF_TRUES__FLAGS;
-       t_10 = CALL_1ARGS( t_11, l_newflags );
-       CHECK_FUNC_RESULT( t_10 )
-       CALL_2ARGS( t_9, l_flagspos, t_10 );
+       /* for flag in newflags do */
+       t_12 = l_newflags;
+       if ( IS_SMALL_LIST(t_12) ) {
+        t_11 = (Obj)(UInt)1;
+        t_9 = INTOBJ_INT(1);
+       }
+       else {
+        t_11 = (Obj)(UInt)0;
+        t_9 = CALL_1ARGS( GF_ITERATOR, t_12 );
+       }
+       while ( 1 ) {
+        if ( t_11 ) {
+         if ( LEN_LIST(t_12) < INT_INTOBJ(t_9) )  break;
+         t_10 = ELMV0_LIST( t_12, INT_INTOBJ(t_9) );
+         t_9 = (Obj)(((UInt)t_9)+4);
+         if ( t_10 == 0 )  continue;
+        }
+        else {
+         if ( CALL_1ARGS( GF_IS_DONE_ITER, t_9 ) != False )  break;
+         t_10 = CALL_1ARGS( GF_NEXT_ITER, t_9 );
+        }
+        l_flag = t_10;
+        
+        /* ADD_LIST( flagspos, flag ); */
+        t_13 = GF_ADD__LIST;
+        CALL_2ARGS( t_13, l_flagspos, l_flag );
+        
+       }
+       /* od */
        
        /* flags := type![2]; */
        C_ELM_POSOBJ_NLE( t_9, l_type, 2 );
@@ -2529,8 +2580,8 @@ static Obj  HdlrFunc7 (
    t_6 = NewFunction( NameFunc[8], 1, 0, HdlrFunc8 );
    SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
    t_7 = NewBag( T_BODY, sizeof(BodyHeader) );
-   SET_STARTLINE_BODY(t_7, 632);
-   SET_ENDLINE_BODY(t_7, 650);
+   SET_STARTLINE_BODY(t_7, 636);
+   SET_ENDLINE_BODY(t_7, 654);
    SET_FILENAME_BODY(t_7, FileName);
    SET_BODY_FUNC(t_6, t_7);
    CHANGED_BAG( STATE(CurrLVars) );
@@ -3133,8 +3184,8 @@ static Obj  HdlrFunc11 (
   t_1 = NewFunction( NameFunc[12], 1, 0, HdlrFunc12 );
   SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
   t_2 = NewBag( T_BODY, sizeof(BodyHeader) );
-  SET_STARTLINE_BODY(t_2, 829);
-  SET_ENDLINE_BODY(t_2, 833);
+  SET_STARTLINE_BODY(t_2, 833);
+  SET_ENDLINE_BODY(t_2, 837);
   SET_FILENAME_BODY(t_2, FileName);
   SET_BODY_FUNC(t_1, t_2);
   CHANGED_BAG( STATE(CurrLVars) );
@@ -3213,8 +3264,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[13], 1, 0, HdlrFunc13 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_7, 850);
- SET_ENDLINE_BODY(t_7, 850);
+ SET_STARTLINE_BODY(t_7, 854);
+ SET_ENDLINE_BODY(t_7, 854);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3276,8 +3327,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[14], 2, 0, HdlrFunc14 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_7, 872);
- SET_ENDLINE_BODY(t_7, 895);
+ SET_STARTLINE_BODY(t_7, 876);
+ SET_ENDLINE_BODY(t_7, 899);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3325,8 +3376,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[15], 2, 0, HdlrFunc15 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_7, 905);
- SET_ENDLINE_BODY(t_7, 913);
+ SET_STARTLINE_BODY(t_7, 909);
+ SET_ENDLINE_BODY(t_7, 917);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3387,8 +3438,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[16], 3, 0, HdlrFunc16 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_7, 922);
- SET_ENDLINE_BODY(t_7, 935);
+ SET_STARTLINE_BODY(t_7, 926);
+ SET_ENDLINE_BODY(t_7, 939);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3761,8 +3812,8 @@ static Obj  HdlrFunc17 (
  t_4 = NewFunction( NameFunc[18], -1, 0, HdlrFunc18 );
  SET_ENVI_FUNC( t_4, STATE(CurrLVars) );
  t_5 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_5, 1001);
- SET_ENDLINE_BODY(t_5, 1017);
+ SET_STARTLINE_BODY(t_5, 1005);
+ SET_ENDLINE_BODY(t_5, 1021);
  SET_FILENAME_BODY(t_5, FileName);
  SET_BODY_FUNC(t_4, t_5);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3807,7 +3858,7 @@ static Obj  HdlrFunc1 (
  AssGVar( G_RUN__IMMEDIATE__METHODS__HITS, INTOBJ_INT(0) );
  
  /* BIND_GLOBAL( "RunImmediateMethods", function ( obj, flags )
-      local flagspos, tried, type, j, imm, i, meth, res, loc, newflags;
+      local flagspos, tried, type, j, imm, i, meth, res, loc, flag, newflags;
       if IGNORE_IMMEDIATE_METHODS then
           return;
       fi;
@@ -3815,7 +3866,10 @@ static Obj  HdlrFunc1 (
           return;
       fi;
       flags := SUB_FLAGS( flags, IMM_FLAGS );
-      flagspos := SHALLOW_COPY_OBJ( TRUES_FLAGS( flags ) );
+      flagspos := [  ];
+      for flag in flags do
+          ADD_LIST( flagspos, flag );
+      od;
       tried := [  ];
       type := TYPE_OBJ( obj );
       flags := type![2];
@@ -3848,7 +3902,9 @@ static Obj  HdlrFunc1 (
                               type := TYPE_OBJ( obj );
                               newflags := SUB_FLAGS( type![2], IMM_FLAGS );
                               newflags := SUB_FLAGS( newflags, flags );
-                              APPEND_LIST_INTR( flagspos, TRUES_FLAGS( newflags ) );
+                              for flag in newflags do
+                                  ADD_LIST( flagspos, flag );
+                              od;
                               flags := type![2];
                           fi;
                       fi;
@@ -3864,7 +3920,7 @@ static Obj  HdlrFunc1 (
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
  SET_STARTLINE_BODY(t_4, 27);
- SET_ENDLINE_BODY(t_4, 126);
+ SET_ENDLINE_BODY(t_4, 130);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3965,8 +4021,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[3], 6, 0, HdlrFunc3 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 146);
- SET_ENDLINE_BODY(t_4, 273);
+ SET_STARTLINE_BODY(t_4, 150);
+ SET_ENDLINE_BODY(t_4, 277);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3981,8 +4037,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[4], -1, 0, HdlrFunc4 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 320);
- SET_ENDLINE_BODY(t_4, 322);
+ SET_STARTLINE_BODY(t_4, 324);
+ SET_ENDLINE_BODY(t_4, 326);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3997,8 +4053,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[5], -1, 0, HdlrFunc5 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 347);
- SET_ENDLINE_BODY(t_4, 349);
+ SET_STARTLINE_BODY(t_4, 351);
+ SET_ENDLINE_BODY(t_4, 353);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4151,8 +4207,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[6], 2, 0, HdlrFunc6 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 360);
- SET_ENDLINE_BODY(t_4, 571);
+ SET_STARTLINE_BODY(t_4, 364);
+ SET_ENDLINE_BODY(t_4, 575);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4210,8 +4266,8 @@ static Obj  HdlrFunc1 (
  t_2 = NewFunction( NameFunc[7], 6, 0, HdlrFunc7 );
  SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
  t_3 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_3, 590);
- SET_ENDLINE_BODY(t_3, 654);
+ SET_STARTLINE_BODY(t_3, 594);
+ SET_ENDLINE_BODY(t_3, 658);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4225,8 +4281,8 @@ static Obj  HdlrFunc1 (
  t_2 = NewFunction( NameFunc[9], 6, 0, HdlrFunc9 );
  SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
  t_3 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_3, 657);
- SET_ENDLINE_BODY(t_3, 663);
+ SET_STARTLINE_BODY(t_3, 661);
+ SET_ENDLINE_BODY(t_3, 667);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4254,8 +4310,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[10], 2, 0, HdlrFunc10 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 676);
- SET_ENDLINE_BODY(t_4, 700);
+ SET_STARTLINE_BODY(t_4, 680);
+ SET_ENDLINE_BODY(t_4, 704);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4339,8 +4395,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[11], 4, 0, HdlrFunc11 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 825);
- SET_ENDLINE_BODY(t_4, 936);
+ SET_STARTLINE_BODY(t_4, 829);
+ SET_ENDLINE_BODY(t_4, 940);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4391,8 +4447,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[17], -1, 0, HdlrFunc17 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 971);
- SET_ENDLINE_BODY(t_4, 1018);
+ SET_STARTLINE_BODY(t_4, 975);
+ SET_ENDLINE_BODY(t_4, 1022);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4695,7 +4751,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "GAPROOT/lib/oper1.g",
- .crc         = -110560148,
+ .crc         = -3672617,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/src/lists.c
+++ b/src/lists.c
@@ -2610,6 +2610,7 @@ static Int InitKernel (
         }
     }
 
+    SetupFlagsListsAsLists();
     /* return success                                                      */
     return 0;
 }

--- a/src/objects.h
+++ b/src/objects.h
@@ -163,7 +163,6 @@ enum TNUM {
 
         T_FUNCTION,
         T_BODY,     // the type of function body bags
-        T_FLAGS,
         T_LVARS,
         T_HVARS,
     END_ENUM_RANGE(LAST_CONSTANT_TNUM),
@@ -212,6 +211,7 @@ enum TNUM {
             NEXT_ENUM_EVEN(T_STRING),
             NEXT_ENUM_EVEN(T_STRING_NSORT),
             NEXT_ENUM_EVEN(T_STRING_SSORT),
+    NEXT_ENUM_EVEN(T_FLAGS),
 
         END_ENUM_RANGE_ODD(LAST_LIST_TNUM),
 
@@ -251,7 +251,7 @@ enum TNUM {
 #ifdef HPCGAP
         LAST_PACKAGE_TNUM   = FIRST_PACKAGE_TNUM + 153,
 #else
-        LAST_PACKAGE_TNUM   = FIRST_PACKAGE_TNUM + 50,
+        LAST_PACKAGE_TNUM   = FIRST_PACKAGE_TNUM + 48,
 #endif
 
     END_ENUM_RANGE(LAST_EXTERNAL_TNUM),

--- a/src/opers.c
+++ b/src/opers.c
@@ -126,6 +126,32 @@ void LoadFlags(
 
 /****************************************************************************
 **
+*F  C_ELM_FLAGS( <list>, <pos> )  . . . . . . . . . . . element of a flags list
+**
+**
+**  returns 1 if the flags list <list> contains the filter <pos>, else 0
+*/
+UInt C_ELM_FLAGS(Obj list, UInt pos) {
+    UInt len = INT_INTOBJ(SIZE_FLAGS(list));
+    Int hi = len -1;
+    Int lo = 0;
+    while (hi >= lo) {
+        Int mid = (hi + lo)/2;
+        UInt2 x = TRUE_FLAGS(list, mid);
+        if (x == pos)
+            return 1;
+        if (x < pos) {
+            lo = mid+1;
+        } else {
+            hi = mid -1;
+        }
+    }
+    return 0;
+}
+
+
+/****************************************************************************
+**
 *F * * * * * * * * * * * * *  GAP flags functions * * * * * * * * * * * * * *
 */
 
@@ -388,7 +414,7 @@ Obj FuncSUB_FLAGS (
 
     len1 = INT_INTOBJ(SIZE_FLAGS(flags1));
     len2 = INT_INTOBJ(SIZE_FLAGS(flags2));
-    NEW_FLAGS(flags, len1);
+    flags = NEW_FLAGS(len1);
     i = 0;
     j = 0;
     k = 0;
@@ -464,9 +490,9 @@ Obj FuncAND_FLAGS (
 
     if (flags1 == flags2)
         return flags1;
-    if (LEN_FLAGS(flags2) == 0)
+    if (SIZE_FLAGS(flags2) == INTOBJ_INT(0))
         return flags1;
-    if (LEN_FLAGS(flags1) == 0)
+    if (SIZE_FLAGS(flags1) == INTOBJ_INT(0))
         return flags2;
 
     // check the cache
@@ -526,7 +552,7 @@ Obj FuncAND_FLAGS (
     /* do the real work                                                    */
     len1 = INT_INTOBJ(SIZE_FLAGS(flags1));
     len2 = INT_INTOBJ(SIZE_FLAGS(flags2));
-    NEW_FLAGS(flags, len1+len2);
+    flags = NEW_FLAGS(len1+len2);
     i = 0;
     j = 0;
     k = 0;
@@ -1101,7 +1127,7 @@ Obj NewFilter (
     getter = NewOperation( name, 1L, nams, (hdlr ? hdlr : DoFilter) );
     SET_FLAG1_FILT(getter, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(getter, INTOBJ_INT(0));
-    NEW_FLAGS( flags, 1 );
+    flags = NEW_FLAGS( 1 );
     SET_SIZE_FLAGS( flags, INTOBJ_INT(1) );
     SET_TRUE_FLAGS( flags, 0, flag1);
     SET_FLAGS_FILT(getter, flags);
@@ -1252,7 +1278,7 @@ Obj NewReturnTrueFilter ( void )
         DoReturnTrueFilter );
     SET_FLAG1_FILT(getter, INTOBJ_INT(0));
     SET_FLAG2_FILT(getter, INTOBJ_INT(0));
-    NEW_FLAGS( flags, 0 );
+    flags = NEW_FLAGS( 0 );
     SET_SIZE_FLAGS( flags, INTOBJ_INT(0) );
     SET_FLAGS_FILT(getter, flags);
     CHANGED_BAG(getter);
@@ -2692,7 +2718,7 @@ static Obj MakeTester( Obj name, Int flag1, Int flag2)
                            DoTestAttribute );
     SET_FLAG1_FILT(tester, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(tester, INTOBJ_INT(flag2));
-    NEW_FLAGS( flags, flag2 );
+    flags = NEW_FLAGS( 1 );
     SET_SIZE_FLAGS( flags, INTOBJ_INT(1) );
     SET_TRUE_FLAGS( flags, 0, flag2);
     SET_FLAGS_FILT(tester, flags);
@@ -2981,7 +3007,7 @@ Obj NewProperty (
 
     SET_FLAG1_FILT(getter, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(getter, INTOBJ_INT(flag2));
-    NEW_FLAGS( flags, flag2 );
+    flags = NEW_FLAGS( 2 );
     SET_SIZE_FLAGS( flags, INTOBJ_INT(2) );
     SET_TRUE_FLAGS(flags, 0, flag1);
     SET_TRUE_FLAGS(flags, 1, flag2);
@@ -3863,7 +3889,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(IS_SUBSET_FLAGS, 2, "flags1, flags2"),
     GVAR_FUNC(TRUES_FLAGS, 1, "flags"),
     GVAR_FUNC(SIZE_FLAGS, 1, "flags"),
-    GVAR_FUNC(ELM_FLAGS, 2, "flags, pos"),
+    //    GVAR_FUNC(ELM_FLAGS, 2, "flags, pos"),
     GVAR_FUNC(FLAG1_FILTER, 1, "oper"),
     GVAR_FUNC(SET_FLAG1_FILTER, 2, "oper, flag1"),
     GVAR_FUNC(FLAG2_FILTER, 1, "oper"),

--- a/src/opers.c
+++ b/src/opers.c
@@ -319,16 +319,18 @@ static Int IS_SUBSET_FLAGS(Obj flags1, Obj flags2)
         return 1;
     UInt i = 0;
     UInt j = 0;
-    UInt2 x = TRUE_FLAGS(flags1,i);
-    UInt2 y = TRUE_FLAGS(flags2,j);
+    UInt2 x,y;
     while (i < len1 && j < len2) {
+        x = TRUE_FLAGS(flags1,i);
+        y = TRUE_FLAGS(flags2,j);
         if (x == y) {
+            i++;
             j++;
-            if (j < len2) y = TRUE_FLAGS(flags2,j);
-        } else if (y < x)
+        } else if (y < x) {
             return 0;
-        i++;
-        if (i < len1) x = TRUE_FLAGS(flags1,i);        
+        } else {
+            i++;
+        }
     }
     return (j == len2);   
 }
@@ -385,27 +387,23 @@ Obj FuncSUB_FLAGS (
     }
 
     len1 = INT_INTOBJ(SIZE_FLAGS(flags1));
-    len2 = INT_INTOBJ(SIZE_FLAGS(flags1));
+    len2 = INT_INTOBJ(SIZE_FLAGS(flags2));
     NEW_FLAGS(flags, len1);
     i = 0;
     j = 0;
     k = 0;
-    x = TRUE_FLAGS(flags1,i);
-    y = TRUE_FLAGS(flags2,j);
     while ( i < len1 && j < len2) {
+        x = TRUE_FLAGS(flags1,i);
+        y = TRUE_FLAGS(flags2,j);
         if (x == y) {
             i++;
             j++;
-            if (i < len1) x = TRUE_FLAGS(flags1,i);
-            if (j < len2) y = TRUE_FLAGS(flags2,j);
         } else if (x < y) {
             SET_TRUE_FLAGS(flags, k, x);
             k++;
             i++;
-            if (i < len1) x = TRUE_FLAGS(flags1,i);
         } else {
             j++;
-            if (j < len2) y = TRUE_FLAGS(flags2,j);
         }
     }
     while (i < len1) {
@@ -439,7 +437,7 @@ Obj FuncAND_FLAGS (
     Int                 len1;
     Int                 len2;
     Int                 i,j,k;
-    UInt2               x,y;
+    UInt2               x,y,z;
 
 #ifdef AND_FLAGS_HASH_SIZE
     Obj                 cache;
@@ -532,25 +530,23 @@ Obj FuncAND_FLAGS (
     i = 0;
     j = 0;
     k = 0;
-    x = TRUE_FLAGS(flags1,i);
-    y = TRUE_FLAGS(flags2,j);
     while ( i < len1 && j < len2) {
+        x = TRUE_FLAGS(flags1,i);
+        y = TRUE_FLAGS(flags2,j);
         if (x == y) {
             i++;
             j++;
-            SET_TRUE_FLAGS(flags, k++, x);
-            if (i < len1) x = TRUE_FLAGS(flags1,i);
-            if (j < len2) y = TRUE_FLAGS(flags2,j);
+            z = x;
         } else if (x < y) {
-            SET_TRUE_FLAGS(flags, k++, x);
             i++;
-            if (i < len1) x = TRUE_FLAGS(flags1,i);
+            z = x;
         } else {
-            SET_TRUE_FLAGS(flags, k++, y);
             j++;
-            if (j < len2) y = TRUE_FLAGS(flags2,j);
+            z = y;
         }
+        SET_TRUE_FLAGS(flags, k++, z);
     }
+    /* Only one of these two loops will go round > 0 times */
     while (i < len1) {
         SET_TRUE_FLAGS(flags, k++, TRUE_FLAGS(flags1, i++) );
     }

--- a/src/opers.c
+++ b/src/opers.c
@@ -92,16 +92,14 @@ Obj TypeFlags (
 void SaveFlags (
     Obj         flags )
 {
-    UInt        i, len, *ptr;
-
-    SaveSubObj(TRUES_FLAGS(flags));
+    UInt        i, len;
+  
+    SaveSubObj(SIZE_FLAGS(flags));
     SaveSubObj(HASH_FLAGS(flags));
     SaveSubObj(AND_CACHE_FLAGS(flags));
-
-    len = NRB_FLAGS(flags);
-    ptr = BLOCKS_FLAGS(flags);
-    for ( i = 1;  i <= len;  i++ )
-        SaveUInt(*ptr++);
+    len = INT_INTOBJ(SIZE_FLAGS(flags));
+    for ( i = 0;  i < len; i++)
+        SaveUInt2(TRUE_FLAGS(flags,i));
 }
 
 
@@ -114,16 +112,15 @@ void LoadFlags(
     Obj         flags )
 {
     Obj         sub;
-    UInt        i, len, *ptr;
+    UInt        i, len;
 
-    sub = LoadSubObj();  SET_TRUES_FLAGS( flags, sub );
+    sub = LoadSubObj();  SET_SIZE_FLAGS( flags, sub );
     sub = LoadSubObj();  SET_HASH_FLAGS( flags, sub );
     sub = LoadSubObj();  SET_AND_CACHE_FLAGS( flags, sub );
     
-    len = NRB_FLAGS(flags);
-    ptr = BLOCKS_FLAGS(flags);
-    for ( i = 1;  i <= len;  i++ )
-        *ptr++ = LoadUInt();
+    len = INT_INTOBJ(SIZE_FLAGS(flags));
+    for ( i = 0;  i < len;  i++ )
+        SET_TRUE_FLAGS(flags, i, LoadUInt2());
 }
 
 
@@ -146,17 +143,13 @@ void LoadFlags(
 **  the lower addressed half-word is the less significant
 **
 */
-#define HASH_FLAGS_SIZE (Int4)67108879L
+#define fnvp 1099511628211ULL
+#define fnvob 14695981039346656037ULL
 
 Obj FuncHASH_FLAGS (
     Obj                 self,
     Obj                 flags )
 {
-    Int4                 hash;
-    Int4                 x;
-    Int                  len;
-    UInt4 *              ptr;
-    Int                  i;
 
     /* do some trivial checks                                              */
     while ( TNUM_OBJ(flags) != T_FLAGS ) {
@@ -169,56 +162,18 @@ Obj FuncHASH_FLAGS (
     }
 
     /* do the real work*/
-#ifndef SYS_IS_64_BIT
 
-    /* 32 bit case  -- this is the "defining" case, others are
-     adjusted to comply with this */
-    len = NRB_FLAGS(flags);
-    ptr = (UInt4 *)BLOCKS_FLAGS(flags);
-    hash = 0;
-    x    = 1;
-    for ( i = len; i >= 1; i-- ) {
-        hash = (hash + (*ptr % HASH_FLAGS_SIZE) * x) % HASH_FLAGS_SIZE;
-        x    = ((8*sizeof(UInt4)-1) * x) % HASH_FLAGS_SIZE;
-        ptr++;
+
+    UInt8 h = fnvob;
+    UInt len = INT_INTOBJ(SIZE_FLAGS(flags));
+    for (UInt i = 0; i < len; i++) {
+        UInt2 pos = TRUE_FLAGS(flags, i);
+        h = (h*fnvp) ^ (pos & 0xFF);
+        h = (h*fnvp) ^ (pos >>8);
     }
-#else
-#ifdef WORDS_BIGENDIAN
+    UInt hash = (h & 0xFFFFFFFUL);
 
-    /* This is the hardest case */
-    len = NRB_FLAGS(flags);
-    ptr = (UInt4 *)BLOCKS_FLAGS(flags);
-    hash = 0;
-    x    = 1;
-    for ( i = len; i >= 1; i-- ) {
-
-        /* least significant 32 bits first */
-        hash = (hash + (ptr[1] % HASH_FLAGS_SIZE) * x) % HASH_FLAGS_SIZE;
-        x    = ((8*sizeof(UInt4)-1) * x) % HASH_FLAGS_SIZE;
-        /* now the more significant */
-        hash = (hash + (*ptr % HASH_FLAGS_SIZE) * x) % HASH_FLAGS_SIZE;
-        x    = ((8*sizeof(UInt4)-1) * x) % HASH_FLAGS_SIZE;
-        
-        ptr+= 2;
-    }
-#else
-
-    /* and the middle case -- for DEC alpha, the 32 bit chunks are
-       in the right order, and we merely have to be sure to process them as
-       32 bit chunks */
-    len = NRB_FLAGS(flags)*(sizeof(UInt)/sizeof(UInt4));
-    ptr = (UInt4 *)BLOCKS_FLAGS(flags);
-    hash = 0;
-    x    = 1;
-    for ( i = len; i >= 1; i-- ) {
-        hash = (hash + (*ptr % HASH_FLAGS_SIZE) * x) % HASH_FLAGS_SIZE;
-        x    = ((8*sizeof(UInt4)-1) * x) % HASH_FLAGS_SIZE;
-        ptr++;
-    }
-#endif
-#endif
     SET_HASH_FLAGS( flags, INTOBJ_INT((UInt)hash+1) );
-    CHANGED_BAG(flags);
     return HASH_FLAGS(flags);
 }
 
@@ -227,19 +182,26 @@ Obj FuncHASH_FLAGS (
 **
 *F  FuncTRUES_FLAGS( <self>, <flags> )  . . .  true positions of a flags list
 **
-**  see 'FuncPositionsTruesBlist' in "blister.c" for information.
 */
+
+Obj TRUES_FLAGS( Obj flags) {
+    UInt len = INT_INTOBJ(SIZE_FLAGS(flags));
+    if (len == 0) {
+        Obj trues = NEW_PLIST_IMM(T_PLIST_EMPTY,0);
+        SET_LEN_PLIST(trues, 0);
+        return trues;
+    }
+    Obj trues = NEW_PLIST_IMM(T_PLIST_CYC_SSORT, len);
+    for (UInt i = 0; i < len; i++)
+        SET_ELM_PLIST(trues, i+1, INTOBJ_INT(TRUE_FLAGS(flags, i)));
+    SET_LEN_PLIST(trues, len);
+    return trues;
+}
+
 Obj FuncTRUES_FLAGS (
     Obj                 self,
     Obj                 flags )
 {
-    Obj                 sub;            /* handle of the result            */
-    Int                 len;            /* logical length of the list      */
-    UInt *              ptr;            /* pointer to flags                */
-    UInt                nrb;            /* number of blocks in flags       */
-    UInt                n;              /* number of bits in flags         */
-    UInt                nn;
-    UInt                i;              /* loop variable                   */
 
     /* get and check the first argument                                    */
     while ( TNUM_OBJ(flags) != T_FLAGS ) {
@@ -247,34 +209,7 @@ Obj FuncTRUES_FLAGS (
             (Int)TNAM_OBJ(flags), 0L,
             "you can replace <flags> via 'return <flags>;'" );
     }
-    if ( TRUES_FLAGS(flags) != 0 ) {
-        return TRUES_FLAGS(flags);
-    }
-
-    /* compute the number of 'true'-s just as in 'FuncSizeBlist'            */
-    nrb = NRB_FLAGS(flags);
-    ptr = (UInt*)BLOCKS_FLAGS(flags);
-    n = COUNT_TRUES_BLOCKS(ptr, nrb);    
-
-    /* make the sublist (we now know its size exactly)                    */
-    sub = NEW_PLIST_IMM( T_PLIST, n );
-    SET_LEN_PLIST( sub, n );
-
-    /* loop over the boolean list and stuff elements into <sub>            */
-    len = LEN_FLAGS( flags );
-    nn  = 1;
-    for ( i = 1; nn <= n && i <= len;  i++ ) {
-        if ( C_ELM_FLAGS( flags, i ) ) {
-            SET_ELM_PLIST( sub, nn, INTOBJ_INT(i) );
-            nn++;
-        }
-    }
-    CHANGED_BAG(sub);
-
-    /* return the sublist                                                  */
-    SET_TRUES_FLAGS( flags, sub );
-    CHANGED_BAG(flags);
-    return sub;
+    return TRUES_FLAGS(flags);
 }
 
 
@@ -288,9 +223,6 @@ Obj FuncSIZE_FLAGS (
     Obj                 self,
     Obj                 flags )
 {
-    UInt *              ptr;            /* pointer to flags                */
-    UInt                nrb;            /* number of blocks in flags       */
-    UInt                n;              /* number of bits in flags         */
 
     /* get and check the first argument                                    */
     while ( TNUM_OBJ(flags) != T_FLAGS ) {
@@ -298,18 +230,7 @@ Obj FuncSIZE_FLAGS (
             (Int)TNAM_OBJ(flags), 0L,
             "you can replace <flags> via 'return <flags>;'" );
     }
-    if ( TRUES_FLAGS(flags) != 0 ) {
-        return INTOBJ_INT( LEN_PLIST( TRUES_FLAGS(flags) ) );
-    }
-
-    /* get the number of blocks and a pointer                              */
-    nrb = NRB_FLAGS(flags);
-    ptr = BLOCKS_FLAGS(flags);
-
-    n = COUNT_TRUES_BLOCKS(ptr, nrb);
-
-    /* return the number of bits                                           */
-    return INTOBJ_INT( n );
+    return SIZE_FLAGS(flags);
 }
 
 
@@ -319,52 +240,36 @@ Obj FuncSIZE_FLAGS (
 */
 Int EqFlags(Obj flags1, Obj flags2)
 {
-    Int                 len1;
-    Int                 len2;
-    UInt  *             ptr1;
-    UInt  *             ptr2;
+    Int                 len;
     Int                 i;
 
     if ( flags1 == flags2 ) {
         return 1;
     }
 
+    if (SIZE_FLAGS(flags1) != SIZE_FLAGS(flags2))
+        return 0;
+
+    Obj h1 = HASH_FLAGS(flags1);
+    if (h1 != 0) {
+        Obj h2 = HASH_FLAGS(flags1);
+        if (h2 != 0 && h2 != h1)
+            return 0;
+    }
+    
     // do the real work
-    len1 = NRB_FLAGS(flags1);
-    len2 = NRB_FLAGS(flags2);
-    ptr1 = BLOCKS_FLAGS(flags1);
-    ptr2 = BLOCKS_FLAGS(flags2);
-    if ( len1 <= len2 ) {
-        for ( i = 1; i <= len1; i++ ) {
-            if ( *ptr1 != *ptr2 )
-                return 0;
-            ptr1++;  ptr2++;
-        }
-        for ( ; i <= len2; i++ ) {
-            if ( 0 != *ptr2 )
-                return 0;
-            ptr2++;
-        }
-    }
-    else {
-        for ( i = 1; i <= len2; i++ ) {
-            if ( *ptr1 != *ptr2 )
-                return 0;
-            ptr1++;  ptr2++;
-        }
-        for ( ; i <= len1; i++ ) {
-            if ( *ptr1 != 0 )
-                return 0;
-            ptr1++;
-        }
-    }
+    
+    len = INT_INTOBJ(SIZE_FLAGS(flags1));
+    for (i = 0; i < len; i++)
+        if (TRUE_FLAGS(flags1,i) != TRUE_FLAGS(flags2,i))
+            return 0;
     return 1;
 }
 
 
 /****************************************************************************
 **
-*F  FuncIS_EQUAL_FLAGS( <self>, <flags1>, <flags2> )  equality of flags lists
+*f  FuncIS_EQUAL_FLAGS( <self>, <flags1>, <flags2> )  equality of flags lists
 */
 Obj FuncIS_EQUAL_FLAGS (
     Obj                 self,
@@ -394,43 +299,38 @@ static Int IsSubsetFlagsCalls;
 /****************************************************************************
 **
 *F  IS_SUBSET_FLAGS( <flags1>, <flags2> ) . subset test with no safety check
+** checks is <flags2> is a subset of <flags1>
 */
 static Int IS_SUBSET_FLAGS(Obj flags1, Obj flags2)
 {
     Int    len1;
     Int    len2;
-    UInt * ptr1;
-    UInt * ptr2;
-    Int    i;
-
+    
+/* do the real work                                                    */
 #ifdef COUNT_OPERS
     IsSubsetFlagsCalls++;
 #endif
 
-    /* compare the bit lists                                               */
-    len1 = NRB_FLAGS(flags1);
-    len2 = NRB_FLAGS(flags2);
-    ptr1 = BLOCKS_FLAGS(flags1);
-    ptr2 = BLOCKS_FLAGS(flags2);
-    if (len1 < len2) {
-        for (i = len2 - 1; i >= len1; i--) {
-            if (ptr2[i] != 0)
-                return 0;
-        }
-        for (i = len1 - 1; i >= 0; i--) {
-            UInt x = ptr2[i];
-            if ((x & ptr1[i]) != x)
-                return 0;
-        }
+    len1 = INT_INTOBJ(SIZE_FLAGS(flags1));
+    len2 = INT_INTOBJ(SIZE_FLAGS(flags2));
+    if (len2 > len1)
+        return 0;
+    if (len2== 0)
+        return 1;
+    UInt i = 0;
+    UInt j = 0;
+    UInt2 x = TRUE_FLAGS(flags1,i);
+    UInt2 y = TRUE_FLAGS(flags2,j);
+    while (i < len1 && j < len2) {
+        if (x == y) {
+            j++;
+            if (j < len2) y = TRUE_FLAGS(flags2,j);
+        } else if (y < x)
+            return 0;
+        i++;
+        if (i < len1) x = TRUE_FLAGS(flags1,i);        
     }
-    else {
-        for (i = len2 - 1; i >= 0; i--) {
-            UInt x = ptr2[i];
-            if ((x & ptr1[i]) != x)
-                return 0;
-        }
-    }
-    return 1;
+    return (j == len2);   
 }
 
 /****************************************************************************
@@ -469,12 +369,8 @@ Obj FuncSUB_FLAGS (
     Obj                 flags;
     Int                 len1;
     Int                 len2;
-    Int                 size1;
-    Int                 size2;
-    UInt *              ptr;
-    UInt *              ptr1;
-    UInt *              ptr2;
-    Int                 i;
+    Int                 i,j,k;
+    UInt2               x,y;
 
     /* do some trivial checks                                              */
     while ( TNUM_OBJ(flags1) != T_FLAGS ) {
@@ -488,30 +384,36 @@ Obj FuncSUB_FLAGS (
             "you can replace <flags2> via 'return <flags2>;'" );
     }
 
-    /* do the real work                                                    */
-    len1   = LEN_FLAGS(flags1);
-    size1  = NRB_FLAGS(flags1);
-    len2   = LEN_FLAGS(flags2);
-    size2  = NRB_FLAGS(flags2);
-    if ( len1 < len2 ) {
-        flags = NEW_FLAGS( len1 );
-        ptr1 = BLOCKS_FLAGS(flags1);
-        ptr2 = BLOCKS_FLAGS(flags2);
-        ptr  = BLOCKS_FLAGS(flags);
-        for ( i = 1; i <= size1; i++ )
-            *ptr++ = *ptr1++ & ~ *ptr2++;
+    len1 = INT_INTOBJ(SIZE_FLAGS(flags1));
+    len2 = INT_INTOBJ(SIZE_FLAGS(flags1));
+    NEW_FLAGS(flags, len1);
+    i = 0;
+    j = 0;
+    k = 0;
+    x = TRUE_FLAGS(flags1,i);
+    y = TRUE_FLAGS(flags2,j);
+    while ( i < len1 && j < len2) {
+        if (x == y) {
+            i++;
+            j++;
+            if (i < len1) x = TRUE_FLAGS(flags1,i);
+            if (j < len2) y = TRUE_FLAGS(flags2,j);
+        } else if (x < y) {
+            SET_TRUE_FLAGS(flags, k, x);
+            k++;
+            i++;
+            if (i < len1) x = TRUE_FLAGS(flags1,i);
+        } else {
+            j++;
+            if (j < len2) y = TRUE_FLAGS(flags2,j);
+        }
     }
-    else {
-        flags = NEW_FLAGS( len1 );
-        ptr1 = BLOCKS_FLAGS(flags1);
-        ptr2 = BLOCKS_FLAGS(flags2);
-        ptr  = BLOCKS_FLAGS(flags);
-        for ( i = 1; i <= size2; i++ )
-            *ptr++ = *ptr1++ & ~ *ptr2++;
-        for (      ; i <= size1; i++ )
-            *ptr++ = *ptr1++;
-    }        
-
+    while (i < len1) {
+        SET_TRUE_FLAGS(flags, k++, TRUE_FLAGS(flags1, i++) );
+    }
+    
+    SET_SIZE_FLAGS(flags, INTOBJ_INT(k));
+    
     return flags;
 }
 
@@ -536,12 +438,8 @@ Obj FuncAND_FLAGS (
     Obj                 flags;
     Int                 len1;
     Int                 len2;
-    Int                 size1;
-    Int                 size2;
-    UInt *              ptr;
-    UInt *              ptr1;
-    UInt *              ptr2;
-    Int                 i;
+    Int                 i,j,k;
+    UInt2               x,y;
 
 #ifdef AND_FLAGS_HASH_SIZE
     Obj                 cache;
@@ -627,33 +525,41 @@ Obj FuncAND_FLAGS (
 #       endif
 #   endif
 
-
     /* do the real work                                                    */
-    len1   = LEN_FLAGS(flags1);
-    size1  = NRB_FLAGS(flags1);
-    len2   = LEN_FLAGS(flags2);
-    size2  = NRB_FLAGS(flags2);
-
-    if ( len1 < len2 ) {
-        flags = NEW_FLAGS( len2 );
-        ptr1 = BLOCKS_FLAGS(flags1);
-        ptr2 = BLOCKS_FLAGS(flags2);
-        ptr  = BLOCKS_FLAGS(flags);
-        for ( i = 1; i <= size1; i++ )
-            *ptr++ = *ptr1++ | *ptr2++;
-        for (      ; i <= size2; i++ )
-            *ptr++ =           *ptr2++;
+    len1 = INT_INTOBJ(SIZE_FLAGS(flags1));
+    len2 = INT_INTOBJ(SIZE_FLAGS(flags2));
+    NEW_FLAGS(flags, len1+len2);
+    i = 0;
+    j = 0;
+    k = 0;
+    x = TRUE_FLAGS(flags1,i);
+    y = TRUE_FLAGS(flags2,j);
+    while ( i < len1 && j < len2) {
+        if (x == y) {
+            i++;
+            j++;
+            SET_TRUE_FLAGS(flags, k++, x);
+            if (i < len1) x = TRUE_FLAGS(flags1,i);
+            if (j < len2) y = TRUE_FLAGS(flags2,j);
+        } else if (x < y) {
+            SET_TRUE_FLAGS(flags, k++, x);
+            i++;
+            if (i < len1) x = TRUE_FLAGS(flags1,i);
+        } else {
+            SET_TRUE_FLAGS(flags, k++, y);
+            j++;
+            if (j < len2) y = TRUE_FLAGS(flags2,j);
+        }
     }
-    else {
-        flags = NEW_FLAGS( len1 );
-        ptr1 = BLOCKS_FLAGS(flags1);
-        ptr2 = BLOCKS_FLAGS(flags2);
-        ptr  = BLOCKS_FLAGS(flags);
-        for ( i = 1; i <= size2; i++ )
-            *ptr++ = *ptr1++ | *ptr2++;
-        for (      ; i <= size1; i++ )
-            *ptr++ = *ptr1++;
-    }        
+    while (i < len1) {
+        SET_TRUE_FLAGS(flags, k++, TRUE_FLAGS(flags1, i++) );
+    }
+    while (j < len2) {
+        SET_TRUE_FLAGS(flags, k++, TRUE_FLAGS(flags2, j++) );
+    }
+    
+    SET_SIZE_FLAGS(flags, INTOBJ_INT(k));
+
 
     /* store result in the cache                                           */
 #   ifdef AND_FLAGS_HASH_SIZE
@@ -1134,11 +1040,11 @@ Obj DoSetFilter (
     flags = FLAGS_TYPE( type );
     
     /* return the value of the feature                                     */
-    if ( val != SAFE_ELM_FLAGS( flags, flag1 ) ) {
+    if ( val != ELM_FLAGS( flags, flag1 ) ) {
         ErrorReturnVoid(
-            "value feature is already set the other way",
-            0L, 0L,
-            "you can 'return;' and ignore it" );
+                        "value feature is already set the other way",
+                        0L, 0L,
+                        "you can 'return;' and ignore it" );
     }
 
     /* return 'void'                                                       */
@@ -1164,7 +1070,6 @@ Obj DoFilter (
     Obj                 self,
     Obj                 obj )
 {
-    Obj                 val;
     Int                 flag1;
     Obj                 type;
     Obj                 flags;
@@ -1176,11 +1081,7 @@ Obj DoFilter (
     type  = TYPE_OBJ( obj );
     flags = FLAGS_TYPE( type );
     
-    /* return the value of the feature                                     */
-    val = SAFE_ELM_FLAGS( flags, flag1 );
-    
-    /* return the value                                                    */
-    return val;
+    return ELM_FLAGS( flags, flag1 );
 }
 
 
@@ -1196,12 +1097,17 @@ Obj NewFilter (
     Obj                 flags;
     
     flag1 = ++CountFlags;
+    if (flag1 >= (1<<16)) {
+        FPUTS_TO_STDERR("#E Too many filters, fatal error\n");
+        SyExit(2);
+    }
 
     getter = NewOperation( name, 1L, nams, (hdlr ? hdlr : DoFilter) );
     SET_FLAG1_FILT(getter, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(getter, INTOBJ_INT(0));
-    flags = NEW_FLAGS( flag1 );
-    SET_ELM_FLAGS( flags, flag1, True );
+    NEW_FLAGS( flags, 1 );
+    SET_SIZE_FLAGS( flags, INTOBJ_INT(1) );
+    SET_TRUE_FLAGS( flags, 0, flag1);
     SET_FLAGS_FILT(getter, flags);
     CHANGED_BAG(getter);
 
@@ -1350,7 +1256,8 @@ Obj NewReturnTrueFilter ( void )
         DoReturnTrueFilter );
     SET_FLAG1_FILT(getter, INTOBJ_INT(0));
     SET_FLAG2_FILT(getter, INTOBJ_INT(0));
-    flags = NEW_FLAGS( 0 );
+    NEW_FLAGS( flags, 0 );
+    SET_SIZE_FLAGS( flags, INTOBJ_INT(0) );
     SET_FLAGS_FILT(getter, flags);
     CHANGED_BAG(getter);
 
@@ -2517,8 +2424,7 @@ Obj DoTestAttribute (
     type  = TYPE_OBJ_FEO( obj );
     flags = FLAGS_TYPE( type );
 
-    /* return whether the value of the attribute is already known          */
-    return SAFE_ELM_FLAGS( flags, flag2 );
+    return ELM_FLAGS(flags, flag2);
 }
 
 
@@ -2545,7 +2451,7 @@ Obj DoAttribute (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the attribute is already known, simply return it     */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 ) ) {
         return DoOperation1Args( self, obj );
     }
     
@@ -2600,7 +2506,7 @@ Obj DoVerboseAttribute (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the attribute is already known, simply return it     */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 )) {
         return DoVerboseOperation1Args( self, obj );
     }
     
@@ -2648,7 +2554,7 @@ Obj DoMutableAttribute (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the attribute is already known, simply return it     */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 ) ) {
         return DoOperation1Args( self, obj );
     }
     
@@ -2695,7 +2601,7 @@ Obj DoVerboseMutableAttribute (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the attribute is already known, simply return it     */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 ) ) {
         return DoVerboseOperation1Args( self, obj );
     }
     
@@ -2790,8 +2696,9 @@ static Obj MakeTester( Obj name, Int flag1, Int flag2)
                            DoTestAttribute );
     SET_FLAG1_FILT(tester, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(tester, INTOBJ_INT(flag2));
-    flags = NEW_FLAGS( flag2 );
-    SET_ELM_FLAGS( flags, flag2, True );
+    NEW_FLAGS( flags, flag2 );
+    SET_SIZE_FLAGS( flags, INTOBJ_INT(1) );
+    SET_TRUE_FLAGS( flags, 0, flag2);
     SET_FLAGS_FILT(tester, flags);
     SET_SETTR_FILT(tester, 0);
     SET_TESTR_FILT(tester, ReturnTrueFilter);
@@ -2900,7 +2807,7 @@ Obj DoSetProperty (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the property is already known, compare it           */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 )) {
         if ( val == ELM_FLAGS( flags, flag1 ) ) {
             return 0;
         }
@@ -2968,7 +2875,7 @@ Obj DoProperty (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the property is already known, simply return it     */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 ) ) {
         return ELM_FLAGS( flags, flag1 );
     }
 
@@ -3024,7 +2931,7 @@ Obj DoVerboseProperty (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the property is already known, simply return it     */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 )) {
         return ELM_FLAGS( flags, flag1 );
     }
 
@@ -3078,9 +2985,10 @@ Obj NewProperty (
 
     SET_FLAG1_FILT(getter, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(getter, INTOBJ_INT(flag2));
-    flags = NEW_FLAGS( flag2 );
-    SET_ELM_FLAGS( flags, flag2, True );
-    SET_ELM_FLAGS( flags, flag1, True );
+    NEW_FLAGS( flags, flag2 );
+    SET_SIZE_FLAGS( flags, INTOBJ_INT(2) );
+    SET_TRUE_FLAGS(flags, 0, flag1);
+    SET_TRUE_FLAGS(flags, 1, flag2);
     SET_FLAGS_FILT(getter, flags);
     SET_SETTR_FILT(getter, setter);
     SET_TESTR_FILT(getter, tester);
@@ -3596,7 +3504,7 @@ Obj DoSetterFunction (
     flag2  = INT_INTOBJ( FLAG2_FILT(tester) );
     type   = TYPE_OBJ_FEO(obj);
     flags  = FLAGS_TYPE(type);
-    if ( SAFE_C_ELM_FLAGS(flags,flag2) ) {
+    if ( C_ELM_FLAGS(flags,flag2)) {
         return 0;
     }
 
@@ -3959,6 +3867,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(IS_SUBSET_FLAGS, 2, "flags1, flags2"),
     GVAR_FUNC(TRUES_FLAGS, 1, "flags"),
     GVAR_FUNC(SIZE_FLAGS, 1, "flags"),
+    GVAR_FUNC(ELM_FLAGS, 2, "flags, pos"),
     GVAR_FUNC(FLAG1_FILTER, 1, "oper"),
     GVAR_FUNC(SET_FLAG1_FILTER, 2, "oper, flag1"),
     GVAR_FUNC(FLAG2_FILTER, 1, "oper"),

--- a/src/opers.h
+++ b/src/opers.h
@@ -230,15 +230,22 @@ static inline void SET_ENABLED_ATTR(Obj oper, Int x)
 ** Set positions (array of UInt2).
 */
 
+/****************************************************************************
+**
+*F  SIZE_PLEN_FLAGS( <fsize> ) . .  bag size for a flags list with <fsize> trues
+*/
+static inline UInt SIZE_PLEN_FLAGS(UInt fsize) {
+    return 3*sizeof(Obj) + 2*fsize;
+}
 
 /****************************************************************************
 **
 *F  NEW_FLAGS( <flags>, <len> ) . . . . . . . . . . . . . . .  new flags list
 */
+
 static inline Obj NEW_FLAGS(UInt len)
-{p
-    UInt size = (3 + ((len+BIPEB-1) >> LBIPEB)) * sizeof(Obj);
-    Obj flags = NewBag(T_FLAGS, size);
+{
+    Obj flags = NewBag(T_FLAGS, SIZE_PLEN_FLAGS(len));
     return flags;
 }
 
@@ -273,33 +280,37 @@ static inline void SET_SIZE_FLAGS(Obj flags, Obj size) {
 **
 *F  HASH_FLAGS( <flags> ) . . . . . . . . . . . .  hash value of <flags> or 0
 */
-static inline UInt LEN_FLAGS(Obj flags)
+static inline Obj HASH_FLAGS(Obj flags)
 {
-    return (SIZE_OBJ(flags) / sizeof(Obj) - 3) << LBIPEB;
-};
+    return CONST_ADDR_OBJ(flags)[1];
+}
+
+/****************************************************************************
+**
+*F  SET_HASH_FLAGS( <flags> ) . . . . . . . . . .  set  hash value of <flags>
+*/
+static inline void SET_HASH_FLAGS(Obj flags, Obj hash)
+{
+    ADDR_OBJ(flags)[1] = hash;
+}
 
 /****************************************************************************
 **
 *F  AND_CACHE_FLAGS( <flags> )  . . . . . . . . . 'and' cache of a flags list
 */
-#define AND_CACHE_FLAGS(list)           (CONST_ADDR_OBJ(list)[2])
+static inline Obj AND_CACHE_FLAGS(Obj flags) {
+    return CONST_ADDR_OBJ(flags)[2];
+}
 
 
 /****************************************************************************
 **
 *F  SET_AND_CACHE_FLAGS( <flags>, <len> ) set the 'and' cache of a flags list
 */
-#define SET_AND_CACHE_FLAGS(flags,andc)  (ADDR_OBJ(flags)[2]=(andc))
+static inline void SET_AND_CACHE_FLAGS(Obj flags, Obj andc) {
+    ADDR_OBJ(flags)[2]=(andc);
+}
 
-
-/****************************************************************************
-**
-*F  NRB_FLAGS( <flags> )  . . . . . .  number of basic blocks of a flags list
-*/
-static inline UInt NRB_FLAGS(Obj flags)
-{
-    return SIZE_OBJ(flags) / sizeof(Obj) - 3;
-};
 
 
 /****************************************************************************
@@ -307,7 +318,6 @@ static inline UInt NRB_FLAGS(Obj flags)
 *F  TRUE_FLAGS( <flags>, <ix> )  the <ix>th set position in flags
 **                               caller is responsible for <ix> being in range
 */
-#define BLOCKS_FLAGS(flags)             ((UInt*)(ADDR_OBJ(flags)+3))
 
 static inline UInt TRUE_FLAGS(Obj flags, UInt ix) {
     return (UInt) ((const UInt2 *)(CONST_ADDR_OBJ(flags) + 3))[ix];

--- a/src/opers.h
+++ b/src/opers.h
@@ -224,11 +224,16 @@ static inline void SET_ENABLED_ATTR(Obj oper, Int x)
 *F * * * * * * * * * * * * internal flags functions * * * * * * * * * * * * *
 **
 ** Attempting change April 2018. Flags will be stored as 
-** Size (INTOBJ)  -- could possibly be a UInt2 instead
-** Hash (INTOBJ)
 ** AND_CACHE -- Obj
+** Size (UInt)  -- could possibly be a UInt2 instead
+** Hash (Uint)
 ** Set positions (array of UInt2).
 */
+
+static inline UInt IS_FLAGS(Obj f) {
+    GAP_ASSERT(TNUM_OBJ(f) != T_FLAGS);
+    return TNUM_OBJ(f) == T_FLAGS + IMMUTABLE;
+}
 
 /****************************************************************************
 **
@@ -245,7 +250,7 @@ static inline UInt SIZE_PLEN_FLAGS(UInt fsize) {
 
 static inline Obj NEW_FLAGS(UInt len)
 {
-    Obj flags = NewBag(T_FLAGS, SIZE_PLEN_FLAGS(len));
+    Obj flags = NewBag(T_FLAGS + IMMUTABLE, SIZE_PLEN_FLAGS(len));
     return flags;
 }
 
@@ -264,34 +269,34 @@ extern Obj TRUES_FLAGS( Obj flags );
 **
 *F  SIZE_FLAGS( <flags> ) . . . . . . . . . . .number of true of <flags> 
 */
-static inline Obj SIZE_FLAGS(Obj flags) {
-    return CONST_ADDR_OBJ(flags)[0];
+static inline UInt SIZE_FLAGS(Obj flags) {
+    return ((const UInt *)CONST_ADDR_OBJ(flags))[1];
 }
 
 /****************************************************************************
 **
-*F  SET_SIZE_FLAGS( <flags>, <hash> ) . . . . . . . . . . . . . . .  set size
+*F  SET_SIZE_FLAGS( <flags>, <size> ) . . . . . . . . . . . . . . .  set size
 */
-static inline void SET_SIZE_FLAGS(Obj flags, Obj size) {
-    ADDR_OBJ(flags)[0] = size;
+static inline void SET_SIZE_FLAGS(Obj flags, UInt size) {
+    ((UInt *)ADDR_OBJ(flags))[1] = size;
 }
 
 /****************************************************************************
 **
 *F  HASH_FLAGS( <flags> ) . . . . . . . . . . . .  hash value of <flags> or 0
 */
-static inline Obj HASH_FLAGS(Obj flags)
+static inline UInt HASH_FLAGS(Obj flags)
 {
-    return CONST_ADDR_OBJ(flags)[1];
+    return ((const UInt *)CONST_ADDR_OBJ(flags))[2];
 }
 
 /****************************************************************************
 **
-*F  SET_HASH_FLAGS( <flags> ) . . . . . . . . . .  set  hash value of <flags>
+*F  SET_HASH_FLAGS( <flags>, <hash> )  . . . . . .  set  hash value of <flags>
 */
-static inline void SET_HASH_FLAGS(Obj flags, Obj hash)
+static inline void SET_HASH_FLAGS(Obj flags, UInt hash)
 {
-    ADDR_OBJ(flags)[1] = hash;
+    ((UInt *)ADDR_OBJ(flags))[2] = hash;
 }
 
 /****************************************************************************
@@ -299,7 +304,7 @@ static inline void SET_HASH_FLAGS(Obj flags, Obj hash)
 *F  AND_CACHE_FLAGS( <flags> )  . . . . . . . . . 'and' cache of a flags list
 */
 static inline Obj AND_CACHE_FLAGS(Obj flags) {
-    return CONST_ADDR_OBJ(flags)[2];
+    return CONST_ADDR_OBJ(flags)[0];
 }
 
 
@@ -308,7 +313,7 @@ static inline Obj AND_CACHE_FLAGS(Obj flags) {
 *F  SET_AND_CACHE_FLAGS( <flags>, <len> ) set the 'and' cache of a flags list
 */
 static inline void SET_AND_CACHE_FLAGS(Obj flags, Obj andc) {
-    ADDR_OBJ(flags)[2]=(andc);
+    ADDR_OBJ(flags)[0]=andc;
 }
 
 
@@ -684,6 +689,8 @@ extern void LoadOperationExtras( Obj oper );
 **
 *F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
 */
+
+extern void SetupFlagsListsAsLists( void );
 
 
 /****************************************************************************

--- a/src/opers.h
+++ b/src/opers.h
@@ -319,8 +319,8 @@ static inline UInt TRUE_FLAGS(Obj flags, UInt ix) {
 **                               caller is responsible for <ix> being in range
 */
 
-static inline void SET_TRUE_FLAGS(Obj flags, UInt ix, UInt filt) {
-    ((UInt2 *)(ADDR_OBJ(flags) +3))[ix] = (UInt2) filt ;
+static inline void SET_TRUE_FLAGS(Obj flags, UInt ix, UInt2 filt) {
+    ((UInt2 *)(ADDR_OBJ(flags) +3))[ix] = filt ;
 }
 
 /****************************************************************************

--- a/src/opers.h
+++ b/src/opers.h
@@ -16,6 +16,7 @@
 
 #include <src/system.h>
 #include <src/calls.h>
+#include <src/bool.h>
 
 
 /****************************************************************************
@@ -221,6 +222,12 @@ static inline void SET_ENABLED_ATTR(Obj oper, Int x)
 /****************************************************************************
 **
 *F * * * * * * * * * * * * internal flags functions * * * * * * * * * * * * *
+**
+** Attempting change April 2018. Flags will be stored as 
+** Size (INTOBJ)  -- could possibly be a UInt2 instead
+** Hash (INTOBJ)
+** AND_CACHE -- Obj
+** Set positions (array of UInt2).
 */
 
 
@@ -229,7 +236,7 @@ static inline void SET_ENABLED_ATTR(Obj oper, Int x)
 *F  NEW_FLAGS( <flags>, <len> ) . . . . . . . . . . . . . . .  new flags list
 */
 static inline Obj NEW_FLAGS(UInt len)
-{
+{p
     UInt size = (3 + ((len+BIPEB-1) >> LBIPEB)) * sizeof(Obj);
     Obj flags = NewBag(T_FLAGS, size);
     return flags;
@@ -242,33 +249,29 @@ static inline Obj NEW_FLAGS(UInt len)
 **
 **  returns the list of trues of <flags> or 0 if the list is not known yet.
 */
-#define TRUES_FLAGS(flags)              (CONST_ADDR_OBJ(flags)[0])
+
+extern Obj TRUES_FLAGS( Obj flags );
 
 
 /****************************************************************************
 **
-*F  SET_TRUES_FLAGS( <flags>, <trues> ) . set number of trues of a flags list
+*F  SIZE_FLAGS( <flags> ) . . . . . . . . . . .number of true of <flags> 
 */
-#define SET_TRUES_FLAGS(flags,trues)    (ADDR_OBJ(flags)[0] = trues)
+static inline Obj SIZE_FLAGS(Obj flags) {
+    return CONST_ADDR_OBJ(flags)[0];
+}
 
+/****************************************************************************
+**
+*F  SET_SIZE_FLAGS( <flags>, <hash> ) . . . . . . . . . . . . . . .  set size
+*/
+static inline void SET_SIZE_FLAGS(Obj flags, Obj size) {
+    ADDR_OBJ(flags)[0] = size;
+}
 
 /****************************************************************************
 **
 *F  HASH_FLAGS( <flags> ) . . . . . . . . . . . .  hash value of <flags> or 0
-*/
-#define HASH_FLAGS(flags)               (CONST_ADDR_OBJ(flags)[1])
-
-
-/****************************************************************************
-**
-*F  SET_HASH_FLAGS( <flags>, <hash> ) . . . . . . . . . . . . . . .  set hash
-*/
-#define SET_HASH_FLAGS(flags,hash)      (ADDR_OBJ(flags)[1] = hash)
-
-
-/****************************************************************************
-**
-*F  LEN_FLAGS( <flags> )  . . . . . . . . . . . . . .  length of a flags list
 */
 static inline UInt LEN_FLAGS(Obj flags)
 {
@@ -301,39 +304,24 @@ static inline UInt NRB_FLAGS(Obj flags)
 
 /****************************************************************************
 **
-*F  BLOCKS_FLAGS( <flags> ) . . . . . . . . . . . . data area of a flags list
+*F  TRUE_FLAGS( <flags>, <ix> )  the <ix>th set position in flags
+**                               caller is responsible for <ix> being in range
 */
 #define BLOCKS_FLAGS(flags)             ((UInt*)(ADDR_OBJ(flags)+3))
 
+static inline UInt TRUE_FLAGS(Obj flags, UInt ix) {
+    return (UInt) ((const UInt2 *)(CONST_ADDR_OBJ(flags) + 3))[ix];
+}
 
 /****************************************************************************
 **
-*F  BLOCK_ELM_FLAGS( <list>, <pos> )  . . . . . . . .  block  of a flags list
-**
-**  'BLOCK_ELM_FLAGS' return the block containing the <pos>-th element of the
-**  flags list <list> as a UInt value, which is also a  valid left hand side.
-**  <pos>  must be a positive  integer  less than or  equal  to the length of
-**  <list>.
-**
-**  Note that 'BLOCK_ELM_FLAGS' is a macro, so do not call it  with arguments
-**  that have side effects.
+*F  SET_TRUE_FLAGS( <flags>, <ix>, <filt> )  the <ix>th set position in flags
+**                               caller is responsible for <ix> being in range
 */
-#define BLOCK_ELM_FLAGS(list, pos)      (BLOCKS_FLAGS(list)[((pos)-1) >> LBIPEB])
 
-
-/****************************************************************************
-**
-*F  MASK_POS_FLAGS( <pos> ) . . .  . .  bit mask for position of a flags list
-**
-**  'MASK_POS_FLAGS(<pos>)' returns a UInt with a single set  bit in position
-**  '(<pos>-1) % BIPEB',
-**  useful for accessing the <pos>-th element of a 'FLAGS' list.
-**
-**  Note that 'MASK_POS_FLAGS'  is a macro, so  do not call it with arguments
-**  that have side effects.
-*/
-#define MASK_POS_FLAGS(pos)             (((UInt) 1)<<(((pos)-1) & (BIPEB-1)))
-
+static inline void SET_TRUE_FLAGS(Obj flags, UInt ix, UInt filt) {
+    ((UInt2 *)(ADDR_OBJ(flags) +3))[ix] = (UInt2) filt ;
+}
 
 /****************************************************************************
 **
@@ -350,14 +338,13 @@ static inline UInt NRB_FLAGS(Obj flags)
 **  since the C compiler can't know that True != False. Using C_ELM_FLAGS
 **  gives slightly nicer C code and potential for a little more optimisation.
 */
-#define C_ELM_FLAGS(list, pos)                                               \
-    ((BLOCK_ELM_FLAGS(list, pos) & MASK_POS_FLAGS(pos)) ? 1 : 0)
+extern UInt C_ELM_FLAGS(Obj list, UInt pos);
 
 #define ELM_FLAGS(list, pos) (C_ELM_FLAGS(list, pos) ? True : False)
 
 static inline Int SAFE_C_ELM_FLAGS(Obj flags, UInt pos)
 {
-    return (pos <= LEN_FLAGS(flags)) ? C_ELM_FLAGS(flags, pos) : 0;
+    return C_ELM_FLAGS(flags, pos);
 }
 
 #define SAFE_ELM_FLAGS(list, pos) (SAFE_C_ELM_FLAGS(list, pos) ? True : False)

--- a/tst/testinstall/kernel/opers.tst
+++ b/tst/testinstall/kernel/opers.tst
@@ -13,7 +13,7 @@ gap> flags2 := FLAGS_FILTER(IsPGroup and IsMutable);
 gap> HASH_FLAGS(fail);
 Error, <flags> must be a flags list (not a boolean or fail)
 gap> HASH_FLAGS(flags);
-2
+82538043
 
 #
 gap> TRUES_FLAGS(fail);


### PR DESCRIPTION
As discussed elsewhere, this is an experimental PR which stores flags lists as lists of 16 bit indices of the set bits, rather than as a long bit vector. In this version, flags lists actually behave as kernel lists, equivalent to their TRUES_FLAGS so TRUES_FLAG is just x->x. The hope is that this is more cache-friendly and causes less garbage collection. At present, my quick experiments suggest that it slows down testinstall by a few percent, but reduces time spent in garbage collection.