### PR TITLE
Improve FFE code a bit and add tests

### DIFF
--- a/hpcgap/lib/ffe.gi
+++ b/hpcgap/lib/ffe.gi
@@ -620,7 +620,7 @@ InstallMethod( RootOfDefiningPolynomial,
 
     coeffs:= ShiftedCoeffs( coeffs[1], coeffs[2] );
     p:= Characteristic( F );
-    d:= ( Length( coeffs ) - 1 ) * DegreeOverPrimeField( F );
+    d:= DegreeOverPrimeField( F );
 
     if Length( coeffs ) = 2 then
       return - coeffs[1] / coeffs[2];

--- a/hpcgap/lib/ffeconway.gi
+++ b/hpcgap/lib/ffeconway.gi
@@ -168,6 +168,9 @@ InstallOtherMethod(ZOp,
         [IsPosInt, IsPosInt],
         function(p,d)
     local   q;
+    if not IsPrimeInt(p) then
+        Error("Z: <p> must be a prime");
+    fi;
     q := p^d;
     if q <= MAXSIZE_GF_INTERNAL or d =1 then
         return Z(q);
@@ -185,7 +188,9 @@ InstallMethod(ZOp,
     p := SmallestRootInt(q);
     d := LogInt(q,p);
     Assert(1, q=p^d);
-    Assert(2, IsProbablyPrimeInt(p));
+    if not IsPrimeInt(p) then
+        Error("Z: <q> must be a positive prime power");
+    fi;
     if d > 1 then
         return FFECONWAY.ZNC(p,d);
     fi;

--- a/lib/ffe.gi
+++ b/lib/ffe.gi
@@ -600,7 +600,7 @@ InstallMethod( RootOfDefiningPolynomial,
 
     coeffs:= ShiftedCoeffs( coeffs[1], coeffs[2] );
     p:= Characteristic( F );
-    d:= ( Length( coeffs ) - 1 ) * DegreeOverPrimeField( F );
+    d:= DegreeOverPrimeField( F );
 
     if Length( coeffs ) = 2 then
       return - coeffs[1] / coeffs[2];

--- a/lib/ffeconway.gi
+++ b/lib/ffeconway.gi
@@ -155,6 +155,9 @@ InstallOtherMethod(ZOp,
         [IsPosInt, IsPosInt],
         function(p,d)
     local   q;
+    if not IsPrimeInt(p) then
+        Error("Z: <p> must be a prime");
+    fi;
     q := p^d;
     if q <= MAXSIZE_GF_INTERNAL or d =1 then
         return Z(q);
@@ -172,7 +175,9 @@ InstallMethod(ZOp,
     p := SmallestRootInt(q);
     d := LogInt(q,p);
     Assert(1, q=p^d);
-    Assert(2, IsProbablyPrimeInt(p));
+    if not IsPrimeInt(p) then
+        Error("Z: <q> must be a positive prime power");
+    fi;
     if d > 1 then
         return FFECONWAY.ZNC(p,d);
     fi;

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -264,7 +264,6 @@ FF              FiniteField (
     succ = (FFV*)(1+ADDR_OBJ( succBag ));
 
     /* if q is a prime find the smallest primitive root $e$, use $x - e$   */
-    /*N 1990/02/04 mschoene this is likely to explode if 'FFV' is 'UInt4'  */
     /*N 1990/02/04 mschoene there are few dumber ways to find prim. roots  */
     if ( d == 1 ) {
         for ( e = 1, i = 1; i != p-1; ++e ) {
@@ -281,7 +280,6 @@ FF              FiniteField (
     }
 
     /* construct 'indx' such that 'e = x^(indx[e]-1) % poly' for every e   */
-    /*N 1990/02/04 mschoene this is likely to explode if 'FFV' is 'UInt4'  */
     indx[ 0 ] = 0;
     for ( e = 1, n = 0; n < q-1; ++n ) {
         indx[ e ] = n + 1;
@@ -698,7 +696,6 @@ Obj             SumFFEFFE (
     fR = FLD_FFE( opR );
     qR = SIZE_FF( fR  );
 
-    /*N 1997/01/04 mschoene this is likely to explode if 'FFV' is 'UInt4'  */
     if ( qL == qR ) {
         fX = fL;
     }
@@ -866,7 +863,6 @@ Obj             DiffFFEFFE (
     fR = FLD_FFE( opR );
     qR = SIZE_FF( fR  );
 
-    /*N 1997/01/04 mschoene this is likely to explode if 'FFV' is 'UInt4'  */
     if ( qL == qR ) {
         fX = fL;
     }
@@ -996,7 +992,6 @@ Obj             ProdFFEFFE (
     fR = FLD_FFE( opR );
     qR = SIZE_FF( fR  );
 
-    /*N 1997/01/04 mschoene this is likely to explode if 'FFV' is 'UInt4'  */
     if ( qL == qR ) {
         fX = fL;
     }
@@ -1165,7 +1160,6 @@ Obj             QuoFFEFFE (
     fR = FLD_FFE( opR );
     qR = SIZE_FF( fR  );
 
-    /*N 1997/01/04 mschoene this is likely to explode if 'FFV' is 'UInt4'  */
     if ( qL == qR ) {
         fX = fL;
     }
@@ -1343,11 +1337,7 @@ Obj PowFFEFFE (
 {
     /* get the field for the result                                        */
     if ( CHAR_FF( FLD_FFE(opL) ) != CHAR_FF( FLD_FFE(opR) ) ) {
-        opR = ErrorReturnObj(
-          "FFE operations: characteristic of conjugating element must be %d",
-          (Int)CHAR_FF(FLD_FFE(opL)), 0L,
-          "you can replace conjugating element <elt> via 'return <elt>;'" );
-        return POW( opL, opR );
+        ErrorMayQuit("<x> and <y> have different characteristic", 0, 0);
     }
 
     /* compute and return the result                                       */
@@ -1406,19 +1396,17 @@ Obj FuncLOG_FFE_DEFAULT (
     Int                 a, b, c, d, t;  /* temporaries                     */
 
     /* check the arguments                                                 */
-    if ( ! IS_FFE(opZ) || VAL_FFE(opZ) == 0 ) {
+    while ( ! IS_FFE(opZ) || VAL_FFE(opZ) == 0 ) {
         opZ = ErrorReturnObj(
             "LogFFE: <z> must be a nonzero finite field element",
              0L, 0L,
              "you can replace <z> via 'return <z>;'" );
-        return FuncLOG_FFE_DEFAULT( self, opZ, opR );
     }
-    if ( ! IS_FFE(opR) || VAL_FFE(opR) == 0 ) {
+    while ( ! IS_FFE(opR) || VAL_FFE(opR) == 0 ) {
         opR = ErrorReturnObj(
             "LogFFE: <r> must be a nonzero finite field element",
              0L, 0L,
              "you can replace <r> via 'return <r>;'" );
-        return FuncLOG_FFE_DEFAULT( self, opZ, opR );
     }
 
     /* get the values, handle trivial cases                                */
@@ -1431,7 +1419,6 @@ Obj FuncLOG_FFE_DEFAULT (
     fR = FLD_FFE( opR );
     qR = SIZE_FF( fR  );
 
-    /*N 1997/01/04 mschoene this is likely to explode if 'FFV' is 'UInt4'  */
     if ( qZ == qR ) {
         fX = fZ;
         qX = qZ;
@@ -1457,7 +1444,6 @@ Obj FuncLOG_FFE_DEFAULT (
     }
 
     /* now solve <l> * (<vR>-1) = (<vZ>-1) % (<qX>-1)                      */
-    /*N 1990/02/04 mschoene this is likely to explode if 'FFV' is 'UInt4'  */
     a = 1;             b = 0;
     c = (Int) (vR-1);  d = (Int) (qX-1);
     while ( d != 0 ) {
@@ -1637,7 +1623,7 @@ Obj FuncZ2 ( Obj self, Obj p, Obj d)
     {
       ip = INT_INTOBJ(p);
       id = INT_INTOBJ(d);
-      if (ip > 1 && id > 0 && id <= 16 && ip <= 65536)
+      if (ip > 1 && id > 0 && id <= 16 && ip < 65536)
         {
           id1 = id;
           q = ip;

--- a/tst/testinstall/ffe.tst
+++ b/tst/testinstall/ffe.tst
@@ -8,7 +8,76 @@
 gap> START_TEST("ffe.tst");
 
 #
+# setup
 #
+gap> bigPrime:=NextPrimeInt(2^60);
+1152921504606847009
+
+#
+# Z, ZOp: constructing FFE elements
+#
+gap> List([2,3,4,5,7,8,9,25,37^3], Z);
+[ Z(2)^0, Z(3), Z(2^2), Z(5), Z(7), Z(2^3), Z(3^2), Z(5^2), Z(37^3) ]
+
+# input validation
+gap> Z(fail);
+Error, Z: <q> must be a positive prime power (not a boolean or fail)
+gap> Z(0);
+Error, Z: <q> must be a positive prime power (not a integer)
+gap> Z(1);
+Error, Z: <q> must be a positive prime power (not a integer)
+gap> Z(-2);
+Error, Z: <q> must be a positive prime power (not a integer)
+gap> Z(6);
+Error, Z: <q> must be a positive prime power (not a integer)
+
+# variant with two arguments
+gap> Z(0,1);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `ZOp' on 2 arguments
+gap> Z(1,0);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `ZOp' on 2 arguments
+gap> Z(2,0);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `ZOp' on 2 arguments
+gap> Z(2,1);
+Z(2)^0
+
+#
+gap> Z(65521,1);
+Z(65521)
+gap> Z(65521,2);
+z
+gap> Z(2^16);
+Z(2^16)
+gap> Z(2,16);
+Z(2^16)
+gap> Z(bigPrime);
+ZmodpZObj( 13, 1152921504606847009 )
+gap> Z(bigPrime^2);
+z
+gap> Z(bigPrime) = Z(bigPrime,1);
+true
+gap> Z(bigPrime^2) = Z(bigPrime,2);
+true
+
+# verify some edge cases which previously were accepted (incorrectly)
+gap> Z(9,1);
+Error, Z: <p> must be a prime
+gap> Z(9,2);
+Error, Z: <p> must be a prime
+gap> Z(2^16,1);
+Error, Z: <p> must be a prime
+gap> Z(2^16,2);
+Error, Z: <p> must be a prime
+gap> Z(2^17,1);
+Error, Z: <p> must be a prime
+gap> Z(2^17,2);
+Error, Z: <p> must be a prime
+
+#
+# Constructing finite fields and their subfields
 #
 gap> GaloisField( 13 );
 GF(13)
@@ -50,65 +119,6 @@ gap> GF(1,2);
 Error, <subfield> must be a prime or a finite field
 
 #
-gap> DefiningPolynomial( f1 );
-x_1^8+x_1^4+x_1^3+x_1^2+Z(2)^0
-gap> DefiningPolynomial( f2 );
-x_1^8+x_1^7+x_1^2+x_1+Z(2)^0
-gap> DefiningPolynomial( f3 );
-x_1^8+x_1^4+x_1^3+x_1^2+Z(2)^0
-gap> RootOfDefiningPolynomial( f1 );
-Z(2^8)
-gap> RootOfDefiningPolynomial( f2 );
-Z(2^8)^53
-gap> RootOfDefiningPolynomial( f3 );
-Z(2^8)
-gap> Z(4) in GF(8);
-false
-gap> Z(4) in GF(16);
-true
-gap> Intersection( GF(2^2), GF(2^3) );
-GF(2)
-gap> Intersection( GF(2^4), GF(2^6) );
-GF(2^2)
-gap> Conjugates( GF(16), Z(4) );
-[ Z(2^2), Z(2^2)^2, Z(2^2), Z(2^2)^2 ]
-gap> Conjugates( AsField( GF(4), GF(16) ), Z(4) );
-[ Z(2^2), Z(2^2) ]
-gap> Conjugates( GF(4), GF(4), Z(4) );
-[ Z(2^2) ]
-gap> Conjugates( AsField( GF(4), GF(4) ), GF(2), Z(4) );
-[ Z(2^2), Z(2^2)^2 ]
-gap> Norm( GF(16), Z(4) );
-Z(2)^0
-gap> Norm( AsField( GF(4), GF(16) ), Z(4) );
-Z(2^2)^2
-gap> Norm( GF(8), GF(8), Z(8) );
-Z(2^3)
-gap> Norm( AsField( GF(8), GF(8) ), GF(2), Z(8) );
-Z(2)^0
-gap> Trace( GF(16), Z(4) );
-0*Z(2)
-gap> Trace( AsField( GF(4), GF(16) ), Z(4) );
-0*Z(2)
-gap> Trace( GF(4), GF(4), Z(4) );
-Z(2^2)
-gap> Trace( AsField( GF(4), GF(4) ), GF(2), Z(4) );
-Z(2)^0
-gap> List( AsSSortedList( GF(8) ), Order );
-[ 0, 1, 7, 7, 7, 7, 7, 7 ]
-gap> SquareRoots( GF(2), Z(2) );
-[ Z(2)^0 ]
-gap> SquareRoots( GF(4), Z(4) );
-[ Z(2^2)^2 ]
-gap> SquareRoots( GF(3), Z(3) );
-[  ]
-gap> SquareRoots( GF(9), Z(3) );
-[ Z(3^2)^2, Z(3^2)^6 ]
-gap> List( AsSSortedList( GF(7) ), Int );
-[ 0, 1, 3, 2, 6, 4, 5 ]
-gap> Print(List( AsSSortedList( GF(8) ), String ),"\n");
-[ "0*Z(2)", "Z(2)^0", "Z(2^3)", "Z(2^3)^2", "Z(2^3)^3", "Z(2^3)^4", 
-  "Z(2^3)^5", "Z(2^3)^6" ]
 gap> FieldByGenerators( GF(2), [ Z(4), Z(8) ] );
 GF(2^6)
 gap> FieldByGenerators( GF(4), [ Z(4), Z(8) ] );
@@ -131,10 +141,102 @@ gap> Subfields( GF(2^6) );
 [ GF(2), GF(2^2), GF(2^3), GF(2^6) ]
 
 #
-# test + and * with FFEs and rationals
+gap> LargeGaloisField(4,1);
+Error, LargeGaloisField: Characteristic must be prime
+gap> LargeGaloisField(bigPrime);
+GF(1152921504606847009)
+gap> F:=LargeGaloisField(bigPrime,2);
+GF(1152921504606847009^2)
+gap> Z(bigPrime,2) = PrimitiveElement(F);
+true
+
 #
-gap> odds:=[5/3, 5, (5/3)^100, 5^100];;
-gap> evens:=[4/3, 4, (4/3)^100, 4^100];;
+# comparing FFEs
+#
+gap> Z(2) < Z(2); Z(2) < Z(2); Z(2) = Z(2);
+false
+false
+true
+gap> Z(2) < 0*Z(2); 0*Z(2) < Z(2); 0*Z(2) = Z(2);
+false
+true
+false
+gap> Z(2) < Z(3); Z(3) < Z(2); Z(3) = Z(2); # cross characteristic
+true
+false
+false
+
+#
+# test arithmetic
+#
+
+# ... in small prime fields
+gap> Z(3) * Z(3);
+Z(3)^0
+gap> Z(3) / Z(3);
+Z(3)^0
+gap> Z(3) + Z(3);
+Z(3)^0
+gap> Z(3) - Z(3);
+0*Z(3)
+gap> Z(3) ^ Z(3);
+Z(3)
+gap> Z(3)^-1;
+Z(3)
+gap> (0*Z(3))^-1;
+Error, FFE operations: <divisor> must not be zero
+
+# ... in cross characteristic (results in error)
+gap> Z(3) * Z(2);
+Error, <x> and <y> have different characteristic
+gap> Z(3) / Z(2);
+Error, <x> and <y> have different characteristic
+gap> Z(3) + Z(2);
+Error, <x> and <y> have different characteristic
+gap> Z(3) - Z(2);
+Error, <x> and <y> have different characteristic
+gap> Z(3) ^ Z(2);
+Error, <x> and <y> have different characteristic
+
+# ... in small non-prime fields
+gap> Z(9) * Z(9);
+Z(3^2)^2
+gap> Z(9) / Z(9);
+Z(3)^0
+gap> Z(9) + Z(9);
+Z(3^2)^5
+gap> Z(9) - Z(9);
+0*Z(3)
+gap> Z(9) ^ Z(9);
+Z(3^2)
+gap> Z(9)^-1;
+Z(3^2)^7
+gap> (0*Z(9))^-1;
+Error, FFE operations: <divisor> must not be zero
+
+# ... in large prime fields
+# TODO
+
+# ... in large non-prime fields over small prime
+# TODO
+
+# ... in large non-prime fields over large prime
+gap> z:=Z(bigPrime,2);
+z
+gap> 5^100*z;
+879649375121325624z
+gap> z*5^100;
+879649375121325624z
+gap> 5^100 mod bigPrime;
+879649375121325624
+gap> (5^100 + 5^100*z)/5^100;
+1+z
+
+#
+# arithmetic between FFEs and rationals
+#
+gap> odds:=[1, 5/3, 5, (5/3)^100, 5^100];;
+gap> evens:=[0, 4/3, 4, (4/3)^100, 4^100];;
 
 #
 gap> ForAll(odds, x -> x + Z(2) = 0*Z(2));
@@ -144,6 +246,16 @@ true
 gap> ForAll(evens, x -> x + Z(2) = Z(2));
 true
 gap> ForAll(evens, x -> Z(2) + x = Z(2));
+true
+
+#
+gap> ForAll(odds, x -> x - Z(2) = 0*Z(2));
+true
+gap> ForAll(odds, x -> Z(2) - x = 0*Z(2));
+true
+gap> ForAll(evens, x -> x - Z(2) = Z(2));
+true
+gap> ForAll(evens, x -> Z(2) - x = Z(2));
 true
 
 #
@@ -157,24 +269,133 @@ gap> ForAll(evens, x -> Z(2) * x = 0*Z(2));
 true
 
 #
-gap> LargeGaloisField(4,1);
-Error, LargeGaloisField: Characteristic must be prime
-gap> p:=NextPrimeInt(2^60);
-1152921504606847009
-gap> LargeGaloisField(p);
-GF(1152921504606847009)
-gap> F:=LargeGaloisField(p,2);
-GF(1152921504606847009^2)
-gap> z:=PrimitiveElement(F);
-z
-gap> 5^100*z;
-879649375121325624z
-gap> z*5^100;
-879649375121325624z
-gap> 5^100 mod p;
-879649375121325624
-gap> (5^100 + 5^100*z)/5^100;
-1+z
+gap> ForAll(odds, x -> x / Z(2) = Z(2));
+true
+gap> ForAll(odds, x -> Z(2) / x = Z(2));
+true
+gap> ForAll(evens, x -> x / Z(2) = 0*Z(2));
+true
+gap> Z(2) / 0;
+Error, FFE operations: <divisor> must not be zero
+gap> Z(2) / 2;
+Error, FFE operations: <divisor> must not be zero
+
+#
+#
+#
+gap> DefiningPolynomial( f1 );
+x_1^8+x_1^4+x_1^3+x_1^2+Z(2)^0
+gap> DefiningPolynomial( f2 );
+x_1^8+x_1^7+x_1^2+x_1+Z(2)^0
+gap> DefiningPolynomial( f3 );
+x_1^8+x_1^4+x_1^3+x_1^2+Z(2)^0
+
+#
+gap> r1 := RootOfDefiningPolynomial( f1 );
+Z(2^8)
+gap> r2 := RootOfDefiningPolynomial( f2 );
+Z(2^8)^53
+gap> r3 := RootOfDefiningPolynomial( f3 );
+Z(2^8)
+gap> sf1:=Subfield(f1, [r1]);;
+gap> SetDefiningPolynomial(sf1, DefiningPolynomial( f1 ));
+gap> RootOfDefiningPolynomial(sf1) = r1;
+true
+gap> sf2:=Subfield(f2, [r2]);;
+gap> SetDefiningPolynomial(sf2, DefiningPolynomial( f2 ));
+gap> RootOfDefiningPolynomial(sf2) = r2;
+true
+gap> sf3:=Subfield(f3, [r3]);;
+gap> SetDefiningPolynomial(sf3, DefiningPolynomial( f3 ));
+gap> RootOfDefiningPolynomial(sf3) = r3;
+true
+
+#
+gap> Z(4) in GF(8);
+false
+gap> Z(4) in GF(16);
+true
+
+#
+gap> Intersection( GF(2^2), GF(2^3) );
+GF(2)
+gap> Intersection( GF(2^4), GF(2^6) );
+GF(2^2)
+
+#
+gap> Conjugates( GF(16), Z(4) );
+[ Z(2^2), Z(2^2)^2, Z(2^2), Z(2^2)^2 ]
+gap> Conjugates( AsField( GF(4), GF(16) ), Z(4) );
+[ Z(2^2), Z(2^2) ]
+gap> Conjugates( GF(4), GF(4), Z(4) );
+[ Z(2^2) ]
+gap> Conjugates( AsField( GF(4), GF(4) ), GF(2), Z(4) );
+[ Z(2^2), Z(2^2)^2 ]
+gap> Conjugates( GF(16), Z(8) );
+Error, <z> must lie in <L>
+
+#
+gap> Norm( GF(16), Z(4) );
+Z(2)^0
+gap> Norm( AsField( GF(4), GF(16) ), Z(4) );
+Z(2^2)^2
+gap> Norm( GF(8), GF(8), Z(8) );
+Z(2^3)
+gap> Norm( AsField( GF(8), GF(8) ), GF(2), Z(8) );
+Z(2)^0
+gap> Norm( GF(16), Z(8) );
+Error, <z> must lie in <L>
+
+#
+gap> Trace( GF(16), Z(4) );
+0*Z(2)
+gap> Trace( AsField( GF(4), GF(16) ), Z(4) );
+0*Z(2)
+gap> Trace( GF(4), GF(4), Z(4) );
+Z(2^2)
+gap> Trace( AsField( GF(4), GF(4) ), GF(2), Z(4) );
+Z(2)^0
+gap> Trace( GF(16), Z(8) );
+Error, <z> must lie in <L>
+
+#
+gap> List( AsSSortedList( GF(8) ), Order );
+[ 0, 1, 7, 7, 7, 7, 7, 7 ]
+gap> Order(Z(bigPrime)) = bigPrime-1;
+true
+gap> Order(Z(bigPrime,1)) = bigPrime-1;
+true
+gap> Order(Z(bigPrime,2)) = bigPrime^2-1;
+true
+
+#
+gap> SquareRoots( GF(2), Z(2) );
+[ Z(2)^0 ]
+gap> SquareRoots( GF(4), Z(4) );
+[ Z(2^2)^2 ]
+gap> SquareRoots( GF(3), Z(3) );
+[  ]
+gap> SquareRoots( GF(3), 0*Z(3) );
+[ 0*Z(3) ]
+gap> SquareRoots( GF(9), Z(3) );
+[ Z(3^2)^2, Z(3^2)^6 ]
+
+#
+gap> List( AsSSortedList( GF(7) ), Int );
+[ 0, 1, 3, 2, 6, 4, 5 ]
+gap> List( AsSSortedList( GF(7) ), IntFFE );
+[ 0, 1, 3, 2, 6, 4, 5 ]
+gap> List( AsSSortedList( GF(7) ), IntFFESymm );
+[ 0, 1, 3, 2, -1, -3, -2 ]
+gap> Print(List( AsSSortedList( GF(8) ), String ),"\n");
+[ "0*Z(2)", "Z(2)^0", "Z(2^3)", "Z(2^3)^2", "Z(2^3)^3", "Z(2^3)^4", 
+  "Z(2^3)^5", "Z(2^3)^6" ]
+gap> Int(Z(4));
+Error, IntFFE: <z> must lie in prime field
+gap> IntFFE(Z(4));
+Error, IntFFE: <z> must lie in prime field
+gap> IntFFESymm(Z(4));
+Error, IntFFE: <z> must lie in prime field
 
 #
 gap> DegreeFFE( [Z(2), Z(4)]);
@@ -186,6 +407,22 @@ gap> DegreeFFE( [[Z(2),Z(8)],[Z(2), Z(4)]]);
 # LogFFE
 #
 gap> q:=25;; r:=Z(q)^7;; ForAll([0..q-2], i -> LogFFE(r^i,r)=i);
+true
+
+# test cases were the elements are (internally) defined in two
+# fields, neither of which contains the other (this requires some
+# extra work by the kernel to compute a common field)
+gap> LogFFE( Z(2^3), Z(2^2) );
+fail
+gap> LogFFE( Z(2^3)^7, Z(2^2) );
+0
+gap> q:=2^6;; q2:=2^2;; r:=Z(q2);;
+gap> Filtered([0..q-1], i->Z(q)^i in GF(q2))
+>  = Filtered([0..q-1], i->LogFFE(Z(q)^i, r) <> fail);
+true
+gap> q:=5^6;; q2:=5^3;; r:=Z(q2)^11;;
+gap> Filtered([0..q-1], i->Z(q)^i in GF(q2))
+>  = Filtered([0..q-1], i->LogFFE(Z(q)^i, r) <> fail);
 true
 
 # test an issue reported by MN on 2009/10/06, added by AK on 2011/01/16
@@ -222,8 +459,6 @@ gap> Rochambeau:=function(F)
 gap> qs:=[2,3,4,5,7,8,9,11,13,16,17,19,25,27,32,64,81,125,128,243,256];;
 gap> ForAll(qs,x->Rochambeau(GF(x))=0);
 true
-gap> STOP_TEST( "ffe.tst", 1);
 
-#############################################################################
-##
-#E
+#
+gap> STOP_TEST( "ffe.tst", 1);


### PR DESCRIPTION
* add more FFE test cases, now finfield.c has almost full coverage
* simplify `FuncLOG_FFE_DEFAULT` input validation
* remove some comments pointing out problem when extending FFV to UInt4: we
  don't plan to do that (and it'd be impractical in the current setup anyway),
  and even if: those comments are not really helpful
* make Z(p,d) stricter about verifying that `p` is a prime; and fixing an edge
  case on 32 bit systems, where Z(65536,2) lead to an overflow (which luckily
  had no consequences whatsoever)
* adjust the error message of the kernel function `PowFFEFFE` (for
  "conjugating" FFE elements) to match those for +, -, *, / in case of
  arguments which have different characteristic.
* fix bug in RootOfDefiningPolynomial

One change in here might be controversial: I add calls to `IsPrimeInt` into `ZOp` for large primes. These could in theory cause a slow down, although, since we cache results of primality checks, usually that should not be noticeable. But it prevents stupid mistakes. So I'd argue it's no problem after all.
