### PR TITLE
Improve \= for domains and lists further

### DIFF
--- a/lib/domain.gi
+++ b/lib/domain.gi
@@ -22,8 +22,11 @@ InstallMethod( \=,
     IsIdenticalObj,
     [ IsCollection and IsList, IsDomain ],
     function( C, D )
-    if HasIsFinite(C) and HasIsFinite(D) and (IsFinite(C) <> IsFinite(D)) then
+    if IsFinite(C) <> IsFinite(D) then
       return false;
+    fi;
+    if not IsFinite(D) then
+        Error("no method found for comparing an infinite domain and an infinite list");
     fi;
     return IsSSortedList( C ) and AsSSortedList( D ) = C;
     end );
@@ -40,8 +43,11 @@ InstallMethod( \=,
     IsIdenticalObj,
     [ IsDomain, IsCollection and IsList ],
     function( D, C )
-    if HasIsFinite(C) and HasIsFinite(D) and (IsFinite(C) <> IsFinite(D)) then
+    if IsFinite(C) <> IsFinite(D) then
       return false;
+    fi;
+    if not IsFinite(C) then
+        Error("no method found for comparing an infinite domain and an infinite list");
     fi;
     return IsSSortedList( C ) and AsSSortedList( D ) = C;
     end );
@@ -58,6 +64,12 @@ InstallMethod( \=,
     IsIdenticalObj,
     [ IsDomain, IsDomain ],
     function( D1, D2 )
+    if IsFinite(D1) <> IsFinite(D2) then
+      return false;
+    fi;
+    if not IsFinite(D1) then
+        Error("no method found for comparing two infinite domains");
+    fi;
     return AsSSortedList( D1 ) = AsSSortedList( D2 );
     end );
 

--- a/tst/testinstall/domain.tst
+++ b/tst/testinstall/domain.tst
@@ -1,0 +1,25 @@
+gap> START_TEST("domain.tst");
+
+# equality for a list and an infinite domain
+gap> CF(4)=[E(4)];
+false
+gap> [E(4)]=CF(4);
+false
+
+# equality of a finite and an infinite domain
+gap> M := Magma(0,1,2);;
+gap> SetIsFinite(M, false);
+gap> I := MagmaIdealByGenerators(M,[0]);;
+gap> IsFinite(I);
+true
+gap> J := MagmaIdealByGenerators(M,[2]);;
+gap> SetIsFinite(J, false);
+gap> M = I;
+false
+gap> I = J;
+false
+gap> M = J;
+Error, no method found for comparing two infinite domains
+
+#
+gap> STOP_TEST("domain.tst");

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -19,12 +19,6 @@ false
 gap> [] = l;
 false
 
-# equality for a list and an infinite domain
-gap> CF(4)=[E(4)];
-false
-gap> [E(4)]=CF(4);
-false
-
 #
 # assignment / extraction, also with selectors
 #


### PR DESCRIPTION
In the fallback method for \= for two domains, or for a domain and a list,
always check the finiteness of the two inputs first. While these checks might
not terminate, they are justified anyway: If they do not terminate, then
virtually always, the calls to `AsSSortedList` resp. `IsSSortedList` will not
terminate either.

If one input is finite and the other infinite, we can return false. If both
inputs are infinite, we raise an error, which is more helpful for the user
than trying to enumerate an infinite domains. Since this is the final
fallback method, such an error is justified (no higher ranked method was
triggered).

Only if both inputs are finite do we actually try to compare them as sorted
lists.

This kind of extends PR #2579.