### PR TITLE
Fork improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -546,7 +546,7 @@ dnl Define kernel version
 dnl
 
 
-gap_kernel_major_version=5
+gap_kernel_major_version=6
 gap_kernel_minor_version=0
 AC_SUBST([gap_kernel_major_version])
 AC_SUBST([gap_kernel_minor_version])

--- a/src/iostream.c
+++ b/src/iostream.c
@@ -29,6 +29,7 @@
 #include "lists.h"
 #include "modules.h"
 #include "stringobj.h"
+#include "sysfiles.h"
 
 #include "hpc/thread.h"
 
@@ -330,7 +331,7 @@ static Int StartChildProcess(Char * dir, Char * prg, Char * args[])
     PtyIOStreams[stream].blocked = 0;
     PtyIOStreams[stream].changed = 0;
     /* fork */
-    PtyIOStreams[stream].childPID = fork();
+    PtyIOStreams[stream].childPID = SyFork();
     if (PtyIOStreams[stream].childPID == 0) {
         /* Set up the child */
         close(PtyIOStreams[stream].ptyFD);

--- a/src/profile.c
+++ b/src/profile.c
@@ -22,11 +22,14 @@
 #include "modules.h"
 #include "plist.h"
 #include "stringobj.h"
+#include "sysfiles.h"
 #include "vars.h"
 
 #include "hpc/thread.h"
 
 #include <sys/time.h>                   // for gettimeofday
+#include <sys/types.h>
+#include <unistd.h>
 #ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>               // definition of 'struct rusage'
 #endif
@@ -114,6 +117,8 @@ struct ProfileState
 {
   // C steam we are writing to
   FILE* Stream;
+  // Filename we are writing to
+  char filename[GAP_PATH_MAX];
   // Did we use 'popen' to open the stream (matters when closing)
   int StreamWasPopened;
   // Are we currently outputting repeats (false=code coverage)
@@ -335,6 +340,26 @@ static void fcloseMaybeCompressed(struct ProfileState* ps)
 #endif
   fclose(ps->Stream);
   ps->Stream = 0;
+}
+
+// When a child is forked off, we force profile information to be stored
+// in a new file for the child, to avoid corruption
+static void ProfileRegisterSyForkOccured(ForkState state)
+{
+    HashLock(&profileState);
+    if (state == PostForkChild && profileState_Active) {
+        char filenamecpy[GAP_PATH_MAX + 20];
+        if (endsWithgz(profileState.filename)) {
+            snprintf(filenamecpy, sizeof(filenamecpy), "%s.%d.gz",
+                     profileState.filename, getpid());
+        }
+        else {
+            snprintf(filenamecpy, sizeof(filenamecpy), "%s.%d",
+                     profileState.filename, getpid());
+        }
+        fcloseMaybeCompressed(&profileState);
+        fopenMaybeCompressed(filenamecpy, &profileState);
+    }
 }
 
 static inline Int8 CPUmicroseconds(void)
@@ -576,10 +601,14 @@ void enableAtStartup(char * filename, Int repeats, TickMethod tickMethod)
         exit(1);
     }
 
+    strlcpy(profileState.filename, filename, GAP_PATH_MAX);
+
     ActivateHooks(&profileHooks);
 
     profileState_Active = 1;
     RegisterSyLongjmpObserver(ProfileRegisterLongJmpOccurred);
+    RegisterSyForkObserver(ProfileRegisterSyForkOccured);
+
     profileState.profiledPreviously = 1;
 #ifdef HPCGAP
     profileState.profiledThread = TLS(threadID);
@@ -706,6 +735,8 @@ Obj FuncACTIVATE_PROFILING(Obj self,
 
     fopenMaybeCompressed(CONST_CSTR_STRING(filename), &profileState);
 
+    strlcpy(profileState.filename, CONST_CSTR_STRING(filename), GAP_PATH_MAX);
+
     if(profileState.Stream == 0) {
       HashUnlock(&profileState);
       return Fail;
@@ -713,6 +744,7 @@ Obj FuncACTIVATE_PROFILING(Obj self,
 
     profileState_Active = 1;
     RegisterSyLongjmpObserver(ProfileRegisterLongJmpOccurred);
+    RegisterSyForkObserver(ProfileRegisterSyForkOccured);
     profileState.profiledPreviously = 1;
 #ifdef HPCGAP
     profileState.profiledThread = TLS(threadID);

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -2956,7 +2956,51 @@ void SySetErrorNo ( void )
 /****************************************************************************
 **
 *F * * * * * * * * * * * * * file and execution * * * * * * * * * * * * * * *
+**
 */
+
+enum { signalSyForkFuncsLen = 16 };
+
+static ForkObserver signalSyforkFuncs[signalSyForkFuncsLen];
+
+Int RegisterSyForkObserver(ForkObserver func)
+{
+    Int i;
+    for (i = 0; i < signalSyForkFuncsLen; ++i) {
+        if (signalSyforkFuncs[i] == func) {
+            return 1;
+        }
+        if (signalSyforkFuncs[i] == 0) {
+            signalSyforkFuncs[i] = func;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+Int SyFork(void)
+{
+    for (int i = 0; i < signalSyForkFuncsLen; ++i) {
+        if (signalSyforkFuncs[i]) {
+            signalSyforkFuncs[i](PreFork);
+        }
+    }
+
+    Int ret = fork();
+    if (ret < 0)
+        return ret;
+
+    ForkState state = (ret == 0) ? PostForkChild : PostForkParent;
+
+    for (int i = 0; i < signalSyForkFuncsLen; ++i) {
+        if (signalSyforkFuncs[i]) {
+            signalSyforkFuncs[i](state);
+        }
+    }
+
+    return ret;
+}
+
 
 /****************************************************************************
 **
@@ -3109,7 +3153,7 @@ UInt SyExecuteProcess (
       func2 = &NullSignalHandler;
 
     /* clone the process                                                   */
-    pid = fork();
+    pid = SyFork();
     if ( pid == -1 ) {
         return -1;
     }

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -3109,7 +3109,7 @@ UInt SyExecuteProcess (
       func2 = &NullSignalHandler;
 
     /* clone the process                                                   */
-    pid = vfork();
+    pid = fork();
     if ( pid == -1 ) {
         return -1;
     }

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -401,6 +401,28 @@ extern void SySetErrorNo ( void );
 *F * * * * * * * * * * * * * file and execution * * * * * * * * * * * * * * *
 */
 
+typedef enum ForkState { PreFork, PostForkChild, PostForkParent } ForkState;
+typedef void (*ForkObserver)(ForkState);
+
+/*
+ *F RegisterSyForkObserver( <func> )
+ ** Register a function to be called before and after fork is called.
+ ** returns 1 on success, 0 if the table of functions is already full.
+ ** This function is idempotent -- if a function is passed multiple times
+ ** it is still only registered once.
+ */
+Int RegisterSyForkObserver(ForkObserver);
+
+/*
+ *F SyFork()
+ ** SyFork wraps the 'fork' system call.
+ ** SyFork will first call all functions passed to SyAddForkWatcher with
+ ** the argument 'PreFork', then call 'fork', then call all watchers again
+ ** with 'PostForkChild' in the child process, and 'PostForkParent' in the
+ ** parent process.
+ */
+Int SyFork(void);
+
 /****************************************************************************
 **
 *F  SyExecuteProcess( <dir>, <prg>, <in>, <out>, <args> ) . . . . new process


### PR DESCRIPTION
This PR adds `SyFork`, a wrapper around for which allows functions to be called pre- and post- fork. Profiling then uses this to create a new profile output for each child, to avoid the profile output getting corrupted.

If/when this is merged, I will force the IO package to use SyFork (when it is available), so forks which happen in IO can also be tracked.