### PR TITLE
Replace all calls to SetFeatureObj, mark it as obsolete

### DIFF
--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -658,7 +658,11 @@ BIND_GLOBAL( "InstallSubsetMaintenance",
       SUBSET_MAINTAINED_INFO[1][ i+1 ]:= MakeImmutable(
                 [ filt1, filt2, operation, operation,
                   function( sub, val )
-                      SetFeatureObj( sub, operation, val );
+                      if val then
+                          SetFilterObj( sub, operation );
+                      else
+                          ResetFilterObj( sub, operation );
+                      fi;
                   end ]);
     fi;
     od; # end atomic

--- a/lib/obsolete.gi
+++ b/lib/obsolete.gi
@@ -942,5 +942,22 @@ BindGlobal( "SetUserPreferences", function( arg )
 
 #############################################################################
 ##
+#F  SetFeatureObj( <obj>, <filter>, <val> )
+##
+##  Moved to obsoletes in October 2018 for GAP 4.11.
+##
+##  still used by guarana, lpres, nq (10/2018)
+##
+BIND_GLOBAL( "SetFeatureObj", function ( obj, filter, val )
+    Info( InfoObsolete, 1, "'SetFeatureObj' is obsolete, use 'SetFilterObj' or 'ResetFilterObj' instead" );
+    if val then
+        SetFilterObj( obj, filter );
+    else
+        ResetFilterObj( obj, filter );
+    fi;
+end );
+
+#############################################################################
+##
 #E
 

--- a/lib/pquot.gi
+++ b/lib/pquot.gi
@@ -513,7 +513,7 @@ UpdateWeightInfo := function( qs )
     od;
     qs!.collector![SCP_AVECTOR2] := avc2;
 
-    SetFeatureObj( qs!.collector, IsUpToDatePolycyclicCollector, true );
+    SetFilterObj( qs!.collector, IsUpToDatePolycyclicCollector );
 end;
 
 #############################################################################

--- a/lib/rwsdt.gi
+++ b/lib/rwsdt.gi
@@ -224,9 +224,9 @@ function( dtrws, orders )
     dtrws![PC_EXPONENTS] := orders;
     if  Length(orders) < dtrws![PC_NUMBER_OF_GENERATORS]  or  
         not IsHomogeneousList( orders )                        then
-	SetFeatureObj( dtrws, IsFinite, false );
+	SetIsFinite( dtrws, false );
     else
-	SetFeatureObj( dtrws, IsFinite, true );
+	SetIsFinite( dtrws, true );
     fi;
 end   );
 
@@ -258,14 +258,14 @@ function( dtrws, i, ord )
     if  ord = infinity  or  ord = 0  then
 	if  IsBound( dtrws![PC_EXPONENTS][i] )  then
 	    Unbind( dtrws![PC_EXPONENTS][i] );
-	    SetFeatureObj( dtrws, IsFinite, false );
+	    SetIsFinite( dtrws, false );
 	fi;
     else
 	dtrws![PC_EXPONENTS][i] := ord;
 	if  0 in RelativeOrders( dtrws )  then
-	    SetFeatureObj( dtrws, IsFinite, false );
+	    SetIsFinite( dtrws, false );
 	else
-	    SetFeatureObj( dtrws, IsFinite, true );
+	    SetIsFinite( dtrws, true );
 	fi;
     fi;
 end   );
@@ -584,7 +584,7 @@ function( dtrws )
     # reduce the coefficients of the deep thought polynomials
     ReduceCoefficientsOfRws(dtrws);
 
-    SetFeatureObj( dtrws, IsUpToDatePolycyclicCollector, true );
+    SetFilterObj( dtrws, IsUpToDatePolycyclicCollector );
 
 end );
 

--- a/lib/rwspcclt.gi
+++ b/lib/rwspcclt.gi
@@ -331,7 +331,7 @@ InstallMethod( OutdatePolycyclicCollector,
     0,
 
 function( col )
-    SetFeatureObj( col, IsUpToDatePolycyclicCollector, false );
+    ResetFilterObj( col, IsUpToDatePolycyclicCollector );
 end );
 
 

--- a/lib/rwspccoc.gi
+++ b/lib/rwspccoc.gi
@@ -166,7 +166,7 @@ function( cc )
     CombiCollector_MakeAvector2(cc);
 
     # 'MakeInverses' is very careful
-    SetFeatureObj( cc, IsUpToDatePolycyclicCollector, true );
+    SetFilterObj( cc, IsUpToDatePolycyclicCollector );
 
     # construct the inverses
     SingleCollector_MakeInverses(cc);
@@ -313,7 +313,7 @@ function( efam, gens, orders )
     cc![SCP_WEIGHTS] := [1..cc![SCP_NUMBER_RWS_GENERATORS]] * 0;
     cc![SCP_CLASS]   := 666666;
 
-    SetFeatureObj( cc, IsCombinatorialCollectorRep, true );
+    SetFilterObj( cc, IsCombinatorialCollectorRep );
 
     # and return
     return cc;
@@ -345,7 +345,7 @@ function( comcol )
     fi;
 
     # it's a combinatorial collector now
-    SetFeatureObj( copy, IsCombinatorialCollectorRep, true );
+    SetFilterObj( copy, IsCombinatorialCollectorRep );
 
     return copy;
 

--- a/lib/rwspcsng.gi
+++ b/lib/rwspcsng.gi
@@ -355,7 +355,7 @@ function( sc )
 
     # return if there is nothing to reduce
     if n = 0  then
-        SetFeatureObj( sc, IsDefaultRhsTypeSingleCollector, true );
+        SetFilterObj( sc, IsDefaultRhsTypeSingleCollector );
         OutdatePolycyclicCollector(sc);
         UpdatePolycyclicCollector(sc);
         return;
@@ -404,7 +404,7 @@ function( sc )
     od;
 
     # now all right hand sides have the default type
-    SetFeatureObj( sc, IsDefaultRhsTypeSingleCollector, true );
+    SetFilterObj( sc, IsDefaultRhsTypeSingleCollector );
 
     # but we have to outdate the collector to force recomputation of avec
     OutdatePolycyclicCollector(sc);
@@ -439,7 +439,7 @@ function( sc, i, j, rhs )
         sc![SCP_CONJUGATES][i][j] := rhs;
         if not sc![SCP_IS_DEFAULT_TYPE](rhs)  then
             Print( "#W  Warning: mixed types in collector\n" );
-            SetFeatureObj( sc, IsDefaultRhsTypeSingleCollector, false );
+            ResetFilterObj( sc, IsDefaultRhsTypeSingleCollector );
         fi;
     fi;
 
@@ -455,7 +455,7 @@ SingleCollector_SetConjugateNC := function( sc, i, j, rhs )
     else
         sc![SCP_CONJUGATES][i][j] := rhs;
         if not sc![SCP_IS_DEFAULT_TYPE](rhs)  then
-            SetFeatureObj( sc, IsDefaultRhsTypeSingleCollector, false );
+            ResetFilterObj( sc, IsDefaultRhsTypeSingleCollector );
         fi;
     fi;
 
@@ -545,7 +545,7 @@ function( sc, i, rhs )
         sc![SCP_POWERS][i] := rhs;
         if not sc![SCP_IS_DEFAULT_TYPE](rhs)  then
             Print( "#  Warning: mixed types in collector\n" );
-            SetFeatureObj( sc, IsDefaultRhsTypeSingleCollector, false );
+            ResetFilterObj( sc, IsDefaultRhsTypeSingleCollector );
         fi;
     fi;
 
@@ -559,7 +559,7 @@ SingleCollector_SetPowerNC := function( sc, i, rhs )
     else
         sc![SCP_POWERS][i] := rhs;
         if not sc![SCP_IS_DEFAULT_TYPE](rhs)  then
-            SetFeatureObj( sc, IsDefaultRhsTypeSingleCollector, false );
+            ResetFilterObj( sc, IsDefaultRhsTypeSingleCollector );
         fi;
     fi;
 
@@ -816,7 +816,7 @@ function( sc )
     SingleCollector_MakeAvector(sc);
 
     # 'MakeInverses' is very careful
-    SetFeatureObj( sc, IsUpToDatePolycyclicCollector, true );
+    SetFilterObj( sc, IsUpToDatePolycyclicCollector );
 
     # construct the inverses
     SingleCollector_MakeInverses(sc);
@@ -1026,13 +1026,13 @@ function( efam, gens, orders )
     type := NewType( fam, IsSingleCollectorRep and bits and IsFinite
                           and IsMutable );
     Objectify( type, sc );
-    SetFeatureObj( sc, HasUnderlyingFamily,      true );
-    SetFeatureObj( sc, HasRelativeOrders,        true );
-    SetFeatureObj( sc, HasGeneratorsOfRws,       true );
-    SetFeatureObj( sc, HasNumberGeneratorsOfRws, true );
+    SetFilterObj( sc, HasUnderlyingFamily      );
+    SetFilterObj( sc, HasRelativeOrders        );
+    SetFilterObj( sc, HasGeneratorsOfRws       );
+    SetFilterObj( sc, HasNumberGeneratorsOfRws );
 
     # there are no right hand sides
-    SetFeatureObj( sc, IsDefaultRhsTypeSingleCollector, true );
+    SetFilterObj( sc, IsDefaultRhsTypeSingleCollector );
 
     # we haven't computed the avector and the inverses
     OutdatePolycyclicCollector(sc);

--- a/lib/type1.g
+++ b/lib/type1.g
@@ -827,26 +827,6 @@ BIND_GLOBAL( "RESET_FILTER_OBJ", ResetFilterObj );
 
 #############################################################################
 ##
-#F  SetFeatureObj( <obj>, <filter>, <val> )
-##
-##  <ManSection>
-##  <Func Name="SetFeatureObj" Arg='obj, filter, val'/>
-##
-##  <Description>
-##  </Description>
-##  </ManSection>
-##
-BIND_GLOBAL( "SetFeatureObj", function ( obj, filter, val )
-    if val then
-        SetFilterObj( obj, filter );
-    else
-        ResetFilterObj( obj, filter );
-    fi;
-end );
-
-
-#############################################################################
-##
 #F  ObjectifyWithAttributes(<obj>,<type>,<attr1>,<val1>,<attr2>,<val2>... )
 ##
 ##  <#GAPDoc Label="ObjectifyWithAttributes">

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include "compiled.h"
-#define FILE_CRC  "-43167549"
+#define FILE_CRC  "-66698575"
 
 /* global variables used in handlers */
 static GVar G_NAME__FUNC;
@@ -194,7 +194,7 @@ static RNam R_HASH__SIZE;
 static RNam R_TYPES;
 
 /* information for the functions */
-static Obj  NameFunc[32];
+static Obj  NameFunc[31];
 static Obj FileName;
 
 /* handler for function 2 */
@@ -2486,49 +2486,6 @@ static Obj  HdlrFunc29 (
 /* handler for function 30 */
 static Obj  HdlrFunc30 (
  Obj  self,
- Obj  a_obj,
- Obj  a_filter,
- Obj  a_val )
-{
- Obj t_1 = 0;
- Bag oldFrame;
- 
- /* allocate new stack frame */
- SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- 
- /* if val then */
- CHECK_BOOL( a_val )
- t_1 = (Obj)(UInt)(a_val != False);
- if ( t_1 ) {
-  
-  /* SetFilterObj( obj, filter ); */
-  t_1 = GF_SetFilterObj;
-  CALL_2ARGS( t_1, a_obj, a_filter );
-  
- }
- 
- /* else */
- else {
-  
-  /* ResetFilterObj( obj, filter ); */
-  t_1 = GF_ResetFilterObj;
-  CALL_2ARGS( t_1, a_obj, a_filter );
-  
- }
- /* fi */
- 
- /* return; */
- SWITCH_TO_OLD_FRAME(oldFrame);
- return 0;
- 
- /* return; */
- SWITCH_TO_OLD_FRAME(oldFrame);
- return 0;
-}
-
-/* handler for function 31 */
-static Obj  HdlrFunc31 (
- Obj  self,
  Obj  a_arg )
 {
  Obj l_obj = 0;
@@ -3609,26 +3566,6 @@ static Obj  HdlrFunc1 (
  CHECK_BOUND( t_3, "ResetFilterObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
- /* BIND_GLOBAL( "SetFeatureObj", function ( obj, filter, val )
-      if val then
-          SetFilterObj( obj, filter );
-      else
-          ResetFilterObj( obj, filter );
-      fi;
-      return;
-  end ); */
- t_1 = GF_BIND__GLOBAL;
- t_2 = MakeString( "SetFeatureObj" );
- t_3 = NewFunction( NameFunc[30], 3, 0, HdlrFunc30 );
- SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
- t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 839);
- SET_ENDLINE_BODY(t_4, 845);
- SET_FILENAME_BODY(t_4, FileName);
- SET_BODY_FUNC(t_3, t_4);
- CHANGED_BAG( STATE(CurrLVars) );
- CALL_2ARGS( t_1, t_2, t_3 );
- 
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "IsAttributeStoringRepFlags" );
@@ -3698,11 +3635,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "ObjectifyWithAttributes" );
- t_3 = NewFunction( NameFunc[31], -1, 0, HdlrFunc31 );
+ t_3 = NewFunction( NameFunc[30], -1, 0, HdlrFunc30 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 893);
- SET_ENDLINE_BODY(t_4, 959);
+ SET_STARTLINE_BODY(t_4, 873);
+ SET_ENDLINE_BODY(t_4, 939);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -3851,7 +3788,6 @@ static Int PostRestore ( StructInitInfo * module )
  NameFunc[28] = 0;
  NameFunc[29] = 0;
  NameFunc[30] = 0;
- NameFunc[31] = 0;
  
  /* return success */
  return 0;
@@ -4018,8 +3954,6 @@ static Int InitKernel ( StructInitInfo * module )
  InitGlobalBag( &(NameFunc[29]), "GAPROOT/lib/type1.g:NameFunc[29]("FILE_CRC")" );
  InitHandlerFunc( HdlrFunc30, "GAPROOT/lib/type1.g:HdlrFunc30("FILE_CRC")" );
  InitGlobalBag( &(NameFunc[30]), "GAPROOT/lib/type1.g:NameFunc[30]("FILE_CRC")" );
- InitHandlerFunc( HdlrFunc31, "GAPROOT/lib/type1.g:HdlrFunc31("FILE_CRC")" );
- InitGlobalBag( &(NameFunc[31]), "GAPROOT/lib/type1.g:NameFunc[31]("FILE_CRC")" );
  
  /* return success */
  return 0;
@@ -4055,7 +3989,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "GAPROOT/lib/type1.g",
- .crc         = -43167549,
+ .crc         = -66698575,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/src/hpc/c_type1.c
+++ b/src/hpc/c_type1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include "compiled.h"
-#define FILE_CRC  "-43167549"
+#define FILE_CRC  "-66698575"
 
 /* global variables used in handlers */
 static GVar G_NAME__FUNC;
@@ -233,7 +233,7 @@ static RNam R_HASH__SIZE;
 static RNam R_TYPES;
 
 /* information for the functions */
-static Obj  NameFunc[32];
+static Obj  NameFunc[31];
 static Obj FileName;
 
 /* handler for function 2 */
@@ -2725,49 +2725,6 @@ static Obj  HdlrFunc29 (
 /* handler for function 30 */
 static Obj  HdlrFunc30 (
  Obj  self,
- Obj  a_obj,
- Obj  a_filter,
- Obj  a_val )
-{
- Obj t_1 = 0;
- Bag oldFrame;
- 
- /* allocate new stack frame */
- SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
- 
- /* if val then */
- CHECK_BOOL( a_val )
- t_1 = (Obj)(UInt)(a_val != False);
- if ( t_1 ) {
-  
-  /* SetFilterObj( obj, filter ); */
-  t_1 = GF_SetFilterObj;
-  CALL_2ARGS( t_1, a_obj, a_filter );
-  
- }
- 
- /* else */
- else {
-  
-  /* ResetFilterObj( obj, filter ); */
-  t_1 = GF_ResetFilterObj;
-  CALL_2ARGS( t_1, a_obj, a_filter );
-  
- }
- /* fi */
- 
- /* return; */
- SWITCH_TO_OLD_FRAME(oldFrame);
- return 0;
- 
- /* return; */
- SWITCH_TO_OLD_FRAME(oldFrame);
- return 0;
-}
-
-/* handler for function 31 */
-static Obj  HdlrFunc31 (
- Obj  self,
  Obj  a_arg )
 {
  Obj l_obj = 0;
@@ -3872,26 +3829,6 @@ static Obj  HdlrFunc1 (
  CHECK_BOUND( t_3, "ResetFilterObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
- /* BIND_GLOBAL( "SetFeatureObj", function ( obj, filter, val )
-      if val then
-          SetFilterObj( obj, filter );
-      else
-          ResetFilterObj( obj, filter );
-      fi;
-      return;
-  end ); */
- t_1 = GF_BIND__GLOBAL;
- t_2 = MakeString( "SetFeatureObj" );
- t_3 = NewFunction( NameFunc[30], 3, 0, HdlrFunc30 );
- SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
- t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 839);
- SET_ENDLINE_BODY(t_4, 845);
- SET_FILENAME_BODY(t_4, FileName);
- SET_BODY_FUNC(t_3, t_4);
- CHANGED_BAG( STATE(CurrLVars) );
- CALL_2ARGS( t_1, t_2, t_3 );
- 
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "IsAttributeStoringRepFlags" );
@@ -3961,11 +3898,11 @@ static Obj  HdlrFunc1 (
   end ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "ObjectifyWithAttributes" );
- t_3 = NewFunction( NameFunc[31], -1, 0, HdlrFunc31 );
+ t_3 = NewFunction( NameFunc[30], -1, 0, HdlrFunc30 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewBag( T_BODY, sizeof(BodyHeader) );
- SET_STARTLINE_BODY(t_4, 893);
- SET_ENDLINE_BODY(t_4, 959);
+ SET_STARTLINE_BODY(t_4, 873);
+ SET_ENDLINE_BODY(t_4, 939);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  CHANGED_BAG( STATE(CurrLVars) );
@@ -4133,7 +4070,6 @@ static Int PostRestore ( StructInitInfo * module )
  NameFunc[28] = 0;
  NameFunc[29] = 0;
  NameFunc[30] = 0;
- NameFunc[31] = 0;
  
  /* return success */
  return 0;
@@ -4320,8 +4256,6 @@ static Int InitKernel ( StructInitInfo * module )
  InitGlobalBag( &(NameFunc[29]), "GAPROOT/lib/type1.g:NameFunc[29]("FILE_CRC")" );
  InitHandlerFunc( HdlrFunc30, "GAPROOT/lib/type1.g:HdlrFunc30("FILE_CRC")" );
  InitGlobalBag( &(NameFunc[30]), "GAPROOT/lib/type1.g:NameFunc[30]("FILE_CRC")" );
- InitHandlerFunc( HdlrFunc31, "GAPROOT/lib/type1.g:HdlrFunc31("FILE_CRC")" );
- InitGlobalBag( &(NameFunc[31]), "GAPROOT/lib/type1.g:NameFunc[31]("FILE_CRC")" );
  
  /* return success */
  return 0;
@@ -4357,7 +4291,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "GAPROOT/lib/type1.g",
- .crc         = -43167549,
+ .crc         = -66698575,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,


### PR DESCRIPTION
Various packages still use it, and most likely also code that people keep
around locally, so we cannot and should not remove it for the foreseeable
future. But at least new code should not use it.