### PR TITLE
Teach Test() to abort test if ctrl-C is pressed

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -136,6 +136,12 @@ InstallGlobalFunction(RunTests, function(arg)
     t := Runtime() - t;
     CloseStream(fres);
     CloseStream(s);
+    # check whether the user aborted by pressing ctrl-C
+    if StartsWith(res, "Error, user interrupt") then
+        BreakOnError := breakOnError;
+        Error("user interrupt");
+        BreakOnError := opts.breakOnError;
+    fi;
     Add(cmp, res);
     Add(times, t);
   od;


### PR DESCRIPTION
This is a bit of a hack, but seems to work very well in practice. You can even resume the test with `return` if you want (but the interrupted line will still lead to diffs).

An arguably "better" (but much more complicated) solution would be to add a flag which the kernel uses to signal to the error handler that the error is a user interrupt; then we could support seamlessly resuming of the interrupted test. But this requires further work, e.g. re-redirecting input/output temporarily, saving and restoring `BreakOnError` and more. Not sure that this would be worth it. In the meantime, this simple solution already gets us most of the benefit.

Resolves #1879