### PR TITLE
Get rid of OBJ_LVAR_%dUP / ASS_LVAR_%dUP macros

### DIFF
--- a/hpcgap/src/c_oper1.c
+++ b/hpcgap/src/c_oper1.c
@@ -2257,7 +2257,7 @@ static Obj  HdlrFunc8 (
  l_found = t_1;
  
  /* for prop in props do */
- t_4 = OBJ_LVAR_1UP( 2 );
+ t_4 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_4, "props" )
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -2338,7 +2338,7 @@ static Obj  HdlrFunc8 (
  if ( t_1 ) {
   
   /* return getter( obj ); */
-  t_2 = OBJ_LVAR_1UP( 1 );
+  t_2 = OBJ_HVAR( (1 << 16) | 1 );
   CHECK_BOUND( t_2, "getter" )
   CHECK_FUNC( t_2 )
   t_1 = CALL_1ARGS( t_2, a_obj );
@@ -2794,7 +2794,7 @@ static Obj  HdlrFunc12 (
   
   /* Error( name, ": <p> must be a prime" ); */
   t_1 = GF_Error;
-  t_2 = OBJ_LVAR_1UP( 1 );
+  t_2 = OBJ_HVAR( (1 << 16) | 1 );
   CHECK_BOUND( t_2, "name" )
   t_3 = MakeString( ": <p> must be a prime" );
   CALL_2ARGS( t_1, t_2, t_3 );
@@ -2866,13 +2866,13 @@ static Obj  HdlrFunc14 (
  SET_BRK_CURR_STAT(0);
  
  /* keytest( key ); */
- t_1 = OBJ_LVAR_1UP( 2 );
+ t_1 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_1, "keytest" )
  CHECK_FUNC( t_1 )
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
- t_2 = OBJ_LVAR_1UP( 4 );
+ t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "attr" )
  CHECK_FUNC( t_2 )
  t_1 = CALL_1ARGS( t_2, a_D );
@@ -2900,7 +2900,7 @@ static Obj  HdlrFunc14 (
  if ( t_1 ) {
   
   /* erg := oper( D, key ); */
-  t_2 = OBJ_LVAR_1UP( 3 );
+  t_2 = OBJ_HVAR( (1 << 16) | 3 );
   CHECK_BOUND( t_2, "oper" )
   CHECK_FUNC( t_2 )
   t_1 = CALL_2ARGS( t_2, a_D, a_key );
@@ -3000,13 +3000,13 @@ static Obj  HdlrFunc15 (
  SET_BRK_CURR_STAT(0);
  
  /* keytest( key ); */
- t_1 = OBJ_LVAR_1UP( 2 );
+ t_1 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_1, "keytest" )
  CHECK_FUNC( t_1 )
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
- t_2 = OBJ_LVAR_1UP( 4 );
+ t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "attr" )
  CHECK_FUNC( t_2 )
  t_1 = CALL_1ARGS( t_2, a_D );
@@ -3075,13 +3075,13 @@ static Obj  HdlrFunc16 (
  SET_BRK_CURR_STAT(0);
  
  /* keytest( key ); */
- t_1 = OBJ_LVAR_1UP( 2 );
+ t_1 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_1, "keytest" )
  CHECK_FUNC( t_1 )
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
- t_2 = OBJ_LVAR_1UP( 4 );
+ t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "attr" )
  CHECK_FUNC( t_2 )
  t_1 = CALL_1ARGS( t_2, a_D );
@@ -3513,11 +3513,11 @@ static Obj  HdlrFunc18 (
  
  /* re := false; */
  t_1 = False;
- ASS_LVAR_1UP( 4, t_1 );
+ ASS_HVAR( (1 << 16) | 4, t_1 );
  
  /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
  t_6 = GF_LEN__LIST;
- t_7 = OBJ_LVAR_1UP( 2 );
+ t_7 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_7, "reqs" )
  t_5 = CALL_1ARGS( t_6, t_7 );
  CHECK_FUNC_RESULT( t_5 )
@@ -3541,18 +3541,18 @@ static Obj  HdlrFunc18 (
    if ( CALL_1ARGS( GF_IS_DONE_ITER, t_1 ) != False )  break;
    t_2 = CALL_1ARGS( GF_NEXT_ITER, t_1 );
   }
-  ASS_LVAR_1UP( 5, t_2 );
+  ASS_HVAR( (1 << 16) | 5, t_2 );
   
   /* re := re or IsBound( cond[i] ) and not Tester( cond[i] )( arg[i] ) and cond[i]( arg[i] ) and Tester( cond[i] )( arg[i] ); */
-  t_7 = OBJ_LVAR_1UP( 4 );
+  t_7 = OBJ_HVAR( (1 << 16) | 4 );
   CHECK_BOUND( t_7, "re" )
   CHECK_BOOL( t_7 )
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = (t_6 ? True : False);
   if ( t_5 == False ) {
-   t_12 = OBJ_LVAR_1UP( 3 );
+   t_12 = OBJ_HVAR( (1 << 16) | 3 );
    CHECK_BOUND( t_12, "cond" )
-   t_13 = OBJ_LVAR_1UP( 5 );
+   t_13 = OBJ_HVAR( (1 << 16) | 5 );
    CHECK_BOUND( t_13, "i" )
    CHECK_INT_POS( t_13 )
    t_11 = C_ISB_LIST( t_12, t_13 );
@@ -3560,16 +3560,16 @@ static Obj  HdlrFunc18 (
    t_9 = t_10;
    if ( t_9 ) {
     t_15 = GF_Tester;
-    t_17 = OBJ_LVAR_1UP( 3 );
+    t_17 = OBJ_HVAR( (1 << 16) | 3 );
     CHECK_BOUND( t_17, "cond" )
-    t_18 = OBJ_LVAR_1UP( 5 );
+    t_18 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_18, "i" )
     CHECK_INT_POS( t_18 )
     C_ELM_LIST_FPL( t_16, t_17, t_18 )
     t_14 = CALL_1ARGS( t_15, t_16 );
     CHECK_FUNC_RESULT( t_14 )
     CHECK_FUNC( t_14 )
-    t_16 = OBJ_LVAR_1UP( 5 );
+    t_16 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_16, "i" )
     CHECK_INT_POS( t_16 )
     C_ELM_LIST_FPL( t_15, a_arg, t_16 )
@@ -3582,14 +3582,14 @@ static Obj  HdlrFunc18 (
    }
    t_8 = t_9;
    if ( t_8 ) {
-    t_13 = OBJ_LVAR_1UP( 3 );
+    t_13 = OBJ_HVAR( (1 << 16) | 3 );
     CHECK_BOUND( t_13, "cond" )
-    t_14 = OBJ_LVAR_1UP( 5 );
+    t_14 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_14, "i" )
     CHECK_INT_POS( t_14 )
     C_ELM_LIST_FPL( t_12, t_13, t_14 )
     CHECK_FUNC( t_12 )
-    t_14 = OBJ_LVAR_1UP( 5 );
+    t_14 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_14, "i" )
     CHECK_INT_POS( t_14 )
     C_ELM_LIST_FPL( t_13, a_arg, t_14 )
@@ -3602,16 +3602,16 @@ static Obj  HdlrFunc18 (
    t_7 = t_8;
    if ( t_7 ) {
     t_12 = GF_Tester;
-    t_14 = OBJ_LVAR_1UP( 3 );
+    t_14 = OBJ_HVAR( (1 << 16) | 3 );
     CHECK_BOUND( t_14, "cond" )
-    t_15 = OBJ_LVAR_1UP( 5 );
+    t_15 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_15, "i" )
     CHECK_INT_POS( t_15 )
     C_ELM_LIST_FPL( t_13, t_14, t_15 )
     t_11 = CALL_1ARGS( t_12, t_13 );
     CHECK_FUNC_RESULT( t_11 )
     CHECK_FUNC( t_11 )
-    t_13 = OBJ_LVAR_1UP( 5 );
+    t_13 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_13, "i" )
     CHECK_INT_POS( t_13 )
     C_ELM_LIST_FPL( t_12, a_arg, t_13 )
@@ -3623,13 +3623,13 @@ static Obj  HdlrFunc18 (
    }
    t_5 = (t_7 ? True : False);
   }
-  ASS_LVAR_1UP( 4, t_5 );
+  ASS_HVAR( (1 << 16) | 4, t_5 );
   
  }
  /* od */
  
  /* if re then */
- t_2 = OBJ_LVAR_1UP( 4 );
+ t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "re" )
  CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -3637,7 +3637,7 @@ static Obj  HdlrFunc18 (
   
   /* return CallFuncList( oper, arg ); */
   t_2 = GF_CallFuncList;
-  t_3 = OBJ_LVAR_1UP( 1 );
+  t_3 = OBJ_HVAR( (1 << 16) | 1 );
   CHECK_BOUND( t_3, "oper" )
   t_1 = CALL_2ARGS( t_2, t_3, a_arg );
   CHECK_FUNC_RESULT( t_1 )

--- a/hpcgap/src/c_type1.c
+++ b/hpcgap/src/c_type1.c
@@ -312,7 +312,7 @@ static Obj  HdlrFunc4 (
  SET_BRK_CURR_STAT(0);
  
  /* obj!.(name) := val; */
- t_1 = OBJ_LVAR_1UP( 1 );
+ t_1 = OBJ_HVAR( (1 << 16) | 1 );
  CHECK_BOUND( t_1, "name" )
  if ( TNUM_OBJ(a_obj) == T_COMOBJ ) {
   AssPRec( a_obj, RNamObj(t_1), a_val );
@@ -327,7 +327,7 @@ static Obj  HdlrFunc4 (
  
  /* SetFilterObj( obj, tester ); */
  t_1 = GF_SetFilterObj;
- t_2 = OBJ_LVAR_1UP( 2 );
+ t_2 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_2, "tester" )
  CALL_2ARGS( t_1, a_obj, t_2 );
  

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -2206,7 +2206,7 @@ static Obj  HdlrFunc8 (
  l_found = t_1;
  
  /* for prop in props do */
- t_4 = OBJ_LVAR_1UP( 2 );
+ t_4 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_4, "props" )
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -2287,7 +2287,7 @@ static Obj  HdlrFunc8 (
  if ( t_1 ) {
   
   /* return getter( obj ); */
-  t_2 = OBJ_LVAR_1UP( 1 );
+  t_2 = OBJ_HVAR( (1 << 16) | 1 );
   CHECK_BOUND( t_2, "getter" )
   CHECK_FUNC( t_2 )
   t_1 = CALL_1ARGS( t_2, a_obj );
@@ -2731,7 +2731,7 @@ static Obj  HdlrFunc12 (
   
   /* Error( name, ": <p> must be a prime" ); */
   t_1 = GF_Error;
-  t_2 = OBJ_LVAR_1UP( 1 );
+  t_2 = OBJ_HVAR( (1 << 16) | 1 );
   CHECK_BOUND( t_2, "name" )
   t_3 = MakeString( ": <p> must be a prime" );
   CALL_2ARGS( t_1, t_2, t_3 );
@@ -2803,13 +2803,13 @@ static Obj  HdlrFunc14 (
  SET_BRK_CURR_STAT(0);
  
  /* keytest( key ); */
- t_1 = OBJ_LVAR_1UP( 2 );
+ t_1 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_1, "keytest" )
  CHECK_FUNC( t_1 )
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
- t_2 = OBJ_LVAR_1UP( 4 );
+ t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "attr" )
  CHECK_FUNC( t_2 )
  t_1 = CALL_1ARGS( t_2, a_D );
@@ -2837,7 +2837,7 @@ static Obj  HdlrFunc14 (
  if ( t_1 ) {
   
   /* erg := oper( D, key ); */
-  t_2 = OBJ_LVAR_1UP( 3 );
+  t_2 = OBJ_HVAR( (1 << 16) | 3 );
   CHECK_BOUND( t_2, "oper" )
   CHECK_FUNC( t_2 )
   t_1 = CALL_2ARGS( t_2, a_D, a_key );
@@ -2937,13 +2937,13 @@ static Obj  HdlrFunc15 (
  SET_BRK_CURR_STAT(0);
  
  /* keytest( key ); */
- t_1 = OBJ_LVAR_1UP( 2 );
+ t_1 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_1, "keytest" )
  CHECK_FUNC( t_1 )
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
- t_2 = OBJ_LVAR_1UP( 4 );
+ t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "attr" )
  CHECK_FUNC( t_2 )
  t_1 = CALL_1ARGS( t_2, a_D );
@@ -3012,13 +3012,13 @@ static Obj  HdlrFunc16 (
  SET_BRK_CURR_STAT(0);
  
  /* keytest( key ); */
- t_1 = OBJ_LVAR_1UP( 2 );
+ t_1 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_1, "keytest" )
  CHECK_FUNC( t_1 )
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
- t_2 = OBJ_LVAR_1UP( 4 );
+ t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "attr" )
  CHECK_FUNC( t_2 )
  t_1 = CALL_1ARGS( t_2, a_D );
@@ -3438,11 +3438,11 @@ static Obj  HdlrFunc18 (
  
  /* re := false; */
  t_1 = False;
- ASS_LVAR_1UP( 4, t_1 );
+ ASS_HVAR( (1 << 16) | 4, t_1 );
  
  /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
  t_6 = GF_LEN__LIST;
- t_7 = OBJ_LVAR_1UP( 2 );
+ t_7 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_7, "reqs" )
  t_5 = CALL_1ARGS( t_6, t_7 );
  CHECK_FUNC_RESULT( t_5 )
@@ -3466,18 +3466,18 @@ static Obj  HdlrFunc18 (
    if ( CALL_1ARGS( GF_IS_DONE_ITER, t_1 ) != False )  break;
    t_2 = CALL_1ARGS( GF_NEXT_ITER, t_1 );
   }
-  ASS_LVAR_1UP( 5, t_2 );
+  ASS_HVAR( (1 << 16) | 5, t_2 );
   
   /* re := re or IsBound( cond[i] ) and not Tester( cond[i] )( arg[i] ) and cond[i]( arg[i] ) and Tester( cond[i] )( arg[i] ); */
-  t_7 = OBJ_LVAR_1UP( 4 );
+  t_7 = OBJ_HVAR( (1 << 16) | 4 );
   CHECK_BOUND( t_7, "re" )
   CHECK_BOOL( t_7 )
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = (t_6 ? True : False);
   if ( t_5 == False ) {
-   t_12 = OBJ_LVAR_1UP( 3 );
+   t_12 = OBJ_HVAR( (1 << 16) | 3 );
    CHECK_BOUND( t_12, "cond" )
-   t_13 = OBJ_LVAR_1UP( 5 );
+   t_13 = OBJ_HVAR( (1 << 16) | 5 );
    CHECK_BOUND( t_13, "i" )
    CHECK_INT_POS( t_13 )
    t_11 = C_ISB_LIST( t_12, t_13 );
@@ -3485,16 +3485,16 @@ static Obj  HdlrFunc18 (
    t_9 = t_10;
    if ( t_9 ) {
     t_15 = GF_Tester;
-    t_17 = OBJ_LVAR_1UP( 3 );
+    t_17 = OBJ_HVAR( (1 << 16) | 3 );
     CHECK_BOUND( t_17, "cond" )
-    t_18 = OBJ_LVAR_1UP( 5 );
+    t_18 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_18, "i" )
     CHECK_INT_POS( t_18 )
     C_ELM_LIST_FPL( t_16, t_17, t_18 )
     t_14 = CALL_1ARGS( t_15, t_16 );
     CHECK_FUNC_RESULT( t_14 )
     CHECK_FUNC( t_14 )
-    t_16 = OBJ_LVAR_1UP( 5 );
+    t_16 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_16, "i" )
     CHECK_INT_POS( t_16 )
     C_ELM_LIST_FPL( t_15, a_arg, t_16 )
@@ -3507,14 +3507,14 @@ static Obj  HdlrFunc18 (
    }
    t_8 = t_9;
    if ( t_8 ) {
-    t_13 = OBJ_LVAR_1UP( 3 );
+    t_13 = OBJ_HVAR( (1 << 16) | 3 );
     CHECK_BOUND( t_13, "cond" )
-    t_14 = OBJ_LVAR_1UP( 5 );
+    t_14 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_14, "i" )
     CHECK_INT_POS( t_14 )
     C_ELM_LIST_FPL( t_12, t_13, t_14 )
     CHECK_FUNC( t_12 )
-    t_14 = OBJ_LVAR_1UP( 5 );
+    t_14 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_14, "i" )
     CHECK_INT_POS( t_14 )
     C_ELM_LIST_FPL( t_13, a_arg, t_14 )
@@ -3527,16 +3527,16 @@ static Obj  HdlrFunc18 (
    t_7 = t_8;
    if ( t_7 ) {
     t_12 = GF_Tester;
-    t_14 = OBJ_LVAR_1UP( 3 );
+    t_14 = OBJ_HVAR( (1 << 16) | 3 );
     CHECK_BOUND( t_14, "cond" )
-    t_15 = OBJ_LVAR_1UP( 5 );
+    t_15 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_15, "i" )
     CHECK_INT_POS( t_15 )
     C_ELM_LIST_FPL( t_13, t_14, t_15 )
     t_11 = CALL_1ARGS( t_12, t_13 );
     CHECK_FUNC_RESULT( t_11 )
     CHECK_FUNC( t_11 )
-    t_13 = OBJ_LVAR_1UP( 5 );
+    t_13 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_13, "i" )
     CHECK_INT_POS( t_13 )
     C_ELM_LIST_FPL( t_12, a_arg, t_13 )
@@ -3548,13 +3548,13 @@ static Obj  HdlrFunc18 (
    }
    t_5 = (t_7 ? True : False);
   }
-  ASS_LVAR_1UP( 4, t_5 );
+  ASS_HVAR( (1 << 16) | 4, t_5 );
   
  }
  /* od */
  
  /* if re then */
- t_2 = OBJ_LVAR_1UP( 4 );
+ t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "re" )
  CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -3562,7 +3562,7 @@ static Obj  HdlrFunc18 (
   
   /* return CallFuncList( oper, arg ); */
   t_2 = GF_CallFuncList;
-  t_3 = OBJ_LVAR_1UP( 1 );
+  t_3 = OBJ_HVAR( (1 << 16) | 1 );
   CHECK_BOUND( t_3, "oper" )
   t_1 = CALL_2ARGS( t_2, t_3, a_arg );
   CHECK_FUNC_RESULT( t_1 )

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -279,7 +279,7 @@ static Obj  HdlrFunc4 (
  SET_BRK_CURR_STAT(0);
  
  /* obj!.(name) := val; */
- t_1 = OBJ_LVAR_1UP( 1 );
+ t_1 = OBJ_HVAR( (1 << 16) | 1 );
  CHECK_BOUND( t_1, "name" )
  if ( TNUM_OBJ(a_obj) == T_COMOBJ ) {
   AssPRec( a_obj, RNamObj(t_1), a_val );
@@ -294,7 +294,7 @@ static Obj  HdlrFunc4 (
  
  /* SetFilterObj( obj, tester ); */
  t_1 = GF_SetFilterObj;
- t_2 = OBJ_LVAR_1UP( 2 );
+ t_2 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_2, "tester" )
  CALL_2ARGS( t_1, a_obj, t_2 );
  

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -119,26 +119,6 @@ typedef UInt    RNam;
 #define SWITCH_TO_NEW_FRAME     SWITCH_TO_NEW_LVARS
 #define SWITCH_TO_OLD_FRAME     SWITCH_TO_OLD_LVARS
 
-#define OBJ_LVAR_0UP(lvar)      OBJ_LVAR(lvar)
-#define OBJ_LVAR_1UP(lvar)      OBJ_HVAR((1<<16) | lvar)
-#define OBJ_LVAR_2UP(lvar)      OBJ_HVAR((2<<16) | lvar)
-#define OBJ_LVAR_3UP(lvar)      OBJ_HVAR((3<<16) | lvar)
-#define OBJ_LVAR_4UP(lvar)      OBJ_HVAR((4<<16) | lvar)
-#define OBJ_LVAR_5UP(lvar)      OBJ_HVAR((5<<16) | lvar)
-#define OBJ_LVAR_6UP(lvar)      OBJ_HVAR((6<<16) | lvar)
-#define OBJ_LVAR_7UP(lvar)      OBJ_HVAR((7<<16) | lvar)
-#define OBJ_LVAR_8UP(lvar)      OBJ_HVAR((8<<16) | lvar)
-
-#define ASS_LVAR_0UP(lvar,obj)  ASS_LVAR(lvar, obj)
-#define ASS_LVAR_1UP(lvar,obj)  ASS_HVAR((1<<16) | lvar, obj);
-#define ASS_LVAR_2UP(lvar,obj)  ASS_HVAR((2<<16) | lvar, obj);
-#define ASS_LVAR_3UP(lvar,obj)  ASS_HVAR((3<<16) | lvar, obj);
-#define ASS_LVAR_4UP(lvar,obj)  ASS_HVAR((4<<16) | lvar, obj);
-#define ASS_LVAR_5UP(lvar,obj)  ASS_HVAR((5<<16) | lvar, obj);
-#define ASS_LVAR_6UP(lvar,obj)  ASS_HVAR((6<<16) | lvar, obj);
-#define ASS_LVAR_7UP(lvar,obj)  ASS_HVAR((7<<16) | lvar, obj);
-#define ASS_LVAR_8UP(lvar,obj)  ASS_HVAR((8<<16) | lvar, obj);
-
 
 /* objects, should into 'objects.c'  * * * * * * * * * * * * * * * * * * * */
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2925,7 +2925,7 @@ CVar CompRefHVar (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* emit the code to get the value                                      */
-    Emit( "%c = OBJ_LVAR_%dUP( %d );\n",
+    Emit( "%c = OBJ_HVAR( (%d << 16) | %d );\n",
           val, GetLevlHVar(hvar), GetIndxHVar(hvar) );
 
     /* emit the code to check that the variable has a value                */
@@ -2956,7 +2956,7 @@ CVar CompIsbHVar (
     isb = CVAR_TEMP( NewTemp( "isb" ) );
 
     /* emit the code to get the value                                      */
-    Emit( "%c = OBJ_LVAR_%dUP( %d );\n",
+    Emit( "%c = OBJ_HVAR( (%d << 16) | %d );\n",
           val, GetLevlHVar(hvar), GetIndxHVar(hvar) );
 
     /* emit the code to check that the variable has a value                */
@@ -4225,7 +4225,7 @@ void CompFor (
                   GetIndxHVar(var), elm );
         }
         else if ( vart == 'h' ) {
-            Emit( "ASS_LVAR_%dUP( %d, %c );\n",
+            Emit( "ASS_HVAR( (%d << 16) | %d, %c );\n",
                   GetLevlHVar(var), GetIndxHVar(var), elm );
         }
         else if ( vart == 'g' ) {
@@ -4538,7 +4538,7 @@ void CompAssHVar (
     /* emit the code for the assignment                                    */
     hvar = (HVar)(ADDR_STAT(stat)[0]);
     CompSetUseHVar( hvar );
-    Emit( "ASS_LVAR_%dUP( %d, %c );\n",
+    Emit( "ASS_HVAR( (%d << 16) | %d, %c );\n",
           GetLevlHVar(hvar), GetIndxHVar(hvar), rhs );
 
     /* free the temporary                                                  */
@@ -4563,7 +4563,7 @@ void CompUnbHVar (
     /* emit the code for the assignment                                    */
     hvar = (HVar)(ADDR_STAT(stat)[0]);
     CompSetUseHVar( hvar );
-    Emit( "ASS_LVAR_%dUP( %d, 0 );\n",
+    Emit( "ASS_HVAR( (%d << 16) | %d, 0 );\n",
           GetLevlHVar(hvar), GetIndxHVar(hvar) );
 }
 


### PR DESCRIPTION
This removes a limitation in the compiler on the nesting level of higher functions.