### PR TITLE
Fix HighestWeightModule for Lie algebras in certain cases

### DIFF
--- a/lib/lierep.gi
+++ b/lib/lierep.gi
@@ -3282,6 +3282,9 @@ InstallMethod( HighestWeightModule,
         
         o:= n2-n1;
         pos:= PositionProperty( o, x -> x <> 0 );
+        if pos = fail then
+            return false;
+        fi;
         return o[pos] < 0;
     end;
 
@@ -3552,7 +3555,7 @@ InstallMethod( HighestWeightModule,
         # be a factor of `b' if we have `a=b'. So reduction within a
         # weight component is the same as linear algebra. We use the 
         # mutable bases in `sps' to perform the linear algebra.
-                                 
+    
         sps:= [ ];
         sortmn:= [ ];                         
         for j in [1..Length(w)] do

--- a/tst/testbugfix/2018-07-04-HighestWeightModule.tst
+++ b/tst/testbugfix/2018-07-04-HighestWeightModule.tst
@@ -1,0 +1,5 @@
+gap> L := SimpleLieAlgebra("G",2,Rationals);
+<Lie algebra of dimension 14 over Rationals>
+gap> W := HighestWeightModule(L,[4,1]);
+<924-dimensional left-module over <Lie algebra of dimension 
+14 over Rationals>>


### PR DESCRIPTION
This is a regression in GAP 4.9 compared to GAP 4.8. As far as I can tell, it
is caused by the new sort functions; for some reason I don't quite
understand, the new sort ends up comparing an element to itself. But the
custom `lexord` sorting function used by `HighestWeightModule` was not
prepared to deal with two equal (much less identical) inputs.

Fixes #2491 

I suggest to backport this to stable-4.9 -- it can wait for GAP 4.9.3, though, if adding it now is inconvenient.