### PR TITLE
Add forms for Omega(e,d,q), except when d odd, q even; some cleanup

### DIFF
--- a/grp/classic.gi
+++ b/grp/classic.gi
@@ -1665,7 +1665,7 @@ BindGlobal( "OmegaZero", function( d, q )
 
 #############################################################################
 ##
-#F  OmegaPlus( <d>, <q> ) . . . . . . . . . . . . . . . . \Omega^-_{<d>}(<q>)
+#F  OmegaPlus( <d>, <q> ) . . . . . . . . . . . . . . . . \Omega^+_{<d>}(<q>)
 ##
 BindGlobal( "OmegaPlus", function( d, q )
     local f, o, m, xi, g, a, mo, n, i, x1, x2, x, h, s, q2, q2i;

--- a/grp/classic.gi
+++ b/grp/classic.gi
@@ -1589,11 +1589,18 @@ BindGlobal( "OmegaZero", function( d, q )
     fi;
     SetSize( g, q^(m^2) * s );
 
-    # construct the bilinear form
-#T add the form!
-
-    # and the quadratic form
-#T add the form!
+    # construct the forms
+      if q mod 2 = 0 then
+      # FIXME: add forms for even characteristic, if that is possible at all
+      # (it doesn't seem to be)
+    else
+      x:= NullMat( d, d, f );
+      for i in [ 1 .. m ] do
+        x[i,d-i+1] := o;
+      od;
+      x[m+1,m+1] := (Characteristic(f)+1)/4*o;
+      SetInvariantQuadraticFormFromMatrix(g, ImmutableMatrix( f, x, true ) );
+    fi;
 
     # and return
     return g;
@@ -1700,11 +1707,13 @@ BindGlobal( "OmegaPlus", function( d, q )
     fi;
     SetSize( g, q^(m*(m-1)) * (q^m-1) * s );
 
-    # construct the bilinear form
-#T add the form!
-
-    # and the quadratic form
-#T add the form!
+    # construct the forms
+    x:= NullMat( d, d, f );
+    for i in [ 1 .. m ] do
+      x[i,d-i+1] := o;
+    od;
+    x:= ImmutableMatrix( f, x, true );
+    SetInvariantQuadraticFormFromMatrix( g, x );
 
     # and return
     return g;
@@ -1783,11 +1792,18 @@ BindGlobal( "OmegaMinus", function( d, q )
     fi;
     SetSize( g, q^(m*(m-1)) * (q^m+1) * s );
 
-    # construct the bilinear form
-#T add the form!
-
-    # and the quadratic form
-#T add the form!
+    # construct the forms
+    x:= NullMat( d, d, f );
+    for i in [ 1 .. m-1 ] do
+      x[i,d-i+1] := o;
+    od;
+    x[m,d-m+1] := -nu - nubar;
+    if q mod 2 = 1 then
+      x[m,d-m] := -o;
+      x[m+1,d-m+1] := xi^( (q+1)/2 );
+    fi;
+    x:= ImmutableMatrix( f, x, true );
+    SetInvariantQuadraticFormFromMatrix( g, x );
 
     # and return
     return g;

--- a/grp/classic.gi
+++ b/grp/classic.gi
@@ -343,6 +343,20 @@ InstallMethod( SpecialUnitaryGroupCons,
 
 #############################################################################
 ##
+#M  SetInvariantQuadraticFormFromMatrix( <g>, <mat> )
+##
+##  Set the invariant quadratic form of <g>  to the matrix <mat>, and also
+##  set the bilinear form to the value required by the documentation, i.e.,
+#   to <mat> + <mat>^T.
+##
+BindGlobal( "SetInvariantQuadraticFormFromMatrix", function( g, mat )
+    SetInvariantQuadraticForm( g, rec( matrix:= mat ) );
+    SetInvariantBilinearForm( g, rec( matrix:= mat+TransposedMat(mat) ) );
+end );
+
+
+#############################################################################
+##
 #F  Oplus45() . . . . . . . . . . . . . . . . . . . . . . . . . . . . O+_4(5)
 ##
 BindGlobal( "Oplus45", function()
@@ -388,13 +402,9 @@ BindGlobal( "Oplus45", function()
     # set the size
     SetSize( g, 28800 );
 
-    # construct the form
-    SetInvariantBilinearForm( g, rec( matrix:= ImmutableMatrix( f,
-        [[0,1,0,0],[1,0,0,0],[0,0,2,0],[0,0,0,2]] * One( f ), true ) ) );
-
-    # and the quadratic form
-    SetInvariantQuadraticForm( g, rec( matrix:= ImmutableMatrix( f,
-        [[0,1,0,0],[0,0,0,0],[0,0,1,0],[0,0,0,1]] * One( f ), true ) ) );
+    # construct the forms
+    SetInvariantQuadraticFormFromMatrix( g, ImmutableMatrix( f,
+        [[0,1,0,0],[0,0,0,0],[0,0,1,0],[0,0,0,1]] * One( f ), true ) );
 
     # and return
     return g;
@@ -450,19 +460,12 @@ BindGlobal( "Opm3", function( s, d )
     SetDimensionOfMatrixGroup( g, d );
     SetFieldOfMatrixGroup( g, f );
 
-    # construct the form
-    delta := List( 2*id, ShallowCopy );
-    delta{[1,2]}{[1,2]} := [[0,1],[1,0]]*One( f );
-    delta[3][3] := 2*One( f )*2;
-    SetInvariantBilinearForm( g,
-        rec( matrix:= ImmutableMatrix( f, delta, true ) ) );
-
-    # construct quadratic form
+    # construct the forms
     delta := List( id, ShallowCopy );
     delta{[1,2]}{[1,2]} := [[0,1],[0,0]]*One( f );
     delta[3][3] := One( f )*2;
-    SetInvariantQuadraticForm( g,
-        rec( matrix:= ImmutableMatrix( f, delta, true ) ) );
+    delta := ImmutableMatrix( f, delta, true );
+    SetInvariantQuadraticFormFromMatrix( g, delta );
 
     # set the size
     delta  := 1;
@@ -527,19 +530,12 @@ BindGlobal( "OpmSmall", function( s, d, q )
     SetDimensionOfMatrixGroup( g, d );
     SetFieldOfMatrixGroup( g, f );
 
-    # construct the form
-    delta := List( 2*id, ShallowCopy );
-    delta{[1,2]}{[1,2]} := [[0,1],[1,0]]*One( f );
-    delta[3][3] := 2*One( f );
-    SetInvariantBilinearForm( g,
-        rec( matrix:= ImmutableMatrix( f, delta, true ) ) );
-
-    # construct quadratic form
+    # construct the forms
     delta := List( id, ShallowCopy );
     delta{[1,2]}{[1,2]} := [[0,1],[0,0]]*One( f );
     delta[3][3] := One( f );
-    SetInvariantQuadraticForm( g,
-        rec( matrix:= ImmutableMatrix( f, delta, true ) ) );
+    delta := ImmutableMatrix( f, delta, true );
+    SetInvariantQuadraticFormFromMatrix( g, delta );
 
     # set the size
     delta  := 1;
@@ -600,20 +596,16 @@ BindGlobal( "OpmOdd", function( s, d, q )
         g := GroupWithGenerators( [
                     [[1,0,0,0],[0,1,2,1],[2,0,2,0],[1,0,0,1]]*One( f ),
                     [[0,2,2,2],[0,1,1,2],[1,0,2,0],[1,2,2,0]]*One( f ) ] );
-        SetInvariantBilinearForm( g, rec( matrix:= ImmutableMatrix( f,
-          [[0,1,0,0],[1,0,0,0],[0,0,1,0],[0,0,0,2]]*One( f ), true ) ) );
-        SetInvariantQuadraticForm( g, rec( matrix:= ImmutableMatrix( f,
-          [[0,1,0,0],[0,0,0,0],[0,0,2,0],[0,0,0,1]]*One( f ), true ) ) );
+        SetInvariantQuadraticFormFromMatrix( g, ImmutableMatrix( f,
+          [[0,1,0,0],[0,0,0,0],[0,0,2,0],[0,0,0,1]]*One( f ), true ) );
         SetSize( g, 1152 );
         return g;
     elif q = 3 and d = 4 and s = -1  then
         g := GroupWithGenerators( [
                     [[0,2,0,0],[2,1,0,1],[0,2,0,1],[0,0,1,0]]*One( f ),
                     [[2,0,0,0],[1,2,0,2],[1,0,0,1],[0,0,1,0]]*One( f ) ] );
-        SetInvariantBilinearForm( g, rec( matrix:= ImmutableMatrix( f,
-          [[0,1,0,0],[1,0,0,0],[0,0,2,0],[0,0,0,2]]*One( f ), true ) ) );
-        SetInvariantQuadraticForm( g, rec( matrix:= ImmutableMatrix( f,
-          [[0,1,0,0],[0,0,0,0],[0,0,1,0],[0,0,0,1]]*One( f ), true ) ) );
+        SetInvariantQuadraticFormFromMatrix( g, ImmutableMatrix( f,
+          [[0,1,0,0],[0,0,0,0],[0,0,1,0],[0,0,0,1]]*One( f ), true ) );
         SetSize( g, 1440 );
         return g;
     elif q = 5 and d = 4 and s = +1  then
@@ -674,19 +666,12 @@ BindGlobal( "OpmOdd", function( s, d, q )
     SetDimensionOfMatrixGroup( g, d );
     SetFieldOfMatrixGroup( g, f );
 
-    # construct the form
-    delta := List( 2*id, ShallowCopy );
-    delta{[1,2]}{[1,2]} := [[0,1],[1,0]]*One( f );
-    delta[3][3] := 2*beta;
-    SetInvariantBilinearForm( g,
-        rec( matrix:= ImmutableMatrix( f, delta, true ) ) );
-
-    # construct quadratic form
+    # construct the forms
     delta := List( id, ShallowCopy );
     delta{[1,2]}{[1,2]} := [[0,1],[0,0]]*One( f );
     delta[3][3] := beta;
-    SetInvariantQuadraticForm( g,
-        rec( matrix:= ImmutableMatrix( f, delta, true ) ) );
+    delta := ImmutableMatrix( f, delta, true );
+    SetInvariantQuadraticFormFromMatrix( g, delta );
 
     # set the size
     delta := 1;
@@ -723,10 +708,8 @@ BindGlobal( "Oplus2", function( q )
     m2:= ImmutableMatrix( f, m2, true );
     # construct the group, set the order, and return
     g := GroupWithGenerators( [ m1, m2 ] );
-    SetInvariantBilinearForm(g,
-        rec( matrix:= ImmutableMatrix( f, m2, true ) ) );
-    SetInvariantQuadraticForm( g, rec( matrix:= ImmutableMatrix( f,
-        [ [ 0, 1 ], [ 0, 0 ] ] * z^0, true ) ) );
+    SetInvariantQuadraticFormFromMatrix( g, ImmutableMatrix( f,
+        [ [ 0, 1 ], [ 0, 0 ] ] * z^0, true ) );
     SetSize( g, 2*(q-1) );
     return g;
 end );
@@ -774,13 +757,9 @@ BindGlobal( "Oplus4Even", function( q )
     # set the size
     SetSize( g, 2*q^2*(q^2-1)^2 );
 
-    # construct the form
-    SetInvariantBilinearForm( g, rec( matrix:= ImmutableMatrix( f,
-      [[0,1,0,0],[1,0,0,0],[0,0,0,1],[0,0,1,0]] * One( f ), true ) ) );
-
-    # and the quadratic form
-    SetInvariantQuadraticForm( g, rec( matrix:= ImmutableMatrix( f,
-      [[0,1,0,0],[0,0,0,0],[0,0,0,1],[0,0,0,0]] * One( f ), true ) ) );
+    # construct the forms
+    SetInvariantQuadraticFormFromMatrix( g, ImmutableMatrix( f,
+      [[0,1,0,0],[0,0,0,0],[0,0,0,1],[0,0,0,0]] * One( f ), true ) );
 
     # and return
     return g;
@@ -888,22 +867,12 @@ BindGlobal( "OplusEven", function( d, q )
     SetDimensionOfMatrixGroup( g, d );
     SetFieldOfMatrixGroup( g, f );
 
-    # construct the form
-    delta := List( 0*id, ShallowCopy );
-    for i  in [ 1 .. d/2 ]  do
-        delta[2*i-1][2*i] := One( f );
-        delta[2*i][2*i-1] := One( f );
-    od;
-    SetInvariantBilinearForm( g,
-        rec( matrix:= ImmutableMatrix( f, delta, true ) ) );
-
-    # construct quadratic form
+    # construct the forms
     delta := List( 0*id, ShallowCopy );
     for i  in [ 1 .. d/2 ]  do
         delta[2*i-1][2*i] := One( f );
     od;
-    SetInvariantQuadraticForm( g,
-        rec( matrix:= ImmutableMatrix( f, delta, true ) ) );
+    SetInvariantQuadraticFormFromMatrix( g, ImmutableMatrix( f, delta, true ) );
 
     # set the size
     delta := 1;
@@ -954,10 +923,8 @@ BindGlobal( "Ominus2", function( q )
     m1:=ImmutableMatrix(GF(q),m1,true);
     m2:=ImmutableMatrix(GF(q),m2,true);
     g := GroupWithGenerators( [ m1, m2 ] );
-    SetInvariantBilinearForm( g, rec( matrix:= ImmutableMatrix( f,
-      [ [ 2, 1 ], [ 1, 2*t ] ] * z^0, true ) ) );
-    SetInvariantQuadraticForm( g, rec( matrix:= ImmutableMatrix( f,
-      [ [ 1, 1 ], [ 0, t ] ] * z^0, true ) ) );
+    SetInvariantQuadraticFormFromMatrix( g, ImmutableMatrix( f,
+      [ [ 1, 1 ], [ 0, t ] ] * z^0, true ) );
     SetSize( g, 2*(q+1) );
 
     return g;
@@ -1016,13 +983,9 @@ BindGlobal( "Ominus4Even", function( q )
     # set the size
     SetSize( g, 2*q^2*(q^2+1)*(q^2-1) );
 
-    # construct the form
-    SetInvariantBilinearForm( g, rec( matrix:= ImmutableMatrix( f,
-      [[0,1,0,0],[1,0,0,0],[0,0,0,1],[0,0,1,0]] * One( f ), true ) ) );
-
-    # and the quadratic form
-    SetInvariantQuadraticForm( g, rec( matrix:= ImmutableMatrix( f,
-      [[0,1,0,0],[0,0,0,0],[0,0,t,1],[0,0,0,t]] * One( f ), true ) ) );
+    # construct the forms
+    SetInvariantQuadraticFormFromMatrix( g, ImmutableMatrix( f,
+      [[0,1,0,0],[0,0,0,0],[0,0,t,1],[0,0,0,t]] * One( f ), true ) );
 
     # and return
     return g;
@@ -1138,24 +1101,14 @@ BindGlobal( "OminusEven", function( d, q )
     SetDimensionOfMatrixGroup( g, d );
     SetFieldOfMatrixGroup( g, f );
 
-    # construct the form
-    delta := List( 0*id, ShallowCopy );
-    for i  in [ 1 .. d/2 ]  do
-        delta[2*i-1][2*i] := One( f );
-        delta[2*i][2*i-1] := One( f );
-    od;
-    SetInvariantBilinearForm( g,
-        rec( matrix:= ImmutableMatrix( f, delta, true ) ) );
-
-    # construct quadratic form
+    # construct the forms
     delta := List( 0*id, ShallowCopy );
     for i  in [ 1 .. d/2 ]  do
         delta[2*i-1][2*i] := One( f );
     od;
     delta[3][3] := t;
     delta[4][4] := t;
-    SetInvariantQuadraticForm( g,
-        rec( matrix:= ImmutableMatrix( f, delta, true ) ) );
+    SetInvariantQuadraticFormFromMatrix( g, ImmutableMatrix( f, delta, true ) );
 
     # set the size
     delta := 1;
@@ -1233,17 +1186,10 @@ BindGlobal( "OzeroOdd", function( d, q, b )
     od;
     SetSize( g, 2 * q^((d-1)^2/4) * s );
 
-    # construct the form
-    s := List( 2*b*id, ShallowCopy );
-    s{[1,2]}{[1,2]} := [[0,1],[1,0]]*One( f );
-    SetInvariantBilinearForm( g,
-        rec( matrix:= ImmutableMatrix( f, s, true ) ) );
-
-    # and the quadratic form
+    # construct the forms
     s := List( b*id, ShallowCopy );
     s{[1,2]}{[1,2]} := [[0,1],[0,0]]*One( f );
-    SetInvariantQuadraticForm( g,
-        rec( matrix:= ImmutableMatrix( f, s, true ) ) );
+    SetInvariantQuadraticFormFromMatrix( g, ImmutableMatrix( f, s, true ) );
 
     # and return
     return g;
@@ -1277,7 +1223,7 @@ end );
 ##  one-to-one in characteristic $2$.
 ##
 BindGlobal( "OzeroEven", function( d, q )
-    local f, z, o, n, mat1, mat2, i, g, size, qi, c, s;
+    local f, z, o, n, mat1, mat2, i, g, size, qi, s;
 
     # <d> must be odd, <q> must be even
     if d mod 2 = 0 then
@@ -1346,6 +1292,7 @@ BindGlobal( "OzeroEven", function( d, q )
     g:= GroupWithGenerators( [ mat1, mat2 ] );
     SetDimensionOfMatrixGroup( g, Length( mat1 ) );
     SetFieldOfMatrixGroup( g, f );
+    SetIsSubgroupSL( g, true );
 
     # add the size
     size := 1;
@@ -1356,24 +1303,14 @@ BindGlobal( "OzeroEven", function( d, q )
     od;
     SetSize( g, q^(((d-1)/2)^2) * size );
 
-    # construct the form
-    c := List( 0 * One( g ), ShallowCopy );
-    for i in [ 2 .. (d+1)/2 ] do
-      c[(d-1)/2+i][i] := o;
-      c[i][(d-1)/2+i] := o;
-    od;
-    SetInvariantBilinearForm( g,
-        rec( matrix:= ImmutableMatrix( f, c, true ) ) );
-    SetIsSubgroupSL( g, true );
-
-    # and the quadratic form
+    # construct the forms
     s := List( 0 * One( g ), ShallowCopy );
     s[1][1]:= o;
     for i in [ 2 .. (d+1)/2 ] do
       s[(d-1)/2+i][i]:= o;
     od;
-    SetInvariantQuadraticForm( g,
-        rec( matrix:= ImmutableMatrix( f, s, true ) ) );
+    s:= ImmutableMatrix( f, s, true );
+    SetInvariantQuadraticFormFromMatrix( g, s );
 
     # and return
     return g;

--- a/tst/testinstall/grp/classic-forms.tst
+++ b/tst/testinstall/grp/classic-forms.tst
@@ -51,7 +51,7 @@ gap> CheckSize := function(g)
 # odd-dimensional general orthogonal groups
 gap> grps:=[];;
 gap> for d in [3,5,7] do
->   for q in [2,3,4,5,7,8,9] do
+>   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, GO(d,q));
 >   od;
 > od;
@@ -67,7 +67,7 @@ true
 # even-dimensional general orthogonal groups
 gap> grps:=[];;
 gap> for d in [2,4,6,8] do
->   for q in [2,3,4,5,7,8,9] do
+>   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, GO(+1,d,q));
 >     Add(grps, GO(-1,d,q));
 >   od;
@@ -84,7 +84,7 @@ true
 # odd-dimensional special orthogonal groups
 gap> grps:=[];;
 gap> for d in [3,5,7] do
->   for q in [2,3,4,5,7,8,9] do
+>   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, SO(d,q));
 >   od;
 > od;
@@ -100,7 +100,7 @@ true
 # even-dimensional special orthogonal groups
 gap> grps:=[];;
 gap> for d in [2,4,6,8] do
->   for q in [2,3,4,5,7,8,9] do
+>   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, SO(+1,d,q));
 >     Add(grps, SO(-1,d,q));
 >   od;
@@ -122,7 +122,7 @@ true
 # odd-dimensional
 gap> grps:=[];;
 gap> for d in [3,5,7] do
->   for q in [2,3,4,5,7,8,9] do
+>   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, Omega(d,q));
 >   od;
 > od;
@@ -139,7 +139,7 @@ true
 # even-dimensional
 gap> grps:=[];;
 gap> for d in [2,4,6,8] do
->   for q in [2,3,4,5,7,8,9] do
+>   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, Omega(+1,d,q));
 >     if d <> 2 then Add(grps, Omega(-1,d,q)); fi;
 >   od;
@@ -161,7 +161,7 @@ true
 # general unitary groups
 gap> grps:=[];;
 gap> for d in [1..6] do
->   for q in [2,3,4,5,7,8,9] do
+>   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, GU(d,q));
 >   od;
 > od;
@@ -175,7 +175,7 @@ true
 # special unitary groups
 gap> grps:=[];;
 gap> for d in [1..6] do
->   for q in [2,3,4,5,7,8,9] do
+>   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, SU(d,q));
 >   od;
 > od;
@@ -191,7 +191,7 @@ true
 #
 gap> grps:=[];;
 gap> for d in [2,4,6,8] do
->   for q in [2,3,4,5,7,8,9] do
+>   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, Sp(d,q));
 >   od;
 > od;

--- a/tst/testinstall/grp/classic-forms.tst
+++ b/tst/testinstall/grp/classic-forms.tst
@@ -1,6 +1,5 @@
 #
 # Tests invariant forms of classic groups
-# TODO: also test quadratic forms
 #
 gap> START_TEST("classic-forms.tst");
 
@@ -117,7 +116,6 @@ true
 #
 # Omega subgroups of special orthogonal groups
 #
-# TODO: add forms to Omega, check them here
 
 # odd-dimensional
 gap> grps:=[];;
@@ -129,10 +127,16 @@ gap> for d in [3,5,7] do
 gap> ForAll(grps, CheckGeneratorsSpecial);
 true
 
-#gap> ForAll(grps, CheckBilinearForm);
-#true
-#gap> ForAll(grps, CheckQuadraticForm);
-#true
+# FIXME: forms are not implemented for odd d, even q
+# gap> ForAll(grps, CheckBilinearForm);
+# true
+# gap> ForAll(grps, CheckQuadraticForm);
+# true
+#
+gap> ForAll(Filtered(grps, g -> Characteristic(g)<>2), CheckBilinearForm);
+true
+gap> ForAll(Filtered(grps, g -> Characteristic(g)<>2), CheckQuadraticForm);
+true
 gap> ForAll(grps, CheckSize);
 true
 
@@ -146,11 +150,10 @@ gap> for d in [2,4,6,8] do
 > od;
 gap> ForAll(grps, CheckGeneratorsSpecial);
 true
-
-#gap> ForAll(grps, CheckBilinearForm);
-#true
-#gap> ForAll(grps, CheckQuadraticForm);
-#true
+gap> ForAll(grps, CheckBilinearForm);
+true
+gap> ForAll(grps, CheckQuadraticForm);
+true
 gap> ForAll(grps, CheckSize);
 true
 

--- a/tst/testinstall/grp/classic-forms.tst
+++ b/tst/testinstall/grp/classic-forms.tst
@@ -4,7 +4,7 @@
 #
 gap> START_TEST("classic-forms.tst");
 
-#
+# verify that the generators are invertible / have determinant 1
 gap> CheckGeneratorsInvertible := function(G)
 >   return ForAll(GeneratorsOfGroup(G),
 >               g -> not IsZero(Determinant(g)));
@@ -13,6 +13,8 @@ gap> CheckGeneratorsSpecial := function(G)
 >   return ForAll(GeneratorsOfGroup(G),
 >               g -> IsOne(Determinant(g)));
 > end;;
+
+# verify that forms are given and preserved
 gap> CheckBilinearForm := function(G)
 >   local M;
 >   M := InvariantBilinearForm(G).matrix;
@@ -38,6 +40,14 @@ gap> CheckSesquilinearForm := function(G)
 >               g -> g*M*TransposedMat(frob(g,aut)) = M);
 > end;;
 
+# verify group size if the underlying module is small
+gap> CheckSize := function(g)
+>    if Size(FieldOfMatrixGroup(g))^DimensionOfMatrixGroup(g) < 1000 then
+>        return Size(g) = Size(Group(GeneratorsOfGroup(g)));
+>    fi;
+>    return true;
+> end;;
+
 # odd-dimensional general orthogonal groups
 gap> grps:=[];;
 gap> for d in [3,5,7] do
@@ -50,6 +60,8 @@ true
 gap> ForAll(grps, CheckBilinearForm);
 true
 gap> ForAll(grps, CheckQuadraticForm);
+true
+gap> ForAll(grps, CheckSize);
 true
 
 # even-dimensional general orthogonal groups
@@ -66,6 +78,8 @@ gap> ForAll(grps, CheckBilinearForm);
 true
 gap> ForAll(grps, CheckQuadraticForm);
 true
+gap> ForAll(grps, CheckSize);
+true
 
 # odd-dimensional special orthogonal groups
 gap> grps:=[];;
@@ -79,6 +93,8 @@ true
 gap> ForAll(grps, CheckBilinearForm);
 true
 gap> ForAll(grps, CheckQuadraticForm);
+true
+gap> ForAll(grps, CheckSize);
 true
 
 # even-dimensional special orthogonal groups
@@ -94,6 +110,8 @@ true
 gap> ForAll(grps, CheckBilinearForm);
 true
 gap> ForAll(grps, CheckQuadraticForm);
+true
+gap> ForAll(grps, CheckSize);
 true
 
 #
@@ -115,6 +133,8 @@ true
 #true
 #gap> ForAll(grps, CheckQuadraticForm);
 #true
+gap> ForAll(grps, CheckSize);
+true
 
 # even-dimensional
 gap> grps:=[];;
@@ -131,6 +151,9 @@ true
 #true
 #gap> ForAll(grps, CheckQuadraticForm);
 #true
+gap> ForAll(grps, CheckSize);
+true
+
 #
 # unitary groups
 #
@@ -146,6 +169,8 @@ gap> ForAll(grps, CheckGeneratorsInvertible);
 true
 gap> ForAll(grps, CheckSesquilinearForm);
 true
+gap> ForAll(grps, CheckSize);
+true
 
 # special unitary groups
 gap> grps:=[];;
@@ -157,6 +182,8 @@ gap> for d in [1..6] do
 gap> ForAll(grps, CheckGeneratorsInvertible);
 true
 gap> ForAll(grps, CheckSesquilinearForm);
+true
+gap> ForAll(grps, CheckSize);
 true
 
 #
@@ -171,6 +198,8 @@ gap> for d in [2,4,6,8] do
 gap> ForAll(grps, CheckGeneratorsSpecial);
 true
 gap> ForAll(grps, CheckBilinearForm);
+true
+gap> ForAll(grps, CheckSize);
 true
 
 #


### PR DESCRIPTION
Also added a new helper `SetInvariantQuadraticFormFromMatrix` which reduces some code duplication and as a side effect enforces the invariant `B = Q + Q^tr`, where B is the Gram matrix of the invariant bilinear form of an orthogonal group G, and Q is the Gram matrix of its invariant quadratic form.

The reason for excluding the case where d is odd, q is even, is described in issue #2576