### PR TITLE
Warning update

### DIFF
--- a/cnf/m4/ax_compiler_flags_cflags.m4
+++ b/cnf/m4/ax_compiler_flags_cflags.m4
@@ -19,13 +19,14 @@
 # LICENSE
 #
 #   Copyright (c) 2014, 2015 Philip Withnall <philip@tecnocode.co.uk>
+#   Copyright (c) 2017, 2018 Reini Urban <rurban@cpan.org>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 14
+#serial 16
 
 AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
     AC_REQUIRE([AC_PROG_SED])
@@ -38,6 +39,13 @@ AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
               [m4_normalize(ifelse([$1],,[WARN_CFLAGS],[$1]))])
 
     AC_LANG_PUSH([C])
+
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+      [#ifndef __cplusplus
+       #error "no C++"
+       #endif]])],
+      [ax_compiler_cxx=yes;],
+      [ax_compiler_cxx=no;])
 
     # Always pass -Werror=unknown-warning-option to get Clang to fail on bad
     # flags, otherwise they are always appended to the warn_cflags variable, and
@@ -69,12 +77,9 @@ AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
             -Wall dnl
             -Wextra dnl
             -Wundef dnl
-            -Wnested-externs dnl
             -Wwrite-strings dnl
             -Wpointer-arith dnl
             dnl -Wmissing-declarations dnl
-            dnl -Wmissing-prototypes dnl
-            dnl -Wstrict-prototypes dnl
             -Wredundant-decls dnl
             -Wno-unused-parameter dnl
             -Wmissing-field-initializers dnl
@@ -95,17 +100,34 @@ AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
             -Wmissing-include-dirs dnl
             -Wunused-but-set-variable dnl
             -Warray-bounds dnl
-            -Wimplicit-function-declaration dnl
             -Wreturn-type dnl
-            -Wswitch-enum dnl
+            dnl -Wswitch-enum dnl
             dnl -Wswitch-default dnl
             -Wno-implicit-fallthrough dnl
             -Wno-inline dnl
+            -Wduplicated-cond dnl
+            -Wduplicated-branches dnl
+            -Wlogical-op dnl
+            -Wrestrict dnl
+            dnl -Wnull-dereference dnl
+            -Wdouble-promotion dnl
             $4 dnl
             $5 dnl
             $6 dnl
             $7 dnl
         ],ax_warn_cflags_variable,[$ax_compiler_flags_test])
+        if test "$ax_compiler_cxx" = "no" ; then
+            # C-only flags. Warn in C++
+            AX_APPEND_COMPILE_FLAGS([ dnl
+            -Wnested-externs dnl
+            dnl -Wmissing-prototypes dnl
+            dnl -Wstrict-prototypes dnl
+            dnl -Wdeclaration-after-statement dnl
+            -Wimplicit-function-declaration dnl
+            -Wold-style-definition dnl
+            -Wjump-misses-init dnl
+            ],ax_warn_cflags_variable,[$ax_compiler_flags_test])
+        fi
     ])
     AS_IF([test "$ax_enable_compile_warnings" = "error"],[
         # "error" flags; -Werror has to be appended unconditionally because

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -349,6 +349,8 @@ static UInt GetNumber(Int readDecimalPoint)
   UInt i = 0;
   Char c;
   UInt seenADigit = 0;
+  UInt seenExp = 0;
+  UInt seenExpDigit = 0;
 
   STATE(ValueObj) = 0;
 
@@ -461,7 +463,7 @@ static UInt GetNumber(Int readDecimalPoint)
     }
 
     // If the next thing is the start of the exponential notation, read it now.
-    UInt seenExp = 0;
+
     if (IsAlpha(c)) {
       if (!seenADigit)
         SyntaxError("Badly formed number: need a digit before or after "
@@ -508,7 +510,6 @@ static UInt GetNumber(Int readDecimalPoint)
 
   // Here we are into the unsigned exponent of a number in scientific
   // notation, so we just read digits
-  UInt seenExpDigit = 0;
 
   while (IsDigit(c)) {
     i = AddCharToValue(i, c);


### PR DESCRIPTION
This updates the list of warnings we use to the latest version, keeping our modifications.

I also disable -Wswitch-enum, as it doesn't let you use 'default' in a switch.

EDIT: There is one warning i needed to fix. This commit first had a big giant diff, now I have a much smaller one. While this does make this function slightly worse (i think), the warning is generally useful so I'd like to keep it.