### PR TITLE
Fix problem with DirectProductElement + and * methods

### DIFF
--- a/lib/tuples.gd
+++ b/lib/tuples.gd
@@ -46,7 +46,8 @@ DeclareInfoClass( "InfoDirectProductElements" );
 ##  The sum and the product of a direct product element and a list in
 ##  <Ref Func="IsListDefault"/> is the list of sums and products,
 ##  respectively.
-##  The sum and the product of a direct product element and a non-list
+##  The sum and the product of a direct product element and an object
+##  that is neither a list nor a collection
 ##  is the direct product element of componentwise sums and products,
 ##  respectively.
 ##  </Description>

--- a/lib/tuples.gi
+++ b/lib/tuples.gi
@@ -470,7 +470,7 @@ InstallOtherMethod( \+,
     "for a direct product element, and a non-list",
     [ IsDirectProductElement, IsObject ],
     function( dpelm, nonlist )
-    if IsList( nonlist ) then
+    if IsListOrCollection( nonlist ) then
       TryNextMethod();
     fi;
     return DirectProductElement( List( dpelm, entry -> entry + nonlist ) );
@@ -480,7 +480,7 @@ InstallOtherMethod( \+,
     "for a non-list, and a direct product element",
     [ IsObject, IsDirectProductElement ],
     function( nonlist, dpelm )
-    if IsList( nonlist ) then
+    if IsListOrCollection( nonlist ) then
       TryNextMethod();
     fi;
     return DirectProductElement( List( dpelm, entry -> nonlist + entry ) );
@@ -490,7 +490,7 @@ InstallOtherMethod( \*,
     "for a direct product element, and a non-list",
     [ IsDirectProductElement, IsObject ],
     function( dpelm, nonlist )
-    if IsList( nonlist ) then
+    if IsListOrCollection( nonlist ) then
       TryNextMethod();
     fi;
     return DirectProductElement( List( dpelm, entry -> entry * nonlist ) );
@@ -500,7 +500,7 @@ InstallOtherMethod( \*,
     "for a non-list, and a direct product element",
     [ IsObject, IsDirectProductElement ],
     function( nonlist, dpelm )
-    if IsList( nonlist ) then
+    if IsListOrCollection( nonlist ) then
       TryNextMethod();
     fi;
     return DirectProductElement( List( dpelm, entry -> nonlist * entry ) );


### PR DESCRIPTION
These are problematic as follows: Suppose you want to know what kind
of object A*B is.

* If A and B are "scalars", it is their sum.
* If A is a "scalar" and B=[x,y] is a list or a direct product element (dpe),
  it is the list [A*x,A*y].
* If A=[x,y] is a list and B is a "scalar", it is the list [x*B, y*B]
* If both are lists, it is their scalar product

But now what if A is a RightCoset in a group G, and B a group element?
Then we might expect this to be the new right coset A*B, at least if B is in G.

But if B is a list or dpe [x,y], it could also mean the dpe  [A*x, A*y].

This ambiguity is the source of problems once the method ranks fluctuate (say as result of `LoadAlPackages`), as that changes which of the two interpretations above takes effect.

For a specific example, consider this:
```
gap> G:=DirectProduct(Group(()), CyclicGroup(2));;
gap> RightCoset(G, One(G)) * One(G);
RightCoset(<group with 2 generators>,[ (), <identity> of ... ])
```
If the `automgrp` package or loaded, or if we run `DeclareFilter("IsFoobar", 100); InstallTrueMethod(IsFoobar, IsFinite);` before this code, the last command will instead result in a method not found error.

This PR uses a hack to work around this particular issue, by modifying some methods which currently try to disambiguate the above situation by checkin the arguments against the filter `IsList`, to instead check `IsListOrCollection`. That solves the method rank issues I am seeing, but still seems rather dubious to me. For example, what now if one forms the direct product of groups, where one groups really has right cosets as its elements? Right now, that doesn't really seem to work, but in theory, it could be made to work...


I'd appreciate any input on this. I note that @ThomasBreuer committed this code 2002-02-21, so perhaps he has some further insights on this.