### PR TITLE
Small fork improvement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -546,7 +546,7 @@ dnl Define kernel version
 dnl
 
 
-gap_kernel_major_version=5
+gap_kernel_major_version=6
 gap_kernel_minor_version=0
 AC_SUBST([gap_kernel_major_version])
 AC_SUBST([gap_kernel_minor_version])

--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -791,6 +791,12 @@ limitations which users should be aware of:
     is most obvious when looking at code coverage examples, which will appear
     to miss lines of code in files not in a function.
   </Item>
+  <Item>
+    If the current GAP is forked, using the <C>IO_fork</C> function in the
+    <Package>IO</Package> package,
+    a new profile output file will be created for the new child process, with
+    the process ID of the child attached to the end of the filename.
+  </Item>
 </List>
 
 Profiles are transformed into a human-readable form with

--- a/src/profile.h
+++ b/src/profile.h
@@ -19,6 +19,11 @@
 *F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
 */
 
+// When a child is forked off, we force profile information to be stored
+// in a new file for the child, to avoid corruption.
+// This function is for use by the IO package
+void InformProfilingThatThisIsAForkedGAP(void);
+
 
 /****************************************************************************
 **


### PR DESCRIPTION
Many apologises for the multiple PRs.

After further thought #2907 is both (a) too complicated, and (b) doesn't even do what I needed (it makes too many files). This adds a tiny part of that PR. I will then make a seperate PR to IO, which calls this function when in the child part of an IO_fork.

While this will tie profiling and IO_fork more tightly, I think that's the right option, as the forks in GAP never make processes which can continue to run GAP.