### PR TITLE
kernel: add missing IntrReturning check to IntrNot

### DIFF
--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1375,8 +1375,9 @@ void            IntrNot ( void )
     Obj                 op;             /* operand                         */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrIgnoring) > 0 ) { return; }
-    if ( STATE(IntrCoding)   > 0 ) { CodeNot(); return; }
+    if ( STATE(IntrReturning) > 0 ) { return; }
+    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    if ( STATE(IntrCoding)    > 0 ) { CodeNot(); return; }
 
 
     /* get and check the operand                                           */


### PR DESCRIPTION
Using `IntrReturning` or `IntrIgnoring` is a possible way to use the parser without executing code. But that requires that we really always check both in every `Intr*` function.