### PR TITLE
FIX: Add IsBiCoset

### DIFF
--- a/doc/ref/groups.xml
+++ b/doc/ref/groups.xml
@@ -175,6 +175,7 @@ free generators, that will map on this element again.
 <#Include Label="RightCosets">
 <#Include Label="CanonicalRightCosetElement">
 <#Include Label="IsRightCoset">
+<#Include Label="IsBiCoset">
 <#Include Label="CosetDecomposition">
 
 </Section>

--- a/lib/csetgrp.gd
+++ b/lib/csetgrp.gd
@@ -322,6 +322,24 @@ DeclareCategory("IsRightCoset", IsDomain and IsExternalOrbit and
 
 #############################################################################
 ##
+#P  IsBiCoset( <C> )
+##
+##  <#GAPDoc Label="IsBiCoset">
+##  <ManSection>
+##  <Prop Name="IsBiCoset" Arg='C'/>
+##
+##  <Description>
+##  A (right) cose is considered a <E>bicoset</E> if its set of elements simultaneously forms a left
+##  coset for the same subgroup. This is the case, for example, if the coset representative normalizes
+##  the subgroup.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareProperty( "IsBiCoset", IsRightCoset );
+
+#############################################################################
+##
 #O  RightCoset( <U>, <g> )
 ##
 ##  <#GAPDoc Label="RightCoset">
@@ -353,6 +371,8 @@ DeclareCategory("IsRightCoset", IsDomain and IsExternalOrbit and
 ##  6
 ##  gap> AsList(c);
 ##  [ (2,3,4), (1,4,2), (1,3,4,2), (1,3)(2,4), (2,4), (1,4,2,3) ]
+##  gap> IsBiCoset(c);
+##  false
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -629,6 +629,14 @@ function(d)
   Print(ViewString(d));
 end);
 
+InstallMethod(IsBiCoset,"test property",true,[IsRightCoset],0,
+function(c)
+local s,r;
+  s:=ActingDomain(c);
+  r:=Representative(c);
+  return ForAll(GeneratorsOfGroup(s),x->r*x/r in s);
+end);
+
 InstallMethodWithRandomSource(Random,
   "for a random source and a RightCoset",
   [IsRandomSource, IsRightCoset],0,
@@ -656,10 +664,17 @@ end);
 InstallOtherMethod(\*,"RightCosets",IsIdenticalObj,
         [IsRightCoset,IsRightCoset],0,
 function(a,b)
-  if ActingDomain(a)<>ActingDomain(b) then
-    Error("no multiplication defined for cosets of different subgroups");
+local c;
+  if ActingDomain(a)<>ActingDomain(b) then TryNextMethod();fi;
+  if not IsBiCoset(a) then # product does not require b to be bicoset
+    TryNextMethod();
+  fi; 
+  c:=RightCoset(ActingDomain(a), Representative(a) * Representative(b) );
+  if IsBiCoset(b) then
+    SetIsBiCoset(c,true);
   fi;
-  return RightCoset(ActingDomain(a), Representative(a) * Representative(b) );
+
+  return c;
 end);
 
 InstallOtherMethod(InverseOp,"Right cosets",true,
@@ -668,10 +683,12 @@ function(a)
 local s,r;
   s:=ActingDomain(a);
   r:=Representative(a);
-  if ForAny(GeneratorsOfGroup(s),x->not x^r in s) then
+  if not IsBiCoset(a) then
     Error("Inversion only works for cosets of normal subgroups");
   fi;
-  return RightCoset(s,Inverse(r));
+  r:=RightCoset(s,Inverse(r));
+  SetIsBiCoset(r,true);
+  return r;
 end);
 
 InstallOtherMethod(OneOp,"Right cosets",true,


### PR DESCRIPTION
and allow coset multiplication only for bicosets (as otherwise its not well-defined.

This fixes #2555

There is no test for the condition of #2555, as the illegal coset multiplication now runs into a `no method found' error.