### PR TITLE
ENHANCE: Improvements to double coset calculations for hard cases

### DIFF
--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -851,12 +851,14 @@ local live,orbs,orbset,done,nr,p,o,os,orbitextender,bahn,i,j,enum,dict,map,pam;
               if IsBound(map[j]) and map[j]>i then map[j]:=map[j]-1; fi;
             od;
 
-            p:=[i..Length(orbs)-1];
-            orbs{p}:=orbs{p+1};Unbind(orbs[Length(orbs)]);
-            orbset{p}:=orbset{p+1};Unbind(orbset[Length(orbset)]);
-            done{p}:=done{p+1};Unbind(done[Length(done)]);
-            bahn{p}:=bahn{p+1};Unbind(bahn[Length(bahn)]);
-            pam{p}:=pam{p+1};Unbind(pam[Length(pam)]);
+            # Remove entry i, i.e.
+            #p:=[i..Length(orbs)-1];
+            #orbs{p}:=orbs{p+1};Unbind(orbs[Length(orbs)]);
+            Remove(orbs,i);
+            Remove(orbset,i);
+            Remove(done,i);
+            Remove(bahn,i);
+            Remove(pam,i);
           else
             done[i]:=-p;
           fi;
@@ -1029,6 +1031,12 @@ local c, flip, maxidx, refineChainActionLimit, cano, tryfct, p, r, t,
 
     fi;
 
+  elif ValueOption("sisyphus")=true then
+    # purely to allow for tests of up-step mechanism in smaller examples.
+    # This is creating unneccessary extra work and thus should never be used
+    # in practice, but will force some code to be run through.
+    c:=Concatenation([TrivialSubgroup(G)],c);
+    cano:=true;
   fi;
 
   r:=[One(G)];

--- a/tst/testextra/doublecoset.tst
+++ b/tst/testextra/doublecoset.tst
@@ -1,0 +1,19 @@
+#############################################################################
+##
+#W  doublecoset.tst                                     Alexander Hulpke
+##
+##
+#Y  Copyright (C)  1997,  Lehrstuhl D für Mathematik,  RWTH Aachen,  Germany
+##
+##  This  file  tests for double coset calculations
+##
+gap> START_TEST("doublecoset.tst");
+gap> g:=SimpleGroup("Co3");;
+gap> m:=MaximalSubgroupClassReps(g);;
+gap> u:=First(m,x->Index(g,x)=17931375);;
+gap> dc:=DoubleCosetRepsAndSizes(g,u,u);;
+gap> Length(dc);Sum(dc,x->x[2])=Size(g);
+913
+true
+
+gap> STOP_TEST( "doublecoset.tst", 1);

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -26,6 +26,14 @@ gap> p:=Image(IsomorphismPermGroup(g));;
 gap> s:=SylowSubgroup(p,7);;
 gap> Length(IntermediateSubgroups(p,s).subgroups);
 71
+gap> g:=SymmetricGroup(9);;s:=SylowSubgroup(g,3);;
+gap> dc:=DoubleCosetRepsAndSizes(g,s,s);;
+gap> Length(dc);Sum(dc,x->x[2])=Size(g);
+88
+true
+gap> dc1:=DoubleCosetRepsAndSizes(g,s,s:sisyphus);;
+gap> Collected(List(dc,x->x[2]))=Collected(List(dc1,x->x[2]));
+true
 
 # Unbind variables so we can GC memory
 gap> Unbind(g); Unbind(dc); Unbind(ac); Unbind(g); Unbind(p); Unbind(s);


### PR DESCRIPTION
Allow for larger up-steps, and improve up-step fusion speed.
Avoid rechecks of transversal steps.

The example I have at hand (H\G/H for G=Fi23, H=S12) runs about two days and thus is not suitable for automatic testing. 

This is unlikely to be urgent, as few users will do such calculations.