### PR TITLE
HPC-GAP: flush method cache if the list of methods changes

### DIFF
--- a/src/opers.c
+++ b/src/opers.c
@@ -3529,7 +3529,7 @@ Obj FuncCHANGED_METHODS_OPERATION (
     n = INT_INTOBJ( narg );
     cacheBag = CacheOper( oper, (UInt) n );
     cache = ADDR_OBJ( cacheBag );
-    for ( i = 0;  i < SIZE_OBJ(cacheBag) / sizeof(Obj);  i++ ) {
+    for ( i = 1;  i < SIZE_OBJ(cacheBag) / sizeof(Obj);  i++ ) {
         cache[i] = 0;
     }
     return 0;

--- a/tst/testinstall/memoize.tst
+++ b/tst/testinstall/memoize.tst
@@ -47,14 +47,20 @@ gap> f3(6);
 Check:6
 36
 
-# HPCGAP currently disables flushing caches
-gap> FlushCaches();
-gap> if IsHPCGAP then Print("Check:6\n"); fi; f1(6);
-Check:6
+# test flushing caches
+gap> f1(6);
 36
-gap> if IsHPCGAP then Print("Check:10\n"); fi; f2(10);
-Check:10
+gap> f2(10);
 100
 gap> f3(6);
+36
+gap> FlushCaches();
+gap> f1(6);
+Check:6
+36
+gap> f2(10);
+Check:10
+100
+gap> f3(6); # f3 disables flushing
 36
 gap> STOP_TEST("memoize.tst", 1);


### PR DESCRIPTION
Fixes #2594