### PR TITLE
refactor access to function bodies

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -1579,7 +1579,7 @@ void CodeCharExpr (
 
     /* allocate the character expression                                   */
     litr = NewExpr( T_CHAR_EXPR, sizeof(UChar) );
-    ((UChar*)ADDR_EXPR(litr))[0] = chr;
+    WRITE_EXPR(litr, 0, chr);
 
     /* push the literal expression                                         */
     PushExpr( litr );

--- a/src/code.c
+++ b/src/code.c
@@ -319,7 +319,7 @@ static Stat PopSeqStat (
         /* enter the statements into the sequence                          */
         for ( i = nr; 1 <= i; i-- ) {
             stat = PopStat();
-            ADDR_STAT(body)[i-1] = stat;
+            WRITE_STAT(body, i - 1, stat);
         }
     }
 
@@ -348,7 +348,7 @@ static inline Stat PopLoopStat(UInt baseType, UInt extra, UInt nr)
     // enter the statements
     for (UInt i = nr; 1 <= i; i--) {
         Stat stat1 = PopStat();
-        ADDR_STAT(stat)[i + extra - 1] = stat1;
+        WRITE_STAT(stat, i + extra - 1, stat1);
     }
 
     return stat;
@@ -433,7 +433,7 @@ void PushUnaryOp (
 
     /* enter the operand                                                   */
     op = PopExpr();
-    ADDR_EXPR(unop)[0] = op;
+    WRITE_EXPR(unop, 0, op);
 
     /* push the unary operator                                             */
     PushExpr( unop );
@@ -459,11 +459,11 @@ void PushBinaryOp (
 
     /* enter the right operand                                             */
     opR = PopExpr();
-    ADDR_EXPR(binop)[1] = opR;
+    WRITE_EXPR(binop, 1, opR);
 
     /* enter the left operand                                              */
     opL = PopExpr();
-    ADDR_EXPR(binop)[0] = opL;
+    WRITE_EXPR(binop, 0, opL);
 
     /* push the binary operator                                            */
     PushExpr( binop );
@@ -530,8 +530,8 @@ void            CodeFuncCallOptionsEnd ( UInt nr )
     for ( i = nr; 1 <= i; i-- ) {
         entry = PopExpr();
         rnam  = PopExpr();
-        ADDR_EXPR(record)[2*(i-1)]   = rnam;
-        ADDR_EXPR(record)[2*(i-1)+1] = entry;
+        WRITE_EXPR(record, 2 * (i - 1), rnam);
+        WRITE_EXPR(record, 2 * (i - 1) + 1, entry);
     }
 
     /* push the record                                                     */
@@ -656,20 +656,20 @@ void CodeFuncCallEnd (
     /* enter the argument expressions                                      */
     for ( i = nr; 1 <= i; i-- ) {
         arg = PopExpr();
-        ARGI_CALL(call,i) = arg;
+        SET_ARGI_CALL(call, i, arg);
     }
 
     /* enter the function expression                                       */
     func = PopExpr();
-    FUNC_CALL(call) = func;
+    SET_FUNC_CALL(call, func);
 
     /* wrap up the call with the options */
     if (options)
       {
         wrapper = NewExpr( funccall ? T_FUNCCALL_OPTS : T_PROCCALL_OPTS, 
                            2*sizeof(Expr));
-        ADDR_EXPR(wrapper)[0] = opts;
-        ADDR_EXPR(wrapper)[1] = call;
+        WRITE_EXPR(wrapper, 0, opts);
+        WRITE_EXPR(wrapper, 1, call);
         call = wrapper;
       }
 
@@ -796,7 +796,7 @@ void CodeFuncExprEnd(UInt nr)
     STAT_HEADER(OFFSET_FIRST_STAT)->type = T_SEQ_STAT+nr-1;
     for ( i = 1; i <= nr; i++ ) {
         stat1 = PopStat();
-        ADDR_STAT(OFFSET_FIRST_STAT)[nr-i] = stat1;
+        WRITE_STAT(OFFSET_FIRST_STAT, nr - i, stat1);
     }
 
     // make the function expression list immutable
@@ -818,7 +818,7 @@ void CodeFuncExprEnd(UInt nr)
         fexs = FEXS_FUNC( CURR_FUNC() );
         len = PushPlist( fexs, fexp );
         expr = NewExpr( T_FUNC_EXPR, sizeof(Expr) );
-        ADDR_EXPR(expr)[0] = (Expr)len;
+        WRITE_EXPR(expr, 0, len);
         PushExpr( expr );
     }
 
@@ -949,8 +949,8 @@ void CodeIfEnd (
     for ( i = nr; 1 <= i; i-- ) {
         Stat body = PopStat();
         cond = PopExpr();
-        ADDR_STAT(stat)[2*(i-1)] = cond;
-        ADDR_STAT(stat)[2*(i-1)+1] = body;
+        WRITE_STAT(stat, 2 * (i - 1), cond);
+        WRITE_STAT(stat, 2 * (i - 1) + 1, body);
     }
 
     /* push the if-statement                                               */
@@ -994,7 +994,7 @@ void CodeForIn ( void )
   Expr var = PopExpr();
   if (TNUM_EXPR(var) == T_REF_GVAR)
     {
-      PushGlobalForLoopVariable((UInt)ADDR_EXPR(var)[0]);
+      PushGlobalForLoopVariable(READ_EXPR(var, 0));
     }
   PushExpr(var);
 }
@@ -1033,10 +1033,10 @@ void CodeForEndBody (
     stat = PopLoopStat(type, 2, nr);
 
     /* enter the list expression                                           */
-    ADDR_STAT(stat)[1] = list;
+    WRITE_STAT(stat, 1, list);
 
     /* enter the variable reference                                        */
-    ADDR_STAT(stat)[0] = var;
+    WRITE_STAT(stat, 0, var);
 
     /* push the for-statement                                              */
     PushStat( stat );
@@ -1099,14 +1099,14 @@ void CodeAtomicEndBody (
     stat = NewStat( T_ATOMIC, sizeof(Stat) + nrexprs*2*sizeof(Stat) );
     
     /* enter the statement sequence */
-    ADDR_STAT(stat)[0] = stat1;
+    WRITE_STAT(stat, 0, stat1);
 
     /* enter the expressions                                                */
     for ( i = 2*nrexprs; 1 <= i; i -= 2 ) {
         e = PopExpr();
         qual = PopExpr();
-        ADDR_STAT(stat)[i] = e;
-        ADDR_STAT(stat)[i-1] = qual;
+        WRITE_STAT(stat, i, e);
+        WRITE_STAT(stat, i - 1, qual);
     }
 
     /* push the atomic-statement                                            */
@@ -1189,7 +1189,7 @@ void CodeWhileEndBody (
 
     /* enter the condition                                                 */
     cond = PopExpr();
-    ADDR_STAT(stat)[0] = cond;
+    WRITE_STAT(stat, 0, cond);
 
     /* push the while-statement                                            */
     PushStat( stat );
@@ -1257,7 +1257,7 @@ void CodeRepeatEnd ( void )
     stat = PopLoopStat(T_REPEAT, 1, nr);
 
     /* enter the condition                                                 */
-    ADDR_STAT(stat)[0] = cond;
+    WRITE_STAT(stat, 0, cond);
 
     /* push the repeat-statement                                           */
     PushStat( stat );
@@ -1319,7 +1319,7 @@ void CodeReturnObj ( void )
 
     /* enter the expression                                                */
     expr = PopExpr();
-    ADDR_STAT(stat)[0] = expr;
+    WRITE_STAT(stat, 0, expr);
 
     /* push the return-statement                                           */
     PushStat( stat );
@@ -1522,7 +1522,7 @@ void CodeIntExpr(Obj val)
     else {
         GAP_ASSERT(TNUM_OBJ(val) == T_INTPOS || TNUM_OBJ(val) == T_INTNEG);
         expr = NewExpr( T_INT_EXPR, sizeof(UInt) + SIZE_OBJ(val) );
-        ((UInt *)ADDR_EXPR(expr))[0] = (UInt)TNUM_OBJ(val);
+        WRITE_EXPR(expr, 0, TNUM_OBJ(val));
         memcpy((UInt *)ADDR_EXPR(expr)+1, CONST_ADDR_OBJ(val), (size_t)SIZE_OBJ(val));
     }
 
@@ -1614,7 +1614,7 @@ void CodePermCycle (
     /* enter the entries                                                   */
     for ( j = nrx; 1 <= j; j-- ) {
         entry = PopExpr();
-        ADDR_EXPR(cycle)[j-1] = entry;
+        WRITE_EXPR(cycle, j - 1, entry);
     }
 
     /* push the cycle                                                      */
@@ -1634,7 +1634,7 @@ void CodePerm (
     /* enter the cycles                                                    */
     for ( i = nrc; 1 <= i; i-- ) {
         cycle = PopExpr();
-        ADDR_EXPR(perm)[i-1] = cycle;
+        WRITE_EXPR(perm, i - 1, cycle);
     }
 
     /* push the permutation                                                */
@@ -1703,7 +1703,7 @@ void CodeListExprEnd (
     for ( i = nr; 1 <= i; i-- ) {
         entry = PopExpr();
         pos   = PopExpr();
-        ADDR_EXPR(list)[ INT_INTEXPR(pos)-1 ] = entry;
+        WRITE_EXPR(list, INT_INTEXPR(pos) - 1, entry);
     }
 
     /* push the list                                                       */
@@ -1811,11 +1811,11 @@ static void CodeLazyFloatExpr(Char * str, UInt len)
     /* copy the string                                                     */
     memcpy((char *)ADDR_EXPR(fl) + 2 * sizeof(UInt), str, len + 1);
 
-    *(UInt *)ADDR_EXPR(fl) = len;
+    WRITE_EXPR(fl, 0, len);
     ix = CheckForCommonFloat(str);
     if (!ix)
         ix = getNextFloatExprNumber();
-    ((UInt *)ADDR_EXPR(fl))[1] = ix;
+    WRITE_EXPR(fl, 1, ix);
 
     /* push the expression */
     PushExpr(fl);
@@ -1836,9 +1836,9 @@ static void CodeEagerFloatExpr(Obj str, Char mark)
     assert(IS_PLIST(EAGER_FLOAT_LITERAL_CACHE));
     ix = PushPlist(EAGER_FLOAT_LITERAL_CACHE, v);
 #endif
-    ADDR_EXPR(fl)[0] = ix;
-    ADDR_EXPR(fl)[1] = l;
-    ADDR_EXPR(fl)[2] = (UInt)mark;
+    WRITE_EXPR(fl, 0, ix);
+    WRITE_EXPR(fl, 1, l);
+    WRITE_EXPR(fl, 2, (UInt)mark);
     memcpy(ADDR_EXPR(fl) + 3, CHARS_STRING(str), l + 1);
     PushExpr(fl);
 }
@@ -1957,8 +1957,8 @@ void CodeRecExprEnd (
     for ( i = nr; 1 <= i; i-- ) {
         entry = PopExpr();
         rnam  = PopExpr();
-        ADDR_EXPR(record)[2*(i-1)]   = rnam;
-        ADDR_EXPR(record)[2*(i-1)+1] = entry;
+        WRITE_EXPR(record, 2 * (i - 1), rnam);
+        WRITE_EXPR(record, 2 * (i - 1) + 1, entry);
     }
 
     /* push the record                                                     */
@@ -1989,10 +1989,10 @@ void CodeAssLVar (
 
     /* enter the right hand side expression                                */
     rhsx = PopExpr();
-    ADDR_STAT(ass)[1] = (Stat)rhsx;
+    WRITE_STAT(ass, 1, rhsx);
 
     /* enter the local variable                                            */
-    ADDR_STAT(ass)[0] = (Stat)lvar;
+    WRITE_STAT(ass, 0, lvar);
 
     /* push the assignment                                                 */
     PushStat( ass );
@@ -2012,7 +2012,7 @@ void CodeUnbLVar (
     ass = NewStat( T_UNB_LVAR, sizeof(Stat) );
 
     /* enter the local variable                                            */
-    ADDR_STAT(ass)[0] = (Stat)lvar;
+    WRITE_STAT(ass, 0, lvar);
 
     /* push the unbind                                                     */
     PushStat( ass );
@@ -2056,7 +2056,7 @@ void CodeIsbLVar (
     ref = NewExpr( T_ISB_LVAR, sizeof(Expr) );
 
     /* enter the local variable                                            */
-    ADDR_EXPR(ref)[0] = (Expr)lvar;
+    WRITE_EXPR(ref, 0, lvar);
 
     /* push the isbound                                                    */
     PushExpr( ref );
@@ -2086,10 +2086,10 @@ void CodeAssHVar (
 
     /* enter the right hand side expression                                */
     rhsx = PopExpr();
-    ADDR_STAT(ass)[1] = (Stat)rhsx;
+    WRITE_STAT(ass, 1, rhsx);
 
     /* enter the higher variable                                           */
-    ADDR_STAT(ass)[0] = (Stat)hvar;
+    WRITE_STAT(ass, 0, hvar);
 
     /* push the assignment                                                 */
     PushStat( ass );
@@ -2109,7 +2109,7 @@ void CodeUnbHVar (
     ass = NewStat( T_UNB_HVAR, sizeof(Stat) );
 
     /* enter the higher variable                                           */
-    ADDR_STAT(ass)[0] = (Stat)hvar;
+    WRITE_STAT(ass, 0, hvar);
 
     /* push the unbind                                                     */
     PushStat( ass );
@@ -2136,7 +2136,7 @@ void CodeRefHVar (
     ref = NewExpr( T_REF_HVAR, sizeof(Expr) );
 
     /* enter the higher variable                                           */
-    ADDR_EXPR(ref)[0] = (Expr)hvar;
+    WRITE_EXPR(ref, 0, hvar);
 
     /* push the reference                                                  */
     PushExpr( ref );
@@ -2156,7 +2156,7 @@ void CodeIsbHVar (
     ref = NewExpr( T_ISB_HVAR, sizeof(Expr) );
 
     /* enter the higher variable                                           */
-    ADDR_EXPR(ref)[0] = (Expr)hvar;
+    WRITE_EXPR(ref, 0, hvar);
 
     /* push the isbound                                                    */
     PushExpr( ref );
@@ -2186,10 +2186,10 @@ void CodeAssGVar (
 
     /* enter the right hand side expression                                */
     rhsx = PopExpr();
-    ADDR_STAT(ass)[1] = (Stat)rhsx;
+    WRITE_STAT(ass, 1, rhsx);
 
     /* enter the global variable                                           */
-    ADDR_STAT(ass)[0] = (Stat)gvar;
+    WRITE_STAT(ass, 0, gvar);
 
     /* push the assignment                                                 */
     PushStat( ass );
@@ -2209,7 +2209,7 @@ void CodeUnbGVar (
     ass = NewStat( T_UNB_GVAR, sizeof(Stat) );
 
     /* enter the global variable                                           */
-    ADDR_STAT(ass)[0] = (Stat)gvar;
+    WRITE_STAT(ass, 0, gvar);
 
     /* push the unbind                                                     */
     PushStat( ass );
@@ -2235,7 +2235,7 @@ void CodeRefGVar (
     ref = NewExpr( T_REF_GVAR, sizeof(Expr) );
 
     /* enter the global variable                                           */
-    ADDR_EXPR(ref)[0] = (Expr)gvar;
+    WRITE_EXPR(ref, 0, gvar);
 
     /* push the reference                                                  */
     PushExpr( ref );
@@ -2255,7 +2255,7 @@ void CodeIsbGVar (
     ref = NewExpr( T_ISB_GVAR, sizeof(Expr) );
 
     /* enter the global variable                                           */
-    ADDR_EXPR(ref)[0] = (Expr)gvar;
+    WRITE_EXPR(ref, 0, gvar);
 
     /* push the isbound                                                    */
     PushExpr( ref );
@@ -2280,17 +2280,17 @@ void CodeAssListUniv (
 
     /* enter the right hand side expression                                */
     rhsx = PopExpr();
-    ADDR_STAT(ass)[narg+1] = (Stat)rhsx;
+    WRITE_STAT(ass, narg + 1, rhsx);
 
     /* enter the position expression                                       */
     for (i = narg; i > 0; i--) {
       pos = PopExpr();
-      ADDR_STAT(ass)[i] = (Stat)pos;
+      WRITE_STAT(ass, i, pos);
     }
 
     /* enter the list expression                                           */
     list = PopExpr();
-    ADDR_STAT(ass)[0] = (Stat)list;
+    WRITE_STAT(ass, 0, list);
 
     /* push the assignment                                                 */
     PushStat( ass );
@@ -2330,7 +2330,7 @@ void CodeAssListLevel ( Int narg,
 
     /* allocate the assignment and enter the level                         */
     ass = NewStat( T_ASS_LIST_LEV, (narg + 3) * sizeof(Stat) );
-    ADDR_STAT(ass)[narg+2] = (Stat)level;
+    WRITE_STAT(ass, narg + 2, level);
 
     /* let 'CodeAssListUniv' do the rest                                   */
     CodeAssListUniv( ass, narg );
@@ -2343,7 +2343,7 @@ void CodeAsssListLevel (
 
     /* allocate the assignment and enter the level                         */
     ass = NewStat( T_ASSS_LIST_LEV, 4 * sizeof(Stat) );
-    ADDR_STAT(ass)[3] = (Stat)level;
+    WRITE_STAT(ass, 3, level);
 
     /* let 'CodeAssListUniv' do the rest                                   */
     CodeAssListUniv( ass, 1 );
@@ -2367,12 +2367,12 @@ void CodeUnbList ( Int narg )
     /* enter the position expressions                                       */
     for (i = narg; i > 0; i--) {
       pos = PopExpr();
-      ADDR_STAT(ass)[i] = (Stat)pos;
+      WRITE_STAT(ass, i, pos);
     }
 
     /* enter the list expression                                           */
     list = PopExpr();
-    ADDR_STAT(ass)[0] = (Stat)list;
+    WRITE_STAT(ass, 0, list);
 
     /* push the unbind                                                     */
     PushStat( ass );
@@ -2398,12 +2398,12 @@ void CodeElmListUniv (
 
     for (i = narg; i > 0; i--) {
       pos = PopExpr();
-      ADDR_EXPR(ref)[i] = pos;
+      WRITE_EXPR(ref, i, pos);
     }
 
     /* enter the list expression                                           */
     list = PopExpr();
-    ADDR_EXPR(ref)[0] = list;
+    WRITE_EXPR(ref, 0, list);
 
     /* push the reference                                                  */
     PushExpr( ref );
@@ -2443,7 +2443,7 @@ void CodeElmListLevel ( Int narg,
 
     /* allocate the reference and enter the level                          */
     ref = NewExpr( T_ELM_LIST_LEV, (narg + 2) * sizeof(Expr));
-    ADDR_EXPR(ref)[narg+1] = (Stat)level;
+    WRITE_EXPR(ref, narg + 1, level);
 
     /* let 'CodeElmListUniv' do the rest                                   */
     CodeElmListUniv( ref, narg );
@@ -2456,7 +2456,7 @@ void CodeElmsListLevel (
 
     /* allocate the reference and enter the level                          */
     ref = NewExpr( T_ELMS_LIST_LEV, 3 * sizeof(Expr) );
-    ADDR_EXPR(ref)[2] = (Stat)level;
+    WRITE_EXPR(ref, 2, level);
 
     /* let 'CodeElmListUniv' do the rest                                   */
     CodeElmListUniv( ref, 1 );
@@ -2480,12 +2480,12 @@ void CodeIsbList ( Int narg )
     /* enter the position expression                                       */
     for (i = narg; i > 0; i--) {
       pos = PopExpr();
-      ADDR_EXPR(ref)[i] = pos;
+      WRITE_EXPR(ref, i, pos);
     }
 
     /* enter the list expression                                           */
     list = PopExpr();
-    ADDR_EXPR(ref)[0] = list;
+    WRITE_EXPR(ref, 0, list);
 
     /* push the isbound                                                    */
     PushExpr( ref );
@@ -2509,14 +2509,14 @@ void            CodeAssRecName (
 
     /* enter the right hand side expression                                */
     rhsx = PopExpr();
-    ADDR_STAT(stat)[2] = (Stat)rhsx;
+    WRITE_STAT(stat, 2, rhsx);
 
     /* enter the name                                                      */
-    ADDR_STAT(stat)[1] = (Stat)rnam;
+    WRITE_STAT(stat, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_STAT(stat)[0] = (Stat)rec;
+    WRITE_STAT(stat, 0, rec);
 
     /* push the assignment                                                 */
     PushStat( stat );
@@ -2534,15 +2534,15 @@ void            CodeAssRecExpr ( void )
 
     /* enter the right hand side expression                                */
     rhsx = PopExpr();
-    ADDR_STAT(stat)[2] = (Stat)rhsx;
+    WRITE_STAT(stat, 2, rhsx);
 
     /* enter the name expression                                           */
     rnam = PopExpr();
-    ADDR_STAT(stat)[1] = (Stat)rnam;
+    WRITE_STAT(stat, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_STAT(stat)[0] = (Stat)rec;
+    WRITE_STAT(stat, 0, rec);
 
     /* push the assignment                                                 */
     PushStat( stat );
@@ -2558,11 +2558,11 @@ void            CodeUnbRecName (
     stat = NewStat( T_UNB_REC_NAME, 2 * sizeof(Stat) );
 
     /* enter the name                                                      */
-    ADDR_STAT(stat)[1] = (Stat)rnam;
+    WRITE_STAT(stat, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_STAT(stat)[0] = (Stat)rec;
+    WRITE_STAT(stat, 0, rec);
 
     /* push the unbind                                                     */
     PushStat( stat );
@@ -2579,11 +2579,11 @@ void            CodeUnbRecExpr ( void )
 
     /* enter the name expression                                           */
     rnam = PopExpr();
-    ADDR_STAT(stat)[1] = (Stat)rnam;
+    WRITE_STAT(stat, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_STAT(stat)[0] = (Stat)rec;
+    WRITE_STAT(stat, 0, rec);
 
     /* push the unbind                                                     */
     PushStat( stat );
@@ -2605,11 +2605,11 @@ void CodeElmRecName (
     expr = NewExpr( T_ELM_REC_NAME, 2 * sizeof(Expr) );
 
     /* enter the name                                                      */
-    ADDR_EXPR(expr)[1] = (Expr)rnam;
+    WRITE_EXPR(expr, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_EXPR(expr)[0] = rec;
+    WRITE_EXPR(expr, 0, rec);
 
     /* push the reference                                                  */
     PushExpr( expr );
@@ -2626,11 +2626,11 @@ void CodeElmRecExpr ( void )
 
     /* enter the expression                                                */
     rnam = PopExpr();
-    ADDR_EXPR(expr)[1] = rnam;
+    WRITE_EXPR(expr, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_EXPR(expr)[0] = rec;
+    WRITE_EXPR(expr, 0, rec);
 
     /* push the reference                                                  */
     PushExpr( expr );
@@ -2651,11 +2651,11 @@ void CodeIsbRecName (
     expr = NewExpr( T_ISB_REC_NAME, 2 * sizeof(Expr) );
 
     /* enter the name                                                      */
-    ADDR_EXPR(expr)[1] = (Expr)rnam;
+    WRITE_EXPR(expr, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_EXPR(expr)[0] = rec;
+    WRITE_EXPR(expr, 0, rec);
 
     /* push the isbound                                                    */
     PushExpr( expr );
@@ -2677,11 +2677,11 @@ void CodeIsbRecExpr ( void )
 
     /* enter the expression                                                */
     rnam = PopExpr();
-    ADDR_EXPR(expr)[1] = rnam;
+    WRITE_EXPR(expr, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_EXPR(expr)[0] = rec;
+    WRITE_EXPR(expr, 0, rec);
 
     /* push the isbound                                                    */
     PushExpr( expr );
@@ -2704,15 +2704,15 @@ void CodeAssPosObjUniv (
 
     /* enter the right hand side expression                                */
     rhsx = PopExpr();
-    ADDR_STAT(ass)[2] = (Stat)rhsx;
+    WRITE_STAT(ass, 2, rhsx);
 
     /* enter the position expression                                       */
     pos = PopExpr();
-    ADDR_STAT(ass)[1] = (Stat)pos;
+    WRITE_STAT(ass, 1, pos);
 
     /* enter the list expression                                           */
     list = PopExpr();
-    ADDR_STAT(ass)[0] = (Stat)list;
+    WRITE_STAT(ass, 0, list);
 
     /* push the assignment                                                 */
     PushStat( ass );
@@ -2747,7 +2747,7 @@ void CodeAssPosObjLevel (
 
     /* allocate the assignment and enter the level                         */
     ass = NewStat( T_ASS_POSOBJ_LEV, 4 * sizeof(Stat) );
-    ADDR_STAT(ass)[3] = (Stat)level;
+    WRITE_STAT(ass, 3, level);
 
     /* let 'CodeAssPosObjUniv' do the rest                                 */
     CodeAssPosObjUniv( ass );
@@ -2760,7 +2760,7 @@ void CodeAsssPosObjLevel (
 
     /* allocate the assignment and enter the level                         */
     ass = NewStat( T_ASSS_POSOBJ_LEV, 4 * sizeof(Stat) );
-    ADDR_STAT(ass)[3] = (Stat)level;
+    WRITE_STAT(ass, 3, level);
 
     /* let 'CodeAssPosObjUniv' do the rest                                 */
     CodeAssPosObjUniv( ass );
@@ -2782,11 +2782,11 @@ void CodeUnbPosObj ( void )
 
     /* enter the position expression                                       */
     pos = PopExpr();
-    ADDR_STAT(ass)[1] = (Stat)pos;
+    WRITE_STAT(ass, 1, pos);
 
     /* enter the list expression                                           */
     list = PopExpr();
-    ADDR_STAT(ass)[0] = (Stat)list;
+    WRITE_STAT(ass, 0, list);
 
     /* push the unbind                                                     */
     PushStat( ass );
@@ -2808,11 +2808,11 @@ void CodeElmPosObjUniv (
 
     /* enter the position expression                                       */
     pos = PopExpr();
-    ADDR_EXPR(ref)[1] = pos;
+    WRITE_EXPR(ref, 1, pos);
 
     /* enter the list expression                                           */
     list = PopExpr();
-    ADDR_EXPR(ref)[0] = list;
+    WRITE_EXPR(ref, 0, list);
 
     /* push the reference                                                  */
     PushExpr( ref );
@@ -2847,7 +2847,7 @@ void CodeElmPosObjLevel (
 
     /* allocate the reference and enter the level                          */
     ref = NewExpr( T_ELM_POSOBJ_LEV, 3 * sizeof(Expr) );
-    ADDR_EXPR(ref)[2] = (Stat)level;
+    WRITE_EXPR(ref, 2, level);
 
     /* let 'CodeElmPosObjUniv' do the rest                                 */
     CodeElmPosObjUniv( ref );
@@ -2860,7 +2860,7 @@ void CodeElmsPosObjLevel (
 
     /* allocate the reference and enter the level                          */
     ref = NewExpr( T_ELMS_POSOBJ_LEV, 3 * sizeof(Expr) );
-    ADDR_EXPR(ref)[2] = (Stat)level;
+    WRITE_EXPR(ref, 2, level);
 
     /* let 'CodeElmPosObjUniv' do the rest                                 */
     CodeElmPosObjUniv( ref );
@@ -2882,11 +2882,11 @@ void CodeIsbPosObj ( void )
 
     /* enter the position expression                                       */
     pos = PopExpr();
-    ADDR_EXPR(ref)[1] = pos;
+    WRITE_EXPR(ref, 1, pos);
 
     /* enter the list expression                                           */
     list = PopExpr();
-    ADDR_EXPR(ref)[0] = list;
+    WRITE_EXPR(ref, 0, list);
 
     /* push the isbound                                                    */
     PushExpr( ref );
@@ -2910,14 +2910,14 @@ void            CodeAssComObjName (
 
     /* enter the right hand side expression                                */
     rhsx = PopExpr();
-    ADDR_STAT(stat)[2] = (Stat)rhsx;
+    WRITE_STAT(stat, 2, rhsx);
 
     /* enter the name                                                      */
-    ADDR_STAT(stat)[1] = (Stat)rnam;
+    WRITE_STAT(stat, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_STAT(stat)[0] = (Stat)rec;
+    WRITE_STAT(stat, 0, rec);
 
     /* push the assignment                                                 */
     PushStat( stat );
@@ -2935,15 +2935,15 @@ void            CodeAssComObjExpr ( void )
 
     /* enter the right hand side expression                                */
     rhsx = PopExpr();
-    ADDR_STAT(stat)[2] = (Stat)rhsx;
+    WRITE_STAT(stat, 2, rhsx);
 
     /* enter the name expression                                           */
     rnam = PopExpr();
-    ADDR_STAT(stat)[1] = (Stat)rnam;
+    WRITE_STAT(stat, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_STAT(stat)[0] = (Stat)rec;
+    WRITE_STAT(stat, 0, rec);
 
     /* push the assignment                                                 */
     PushStat( stat );
@@ -2959,11 +2959,11 @@ void            CodeUnbComObjName (
     stat = NewStat( T_UNB_COMOBJ_NAME, 2 * sizeof(Stat) );
 
     /* enter the name                                                      */
-    ADDR_STAT(stat)[1] = (Stat)rnam;
+    WRITE_STAT(stat, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_STAT(stat)[0] = (Stat)rec;
+    WRITE_STAT(stat, 0, rec);
 
     /* push the unbind                                                     */
     PushStat( stat );
@@ -2980,11 +2980,11 @@ void            CodeUnbComObjExpr ( void )
 
     /* enter the name expression                                           */
     rnam = PopExpr();
-    ADDR_STAT(stat)[1] = (Stat)rnam;
+    WRITE_STAT(stat, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_STAT(stat)[0] = (Stat)rec;
+    WRITE_STAT(stat, 0, rec);
 
     /* push the unbind                                                     */
     PushStat( stat );
@@ -3006,11 +3006,11 @@ void CodeElmComObjName (
     expr = NewExpr( T_ELM_COMOBJ_NAME, 2 * sizeof(Expr) );
 
     /* enter the name                                                      */
-    ADDR_EXPR(expr)[1] = (Expr)rnam;
+    WRITE_EXPR(expr, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_EXPR(expr)[0] = rec;
+    WRITE_EXPR(expr, 0, rec);
 
     /* push the reference                                                  */
     PushExpr( expr );
@@ -3027,11 +3027,11 @@ void CodeElmComObjExpr ( void )
 
     /* enter the expression                                                */
     rnam = PopExpr();
-    ADDR_EXPR(expr)[1] = rnam;
+    WRITE_EXPR(expr, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_EXPR(expr)[0] = rec;
+    WRITE_EXPR(expr, 0, rec);
 
     /* push the reference                                                  */
     PushExpr( expr );
@@ -3052,11 +3052,11 @@ void CodeIsbComObjName (
     expr = NewExpr( T_ISB_COMOBJ_NAME, 2 * sizeof(Expr) );
 
     /* enter the name                                                      */
-    ADDR_EXPR(expr)[1] = (Expr)rnam;
+    WRITE_EXPR(expr, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_EXPR(expr)[0] = rec;
+    WRITE_EXPR(expr, 0, rec);
 
     /* push the isbound                                                    */
     PushExpr( expr );
@@ -3077,11 +3077,11 @@ void CodeIsbComObjExpr ( void )
 
     /* enter the expression                                                */
     rnam = PopExpr();
-    ADDR_EXPR(expr)[1] = rnam;
+    WRITE_EXPR(expr, 1, rnam);
 
     /* enter the record expression                                         */
     rec = PopExpr();
-    ADDR_EXPR(expr)[0] = rec;
+    WRITE_EXPR(expr, 0, rec);
 
     /* push the isbound                                                    */
     PushExpr( expr );
@@ -3133,7 +3133,7 @@ void CodeInfoEnd   (
     /* narg only counts the printable arguments                            */
     for ( i = narg + 2; 0 < i; i-- ) {
         expr = PopExpr();
-        ARGI_INFO( stat, i ) = expr;
+        SET_ARGI_INFO(stat, i, expr);
     }
 
     /* push the statement                                                  */
@@ -3169,8 +3169,8 @@ void CodeAssertEnd2Args ( void )
 
     stat = NewStat( T_ASSERT_2ARGS, 2*sizeof(Expr) );
 
-    ADDR_STAT(stat)[1] = PopExpr(); /* condition */
-    ADDR_STAT(stat)[0] = PopExpr(); /* level */
+    WRITE_STAT(stat, 1, PopExpr()); /* condition */
+    WRITE_STAT(stat, 0, PopExpr()); /* level */
 
     PushStat( stat );
 }
@@ -3181,9 +3181,9 @@ void CodeAssertEnd3Args ( void )
 
     stat = NewStat( T_ASSERT_3ARGS, 3*sizeof(Expr) );
 
-    ADDR_STAT(stat)[2] = PopExpr(); /* message */
-    ADDR_STAT(stat)[1] = PopExpr(); /* condition */
-    ADDR_STAT(stat)[0] = PopExpr(); /* level */
+    WRITE_STAT(stat, 2, PopExpr()); /* message */
+    WRITE_STAT(stat, 1, PopExpr()); /* condition */
+    WRITE_STAT(stat, 0, PopExpr()); /* level */
 
     PushStat( stat );
 }

--- a/src/code.h
+++ b/src/code.h
@@ -236,6 +236,8 @@ enum STAT_TNUM {
 
 
 #define STAT_HEADER(stat) (((StatHeader *)ADDR_STAT(stat)) - 1)
+#define CONST_STAT_HEADER(stat)                                              \
+    (((const StatHeader *)CONST_ADDR_STAT(stat)) - 1)
 
 
 /****************************************************************************
@@ -244,7 +246,7 @@ enum STAT_TNUM {
 **
 **  'TNUM_STAT' returns the type of the statement <stat>.
 */
-#define TNUM_STAT(stat) (STAT_HEADER(stat)->type)
+#define TNUM_STAT(stat) (CONST_STAT_HEADER(stat)->type)
 
 
 /****************************************************************************
@@ -253,7 +255,7 @@ enum STAT_TNUM {
 **
 **  'SIZE_STAT' returns the size of the statement <stat>.
 */
-#define SIZE_STAT(stat) (STAT_HEADER(stat)->size)
+#define SIZE_STAT(stat) (CONST_STAT_HEADER(stat)->size)
 
 /****************************************************************************
 **
@@ -261,7 +263,7 @@ enum STAT_TNUM {
 **
 **  'LINE_STAT' returns the line number of the statement <stat>.
 */
-#define LINE_STAT(stat) (STAT_HEADER(stat)->line)
+#define LINE_STAT(stat) (CONST_STAT_HEADER(stat)->line)
 
 /****************************************************************************
 **
@@ -270,8 +272,7 @@ enum STAT_TNUM {
 **  'VISITED_STAT' returns true if the statement has ever been executed
 **  while profiling is turned on.
 */
-#define VISITED_STAT(stat) (STAT_HEADER(stat)->visited)
-
+#define VISITED_STAT(stat) (CONST_STAT_HEADER(stat)->visited)
 
 
 /****************************************************************************
@@ -281,8 +282,12 @@ enum STAT_TNUM {
 **  'ADDR_STAT' returns   the  absolute address of the    memory block of the
 **  statement <stat>.
 */
-#define ADDR_STAT(stat) ((Stat*)(((char*)STATE(PtrBody))+(stat)))
+#define ADDR_STAT(stat) ((Stat *)(((char *)STATE(PtrBody)) + (stat)))
+#define CONST_ADDR_STAT(stat)                                                \
+    ((const Stat *)(((const char *)STATE(PtrBody)) + (stat)))
 
+#define READ_STAT(stat, idx) (CONST_ADDR_STAT(stat)[idx])
+#define WRITE_STAT(stat, idx, val) ADDR_STAT(stat)[idx] = val
 
 /****************************************************************************
 **
@@ -466,7 +471,10 @@ enum EXPR_TNUM {
 **  'T_REFLVAR' or 'T_INTEXPR'.
 */
 #define ADDR_EXPR(expr) ADDR_STAT(expr)
+#define CONST_ADDR_EXPR(expr) CONST_ADDR_STAT(expr)
 
+#define READ_EXPR(expr, idx) (CONST_ADDR_EXPR(expr)[idx])
+#define WRITE_EXPR(expr, idx, val) ADDR_EXPR(expr)[idx] = val
 
 /****************************************************************************
 **
@@ -489,8 +497,10 @@ enum EXPR_TNUM {
 **  'SIZE_NARG_CALL' returns the size a  function call bag  should have for a
 **  function call bag with <narg> arguments.
 */
-#define FUNC_CALL(call)         (* (ADDR_EXPR((call)) +0     ) )
-#define ARGI_CALL(call,i)       (* (ADDR_EXPR((call)) +0 +(i)) )
+#define SET_FUNC_CALL(call,x)   WRITE_EXPR(call, 0, x)
+#define SET_ARGI_CALL(call,i,x) WRITE_EXPR(call, i, x)
+#define FUNC_CALL(call)         READ_EXPR(call, 0)
+#define ARGI_CALL(call,i)       READ_EXPR(call, i)
 #define NARG_SIZE_CALL(size)    (((size) / sizeof(Expr)) - 1)
 #define SIZE_NARG_CALL(narg)    (((narg) + 1) * sizeof(Expr))
 
@@ -511,7 +521,8 @@ enum EXPR_TNUM {
 **  'SIZE_NARG_INFO' returns the size a  function call bag  should have for a
 **  function call bag with <narg> arguments.
 */
-#define ARGI_INFO(info,i)       (* (ADDR_STAT((info))+(i) -1) )
+#define SET_ARGI_INFO(info,i,x) WRITE_STAT(info, (i) - 1, x)
+#define ARGI_INFO(info,i)       READ_STAT(info, (i) - 1)
 #define NARG_SIZE_INFO(size)    ((size) / sizeof(Expr))
 #define SIZE_NARG_INFO(narg)    ((narg) * sizeof(Expr))
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1027,7 +1027,7 @@ CVar CompFunccall0to6Args (
     /* special case to inline 'Length'                                     */
     if ( CompFastListFuncs
       && TNUM_EXPR( FUNC_CALL(expr) ) == T_REF_GVAR
-      && ADDR_EXPR( FUNC_CALL(expr) )[0] == G_Length
+      && READ_EXPR( FUNC_CALL(expr), 0 ) == G_Length
       && NARG_SIZE_CALL(SIZE_EXPR(expr)) == 1 ) {
         result = CVAR_TEMP( NewTemp( "result" ) );
         args[1] = CompExpr( ARGI_CALL(expr,1) );
@@ -1142,7 +1142,7 @@ CVar CompFunccallXArgs (
 CVar CompFunccallOpts(
                       Expr expr)
 {
-  CVar opts = CompExpr(ADDR_STAT(expr)[0]);
+  CVar opts = CompExpr(READ_STAT(expr, 0));
   GVar pushOptions;
   GVar popOptions;
   CVar result;
@@ -1152,7 +1152,7 @@ CVar CompFunccallOpts(
   CompSetUseGVar(popOptions, COMP_USE_GVAR_FOPY);
   Emit("CALL_1ARGS( GF_PushOptions, %c );\n", opts);
   if (IS_TEMP_CVAR( opts) ) FreeTemp( TEMP_CVAR( opts ));
-  result = CompExpr(ADDR_STAT(expr)[1]);
+  result = CompExpr(READ_STAT(expr, 1));
   Emit("CALL_0ARGS( GF_PopOptions );\n");
   return result;
 }
@@ -1174,7 +1174,7 @@ CVar CompFuncExpr (
 
     /* get the number of the function                                      */
     fexs = FEXS_FUNC( CURR_FUNC() );
-    fexp = ELM_PLIST( fexs, ((Int*)ADDR_EXPR(expr))[0] );
+    fexp = ELM_PLIST(fexs, READ_EXPR(expr, 0));
     nr   = NR_INFO( INFO_FEXP( fexp ) );
 
     /* allocate a new temporary for the function                           */
@@ -1220,14 +1220,14 @@ CVar CompOr (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the left expression                                         */
-    left = CompBoolExpr( ADDR_EXPR(expr)[0] );
+    left = CompBoolExpr(READ_EXPR(expr, 0));
     Emit( "%c = (%c ? True : False);\n", val, left );
     Emit( "if ( %c == False ) {\n", val );
     only_left = NewInfoCVars();
     CopyInfoCVars( only_left, INFO_FEXP(CURR_FUNC()) );
 
     /* compile the right expression                                        */
-    right = CompBoolExpr( ADDR_EXPR(expr)[1] );
+    right = CompBoolExpr(READ_EXPR(expr, 1));
     Emit( "%c = (%c ? True : False);\n", val, right );
     Emit( "}\n" );
 
@@ -1260,14 +1260,14 @@ CVar CompOrBool (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the left expression                                         */
-    left = CompBoolExpr( ADDR_EXPR(expr)[0] );
+    left = CompBoolExpr(READ_EXPR(expr, 0));
     Emit( "%c = %c;\n", val, left );
     Emit( "if ( ! %c ) {\n", val );
     only_left = NewInfoCVars();
     CopyInfoCVars( only_left, INFO_FEXP(CURR_FUNC()) );
 
     /* compile the right expression                                        */
-    right = CompBoolExpr( ADDR_EXPR(expr)[1] );
+    right = CompBoolExpr(READ_EXPR(expr, 1));
     Emit( "%c = %c;\n", val, right );
     Emit( "}\n" );
 
@@ -1301,7 +1301,7 @@ CVar CompAnd (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the left expression                                         */
-    left = CompExpr( ADDR_EXPR(expr)[0] );
+    left = CompExpr(READ_EXPR(expr, 0));
     only_left = NewInfoCVars();
     CopyInfoCVars( only_left, INFO_FEXP(CURR_FUNC()) );
 
@@ -1312,7 +1312,7 @@ CVar CompAnd (
 
     /* emit the code for the case that the left value is 'true'            */
     Emit( "else if ( %c == True ) {\n", left );
-    right1 = CompExpr( ADDR_EXPR(expr)[1] );
+    right1 = CompExpr(READ_EXPR(expr, 1));
     CompCheckBool( right1 );
     Emit( "%c = %c;\n", val, right1 );
     Emit( "}\n" );
@@ -1320,7 +1320,7 @@ CVar CompAnd (
     /* emit the code for the case that the left value is a filter          */
     Emit( "else {\n" );
     CompCheckFunc( left );
-    right2 = CompExpr( ADDR_EXPR(expr)[1] );
+    right2 = CompExpr(READ_EXPR(expr, 1));
     CompCheckFunc( right2 );
     Emit( "%c = NewAndFilter( %c, %c );\n", val, left, right2 );
     Emit( "}\n" );
@@ -1355,14 +1355,14 @@ CVar CompAndBool (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the left expression                                         */
-    left = CompBoolExpr( ADDR_EXPR(expr)[0] );
+    left = CompBoolExpr(READ_EXPR(expr, 0));
     Emit( "%c = %c;\n", val, left );
     Emit( "if ( %c ) {\n", val );
     only_left = NewInfoCVars();
     CopyInfoCVars( only_left, INFO_FEXP(CURR_FUNC()) );
 
     /* compile the right expression                                        */
-    right = CompBoolExpr( ADDR_EXPR(expr)[1] );
+    right = CompBoolExpr(READ_EXPR(expr, 1));
     Emit( "%c = %c;\n", val, right );
     Emit( "}\n" );
 
@@ -1393,7 +1393,7 @@ CVar CompNot (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the operand                                                 */
-    left = CompBoolExpr( ADDR_EXPR(expr)[0] );
+    left = CompBoolExpr(READ_EXPR(expr, 0));
 
     /* invert the operand                                                  */
     Emit( "%c = (%c ? False : True);\n", val, left );
@@ -1423,7 +1423,7 @@ CVar CompNotBool (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the operand                                                 */
-    left = CompBoolExpr( ADDR_EXPR(expr)[0] );
+    left = CompBoolExpr(READ_EXPR(expr, 0));
 
     /* invert the operand                                                  */
     Emit( "%c = (Obj)(UInt)( ! ((Int)%c) );\n", val, left );
@@ -1454,8 +1454,8 @@ CVar CompEq (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -1492,8 +1492,8 @@ CVar CompEqBool (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -1530,8 +1530,8 @@ CVar CompNe (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -1568,8 +1568,8 @@ CVar CompNeBool (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -1606,8 +1606,8 @@ CVar CompLt (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -1644,8 +1644,8 @@ CVar CompLtBool (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -1682,8 +1682,8 @@ CVar CompGe (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -1720,8 +1720,8 @@ CVar CompGeBool (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -1758,8 +1758,8 @@ CVar CompGt (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -1796,8 +1796,8 @@ CVar CompGtBool (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -1834,8 +1834,8 @@ CVar CompLe (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -1872,8 +1872,8 @@ CVar            CompLeBool (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -1910,8 +1910,8 @@ CVar CompIn (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     Emit( "%c = (IN( %c, %c ) ?  True : False);\n", val, left, right );
@@ -1943,8 +1943,8 @@ CVar CompInBool (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     Emit( "%c = (Obj)(UInt)(IN( %c, %c ));\n", val, left, right );
@@ -1976,8 +1976,8 @@ CVar CompSum (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -2021,7 +2021,7 @@ CVar CompAInv (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the operands                                                */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
+    left = CompExpr(READ_EXPR(expr, 0));
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) ) {
@@ -2065,8 +2065,8 @@ CVar CompDiff (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -2111,8 +2111,8 @@ CVar CompProd (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     if ( HasInfoCVar(left,W_INT_SMALL) && HasInfoCVar(right,W_INT_SMALL) ) {
@@ -2157,8 +2157,8 @@ CVar CompQuo (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     Emit( "%c = QUO( %c, %c );\n", val, left, right );
@@ -2190,8 +2190,8 @@ CVar CompMod (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     Emit( "%c = MOD( %c, %c );\n", val, left, right );
@@ -2228,8 +2228,8 @@ CVar CompPow (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* compile the two operands                                            */
-    left  = CompExpr( ADDR_EXPR(expr)[0] );
-    right = CompExpr( ADDR_EXPR(expr)[1] );
+    left  = CompExpr( READ_EXPR(expr, 0) );
+    right = CompExpr( READ_EXPR(expr, 1) );
 
     /* emit the code                                                       */
     Emit( "%c = POW( %c, %c );\n", val, left, right );
@@ -2285,7 +2285,7 @@ CVar CompIntExpr (
     else {
         val = CVAR_TEMP( NewTemp( "val" ) );
         siz = SIZE_EXPR(expr) - sizeof(UInt);
-        typ = *(UInt *)ADDR_EXPR(expr);
+        typ = READ_EXPR(expr, 0);
         Emit( "%c = C_MAKE_INTEGER_BAG(%d, %d);\n",val, siz, typ);
         if ( typ == T_INTPOS ) {
             SetInfoCVar(val, W_INT_POS);
@@ -2296,9 +2296,11 @@ CVar CompIntExpr (
 
         for ( i = 0; i < siz/INTEGER_UNIT_SIZE; i++ ) {
 #if INTEGER_UNIT_SIZE == 4
-            Emit( "C_SET_LIMB4( %c, %d, %dL);\n",val, i, ((UInt4 *)((UInt *)ADDR_EXPR(expr) + 1))[i]);
+            Emit("C_SET_LIMB4( %c, %d, %dL);\n", val, i,
+                 ((UInt4 *)((const UInt *)CONST_ADDR_EXPR(expr) + 1))[i]);
 #elif INTEGER_UNIT_SIZE == 8
-            Emit( "C_SET_LIMB8( %c, %d, %dLL);\n",val, i, ((UInt8*)((UInt *)ADDR_EXPR(expr) + 1))[i]);
+            Emit("C_SET_LIMB8( %c, %d, %dLL);\n", val, i,
+                 ((UInt8 *)((const UInt *)CONST_ADDR_EXPR(expr) + 1))[i]);
 #else
             #error unsupported INTEGER_UNIT_SIZE
 #endif
@@ -2390,7 +2392,7 @@ CVar            CompCharExpr (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* emit the code                                                       */
-    Emit( "%c = ObjsChar[%d];\n", val, (Int)(((UChar*)ADDR_EXPR(expr))[0]));
+    Emit( "%c = ObjsChar[%d];\n", val, (Int)(((const UChar*)CONST_ADDR_EXPR(expr))[0]));
 
     /* we know that we have a value                                        */
     SetInfoCVar( val, W_BOUND );
@@ -2439,7 +2441,7 @@ CVar CompPermExpr (
     Emit( "SET_LEN_PLIST( %c, %d );\n", lprm, n );
 
     for ( i = 1;  i <= n;  i++ ) {
-        cycle = ADDR_EXPR(expr)[i-1];
+        cycle = READ_EXPR(expr, i - 1);
         csize = SIZE_EXPR(cycle)/sizeof(Expr);
         Emit( "%c = NEW_PLIST( T_PLIST, %d );\n", lcyc, csize );
         Emit( "SET_LEN_PLIST( %c, %d );\n", lcyc, csize );
@@ -2448,7 +2450,7 @@ CVar CompPermExpr (
 
         /* loop over the entries of the cycle                              */
         for ( j = 1;  j <= csize;  j++ ) {
-            val = CompExpr( ADDR_EXPR(cycle)[j-1] );
+            val = CompExpr(READ_EXPR(cycle, j - 1));
             Emit( "SET_ELM_PLIST( %c, %d, %c );\n", lcyc, j, val );
             Emit( "CHANGED_BAG( %c );\n", lcyc );
             if ( IS_TEMP_CVAR(val) )  FreeTemp( TEMP_CVAR(val) );
@@ -2566,31 +2568,31 @@ void CompListExpr2 (
     for ( i = 1; i <= len; i++ ) {
 
         /* if the subexpression is empty                                   */
-        if ( ADDR_EXPR(expr)[i-1] == 0 ) {
+        if (READ_EXPR(expr, i - 1) == 0) {
             continue;
         }
 
         /* special case if subexpression is a list expression              */
-        else if ( TNUM_EXPR( ADDR_EXPR(expr)[i-1] ) == T_LIST_EXPR ) {
-            sub = CompListExpr1( ADDR_EXPR(expr)[i-1] );
+        else if (TNUM_EXPR(READ_EXPR(expr, i - 1)) == T_LIST_EXPR) {
+            sub = CompListExpr1(READ_EXPR(expr, i - 1));
             Emit( "SET_ELM_PLIST( %c, %d, %c );\n", list, i, sub );
             Emit( "CHANGED_BAG( %c );\n", list );
-            CompListExpr2( sub, ADDR_EXPR(expr)[i-1] );
+            CompListExpr2(sub, READ_EXPR(expr, i - 1));
             if ( IS_TEMP_CVAR( sub ) )  FreeTemp( TEMP_CVAR( sub ) );
         }
 
         /* special case if subexpression is a record expression            */
-        else if ( TNUM_EXPR( ADDR_EXPR(expr)[i-1] ) == T_REC_EXPR ) {
-            sub = CompRecExpr1( ADDR_EXPR(expr)[i-1] );
+        else if (TNUM_EXPR(READ_EXPR(expr, i - 1)) == T_REC_EXPR) {
+            sub = CompRecExpr1(READ_EXPR(expr, i - 1));
             Emit( "SET_ELM_PLIST( %c, %d, %c );\n", list, i, sub );
             Emit( "CHANGED_BAG( %c );\n", list );
-            CompRecExpr2( sub, ADDR_EXPR(expr)[i-1] );
+            CompRecExpr2(sub, READ_EXPR(expr, i - 1));
             if ( IS_TEMP_CVAR( sub ) )  FreeTemp( TEMP_CVAR( sub ) );
         }
 
         /* general case                                                    */
         else {
-            sub = CompExpr( ADDR_EXPR(expr)[i-1] );
+            sub = CompExpr(READ_EXPR(expr, i - 1));
             Emit( "SET_ELM_PLIST( %c, %d, %c );\n", list, i, sub );
             if ( ! HasInfoCVar( sub, W_INT_SMALL ) ) {
                 Emit( "CHANGED_BAG( %c );\n", list );
@@ -2620,14 +2622,14 @@ CVar CompRangeExpr (
 
     /* evaluate the expressions                                            */
     if ( SIZE_EXPR(expr) == 2 * sizeof(Expr) ) {
-        first  = CompExpr( ADDR_EXPR(expr)[0] );
+        first  = CompExpr( READ_EXPR(expr, 0) );
         second = 0;
-        last   = CompExpr( ADDR_EXPR(expr)[1] );
+        last   = CompExpr( READ_EXPR(expr, 1) );
     }
     else {
-        first  = CompExpr( ADDR_EXPR(expr)[0] );
-        second = CompExpr( ADDR_EXPR(expr)[1] );
-        last   = CompExpr( ADDR_EXPR(expr)[2] );
+        first  = CompExpr( READ_EXPR(expr, 0) );
+        second = CompExpr( READ_EXPR(expr, 1) );
+        last   = CompExpr( READ_EXPR(expr, 2) );
     }
 
     /* emit the code                                                       */
@@ -2675,7 +2677,7 @@ CVar CompStringExpr (
     Emit( "%c = MakeString( \"%C\" );\n",
           /* the sizeof(UInt) offset is to get past the length of the string
              which is now stored in the front of the literal */
-          string, sizeof(UInt)+ (Char*)ADDR_EXPR(expr) );
+          string, sizeof(UInt)+ (const Char*)CONST_ADDR_EXPR(expr) );
 
     /* we know that the result is a list                                   */
     SetInfoCVar( string, W_LIST );
@@ -2783,7 +2785,7 @@ void            CompRecExpr2 (
     for ( i = 1; i <= len; i++ ) {
 
         /* handle the name                                                 */
-        tmp = ADDR_EXPR(expr)[2*i-2];
+        tmp = READ_EXPR(expr, 2 * i - 2);
         rnam = CVAR_TEMP( NewTemp( "rnam" ) );
         if ( IS_INTEXPR(tmp) ) {
             CompSetUseRNam( (UInt)INT_INTEXPR(tmp), COMP_USE_RNAM_ID );
@@ -2796,7 +2798,7 @@ void            CompRecExpr2 (
         }
 
         /* if the subexpression is empty (cannot happen for records)       */
-        tmp = ADDR_EXPR(expr)[2*i-1];
+        tmp = READ_EXPR(expr, 2 * i - 1);
         if ( tmp == 0 ) {
             if ( IS_TEMP_CVAR( rnam ) )  FreeTemp( TEMP_CVAR( rnam ) );
             continue;
@@ -2847,7 +2849,7 @@ CVar CompRefLVar (
         lvar = LVAR_REFLVAR(expr);
     }
     else {
-        lvar = (LVar)(ADDR_EXPR(expr)[0]);
+        lvar = (LVar)(READ_EXPR(expr, 0));
     }
 
     /* emit the code to get the value                                      */
@@ -2879,7 +2881,7 @@ CVar CompIsbLVar (
     LVar                lvar;           /* local variable                  */
 
     /* get the local variable                                              */
-    lvar = (LVar)(ADDR_EXPR(expr)[0]);
+    lvar = (LVar)(READ_EXPR(expr, 0));
 
     /* allocate a new temporary for the result                             */
     isb = CVAR_TEMP( NewTemp( "isb" ) );
@@ -2918,7 +2920,7 @@ CVar CompRefHVar (
     HVar                hvar;           /* higher variable                 */
 
     /* get the higher variable                                             */
-    hvar = (HVar)(ADDR_EXPR(expr)[0]);
+    hvar = (HVar)(READ_EXPR(expr, 0));
     CompSetUseHVar( hvar );
 
     /* allocate a new temporary for the value                              */
@@ -2948,7 +2950,7 @@ CVar CompIsbHVar (
     HVar                hvar;           /* higher variable                 */
 
     /* get the higher variable                                             */
-    hvar = (HVar)(ADDR_EXPR(expr)[0]);
+    hvar = (HVar)(READ_EXPR(expr, 0));
     CompSetUseHVar( hvar );
 
     /* allocate new temporaries for the value and the result               */
@@ -2984,7 +2986,7 @@ CVar CompRefGVar (
     GVar                gvar;           /* higher variable                 */
 
     /* get the global variable                                             */
-    gvar = (GVar)(ADDR_EXPR(expr)[0]);
+    gvar = (GVar)(READ_EXPR(expr, 0));
     CompSetUseGVar( gvar, COMP_USE_GVAR_COPY );
 
     /* allocate a new global variable for the value                        */
@@ -3012,7 +3014,7 @@ CVar CompRefGVarFopy (
     GVar                gvar;           /* higher variable                 */
 
     /* get the global variable                                             */
-    gvar = (GVar)(ADDR_EXPR(expr)[0]);
+    gvar = (GVar)(READ_EXPR(expr, 0));
     CompSetUseGVar( gvar, COMP_USE_GVAR_FOPY );
 
     /* allocate a new temporary for the value                              */
@@ -3041,7 +3043,7 @@ CVar CompIsbGVar (
     GVar                gvar;           /* higher variable                 */
 
     /* get the global variable                                             */
-    gvar = (GVar)(ADDR_EXPR(expr)[0]);
+    gvar = (GVar)(READ_EXPR(expr, 0));
     CompSetUseGVar( gvar, COMP_USE_GVAR_COPY );
 
     /* allocate new temporaries for the value and the result               */
@@ -3080,10 +3082,10 @@ CVar CompElmList (
     elm = CVAR_TEMP( NewTemp( "elm" ) );
 
     /* compile the list expression (checking is done by 'ELM_LIST')        */
-    list = CompExpr( ADDR_EXPR(expr)[0] );
+    list = CompExpr(READ_EXPR(expr, 0));
 
     /* compile and check the position expression                           */
-    pos = CompExpr( ADDR_EXPR(expr)[1] );
+    pos = CompExpr(READ_EXPR(expr, 1));
     CompCheckIntPos( pos );
 
     /* emit the code to get the element                                    */
@@ -3127,10 +3129,10 @@ CVar CompElmsList (
     elms = CVAR_TEMP( NewTemp( "elms" ) );
 
     /* compile the list expression (checking is done by 'ElmsListCheck')   */
-    list = CompExpr( ADDR_EXPR(expr)[0] );
+    list = CompExpr(READ_EXPR(expr, 0));
 
     /* compile the position expression (checking done by 'ElmsListCheck')  */
-    poss = CompExpr( ADDR_EXPR(expr)[1] );
+    poss = CompExpr(READ_EXPR(expr, 1));
 
     /* emit the code to get the element                                    */
     Emit( "%c = ElmsListCheck( %c, %c );\n", elms, list, poss );
@@ -3159,14 +3161,14 @@ CVar CompElmListLev (
     Int                 level;          /* level                           */
 
     /* compile the lists expression                                        */
-    lists = CompExpr( ADDR_EXPR(expr)[0] );
+    lists = CompExpr(READ_EXPR(expr, 0));
 
     /* compile and check the position expression                           */
-    pos = CompExpr( ADDR_EXPR(expr)[1] );
+    pos = CompExpr(READ_EXPR(expr, 1));
     CompCheckIntSmallPos( pos );
 
     /* get the level                                                       */
-    level = (Int)(ADDR_EXPR(expr)[2]);
+    level = (Int)(READ_EXPR(expr, 2));
 
     /* emit the code to select the elements from several lists (to <lists>)*/
     Emit( "ElmListLevel( %c, %c, %d );\n", lists, pos, level );
@@ -3191,13 +3193,13 @@ CVar CompElmsListLev (
     Int                 level;          /* level                           */
 
     /* compile the lists expression                                        */
-    lists = CompExpr( ADDR_EXPR(expr)[0] );
+    lists = CompExpr(READ_EXPR(expr, 0));
 
     /* compile the position expression (checking done by 'ElmsListLevel')  */
-    poss = CompExpr( ADDR_EXPR(expr)[1] );
+    poss = CompExpr(READ_EXPR(expr, 1));
 
     /* get the level                                                       */
-    level = (Int)(ADDR_EXPR(expr)[2]);
+    level = (Int)(READ_EXPR(expr, 2));
 
     /* emit the code to select the elements from several lists (to <lists>)*/
     Emit( "ElmsListLevelCheck( %c, %c, %d );\n", lists, poss, level );
@@ -3225,10 +3227,10 @@ CVar CompIsbList (
     isb = CVAR_TEMP( NewTemp( "isb" ) );
 
     /* compile the list expression (checking is done by 'ISB_LIST')        */
-    list = CompExpr( ADDR_EXPR(expr)[0] );
+    list = CompExpr(READ_EXPR(expr, 0));
 
     /* compile and check the position expression                           */
-    pos = CompExpr( ADDR_EXPR(expr)[1] );
+    pos = CompExpr(READ_EXPR(expr, 1));
     CompCheckIntPos( pos );
 
     /* emit the code to test the element                                   */
@@ -3261,10 +3263,10 @@ CVar CompElmRecName (
     elm = CVAR_TEMP( NewTemp( "elm" ) );
 
     /* compile the record expression (checking is done by 'ELM_REC')       */
-    record = CompExpr( ADDR_EXPR(expr)[0] );
+    record = CompExpr(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(ADDR_EXPR(expr)[1]);
+    rnam = (UInt)(READ_EXPR(expr, 1));
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code to select the element of the record                   */
@@ -3296,10 +3298,10 @@ CVar CompElmRecExpr (
     elm = CVAR_TEMP( NewTemp( "elm" ) );
 
     /* compile the record expression (checking is done by 'ELM_REC')       */
-    record = CompExpr( ADDR_EXPR(expr)[0] );
+    record = CompExpr(READ_EXPR(expr, 0));
 
     /* compile the record name expression                                  */
-    rnam = CompExpr( ADDR_EXPR(expr)[1] );
+    rnam = CompExpr(READ_EXPR(expr, 1));
 
     /* emit the code to select the element of the record                   */
     Emit( "%c = ELM_REC( %c, RNamObj(%c) );\n", elm, record, rnam );
@@ -3331,10 +3333,10 @@ CVar CompIsbRecName (
     isb = CVAR_TEMP( NewTemp( "isb" ) );
 
     /* compile the record expression (checking is done by 'ISB_REC')       */
-    record = CompExpr( ADDR_EXPR(expr)[0] );
+    record = CompExpr(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(ADDR_EXPR(expr)[1]);
+    rnam = (UInt)(READ_EXPR(expr, 1));
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code to test the element                                   */
@@ -3367,10 +3369,10 @@ CVar CompIsbRecExpr (
     isb = CVAR_TEMP( NewTemp( "isb" ) );
 
     /* compile the record expression (checking is done by 'ISB_REC')       */
-    record = CompExpr( ADDR_EXPR(expr)[0] );
+    record = CompExpr(READ_EXPR(expr, 0));
 
     /* compile the record name expression                                  */
-    rnam = CompExpr( ADDR_EXPR(expr)[1] );
+    rnam = CompExpr(READ_EXPR(expr, 1));
 
     /* emit the code to test the element                                   */
     Emit( "%c = (ISB_REC( %c, RNamObj(%c) ) ? True : False);\n",
@@ -3403,10 +3405,10 @@ CVar CompElmPosObj (
     elm = CVAR_TEMP( NewTemp( "elm" ) );
 
     /* compile the list expression (checking is done by 'ELM_LIST')        */
-    list = CompExpr( ADDR_EXPR(expr)[0] );
+    list = CompExpr(READ_EXPR(expr, 0));
 
     /* compile and check the position expression                           */
-    pos = CompExpr( ADDR_EXPR(expr)[1] );
+    pos = CompExpr(READ_EXPR(expr, 1));
     CompCheckIntSmallPos( pos );
 
     /* emit the code to get the element                                    */
@@ -3480,10 +3482,10 @@ CVar CompIsbPosObj (
     isb = CVAR_TEMP( NewTemp( "isb" ) );
 
     /* compile the list expression (checking is done by 'ISB_LIST')        */
-    list = CompExpr( ADDR_EXPR(expr)[0] );
+    list = CompExpr(READ_EXPR(expr, 0));
 
     /* compile and check the position expression                           */
-    pos = CompExpr( ADDR_EXPR(expr)[1] );
+    pos = CompExpr(READ_EXPR(expr, 1));
     CompCheckIntSmallPos( pos );
 
     /* emit the code to test the element                                   */
@@ -3525,10 +3527,10 @@ CVar CompElmComObjName (
     elm = CVAR_TEMP( NewTemp( "elm" ) );
 
     /* compile the record expression (checking is done by 'ELM_REC')       */
-    record = CompExpr( ADDR_EXPR(expr)[0] );
+    record = CompExpr(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(ADDR_EXPR(expr)[1]);
+    rnam = (UInt)(READ_EXPR(expr, 1));
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code to select the element of the record                   */
@@ -3569,10 +3571,10 @@ CVar CompElmComObjExpr (
     elm = CVAR_TEMP( NewTemp( "elm" ) );
 
     /* compile the record expression (checking is done by 'ELM_REC')       */
-    record = CompExpr( ADDR_EXPR(expr)[0] );
+    record = CompExpr(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = CompExpr( ADDR_EXPR(expr)[1] );
+    rnam = CompExpr(READ_EXPR(expr, 1));
 
     /* emit the code to select the element of the record                   */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
@@ -3612,10 +3614,10 @@ CVar CompIsbComObjName (
     isb = CVAR_TEMP( NewTemp( "isb" ) );
 
     /* compile the record expression (checking is done by 'ISB_REC')       */
-    record = CompExpr( ADDR_EXPR(expr)[0] );
+    record = CompExpr(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(ADDR_EXPR(expr)[1]);
+    rnam = (UInt)(READ_EXPR(expr, 1));
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code to test the element                                   */
@@ -3658,10 +3660,10 @@ CVar CompIsbComObjExpr (
     isb = CVAR_TEMP( NewTemp( "isb" ) );
 
     /* compile the record expression (checking is done by 'ISB_REC')       */
-    record = CompExpr( ADDR_EXPR(expr)[0] );
+    record = CompExpr(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = CompExpr( ADDR_EXPR(expr)[1] );
+    rnam = CompExpr(READ_EXPR(expr, 1));
 
     /* emit the code to test the element                                   */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
@@ -3748,7 +3750,7 @@ void CompProccall0to6Args (
     /* special case to inline 'Add'                                        */
     if ( CompFastListFuncs
       && TNUM_EXPR( FUNC_CALL(stat) ) == T_REF_GVAR
-      && ADDR_EXPR( FUNC_CALL(stat) )[0] == G_Add
+      && READ_EXPR( FUNC_CALL(stat), 0 ) == G_Add
       && NARG_SIZE_CALL(SIZE_EXPR(stat)) == 2 ) {
         args[1] = CompExpr( ARGI_CALL(stat,1) );
         args[2] = CompExpr( ARGI_CALL(stat,2) );
@@ -3849,7 +3851,7 @@ void CompProccallXArgs (
 void CompProccallOpts(
                       Stat stat)
 {
-  CVar opts = CompExpr(ADDR_STAT(stat)[0]);
+  CVar opts = CompExpr(READ_STAT(stat, 0));
   GVar pushOptions;
   GVar popOptions;
   pushOptions = GVarName("PushOptions");
@@ -3858,7 +3860,7 @@ void CompProccallOpts(
   CompSetUseGVar(popOptions, COMP_USE_GVAR_FOPY);
   Emit("CALL_1ARGS( GF_PushOptions, %c );\n", opts);
   if (IS_TEMP_CVAR( opts) ) FreeTemp( TEMP_CVAR( opts ));
-  CompStat(ADDR_STAT(stat)[1]);
+  CompStat(READ_STAT(stat, 1));
   Emit("CALL_0ARGS( GF_PopOptions );\n");
 }
      
@@ -3878,7 +3880,7 @@ void CompSeqStat (
 
     /* compile the statements                                              */
     for ( i = 1; i <= nr; i++ ) {
-        CompStat( ADDR_STAT( stat )[i-1] );
+        CompStat(READ_STAT(stat, i - 1));
     }
 }
 
@@ -3902,12 +3904,12 @@ void CompIf (
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
         Emit( "\n/* if " );
-        PrintExpr( ADDR_EXPR(stat)[0] );
+        PrintExpr(READ_EXPR(stat, 0));
         Emit( " then */\n" );
     }
 
     /* compile the expression                                              */
-    cond = CompBoolExpr( ADDR_STAT( stat )[0] );
+    cond = CompBoolExpr(READ_STAT(stat, 0));
 
     /* emit the code to test the condition                                 */
     Emit( "if ( %c ) {\n", cond );
@@ -3918,7 +3920,7 @@ void CompIf (
     CopyInfoCVars( info_in, INFO_FEXP(CURR_FUNC()) );
 
     /* compile the body                                                    */
-    CompStat( ADDR_STAT( stat )[1] );
+    CompStat(READ_STAT(stat, 1));
 
     /* remember what we know after executing the first body                */
     info_out = NewInfoCVars();
@@ -3931,13 +3933,13 @@ void CompIf (
     for ( i = 2; i <= nr; i++ ) {
 
         /* do not handle 'else' branch here                                */
-        if ( i == nr && TNUM_EXPR(ADDR_STAT(stat)[2*(i-1)]) == T_TRUE_EXPR )
+        if (i == nr && TNUM_EXPR(READ_STAT(stat, 2 * (i - 1))) == T_TRUE_EXPR)
             break;
 
         /* print a comment                                                 */
         if ( CompPass == 2 ) {
             Emit( "\n/* elif " );
-            PrintExpr( ADDR_EXPR(stat)[2*(i-1)] );
+            PrintExpr(READ_EXPR(stat, 2 * (i - 1)));
             Emit( " then */\n" );
         }
 
@@ -3948,7 +3950,7 @@ void CompIf (
         CopyInfoCVars( INFO_FEXP(CURR_FUNC()), info_in );
 
         /* compile the expression                                          */
-        cond = CompBoolExpr( ADDR_STAT( stat )[2*(i-1)] );
+        cond = CompBoolExpr(READ_STAT(stat, 2 * (i - 1)));
 
         /* emit the code to test the condition                             */
         Emit( "if ( %c ) {\n", cond );
@@ -3958,7 +3960,7 @@ void CompIf (
         CopyInfoCVars( info_in, INFO_FEXP(CURR_FUNC()) );
 
         /* compile the body                                                */
-        CompStat( ADDR_STAT( stat )[2*(i-1)+1] );
+        CompStat(READ_STAT(stat, 2 * (i - 1) + 1));
 
         /* remember what we know after executing one of the previous bodies*/
         MergeInfoCVars( info_out, INFO_FEXP(CURR_FUNC()) );
@@ -3983,7 +3985,7 @@ void CompIf (
         CopyInfoCVars( INFO_FEXP(CURR_FUNC()), info_in );
 
         /* compile the body                                                */
-        CompStat( ADDR_STAT( stat )[2*(i-1)+1] );
+        CompStat(READ_STAT(stat, 2 * (i - 1) + 1));
 
         /* remember what we know after executing one of the previous bodies*/
         MergeInfoCVars( info_out, INFO_FEXP(CURR_FUNC()) );
@@ -4006,7 +4008,7 @@ void CompIf (
 
     /* close all unbalanced parenthesis                                    */
     for ( i = 2; i <= nr; i++ ) {
-        if ( i == nr && TNUM_EXPR(ADDR_STAT(stat)[2*(i-1)]) == T_TRUE_EXPR )
+        if (i == nr && TNUM_EXPR(READ_STAT(stat, 2 * (i - 1))) == T_TRUE_EXPR)
             break;
         Emit( "}\n" );
     }
@@ -4038,35 +4040,35 @@ void CompFor (
     Int                 i;              /* loop variable                   */
 
     /* handle 'for <lvar> in [<first>..<last>] do'                         */
-    if ( IS_REFLVAR( ADDR_STAT(stat)[0] )
-      && ! CompGetUseHVar( LVAR_REFLVAR( ADDR_STAT(stat)[0] ) )
-      && TNUM_EXPR( ADDR_STAT(stat)[1] ) == T_RANGE_EXPR
-      && SIZE_EXPR( ADDR_STAT(stat)[1] ) == 2*sizeof(Expr) ) {
+    if ( IS_REFLVAR( READ_STAT(stat, 0) )
+      && ! CompGetUseHVar( LVAR_REFLVAR( READ_STAT(stat, 0) ) )
+      && TNUM_EXPR( READ_STAT(stat, 1) ) == T_RANGE_EXPR
+      && SIZE_EXPR( READ_STAT(stat, 1) ) == 2*sizeof(Expr) ) {
 
         /* print a comment                                                 */
         if ( CompPass == 2 ) {
             Emit( "\n/* for " );
-            PrintExpr( ADDR_EXPR(stat)[0] );
+            PrintExpr(READ_EXPR(stat, 0));
             Emit( " in " );
-            PrintExpr( ADDR_EXPR(stat)[1] );
+            PrintExpr(READ_EXPR(stat, 1));
             Emit( " do */\n" );
         }
 
         /* get the local variable                                          */
-        var = LVAR_REFLVAR( ADDR_STAT(stat)[0] );
+        var = LVAR_REFLVAR(READ_STAT(stat, 0));
 
         /* allocate a new temporary for the loop variable                  */
         lidx = CVAR_TEMP( NewTemp( "lidx" ) );
 
         /* compile and check the first and last value                      */
-        first = CompExpr( ADDR_EXPR( ADDR_STAT(stat)[1] )[0] );
+        first = CompExpr(READ_EXPR(READ_STAT(stat, 1), 0));
         CompCheckIntSmall( first );
 
         /* compile and check the last value                                */
         /* if the last value is in a local variable,                       */
         /* we must copy it into a temporary,                               */
         /* because the local variable may change its value in the body     */
-        last  = CompExpr( ADDR_EXPR( ADDR_STAT(stat)[1] )[1] );
+        last = CompExpr(READ_EXPR(READ_STAT(stat, 1), 1));
         CompCheckIntSmall( last  );
         if ( IS_LVAR_CVAR(last) ) {
             elm = CVAR_TEMP( NewTemp( "last" ) );
@@ -4087,7 +4089,7 @@ void CompFor (
                 SetInfoCVar( CVAR_LVAR(var), W_INT_SMALL );
             }
             for ( i = 2; i < SIZE_STAT(stat)/sizeof(Stat); i++ ) {
-                CompStat( ADDR_STAT(stat)[i] );
+                CompStat(READ_STAT(stat, i));
             }
             MergeInfoCVars( INFO_FEXP(CURR_FUNC()), prev );
         } while ( ! IsEqInfoCVars( INFO_FEXP(CURR_FUNC()), prev ) );
@@ -4112,7 +4114,7 @@ void CompFor (
 
         /* compile the body                                                */
         for ( i = 2; i < SIZE_STAT(stat)/sizeof(Stat); i++ ) {
-            CompStat( ADDR_STAT(stat)[i] );
+            CompStat(READ_STAT(stat, i));
         }
 
         /* emit the end code                                               */
@@ -4132,28 +4134,28 @@ void CompFor (
         /* print a comment                                                 */
         if ( CompPass == 2 ) {
             Emit( "\n/* for " );
-            PrintExpr( ADDR_EXPR(stat)[0] );
+            PrintExpr(READ_EXPR(stat, 0));
             Emit( " in " );
-            PrintExpr( ADDR_EXPR(stat)[1] );
+            PrintExpr(READ_EXPR(stat, 1));
             Emit( " do */\n" );
         }
 
         /* get the variable (initialize them first to please 'lint')       */
-        if ( IS_REFLVAR( ADDR_STAT(stat)[0] )
-          && ! CompGetUseHVar( LVAR_REFLVAR( ADDR_STAT(stat)[0] ) ) ) {
-            var = LVAR_REFLVAR( ADDR_STAT(stat)[0] );
+        if ( IS_REFLVAR( READ_STAT(stat, 0) )
+          && ! CompGetUseHVar( LVAR_REFLVAR( READ_STAT(stat, 0) ) ) ) {
+            var = LVAR_REFLVAR( READ_STAT(stat, 0) );
             vart = 'l';
         }
-        else if ( IS_REFLVAR( ADDR_STAT(stat)[0] ) ) {
-            var = LVAR_REFLVAR( ADDR_STAT(stat)[0] );
+        else if (IS_REFLVAR(READ_STAT(stat, 0))) {
+            var = LVAR_REFLVAR(READ_STAT(stat, 0));
             vart = 'm';
         }
-        else if ( TNUM_EXPR( ADDR_STAT(stat)[0] ) == T_REF_HVAR ) {
-            var = (UInt)(ADDR_EXPR( ADDR_STAT(stat)[0] )[0]);
+        else if (TNUM_EXPR(READ_STAT(stat, 0)) == T_REF_HVAR) {
+            var = (UInt)(READ_EXPR(READ_STAT(stat, 0), 0));
             vart = 'h';
         }
-        else /* if ( TNUM_EXPR( ADDR_STAT(stat)[0] ) == T_REF_GVAR ) */ {
-            var = (UInt)(ADDR_EXPR( ADDR_STAT(stat)[0] )[0]);
+        else /* if ( TNUM_EXPR( READ_STAT(stat, 0) ) == T_REF_GVAR ) */ {
+            var = (UInt)(READ_EXPR(READ_STAT(stat, 0), 0));
             CompSetUseGVar( var, COMP_USE_GVAR_ID );
             vart = 'g';
         }
@@ -4164,7 +4166,7 @@ void CompFor (
         islist = CVAR_TEMP( NewTemp( "islist" ) );
 
         /* compile and check the first and last value                      */
-        list = CompExpr( ADDR_STAT(stat)[1] );
+        list = CompExpr(READ_STAT(stat, 1));
 
         /* SL Patch added to try and avoid a bug */
         if (IS_LVAR_CVAR(list))
@@ -4186,7 +4188,7 @@ void CompFor (
                 SetInfoCVar( CVAR_LVAR(var), W_BOUND );
             }
             for ( i = 2; i < SIZE_STAT(stat)/sizeof(Stat); i++ ) {
-                CompStat( ADDR_STAT(stat)[i] );
+                CompStat(READ_STAT(stat, i));
             }
             MergeInfoCVars( INFO_FEXP(CURR_FUNC()), prev );
         } while ( ! IsEqInfoCVars( INFO_FEXP(CURR_FUNC()), prev ) );
@@ -4240,7 +4242,7 @@ void CompFor (
 
         /* compile the body                                                */
         for ( i = 2; i < SIZE_STAT(stat)/sizeof(Stat); i++ ) {
-            CompStat( ADDR_STAT(stat)[i] );
+            CompStat(READ_STAT(stat, i));
         }
 
         /* emit the end code                                               */
@@ -4278,11 +4280,11 @@ void CompWhile (
     prev = NewInfoCVars();
     do {
         CopyInfoCVars( prev, INFO_FEXP(CURR_FUNC()) );
-        cond = CompBoolExpr( ADDR_STAT(stat)[0] );
+        cond = CompBoolExpr(READ_STAT(stat, 0));
         Emit( "if ( ! %c ) break;\n", cond );
         if ( IS_TEMP_CVAR( cond ) )  FreeTemp( TEMP_CVAR( cond ) );
         for ( i = 1; i < SIZE_STAT(stat)/sizeof(Stat); i++ ) {
-            CompStat( ADDR_STAT(stat)[i] );
+            CompStat(READ_STAT(stat, i));
         }
         MergeInfoCVars( INFO_FEXP(CURR_FUNC()), prev );
     } while ( ! IsEqInfoCVars( INFO_FEXP(CURR_FUNC()), prev ) );
@@ -4292,7 +4294,7 @@ void CompWhile (
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
         Emit( "\n/* while " );
-        PrintExpr( ADDR_EXPR(stat)[0] );
+        PrintExpr(READ_EXPR(stat, 0));
         Emit( " od */\n" );
     }
 
@@ -4300,13 +4302,13 @@ void CompWhile (
     Emit( "while ( 1 ) {\n" );
 
     /* compile the condition                                               */
-    cond = CompBoolExpr( ADDR_STAT(stat)[0] );
+    cond = CompBoolExpr(READ_STAT(stat, 0));
     Emit( "if ( ! %c ) break;\n", cond );
     if ( IS_TEMP_CVAR( cond ) )  FreeTemp( TEMP_CVAR( cond ) );
 
     /* compile the body                                                    */
     for ( i = 1; i < SIZE_STAT(stat)/sizeof(Stat); i++ ) {
-        CompStat( ADDR_STAT(stat)[i] );
+        CompStat(READ_STAT(stat, i));
     }
 
     /* thats it                                                            */
@@ -4337,9 +4339,9 @@ void CompRepeat (
     do {
         CopyInfoCVars( prev, INFO_FEXP(CURR_FUNC()) );
         for ( i = 1; i < SIZE_STAT(stat)/sizeof(Stat); i++ ) {
-            CompStat( ADDR_STAT(stat)[i] );
+            CompStat(READ_STAT(stat, i));
         }
-        cond = CompBoolExpr( ADDR_STAT(stat)[0] );
+        cond = CompBoolExpr(READ_STAT(stat, 0));
         Emit( "if ( %c ) break;\n", cond );
         if ( IS_TEMP_CVAR( cond ) )  FreeTemp( TEMP_CVAR( cond ) );
         MergeInfoCVars( INFO_FEXP(CURR_FUNC()), prev );
@@ -4357,18 +4359,18 @@ void CompRepeat (
 
     /* compile the body                                                    */
     for ( i = 1; i < SIZE_STAT(stat)/sizeof(Stat); i++ ) {
-        CompStat( ADDR_STAT(stat)[i] );
+        CompStat(READ_STAT(stat, i));
     }
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
         Emit( "\n/* until " );
-        PrintExpr( ADDR_EXPR(stat)[0] );
+        PrintExpr(READ_EXPR(stat, 0));
         Emit( " */\n" );
     }
 
     /* compile the condition                                               */
-    cond = CompBoolExpr( ADDR_STAT(stat)[0] );
+    cond = CompBoolExpr(READ_STAT(stat, 0));
     Emit( "if ( %c ) break;\n", cond );
     if ( IS_TEMP_CVAR( cond ) )  FreeTemp( TEMP_CVAR( cond ) );
 
@@ -4423,7 +4425,7 @@ void CompReturnObj (
     }
 
     /* compile the expression                                              */
-    obj = CompExpr( ADDR_STAT(stat)[0] );
+    obj = CompExpr(READ_STAT(stat, 0));
 
     /* emit code to remove stack frame                                     */
     Emit( "RES_BRK_CURR_STAT();\n" );
@@ -4474,10 +4476,10 @@ void            CompAssLVar (
     }
 
     /* compile the right hand side expression                              */
-    rhs = CompExpr( ADDR_STAT(stat)[1] );
+    rhs = CompExpr(READ_STAT(stat, 1));
 
     /* emit the code for the assignment                                    */
-    lvar = (LVar)(ADDR_STAT(stat)[0]);
+    lvar = (LVar)(READ_STAT(stat, 0));
     if ( CompGetUseHVar( lvar ) ) {
         Emit( "ASS_LVAR( %d, %c );\n", GetIndxHVar(lvar), rhs );
     }
@@ -4506,7 +4508,7 @@ void CompUnbLVar (
     }
 
     /* emit the code for the assignment                                    */
-    lvar = (LVar)(ADDR_STAT(stat)[0]);
+    lvar = (LVar)(READ_STAT(stat, 0));
     if ( CompGetUseHVar( lvar ) ) {
         Emit( "ASS_LVAR( %d, 0 );\n", GetIndxHVar(lvar) );
     }
@@ -4533,10 +4535,10 @@ void CompAssHVar (
     }
 
     /* compile the right hand side expression                              */
-    rhs = CompExpr( ADDR_STAT(stat)[1] );
+    rhs = CompExpr(READ_STAT(stat, 1));
 
     /* emit the code for the assignment                                    */
-    hvar = (HVar)(ADDR_STAT(stat)[0]);
+    hvar = (HVar)(READ_STAT(stat, 0));
     CompSetUseHVar( hvar );
     Emit( "ASS_HVAR( (%d << 16) | %d, %c );\n",
           GetLevlHVar(hvar), GetIndxHVar(hvar), rhs );
@@ -4561,7 +4563,7 @@ void CompUnbHVar (
     }
 
     /* emit the code for the assignment                                    */
-    hvar = (HVar)(ADDR_STAT(stat)[0]);
+    hvar = (HVar)(READ_STAT(stat, 0));
     CompSetUseHVar( hvar );
     Emit( "ASS_HVAR( (%d << 16) | %d, 0 );\n",
           GetLevlHVar(hvar), GetIndxHVar(hvar) );
@@ -4584,10 +4586,10 @@ void CompAssGVar (
     }
 
     /* compile the right hand side expression                              */
-    rhs = CompExpr( ADDR_STAT(stat)[1] );
+    rhs = CompExpr(READ_STAT(stat, 1));
 
     /* emit the code for the assignment                                    */
-    gvar = (GVar)(ADDR_STAT(stat)[0]);
+    gvar = (GVar)(READ_STAT(stat, 0));
     CompSetUseGVar( gvar, COMP_USE_GVAR_ID );
     Emit( "AssGVar( G_%n, %c );\n", NameGVar(gvar), rhs );
 
@@ -4611,7 +4613,7 @@ void            CompUnbGVar (
     }
 
     /* emit the code for the assignment                                    */
-    gvar = (GVar)(ADDR_STAT(stat)[0]);
+    gvar = (GVar)(READ_STAT(stat, 0));
     CompSetUseGVar( gvar, COMP_USE_GVAR_ID );
     Emit( "AssGVar( G_%n, 0 );\n", NameGVar(gvar) );
 }
@@ -4634,14 +4636,14 @@ void CompAssList (
     }
 
     /* compile the list expression                                         */
-    list = CompExpr( ADDR_STAT(stat)[0] );
+    list = CompExpr(READ_STAT(stat, 0));
 
     /* compile and check the position expression                           */
-    pos = CompExpr( ADDR_STAT(stat)[1] );
+    pos = CompExpr(READ_STAT(stat, 1));
     CompCheckIntPos( pos );
 
     /* compile the right hand side                                         */
-    rhs = CompExpr( ADDR_STAT(stat)[2] );
+    rhs = CompExpr(READ_STAT(stat, 2));
 
     /* emit the code                                                       */
     if ( CompFastPlainLists ) {
@@ -4680,13 +4682,13 @@ void CompAsssList (
     }
 
     /* compile the list expression                                         */
-    list = CompExpr( ADDR_STAT(stat)[0] );
+    list = CompExpr(READ_STAT(stat, 0));
 
     /* compile and check the position expression                           */
-    poss = CompExpr( ADDR_STAT(stat)[1] );
+    poss = CompExpr(READ_STAT(stat, 1));
 
     /* compile the right hand side                                         */
-    rhss = CompExpr( ADDR_STAT(stat)[2] );
+    rhss = CompExpr(READ_STAT(stat, 2));
 
     /* emit the code                                                       */
     Emit( "AsssListCheck( %c, %c, %c );\n", list, poss, rhss );
@@ -4716,17 +4718,17 @@ void CompAssListLev (
     }
 
     /* compile the list expressions                                        */
-    lists = CompExpr( ADDR_STAT(stat)[0] );
+    lists = CompExpr(READ_STAT(stat, 0));
 
     /* compile and check the position expression                           */
-    pos = CompExpr( ADDR_STAT(stat)[1] );
+    pos = CompExpr(READ_STAT(stat, 1));
     CompCheckIntSmallPos( pos );
 
     /* compile the right hand sides                                        */
-    rhss = CompExpr( ADDR_STAT(stat)[2] );
+    rhss = CompExpr(READ_STAT(stat, 2));
 
     /* get the level                                                       */
-    level = (Int)(ADDR_STAT(stat)[3]);
+    level = (Int)(READ_STAT(stat, 3));
 
     /* emit the code                                                       */
     Emit( "AssListLevel( %c, %c, %c, %d );\n", lists, pos, rhss, level );
@@ -4756,16 +4758,16 @@ void CompAsssListLev (
     }
 
     /* compile the list expressions                                        */
-    lists = CompExpr( ADDR_STAT(stat)[0] );
+    lists = CompExpr(READ_STAT(stat, 0));
 
     /* compile and check the position expression                           */
-    poss = CompExpr( ADDR_STAT(stat)[1] );
+    poss = CompExpr(READ_STAT(stat, 1));
 
     /* compile the right hand side                                         */
-    rhss = CompExpr( ADDR_STAT(stat)[2] );
+    rhss = CompExpr(READ_STAT(stat, 2));
 
     /* get the level                                                       */
-    level = (Int)(ADDR_STAT(stat)[3]);
+    level = (Int)(READ_STAT(stat, 3));
 
     /* emit the code                                                       */
     Emit( "AsssListLevelCheck( %c, %c, %c, %d );\n",
@@ -4794,10 +4796,10 @@ void CompUnbList (
     }
 
     /* compile the list expression                                         */
-    list = CompExpr( ADDR_STAT(stat)[0] );
+    list = CompExpr(READ_STAT(stat, 0));
 
     /* compile and check the position expression                           */
-    pos = CompExpr( ADDR_STAT(stat)[1] );
+    pos = CompExpr(READ_STAT(stat, 1));
     CompCheckIntPos( pos );
 
     /* emit the code                                                       */
@@ -4826,14 +4828,14 @@ void CompAssRecName (
     }
 
     /* compile the record expression                                       */
-    record = CompExpr( ADDR_STAT(stat)[0] );
+    record = CompExpr(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(ADDR_STAT(stat)[1]);
+    rnam = (UInt)(READ_STAT(stat, 1));
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* compile the right hand side                                         */
-    rhs = CompExpr( ADDR_STAT(stat)[2] );
+    rhs = CompExpr(READ_STAT(stat, 2));
 
     /* emit the code for the assignment                                    */
     Emit( "ASS_REC( %c, R_%n, %c );\n", record, NAME_RNAM(rnam), rhs );
@@ -4861,13 +4863,13 @@ void CompAssRecExpr (
     }
 
     /* compile the record expression                                       */
-    record = CompExpr( ADDR_STAT(stat)[0] );
+    record = CompExpr(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = CompExpr( ADDR_STAT(stat)[1] );
+    rnam = CompExpr(READ_STAT(stat, 1));
 
     /* compile the right hand side                                         */
-    rhs = CompExpr( ADDR_STAT(stat)[2] );
+    rhs = CompExpr(READ_STAT(stat, 2));
 
     /* emit the code for the assignment                                    */
     Emit( "ASS_REC( %c, RNamObj(%c), %c );\n", record, rnam, rhs );
@@ -4895,10 +4897,10 @@ void CompUnbRecName (
     }
 
     /* compile the record expression                                       */
-    record = CompExpr( ADDR_STAT(stat)[0] );
+    record = CompExpr(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(ADDR_STAT(stat)[1]);
+    rnam = (UInt)(READ_STAT(stat, 1));
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code for the assignment                                    */
@@ -4925,10 +4927,10 @@ void            CompUnbRecExpr (
     }
 
     /* compile the record expression                                       */
-    record = CompExpr( ADDR_STAT(stat)[0] );
+    record = CompExpr(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = CompExpr( ADDR_STAT(stat)[1] );
+    rnam = CompExpr(READ_STAT(stat, 1));
 
     /* emit the code for the assignment                                    */
     Emit( "UNB_REC( %c, RNamObj(%c) );\n", record, rnam );
@@ -4956,14 +4958,14 @@ void CompAssPosObj (
     }
 
     /* compile the list expression                                         */
-    list = CompExpr( ADDR_STAT(stat)[0] );
+    list = CompExpr(READ_STAT(stat, 0));
 
     /* compile and check the position expression                           */
-    pos = CompExpr( ADDR_STAT(stat)[1] );
+    pos = CompExpr(READ_STAT(stat, 1));
     CompCheckIntSmallPos( pos );
 
     /* compile the right hand side                                         */
-    rhs = CompExpr( ADDR_STAT(stat)[2] );
+    rhs = CompExpr(READ_STAT(stat, 2));
 
     /* emit the code                                                       */
     if ( HasInfoCVar( rhs, W_INT_SMALL ) ) {
@@ -4998,13 +5000,13 @@ void CompAsssPosObj (
     }
 
     /* compile the list expression                                         */
-    list = CompExpr( ADDR_STAT(stat)[0] );
+    list = CompExpr(READ_STAT(stat, 0));
 
     /* compile and check the position expression                           */
-    poss = CompExpr( ADDR_STAT(stat)[1] );
+    poss = CompExpr(READ_STAT(stat, 1));
 
     /* compile the right hand side                                         */
-    rhss = CompExpr( ADDR_STAT(stat)[2] );
+    rhss = CompExpr(READ_STAT(stat, 2));
 
     /* emit the code                                                       */
     Emit( "AsssPosObjCheck( %c, %c, %c );\n", list, poss, rhss );
@@ -5054,10 +5056,10 @@ void CompUnbPosObj (
     }
 
     /* compile the list expression                                         */
-    list = CompExpr( ADDR_STAT(stat)[0] );
+    list = CompExpr(READ_STAT(stat, 0));
 
     /* compile and check the position expression                           */
-    pos = CompExpr( ADDR_STAT(stat)[1] );
+    pos = CompExpr(READ_STAT(stat, 1));
     CompCheckIntSmallPos( pos );
 
     /* emit the code                                                       */
@@ -5092,14 +5094,14 @@ void CompAssComObjName (
     }
 
     /* compile the record expression                                       */
-    record = CompExpr( ADDR_STAT(stat)[0] );
+    record = CompExpr(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(ADDR_STAT(stat)[1]);
+    rnam = (UInt)(READ_STAT(stat, 1));
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* compile the right hand side                                         */
-    rhs = CompExpr( ADDR_STAT(stat)[2] );
+    rhs = CompExpr(READ_STAT(stat, 2));
 
     /* emit the code for the assignment                                    */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
@@ -5135,13 +5137,13 @@ void CompAssComObjExpr (
     }
 
     /* compile the record expression                                       */
-    record = CompExpr( ADDR_STAT(stat)[0] );
+    record = CompExpr(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = CompExpr( ADDR_STAT(stat)[1] );
+    rnam = CompExpr(READ_STAT(stat, 1));
 
     /* compile the right hand side                                         */
-    rhs = CompExpr( ADDR_STAT(stat)[2] );
+    rhs = CompExpr(READ_STAT(stat, 2));
 
     /* emit the code for the assignment                                    */
     Emit( "if ( TNUM_OBJ(%c) == T_COMOBJ ) {\n", record );
@@ -5177,10 +5179,10 @@ void CompUnbComObjName (
     }
 
     /* compile the record expression                                       */
-    record = CompExpr( ADDR_STAT(stat)[0] );
+    record = CompExpr(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(ADDR_STAT(stat)[1]);
+    rnam = (UInt)(READ_STAT(stat, 1));
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code for the assignment                                    */
@@ -5215,10 +5217,10 @@ void CompUnbComObjExpr (
     }
 
     /* compile the record expression                                       */
-    record = CompExpr( ADDR_STAT(stat)[0] );
+    record = CompExpr(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = CompExpr( ADDR_STAT(stat)[1] );
+    rnam = CompExpr(READ_STAT(stat, 1));
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code for the assignment                                    */
@@ -5299,9 +5301,9 @@ void CompAssert2 (
     CVar                cnd;            /* the condition                   */
 
     Emit( "\n/* Assert( ... ); */\n" );
-    lev = CompExpr( ADDR_STAT(stat)[0] );
+    lev = CompExpr(READ_STAT(stat, 0));
     Emit( "if ( ! LT(CurrentAssertionLevel, %c) ) {\n", lev );
-    cnd = CompBoolExpr( ADDR_STAT(stat)[1] );
+    cnd = CompBoolExpr(READ_STAT(stat, 1));
     Emit( "if ( ! %c ) {\n", cnd );
     Emit( "ErrorReturnVoid(\"Assertion failure\",0L,0L,\"you may 'return;'\"" );
     Emit( ");\n");
@@ -5326,11 +5328,11 @@ void CompAssert3 (
     CVar                msg;            /* the message                     */
 
     Emit( "\n/* Assert( ... ); */\n" );
-    lev = CompExpr( ADDR_STAT(stat)[0] );
+    lev = CompExpr(READ_STAT(stat, 0));
     Emit( "if ( ! LT(CurrentAssertionLevel, %c) ) {\n", lev );
-    cnd = CompBoolExpr( ADDR_STAT(stat)[1] );
+    cnd = CompBoolExpr(READ_STAT(stat, 1));
     Emit( "if ( ! %c ) {\n", cnd );
-    msg = CompExpr( ADDR_STAT(stat)[2] );
+    msg = CompExpr(READ_STAT(stat, 2));
     Emit( "if ( %c != (Obj)(UInt)0 )", msg );
     Emit( "{\n if ( IS_STRING_REP ( %c ) )\n", msg);
     Emit( "   PrintString1( %c);\n else\n   PrintObj(%c);\n}\n", msg, msg );
@@ -5399,7 +5401,7 @@ void CompFunc (
 
     }
 
-    /* switch to this function (so that 'ADDR_STAT' and 'ADDR_EXPR' work)  */
+    /* switch to this function (so that 'CONST_ADDR_STAT' and 'CONST_ADDR_EXPR' work)  */
     SWITCH_TO_NEW_LVARS( func, narg, nloc, oldFrame );
 
     /* get the info bag                                                    */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -3158,7 +3158,7 @@ CVar CompElmListLev (
 {
     CVar                lists;          /* lists                           */
     CVar                pos;            /* position                        */
-    Int                 level;          /* level                           */
+    UInt                level;          /* level                           */
 
     /* compile the lists expression                                        */
     lists = CompExpr(READ_EXPR(expr, 0));
@@ -3168,7 +3168,7 @@ CVar CompElmListLev (
     CompCheckIntSmallPos( pos );
 
     /* get the level                                                       */
-    level = (Int)(READ_EXPR(expr, 2));
+    level = READ_EXPR(expr, 2);
 
     /* emit the code to select the elements from several lists (to <lists>)*/
     Emit( "ElmListLevel( %c, %c, %d );\n", lists, pos, level );
@@ -3190,7 +3190,7 @@ CVar CompElmsListLev (
 {
     CVar                lists;          /* lists                           */
     CVar                poss;           /* positions                       */
-    Int                 level;          /* level                           */
+    UInt                level;          /* level                           */
 
     /* compile the lists expression                                        */
     lists = CompExpr(READ_EXPR(expr, 0));
@@ -3199,7 +3199,7 @@ CVar CompElmsListLev (
     poss = CompExpr(READ_EXPR(expr, 1));
 
     /* get the level                                                       */
-    level = (Int)(READ_EXPR(expr, 2));
+    level = READ_EXPR(expr, 2);
 
     /* emit the code to select the elements from several lists (to <lists>)*/
     Emit( "ElmsListLevelCheck( %c, %c, %d );\n", lists, poss, level );
@@ -3266,7 +3266,7 @@ CVar CompElmRecName (
     record = CompExpr(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(READ_EXPR(expr, 1));
+    rnam = READ_EXPR(expr, 1);
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code to select the element of the record                   */
@@ -3336,7 +3336,7 @@ CVar CompIsbRecName (
     record = CompExpr(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(READ_EXPR(expr, 1));
+    rnam = READ_EXPR(expr, 1);
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code to test the element                                   */
@@ -3530,7 +3530,7 @@ CVar CompElmComObjName (
     record = CompExpr(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(READ_EXPR(expr, 1));
+    rnam = READ_EXPR(expr, 1);
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code to select the element of the record                   */
@@ -3617,7 +3617,7 @@ CVar CompIsbComObjName (
     record = CompExpr(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(READ_EXPR(expr, 1));
+    rnam = READ_EXPR(expr, 1);
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code to test the element                                   */
@@ -4151,11 +4151,11 @@ void CompFor (
             vart = 'm';
         }
         else if (TNUM_EXPR(READ_STAT(stat, 0)) == T_REF_HVAR) {
-            var = (UInt)(READ_EXPR(READ_STAT(stat, 0), 0));
+            var = READ_EXPR(READ_STAT(stat, 0), 0);
             vart = 'h';
         }
         else /* if ( TNUM_EXPR( READ_STAT(stat, 0) ) == T_REF_GVAR ) */ {
-            var = (UInt)(READ_EXPR(READ_STAT(stat, 0), 0));
+            var = READ_EXPR(READ_STAT(stat, 0), 0);
             CompSetUseGVar( var, COMP_USE_GVAR_ID );
             vart = 'g';
         }
@@ -4710,7 +4710,7 @@ void CompAssListLev (
     CVar                lists;          /* lists                           */
     CVar                pos;            /* position                        */
     CVar                rhss;           /* right hand sides                */
-    Int                 level;          /* level                           */
+    UInt                level;          /* level                           */
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
@@ -4728,7 +4728,7 @@ void CompAssListLev (
     rhss = CompExpr(READ_STAT(stat, 2));
 
     /* get the level                                                       */
-    level = (Int)(READ_STAT(stat, 3));
+    level = READ_STAT(stat, 3);
 
     /* emit the code                                                       */
     Emit( "AssListLevel( %c, %c, %c, %d );\n", lists, pos, rhss, level );
@@ -4750,7 +4750,7 @@ void CompAsssListLev (
     CVar                lists;          /* list                            */
     CVar                poss;           /* positions                       */
     CVar                rhss;           /* right hand sides                */
-    Int                 level;          /* level                           */
+    UInt                level;          /* level                           */
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
@@ -4767,7 +4767,7 @@ void CompAsssListLev (
     rhss = CompExpr(READ_STAT(stat, 2));
 
     /* get the level                                                       */
-    level = (Int)(READ_STAT(stat, 3));
+    level = READ_STAT(stat, 3);
 
     /* emit the code                                                       */
     Emit( "AsssListLevelCheck( %c, %c, %c, %d );\n",
@@ -4831,7 +4831,7 @@ void CompAssRecName (
     record = CompExpr(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(READ_STAT(stat, 1));
+    rnam = READ_STAT(stat, 1);
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* compile the right hand side                                         */
@@ -4900,7 +4900,7 @@ void CompUnbRecName (
     record = CompExpr(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(READ_STAT(stat, 1));
+    rnam = READ_STAT(stat, 1);
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code for the assignment                                    */
@@ -5097,7 +5097,7 @@ void CompAssComObjName (
     record = CompExpr(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(READ_STAT(stat, 1));
+    rnam = READ_STAT(stat, 1);
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* compile the right hand side                                         */
@@ -5182,7 +5182,7 @@ void CompUnbComObjName (
     record = CompExpr(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(READ_STAT(stat, 1));
+    rnam = READ_STAT(stat, 1);
     CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code for the assignment                                    */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2392,7 +2392,7 @@ CVar            CompCharExpr (
     val = CVAR_TEMP( NewTemp( "val" ) );
 
     /* emit the code                                                       */
-    Emit( "%c = ObjsChar[%d];\n", val, (Int)(((const UChar*)CONST_ADDR_EXPR(expr))[0]));
+    Emit( "%c = ObjsChar[%d];\n", val, READ_EXPR(expr, 0));
 
     /* we know that we have a value                                        */
     SetInfoCVar( val, W_BOUND );

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -796,7 +796,7 @@ Obj             EvalFalseExpr (
 Obj             EvalCharExpr (
     Expr                expr )
 {
-    return ObjsChar[ ((const UChar*)CONST_ADDR_EXPR(expr))[0] ];
+    return ObjsChar[ READ_EXPR(expr, 0) ];
 }
 
 
@@ -1643,7 +1643,7 @@ void            PrintCharExpr (
 {
     UChar               chr;
 
-    chr = *(const UChar*)CONST_ADDR_EXPR(expr);
+    chr = READ_EXPR(expr, 0);
     if      ( chr == '\n'  )  Pr("'\\n'",0L,0L);
     else if ( chr == '\t'  )  Pr("'\\t'",0L,0L);
     else if ( chr == '\r'  )  Pr("'\\r'",0L,0L);

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -136,14 +136,14 @@ Obj             EvalOr (
     Expr                tmp;            /* temporary expression            */
 
     /* evaluate and test the left operand                                  */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_BOOL_EXPR( tmp );
     if ( opL != False ) {
         return True;
     }
 
     /* evaluate and test the right operand                                 */
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     return EVAL_BOOL_EXPR( tmp );
 }
 
@@ -170,7 +170,7 @@ Obj             EvalAnd (
     Expr                tmp;            /* temporary expression            */
 
     /* if the left operand is 'false', this is the result                  */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
     if      ( opL == False ) {
         return opL;
@@ -178,13 +178,13 @@ Obj             EvalAnd (
 
     /* if the left operand is 'true', the result is the right operand      */
     else if ( opL == True  ) {
-        tmp = ADDR_EXPR(expr)[1];
+        tmp = READ_EXPR(expr, 1);
         return EVAL_BOOL_EXPR( tmp );
     }
 
     /* handle the 'and' of two filters                                    */
     else if ( TNUM_OBJ(opL) == T_FUNCTION ) {
-        tmp = ADDR_EXPR(expr)[1];
+        tmp = READ_EXPR(expr, 1);
         opR = EVAL_EXPR( tmp );
         if ( TNUM_OBJ(opR) == T_FUNCTION ) {
             return NewAndFilter( opL, opR );
@@ -224,7 +224,7 @@ Obj             EvalNot (
     Expr                tmp;            /* temporary expression            */
 
     /* evaluate the operand to a boolean                                   */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     op = EVAL_BOOL_EXPR( tmp );
 
     /* compute the negation                                                */
@@ -255,9 +255,9 @@ Obj             EvalEq (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* compare the operands                                                */
@@ -289,9 +289,9 @@ Obj             EvalNe (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* compare the operands                                                */
@@ -323,9 +323,9 @@ Obj             EvalLt (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* compare the operands                                                */
@@ -357,9 +357,9 @@ Obj             EvalGe (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* compare the operands                                                */
@@ -391,9 +391,9 @@ Obj             EvalGt (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* compare the operands                                                */
@@ -425,9 +425,9 @@ Obj             EvalLe (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* compare the operands                                                */
@@ -457,11 +457,11 @@ Obj             EvalIn (
     Expr                tmp;            /* temporary expression            */
 
     /* evaluate <opL>                                                      */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
 
     /* evaluate <opR>                                                      */
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* perform the test                                                    */
@@ -493,9 +493,9 @@ Obj             EvalSum (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* first try to treat the operands as small integers with small result */
@@ -530,7 +530,7 @@ Obj             EvalAInv (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
 
     /* compute the additive inverse                                        */
@@ -562,9 +562,9 @@ Obj             EvalDiff (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* first try to treat the operands as small integers with small result */
@@ -601,9 +601,9 @@ Obj             EvalProd (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* first try to treat the operands as small integers with small result */
@@ -640,9 +640,9 @@ Obj             EvalQuo (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* dispatch to the division function                                   */
@@ -674,9 +674,9 @@ Obj             EvalMod (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* dispatch to the remainder function                                  */
@@ -708,9 +708,9 @@ Obj             EvalPow (
     Expr                tmp;            /* temporary expression            */
 
     /* get the operands                                                    */
-    tmp = ADDR_EXPR(expr)[0];
+    tmp = READ_EXPR(expr, 0);
     opL = EVAL_EXPR( tmp );
-    tmp = ADDR_EXPR(expr)[1];
+    tmp = READ_EXPR(expr, 1);
     opR = EVAL_EXPR( tmp );
 
     /* dispatch to the powering function                                   */
@@ -729,17 +729,15 @@ Obj             EvalPow (
 **  'EvalIntExpr' evaluates the literal integer expression <expr> and returns
 **  its value.
 */
-#define IDDR_EXPR(expr)         ((UInt2*)ADDR_EXPR(expr))
-
 Obj             EvalIntExpr (
     Expr                expr )
 {
     Obj                 val;            /* integer, result                 */
 
-    
     /* allocate the integer                                                */
-    val = NewBag( ((UInt *)ADDR_EXPR(expr))[0], SIZE_EXPR(expr)-sizeof(UInt));
-    memcpy(ADDR_OBJ(val), ((UInt *)ADDR_EXPR(expr))+1, SIZE_EXPR(expr)-sizeof(UInt));
+    val = NewBag(READ_EXPR(expr, 0), SIZE_EXPR(expr) - sizeof(UInt));
+    memcpy(ADDR_OBJ(val), ((const UInt *)CONST_ADDR_EXPR(expr)) + 1,
+           SIZE_EXPR(expr) - sizeof(UInt));
 
     /* return the value                                                    */
     return val;
@@ -798,7 +796,7 @@ Obj             EvalFalseExpr (
 Obj             EvalCharExpr (
     Expr                expr )
 {
-    return ObjsChar[ ((UChar*)ADDR_EXPR(expr))[0] ];
+    return ObjsChar[ ((const UChar*)CONST_ADDR_EXPR(expr))[0] ];
 }
 
 
@@ -831,7 +829,7 @@ Obj             EvalPermExpr (
 
     /* loop over the cycles                                                */
     for ( i = 1; i <= SIZE_EXPR(expr)/sizeof(Expr); i++ ) {
-        cycle = ADDR_EXPR(expr)[i-1];
+        cycle = READ_EXPR(expr, i - 1);
 
         // Need to inform profiling this cycle expression is executed, as
         // we never call EVAL_EXPR on it.
@@ -841,7 +839,7 @@ Obj             EvalPermExpr (
         for ( j = SIZE_EXPR(cycle)/sizeof(Expr); 1 <= j; j-- ) {
 
             /* get and check current entry for the cycle                   */
-            val = EVAL_EXPR( ADDR_EXPR( cycle )[j-1] );
+            val = EVAL_EXPR(READ_EXPR(cycle, j - 1));
             while ( ! IS_INTOBJ(val) || INT_INTOBJ(val) <= 0 ) {
                 val = ErrorReturnObj(
               "Permutation: <expr> must be a positive integer (not a %s)",
@@ -1049,7 +1047,7 @@ ALWAYS_INLINE void ListExpr2(Obj list, Expr expr, Int tildeInUse)
     for ( i = 1; i <= len; i++ ) {
 
         /* if the subexpression is empty                                   */
-        if ( ADDR_EXPR(expr)[i-1] == 0 ) {
+        if ( READ_EXPR(expr, i-1) == 0 ) {
           if (!posshole)
             posshole = 1;
           continue;
@@ -1063,7 +1061,7 @@ ALWAYS_INLINE void ListExpr2(Obj list, Expr expr, Int tildeInUse)
                 }
                 posshole = 2;
               }
-            sub = EVAL_EXPR( ADDR_EXPR(expr)[i-1] );
+            sub = EVAL_EXPR( READ_EXPR(expr, i-1) );
             if (tildeInUse) {
                 ASS_LIST(list, i, sub);
             }
@@ -1098,7 +1096,7 @@ Obj             EvalRangeExpr (
     Int                 high;           /* high (as C integer)             */
 
     /* evaluate the low value                                              */
-    val = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    val = EVAL_EXPR(READ_EXPR(expr, 0));
     while ( ! IS_INTOBJ(val) ) {
         val = ErrorReturnObj(
             "Range: <first> must be an integer less than 2^%d (not a %s)",
@@ -1109,7 +1107,7 @@ Obj             EvalRangeExpr (
 
     /* evaluate the second value (if present)                              */
     if ( SIZE_EXPR(expr) == 3*sizeof(Expr) ) {
-        val = EVAL_EXPR( ADDR_EXPR(expr)[1] );
+        val = EVAL_EXPR(READ_EXPR(expr, 1));
         while ( ! IS_INTOBJ(val) || INT_INTOBJ(val) == low ) {
             if ( ! IS_INTOBJ(val) ) {
                 val = ErrorReturnObj(
@@ -1131,7 +1129,7 @@ Obj             EvalRangeExpr (
     }
 
     /* evaluate and check the high value                                   */
-    val = EVAL_EXPR( ADDR_EXPR(expr)[ SIZE_EXPR(expr)/sizeof(Expr)-1 ] );
+    val = EVAL_EXPR(READ_EXPR(expr, SIZE_EXPR(expr) / sizeof(Expr) - 1));
     while ( ! IS_INTOBJ(val) || (INT_INTOBJ(val) - low) % inc != 0 ) {
         if ( ! IS_INTOBJ(val) ) {
             val = ErrorReturnObj(
@@ -1193,10 +1191,10 @@ Obj             EvalStringExpr (
 {
     Obj                 string;         /* string value, result            */
     UInt                 len;           /* size of expression              */
-    
-    len = *((UInt *)ADDR_EXPR(expr));
+
+    len = READ_EXPR(expr, 0);
     string = NEW_STRING(len);
-    memcpy(ADDR_OBJ(string), ADDR_EXPR(expr), SIZEBAG_STRINGLEN(len) );
+    memcpy(ADDR_OBJ(string), CONST_ADDR_EXPR(expr), SIZEBAG_STRINGLEN(len));
 
     /* return the string                                                   */
     return string;
@@ -1226,7 +1224,7 @@ Obj             EvalFloatExprLazy (
      * cache concurrently in that it won't crash, but may occasionally
      * result in evaluating a floating point literal twice.
      */
-    ix = ((UInt *)ADDR_EXPR(expr))[1];
+    ix = READ_EXPR(expr, 1);
     if (ix && (!MAX_FLOAT_LITERAL_CACHE_SIZE || 
                MAX_FLOAT_LITERAL_CACHE_SIZE == INTOBJ_INT(0) ||
                ix <= INT_INTOBJ(MAX_FLOAT_LITERAL_CACHE_SIZE))) {
@@ -1236,11 +1234,10 @@ Obj             EvalFloatExprLazy (
       if (fl)
         return fl;
     }
-    len = *((UInt *)ADDR_EXPR(expr));
+    len = READ_EXPR(expr, 0);
     string = NEW_STRING(len);
-    memcpy(CHARS_STRING(string), 
-           (char *)ADDR_EXPR(expr) + 2*sizeof(UInt),
-           len );
+    memcpy(CHARS_STRING(string),
+           (const char *)CONST_ADDR_EXPR(expr) + 2 * sizeof(UInt), len);
     fl = CALL_1ARGS(CONVERT_FLOAT_LITERAL, string);
     if (cache) {
       ASS_LIST(cache, ix, fl);
@@ -1260,7 +1257,7 @@ extern Obj EAGER_FLOAT_LITERAL_CACHE;
 
 Obj EvalFloatExprEager(Expr expr)
 {
-    UInt ix = ((UInt *)ADDR_EXPR(expr))[0];
+    UInt ix = READ_EXPR(expr, 0);
     Obj fl = ELM_LIST(EAGER_FLOAT_LITERAL_CACHE, ix);
     return fl;
 }
@@ -1383,7 +1380,7 @@ void            RecExpr2 (
     for ( i = 1; i <= len; i++ ) {
 
         /* handle the name                                                 */
-        tmp = ADDR_EXPR(expr)[2*i-2];
+        tmp = READ_EXPR(expr, 2 * i - 2);
         if ( IS_INTEXPR(tmp) ) {
             rnam = (UInt)INT_INTEXPR(tmp);
         }
@@ -1392,7 +1389,7 @@ void            RecExpr2 (
         }
 
         /* if the subexpression is empty (cannot happen for records)       */
-        tmp = ADDR_EXPR(expr)[2*i-1];
+        tmp = READ_EXPR(expr, 2 * i - 1);
         if ( tmp == 0 ) {
             continue;
         }
@@ -1483,7 +1480,7 @@ void            PrintNot (
     else Pr("%2>",0L,0L);
     
     Pr("not%> ",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<",0L,0L);
     
     /* if necessary print the closing parenthesis                          */
@@ -1514,7 +1511,7 @@ void            PrintAInv (
     else Pr("%2>",0L,0L);
     
     Pr("-%> ",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<",0L,0L);
     
     /* if necessary print the closing parenthesis                          */
@@ -1558,16 +1555,16 @@ void            PrintBinop (
 
     /* print the left operand                                              */
     if ( TNUM_EXPR(expr) == T_POW
-         && ((  (IS_INTEXPR(ADDR_EXPR(expr)[0])
-                 && INT_INTEXPR(ADDR_EXPR(expr)[0]) < 0)
-                || TNUM_EXPR(ADDR_EXPR(expr)[0]) == T_INTNEG)
-             || TNUM_EXPR(ADDR_EXPR(expr)[0]) == T_POW) ) {
+         && ((  (IS_INTEXPR(READ_EXPR(expr, 0))
+                 && INT_INTEXPR(READ_EXPR(expr, 0)) < 0)
+                || TNUM_EXPR(READ_EXPR(expr, 0)) == T_INTNEG)
+             || TNUM_EXPR(READ_EXPR(expr, 0)) == T_POW) ) {
         Pr( "(", 0L, 0L );
-        PrintExpr( ADDR_EXPR(expr)[0] );
+        PrintExpr(READ_EXPR(expr, 0));
         Pr( ")", 0L, 0L );
     }
     else {
-        PrintExpr( ADDR_EXPR(expr)[0] );
+        PrintExpr(READ_EXPR(expr, 0));
     }
 
     /* print the operator                                                  */
@@ -1575,7 +1572,7 @@ void            PrintBinop (
 
     /* print the right operand                                             */
     PrintPrecedence++;
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     PrintPrecedence--;
 
     /* if necessary print the closing parenthesis                          */
@@ -1646,7 +1643,7 @@ void            PrintCharExpr (
 {
     UChar               chr;
 
-    chr = *(UChar*)ADDR_EXPR(expr);
+    chr = *(const UChar*)CONST_ADDR_EXPR(expr);
     if      ( chr == '\n'  )  Pr("'\\n'",0L,0L);
     else if ( chr == '\t'  )  Pr("'\\t'",0L,0L);
     else if ( chr == '\r'  )  Pr("'\\r'",0L,0L);
@@ -1677,13 +1674,13 @@ void            PrintPermExpr (
     
     /* print all cycles                                                    */
     for ( i = 1; i <= SIZE_EXPR(expr)/sizeof(Expr); i++ ) {
-        cycle = ADDR_EXPR(expr)[i-1];
+        cycle = READ_EXPR(expr, i - 1);
         Pr("%>(",0L,0L);
 
         /* print all entries of that cycle                                 */
         for ( j = 1; j <= SIZE_EXPR(cycle)/sizeof(Expr); j++ ) {
             Pr("%>",0L,0L);
-            PrintExpr( ADDR_EXPR(cycle)[j-1] );
+            PrintExpr(READ_EXPR(cycle, j - 1));
             Pr("%<",0L,0L);
             if ( j < SIZE_EXPR(cycle)/sizeof(Expr) )  Pr(",",0L,0L);
         }
@@ -1712,7 +1709,7 @@ void            PrintListExpr (
     /* loop over the entries                                               */
     Pr("%2>[ %2>",0L,0L);
     for ( i = 1;  i <= len;  i++ ) {
-        elm = ADDR_EXPR(expr)[i-1];
+        elm = READ_EXPR(expr, i - 1);
         if ( elm != 0 ) {
             if ( 1 < i )  Pr("%<,%< %2>",0L,0L);
             PrintExpr( elm );
@@ -1735,14 +1732,14 @@ void            PrintRangeExpr (
     Expr                expr )
 {
     if ( SIZE_EXPR( expr ) == 2*sizeof(Expr) ) {
-        Pr("%2>[ %2>",0L,0L);    PrintExpr( ADDR_EXPR(expr)[0] );
-        Pr("%2< .. %2>",0L,0L);  PrintExpr( ADDR_EXPR(expr)[1] );
+        Pr("%2>[ %2>",0L,0L);    PrintExpr( READ_EXPR(expr, 0) );
+        Pr("%2< .. %2>",0L,0L);  PrintExpr( READ_EXPR(expr, 1) );
         Pr(" %4<]",0L,0L);
     }
     else {
-        Pr("%2>[ %2>",0L,0L);    PrintExpr( ADDR_EXPR(expr)[0] );
-        Pr("%<,%< %2>",0L,0L);   PrintExpr( ADDR_EXPR(expr)[1] );
-        Pr("%2< .. %2>",0L,0L);  PrintExpr( ADDR_EXPR(expr)[2] );
+        Pr("%2>[ %2>",0L,0L);    PrintExpr( READ_EXPR(expr, 0) );
+        Pr("%<,%< %2>",0L,0L);   PrintExpr( READ_EXPR(expr, 1) );
+        Pr("%2< .. %2>",0L,0L);  PrintExpr( READ_EXPR(expr, 2) );
         Pr(" %4<]",0L,0L);
     }
 }
@@ -1758,7 +1755,6 @@ void            PrintStringExpr (
     Expr                expr )
 {
     PrintString(EvalStringExpr(expr));
-    /*Pr( "\"%S\"", (Int)ADDR_EXPR(expr), 0L );*/
 }
 
 /****************************************************************************
@@ -1770,7 +1766,7 @@ void            PrintStringExpr (
 void            PrintFloatExprLazy (
     Expr                expr )
 {
-  Pr("%s", (Int)(((char *)ADDR_EXPR(expr) + 2*sizeof(UInt))), 0L);
+  Pr("%s", (Int)(((const char *)CONST_ADDR_EXPR(expr) + 2*sizeof(UInt))), 0L);
 }
 
 /****************************************************************************
@@ -1783,9 +1779,9 @@ void            PrintFloatExprEager (
     Expr                expr )
 {
   Char mark;
-  Pr("%s", (Int)(((char *)ADDR_EXPR(expr) + 3*sizeof(UInt))), 0L);
+  Pr("%s", (Int)(((const char *)CONST_ADDR_EXPR(expr) + 3*sizeof(UInt))), 0L);
   Pr("_",0L,0L);
-  mark = (Char)(((UInt *)ADDR_EXPR(expr))[2]);
+  mark = (Char)(((const UInt *)CONST_ADDR_EXPR(expr))[2]);
   if (mark != '\0') {
     Pr("%c",mark,0L);
   }
@@ -1806,7 +1802,7 @@ void            PrintRecExpr1 (
   
   for ( i = 1; i <= SIZE_EXPR(expr)/(2*sizeof(Expr)); i++ ) {
         /* print an ordinary record name                                   */
-        tmp = ADDR_EXPR(expr)[2*i-2];
+        tmp = READ_EXPR(expr, 2 * i - 2);
         if ( IS_INTEXPR(tmp) ) {
             Pr( "%H", (Int)NAME_RNAM( INT_INTEXPR(tmp) ), 0L );
         }
@@ -1819,7 +1815,7 @@ void            PrintRecExpr1 (
         }
 
         /* print the component                                             */
-        tmp = ADDR_EXPR(expr)[2*i-1];
+        tmp = READ_EXPR(expr, 2 * i - 1);
         Pr("%< := %>",0L,0L);
         PrintExpr( tmp );
         if ( i < SIZE_EXPR(expr)/(2*sizeof(Expr)) )

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -94,10 +94,10 @@ static UInt ExecProccallOpts(Stat call)
   Obj opts;
   
   SET_BRK_CURR_STAT( call );
-  opts = EVAL_EXPR( ADDR_STAT(call)[0] );
+  opts = EVAL_EXPR(READ_STAT(call, 0));
   CALL_1ARGS(PushOptions, opts);
 
-  EXEC_STAT( ADDR_STAT( call )[1]);
+  EXEC_STAT(READ_STAT(call, 1));
 
   CALL_0ARGS(PopOptions);
   
@@ -282,12 +282,12 @@ static Obj EvalFunccallOpts(Expr call)
 {
   Obj opts;
   Obj res;
-  
-  
-  opts = EVAL_EXPR( ADDR_STAT(call)[0] );
+
+
+  opts = EVAL_EXPR(READ_STAT(call, 0));
   CALL_1ARGS(PushOptions, opts);
 
-  res = EVAL_EXPR( ADDR_STAT( call )[1]);
+  res = EVAL_EXPR(READ_STAT(call, 1));
 
   CALL_0ARGS(PopOptions);
   
@@ -718,7 +718,7 @@ Obj             EvalFuncExpr (
 
     /* get the function expression bag                                     */
     fexs = FEXS_FUNC( CURR_FUNC() );
-    fexp = ELM_PLIST( fexs, (Int)(ADDR_EXPR(expr)[0]) );
+    fexp = ELM_PLIST(fexs, (Int)(READ_EXPR(expr, 0)));
 
     /* and make the function                                               */
     return MakeFunction( fexp );
@@ -739,7 +739,7 @@ void            PrintFuncExpr (
 
     /* get the function expression bag                                     */
     fexs = FEXS_FUNC( CURR_FUNC() );
-    fexp = ELM_PLIST( fexs, (Int)(ADDR_EXPR(expr)[0]) );
+    fexp = ELM_PLIST(fexs, (Int)(READ_EXPR(expr, 0)));
     PrintFunction( fexp );
     /* Pr("function ... end",0L,0L); */
 }
@@ -812,10 +812,10 @@ void            PrintFunccall (
 void             PrintFunccallOpts (
     Expr                call )
 {
-  PrintFunccall1( ADDR_STAT( call )[1]);
-  Pr(" :%2> ", 0L, 0L);
-  PrintRecExpr1 ( ADDR_STAT( call )[0]);
-  Pr(" %4<)",0L,0L);
+    PrintFunccall1(READ_STAT(call, 1));
+    Pr(" :%2> ", 0L, 0L);
+    PrintRecExpr1(READ_STAT(call, 0));
+    Pr(" %4<)", 0L, 0L);
 }
 
   

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -718,7 +718,7 @@ Obj             EvalFuncExpr (
 
     /* get the function expression bag                                     */
     fexs = FEXS_FUNC( CURR_FUNC() );
-    fexp = ELM_PLIST(fexs, (Int)(READ_EXPR(expr, 0)));
+    fexp = ELM_PLIST(fexs, READ_EXPR(expr, 0));
 
     /* and make the function                                               */
     return MakeFunction( fexp );
@@ -739,7 +739,7 @@ void            PrintFuncExpr (
 
     /* get the function expression bag                                     */
     fexs = FEXS_FUNC( CURR_FUNC() );
-    fexp = ELM_PLIST(fexs, (Int)(READ_EXPR(expr, 0)));
+    fexp = ELM_PLIST(fexs, READ_EXPR(expr, 0));
     PrintFunction( fexp );
     /* Pr("function ... end",0L,0L); */
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -1568,7 +1568,7 @@ void            PrintReturnObj (
 {
     Expr expr = READ_STAT(stat, 0);
     if (TNUM_EXPR(expr) == T_REF_GVAR &&
-        (UInt)(READ_STAT(expr, 0)) == GVarName("TRY_NEXT_METHOD")) {
+        READ_STAT(expr, 0) == GVarName("TRY_NEXT_METHOD")) {
         Pr( "TryNextMethod();", 0L, 0L );
     }
     else {

--- a/src/vars.c
+++ b/src/vars.c
@@ -164,8 +164,8 @@ UInt            ExecAssLVar (
 
     /* assign the right hand side to the local variable                    */
     SET_BRK_CURR_STAT( stat );
-    rhs = EVAL_EXPR( ADDR_STAT(stat)[1] );
-    ASS_LVAR( (UInt)(ADDR_STAT(stat)[0]), rhs );
+    rhs = EVAL_EXPR(READ_STAT(stat, 1));
+    ASS_LVAR((UInt)(READ_STAT(stat, 0)), rhs);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -175,7 +175,7 @@ UInt            ExecUnbLVar (
     Stat                stat )
 {
     /* unbind the local variable                                           */
-    ASS_LVAR( (UInt)(ADDR_STAT(stat)[0]), (Obj)0 );
+    ASS_LVAR((UInt)(READ_STAT(stat, 0)), (Obj)0);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -189,7 +189,7 @@ Obj             EvalIsbLVar (
     Obj                 val;            /* value, result                   */
 
     /* get the value of the local variable                                 */
-    val = OBJ_LVAR( (UInt)(ADDR_EXPR(expr)[0]) );
+    val = OBJ_LVAR((UInt)(READ_EXPR(expr, 0)));
 
     /* return the value                                                    */
     return (val != (Obj)0 ? True : False);
@@ -206,9 +206,9 @@ void            PrintAssLVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
-    Pr( "%H", (Int)NAME_LVAR( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr("%H", (Int)NAME_LVAR((UInt)(READ_STAT(stat, 0))), 0L);
     Pr( "%< %>:= ", 0L, 0L );
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     Pr( "%2<;", 0L, 0L );
 }
 
@@ -216,7 +216,7 @@ void            PrintUnbLVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
-    Pr( "%H", (Int)NAME_LVAR( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr("%H", (Int)NAME_LVAR((UInt)(READ_STAT(stat, 0))), 0L);
     Pr( " );", 0L, 0L );
 }
 
@@ -237,7 +237,7 @@ void            PrintIsbLVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr( "%H", (Int)NAME_LVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
+    Pr("%H", (Int)NAME_LVAR((UInt)(READ_EXPR(expr, 0))), 0L);
     Pr( " )", 0L, 0L );
 }
 
@@ -321,8 +321,8 @@ UInt            ExecAssHVar (
 
     /* assign the right hand side to the higher variable                   */
     SET_BRK_CURR_STAT( stat );
-    rhs = EVAL_EXPR( ADDR_STAT(stat)[1] );
-    ASS_HVAR( (UInt)(ADDR_STAT(stat)[0]), rhs );
+    rhs = EVAL_EXPR(READ_STAT(stat, 1));
+    ASS_HVAR((UInt)(READ_STAT(stat, 0)), rhs);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -332,7 +332,7 @@ UInt            ExecUnbHVar (
     Stat                stat )
 {
     /* unbind the higher variable                                          */
-    ASS_HVAR( (UInt)(ADDR_STAT(stat)[0]), 0 );
+    ASS_HVAR((UInt)(READ_STAT(stat, 0)), 0);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -350,7 +350,7 @@ Obj             EvalRefHVar (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
-    UInt hvar = (UInt)(ADDR_EXPR(expr)[0]);
+    UInt                hvar = (UInt)(READ_EXPR(expr, 0));
 
     /* get and check the value of the higher variable                      */
     while ( (val = OBJ_HVAR(hvar)) == 0 ) {
@@ -370,7 +370,7 @@ Obj             EvalIsbHVar (
     Obj                 val;            /* value, result                   */
 
     /* get the value of the higher variable                                */
-    val = OBJ_HVAR( (UInt)(ADDR_EXPR(expr)[0]) );
+    val = OBJ_HVAR((UInt)(READ_EXPR(expr, 0)));
 
     /* return the value                                                    */
     return (val != (Obj)0 ? True : False);
@@ -387,9 +387,9 @@ void            PrintAssHVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
-    Pr( "%H", (Int)NAME_HVAR( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr("%H", (Int)NAME_HVAR((UInt)(READ_STAT(stat, 0))), 0L);
     Pr( "%< %>:= ", 0L, 0L );
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     Pr( "%2<;", 0L, 0L );
 }
 
@@ -397,7 +397,7 @@ void            PrintUnbHVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
-    Pr( "%H", (Int)NAME_HVAR( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr("%H", (Int)NAME_HVAR((UInt)(READ_STAT(stat, 0))), 0L);
     Pr( " );", 0L, 0L );
 }
 
@@ -411,14 +411,14 @@ void            PrintUnbHVar (
 void            PrintRefHVar (
     Expr                expr )
 {
-    Pr( "%H", (Int)NAME_HVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
+    Pr("%H", (Int)NAME_HVAR((UInt)(READ_EXPR(expr, 0))), 0L);
 }
 
 void            PrintIsbHVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr( "%H", (Int)NAME_HVAR( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
+    Pr("%H", (Int)NAME_HVAR((UInt)(READ_EXPR(expr, 0))), 0L);
     Pr( " )", 0L, 0L );
 }
 
@@ -437,8 +437,8 @@ UInt            ExecAssGVar (
 
     /* assign the right hand side to the global variable                   */
     SET_BRK_CURR_STAT( stat );
-    rhs = EVAL_EXPR( ADDR_STAT(stat)[1] );
-    AssGVar( (UInt)(ADDR_STAT(stat)[0]), rhs );
+    rhs = EVAL_EXPR(READ_STAT(stat, 1));
+    AssGVar((UInt)(READ_STAT(stat, 0)), rhs);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -448,7 +448,7 @@ UInt            ExecUnbGVar (
     Stat                stat )
 {
     /* unbind the global variable                                          */
-    AssGVar( (UInt)(ADDR_STAT(stat)[0]), (Obj)0 );
+    AssGVar((UInt)(READ_STAT(stat, 0)), (Obj)0);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -468,10 +468,10 @@ Obj             EvalRefGVar (
     Obj                 val;            /* value, result                   */
 
     /* get and check the value of the global variable                      */
-    while ( (val = ValAutoGVar( (UInt)(ADDR_EXPR(expr)[0]) )) == 0 ) {
+    while ( (val = ValAutoGVar( (UInt)(READ_EXPR(expr, 0)) )) == 0 ) {
         ErrorReturnVoid(
             "Variable: '%g' must have an assigned value",
-            (Int)NameGVar( (UInt)(ADDR_EXPR(expr)[0]) ), 0L,
+            (Int)NameGVar( (UInt)(READ_EXPR(expr, 0)) ), 0L,
             "you can 'return;' after assigning a value" );
     }
 
@@ -485,7 +485,7 @@ Obj             EvalIsbGVar (
     Obj                 val;            /* value, result                   */
 
     /* get the value of the global variable                                */
-    val = ValAutoGVar( (UInt)(ADDR_EXPR(expr)[0]) );
+    val = ValAutoGVar((UInt)(READ_EXPR(expr, 0)));
 
     /* return the value                                                    */
     return (val != (Obj)0 ? True : False);
@@ -502,9 +502,9 @@ void            PrintAssGVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
-    Pr( "%H", (Int)NameGVar( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr("%H", (Int)NameGVar((UInt)(READ_STAT(stat, 0))), 0L);
     Pr( "%< %>:= ", 0L, 0L );
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     Pr( "%2<;", 0L, 0L );
 }
 
@@ -512,7 +512,7 @@ void            PrintUnbGVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
-    Pr( "%H", (Int)NameGVar( (UInt)(ADDR_STAT(stat)[0]) ), 0L );
+    Pr("%H", (Int)NameGVar((UInt)(READ_STAT(stat, 0))), 0L);
     Pr( " );", 0L, 0L );
 }
 
@@ -526,14 +526,14 @@ void            PrintUnbGVar (
 void            PrintRefGVar (
     Expr                expr )
 {
-    Pr( "%H", (Int)NameGVar( (UInt)(ADDR_STAT(expr)[0]) ), 0L );
+    Pr("%H", (Int)NameGVar((UInt)(READ_STAT(expr, 0))), 0L);
 }
 
 void            PrintIsbGVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr( "%H", (Int)NameGVar( (UInt)(ADDR_EXPR(expr)[0]) ), 0L );
+    Pr("%H", (Int)NameGVar((UInt)(READ_EXPR(expr, 0))), 0L);
     Pr( " )", 0L, 0L );
 }
 
@@ -555,13 +555,13 @@ UInt            ExecAssList (
 
     /* evaluate the list (checking is done by 'ASS_LIST')                  */
     SET_BRK_CURR_STAT( stat );
-    list = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    list = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate the position                                               */
-    pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
+    pos = EVAL_EXPR(READ_STAT(stat, 1));
 
     /* evaluate the right hand side                                        */
-    rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
+    rhs = EVAL_EXPR(READ_STAT(stat, 2));
 
     if (IS_POS_INTOBJ(pos)) {
         p = INT_INTOBJ(pos);
@@ -604,14 +604,14 @@ UInt            ExecAss2List (
 
     /* evaluate the list (checking is done by 'ASS_LIST')                  */
     SET_BRK_CURR_STAT( stat );
-    list = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    list = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate the position                                               */
-    pos1 = EVAL_EXPR( ADDR_STAT(stat)[1] );
-    pos2 = EVAL_EXPR( ADDR_STAT(stat)[2] );
+    pos1 = EVAL_EXPR(READ_STAT(stat, 1));
+    pos2 = EVAL_EXPR(READ_STAT(stat, 2));
 
     /* evaluate the right hand side                                        */
-    rhs = EVAL_EXPR( ADDR_STAT(stat)[3] );
+    rhs = EVAL_EXPR(READ_STAT(stat, 3));
 
     ASS2_LIST( list, pos1, pos2, rhs );
 
@@ -637,21 +637,21 @@ UInt            ExecAssXList (
 
     /* evaluate the list (checking is done by 'ASS_LIST')                  */
     SET_BRK_CURR_STAT( stat );
-    list = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    list = EVAL_EXPR(READ_STAT(stat, 0));
 
     narg = SIZE_STAT(stat)/sizeof(Stat) - 2;
     ixs = NEW_PLIST(T_PLIST,narg);
 
     for (i = 1; i <= narg; i++) {
       /* evaluate the position                                             */
-      pos = EVAL_EXPR( ADDR_STAT(stat)[i] );
+      pos = EVAL_EXPR(READ_STAT(stat, i));
       SET_ELM_PLIST(ixs,i,pos);
       CHANGED_BAG(ixs);
     }
     SET_LEN_PLIST(ixs,narg);
 
     /* evaluate the right hand side                                        */
-    rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
+    rhs = EVAL_EXPR(READ_STAT(stat, 2));
 
     ASSB_LIST(list, ixs, rhs);
 
@@ -676,14 +676,14 @@ UInt            ExecAsssList (
 
     /* evaluate the list (checking is done by 'ASSS_LIST')                 */
     SET_BRK_CURR_STAT( stat );
-    list = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    list = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate and check the positions                                    */
-    poss = EVAL_EXPR( ADDR_STAT(stat)[1] );
+    poss = EVAL_EXPR(READ_STAT(stat, 1));
     CheckIsPossList("List Assignment", poss);
 
     /* evaluate and check right hand sides                                 */
-    rhss = EVAL_EXPR( ADDR_STAT(stat)[2] );
+    rhss = EVAL_EXPR(READ_STAT(stat, 2));
     CheckIsDenseList("List Assignment", "rhss", rhss);
     CheckSameLength("List Assignment", "rhss", "positions", rhss, poss);
 
@@ -722,21 +722,21 @@ UInt            ExecAssListLevel (
     /* evaluate lists (if this works, then <lists> is nested <level> deep, */
     /* checking it is nested <level>+1 deep is done by 'AssListLevel')     */
     SET_BRK_CURR_STAT( stat );
-    lists = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    lists = EVAL_EXPR(READ_STAT(stat, 0));
     narg = SIZE_STAT(stat)/sizeof(Stat) -3;
     ixs = NEW_PLIST(T_PLIST, narg);
     for (i = 1; i <= narg; i++) {
-      pos = EVAL_EXPR(ADDR_STAT(stat)[i]);
-      SET_ELM_PLIST(ixs,i,pos);
-      CHANGED_BAG(ixs);
+        pos = EVAL_EXPR(READ_STAT(stat, i));
+        SET_ELM_PLIST(ixs, i, pos);
+        CHANGED_BAG(ixs);
     }
     SET_LEN_PLIST(ixs, narg);
 
     /* evaluate right hand sides (checking is done by 'AssListLevel')      */
-    rhss = EVAL_EXPR( ADDR_STAT(stat)[narg+1] );
-      
+    rhss = EVAL_EXPR(READ_STAT(stat, narg + 1));
+
     /* get the level                                                       */
-    level = (Int)(ADDR_STAT(stat)[narg+2]);
+    level = (Int)(READ_STAT(stat, narg + 2));
 
     /* assign the right hand sides to the elements of several lists        */
     AssListLevel( lists, ixs, rhss, level );
@@ -771,17 +771,17 @@ UInt            ExecAsssListLevel (
     /* evaluate lists (if this works, then <lists> is nested <level> deep, */
     /* checking it is nested <level>+1 deep is done by 'AsssListLevel')    */
     SET_BRK_CURR_STAT( stat );
-    lists = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    lists = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate and check the positions                                    */
-    poss = EVAL_EXPR( ADDR_EXPR(stat)[1] );
+    poss = EVAL_EXPR(READ_EXPR(stat, 1));
     CheckIsPossList("List Assignment", poss);
 
     /* evaluate right hand sides (checking is done by 'AsssListLevel')     */
-    rhss = EVAL_EXPR( ADDR_STAT(stat)[2] );
+    rhss = EVAL_EXPR(READ_STAT(stat, 2));
 
     /* get the level                                                       */
-    level = (Int)(ADDR_STAT(stat)[3]);
+    level = (Int)(READ_STAT(stat, 3));
 
     /* assign the right hand sides to several elements of several lists    */
     AsssListLevel( lists, poss, rhss, level );
@@ -809,10 +809,10 @@ UInt            ExecUnbList (
 
     /* evaluate the list (checking is done by 'LEN_LIST')                  */
     SET_BRK_CURR_STAT( stat );
-    list = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    list = EVAL_EXPR(READ_STAT(stat, 0));
     narg = SIZE_STAT(stat)/sizeof(Stat) - 1;
     if (narg == 1) {
-      pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
+      pos = EVAL_EXPR( READ_STAT(stat, 1) );
       /* unbind the element                                                */
       if (IS_POS_INTOBJ(pos)) {
         UNB_LIST( list, INT_INTOBJ(pos) );
@@ -823,8 +823,8 @@ UInt            ExecUnbList (
       ixs = NEW_PLIST(T_PLIST, narg);
       for (i = 1; i <= narg; i++) {
 	/* evaluate the position                                               */
-	pos = EVAL_EXPR( ADDR_STAT(stat)[i] );
-	SET_ELM_PLIST(ixs,i,pos);
+        pos = EVAL_EXPR(READ_STAT(stat, i));
+        SET_ELM_PLIST(ixs,i,pos);
 	CHANGED_BAG(ixs);
       }
       SET_LEN_PLIST(ixs, narg);
@@ -853,10 +853,10 @@ Obj             EvalElmList (
     Int                 p;              /* position, as C integer          */
 
     /* evaluate the list (checking is done by 'ELM_LIST')                  */
-    list = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    list = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate and check the position                                     */
-    pos = EVAL_EXPR( ADDR_EXPR(expr)[1] );
+    pos = EVAL_EXPR(READ_EXPR(expr, 1));
 
     SET_BRK_CALL_TO(expr);     /* Note possible call for FuncWhere */
 
@@ -901,12 +901,12 @@ Obj             EvalElm2List (
     Obj                 pos2;           /* position, right operand         */
 
     /* evaluate the list (checking is done by 'ELM2_LIST')                 */
-    list = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    list = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate and check the positions                                    */
-    pos1 = EVAL_EXPR( ADDR_EXPR(expr)[1] ); 
-    pos2 = EVAL_EXPR( ADDR_EXPR(expr)[2] ); 
-   
+    pos1 = EVAL_EXPR(READ_EXPR(expr, 1));
+    pos2 = EVAL_EXPR(READ_EXPR(expr, 2));
+
     elm = ELM2_LIST(list, pos1, pos2);
 
     /* return the element                                                  */
@@ -932,13 +932,13 @@ Obj             EvalElmXList (
      
 
     /* evaluate the list (checking is done by 'ELM2_LIST')                 */
-    list = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    list = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate and check the positions                                    */
     narg = SIZE_EXPR(expr)/sizeof(Expr) -1;
     ixs = NEW_PLIST(T_PLIST,narg);
     for (i = 1; i <= narg; i++) {
-      pos = EVAL_EXPR( ADDR_EXPR(expr)[i] );
+      pos = EVAL_EXPR( READ_EXPR(expr, i) );
       SET_ELM_PLIST(ixs,i,pos);
       CHANGED_BAG(ixs);
     }
@@ -966,10 +966,10 @@ Obj             EvalElmsList (
     Obj                 poss;           /* positions, right operand        */
 
     /* evaluate the list (checking is done by 'ELMS_LIST')                 */
-    list = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    list = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate and check the positions                                    */
-    poss = EVAL_EXPR( ADDR_EXPR(expr)[1] );
+    poss = EVAL_EXPR(READ_EXPR(expr, 1));
     CheckIsPossList("List Elements", poss);
 
     /* select several elements from the list                               */
@@ -1005,18 +1005,18 @@ Obj             EvalElmListLevel (
 
     /* evaluate lists (if this works, then <lists> is nested <level> deep, */
     /* checking it is nested <level>+1 deep is done by 'ElmListLevel')     */
-    lists = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    lists = EVAL_EXPR(READ_EXPR(expr, 0));
     narg = SIZE_EXPR(expr)/sizeof(Expr) -2;
     ixs = NEW_PLIST(T_PLIST, narg);
     for (i = 1; i <= narg; i++) {
-      pos = EVAL_EXPR( ADDR_EXPR(expr)[i]);
+      pos = EVAL_EXPR( READ_EXPR(expr, i));
       SET_ELM_PLIST(ixs, i, pos);
       CHANGED_BAG(ixs);
     }
     SET_LEN_PLIST(ixs, narg);
     /* get the level                                                       */
-    level = (Int)(ADDR_EXPR(expr)[narg+1]);
-    
+    level = (Int)(READ_EXPR(expr, narg + 1));
+
     /* select the elements from several lists (store them in <lists>)      */
     ElmListLevel( lists, ixs, level );
 
@@ -1048,14 +1048,14 @@ Obj             EvalElmsListLevel (
 
     /* evaluate lists (if this works, then <lists> is nested <level> deep, */
     /* checking it is nested <level>+1 deep is done by 'ElmsListLevel')    */
-    lists = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    lists = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate and check the positions                                    */
-    poss = EVAL_EXPR( ADDR_EXPR(expr)[1] );
+    poss = EVAL_EXPR(READ_EXPR(expr, 1));
     CheckIsPossList("List Elements", poss);
 
     /* get the level                                                       */
-    level = (Int)(ADDR_EXPR(expr)[2]);
+    level = (Int)(READ_EXPR(expr, 2));
 
     /* select several elements from several lists (store them in <lists>)  */
     ElmsListLevel( lists, poss, level );
@@ -1081,12 +1081,12 @@ Obj             EvalIsbList (
     Int narg, i;
 
     /* evaluate the list (checking is done by 'ISB_LIST')                  */
-    list = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    list = EVAL_EXPR(READ_EXPR(expr, 0));
     narg = SIZE_EXPR(expr)/sizeof(Expr) -1;
     if (narg == 1) {
       /* evaluate and check the position                                   */
-      pos = EVAL_EXPR( ADDR_EXPR(expr)[1] );
-      
+      pos = EVAL_EXPR(READ_EXPR(expr, 1));
+
       if (IS_POS_INTOBJ(pos))
         return ISB_LIST( list, INT_INTOBJ(pos) ) ? True : False;
       else
@@ -1094,7 +1094,7 @@ Obj             EvalIsbList (
     } else {
       ixs = NEW_PLIST(T_PLIST, narg);
       for (i = 1; i <= narg; i++) {
-	pos = EVAL_EXPR( ADDR_EXPR(expr)[i] );
+	pos = EVAL_EXPR( READ_EXPR(expr, i) );
 	SET_ELM_PLIST(ixs,i,pos);
 	CHANGED_BAG(ixs);
       }
@@ -1118,12 +1118,12 @@ void            PrintAssList (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<[",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     Pr("%<]",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[2] );
+    PrintExpr(READ_EXPR(stat, 2));
     Pr("%2<;",0L,0L);
 }
 
@@ -1131,14 +1131,14 @@ void            PrintAss2List (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<[",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     Pr("%<, %>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[2] );
+    PrintExpr(READ_EXPR(stat, 2));
     Pr("%<]",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[3] );
+    PrintExpr(READ_EXPR(stat, 3));
     Pr("%2<;",0L,0L);
 }
 
@@ -1148,16 +1148,16 @@ void            PrintAssXList (
   Int narg = SIZE_STAT(stat)/sizeof(stat) - 2;
   Int i;
     Pr("%4>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<[",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     for (i = 2; i <= narg; i++) {
       Pr("%<, %>",0L,0L);
-      PrintExpr( ADDR_EXPR(stat)[i] );
+      PrintExpr(READ_EXPR(stat, i));
     }
     Pr("%<]",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[narg + 1] );
+    PrintExpr(READ_EXPR(stat, narg + 1));
     Pr("%2<;",0L,0L);
 }
 
@@ -1168,12 +1168,12 @@ void            PrintUnbList (
   Int i;
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<[",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     for (i = 2; i <= narg; i++) {
       Pr("%<, %>",0L,0L);
-      PrintExpr( ADDR_EXPR(stat)[i]);
+      PrintExpr(READ_EXPR(stat, i));
     }
     Pr("%<]",0L,0L);
     Pr( " );", 0L, 0L );
@@ -1193,12 +1193,12 @@ void            PrintAsssList (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<{",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     Pr("%<}",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[2] );
+    PrintExpr(READ_EXPR(stat, 2));
     Pr("%2<;",0L,0L);
 }
 
@@ -1216,9 +1216,9 @@ void            PrintElmList (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<[",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     Pr("%<]",0L,0L);
 }
 
@@ -1226,11 +1226,11 @@ void PrintElm2List (
 		     Expr expr )
 {
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<[",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     Pr("%<, %<",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[2] );
+    PrintExpr(READ_EXPR(expr, 2));
     Pr("%<]",0L,0L);
 }
 
@@ -1240,12 +1240,12 @@ void PrintElmXList (
   Int i;
   Int narg = SIZE_EXPR(expr)/sizeof(Expr) -1 ;
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<[",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     for (i = 2; i <= narg; i++) {
       Pr("%<, %<",0L,0L);
-      PrintExpr( ADDR_EXPR(expr)[i] );
+      PrintExpr(READ_EXPR(expr, i));
     }
     Pr("%<]",0L,0L);
 }
@@ -1256,12 +1256,12 @@ void PrintElmListLevel (
   Int i;
   Int narg = SIZE_EXPR(expr)/sizeof(Expr) -2 ;
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<[",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     for (i = 2; i <= narg; i++) {
       Pr("%<, %<",0L,0L);
-      PrintExpr( ADDR_EXPR(expr)[i] );
+      PrintExpr(READ_EXPR(expr, i));
     }
     Pr("%<]",0L,0L);
 }
@@ -1274,12 +1274,12 @@ void            PrintIsbList (
   Int i;
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<[",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     for (i = 2; i <= narg; i++) {
       Pr("%<, %>", 0L, 0L);
-      PrintExpr(ADDR_EXPR(expr)[i] );
+      PrintExpr(READ_EXPR(expr, i));
     }
     Pr("%<]",0L,0L);
     Pr( " )", 0L, 0L );
@@ -1299,9 +1299,9 @@ void            PrintElmsList (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<{",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     Pr("%<}",0L,0L);
 }
 
@@ -1322,13 +1322,13 @@ UInt            ExecAssRecName (
 
     /* evaluate the record (checking is done by 'ASS_REC')                 */
     SET_BRK_CURR_STAT( stat );
-    record = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(ADDR_STAT(stat)[1]);
+    rnam = (UInt)(READ_STAT(stat, 1));
 
     /* evaluate the right hand side                                        */
-    rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
+    rhs = EVAL_EXPR(READ_STAT(stat, 2));
 
     /* assign the right hand side to the element of the record             */
     ASS_REC( record, rnam, rhs );
@@ -1354,13 +1354,13 @@ UInt            ExecAssRecExpr (
 
     /* evaluate the record (checking is done by 'ASS_REC')                 */
     SET_BRK_CURR_STAT( stat );
-    record = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate the name and convert it to a record name                   */
-    rnam = RNamObj( EVAL_EXPR( ADDR_STAT(stat)[1] ) );
+    rnam = RNamObj(EVAL_EXPR(READ_STAT(stat, 1)));
 
     /* evaluate the right hand side                                        */
-    rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
+    rhs = EVAL_EXPR(READ_STAT(stat, 2));
 
     /* assign the right hand side to the element of the record             */
     ASS_REC( record, rnam, rhs );
@@ -1385,10 +1385,10 @@ UInt            ExecUnbRecName (
 
     /* evaluate the record (checking is done by 'UNB_REC')                 */
     SET_BRK_CURR_STAT( stat );
-    record = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(ADDR_STAT(stat)[1]);
+    rnam = (UInt)(READ_STAT(stat, 1));
 
     /* unbind the element of the record                                    */
     UNB_REC( record, rnam );
@@ -1413,10 +1413,10 @@ UInt            ExecUnbRecExpr (
 
     /* evaluate the record (checking is done by 'UNB_REC')                 */
     SET_BRK_CURR_STAT( stat );
-    record = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate the name and convert it to a record name                   */
-    rnam = RNamObj( EVAL_EXPR( ADDR_STAT(stat)[1] ) );
+    rnam = RNamObj(EVAL_EXPR(READ_STAT(stat, 1)));
 
     /* unbind the element of the record                                    */
     UNB_REC( record, rnam );
@@ -1441,10 +1441,10 @@ Obj             EvalElmRecName (
     UInt                rnam;           /* the name, right operand         */
 
     /* evaluate the record (checking is done by 'ELM_REC')                 */
-    record = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    record = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(ADDR_EXPR(expr)[1]);
+    rnam = (UInt)(READ_EXPR(expr, 1));
 
     /* select the element of the record                                    */
     elm = ELM_REC( record, rnam );
@@ -1469,10 +1469,10 @@ Obj             EvalElmRecExpr (
     UInt                rnam;           /* the name, right operand         */
 
     /* evaluate the record (checking is done by 'ELM_REC')                 */
-    record = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    record = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate the name and convert it to a record name                   */
-    rnam = RNamObj( EVAL_EXPR( ADDR_EXPR(expr)[1] ) );
+    rnam = RNamObj(EVAL_EXPR(READ_EXPR(expr, 1)));
 
     /* select the element of the record                                    */
     elm = ELM_REC( record, rnam );
@@ -1496,10 +1496,10 @@ Obj             EvalIsbRecName (
     UInt                rnam;           /* the name, right operand         */
 
     /* evaluate the record (checking is done by 'ISB_REC')                 */
-    record = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    record = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(ADDR_EXPR(expr)[1]);
+    rnam = (UInt)(READ_EXPR(expr, 1));
 
     /* return the result                                                   */
     return (ISB_REC( record, rnam ) ? True : False);
@@ -1520,10 +1520,10 @@ Obj             EvalIsbRecExpr (
     UInt                rnam;           /* the name, right operand         */
 
     /* evaluate the record (checking is done by 'ISB_REC')                 */
-    record = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    record = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate the name and convert it to a record name                   */
-    rnam = RNamObj( EVAL_EXPR( ADDR_EXPR(expr)[1] ) );
+    rnam = RNamObj(EVAL_EXPR(READ_EXPR(expr, 1)));
 
     /* return the result                                                   */
     return (ISB_REC( record, rnam ) ? True : False);
@@ -1541,12 +1541,12 @@ void            PrintAssRecName (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<.",0L,0L);
-    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
+    Pr("%H", (Int)NAME_RNAM((UInt)(READ_STAT(stat, 1))), 0L);
     Pr("%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[2] );
+    PrintExpr(READ_EXPR(stat, 2));
     Pr("%2<;",0L,0L);
 }
 
@@ -1555,9 +1555,9 @@ void            PrintUnbRecName (
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<.",0L,0L);
-    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
+    Pr("%H", (Int)NAME_RNAM((UInt)(READ_STAT(stat, 1))), 0L);
     Pr("%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -1574,12 +1574,12 @@ void            PrintAssRecExpr (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<.(",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     Pr(")%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[2] );
+    PrintExpr(READ_EXPR(stat, 2));
     Pr("%2<;",0L,0L);
 }
 
@@ -1588,9 +1588,9 @@ void            PrintUnbRecExpr (
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<.(",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     Pr(")%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -1607,9 +1607,9 @@ void            PrintElmRecName (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<.",0L,0L);
-    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
+    Pr("%H", (Int)NAME_RNAM((UInt)(READ_EXPR(expr, 1))), 0L);
     Pr("%<",0L,0L);
 }
 
@@ -1618,9 +1618,9 @@ void            PrintIsbRecName (
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<.",0L,0L);
-    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
+    Pr("%H", (Int)NAME_RNAM((UInt)(READ_EXPR(expr, 1))), 0L);
     Pr("%<",0L,0L);
     Pr( " )", 0L, 0L );
 }
@@ -1637,9 +1637,9 @@ void            PrintElmRecExpr (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<.(",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     Pr(")%<",0L,0L);
 }
 
@@ -1648,9 +1648,9 @@ void            PrintIsbRecExpr (
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<.(",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     Pr(")%<",0L,0L);
     Pr( " )", 0L, 0L );
 }
@@ -1673,10 +1673,10 @@ UInt            ExecAssPosObj (
 
     /* evaluate the list (checking is done by 'ASS_LIST')                  */
     SET_BRK_CURR_STAT( stat );
-    list = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    list = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate and check the position                                     */
-    pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
+    pos = EVAL_EXPR(READ_STAT(stat, 1));
     while ( ! IS_POS_INTOBJ(pos) ) {
         pos = ErrorReturnObj(
          "PosObj Assignment: <position> must be a positive integer (not a %s)",
@@ -1686,7 +1686,7 @@ UInt            ExecAssPosObj (
     p = INT_INTOBJ(pos);
 
     /* evaluate the right hand side                                        */
-    rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
+    rhs = EVAL_EXPR(READ_STAT(stat, 2));
 
     /* special case for plain list                                         */
     if ( TNUM_OBJ(list) == T_POSOBJ ) {
@@ -1727,10 +1727,10 @@ UInt            ExecUnbPosObj (
 
     /* evaluate the list (checking is done by 'LEN_LIST')                  */
     SET_BRK_CURR_STAT( stat );
-    list = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    list = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate and check the position                                     */
-    pos = EVAL_EXPR( ADDR_STAT(stat)[1] );
+    pos = EVAL_EXPR(READ_STAT(stat, 1));
     while ( ! IS_POS_INTOBJ(pos) ) {
         pos = ErrorReturnObj(
          "PosObj Assignment: <position> must be a positive integer (not a %s)",
@@ -1776,10 +1776,10 @@ Obj             EvalElmPosObj (
     Int                 p;              /* position, as C integer          */
 
     /* evaluate the list (checking is done by 'ELM_LIST')                  */
-    list = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    list = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate and check the position                                     */
-    pos = EVAL_EXPR( ADDR_EXPR(expr)[1] );
+    pos = EVAL_EXPR(READ_EXPR(expr, 1));
     while ( ! IS_POS_INTOBJ(pos) ) {
         pos = ErrorReturnObj(
             "PosObj Element: <position> must be a positive integer (not a %s)",
@@ -1843,10 +1843,10 @@ Obj             EvalIsbPosObj (
     Int                 p;              /* position, as C integer          */
 
     /* evaluate the list (checking is done by 'ISB_LIST')                  */
-    list = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    list = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate and check the position                                     */
-    pos = EVAL_EXPR( ADDR_EXPR(expr)[1] );
+    pos = EVAL_EXPR(READ_EXPR(expr, 1));
     while ( ! IS_POS_INTOBJ(pos) ) {
         pos = ErrorReturnObj(
             "PosObj Element: <position> must be a positive integer (not a %s)",
@@ -1895,12 +1895,12 @@ void            PrintAssPosObj (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<![",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     Pr("%<]",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[2] );
+    PrintExpr(READ_EXPR(stat, 2));
     Pr("%2<;",0L,0L);
 }
 
@@ -1909,9 +1909,9 @@ void            PrintUnbPosObj (
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<![",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     Pr("%<]",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -1930,9 +1930,9 @@ void            PrintElmPosObj (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<![",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     Pr("%<]",0L,0L);
 }
 
@@ -1941,9 +1941,9 @@ void            PrintIsbPosObj (
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<![",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     Pr("%<]",0L,0L);
     Pr( " )", 0L, 0L );
 }
@@ -1965,13 +1965,13 @@ UInt            ExecAssComObjName (
 
     /* evaluate the record (checking is done by 'ASS_REC')                 */
     SET_BRK_CURR_STAT( stat );
-    record = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(ADDR_STAT(stat)[1]);
+    rnam = (UInt)(READ_STAT(stat, 1));
 
     /* evaluate the right hand side                                        */
-    rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
+    rhs = EVAL_EXPR(READ_STAT(stat, 2));
 
     /* assign the right hand side to the element of the record             */
     switch (TNUM_OBJ(record)) {
@@ -2021,13 +2021,13 @@ UInt            ExecAssComObjExpr (
 
     /* evaluate the record (checking is done by 'ASS_REC')                 */
     SET_BRK_CURR_STAT( stat );
-    record = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate the name and convert it to a record name                   */
-    rnam = RNamObj( EVAL_EXPR( ADDR_STAT(stat)[1] ) );
+    rnam = RNamObj(EVAL_EXPR(READ_STAT(stat, 1)));
 
     /* evaluate the right hand side                                        */
-    rhs = EVAL_EXPR( ADDR_STAT(stat)[2] );
+    rhs = EVAL_EXPR(READ_STAT(stat, 2));
 
     /* assign the right hand side to the element of the record             */
     switch (TNUM_OBJ(record)) {
@@ -2064,10 +2064,10 @@ UInt            ExecUnbComObjName (
 
     /* evaluate the record (checking is done by 'UNB_REC')                 */
     SET_BRK_CURR_STAT( stat );
-    record = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(ADDR_STAT(stat)[1]);
+    rnam = (UInt)(READ_STAT(stat, 1));
 
     /* unbind the element of the record                                    */
     switch (TNUM_OBJ(record)) {
@@ -2104,10 +2104,10 @@ UInt            ExecUnbComObjExpr (
 
     /* evaluate the record (checking is done by 'UNB_REC')                 */
     SET_BRK_CURR_STAT( stat );
-    record = EVAL_EXPR( ADDR_STAT(stat)[0] );
+    record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate the name and convert it to a record name                   */
-    rnam = RNamObj( EVAL_EXPR( ADDR_STAT(stat)[1] ) );
+    rnam = RNamObj(EVAL_EXPR(READ_STAT(stat, 1)));
 
     /* unbind the element of the record                                    */
     switch (TNUM_OBJ(record)) {
@@ -2144,10 +2144,10 @@ Obj             EvalElmComObjName (
     UInt                rnam;           /* the name, right operand         */
 
     /* evaluate the record (checking is done by 'ELM_REC')                 */
-    record = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    record = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(ADDR_EXPR(expr)[1]);
+    rnam = (UInt)(READ_EXPR(expr, 1));
 
     /* select the element of the record                                    */
     switch (TNUM_OBJ(record)) {
@@ -2184,10 +2184,10 @@ Obj             EvalElmComObjExpr (
     UInt                rnam;           /* the name, right operand         */
 
     /* evaluate the record (checking is done by 'ELM_REC')                 */
-    record = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    record = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate the name and convert it to a record name                   */
-    rnam = RNamObj( EVAL_EXPR( ADDR_EXPR(expr)[1] ) );
+    rnam = RNamObj(EVAL_EXPR(READ_EXPR(expr, 1)));
 
     /* select the element of the record                                    */
     switch (TNUM_OBJ(record)) {
@@ -2224,10 +2224,10 @@ Obj             EvalIsbComObjName (
     UInt                rnam;           /* the name, right operand         */
 
     /* evaluate the record (checking is done by 'ISB_REC')                 */
-    record = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    record = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(ADDR_EXPR(expr)[1]);
+    rnam = (UInt)(READ_EXPR(expr, 1));
 
     /* select the element of the record                                    */
     switch (TNUM_OBJ(record)) {
@@ -2264,10 +2264,10 @@ Obj             EvalIsbComObjExpr (
     UInt                rnam;           /* the name, right operand         */
 
     /* evaluate the record (checking is done by 'ISB_REC')                 */
-    record = EVAL_EXPR( ADDR_EXPR(expr)[0] );
+    record = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate the name and convert it to a record name                   */
-    rnam = RNamObj( EVAL_EXPR( ADDR_EXPR(expr)[1] ) );
+    rnam = RNamObj(EVAL_EXPR(READ_EXPR(expr, 1)));
 
     /* select the element of the record                                    */
     switch (TNUM_OBJ(record)) {
@@ -2300,12 +2300,12 @@ void            PrintAssComObjName (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<!.",0L,0L);
-    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
+    Pr("%H", (Int)NAME_RNAM((UInt)(READ_STAT(stat, 1))), 0L);
     Pr("%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[2] );
+    PrintExpr(READ_EXPR(stat, 2));
     Pr("%2<;",0L,0L);
 }
 
@@ -2314,9 +2314,9 @@ void            PrintUnbComObjName (
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<!.",0L,0L);
-    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_STAT(stat)[1])),0L);
+    Pr("%H", (Int)NAME_RNAM((UInt)(READ_STAT(stat, 1))), 0L);
     Pr("%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -2333,12 +2333,12 @@ void            PrintAssComObjExpr (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<!.(",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     Pr(")%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[2] );
+    PrintExpr(READ_EXPR(stat, 2));
     Pr("%2<;",0L,0L);
 }
 
@@ -2347,9 +2347,9 @@ void            PrintUnbComObjExpr (
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[0] );
+    PrintExpr(READ_EXPR(stat, 0));
     Pr("%<!.(",0L,0L);
-    PrintExpr( ADDR_EXPR(stat)[1] );
+    PrintExpr(READ_EXPR(stat, 1));
     Pr(")%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -2366,9 +2366,9 @@ void            PrintElmComObjName (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<!.",0L,0L);
-    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
+    Pr("%H", (Int)NAME_RNAM((UInt)(READ_EXPR(expr, 1))), 0L);
     Pr("%<",0L,0L);
 }
 
@@ -2377,9 +2377,9 @@ void            PrintIsbComObjName (
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<!.",0L,0L);
-    Pr("%H",(Int)NAME_RNAM((UInt)(ADDR_EXPR(expr)[1])),0L);
+    Pr("%H", (Int)NAME_RNAM((UInt)(READ_EXPR(expr, 1))), 0L);
     Pr("%<",0L,0L);
     Pr( " )", 0L, 0L );
 }
@@ -2396,9 +2396,9 @@ void            PrintElmComObjExpr (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<!.(",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     Pr(")%<",0L,0L);
 }
 
@@ -2407,9 +2407,9 @@ void            PrintIsbComObjExpr (
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[0] );
+    PrintExpr(READ_EXPR(expr, 0));
     Pr("%<!.(",0L,0L);
-    PrintExpr( ADDR_EXPR(expr)[1] );
+    PrintExpr(READ_EXPR(expr, 1));
     Pr(")%<",0L,0L);
     Pr( " )", 0L, 0L );
 }

--- a/src/vars.c
+++ b/src/vars.c
@@ -165,7 +165,7 @@ UInt            ExecAssLVar (
     /* assign the right hand side to the local variable                    */
     SET_BRK_CURR_STAT( stat );
     rhs = EVAL_EXPR(READ_STAT(stat, 1));
-    ASS_LVAR((UInt)(READ_STAT(stat, 0)), rhs);
+    ASS_LVAR(READ_STAT(stat, 0), rhs);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -175,7 +175,7 @@ UInt            ExecUnbLVar (
     Stat                stat )
 {
     /* unbind the local variable                                           */
-    ASS_LVAR((UInt)(READ_STAT(stat, 0)), (Obj)0);
+    ASS_LVAR(READ_STAT(stat, 0), (Obj)0);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -189,7 +189,7 @@ Obj             EvalIsbLVar (
     Obj                 val;            /* value, result                   */
 
     /* get the value of the local variable                                 */
-    val = OBJ_LVAR((UInt)(READ_EXPR(expr, 0)));
+    val = OBJ_LVAR(READ_EXPR(expr, 0));
 
     /* return the value                                                    */
     return (val != (Obj)0 ? True : False);
@@ -206,7 +206,7 @@ void            PrintAssLVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
-    Pr("%H", (Int)NAME_LVAR((UInt)(READ_STAT(stat, 0))), 0L);
+    Pr("%H", (Int)NAME_LVAR(READ_STAT(stat, 0)), 0L);
     Pr( "%< %>:= ", 0L, 0L );
     PrintExpr(READ_EXPR(stat, 1));
     Pr( "%2<;", 0L, 0L );
@@ -216,7 +216,7 @@ void            PrintUnbLVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
-    Pr("%H", (Int)NAME_LVAR((UInt)(READ_STAT(stat, 0))), 0L);
+    Pr("%H", (Int)NAME_LVAR(READ_STAT(stat, 0)), 0L);
     Pr( " );", 0L, 0L );
 }
 
@@ -237,7 +237,7 @@ void            PrintIsbLVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr("%H", (Int)NAME_LVAR((UInt)(READ_EXPR(expr, 0))), 0L);
+    Pr("%H", (Int)NAME_LVAR(READ_EXPR(expr, 0)), 0L);
     Pr( " )", 0L, 0L );
 }
 
@@ -322,7 +322,7 @@ UInt            ExecAssHVar (
     /* assign the right hand side to the higher variable                   */
     SET_BRK_CURR_STAT( stat );
     rhs = EVAL_EXPR(READ_STAT(stat, 1));
-    ASS_HVAR((UInt)(READ_STAT(stat, 0)), rhs);
+    ASS_HVAR(READ_STAT(stat, 0), rhs);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -332,7 +332,7 @@ UInt            ExecUnbHVar (
     Stat                stat )
 {
     /* unbind the higher variable                                          */
-    ASS_HVAR((UInt)(READ_STAT(stat, 0)), 0);
+    ASS_HVAR(READ_STAT(stat, 0), 0);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -350,7 +350,7 @@ Obj             EvalRefHVar (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
-    UInt                hvar = (UInt)(READ_EXPR(expr, 0));
+    UInt                hvar = READ_EXPR(expr, 0);
 
     /* get and check the value of the higher variable                      */
     while ( (val = OBJ_HVAR(hvar)) == 0 ) {
@@ -370,7 +370,7 @@ Obj             EvalIsbHVar (
     Obj                 val;            /* value, result                   */
 
     /* get the value of the higher variable                                */
-    val = OBJ_HVAR((UInt)(READ_EXPR(expr, 0)));
+    val = OBJ_HVAR(READ_EXPR(expr, 0));
 
     /* return the value                                                    */
     return (val != (Obj)0 ? True : False);
@@ -387,7 +387,7 @@ void            PrintAssHVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
-    Pr("%H", (Int)NAME_HVAR((UInt)(READ_STAT(stat, 0))), 0L);
+    Pr("%H", (Int)NAME_HVAR(READ_STAT(stat, 0)), 0L);
     Pr( "%< %>:= ", 0L, 0L );
     PrintExpr(READ_EXPR(stat, 1));
     Pr( "%2<;", 0L, 0L );
@@ -397,7 +397,7 @@ void            PrintUnbHVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
-    Pr("%H", (Int)NAME_HVAR((UInt)(READ_STAT(stat, 0))), 0L);
+    Pr("%H", (Int)NAME_HVAR(READ_STAT(stat, 0)), 0L);
     Pr( " );", 0L, 0L );
 }
 
@@ -411,14 +411,14 @@ void            PrintUnbHVar (
 void            PrintRefHVar (
     Expr                expr )
 {
-    Pr("%H", (Int)NAME_HVAR((UInt)(READ_EXPR(expr, 0))), 0L);
+    Pr("%H", (Int)NAME_HVAR(READ_EXPR(expr, 0)), 0L);
 }
 
 void            PrintIsbHVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr("%H", (Int)NAME_HVAR((UInt)(READ_EXPR(expr, 0))), 0L);
+    Pr("%H", (Int)NAME_HVAR(READ_EXPR(expr, 0)), 0L);
     Pr( " )", 0L, 0L );
 }
 
@@ -438,7 +438,7 @@ UInt            ExecAssGVar (
     /* assign the right hand side to the global variable                   */
     SET_BRK_CURR_STAT( stat );
     rhs = EVAL_EXPR(READ_STAT(stat, 1));
-    AssGVar((UInt)(READ_STAT(stat, 0)), rhs);
+    AssGVar(READ_STAT(stat, 0), rhs);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -448,7 +448,7 @@ UInt            ExecUnbGVar (
     Stat                stat )
 {
     /* unbind the global variable                                          */
-    AssGVar((UInt)(READ_STAT(stat, 0)), (Obj)0);
+    AssGVar(READ_STAT(stat, 0), (Obj)0);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -468,10 +468,10 @@ Obj             EvalRefGVar (
     Obj                 val;            /* value, result                   */
 
     /* get and check the value of the global variable                      */
-    while ( (val = ValAutoGVar( (UInt)(READ_EXPR(expr, 0)) )) == 0 ) {
+    while ( (val = ValAutoGVar( READ_EXPR(expr, 0) )) == 0 ) {
         ErrorReturnVoid(
             "Variable: '%g' must have an assigned value",
-            (Int)NameGVar( (UInt)(READ_EXPR(expr, 0)) ), 0L,
+            (Int)NameGVar( READ_EXPR(expr, 0) ), 0L,
             "you can 'return;' after assigning a value" );
     }
 
@@ -485,7 +485,7 @@ Obj             EvalIsbGVar (
     Obj                 val;            /* value, result                   */
 
     /* get the value of the global variable                                */
-    val = ValAutoGVar((UInt)(READ_EXPR(expr, 0)));
+    val = ValAutoGVar(READ_EXPR(expr, 0));
 
     /* return the value                                                    */
     return (val != (Obj)0 ? True : False);
@@ -502,7 +502,7 @@ void            PrintAssGVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
-    Pr("%H", (Int)NameGVar((UInt)(READ_STAT(stat, 0))), 0L);
+    Pr("%H", (Int)NameGVar(READ_STAT(stat, 0)), 0L);
     Pr( "%< %>:= ", 0L, 0L );
     PrintExpr(READ_EXPR(stat, 1));
     Pr( "%2<;", 0L, 0L );
@@ -512,7 +512,7 @@ void            PrintUnbGVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
-    Pr("%H", (Int)NameGVar((UInt)(READ_STAT(stat, 0))), 0L);
+    Pr("%H", (Int)NameGVar(READ_STAT(stat, 0)), 0L);
     Pr( " );", 0L, 0L );
 }
 
@@ -526,14 +526,14 @@ void            PrintUnbGVar (
 void            PrintRefGVar (
     Expr                expr )
 {
-    Pr("%H", (Int)NameGVar((UInt)(READ_STAT(expr, 0))), 0L);
+    Pr("%H", (Int)NameGVar(READ_STAT(expr, 0)), 0L);
 }
 
 void            PrintIsbGVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr("%H", (Int)NameGVar((UInt)(READ_EXPR(expr, 0))), 0L);
+    Pr("%H", (Int)NameGVar(READ_EXPR(expr, 0)), 0L);
     Pr( " )", 0L, 0L );
 }
 
@@ -715,7 +715,7 @@ UInt            ExecAssListLevel (
     Obj                 lists;          /* lists, left operand             */
     Obj                 pos;            /* position, left operand          */
     Obj                 rhss;           /* right hand sides, right operand */
-    Int                 level;          /* level                           */
+    UInt                level;          /* level                           */
     Int narg,i;
     Obj ixs;
 
@@ -736,7 +736,7 @@ UInt            ExecAssListLevel (
     rhss = EVAL_EXPR(READ_STAT(stat, narg + 1));
 
     /* get the level                                                       */
-    level = (Int)(READ_STAT(stat, narg + 2));
+    level = READ_STAT(stat, narg + 2);
 
     /* assign the right hand sides to the elements of several lists        */
     AssListLevel( lists, ixs, rhss, level );
@@ -766,7 +766,7 @@ UInt            ExecAsssListLevel (
     Obj                 lists;          /* lists, left operand             */
     Obj                 poss;           /* position, left operand          */
     Obj                 rhss;           /* right hand sides, right operand */
-    Int                 level;          /* level                           */
+    UInt                level;          /* level                           */
 
     /* evaluate lists (if this works, then <lists> is nested <level> deep, */
     /* checking it is nested <level>+1 deep is done by 'AsssListLevel')    */
@@ -781,7 +781,7 @@ UInt            ExecAsssListLevel (
     rhss = EVAL_EXPR(READ_STAT(stat, 2));
 
     /* get the level                                                       */
-    level = (Int)(READ_STAT(stat, 3));
+    level = READ_STAT(stat, 3);
 
     /* assign the right hand sides to several elements of several lists    */
     AsssListLevel( lists, poss, rhss, level );
@@ -999,7 +999,7 @@ Obj             EvalElmListLevel (
     Obj                 lists;          /* lists, left operand             */
     Obj                 pos;            /* position, right operand         */
     Obj                 ixs;
-    Int                 level;          /* level                           */
+    UInt                level;          /* level                           */
     Int narg;
     Int i;
 
@@ -1015,7 +1015,7 @@ Obj             EvalElmListLevel (
     }
     SET_LEN_PLIST(ixs, narg);
     /* get the level                                                       */
-    level = (Int)(READ_EXPR(expr, narg + 1));
+    level = READ_EXPR(expr, narg + 1);
 
     /* select the elements from several lists (store them in <lists>)      */
     ElmListLevel( lists, ixs, level );
@@ -1044,7 +1044,7 @@ Obj             EvalElmsListLevel (
 {
     Obj                 lists;          /* lists, left operand             */
     Obj                 poss;           /* positions, right operand        */
-    Int                 level;          /* level                           */
+    UInt                level;          /* level                           */
 
     /* evaluate lists (if this works, then <lists> is nested <level> deep, */
     /* checking it is nested <level>+1 deep is done by 'ElmsListLevel')    */
@@ -1055,7 +1055,7 @@ Obj             EvalElmsListLevel (
     CheckIsPossList("List Elements", poss);
 
     /* get the level                                                       */
-    level = (Int)(READ_EXPR(expr, 2));
+    level = READ_EXPR(expr, 2);
 
     /* select several elements from several lists (store them in <lists>)  */
     ElmsListLevel( lists, poss, level );
@@ -1325,7 +1325,7 @@ UInt            ExecAssRecName (
     record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(READ_STAT(stat, 1));
+    rnam = READ_STAT(stat, 1);
 
     /* evaluate the right hand side                                        */
     rhs = EVAL_EXPR(READ_STAT(stat, 2));
@@ -1388,7 +1388,7 @@ UInt            ExecUnbRecName (
     record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(READ_STAT(stat, 1));
+    rnam = READ_STAT(stat, 1);
 
     /* unbind the element of the record                                    */
     UNB_REC( record, rnam );
@@ -1444,7 +1444,7 @@ Obj             EvalElmRecName (
     record = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(READ_EXPR(expr, 1));
+    rnam = READ_EXPR(expr, 1);
 
     /* select the element of the record                                    */
     elm = ELM_REC( record, rnam );
@@ -1499,7 +1499,7 @@ Obj             EvalIsbRecName (
     record = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(READ_EXPR(expr, 1));
+    rnam = READ_EXPR(expr, 1);
 
     /* return the result                                                   */
     return (ISB_REC( record, rnam ) ? True : False);
@@ -1543,7 +1543,7 @@ void            PrintAssRecName (
     Pr("%4>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
     Pr("%<.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM((UInt)(READ_STAT(stat, 1))), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_STAT(stat, 1)), 0L);
     Pr("%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
     PrintExpr(READ_EXPR(stat, 2));
@@ -1557,7 +1557,7 @@ void            PrintUnbRecName (
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
     Pr("%<.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM((UInt)(READ_STAT(stat, 1))), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_STAT(stat, 1)), 0L);
     Pr("%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -1609,7 +1609,7 @@ void            PrintElmRecName (
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
     Pr("%<.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM((UInt)(READ_EXPR(expr, 1))), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_EXPR(expr, 1)), 0L);
     Pr("%<",0L,0L);
 }
 
@@ -1620,7 +1620,7 @@ void            PrintIsbRecName (
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
     Pr("%<.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM((UInt)(READ_EXPR(expr, 1))), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_EXPR(expr, 1)), 0L);
     Pr("%<",0L,0L);
     Pr( " )", 0L, 0L );
 }
@@ -1968,7 +1968,7 @@ UInt            ExecAssComObjName (
     record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(READ_STAT(stat, 1));
+    rnam = READ_STAT(stat, 1);
 
     /* evaluate the right hand side                                        */
     rhs = EVAL_EXPR(READ_STAT(stat, 2));
@@ -2067,7 +2067,7 @@ UInt            ExecUnbComObjName (
     record = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
-    rnam = (UInt)(READ_STAT(stat, 1));
+    rnam = READ_STAT(stat, 1);
 
     /* unbind the element of the record                                    */
     switch (TNUM_OBJ(record)) {
@@ -2147,7 +2147,7 @@ Obj             EvalElmComObjName (
     record = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(READ_EXPR(expr, 1));
+    rnam = READ_EXPR(expr, 1);
 
     /* select the element of the record                                    */
     switch (TNUM_OBJ(record)) {
@@ -2227,7 +2227,7 @@ Obj             EvalIsbComObjName (
     record = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
-    rnam = (UInt)(READ_EXPR(expr, 1));
+    rnam = READ_EXPR(expr, 1);
 
     /* select the element of the record                                    */
     switch (TNUM_OBJ(record)) {
@@ -2302,7 +2302,7 @@ void            PrintAssComObjName (
     Pr("%4>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
     Pr("%<!.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM((UInt)(READ_STAT(stat, 1))), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_STAT(stat, 1)), 0L);
     Pr("%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
     PrintExpr(READ_EXPR(stat, 2));
@@ -2316,7 +2316,7 @@ void            PrintUnbComObjName (
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
     Pr("%<!.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM((UInt)(READ_STAT(stat, 1))), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_STAT(stat, 1)), 0L);
     Pr("%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -2368,7 +2368,7 @@ void            PrintElmComObjName (
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
     Pr("%<!.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM((UInt)(READ_EXPR(expr, 1))), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_EXPR(expr, 1)), 0L);
     Pr("%<",0L,0L);
 }
 
@@ -2379,7 +2379,7 @@ void            PrintIsbComObjName (
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
     Pr("%<!.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM((UInt)(READ_EXPR(expr, 1))), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_EXPR(expr, 1)), 0L);
     Pr("%<",0L,0L);
     Pr( " )", 0L, 0L );
 }


### PR DESCRIPTION
Add READ_{EXPR,STAT}, WRITE_{EXPR,STAT}, CONST_ADDR_{EXPR,STAT} helpers to improve over code readability, and to make code which only reads from the body immediately distinguishable from code which writes to it.

With this change, it becomes trivial to see that code.c is the only place we ever write into function bodies.

This enables future refactoring of the coder; e.g. we can stop using `PtrBody` in it, which is a useful optimization for the code executor, but less so for generating code.


@markuspf I am not sure if this has any potential overlap with your syntax tree work; since I don't want to sabotage that, please let me know if this is the case, and we should put this PR here on hold.