### PR TITLE
WIP: Reformat Flags Lists 2

### DIFF
--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -539,6 +539,7 @@ BIND_GLOBAL( "InstallSubsetMaintenance",
           triple,         # loop over `SUBSET_MAINTAINED_INFO[2]'
           req,
           flag,
+          flags,
           filt1,
           filt2,
           i;
@@ -552,10 +553,12 @@ BIND_GLOBAL( "InstallSubsetMaintenance",
     # (We must not call `SUBTR_SET' here because the lists types may be
     # not yet defined.)
     filtssub:= [];
-    for flag in TRUES_FLAGS( FLAGS_FILTER( sub_req ) ) do
-      if not INFO_FILTERS[flag] in FNUM_CATS_AND_REPS then
-        ADD_LIST_DEFAULT( filtssub, flag );
-      fi;
+    flags := FLAGS_FILTER(sub_req);    
+    for i in [1..SIZE_FLAGS(flags)] do
+        flag := TRUE_FLAGS(flags, i);
+        if not INFO_FILTERS[flag] in FNUM_CATS_AND_REPS then
+            ADD_LIST_DEFAULT( filtssub, flag );
+        fi;
     od;
 
     for triple in SUBSET_MAINTAINED_INFO[2] do
@@ -588,10 +591,11 @@ BIND_GLOBAL( "InstallSubsetMaintenance",
     # (We must not call `SUBTR_SET' here because the lists types may be
     # not yet defined.)
     filtsopr:= [];
-    for flag in TRUES_FLAGS( filt1 ) do
-      if not INFO_FILTERS[flag] in FNUM_CATS_AND_REPS then
-        ADD_LIST_DEFAULT( filtsopr, flag );
-      fi;
+    for i in [1..SIZE_FLAGS(filt1)] do
+        flag := TRUE_FLAGS(filt1, i);
+        if not INFO_FILTERS[flag] in FNUM_CATS_AND_REPS then
+            ADD_LIST_DEFAULT( filtsopr, flag );
+        fi;
     od;
     for triple in SUBSET_MAINTAINED_INFO[2] do
       req:= SHALLOW_COPY_OBJ( filtsopr );

--- a/lib/filter.g
+++ b/lib/filter.g
@@ -85,6 +85,15 @@ BIND_GLOBAL( "FNUM_CATS_AND_REPS", MakeImmutable([ 1 .. 4 ]) );
 IMM_FLAGS := FLAGS_FILTER( IS_OBJECT );
 #T EMPTY_FLAGS not yet defined !
 
+#############################################################################
+##
+#V  TRUES_FLAGS 
+##
+## This was a kernel function, but APPEND_TRUES_FLAGS has superceded it
+## included here for backwards compatibilty
+##
+
+BIND_GLOBAL( "TRUES_FLAGS", flags -> APPEND_TRUES_FLAGS([], flags));
 
 #############################################################################
 ##
@@ -161,7 +170,7 @@ BIND_GLOBAL( "InstallTrueMethodNewFilter", function ( tofilt, from )
         if IS_AND_FILTER(from) then
           ADD_LIST( IMPLICATIONS_COMPOSED, imp );
         else
-          IMPLICATIONS_SIMPLE[ TRUES_FLAGS( imp[2] )[1] ]:= imp;
+          IMPLICATIONS_SIMPLE[ TRUE_FLAGS( imp[2], 1) ]:= imp;
         fi;
       fi;
     od;
@@ -401,6 +410,7 @@ BIND_GLOBAL("NICE_FLAGS",QUO_INT(SUM_FLAGS,30));
 BIND_GLOBAL( "CANONICAL_BASIS_FLAGS", QUO_INT(SUM_FLAGS,5) );
 
 
+
 #############################################################################
 ##
 #F  RankFilter( <filter> )  . . . . . . . . . . . . . . . .  rank of a filter
@@ -408,7 +418,7 @@ BIND_GLOBAL( "CANONICAL_BASIS_FLAGS", QUO_INT(SUM_FLAGS,5) );
 ##  Compute the rank including the hidden implications.
 ##
 BIND_GLOBAL( "RankFilter", function( filter )
-    local   rank,  flags,  i;
+    local   rank,  flags,  flags1, i, j;
 
     rank  := 0;
     if IS_FUNCTION(filter)  then
@@ -416,7 +426,9 @@ BIND_GLOBAL( "RankFilter", function( filter )
     else
         flags := filter;
     fi;
-    for i  in TRUES_FLAGS(WITH_HIDDEN_IMPS_FLAGS(flags))  do
+    flags1 := WITH_HIDDEN_IMPS_FLAGS(flags);    
+    for j in [1..SIZE_FLAGS(flags1)] do
+        i := TRUE_FLAGS(flags1, j);
         if IsBound(RANK_FILTERS[i])  then
             rank := rank + RANK_FILTERS[i];
         else

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -270,7 +270,8 @@ BIND_GLOBAL( "INSTALL_IMMEDIATE_METHOD",
             k,
             replace,
             pos,
-            imm;
+            imm, 
+            x;
 
     # Check whether <oper> really is an operation.
     if not IS_OPERATION(oper)  then
@@ -285,14 +286,15 @@ BIND_GLOBAL( "INSTALL_IMMEDIATE_METHOD",
     fi;
 
     # Find the requirements.
-    flags := TRUES_FLAGS( FLAGS_FILTER( filter ) );
-    if LEN_LIST( flags ) = 0 then
+    flags := FLAGS_FILTER( filter ) ;
+    if SIZE_FLAGS( flags ) = 0 then
         Error( "no immediate methods without requirements!" );
-    elif FLAG1_FILTER( IS_MUTABLE_OBJ ) in flags  then
+    elif FLAGS_CONTAINS_FILTER( flags, FLAG1_FILTER(IS_MUTABLE_OBJ) )  then
         Error( "no immediate methods for mutable objects!" );
     fi;
     relev := [];
-    for i  in flags  do
+    for j in [1..SIZE_FLAGS(flags)] do
+        i := TRUE_FLAGS(flags,j);
         if not INFO_FILTERS[i] in FNUM_CATS_AND_REPS  then
             ADD_LIST( relev, i );
         fi;
@@ -301,7 +303,7 @@ BIND_GLOBAL( "INSTALL_IMMEDIATE_METHOD",
     # All requirements are categories/representations.
     # Install the method for one of them.
     if LEN_LIST( relev ) = 0  then
-        relev:= [ flags[1] ];
+        relev:= [ TRUE_FLAGS(flags,1) ];
     fi;
     flags:= relev;
 
@@ -312,7 +314,7 @@ BIND_GLOBAL( "INSTALL_IMMEDIATE_METHOD",
     # to another one with a bigger number.)
     relev  := [];
     rflags := [];
-    for i  in flags  do
+    for i in flags do
 
       # Get the implications of this filter.
       wif:= WITH_IMPS_FLAGS( FLAGS_FILTER( FILTERS[i] ) );

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -47,7 +47,7 @@ BIND_GLOBAL( "RunImmediateMethods", function ( obj, flags )
     if IS_SUBSET_FLAGS( IMM_FLAGS, flags ) then return; fi;
     flags := SUB_FLAGS( flags, IMM_FLAGS );
 
-    flagspos := SHALLOW_COPY_OBJ(TRUES_FLAGS(flags));
+    flagspos := TRUES_FLAGS(flags);
     tried    := [];
     type     := TYPE_OBJ( obj );
     flags    := type![2];
@@ -111,8 +111,7 @@ BIND_GLOBAL( "RunImmediateMethods", function ( obj, flags )
 
                           newflags := SUB_FLAGS( type![2], IMM_FLAGS );
                           newflags := SUB_FLAGS( newflags, flags );
-                          APPEND_LIST_INTR( flagspos,
-                                            TRUES_FLAGS( newflags ) );
+                          APPEND_TRUES_FLAGS( flagspos, newflags );
 
                           flags := type![2];
 
@@ -589,7 +588,7 @@ LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (BASE_SIZE_METHODS_OPER_ENT
 InstallAttributeFunction(
     function ( name, filter, getter, setter, tester, mutflag )
 
-    local flags, rank, cats, props, i, lk;
+    local flags, rank, cats, props, i, j, lk;
 
     if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then
 
@@ -602,7 +601,8 @@ InstallAttributeFunction(
             # to replace the explicit locking and unlocking here.
             lk := READ_LOCK(FILTER_REGION);
         fi;
-        for i in TRUES_FLAGS( flags ) do
+        for j in [1..SIZE_FLAGS(flags)] do
+            i := TRUE_FLAGS(flags,j);
             if INFO_FILTERS[i] in FNUM_CATS_AND_REPS  then
                 cats := cats and FILTERS[i];
                 rank := rank - RankFilter( FILTERS[i] );

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include <src/compiled.h>
-#define FILE_CRC  "-110560148"
+#define FILE_CRC  "-56568689"
 
 /* global variables used in handlers */
 static GVar G_REREADING;
@@ -54,8 +54,12 @@ static GVar G_WITH__HIDDEN__IMPS__FLAGS;
 static Obj  GF_WITH__HIDDEN__IMPS__FLAGS;
 static GVar G_IS__SUBSET__FLAGS;
 static Obj  GF_IS__SUBSET__FLAGS;
-static GVar G_TRUES__FLAGS;
-static Obj  GF_TRUES__FLAGS;
+static GVar G_APPEND__TRUES__FLAGS;
+static Obj  GF_APPEND__TRUES__FLAGS;
+static GVar G_SIZE__FLAGS;
+static Obj  GF_SIZE__FLAGS;
+static GVar G_TRUE__FLAGS;
+static Obj  GF_TRUE__FLAGS;
 static GVar G_FLAG1__FILTER;
 static Obj  GF_FLAG1__FILTER;
 static GVar G_FLAGS__FILTER;
@@ -98,6 +102,8 @@ static GVar G_IGNORE__IMMEDIATE__METHODS;
 static Obj  GC_IGNORE__IMMEDIATE__METHODS;
 static GVar G_IMM__FLAGS;
 static Obj  GC_IMM__FLAGS;
+static GVar G_TRUES__FLAGS;
+static Obj  GF_TRUES__FLAGS;
 static GVar G_TRACE__IMMEDIATE__METHODS;
 static Obj  GC_TRACE__IMMEDIATE__METHODS;
 static GVar G_IMMEDIATES;
@@ -260,12 +266,9 @@ static Obj  HdlrFunc2 (
  CHECK_FUNC_RESULT( t_1 )
  a_flags = t_1;
  
- /* flagspos := SHALLOW_COPY_OBJ( TRUES_FLAGS( flags ) ); */
- t_2 = GF_SHALLOW__COPY__OBJ;
- t_4 = GF_TRUES__FLAGS;
- t_3 = CALL_1ARGS( t_4, a_flags );
- CHECK_FUNC_RESULT( t_3 )
- t_1 = CALL_1ARGS( t_2, t_3 );
+ /* flagspos := TRUES_FLAGS( flags ); */
+ t_2 = GF_TRUES__FLAGS;
+ t_1 = CALL_1ARGS( t_2, a_flags );
  CHECK_FUNC_RESULT( t_1 )
  l_flagspos = t_1;
  
@@ -550,12 +553,9 @@ static Obj  HdlrFunc2 (
        CHECK_FUNC_RESULT( t_9 )
        l_newflags = t_9;
        
-       /* APPEND_LIST_INTR( flagspos, TRUES_FLAGS( newflags ) ); */
-       t_9 = GF_APPEND__LIST__INTR;
-       t_11 = GF_TRUES__FLAGS;
-       t_10 = CALL_1ARGS( t_11, l_newflags );
-       CHECK_FUNC_RESULT( t_10 )
-       CALL_2ARGS( t_9, l_flagspos, t_10 );
+       /* APPEND_TRUES_FLAGS( flagspos, newflags ); */
+       t_9 = GF_APPEND__TRUES__FLAGS;
+       CALL_2ARGS( t_9, l_flagspos, l_newflags );
        
        /* flags := type![2]; */
        C_ELM_POSOBJ_NLE( t_9, l_type, 2 );
@@ -2336,6 +2336,7 @@ static Obj  HdlrFunc7 (
  Obj l_rank = 0;
  Obj l_cats = 0;
  Obj l_i = 0;
+ Obj l_j = 0;
  Obj l_lk = 0;
  Obj t_1 = 0;
  Obj t_2 = 0;
@@ -2344,12 +2345,11 @@ static Obj  HdlrFunc7 (
  Obj t_5 = 0;
  Obj t_6 = 0;
  Obj t_7 = 0;
- Obj t_8 = 0;
- Obj t_9 = 0;
  (void)l_flags;
  (void)l_rank;
  (void)l_cats;
  (void)l_i;
+ (void)l_j;
  (void)l_lk;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
@@ -2390,92 +2390,83 @@ static Obj  HdlrFunc7 (
   SET_LEN_PLIST( t_1, 0 );
   ASS_LVAR( 2, t_1 );
   
-  /* for i in TRUES_FLAGS( flags ) do */
-  t_5 = GF_TRUES__FLAGS;
-  t_4 = CALL_1ARGS( t_5, l_flags );
-  CHECK_FUNC_RESULT( t_4 )
-  if ( IS_SMALL_LIST(t_4) ) {
-   t_3 = (Obj)(UInt)1;
-   t_1 = INTOBJ_INT(1);
-  }
-  else {
-   t_3 = (Obj)(UInt)0;
-   t_1 = CALL_1ARGS( GF_ITERATOR, t_4 );
-  }
-  while ( 1 ) {
-   if ( t_3 ) {
-    if ( LEN_LIST(t_4) < INT_INTOBJ(t_1) )  break;
-    t_2 = ELMV0_LIST( t_4, INT_INTOBJ(t_1) );
-    t_1 = (Obj)(((UInt)t_1)+4);
-    if ( t_2 == 0 )  continue;
-   }
-   else {
-    if ( CALL_1ARGS( GF_IS_DONE_ITER, t_1 ) != False )  break;
-    t_2 = CALL_1ARGS( GF_NEXT_ITER, t_1 );
-   }
-   l_i = t_2;
+  /* for j in [ 1 .. SIZE_FLAGS( flags ) ] do */
+  t_3 = GF_SIZE__FLAGS;
+  t_2 = CALL_1ARGS( t_3, l_flags );
+  CHECK_FUNC_RESULT( t_2 )
+  CHECK_INT_SMALL( t_2 )
+  for ( t_1 = INTOBJ_INT(1);
+        ((Int)t_1) <= ((Int)t_2);
+        t_1 = (Obj)(((UInt)t_1)+4) ) {
+   l_j = t_1;
+   
+   /* i := TRUE_FLAGS( flags, j ); */
+   t_4 = GF_TRUE__FLAGS;
+   t_3 = CALL_2ARGS( t_4, l_flags, l_j );
+   CHECK_FUNC_RESULT( t_3 )
+   l_i = t_3;
    
    /* if INFO_FILTERS[i] in FNUM_CATS_AND_REPS then */
-   t_7 = GC_INFO__FILTERS;
-   CHECK_BOUND( t_7, "INFO_FILTERS" )
+   t_5 = GC_INFO__FILTERS;
+   CHECK_BOUND( t_5, "INFO_FILTERS" )
    CHECK_INT_POS( l_i )
-   C_ELM_LIST_FPL( t_6, t_7, l_i )
-   t_7 = GC_FNUM__CATS__AND__REPS;
-   CHECK_BOUND( t_7, "FNUM_CATS_AND_REPS" )
-   t_5 = (Obj)(UInt)(IN( t_6, t_7 ));
-   if ( t_5 ) {
+   C_ELM_LIST_FPL( t_4, t_5, l_i )
+   t_5 = GC_FNUM__CATS__AND__REPS;
+   CHECK_BOUND( t_5, "FNUM_CATS_AND_REPS" )
+   t_3 = (Obj)(UInt)(IN( t_4, t_5 ));
+   if ( t_3 ) {
     
     /* cats := cats and FILTERS[i]; */
     if ( l_cats == False ) {
-     t_5 = l_cats;
+     t_3 = l_cats;
     }
     else if ( l_cats == True ) {
-     t_7 = GC_FILTERS;
-     CHECK_BOUND( t_7, "FILTERS" )
-     C_ELM_LIST_FPL( t_6, t_7, l_i )
-     CHECK_BOOL( t_6 )
-     t_5 = t_6;
+     t_5 = GC_FILTERS;
+     CHECK_BOUND( t_5, "FILTERS" )
+     C_ELM_LIST_FPL( t_4, t_5, l_i )
+     CHECK_BOOL( t_4 )
+     t_3 = t_4;
     }
     else {
      CHECK_FUNC( l_cats )
-     t_8 = GC_FILTERS;
-     CHECK_BOUND( t_8, "FILTERS" )
-     C_ELM_LIST_FPL( t_7, t_8, l_i )
-     CHECK_FUNC( t_7 )
-     t_5 = NewAndFilter( l_cats, t_7 );
+     t_6 = GC_FILTERS;
+     CHECK_BOUND( t_6, "FILTERS" )
+     C_ELM_LIST_FPL( t_5, t_6, l_i )
+     CHECK_FUNC( t_5 )
+     t_3 = NewAndFilter( l_cats, t_5 );
     }
-    l_cats = t_5;
+    l_cats = t_3;
     
     /* rank := rank - RankFilter( FILTERS[i] ); */
-    t_7 = GF_RankFilter;
-    t_9 = GC_FILTERS;
-    CHECK_BOUND( t_9, "FILTERS" )
-    C_ELM_LIST_FPL( t_8, t_9, l_i )
-    t_6 = CALL_1ARGS( t_7, t_8 );
-    CHECK_FUNC_RESULT( t_6 )
-    C_DIFF_FIA( t_5, l_rank, t_6 )
-    l_rank = t_5;
+    t_5 = GF_RankFilter;
+    t_7 = GC_FILTERS;
+    CHECK_BOUND( t_7, "FILTERS" )
+    C_ELM_LIST_FPL( t_6, t_7, l_i )
+    t_4 = CALL_1ARGS( t_5, t_6 );
+    CHECK_FUNC_RESULT( t_4 )
+    C_DIFF_FIA( t_3, l_rank, t_4 )
+    l_rank = t_3;
     
    }
    
    /* elif INFO_FILTERS[i] in FNUM_PROS then */
    else {
-    t_7 = GC_INFO__FILTERS;
-    CHECK_BOUND( t_7, "INFO_FILTERS" )
-    C_ELM_LIST_FPL( t_6, t_7, l_i )
-    t_7 = GC_FNUM__PROS;
-    CHECK_BOUND( t_7, "FNUM_PROS" )
-    t_5 = (Obj)(UInt)(IN( t_6, t_7 ));
-    if ( t_5 ) {
+    t_5 = GC_INFO__FILTERS;
+    CHECK_BOUND( t_5, "INFO_FILTERS" )
+    C_ELM_LIST_FPL( t_4, t_5, l_i )
+    t_5 = GC_FNUM__PROS;
+    CHECK_BOUND( t_5, "FNUM_PROS" )
+    t_3 = (Obj)(UInt)(IN( t_4, t_5 ));
+    if ( t_3 ) {
      
      /* ADD_LIST( props, FILTERS[i] ); */
-     t_5 = GF_ADD__LIST;
-     t_6 = OBJ_LVAR( 2 );
-     CHECK_BOUND( t_6, "props" )
-     t_8 = GC_FILTERS;
-     CHECK_BOUND( t_8, "FILTERS" )
-     C_ELM_LIST_FPL( t_7, t_8, l_i )
-     CALL_2ARGS( t_5, t_6, t_7 );
+     t_3 = GF_ADD__LIST;
+     t_4 = OBJ_LVAR( 2 );
+     CHECK_BOUND( t_4, "props" )
+     t_6 = GC_FILTERS;
+     CHECK_BOUND( t_6, "FILTERS" )
+     C_ELM_LIST_FPL( t_5, t_6, l_i )
+     CALL_2ARGS( t_3, t_4, t_5 );
      
     }
    }
@@ -3815,7 +3806,7 @@ static Obj  HdlrFunc1 (
           return;
       fi;
       flags := SUB_FLAGS( flags, IMM_FLAGS );
-      flagspos := SHALLOW_COPY_OBJ( TRUES_FLAGS( flags ) );
+      flagspos := TRUES_FLAGS( flags );
       tried := [  ];
       type := TYPE_OBJ( obj );
       flags := type![2];
@@ -3848,7 +3839,7 @@ static Obj  HdlrFunc1 (
                               type := TYPE_OBJ( obj );
                               newflags := SUB_FLAGS( type![2], IMM_FLAGS );
                               newflags := SUB_FLAGS( newflags, flags );
-                              APPEND_LIST_INTR( flagspos, TRUES_FLAGS( newflags ) );
+                              APPEND_TRUES_FLAGS( flagspos, newflags );
                               flags := type![2];
                           fi;
                       fi;
@@ -3864,7 +3855,7 @@ static Obj  HdlrFunc1 (
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
  SET_STARTLINE_BODY(t_4, 27);
- SET_ENDLINE_BODY(t_4, 126);
+ SET_ENDLINE_BODY(t_4, 125);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3965,8 +3956,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[3], 6, 0, HdlrFunc3 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 146);
- SET_ENDLINE_BODY(t_4, 273);
+ SET_STARTLINE_BODY(t_4, 145);
+ SET_ENDLINE_BODY(t_4, 272);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3981,8 +3972,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[4], -1, 0, HdlrFunc4 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 320);
- SET_ENDLINE_BODY(t_4, 322);
+ SET_STARTLINE_BODY(t_4, 319);
+ SET_ENDLINE_BODY(t_4, 321);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3997,8 +3988,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[5], -1, 0, HdlrFunc5 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 347);
- SET_ENDLINE_BODY(t_4, 349);
+ SET_STARTLINE_BODY(t_4, 346);
+ SET_ENDLINE_BODY(t_4, 348);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4151,8 +4142,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[6], 2, 0, HdlrFunc6 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 360);
- SET_ENDLINE_BODY(t_4, 571);
+ SET_STARTLINE_BODY(t_4, 359);
+ SET_ENDLINE_BODY(t_4, 570);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4166,14 +4157,15 @@ static Obj  HdlrFunc1 (
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
-      local flags, rank, cats, props, i, lk;
+      local flags, rank, cats, props, i, j, lk;
       if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then
           flags := FLAGS_FILTER( filter );
           rank := 0;
           cats := IS_OBJECT;
           props := [  ];
           ;
-          for i in TRUES_FLAGS( flags ) do
+          for j in [ 1 .. SIZE_FLAGS( flags ) ] do
+              i := TRUE_FLAGS( flags, j );
               if INFO_FILTERS[i] in FNUM_CATS_AND_REPS then
                   cats := cats and FILTERS[i];
                   rank := rank - RankFilter( FILTERS[i] );
@@ -4210,7 +4202,7 @@ static Obj  HdlrFunc1 (
  t_2 = NewFunction( NameFunc[7], 6, 0, HdlrFunc7 );
  SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
  t_3 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_3, 590);
+ SET_STARTLINE_BODY(t_3, 589);
  SET_ENDLINE_BODY(t_3, 654);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
@@ -4455,7 +4447,9 @@ static Int PostRestore ( StructInitInfo * module )
  G_SUB__FLAGS = GVarName( "SUB_FLAGS" );
  G_WITH__HIDDEN__IMPS__FLAGS = GVarName( "WITH_HIDDEN_IMPS_FLAGS" );
  G_IS__SUBSET__FLAGS = GVarName( "IS_SUBSET_FLAGS" );
- G_TRUES__FLAGS = GVarName( "TRUES_FLAGS" );
+ G_APPEND__TRUES__FLAGS = GVarName( "APPEND_TRUES_FLAGS" );
+ G_SIZE__FLAGS = GVarName( "SIZE_FLAGS" );
+ G_TRUE__FLAGS = GVarName( "TRUE_FLAGS" );
  G_FLAG1__FILTER = GVarName( "FLAG1_FILTER" );
  G_FLAGS__FILTER = GVarName( "FLAGS_FILTER" );
  G_METHODS__OPERATION = GVarName( "METHODS_OPERATION" );
@@ -4477,6 +4471,7 @@ static Int PostRestore ( StructInitInfo * module )
  G_BIND__GLOBAL = GVarName( "BIND_GLOBAL" );
  G_IGNORE__IMMEDIATE__METHODS = GVarName( "IGNORE_IMMEDIATE_METHODS" );
  G_IMM__FLAGS = GVarName( "IMM_FLAGS" );
+ G_TRUES__FLAGS = GVarName( "TRUES_FLAGS" );
  G_TRACE__IMMEDIATE__METHODS = GVarName( "TRACE_IMMEDIATE_METHODS" );
  G_IMMEDIATES = GVarName( "IMMEDIATES" );
  G_SIZE__IMMEDIATE__METHOD__ENTRY = GVarName( "SIZE_IMMEDIATE_METHOD_ENTRY" );
@@ -4568,7 +4563,9 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "SUB_FLAGS", &GF_SUB__FLAGS );
  InitFopyGVar( "WITH_HIDDEN_IMPS_FLAGS", &GF_WITH__HIDDEN__IMPS__FLAGS );
  InitFopyGVar( "IS_SUBSET_FLAGS", &GF_IS__SUBSET__FLAGS );
- InitFopyGVar( "TRUES_FLAGS", &GF_TRUES__FLAGS );
+ InitFopyGVar( "APPEND_TRUES_FLAGS", &GF_APPEND__TRUES__FLAGS );
+ InitFopyGVar( "SIZE_FLAGS", &GF_SIZE__FLAGS );
+ InitFopyGVar( "TRUE_FLAGS", &GF_TRUE__FLAGS );
  InitFopyGVar( "FLAG1_FILTER", &GF_FLAG1__FILTER );
  InitFopyGVar( "FLAGS_FILTER", &GF_FLAGS__FILTER );
  InitFopyGVar( "METHODS_OPERATION", &GF_METHODS__OPERATION );
@@ -4590,6 +4587,7 @@ static Int InitKernel ( StructInitInfo * module )
  InitFopyGVar( "BIND_GLOBAL", &GF_BIND__GLOBAL );
  InitCopyGVar( "IGNORE_IMMEDIATE_METHODS", &GC_IGNORE__IMMEDIATE__METHODS );
  InitCopyGVar( "IMM_FLAGS", &GC_IMM__FLAGS );
+ InitFopyGVar( "TRUES_FLAGS", &GF_TRUES__FLAGS );
  InitCopyGVar( "TRACE_IMMEDIATE_METHODS", &GC_TRACE__IMMEDIATE__METHODS );
  InitCopyGVar( "IMMEDIATES", &GC_IMMEDIATES );
  InitCopyGVar( "SIZE_IMMEDIATE_METHOD_ENTRY", &GC_SIZE__IMMEDIATE__METHOD__ENTRY );
@@ -4695,7 +4693,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "GAPROOT/lib/oper1.g",
- .crc         = -110560148,
+ .crc         = -56568689,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/src/opers.c
+++ b/src/opers.c
@@ -133,9 +133,10 @@ UInt FILT_IN_FLAGS(Obj flags, UInt filt)
     UInt len = SIZE_FLAGS(flags);
     Int  hi = len - 1;
     Int  lo = 0;
+    const UInt2 *trues = ADDR_TRUES_FLAGS(flags);
     while (hi >= lo) {
         Int   mid = (hi + lo) / 2;
-        UInt2 x = TRUE_FLAGS(flags, mid);
+        UInt2 x = trues[mid];
         if (x == filt)
             return 1;
         if (x < filt) {
@@ -384,9 +385,12 @@ static Int IS_SUBSET_FLAGS(Obj flags1, Obj flags2)
     Int   i = len1 - 1;
     Int   j = len2 - 1;
     UInt2 x, y;
+    const UInt2 *trues1, *trues2;
+    trues1 = ADDR_TRUES_FLAGS(flags1);
+    trues2 = ADDR_TRUES_FLAGS(flags2);
     while (i >= 0 && j >= 0) {
-        x = TRUE_FLAGS(flags1, i);
-        y = TRUE_FLAGS(flags2, j);
+        x = trues1[i];
+        y = trues2[j];
         if (x == y) {
             i--;
             j--;

--- a/src/opers.c
+++ b/src/opers.c
@@ -123,24 +123,22 @@ void LoadFlags(Obj flags)
 
 /****************************************************************************
 **
-*F  C_ELM_FLAGS( <list>, <pos> )  . . . . . . . . . . . element of a flags
-*list
+*F  FILT_IN_FLAGS( <flags>, <filt> )  . . . . . . . . . . . test
 **
 **
-**  returns 1 if the flags list <list> contains the filter <pos>, else 0
-*T Rename
+**  returns 1 if the flags list <list> contains the filter <filt>, else 0
 */
-UInt C_ELM_FLAGS(Obj list, UInt pos)
+UInt FILT_IN_FLAGS(Obj flags, UInt filt)
 {
-    UInt len = SIZE_FLAGS(list);
+    UInt len = SIZE_FLAGS(flags);
     Int  hi = len - 1;
     Int  lo = 0;
     while (hi >= lo) {
         Int   mid = (hi + lo) / 2;
-        UInt2 x = TRUE_FLAGS(list, mid);
-        if (x == pos)
+        UInt2 x = TRUE_FLAGS(flags, mid);
+        if (x == filt)
             return 1;
-        if (x < pos) {
+        if (x < filt) {
             lo = mid + 1;
         }
         else {
@@ -174,7 +172,7 @@ Obj FuncFLAGS_CONTAINS_FILTER(Obj self, Obj flags, Obj filter)
     Int filt = INT_INTOBJ(filter);
     if (filt < 0)
         ErrorMayQuit("FLAGS_CONTAINS_FILTER: <filter> must be non-negative", 0L, 0L);
-    return C_ELM_FLAGS(flags, filt) ? True: False;    
+    return FILT_IN_FLAGS(flags, filt) ? True: False;    
 }
     
 
@@ -1078,7 +1076,7 @@ Obj DoSetFilter(Obj self, Obj obj, Obj val)
     flags = FLAGS_TYPE(type);
 
     /* return the value of the feature                                     */
-    if (val != ELM_FLAGS(flags, flag1)) {
+    if ((val == True) != FILT_IN_FLAGS(flags, flag1)) {
         ErrorReturnVoid("value feature is already set the other way", 0L, 0L,
                         "you can 'return;' and ignore it");
     }
@@ -1113,7 +1111,7 @@ Obj DoFilter(Obj self, Obj obj)
     type = TYPE_OBJ(obj);
     flags = FLAGS_TYPE(type);
 
-    return ELM_FLAGS(flags, flag1);
+    return FILT_IN_FLAGS(flags, flag1) ? True: False;
 }
 
 
@@ -2399,7 +2397,7 @@ Obj DoTestAttribute(Obj self, Obj obj)
     type = TYPE_OBJ_FEO(obj);
     flags = FLAGS_TYPE(type);
 
-    return ELM_FLAGS(flags, flag2);
+    return FILT_IN_FLAGS(flags, flag2) ? True : False;
 }
 
 
@@ -2424,7 +2422,7 @@ Obj DoAttribute(Obj self, Obj obj)
     flags = FLAGS_TYPE(type);
 
     /* if the value of the attribute is already known, simply return it     */
-    if (C_ELM_FLAGS(flags, flag2)) {
+    if (FILT_IN_FLAGS(flags, flag2)) {
         return DoOperation1Args(self, obj);
     }
 
@@ -2477,7 +2475,7 @@ Obj DoVerboseAttribute(Obj self, Obj obj)
     flags = FLAGS_TYPE(type);
 
     /* if the value of the attribute is already known, simply return it     */
-    if (C_ELM_FLAGS(flags, flag2)) {
+    if (FILT_IN_FLAGS(flags, flag2)) {
         return DoVerboseOperation1Args(self, obj);
     }
 
@@ -2523,7 +2521,7 @@ Obj DoMutableAttribute(Obj self, Obj obj)
     flags = FLAGS_TYPE(type);
 
     /* if the value of the attribute is already known, simply return it     */
-    if (C_ELM_FLAGS(flags, flag2)) {
+    if (FILT_IN_FLAGS(flags, flag2)) {
         return DoOperation1Args(self, obj);
     }
 
@@ -2568,7 +2566,7 @@ Obj DoVerboseMutableAttribute(Obj self, Obj obj)
     flags = FLAGS_TYPE(type);
 
     /* if the value of the attribute is already known, simply return it     */
-    if (C_ELM_FLAGS(flags, flag2)) {
+    if (FILT_IN_FLAGS(flags, flag2)) {
         return DoVerboseOperation1Args(self, obj);
     }
 
@@ -2767,8 +2765,8 @@ Obj DoSetProperty(Obj self, Obj obj, Obj val)
     flags = FLAGS_TYPE(type);
 
     /* if the value of the property is already known, compare it           */
-    if (C_ELM_FLAGS(flags, flag2)) {
-        if (val == ELM_FLAGS(flags, flag1)) {
+    if (FILT_IN_FLAGS(flags, flag2)) {
+        if ((val == True) == FILT_IN_FLAGS(flags, flag1)) {
             return 0;
         }
         else {
@@ -2829,8 +2827,8 @@ Obj DoProperty(Obj self, Obj obj)
     flags = FLAGS_TYPE(type);
 
     /* if the value of the property is already known, simply return it     */
-    if (C_ELM_FLAGS(flags, flag2)) {
-        return ELM_FLAGS(flags, flag1);
+    if (FILT_IN_FLAGS(flags, flag2)) {
+        return FILT_IN_FLAGS(flags, flag1) ? True : False;
     }
 
     /* call the operation to compute the value                             */
@@ -2882,8 +2880,8 @@ Obj DoVerboseProperty(Obj self, Obj obj)
     flags = FLAGS_TYPE(type);
 
     /* if the value of the property is already known, simply return it     */
-    if (C_ELM_FLAGS(flags, flag2)) {
-        return ELM_FLAGS(flags, flag1);
+    if (FILT_IN_FLAGS(flags, flag2)) {
+        return FILT_IN_FLAGS(flags, flag1) ? True: False;
     }
 
     /* call the operation to compute the value                             */
@@ -3409,7 +3407,7 @@ Obj DoSetterFunction(Obj self, Obj obj, Obj value)
     flag2 = INT_INTOBJ(FLAG2_FILT(tester));
     type = TYPE_OBJ_FEO(obj);
     flags = FLAGS_TYPE(type);
-    if (C_ELM_FLAGS(flags, flag2)) {
+    if (FILT_IN_FLAGS(flags, flag2)) {
         return 0;
     }
 
@@ -4006,7 +4004,7 @@ static Int InitKernel(StructInitInfo * module)
 
     /* install the marking function                                        */
     InfoBags[T_FLAGS].name = "flags list";
-    InitMarkFuncBags( T_FLAGS, MarkThreeSubBags );
+    InitMarkFuncBags( T_FLAGS, MarkOneSubBags );
 
     /* install the printing function                                       */
     PrintObjFuncs[T_FLAGS] = PrintFlags;

--- a/src/opers.c
+++ b/src/opers.c
@@ -319,16 +319,18 @@ static Int IS_SUBSET_FLAGS(Obj flags1, Obj flags2)
         return 1;
     UInt i = 0;
     UInt j = 0;
-    UInt2 x = TRUE_FLAGS(flags1,i);
-    UInt2 y = TRUE_FLAGS(flags2,j);
+    UInt2 x,y;
     while (i < len1 && j < len2) {
+        x = TRUE_FLAGS(flags1,i);
+        y = TRUE_FLAGS(flags2,j);
         if (x == y) {
+            i++;
             j++;
-            if (j < len2) y = TRUE_FLAGS(flags2,j);
-        } else if (y < x)
+        } else if (y < x) {
             return 0;
-        i++;
-        if (i < len1) x = TRUE_FLAGS(flags1,i);        
+        } else {
+            i++;
+        }
     }
     return (j == len2);   
 }
@@ -385,27 +387,23 @@ Obj FuncSUB_FLAGS (
     }
 
     len1 = INT_INTOBJ(SIZE_FLAGS(flags1));
-    len2 = INT_INTOBJ(SIZE_FLAGS(flags1));
+    len2 = INT_INTOBJ(SIZE_FLAGS(flags2));
     NEW_FLAGS(flags, len1);
     i = 0;
     j = 0;
     k = 0;
-    x = TRUE_FLAGS(flags1,i);
-    y = TRUE_FLAGS(flags2,j);
     while ( i < len1 && j < len2) {
+        x = TRUE_FLAGS(flags1,i);
+        y = TRUE_FLAGS(flags2,j);
         if (x == y) {
             i++;
             j++;
-            if (i < len1) x = TRUE_FLAGS(flags1,i);
-            if (j < len2) y = TRUE_FLAGS(flags2,j);
         } else if (x < y) {
             SET_TRUE_FLAGS(flags, k, x);
             k++;
             i++;
-            if (i < len1) x = TRUE_FLAGS(flags1,i);
         } else {
             j++;
-            if (j < len2) y = TRUE_FLAGS(flags2,j);
         }
     }
     while (i < len1) {
@@ -439,7 +437,7 @@ Obj FuncAND_FLAGS (
     Int                 len1;
     Int                 len2;
     Int                 i,j,k;
-    UInt2               x,y;
+    UInt2               x,y,z;
 
 #ifdef AND_FLAGS_HASH_SIZE
     Obj                 cache;
@@ -532,25 +530,23 @@ Obj FuncAND_FLAGS (
     i = 0;
     j = 0;
     k = 0;
-    x = TRUE_FLAGS(flags1,i);
-    y = TRUE_FLAGS(flags2,j);
     while ( i < len1 && j < len2) {
+        x = TRUE_FLAGS(flags1,i);
+        y = TRUE_FLAGS(flags2,j);
         if (x == y) {
             i++;
             j++;
-            SET_TRUE_FLAGS(flags, k++, x);
-            if (i < len1) x = TRUE_FLAGS(flags1,i);
-            if (j < len2) y = TRUE_FLAGS(flags2,j);
+            z = x;
         } else if (x < y) {
-            SET_TRUE_FLAGS(flags, k++, x);
             i++;
-            if (i < len1) x = TRUE_FLAGS(flags1,i);
+            z = x;
         } else {
-            SET_TRUE_FLAGS(flags, k++, y);
             j++;
-            if (j < len2) y = TRUE_FLAGS(flags2,j);
+            z = y;
         }
+        SET_TRUE_FLAGS(flags, k++, z);
     }
+    /* Only one of these two loops will go round > 0 times */
     while (i < len1) {
         SET_TRUE_FLAGS(flags, k++, TRUE_FLAGS(flags1, i++) );
     }

--- a/src/opers.c
+++ b/src/opers.c
@@ -92,16 +92,14 @@ Obj TypeFlags (
 void SaveFlags (
     Obj         flags )
 {
-    UInt        i, len, *ptr;
-
-    SaveSubObj(TRUES_FLAGS(flags));
+    UInt        i, len;
+  
+    SaveSubObj(SIZE_FLAGS(flags));
     SaveSubObj(HASH_FLAGS(flags));
     SaveSubObj(AND_CACHE_FLAGS(flags));
-
-    len = NRB_FLAGS(flags);
-    ptr = BLOCKS_FLAGS(flags);
-    for ( i = 1;  i <= len;  i++ )
-        SaveUInt(*ptr++);
+    len = INT_INTOBJ(SIZE_FLAGS(flags));
+    for ( i = 0;  i < len; i++)
+        SaveUInt2(TRUE_FLAGS(flags,i));
 }
 
 
@@ -114,16 +112,15 @@ void LoadFlags(
     Obj         flags )
 {
     Obj         sub;
-    UInt        i, len, *ptr;
+    UInt        i, len;
 
-    sub = LoadSubObj();  SET_TRUES_FLAGS( flags, sub );
+    sub = LoadSubObj();  SET_SIZE_FLAGS( flags, sub );
     sub = LoadSubObj();  SET_HASH_FLAGS( flags, sub );
     sub = LoadSubObj();  SET_AND_CACHE_FLAGS( flags, sub );
     
-    len = NRB_FLAGS(flags);
-    ptr = BLOCKS_FLAGS(flags);
-    for ( i = 1;  i <= len;  i++ )
-        *ptr++ = LoadUInt();
+    len = INT_INTOBJ(SIZE_FLAGS(flags));
+    for ( i = 0;  i < len;  i++ )
+        SET_TRUE_FLAGS(flags, i, LoadUInt2());
 }
 
 
@@ -146,17 +143,13 @@ void LoadFlags(
 **  the lower addressed half-word is the less significant
 **
 */
-#define HASH_FLAGS_SIZE (Int4)67108879L
+#define fnvp 1099511628211ULL
+#define fnvob 14695981039346656037ULL
 
 Obj FuncHASH_FLAGS (
     Obj                 self,
     Obj                 flags )
 {
-    Int4                 hash;
-    Int4                 x;
-    Int                  len;
-    UInt4 *              ptr;
-    Int                  i;
 
     /* do some trivial checks                                              */
     while ( TNUM_OBJ(flags) != T_FLAGS ) {
@@ -169,56 +162,18 @@ Obj FuncHASH_FLAGS (
     }
 
     /* do the real work*/
-#ifndef SYS_IS_64_BIT
 
-    /* 32 bit case  -- this is the "defining" case, others are
-     adjusted to comply with this */
-    len = NRB_FLAGS(flags);
-    ptr = (UInt4 *)BLOCKS_FLAGS(flags);
-    hash = 0;
-    x    = 1;
-    for ( i = len; i >= 1; i-- ) {
-        hash = (hash + (*ptr % HASH_FLAGS_SIZE) * x) % HASH_FLAGS_SIZE;
-        x    = ((8*sizeof(UInt4)-1) * x) % HASH_FLAGS_SIZE;
-        ptr++;
+
+    UInt8 h = fnvob;
+    UInt len = INT_INTOBJ(SIZE_FLAGS(flags));
+    for (UInt i = 0; i < len; i++) {
+        UInt2 pos = TRUE_FLAGS(flags, i);
+        h = (h*fnvp) ^ (pos & 0xFF);
+        h = (h*fnvp) ^ (pos >>8);
     }
-#else
-#ifdef WORDS_BIGENDIAN
+    UInt hash = (h & 0xFFFFFFFUL);
 
-    /* This is the hardest case */
-    len = NRB_FLAGS(flags);
-    ptr = (UInt4 *)BLOCKS_FLAGS(flags);
-    hash = 0;
-    x    = 1;
-    for ( i = len; i >= 1; i-- ) {
-
-        /* least significant 32 bits first */
-        hash = (hash + (ptr[1] % HASH_FLAGS_SIZE) * x) % HASH_FLAGS_SIZE;
-        x    = ((8*sizeof(UInt4)-1) * x) % HASH_FLAGS_SIZE;
-        /* now the more significant */
-        hash = (hash + (*ptr % HASH_FLAGS_SIZE) * x) % HASH_FLAGS_SIZE;
-        x    = ((8*sizeof(UInt4)-1) * x) % HASH_FLAGS_SIZE;
-        
-        ptr+= 2;
-    }
-#else
-
-    /* and the middle case -- for DEC alpha, the 32 bit chunks are
-       in the right order, and we merely have to be sure to process them as
-       32 bit chunks */
-    len = NRB_FLAGS(flags)*(sizeof(UInt)/sizeof(UInt4));
-    ptr = (UInt4 *)BLOCKS_FLAGS(flags);
-    hash = 0;
-    x    = 1;
-    for ( i = len; i >= 1; i-- ) {
-        hash = (hash + (*ptr % HASH_FLAGS_SIZE) * x) % HASH_FLAGS_SIZE;
-        x    = ((8*sizeof(UInt4)-1) * x) % HASH_FLAGS_SIZE;
-        ptr++;
-    }
-#endif
-#endif
     SET_HASH_FLAGS( flags, INTOBJ_INT((UInt)hash+1) );
-    CHANGED_BAG(flags);
     return HASH_FLAGS(flags);
 }
 
@@ -227,19 +182,26 @@ Obj FuncHASH_FLAGS (
 **
 *F  FuncTRUES_FLAGS( <self>, <flags> )  . . .  true positions of a flags list
 **
-**  see 'FuncPositionsTruesBlist' in "blister.c" for information.
 */
+
+Obj TRUES_FLAGS( Obj flags) {
+    UInt len = INT_INTOBJ(SIZE_FLAGS(flags));
+    if (len == 0) {
+        Obj trues = NEW_PLIST_IMM(T_PLIST_EMPTY,0);
+        SET_LEN_PLIST(trues, 0);
+        return trues;
+    }
+    Obj trues = NEW_PLIST_IMM(T_PLIST_CYC_SSORT, len);
+    for (UInt i = 0; i < len; i++)
+        SET_ELM_PLIST(trues, i+1, INTOBJ_INT(TRUE_FLAGS(flags, i)));
+    SET_LEN_PLIST(trues, len);
+    return trues;
+}
+
 Obj FuncTRUES_FLAGS (
     Obj                 self,
     Obj                 flags )
 {
-    Obj                 sub;            /* handle of the result            */
-    Int                 len;            /* logical length of the list      */
-    UInt *              ptr;            /* pointer to flags                */
-    UInt                nrb;            /* number of blocks in flags       */
-    UInt                n;              /* number of bits in flags         */
-    UInt                nn;
-    UInt                i;              /* loop variable                   */
 
     /* get and check the first argument                                    */
     while ( TNUM_OBJ(flags) != T_FLAGS ) {
@@ -247,34 +209,7 @@ Obj FuncTRUES_FLAGS (
             (Int)TNAM_OBJ(flags), 0L,
             "you can replace <flags> via 'return <flags>;'" );
     }
-    if ( TRUES_FLAGS(flags) != 0 ) {
-        return TRUES_FLAGS(flags);
-    }
-
-    /* compute the number of 'true'-s just as in 'FuncSizeBlist'            */
-    nrb = NRB_FLAGS(flags);
-    ptr = (UInt*)BLOCKS_FLAGS(flags);
-    n = COUNT_TRUES_BLOCKS(ptr, nrb);    
-
-    /* make the sublist (we now know its size exactly)                    */
-    sub = NEW_PLIST_IMM( T_PLIST, n );
-    SET_LEN_PLIST( sub, n );
-
-    /* loop over the boolean list and stuff elements into <sub>            */
-    len = LEN_FLAGS( flags );
-    nn  = 1;
-    for ( i = 1; nn <= n && i <= len;  i++ ) {
-        if ( C_ELM_FLAGS( flags, i ) ) {
-            SET_ELM_PLIST( sub, nn, INTOBJ_INT(i) );
-            nn++;
-        }
-    }
-    CHANGED_BAG(sub);
-
-    /* return the sublist                                                  */
-    SET_TRUES_FLAGS( flags, sub );
-    CHANGED_BAG(flags);
-    return sub;
+    return TRUES_FLAGS(flags);
 }
 
 
@@ -288,9 +223,6 @@ Obj FuncSIZE_FLAGS (
     Obj                 self,
     Obj                 flags )
 {
-    UInt *              ptr;            /* pointer to flags                */
-    UInt                nrb;            /* number of blocks in flags       */
-    UInt                n;              /* number of bits in flags         */
 
     /* get and check the first argument                                    */
     while ( TNUM_OBJ(flags) != T_FLAGS ) {
@@ -298,18 +230,7 @@ Obj FuncSIZE_FLAGS (
             (Int)TNAM_OBJ(flags), 0L,
             "you can replace <flags> via 'return <flags>;'" );
     }
-    if ( TRUES_FLAGS(flags) != 0 ) {
-        return INTOBJ_INT( LEN_PLIST( TRUES_FLAGS(flags) ) );
-    }
-
-    /* get the number of blocks and a pointer                              */
-    nrb = NRB_FLAGS(flags);
-    ptr = BLOCKS_FLAGS(flags);
-
-    n = COUNT_TRUES_BLOCKS(ptr, nrb);
-
-    /* return the number of bits                                           */
-    return INTOBJ_INT( n );
+    return SIZE_FLAGS(flags);
 }
 
 
@@ -319,52 +240,36 @@ Obj FuncSIZE_FLAGS (
 */
 Int EqFlags(Obj flags1, Obj flags2)
 {
-    Int                 len1;
-    Int                 len2;
-    UInt  *             ptr1;
-    UInt  *             ptr2;
+    Int                 len;
     Int                 i;
 
     if ( flags1 == flags2 ) {
         return 1;
     }
 
+    if (SIZE_FLAGS(flags1) != SIZE_FLAGS(flags2))
+        return 0;
+
+    Obj h1 = HASH_FLAGS(flags1);
+    if (h1 != 0) {
+        Obj h2 = HASH_FLAGS(flags1);
+        if (h2 != 0 && h2 != h1)
+            return 0;
+    }
+    
     // do the real work
-    len1 = NRB_FLAGS(flags1);
-    len2 = NRB_FLAGS(flags2);
-    ptr1 = BLOCKS_FLAGS(flags1);
-    ptr2 = BLOCKS_FLAGS(flags2);
-    if ( len1 <= len2 ) {
-        for ( i = 1; i <= len1; i++ ) {
-            if ( *ptr1 != *ptr2 )
-                return 0;
-            ptr1++;  ptr2++;
-        }
-        for ( ; i <= len2; i++ ) {
-            if ( 0 != *ptr2 )
-                return 0;
-            ptr2++;
-        }
-    }
-    else {
-        for ( i = 1; i <= len2; i++ ) {
-            if ( *ptr1 != *ptr2 )
-                return 0;
-            ptr1++;  ptr2++;
-        }
-        for ( ; i <= len1; i++ ) {
-            if ( *ptr1 != 0 )
-                return 0;
-            ptr1++;
-        }
-    }
+    
+    len = INT_INTOBJ(SIZE_FLAGS(flags1));
+    for (i = 0; i < len; i++)
+        if (TRUE_FLAGS(flags1,i) != TRUE_FLAGS(flags2,i))
+            return 0;
     return 1;
 }
 
 
 /****************************************************************************
 **
-*F  FuncIS_EQUAL_FLAGS( <self>, <flags1>, <flags2> )  equality of flags lists
+*f  FuncIS_EQUAL_FLAGS( <self>, <flags1>, <flags2> )  equality of flags lists
 */
 Obj FuncIS_EQUAL_FLAGS (
     Obj                 self,
@@ -394,43 +299,38 @@ static Int IsSubsetFlagsCalls;
 /****************************************************************************
 **
 *F  IS_SUBSET_FLAGS( <flags1>, <flags2> ) . subset test with no safety check
+** checks is <flags2> is a subset of <flags1>
 */
 static Int IS_SUBSET_FLAGS(Obj flags1, Obj flags2)
 {
     Int    len1;
     Int    len2;
-    UInt * ptr1;
-    UInt * ptr2;
-    Int    i;
-
+    
+/* do the real work                                                    */
 #ifdef COUNT_OPERS
     IsSubsetFlagsCalls++;
 #endif
 
-    /* compare the bit lists                                               */
-    len1 = NRB_FLAGS(flags1);
-    len2 = NRB_FLAGS(flags2);
-    ptr1 = BLOCKS_FLAGS(flags1);
-    ptr2 = BLOCKS_FLAGS(flags2);
-    if (len1 < len2) {
-        for (i = len2 - 1; i >= len1; i--) {
-            if (ptr2[i] != 0)
-                return 0;
-        }
-        for (i = len1 - 1; i >= 0; i--) {
-            UInt x = ptr2[i];
-            if ((x & ptr1[i]) != x)
-                return 0;
-        }
+    len1 = INT_INTOBJ(SIZE_FLAGS(flags1));
+    len2 = INT_INTOBJ(SIZE_FLAGS(flags2));
+    if (len2 > len1)
+        return 0;
+    if (len2== 0)
+        return 1;
+    UInt i = 0;
+    UInt j = 0;
+    UInt2 x = TRUE_FLAGS(flags1,i);
+    UInt2 y = TRUE_FLAGS(flags2,j);
+    while (i < len1 && j < len2) {
+        if (x == y) {
+            j++;
+            if (j < len2) y = TRUE_FLAGS(flags2,j);
+        } else if (y < x)
+            return 0;
+        i++;
+        if (i < len1) x = TRUE_FLAGS(flags1,i);        
     }
-    else {
-        for (i = len2 - 1; i >= 0; i--) {
-            UInt x = ptr2[i];
-            if ((x & ptr1[i]) != x)
-                return 0;
-        }
-    }
-    return 1;
+    return (j == len2);   
 }
 
 /****************************************************************************
@@ -469,12 +369,8 @@ Obj FuncSUB_FLAGS (
     Obj                 flags;
     Int                 len1;
     Int                 len2;
-    Int                 size1;
-    Int                 size2;
-    UInt *              ptr;
-    UInt *              ptr1;
-    UInt *              ptr2;
-    Int                 i;
+    Int                 i,j,k;
+    UInt2               x,y;
 
     /* do some trivial checks                                              */
     while ( TNUM_OBJ(flags1) != T_FLAGS ) {
@@ -488,30 +384,36 @@ Obj FuncSUB_FLAGS (
             "you can replace <flags2> via 'return <flags2>;'" );
     }
 
-    /* do the real work                                                    */
-    len1   = LEN_FLAGS(flags1);
-    size1  = NRB_FLAGS(flags1);
-    len2   = LEN_FLAGS(flags2);
-    size2  = NRB_FLAGS(flags2);
-    if ( len1 < len2 ) {
-        flags = NEW_FLAGS( len1 );
-        ptr1 = BLOCKS_FLAGS(flags1);
-        ptr2 = BLOCKS_FLAGS(flags2);
-        ptr  = BLOCKS_FLAGS(flags);
-        for ( i = 1; i <= size1; i++ )
-            *ptr++ = *ptr1++ & ~ *ptr2++;
+    len1 = INT_INTOBJ(SIZE_FLAGS(flags1));
+    len2 = INT_INTOBJ(SIZE_FLAGS(flags1));
+    NEW_FLAGS(flags, len1);
+    i = 0;
+    j = 0;
+    k = 0;
+    x = TRUE_FLAGS(flags1,i);
+    y = TRUE_FLAGS(flags2,j);
+    while ( i < len1 && j < len2) {
+        if (x == y) {
+            i++;
+            j++;
+            if (i < len1) x = TRUE_FLAGS(flags1,i);
+            if (j < len2) y = TRUE_FLAGS(flags2,j);
+        } else if (x < y) {
+            SET_TRUE_FLAGS(flags, k, x);
+            k++;
+            i++;
+            if (i < len1) x = TRUE_FLAGS(flags1,i);
+        } else {
+            j++;
+            if (j < len2) y = TRUE_FLAGS(flags2,j);
+        }
     }
-    else {
-        flags = NEW_FLAGS( len1 );
-        ptr1 = BLOCKS_FLAGS(flags1);
-        ptr2 = BLOCKS_FLAGS(flags2);
-        ptr  = BLOCKS_FLAGS(flags);
-        for ( i = 1; i <= size2; i++ )
-            *ptr++ = *ptr1++ & ~ *ptr2++;
-        for (      ; i <= size1; i++ )
-            *ptr++ = *ptr1++;
-    }        
-
+    while (i < len1) {
+        SET_TRUE_FLAGS(flags, k++, TRUE_FLAGS(flags1, i++) );
+    }
+    
+    SET_SIZE_FLAGS(flags, INTOBJ_INT(k));
+    
     return flags;
 }
 
@@ -536,12 +438,8 @@ Obj FuncAND_FLAGS (
     Obj                 flags;
     Int                 len1;
     Int                 len2;
-    Int                 size1;
-    Int                 size2;
-    UInt *              ptr;
-    UInt *              ptr1;
-    UInt *              ptr2;
-    Int                 i;
+    Int                 i,j,k;
+    UInt2               x,y;
 
 #ifdef AND_FLAGS_HASH_SIZE
     Obj                 cache;
@@ -627,33 +525,41 @@ Obj FuncAND_FLAGS (
 #       endif
 #   endif
 
-
     /* do the real work                                                    */
-    len1   = LEN_FLAGS(flags1);
-    size1  = NRB_FLAGS(flags1);
-    len2   = LEN_FLAGS(flags2);
-    size2  = NRB_FLAGS(flags2);
-
-    if ( len1 < len2 ) {
-        flags = NEW_FLAGS( len2 );
-        ptr1 = BLOCKS_FLAGS(flags1);
-        ptr2 = BLOCKS_FLAGS(flags2);
-        ptr  = BLOCKS_FLAGS(flags);
-        for ( i = 1; i <= size1; i++ )
-            *ptr++ = *ptr1++ | *ptr2++;
-        for (      ; i <= size2; i++ )
-            *ptr++ =           *ptr2++;
+    len1 = INT_INTOBJ(SIZE_FLAGS(flags1));
+    len2 = INT_INTOBJ(SIZE_FLAGS(flags2));
+    NEW_FLAGS(flags, len1+len2);
+    i = 0;
+    j = 0;
+    k = 0;
+    x = TRUE_FLAGS(flags1,i);
+    y = TRUE_FLAGS(flags2,j);
+    while ( i < len1 && j < len2) {
+        if (x == y) {
+            i++;
+            j++;
+            SET_TRUE_FLAGS(flags, k++, x);
+            if (i < len1) x = TRUE_FLAGS(flags1,i);
+            if (j < len2) y = TRUE_FLAGS(flags2,j);
+        } else if (x < y) {
+            SET_TRUE_FLAGS(flags, k++, x);
+            i++;
+            if (i < len1) x = TRUE_FLAGS(flags1,i);
+        } else {
+            SET_TRUE_FLAGS(flags, k++, y);
+            j++;
+            if (j < len2) y = TRUE_FLAGS(flags2,j);
+        }
     }
-    else {
-        flags = NEW_FLAGS( len1 );
-        ptr1 = BLOCKS_FLAGS(flags1);
-        ptr2 = BLOCKS_FLAGS(flags2);
-        ptr  = BLOCKS_FLAGS(flags);
-        for ( i = 1; i <= size2; i++ )
-            *ptr++ = *ptr1++ | *ptr2++;
-        for (      ; i <= size1; i++ )
-            *ptr++ = *ptr1++;
-    }        
+    while (i < len1) {
+        SET_TRUE_FLAGS(flags, k++, TRUE_FLAGS(flags1, i++) );
+    }
+    while (j < len2) {
+        SET_TRUE_FLAGS(flags, k++, TRUE_FLAGS(flags2, j++) );
+    }
+    
+    SET_SIZE_FLAGS(flags, INTOBJ_INT(k));
+
 
     /* store result in the cache                                           */
 #   ifdef AND_FLAGS_HASH_SIZE
@@ -1134,11 +1040,11 @@ Obj DoSetFilter (
     flags = FLAGS_TYPE( type );
     
     /* return the value of the feature                                     */
-    if ( val != SAFE_ELM_FLAGS( flags, flag1 ) ) {
+    if ( val != ELM_FLAGS( flags, flag1 ) ) {
         ErrorReturnVoid(
-            "value feature is already set the other way",
-            0L, 0L,
-            "you can 'return;' and ignore it" );
+                        "value feature is already set the other way",
+                        0L, 0L,
+                        "you can 'return;' and ignore it" );
     }
 
     /* return 'void'                                                       */
@@ -1164,7 +1070,6 @@ Obj DoFilter (
     Obj                 self,
     Obj                 obj )
 {
-    Obj                 val;
     Int                 flag1;
     Obj                 type;
     Obj                 flags;
@@ -1176,11 +1081,7 @@ Obj DoFilter (
     type  = TYPE_OBJ( obj );
     flags = FLAGS_TYPE( type );
     
-    /* return the value of the feature                                     */
-    val = SAFE_ELM_FLAGS( flags, flag1 );
-    
-    /* return the value                                                    */
-    return val;
+    return ELM_FLAGS( flags, flag1 );
 }
 
 
@@ -1196,12 +1097,17 @@ Obj NewFilter (
     Obj                 flags;
     
     flag1 = ++CountFlags;
+    if (flag1 >= (1<<16)) {
+        FPUTS_TO_STDERR("#E Too many filters, fatal error\n");
+        SyExit(2);
+    }
 
     getter = NewOperation( name, 1L, nams, (hdlr ? hdlr : DoFilter) );
     SET_FLAG1_FILT(getter, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(getter, INTOBJ_INT(0));
-    flags = NEW_FLAGS( flag1 );
-    SET_ELM_FLAGS( flags, flag1, True );
+    NEW_FLAGS( flags, 1 );
+    SET_SIZE_FLAGS( flags, INTOBJ_INT(1) );
+    SET_TRUE_FLAGS( flags, 0, flag1);
     SET_FLAGS_FILT(getter, flags);
     CHANGED_BAG(getter);
 
@@ -1350,7 +1256,8 @@ Obj NewReturnTrueFilter ( void )
         DoReturnTrueFilter );
     SET_FLAG1_FILT(getter, INTOBJ_INT(0));
     SET_FLAG2_FILT(getter, INTOBJ_INT(0));
-    flags = NEW_FLAGS( 0 );
+    NEW_FLAGS( flags, 0 );
+    SET_SIZE_FLAGS( flags, INTOBJ_INT(0) );
     SET_FLAGS_FILT(getter, flags);
     CHANGED_BAG(getter);
 
@@ -2524,8 +2431,7 @@ Obj DoTestAttribute (
     type  = TYPE_OBJ_FEO( obj );
     flags = FLAGS_TYPE( type );
 
-    /* return whether the value of the attribute is already known          */
-    return SAFE_ELM_FLAGS( flags, flag2 );
+    return ELM_FLAGS(flags, flag2);
 }
 
 
@@ -2552,7 +2458,7 @@ Obj DoAttribute (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the attribute is already known, simply return it     */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 ) ) {
         return DoOperation1Args( self, obj );
     }
     
@@ -2607,7 +2513,7 @@ Obj DoVerboseAttribute (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the attribute is already known, simply return it     */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 )) {
         return DoVerboseOperation1Args( self, obj );
     }
     
@@ -2655,7 +2561,7 @@ Obj DoMutableAttribute (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the attribute is already known, simply return it     */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 ) ) {
         return DoOperation1Args( self, obj );
     }
     
@@ -2702,7 +2608,7 @@ Obj DoVerboseMutableAttribute (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the attribute is already known, simply return it     */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 ) ) {
         return DoVerboseOperation1Args( self, obj );
     }
     
@@ -2797,8 +2703,9 @@ static Obj MakeTester( Obj name, Int flag1, Int flag2)
                            DoTestAttribute );
     SET_FLAG1_FILT(tester, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(tester, INTOBJ_INT(flag2));
-    flags = NEW_FLAGS( flag2 );
-    SET_ELM_FLAGS( flags, flag2, True );
+    NEW_FLAGS( flags, flag2 );
+    SET_SIZE_FLAGS( flags, INTOBJ_INT(1) );
+    SET_TRUE_FLAGS( flags, 0, flag2);
     SET_FLAGS_FILT(tester, flags);
     SET_SETTR_FILT(tester, 0);
     SET_TESTR_FILT(tester, ReturnTrueFilter);
@@ -2907,7 +2814,7 @@ Obj DoSetProperty (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the property is already known, compare it           */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 )) {
         if ( val == ELM_FLAGS( flags, flag1 ) ) {
             return 0;
         }
@@ -2975,7 +2882,7 @@ Obj DoProperty (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the property is already known, simply return it     */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 ) ) {
         return ELM_FLAGS( flags, flag1 );
     }
 
@@ -3031,7 +2938,7 @@ Obj DoVerboseProperty (
     flags = FLAGS_TYPE( type );
 
     /* if the value of the property is already known, simply return it     */
-    if ( SAFE_C_ELM_FLAGS( flags, flag2 ) ) {
+    if ( C_ELM_FLAGS( flags, flag2 )) {
         return ELM_FLAGS( flags, flag1 );
     }
 
@@ -3085,9 +2992,10 @@ Obj NewProperty (
 
     SET_FLAG1_FILT(getter, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(getter, INTOBJ_INT(flag2));
-    flags = NEW_FLAGS( flag2 );
-    SET_ELM_FLAGS( flags, flag2, True );
-    SET_ELM_FLAGS( flags, flag1, True );
+    NEW_FLAGS( flags, flag2 );
+    SET_SIZE_FLAGS( flags, INTOBJ_INT(2) );
+    SET_TRUE_FLAGS(flags, 0, flag1);
+    SET_TRUE_FLAGS(flags, 1, flag2);
     SET_FLAGS_FILT(getter, flags);
     SET_SETTR_FILT(getter, setter);
     SET_TESTR_FILT(getter, tester);
@@ -3603,7 +3511,7 @@ Obj DoSetterFunction (
     flag2  = INT_INTOBJ( FLAG2_FILT(tester) );
     type   = TYPE_OBJ_FEO(obj);
     flags  = FLAGS_TYPE(type);
-    if ( SAFE_C_ELM_FLAGS(flags,flag2) ) {
+    if ( C_ELM_FLAGS(flags,flag2)) {
         return 0;
     }
 
@@ -3966,6 +3874,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(IS_SUBSET_FLAGS, 2, "flags1, flags2"),
     GVAR_FUNC(TRUES_FLAGS, 1, "flags"),
     GVAR_FUNC(SIZE_FLAGS, 1, "flags"),
+    GVAR_FUNC(ELM_FLAGS, 2, "flags, pos"),
     GVAR_FUNC(FLAG1_FILTER, 1, "oper"),
     GVAR_FUNC(SET_FLAG1_FILTER, 2, "oper, flag1"),
     GVAR_FUNC(FLAG2_FILTER, 1, "oper"),

--- a/src/opers.c
+++ b/src/opers.c
@@ -126,6 +126,32 @@ void LoadFlags(
 
 /****************************************************************************
 **
+*F  C_ELM_FLAGS( <list>, <pos> )  . . . . . . . . . . . element of a flags list
+**
+**
+**  returns 1 if the flags list <list> contains the filter <pos>, else 0
+*/
+UInt C_ELM_FLAGS(Obj list, UInt pos) {
+    UInt len = INT_INTOBJ(SIZE_FLAGS(list));
+    Int hi = len -1;
+    Int lo = 0;
+    while (hi >= lo) {
+        Int mid = (hi + lo)/2;
+        UInt2 x = TRUE_FLAGS(list, mid);
+        if (x == pos)
+            return 1;
+        if (x < pos) {
+            lo = mid+1;
+        } else {
+            hi = mid -1;
+        }
+    }
+    return 0;
+}
+
+
+/****************************************************************************
+**
 *F * * * * * * * * * * * * *  GAP flags functions * * * * * * * * * * * * * *
 */
 
@@ -388,7 +414,7 @@ Obj FuncSUB_FLAGS (
 
     len1 = INT_INTOBJ(SIZE_FLAGS(flags1));
     len2 = INT_INTOBJ(SIZE_FLAGS(flags2));
-    NEW_FLAGS(flags, len1);
+    flags = NEW_FLAGS(len1);
     i = 0;
     j = 0;
     k = 0;
@@ -464,9 +490,9 @@ Obj FuncAND_FLAGS (
 
     if (flags1 == flags2)
         return flags1;
-    if (LEN_FLAGS(flags2) == 0)
+    if (SIZE_FLAGS(flags2) == INTOBJ_INT(0))
         return flags1;
-    if (LEN_FLAGS(flags1) == 0)
+    if (SIZE_FLAGS(flags1) == INTOBJ_INT(0))
         return flags2;
 
     // check the cache
@@ -526,7 +552,7 @@ Obj FuncAND_FLAGS (
     /* do the real work                                                    */
     len1 = INT_INTOBJ(SIZE_FLAGS(flags1));
     len2 = INT_INTOBJ(SIZE_FLAGS(flags2));
-    NEW_FLAGS(flags, len1+len2);
+    flags = NEW_FLAGS(len1+len2);
     i = 0;
     j = 0;
     k = 0;
@@ -1101,7 +1127,7 @@ Obj NewFilter (
     getter = NewOperation( name, 1L, nams, (hdlr ? hdlr : DoFilter) );
     SET_FLAG1_FILT(getter, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(getter, INTOBJ_INT(0));
-    NEW_FLAGS( flags, 1 );
+    flags = NEW_FLAGS( 1 );
     SET_SIZE_FLAGS( flags, INTOBJ_INT(1) );
     SET_TRUE_FLAGS( flags, 0, flag1);
     SET_FLAGS_FILT(getter, flags);
@@ -1252,7 +1278,7 @@ Obj NewReturnTrueFilter ( void )
         DoReturnTrueFilter );
     SET_FLAG1_FILT(getter, INTOBJ_INT(0));
     SET_FLAG2_FILT(getter, INTOBJ_INT(0));
-    NEW_FLAGS( flags, 0 );
+    flags = NEW_FLAGS( 0 );
     SET_SIZE_FLAGS( flags, INTOBJ_INT(0) );
     SET_FLAGS_FILT(getter, flags);
     CHANGED_BAG(getter);
@@ -2699,7 +2725,7 @@ static Obj MakeTester( Obj name, Int flag1, Int flag2)
                            DoTestAttribute );
     SET_FLAG1_FILT(tester, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(tester, INTOBJ_INT(flag2));
-    NEW_FLAGS( flags, flag2 );
+    flags = NEW_FLAGS( 1 );
     SET_SIZE_FLAGS( flags, INTOBJ_INT(1) );
     SET_TRUE_FLAGS( flags, 0, flag2);
     SET_FLAGS_FILT(tester, flags);
@@ -2988,7 +3014,7 @@ Obj NewProperty (
 
     SET_FLAG1_FILT(getter, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(getter, INTOBJ_INT(flag2));
-    NEW_FLAGS( flags, flag2 );
+    flags = NEW_FLAGS( 2 );
     SET_SIZE_FLAGS( flags, INTOBJ_INT(2) );
     SET_TRUE_FLAGS(flags, 0, flag1);
     SET_TRUE_FLAGS(flags, 1, flag2);
@@ -3870,7 +3896,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(IS_SUBSET_FLAGS, 2, "flags1, flags2"),
     GVAR_FUNC(TRUES_FLAGS, 1, "flags"),
     GVAR_FUNC(SIZE_FLAGS, 1, "flags"),
-    GVAR_FUNC(ELM_FLAGS, 2, "flags, pos"),
+    //    GVAR_FUNC(ELM_FLAGS, 2, "flags, pos"),
     GVAR_FUNC(FLAG1_FILTER, 1, "oper"),
     GVAR_FUNC(SET_FLAG1_FILTER, 2, "oper, flag1"),
     GVAR_FUNC(FLAG2_FILTER, 1, "oper"),

--- a/src/opers.h
+++ b/src/opers.h
@@ -224,9 +224,9 @@ static inline void SET_ENABLED_ATTR(Obj oper, Int x)
 *F * * * * * * * * * * * * internal flags functions * * * * * * * * * * * * *
 **
 ** Attempting change April 2018. Flags will be stored as 
-** Size (INTOBJ)  -- could possibly be a UInt2 instead
-** Hash (INTOBJ)
-** AND_CACHE -- Obj
+** AND_CACHE -- Obj (put this first for GASMAN's convenience) 
+** Size (UInt)  -- could possibly be a UInt2 instead
+** Hash (UInt)
 ** Set positions (array of UInt2).
 */
 
@@ -252,46 +252,36 @@ static inline Obj NEW_FLAGS(UInt len)
 
 /****************************************************************************
 **
-*F  TRUES_FLAGS( <flags> )  . . . . . . . . . . list of trues of a flags list
-**
-**  returns the list of trues of <flags> or 0 if the list is not known yet.
-*/
-
-extern Obj TRUES_FLAGS( Obj flags );
-
-
-/****************************************************************************
-**
 *F  SIZE_FLAGS( <flags> ) . . . . . . . . . . .number of true of <flags> 
 */
-static inline Obj SIZE_FLAGS(Obj flags) {
-    return CONST_ADDR_OBJ(flags)[0];
+static inline UInt SIZE_FLAGS(Obj flags) {
+    return ((const UInt *)CONST_ADDR_OBJ(flags))[1];
 }
 
 /****************************************************************************
 **
 *F  SET_SIZE_FLAGS( <flags>, <hash> ) . . . . . . . . . . . . . . .  set size
 */
-static inline void SET_SIZE_FLAGS(Obj flags, Obj size) {
-    ADDR_OBJ(flags)[0] = size;
+static inline void SET_SIZE_FLAGS(Obj flags, UInt size) {
+    ((UInt *)ADDR_OBJ(flags))[1] = size;
 }
 
 /****************************************************************************
 **
 *F  HASH_FLAGS( <flags> ) . . . . . . . . . . . .  hash value of <flags> or 0
 */
-static inline Obj HASH_FLAGS(Obj flags)
+static inline UInt HASH_FLAGS(Obj flags)
 {
-    return CONST_ADDR_OBJ(flags)[1];
+    return ((const UInt *)CONST_ADDR_OBJ(flags))[2];
 }
 
 /****************************************************************************
 **
 *F  SET_HASH_FLAGS( <flags> ) . . . . . . . . . .  set  hash value of <flags>
 */
-static inline void SET_HASH_FLAGS(Obj flags, Obj hash)
+static inline void SET_HASH_FLAGS(Obj flags, UInt hash)
 {
-    ADDR_OBJ(flags)[1] = hash;
+    ((UInt *)ADDR_OBJ(flags))[2] = hash;
 }
 
 /****************************************************************************
@@ -299,7 +289,7 @@ static inline void SET_HASH_FLAGS(Obj flags, Obj hash)
 *F  AND_CACHE_FLAGS( <flags> )  . . . . . . . . . 'and' cache of a flags list
 */
 static inline Obj AND_CACHE_FLAGS(Obj flags) {
-    return CONST_ADDR_OBJ(flags)[2];
+    return CONST_ADDR_OBJ(flags)[0];
 }
 
 
@@ -308,7 +298,7 @@ static inline Obj AND_CACHE_FLAGS(Obj flags) {
 *F  SET_AND_CACHE_FLAGS( <flags>, <len> ) set the 'and' cache of a flags list
 */
 static inline void SET_AND_CACHE_FLAGS(Obj flags, Obj andc) {
-    ADDR_OBJ(flags)[2]=(andc);
+    ADDR_OBJ(flags)[0]=andc;
 }
 
 
@@ -347,6 +337,8 @@ static inline void SET_TRUE_FLAGS(Obj flags, UInt ix, UInt2 filt) {
 **  'C_ELM_FLAGS' returns a result which it is better to use inside the kernel
 **  since the C compiler can't know that True != False. Using C_ELM_FLAGS
 **  gives slightly nicer C code and potential for a little more optimisation.
+**
+*T revisit this to reflect appropriate names and usage
 */
 extern UInt C_ELM_FLAGS(Obj list, UInt pos);
 
@@ -360,25 +352,12 @@ static inline Int SAFE_C_ELM_FLAGS(Obj flags, UInt pos)
 #define SAFE_ELM_FLAGS(list, pos) (SAFE_C_ELM_FLAGS(list, pos) ? True : False)
 
 
-/****************************************************************************
-**
-*F  SET_ELM_FLAGS( <list>, <pos>, <val> ) . .  set an element of a flags list
-**
-**  'SET_ELM_FLAGS' sets  the element at position <pos>   in the flags list
-**  <list> to the value <val>.  <pos> must be a positive integer less than or
-**  equal to the length of <hdList>.  <val> must be either 'true' or 'false'.
-**
-**  Note that  'SET_ELM_FLAGS' is  a macro, so do not  call it with arguments
-**  that have side effects.
-*/
-#define SET_ELM_FLAGS(list,pos,val)  \
- ((val) == True ? \
-  (BLOCK_ELM_FLAGS(list, pos) |= MASK_POS_FLAGS(pos)) : \
-  (BLOCK_ELM_FLAGS(list, pos) &= ~MASK_POS_FLAGS(pos)))
 
 /****************************************************************************
 **
 *F  FuncIS_SUBSET_FLAGS( <self>, <flags1>, <flags2> ) . . . . . . subset test
+**
+*T  export a proper function, rather than a handler
 */
 
 extern Obj FuncIS_SUBSET_FLAGS( Obj self, Obj flags1, Obj flags2 );

--- a/src/opers.h
+++ b/src/opers.h
@@ -230,15 +230,22 @@ static inline void SET_ENABLED_ATTR(Obj oper, Int x)
 ** Set positions (array of UInt2).
 */
 
+/****************************************************************************
+**
+*F  SIZE_PLEN_FLAGS( <fsize> ) . .  bag size for a flags list with <fsize> trues
+*/
+static inline UInt SIZE_PLEN_FLAGS(UInt fsize) {
+    return 3*sizeof(Obj) + 2*fsize;
+}
 
 /****************************************************************************
 **
 *F  NEW_FLAGS( <flags>, <len> ) . . . . . . . . . . . . . . .  new flags list
 */
+
 static inline Obj NEW_FLAGS(UInt len)
-{p
-    UInt size = (3 + ((len+BIPEB-1) >> LBIPEB)) * sizeof(Obj);
-    Obj flags = NewBag(T_FLAGS, size);
+{
+    Obj flags = NewBag(T_FLAGS, SIZE_PLEN_FLAGS(len));
     return flags;
 }
 
@@ -273,33 +280,37 @@ static inline void SET_SIZE_FLAGS(Obj flags, Obj size) {
 **
 *F  HASH_FLAGS( <flags> ) . . . . . . . . . . . .  hash value of <flags> or 0
 */
-static inline UInt LEN_FLAGS(Obj flags)
+static inline Obj HASH_FLAGS(Obj flags)
 {
-    return (SIZE_OBJ(flags) / sizeof(Obj) - 3) << LBIPEB;
-};
+    return CONST_ADDR_OBJ(flags)[1];
+}
+
+/****************************************************************************
+**
+*F  SET_HASH_FLAGS( <flags> ) . . . . . . . . . .  set  hash value of <flags>
+*/
+static inline void SET_HASH_FLAGS(Obj flags, Obj hash)
+{
+    ADDR_OBJ(flags)[1] = hash;
+}
 
 /****************************************************************************
 **
 *F  AND_CACHE_FLAGS( <flags> )  . . . . . . . . . 'and' cache of a flags list
 */
-#define AND_CACHE_FLAGS(list)           (CONST_ADDR_OBJ(list)[2])
+static inline Obj AND_CACHE_FLAGS(Obj flags) {
+    return CONST_ADDR_OBJ(flags)[2];
+}
 
 
 /****************************************************************************
 **
 *F  SET_AND_CACHE_FLAGS( <flags>, <len> ) set the 'and' cache of a flags list
 */
-#define SET_AND_CACHE_FLAGS(flags,andc)  (ADDR_OBJ(flags)[2]=(andc))
+static inline void SET_AND_CACHE_FLAGS(Obj flags, Obj andc) {
+    ADDR_OBJ(flags)[2]=(andc);
+}
 
-
-/****************************************************************************
-**
-*F  NRB_FLAGS( <flags> )  . . . . . .  number of basic blocks of a flags list
-*/
-static inline UInt NRB_FLAGS(Obj flags)
-{
-    return SIZE_OBJ(flags) / sizeof(Obj) - 3;
-};
 
 
 /****************************************************************************
@@ -307,7 +318,6 @@ static inline UInt NRB_FLAGS(Obj flags)
 *F  TRUE_FLAGS( <flags>, <ix> )  the <ix>th set position in flags
 **                               caller is responsible for <ix> being in range
 */
-#define BLOCKS_FLAGS(flags)             ((UInt*)(ADDR_OBJ(flags)+3))
 
 static inline UInt TRUE_FLAGS(Obj flags, UInt ix) {
     return (UInt) ((const UInt2 *)(CONST_ADDR_OBJ(flags) + 3))[ix];

--- a/src/opers.h
+++ b/src/opers.h
@@ -319,8 +319,8 @@ static inline UInt TRUE_FLAGS(Obj flags, UInt ix) {
 **                               caller is responsible for <ix> being in range
 */
 
-static inline void SET_TRUE_FLAGS(Obj flags, UInt ix, UInt filt) {
-    ((UInt2 *)(ADDR_OBJ(flags) +3))[ix] = (UInt2) filt ;
+static inline void SET_TRUE_FLAGS(Obj flags, UInt ix, UInt2 filt) {
+    ((UInt2 *)(ADDR_OBJ(flags) +3))[ix] = filt ;
 }
 
 /****************************************************************************

--- a/src/opers.h
+++ b/src/opers.h
@@ -16,6 +16,7 @@
 
 #include <src/system.h>
 #include <src/calls.h>
+#include <src/bool.h>
 
 
 /****************************************************************************
@@ -221,6 +222,12 @@ static inline void SET_ENABLED_ATTR(Obj oper, Int x)
 /****************************************************************************
 **
 *F * * * * * * * * * * * * internal flags functions * * * * * * * * * * * * *
+**
+** Attempting change April 2018. Flags will be stored as 
+** Size (INTOBJ)  -- could possibly be a UInt2 instead
+** Hash (INTOBJ)
+** AND_CACHE -- Obj
+** Set positions (array of UInt2).
 */
 
 
@@ -229,7 +236,7 @@ static inline void SET_ENABLED_ATTR(Obj oper, Int x)
 *F  NEW_FLAGS( <flags>, <len> ) . . . . . . . . . . . . . . .  new flags list
 */
 static inline Obj NEW_FLAGS(UInt len)
-{
+{p
     UInt size = (3 + ((len+BIPEB-1) >> LBIPEB)) * sizeof(Obj);
     Obj flags = NewBag(T_FLAGS, size);
     return flags;
@@ -242,33 +249,29 @@ static inline Obj NEW_FLAGS(UInt len)
 **
 **  returns the list of trues of <flags> or 0 if the list is not known yet.
 */
-#define TRUES_FLAGS(flags)              (CONST_ADDR_OBJ(flags)[0])
+
+extern Obj TRUES_FLAGS( Obj flags );
 
 
 /****************************************************************************
 **
-*F  SET_TRUES_FLAGS( <flags>, <trues> ) . set number of trues of a flags list
+*F  SIZE_FLAGS( <flags> ) . . . . . . . . . . .number of true of <flags> 
 */
-#define SET_TRUES_FLAGS(flags,trues)    (ADDR_OBJ(flags)[0] = trues)
+static inline Obj SIZE_FLAGS(Obj flags) {
+    return CONST_ADDR_OBJ(flags)[0];
+}
 
+/****************************************************************************
+**
+*F  SET_SIZE_FLAGS( <flags>, <hash> ) . . . . . . . . . . . . . . .  set size
+*/
+static inline void SET_SIZE_FLAGS(Obj flags, Obj size) {
+    ADDR_OBJ(flags)[0] = size;
+}
 
 /****************************************************************************
 **
 *F  HASH_FLAGS( <flags> ) . . . . . . . . . . . .  hash value of <flags> or 0
-*/
-#define HASH_FLAGS(flags)               (CONST_ADDR_OBJ(flags)[1])
-
-
-/****************************************************************************
-**
-*F  SET_HASH_FLAGS( <flags>, <hash> ) . . . . . . . . . . . . . . .  set hash
-*/
-#define SET_HASH_FLAGS(flags,hash)      (ADDR_OBJ(flags)[1] = hash)
-
-
-/****************************************************************************
-**
-*F  LEN_FLAGS( <flags> )  . . . . . . . . . . . . . .  length of a flags list
 */
 static inline UInt LEN_FLAGS(Obj flags)
 {
@@ -301,39 +304,24 @@ static inline UInt NRB_FLAGS(Obj flags)
 
 /****************************************************************************
 **
-*F  BLOCKS_FLAGS( <flags> ) . . . . . . . . . . . . data area of a flags list
+*F  TRUE_FLAGS( <flags>, <ix> )  the <ix>th set position in flags
+**                               caller is responsible for <ix> being in range
 */
 #define BLOCKS_FLAGS(flags)             ((UInt*)(ADDR_OBJ(flags)+3))
 
+static inline UInt TRUE_FLAGS(Obj flags, UInt ix) {
+    return (UInt) ((const UInt2 *)(CONST_ADDR_OBJ(flags) + 3))[ix];
+}
 
 /****************************************************************************
 **
-*F  BLOCK_ELM_FLAGS( <list>, <pos> )  . . . . . . . .  block  of a flags list
-**
-**  'BLOCK_ELM_FLAGS' return the block containing the <pos>-th element of the
-**  flags list <list> as a UInt value, which is also a  valid left hand side.
-**  <pos>  must be a positive  integer  less than or  equal  to the length of
-**  <list>.
-**
-**  Note that 'BLOCK_ELM_FLAGS' is a macro, so do not call it  with arguments
-**  that have side effects.
+*F  SET_TRUE_FLAGS( <flags>, <ix>, <filt> )  the <ix>th set position in flags
+**                               caller is responsible for <ix> being in range
 */
-#define BLOCK_ELM_FLAGS(list, pos)      (BLOCKS_FLAGS(list)[((pos)-1) >> LBIPEB])
 
-
-/****************************************************************************
-**
-*F  MASK_POS_FLAGS( <pos> ) . . .  . .  bit mask for position of a flags list
-**
-**  'MASK_POS_FLAGS(<pos>)' returns a UInt with a single set  bit in position
-**  '(<pos>-1) % BIPEB',
-**  useful for accessing the <pos>-th element of a 'FLAGS' list.
-**
-**  Note that 'MASK_POS_FLAGS'  is a macro, so  do not call it with arguments
-**  that have side effects.
-*/
-#define MASK_POS_FLAGS(pos)             (((UInt) 1)<<(((pos)-1) & (BIPEB-1)))
-
+static inline void SET_TRUE_FLAGS(Obj flags, UInt ix, UInt filt) {
+    ((UInt2 *)(ADDR_OBJ(flags) +3))[ix] = (UInt2) filt ;
+}
 
 /****************************************************************************
 **
@@ -350,14 +338,13 @@ static inline UInt NRB_FLAGS(Obj flags)
 **  since the C compiler can't know that True != False. Using C_ELM_FLAGS
 **  gives slightly nicer C code and potential for a little more optimisation.
 */
-#define C_ELM_FLAGS(list, pos)                                               \
-    ((BLOCK_ELM_FLAGS(list, pos) & MASK_POS_FLAGS(pos)) ? 1 : 0)
+extern UInt C_ELM_FLAGS(Obj list, UInt pos);
 
 #define ELM_FLAGS(list, pos) (C_ELM_FLAGS(list, pos) ? True : False)
 
 static inline Int SAFE_C_ELM_FLAGS(Obj flags, UInt pos)
 {
-    return (pos <= LEN_FLAGS(flags)) ? C_ELM_FLAGS(flags, pos) : 0;
+    return C_ELM_FLAGS(flags, pos);
 }
 
 #define SAFE_ELM_FLAGS(list, pos) (SAFE_C_ELM_FLAGS(list, pos) ? True : False)

--- a/src/opers.h
+++ b/src/opers.h
@@ -271,7 +271,7 @@ static inline FlagsHeader* HEADER_FLAGS(Obj flags) {
 }
 
 static inline const FlagsHeader* CONST_HEADER_FLAGS(Obj flags) {
-    return (FlagsHeader *)CONST_ADDR_OBJ(flags);
+    return (const FlagsHeader *)CONST_ADDR_OBJ(flags);
 }
 
 /****************************************************************************
@@ -329,6 +329,10 @@ static inline void SET_AND_CACHE_FLAGS(Obj flags, Obj andc)
     HEADER_FLAGS(flags)->andCache = andc;
 }
 
+static inline const UInt2* ADDR_TRUES_FLAGS(Obj flags)
+{
+    return &(HEADER_FLAGS(flags)->trues[0]);
+}
 
 /****************************************************************************
 **

--- a/tst/testinstall/kernel/opers.tst
+++ b/tst/testinstall/kernel/opers.tst
@@ -13,7 +13,7 @@ gap> flags2 := FLAGS_FILTER(IsPGroup and IsMutable);
 gap> HASH_FLAGS(fail);
 Error, <flags> must be a flags list (not a boolean or fail)
 gap> HASH_FLAGS(flags);
-2
+82538043
 
 #
 gap> TRUES_FLAGS(fail);


### PR DESCRIPTION
This is a heavily reworked version of #2457 which avoids all the complication of making flags bags be kernel lists by adding a few more GAP callable functions. Also does some code tidying.

The changes to opers.c and opers.h were sufficiently wide-ranging that I have clang-formatted the entire files.