### PR TITLE
 Revert "Downrank MatrixObj methods to unbreak Semigroups"

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -201,9 +201,6 @@ InstallMethod( Matrix,
 
 InstallMethod( Matrix,
   [IsSemiring, IsMatrixObj],
-  # FIXME: Remove this downranking, it was introduced to prevent
-  #        Semigroups from breaking ahead of the 4.10 release
-  -SUM_FLAGS,
   function( basedomain, mat )
     # TODO: can we do better? encourage MatrixObj implementors to overload this?
     return NewMatrix( DefaultMatrixRepForBaseDomain(basedomain), basedomain, NrCols(mat), Unpack(mat) );


### PR DESCRIPTION
This reverts  "Downrank MatrixObj methods to unbreak Semigroups" again and serves as a reminder that we need to take care of this issue after 4.10 is released.