### PR TITLE
hpcgap kernel: add enums for lock modes/status/qualifiers

### DIFF
--- a/doc/hpc/regions.xml
+++ b/doc/hpc/regions.xml
@@ -746,6 +746,7 @@ It is generally safe to use if all threads but the current one are paused.
     <Subsection Label="The atomic statement.">
       <Heading>The <C>atomic</C> statement.</Heading>
 
+<Index Key="atomic" Subkey="no value"><K>atomic</K></Index>
 The <C>atomic</C> statement ensures exclusive or read-only access to one or more shared regions for statements within
 its scope. It has the following syntax:
 

--- a/src/calls.c
+++ b/src/calls.c
@@ -54,6 +54,9 @@
 #include "stringobj.h"
 #include "vars.h"
 
+#ifdef HPCGAP
+#include "hpc/thread.h"
+#endif
 
 void SET_NAME_FUNC(Obj func, Obj name)
 {
@@ -1125,10 +1128,10 @@ void PrintFunction (
 #ifdef HPCGAP
         if (locks) {
             switch(locks[i-1]) {
-            case 1:
+            case LOCK_QUAL_READONLY:
                 Pr("%>readonly %<", 0L, 0L);
                 break;
-            case 2:
+            case LOCK_QUAL_READWRITE:
                 Pr("%>readwrite %<", 0L, 0L);
                 break;
             }

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -449,23 +449,23 @@ static void LockFuncArgs(Obj func, Int narg, const Obj * args)
 {
     Int i;
     int count = 0;
-    int *mode = alloca(narg * sizeof(int));
+    LockMode * mode = alloca(narg * sizeof(int));
     UChar *locks = CHARS_STRING(LCKS_FUNC(func));
     Obj *objects = alloca(narg * sizeof(Obj));
     for (i=0; i<narg; i++) {
       Obj obj = args[i];
       switch (locks[i]) {
-        case 1:
+      case LOCK_QUAL_READONLY:
           if (CheckReadAccess(obj))
             break;
-          mode[count] = 0;
+          mode[count] = LOCK_MODE_READONLY;
           objects[count] = obj;
           count++;
           break;
-        case 2:
+      case LOCK_QUAL_READWRITE:
           if (CheckWriteAccess(obj))
             break;
-          mode[count] = 1;
+          mode[count] = LOCK_MODE_READWRITE;
           objects[count] = obj;
           count++;
           break;

--- a/src/hpc/thread.h
+++ b/src/hpc/thread.h
@@ -68,11 +68,32 @@ void GCThreadHandler(void);
 
 void InitMainThread(void);
 
-int IsLocked(Region *region);
-void GetLockStatus(int count, Obj *objects, int *status);
-int LockObject(Obj obj, int mode);
-int LockObjects(int count, Obj *objects, const int *mode);
-int TryLockObjects(int count, Obj *objects, const int *mode);
+typedef enum LockQual {
+    LOCK_QUAL_NONE = 0,
+    LOCK_QUAL_READONLY = 1,
+    LOCK_QUAL_READWRITE = 2,
+} LockQual;
+
+typedef enum LockStatus {
+    LOCK_STATUS_UNLOCKED = 0,
+    LOCK_STATUS_READWRITE_LOCKED = 1,
+    LOCK_STATUS_READONLY_LOCKED = 2,
+} LockStatus;
+
+LockStatus IsLocked(Region *region);
+void GetLockStatus(int count, Obj *objects, LockStatus *status);
+
+
+typedef enum LockMode {
+    LOCK_MODE_READONLY = 0,
+    LOCK_MODE_READWRITE = 1,
+    LOCK_MODE_DEFAULT = LOCK_MODE_READWRITE,
+} LockMode;
+
+int LockObject(Obj obj, LockMode mode);
+int LockObjects(int count, Obj * objects, const LockMode * mode);
+int TryLockObjects(int count, Obj * objects, const LockMode * mode);
+
 void PushRegionLock(Region *region);
 void PopRegionLocks(int newSP);
 int RegionLockSP(void);

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -334,7 +334,6 @@ extern  void            IntrAtomicEnd ( void );
 #ifdef HPCGAP
 /* TODO: move these constants to a more appropriate location */
 enum {
-    DEFAULT_LOCK_TYPE  = 1,
     MAX_ATOMIC_OBJS = 256
 };
 #endif


### PR DESCRIPTION
Various magic constants (0, 1, 2) were used to indicate the status of locks;
to indicate the desired mode for a lock; and to indicate the presence of
readonly/readwrite keywords.

The use of these magic constants made it rather difficult to correctly
understand some of the code. By introducing bespoke names for them, the code
flow is much easier to understand.

This commit also fixes a possible OOB access to the LCKS_FUNC of an atomic
function: we only added entries to it for arguments with a qualifier; but
code later on assumes that LCKS_FUNC has entries for every argument.

Also removed some bogus code in FuncLOCK FuncTRYLOCK which apparently was
meant to accept odd/even integer values instead of true/false (which is
undocumented); but that code used `&& 1` instead of `& 1`, so always produced
readwrite mode.