### PR TITLE
Cleanup stacks in pc group collection code

### DIFF
--- a/src/objccoll-impl.h
+++ b/src/objccoll-impl.h
@@ -204,40 +204,36 @@ Int CombiCollectWord ( Obj sc, Obj vv, Obj w )
     max = STATE(SC_MAX_STACK_SIZE);
 
     /* ensure that the stacks are large enough                             */
-    if ( SIZE_OBJ(vnw)/sizeof(Obj) < max+1 ) {
-        ResizeBag( vnw, sizeof(Obj)*(max+1) );
-        RetypeBag( vnw, T_STRING );
+    const UInt desiredStackSize = sizeof(Obj) * (max + 2);
+    if ( SIZE_OBJ(vnw) < desiredStackSize ) {
+        ResizeBag( vnw, desiredStackSize );
         resized = 1;
     }
-    if ( SIZE_OBJ(vlw)/sizeof(Obj) < max+1 ) {
-        ResizeBag( vlw, sizeof(Obj)*(max+1) );
-        RetypeBag( vlw, T_STRING );
+    if ( SIZE_OBJ(vlw) < desiredStackSize ) {
+        ResizeBag( vlw, desiredStackSize );
         resized = 1;
     }
-    if ( SIZE_OBJ(vpw)/sizeof(Obj) < max+1 ) {
-        ResizeBag( vpw, sizeof(Obj)*(max+1) );
-        RetypeBag( vpw, T_STRING );
+    if ( SIZE_OBJ(vpw) < desiredStackSize ) {
+        ResizeBag( vpw, desiredStackSize );
         resized = 1;
     }
-    if ( SIZE_OBJ(vew)/sizeof(Obj) < max+1 ) {
-        ResizeBag( vew, sizeof(Obj)*(max+1) );
-        RetypeBag( vew, T_STRING );
+    if ( SIZE_OBJ(vew) < desiredStackSize ) {
+        ResizeBag( vew, desiredStackSize );
         resized = 1;
     }
-    if ( SIZE_OBJ(vge)/sizeof(Obj) < max+1 ) {
-        ResizeBag( vge, sizeof(Obj)*(max+1) );
-        RetypeBag( vge, T_STRING );
+    if ( SIZE_OBJ(vge) < desiredStackSize ) {
+        ResizeBag( vge, desiredStackSize );
         resized = 1;
     }
     if( resized ) return -1;
 
     /* from now on we use addresses instead of handles most of the time    */
     v  = (Int*)ADDR_OBJ(vv);
-    nw = (UIntN**)ADDR_OBJ(vnw);
-    lw = (UIntN**)ADDR_OBJ(vlw);
-    pw = (UIntN**)ADDR_OBJ(vpw);
-    ew = (UIntN*)ADDR_OBJ(vew);
-    ge = (Int*)ADDR_OBJ(vge);
+    nw = (UIntN**)(ADDR_OBJ(vnw)+1);
+    lw = (UIntN**)(ADDR_OBJ(vlw)+1);
+    pw = (UIntN**)(ADDR_OBJ(vpw)+1);
+    ew = (UIntN*)(ADDR_OBJ(vew)+1);
+    ge = (Int*)(ADDR_OBJ(vge)+1);
 
     /* conjugates, powers, order, generators, avector, inverses            */
     vpow = SC_POWERS(sc);

--- a/src/objcftl.h
+++ b/src/objcftl.h
@@ -27,13 +27,34 @@
 #define PC_DEEP_THOUGHT_BOUND       13
 #define PC_ORDERS                   14
 
+// TODO: the following stack related positions are not
+// used anymore by CollectPolycyc, and will not be used
+// anymore in future releases of the polycyclic package.
+// We should phase them out for GAP 4.10.
 #define PC_WORD_STACK               15
 #define PC_STACK_SIZE               16
 #define PC_WORD_EXPONENT_STACK      17
 #define PC_SYLLABLE_STACK           18
 #define PC_EXPONENT_STACK           19
 #define PC_STACK_POINTER            20
+// TODO: end obsolete
+
 #define PC_DEFAULT_TYPE             21
+
+/* the following are defined in polycyclic:
+
+#define PC_PCP_ELEMENTS_FAMILY          22
+#define PC_PCP_ELEMENTS_TYPE            23
+
+#define PC_COMMUTATORS                  24
+#define PC_INVERSECOMMUTATORS           25
+#define PC_COMMUTATORSINVERSE           26
+#define PC_INVERSECOMMUTATORSINVERSE    27
+
+#define PC_NILPOTENT_COMMUTE            28
+#define PC_WEIGHTS                      29
+#define PC_ABELIAN_START                30
+*/
 
 /****************************************************************************
 **

--- a/src/objscoll-impl.h
+++ b/src/objscoll-impl.h
@@ -268,42 +268,38 @@ Int SingleCollectWord ( Obj sc, Obj vv, Obj w )
     max = STATE(SC_MAX_STACK_SIZE);
 
     /* ensure that the stacks are large enough                             */
-    if ( SIZE_OBJ(vnw)/sizeof(Obj) < max+1 ) {
-        ResizeBag( vnw, sizeof(Obj)*(max+1) );
-        RetypeBag( vnw, T_STRING );
+    const UInt desiredStackSize = sizeof(Obj) * (max + 2);
+    if ( SIZE_OBJ(vnw) < desiredStackSize ) {
+        ResizeBag( vnw, desiredStackSize );
         resized = 1;
     }
-    if ( SIZE_OBJ(vlw)/sizeof(Obj) < max+1 ) {
-        ResizeBag( vlw, sizeof(Obj)*(max+1) );
-        RetypeBag( vlw, T_STRING );
+    if ( SIZE_OBJ(vlw) < desiredStackSize ) {
+        ResizeBag( vlw, desiredStackSize );
         resized = 1;
     }
-    if ( SIZE_OBJ(vpw)/sizeof(Obj) < max+1 ) {
-        ResizeBag( vpw, sizeof(Obj)*(max+1) );
-        RetypeBag( vpw, T_STRING );
+    if ( SIZE_OBJ(vpw) < desiredStackSize ) {
+        ResizeBag( vpw, desiredStackSize );
         resized = 1;
     }
-    if ( SIZE_OBJ(vew)/sizeof(Obj) < max+1 ) {
-        ResizeBag( vew, sizeof(Obj)*(max+1) );
-        RetypeBag( vew, T_STRING );
+    if ( SIZE_OBJ(vew) < desiredStackSize ) {
+        ResizeBag( vew, desiredStackSize );
         resized = 1;
     }
-    if ( SIZE_OBJ(vge)/sizeof(Obj) < max+1 ) {
-        ResizeBag( vge, sizeof(Obj)*(max+1) );
-        RetypeBag( vge, T_STRING );
+    if ( SIZE_OBJ(vge) < desiredStackSize ) {
+        ResizeBag( vge, desiredStackSize );
         resized = 1;
     }
     if( resized ) return -1;
 
     /* from now on we use addresses instead of handles most of the time    */
     v  = (Int*)ADDR_OBJ(vv);
-    nw = (UIntN**)ADDR_OBJ(vnw);
-    lw = (UIntN**)ADDR_OBJ(vlw);
-    pw = (UIntN**)ADDR_OBJ(vpw);
-    ew = (UIntN*)ADDR_OBJ(vew);
-    ge = (Int*)ADDR_OBJ(vge);
+    nw = (UIntN**)(ADDR_OBJ(vnw)+1);
+    lw = (UIntN**)(ADDR_OBJ(vlw)+1);
+    pw = (UIntN**)(ADDR_OBJ(vpw)+1);
+    ew = (UIntN*)(ADDR_OBJ(vew)+1);
+    ge = (Int*)(ADDR_OBJ(vge)+1);
 
-    /* conjujagtes, powers, order, generators, avector, inverses           */
+    /* conjuagtes, powers, order, generators, avector, inverses           */
     vpow = SC_POWERS(sc);
     lpow = LEN_PLIST(vpow);
     pow  = CONST_ADDR_OBJ(vpow);

--- a/src/objscoll.c
+++ b/src/objscoll.c
@@ -799,16 +799,6 @@ static Int InitLibrary (
 
 static void InitModuleState(ModuleStateOffset offset)
 {
-    const UInt maxStackSize = 256;
-    STATE(SC_NW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
-    STATE(SC_LW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
-    STATE(SC_PW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
-    STATE(SC_EW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
-    STATE(SC_GE_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
-    STATE(SC_CW_VECTOR) = NEW_STRING(0);
-    STATE(SC_CW2_VECTOR) = NEW_STRING(0);
-    STATE(SC_MAX_STACK_SIZE) = maxStackSize;
-
 #ifndef HPCGAP
     InitGlobalBag( &STATE(SC_NW_STACK), "SC_NW_STACK" );
     InitGlobalBag( &STATE(SC_LW_STACK), "SC_LW_STACK" );
@@ -818,6 +808,16 @@ static void InitModuleState(ModuleStateOffset offset)
     InitGlobalBag( &STATE(SC_CW_VECTOR), "SC_CW_VECTOR" );
     InitGlobalBag( &STATE(SC_CW2_VECTOR), "SC_CW2_VECTOR" );
 #endif
+
+    const UInt maxStackSize = 256;
+    STATE(SC_NW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
+    STATE(SC_LW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
+    STATE(SC_PW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
+    STATE(SC_EW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
+    STATE(SC_GE_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
+    STATE(SC_CW_VECTOR) = NEW_STRING(0);
+    STATE(SC_CW2_VECTOR) = NEW_STRING(0);
+    STATE(SC_MAX_STACK_SIZE) = maxStackSize;
 }
 
 /****************************************************************************

--- a/src/objscoll.c
+++ b/src/objscoll.c
@@ -40,6 +40,8 @@
 *F * * * * * * * * * * * * local defines and typedefs * * * * * * * * * * * *
 */
 
+static Obj TYPE_KERNEL_OBJECT;
+
 /****************************************************************************
 **
 *T  FinPowConjCol
@@ -724,19 +726,6 @@ static StructGVarFunc GVarFuncs [] = {
 };
 
 
-/*
- * Allocate a Plist of the given length, pre-allocating
- * the number of entries given by 'reserved'.
- */
-static inline Obj NewPlist( UInt tnum, UInt len, UInt reserved )
-{
-    Obj obj;
-    obj = NEW_PLIST( tnum, reserved );
-    SET_LEN_PLIST( obj, len );
-    return obj;
-}
-
-
 /****************************************************************************
 **
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
@@ -746,6 +735,8 @@ static Int InitKernel (
 {
     /* init filters and functions                                          */
     InitHdlrFuncsFromTable( GVarFuncs );
+
+    ImportGVarFromLibrary( "TYPE_KERNEL_OBJECT", &TYPE_KERNEL_OBJECT );
 
     /* return success                                                      */
     return 0;
@@ -810,11 +801,19 @@ static void InitModuleState(ModuleStateOffset offset)
 #endif
 
     const UInt maxStackSize = 256;
-    STATE(SC_NW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
-    STATE(SC_LW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
-    STATE(SC_PW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
-    STATE(SC_EW_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
-    STATE(SC_GE_STACK) = NewPlist(T_PLIST_EMPTY, 0, maxStackSize);
+    const UInt desiredStackSize = sizeof(Obj) * (maxStackSize + 2);
+    STATE(SC_NW_STACK) = NewBag(T_DATOBJ, desiredStackSize);
+    STATE(SC_LW_STACK) = NewBag(T_DATOBJ, desiredStackSize);
+    STATE(SC_PW_STACK) = NewBag(T_DATOBJ, desiredStackSize);
+    STATE(SC_EW_STACK) = NewBag(T_DATOBJ, desiredStackSize);
+    STATE(SC_GE_STACK) = NewBag(T_DATOBJ, desiredStackSize);
+
+    SET_TYPE_DATOBJ(STATE(SC_NW_STACK), TYPE_KERNEL_OBJECT);
+    SET_TYPE_DATOBJ(STATE(SC_LW_STACK), TYPE_KERNEL_OBJECT);
+    SET_TYPE_DATOBJ(STATE(SC_PW_STACK), TYPE_KERNEL_OBJECT);
+    SET_TYPE_DATOBJ(STATE(SC_EW_STACK), TYPE_KERNEL_OBJECT);
+    SET_TYPE_DATOBJ(STATE(SC_GE_STACK), TYPE_KERNEL_OBJECT);
+
     STATE(SC_CW_VECTOR) = NEW_STRING(0);
     STATE(SC_CW2_VECTOR) = NEW_STRING(0);
     STATE(SC_MAX_STACK_SIZE) = maxStackSize;


### PR DESCRIPTION
The first commit is motivated by the Julia GC work: the classic pc group collected code in the kernel (ab)used T_PLIST_EMPTY resp. T_STRING objects to store various stacks, but overwrote the length slot with garbage in the process. We change it to use a T_DATOBJ, and take care not to overwrite its type slot.

The second commit adds in-kernel stacks for the "new" pc(p) group collector, used by the polycyclic package. Right now, every pcp group collector has its own set of stacks, resulting in collector objects which are several hundred kilobytes big. This is a crazy waste if you have many collectors around.

TODO: more tests; and in order to allow polycyclic to smoothly transition away from the stacks-in-collectors, we need to add a way for it to find out when it can do that. I guess I'll just add a constant `NO_STACKS_INSIDE_COLLECTORS` or so, and then make a polycyclic release using it to disable the stack if it is set to true. And once that happened, we can think about removing the relevant constants like `PC_WORD_EXPONENT_STACK` from the kernel...