### PR TITLE
Overhaul tracking of current statement

### DIFF
--- a/doc/dev/kernel.xml
+++ b/doc/dev/kernel.xml
@@ -886,7 +886,6 @@ CHANGED_BAG( t_1 );
 t_2 = POW( a_x, INTOBJ_INT(3) );
 SET_ELM_PLIST( t_1, 3, t_2 );
 CHANGED_BAG( t_1 );
-RES_BRK_CURR_STAT();
 SWITCH_TO_OLD_FRAME(oldFrame);
 return t_1;
 ]]>

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -218,12 +218,9 @@ static Obj  HdlrFunc2 (
  (void)l_loc;
  (void)l_newflags;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if IGNORE_IMMEDIATE_METHODS then */
  t_2 = GC_IGNORE__IMMEDIATE__METHODS;
@@ -233,7 +230,6 @@ static Obj  HdlrFunc2 (
  if ( t_1 ) {
   
   /* return; */
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return 0;
   
@@ -251,7 +247,6 @@ static Obj  HdlrFunc2 (
  if ( t_1 ) {
   
   /* return; */
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return 0;
   
@@ -586,12 +581,10 @@ static Obj  HdlrFunc2 (
  /* od */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -635,12 +628,9 @@ static Obj  HdlrFunc3 (
  (void)l_lk;
  (void)l_rank;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if IS_FUNCTION( baserank ) then */
  t_3 = GF_IS__FUNCTION;
@@ -1284,12 +1274,10 @@ static Obj  HdlrFunc3 (
  CALL_2ARGS( t_1, a_opr, l_narg );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1302,12 +1290,9 @@ static Obj  HdlrFunc4 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* INSTALL_METHOD( arg, true ); */
  t_1 = GF_INSTALL__METHOD;
@@ -1315,12 +1300,10 @@ static Obj  HdlrFunc4 (
  CALL_2ARGS( t_1, a_arg, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1333,12 +1316,9 @@ static Obj  HdlrFunc5 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* INSTALL_METHOD( arg, false ); */
  t_1 = GF_INSTALL__METHOD;
@@ -1346,12 +1326,10 @@ static Obj  HdlrFunc5 (
  CALL_2ARGS( t_1, a_arg, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1416,12 +1394,9 @@ static Obj  HdlrFunc6 (
  (void)l_notmatch;
  (void)l_lk;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* len := LEN_LIST( arglist ); */
  t_2 = GF_LEN__LIST;
@@ -2397,12 +2372,10 @@ static Obj  HdlrFunc6 (
  CALL_6ARGS( t_1, l_opr, l_info, l_rel, l_flags, l_rank, l_method );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2428,12 +2401,9 @@ static Obj  HdlrFunc8 (
  (void)l_found;
  (void)l_prop;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* found := false; */
  t_1 = False;
@@ -2503,7 +2473,6 @@ static Obj  HdlrFunc8 (
     /* TryNextMethod(); */
     t_5 = GC_TRY__NEXT__METHOD;
     CHECK_BOUND( t_5, "TRY_NEXT_METHOD" )
-    RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_5;
     
@@ -2526,7 +2495,6 @@ static Obj  HdlrFunc8 (
   CHECK_FUNC( t_2 )
   t_1 = CALL_1ARGS( t_2, a_obj );
   CHECK_FUNC_RESULT( t_1 )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2538,7 +2506,6 @@ static Obj  HdlrFunc8 (
   /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
   CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2546,12 +2513,10 @@ static Obj  HdlrFunc8 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2586,13 +2551,10 @@ static Obj  HdlrFunc7 (
  (void)l_i;
  (void)l_lk;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,2,0,oldFrame);
  ASS_LVAR( 1, a_getter );
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then */
  t_4 = GF_IS__IDENTICAL__OBJ;
@@ -2780,12 +2742,10 @@ static Obj  HdlrFunc7 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2806,12 +2766,9 @@ static Obj  HdlrFunc9 (
  Obj t_4 = 0;
  Obj t_5 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* InstallOtherMethod( setter, "default method, does nothing", true, [ IS_OBJECT, IS_OBJECT ], 0, DO_NOTHING_SETTER ); */
  t_1 = GF_InstallOtherMethod;
@@ -2832,12 +2789,10 @@ static Obj  HdlrFunc9 (
  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2861,12 +2816,9 @@ static Obj  HdlrFunc10 (
  (void)l_j;
  (void)l_k;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* k := LEN_LIST( list ) + 1; */
  t_3 = GF_LEN__LIST;
@@ -2930,12 +2882,10 @@ static Obj  HdlrFunc10 (
  /* od */
  
  /* return k; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_k;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2950,12 +2900,9 @@ static Obj  HdlrFunc12 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if not IsPrimeInt( key ) then */
  t_4 = GF_IsPrimeInt;
@@ -2977,12 +2924,10 @@ static Obj  HdlrFunc12 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2994,22 +2939,17 @@ static Obj  HdlrFunc13 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return [  ]; */
  t_1 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_1, 0 );
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3032,12 +2972,9 @@ static Obj  HdlrFunc14 (
  (void)l_i;
  (void)l_erg;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
@@ -3140,12 +3077,10 @@ static Obj  HdlrFunc14 (
  C_SUM_FIA( t_2, l_i, INTOBJ_INT(1) )
  CHECK_INT_POS( t_2 )
  C_ELM_LIST_FPL( t_1, l_known, t_2 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3166,12 +3101,9 @@ static Obj  HdlrFunc15 (
  (void)l_known;
  (void)l_i;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
@@ -3217,12 +3149,10 @@ static Obj  HdlrFunc15 (
   "<expr> must be 'true' or 'false' or a filter (not a %s)",
   (Int)TNAM_OBJ(t_2), 0L );
  }
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3244,12 +3174,9 @@ static Obj  HdlrFunc16 (
  (void)l_known;
  (void)l_i;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
@@ -3318,12 +3245,10 @@ static Obj  HdlrFunc16 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3348,14 +3273,11 @@ static Obj  HdlrFunc11 (
  (void)l_str;
  (void)l_lk;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,4,0,oldFrame);
  ASS_LVAR( 1, a_name );
  ASS_LVAR( 2, a_keytest );
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if keytest = "prime" then */
  t_2 = OBJ_LVAR( 2 );
@@ -3635,12 +3557,10 @@ static Obj  HdlrFunc11 (
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3669,12 +3589,9 @@ static Obj  HdlrFunc18 (
  Obj t_17 = 0;
  Obj t_18 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* re := false; */
  t_1 = False;
@@ -3806,7 +3723,6 @@ static Obj  HdlrFunc18 (
   CHECK_BOUND( t_3, "oper" )
   t_1 = CALL_2ARGS( t_2, t_3, a_arg );
   CHECK_FUNC_RESULT( t_1 )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -3818,7 +3734,6 @@ static Obj  HdlrFunc18 (
   /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
   CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -3826,12 +3741,10 @@ static Obj  HdlrFunc18 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3856,12 +3769,9 @@ static Obj  HdlrFunc17 (
  (void)l_fampred;
  (void)l_val;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,5,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if LEN_LIST( arg ) = 5 then */
  t_3 = GF_LEN__LIST;
@@ -4009,12 +3919,10 @@ static Obj  HdlrFunc17 (
  CALL_6ARGS( t_1, t_2, l_info, l_fampred, t_3, l_val, t_4 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -4030,12 +3938,9 @@ static Obj  HdlrFunc1 (
  Obj t_5 = 0;
  Obj t_6 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* RUN_IMMEDIATE_METHODS_RUNS := 0; */
  AssGVar( G_RUN__IMMEDIATE__METHODS__RUNS, INTOBJ_INT(0) );
@@ -4680,12 +4585,10 @@ static Obj  HdlrFunc1 (
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -215,12 +215,9 @@ static Obj  HdlrFunc2 (
  Obj t_6 = 0;
  Obj t_7 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* InstallOtherMethod( getter, "system getter", true, [ IsAttributeStoringRep and tester ], GETTER_FLAGS, GETTER_FUNCTION( name ) ); */
  t_1 = GF_InstallOtherMethod;
@@ -255,12 +252,10 @@ static Obj  HdlrFunc2 (
  CALL_6ARGS( t_1, a_getter, t_2, t_3, t_4, t_5, t_6 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -274,12 +269,9 @@ static Obj  HdlrFunc4 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* obj!.(name) := val; */
  t_1 = OBJ_HVAR( (1 << 16) | 1 );
@@ -293,12 +285,10 @@ static Obj  HdlrFunc4 (
  CALL_2ARGS( t_1, a_obj, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -322,14 +312,11 @@ static Obj  HdlrFunc3 (
  Obj t_7 = 0;
  Obj t_8 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,2,0,oldFrame);
  ASS_LVAR( 1, a_name );
  ASS_LVAR( 2, a_tester );
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if mutflag then */
  CHECK_BOOL( a_mutflag )
@@ -396,12 +383,10 @@ static Obj  HdlrFunc3 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -431,12 +416,9 @@ static Obj  HdlrFunc5 (
  (void)l_pair;
  (void)l_family;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* imp_filter := WITH_IMPS_FLAGS( AND_FLAGS( imp_filter, req_filter ) ); */
  t_2 = GF_WITH__IMPS__FLAGS;
@@ -544,12 +526,10 @@ static Obj  HdlrFunc5 (
  C_ASS_LIST_FPL_INTOBJ( t_1, INTOBJ_INT(27), INTOBJ_INT(0) )
  
  /* return family; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_family;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -565,12 +545,9 @@ static Obj  HdlrFunc6 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_FAMILY( typeOfFamilies, name, EMPTY_FLAGS, EMPTY_FLAGS ); */
  t_2 = GF_NEW__FAMILY;
@@ -580,12 +557,10 @@ static Obj  HdlrFunc6 (
  CHECK_BOUND( t_4, "EMPTY_FLAGS" )
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -602,12 +577,9 @@ static Obj  HdlrFunc7 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), EMPTY_FLAGS ); */
  t_2 = GF_NEW__FAMILY;
@@ -618,12 +590,10 @@ static Obj  HdlrFunc7 (
  CHECK_BOUND( t_4, "EMPTY_FLAGS" )
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -642,12 +612,9 @@ static Obj  HdlrFunc8 (
  Obj t_4 = 0;
  Obj t_5 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) ); */
  t_2 = GF_NEW__FAMILY;
@@ -659,12 +626,10 @@ static Obj  HdlrFunc8 (
  CHECK_FUNC_RESULT( t_4 )
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -685,12 +650,9 @@ static Obj  HdlrFunc9 (
  Obj t_5 = 0;
  Obj t_6 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_FAMILY( Subtype( typeOfFamilies, filter ), name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) ); */
  t_2 = GF_NEW__FAMILY;
@@ -705,12 +667,10 @@ static Obj  HdlrFunc9 (
  CHECK_FUNC_RESULT( t_5 )
  t_1 = CALL_4ARGS( t_2, t_3, a_name, t_4, t_5 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -728,12 +688,9 @@ static Obj  HdlrFunc10 (
  Obj t_6 = 0;
  Obj t_7 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if LEN_LIST( arg ) = 1 then */
  t_3 = GF_LEN__LIST;
@@ -749,7 +706,6 @@ static Obj  HdlrFunc10 (
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
   CHECK_FUNC_RESULT( t_1 )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -771,7 +727,6 @@ static Obj  HdlrFunc10 (
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
    CHECK_FUNC_RESULT( t_1 )
-   RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_1;
    
@@ -794,7 +749,6 @@ static Obj  HdlrFunc10 (
     C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
     t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
     CHECK_FUNC_RESULT( t_1 )
-    RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_1;
     
@@ -818,7 +772,6 @@ static Obj  HdlrFunc10 (
      C_ELM_LIST_FPL( t_7, a_arg, INTOBJ_INT(4) )
      t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, t_7 );
      CHECK_FUNC_RESULT( t_1 )
-     RES_BRK_CURR_STAT();
      SWITCH_TO_OLD_FRAME(oldFrame);
      return t_1;
      
@@ -839,12 +792,10 @@ static Obj  HdlrFunc10 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -889,12 +840,9 @@ static Obj  HdlrFunc11 (
  (void)l_i;
  (void)l_match;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* cache := family!.TYPES; */
  t_1 = ElmComObj( a_family, R_TYPES );
@@ -1006,7 +954,6 @@ static Obj  HdlrFunc11 (
       AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
       
       /* return cached; */
-      RES_BRK_CURR_STAT();
       SWITCH_TO_OLD_FRAME(oldFrame);
       return l_cached;
       
@@ -1103,7 +1050,6 @@ static Obj  HdlrFunc11 (
       AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
       
       /* return cached; */
-      RES_BRK_CURR_STAT();
       SWITCH_TO_OLD_FRAME(oldFrame);
       return l_cached;
       
@@ -1313,12 +1259,10 @@ static Obj  HdlrFunc11 (
  AssComObj( a_family, R_nTYPES, t_1 );
  
  /* return type; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_type;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1340,12 +1284,9 @@ static Obj  HdlrFunc12 (
  Obj t_8 = 0;
  Obj t_9 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail, fail ); */
  t_2 = GF_NEW__TYPE;
@@ -1365,12 +1306,10 @@ static Obj  HdlrFunc12 (
  CHECK_BOUND( t_5, "fail" )
  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1393,12 +1332,9 @@ static Obj  HdlrFunc13 (
  Obj t_8 = 0;
  Obj t_9 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, fail ); */
  t_2 = GF_NEW__TYPE;
@@ -1416,12 +1352,10 @@ static Obj  HdlrFunc13 (
  CHECK_BOUND( t_4, "fail" )
  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, t_4 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1440,12 +1374,9 @@ static Obj  HdlrFunc14 (
  Obj t_6 = 0;
  (void)l_type;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if not IsFamily( arg[1] ) then */
  t_4 = GF_IsFamily;
@@ -1519,12 +1450,10 @@ static Obj  HdlrFunc14 (
  
  /* return type; */
  CHECK_BOUND( l_type, "type" )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_type;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1547,12 +1476,9 @@ static Obj  HdlrFunc15 (
  Obj t_10 = 0;
  Obj t_11 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![3], type ); */
  t_2 = GF_NEW__TYPE;
@@ -1572,12 +1498,10 @@ static Obj  HdlrFunc15 (
  t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1601,12 +1525,9 @@ static Obj  HdlrFunc16 (
  Obj t_10 = 0;
  Obj t_11 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
@@ -1625,12 +1546,10 @@ static Obj  HdlrFunc16 (
  CHECK_FUNC_RESULT( t_5 )
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1650,12 +1569,9 @@ static Obj  HdlrFunc17 (
  (void)l_p;
  (void)l_type;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if not IsType( arg[1] ) then */
  t_4 = GF_IsType;
@@ -1708,12 +1624,10 @@ static Obj  HdlrFunc17 (
  /* fi */
  
  /* return type; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_type;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1734,12 +1648,9 @@ static Obj  HdlrFunc18 (
  Obj t_8 = 0;
  Obj t_9 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![3], type ); */
  t_2 = GF_NEW__TYPE;
@@ -1756,12 +1667,10 @@ static Obj  HdlrFunc18 (
  t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1783,12 +1692,9 @@ static Obj  HdlrFunc19 (
  Obj t_8 = 0;
  Obj t_9 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
@@ -1804,12 +1710,10 @@ static Obj  HdlrFunc19 (
  CHECK_FUNC_RESULT( t_5 )
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1825,12 +1729,9 @@ static Obj  HdlrFunc20 (
  Obj t_4 = 0;
  Obj t_5 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if not IsType( arg[1] ) then */
  t_4 = GF_IsType;
@@ -1863,7 +1764,6 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
   CHECK_FUNC_RESULT( t_1 )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -1879,7 +1779,6 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
   CHECK_FUNC_RESULT( t_1 )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -1887,12 +1786,10 @@ static Obj  HdlrFunc20 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1904,21 +1801,16 @@ static Obj  HdlrFunc21 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return K![1]; */
  t_1 = ElmPosObj( a_K, 1 );
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1930,21 +1822,16 @@ static Obj  HdlrFunc22 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return K![2]; */
  t_1 = ElmPosObj( a_K, 2 );
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1956,21 +1843,16 @@ static Obj  HdlrFunc23 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return K![3]; */
  t_1 = ElmPosObj( a_K, 3 );
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1982,23 +1864,18 @@ static Obj  HdlrFunc24 (
  Obj  a_data )
 {
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* K![3] := data; */
  AssPosObj( a_K, 3, a_data );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2013,12 +1890,9 @@ static Obj  HdlrFunc25 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return FlagsType( TypeObj( obj ) ); */
  t_2 = GF_FlagsType;
@@ -2027,12 +1901,10 @@ static Obj  HdlrFunc25 (
  CHECK_FUNC_RESULT( t_3 )
  t_1 = CALL_1ARGS( t_2, t_3 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2047,12 +1919,9 @@ static Obj  HdlrFunc26 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return DataType( TypeObj( obj ) ); */
  t_2 = GF_DataType;
@@ -2061,12 +1930,10 @@ static Obj  HdlrFunc26 (
  CHECK_FUNC_RESULT( t_3 )
  t_1 = CALL_1ARGS( t_2, t_3 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2084,12 +1951,9 @@ static Obj  HdlrFunc27 (
  Obj t_4 = 0;
  (void)l_flags;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if not IsType( type ) then */
  t_4 = GF_IsType;
@@ -2157,12 +2021,10 @@ static Obj  HdlrFunc27 (
  /* fi */
  
  /* return obj; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return a_obj;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2184,12 +2046,9 @@ static Obj  HdlrFunc28 (
  (void)l_type;
  (void)l_newtype;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
@@ -2436,12 +2295,10 @@ static Obj  HdlrFunc28 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2458,12 +2315,9 @@ static Obj  HdlrFunc29 (
  Obj t_4 = 0;
  Obj t_5 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if IS_AND_FILTER( filter ) then */
  t_3 = GF_IS__AND__FILTER;
@@ -2621,12 +2475,10 @@ static Obj  HdlrFunc29 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2640,12 +2492,9 @@ static Obj  HdlrFunc30 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if val then */
  CHECK_BOOL( a_val )
@@ -2669,12 +2518,10 @@ static Obj  HdlrFunc30 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2712,12 +2559,9 @@ static Obj  HdlrFunc31 (
  (void)l_extra;
  (void)l_nflags;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* obj := arg[1]; */
  C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(1) )
@@ -3041,12 +2885,10 @@ static Obj  HdlrFunc31 (
  /* od */
  
  /* return obj; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_obj;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3061,12 +2903,9 @@ static Obj  HdlrFunc1 (
  Obj t_4 = 0;
  Obj t_5 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
       InstallOtherMethod( getter, "system getter", true, [ IsAttributeStoringRep and tester ], GETTER_FLAGS, GETTER_FUNCTION( name ) );
@@ -3870,12 +3709,10 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -4341,7 +4341,6 @@ void CompReturnObj (
     obj = CompExpr(READ_STAT(stat, 0));
 
     /* emit code to remove stack frame                                     */
-    Emit( "RES_BRK_CURR_STAT();\n" );
     Emit( "SWITCH_TO_OLD_FRAME(oldFrame);\n" );
 
     /* emit code to return from function                                   */
@@ -4365,7 +4364,6 @@ void CompReturnVoid (
     }
 
     /* emit code to remove stack frame                                     */
-    Emit( "RES_BRK_CURR_STAT();\n");
     Emit( "SWITCH_TO_OLD_FRAME(oldFrame);\n" );
 
     /* emit code to return from function                                   */
@@ -5274,7 +5272,6 @@ void CompFunc (
 
     /* emit the code for the higher variables                              */
     Emit( "Bag oldFrame;\n" );
-    Emit( "OLD_BRK_CURR_STAT\n");
 
     /* emit the code to get the arguments for xarg functions               */
     if ( 6 < narg ) {
@@ -5294,32 +5291,14 @@ void CompFunc (
     }
 
     /* emit the code to switch to a new frame for outer functions          */
-#if 1
-    /* Try and get better debugging by always doing this */
-    if (1) {
-#else
-      /* this was the old code */
-    if ( NHVAR_INFO(info) != 0 ) {
-#endif
-        Emit( "\n/* allocate new stack frame */\n" );
-        Emit( "SWITCH_TO_NEW_FRAME(self,%d,0,oldFrame);\n",NHVAR_INFO(info));
-        for ( i = 1; i <= narg; i++ ) {
-            if ( CompGetUseHVar( i ) ) {
-                Emit( "ASS_LVAR( %d, %c );\n",GetIndxHVar(i),CVAR_LVAR(i));
-            }
+    Emit( "\n/* allocate new stack frame */\n" );
+    Emit( "SWITCH_TO_NEW_FRAME(self,%d,0,oldFrame);\n",NHVAR_INFO(info));
+    for ( i = 1; i <= narg; i++ ) {
+        if ( CompGetUseHVar( i ) ) {
+            Emit( "ASS_LVAR( %d, %c );\n",GetIndxHVar(i),CVAR_LVAR(i));
         }
     }
-    else {
-        Emit( "\n/* restoring old stack frame */\n" );
-        Emit( "oldFrame = STATE(CurrLVars);\n" );
-        Emit( "SWITCH_TO_OLD_FRAME(ENVI_FUNC(self));\n" );
-    }
 
-    /* emit the code to save and zero the "current statement" information
-     so that the break loop behaves */
-    Emit( "REM_BRK_CURR_STAT();\n");
-    Emit( "SET_BRK_CURR_STAT(0);\n");
-    
     /* we know all the arguments have values                               */
     for ( i = 1; i <= narg; i++ ) {
         SetInfoCVar( CVAR_LVAR(i), W_BOUND );
@@ -5333,7 +5312,6 @@ void CompFunc (
 
     /* emit the code to switch back to the old frame and return            */
     Emit( "\n/* return; */\n" );
-    Emit( "RES_BRK_CURR_STAT();\n" );
     Emit( "SWITCH_TO_OLD_FRAME(oldFrame);\n" );
     Emit( "return 0;\n" );
     Emit( "}\n" );

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -821,32 +821,23 @@ void             PrintFunccallOpts (
 *F  ExecBegin() . . . . . . . . . . . . . . . . . . . . .  begin an execution
 *F  ExecEnd(<error>)  . . . . . . . . . . . . . . . . . . .  end an execution
 */
-/* TL: Obj             ExecState; */
 
-void            ExecBegin ( Obj frame )
+void ExecBegin(Obj frame)
 {
-    Obj                 execState;      /* old execution state             */
+    // remember the old execution state
+    PushPlist(FuncsState()->ExecState, STATE(CurrLVars));
 
-    /* remember the old execution state                                    */
-    execState = NEW_PLIST(T_PLIST, 2);
-    SET_LEN_PLIST(execState, 2);
-    SET_ELM_PLIST(execState, 1, FuncsState()->ExecState);
-    SET_ELM_PLIST(execState, 2, STATE(CurrLVars));
-    /* the 'CHANGED_BAG(STATE(CurrLVars))' is needed because it is delayed        */
+    // the 'CHANGED_BAG(STATE(CurrLVars))' is needed because it is delayed
     CHANGED_BAG( STATE(CurrLVars) );
-    FuncsState()->ExecState = execState;
 
-    /* set up new state                                                    */
+    // set up new state
     SWITCH_TO_OLD_LVARS( frame );
-    SET_BRK_CURR_STAT( 0 );
 }
 
-void            ExecEnd (
-    UInt                error )
+void ExecEnd(UInt error)
 {
-    /* switch back to the old state                                    */
-    SWITCH_TO_OLD_LVARS( ELM_PLIST(FuncsState()->ExecState, 2) );
-    FuncsState()->ExecState = ELM_PLIST(FuncsState()->ExecState, 1);
+    // switch back to the old state
+    SWITCH_TO_OLD_LVARS(PopPlist(FuncsState()->ExecState));
 }
 
 /****************************************************************************
@@ -986,7 +977,7 @@ static Int InitKernel (
 
 static Int InitModuleState(void)
 {
-    FuncsState()->ExecState = 0;
+    FuncsState()->ExecState = NEW_PLIST(T_PLIST_EMPTY, 16);
     FuncsState()->RecursionDepth = 0;
 
     // return success

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -93,7 +93,6 @@ static UInt ExecProccallOpts(Stat call)
 {
   Obj opts;
   
-  SET_BRK_CURR_STAT( call );
   opts = EVAL_EXPR(READ_STAT(call, 0));
   CALL_1ARGS(PushOptions, opts);
 
@@ -131,8 +130,6 @@ static ALWAYS_INLINE Obj EvalOrExecCall(Int ignoreResult, UInt nr, Stat call)
     Obj result;
 
     // evaluate the function
-    if (ignoreResult)
-        SET_BRK_CURR_STAT( call );
     func = EVAL_EXPR( FUNC_CALL( call ) );
  
     // evaluate the arguments
@@ -426,16 +423,6 @@ void RecursionDepthTrap( void )
 
 #endif
 
-static void ExecFuncHelper(void)
-{
-    OLD_BRK_CURR_STAT   // old executing statement
-
-    // execute the statement sequence
-    REM_BRK_CURR_STAT();
-    EXEC_STAT( OFFSET_FIRST_STAT );
-    RES_BRK_CURR_STAT();
-}
-
 static Obj PopReturnObjStat(void)
 {
     Obj returnObjStat = STATE(ReturnObjStat);
@@ -500,7 +487,7 @@ static ALWAYS_INLINE Obj DoExecFunc(Obj func, Int narg, const Obj *arg)
         ASS_LVAR( i+1, arg[i] );
 
     /* execute the statement sequence                                      */
-    ExecFuncHelper();
+    EXEC_STAT( OFFSET_FIRST_STAT );
 #ifdef HPCGAP
     CLEAR_LOCK_STACK();
 #endif
@@ -588,7 +575,7 @@ static Obj DoExecFuncXargs(Obj func, Obj args)
     }
 
     /* execute the statement sequence                                      */
-    ExecFuncHelper();
+    EXEC_STAT( OFFSET_FIRST_STAT );
 #ifdef HPCGAP
     CLEAR_LOCK_STACK();
 #endif
@@ -641,7 +628,7 @@ static Obj DoPartialUnWrapFunc(Obj func, Obj args)
     ASS_LVAR(named+1, args);
 
     /* execute the statement sequence                                      */
-    ExecFuncHelper();
+    EXEC_STAT( OFFSET_FIRST_STAT );
 #ifdef HPCGAP
     CLEAR_LOCK_STACK();
 #endif

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -828,13 +828,12 @@ void            ExecBegin ( Obj frame )
     Obj                 execState;      /* old execution state             */
 
     /* remember the old execution state                                    */
-    execState = NEW_PLIST(T_PLIST, 3);
-    SET_LEN_PLIST(execState, 3);
+    execState = NEW_PLIST(T_PLIST, 2);
+    SET_LEN_PLIST(execState, 2);
     SET_ELM_PLIST(execState, 1, FuncsState()->ExecState);
     SET_ELM_PLIST(execState, 2, STATE(CurrLVars));
     /* the 'CHANGED_BAG(STATE(CurrLVars))' is needed because it is delayed        */
     CHANGED_BAG( STATE(CurrLVars) );
-    SET_ELM_PLIST(execState, 3, INTOBJ_INT((Int)STATE(CurrStat)));
     FuncsState()->ExecState = execState;
 
     /* set up new state                                                    */
@@ -845,16 +844,7 @@ void            ExecBegin ( Obj frame )
 void            ExecEnd (
     UInt                error )
 {
-    /* if everything went fine                                             */
-    if ( ! error ) {
-
-        /* the state must be primal again                                  */
-        assert( STATE(CurrStat)  == 0 );
-
-    }
-
     /* switch back to the old state                                    */
-    SET_BRK_CURR_STAT((Stat)INT_INTOBJ(ELM_PLIST(FuncsState()->ExecState, 3)));
     SWITCH_TO_OLD_LVARS( ELM_PLIST(FuncsState()->ExecState, 2) );
     FuncsState()->ExecState = ELM_PLIST(FuncsState()->ExecState, 1);
 }

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -69,7 +69,6 @@ typedef struct GAPState {
     Char * In;
 
     /* From stats.c */
-    Stat CurrStat;
     Obj  ReturnObjStat;
     UInt (**CurrExecStatFuncs)(Stat);
 

--- a/src/hpc/c_oper1.c
+++ b/src/hpc/c_oper1.c
@@ -234,12 +234,9 @@ static Obj  HdlrFunc2 (
  (void)l_loc;
  (void)l_newflags;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if IGNORE_IMMEDIATE_METHODS then */
  t_2 = GC_IGNORE__IMMEDIATE__METHODS;
@@ -249,7 +246,6 @@ static Obj  HdlrFunc2 (
  if ( t_1 ) {
   
   /* return; */
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return 0;
   
@@ -267,7 +263,6 @@ static Obj  HdlrFunc2 (
  if ( t_1 ) {
   
   /* return; */
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return 0;
   
@@ -602,12 +597,10 @@ static Obj  HdlrFunc2 (
  /* od */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -651,12 +644,9 @@ static Obj  HdlrFunc3 (
  (void)l_lk;
  (void)l_rank;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* lk := WRITE_LOCK( METHODS_OPERATION_REGION ); */
  t_2 = GF_WRITE__LOCK;
@@ -1323,12 +1313,10 @@ static Obj  HdlrFunc3 (
  CALL_1ARGS( t_1, l_lk );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1341,12 +1329,9 @@ static Obj  HdlrFunc4 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* INSTALL_METHOD( arg, true ); */
  t_1 = GF_INSTALL__METHOD;
@@ -1354,12 +1339,10 @@ static Obj  HdlrFunc4 (
  CALL_2ARGS( t_1, a_arg, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1372,12 +1355,9 @@ static Obj  HdlrFunc5 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* INSTALL_METHOD( arg, false ); */
  t_1 = GF_INSTALL__METHOD;
@@ -1385,12 +1365,10 @@ static Obj  HdlrFunc5 (
  CALL_2ARGS( t_1, a_arg, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1455,12 +1433,9 @@ static Obj  HdlrFunc6 (
  (void)l_notmatch;
  (void)l_lk;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* lk := READ_LOCK( OPERATIONS_REGION ); */
  t_2 = GF_READ__LOCK;
@@ -2448,12 +2423,10 @@ static Obj  HdlrFunc6 (
  CALL_1ARGS( t_1, l_lk );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2479,12 +2452,9 @@ static Obj  HdlrFunc8 (
  (void)l_found;
  (void)l_prop;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* found := false; */
  t_1 = False;
@@ -2554,7 +2524,6 @@ static Obj  HdlrFunc8 (
     /* TryNextMethod(); */
     t_5 = GC_TRY__NEXT__METHOD;
     CHECK_BOUND( t_5, "TRY_NEXT_METHOD" )
-    RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_5;
     
@@ -2577,7 +2546,6 @@ static Obj  HdlrFunc8 (
   CHECK_FUNC( t_2 )
   t_1 = CALL_1ARGS( t_2, a_obj );
   CHECK_FUNC_RESULT( t_1 )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2589,7 +2557,6 @@ static Obj  HdlrFunc8 (
   /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
   CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2597,12 +2564,10 @@ static Obj  HdlrFunc8 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2637,13 +2602,10 @@ static Obj  HdlrFunc7 (
  (void)l_i;
  (void)l_lk;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,2,0,oldFrame);
  ASS_LVAR( 1, a_getter );
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then */
  t_4 = GF_IS__IDENTICAL__OBJ;
@@ -2843,12 +2805,10 @@ static Obj  HdlrFunc7 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2869,12 +2829,9 @@ static Obj  HdlrFunc9 (
  Obj t_4 = 0;
  Obj t_5 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* InstallOtherMethod( setter, "default method, does nothing", true, [ IS_OBJECT, IS_OBJECT ], 0, DO_NOTHING_SETTER ); */
  t_1 = GF_InstallOtherMethod;
@@ -2895,12 +2852,10 @@ static Obj  HdlrFunc9 (
  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2924,12 +2879,9 @@ static Obj  HdlrFunc10 (
  (void)l_j;
  (void)l_k;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* k := LEN_LIST( list ) + 1; */
  t_3 = GF_LEN__LIST;
@@ -2993,12 +2945,10 @@ static Obj  HdlrFunc10 (
  /* od */
  
  /* return k; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_k;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3013,12 +2963,9 @@ static Obj  HdlrFunc12 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if not IsPrimeInt( key ) then */
  t_4 = GF_IsPrimeInt;
@@ -3040,12 +2987,10 @@ static Obj  HdlrFunc12 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3057,22 +3002,17 @@ static Obj  HdlrFunc13 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return [  ]; */
  t_1 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_1, 0 );
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3095,12 +3035,9 @@ static Obj  HdlrFunc14 (
  (void)l_i;
  (void)l_erg;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
@@ -3203,12 +3140,10 @@ static Obj  HdlrFunc14 (
  C_SUM_FIA( t_2, l_i, INTOBJ_INT(1) )
  CHECK_INT_POS( t_2 )
  C_ELM_LIST_FPL( t_1, l_known, t_2 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3229,12 +3164,9 @@ static Obj  HdlrFunc15 (
  (void)l_known;
  (void)l_i;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
@@ -3280,12 +3212,10 @@ static Obj  HdlrFunc15 (
   "<expr> must be 'true' or 'false' or a filter (not a %s)",
   (Int)TNAM_OBJ(t_2), 0L );
  }
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3307,12 +3237,9 @@ static Obj  HdlrFunc16 (
  (void)l_known;
  (void)l_i;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
@@ -3381,12 +3308,10 @@ static Obj  HdlrFunc16 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3411,14 +3336,11 @@ static Obj  HdlrFunc11 (
  (void)l_str;
  (void)l_lk;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,4,0,oldFrame);
  ASS_LVAR( 1, a_name );
  ASS_LVAR( 2, a_keytest );
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if keytest = "prime" then */
  t_2 = OBJ_LVAR( 2 );
@@ -3710,12 +3632,10 @@ static Obj  HdlrFunc11 (
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3744,12 +3664,9 @@ static Obj  HdlrFunc18 (
  Obj t_17 = 0;
  Obj t_18 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* re := false; */
  t_1 = False;
@@ -3881,7 +3798,6 @@ static Obj  HdlrFunc18 (
   CHECK_BOUND( t_3, "oper" )
   t_1 = CALL_2ARGS( t_2, t_3, a_arg );
   CHECK_FUNC_RESULT( t_1 )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -3893,7 +3809,6 @@ static Obj  HdlrFunc18 (
   /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
   CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -3901,12 +3816,10 @@ static Obj  HdlrFunc18 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3931,12 +3844,9 @@ static Obj  HdlrFunc17 (
  (void)l_fampred;
  (void)l_val;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,5,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if LEN_LIST( arg ) = 5 then */
  t_3 = GF_LEN__LIST;
@@ -4084,12 +3994,10 @@ static Obj  HdlrFunc17 (
  CALL_6ARGS( t_1, t_2, l_info, l_fampred, t_3, l_val, t_4 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -4105,12 +4013,9 @@ static Obj  HdlrFunc1 (
  Obj t_5 = 0;
  Obj t_6 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* RUN_IMMEDIATE_METHODS_RUNS := 0; */
  AssGVar( G_RUN__IMMEDIATE__METHODS__RUNS, INTOBJ_INT(0) );
@@ -4765,12 +4670,10 @@ static Obj  HdlrFunc1 (
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/src/hpc/c_type1.c
+++ b/src/hpc/c_type1.c
@@ -254,12 +254,9 @@ static Obj  HdlrFunc2 (
  Obj t_6 = 0;
  Obj t_7 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* InstallOtherMethod( getter, "system getter", true, [ IsAttributeStoringRep and tester ], GETTER_FLAGS, GETTER_FUNCTION( name ) ); */
  t_1 = GF_InstallOtherMethod;
@@ -294,12 +291,10 @@ static Obj  HdlrFunc2 (
  CALL_6ARGS( t_1, a_getter, t_2, t_3, t_4, t_5, t_6 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -313,12 +308,9 @@ static Obj  HdlrFunc4 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* obj!.(name) := val; */
  t_1 = OBJ_HVAR( (1 << 16) | 1 );
@@ -332,12 +324,10 @@ static Obj  HdlrFunc4 (
  CALL_2ARGS( t_1, a_obj, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -361,14 +351,11 @@ static Obj  HdlrFunc3 (
  Obj t_7 = 0;
  Obj t_8 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,2,0,oldFrame);
  ASS_LVAR( 1, a_name );
  ASS_LVAR( 2, a_tester );
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if mutflag then */
  CHECK_BOOL( a_mutflag )
@@ -435,12 +422,10 @@ static Obj  HdlrFunc3 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -470,12 +455,9 @@ static Obj  HdlrFunc5 (
  (void)l_pair;
  (void)l_family;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* imp_filter := WITH_IMPS_FLAGS( AND_FLAGS( imp_filter, req_filter ) ); */
  t_2 = GF_WITH__IMPS__FLAGS;
@@ -612,12 +594,10 @@ static Obj  HdlrFunc5 (
  AssComObj( l_family, R_TYPES__LIST__FAM, t_1 );
  
  /* return family; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_family;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -633,12 +613,9 @@ static Obj  HdlrFunc6 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_FAMILY( typeOfFamilies, name, EMPTY_FLAGS, EMPTY_FLAGS ); */
  t_2 = GF_NEW__FAMILY;
@@ -648,12 +625,10 @@ static Obj  HdlrFunc6 (
  CHECK_BOUND( t_4, "EMPTY_FLAGS" )
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -670,12 +645,9 @@ static Obj  HdlrFunc7 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), EMPTY_FLAGS ); */
  t_2 = GF_NEW__FAMILY;
@@ -686,12 +658,10 @@ static Obj  HdlrFunc7 (
  CHECK_BOUND( t_4, "EMPTY_FLAGS" )
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -710,12 +680,9 @@ static Obj  HdlrFunc8 (
  Obj t_4 = 0;
  Obj t_5 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) ); */
  t_2 = GF_NEW__FAMILY;
@@ -727,12 +694,10 @@ static Obj  HdlrFunc8 (
  CHECK_FUNC_RESULT( t_4 )
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -753,12 +718,9 @@ static Obj  HdlrFunc9 (
  Obj t_5 = 0;
  Obj t_6 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_FAMILY( Subtype( typeOfFamilies, filter ), name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) ); */
  t_2 = GF_NEW__FAMILY;
@@ -773,12 +735,10 @@ static Obj  HdlrFunc9 (
  CHECK_FUNC_RESULT( t_5 )
  t_1 = CALL_4ARGS( t_2, t_3, a_name, t_4, t_5 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -796,12 +756,9 @@ static Obj  HdlrFunc10 (
  Obj t_6 = 0;
  Obj t_7 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if LEN_LIST( arg ) = 1 then */
  t_3 = GF_LEN__LIST;
@@ -817,7 +774,6 @@ static Obj  HdlrFunc10 (
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
   CHECK_FUNC_RESULT( t_1 )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -839,7 +795,6 @@ static Obj  HdlrFunc10 (
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
    CHECK_FUNC_RESULT( t_1 )
-   RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_1;
    
@@ -862,7 +817,6 @@ static Obj  HdlrFunc10 (
     C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
     t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
     CHECK_FUNC_RESULT( t_1 )
-    RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_1;
     
@@ -886,7 +840,6 @@ static Obj  HdlrFunc10 (
      C_ELM_LIST_FPL( t_7, a_arg, INTOBJ_INT(4) )
      t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, t_7 );
      CHECK_FUNC_RESULT( t_1 )
-     RES_BRK_CURR_STAT();
      SWITCH_TO_OLD_FRAME(oldFrame);
      return t_1;
      
@@ -907,12 +860,10 @@ static Obj  HdlrFunc10 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -957,12 +908,9 @@ static Obj  HdlrFunc11 (
  (void)l_i;
  (void)l_match;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* lock := WRITE_LOCK( DS_TYPE_CACHE ); */
  t_2 = GF_WRITE__LOCK;
@@ -1086,7 +1034,6 @@ static Obj  HdlrFunc11 (
       CALL_1ARGS( t_1, l_lock );
       
       /* return cached; */
-      RES_BRK_CURR_STAT();
       SWITCH_TO_OLD_FRAME(oldFrame);
       return l_cached;
       
@@ -1187,7 +1134,6 @@ static Obj  HdlrFunc11 (
       CALL_1ARGS( t_1, l_lock );
       
       /* return cached; */
-      RES_BRK_CURR_STAT();
       SWITCH_TO_OLD_FRAME(oldFrame);
       return l_cached;
       
@@ -1417,12 +1363,10 @@ static Obj  HdlrFunc11 (
  CALL_1ARGS( t_1, l_lock );
  
  /* return type; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_type;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1444,12 +1388,9 @@ static Obj  HdlrFunc12 (
  Obj t_8 = 0;
  Obj t_9 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail, fail ); */
  t_2 = GF_NEW__TYPE;
@@ -1469,12 +1410,10 @@ static Obj  HdlrFunc12 (
  CHECK_BOUND( t_5, "fail" )
  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1497,12 +1436,9 @@ static Obj  HdlrFunc13 (
  Obj t_8 = 0;
  Obj t_9 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, fail ); */
  t_2 = GF_NEW__TYPE;
@@ -1520,12 +1456,10 @@ static Obj  HdlrFunc13 (
  CHECK_BOUND( t_4, "fail" )
  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, t_4 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1544,12 +1478,9 @@ static Obj  HdlrFunc14 (
  Obj t_6 = 0;
  (void)l_type;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if not IsFamily( arg[1] ) then */
  t_4 = GF_IsFamily;
@@ -1623,12 +1554,10 @@ static Obj  HdlrFunc14 (
  
  /* return type; */
  CHECK_BOUND( l_type, "type" )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_type;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1651,12 +1580,9 @@ static Obj  HdlrFunc15 (
  Obj t_10 = 0;
  Obj t_11 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![3], type ); */
  t_2 = GF_NEW__TYPE;
@@ -1676,12 +1602,10 @@ static Obj  HdlrFunc15 (
  t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1705,12 +1629,9 @@ static Obj  HdlrFunc16 (
  Obj t_10 = 0;
  Obj t_11 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
@@ -1729,12 +1650,10 @@ static Obj  HdlrFunc16 (
  CHECK_FUNC_RESULT( t_5 )
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1754,12 +1673,9 @@ static Obj  HdlrFunc17 (
  (void)l_p;
  (void)l_type;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* p := READ_LOCK( arg ); */
  t_2 = GF_READ__LOCK;
@@ -1822,12 +1738,10 @@ static Obj  HdlrFunc17 (
  CALL_1ARGS( t_1, l_p );
  
  /* return type; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_type;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1848,12 +1762,9 @@ static Obj  HdlrFunc18 (
  Obj t_8 = 0;
  Obj t_9 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![3], type ); */
  t_2 = GF_NEW__TYPE;
@@ -1870,12 +1781,10 @@ static Obj  HdlrFunc18 (
  t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1897,12 +1806,9 @@ static Obj  HdlrFunc19 (
  Obj t_8 = 0;
  Obj t_9 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
@@ -1918,12 +1824,10 @@ static Obj  HdlrFunc19 (
  CHECK_FUNC_RESULT( t_5 )
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1939,12 +1843,9 @@ static Obj  HdlrFunc20 (
  Obj t_4 = 0;
  Obj t_5 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if not IsType( arg[1] ) then */
  t_4 = GF_IsType;
@@ -1977,7 +1878,6 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
   CHECK_FUNC_RESULT( t_1 )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -1993,7 +1893,6 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
   CHECK_FUNC_RESULT( t_1 )
-  RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2001,12 +1900,10 @@ static Obj  HdlrFunc20 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2018,21 +1915,16 @@ static Obj  HdlrFunc21 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return K![1]; */
  t_1 = ElmPosObj( a_K, 1 );
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2044,21 +1936,16 @@ static Obj  HdlrFunc22 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return K![2]; */
  t_1 = ElmPosObj( a_K, 2 );
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2070,21 +1957,16 @@ static Obj  HdlrFunc23 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return K![3]; */
  t_1 = ElmPosObj( a_K, 3 );
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2099,12 +1981,9 @@ static Obj  HdlrFunc24 (
  Obj t_2 = 0;
  Obj t_3 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* StrictBindOnce( K, 3, MakeImmutable( data ) ); */
  t_1 = GF_StrictBindOnce;
@@ -2114,12 +1993,10 @@ static Obj  HdlrFunc24 (
  CALL_3ARGS( t_1, a_K, INTOBJ_INT(3), t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2134,12 +2011,9 @@ static Obj  HdlrFunc25 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return FlagsType( TypeObj( obj ) ); */
  t_2 = GF_FlagsType;
@@ -2148,12 +2022,10 @@ static Obj  HdlrFunc25 (
  CHECK_FUNC_RESULT( t_3 )
  t_1 = CALL_1ARGS( t_2, t_3 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2168,12 +2040,9 @@ static Obj  HdlrFunc26 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return DataType( TypeObj( obj ) ); */
  t_2 = GF_DataType;
@@ -2182,12 +2051,10 @@ static Obj  HdlrFunc26 (
  CHECK_FUNC_RESULT( t_3 )
  t_1 = CALL_1ARGS( t_2, t_3 );
  CHECK_FUNC_RESULT( t_1 )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2206,12 +2073,9 @@ static Obj  HdlrFunc27 (
  Obj t_5 = 0;
  (void)l_flags;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if not IsType( type ) then */
  t_4 = GF_IsType;
@@ -2396,12 +2260,10 @@ static Obj  HdlrFunc27 (
  /* fi */
  
  /* return obj; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return a_obj;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2423,12 +2285,9 @@ static Obj  HdlrFunc28 (
  (void)l_type;
  (void)l_newtype;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
@@ -2675,12 +2534,10 @@ static Obj  HdlrFunc28 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2697,12 +2554,9 @@ static Obj  HdlrFunc29 (
  Obj t_4 = 0;
  Obj t_5 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if IS_AND_FILTER( filter ) then */
  t_3 = GF_IS__AND__FILTER;
@@ -2860,12 +2714,10 @@ static Obj  HdlrFunc29 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2879,12 +2731,9 @@ static Obj  HdlrFunc30 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* if val then */
  CHECK_BOOL( a_val )
@@ -2908,12 +2757,10 @@ static Obj  HdlrFunc30 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -2951,12 +2798,9 @@ static Obj  HdlrFunc31 (
  (void)l_extra;
  (void)l_nflags;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* obj := arg[1]; */
  C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(1) )
@@ -3280,12 +3124,10 @@ static Obj  HdlrFunc31 (
  /* od */
  
  /* return obj; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_obj;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -3300,12 +3142,9 @@ static Obj  HdlrFunc1 (
  Obj t_4 = 0;
  Obj t_5 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
       InstallOtherMethod( getter, "system getter", true, [ IsAttributeStoringRep and tester ], GETTER_FLAGS, GETTER_FUNCTION( name ) );
@@ -4133,12 +3972,10 @@ static Obj  HdlrFunc1 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -9,6 +9,7 @@
 #include "plist.h"
 #include "stats.h"
 #include "stringobj.h"
+#include "vars.h"
 
 #include "hpc/guards.h"
 #include "hpc/misc.h"
@@ -860,7 +861,7 @@ static void InterruptCurrentThread(int locked, Stat stat)
     if (!locked)
         pthread_mutex_lock(thread->lock);
     STATE(CurrExecStatFuncs) = ExecStatFuncs;
-    SET_BRK_CURR_STAT(stat);
+    SET_BRK_CALL_TO(stat);
     state = GetThreadState(TLS(threadID));
     if ((state & TSTATE_MASK) == TSTATE_INTERRUPTED)
         UpdateThreadState(TLS(threadID), state, TSTATE_RUNNING);

--- a/src/stats.c
+++ b/src/stats.c
@@ -209,7 +209,6 @@ UInt            ExecIf (
     Stat                body;           /* body                            */
 
     /* if the condition evaluates to 'true', execute the if-branch body    */
-    SET_BRK_CURR_STAT( stat );
     cond = READ_STAT(stat, 0);
     if ( EVAL_BOOL_EXPR( cond ) != False ) {
 
@@ -230,7 +229,6 @@ UInt            ExecIfElse (
     Stat                body;           /* body                            */
 
     /* if the condition evaluates to 'true', execute the if-branch body    */
-    SET_BRK_CURR_STAT( stat );
     cond = READ_STAT(stat, 0);
     if ( EVAL_BOOL_EXPR( cond ) != False ) {
 
@@ -260,7 +258,6 @@ UInt            ExecIfElif (
     for ( i = 1; i <= nr; i++ ) {
 
         /* if the condition evaluates to 'true', execute the branch body   */
-        SET_BRK_CURR_STAT( stat );
         cond = READ_STAT(stat, 2 * (i - 1));
         if ( EVAL_BOOL_EXPR( cond ) != False ) {
 
@@ -291,7 +288,6 @@ UInt            ExecIfElifElse (
     for ( i = 1; i <= nr; i++ ) {
 
         /* if the condition evaluates to 'true', execute the branch body   */
-        SET_BRK_CURR_STAT( stat );
         cond = READ_STAT(stat, 2 * (i - 1));
         if ( EVAL_BOOL_EXPR( cond ) != False ) {
 
@@ -369,7 +365,6 @@ static ALWAYS_INLINE UInt ExecForHelper(Stat stat, UInt nr)
     }
 
     /* evaluate the list                                                   */
-    SET_BRK_CURR_STAT( stat );
     list = EVAL_EXPR(READ_STAT(stat, 1));
 
     /* get the body                                                        */
@@ -511,7 +506,6 @@ static ALWAYS_INLINE UInt ExecForRangeHelper(Stat stat, UInt nr)
     lvar = LVAR_REFLVAR(READ_STAT(stat, 0));
 
     /* evaluate the range                                                  */
-    SET_BRK_CURR_STAT( stat );
     VisitStatIfHooked(READ_STAT(stat, 1));
     elm = EVAL_EXPR(READ_EXPR(READ_STAT(stat, 1), 0));
     while ( ! IS_INTOBJ(elm) ) {
@@ -591,7 +585,6 @@ UInt ExecAtomic(Stat stat)
   UInt nrexprs,i,j,status;
   Obj o;
   
-  SET_BRK_CURR_STAT( stat );
   nrexprs = ((SIZE_STAT(stat)/sizeof(Stat))-1)/2;
   
   j = 0;
@@ -678,7 +671,6 @@ static ALWAYS_INLINE UInt ExecWhileHelper(Stat stat, UInt nr)
     body3 = (nr >= 3) ? READ_STAT(stat, 3) : 0;
 
     /* while the condition evaluates to 'true', execute the body           */
-    SET_BRK_CURR_STAT( stat );
     while ( EVAL_BOOL_EXPR( cond ) != False ) {
 
 #if !defined(HAVE_SIGNAL)
@@ -694,8 +686,6 @@ static ALWAYS_INLINE UInt ExecWhileHelper(Stat stat, UInt nr)
             EXEC_STAT_IN_LOOP(body2);
         if (nr >= 3)
             EXEC_STAT_IN_LOOP(body3);
-
-        SET_BRK_CURR_STAT( stat );
 
     }
 
@@ -752,7 +742,6 @@ static ALWAYS_INLINE UInt ExecRepeatHelper(Stat stat, UInt nr)
     body3 = (nr >= 3) ? READ_STAT(stat, 3) : 0;
 
     /* execute the body until the condition evaluates to 'true'            */
-    SET_BRK_CURR_STAT( stat );
     do {
 
 #if !defined(HAVE_SIGNAL)
@@ -768,8 +757,6 @@ static ALWAYS_INLINE UInt ExecRepeatHelper(Stat stat, UInt nr)
             EXEC_STAT_IN_LOOP(body2);
         if (nr >= 3)
             EXEC_STAT_IN_LOOP(body3);
-
-        SET_BRK_CURR_STAT( stat );
 
     } while ( EVAL_BOOL_EXPR( cond ) == False );
 
@@ -870,9 +857,6 @@ UInt ExecInfo (
     selectors = EVAL_EXPR( ARGI_INFO( stat, 1 ) );
     level = EVAL_EXPR( ARGI_INFO( stat, 2) );
 
-    SET_BRK_CALL_TO( stat );
-    SET_BRK_CURR_STAT( stat );
-
     selected = InfoCheckLevel(selectors, level);
     if (selected == True) {
 
@@ -917,9 +901,6 @@ UInt ExecAssert2Args (
     Obj             level;
     Obj             decision;
 
-    SET_BRK_CURR_STAT( stat );
-    SET_BRK_CALL_TO( stat );
-
     level = EVAL_EXPR(READ_STAT(stat, 0));
     if ( ! LT(CurrentAssertionLevel, level) )  {
         decision = EVAL_EXPR(READ_STAT(stat, 1));
@@ -930,7 +911,6 @@ UInt ExecAssert2Args (
           "you may 'return true;' or 'return false;'");
         }
         if ( decision == False ) {
-            SET_BRK_CURR_STAT( stat );
             ErrorReturnVoid( "Assertion failure", 0L, 0L, "you may 'return;'");
         }
     }
@@ -953,9 +933,6 @@ UInt ExecAssert3Args (
     Obj             decision;
     Obj             message;
 
-    SET_BRK_CURR_STAT( stat );
-    SET_BRK_CALL_TO( stat );
-
     level = EVAL_EXPR(READ_STAT(stat, 0));
     if ( ! LT(CurrentAssertionLevel, level) ) {
         decision = EVAL_EXPR(READ_STAT(stat, 1));
@@ -968,6 +945,7 @@ UInt ExecAssert3Args (
         if ( decision == False ) {
             message = EVAL_EXPR(READ_STAT(stat, 2));
             if ( message != (Obj) 0 ) {
+                SET_BRK_CALL_TO( stat );
                 if (IS_STRING_REP( message ))
                     PrintString1( message );
                 else
@@ -1004,7 +982,6 @@ UInt            ExecReturnObj (
 #endif
 
     /* evaluate the expression                                             */
-    SET_BRK_CURR_STAT( stat );
     STATE(ReturnObjStat) = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* return up to function interpreter                                   */
@@ -1115,7 +1092,6 @@ UInt ExecIntrStat (
     HaveInterrupt();
 
     /* and now for something completely different                          */
-    SET_BRK_CURR_STAT( stat );
     if ( SyStorOverrun != 0 ) {
       SyStorOverrun = 0; /* reset */
       ErrorReturnVoid(

--- a/src/stats.c
+++ b/src/stats.c
@@ -45,6 +45,7 @@
 inline UInt EXEC_STAT(Stat stat)
 {
     UInt tnum = TNUM_STAT(stat);
+    SET_BRK_CALL_TO(stat);
     return (*STATE(CurrExecStatFuncs)[ tnum ]) ( stat );
 }
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -238,6 +238,8 @@ UInt            ExecIfElse (
 
     }
 
+    SET_BRK_CALL_TO(stat);
+
     /* otherwise execute the else-branch body and leave                    */
     body = READ_STAT(stat, 3);
     return EXEC_STAT( body );
@@ -267,6 +269,7 @@ UInt            ExecIfElif (
 
         }
 
+        SET_BRK_CALL_TO(stat);
     }
 
     /* return 0 (to indicate that no leave-statement was executed)         */
@@ -297,6 +300,7 @@ UInt            ExecIfElifElse (
 
         }
 
+        SET_BRK_CALL_TO(stat);
     }
 
     /* otherwise execute the else-branch body and leave                    */
@@ -687,6 +691,7 @@ static ALWAYS_INLINE UInt ExecWhileHelper(Stat stat, UInt nr)
         if (nr >= 3)
             EXEC_STAT_IN_LOOP(body3);
 
+        SET_BRK_CALL_TO(stat);
     }
 
     /* return 0 (to indicate that no leave-statement was executed)         */
@@ -757,6 +762,8 @@ static ALWAYS_INLINE UInt ExecRepeatHelper(Stat stat, UInt nr)
             EXEC_STAT_IN_LOOP(body2);
         if (nr >= 3)
             EXEC_STAT_IN_LOOP(body3);
+
+        SET_BRK_CALL_TO(stat);
 
     } while ( EVAL_BOOL_EXPR( cond ) == False );
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -74,17 +74,6 @@ UInt            (* ExecStatFuncs[256]) ( Stat stat );
 
 /****************************************************************************
 **
-*V  CurrStat  . . . . . . . . . . . . . . . . .  currently executed statement
-**
-**  'CurrStat'  is the statement that  is currently being executed.  The sole
-**  purpose of 'CurrStat' is to make it possible to  point to the location in
-**  case an error is signalled.
-*/
-/* TL: Stat            CurrStat; */
-
-
-/****************************************************************************
-**
 *V  ReturnObjStat . . . . . . . . . . . . . . . .  result of return-statement
 **
 **  'ReturnObjStat'  is   the result of the   return-statement  that was last

--- a/src/stats.h
+++ b/src/stats.h
@@ -64,34 +64,15 @@ extern  UInt 		(* IntrExecStatFuncs[256]) ( Stat stat );
 
 /****************************************************************************
 **
-*V  CurrStat  . . . . . . . . . . . . . . . . .  currently executed statement
-**
-**  'CurrStat'  is the statement that  is currently being executed.  The sole
-**  purpose of 'CurrStat' is to make it possible to  point to the location in
-**  case an error is signalled.
-*/
-/* TL: extern  Stat            CurrStat; */
-
-
-/****************************************************************************
-**
 *F  SET_BRK_CURR_STAT(<stat>) . . . . . . . set currently executing statement
 *F  OLD_BRK_CURR_STAT . . . . . . . . .  define variable to remember CurrStat
 *F  REM_BRK_CURR_STAT() . . . . . . .  remember currently executing statement
 *F  RES_BRK_CURR_STAT() . . . . . . . . restore currently executing statement
 */
-#ifndef NO_BRK_CURR_STAT
-#define SET_BRK_CURR_STAT(stat) (STATE(CurrStat) = (stat))
-#define OLD_BRK_CURR_STAT       Stat oldStat;
-#define REM_BRK_CURR_STAT()     (oldStat = STATE(CurrStat))
-#define RES_BRK_CURR_STAT()     (STATE(CurrStat) = oldStat)
-#endif
-#ifdef  NO_BRK_CURR_STAT
-#define SET_BRK_CURR_STAT(stat) /* do nothing */
-#define OLD_BRK_CURR_STAT       /* do nothing */
-#define REM_BRK_CURR_STAT()     /* do nothing */
-#define RES_BRK_CURR_STAT()     /* do nothing */
-#endif
+#define SET_BRK_CURR_STAT(stat) do {} while (0) /* do nothing */
+#define OLD_BRK_CURR_STAT       do {} while (0) /* do nothing */ ;
+#define REM_BRK_CURR_STAT()     do {} while (0) /* do nothing */
+#define RES_BRK_CURR_STAT()     do {} while (0) /* do nothing */
 
 
 /****************************************************************************

--- a/src/stats.h
+++ b/src/stats.h
@@ -64,19 +64,6 @@ extern  UInt 		(* IntrExecStatFuncs[256]) ( Stat stat );
 
 /****************************************************************************
 **
-*F  SET_BRK_CURR_STAT(<stat>) . . . . . . . set currently executing statement
-*F  OLD_BRK_CURR_STAT . . . . . . . . .  define variable to remember CurrStat
-*F  REM_BRK_CURR_STAT() . . . . . . .  remember currently executing statement
-*F  RES_BRK_CURR_STAT() . . . . . . . . restore currently executing statement
-*/
-#define SET_BRK_CURR_STAT(stat) do {} while (0) /* do nothing */
-#define OLD_BRK_CURR_STAT       do {} while (0) /* do nothing */ ;
-#define REM_BRK_CURR_STAT()     do {} while (0) /* do nothing */
-#define RES_BRK_CURR_STAT()     do {} while (0) /* do nothing */
-
-
-/****************************************************************************
-**
 *V  ReturnObjStat . . . . . . . . . . . . . . . .  result of return-statement
 **
 **  'ReturnObjStat'  is   the result of the   return-statement  that was last

--- a/src/vars.c
+++ b/src/vars.c
@@ -818,8 +818,6 @@ Obj             EvalElmList (
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
 
-    SET_BRK_CALL_TO(expr);     /* Note possible call for FuncWhere */
-
     if (IS_POS_INTOBJ(pos)) {
         p = INT_INTOBJ( pos );
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -163,7 +163,6 @@ UInt            ExecAssLVar (
     Obj                 rhs;            /* value of right hand side        */
 
     /* assign the right hand side to the local variable                    */
-    SET_BRK_CURR_STAT( stat );
     rhs = EVAL_EXPR(READ_STAT(stat, 1));
     ASS_LVAR(READ_STAT(stat, 0), rhs);
 
@@ -320,7 +319,6 @@ UInt            ExecAssHVar (
     Obj                 rhs;            /* value of right hand side        */
 
     /* assign the right hand side to the higher variable                   */
-    SET_BRK_CURR_STAT( stat );
     rhs = EVAL_EXPR(READ_STAT(stat, 1));
     ASS_HVAR(READ_STAT(stat, 0), rhs);
 
@@ -436,7 +434,6 @@ UInt            ExecAssGVar (
     Obj                 rhs;            /* value of right hand side        */
 
     /* assign the right hand side to the global variable                   */
-    SET_BRK_CURR_STAT( stat );
     rhs = EVAL_EXPR(READ_STAT(stat, 1));
     AssGVar(READ_STAT(stat, 0), rhs);
 
@@ -554,7 +551,6 @@ UInt            ExecAssList (
     Obj                 rhs;            /* right hand side, right operand  */
 
     /* evaluate the list (checking is done by 'ASS_LIST')                  */
-    SET_BRK_CURR_STAT( stat );
     list = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate the position                                               */
@@ -603,7 +599,6 @@ UInt            ExecAss2List (
     Obj                 rhs;            /* right hand side, right operand  */
 
     /* evaluate the list (checking is done by 'ASS_LIST')                  */
-    SET_BRK_CURR_STAT( stat );
     list = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate the position                                               */
@@ -635,7 +630,6 @@ UInt            ExecAsssList (
     Obj                 rhss;           /* right hand sides, right operand */
 
     /* evaluate the list (checking is done by 'ASSS_LIST')                 */
-    SET_BRK_CURR_STAT( stat );
     list = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate and check the positions                                    */
@@ -681,7 +675,6 @@ UInt            ExecAssListLevel (
 
     /* evaluate lists (if this works, then <lists> is nested <level> deep, */
     /* checking it is nested <level>+1 deep is done by 'AssListLevel')     */
-    SET_BRK_CURR_STAT( stat );
     lists = EVAL_EXPR(READ_STAT(stat, 0));
     narg = SIZE_STAT(stat)/sizeof(Stat) -3;
     ixs = NEW_PLIST(T_PLIST, narg);
@@ -730,7 +723,6 @@ UInt            ExecAsssListLevel (
 
     /* evaluate lists (if this works, then <lists> is nested <level> deep, */
     /* checking it is nested <level>+1 deep is done by 'AsssListLevel')    */
-    SET_BRK_CURR_STAT( stat );
     lists = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate and check the positions                                    */
@@ -768,7 +760,6 @@ UInt            ExecUnbList (
     Int i;
 
     /* evaluate the list (checking is done by 'LEN_LIST')                  */
-    SET_BRK_CURR_STAT( stat );
     list = EVAL_EXPR(READ_STAT(stat, 0));
     narg = SIZE_STAT(stat)/sizeof(Stat) - 1;
     if (narg == 1) {
@@ -1207,7 +1198,6 @@ UInt            ExecAssRecName (
     Obj                 rhs;            /* rhs, right operand              */
 
     /* evaluate the record (checking is done by 'ASS_REC')                 */
-    SET_BRK_CURR_STAT( stat );
     record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
@@ -1239,7 +1229,6 @@ UInt            ExecAssRecExpr (
     Obj                 rhs;            /* rhs, right operand              */
 
     /* evaluate the record (checking is done by 'ASS_REC')                 */
-    SET_BRK_CURR_STAT( stat );
     record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate the name and convert it to a record name                   */
@@ -1270,7 +1259,6 @@ UInt            ExecUnbRecName (
     UInt                rnam;           /* name, left operand              */
 
     /* evaluate the record (checking is done by 'UNB_REC')                 */
-    SET_BRK_CURR_STAT( stat );
     record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
@@ -1298,7 +1286,6 @@ UInt            ExecUnbRecExpr (
     UInt                rnam;           /* name, left operand              */
 
     /* evaluate the record (checking is done by 'UNB_REC')                 */
-    SET_BRK_CURR_STAT( stat );
     record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate the name and convert it to a record name                   */
@@ -1558,7 +1545,6 @@ UInt            ExecAssPosObj (
     Obj                 rhs;            /* right hand side, right operand  */
 
     /* evaluate the list (checking is done by 'ASS_LIST')                  */
-    SET_BRK_CURR_STAT( stat );
     list = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate and check the position                                     */
@@ -1597,7 +1583,6 @@ UInt            ExecUnbPosObj (
     Int                 p;              /* position, as a C integer        */
 
     /* evaluate the list (checking is done by 'LEN_LIST')                  */
-    SET_BRK_CURR_STAT( stat );
     list = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate and check the position                                     */
@@ -1772,7 +1757,6 @@ UInt            ExecAssComObjName (
     Obj                 rhs;            /* rhs, right operand              */
 
     /* evaluate the record (checking is done by 'ASS_REC')                 */
-    SET_BRK_CURR_STAT( stat );
     record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
@@ -1804,7 +1788,6 @@ UInt            ExecAssComObjExpr (
     Obj                 rhs;            /* rhs, right operand              */
 
     /* evaluate the record (checking is done by 'ASS_REC')                 */
-    SET_BRK_CURR_STAT( stat );
     record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate the name and convert it to a record name                   */
@@ -1835,7 +1818,6 @@ UInt            ExecUnbComObjName (
     UInt                rnam;           /* name, left operand              */
 
     /* evaluate the record (checking is done by 'UNB_REC')                 */
-    SET_BRK_CURR_STAT( stat );
     record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
@@ -1863,7 +1845,6 @@ UInt            ExecUnbComObjExpr (
     UInt                rnam;           /* name, left operand              */
 
     /* evaluate the record (checking is done by 'UNB_REC')                 */
-    SET_BRK_CURR_STAT( stat );
     record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate the name and convert it to a record name                   */

--- a/src/vars.h
+++ b/src/vars.h
@@ -203,6 +203,7 @@ static inline Obj SwitchToNewLvars(Obj func, UInt narg, UInt nloc)
   // create new lvars (may cause garbage collection)
   Obj new_lvars = NewLVarsBag( narg+nloc );
   LVarsHeader * hdr = (LVarsHeader *)ADDR_OBJ(new_lvars);
+  hdr->stat = 0;
   hdr->func = func;
   hdr->parent = old;
 

--- a/tst/test-compile/and_filter.g.dynamic.c
+++ b/tst/test-compile/and_filter.g.dynamic.c
@@ -27,12 +27,9 @@ static Obj  HdlrFunc3 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return false and 1; */
  t_2 = False;
@@ -51,12 +48,10 @@ static Obj  HdlrFunc3 (
   "<expr> must be 'true' or 'false' or a filter (not a %s)",
   (Int)TNAM_OBJ(t_2), 0L );
  }
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -69,12 +64,9 @@ static Obj  HdlrFunc4 (
  Obj t_2 = 0;
  Obj t_3 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return true or 1; */
  t_3 = True;
@@ -85,12 +77,10 @@ static Obj  HdlrFunc4 (
   t_3 = (Obj)(UInt)(INTOBJ_INT(1) != False);
   t_1 = (t_3 ? True : False);
  }
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -104,12 +94,9 @@ static Obj  HdlrFunc5 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return Center and IsAssociative; */
  t_2 = GC_Center;
@@ -133,12 +120,10 @@ static Obj  HdlrFunc5 (
   "<expr> must be 'true' or 'false' or a filter (not a %s)",
   (Int)TNAM_OBJ(t_2), 0L );
  }
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -152,12 +137,9 @@ static Obj  HdlrFunc6 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return IsAssociative and Center; */
  t_2 = GC_IsAssociative;
@@ -181,12 +163,10 @@ static Obj  HdlrFunc6 (
   "<expr> must be 'true' or 'false' or a filter (not a %s)",
   (Int)TNAM_OBJ(t_2), 0L );
  }
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -201,12 +181,9 @@ static Obj  HdlrFunc2 (
  Obj t_4 = 0;
  Obj t_5 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( false and 1, "\n" ); */
  t_1 = GF_Print;
@@ -339,12 +316,10 @@ static Obj  HdlrFunc2 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -356,12 +331,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* runtest := function (  )
       Print( false and 1, "\n" );
@@ -393,12 +365,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/and_filter.g.static.c
+++ b/tst/test-compile/and_filter.g.static.c
@@ -27,12 +27,9 @@ static Obj  HdlrFunc3 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return false and 1; */
  t_2 = False;
@@ -51,12 +48,10 @@ static Obj  HdlrFunc3 (
   "<expr> must be 'true' or 'false' or a filter (not a %s)",
   (Int)TNAM_OBJ(t_2), 0L );
  }
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -69,12 +64,9 @@ static Obj  HdlrFunc4 (
  Obj t_2 = 0;
  Obj t_3 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return true or 1; */
  t_3 = True;
@@ -85,12 +77,10 @@ static Obj  HdlrFunc4 (
   t_3 = (Obj)(UInt)(INTOBJ_INT(1) != False);
   t_1 = (t_3 ? True : False);
  }
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -104,12 +94,9 @@ static Obj  HdlrFunc5 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return Center and IsAssociative; */
  t_2 = GC_Center;
@@ -133,12 +120,10 @@ static Obj  HdlrFunc5 (
   "<expr> must be 'true' or 'false' or a filter (not a %s)",
   (Int)TNAM_OBJ(t_2), 0L );
  }
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -152,12 +137,9 @@ static Obj  HdlrFunc6 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return IsAssociative and Center; */
  t_2 = GC_IsAssociative;
@@ -181,12 +163,10 @@ static Obj  HdlrFunc6 (
   "<expr> must be 'true' or 'false' or a filter (not a %s)",
   (Int)TNAM_OBJ(t_2), 0L );
  }
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -201,12 +181,9 @@ static Obj  HdlrFunc2 (
  Obj t_4 = 0;
  Obj t_5 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( false and 1, "\n" ); */
  t_1 = GF_Print;
@@ -339,12 +316,10 @@ static Obj  HdlrFunc2 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -356,12 +331,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* runtest := function (  )
       Print( false and 1, "\n" );
@@ -393,12 +365,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/assert.g.dynamic.c
+++ b/tst/test-compile/assert.g.dynamic.c
@@ -25,12 +25,9 @@ static Obj  HdlrFunc2 (
  Obj t_2 = 0;
  Obj t_3 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( AssertionLevel(  ), "\n" ); */
  t_1 = GF_Print;
@@ -169,12 +166,10 @@ static Obj  HdlrFunc2 (
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -186,12 +181,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* runtest := function (  )
       Print( AssertionLevel(  ), "\n" );
@@ -220,12 +212,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/assert.g.static.c
+++ b/tst/test-compile/assert.g.static.c
@@ -25,12 +25,9 @@ static Obj  HdlrFunc2 (
  Obj t_2 = 0;
  Obj t_3 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( AssertionLevel(  ), "\n" ); */
  t_1 = GF_Print;
@@ -169,12 +166,10 @@ static Obj  HdlrFunc2 (
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -186,12 +181,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* runtest := function (  )
       Print( AssertionLevel(  ), "\n" );
@@ -220,12 +212,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/basics.g.dynamic.c
+++ b/tst/test-compile/basics.g.dynamic.c
@@ -54,12 +54,9 @@ static Obj  HdlrFunc2 (
  (void)l_x;
  (void)l_y;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* x := 10 ^ 5; */
  t_1 = POW( INTOBJ_INT(10), INTOBJ_INT(5) );
@@ -134,12 +131,10 @@ static Obj  HdlrFunc2 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -151,21 +146,16 @@ static Obj  HdlrFunc4 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return Length( args ); */
  C_LEN_LIST_FPL( t_1, a_args )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -178,12 +168,9 @@ static Obj  HdlrFunc5 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Display( Length( args ) ); */
  t_1 = GF_Display;
@@ -191,12 +178,10 @@ static Obj  HdlrFunc5 (
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -212,12 +197,9 @@ static Obj  HdlrFunc3 (
  Obj t_4 = 0;
  (void)l_vararg__fun;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* vararg_fun := function ( args... )
       return Length( args );
@@ -431,12 +413,10 @@ static Obj  HdlrFunc3 (
  CALL_0ARGS( GF_PopOptions );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -452,12 +432,9 @@ static Obj  HdlrFunc6 (
  Obj t_4 = 0;
  (void)l_x;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( "setting x to 2 ...\n" ); */
  t_1 = GF_Print;
@@ -876,12 +853,10 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -894,12 +869,9 @@ static Obj  HdlrFunc7 (
  Obj t_1 = 0;
  (void)l_x;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* x := 5; */
  l_x = INTOBJ_INT(5);
@@ -917,12 +889,10 @@ static Obj  HdlrFunc7 (
  l_x = t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -934,20 +904,15 @@ static Obj  HdlrFunc8 (
  Obj l_x = 0;
  (void)l_x;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -965,12 +930,9 @@ static Obj  HdlrFunc9 (
  Obj t_6 = 0;
  (void)l_x;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Display( [  ] ); */
  t_1 = GF_Display;
@@ -1055,12 +1017,10 @@ static Obj  HdlrFunc9 (
  CALL_3ARGS( t_1, t_2, t_3, t_4 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1075,12 +1035,9 @@ static Obj  HdlrFunc10 (
  Obj t_3 = 0;
  (void)l_x;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( "Testing IsBound and Unbind for lvar\n" ); */
  t_1 = GF_Print;
@@ -1289,12 +1246,10 @@ static Obj  HdlrFunc10 (
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1308,12 +1263,9 @@ static Obj  HdlrFunc11 (
  Obj t_2 = 0;
  (void)l_x;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Display( "testing repeat loop" ); */
  t_1 = GF_Display;
@@ -1460,12 +1412,10 @@ static Obj  HdlrFunc11 (
  /* od */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1477,12 +1427,9 @@ static Obj  HdlrFunc12 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* test_int_constants(  ); */
  t_1 = GF_test__int__constants;
@@ -1522,12 +1469,10 @@ static Obj  HdlrFunc12 (
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1539,12 +1484,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* test_int_constants := function (  )
       local x, y;
@@ -1908,12 +1850,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/basics.g.static.c
+++ b/tst/test-compile/basics.g.static.c
@@ -54,12 +54,9 @@ static Obj  HdlrFunc2 (
  (void)l_x;
  (void)l_y;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* x := 10 ^ 5; */
  t_1 = POW( INTOBJ_INT(10), INTOBJ_INT(5) );
@@ -134,12 +131,10 @@ static Obj  HdlrFunc2 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -151,21 +146,16 @@ static Obj  HdlrFunc4 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return Length( args ); */
  C_LEN_LIST_FPL( t_1, a_args )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -178,12 +168,9 @@ static Obj  HdlrFunc5 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Display( Length( args ) ); */
  t_1 = GF_Display;
@@ -191,12 +178,10 @@ static Obj  HdlrFunc5 (
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -212,12 +197,9 @@ static Obj  HdlrFunc3 (
  Obj t_4 = 0;
  (void)l_vararg__fun;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* vararg_fun := function ( args... )
       return Length( args );
@@ -431,12 +413,10 @@ static Obj  HdlrFunc3 (
  CALL_0ARGS( GF_PopOptions );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -452,12 +432,9 @@ static Obj  HdlrFunc6 (
  Obj t_4 = 0;
  (void)l_x;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( "setting x to 2 ...\n" ); */
  t_1 = GF_Print;
@@ -876,12 +853,10 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -894,12 +869,9 @@ static Obj  HdlrFunc7 (
  Obj t_1 = 0;
  (void)l_x;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* x := 5; */
  l_x = INTOBJ_INT(5);
@@ -917,12 +889,10 @@ static Obj  HdlrFunc7 (
  l_x = t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -934,20 +904,15 @@ static Obj  HdlrFunc8 (
  Obj l_x = 0;
  (void)l_x;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -965,12 +930,9 @@ static Obj  HdlrFunc9 (
  Obj t_6 = 0;
  (void)l_x;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Display( [  ] ); */
  t_1 = GF_Display;
@@ -1055,12 +1017,10 @@ static Obj  HdlrFunc9 (
  CALL_3ARGS( t_1, t_2, t_3, t_4 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1075,12 +1035,9 @@ static Obj  HdlrFunc10 (
  Obj t_3 = 0;
  (void)l_x;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( "Testing IsBound and Unbind for lvar\n" ); */
  t_1 = GF_Print;
@@ -1289,12 +1246,10 @@ static Obj  HdlrFunc10 (
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1308,12 +1263,9 @@ static Obj  HdlrFunc11 (
  Obj t_2 = 0;
  (void)l_x;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Display( "testing repeat loop" ); */
  t_1 = GF_Display;
@@ -1460,12 +1412,10 @@ static Obj  HdlrFunc11 (
  /* od */
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1477,12 +1427,9 @@ static Obj  HdlrFunc12 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* test_int_constants(  ); */
  t_1 = GF_test__int__constants;
@@ -1522,12 +1469,10 @@ static Obj  HdlrFunc12 (
  CALL_1ARGS( t_1, t_2 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -1539,12 +1484,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* test_int_constants := function (  )
       local x, y;
@@ -1908,12 +1850,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/function_types.g.dynamic.c
+++ b/tst/test-compile/function_types.g.dynamic.c
@@ -30,12 +30,9 @@ static Obj  HdlrFunc2 (
  Obj t_2 = 0;
  Obj t_3 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( "f1:", a, "\n" ); */
  t_1 = GF_Print;
@@ -44,12 +41,10 @@ static Obj  HdlrFunc2 (
  CALL_3ARGS( t_1, t_2, a_a, t_3 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -65,12 +60,9 @@ static Obj  HdlrFunc3 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( "f2:", a, ":", b, "\n" ); */
  t_1 = GF_Print;
@@ -80,12 +72,10 @@ static Obj  HdlrFunc3 (
  CALL_5ARGS( t_1, t_2, a_a, t_3, a_b, t_4 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -99,12 +89,9 @@ static Obj  HdlrFunc4 (
  Obj t_2 = 0;
  Obj t_3 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( "f3:", a, "\n" ); */
  t_1 = GF_Print;
@@ -113,12 +100,10 @@ static Obj  HdlrFunc4 (
  CALL_3ARGS( t_1, t_2, a_a, t_3 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -135,7 +120,6 @@ static Obj  HdlrFunc5 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  CHECK_NR_AT_LEAST_ARGS( 2, args )
  a_a = ELM_PLIST( args, 1 );
  Obj x_temp_range = Range2Check(INTOBJ_INT(2), INTOBJ_INT(LEN_PLIST(args)));
@@ -143,8 +127,6 @@ static Obj  HdlrFunc5 (
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( "f4:", a, ":", b, "\n" ); */
  t_1 = GF_Print;
@@ -154,12 +136,10 @@ static Obj  HdlrFunc5 (
  CALL_5ARGS( t_1, t_2, a_a, t_3, a_b, t_4 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -170,12 +150,9 @@ static Obj  HdlrFunc6 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* f1( 2 ); */
  t_1 = GF_f1;
@@ -210,12 +187,10 @@ static Obj  HdlrFunc6 (
  CALL_3ARGS( t_1, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -227,12 +202,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* f1 := function ( a )
       Print( "f1:", a, "\n" );
@@ -312,12 +284,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/function_types.g.static.c
+++ b/tst/test-compile/function_types.g.static.c
@@ -30,12 +30,9 @@ static Obj  HdlrFunc2 (
  Obj t_2 = 0;
  Obj t_3 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( "f1:", a, "\n" ); */
  t_1 = GF_Print;
@@ -44,12 +41,10 @@ static Obj  HdlrFunc2 (
  CALL_3ARGS( t_1, t_2, a_a, t_3 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -65,12 +60,9 @@ static Obj  HdlrFunc3 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( "f2:", a, ":", b, "\n" ); */
  t_1 = GF_Print;
@@ -80,12 +72,10 @@ static Obj  HdlrFunc3 (
  CALL_5ARGS( t_1, t_2, a_a, t_3, a_b, t_4 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -99,12 +89,9 @@ static Obj  HdlrFunc4 (
  Obj t_2 = 0;
  Obj t_3 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( "f3:", a, "\n" ); */
  t_1 = GF_Print;
@@ -113,12 +100,10 @@ static Obj  HdlrFunc4 (
  CALL_3ARGS( t_1, t_2, a_a, t_3 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -135,7 +120,6 @@ static Obj  HdlrFunc5 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  CHECK_NR_AT_LEAST_ARGS( 2, args )
  a_a = ELM_PLIST( args, 1 );
  Obj x_temp_range = Range2Check(INTOBJ_INT(2), INTOBJ_INT(LEN_PLIST(args)));
@@ -143,8 +127,6 @@ static Obj  HdlrFunc5 (
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( "f4:", a, ":", b, "\n" ); */
  t_1 = GF_Print;
@@ -154,12 +136,10 @@ static Obj  HdlrFunc5 (
  CALL_5ARGS( t_1, t_2, a_a, t_3, a_b, t_4 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -170,12 +150,9 @@ static Obj  HdlrFunc6 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* f1( 2 ); */
  t_1 = GF_f1;
@@ -210,12 +187,10 @@ static Obj  HdlrFunc6 (
  CALL_3ARGS( t_1, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -227,12 +202,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* f1 := function ( a )
       Print( "f1:", a, "\n" );
@@ -312,12 +284,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/info.g.dynamic.c
+++ b/tst/test-compile/info.g.dynamic.c
@@ -28,12 +28,9 @@ static Obj  HdlrFunc2 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( InfoLevel( InfoDebug ), "\n" ); */
  t_1 = GF_Print;
@@ -127,12 +124,10 @@ static Obj  HdlrFunc2 (
  }
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -144,12 +139,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* runtest := function (  )
       Print( InfoLevel( InfoDebug ), "\n" );
@@ -173,12 +165,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/info.g.static.c
+++ b/tst/test-compile/info.g.static.c
@@ -28,12 +28,9 @@ static Obj  HdlrFunc2 (
  Obj t_3 = 0;
  Obj t_4 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( InfoLevel( InfoDebug ), "\n" ); */
  t_1 = GF_Print;
@@ -127,12 +124,10 @@ static Obj  HdlrFunc2 (
  }
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -144,12 +139,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* runtest := function (  )
       Print( InfoLevel( InfoDebug ), "\n" );
@@ -173,12 +165,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/plus.g.dynamic.c
+++ b/tst/test-compile/plus.g.dynamic.c
@@ -17,21 +17,16 @@ static Obj  HdlrFunc2 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return 1 + 2; */
  C_SUM_INTOBJS( t_1, INTOBJ_INT(1), INTOBJ_INT(2) )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -43,12 +38,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* runtest := function (  )
       return 1 + 2;
@@ -64,12 +56,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/plus.g.static.c
+++ b/tst/test-compile/plus.g.static.c
@@ -17,21 +17,16 @@ static Obj  HdlrFunc2 (
 {
  Obj t_1 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* return 1 + 2; */
  C_SUM_INTOBJS( t_1, INTOBJ_INT(1), INTOBJ_INT(2) )
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -43,12 +38,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* runtest := function (  )
       return 1 + 2;
@@ -64,12 +56,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/print_various.g.dynamic.c
+++ b/tst/test-compile/print_various.g.dynamic.c
@@ -26,12 +26,9 @@ static Obj  HdlrFunc2 (
  Obj t_5 = 0;
  Obj t_6 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( 1, "\n" ); */
  t_1 = GF_Print;
@@ -103,12 +100,10 @@ static Obj  HdlrFunc2 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -120,12 +115,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* runtest := function (  )
       Print( 1, "\n" );
@@ -146,12 +138,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/test-compile/print_various.g.static.c
+++ b/tst/test-compile/print_various.g.static.c
@@ -26,12 +26,9 @@ static Obj  HdlrFunc2 (
  Obj t_5 = 0;
  Obj t_6 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* Print( 1, "\n" ); */
  t_1 = GF_Print;
@@ -103,12 +100,10 @@ static Obj  HdlrFunc2 (
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }
@@ -120,12 +115,9 @@ static Obj  HdlrFunc1 (
  Obj t_1 = 0;
  Obj t_2 = 0;
  Bag oldFrame;
- OLD_BRK_CURR_STAT
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- REM_BRK_CURR_STAT();
- SET_BRK_CURR_STAT(0);
  
  /* runtest := function (  )
       Print( 1, "\n" );
@@ -146,12 +138,10 @@ static Obj  HdlrFunc1 (
  AssGVar( G_runtest, t_1 );
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
  
  /* return; */
- RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
 }

--- a/tst/testspecial/backtrace.g
+++ b/tst/testspecial/backtrace.g
@@ -66,3 +66,9 @@ f:=function() local x; Assert(0, 1, "hello"); return 2; end;;
 f();
 Where();
 quit;
+
+# Verify issue #2656 is fixed
+l := [[1]];; f := {} -> l[2,1];;
+f();
+Where();
+quit;

--- a/tst/testspecial/backtrace.g
+++ b/tst/testspecial/backtrace.g
@@ -1,0 +1,68 @@
+f := function() 
+  local l;
+  l := 0 * [1..6];
+  l[[1..3]] := 1;
+end;
+f();
+Where();
+quit;
+
+
+f:=function() if true = 1/0 then return 1; fi; return 2; end;;
+f();
+Where();
+quit;
+
+
+f:=function() local x; if x then return 1; fi; return 2; end;;
+f();
+Where();
+quit;
+
+
+f:=function() if 1 then return 1; fi; return 2; end;;
+f();
+Where();
+quit;
+
+
+f:=function() if 1 < 0 then return 1; elif 1 then return 2; fi; return 3; end;;
+f();
+Where();
+quit;
+
+
+f:=function() while 1 do return 1; od; return 2; end;;
+f();
+Where();
+quit;
+
+
+f:=function() local i; for i in 1 do return 1; od; return 2; end;;
+f();
+Where();
+quit;
+
+
+f:=function() local i; for i in true do return 1; od; return 2; end;;
+f();
+Where();
+quit;
+
+
+f:=function() local x; repeat x:=1; until 1; return 2; end;;
+f();
+Where();
+quit;
+
+
+f:=function() local x; Assert(0, 1); return 2; end;;
+f();
+Where();
+quit;
+
+
+f:=function() local x; Assert(0, 1, "hello"); return 2; end;;
+f();
+Where();
+quit;

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -170,4 +170,19 @@ brk> Where();
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> quit;
+gap> 
+gap> # Verify issue #2656 is fixed
+gap> l := [[1]];; f := {} -> l[2,1];;
+gap> f();
+Error, List Element: <list>[2] must have an assigned value in
+  return m[i][j]; at GAPROOT/lib/matrix.gi:29 called from 
+return l[2, 1]; at *stdin*:39 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:40
+you can 'return;' after assigning a value
+brk> Where();
+return l[2, 1]; at *stdin*:39 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:1
+brk> quit;
 gap> QUIT;

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -21,9 +21,7 @@ gap>
 gap> f:=function() if true = 1/0 then return 1; fi; return 2; end;;
 gap> f();
 Error, Rational operations: <divisor> must not be zero in
-  if true = 1 / 0 then
-    return 1;
-fi; at *stdin*:9 called from 
+  1 / 0 at *stdin*:9 called from 
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:10
 you can replace <divisor> via 'return <divisor>;'
@@ -66,11 +64,7 @@ gap>
 gap> f:=function() if 1 < 0 then return 1; elif 1 then return 2; fi; return 3; end;;
 gap> f();
 Error, <expr> must be 'true' or 'false' (not a integer) in
-  if 1 < 0 then
-    return 1;
-elif 1 then
-    return 2;
-fi; at *stdin*:18 called from 
+  1 < 0 at *stdin*:18 called from 
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:19
 you can replace <expr> via 'return <expr>;'
@@ -136,9 +130,7 @@ gap>
 gap> f:=function() local x; repeat x:=1; until 1; return 2; end;;
 gap> f();
 Error, <expr> must be 'true' or 'false' (not a integer) in
-  repeat
-    x := 1;
-until 1; at *stdin*:30 called from 
+  x := 1; at *stdin*:30 called from 
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:31
 you can replace <expr> via 'return <expr>;'

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -1,0 +1,167 @@
+gap> f := function() 
+>   local l;
+>   l := 0 * [1..6];
+>   l[[1..3]] := 1;
+> end;
+function(  ) ... end
+gap> f();
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `[]:=' on 3 arguments at GAPROOT/lib/methsel2.g:250 called from
+0 * [ 1 .. 6 ] at *stdin*:4 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:7
+type 'quit;' to quit to outer loop
+brk> Where();
+0 * [ 1 .. 6 ] at *stdin*:4 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:1
+brk> quit;
+gap> 
+gap> 
+gap> f:=function() if true = 1/0 then return 1; fi; return 2; end;;
+gap> f();
+Error, Rational operations: <divisor> must not be zero in
+  if true = 1 / 0 then
+    return 1;
+fi; at *stdin*:9 called from 
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:10
+you can replace <divisor> via 'return <divisor>;'
+brk> Where();
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:1
+brk> quit;
+gap> 
+gap> 
+gap> f:=function() local x; if x then return 1; fi; return 2; end;;
+gap> f();
+Error, Variable: 'x' must have an assigned value in
+  if x then
+    return 1;
+fi; at *stdin*:12 called from 
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:13
+you can 'return;' after assigning a value
+brk> Where();
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:1
+brk> quit;
+gap> 
+gap> 
+gap> f:=function() if 1 then return 1; fi; return 2; end;;
+gap> f();
+Error, <expr> must be 'true' or 'false' (not a integer) in
+  if 1 then
+    return 1;
+fi; at *stdin*:15 called from 
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:16
+you can replace <expr> via 'return <expr>;'
+brk> Where();
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:1
+brk> quit;
+gap> 
+gap> 
+gap> f:=function() if 1 < 0 then return 1; elif 1 then return 2; fi; return 3; end;;
+gap> f();
+Error, <expr> must be 'true' or 'false' (not a integer) in
+  if 1 < 0 then
+    return 1;
+elif 1 then
+    return 2;
+fi; at *stdin*:18 called from 
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:19
+you can replace <expr> via 'return <expr>;'
+brk> Where();
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:1
+brk> quit;
+gap> 
+gap> 
+gap> f:=function() while 1 do return 1; od; return 2; end;;
+gap> f();
+Error, <expr> must be 'true' or 'false' (not a integer) in
+  while 1 do
+    return 1;
+od; at *stdin*:21 called from 
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:22
+you can replace <expr> via 'return <expr>;'
+brk> Where();
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:1
+brk> quit;
+gap> 
+gap> 
+gap> f:=function() local i; for i in 1 do return 1; od; return 2; end;;
+gap> f();
+Error, You cannot loop over the integer 1 did you mean the range [1..1] at GAPROOT/lib/integer.gi:1742 called from
+<corrupted statement>  called from
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:25
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> Where();
+<corrupted statement>  called from
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:1
+brk> quit;
+gap> 
+gap> 
+gap> f:=function() local i; for i in true do return 1; od; return 2; end;;
+gap> f();
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `Iterator' on 1 arguments at GAPROOT/lib/methsel2.g:250 called from
+<corrupted statement>  called from
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:28
+type 'quit;' to quit to outer loop
+brk> Where();
+<corrupted statement>  called from
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:1
+brk> quit;
+gap> 
+gap> 
+gap> f:=function() local x; repeat x:=1; until 1; return 2; end;;
+gap> f();
+Error, <expr> must be 'true' or 'false' (not a integer) in
+  repeat
+    x := 1;
+until 1; at *stdin*:30 called from 
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:31
+you can replace <expr> via 'return <expr>;'
+brk> Where();
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:1
+brk> quit;
+gap> 
+gap> 
+gap> f:=function() local x; Assert(0, 1); return 2; end;;
+gap> f();
+Error, Assertion condition must evaluate to 'true' or 'false', not a integer in
+  Assert( 0, 1 ); at *stdin*:33 called from 
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:34
+you may 'return true;' or 'return false;'
+brk> Where();
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:1
+brk> quit;
+gap> 
+gap> 
+gap> f:=function() local x; Assert(0, 1, "hello"); return 2; end;;
+gap> f();
+Error, Assertion condition must evaluate to 'true' or 'false', not a integer in
+  Assert( 0, 1, "hello" ); at *stdin*:36 called from 
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:37
+you may 'return true;' or 'return false;'
+brk> Where();
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:1
+brk> quit;
+gap> QUIT;

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -7,12 +7,12 @@ function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[]:=' on 3 arguments at GAPROOT/lib/methsel2.g:250 called from
-0 * [ 1 .. 6 ] at *stdin*:4 called from
+l[[ 1 .. 3 ]] := 1; at *stdin*:5 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:7
 type 'quit;' to quit to outer loop
 brk> Where();
-0 * [ 1 .. 6 ] at *stdin*:4 called from
+l[[ 1 .. 3 ]] := 1; at *stdin*:5 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> quit;
@@ -98,13 +98,17 @@ gap>
 gap> f:=function() local i; for i in 1 do return 1; od; return 2; end;;
 gap> f();
 Error, You cannot loop over the integer 1 did you mean the range [1..1] at GAPROOT/lib/integer.gi:1742 called from
-<corrupted statement>  called from
+for i in 1 do
+    return 1;
+od; at *stdin*:24 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:25
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> Where();
-<corrupted statement>  called from
+for i in 1 do
+    return 1;
+od; at *stdin*:24 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> quit;
@@ -114,12 +118,16 @@ gap> f:=function() local i; for i in true do return 1; od; return 2; end;;
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Iterator' on 1 arguments at GAPROOT/lib/methsel2.g:250 called from
-<corrupted statement>  called from
+for i in true do
+    return 1;
+od; at *stdin*:27 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:28
 type 'quit;' to quit to outer loop
 brk> Where();
-<corrupted statement>  called from
+for i in true do
+    return 1;
+od; at *stdin*:27 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> quit;

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -64,7 +64,11 @@ gap>
 gap> f:=function() if 1 < 0 then return 1; elif 1 then return 2; fi; return 3; end;;
 gap> f();
 Error, <expr> must be 'true' or 'false' (not a integer) in
-  1 < 0 at *stdin*:18 called from 
+  if 1 < 0 then
+    return 1;
+elif 1 then
+    return 2;
+fi; at *stdin*:18 called from 
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:19
 you can replace <expr> via 'return <expr>;'
@@ -130,7 +134,9 @@ gap>
 gap> f:=function() local x; repeat x:=1; until 1; return 2; end;;
 gap> f();
 Error, <expr> must be 'true' or 'false' (not a integer) in
-  x := 1; at *stdin*:30 called from 
+  repeat
+    x := 1;
+until 1; at *stdin*:30 called from 
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:31
 you can replace <expr> via 'return <expr>;'

--- a/tst/testspecial/bad-array-double-1.g.out
+++ b/tst/testspecial/bad-array-double-1.g.out
@@ -5,7 +5,7 @@ function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[]' on 3 arguments at GAPROOT/lib/methsel2.g:250 called from
-<corrupted statement>  called from
+return "abc"[1, 1]; at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-int-0.g.out
+++ b/tst/testspecial/bad-array-int-0.g.out
@@ -7,7 +7,7 @@ function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[]' on 2 arguments at GAPROOT/lib/methsel2.g:250 called from
-l[0] at *stdin*:5 called from
+return l[0]; at *stdin*:5 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:7
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-int-1.g.out
+++ b/tst/testspecial/bad-array-int-1.g.out
@@ -4,7 +4,7 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, List Element: <list> must be a list (not a integer) in
-  return 1[1]; at *stdin*:3 called from 
+  1[1] at *stdin*:3 called from 
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 you can replace <list> via 'return <list>;'

--- a/tst/testspecial/bad-array-int-1.g.out
+++ b/tst/testspecial/bad-array-int-1.g.out
@@ -4,7 +4,7 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, List Element: <list> must be a list (not a integer) in
-  1[1] at *stdin*:3 called from 
+  return 1[1]; at *stdin*:3 called from 
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 you can replace <list> via 'return <list>;'

--- a/tst/testspecial/bad-array-string.g.out
+++ b/tst/testspecial/bad-array-string.g.out
@@ -5,7 +5,7 @@ function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[]' on 2 arguments at GAPROOT/lib/methsel2.g:250 called from
-1["abc"] at *stdin*:3 called from
+return 1["abc"]; at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/debug-var.g.out
+++ b/tst/testspecial/debug-var.g.out
@@ -33,7 +33,7 @@ Syntax warning: Unbound global variable in *errin*:6
 unbound_global;
               ^
 Error, Variable: 'unbound_global' must have a value in
-  <corrupted statement>  called from 
+  Error( "breakpoint" ); at *stdin*:9 called from 
 g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:6
@@ -47,7 +47,7 @@ brk> IsBound(y);
 true
 brk> unbound_higher;
 Error, Variable: 'unbound_higher' must have an assigned value in
-  <corrupted statement>  called from 
+  Error( "breakpoint" ); at *stdin*:9 called from 
 g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:12
@@ -63,7 +63,7 @@ brk> IsBound(z);
 true
 brk> unbound_local;
 Error, Variable: 'unbound_local' must have an assigned value in
-  <corrupted statement>  called from 
+  Error( "breakpoint" ); at *stdin*:9 called from 
 g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:17
@@ -109,7 +109,7 @@ brk_2> IsBound(y);
 true
 brk_2> unbound_higher;
 Error, Variable: <debug-variable-1-4> must have a value in
-  <corrupted statement>  called from 
+  Error( "foobar" ); at *stdin*:20 called from 
 Error( "breakpoint" ); at *stdin*:9 called from
 g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
@@ -119,7 +119,7 @@ brk_2> # check coding of dvars
 brk_2> function() return unbound_higher; end;
 Error, Variable: <debug-variable-1-4> cannot be used here in
   <corrupted statement>  called from 
-<corrupted statement>  called from
+Error( "foobar" ); at *stdin*:20 called from
 Error( "breakpoint" ); at *stdin*:9 called from
 g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
@@ -127,7 +127,7 @@ g( 10 ) at *stdin*:12 called from
 brk_2> function() return IsBound(unbound_higher); end;
 Error, Variable: <debug-variable-1-4> cannot be used here in
   <corrupted statement>  called from 
-<corrupted statement>  called from
+Error( "foobar" ); at *stdin*:20 called from
 Error( "breakpoint" ); at *stdin*:9 called from
 g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
@@ -135,7 +135,7 @@ g( 10 ) at *stdin*:12 called from
 brk_2> function() Unbind(unbound_higher); end;
 Error, Variable: <debug-variable-1-4> cannot be used here in
   <corrupted statement>  called from 
-<corrupted statement>  called from
+Error( "foobar" ); at *stdin*:20 called from
 Error( "breakpoint" ); at *stdin*:9 called from
 g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
@@ -143,7 +143,7 @@ g( 10 ) at *stdin*:12 called from
 brk_2> function() unbound_higher:=0; end;
 Error, Variable: <debug-variable-1-4> cannot be used here in
   <corrupted statement>  called from 
-<corrupted statement>  called from
+Error( "foobar" ); at *stdin*:20 called from
 Error( "breakpoint" ); at *stdin*:9 called from
 g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )

--- a/tst/testspecial/up-down-env.g.out
+++ b/tst/testspecial/up-down-env.g.out
@@ -2,7 +2,7 @@ gap> f:=lvl -> 1/lvl + f(lvl-1);
 function( lvl ) ... end
 gap> f(7);
 Error, Rational operations: <divisor> must not be zero in
-  return 1 / lvl + f( (lvl - 1) ); at *stdin*:2 called from 
+  1 / lvl at *stdin*:2 called from 
 f( lvl - 1 ) at *stdin*:2 called from
 f( lvl - 1 ) at *stdin*:2 called from
 f( lvl - 1 ) at *stdin*:2 called from


### PR DESCRIPTION
This PR unifies the code we use to track the current statement and expression. It resolves various bugs where backtraces indicated the wrong statement as the current one, ans also gets rid of some cases where "<corrupt statement>" was printed.

This needs more work on the long run (in future PRs), in particular for the case where there is an error in the condition expression of an `if` statement or a loop: then what should we print? Just the expression in which the error occurred? But that could be a simple integer (in `if 1 then ... fi`), which is not helpful (and in this particular case, would even lead to a "corrupt statement" message for technical reasons).

Or perhaps the whole statement should be printed? But that could span dozens of lines. Slightly better is to print, say, a while loop as `while COND do ... od;`, i.e. replace the body by `...`. But (a) the condition still could be multiple lines long, and (b) this does not work very well for an `if/elif/elif/.../else/fi` with multiple branches. 

Or "just the line on which the error occurred" -- but that then depends on the on-disk representation of the data, which opens its own can of worms, so I'd rather avoid it.

For now, I think my favorite would be to just print `while COND do` (no `...` or `od;`), resp. `if COND then` or `elif COND then` etc. But we lack the facilities for that -- esp. for the `elif` we currently don't even have place where to store on which of the various "branches" of a "multi-condition if statement" we are.

So, this needs work, but not today... I plan to turn the above into an issue later.

Resolves #616
Fixes #2656