### PR TITLE
Clean up Weak Dead bags function

### DIFF
--- a/dev/manualchapters
+++ b/dev/manualchapters
@@ -2143,7 +2143,7 @@ look worse than others)
   For example, recently they turned out to be very useful in a package
   about homology (by Barakat et al.): AK: reduced the level of warning.
 -4 cross-references to the undocumented functions MarkBagWeakly, MARK_BAG,
-  IS_WEAK_DEAD_BAG, ListsFamily.
+  IsWeakDeadBag, ListsFamily.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Chapter 87: Stabilizer Chains (preliminary)
 % File: ./stbchain.xml (line 10)

--- a/doc/dev/kernel.xml
+++ b/doc/dev/kernel.xml
@@ -320,7 +320,7 @@ marking functions  of weak pointer objects.  A  bag which is  marked both
 weakly and strongly  is treated as strongly marked.   A bag which is only
 weakly marked will be recovered by garbage collection, but its identifier
 remains, marked      in   a    way    which   can     be   detected    by
-<C>IS_WEAK_DEAD_BAG</C>. This should  always be checked before copying or
+<C>IsWeakDeadBag</C>. This should  always be checked before copying or
 using such an identifier.
 <P/>
 &GASMAN; already provides the following standard 

--- a/doc/ref/weakptr.xml
+++ b/doc/ref/weakptr.xml
@@ -240,7 +240,7 @@ their subobjects must meet three conditions.
 Firstly, the marking function installed for that tnum must use
 <C>MarkBagWeakly</C> for those subbags, rather than <C>MarkBag</C>.
 Secondly, before any access to such a subbag, it must be checked with
-<C>IS_WEAK_DEAD_BAG</C>.
+<C>IsWeakDeadBag</C>.
 If that returns <K>true</K>, then the subbag has evaporated in a recent garbage
 collection and must not be accessed.
 Typically the reference to it should be removed.

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -754,8 +754,12 @@ void MarkBagWeakly(Bag bag)
 
 Int IsWeakDeadBag(Bag bag)
 {
-    return (((UInt)bag & (sizeof(Bag) - 1)) == 0) && (Bag)MptrBags <= bag &&
-           bag < (Bag)MptrEndBags && (((UInt)*bag) & (sizeof(Bag) - 1)) == 1;
+    CANARY_DISABLE_VALGRIND();
+    Int isWeakDeadBag = (((UInt)bag & (sizeof(Bag) - 1)) == 0) &&
+                        (Bag)MptrBags <= bag && bag < (Bag)MptrEndBags &&
+                        (((UInt)*bag) & (sizeof(Bag) - 1)) == 1;
+    CANARY_ENABLE_VALGRIND();
+    return isWeakDeadBag;
 }
 
 

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -752,7 +752,7 @@ void MarkBagWeakly(Bag bag)
     }
 }
 
-Int IS_WEAK_DEAD_BAG(Bag bag)
+Int IsWeakDeadBag(Bag bag)
 {
     return (((UInt)bag & (sizeof(Bag) - 1)) == 0) && (Bag)MptrBags <= bag &&
            bag < (Bag)MptrEndBags && (((UInt)*bag) & (sizeof(Bag) - 1)) == 1;
@@ -1892,7 +1892,7 @@ linked from weak pointer objects but whose bag bodies have been
 collected.  Two values are used so that old masterpointers of this
 kind can be reclaimed after a full garbage collection. The values must
 not look like valid pointers, and should be congruent to 1 mod sizeof(Bag),
-to ensure that IS_WEAK_DEAD_BAG works correctly.
+to ensure that IsWeakDeadBag works correctly.
 */
 
 Bag * NewWeakDeadBagMarker = (Bag *)(1000*sizeof(Bag) + 1L);

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -752,6 +752,12 @@ void MarkBagWeakly(Bag bag)
     }
 }
 
+Int IS_WEAK_DEAD_BAG(Bag bag)
+{
+    return (((UInt)bag & (sizeof(Bag) - 1)) == 0) && (Bag)MptrBags <= bag &&
+           bag < (Bag)MptrEndBags && (((UInt)*bag) & (sizeof(Bag) - 1)) == 1;
+}
+
 
 /****************************************************************************
 **

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -192,7 +192,10 @@ static inline void CLEAR_BAG_FLAG(Bag bag, uint8_t flag)
 **
 **  See also 'IS_INTOBJ' and 'IS_FFE'.
 */
-#define IS_BAG_REF(bag) (bag && !((Int)(bag)& 0x03))
+static inline Int IS_BAG_REF(Obj bag)
+{
+    return bag && !((Int)bag & 0x03);
+}
 
 
 /****************************************************************************

--- a/src/gasman_intern.h
+++ b/src/gasman_intern.h
@@ -17,20 +17,20 @@
 **  weakly and strongly  is treated as strongly marked.   A bag which is only
 **  weakly marked will be recovered by garbage collection, but its identifier
 **  remains, marked      in   a    way    which   can     be   detected    by
-**  "IS_WEAK_DEAD_BAG". Which should  always be   checked before copying   or
+**  "IsWeakDeadBag". Which should  always be   checked before copying   or
 **  using such an identifier.
 */
 extern void MarkBagWeakly( Bag bag );
 
 /****************************************************************************
 **
-*F  IS_WEAK_DEAD_BAG(<bag>) . . . . . . . . check if <bag> is a weak dead bag
+*F  IsWeakDeadBag(<bag>) . . . . . . . . check if <bag> is a weak dead bag
 **
-**  'IS_WEAK_DEAD_BAG' checks if <bag> is a master pointer which refers to
+**  'IsWeakDeadBag' checks if <bag> is a master pointer which refers to
 **  an object which was freed as the only references to it were weak.
 **  This is used for implement weak pointer references.
 */
-extern Int IS_WEAK_DEAD_BAG(Bag bag);
+extern Int IsWeakDeadBag(Bag bag);
 
 /****************************************************************************
 **

--- a/src/gasman_intern.h
+++ b/src/gasman_intern.h
@@ -22,6 +22,15 @@
 */
 extern void MarkBagWeakly( Bag bag );
 
+/****************************************************************************
+**
+*F  IS_WEAK_DEAD_BAG(<bag>) . . . . . . . . check if <bag> is a weak dead bag
+**
+**  'IS_WEAK_DEAD_BAG' checks if <bag> is a master pointer which refers to
+**  an object which was freed as the only references to it were weak.
+**  This is used for implement weak pointer references.
+*/
+extern Int IS_WEAK_DEAD_BAG(Bag bag);
 
 /****************************************************************************
 **

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -49,14 +49,7 @@
 *F
 */
 
-#ifdef USE_GASMAN
-
-#define IS_WEAK_DEAD_BAG(bag) ( (((UInt)bag & (sizeof(Bag)-1)) == 0) && \
-                                (Bag)MptrBags <= (bag)    &&          \
-                                (bag) < (Bag)MptrEndBags  &&              \
-                                (((UInt)*bag) & (sizeof(Bag)-1)) == 1)
-
-#elif defined(USE_BOEHM_GC)
+#if defined(USE_BOEHM_GC)
 
 static inline void REGISTER_WP(Obj wp, UInt pos, Obj obj)
 {

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -114,7 +114,7 @@ static inline Obj ELM_WPOBJ(Obj list, UInt pos)
     Bag elm = CONST_ADDR_OBJ(list)[pos];
 
 #ifdef USE_GASMAN
-    if (IS_WEAK_DEAD_BAG(elm)) {
+    if (IsWeakDeadBag(elm)) {
         ADDR_OBJ(list)[pos] = 0;
         return 0;
     }
@@ -615,7 +615,7 @@ static void SweepWeakPointerObj( Bag *src, Bag *dst, UInt len)
   while (len --)
     {
       elm = *src++;
-      *dst ++ = IS_WEAK_DEAD_BAG(elm) ? (Bag) 0 : elm;
+      *dst ++ = IsWeakDeadBag(elm) ? (Bag) 0 : elm;
     }
 }
 


### PR DESCRIPTION
The handling of weak dead bags was previously spread around. This PR moves it all into gasman-related files, and does some minor cleaning / reformatting.

Also (and why I started doing this), make weak dead bags not report warnings when using valgrind.