### PR TITLE
Remove primgrp, smallgrp, transgrp from required packages

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1745,9 +1745,24 @@ DeclareUserPreference( rec(
 For backwards compatibility, the default lists most of packages \
 that were autoloaded in GAP 4.4 (add or remove packages as you like)."
     ],
-  default:= [ "autpgrp", "alnuth", "crisp", "ctbllib", "factint", "fga", 
-              "irredsol", "laguna", "polenta", "polycyclic", "resclasses", 
-              "sophus", "tomlib" ],
+  default:= [
+    "autpgrp",
+    "alnuth",
+    "crisp",
+    "ctbllib",
+    "factint",
+    "fga",
+    "irredsol",
+    "laguna",
+    "polenta",
+    "polycyclic",
+    "primgrp",
+    "resclasses",
+    "smallgrp",
+    "sophus",
+    "tomlib",
+    "transgrp",
+    ],
   values:= function() return RecNames( GAPInfo.PackagesInfo ); end,
   multi:= true,
   ) );

--- a/lib/system.g
+++ b/lib/system.g
@@ -30,9 +30,6 @@ BIND_GLOBAL( "GAPInfo", rec(
     Dependencies := MakeImmutable(rec(
       NeededOtherPackages := [
         [ "gapdoc", ">= 1.2" ],
-        [ "primgrp", ">= 3.1.0" ],
-        [ "smallgrp", ">= 1.0" ],
-        [ "transgrp", ">= 1.0" ],
       ],
     )),
 # There is no SuggestedOtherPackages here because the default value of


### PR DESCRIPTION
This starts work on issue #2434. Let's see what breaks, if anything.

Though we may not see any breakage without dedicated tests, at least in packages...

