### PR TITLE
Don't call DisplayString from String method

### DIFF
--- a/lib/function.gi
+++ b/lib/function.gi
@@ -73,9 +73,11 @@ end);
 
 InstallMethod(String, "for a function, with whitespace reduced", [IsFunction and IsInternalRep],
 function(fun)
-    local  s, str;
-    s := ShallowCopy(DisplayString(fun));
-    Remove(s);
+    local  s, stream;
+    s := "";
+    stream := OutputTextString(s, true);
+    PrintTo(stream, fun);
+    CloseStream(stream);
     NormalizeWhitespace(s);
     return MakeImmutable(s);
 end);


### PR DESCRIPTION
Fixes #2620 

We could backport this to 4.9, it's a fairly trivial and self-contained change. OTOH, it's unlikely that the old code ever causes problems for anybody, so I am not sure that it's worth the effort (nor whether it's worth mentioning this in release notes... I tend to say "no" to that).