### PR TITLE
Fix typo in checking if a filename is *stderr*

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -737,7 +737,7 @@ static Obj PRINT_OR_APPEND_TO(Obj args, int append)
     i = append ? OpenAppend( CSTR_STRING(filename) )
                : OpenOutput( CSTR_STRING(filename) );
     if ( ! i ) {
-        if (strcmp(CSTR_STRING(filename), "*errout*")) {
+        if (strcmp(CSTR_STRING(filename), "*errout*") == 0) {
             // When trying to print an error opening *errout* failed,
             // We exit GAP after trying to print an error.
             // First try printing an error to stderr

--- a/tst/testinstall/streams.tst
+++ b/tst/testinstall/streams.tst
@@ -92,5 +92,15 @@ gap> ReadAllLine(stream, false, line -> 0 < Length(line) and line[Length(line)] 
 gap> ReadAllLine(stream);
 fail
 
+# Invalid files
+gap> PrintTo("/", "out");
+Error, PrintTo: cannot open '/' for output
+gap> OutputTextFile("/", true);
+fail
+
+# Assume this file does not exist
+gap> InputTextFile("/filewhichdoesnotexist/lspdsiodfsjfdsjofdsjkfd/fdsjkfds");
+fail
+
 #
 gap> STOP_TEST( "streams.tst", 1);


### PR DESCRIPTION
This fixes a typo in some code I previously wrote, and adds tests to make sure it works now.