### PR TITLE
kernel: make OnLeftInverse use LQUO

### DIFF
--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1369,8 +1369,7 @@ Obj             FuncOnLeftInverse (
     Obj                 point,
     Obj                 elm )
 {
-    elm = INV(elm);
-    return PROD( elm, point );
+    return LQUO(elm, point);
 }
 
 /****************************************************************************

--- a/tst/testbugfix/2018-10-08-OnLeftInverse.tst
+++ b/tst/testbugfix/2018-10-08-OnLeftInverse.tst
@@ -1,0 +1,26 @@
+# Ensure OnLeftInverse preserves the mutability of its
+# input arguments.
+gap> m:=IdentityMat(2);
+[ [ 1, 0 ], [ 0, 1 ] ]
+gap> IsMutable(m);
+true
+gap> IsMutable(m/m);
+true
+gap> IsMutable(LQUO(m,m));
+true
+gap> IsMutable(OnRight(m,m));
+true
+gap> IsMutable(OnLeftInverse(m,m));
+true
+
+#
+gap> MakeImmutable(m);
+[ [ 1, 0 ], [ 0, 1 ] ]
+gap> IsMutable(m/m);
+false
+gap> IsMutable(LQUO(m,m));
+false
+gap> IsMutable(OnRight(m,m));
+false
+gap> IsMutable(OnLeftInverse(m,m));
+false


### PR DESCRIPTION
This ensures that the mutability of the inputs correctly transfers to
the results. In addition, we now benefit from kernel functions
handling LQUO for e.g. permutations.