### PR TITLE
Add DEBUG_MASTERPOINTERS to --enable-debug.

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -23,6 +23,7 @@
 #define COUNT_BAGS
 #define COUNT_OPERS
 #define DEBUG_GMP 1
+#define DEBUG_MASTERPOINTERS
 #else
 #define GAP_ASSERT(x)
 #endif

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -914,6 +914,10 @@ Bag NextBagRestoring( UInt type, UInt flags, UInt size )
   header->flags = flags;
   header->size = size;
   header->link = NextMptrRestoring;
+#if SIZEOF_VOID_P == 4
+  header->reserved = 0;
+#endif
+
   NextMptrRestoring++;
 
   if ((Bag *)NextMptrRestoring >= MptrEndBags)
@@ -1267,6 +1271,9 @@ Bag NewBag (
     header->type = type;
     header->flags = 0;
     header->size = size;
+#if SIZEOF_VOID_P == 4
+    header->reserved = 0;
+#endif
 
     /* enter link word                                                     */
     header->link = bag;
@@ -1411,6 +1418,9 @@ UInt ResizeBag (
     UInt type     = header->type;
     UInt flags    = header->flags;
     UInt old_size = header->size;
+#if SIZEOF_VOID_P == 4
+    GAP_ASSERT(header->reserved == 0);
+#endif
 
 #ifdef COUNT_BAGS
     /* update the statistics                                               */
@@ -1446,6 +1456,9 @@ UInt ResizeBag (
         }
 
         header->size = new_size;
+#if SIZEOF_VOID_P == 4
+        GAP_ASSERT(header->reserved == 0);
+#endif
     }
 
     // if the last bag is enlarged ...
@@ -1474,6 +1487,9 @@ UInt ResizeBag (
         ADD_CANARY();
 
         header->size = new_size;
+#if SIZEOF_VOID_P == 4
+        GAP_ASSERT(header->reserved == 0);
+#endif
     }
 
     // if the bag is enlarged ...
@@ -1493,6 +1509,9 @@ UInt ResizeBag (
         header->type = 255;
         header->flags = 0;
         header->size = sizeof(BagHeader) + (WORDS_BAG(old_size) - 1) * sizeof(Bag);
+#if SIZEOF_VOID_P == 4
+        GAP_ASSERT(header->reserved == 0);
+#endif
 
         /* allocate the storage for the bag                                */
         BagHeader * newHeader = (BagHeader *)AllocBags;
@@ -1502,6 +1521,10 @@ UInt ResizeBag (
         newHeader->type = type;
         newHeader->flags = flags;
         newHeader->size = new_size;
+#if SIZEOF_VOID_P == 4
+        GAP_ASSERT(newHeader->reserved == 0);
+#endif
+
 
 #ifdef COUNT_BAGS
         InfoBags[type].sizeAll  += new_size;

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1951,7 +1951,12 @@ again:
         // extract the head from the linked list
         first = MarkedBags;
         MarkedBags = LINK_BAG(first);
-        LINK_BAG(first) = MARKED_ALIVE(first);
+        if (CONST_PTR_BAG(first) > YoungBags) {
+            LINK_BAG(first) = MARKED_ALIVE(first);
+        }
+        else {
+            LINK_BAG(first) = first;
+        }
 
         // mark subbags
         (*TabMarkFuncBags[TNUM_BAG(first)])( first );
@@ -2323,6 +2328,10 @@ void CheckMasterPointers( void )
         // otherwise, error out
         if (!IS_BAG_BODY(*ptr))
             Panic("Bad master pointer detected");
+
+        if (GET_MARK_BITS(LINK_BAG(bag))) {
+            Panic("Master pointer with Mark bits detected");
+        }
 
         // sanity check: the link pointer must either point back; or else
         // this bag must be part of the chain of changed bags (which thus

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -2000,7 +2000,7 @@ again:
         else if (GET_MARK_BITS(header->link) == DEAD) {
 #ifdef DEBUG_MASTERPOINTERS
             if (CONST_PTR_BAG(UNMARKED_DEAD(header->link)) != DATA(header)) {
-                Panic("incorrectly marked bag");
+                Panic("incorrectly marked DEAD bag");
             }
 #endif
 
@@ -2033,7 +2033,7 @@ again:
         else if (GET_MARK_BITS(header->link) == HALFDEAD) {
 #ifdef DEBUG_MASTERPOINTERS
             if (CONST_PTR_BAG(UNMARKED_HALFDEAD(header->link)) != DATA(header)) {
-                Panic("incorrectly marked bag");
+                Panic("incorrectly marked HALFDEAD bag");
             }
 #endif
 
@@ -2063,7 +2063,7 @@ again:
         else if (GET_MARK_BITS(header->link) == ALIVE) {
 #ifdef DEBUG_MASTERPOINTERS
             if (CONST_PTR_BAG(UNMARKED_ALIVE(header->link)) != DATA(header)) {
-                Panic("incorrectly marked bag");
+                Panic("incorrectly marked ALIVE bag");
             }
 #endif
 

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1951,6 +1951,13 @@ again:
         // extract the head from the linked list
         first = MarkedBags;
         MarkedBags = LINK_BAG(first);
+        // Gasman in some places treats as bag where
+        // CONST_PTR_BAG(bag) == YoungBags as a young bag, and in other
+        // places as an old bag. However, this is not a problem because
+        // it is not possible for such a bag to exist. Sanity check
+        // this condition.
+        GAP_ASSERT(CONST_PTR_BAG(first) != YoungBags);
+
         if (CONST_PTR_BAG(first) > YoungBags) {
             LINK_BAG(first) = MARKED_ALIVE(first);
         }

--- a/src/trans.c
+++ b/src/trans.c
@@ -3139,9 +3139,10 @@ Obj FuncCYCLES_TRANS(Obj self, Obj f)
         return out;
     }
 
-    seen = ResizeInitTmpTrans(deg);
     out = NEW_PLIST(T_PLIST, 0);
     nr = 0;
+
+    seen = ResizeInitTmpTrans(deg);
 
     if (TNUM_OBJ(f) == T_TRANS2) {
         ptf2 = CONST_ADDR_TRANS2(f);

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -2592,14 +2592,14 @@ UInt CosetLeadersInner8Bits( Obj veclis,
                 return found;
         }
 
-        settab = SETELT_FIELDINFO_8BIT(info);
-        feltffe = FELT_FFE_FIELDINFO_8BIT(info);
         vp = ELM_PLIST(veclis, pos);
         for (i = 1; i < q; i++) {
             u = ELM_PLIST(vp, i);
             AddVec8BitVec8BitInner(w, w, u, 1, lenw);
             ptr = BYTES_VEC8BIT(v) + (pos - 1) / elts;
             x = ELM_PLIST(felts, i + 1);
+            settab = SETELT_FIELDINFO_8BIT(info);
+            feltffe = FELT_FFE_FIELDINFO_8BIT(info);
             *ptr = settab[*ptr + 256 * (elts * feltffe[VAL_FFE(x)] + ((pos - 1) % elts))];
             found += CosetLeadersInner8Bits(veclis, v, w, weight - 1, pos + 1, leaders, tofind - found, felts);
             if (found == tofind)


### PR DESCRIPTION
This PR adds some existing gasman checks to --enable-debug.

In the process, I found most of the checks were failing. The failures in header->reserved were harmless (we weren't setting it to 0 in some place). The bad issue could, in some circumstances, cause a very hard to reproduce crash (I believe, unless there is some other bug hiding). Either way, both issues should get cleaned up.