### PR TITLE
Remove tests viewing matrices

### DIFF
--- a/tst/testinstall/MatrixObj/TraceMat.tst
+++ b/tst/testinstall/MatrixObj/TraceMat.tst
@@ -1,12 +1,9 @@
 gap> START_TEST( "TraceMat.tst" );
 gap> l := [[1,2],[3,4]];
 [ [ 1, 2 ], [ 3, 4 ] ]
-gap> m1 := Matrix(l);
-<2x2-matrix over Rationals>
-gap> m2 := Matrix(Integers,l);
-<2x2-matrix over Integers>
-gap> m3 := Matrix(GF(7),l*One(GF(7)));
-[ [ Z(7)^0, Z(7)^2 ], [ Z(7), Z(7)^4 ] ]
+gap> m1 := Matrix(l);;
+gap> m2 := Matrix(Integers,l);;
+gap> m3 := Matrix(GF(7),l*One(GF(7)));;
 gap> TraceMat( m1 );
 5
 gap> TraceMat( m2 );


### PR DESCRIPTION
The printing tests cause tests with the Semigroups package loaded to fail,
because Semigroups has its own implementation of MatrixObjs that currently
conflicts in small ways with the GAP library.

Testing `ViewObj` is not that useful currently anyway, so removing these tests doesn't hurt right now, but makes all tests pass with `Semigroups` `stable-3.0` branch and `GAP`'s `master` branch.