### PR TITLE
Fixed the generators in OmegaZero(2m+1,2^k)

### DIFF
--- a/grp/classic.gd
+++ b/grp/classic.gd
@@ -13,22 +13,35 @@
 ##
 ##  <#GAPDoc Label="[1]{classic}">
 ##  The following functions return classical groups.
+##  <P/>
 ##  For the linear, symplectic, and unitary groups (the latter in dimension
 ##  at least <M>3</M>),
 ##  the generators are taken from&nbsp;<Cite Key="Tay87"/>.
 ##  For the unitary groups in dimension <M>2</M>, the isomorphism of
 ##  SU<M>(2,q)</M> and SL<M>(2,q)</M> is used,
 ##  see for example&nbsp;<Cite Key="Hup67"/>.
+##  <P/>
 ##  The generators of the general and special orthogonal groups are taken
 ##  from&nbsp;<Cite Key="IshibashiEarnest94"/> and
 ##  <Cite Key="KleidmanLiebeck90"/>,
 ##  except that the generators of the groups in odd dimension in even
 ##  characteristic are constructed via the isomorphism to a symplectic group,
 ##  see for example&nbsp;<Cite Key="Car72a"/>.
+##  <P/>
 ##  The generators of the groups <M>\Omega^\epsilon(d, q)</M> are taken
 ##  from&nbsp;<Cite Key="RylandsTalor98"/>,
-##  except that the generators of SO<M>(5, 2)</M> are taken for
-##  <M>\Omega(5, 2)</M>.
+##  except that in odd dimension and even characteristic,
+##  the generators of SO<M>(d, q)</M> are taken for <M>\Omega(d, q)</M>.
+##  Note that the generators claimed
+##  in&nbsp;<Cite Key="RylandsTalor98" Where="Section 4.5 and 4.6"/>
+##  do not describe orthogonal groups, one would have to transpose these
+##  matrices in order to get groups that respect the required forms.
+##  The matrices from&nbsp;<Cite Key="RylandsTalor98"/> generate groups
+##  of the right isomorphism types but not orthogonal groups,
+##  except in the case <M>(d,q) = (5,2)</M>,
+##  where the matrices from&nbsp;<Cite Key="RylandsTalor98"/> generate
+##  the simple group <M>S_4(2)'</M> and not the group <M>S_4(2)</M>.
+##  <P/>
 ##  The generators for the semilinear groups are constructed from the
 ##  generators of the corresponding linear groups plus one additional
 ##  generator that describes the action of the group of field automorphisms;

--- a/grp/classic.gi
+++ b/grp/classic.gi
@@ -1491,24 +1491,30 @@ end);
 #F  OmegaZero( <d>, <q> ) . . . . . . . . . . . . . . . . \Omega^0_{<d>}(<q>)
 ##
 BindGlobal( "OmegaZero", function( d, q )
-    local f, o, m, mo, n, i, x1, x2, x, g, xi, h, s, q2, q2i;
+    local f, o, m, mo, n, i, x, g, xi, h, s, q2, q2i;
 
     # <d> must be odd
     if d mod 2 = 0 then
       Error( "<d> must be odd" );
     elif d < 3 then
       Error( "<d> must be at least 3" );
+    elif q mod 2 = 0 then
+      # For even q, the generators claimed in [RylandsTalor98] are wrong:
+      # For (d,q) = (5,2), the matrices generate only S4(2)' not S4(2).
+      # In the other cases, the matrices would have to be transposed
+      # in order to respect a form as required;
+      # thus they describe a group of the right isomorphism type
+      # but not an orthogonal group.
+      # We return the isomorphic group SO(d,q) in these cases;
+      # note that this is the definition of Omega(d,q) for odd d and even q
+      # in the ATLAS of Finite Groups [CCN85, p. xi].
+      return SO( d, q );
     fi;
     f:= GF(q);
     o:= One( f );
     m:= ( d-1 ) / 2;
 
-    if d = 5 and q = 2 then
-      # The matrices given in [RylandsTalor98] generate only A6 not S6.
-      # So we take the isomorphic group SO( 5, 2 ) instead.
-      return SO( 5, 2 );
-
-    elif 3 < d then
+    if 3 < d then
       # Omega(0,d,q) for d=2m+1, m >= 2, Section 4.5
       if d mod 4 = 3 then
         mo:= -o;  # (-1)^m
@@ -1525,22 +1531,11 @@ BindGlobal( "OmegaZero", function( d, q )
         n[ d+1-i ][ d-i ]:= o;
       od;
 
-      if q mod 2 = 0 then
-        # $x = x_{\epsilon_1 - \epsilon_m}(1) x_{-\alpha_1}(1)$
-        x1:= IdentityMat( d, f );
-        x1[1][m]:= o;
-        x1[ m+2 ][d]:= o;
-        x2:= IdentityMat( d, f );
-        x2[ m+1 ][m]:= o;
-        x2[ m+2 ][m]:= o;
-        x:= x1 * x2;
-      else
-        # $x = x_{\alpha_1}(1)$
-        x:= IdentityMat( d, f );
-        x[m][ m+1 ]:= 2*o;
-        x[ m+1 ][ m+2 ]:= -o;
-        x[m][ m+2 ]:= -o;
-      fi;
+      # $x = x_{\alpha_1}(1)$
+      x:= IdentityMat( d, f );
+      x[m][ m+1 ]:= 2*o;
+      x[ m+1 ][ m+2 ]:= -o;
+      x[m][ m+2 ]:= -o;
 
       if q <= 3 then
         # the matrices $x$ and $n$
@@ -1590,17 +1585,12 @@ BindGlobal( "OmegaZero", function( d, q )
     SetSize( g, q^(m^2) * s );
 
     # construct the forms
-      if q mod 2 = 0 then
-      # FIXME: add forms for even characteristic, if that is possible at all
-      # (it doesn't seem to be)
-    else
-      x:= NullMat( d, d, f );
-      for i in [ 1 .. m ] do
-        x[i,d-i+1] := o;
-      od;
-      x[m+1,m+1] := (Characteristic(f)+1)/4*o;
-      SetInvariantQuadraticFormFromMatrix(g, ImmutableMatrix( f, x, true ) );
-    fi;
+    x:= NullMat( d, d, f );
+    for i in [ 1 .. m ] do
+      x[i,d-i+1] := o;
+    od;
+    x[m+1,m+1] := (Characteristic(f)+1)/4*o;
+    SetInvariantQuadraticFormFromMatrix(g, ImmutableMatrix( f, x, true ) );
 
     # and return
     return g;

--- a/tst/testinstall/grp/classic-G.tst
+++ b/tst/testinstall/grp/classic-G.tst
@@ -131,7 +131,7 @@ Error, <subfield> must be a prime or a finite field
 
 #
 gap> Omega(3,2);
-Omega(0,3,2)
+GO(0,3,2)
 gap> Omega(3,3);
 Omega(0,3,3)
 gap> Omega(5,2);

--- a/tst/testinstall/grp/classic-forms.tst
+++ b/tst/testinstall/grp/classic-forms.tst
@@ -126,16 +126,9 @@ gap> for d in [3,5,7] do
 > od;
 gap> ForAll(grps, CheckGeneratorsSpecial);
 true
-
-# FIXME: forms are not implemented for odd d, even q
-# gap> ForAll(grps, CheckBilinearForm);
-# true
-# gap> ForAll(grps, CheckQuadraticForm);
-# true
-#
-gap> ForAll(Filtered(grps, g -> Characteristic(g)<>2), CheckBilinearForm);
+gap> ForAll(grps, CheckBilinearForm);
 true
-gap> ForAll(Filtered(grps, g -> Characteristic(g)<>2), CheckQuadraticForm);
+gap> ForAll(grps, CheckQuadraticForm);
 true
 gap> ForAll(grps, CheckSize);
 true


### PR DESCRIPTION
For odd d and even q,
the generators for the matrix groups Omega(0,d,q)
from the Rylands/Taylor paper were not correct;
one would have to transpose the matrices in order to get
a group that respects a form as required.

Instead of transposing the generators, we delegate to `SO`,
which has the advantage to reduce the possible confusion
about the choice of different forms for related orthogonal groups.

Resolves #2576