### PR TITLE
kernel: get rid of FN_IS_EMPTY

### DIFF
--- a/dev/lists.txt
+++ b/dev/lists.txt
@@ -424,7 +424,6 @@ check if filter <fnum> is known for <list>
 
 filter numbers
 --------------
-FN_IS_EMPTY:            empty list
 FN_IS_SSORT:            strictly sorted
 FN_IS_NSORT:            not strictly sorted
 FN_IS_DENSE:            dense

--- a/src/blister.c
+++ b/src/blister.c
@@ -2045,7 +2045,6 @@ static Int ClearFiltsTab [] = {
 static Int HasFiltTab [] = {
 
     /* mutable boolean list                                                */
-    T_BLIST,                    FN_IS_EMPTY,    0,
     T_BLIST,                    FN_IS_DENSE,    1,
     T_BLIST,                    FN_IS_NDENSE,   0,
     T_BLIST,                    FN_IS_HOMOG,    1,
@@ -2055,7 +2054,6 @@ static Int HasFiltTab [] = {
     T_BLIST,                    FN_IS_NSORT,    0,
 
     /* nsort mutable boolean list                                          */
-    T_BLIST_NSORT,              FN_IS_EMPTY,    0,
     T_BLIST_NSORT,              FN_IS_DENSE,    1,
     T_BLIST_NSORT,              FN_IS_NDENSE,   0,
     T_BLIST_NSORT,              FN_IS_HOMOG,    1,
@@ -2065,7 +2063,6 @@ static Int HasFiltTab [] = {
     T_BLIST_NSORT,              FN_IS_NSORT,    1,
 
     /* ssort mutable boolean list                                          */
-    T_BLIST_SSORT,              FN_IS_EMPTY,    0,
     T_BLIST_SSORT,              FN_IS_DENSE,    1,
     T_BLIST_SSORT,              FN_IS_NDENSE,   0,
     T_BLIST_SSORT,              FN_IS_HOMOG,    1,
@@ -2085,7 +2082,6 @@ static Int HasFiltTab [] = {
 static Int SetFiltTab [] = {
 
     /* mutable boolean list                                                */
-    T_BLIST,                    FN_IS_EMPTY,    T_BLIST_SSORT,
     T_BLIST,                    FN_IS_DENSE,    T_BLIST,
     T_BLIST,                    FN_IS_NDENSE,   -1,
     T_BLIST,                    FN_IS_HOMOG,    T_BLIST,
@@ -2095,7 +2091,6 @@ static Int SetFiltTab [] = {
     T_BLIST,                    FN_IS_NSORT,    T_BLIST_NSORT,
 
     /* nsort mutable boolean list                                          */
-    T_BLIST_NSORT,              FN_IS_EMPTY,    -1,
     T_BLIST_NSORT,              FN_IS_DENSE,    T_BLIST_NSORT,
     T_BLIST_NSORT,              FN_IS_NDENSE,   -1,
     T_BLIST_NSORT,              FN_IS_HOMOG,    T_BLIST_NSORT,
@@ -2105,7 +2100,6 @@ static Int SetFiltTab [] = {
     T_BLIST_NSORT,              FN_IS_NSORT,    T_BLIST_NSORT,
 
     /* ssort mutable boolean list                                          */
-    T_BLIST_SSORT,              FN_IS_EMPTY,    T_BLIST_SSORT,
     T_BLIST_SSORT,              FN_IS_DENSE,    T_BLIST_SSORT,
     T_BLIST_SSORT,              FN_IS_NDENSE,   -1,
     T_BLIST_SSORT,              FN_IS_HOMOG,    T_BLIST_SSORT,
@@ -2126,7 +2120,6 @@ static Int SetFiltTab [] = {
 static Int ResetFiltTab [] = {
 
     /* mutable boolean list                                                */
-    T_BLIST,                    FN_IS_EMPTY,    T_BLIST,
     T_BLIST,                    FN_IS_DENSE,    T_BLIST,
     T_BLIST,                    FN_IS_NDENSE,   T_BLIST,
     T_BLIST,                    FN_IS_HOMOG,    T_BLIST,
@@ -2136,7 +2129,6 @@ static Int ResetFiltTab [] = {
     T_BLIST,                    FN_IS_NSORT,    T_BLIST,
 
     /* nsort mutable boolean list                                          */
-    T_BLIST_NSORT,              FN_IS_EMPTY,    T_BLIST_NSORT,
     T_BLIST_NSORT,              FN_IS_DENSE,    T_BLIST_NSORT,
     T_BLIST_NSORT,              FN_IS_NDENSE,   T_BLIST_NSORT,
     T_BLIST_NSORT,              FN_IS_HOMOG,    T_BLIST_NSORT,
@@ -2146,7 +2138,6 @@ static Int ResetFiltTab [] = {
     T_BLIST_NSORT,              FN_IS_NSORT,    T_BLIST,
 
     /* ssort mutable boolean list                                          */
-    T_BLIST_SSORT,              FN_IS_EMPTY,    T_BLIST_SSORT,
     T_BLIST_SSORT,              FN_IS_DENSE,    T_BLIST_SSORT,
     T_BLIST_SSORT,              FN_IS_NDENSE,   T_BLIST_SSORT,
     T_BLIST_SSORT,              FN_IS_HOMOG,    T_BLIST_SSORT,

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1208,7 +1208,7 @@ Obj             FuncOnTuples (
     }
 
     /* special case for the empty list */
-    if (HAS_FILT_LIST(tuple, FN_IS_EMPTY) || LEN_LIST(tuple) == 0) {
+    if (LEN_LIST(tuple) == 0) {
       if (IS_MUTABLE_OBJ(tuple)) {
         img = NEW_PLIST(T_PLIST_EMPTY, 0);
         return img;
@@ -1279,7 +1279,7 @@ Obj             FuncOnSets (
     }
 
     /* special case for the empty list */
-    if (HAS_FILT_LIST(set, FN_IS_EMPTY) || LEN_LIST(set) == 0) {
+    if (LEN_LIST(set) == 0) {
       if (IS_MUTABLE_OBJ(set)) {
         img = NEW_PLIST(T_PLIST_EMPTY, 0);
         return img;

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -346,6 +346,9 @@ Obj             ZeroListDefault (
 
     /* make the result list -- same mutability as argument */
     len = LEN_LIST( list );
+    if (len == 0) {
+        return NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(list), T_PLIST_EMPTY, 0);
+    }
     res = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(list), T_PLIST, len );
     SET_LEN_PLIST( res, len );
 
@@ -362,9 +365,7 @@ Obj             ZeroListDefault (
       }
     /* Now adjust the result TNUM info */
 
-    if (len == 0)
-      SET_FILT_LIST( res, FN_IS_EMPTY );
-    else if (IS_PLIST( list ))
+    if (IS_PLIST( list ))
       {
         if (TNUM_OBJ(list) == T_PLIST_FFE ||
             TNUM_OBJ(list) == T_PLIST_FFE+IMMUTABLE)
@@ -412,6 +413,9 @@ Obj             ZeroListMutDefault (
 
     /* make the result list -- always mutable */
     len = LEN_LIST( list );
+    if (len == 0) {
+        return NEW_PLIST(T_PLIST_EMPTY, 0);
+    }
     res = NEW_PLIST(  T_PLIST ,len );
     SET_LEN_PLIST( res, len );
 
@@ -428,9 +432,7 @@ Obj             ZeroListMutDefault (
       }
     /* Now adjust the result TNUM info */
 
-    if (len == 0)
-      SET_FILT_LIST( res, FN_IS_EMPTY );
-    else if (IS_PLIST( list ))
+    if (IS_PLIST( list ))
       {
         if (TNUM_OBJ(list) == T_PLIST_FFE ||
             TNUM_OBJ(list) == T_PLIST_FFE+IMMUTABLE)
@@ -513,6 +515,9 @@ Obj AInvMutListDefault (
     /* make the result list -- always mutable, since this might be a method for
        AdditiveInverseOp */
     len = LEN_LIST( list );
+    if (len == 0) {
+        return NEW_PLIST(T_PLIST_EMPTY, 0);
+    }
     res = NEW_PLIST( T_PLIST , len );
     SET_LEN_PLIST( res, len );
 
@@ -528,10 +533,7 @@ Obj AInvMutListDefault (
 
     /* Now adjust the result TNUM info */
 
-    if (len == 0)
-      SET_FILT_LIST( res, FN_IS_EMPTY );
-    else if (IS_PLIST( list ))
-      {
+    if (IS_PLIST(list)) {
         if (TNUM_OBJ(list) == T_PLIST_FFE ||
             TNUM_OBJ(list) == T_PLIST_FFE+IMMUTABLE)
           RetypeBag(res, T_PLIST_FFE);
@@ -572,6 +574,9 @@ Obj AInvListDefault (
 
     /* make the result list -- same mutability as input */
     len = LEN_LIST( list );
+    if (len == 0) {
+        return NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_OBJ(list), T_PLIST_EMPTY, 0);
+    }
     res = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(list), T_PLIST, len );
     SET_LEN_PLIST( res, len );
 
@@ -587,10 +592,7 @@ Obj AInvListDefault (
 
     /* Now adjust the result TNUM info */
 
-    if (len == 0)
-      SET_FILT_LIST( res, FN_IS_EMPTY );
-    else if (IS_PLIST( list ))
-      {
+    if (IS_PLIST(list)) {
         if (TNUM_OBJ(list) == T_PLIST_FFE ||
             TNUM_OBJ(list) == T_PLIST_FFE+IMMUTABLE)
           RetypeBag(res, TNUM_OBJ(list));
@@ -660,11 +662,15 @@ Obj             DiffSclList (
     Obj                 elmR;           /* one element of right operand    */
     Int                 len;            /* length                          */
     Int                 i;              /* loop variable                   */
+    Int                 mut;
 
     /* make the result list                                                */
     len = LEN_LIST( listR );
-    listD = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR),
-                           T_PLIST, len );
+    mut = IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR);
+    if (len == 0) {
+        return NEW_PLIST_WITH_MUTABILITY(mut, T_PLIST_EMPTY, 0);
+    }
+    listD = NEW_PLIST_WITH_MUTABILITY(mut, T_PLIST, len);
     SET_LEN_PLIST( listD, len );
 
     /* loop over the entries and subtract                                  */
@@ -680,9 +686,7 @@ Obj             DiffSclList (
 
     /* Now adjust the result TNUM info */
 
-    if (len == 0)
-      SET_FILT_LIST( listD, FN_IS_EMPTY );
-    else if (IS_PLIST( listR ))
+    if (IS_PLIST( listR ))
       {
          if (HAS_FILT_LIST(listR, FN_IS_DENSE))
            SET_FILT_LIST( listD, FN_IS_DENSE );
@@ -702,11 +706,15 @@ Obj             DiffListScl (
     Obj                 elmL;           /* one element of left operand     */
     Int                 len;            /* length                          */
     Int                 i;              /* loop variable                   */
+    Int                 mut;
 
     /* make the result list                                                */
     len = LEN_LIST( listL );
-    listD = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listL)|| IS_MUTABLE_OBJ(listR),
-                           T_PLIST, len );
+    mut = IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR);
+    if (len == 0) {
+        return NEW_PLIST_WITH_MUTABILITY(mut, T_PLIST_EMPTY, 0);
+    }
+    listD = NEW_PLIST_WITH_MUTABILITY(mut, T_PLIST, len);
     SET_LEN_PLIST( listD, len );
 
     /* loop over the entries and subtract                                  */
@@ -723,9 +731,7 @@ Obj             DiffListScl (
 
     /* Now adjust the result TNUM info */
 
-    if (len == 0)
-      SET_FILT_LIST( listD, FN_IS_EMPTY );
-    else if (IS_PLIST( listL ))
+    if (IS_PLIST( listL ))
       {
          if (HAS_FILT_LIST(listL, FN_IS_DENSE))
            SET_FILT_LIST( listD, FN_IS_DENSE );
@@ -744,16 +750,19 @@ Obj             DiffListList (
     Obj                 elmD;           /* one element of the difference   */
     Obj                 elmL;           /* one element of the left list    */
     Obj                 elmR;           /* one element of the right list   */
-    Int                 lenL,lenR,lenD; /* length                          */
     Int                 i;              /* loop variable                   */
     UInt                mutD;
+    Int                 mut;
 
     /* get and check the length                                            */
-    lenL = LEN_LIST( listL );
-    lenR = LEN_LIST( listR );
-    lenD = (lenR > lenL) ? lenR : lenL;
-    listD = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR),
-                           T_PLIST, lenD );
+    const UInt lenL = LEN_LIST(listL);
+    const UInt lenR = LEN_LIST(listR);
+    const UInt lenD = (lenR > lenL) ? lenR : lenL;
+    mut = IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR);
+    if (lenD == 0) {
+        return NEW_PLIST_WITH_MUTABILITY(mut, T_PLIST_EMPTY, 0);
+    }
+    listD = NEW_PLIST_WITH_MUTABILITY(mut, T_PLIST, lenD);
     SET_LEN_PLIST( listD, lenD );
 
     /* Sort out mutability */
@@ -807,9 +816,7 @@ Obj             DiffListList (
     /* Now adjust the result TNUM info. There's not so much we
        can say here with total reliability */
 
-    if (lenD == 0)
-      SET_FILT_LIST( listD, FN_IS_EMPTY );
-    else if (IS_PLIST( listR ) && IS_PLIST(listL) &&
+    if (IS_PLIST( listR ) && IS_PLIST(listL) &&
              HAS_FILT_LIST(listR, FN_IS_DENSE) &&
              HAS_FILT_LIST(listL, FN_IS_DENSE))
       SET_FILT_LIST( listD, FN_IS_DENSE );
@@ -881,11 +888,15 @@ Obj             ProdSclList (
     Obj                 elmR;           /* one element of right operand    */
     Int                 len;            /* length                          */
     Int                 i;              /* loop variable                   */
+    Int                 mut;
 
     /* make the result list                                                */
     len = LEN_LIST( listR );
-    listP = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR),
-                           T_PLIST, len );
+    mut = IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR);
+    if (len == 0) {
+        return NEW_PLIST_WITH_MUTABILITY(mut, T_PLIST_EMPTY, 0);
+    }
+    listP = NEW_PLIST_WITH_MUTABILITY(mut, T_PLIST, len);
     SET_LEN_PLIST( listP, len );
 
     /* loop over the entries and multiply                                  */
@@ -898,9 +909,7 @@ Obj             ProdSclList (
             CHANGED_BAG( listP );
           }
     }
-    if (len == 0)
-      SET_FILT_LIST( listP, FN_IS_EMPTY );
-    else if (IS_PLIST( listR ))
+    if (IS_PLIST( listR ))
       {
          if (HAS_FILT_LIST(listR, FN_IS_DENSE))
            SET_FILT_LIST( listP, FN_IS_DENSE );
@@ -921,11 +930,15 @@ Obj             ProdListScl (
     Obj                 elmL;           /* one element of left operand     */
     Int                 len;            /* length                          */
     Int                 i;              /* loop variable                   */
+    Int                 mut;
 
     /* make the result list                                                */
     len = LEN_LIST( listL );
-    listP = NEW_PLIST_WITH_MUTABILITY( IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR),
-                           T_PLIST, len );
+    mut = IS_MUTABLE_OBJ(listL) || IS_MUTABLE_OBJ(listR);
+    if (len == 0) {
+        return NEW_PLIST_WITH_MUTABILITY(mut, T_PLIST_EMPTY, 0);
+    }
+    listP = NEW_PLIST_WITH_MUTABILITY(mut, T_PLIST, len);
     SET_LEN_PLIST( listP, len );
 
     /* loop over the entries and multiply                                  */
@@ -938,9 +951,7 @@ Obj             ProdListScl (
         }
     }
 
-    if (len == 0)
-      SET_FILT_LIST( listP, FN_IS_EMPTY );
-    else if (IS_PLIST( listL ))
+    if (IS_PLIST( listL ))
       {
          if (HAS_FILT_LIST(listL, FN_IS_DENSE))
            SET_FILT_LIST( listP, FN_IS_DENSE );

--- a/src/lists.c
+++ b/src/lists.c
@@ -2595,12 +2595,14 @@ static Int CheckInit (
     Int         j;              /* loop variable                           */
     Int         success = 1;
 
-    Int         fnums[] = { FN_IS_EMPTY, FN_IS_DENSE,
-                            FN_IS_NDENSE, FN_IS_HOMOG, FN_IS_NHOMOG,
-                            FN_IS_TABLE, FN_IS_SSORT, FN_IS_NSORT };
-    const Char *fnams[] = { "empty", "dense", "ndense",
-                            "homog", "nhomog", "table", "ssort",
-                            "nsort" };
+    Int         fnums[] = { FN_IS_DENSE, FN_IS_NDENSE,
+                            FN_IS_HOMOG, FN_IS_NHOMOG,
+                            FN_IS_TABLE,
+                            FN_IS_SSORT, FN_IS_NSORT };
+    const Char *fnams[] = { "dense", "ndense",
+                            "homog", "nhomog",
+                            "table",
+                            "ssort", "nsort" };
 
 
     /* fix unknown list types                                              */
@@ -2730,7 +2732,7 @@ static Int CheckInit (
             }
         }
 
-        if ( HasFiltListTNums[i][FN_IS_EMPTY] ) {
+        if ( i == T_PLIST_EMPTY || i == T_PLIST_EMPTY+IMMUTABLE ) {
             if ( ! HasFiltListTNums[i][FN_IS_DENSE] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ empty -> dense ] missing\n",

--- a/src/lists.h
+++ b/src/lists.h
@@ -817,9 +817,6 @@ extern  Obj             TYPES_LIST_FAM (
 */
 
 enum {
-    /** filter number for 'IsEmpty' */
-    FN_IS_EMPTY,
-
     /** filter number for 'IsSSortedList' */
     FN_IS_SSORT,
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -247,8 +247,8 @@ Int KTNumPlist (
 
     /* special case for empty list                                         */
     if ( lenList == 0 ) {
-        SET_FILT_LIST( list, FN_IS_EMPTY );
-        res = TNUM_OBJ(list);
+        res = IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE;
+        RetypeBagIfWritable(list, res);
 	if (famfirst != (Obj *) 0)
 	  *famfirst = (Obj) 0;
         return res;
@@ -1607,8 +1607,8 @@ void UnbPlist (
         SET_ELM_PLIST( list, pos, 0 );
         while ( 1 <= pos && ELM_PLIST( list, pos ) == 0 ) { pos--; }
         SET_LEN_PLIST( list, pos );
-	if (LEN_PLIST( list) == 0)
-	  SET_FILT_LIST(list, FN_IS_EMPTY);
+        if (LEN_PLIST(list) == 0)
+            RetypeBagIfWritable(list, T_PLIST_EMPTY);
     }
 }
 
@@ -2080,7 +2080,7 @@ Int             IsDensePlist (
 
     /* special case for empty list                                         */
     if ( lenList == 0 ) {
-        SET_FILT_LIST( list, FN_IS_EMPTY );
+        RetypeBagIfWritable(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
         return 1L;
     }
 
@@ -2161,7 +2161,7 @@ Int             IsSSortPlist (
 
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
-        SET_FILT_LIST( list, FN_IS_EMPTY );
+        RetypeBagIfWritable(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
         return 2L;
     }
 
@@ -2248,7 +2248,7 @@ Int             IsSSortPlistDense (
 
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
-        SET_FILT_LIST( list, FN_IS_EMPTY );
+        RetypeBagIfWritable(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
         return 2L;
     }
 
@@ -2316,7 +2316,7 @@ Int             IsSSortPlistHom (
 
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
-        SET_FILT_LIST( list, FN_IS_EMPTY );
+        RetypeBagIfWritable(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
         return 2L;
     }
 
@@ -2895,7 +2895,6 @@ static Int ClearFiltsTab [] = {
 static Int HasFiltTab [] = {
 
     // plain lists
-    T_PLIST,                      FN_IS_EMPTY,    0,
     T_PLIST,                      FN_IS_DENSE,    0,
     T_PLIST,                      FN_IS_NDENSE,   0,
     T_PLIST,                      FN_IS_HOMOG,    0,
@@ -2906,7 +2905,6 @@ static Int HasFiltTab [] = {
     T_PLIST,                      FN_IS_NSORT,    0,
 
     // empty list
-    T_PLIST_EMPTY,                FN_IS_EMPTY,    1,
     T_PLIST_EMPTY,                FN_IS_DENSE,    1,
     T_PLIST_EMPTY,                FN_IS_NDENSE,   0,
     T_PLIST_EMPTY,                FN_IS_HOMOG,    1,
@@ -2917,7 +2915,6 @@ static Int HasFiltTab [] = {
     T_PLIST_EMPTY,                FN_IS_NSORT,    0,
 
     // dense list
-    T_PLIST_DENSE,                FN_IS_EMPTY,    0,
     T_PLIST_DENSE,                FN_IS_DENSE,    1,
     T_PLIST_DENSE,                FN_IS_NDENSE,   0,
     T_PLIST_DENSE,                FN_IS_HOMOG,    0,
@@ -2928,7 +2925,6 @@ static Int HasFiltTab [] = {
     T_PLIST_DENSE,                FN_IS_NSORT,    0,
 
     // dense list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM,           FN_IS_EMPTY,    0,
     T_PLIST_DENSE_NHOM,           FN_IS_DENSE,    1,
     T_PLIST_DENSE_NHOM,           FN_IS_NDENSE,   0,
     T_PLIST_DENSE_NHOM,           FN_IS_HOMOG,    0,
@@ -2939,7 +2935,6 @@ static Int HasFiltTab [] = {
     T_PLIST_DENSE_NHOM,           FN_IS_NSORT,    0,
 
     // dense ssorted list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM_SSORT,      FN_IS_EMPTY,    0,
     T_PLIST_DENSE_NHOM_SSORT,      FN_IS_DENSE,    1,
     T_PLIST_DENSE_NHOM_SSORT,      FN_IS_NDENSE,   0,
     T_PLIST_DENSE_NHOM_SSORT,      FN_IS_HOMOG,    0,
@@ -2950,7 +2945,6 @@ static Int HasFiltTab [] = {
     T_PLIST_DENSE_NHOM_SSORT,      FN_IS_NSORT,    0,
 
     // dense nsorted list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM_NSORT,           FN_IS_EMPTY,    0,
     T_PLIST_DENSE_NHOM_NSORT,           FN_IS_DENSE,    1,
     T_PLIST_DENSE_NHOM_NSORT,           FN_IS_NDENSE,   0,
     T_PLIST_DENSE_NHOM_NSORT,           FN_IS_HOMOG,    0,
@@ -2961,7 +2955,6 @@ static Int HasFiltTab [] = {
     T_PLIST_DENSE_NHOM_NSORT,           FN_IS_NSORT,    1,
 
     // a mutable list with holes
-    T_PLIST_NDENSE,               FN_IS_EMPTY,    0,
     T_PLIST_NDENSE,               FN_IS_DENSE,    0,
     T_PLIST_NDENSE,               FN_IS_NDENSE,   1,
     T_PLIST_NDENSE,               FN_IS_HOMOG,    0,
@@ -2972,7 +2965,6 @@ static Int HasFiltTab [] = {
     T_PLIST_NDENSE,               FN_IS_NSORT,    0,
 
     // dense list, which conts imms, is homogeneous, not a table
-    T_PLIST_HOM,                  FN_IS_EMPTY,    0,
     T_PLIST_HOM,                  FN_IS_DENSE,    1,
     T_PLIST_HOM,                  FN_IS_NDENSE,   0,
     T_PLIST_HOM,                  FN_IS_HOMOG,    1,
@@ -2983,7 +2975,6 @@ static Int HasFiltTab [] = {
     T_PLIST_HOM,                  FN_IS_NSORT,    0,
 
     // ssort dense list, which conts imms, is homog, not a table
-    T_PLIST_HOM_SSORT,            FN_IS_EMPTY,    0,
     T_PLIST_HOM_SSORT,            FN_IS_DENSE,    1,
     T_PLIST_HOM_SSORT,            FN_IS_NDENSE,   0,
     T_PLIST_HOM_SSORT,            FN_IS_HOMOG,    1,
@@ -2994,7 +2985,6 @@ static Int HasFiltTab [] = {
     T_PLIST_HOM_SSORT,            FN_IS_NSORT,    0,
 
     // nsort dense list, which conts imms, is homog, not a table
-    T_PLIST_HOM_NSORT,            FN_IS_EMPTY,    0,
     T_PLIST_HOM_NSORT,            FN_IS_DENSE,    1,
     T_PLIST_HOM_NSORT,            FN_IS_NDENSE,   0,
     T_PLIST_HOM_NSORT,            FN_IS_HOMOG,    1,
@@ -3005,7 +2995,6 @@ static Int HasFiltTab [] = {
     T_PLIST_HOM_NSORT,            FN_IS_NSORT,    1,
 
     // dense list, which is immutable, homog, non-empty, table
-    T_PLIST_TAB,                  FN_IS_EMPTY,    0,
     T_PLIST_TAB,                  FN_IS_DENSE,    1,
     T_PLIST_TAB,                  FN_IS_NDENSE,   0,
     T_PLIST_TAB,                  FN_IS_HOMOG,    1,
@@ -3016,7 +3005,6 @@ static Int HasFiltTab [] = {
     T_PLIST_TAB,                  FN_IS_NSORT,    0,
 
     // ssort, dense list, which is imm, homog, non-empty, table
-    T_PLIST_TAB_SSORT,            FN_IS_EMPTY,    0,
     T_PLIST_TAB_SSORT,            FN_IS_DENSE,    1,
     T_PLIST_TAB_SSORT,            FN_IS_NDENSE,   0,
     T_PLIST_TAB_SSORT,            FN_IS_HOMOG,    1,
@@ -3027,7 +3015,6 @@ static Int HasFiltTab [] = {
     T_PLIST_TAB_SSORT,            FN_IS_NSORT,    0,
 
     // nsort, dense list, which is imm, homog, non-empty, table
-    T_PLIST_TAB_NSORT,            FN_IS_EMPTY,    0,
     T_PLIST_TAB_NSORT,            FN_IS_DENSE,    1,
     T_PLIST_TAB_NSORT,            FN_IS_NDENSE,   0,
     T_PLIST_TAB_NSORT,            FN_IS_HOMOG,    1,
@@ -3038,7 +3025,6 @@ static Int HasFiltTab [] = {
     T_PLIST_TAB_NSORT,            FN_IS_NSORT,    1,
 
     // dense list, which is immutable, homog, non-empty, rect table
-    T_PLIST_TAB_RECT,                  FN_IS_EMPTY,    0,
     T_PLIST_TAB_RECT,                  FN_IS_DENSE,    1,
     T_PLIST_TAB_RECT,                  FN_IS_NDENSE,   0,
     T_PLIST_TAB_RECT,                  FN_IS_HOMOG,    1,
@@ -3049,7 +3035,6 @@ static Int HasFiltTab [] = {
     T_PLIST_TAB_RECT,                  FN_IS_NSORT,    0,
 
     // ssort, dense list, which is imm, homog, non-empty, rect table
-    T_PLIST_TAB_RECT_SSORT,            FN_IS_EMPTY,    0,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_DENSE,    1,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_NDENSE,   0,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_HOMOG,    1,
@@ -3060,7 +3045,6 @@ static Int HasFiltTab [] = {
     T_PLIST_TAB_RECT_SSORT,            FN_IS_NSORT,    0,
 
     // nsort, dense list, which is imm, homog, non-empty, rect table
-    T_PLIST_TAB_RECT_NSORT,            FN_IS_EMPTY,    0,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_DENSE,    1,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_NDENSE,   0,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_HOMOG,    1,
@@ -3071,7 +3055,6 @@ static Int HasFiltTab [] = {
     T_PLIST_TAB_RECT_NSORT,            FN_IS_NSORT,    1,
 
     // dense list, which only contains objects of type <= T_CYC
-    T_PLIST_CYC,                  FN_IS_EMPTY,    0,
     T_PLIST_CYC,                  FN_IS_DENSE,    1,
     T_PLIST_CYC,                  FN_IS_NDENSE,   0,
     T_PLIST_CYC,                  FN_IS_HOMOG,    1,
@@ -3082,7 +3065,6 @@ static Int HasFiltTab [] = {
     T_PLIST_CYC,                  FN_IS_NSORT,    0,
 
     // ssort dense list, which only contains objs of type <= T_CYC
-    T_PLIST_CYC_SSORT,            FN_IS_EMPTY,    0,
     T_PLIST_CYC_SSORT,            FN_IS_DENSE,    1,
     T_PLIST_CYC_SSORT,            FN_IS_NDENSE,   0,
     T_PLIST_CYC_SSORT,            FN_IS_HOMOG,    1,
@@ -3093,7 +3075,6 @@ static Int HasFiltTab [] = {
     T_PLIST_CYC_SSORT,            FN_IS_NSORT,    0,
 
     // nsort dense list, which only contains objs of type <= T_CYC
-    T_PLIST_CYC_NSORT,            FN_IS_EMPTY,    0,
     T_PLIST_CYC_NSORT,            FN_IS_DENSE,    1,
     T_PLIST_CYC_NSORT,            FN_IS_NDENSE,   0,
     T_PLIST_CYC_NSORT,            FN_IS_HOMOG,    1,
@@ -3105,7 +3086,6 @@ static Int HasFiltTab [] = {
 
     // dense list, which only contains objects of type T_FFE
     // all written over the same field
-    T_PLIST_FFE,            FN_IS_EMPTY,    0,
     T_PLIST_FFE,            FN_IS_DENSE,    1,
     T_PLIST_FFE,            FN_IS_NDENSE,   0,
     T_PLIST_FFE,            FN_IS_HOMOG,    1,
@@ -3126,7 +3106,6 @@ static Int HasFiltTab [] = {
 static Int SetFiltTab [] = {
 
     // plain lists
-    T_PLIST,                      FN_IS_EMPTY,   T_PLIST_EMPTY,
     T_PLIST,                      FN_IS_DENSE,   T_PLIST_DENSE,
     T_PLIST,                      FN_IS_NDENSE,  T_PLIST_NDENSE,
     T_PLIST,                      FN_IS_HOMOG,   T_PLIST_HOM,
@@ -3137,7 +3116,6 @@ static Int SetFiltTab [] = {
     T_PLIST,                      FN_IS_NSORT,   T_PLIST,
 
     // empty list
-    T_PLIST_EMPTY,                FN_IS_EMPTY,   T_PLIST_EMPTY,
     T_PLIST_EMPTY,                FN_IS_DENSE,   T_PLIST_EMPTY,
     T_PLIST_EMPTY,                FN_IS_NDENSE,  -1,
     T_PLIST_EMPTY,                FN_IS_HOMOG,   T_PLIST_EMPTY,
@@ -3148,7 +3126,6 @@ static Int SetFiltTab [] = {
     T_PLIST_EMPTY,                FN_IS_NSORT,   -1,
 
     // dense list
-    T_PLIST_DENSE,                FN_IS_EMPTY,   T_PLIST_EMPTY,
     T_PLIST_DENSE,                FN_IS_DENSE,   T_PLIST_DENSE,
     T_PLIST_DENSE,                FN_IS_NDENSE,  -1,
     T_PLIST_DENSE,                FN_IS_HOMOG,   T_PLIST_HOM,
@@ -3159,7 +3136,6 @@ static Int SetFiltTab [] = {
     T_PLIST_DENSE,                FN_IS_NSORT,   T_PLIST_DENSE,
 
     // dense list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM,           FN_IS_EMPTY,   -1,
     T_PLIST_DENSE_NHOM,           FN_IS_DENSE,   T_PLIST_DENSE_NHOM,
     T_PLIST_DENSE_NHOM,           FN_IS_NDENSE,  -1,
     T_PLIST_DENSE_NHOM,           FN_IS_HOMOG,   -1,
@@ -3170,7 +3146,6 @@ static Int SetFiltTab [] = {
     T_PLIST_DENSE_NHOM,           FN_IS_NSORT,   T_PLIST_DENSE_NHOM_NSORT,
 
     // dense ssorted list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM_SSORT,     FN_IS_EMPTY,   -1,
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_DENSE,   T_PLIST_DENSE_NHOM_SSORT,
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_NDENSE,  -1,
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_HOMOG,   -1,
@@ -3181,7 +3156,6 @@ static Int SetFiltTab [] = {
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_NSORT,   -1,
 
     // dense nsorted list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM_NSORT,     FN_IS_EMPTY,   -1,
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_DENSE,   T_PLIST_DENSE_NHOM_NSORT,
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_NDENSE,  -1,
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_HOMOG,   -1,
@@ -3192,7 +3166,6 @@ static Int SetFiltTab [] = {
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_NSORT,   T_PLIST_DENSE_NHOM_NSORT,
 
     // a mutable list with holes
-    T_PLIST_NDENSE,               FN_IS_EMPTY,   -1,
     T_PLIST_NDENSE,               FN_IS_DENSE,   -1,
     T_PLIST_NDENSE,               FN_IS_NDENSE,  T_PLIST_NDENSE,
     T_PLIST_NDENSE,               FN_IS_HOMOG,   -1,
@@ -3203,7 +3176,6 @@ static Int SetFiltTab [] = {
     T_PLIST_NDENSE,               FN_IS_NSORT,   T_PLIST_NDENSE,
 
     // dense list, which conts imms, is homogeneous, not a table
-    T_PLIST_HOM,                  FN_IS_EMPTY,   T_PLIST_EMPTY,
     T_PLIST_HOM,                  FN_IS_DENSE,   T_PLIST_HOM,
     T_PLIST_HOM,                  FN_IS_NDENSE,  -1,
     T_PLIST_HOM,                  FN_IS_HOMOG,   T_PLIST_HOM,
@@ -3214,7 +3186,6 @@ static Int SetFiltTab [] = {
     T_PLIST_HOM,                  FN_IS_NSORT,   T_PLIST_HOM_NSORT,
 
     // ssort dense list, which conts imms, is homog, not a table
-    T_PLIST_HOM_SSORT,            FN_IS_EMPTY,   T_PLIST_EMPTY,
     T_PLIST_HOM_SSORT,            FN_IS_DENSE,   T_PLIST_HOM_SSORT,
     T_PLIST_HOM_SSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_HOM_SSORT,            FN_IS_HOMOG,   T_PLIST_HOM_SSORT,
@@ -3225,7 +3196,6 @@ static Int SetFiltTab [] = {
     T_PLIST_HOM_SSORT,            FN_IS_NSORT,   -1,
 
     // nsort dense list, which conts imms, is homog, not a table
-    T_PLIST_HOM_NSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_HOM_NSORT,            FN_IS_DENSE,   T_PLIST_HOM_NSORT,
     T_PLIST_HOM_NSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_HOM_NSORT,            FN_IS_HOMOG,   T_PLIST_HOM_NSORT,
@@ -3236,7 +3206,6 @@ static Int SetFiltTab [] = {
     T_PLIST_HOM_NSORT,            FN_IS_NSORT,   T_PLIST_HOM_NSORT,
 
     // dense list, which is immutable, homog, non-empty, table
-    T_PLIST_TAB,                  FN_IS_EMPTY,   -1,
     T_PLIST_TAB,                  FN_IS_DENSE,   T_PLIST_TAB,
     T_PLIST_TAB,                  FN_IS_NDENSE,  -1,
     T_PLIST_TAB,                  FN_IS_HOMOG,   T_PLIST_TAB,
@@ -3247,7 +3216,6 @@ static Int SetFiltTab [] = {
     T_PLIST_TAB,                  FN_IS_NSORT,   T_PLIST_TAB_NSORT,
 
     // ssort, dense list, which is imm, homog, non-empty, table
-    T_PLIST_TAB_SSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_TAB_SSORT,            FN_IS_DENSE,   T_PLIST_TAB_SSORT,
     T_PLIST_TAB_SSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_TAB_SSORT,            FN_IS_HOMOG,   T_PLIST_TAB_SSORT,
@@ -3258,7 +3226,6 @@ static Int SetFiltTab [] = {
     T_PLIST_TAB_SSORT,            FN_IS_NSORT,   -1,
 
     // nsort, dense list, which is imm, homog, non-empty, table
-    T_PLIST_TAB_NSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_TAB_NSORT,            FN_IS_DENSE,   T_PLIST_TAB_NSORT,
     T_PLIST_TAB_NSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_TAB_NSORT,            FN_IS_HOMOG,   T_PLIST_TAB_NSORT,
@@ -3269,7 +3236,6 @@ static Int SetFiltTab [] = {
     T_PLIST_TAB_NSORT,            FN_IS_NSORT,   T_PLIST_TAB_NSORT,
 
     // dense list, which is immutable, homog, non-empty, rect table
-    T_PLIST_TAB_RECT,                  FN_IS_EMPTY,   -1,
     T_PLIST_TAB_RECT,                  FN_IS_DENSE,   T_PLIST_TAB_RECT,
     T_PLIST_TAB_RECT,                  FN_IS_NDENSE,  -1,
     T_PLIST_TAB_RECT,                  FN_IS_HOMOG,   T_PLIST_TAB_RECT,
@@ -3280,7 +3246,6 @@ static Int SetFiltTab [] = {
     T_PLIST_TAB_RECT,                  FN_IS_NSORT,   T_PLIST_TAB_RECT_NSORT,
 
     // ssort, dense list, which is imm, homog, non-empty, rect table
-    T_PLIST_TAB_RECT_SSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_DENSE,   T_PLIST_TAB_RECT_SSORT,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_HOMOG,   T_PLIST_TAB_RECT_SSORT,
@@ -3291,7 +3256,6 @@ static Int SetFiltTab [] = {
     T_PLIST_TAB_RECT_SSORT,            FN_IS_NSORT,   -1,
 
     // nsort, dense list, which is imm, homog, non-empty, rect table
-    T_PLIST_TAB_RECT_NSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_DENSE,   T_PLIST_TAB_RECT_NSORT,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_HOMOG,   T_PLIST_TAB_RECT_NSORT,
@@ -3302,7 +3266,6 @@ static Int SetFiltTab [] = {
     T_PLIST_TAB_RECT_NSORT,            FN_IS_NSORT,   T_PLIST_TAB_RECT_NSORT,
 
     // dense list, which only contains objects of type <= T_CYC
-    T_PLIST_CYC,                  FN_IS_EMPTY,   -1,
     T_PLIST_CYC,                  FN_IS_DENSE,   T_PLIST_CYC,
     T_PLIST_CYC,                  FN_IS_NDENSE,  -1,
     T_PLIST_CYC,                  FN_IS_HOMOG,   T_PLIST_CYC,
@@ -3313,7 +3276,6 @@ static Int SetFiltTab [] = {
     T_PLIST_CYC,                  FN_IS_NSORT,   T_PLIST_CYC_NSORT,
 
     // ssort dense list, which only contains objs of type <= T_CYC
-    T_PLIST_CYC_SSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_CYC_SSORT,            FN_IS_DENSE,   T_PLIST_CYC_SSORT,
     T_PLIST_CYC_SSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_CYC_SSORT,            FN_IS_HOMOG,   T_PLIST_CYC_SSORT,
@@ -3324,7 +3286,6 @@ static Int SetFiltTab [] = {
     T_PLIST_CYC_SSORT,            FN_IS_NSORT,   -1,
 
     // nsort dense list, which only contains objs of type <= T_CYC
-    T_PLIST_CYC_NSORT,            FN_IS_EMPTY,   -1,
     T_PLIST_CYC_NSORT,            FN_IS_DENSE,   T_PLIST_CYC_NSORT,
     T_PLIST_CYC_NSORT,            FN_IS_NDENSE,  -1,
     T_PLIST_CYC_NSORT,            FN_IS_HOMOG,   T_PLIST_CYC_NSORT,
@@ -3335,7 +3296,6 @@ static Int SetFiltTab [] = {
     T_PLIST_CYC_NSORT,            FN_IS_NSORT,   T_PLIST_CYC_NSORT,
 
     // dense list, which only contains objects of type T_FFE
-    T_PLIST_FFE,            FN_IS_EMPTY,   -1,
     T_PLIST_FFE,            FN_IS_DENSE,   T_PLIST_FFE,
     T_PLIST_FFE,            FN_IS_NDENSE,  -1,
     T_PLIST_FFE,            FN_IS_HOMOG,   T_PLIST_FFE,
@@ -3356,7 +3316,6 @@ static Int SetFiltTab [] = {
 static Int ResetFiltTab [] = {
 
     // plain lists
-    T_PLIST,                      FN_IS_EMPTY,   T_PLIST,
     T_PLIST,                      FN_IS_DENSE,   T_PLIST,
     T_PLIST,                      FN_IS_NDENSE,  T_PLIST,
     T_PLIST,                      FN_IS_HOMOG,   T_PLIST,
@@ -3367,7 +3326,6 @@ static Int ResetFiltTab [] = {
     T_PLIST,                      FN_IS_NSORT,   T_PLIST,
 
     // empty list
-    T_PLIST_EMPTY,                FN_IS_EMPTY,   T_PLIST,
     T_PLIST_EMPTY,                FN_IS_DENSE,   T_PLIST,
     T_PLIST_EMPTY,                FN_IS_NDENSE,  T_PLIST_EMPTY,
     T_PLIST_EMPTY,                FN_IS_HOMOG,   T_PLIST,
@@ -3378,7 +3336,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_EMPTY,                FN_IS_NSORT,   T_PLIST_EMPTY,
 
     // dense list
-    T_PLIST_DENSE,                FN_IS_EMPTY,   T_PLIST_DENSE,
     T_PLIST_DENSE,                FN_IS_DENSE,   T_PLIST,
     T_PLIST_DENSE,                FN_IS_NDENSE,  T_PLIST_DENSE,
     T_PLIST_DENSE,                FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3389,7 +3346,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_DENSE,                FN_IS_NSORT,   T_PLIST_DENSE,
 
     // dense list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM,           FN_IS_EMPTY,   T_PLIST_DENSE_NHOM,
     T_PLIST_DENSE_NHOM,           FN_IS_DENSE,   T_PLIST,
     T_PLIST_DENSE_NHOM,           FN_IS_NDENSE,  T_PLIST_DENSE_NHOM,
     T_PLIST_DENSE_NHOM,           FN_IS_HOMOG,   T_PLIST_DENSE_NHOM,
@@ -3400,7 +3356,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_DENSE_NHOM,           FN_IS_NSORT,   T_PLIST_DENSE_NHOM,
 
     // dense ssorted list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM_SSORT,     FN_IS_EMPTY,   T_PLIST_DENSE_NHOM_SSORT,
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_DENSE,   T_PLIST,
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_NDENSE,  T_PLIST_DENSE_NHOM_SSORT,
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_HOMOG,   T_PLIST_DENSE_NHOM_SSORT,
@@ -3411,7 +3366,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_DENSE_NHOM_SSORT,     FN_IS_NSORT,   T_PLIST_DENSE_NHOM_SSORT,
 
     // dense nsorted list, which contains immutables and is not homog
-    T_PLIST_DENSE_NHOM_NSORT,     FN_IS_EMPTY,   T_PLIST_DENSE_NHOM_NSORT,
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_DENSE,   T_PLIST,
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_NDENSE,  T_PLIST_DENSE_NHOM_NSORT,
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_HOMOG,   T_PLIST_DENSE_NHOM_NSORT,
@@ -3422,7 +3376,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_DENSE_NHOM_NSORT,     FN_IS_NSORT,   T_PLIST_DENSE_NHOM,
 
     // a mutable list with holes
-    T_PLIST_NDENSE,               FN_IS_EMPTY,   T_PLIST_NDENSE,
     T_PLIST_NDENSE,               FN_IS_DENSE,   T_PLIST_NDENSE,
     T_PLIST_NDENSE,               FN_IS_NDENSE,  T_PLIST,
     T_PLIST_NDENSE,               FN_IS_HOMOG,   T_PLIST_NDENSE,
@@ -3433,7 +3386,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_NDENSE,               FN_IS_NSORT,   T_PLIST_NDENSE,
 
     // dense list, which conts imms, is homogeneous, not a table
-    T_PLIST_HOM,                  FN_IS_EMPTY,   T_PLIST_HOM,
     T_PLIST_HOM,                  FN_IS_DENSE,   T_PLIST,
     T_PLIST_HOM,                  FN_IS_NDENSE,  T_PLIST_HOM,
     T_PLIST_HOM,                  FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3444,7 +3396,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_HOM,                  FN_IS_NSORT,   T_PLIST_HOM,
 
     // ssort dense list, which conts imms, is homog, not a table
-    T_PLIST_HOM_SSORT,            FN_IS_EMPTY,   T_PLIST_HOM_SSORT,
     T_PLIST_HOM_SSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_HOM_SSORT,            FN_IS_NDENSE,  T_PLIST_HOM_SSORT,
     T_PLIST_HOM_SSORT,            FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3455,7 +3406,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_HOM_SSORT,            FN_IS_NSORT,   T_PLIST_HOM_SSORT,
 
     // nsort dense list, which conts imms, is homog, not a table
-    T_PLIST_HOM_NSORT,            FN_IS_EMPTY,   T_PLIST_HOM_NSORT,
     T_PLIST_HOM_NSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_HOM_NSORT,            FN_IS_NDENSE,  T_PLIST_HOM_NSORT,
     T_PLIST_HOM_NSORT,            FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3466,7 +3416,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_HOM_NSORT,            FN_IS_NSORT,   T_PLIST_HOM,
 
     // dense list, which is immutable, homog, non-empty, table
-    T_PLIST_TAB,                  FN_IS_EMPTY,   T_PLIST_TAB,
     T_PLIST_TAB,                  FN_IS_DENSE,   T_PLIST,
     T_PLIST_TAB,                  FN_IS_NDENSE,  T_PLIST_TAB,
     T_PLIST_TAB,                  FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3477,7 +3426,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_TAB,                  FN_IS_NSORT,   T_PLIST_TAB,
 
     // ssort, dense list, which is imm, homog, non-empty, table
-    T_PLIST_TAB_SSORT,            FN_IS_EMPTY,   T_PLIST_TAB_SSORT,
     T_PLIST_TAB_SSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_TAB_SSORT,            FN_IS_NDENSE,  T_PLIST_TAB_SSORT,
     T_PLIST_TAB_SSORT,            FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3488,7 +3436,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_TAB_SSORT,            FN_IS_NSORT,   T_PLIST_TAB_SSORT,
 
     // nsort, dense list, which is imm, homog, non-empty, table
-    T_PLIST_TAB_NSORT,            FN_IS_EMPTY,   T_PLIST_TAB_NSORT,
     T_PLIST_TAB_NSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_TAB_NSORT,            FN_IS_NDENSE,  T_PLIST_TAB_NSORT,
     T_PLIST_TAB_NSORT,            FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3499,7 +3446,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_TAB_NSORT,            FN_IS_NSORT,   T_PLIST_TAB,
 
     // dense list, which is immutable, homog, non-empty, rect table
-    T_PLIST_TAB_RECT,                  FN_IS_EMPTY,   T_PLIST_TAB_RECT,
     T_PLIST_TAB_RECT,                  FN_IS_DENSE,   T_PLIST,
     T_PLIST_TAB_RECT,                  FN_IS_NDENSE,  T_PLIST_TAB_RECT,
     T_PLIST_TAB_RECT,                  FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3510,7 +3456,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_TAB_RECT,                  FN_IS_NSORT,   T_PLIST_TAB_RECT,
 
     // ssort, dense list, which is imm, homog, non-empty, rect table
-    T_PLIST_TAB_RECT_SSORT,            FN_IS_EMPTY,   T_PLIST_TAB_RECT_SSORT,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_NDENSE,  T_PLIST_TAB_RECT_SSORT,
     T_PLIST_TAB_RECT_SSORT,            FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3521,7 +3466,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_TAB_RECT_SSORT,            FN_IS_NSORT,   T_PLIST_TAB_RECT_SSORT,
 
     // loop variables
-    T_PLIST_TAB_RECT_NSORT,            FN_IS_EMPTY,   T_PLIST_TAB_RECT_NSORT,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_NDENSE,  T_PLIST_TAB_RECT_NSORT,
     T_PLIST_TAB_RECT_NSORT,            FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3532,7 +3476,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_TAB_RECT_NSORT,            FN_IS_NSORT,   T_PLIST_TAB_RECT,
 
     // dense list, which only contains objects of type <= T_CYC
-    T_PLIST_CYC,                  FN_IS_EMPTY,   T_PLIST_CYC,
     T_PLIST_CYC,                  FN_IS_DENSE,   T_PLIST,
     T_PLIST_CYC,                  FN_IS_NDENSE,  T_PLIST_CYC,
     T_PLIST_CYC,                  FN_IS_HOMOG,   T_PLIST_DENSE,
@@ -3543,7 +3486,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_CYC,                  FN_IS_NSORT,   T_PLIST_CYC,
 
     // ssort dense list, which only contains objs of type <= T_CYC
-    T_PLIST_CYC_SSORT,            FN_IS_EMPTY,   T_PLIST_CYC_SSORT,
     T_PLIST_CYC_SSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_CYC_SSORT,            FN_IS_NDENSE,  T_PLIST_CYC_SSORT,
     T_PLIST_CYC_SSORT,            FN_IS_HOMOG,   T_PLIST,
@@ -3554,7 +3496,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_CYC_SSORT,            FN_IS_NSORT,   T_PLIST_CYC_SSORT,
 
     // nsort dense list, which only contains objs of type <= T_CYC
-    T_PLIST_CYC_NSORT,            FN_IS_EMPTY,   T_PLIST_CYC_NSORT,
     T_PLIST_CYC_NSORT,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_CYC_NSORT,            FN_IS_NDENSE,  T_PLIST_CYC_NSORT,
     T_PLIST_CYC_NSORT,            FN_IS_HOMOG,   T_PLIST,
@@ -3565,7 +3506,6 @@ static Int ResetFiltTab [] = {
     T_PLIST_CYC_NSORT,            FN_IS_NSORT,   T_PLIST_CYC,
 
     // dense list, which only contains objects of type T_FFE
-    T_PLIST_FFE,            FN_IS_EMPTY,   T_PLIST_FFE,
     T_PLIST_FFE,            FN_IS_DENSE,   T_PLIST,
     T_PLIST_FFE,            FN_IS_NDENSE,  T_PLIST_FFE,
     T_PLIST_FFE,            FN_IS_HOMOG,   T_PLIST,

--- a/src/range.c
+++ b/src/range.c
@@ -1095,7 +1095,6 @@ static Int ClearFiltsTab [] = {
 static Int HasFiltTab [] = {
 
     // nsort range
-    T_RANGE_NSORT,              FN_IS_EMPTY,    0,
     T_RANGE_NSORT,              FN_IS_DENSE,    1,
     T_RANGE_NSORT,              FN_IS_NDENSE,   0,
     T_RANGE_NSORT,              FN_IS_HOMOG,    1,
@@ -1106,7 +1105,6 @@ static Int HasFiltTab [] = {
     T_RANGE_NSORT,              FN_IS_NSORT,    1,
 
     // ssort range
-    T_RANGE_SSORT,              FN_IS_EMPTY,    0,
     T_RANGE_SSORT,              FN_IS_DENSE,    1,
     T_RANGE_SSORT,              FN_IS_NDENSE,   0,
     T_RANGE_SSORT,              FN_IS_HOMOG,    1,
@@ -1127,7 +1125,6 @@ static Int HasFiltTab [] = {
 static Int SetFiltTab [] = {
 
     // nsort range
-    T_RANGE_NSORT,              FN_IS_EMPTY,    -1,
     T_RANGE_NSORT,              FN_IS_DENSE,    T_RANGE_NSORT,
     T_RANGE_NSORT,              FN_IS_NDENSE,   -1,
     T_RANGE_NSORT,              FN_IS_HOMOG,    T_RANGE_NSORT,
@@ -1138,7 +1135,6 @@ static Int SetFiltTab [] = {
     T_RANGE_NSORT,              FN_IS_NSORT,    T_RANGE_NSORT,
 
     // ssort range
-    T_RANGE_SSORT,              FN_IS_EMPTY,    T_RANGE_SSORT,
     T_RANGE_SSORT,              FN_IS_DENSE,    T_RANGE_SSORT,
     T_RANGE_SSORT,              FN_IS_NDENSE,   -1,
     T_RANGE_SSORT,              FN_IS_HOMOG,    T_RANGE_SSORT,
@@ -1160,7 +1156,6 @@ static Int SetFiltTab [] = {
 static Int ResetFiltTab [] = {
 
     // nsort range
-    T_RANGE_NSORT,              FN_IS_EMPTY,    T_RANGE_NSORT,
     T_RANGE_NSORT,              FN_IS_DENSE,    T_RANGE_NSORT,
     T_RANGE_NSORT,              FN_IS_NDENSE,   T_RANGE_NSORT,
     T_RANGE_NSORT,              FN_IS_HOMOG,    T_RANGE_NSORT,
@@ -1171,7 +1166,6 @@ static Int ResetFiltTab [] = {
     T_RANGE_NSORT,              FN_IS_NSORT,    T_RANGE_NSORT,
 
     // ssort range
-    T_RANGE_SSORT,              FN_IS_EMPTY,    T_RANGE_SSORT,
     T_RANGE_SSORT,              FN_IS_DENSE,    T_RANGE_SSORT,
     T_RANGE_SSORT,              FN_IS_NDENSE,   T_RANGE_SSORT,
     T_RANGE_SSORT,              FN_IS_HOMOG,    T_RANGE_SSORT,

--- a/src/set.c
+++ b/src/set.c
@@ -62,7 +62,7 @@ Int IsSet (
 
         /* if <list> is the empty list, it is a set (:-)                     */
         if ( LEN_PLIST(list) == 0 ) {
-            SET_FILT_LIST( list, FN_IS_EMPTY );
+            RetypeBagIfWritable(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
             isSet = 1;
         }
 
@@ -84,7 +84,7 @@ Int IsSet (
         /* if <list> is the empty list, it is a set (:-)                     */
         if ( LEN_LIST(list) == 0 ) {
             PLAIN_LIST( list );
-            SET_FILT_LIST( list, FN_IS_EMPTY );
+            RetypeBagIfWritable(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
             isSet = 1;
         }
 
@@ -575,15 +575,13 @@ Obj FuncREM_SET (
         for ( i = pos; i < len; i++ ) {
 	    *ptr = *(ptr+1);
 	    ptr ++;
-	    /*             SET_ELM_PLIST( set, i, ELM_PLIST(set,i+1) ); */
         }
         SET_ELM_PLIST( set, len, 0 );
         SET_LEN_PLIST( set, len-1 );
 
         /* fix up the type of the result                                   */
         if ( len-1 == 0 ) {
-            CLEAR_FILTS_LIST(set);
-            SET_FILT_LIST( set, FN_IS_EMPTY );
+            RetypeBag(set, T_PLIST_EMPTY);
         }
     }
 
@@ -858,8 +856,7 @@ Obj FuncINTER_SET (
 
     /* fix up the type of the result                                       */
     if ( lenr == 0 ) {
-      CLEAR_FILTS_LIST(set1);
-      SET_FILT_LIST( set1, FN_IS_EMPTY );
+        RetypeBag(set1, T_PLIST_EMPTY);
     }
     else if ( lenr == 1) {
       if (TNUM_OBJ(ELM_PLIST(set1,1)) <= T_CYC)
@@ -1019,8 +1016,7 @@ Obj FuncSUBTR_SET (
 
     /* fix up the type of the result                                       */
     if ( lenr == 0 ) {
-        CLEAR_FILTS_LIST(set1);
-        SET_FILT_LIST( set1, FN_IS_EMPTY );
+        RetypeBag(set1, T_PLIST_EMPTY);
     }
     else if ( lenr == 1) {
       if (TNUM_OBJ(ELM_PLIST(set1,1)) <= T_CYC)

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -2063,7 +2063,6 @@ static Int ClearFiltsTab [] = {
 static Int HasFiltTab [] = {
 
     // string
-    T_STRING,                  FN_IS_EMPTY,   0,
     T_STRING,                  FN_IS_DENSE,   1,
     T_STRING,                  FN_IS_NDENSE,  0,
     T_STRING,                  FN_IS_HOMOG,   1,
@@ -2074,7 +2073,6 @@ static Int HasFiltTab [] = {
     T_STRING,                  FN_IS_NSORT,   0,
 
     // ssort string
-    T_STRING_SSORT,            FN_IS_EMPTY,   0,
     T_STRING_SSORT,            FN_IS_DENSE,   1,
     T_STRING_SSORT,            FN_IS_NDENSE,  0,
     T_STRING_SSORT,            FN_IS_HOMOG,   1,
@@ -2085,7 +2083,6 @@ static Int HasFiltTab [] = {
     T_STRING_SSORT,            FN_IS_NSORT,   0,
 
     // nsort string
-    T_STRING_NSORT,            FN_IS_EMPTY,   0,
     T_STRING_NSORT,            FN_IS_DENSE,   1,
     T_STRING_NSORT,            FN_IS_NDENSE,  0,
     T_STRING_NSORT,            FN_IS_HOMOG,   1,
@@ -2106,7 +2103,6 @@ static Int HasFiltTab [] = {
 static Int SetFiltTab [] = {
 
     // string
-    T_STRING,                  FN_IS_EMPTY,   T_STRING_SSORT,
     T_STRING,                  FN_IS_DENSE,   T_STRING,
     T_STRING,                  FN_IS_NDENSE,  -1,
     T_STRING,                  FN_IS_HOMOG,   T_STRING,
@@ -2117,7 +2113,6 @@ static Int SetFiltTab [] = {
     T_STRING,                  FN_IS_NSORT,   T_STRING_NSORT,
 
     // ssort string
-    T_STRING_SSORT,            FN_IS_EMPTY,   T_STRING_SSORT,
     T_STRING_SSORT,            FN_IS_DENSE,   T_STRING_SSORT,
     T_STRING_SSORT,            FN_IS_NDENSE,  -1,
     T_STRING_SSORT,            FN_IS_HOMOG,   T_STRING_SSORT,
@@ -2128,7 +2123,6 @@ static Int SetFiltTab [] = {
     T_STRING_SSORT,            FN_IS_NSORT,   -1,
 
     // nsort string
-    T_STRING_NSORT,            FN_IS_EMPTY,   -1,
     T_STRING_NSORT,            FN_IS_DENSE,   T_STRING_NSORT,
     T_STRING_NSORT,            FN_IS_NDENSE,  -1,
     T_STRING_NSORT,            FN_IS_HOMOG,   T_STRING_NSORT,
@@ -2150,7 +2144,6 @@ static Int SetFiltTab [] = {
 static Int ResetFiltTab [] = {
 
     // string
-    T_STRING,                  FN_IS_EMPTY,   T_STRING,
     T_STRING,                  FN_IS_DENSE,   T_STRING,
     T_STRING,                  FN_IS_NDENSE,  T_STRING,
     T_STRING,                  FN_IS_HOMOG,   T_STRING,
@@ -2161,7 +2154,6 @@ static Int ResetFiltTab [] = {
     T_STRING,                  FN_IS_NSORT,   T_STRING,
 
     // ssort string
-    T_STRING_SSORT,            FN_IS_EMPTY,   T_STRING_SSORT,
     T_STRING_SSORT,            FN_IS_DENSE,   T_STRING_SSORT,
     T_STRING_SSORT,            FN_IS_NDENSE,  T_STRING_SSORT,
     T_STRING_SSORT,            FN_IS_HOMOG,   T_STRING_SSORT,
@@ -2172,7 +2164,6 @@ static Int ResetFiltTab [] = {
     T_STRING_SSORT,            FN_IS_NSORT,   T_STRING_SSORT,
 
     // nsort string
-    T_STRING_NSORT,            FN_IS_EMPTY,   T_STRING_NSORT,
     T_STRING_NSORT,            FN_IS_DENSE,   T_STRING_NSORT,
     T_STRING_NSORT,            FN_IS_NDENSE,  T_STRING_NSORT,
     T_STRING_NSORT,            FN_IS_HOMOG,   T_STRING_NSORT,


### PR DESCRIPTION
This tnum based kernel filter FN_IS_EMPTY is/was used for two purposes:
1. to test if a list is known-to-be-empty, via HAS_FILT_LIST
2. to mark a list as known-to-be-empty, via SET_FILT_LIST

The former in practice amounts to testing if the tnum is T_PLIST_EMPTY or
T_PLIST_EMPTY+IMMUTABLE. While that is fast, it is of limited usefulness. The
only two places testing this were replaced by a call to LEN_LIST.

Similarly, the former essentially amounts to setting the tnum of a plist to
T_PLIST_EMPTY resp. T_PLIST_EMPTY+IMMUTABLE; while in theory it could be used
on other types of lists, in practice it is only ever used on plists. Thus we
can replace it by suitable calls to RetypeBag or RetypeBagIfWritable, and/or
by creating empty plists from the start.

This is a revival of PR #1989
