### PR TITLE
IsIteratorByFunctionsRep should become IsNonAtomicComponentObjectRep

### DIFF
--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -876,9 +876,15 @@ InstallOtherMethod( NextIterator,
 ##
 #F  IteratorByFunctions( <record> )
 ##
+if IsHPCGAP then
+DeclareRepresentation( "IsIteratorByFunctionsRep", IsNonAtomicComponentObjectRep,
+    [ "NextIterator", "IsDoneIterator", "ShallowCopy",
+    , "ViewObj", "PrintObj"] );
+else
 DeclareRepresentation( "IsIteratorByFunctionsRep", IsComponentObjectRep,
     [ "NextIterator", "IsDoneIterator", "ShallowCopy",
     , "ViewObj", "PrintObj"] );
+fi;
 
 DeclareSynonym( "IsIteratorByFunctions",
     IsIteratorByFunctionsRep and IsIterator );


### PR DESCRIPTION
We are using hpcgap to pop so-called recursive iterators using multiple threads. A recursive iterator is one which either produces a leaf or another recursive iterator. @rbehrends suggested this patch for his hpcgap-code to work.