### PR TITLE
kernel: filter/attribute/property handlers must have 2 args

### DIFF
--- a/src/modules.h
+++ b/src/modules.h
@@ -135,7 +135,7 @@ typedef struct {
     const Char * name;
     const Char * argument;
     Obj *        filter;
-    Obj (*handler)(/*arguments*/);
+    Obj (*handler)(Obj, Obj);
     const Char * cookie;
 } StructGVarFilt;
 
@@ -155,7 +155,7 @@ typedef struct {
     const Char * name;
     const Char * argument;
     Obj *        attribute;
-    Obj (*handler)(/*arguments*/);
+    Obj (*handler)(Obj, Obj);
     const Char * cookie;
 } StructGVarAttr;
 
@@ -168,7 +168,7 @@ typedef struct {
     const Char * name;
     const Char * argument;
     Obj *        property;
-    Obj (*handler)(/*arguments*/);
+    Obj (*handler)(Obj, Obj);
     const Char * cookie;
 } StructGVarProp;
 


### PR DESCRIPTION
This should not affect any currently working code, but it prevents programming
mistakes where one accidentally uses a handler function with a wrong number of
arguments (e.g. forgetting the `self` argument). We sadly can't do this for
other handlers, as they can take a variable number of arguments.