### PR TITLE
Profile interpreted code

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -1360,6 +1360,9 @@ Obj FuncKERNEL_INFO(Obj self) {
   tmp = MakeImmString( SyKernelVersion );
   r = RNamName("KERNEL_VERSION");
   AssPRec(res,r,tmp);
+  tmp = INTOBJ_INT(GAP_KERNEL_API_VERSION);
+  r = RNamName("KERNEL_API_VERSION");
+  AssPRec(res, r, tmp);
   tmp = MakeImmString( SyBuildVersion );
   r = RNamName("BUILD_VERSION");
   AssPRec(res,r,tmp);

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -60,6 +60,10 @@ typedef struct GAPState {
     UInt   SymbolStartPos;
     UInt   SymbolStartLine;
 
+    // Used for recording the first line of the fragment of code currently
+    // begin interpreted, so the current line is outputted when profiling
+    UInt InterpreterStartLine;
+
     const Char * Prompt;
 
     Char * In;

--- a/src/io.c
+++ b/src/io.c
@@ -54,14 +54,21 @@
 **  terminated by the character '\0'.  Because 'line' holds  only part of the
 **  line for very long lines the last character need not be a <newline>.
 **
+**  'stream' is non-zero if the input points to a stream.
+**
+**  'sline' contains the next line from the stream as GAP string.
+**
+**  The following variables are used to store the state of the interpreter
+**  and stream when another input file is opened:
+**
 **  'ptr' points to the current character within that line.  This is not used
 **  for the current input file, where 'In' points to the  current  character.
 **
 **  'number' is the number of the current line, is used in error messages.
 **
-**  'stream' is none zero if the input points to a stream.
+**  'interpreterStartLine' is the number of the line where the fragment of
+**  code currently being interpreted started. This is used for profiling
 **
-**  'sline' contains the next line from the stream as GAP string.
 **
 */
 typedef struct {
@@ -72,6 +79,7 @@ typedef struct {
     Char   line[32768];
     Char * ptr;
     UInt   symbol;
+    Int    interpreterStartLine;
     Int    number;
     Obj    stream;
     UInt   isstringstream;
@@ -537,6 +545,7 @@ UInt OpenInputStream(Obj stream, UInt echo)
         GAP_ASSERT(IS_CHAR_PUSHBACK_EMPTY());
         IO()->Input->ptr = STATE(In);
         IO()->Input->symbol = STATE(Symbol);
+        IO()->Input->interpreterStartLine = STATE(InterpreterStartLine);
     }
 
     /* enter the file identifier and the file name                         */
@@ -561,6 +570,7 @@ UInt OpenInputStream(Obj stream, UInt echo)
     STATE(In) = IO()->Input->line;
     STATE(In)[0] = STATE(In)[1] = '\0';
     STATE(Symbol) = S_ILLEGAL;
+    STATE(InterpreterStartLine) = 0;
     IO()->Input->number = 1;
 
     /* indicate success                                                    */
@@ -602,6 +612,7 @@ UInt CloseInput ( void )
     IO()->Input = IO()->InputStack[sp - 1];
     STATE(In) = IO()->Input->ptr;
     STATE(Symbol) = IO()->Input->symbol;
+    STATE(InterpreterStartLine) = IO()->Input->interpreterStartLine;
 
     /* indicate success                                                    */
     return 1;

--- a/src/modules.h
+++ b/src/modules.h
@@ -40,7 +40,7 @@
 **
 */
 
-#define GAP_KERNEL_MAJOR_VERSION 4
+#define GAP_KERNEL_MAJOR_VERSION 5
 #define GAP_KERNEL_MINOR_VERSION 0
 #define GAP_KERNEL_API_VERSION                                               \
     ((GAP_KERNEL_MAJOR_VERSION)*1000 + (GAP_KERNEL_MINOR_VERSION))

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -195,6 +195,10 @@ void Match (
 {
     Char                errmsg [256];
 
+    if (STATE(InterpreterStartLine) == 0) {
+        STATE(InterpreterStartLine) = STATE(SymbolStartLine);
+    }
+
     // if 'STATE(Symbol)' is the expected symbol match it away
     if ( symbol == STATE(Symbol) ) {
         STATE(Symbol) = NextSymbol();


### PR DESCRIPTION
I noticed after a recent PR of Max's, it is now easy to add profiling of interpreted code.

This PR does that. I have benchmarked carefully and can't measure any more overhead -- this isn't surprising as the interpreter runs very little code (any function or loop is "coded", and then run as bytecode).

I export KERNEL_API_VERSION, because in the profiling package and debugging package I need to know if this PR happened. In profiling it just breaks testing, in debugging it breaks the package but I will release an updated version.

It might be the case we get some strange coverage out, I'm partly going to see what this PR produces, and compare with previous GAP.