### PR TITLE
kernel: add MAX_FUNC_LVARS, MAX_FUNC_EXPR_NESTING

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -18,6 +18,7 @@
 #include "bool.h"
 #include "calls.h"
 #include "funcs.h"
+#include "gap.h"
 #include "gapstate.h"
 #include "gvars.h"
 #include "hookintrprtr.h"
@@ -61,19 +62,18 @@ static Obj TYPE_KERNEL_OBJECT;
 **  'OffsBody' is the  offset in the current   body.  It is  only valid while
 **  coding.
 */
-#define MAX_FUNC_EXPR_NESTING 1024
 /* TL: Stat OffsBody; */
 
 /* TL: Stat OffsBodyStack[1024]; */
 /* TL: UInt OffsBodyCount = 0; */
 
 static inline void PushOffsBody( void ) {
-  assert(STATE(OffsBodyCount) <= MAX_FUNC_EXPR_NESTING-1);
+  GAP_ASSERT(STATE(OffsBodyCount) < MAX_FUNC_EXPR_NESTING);
   STATE(OffsBodyStack)[STATE(OffsBodyCount)++] = STATE(OffsBody);
 }
 
 static inline void PopOffsBody( void ) {
-  assert(STATE(OffsBodyCount));
+  GAP_ASSERT(STATE(OffsBodyCount));
   STATE(OffsBody) = STATE(OffsBodyStack)[--STATE(OffsBodyCount)];
 }
 

--- a/src/gap.h
+++ b/src/gap.h
@@ -87,6 +87,38 @@ enum {
 
 /****************************************************************************
 **
+*S  MAX_FUNC_EXPR_NESTING_BITS
+*S  MAX_FUNC_EXPR_NESTING . . . . . . . . . . . . . . . maximal nesting level
+**
+**  GAP functions can be nested; any function 'A' can contain definition of
+**  another function 'B', and function 'B' then has full access to the local
+**  variables of 'A', including its arguments. As encoding access to such
+**  "higher" local variables must be encoded in limited storage, we also
+**  limit how deeply functions can be nested.
+*/
+enum {
+    MAX_FUNC_EXPR_NESTING_BITS = 10,
+    MAX_FUNC_EXPR_NESTING      = 1L << MAX_FUNC_EXPR_NESTING_BITS,
+};
+
+
+/****************************************************************************
+**
+*S  MAX_FUNC_LVARS_BITS
+*S  MAX_FUNC_LVARS_MASK
+*S  MAX_FUNC_LVARS  . . . .  maximal numbers of local variables in a function
+**
+**  Note that function arguments also count as local variables.
+*/
+enum {
+    MAX_FUNC_LVARS_BITS = 16,
+    MAX_FUNC_LVARS      = 1L << MAX_FUNC_LVARS_BITS,
+    MAX_FUNC_LVARS_MASK = MAX_FUNC_LVARS - 1,
+};
+
+
+/****************************************************************************
+**
 *F  InitializeGap( <argc>, <argv> ) . . . . . . . . . . . . . . . .  init GAP
 */
 extern void InitializeGap (

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2697,7 +2697,7 @@ void            IntrAssDVar (
 
     if ( STATE(IntrCoding) > 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
-                   dvar >> 10, dvar & 0x3FF );
+                   dvar >> MAX_FUNC_LVARS_BITS, dvar & MAX_FUNC_LVARS_MASK );
     }
 
 
@@ -2728,7 +2728,7 @@ void            IntrUnbDVar (
 
     if ( STATE(IntrCoding) > 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
-                   dvar >> 10, dvar & 0x3FF );
+                   dvar >> MAX_FUNC_LVARS_BITS, dvar & MAX_FUNC_LVARS_MASK );
     }
 
     /* assign the right hand side                                          */
@@ -2761,7 +2761,7 @@ void            IntrRefDVar (
 
     if ( STATE(IntrCoding) > 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
-                   dvar >> 10, dvar & 0x3FF );
+                   dvar >> MAX_FUNC_LVARS_BITS, dvar & MAX_FUNC_LVARS_MASK );
     }
 
     /* get and check the value                                             */
@@ -2771,7 +2771,7 @@ void            IntrRefDVar (
     val = OBJ_HVAR_WITH_CONTEXT(context, dvar);
     if ( val == 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> must have a value",
-                   dvar >> 10, dvar & 0xFFFF );
+                   dvar >> MAX_FUNC_LVARS_BITS, dvar & MAX_FUNC_LVARS_MASK );
     }
 
     /* push the value                                                      */

--- a/src/vars.c
+++ b/src/vars.c
@@ -24,6 +24,7 @@
 #include "code.h"
 #include "error.h"
 #include "exprs.h"
+#include "gap.h"
 #include "gaputils.h"
 #include "gvars.h"
 #include "hookintrprtr.h"
@@ -271,24 +272,24 @@ Obj NAME_HVAR(UInt hvar)
 void ASS_HVAR_WITH_CONTEXT(Obj context, UInt hvar, Obj val)
 {
     // walk up the environment chain to the correct values bag
-    for (UInt i = 1; i <= (hvar >> 16); i++) {
+    for (UInt i = 1; i <= (hvar >> MAX_FUNC_LVARS_BITS); i++) {
         context = ENVI_FUNC(FUNC_LVARS(context));
     }
 
     // assign the value
-    ASS_LVAR_WITH_CONTEXT(context, hvar & 0xFFFF, val);
+    ASS_LVAR_WITH_CONTEXT(context, hvar & MAX_FUNC_LVARS_MASK, val);
     CHANGED_BAG(context);
 }
 
 Obj OBJ_HVAR_WITH_CONTEXT(Obj context, UInt hvar)
 {
     // walk up the environment chain to the correct values bag
-    for (UInt i = 1; i <= (hvar >> 16); i++) {
+    for (UInt i = 1; i <= (hvar >> MAX_FUNC_LVARS_BITS); i++) {
         context = ENVI_FUNC(FUNC_LVARS(context));
     }
 
     // get the value
-    Obj val = OBJ_LVAR_WITH_CONTEXT(context, hvar & 0xFFFF);
+    Obj val = OBJ_LVAR_WITH_CONTEXT(context, hvar & MAX_FUNC_LVARS_MASK);
 
     // return the value
     return val;
@@ -297,12 +298,12 @@ Obj OBJ_HVAR_WITH_CONTEXT(Obj context, UInt hvar)
 Obj NAME_HVAR_WITH_CONTEXT(Obj context, UInt hvar)
 {
     // walk up the environment chain to the correct values bag
-    for (UInt i = 1; i <= (hvar >> 16); i++) {
+    for (UInt i = 1; i <= (hvar >> MAX_FUNC_LVARS_BITS); i++) {
         context = ENVI_FUNC(FUNC_LVARS(context));
     }
 
     // get the name
-    return NAME_LVAR_WITH_CONTEXT(context, hvar & 0xFFFF);
+    return NAME_LVAR_WITH_CONTEXT(context, hvar & MAX_FUNC_LVARS_MASK);
 }
 
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -349,15 +349,14 @@ Obj             EvalRefHVar (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
+    UInt hvar = (UInt)(ADDR_EXPR(expr)[0]);
 
     /* get and check the value of the higher variable                      */
-    if ( (val = OBJ_HVAR( (UInt)(ADDR_EXPR(expr)[0]) )) == 0 ) {
-        while ( (val = OBJ_HVAR( (UInt)(ADDR_EXPR(expr)[0]) )) == 0 ) {
-            ErrorReturnVoid(
-                "Variable: '%g' must have an assigned value",
-                (Int)NAME_HVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L,
-                "you can 'return;' after assigning a value" );
-        }
+    while ( (val = OBJ_HVAR(hvar)) == 0 ) {
+        ErrorReturnVoid(
+            "Variable: '%g' must have an assigned value",
+            (Int)NAME_HVAR(hvar), 0L,
+            "you can 'return;' after assigning a value" );
     }
 
     /* return the value                                                    */

--- a/tst/test-error/debug-var.g.out
+++ b/tst/test-error/debug-var.g.out
@@ -108,7 +108,7 @@ brk_2> y:=100;
 brk_2> IsBound(y);
 true
 brk_2> unbound_higher;
-Error, Variable: <debug-variable-64-4> must have a value in
+Error, Variable: <debug-variable-1-4> must have a value in
   <corrupted statement>  called from 
 Error( "breakpoint" ); at *stdin*:9 called from
 g( 10 ) at *stdin*:12 called from


### PR DESCRIPTION
... instead of hardcoding these values in various places (which in fact was also done inconsistently before)

Also simplify a check in `EvalRefHVar`

Resolves #2206