### PR TITLE
Replace GAP_ROOT_PATHS in tests with 'GAP_ROOT_PATH'

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -87,7 +87,7 @@ end);
 
 InstallGlobalFunction(RunTests, function(arg)
   local tests, opts, breakOnError, inp, outp, pos, cmp, times, ttime, nrlines,
-        s, res, fres, t, f, i;
+        s, res, fres, t, f, i, gaproot;
   # don't enter break loop in case of error during test
   tests := arg[1];
   opts := rec( breakOnError := false, showProgress := "some" );
@@ -142,6 +142,11 @@ InstallGlobalFunction(RunTests, function(arg)
         Error("user interrupt");
         BreakOnError := opts.breakOnError;
     fi;
+    # Remove explicit references to GAP's root path, so
+    # tests can be run on multiple machines
+    for gaproot in GAPInfo.KernelInfo.GAP_ROOT_PATHS do
+        res := ReplacedString(res, gaproot, "GAPROOT/");
+    od;
     Add(cmp, res);
     Add(times, t);
   od;
@@ -200,6 +205,9 @@ end;
 ##  lines starting with <C>"#"</C>.<Br/>
 ##  All other lines are considered as &GAP; output from the
 ##  preceding &GAP; input.
+##  To simplify running tests when GAP is installed in different locations,
+##  any directory in GAPInfo.KernelInfo.GAP_ROOT_PATHS is replaced with the
+##  string GAPROOT/.
 ##  <P/>
 ##  By default the actual &GAP; output is compared exactly with the
 ##  stored output, and if these are different some information about the 

--- a/tst/testinstall/opers/LocationFunc.tst
+++ b/tst/testinstall/opers/LocationFunc.tst
@@ -5,6 +5,10 @@ gap> f:=x->x;;
 gap> LocationFunc(f);
 "stream:1"
 
+# Library function
+gap> LocationFunc(OnQuit);
+"GAPROOT/lib/error.g:32"
+
 # GAP function which was compiled to C code by gac
 gap> LocationFunc(INSTALL_METHOD_FLAGS);
 "GAPROOT/lib/oper1.g:146"


### PR DESCRIPTION
As suggested in #2896.

I decided to use the string `'GAP_ROOT_PATH'`, rather than `GAPROOT`, because GAP actually outputs `GAPROOT` in some places and I thought it might be better if the replacement isn't something that GAP already outputs as standard (also it more tightly ties it to the `GAP_ROOT_PATH` variable. I put it in single quotes because otherwise you get `GAP_ROOT_PATHlib/init.g`, which looks bad, but I didn't really want to start stripping slashes (maybe I should)