### PR TITLE
Teach BuildPackages.sh how to build simpcomp

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -214,6 +214,10 @@ build_one_package() {
     ;;
 
     simpcomp*)
+      chmod a+x configure depcomp install-sh missing && \
+      echo_run ./configure && \
+      echo_run "$MAKE" && \
+      mkdir -p bin && test -x bin/bistellar || mv bistellar bin
     ;;
 
     *)


### PR DESCRIPTION
... by working around missing executable bits, and moving the bistellar executable into a place where GAP can find it

I would suggest backporting this to stable-4.9. Even if they release a version with fixed, this patch is still useful, as it prevents the script from passing `--with-gaproot` to the simpcomp `configure`, which does not support it.