### PR TITLE
Removed <Ref> to undocumented NewVector

### DIFF
--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -507,7 +507,7 @@ DeclareOperation( "Vector", [IsList]);
 ##    <Oper Arg="V" Name="ConstructingFilter" Label="for IsVectorObj"/>
 ##    <Returns>a filter</Returns>
 ##    <Description>
-##      Returns a filter <C>f</C> such that if <Ref Oper="NewVector"/> is
+##      Returns a filter <C>f</C> such that if <C>NewVector</C> is
 ##      called with <C>f</C> a vector in the same representation as <A>V</A>
 ##      is produced.
 ##    </Description>


### PR DESCRIPTION
`NewVector` is undocumented - removed `<Ref>` to avoid unresolved cross-reference. 

More stuff from the new matrix obj implementation should be documented, but that is outside the scope of this PR, which has to fix a tiny problem when building GAP 4.10.0 manuals.