### PR TITLE
io: only increment line number for LF, not for CR

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -1228,8 +1228,7 @@ Char GetLine ( void )
     }
 
     /* bump the line number                                                */
-    if (IO()->Input->line < STATE(In) &&
-        (*(STATE(In) - 1) == '\n' || *(STATE(In) - 1) == '\r')) {
+    if (IO()->Input->line < STATE(In) && *(STATE(In) - 1) == '\n') {
         IO()->Input->number++;
     }
 

--- a/tst/test-error/line-continuation.g
+++ b/tst/test-error/line-continuation.g
@@ -1,0 +1,8 @@
+#
+# Verify that a CRLF after a line continuation increments the current line
+# counter only once, so that both examples below report the error in line 2.
+#
+EvalString("123\\\n45x;");
+quit;
+EvalString("123\\\r\n45x;");
+quit;

--- a/tst/test-error/line-continuation.g.out
+++ b/tst/test-error/line-continuation.g.out
@@ -1,0 +1,25 @@
+gap> #
+gap> # Verify that a CRLF after a line continuation increments the current line
+gap> # counter only once, so that both examples below report the error in line 2.
+gap> #
+gap> EvalString("123\\\n45x;");
+Error, Variable: '12345x' must have a value
+not in any function at stream:2
+Error, Could not evaluate string.
+ at GAPROOT/lib/string.gi:655 called from
+<function "EvalString">( <arguments> )
+ called from read-eval loop at *stdin*:6
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> quit;
+gap> EvalString("123\\\r\n45x;");
+Error, Variable: '12345x' must have a value
+not in any function at stream:2
+Error, Could not evaluate string.
+ at GAPROOT/lib/string.gi:655 called from
+<function "EvalString">( <arguments> )
+ called from read-eval loop at *stdin*:6
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> quit;
+gap> QUIT;


### PR DESCRIPTION
This avoids counting lines terminated by CRLF twice, fixing a very obscure bug.