### PR TITLE
kernel: use zlib to write profile data

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -665,7 +665,6 @@ dnl various functions to deal with child processes
 AC_HEADER_SYS_WAIT
 AC_TYPE_PID_T
 AC_FUNC_FORK
-AC_CHECK_FUNCS([popen])
 
 dnl signal handling
 AC_CHECK_TYPE([sig_atomic_t], [],


### PR DESCRIPTION
This also gets rid of the last use of `popen`, so remove the check for it from `configure.ac`.

This completes the work begun in PR #2663.