### PR TITLE
Add missing { } around macro

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -1824,10 +1824,11 @@ void InitializeGap (
         /* Call POST_RESTORE which is a GAP function that now takes control, 
            calls the post restore functions and then runs a GAP session */
         if (POST_RESTORE != (Obj) 0 &&
-            IS_FUNC(POST_RESTORE))
+            IS_FUNC(POST_RESTORE)) {
           TRY_IF_NO_ERROR {
             CALL_0ARGS(POST_RESTORE);
           }
+        }
     }
 
 


### PR DESCRIPTION
Hopefully obvious -- the TRY_IF_NO_ERROR is a macro, and when expanded doesn't bind "correctly". The { } just enforce what we always wanted, and are generally good practice around macros anyway.