### PR TITLE
WIP: Redirect `*errout*`

### DIFF
--- a/src/io.h
+++ b/src/io.h
@@ -429,6 +429,7 @@ extern  void            SPrTo (
 
 extern void FlushRestOfInputLine( void );
 
+extern int ERROUT_REDIRECT; // is zero or points to where errout is redirected
 
 StructInitInfo * InitInfoIO(void);
 

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -896,7 +896,7 @@ Int SyFopen (
         if ( strcmp( mode, "w" ) != 0 && strcmp( mode, "a" ) != 0 )
           return -1;
         else
-          return 3;
+          return ERROUT_REDIRECT ? ERROUT_REDIRECT : 3;
     }
 
     HashLock(&syBuf);


### PR DESCRIPTION
With this code I can redirect `*errout*` to any other file. Do you think this is too hacky?

Once I can also redirect `*errout*` to a GAP object, maybe it would be possible to get rid of the `LockCurrentOutput` function and the associated variables (which are used by the test-suite to send the error output into a string).