### PR TITLE
FIX: Cleanup (Isomorphism)SimplifiedFpGroup

### DIFF
--- a/lib/tietze.gi
+++ b/lib/tietze.gi
@@ -1182,54 +1182,6 @@ end );
 
 #############################################################################
 ##
-#M  SimplifiedFpGroup( <FpGroup> ) . . . . . . . . .  sinplify the FpGroup by
-#M                                                     Tietze transformations
-##
-##  `SimplifiedFpGroup'  returns a group  isomorphic to the given one  with a
-##  presentation which has been tried to simplify via Tietze transformations.
-##
-InstallGlobalFunction( SimplifiedFpGroup, function ( G )
-
-    local H, T,map,mapi;
-
-    # check the given argument to be a finitely presented group.
-    if not ( IsSubgroupFpGroup( G ) and IsGroupOfFamily( G ) ) then
-        Error( "argument must be a finitely presented group" );
-    fi;
-
-    # convert the given group presentation to a Tietze presentation.
-    T := PresentationFpGroup( G, 0 );
-
-    # perform Tietze transformations.
-    TzInitGeneratorImages(T);
-    TzGo( T );
-
-  # reconvert the Tietze presentation to a group presentation.
-  H := FpGroupPresentation( T );
-
-  # translate info
-  map:=GroupHomomorphismByImagesNC(G,H,GeneratorsOfGroup(G),
-        List(TzImagesOldGens(T),
-          i->MappedWord(i,GeneratorsOfPresentation(T),
-                          GeneratorsOfGroup(H))));
-
-  mapi:=GroupHomomorphismByImagesNC(H,G,GeneratorsOfGroup(H),
-        List(TzPreImagesNewGens(T),
-          i->MappedWord(i,OldGeneratorsOfPresentation(T),
-                          GeneratorsOfGroup(G))));
-
-  SetIsBijective(map,true);
-  SetInverseGeneralMapping(map,mapi);
-  SetInverseGeneralMapping(mapi,map);
-  ProcessEpimorphismToNewFpGroup(map);
-
-  # return the resulting group.
-  return H;
-end );
-
-
-#############################################################################
-##
 #M  AbstractWordTietzeWord( <word>, <fgens> )  . . . .  convert a Tietze word
 #M                                                        to an abstract word
 ##

--- a/tst/testinstall/grpfp.tst
+++ b/tst/testinstall/grpfp.tst
@@ -101,6 +101,18 @@ gap> Print( Collected( List( l, x -> Index( c2, x ) ) ), "\n" );
 gap> Print( Collected( List( LowIndexSubgroupsFpGroup( g, s, 5 ),
 >                            x -> Index( c2, x ) ) ), "\n" );
 [ [ 12, 1 ], [ 24, 1 ], [ 48, 1 ] ]
+
+# Tietze simplifications
+gap> F:=FreeGroup("a");;
+gap> SimplifiedFpGroup(F/[GeneratorsOfGroup(F)[1]]);
+<fp group on the generators [  ]>
+gap> F:=FreeGroup("a","b","c");;
+gap> rels:=ParseRelators(F,"a2,b3,c4,abC");
+[ a^2, b^3, c^4, a*b*c^-1 ]
+gap> IsomorphismSimplifiedFpGroup(F/rels);
+[ a, b, c ] -> [ c*b^-1, b, c ]
+
+#
 gap> STOP_TEST( "grpfp.tst", 1);
 
 #############################################################################


### PR DESCRIPTION
- Avoid code duplication between isomorphism and group method.
- Resolve issue with calling MappedWord on empty generator set.
- Added tests for simplification

This fixes #2911