### PR TITLE
kernel: make STATE(Intr*) almost private to intrprtr.c

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -892,18 +892,19 @@ void CodeIfElse ( void )
     CodeTrueExpr();
 }
 
-void CodeIfBeginBody ( void )
+Int CodeIfBeginBody ( void )
 {
     // get and check the condition
     Expr cond = PopExpr();
 
     // if the condition is 'false', ignore the body
     if (TNUM_EXPR(cond) == T_FALSE_EXPR) {
-        STATE(IntrIgnoring) = 1;
+        return 1; // signal interpreter to set IntrIgnoring to 1
     }
     else {
         // put the condition expression back on the stack
         PushExpr(cond);
+        return 0;
     }
 }
 
@@ -917,11 +918,9 @@ Int CodeIfEndBody (
     Expr cond = PopExpr();
     PushExpr(cond);
 
-    // if the condition is 'true', ignore other branches of the if-statement
-    if (TNUM_EXPR(cond) == T_TRUE_EXPR) {
-        STATE(IntrIgnoring) = 1;
-    }
-    return 1;
+    // if the condition is 'true', signal interpreter to set IntrIgnoring to 1,
+    // so that other branches of the if-statement are ignored
+    return TNUM_EXPR(cond) == T_TRUE_EXPR;
 }
 
 void CodeIfEnd (

--- a/src/code.h
+++ b/src/code.h
@@ -678,7 +678,7 @@ extern  void            CodeIfElif ( void );
 
 extern  void            CodeIfElse ( void );
 
-extern  void            CodeIfBeginBody ( void );
+extern  Int             CodeIfBeginBody ( void );
 
 extern  Int             CodeIfEndBody (
             UInt                nr );

--- a/src/gap.c
+++ b/src/gap.c
@@ -1506,8 +1506,6 @@ void ThreadedInterpreter(void *funcargs) {
   int i;
 
   /* initialize everything and begin an interpreter                       */
-  STATE(IntrCoding) = 0;
-  STATE(IntrIgnoring) = 0;
   STATE(NrError) = 0;
   STATE(ThrownObject) = 0;
 
@@ -1759,8 +1757,6 @@ void InitializeGap (
     InitMsgsFuncBags( SyMsgsBags );
 #endif
 
-    STATE(IntrCoding)   = 0;
-    STATE(IntrIgnoring) = 0;
     STATE(NrError)      = 0;
     STATE(ThrownObject) = 0;
     STATE(UserHasQUIT) = 0;

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -181,6 +181,12 @@ static inline void StartFakeFuncExpr(Int startLine)
     // exist, and we have to create an empty local variable names list to
     // match the function expression that we are creating.
     //
+    // Without this, access to variables defined in the existing local
+    // variable context will be coded as LVAR accesses; but when we then
+    // execute this code, they will not actually be available in the current
+    // context, but rather one level up, i.e., they really should have been
+    // coded as HVARs.
+    //
     // If we are not in a break loop, then this would be a waste of time and
     // effort
     if (LEN_PLIST(STATE(StackNams)) > 0) {

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -316,6 +316,16 @@ ExecStatus IntrEnd(UInt error, Obj *result)
 }
 
 
+void IntrAbortCoding(Obj lvars)
+{
+    if (STATE(IntrCoding)) {
+        CodeEnd(1);
+        STATE(IntrCoding)--;
+        SWITCH_TO_OLD_LVARS(lvars);
+    }
+}
+
+
 /****************************************************************************
 **
 *F  IntrFuncCallBegin() . . . . . . . . . . .  interpret function call, begin

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -564,7 +564,10 @@ void            IntrIfBeginBody ( void )
     /* ignore or code                                                      */
     if ( STATE(IntrReturning) > 0 ) { return; }
     if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
-    if ( STATE(IntrCoding)    > 0 ) { CodeIfBeginBody(); return; }
+    if ( STATE(IntrCoding)    > 0 ) {
+        STATE(IntrIgnoring) = CodeIfBeginBody();
+        return;
+    }
 
 
     /* get and check the condition                                         */
@@ -589,7 +592,10 @@ Int            IntrIfEndBody (
     /* ignore or code                                                      */
     if ( STATE(IntrReturning) > 0 ) { return 0; }
     if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)--; return 0; }
-    if ( STATE(IntrCoding)    > 0 ) { return CodeIfEndBody( nr ); }
+    if ( STATE(IntrCoding)    > 0 ) {
+        STATE(IntrIgnoring) = CodeIfEndBody( nr );
+        return 1;
+    }
 
     /* otherwise drop the values for the statements executed in the body   */
     for ( i = nr; 1 <= i; i-- ) {

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -4531,6 +4531,16 @@ static Int InitLibrary (
     return 0;
 }
 
+static Int InitModuleState(void)
+{
+    STATE(IntrCoding) = 0;
+    STATE(IntrIgnoring) = 0;
+    STATE(IntrReturning) = 0;
+
+    // return success
+    return 0;
+}
+
 
 /****************************************************************************
 **
@@ -4543,6 +4553,8 @@ static StructInitInfo module = {
     .name = "intrprtr",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
+
+    .initModuleState = InitModuleState,
 };
 
 StructInitInfo * InitInfoIntrprtr ( void )

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -85,6 +85,16 @@ extern ExecStatus IntrEnd(UInt error, Obj *result);
 
 /****************************************************************************
 **
+*F  IntrAbortCoding(<lvars>) . . . . . . . . . . . . . . . . . . abort coding
+**
+**  'IntrAbortCoding' aborts coding, if it is active, and resets the active
+**  lvars to <lvars>.
+*/
+extern void IntrAbortCoding(Obj lvars);
+
+
+/****************************************************************************
+**
 *F  IntrFuncCallBegin() . . . . . . . . . . .  interpret function call, begin
 *F  IntrFuncCallEnd(<funccall>,<options>,<nr>)  interpret function call, end
 **

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -57,7 +57,11 @@ static void SyntaxErrorOrWarning(const Char * msg, UInt error)
 
         // print the current line
         const char * line = GetInputLineBuffer();
-        Pr("%s", (Int)line, 0);
+        const UInt len = strlen(line);
+        if (len > 0 && line[len-1] != '\n')
+            Pr("%s\n", (Int)line, 0);
+        else
+            Pr("%s", (Int)line, 0);
 
         // print a '^' pointing to the current position
         Int startPos = STATE(SymbolStartPos);

--- a/tst/testinstall/break.tst
+++ b/tst/testinstall/break.tst
@@ -81,6 +81,26 @@ Syntax error: 'QUIT;' cannot be used in this context in stream:1
 for i in [1..5] do QUIT; od;
                    ^^^^
 
+# some more similar tests, which (together with the above)
+# cover all calls to IntrAbortCoding
+gap> while true do QUIT; od;
+Syntax error: 'QUIT;' cannot be used in this context in stream:1
+while true do QUIT; od;
+              ^^^^
+gap> repeat QUIT; until false;
+Syntax error: 'QUIT;' cannot be used in this context in stream:1
+repeat QUIT; until false;
+       ^^^^
+gap> atomic fail do QUIT; od;
+Syntax error: 'QUIT;' cannot be used in this context in stream:1
+atomic fail do QUIT; od;
+               ^^^^
+gap> f:=ReadAsFunction(InputTextString("QUIT; return 1;"));
+Syntax error: 'QUIT;' cannot be used in this context in stream:1
+QUIT; return 1;
+^^^^
+fail
+
 #
 gap> f := function() local i; for i in [1..5] do continue; od; end;;
 gap> f();

--- a/tst/testinstall/kernel/read.tst
+++ b/tst/testinstall/kernel/read.tst
@@ -131,4 +131,82 @@ Syntax error: Badly formed number in stream:1
 ^^^^^
 
 #
+# ReadEvalFile / READ_AS_FUNC / READ_AS_FUNC_STREAM / ReadAsFunction
+#
+gap> f:=ReadAsFunction(InputTextString("return 1;"));
+function(  ) ... end
+gap> Display(f);
+function (  )
+    return 1;
+end
+gap> f();
+1
+gap> f:={} -> ReadAsFunction(InputTextString("return 1;"));;
+gap> f();
+function(  ) ... end
+gap> Display(f());
+function (  )
+    return 1;
+end
+gap> f()();
+1
+
+# check that locals are supported
+gap> f:=ReadAsFunction(InputTextString("local x; x:=1; return x;"));
+function(  ) ... end
+gap> Display(f);
+function (  )
+    local x;
+    x := 1;
+    return x;
+end
+gap> f();
+1
+
+# and nested functions
+gap> f:=ReadAsFunction(InputTextString("local x; x := function(a) return a; end;; return x(1);"));
+function(  ) ... end
+gap> Display(f);
+function (  )
+    local x;
+    x := function ( a )
+          return a;
+      end;
+    return x( 1 );
+end
+gap> f();
+1
+
+# with syntax errors
+gap> f:=ReadAsFunction(InputTextString("return 1"));;
+Syntax error: ; expected in stream:1
+
+gap> f:={} -> ReadAsFunction(InputTextString("return 1"));;
+gap> f();
+Syntax error: ; expected in stream:1
+
+fail
+
+# with execution errors
+gap> f:=ReadAsFunction(InputTextString("return 1/0;"));;
+gap> f();
+Error, Rational operations: <divisor> must not be zero
+gap> f:={} -> ReadAsFunction(InputTextString("return 1/0;"));;
+gap> f();
+function(  ) ... end
+gap> f()();
+Error, Rational operations: <divisor> must not be zero
+
+# with syntax errors nested one level deep
+gap> f:=ReadAsFunction(InputTextString("local x; x := function(a) return a end;; return x(1);"));;
+Syntax error: ; expected in stream:1
+local x; x := function(a) return a end;; return x(1);
+                                   ^^^
+gap> f:={} -> ReadAsFunction(InputTextString("return 1"));;
+gap> f();
+Syntax error: ; expected in stream:1
+
+fail
+
+#
 gap> STOP_TEST("kernel/read.tst", 1);

--- a/tst/testspecial/break-loop-loop.g
+++ b/tst/testspecial/break-loop-loop.g
@@ -1,0 +1,7 @@
+# test iterating over local variables from within a break loop
+f:=function(x) local y; y:=42; Error("bar"); end;;
+i:=0;
+f(1);
+x;
+y;
+for i in [x..y] do od;

--- a/tst/testspecial/break-loop-loop.g.out
+++ b/tst/testspecial/break-loop-loop.g.out
@@ -1,0 +1,16 @@
+gap> # test iterating over local variables from within a break loop
+gap> f:=function(x) local y; y:=42; Error("bar"); end;;
+gap> i:=0;
+0
+gap> f(1);
+Error, bar at *stdin*:3 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:5
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> x;
+1
+brk> y;
+42
+brk> for i in [x..y] do od;
+brk> QUIT;


### PR DESCRIPTION
This is another part of the ongoing effort to separate io, scanner, reader, interpreter and coder.

Right now, read.c still accesses `STATE(Intr*)` as part of saving/restoring the "reader state". While it'd be trivial to encapsulate this by a new getter/setter API, I'd rather rethink how we (re)store this state (and I also have the suspicion that we currently do not (re)store all state we should (re)store, nor do we do this in all places that ought to do it).