### PR TITLE
kernel: fix `for x in iter do` optimization

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -429,7 +429,7 @@ static ALWAYS_INLINE UInt ExecForHelper(Stat stat, UInt nr)
         /* get the iterator                                                */
         list = CALL_1ARGS( ITERATOR, list );
 
-        if ( CALL_1ARGS( STD_ITER, list ) == True && IS_PREC(list) ) {
+        if (IS_PREC_OR_COMOBJ(list) && CALL_1ARGS(STD_ITER, list) == True) {
             /* this can avoid method selection overhead on iterator        */
             dfun = ElmPRec( list, RNamName("IsDoneIterator") );
             nfun = ElmPRec( list, RNamName("NextIterator") );


### PR DESCRIPTION
This optimization is supposed to bypass method selection overhead for standard
iterators. It was never used, because all our standard iterators are component
objects, but only looked for precords (legacy from GAP 3??).

Also do `IS_PREC_OR_COMOBJ(list)` before `CALL_1ARGS(STD_ITER, list)`.


There are already plenty of tests which exercise the newly enabled code, so I did not add new tests. I also did not try to run any (micro-)benchmarks to find out if this optimization is worth it. OTOH, there is a case to be made that it is unsafe: the method returned by method lookup could change from iteration to iteration, so technically, this optimization is incorrect. But then, I can't imagine any serious code (i.e. not written specifically to triggers this) ever would. 

Still, one may argue that this code should simply be removed, instead of being fixed. I am open to discussing this.