### PR TITLE
fix and document `CharacterValueWreathSymmetric`

### DIFF
--- a/doc/manualbib.xml
+++ b/doc/manualbib.xml
@@ -2878,6 +2878,25 @@
   <other type="fjournal">Journal of Algebra</other>
 </article></entry>
 
+<entry id="JK81"><book>
+  <author>
+    <name><first>Gordon</first><last>James</last></name>
+    <name><first>Adalbert</first><last>Kerber</last></name>
+  </author>
+  <title>The representation theory of the symmetric group</title>
+  <publisher>Addison-Wesley Publishing Co., Reading, Mass.</publisher>
+  <year>1981</year>
+  <volume>16</volume>
+  <series>Encyclopedia of Mathematics and its Applications</series>
+  <note>With a foreword by P. M. Cohn,
+              With an introduction by Gilbert de B. Robinson</note>
+  <isbn>0-201-13515-9</isbn>
+  <mrnumber>644144</mrnumber>
+  <mrclass>20-02 (20C30)</mrclass>
+  <mrreviewer>A. O. Morris</mrreviewer>
+  <other type="pages">xxviii+510</other>
+</book></entry>
+
 <entry id="JLPW95"><book>
   <author>
     <name><first>Christoph</first><last>Jansen</last></name>

--- a/doc/ref/combinat.xml
+++ b/doc/ref/combinat.xml
@@ -69,6 +69,7 @@ subsets.
 <#Include Label="PowerPartition">
 <#Include Label="PartitionTuples">
 <#Include Label="NrPartitionTuples">
+<#Include Label="BetaSet">
 
 </Section>
 

--- a/doc/ref/ctbl.xml
+++ b/doc/ref/ctbl.xml
@@ -609,6 +609,7 @@ gap> SetInfoLevel( InfoCharacterTable, 0 );
 <#Include Label="CharacterTableIsoclinic">
 <#Include Label="CharacterTableOfNormalSubgroup">
 <#Include Label="CharacterTableWreathSymmetric">
+<#Include Label="CharacterValueWreathSymmetric">
 
 </Section>
 

--- a/lib/combinat.gd
+++ b/lib/combinat.gd
@@ -1250,7 +1250,9 @@ DeclareGlobalFunction("PowerPartition");
 ##  <P/>
 ##  <A>r</A>-tuples of partitions describe the classes and the characters
 ##  of wreath products of groups with <A>r</A> conjugacy classes with the
-##  symmetric group <M>S_n</M>.
+##  symmetric group on <A>n</A> points,
+##  see <Ref Func="CharacterTableWreathSymmetric"/>
+##  and <Ref Func="CharacterValueWreathSymmetric"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/ctblsymm.gd
+++ b/lib/ctblsymm.gd
@@ -1,6 +1,6 @@
 #############################################################################
 ##
-#W  ctblsymm.gd                 GAP library                    Götz Pfeiffer
+#W  ctblsymm.gd                 GAP library                     Götz Pfeiffer
 #W                                                               Felix Noeske
 ##
 ##
@@ -74,12 +74,27 @@
 ##
 #F  BetaSet( <alpha> )  . . . . . . . . . . . . . . . . . . . . . . beta set.
 ##
+##  <#GAPDoc Label="BetaSet">
 ##  <ManSection>
 ##  <Func Name="BetaSet" Arg='alpha'/>
 ##
 ##  <Description>
+##  For a list <A>alpha</A> that describes a partition of a nonnegative
+##  integer (see <Ref Func="Partitions"/>),
+##  <Ref Func="BetaSet"/> returns the list of integers obtained by reversing
+##  the order of <A>alpha</A>
+##  and then adding the sequence <C>[ 0, 1, 2, ... ]</C> of the same length,
+##  cf. <Cite Key="JK81" Where="Section 2.7"/>.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> BetaSet( [ 4, 2, 1 ] );
+##  [ 1, 3, 6 ]
+##  gap> BetaSet( [] );
+##  [  ]
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
+##  <#/GAPDoc>
 ##
 DeclareGlobalFunction( "BetaSet" );
 
@@ -230,16 +245,58 @@ DeclareGlobalVariable( "CharTableWeylD",
 
 #############################################################################
 ##
-#F  CharValueWreathSymmetric(<sub>,<n>,<beta>,<pi>) . char. value in G wr Sn.
+#F  CharacterValueWreathSymmetric( <tbl>, <n>, <beta>, <pi> ) . .
+#F                                        . . . .  character value in G wr Sn
 ##
+##  <#GAPDoc Label="CharacterValueWreathSymmetric">
 ##  <ManSection>
-##  <Func Name="CharValueWreathSymmetric" Arg='sub,n,beta,pi'/>
+##  <Func Name="CharacterValueWreathSymmetric" Arg='tbl, n, beta, pi'/>
 ##
 ##  <Description>
+##  Let <A>tbl</A> be the ordinary character table of a group <M>G</M>, say.
+##  The aim of this function is to compute a single character value
+##  from the character table of the wreath product of <M>G</M>
+##  with the full symmetric group on <A>n</A> points.
+##  <P/>
+##  The conjugacy classes and the irreducible characters of this
+##  wreath product are parametrized by <M>r</M>-tuples of partitions
+##  which together form a partition of <A>n</A>
+##  (see <Ref Func="PartitionTuples"/>),
+##  where <M>r</M> is the number of conjugacy classes of <M>G</M>.
+##  <P/>
+##  We describe the conjugacy class for which we want to compute the value
+##  by the <M>r</M>-tuple <A>pi</A> of partitions in question,
+##  and describe the character for which we want to compute the value
+##  by the <M>r</M>-tuple <A>beta</A> of <Ref Func="BetaSet"/> values of the
+##  <M>r</M>-tuple of partitions in question.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> n:= 4;;
+##  gap> classpara:= [ [], [ 2, 1, 1 ] ];;
+##  gap> charpara:= [ [ 2, 1 ], [ 1 ] ];;
+##  gap> betas:= List( charpara, BetaSet );;
+##  gap> c2:= CharacterTable( "Cyclic", 2 );;
+##  gap> CharacterValueWreathSymmetric( c2, n, betas, classpara );
+##  0
+##  gap> wr:= CharacterTableWreathSymmetric( c2, n );;
+##  gap> classpos:= Position( ClassParameters( wr ), classpara );;
+##  gap> charpos:= Position( CharacterParameters( wr ), charpara );;
+##  gap> Irr( wr )[ charpos, classpos ];
+##  0
+##  ]]></Example>
+##  <P/>
+##  This function can be useful if one is interested in only a few
+##  character values.
+##  If many character values are needed then it is probably faster to
+##  compute the whole character table of the wreath product using
+##  <Ref Func="CharacterTableWreathSymmetric"/>,
+##  which uses intermediate results of recursive computations
+##  and therefore can avoid repetitions.
 ##  </Description>
 ##  </ManSection>
+##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "CharValueWreathSymmetric" );
+DeclareGlobalFunction( "CharacterValueWreathSymmetric" );
 
 
 #############################################################################

--- a/lib/ctblsymm.gi
+++ b/lib/ctblsymm.gi
@@ -1,6 +1,6 @@
 #############################################################################
 ##
-#W  ctblsymm.gi                 GAP library                    Götz Pfeiffer
+#W  ctblsymm.gi                 GAP library                     Götz Pfeiffer
 #W                                                               Felix Noeske
 ##
 ##
@@ -1054,12 +1054,14 @@ CharTableWeylD.matrix := function(n)
 end;
 MakeImmutable(CharTableWeylD);
 
+
 #############################################################################
 ##
-#F  CharValueWreathSymmetric( <sub>, <n>, <beta>, <pi> ) . .
-#F                                        . . . . character value in G wr Sn.
+#F  CharacterValueWreathSymmetric( <tbl>, <n>, <beta>, <pi> ) . .
+#F                                        . . . .  character value in G wr Sn
 ##
-InstallGlobalFunction( CharValueWreathSymmetric, function(sub, n, beta, pi)
+InstallGlobalFunction( CharacterValueWreathSymmetric,
+    function( sub, n, beta, pi )
     local i, j, k, lb, o, s, t, r, gamma, rho, sign, val, subirreds;
 
     #  termination condition.
@@ -1112,11 +1114,13 @@ InstallGlobalFunction( CharValueWreathSymmetric, function(sub, n, beta, pi)
 
              #  construct new beta set.
              gamma:= ShallowCopy(beta);
-             SubtractSet(gamma[s], [i]);
+             gamma[s]:= ShallowCopy( gamma[s] );
+             RemoveSet( gamma[s], i );
              AddSet(gamma[s], i-k);
 
              #  enter recursion.
-             val:= val + sign*CharValueWreathSymmetric(sub, n-k, gamma, rho);
+             val:= val +
+                sign * CharacterValueWreathSymmetric( sub, n-k, gamma, rho );
           fi;
        od;
     od;

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -265,6 +265,19 @@ DeclareObsoleteSynonymAttr( "NormedVectors", "NormedRowVectors" );
 
 #############################################################################
 ##
+#F  CharValueWreathSymmetric( <tbl>, <n>, <beta>, <pi> )  . .
+#F                                        . . . .  character value in G wr Sn
+##
+##  This function was never documented but had been available for decades.
+##  Its functionality became documented under the more suitable name
+##  'CharacterValueWreathSymmetric' in GAP 4.10.
+##
+DeclareObsoleteSynonym( "CharValueWreathSymmetric",
+    "CharacterValueWreathSymmetric" );
+
+
+#############################################################################
+##
 #O  FormattedString( <obj>, <nr> )  . . formatted string repres. of an object
 ##
 ##  This variable name was never documented and is obsolete.

--- a/tst/teststandard/ctblsymm.tst
+++ b/tst/teststandard/ctblsymm.tst
@@ -1,0 +1,30 @@
+#############################################################################
+##
+#W  ctblsymm.tst               GAP Library                      Thomas Breuer
+##
+##
+#Y  Copyright (C)  2018,  Lehrstuhl D für Mathematik,  RWTH Aachen,  Germany
+##
+gap> START_TEST( "ctblsymm.tst" );
+
+#
+gap> c3:= CharacterTable( "Cyclic", 3 );;
+gap> n:= 3;;
+gap> wr:= CharacterTableWreathSymmetric( c3, n );;
+gap> irr:= Irr( wr );;
+gap> for i in [ 1 .. Length( irr ) ] do
+>      betas:= List( CharacterParameters( wr )[i], BetaSet );
+>      if List( ClassParameters( wr ), 
+>               c -> CharacterValueWreathSymmetric( c3, n, betas, c ) ) 
+>         <> irr[i] then
+>        Error( "wrong result!" );
+>      fi;
+>    od;
+
+#
+gap> STOP_TEST( "ctblsymm.tst" );
+
+#############################################################################
+##
+#E
+


### PR DESCRIPTION
The undocumented function `CharValueWreathSymmetric` was not correct.
It was not used anywhere in the library,
but perhaps somebody else has used it.

I have fixed the bug and documented the function
(including a cross-reference from `PartitionTuples`).
For that, I have renamed it to `CharacterValueWreathSymmetric`,
and added the old name as an obsolete synonym.

It would be good to add a cross-reference to the function `BetaSet`.
This function belongs to the GAP library and *is* documented,
but the documentation belongs to the package `hecke`.
I think the right solution for this problem is to ask @dtraytel
to remove the documentation of `BetaSet` from his package;
afterwards we can then add documentation to the GAP Reference Manual.

(Besides that, I have corrected some misleading comments about the use
of obsolete variable names.)