### PR TITLE
Downrank methods for `Matrix` and `BaseDomain` introduced in #2640 to unbreak `Semigroups` on `master`

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -179,6 +179,9 @@ InstallMethod( Matrix,
 #
 InstallMethod( Matrix,
   [IsSemiring, IsList, IsInt],
+  # FIXME: Remove this downranking, it was introduced to prevent
+  #        Semigroups from breaking ahead of the 4.10 release
+  -SUM_FLAGS,
   function( basedomain, list, nrCols )
     local rep;
     rep := DefaultMatrixRepForBaseDomain(basedomain);
@@ -187,6 +190,9 @@ InstallMethod( Matrix,
 
 InstallMethod( Matrix,
   [IsSemiring, IsList],
+  # FIXME: Remove this downranking, it was introduced to prevent
+  #        Semigroups from breaking ahead of the 4.10 release
+  -SUM_FLAGS,
   function( basedomain, list )
     local rep;
     if Length(list) = 0 then Error("list must be not empty"); fi;
@@ -196,6 +202,9 @@ InstallMethod( Matrix,
 
 InstallMethod( Matrix,
   [IsSemiring, IsMatrixObj],
+  # FIXME: Remove this downranking, it was introduced to prevent
+  #        Semigroups from breaking ahead of the 4.10 release
+  -SUM_FLAGS,
   function( basedomain, mat )
     # TODO: can we do better? encourage MatrixObj implementors to overload this?
     return NewMatrix( DefaultMatrixRepForBaseDomain(basedomain), basedomain, NrCols(mat), Unpack(mat) );

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -1222,6 +1222,9 @@ end );
 InstallOtherMethod( BaseDomain,
     "generic method for a row vector",
     [ IsRowVector ],
+    # FIXME: Remove this downranking, it was introduced to prevent
+    #        Semigroups from breaking ahead of the 4.10 release
+    -SUM_FLAGS,
     DefaultRing );
 
 InstallOtherMethod( OneOfBaseDomain,
@@ -1248,7 +1251,6 @@ InstallOtherMethod( ZeroOfBaseDomain,
     "generic method for a matrix that is a plain list",
     [ IsMatrix and IsPlistRep ],
     mat -> Zero( mat[1,1] ) );
-
 
 #############################################################################
 ##


### PR DESCRIPTION
This addresses #2737 in that `SemigroupsTestStandard()` passes now.

An alternative solution would just rank down the appropriate methods for `Matrix` and `BaseDomain` until a fix is integrated into Semigroups.

The fix for `Semigroups` will likely involve taking most custom matrix code out, which was the long-term plan all along according to @james-d-mitchell. For that it would obviously be good if the `MatrixObj` code was suitably stable (at least by the time releases happen). 