### PR TITLE
Start to refactor module state initialization

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -3369,11 +3369,11 @@ static StructInitInfo module = {
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
     .preSave = PreSave,
-    .postRestore = PostRestore
+    .postRestore = PostRestore,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoCode ( void )
 {
-    RegisterModuleState(0, InitModuleState, 0);
     return &module;
 }

--- a/src/code.c
+++ b/src/code.c
@@ -3336,7 +3336,7 @@ static Int PreSave (
   return 0;
 }
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
     STATE(OffsBodyCount) = 0;
 
@@ -3352,6 +3352,9 @@ static void InitModuleState(ModuleStateOffset offset)
     static Stat MainOffsBodyStack[MAX_FUNC_EXPR_NESTING];
     STATE(OffsBodyStack) = MainOffsBodyStack;
 #endif
+
+    // return success
+    return 0;
 }
 
 /****************************************************************************

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -2277,10 +2277,13 @@ static StructInitInfo module = {
     .name = "cyclotom",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
+
+    .moduleStateSize = sizeof(struct CycModuleState),
+    .moduleStateOffsetPtr = &CycStateOffset,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoCyc ( void )
 {
-    CycStateOffset = RegisterModuleState(sizeof(struct CycModuleState), InitModuleState, 0);
     return &module;
 }

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -2255,11 +2255,14 @@ static Int InitLibrary (
 }
 
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
     ResultCyc = 0;
     LastECyc = 0;
     LastNCyc = 0;
+
+    // return success
+    return 0;
 }
 
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1193,10 +1193,13 @@ static StructInitInfo module = {
     .name = "funcs",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
+
+    .moduleStateSize = sizeof(struct FuncsModuleState),
+    .moduleStateOffsetPtr = &FuncsStateOffset,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoFuncs ( void )
 {
-    FuncsStateOffset = RegisterModuleState(sizeof(struct FuncsModuleState), InitModuleState, 0);
     return &module;
 }

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1173,10 +1173,13 @@ static Int InitKernel (
     return 0;
 }
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
     FuncsState()->ExecState = 0;
     FuncsState()->RecursionDepth = 0;
+
+    // return success
+    return 0;
 }
 
 /****************************************************************************

--- a/src/gapstate.c
+++ b/src/gapstate.c
@@ -63,7 +63,7 @@ void RunModuleConstructors(GAPState *state)
     for (i = 0; i < StateDescriptorCount; i++) {
         StateDescriptor * handler = StateDescriptors + i;
         if (handler->constructor)
-            handler->constructor(handler->offset);
+            handler->constructor();
     }
 }
 

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -155,8 +155,8 @@ static inline GAPState * ActiveGAPState(void)
 
 // Offset into StateSlots
 typedef Int ModuleStateOffset;
-typedef void (*ModuleConstructor)(ModuleStateOffset offset);
-typedef void (*ModuleDestructor)();
+typedef Int (*ModuleConstructor)(void);
+typedef Int (*ModuleDestructor)(void);
 
 static inline void *StateSlotsAtOffset(ModuleStateOffset offset)
 {

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1778,11 +1778,11 @@ static StructInitInfo module = {
     .checkInit = CheckInit,
     .preSave = PreSave,
     .postSave = PostSave,
-    .postRestore = PostRestore
+    .postRestore = PostRestore,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoGVars ( void )
 {
-    RegisterModuleState(0, InitModuleState, 0);
     return &module;
 }

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1753,11 +1753,14 @@ static Int CheckInit (
 }
 
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
     /* Create the current namespace: */
     STATE(CurrNamespace) = NEW_STRING(0);
     SET_LEN_STRING(STATE(CurrNamespace), 0);
+
+    // return success
+    return 0;
 }
 
 

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -1558,12 +1558,13 @@ void UnbAList(Obj list, Int pos)
   HashUnlockShared(list);
 }
 
-void InitAObjectsState(ModuleStateOffset offset)
+Int InitAObjectsState(void)
 {
     TLS(tlRecords) = (Obj)0;
+    return 0;
 }
 
-void DestroyAObjectsState(void)
+Int DestroyAObjectsState(void)
 {
     Obj  records;
     UInt i, len;
@@ -1573,6 +1574,7 @@ void DestroyAObjectsState(void)
         for (i = 1; i <= len; i++)
             UpdateThreadRecord(ELM_PLIST(records, i), (Obj)0);
     }
+    return 0;
 }
 
 #endif /* WARD_ENABLED */

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -2075,10 +2075,11 @@ static StructInitInfo module = {
     .name = "aobjects",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
+    .initModuleState = InitAObjectsState,
+    .destroyModuleState = DestroyAObjectsState,
 };
 
 StructInitInfo * InitInfoAObjects ( void )
 {
-    RegisterModuleState(0, InitAObjectsState, DestroyAObjectsState);
     return &module;
 }

--- a/src/hpc/aobjects.h
+++ b/src/hpc/aobjects.h
@@ -30,9 +30,6 @@ Obj ElmAList(Obj list, Int pos);
 Obj Elm0AList(Obj list, Int pos);
 Obj LengthAList(Obj list);
 
-void InitAObjectsState();
-void DestroyAObjectsState();
-
 
 /*****************************************************************************
 **

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -1201,12 +1201,13 @@ static StructInitInfo module = {
     .name = "serialize",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
+
+    .moduleStateSize = sizeof(SerializeModuleState),
+    .moduleStateOffsetPtr = &SerializeStateOffset,
 };
 
 StructInitInfo * InitInfoSerialize(void)
 {
-    SerializeStateOffset =
-        RegisterModuleState(sizeof(SerializeModuleState), 0, 0);
     return &module;
 }
 

--- a/src/io.c
+++ b/src/io.c
@@ -2142,10 +2142,12 @@ static StructInitInfo module = {
     .name = "scanner",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
+
+    .moduleStateSize = sizeof(struct IOModuleState),
+    .moduleStateOffsetPtr = &IOStateOffset,
 };
 
 StructInitInfo * InitInfoIO ( void )
 {
-    IOStateOffset = RegisterModuleState(sizeof(struct IOModuleState), 0, 0);
     return &module;
 }

--- a/src/io.c
+++ b/src/io.c
@@ -2131,10 +2131,6 @@ static Int InitKernel (
     return 0;
 }
 
-static void InitModuleState(ModuleStateOffset offset)
-{
-}
-
 /****************************************************************************
 **
 *F  InitInfoIO() . . . . . . . . . . . . . . . . table of init functions
@@ -2150,7 +2146,6 @@ static StructInitInfo module = {
 
 StructInitInfo * InitInfoIO ( void )
 {
-    IOStateOffset =
-        RegisterModuleState(sizeof(struct IOModuleState), InitModuleState, 0);
+    IOStateOffset = RegisterModuleState(sizeof(struct IOModuleState), 0, 0);
     return &module;
 }

--- a/src/modules.c
+++ b/src/modules.c
@@ -869,6 +869,16 @@ void ModulesSetup(void)
             FPUTS_TO_STDERR(info->name);
             FPUTS_TO_STDERR(")\n");
         }
+
+        // register module state if necessary
+        if (info->moduleStateSize || info->initModuleState ||
+            info->destroyModuleState) {
+            UInt offset = RegisterModuleState(info->moduleStateSize,
+                                              info->initModuleState,
+                                              info->destroyModuleState);
+            if (info->moduleStateOffsetPtr)
+                *info->moduleStateOffsetPtr = offset;
+        }
     }
     NrBuiltinModules = NrModules;
 }

--- a/src/modules.h
+++ b/src/modules.h
@@ -40,7 +40,7 @@
 **
 */
 
-#define GAP_KERNEL_MAJOR_VERSION 2
+#define GAP_KERNEL_MAJOR_VERSION 3
 #define GAP_KERNEL_MINOR_VERSION 0
 #define GAP_KERNEL_API_VERSION                                               \
     ((GAP_KERNEL_MAJOR_VERSION)*1000 + (GAP_KERNEL_MINOR_VERSION))
@@ -113,6 +113,19 @@ struct init_info {
 
     /* function to call after restoring workspace                          */
     Int (*postRestore)(StructInitInfo *);
+
+    // number of bytes this module needs for its per-thread module state
+    UInt moduleStateSize;
+
+    // if this is not zero, then the module state offset is stored into
+    // the address this points at
+    Int * moduleStateOffsetPtr;
+
+    // initialize thread local module state
+    Int (*initModuleState)(void);
+
+    // destroy thread local module state
+    Int (*destroyModuleState)(void);
 
 };
 

--- a/src/objcftl.c
+++ b/src/objcftl.c
@@ -445,11 +445,14 @@ static StructInitInfo module = {
     .name = "objcftl",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
-    .postRestore = PostRestore
+    .postRestore = PostRestore,
+
+    .moduleStateSize = sizeof(struct CFTLModuleState),
+    .moduleStateOffsetPtr = &CFTLStateOffset,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoPcc ( void )
 {
-    CFTLStateOffset = RegisterModuleState(sizeof(struct CFTLModuleState), InitModuleState, 0);
     return &module;
 }

--- a/src/objcftl.c
+++ b/src/objcftl.c
@@ -418,7 +418,7 @@ static Int InitLibrary (
     return 0;
 }
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
     InitGlobalBag( &CFTLState()->WORD_STACK, "WORD_STACK" );
     InitGlobalBag( &CFTLState()->WORD_EXPONENT_STACK, "WORD_EXPONENT_STACK" );
@@ -429,6 +429,9 @@ static void InitModuleState(ModuleStateOffset offset)
     CFTLState()->WORD_EXPONENT_STACK = NEW_PLIST( T_PLIST, 4096 );
     CFTLState()->SYLLABLE_STACK = NEW_PLIST( T_PLIST, 4096 );
     CFTLState()->EXPONENT_STACK = NEW_PLIST( T_PLIST, 4096 );
+
+    // return success
+    return 0;
 }
 
 /****************************************************************************

--- a/src/objects.c
+++ b/src/objects.c
@@ -2315,10 +2315,12 @@ static StructInitInfo module = {
     .name = "objects",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
+
+    .moduleStateSize = sizeof(ObjectsModuleState),
+    .moduleStateOffsetPtr = &ObjectsStateOffset,
 };
 
 StructInitInfo * InitInfoObjects ( void )
 {
-    ObjectsStateOffset = RegisterModuleState(sizeof(ObjectsModuleState), 0, 0);
     return &module;
 }

--- a/src/objscoll.c
+++ b/src/objscoll.c
@@ -788,7 +788,7 @@ static Int InitLibrary (
     return 0;
 }
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
 #ifndef HPCGAP
     InitGlobalBag( &STATE(SC_NW_STACK), "SC_NW_STACK" );
@@ -817,6 +817,9 @@ static void InitModuleState(ModuleStateOffset offset)
     STATE(SC_CW_VECTOR) = NEW_STRING(0);
     STATE(SC_CW2_VECTOR) = NEW_STRING(0);
     STATE(SC_MAX_STACK_SIZE) = maxStackSize;
+
+    // return success
+    return 0;
 }
 
 /****************************************************************************

--- a/src/objscoll.c
+++ b/src/objscoll.c
@@ -833,10 +833,10 @@ static StructInitInfo module = {
     .name = "objscoll",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoSingleCollector ( void )
 {
-    RegisterModuleState(0, InitModuleState, 0);
     return &module;
 }

--- a/src/opers.c
+++ b/src/opers.c
@@ -4264,11 +4264,11 @@ static StructInitInfo module = {
     .name = "opers",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
-    .postRestore = postRestore
+    .postRestore = postRestore,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoOpers ( void )
 {
-    RegisterModuleState(0, InitModuleState, 0);
     return &module;
 }

--- a/src/opers.c
+++ b/src/opers.c
@@ -4240,7 +4240,7 @@ static Int InitLibrary (
     return 0;
 }
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
 #ifdef HPCGAP
     STATE(MethodCache) = NEW_PLIST(T_PLIST, 1);
@@ -4248,6 +4248,9 @@ static void InitModuleState(ModuleStateOffset offset)
     STATE(MethodCacheSize) = 1;
     SET_LEN_PLIST(STATE(MethodCache), 1);
 #endif
+
+    // return success
+    return 0;
 }
 
 /****************************************************************************

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -4553,10 +4553,13 @@ static Int InitLibrary (
 }
 
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
     /* make the buffer bag                                                 */
     TmpPerm = 0;
+
+    // return success
+    return 0;
 }
 
 

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -4574,10 +4574,13 @@ static StructInitInfo module = {
     .name = "permutat",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
+
+    .moduleStateSize = sizeof(PermutatModuleState),
+    .moduleStateOffsetPtr = &PermutatStateOffset,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoPermutat ( void )
 {
-    PermutatStateOffset = RegisterModuleState(sizeof(PermutatModuleState), InitModuleState, 0);
     return &module;
 }

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -6728,11 +6728,13 @@ static StructInitInfo module = {
     .name = "pperm",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
+
+    .moduleStateSize = sizeof(PPermModuleState),
+    .moduleStateOffsetPtr = &PPermStateOffset,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoPPerm(void)
 {
-    PPermStateOffset =
-        RegisterModuleState(sizeof(PPermModuleState), InitModuleState, 0);
     return &module;
 }

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -6708,9 +6708,12 @@ static Int InitLibrary(StructInitInfo * module)
 }
 
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
     TmpPPerm = 0;
+
+    // return success
+    return 0;
 }
 
 

--- a/src/read.c
+++ b/src/read.c
@@ -2924,7 +2924,7 @@ static Int InitKernel (
 }
 
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
     STATE(ErrorLVars) = (UInt **)0;
     STATE(StackNams) = NEW_PLIST(T_PLIST, 16);
@@ -2932,6 +2932,9 @@ static void InitModuleState(ModuleStateOffset offset)
     STATE(ReadTilde) = 0;
     STATE(CurrLHSGVar) = 0;
     STATE(CurrentGlobalForLoopDepth) = 0;
+
+    // return success
+    return 0;
 }
 
 

--- a/src/read.c
+++ b/src/read.c
@@ -2948,10 +2948,10 @@ static StructInitInfo module = {
     .type = MODULE_BUILTIN,
     .name = "read",
     .initKernel = InitKernel,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoRead ( void )
 {
-    RegisterModuleState(0, InitModuleState, 0);
     return &module;
 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1035,10 +1035,6 @@ static Int InitKernel (
     return 0;
 }
 
-static void InitModuleState(ModuleStateOffset offset)
-{
-}
-
 /****************************************************************************
 **
 *F  InitInfoScanner() . . . . . . . . . . . . . . . . table of init functions
@@ -1054,6 +1050,5 @@ static StructInitInfo module = {
 
 StructInitInfo * InitInfoScanner ( void )
 {
-    RegisterModuleState(0, InitModuleState, 0);
     return &module;
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -1714,7 +1714,7 @@ static Int InitKernel (
     return 0;
 }
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
     STATE(CurrExecStatFuncs) = ExecStatFuncs;
 #ifdef HPCGAP
@@ -1724,6 +1724,9 @@ static void InitModuleState(ModuleStateOffset offset)
         STATE(CurrExecStatFuncs) = IntrExecStatFuncs;
     }
 #endif
+
+    // return success
+    return 0;
 }
 
 /****************************************************************************

--- a/src/stats.c
+++ b/src/stats.c
@@ -1740,10 +1740,10 @@ static StructInitInfo module = {
     .name = "stats",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoStats ( void )
 {
-    RegisterModuleState(0, InitModuleState, 0);
     return &module;
 }

--- a/src/trans.c
+++ b/src/trans.c
@@ -5669,9 +5669,12 @@ static Int InitLibrary(StructInitInfo * module)
     return 0;
 }
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
     TmpTrans = 0;
+
+    // return success
+    return 0;
 }
 
 /****************************************************************************

--- a/src/trans.c
+++ b/src/trans.c
@@ -5688,10 +5688,12 @@ static StructInitInfo module = {
     .name = "trans",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
+    .moduleStateSize = sizeof(TransModuleState),
+    .moduleStateOffsetPtr = &TransStateOffset,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoTrans(void)
 {
-    TransStateOffset = RegisterModuleState(sizeof(TransModuleState), InitModuleState, 0);
     return &module;
 }

--- a/src/vars.c
+++ b/src/vars.c
@@ -2764,7 +2764,7 @@ static Int InitLibrary (
 }
 
 
-static void InitModuleState(ModuleStateOffset offset)
+static Int InitModuleState(void)
 {
     Obj tmpFunc, tmpBody;
 
@@ -2778,6 +2778,9 @@ static void InitModuleState(ModuleStateOffset offset)
     SET_BODY_FUNC( tmpFunc, tmpBody );
 
     STATE(CurrLVars) = STATE(BottomLVars);
+
+    // return success
+    return 0;
 }
 
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -2795,11 +2795,11 @@ static StructInitInfo module = {
     .name = "vars",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
-    .postRestore = PostRestore
+    .postRestore = PostRestore,
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoVars ( void )
 {
-    RegisterModuleState(0, InitModuleState, 0);
     return &module;
 }


### PR DESCRIPTION
This is the first part of PR #2512; the changes in here should be fairly obvious (at least if read commit-by-commit), and have no harmful effect.

Another semi-required part for PR #2512 is PR #2507, simply because it touches some overlapping code; but we can also postpone PR #2507, though then I'll have to rewrite parts of all involved PRs later on.

After this PR is merged, and the fate of PR #2507 is decided, I can rebase PR #2512, and it'll only contain the "difficult" bits of the module state changes (namely, those affecting in which order we call InitLibrary vs. InitModuleState