### PR TITLE
Fix missing syntax warning for using undefined gvar

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -806,11 +806,13 @@ static void ReadCallVarAss(TypSymbolSet follow, Char mode)
         }
         else {
             Match( S_ASSIGN, ":=", follow );
+            UInt currLHSGVar = ReaderState()->CurrLHSGVar;
             if ( LEN_PLIST(STATE(StackNams)) == 0 || !STATE(IntrCoding) ) {
                 ReaderState()->CurrLHSGVar = (ref.type == R_GVAR ? ref.var : 0);
             }
             ReadExpr( follow, 'r' );
             AssignRef(ref);
+            ReaderState()->CurrLHSGVar = currLHSGVar;
         }
     }
 

--- a/tst/testbugfix/2018-06-29-CurrLHSGVar.tst
+++ b/tst/testbugfix/2018-06-29-CurrLHSGVar.tst
@@ -1,0 +1,19 @@
+# This always produced a warning"
+gap> Unbind(string);
+gap> for i in [ 1 .. 10 ] do
+>     string := "aaaabbbb";
+>     xxx := List( [], x -> string );
+> od;
+Syntax warning: Unbound global variable in stream:3
+    xxx := List( [], x -> string );
+                                 ^
+
+# ... but this did not; now it does
+gap> Unbind(string);
+gap> for i in [ 1 .. 10 ] do
+>     string := "aaaabbbb";
+>     List( [], x -> string );
+> od;
+Syntax warning: Unbound global variable in stream:3
+    List( [], x -> string );
+                          ^

--- a/tst/teststandard/ctblsymm.tst
+++ b/tst/teststandard/ctblsymm.tst
@@ -12,6 +12,7 @@ gap> c3:= CharacterTable( CyclicGroup( 3 ) );;
 gap> n:= 3;;
 gap> wr:= CharacterTableWreathSymmetric( c3, n );;
 gap> irr:= Irr( wr );;
+gap> betas:=fail;;
 gap> for i in [ 1 .. Length( irr ) ] do
 >      betas:= List( CharacterParameters( wr )[i], BetaSet );
 >      if List( ClassParameters( wr ), 


### PR DESCRIPTION
We normally issue a warning when code is parsed that uses a variable
identifier which has not yet been defined, which GAP then resolves as the
name of a gvar.

However, we suppress this warning if it is for the assignment to a global
variable.

But in some rare cases, this suppressed too much: if the very next line after
such an assignment wasn't an assignment itself, and accessed the gvar, we did
not print a warning.

This addresses part of issue #1800, though it does not implement the feature "requested" by @sebasguts there.

It also shows up one "problem" (?) in transgrp:
```
Syntax warning: Unbound global variable in GAPROOT/pkg/transgrp/lib/trans.grp:240
	  TRANSAVAILABLE[tradeg]:=true;
	                ^
```
Note that `TRANSAVAILABLE` actually gets defined before the offending line; but since it is wrapped in an atomic (and hence coding is enabled), the warning gets triggered. Simple fix would be to init `TRANSAVAILABLE` outside of that atomic; or even get rid of the atomic (it's not clear to me what it is for). I'll try to look into this and prepare a patch for transgrp. In the meantime, we should of course not merge this.