### PR TITLE
Travis: add libcurl for curlInterface; don't build Digraphs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ matrix:
           - libgmp-dev:i386
           - libreadline-dev:i386
           - libncurses5-dev:i386    # for Browse
+          - libcurl4-openssl-dev:i386 # for curlInterface
           - libboost-dev:i386       # for NormalizInterface
           - libmpfr-dev:i386        # for float
           - libmpfi-dev:i386        # for float

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -59,6 +59,9 @@ do
     # HACK to work out timestamp issues with anupq
     touch anupq*/configure* anupq*/Makefile* anupq*/aclocal.m4
 
+    # HACK: skip building digraphs for now -- it doesn't link reliably on travis
+    rm -rf digraphs-*
+
     # HACK: skip building semigroups-3.x for now -- it requires GCC >= 5, which Travis doesn't have
     rm -rf semigroups-3.*
 


### PR DESCRIPTION
The new curlInterface requires `libcurl4-openssl-dev`. For the 32-bit build one should add `libcurl4-openssl-dev:i386`.