### PR TITLE
kernel: rename IS_MUTABLE_PLIST to IS_PLIST_MUTABLE

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -148,7 +148,7 @@ VoidFunc debug_func_pointers[] = {
     (VoidFunc)IS_MODULE_BUILTIN,
     (VoidFunc)IS_MODULE_DYNAMIC,
     (VoidFunc)IS_MODULE_STATIC,
-    (VoidFunc)IS_MUTABLE_PLIST,
+    (VoidFunc)IS_PLIST_MUTABLE,
     (VoidFunc)IS_NONNEG_INTOBJ,
     (VoidFunc)IS_PLIST,
     (VoidFunc)IS_PLIST_OR_POSOBJ,

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -83,7 +83,7 @@ void            AddPlist3 (
 {
   UInt len;
 
-    if ( ! IS_MUTABLE_PLIST(list) ) {
+    if ( ! IS_PLIST_MUTABLE(list) ) {
         list = ErrorReturnObj(
                 "List Assignment: <list> must be a mutable list",
                 0L, 0L,
@@ -200,7 +200,7 @@ Obj            RemPlist (
     Int                 pos;           
     Obj removed; 
 
-    if ( ! IS_MUTABLE_PLIST(list) ) {
+    if ( ! IS_PLIST_MUTABLE(list) ) {
         list = ErrorReturnObj(
                 "Remove: <list> must be a mutable list",
                 0L, 0L,

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -3578,7 +3578,7 @@ Obj             OnTuplesPerm (
     const UInt len = LEN_PLIST(tup);
 
     /* make a bag for the result and initialize pointers                   */
-    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(tup), T_PLIST, len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_PLIST_MUTABLE(tup), T_PLIST, len);
     SET_LEN_PLIST(res, len);
 
     /* handle small permutations                                           */
@@ -3686,7 +3686,7 @@ Obj             OnSetsPerm (
     const UInt len = LEN_PLIST(set);
 
     /* make a bag for the result and initialize pointers                   */
-    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(set), T_PLIST, len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_PLIST_MUTABLE(set), T_PLIST, len);
     SET_LEN_PLIST(res, len);
 
     /* handle small permutations                                           */
@@ -3758,7 +3758,7 @@ Obj             OnSetsPerm (
     // sort the result
     if (isint) {
         SortPlistByRawObj(res);
-        RetypeBag(res, IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
+        RetypeBag(res, IS_PLIST_MUTABLE(set) ? T_PLIST_CYC_SSORT
                                              : T_PLIST_CYC_SSORT + IMMUTABLE);
     }
     else {

--- a/src/plist.c
+++ b/src/plist.c
@@ -269,7 +269,7 @@ Int KTNumPlist (
 #endif
     else if (TEST_OBJ_FLAG(elm, TESTING)) {
         isHom   = 0;
-        areMut  = IS_MUTABLE_PLIST(elm);
+        areMut  = IS_PLIST_MUTABLE(elm);
         isTable = 0;
     }
     else {
@@ -332,7 +332,7 @@ Int KTNumPlist (
 #endif
         else if (TEST_OBJ_FLAG(elm, TESTING)) {
             isHom   = 0;
-            areMut  = (areMut || IS_MUTABLE_PLIST(elm));
+            areMut  = (areMut || IS_PLIST_MUTABLE(elm));
             isTable = 0;
             isRect = 0;
         }
@@ -798,7 +798,7 @@ Obj             ShallowCopyPlist (
 
     /* make the new object and copy the contents                           */
     len = LEN_PLIST(list);
-    if ( ! IS_MUTABLE_PLIST(list) ) {
+    if ( ! IS_PLIST_MUTABLE(list) ) {
         new = NEW_PLIST( TNUM_OBJ(list) - IMMUTABLE, len );
     }
     else {
@@ -2608,7 +2608,7 @@ Obj FuncASS_PLIST_DEFAULT (
             "you can replace <pos> via 'return <pos>;'" );
         return FuncASS_PLIST_DEFAULT( self, plist, pos, val );
     }
-    while ( ! IS_PLIST(plist) || ! IS_MUTABLE_PLIST(plist) ) {
+    while ( ! IS_PLIST(plist) || ! IS_PLIST_MUTABLE(plist) ) {
         plist = ErrorReturnObj(
             "<list> must be a mutable plain list (not a %s)",
             (Int)TNAM_OBJ(plist), 0,

--- a/src/plist.h
+++ b/src/plist.h
@@ -232,10 +232,11 @@ static inline Int IS_DENSE_PLIST(Obj list)
 
 /****************************************************************************
 **
-*F  IS_MUTABLE_PLIST( <list> )  . . . . . . . . . . . is a plain list mutable
+*F  IS_PLIST_MUTABLE( <list> )  . . . . . . . . . . . is a plain list mutable
 */
-static inline Int IS_MUTABLE_PLIST(Obj list)
+static inline Int IS_PLIST_MUTABLE(Obj list)
 {
+    GAP_ASSERT(IS_PLIST(list));
     return !((TNUM_OBJ(list) - T_PLIST) % 2);
 }
 

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -165,7 +165,7 @@ static inline Obj DOM_PPERM(Obj f)
 static inline void SET_IMG_PPERM(Obj f, Obj img)
 {
     GAP_ASSERT(IS_PPERM(f));
-    GAP_ASSERT(IS_PLIST(img) && !IS_MUTABLE_PLIST(img));
+    GAP_ASSERT(IS_PLIST(img) && !IS_PLIST_MUTABLE(img));
     GAP_ASSERT(DOM_PPERM(f) == NULL ||
                LEN_PLIST(img) == LEN_PLIST(DOM_PPERM(f)));
     // TODO check entries of img are valid
@@ -175,7 +175,7 @@ static inline void SET_IMG_PPERM(Obj f, Obj img)
 static inline void SET_DOM_PPERM(Obj f, Obj dom)
 {
     GAP_ASSERT(IS_PPERM(f));
-    GAP_ASSERT(IS_PLIST(dom) && !IS_MUTABLE_PLIST(dom));
+    GAP_ASSERT(IS_PLIST(dom) && !IS_PLIST_MUTABLE(dom));
     GAP_ASSERT(IMG_PPERM(f) == NULL ||
                LEN_PLIST(dom) == LEN_PLIST(IMG_PPERM(f)));
     // TODO check entries of img are valid
@@ -6183,7 +6183,7 @@ Obj OnSetsPPerm(Obj set, Obj f)
 
     const UInt len = LEN_PLIST(set);
 
-    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(set), T_PLIST, len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_PLIST_MUTABLE(set), T_PLIST, len);
 
     /* get the pointer                                                 */
     ptset = CONST_ADDR_OBJ(set) + len;
@@ -6242,7 +6242,7 @@ Obj OnSetsPPerm(Obj set, Obj f)
         }
     }
     if (reslen == 0) {
-        RetypeBag(res, IS_MUTABLE_PLIST(set) ? T_PLIST_EMPTY
+        RetypeBag(res, IS_PLIST_MUTABLE(set) ? T_PLIST_EMPTY
                                              : T_PLIST_EMPTY + IMMUTABLE);
         return res;
     }
@@ -6252,7 +6252,7 @@ Obj OnSetsPPerm(Obj set, Obj f)
     // sort the result
     if (isint) {
         SortPlistByRawObj(res);
-        RetypeBag(res, IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
+        RetypeBag(res, IS_PLIST_MUTABLE(set) ? T_PLIST_CYC_SSORT
                                              : T_PLIST_CYC_SSORT + IMMUTABLE);
     }
     else {
@@ -6287,7 +6287,7 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
 
     const UInt len = LEN_PLIST(tup);
 
-    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(tup), T_PLIST_CYC, len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_PLIST_MUTABLE(tup), T_PLIST_CYC, len);
 
     /* get the pointer                                                 */
     pttup = CONST_ADDR_OBJ(tup) + 1;
@@ -6366,7 +6366,7 @@ Obj FuncOnPosIntSetsPartialPerm(Obj self, Obj set, Obj f)
     }
 
     PLAIN_LIST(set);
-    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(set), T_PLIST_CYC_SSORT,
+    res = NEW_PLIST_WITH_MUTABILITY(IS_PLIST_MUTABLE(set), T_PLIST_CYC_SSORT,
                                     LEN_PLIST(set));
 
     /* get the pointer                                                 */
@@ -6404,12 +6404,12 @@ Obj FuncOnPosIntSetsPartialPerm(Obj self, Obj set, Obj f)
     SET_LEN_PLIST(res, reslen);
 
     if (reslen == 0) {
-        RetypeBag(res, IS_MUTABLE_PLIST(set) ? T_PLIST_EMPTY
+        RetypeBag(res, IS_PLIST_MUTABLE(set) ? T_PLIST_EMPTY
                                              : T_PLIST_EMPTY + IMMUTABLE);
     }
     else {
         SortPlistByRawObj(res);
-        RetypeBag(res, IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
+        RetypeBag(res, IS_PLIST_MUTABLE(set) ? T_PLIST_CYC_SSORT
                                              : T_PLIST_CYC_SSORT + IMMUTABLE);
     }
 

--- a/src/trans.c
+++ b/src/trans.c
@@ -103,14 +103,14 @@ static inline Obj EXT_TRANS(Obj f)
 static inline void SET_IMG_TRANS(Obj f, Obj img)
 {
     GAP_ASSERT(IS_TRANS(f));
-    GAP_ASSERT(img == NULL || (IS_PLIST(img) && !IS_MUTABLE_PLIST(img)));
+    GAP_ASSERT(img == NULL || (IS_PLIST(img) && !IS_PLIST_MUTABLE(img)));
     ADDR_OBJ(f)[0] = img;
 }
 
 static inline void SET_KER_TRANS(Obj f, Obj ker)
 {
     GAP_ASSERT(IS_TRANS(f));
-    GAP_ASSERT(ker == NULL || (IS_PLIST(ker) && !IS_MUTABLE_PLIST(ker) &&
+    GAP_ASSERT(ker == NULL || (IS_PLIST(ker) && !IS_PLIST_MUTABLE(ker) &&
                                LEN_PLIST(ker) == DEG_TRANS(f)));
     ADDR_OBJ(f)[1] = ker;
 }
@@ -3829,7 +3829,7 @@ Obj FuncOnPosIntSetsTrans(Obj self, Obj set, Obj f, Obj n)
 
     const UInt len = LEN_PLIST(set);
 
-    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(set), T_PLIST_CYC_SSORT, len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_PLIST_MUTABLE(set), T_PLIST_CYC_SSORT, len);
     SET_LEN_PLIST(res, len);
 
     ptset = CONST_ADDR_OBJ(set) + len;
@@ -5235,7 +5235,7 @@ Obj OnSetsTrans(Obj set, Obj f)
 
     const UInt len = LEN_PLIST(set);
 
-    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(set), T_PLIST, len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_PLIST_MUTABLE(set), T_PLIST, len);
     SET_LEN_PLIST(res, len);
 
     ptset = CONST_ADDR_OBJ(set) + len;
@@ -5295,7 +5295,7 @@ Obj OnSetsTrans(Obj set, Obj f)
         SortPlistByRawObj(res);
         REMOVE_DUPS_PLIST_INTOBJ(res);
 
-        RetypeBag(res, IS_MUTABLE_PLIST(set) ? T_PLIST_CYC_SSORT
+        RetypeBag(res, IS_PLIST_MUTABLE(set) ? T_PLIST_CYC_SSORT
                                              : T_PLIST_CYC_SSORT + IMMUTABLE);
     }
     else {
@@ -5329,7 +5329,7 @@ Obj OnTuplesTrans(Obj tup, Obj f)
 
     const UInt len = LEN_PLIST(tup);
 
-    res = NEW_PLIST_WITH_MUTABILITY(IS_MUTABLE_PLIST(tup), T_PLIST, len);
+    res = NEW_PLIST_WITH_MUTABILITY(IS_PLIST_MUTABLE(tup), T_PLIST, len);
     SET_LEN_PLIST(res, len);
 
     pttup = CONST_ADDR_OBJ(tup) + len;

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1415,7 +1415,7 @@ void ConvGF2Vec (
     /* retype and resize bag                                               */
     ResizeWordSizedBag( list, SIZE_PLEN_GF2VEC(len) );
     SET_LEN_GF2VEC( list, len );
-    if ( IS_MUTABLE_PLIST( list ) ) {
+    if ( IS_PLIST_MUTABLE( list ) ) {
         SetTypeDatObj( list, TYPE_LIST_GF2VEC);
     } else {
         SetTypeDatObj( list, TYPE_LIST_GF2VEC_IMM);
@@ -1504,7 +1504,7 @@ Obj NewGF2Vec (
     }
 
     /* mutability should be inherited from the argument */
-    if ( IS_MUTABLE_PLIST( list ) )
+    if ( IS_PLIST_MUTABLE( list ) )
         SetTypeDatObj( res , TYPE_LIST_GF2VEC);
     else
         SetTypeDatObj( res , TYPE_LIST_GF2VEC_IMM);
@@ -1564,7 +1564,7 @@ Obj FuncCONV_GF2MAT( Obj self, Obj list)
       SET_ELM_PLIST(list, i+1, tmp);
     }
   SET_ELM_PLIST(list,1,INTOBJ_INT(len));
-  mut = IS_MUTABLE_PLIST(list);
+  mut = IS_PLIST_MUTABLE(list);
   RetypeBag(list, T_POSOBJ);
   SET_TYPE_POSOBJ(list, mut ? TYPE_LIST_GF2MAT : TYPE_LIST_GF2MAT_IMM);
   return (Obj) 0;


### PR DESCRIPTION
This helper tests whether a plist is mutable, not whether an object is a
mutable plist. In other words: it assumes that the input is already known to
be a plist, and hence does not normally verify that. A newly added assert
verifies this now in debug builds, to catch accidental misuse.