### PR TITLE
kernel+buildsys: allow using Boehm GC in GAP

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,9 +213,7 @@ AS_IF([test "x$with_gc" = xdefault],
     ])
 AS_CASE([$with_gc],
     [none|no],  [AC_MSG_ERROR([cannot run GAP without a garbage collector])],
-    [boehm],    [AS_IF([test "x$enable_hpcgap" = xno],
-                    [AC_MSG_ERROR([Boehm GC can only be used with HPC-GAP])])
-                 AC_SUBST([GC_SOURCES], [src/boehm_gc.c])
+    [boehm],    [AC_SUBST([GC_SOURCES], [src/boehm_gc.c])
                  AC_DEFINE([USE_BOEHM_GC],  [1], [define as 1 if Boehm GC is used])
                 ],
     [gasman],   [AS_IF([test "x$enable_hpcgap" = xyes],
@@ -536,8 +534,11 @@ AS_IF([test "x$enable_hpcgap" = xyes],
         )
   AC_PATH_PROG([ADDGUARDS2], [addguards2c addguards2], [], [$WARD_PATH])
   AS_IF([test "x$ADDGUARDS2" = x], AC_MSG_ERROR([could not locate addguards2]))
+  ]
+)
 
-
+AS_IF([test "x$with_gc" = xboehm],
+  [
   # We bundle two libraries we need for HPC-GAP:
   # Boehm garbage collector, see http://www.hboehm.info/gc/
   # libatomic_ops - part of Boehm GC, but see also https://github.com/ivmai/libatomic_ops
@@ -560,11 +561,8 @@ AS_IF([test "x$enable_hpcgap" = xyes],
 
   ATOMIC_OPS_CFLAGS=$LIBATOMIC_OPS_CPPFLAGS
   ATOMIC_OPS_LIBS=$LIBATOMIC_OPS_LDFLAGS
-  ]
-)
 
-AS_IF([test "x$with_gc" = xboehm],
-  [
+
   BUILD_BOEHM_GC=yes
   BOEHM_GC_CPPFLAGS='-I${abs_builddir}/extern/install/gc/include'
   BOEHM_GC_LDFLAGS='${abs_builddir}/extern/install/gc/lib/libgc.la'

--- a/lib/init.g
+++ b/lib/init.g
@@ -564,6 +564,9 @@ BindGlobal( "ShowKernelInformation", function()
     fi;
     Add( config, str );
   fi;
+  if IsBound( GAPInfo.KernelInfo.GC ) then
+    Add( config, GAPInfo.KernelInfo.GC );
+  fi;
   if IsBound( GAPInfo.KernelInfo.JULIA_VERSION ) then
     str := "Julia ";
     Append(str, GAPInfo.KernelInfo.JULIA_VERSION);

--- a/src/gap.c
+++ b/src/gap.c
@@ -1438,6 +1438,18 @@ Obj FuncKERNEL_INFO(Obj self) {
   r = RNamName("GMP_VERSION");
   AssPRec(res, r, str);
 
+  /* export name of the garbage collector we use  */
+  r = RNamName("GC");
+#if defined(USE_GASMAN)
+    AssPRec(res, r, MakeImmString("GASMAN"));
+#elif defined(USE_BOEHM_GC)
+    AssPRec(res, r, MakeImmString("Boehm GC"));
+#elif defined(USE_JULIA_GC)
+    AssPRec(res, r, MakeImmString("Julia GC"));
+#else
+    #error Unsupported garbage collector
+#endif
+
 #ifdef USE_JULIA_GC
   /* export Julia version  */
   str = MakeImmString( jl_ver_string() );

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -98,7 +98,7 @@ typedef struct GAPState {
     UInt1 StateSlots[STATE_SLOTS_SIZE];
 
 /* Allocation */
-#if !defined(USE_GASMAN)
+#if defined(USE_BOEHM_GC)
 #define MAX_GC_PREFIX_DESC 4
     void ** FreeList[MAX_GC_PREFIX_DESC + 2];
 #endif

--- a/src/objects.c
+++ b/src/objects.c
@@ -508,7 +508,8 @@ void CLEAN_OBJ(Obj obj)
         CleanObjFuncs[tnum](obj);
 }
 
-#if defined(USE_GASMAN) || defined(USE_JULIA_GC)
+#if !defined(USE_THREADSAFE_COPYING) && !defined(USE_BOEHM_GC)
+
 extern TNumMarkFuncBags TabMarkFuncBags[NUM_TYPES];
 
 void MarkCopyingSubBags(Obj obj)
@@ -1989,7 +1990,7 @@ static Int InitKernel (
     InitMarkFuncBags( T_COMOBJ          , MarkPRecSubBags );
     InitMarkFuncBags( T_POSOBJ          , MarkAllSubBags  );
     InitMarkFuncBags( T_DATOBJ          , MarkOneSubBags  );
-#if !defined(USE_THREADSAFE_COPYING)
+#if !defined(USE_THREADSAFE_COPYING) && !defined(USE_BOEHM_GC)
     InitMarkFuncBags(T_COPYING, MarkCopyingSubBags);
 #endif
 


### PR DESCRIPTION
This is mainly useful for debugging slowdowns of HPC-GAP, to figure out how much of them is due to the use of Boehm GC.

## Regular timings

Some timings for `time ./gap -A tst/testinstall.g`.

Caveat: All timings were taken on my work laptop, so they should be taken with a considerable grain of salt. I'll try to redo them on a Ubuntu server without load later on

### GASMAN:
```
total     80750 ms (22963 ms GC) and 9.16GB allocated
real	1m25.909s
user	1m22.204s
sys	0m1.158s
```

### Boehm GC:
```
total    123208 ms (0 ms GC) and 7.97GB allocated
real    1m23.706s
user    2m4.840s
sys     0m2.149s
```

### Julia GC:
```
total    120054 ms (55442 ms GC) and 9.44GB allocated
real	2m7.917s
user	2m2.207s
sys	0m2.981s
```

## Timings with `GASMAN( "collect" );` in `START_TEST` disabled

### GASMAN:
```
total     84469 ms (0 ms GC) and 7.97GB allocated
real    1m20.435s
user    1m26.238s
sys     0m1.897s
```

### Boehm GC:
```
total     68205 ms (9362 ms GC) and 9.17GB allocated
real	1m13.535s
user	1m9.587s
sys	0m1.158s
```

### Julia GC:
```
total     77527 ms (11496 ms GC) and 9.46GB allocated
real	1m25.048s
user	1m19.693s
sys	0m2.942s
```