### PR TITLE
kernel: encapsulate syBuf and syBuffers

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -2015,7 +2015,7 @@ Obj FuncIS_INPUT_TTY(Obj self)
     GAP_ASSERT(IO()->Input);
     if (IO()->Input->isstream)
         return False;
-    return syBuf[IO()->Input->file].isTTY ? True : False;
+    return SyBufIsTTY(IO()->Input->file) ? True : False;
 }
 
 Obj FuncIS_OUTPUT_TTY(Obj self)
@@ -2023,7 +2023,7 @@ Obj FuncIS_OUTPUT_TTY(Obj self)
     GAP_ASSERT(IO()->Output);
     if (IO()->Output->isstream)
         return False;
-    return syBuf[IO()->Output->file].isTTY ? True : False;
+    return SyBufIsTTY(IO()->Output->file) ? True : False;
 }
 
 Obj FuncGET_FILENAME_CACHE(Obj self)

--- a/src/streams.c
+++ b/src/streams.c
@@ -1929,21 +1929,19 @@ Obj FuncFD_OF_FILE(Obj self,Obj fid)
 #ifdef HPCGAP
 Obj FuncRAW_MODE_FILE(Obj self, Obj fid, Obj onoff)
 {
-  Int fd;
-  int fdi;
-  while (fid == (Obj) 0 || !(IS_INTOBJ(fid)))
-  {
-    fid = ErrorReturnObj(
-           "<fid> must be a small integer (not a %s)",
-           (Int)TNAM_OBJ(fid),0L,
-           "you can replace <fid> via 'return <fid>;'" );
-  }
-  fd = INT_INTOBJ(fid);
-  fdi = SyBufFileno(fd);
-  if (onoff == False || onoff == Fail)
-    return syStopraw(fdi), False;
-  else
-    return syStartraw(fdi) ? True : False;
+    while (!IS_INTOBJ(fid)) {
+        fid = ErrorReturnObj("<fid> must be a small integer (not a %s)",
+                             (Int)TNAM_OBJ(fid), 0L,
+                             "you can replace <fid> via 'return <fid>;'");
+    }
+
+    Int fd = INT_INTOBJ(fid);
+    if (onoff == False || onoff == Fail) {
+        syStopraw(fd);
+        return False;
+    }
+    else
+        return syStartraw(fd) ? True : False;
 }
 #endif
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -1613,12 +1613,6 @@ Obj FuncPOSITION_FILE (
         return Fail;
     }
 
-    // Need to account for characters in buffer
-    if (syBuf[ifid].bufno >= 0) {
-        UInt bufno = syBuf[ifid].bufno;
-        ret -= syBuffers[bufno].buflen - syBuffers[bufno].bufstart;
-    }
-
     return INTOBJ_INT(ret);
 }
 
@@ -1746,31 +1740,13 @@ Obj FuncREAD_ALL_FILE (
     len = 0;
     lstr = 0;
 
-
-    if (syBuf[ifid].bufno >= 0) {
-        UInt bufno = syBuf[ifid].bufno;
-
-        /* first drain the buffer */
-        lstr = syBuffers[bufno].buflen - syBuffers[bufno].bufstart;
-        if (ilim != -1) {
-            if (lstr > ilim)
-                lstr = ilim;
-            ilim -= lstr;
-        }
-        GROW_STRING(str, lstr);
-        memcpy(CHARS_STRING(str),
-               syBuffers[bufno].buf + syBuffers[bufno].bufstart, lstr);
-        len = lstr;
-        SET_LEN_STRING(str, len);
-        syBuffers[bufno].bufstart += lstr;
-    }
 #ifdef SYS_IS_CYGWIN32
  getmore:
 #endif
     while (ilim == -1 || len < ilim ) {
       if ( len > 0 && !HasAvailableBytes(ifid))
           break;
-      if (syBuf[ifid].isTTY) {
+      if (SyBufIsTTY(ifid)) {
           if (ilim == -1) {
               Pr("#W Warning -- reading to  end of input tty will never "
                  "end\n",
@@ -1789,11 +1765,11 @@ Obj FuncREAD_ALL_FILE (
           do {
               csize =
                   (ilim == -1 || (ilim - len) > 20000) ? 20000 : ilim - len;
-              lstr = SyRead(ifid, buf, csize);
+              lstr = SyReadWithBuffer(ifid, buf, csize);
           } while (lstr == -1 && errno == EAGAIN);
       }
       if (lstr <= 0) {
-          syBuf[ifid].ateof = 1;
+          SyBufSetEOF(ifid);
           break;
       }
       GROW_STRING( str, len+lstr );
@@ -1854,11 +1830,6 @@ Obj FuncSEEK_POSITION_FILE (
             "you can replace <pos> via 'return <pos>;'" );
     }
     
-    if (syBuf[INT_INTOBJ(fid)].bufno >= 0)
-    {
-            syBuffers[syBuf[INT_INTOBJ(fid)].bufno].buflen = 0;
-            syBuffers[syBuf[INT_INTOBJ(fid)].bufno].bufstart = 0;
-    }
     ret = SyFseek( INT_INTOBJ(fid), INT_INTOBJ(pos) );
     return ret == -1 ? Fail : True;
 }
@@ -1951,12 +1922,7 @@ Obj FuncFD_OF_FILE(Obj self,Obj fid)
   }
 
   Int fd = INT_INTOBJ(fid);
-
-  // gzipped files don't have a fd
-  if (syBuf[fd].type == gzip_socket)
-      return INTOBJ_INT(-1);
-
-  Int fdi = syBuf[fd].fp;
+  Int fdi = SyBufFileno(fd);
   return INTOBJ_INT(fdi);
 }
 
@@ -1973,7 +1939,7 @@ Obj FuncRAW_MODE_FILE(Obj self, Obj fid, Obj onoff)
            "you can replace <fid> via 'return <fid>;'" );
   }
   fd = INT_INTOBJ(fid);
-  fdi = syBuf[fd].fp;
+  fdi = SyBufFileno(fd);
   if (onoff == False || onoff == Fail)
     return syStopraw(fdi), False;
   else

--- a/src/system.c
+++ b/src/system.c
@@ -1144,60 +1144,8 @@ void InitSystem (
     }
 
     preAllocAmount = 4*1024*1024;
-    
-    /* open the standard files                                             */
-    struct stat stat_in, stat_out, stat_err;
-    fstat(fileno(stdin), &stat_in);
-    fstat(fileno(stdout), &stat_out);
-    fstat(fileno(stderr), &stat_err);
 
-    // set up stdin
-    syBuf[0].type = raw_socket;
-    syBuf[0].fp = fileno(stdin);
-    syBuf[0].echo = fileno(stdout);
-    syBuf[0].bufno = -1;
-    syBuf[0].isTTY = isatty(fileno(stdin));
-    if (syBuf[0].isTTY) {
-        // if stdin is on a terminal, make sure stdout in on the same terminal
-        if (stat_in.st_dev != stat_out.st_dev ||
-            stat_in.st_ino != stat_out.st_ino)
-            syBuf[0].echo = open( ttyname(fileno(stdin)), O_WRONLY );
-    }
-
-    // set up stdout
-    syBuf[1].type = raw_socket;
-    syBuf[1].echo = syBuf[1].fp = fileno(stdout); 
-    syBuf[1].bufno = -1;
-    syBuf[1].isTTY = isatty(fileno(stdout));
-
-    // set up errin (defaults to stdin, unless stderr is on a terminal)
-    syBuf[2].type = raw_socket;
-    syBuf[2].fp = fileno(stdin);
-    syBuf[2].echo = fileno(stderr);
-    syBuf[2].bufno = -1;
-    syBuf[2].isTTY = isatty(fileno(stderr));
-    if (syBuf[2].isTTY) {
-        // if stderr is on a terminal, make sure errin in on the same terminal
-        if (stat_in.st_dev != stat_err.st_dev ||
-            stat_in.st_ino != stat_err.st_ino)
-            syBuf[2].fp = open( ttyname(fileno(stderr)), O_RDONLY );
-    }
-
-    // set up errout
-    syBuf[3].type = raw_socket;
-    syBuf[3].echo = syBuf[3].fp = fileno(stderr);
-    syBuf[3].bufno = -1;
-
-    // turn off buffering
-    setbuf(stdin, (char *)0);
-    setbuf(stdout, (char *)0);
-    setbuf(stderr, (char *)0);
-
-    for (i = 4; i < ARRAY_SIZE(syBuf); i++)
-        SyMarkBufUnused(i);
-
-    for (i = 0; i < ARRAY_SIZE(syBuffers); i++)
-        syBuffers[i].inuse = 0;
+    InitSysFiles();
 
 #ifdef HAVE_LIBREADLINE
     rl_initialize ();
@@ -1299,10 +1247,7 @@ void InitSystem (
     if ( SyWindow ) {
       /*         SyLineEdit   = 1;
                  SyCTRD       = 1; */
-        syBuf[2].fp = syBuf[0].fp;  syBuf[2].echo = syBuf[0].echo;
-        syBuf[2].isTTY = syBuf[0].isTTY;
-        syBuf[3].fp = syBuf[1].fp;
-        syBuf[3].echo = syBuf[1].echo;
+        SyRedirectStderrToStdOut();
         syWinPut( 0, "@p", "1." );
     }
    


### PR DESCRIPTION
* remove leftovers of pipe support (pipehandle, pipe_socket)
* make SyBufInUse internal
* make SyMarkBufUnused internal and rename to SyBufMarkUnused
* rename SyFileno to SyBufFileno
* add InitSysFiles()
* add SyBufIsTTY()
* add SyReadWithBuffer()
* add SyRedirectStderrToStdOut()
* add SyBufSetEOF()  (this one is a bit of a hack; the EOF handling really should be done inside `sysfiles.c`; but I wanted to keep the change as minimal as possible for now, to avoid regressions)
* make syBuf and syBuffers private