### PR TITLE
Revert remove matrix printing test

### DIFF
--- a/tst/testinstall/MatrixObj/TraceMat.tst
+++ b/tst/testinstall/MatrixObj/TraceMat.tst
@@ -1,9 +1,12 @@
 gap> START_TEST( "TraceMat.tst" );
 gap> l := [[1,2],[3,4]];
 [ [ 1, 2 ], [ 3, 4 ] ]
-gap> m1 := Matrix(l);;
-gap> m2 := Matrix(Integers,l);;
-gap> m3 := Matrix(GF(7),l*One(GF(7)));;
+gap> m1 := Matrix(l);
+<2x2-matrix over Rationals>
+gap> m2 := Matrix(Integers,l);
+<2x2-matrix over Integers>
+gap> m3 := Matrix(GF(7),l*One(GF(7)));
+[ [ Z(7)^0, Z(7)^2 ], [ Z(7), Z(7)^4 ] ]
 gap> TraceMat( m1 );
 5
 gap> TraceMat( m2 );


### PR DESCRIPTION
Revert #2784, just in case we decide to put tests back in that are testing printing of matrices. (arguably they would not go into `TraceMat.tst` though.

Feel free to just close this again if you feel this is unnecessary or addressed otherwise.