### PR TITLE
Adjust a bugfix test for compatibility with Semigroups

### DIFF
--- a/tst/testbugfix/2018-05-09-submagma.tst
+++ b/tst/testbugfix/2018-05-09-submagma.tst
@@ -30,15 +30,12 @@ gap> IsMagmaWithInverses(asub);
 false
 
 #
-gap> mgm:=Magma( () );
-<commutative semigroup with 1 generator>
+gap> mgm:=Magma( () );;
 gap> Size(mgm);
 1
 gap> IsTrivial(mgm);
 true
 gap> IsEmpty(mgm);
-false
-gap> IsMagmaWithInverses(mgm);
 false
 
 #


### PR DESCRIPTION
A test in `tst/testbugfix/2018-05-09-submagma.tst` has different output with and without the Semigroups package loaded, in ways that I believe are not particularly important. See https://github.com/gap-packages/Semigroups/issues/492 and its duplicate (whoops) https://github.com/gap-packages/Semigroups/issues/511. This PR removes the varying output.

With more mathematical detail:

With the semigroups pacakge loaded, a magma generated by the identity permutation knows that it is trivial, and therefore a group, and so it prints the magma differently. Furthermore, such a magma satisfies `IsMagmaWithInverses` with Semigroups loaded, but not without. This PR adjusts the output of the tests in a bugfix file to accommodate this different behaviour.