### PR TITLE
Add MethodsOperation

### DIFF
--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1931,6 +1931,36 @@ end);
 
 fi;
 
+if BASE_SIZE_METHODS_OPER_ENTRY <> 5 then
+    Error("MethodsOperation must be updated for new BASE_SIZE_METHODS_OPER_ENTRY");
+fi;
+
+# TODO: document this?!
+BIND_GLOBAL("MethodsOperation", function(oper, nargs)
+    local meths, len, result, i, m;
+
+    meths := METHODS_OPERATION(oper, nargs);
+    if meths = fail then
+        return fail;
+    fi;
+    len := BASE_SIZE_METHODS_OPER_ENTRY + nargs;
+    result := [];
+    for i in [0, len .. LENGTH(meths) - len] do
+        m := rec(
+            famPred := meths[i + 1],
+            argFilt := meths{[i + 2 .. i + nargs + 1]},
+            func    := meths[i + nargs + 2],
+            rank    := meths[i + nargs + 3],
+            info    := meths[i + nargs + 4],
+            );
+        ADD_LIST(result, m);
+        if IsBound(meths[ + nargs + 5]) then
+            m.location := meths[ + nargs + 5];
+        fi;
+    od;
+    return result;
+end );
+
 #############################################################################
 ##
 #E

--- a/lib/operdebug.g
+++ b/lib/operdebug.g
@@ -30,16 +30,15 @@ BIND_GLOBAL("WriteMethodOverview", function(fname)
     return Concatenation(":",String(n),"\c");
   end;
   f := function()
-    local nam, m, s, op, i, j;
+    local op, nam, i, ms, m;
     for op in OPERATIONS do
       nam := NameFunction(op);
       for i in [0..6] do
-        m := METHODS_OPERATION(op, i);
-        s := BASE_SIZE_METHODS_OPER_ENTRY + i;
-        for j in [1..Length(m)/s] do
+        ms := MethodsOperation(op, i);
+        for m in ms do
           Print(nam,";\c",i,";",
-                relname(m[j*s][1]),":",m[j*s][2],";\c",
-                m[j*s-2],"\n");
+                relname(m.location[1]),":",m.location[2],";\c",
+                m.rank,"\n");
         od;
       od;
     od;

--- a/lib/profile.g
+++ b/lib/profile.g
@@ -666,14 +666,14 @@ BIND_GLOBAL("ProfileMethods",function( arg )
     for op  in arg  do
         name := NameFunction(op);
         for i  in [ 0 .. 6 ]  do
-            meth := METHODS_OPERATION( op, i );
+            meth := MethodsOperation( op, i );
             if meth <> fail  then
-                for j  in [ 0, (BASE_SIZE_METHODS_OPER_ENTRY+i) .. Length(meth)-(BASE_SIZE_METHODS_OPER_ENTRY+i) ]  do
-                    Add( funcs, meth[j+(2+i)] );
-                    if name = meth[j+(4+i)]  then
+                for j in meth do
+                    Add( funcs, j.func );
+                    if name = j.info  then
                         Add( names, [ "Meth(", name, ")" ] );
                     else
-                        Add( names, meth[j+(4+i)] );
+                        Add( names, j.info );
                     fi;
                 od;
             fi;
@@ -716,10 +716,10 @@ BIND_GLOBAL("UnprofileMethods",function( arg )
     funcs := [];
     for op  in arg  do
         for i  in [ 0 .. 6 ]  do
-            meth := METHODS_OPERATION( op, i );
+            meth := MethodsOperation( op, i );
             if meth <> fail  then
-                for j  in [ 0, (BASE_SIZE_METHODS_OPER_ENTRY+i) .. Length(meth)-(BASE_SIZE_METHODS_OPER_ENTRY+i) ]  do
-                    Add( funcs, meth[j+(2+i)] );
+                for j in meth do
+                    Add( funcs, j.func );
                 od;
             fi;
         od;

--- a/tst/testbugfix/2005-08-10-t00086.tst
+++ b/tst/testbugfix/2005-08-10-t00086.tst
@@ -1,3 +1,10 @@
 # 2005/08/10 (TB)
+#
+# Up to now, the method installed for testing the membership of rationals
+# in the field of rationals via <span class="code">IsRat</span>
+# was not called; instead a more general method was used that called
+# <span class="code">Conductor</span> and thus was much slower.
+# Now the special method has been ranked up by changing the requirements
+# in the method installation.
 gap> ApplicableMethod( \in, [ 1, Rationals ] );
 function( x, Rationals ) ... end

--- a/tst/testinstall/methwhy.tst
+++ b/tst/testinstall/methwhy.tst
@@ -1,0 +1,210 @@
+gap> START_TEST("methwy.tst");
+
+#
+gap> ApplicableMethod();
+Error, usage: ApplicableMethod(<opr>,<arglist>[,<verbosity>[,<nr>]])
+
+#
+gap> foobar := NewOperation("foobar", [IsObject]);
+<Operation "foobar">
+gap> InstallMethod(foobar, "for an integer", [IsInt], 1-RankFilter(IsInt), x -> 1);
+gap> InstallMethod(foobar, "for a list", [IsList], 42-RankFilter(IsList), Length);
+gap> InstallMethod(foobar, "for a string", [IsString], 2*SUM_FLAGS+1-RankFilter(IsString), x -> StartsWith(x, "foo"));
+gap> InstallMethod(foobar, [IsObject], x -> fail); # fallback with no info string
+
+# also install multi argument methods, to make sure that there
+# is no bug which just happens to work with 1 argument
+gap> InstallOtherMethod(foobar, "for two lists", [IsList, IsList], 17-2*RankFilter(IsList), Concatenation);
+gap> InstallOtherMethod(foobar, "for no argument", [], {}->1);
+gap> InstallOtherMethod(foobar, "for 2 integers", [IsInt, IsInt], -2*RankFilter(IsInt), {x,y...}->1);
+gap> InstallOtherMethod(foobar, "for 3 integers", [IsInt, IsInt, IsInt], -3*RankFilter(IsInt), {x,y...}->1);
+gap> InstallOtherMethod(foobar, "for 4 integers", [IsInt, IsInt, IsInt, IsInt], -4*RankFilter(IsInt), {x,y...}->1);
+gap> InstallOtherMethod(foobar, "for 5 integers", [IsInt, IsInt, IsInt, IsInt, IsInt], -5*RankFilter(IsInt), {x,y...}->1);
+gap> InstallOtherMethod(foobar, "for 6 integers", [IsInt, IsInt, IsInt, IsInt, IsInt, IsInt], -6*RankFilter(IsInt), {x,y...}->1);
+
+#
+#
+#
+gap> Display(ApplicableMethod(foobar, [1]));
+function ( x )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [ ['a'] ], 1));
+#I  Searching Method for foobar with 1 arguments:
+#I  Total: 4 entries
+#I  Method 1: ``foobar: for a string'' at stream:1 , value: 2*SUM_FLAGS+1
+function ( x )
+    return StartsWith( x, "foo" );
+end
+gap> Display(ApplicableMethod(foobar, [ ['a'] ], 1, 2));
+#I  Searching Method for foobar with 1 arguments:
+#I  Total: 4 entries
+#I  Method 1: ``foobar: for a string'' at stream:1 , value: 2*SUM_FLAGS+1
+#I  Skipped:
+#I  Method 2: ``foobar: for a list'' at stream:1 , value: 42
+<Attribute "Length">
+gap> Display(ApplicableMethod(foobar, [fail], 1));
+#I  Searching Method for foobar with 1 arguments:
+#I  Total: 4 entries
+#I  Method 4: ``foobar'' at stream:1 , value: 0
+function ( x )
+    return fail;
+end
+gap> Display(ApplicableMethod(foobar, [fail], 4));
+#I  Searching Method for foobar with 1 arguments:
+#I  Total: 4 entries
+#I  Method 1: ``foobar: for a string'' at stream:1, value: 2*SUM_FLAGS+1
+#I   - 1st argument needs [ "IsString" ]
+#I  Method 2: ``foobar: for a list'' at stream:1, value: 42
+#I   - 1st argument needs [ "IsList" ]
+#I  Method 3: ``foobar: for an integer'' at stream:1, value: 1
+#I   - 1st argument needs [ "IsInt" ]
+#I  Method 4: ``foobar'' at stream:1, value: 0
+function ( x )
+    return fail;
+end
+gap> ApplicableMethod(foobar, [fail], 6);; Print("\n");
+#I  Searching Method for foobar with 1 arguments:
+#I  Total: 4 entries
+#I  Method 1: ``foobar: for a string'' at stream:1, value: 2*SUM_FLAGS+1
+#I   - 1st argument needs [ "IsString" ]
+#I  Method 2: ``foobar: for a list'' at stream:1, value: 42
+#I   - 1st argument needs [ "IsList" ]
+#I  Method 3: ``foobar: for an integer'' at stream:1, value: 1
+#I   - 1st argument needs [ "IsInt" ]
+#I  Method 4: ``foobar'' at stream:1, value: 0
+#I  Function Body:
+function ( x )
+    return fail;
+end
+
+#
+# Test other methods with two args
+#
+gap> Display(ApplicableMethod(foobar, [1, 2]));
+function ( x, y... )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [1, 2], 1));
+#I  Searching Method for foobar with 2 arguments:
+#I  Total: 2 entries
+#I  Method 2: ``foobar: for 2 integers'' at stream:1 , value: 0
+function ( x, y... )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [1, 2], 2));
+#I  Searching Method for foobar with 2 arguments:
+#I  Total: 2 entries
+#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
+#I  Method 2: ``foobar: for 2 integers'' at stream:1, value: 0
+function ( x, y... )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [1, 2], 3));
+#I  Searching Method for foobar with 2 arguments:
+#I  Total: 2 entries
+#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
+#I   - 1st argument needs [ "IsList" ]
+#I  Method 2: ``foobar: for 2 integers'' at stream:1, value: 0
+function ( x, y... )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [1, 2], 4));
+#I  Searching Method for foobar with 2 arguments:
+#I  Total: 2 entries
+#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
+#I   - 1st argument needs [ "IsList" ]
+#I   - 2nd argument needs [ "IsList" ]
+#I  Method 2: ``foobar: for 2 integers'' at stream:1, value: 0
+function ( x, y... )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [1, 2], 5));
+#I  Searching Method for foobar with 2 arguments:
+#I  Total: 2 entries
+#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
+#I   - 1st argument needs [ "IsList" ]
+#I   - 2nd argument needs [ "IsList" ]
+#I  Method 2: ``foobar: for 2 integers'' at stream:1, value: 0
+function ( x, y... )
+    return 1;
+end
+
+# check the method for two lists
+gap> ApplicableMethod(foobar, [[1], []], 5);;
+#I  Searching Method for foobar with 2 arguments:
+#I  Total: 2 entries
+#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
+
+# no method found
+gap> ApplicableMethod(foobar, [1, []], 5);
+#I  Searching Method for foobar with 2 arguments:
+#I  Total: 2 entries
+#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
+#I   - 1st argument needs [ "IsList" ]
+#I  Method 2: ``foobar: for 2 integers'' at stream:1, value: 0
+#I   - 2nd argument needs [ "IsInt" ]
+fail
+
+#
+# check 0-6 arguments
+#
+gap> Display(ApplicableMethod(foobar, [], 5));
+#I  Searching Method for foobar with 0 arguments:
+#I  Total: 1 entries
+#I  Method 1: ``foobar: for no argument'' at stream:1, value: 0
+function (  )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [1], 5));
+#I  Searching Method for foobar with 1 arguments:
+#I  Total: 4 entries
+#I  Method 1: ``foobar: for a string'' at stream:1, value: 2*SUM_FLAGS+1
+#I   - 1st argument needs [ "IsString" ]
+#I  Method 2: ``foobar: for a list'' at stream:1, value: 42
+#I   - 1st argument needs [ "IsList" ]
+#I  Method 3: ``foobar: for an integer'' at stream:1, value: 1
+function ( x )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [1,2], 5));
+#I  Searching Method for foobar with 2 arguments:
+#I  Total: 2 entries
+#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
+#I   - 1st argument needs [ "IsList" ]
+#I   - 2nd argument needs [ "IsList" ]
+#I  Method 2: ``foobar: for 2 integers'' at stream:1, value: 0
+function ( x, y... )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [1..3], 5));
+#I  Searching Method for foobar with 3 arguments:
+#I  Total: 1 entries
+#I  Method 1: ``foobar: for 3 integers'' at stream:1, value: 0
+function ( x, y... )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [1..4], 5));
+#I  Searching Method for foobar with 4 arguments:
+#I  Total: 1 entries
+#I  Method 1: ``foobar: for 4 integers'' at stream:1, value: 0
+function ( x, y... )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [1..5], 5));
+#I  Searching Method for foobar with 5 arguments:
+#I  Total: 1 entries
+#I  Method 1: ``foobar: for 5 integers'' at stream:1, value: 0
+function ( x, y... )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [1..6], 5));
+#I  Searching Method for foobar with 6 arguments:
+#I  Total: 1 entries
+#I  Method 1: ``foobar: for 6 integers'' at stream:1, value: 0
+function ( x, y... )
+    return 1;
+end
+
+#
+gap> STOP_TEST("methwy.tst");

--- a/tst/testutil.g
+++ b/tst/testutil.g
@@ -448,9 +448,9 @@ for name in rules do
   report:=[];
 
   for nargs in [1..2] do
-    f:=METHODS_OPERATION( ValueGlobal(name), nargs );
-    for m in [1..Length(f)/(BASE_SIZE_METHODS_OPER_ENTRY+nargs)] do
-      met := f[(m-1)*(BASE_SIZE_METHODS_OPER_ENTRY+nargs)+2+nargs];
+    f:=MethodsOperation( ValueGlobal(name), nargs );
+    for m in f do
+      met := m.method;
       str := "";
       ots := OutputTextString(str,true);;
       PrintTo( ots, met );
@@ -469,7 +469,7 @@ for name in rules do
       od;
       if Length(illegal_delegations) > 0 then
         Add( report, [ FILENAME_FUNC( met ), STARTLINE_FUNC( met ),
-                       f[m*(BASE_SIZE_METHODS_OPER_ENTRY+nargs)+4+nargs], illegal_delegations, met ] );
+                       m.info, illegal_delegations, met ] );
       fi;
     od;
   od;


### PR DESCRIPTION
This is a high-level wrapper for METHODS_OPERATION; it has some overhead, as
it creates a fresh list of records for each method when called; but it's
output has the advantage of being easier to process, leading to much easier
to understand code; and at the same time, it's future proof against
modifications to the way we store methods internally.

This would then also be useful for e.g. the browse package.

Also added a test for ApplicableMethod.

This PR also fixes the bad output of `CheckOutputDelegations` in master described in issue #2620.


Open question: should this be documented for users or not?