### PR TITLE
hpcgap: disable tst/teststandard/processes/children.tst

### DIFF
--- a/tst/teststandard/processes/children.tst
+++ b/tst/teststandard/processes/children.tst
@@ -11,7 +11,9 @@ gap> runChild := function(ms, ignoresignals)
 >    if ignoresignals then signal := "1"; else signal := "0"; fi;
 >    return InputOutputLocalProcess(d, checkpl, [ String(time), signal]);
 >  end;;
-gap> for i in [1..200] do
+gap> reps:=200;;
+gap> if IsHPCGAP then reps:=0; fi;  # FIXME: this test is broken in HPC-GAP
+gap> for i in [1..reps] do
 > children := List([1..20], x -> runChild(Random([1..2000]), Random([false,true])));;
 > if ForAny(children, x -> x=fail) then Print("Failed producing child\n"); fi;
 > Perform(children, CloseStream);


### PR DESCRIPTION
It crashes in HPC-GAP and also garbles our coverage data.