### PR TITLE
kernel: replace COPYING tnums by single T_COPYING

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -232,9 +232,8 @@ Obj CopyBlist (
 {
     Obj copy;
 
-    if (!IS_MUTABLE_OBJ(list)) {
-        return list;
-    }
+    // immutable input is handled by COPY_OBJ
+    GAP_ASSERT(IS_MUTABLE_OBJ(list));
 
     copy = DoCopyBlist(list, mut);
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -1742,10 +1742,6 @@ StructInitInfo * InitInfoGap ( void )
 **  general    `InitLibrary'  will  create    all objects    and  then  calls
 **  `PostRestore'.  This function is only used when restoring.
 */
-#ifdef USE_GASMAN
-extern TNumMarkFuncBags TabMarkFuncBags [ NUM_TYPES ];
-#endif
-
 static Obj POST_RESTORE;
 
 void InitializeGap (
@@ -1806,14 +1802,6 @@ void InitializeGap (
                 }
             }
         }
-    }
-#endif
-
-#ifdef USE_GASMAN
-    /* and now for a special hack                                          */
-    for ( UInt i = LAST_CONSTANT_TNUM+1; i <= LAST_REAL_TNUM; i++ ) {
-      if (TabMarkFuncBags[i + COPYING] == MarkAllSubBagsDefault)
-        TabMarkFuncBags[ i+COPYING ] = TabMarkFuncBags[ i ];
     }
 #endif
 

--- a/src/modules.h
+++ b/src/modules.h
@@ -40,7 +40,7 @@
 **
 */
 
-#define GAP_KERNEL_MAJOR_VERSION 3
+#define GAP_KERNEL_MAJOR_VERSION 4
 #define GAP_KERNEL_MINOR_VERSION 0
 #define GAP_KERNEL_API_VERSION                                               \
     ((GAP_KERNEL_MAJOR_VERSION)*1000 + (GAP_KERNEL_MINOR_VERSION))

--- a/src/objects.c
+++ b/src/objects.c
@@ -470,6 +470,9 @@ extern Obj COPY_OBJ(Obj obj, Int mut)
         // return pointer to the copy
         copy = ELM_PLIST(fpl, 2);
     }
+    else if (!IS_MUTABLE_OBJ(obj)) {
+        copy = obj;
+    }
     else {
         copy = (*CopyObjFuncs[tnum])(obj, mut);
     }
@@ -575,10 +578,8 @@ Obj CopyObjPosObj (
     Obj                 tmp;            /* temporary variable              */
     UInt                i;              /* loop variable                   */
 
-    /* don't change immutable objects                                      */
-    if ( ! IS_MUTABLE_OBJ(obj) ) {
-        return obj;
-    }
+    // immutable input is handled by COPY_OBJ
+    GAP_ASSERT(IS_MUTABLE_OBJ(obj));
 
     /* if the object is not copyable return                                */
     if ( ! IS_COPYABLE_OBJ(obj) ) {
@@ -639,10 +640,8 @@ Obj CopyObjComObj (
     Obj                 copy;           /* copy, result                    */
     Obj                 tmp;            /* temporary variable              */
 
-    /* don't change immutable objects                                      */
-    if ( ! IS_MUTABLE_OBJ(obj) ) {
-        return obj;
-    }
+    // immutable input is handled by COPY_OBJ
+    GAP_ASSERT(IS_MUTABLE_OBJ(obj));
 
     /* if the object is not copyable return                                */
     if ( ! IS_COPYABLE_OBJ(obj) ) {
@@ -703,10 +702,8 @@ Obj CopyObjDatObj (
 {
     Obj                 copy;           /* copy, result                    */
 
-    /* don't change immutable objects                                      */
-    if ( ! IS_MUTABLE_OBJ(obj) ) {
-        return obj;
-    }
+    // immutable input is handled by COPY_OBJ
+    GAP_ASSERT(IS_MUTABLE_OBJ(obj));
 
     /* if the object is not copyable return                                */
     if ( ! IS_COPYABLE_OBJ(obj) ) {

--- a/src/plist.c
+++ b/src/plist.c
@@ -933,11 +933,7 @@ Obj CopyPlist (
     ADDR_OBJ(copy)[0] = ADDR_OBJ(list)[0];
 
     /* leave a forwarding pointer                                          */
-    ADDR_OBJ(list)[0] = copy;
-    CHANGED_BAG( list );
-
-    /* now it is copied                                                    */
-    RetypeBag( list, TNUM_OBJ(list) + COPYING );
+    PrepareCopy(list, copy);
 
     /* copy the subvalues                                                  */
     for ( i = 1; i <= LEN_PLIST(copy); i++ ) {
@@ -952,43 +948,14 @@ Obj CopyPlist (
     return copy;
 }
 
-
 /****************************************************************************
 **
-*F  CopyPlistCopy( <list>, <mut> )  . . . . . . . .  copy a copied plain list
-*/
-Obj CopyPlistCopy (
-    Obj                 list,
-    Int                 mut )
-{
-    return CONST_ADDR_OBJ(list)[0];
-}
-
-
-/****************************************************************************
-**
-*F  CleanPlist( <list> )  . . . . . . . . . . . . . . . clean up a plain list
+*F  CleanPlist( <list> )  . . . . . . . . . . .  clean up a copied plain list
 */
 void CleanPlist (
     Obj                 list )
 {
-}
-
-
-/****************************************************************************
-**
-*F  CleanPlistCopy( <list> )  . . . . . . . . .  clean up a copied plain list
-*/
-void CleanPlistCopy (
-    Obj                 list )
-{
     UInt                i;              /* loop variable                   */
-
-    /* remove the forwarding pointer                                       */
-    ADDR_OBJ(list)[0] = CONST_ADDR_OBJ(CONST_ADDR_OBJ(list)[0])[0];
-
-    /* now it is cleaned                                                   */
-    RetypeBag( list, TNUM_OBJ(list) - COPYING );
 
     /* clean the subvalues                                                 */
     for ( i = 1; i <= LEN_PLIST(list); i++ ) {
@@ -2720,143 +2687,63 @@ Obj FuncIsRectangularTablePlist( Obj self, Obj plist)
 static StructBagNames BagNames[] = {
   { T_PLIST,                                "list (plain)" },
   { T_PLIST            +IMMUTABLE,          "list (plain,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST                       +COPYING, "list (plain,copied)" },
-  { T_PLIST            +IMMUTABLE +COPYING, "list (plain,imm,copied)" },
-#endif
 
   { T_PLIST_NDENSE,                         "list (plain,ndense)" },
   { T_PLIST_NDENSE     +IMMUTABLE,          "list (plain,ndense,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_NDENSE                +COPYING, "list (plain,ndense,copied)" },
-  { T_PLIST_NDENSE     +IMMUTABLE +COPYING, "list (plain,ndense,imm,copied)" },
-#endif
 
   { T_PLIST_DENSE,                          "list (plain,dense)" },
   { T_PLIST_DENSE      +IMMUTABLE,          "list (plain,dense,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_DENSE                 +COPYING, "list (plain,dense,copied)" },
-  { T_PLIST_DENSE      +IMMUTABLE +COPYING, "list (plain,dense,imm,copied)" },
-#endif
 
   { T_PLIST_DENSE_NHOM,                     "list (plain,dense,nhom)" },
   { T_PLIST_DENSE_NHOM +IMMUTABLE,          "list (plain,dense,nhom,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_DENSE_NHOM            +COPYING, "list (plain,dense,nhom,copied)" },
-  { T_PLIST_DENSE_NHOM +IMMUTABLE +COPYING, "list (plain,dense,nhom,imm,copied)" },
-#endif
 
   { T_PLIST_DENSE_NHOM_SSORT,                     "list (plain,dense,nhom,ssort)" },
   { T_PLIST_DENSE_NHOM_SSORT +IMMUTABLE,          "list (plain,dense,nhom,ssort,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_DENSE_NHOM_SSORT            +COPYING, "list (plain,dense,nhom,ssort,copied)" },
-  { T_PLIST_DENSE_NHOM_SSORT +IMMUTABLE +COPYING, "list (plain,dense,nhom,ssort,imm,copied)" },
-#endif
 
   { T_PLIST_DENSE_NHOM_NSORT,                     "list (plain,dense,nhom,nsort)" },
   { T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE,          "list (plain,dense,nhom,nsort,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_DENSE_NHOM_NSORT            +COPYING, "list (plain,dense,nhom,nsort,copied)" },
-  { T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE +COPYING, "list (plain,dense,nhom,nsort,imm,copied)" },
-#endif
 
   { T_PLIST_EMPTY,                          "list (plain,empty)" },
   { T_PLIST_EMPTY      +IMMUTABLE,          "list (plain,empty,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_EMPTY                 +COPYING, "list (plain,empty,copied)" },
-  { T_PLIST_EMPTY      +IMMUTABLE +COPYING, "list (plain,empty,imm,copied)" },
-#endif
 
   { T_PLIST_HOM,                            "list (plain,hom)" },
   { T_PLIST_HOM        +IMMUTABLE,          "list (plain,hom,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_HOM                   +COPYING, "list (plain,hom,copied)" },
-  { T_PLIST_HOM        +IMMUTABLE +COPYING, "list (plain,hom,imm,copied)" },
-#endif
 
   { T_PLIST_HOM_NSORT,                      "list (plain,hom,nsort)" },
   { T_PLIST_HOM_NSORT  +IMMUTABLE,          "list (plain,hom,nsort,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_HOM_NSORT             +COPYING, "list (plain,hom,nsort,copied)" },
-  { T_PLIST_HOM_NSORT  +IMMUTABLE +COPYING, "list (plain,hom,nsort,imm,copied)" },
-#endif
 
   { T_PLIST_HOM_SSORT,                      "list (plain,hom,ssort)" },
   { T_PLIST_HOM_SSORT +IMMUTABLE,           "list (plain,hom,ssort,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_HOM_SSORT            +COPYING,  "list (plain,hom,ssort,copied)" },
-  { T_PLIST_HOM_SSORT +IMMUTABLE +COPYING,  "list (plain,hom,ssort,imm,copied)" },
-#endif
 
   { T_PLIST_TAB,                            "list (plain,table)" },
   { T_PLIST_TAB       +IMMUTABLE,           "list (plain,table,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_TAB                  +COPYING,  "list (plain,table,copied)" },
-  { T_PLIST_TAB       +IMMUTABLE +COPYING,  "list (plain,table,imm,copied)" },
-#endif
 
   { T_PLIST_TAB_NSORT,                      "list (plain,table,nsort)" },
   { T_PLIST_TAB_NSORT +IMMUTABLE,           "list (plain,table,nsort,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_TAB_NSORT            +COPYING,  "list (plain,table,nsort,copied)" },
-  { T_PLIST_TAB_NSORT +IMMUTABLE +COPYING,  "list (plain,table,nsort,imm,copied)" },
-#endif
 
   { T_PLIST_TAB_SSORT,                      "list (plain,table,ssort)" },
   { T_PLIST_TAB_SSORT +IMMUTABLE,           "list (plain,table,ssort,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_TAB_SSORT            +COPYING,  "list (plain,table,ssort,copied)" },
-  { T_PLIST_TAB_SSORT +IMMUTABLE +COPYING,  "list (plain,table,ssort,imm,copied)" },
-#endif
 
   { T_PLIST_TAB_RECT,                            "list (plain,rect table)" },
   { T_PLIST_TAB_RECT       +IMMUTABLE,           "list (plain,rect table,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_TAB_RECT                  +COPYING,  "list (plain,rect table,copied)" },
-  { T_PLIST_TAB_RECT       +IMMUTABLE +COPYING,  "list (plain,rect table,imm,copied)" },
-#endif
 
   { T_PLIST_TAB_RECT_NSORT,                      "list (plain,rect table,nsort)" },
   { T_PLIST_TAB_RECT_NSORT +IMMUTABLE,           "list (plain,rect table,nsort,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_TAB_RECT_NSORT            +COPYING,  "list (plain,rect table,nsort,copied)" },
-  { T_PLIST_TAB_RECT_NSORT +IMMUTABLE +COPYING,  "list (plain,rect table,nsort,imm,copied)" },
-#endif
 
   { T_PLIST_TAB_RECT_SSORT,                      "list (plain,rect table,ssort)" },
   { T_PLIST_TAB_RECT_SSORT +IMMUTABLE,           "list (plain,rect table,ssort,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_TAB_RECT_SSORT            +COPYING,  "list (plain,rect table,ssort,copied)" },
-  { T_PLIST_TAB_RECT_SSORT +IMMUTABLE +COPYING,  "list (plain,rect table,ssort,imm,copied)" },
-#endif
 
   { T_PLIST_CYC,                            "list (plain,cyc)" },
   { T_PLIST_CYC       +IMMUTABLE,           "list (plain,cyc,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_CYC                  +COPYING,  "list (plain,cyc,copied)" },
-  { T_PLIST_CYC       +IMMUTABLE +COPYING,  "list (plain,cyc,imm,copied)" },
-#endif
 
   { T_PLIST_CYC_NSORT,                      "list (plain,cyc,nsort)" },
   { T_PLIST_CYC_NSORT +IMMUTABLE,           "list (plain,cyc,nsort,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_CYC_NSORT            +COPYING,  "list (plain,cyc,nsort,copied)" },
-  { T_PLIST_CYC_NSORT +IMMUTABLE +COPYING,  "list (plain,cyc,nsort,imm,copied)" },
-#endif
 
   { T_PLIST_CYC_SSORT,                      "list (plain,cyc,ssort)" },
   { T_PLIST_CYC_SSORT +IMMUTABLE,           "list (plain,cyc,ssort,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_CYC_SSORT            +COPYING,  "list (plain,cyc,ssort,copied)" },
-  { T_PLIST_CYC_SSORT +IMMUTABLE +COPYING,  "list (plain,cyc,ssort,imm,copied)" },
-#endif
 
   { T_PLIST_FFE,                     "list (sml fin fld elms)" },
   { T_PLIST_FFE +IMMUTABLE,          "list (sml fin fld elms,imm)" },
-#if !defined(USE_THREADSAFE_COPYING)
-  { T_PLIST_FFE            +COPYING, "list (sml fin fld elms,copied)" },
-  { T_PLIST_FFE +IMMUTABLE +COPYING, "list (sml fin fld elms,imm,copied)" },
-#endif
 
   { -1,                                     "" }
 };
@@ -3566,18 +3453,10 @@ static Int InitKernel (
     for ( t1 = T_PLIST;  t1 < T_PLIST_FFE ;  t1 += 2 ) {
         InitMarkFuncBags( t1                     , MarkAllButFirstSubBags );
         InitMarkFuncBags( t1 +IMMUTABLE          , MarkAllButFirstSubBags );
-#if !defined(USE_THREADSAFE_COPYING)
-        InitMarkFuncBags( t1            +COPYING , MarkAllSubBags );
-        InitMarkFuncBags( t1 +IMMUTABLE +COPYING , MarkAllSubBags );
-#endif
     }
 
     InitMarkFuncBags( T_PLIST_FFE                     , MarkNoSubBags );
     InitMarkFuncBags( T_PLIST_FFE +IMMUTABLE          , MarkNoSubBags );
-#if !defined(USE_THREADSAFE_COPYING)
-    InitMarkFuncBags( T_PLIST_FFE            +COPYING , MarkNoSubBags );
-    InitMarkFuncBags( T_PLIST_FFE +IMMUTABLE +COPYING , MarkNoSubBags );
-#endif
     
     /* If T_PLIST_FFE is not the last PLIST type then some more
        work needs to be done here */
@@ -3685,12 +3564,8 @@ static Int InitKernel (
     for ( t1 = T_PLIST; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {
         CopyObjFuncs [ t1                     ] = CopyPlist;
         CopyObjFuncs [ t1 +IMMUTABLE          ] = CopyPlist;
-        CopyObjFuncs [ t1            +COPYING ] = CopyPlistCopy;
-        CopyObjFuncs [ t1 +IMMUTABLE +COPYING ] = CopyPlistCopy;
         CleanObjFuncs[ t1                     ] = CleanPlist;
         CleanObjFuncs[ t1 +IMMUTABLE          ] = CleanPlist;
-        CleanObjFuncs[ t1            +COPYING ] = CleanPlistCopy;
-        CleanObjFuncs[ t1 +IMMUTABLE +COPYING ] = CleanPlistCopy;
     }
 #endif
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -918,10 +918,8 @@ Obj CopyPlist (
     Obj                 tmp;            /* temporary variable              */
     UInt                i;              /* loop variable                   */
 
-    /* don't change immutable objects                                      */
-    if ( ! IS_MUTABLE_OBJ(list) ) {
-        return list;
-    }
+    // immutable input is handled by COPY_OBJ
+    GAP_ASSERT(IS_MUTABLE_OBJ(list));
 
     /* make a copy                                                         */
     if ( mut ) {

--- a/src/precord.c
+++ b/src/precord.c
@@ -168,10 +168,8 @@ Obj CopyPRec (
     Obj                 copy;           /* copy, result                    */
     Obj                 tmp;            /* temporary variable              */
 
-    /* don't change immutable objects                                      */
-    if ( ! IS_MUTABLE_OBJ(rec) ) {
-        return rec;
-    }
+    // immutable input is handled by COPY_OBJ
+    GAP_ASSERT(IS_MUTABLE_OBJ(rec));
 
     /* make a copy                                                     */
     if ( mut ) {

--- a/src/precord.h
+++ b/src/precord.h
@@ -51,18 +51,13 @@ static inline Int IS_PREC(Obj rec)
 **  This function is used in a GAP_ASSERT checking if calling functions like
 **  SET_ELM_PREC is acceptable on an Obj.
 **
-**  Unlike IS_PREC, this function also accepts precs which are being copied
-**  (and hence have the COPYING flag set), as well as component objects
-**  (which have the same memory layout as precs), as the precs APIs using it
-**  for assertion checks are in practice invoked on such objects, too.
+**  Unlike IS_PREC, this function also accepts component objects (which have
+**  the same memory layout as precs), as the precs APIs using it for
+**  assertion checks are in practice invoked on such objects, too.
 */
 static inline Int IS_PREC_OR_COMOBJ(Obj rec)
 {
     UInt tnum = TNUM_OBJ(rec);
-#if !defined(USE_THREADSAFE_COPYING)
-    if (tnum == T_COPYING)
-        return 1;
-#endif
     return tnum == T_PREC || tnum == T_PREC+IMMUTABLE || tnum == T_COMOBJ;
 }
 

--- a/src/precord.h
+++ b/src/precord.h
@@ -60,8 +60,8 @@ static inline Int IS_PREC_OR_COMOBJ(Obj rec)
 {
     UInt tnum = TNUM_OBJ(rec);
 #if !defined(USE_THREADSAFE_COPYING)
-    if (tnum > COPYING)
-        tnum -= COPYING;
+    if (tnum == T_COPYING)
+        return 1;
 #endif
     return tnum == T_PREC || tnum == T_PREC+IMMUTABLE || tnum == T_COMOBJ;
 }

--- a/src/range.c
+++ b/src/range.c
@@ -119,10 +119,8 @@ Obj CopyRange (
 {
     Obj                 copy;           /* copy, result                    */
 
-    /* don't change immutable objects                                      */
-    if ( ! IS_MUTABLE_OBJ(list) ) {
-        return list;
-    }
+    // immutable input is handled by COPY_OBJ
+    GAP_ASSERT(IS_MUTABLE_OBJ(list));
 
     /* make a copy                                                         */
     if ( mut ) {

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -572,10 +572,8 @@ Obj CopyString (
 {
     Obj                 copy;           /* handle of the copy, result      */
 
-    /* just return immutable objects                                       */
-    if ( ! IS_MUTABLE_OBJ(list) ) {
-        return list;
-    }
+    // immutable input is handled by COPY_OBJ
+    GAP_ASSERT(IS_MUTABLE_OBJ(list));
 
     /* make object for  copy                                               */
     if ( mut ) {

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -664,6 +664,9 @@ Obj CopyObjWPObj (
     Obj                 elm;
     UInt                i;              /* loop variable                   */
 
+    // immutable input is handled by COPY_OBJ
+    GAP_ASSERT(IS_MUTABLE_OBJ(obj));
+
     /* make a copy                                                         */
     if ( mut ) {
         copy = NewBag( T_WPOBJ, SIZE_OBJ(obj) );


### PR DESCRIPTION
This removes a lot of duplicate code, and makes it simpler to add further copying functions in the future.

Point in case: the semigroups package (the only to implement a non-trivial `CopyObjFuncs` entry) gets it wrong (paging @james-d-mitchell ), as it does not use a forwarding pointer approach at al. That is, it violates this invariant:
```gap
gap> x := [];; # imagine a T_SEMI here, I have no idea how to create one
gap> y := [ x, x ];;
gap> IsIdenticalObj(y[1], y[2]);
true
gap> z := StructuralCopy(y);
[ [  ], [  ] ]
gap> IsIdenticalObj(y[1], z[1]);
false
gap> IsIdenticalObj(z[1], z[2]);  # <- I predict this will return false if x is a T_SEMI
true
```
Now, I am not blaming anybody here: the copying logic in the GAP kernel simply is not that easy to understand. In fact, we made the same mistake in the `SingularInterface` package. With the changes in this PR, getting it right will be much simpler

I have incremented `GAP_KERNEL_MAJOR_VERSION` to detect the new code in the semigroups code. Among the few other packages implementing `CopyObjFuncs`, only SingularInterface needs a fix.

In addition, this is a first small step towards reducing the differences between the "traditional" copying code, and the HPC-GAP copying code; my hope is that we can eventually share a lot of the code to implement them.

This should not be merged before we branch stable-4.10, it's too risky.