### PR TITLE
Export READ_ALL_COMMANDS via header file

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -125,8 +125,7 @@ static Int READ_COMMAND(Obj *evalResult)
 **  that can read a single command from a stream without losing the rest of
 **  its content.
 */
-Obj FuncREAD_ALL_COMMANDS(
-    Obj self, Obj instream, Obj echo, Obj capture, Obj resultCallback)
+Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
 {
     ExecStatus status;
     UInt       dualSemicolon;
@@ -201,6 +200,13 @@ Obj FuncREAD_ALL_COMMANDS(
 
     return resultList;
 }
+
+Obj FuncREAD_ALL_COMMANDS(
+    Obj self, Obj instream, Obj echo, Obj capture, Obj resultCallback)
+{
+    return READ_ALL_COMMANDS(instream, echo, capture, resultCallback);
+}
+
 
 /*
  Returns a list with one or two entries. The first

--- a/src/streams.h
+++ b/src/streams.h
@@ -42,6 +42,11 @@ extern Obj READ_AS_FUNC ( void );
 */
 extern Int READ_GAP_ROOT ( const Char * filename );
 
+// READ_ALL_COMMANDS reads a string of GAP statements and executes them
+// allowing to capture and process outputs
+extern Obj
+READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback);
+
 
 /****************************************************************************
 **


### PR DESCRIPTION
Needed for #2702, though I am a bit reluctant to give this function more credibility by exporting it through a header file.

Also separate `FuncREAD_ALL_COMMANDS` (exported to GAP level) and `READ_ALL_COMMANDS` (kernel function) for conistency.