### PR TITLE
Fix GreensXClasses for a Green's class

### DIFF
--- a/lib/semirel.gd
+++ b/lib/semirel.gd
@@ -200,23 +200,33 @@ DeclareSynonymAttr("AssociatedSemigroup", ParentAttr);
 
 #############################################################################
 ##
-#A  GreensRClasses(<semigroup>)
-#A  GreensLClasses(<semigroup>)
-#A  GreensJClasses(<semigroup>)
-#A  GreensDClasses(<semigroup>)
-#A  GreensHClasses(<semigroup>)
+#A  GreensRClasses(<S>)
+#A  GreensLClasses(<S>)
+#A  GreensHClasses(<S>)
+#A  GreensJClasses(<S>)
+#A  GreensDClasses(<S>)
 ##
 ##  <#GAPDoc Label="GreensRClasses">
 ##  <ManSection>
-##  <Attr Name="GreensRClasses" Arg='semigroup'/>
-##  <Attr Name="GreensLClasses" Arg='semigroup'/>
-##  <Attr Name="GreensJClasses" Arg='semigroup'/>
-##  <Attr Name="GreensDClasses" Arg='semigroup'/>
-##  <Attr Name="GreensHClasses" Arg='semigroup'/>
+##  <Attr Name="GreensRClasses" Arg="S"/>
+##  <Attr Name="GreensLClasses" Arg="S"/>
+##  <Attr Name="GreensHClasses" Arg="S"/>
+##  <Attr Name="GreensJClasses" Arg="S"/>
+##  <Attr Name="GreensDClasses" Arg="S"/>
 ##
 ##  <Description>
-##  return the <M>R</M>, <M>L</M>, <M>J</M>, <M>H</M>, or <M>D</M>
-##  Green's classes, respectively for semigroup <A>semigroup</A>.
+##  If <A>S</A> is a semigroup, then these attributes return the Green's
+#   <M>R</M>-, <M>L</M>-, <M>H</M>-, <M>J</M>-, or
+##  <M>D</M>-classes, respectively for the semigroup <A>S</A>.
+##  <P/>
+##  Additionally, if <A>S</A> is a Green's <M>D</M>-class of a semigroup, then
+##  <C>GreensRClasses</C> and <C>GreensLClasses</C> return the Green's <M>R</M>-
+##  or <M>L-</M>classes of the semigroup, respectively, contained in the
+##  <M>D</M>-class <A>S</A>;
+##  if <A>S</A> is a Green's <M>D</M>-, <M>R</M>-, or <M>L</M>-class of a
+##  semigroup, then <C>GreensHClasses</C> returns the Green's <M>H</M>-classes
+##  of the semigroup contained in the Green's class <A>S</A>.
+##  <P/>
 ##  <Ref Func="EquivalenceClasses" Label="attribute"/> for a Green's relation
 ##  lead to one of these functions.
 ##  </Description>
@@ -230,7 +240,9 @@ DeclareAttribute("GreensJClasses", IsSemigroup);
 DeclareAttribute("GreensDClasses", IsSemigroup);
 DeclareAttribute("GreensHClasses", IsSemigroup);
 
-DeclareAttribute("GreensHClasses", IsGreensClass);
+DeclareAttribute("GreensHClasses", IsGreensDClass);
+DeclareAttribute("GreensHClasses", IsGreensLClass);
+DeclareAttribute("GreensHClasses", IsGreensRClass);
 DeclareAttribute("GreensRClasses", IsGreensDClass);
 DeclareAttribute("GreensLClasses", IsGreensDClass);
 

--- a/lib/semirel.gi
+++ b/lib/semirel.gi
@@ -719,14 +719,14 @@ function(semi)
   return GreensHClasses(semi);
 end);
 
-InstallOtherMethod(GreensHClasses, "for a Green's Class", true, [IsGreensDClass], 0,
-x-> GreensHClasses(CanonicalGreensClass(x)));
+InstallMethod(GreensHClasses, "for a Green's D-class", [IsGreensDClass],
+x -> Filtered(GreensHClasses(ParentAttr(x)), y -> Representative(y) in x));
 
-InstallOtherMethod(GreensHClasses, "for a Green's Class", true, [IsGreensRClass], 0,
-x-> GreensHClasses(CanonicalGreensClass(x)));
+InstallMethod(GreensHClasses, "for a Green's R-class", [IsGreensRClass],
+x -> Filtered(GreensHClasses(ParentAttr(x)), y -> Representative(y) in x));
 
-InstallOtherMethod(GreensHClasses, "for a Green's Class", true, [IsGreensLClass], 0,
-x-> GreensHClasses(CanonicalGreensClass(x)));
+InstallMethod(GreensHClasses, "for a Green's L-class", [IsGreensLClass],
+x -> Filtered(GreensHClasses(ParentAttr(x)), y -> Representative(y) in x));
 
 #############################################################################
 ##

--- a/tst/testinstall/semirel.tst
+++ b/tst/testinstall/semirel.tst
@@ -135,6 +135,39 @@ gap> LClassOfHClass(H);
 <Green's L-class: Transformation( [ 2, 4, 3, 4 ] )>
 gap> RClassOfHClass(H);
 <Green's R-class: Transformation( [ 2, 4, 3, 4 ] )>
+
+# GreensXClasses for a GreensClass
+gap> S := Semigroup([Transformation([1, 1, 1, 1]),
+>                    Transformation([1, 1, 1, 2]),
+>                    Transformation([1, 1, 1, 3])]);;
+gap> D := GreensDClasses(S); 
+[ <Green's D-class: Transformation( [ 1, 1, 1, 1 ] )>, 
+  <Green's D-class: Transformation( [ 1, 1, 1, 2 ] )>, 
+  <Green's D-class: Transformation( [ 1, 1, 1, 3 ] )> ]
+gap> L := GreensLClasses(S);
+[ <Green's L-class: Transformation( [ 1, 1, 1, 1 ] )>, 
+  <Green's L-class: Transformation( [ 1, 1, 1, 2 ] )>, 
+  <Green's L-class: Transformation( [ 1, 1, 1, 3 ] )> ]
+gap> R := GreensRClasses(S);
+[ <Green's R-class: Transformation( [ 1, 1, 1, 1 ] )>, 
+  <Green's R-class: Transformation( [ 1, 1, 1, 2 ] )>, 
+  <Green's R-class: Transformation( [ 1, 1, 1, 3 ] )> ]
+gap> H := GreensHClasses(S);
+[ <Green's H-class: Transformation( [ 1, 1, 1, 1 ] )>, 
+  <Green's H-class: Transformation( [ 1, 1, 1, 2 ] )>, 
+  <Green's H-class: Transformation( [ 1, 1, 1, 3 ] )> ]
+gap> Concatenation(List(D, GreensLClasses)) = L;
+true
+gap> Concatenation(List(D, GreensRClasses)) = R;
+true
+gap> Concatenation(List(D, GreensHClasses)) = H;
+true
+gap> Concatenation(List(L, GreensHClasses)) = H;
+true
+gap> Concatenation(List(R, GreensHClasses)) = H;
+true
+
+#
 gap> STOP_TEST( "semirel.tst", 1);
 
 #############################################################################


### PR DESCRIPTION
Previously, there was undocumented and broken support for computing the `GreensXClasses` (where `X` is in `{H, L, R}` contained in a particular type of Green's class. This arose from the following issue on the Semigroups package issue tracker: https://github.com/gap-packages/Semigroups/issues/413

I have now made a simple fix, and documented this behaviour (it doesn't have brilliant performance, but it is better than an error).