### PR TITLE
`ViewString` methods for various types of objects

### DIFF
--- a/hpcgap/lib/ffe.gi
+++ b/hpcgap/lib/ffe.gi
@@ -674,10 +674,10 @@ InstallMethod( String, "for a field of FFEs",
 InstallMethod( ViewString, "for a field of FFEs",
         [ IsField and IsFFECollection ], 10, GAPInfo.tmpGFstring );
 Unbind(GAPInfo.tmpGFstring);
+
 InstallMethod( ViewObj, "for a field of FFEs",
-        [ IsField and IsFFECollection ], 10, function( F )
-    Print( ViewString(F) );
-end );
+    [ IsField and IsFFECollection ], 10,
+    DelegateFromViewObjToViewString );
 
 InstallMethod( PrintObj, "for a field of FFEs",
         [ IsField and IsFFECollection ], 10, function( F )

--- a/hpcgap/lib/ffeconway.gi
+++ b/hpcgap/lib/ffeconway.gi
@@ -313,9 +313,8 @@ end);
 
 InstallMethod(ViewObj, "For large finite field elements",
         [IsFFE and IsCoeffsModConwayPolRep], 
-        function(x)
-    Print(ViewString(x));
-end);
+    DelegateFromViewObjToViewString );
+
 
 #############################################################################
 ##

--- a/hpcgap/lib/fldabnum.gi
+++ b/hpcgap/lib/fldabnum.gi
@@ -278,32 +278,42 @@ end );
 
 #############################################################################
 ##
+#M  ViewString( <F> ) . . . . . . . . . . . . . . for an abelian number field
+##
+InstallMethod( ViewString,
+    "for abelian number field of cyclotomics",
+    [ IsAbelianNumberField and IsCyclotomicCollection ],
+    function( F )
+    if IsPrimeField( LeftActingDomain( F ) ) then
+      return STRINGIFY( "NF(", Conductor( F ), ",",
+                 GaloisStabilizer( F ), ")" );
+    else
+      return STRINGIFY( "AsField( ", ViewString( LeftActingDomain( F ) ),
+                 ", NF(", Conductor( F ), ",", GaloisStabilizer( F ), ") )" );
+    fi;
+    end );
+
+InstallMethod( ViewString,
+    "for cyclotomic field of cyclotomics",
+    [ IsCyclotomicField and IsCyclotomicCollection ],
+    function( F )
+    if IsPrimeField( LeftActingDomain( F ) ) then
+      return STRINGIFY( "CF(", Conductor( F ), ")" );
+    else
+      return STRINGIFY( "AsField( ", ViewString( LeftActingDomain( F ) ),
+                 ", CF(", Conductor( F ), ") )" );
+    fi;
+    end );
+
+
+#############################################################################
+##
 #M  ViewObj( <F> )  . . . . . . . . . . . . . .  view an abelian number field
 ##
 InstallMethod( ViewObj,
     "for abelian number field of cyclotomics",
     [ IsAbelianNumberField and IsCyclotomicCollection ],
-    function( F )
-    if IsPrimeField( LeftActingDomain( F ) ) then
-      Print( "NF(", Conductor( F ), ",",
-              GaloisStabilizer( F ), ")" );
-    else
-      Print( "AsField( ", LeftActingDomain( F ),
-             ", NF(", Conductor( F ), ",", GaloisStabilizer( F ), ") )" );
-    fi;
-    end );
-
-InstallMethod( ViewObj,
-    "for cyclotomic field of cyclotomics",
-    [ IsCyclotomicField and IsCyclotomicCollection ],
-    function( F )
-    if IsPrimeField( LeftActingDomain( F ) ) then
-      Print( "CF(", Conductor( F ), ")" );
-    else
-      Print( "AsField( ", LeftActingDomain( F ),
-             ", CF(", Conductor( F ), ") )" );
-    fi;
-    end );
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################

--- a/hpcgap/lib/ringpoly.gi
+++ b/hpcgap/lib/ringpoly.gi
@@ -319,8 +319,9 @@ end);
 #M  ViewString( <pring> ) . . . . . . . . . . . . . . . for a polynomial ring
 ##
 InstallMethod( ViewString,
-               "for a polynomial ring", true,  [ IsPolynomialRing ], 0,
-
+    "for a polynomial ring",
+    [ IsPolynomialRing ],
+    RankFilter( IsFLMLOR ),  # override the higher ranking FLMLOR method
   R -> Concatenation(ViewString(LeftActingDomain(R)),
                      Filtered(String(IndeterminatesOfPolynomialRing(R)),
                               ch -> ch <> ' ')) );
@@ -333,10 +334,8 @@ InstallMethod( ViewObj,
               "for a polynomial ring", true, [ IsPolynomialRing ],
               # override the higher ranking FLMLOR method
               RankFilter(IsFLMLOR),
+    DelegateFromViewObjToViewString );
 
-  function( R )
-    Print(ViewString(R));
-  end );
 
 #############################################################################
 ##

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -247,21 +247,29 @@ end );
 
 #############################################################################
 ##
+#M  ViewString( <gf2vec> )  . . . . . . . . . . . . . . . .  for a GF2 vector
+##
+InstallMethod( ViewString,
+    "for GF2 vector",
+    [ IsRowVector and IsFinite and IsGF2VectorRep ],
+    function( vec )
+      if IsMutable(vec)  then
+        return STRINGIFY( "<a GF2 vector of length ", Length( vec ), ">" );
+      else
+        return STRINGIFY( "<an immutable GF2 vector of length ",
+                   Length( vec ), ">" );
+      fi;
+    end );
+
+
+#############################################################################
+##
 #M  ViewObj( <gf2vec> ) . . . . . . . . . . . . . . . . . . view a GF2 vector
 ##
 InstallMethod( ViewObj,
     "for GF2 vector",
-    true,
     [ IsRowVector and IsFinite and IsGF2VectorRep ],
-    0,
-
-function( vec )
-    if IsMutable(vec)  then
-        Print( "<a GF2 vector of length ", Length(vec), ">" );
-    else
-        Print( "<an immutable GF2 vector of length ", Length(vec), ">" );
-    fi;
-end );
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################
@@ -695,30 +703,37 @@ end );
 
 #############################################################################
 ##
+#M  ViewString( <gf2mat> )  . . . . . . . . . . . . . . . .  for a GF2 matrix
+##
+InstallMethod( ViewString,
+    "for GF2 matrix",
+    [ IsMatrix and IsFinite and IsGF2MatrixRep ],
+    function( mat )
+    if Length( mat ) = 0 then
+      if IsMutable( mat ) then
+        return "<a 0x0 matrix over GF2>";
+      else
+        return "<an immutable 0x0 matrix over GF2>";
+      fi;
+    elif IsMutable( mat ) then
+      return STRINGIFY( "<a ", Length( mat ), "x", Length( mat[1] ),
+                 " matrix over GF2>" );
+    else
+      return STRINGIFY( "<an immutable ", Length( mat ), "x",
+                 Length( mat[1] ), " matrix over GF2>" );
+    fi;
+    end );
+
+
+#############################################################################
+##
 #M  ViewObj( <gf2mat> )   . . . . . . . . . . . . . . . .   view a GF2 matrix
 ##
 InstallMethod( ViewObj,
     "for GF2 matrix",
-    true,
     [ IsMatrix and IsFinite and IsGF2MatrixRep ],
-    0,
+    DelegateFromViewObjToViewString );
 
-function( mat )
-    if Length(mat) = 0  then
-        if IsMutable(mat)  then
-            Print( "<a 0x0 matrix over GF2>" );
-        else
-            Print( "<an immutable 0x0 matrix over GF2>" );
-        fi;
-    else
-        if IsMutable(mat)  then
-            Print("<a ",Length(mat),"x",Length(mat[1])," matrix over GF2>");
-        else
-            Print( "<an immutable ", Length(mat), "x", Length(mat[1]),
-                   " matrix over GF2>" );
-        fi;
-    fi;
-end );
 
 #############################################################################
 ##

--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -1865,6 +1865,40 @@ InstallMethod( IsSubset,
 
 #############################################################################
 ##
+#M  ViewString( <A> ) . . . . . . . . . . . . . . . . . . . . .  for a FLMLOR
+##
+##  show left acting domain, if known also dimension or no. of generators
+##
+InstallMethod( ViewString,
+    "for a FLMLOR",
+    [ IsFLMLOR ],
+    function( A )
+    return STRINGIFY( "<free left module over ",
+                      ViewString( LeftActingDomain( A ) ), ", and ring>" );
+    end );
+
+InstallMethod( ViewString,
+    "for a FLMLOR with known dimension",
+    [ IsFLMLOR and HasDimension ], 1,   # override method requiring gens.
+    function( A )
+    return STRINGIFY( "<free left module of dimension ", Dimension( A ),
+               " over ", ViewString( LeftActingDomain( A ) ),
+               ", and ring>" );
+    end );
+
+InstallMethod( ViewString,
+    "for a FLMLOR with known generators",
+    [ IsFLMLOR and HasGeneratorsOfAlgebra ],
+    function( A )
+    return STRINGIFY( "<free left module over ",
+               ViewString( LeftActingDomain( A ) ),
+               ", and ring, with ",
+               Length( GeneratorsOfFLMLOR( A ) ), " generators>" );
+    end );
+
+
+#############################################################################
+##
 #M  ViewObj( <A> )  . . . . . . . . . . . . . . . . . . . . . . view a FLMLOR
 ##
 ##  print left acting domain, if known also dimension or no. of generators
@@ -1872,26 +1906,7 @@ InstallMethod( IsSubset,
 InstallMethod( ViewObj,
     "for a FLMLOR",
     [ IsFLMLOR ],
-    function( A )
-    Print( "<free left module over ", LeftActingDomain( A ), ", and ring>" );
-    end );
-
-InstallMethod( ViewObj,
-    "for a FLMLOR with known dimension",
-    [ IsFLMLOR and HasDimension ], 1,   # override method requiring gens.
-    function( A )
-    Print( "<free left module of dimension ", Dimension( A ),
-           " over ", LeftActingDomain( A ), ", and ring>" );
-    end );
-
-InstallMethod( ViewObj,
-    "for a FLMLOR with known generators",
-    [ IsFLMLOR and HasGeneratorsOfAlgebra ],
-    function( A )
-    Print( "<free left module over ", LeftActingDomain( A ),
-           ", and ring, with ",
-           Length( GeneratorsOfFLMLOR( A ) ), " generators>" );
-    end );
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################
@@ -1920,6 +1935,41 @@ InstallMethod( PrintObj,
 
 #############################################################################
 ##
+#M  ViewString( <A> ) . . . . . . . . . . . . . . . . . for a FLMLOR-with-one
+##
+##  show left acting domain, if known also dimension or no. of generators
+##
+InstallMethod( ViewString,
+    "for a FLMLOR-with-one",
+    [ IsFLMLORWithOne ],
+    function( A )
+    return STRINGIFY( "<free left module over ",
+               ViewString( LeftActingDomain( A ) ),
+               ", and ring-with-one>" );
+    end );
+
+InstallMethod( ViewString,
+    "for a FLMLOR-with-one with known dimension",
+    [ IsFLMLORWithOne and HasDimension ], 1,   # override method requ. gens.
+    function( A )
+    return STRINGIFY( "<free left module of dimension ", Dimension( A ),
+               " over ", ViewString( LeftActingDomain( A ) ),
+               ", and ring-with-one>" );
+    end );
+
+InstallMethod( ViewString,
+    "for a FLMLOR-with-one with known generators",
+    [ IsFLMLORWithOne and HasGeneratorsOfFLMLORWithOne ],
+    function( A )
+    return STRINGIFY( "<free left module over ",
+               ViewString( LeftActingDomain( A ) ),
+               ", and ring-with-one, with ",
+               Length( GeneratorsOfAlgebraWithOne( A ) ), " generators>" );
+    end );
+
+
+#############################################################################
+##
 #M  ViewObj( <A> )  . . . . . . . . . . . . . . . . .  view a FLMLOR-with-one
 ##
 ##  print left acting domain, if known also dimension or no. of generators
@@ -1927,28 +1977,7 @@ InstallMethod( PrintObj,
 InstallMethod( ViewObj,
     "for a FLMLOR-with-one",
     [ IsFLMLORWithOne ],
-    function( A )
-    Print( "<free left module over ", LeftActingDomain( A ),
-           ", and ring-with-one>" );
-    end );
-
-InstallMethod( ViewObj,
-    "for a FLMLOR-with-one with known dimension",
-    [ IsFLMLORWithOne and HasDimension ], 1,   # override method requ. gens.
-    function( A )
-    Print( "<free left module of dimension ", Dimension( A ),
-           " over ", LeftActingDomain( A ), ", and ring-with-one>" );
-    end );
-
-InstallMethod( ViewObj,
-    "for a FLMLOR-with-one with known generators",
-    [ IsFLMLORWithOne and HasGeneratorsOfFLMLORWithOne ],
-    function( A )
-    Print( "<free left module over ", LeftActingDomain( A ),
-           ", and ring-with-one, with ",
-           Length( GeneratorsOfAlgebraWithOne( A ) ), " generators>" );
-
-    end );
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################
@@ -1978,6 +2007,38 @@ InstallMethod( PrintObj,
 
 #############################################################################
 ##
+#M  ViewString( <A> ) . . . . . . . . . . . . . . . . . . . .  for an algebra
+##
+##  show left acting domain, if known also dimension or no. of generators
+##
+InstallMethod( ViewString,
+    "for an algebra",
+    [ IsAlgebra ],
+    function( A )
+    return STRINGIFY( "<algebra over ",
+               ViewString( LeftActingDomain( A ) ), ">" );
+    end );
+
+InstallMethod( ViewString,
+    "for an algebra with known dimension",
+    [ IsAlgebra and HasDimension ], 1,   # override method requiring gens.
+    function( A )
+    return STRINGIFY( "<algebra of dimension ", Dimension( A ),
+           " over ", ViewString( LeftActingDomain( A ) ), ">" );
+    end );
+
+InstallMethod( ViewString,
+    "for an algebra with known generators",
+    [ IsAlgebra and HasGeneratorsOfAlgebra ],
+    function( A )
+    return STRINGIFY( "<algebra over ", ViewString( LeftActingDomain( A ) ),
+               ", with ", Length( GeneratorsOfAlgebra( A ) ),
+               " generators>" );
+    end );
+
+
+#############################################################################
+##
 #M  ViewObj( <A> )  . . . . . . . . . . . . . . . . . . . . . view an algebra
 ##
 ##  print left acting domain, if known also dimension or no. of generators
@@ -1985,25 +2046,7 @@ InstallMethod( PrintObj,
 InstallMethod( ViewObj,
     "for an algebra",
     [ IsAlgebra ],
-    function( A )
-    Print( "<algebra over ", LeftActingDomain( A ), ">" );
-    end );
-
-InstallMethod( ViewObj,
-    "for an algebra with known dimension",
-    [ IsAlgebra and HasDimension ], 1,   # override method requiring gens.
-    function( A )
-    Print( "<algebra of dimension ", Dimension( A ),
-           " over ", LeftActingDomain( A ), ">" );
-    end );
-
-InstallMethod( ViewObj,
-    "for an algebra with known generators",
-    [ IsAlgebra and HasGeneratorsOfAlgebra ],
-    function( A )
-    Print( "<algebra over ", LeftActingDomain( A ), ", with ",
-           Length( GeneratorsOfAlgebra( A ) ), " generators>" );
-    end );
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################
@@ -2032,34 +2075,50 @@ InstallMethod( PrintObj,
 
 #############################################################################
 ##
+#M  ViewString( <A> ) . . . . . . . . . . . . . . . . for an algebra-with-one
+##
+##  show left acting domain, if known also dimension or no. of generators
+##
+InstallMethod( ViewString,
+    "for an algebra-with-one",
+    [ IsAlgebraWithOne ],
+    function( A )
+    if IsIdenticalObj( A, LeftActingDomain( A ) ) then
+      return "<algebra-with-one over itself>";
+    else
+      return STRINGIFY( "<algebra-with-one over ",
+                 ViewString( LeftActingDomain( A ) ), ">" );
+    fi;
+    end );
+
+InstallMethod( ViewString,
+    "for an algebra-with-one with known dimension",
+    [ IsAlgebraWithOne and HasDimension ], 1,   # override method requ. gens.
+    function( A )
+    return STRINGIFY( "<algebra-with-one of dimension ", Dimension( A ),
+               " over ", ViewString( LeftActingDomain( A ) ), ">" );
+    end );
+
+InstallMethod( ViewString,
+    "for an algebra-with-one with known generators",
+    [ IsAlgebraWithOne and HasGeneratorsOfAlgebraWithOne ],
+    function( A )
+    return STRINGIFY( "<algebra-with-one over ",
+               ViewString( LeftActingDomain( A ) ), ", with ",
+               Length( GeneratorsOfAlgebraWithOne( A ) ), " generators>" );
+    end );
+
+
+#############################################################################
+##
 #M  ViewObj( <A> )  . . . . . . . . . . . . . . . .  view an algebra-with-one
 ##
 ##  print left acting domain, if known also dimension or no. of generators
 ##
-InstallMethod( ViewObj, "for an algebra-with-one", [ IsAlgebraWithOne ],
-function( A )
-  if IsIdenticalObj(A,LeftActingDomain(A)) then
-    Print( "<algebra-with-one over itself>" );
-  else
-    Print( "<algebra-with-one over ", LeftActingDomain( A ), ">" );
-  fi;
-end );
-
 InstallMethod( ViewObj,
-    "for an algebra-with-one with known dimension",
-    [ IsAlgebraWithOne and HasDimension ], 1,   # override method requ. gens.
-    function( A )
-    Print( "<algebra-with-one of dimension ", Dimension( A ),
-           " over ", LeftActingDomain( A ), ">" );
-    end );
-
-InstallMethod( ViewObj,
-    "for an algebra-with-one with known generators",
-    [ IsAlgebraWithOne and HasGeneratorsOfAlgebraWithOne ],
-    function( A )
-    Print( "<algebra-with-one over ", LeftActingDomain( A ), ", with ",
-           Length( GeneratorsOfAlgebraWithOne( A ) ), " generators>" );
-    end );
+    "for an algebra-with-one",
+    [ IsAlgebraWithOne ],
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################
@@ -2089,32 +2148,46 @@ InstallMethod( PrintObj,
 
 #############################################################################
 ##
-#M  ViewObj( <A> )  . . . . . . . . . . . . . . . . . . view a Lie algebra
+#M  ViewString( <A> ) . . . . . . . . . . . . . . . . . . . for a Lie algebra
+##
+##  show left acting domain, if known also dimension or no. of generators
+##
+InstallMethod( ViewString,
+    "for a Lie algebra",
+    [ IsLieAlgebra ],
+    function( A )
+    return STRINGIFY( "<Lie algebra over ",
+               ViewString( LeftActingDomain( A ) ), ">" );
+    end );
+
+InstallMethod( ViewString,
+    "for a Lie algebra with known dimension",
+    [ IsLieAlgebra and HasDimension ], 1,       # override method requ. gens.
+    function( A )
+    return STRINGIFY( "<Lie algebra of dimension ", Dimension( A ),
+               " over ", ViewString( LeftActingDomain( A ) ), ">" );
+    end );
+
+InstallMethod( ViewString,
+    "for a Lie algebra with known generators",
+    [ IsLieAlgebra and HasGeneratorsOfAlgebra ],
+    function( A )
+    return STRINGIFY( "<Lie algebra over ",
+               ViewString( LeftActingDomain( A ) ), ", with ",
+               Length( GeneratorsOfAlgebra( A ) ), " generators>" );
+end );
+
+
+#############################################################################
+##
+#M  ViewObj( <A> )  . . . . . . . . . . . . . . . . . . .  view a Lie algebra
 ##
 ##  print left acting domain, if known also dimension or no. of generators
 ##
 InstallMethod( ViewObj,
     "for a Lie algebra",
     [ IsLieAlgebra ],
-    function( A )
-    Print( "<Lie algebra over ", LeftActingDomain( A ), ">" );
-    end );
-
-InstallMethod( ViewObj,
-    "for a Lie algebra with known dimension",
-    [ IsLieAlgebra and HasDimension ], 1,       # override method requ. gens.
-    function( A )
-    Print( "<Lie algebra of dimension ", Dimension( A ),
-           " over ", LeftActingDomain( A ), ">" );
-    end );
-
-InstallMethod( ViewObj,
-    "for a Lie algebra with known generators",
-    [ IsLieAlgebra and HasGeneratorsOfAlgebra ],
-    function( A )
-    Print( "<Lie algebra over ", LeftActingDomain( A ), ", with ",
-           Length( GeneratorsOfAlgebra( A ) ), " generators>" );
-end );
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################

--- a/lib/algrep.gi
+++ b/lib/algrep.gi
@@ -13,8 +13,8 @@
 
 #############################################################################
 ##
-#M  PrintObj( <obj> ) . . . . . . . . . . . . . . . . for an algebra module
-#M  ViewObj( <obj> ) . . . . . . . . . . . . . . . .  for an algebra module
+#M  PrintObj( <obj> ) . . . . . . . . . . . . . . . . . for an algebra module
+#M  ViewString( <A> ) . . . . . . . . . . . . . . . . . for an algebra module
 ##
 InstallMethod( PrintObj,
     "for algebra module",
@@ -46,35 +46,44 @@ InstallMethod( PrintObj,
 
   end );
 
-  InstallMethod( ViewObj,
+InstallMethod( ViewString,
     "for algebra module",
-    true, [ IsVectorSpace and IsAlgebraModule ], 0,
+    [ IsVectorSpace and IsAlgebraModule ],
     function( V )
+    local str;
 
-      if HasDimension( V ) then
-         Print("<", Dimension(V), "-dimensional " );
-      else
-         Print( "<" );
-      fi;
-      if IsLeftAlgebraModuleElementCollection( V ) then
-          if IsRightAlgebraModuleElementCollection( V ) then
-              Print("bi-module over ");
-              View( LeftActingAlgebra( V ) );
-              Print( " (left) and " );
-              View( RightActingAlgebra( V ) );
-              Print( " (right)>" );
-          else
-              Print("left-module over ");
-              View( LeftActingAlgebra( V ) );
-              Print(">");
-          fi;
-      else
-          Print("right-module over ");
-          View( RightActingAlgebra( V ) );
-          Print(">");
-      fi;
+    str:= "<";
+    if HasDimension( V ) then
+      str:= STRINGIFY( str, Dimension( V ), "-dimensional " );
+    fi;
 
-end );
+    if IsLeftAlgebraModuleElementCollection( V ) then
+      if IsRightAlgebraModuleElementCollection( V ) then
+        return STRINGIFY( str, "bi-module over ",
+                          ViewString( LeftActingAlgebra( V ) ),
+                          " (left) and ",
+                          ViewString( RightActingAlgebra( V ) ),
+                          " (right)>" );
+      else
+        return STRINGIFY( str, "left-module over ",
+                          ViewString( LeftActingAlgebra( V ) ), ">" );
+      fi;
+    else
+      return STRINGIFY( str, "right-module over ",
+                        ViewString( RightActingAlgebra( V ) ), ">" );
+    fi;
+    end );
+
+
+#############################################################################
+##
+#M  ViewObj( <A> )  . . . . . . . . . . . . . . . . .  view an algebra module
+##
+InstallMethod( ViewObj,
+    "for algebra module",
+    [ IsVectorSpace and IsAlgebraModule ],
+    DelegateFromViewObjToViewString );
+
 
 ############################################################################
 ##

--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -625,9 +625,7 @@ function(d)
 end);
 
 InstallMethod(ViewObj,"RightCoset",true,[IsRightCoset],0,
-function(d)
-  Print(ViewString(d));
-end);
+    DelegateFromViewObjToViewString );
 
 InstallMethodWithRandomSource(Random,
   "for a random source and a RightCoset",

--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -4418,32 +4418,9 @@ end );
 #M  ViewObj( <tbl> )  . . . . . . . . . . . . . . . . . for a character table
 ##
 InstallMethod( ViewObj,
-    "for an ordinary table",
-    [ IsOrdinaryTable ],
-    function( tbl )
-    Print( "CharacterTable( " );
-    if HasUnderlyingGroup( tbl ) then
-      View( UnderlyingGroup( tbl ) );
-    else
-      View( Identifier( tbl ) );
-    fi;
-    Print(  " )" );
-    end );
-
-InstallMethod( ViewObj,
-    "for a Brauer table",
-    [ IsBrauerTable ],
-    function( tbl )
-    local ordtbl;
-    ordtbl:= OrdinaryCharacterTable( tbl );
-    Print( "BrauerTable( " );
-    if HasUnderlyingGroup( ordtbl ) then
-      View( UnderlyingGroup( ordtbl ) );
-    else
-      View( Identifier( ordtbl ) );
-    fi;
-    Print( ", ", UnderlyingCharacteristic( tbl ), " )" );
-    end );
+    "for a character table",
+    [ IsCharacterTable ],
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################

--- a/lib/ffe.gi
+++ b/lib/ffe.gi
@@ -654,10 +654,10 @@ InstallMethod( String, "for a field of FFEs",
 InstallMethod( ViewString, "for a field of FFEs",
         [ IsField and IsFFECollection ], 10, GAPInfo.tmpGFstring );
 Unbind(GAPInfo.tmpGFstring);
+
 InstallMethod( ViewObj, "for a field of FFEs",
-        [ IsField and IsFFECollection ], 10, function( F )
-    Print( ViewString(F) );
-end );
+    [ IsField and IsFFECollection ], 10,
+    DelegateFromViewObjToViewString );
 
 InstallMethod( PrintObj, "for a field of FFEs",
         [ IsField and IsFFECollection ], 10, function( F )

--- a/lib/ffeconway.gi
+++ b/lib/ffeconway.gi
@@ -300,9 +300,8 @@ end);
 
 InstallMethod(ViewObj, "For large finite field elements",
         [IsFFE and IsCoeffsModConwayPolRep], 
-        function(x)
-    Print(ViewString(x));
-end);
+    DelegateFromViewObjToViewString );
+
 
 #############################################################################
 ##

--- a/lib/fldabnum.gi
+++ b/lib/fldabnum.gi
@@ -267,32 +267,42 @@ end );
 
 #############################################################################
 ##
+#M  ViewString( <F> ) . . . . . . . . . . . . . . for an abelian number field
+##
+InstallMethod( ViewString,
+    "for abelian number field of cyclotomics",
+    [ IsAbelianNumberField and IsCyclotomicCollection ],
+    function( F )
+    if IsPrimeField( LeftActingDomain( F ) ) then
+      return STRINGIFY( "NF(", Conductor( F ), ",",
+                 GaloisStabilizer( F ), ")" );
+    else
+      return STRINGIFY( "AsField( ", ViewString( LeftActingDomain( F ) ),
+                 ", NF(", Conductor( F ), ",", GaloisStabilizer( F ), ") )" );
+    fi;
+    end );
+
+InstallMethod( ViewString,
+    "for cyclotomic field of cyclotomics",
+    [ IsCyclotomicField and IsCyclotomicCollection ],
+    function( F )
+    if IsPrimeField( LeftActingDomain( F ) ) then
+      return STRINGIFY( "CF(", Conductor( F ), ")" );
+    else
+      return STRINGIFY( "AsField( ", ViewString( LeftActingDomain( F ) ),
+                 ", CF(", Conductor( F ), ") )" );
+    fi;
+    end );
+
+
+#############################################################################
+##
 #M  ViewObj( <F> )  . . . . . . . . . . . . . .  view an abelian number field
 ##
 InstallMethod( ViewObj,
     "for abelian number field of cyclotomics",
     [ IsAbelianNumberField and IsCyclotomicCollection ],
-    function( F )
-    if IsPrimeField( LeftActingDomain( F ) ) then
-      Print( "NF(", Conductor( F ), ",",
-              GaloisStabilizer( F ), ")" );
-    else
-      Print( "AsField( ", LeftActingDomain( F ),
-             ", NF(", Conductor( F ), ",", GaloisStabilizer( F ), ") )" );
-    fi;
-    end );
-
-InstallMethod( ViewObj,
-    "for cyclotomic field of cyclotomics",
-    [ IsCyclotomicField and IsCyclotomicCollection ],
-    function( F )
-    if IsPrimeField( LeftActingDomain( F ) ) then
-      Print( "CF(", Conductor( F ), ")" );
-    else
-      Print( "AsField( ", LeftActingDomain( F ),
-             ", CF(", Conductor( F ), ") )" );
-    fi;
-    end );
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################

--- a/lib/float.gi
+++ b/lib/float.gi
@@ -455,9 +455,7 @@ InstallMethod( ObjByExtRep, "for floats", [ IsFloatFamily, IsCyclotomicCollectio
 end);
 
 InstallMethod( ViewObj, "for floats", [ IsFloat ],
-        function ( x )
-    Print(ViewString(x));
-end);
+    DelegateFromViewObjToViewString );
 
 InstallMethod( Display, "for floats", [ IsFloat ],
         function ( x )

--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -1812,19 +1812,14 @@ end );
 
 InstallMethod( ViewObj,
     "for natural alternating group",
-    true,
-    [ IsNaturalAlternatingGroup ], 0,
-function(alt)
-    Print(ViewString(alt));
-end );
+    [ IsNaturalAlternatingGroup ],
+    DelegateFromViewObjToViewString );
 
 InstallMethod( ViewObj,
     "for natural symmetric group",
-    true,
-    [ IsNaturalSymmetricGroup ], 0,
-function(sym)
-    Print(ViewString(sym));
-end );
+    [ IsNaturalSymmetricGroup ],
+    DelegateFromViewObjToViewString );
+
 
 #############################################################################
 ##

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -4305,9 +4305,8 @@ InstallMethod( ViewString,
 
 InstallMethod( ViewObj, "for a group",
     [ IsGroup ],
-        function(G)
-    Print(ViewString(G));
-end);   
+    DelegateFromViewObjToViewString );
+
 
 #############################################################################
 ##

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -5059,42 +5059,60 @@ local iso,k,id,f;
 	       ReducedForm(k,GroupwordToMonword(id,w)));
 end);
 
+
 #############################################################################
 ##
-#M  ViewObj(<G>)
+#M  ViewString( <G> )
 ##
-InstallMethod(ViewObj,"fp group",true,[IsSubgroupFpGroup],
- 10,# to override the pure `Size' method
-function(G)
-  if IsFreeGroup(G) then TryNextMethod();fi;
-  if IsGroupOfFamily(G) then
-    Print("<fp group");
-    if HasSize(G) then
-      Print(" of size ",Size(G));
-    fi;
-    if Length(GeneratorsOfGroup(G)) > GAPInfo.ViewLength * 10 then
-      Print(" with ",Length(GeneratorsOfGroup(G))," generators>");
-    else
-      Print(" on the generators ",GeneratorsOfGroup(G),">");
-    fi;
-  else
-    Print("Group(");
-    if HasGeneratorsOfGroup(G) then
-      if not IsBound(G!.gensWordLengthSum) then
-	G!.gensWordLengthSum:=Sum(List(GeneratorsOfGroup(G),
-	         i->Length(UnderlyingElement(i))));
+InstallMethod( ViewString,
+    "fp group",
+    [ IsSubgroupFpGroup ],
+    10,  # to override the pure `Size' method
+    function( G )
+    local str;
+
+    if IsFreeGroup( G ) then
+      TryNextMethod();
+    elif IsGroupOfFamily( G ) then
+      str:= "<fp group";
+      if HasSize( G ) then
+        str:= STRINGIFY( str, " of size ", Size( G ) );
+      fi;
+      if Length( GeneratorsOfGroup( G ) ) > GAPInfo.ViewLength * 10 then
+        return STRINGIFY( str, " with ", Length( GeneratorsOfGroup( G ) ),
+                          " generators>" );
+      else
+        return STRINGIFY( str, " on the generators ",
+                          ViewString( GeneratorsOfGroup( G ) ), ">" );
+      fi;
+    elif HasGeneratorsOfGroup( G ) then
+      if not IsBound( G!.gensWordLengthSum ) then
+        G!.gensWordLengthSum:= Sum( List( GeneratorsOfGroup( G ),
+            i -> Length( UnderlyingElement( i ) ) ) );
       fi;
       if G!.gensWordLengthSum <= GAPInfo.ViewLength * 30 then
-        Print(GeneratorsOfGroup(G));
+        return STRINGIFY( "Group(", ViewString( GeneratorsOfGroup( G ) ),
+                          ")" );
       else
-        Print("<",Length(GeneratorsOfGroup(G))," generators>");
+        return STRINGIFY( "Group(<", Length( GeneratorsOfGroup( G ) ),
+                          " generators>)" );
       fi;
     else
-      Print("<fp, no generators known>");
+      return "Group(<fp, no generators known>)";
     fi;
-    Print(")");
-  fi;
-end);
+    end );
+
+
+#############################################################################
+##
+#M  ViewObj( <G> )  . . . . . . . . . . . . . . . . . . .  view an f.p. group
+##
+InstallMethod( ViewObj,
+    "fp group",
+    [ IsSubgroupFpGroup ],
+    10,  # to override the pure `Size' method
+    DelegateFromViewObjToViewString );
+
 
 #############################################################################
 ##

--- a/lib/grpfree.gi
+++ b/lib/grpfree.gi
@@ -570,35 +570,45 @@ InstallOtherMethod( ElementOfFpGroup,
 
 #############################################################################
 ##
-#M  ViewObj(<G>)
+#M  ViewString( <G> )
+##
+InstallMethod( ViewString,
+    "subgroup of free group",
+    [ IsFreeGroup ],
+    function(G)
+    if IsGroupOfFamily( G ) then
+      if Length( GeneratorsOfGroup( G ) ) > GAPInfo.ViewLength * 10 then
+        return STRINGIFY( "<free group with ",
+                          Length( GeneratorsOfGroup( G ) ), " generators>" );
+      else
+        return STRINGIFY( "<free group on the generators ",
+                          ViewString( GeneratorsOfGroup( G ) ), ">" );
+      fi;
+    elif HasGeneratorsOfGroup( G ) then
+      if not IsBound( G!.gensWordLengthSum ) then
+	G!.gensWordLengthSum:= Sum( List( GeneratorsOfGroup( G ), Length ) );
+      fi;
+      if G!.gensWordLengthSum <= GAPInfo.ViewLength * 30 then
+        return STRINGIFY( "Group(", ViewString( GeneratorsOfGroup( G ) ),
+                          ")" );
+      else
+        return STRINGIFY( "Group(<", Length( GeneratorsOfGroup( G ) ),
+                          " generators>)" );
+      fi;
+    else
+      return STRINGIFY( "Group(<free, no generators known>)" );
+    fi;
+    end);
+
+
+#############################################################################
+##
+#M  ViewObj( <G> )  . . . . . . . . . . . . . . . . . . . . view a free group
 ##
 InstallMethod( ViewObj,
     "subgroup of free group",
     [ IsFreeGroup ],
-function(G)
-  if IsGroupOfFamily(G) then
-    if Length(GeneratorsOfGroup(G)) > GAPInfo.ViewLength * 10 then
-      Print("<free group with ",Length(GeneratorsOfGroup(G))," generators>");
-    else
-      Print("<free group on the generators ",GeneratorsOfGroup(G),">");
-    fi;
-  else
-    Print("Group(");
-    if HasGeneratorsOfGroup(G) then
-      if not IsBound(G!.gensWordLengthSum) then
-	G!.gensWordLengthSum:=Sum(List(GeneratorsOfGroup(G),Length));
-      fi;
-      if G!.gensWordLengthSum <= GAPInfo.ViewLength * 30 then
-        Print(GeneratorsOfGroup(G));
-      else
-        Print("<",Length(GeneratorsOfGroup(G))," generators>");
-      fi;
-    else
-      Print("<free, no generators known>");
-    fi;
-    Print(")");
-  fi;
-end);
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################

--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -665,30 +665,57 @@ local mon,dom,S,o,oimgs,p,i,g;
   return e;
 end);
 
+
 #############################################################################
 ##
-#M  ViewObj( <matgrp> )
+#M  ViewString( <matgrp> )
 ##
-InstallMethod( ViewObj,
+InstallMethod( ViewString,
     "for a matrix group with stored generators",
     [ IsMatrixGroup and HasGeneratorsOfGroup ],
-function(G)
-local gens;
-  gens:=GeneratorsOfGroup(G);
-  if Length(gens)>0 and Length(gens)*
-                        Length(gens[1])^2 / GAPInfo.ViewLength > 8 then
-    Print("<matrix group");
-    if HasSize(G) then
-      Print(" of size ",Size(G));
+    function( G )
+    local gens;
+
+    gens:= GeneratorsOfGroup( G );
+    if Length( gens ) > 0 and
+       Length( gens ) * Length( gens[1] )^2 <= 8 * GAPInfo.ViewLength then
+      return STRINGIFY( "Group(", ViewString( gens ), ")" );
+    elif HasSize( G ) then
+      return STRINGIFY( "<matrix group of size ", Size( G ),
+                 " with ", Length( gens ), " generators>" );
+    else
+      return STRINGIFY( "<matrix group with ", Length( gens ),
+                 " generators>" );
     fi;
-    Print(" with ",Length(GeneratorsOfGroup(G)),
-          " generators>");
-  else
-    Print("Group(");
-    ViewObj(GeneratorsOfGroup(G));
-    Print(")");
-  fi;
-end);
+    end );
+
+
+#############################################################################
+##
+#M  ViewString( <matgrp> )
+##
+InstallMethod( ViewString,"for a matrix group",
+    [ IsMatrixGroup ],
+    function( G )
+    local d, str;
+
+    d:= String( DimensionOfMatrixGroup( G ) );
+    str:= STRINGIFY( "<group of ", d, "x", d, " matrices" );
+    if HasSize( G ) then
+      str:= STRINGIFY( str, " of size ", Size( G ) );
+    fi;
+    if HasFieldOfMatrixGroup( G ) then
+      return STRINGIFY( str, " over ",
+                 ViewString( FieldOfMatrixGroup( G ) ), ">" );
+    elif HasDefaultFieldOfMatrixGroup( G ) then
+      return STRINGIFY( str, " over ",
+                 ViewString( DefaultFieldOfMatrixGroup( G ) ), ">" );
+    else
+      return STRINGIFY( str, " in characteristic ",
+                 Characteristic( One( G ) ), ">" );
+    fi;
+    end );
+
 
 #############################################################################
 ##
@@ -696,21 +723,8 @@ end);
 ##
 InstallMethod( ViewObj,"for a matrix group",
     [ IsMatrixGroup ],
-function(G)
-local d;
-  d:=DimensionOfMatrixGroup(G);
-  Print("<group of ",d,"x",d," matrices");
-  if HasSize(G) then
-    Print(" of size ",Size(G));
-  fi;
-  if HasFieldOfMatrixGroup(G) then
-    Print(" over ",FieldOfMatrixGroup(G),">");
-  elif HasDefaultFieldOfMatrixGroup(G) then
-    Print(" over ",DefaultFieldOfMatrixGroup(G),">");
-  else
-    Print(" in characteristic ",Characteristic(One(G)),">");
-  fi;
-end);
+    DelegateFromViewObjToViewString );
+
 
 #############################################################################
 ##

--- a/lib/grppc.gi
+++ b/lib/grppc.gi
@@ -2227,27 +2227,37 @@ function(G)
   return IsInt(Size(G)) and IsPrimeInt(Size(G));
 end);
 
+
+#############################################################################
+##
+#M  ViewString( <G> )
+##
+InstallMethod( ViewString,
+    "pc group",
+    [ IsPcGroup ],
+    function( G )
+    if HasParent( G ) and
+       Length( GeneratorsOfGroup( G ) )
+       * Length( GeneratorsOfGroup( Parent( G ) ) )
+       <= 50 * GAPInfo.ViewLength then
+      return STRINGIFY( "Group(", ViewString( GeneratorsOfGroup( G ) ), ")" );
+    elif HasSize( G ) then
+      return STRINGIFY( "<pc group of size ", Size( G ), " with ",
+                 Length( GeneratorsOfGroup( G ) ), " generators>" );
+    else
+      return STRINGIFY( "<pc group with ",
+                 Length( GeneratorsOfGroup( G ) ), " generators>" );
+    fi;
+    end);
+
+
 #############################################################################
 ##
 #M  ViewObj(<G>)
 ##
 InstallMethod(ViewObj,"pc group",true,[IsPcGroup],0,
-function(G)
-  if (not HasParent(G)) or
-   Length(GeneratorsOfGroup(G))*Length(GeneratorsOfGroup(Parent(G)))
-     / GAPInfo.ViewLength > 50 then
-    Print("<pc group");
-    if HasSize(G) then
-      Print(" of size ",Size(G));
-    fi;
-    Print(" with ",Length(GeneratorsOfGroup(G)),
-          " generators>");
-  else
-    Print("Group(");
-    ViewObj(GeneratorsOfGroup(G));
-    Print(")");
-  fi;
-end);
+    DelegateFromViewObjToViewString );
+
 
 #############################################################################
 ##

--- a/lib/ideal.gi
+++ b/lib/ideal.gi
@@ -342,56 +342,86 @@ InstallMethod( PrintObj,
 
 #############################################################################
 ##
-#M  ViewObj( <I> )  . . . . . . . . . . . . . . . . . . . . . .  for an ideal
+#M  ViewString( <I> ) . . . . . . . . . . . . . . . . . . . . .  for an ideal
 ##
-InstallMethod( ViewObj,
+InstallMethod( ViewString,
     "for a left ideal with known generators",
-    true,
     [ IsRing and HasLeftActingRingOfIdeal and HasGeneratorsOfLeftIdeal ],
     100,  # stronger than methods for the different kinds of algebras
     function( I )
-    Print( "\>\><left ideal in \>\>" );
-    View( LeftActingRingOfIdeal( I ) );
     if HasDimension( I ) then
-      Print( "\<,\< \>\>(dimension ", Dimension( I ), "\<\<\<\<)>" );
+      return STRINGIFY( "\>\><left ideal in \>\>",
+                 ViewString( LeftActingRingOfIdeal( I ) ),
+                 "\<,\< \>\>(dimension ", Dimension( I ),
+                 "\<\<\<\<)>" );
     else
-      Print( "\<,\< \>\>(", Length( GeneratorsOfLeftIdeal( I ) ),
-             " generators)\<\<\<\<>" );
+      return STRINGIFY( "\>\><left ideal in \>\>",
+                 ViewString( LeftActingRingOfIdeal( I ) ),
+                 "\<,\< \>\>(", Length( GeneratorsOfLeftIdeal( I ) ),
+                 " generators)\<\<\<\<>" );
     fi;
     end );
 
-InstallMethod( ViewObj,
+InstallMethod( ViewString,
     "for a right ideal with known generators",
-    true,
     [ IsRing and HasRightActingRingOfIdeal and HasGeneratorsOfRightIdeal ],
     100,  # stronger than methods for the different kinds of algebras
     function( I )
-    Print( "\>\><right ideal in \>\>" );
-    View( RightActingRingOfIdeal( I ) );
     if HasDimension( I ) then
-      Print( "\<,\< \>\>(dimension ", Dimension( I ), "\<\<\<\<)>" );
+      return STRINGIFY( "\>\><right ideal in \>\>",
+                 ViewString( RightActingRingOfIdeal( I ) ),
+                 "\<,\< \>\>(dimension ", Dimension( I ),
+                 "\<\<\<\<)>" );
     else
-      Print( "\<,\< \>\>(", Length( GeneratorsOfRightIdeal( I ) ),
-             " generators)\<\<\<\<>" );
+      return STRINGIFY( "\>\><right ideal in \>\>",
+                 ViewString( RightActingRingOfIdeal( I ) ),
+                 "\<,\< \>\>(", Length( GeneratorsOfRightIdeal( I ) ),
+                 " generators)\<\<\<\<>" );
     fi;
     end );
 
-InstallMethod( ViewObj,
+InstallMethod( ViewString,
     "for a two-sided ideal with known generators",
-    true,
     [ IsRing and HasLeftActingRingOfIdeal and HasRightActingRingOfIdeal
              and HasGeneratorsOfTwoSidedIdeal ],
     100,  # stronger than methods for the different kinds of algebras
     function( I )
-    Print( "\>\><two-sided ideal in \>\>" );
-    View( RightActingRingOfIdeal( I ) );
     if HasDimension( I ) then
-      Print( "\<,\< \>\>(dimension ", Dimension( I ), "\<\<\<\<)>" );
+      return STRINGIFY( "\>\><two-sided ideal in \>\>",
+                 ViewString( RightActingRingOfIdeal( I ) ),
+                 "\<,\< \>\>(dimension ", Dimension( I ),
+                 "\<\<\<\<)>" );
     else
-      Print( "\<,\< \>\>(", Length( GeneratorsOfTwoSidedIdeal( I ) ),
-             " generators)\<\<\<\<>" );
+      return STRINGIFY( "\>\><two-sided ideal in \>\>",
+                 ViewString( RightActingRingOfIdeal( I ) ),
+                 "\<,\< \>\>(", Length( GeneratorsOfTwoSidedIdeal( I ) ),
+                 " generators)\<\<\<\<>" );
     fi;
     end );
+
+
+#############################################################################
+##
+#M  ViewObj( <I> )  . . . . . . . . . . . . . . . . . . . . . .  for an ideal
+##
+InstallMethod( ViewObj,
+    "for a left ideal with known generators",
+    [ IsRing and HasLeftActingRingOfIdeal and HasGeneratorsOfLeftIdeal ],
+    100,  # stronger than methods for the different kinds of algebras
+    DelegateFromViewObjToViewString );
+
+InstallMethod( ViewObj,
+    "for a right ideal with known generators",
+    [ IsRing and HasRightActingRingOfIdeal and HasGeneratorsOfRightIdeal ],
+    100,  # stronger than methods for the different kinds of algebras
+    DelegateFromViewObjToViewString );
+
+InstallMethod( ViewObj,
+    "for a two-sided ideal with known generators",
+    [ IsRing and HasLeftActingRingOfIdeal and HasRightActingRingOfIdeal
+             and HasGeneratorsOfTwoSidedIdeal ],
+    100,  # stronger than methods for the different kinds of algebras
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################

--- a/lib/modulmat.gi
+++ b/lib/modulmat.gi
@@ -217,7 +217,24 @@ InstallMethod( GeneratorsOfLeftModule,
 
 #############################################################################
 ##
-#M  ViewObj( <M> )
+#M  ViewString( <M> ) . . . . . . . . . . . . . . . . . .  full matrix module
+##
+InstallMethod( ViewString,
+    "for full matrix module",
+    [ IsFreeLeftModule and IsFullMatrixModule ],
+    function( M )
+    if IsLieObjectCollection( M ) then
+      TryNextMethod();
+    fi;
+    return STRINGIFY( "( ",
+               ViewString( LeftActingDomain( M ) ),
+               "^", DimensionOfVectors( M ), " )" );
+    end );
+
+
+#############################################################################
+##
+#M  ViewObj( <M> )  . . . . . . . . . . . . . . . . . . .  full matrix module
 ##
 InstallMethod( ViewObj,
     "for full matrix module",
@@ -226,9 +243,7 @@ InstallMethod( ViewObj,
     if IsLieObjectCollection( M ) then
       TryNextMethod();
     fi;
-    Print( "( " );
-    View( LeftActingDomain( M ) );
-    Print( "^", DimensionOfVectors( M ), " )" );
+    DelegateFromViewObjToViewString( M );
     end );
 
 

--- a/lib/object.gi
+++ b/lib/object.gi
@@ -428,6 +428,30 @@ InstallMethod( ViewObj,
 
 #############################################################################
 ##
+#F  DelegateFromViewObjToViewString( <obj> )
+##
+##  Simply replacing the 'ViewObj' method for an object by a 'ViewString'
+##  method does usually not have the intended effect,
+##  since probably a 'ViewObj' method for another (a bit more general) object
+##  would be applicable.
+##
+##  As long as lots of such 'ViewObj' methods are installed,
+##  we can install the appropriate 'ViewString' methods (which are needed
+##  for example in jupyter notebooks) and replace the in principle obsolete
+##  'ViewObj' method by 'DelegateFromViewObjToViewString'.
+##
+##  (Once it will be available in enough situations,
+##  it may make sense to call 'TryNextMethod()' inside, and to see where
+##  the bahaviour of GAP changes.)
+##
+BIND_GLOBAL( "DelegateFromViewObjToViewString",
+    function( obj )
+      Print( ViewString( obj ) );
+    end );
+
+
+#############################################################################
+##
 #M  ViewString( <obj> ) . . . . . . . . . . . . . . . for an object with name
 ##
 InstallMethod( ViewString, "for an object with name", true,

--- a/lib/ring.gi
+++ b/lib/ring.gi
@@ -55,24 +55,44 @@ InstallMethod( PrintObj,
 
 #############################################################################
 ##
+#M  ViewString( <R> ) . . . . . . . . . . . . . . . . . . . . . .  for a ring
+##
+InstallMethod( ViewString,
+    "for a ring",
+    [ IsRing ],
+    R -> "<ring>" );
+
+InstallMethod( ViewString,
+    "for a ring with known generators",
+    [ IsRing and HasGeneratorsOfRing ],
+    R -> STRINGIFY( "<ring with ", Length( GeneratorsOfRing( R ) ),
+             " generators>" ) );
+
+
+#############################################################################
+##
+#M  ViewString( <R> ) . . . . . . . . . . . . . . . . . . for a ring-with-one
+##
+InstallMethod( ViewString,
+    "for a ring-with-one",
+    [ IsRingWithOne ],
+    R -> "<ring-with-one>" );
+
+InstallMethod( ViewString,
+    "for a ring-with-one with known generators",
+    [ IsRingWithOne and HasGeneratorsOfRingWithOne ],
+    R -> STRINGIFY( "<ring-with-one, with ",
+             Length( GeneratorsOfRingWithOne( R ) ), " generators>" ) );
+
+
+#############################################################################
+##
 #M  ViewObj( <R> )  . . . . . . . . . . . . . . . . . . . . . . . view a ring
 ##
 InstallMethod( ViewObj,
     "for a ring",
-    true,
-    [ IsRing ], 0,
-    function( R )
-    Print( "<ring>" );
-    end );
-
-InstallMethod( ViewObj,
-    "for a ring with known generators",
-    true,
-    [ IsRing and HasGeneratorsOfRing ], 0,
-    function( R )
-    Print( "<ring with ", Length( GeneratorsOfRing( R ) ),
-           " generators>" );
-    end );
+    [ IsRing ],
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################
@@ -81,20 +101,8 @@ InstallMethod( ViewObj,
 ##
 InstallMethod( ViewObj,
     "for a ring-with-one",
-    true,
-    [ IsRingWithOne ], 0,
-    function( R )
-    Print( "<ring-with-one>" );
-    end );
-
-InstallMethod( ViewObj,
-    "for a ring-with-one with known generators",
-    true,
-    [ IsRingWithOne and HasGeneratorsOfRingWithOne ], 0,
-    function( R )
-    Print( "<ring-with-one, with ", Length( GeneratorsOfRingWithOne( R ) ),
-           " generators>" );
-    end );
+    [ IsRingWithOne ],
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################

--- a/lib/ringpoly.gi
+++ b/lib/ringpoly.gi
@@ -317,8 +317,9 @@ end);
 #M  ViewString( <pring> ) . . . . . . . . . . . . . . . for a polynomial ring
 ##
 InstallMethod( ViewString,
-               "for a polynomial ring", true,  [ IsPolynomialRing ], 0,
-
+    "for a polynomial ring",
+    [ IsPolynomialRing ],
+    RankFilter( IsFLMLOR ),  # override the higher ranking FLMLOR method
   R -> Concatenation(ViewString(LeftActingDomain(R)),
                      Filtered(String(IndeterminatesOfPolynomialRing(R)),
                               ch -> ch <> ' ')) );
@@ -331,10 +332,8 @@ InstallMethod( ViewObj,
               "for a polynomial ring", true, [ IsPolynomialRing ],
               # override the higher ranking FLMLOR method
               RankFilter(IsFLMLOR),
+    DelegateFromViewObjToViewString );
 
-  function( R )
-    Print(ViewString(R));
-  end );
 
 #############################################################################
 ##

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -247,21 +247,29 @@ end );
 
 #############################################################################
 ##
+#M  ViewString( <gf2vec> )  . . . . . . . . . . . . . . . .  for a GF2 vector
+##
+InstallMethod( ViewString,
+    "for GF2 vector",
+    [ IsRowVector and IsFinite and IsGF2VectorRep ],
+    function( vec )
+      if IsMutable(vec)  then
+        return STRINGIFY( "<a GF2 vector of length ", Length( vec ), ">" );
+      else
+        return STRINGIFY( "<an immutable GF2 vector of length ",
+                   Length( vec ), ">" );
+      fi;
+    end );
+
+
+#############################################################################
+##
 #M  ViewObj( <gf2vec> ) . . . . . . . . . . . . . . . . . . view a GF2 vector
 ##
 InstallMethod( ViewObj,
     "for GF2 vector",
-    true,
     [ IsRowVector and IsFinite and IsGF2VectorRep ],
-    0,
-
-function( vec )
-    if IsMutable(vec)  then
-        Print( "<a GF2 vector of length ", Length(vec), ">" );
-    else
-        Print( "<an immutable GF2 vector of length ", Length(vec), ">" );
-    fi;
-end );
+    DelegateFromViewObjToViewString );
 
 
 #############################################################################
@@ -695,30 +703,37 @@ end );
 
 #############################################################################
 ##
+#M  ViewString( <gf2mat> )  . . . . . . . . . . . . . . . .  for a GF2 matrix
+##
+InstallMethod( ViewString,
+    "for GF2 matrix",
+    [ IsMatrix and IsFinite and IsGF2MatrixRep ],
+    function( mat )
+    if Length( mat ) = 0 then
+      if IsMutable( mat ) then
+        return "<a 0x0 matrix over GF2>";
+      else
+        return "<an immutable 0x0 matrix over GF2>";
+      fi;
+    elif IsMutable( mat ) then
+      return STRINGIFY( "<a ", Length( mat ), "x", Length( mat[1] ),
+                 " matrix over GF2>" );
+    else
+      return STRINGIFY( "<an immutable ", Length( mat ), "x",
+                 Length( mat[1] ), " matrix over GF2>" );
+    fi;
+    end );
+
+
+#############################################################################
+##
 #M  ViewObj( <gf2mat> )   . . . . . . . . . . . . . . . .   view a GF2 matrix
 ##
 InstallMethod( ViewObj,
     "for GF2 matrix",
-    true,
     [ IsMatrix and IsFinite and IsGF2MatrixRep ],
-    0,
+    DelegateFromViewObjToViewString );
 
-function( mat )
-    if Length(mat) = 0  then
-        if IsMutable(mat)  then
-            Print( "<a 0x0 matrix over GF2>" );
-        else
-            Print( "<an immutable 0x0 matrix over GF2>" );
-        fi;
-    else
-        if IsMutable(mat)  then
-            Print("<a ",Length(mat),"x",Length(mat[1])," matrix over GF2>");
-        else
-            Print( "<an immutable ", Length(mat), "x", Length(mat[1]),
-                   " matrix over GF2>" );
-        fi;
-    fi;
-end );
 
 #############################################################################
 ##

--- a/tst/testbugfix/00005.tst
+++ b/tst/testbugfix/00005.tst
@@ -12,7 +12,7 @@ gap> IsFinite(N);
 false
 gap> G:=GroupByGenerators( [ [ [ 0, -1, 0, 0 ], [ 1, 0, 0, 0 ],
 >   [ 0, 0, 0, -1 ], [ 0, 0, 1, 0 ] ] ] );
-Group([ [ [ 0, -1, 0, 0 ], [ 1, 0, 0, 0 ], [ 0, 0, 0, -1 ], [ 0, 0, 1, 0 ] ] 
- ])
+Group([ [ [ 0, -1, 0, 0 ], [ 1, 0, 0, 0 ], [ 0, 0, 0, -1 ], [ 0, 0, 1,
+ 0 ] ] ])
 gap> Centralizer(N,G);
 <matrix group with 6 generators>

--- a/tst/testbugfix/2017-07-06-DoImmutableMatrix.tst
+++ b/tst/testbugfix/2017-07-06-DoImmutableMatrix.tst
@@ -1,6 +1,6 @@
 # handling of finite fields of size q <= 256 but not GF(q)
 gap> f1 := AlgebraicExtension(GF(3), CyclotomicPolynomial(GF(3), 5));
-<algebra-with-one of dimension 4 over GF(3)>
+<field of size 81>
 gap> a := RootOfDefiningPolynomial(f1);
 a
 gap> mat := [[a]];

--- a/tst/testbugfix/2018-07-04-HighestWeightModule.tst
+++ b/tst/testbugfix/2018-07-04-HighestWeightModule.tst
@@ -1,5 +1,5 @@
 gap> L := SimpleLieAlgebra("G",2,Rationals);
 <Lie algebra of dimension 14 over Rationals>
 gap> W := HighestWeightModule(L,[4,1]);
-<924-dimensional left-module over <Lie algebra of dimension 
-14 over Rationals>>
+<924-dimensional left-module over <Lie algebra of dimension 14 over Rationals>\
+>

--- a/tst/testinstall/algmat.tst
+++ b/tst/testinstall/algmat.tst
@@ -54,6 +54,8 @@ gap> Dimension( b );
 gap> c:= Algebra( CF(5), [ [ [ 1, E(5) ], [ E(5), 0 ] ] ],
 >                     [ [ 0, 0 ], [ 0, 0 ] ] );
 <algebra over CF(5), with 1 generators>
+gap> ViewString( CF(5) );
+"CF(5)"
 gap> IsGaussianMatrixSpace( c );
 true
 gap> Dimension( c );

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -48,7 +48,7 @@ CharacterTable( <pc group of size 8 with 3 generators> )
 gap> Print( t, "\n" );
 CharacterTable( Group( [ f1, f2, f3 ] ) )
 gap> ViewString( t );
-"CharacterTable( <group of size 8 with 3 generators> )"
+"CharacterTable( <pc group of size 8 with 3 generators> )"
 gap> PrintString( t );
 "CharacterTable( \"Group( \>[ f1, f2, f3 ]\<\> )\< )"
 gap> t:= CharacterTable( SymmetricGroup( 5 ) );;
@@ -67,3 +67,4 @@ gap> STOP_TEST( "ctbl.tst", 1);
 #############################################################################
 ##
 #E
+

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -134,6 +134,8 @@ Rationals
 1
 gap> G:=CyclicGroup(IsMatrixGroup, GF(2), 1);
 Group([ <an immutable 1x1 matrix over GF2> ])
+gap> ViewString( G );
+"Group([ <an immutable 1x1 matrix over GF2> ])"
 gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
 GF(2)
 1

--- a/tst/testinstall/grpmat.tst
+++ b/tst/testinstall/grpmat.tst
@@ -6,6 +6,16 @@
 #Y  Copyright (C)  1997,  Lehrstuhl D für Mathematik,  RWTH Aachen,  Germany
 ##
 gap> START_TEST("grpmat.tst");
+
+##  test 'ViewObj' for matrix groups
+gap> G:= GroupByGenerators( GeneratorsOfGroup( GL( 5, 2 ) ) );
+<matrix group with 2 generators>
+gap> Size( G );; G;
+<matrix group of size 9999360 with 2 generators>
+gap> TrivialSubgroup( G );
+<matrix group of size 1 with 0 generators>
+
+##
 gap> i := E(4);; G := Group([[i,0],[0,-i]],[[0,1],[-1,0]]);;
 gap> gens := GeneratorsOfGroup( G );; IsSSortedList( gens );
 false


### PR DESCRIPTION
The Jupyter kernel for GAP uses `ViewString` for showing outputs.
In a terminal session, `ViewObj` is used for that.
The outputs of these two operations are different,
mainly because several special `ViewObj` methods do not have
corresponding `StringObj` methods.

One way to achieve a better output in Jupyter notebooks is
to add the missing `ViewString` methods.
In order to avoid code duplication, the individual `ViewObj` methods
can then be replaced by delegations to `ViewString`.

The new global function `DelegateFromViewObjToViewString`
can be installed for these delegations.

Note:

- Simply omitting the corresponding `ViewObj` methods would not be
  appropriate.
  There is a low rank `ViewObj` method that tries `ViewString`
  (which is still ranked higher than `PrintObj`, the documented default
  of `ViewObj`, which is not what one wants here),
  but other applicable `ViewObj` methods may have higher rank.

  (Some GAP script could be used to find out where this happens,
  by checking the applicable `ViewObj` methods for individual methods
  ranked above `DelegateFromViewObjToViewString`.
  Where this does not happen, eventually the delegation could be removed.)

- Delegating from `ViewObj` to `ViewString` slows `ViewObj` down,
  already because of the additional objects that get created and later
  have to be cleaned up; but I regard `ViewObj` as not time critical.

Here is the list of changes from the current pull request:

(Originally I had wanted to add only methods for ideals,
but the recursive structure of `ViewString` made it necessary
to add more methods until the manual example tests ran without
differences.)

- added `ViewString` methods for the following structures:

  `IsAbelianNumberField and IsCyclotomicCollection`,
  `IsAlgebra`, `IsAlgebraWithOne`,
  `IsCyclotomicField and IsCyclotomicCollection`, `IsFLMLOR`,
  `IsFLMLORWithOne`, `IsLieAlgebra`, `IsMatrixGroup`,
  `IsMatrix and IsFinite and IsGF2MatrixRep`, `IsPcGroup`, `IsPolynomialRing`,
  `IsRightCoset`, `IsRing`, `IsRingWithOne`,
  `IsRing and HasLeftActingRingOfIdeal and HasGeneratorsOfLeftIdeal`,
  `IsRing and HasRightActingRingOfIdeal and HasGeneratorsOfRightIdeal`,
  `IsRing and HasLeftActingRingOfIdeal and HasRightActingRingOfIdeal and
  HasGeneratorsOfTwoSidedIdeal`,
  `IsRowVector and IsFinite and IsGF2VectorRep`

- replaced the corresponding `ViewObj` methods by the new global function
  `DelegateFromViewObjToViewString`

- replaced available `ViewObj` methods which called `ViewString`
  by `DelegateFromViewObjToViewString`:

  `IsCharacterTable`, `IsField and IsFFECollection`, `IsFloat`,
  `IsFFE and IsCoeffsModConwayPolRep`, `IsGroup`,
  `IsNaturalAlternatingGroup`, `IsNaturalSymmetricGroup`

- for matrix groups, installed a `ViewString` method
  with output different from what `ViewObj` showed:
  Up to now, `Group([  ])` was printed for trivial matrix groups,
  which does not make sense.

- adjusted and added a few tests;
  note that the manual examples contain already many places where the output
  of `ViewObj` is (implicity) shown