### PR TITLE
Refactor READ_ALL_COMMANDS

### DIFF
--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -234,6 +234,14 @@ function( stream )
     CloseStream(stream);
 end );
 
+BindGlobal("LIBGAP_EvalString",
+function(string)
+   local instream, obj;
+   instream := InputTextString(string);
+   obj := READ_ALL_COMMANDS(instream, 0, false);
+   return obj;
+end);
+
 
 #############################################################################
 ##

--- a/src/streams.c
+++ b/src/streams.c
@@ -15,6 +15,7 @@
 #include "streams.h"
 
 #include "bool.h"
+#include "calls.h"
 #include "error.h"
 #include "funcs.h"
 #include "gap.h"
@@ -23,6 +24,7 @@
 #include "lists.h"
 #include "modules.h"
 #include "io.h"
+#include "opers.h"
 #include "plist.h"
 #include "precord.h"
 #include "read.h"
@@ -79,69 +81,113 @@ static Int READ_COMMAND(Obj *evalResult)
     return 1;
 }
 
-
-/*
- * This function reads all code from the stream and returns either `fail` if the stream
- * cannot be opened, or executes all statements in the stream and returns a list of lists,
- * each entry of which reflects the result of the execution of one statement.
- *
- * The results are returned as lists with at most three bound positions.
- *
- * If the first entry is `true`, then the second entry is bound to the result of
- * the statement if there was one, and unbound otherwise, and the third entry
- * reflects whether the statement ended in a dual semicolon,
- * if the first entry is `false', an error occurred during the execution of a statement,
- * and no other positions of the list are bound.
- *
- * This function is currently used in interactive tools such as the GAP Jupyter kernel to
- * execute cells and is likely to be replaced by a function that can read a single command
- * from a stream without losing the rest of its content.
- */
-Obj FuncREAD_ALL_COMMANDS( Obj self, Obj stream, Obj echo )
+/****************************************************************************
+**
+*F  FuncREAD_ALL_COMMANDS( <self>, <instream>, <echo>, <outputFunc> )
+**
+**  FuncREAD_ALL_COMMANDS reads all code from <instream> and returns either
+**  fail if the stream cannot be opened, or executes all statements in the
+**  stream and returns a list of lists, each entry of which reflects the
+**  result of the execution of one statement.
+**
+**  The results are returned as lists of length three if <outputFunc> is
+**  false, or five, if <outputFunc> is a function.
+**
+**  If the first entry is true, then the second entry is bound to the result
+**  of the statement if there was one, and unbound otherwise, and the third
+**  entry reflects whether the statement ended in a dual semicolon. If the
+**  first entry is false, an error occurred during the execution of a
+**  statement. In this case, if <outputFunc> is false, only the first entry
+**  is set. If <outputFunc> is a function, only the first and the fifth entry
+**  are set. If <outputFunc> is a function, the fourth entry of the list is
+**  <outputFunc> applied to the result, if there was one, and if the
+**  statement did not end in a dual semicolon. Furthermore, if <outputFunc>
+**  is not false, the fifth entry contains a string of all output printed
+**  while the corresponding statement was executed. If <outputFunc> is false,
+**  all intermediate output is discarded.
+**
+**  This function is currently used in interactive tools such as the GAP
+**  Jupyter kernel to execute cells and is likely to be replaced by a
+**  function that can read a single command from a stream without losing the
+**  rest of its content.
+*/
+Obj FuncREAD_ALL_COMMANDS(Obj self, Obj instream, Obj echo, Obj outputFunc)
 {
     ExecStatus status;
-    Int resultCount, resultCapacity;
-    UInt dualSemicolon;
-    Obj result, resultList;
-    Obj evalResult;
+    UInt       dualSemicolon;
+    Obj        result, resultList;
+    Obj        evalResult;
+    Obj        outstream = 0;
+    Obj        outstreamString = 0;
 
-    /* try to open the stream */
-    if (!OpenInputStream(stream, echo == True)) {
+    /* try to open the streams */
+    if (!OpenInputStream(instream, echo == True)) {
         return Fail;
     }
 
-    resultCount = 0;
-    resultCapacity = 16;
-    resultList = NEW_PLIST( T_PLIST, resultCapacity );
-    SET_LEN_PLIST(resultList, resultCount);
+
+    if (outputFunc != False) {
+        outstreamString = NEW_STRING(0);
+        outstream = DoOperation2Args(ValGVar(GVarName("OutputTextString")),
+                                     outstreamString, True);
+    }
+    if (outstream && !OpenOutputStream(outstream)) {
+        CloseInput();
+        return Fail;
+    }
+
+    resultList = NEW_PLIST(T_PLIST, 16);
 
     do {
         ClearError();
-        status = ReadEvalCommand(STATE(BottomLVars), &evalResult, &dualSemicolon);
 
-        if(!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT))) {
-            resultCount++;
-            if (resultCount > resultCapacity) {
-                resultCapacity += 16;
-                GROW_PLIST(resultList, resultCapacity);
+        if (outstream) {
+            // Clean in case Callback function had output
+            SET_LEN_STRING(outstreamString, 0);
+        }
+
+        status =
+            ReadEvalCommand(STATE(BottomLVars), &evalResult, &dualSemicolon);
+
+        if (!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT))) {
+            if (outputFunc != False) {
+                Obj copy = CopyToStringRep(outstreamString);
+                SET_LEN_STRING(outstreamString, 0);
+                result = NEW_PLIST(T_PLIST, 5);
+                SET_LEN_PLIST(result, 5);
+                SET_ELM_PLIST(result, 5, copy);
+                CHANGED_BAG(result);
             }
-            result = NEW_PLIST( T_PLIST, 3 );
-            SET_LEN_PLIST(result, 1);
-            SET_ELM_PLIST(result, 1, False);
-            SET_ELM_PLIST(resultList, resultCount, result );
-            SET_LEN_PLIST(resultList, resultCount );
-
-            if(!(status & STATUS_ERROR)) {
+            else {
+                result = NEW_PLIST(T_PLIST, 3);
                 SET_LEN_PLIST(result, 3);
+            }
+            SET_ELM_PLIST(result, 1, False);
+            PushPlist(resultList, result);
+
+            if (!(status & STATUS_ERROR)) {
                 SET_ELM_PLIST(result, 1, True);
                 SET_ELM_PLIST(result, 3, dualSemicolon ? True : False);
 
                 if (evalResult) {
                     SET_ELM_PLIST(result, 2, evalResult);
+                    CHANGED_BAG(result);
+                }
+
+                if (evalResult && outputFunc != False && !dualSemicolon) {
+                    Obj tmp = CALL_1ARGS(outputFunc, evalResult);
+                    SET_ELM_PLIST(result, 4, tmp);
+                    CHANGED_BAG(result);
                 }
             }
+            else {
+                SET_LEN_PLIST(result, 1);
+            }
         }
-    } while(!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT)));
+    } while (!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT)));
+
+    if (outstream)
+        CloseOutput();
     CloseInput();
     ClearError();
 
@@ -2132,7 +2178,7 @@ static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC(READ, 1, "filename"),
     GVAR_FUNC(READ_NORECOVERY, 1, "filename"),
-    GVAR_FUNC(READ_ALL_COMMANDS, 2, "stream, echo"),
+    GVAR_FUNC(READ_ALL_COMMANDS, 3, "instream, echo, outputFunc"),
     GVAR_FUNC(READ_COMMAND_REAL, 2, "stream, echo"),
     GVAR_FUNC(READ_STREAM, 1, "stream"),
     GVAR_FUNC(READ_STREAM_LOOP, 2, "stream, catchstderrout"),
@@ -2183,7 +2229,8 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(RAW_MODE_FILE, 2, "fid, bool"),
 #endif
 #ifdef HAVE_SELECT
-    GVAR_FUNC(UNIXSelect, 5, "inlist, outlist, exclist, timeoutsec, timeoutusec"),
+    GVAR_FUNC(
+        UNIXSelect, 5, "inlist, outlist, exclist, timeoutsec, timeoutusec"),
 #endif
     GVAR_FUNC(ExecuteProcess, 5, "dir, prg, in, out, args"),
     { 0, 0, 0, 0, 0 }

--- a/tst/testinstall/read.tst
+++ b/tst/testinstall/read.tst
@@ -83,14 +83,16 @@ gap> FileString( Filename(dir, "test.g.gz"), "\037\213\b\b0,\362W\000\ctest.g\00
 32
 gap> StringFile( Filename(dir, "test.g") ) = "1+1;\n" or ARCH_IS_WINDOWS(); # works only when Cygwin installed with gzip
 true
-gap> READ_ALL_COMMANDS(InputTextString(""), false);
+gap> READ_ALL_COMMANDS(InputTextString(""), false, false);
 [  ]
-gap> READ_ALL_COMMANDS(InputTextString("a := (3,7,1); y := a^(-1);"), false);
+gap> READ_ALL_COMMANDS(InputTextString("a := (3,7,1); y := a^(-1);"), false, false);
 [ [ true, (1,3,7), false ], [ true, (1,7,3), false ] ]
-gap> READ_ALL_COMMANDS(InputTextString("Unbind(x); z := x;"), false);
+gap> READ_ALL_COMMANDS(InputTextString("Unbind(x); z := x;"), false, false);
 Error, Variable: 'x' must have a value
 [ [ true,, false ], [ false ] ]
-gap> p := READ_ALL_COMMANDS(InputTextString("1;;2;3;;4;5;6;7;8;9;10;11;12;13;14;;15;16;17;18;"), false);;
+gap> READ_ALL_COMMANDS(InputTextString("SymmetricGroup(5);"), false, ViewString );
+[ [ true, Sym( [ 1 .. 5 ] ), false, "Sym( [ 1 .. 5 ] )", "" ] ]
+gap> p := READ_ALL_COMMANDS(InputTextString("1;;2;3;;4;5;6;7;8;9;10;11;12;13;14;;15;16;17;18;"), false, false);;
 gap> p;
 [ [ true, 1, true ], [ true, 2, false ], [ true, 3, true ], 
   [ true, 4, false ], [ true, 5, false ], [ true, 6, false ], 


### PR DESCRIPTION
EDIT: I decided to take the ReadTo functions out of this PR for now.

I changed `READ_ALL_COMMANDS` to take a function callback that is executed after each statement is evalutated. Maybe we can discuss/review/merge this first, before we write the ReadTo-Functions.

THE FOLLOWING IS OBSOLETE:

~~The two functions take a string of GAP statements, execute the statements, and return a list of results.~~
~~The PR consists of two parts:~~

~~* First part exposes the functions `OpenOutputStream` and `CloseStream` to the GAP level, and furthermore adds an output stream argument to `READ_ALL_COMMANDS`~~
~~* Second part adds the two functions, and tests for them~~
