### PR TITLE
kernel: prevent OffsBodyStack from overflowing

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -599,6 +599,7 @@ Obj CodeEnd(UInt error)
         /* the stacks must be empty                                        */
         GAP_ASSERT(CS(CountStat) == 0);
         GAP_ASSERT(CS(CountExpr) == 0);
+        GAP_ASSERT(CS(OffsBodyCount) == 0);
 
         /* we must be back to 'STATE(CurrLVars)'                                  */
         GAP_ASSERT(STATE(CurrLVars) == CS(CodeLVars));
@@ -613,6 +614,7 @@ Obj CodeEnd(UInt error)
         /* empty the stacks                                                */
         CS(CountStat) = 0;
         CS(CountExpr) = 0;
+        CS(OffsBodyCount) = 0;
 
         /* go back to the correct frame                                    */
         SWITCH_TO_OLD_LVARS(CS(CodeLVars));

--- a/tst/testbugfix/2018-09-07-OffsBodyStack-overflow.tst
+++ b/tst/testbugfix/2018-09-07-OffsBodyStack-overflow.tst
@@ -1,0 +1,8 @@
+#
+# Aborting parsing of a function expression failed to reset OffsBodyStack,
+# which would eventually crash GAP (if you were lucky), or silently corrupt
+# the heap.
+#
+gap> for i in [1..2000] do
+>   Test(InputTextString("gap> function() QUIT; end;"), rec(reportDiff:=Ignore));
+> od;


### PR DESCRIPTION
Fixes #2787