### PR TITLE
Fix ShallowCopy for IteratorOfCartesianProduct

### DIFF
--- a/lib/combinat.gi
+++ b/lib/combinat.gi
@@ -799,6 +799,7 @@ BindGlobal( "NextIterator_Cartesian",
 
 BindGlobal( "ShallowCopy_Cartesian", 
             iter -> rec( 
+                      sets := iter!.sets,
                      sizes := iter!.sizes,
                          n := iter!.n,
                       next := ShallowCopy( iter!.next ) ) );
@@ -820,9 +821,8 @@ BindGlobal( "IteratorOfCartesianProduct2",
            NextIterator   := NextIterator_Cartesian,
            ShallowCopy    := ShallowCopy_Cartesian,
            sets           := s,                      # list of sets
-           sizes          := List( s, Size ),        # sizes of sets
+           sizes          := MakeImmutable( List( s, Size ) ),
            n              := n,                      # number of sets
-           nextelts       := List( s, x -> x[1] ),   # list of 1st elements
            next           := 0 * [ 1 .. n ] + 1 ) ); # list of 1's
     end);
     

--- a/tst/testinstall/combinat.tst
+++ b/tst/testinstall/combinat.tst
@@ -229,6 +229,26 @@ gap> Print(List( [0..3], k -> NrTuples( [1..3], k ) ),"\n");
 gap> NrTuples( [1..8], 4 );
 4096
 
+#
+# IteratorOfCartesianProduct
+#
+
+# empty cartesian product
+gap> it:=IteratorOfCartesianProduct([[1,2],[]]);;
+gap> IsDoneIterator(it);
+true
+gap> List(it);
+[  ]
+
+# non-empty cartesian product
+gap> it:=IteratorOfCartesianProduct([1,2], [3,4]);;
+gap> IsDoneIterator(it);
+false
+gap> List(it);
+[ [ 1, 3 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ] ]
+gap> List(it); # do it again, to verify the original iterator was not modified
+[ [ 1, 3 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ] ]
+
 #F  PermutationsList( <mset> )  . . . . . . set of permutations of a multiset
 gap> PermutationsList( [] );
 [ [  ] ]


### PR DESCRIPTION
Reported by @mohamed-barakat 

Could be backported to 4.10 (but feel free to disagree, and remove the backport label again).