### PR TITLE
kernel: add SKIP_IF_{RETURNING,IGNORING} to interpreter

### DIFF
--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -83,6 +83,10 @@
 /* TL: UInt IntrCoding; */
 
 
+#define SKIP_IF_RETURNING() if ( STATE(IntrReturning) > 0 ) { return; }
+#define SKIP_IF_IGNORING()  if ( STATE(IntrIgnoring)  > 0 ) { return; }
+
+
 /****************************************************************************
 **
 *F  StackObj  . . . . . . . . . . . . . . . . . . . . . . . . .  values stack
@@ -329,8 +333,8 @@ ExecStatus IntrEnd(UInt error, Obj *result)
 void            IntrFuncCallBegin ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallBegin(); return; }
 
 }
@@ -357,8 +361,8 @@ void            IntrFuncCallEnd (
     UInt                i;              /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) {
       CodeFuncCallEnd( funccall, options, nr );
       return; }
@@ -454,8 +458,8 @@ void            IntrFuncExprBegin (
     Int                 startLine)
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     if (STATE(IntrCoding) == 0) {
         CodeBegin();
@@ -469,8 +473,8 @@ void            IntrFuncExprBegin (
 void IntrFuncExprEnd(UInt nr)
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert(STATE(IntrCoding) > 0);
@@ -523,7 +527,7 @@ void IntrFuncExprEnd(UInt nr)
 void            IntrIfBegin ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
 
     // if IntrIgnoring is positive, increment it, as IntrIgnoring == 1 has a
     // special meaning when parsing if-statements -- it is used to skip
@@ -539,8 +543,8 @@ void            IntrIfBegin ( void )
 void            IntrIfElif ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeIfElif(); return; }
 
 }
@@ -548,8 +552,8 @@ void            IntrIfElif ( void )
 void            IntrIfElse ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeIfElse(); return; }
 
 
@@ -562,7 +566,7 @@ void            IntrIfBeginBody ( void )
     Obj                 cond;           /* value of condition              */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
     if ( STATE(IntrCoding)    > 0 ) { CodeIfBeginBody(); return; }
 
@@ -606,7 +610,7 @@ void            IntrIfEnd (
     UInt                nr )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 1 ) { STATE(IntrIgnoring)--; return; }
 
     // if one branch was executed (ignoring the others), reset IntrIgnoring
@@ -654,8 +658,8 @@ void            IntrIfEnd (
 void IntrForBegin ( void )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     if (STATE(IntrCoding) == 0)
         StartFakeFuncExpr(0);
@@ -669,8 +673,8 @@ void IntrForBegin ( void )
 void IntrForIn ( void )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert( STATE(IntrCoding) > 0 );
@@ -680,8 +684,8 @@ void IntrForIn ( void )
 void IntrForBeginBody ( void )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert( STATE(IntrCoding) > 0 );
@@ -692,8 +696,8 @@ void IntrForEndBody (
     UInt                nr )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert(STATE(IntrCoding) > 0);
@@ -703,8 +707,8 @@ void IntrForEndBody (
 void IntrForEnd ( void )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert( STATE(IntrCoding) > 0 );
@@ -746,8 +750,8 @@ void IntrForEnd ( void )
 void            IntrWhileBegin ( void )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     if (STATE(IntrCoding) == 0)
         StartFakeFuncExpr(0);
@@ -761,8 +765,8 @@ void            IntrWhileBegin ( void )
 void            IntrWhileBeginBody ( void )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert( STATE(IntrCoding) > 0 );
@@ -773,8 +777,8 @@ void            IntrWhileEndBody (
     UInt                nr )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert( STATE(IntrCoding) > 0 );
@@ -784,8 +788,8 @@ void            IntrWhileEndBody (
 void            IntrWhileEnd ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert( STATE(IntrCoding) > 0 );
@@ -810,7 +814,7 @@ void            IntrWhileEnd ( void )
 void IntrQualifiedExprBegin(UInt qual) 
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
     if ( STATE(IntrCoding)    > 0 ) { CodeQualifiedExprBegin(qual); return; }
     PushObj(INTOBJ_INT(qual));
@@ -819,7 +823,7 @@ void IntrQualifiedExprBegin(UInt qual)
 void IntrQualifiedExprEnd( void ) 
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)--; return; }
     if ( STATE(IntrCoding)    > 0 ) { CodeQualifiedExprEnd(); return; }
 }
@@ -854,8 +858,8 @@ void IntrQualifiedExprEnd( void )
 void            IntrAtomicBegin ( void )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     if (STATE(IntrCoding) == 0)
         StartFakeFuncExpr(GetInputLineNumber());
@@ -868,8 +872,8 @@ void            IntrAtomicBegin ( void )
 void            IntrAtomicBeginBody ( UInt nrexprs )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert(STATE(IntrCoding) > 0);
@@ -880,8 +884,8 @@ void            IntrAtomicEndBody (
     Int                nrstats )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     // must be coding
     assert(STATE(IntrCoding) > 0);
@@ -891,8 +895,8 @@ void            IntrAtomicEndBody (
 void            IntrAtomicEnd ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert(STATE(IntrCoding) > 0);
@@ -934,8 +938,8 @@ void            IntrAtomicEnd ( void )
 void            IntrRepeatBegin ( void )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     if (STATE(IntrCoding) == 0)
         StartFakeFuncExpr(GetInputLineNumber());
@@ -949,8 +953,8 @@ void            IntrRepeatBegin ( void )
 void            IntrRepeatBeginBody ( void )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert( STATE(IntrCoding) > 0 );
@@ -961,8 +965,8 @@ void            IntrRepeatEndBody (
     UInt                nr )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert( STATE(IntrCoding) > 0 );
@@ -972,8 +976,8 @@ void            IntrRepeatEndBody (
 void            IntrRepeatEnd ( void )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     assert( STATE(IntrCoding) > 0 );
@@ -999,8 +1003,8 @@ void            IntrRepeatEnd ( void )
 void            IntrBreak ( void )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     if ( STATE(IntrCoding) == 0 )
@@ -1023,8 +1027,8 @@ void            IntrBreak ( void )
 void            IntrContinue ( void )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     if ( STATE(IntrCoding) == 0 )
@@ -1047,8 +1051,8 @@ void            IntrReturnObj ( void )
     Obj                 val;            /* return value                    */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeReturnObj(); return; }
 
 
@@ -1072,8 +1076,8 @@ void            IntrReturnObj ( void )
 void            IntrReturnVoid ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeReturnVoid(); return; }
 
 
@@ -1096,8 +1100,8 @@ void            IntrReturnVoid ( void )
 void            IntrQuit ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* 'quit' is not allowed in functions (by the reader)                  */
     assert( STATE(IntrCoding) == 0 );
@@ -1120,8 +1124,8 @@ void            IntrQuit ( void )
 void            IntrQUIT ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* 'QUIT' is not allowed in functions (by the reader)                  */
     assert( STATE(IntrCoding) == 0 );
@@ -1147,12 +1151,8 @@ void IntrHelp(Obj topic)
     Obj  help;
     Obj  res;
 
-    if (STATE(IntrReturning) > 0) {
-        return;
-    }
-    if (STATE(IntrIgnoring) > 0) {
-        return;
-    }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     // '?' is not allowed in functions (by the reader)
     assert( STATE(IntrCoding) == 0 );
@@ -1195,7 +1195,7 @@ void            IntrOrL ( void )
     Obj                 opL;            /* value of left operand           */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
     if ( STATE(IntrCoding)    > 0 ) { CodeOrL(); return; }
 
@@ -1215,7 +1215,7 @@ void            IntrOr ( void )
     Obj                 opR;            /* value of right operand          */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 1 ) { STATE(IntrIgnoring)--; return; }
     if ( STATE(IntrCoding)    > 0 ) { CodeOr(); return; }
 
@@ -1269,7 +1269,7 @@ void            IntrAndL ( void )
     Obj                 opL;            /* value of left operand           */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
     if ( STATE(IntrCoding)    > 0 ) { CodeAndL(); return; }
 
@@ -1289,7 +1289,7 @@ void            IntrAnd ( void )
     Obj                 opR;            /* value of right operand          */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 1 ) { STATE(IntrIgnoring)--; return; }
     if ( STATE(IntrCoding)    > 0 ) { CodeAnd(); return; }
 
@@ -1352,8 +1352,8 @@ void            IntrNot ( void )
     Obj                 op;             /* operand                         */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeNot(); return; }
 
 
@@ -1407,8 +1407,8 @@ void            IntrEq ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeEq(); return; }
 
 
@@ -1426,8 +1426,8 @@ void            IntrEq ( void )
 void            IntrNe ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeNe(); return; }
 
 
@@ -1443,8 +1443,8 @@ void            IntrLt ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeLt(); return; }
 
 
@@ -1462,8 +1462,8 @@ void            IntrLt ( void )
 void            IntrGe ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeGe(); return; }
 
 
@@ -1475,8 +1475,8 @@ void            IntrGe ( void )
 void            IntrGt ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeGt(); return; }
 
 
@@ -1488,8 +1488,8 @@ void            IntrGt ( void )
 void            IntrLe ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeLe(); return; }
 
 
@@ -1514,8 +1514,8 @@ void            IntrIn ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeIn(); return; }
 
 
@@ -1552,8 +1552,8 @@ void            IntrSum ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeSum(); return; }
 
 
@@ -1574,8 +1574,8 @@ void            IntrAInv ( void )
     Obj                 opL;            /* left operand                    */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAInv(); return; }
 
 
@@ -1596,8 +1596,8 @@ void            IntrDiff ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeDiff(); return; }
 
 
@@ -1619,8 +1619,8 @@ void            IntrProd ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeProd(); return; }
 
 
@@ -1642,8 +1642,8 @@ void            IntrQuo ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeQuo(); return; }
 
 
@@ -1665,8 +1665,8 @@ void            IntrMod ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeMod(); return; }
 
 
@@ -1688,8 +1688,8 @@ void            IntrPow ( void )
     Obj                 opR;            /* right operand                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodePow(); return; }
 
 
@@ -1715,8 +1715,8 @@ void            IntrPow ( void )
 void IntrIntExpr(Obj string, Char * str)
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     
     Obj val = IntStringInternal(string, str);
     GAP_ASSERT(val != Fail);
@@ -1764,8 +1764,8 @@ static Obj ConvertFloatLiteralEager(Obj str)
 void IntrFloatExpr(Obj string, Char * str)
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) {
         if (string)
             CodeLongFloatExpr(string);
@@ -1790,12 +1790,8 @@ void IntrFloatExpr(Obj string, Char * str)
 void IntrIntObjExpr(Obj val)
 {
     /* ignore or code                                                      */
-    if (STATE(IntrReturning) > 0) {
-        return;
-    }
-    if (STATE(IntrIgnoring) > 0) {
-        return;
-    }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if (STATE(IntrCoding) > 0) {
         CodeIntExpr(val);
         return;
@@ -1815,8 +1811,8 @@ void IntrIntObjExpr(Obj val)
 void            IntrTrueExpr ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeTrueExpr(); return; }
 
 
@@ -1834,8 +1830,8 @@ void            IntrTrueExpr ( void )
 void            IntrFalseExpr ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeFalseExpr(); return; }
 
 
@@ -1857,8 +1853,8 @@ void            IntrFalseExpr ( void )
 void            IntrTildeExpr ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeTildeExpr(); return; }
 
     if(! (STATE(Tilde)) ) {
@@ -1881,8 +1877,8 @@ void            IntrCharExpr (
     Char                chr )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeCharExpr( chr ); return; }
 
 
@@ -1908,8 +1904,8 @@ void            IntrPermCycle (
     UInt                j, k;           /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodePermCycle(nrx,nrc); return; }
 
 
@@ -1991,8 +1987,8 @@ void            IntrPerm (
     UInt                k;              /* loop variable                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodePerm(nrc); return; }
 
 
@@ -2045,8 +2041,8 @@ void            IntrListExprBegin (
     Obj                 old;            /* old value of '~'                */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeListExprBegin( top ); return; }
 
 
@@ -2070,8 +2066,8 @@ void            IntrListExprBeginElm (
     UInt                pos )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeListExprBeginElm( pos ); return; }
 
 
@@ -2087,8 +2083,8 @@ void            IntrListExprEndElm ( void )
     Obj                 val;            /* value to assign into list       */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeListExprEndElm(); return; }
 
 
@@ -2123,8 +2119,8 @@ void            IntrListExprEnd (
     Obj                 val;            /* temporary value                 */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeListExprEnd(nr,range,top,tilde); return; }
 
 
@@ -2235,8 +2231,8 @@ void           IntrStringExpr (
     Obj               string )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeStringExpr( string ); return; }
 
 
@@ -2259,8 +2255,8 @@ void            IntrRecExprBegin (
     Obj                 old;            /* old value of '~'                */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeRecExprBegin( top ); return; }
 
 
@@ -2284,8 +2280,8 @@ void            IntrRecExprBeginElmName (
     UInt                rnam )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeRecExprBeginElmName( rnam ); return; }
 
 
@@ -2298,8 +2294,8 @@ void            IntrRecExprBeginElmExpr ( void )
     UInt                rnam;           /* record name                     */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeRecExprBeginElmExpr(); return; }
 
 
@@ -2317,8 +2313,8 @@ void            IntrRecExprEndElm ( void )
     Obj                 val;            /* value of record element         */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeRecExprEndElm(); return; }
 
 
@@ -2347,8 +2343,8 @@ void            IntrRecExprEnd (
     Obj                 old;            /* old value of '~'                */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeRecExprEnd(nr,top,tilde); return; }
 
 
@@ -2378,8 +2374,8 @@ void            IntrFuncCallOptionsBegin ( void )
     Obj                 record;         /* new record                      */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsBegin( ); return; }
 
 
@@ -2393,8 +2389,8 @@ void            IntrFuncCallOptionsBeginElmName (
     UInt                rnam )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsBeginElmName( rnam ); return; }
 
 
@@ -2407,8 +2403,8 @@ void            IntrFuncCallOptionsBeginElmExpr ( void )
     UInt                rnam;           /* record name                     */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsBeginElmExpr(); return; }
 
 
@@ -2426,8 +2422,8 @@ void            IntrFuncCallOptionsEndElm ( void )
     Obj                 val;            /* value of record element         */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsEndElm(); return; }
 
 
@@ -2454,8 +2450,8 @@ void            IntrFuncCallOptionsEndElmEmpty ( void )
     Obj                 val;            /* value of record element         */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsEndElmEmpty(); return; }
 
 
@@ -2478,8 +2474,8 @@ void            IntrFuncCallOptionsEndElmEmpty ( void )
 void            IntrFuncCallOptionsEnd ( UInt nr )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeFuncCallOptionsEnd(nr); return; }
 
 
@@ -2495,8 +2491,8 @@ void            IntrAssLVar (
 {
   Obj val;
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     if ( STATE(IntrCoding) > 0 )
@@ -2514,8 +2510,8 @@ void            IntrUnbLVar (
     UInt                lvar )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     if ( STATE(IntrCoding) > 0 )
@@ -2538,8 +2534,8 @@ void            IntrRefLVar (
 {
   Obj val;
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     if ( STATE(IntrCoding) > 0 )
@@ -2563,8 +2559,8 @@ void            IntrIsbLVar (
     UInt                lvar )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     if( STATE(IntrCoding) > 0 )
@@ -2586,8 +2582,8 @@ void            IntrAssHVar (
 {
   Obj val;
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     if( STATE(IntrCoding) > 0 )
@@ -2604,8 +2600,8 @@ void            IntrUnbHVar (
     UInt                hvar )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     if ( STATE(IntrCoding) > 0 )
@@ -2627,8 +2623,8 @@ void            IntrRefHVar (
 {
   Obj val;
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     if( STATE(IntrCoding) > 0 )
@@ -2650,8 +2646,8 @@ void            IntrIsbHVar (
     UInt                hvar )
 {
     /* ignore                                                              */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
     if( STATE(IntrCoding) > 0 )
@@ -2676,8 +2672,8 @@ void            IntrAssDVar (
     Obj                 context;
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     /* if ( STATE(IntrCoding)    > 0 ) { CodeAssDVar( gvar ); return; } */
 
 
@@ -2707,8 +2703,8 @@ void            IntrUnbDVar (
     Obj                 context;
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     /* if ( STATE(IntrCoding)    > 0 ) { CodeUnbGVar( gvar ); return; } */
 
 
@@ -2740,8 +2736,8 @@ void            IntrRefDVar (
     Obj                 context;
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     /* if ( STATE(IntrCoding)    > 0 ) { CodeRefGVar( gvar ); return; } */
 
 
@@ -2772,8 +2768,8 @@ void            IntrIsbDVar (
     Obj                 context;
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     /* if ( STATE(IntrCoding)    > 0 ) { CodeIsbGVar( gvar ); return; } */
 
 
@@ -2798,8 +2794,8 @@ void            IntrAssGVar (
     Obj                 rhs;            /* right hand side                 */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAssGVar( gvar ); return; }
 
 
@@ -2817,8 +2813,8 @@ void            IntrUnbGVar (
     UInt                gvar )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeUnbGVar( gvar ); return; }
 
 
@@ -2840,8 +2836,8 @@ void            IntrRefGVar (
     Obj                 val;            /* value, result                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeRefGVar( gvar ); return; }
 
 
@@ -2862,8 +2858,8 @@ void            IntrIsbGVar (
     Obj                 val;            /* value, result                   */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeIsbGVar( gvar ); return; }
 
 
@@ -2891,8 +2887,8 @@ void            IntrAssList ( Int narg )
     GAP_ASSERT(narg == 1 || narg == 2);
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAssList( narg); return; }
 
     /* get the right hand side                                             */
@@ -2933,8 +2929,8 @@ void            IntrAsssList ( void )
     Obj                 rhss;           /* right hand sides                */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAsssList(); return; }
 
 
@@ -2968,8 +2964,8 @@ void            IntrAssListLevel (
     Int i;
     
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAssListLevel( narg, level ); return; }
 
     /* get right hand sides (checking is done by 'AssListLevel')           */
@@ -3003,8 +2999,8 @@ void            IntrAsssListLevel (
     Obj                 rhss;           /* right hand sides, right operand */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAsssListLevel( level ); return; }
 
 
@@ -3034,8 +3030,8 @@ void            IntrUnbList ( Int narg )
     GAP_ASSERT(narg == 1 || narg == 2);
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeUnbList( narg); return; }
 
     if (narg == 1) {
@@ -3082,8 +3078,8 @@ void            IntrElmList ( Int narg )
     GAP_ASSERT(narg == 1 || narg == 2);
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeElmList( narg ); return; }
 
     if (narg == 1) {
@@ -3120,8 +3116,8 @@ void            IntrElmsList ( void )
     Obj                 poss;           /* positions, right operand        */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeElmsList(); return; }
 
 
@@ -3148,8 +3144,8 @@ void            IntrElmListLevel ( Int narg,
     Int i;
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeElmListLevel( narg, level ); return; }
 
     /* get the positions */
@@ -3187,8 +3183,8 @@ void            IntrElmsListLevel (
     Obj                 poss;           /* positions, right operand        */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeElmsListLevel( level ); return; }
 
 
@@ -3216,8 +3212,8 @@ void            IntrIsbList ( Int narg )
     GAP_ASSERT(narg == 1 || narg == 2);
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeIsbList(narg); return; }
 
     if (narg == 1) {
@@ -3260,8 +3256,8 @@ void            IntrAssRecName (
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAssRecName( rnam ); return; }
 
 
@@ -3285,8 +3281,8 @@ void            IntrAssRecExpr ( void )
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAssRecExpr(); return; }
 
 
@@ -3312,8 +3308,8 @@ void            IntrUnbRecName (
     Obj                 record;         /* record, left operand            */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeUnbRecName( rnam ); return; }
 
 
@@ -3333,8 +3329,8 @@ void            IntrUnbRecExpr ( void )
     UInt                rnam;           /* name, left operand              */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeUnbRecExpr(); return; }
 
 
@@ -3364,8 +3360,8 @@ void            IntrElmRecName (
     Obj                 record;         /* the record, left operand        */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeElmRecName( rnam ); return; }
 
 
@@ -3386,8 +3382,8 @@ void            IntrElmRecExpr ( void )
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeElmRecExpr(); return; }
 
 
@@ -3411,8 +3407,8 @@ void            IntrIsbRecName (
     Obj                 record;         /* the record, left operand        */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeIsbRecName( rnam ); return; }
 
 
@@ -3433,8 +3429,8 @@ void            IntrIsbRecExpr ( void )
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeIsbRecExpr(); return; }
 
 
@@ -3467,8 +3463,8 @@ void            IntrAssPosObj ( void )
     Obj                 rhs;            /* right hand side                 */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAssPosObj(); return; }
 
 
@@ -3522,8 +3518,8 @@ void            IntrAsssPosObj ( void )
     Obj                 rhss;           /* right hand sides                */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAsssPosObj(); return; }
 
 
@@ -3562,8 +3558,8 @@ void            IntrAssPosObjLevel (
     Obj                 rhss;           /* right hand sides, right operand */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAssPosObjLevel( level ); return; }
 
 
@@ -3594,8 +3590,8 @@ void            IntrAsssPosObjLevel (
     Obj                 rhss;           /* right hand sides, right operand */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAsssPosObjLevel( level ); return; }
 
 
@@ -3622,8 +3618,8 @@ void            IntrUnbPosObj ( void )
     Int                 p;              /* position, as a C integer        */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeUnbPosObj(); return; }
 
 
@@ -3681,8 +3677,8 @@ void            IntrElmPosObj ( void )
     Int                 p;              /* position, as C integer          */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeElmPosObj(); return; }
 
 
@@ -3747,8 +3743,8 @@ void            IntrElmsPosObj ( void )
     Obj                 poss;           /* positions, right operand        */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeElmsPosObj(); return; }
 
 
@@ -3783,8 +3779,8 @@ void            IntrElmPosObjLevel (
     Obj                 pos;            /* position, right operand         */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeElmPosObjLevel( level ); return; }
 
 
@@ -3816,8 +3812,8 @@ void            IntrElmsPosObjLevel (
     Obj                 poss;           /* positions, right operand        */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeElmsPosObjLevel( level ); return; }
 
 
@@ -3846,8 +3842,8 @@ void            IntrIsbPosObj ( void )
     Int                 p;              /* position, as C integer          */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeIsbPosObj(); return; }
 
 
@@ -3906,8 +3902,8 @@ void            IntrAssComObjName (
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAssComObjName( rnam ); return; }
 
 
@@ -3943,8 +3939,8 @@ void            IntrAssComObjExpr ( void )
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAssComObjExpr(); return; }
 
 
@@ -3982,8 +3978,8 @@ void            IntrUnbComObjName (
     Obj                 record;         /* record, left operand            */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeUnbComObjName( rnam ); return; }
 
 
@@ -4015,8 +4011,8 @@ void            IntrUnbComObjExpr ( void )
     UInt                rnam;           /* name, left operand              */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeUnbComObjExpr(); return; }
 
 
@@ -4058,8 +4054,8 @@ void            IntrElmComObjName (
     Obj                 record;         /* the record, left operand        */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeElmComObjName( rnam ); return; }
 
 
@@ -4093,8 +4089,8 @@ void            IntrElmComObjExpr ( void )
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeElmComObjExpr(); return; }
 
 
@@ -4130,8 +4126,8 @@ void            IntrIsbComObjName (
     Obj                 record;         /* the record, left operand        */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeIsbComObjName( rnam ); return; }
 
 
@@ -4164,8 +4160,8 @@ void            IntrIsbComObjExpr ( void )
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeIsbComObjExpr(); return; }
 
 
@@ -4203,8 +4199,8 @@ void            IntrIsbComObjExpr ( void )
 void             IntrEmpty ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeEmpty(); return; }
 
 
@@ -4237,8 +4233,8 @@ void             IntrEmpty ( void )
 void            IntrInfoBegin( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeInfoBegin(); return; }
 
 }
@@ -4302,7 +4298,7 @@ void            IntrInfoMiddle( void )
                         gets printed or not */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
     if ( STATE(IntrCoding)    > 0 ) { CodeInfoMiddle(); return; }
 
@@ -4326,7 +4322,7 @@ void            IntrInfoEnd( UInt narg )
      Obj args;    /* gathers up the arguments to be printed */
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 1 ) { STATE(IntrIgnoring)--; return; }
     if ( STATE(IntrCoding)    > 0 ) { CodeInfoEnd( narg ); return; }
 
@@ -4382,8 +4378,8 @@ Obj              CurrentAssertionLevel;
 void              IntrAssertBegin ( void )
 {
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
-    if ( STATE(IntrIgnoring)  > 0 ) { return; }
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
     if ( STATE(IntrCoding)    > 0 ) { CodeAssertBegin(); return; }
 
 }
@@ -4394,7 +4390,7 @@ void             IntrAssertAfterLevel ( void )
   Obj level;
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
     if ( STATE(IntrCoding)    > 0 ) { CodeAssertAfterLevel(); return; }
 
@@ -4410,7 +4406,7 @@ void             IntrAssertAfterCondition ( void )
   Obj condition;
 
     /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
     if ( STATE(IntrCoding)    > 0 ) { CodeAssertAfterCondition(); return; }
 
@@ -4428,7 +4424,7 @@ void             IntrAssertAfterCondition ( void )
 void             IntrAssertEnd2Args ( void )
 {
       /* ignore or code                                                      */
-    if ( STATE(IntrReturning) > 0 ) { return; }
+    SKIP_IF_RETURNING();
     if ( STATE(IntrIgnoring)  > 2 ) { STATE(IntrIgnoring) -= 2; return; }
     if ( STATE(IntrCoding)    > 0 ) { CodeAssertEnd2Args(); return; }
 
@@ -4447,7 +4443,7 @@ void             IntrAssertEnd3Args ( void )
 {
   Obj message;
   /* ignore or code                                                      */
-  if ( STATE(IntrReturning) > 0 ) { return; }
+  SKIP_IF_RETURNING();
   if ( STATE(IntrIgnoring)  > 2 ) { STATE(IntrIgnoring) -= 2; return; }
   if ( STATE(IntrCoding)    > 0 ) { CodeAssertEnd3Args(); return; }
 


### PR DESCRIPTION
This makes it easier to locate the few places in which `STATE(IntrIgnoring)` and `STATE(IntrReturning)` are used non-trivially.

This PR was of course created using search&replace.