### PR TITLE
Fix task scanner to use new Julia API call

### DIFF
--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -529,8 +529,11 @@ void GapRootScanner(int full)
 
 void GapTaskScanner(jl_task_t * task, int root_task)
 {
-    if (task->stkbuf) {
-        TryMarkRange(task->stkbuf, (char *)task->stkbuf + task->bufsz);
+    size_t size;
+    int    tid;
+    void * stack = jl_task_stack_buffer(task, &size, &tid);
+    if (stack && tid < 0) {
+        TryMarkRange(stack, (char *)stack + size);
     }
 }
 


### PR DESCRIPTION
With this, GAP can be used with the Julia master branch (and thus with Julia 1.1, when it comes out).

This is localized to the Julia GC code, so it should be safe to backport to GAP 4.10.