### PR TITLE
Tweak tst/testbugfix/2005-08-29-t00318.tst

### DIFF
--- a/tst/testbugfix/2005-08-29-t00318.tst
+++ b/tst/testbugfix/2005-08-29-t00318.tst
@@ -1,3 +1,7 @@
 # 2005/08/29 (TB)
-gap> LoadPackage("ctbllib", "=0.0",false);
+gap> x := TestPackageAvailability("ctbllib");;
+gap> if x <> fail then
+>   x := LoadPackage("ctbllib", "=0.0",false);
+> fi;
+gap> x;
 fail


### PR DESCRIPTION
This is a follow-up to #2810; unfortunately I missed one. Sorry! See also #2809.

(This test previously produced diffs if the ctbllib package was not available to be loaded. This commit avoids this problem by first checking whether the package is available.)