### PR TITLE
New command line option --alwaystrace

### DIFF
--- a/hpcgap/lib/hpc/stdtasks.g
+++ b/hpcgap/lib/hpc/stdtasks.g
@@ -18,7 +18,7 @@ TASKS := AtomicRecord( rec (
   WorkerThread := function(context)
     local task;
     BreakOnError := false;
-    SilentErrors := true;
+    SilentNonInteractiveErrors := true;
     WaitSemaphore(context.semaphore);
     while true do
       WaitSemaphore(context.semaphore);

--- a/lib/error.g
+++ b/lib/error.g
@@ -117,7 +117,7 @@ BIND_GLOBAL("ErrorInner",
             printEarlyMessage, printEarlyTraceback, lastErrorStream,
             shellOut, shellIn;
 
-	context := arg[1].context;
+    context := arg[1].context;
     if not IsLVarsBag(context) then
         PrintTo("*errout*", "ErrorInner:   option context must be a local variables bag\n");
         LEAVE_ALL_NAMESPACES();
@@ -271,10 +271,8 @@ BIND_GLOBAL("ErrorInner",
     if SHOULD_QUIT_ON_BREAK() then
         # Again, the default is to not print the rest of the traceback.
         # If AlwaysPrintTracebackOnError is true we do so anyways.
-        if
-            AlwaysPrintTracebackOnError
-            and IsBound(OnBreak) and IsFunction(OnBreak)
-        then
+        if AlwaysPrintTracebackOnError
+            and IsBound(OnBreak) and IsFunction(OnBreak) then
             OnBreak();
         fi;
         FORCE_QUIT_GAP(1);
@@ -317,10 +315,10 @@ BIND_GLOBAL("ErrorInner",
         if IsBound(OnQuit) and IsFunction(OnQuit) then
             OnQuit();
         fi;
-	if ErrorLevel = 0 then LEAVE_ALL_NAMESPACES(); fi;
+        if ErrorLevel = 0 then LEAVE_ALL_NAMESPACES(); fi;
         if not justQuit then
-	   # dont try and do anything else after this before the longjump 	
-            SetUserHasQuit(1);	
+           # dont try and do anything else after this before the longjump
+            SetUserHasQuit(1);
         fi;
         JUMP_TO_CATCH(3);
     fi;

--- a/lib/init.g
+++ b/lib/init.g
@@ -247,8 +247,13 @@ CallAndInstallPostRestore( function()
     UNBIND_GLOBAL( "DEBUG_LOADING" );
 
     if IsHPCGAP then
+      # In HPC-GAP we want to decide how to handle errors on a per thread
+      # basis. E.g. the break loop can be disabled in a worker thread that
+      # runs tasks.
       BindThreadLocal( "BreakOnError", not GAPInfo.CommandLineOptions.T );
       BindThreadLocal( "SilentNonInteractiveErrors", false );
+      # We store the error messages on a per thread basis to be able to
+      # e.g. access them independently from the main thread.
       BindThreadLocal( "LastErrorMessage", "" );
     else
       ASS_GVAR( "BreakOnError", not GAPInfo.CommandLineOptions.T );

--- a/lib/init.g
+++ b/lib/init.g
@@ -248,11 +248,11 @@ CallAndInstallPostRestore( function()
 
     if IsHPCGAP then
       BindThreadLocal( "BreakOnError", not GAPInfo.CommandLineOptions.T );
-      BindThreadLocal( "SilentErrors", false );
+      BindThreadLocal( "SilentNonInteractiveErrors", false );
       BindThreadLocal( "LastErrorMessage", "" );
     else
       ASS_GVAR( "BreakOnError", not GAPInfo.CommandLineOptions.T );
-      ASS_GVAR( "SilentErrors", false );
+      ASS_GVAR( "SilentNonInteractiveErrors", false );
     fi;
 end);
 

--- a/lib/init.g
+++ b/lib/init.g
@@ -236,6 +236,8 @@ fi;
 ##
 ##  - Unbind `DEBUG_LOADING', since later the `-D' option can be checked.
 ##  - Set or disable break loop according to the `-T' option.
+##  - Set whether traceback may be suppressed (e.g. by `-T') according to the
+##    `--alwaystrace' option.
 ##
 CallAndInstallPostRestore( function()
     if DEBUG_LOADING then
@@ -251,12 +253,17 @@ CallAndInstallPostRestore( function()
       # basis. E.g. the break loop can be disabled in a worker thread that
       # runs tasks.
       BindThreadLocal( "BreakOnError", not GAPInfo.CommandLineOptions.T );
+      BindThreadLocal(
+        "AlwaysPrintTracebackOnError",
+        GAPInfo.CommandLineOptions.alwaystrace
+      );
       BindThreadLocal( "SilentNonInteractiveErrors", false );
       # We store the error messages on a per thread basis to be able to
       # e.g. access them independently from the main thread.
       BindThreadLocal( "LastErrorMessage", "" );
     else
       ASS_GVAR( "BreakOnError", not GAPInfo.CommandLineOptions.T );
+      ASS_GVAR( "AlwaysPrintTracebackOnError", GAPInfo.CommandLineOptions.alwaystrace );
       ASS_GVAR( "SilentNonInteractiveErrors", false );
     fi;
 end);

--- a/lib/system.g
+++ b/lib/system.g
@@ -94,7 +94,7 @@ BIND_GLOBAL( "GAPInfo", rec(
       rec( short:= "M", default := false, help := ["disable/enable loading of compiled modules"] ),
       rec( short:= "N", default := false, help := ["do not use hidden implications"] ),
       rec( short:= "O", default := false, help := ["disable/enable loading of obsolete files"] ),
-      rec( short:= "T", default := false, help := ["disable/enable break loop and error traceback"] ),
+      rec( short:= "T", long := "nobreakloop", default := false, help := ["disable/enable break loop and error traceback"] ),
       rec( long := "quitonbreak", default := false, help := ["quit GAP with non-zero return value instead of entering break loop"]),
       ,
       rec( short:= "L", default := "", arg := "<file>", help := [ "restore a saved workspace"] ),

--- a/lib/system.g
+++ b/lib/system.g
@@ -95,6 +95,7 @@ BIND_GLOBAL( "GAPInfo", rec(
       rec( short:= "N", default := false, help := ["do not use hidden implications"] ),
       rec( short:= "O", default := false, help := ["disable/enable loading of obsolete files"] ),
       rec( short:= "T", long := "nobreakloop", default := false, help := ["disable/enable break loop and error traceback"] ),
+      rec( long := "alwaystrace", default := false, help := ["always print error traceback (overrides behaviour of -T)"] ),
       rec( long := "quitonbreak", default := false, help := ["quit GAP with non-zero return value instead of entering break loop"]),
       ,
       rec( short:= "L", default := "", arg := "<file>", help := [ "restore a saved workspace"] ),


### PR DESCRIPTION
Also introduces a new global variable `AlwaysPrintTracebackOnError`.

Funtionality and documentation yet to be implemented.