### PR TITLE
Allow a help expression to return a value

### DIFF
--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1168,6 +1168,7 @@ void IntrHelp(Obj topic)
 {
     UInt hgvar;
     Obj  help;
+    Obj  res;
 
     if (STATE(IntrReturning) > 0) {
         return;
@@ -1191,8 +1192,11 @@ void IntrHelp(Obj topic)
                    0L, 0L );
     }
 
-    CALL_1ARGS(help, topic);
-    PushVoidObj();
+    res = CALL_1ARGS(help, topic);
+    if (res)
+        PushObj(res);
+    else
+        PushVoidObj();
 }
 
 


### PR DESCRIPTION
We introduced special syntax to access help in 60892e60, but didn't allow
a help expression to return a result.

This broke how help works in the JupyterKernel, this commits merely repairs
the previous behaviour.