### PR TITLE
New GAP-level variable ErrorOutput for "*errout*"

### DIFF
--- a/lib/error.g
+++ b/lib/error.g
@@ -18,6 +18,10 @@ CallAndInstallPostRestore( function()
     ASS_GVAR( "QUITTING", false );
 end);
 
+#############################################################################
+##
+## Default stream for error messages.
+ERROR_OUTPUT := "*errout*";
 
 #############################################################################
 ##


### PR DESCRIPTION
This is a "revival" of #1815.

### Changes in comparison to PR #1815
The changes to markus' PR are
- I got rid of the C level declarations
- I'm using `"*errout*"` instead of wrapping it in an OutputTextFile(). The reason being that when using `OutputTextFile("*errout*", bool)` (with bool true or false) `make testinstall` fails due to the error messages vanishing into thin air. Actually they still appear in the terminal, but before all of the "testing: ..." output. I guess this may be somehow related to #2823?
- I did not define StandardInput and StandardOutput. If GAP's i/o is going to
be refactored by using GAP level IsOutputTextStream objects we can still define them then.

I did not do changes to `colorprompt.g` since I think `STDOut` is only defined in this file because there is no method installed for `WriteAll` which can take `"*stdout*"` as an argument. Also I have the feeling defining `ErrorOutput` should be a temporary solution only.