### PR TITLE
Remove superflous libgap.so target

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -388,10 +388,6 @@ gap$(EXEEXT): libgap.la cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
 
 else
 
-all: libgap.so
-libgap.so: symlinks libgap.la
-	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) -shared $(OBJS) $(GAP_LIBS) -o $@
-
 # Linking rule and dependencies for the main gap executable
 gap$(EXEEXT): $(OBJS) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
 	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $(OBJS) $(GAP_LIBS) -o $@
@@ -460,7 +456,6 @@ clean:
 	rm -rf obj
 	rm -f gap$(EXEEXT) gac ffgen
 	rm -f libgap.la
-	rm -f libgap.so
 	rm -f gen/gap_version.c
 	rm -f doc/wsp.g
 	rm -f cnf/GAP-{CFLAGS,CPPFLAGS,LDFLAGS,LIBS,OBJS}


### PR DESCRIPTION
In future, with a working install target, the correct (system dependent) shared
library file will be installed.