### PR TITLE
Fix some HPC-GAP bugs and switch HPC-GAP build to use testtravis ...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
     - env: TEST_SUITES=testmanuals CONFIGFLAGS="--enable-debug"
 
     # HPC-GAP builds (for efficiency, we don't build all combinations)
-    - env: TEST_SUITES="docomp testinstall" ABI=64 HPCGAP=yes CONFIGFLAGS="--enable-debug"
+    - env: TEST_SUITES="docomp testtravis" ABI=64 HPCGAP=yes CONFIGFLAGS="--enable-debug"
 
     # out of tree builds -- these are mainly done to verify that the build
     # system work in this scenario. Since we don't expect the test results to

--- a/hpcgap/tst/teststandard/hpc/alist.tst
+++ b/hpcgap/tst/teststandard/hpc/alist.tst
@@ -9,7 +9,7 @@
 gap> START_TEST("alist.tst");
 gap> if IsHPCGAP and not ARCH_IS_WINDOWS() then tasks := 100; else tasks := 10; fi;;
 gap> taskssum := (tasks*(tasks+1))/2;;
-gap> a := AtomicList([1,1,1,1]);
+gap> a := AtomicList([1,1,1,1]);;
 gap> f := function(job)
 > local check;
 > check := false;
@@ -20,12 +20,12 @@ gap> f := function(job)
 > end;;
 gap> joblist := [];;
 gap> for j in [1..4] do for i in [1..tasks] do Add(joblist, [j, i, i+1]); od; od;
-gap> results := List(joblist, x -> RunTask(f, x));
+gap> results := List(joblist, x -> RunTask(f, x));;
 gap> ForAll(results, TaskResult);
 true
 gap> ForAll([1..4], x -> a[x] = tasks + 1);
 true
-gap> a := AtomicList([]);
+gap> a := AtomicList([]);;
 gap> binder := function(val)
 > local i, j, count;
 > count := 0;
@@ -53,7 +53,7 @@ gap> unbinder := function(val)
 >    fi;
 >  od;
 > od;
-> end;
+> end;;
 gap> tasklist := [RunTask(binder, 1), RunTask(binder, 2),
 >              RunTask(unbinder, 1), RunTask(unbinder, 2)];;
 gap> List(tasklist, TaskResult);

--- a/lib/algfld.gi
+++ b/lib/algfld.gi
@@ -64,7 +64,7 @@ end;
 InstallMethod(AlgebraicElementsFamily,"generic",true,
   [IsField,IsUnivariatePolynomial,IsBool],0,
 function(f,p,check)
-local fam,i,cof,red,rchar,impattr,deg;
+local fam,i,cof,red,rchar,impattr,deg,tmp;
   if check and not IsIrreducibleRingElement(PolynomialRing(f,
              [IndeterminateNumberOfLaurentPolynomial(p)]),p) then
     Error("<p> must be irreducible over f");
@@ -101,7 +101,7 @@ local fam,i,cof,red,rchar,impattr,deg;
   fam!.deg:=deg;
   i:=List([1..DegreeOfLaurentPolynomial(p)],i->fam!.zeroCoefficient);
   i[2]:=fam!.oneCoefficient;
-  i:=ImmutableVector(Size(f),i,true);
+  i:=ImmutableVector(f,i,true);
   fam!.primitiveElm:=MakeImmutable(ObjByExtRep(fam,i));
   fam!.indeterminateName:=MakeImmutable("a");
 
@@ -113,7 +113,10 @@ local fam,i,cof,red,rchar,impattr,deg;
     Add(cof,fam!.oneCoefficient);
     if rchar>0 then
       if IsHPCGAP then
-        cof := CopyToVectorRep(cof,rchar); # rchar is <= 256
+        tmp := CopyToVectorRep(cof,rchar); # rchar is <= 256
+        if tmp <> fail then
+          cof := tmp;
+        fi;
       else
         ConvertToVectorRep(cof,rchar);
       fi;


### PR DESCRIPTION
... instead of testinstall. While this makes it slower, this also means we get slightly higher code coverage on the HPC-GAP code.

Also, it uncovered several bugs in HPC-GAP. Two of them are fixed in here, others were fixed in other PRs.