### PR TITLE
Change Test() to reject unexpected or invalid inputs

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -63,6 +63,7 @@ InstallGlobalFunction(ParseTestInput, function(str, ignorecomments)
       Add(outp[Length(outp)], '\n');
       i := i+1;
     else
+      Error("Invalid data in test file");
       i := i+1;
     fi;
   od;


### PR DESCRIPTION
This is a somewhat experimental change to fix #2506 -- let's see if the GAP test suite passes with it.

Assuming this works for the test suite, I wonder if there are any reasonable scenarios where the new `Error` call is triggered and where this is undesirable. If anybody knows such an example, please bring it up. In that case, we could add an option to turn off that error; or restrict the cases in which it is triggered.
