### PR TITLE
Fix CanEasilyDetermineCanonicalRepresentativeExternalSet

### DIFF
--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -377,7 +377,7 @@ DeclareAttribute( "CanonicalRepresentativeDeterminatorOfExternalSet",
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareAttribute( "CanEasilyDetermineCanonicalRepresentativeExternalSet",
+DeclareProperty( "CanEasilyDetermineCanonicalRepresentativeExternalSet",
     IsExternalSet );
 
 InstallTrueMethod(CanEasilyDetermineCanonicalRepresentativeExternalSet,


### PR DESCRIPTION
This was declared as an attribute, but should be a property.
Due to a bug in GAP, we nevertheless accept expressions like

    IsExternalOrbit and CanEasilyDetermineCanonicalRepresentativeExternalSet

e.g. when installing methods. But that does *not* do what one might expect in
method selection; rather, it is equivalent to

    IsExternalOrbit and HasCanEasilyDetermineCanonicalRepresentativeExternalSet

as can be verified with this code (only *before* this commit)

    gap> f1 := IsExternalOrbit and CanEasilyDetermineCanonicalRepresentativeExternalSet;;
    gap> f2 := IsExternalOrbit and HasCanEasilyDetermineCanonicalRepresentativeExternalSet;;
    gap> FLAGS_FILTER(f1) = FLAGS_FILTER(f2);
    true


This is part of PR #2732, but should not be delayed by the rest of that PR.