### PR TITLE
Tweak READ_ALL_COMMANDS (yet again)

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -87,40 +87,43 @@ static Int READ_COMMAND(Obj *evalResult)
 *F  FuncREAD_ALL_COMMANDS( <self>, <instream>, <echo>, <capture>, <outputFunc> )
 **
 **  FuncREAD_ALL_COMMANDS attempts to execute all statements read from the
-**  stream <instream> and returns fail if the stream cannot be opened, or a list
-**  of lists, each entry of which reflects the result of the execution of one
-**  statement.
+**  stream <instream>. It returns 'fail' if the stream cannot be opened,
+**  otherwise a list of lists, each entry of which reflects the result of the
+**  execution of one statement.
 **
-**  If the parameter <echo> is True, then the statements are echoed to the
+**  If the parameter <echo> is 'true', then the statements are echoed to the
 **  current output.
 **
-**  If the parameter <capture> is True, then any output occurring during
-**  execution of a statement, including the output of <outputFunc>, is captured
-**  into a string.
+**  If the parameter <capture> is 'true', then any output occurring during
+**  execution of a statement, including the output of <outputFunc>, is
+**  captured into a string.
 **
 **  If <resultCallback> is a function, then this function is called on every
-**  statement result, otherwise this parameter is ignored.
-**  Possible outputs of this function are captured if <capture> is True.
+**  statement result, otherwise this parameter is ignored. Possible outputs of
+**  this function are captured if <capture> is 'true'.
 **
-**  The results are returned as lists of length five, the structure of which
-**  is explained below.
+**  The results are returned as lists of length at most five, the structure of
+**  which is explained below:
 **
-**  The first entry is either true if the statement was executed successfully,
-**  and false otherwise.
+**  - The first entry is 'true' if the statement was executed successfully,
+**    and 'false' otherwise.
 **
-**  If the first entry is true, then the second entry is bound to the result
-**  of the statement if there was one, and unbound otherwise.
+**  - If the first entry is 'true', then the second entry is bound to the
+**    result of the statement if there was one, and unbound otherwise.
 **
-**  The third entry is true if the statement ended in a dual semicolon.
+**  - The third entry is 'true' if the statement ended in a dual semicolon,
+**    and 'false' otherwise.
 **
-**  The fourth entry contains the return value of <resultCallback> if applicable.
+**  - The fourth entry contains the return value of <resultCallback> if
+**    applicable.
 **
-**  The fifth entry contains the captured output as a string, if <capture> is True.
+**  - The fifth entry contains the captured output as a string, if <capture>
+**    is 'true'.
 **
 **  This function is currently used in interactive tools such as the GAP
-**  Jupyter kernel to execute cells and is likely to be replaced by a
-**  function that can read a single command from a stream without losing the
-**  rest of its content.
+**  Jupyter kernel to execute cells and is likely to be replaced by a function
+**  that can read a single command from a stream without losing the rest of
+**  its content.
 */
 Obj FuncREAD_ALL_COMMANDS(
     Obj self, Obj instream, Obj echo, Obj capture, Obj resultCallback)
@@ -163,24 +166,21 @@ Obj FuncREAD_ALL_COMMANDS(
 
         if (!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT))) {
             result = NEW_PLIST(T_PLIST, 5);
-            SET_LEN_PLIST(result, 5);
-            SET_ELM_PLIST(result, 1, False);
+            AssPlist(result, 1, False);
             PushPlist(resultList, result);
 
             if (!(status & STATUS_ERROR)) {
 
-                SET_ELM_PLIST(result, 1, True);
-                SET_ELM_PLIST(result, 3, dualSemicolon ? True : False);
+                AssPlist(result, 1, True);
+                AssPlist(result, 3, dualSemicolon ? True : False);
 
                 if (evalResult) {
-                    SET_ELM_PLIST(result, 2, evalResult);
-                    CHANGED_BAG(result);
+                    AssPlist(result, 2, evalResult);
                 }
 
                 if (evalResult && IS_FUNC(resultCallback) && !dualSemicolon) {
                     Obj tmp = CALL_1ARGS(resultCallback, evalResult);
-                    SET_ELM_PLIST(result, 4, tmp);
-                    CHANGED_BAG(result);
+                    AssPlist(result, 4, tmp);
                 }
             }
             // Capture output
@@ -189,8 +189,7 @@ Obj FuncREAD_ALL_COMMANDS(
                 Pr("\03", 0L, 0L);
                 copy = CopyToStringRep(outstreamString);
                 SET_LEN_STRING(outstreamString, 0);
-                SET_ELM_PLIST(result, 5, copy);
-                CHANGED_BAG(result);
+                AssPlist(result, 5, copy);
             }
         }
     } while (!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT)));

--- a/src/streams.c
+++ b/src/streams.c
@@ -84,39 +84,51 @@ static Int READ_COMMAND(Obj *evalResult)
 
 /****************************************************************************
 **
-*F  FuncREAD_ALL_COMMANDS( <self>, <instream>, <echo>, <outputFunc> )
+*F  FuncREAD_ALL_COMMANDS( <self>, <instream>, <echo>, <capture>, <outputFunc> )
 **
-**  FuncREAD_ALL_COMMANDS reads all code from <instream> and returns either
-**  fail if the stream cannot be opened, or executes all statements in the
-**  stream and returns a list of lists, each entry of which reflects the
-**  result of the execution of one statement.
+**  FuncREAD_ALL_COMMANDS attempts to execute all statements read from the
+**  stream <instream> and returns fail if the stream cannot be opened, or a list
+**  of lists, each entry of which reflects the result of the execution of one
+**  statement.
 **
-**  The results are returned as lists of length three if <outputFunc> is
-**  false, or five, if <outputFunc> is a function.
+**  If the parameter <echo> is True, then the statements are echoed to the
+**  current output.
+**
+**  If the parameter <capture> is True, then any output occurring during
+**  execution of a statement, including the output of <outputFunc>, is captured
+**  into a string.
+**
+**  If <resultCallback> is a function, then this function is called on every
+**  statement result, otherwise this parameter is ignored.
+**  Possible outputs of this function are captured if <capture> is True.
+**
+**  The results are returned as lists of length five, the structure of which
+**  is explained below.
+**
+**  The first entry is either true if the statement was executed successfully,
+**  and false otherwise.
 **
 **  If the first entry is true, then the second entry is bound to the result
-**  of the statement if there was one, and unbound otherwise, and the third
-**  entry reflects whether the statement ended in a dual semicolon. If the
-**  first entry is false, an error occurred during the execution of a
-**  statement. In this case, if <outputFunc> is false, only the first entry
-**  is set. If <outputFunc> is a function, only the first and the fifth entry
-**  are set. If <outputFunc> is a function, the fourth entry of the list is
-**  <outputFunc> applied to the result, if there was one, and if the
-**  statement did not end in a dual semicolon. Furthermore, if <outputFunc>
-**  is not false, the fifth entry contains a string of all output printed
-**  while the corresponding statement was executed. If <outputFunc> is false,
-**  all intermediate output is discarded.
+**  of the statement if there was one, and unbound otherwise.
+**
+**  The third entry is true if the statement ended in a dual semicolon.
+**
+**  The fourth entry contains the return value of <resultCallback> if applicable.
+**
+**  The fifth entry contains the captured output as a string, if <capture> is True.
 **
 **  This function is currently used in interactive tools such as the GAP
 **  Jupyter kernel to execute cells and is likely to be replaced by a
 **  function that can read a single command from a stream without losing the
 **  rest of its content.
 */
-Obj FuncREAD_ALL_COMMANDS(Obj self, Obj instream, Obj echo, Obj outputFunc)
+Obj FuncREAD_ALL_COMMANDS(
+    Obj self, Obj instream, Obj echo, Obj capture, Obj resultCallback)
 {
     ExecStatus status;
     UInt       dualSemicolon;
     Obj        result, resultList;
+    Obj        copy;
     Obj        evalResult;
     Obj        outstream = 0;
     Obj        outstreamString = 0;
@@ -127,7 +139,7 @@ Obj FuncREAD_ALL_COMMANDS(Obj self, Obj instream, Obj echo, Obj outputFunc)
     }
 
 
-    if (outputFunc != False) {
+    if (capture == True) {
         outstreamString = NEW_STRING(0);
         outstream = DoOperation2Args(ValGVar(GVarName("OutputTextString")),
                                      outstreamString, True);
@@ -141,9 +153,8 @@ Obj FuncREAD_ALL_COMMANDS(Obj self, Obj instream, Obj echo, Obj outputFunc)
 
     do {
         ClearError();
-
         if (outstream) {
-            // Clean in case Callback function had output
+            // Clean in case there has been any output
             SET_LEN_STRING(outstreamString, 0);
         }
 
@@ -151,22 +162,13 @@ Obj FuncREAD_ALL_COMMANDS(Obj self, Obj instream, Obj echo, Obj outputFunc)
             ReadEvalCommand(STATE(BottomLVars), &evalResult, &dualSemicolon);
 
         if (!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT))) {
-            if (outputFunc != False) {
-                Obj copy = CopyToStringRep(outstreamString);
-                SET_LEN_STRING(outstreamString, 0);
-                result = NEW_PLIST(T_PLIST, 5);
-                SET_LEN_PLIST(result, 5);
-                SET_ELM_PLIST(result, 5, copy);
-                CHANGED_BAG(result);
-            }
-            else {
-                result = NEW_PLIST(T_PLIST, 3);
-                SET_LEN_PLIST(result, 3);
-            }
+            result = NEW_PLIST(T_PLIST, 5);
+            SET_LEN_PLIST(result, 5);
             SET_ELM_PLIST(result, 1, False);
             PushPlist(resultList, result);
 
             if (!(status & STATUS_ERROR)) {
+
                 SET_ELM_PLIST(result, 1, True);
                 SET_ELM_PLIST(result, 3, dualSemicolon ? True : False);
 
@@ -175,14 +177,20 @@ Obj FuncREAD_ALL_COMMANDS(Obj self, Obj instream, Obj echo, Obj outputFunc)
                     CHANGED_BAG(result);
                 }
 
-                if (evalResult && outputFunc != False && !dualSemicolon) {
-                    Obj tmp = CALL_1ARGS(outputFunc, evalResult);
+                if (evalResult && IS_FUNC(resultCallback) && !dualSemicolon) {
+                    Obj tmp = CALL_1ARGS(resultCallback, evalResult);
                     SET_ELM_PLIST(result, 4, tmp);
                     CHANGED_BAG(result);
                 }
             }
-            else {
-                SET_LEN_PLIST(result, 1);
+            // Capture output
+            if (capture == True) {
+                // Flush output
+                Pr("\03", 0L, 0L);
+                copy = CopyToStringRep(outstreamString);
+                SET_LEN_STRING(outstreamString, 0);
+                SET_ELM_PLIST(result, 5, copy);
+                CHANGED_BAG(result);
             }
         }
     } while (!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT)));
@@ -2179,7 +2187,7 @@ static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC(READ, 1, "filename"),
     GVAR_FUNC(READ_NORECOVERY, 1, "filename"),
-    GVAR_FUNC(READ_ALL_COMMANDS, 3, "instream, echo, outputFunc"),
+    GVAR_FUNC(READ_ALL_COMMANDS, 4, "instream, echo, capture, outputFunc"),
     GVAR_FUNC(READ_COMMAND_REAL, 2, "stream, echo"),
     GVAR_FUNC(READ_STREAM, 1, "stream"),
     GVAR_FUNC(READ_STREAM_LOOP, 2, "stream, catchstderrout"),

--- a/tst/testinstall/read.tst
+++ b/tst/testinstall/read.tst
@@ -83,21 +83,28 @@ gap> FileString( Filename(dir, "test.g.gz"), "\037\213\b\b0,\362W\000\ctest.g\00
 32
 gap> StringFile( Filename(dir, "test.g") ) = "1+1;\n" or ARCH_IS_WINDOWS(); # works only when Cygwin installed with gzip
 true
-gap> READ_ALL_COMMANDS(InputTextString(""), false, false);
+gap> READ_ALL_COMMANDS(InputTextString(""), false, false, false);
 [  ]
-gap> READ_ALL_COMMANDS(InputTextString("a := (3,7,1); y := a^(-1);"), false, false);
-[ [ true, (1,3,7), false ], [ true, (1,7,3), false ] ]
-gap> READ_ALL_COMMANDS(InputTextString("Unbind(x); z := x;"), false, false);
+gap> READ_ALL_COMMANDS(InputTextString("a := (3,7,1); y := a^(-1);"), false, false, false);
+[ [ true, (1,3,7), false,, ], [ true, (1,7,3), false,, ] ]
+gap> READ_ALL_COMMANDS(InputTextString("Unbind(x); z := x;"), false, false, false);
 Error, Variable: 'x' must have a value
-[ [ true,, false ], [ false ] ]
-gap> READ_ALL_COMMANDS(InputTextString("SymmetricGroup(5);"), false, ViewString );
-[ [ true, Sym( [ 1 .. 5 ] ), false, "Sym( [ 1 .. 5 ] )", "" ] ]
-gap> p := READ_ALL_COMMANDS(InputTextString("1;;2;3;;4;5;6;7;8;9;10;11;12;13;14;;15;16;17;18;"), false, false);;
-gap> p;
-[ [ true, 1, true ], [ true, 2, false ], [ true, 3, true ], 
-  [ true, 4, false ], [ true, 5, false ], [ true, 6, false ], 
-  [ true, 7, false ], [ true, 8, false ], [ true, 9, false ], 
-  [ true, 10, false ], [ true, 11, false ], [ true, 12, false ], 
-  [ true, 13, false ], [ true, 14, true ], [ true, 15, false ], 
-  [ true, 16, false ], [ true, 17, false ], [ true, 18, false ] ]
+[ [ true,, false,, ], [ false,,,, ] ]
+gap> READ_ALL_COMMANDS(InputTextString("SymmetricGroup(5);"), false, false, ViewString );
+[ [ true, Sym( [ 1 .. 5 ] ), false, "Sym( [ 1 .. 5 ] )", ] ]
+gap> READ_ALL_COMMANDS(InputTextString("1;;2;3;;4;5;6;7;8;9;10;11;12;13;14;;15;16;17;18;"), false, false, false);
+[ [ true, 1, true,, ], [ true, 2, false,, ], [ true, 3, true,, ], 
+  [ true, 4, false,, ], [ true, 5, false,, ], [ true, 6, false,, ], 
+  [ true, 7, false,, ], [ true, 8, false,, ], [ true, 9, false,, ], 
+  [ true, 10, false,, ], [ true, 11, false,, ], [ true, 12, false,, ], 
+  [ true, 13, false,, ], [ true, 14, true,, ], [ true, 15, false,, ], 
+  [ true, 16, false,, ], [ true, 17, false,, ], [ true, 18, false,, ] ]
+gap> READ_ALL_COMMANDS(InputTextString("Print(\"Hello, world\");"), false, true, false );
+[ [ true,, false,, "Hello, world" ] ]
+gap> READ_ALL_COMMANDS(InputTextString("SymmetricGroup(42); Print(\"Hello, world\");"), false, true, ViewObj );
+[ [ true, Sym( [ 1 .. 42 ] ), false,, "Sym( [ 1 .. 42 ] )" ], 
+  [ true,, false,, "Hello, world" ] ]
+gap> READ_ALL_COMMANDS(InputTextString("SymmetricGroup(42); Print(\"Hello, world\");"), false, true, function(o) ViewObj(o); return o; end );
+[ [ true, Sym( [ 1 .. 42 ] ), false, Sym( [ 1 .. 42 ] ), "Sym( [ 1 .. 42 ] )" 
+     ], [ true,, false,, "Hello, world" ] ]
 gap> STOP_TEST( "read.tst", 1);

--- a/tst/testinstall/read.tst
+++ b/tst/testinstall/read.tst
@@ -86,19 +86,19 @@ true
 gap> READ_ALL_COMMANDS(InputTextString(""), false, false, false);
 [  ]
 gap> READ_ALL_COMMANDS(InputTextString("a := (3,7,1); y := a^(-1);"), false, false, false);
-[ [ true, (1,3,7), false,, ], [ true, (1,7,3), false,, ] ]
+[ [ true, (1,3,7), false ], [ true, (1,7,3), false ] ]
 gap> READ_ALL_COMMANDS(InputTextString("Unbind(x); z := x;"), false, false, false);
 Error, Variable: 'x' must have a value
-[ [ true,, false,, ], [ false,,,, ] ]
+[ [ true,, false ], [ false ] ]
 gap> READ_ALL_COMMANDS(InputTextString("SymmetricGroup(5);"), false, false, ViewString );
-[ [ true, Sym( [ 1 .. 5 ] ), false, "Sym( [ 1 .. 5 ] )", ] ]
+[ [ true, Sym( [ 1 .. 5 ] ), false, "Sym( [ 1 .. 5 ] )" ] ]
 gap> READ_ALL_COMMANDS(InputTextString("1;;2;3;;4;5;6;7;8;9;10;11;12;13;14;;15;16;17;18;"), false, false, false);
-[ [ true, 1, true,, ], [ true, 2, false,, ], [ true, 3, true,, ], 
-  [ true, 4, false,, ], [ true, 5, false,, ], [ true, 6, false,, ], 
-  [ true, 7, false,, ], [ true, 8, false,, ], [ true, 9, false,, ], 
-  [ true, 10, false,, ], [ true, 11, false,, ], [ true, 12, false,, ], 
-  [ true, 13, false,, ], [ true, 14, true,, ], [ true, 15, false,, ], 
-  [ true, 16, false,, ], [ true, 17, false,, ], [ true, 18, false,, ] ]
+[ [ true, 1, true ], [ true, 2, false ], [ true, 3, true ], 
+  [ true, 4, false ], [ true, 5, false ], [ true, 6, false ], 
+  [ true, 7, false ], [ true, 8, false ], [ true, 9, false ], 
+  [ true, 10, false ], [ true, 11, false ], [ true, 12, false ], 
+  [ true, 13, false ], [ true, 14, true ], [ true, 15, false ], 
+  [ true, 16, false ], [ true, 17, false ], [ true, 18, false ] ]
 gap> READ_ALL_COMMANDS(InputTextString("Print(\"Hello, world\");"), false, true, false );
 [ [ true,, false,, "Hello, world" ] ]
 gap> READ_ALL_COMMANDS(InputTextString("SymmetricGroup(42); Print(\"Hello, world\");"), false, true, ViewObj );


### PR DESCRIPTION
A (hopefully final, this has become a festering wound now), tweak to `READ_ALL_COMMANDS` to accommodate for some oddities.
The following things are changed:

 * Rename the `outputFunc` parameter to `resultCallback`
 * Introduce an extra parameter `capture` which requests the function
   to capture all output, including output that might be generated
   by the `resultCallback`
 * Make output capture independent of whether a `resultCallback` was given
 * Always return a list of length 5
 * Make the documentation a bit simpler
 * Flush the output stream before we copy the result out, otherwise we might miss some output