### PR TITLE
Immutable entries of mutable attributes of char. tables

### DIFF
--- a/lib/ctblfuns.gi
+++ b/lib/ctblfuns.gi
@@ -640,7 +640,7 @@ InstallMethod( GlobalPartitionOfClasses,
       # The number of root classes is by definition invariant under
       # table automorphisms.
       for map in Compacted( ComputedPowerMaps( tbl ) ) do
-        inv:= 0 * map;
+        inv:= ZeroMutable( map );
         for j in map do
           inv[j]:= inv[j] + 1;
         od;
@@ -3616,7 +3616,7 @@ InstallOtherMethod( Symmetrizations,
     [ IsCharacterTable, IsHomogeneousList, IsRecord ],
     function( tbl, characters, arec )
     local i, j, l, n,
-          tbl_powermap,     # computed power maps of 'tbl'
+          powermap,
           cyclestruct,
           classparam,
           symmirreds,
@@ -3626,7 +3626,6 @@ InstallOtherMethod( Symmetrizations,
           symmetrizations,
           chi,
           psi,
-          powermap,
           prodmatrix,
           single,
           value,
@@ -3651,17 +3650,14 @@ InstallOtherMethod( Symmetrizations,
       od;
     od;
 
-    tbl_powermap:= ShallowCopy( ComputedPowerMaps( tbl ) );
-#T better do the computation of necessary power maps only once!
-
     # Compute necessary power maps.
+    powermap:= ComputedPowerMaps( tbl );
     for i in [ 1 .. n ] do
-      if not IsBound( tbl_powermap[i] ) then
-        tbl_powermap[i]:= PowerMap( tbl, i );
+      if not IsBound( powermap[i] ) then
+        powermap[i]:= MakeImmutable( PowerMap( tbl, i ) );
       fi;
     od;
 
-    powermap:= tbl_powermap;
     symmetrizations:= [];
     for chi in characters do
 
@@ -3761,7 +3757,7 @@ InstallGlobalFunction( SymmetricParts, function( tbl, characters, n )
     powermap:= ComputedPowerMaps( tbl );
     for i in [ 1 .. n ] do
       if not IsBound( powermap[i] ) then
-        powermap[i]:= PowerMap( tbl, i );
+        powermap[i]:= MakeImmutable( PowerMap( tbl, i ) );
       fi;
     od;
 
@@ -3843,7 +3839,7 @@ InstallGlobalFunction( AntiSymmetricParts, function( tbl, characters, n )
     powermap:= ComputedPowerMaps( tbl );
     for i in [ 1 .. n ] do
       if not IsBound( powermap[i] ) then
-        powermap[i]:= PowerMap( tbl, i );
+        powermap[i]:= MakeImmutable( PowerMap( tbl, i ) );
       fi;
     od;
 

--- a/lib/ctblgrp.gi
+++ b/lib/ctblgrp.gi
@@ -144,7 +144,7 @@ local p,primes,i,cl,spr,j,allpowermaps,pm,ex;
   D.inversemap:=p;
 
   allpowermaps:=ComputedPowerMaps(D.characterTable);
-  allpowermaps[1]:=D.classrange;
+  allpowermaps[1]:= Immutable( D.classrange );
   D.powermap:=allpowermaps;
 
   # get all primes smaller than the largest element order
@@ -214,8 +214,8 @@ fi;
       fi;
     od;
 
+    MakeImmutable( pm );
   od;
-
 end;
 
 #############################################################################

--- a/lib/ctblmaps.gd
+++ b/lib/ctblmaps.gd
@@ -970,7 +970,7 @@ DeclareAttributeSuppCT( "NamesOfFusionSources",
 ##  <Mark><C>parameters</C></Mark>
 ##  <Item>
 ##    a record with components <C>maxamb</C>, <C>minamb</C> and <C>maxlen</C>
-##    which control the subroutine
+##    (and perhaps some optional components) which control the subroutine
 ##    <Ref Func="FusionsAllowedByRestrictions"/>;
 ##    it only uses characters with current indeterminateness up to
 ##    <C>maxamb</C>,
@@ -2368,13 +2368,21 @@ DeclareGlobalFunction( "ConsiderTableAutomorphisms" );
 ##  characters of <A>subtbl</A> and <A>tbl</A>, respectively,
 ##  <A>approxmap</A> a parametrized map that is an approximation of the class
 ##  fusion of <A>subtbl</A> in <A>tbl</A>,
-##  and <A>parameters</A> a record with components
+##  and <A>parameters</A> a record with the mandatory components
 ##  <C>maxlen</C>, <C>minamb</C>, <C>maxamb</C> (three integers),
 ##  <C>quick</C> (a Boolean),
-##  and <C>contained</C> (a function).
-##  Usual values of <C>contained</C> are
+##  and <C>contained</C> (a function, usual values are
 ##  <Ref Func="ContainedCharacters"/> or
-##  <Ref Func="ContainedPossibleCharacters"/>.
+##  <Ref Func="ContainedPossibleCharacters"/>);
+##  optional components of the <A>parameters</A> record are
+##  <C>testdec</C> (the function that tests the decomposability, 
+##  the default is <Ref Func="NonnegIntScalarProducts"/>),
+##  <C>powermaps</C> (the power paps of <A>subtbl</A> that shall be used for
+##  compatibility checks, the default is the <Ref Attr="ComputedPowerMaps"/>
+##  value),
+##  <C>subpowermaps</C> (the power paps of <A>tbl</A> that shall be used for
+##  compatibility checks, the default is the <Ref Attr="ComputedPowerMaps"/>
+##  value).
 ##  <P/>
 ##  <Ref Func="FusionsAllowedByRestrictions"/> replaces the entries of
 ##  <A>approxmap</A> by improved values,

--- a/lib/ctblsymm.gi
+++ b/lib/ctblsymm.gi
@@ -1187,8 +1187,8 @@ InstallGlobalFunction( CharacterTableWreathSymmetric, function( sub, n )
     powermap:= tbl.ComputedPowerMaps;
     for prime in PrimeDivisors( tbl.Size ) do
        spm:= PowerMap( sub, prime );
-       powermap[prime]:= List( [ 1 .. nccl ],
-           i -> Position(parts, PowerWreath(spm, parts[i], prime)) );
+       powermap[prime]:= MakeImmutable( List( [ 1 .. nccl ],
+           i -> Position(parts, PowerWreath(spm, parts[i], prime)) ) );
     od;
 
     # \ldots and `Irr'.
@@ -1252,7 +1252,8 @@ InstallMethod( Irr,
     fun:= gentbl.powermap[1];
     for p in PrimeDivisors( Size( G ) ) do
       if not IsBound( pow[p] ) then
-        pow[p]:= List( cp, x -> Position( cp, fun( deg, x[2], p ) ) );
+        pow[p]:= MakeImmutable(
+                     List( cp, x -> Position( cp, fun( deg, x[2], p ) ) ) );
       fi;
     od;
 
@@ -1837,6 +1838,7 @@ InstallValue( CharTableDoubleCoverSymmetric, MakeImmutable ( rec(
               fi;
             fi;
           od;
+          MakeImmutable( pow[p] );
         od;
 
         # Make the character parameters unique.
@@ -1861,9 +1863,10 @@ InstallValue( CharTableDoubleCoverSymmetric, MakeImmutable ( rec(
                     OrdersClassRepresentatives:= ord,
                     ComputedClassFusions:=
                         [ rec( name:= Concatenation("Sym(",String(n),")"),
-                               map:= fus ) ],
-                    Irr:= Concatenation( CharTableSymmetric.matrix( n )
-                              { [ 1 .. nrparts ] }{ fus }, chars ) );
+                               map:= MakeImmutable( fus ) ) ],
+                    Irr:= MakeImmutable( Concatenation(
+                              CharTableSymmetric.matrix( n )
+                              { [ 1 .. nrparts ] }{ fus }, chars ) ) );
         end,
     domain:= IsPosInt ) ) );
 
@@ -2125,6 +2128,7 @@ InstallValue( CharTableDoubleCoverAlternating, MakeImmutable( rec(
               fi;
             fi;
           od;
+          MakeImmutable( pow[p] );
         od;
 
         # add the characters of Alt_n
@@ -2160,12 +2164,12 @@ InstallValue( CharTableDoubleCoverAlternating, MakeImmutable( rec(
                     ComputedClassFusions:=
                         [ rec( name:= Concatenation( "Alt(", String( n ),
                                                      ")" ),
-                               map:= fus1 ),
+                               map:= MakeImmutable( fus1 ) ),
                           rec( name:= Concatenation( "2.Sym(", String( n ),
                                                      ")" ),
-                               map:= fus2 ) ],
-                    Irr:= Concatenation( tbl.Irr{
-                            [ 1 .. Length( tbl.Irr ) ] }{ fus1 }, chars ) );
+                               map:= MakeImmutable( fus2 ) ) ],
+                    Irr:= MakeImmutable( Concatenation( tbl.Irr{
+                            [ 1 .. Length( tbl.Irr ) ] }{ fus1 }, chars ) ) );
         end,
     domain:= IsPosInt ) ) );
 

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -61,6 +61,31 @@ gap> ViewString( t );
 gap> PrintString( t );
 "CharacterTable( \"Group( \>[ (1,2,3,4,5), (1,2) ]\<\> )\< )"
 
+# entries of mutable attributes are immutable
+gap> t:= CharacterTable( SymmetricGroup( 5 ) );
+CharacterTable( Sym( [ 1 .. 5 ] ) )
+gap> PowerMap( t, 2 );;  PowerMap( t, 3 );;
+gap> Length( ComputedPowerMaps( t ) );
+3
+gap> IsMutable( ComputedPowerMaps( t ) );
+true
+gap> ForAny( ComputedPowerMaps( t ), IsMutable );
+false
+gap> Indicator( t, 2 );;
+gap> Length( ComputedIndicators( t ) );
+2
+gap> IsMutable( ComputedIndicators( t ) );
+true
+gap> ForAny( ComputedIndicators( t ), IsMutable );
+false
+gap> PrimeBlocks( t, 2 );;
+gap> Length( ComputedPrimeBlockss( t ) );
+2
+gap> IsMutable( ComputedPrimeBlockss( t ) );
+true
+gap> ForAny( ComputedPrimeBlockss( t ), IsMutable );
+false
+
 ##
 gap> STOP_TEST( "ctbl.tst", 1);
 


### PR DESCRIPTION
Character tables use several mutable attributes whose values are
extendible lists:
`ComputedClassFusions`, `ComputedIndicators`, `ComputedPowerMaps`,
`ComputedPrimeBlockss`.

Up to now, the entries of these lists were mutable.
 @frankluebeck suggested to make these entries immutable.
This change makes sense.

*Note*:
The change may have side-effects w.r.t. users' GAP code.
For example, the object returned by
```
0 * ComputedPowerMaps( CharacterTable( "A5" ) )[2]`
```
had been a *mutable* list before the changes,
and will be an *immutable* list after the changes.

In order to achieve the immutability,
the following changes were necessary.

- Extended `SupportedCharacterTableInfo` and `DeclareAttributeSuppCT`
  such that the mutability of the attribute in question is recorded;
  there seems to be no way (and no need) to access this information
  from the attribute itself,

- changed `DeclarePropertySuppCT`, here mutability makes no sense,

- let `ConvertToCharacterTableNC` make the entries of mutable attributes
  immutable.

Other changes in the context of mutability of attributes for character tables:

- Removed the `DeclareAttributeSuppCT` call for `InfoText`;
  meanwhile this attribute is declared for arbitrary GAP objects,
  redeclaring it for special objects is logically wrong,

- call `MakeImmutable` for (entries of) attribute values before the
  conversion of a record to a character table object,
  in order to avoid the creation of a copy in the standard process of
  setting attribute values,

- documented some optional components of an argument for
  `ContainedPossibleCharacters`.