### PR TITLE
Fix HPC-GAP version of TYPE_FIELDINFO_8BIT

### DIFF
--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -97,9 +97,8 @@ end);
 ##  doesn't really say anything, because there are no applicable operations.
 ##
 
-InstallValue( TYPE_FIELDINFO_8BIT,
-  NewType(NewFamily("FieldInfo8BitFamily", IsObject),
-          IsObject and IsDataObjectRep));
+InstallValue( TYPE_FIELDINFO_8BIT, TYPE_KERNEL_OBJECT);
+
 
 #############################################################################
 ##

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -78,7 +78,6 @@ end);
 ##  doesn't really say anything, because there are no applicable operations.
 ##
 
-
 InstallValue( TYPE_FIELDINFO_8BIT, TYPE_KERNEL_OBJECT);
 
 


### PR DESCRIPTION
... by setting it to TYPE_KERNEL_OBJECT


I noticed this drift between GAP and HPC-GAP library while looking for the causes of the failures on #2484 -- sadly, this doesn't really help with that, but it's a fix nevertheless.