### PR TITLE
Add SUM_FLAGS to Iterator for free groups

### DIFF
--- a/lib/grpfree.gi
+++ b/lib/grpfree.gi
@@ -93,6 +93,7 @@ BindGlobal( "ShallowCopy_FreeGroup", iter -> rec(
 InstallMethod( Iterator,
     "for a free group",
     [ IsAssocWordWithInverseCollection and IsWholeFamily and IsGroup ],
+    SUM_FLAGS,
     G -> IteratorByFunctions( rec(
              IsDoneIterator := ReturnFalse,
              NextIterator   := NextIterator_FreeGroup,


### PR DESCRIPTION
In GAP `stable-4.10`, the library method for `Iterator` for a free group is sometimes replaced by a higher ranked method from the `RCWA` package (in particular, when Alexander's tests do `LoadAllPackages();` and the method exists in `rcwa-4.6.2/lib/rcwagrp.gi:2903`). In GAP `master`, with the method ordering fixed, this doesn't happen; and in principle there is nothing wrong with `RCWA` installing a new method. However, it is causing problems for the Semigroups package (which can hopefully be resolved soon: see https://github.com/gap-packages/Semigroups/issues/532).

In the first instance: is it sensible to add SUM_FLAGS to the library method for `Iterator` for free groups? It seems to fit in with the philosophy of ranking representation-specific methods very highly. But since it's not directly causing any problems (apart from to the Semigroups package, but probably due to a bug), perhaps we should leave it alone.

Your opinions are welcome.