### PR TITLE
kernel: add {Ass,Elm,Isb,Unb}PosObj helpers

### DIFF
--- a/lib/compiler.g
+++ b/lib/compiler.g
@@ -247,7 +247,6 @@ end );
 ##  "FastPlainLists"
 ##  "CheckTypes"
 ##  "CheckListElements"
-##  "CheckPosObjElements"
 ##
 CompileFunc := function( arg )
     local   output,  func,  name,  arguments;
@@ -262,8 +261,7 @@ CompileFunc := function( arg )
         fastintarith        := "switch/true",
         fastplainlists      := "switch/true",
         checktypes          := "switch/true",
-        checklistelements   := "switch/true",
-        checkposobjelements := "switch/true" );
+        checklistelements   := "switch/true" );
 
     arguments := ParseArguments( arguments, arg, 4 );
 
@@ -271,7 +269,7 @@ CompileFunc := function( arg )
         output, func, name,
         arguments.magic1, arguments.magic2, arguments.fastintarith,
         arguments.fastplainlists, arguments.checktypes,
-        arguments.checklistelements, arguments.checkposobjelements );
+        arguments.checklistelements );
 
 end;
 

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -287,7 +287,7 @@ static Obj  HdlrFunc2 (
  l_type = t_1;
  
  /* flags := type![2]; */
- C_ELM_POSOBJ_NLE( t_1, l_type, 2 );
+ t_1 = ElmPosObj( l_type, 2 );
  a_flags = t_1;
  
  /* RUN_IMMEDIATE_METHODS_RUNS := RUN_IMMEDIATE_METHODS_RUNS + 1; */
@@ -543,7 +543,7 @@ static Obj  HdlrFunc2 (
        
        /* newflags := SUB_FLAGS( type![2], IMM_FLAGS ); */
        t_10 = GF_SUB__FLAGS;
-       C_ELM_POSOBJ_NLE( t_11, l_type, 2 );
+       t_11 = ElmPosObj( l_type, 2 );
        t_12 = GC_IMM__FLAGS;
        CHECK_BOUND( t_12, "IMM_FLAGS" )
        t_9 = CALL_2ARGS( t_10, t_11, t_12 );
@@ -564,7 +564,7 @@ static Obj  HdlrFunc2 (
        CALL_2ARGS( t_9, l_flagspos, t_10 );
        
        /* flags := type![2]; */
-       C_ELM_POSOBJ_NLE( t_9, l_type, 2 );
+       t_9 = ElmPosObj( l_type, 2 );
        a_flags = t_9;
        
       }

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -918,7 +918,7 @@ static Obj  HdlrFunc11 (
   
   /* if IS_EQUAL_FLAGS( flags, cached![2] ) then */
   t_3 = GF_IS__EQUAL__FLAGS;
-  C_ELM_POSOBJ_NLE( t_4, l_cached, 2 );
+  t_4 = ElmPosObj( l_cached, 2 );
   t_2 = CALL_2ARGS( t_3, a_flags, t_4 );
   CHECK_FUNC_RESULT( t_2 )
   CHECK_BOOL( t_2 )
@@ -926,12 +926,12 @@ static Obj  HdlrFunc11 (
   if ( t_1 ) {
    
    /* flags := cached![2]; */
-   C_ELM_POSOBJ_NLE( t_1, l_cached, 2 );
+   t_1 = ElmPosObj( l_cached, 2 );
    a_flags = t_1;
    
    /* if IS_IDENTICAL_OBJ( data, cached![3] ) and IS_IDENTICAL_OBJ( typeOfTypes, TYPE_OBJ( cached ) ) then */
    t_4 = GF_IS__IDENTICAL__OBJ;
-   C_ELM_POSOBJ_NLE( t_5, l_cached, 3 );
+   t_5 = ElmPosObj( l_cached, 3 );
    t_3 = CALL_2ARGS( t_4, a_data, t_5 );
    CHECK_FUNC_RESULT( t_3 )
    CHECK_BOOL( t_3 )
@@ -975,17 +975,7 @@ static Obj  HdlrFunc11 (
       l_i = t_1;
       
       /* if IsBound( cached![i] ) then */
-      if ( TNUM_OBJ(l_cached) == T_POSOBJ ) {
-       t_4 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_cached)/sizeof(Obj)-1
-          && ELM_PLIST(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False);
-#ifdef HPCGAP
-      } else if ( TNUM_OBJ(l_cached) == T_APOSOBJ ) {
-       t_4 = Elm0AList(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False;
-#endif
-      }
-      else {
-       t_4 = (ISB_LIST( l_cached, INT_INTOBJ(l_i) ) ? True : False);
-      }
+      t_4 = IsbPosObj( l_cached, INT_INTOBJ(l_i) ) ? True : False;
       t_3 = (Obj)(UInt)(t_4 != False);
       if ( t_3 ) {
        
@@ -1048,28 +1038,8 @@ static Obj  HdlrFunc11 (
       l_i = t_1;
       
       /* if IsBound( parent![i] ) <> IsBound( cached![i] ) then */
-      if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
-       t_4 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
-          && ELM_PLIST(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False);
-#ifdef HPCGAP
-      } else if ( TNUM_OBJ(a_parent) == T_APOSOBJ ) {
-       t_4 = Elm0AList(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False;
-#endif
-      }
-      else {
-       t_4 = (ISB_LIST( a_parent, INT_INTOBJ(l_i) ) ? True : False);
-      }
-      if ( TNUM_OBJ(l_cached) == T_POSOBJ ) {
-       t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_cached)/sizeof(Obj)-1
-          && ELM_PLIST(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False);
-#ifdef HPCGAP
-      } else if ( TNUM_OBJ(l_cached) == T_APOSOBJ ) {
-       t_5 = Elm0AList(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False;
-#endif
-      }
-      else {
-       t_5 = (ISB_LIST( l_cached, INT_INTOBJ(l_i) ) ? True : False);
-      }
+      t_4 = IsbPosObj( a_parent, INT_INTOBJ(l_i) ) ? True : False;
+      t_5 = IsbPosObj( l_cached, INT_INTOBJ(l_i) ) ? True : False;
       t_3 = (Obj)(UInt)( ! EQ( t_4, t_5 ));
       if ( t_3 ) {
        
@@ -1084,39 +1054,19 @@ static Obj  HdlrFunc11 (
       /* fi */
       
       /* if IsBound( parent![i] ) and IsBound( cached![i] ) and not IS_IDENTICAL_OBJ( parent![i], cached![i] ) then */
-      if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
-       t_6 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
-          && ELM_PLIST(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False);
-#ifdef HPCGAP
-      } else if ( TNUM_OBJ(a_parent) == T_APOSOBJ ) {
-       t_6 = Elm0AList(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False;
-#endif
-      }
-      else {
-       t_6 = (ISB_LIST( a_parent, INT_INTOBJ(l_i) ) ? True : False);
-      }
+      t_6 = IsbPosObj( a_parent, INT_INTOBJ(l_i) ) ? True : False;
       t_5 = (Obj)(UInt)(t_6 != False);
       t_4 = t_5;
       if ( t_4 ) {
-       if ( TNUM_OBJ(l_cached) == T_POSOBJ ) {
-        t_7 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_cached)/sizeof(Obj)-1
-           && ELM_PLIST(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False);
-#ifdef HPCGAP
-       } else if ( TNUM_OBJ(l_cached) == T_APOSOBJ ) {
-        t_7 = Elm0AList(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False;
-#endif
-       }
-       else {
-        t_7 = (ISB_LIST( l_cached, INT_INTOBJ(l_i) ) ? True : False);
-       }
+       t_7 = IsbPosObj( l_cached, INT_INTOBJ(l_i) ) ? True : False;
        t_6 = (Obj)(UInt)(t_7 != False);
        t_4 = t_6;
       }
       t_3 = t_4;
       if ( t_3 ) {
        t_8 = GF_IS__IDENTICAL__OBJ;
-       C_ELM_POSOBJ_NLE( t_9, a_parent, INT_INTOBJ(l_i) );
-       C_ELM_POSOBJ_NLE( t_10, l_cached, INT_INTOBJ(l_i) );
+       t_9 = ElmPosObj( a_parent, INT_INTOBJ(l_i) );
+       t_10 = ElmPosObj( l_cached, INT_INTOBJ(l_i) );
        t_7 = CALL_2ARGS( t_8, t_9, t_10 );
        CHECK_FUNC_RESULT( t_7 )
        CHECK_BOOL( t_7 )
@@ -1246,17 +1196,7 @@ static Obj  HdlrFunc11 (
    l_i = t_1;
    
    /* if IsBound( parent![i] ) and not IsBound( type[i] ) then */
-   if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
-    t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
-       && ELM_PLIST(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False);
-#ifdef HPCGAP
-   } else if ( TNUM_OBJ(a_parent) == T_APOSOBJ ) {
-    t_5 = Elm0AList(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False;
-#endif
-   }
-   else {
-    t_5 = (ISB_LIST( a_parent, INT_INTOBJ(l_i) ) ? True : False);
-   }
+   t_5 = IsbPosObj( a_parent, INT_INTOBJ(l_i) ) ? True : False;
    t_4 = (Obj)(UInt)(t_5 != False);
    t_3 = t_4;
    if ( t_3 ) {
@@ -1268,7 +1208,7 @@ static Obj  HdlrFunc11 (
    if ( t_3 ) {
     
     /* type[i] := parent![i]; */
-    C_ELM_POSOBJ_NLE( t_3, a_parent, INT_INTOBJ(l_i) );
+    t_3 = ElmPosObj( a_parent, INT_INTOBJ(l_i) );
     C_ASS_LIST_FPL( l_type, l_i, t_3 )
     
    }
@@ -1327,7 +1267,7 @@ static Obj  HdlrFunc11 (
    
    /* ncache[HASH_FLAGS( t![2] ) mod ncl + 1] := t; */
    t_8 = GF_HASH__FLAGS;
-   C_ELM_POSOBJ_NLE( t_9, l_t, 2 );
+   t_9 = ElmPosObj( l_t, 2 );
    t_7 = CALL_1ARGS( t_8, t_9 );
    CHECK_FUNC_RESULT( t_7 )
    t_6 = MOD( t_7, l_ncl );
@@ -1615,10 +1555,10 @@ static Obj  HdlrFunc15 (
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
- C_ELM_POSOBJ_NLE( t_4, a_type, 1 );
+ t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
- C_ELM_POSOBJ_NLE( t_9, a_type, 2 );
+ t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
  CHECK_FUNC_RESULT( t_10 )
@@ -1626,7 +1566,7 @@ static Obj  HdlrFunc15 (
  CHECK_FUNC_RESULT( t_7 )
  t_5 = CALL_1ARGS( t_6, t_7 );
  CHECK_FUNC_RESULT( t_5 )
- C_ELM_POSOBJ_NLE( t_6, a_type, 3 );
+ t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
  CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
@@ -1669,10 +1609,10 @@ static Obj  HdlrFunc16 (
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
- C_ELM_POSOBJ_NLE( t_4, a_type, 1 );
+ t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
- C_ELM_POSOBJ_NLE( t_9, a_type, 2 );
+ t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
  CHECK_FUNC_RESULT( t_10 )
@@ -1802,15 +1742,15 @@ static Obj  HdlrFunc18 (
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
- C_ELM_POSOBJ_NLE( t_4, a_type, 1 );
+ t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_SUB__FLAGS;
- C_ELM_POSOBJ_NLE( t_7, a_type, 2 );
+ t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
  CHECK_FUNC_RESULT( t_8 )
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
  CHECK_FUNC_RESULT( t_5 )
- C_ELM_POSOBJ_NLE( t_6, a_type, 3 );
+ t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
  CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
@@ -1851,9 +1791,9 @@ static Obj  HdlrFunc19 (
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
- C_ELM_POSOBJ_NLE( t_4, a_type, 1 );
+ t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_SUB__FLAGS;
- C_ELM_POSOBJ_NLE( t_7, a_type, 2 );
+ t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
  CHECK_FUNC_RESULT( t_8 )
@@ -1969,7 +1909,7 @@ static Obj  HdlrFunc21 (
  SET_BRK_CURR_STAT(0);
  
  /* return K![1]; */
- C_ELM_POSOBJ_NLE( t_1, a_K, 1 );
+ t_1 = ElmPosObj( a_K, 1 );
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1995,7 +1935,7 @@ static Obj  HdlrFunc22 (
  SET_BRK_CURR_STAT(0);
  
  /* return K![2]; */
- C_ELM_POSOBJ_NLE( t_1, a_K, 2 );
+ t_1 = ElmPosObj( a_K, 2 );
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2021,7 +1961,7 @@ static Obj  HdlrFunc23 (
  SET_BRK_CURR_STAT(0);
  
  /* return K![3]; */
- C_ELM_POSOBJ_NLE( t_1, a_K, 3 );
+ t_1 = ElmPosObj( a_K, 3 );
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2047,7 +1987,7 @@ static Obj  HdlrFunc24 (
  SET_BRK_CURR_STAT(0);
  
  /* K![3] := data; */
- C_ASS_POSOBJ( a_K, 3, a_data )
+ AssPosObj( a_K, 3, a_data );
  
  /* return; */
  RES_BRK_CURR_STAT();
@@ -2207,7 +2147,7 @@ static Obj  HdlrFunc27 (
   
   /* RunImmediateMethods( obj, type![2] ); */
   t_1 = GF_RunImmediateMethods;
-  C_ELM_POSOBJ_NLE( t_2, a_type, 2 );
+  t_2 = ElmPosObj( a_type, 2 );
   CALL_2ARGS( t_1, a_obj, t_2 );
   
  }
@@ -2292,8 +2232,8 @@ static Obj  HdlrFunc28 (
    /* RunImmediateMethods( obj, SUB_FLAGS( newtype![2], type![2] ) ); */
    t_1 = GF_RunImmediateMethods;
    t_3 = GF_SUB__FLAGS;
-   C_ELM_POSOBJ_NLE( t_4, l_newtype, 2 );
-   C_ELM_POSOBJ_NLE( t_5, l_type, 2 );
+   t_4 = ElmPosObj( l_newtype, 2 );
+   t_5 = ElmPosObj( l_type, 2 );
    t_2 = CALL_2ARGS( t_3, t_4, t_5 );
    CHECK_FUNC_RESULT( t_2 )
    CALL_2ARGS( t_1, a_obj, t_2 );
@@ -2348,8 +2288,8 @@ static Obj  HdlrFunc28 (
     /* RunImmediateMethods( obj, SUB_FLAGS( newtype![2], type![2] ) ); */
     t_1 = GF_RunImmediateMethods;
     t_3 = GF_SUB__FLAGS;
-    C_ELM_POSOBJ_NLE( t_4, l_newtype, 2 );
-    C_ELM_POSOBJ_NLE( t_5, l_type, 2 );
+    t_4 = ElmPosObj( l_newtype, 2 );
+    t_5 = ElmPosObj( l_type, 2 );
     t_2 = CALL_2ARGS( t_3, t_4, t_5 );
     CHECK_FUNC_RESULT( t_2 )
     CALL_2ARGS( t_1, a_obj, t_2 );
@@ -2404,8 +2344,8 @@ static Obj  HdlrFunc28 (
      /* RunImmediateMethods( obj, SUB_FLAGS( newtype![2], type![2] ) ); */
      t_1 = GF_RunImmediateMethods;
      t_3 = GF_SUB__FLAGS;
-     C_ELM_POSOBJ_NLE( t_4, l_newtype, 2 );
-     C_ELM_POSOBJ_NLE( t_5, l_type, 2 );
+     t_4 = ElmPosObj( l_newtype, 2 );
+     t_5 = ElmPosObj( l_type, 2 );
      t_2 = CALL_2ARGS( t_3, t_4, t_5 );
      CHECK_FUNC_RESULT( t_2 )
      CALL_2ARGS( t_1, a_obj, t_2 );

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -120,45 +120,6 @@ typedef UInt    RNam;
 #define SWITCH_TO_OLD_FRAME     SWITCH_TO_OLD_LVARS
 
 
-/* objects, should into 'objects.c'  * * * * * * * * * * * * * * * * * * * */
-
-/* there should be a function for C_ELM_POSOBJ */
-#define C_ELM_POSOBJ( elm, list, pos ) NOT_READY_YET
-
-
-#define C_ELM_POSOBJ_NLE( elm, list, pos ) \
-    if ( TNUM_OBJ(list) == T_POSOBJ ) { \
-        elm = ELM_PLIST( list, pos ); \
-    } \
-    else { \
-        elm = ELMW_LIST( list, pos ); \
-    }
-
-#define C_ASS_POSOBJ_INTOBJ( list, pos, elm ) \
-    if ( TNUM_OBJ(list) == T_POSOBJ ) { \
-        if ( SIZE_OBJ(list)/sizeof(Obj)-1 < pos ) { \
-            ResizeBag( list, (pos+1)*sizeof(Obj) ); \
-        } \
-        SET_ELM_PLIST( list, pos, elm ); \
-    } \
-    else { \
-        ASS_LIST( list, pos, elm ); \
-    }
-
-#define C_ASS_POSOBJ( list, pos, elm ) \
-    if ( TNUM_OBJ(list) == T_POSOBJ ) { \
-        if ( SIZE_OBJ(list)/sizeof(Obj)-1 < pos ) { \
-            ResizeBag( list, (pos+1)*sizeof(Obj) ); \
-        } \
-        SET_ELM_PLIST( list, pos, elm ); \
-        CHANGED_BAG(list); \
-    } \
-    else { \
-        ASS_LIST( list, pos, elm ); \
-    }
-
-
-
 /* lists, should go into 'lists.c' * * * * * * * * * * * * * * * * * * * * */
 #define C_LEN_LIST(len,list) \
  len = LENGTH(list);

--- a/src/hpc/c_oper1.c
+++ b/src/hpc/c_oper1.c
@@ -303,7 +303,7 @@ static Obj  HdlrFunc2 (
  l_type = t_1;
  
  /* flags := type![2]; */
- C_ELM_POSOBJ_NLE( t_1, l_type, 2 );
+ t_1 = ElmPosObj( l_type, 2 );
  a_flags = t_1;
  
  /* RUN_IMMEDIATE_METHODS_RUNS := RUN_IMMEDIATE_METHODS_RUNS + 1; */
@@ -559,7 +559,7 @@ static Obj  HdlrFunc2 (
        
        /* newflags := SUB_FLAGS( type![2], IMM_FLAGS ); */
        t_10 = GF_SUB__FLAGS;
-       C_ELM_POSOBJ_NLE( t_11, l_type, 2 );
+       t_11 = ElmPosObj( l_type, 2 );
        t_12 = GC_IMM__FLAGS;
        CHECK_BOUND( t_12, "IMM_FLAGS" )
        t_9 = CALL_2ARGS( t_10, t_11, t_12 );
@@ -580,7 +580,7 @@ static Obj  HdlrFunc2 (
        CALL_2ARGS( t_9, l_flagspos, t_10 );
        
        /* flags := type![2]; */
-       C_ELM_POSOBJ_NLE( t_9, l_type, 2 );
+       t_9 = ElmPosObj( l_type, 2 );
        a_flags = t_9;
        
       }

--- a/src/hpc/c_type1.c
+++ b/src/hpc/c_type1.c
@@ -994,7 +994,7 @@ static Obj  HdlrFunc11 (
   
   /* if IS_EQUAL_FLAGS( flags, cached![2] ) then */
   t_3 = GF_IS__EQUAL__FLAGS;
-  C_ELM_POSOBJ_NLE( t_4, l_cached, 2 );
+  t_4 = ElmPosObj( l_cached, 2 );
   t_2 = CALL_2ARGS( t_3, a_flags, t_4 );
   CHECK_FUNC_RESULT( t_2 )
   CHECK_BOOL( t_2 )
@@ -1002,12 +1002,12 @@ static Obj  HdlrFunc11 (
   if ( t_1 ) {
    
    /* flags := cached![2]; */
-   C_ELM_POSOBJ_NLE( t_1, l_cached, 2 );
+   t_1 = ElmPosObj( l_cached, 2 );
    a_flags = t_1;
    
    /* if IS_IDENTICAL_OBJ( data, cached![3] ) and IS_IDENTICAL_OBJ( typeOfTypes, TYPE_OBJ( cached ) ) then */
    t_4 = GF_IS__IDENTICAL__OBJ;
-   C_ELM_POSOBJ_NLE( t_5, l_cached, 3 );
+   t_5 = ElmPosObj( l_cached, 3 );
    t_3 = CALL_2ARGS( t_4, a_data, t_5 );
    CHECK_FUNC_RESULT( t_3 )
    CHECK_BOOL( t_3 )
@@ -1051,17 +1051,7 @@ static Obj  HdlrFunc11 (
       l_i = t_1;
       
       /* if IsBound( cached![i] ) then */
-      if ( TNUM_OBJ(l_cached) == T_POSOBJ ) {
-       t_4 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_cached)/sizeof(Obj)-1
-          && ELM_PLIST(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False);
-#ifdef HPCGAP
-      } else if ( TNUM_OBJ(l_cached) == T_APOSOBJ ) {
-       t_4 = Elm0AList(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False;
-#endif
-      }
-      else {
-       t_4 = (ISB_LIST( l_cached, INT_INTOBJ(l_i) ) ? True : False);
-      }
+      t_4 = IsbPosObj( l_cached, INT_INTOBJ(l_i) ) ? True : False;
       t_3 = (Obj)(UInt)(t_4 != False);
       if ( t_3 ) {
        
@@ -1128,28 +1118,8 @@ static Obj  HdlrFunc11 (
       l_i = t_1;
       
       /* if IsBound( parent![i] ) <> IsBound( cached![i] ) then */
-      if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
-       t_4 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
-          && ELM_PLIST(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False);
-#ifdef HPCGAP
-      } else if ( TNUM_OBJ(a_parent) == T_APOSOBJ ) {
-       t_4 = Elm0AList(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False;
-#endif
-      }
-      else {
-       t_4 = (ISB_LIST( a_parent, INT_INTOBJ(l_i) ) ? True : False);
-      }
-      if ( TNUM_OBJ(l_cached) == T_POSOBJ ) {
-       t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_cached)/sizeof(Obj)-1
-          && ELM_PLIST(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False);
-#ifdef HPCGAP
-      } else if ( TNUM_OBJ(l_cached) == T_APOSOBJ ) {
-       t_5 = Elm0AList(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False;
-#endif
-      }
-      else {
-       t_5 = (ISB_LIST( l_cached, INT_INTOBJ(l_i) ) ? True : False);
-      }
+      t_4 = IsbPosObj( a_parent, INT_INTOBJ(l_i) ) ? True : False;
+      t_5 = IsbPosObj( l_cached, INT_INTOBJ(l_i) ) ? True : False;
       t_3 = (Obj)(UInt)( ! EQ( t_4, t_5 ));
       if ( t_3 ) {
        
@@ -1164,39 +1134,19 @@ static Obj  HdlrFunc11 (
       /* fi */
       
       /* if IsBound( parent![i] ) and IsBound( cached![i] ) and not IS_IDENTICAL_OBJ( parent![i], cached![i] ) then */
-      if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
-       t_6 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
-          && ELM_PLIST(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False);
-#ifdef HPCGAP
-      } else if ( TNUM_OBJ(a_parent) == T_APOSOBJ ) {
-       t_6 = Elm0AList(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False;
-#endif
-      }
-      else {
-       t_6 = (ISB_LIST( a_parent, INT_INTOBJ(l_i) ) ? True : False);
-      }
+      t_6 = IsbPosObj( a_parent, INT_INTOBJ(l_i) ) ? True : False;
       t_5 = (Obj)(UInt)(t_6 != False);
       t_4 = t_5;
       if ( t_4 ) {
-       if ( TNUM_OBJ(l_cached) == T_POSOBJ ) {
-        t_7 = (INT_INTOBJ(l_i) <= SIZE_OBJ(l_cached)/sizeof(Obj)-1
-           && ELM_PLIST(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False);
-#ifdef HPCGAP
-       } else if ( TNUM_OBJ(l_cached) == T_APOSOBJ ) {
-        t_7 = Elm0AList(l_cached,INT_INTOBJ(l_i)) != 0 ? True : False;
-#endif
-       }
-       else {
-        t_7 = (ISB_LIST( l_cached, INT_INTOBJ(l_i) ) ? True : False);
-       }
+       t_7 = IsbPosObj( l_cached, INT_INTOBJ(l_i) ) ? True : False;
        t_6 = (Obj)(UInt)(t_7 != False);
        t_4 = t_6;
       }
       t_3 = t_4;
       if ( t_3 ) {
        t_8 = GF_IS__IDENTICAL__OBJ;
-       C_ELM_POSOBJ_NLE( t_9, a_parent, INT_INTOBJ(l_i) );
-       C_ELM_POSOBJ_NLE( t_10, l_cached, INT_INTOBJ(l_i) );
+       t_9 = ElmPosObj( a_parent, INT_INTOBJ(l_i) );
+       t_10 = ElmPosObj( l_cached, INT_INTOBJ(l_i) );
        t_7 = CALL_2ARGS( t_8, t_9, t_10 );
        CHECK_FUNC_RESULT( t_7 )
        CHECK_BOOL( t_7 )
@@ -1336,17 +1286,7 @@ static Obj  HdlrFunc11 (
    l_i = t_1;
    
    /* if IsBound( parent![i] ) and not IsBound( type[i] ) then */
-   if ( TNUM_OBJ(a_parent) == T_POSOBJ ) {
-    t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_parent)/sizeof(Obj)-1
-       && ELM_PLIST(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False);
-#ifdef HPCGAP
-   } else if ( TNUM_OBJ(a_parent) == T_APOSOBJ ) {
-    t_5 = Elm0AList(a_parent,INT_INTOBJ(l_i)) != 0 ? True : False;
-#endif
-   }
-   else {
-    t_5 = (ISB_LIST( a_parent, INT_INTOBJ(l_i) ) ? True : False);
-   }
+   t_5 = IsbPosObj( a_parent, INT_INTOBJ(l_i) ) ? True : False;
    t_4 = (Obj)(UInt)(t_5 != False);
    t_3 = t_4;
    if ( t_3 ) {
@@ -1358,7 +1298,7 @@ static Obj  HdlrFunc11 (
    if ( t_3 ) {
     
     /* type[i] := parent![i]; */
-    C_ELM_POSOBJ_NLE( t_3, a_parent, INT_INTOBJ(l_i) );
+    t_3 = ElmPosObj( a_parent, INT_INTOBJ(l_i) );
     C_ASS_LIST_FPL( l_type, l_i, t_3 )
     
    }
@@ -1423,7 +1363,7 @@ static Obj  HdlrFunc11 (
    
    /* ncache[HASH_FLAGS( t![2] ) mod ncl + 1] := t; */
    t_8 = GF_HASH__FLAGS;
-   C_ELM_POSOBJ_NLE( t_9, l_t, 2 );
+   t_9 = ElmPosObj( l_t, 2 );
    t_7 = CALL_1ARGS( t_8, t_9 );
    CHECK_FUNC_RESULT( t_7 )
    t_6 = MOD( t_7, l_ncl );
@@ -1719,10 +1659,10 @@ static Obj  HdlrFunc15 (
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
- C_ELM_POSOBJ_NLE( t_4, a_type, 1 );
+ t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
- C_ELM_POSOBJ_NLE( t_9, a_type, 2 );
+ t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
  CHECK_FUNC_RESULT( t_10 )
@@ -1730,7 +1670,7 @@ static Obj  HdlrFunc15 (
  CHECK_FUNC_RESULT( t_7 )
  t_5 = CALL_1ARGS( t_6, t_7 );
  CHECK_FUNC_RESULT( t_5 )
- C_ELM_POSOBJ_NLE( t_6, a_type, 3 );
+ t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
  CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
@@ -1773,10 +1713,10 @@ static Obj  HdlrFunc16 (
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
- C_ELM_POSOBJ_NLE( t_4, a_type, 1 );
+ t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
- C_ELM_POSOBJ_NLE( t_9, a_type, 2 );
+ t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
  CHECK_FUNC_RESULT( t_10 )
@@ -1916,15 +1856,15 @@ static Obj  HdlrFunc18 (
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
- C_ELM_POSOBJ_NLE( t_4, a_type, 1 );
+ t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_SUB__FLAGS;
- C_ELM_POSOBJ_NLE( t_7, a_type, 2 );
+ t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
  CHECK_FUNC_RESULT( t_8 )
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
  CHECK_FUNC_RESULT( t_5 )
- C_ELM_POSOBJ_NLE( t_6, a_type, 3 );
+ t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
  CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
@@ -1965,9 +1905,9 @@ static Obj  HdlrFunc19 (
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
  CHECK_BOUND( t_3, "TypeOfTypes" )
- C_ELM_POSOBJ_NLE( t_4, a_type, 1 );
+ t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_SUB__FLAGS;
- C_ELM_POSOBJ_NLE( t_7, a_type, 2 );
+ t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
  CHECK_FUNC_RESULT( t_8 )
@@ -2083,7 +2023,7 @@ static Obj  HdlrFunc21 (
  SET_BRK_CURR_STAT(0);
  
  /* return K![1]; */
- C_ELM_POSOBJ_NLE( t_1, a_K, 1 );
+ t_1 = ElmPosObj( a_K, 1 );
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2109,7 +2049,7 @@ static Obj  HdlrFunc22 (
  SET_BRK_CURR_STAT(0);
  
  /* return K![2]; */
- C_ELM_POSOBJ_NLE( t_1, a_K, 2 );
+ t_1 = ElmPosObj( a_K, 2 );
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2135,7 +2075,7 @@ static Obj  HdlrFunc23 (
  SET_BRK_CURR_STAT(0);
  
  /* return K![3]; */
- C_ELM_POSOBJ_NLE( t_1, a_K, 3 );
+ t_1 = ElmPosObj( a_K, 3 );
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2431,7 +2371,7 @@ static Obj  HdlrFunc27 (
   
   /* RunImmediateMethods( obj, type![2] ); */
   t_1 = GF_RunImmediateMethods;
-  C_ELM_POSOBJ_NLE( t_2, a_type, 2 );
+  t_2 = ElmPosObj( a_type, 2 );
   CALL_2ARGS( t_1, a_obj, t_2 );
   
  }
@@ -2531,8 +2471,8 @@ static Obj  HdlrFunc28 (
    /* RunImmediateMethods( obj, SUB_FLAGS( newtype![2], type![2] ) ); */
    t_1 = GF_RunImmediateMethods;
    t_3 = GF_SUB__FLAGS;
-   C_ELM_POSOBJ_NLE( t_4, l_newtype, 2 );
-   C_ELM_POSOBJ_NLE( t_5, l_type, 2 );
+   t_4 = ElmPosObj( l_newtype, 2 );
+   t_5 = ElmPosObj( l_type, 2 );
    t_2 = CALL_2ARGS( t_3, t_4, t_5 );
    CHECK_FUNC_RESULT( t_2 )
    CALL_2ARGS( t_1, a_obj, t_2 );
@@ -2587,8 +2527,8 @@ static Obj  HdlrFunc28 (
     /* RunImmediateMethods( obj, SUB_FLAGS( newtype![2], type![2] ) ); */
     t_1 = GF_RunImmediateMethods;
     t_3 = GF_SUB__FLAGS;
-    C_ELM_POSOBJ_NLE( t_4, l_newtype, 2 );
-    C_ELM_POSOBJ_NLE( t_5, l_type, 2 );
+    t_4 = ElmPosObj( l_newtype, 2 );
+    t_5 = ElmPosObj( l_type, 2 );
     t_2 = CALL_2ARGS( t_3, t_4, t_5 );
     CHECK_FUNC_RESULT( t_2 )
     CALL_2ARGS( t_1, a_obj, t_2 );
@@ -2643,8 +2583,8 @@ static Obj  HdlrFunc28 (
      /* RunImmediateMethods( obj, SUB_FLAGS( newtype![2], type![2] ) ); */
      t_1 = GF_RunImmediateMethods;
      t_3 = GF_SUB__FLAGS;
-     C_ELM_POSOBJ_NLE( t_4, l_newtype, 2 );
-     C_ELM_POSOBJ_NLE( t_5, l_type, 2 );
+     t_4 = ElmPosObj( l_newtype, 2 );
+     t_5 = ElmPosObj( l_type, 2 );
      t_2 = CALL_2ARGS( t_3, t_4, t_5 );
      CHECK_FUNC_RESULT( t_2 )
      CALL_2ARGS( t_1, a_obj, t_2 );

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -3528,28 +3528,7 @@ void            IntrAssPosObj ( void )
     list = PopObj();
 
     /* assign to the element of the list                                   */
-    if ( TNUM_OBJ(list) == T_POSOBJ ) {
-#ifdef HPCGAP
-        /* Because BindOnce() functions can reallocate the list even if they
-         * only have read-only access, we have to be careful when accessing
-         * positional objects. Hence the explicit WriteGuard().
-         */
-        WriteGuard(list);
-#endif
-        if ( SIZE_OBJ(list)/sizeof(Obj) - 1 < p ) {
-            ResizeBag( list, (p+1) * sizeof(Obj) );
-        }
-        SET_ELM_PLIST( list, p, rhs );
-        CHANGED_BAG( list );
-    }
-#ifdef HPCGAP
-    else if ( TNUM_OBJ(list) == T_APOSOBJ ) {
-        AssListFuncs[T_FIXALIST]( list, p, rhs );
-    }
-#endif
-    else {
-        ASS_LIST( list, p, rhs );
-    }
+    AssPosObj( list, p, rhs );
 
     /* push the right hand side again                                      */
     PushObj( rhs );
@@ -3580,26 +3559,7 @@ void            IntrUnbPosObj ( void )
     list = PopObj();
 
     /* unbind the element                                                  */
-    if ( TNUM_OBJ(list) == T_POSOBJ ) {
-#ifdef HPCGAP
-        /* Because BindOnce() functions can reallocate the list even if they
-         * only have read-only access, we have to be careful when accessing
-         * positional objects. Hence the explicit WriteGuard().
-         */
-        WriteGuard(list);
-#endif
-        if ( p <= SIZE_OBJ(list)/sizeof(Obj)-1 ) {
-            SET_ELM_PLIST( list, p, 0 );
-        }
-    }
-#ifdef HPCGAP
-    else if ( TNUM_OBJ(list) == T_APOSOBJ ) {
-        UnbListFuncs[T_FIXALIST]( list, p );
-    }
-#endif
-    else {
-        UNB_LIST( list, p );
-    }
+    UnbPosObj( list, p );
 
     /* push void                                                           */
     PushVoidObj();
@@ -3636,42 +3596,7 @@ void            IntrElmPosObj ( void )
     list = PopObj();
 
     /* get the element of the list                                         */
-    if ( TNUM_OBJ(list) == T_POSOBJ ) {
-#ifdef HPCGAP
-        /* Because BindOnce() functions can reallocate the list even if they
-         * only have read-only access, we have to be careful when accessing
-         * positional objects.
-         */
-        const Bag *contents = CONST_PTR_BAG(list);
-        MEMBAR_READ(); /* essential memory barrier */
-        if ( SIZE_BAG_CONTENTS(contents)/sizeof(Obj)-1 < p ) {
-            ErrorQuit(
-                "PosObj Element: <posobj>![%d] must have an assigned value",
-                (Int)p, 0L );
-        }
-        elm = contents[p];
-#else
-        if ( SIZE_OBJ(list)/sizeof(Obj)-1 < p ) {
-            ErrorQuit(
-                "PosObj Element: <posobj>![%d] must have an assigned value",
-                (Int)p, 0L );
-        }
-        elm = ELM_PLIST( list, p );
-#endif
-        if ( elm == 0 ) {
-            ErrorQuit(
-                "PosObj Element: <posobj>![%d] must have an assigned value",
-                (Int)p, 0L );
-        }
-    }
-#ifdef HPCGAP
-    else if ( TNUM_OBJ(list) == T_APOSOBJ ) {
-        elm = ElmListFuncs[T_FIXALIST]( list, p );
-    }
-#endif
-    else {
-        elm = ELM_LIST( list, p );
-    }
+    elm = ElmPosObj( list, p );
 
     /* push the element                                                    */
     PushObj( elm );
@@ -3703,30 +3628,7 @@ void            IntrIsbPosObj ( void )
     list = PopObj();
 
     /* get the result                                                      */
-    if ( TNUM_OBJ(list) == T_POSOBJ ) {
-#ifdef HPCGAP
-        /* Because BindOnce() functions can reallocate the list even if they
-         * only have read-only access, we have to be careful when accessing
-         * positional objects.
-         */
-        const Bag *contents = CONST_PTR_BAG(list);
-        if (p > SIZE_BAG_CONTENTS(contents)/sizeof(Obj)-1)
-          isb = False;
-        else
-          isb = contents[p] != 0 ? True : False;
-#else
-        isb = (p <= SIZE_OBJ(list)/sizeof(Obj)-1 && ELM_PLIST(list,p) != 0 ?
-               True : False);
-#endif
-    }
-#ifdef HPCGAP
-    else if ( TNUM_OBJ(list) == T_APOSOBJ ) {
-        isb = (IsbListFuncs[T_FIXALIST]( list, p ) ? True : False);
-    }
-#endif
-    else {
-        isb = (ISB_LIST( list, p ) ? True : False);
-    }
+    isb = IsbPosObj( list, p ) ? True : False;
 
     /* push the result                                                     */
     PushObj( isb );

--- a/src/objects.h
+++ b/src/objects.h
@@ -864,6 +864,19 @@ static inline void SET_TYPE_POSOBJ(Obj obj, Obj val)
 
 /****************************************************************************
 **
+*F  AssPosbj( <obj>, <rnam>, <val> )
+*F  UnbPosbj( <obj>, <rnam> )
+*F  ElmPosbj( <obj>, <rnam> )
+*F  IsbPosbj( <obj>, <rnam> )
+*/
+extern void AssPosObj(Obj obj, Int idx, Obj val);
+extern void UnbPosObj(Obj obj, Int idx);
+extern Obj  ElmPosObj(Obj obj, Int idx);
+extern Int  IsbPosObj(Obj obj, Int idx);
+
+
+/****************************************************************************
+**
 *F  IS_DATOBJ( <obj> )  . . . . . . . . . . . . .  is an object a data object
 */
 static inline Int IS_DATOBJ(Obj obj)

--- a/src/vars.c
+++ b/src/vars.c
@@ -1577,22 +1577,7 @@ UInt            ExecAssPosObj (
     rhs = EVAL_EXPR(READ_STAT(stat, 2));
 
     /* special case for plain list                                         */
-    if ( TNUM_OBJ(list) == T_POSOBJ ) {
-#ifdef HPCGAP
-        WriteGuard(list);
-#endif
-        if ( SIZE_OBJ(list)/sizeof(Obj)-1 < p ) {
-            ResizeBag( list, (p+1) * sizeof(Obj) );
-        }
-        SET_ELM_PLIST( list, p, rhs );
-        CHANGED_BAG( list );
-#ifdef HPCGAP
-    } else if ( TNUM_OBJ(list) == T_APOSOBJ ) {
-        AssListFuncs[T_FIXALIST](list, p, rhs);
-#endif
-    } else {
-        ASS_LIST( list, p, rhs );
-    }
+    AssPosObj(list, p, rhs);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -1628,20 +1613,7 @@ UInt            ExecUnbPosObj (
     p = INT_INTOBJ(pos);
 
     /* unbind the element                                                  */
-    if ( TNUM_OBJ(list) == T_POSOBJ ) {
-#ifdef HPCGAP
-        WriteGuard(list);
-#endif
-        if ( p <= SIZE_OBJ(list)/sizeof(Obj)-1 ) {
-            SET_ELM_PLIST( list, p, 0 );
-        }
-#ifdef HPCGAP
-    } else if (TNUM_OBJ(list) == T_APOSOBJ ) {
-        UnbListFuncs[T_FIXALIST](list, p);
-#endif
-    } else {
-        UNB_LIST( list, p );
-    }
+    UnbPosObj(list, p);
 
     /* return 0 (to indicate that no leave-statement was executed)         */
     return 0;
@@ -1677,38 +1649,7 @@ Obj             EvalElmPosObj (
     p = INT_INTOBJ( pos );
 
     /* special case for plain lists (use generic code to signal errors)    */
-    if ( TNUM_OBJ(list) == T_POSOBJ ) {
-#ifdef HPCGAP
-        const Bag *contents = CONST_PTR_BAG(list);
-        while ( SIZE_BAG_CONTENTS(contents)/sizeof(Obj)-1 < p ) {
-            ErrorReturnVoid(
-                "PosObj Element: <PosObj>![%d] must have an assigned value",
-                (Int)p, 0L,
-                "you can 'return;' after assigning a value" );
-        }
-        elm = contents[p];
-#else
-        while ( SIZE_OBJ(list)/sizeof(Obj)-1 < p ) {
-            ErrorReturnVoid(
-                "PosObj Element: <PosObj>![%d] must have an assigned value",
-                (Int)p, 0L,
-                "you can 'return;' after assigning a value" );
-        }
-        elm = ELM_PLIST( list, p );
-#endif
-        while ( elm == 0 ) {
-            ErrorReturnVoid(
-                "PosObj Element: <PosObj>![%d] must have an assigned value",
-                (Int)p, 0L,
-                "you can 'return;' after assigning a value" );
-        }
-#ifdef HPCGAP
-    } else if ( TNUM_OBJ(list) == T_APOSOBJ ) {
-        elm = ElmListFuncs[T_FIXALIST](list, p);
-#endif
-    } else {
-        elm = ELM_LIST( list, p );
-    }
+    elm = ElmPosObj(list, p);
 
     /* return the element                                                  */
     return elm;
@@ -1744,26 +1685,7 @@ Obj             EvalIsbPosObj (
     p = INT_INTOBJ( pos );
 
     /* get the result                                                      */
-    if ( TNUM_OBJ(list) == T_POSOBJ ) {
-#ifdef HPCGAP
-        const Bag *contents = CONST_PTR_BAG(list);
-        if (p > SIZE_BAG_CONTENTS(contents)/sizeof(Obj)-1)
-          isb = False;
-        else
-          isb = contents[p] != 0 ? True : False;
-#else
-        isb = (p <= SIZE_OBJ(list)/sizeof(Obj)-1 && ELM_PLIST(list,p) != 0 ?
-               True : False);
-#endif
-    }
-#ifdef HPCGAP
-    else if ( TNUM_OBJ(list) == T_APOSOBJ ) {
-        isb = IsbListFuncs[T_FIXALIST](list, p) ? True : False;
-    }
-#endif
-    else {
-        isb = (ISB_LIST( list, p ) ? True : False);
-    }
+    isb = IsbPosObj(list, p) ? True : False;
 
     /* return the result                                                   */
     return isb;

--- a/tst/test-compile/basics.g.dynamic.c
+++ b/tst/test-compile/basics.g.dynamic.c
@@ -1167,42 +1167,15 @@ static Obj  HdlrFunc10 (
  
  /* Display( IsBound( x![2] ) ); */
  t_1 = GF_Display;
- if ( TNUM_OBJ(l_x) == T_POSOBJ ) {
-  t_2 = (2 <= SIZE_OBJ(l_x)/sizeof(Obj)-1
-     && ELM_PLIST(l_x,2) != 0 ? True : False);
-#ifdef HPCGAP
- } else if ( TNUM_OBJ(l_x) == T_APOSOBJ ) {
-  t_2 = Elm0AList(l_x,2) != 0 ? True : False;
-#endif
- }
- else {
-  t_2 = (ISB_LIST( l_x, 2 ) ? True : False);
- }
+ t_2 = IsbPosObj( l_x, 2 ) ? True : False;
  CALL_1ARGS( t_1, t_2 );
  
  /* Unbind( x![2] ); */
- if ( TNUM_OBJ(l_x) == T_POSOBJ ) {
-  if ( 2 <= SIZE_OBJ(l_x)/sizeof(Obj)-1 ) {
-   SET_ELM_PLIST( l_x, 2, 0 );
-  }
- }
- else {
-  UNB_LIST( l_x, 2 );
- }
+ UnbPosObj( l_x, 2 );
  
  /* Display( IsBound( x![2] ) ); */
  t_1 = GF_Display;
- if ( TNUM_OBJ(l_x) == T_POSOBJ ) {
-  t_2 = (2 <= SIZE_OBJ(l_x)/sizeof(Obj)-1
-     && ELM_PLIST(l_x,2) != 0 ? True : False);
-#ifdef HPCGAP
- } else if ( TNUM_OBJ(l_x) == T_APOSOBJ ) {
-  t_2 = Elm0AList(l_x,2) != 0 ? True : False;
-#endif
- }
- else {
-  t_2 = (ISB_LIST( l_x, 2 ) ? True : False);
- }
+ t_2 = IsbPosObj( l_x, 2 ) ? True : False;
  CALL_1ARGS( t_1, t_2 );
  
  /* Print( "Testing IsBound and Unbind for record\n" ); */

--- a/tst/test-compile/basics.g.static.c
+++ b/tst/test-compile/basics.g.static.c
@@ -1167,42 +1167,15 @@ static Obj  HdlrFunc10 (
  
  /* Display( IsBound( x![2] ) ); */
  t_1 = GF_Display;
- if ( TNUM_OBJ(l_x) == T_POSOBJ ) {
-  t_2 = (2 <= SIZE_OBJ(l_x)/sizeof(Obj)-1
-     && ELM_PLIST(l_x,2) != 0 ? True : False);
-#ifdef HPCGAP
- } else if ( TNUM_OBJ(l_x) == T_APOSOBJ ) {
-  t_2 = Elm0AList(l_x,2) != 0 ? True : False;
-#endif
- }
- else {
-  t_2 = (ISB_LIST( l_x, 2 ) ? True : False);
- }
+ t_2 = IsbPosObj( l_x, 2 ) ? True : False;
  CALL_1ARGS( t_1, t_2 );
  
  /* Unbind( x![2] ); */
- if ( TNUM_OBJ(l_x) == T_POSOBJ ) {
-  if ( 2 <= SIZE_OBJ(l_x)/sizeof(Obj)-1 ) {
-   SET_ELM_PLIST( l_x, 2, 0 );
-  }
- }
- else {
-  UNB_LIST( l_x, 2 );
- }
+ UnbPosObj( l_x, 2 );
  
  /* Display( IsBound( x![2] ) ); */
  t_1 = GF_Display;
- if ( TNUM_OBJ(l_x) == T_POSOBJ ) {
-  t_2 = (2 <= SIZE_OBJ(l_x)/sizeof(Obj)-1
-     && ELM_PLIST(l_x,2) != 0 ? True : False);
-#ifdef HPCGAP
- } else if ( TNUM_OBJ(l_x) == T_APOSOBJ ) {
-  t_2 = Elm0AList(l_x,2) != 0 ? True : False;
-#endif
- }
- else {
-  t_2 = (ISB_LIST( l_x, 2 ) ? True : False);
- }
+ t_2 = IsbPosObj( l_x, 2 ) ? True : False;
  CALL_1ARGS( t_1, t_2 );
  
  /* Print( "Testing IsBound and Unbind for record\n" ); */


### PR DESCRIPTION
Note the `MEMBAR_READ` call in `ElmPosObj` which is "essential" according
to a comment: this call was previously only present in the interpreter,
but missing in the executor.

Also, the code generated by the GAP compiler was more or less completely
broken in HPC-GAP, and lacked input validation in `C_ELM_POSOBJ`, which
`ElmPosObj` now provides "for free".

@rbehrends it'd be great if you checked the few HPC-GAP related bits in this PR!