### PR TITLE
Sync recent change to HPC-GAP

### DIFF
--- a/hpcgap/lib/coll.gd
+++ b/hpcgap/lib/coll.gd
@@ -1425,7 +1425,7 @@ DeclareProperty( "IsNonTrivial", IsCollection );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareProperty( "IsFinite", IsCollection );
+DeclareProperty( "IsFinite", IsListOrCollection );
 
 InstallSubsetMaintenance( IsFinite,
     IsCollection and IsFinite, IsCollection );


### PR DESCRIPTION
This syncs a change from PR #2222 which was added there "at the last minute", and for which I subsequently forgot to also apply it to `hpcgap/lib`.
