### PR TITLE
More scanner refactoring

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -104,28 +104,28 @@ void SyntaxWarning(const Char * msg)
 **
 *F  AppendBufToString()
 **
-**  Append 'bufLen' bytes from the string buffer 'buf' to the string object
+**  Append 'bufsize' bytes from the string buffer 'buf' to the string object
 **  'string'. If 'string' is 0, then a new string object is allocated first.
 **
 **  The string object is returned at the end, regardless of whether it was
 **  given as an argument, or created from scratch.
 **
 */
-static Obj AppendBufToString(Obj string, const char * buf, UInt bufLen)
+static Obj AppendBufToString(Obj string, const char * buf, UInt bufsize)
 {
     char *s;
     if (string == 0) {
-        string = NEW_STRING(bufLen);
+        string = NEW_STRING(bufsize);
         s = CSTR_STRING(string);
     }
     else {
         const UInt len = GET_LEN_STRING(string);
-        GROW_STRING(string, len + bufLen);
-        SET_LEN_STRING(string, len + bufLen);
+        GROW_STRING(string, len + bufsize);
+        SET_LEN_STRING(string, len + bufsize);
         s = CSTR_STRING(string) + len;
     }
-    memcpy(s, buf, bufLen);
-    s[bufLen] = '\0';
+    memcpy(s, buf, bufsize);
+    s[bufsize] = '\0';
     return string;
 }
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -251,7 +251,7 @@ static UInt GetIdent(Int i)
         }
 
         /// put char into 'STATE(Value)' but only if there is room
-        if (i < SAFE_VALUE_SIZE - 1)
+        if (i < MAX_VALUE_LEN - 1)
             STATE(Value)[i] = c;
 
         // read the next character
@@ -259,9 +259,9 @@ static UInt GetIdent(Int i)
     }
 
     // terminate the identifier and lets assume that it is not a keyword
-    if (i > SAFE_VALUE_SIZE-1) {
+    if (i > MAX_VALUE_LEN - 1) {
         SyntaxError("Identifiers in GAP must consist of at most 1023 characters.");
-        i = SAFE_VALUE_SIZE-1;
+        i = MAX_VALUE_LEN - 1;
     }
     STATE(Value)[i] = '\0';
 
@@ -348,7 +348,7 @@ static UInt AddCharToBuf(Obj * string, Char * buf, UInt bufsize, UInt pos, Char 
 
 static UInt AddCharToValue(UInt pos, Char c)
 {
-    return AddCharToBuf(&STATE(ValueObj), STATE(Value), SAFE_VALUE_SIZE - 1, pos, c);
+    return AddCharToBuf(&STATE(ValueObj), STATE(Value), MAX_VALUE_LEN - 1, pos, c);
 }
 
 static UInt GetNumber(Int readDecimalPoint)
@@ -380,8 +380,8 @@ static UInt GetNumber(Int readDecimalPoint)
       // if necessary, copy back from STATE(ValueObj) to STATE(Value)
       if (STATE(ValueObj)) {
         i = GET_LEN_STRING(STATE(ValueObj));
-        GAP_ASSERT(i >= SAFE_VALUE_SIZE-1);
-        memcpy(STATE(Value), CSTR_STRING(STATE(ValueObj)), SAFE_VALUE_SIZE);
+        GAP_ASSERT(i >= MAX_VALUE_LEN - 1);
+        memcpy(STATE(Value), CSTR_STRING(STATE(ValueObj)), MAX_VALUE_LEN);
         STATE(ValueObj) = 0;
       }
       // this looks like an identifier, scan the rest of it
@@ -391,7 +391,7 @@ static UInt GetNumber(Int readDecimalPoint)
     // Or maybe we saw a '.' which could indicate one of two things: a
     // float literal or S_DOT, i.e., '.' used to access a record entry.
     if (c == '.') {
-      GAP_ASSERT(i < SAFE_VALUE_SIZE - 1);
+      GAP_ASSERT(i < MAX_VALUE_LEN - 1);
 
       // If the symbol before this integer was S_DOT then we must be in
       // a nested record element expression, so don't look for a float.

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -207,7 +207,6 @@ typedef UInt            TypSymbolSet;
 **  'GetIdent' truncates an identifier after that many characters.
 */
 
-#define         SAFE_VALUE_SIZE 1024
 
 /****************************************************************************
 **


### PR DESCRIPTION
Motivation: this (IMHO) simplifies the code parsing strings, i.e., makes it more readable. It also encapsulates the handling of the value buffer, meaning that if we ever want to change the buffer size, doing so is trivial (on does not have to adjust checks in multiple places, nor use strange checks like `if (i + 2 >= sizeof(buf))`