### PR TITLE
FIX: Bad Memory inefficiency in new MTC.

### DIFF
--- a/lib/tietze.gd
+++ b/lib/tietze.gd
@@ -393,54 +393,7 @@ DeclareGlobalFunction("AddRelator");
 ##  <P/>
 ##  This time we end up with a shorter presentation.
 ##  <P/>
-##  As an example of an implicit call of the function
-##  <Ref Func="DecodeTree"/> via the command
-##  <Ref Func="PresentationSubgroupMtc"/> we handle a subgroup
-##  of index 240 in a
-##  group of order 40320 given by a presentation due to
-##  B.&nbsp;H.&nbsp;Neumann.
-##  Note that we increase the level of <Ref InfoClass="InfoFpGroup"/>
-##  temporarily to get some additional output.
 ##  <P/>
-##  <Example><![CDATA[
-##  gap> F3 := FreeGroup( "a", "b", "c" );;
-##  gap> a := F3.1;;  b := F3.2;;  c := F3.3;;
-##  gap> G := F3 / [ a^3, b^3, c^3, (a*b)^5, (a^-1*b)^5, (a*c)^4,
-##  >     (a*c^-1)^4, a*b^-1*a*b*c^-1*a*c*a*c^-1, (b*c)^3, (b^-1*c)^4 ];;
-##  gap> a := G.1;;  b := G.2;;  c := G.3;;
-##  gap> H := Subgroup( G, [ a, c ] );;
-##  gap> SetInfoLevel( InfoFpGroup, 1 );
-##  gap> P := PresentationSubgroupMtc( G, H );;
-##  #I  there are 4 generators and 144 relators of total length 4373
-##  #I  there are 4 generators and 140 relators of total length 3898
-##  #I  there are 4 generators and 137 relators of total length 3715
-##  #I  there are 4 generators and 135 relators of total length 3380
-##  #I  there are 4 generators and 134 relators of total length 3291
-##  #I  there are 4 generators and 133 relators of total length 3212
-##  #I  there are 3 generators and 129 relators of total length 6494
-##  #I  there are 3 generators and 128 relators of total length 5465
-##  #I  there are 3 generators and 127 relators of total length 3722
-##  #I  there are 3 generators and 126 relators of total length 3048
-##  #I  there are 2 generators and 10 relators of total length 118
-##  #I  there are 2 generators and 5 relators of total length 38
-##  gap> TzGoGo( P );
-##  gap> TzPrintGenerators( P );
-##  #I  1.  _x1   19 occurrences
-##  #I  2.  _x2   19 occurrences
-##  gap> TzPrint( P );
-##  #I  generators: [ _x1, _x2 ]
-##  #I  relators:
-##  #I  1.  3  [ 1, 1, 1 ]
-##  #I  2.  3  [ 2, 2, 2 ]
-##  #I  3.  8  [ 1, -2, 1, -2, 1, -2, 1, -2 ]
-##  #I  4.  8  [ 2, 1, 2, 1, 2, 1, 2, 1 ]
-##  #I  5.  16  [ 2, -1, 2, 1, 2, -1, 2, 1, 2, -1, 2, 1, 2, -1, 2, 1 ]
-##  gap> K :=  FpGroupPresentation( P );
-##  <fp group on the generators [ _x1, _x2 ]>
-##  gap> SetInfoLevel( InfoFpGroup, 0 );
-##  gap> Size( K );
-##  168
-##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -1603,7 +1556,7 @@ DeclareAttribute("TzOptions",IsPresentation,"mutable");
 ##  <A>P</A>.
 ##  <Example><![CDATA[
 ##  gap> TzPrintOptions( P );
-##  #I  protected          = 2
+##  #I  protected          = 0
 ##  #I  eliminationsLimit  = 100
 ##  #I  expandLimit        = 150
 ##  #I  generatorsLimit    = 0

--- a/tst/testbugfix/2018-09-13-MTC.tst
+++ b/tst/testbugfix/2018-09-13-MTC.tst
@@ -1,0 +1,8 @@
+#MTC memory request/drop issue , Github PR#2812
+# was reported in forum email
+# https://mail.gap-system.org/pipermail/forum/2018/005793.html
+gap> F:=FreeGroup("a","b");;
+gap> rels:=ParseRelators(F,"a2,b4,(ab)11, (ab2)5,[a,bab]3,(ababaB)5");;
+gap> G:=F/rels;;
+gap> Size(G);
+443520


### PR DESCRIPTION
The new MTC was allocating and releasing memory excessively, in particular once the coset table got larger. This was reported by P.Timmons for the case of M22 in gap-forum, in test examples that do not create such a large coset table (here: 1.6 million definitions) the change is not so dramatic and might be overlooked.

This was fixed by re-using the same memory over and over again.

Also fixed wrong index in tracing backwards. in the deductions routine -- this will have slowed down tracing. (Cannot lead to wrong results, only unbearably slow calculations)

Special treatment for generators that are known to be of order 2 b/c of x^2 relator -- instead of using consequences every time, set column equal to column of inverse and do not run through inverse when looping over generators.