### PR TITLE
PageSource should show local file

### DIFF
--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -433,10 +433,13 @@ BIND_GLOBAL("PageSource", function ( fun, nr... )
     l := fail;
     f := FILENAME_FUNC( fun );
     if IsString(f) and Length(f)>0 and f[1] <> '/' then
-      if Length(f) > 7 and f{[1..8]} = "GAPROOT/" then
-        f := f{[9..Length(f)]};
+      # first assume it is a local path, otherwise look in GAP roots
+      if not IsReadableFile(f) then
+        if Length(f) > 7 and f{[1..8]} = "GAPROOT/" then
+          f := f{[9..Length(f)]};
+        fi;
+        f := Filename(List(GAPInfo.RootPaths, Directory), f);
       fi;
-      f := Filename(List(GAPInfo.RootPaths, Directory), f);
     fi;
     if f = fail and fun in OPERATIONS then
       # for operations we show the location(s) of their declaration


### PR DESCRIPTION
So far, we assumed in PageSource that if FILENAME_FUNC returns a string not
starting with '/' that the pathname was relative to a GAP root. This is not
true if a function was read from a file relative to GAPs current directory.

Remark: It would be good to store a full path with function read from a
local file.