### PR TITLE
Win cyg fix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,15 +2,22 @@
 clone_depth: 5                  # clone entire repository history if not defined
 
 environment:
-  CFLAGS: "--coverage"
-  LDFLAGS: "--coverage"
   TEST_SUITES: testinstall
+
+  # To test building GAP both using the bundled libraries (zlib and GMP), as
+  # well as using the versions distributed with cygwin, we do the former in
+  # the 32 bit build and the latter in the 64 bit build. But building zlib
+  # does not see to work if '--coverage' is used, so we only use that flag in
+  # the 64 bit build.
   matrix:
     - CYG_ARCH: x86
       CYG_ROOT: C:\cygwin
       ABI: 32
     - CYG_ARCH: x86_64
       CYG_ROOT: C:\cygwin64
+      PACKAGES: "-P libgmp-devel,zlib-devel"
+      CFLAGS: "--coverage"
+      LDFLAGS: "--coverage"
 # FIXME: HPC-GAP builds on AppVeyor are disabled for now, as they experience
 # weird errors in building ward (which I cannot replicate on a Windows VM).
 #    - CYG_ARCH: x86
@@ -28,7 +35,7 @@ cache:
   - packages-master.tar.gz
 
 install:
-  - '%CYG_ROOT%\setup-%CYG_ARCH%.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l %CYG_ROOT%/var/cache/setup -P libgmp-devel,zlib-devel'
+  - '%CYG_ROOT%\setup-%CYG_ARCH%.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l %CYG_ROOT%/var/cache/setup %PACKAGES%'
 
 # scripts that run after cloning repository
 build_script:

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -555,8 +555,16 @@ ZLIB_FILES := $(ZLIB_PREFIX)/include/zlib.h
 EXTERN_FILES += $(ZLIB_FILES)
 
 zlib: $(ZLIB_FILES)
+ifeq ($(SYS_IS_CYGWIN32),yes)
+$(ZLIB_FILES):
+	MAKE=$(MAKE) CFLAGS="$(CFLAGS) $(ABI_CFLAGS)" $(srcdir)/cnf/build-cygwin-zlib.sh
+
+else
+
 $(ZLIB_FILES):
 	MAKE=$(MAKE) CFLAGS="$(CFLAGS) $(ABI_CFLAGS)" $(srcdir)/cnf/build-extern.sh zlib "$(abs_srcdir)/extern/zlib"
+
+endif # SYS_IS_CYGWIN32
 
 .PHONY: zlib
 

--- a/cnf/build-cygwin-zlib.sh
+++ b/cnf/build-cygwin-zlib.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# zlib on Cygwin requires a special build procedure 
+# The following is taken from the zlib package in Cygwin
+
+cd extern/zlib &&
+make -f win32/Makefile.gcc \
+		SHAREDLIB=cygz.dll IMPLIB=libz.dll.a \
+		SHARED_MODE=1 \
+		prefix= \
+		BINARY_PATH=../install/zlib/bin \
+		INCLUDE_PATH=../install/zlib/include \
+		LIBRARY_PATH=../install/zlib/lib \
+        all install

--- a/configure.ac
+++ b/configure.ac
@@ -394,6 +394,7 @@ AS_CASE([$with_zlib],
   ]
 )
 
+
 AS_IF([test $BUILD_ZLIB = no],
   [
     # try to link against zlib
@@ -410,14 +411,17 @@ AS_IF([test $BUILD_ZLIB = no],
 
 # Use bundled zlib if requested
 AS_IF([test x$BUILD_ZLIB = xyes],[
-  AS_CASE([$host_os],
-    [*cygwin*],[
-        AC_MSG_ERROR([Builtin zlib not supported on cygwin. Install zlib-devel package])
-    ]
-  )
   BUILD_ZLIB=yes
   ZLIB_CPPFLAGS='-I${abs_builddir}/extern/install/zlib/include'
-  ZLIB_LDFLAGS='${abs_builddir}/extern/install/zlib/lib/libz.a'
+  AS_CASE([$host_os],
+    [*cygwin*],[
+      ZLIB_LDFLAGS='-L${abs_builddir}/extern/install/zlib/lib/ -lz'
+    ],
+    [*],[
+      ZLIB_LDFLAGS='${abs_builddir}/extern/install/zlib/lib/libz.a'
+    ]
+  )
+
   ZLIB_LIBS=
 ])
 

--- a/extern/zlib/win32/zlib.def
+++ b/extern/zlib/win32/zlib.def
@@ -91,4 +91,3 @@ EXPORTS
     inflateCodesUsed
     inflateResetKeep
     deflateResetKeep
-    gzopen_w


### PR DESCRIPTION
This fixes builtin zlib on windows. It does make building a bit less neat, as the win32 Makefile for zlib will only work inside the zlib source directory.

I have added a commit to check that appveyor works both with and without gmp-devel and zlib-devel, but once it passes I'd like to remove it before commit, as running that test forever more seems unnecessary.