### PR TITLE
Fix calling AtExit methods after loading a workspace

### DIFF
--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1616,6 +1616,7 @@ end );
 #F  InstallAtExit( <func> ) . . . . . . . . . . function to call when exiting
 ##
 BIND_GLOBAL( "InstallAtExit", function( func )
+    local f;
     if not IS_FUNCTION(func)  then
         Error( "<func> must be a function" );
     fi;
@@ -1624,6 +1625,13 @@ BIND_GLOBAL( "InstallAtExit", function( func )
             Error( "<func> must accept zero arguments" );
         fi;
     fi;
+    # Return if function has already been installed
+    # Use this long form to support both List and AtomicList
+    for f in GAPInfo.AtExitFuncs do
+        if f = func then
+            return;
+        fi;
+    od;
     ADD_LIST( GAPInfo.AtExitFuncs, func );
 end );
 

--- a/lib/session.g
+++ b/lib/session.g
@@ -71,6 +71,7 @@ BindGlobal("POST_RESTORE", function()
         fi;
     od;
     SESSION();
+    PROGRAM_CLEAN_UP();
 end);
 
 if IsHPCGAP then


### PR DESCRIPTION
This patch just ensures we call "CLEAN_UP_PROGRAM" after restoring a workspace, mainly so the AtExit handlers are run.

While fixing this I noticed a different (small) bug, which is when restoring a workspace some handlers end up getting installed twice. The easiest fix for this (in my opinion) is to just skip the second time the handler is installed.

Fixes #2558