### PR TITLE
buildsys: fix C -> C++ transition for out-of-tree builds

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -332,9 +332,9 @@ DEPFLAGS = -MQ "$@" -MMD -MP -MF $(DEPFILE)
 # (e.g. during a `git bisect`) still runs into the above error. To work
 # around that, we add a few explicit rules down below, for files that were
 # changed from .c to .cc
-src/objfgelm.c:
-src/objpcgel.c:
-src/permutat.c:
+$(srcdir)/src/objfgelm.c:
+$(srcdir)/src/objpcgel.c:
+$(srcdir)/src/permutat.c:
 
 # Build rule for C++ source files
 obj/%.lo: %.cc cnf/GAP-CXXFLAGS cnf/GAP-CPPFLAGS libtool


### PR DESCRIPTION
This ensures that an out-of-tree build which was last compiled before the C++ changes were merged will recompile fine after this commit, with the C++ changes in.

Would be good to merge this ASAP, to ensure people have a smooth transition with their existing GAP builds.