### PR TITLE
Fix functions reading off end of bags

### DIFF
--- a/lib/listcoef.gi
+++ b/lib/listcoef.gi
@@ -236,7 +236,7 @@ function( l, s )
     for i  in [ 1 .. Length(l)-s ]  do
         l[i] := l[i+s];
     od;
-    for i  in [ Length(l)-s+1 .. Length(l) ]  do
+    for i  in [ Maximum(1, Length(l)-s+1) .. Length(l) ]  do
         Unbind(l[i]);
     od;
 end );

--- a/src/objfgelm.c
+++ b/src/objfgelm.c
@@ -486,7 +486,7 @@ Obj Func8Bits_Less (
             /* compare the exponents, and check the next generator.  This  */
             /* amounts to stripping off the common prefix  x^|expl-expr|.  */
             if( exl > exr ) {
-                if( nr > 0 ) {
+                if( nr > 1 ) {
                   lexico = (*pl & genm) < (*(pr+1) & genm) ? True : False;
                   break;
                 }
@@ -494,7 +494,7 @@ Obj Func8Bits_Less (
                     /* <r> is now essentially the empty word.             */
                     return False;
             }
-            if( nl > 0 ) {  /* exl < exr                                  */
+            if( nl > 1 ) {  /* exl < exr                                  */
                 lexico = (*(pl+1) & genm) < (*pr & genm) ? True : False;
                 break;
             }
@@ -1443,7 +1443,7 @@ Obj Func16Bits_Less (
             /* compare the exponents, and check the next generator.  This  */
             /* amounts to stripping off the common prefix  x^|expl-expr|.  */
             if( exl > exr ) {
-                if( nr > 0 ) {
+                if( nr > 1 ) {
                   lexico = (*pl & genm) < (*(pr+1) & genm) ? True : False;
                   break;
                 }
@@ -1451,7 +1451,7 @@ Obj Func16Bits_Less (
                     /* <r> is now essentially the empty word.             */
                     return False;
             }
-            if( nl > 0 ) {  /* exl < exr                                  */
+            if( nl > 1 ) {  /* exl < exr                                  */
                 lexico = (*(pl+1) & genm) < (*pr & genm) ? True : False;
                 break;
             }
@@ -2400,7 +2400,7 @@ Obj Func32Bits_Less (
             /* compare the exponents, and check the next generator.  This  */
             /* amounts to stripping off the common prefix  x^|expl-expr|.  */
             if( exl > exr ) {
-                if( nr > 0 ) {
+                if( nr > 1 ) {
                   lexico = (*pl & genm) < (*(pr+1) & genm) ? True : False;
                   break;
                 }
@@ -2408,7 +2408,7 @@ Obj Func32Bits_Less (
                     /* <r> is now essentially the empty word.             */
                     return False;
             }
-            if( nl > 0 ) {  /* exl < exr                                  */
+            if( nl > 1 ) {  /* exl < exr                                  */
                 lexico = (*(pl+1) & genm) < (*pr & genm) ? True : False;
                 break;
             }

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -2036,12 +2036,6 @@ Int CmpVec8BitVec8Bit( Obj vl, Obj vr )
         }
     }
     /* now the final byte */
-
-    /* a quick and easy case */
-    if (lenl == lenr && *ptrL == *ptrR)
-        return 0;
-
-    /* the more general case */
     if (lenl < lenr)
         len = lenl;
     else

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -4295,10 +4295,10 @@ void ShiftLeftVec8Bit( Obj vec, UInt amount)
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     ptr1 = BYTES_VEC8BIT(vec);
     ptr2 = BYTES_VEC8BIT(vec) + amount / elts;
+    end = BYTES_VEC8BIT(vec) + (len + elts - 1) / elts;
 
     /* The easy case is just a shift by bytes */
     if (amount % elts == 0) {
-        end = BYTES_VEC8BIT(vec) + (len + elts - 1) / elts;
         while (ptr2 < end)
             *ptr1++ = *ptr2++;
     } else {
@@ -4314,7 +4314,12 @@ void ShiftLeftVec8Bit( Obj vec, UInt amount)
             x = gettab[fbyte + 256 * (from % elts)];
             tbyte = settab[tbyte + 256 * (to % elts + elts * x)];
             if (++from % elts == 0)
-                fbyte = *++ptr2;
+            {
+                if(++ptr2 < end)
+                    fbyte = *ptr2;
+                else
+                    fbyte = 0;
+            }
             if (++to % elts == 0) {
                 *ptr1++ = tbyte;
                 tbyte = 0;

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -3690,12 +3690,17 @@ void ShiftLeftGF2Vec( Obj vec, UInt amount )
       ptr1 = BLOCKS_GF2VEC(vec);
       ptr2 = ptr1 + amount/BIPEB;
       off = amount % BIPEB;
-      for (i = 0; i < (len - amount + BIPEB - 1)/BIPEB; i++)
-	{
-	  block = (*ptr2++) >> off;
-	  block |= (*ptr2) << (BIPEB - off);
-	  *ptr1++ = block;
-	}
+      for (i = 0; i < (len - amount + BIPEB - 1)/BIPEB - 1; i++)
+      {
+        block = (*ptr2++) >> off;
+        block |= (*ptr2) << (BIPEB - off);
+        *ptr1++ = block;
+      }
+      // Handle last block seperately to avoid reading off end of Bag
+      block = (*ptr2++) >> off;
+      if(ptr2 < BLOCKS_GF2VEC(vec) + NUMBER_BLOCKS_GF2VEC(vec))
+        block |= (*ptr2) << (BIPEB - off);
+      *ptr1 = block;
     }
   ResizeGF2Vec(vec, len-amount);
 }

--- a/tst/testinstall/vecmat.tst
+++ b/tst/testinstall/vecmat.tst
@@ -362,4 +362,42 @@ gap> DistanceVecFFE(v1,v2);
 2
 
 #
+gap> checkShift := function(filt, field, length, shift)
+> local w;
+> w := NewVector(filt, field, List([1..length], x -> Random(field)));
+> v := StructuralCopy(w);
+> LeftShiftRowVector(v, shift);
+> if Length(v) <> Maximum(0, length - shift) then
+>   Print("failed left shift\n");
+> fi;
+> if ForAny([1..length-shift], i -> (w[i+shift] <> v[i])) then
+>   Print("failed left shift\n");
+> fi;
+> v := StructuralCopy(w);
+> RightShiftRowVector(v, shift, Zero(field));
+> if Length(v) <> length + shift then
+>   Print("failed right shift\n");
+> fi;
+> if ForAny([1..length], i -> (w[i] <> v[i+shift])) then
+>   Print("failed right shift\n");
+> fi;
+> if ForAny([1..shift], i -> (v[i] <> Zero(field))) then
+>   Print("failed right shift\n");
+> fi;
+> end;;
+
+# Check around powers of two
+gap> testlens := [0,1,2,7,8,9,15,16,17,31,32,33,62,63,64,65,66,126,127,128,129];;
+gap> for types in [[IsGF2VectorRep, GF(2)],
+>                  [IsPlistVectorRep, Integers],
+>                  [Is8BitVectorRep, GF(2)],
+>                  [Is8BitVectorRep, GF(9)]] do
+>      for i in testlens do
+>        for j in testlens do
+>          checkShift(IsGF2VectorRep, GF(2), i, j);
+>        od;
+>      od;
+>    od;
+
+#
 gap> STOP_TEST("vecmat.tst");


### PR DESCRIPTION
This is a selection of small fixes which stop functions reading off the end of bags.

These are not examples of where GAP is reading off the end of the Bag just so whole words can be read, but actively reading into other memory.

I don't think any of these could actually cause a bug (other than if, using some memory manager, GAP crashed because it read into disallowed memory), so they can't really be tested.