### PR TITLE
Add BannerFunction to PackageInfo.g

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1105,7 +1105,7 @@ InstallGlobalFunction( DefaultPackageBannerString, function( inforec )
       Append( str, inforec.PackageWWWHome );
       Append( str, "\n" );
     fi;
-    
+
     # temporary hack, in some package names with umlauts are in HTML encoding
     str := Concatenation(sep, RecodeForCurrentTerminal(str), sep);
     str:= ReplacedString( str, "&auml;", RecodeForCurrentTerminal("ä") );
@@ -1331,7 +1331,9 @@ BindGlobal( "LoadPackage_ReadImplementationParts",
 
         # If the component `BannerString' is bound in `info' then we print
         # this string, otherwise we print the default banner string.
-        if IsBound( info.BannerString ) then
+        if IsBound( info.BannerFunction ) then
+          bannerstring:= RecodeForCurrentTerminal(info.BannerFunction(info));
+        elif IsBound( info.BannerString ) then
           bannerstring:= RecodeForCurrentTerminal(info.BannerString);
         else
           bannerstring:= DefaultPackageBannerString( info );
@@ -2280,6 +2282,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
       fi;
     fi;
     TestMandat( record, "AvailabilityTest", IsFunction, "a function" );
+    TestOption( record, "BannerFunction", IsFunction, "a function" );
     TestOption( record, "BannerString", IsString, "a string" );
     TestOption( record, "TestFile", IsFilename,
                 "a string denoting a relative path to a readable file" );


### PR DESCRIPTION
This implements some in the idea described in issue #2568, by adding two new keys to the package info record (their names are of course still open for discussion):

* <s>`BannerExtra` can set to a string, or to a function returning a string; the string will be printed as part of the the *default* banner, as produced by `DefaultPackageBannerString`. This can be used to print some additional information in the banner, e.g. extra acknowledgements; or dynamic info about build configuration for a package with kernel extension.</s>

* `BannerFunction` can be set to a function which takes the info record as argument, and returns a string which is used just like `BannerString`. This way, one can print a custom banner string with dynamic data, such as information about the build configuration for a package with kernel extension.

One alternative suggestion was to just allow setting `BannerString` to a function. What I don't like about that is that such a package then cannot be loaded by older GAP versions anymore. While with the approach in this PR, a package using either of the two new keys would still be useable in older GAP versions.

Still missing is documentation for these new keys -- but I am not going to write that unless I know we'll (very likely) merge this.

UPDATE: I removed `BannerExtra`

Closes #2568