### PR TITLE
Fix regenerate_error_tests.sh to work with POSIX sed

### DIFF
--- a/tst/test-error/run_gap.sh
+++ b/tst/test-error/run_gap.sh
@@ -14,6 +14,7 @@ outfile="$3"
 # 3) Rewrite the root of gap with the string GAPROOT,
 #    so the output is usable on other machines
 GAPROOT=$(cd ../..; pwd)
-( echo "LogTo(\"$outfile\");" ; cat "$gfile" ; echo "QUIT;" ) |
+( echo "LogTo(\"${outfile}.tmp\");" ; cat "$gfile" ; echo "QUIT;" ) |
     "$gap" -r -A -b -x 200 2>/dev/null >/dev/null
-sed -i -e "s:${GAPROOT//:/\\:}:GAPROOT:g" "$outfile"
+sed "s:${GAPROOT//:/\\:}:GAPROOT:g" < "${outfile}.tmp" >"${outfile}"
+rm "${outfile}.tmp"


### PR DESCRIPTION
The `-i` option for sed is not part of POSIX, and its semantics differ between
GNU sed (as usually shipped with Linux distros) and BSD sed (as shipped with
macOS). Other sed implementations may not support it at all. Hence, we change
regenerate_error_tests.sh to not use it, by instead creating a temporary
file, and feeding that through sed into the final file.