### PR TITLE
WIP: New HPC-GAP guard checking without using ward

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,22 @@ AS_CASE([$with_gc],
 AC_MSG_RESULT([$with_gc])
 
 dnl
+dnl User setting: disable guards (race protection)
+dnl
+
+AC_ARG_ENABLE([guards],
+    [AS_HELP_STRING([--enable-guards],
+        [enable guards for race protection in HPC-GAP])],
+    [enable_guards=$enableval],
+    [enable_guards=no])
+
+AS_IF([[test "x$enable_guards" == "xyes"]], [
+    AC_DEFINE([USE_HPC_GUARDS], [1], [define as 1 if guards should be checked])
+])
+AC_MSG_CHECKING([whether to use guards for race protection in HPC-GAP])
+AC_MSG_RESULT([$enable_guards])
+
+dnl
 dnl User setting: native thread-local storage (off by default)
 dnl See src/hpc/tls.h for more details on thread-local storage options.
 dnl
@@ -978,6 +994,9 @@ AS_IF([test "x$enable_hpcgap" = xyes],[
   AS_BOX([WARNING: Experimental HPC-GAP mode enabled])
   dnl also enable backtrace, to help debug spurious crashes
   AC_DEFINE([GAP_PRINT_BACKTRACE], [1], [to enable backtraces upon crashes])
+  AS_IF([test "x$enable_guards" = xno], [
+    AS_BOX([WARNING: HPC-GAP guards (race condition protection) are disabled.])
+    ])
   ])
 
 AS_IF([test "x$enable_macos_tls_asm" = xno],[

--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,13 @@ AC_MSG_CHECKING([whether to use guards for race protection in HPC-GAP])
 AC_MSG_RESULT([$enable_guards])
 
 dnl
+dnl Check: --enable-guards requires --enable-hpcgap
+dnl
+
+AS_IF([[test "x$enable_guards" == "xyes" && test "x$enable_hpcgap" == "xno"]],
+  [AC_MSG_ERROR([Option --enable-guards requires --enable-hpcgap])])
+
+dnl
 dnl User setting: native thread-local storage (off by default)
 dnl See src/hpc/tls.h for more details on thread-local storage options.
 dnl

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -23,7 +23,7 @@ BUILDDIR=$PWD
 
 if [[ $HPCGAP = yes ]]
 then
-  CONFIGFLAGS="--enable-hpcgap $CONFIGFLAGS"
+  CONFIGFLAGS="--enable-hpcgap --enable-guards $CONFIGFLAGS"
 fi
 
 
@@ -40,8 +40,22 @@ then
 fi
 
 
-# configure and make GAP
+# configure
 time "$SRCDIR/configure" --enable-Werror $CONFIGFLAGS
+
+if [[ $HPCGAP = yes ]]
+then
+  git clone https://github.com/rbehrends/unward
+  cd unward
+  ./configure CC=gcc CXX=g++ CFLAGS=-O2 CXXFLAGS=-O2
+  make
+  cd ..
+  unward/bin/unward --inplace src
+  # commit the result to prevent the docomp test from triggering
+  git commit -m "Unward" src
+fi
+
+# build GAP
 time make V=1 -j4
 
 # Use alternative downloader which retries on failure and uses the Travis cache

--- a/lib/helpview.gd
+++ b/lib/helpview.gd
@@ -34,7 +34,11 @@
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
-BindGlobal("HELP_VIEWER_INFO", rec());
+if IsHPCGAP then
+    BindGlobal("HELP_VIEWER_INFO", AtomicRecord());
+else
+    BindGlobal("HELP_VIEWER_INFO", rec());
+fi;
 
 DeclareGlobalFunction("FindWindowId");
 DeclareGlobalFunction("SetHelpViewer");

--- a/lib/helpview.gi
+++ b/lib/helpview.gi
@@ -432,10 +432,6 @@ show := function(file)
 end
 );
 
-if IsHPCGAP then
-    MakeReadOnlyObj(HELP_VIEWER_INFO);
-fi;
-
 #############################################################################
 ##
 #F  SetHelpViewer(<viewer>):  Set the viewer used for help

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -1690,5 +1690,5 @@ SMTX.SetEndAlgResidue:=SMTX.Setter("endAlgResidue");
 SMTX.EndAlgResidue:=SMTX.Getter("endAlgResidue");
 
 if IsHPCGAP then
-    MakeReadOnlyObj(SMTX);
+    SMTX := AtomicRecord(SMTX);
 fi;

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -334,6 +334,9 @@ void RetypeBagIntern(Bag bag, UInt new_type)
     if (old_type == new_type)
         return;
 
+#if defined(HPCGAP) && defined(USE_HPC_GUARDS)
+    WriteGuard(bag);
+#endif
     /* change the size-type word                                           */
     header->type = new_type;
     {
@@ -456,6 +459,9 @@ UInt ResizeBag(Bag bag, UInt new_size)
     CollectBags(0, 0);
 #endif
 
+#if defined(HPCGAP) && defined(USE_HPC_GUARDS)
+    WriteGuard(bag);
+#endif
     BagHeader * header = BAG_HEADER(bag);
 
     /* get type and old size of the bag                                    */

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -311,6 +311,8 @@ EXPORT_INLINE UInt SIZE_BAG_CONTENTS(const void *ptr)
 **  calling 'CHANGED_BAG(old)' in the above example (see "CHANGED_BAG").
 */
 #ifdef HPCGAP
+extern int ExtendedGuardCheck(Bag) PURE_FUNC;
+
 EXPORT_INLINE int ReadCheck(Bag bag)
 {
     Region *region;
@@ -321,18 +323,18 @@ EXPORT_INLINE int ReadCheck(Bag bag)
         return 1;
     if (region->readers[TLS(threadID)])
         return 1;
-    return 0;
+    return ExtendedGuardCheck(bag);
 }
 
 EXPORT_INLINE int WriteCheck(Bag bag)
 {
-    Region *region;
+    Region * region;
     region = REGION(bag);
-    return !region || region->owner == GetTLS();
+    return !region || region->owner == GetTLS() || ExtendedGuardCheck(bag);
 }
 
-extern void HandleReadGuardError(Bag);
-extern void HandleWriteGuardError(Bag);
+extern void HandleReadGuardError(Bag) NORETURN;
+extern void HandleWriteGuardError(Bag) NORETURN;
 #endif // HPCGAP
 
 EXPORT_INLINE Bag *PTR_BAG(Bag bag)

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -151,6 +151,46 @@ EXPORT_INLINE UInt TNUM_BAG(Bag bag)
     return CONST_BAG_HEADER(bag)->type;
 }
 
+/****************************************************************************
+**
+*F  ReadCheck(<bag>) . . . . . . . . . . . . . is the bag readable in HPCGAP?
+*F  WriteCheck(<bag>)  . . . . . . . . . . . . is the bag writable in HPCGAP?
+*F  HandleReadGuardError(<bag>)  . . . . . . . . . . signal read access error
+*F  HandleWriteGuardError(<bag>) . . . . . . . . .  signal write access error
+**
+**  These funtion handle access checks in HPCGAP, i.e. whether a bag can
+**  safely be read or modified without causing race conditions. These are
+**  called in functions such as PTR_BAG() and CONST_PTR_BAG(), which should
+**  implicitly or explicitly guard all object accesses. In order to access
+**  objects without triggering checks, alternative functions UNSAFE_PTR_BAG()
+**  and UNSAFE_CONST_PTR_BAG() are provided.
+*/
+#ifdef HPCGAP
+extern int ExtendedGuardCheck(Bag) PURE_FUNC;
+
+EXPORT_INLINE int ReadCheck(Bag bag)
+{
+    Region *region;
+    region = REGION(bag);
+    if (!region)
+        return 1;
+    if (region->owner == GetTLS())
+        return 1;
+    if (region->readers[TLS(threadID)])
+        return 1;
+    return ExtendedGuardCheck(bag);
+}
+
+EXPORT_INLINE int WriteCheck(Bag bag)
+{
+    Region * region;
+    region = REGION(bag);
+    return !region || region->owner == GetTLS() || ExtendedGuardCheck(bag);
+}
+
+extern void HandleReadGuardError(Bag) NORETURN;
+extern void HandleWriteGuardError(Bag) NORETURN;
+#endif // HPCGAP
 
 /****************************************************************************
 **
@@ -310,33 +350,6 @@ EXPORT_INLINE UInt SIZE_BAG_CONTENTS(const void *ptr)
 **  the application  must inform {\Gasman}  that it  has changed  the bag, by
 **  calling 'CHANGED_BAG(old)' in the above example (see "CHANGED_BAG").
 */
-#ifdef HPCGAP
-extern int ExtendedGuardCheck(Bag) PURE_FUNC;
-
-EXPORT_INLINE int ReadCheck(Bag bag)
-{
-    Region *region;
-    region = REGION(bag);
-    if (!region)
-        return 1;
-    if (region->owner == GetTLS())
-        return 1;
-    if (region->readers[TLS(threadID)])
-        return 1;
-    return ExtendedGuardCheck(bag);
-}
-
-EXPORT_INLINE int WriteCheck(Bag bag)
-{
-    Region * region;
-    region = REGION(bag);
-    return !region || region->owner == GetTLS() || ExtendedGuardCheck(bag);
-}
-
-extern void HandleReadGuardError(Bag) NORETURN;
-extern void HandleWriteGuardError(Bag) NORETURN;
-#endif // HPCGAP
-
 EXPORT_INLINE Bag *PTR_BAG(Bag bag)
 {
     GAP_ASSERT(bag != 0);

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1516,7 +1516,6 @@ Obj GVarFunction(GVarDescriptor *gvar)
     ErrorQuit("Global variable '%s' not initialized", (UInt)(gvar->name), 0);
   if (REGION(result))
     ErrorQuit("Global variable '%s' is not a function", (UInt)(gvar->name), 0);
-  ImpliedWriteGuard(result);
   if (TNUM_OBJ(result) != T_FUNCTION)
     ErrorQuit("Global variable '%s' is not a function", (UInt)(gvar->name), 0);
   MEMBAR_READ();
@@ -1530,7 +1529,6 @@ Obj GVarOptFunction(GVarDescriptor *gvar)
     return (Obj) 0;
   if (REGION(result))
     return (Obj) 0;
-  ImpliedWriteGuard(result);
   if (TNUM_OBJ(result) != T_FUNCTION)
     return (Obj) 0;
   MEMBAR_READ();

--- a/src/hpc/guards.h
+++ b/src/hpc/guards.h
@@ -11,6 +11,7 @@
 #ifndef GAP_HPC_GUARD_H
 #define GAP_HPC_GUARD_H
 
+#include "gasman.h"
 #include "hpc/region.h"
 #include "hpc/tls.h"
 
@@ -18,101 +19,64 @@
 #error This header is only meant to be used with HPC-GAP
 #endif
 
-#ifdef VERBOSE_GUARDS
-void WriteGuardError(Bag bag,
-    const char *file, unsigned line, const char *func, const char *expr);
-void ReadGuardError(Bag bag,
-    const char *file, unsigned line, const char *func, const char *expr);
-#else
-void WriteGuardError(Bag bag);
-void ReadGuardError(Bag bag);
-#endif
-
-#ifdef VERBOSE_GUARDS
-#define WriteGuard(bag) WriteGuardFull(bag, __FILE__, __LINE__, __FUNCTION__, #bag)
-static ALWAYS_INLINE Bag WriteGuardFull(Bag bag,
-  const char *file, unsigned line, const char *func, const char *expr)
-#else
 static ALWAYS_INLINE Bag WriteGuard(Bag bag)
-#endif
 {
-  Region *region;
-  if (!IS_BAG_REF(bag))
+    if (!WriteCheck(bag))
+        HandleWriteGuardError(bag);
     return bag;
-  region = REGION(bag);
-  if (region && region->owner != GetTLS() && region->alt_owner != GetTLS())
-    WriteGuardError(bag
-#ifdef VERBOSE_GUARDS
-    , file, line, func, expr
-#endif
-    );
-  return bag;
 }
+
 
 EXPORT_INLINE Bag ImpliedWriteGuard(Bag bag)
 {
-  return bag;
+    return bag;
 }
 
 EXPORT_INLINE int CheckWriteAccess(Bag bag)
 {
-  Region *region;
-  if (!IS_BAG_REF(bag))
-    return 1;
-  region = REGION(bag);
-  return !(region && region->owner != GetTLS() && region->alt_owner != GetTLS())
-    || TLS(DisableGuards) >= 2;
+    Region * region;
+    if (!IS_BAG_REF(bag))
+        return 1;
+    region = REGION(bag);
+    return !(region && region->owner != GetTLS() &&
+             region->alt_owner != GetTLS()) ||
+           TLS(DisableGuards) >= 2;
 }
 
 EXPORT_INLINE int CheckExclusiveWriteAccess(Bag bag)
 {
-  Region *region;
-  if (!IS_BAG_REF(bag))
-    return 1;
-  region = REGION(bag);
-  if (!region)
-    return 0;
-  return region->owner == GetTLS() || region->alt_owner == GetTLS()
-    || TLS(DisableGuards) >= 2;
+    Region * region;
+    if (!IS_BAG_REF(bag))
+        return 1;
+    region = REGION(bag);
+    if (!region)
+        return 0;
+    return region->owner == GetTLS() || region->alt_owner == GetTLS() ||
+           TLS(DisableGuards) >= 2;
 }
 
-#ifdef VERBOSE_GUARDS
-#define ReadGuard(bag) ReadGuardFull(bag, __FILE__, __LINE__, __FUNCTION__, #bag)
-static ALWAYS_INLINE Bag ReadGuardFull(Bag bag,
-  const char *file, unsigned line, const char *func, const char *expr)
-#else
 static ALWAYS_INLINE Bag ReadGuard(Bag bag)
-#endif
 {
-  Region *region;
-  if (!IS_BAG_REF(bag))
+    if (!ReadCheck(bag))
+        HandleReadGuardError(bag);
     return bag;
-  region = REGION(bag);
-  if (region && region->owner != GetTLS() &&
-      !region->readers[TLS(threadID)] && region->alt_owner != GetTLS())
-    ReadGuardError(bag
-#ifdef VERBOSE_GUARDS
-    , file, line, func, expr
-#endif
-    );
-  return bag;
 }
-
 
 static ALWAYS_INLINE Bag ImpliedReadGuard(Bag bag)
 {
-  return bag;
+    return bag;
 }
 
 static ALWAYS_INLINE int CheckReadAccess(Bag bag)
 {
-  Region *region;
-  if (!IS_BAG_REF(bag))
-    return 1;
-  region = REGION(bag);
-  return !(region && region->owner != GetTLS() &&
-    !region->readers[TLS(threadID)] && region->alt_owner != GetTLS())
-    || TLS(DisableGuards) >= 2;
+    Region * region;
+    if (!IS_BAG_REF(bag))
+        return 1;
+    region = REGION(bag);
+    return !(region && region->owner != GetTLS() &&
+             !region->readers[TLS(threadID)] &&
+             region->alt_owner != GetTLS()) ||
+           TLS(DisableGuards) >= 2;
 }
 
-#endif // GAP_HPC_GUARD_H
+#endif    // GAP_HPC_GUARD_H

--- a/src/hpc/guards.h
+++ b/src/hpc/guards.h
@@ -27,11 +27,6 @@ static ALWAYS_INLINE Bag WriteGuard(Bag bag)
 }
 
 
-EXPORT_INLINE Bag ImpliedWriteGuard(Bag bag)
-{
-    return bag;
-}
-
 EXPORT_INLINE int CheckWriteAccess(Bag bag)
 {
     Region * region;
@@ -59,11 +54,6 @@ static ALWAYS_INLINE Bag ReadGuard(Bag bag)
 {
     if (!ReadCheck(bag))
         HandleReadGuardError(bag);
-    return bag;
-}
-
-static ALWAYS_INLINE Bag ImpliedReadGuard(Bag bag)
-{
     return bag;
 }
 

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -1311,11 +1311,20 @@ Region * CurrentRegion(void)
     return TLS(currentRegion);
 }
 
+// Kernel debugging information for guards.
+//
+// When compiled with -DDEBUG_GUARDS, the GAP variable GUARD_ERROR_STACK
+// will contain the C stack after an error, allowing us to located where
+// it occurred without having to fire up a debugger first.
+//
+// The variables NumReadErrors and NumWriteErrors track the number of
+// failed guard checks. These are used in conjunction with the low-level
+// function DISABLE_GUARDS() in order to track how many guard failures
+// occur in a given section of code.
+
 #ifdef DEBUG_GUARDS
 extern GVarDescriptor GUARD_ERROR_STACK;
 #endif
-
-// These are temporary debugging functions.
 
 static Int NumReadErrors = 0;
 static Int NumWriteErrors = 0;

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -1363,15 +1363,20 @@ void SetGuardErrorStack(void)
 }
 #endif
 
-void HandleReadGuardError(Bag bag)
+int ExtendedGuardCheck(Bag bag)
 {
-    NumReadErrors++;
     // We shift some of the rarer checks here to
     // avoid overloading ReadCheck().
     if (REGION(bag)->alt_owner == GetTLS())
-        return;
+        return 1;
     if (TLS(DisableGuards))
-        return;
+        return 1;
+    return 0;
+}
+
+void HandleReadGuardError(Bag bag)
+{
+    NumReadErrors++;
     SetGVar(&LastInaccessibleGVar, bag);
 #ifdef DEBUG_GUARDS
     SetGuardErrorStack();
@@ -1386,10 +1391,6 @@ void HandleWriteGuardError(Bag bag)
     NumWriteErrors++;
     // We shift some of the rarer checks here to
     // avoid overloading ReadCheck().
-    if (REGION(bag)->alt_owner == GetTLS())
-        return;
-    if (TLS(DisableGuards))
-        return;
     SetGVar(&LastInaccessibleGVar, bag);
 #ifdef DEBUG_GUARDS
     SetGuardErrorStack();

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -1313,9 +1313,10 @@ Region * CurrentRegion(void)
 
 // Kernel debugging information for guards.
 //
-// When compiled with -DDEBUG_GUARDS, the GAP variable GUARD_ERROR_STACK
-// will contain the C stack after an error, allowing us to located where
-// it occurred without having to fire up a debugger first.
+// When DEBUG_GUARDS is #defined, the GAP variable GUARD_ERROR_STACK
+// is set to a GAP plain list describing the C stack after an error,
+// allowing us to located where it occurred without having to fire up a
+// debugger first.
 //
 // The variables NumReadErrors and NumWriteErrors track the number of
 // failed guard checks. These are used in conjunction with the low-level

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -1311,73 +1311,82 @@ Region * CurrentRegion(void)
     return TLS(currentRegion);
 }
 
-#ifdef VERBOSE_GUARDS
+#ifdef DEBUG_GUARDS
+extern GVarDescriptor GUARD_ERROR_STACK;
+#endif
 
-static void PrintGuardError(char *       buffer,
-                            char *       mode,
-                            Obj          obj,
-                            const char * file,
-                            unsigned     line,
-                            const char * func,
-                            const char * expr)
-{
-    sprintf(buffer, "No %s access to object %llu of type %s\n"
-                    "in %s, line %u, function %s(), accessing %s",
-            mode, (unsigned long long)(UInt)obj, TNAM_OBJ(obj), file, line,
-            func, expr);
-}
-void WriteGuardError(Obj          o,
-                     const char * file,
-                     unsigned     line,
-                     const char * func,
-                     const char * expr)
-{
-    char * buffer = alloca(strlen(file) + strlen(func) + strlen(expr) + 200);
-    ImpliedReadGuard(o);
-    if (TLS(DisableGuards))
-        return;
-    SetGVar(&LastInaccessibleGVar, o);
-    PrintGuardError(buffer, "write", o, file, line, func, expr);
-    ErrorMayQuit("%s", (UInt)buffer, 0);
-}
+// These are temporary debugging functions.
 
-void ReadGuardError(Obj          o,
-                    const char * file,
-                    unsigned     line,
-                    const char * func,
-                    const char * expr)
-{
-    char * buffer = alloca(strlen(file) + strlen(func) + strlen(expr) + 200);
-    ImpliedReadGuard(o);
-    if (TLS(DisableGuards))
-        return;
-    SetGVar(&LastInaccessibleGVar, o);
-    PrintGuardError(buffer, "read", o, file, line, func, expr);
-    ErrorMayQuit("%s", (UInt)buffer, 0);
-}
+static Int NumReadErrors = 0;
+static Int NumWriteErrors = 0;
 
-#else
-void WriteGuardError(Obj o)
-{
-    ImpliedReadGuard(o);
-    if (TLS(DisableGuards))
-        return;
-    SetGVar(&LastInaccessibleGVar, o);
-    ErrorMayQuit(
-        "Attempt to write object %i of type %s without having write access",
-        (Int)o, (Int)TNAM_OBJ(o));
-}
+#ifdef DEBUG_GUARDS
 
-void ReadGuardError(Obj o)
+#include <execinfo.h>
+
+#define BACKTRACE_DEPTH 128
+
+// Record the backtrace in a global GAP variable.
+
+void SetGuardErrorStack(void)
 {
-    ImpliedReadGuard(o);
-    if (TLS(DisableGuards))
-        return;
-    SetGVar(&LastInaccessibleGVar, o);
-    ErrorMayQuit(
-        "Attempt to read object %i of type %s without having read access",
-        (Int)o, (Int)TNAM_OBJ(o));
+    void *  callstack[BACKTRACE_DEPTH];
+    int     depth = backtrace(callstack, BACKTRACE_DEPTH);
+    char ** calls = backtrace_symbols(callstack, depth);
+    Obj     stack = NEW_PLIST_IMM(T_PLIST, depth);
+    SET_LEN_PLIST(stack, depth - 1);
+    for (int i = 1; i < depth; i++) {
+        char * p = calls[i] + 1;
+        char * q = p;
+        while (*p) {
+            if (p[-1] == ' ' && p[0] == ' ')
+                p++;
+            else
+                *q++ = *p++;
+        }
+        *q++ = 0;
+        SET_ELM_PLIST(stack, i, MakeImmString(calls[i]));
+        CHANGED_BAG(stack);
+    }
+    free(calls);
+    SetGVar(&GUARD_ERROR_STACK, stack);
 }
 #endif
+
+void HandleReadGuardError(Bag bag)
+{
+    NumReadErrors++;
+    // We shift some of the rarer checks here to
+    // avoid overloading ReadCheck().
+    if (REGION(bag)->alt_owner == GetTLS())
+        return;
+    if (TLS(DisableGuards))
+        return;
+    SetGVar(&LastInaccessibleGVar, bag);
+#ifdef DEBUG_GUARDS
+    SetGuardErrorStack();
+#endif
+    ErrorMayQuit(
+        "Attempt to read object %i of type %s without having read access",
+        (Int)bag, (Int)TNAM_OBJ(bag));
+}
+
+void HandleWriteGuardError(Bag bag)
+{
+    NumWriteErrors++;
+    // We shift some of the rarer checks here to
+    // avoid overloading ReadCheck().
+    if (REGION(bag)->alt_owner == GetTLS())
+        return;
+    if (TLS(DisableGuards))
+        return;
+    SetGVar(&LastInaccessibleGVar, bag);
+#ifdef DEBUG_GUARDS
+    SetGuardErrorStack();
+#endif
+    ErrorMayQuit(
+        "Attempt to write object %i of type %s without having write access",
+        (Int)bag, (Int)TNAM_OBJ(bag));
+}
 
 #endif

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -929,6 +929,9 @@ static void PrintRegion(Obj);
 
 GVarDescriptor LastInaccessibleGVar;
 static GVarDescriptor MAX_INTERRUPTGVar;
+#ifdef DEBUG_GUARDS
+GVarDescriptor GUARD_ERROR_STACK;
+#endif
 
 static UInt RNAM_SIGINT;
 static UInt RNAM_SIGCHLD;
@@ -2617,6 +2620,9 @@ static Int InitKernel(StructInitInfo * module)
 
     DeclareGVar(&LastInaccessibleGVar, "LastInaccessible");
     DeclareGVar(&MAX_INTERRUPTGVar, "MAX_INTERRUPT");
+#ifdef DEBUG_GUARDS
+    DeclareGVar(&GUARD_ERROR_STACK, "GUARD_ERROR_STACK");
+#endif
 
     // install mark functions
     InitMarkFuncBags(T_THREAD, MarkNoSubBags);

--- a/src/hpc/tls.h
+++ b/src/hpc/tls.h
@@ -108,18 +108,6 @@ extern __thread ThreadLocalStorage *TLSInstance;
 
 #include <pthread.h>
 
-#ifdef HAVE_FUNC_ATTRIBUTE_PURE
-#define PURE_FUNC __attribute__((pure))
-#else
-#define PURE_FUNC
-#endif
-
-#ifdef HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR
-#define CONSTRUCTOR_FUNC __attribute__((constructor))
-#else
-#define CONSTRUCTOR_FUNC
-#endif
-
 #ifdef ALLOW_PURE_PTHREAD_GETSPECIFIC
 // pthread_getspecific() is not defined as pure by default; redeclaring
 // it as such works for gcc/clang and allows the compiler to hoist calls

--- a/src/hpc/tlsconfig.h
+++ b/src/hpc/tlsconfig.h
@@ -21,7 +21,11 @@
 #ifndef USE_NATIVE_TLS
 
 enum {
-    TLS_SIZE = (sizeof(UInt) == 8) ? (1 << 20) : (1 << 18),
+#ifdef HAVE_SYS_RESOURCE_H
+    TLS_SIZE = (sizeof(UInt) == 8) ? (1 << 23) : (1 << 22),
+#else
+    TLS_SIZE = (sizeof(UInt) == 8) ? (1 << 22) : (1 << 21),
+#endif
 };
 #define TLS_MASK (~(TLS_SIZE - 1))
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -145,7 +145,6 @@ static Obj AttrLENGTH(Obj self, Obj list)
     /* internal list types                                                 */
 #ifdef HPCGAP
     ReadGuard(list);
-    ImpliedWriteGuard(list);
     if ( (FIRST_LIST_TNUM<=TNUM_OBJ(list) && TNUM_OBJ(list)<=LAST_LIST_TNUM)
          || TNUM_OBJ(list) == T_ALIST || TNUM_OBJ(list) == T_FIXALIST) {
         return ObjInt_Int( LEN_LIST(list) );

--- a/src/lists.c
+++ b/src/lists.c
@@ -144,7 +144,6 @@ static Obj AttrLENGTH(Obj self, Obj list)
 {
     /* internal list types                                                 */
 #ifdef HPCGAP
-    ReadGuard(list);
     if ( (FIRST_LIST_TNUM<=TNUM_OBJ(list) && TNUM_OBJ(list)<=LAST_LIST_TNUM)
          || TNUM_OBJ(list) == T_ALIST || TNUM_OBJ(list) == T_FIXALIST) {
         return ObjInt_Int( LEN_LIST(list) );

--- a/src/objects.c
+++ b/src/objects.c
@@ -208,18 +208,10 @@ void SET_TYPE_OBJ(Obj obj, Obj type)
         CHANGED_BAG(obj);
         break;
     case T_COMOBJ:
-#ifdef HPCGAP
-        ReadGuard(obj);
-        MEMBAR_WRITE();
-#endif
         SET_TYPE_COMOBJ(obj, type);
         CHANGED_BAG(obj);
         break;
     case T_POSOBJ:
-#ifdef HPCGAP
-        ReadGuard(obj);
-        MEMBAR_WRITE();
-#endif
         SET_TYPE_POSOBJ(obj, type);
         CHANGED_BAG(obj);
         break;

--- a/src/objects.h
+++ b/src/objects.h
@@ -841,7 +841,13 @@ EXPORT_INLINE Obj TYPE_COMOBJ(Obj obj)
 */
 EXPORT_INLINE void SET_TYPE_COMOBJ(Obj obj, Obj val)
 {
+#ifdef HPCGAP
+    MEMBAR_WRITE();
+    // Only require a read guard
+    ((Obj *) CONST_ADDR_OBJ(obj))[0] = val;
+#else
     ADDR_OBJ(obj)[0] = val;
+#endif
 }
 
 
@@ -884,7 +890,13 @@ EXPORT_INLINE Obj TYPE_POSOBJ(Obj obj)
 */
 EXPORT_INLINE void SET_TYPE_POSOBJ(Obj obj, Obj val)
 {
+#ifdef HPCGAP
+    MEMBAR_WRITE();
+    // Only require a read guard
+    ((Obj *) CONST_ADDR_OBJ(obj))[0] = val;
+#else
     ADDR_OBJ(obj)[0] = val;
+#endif
 }
 
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -831,7 +831,11 @@ EXPORT_INLINE BOOL IS_COMOBJ(Obj obj)
 */
 EXPORT_INLINE Obj TYPE_COMOBJ(Obj obj)
 {
-    return CONST_ADDR_OBJ(obj)[0];
+    Obj result = CONST_ADDR_OBJ(obj)[0];
+#ifdef HPCGAP
+    MEMBAR_READ();
+#endif
+    return result;
 }
 
 
@@ -843,8 +847,7 @@ EXPORT_INLINE void SET_TYPE_COMOBJ(Obj obj, Obj val)
 {
 #ifdef HPCGAP
     MEMBAR_WRITE();
-    // Only require a read guard
-    ((Obj *) CONST_ADDR_OBJ(obj))[0] = val;
+    UNSAFE_PTR_BAG(obj)[0] = val;
 #else
     ADDR_OBJ(obj)[0] = val;
 #endif
@@ -880,7 +883,11 @@ EXPORT_INLINE BOOL IS_POSOBJ(Obj obj)
 */
 EXPORT_INLINE Obj TYPE_POSOBJ(Obj obj)
 {
-    return CONST_ADDR_OBJ(obj)[0];
+    Obj result = CONST_ADDR_OBJ(obj)[0];
+#ifdef HPCGAP
+    MEMBAR_READ();
+#endif
+    return result;
 }
 
 
@@ -892,8 +899,7 @@ EXPORT_INLINE void SET_TYPE_POSOBJ(Obj obj, Obj val)
 {
 #ifdef HPCGAP
     MEMBAR_WRITE();
-    // Only require a read guard
-    ((Obj *) CONST_ADDR_OBJ(obj))[0] = val;
+    UNSAFE_PTR_BAG(obj)[0] = val;
 #else
     ADDR_OBJ(obj)[0] = val;
 #endif
@@ -929,7 +935,11 @@ EXPORT_INLINE BOOL IS_DATOBJ(Obj obj)
 */
 EXPORT_INLINE Obj TYPE_DATOBJ(Obj obj)
 {
-    return CONST_ADDR_OBJ(obj)[0];
+    Obj result = CONST_ADDR_OBJ(obj)[0];
+#ifdef HPCGAP
+    MEMBAR_READ();
+#endif
+    return result;
 }
 
 
@@ -941,7 +951,12 @@ EXPORT_INLINE Obj TYPE_DATOBJ(Obj obj)
 */
 EXPORT_INLINE void SET_TYPE_DATOBJ(Obj obj, Obj val)
 {
+#ifdef HPCGAP
+    MEMBAR_WRITE();
+    UNSAFE_PTR_BAG(obj)[0] = val;
+#else
     ADDR_OBJ(obj)[0] = val;
+#endif
 }
 
 void SetTypeDatObj(Obj obj, Obj type);

--- a/src/opers.cc
+++ b/src/opers.cc
@@ -1501,10 +1501,6 @@ static Obj FuncCOMPACT_TYPE_IDS(Obj self)
 // TYPE_OBJ
 static inline Obj TYPE_OBJ_FEO(Obj obj)
 {
-#ifdef HPCGAP
-    /* TODO: We need to be able to automatically derive this. */
-    ImpliedWriteGuard(obj);
-#endif
     switch ( TNUM_OBJ( obj ) ) {
     case T_COMOBJ:
         return TYPE_COMOBJ(obj);
@@ -2502,9 +2498,6 @@ static Obj WRAP_NAME(Obj name, const char *addon)
     UInt name_len = GET_LEN_STRING(name);
     UInt addon_len = strlen(addon);
     Obj fname = NEW_STRING( name_len + addon_len + 2 );
-#ifdef HPCGAP
-    ImpliedWriteGuard(fname);
-#endif
 
     char *ptr = CSTR_STRING(fname);
     memcpy( ptr, addon, addon_len );

--- a/src/system.h
+++ b/src/system.h
@@ -25,6 +25,12 @@
 #endif
 
 
+// If we are not running HPC-GAP, disable read and write guards.
+
+#ifndef HPCGAP
+#undef USE_HPC_GUARDS
+#endif
+
 /****************************************************************************
 **
 *S  GAP_PATH_MAX . . . . . . . . . . . .  size for buffers storing file paths

--- a/src/system.h
+++ b/src/system.h
@@ -25,10 +25,12 @@
 #endif
 
 
-// If we are not running HPC-GAP, disable read and write guards.
+// If we are not running HPC-GAP, guards should be disabled
 
 #ifndef HPCGAP
-#undef USE_HPC_GUARDS
+#ifdef USE_HPC_GUARDS
+#error Do not use --enable-guards without --enable-hpcgap.
+#endif
 #endif
 
 /****************************************************************************

--- a/src/system.h
+++ b/src/system.h
@@ -25,14 +25,6 @@
 #endif
 
 
-// If we are not running HPC-GAP, guards should be disabled
-
-#ifndef HPCGAP
-#ifdef USE_HPC_GUARDS
-#error Do not use --enable-guards without --enable-hpcgap.
-#endif
-#endif
-
 /****************************************************************************
 **
 *S  GAP_PATH_MAX . . . . . . . . . . . .  size for buffers storing file paths

--- a/src/system.h
+++ b/src/system.h
@@ -106,6 +106,18 @@ enum {
 #define NOINLINE
 #endif
 
+#ifdef HAVE_FUNC_ATTRIBUTE_PURE
+#define PURE_FUNC __attribute__((pure))
+#else
+#define PURE_FUNC
+#endif
+
+#ifdef HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR
+#define CONSTRUCTOR_FUNC __attribute__((constructor))
+#else
+#define CONSTRUCTOR_FUNC
+#endif
+
 
 /****************************************************************************
 **


### PR DESCRIPTION
This is the start of the work on getting rid of Ward as a dependency.

To try this code out, first install `unward` from https://github.com/rbehrends/unward; we assume that it is stored in a directory called `$UNWARD`. To build it, do:

```sh
cd $UNWARD
./configure
make
```

After that, go to the GAP directory and build that:
   
```
./configure --enable-hpcgap
$UNWARD/bin/unward --inplace src
make
```

Fixes #2565