### PR TITLE
GASMAN: make some vars static; cleanup InitBags interface & docs

### DIFF
--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -314,7 +314,6 @@ void InitMarkFuncBags(UInt type, TNumMarkFuncBags mark_func)
 }
 
 void InitBags(UInt              initial_size,
-              TNumStackFuncBags stack_func,
               Bag *             stack_bottom,
               UInt              stack_align)
 {

--- a/src/gap.c
+++ b/src/gap.c
@@ -1746,8 +1746,9 @@ void InitializeGap (
     InitSystem( *pargc, argv );
 
     /* Initialise memory  -- have to do this here to make sure we are at top of C stack */
-    InitBags( SyStorMin,
-              0, (Bag*)(((UInt)pargc/C_STACK_ALIGN)*C_STACK_ALIGN), C_STACK_ALIGN );
+    InitBags(SyStorMin,
+             (Bag *)(((UInt)pargc / C_STACK_ALIGN) * C_STACK_ALIGN),
+             C_STACK_ALIGN);
 #ifdef USE_GASMAN
     InitMsgsFuncBags( SyMsgsBags );
 #endif

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1118,8 +1118,6 @@ void FinishBags( void )
 **  in global variables. It also allocates the initial workspace, and sets up
 **  the linked list of available masterpointer.
 */
-TNumStackFuncBags       StackFuncBags;
-
 TNumExtraMarkFuncBags   ExtraMarkFuncBags;
 
 static Bag * StackBottomBags;
@@ -1128,7 +1126,6 @@ static UInt StackAlignBags;
 
 void            InitBags (
     UInt                initial_size,
-    TNumStackFuncBags   stack_func,
     Bag *               stack_bottom,
     UInt                stack_align )
 {
@@ -1140,8 +1137,7 @@ void            InitBags (
     /* install the allocator and the abort function                        */
     ExtraMarkFuncBags = 0;
 
-    /* install the stack marking function and values                       */
-    StackFuncBags   = stack_func;
+    // install the stack values
     StackBottomBags = stack_bottom;
     StackAlignBags  = stack_align;
 
@@ -1886,16 +1882,11 @@ again:
     }
 
     /* mark from the stack                                                 */
-    if ( StackFuncBags ) {
-        (*StackFuncBags)();
-    }
-    else {
-      sySetjmp( RegsBags );
+    sySetjmp( RegsBags );
 #if defined(SPARC)
-        SparcStackFuncBags();
+    SparcStackFuncBags();
 #endif
-        GenStackFuncBags();
-    }
+    GenStackFuncBags();
 
     /* mark the subbags of the changed old bags                            */
     while ( ChangedBags != 0 ) {

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -354,7 +354,7 @@ static int SanityCheckGasmanPointers(void)
 **  collection  its  masterpointer  is  added   to  the  list  of   available
 **  masterpointers again.
 */
-Bag FreeMptrBags;
+static Bag FreeMptrBags;
 
 
 /****************************************************************************
@@ -435,7 +435,7 @@ Bag                     ChangedBags;
 **  'CollectBags' will   mark the bags   in a  depth-first  order.   This  is
 **  probably good to improve the locality of reference.
 */
-Bag                     MarkedBags;
+static Bag MarkedBags;
 
 
 /****************************************************************************
@@ -491,7 +491,7 @@ static inline UInt IS_BAG_BODY(void * ptr)
 **  'InitMsgsFuncBags'  simply  stores  the  printing  function  in a  global
 **  variable.
 */
-TNumMsgsFuncBags        MsgsFuncBags;
+static TNumMsgsFuncBags MsgsFuncBags;
 
 void            InitMsgsFuncBags (
     TNumMsgsFuncBags    msgs_func )
@@ -505,7 +505,7 @@ void            InitMsgsFuncBags (
 *F  InitSweepFuncBags(<type>,<mark-func>)  . . . .  install sweeping function
 */
 
-TNumSweepFuncBags TabSweepFuncBags [ NTYPES ];
+static TNumSweepFuncBags TabSweepFuncBags[NTYPES];
 
 
 void InitSweepFuncBags (
@@ -659,8 +659,8 @@ void MarkAllSubBagsDefault(Bag bag)
 }
 
 #ifdef DEBUG_GASMAN_MARKING
-UInt BadMarksCounter = 0;
-Int DisableMarkBagValidation = 0;
+static UInt BadMarksCounter = 0;
+static Int  DisableMarkBagValidation = 0;
 #endif
 
 
@@ -961,7 +961,7 @@ void FinishedRestoringBags( void )
 **
 **  'InitFreeFuncBag' is really too simple for an explanation.
 */
-TNumFreeFuncBags        TabFreeFuncBags [ 256 ];
+static TNumFreeFuncBags TabFreeFuncBags[256];
 
 void            InitFreeFuncBag (
     UInt                type,
@@ -977,9 +977,9 @@ void            InitFreeFuncBag (
 **
 **  'InitCollectFuncBags' is really too simple for an explanation.
 */
-TNumCollectFuncBags     BeforeCollectFuncBags;
+static TNumCollectFuncBags BeforeCollectFuncBags;
 
-TNumCollectFuncBags     AfterCollectFuncBags;
+static TNumCollectFuncBags AfterCollectFuncBags;
 
 void            InitCollectFuncBags (
     TNumCollectFuncBags before_func,
@@ -1122,9 +1122,9 @@ TNumStackFuncBags       StackFuncBags;
 
 TNumExtraMarkFuncBags   ExtraMarkFuncBags;
 
-Bag *                   StackBottomBags;
+static Bag * StackBottomBags;
 
-UInt                    StackAlignBags;
+static UInt StackAlignBags;
 
 void            InitBags (
     UInt                initial_size,

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -970,51 +970,31 @@ extern  void            InitCollectFuncBags (
 **
 *F  InitBags(...) . . . . . . . . . . . . . . . . . . . . . initialize Gasman
 **
-**  InitBags( <alloc-func>, <initial-size>,
-**            <stack-func>, <stack-start>, <stack-align>,
-**            <abort-func> )
+**  InitBags( <initialSize>, <stackStart>, <stackAlign> )
 **
 **  'InitBags'  initializes {\Gasman}.  It  must be called from a application
 **  using {\Gasman} before any bags can be allocated.
 **
-**  <initial-size> must be the size of  the initial workspace that 'InitBags'
+**  <initialSize> must be the size of  the initial workspace that 'InitBags'
 **  should allocate.  This   value is automatically rounded   up to the  next
 **  multiple of 1/2 MByte by 'InitBags'.
 **
-**  <stack-func>  must be   a    function    that  applies  'MarkBag'   (see
-**  "InitMarkFuncBags") to each possible bag identifier on the application\'s
-**  stack, i.e., the stack where the applications local variables  are saved.
-**  This should be a function of no  arguments  and return type 'void'.  This
-**  function   is  called  from  'CollectBags'  to  mark   all bags  that are
-**  accessible from  local variables.   There  is a generic function for this
-**  purpose, which is called  when the application passes  0 as <stack-func>,
-**  which will work all right on most machines, but *may* fail on some of the
-**  more exotic machines.
+**  <stackStart> must be the start of the stack. Note that the start of the
+**  stack is either the bottom or the top of the stack, depending on whether
+**  the stack grows upward or downward. A value that usually works is the
+**  address of the argument 'argc' of the 'main' function of the application,
+**  i.e., '(Bag\*)\&argc'.
 **
-**  If the application passes 0 as value for <stack-func>, <stack-start> must
-**  be the start of the stack.   Note that the  start of the  stack is either
-**  the bottom or the top of the stack, depending  on whether the stack grows
-**  upward  or downward.  A  value that usually works is  the address  of the
-**  argument  'argc'   of the  'main' function    of the  application,  i.e.,
-**  '(Bag\*)\&argc'.  If  the application   provides  another   <stack-func>,
-**  <stack-start> is ignored.
-**
-**  If the application passes 0 as value for <stack-func>, <stack-align> must
-**  be  the alignment  of items  of  type 'Bag' on the  stack.   It must be a
-**  divisor of 'sizeof(Bag)'.  The addresses of  all identifiers on the stack
-**  must be a multiple  of <stack-align>.  So if  it is 1, identifiers may be
-**  anywhere on the stack, and  if it is  'sizeof(Bag)', identifiers may only
-**  be at addresses that are a multiple of 'sizeof(Bag)'.  This value depends
-**  on  the   machine,  the  operating system,   and   the compiler.   If the
-**  application provides another <stack-func>, <stack-align> is ignored.
+**  <stackAlign> must be the alignment of items of type 'Bag' on the stack.
+**  It must be a divisor of 'sizeof(Bag)'. The addresses of all identifiers
+**  on the stack must be a multiple of <stackAlign>. If it is 1, identifiers
+**  may be anywhere on the stack, and if it is 'sizeof(Bag)', identifiers may
+**  only be at addresses that are a multiple of 'sizeof(Bag)'. This value
+**  depends on the machine, the operating system, and the compiler.
 */
-typedef void (*TNumStackFuncBags)(void);
 typedef void (*TNumExtraMarkFuncBags)(void);
 
-extern void InitBags(UInt              initial_size,
-                     TNumStackFuncBags stack_func,
-                     Bag *             stack_bottom,
-                     UInt              stack_align);
+extern void InitBags(UInt initialSize, Bag * stackStart, UInt stackAlign);
 
 /****************************************************************************
 **


### PR DESCRIPTION
The main change here is the removal of the `stack_func` argument from `InitBags`, which was never used. The only scenario in which it might be relevant is if some future system architecture we want to support is not supported by our current stack scanner. But I think we'd then simply put the new code into `gasman.c`; we wouldn't set a custom `stack_func`.

Note that this does not touch the `ExtraMarkFuncBags` which @markuspf added for libgap, it stays in place.