### PR TITLE
Fix xgap redirection of errout

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -1302,6 +1302,7 @@ void InitSystem (
         syBuf[2].fp = syBuf[0].fp;  syBuf[2].echo = syBuf[0].echo;
         syBuf[2].isTTY = syBuf[0].isTTY;
         syBuf[3].fp = syBuf[1].fp;
+        syBuf[3].echo = syBuf[1].echo;
         syWinPut( 0, "@p", "1." );
     }
    


### PR DESCRIPTION
This fixes xgap's special redirection of errout. Without this, xgap (and gap.app, which uses the same interface) don't correctly display break loops.