### PR TITLE
Fix several bugs (including crashes) 

### DIFF
--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -1653,8 +1653,7 @@ It is an error to use this statement other than inside a loop.
 <P/>
 <Log><![CDATA[
 gap> break;
-Error, A break statement can only appear inside a loop
-not in any function
+Syntax error: 'break' statement not enclosed in a loop
 ]]></Log>
 
 </Section>
@@ -1688,8 +1687,7 @@ It is an error to use this statement other than inside a loop.
 <P/>
 <Log><![CDATA[
 gap> continue;
-Error, A continue statement can only appear inside a loop
-not in any function
+Syntax error: 'continue' statement not enclosed in a loop
 ]]></Log>
 
 </Section>

--- a/src/code.c
+++ b/src/code.c
@@ -2316,13 +2316,13 @@ void CodeAssList ( Int narg )
 {
     Stat                ass;            /* assignment, result              */
 
+    GAP_ASSERT(narg == 1 || narg == 2);
+
     /* allocate the assignment                                             */
     if (narg == 1)
       ass = NewStat( T_ASS_LIST, 3 * sizeof(Stat) );
-    else if (narg == 2)
+    else /* if (narg == 2) */
       ass = NewStat( T_ASS2_LIST, 4 * sizeof(Stat));
-    else
-      ass = NewStat( T_ASSX_LIST, (narg + 2) * sizeof(Stat));
 
     /* let 'CodeAssListUniv' do the rest                                   */
     CodeAssListUniv( ass, narg );
@@ -2429,13 +2429,13 @@ void CodeElmList ( Int narg )
 {
     Expr                ref;            /* reference, result               */
 
+    GAP_ASSERT(narg == 1 || narg == 2);
+
     /* allocate the reference                                              */
     if (narg == 1)
       ref = NewExpr( T_ELM_LIST, 2 * sizeof(Expr) );
-    else if (narg == 2)
+    else /* if (narg == 2) */
       ref = NewExpr( T_ELM2_LIST, 3 * sizeof(Expr) );
-    else
-      ref = NewExpr( T_ELMX_LIST, (narg + 1) * sizeof(Expr));
       
     /* let 'CodeElmListUniv' to the rest                                   */
     CodeElmListUniv( ref, narg );

--- a/src/code.c
+++ b/src/code.c
@@ -2287,9 +2287,7 @@ void CodeIsbGVar (
 *F  CodeAssListLevel( <level> ) . . . . . .  code assignment to several lists
 *F  CodeAsssListLevel( <level> )  . code multiple assignment to several lists
 */
-void CodeAssListUniv ( 
-		      Stat                ass,
-		       Int narg)
+static void CodeAssListUniv(Stat ass, Int narg)
 {
     Expr                list;           /* list expression                 */
     Expr                pos;            /* position expression             */
@@ -2404,7 +2402,7 @@ void CodeUnbList ( Int narg )
 *F  CodeElmListLevel( <level> ) . . . . . . . code selection of several lists
 *F  CodeElmsListLevel( <level> )  .  code multiple selection of several lists
 */
-void CodeElmListUniv (
+static void CodeElmListUniv (
 		      Expr                ref,
 		      Int narg)
 {
@@ -2709,16 +2707,16 @@ void CodeIsbRecExpr ( void )
 /****************************************************************************
 **
 *F  CodeAssPosObj() . . . . . . . . . . . . . . . . code assignment to a list
-*F  CodeAsssPosObj()  . . . . . . . . . .  code multiple assignment to a list
-*F  CodeAssPosObjLevel( <level> ) . . . . .  code assignment to several lists
-*F  CodeAsssPosObjLevel( <level> )  code multiple assignment to several lists
 */
-void CodeAssPosObjUniv (
-    Stat                ass )
+void CodeAssPosObj ( void )
 {
+    Stat                ass;            /* assignment, result              */
     Expr                list;           /* list expression                 */
     Expr                pos;            /* position expression             */
     Expr                rhsx;           /* right hand side expression      */
+
+    /* allocate the assignment                                             */
+    ass = NewStat( T_ASS_POSOBJ, 3 * sizeof(Stat) );
 
     /* enter the right hand side expression                                */
     rhsx = PopExpr();
@@ -2734,54 +2732,6 @@ void CodeAssPosObjUniv (
 
     /* push the assignment                                                 */
     PushStat( ass );
-}
-
-void CodeAssPosObj ( void )
-{
-    Stat                ass;            /* assignment, result              */
-
-    /* allocate the assignment                                             */
-    ass = NewStat( T_ASS_POSOBJ, 3 * sizeof(Stat) );
-
-    /* let 'CodeAssPosObjUniv' do the rest                                 */
-    CodeAssPosObjUniv( ass );
-}
-
-void CodeAsssPosObj ( void )
-{
-    Stat                ass;            /* assignment, result              */
-
-    /* allocate the assignment                                             */
-    ass = NewStat( T_ASSS_POSOBJ, 3 * sizeof(Stat) );
-
-    /* let 'CodeAssPosObjUniv' do the rest                                 */
-    CodeAssPosObjUniv( ass );
-}
-
-void CodeAssPosObjLevel (
-    UInt                level )
-{
-    Stat                ass;            /* assignment, result              */
-
-    /* allocate the assignment and enter the level                         */
-    ass = NewStat( T_ASS_POSOBJ_LEV, 4 * sizeof(Stat) );
-    WRITE_STAT(ass, 3, level);
-
-    /* let 'CodeAssPosObjUniv' do the rest                                 */
-    CodeAssPosObjUniv( ass );
-}
-
-void CodeAsssPosObjLevel (
-    UInt                level )
-{
-    Stat                ass;            /* assignment, result              */
-
-    /* allocate the assignment and enter the level                         */
-    ass = NewStat( T_ASSS_POSOBJ_LEV, 4 * sizeof(Stat) );
-    WRITE_STAT(ass, 3, level);
-
-    /* let 'CodeAssPosObjUniv' do the rest                                 */
-    CodeAssPosObjUniv( ass );
 }
 
 
@@ -2814,15 +2764,15 @@ void CodeUnbPosObj ( void )
 /****************************************************************************
 **
 *F  CodeElmPosObj() . . . . . . . . . . . . . . . .  code selection of a list
-*F  CodeElmsPosObj()  . . . . . . . . . . . code multiple selection of a list
-*F  CodeElmPosObjLevel( <level> ) . . . . . . code selection of several lists
-*F  CodeElmsPosObjLevel( <level> )   code multiple selection of several lists
 */
-void CodeElmPosObjUniv (
-    Expr                ref )
+void CodeElmPosObj ( void )
 {
+    Expr                ref;            /* reference, result               */
     Expr                list;           /* list expression                 */
     Expr                pos;            /* position expression             */
+
+    /* allocate the reference                                              */
+    ref = NewExpr( T_ELM_POSOBJ, 2 * sizeof(Expr) );
 
     /* enter the position expression                                       */
     pos = PopExpr();
@@ -2834,54 +2784,6 @@ void CodeElmPosObjUniv (
 
     /* push the reference                                                  */
     PushExpr( ref );
-}
-
-void CodeElmPosObj ( void )
-{
-    Expr                ref;            /* reference, result               */
-
-    /* allocate the reference                                              */
-    ref = NewExpr( T_ELM_POSOBJ, 2 * sizeof(Expr) );
-
-    /* let 'CodeElmPosObjUniv' to the rest                                   */
-    CodeElmPosObjUniv( ref );
-}
-
-void CodeElmsPosObj ( void )
-{
-    Expr                ref;            /* reference, result               */
-
-    /* allocate the reference                                              */
-    ref = NewExpr( T_ELMS_POSOBJ, 2 * sizeof(Expr) );
-
-    /* let 'CodeElmPosObjUniv' to the rest                                   */
-    CodeElmPosObjUniv( ref );
-}
-
-void CodeElmPosObjLevel (
-    UInt                level )
-{
-    Expr                ref;            /* reference, result               */
-
-    /* allocate the reference and enter the level                          */
-    ref = NewExpr( T_ELM_POSOBJ_LEV, 3 * sizeof(Expr) );
-    WRITE_EXPR(ref, 2, level);
-
-    /* let 'CodeElmPosObjUniv' do the rest                                 */
-    CodeElmPosObjUniv( ref );
-}
-
-void CodeElmsPosObjLevel (
-    UInt                level )
-{
-    Expr                ref;            /* reference, result               */
-
-    /* allocate the reference and enter the level                          */
-    ref = NewExpr( T_ELMS_POSOBJ_LEV, 3 * sizeof(Expr) );
-    WRITE_EXPR(ref, 2, level);
-
-    /* let 'CodeElmPosObjUniv' do the rest                                 */
-    CodeElmPosObjUniv( ref );
 }
 
 

--- a/src/code.h
+++ b/src/code.h
@@ -216,9 +216,6 @@ enum STAT_TNUM {
         T_UNB_REC_EXPR,
 
         T_ASS_POSOBJ,
-        T_ASSS_POSOBJ,
-        T_ASS_POSOBJ_LEV,
-        T_ASSS_POSOBJ_LEV,
         T_UNB_POSOBJ,
 
         T_ASS_COMOBJ_NAME,
@@ -424,9 +421,6 @@ enum EXPR_TNUM {
     T_ISB_REC_EXPR,
 
     T_ELM_POSOBJ,
-    T_ELMS_POSOBJ,
-    T_ELM_POSOBJ_LEV,
-    T_ELMS_POSOBJ_LEV,
     T_ISB_POSOBJ,
 
     T_ELM_COMOBJ_NAME,
@@ -1254,19 +1248,8 @@ extern  void            CodeIsbRecExpr ( void );
 /****************************************************************************
 **
 *F  CodeAssPosObj() . . . . . . . . . . . . . . . . code assignment to a list
-*F  CodeAsssPosObj()  . . . . . . . . . .  code multiple assignment to a list
-*F  CodeAssPosObjLevel(<level>) . . . . . .  code assignment to several lists
-*F  CodeAsssPosObjLevel(<level>)  . code multiple assignment to several lists
 */
 extern  void            CodeAssPosObj ( void );
-
-extern  void            CodeAsssPosObj ( void );
-
-extern  void            CodeAssPosObjLevel (
-            UInt                level );
-
-extern  void            CodeAsssPosObjLevel (
-            UInt                level );
 
 extern  void            CodeUnbPosObj ( void );
 
@@ -1274,19 +1257,8 @@ extern  void            CodeUnbPosObj ( void );
 /****************************************************************************
 **
 *F  CodeElmPosObj() . . . . . . . . . . . . . . . .  code selection of a list
-*F  CodeElmsPosObj()  . . . . . . . . . . . code multiple selection of a list
-*F  CodeElmPosObjLevel(<level>) . . . . . . . code selection of several lists
-*F  CodeElmsPosObjLevel(<level>)  .  code multiple selection of several lists
 */
 extern  void            CodeElmPosObj ( void );
-
-extern  void            CodeElmsPosObj ( void );
-
-extern  void            CodeElmPosObjLevel (
-            UInt                level );
-
-extern  void            CodeElmsPosObjLevel (
-            UInt                level );
 
 extern  void            CodeIsbPosObj ( void );
 

--- a/src/code.h
+++ b/src/code.h
@@ -204,7 +204,6 @@ enum STAT_TNUM {
 
         T_ASS_LIST,
         T_ASS2_LIST,
-        T_ASSX_LIST,
         T_ASSS_LIST,
         T_ASS_LIST_LEV,
         T_ASSS_LIST_LEV,
@@ -409,7 +408,6 @@ enum EXPR_TNUM {
 
     T_ELM_LIST,
     T_ELM2_LIST,
-    T_ELMX_LIST,
     T_ELMS_LIST,
     T_ELM_LIST_LEV,
     T_ELMS_LIST_LEV,

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -3434,42 +3434,6 @@ CVar CompElmPosObj (
 
 /****************************************************************************
 **
-*F  CompElmsPosObj( <expr> )  . . . . . . . . . . . . . . . . . T_ELMS_POSOBJ
-*/
-CVar CompElmsPosObj (
-    Expr                expr )
-{
-    Emit( "CANNOT COMPILE EXPRESSION OF TNUM %d;\n", TNUM_EXPR(expr) );
-    return 0;
-}
-
-
-/****************************************************************************
-**
-*F  CompElmPosObjLev( <expr> )  . . . . . . . . . . . . . .  T_ELM_POSOBJ_LEV
-*/
-CVar CompElmPosObjLev (
-    Expr                expr )
-{
-    Emit( "CANNOT COMPILE EXPRESSION OF TNUM %d;\n", TNUM_EXPR(expr) );
-    return 0;
-}
-
-
-/****************************************************************************
-**
-*F  CompElmsPosObjLev( <expr> ) . . . . . . . . . . . . . . . . T_ELMS_POSOBJ
-*/
-CVar CompElmsPosObjLev (
-    Expr                expr )
-{
-    Emit( "CANNOT COMPILE EXPRESSION OF TNUM %d;\n", TNUM_EXPR(expr) );
-    return 0;
-}
-
-
-/****************************************************************************
-**
 *F  CompIsbPosObj( <expr> ) . . . . . . . . . . . . . . . . . .  T_ISB_POSOBJ
 */
 CVar CompIsbPosObj (
@@ -4983,64 +4947,6 @@ void CompAssPosObj (
 }
 
 
-
-/****************************************************************************
-**
-*F  CompAsssPosObj( <stat> )  . . . . . . . . . . . . . . . . . T_ASSS_POSOBJ
-*/
-void CompAsssPosObj (
-    Stat                stat )
-{
-    CVar                list;           /* list                            */
-    CVar                poss;           /* positions                       */
-    CVar                rhss;           /* right hand sides                */
-
-    /* print a comment                                                     */
-    if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
-    }
-
-    /* compile the list expression                                         */
-    list = CompExpr(READ_STAT(stat, 0));
-
-    /* compile and check the position expression                           */
-    poss = CompExpr(READ_STAT(stat, 1));
-
-    /* compile the right hand side                                         */
-    rhss = CompExpr(READ_STAT(stat, 2));
-
-    /* emit the code                                                       */
-    Emit( "AsssPosObjCheck( %c, %c, %c );\n", list, poss, rhss );
-
-    /* free the temporaries                                                */
-    if ( IS_TEMP_CVAR( rhss ) )  FreeTemp( TEMP_CVAR( rhss ) );
-    if ( IS_TEMP_CVAR( poss ) )  FreeTemp( TEMP_CVAR( poss ) );
-    if ( IS_TEMP_CVAR( list ) )  FreeTemp( TEMP_CVAR( list ) );
-}
-
-
-/****************************************************************************
-**
-*F  CompAssPosObjLev( <stat> )  . . . . . . . . . . . . . .  T_ASS_POSOBJ_LEV
-*/
-void CompAssPosObjLev (
-    Stat                stat )
-{
-    Emit( "CANNOT COMPILE STATEMENT OF TNUM %d;\n", TNUM_STAT(stat) );
-}
-
-
-/****************************************************************************
-**
-*F  CompAsssPosObjLev( <stat> ) . . . . . . . . . . . . . . T_ASSS_POSOBJ_LEV
-*/
-void CompAsssPosObjLev (
-    Stat                stat )
-{
-    Emit( "CANNOT COMPILE STATEMENT OF TNUM %d;\n", TNUM_STAT(stat) );
-}
-
-
 /****************************************************************************
 **
 *F  CompUnbPosObj( <stat> ) . . . . . . . . . . . . . . . . . .  T_UNB_POSOBJ
@@ -5918,9 +5824,6 @@ static Int InitKernel (
     CompExprFuncs[ T_ISB_REC_EXPR    ] = CompIsbRecExpr;
 
     CompExprFuncs[ T_ELM_POSOBJ      ] = CompElmPosObj;
-    CompExprFuncs[ T_ELMS_POSOBJ     ] = CompElmsPosObj;
-    CompExprFuncs[ T_ELM_POSOBJ_LEV  ] = CompElmPosObjLev;
-    CompExprFuncs[ T_ELMS_POSOBJ_LEV ] = CompElmsPosObjLev;
     CompExprFuncs[ T_ISB_POSOBJ      ] = CompIsbPosObj;
     CompExprFuncs[ T_ELM_COMOBJ_NAME ] = CompElmComObjName;
     CompExprFuncs[ T_ELM_COMOBJ_EXPR ] = CompElmComObjExpr;
@@ -6005,9 +5908,6 @@ static Int InitKernel (
     CompStatFuncs[ T_UNB_REC_EXPR    ] = CompUnbRecExpr;
 
     CompStatFuncs[ T_ASS_POSOBJ      ] = CompAssPosObj;
-    CompStatFuncs[ T_ASSS_POSOBJ     ] = CompAsssPosObj;
-    CompStatFuncs[ T_ASS_POSOBJ_LEV  ] = CompAssPosObjLev;
-    CompStatFuncs[ T_ASSS_POSOBJ_LEV ] = CompAsssPosObjLev;
     CompStatFuncs[ T_UNB_POSOBJ      ] = CompUnbPosObj;
     CompStatFuncs[ T_ASS_COMOBJ_NAME ] = CompAssComObjName;
     CompStatFuncs[ T_ASS_COMOBJ_EXPR ] = CompAssComObjExpr;

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -847,9 +847,9 @@ Obj             EvalPermExpr (
                     "you can replace <expr> via 'return <expr>;'" );
             }
             c = INT_INTOBJ(val);
-	    if (c > MAX_DEG_PERM4)
-	      ErrorMayQuit( "Permutation literal exceeds maximum permutation degree -- %i vs %i",
-			    c, MAX_DEG_PERM4);
+            if (c > MAX_DEG_PERM4)
+              ErrorMayQuit( "Permutation literal exceeds maximum permutation degree -- %i vs %i",
+                            c, MAX_DEG_PERM4);
 
             /* if necessary resize the permutation                         */
             if (DEG_PERM4(perm) < c) {
@@ -867,9 +867,9 @@ Obj             EvalPermExpr (
             ptr4 = ADDR_PERM4( perm );
             if ( (p != 0 && p == c) || (ptr4[c-1] != c-1) ) {
                 return ErrorReturnObj(
-                    "Permutation: cycles must be disjoint",
+                    "Permutation: cycles must be disjoint and duplicate-free",
                     0L, 0L,
-                    "you can replace permutation <perm> via 'return <perm>;'" );
+                    "you can replace the permutation <perm> via 'return <perm>;'" );
             }
 
             /* enter the previous entry at current location                */
@@ -883,6 +883,9 @@ Obj             EvalPermExpr (
 
         /* enter first (last popped) entry at last (first popped) location */
         ptr4 = ADDR_PERM4( perm );
+        if (ptr4[l-1] != l-1) {
+            ErrorQuit("Permutation: cycles must be disjoint and duplicate-free", 0L, 0L );
+        }
         ptr4[l-1] = p-1;
 
     }

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -3470,9 +3470,6 @@ void            IntrIsbRecExpr ( void )
 /****************************************************************************
 **
 *F  IntrAssPosObj() . . . . . . . . . . . . .  interpret assignment to a list
-*F  IntrAsssPosObj()  . . . . . . . . interpret multiple assignment to a list
-*F  IntrAssPosObjLevel(<level>) . . . . interpret assignment to several lists
-*F  IntrAsssPosObjLevel(<level>)  . intr multiple assignment to several lists
 */
 void            IntrAssPosObj ( void )
 {
@@ -3530,106 +3527,6 @@ void            IntrAssPosObj ( void )
     PushObj( rhs );
 }
 
-void            IntrAsssPosObj ( void )
-{
-    Obj                 list;           /* list                            */
-    Obj                 poss;           /* positions                       */
-    Obj                 rhss;           /* right hand sides                */
-
-    /* ignore or code                                                      */
-    SKIP_IF_RETURNING();
-    SKIP_IF_IGNORING();
-    if ( STATE(IntrCoding)    > 0 ) { CodeAsssPosObj(); return; }
-
-
-    /* get the right hand sides                                            */
-    rhss = PopObj();
-    CheckIsDenseList("PosObj Assignment", "rhss", rhss);
-
-    /* get and check the positions                                         */
-    poss = PopObj();
-    CheckIsPossList("PosObj Assignment", poss);
-    CheckSameLength("List Assignment", "rhss", "positions", rhss, poss);
-
-    /* get the list (checking is done by 'ASSS_LIST')                      */
-    list = PopObj();
-
-    /* assign to several elements of the list                              */
-    if ( TNUM_OBJ(list) == T_POSOBJ
-#ifdef HPCGAP
-    || TNUM_OBJ(list) == T_APOSOBJ
-#endif
-    ) {
-        ErrorQuit( "sorry: <posobj>!{<poss>} not yet implemented", 0L, 0L );
-    }
-    else {
-        ASSS_LIST( list, poss, rhss );
-    }
-
-    /* push the right hand sides again                                     */
-    PushObj( rhss );
-}
-
-void            IntrAssPosObjLevel (
-    UInt                level )
-{
-    Obj                 pos;            /* position, left operand          */
-    Obj                 rhss;           /* right hand sides, right operand */
-
-    /* ignore or code                                                      */
-    SKIP_IF_RETURNING();
-    SKIP_IF_IGNORING();
-    if ( STATE(IntrCoding)    > 0 ) { CodeAssPosObjLevel( level ); return; }
-
-
-    /* get right hand sides (checking is done by 'AssPosObjLevel')           */
-    rhss = PopObj();
-
-    /* get and check the position                                          */
-    pos = PopObj();
-    if ( ! IS_POS_INTOBJ(pos) ) {
-        ErrorQuit(
-         "PosObj Assignment: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
-    }
-
-    /* assign the right hand sides to the elements of several lists        */
-    ErrorQuit(
-        "sorry: <lists>{<poss>}![<pos>] not yet implemented",
-        0L, 0L );
-
-    /* push the assigned values again                                      */
-    PushObj( rhss );
-}
-
-void            IntrAsssPosObjLevel (
-    UInt                level )
-{
-    Obj                 poss;           /* position, left operand          */
-    Obj                 rhss;           /* right hand sides, right operand */
-
-    /* ignore or code                                                      */
-    SKIP_IF_RETURNING();
-    SKIP_IF_IGNORING();
-    if ( STATE(IntrCoding)    > 0 ) { CodeAsssPosObjLevel( level ); return; }
-
-
-    /* get right hand sides (checking is done by 'AsssPosObjLevel')          */
-    rhss = PopObj();
-
-    /* get and check the positions                                         */
-    poss = PopObj();
-    CheckIsPossList("PosObj Assignment", poss);
-
-    /* assign the right hand sides to several elements of several lists    */
-    ErrorQuit(
-        "sorry: <lists>{<poss>}!{<poss>} not yet implemented",
-        0L, 0L );
-
-    /* push the assigned values again                                      */
-    PushObj( rhss );
-}
-
 void            IntrUnbPosObj ( void )
 {
     Obj                 list;           /* list                            */
@@ -3684,9 +3581,6 @@ void            IntrUnbPosObj ( void )
 /****************************************************************************
 **
 *F  IntrElmPosObj() . . . . . . . . . . . . . . interpret selection of a list
-*F  IntrElmsPosObj()  . . . . . . . .  interpret multiple selection of a list
-*F  IntrElmPosObjLevel(<level>) . . . .  interpret selection of several lists
-*F  IntrElmsPosObjLevel(<level>)  .  intr multiple selection of several lists
 */
 void            IntrElmPosObj ( void )
 {
@@ -3753,104 +3647,6 @@ void            IntrElmPosObj ( void )
 
     /* push the element                                                    */
     PushObj( elm );
-}
-
-void            IntrElmsPosObj ( void )
-{
-    Obj                 elms;           /* elements, result                */
-    Obj                 list;           /* list, left operand              */
-    Obj                 poss;           /* positions, right operand        */
-
-    /* ignore or code                                                      */
-    SKIP_IF_RETURNING();
-    SKIP_IF_IGNORING();
-    if ( STATE(IntrCoding)    > 0 ) { CodeElmsPosObj(); return; }
-
-
-    /* get and check the positions                                         */
-    poss = PopObj();
-    CheckIsPossList("PosObj Elements", poss);
-
-    /* get the list (checking is done by 'ELMS_LIST')                      */
-    list = PopObj();
-
-    /* select several elements from the list                               */
-    if ( TNUM_OBJ(list) == T_POSOBJ
-#ifdef HPCGAP
-    || TNUM_OBJ(list) == T_APOSOBJ
-#endif
-    ) {
-        elms = 0;
-        ErrorQuit( "sorry: <posobj>!{<poss>} not yet implemented", 0L, 0L );
-    }
-    else {
-        elms = ELMS_LIST( list, poss );
-    }
-
-    /* push the elements                                                   */
-    PushObj( elms );
-}
-
-void            IntrElmPosObjLevel (
-    UInt                level )
-{
-    Obj                 lists;          /* lists, left operand             */
-    Obj                 pos;            /* position, right operand         */
-
-    /* ignore or code                                                      */
-    SKIP_IF_RETURNING();
-    SKIP_IF_IGNORING();
-    if ( STATE(IntrCoding)    > 0 ) { CodeElmPosObjLevel( level ); return; }
-
-
-    /* get and check the position                                          */
-    pos = PopObj();
-    if ( ! IS_POS_INTOBJ(pos) ) {
-        ErrorQuit(
-            "PosObj Element: <position> must be a positive integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
-    }
-
-    /* get lists (if this works, then <lists> is nested <level> deep,      */
-    /* checking it is nested <level>+1 deep is done by 'ElmPosObjLevel')     */
-    lists = PopObj();
-
-    /* select the elements from several lists (store them in <lists>)      */
-    ErrorQuit(
-        "sorry: <lists>{<poss>}![<pos>] not yet implemented",
-        0L, 0L );
-
-    /* push the elements                                                   */
-    PushObj( lists );
-}
-
-void            IntrElmsPosObjLevel (
-    UInt                level )
-{
-    Obj                 lists;          /* lists, left operand             */
-    Obj                 poss;           /* positions, right operand        */
-
-    /* ignore or code                                                      */
-    SKIP_IF_RETURNING();
-    SKIP_IF_IGNORING();
-    if ( STATE(IntrCoding)    > 0 ) { CodeElmsPosObjLevel( level ); return; }
-
-
-    /* get and check the positions                                         */
-    poss = PopObj();
-    CheckIsPossList("PosObj Elements", poss);
-
-    /* get lists (if this works, then <lists> is nested <level> deep,      */
-    /* checking it is nested <level>+1 deep is done by 'ElmsPosObjLevel')    */
-    lists = PopObj();
-
-    /* select several elements from several lists (store them in <lists>)  */
-    ErrorQuit(
-        "sorry: <lists>{<poss>}!{<poss>} not yet implemented",
-        0L, 0L );
-
-    /* push the elements                                                   */
-    PushObj( lists );
 }
 
 void            IntrIsbPosObj ( void )

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2696,8 +2696,6 @@ void            IntrAssDVar (
     /* ignore or code                                                      */
     SKIP_IF_RETURNING();
     SKIP_IF_IGNORING();
-    /* if ( STATE(IntrCoding)    > 0 ) { CodeAssDVar( gvar ); return; } */
-
 
     if ( STATE(IntrCoding) > 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
@@ -2727,8 +2725,6 @@ void            IntrUnbDVar (
     /* ignore or code                                                      */
     SKIP_IF_RETURNING();
     SKIP_IF_IGNORING();
-    /* if ( STATE(IntrCoding)    > 0 ) { CodeUnbGVar( gvar ); return; } */
-
 
     if ( STATE(IntrCoding) > 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
@@ -2760,8 +2756,6 @@ void            IntrRefDVar (
     /* ignore or code                                                      */
     SKIP_IF_RETURNING();
     SKIP_IF_IGNORING();
-    /* if ( STATE(IntrCoding)    > 0 ) { CodeRefGVar( gvar ); return; } */
-
 
     if ( STATE(IntrCoding) > 0 ) {
         ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
@@ -2792,8 +2786,11 @@ void            IntrIsbDVar (
     /* ignore or code                                                      */
     SKIP_IF_RETURNING();
     SKIP_IF_IGNORING();
-    /* if ( STATE(IntrCoding)    > 0 ) { CodeIsbGVar( gvar ); return; } */
 
+    if ( STATE(IntrCoding) > 0 ) {
+        ErrorQuit( "Variable: <debug-variable-%d-%d> cannot be used here",
+                   dvar >> MAX_FUNC_LVARS_BITS, dvar & MAX_FUNC_LVARS_MASK );
+    }
 
     /* get the value                                                       */
     context = STATE(ErrorLVars);

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -832,22 +832,26 @@ void            IntrWhileEnd ( void )
 **                                       by readwrite or readonly
 **
 */
-
 void IntrQualifiedExprBegin(UInt qual) 
 {
     /* ignore or code                                                      */
     SKIP_IF_RETURNING();
-    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)++; return; }
-    if ( STATE(IntrCoding)    > 0 ) { CodeQualifiedExprBegin(qual); return; }
-    PushObj(INTOBJ_INT(qual));
+    SKIP_IF_IGNORING();
+
+    /* otherwise must be coding                                            */
+    GAP_ASSERT(STATE(IntrCoding) > 0);
+    CodeQualifiedExprBegin(qual);
 }
 
 void IntrQualifiedExprEnd( void ) 
 {
     /* ignore or code                                                      */
     SKIP_IF_RETURNING();
-    if ( STATE(IntrIgnoring)  > 0 ) { STATE(IntrIgnoring)--; return; }
-    if ( STATE(IntrCoding)    > 0 ) { CodeQualifiedExprEnd(); return; }
+    SKIP_IF_IGNORING();
+
+    /* otherwise must be coding                                            */
+    GAP_ASSERT(STATE(IntrCoding) > 0);
+    CodeQualifiedExprEnd();
 }
 
 /****************************************************************************
@@ -1029,10 +1033,8 @@ void            IntrBreak ( void )
     SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
-    if ( STATE(IntrCoding) == 0 )
-      ErrorQuit("'break' statement can only appear inside a loop",0L,0L);
-    else
-      CodeBreak();
+    GAP_ASSERT(STATE(IntrCoding) > 0);
+    CodeBreak();
 }
 
 
@@ -1053,10 +1055,8 @@ void            IntrContinue ( void )
     SKIP_IF_IGNORING();
 
     /* otherwise must be coding                                            */
-    if ( STATE(IntrCoding) == 0 )
-      ErrorQuit("'continue' statement can only appear inside a loop",0L,0L);
-    else
-      CodeContinue();
+    GAP_ASSERT(STATE(IntrCoding) > 0);
+    CodeContinue();
 }
 
 

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -839,19 +839,8 @@ extern  void            IntrIsbRecExpr ( void );
 /****************************************************************************
 **
 *F  IntrAssPosObj() . . . . . . . . . . . .  interpret assignment to a posobj
-*F  IntrAsssPosObj() . . . . . . .  interpret multiple assignment to a posobj
-*F  IntrAssPosObjLevel(<level>) . . . interpret assignment to several posobjs
-*F  IntrAsssPosObjLevel(<level>)  intr multiple assignment to several posobjs
 */
 extern  void            IntrAssPosObj ( void );
-
-extern  void            IntrAsssPosObj ( void );
-
-extern  void            IntrAssPosObjLevel (
-            UInt                level );
-
-extern  void            IntrAsssPosObjLevel (
-            UInt                level );
 
 extern  void            IntrUnbPosObj ( void );
 
@@ -859,19 +848,8 @@ extern  void            IntrUnbPosObj ( void );
 /****************************************************************************
 **
 *F  IntrElmPosObj() . . . . . . . . . . . . . interpret selection of a posobj
-*F  IntrElmsPosObj() . . . . . . . . interpret multiple selection of a posobj
-*F  IntrElmPosObjLevel(<level>) . . .  interpret selection of several posobjs
-*F  IntrElmsPosObjLevel(<level>) . intr multiple selection of several posobjs
 */
 extern  void            IntrElmPosObj ( void );
-
-extern  void            IntrElmsPosObj ( void );
-
-extern  void            IntrElmPosObjLevel (
-            UInt                level );
-
-extern  void            IntrElmsPosObjLevel (
-            UInt                level );
 
 extern  void            IntrIsbPosObj ( void );
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -2130,27 +2130,6 @@ void AsssListCheck (
 
 /****************************************************************************
 **
-*F  AsssPosObjCheck( <list>, <poss>, <rhss> ) . . . . . . . . . . . ASSS_LIST
-*/
-void AsssPosObjCheck (
-    Obj                 list,
-    Obj                 poss,
-    Obj                 rhss )
-{
-    CheckIsPossList("List Assignment", poss);
-    CheckIsDenseList("List Assignment", "rhss", rhss);
-    CheckSameLength("List Assignment", "rhss", "positions", rhss, poss);
-    if ( TNUM_OBJ(list) == T_POSOBJ ) {
-        ErrorQuit( "sorry: <posobj>!{<poss>} not yet implemented", 0L, 0L );
-    }
-    else {
-        ASSS_LIST( list, poss, rhss );
-    }
-}
-
-
-/****************************************************************************
-**
 *F  AsssListLevelCheck( <lists>, <poss>, <rhss>, <level> )  . . AsssListLevel
 */
 void AsssListLevelCheck (

--- a/src/lists.h
+++ b/src/lists.h
@@ -977,16 +977,6 @@ extern void AsssListCheck (
 
 /****************************************************************************
 **
-*F  AsssPosObjCheck( <list>, <poss>, <rhss> ) . . . . . . . . . . . ASSS_LIST
-*/
-extern void AsssPosObjCheck (
-    Obj                 list,
-    Obj                 poss,
-    Obj                 rhss );
-
-
-/****************************************************************************
-**
 *F  AsssListLevelCheck( <lists>, <poss>, <rhss>, <level> )  . . AsssListLevel
 */
 extern void AsssListLevelCheck (

--- a/src/permutat.c
+++ b/src/permutat.c
@@ -3870,14 +3870,14 @@ Obj Array2Perm (
             val = ELM_LIST( cycle, j );
             while ( ! IS_INTOBJ(val) || INT_INTOBJ(val) <= 0 ) {
                 val = ErrorReturnObj(
-              "Permutation: <expr> must be a positive integer (not to a %s)",
+              "Permutation: <expr> must be a positive integer (not a %s)",
                     (Int)TNAM_OBJ(val), 0L,
                     "you can replace <expr> via 'return <expr>;'" );
             }
             c = INT_INTOBJ(val);
-	    if (c > MAX_DEG_PERM4)
-	      ErrorMayQuit( "Permutation literal exceeds maximum permutatuion degree -- %i vs %i",
-			    c, MAX_DEG_PERM4);
+            if (c > MAX_DEG_PERM4)
+              ErrorMayQuit( "Permutation literal exceeds maximum permutation degree -- %i vs %i",
+                            c, MAX_DEG_PERM4);
 
             /* if necessary resize the permutation                         */
             if (DEG_PERM4(perm) < c) {
@@ -3895,7 +3895,7 @@ Obj Array2Perm (
             ptr4 = ADDR_PERM4( perm );
             if ( (p != 0 && p == c) || (ptr4[c-1] != c-1) ) {
                 return ErrorReturnObj(
-                    "Permutation: cycles must be disjoint",
+                    "Permutation: cycles must be disjoint and duplicate-free",
                     0L, 0L,
                     "you can replace the permutation <perm> via 'return <perm>;'" );
             }
@@ -3911,6 +3911,9 @@ Obj Array2Perm (
 
         /* enter first (last popped) entry at last (first popped) location */
         ptr4 = ADDR_PERM4( perm );
+        if (ptr4[l-1] != l-1) {
+            ErrorQuit("Permutation: cycles must be disjoint and duplicate-free", 0L, 0L );
+        }
         ptr4[l-1] = p-1;
 
     }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -935,7 +935,6 @@ static UInt NextSymbol(void)
     case '!':         symbol = S_ILLEGAL;       c = GET_NEXT_CHAR();
       if (c == '.') { symbol = S_BDOT;              GET_NEXT_CHAR(); break; }
       if (c == '[') { symbol = S_BLBRACK;           GET_NEXT_CHAR(); break; }
-      if (c == '{') { symbol = S_BLBRACE;           GET_NEXT_CHAR(); break; }
       break;
     case '[':         symbol = S_LBRACK;            GET_NEXT_CHAR(); break;
     case ']':         symbol = S_RBRACK;            GET_NEXT_CHAR(); break;

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -41,7 +41,6 @@ enum SCANNER_SYMBOLS {
     S_LBRACK            = (1UL<< 4)+0,
     S_LBRACE            = (1UL<< 4)+1,
     S_BLBRACK           = (1UL<< 4)+2,
-    S_BLBRACE           = (1UL<< 4)+3,
     S_RBRACK            = (1UL<< 5)+0,
     S_RBRACE            = (1UL<< 5)+1,
     S_DOT               = (1UL<< 6)+0,

--- a/src/vars.c
+++ b/src/vars.c
@@ -618,46 +618,6 @@ UInt            ExecAss2List (
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
 }
-/****************************************************************************
-**
-*F  ExecAssXList(<ass>)  . . . . . . . . . . .  assign to an element of a list
-**
-**  'ExecAssXList'  executes the list  assignment statement <stat> of the form
-**  '<list>[<position>,<position>,<position>[,<position>]*] := <rhs>;'.
-*/
-UInt            ExecAssXList (
-    Expr                stat )
-{
-    Obj                 list;           /* list, left operand              */
-    Obj                 pos;            /* position, left operand          */
-    Obj                 rhs;            /* right hand side, right operand  */
-    Obj ixs;
-    Int i;
-    Int narg;
-
-    /* evaluate the list (checking is done by 'ASS_LIST')                  */
-    SET_BRK_CURR_STAT( stat );
-    list = EVAL_EXPR(READ_STAT(stat, 0));
-
-    narg = SIZE_STAT(stat)/sizeof(Stat) - 2;
-    ixs = NEW_PLIST(T_PLIST,narg);
-
-    for (i = 1; i <= narg; i++) {
-      /* evaluate the position                                             */
-      pos = EVAL_EXPR(READ_STAT(stat, i));
-      SET_ELM_PLIST(ixs,i,pos);
-      CHANGED_BAG(ixs);
-    }
-    SET_LEN_PLIST(ixs,narg);
-
-    /* evaluate the right hand side                                        */
-    rhs = EVAL_EXPR(READ_STAT(stat, 2));
-
-    ASSB_LIST(list, ixs, rhs);
-
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
-}
 
 
 /****************************************************************************
@@ -913,43 +873,6 @@ Obj             EvalElm2List (
     return elm;
 }
 
-/****************************************************************************
-**
-*F  EvalElmXList(<expr>) . . . . . . . . . . . . select an element of a list
-**
-**  'EvalElmXList' evaluates the list  element expression  <expr> of the  form
-**  '<list>[<pos1>,<pos2>,<pos3>,....]'.
-*/
-Obj             EvalElmXList (
-    Expr                expr )
-{
-    Obj                 elm;            /* element, result                 */
-    Obj                 list;           /* list, left operand              */
-    Obj                 pos;            /* position, right operand         */
-    Obj ixs;
-    Int narg;
-    Int i;
-     
-
-    /* evaluate the list (checking is done by 'ELM2_LIST')                 */
-    list = EVAL_EXPR(READ_EXPR(expr, 0));
-
-    /* evaluate and check the positions                                    */
-    narg = SIZE_EXPR(expr)/sizeof(Expr) -1;
-    ixs = NEW_PLIST(T_PLIST,narg);
-    for (i = 1; i <= narg; i++) {
-      pos = EVAL_EXPR( READ_EXPR(expr, i) );
-      SET_ELM_PLIST(ixs,i,pos);
-      CHANGED_BAG(ixs);
-    }
-    SET_LEN_PLIST(ixs,narg);
-   
-    elm = ELMB_LIST(list,ixs);
-
-    /* return the element                                                  */
-    return elm;
-}
-
 
 /****************************************************************************
 **
@@ -1142,25 +1065,6 @@ void            PrintAss2List (
     Pr("%2<;",0L,0L);
 }
 
-void            PrintAssXList (
-    Stat                stat )
-{
-  Int narg = SIZE_STAT(stat)/sizeof(stat) - 2;
-  Int i;
-    Pr("%4>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
-    Pr("%<[",0L,0L);
-    PrintExpr(READ_EXPR(stat, 1));
-    for (i = 2; i <= narg; i++) {
-      Pr("%<, %>",0L,0L);
-      PrintExpr(READ_EXPR(stat, i));
-    }
-    Pr("%<]",0L,0L);
-    Pr("%< %>:= ",0L,0L);
-    PrintExpr(READ_EXPR(stat, narg + 1));
-    Pr("%2<;",0L,0L);
-}
-
 void            PrintUnbList (
     Stat                stat )
 {
@@ -1231,22 +1135,6 @@ void PrintElm2List (
     PrintExpr(READ_EXPR(expr, 1));
     Pr("%<, %<",0L,0L);
     PrintExpr(READ_EXPR(expr, 2));
-    Pr("%<]",0L,0L);
-}
-
-void PrintElmXList (
-		     Expr expr )
-{
-  Int i;
-  Int narg = SIZE_EXPR(expr)/sizeof(Expr) -1 ;
-    Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
-    Pr("%<[",0L,0L);
-    PrintExpr(READ_EXPR(expr, 1));
-    for (i = 2; i <= narg; i++) {
-      Pr("%<, %<",0L,0L);
-      PrintExpr(READ_EXPR(expr, i));
-    }
     Pr("%<]",0L,0L);
 }
 
@@ -2657,9 +2545,7 @@ static Int InitKernel (
     InstallExecStatFunc( T_ASS_LIST_LEV   , ExecAssListLevel);
     InstallExecStatFunc( T_ASSS_LIST_LEV  , ExecAsssListLevel);
     InstallExecStatFunc( T_ASS2_LIST  , ExecAss2List);
-    InstallExecStatFunc( T_ASSX_LIST  , ExecAssXList);
     InstallPrintStatFunc( T_ASS2_LIST  , PrintAss2List);
-    InstallPrintStatFunc( T_ASSX_LIST  , PrintAssXList);
     
     InstallExecStatFunc( T_UNB_LIST       , ExecUnbList);
     InstallEvalExprFunc( T_ELM_LIST       , EvalElmList);
@@ -2668,9 +2554,7 @@ static Int InitKernel (
     InstallEvalExprFunc( T_ELMS_LIST_LEV  , EvalElmsListLevel);
     InstallEvalExprFunc( T_ISB_LIST       , EvalIsbList);
     InstallEvalExprFunc( T_ELM2_LIST      , EvalElm2List);
-    InstallEvalExprFunc( T_ELMX_LIST      , EvalElmXList);
     InstallPrintExprFunc( T_ELM2_LIST     , PrintElm2List);
-    InstallPrintExprFunc( T_ELMX_LIST     , PrintElmXList);
     
     InstallPrintStatFunc( T_ASS_LIST       , PrintAssList);
     InstallPrintStatFunc( T_ASSS_LIST      , PrintAsssList);

--- a/tst/testinstall/coder.tst
+++ b/tst/testinstall/coder.tst
@@ -1,0 +1,293 @@
+#
+# Tests for the GAP coder logic.
+#
+# For now this mostly focuses on testing edge cases and error
+# handling in the coder.
+#
+# The files coder.tst and interpreter.tst closely mirror each other.
+#
+gap> START_TEST("coder.tst");
+
+#
+# function call with options
+#
+gap> f:=x->ValueOption("a");;
+gap> ({}-> f(1) )();
+fail
+gap> ({}-> f(1 : a) )();
+true
+gap> ({}-> f(1 : ("a") ) )();
+true
+gap> ({}-> f(1 : a := 23) )();
+23
+gap> ({}-> f(1 : ("a") := 23 ) )();
+23
+
+#
+# records
+#
+gap> function()
+>   local r;
+>   r := rec(a:=1);
+>   Display(r);
+>   r.a := 1;
+>   Display(r.a);
+>   Display(IsBound(r.a));
+>   Unbind(r.a);
+>   return r;
+> end();
+rec(
+  a := 1 )
+1
+true
+rec(  )
+
+#
+gap> function()
+>   local r;
+>   r := rec(a:=1);
+>   Display(r);
+>   r!.a := 1;
+>   Display(r!.a);
+>   Display(IsBound(r!.a));
+>   Unbind(r!.a);
+>   return r;
+> end();
+rec(
+  a := 1 )
+1
+true
+rec(  )
+
+#
+gap> function()
+>   local r;
+>   r := rec(("a"):=1);
+>   Display(r);
+>   r.("a") := 1;
+>   Display(r.("a"));
+>   Display(IsBound(r.("a")));
+>   Unbind(r.("a"));
+>   return r;
+> end();
+rec(
+  a := 1 )
+1
+true
+rec(  )
+
+#
+gap> function()
+>   local r;
+>   r := rec(("a"):=1);
+>   Display(r);
+>   r!.("a") := 1;
+>   Display(r!.("a"));
+>   Display(IsBound(r!.("a")));
+>   Unbind(r!.("a"));
+>   return r;
+> end();
+rec(
+  a := 1 )
+1
+true
+rec(  )
+
+#
+# component objects (atomic by default in HPC-GAP)
+#
+gap> r := Objectify(NewType(NewFamily("MockFamily"), IsComponentObjectRep), rec());;
+
+#
+gap> function()
+>   r!.a := 1;
+>   Display(r!.a);
+>   Display(IsBound(r!.a));
+>   Unbind(r!.a);
+>   Display(IsBound(r!.a));
+> end();
+1
+true
+false
+
+#
+gap> function()
+>   r!.("a") := 1;
+>   Display(r!.("a"));
+>   Display(IsBound(r!.("a")));
+>   Unbind(r!.("a"));
+>   Display(IsBound(r!.("a")));
+> end();
+1
+true
+false
+
+#
+# lists
+#
+gap> function()
+>   local l;
+>   l:=[1,2,3];
+>   Display(l);
+>   l[1] := 42;
+>   Display(l[1]);
+>   Display(IsBound(l[1]));
+>   Unbind(l[1]);
+>   Display(l);
+>   l{[1,3]} := [42, 23];
+>   Display(l);
+>   Display(l{[3,1]});
+> end();
+[ 1, 2, 3 ]
+42
+true
+[ , 2, 3 ]
+[ 42, 2, 23 ]
+[ 23, 42 ]
+gap> function()
+>   local l;
+>   l:=[1,2,3];
+>   IsBound(l{[1,3]});
+> end;
+Syntax error: statement expected in stream:4
+  IsBound(l{[1,3]});
+  ^^^^^^^
+gap> function()
+>   local l;
+>   l:=[1,2,3];
+>   Unbind(l{[1,3]});
+> end;
+Syntax error: Illegal operand for 'Unbind' in stream:4
+  Unbind(l{[1,3]});
+                 ^
+
+#
+gap> f:=function()
+>   local l;
+>   l:=[1,2,3];
+>   Display(l);
+>   l![1] := 42;
+>   Display(l![1]);
+>   Display(IsBound(l![1]));
+>   Unbind(l![1]);
+>   Display(l);
+> end;;
+gap> Display(f);
+function (  )
+    local l;
+    l := [ 1, 2, 3 ];
+    Display( l );
+    l![1] := 42;
+    Display( l![1] );
+    Display( IsBound( l![1] ) );
+    Unbind( l![1] );
+    Display( l );
+    return;
+end
+gap> f();
+[ 1, 2, 3 ]
+42
+true
+[ , 2, 3 ]
+
+#
+gap> l := [1,2,3];;
+gap> function() l![fail] := 42; end();
+Error, PosObj Assignment: <position> must be a positive integer (not a boolean\
+ or fail)
+gap> function() return l![fail]; end();
+Error, PosObj Element: <position> must be a positive integer (not a boolean or\
+ fail)
+gap> function() return IsBound(l![fail]); end();
+Error, PosObj Element: <position> must be a positive integer (not a boolean or\
+ fail)
+gap> function() Unbind(l![fail]); end();
+Error, PosObj Assignment: <position> must be a positive integer (not a boolean\
+ or fail)
+
+#
+# posobj
+#
+gap> l := Objectify(NewType(NewFamily("MockFamily"), IsPositionalObjectRep),[]);;
+
+#
+gap> l![1] := 42;
+42
+gap> l![1];
+42
+gap> IsBound(l![1]);
+true
+gap> Unbind(l![1]);
+gap> IsBound(l![1]);
+false
+
+#
+gap> function()
+>   l![1] := 42;
+>   Display(l![1]);
+>   Display(IsBound(l![1]));
+>   Unbind(l![1]);
+>   Display(IsBound(l![1]));
+> end();
+42
+true
+false
+
+#
+gap> function() l![fail] := 42; end();
+Error, PosObj Assignment: <position> must be a positive integer (not a boolean\
+ or fail)
+gap> function() return l![fail]; end();
+Error, PosObj Element: <position> must be a positive integer (not a boolean or\
+ fail)
+gap> function() return IsBound(l![fail]); end();
+Error, PosObj Element: <position> must be a positive integer (not a boolean or\
+ fail)
+gap> function() Unbind(l![fail]); end();
+Error, PosObj Assignment: <position> must be a positive integer (not a boolean\
+ or fail)
+
+#
+# atomic posobj (HPC-GAP)
+#
+gap> l := Objectify(NewType(NewFamily("MockFamily"), IsAtomicPositionalObjectRep),[23]);;
+
+#
+gap> l![1] := 42;
+42
+gap> l![1];
+42
+gap> IsBound(l![1]);
+true
+gap> Unbind(l![1]);
+gap> IsBound(l![1]);
+false
+
+#
+gap> function()
+>   l![1] := 42;
+>   Display(l![1]);
+>   Display(IsBound(l![1]));
+>   Unbind(l![1]);
+>   Display(IsBound(l![1]));
+> end();
+42
+true
+false
+
+#
+gap> function() l![fail] := 42; end();
+Error, PosObj Assignment: <position> must be a positive integer (not a boolean\
+ or fail)
+gap> function() return l![fail]; end();
+Error, PosObj Element: <position> must be a positive integer (not a boolean or\
+ fail)
+gap> function() return IsBound(l![fail]); end();
+Error, PosObj Element: <position> must be a positive integer (not a boolean or\
+ fail)
+gap> function() Unbind(l![fail]); end();
+Error, PosObj Assignment: <position> must be a positive integer (not a boolean\
+ or fail)
+
+#
+gap> STOP_TEST("coder.tst", 1);

--- a/tst/testinstall/integer.tst
+++ b/tst/testinstall/integer.tst
@@ -39,15 +39,23 @@ gap> last = List([1..10], n->PrimeDivisors(-n));
 true
 
 #
-gap> n:=(2^31-1)*(2^61-1);;
+gap> n:=(2^31-1)*(2^61-1);; # product of two "small" primes
 gap> PartialFactorization(n);
 [ 2147483647, 2305843009213693951 ]
 gap> FactorsInt(n);
 [ 2147483647, 2305843009213693951 ]
-gap> PartialFactorization(2^155-19);
+gap> n:=2^155-19;; # not a prime; GAP fails to fully factorize it, though FactInt finds all 4 factors
+gap> PartialFactorization(n);
 [ 167, 273484587823896504154881143846609846492502347 ]
-gap> n:=(2^2203-1)*(2^2281-1);;
+gap> n:=(2^2203-1)*(2^2281-1);;  # product of two "large" primes
 gap> PartialFactorization(n) = [ n ];
+true
+gap> n:=2^255-19;; # this is a "large" prime for which GAP only knows it is probably prime
+gap> PartialFactorization(n) = [ n ];
+true
+gap> FactorsInt(n) = [ n ];
+#I  FactorsInt: used the following factor(s) which are probably primes:
+#I        57896044618658097711785492504343953926634992332820282019728792003956564819949
 true
 
 #

--- a/tst/testinstall/interpreter.tst
+++ b/tst/testinstall/interpreter.tst
@@ -4,6 +4,9 @@
 # For now this mostly focuses on testing edge cases and error
 # handling in the interpreter.
 #
+# The files coder.tst and interpreter.tst closely mirror each other.
+#
+gap> START_TEST("interpreter.tst");
 
 #
 # non boolean expression as condition
@@ -74,7 +77,7 @@ rec(  )
 #
 gap> r!.a := 1;
 1
-gap> r!.("a");
+gap> r!.a;
 1
 gap> IsBound(r!.a);
 true
@@ -105,7 +108,30 @@ gap> r;
 rec(  )
 
 #
-# lists and posobj
+# component objects (atomic by default in HPC-GAP)
+#
+gap> r := Objectify(NewType(NewFamily("MockFamily"), IsComponentObjectRep), rec());;
+
+#
+gap> r!.a := 1;
+1
+gap> r!.a;
+1
+gap> IsBound(r!.a);
+true
+gap> Unbind(r!.a);
+
+#
+gap> r!.("a") := 1;
+1
+gap> r!.("a");
+1
+gap> IsBound(r!.("a"));
+true
+gap> Unbind(r!.("a"));
+
+#
+# lists
 #
 gap> l:=[1,2,3];
 [ 1, 2, 3 ]
@@ -133,6 +159,20 @@ gap> l;
 [ , 2, 3 ]
 
 #
+gap> l![fail] := 42;
+Error, PosObj Assignment: <position> must be a positive integer (not a boolean\
+ or fail)
+gap> l![fail];
+Error, PosObj Element: <position> must be a positive integer (not a boolean or\
+ fail)
+gap> IsBound(l![fail]);
+Error, PosObj Element: <position> must be a positive integer (not a boolean or\
+ fail)
+gap> Unbind(l![fail]);
+Error, PosObj Assignment: <position> must be a positive integer (not a boolean\
+ or fail)
+
+#
 gap> l{[1,3]} := [42, 23];
 [ 42, 23 ]
 gap> l{[3,1]};
@@ -149,17 +189,65 @@ gap> l;
 [ 42, 2, 23 ]
 
 #
-gap> l!{[1,3]} := [42, 23];
-[ 42, 23 ]
-gap> l!{[3,1]};
-[ 23, 42 ]
-gap> IsBound(l!{[1,3]});
-Syntax error: Illegal operand for 'IsBound' in stream:1
-IsBound(l!{[1,3]});
-                 ^
-gap> Unbind(l!{[1,3]});
-Syntax error: Illegal operand for 'Unbind' in stream:1
-Unbind(l!{[1,3]});
-                ^
-gap> l;
-[ 42, 2, 23 ]
+# posobj
+#
+gap> l := Objectify(NewType(NewFamily("MockFamily"), IsPositionalObjectRep),[]);;
+
+#
+gap> l![1] := 42;
+42
+gap> l![1];
+42
+gap> IsBound(l![1]);
+true
+gap> Unbind(l![1]);
+gap> IsBound(l![1]);
+false
+
+#
+gap> l![fail] := 42;
+Error, PosObj Assignment: <position> must be a positive integer (not a boolean\
+ or fail)
+gap> l![fail];
+Error, PosObj Element: <position> must be a positive integer (not a boolean or\
+ fail)
+gap> IsBound(l![fail]);
+Error, PosObj Element: <position> must be a positive integer (not a boolean or\
+ fail)
+gap> Unbind(l![fail]);
+Error, PosObj Assignment: <position> must be a positive integer (not a boolean\
+ or fail)
+
+#
+# atomic posobj (HPC-GAP)
+#
+gap> l := Objectify(NewType(NewFamily("MockFamily"), IsAtomicPositionalObjectRep),[23]);;
+
+#
+gap> l![1] := 42;
+42
+gap> l![1];
+42
+gap> IsBound(l![1]);
+true
+gap> Unbind(l![1]);
+gap> IsBound(l![1]);
+false
+
+#
+gap> l![fail] := 42;
+Error, PosObj Assignment: <position> must be a positive integer (not a boolean\
+ or fail)
+gap> l![fail];
+Error, PosObj Element: <position> must be a positive integer (not a boolean or\
+ fail)
+gap> IsBound(l![fail]);
+Error, PosObj Element: <position> must be a positive integer (not a boolean or\
+ fail)
+gap> Unbind(l![fail]);
+Error, PosObj Assignment: <position> must be a positive integer (not a boolean\
+ or fail)
+
+#
+#
+gap> STOP_TEST("interpreter.tst", 1);

--- a/tst/testinstall/kernel/exprs.tst
+++ b/tst/testinstall/kernel/exprs.tst
@@ -3,7 +3,28 @@
 #
 gap> START_TEST("kernel/exprs.tst");
 
-#
+# EvalPermExpr
+gap> f:={a,b} -> (a,b);;
+gap> f(1,2);
+(1,2)
+gap> f(2,1);
+(1,2)
+gap> f(2,2);
+Error, Permutation: cycles must be disjoint and duplicate-free
+gap> f(2,fail);
+Error, Permutation: <expr> must be a positive integer (not a boolean or fail)
+gap> f:={a,b,c,d} -> (a,b,c,d);;
+gap> f(1,2,3,4);
+(1,2,3,4)
+gap> f(1,2,3,2);
+Error, Permutation: cycles must be disjoint and duplicate-free
+gap> f:={a,b,c,d} -> (a,b)(c,d);;
+gap> f(1,2,3,4);
+(1,2)(3,4)
+gap> f(1,2,3,2);
+Error, Permutation: cycles must be disjoint and duplicate-free
+gap> f(1,2,1,2);
+Error, Permutation: cycles must be disjoint and duplicate-free
 
 #
 gap> STOP_TEST("kernel/exprs.tst", 1);

--- a/tst/testinstall/kernel/exprs.tst
+++ b/tst/testinstall/kernel/exprs.tst
@@ -26,5 +26,43 @@ Error, Permutation: cycles must be disjoint and duplicate-free
 gap> f(1,2,1,2);
 Error, Permutation: cycles must be disjoint and duplicate-free
 
+# EvalRangeExpr
+gap> f:={a,b,c} -> [a,b..c];;
+gap> f(1,2,3);
+[ 1 .. 3 ]
+gap> f(1,3,5);
+[ 1, 3 .. 5 ]
+gap> f(1,1,1);
+Error, Range: <second> must not be equal to <first> (1)
+gap> f(1,3,4);
+Error, Range: <last>-<first> (3) must be divisible by <inc> (2)
+
+# EvalRecExpr
+gap> f:={a,b} -> rec( (a) := b );;
+gap> f(1,2);
+rec( 1 := 2 )
+gap> f(fail,2);
+Error, Record: '<rec>.(<obj>)' <obj> must be a string or an integer
+
+# PrintBinop
+gap> Display(x-> (-2)^x);
+function ( x )
+    return (-2) ^ x;
+end
+gap> Display( x -> 2 * f( 3 + 4 ));
+function ( x )
+    return 2 * f( (3 + 4) );
+end
+
+# PrintTildeExpr, EvalTildeExpr
+gap> l := [x -> ~];;
+gap> f := l[1];;
+gap> Display(f);
+function ( x )
+    return ~;
+end
+gap> f(1);
+Error, '~' does not have a value here
+
 #
 gap> STOP_TEST("kernel/exprs.tst", 1);

--- a/tst/testinstall/kernel/read.tst
+++ b/tst/testinstall/kernel/read.tst
@@ -65,6 +65,11 @@ rec("a":=1);
     ^^^
 
 #
+# ReadAtomic
+#
+gap> f := atomic function() end;;
+
+#
 # ReadEvalCommand
 #
 # See also https://github.com/gap-system/gap/issues/995

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -38,26 +38,10 @@ gap> a := [ [ [1, 2], [3, 4] ], [ [5, 6], [7, 8] ] ];
 [ [ [ 1, 2 ], [ 3, 4 ] ], [ [ 5, 6 ], [ 7, 8 ] ] ]
 gap> a{[1]};
 [ [ [ 1, 2 ], [ 3, 4 ] ] ]
-gap> a!{[1]};
-[ [ [ 1, 2 ], [ 3, 4 ] ] ]
 gap> a{[1]}{[1]};
 [ [ [ 1, 2 ] ] ]
-gap> a!{[1]}{[1]};
-[ [ [ 1, 2 ] ] ]
-gap> a!{[1]}[1][1];
-[ 1 ]
-gap> a!{[1]}[1][2];
-[ 2 ]
-gap> a!{[1]}[1]{[1]};
-[ [ 1 ] ]
-gap> a!{[1]}[1]{[2]};
-[ [ 2 ] ]
-gap> a{[1]}!{[1]};
-Error, sorry: <lists>{<poss>}!{<poss>} not yet implemented
 gap> a{[1]}{[1]}[1];
 [ [ 1 ] ]
-gap> a{[1]}{[1]}![1];
-Error, sorry: <lists>{<poss>}![<pos>] not yet implemented
 
 #
 gap> a{[1,,2]}:=1;
@@ -70,8 +54,6 @@ gap> a{[1]}{[1]}[1] := 42;
 Error, List Assignment: <objs> must be a dense list
 gap> a{[1]}{[1]}[1] := [ 42 ];
 Error, List Assignment: <objs> must be a dense list
-gap> a{[1]}{[1]}![1] := [ [ 42 ] ];
-Error, sorry: <lists>{<poss>}![<pos>] not yet implemented
 gap> a{[1]}{[1]}[1] := [ [ 42 ] ];
 [ [ 42 ] ]
 gap> a;
@@ -90,10 +72,6 @@ gap> a{[1]}{[1,,3]} := [ [ [ 18, 19 ] ] ];
 Error, List Assignment: <positions> must be a dense list of positive integers
 gap> a{[1]}{[1]} := [ [ [ 18, 19 ] ] ];
 [ [ [ 18, 19 ] ] ]
-gap> a!{[1]}{[1]} := [ [ [ 18, 19 ] ] ];
-[ [ [ 18, 19 ] ] ]
-gap> a{[1]}!{[1]} := [ [ [ 18, 19 ] ] ];
-Error, sorry: <lists>{<poss>}!{<poss>} not yet implemented
 gap> a;
 [ [ [ 18, 19 ], [ 3, 4 ] ], [ [ 5, 6 ], [ 7, 8 ] ] ]
 

--- a/tst/testinstall/perm.tst
+++ b/tst/testinstall/perm.tst
@@ -22,6 +22,8 @@ gap> (1,2,0);
 Error, Permutation: <expr> must be a positive integer (not a integer)
 gap> (1,2)(1,2);
 Error, Permutation: cycles must be disjoint and duplicate-free
+gap> (1,2,3,2);
+Error, Permutation: cycles must be disjoint and duplicate-free
 
 # The GAP kernel implements many functions in multiple variants, e.g. to
 # compare permutations for equality, there are actually four functions in the

--- a/tst/testspecial/debug-var.g
+++ b/tst/testspecial/debug-var.g
@@ -49,5 +49,9 @@ Unbind(y);
 y:=100;
 IsBound(y);
 unbound_higher;
-quit;
 
+# check coding of dvars
+function() return unbound_higher; end;
+function() return IsBound(unbound_higher); end;
+function() Unbind(unbound_higher); end;
+function() unbound_higher:=0; end;

--- a/tst/testspecial/debug-var.g.out
+++ b/tst/testspecial/debug-var.g.out
@@ -114,6 +114,38 @@ Error( "breakpoint" ); at *stdin*:9 called from
 g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:6
-brk_2> quit;
-brk> 
-brk> QUIT;
+brk_2> 
+brk_2> # check coding of dvars
+brk_2> function() return unbound_higher; end;
+Error, Variable: <debug-variable-1-4> cannot be used here in
+  <corrupted statement>  called from 
+<corrupted statement>  called from
+Error( "breakpoint" ); at *stdin*:9 called from
+g( 10 ) at *stdin*:12 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:9
+brk_2> function() return IsBound(unbound_higher); end;
+Error, Variable: <debug-variable-1-4> cannot be used here in
+  <corrupted statement>  called from 
+<corrupted statement>  called from
+Error( "breakpoint" ); at *stdin*:9 called from
+g( 10 ) at *stdin*:12 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:10
+brk_2> function() Unbind(unbound_higher); end;
+Error, Variable: <debug-variable-1-4> cannot be used here in
+  <corrupted statement>  called from 
+<corrupted statement>  called from
+Error( "breakpoint" ); at *stdin*:9 called from
+g( 10 ) at *stdin*:12 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:11
+brk_2> function() unbound_higher:=0; end;
+Error, Variable: <debug-variable-1-4> cannot be used here in
+  <corrupted statement>  called from 
+<corrupted statement>  called from
+Error( "breakpoint" ); at *stdin*:9 called from
+g( 10 ) at *stdin*:12 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:12
+brk_2> QUIT;


### PR DESCRIPTION
1. remove incomplete support for !{...} syntax, fixes crashes; fixes #2765 
2. reject invalid permutations in code and compiler, instead of producing permutation in a broken and thus potentially dangerous state. Example of the old, buggy behaviour:
```
gap> f:=x->(1,2,3,2);; pi:=f(0);
(1,2)
gap> 3^pi;
2
gap> ;
gap> MovedPoints(pi);
[ 1, 2, 3 ]
```
3. fix crash (at least with assertions on) when coding `IsBound(dvar)` (probably the most obscure of the three bugs)
4. add more tests for the interpreter and coder (creating these tests ultimately revealed the three bugs above)
5. remove some dead code