### PR TITLE
Travis: start GAP with disabled obsoletes in one of the tests

### DIFF
--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -131,7 +131,11 @@ GAPInput
     ;;
 
   testmanuals)
-    $GAP $SRCDIR/tst/extractmanuals.g
+    # Start GAP with -O option to disable obsoletes. The test
+    # will fail if there will be an error message, but warnings
+    # should be checked manually in the test log. Since some
+    # packages may still use obsoletes, we use -A option.
+    $GAP -O -A $SRCDIR/tst/extractmanuals.g
 
     $GAP <<GAPInput
         SetUserPreference("ReproducibleBehaviour", true);


### PR DESCRIPTION
This is an experiment to see how much Travis CI tests will fail. To start with, GAP is called with `-O` everywhere. Most likely, this PR will evolve into disabling loading obsoletes only in some tests - we do want to test obsolete parts of the code too, since they are loaded by default.

