### PR TITLE
buildsys: simplify C compilation build rule

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -263,8 +263,8 @@ endif # end of HPCGAP specific code
 ########################################################################
 
 # OBJS shall contain the names of all object files that constitute GAP.
-# So turn all src/*.c and gen/*.c file names in SOURCES into obj/*.lo
-OBJS = $(patsubst gen/%.c,obj/%.lo,$(patsubst src/%.c,obj/%.lo,$(SOURCES)))
+# So turn all FOO/*.c file names in SOURCES into obj/FOO/*.lo
+OBJS = $(patsubst %.c,obj/%.lo,$(SOURCES))
 
 # ensure config.h is built before the compilers gets invoked
 $(OBJS): gen/config.h
@@ -344,16 +344,7 @@ DEPFLAGS = -MQ "$@" -MMD -MP -MF $(DEPFILE)
 COMPILE=$(LIBTOOL) --mode=compile $(CC)
 
 # Build rule for C source files
-# Disabled for HPC-GAP, to ensure we always use the output of ward
-# and not the original source files
-ifeq ($(HPCGAP),no)
-obj/%.lo: src/%.c cnf/GAP-CFLAGS cnf/GAP-CPPFLAGS libtool
-	@$(MKDIR_P) $(@D)/$(DEPDIRNAME)
-	$(QUIET_CC)$(COMPILE) $(DEPFLAGS) $(GAP_CFLAGS) $(GAP_CPPFLAGS) -c $< -o $@
-endif
-
-# Build rule for generated C source files
-obj/%.lo: gen/%.c cnf/GAP-CFLAGS cnf/GAP-CPPFLAGS libtool
+obj/%.lo: %.c cnf/GAP-CFLAGS cnf/GAP-CPPFLAGS libtool
 	@$(MKDIR_P) $(@D)/$(DEPDIRNAME)
 	$(QUIET_CC)$(COMPILE) $(DEPFLAGS) $(GAP_CFLAGS) $(GAP_CPPFLAGS) -c $< -o $@
 

--- a/cnf/gac.in
+++ b/cnf/gac.in
@@ -408,7 +408,7 @@ if [ $comp_howfar = "link" ]; then
         if [ "X${output}" = "X" ]; then output="gacout"; fi
 
         for object in $GAP_OBJS;  do
-            if [ ${object} != "obj/compstat.lo" ]; then
+            if [ ${object} != "obj/src/compstat.lo" ]; then
                 objects="${abs_top_builddir}/${object} ${objects}"
             fi
         done


### PR DESCRIPTION
Instead of having two Makefile rules for C compilation, one for gen/*.c and one for src/*.c, use a single rule, by uniformly placing the object files for FOO/*.c into obj/FOO/*.c.

As a side effect, it now becomes trivial to use the general build rule for C
files in arbitrary locations, e.g. as part of the test suite.

This change comes from PR #2667, but it may be of independent use in PR #2702 for the C test file; and also for writing C based kernel tests, see issue #1917.