### PR TITLE
Tweak some error messages

### DIFF
--- a/lib/algsc.gi
+++ b/lib/algsc.gi
@@ -122,7 +122,7 @@ InstallMethod( ObjByExtRep,
                         ElementsFamily( FamilyObj( coeffs ) ) ) then
       Error( "family of <coeffs> does not fit to <Fam>" );
     elif Length( coeffs ) <> Length( Fam!.names ) then
-      Error( "<coeffs> must be a list of length ", Fam!.names );
+      Error( "<coeffs> must be a list of length ", Length( Fam!.names ) );
     fi;
     return Objectify( Fam!.defaultTypeDenseCoeffVectorRep,
                       [ Immutable( coeffs ) ] );

--- a/lib/ringsc.gi
+++ b/lib/ringsc.gi
@@ -33,7 +33,7 @@ InstallMethod( ObjByExtRep,
     [ IsSCRingObjFamily, IsHomogeneousList ],
     function( Fam, coeffs )
     if Length( coeffs ) <> Length( Fam!.names ) then
-      Error( "<coeffs> must be a list of length ", Fam!.names );
+      Error( "<coeffs> must be a list of length ", Length( Fam!.names ) );
     elif not ForAll( [1..Length(coeffs)], IsInt ) and
       ForAll([1..Length(coeffs)],p->Fam!.moduli[p]=0 or 
 	(0<=coeffs[p] and coeffs[p]<Fam!.moduli[p])) then

--- a/tst/testinstall/algsc.tst
+++ b/tst/testinstall/algsc.tst
@@ -43,7 +43,7 @@ gap> fam:= ElementsFamily( FamilyObj( a ) );
 gap> ObjByExtRep( fam, [ 0, 1, 0, 1 ] * Z(2) );
 Error, family of <coeffs> does not fit to <Fam>
 gap> ObjByExtRep( fam, [ 0, 1, 0 ] );
-Error, <coeffs> must be a list of length [ "v.1", "v.2", "v.3", "v.4" ]
+Error, <coeffs> must be a list of length 4
 gap> v:= ObjByExtRep( fam, [ 0, 1, 0, 1 ] );
 v.2+v.4
 gap> t:= AlgebraByStructureConstants( Rationals, [ 0, 0 ] );


### PR DESCRIPTION
This resolves the observation by @ThomasBreuer on PR #2802, where a test did not match a change to a certain error message.

The problem was that the same error message code was used in two other places, and my test did not actually test the one I changed. Now, the test is triggering one of the (in total, together with PR #2802) three changed error messages. I have not yet tried to write tests that trigger the other two.