### PR TITLE
Random permutation of points when selecting base in centralizer

### DIFF
--- a/doc/tut/group.xml
+++ b/doc/tut/group.xml
@@ -832,7 +832,7 @@ usual way we now look for the subgroups above <C>u105</C>.
 <Example><![CDATA[
 gap> blocks := Blocks( a8, orb );; Length( blocks );
 15
-gap> blocks[1];
+gap> Set(blocks[1]);
 [ (1,2)(3,4)(5,6)(7,8), (1,3)(2,4)(5,7)(6,8), (1,4)(2,3)(5,8)(6,7),
   (1,5)(2,6)(3,7)(4,8), (1,6)(2,5)(3,8)(4,7), (1,7)(2,8)(3,5)(4,6),
   (1,8)(2,7)(3,6)(4,5) ]
@@ -862,7 +862,7 @@ lie in one orbit under the group,
 <Example><![CDATA[
 gap> rep := RepresentativeAction( a8, (1,2)(3,4)(5,6)(7,8),
 >                                        (1,3)(2,4)(5,8)(6,7) );
-(2,3)(6,8)
+(1,5,7,2,8,4,3)
 gap> u15 := ClosureGroup( u105, rep );; Index( a8, u15 );
 15
 ]]></Example>

--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -3944,10 +3944,10 @@ DeclareAttributeSuppCT( "SourceOfIsoclinicTable", IsNearlyCharacterTable,
 ##  gap> tg:= CharacterTable( g );;
 ##  gap> IsRecord(
 ##  >        TransformingPermutationsCharacterTables( index2[1], tg ) );
-##  false
+##  true
 ##  gap> IsRecord(
 ##  >        TransformingPermutationsCharacterTables( index2[2], tg ) );
-##  true
+##  false
 ##  ]]></Example>
 ##  <P/>
 ##  Alternatively, we could construct the character table of the central

--- a/lib/ctblfuns.gd
+++ b/lib/ctblfuns.gd
@@ -1345,7 +1345,7 @@ DeclareOperation( "Norm", [ IsOrdinaryTable, IsHomogeneousList ] );
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> List( Irr( S4 ), CentreOfCharacter );
-##  [ Group([ (), (1,2), (1,2)(3,4), (1,2,3), (1,2,3,4) ]), Group(()), 
+##  [ Group([ (), (1,2), (1,2)(3,4), (1,2,3), (1,2,3,4) ]), Group(()),
 ##    Group([ (1,2)(3,4), (1,4)(2,3) ]), Group(()), Group([ (), (1,2), (1,
 ##     2)(3,4), (1,2,3), (1,2,3,4) ]) ]
 ##  ]]></Example>

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1877,7 +1877,7 @@ DeclareAttribute( "MinimalNormalSubgroups", IsGroup );
 ##  returns a list of all normal subgroups of <A>G</A>.
 ##  <Example><![CDATA[
 ##  gap> g:=SymmetricGroup(4);;NormalSubgroups(g);
-##  [ Sym( [ 1 .. 4 ] ), Alt( [ 1 .. 4 ] ), Group([ (1,4)(2,3), (1,3) 
+##  [ Sym( [ 1 .. 4 ] ), Alt( [ 1 .. 4 ] ), Group([ (1,4)(2,3), (1,3)
 ##    (2,4) ]), Group(()) ]
 ##  ]]></Example>
 ##  <P/>

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -2358,8 +2358,21 @@ local  Omega,      # a common operation domain for <G>, <E> and <F>
   # Find the order in which to process the points in the base choice.
   #SortParallel( ShallowCopy( -cycles.lengths ), order );
 
-  # random permutation to avoid falling into bad case out of habit
-  i:=FLOYDS_ALGORITHM(GlobalMersenneTwister,Length(cycles.firsts),false);
+  # The criterion for selection of base points is to select them according
+  # to (descending) cycle length of the permutation to be conjugated. At the
+  # moment no other criterion is used (though experiments can observe a
+  # significant impact on run time -- there is work TODO).
+  # Beyond this choice, the base point order is determined as a side effect
+  # of the sorting algorithm.
+  # To avoid particular configurations falling repeatedly into a bad case,
+  # we permute the base points to obtain a random ordering beyond the
+  # criterion used. This can be turned off through an option for debugging
+  # purposes.
+  if ValueOption("norandom")=true then
+    i:=[1..Length(cycles.firsts)];
+  else
+    i:=FLOYDS_ALGORITHM(GlobalMersenneTwister,Length(cycles.firsts),false);
+  fi;
   order := cycles.points{ cycles.firsts{i} };
   SortParallel( -(cycles.lengths{i}), order );
 

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -2371,7 +2371,8 @@ local  Omega,      # a common operation domain for <G>, <E> and <F>
   if ValueOption("norandom")=true then
     i:=[1..Length(cycles.firsts)];
   else
-    i:=FLOYDS_ALGORITHM(GlobalMersenneTwister,Length(cycles.firsts),false);
+    i:=FLOYDS_ALGORITHM(RandomSource(IsMersenneTwister),
+         Length(cycles.firsts),false);
   fi;
   order := cycles.points{ cycles.firsts{i} };
   SortParallel( -(cycles.lengths{i}), order );

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -2356,8 +2356,12 @@ local  Omega,      # a common operation domain for <G>, <E> and <F>
   od;
   
   # Find the order in which to process the points in the base choice.
-  order := cycles.points{ cycles.firsts };
-  SortParallel( ShallowCopy( -cycles.lengths ), order );
+  #SortParallel( ShallowCopy( -cycles.lengths ), order );
+
+  # random permutation to avoid falling into bad case out of habit
+  i:=FLOYDS_ALGORITHM(GlobalMersenneTwister,Length(cycles.firsts),false);
+  order := cycles.points{ cycles.firsts{i} };
+  SortParallel( -(cycles.lengths{i}), order );
 
   repeat
 


### PR DESCRIPTION
This gets (generically) around the problem observed in #2783.

The assumption is that there are few badly behaved cases, and the random
permutation makes it unlikely that any specific setup will out of habit fall
into bad cases. (The prior strategy clearly only relied on lexicography of
points and so is not specific).