### PR TITLE
kernel: simplify bool.c and add test cases

### DIFF
--- a/src/bool.c
+++ b/src/bool.c
@@ -98,9 +98,6 @@ void PrintBool (
     else if ( bool == Fail ) {
         Pr( "fail", 0L, 0L );
     }
-    else if ( bool == Undefined ) {
-        Pr( "Undefined", 0L, 0L );
-    }
     else {
         Pr( "<<very strange boolean value>>", 0L, 0L );
     }
@@ -111,19 +108,14 @@ void PrintBool (
 **
 *F  EqBool( <boolL>, <boolR> )  . . . . . . . . .  test if <boolL> =  <boolR>
 **
-**  'EqBool' returns 'True' if the two boolean values <boolL> and <boolR> are
-**  equal, and 'False' otherwise.
+**  'EqBool' returns '1' if the two boolean values <boolL> and <boolR> are
+**  equal, and '0' otherwise.
 */
 Int EqBool (
     Obj                 boolL,
     Obj                 boolR )
 {
-    if ( boolL == boolR ) {
-        return 1L;
-    }
-    else {
-        return 0L;
-    }
+    return boolL == boolR;
 }
 
 
@@ -131,15 +123,17 @@ Int EqBool (
 **
 *F  LtBool( <boolL>, <boolR> )  . . . . . . . . .  test if <boolL> <  <boolR>
 **
-**  The ordering of Booleans is true < false <= fail (the <= comes from
-**  the fact that Fail may be equal to False in some compatibility modes
+**  The ordering of Booleans is true < false < fail.
 */
 Int LtBool (
     Obj                 boolL,
     Obj                 boolR )
 {
-  return  ( boolL == True && boolR != True) ||
-    ( boolL == False && boolR == Fail && boolL != boolR);
+    if (boolL == True)
+        return boolR != True;
+    if (boolL == False)
+        return boolR == Fail;
+    return 0;
 }
 
 

--- a/tst/testinstall/kernel/bool.tst
+++ b/tst/testinstall/kernel/bool.tst
@@ -1,0 +1,47 @@
+#
+# Tests for functions defined in src/bool.c
+#
+gap> START_TEST("kernel/bool.tst");
+
+# TypeBool
+gap> t:=TypeObj(true);
+<Type: (BooleanFamily, [ IsBool, IsInternalRep ]), data: fail,>
+gap> IsIdenticalObj(t, TypeObj(false));
+true
+gap> IsIdenticalObj(t, TypeObj(fail));
+true
+
+# PrintBool
+gap> b := [ true, false, fail ];
+[ true, false, fail ]
+
+# EqBool
+gap> SetX([1..3],[1..3],{i,j} -> (i < j) = (b[i] < b[j]));
+[ true ]
+
+# LtBool
+gap> IsSet(b);
+true
+gap> SetX([1..3],[1..3],{i,j} -> (i < j) = (b[i] < b[j]));
+[ true ]
+
+# IsBoolHandler
+gap> ForAll(b, IsBool);
+true
+gap> ForAny([1, 'x', "x", 0.0], IsBool);
+false
+
+# ReturnTrue
+gap> List([0..7], n -> CallFuncList(ReturnTrue,[1..n]));
+[ true, true, true, true, true, true, true, true ]
+
+# ReturnFalse
+gap> List([0..7], n -> CallFuncList(ReturnFalse,[1..n]));
+[ false, false, false, false, false, false, false, false ]
+
+# ReturnFail
+gap> List([0..7], n -> CallFuncList(ReturnFail,[1..n]));
+[ fail, fail, fail, fail, fail, fail, fail, fail ]
+
+#
+gap> STOP_TEST("kernel/bool.tst", 1);


### PR DESCRIPTION
Since `Undefined` should never leak out of low level code, there is no
point in adding print support for it. Also simplify EqBool and LtBool.

This should get code coverage to almost 100% (only exception is the `PrintBool` case for "very strange boolean value"