### PR TITLE
kernel: use HaveInterrupt instead of SyIsIntr

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -1193,10 +1193,6 @@ Obj FuncFUNC_BODY_SIZE(Obj self, Obj f)
 **
 */
 
-#ifdef HPCGAP
-  extern UInt HaveInterrupt();
-#endif
-
 Obj FuncSleep( Obj self, Obj secs )
 {
   Int  s;
@@ -1210,11 +1206,7 @@ Obj FuncSleep( Obj self, Obj secs )
     SySleep((UInt)s);
   
   /* either we used up the time, or we were interrupted. */
-#ifdef HPCGAP
   if (HaveInterrupt())
-#else
-  if (SyIsIntr())
-#endif
     {
       ClearError(); /* The interrupt may still be pending */
       ErrorReturnVoid("user interrupt in sleep", 0L, 0L,
@@ -1244,11 +1236,7 @@ Obj FuncMicroSleep( Obj self, Obj msecs )
     SyUSleep((UInt)s);
   
   /* either we used up the time, or we were interrupted. */
-#ifdef HPCGAP
   if (HaveInterrupt())
-#else
-  if (SyIsIntr())
-#endif
     {
       ClearError(); /* The interrupt may still be pending */
       ErrorReturnVoid("user interrupt in microsleep", 0L, 0L,

--- a/src/objects.c
+++ b/src/objects.c
@@ -25,7 +25,6 @@
 #include "records.h"
 #include "saveload.h"
 #include "stringobj.h"
-#include "sysfiles.h"
 
 #ifdef HPCGAP
 #include "hpc/aobjects.h"
@@ -942,17 +941,6 @@ void            PrintObj (
     UInt                lastPV;        /* save LastPV */
     UInt                fromview;      /* non-zero when we were called
                                         from viewObj of the SAME object */
-
-    /* check for interrupts                                                */
-    if ( SyIsIntr() ) {
-        i = STATE(PrintObjDepth);
-        Pr( "%c%c", (Int)'\03', (Int)'\04' );
-        ErrorReturnVoid(
-            "user interrupt while printing",
-            0L, 0L,
-            "you can 'return;'" );
-        STATE(PrintObjDepth) = i;
-    }
 
 #if defined(HPCGAP) && !defined(WARD_ENABLED)
    if (IS_BAG_REF(obj) && !CheckReadAccess(obj)) {

--- a/src/stats.c
+++ b/src/stats.c
@@ -113,16 +113,14 @@ UInt            ExecUnknownStat (
 
 /****************************************************************************
 **
-*F  UInt HaveInterrupt() . . . . . . . . check for user interrupts
+*F  HaveInterrupt . . . . . . . . . . . . . . . . . check for user interrupts
 **
 */
-
 #ifdef HPCGAP
-UInt HaveInterrupt( void ) {
-  return STATE(CurrExecStatFuncs) == IntrExecStatFuncs;
+UInt HaveInterrupt(void)
+{
+    return STATE(CurrExecStatFuncs) == IntrExecStatFuncs;
 }
-#else
-#define HaveInterrupt()   SyIsIntr()
 #endif
 
 /****************************************************************************
@@ -1084,10 +1082,9 @@ static void UnInterruptExecStat(void)
 **  allowing GAP execution in the usual way
 **
 **  This will do nothing (pretty quickly) if Ctrl-C has not been pressed and 
-**  return 0. Otherwise it
-**   will respond appropriately.  This may result in a longjmp
-**  or in returning to the caller after arbitrary execution of GAP code
-** including possible garbage collection. In this case 1 is returned.
+**  return 0. Otherwise it will respond appropriately. This may result in a
+**  longjmp or in returning to the caller after arbitrary execution of GAP
+**  code including possible garbage collection. In this case 1 is returned.
 */
 
 UInt TakeInterrupt( void )

--- a/src/stats.h
+++ b/src/stats.h
@@ -105,7 +105,23 @@ extern  UInt 		(* IntrExecStatFuncs[256]) ( Stat stat );
 /* TL: extern  Obj             ReturnObjStat; */
 
 
+/****************************************************************************
+**
+*F  HaveInterrupt . . . . . . . . . . . . . . . . . check for user interrupts
+**
+*/
+#ifdef HPCGAP
+extern UInt HaveInterrupt(void);
+#else
+#define HaveInterrupt() SyIsIntr()
+#endif
+
+
+/****************************************************************************
+**
+*/
 extern UInt TakeInterrupt();
+
 
 /****************************************************************************
 **


### PR DESCRIPTION
Also get rid of user interrupt check in the kernel function PrintObj():
the only ways I found to trigger that in practice first resulted in
the generic ctrl-C handler triggering; only upon using `return;` to
continue from that did the interrupt check in `PrintObj()` trigger,
meaning that the user had to use `return;` twice.

To see an example (using GAP *before* this commit, of course), you
can run this code and interrupt the printing.

    l:=[1..10];;
    for i in [1..5] do l:=List([1..10], i -> ShallowCopy(l)); od;
    PrintObj(l);