### PR TITLE
Add missing header

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -14,6 +14,7 @@
 #include <src/bool.h>
 #include <src/calls.h>
 #include <src/code.h>
+#include <src/funcs.h>
 #include <src/gap.h>
 #include <src/hookintrprtr.h>
 #include <src/io.h>


### PR DESCRIPTION
Adds a missing header in profile.c. This fixes building the stable-4.9 branch.