### PR TITLE
kernel: unify forwarding pointer in list copying code

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -236,20 +236,18 @@ Obj CopyBlist (
     Int                 mut )
 {
     Obj copy;
-    Obj tmp;
 
     if (!IS_MUTABLE_OBJ(list)) {
         return list;
     }
 
     copy = DoCopyBlist(list, mut);
+
     /* leave a forwarding pointer */
-    tmp = NEW_PLIST( T_PLIST, 2 );
-    SET_LEN_PLIST( tmp, 2 );
-    SET_ELM_PLIST( tmp, 1, CONST_ADDR_OBJ(list)[0] );
-    SET_ELM_PLIST( tmp, 2, copy );
-    ADDR_OBJ(list)[0] = tmp;
+    ADDR_OBJ(list)[0] = copy;
     CHANGED_BAG(list);
+
+    /* now it is copied                                                    */
     RetypeBag( list, TNUM_OBJ(list) + COPYING );
     return copy;
 }
@@ -271,7 +269,7 @@ Obj ShallowCopyBlist ( Obj list)
 */
 Obj CopyBlistCopy(Obj list, Int mut)
 {
-    return ELM_PLIST(CONST_ADDR_OBJ(list)[0], 2);
+    return CONST_ADDR_OBJ(list)[0];
 }
 
 
@@ -292,7 +290,7 @@ void CleanBlist (
 void CleanBlistCopy(Obj list)
 {
     /* remove the forwarding pointer */
-    ADDR_OBJ(list)[0] = ELM_PLIST(CONST_ADDR_OBJ(list)[0], 1);
+    ADDR_OBJ(list)[0] = CONST_ADDR_OBJ(CONST_ADDR_OBJ(list)[0])[0];
 
     /* now it is cleaned */
     RetypeBag(list, TNUM_OBJ(list) - COPYING);

--- a/src/objects.c
+++ b/src/objects.c
@@ -498,6 +498,12 @@ Obj CopyObjPosObj (
     }
 
     /* leave a forwarding pointer                                          */
+    // Note that unlike for plists, ranges etc., we cannot simply restore the
+    // overwritten value (which points to the type of <obj>) by copying the
+    // value from <copy>, as the type may have changed in case we are making
+    // an immutable copy of a mutable object. Hence the forwarding pointer
+    // actually points to a plist with two entries: the overwritten value, and
+    // the actual forwarding pointer.
     tmp = NEW_PLIST( T_PLIST, 2 );
     SET_LEN_PLIST( tmp, 2 );
     SET_ELM_PLIST(tmp, 1, CONST_ADDR_OBJ(obj)[0]);
@@ -601,6 +607,12 @@ Obj CopyObjComObj (
     }
 
     /* leave a forwarding pointer                                          */
+    // Note that unlike for plists, ranges etc., we cannot simply restore the
+    // overwritten value (which points to the type of <obj>) by copying the
+    // value from <copy>, as the type may have changed in case we are making
+    // an immutable copy of a mutable object. Hence the forwarding pointer
+    // actually points to a plist with two entries: the overwritten value, and
+    // the actual forwarding pointer.
     tmp = NEW_PLIST( T_PLIST, 2 );
     SET_LEN_PLIST( tmp, 2 );
     SET_ELM_PLIST(tmp, 1, CONST_ADDR_OBJ(obj)[0]);
@@ -703,6 +715,12 @@ Obj CopyObjDatObj (
     }
 
     /* leave a forwarding pointer                                          */
+    // Note that unlike for plists, ranges etc., we cannot simply restore the
+    // overwritten value (which points to the type of <obj>) by copying the
+    // value from <copy>, as the type may have changed in case we are making
+    // an immutable copy of a mutable object. Hence the forwarding pointer
+    // actually points to a plist with two entries: the overwritten value, and
+    // the actual forwarding pointer.
     tmp = NEW_PLIST( T_PLIST, 2 );
     SET_LEN_PLIST( tmp, 2 );
     SET_ELM_PLIST(tmp, 1, CONST_ADDR_OBJ(obj)[0]);

--- a/src/plist.c
+++ b/src/plist.c
@@ -941,8 +941,8 @@ Obj CopyPlist (
 
     /* copy the subvalues                                                  */
     for ( i = 1; i <= LEN_PLIST(copy); i++ ) {
-        if ( ADDR_OBJ(list)[i] != 0 ) {
-            tmp = COPY_OBJ( ADDR_OBJ(list)[i], mut );
+        if (CONST_ADDR_OBJ(list)[i] != 0) {
+            tmp = COPY_OBJ(CONST_ADDR_OBJ(list)[i], mut);
             ADDR_OBJ(copy)[i] = tmp;
             CHANGED_BAG( copy );
         }
@@ -961,7 +961,7 @@ Obj CopyPlistCopy (
     Obj                 list,
     Int                 mut )
 {
-    return ADDR_OBJ(list)[0];
+    return CONST_ADDR_OBJ(list)[0];
 }
 
 
@@ -985,7 +985,7 @@ void CleanPlistCopy (
     UInt                i;              /* loop variable                   */
 
     /* remove the forwarding pointer                                       */
-    ADDR_OBJ(list)[0] = ADDR_OBJ( ADDR_OBJ(list)[0] )[0];
+    ADDR_OBJ(list)[0] = CONST_ADDR_OBJ(CONST_ADDR_OBJ(list)[0])[0];
 
     /* now it is cleaned                                                   */
     RetypeBag( list, TNUM_OBJ(list) - COPYING );

--- a/src/precord.c
+++ b/src/precord.c
@@ -207,7 +207,7 @@ Obj CopyPRecCopy (
     Obj                 rec,
     Int                 mut )
 {
-    return ADDR_OBJ(rec)[0];
+    return CONST_ADDR_OBJ(rec)[0];
 }
 
 void CleanPRec (

--- a/src/range.c
+++ b/src/range.c
@@ -163,7 +163,7 @@ Obj CopyRangeCopy (
     Obj                 list,
     Int                 mut )
 {
-    return ADDR_OBJ(list)[0];
+    return CONST_ADDR_OBJ(list)[0];
 }
 
 

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -697,11 +697,7 @@ Obj CopyObjWPObj (
     }
 
     /* leave a forwarding pointer                                          */
-    tmp = NEW_PLIST( T_PLIST, 2 );
-    SET_LEN_PLIST( tmp, 2 );
-    SET_ELM_PLIST( tmp, 1, CONST_ADDR_OBJ(obj)[0] );
-    SET_ELM_PLIST( tmp, 2, copy );
-    ADDR_OBJ(obj)[0] = tmp;
+    ADDR_OBJ(obj)[0] = copy;
     CHANGED_BAG(obj);
 
     /* now it is copied                                                    */
@@ -808,7 +804,7 @@ Obj CopyObjWPObjCopy (
     Obj                 obj,
     Int                 mut )
 {
-    return ELM_PLIST( CONST_ADDR_OBJ(obj)[0], 2 );
+    return CONST_ADDR_OBJ(obj)[0];
 }
 
 
@@ -823,8 +819,7 @@ void CleanObjWPObjCopy (
     Obj                 elm;            /* subobject                       */
 
     /* remove the forwarding pointer                                       */
-    ADDR_OBJ(obj)[0] = ELM_PLIST( CONST_ADDR_OBJ(obj)[0], 1 );
-    CHANGED_BAG(obj);
+    ADDR_OBJ(obj)[0] = CONST_ADDR_OBJ(CONST_ADDR_OBJ(obj)[0])[0];
 
     /* now it is cleaned                                                   */
     RetypeBag( obj, TNUM_OBJ(obj) - COPYING );


### PR DESCRIPTION
This gets rid of some 2-element plists used to store forwarding pointers, which were still used by the blist, pos obj and wp obj code. Also changes some `ADDR_OBJ` to `CONST_ADDR_OBJ`