### PR TITLE
Add kernel helper IS_FILTER, other tweaks

### DIFF
--- a/lib/filter.g
+++ b/lib/filter.g
@@ -359,11 +359,7 @@ end);
 ##  We handle IsObject as a special case, as it is equal to ReturnTrue,
 ##  as all objects satisfy IsObject!
 ##
-BIND_GLOBAL( "IsFilter",
-    x -> IS_IDENTICAL_OBJ(x, IS_OBJECT)
-         or ( IS_OPERATION( x ) and NARG_FUNC( x ) = 1
-              and ( (FLAG1_FILTER( x ) <> 0 and FLAGS_FILTER(x) <> false)
-                    or IS_ELEMENTARY_FILTER(x) ) ) );
+BIND_GLOBAL( "IsFilter", IS_FILTER );
 
 
 ## Global Rank declarations

--- a/src/opers.c
+++ b/src/opers.c
@@ -1195,6 +1195,7 @@ Obj NewFilter (
     flags = NEW_FLAGS( flag1 );
     SET_ELM_FLAGS( flags, flag1, True );
     SET_FLAGS_FILT(getter, flags);
+    SET_IS_FILTER(getter);
     CHANGED_BAG(getter);
 
     setter = NewSetterFilter( getter );
@@ -1203,6 +1204,11 @@ Obj NewFilter (
     CHANGED_BAG(getter);
 
     return getter;    
+}
+
+Obj FuncIS_FILTER(Obj self, Obj obj)
+{
+    return IS_FILTER(obj) ? True : False;
 }
 
 
@@ -1267,6 +1273,7 @@ Obj NewAndFilter (
     SET_FLAGS_FILT(getter, flags);
     SET_SETTR_FILT(getter, INTOBJ_INT(0xBADBABE));
     SET_TESTR_FILT(getter, INTOBJ_INT(0xBADBABE));
+    SET_IS_FILTER(getter);
     CHANGED_BAG(getter);
 
     return getter;
@@ -1344,6 +1351,7 @@ Obj NewReturnTrueFilter ( void )
     SET_FLAG2_FILT(getter, INTOBJ_INT(0));
     flags = NEW_FLAGS( 0 );
     SET_FLAGS_FILT(getter, flags);
+    SET_IS_FILTER(getter);
     CHANGED_BAG(getter);
 
     setter = SetterReturnTrueFilter( getter );
@@ -2810,6 +2818,7 @@ static Obj MakeTester( Obj name, Int flag1, Int flag2)
     SET_FLAGS_FILT(tester, flags);
     SET_SETTR_FILT(tester, 0);
     SET_TESTR_FILT(tester, ReturnTrueFilter);
+    SET_IS_FILTER(tester);
     CHANGED_BAG(tester);
     return tester;
 }
@@ -3105,7 +3114,8 @@ Obj NewProperty (
     SET_FLAGS_FILT(getter, flags);
     SET_SETTR_FILT(getter, setter);
     SET_TESTR_FILT(getter, tester);
-    SET_ENABLED_ATTR(getter,1);
+    SET_ENABLED_ATTR(getter, 1);
+    SET_IS_FILTER(getter);
     CHANGED_BAG(getter);
 
     /*N 1996/06/28 mschoene bad hack see comment in <setter>               */
@@ -3214,7 +3224,7 @@ void SaveOperationExtras (
     SaveSubObj(header->flags);
     SaveSubObj(header->setter);
     SaveSubObj(header->tester);
-    SaveSubObj(header->enabled);
+    SaveSubObj(header->extra);
     for (UInt i = 0; i <= 7; i++)
         SaveSubObj(header->methods[i]);
 #ifdef HPCGAP
@@ -3245,7 +3255,7 @@ void LoadOperationExtras (
     header->flags = LoadSubObj();
     header->setter = LoadSubObj();
     header->tester = LoadSubObj();
-    header->enabled = LoadSubObj();
+    header->extra = LoadSubObj();
     for (UInt i = 0; i <= 7; i++)
         header->methods[i] = LoadSubObj();
 #ifdef HPCGAP
@@ -3990,6 +4000,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(CLEAR_CACHE_INFO, 0, ""),
     GVAR_FUNC(SET_ATTRIBUTE_STORING, 2, "attr, val"),
     GVAR_FUNC(DO_NOTHING_SETTER, 2, "obj, val"),
+    GVAR_FUNC(IS_FILTER, 1, "obj"),
     GVAR_FUNC(IS_AND_FILTER, 1, "filter"),
     GVAR_FUNC(IS_CONSTRUCTOR, 1, "x"),
     GVAR_FUNC(COMPACT_TYPE_IDS, 0, ""),

--- a/src/opers.c
+++ b/src/opers.c
@@ -1299,12 +1299,6 @@ Obj ReturnTrueFilter;
 **
 *F  NewReturnTrueFilter() . . . . . . . . . . create a new return true filter
 */
-Obj TesterReturnTrueFilter (
-    Obj                 getter )
-{
-    return getter;
-}
-
 Obj DoSetReturnTrueFilter (
     Obj                 self,
     Obj                 obj,
@@ -1344,7 +1338,6 @@ Obj NewReturnTrueFilter ( void )
 {
     Obj                 getter;
     Obj                 setter;
-    Obj                 tester;
     Obj                 flags;
 
     getter = NewFunctionT( T_FUNCTION, sizeof(OperBag),
@@ -1361,9 +1354,8 @@ Obj NewReturnTrueFilter ( void )
     SET_SETTR_FILT(getter, setter);
     CHANGED_BAG(getter);
 
-    tester = TesterReturnTrueFilter( getter );
-    SET_TESTR_FILT(getter, tester);
-    CHANGED_BAG(getter);
+    // the tester also returns true, so we can reuse the getter
+    SET_TESTR_FILT(getter, getter);
         
     return getter;
 }

--- a/src/opers.c
+++ b/src/opers.c
@@ -1254,6 +1254,9 @@ Obj NewAndFilter (
     if ( oper2 == ReturnTrueFilter )
         return oper1;
 
+    if ( oper1 == oper2 )
+        return oper1;
+
     str_len = GET_LEN_STRING(NAME_FUNC(oper1)) + GET_LEN_STRING(NAME_FUNC(oper2)) + 8;
     str = NEW_STRING(str_len);
     s = CSTR_STRING(str);


### PR DESCRIPTION
In particular, before this PR, we get this:
```
gap> Center and IsAssociative;
<Filter "(Centre and IsAssociative)">
gap> FirstOp and IsAssociative;
Error, <flags1> must be a flags list (not a boolean or fail)
```
Note that Center is an attribute, not a filter.

With this PR:
```
gap> Center and IsAssociative;
Error, <expr> must be 'true' or 'false' or a filter (not a function)
gap> FirstOp and IsAssociative;
Error, <expr> must be 'true' or 'false' or a filter (not a function)
```

In addition, argument validation for `and` differed slightly between interpreter and executor, which this PR also fixes.


I am on the fence whether this should be considered relevant for the release notes. On the one hand, probably nobody ever noticed these quirks. On the other, this is a change in what kind of inputs GAP accepts...