### PR TITLE
MatrixObj: Rename MultRowVector to MultVector, and add doc, code, tests

### DIFF
--- a/doc/ref/obsolete.xml
+++ b/doc/ref/obsolete.xml
@@ -174,6 +174,10 @@ Here are some further name changes.
   <Item><C>MutableNullMat</C></Item>
   <Item><Ref Func="NullMat"/></Item>
 </Row>
+<Row>
+  <Item><C>MultRowVector</C></Item>
+  <Item><Ref Oper="MultVectorLeft"/></Item>
+</Row>
 </Table>
 
 
@@ -185,6 +189,11 @@ Instead of <C>PositionFirstComponent(list,obj)</C>, you may use
 <C>PositionProperty(list,x->x[1]=obj)</C> as a replacement, depending on
 your specific use case.
 
+<Index Key="MultRowVector"><C>MultRowVector</C></Index>
+The five argument version of the operation <C>MultRowVector</C> has been
+deprecated in GAP 4.10 since it was unused and only available for coefficient
+lists.
+Note that <C>MultRowVector</C> was also renamed to <C>MultVectorLeft</C>.
 
 <ManSection>
 <InfoClass Name="InfoObsolete"/>

--- a/doc/ref/vector.xml
+++ b/doc/ref/vector.xml
@@ -190,7 +190,7 @@ than the <Q>natural</Q> field of the problem.
 <#Include Label="[1]{listcoef}">
 <#Include Label="AddRowVector">
 <#Include Label="AddCoeffs">
-<#Include Label="MultRowVector">
+<#Include Label="MultVector">
 <#Include Label="CoeffsMod">
 
 </Section>

--- a/hpcgap/lib/ffeconway.gi
+++ b/hpcgap/lib/ffeconway.gi
@@ -955,7 +955,7 @@ InstallMethod(InverseOp,
         s := t;
     od;
     Assert(1,Length(a) = 1);
-    MultRowVector(r,Inverse(a[1]));
+    MultVector(r,Inverse(a[1]));
     if AssertionLevel() >= 2 then
         t := ProductCoeffs(x![1],r);
         fam!.ConwayFldEltReducers[d](t);

--- a/hpcgap/lib/polyrat.gi
+++ b/hpcgap/lib/polyrat.gi
@@ -563,7 +563,7 @@ local fam,gcd, u, v, w, val, r, s;
   od;
   #gcd := u * (a/u[Length(u)]);
   gcd:=u;
-  MultRowVector(gcd,a/u[Length(u)]);
+  MultVector(gcd,a/u[Length(u)]);
   ReduceCoeffsMod(gcd,p);
 
   # and return the polynomial
@@ -943,19 +943,19 @@ BindGlobal("RPGcdRepresentationModPrime",function(f,g,p)
   # convert <s> and <x> back into polynomials
   if 0 = Length(g)  then
     #sx := q * sx;
-    MultRowVector(sx,q);
+    MultVector(sx,q);
     ReduceCoeffsMod(sx,p);
     return [ LaurentPolynomialByCoefficients(brci[1],sx,0,brci[2]),
          Zero(brci[1]) ];
   else
     #hx := q * sx;
     hx:=ShallowCopy(sx);
-    MultRowVector(hx,q);
+    MultVector(hx,q);
     ReduceCoeffsMod(hx,p);
     hx := LaurentPolynomialByCoefficients(brci[1],hx,0,brci[2]);
     AddCoeffs(s,ProductCoeffs(sx,f),-1);
     #s := q * s;
-    MultRowVector(s,q);
+    MultVector(s,q);
     ReduceCoeffsMod(s,p);
     s := LaurentPolynomialByCoefficients(brci[1],s,0,brci[2]);
     g := LaurentPolynomialByCoefficients(brci[1],g,0,brci[2]);

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -583,15 +583,15 @@ InstallOtherMethod( AddRowVector, "For 2 8 bit vectors",
 
 #############################################################################
 ##
-#M  MultRowVector( <vec>, <ffe> )
+#M  MultVector( <vec>, <ffe> )
 ##
 ##  multiply <vec> by <ffe> in place
 ##
 
-InstallOtherMethod( MultRowVector, "For an 8 bit vector and an ffe",
+InstallOtherMethod( MultVector, "For an 8 bit vector and an ffe",
         IsCollsElms, [ IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep], 0,
-        MULT_ROWVECTOR_VEC8BITS);
+        MULT_VECTOR_VEC8BITS);
 
 #############################################################################
 ##

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -1809,13 +1809,13 @@ end);
 
 #############################################################################
 ##
-#M  MultRowVector( <vl>, <mul>)
+#M  MultVector( <vl>, <mul>)
 ##
 
-InstallOtherMethod( MultRowVector, "for GF(2) vector and char 2 scalar",
+InstallOtherMethod( MultVector, "for GF(2) vector and char 2 scalar",
         IsCollsElms, [IsGF2VectorRep and IsRowVector and IsMutable,
                 IsFFE], 0,
-        MULT_ROW_VECTOR_GF2VECS_2);
+        MULT_VECTOR_GF2VECS_2);
 
 #############################################################################
 ##
@@ -2361,7 +2361,7 @@ InstallMethod( Randomize, "for a mutable gf2 vector",
   [ IsGF2VectorRep and IsMutable ],
   function( v ) 
     local i;
-    MultRowVector(v,0);
+    MultVector(v,0);
     for i in [1..Length(v)] do 
         if Random(0,1) = 1 then v[i] := Z(2); fi;
     od;
@@ -2371,7 +2371,7 @@ InstallMethod( Randomize, "for a mutable gf2 vector and a random source",
   [ IsGF2VectorRep and IsMutable, IsRandomSource ],
   function( v, rs ) 
     local i;
-    MultRowVector(v,0);
+    MultVector(v,0);
     for i in [1..Length(v)] do 
         if Random(rs,0,1) = 1 then v[i] := Z(2); fi;
     od;

--- a/lib/claspcgs.gi
+++ b/lib/claspcgs.gi
@@ -208,7 +208,7 @@ local   classes,    # classes to be constructed, the result
         if IsIdenticalObj( FamilyObj( U ), FamilyObj( cl.candidates ) )  then
             for c  in cl.candidates  do
                 exp:=ExponentsOfPcElement( N, LeftQuotient( h, c ) );
-                MultRowVector( exp, One( field ) );
+                MultVector( exp, One( field ) );
                 w:=exp * N!.subspace.projection;
                 exp{ N!.subspace.baseComplement }:=
                   exp{ N!.subspace.baseComplement }-w;

--- a/lib/ffeconway.gi
+++ b/lib/ffeconway.gi
@@ -925,7 +925,7 @@ InstallMethod(InverseOp,
         s := t;
     od;
     Assert(1,Length(a) = 1);
-    MultRowVector(r,Inverse(a[1]));
+    MultVector(r,Inverse(a[1]));
     if AssertionLevel() >= 2 then
         t := ProductCoeffs(x![1],r);
         fam!.ConwayFldEltReducers[d](t);

--- a/lib/grpffmat.gi
+++ b/lib/grpffmat.gi
@@ -529,7 +529,7 @@ function(rs, G)
     local m;
     m:= RandomInvertibleMat( rs, DimensionOfMatrixGroup( G ),
                 FieldOfMatrixGroup( G ) );
-    MultRowVector(m[1], DeterminantMat(m)^-1);
+    MultVector(m[1], DeterminantMat(m)^-1);
     return ImmutableMatrix(FieldOfMatrixGroup(G), m, true);
 end);
 

--- a/lib/listcoef.gd
+++ b/lib/listcoef.gd
@@ -97,29 +97,29 @@ DeclareOperation(
 
 #############################################################################
 ##
-#O  MultRowVectorLeft( <list>, <mul> )
+#O  MultVectorLeft( <list>, <mul> )
 ##
-##  <#GAPDoc Label="MultRowVector">
+##  <#GAPDoc Label="MultVector">
 ##  <ManSection>
-##  <Oper Name="MultRowVector" Arg='list1, mul'/>
-##  <Oper Name="MultRowVectorLeft" Arg='list1, mul'/>
+##  <Oper Name="MultVector" Arg='list1, mul'/>
+##  <Oper Name="MultVectorLeft" Arg='list1, mul'/>
 ##  <Returns>nothing</Returns>
 ##
 ##  <Description>
 ##  This operation calculates <A>mul</A>*<A>list1</A> in-place.
 ##  <P/>
-##  Note that <C>MultRowVector</C> is just a synonym for
-##  <C>MultRowVectorLeft</C>.
+##  Note that <C>MultVector</C> is just a synonym for
+##  <C>MultVectorLeft</C>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareOperation(
-    "MultRowVectorLeft",
+    "MultVectorLeft",
         [ IsMutable and IsList,
           IsObject ] );
-# For VectorObj objects there also exists a MultRowVectorRight operation
-DeclareSynonym( "MultRowVector", MultRowVectorLeft );
+# For VectorObj objects there also exists a MultVectorRight operation
+DeclareSynonym( "MultVector", MultVectorLeft );
 
 #############################################################################
 ##

--- a/lib/listcoef.gd
+++ b/lib/listcoef.gd
@@ -97,30 +97,29 @@ DeclareOperation(
 
 #############################################################################
 ##
-#O  MultRowVector( <list1>, <poss1>, <list2>, <poss2>, <mul> )
-#O  MultRowVector( <list>, <mul> )
+#O  MultRowVectorLeft( <list>, <mul> )
 ##
 ##  <#GAPDoc Label="MultRowVector">
 ##  <ManSection>
-##  <Oper Name="MultRowVector" Arg='list1, [poss1, list2, poss2, ]mul'/>
+##  <Oper Name="MultRowVector" Arg='list1, mul'/>
+##  <Oper Name="MultRowVectorLeft" Arg='list1, mul'/>
+##  <Returns>nothing</Returns>
 ##
 ##  <Description>
-##  The five argument version of this operation replaces
-##  <A>list1</A><C>[</C><A>poss1</A><C>[</C><M>i</M><C>]]</C> by
-##  <C><A>mul</A>*<A>list2</A>[<A>poss2</A>[</C><M>i</M><C>]]</C> for <M>i</M>
-##  between <M>1</M> and <C>Length( <A>poss1</A> )</C>.
+##  This operation calculates <A>mul</A>*<A>list1</A> in-place.
 ##  <P/>
-##  The two-argument version simply multiplies each element of <A>list1</A>, 
-##  in-place, by <A>mul</A>.
+##  Note that <C>MultRowVector</C> is just a synonym for
+##  <C>MultRowVectorLeft</C>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareOperation(
-    "MultRowVector",
-        [ IsMutable and IsList, 
-          IsList, IsList, IsList, IsMultiplicativeElement ] );
-
+    "MultRowVectorLeft",
+        [ IsMutable and IsList,
+          IsObject ] );
+# For VectorObj objects there also exists a MultRowVectorRight operation
+DeclareSynonym( "MultRowVector", MultRowVectorLeft );
 
 #############################################################################
 ##

--- a/lib/listcoef.gi
+++ b/lib/listcoef.gi
@@ -262,9 +262,9 @@ end );
 
 #############################################################################
 ##
-#M  MultRowVectorLeft( <list>, <mul> )
+#M  MultVectorLeft( <list>, <mul> )
 ##
-InstallMethod( MultRowVectorLeft,
+InstallMethod( MultVectorLeft,
     "for a mutable dense list, and an object",
     [ IsDenseList and IsMutable,
       IsObject ],
@@ -274,32 +274,32 @@ function( l, m )
         l[i] := m * l[i];
     od;
 end );
-InstallOtherMethod( MultRowVectorLeft, "error if immutable",
+InstallOtherMethod( MultVectorLeft, "error if immutable",
     [ IsList, IsObject ],
     L1_IMMUTABLE_ERROR);
 
-InstallMethod( MultRowVectorLeft,
+InstallMethod( MultVectorLeft,
     "kernel method for a mutable dense small list, and an object",
     IsCollsElms,
     [ IsSmallList and IsDenseList and IsMutable,
       IsObject ],
-    MULT_ROW_VECTOR_LEFT_2
+    MULT_VECTOR_LEFT_2
 );
-InstallMethod( MultRowVectorLeft,
+InstallMethod( MultVectorLeft,
     "kernel method for a mutable dense plain list of \
 cyclotomics, and a cyclotomic",
     IsCollsElms,
     [ IsDenseList and IsMutable and IsPlistRep and IsCyclotomicCollection,
       IsCyclotomic ],
-    MULT_ROW_VECTOR_2_FAST
+    MULT_VECTOR_2_FAST
 );
-InstallMethod( MultRowVectorLeft,
+InstallMethod( MultVectorLeft,
     "kernel method for a mutable row vector of ffes in \
 plain list rep, and an ffe",
     IsCollsElms,
     [ IsRowVector and IsMutable and IsPlistRep and IsFFECollection,
       IsFFE],0,
-    MULT_ROWVECTOR_VECFFES );
+    MULT_VECTOR_VECFFES );
 
 
 #############################################################################

--- a/lib/listcoef.gi
+++ b/lib/listcoef.gi
@@ -262,73 +262,44 @@ end );
 
 #############################################################################
 ##
-#M  MultRowVector( <list1>, <poss1>, <list2>, <poss2>, <mult> )
+#M  MultRowVectorLeft( <list>, <mul> )
 ##
-InstallMethod( MultRowVector,"generic method",
-    true,
+InstallMethod( MultRowVectorLeft,
+    "for a mutable dense list, and an object",
     [ IsDenseList and IsMutable,
-      IsDenseList,
-      IsDenseList,
-      IsDenseList,
-      IsMultiplicativeElement ],
-    0,
-
-function( l1, p1, l2, p2, m )
-    l1{p1} := m * l2{p2};
-end );
-
-InstallOtherMethod( MultRowVector,"error if immutable",true,
-    [ IsList,IsObject,IsObject,IsObject,IsObject],0,
-    L1_IMMUTABLE_ERROR);
-
-#############################################################################
-##
-#M  MultRowVector( <list>, <mul> )
-##
-InstallOtherMethod( MultRowVector,
-        "two argument generic method",
-    true,
-    [ IsDenseList and IsMutable,
-      IsMultiplicativeElement ],
-    0,
-
+      IsObject ],
 function( l, m )
     local   i;
-
     for i  in [ 1 .. Length(l) ]  do
         l[i] := m * l[i];
     od;
 end );
-
-InstallOtherMethod( MultRowVector,"error if immutable",true,
-    [ IsList,IsObject],0,
+InstallOtherMethod( MultRowVectorLeft, "error if immutable",
+    [ IsList, IsObject ],
     L1_IMMUTABLE_ERROR);
 
-InstallOtherMethod( MultRowVector,
-        "Two argument kernel method for small list",
+InstallMethod( MultRowVectorLeft,
+    "kernel method for a mutable dense small list, and an object",
     IsCollsElms,
     [ IsSmallList and IsDenseList and IsMutable,
-      IsMultiplicativeElement ],
-    0,
-    MULT_ROW_VECTOR_2    
+      IsObject ],
+    MULT_ROW_VECTOR_LEFT_2
 );
-
-InstallOtherMethod( MultRowVector,
-        "Two argument kernel method for plain list of cyclotomics and an integer",
+InstallMethod( MultRowVectorLeft,
+    "kernel method for a mutable dense plain list of \
+cyclotomics, and a cyclotomic",
     IsCollsElms,
-        [ IsSmallList and IsDenseList and IsMutable and IsPlistRep and
-          IsCyclotomicCollection,
+    [ IsDenseList and IsMutable and IsPlistRep and IsCyclotomicCollection,
       IsCyclotomic ],
-    0,
-    MULT_ROW_VECTOR_2_FAST    
+    MULT_ROW_VECTOR_2_FAST
 );
-
-InstallOtherMethod( MultRowVector,
-        "kernel method for vecffe (2 args)",
-        IsCollsElms,
-        [ IsRowVector and IsMutable and IsPlistRep and IsFFECollection,
-          IsFFE],0,
-        MULT_ROWVECTOR_VECFFES );
+InstallMethod( MultRowVectorLeft,
+    "kernel method for a mutable row vector of ffes in \
+plain list rep, and an ffe",
+    IsCollsElms,
+    [ IsRowVector and IsMutable and IsPlistRep and IsFFECollection,
+      IsFFE],0,
+    MULT_ROWVECTOR_VECFFES );
 
 
 #############################################################################

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -589,7 +589,7 @@ end );
 ############################################################################
 # Arithmetical operations:
 ############################################################################
-InstallMethod( MultRowVectorLeft,
+InstallMethod( MultVectorLeft,
   "generic method for a mutable vector, and an object",
   [ IsVectorObj and IsMutable, IsObject ],
   function( v, s )
@@ -599,7 +599,7 @@ InstallMethod( MultRowVectorLeft,
     od;
   end );
 
-InstallMethod( MultRowVectorRight,
+InstallMethod( MultVectorRight,
   "generic method for a mutable vector, and an object",
   [ IsVectorObj and IsMutable, IsObject ],
   function( v, s )
@@ -609,7 +609,7 @@ InstallMethod( MultRowVectorRight,
     od;
   end );
 
-InstallMethod( MultRowVectorLeft,
+InstallMethod( MultVectorLeft,
   "generic method for a mutable vector, an object, an int, \
 and an int",
   [ IsVectorObj and IsMutable, IsObject, IsInt, IsInt ],
@@ -620,7 +620,7 @@ and an int",
     od;
   end );
 
-InstallMethod( MultRowVectorRight,
+InstallMethod( MultVectorRight,
   "generic method for a mutable vector, an object, an int, \
 and an int",
   [ IsVectorObj and IsMutable, IsObject, IsInt, IsInt ],

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -586,6 +586,51 @@ InstallMethod( Randomize,
     od;
 end );
 
+############################################################################
+# Arithmetical operations:
+############################################################################
+InstallMethod( MultRowVectorLeft,
+  "generic method for a mutable vector, and an object",
+  [ IsVectorObj and IsMutable, IsObject ],
+  function( v, s )
+    local i;
+    for i in [1 .. Length(v)] do
+      v[i] := s * v[i];
+    od;
+  end );
+
+InstallMethod( MultRowVectorRight,
+  "generic method for a mutable vector, and an object",
+  [ IsVectorObj and IsMutable, IsObject ],
+  function( v, s )
+    local i;
+    for i in [1 .. Length(v)] do
+      v[i] := v[i] * s;
+    od;
+  end );
+
+InstallMethod( MultRowVectorLeft,
+  "generic method for a mutable vector, an object, an int, \
+and an int",
+  [ IsVectorObj and IsMutable, IsObject, IsInt, IsInt ],
+  function( v, s, from, to )
+    local i;
+    for i in [from .. to] do
+      v[i] := s * v[i];
+    od;
+  end );
+
+InstallMethod( MultRowVectorRight,
+  "generic method for a mutable vector, an object, an int, \
+and an int",
+  [ IsVectorObj and IsMutable, IsObject, IsInt, IsInt ],
+  function( v, s, from, to )
+    local i;
+    for i in [from .. to] do
+      v[i] := v[i] * s;
+    od;
+  end );
+
 #
 # Compatibility code: Install MatrixObj methods for IsMatrix.
 #

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -384,24 +384,24 @@ DeclareOperation( "AddRowVector",
 
 #############################################################################
 ##
-#O  MultRowVector( <vec>, <mul>[, <from>, <to>] )
-#O  MultRowVectorLeft( <vec>, <mul>[, <from>, <to>] )
-#O  MultRowVectorRight( <vec>, <mul>[, <from>, <to>] )
+#O  MultVector( <vec>, <mul>[, <from>, <to>] )
+#O  MultVectorLeft( <vec>, <mul>[, <from>, <to>] )
+#O  MultVectorRight( <vec>, <mul>[, <from>, <to>] )
 ##
-##  <#GAPDoc Label="MatObj_MultRowVectorLeft">
+##  <#GAPDoc Label="MatObj_MultVectorLeft">
 ##  <ManSection>
-##  <Oper Name="MultRowVector" Arg='vec, mul[, from, to]'/>
-##  <Oper Name="MultRowVectorLeft" Arg='vec, mul[, from, to]'/>
-##  <Oper Name="MultRowVectorRight" Arg='vec, mul[, from, to]'/>
+##  <Oper Name="MultVector" Arg='vec, mul[, from, to]'/>
+##  <Oper Name="MultVectorLeft" Arg='vec, mul[, from, to]'/>
+##  <Oper Name="MultVectorRight" Arg='vec, mul[, from, to]'/>
 ##  <Returns>nothing</Returns>
 ##
 ##  <Description>
 ##  These operations multiply <A>mul</A> with <A>vec</A> in-place
-##  where <C>MultRowVectorLeft</C> multiplies with <A>mul</A> from the left
-##  and <C>MultRowVectorRight</C> does so from the right.
+##  where <C>MultVectorLeft</C> multiplies with <A>mul</A> from the left
+##  and <C>MultVectorRight</C> does so from the right.
 ##  </P>
-##  Note that <C>MultRowVector</C> is just a synonym for
-##  <C>MultRowVectorLeft</C>.
+##  Note that <C>MultVector</C> is just a synonym for
+##  <C>MultVectorLeft</C>.
 ##  </P>
 ##  If the optional parameters <A>from</A> and <A>to</A> are given only the
 ##  index range <C>[<A>from</A>..<A>to</A>]</C> is guaranteed to be 
@@ -414,15 +414,15 @@ DeclareOperation( "AddRowVector",
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "MultRowVectorLeft",
+DeclareOperation( "MultVectorLeft",
   [ IsVectorObj and IsMutable, IsObject ] );
-DeclareOperation( "MultRowVectorRight",
+DeclareOperation( "MultVectorRight",
   [ IsVectorObj and IsMutable, IsObject ] );
-DeclareOperation( "MultRowVectorLeft",
+DeclareOperation( "MultVectorLeft",
   [ IsVectorObj and IsMutable, IsObject, IsInt, IsInt ] );
-DeclareOperation( "MultRowVectorRight",
+DeclareOperation( "MultVectorRight",
   [ IsVectorObj and IsMutable, IsObject, IsInt, IsInt ] );
-#  Note that MultRowVector is declared a synonym for MultRowVectorLeft in
+#  Note that MultVector is declared a synonym for MultVectorLeft in
 #  listcoef.gd
 
 
@@ -601,7 +601,7 @@ DeclareOperation( "Randomize", [IsVectorObj and IsMutable,IsRandomSource] );
 ##
 ## TODO: link to ExtractSubVector
 ## 
-## TODO: In AddRowVector and MultRowVector, the destination is always the first argument;
+## TODO: In AddRowVector and MultVector, the destination is always the first argument;
 ##   it would be better if we were consistent...
 ##
 ## TODO: Maybe also have a version of this as follows:

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -382,25 +382,48 @@ DeclareOperation( "AddRowVector",
 
 
 
-# TODO: rename MultRowVector to MultVector; but keep in mind that
-# historically there already was MultRowVector, so be careful to not break that
-DeclareOperation( "MultRowVector",
+#############################################################################
+##
+#O  MultRowVector( <vec>, <mul>[, <from>, <to>] )
+#O  MultRowVectorLeft( <vec>, <mul>[, <from>, <to>] )
+#O  MultRowVectorRight( <vec>, <mul>[, <from>, <to>] )
+##
+##  <#GAPDoc Label="MatObj_MultRowVectorLeft">
+##  <ManSection>
+##  <Oper Name="MultRowVector" Arg='vec, mul[, from, to]'/>
+##  <Oper Name="MultRowVectorLeft" Arg='vec, mul[, from, to]'/>
+##  <Oper Name="MultRowVectorRight" Arg='vec, mul[, from, to]'/>
+##  <Returns>nothing</Returns>
+##
+##  <Description>
+##  These operations multiply <A>mul</A> with <A>vec</A> in-place
+##  where <C>MultRowVectorLeft</C> multiplies with <A>mul</A> from the left
+##  and <C>MultRowVectorRight</C> does so from the right.
+##  </P>
+##  Note that <C>MultRowVector</C> is just a synonym for
+##  <C>MultRowVectorLeft</C>.
+##  </P>
+##  If the optional parameters <A>from</A> and <A>to</A> are given only the
+##  index range <C>[<A>from</A>..<A>to</A>]</C> is guaranteed to be 
+##  affected. Other indices <E>may</E> be affected, if it is more convenient
+##  to do so.
+##  This can be helpful if entries of <A>vec</A> are known to be zero.
+##  </P>
+##  If <A>from</A> is bigger than <A>to</A>, the operation does nothing.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation( "MultRowVectorLeft",
   [ IsVectorObj and IsMutable, IsObject ] );
-
-#
-# Also, make it explicit from which side we multiply
-# DeclareOperation( "MultRowVectorFromLeft",
-#   [ IsVectorObj and IsMutable, IsObject ] );
-# DeclareOperation( "MultRowVectorFromRight",
-#   [ IsVectorObj and IsMutable, IsObject ] );
-#DeclareSynonym( "MultRowVector", MultRowVectorFromRight );
-
-# do we really need the following? for what? is any code using this right now?
-# ( a, pa, b, pb, s ) ->  a{pa} := b{pb} * s;
-DeclareOperation( "MultRowVector",
-  [ IsVectorObj and IsMutable, IsList, IsVectorObj, IsList, IsObject ] );
-
-# maybe have this:   vec := vec{[from..to]} * scal ?? cvec has it
+DeclareOperation( "MultRowVectorRight",
+  [ IsVectorObj and IsMutable, IsObject ] );
+DeclareOperation( "MultRowVectorLeft",
+  [ IsVectorObj and IsMutable, IsObject, IsInt, IsInt ] );
+DeclareOperation( "MultRowVectorRight",
+  [ IsVectorObj and IsMutable, IsObject, IsInt, IsInt ] );
+#  Note that MultRowVector is declared a synonym for MultRowVectorLeft in
+#  listcoef.gd
 
 
 # The following operations for scalars and vectors are possible for scalars in the BaseDomain

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -415,27 +415,27 @@ InstallMethod( AddRowVector,
     fi;
   end );
 
-InstallMethod( MultRowVectorLeft,
+InstallMethod( MultVectorLeft,
   "for a plist vector, and an object",
   [ IsPlistVectorRep and IsMutable, IsObject ],
   function( v, s )
-    MULT_ROW_VECTOR_LEFT_2(v![ELSPOS],s);
+    MULT_VECTOR_LEFT_2(v![ELSPOS],s);
   end );
 
-InstallMethod( MultRowVectorRight,
+InstallMethod( MultVectorRight,
   "for a plist vector, and an object",
   [ IsPlistVectorRep and IsMutable, IsObject ],
   function( v, s )
-    MULT_ROW_VECTOR_RIGHT_2(v![ELSPOS],s);
+    MULT_VECTOR_RIGHT_2(v![ELSPOS],s);
   end );
 
-InstallOtherMethod( MultRowVectorLeft, "for an integer vector, and a small integer",
+InstallOtherMethod( MultVectorLeft, "for an integer vector, and a small integer",
   [ IsPlistVectorRep and IsIntVector and IsMutable, IsSmallIntRep ],
   function( v, s )
-    MULT_ROW_VECTOR_2_FAST(v![ELSPOS],s);
+    MULT_VECTOR_2_FAST(v![ELSPOS],s);
   end );
 
-# The four argument version of MultRowVectorLeft / ..Right uses the generic
+# The four argument version of MultVectorLeft / ..Right uses the generic
 # implementation in matobj.gi
 
 InstallMethod( \*, "for a plist vector and a scalar",

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -415,29 +415,28 @@ InstallMethod( AddRowVector,
     fi;
   end );
 
-InstallMethod( MultRowVector, "for a plist vector, and a scalar",
+InstallMethod( MultRowVectorLeft,
+  "for a plist vector, and an object",
   [ IsPlistVectorRep and IsMutable, IsObject ],
   function( v, s )
-    MULT_ROW_VECTOR_2(v![ELSPOS],s);
+    MULT_ROW_VECTOR_LEFT_2(v![ELSPOS],s);
   end );
 
-InstallMethod( MultRowVector, "for a plist vector, and a scalar",
-  [ IsPlistVectorRep and IsIntVector and IsMutable, IsObject ],
+InstallMethod( MultRowVectorRight,
+  "for a plist vector, and an object",
+  [ IsPlistVectorRep and IsMutable, IsObject ],
   function( v, s )
-    if IsSmallIntRep(s) then
-        MULT_ROW_VECTOR_2_FAST(v![ELSPOS],s);
-    else
-        MULT_ROW_VECTOR_2(v![ELSPOS],s);
-    fi;
+    MULT_ROW_VECTOR_RIGHT_2(v![ELSPOS],s);
   end );
 
-InstallMethod( MultRowVector,
-  "for a plist vector, a list, a plist vector, a list, and a scalar",
-  [ IsPlistVectorRep and IsMutable, IsList,
-    IsPlistVectorRep, IsList, IsObject ],
-  function( a, pa, b, pb, s )
-    a![ELSPOS]{pa} := b![ELSPOS]{pb} * s;
+InstallOtherMethod( MultRowVectorLeft, "for an integer vector, and a small integer",
+  [ IsPlistVectorRep and IsIntVector and IsMutable, IsSmallIntRep ],
+  function( v, s )
+    MULT_ROW_VECTOR_2_FAST(v![ELSPOS],s);
   end );
+
+# The four argument version of MultRowVectorLeft / ..Right uses the generic
+# implementation in matobj.gi
 
 InstallMethod( \*, "for a plist vector and a scalar",
   [ IsPlistVectorRep, IsScalar ],

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -414,10 +414,10 @@ BindGlobal( "Matrix_OrderPolynomialInner", function( fld, mat, vec, vecs)
 
         if piv <=d  then
             x := Inverse(w[piv]);
-            MultRowVector(p, x);
+            MultVector(p, x);
             MakeImmutable(p);
             pols[piv] := p;
-            MultRowVector(w, x );
+            MultVector(w, x );
             MakeImmutable(w);
             vecs[piv] := w;
             vec := vec*mat;
@@ -541,7 +541,7 @@ BindGlobal( "Matrix_MinimalPolynomialSameField", function( fld, mat, ind )
                             piv := PositionNonZero(w, piv);
                         until piv > n or not IsBound(base[piv]);
                         if piv <= n then
-                            MultRowVector(w,Inverse(w[piv]));
+                            MultVector(w,Inverse(w[piv]));
                             MakeImmutable(w);
                             base[piv] := w;
                             dim := dim+1;
@@ -1353,11 +1353,11 @@ InstallMethod( DeterminantMatDestructive,
                 row2 := mat[j];
                 mult := -row2[k];
                 if  mult <> zero then
-                    MultRowVector( row2, piv );
+                    MultVector( row2, piv );
                     AddRowVector( row2, row, mult, k, m );
-                    MultRowVector( row2, Inverse(det) );
+                    MultVector( row2, Inverse(det) );
                 else
-                    MultRowVector( row2, piv/det);
+                    MultVector( row2, piv/det);
                 fi;
             od;
 
@@ -1435,7 +1435,7 @@ function( mat )
             # ... and normalize the row.
             x := row[k];
             det := det * x;
-            MultRowVector( mat[k], Inverse(x) );
+            MultVector( mat[k], Inverse(x) );
 
             # clear all entries in this column, adjust only columns > k
             # (Note that we need not clear the rows from 'k+1' to 'j'.)
@@ -1709,11 +1709,11 @@ local R,M,transform,divide,swaprow, swapcol, addcol, addrow, multcol, multrow, l
   end;
 
   multrow:=function(a,m)
-    MultRowVector(M[a],m);
+    MultVector(M[a],m);
     if transform then
-      MultRowVector(left[a],m);
+      MultVector(left[a],m);
       if basmat<>fail then
-	MultRowVector(basmat[a],1/m);
+	MultVector(basmat[a],1/m);
       fi;
     fi;
   end;
@@ -2310,7 +2310,7 @@ InstallMethod( SemiEchelonMatDestructive,
             if inv = fail then
               return fail;
             fi;
-            MultRowVector( row, inv );
+            MultVector( row, inv );
             Add( vectors, row );
             Add( nzheads, j );
             heads[j]:= Length( vectors );
@@ -2958,7 +2958,7 @@ InstallMethod( TriangulizeMat,
                if x = fail then
                  TryNextMethod();
                fi;
-               MultRowVector( row, x );
+               MultVector( row, x );
                mat[i] := row;
 
                # clear all entries in this column

--- a/lib/meataxe.gi
+++ b/lib/meataxe.gi
@@ -421,7 +421,7 @@ SMTX_SpinnedBasis:=function( arg  )
             subdim:=subdim + 1;
             leadpos[subdim]:=j;
             #w:=(w[j]^-1) * w;
-            MultRowVector(w,w[j]^-1);
+            MultVector(w,w[j]^-1);
             Add( ans, w );
             if subdim = dim then
                ans:=ImmutableMatrix(F,ans);

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -575,6 +575,33 @@ DeclareObsoleteSynonym( "MutableNullMat", "NullMat" );
 
 #############################################################################
 ##
+#O  MultRowVector( <list1>, <poss1>, <list2>, <poss2>, <mul> )
+##
+##  <#GAPDoc Label="MultRowVector_Obsolete">
+##  <ManSection>
+##  <Oper Name="MultRowVector" Arg='list1, [poss1, list2, poss2, ]mul'/>
+##  <Returns>nothing</Returns>
+##
+##  <Description>
+##  The two argument version of this operation is an obsolete synonym for
+##  <C>MultVectorLeft</C>, which calculates <A>mul</A>*<A>list1</A> in-place.
+##  New code should use <C>MultVectorLeft</C> or its synonym
+##  <C>MultVector</C> instead.
+##  <P/>
+##  <E>The five argument version of this operation is kept for compatibility
+##  with older versions of &GAP; and will be removed eventually.</E>
+##  It replaces
+##  <A>list1</A><C>[</C><A>poss1</A><C>[</C><M>i</M><C>]]</C> by
+##  <C><A>mul</A>*<A>list2</A>[<A>poss2</A>[</C><M>i</M><C>]]</C> for <M>i</M>
+##  between <M>1</M> and <C>Length( <A>poss1</A> )</C>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareObsoleteSynonym( "MultRowVector", "MultVector" );
+
+#############################################################################
+##
 #O  ReadTest 
 ##
 ##  `ReadTest' is superseded by more robust and flexible `Test'. Since the

--- a/lib/obsolete.gi
+++ b/lib/obsolete.gi
@@ -168,7 +168,7 @@
 #             mat{[d..nrrows]}[pivl] := col;
 #         fi;
 #         if mat[d][d] < 0  then
-#             MultRowVector(mat[d],-1);
+#             MultVector(mat[d],-1);
 #         fi;
 # 
 #         # now perform row operations so that the entries in the
@@ -252,7 +252,7 @@
 #                 mat{[d..nrrows]}[pivl] := col;
 #             fi;
 #             if mat[d][d] < 0  then
-#                 MultRowVector(mat[d],-1);
+#                 MultVector(mat[d],-1);
 #             fi;
 # 
 #             # now perform row operations so that the entries in the
@@ -876,6 +876,28 @@ end);
 # #    return fail;
 # #  fi;
 # end );
+
+#############################################################################
+##
+#M  MultVector( <list1>, <poss1>, <list2>, <poss2>, <mult> )
+##
+InstallOtherMethod( MultVector, "obsolete five argument method",
+    true,
+    [ IsDenseList and IsMutable,
+      IsDenseList,
+      IsDenseList,
+      IsDenseList,
+      IsObject ],
+    0,
+function( l1, p1, l2, p2, m )
+    InfoObsolete(1, "This usage of `MultVector` is no longer",
+           "supported and will be removed eventually." );
+    l1{p1} := m * l2{p2};
+end );
+
+InstallOtherMethod( MultVector, "error if immutable", true,
+    [ IsList,IsObject,IsObject,IsObject,IsObject],0,
+    L1_IMMUTABLE_ERROR);
 
 #############################################################################
 ##

--- a/lib/onecohom.gi
+++ b/lib/onecohom.gi
@@ -1238,14 +1238,14 @@ local   cobounds,cocycles,    # base of one coboundaries and cocycles
                 Append(RS,OCSmallEquationMatrix(ocr,rels[i],g));
             od;
             RR:=OCSmallEquationVector(ocr,rels[i]);
-	    MultRowVector(RR,-One(ocr.field));
+	    MultVector(RR,-One(ocr.field));
 
         else
             for g in gens do
                 Append(RS,OCEquationMatrix(ocr,rels[i],g));
             od;
             RR:=OCEquationVector(ocr,rels[i]);
-	    MultRowVector(RR,-One(ocr.field));
+	    MultVector(RR,-One(ocr.field));
 
         fi;
 

--- a/lib/polyrat.gi
+++ b/lib/polyrat.gi
@@ -551,7 +551,7 @@ local fam,gcd, u, v, w, val, r, s;
   od;
   #gcd := u * (a/u[Length(u)]);
   gcd:=u;
-  MultRowVector(gcd,a/u[Length(u)]);
+  MultVector(gcd,a/u[Length(u)]);
   ReduceCoeffsMod(gcd,p);
 
   # and return the polynomial
@@ -931,19 +931,19 @@ BindGlobal("RPGcdRepresentationModPrime",function(f,g,p)
   # convert <s> and <x> back into polynomials
   if 0 = Length(g)  then
     #sx := q * sx;
-    MultRowVector(sx,q);
+    MultVector(sx,q);
     ReduceCoeffsMod(sx,p);
     return [ LaurentPolynomialByCoefficients(brci[1],sx,0,brci[2]),
          Zero(brci[1]) ];
   else
     #hx := q * sx;
     hx:=ShallowCopy(sx);
-    MultRowVector(hx,q);
+    MultVector(hx,q);
     ReduceCoeffsMod(hx,p);
     hx := LaurentPolynomialByCoefficients(brci[1],hx,0,brci[2]);
     AddCoeffs(s,ProductCoeffs(sx,f),-1);
     #s := q * s;
-    MultRowVector(s,q);
+    MultVector(s,q);
     ReduceCoeffsMod(s,p);
     s := LaurentPolynomialByCoefficients(brci[1],s,0,brci[2]);
     g := LaurentPolynomialByCoefficients(brci[1],g,0,brci[2]);

--- a/lib/sparsevectorsorted.gi
+++ b/lib/sparsevectorsorted.gi
@@ -74,7 +74,7 @@ InstallGlobalFunction(SparseVectorBySortedList, function(arg)
     return l;
 end);
 
-## AddRowVector, MultRowVector
+## AddRowVector, MultVector
 ## products with scalars, scalar product, AddCoeffs, MultCoeffs,
 ##  more coeffs functions
 ## maybe product with matrices
@@ -267,9 +267,9 @@ InstallMethod(DIFF, [IsSparseRowVector and IsSparseListBySortedListRep, IsSparse
         function(v1,v2) return SUM(v1, AINV(v2)); end);
 
 
-InstallOtherMethod( MultRowVector, [IsSparseRowVector and IsSparseListBySortedListRep and IsMutable, IsMultiplicativeElement],
+InstallOtherMethod( MultVector, [IsSparseRowVector and IsSparseListBySortedListRep and IsMutable, IsMultiplicativeElement],
         function(v,x)
-    MultRowVector(v![SL_VALS],x);
+    MultVector(v![SL_VALS],x);
 end);
 
 InstallMethod( \*, [IsSparseRowVector and IsSparseListBySortedListRep, IsMultiplicativeElement],

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -572,15 +572,15 @@ InstallOtherMethod( AddRowVector, "For 2 8 bit vectors",
 
 #############################################################################
 ##
-#M  MultRowVector( <vec>, <ffe> )
+#M  MultVector( <vec>, <ffe> )
 ##
 ##  multiply <vec> by <ffe> in place
 ##
 
-InstallOtherMethod( MultRowVector, "For an 8 bit vector and an ffe",
+InstallOtherMethod( MultVector, "For an 8 bit vector and an ffe",
         IsCollsElms, [ IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep], 0,
-        MULT_ROWVECTOR_VEC8BITS);
+        MULT_VECTOR_VEC8BITS);
 
 #############################################################################
 ##

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1620,13 +1620,13 @@ end);
 
 #############################################################################
 ##
-#M  MultRowVector( <vl>, <mul>)
+#M  MultVector( <vl>, <mul>)
 ##
 
-InstallOtherMethod( MultRowVector, "for GF(2) vector and char 2 scalar",
+InstallOtherMethod( MultVector, "for GF(2) vector and char 2 scalar",
         IsCollsElms, [IsGF2VectorRep and IsRowVector and IsMutable,
                 IsFFE], 0,
-        MULT_ROW_VECTOR_GF2VECS_2);
+        MULT_VECTOR_GF2VECS_2);
 
 #############################################################################
 ##
@@ -2172,7 +2172,7 @@ InstallMethod( Randomize, "for a mutable gf2 vector",
   [ IsGF2VectorRep and IsMutable ],
   function( v ) 
     local i;
-    MultRowVector(v,0);
+    MultVector(v,0);
     for i in [1..Length(v)] do 
         if Random(0,1) = 1 then v[i] := Z(2); fi;
     od;
@@ -2182,7 +2182,7 @@ InstallMethod( Randomize, "for a mutable gf2 vector and a random source",
   [ IsGF2VectorRep and IsMutable, IsRandomSource ],
   function( v, rs ) 
     local i;
-    MultRowVector(v,0);
+    MultVector(v,0);
     for i in [1..Length(v)] do 
         if Random(rs,0,1) = 1 then v[i] := Z(2); fi;
     od;

--- a/lib/vspcmat.gi
+++ b/lib/vspcmat.gi
@@ -1072,7 +1072,7 @@ InstallMethod( CloseMutableBasis,
         if j <= n then
           scalar:= Inverse( v[i][j] );
           for k in [ 1 .. m ] do
-            MultRowVector( v[k], scalar );
+            MultVector( v[k], scalar );
           od;
           Add( basisvectors, v );
           heads[i][j]:= Length( basisvectors );

--- a/lib/vspcrow.gi
+++ b/lib/vspcrow.gi
@@ -1583,7 +1583,7 @@ InstallMethod( CloseMutableBasis,
       # If necessary add the sifted vector, and update the basis info.
       j := PositionNonZero( v );
       if j <= ncols then
-        MultRowVector( v, Inverse( v[j] ) );
+        MultVector( v, Inverse( v[j] ) );
         Add( basisvectors, v );
         heads[j]:= Length( basisvectors );
       fi;

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -1315,7 +1315,7 @@ Obj FuncINV_MATRIX_IMMUTABLE( Obj self, Obj mat)
 /* We need these to redispatch when the user has supplied a replacement value. */
 
 static Obj AddRowVectorOp;   /* BH changed to static */
-static Obj MultRowVectorLeftOp; /* BH changed to static */
+static Obj MultVectorLeftOp; /* BH changed to static */
 
 Obj FuncADD_ROW_VECTOR_5( Obj self,
                           Obj list1,
@@ -1547,7 +1547,7 @@ Obj FuncADD_ROW_VECTOR_2_FAST ( Obj self,
 
 /****************************************************************************
 **
-*F  MULT_ROW_VECTOR_LEFT_RIGHT_2( <list>, <mult>, <left> )
+*F  MULT_VECTOR_LEFT_RIGHT_2( <list>, <mult>, <left> )
 **
 **  This function destructively multiplies the entries of <list> by <mult>.
 **  It multiplies with <mult> from the left if <left> is not 0 and from the
@@ -1555,7 +1555,7 @@ Obj FuncADD_ROW_VECTOR_2_FAST ( Obj self,
 **  It does very little checking.
 **
 */
-static inline Obj MULT_ROW_VECTOR_LEFT_RIGHT_2(Obj list, Obj mult, UInt left)
+static inline Obj MULT_VECTOR_LEFT_RIGHT_2(Obj list, Obj mult, UInt left)
 {
   UInt i;
   Obj prd;
@@ -1577,19 +1577,19 @@ static inline Obj MULT_ROW_VECTOR_LEFT_RIGHT_2(Obj list, Obj mult, UInt left)
   return 0;
 }
 
-Obj FuncMULT_ROW_VECTOR_LEFT_2(Obj self, Obj list, Obj mult)
+Obj FuncMULT_VECTOR_LEFT_2(Obj self, Obj list, Obj mult)
 {
-    return MULT_ROW_VECTOR_LEFT_RIGHT_2(list, mult, 1);
+    return MULT_VECTOR_LEFT_RIGHT_2(list, mult, 1);
 }
 
-Obj FuncMULT_ROW_VECTOR_RIGHT_2(Obj self, Obj list, Obj mult)
+Obj FuncMULT_VECTOR_RIGHT_2(Obj self, Obj list, Obj mult)
 {
-    return MULT_ROW_VECTOR_LEFT_RIGHT_2(list, mult, 0);
+    return MULT_VECTOR_LEFT_RIGHT_2(list, mult, 0);
 }
 
 /****************************************************************************
 **
-*F  FuncMULT_ROW_VECTOR_2_FAST( <self>, <list>, <mult> )
+*F  FuncMULT_VECTOR_2_FAST( <self>, <list>, <mult> )
 **
 **  This function destructively multiplies the entries of <list> by <mult>
 **  It does very little checking
@@ -1598,7 +1598,7 @@ Obj FuncMULT_ROW_VECTOR_RIGHT_2(Obj self, Obj list, Obj mult)
 **  multiplier
 */
 
-Obj FuncMULT_ROW_VECTOR_2_FAST( Obj self,
+Obj FuncMULT_VECTOR_2_FAST( Obj self,
                                 Obj list,
                                 Obj mult )
 {
@@ -1658,7 +1658,7 @@ Obj FuncPROD_VEC_MAT_DEFAULT( Obj self,
           if (res == (Obj)0)
             {
               res = SHALLOW_COPY_OBJ(vecr);
-              CALL_2ARGS(MultRowVectorLeftOp, res, elt);
+              CALL_2ARGS(MultVectorLeftOp, res, elt);
             }
           else
             CALL_3ARGS(AddRowVectorOp, res, vecr, elt);
@@ -1676,7 +1676,7 @@ Obj FuncPROD_VEC_MAT_DEFAULT( Obj self,
 *F  FuncINV_MAT_DEFAULT
 **
 **  A faster version of InvMat for those matrices for whose rows AddRowVector
-** and MultRowVectorLeft make sense (and might have fast kernel methods)
+** and MultVectorLeft make sense (and might have fast kernel methods)
 **
 */
 
@@ -1777,8 +1777,8 @@ Obj InvMatWithRowVecs( Obj mat, UInt mut)
       if (!EQ(x, one))
         {
           xi = INV(x);
-          CALL_2ARGS(MultRowVectorLeftOp, row, xi);
-          CALL_2ARGS(MultRowVectorLeftOp, row2, xi);
+          CALL_2ARGS(MultVectorLeftOp, row, xi);
+          CALL_2ARGS(MultVectorLeftOp, row2, xi);
         }
 
       /* Clear the entries. We know that we can ignore the entries in rows i..j */
@@ -2234,9 +2234,9 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(ADD_ROW_VECTOR_3_FAST, 3, "list1, list2, mult"),
     GVAR_FUNC(ADD_ROW_VECTOR_2, 2, "list1, list2"),
     GVAR_FUNC(ADD_ROW_VECTOR_2_FAST, 2, "list1, list2"),
-    GVAR_FUNC(MULT_ROW_VECTOR_LEFT_2, 2, "list, mult"),
-    GVAR_FUNC(MULT_ROW_VECTOR_RIGHT_2, 2, "list, mult"),
-    GVAR_FUNC(MULT_ROW_VECTOR_2_FAST, 2, "list, mult"),
+    GVAR_FUNC(MULT_VECTOR_LEFT_2, 2, "list, mult"),
+    GVAR_FUNC(MULT_VECTOR_RIGHT_2, 2, "list, mult"),
+    GVAR_FUNC(MULT_VECTOR_2_FAST, 2, "list, mult"),
     GVAR_FUNC(PROD_VEC_MAT_DEFAULT, 2, "vec, mat"),
     GVAR_FUNC(INV_MAT_DEFAULT_MUTABLE, 1, "mat"),
     GVAR_FUNC(INV_MAT_DEFAULT_SAME_MUTABILITY, 1, "mat"),
@@ -2267,7 +2267,7 @@ static Int InitKernel (
     InitHdlrFuncsFromTable( GVarFuncs );
 
     InitFopyGVar( "AddRowVector", &AddRowVectorOp );
-    InitFopyGVar("MultRowVectorLeft", &MultRowVectorLeftOp);
+    InitFopyGVar("MultVectorLeft", &MultVectorLeftOp);
     InitFopyGVar( "ConvertToMatrixRep", &ConvertToMatrixRep );
 
 

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -1315,7 +1315,7 @@ Obj FuncINV_MATRIX_IMMUTABLE( Obj self, Obj mat)
 /* We need these to redispatch when the user has supplied a replacement value. */
 
 static Obj AddRowVectorOp;   /* BH changed to static */
-static Obj MultRowVectorOp;  /* BH changed to static */
+static Obj MultRowVectorLeftOp; /* BH changed to static */
 
 Obj FuncADD_ROW_VECTOR_5( Obj self,
                           Obj list1,
@@ -1547,28 +1547,44 @@ Obj FuncADD_ROW_VECTOR_2_FAST ( Obj self,
 
 /****************************************************************************
 **
-*F  FuncMULT_ROW_VECTOR_2( <self>, <list>, <mult> )
+*F  MULT_ROW_VECTOR_LEFT_RIGHT_2( <list>, <mult>, <left> )
 **
-**  This function destructively multiplies the entries of <list> by <mult>
-**  It does very little checking
+**  This function destructively multiplies the entries of <list> by <mult>.
+**  It multiplies with <mult> from the left if <left> is not 0 and from the
+**  right otherwise.
+**  It does very little checking.
 **
 */
-
-Obj FuncMULT_ROW_VECTOR_2( Obj self,
-                           Obj list,
-                           Obj mult )
+static inline Obj MULT_ROW_VECTOR_LEFT_RIGHT_2(Obj list, Obj mult, UInt left)
 {
   UInt i;
   Obj prd;
   UInt len = LEN_LIST(list);
-  for (i = 1; i <= len; i++)
-    {
-      prd = ELMW_LIST(list,i);
-      prd = PROD(prd,mult);
-      ASS_LIST(list,i,prd);
-      CHANGED_BAG(list);
-    }
+  if (left != 0)
+      for (i = 1; i <= len; i++) {
+          prd = ELMW_LIST(list, i);
+          prd = PROD(mult, prd);
+          ASS_LIST(list, i, prd);
+          CHANGED_BAG(list);
+      }
+  else
+      for (i = 1; i <= len; i++) {
+          prd = ELMW_LIST(list, i);
+          prd = PROD(prd, mult);
+          ASS_LIST(list, i, prd);
+          CHANGED_BAG(list);
+      }
   return 0;
+}
+
+Obj FuncMULT_ROW_VECTOR_LEFT_2(Obj self, Obj list, Obj mult)
+{
+    return MULT_ROW_VECTOR_LEFT_RIGHT_2(list, mult, 1);
+}
+
+Obj FuncMULT_ROW_VECTOR_RIGHT_2(Obj self, Obj list, Obj mult)
+{
+    return MULT_ROW_VECTOR_LEFT_RIGHT_2(list, mult, 0);
 }
 
 /****************************************************************************
@@ -1642,7 +1658,7 @@ Obj FuncPROD_VEC_MAT_DEFAULT( Obj self,
           if (res == (Obj)0)
             {
               res = SHALLOW_COPY_OBJ(vecr);
-              CALL_2ARGS(MultRowVectorOp,res,elt);
+              CALL_2ARGS(MultRowVectorLeftOp, res, elt);
             }
           else
             CALL_3ARGS(AddRowVectorOp, res, vecr, elt);
@@ -1660,7 +1676,7 @@ Obj FuncPROD_VEC_MAT_DEFAULT( Obj self,
 *F  FuncINV_MAT_DEFAULT
 **
 **  A faster version of InvMat for those matrices for whose rows AddRowVector
-** and MultRowVector make sense (and might have fast kernel methods)
+** and MultRowVectorLeft make sense (and might have fast kernel methods)
 **
 */
 
@@ -1761,8 +1777,8 @@ Obj InvMatWithRowVecs( Obj mat, UInt mut)
       if (!EQ(x, one))
         {
           xi = INV(x);
-          CALL_2ARGS(MultRowVectorOp, row, xi);
-          CALL_2ARGS(MultRowVectorOp, row2, xi);
+          CALL_2ARGS(MultRowVectorLeftOp, row, xi);
+          CALL_2ARGS(MultRowVectorLeftOp, row2, xi);
         }
 
       /* Clear the entries. We know that we can ignore the entries in rows i..j */
@@ -2187,7 +2203,7 @@ static Obj  FuncMONOM_PROD( Obj self, Obj m1, Obj m2 ) {
 **
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
-static StructGVarFunc GVarFuncs [] = {
+static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC(EQ_LIST_LIST_DEFAULT, 2, "listL, listR"),
     GVAR_FUNC(LT_LIST_LIST_DEFAULT, 2, "listL, listR"),
@@ -2218,7 +2234,8 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(ADD_ROW_VECTOR_3_FAST, 3, "list1, list2, mult"),
     GVAR_FUNC(ADD_ROW_VECTOR_2, 2, "list1, list2"),
     GVAR_FUNC(ADD_ROW_VECTOR_2_FAST, 2, "list1, list2"),
-    GVAR_FUNC(MULT_ROW_VECTOR_2, 2, "list, mult"),
+    GVAR_FUNC(MULT_ROW_VECTOR_LEFT_2, 2, "list, mult"),
+    GVAR_FUNC(MULT_ROW_VECTOR_RIGHT_2, 2, "list, mult"),
     GVAR_FUNC(MULT_ROW_VECTOR_2_FAST, 2, "list, mult"),
     GVAR_FUNC(PROD_VEC_MAT_DEFAULT, 2, "vec, mat"),
     GVAR_FUNC(INV_MAT_DEFAULT_MUTABLE, 1, "mat"),
@@ -2250,7 +2267,7 @@ static Int InitKernel (
     InitHdlrFuncsFromTable( GVarFuncs );
 
     InitFopyGVar( "AddRowVector", &AddRowVectorOp );
-    InitFopyGVar( "MultRowVector", &MultRowVectorOp );
+    InitFopyGVar("MultRowVectorLeft", &MultRowVectorLeftOp);
     InitFopyGVar( "ConvertToMatrixRep", &ConvertToMatrixRep );
 
 

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -1631,12 +1631,12 @@ void  AddVec8BitVec8BitMultInner( Obj sum,
 
 /****************************************************************************
 **
-*F  FuncMULT_ROW_VECTOR( <self>, <vec>, <mul> )
+*F  FuncMULT_VECTOR( <self>, <vec>, <mul> )
 **
 **  In-place scalar multiply
 */
 
-Obj FuncMULT_ROWVECTOR_VEC8BITS( Obj self, Obj vec, Obj mul)
+Obj FuncMULT_VECTOR_VEC8BITS( Obj self, Obj vec, Obj mul)
 {
     UInt q;
     q = FIELD_VEC8BIT(vec);
@@ -5832,7 +5832,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(ADD_ROWVECTOR_VEC8BITS_5, 5, "gfqvecl, gfqvecr, mul, from, to"),
     GVAR_FUNC(ADD_ROWVECTOR_VEC8BITS_3, 3, "gfqvecl, gfqvecr, mul"),
     GVAR_FUNC(ADD_ROWVECTOR_VEC8BITS_2, 2, "gfqvecl, gfqvecr"),
-    GVAR_FUNC(MULT_ROWVECTOR_VEC8BITS, 2, "gfqvec, ffe"),
+    GVAR_FUNC(MULT_VECTOR_VEC8BITS, 2, "gfqvec, ffe"),
     GVAR_FUNC(POSITION_NONZERO_VEC8BIT, 2, "vec8bit, zero"),
     GVAR_FUNC(POSITION_NONZERO_VEC8BIT3, 3, "vec8bit, zero, from"),
     GVAR_FUNC(APPEND_VEC8BIT, 2, "vec8bitl, vec8bitr"),

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -734,13 +734,13 @@ Obj FuncADD_ROWVECTOR_VECFFES_3( Obj self, Obj vecL, Obj vecR, Obj mult )
 }
 /****************************************************************************
 **
-*F  FuncMULT_ROWVECTOR_VECFFES( <self>, <vec>, <mult> )
+*F  FuncMULT_VECTOR_VECFFES( <self>, <vec>, <mult> )
 **
 */
 
-static Obj MultRowVectorLeftOp; /* BH changed to static */
+static Obj MultVectorLeftOp; /* BH changed to static */
 
-Obj FuncMULT_ROWVECTOR_VECFFES( Obj self, Obj vec, Obj mult )
+Obj FuncMULT_VECTOR_VECFFES( Obj self, Obj vec, Obj mult )
 {
     Obj *ptr;
     FFV  valM;
@@ -772,10 +772,10 @@ Obj FuncMULT_ROWVECTOR_VECFFES( Obj self, Obj vec, Obj mult )
         /* check the characteristic                                        */
         if (CHAR_FF(fld) != CHAR_FF(FLD_FFE(mult))) {
             mult = ErrorReturnObj(
-                "MultRowVector: <multiplier> has different field",
+                "MultVector: <multiplier> has different field",
                 0L, 0L,
                 "you can replace <multiplier> via 'return <multiplier>;'");
-            return CALL_2ARGS(MultRowVectorLeftOp, vec, mult);
+            return CALL_2ARGS(MultVectorLeftOp, vec, mult);
         }
 
         /* if the multiplier is over a non subfield then redispatch */
@@ -1087,7 +1087,7 @@ static StructGVarFunc GVarFuncs [] = {
 
   GVAR_FUNC(ADD_ROWVECTOR_VECFFES_3, 3, "vecl, vecr, mult"),
   GVAR_FUNC(ADD_ROWVECTOR_VECFFES_2, 2, "vecl, vecr"),
-  GVAR_FUNC(MULT_ROWVECTOR_VECFFES, 2, "vec, mult"),
+  GVAR_FUNC(MULT_VECTOR_VECFFES, 2, "vec, mult"),
   GVAR_FUNC(IS_VECFFE, 1, "vec"),
   GVAR_FUNC(COMMON_FIELD_VECFFE, 1, "vec"),
   GVAR_FUNC(SMALLEST_FIELD_VECFFE, 1, "vec"),

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -738,7 +738,7 @@ Obj FuncADD_ROWVECTOR_VECFFES_3( Obj self, Obj vecL, Obj vecR, Obj mult )
 **
 */
 
-static Obj MultRowVectorOp;   /* BH changed to static */
+static Obj MultRowVectorLeftOp; /* BH changed to static */
 
 Obj FuncMULT_ROWVECTOR_VECFFES( Obj self, Obj vec, Obj mult )
 {
@@ -775,7 +775,7 @@ Obj FuncMULT_ROWVECTOR_VECFFES( Obj self, Obj vec, Obj mult )
                 "MultRowVector: <multiplier> has different field",
                 0L, 0L,
                 "you can replace <multiplier> via 'return <multiplier>;'");
-            return CALL_2ARGS(MultRowVectorOp, vec, mult);
+            return CALL_2ARGS(MultRowVectorLeftOp, vec, mult);
         }
 
         /* if the multiplier is over a non subfield then redispatch */

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -2382,11 +2382,11 @@ Obj FuncSUM_GF2VEC_GF2VEC (
 
 /****************************************************************************
 **
-*F  FuncMULT_ROW_VECTOR_GF2VECS_2( <self>, <vl>, <mul> )
+*F  FuncMULT_VECTOR_GF2VECS_2( <self>, <vl>, <mul> )
 **                                      . . . . .  sum of GF2 vectors
 **
 */
-Obj FuncMULT_ROW_VECTOR_GF2VECS_2 (
+Obj FuncMULT_VECTOR_GF2VECS_2 (
     Obj                 self,
     Obj                 vl,
     Obj                 mul )
@@ -4503,7 +4503,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(SHRINKCOEFFS_GF2VEC, 1, "gf2vec"),
     GVAR_FUNC(POSITION_NONZERO_GF2VEC, 2, "gf2vec, zero"),
     GVAR_FUNC(POSITION_NONZERO_GF2VEC3, 3, "gf2vec, zero, from"),
-    GVAR_FUNC(MULT_ROW_VECTOR_GF2VECS_2, 2, "gf2vecl, mul"),
+    GVAR_FUNC(MULT_VECTOR_GF2VECS_2, 2, "gf2vecl, mul"),
     GVAR_FUNC(APPEND_GF2VEC, 2, "gf2vecl, gf2vecr"),
     GVAR_FUNC(SHALLOWCOPY_GF2VEC, 1, "gf2vec"),
     GVAR_FUNC(NUMBER_GF2VEC, 1, "gf2vec"),

--- a/tst/test-matobj/MultVector.tst
+++ b/tst/test-matobj/MultVector.tst
@@ -1,0 +1,45 @@
+gap> START_TEST("MultVector.tst");
+
+# Finite Fields
+gap> v := NewVector( IsPlistVectorRep, GF(5), [Z(5)^1, Z(5)^2, Z(5)^0, Z(5)^4, 0*Z(5), Z(5)^3 ]  );
+<plist vector over GF(5) of length 6>
+gap> MultVector(v, Z(5)^3);
+gap> Unpack(v);
+[ Z(5)^0, Z(5), Z(5)^3, Z(5)^3, 0*Z(5), Z(5)^2 ]
+gap> MultVector(v, -1);
+gap> Unpack(v);
+[ Z(5)^2, Z(5)^3, Z(5), Z(5), 0*Z(5), Z(5)^0 ]
+gap> MultVector(v, Z(5)^3, 3, 4);
+gap> Unpack(v);
+[ Z(5)^2, Z(5)^3, Z(5)^0, Z(5)^0, 0*Z(5), Z(5)^0 ]
+
+# Integers
+gap> n := NewVector( IsPlistVectorRep, Integers, [1,2,0] );
+<plist vector over Integers of length 3>
+gap> IsIntVector(n);
+true
+gap> MultVector(n, 2);
+gap> Unpack(n);
+[ 2, 4, 0 ]
+
+# Quaternions: multiplication from left and right
+gap> Q := QuaternionAlgebra( Rationals );
+<algebra-with-one of dimension 4 over Rationals>
+gap> q := NewVector( IsPlistVectorRep, Q, [One(Q), Zero(Q), Q.2, Q.3] );
+<plist vector over AlgebraWithOne( Rationals, [ e, i, j, k ] ) of length 4>
+gap> MultVectorRight(q, Q.2);
+gap> Unpack(q);
+[ i, 0*e, (-1)*e, (-1)*k ]
+gap> MultVectorLeft(q, Q.2);
+gap> Unpack(q);
+[ (-1)*e, 0*e, (-1)*i, j ]
+gap> MultVectorRight(q, 1);
+gap> Unpack(q);
+[ (-1)*e, 0*e, (-1)*i, j ]
+gap> MultVectorRight(q, Q.2, 3, 4);
+gap> Unpack(q);
+[ (-1)*e, 0*e, e, (-1)*k ]
+gap> MultVectorLeft(q, Q.2, 3, 4);
+gap> Unpack(q);
+[ (-1)*e, 0*e, i, j ]
+gap> STOP_TEST("MultVector.tst");


### PR DESCRIPTION
With PR #2640 merged, I am submitting the remaining MatrixObj changes as separate PRs.

This contains @ssiccha work on `MultRowVector` resp. `MultVector` from PR #1685. I think these change are fine, but perhaps we want to squash them into a single commit (and/or split them differently across commits than right now). Also, the changes are a bit more extensive, and I felt it was best to give people a chance to review them separately once again (back then, @frankluebeck briefly commented on the PR, but I think I was the only one to extensively review it.

@ssiccha feel free to approve, even though these are your own changes ;-). In fact, that means you are uniquely qualified to review this now ;-).