### PR TITLE
kernel: use InitBagNamesFromTable in more places, add TNAM_TNUM helper

### DIFF
--- a/src/bool.c
+++ b/src/bool.c
@@ -323,6 +323,16 @@ void LoadBool( Obj obj )
 
 /****************************************************************************
 **
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_BOOL, "boolean or fail" },
+  { -1,     "" }
+};
+
+
+/****************************************************************************
+**
 *V  GVarFilts . . . . . . . . . . . . . . . . . . . list of filters to export
 */
 static StructGVarFilt GVarFilts [] = {
@@ -342,8 +352,10 @@ static StructGVarFilt GVarFilts [] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
+
     /* install the marking functions for boolean values                    */
-    InfoBags[ T_BOOL ].name = "boolean or fail";
     InitMarkFuncBags( T_BOOL, MarkNoSubBags );
 
     /* init filters and functions                                          */

--- a/src/calls.c
+++ b/src/calls.c
@@ -1795,6 +1795,17 @@ void MarkFunctionSubBags(Obj func)
 *F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
 */
 
+
+/****************************************************************************
+**
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_FUNCTION, "function" },
+  { -1,         ""         }
+};
+
+
 /****************************************************************************
 **
 *V  GVarFilts . . . . . . . . . . . . . . . . . . . list of filters to export
@@ -1853,9 +1864,10 @@ static StructGVarFunc GVarFuncs [] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
-  
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
+
     /* install the marking functions                                       */
-    InfoBags[ T_FUNCTION ].name = "function";
     InitMarkFuncBags(T_FUNCTION, MarkFunctionSubBags);
 
 #ifdef HPCGAP

--- a/src/code.c
+++ b/src/code.c
@@ -3259,13 +3259,24 @@ void LoadBody ( Obj body )
 
 /****************************************************************************
 **
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_BODY, "function body bag" },
+  { -1,     ""                  }
+};
+
+/****************************************************************************
+**
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
 */
 static Int InitKernel (
     StructInitInfo *    module )
 {
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
+
     /* install the marking functions for function body bags                */
-    InfoBags[ T_BODY ].name = "function body bag";
     InitMarkFuncBags( T_BODY, MarkThreeSubBags );
 
     SaveObjFuncs[ T_BODY ] = SaveBody;

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -2092,6 +2092,16 @@ void  LoadCyc ( Obj cyc )
 
 /****************************************************************************
 **
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_CYC, "cyclotomic" },
+  { -1,    ""           }
+};
+
+
+/****************************************************************************
+**
 *V  GVarFilts . . . . . . . . . . . . . . . . . . . list of filters to export
 */
 static StructGVarFilt GVarFilts [] = {
@@ -2140,6 +2150,7 @@ static StructGVarFunc GVarFuncs [] = {
   { 0, 0, 0, 0, 0 }
 };
 
+
 /****************************************************************************
 **
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
@@ -2147,8 +2158,10 @@ static StructGVarFunc GVarFuncs [] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
+
     /* install the marking function                                        */
-    InfoBags[ T_CYC ].name = "cyclotomic";
     InitMarkFuncBags( T_CYC, MarkCycSubBags );
 
     /* create the result buffer                                            */

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -1654,6 +1654,16 @@ Obj FuncZ2 ( Obj self, Obj p, Obj d)
 
 /****************************************************************************
 **
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_FFE, "ffe" },
+  { -1,    "" }
+};
+
+
+/****************************************************************************
+**
 *V  GVarFilts . . . . . . . . . . . . . . . . . . . list of filters to export
 */
 static StructGVarFilt GVarFilts [] = {
@@ -1687,9 +1697,8 @@ static StructGVarFunc GVarFuncs [] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
-    /* install the marking function                                        */
-    InfoBags[ T_FFE ].name = "ffe";
-    /* InitMarkFuncBags( T_FFE, MarkNoSubBags ); */
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
 
     /* install the type functions                                          */
     ImportFuncFromLibrary( "TYPE_FFE", &TYPE_FFE );

--- a/src/gap.c
+++ b/src/gap.c
@@ -916,10 +916,10 @@ again:
             Pr( "%8s %8s ",  (Int)"alive", (Int)"kbyte" );
             Pr( "%8s %8s\n",  (Int)"total", (Int)"kbyte" );
             for ( UInt k = 0; k < NUM_TYPES; k++ ) {
-                if ( InfoBags[k].name != 0 ) {
+                if ( TNAM_TNUM(k) != 0 ) {
                     Char buf[41];
                     buf[0] = '\0';
-                    strlcat( buf, InfoBags[k].name, sizeof(buf) );
+                    strlcat( buf, TNAM_TNUM(k), sizeof(buf) );
                     Pr("%40s ",    (Int)buf, 0L );
                     Pr("%8d %8d ", (Int)InfoBags[k].nrLive,
                                    (Int)(InfoBags[k].sizeLive/1024));
@@ -937,14 +937,14 @@ again:
             Pr( "%8s %8s ",  (Int)"alive", (Int)"kbyte" );
             Pr( "%8s %8s\n",  (Int)"total", (Int)"kbyte" );
             for ( UInt k = 0; k < NUM_TYPES; k++ ) {
-                if ( InfoBags[k].name != 0 && 
+                if ( TNAM_TNUM(k) != 0 && 
                      (InfoBags[k].nrLive != 0 ||
                       InfoBags[k].sizeLive != 0 ||
                       InfoBags[k].nrAll != 0 ||
                       InfoBags[k].sizeAll != 0) ) {
                     Char buf[41];
                     buf[0] = '\0';
-                    strlcat( buf, InfoBags[k].name, sizeof(buf) );
+                    strlcat( buf, TNAM_TNUM(k), sizeof(buf) );
                     Pr("%40s ",    (Int)buf, 0L );
                     Pr("%8d %8d ", (Int)InfoBags[k].nrLive,
                                    (Int)(InfoBags[k].sizeLive/1024));
@@ -1791,11 +1791,11 @@ void InitializeGap (
             Pr( "%8s %8s ",  (Int)"alive", (Int)"kbyte" );
             Pr( "%8s %8s\n",  (Int)"total", (Int)"kbyte" );
             for ( Int i = 0;  i < NUM_TYPES;  i++ ) {
-                if ( InfoBags[i].name != 0 && InfoBags[i].nrAll != 0 ) {
+                if ( TNAM_TNUM(i) != 0 && InfoBags[i].nrAll != 0 ) {
                     char    buf[41];
 
                     buf[0] = '\0';
-                    strlcat( buf, InfoBags[i].name, sizeof(buf) );
+                    strlcat( buf, TNAM_TNUM(i), sizeof(buf) );
                     Pr("#W  %36s ",    (Int)buf, 0L );
                     Pr("%8d %8d ", (Int)InfoBags[i].nrLive,
                        (Int)(InfoBags[i].sizeLive/1024));

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -1787,6 +1787,27 @@ Obj FuncTestBindOnceExpr(Obj self, Obj obj, Obj index, Obj new) {
 
 /****************************************************************************
 **
+*F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
+*/
+
+
+/****************************************************************************
+**
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+    { T_ALIST, "atomic list" },
+    { T_FIXALIST, "fixed atomic list" },
+    { T_APOSOBJ, "atomic positional object" },
+    { T_AREC, "atomic record" },
+    { T_ACOMOBJ, "atomic component object" },
+    { T_TLREC, "thread-local record" },
+    { -1,    "" }
+};
+
+
+/****************************************************************************
+**
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
 
@@ -1875,13 +1896,9 @@ static Int InitKernel (
   UsageCap[7] = 96;
   for (i=8; i<sizeof(UInt)*8; i++)
     UsageCap[i] = (1<<i)/3 * 2;
-  /* install info string */
-  InfoBags[T_ALIST].name = "atomic list";
-  InfoBags[T_FIXALIST].name = "fixed atomic list";
-  InfoBags[T_APOSOBJ].name = "atomic positional object";
-  InfoBags[T_AREC].name = "atomic record";
-  InfoBags[T_ACOMOBJ].name = "atomic component object";
-  InfoBags[T_TLREC].name = "thread-local record";
+
+  // set the bag type names (for error messages and debugging)
+  InitBagNamesFromTable(BagNames);
   
   /* install the kind methods */
   TypeObjFuncs[ T_ALIST ] = TypeAList;

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -2526,6 +2526,29 @@ Obj FuncTHREAD_COUNTERS_GET(Obj self)
 
 /****************************************************************************
 **
+*F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
+*/
+
+
+/****************************************************************************
+**
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+    // install info string
+    { T_THREAD, "thread" },
+    { T_MONITOR, "monitor" },
+    { T_REGION, "region" },
+    { T_SEMAPHORE, "semaphore" },
+    { T_CHANNEL, "channel" },
+    { T_BARRIER, "barrier" },
+    { T_SYNCVAR, "syncvar" },
+    { -1,    "" }
+};
+
+
+/****************************************************************************
+**
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
 static StructGVarFunc GVarFuncs[] = {
@@ -2645,14 +2668,8 @@ static StructGVarFunc GVarFuncs[] = {
 */
 static Int InitKernel(StructInitInfo * module)
 {
-    // install info string
-    InfoBags[T_THREAD].name = "thread";
-    InfoBags[T_MONITOR].name = "monitor";
-    InfoBags[T_REGION].name = "region";
-    InfoBags[T_SEMAPHORE].name = "semaphore";
-    InfoBags[T_CHANNEL].name = "channel";
-    InfoBags[T_BARRIER].name = "barrier";
-    InfoBags[T_SYNCVAR].name = "syncvar";
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable(BagNames);
 
     // install the type methods
     TypeObjFuncs[T_THREAD] = TypeThread;

--- a/src/integer.c
+++ b/src/integer.c
@@ -2736,6 +2736,24 @@ Obj FuncRandomIntegerMT(Obj self, Obj mtstr, Obj nrbits)
 *F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
 */
 
+
+/****************************************************************************
+**
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_INT,    "integer" },
+#ifdef SYS_IS_64_BIT
+  { T_INTPOS, "integer (>= 2^60)" },
+  { T_INTNEG, "integer (< -2^60)" },
+#else
+  { T_INTPOS, "integer (>= 2^28)" },
+  { T_INTNEG, "integer (< -2^28)" },
+#endif
+  { -1, "" }
+};
+
+
 /****************************************************************************
 **
 *V  GVarFilts . . . . . . . . . . . . . . . . . . . list of filters to export
@@ -2797,15 +2815,10 @@ static Int InitKernel ( StructInitInfo * module )
   InitHdlrFiltsFromTable( GVarFilts );
   InitHdlrFuncsFromTable( GVarFuncs );
   
+  // set the bag type names (for error messages and debugging)
+  InitBagNamesFromTable( BagNames );
+
   /* install the marking functions                                         */
-  InfoBags[         T_INT    ].name = "integer";
-#ifdef SYS_IS_64_BIT
-  InfoBags[         T_INTPOS ].name = "integer (>= 2^60)";
-  InfoBags[         T_INTNEG ].name = "integer (< -2^60)";
-#else
-  InfoBags[         T_INTPOS ].name = "integer (>= 2^28)";
-  InfoBags[         T_INTNEG ].name = "integer (< -2^28)";
-#endif
   InitMarkFuncBags( T_INTPOS, MarkNoSubBags );
   InitMarkFuncBags( T_INTNEG, MarkNoSubBags );
   

--- a/src/lists.c
+++ b/src/lists.c
@@ -2607,19 +2607,15 @@ static Int CheckInit (
 
     /* fix unknown list types                                              */
     for ( i = FIRST_LIST_TNUM;  i <= LAST_LIST_TNUM;  i +=2 ) {
-        if ( InfoBags[i].name == 0 ) {
-            InfoBags[i].name = "unknown list type";
-        }
-        if ( InfoBags[i+IMMUTABLE].name == 0 ) {
-            InfoBags[i+IMMUTABLE].name = "unknown immutable list type";
-        }
+        GAP_ASSERT( TNAM_TNUM(i) );
+        GAP_ASSERT( TNAM_TNUM(i + IMMUTABLE) );
     }
 
     /* check that all relevant `ClearFiltListTNums' are installed          */
     for ( i = FIRST_LIST_TNUM;  i <= LAST_LIST_TNUM;  i++ ) {
         if ( ClearFiltsTNums[i] == 0 ) {
             Pr( "#W  ClearFiltsListTNums [%s] missing\n",
-                    (Int)(InfoBags[i].name), 0L );
+                    (Int)TNAM_TNUM(i), 0L );
             success = 0;
         }
     }
@@ -2630,7 +2626,7 @@ static Int CheckInit (
         for ( j = 0;  j < ARRAY_SIZE(fnums);  j++ ) {
             if ( HasFiltListTNums[i][fnums[j]] == -1 ) {
                 Pr( "#W  HasFiltListTNums [%s] [%s] missing\n",
-                    (Int)(InfoBags[i].name), (Int)fnams[j] );
+                    (Int)TNAM_TNUM(i), (Int)fnams[j] );
                 success = 0;
                 HasFiltListTNums[i][fnums[j]] = 0;
             }
@@ -2643,7 +2639,7 @@ static Int CheckInit (
         for ( j = 0;  j < ARRAY_SIZE(fnums);  j++ ) {
             if ( SetFiltListTNums[i][fnums[j]] == 0 ) {
                 Pr( "#W  SetFiltListTNums [%s] [%s] missing\n",
-                    (Int)(InfoBags[i].name), (Int)fnams[j] );
+                    (Int)TNAM_TNUM(i), (Int)fnams[j] );
                 success = 0;
             }
         }
@@ -2655,7 +2651,7 @@ static Int CheckInit (
         for ( j = 0;  j < ARRAY_SIZE(fnums);  j++ ) {
             if ( ResetFiltListTNums[i][fnums[j]] == 0 ) {
                 Pr( "#W  ResetFiltListTNums [%s] [%s] missing\n",
-                    (Int)(InfoBags[i].name), (Int)fnams[j] );
+                    (Int)TNAM_TNUM(i), (Int)fnams[j] );
                 success = 0;
             }
         }
@@ -2674,7 +2670,7 @@ static Int CheckInit (
                 else if ( new != -1 && HasFiltListTNums[new][fnums[j]] ) {
                     Pr(
                      "#W  ResetFiltListTNums [%s] [%s] failed to reset\n",
-                     (Int)(InfoBags[i].name), (Int)fnams[j] );
+                     (Int)TNAM_TNUM(i), (Int)fnams[j] );
                     success = 0;
                 }
             }
@@ -2690,7 +2686,7 @@ static Int CheckInit (
                 if ( new != -1 && new != i ) {
                     Pr(
                      "#W  SetFiltListTNums [%s] [%s] must not change\n",
-                     (Int)(InfoBags[i].name), (Int)fnams[j] );
+                     (Int)TNAM_TNUM(i), (Int)fnams[j] );
                     success = 0;
                 }
             }
@@ -2703,7 +2699,7 @@ static Int CheckInit (
         if ( (i & IMMUTABLE) == 0 ) {
             if ( ClearFiltsTNums[i]+IMMUTABLE != ClearFiltsTNums[i+IMMUTABLE]) {
                 Pr( "#W  ClearFiltsTNums [%s] mismatch between mutable and immutable\n",
-                    (Int)(InfoBags[i].name), 0 );
+                    (Int)TNAM_TNUM(i), 0 );
                 success = 0;
             }
             for ( j = 0;  j < ARRAY_SIZE(fnums);  j++ ) {
@@ -2711,21 +2707,21 @@ static Int CheckInit (
                 if ( HasFiltListTNums[i][fnums[j]] !=
                      HasFiltListTNums[i+IMMUTABLE][fnums[j]]) {
                     Pr( "#W  HasFiltListTNums [%s] [%s] mismatch between mutable and immutable\n",
-                        (Int)(InfoBags[i].name), (Int)fnams[j] );
+                        (Int)TNAM_TNUM(i), (Int)fnams[j] );
                     success = 0;
                 }
 
                 if ( (SetFiltListTNums[i][fnums[j]] | IMMUTABLE) !=
                      SetFiltListTNums[i+IMMUTABLE][fnums[j]]) {
                     Pr( "#W  SetFiltListTNums [%s] [%s] mismatch between mutable and immutable\n",
-                        (Int)(InfoBags[i].name), (Int)fnams[j] );
+                        (Int)TNAM_TNUM(i), (Int)fnams[j] );
                     success = 0;
                 }
 
                 if ( (ResetFiltListTNums[i][fnums[j]] | IMMUTABLE) !=
                      ResetFiltListTNums[i+IMMUTABLE][fnums[j]]) {
                     Pr( "#W  ResetFiltListTNums [%s] [%s] mismatch between mutable and immutable\n",
-                        (Int)(InfoBags[i].name), (Int)fnams[j] );
+                        (Int)TNAM_TNUM(i), (Int)fnams[j] );
                     success = 0;
                 }
 
@@ -2736,43 +2732,43 @@ static Int CheckInit (
             if ( ! HasFiltListTNums[i][FN_IS_DENSE] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ empty -> dense ] missing\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
             if ( HasFiltListTNums[i][FN_IS_NDENSE] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ empty + ndense ] illegal\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
             if ( ! HasFiltListTNums[i][FN_IS_HOMOG] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ empty -> homog ] missing\n",
-                 (Int)(InfoBags[i].name), 0L );
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
             if ( HasFiltListTNums[i][FN_IS_NHOMOG] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ empty + nhomog ] illegal\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
             if ( ! HasFiltListTNums[i][FN_IS_SSORT] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ empty -> ssort ] missing\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
             if ( HasFiltListTNums[i][FN_IS_NSORT] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ empty + nsort ] illegal\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
             if ( HasFiltListTNums[i][FN_IS_TABLE] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ empty + table ] illegal\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
         }
@@ -2781,7 +2777,7 @@ static Int CheckInit (
             if ( HasFiltListTNums[i][FN_IS_NDENSE] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ dense + ndense ] illegal\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
         }
@@ -2790,13 +2786,13 @@ static Int CheckInit (
             if ( HasFiltListTNums[i][FN_IS_HOMOG] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ ndense + homog ] illegal\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
             if ( HasFiltListTNums[i][FN_IS_TABLE] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ ndense + table ] illegal\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
         }
@@ -2805,19 +2801,19 @@ static Int CheckInit (
             if ( HasFiltListTNums[i][FN_IS_NHOMOG] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ homog + nhomog ] illegal\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
             if ( ! HasFiltListTNums[i][FN_IS_DENSE] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ homog -> dense ] missing\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
             if ( HasFiltListTNums[i][FN_IS_NDENSE] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ homog + ndense ] illegal\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
         }
@@ -2826,7 +2822,7 @@ static Int CheckInit (
             if ( HasFiltListTNums[i][FN_IS_TABLE] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ nhomog + table ] illegal\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
         }
@@ -2835,13 +2831,13 @@ static Int CheckInit (
             if ( ! HasFiltListTNums[i][FN_IS_HOMOG] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ table -> homog ] missing\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
             if ( ! HasFiltListTNums[i][FN_IS_DENSE] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ table -> dense ] missing\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
         }
@@ -2850,7 +2846,7 @@ static Int CheckInit (
             if ( HasFiltListTNums[i][FN_IS_NSORT] ) {
                 Pr(
                  "#W  HasFiltListTNums [%s] [ ssort + nsort ] illegal\n",
-                 (Int)(InfoBags[i].name), 0L );   
+                 (Int)TNAM_TNUM(i), 0L );
                 success = 0;
             }
         }           

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -467,6 +467,16 @@ Obj FuncFREXP_MACFLOAT( Obj self, Obj f)
 
 /****************************************************************************
 **
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_MACFLOAT, "macfloat" },
+  { -1,    "" }
+};
+
+
+/****************************************************************************
+**
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
 static StructGVarFunc GVarFuncs [] = {
@@ -528,8 +538,10 @@ extern Int EqObject (Obj,Obj);
 static Int InitKernel (
     StructInitInfo *    module )
 {
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
+
     /* install the marking functions for macfloatean values                    */
-    InfoBags[ T_MACFLOAT ].name = "macfloat";
     InitMarkFuncBags( T_MACFLOAT, MarkNoSubBags );
 #ifdef HPCGAP
     MakeBagTypePublic( T_MACFLOAT );

--- a/src/objects.c
+++ b/src/objects.c
@@ -1931,6 +1931,23 @@ Obj FuncDEBUG_TNUM_NAMES(Obj self)
 
 /****************************************************************************
 **
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_COMOBJ,                         "object (component)"             },
+  { T_POSOBJ,                         "object (positional)"            },
+  { T_DATOBJ,                         "object (data)"                  },
+#if !defined(USE_THREADSAFE_COPYING)
+  { T_COMOBJ      +COPYING,           "object (component,copied)"      },
+  { T_POSOBJ      +COPYING,           "object (positional,copied)"     },
+  { T_DATOBJ      +COPYING,           "object (data,copied)"           },
+#endif
+  { -1,                               ""                               }
+};
+
+
+/****************************************************************************
+**
 *V  GVarFilts . . . . . . . . . . . . . . . . . . . list of filters to export
 */
 static StructGVarFilt GVarFilts [] = {
@@ -2013,19 +2030,17 @@ static Int InitKernel (
 {
     Int                 t;              /* loop variable                   */
 
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
+
     /* install the marking methods                                         */
-    InfoBags[         T_COMOBJ          ].name = "object (component)";
     InitMarkFuncBags( T_COMOBJ          , MarkPRecSubBags );
-    InfoBags[         T_POSOBJ          ].name = "object (positional)";
     InitMarkFuncBags( T_POSOBJ          , MarkAllSubBags  );
-    InfoBags[         T_DATOBJ          ].name = "object (data)";
     InitMarkFuncBags( T_DATOBJ          , MarkOneSubBags  );
+
 #if !defined(USE_THREADSAFE_COPYING)
-    InfoBags[         T_COMOBJ +COPYING ].name = "object (component,copied)";
     InitMarkFuncBags( T_COMOBJ +COPYING , MarkPRecSubBags );
-    InfoBags[         T_POSOBJ +COPYING ].name = "object (positional,copied)";
     InitMarkFuncBags( T_POSOBJ +COPYING , MarkAllSubBags  );
-    InfoBags[         T_DATOBJ +COPYING ].name = "object (data,copied)";
     InitMarkFuncBags( T_DATOBJ +COPYING , MarkOneSubBags  );
 #endif
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -91,6 +91,11 @@ Int RegisterPackageTNUM( const char *name, Obj (*typeObjFunc)(Obj obj) )
     return tnum;
 }
 
+const Char * TNAM_TNUM(UInt tnum)
+{
+    return InfoBags[tnum].name;
+}
+
 
 /****************************************************************************
 **
@@ -1896,7 +1901,7 @@ Obj FuncDEBUG_TNUM_NAMES(Obj self)
         START_SYMBOLIC_TNUM(FIRST_COPYING_TNUM);
         START_SYMBOLIC_TNUM(FIRST_PACKAGE_TNUM + COPYING);
 #endif
-        const char *name = InfoBags[k].name;
+        const char *name = TNAM_TNUM(k);
         Pr("%3d: %s", k, (Int)indentStr);
         Pr("%s%s\n", (Int)indentStr, (Int)(name ? name : "."));
         STOP_SYMBOLIC_TNUM(LAST_MULT_TNUM);

--- a/src/objects.h
+++ b/src/objects.h
@@ -365,11 +365,18 @@ static inline UInt TNUM_OBJ(Obj obj)
 
 /****************************************************************************
 **
+*F  TNAM_TNUM( <obj> ) . . . . . . . . . . . . . . . . . . . . name of a type
+*/
+const Char * TNAM_TNUM(UInt tnum);
+
+
+/****************************************************************************
+**
 *F  TNAM_OBJ( <obj> ) . . . . . . . . . . . . . name of the type of an object
 */
 static inline const Char * TNAM_OBJ(Obj obj)
 {
-    return InfoBags[TNUM_OBJ(obj)].name;
+    return TNAM_TNUM(TNUM_OBJ(obj));
 }
 
 

--- a/src/objset.c
+++ b/src/objset.c
@@ -983,9 +983,27 @@ static Obj FuncOBJ_MAP_KEYS(Obj self, Obj map) {
 
 /****************************************************************************
 **
-*V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
+*F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
 */
 
+
+/****************************************************************************
+**
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_OBJSET,           "object set" },
+  { T_OBJSET+IMMUTABLE, "immutable object set" },
+  { T_OBJMAP,           "object map" },
+  { T_OBJMAP+IMMUTABLE, "immutable object map" },
+  { -1, "" }
+};
+
+
+/****************************************************************************
+**
+*V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
+*/
 static StructGVarFunc GVarFuncs [] = {
 
     GVAR_FUNC(OBJ_SET, -1, "[list]"),
@@ -1014,11 +1032,9 @@ static StructGVarFunc GVarFuncs [] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
-  /* install info string */
-  InfoBags[T_OBJSET].name = "object set";
-  InfoBags[T_OBJSET+IMMUTABLE].name = "immutable object set";
-  InfoBags[T_OBJMAP].name = "object map";
-  InfoBags[T_OBJMAP+IMMUTABLE].name = "immutable object map";
+  // set the bag type names (for error messages and debugging)
+  InitBagNamesFromTable( BagNames );
+
   /* install kind functions */
   TypeObjFuncs[T_OBJSET          ] = TypeObjSet;
   TypeObjFuncs[T_OBJSET+IMMUTABLE] = TypeObjSet;

--- a/src/objset.c
+++ b/src/objset.c
@@ -768,13 +768,13 @@ static void CheckArgument(const char *func, Obj obj, Int t1, Int t2) {
   Int tnum = TNUM_OBJ(obj);
   if (t2 < 0 && tnum == t1+IMMUTABLE) {
     ErrorQuit("%s: First argument must be a mutable %s",
-      (Int) func,
-      (Int) InfoBags[t1].name);
+      (Int)func,
+      (Int)TNAM_TNUM(t1));
   }
   if (tnum != t1 && tnum != t2) {
     ErrorQuit("%s: First argument must be an %s",
-      (Int) func,
-      (Int) InfoBags[t1].name);
+      (Int)func,
+      (Int)TNAM_TNUM(t1));
   }
 }
 

--- a/src/opers.c
+++ b/src/opers.c
@@ -3937,6 +3937,16 @@ Obj FuncDO_NOTHING_SETTER( Obj self, Obj obj, Obj val)
 
 /****************************************************************************
 **
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_FLAGS, "flags list" },
+  { -1, "" }
+};
+
+
+/****************************************************************************
+**
 *V  GVarFilts . . . . . . . . . . . . . . . . . . . list of filters to export
 */
 static StructGVarFilt GVarFilts [] = {
@@ -4137,8 +4147,10 @@ static Int InitKernel (
     InitHdlrFiltsFromTable( GVarFilts );
     InitHdlrFuncsFromTable( GVarFuncs );
 
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
+
     /* install the marking function                                        */
-    InfoBags[T_FLAGS].name = "flags list";
     InitMarkFuncBags( T_FLAGS, MarkThreeSubBags );
 
     /* install the printing function                                       */

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -4366,18 +4366,25 @@ Obj FuncSCR_SIFT_HELPER(Obj self, Obj S, Obj g, Obj n)
   }
   /* so we're done sifting, and now we just have to clean up result */  
   return result;
-  
-  
 }
-  
-  
-  
 
 
 /****************************************************************************
 **
 *F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
 */
+
+
+/****************************************************************************
+**
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_PERM2, "permutation (small)" },
+  { T_PERM4, "permutation (large)" },
+  { -1, "" }
+};
+
 
 /****************************************************************************
 **
@@ -4429,10 +4436,11 @@ static StructGVarFunc GVarFuncs [] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
+
     /* install the marking function                                        */
-    InfoBags[           T_PERM2         ].name = "permutation (small)";
     InitMarkFuncBags(T_PERM2, MarkOneSubBags);
-    InfoBags[           T_PERM4         ].name = "permutation (large)";
     InitMarkFuncBags(T_PERM4, MarkOneSubBags);
 
 #ifdef HPCGAP

--- a/src/pperm.c
+++ b/src/pperm.c
@@ -6502,8 +6502,22 @@ Obj IsPPermHandler(Obj self, Obj val)
     }
 }
 
-/*F * * * * * * * * * * * * initialize module * * * * * * * * * * * * * *
- */
+/****************************************************************************
+**
+*F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
+*/
+
+
+/****************************************************************************
+**
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_PPERM2,                         "partial perm (small)"           },
+  { T_PPERM4,                         "partial perm (large)"           },
+  { -1,                               ""                               }
+};
+
 
 /**************************************************************************
 **
@@ -6517,6 +6531,7 @@ static StructGVarFilt GVarFilts[] = {
     { 0, 0, 0, 0, 0 }
 
 };
+
 
 /****************************************************************************
  *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
@@ -6572,10 +6587,10 @@ static StructGVarFunc GVarFuncs[] = {
  */
 static Int InitKernel(StructInitInfo * module)
 {
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
 
     /* install the marking function                                        */
-    InfoBags[T_PPERM2].name = "partial perm (small)";
-    InfoBags[T_PPERM4].name = "partial perm (large)";
     InitMarkFuncBags(T_PPERM2, MarkTwoSubBags);
     InitMarkFuncBags(T_PPERM4, MarkTwoSubBags);
 

--- a/src/rational.c
+++ b/src/rational.c
@@ -860,6 +860,14 @@ static StructGVarFunc GVarFuncs [] = {
     { 0, 0, 0, 0, 0 }
 
 };
+/****************************************************************************
+**
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_RAT, "rational" },
+  { -1,    ""         }
+};
 
 
 /****************************************************************************
@@ -869,8 +877,10 @@ static StructGVarFunc GVarFuncs [] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
+
     /* install the marking function                                        */
-    InfoBags[         T_RAT ].name = "rational";
     /* MarkTwoSubBags() is faster for Gasman, but MarkAllSubBags() is
      * more space-efficient for the Boehm GC and does not incur a
      * speed penalty.

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -372,7 +372,7 @@ static void LoadBagData ( void )
   flags = LoadUInt1();
   size = LoadUInt();
 
-    if (InfoBags[type].name == NULL)
+    if (TNAM_TNUM(type) == NULL)
       {
         Pr("Bad type %d, size %d\n",type,size);
         exit(1);

--- a/src/trans.c
+++ b/src/trans.c
@@ -5472,8 +5472,20 @@ Obj IsTransHandler(Obj self, Obj val)
     }
 }
 
-/*F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * *
- */
+/****************************************************************************
+**
+*F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
+*/
+
+/****************************************************************************
+**
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_TRANS2, "transformation (small)" },
+  { T_TRANS4, "transformation (large)" },
+  { -1, "" }
+};
 
 /****************************************************************************
 **
@@ -5553,15 +5565,17 @@ static StructGVarFunc GVarFuncs[] = {
     { 0, 0, 0, 0, 0 }
 
 };
+
+
 /******************************************************************************
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
 */
 static Int InitKernel(StructInitInfo * module)
 {
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
 
     /* install the marking functions                                       */
-    InfoBags[T_TRANS2].name = "transformation (small)";
-    InfoBags[T_TRANS4].name = "transformation (large)";
     InitMarkFuncBags(T_TRANS2, MarkThreeSubBags);
     InitMarkFuncBags(T_TRANS4, MarkThreeSubBags);
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -2554,6 +2554,16 @@ void PrintLVars( Obj lvars )
 
 /****************************************************************************
 **
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_LVARS, "values bag"         },
+  { T_HVARS, "high variables bag" },
+  { -1,      ""                   }
+};
+
+/****************************************************************************
+**
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
 static StructGVarFunc GVarFuncs [] = {
@@ -2585,10 +2595,11 @@ static Int InitKernel (
     }
 #endif
 
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
+
     /* install the marking functions for local variables bag               */
-    InfoBags[ T_LVARS ].name = "values bag";
     InitMarkFuncBags( T_LVARS, MarkAllButFirstSubBags );
-    InfoBags[ T_HVARS ].name = "high variables bag";
     InitMarkFuncBags( T_HVARS, MarkAllButFirstSubBags );
 
 #ifdef HPCGAP

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -866,6 +866,19 @@ void LoadWPObj(Obj wpobj)
 
 /****************************************************************************
 **
+*V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
+*/
+static StructBagNames BagNames[] = {
+  { T_WPOBJ,                          "object (weakptr)"               },
+#if !defined(USE_THREADSAFE_COPYING)
+  { T_WPOBJ       +COPYING,           "object (weakptr, copied)"       },
+#endif
+  { -1,                               ""                               }
+};
+
+
+/****************************************************************************
+**
 *V  GVarFilts . . . . . . . . . . . . . . . . . . . list of filters to export
 */
 static StructGVarFilt GVarFilts [] = {
@@ -900,12 +913,10 @@ static StructGVarFunc GVarFuncs [] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
-    /* install the marking and sweeping methods                            */
-    InfoBags[ T_WPOBJ          ].name = "object (weakptr)";
-#if !defined(USE_THREADSAFE_COPYING)
-    InfoBags[ T_WPOBJ +COPYING ].name = "object (weakptr, copied)";
-#endif
+    // set the bag type names (for error messages and debugging)
+    InitBagNamesFromTable( BagNames );
 
+    /* install the marking and sweeping methods                            */
 #if defined(USE_BOEHM_GC)
     /* force atomic allocation of these pointers */
     InitMarkFuncBags ( T_WPOBJ,          MarkNoSubBags   );


### PR DESCRIPTION
The eventual goal here is to make `InfoBags` private (and to split it: on the one hand, it contains a list of TNUM-names, which belongs into objects.c; on the other hand, it contains GASMAN statistics, which belong into `gasman.c` resp. `gasman_intern.h`.

However a few packages access `InfoBags`, so this will take some more effort.