### PR TITLE
kernel: fix bug in MarkWeakPointerObj during copying

### DIFF
--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -590,6 +590,12 @@ Obj FuncIsWPObj( Obj self, Obj wp)
 
 static void MarkWeakPointerObj(Obj wp)
 {
+#if !defined(USE_THREADSAFE_COPYING)
+    // mark the forwarding pointer
+    if (TNUM_OBJ(wp) == T_WPOBJ + COPYING)
+        MarkBag(CONST_ADDR_OBJ(wp)[0]);
+#endif
+
     // can't use the stored length here, in case we are in the middle of
     // copying
     const UInt len = SIZE_BAG(wp) / sizeof(Obj) - 1;


### PR DESCRIPTION
We did not mark the forwarding pointer when copying. As a result, a badly timed GC could have reaped the copy of the wpobj, and then when we try to finalize the copying, a crash (or, if we were really unlucky, corrupt data) could have resulted.

I never observed this manifest, though; I only discovered it while trying together with @rbehrends to track down a crash with Julia GC; while inspecting our code in PR #2688, I realized that the bug fixed here exists (and that I had "accidentally" fixed it in PR #2688 for Julia GC, because I changed the code there to not use `MarkWeakPointerObj` anymore).

This issue is also resolved by PR #2777, which completely refactors the copying code, and essentially makes this kind of bug impossible.