### PR TITLE
kernel: fix GAP_STATIC_ASSERT fallback code

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -36,8 +36,10 @@
 #else
 // If the compiler does not support _Static_assert resp. static_assert,
 // fall back to a hack (the error message is a bit ugly in that case).
+#define _intern_CONCAT_(X, Y)  X ## Y
+#define _intern_CONCAT(X, Y)  _intern_CONCAT_(X,Y)
 #define GAP_STATIC_ASSERT(cond, msg) \
-    typedef char static_assertion_##__LINE__[(cond)? 1 : -1]
+    typedef char _intern_CONCAT(static_assertion_, __LINE__)[(cond)? 1 : -1]
 #endif
 
 


### PR DESCRIPTION
If `_Static_assert` resp. `static_assert` are not available, we fall back to a
trick involving a typedef that's invalid if the assertion fails.

In order to avoid clashes with repeating (identical) typedefs, we tried to
insert the line number (via the `__LINE__` macro), but that did not actually
work due to the way the C preprocessor works. To fix this, we need to use two
helper macros which ensure `__LINE__` get evaluated before being concatenated
to another string.


I am not sure whether it's worth to mention this in the release notes; but then we *did* get a report involving this problem, so perhaps it is... In any case, I've not yet added any "release notes" labels.