### PR TITLE
Stop out-of-bounds read, and ensure all bytes are used, in FuncIntRandomMT

### DIFF
--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -118,7 +118,7 @@ Obj FuncInitRandomMT( Obj self, Obj initstr)
       mt[i] &= 0xffffffffUL;
       i++; j++;
       if (i>=N) { mt[0] = mt[N-1]; i=1; }
-      if (j>=key_length) j=0;
+      if (4 * j >= byte_key_length) j=0;
   }
   for (k=N-1; k; k--) {
       mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 30)) * 1566083941UL)) - i;

--- a/tst/testinstall/random.tst
+++ b/tst/testinstall/random.tst
@@ -154,5 +154,30 @@ gap> randomTest([1,-6,"cheese", Group(())], Random);
 gap> randomTest(PadicExtensionNumberFamily(3, 5, [1,1,1], [1,1]), Random, function(x,y) return IsPadicExtensionNumber(x); end);
 gap> randomTest(PurePadicNumberFamily(2,20), Random, function(x,y) return IsPurePadicNumber(x); end);
 
+# Test initialising random number generator
+# We take a string and 0-pad it to 4 bytes
+gap> getOneInt := function(str)
+>   Init(GlobalMersenneTwister, str);
+>   return Random([1..100000]);
+> end;;
+gap> getOneInt("") = getOneInt("\000");
+true
+gap> getOneInt("a") = getOneInt("b");
+false
+gap> getOneInt("") = getOneInt("\000\000\000\000");
+true
+gap> getOneInt("a") = getOneInt("a\000");
+true
+gap> getOneInt("a") = getOneInt("a\000\000\000");
+true
+gap> getOneInt("a") = getOneInt("a\000\000\000\000");
+false
+gap> getOneInt("a") = getOneInt("a\000\000\000a\000\000\000");
+false
+gap> getOneInt("a\000\000\000a\000\000\000") = getOneInt("a\000\000\000a");
+true
+gap> getOneInt("a") = getOneInt("a\000\000\000b");
+false
+
 #
 gap> STOP_TEST("random.tst", 1);


### PR DESCRIPTION
This stops FuncIntRandomMT from reading off the end of a bag.

This isn't (currently) an actual problem, as it only reads up to a word-size, which is fine in GASMAN.

This appears to be (based on valgrind testing) the only place where we read a bag in word-sized chunks, where it's not reasonable to make sure the bag is word-sized at construction time.