### PR TITLE
Move GAP kernel version to configure script

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -28,6 +28,10 @@ GC_SOURCES = @GC_SOURCES@
 COMPAT_MODE = @COMPAT_MODE@
 GAPARCH = @GAPARCH@
 
+# GAP kernel version
+GAP_KERNEL_MINOR_VERSION = @gap_kernel_minor_version@
+GAP_KERNEL_MAJOR_VERSION = @gap_kernel_major_version@
+
 # autoconf package metadata
 PACKAGE_BUGREPORT = @PACKAGE_BUGREPORT@
 PACKAGE_NAME = @PACKAGE_NAME@

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -674,6 +674,9 @@ sysinfo.gap: config.status $(srcdir)/Makefile.rules cnf/GAP-CFLAGS cnf/GAP-CPPFL
 	@echo "GAP_HPCGAP=$(HPCGAP)" >> $@
 	@echo "GAP_ADDGUARDS2=$(ADDGUARDS2)" >> $@
 	@echo "" >> $@
+	@echo "GAP_KERNEL_MAJOR_VERSION=$(GAP_KERNEL_MAJOR_VERSION)" >> $@
+	@echo "GAP_KERNEL_MINOR_VERSION=$(GAP_KERNEL_MINOR_VERSION)" >> $@
+	@echo "" >> $@
 	@echo "GAP_BIN_DIR=\"$(abs_builddir)\"" >> $@
 	@echo "GAP_LIB_DIR=\"$(abs_srcdir)\"" >> $@
 	@echo "" >> $@

--- a/configure.ac
+++ b/configure.ac
@@ -575,13 +575,25 @@ AS_IF([test "x$with_gc" = xboehm],
   ]
 )
 
+dnl
+dnl Define kernel version
+dnl
+
+
+gap_kernel_major_version=5
+gap_kernel_minor_version=0
+AC_SUBST([gap_kernel_major_version])
+AC_SUBST([gap_kernel_minor_version])
+
+AC_DEFINE_UNQUOTED([GAP_KERNEL_MAJOR_VERSION], $gap_kernel_major_version, [The major version of the kernel ABI])
+AC_DEFINE_UNQUOTED([GAP_KERNEL_MINOR_VERSION], $gap_kernel_minor_version, [The minor version of the kernel ABI])
 
 dnl
 dnl User setting: Compatibility mode (on by default)
 dnl
 AS_IF([test "x$enable_hpcgap" = xyes],
-  [GAPARCH="$host-hpcgap${ABI}"],
-  [GAPARCH="$host-default${ABI}"])
+  [GAPARCH="$host-hpcgap${ABI}-kv${gap_kernel_major_version}"],
+  [GAPARCH="$host-default${ABI}-kv${gap_kernel_major_version}"])
 AS_IF([test "x$ARCHEXT" != "x"],
   [GAPARCH="$GAPARCH-$ARCHEXT"])
 AS_IF([test "x$ARCH" != "x"],

--- a/src/modules.h
+++ b/src/modules.h
@@ -40,8 +40,9 @@
 **
 */
 
-#define GAP_KERNEL_MAJOR_VERSION 5
-#define GAP_KERNEL_MINOR_VERSION 0
+// GAP_KERNEL_MAJOR_VERSION and GAP_KERNEL_MINOR_VERSION are defined in
+// config.h
+
 #define GAP_KERNEL_API_VERSION                                               \
     ((GAP_KERNEL_MAJOR_VERSION)*1000 + (GAP_KERNEL_MINOR_VERSION))
 


### PR DESCRIPTION
This lifts the GAP kernel version to the configure script, so it can be used during configure and creating the Makefile. The kernel version is used in two new places:

1) We put it in sysinfo.gap, so it's easier for packages to get it
2) We put it in the build directory (so mine is now `x86_64-pc-linux-gnu-default64-abi4`, note the `abi4`)

2) is useful when using thee same package directory with multiple versions of GAP (which will be particularly useful in a world where more people use the new package manager...)

1) is useful for languages (in my case Rust) where we want to create packages and need to know the kernel version, but don't want to have to dig through C header files to find it.

There are two broad things I'm interested in:

A) Does putting something like the major kernel version in the gaparch seem like a good idea, to make it easier for GAPs to co-exist?

B) Does this seem like a sensible way to do it?
