### PR TITLE
Added IsLIBGAP constant

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -927,6 +927,17 @@ BindGlobal ("ShowSystemInformation", function ()
     ShowPackageInformation();
 end );
 
+
+#############################################################################
+##
+## Initialize the IsLIBGAP variable (if not done before). If this variable
+## is false, an interactive session will be started.
+## Otherwise no interactive session is started.
+##
+if not IsBound( IsLIBGAP ) then
+  BIND_CONSTANT( "IsLIBGAP", false );
+fi;
+
 #############################################################################
 ##
 ##  Finally, deal with the lists of global variables.
@@ -1016,7 +1027,9 @@ InstallAndCallPostRestore( function()
     od;
 end );
 
-if IsHPCGAP and THREAD_UI() then
+if IsLIBGAP then
+  # GAP is used as a library, do not start an interactive session
+elif IsHPCGAP and THREAD_UI() then
   ReadLib("hpc/consoleui.g");
   MULTI_SESSION();
 else

--- a/tst/testinstall/IsLIBGAP.tst
+++ b/tst/testinstall/IsLIBGAP.tst
@@ -1,0 +1,12 @@
+#############################################################################
+##
+#W  IsLIBGAP.tst                  GAP library               Sebastian Gutsche
+##
+##
+#Y  Copyright (C)  2018,  GAP Group
+##
+gap> START_TEST("IsLIBGAP.tst");
+gap> IsBound( IsLIBGAP );
+true
+gap> STOP_TEST( "IsLIBGAP.tst", 1);
+


### PR DESCRIPTION
This constant can be set to true in the initialize_libgap function (future work)
to stop GAP from starting an interactive session

This replaces #2527 