### PR TITLE
kernel: catch some invalid uses of '~'; add tests

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2502,7 +2502,7 @@ CVar CompListTildeExpr (
 
     /* remember the old value of '~'                                       */
     tilde = CVAR_TEMP( NewTemp( "tilde" ) );
-    Emit( "%c = STATE( Tilde );\n", tilde );
+    Emit( "%c = STATE(Tilde);\n", tilde );
 
     /* create the list value                                               */
     list = CompListExpr1( expr );
@@ -2718,19 +2718,19 @@ CVar CompRecTildeExpr (
 
     /* remember the old value of '~'                                       */
     tilde = CVAR_TEMP( NewTemp( "tilde" ) );
-    Emit( "%c = STATE( Tilde );\n", tilde );
+    Emit( "%c = STATE(Tilde);\n", tilde );
 
     /* create the record value                                             */
     rec = CompRecExpr1( expr );
 
     /* assign the record value to the variable '~'                         */
-    Emit( "STATE( Tilde ) = %c;\n", rec );
+    Emit( "STATE(Tilde) = %c;\n", rec );
 
     /* evaluate the subexpressions into the record value                   */
     CompRecExpr2( rec, expr );
 
     /* restore the old value of '~'                                        */
-    Emit( "STATE( Tilde ) = %c;\n", tilde );
+    Emit( "STATE(Tilde) = %c;\n", tilde );
     if ( IS_TEMP_CVAR( tilde ) )  FreeTemp( TEMP_CVAR( tilde ) );
 
     /* return the record value                                             */

--- a/src/error.c
+++ b/src/error.c
@@ -255,14 +255,12 @@ Obj FuncCALL_WITH_CATCH(Obj self, Obj func, volatile Obj args)
         SWITCH_TO_OLD_LVARS(currLVars);
         STATE(CurrStat) = currStat;
         SetRecursionDepth(recursionDepth);
-#ifdef HPCGAP
         STATE(Tilde) = tilde;
+#ifdef HPCGAP
         PopRegionLocks(lockSP);
         TLS(currentRegion) = savedRegion;
         if (TLS(CurrentHashLock))
             HashUnlock(TLS(CurrentHashLock));
-#else
-        STATE(Tilde) = tilde;
 #endif
     }
     else {

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -959,7 +959,7 @@ Obj             EvalListTildeExpr (
     Obj                 tilde;          /* old value of tilde              */
 
     /* remember the old value of '~'                                       */
-    tilde = STATE( Tilde );
+    tilde = STATE(Tilde);
 
     /* create the list value                                               */
     list = ListExpr1(expr, 1);
@@ -1309,7 +1309,7 @@ Obj             EvalRecTildeExpr (
     Obj                 tilde;          /* old value of tilde              */
 
     /* remember the old value of '~'                                       */
-    tilde = STATE( Tilde );
+    tilde = STATE(Tilde);
 
     /* create the record value                                             */
     rec = RecExpr1( expr );

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2056,7 +2056,7 @@ void            IntrListExprBegin (
     /* if this is an outmost list, save it for reference in '~'            */
     /* (and save the old value of '~' on the values stack)                 */
     if ( top ) {
-        old = STATE( Tilde );
+        old = STATE(Tilde);
         if ( old != 0 ) { PushObj( old ); }
         else            { PushVoidObj();  }
         STATE(Tilde) = list;
@@ -2270,10 +2270,10 @@ void            IntrRecExprBegin (
     /* if this is an outmost record, save it for reference in '~'          */
     /* (and save the old value of '~' on the values stack)                 */
     if ( top ) {
-        old = STATE( Tilde );
+        old = STATE(Tilde);
         if ( old != 0 ) { PushObj( old ); }
         else            { PushVoidObj();  }
-        STATE( Tilde ) = record;
+        STATE(Tilde) = record;
     }
 
     /* push the record                                                     */

--- a/src/read.c
+++ b/src/read.c
@@ -1080,8 +1080,7 @@ static void ReadRecExpr (
         nr++;
       }
 
-    }
-  while ( STATE(Symbol) == S_COMMA );
+    } while (STATE(Symbol) == S_COMMA);
 
     /* ')'                                                                 */
     Match( S_RPAREN, ")", follow );

--- a/src/read.c
+++ b/src/read.c
@@ -1235,7 +1235,7 @@ static void ReadFuncExprBody(
     // push the new local variables list
     PushPlist(STATE(StackNams), args.nams);
 
-    // begin interpreting the function expression (with 1 argument)
+    // begin interpreting the function expression
     TRY_IF_NO_ERROR {
         IntrFuncExprBegin(args.isvarg ? -args.narg : args.narg, nloc,
                           args.nams, startLine);
@@ -1480,6 +1480,9 @@ static void ReadLiteral (
 
     /* '~'                                                                 */
     case S_TILDE:
+        if (ReaderState()->ReadTop == 0) {
+            SyntaxError("'~' not allowed here");
+        }
         ReaderState()->ReadTilde = 1;
         TRY_IF_NO_ERROR { IntrTildeExpr(); }
         Match( S_TILDE, "~", follow );

--- a/tst/testinstall/interpreter.tst
+++ b/tst/testinstall/interpreter.tst
@@ -40,12 +40,6 @@ gap> ?qwert_asdf
 Help: no matching entry found
 
 #
-# tilde
-#
-gap> ~;
-Error, '~' does not have a value here
-
-#
 # function call with options
 #
 gap> f:=x->ValueOption("a");;

--- a/tst/testinstall/tilde.tst
+++ b/tst/testinstall/tilde.tst
@@ -1,9 +1,13 @@
 gap> START_TEST("tilde.tst");
+
+#
 gap> aqq~ := 1;
 Error, Variable: 'aqq' must have a value
 Syntax error: ; expected in stream:1
 aqq~ := 1;
    ^
+
+#
 gap> l := [2, ~];
 [ 2, ~ ]
 gap> l = l[2];
@@ -18,6 +22,71 @@ gap> r.x;
 rec( x := ~, y := [ 1, 2, ~ ] )
 gap> r.y[3];
 rec( x := ~, y := [ 1, 2, ~ ] )
+
+#
+gap> [ ~ ];
+[ ~ ]
+gap> [ 1, 2, [0 .. Length(~)] ];
+[ 1, 2, [ 0 .. 2 ] ]
+gap> [0, 1 + ~, 2 ];
+[ 0, [ 1 ], 2 ]
+
+#
+gap> [ (x->~)(1) ];
+[ ~ ]
+gap> l := [ x->~ ];  # this function escapes with an invalid tilde reference
+[ function( x ) ... end ]
+gap> f := l[1];;
+gap> f(1);
+Error, '~' does not have a value here
+gap> [ f(1) ];
+[ ~ ]
+
+#
+gap> ~;
+Syntax error: '~' not allowed here in stream:1
+~;
+^
+gap> (1,~);
+Syntax error: '~' not allowed here in stream:1
+(1,~);
+   ^
+gap> x->~;
+Syntax error: '~' not allowed here in stream:1
+x->~;
+   ^
+gap> x -> (1,~);
+Syntax error: '~' not allowed here in stream:1
+x -> (1,~);
+        ^
+
+#
+gap> [1..~];
+Syntax error: Sorry, '~' not allowed in range in stream:1
+[1..~];
+     ^
+gap> [~..1];
+Syntax error: Sorry, '~' not allowed in range in stream:1
+[~..1];
+     ^
+gap> [1,~..5];
+Syntax error: Sorry, '~' not allowed in range in stream:1
+[1,~..5];
+       ^
+gap> x->[1..~];
+Syntax error: Sorry, '~' not allowed in range in stream:1
+x->[1..~];
+        ^
+gap> x->[~..1];
+Syntax error: Sorry, '~' not allowed in range in stream:1
+x->[~..1];
+        ^
+gap> x->[1,~..5];
+Syntax error: Sorry, '~' not allowed in range in stream:1
+x->[1,~..5];
+          ^
+
+#
 gap> f := function(~) local a; end;
 Syntax error: identifier expected in stream:1
 f := function(~) local a; end;
@@ -42,6 +111,8 @@ gap> {~,~} -> 2;
 Syntax error: identifier expected in stream:1
 {~,~} -> 2;
  ^
+
+#
 gap> list1 := [1,~];
 [ 1, ~ ]
 gap> list2 := [1,[1,[1,[1,0]]]];
@@ -96,4 +167,6 @@ gap> [2,rem(~),3,4,rem(~),5,6,rem(~)];
 [ , 1, 3,, 1, 5,, 1 ]
 gap> (function() return  [2,rem(~),3,4,rem(~),5,6,rem(~)]; end)();
 [ , 1, 3,, 1, 5,, 1 ]
+
+#
 gap> STOP_TEST( "tilde.tst", 1);


### PR DESCRIPTION
Also, print a (more) helpful error message.

Before:

    gap> ~;
    Error, '~' does not have a value here
    not in any function at *stdin*:1
    gap> x -> ~;
    function( x ) ... end
    gap> x -> (1,~);
    function( x ) ... end
    gap> (1,~);
    Error, '~' does not have a value here
    not in any function at *stdin*:4

After:

    gap> ~;
    Syntax error: '~' not allowed here
    ~;
    ^
    gap> x -> ~;
    Syntax error: '~' not allowed here
    x -> ~;
         ^
    gap> x -> (1,~);
    Syntax error: '~' not allowed here
    x -> (1,~);
            ^
    gap> (1,~);
    Syntax error: '~' not allowed here
    (1,~);
       ^