### PR TITLE
Add --enable-libgap to build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,8 @@ doc/gapmacrodoc.idx
 /hpcgap/ward
 
 /builds/
+
+#libGAP
+libgap.la
+.libs
+

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -24,6 +24,9 @@ ADDGUARDS2 = @ADDGUARDS2@
 # garbage collector source files
 GC_SOURCES = @GC_SOURCES@
 
+# Dynamic library
+BUILD_LIBGAP = @BUILD_LIBGAP@
+
 # compatibility mode
 COMPAT_MODE = @COMPAT_MODE@
 GAPARCH = @GAPARCH@

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -16,7 +16,7 @@
 all: gap$(EXEEXT) gac
 .PHONY: all
 
-libgap: libgap.la
+libgap: libgap.la sysinfo.gap symlinks
 .PHONY: libgap
 
 # Backwards compatibility: add "default" target as alias for "all"
@@ -412,6 +412,10 @@ gap$(EXEEXT): $(OBJS) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
 
 endif
 
+ifeq ($(BUILD_LIBGAP),yes)
+libgap.so: $(OBJS)
+	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) -shared $(OBJS) $(GAP_LIBS) -o $@
+endif
 
 ########################################################################
 # The "docomp" target regenerates the various src/c_*.c files, and

--- a/configure.ac
+++ b/configure.ac
@@ -228,6 +228,17 @@ AS_CASE([$with_gc],
 AC_MSG_RESULT([$with_gc])
 
 dnl
+dnl User setting: dynamic library mode (off by default)
+dnl
+AC_ARG_ENABLE([libgap],
+    [AS_HELP_STRING([--enable-libgap], [enable building of dynamic library])],
+    [AC_DEFINE([BUILD_LIBGAP], [1], [define if building libgap])],
+    [enable_libgap=no]
+)
+AC_MSG_CHECKING([whether to enable dynamic library mode])
+AC_MSG_RESULT([$enable_libgap])
+
+dnl
 dnl User setting: Debug mode (off by default)
 dnl
 AC_ARG_ENABLE([debug],


### PR DESCRIPTION
Building GAP as an executable with --enable-libgap will yield a binary
that ignores most signals.

Added libgap files to .gitignore

Added sysinfo.gap target to libgap target

Added symlinks target to libgap target

This is part of building LibGAP, see https://github.com/gap-system/gap/projects/5