### PR TITLE
Switch Travis to use Ubuntu 16.04 "xenial", and other CI tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
   global:
     - CFLAGS="--coverage -O2"
     - LDFLAGS="--coverage"
-    # default config flags: enable debug asserts, and treat compiler warnings as errors
-    - CONFIGFLAGS="--enable-debug --enable-Werror"
+    # default config flags: enable debug asserts
+    - CONFIGFLAGS="--enable-debug"
 
 addons:
   apt_packages:
@@ -22,7 +22,7 @@ matrix:
     # the same in 32 bit mode, and with debugging turned off, to (a) make it
     # a lot faster, and (b) to make sure nobody accidentally put some vital
     # computing into code that is only run when debugging is on.
-    - env: TEST_SUITES="docomp testtravis" ABI=32 CONFIGFLAGS="--enable-Werror"
+    - env: TEST_SUITES="docomp testtravis" ABI=32 CONFIGFLAGS=""
       addons:
         apt_packages:
           - gcc-multilib
@@ -95,7 +95,7 @@ matrix:
     - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=64 BUILDDIR=build
     # for 32bit mode, also turn off debugging (see elsewhere in this file for
     # an explanation)
-    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=32 BUILDDIR=build CONFIGFLAGS="--enable-Werror"
+    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=32 BUILDDIR=build CONFIGFLAGS=""
       addons:
         apt_packages:
           - gcc-multilib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-# We want Ubuntu 14.04 "Trust" instead of 12.04 "Precise" to get newer
-# and less buggy gcov
-dist: trusty
+# Force Ubuntu 16.04 "Xenial" to get newer GCC, binutils etc.
+dist: xenial
 language: c
 
 env:
@@ -45,7 +44,7 @@ matrix:
           - libreadline-dev
           - libboost-dev            # for NormalizInterface
           - libmpfr-dev             # for float
-          - libmpfi-dev             # for float
+          - libmpfi0-dev            # for float
           - libmpc-dev              # for float
           #- libfplll-dev           # for float
           - pari-gp                 # for alnuth
@@ -62,7 +61,7 @@ matrix:
           - libcurl4-openssl-dev:i386 # for curlInterface
           - libboost-dev:i386       # for NormalizInterface
           - libmpfr-dev:i386        # for float
-          - libmpfi-dev:i386        # for float
+          - libmpfi0-dev:i386       # for float
           - libmpc-dev:i386         # for float
           #- libfplll-dev:i386      # for float
           - pari-gp:i386            # for alnuth

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,10 +116,13 @@ matrix:
     - env: TEST_SUITES="testlibgap"
 
 script:
+  - set -e
   - gcov --version
-  - bash etc/ci-prepare.sh && bash etc/ci.sh
+  - bash etc/ci-prepare.sh
+  - bash etc/ci.sh
 
 after_script:
+  - set -e
   - bash etc/ci-gather-coverage.sh
   - bash <(curl -s https://codecov.io/bash)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,11 @@ matrix:
           - libreadline-dev:i386
 
     # compiler packages and run package tests
-    - env: TEST_SUITES=testpackages
+    # don't use --coverage in CFLAGS, it causes the weird `atexit` bug in
+    # digraphs and other kernel extensions using C++ code (due to GCC's
+    # `profiler_trace.h` calling `atexit`; but that fails in loadable modules
+    # for technical reasons)
+    - env: TEST_SUITES=testpackages CFLAGS="-O2" LDFLAGS=
       addons:
         apt_packages:
           - gcc-multilib
@@ -47,7 +51,7 @@ matrix:
           - pari-gp                 # for alnuth
           - libzmq3-dev             # for ZeroMQInterface
 
-    - env: TEST_SUITES=testpackages ABI=32
+    - env: TEST_SUITES=testpackages CFLAGS="-O2" LDFLAGS= ABI=32
       addons:
         apt_packages:
           - gcc-multilib

--- a/etc/ci-gather-coverage.sh
+++ b/etc/ci-gather-coverage.sh
@@ -18,7 +18,7 @@ fi
 SRCDIR=${SRCDIR:-$PWD}
 
 # Make sure any Error() immediately exits GAP with exit code 1.
-GAP="bin/gap.sh --quitonbreak -q"
+GAP="bin/gap.sh --quitonbreak --nointeract --alwaystrace -q"
 
 # change into BUILDDIR (creating it if necessary), and turn it into an absolute path
 if [[ -n "$BUILDDIR" ]]
@@ -38,12 +38,15 @@ if LoadPackage("profiling") <> true then
     FORCE_QUIT_GAP(1);
 fi;
 d := Directory("$COVDIR");;
+Print("Scanning for coverage data...\n");
 covs := [];;
 for f in DirectoryContents(d) do
     if f in [".", ".."] then continue; fi;
-    Add(covs, Filename(d, f));
+    f := Filename(d, f);
+    Add(covs, f);
+    Print("  ", f, "\n");
 od;
-Print("Merging coverage results\n");
+Print("Merging ", Length(covs), " coverage files...\n");
 r := MergeLineByLineProfiles(covs);;
 Print("Outputting JSON\n");
 OutputJsonCoverage(r, "gap-coverage.json");;

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -40,8 +40,8 @@ fi
 
 
 # configure and make GAP
-"$SRCDIR/configure" $CONFIGFLAGS --enable-Werror
-make V=1 -j4
+time "$SRCDIR/configure" $CONFIGFLAGS --enable-Werror
+time make V=1 -j4
 
 # download packages; instruct wget to retry several times if the
 # connection is refused, to work around intermittent failures

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -44,26 +44,15 @@ do
     rm -rf pargap*
     # skip PolymakeInterface: no polynmake installed (TODO: is there a polymake package we can use)
     rm -rf PolymakeInterface*
+    # skip xgap: no X11 headers, and no means to test it
+    rm -rf xgap*
 
     # HACK to work out timestamp issues with anupq
     touch anupq*/configure* anupq*/Makefile* anupq*/aclocal.m4
 
-    # HACK: skip building digraphs for now -- it doesn't link reliably on travis
-    rm -rf digraphs-*
-
-    # HACK: skip building semigroups-3.x for now -- it requires GCC >= 5, which Travis doesn't have
-    rm -rf semigroups-3.*
-
-    # HACK: skip building float for now -- it doesn't link reliably on travis
-    rm -rf float-*
-
-    if [[ x"$ABI" == "x32" ]]
-    then
-      # HACK: disable NormalizInterface in 32bit mode for now. Version
-      # 0.9.8 doesn't make it easy to support 32bit. With the next
-      # release of the package, this will hopefully change.
-      rm -rf NormalizInterface-0.9.8
-    fi
+    # HACK: workaround GMP 5 bug causing "error: '::max_align_t' has not been declared",
+    # see <https://gcc.gnu.org/gcc-4.9/porting_to.html>
+    printf "%s\n" 1 i "#include <stddef.h>" . w | ed float*/src/mp_poly.C
 
     # reset CFLAGS and LDFLAGS before compiling packages, to prevent
     # them from being compiled with coverage gathering, because


### PR DESCRIPTION
This should allow us to build semigroups and digraphs again (alas, it seems digraphs still runs into these weird atexit troubles...)