### PR TITLE
kernel: replace NEW_WORD by NewWord

### DIFF
--- a/src/collectors.cc
+++ b/src/collectors.cc
@@ -163,7 +163,7 @@ Obj WordVectorAndClear ( Obj type, Obj vv, Int num )
     expm = (1UL << ebits) - 1;
 
     /* construct a new object                                              */
-    NEW_WORD( obj, type, num );
+    obj = NewWord(type, num);
 
     /* clear <vv>                                                          */
     ptr = DATA_WORD(obj);
@@ -655,7 +655,7 @@ Int Solution(
     expm = (1UL << ebits) - 1;
 
     /* use <g> as right argument for the collector                         */
-    NEW_WORD( g, SC_DEFAULT_TYPE(sc), 1 );
+    g = NewWord(SC_DEFAULT_TYPE(sc), 1);
 
     /* start clearing <ww>, storing the result in <uu>                     */
     ptr = (Int*)(ADDR_OBJ(ww)+1);
@@ -1471,7 +1471,7 @@ Obj ReducedPowerSmallInt (
 
     /* return the trivial word if <pow> is zero                            */
     if ( pow == 0 ) {
-        NEW_WORD( res, type, 0 );
+        res = NewWord(type, 0);
         return res;
     }
 

--- a/src/objfgelm.h
+++ b/src/objfgelm.h
@@ -12,11 +12,6 @@
 #define GAP_OBJFGELM_H
 
 #include "objects.h"
-#include "plist.h"
-
-#ifdef HPCGAP
-#include "hpc/guards.h"
-#endif
 
 /****************************************************************************
 **
@@ -121,30 +116,12 @@
 
 /****************************************************************************
 **
-*F  NEW_WORD( <word>, <type>, <npairs> )
+*F  NewWord( <type>, <npairs> )
 **
-**  'NEW_WORD' creates  a new object which has  the given <type> and room for
-**  <npairs> pairs of generator number/exponent.  The new  word is return  in
-**  <word>.
+**  'NewWord' returns a new object which has the given <type> and room for
+**  <npairs> pairs of generator number/exponent.
 */
-static inline Obj NewWord(Obj type, UInt npairs) {
-  Obj word;
-#ifdef HPCGAP
-  ReadGuard(type);
-#endif
-  word = NewBag(T_DATOBJ,2*sizeof(Obj)+npairs*BITS_WORDTYPE(type)/8L);
-  ADDR_OBJ(word)[1] = INTOBJ_INT(npairs);
-  SetTypeDatObj(word, type);
-#ifdef HPCGAP
-  MakeBagReadOnly( word );
-#endif
-  return word;
-}
-
-#define NEW_WORD(word, type, npairs) \
-  do { \
-    (word) = NewWord((type), (npairs)); \
-  } while(0)
+extern Obj NewWord(Obj type, UInt npairs);
 
 
 /****************************************************************************


### PR DESCRIPTION
Also move implementation of NewWord from .h into .c file; it is
not that performance critical, and this way, we don't have to include
HPC-GAP specific headers from `objfgelm.h`.