### PR TITLE
Validate PackageInfo.g when loading packages

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1578,6 +1578,10 @@ InstallGlobalFunction( LoadPackage, function( arg )
         info:= First( PackageInfo( pkgname ),
                       r -> r.InstallationPath = paths[2][ pos ][1] );
 
+        if not ValidatePackageInfo(info) then
+           Print("#E Validation of package ", pkgname, " from ", info.InstallationPath, " failed\n");
+        fi;
+
         # Notify the documentation (for the available version).
         LoadPackageDocumentation( info );
 


### PR DESCRIPTION
This helps package authors notice earlier if a package update they made failed.

One could also be more aggressive and validate every package record as we load it; but I have far too many packages which are not validating sitting around (e.g. undeposited ones from gap-packages)