### PR TITLE
Remove popen

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -865,16 +865,6 @@ Int SyFopen (
         syBuf[fid].type = gzip_socket;
         syBuf[fid].bufno = -1;
     }
-#ifdef HAVE_POPEN
-   else if ( strncmp(mode,"r",1) == 0
-           && SyIsReadableFile(namegz) == 0
-             && ( (syBuf[fid].pipehandle = popen(cmd,"r"))
-               ) ) {
-        syBuf[fid].type = pipe_socket;
-        syBuf[fid].fp = fileno(syBuf[fid].pipehandle);
-        syBuf[fid].bufno = -1;
-    }
-#endif
     else {
         HashUnlock(&syBuf);
         return (Int)-1;
@@ -3214,16 +3204,13 @@ Int SyIsExistingFile ( const Char * name )
 Int SyIsReadableFile ( const Char * name )
 {
     Int         res;
-#ifdef HAVE_POPEN
     Char        xname[1024];
-#endif
 
     SyClearErrorNo();
     res = access( name, R_OK );
     if ( res == -1 ) {
-      /* if there is popen then we might be able to read the file via gunzip */
+      /* we might be able to read the file via zlib */
 
-#ifdef HAVE_POPEN
       /* beware of buffer overflows */
       if ( strlcpy(xname, name, sizeof(xname)) < sizeof(xname) &&
             strlcat(xname, ".gz", sizeof(xname))  < sizeof(xname) ) {
@@ -3231,7 +3218,6 @@ Int SyIsReadableFile ( const Char * name )
       }
 
       if (res == -1)
-#endif
         SySetErrorNo();
     }
     return res;


### PR DESCRIPTION
This removes code which checks for POPEN to decide if we support gzipped files, as now we always do. This is required to support gzipped files when compiling gap to javascript, and is good general cleanup.

There is some gzip / popen code left in profiling, as there is a subtle issue there (we start compressing so early GAP hasn't even set up streams yet).
