### PR TITLE
Makefile: end GNU make warning with newline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #
 .DEFAULT:
 	@if test -f GNUmakefile ; then \
-	    printf "Please use GNU make to build GAP (try 'gmake' or 'gnumake')" ; \
+	    printf "Please use GNU make to build GAP (try 'gmake' or 'gnumake')\n" ; \
 	  else \
 		printf "You need to run "; \
 		if ! test -f configure ; then \


### PR DESCRIPTION
I just tried `make` for GAP on a system where `make` is not GNU make, and noticed that our error message for that is missing a trailing newline.