### PR TITLE
Fix MemoizePosIntFunction for errorHandler not returning a value

### DIFF
--- a/lib/cache.gi
+++ b/lib/cache.gi
@@ -37,7 +37,7 @@ function(func, extra...)
     fi;
 
     original := AtomicList(options.defaults);
-    
+
     boundvals := MakeWriteOnceAtomic(AtomicList(original));
 
     if options.flush then
@@ -51,7 +51,11 @@ function(func, extra...)
     return function(val)
         local v, boundcpy;
         if not IsPosInt(val) then
-            return options.errorHandler(val);
+            v := CallFuncListWrap(options.errorHandler, [val]);
+            if v <> [] then
+                return v[1];
+            fi;
+            return;
         fi;
         # Make a copy of the reference to boundvals, in case the cache
         # is flushed, which will causes boundvals to be bound to a new list.

--- a/tst/testinstall/memoize.tst
+++ b/tst/testinstall/memoize.tst
@@ -46,6 +46,15 @@ gap> f3(2);
 gap> f3(6);
 Check:6
 36
+gap> f4 := MemoizePosIntFunction(func,
+> rec(defaults := [10,,20], errorHandler := function(x) Print("Woops\n"); end));;
+gap> f4(1);
+10
+gap> f4(2);
+Check:2
+4
+gap> f4("Hello, world");
+Woops
 
 # HPCGAP currently disables flushing caches
 gap> FlushCaches();


### PR DESCRIPTION
Before this patch, if the optional errorHandler did not return a value,
we ran into a followup error that the error handler needs to return a value.

This PR changes the behaviour of the function returned by
`MemoizePosIntFunction` to just return if no value was returned by the
errorHandler.