### PR TITLE
Don't use fast method for composing with identity mapping if source & range don't match

### DIFF
--- a/lib/mapprep.gi
+++ b/lib/mapprep.gi
@@ -1387,9 +1387,7 @@ InstallMethod( CompositionMapping2,
   [ IsGeneralMapping and IsOne, IsGeneralMapping ],
   SUM_FLAGS + 1,  # should be higher than the rank for a zero mapping
 function( id, map )
-  if    not IsSubset(Source(id),Range(map))
-    and not IsSubset(Source(id),ImagesSource(map))
-  then
+  if not IsSubset(Source(id),Range(map)) then
     # if the identity is defined on something smaller, we need to take a
     # true `CompositionMapping'.
     TryNextMethod();

--- a/tst/testbugfix/2018-06-11-mapping.tst
+++ b/tst/testbugfix/2018-06-11-mapping.tst
@@ -1,0 +1,13 @@
+# There was a bug where composition of an identity mapping and another
+# mapping x where the Source of the identity mapping contained the
+# ImagesSource of x, but not its whole range, simply returned x,
+# resulting in a composition whose Range was strictly bigger than that
+# of its first argument, and causing problems in IsomorphismPermGroup
+#
+gap> g := SymmetricGroup(7);;
+gap> phi := GroupGeneralMappingByImages(g,g,[(1,2,3,4,5),(1,2)],[(1,2,3,4,6),(1,2)]);
+[ (1,2,3,4,5), (1,2) ] -> [ (1,2,3,4,6), (1,2) ]
+gap> psi := IdentityMapping(SymmetricGroup(6));
+IdentityMapping( Sym( [ 1 .. 6 ] ) )
+gap> Range(CompositionMapping(psi,phi));
+Sym( [ 1 .. 6 ] )


### PR DESCRIPTION
The code that was there could produce a composition whose range didn't match the second argument, which can never be right. 