### PR TITLE
Refactor RECALCULATE_ALL_METHOD_RANKS

### DIFF
--- a/tst/testinstall/method-reordering.tst
+++ b/tst/testinstall/method-reordering.tst
@@ -1,6 +1,7 @@
 gap> START_TEST("method-reordering.tst");
 gap> CheckReorder := function(explicit)
 >    local  f1, f2, f3, myOp, fam, t, o, o2, myC;
+>    CHECK_ALL_METHOD_RANKS();
 >    f1 := NewFilter("filter1",100);
 >    f2 := NewFilter("filter1",10);
 >    f3 := NewFilter("filter1",1);
@@ -30,6 +31,10 @@ gap> CheckReorder(false);
 false
 gap> CheckReorder(true);
 true
+gap> CHECK_ALL_METHOD_RANKS();
+true
 gap> ResumeMethodReordering();
+gap> CHECK_ALL_METHOD_RANKS();
+true
 gap> Unbind(CheckReorder);
 gap> STOP_TEST("method-reordering.tst");


### PR DESCRIPTION
This refactors `RECALCULATE_ALL_METHOD_RANKS` to make it (IMHO) easier to read.

It also changes `tst/testinstall/method-reordering.tst` to call `CHECK_ALL_METHOD_RANKS()`.