### PR TITLE
kernel: streamline weak pointer object code; fix `MakeImmutable` for weak pointer objects

### DIFF
--- a/src/gasman.h
+++ b/src/gasman.h
@@ -348,7 +348,7 @@ static inline void SET_PTR_BAG(Bag bag, Bag *val)
 **  is incorrect as mentioned in the section for 'PTR_BAG' (see "PTR_BAG").
 */
 
-#if !defined(USE_GASMAN)
+#if defined(USE_BOEHM_GC)
 
 static inline void CHANGED_BAG(Bag bag)
 {
@@ -370,7 +370,7 @@ static inline void CHANGED_BAG(Bag bag)
 
 extern void CHANGED_BAG(Bag b);
 
-#else
+#elif defined(USE_GASMAN)
 
 extern Bag * YoungBags;
 extern Bag   ChangedBags;
@@ -381,6 +381,10 @@ static inline void CHANGED_BAG(Bag bag)
         ChangedBags = bag;
     }
 }
+
+#else
+
+#error unknown garbage collector
 
 #endif
 

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -10,10 +10,10 @@
 *Y  (C) 1998 School Math and Comp. Sci., University of St Andrews, Scotland
 *Y  Copyright (C) 2002 The GAP Group
 **
-**  This file contains the functions that deal with weak pointer objects
+**  This file contains the functions that deal with weak pointer objects.
 **  A weak pointer object looks like a plain list, except that its entries
 **  are NOT kept alive through a garbage collection (unless they are contained
-**  in some other kind of object). 
+**  in some other kind of object).
 */
 
 #include "weakptr.h"
@@ -137,12 +137,11 @@ static inline void SET_ELM_WPOBJ(Obj list, UInt pos, Obj val)
 
 /****************************************************************************
 **
-*F  GROW_WPOBJ(<wp>,<need>) . make sure a weak pointer object is large enough
+*F  GROW_WPOBJ(<wp>,<need>) . . .  ensure weak pointer object is large enough
 **
-**  'GROW_WPOBJ' grows the weak pointer   object <wp> if necessary  to
-**  ensure that it has room for at least <need> elements.
+**  'GROW_WPOBJ' grows the weak pointer object <wp> if necessary to ensure
+**  that it has room for at least <need> elements.
 */
-
 static inline void GROW_WPOBJ(Obj wp, UInt need)
 {
   UInt                plen;           /* new physical length             */
@@ -186,7 +185,7 @@ static inline void GROW_WPOBJ(Obj wp, UInt need)
 
 /****************************************************************************
 **
-*F  FuncWeakPointerObj( <self>, <list> ) . . . . . make a weak pointer object
+*F  FuncWeakPointerObj(<self>,<list>) . . . . . .  make a weak pointer object
 **
 **  Handler for the GAP function WeakPointerObject(<list>), which makes a new
 **  WP object.
@@ -231,11 +230,11 @@ Obj FuncWeakPointerObj(Obj self, Obj list)
 
 /****************************************************************************
 **
-*F  LengthWPObj(<wp>) . . . . . . . . . . . . . . current length of WP Object
+*F  LengthWPObj(<wp>) . . . . . . . . . . . . . . current length of WP object
 **
-**  'LengthWPObj(<wp>)' returns  the   current length  of WP  Object  as  a C
-**  integer  the   value cannot be   trusted past  a   garbage collection, as
-**  trailing items may evaporate.
+**  'LengthWPObj' returns the length of the WP object <wp> as a C integer.
+**  The value cannot be trusted past a garbage collection, as trailing items
+**  may evaporate.
 **   
 **  Any identifiers of trailing objects that have evaporated in a garbage
 **  collection are cleaned up by this function. However, for HPC-GAP, this
@@ -266,12 +265,11 @@ Int LengthWPObj(Obj wp)
 
 /****************************************************************************
 **
-*F  FuncLengthWPObj(<wp>) . . . . . . . . . . . . current length of WP Object
+*F  FuncLengthWPObj(<wp>) . . . . . . . . . . . . current length of WP object
 **
-**  'FuncLengthWPObj(<wp>)' is a handler for a  GAP function that returns the
-**  current length of WP  Object. The value  cannot be trusted past a garbage
+**  'FuncLengthWPObj' is a handler for a GAP function that returns the length
+**  of the WP object <wp>. The value cannot be trusted past a garbage
 **  collection, as trailing items may evaporate.
-** 
 */
 
 Obj FuncLengthWPObj(Obj self, Obj wp)
@@ -287,11 +285,10 @@ Obj FuncLengthWPObj(Obj self, Obj wp)
 
 /****************************************************************************
 **
-*F  FuncSetElmWPObj(<self>, <wp>, <pos>, <obj> ) . set an entry in a WP Object
+*F  FuncSetElmWPObj(<self>,<wp>,<pos>,<obj>) . .  set an entry in a WP object
 **
-**  'FuncSetElmWPObj(<self>, <wp>,  <pos>, <obj>  )'  is a  handler for a GAP
-**  function that sets an entry in a WP object.
-** 
+**  'FuncSetElmWPObj'  is a handler for a GAP function that sets an entry in
+**  a WP object.
 */
 
 Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
@@ -343,9 +340,9 @@ Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 
 /****************************************************************************
 **
-*F  IsBoundElmWPObj( <wp>, <pos> ) .  . . . . is an entry bound in a WP Object
+*F  IsBoundElmWPObj(<wp>,<pos>) .  . . . . is an entry bound in a WP object
 **
-**  'IsBoundElmWPObj( <wp>, <pos> )' returns 1 is there is (currently) a live
+**  'IsBoundElmWPObj' returns 1 is there is (currently) a live
 **  value at position pos or the WP object wp and  0 otherwise, cleaning up a
 **  dead entry if there is one
 ** */
@@ -393,13 +390,11 @@ Int IsBoundElmWPObj( Obj wp, Obj pos)
 
 /****************************************************************************
 **
-*F  FuncIsBoundElmWPObj( <self>, <wp>, <pos> ) . . . . . . .IsBound WP Object
+*F  FuncIsBoundElmWPObj(<self>,<wp>,<pos>) . . IsBound handler for WP objects
 **
-**  GAP  handler for IsBound  test on WP Object.   Remember that bindings can
+**  GAP  handler for IsBound  test on WP object.   Remember that bindings can
 **  evaporate in any garbage collection.
 */
-
-
 Obj FuncIsBoundElmWPObj( Obj self, Obj wp, Obj pos)
 {
   return IsBoundElmWPObj(wp, pos) ? True : False;
@@ -408,9 +403,9 @@ Obj FuncIsBoundElmWPObj( Obj self, Obj wp, Obj pos)
 
 /****************************************************************************
 **
-*F  FuncUnbindElmWPObj( <self>, <wp>, <pos> ) . . . . . . . .Unbind WP Object
+*F  FuncUnbindElmWPObj(<self>,<wp>,<pos>) . . . Unbind handler for WP objects
 **
-**  GAP  handler for Unbind on WP Object. 
+**  GAP  handler for Unbind on WP object. 
 */
 
 Obj FuncUnbindElmWPObj( Obj self, Obj wp, Obj pos)
@@ -456,19 +451,10 @@ Obj FuncUnbindElmWPObj( Obj self, Obj wp, Obj pos)
 
 /****************************************************************************
 **
-*F  FuncElmWPObj( <self>, <wp>, <pos> ) . . . . . . . . . . .Access WP Object
+*F  ElmDefWPList(<wp>,<ipos>,<def>)
 **
-**  GAP handler for access to WP Object. If the entry is not bound, then fail
-**  is  returned. It would not be  correct to return  an error, because there
-**  would be no  way  to  safely access  an  element, which  might  evaporate
-**  between a  call   to IsBound and the    access. This, of  course,  causes
-**  possible  confusion  with a WP  object which  does have  a  value of fail
-**  stored in  it. This, however  can be  checked  with a subsequent  call to
-**  IsBound, relying on the fact  that fail can never  dissapear in a garbage
-**  collection.
+**  Provide implementation of 'ElmDefListFuncs'.
 */
-
-// Provide implementation of ElmDefListFuncs
 Obj ElmDefWPList(Obj wp, Int ipos, Obj def)
 {
     GAP_ASSERT(TNUM_OBJ(wp) == T_WPOBJ);
@@ -497,6 +483,20 @@ Obj ElmDefWPList(Obj wp, Int ipos, Obj def)
   return elm;
 }
 
+
+/****************************************************************************
+**
+*F  FuncElmWPObj(<self>,<wp>,<pos>) . . . . . . . access entry of a WP object
+**
+**  GAP handler for access to WP object. If the entry is not bound, then fail
+**  is  returned. It would not be  correct to return  an error, because there
+**  would be no  way  to  safely access  an  element, which  might  evaporate
+**  between a  call   to IsBound and the    access. This, of  course,  causes
+**  possible  confusion  with a WP  object which  does have  a  value of fail
+**  stored in  it. This, however  can be  checked  with a subsequent  call to
+**  IsBound, relying on the fact  that fail can never  dissapear in a garbage
+**  collection.
+*/
 Obj FuncElmWPObj(Obj self, Obj wp, Obj pos)
 {
     if (TNUM_OBJ(wp) != T_WPOBJ) {
@@ -521,10 +521,10 @@ Obj FuncElmWPObj(Obj self, Obj wp, Obj pos)
 
 /****************************************************************************
 **
-*F  TypeWPObj( <wp> ) . . . . . . . . . . . . . . . . . . . Type of WP Object
+*F  TypeWPObj(<wp>) . . . . . . . . . . . . . . . . . . . . type of WP object
 **
-**  This is imported from the library variable  TYPE_WPOBJ. They all have the
-**  same type
+**  This returns the library variable TYPE_WPOBJ. All WP objects have the
+**  same type.
 */
 
 Obj TYPE_WPOBJ;              
@@ -537,7 +537,7 @@ Obj TypeWPObj( Obj wp )
 
 /****************************************************************************
 **
-*F  FuncIsWPObj( <self>, <wp>) . . . . . . . Handler for GAP function IsWPObj
+*F  FuncIsWPObj(<self>,<wp>) . . . . . . . . handler for GAP function IsWPObj
 */
 static Obj IsWPObjFilt;
 
@@ -548,12 +548,12 @@ Obj FuncIsWPObj( Obj self, Obj wp)
 
 /****************************************************************************
 **
-*F  MarkWeakPointerObj( <wp> ) . . . . . . . . . . . . . . . Marking function
-*F  SweepWeakPointerObj( <src>, <dst>, <len> ) . . . . . . .Sweeping function
+*F  MarkWeakPointerObj(<wp>) . . . . . . . . . . . . . . . . Marking function
+*F  SweepWeakPointerObj(<src>,<dst>,<len>) . . . . . . . .  Sweeping function
 **
-**  These functions are installed for GASMAN to use in garbage collection. The
-**  sweeping function must  clean up any  dead  weak pointers encountered  so
-**  that, after a  full  GC, the  masterpointers  occupied by the  dead  weak
+**  These functions are installed for GASMAN to use in garbage collection.
+**  The sweeping function must clean up any dead weak pointers encountered so
+**  that, after a full GC, the masterpointers occupied by the dead weak
 **  pointers can be reclaimed.  
 */
 
@@ -621,7 +621,7 @@ void CopyWPObj(Obj copy, Obj original)
 
 /****************************************************************************
 **
-*F  CopyObjWPObj( <obj>, <mut> ) . . . . . . . . .  copy a positional object
+*F  CopyObjWPObj(<obj>,<mut>) . . . . . . . . . . . . . . .  copy a WP object
 **
 **  Note  that an  immutable   copy of  a  weak  pointer  object is a  normal
 **  immutable plist. An Immutable WP object is a contradiction.
@@ -682,7 +682,7 @@ Obj CopyObjWPObj (
 
 /****************************************************************************
 **
-*F  MakeImmutableWPObj( <obj> ) . . . . . . . . . . make immutable in place
+*F  MakeImmutableWPObj(<obj>) . . . . . . . . . . . . make immutable in place
 **
 */
 
@@ -722,7 +722,7 @@ void MakeImmutableWPObj( Obj obj )
 
 /****************************************************************************
 **
-*F  CleanObjWPObj( <obj> ) . . . . . . . . . . . . . . . . . . .  clean WPobj
+*F  CleanObjWPObj(<obj>) . . . . . . . . . . . . . . . . . .  clean WP object
 */
 void CleanObjWPObj (
     Obj                 obj )
@@ -732,7 +732,7 @@ void CleanObjWPObj (
 
 /****************************************************************************
 **
-*F  CopyObjWPObjCopy( <obj>, <mut> ) . . . . . . . . . .  . copy a WPobj copy
+*F  CopyObjWPObjCopy(<obj>,<mut>) . . . . . . . . . . . copy a WP object copy
 */
 Obj CopyObjWPObjCopy (
     Obj                 obj,
@@ -744,7 +744,7 @@ Obj CopyObjWPObjCopy (
 
 /****************************************************************************
 **
-*F  CleanObjWPObjCopy( <obj> ) . . . . . . . . . . . . . . clean WPobj copy
+*F  CleanObjWPObjCopy(<obj>) . . . . . . . . . . . . . . clean WP object copy
 */
 void CleanObjWPObjCopy (
     Obj                 obj )
@@ -773,7 +773,7 @@ void CleanObjWPObjCopy (
 
 /****************************************************************************
 **
-*F  SaveWPObj( <wpobj> )
+*F  SaveWPObj(<wpobj>)
 */
 
 void SaveWPObj(Obj wpobj)
@@ -787,7 +787,7 @@ void SaveWPObj(Obj wpobj)
 
 /****************************************************************************
 **
-*F  LoadWPObj( <wpobj> )
+*F  LoadWPObj(<wpobj>)
 */
 
 void LoadWPObj(Obj wpobj)
@@ -837,7 +837,7 @@ static StructGVarFunc GVarFuncs [] = {
 
 /****************************************************************************
 **
-*F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
+*F  InitKernel(<module>) . . . . . . . . .  initialise kernel data structures
 */
 static Int InitKernel (
     StructInitInfo *    module )
@@ -898,7 +898,7 @@ static Int InitKernel (
 
 /****************************************************************************
 **
-*F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
+*F  InitLibrary(<module>) . . . . . . . .  initialise library data structures
 */
 static Int InitLibrary (
     StructInitInfo *    module )

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -551,13 +551,14 @@ Obj FuncIsWPObj( Obj self, Obj wp)
 
 #if defined(USE_GASMAN)
 
-static void MarkWeakPointerObj( Obj wp) 
+static void MarkWeakPointerObj(Obj wp)
 {
-  Int i;
-  /* can't use the stored length here, in case we
-     are in the middle of copying */
-  for (i = 1; i <= (SIZE_BAG(wp)/sizeof(Obj))-1; i++)
-    MarkBagWeakly(ELM_WPOBJ(wp,i));
+    // can't use the stored length here, in case we are in the middle of
+    // copying
+    const UInt len = SIZE_BAG(wp) / sizeof(Obj) - 1;
+    for (UInt i = 1; i <= len; i++) {
+        MarkBagWeakly(ADDR_OBJ(wp)[i]);
+    }
 }
 
 static void SweepWeakPointerObj( Bag *src, Bag *dst, UInt len)

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -65,35 +65,33 @@
 
 /****************************************************************************
 **
-*F  STORE_LEN_WPOBJ(<wp>,<len>) . . . . . . .  set the length of a WP object
+*F  STORE_LEN_WPOBJ(<wp>,<len>) . . . . . . . . set the length of a WP object
 **
-**  'STORE_LEN_WPOBJ' sets the length of  the WP object  <wp> to <len>.
-**
-**  Note  that 'STORE_LEN_WPOBJ'  is a macro, so do not call it with  arguments
-**  that have side effects.
+**  'STORE_LEN_WPOBJ' sets the length of the WP object <wp> to <len>.
 ** 
-**  Objects at the end of wp may evaporate, so the stored length can only
+**  Objects at the end of <wp> may evaporate, so the stored length can only
 **  be regarded as an upper bound.
 */
-
-#define STORE_LEN_WPOBJ(wp,len)         (ADDR_OBJ(wp)[0] = (Obj)(len))
+static inline void STORE_LEN_WPOBJ(Obj wp, Int len)
+{
+    ADDR_OBJ(wp)[0] = (Obj)len;
+}
 
 
 /****************************************************************************
 **
-*F  STORED_ LEN_WPOBJ(<wp>). . .. . . . . . .  stored length of a WP Object
+*F  STORED_LEN_WPOBJ(<wp>) . . . . . . . . . . . stored length of a WP object
 **
 **  'STORED_LEN_WPOBJ' returns the stored length of the WP object <wp> 
 **  as a C integer.
 **
-**  Note that 'STORED_LEN_WPOBJ' is a  macro, so do  not call it 
-**  with arguments that have side effects.
-**
 **  Note that as the list can mutate under your feet, the length may be
-**  an overestimate
+**  an overestimate.
 */
-
-#define STORED_LEN_WPOBJ(wp)                 ((Int)(CONST_ADDR_OBJ(wp)[0]))
+static inline Int STORED_LEN_WPOBJ(Obj wp)
+{
+    return (Int)(CONST_ADDR_OBJ(wp)[0]);
+}
 
 /****************************************************************************
 **

--- a/tst/testinstall/weakptr.tst
+++ b/tst/testinstall/weakptr.tst
@@ -75,14 +75,15 @@ true
 #
 gap> w[1];
 1
-gap> w{[2..4]} := [[1,2],E(5),311]; 
-[ [ 1, 2 ], E(5), 311 ]
+gap> l := [ 311 ];; # keep ref so that this list is not garbage collected
+gap> w{[2..4]} := [[1,2],E(5),l]; 
+[ [ 1, 2 ], E(5), [ 311 ] ]
 gap> Print(w,"\n");
-WeakPointerObj( [ 1, [ 1, 2 ], E(5), 311, , fail ] )
+WeakPointerObj( [ 1, [ 1, 2 ], E(5), [ 311 ], , fail ] )
 gap> Print(StructuralCopy(w),"\n");
-WeakPointerObj( [ 1, [ 1, 2 ], E(5), 311, , fail ] )
+WeakPointerObj( [ 1, [ 1, 2 ], E(5), [ 311 ], , fail ] )
 gap> Immutable(w);
-[ 1, [ 1, 2 ], E(5), 311,, fail ]
+[ 1, [ 1, 2 ], E(5), [ 311 ],, fail ]
 gap> IsBound(w[2]);
 true
 gap> GASMAN("collect");
@@ -90,13 +91,38 @@ gap> IsBound(w[5]);
 false
 gap> Unbind(w[2]);
 gap> Print(w,"\n");
-WeakPointerObj( [ 1, , E(5), 311, , fail ] )
+WeakPointerObj( [ 1, , E(5), [ 311 ], , fail ] )
 gap> Immutable(w);
-[ 1,, E(5), 311,, fail ]
+[ 1,, E(5), [ 311 ],, fail ]
 gap> w;
-WeakPointerObj( [ 1, , E(5), 311, , fail ] )
+WeakPointerObj( [ 1, , E(5), [ 311 ], , fail ] )
 gap> MakeImmutable(w);
-[ 1,, E(5), 311,, fail ]
+[ 1,, E(5), [ 311 ],, fail ]
 gap> w;
-[ 1,, E(5), 311,, fail ]
+[ 1,, E(5), [ 311 ],, fail ]
+gap> IsMutable(w);
+false
+gap> ForAny(w, IsMutable);
+false
+
+#
+# test recursive MakeImmutable
+#
+gap> w := WeakPointerObj([ ~ ]);;
+gap> MakeImmutable(w);
+[ [ ~[1] ] ]
+
+#
+gap> w := WeakPointerObj([ 1 ]);;
+gap> w[1] := w;;
+gap> MakeImmutable(w);
+[ ~ ]
+
+#
+gap> w := WeakPointerObj([ rec() ]);;
+gap> w[1].self := w;;
+gap> MakeImmutable(w);
+[ rec( self := ~ ) ]
+
+#
 gap> STOP_TEST( "weakptr.tst", 1);


### PR DESCRIPTION
While preparing PR #2092 for merging, I noticed that there was a problem with the weak pointer object code in it. Also, @ChrisJefferson made some good suggestions on how to minimize the difference for the wp code in GASMAN and Julia.

The result is this PR, which cleans up the weak pointer object code. Most of the changes in here actually already wer in PR #2092, but intermingled with Julia GC specific code.

My hope is that we can merge this PR speedily, and then afterwards merge PR #2092 (which I will shortly rebased based on this PR).