### PR TITLE
Adjust declaration of GreensHClasses (sorry)

### DIFF
--- a/lib/semirel.gd
+++ b/lib/semirel.gd
@@ -240,9 +240,7 @@ DeclareAttribute("GreensJClasses", IsSemigroup);
 DeclareAttribute("GreensDClasses", IsSemigroup);
 DeclareAttribute("GreensHClasses", IsSemigroup);
 
-DeclareAttribute("GreensHClasses", IsGreensDClass);
-DeclareAttribute("GreensHClasses", IsGreensLClass);
-DeclareAttribute("GreensHClasses", IsGreensRClass);
+DeclareAttribute("GreensHClasses", IsGreensClass);
 DeclareAttribute("GreensRClasses", IsGreensDClass);
 DeclareAttribute("GreensLClasses", IsGreensDClass);
 


### PR DESCRIPTION
Firstly: I am really sorry. Due to my carelessness, my PR #2830 was bad. I changed the declaration of `GreensHClasses` for some reason. This was fine for GAP, but it broke the Semigroups package (it no longer loads!), so I've put it back to how it was, which works properly. I would appreciate if this could be merged quickly so that Semigroups can be loaded with the GAP master branch.