### PR TITLE
Add NormalSubgroups methods for symmetric and alternating permutation groups

### DIFF
--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -2447,6 +2447,30 @@ InstallMethod( RadicalGroup, "symmetric", true,
 InstallMethod( RadicalGroup, "alternating", true,
     [ IsNaturalAlternatingGroup and IsFinite], 0,RadicalSymmAlt);
 
+InstallMethod(NormalSubgroups,
+"for a symmetric group",
+[IsSymmetricGroup],
+RankFilter(IsPermGroup),
+function(S)
+  if SymmetricDegree(S) <= 4 then
+    # S is soluble, so this includes the trivial group (and Klein 4)
+    return DerivedSeriesOfGroup(S);
+  fi;
+  # DerivedSubgroup is the alternating group
+  return [S, DerivedSubgroup(S), TrivialSubgroup(S)];
+end);
+
+InstallMethod(NormalSubgroups,
+"for an alternating group",
+[IsAlternatingGroup],
+RankFilter(IsPermGroup),
+function(A)
+  if AlternatingDegree(A) <= 4 then
+    # S is soluble, so this includes the trivial group (and Klein 4)
+    return DerivedSeriesOfGroup(A);
+  fi;
+  return [A, TrivialSubgroup(A)];
+end);
 
 #############################################################################
 ##

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1868,8 +1868,8 @@ DeclareAttribute( "MinimalNormalSubgroups", IsGroup );
 ##  returns a list of all normal subgroups of <A>G</A>.
 ##  <Example><![CDATA[
 ##  gap> g:=SymmetricGroup(4);;NormalSubgroups(g);
-##  [ Sym( [ 1 .. 4 ] ), Group([ (2,4,3), (1,4)(2,3), (1,3)(2,4) ]), 
-##    Group([ (1,4)(2,3), (1,3)(2,4) ]), Group(()) ]
+##  [ Sym( [ 1 .. 4 ] ), Alt( [ 1 .. 4 ] ), Group([ (1,4)(2,3), (1,2) 
+##    (3,4) ]), Group(()) ]
 ##  ]]></Example>
 ##  <P/>
 ##  The algorithm for the computation of normal subgroups is described in

--- a/tst/testinstall/opers/NormalSubgroups.tst
+++ b/tst/testinstall/opers/NormalSubgroups.tst
@@ -1,0 +1,113 @@
+gap> START_TEST("NormalSubgroups.tst");
+
+# Natural symmetric groups
+gap> NormalSubgroups(SymmetricGroup(0)) = [Group(())];
+true
+gap> NormalSubgroups(SymmetricGroup(1)) = [Group(())];
+true
+gap> Set(NormalSubgroups(SymmetricGroup(2))) =
+> Set([Group(()), SymmetricGroup(2)]);
+true
+gap> Set(NormalSubgroups(SymmetricGroup(3))) =
+> Set([Group(()), AlternatingGroup(3), SymmetricGroup(3)]);
+true
+gap> Set(NormalSubgroups(SymmetricGroup(4))) =
+> Set([Group(()), Group((1,2)(3,4), (1,3)(2,4)),
+>  AlternatingGroup(4), SymmetricGroup(4)]);
+true
+gap> Set(NormalSubgroups(SymmetricGroup(5))) =
+> Set([Group(()), AlternatingGroup(5), SymmetricGroup(5)]);
+true
+gap> Set(NormalSubgroups(SymmetricGroup(6))) =
+> Set([Group(()), AlternatingGroup(6), SymmetricGroup(6)]);
+true
+gap> Set(NormalSubgroups(SymmetricGroup(15))) =
+> Set([Group(()), AlternatingGroup(15), SymmetricGroup(15)]);
+true
+gap> Set(NormalSubgroups(SymmetricGroup([3,7,4,11,70]))) =
+> Set([Group(()), AlternatingGroup([3, 4, 7, 11, 70]),
+>      SymmetricGroup([3, 4, 7, 11, 70])]);
+true
+gap> Set(NormalSubgroups(SymmetricGroup([7,4,13,21]))) =
+> Set([Group(()), Group((4,7)(13,21), (4,13)(7,21)),
+>      AlternatingGroup([4, 7, 13, 21]), SymmetricGroup([4, 7, 13, 21])]);
+true
+gap> NormalSubgroups(SymmetricGroup([42])) = [Group(())];
+true
+gap> NormalSubgroups(SymmetricGroup([])) = [Group(())];
+true
+gap> G := Group((7,3,5,11), (11,3), (5,3));;
+gap> IsNaturalSymmetricGroup(G);
+true
+gap> Set(NormalSubgroups(G)) =
+> Set([Group(()), Group((3,5)(7,11), (3,7)(5,11)),
+>      AlternatingGroup([3, 5, 7, 11]), SymmetricGroup([3, 5, 7, 11])]);
+true
+
+# Non-natural symmetric groups
+gap> S4 := Group((1,2,3,4), (1,2));;
+gap> hom := ActionHomomorphism(S4, Arrangements([1..4], 4), OnTuples);;
+gap> G := Image(hom);;
+gap> IsSymmetricGroup(G);
+true
+gap> SymmetricDegree(G);
+4
+gap> MovedPoints(G) = [1..24];
+true
+gap> Set(NormalSubgroups(G)) = Set([G,
+> Group([(1,13,9)(2,14,10)(3,15,7)(4,16,8)
+>        (5,17,12)(6,18,11)(19,23,22)(20,24,21),
+>        (1,21,16)(2,22,15)(3,19,18)(4,20,17)
+>        (5,24,13)(6,23,14)(7,11,10)(8,12,9)]), 
+> Group([(1,24)(2,23)(3,22)(4,21)(5,20)(6,19)
+>        (7,18)(8,17)(9,16)(10,15)(11,14)(12,13),
+>        (1,8)(2,7)(3,11)(4,12)(5,9)(6,10)
+>        (13,21)(14,22)(15,19)(16,20)(17,24)(18,23)]),
+> Group(())]);
+true
+
+# Natural alternating groups
+gap> NormalSubgroups(AlternatingGroup(0)) = [Group(())];
+true
+gap> NormalSubgroups(AlternatingGroup(1)) = [Group(())];
+true
+gap> Set(NormalSubgroups(AlternatingGroup(2))) =
+> Set([Group(()), AlternatingGroup(2)]);
+true
+gap> Set(NormalSubgroups(AlternatingGroup(3))) =
+> Set([Group(()), AlternatingGroup(3)]);
+true
+gap> Set(NormalSubgroups(AlternatingGroup(4))) =
+> Set([Group(()), Group((1,2)(3,4), (1,3)(2,4)),
+>  AlternatingGroup(4)]);
+true
+gap> Set(NormalSubgroups(AlternatingGroup(5))) =
+> Set([Group(()), AlternatingGroup(5)]);
+true
+gap> Set(NormalSubgroups(AlternatingGroup(6))) =
+> Set([Group(()), AlternatingGroup(6)]);
+true
+gap> Set(NormalSubgroups(AlternatingGroup(15))) =
+> Set([Group(()), AlternatingGroup(15)]);
+true
+gap> Set(NormalSubgroups(AlternatingGroup([3,7,4,11,70]))) =
+> Set([Group(()), AlternatingGroup([3, 4, 7, 11, 70])]);
+true
+gap> Set(NormalSubgroups(AlternatingGroup([7,4,13,21]))) =
+> Set([Group(()), Group((4,7)(13,21), (4,13)(7,21)),
+>      AlternatingGroup([4, 7, 13, 21])]);
+true
+gap> NormalSubgroups(AlternatingGroup([42])) = [Group(())];
+true
+gap> NormalSubgroups(AlternatingGroup([])) = [Group(())];
+true
+gap> G := Group((7,3,5), (11,3,7));;
+gap> IsNaturalAlternatingGroup(G);
+true
+gap> Set(NormalSubgroups(G)) =
+> Set([Group(()), Group((3,5)(7,11), (3,7)(5,11)),
+>      AlternatingGroup([3, 5, 7, 11])]);
+true
+
+#
+gap> STOP_TEST( "NormalSubgroups.tst", 1);


### PR DESCRIPTION
The normal subgroups of a symmetric group are well-known and simply described: the trivial group, the Klein 4-group (if n=4), the alternating group, and the symmetric group itself.  An alternating group's normal subgroups are even simpler: the same but without the symmetric group.  The `NormalSubgroups` attribute in GAP should reflect this knowledge by having special methods for permutation groups that are known to be symmetric or alternating.

At the moment, some laborious work is done which means that calling, for example, `NormalSubgroups(SymmetricGroup(40))`, takes several seconds, while larger examples run for a very long time.  This PR introduces simple methods that return the appropriate subgroups.

Note that this only applies to *permutation* groups, since it is easy to describe subgroups based on their moved points.  Note also that this is **not** a fix for Issue #2683, a bug that probably applies to non-symmetric groups as well.