### PR TITLE
Fix crash when using OnTuples or OnSets on empty lists

### DIFF
--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1208,7 +1208,7 @@ Obj             FuncOnTuples (
     }
 
     /* special case for the empty list */
-    if ( HAS_FILT_LIST( tuple, FN_IS_EMPTY )) {
+    if (HAS_FILT_LIST(tuple, FN_IS_EMPTY) || LEN_LIST(tuple) == 0) {
       if (IS_MUTABLE_OBJ(tuple)) {
         img = NEW_PLIST(T_PLIST_EMPTY, 0);
         return img;
@@ -1279,7 +1279,7 @@ Obj             FuncOnSets (
     }
 
     /* special case for the empty list */
-    if ( HAS_FILT_LIST( set, FN_IS_EMPTY )) {
+    if (HAS_FILT_LIST(set, FN_IS_EMPTY) || LEN_LIST(set) == 0) {
       if (IS_MUTABLE_OBJ(set)) {
         img = NEW_PLIST(T_PLIST_EMPTY, 0);
         return img;

--- a/tst/testbugfix/2018-06-18-empty-OnTuples.tst
+++ b/tst/testbugfix/2018-06-18-empty-OnTuples.tst
@@ -1,0 +1,18 @@
+#
+# make sure OnTuples works correct even for plists that don't know they
+# are empty
+#
+gap> adj := [[2], [], [2]];;
+gap> new := List([1, 2], i -> []);;
+gap> perm := (2, 1);;
+gap> for i in [1, 2] do
+> new[i ^ perm] := Concatenation(new[i ^ perm], adj[i]);;
+> od;
+gap> List(new, TNAM_OBJ);
+[ "list (plain)", "list (plain)" ]
+gap> List(new, x -> OnTuples(x, perm));
+[ [  ], [ 1 ] ]
+gap> List(new, TNAM_OBJ);
+[ "list (plain)", "list (plain)" ]
+gap> List(new, x -> OnSets(x, perm));
+[ [  ], [ 1 ] ]


### PR DESCRIPTION
... if those empty lists don't yet know that they are empty

Fixes #2561 

Not for release notes, as this works fine in GAP 4.9 and is a relatively recent regression.