### PR TITLE
Make IsomorphismTransformationSemigroup return IdentityMapping for a transformation semigroup

### DIFF
--- a/lib/semitran.gi
+++ b/lib/semitran.gi
@@ -383,9 +383,8 @@ end);
 InstallMethod(IsomorphismTransformationSemigroup, 
 "for a transformation semigroup", 
 [IsTransformationSemigroup], 
-function(S)
-  return MagmaIsomorphismByFunctionsNC(S, S, IdFunc, IdFunc);
-end);
+SUM_FLAGS,
+IdentityMapping);
 
 InstallMethod(IsomorphismTransformationSemigroup, "for partial perm semigroup",
 [IsPartialPermSemigroup],

--- a/tst/testinstall/semitran.tst
+++ b/tst/testinstall/semitran.tst
@@ -287,9 +287,8 @@ Error, the argument must be a semigroup with a multiplicative neutral element
 # Test IsomorphismTransformationSemigroup for a transformation semigroup
 gap> S := Semigroup(Transformation([1, 4, 6, 2, 5, 3, 7, 8, 9, 9]));;
 gap> IsomorphismTransformationSemigroup(S);
-MappingByFunction( <commutative transformation semigroup of degree 10 with 1 
- generator>, <commutative transformation semigroup of degree 10 with 1 
- generator>, function( object ) ... end, function( object ) ... end )
+IdentityMapping( <commutative transformation semigroup of degree 10 with 1 
+ generator> )
 gap> BruteForceIsoCheck(last);
 true
 gap> BruteForceInverseCheck(last2);


### PR DESCRIPTION
I think it is appropriate that `IsomorphismTransformationSemigroup` for a transformation semigroup should simply return the `IdentityMapping`, and indeed this should always be the case, and so I've increased the rank by `SUM_FLAGS`. This is analogous to the situation for perm groups:
https://github.com/gap-system/gap/blob/d0fb0f5e5482750010ed337315d501eb6e5a32e2/lib/ghomperm.gi#L1928-L1933