### PR TITLE
WIP: Exchange PrintExpr by StringExpr

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,9 @@
+
+PrintStatFuncs
+    - table, instead use
+    const char *    (* CStringsForStats[256] ) ( Stat stat );
+void InstallPrintStatFunc(Int pos, void (*stat)(Stat))
+
+What are these?
+PrintSeqStat
+OriginalPrintStatFuncsForHook

--- a/src/exprs.h
+++ b/src/exprs.h
@@ -129,6 +129,9 @@ extern void PrintRecExpr1 ( Expr expr ); /* needed for printing
 */
 extern  void            (* PrintExprFuncs [256] ) ( Expr expr );
 
+// POC: exchange PrintExpr by StringExpr
+extern Obj      StringExpr( Obj string, Expr expr );
+extern Obj      (* StringExprFuncs[256] ) ( Obj string, Expr expr );
 
 /****************************************************************************
 **

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -100,6 +100,12 @@ void InstallPrintExprFunc(Int pos, void (*expr)(Expr))
     HashUnlock(&activeHooks);
 }
 
+// POC: exchange PrintExpr by StringExpr
+void InstallStringExprFunc(Int pos, Obj (*expr)(Obj, Expr))
+{
+    StringExprFuncs[pos] = expr;
+}
+
 UInt ProfileExecStatPassthrough(Stat stat)
 {
     GAP_HOOK_LOOP(visitStat, stat);

--- a/src/hookintrprtr.h
+++ b/src/hookintrprtr.h
@@ -19,6 +19,8 @@ void InstallEvalExprFunc(Int, Obj (*)(Expr));
 void InstallExecStatFunc(Int, UInt (*)(Stat));
 void InstallPrintStatFunc(Int, void (*)(Stat));
 void InstallPrintExprFunc(Int, void (*)(Expr));
+// POC: exchange PrintExpr by StringExpr
+void InstallStringExprFunc(Int, Obj (*)(Obj, Expr));
 
 
 /****************************************************************************

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -126,7 +126,7 @@ void SyntaxWarning(const Char * msg)
 **  given as an argument, or created from scratch.
 **
 */
-static Obj AppendBufToString(Obj string, const char * buf, UInt bufsize)
+Obj AppendBufToString(Obj string, const char * buf, UInt bufsize)
 {
     char *s;
     if (string == 0) {

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -285,6 +285,9 @@ extern  void            SyntaxError (
 extern  void            SyntaxWarning (
             const Char *        msg );
 
+// POC: exchange PrintExpr by StringExpr
+// FIXME: Move this to stringobj.c/h
+extern Obj AppendBufToString(Obj, const char *, UInt);
 
 /****************************************************************************
 **


### PR DESCRIPTION
Adds a kernel function `StringExpr` which can return "the" string
of an expression. It either creates a new string or appends this
to a given string.

Introduces a new dispatch table called StringExprFuncs which
StringExpr dispatches to.

PrintExpr can be replaced by doing `Pr(StringExpr(..), ..);`.

The PrintExpr calls in PRINT_CURRENT_STATEMENT could then be replaced
by `PrintTo(.., StringExpr(..));`. This in turn makes it possible
to remove the current `OpenOutput(); ... CloseOutput();` hack.

Also makes the function AppendBufToString extern instead of static.