### PR TITLE
Make CALL_WITH_CATCH work with Kernel functions

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -249,6 +249,9 @@ Obj FuncCALL_WITH_CATCH(Obj self, Obj func, volatile Obj args)
     }
     else {
         Obj result = CallFuncList(func, args);
+        // Make an explicit check if an interrupt occurred
+        // in case func was a kernel function.
+        TakeInterrupt();
 #ifdef HPCGAP
         /* There should be no locks to pop off the stack, but better safe than
          * sorry. */


### PR DESCRIPTION
If CALL_WITH_CATCH is used to call a kernel function and an interrupt
occurs, the function returns without ever checking for interrupts.
Add an explicit check.

This is annoying hard to write a test for, but is (hopefully!) fairly obvious (if you look at what TakeInterrupt does), and is useful for packages like IO and ZeroMQ, which have functions which can enter a wait loop, which we might want to CALL_WITH_CATCH.