### PR TITLE
kernel: use stat, lstat, mkdtemp, mkstemp unconditionally

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -730,10 +730,6 @@ AC_CHECK_FUNCS([vm_allocate sbrk madvise sysconf])
 dnl check for functions dealing with strings and integers
 AC_CHECK_FUNCS([strlcpy strlcmp strlcat])
 
-dnl check for file access functions
-AC_HEADER_STAT
-AC_CHECK_FUNCS([stat lstat mkdtemp mkstemp])
-
 dnl check for large-file support (for accessing files whose sizes or inodes require 64bits)
 AC_SYS_LARGEFILE
 


### PR DESCRIPTION
Remove configure checks for these functions, and use them unconditionally (in
fact, we already did for stat). They are part of POSIX and have been present
in Linux, BSD, Mac OS X and cygwin for a long time.