### PR TITLE
Make AtExit a stack and handle DirectoryTemporary better

### DIFF
--- a/lib/files.gd
+++ b/lib/files.gd
@@ -501,7 +501,11 @@ DeclareGlobalFunction( "RemoveDirectoryRecursively" );
 InstallAtExit( function()
   local path;
   for path in GAPInfo.DirectoriesTemporary do
-      RemoveDirectoryRecursively(path);
+      if IsDir(path) = 'D' then
+          RemoveDirectoryRecursively(path);
+      else
+          PRINT_TO("*errout*", "Temporary directory already removed: ", path, "\n");
+      fi;
   od;
   end );
 

--- a/lib/session.g
+++ b/lib/session.g
@@ -24,9 +24,10 @@ end);
 BIND_GLOBAL("PROGRAM_CLEAN_UP", function()
     local f;
     if IsBound( GAPInfo.AtExitFuncs ) and IsList( GAPInfo.AtExitFuncs ) then
-        for f in GAPInfo.AtExitFuncs do
+        while not IsEmpty(GAPInfo.AtExitFuncs) do
+            f := Remove(GAPInfo.AtExitFuncs);
             if IsFunction(f) then
-                CALL_WITH_CATCH(f,[]);        # really should be CALL_WITH_CATCH here
+                CALL_WITH_CATCH(f,[]);
             fi;
         od;
     fi;

--- a/tst/testspecial/at-exit.g
+++ b/tst/testspecial/at-exit.g
@@ -1,0 +1,6 @@
+# Check InstallAtExit is run in reverse order
+InstallAtExit(function() Print("First Call\n"); end);
+
+# Check InstallAtExit recovers from Errors
+InstallAtExit(function() Print("Step 1\n"); Error("ERROR!"); Print("Step 2\n"); end);
+InstallAtExit(function() Print("Last Call\n"); end);

--- a/tst/testspecial/at-exit.g.out
+++ b/tst/testspecial/at-exit.g.out
@@ -1,0 +1,11 @@
+gap> # Check InstallAtExit is run in reverse order
+gap> InstallAtExit(function() Print("First Call\n"); end);
+gap> 
+gap> # Check InstallAtExit recovers from Errors
+gap> InstallAtExit(function() Print("Step 1\n"); Error("ERROR!"); Print("Step 2\n"); end);
+gap> InstallAtExit(function() Print("Last Call\n"); end);
+gap> QUIT;
+Last Call
+Step 1
+Error, ERROR!
+First Call


### PR DESCRIPTION
This is kind of 2 PRs merged together, can split if required.

Firstly, the error message when cleaning up a DirectoryTemporary if it was already deleted wasn't useful, and other temporary directories wouldn't be deleted after the first failing one. This could easily occur if a temporary directory was made, then IO_fork was called.

Secondly, while debugging this I was having some problems which turned out to be caused by the fact the AtExit functions are run in-order. This is against how exit handlers normally work, as it means the first handlers GAP installs (which do things like flush buffers) get run before later, or user-installed handlers.

I pop the list of AtExit handlers, rather than just calling `Reverse` on the list, in case new handlers are installed as GAP is closing.

