### PR TITLE
Merge PRINT_OR_APPEND_TO and its ..._STREAM variant

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -791,6 +791,11 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
         }
     }
     else {
+        if (CALL_1ARGS(IsOutputStream, destination) != True) {
+            ErrorQuit("%s: <outstream> must be an output stream",
+                      (Int)funcname, 0L);
+            return 0;
+        }
         i = OpenOutputStream(destination);
         if (!i) {
             ErrorQuit("%s: cannot open stream for output", (Int)funcname, 0L);


### PR DESCRIPTION
These commits first make the two variants more similar. Then they are merged into a function called
`PRINT_OR_APPEND_TO_FILE_OR_STREAM`.

`PRINT_TO` is changed a bit in a separate commit first:

### kernel: Tidy up PRINT_OR_APPEND_TO

Make PRINT_OR_APPEND_TO more similar to PRINT_OR_APPEND_TO_STREAM:
- Removes the check for whether `filename` is a string. The function
  PRINT_OR_APPEND_TO is called only from the GAP level by PrintTo and
  AppendTo. Both of these already check whether the corresponding
  parameter is a string.

- Instead of first trying to print to stderr and then to stdout, the
  function now uses `Panic`.

- Move the TRY_IF_NO_ERROR to encompass the whole block where the
  printing happens  since PrintFunction may also execute GAP code.
  Also this makes the printing block exactly the same as in
  PRINT_OR_APPEND_TO_STREAM.
