### PR TITLE
Rewrite EvalString

### DIFF
--- a/lib/string.gi
+++ b/lib/string.gi
@@ -642,23 +642,19 @@ InstallGlobalFunction("RemoveCharacters", REMOVE_CHARACTERS);
 ##
 #F  EvalString( <expr> ) . . . . . . . . . . . . evaluate a string expression
 ##
-_EVALSTRINGTMP := 0;
 InstallGlobalFunction("EvalString", function( s )
   local a, f, res;
-  a := "_EVALSTRINGTMP:=";
+  # Prepend 'return' and append ';' to the given string; also add newlines to
+  # ensure that if there are syntax errors in the evaluated string, GAP
+  # prints only the evaluated string, but not the 'return' and ';' we prepend
+  # resp. append.
+  a := "return\n";
   Append(a, s);
-  Add(a, ';');
-  Unbind(_EVALSTRINGTMP);
+  Append(a, ";\n");
   f := InputTextString(a);
-  Read(f);
-  if not IsBound(_EVALSTRINGTMP) then
-    Error("Could not evaluate string.\n");
-  fi;
-  res := _EVALSTRINGTMP;
-  Unbind(_EVALSTRINGTMP);
-  return res;
+  f := ReadAsFunction(f);
+  return f();
 end);
-Unbind(_EVALSTRINGTMP);
 
 #############################################################################
 ##

--- a/tst/test-error/line-continuation.g.out
+++ b/tst/test-error/line-continuation.g.out
@@ -3,23 +3,25 @@ gap> # Verify that a CRLF after a line continuation increments the current line
 gap> # counter only once, so that both examples below report the error in line 2.
 gap> #
 gap> EvalString("123\\\n45x;");
-Error, Variable: '12345x' must have a value
-not in any function at stream:2
-Error, Could not evaluate string.
- at GAPROOT/lib/string.gi:655 called from
+Syntax warning: Unbound global variable in stream:3
+45x;;
+    ^
+Error, Variable: '12345x' must have an assigned value in
+  return 12345x; at stream:3 called from 
+f(  ) at GAPROOT/lib/string.gi:656 called from
 <function "EvalString">( <arguments> )
  called from read-eval loop at *stdin*:6
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+you can 'return;' after assigning a value
 brk> quit;
 gap> EvalString("123\\\r\n45x;");
-Error, Variable: '12345x' must have a value
-not in any function at stream:2
-Error, Could not evaluate string.
- at GAPROOT/lib/string.gi:655 called from
+Syntax warning: Unbound global variable in stream:3
+45x;;
+    ^
+Error, Variable: '12345x' must have an assigned value in
+  return 12345x; at stream:3 called from 
+f(  ) at GAPROOT/lib/string.gi:656 called from
 <function "EvalString">( <arguments> )
  called from read-eval loop at *stdin*:6
-you can 'quit;' to quit to outer loop, or
-you can 'return;' to continue
+you can 'return;' after assigning a value
 brk> quit;
 gap> QUIT;

--- a/tst/testinstall/evalstring.tst
+++ b/tst/testinstall/evalstring.tst
@@ -1,0 +1,71 @@
+gap> START_TEST("evalstring.tst");
+
+#
+gap> EvalString("1+1");
+2
+gap> EvalString("(1,2,3) * (2,3,4)^2") = (1,2,3) * (2,3,4)^2;
+true
+
+#
+gap> global_a := 0;;
+gap> global_b := 0;;
+gap> example := function ( local_a )
+>     local  local_b;
+>     local_b := 5;
+>     global_a := local_a;
+>     global_b := local_b;
+>     return EvalString( "global_a * global_b" );
+> end;;
+gap> example( 2 );
+10
+
+#
+# Error cases
+#
+
+#
+gap> EvalString("");
+Error, Function Calls: <func> must return a value
+
+#
+gap> f := function() local x; return x; end;;
+gap> EvalString("f();");
+Error, Variable: 'x' must have an assigned value
+
+#
+gap> Unbind(local_a); Unbind(local_b);
+gap> example := function ( local_a )
+>   local local_b;
+>   local_b := 5;
+>   return EvalString( "local_a * local_b" );
+> end;;
+gap> example(1);
+Syntax warning: Unbound global variable in stream:2
+local_a * local_b;
+        ^
+Syntax warning: Unbound global variable in stream:2
+local_a * local_b;
+                 ^
+Error, Variable: 'local_a' must have an assigned value
+
+#
+gap> x:=0;
+0
+gap> EvalString("x := 15;");
+Syntax error: ; expected in stream:2
+x := 15;;
+   ^
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+The 1st argument is 'fail' which might point to an earlier problem
+
+
+#
+gap> EvalString("Print(\"Hello, world\\n\");");
+Hello, world
+Error, Function Calls: <func> must return a value
+gap> EvalString("15 + 1; Print(\"Hello, world\");");
+16
+
+#
+gap> STOP_TEST( "evalstring.tst", 1);

--- a/tst/testinstall/kernel/scanner.tst
+++ b/tst/testinstall/kernel/scanner.tst
@@ -123,18 +123,23 @@ a.x111111111111111111111111111111111111111111111111111111111111111111111111111\
 # test EOF inside a string literal
 #
 gap> EvalString("\"123");
-Syntax error: String must end with " before end of file in stream:1
+Syntax error: String must not include <newline> in stream:2
+"123;
+    ^
+Syntax error: ; expected in stream:3
 ^
-Syntax error: ; expected in stream:1
-^
-Error, Could not evaluate string.
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+The 1st argument is 'fail' which might point to an earlier problem
 
 gap> EvalString("\"\"\"123");
-Syntax error: String must end with """ before end of file in stream:1
+Syntax error: String must end with """ before end of file in stream:3
 ^
-Syntax error: ; expected in stream:1
+Syntax error: ; expected in stream:3
 ^
-Error, Could not evaluate string.
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+The 1st argument is 'fail' which might point to an earlier problem
 
 gap> obj := """
 Syntax error: String must end with """ before end of file in stream:2


### PR DESCRIPTION
Do not use a temporary variable to store results, and be more strict about
what we accept (to match the documentation).

This is an alternative to #2186. On the one hand, unlike that PR, this PR tries to stick to what is documented about `EvalString`. On the other hand, this PR makes `EvalString` a bit stricter, so that means one has to worry that it could break packages which rely on the current undocumented behaviour. So all in all, I am not sure it's worth it -- then again, it *is* IMHO quite a bit cleaner.


Closes #2186.
