### PR TITLE
kernel: rewrite SyFindOrLinkGapRootFile, update comments

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -425,7 +425,7 @@ Int READ_GAP_ROOT ( const Char * filename )
             Pr( "#I  READ_GAP_ROOT: loading '%s' as GAP file\n",
                 (Int)filename, 0L );
         }
-        if ( OpenInput(result.pathname) ) {
+        if ( OpenInput(result.path) ) {
             while ( 1 ) {
                 ClearError();
                 Obj evalResult;

--- a/src/streams.c
+++ b/src/streams.c
@@ -385,14 +385,16 @@ Int READ_GAP_ROOT ( const Char * filename )
         return 0;
     }
 
-    /* dynamically or statically linked                                    */
-    else if ( res == 1 || res == 2 ) {
-        // This code section covers loading of GAC compiled code; in contrast
-        // to FuncLOAD_STAT and FuncLOAD_DYN, which are typically used by
-        // kernel extensions to load C/C++ code.
+    // statically linked
+    else if (res == 2) {
+        // This code section covers transparently loading GAC compiled
+        // versions of GAP source files, by running code similar to that in
+        // FuncLOAD_STAT. For example, lib/oper1.g is compiled into C code
+        // which is stored in src/c_oper1.c; when reading lib/oper1.g, we
+        // instead will load its compiled version.
         if ( SyDebugLoading ) {
-            const char *s = (res == 1) ? "dynamically" : "statically";
-            Pr( "#I  READ_GAP_ROOT: loading '%s' %s\n", (Int)filename, (Int)s );
+            Pr("#I  READ_GAP_ROOT: loading '%s' statically\n", (Int)filename,
+               0);
         }
         info = result.module_info;
         res  = info->initKernel(info);

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -108,16 +108,15 @@ ssize_t echoandcheck(int fid, const char *buf, size_t count) {
 *F  SyFindOrLinkGapRootFile( <filename>, <result> ) . . . . . .  load or link
 **
 **  'SyFindOrLinkGapRootFile'  tries to find a GAP  file in the root area and
-**  check  if   there is a corresponding    statically  or dynamically linked
-**  module.  If the CRC matches this module  is loaded otherwise the filename
-**  is returned.
+**  check if there is a corresponding statically linked module. If the CRC
+**  matches the statically linked module is loaded, and <result->module_info>
+**  is set to point to its StructInitInfo instance.
 **
 **  The function returns:
 **
 **  0: no file or module was found
-**  1: if a dynamically linked module was found
 **  2: if a statically linked module was found
-**  3: a GAP file was found
+**  3: if only a GAP file was found; its path is stored in  <result->pathname>
 */
 Int SyFindOrLinkGapRootFile (
     const Char *        filename,

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -29,16 +29,15 @@
 *F  SyFindOrLinkGapRootFile( <filename>, <result> ) . . . . . .  load or link
 **
 **  'SyFindOrLinkGapRootFile'  tries to find a GAP  file in the root area and
-**  check  if   there is a corresponding    statically  or dynamically linked
-**  module.  If the CRC matches this module  is loaded otherwise the filename
-**  is returned.
+**  check if there is a corresponding statically linked module. If the CRC
+**  matches the statically linked module is loaded, and <result->module_info>
+**  is set to point to its StructInitInfo instance.
 **
 **  The function returns:
 **
 **  0: no file or module was found
-**  1: if a dynamically linked module was found
 **  2: if a statically linked module was found
-**  3: a GAP file was found
+**  3: if only a GAP file was found; its path is stored in  <result->pathname>
 */
 
 typedef union {

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -36,13 +36,13 @@
 **  The function returns:
 **
 **  0: no file or module was found
-**  2: if a statically linked module was found
-**  3: if only a GAP file was found; its path is stored in  <result->pathname>
+**  2: a statically linked module was found
+**  3: only a GAP file was found; its path is stored in  <result->path>
 */
 
 typedef union {
-  Char pathname[GAP_PATH_MAX];
-  StructInitInfo * module_info;
+    Char             path[GAP_PATH_MAX];
+    StructInitInfo * module_info;
 } TypGRF_Data;
 
 extern Int SyFindOrLinkGapRootFile (

--- a/src/system.c
+++ b/src/system.c
@@ -273,7 +273,7 @@ Int SyLoadSystemInitFile = 1;
 
 /****************************************************************************
 **
-*V  SyUseModule . . . . . check for dynamic/static modules in 'READ_GAP_ROOT'
+*V  SyUseModule . . . . . . . . . check for static modules in 'READ_GAP_ROOT'
 */
 int SyUseModule;
 

--- a/src/system.h
+++ b/src/system.h
@@ -496,7 +496,7 @@ extern Int SyLoadSystemInitFile;
 
 /****************************************************************************
 **
-*V  SyUseModule . . . . . check for dynamic/static modules in 'READ_GAP_ROOT'
+*V  SyUseModule . . . . . . . . . check for static modules in 'READ_GAP_ROOT'
 */
 extern int SyUseModule;
 


### PR DESCRIPTION
Rewriting `SyFindOrLinkGapRootFile` extends simplification work begun by @stevelinton in PR #448. I also update relevant documentation comments to actually reflect current reality. Specifically, we (well, @stevelinton) removed the ability to load GAC compiled replacements for GAP library files *dynamically* -- we now only look for statically linked ones, like `src/c_oper1.c`. However, the documentation for `SyFindOrLinkGapRootFile` and various other places still referred to the dynamic versions. There also was a return code for that.

The first commit in this PR updates all these comments.

The second commit then completely rewrites `SyFindOrLinkGapRootFile` for clarity.

The third and final commit simplifies `READ_GAP_ROOT` by taking advantage of the fact that the return value for dynamlically linked files is now unused. It also corrects and expands a comment.


UPDATE: this PR also used to modify the `StructInitInfo` typedef, but that was moved to PR #2541