### PR TITLE
Rename QuaternionGroup to DicyclicGroup, Document IsDihedralGroup and IsQuaternionGroup

### DIFF
--- a/doc/ref/grplib.xml
+++ b/doc/ref/grplib.xml
@@ -89,7 +89,7 @@ calculations.
 <#Include Label="ElementaryAbelianGroup">
 <#Include Label="FreeAbelianGroup">
 <#Include Label="DihedralGroup">
-<#Include Label="QuaternionGroup">
+<#Include Label="DicyclicGroup">
 <#Include Label="ExtraspecialGroup">
 <#Include Label="AlternatingGroup">
 <#Include Label="SymmetricGroup">

--- a/doc/ref/grplib.xml
+++ b/doc/ref/grplib.xml
@@ -89,7 +89,9 @@ calculations.
 <#Include Label="ElementaryAbelianGroup">
 <#Include Label="FreeAbelianGroup">
 <#Include Label="DihedralGroup">
+<#Include Label="IsDihedralGroup">
 <#Include Label="DicyclicGroup">
+<#Include Label="IsQuaternionGroup">
 <#Include Label="ExtraspecialGroup">
 <#Include Label="AlternatingGroup">
 <#Include Label="SymmetricGroup">

--- a/grp/basic.gd
+++ b/grp/basic.gd
@@ -343,31 +343,31 @@ end );
 
 #############################################################################
 ##
-#O  QuaternionGroupCons( <filter>, <n> )
+#O  DicyclicGroupCons( <filter>, <n> )
 ##
 ##  <ManSection>
-##  <Oper Name="QuaternionGroupCons" Arg='filter, n'/>
+##  <Oper Name="DicyclicGroupCons" Arg='filter, n'/>
 ##
 ##  <Description>
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareConstructor( "QuaternionGroupCons", [ IsGroup, IsInt ] );
+DeclareConstructor( "DicyclicGroupCons", [ IsGroup, IsInt ] );
+DeclareSynonym("QuaternionGroupCons", DicyclicGroupCons);
 
 
 #############################################################################
 ##
-#F  QuaternionGroup( [<filt>, ]<n> )  . . . . . . . quaternion group of order <n>
+#F  DicyclicGroup( [<filt>, [<field>, ] ]<n> )  Dicyclic group of order <n>
 ##
-##  <#GAPDoc Label="QuaternionGroup">
+##  <#GAPDoc Label="DicyclicGroup">
 ##  <ManSection>
-##  <Func Name="QuaternionGroup" Arg='[filt, ]n'/>
-##  <Func Name="DicyclicGroup" Arg='[filt, ]n'/>
+##  <Func Name="DicyclicGroup" Arg='[filt, [field, ]]n'/>
+##  <Func Name="QuaternionGroup" Arg='[filt, [field, ]]n'/>
 ##
 ##  <Description>
-##  constructs the generalized quaternion group (or dicyclic group) of size
-##  <A>n</A> in the category given by the filter <A>filt</A>.  Here, <A>n</A>
-##  is a multiple of 4.
+##  constructs the dicyclic group of size <A>n</A> in the category given by the
+##  filter <A>filt</A>. Here, <A>n</A> is a multiple of 4.
 ##  If <A>filt</A> is not given it defaults to <Ref Func="IsPcGroup"/>.
 ##  For more information on possible values of <A>filt</A> see section
 ##  (<Ref Sect="Basic Groups"/>).
@@ -375,8 +375,8 @@ DeclareConstructor( "QuaternionGroupCons", [ IsGroup, IsInt ] );
 ##  degree and minimal dimension in coprime characteristic).
 ##  <P/>
 ##  <Example><![CDATA[
-##  gap> QuaternionGroup(32);
-##  <pc group of size 32 with 5 generators>
+##  gap> DicyclicGroup(24);
+##  <pc group of size 24 with 4 generators>
 ##  gap> g:=QuaternionGroup(IsMatrixGroup,CF(16),32);
 ##  Group([ [ [ 0, 1 ], [ -1, 0 ] ], [ [ E(16), 0 ], [ 0, -E(16)^7 ] ] ])
 ##  ]]></Example>
@@ -384,23 +384,23 @@ DeclareConstructor( "QuaternionGroupCons", [ IsGroup, IsInt ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-BindGlobal( "QuaternionGroup", function ( arg )
+BindGlobal( "DicyclicGroup", function ( arg )
 
   if Length(arg) = 1  then
-    return QuaternionGroupCons( IsPcGroup, arg[1] );
+    return DicyclicGroupCons( IsPcGroup, arg[1] );
   elif IsOperation(arg[1]) then
     if Length(arg) = 2  then
-      return QuaternionGroupCons( arg[1], arg[2] );
+      return DicyclicGroupCons( arg[1], arg[2] );
     elif Length(arg) = 3  then
       # some filters require extra arguments, e.g. IsMatrixGroup + field
-      return QuaternionGroupCons( arg[1], arg[2], arg[3] );
+      return DicyclicGroupCons( arg[1], arg[2], arg[3] );
     fi;
   fi;
-  Error( "usage: QuaternionGroup( [<filter>, ]<size> )" );
+  Error( "usage: DicyclicGroup( [<filter>, [<field>, ] ]<size> )" );
 
 end );
 
-DeclareSynonym( "DicyclicGroup", QuaternionGroup );
+DeclareSynonym( "QuaternionGroup", DicyclicGroup );
 
 
 #############################################################################

--- a/grp/basic.gd
+++ b/grp/basic.gd
@@ -392,21 +392,20 @@ function(args, quaternion)
     local size;
 
     if Length(args) = 1 then
-        res := [ IsPcGroup, args[1] ];
+        args := [ IsPcGroup, args[1] ];
     elif Length(args) = 2 then
-        res := args;
+        # 2 inputs are valid, but we just reuse args
+        # args := args;
     elif Length(args) = 3 then
-        res := args;
-
-        if not IsField(res[2]) then
+        if not IsField(args[2]) then
             ErrorNoReturn("usage: <field> must be a field");
         fi;
     else
         ErrorNoReturn("usage: DicyclicGroup( [<filter>, [<field>, ] ] <size> )");
     fi;
 
-    size := res[Length(res)];
-    if not IsFilter(res[1]) then
+    size := args[Length(args)];
+    if not IsFilter(args[1]) then
         ErrorNoReturn("usage: <filter> must be a filter");
     fi;
 
@@ -428,7 +427,7 @@ function(args, quaternion)
         fi;
     fi;
 
-    return res;
+    return args;
 end);
 
 BindGlobal( "DicyclicGroup",

--- a/grp/basic.gd
+++ b/grp/basic.gd
@@ -367,9 +367,9 @@ DeclareSynonym("QuaternionGroupCons", DicyclicGroupCons);
 ##
 ##  <Description>
 ##  <Ref Func="DicyclicGroup"/> constructs the dicyclic group of size <A>n</A>
-##  in the category given by the #  filter <A>filt</A>. Here, <A>n</A> is a
-##  multiple of 4. <Ref Func="QuaternionGroup"/> is a synonym for
-##  <Ref Func="DicyclicGroup" /> provided for backward compatibility, but will
+##  in the category given by the filter <A>filt</A>. Here, <A>n</A> must be a
+##  multiple of 4. The synonym <Ref Func="QuaternionGroup"/> for
+##  <Ref Func="DicyclicGroup" /> is provided for backward compatibility, but will
 ##  print a warning if <A>n</A> is not a power of <M>2</M>.
 ##  If <A>filt</A> is not given it defaults to <Ref Func="IsPcGroup"/>.
 ##  For more information on possible values of <A>filt</A> see section
@@ -389,23 +389,14 @@ DeclareSynonym("QuaternionGroupCons", DicyclicGroupCons);
 ##
 BindGlobal( "GRPLIB_DicyclicParameterCheck",
 function(args, quaternion)
-    local res, size;
-
-    res := [];
+    local size;
 
     if Length(args) = 1 then
-        res[1] := IsPcGroup;
-        res[2] := args[1];
-        size := res[2];
+        res := [ IsPcGroup, args[1] ];
     elif Length(args) = 2 then
-        res[1] := args[1];
-        res[2] := args[2];
-        size := res[2];
+        res := args;
     elif Length(args) = 3 then
-        res[1] := args[1];
-        res[2] := args[2];
-        res[3] := args[3];
-        size := res[3];
+        res := args;
 
         if not IsField(res[2]) then
             ErrorNoReturn("usage: <field> must be a field");
@@ -414,6 +405,7 @@ function(args, quaternion)
         ErrorNoReturn("usage: DicyclicGroup( [<filter>, [<field>, ] ] <size> )");
     fi;
 
+    size := res[Length(res)];
     if not IsFilter(res[1]) then
         ErrorNoReturn("usage: <filter> must be a filter");
     fi;
@@ -426,8 +418,13 @@ function(args, quaternion)
         if quaternion = "error" then
             ErrorNoReturn("usage: <size> must be a power of 2 and at least 8");
         elif quaternion = "warn" then
-            Info(InfoWarning, 1, "Warning: QuaternionGroup called with <size> ", size,
-                                 " which is less than 8, or not a power of 2.");
+            if not IsPrimePowerInt(size) then
+                Info(InfoWarning, 1, "Warning: QuaternionGroup called with <size> ", size,
+                                     " which is not a power of 2");
+            else
+                Info(InfoWarning, 1, "Warning: QuaternionGroup called with <size> ", size,
+                                     " which is less than 8");
+            fi;
         fi;
     fi;
 

--- a/grp/basic.gd
+++ b/grp/basic.gd
@@ -366,8 +366,11 @@ DeclareSynonym("QuaternionGroupCons", DicyclicGroupCons);
 ##  <Func Name="QuaternionGroup" Arg='[filt, [field, ]]n'/>
 ##
 ##  <Description>
-##  constructs the dicyclic group of size <A>n</A> in the category given by the
-##  filter <A>filt</A>. Here, <A>n</A> is a multiple of 4.
+##  <Ref Func="DicyclicGroup"/> constructs the dicyclic group of size <A>n</A>
+##  in the category given by the #  filter <A>filt</A>. Here, <A>n</A> is a
+##  multiple of 4. <Ref Func="QuaternionGroup"/> is a synonym for
+##  <Ref Func="DicyclicGroup" /> provided for backward compatibility, but will
+##  print a warning if <A>n</A> is not a power of <M>2</M>.
 ##  If <A>filt</A> is not given it defaults to <Ref Func="IsPcGroup"/>.
 ##  For more information on possible values of <A>filt</A> see section
 ##  (<Ref Sect="Basic Groups"/>).
@@ -455,7 +458,7 @@ function(args...)
 
     res := GRPLIB_DicyclicParameterCheck(args, "error");
     grp := CallFuncList(DicyclicGroupCons, res);
-    SetIsQuaternionGroup(grp, true);
+    SetIsGeneralisedQuaternionGroup(grp, true);
 
     return grp;
 end);

--- a/grp/basicfp.gi
+++ b/grp/basicfp.gi
@@ -174,9 +174,9 @@ end );
 
 #############################################################################
 ##
-#M  QuaternionGroupCons( <IsFpGroup and IsFinite>, <n> )
+#M  DicyclicGroupCons( <IsFpGroup and IsFinite>, <n> )
 ##
-InstallMethod( QuaternionGroupCons,
+InstallMethod( DicyclicGroupCons,
     "fp group",
     true,
     [ IsFpGroup and IsFinite,

--- a/grp/basicmat.gi
+++ b/grp/basicmat.gi
@@ -68,23 +68,23 @@ end );
 
 #############################################################################
 ##
-#M  QuaternionGroupCons( <IsMatrixGroup>, <n> )
+#M  DicyclicGroupCons( <IsMatrixGroup>, <n> )
 ##
-InstallMethod( QuaternionGroupCons,
+InstallMethod( DicyclicGroupCons,
     "matrix group for default field",
     true,
     [ IsMatrixGroup and IsFinite,
       IsInt and IsPosRat ],
     0,
 function( filter, n )
-  return QuaternionGroup( filter, Rationals, n );
+  return DicyclicGroup( filter, Rationals, n );
 end );
 
 #############################################################################
 ##
-#M  QuaternionGroupCons( <IsMatrixGroup>, <field>, <n> )
+#M  DicyclicGroupCons( <IsMatrixGroup>, <field>, <n> )
 ##
-InstallOtherMethod( QuaternionGroupCons,
+InstallOtherMethod( DicyclicGroupCons,
     "matrix group for given field",
     true,
     [ IsMatrixGroup and IsFinite,
@@ -103,7 +103,7 @@ function( filter, fld, n )
     one := 1;
   elif Characteristic( fld ) = 0 or (0 = n mod Characteristic( fld ))
   then # XXX: regular rep is not minimal
-    grp := QuaternionGroup( IsPermGroup, n );
+    grp := DicyclicGroup( IsPermGroup, n );
     grp := Group( List( GeneratorsOfGroup( grp ), prm -> PermutationMat( prm, NrMovedPoints( grp ), fld ) ) );
     SetSize( grp, n );
     return grp;

--- a/grp/basicpcg.gi
+++ b/grp/basicpcg.gi
@@ -217,9 +217,9 @@ end );
 
 #############################################################################
 ##
-#M  QuaternionGroupCons( <IsPcGroup and IsFinite>, <n> )
+#M  DicyclicGroupCons( <IsPcGroup and IsFinite>, <n> )
 ##
-InstallMethod( QuaternionGroupCons,
+InstallMethod( DicyclicGroupCons,
     "pc group",
     true,
     [ IsPcGroup and IsFinite,

--- a/grp/basicprm.gi
+++ b/grp/basicprm.gi
@@ -236,9 +236,9 @@ InstallMethod( DihedralGroupCons,
 
 #############################################################################
 ##
-#M  QuaternionGroupCons( <IsPermGroup>, <4n> )
+#M  DicyclicGroupCons( <IsPermGroup>, <4n> )
 ##
-InstallMethod( QuaternionGroupCons,
+InstallMethod( DicyclicGroupCons,
     "perm. group",
     true,
     [ IsPermGroup, IsPosInt ], 0,

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -3220,7 +3220,7 @@ DeclareOperation("CentralizerModulo", [IsGroup,IsGroup,IsObject]);
 ##  <M>U_1:= <A>G</A></M>,
 ##  <M>U_i:= [<A>G</A>, U_{{i-1}}] U_{{i-1}}^{<A>p</A>}</M>.
 ##  <Example><![CDATA[
-##  gap> g:=QuaternionGroup(12);;
+##  gap> g:=DicyclicGroup(12);;
 ##  gap> PCentralSeries(g,2);
 ##  [ <pc group of size 12 with 3 generators>, Group([ y3, y*y3 ]), Group([ y*y3 ]) ]
 ##  gap> g:=SymmetricGroup(4);;
@@ -3250,7 +3250,7 @@ KeyDependentOperation( "PCentralSeries", IsGroup, IsPosInt, "prime" );
 ##  <Ref Func="PCentralSeries"/>.
 ##  <P/>
 ##  <Example><![CDATA[
-##  gap> g:=QuaternionGroup(12);;
+##  gap> g:=DicyclicGroup(12);;
 ##  gap> PRump(g,2) = PCentralSeries(g,2)[2];
 ##  true
 ##  gap> g:=SymmetricGroup(4);;
@@ -3279,7 +3279,7 @@ KeyDependentOperation( "PRump", IsGroup, IsPosInt, "prime" );
 ##  It is the core of a Sylow <A>p</A>-subgroup of <A>G</A>,
 ##  see <Ref Func="Core"/>.
 ##  <Example><![CDATA[
-##  gap> g:=QuaternionGroup(12);;
+##  gap> g:=DicyclicGroup(12);;
 ##  gap> PCore(g,2);
 ##  Group([ y3 ])
 ##  gap> PCore(g,2) = Core(g,SylowSubgroup(g,2));

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -452,6 +452,8 @@ DeclareProperty( "IsDihedralGroup", IsGroup );
 DeclareAttribute( "DihedralGenerators", IsGroup );
 
 InstallTrueMethod( IsGroup, IsDihedralGroup );
+InstallTrueMethod( IsDihedralGroup, HasDihedralGenerators );
+
 
 #############################################################################
 ##
@@ -484,8 +486,9 @@ DeclareAttribute( "GeneralisedQuaternionGenerators", IsGroup );
 DeclareSynonymAttr( "IsQuaternionGroup", IsGeneralisedQuaternionGroup );
 DeclareSynonymAttr( "QuaternionGenerators", GeneralisedQuaternionGenerators );
 
-
 InstallTrueMethod( IsGroup, IsQuaternionGroup );
+InstallTrueMethod( IsGeneralisedQuaternionGroup, HasGeneralisedQuaternionGenerators );
+
 
 #############################################################################
 ##

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -439,8 +439,9 @@ DeclareSynonym( "DecompositionTypes", DecompositionTypesOfGroup );
 ##  <Attr Name="DihedralGenerators" Arg="G"/>
 ##
 ##  <Description>
-##    Indicates whether the group <A>G</A> is a dihedral group.
-##    If it is, methods may set the attribute <C>DihedralGenerators</C> to
+##    <Ref Prop="IsDihedralGroup"/> indicates whether the group <A>G</A> is a
+##   dihedral group. If it is, methods may set the attribute
+##    <Ref Attr="DihedralGenerators" /> to
 ##    [<A>t</A>,<A>s</A>], where <A>t</A> and <A>s</A> are two elements such
 ##    that <A>G</A> = <M>\langle t, s | t^2 = s^n = 1, s^t = s^{-1} \rangle</M>.
 ##  </Description>
@@ -459,21 +460,30 @@ InstallTrueMethod( IsGroup, IsDihedralGroup );
 ##
 ##  <#GAPDoc Label="IsQuaternionGroup">
 ##  <ManSection>
+##  <Prop Name="IsGeneralisedQuaternionGroup" Arg="G"/>
 ##  <Prop Name="IsQuaternionGroup" Arg="G"/>
+##  <Attr Name="GeneralisedQuaternionGenerators" Arg="G"/>
 ##  <Attr Name="QuaternionGenerators" Arg="G"/>
 ##
 ##  <Description>
-##    Indicates whether the group <A>G</A> is a generalized quaternion group 
-##    of size <M>N = 2^(k+1)</M>, <M>k >= 2</M>. If it is, methods may set
-##    the attribute <C>QuaternionGenerators</C> to [<A>t</A>,<A>s</A>],
-##    where <A>t</A> and <A>s</A> are two elements such that <A>G</A> =
+##    <Ref Prop="IsGeneralisedQuaternionGroup"/> indicates whether the group
+##    <A>G</A> is a generalized quaternion group of size <M>N = 2^(k+1)</M>,
+##    <M>k >= 2</M>.
+##    If it is, methods may set the attribute <Ref Attr="GeneralisedQuaternionGenerators" />
+##    to [<A>t</A>,<A>s</A>], where <A>t</A> and <A>s</A> are two elements such that <A>G</A> =
 ##    <M>\langle t, s | s^{(2^k)} = 1, t^2 = s^{(2^k-1)}, s^t = s^{-1} \rangle</M>.
+##    <Ref Prop="IsQuaternionGroup"/> and <Ref Attr="QuaternionGenerators" /> are
+##    provided for backwards compatibility with existing code.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareProperty( "IsQuaternionGroup", IsGroup );
-DeclareAttribute( "QuaternionGenerators", IsGroup );
+DeclareProperty( "IsGeneralisedQuaternionGroup", IsGroup );
+DeclareAttribute( "GeneralisedQuaternionGenerators", IsGroup );
+# Backwards compatibility
+DeclareSynonymAttr( "IsQuaternionGroup", IsGeneralisedQuaternionGroup );
+DeclareSynonymAttr( "QuaternionGenerators", GeneralisedQuaternionGenerators );
+
 
 InstallTrueMethod( IsGroup, IsQuaternionGroup );
 

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -433,6 +433,7 @@ DeclareSynonym( "DecompositionTypes", DecompositionTypesOfGroup );
 #P  IsDihedralGroup( <G> )
 #A  DihedralGenerators( <G> )
 ##
+##  <#GAPDoc Label="IsDihedralGroup">
 ##  <ManSection>
 ##  <Prop Name="IsDihedralGroup" Arg="G"/>
 ##  <Attr Name="DihedralGenerators" Arg="G"/>
@@ -441,9 +442,10 @@ DeclareSynonym( "DecompositionTypes", DecompositionTypesOfGroup );
 ##    Indicates whether the group <A>G</A> is a dihedral group.
 ##    If it is, methods may set the attribute <C>DihedralGenerators</C> to
 ##    [<A>t</A>,<A>s</A>], where <A>t</A> and <A>s</A> are two elements such
-##    that <A>G</A> = <M><A>t, s | t^2 = s^n = 1, s^t = s^-1</A></M>.
+##    that <A>G</A> = <M>\langle t, s | t^2 = s^n = 1, s^t = s^{-1} \rangle</M>.
 ##  </Description>
 ##  </ManSection>
+##  <#/GAPDoc>
 ##
 DeclareProperty( "IsDihedralGroup", IsGroup );
 DeclareAttribute( "DihedralGenerators", IsGroup );
@@ -455,6 +457,7 @@ InstallTrueMethod( IsGroup, IsDihedralGroup );
 #P  IsQuaternionGroup( <G> )
 #A  QuaternionGenerators( <G> )
 ##
+##  <#GAPDoc Label="IsQuaternionGroup">
 ##  <ManSection>
 ##  <Prop Name="IsQuaternionGroup" Arg="G"/>
 ##  <Attr Name="QuaternionGenerators" Arg="G"/>
@@ -464,9 +467,10 @@ InstallTrueMethod( IsGroup, IsDihedralGroup );
 ##    of size <M>N = 2^(k+1)</M>, <M>k >= 2</M>. If it is, methods may set
 ##    the attribute <C>QuaternionGenerators</C> to [<A>t</A>,<A>s</A>],
 ##    where <A>t</A> and <A>s</A> are two elements such that <A>G</A> =
-##    <M><A>t, s | s^(2^k) = 1, t^2 = s^(2^k-1), s^t = s^-1</A></M>.
+##    <M>\langle t, s | s^{(2^k)} = 1, t^2 = s^{(2^k-1)}, s^t = s^{-1} \rangle</M>.
 ##  </Description>
 ##  </ManSection>
+##  <#/GAPDoc>
 ##
 DeclareProperty( "IsQuaternionGroup", IsGroup );
 DeclareAttribute( "QuaternionGenerators", IsGroup );

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -994,13 +994,11 @@ InstallMethod( IsDihedralGroup,
 function(G)
     local gens;
 
-    if not HasDihedralGenerators(G) then
-        gens := DoComputeDihedralGenerators(G);
-        if gens = fail then
-            return false;
-        else
-            SetDihedralGenerators(G, gens);
-        fi;
+    gens := DoComputeDihedralGenerators(G);
+    if gens = fail then
+        return false;
+    else
+        SetDihedralGenerators(G, gens);
     fi;
     return true;
 end);
@@ -1012,10 +1010,10 @@ function(G)
     local gens;
 
     gens := DoComputeDihedralGenerators(G);
+    SetIsDihedralGroup(G, gens <> fail);
     if gens = fail then
         ErrorNoReturn("G is not a dihedral group");
     fi;
-    SetIsDihedralGroup(G, true);
     return gens;
 end);
 
@@ -1072,13 +1070,11 @@ InstallMethod( IsGeneralisedQuaternionGroup,
 function(G)
     local gens;
 
-    if not HasGeneralisedQuaternionGenerators(G) then
-        gens := DoComputeGeneralisedQuaternionGenerators(G);
-        if gens = fail then
-            return false;
-        else
-            SetGeneralisedQuaternionGenerators(G, gens);
-        fi;
+    gens := DoComputeGeneralisedQuaternionGenerators(G);
+    if gens = fail then
+        return false;
+    else
+        SetGeneralisedQuaternionGenerators(G, gens);
     fi;
     return true;
 end);
@@ -1090,10 +1086,10 @@ function(G)
     local gens;
 
     gens := DoComputeGeneralisedQuaternionGenerators(G);
+    SetIsGeneralisedQuaternionGroup(G, gens <> fail);
     if gens = fail then
         ErrorNoReturn("G is not a generalised quaternion group");
     fi;
-    SetIsGeneralisedQuaternionGroup(G, true);
     return gens;
 end);
 #############################################################################

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -295,8 +295,10 @@ gap> GeneralisedQuaternionGroup(IsMatrixGroup, 32);
 gap> F:=FunctionField(GF(16),1);;
 gap> Q:=GeneralisedQuaternionGroup(IsMatrixGroup, F, 256); 
 <matrix group of size 256 with 2 generators>
-gap> HasIsQuaternionGroup(Q);
+gap> HasIsGeneralisedQuaternionGroup(Q);
 true
+gap> GeneralisedQuaternionGenerators(Q);
+
 gap> Unbind(F);; Unbind(Q);;
 
 #

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -225,6 +225,32 @@ Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 2nd choice method found for `DihedralGroupCons' on 2 arguments
 
 #
+gap> Q := DihedralGroup(32);;
+gap> gens := DihedralGenerators(Q);;
+gap> Group(gens) = Q;
+true
+gap> Q := Group(GeneratorsOfGroup(DihedralGroup(IsPermGroup, 32)));;
+gap> HasIsDihedralGroup(Q);
+false
+gap> HasDihedralGenerators(Q);
+false
+gap> gens := DihedralGenerators(Q);;
+gap> Group(gens) = Q;
+true
+gap> IsDihedralGroup(Q);
+true
+gap> Q := Group(GeneratorsOfGroup(DihedralGroup(IsPermGroup, 32)));;
+gap> HasIsDihedralGroup(Q);
+false
+gap> HasDihedralGenerators(Q);
+false
+gap> IsDihedralGroup(Q);
+true
+gap> HasDihedralGenerators(Q);
+true
+gap> Unbind(F);; Unbind(Q);;
+
+#
 # dicyclic groups
 #
 gap> IdGroup(DicyclicGroup(4));
@@ -288,8 +314,11 @@ gap> QuaternionGroup(11);
 Error, usage: <size> must be a positive integer divisible by 4
 gap> GeneralisedQuaternionGroup(16);
 <pc group of size 16 with 4 generators>
-gap> GeneralisedQuaternionGroup(IsFpGroup, 32);
+gap> Q := GeneralisedQuaternionGroup(IsFpGroup, 32);
 <fp group of size 32 on the generators [ r, s ]>
+gap> gens := GeneralisedQuaternionGenerators(Q);;
+gap> Group(gens) = Q;
+true
 gap> GeneralisedQuaternionGroup(IsMatrixGroup, 32);
 <matrix group of size 32 with 2 generators>
 gap> F:=FunctionField(GF(16),1);;
@@ -297,8 +326,25 @@ gap> Q:=GeneralisedQuaternionGroup(IsMatrixGroup, F, 256);
 <matrix group of size 256 with 2 generators>
 gap> HasIsGeneralisedQuaternionGroup(Q);
 true
-gap> GeneralisedQuaternionGenerators(Q);
-
+gap> Q := Group(GeneratorsOfGroup(GeneralisedQuaternionGroup(IsPermGroup, 32)));;
+gap> HasIsGeneralisedQuaternionGroup(Q);
+false
+gap> HasGeneralisedQuaternionGenerators(Q);
+false
+gap> gens := GeneralisedQuaternionGenerators(Q);;
+gap> Group(gens) = Q;
+true
+gap> IsGeneralisedQuaternionGroup(Q);
+true
+gap> Q := Group(GeneratorsOfGroup(GeneralisedQuaternionGroup(IsPermGroup, 32)));;
+gap> HasIsGeneralisedQuaternionGroup(Q);
+false
+gap> HasGeneralisedQuaternionGenerators(Q);
+false
+gap> IsGeneralisedQuaternionGroup(Q);
+true
+gap> HasGeneralisedQuaternionGenerators(Q);
+true
 gap> Unbind(F);; Unbind(Q);;
 
 #

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -225,7 +225,7 @@ Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 2nd choice method found for `DihedralGroupCons' on 2 arguments
 
 #
-# quaternion groups
+# dicyclic groups
 #
 gap> IdGroup(DicyclicGroup(4));
 [ 4, 1 ]
@@ -263,19 +263,41 @@ gap> DimensionOfMatrixGroup(G);
 
 #
 gap> DicyclicGroup(2,3);
-Error, usage: DicyclicGroup( [<filter>, [<field>, ] ]<size> )
+Error, usage: <filter> must be a filter
 gap> DicyclicGroup(IsRing,3);
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `DicyclicGroupCons' on 2 arguments
+Error, usage: <size> must be a positive integer divisible by 4
 gap> DicyclicGroup(0);
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `DicyclicGroupCons' on 2 arguments
+Error, usage: <size> must be a positive integer divisible by 4
 gap> DicyclicGroup(1);
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 2nd choice method found for `DicyclicGroupCons' on 2 arguments
+Error, usage: <size> must be a positive integer divisible by 4
 gap> DicyclicGroup(IsFpGroup,1);
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 2nd choice method found for `DicyclicGroupCons' on 2 arguments
+Error, usage: <size> must be a positive integer divisible by 4
+
+#
+# (generalised) quaternion groups
+#
+gap> QuaternionGroup(4);
+#I  Warning: QuaternionGroup called with <size> 4 which is less than 8, or not a power of 2.
+<pc group of size 4 with 2 generators>
+gap> QuaternionGroup(8);
+<pc group of size 8 with 3 generators>
+gap> QuaternionGroup(12);
+#I  Warning: QuaternionGroup called with <size> 12 which is less than 8, or not a power of 2.
+<pc group of size 12 with 3 generators>
+gap> QuaternionGroup(11);
+Error, usage: <size> must be a positive integer divisible by 4
+gap> GeneralisedQuaternionGroup(16);
+<pc group of size 16 with 4 generators>
+gap> GeneralisedQuaternionGroup(IsFpGroup, 32);
+<fp group of size 32 on the generators [ r, s ]>
+gap> GeneralisedQuaternionGroup(IsMatrixGroup, 32);
+<matrix group of size 32 with 2 generators>
+gap> F:=FunctionField(GF(16),1);;
+gap> Q:=GeneralisedQuaternionGroup(IsMatrixGroup, F, 256); 
+<matrix group of size 256 with 2 generators>
+gap> HasIsQuaternionGroup(Q);
+true
+gap> Unbind(F);; Unbind(Q);;
 
 #
 # elementary abelian groups

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -227,55 +227,55 @@ Error, no 2nd choice method found for `DihedralGroupCons' on 2 arguments
 #
 # quaternion groups
 #
-gap> IdGroup(QuaternionGroup(4));
+gap> IdGroup(DicyclicGroup(4));
 [ 4, 1 ]
-gap> IdGroup(QuaternionGroup(IsFpGroup,4));
+gap> IdGroup(DicyclicGroup(IsFpGroup,4));
 [ 4, 1 ]
-gap> QuaternionGroup(8);
+gap> DicyclicGroup(8);
 <pc group of size 8 with 3 generators>
-gap> QuaternionGroup(IsPcGroup,8);
+gap> DicyclicGroup(IsPcGroup,8);
 <pc group of size 8 with 3 generators>
-gap> QuaternionGroup(IsPermGroup,8);
+gap> DicyclicGroup(IsPermGroup,8);
 Group([ (1,5,3,7)(2,8,4,6), (1,2,3,4)(5,6,7,8) ])
-gap> QuaternionGroup(IsFpGroup,8);
+gap> DicyclicGroup(IsFpGroup,8);
 <fp group of size 8 on the generators [ r, s ]>
-gap> G:=QuaternionGroup(IsMatrixGroup, 8);
+gap> G:=DicyclicGroup(IsMatrixGroup, 8);
 <matrix group of size 8 with 2 generators>
 gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
 Rationals
 4
-gap> G:=QuaternionGroup(IsMatrixGroup, GF(2), 8);
+gap> G:=DicyclicGroup(IsMatrixGroup, GF(2), 8);
 <matrix group of size 8 with 2 generators>
 gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
 GF(2)
 8
-gap> G:=QuaternionGroup(IsMatrixGroup, GF(3), 8);
+gap> G:=DicyclicGroup(IsMatrixGroup, GF(3), 8);
 <matrix group of size 8 with 2 generators>
 gap> FieldOfMatrixGroup(G); DimensionOfMatrixGroup(G);
 GF(3)
 4
 gap> F:=FunctionField(GF(3),["t"]);
 FunctionField(...,[ t ])
-gap> G:=QuaternionGroup(IsMatrixGroup, F, 8);
+gap> G:=DicyclicGroup(IsMatrixGroup, F, 8);
 <matrix group of size 8 with 2 generators>
 gap> DimensionOfMatrixGroup(G);
 4
 
 #
-gap> QuaternionGroup(2,3);
-Error, usage: QuaternionGroup( [<filter>, ]<size> )
-gap> QuaternionGroup(IsRing,3);
+gap> DicyclicGroup(2,3);
+Error, usage: DicyclicGroup( [<filter>, [<field>, ] ]<size> )
+gap> DicyclicGroup(IsRing,3);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `QuaternionGroupCons' on 2 arguments
-gap> QuaternionGroup(0);
+Error, no 1st choice method found for `DicyclicGroupCons' on 2 arguments
+gap> DicyclicGroup(0);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `QuaternionGroupCons' on 2 arguments
-gap> QuaternionGroup(1);
+Error, no 1st choice method found for `DicyclicGroupCons' on 2 arguments
+gap> DicyclicGroup(1);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 2nd choice method found for `QuaternionGroupCons' on 2 arguments
-gap> QuaternionGroup(IsFpGroup,1);
+Error, no 2nd choice method found for `DicyclicGroupCons' on 2 arguments
+gap> DicyclicGroup(IsFpGroup,1);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 2nd choice method found for `QuaternionGroupCons' on 2 arguments
+Error, no 2nd choice method found for `DicyclicGroupCons' on 2 arguments
 
 #
 # elementary abelian groups

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -303,12 +303,12 @@ Error, usage: <size> must be a positive integer divisible by 4
 # (generalised) quaternion groups
 #
 gap> QuaternionGroup(4);
-#I  Warning: QuaternionGroup called with <size> 4 which is less than 8, or not a power of 2.
+#I  Warning: QuaternionGroup called with <size> 4 which is less than 8
 <pc group of size 4 with 2 generators>
 gap> QuaternionGroup(8);
 <pc group of size 8 with 3 generators>
 gap> QuaternionGroup(12);
-#I  Warning: QuaternionGroup called with <size> 12 which is less than 8, or not a power of 2.
+#I  Warning: QuaternionGroup called with <size> 12 which is not a power of 2
 <pc group of size 12 with 3 generators>
 gap> QuaternionGroup(11);
 Error, usage: <size> must be a positive integer divisible by 4


### PR DESCRIPTION
This PR renames `QuaternionGroup` to `DicyclicGroup` and `QuaternionGroupCons` to `DicyclicGroupCons`. 

This is because these functions/constructors allow creation of groups that are not strictly speaking (generalised) quaternion groups: Their only requirement is that the given size of the group is a multiple of four, but the common definition of a generalised quaternion group is that its size is a power of 2 greater than 8. 

The polycyclic package installs a method for `QuaternionGroupCons` which should probably be changed to `DicyclicGroupCons` as well, as it happily produces Dicyclic groups. I'll submit a PR for polycyclic, but have left the declaration of `QuaternionGroupCons` in here for the time being to not break code.

Additionally we enable existing documentation for `IsDihedralGroup` and `IsQuaternionGroup`, methods to recognise whether a given group is a dihedral group or a (generalised) quaternion group: Issue #2725 arose because one could create a group using `QuaternionGroup` for which `IsQuaternionGroup` was `false`. 

Closes #2725 