### PR TITLE
kernel: make module state initialization order consistent

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -1774,7 +1774,6 @@ void InitializeGap (
 #ifdef HPCGAP
     InitMainThread();
 #endif
-    ModulesInitModuleState();
 
     InitGlobalBag(&POST_RESTORE, "gap.c: POST_RESTORE");
     InitFopyGVar( "POST_RESTORE", &POST_RESTORE);
@@ -1813,9 +1812,9 @@ void InitializeGap (
 
     /* if we are restoring, load the workspace and call the post restore   */
     if ( SyRestoring ) {
+        ModulesInitModuleState();
         LoadWorkspace(SyRestoring);
         SyRestoring = NULL;
-
 
         /* Call POST_RESTORE which is a GAP function that now takes control, 
            calls the post restore functions and then runs a GAP session */
@@ -1836,6 +1835,8 @@ void InitializeGap (
 
         SyInitializing = 1;
         ModulesInitLibrary();
+        ModulesInitModuleState();
+
     }
 
     /* check initialisation                                                */

--- a/src/objcftl.c
+++ b/src/objcftl.c
@@ -368,18 +368,6 @@ static Int InitKernel (
 
 /****************************************************************************
 **
-*F  PostRestore( <module> ) . . . . . . . . . . . . . after restore workspace
-*/
-static Int PostRestore (
-    StructInitInfo *    module )
-{
-    /* return success                                                      */
-    return 0;
-}
-
-
-/****************************************************************************
-**
 *F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
 */
 static Int InitLibrary (
@@ -445,7 +433,6 @@ static StructInitInfo module = {
     .name = "objcftl",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
-    .postRestore = PostRestore,
 
     .moduleStateSize = sizeof(struct CFTLModuleState),
     .moduleStateOffsetPtr = &CFTLStateOffset,

--- a/src/stats.c
+++ b/src/stats.c
@@ -1582,19 +1582,6 @@ void            PrintReturnVoid (
 */
 
 
-
-/****************************************************************************
-**
-*F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
-*/
-static Int InitLibrary (
-    StructInitInfo *    module )
-{
-
-    /* return success                                                      */
-    return 0;
-}
-
 /****************************************************************************
 **
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
@@ -1728,7 +1715,6 @@ static StructInitInfo module = {
     .type = MODULE_BUILTIN,
     .name = "stats",
     .initKernel = InitKernel,
-    .initLibrary = InitLibrary,
     .initModuleState = InitModuleState,
 };
 

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -3883,21 +3883,8 @@ void InitSysFiles(void)
     setbuf(stderr, (char *)0);
 }
 
-/* NB Should probably do some checks preSave for open files etc and refuse to save
+/* TODO: Should probably do some checks preSave for open files etc and refuse to save
    if any are found */
-
-/****************************************************************************
-**
-*F  postResore( <module> ) . . . . . . .re-initialise library data structures
-*/
-
-static Int postRestore (
-    StructInitInfo *    module )
-{
-
-    /* return success                                                      */
-    return 0;
-}
 
 /****************************************************************************
 **
@@ -3937,7 +3924,7 @@ static Int InitLibrary(
   /* init filters and functions                                          */
   InitGVarFuncsFromTable( GVarFuncs );
 
-  return postRestore( module );
+  return 0;
 }
 
 /****************************************************************************
@@ -3951,7 +3938,6 @@ static StructInitInfo module = {
     .name = "sysfiles",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
-    .postRestore = postRestore
 };
 
 StructInitInfo * InitInfoSysFiles ( void )

--- a/src/vars.c
+++ b/src/vars.c
@@ -2771,7 +2771,7 @@ static Int InitLibrary (
     InitGVarFuncsFromTable( GVarFuncs );
 
     /* return success                                                      */
-    return PostRestore( module );
+    return 0;
 }
 
 
@@ -2789,6 +2789,7 @@ static Int InitModuleState(void)
     SET_BODY_FUNC( tmpFunc, tmpBody );
 
     STATE(CurrLVars) = STATE(BottomLVars);
+    SWITCH_TO_OLD_LVARS( STATE(BottomLVars) );
 
     // return success
     return 0;


### PR DESCRIPTION
This PR ensures that the order in which the various module initialization functions are called is consistent between the main thread, and other threads.

Specifically, with this PR, we (still) always call `InitKernel` first (and only once per module, on the main thread); then `InitLibrary` (also only once and on the main thread); and then `InitModuleState` (once per thread). 

In contrast, previously we called `InitLibrary` *after* `InitModuleState` on the main thread; but on all other threads, of course `InitModuleState` was by necessity called after the single `InitLibrary` call during startup.


OLD DESCRIPTION FOLLOWS:

This changes the way we handle module state initialization: `InitModuleState` is now a member of `StructInitInfo`, just like `InitKernel`, `InitLibrary` etc. -- and so are the size of the module state (if any) etc.. As a result, `RegisterModuleState` can be removed, and module state handling is now similar to all other aspects of the module "API".

This is work in progress; the commits are not yet cleaned up, some comments still need to be adapted, moved and written etc. I mainly submit it here already now to (a) get some test feedback from Travis, and (b) to get some early feedback on this: no point in wasting time on cleaning this up if it has no chance of ever being merged anyway...

Contains PR #2507