### PR TITLE
Install {8,16,32}Bits_Quotient kernel funcs as methods

### DIFF
--- a/lib/wordrep.gi
+++ b/lib/wordrep.gi
@@ -468,6 +468,12 @@ InstallMethod( \*,
     [ Is8BitsAssocWord, Is8BitsAssocWord ], 0,
     8Bits_Product );
 
+InstallMethod( \/,
+    "for two 8 bits assoc. words",
+    IsIdenticalObj,
+    [ Is8BitsAssocWord, Is8BitsAssocWord and IsMultiplicativeElementWithInverse ], 0,
+    8Bits_Quotient );
+
 InstallMethod( OneOp,
     "for an 8 bits assoc. word-with-one",
     true,
@@ -561,6 +567,12 @@ InstallMethod( \*,
     [ Is16BitsAssocWord, Is16BitsAssocWord ], 0,
     16Bits_Product );
 
+InstallMethod( \/,
+    "for two 16 bits assoc. words",
+    IsIdenticalObj,
+    [ Is16BitsAssocWord, Is16BitsAssocWord and IsMultiplicativeElementWithInverse ], 0,
+    16Bits_Quotient );
+
 InstallMethod( OneOp,
     "for a 16 bits assoc. word-with-one",
     true,
@@ -653,6 +665,12 @@ InstallMethod( \*,
     IsIdenticalObj,
     [ Is32BitsAssocWord, Is32BitsAssocWord ], 0,
     32Bits_Product );
+
+InstallMethod( \/,
+    "for two 32 bits assoc. words",
+    IsIdenticalObj,
+    [ Is32BitsAssocWord, Is32BitsAssocWord and IsMultiplicativeElementWithInverse ], 0,
+    32Bits_Quotient );
 
 InstallMethod( OneOp,
     "for a 32 bits assoc. word-with-one",

--- a/tst/testinstall/wordrep.tst
+++ b/tst/testinstall/wordrep.tst
@@ -197,11 +197,11 @@ gap> words32 := [u32,v32,w32,x32];; ForAll(words32, Is32BitsAssocWord);
 true
 
 #
-gap> SetX(words8, words8, {a,b} -> (a/b) = 8Bits_Quotient(a,b));
+gap> SetX(words8, words8, {a,b} -> (a/b) * b = a);
 [ true ]
-gap> SetX(words16, words16, {a,b} -> (a/b) = 16Bits_Quotient(a,b));
+gap> SetX(words16, words16, {a,b} -> (a/b) * b = a);
 [ true ]
-gap> SetX(words32, words32, {a,b} -> (a/b) = 32Bits_Quotient(a,b));
+gap> SetX(words32, words32, {a,b} -> (a/b) * b = a);
 [ true ]
 
 #


### PR DESCRIPTION
This is an alternative to #2615.

Note that some benchmarks indicate that these kernel functions do provide a noticeable speed up: (here `x32` and `u32` are defined in `tst/testinstall/wordrep.tst`):
```
gap> GASMAN("collect"); for i in [1..1000000] do x:=x32/u32; od; time;
1542
gap> GASMAN("collect"); for i in [1..1000000] do x:=x32/u32; od; time;
1475
gap> GASMAN("collect"); for i in [1..1000000] do x:=32Bits_Quotient(x32,u32); od; time;
91
gap> GASMAN("collect"); for i in [1..1000000] do x:=32Bits_Quotient(x32,u32); od; time;
87
```
But I wonder if there is a reason they were not used?

Resolves #2504. Closes #2615.