### PR TITLE
Avoid calling `SaveCStr` with NULL

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -1700,21 +1700,19 @@ Int IsKernelFunction(Obj func)
 
 #ifdef USE_GASMAN
 
-static void SaveHandler( ObjFunc hdlr )
+static void SaveHandler(ObjFunc hdlr)
 {
-  const Char * cookie;
-  if (hdlr == (ObjFunc)0)
-    SaveCStr("");
-  else
-    {
-      cookie = CookieOfHandler(hdlr);
-      if (!cookie)
-	{
-	  Pr("No cookie for Handler -- workspace will be corrupt\n",0,0);
-	  SaveCStr("");
-	}
-      else
-        SaveCStr(cookie);
+    const Char * cookie;
+    if (hdlr == (ObjFunc)0)
+        SaveCStr("");
+    else {
+        cookie = CookieOfHandler(hdlr);
+        if (!cookie) {
+            Pr("No cookie for Handler -- workspace will be corrupt\n", 0, 0);
+            SaveCStr("");
+        }
+        else
+            SaveCStr(cookie);
     }
 }
 

--- a/src/calls.c
+++ b/src/calls.c
@@ -1713,7 +1713,8 @@ static void SaveHandler( ObjFunc hdlr )
 	  Pr("No cookie for Handler -- workspace will be corrupt\n",0,0);
 	  SaveCStr("");
 	}
-      SaveCStr(cookie);
+      else
+        SaveCStr(cookie);
     }
 }
 


### PR DESCRIPTION
Don't crash after warning that the saved workspace will be corrupt.