### PR TITLE
Update the doc of the -T command line option

### DIFF
--- a/doc/ref/run.xml
+++ b/doc/ref/run.xml
@@ -380,7 +380,8 @@ option.
 <C>-T</C></Mark>
 <Item>
 suppresses the usual break loop behaviour of  &GAP;.  With  this  option
-&GAP; behaves as if the user <K>quit</K> immediately from every  break  loop.
+&GAP; behaves as if the user <K>quit</K> immediately from every  break  loop,
+and also suppresses displaying any error backtrace.
 This is intended for automated testing of &GAP;. This option may be 
 repeated to toggle this behavior on and off.
 </Item>

--- a/lib/system.g
+++ b/lib/system.g
@@ -94,7 +94,7 @@ BIND_GLOBAL( "GAPInfo", rec(
       rec( short:= "M", default := false, help := ["disable/enable loading of compiled modules"] ),
       rec( short:= "N", default := false, help := ["do not use hidden implications"] ),
       rec( short:= "O", default := false, help := ["disable/enable loading of obsolete files"] ),
-      rec( short:= "T", default := false, help := ["disable/enable break loop"] ),
+      rec( short:= "T", default := false, help := ["disable/enable break loop and error traceback"] ),
       rec( long := "quitonbreak", default := false, help := ["quit GAP with non-zero return value instead of entering break loop"]),
       ,
       rec( short:= "L", default := "", arg := "<file>", help := [ "restore a saved workspace"] ),


### PR DESCRIPTION
It now says that -T disables the break loop and printing tracebacks.

Fixes #2546.