### PR TITLE
ProjectiveActionOnFullSpace: use list of vectors as domain

### DIFF
--- a/lib/grpffmat.gi
+++ b/lib/grpffmat.gi
@@ -180,8 +180,7 @@ InstallGlobalFunction(ProjectiveActionOnFullSpace,function(g,f,n)
 local o;
   # as the groups are large, we can take all normed vectors
   o:=NormedRowVectors(f^n);
-  o:=ImmutableMatrix(f,o);
-  o:=Set(o);
+  o:=Set(o, r -> ImmutableVector(f, r));
   return Action(g,o,OnLines);
 end);
 


### PR DESCRIPTION
... for an action, instead of a matrix

This change is motivated by (and also part of) PR #2640 -- in general, a MatrixObj is *not* a list-of-row-vectors.

The code using the domain later on really only needs it as a list, as far as I could tell.