### PR TITLE
Fix IsNilpotentGroup: infinite does not imply "not p-group"

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -414,7 +414,7 @@ InstallMethod( IsNilpotentGroup,
     elif s = 1 then
         SetIsPGroup( G, true );
         return true;
-    else
+    elif s <> infinity then
         SetIsPGroup( G, false );
     fi;
     TryNextMethod();


### PR DESCRIPTION
This should be backported to 4.10.