### PR TITLE
Add SUM_FLAGS to rank of IsomorphismPermGroup for IsPermGroup

### DIFF
--- a/lib/ghomperm.gi
+++ b/lib/ghomperm.gi
@@ -1928,7 +1928,8 @@ end);
 InstallMethod( IsomorphismPermGroup,
     "perm groups",
     true,
-    [ IsPermGroup ], 0,
+    [ IsPermGroup ],
+    SUM_FLAGS,
     IdentityMapping );
 
 

--- a/tst/testinstall/grpperm.tst
+++ b/tst/testinstall/grpperm.tst
@@ -77,4 +77,6 @@ gap> IsSolvable(G);
 false
 gap> Length(MinimalGeneratingSet(G));
 2
+gap> IsomorphismPermGroup(G) = IdentityMapping(G);
+true
 gap> STOP_TEST( "grpperm.tst", 1);


### PR DESCRIPTION
(This PR arose from https://github.com/gap-system/gap/issues/2818).

As discussed by @fingolfin in https://github.com/gap-system/gap/issues/2818#issuecomment-421863573, different GAP library methods for `IsomorphismPermGroup` for a perm group apply, depending on which/how many packages are loaded. It seems sensible that `IsomorphismPermGroup` should always return the `IdentityMapping` for a perm group. Adding `SUM_FLAGS` should achieve this.

Note that when/if this PR is merged, the tests in the development version of Semigroups will be able to run without errors in both the `master` and `stable-4.10` branches, given https://github.com/gap-packages/Semigroups/pull/524.