### PR TITLE
Add support for '-c <expr>' command line argument

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -1020,20 +1020,33 @@ fi;
 ResumeMethodReordering();
 
 InstallAndCallPostRestore( function()
-    local i, status;
+    local i, f, status;
     for i in [1..Length(GAPInfo.InitFiles)] do
-        status := READ_NORECOVERY(GAPInfo.InitFiles[i]);
+        f := GAPInfo.InitFiles[i];
+        if IsRecord(f) then
+            status := READ_NORECOVERY(InputTextString(f.command));
+        else
+            status := READ_NORECOVERY(f);
+        fi;
         if status = fail then
-            PRINT_TO( "*errout*", "Reading file \"", GAPInfo.InitFiles[i],
-                "\" has been aborted.\n");
+            if IsRecord(f) then
+                PRINT_TO( "*errout*", "Executing command \"", f.command,
+                    "\" has been aborted.\n");
+            else
+                PRINT_TO( "*errout*", "Reading file \"", f,
+                    "\" has been aborted.\n");
+            fi;
             if i < Length (GAPInfo.InitFiles) then
                 PRINT_TO( "*errout*",
-                    "The remaining files on the command line will not be read.\n" );
+                    "The remaining files or commands on the command line will not be read.\n" );
             fi;
             break;
         elif status = false then
-            PRINT_TO( "*errout*", 
-                "Could not read file \"", GAPInfo.InitFiles[i],"\".\n" );
+            if IsRecord(f) then
+                PRINT_TO( "*errout*", "Could not execute command \"", f.command, "\".\n" );
+            else
+                PRINT_TO( "*errout*", "Could not read file \"", f, "\".\n" );
+            fi;
         fi;
     od;
 end );

--- a/lib/system.g
+++ b/lib/system.g
@@ -115,7 +115,9 @@ BIND_GLOBAL( "GAPInfo", rec(
       rec( long := "norepl", default := false,
            help := [ "Disable the GAP read-evaluate-print loop (REPL)" ] ),
       rec( long := "nointeract", default := false,
-           help := [ "Start GAP in non-interactive mode (disable read-evaluate-print loop (REPL) and break loop)" ] )
+           help := [ "Start GAP in non-interactive mode (disable read-evaluate-print loop (REPL) and break loop)" ] ),
+      ,
+      rec( short:= "c", default := "", arg := "<expr>", help := [ "execute the given expression"] ),
     ],
     ) );
 
@@ -361,7 +363,10 @@ CallAndInstallPostRestore( function()
           elif IS_INT( value ) then
             CommandLineOptions.( opt ):= CommandLineOptions.( opt ) + 1;
           elif i <= LENGTH( line ) then
-            if IS_STRING_REP( value ) then
+            if opt = "c" then
+              ADD_LIST_DEFAULT( InitFiles, rec( command := line[i] ) );
+              i := i+1;
+            elif IS_STRING_REP( value ) then
               # string
               CommandLineOptions.( opt ):= line[i];
               i := i+1;

--- a/src/streams.c
+++ b/src/streams.c
@@ -984,26 +984,24 @@ Obj FuncREAD (
 **
 *F  FuncREAD_NORECOVERY( <self>, <filename> )  . . .  . . . . . . read a file
 **
-** Read the current input and close the input stream. Disable the normal 
-** mechanism which ensures that quitting from a break loop gets you back to a 
-** live prompt. This is initially designed for the files read from the command 
-** line
+**  Read the current input and close the input stream. Disable the normal 
+**  mechanism which ensures that quitting from a break loop gets you back to
+**  a live prompt. This is initially designed for the files read from the
+**  command line.
 */
 Obj FuncREAD_NORECOVERY (
     Obj                 self,
-    Obj                 filename )
+    Obj                 input )
 {
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "READ: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
+    if ( IsStringConv( input ) ) {
+        if ( ! OpenInput( CONST_CSTR_STRING(input) ) ) {
+            return False;
+        }
     }
-
-    /* try to open the file                                                */
-    if ( ! OpenInput( CONST_CSTR_STRING(filename) ) ) {
-        return False;
+    else {
+        if (!OpenInputStream(input, 0)) {
+            return False;
+        }
     }
 
     /* read the file */


### PR DESCRIPTION
This works similar to the -c option for sh resp. bash, or the -e option
for perl and sed: It instructs GAP to execute the code given as argument
to -c.

This option can be used multiple times, and also mixed with filenames.
GAP will read the files resp. execute the expressions sequentially.
For example, given files a.g and b.g which just print the letter A reps. B,
one can do this:

    $ gap -b a.g -c 'Display(true);' b.g -c 'Display(123);' a.g -c 'QUIT;'
    A
    true
    B
    123
    A
    $