### PR TITLE
gap.sh should respect the GAP_DIR environment var

### DIFF
--- a/cnf/compat/gap.sh.in
+++ b/cnf/compat/gap.sh.in
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 GAP_EXE=$GAP_DIR
-if [ "x$GAP_DIR" = "x" ];  then
-GAP_DIR=$(cd "@abs_top_srcdir@" && pwd)
-GAP_EXE=@abs_top_builddir@
+if [ "x$GAP_DIR" = "x" ]; then
+  GAP_DIR=$(cd "@abs_top_srcdir@" && pwd)
+  GAP_EXE=@abs_top_builddir@
 fi
 
 exec "$GAP_EXE/gap" -l "$GAP_DIR" "$@"

--- a/cnf/compat/gap.sh.in
+++ b/cnf/compat/gap.sh.in
@@ -1,4 +1,9 @@
 #!/bin/sh
 
-GAPDIR=$(cd "@abs_top_srcdir@" && pwd)
-exec "@abs_top_builddir@/gap" -l "$GAPDIR" "$@"
+GAP_EXE=$GAP_DIR
+if [ "x$GAP_DIR" = "x" ];  then
+GAP_DIR=$(cd "@abs_top_srcdir@" && pwd)
+GAP_EXE=@abs_top_builddir@
+fi
+
+exec "$GAP_EXE/gap" -l "$GAP_DIR" "$@"


### PR DESCRIPTION
In previous versions of GAP, if the GAP_DIR environment variable was set, then GAP used this variable to determine the location of GAP.  (Otherwise, it uses sensible defaults.)  This patch returns to this behavior.