### PR TITLE
Extend obsolete to support multiple levels

### DIFF
--- a/doc/ref/obsolete.xml
+++ b/doc/ref/obsolete.xml
@@ -199,13 +199,16 @@ Note that <C>MultRowVector</C> was also renamed to <C>MultVectorLeft</C>.
 <InfoClass Name="InfoObsolete"/>
 <Description>
 is an info class to display warnings when an obsolete variable is used.
-By default, these warnings are switched off since the info level for 
-this class is 0. Setting it to 1 will trigger warnings if &GAP; will 
-detect that an obsolete variable is used at runtime.
+By default, the info level for this class is set to 1, which will only
+show variables which will be removed in the next major version of GAP.
+Setting it to 2 will trigger further warnings, for variables which have
+alternative names, or may be removed in future.
+
+This class can be set to 0 to disable all obsolete warnings.
 <P/>
-To check that the &GAP; code does not use obsolete variables at the 
-parsing time, and not at a runtime, use <C>-O</C> command line option,
-see <Ref Sect="Command Line Options"/>. 
+To check that the &GAP; code does not use any obsolete variables at
+parsing time, and not at a runtime, use the <C>-O</C> command line option,
+see <Ref Sect="Command Line Options"/>.
 </Description>
 </ManSection>
 

--- a/lib/info.gi
+++ b/lib/info.gi
@@ -429,8 +429,9 @@ end);
 ##
 #V  InfoObsolete
 ##
-##  This info class has a default level of 0.
-##  Warnings can be switched on by setting its level to one.
+##  This info class has a default level of 1.
+##  Warnings can be disabled entirely by setting its level to 0, and further
+##  warnings can be switched on by setting its level to 2.
 ##
 DeclareInfoClass( "InfoObsolete" );
-SetInfoLevel(InfoObsolete,0);
+SetInfoLevel(InfoObsolete,1);

--- a/tst/testbugfix/2013-06-14-t00300.tst
+++ b/tst/testbugfix/2013-06-14-t00300.tst
@@ -3,7 +3,7 @@ gap> foo:=function() return 42; end;
 function(  ) ... end
 gap> DeclareObsoleteSynonym("bar","foo");
 gap> oldLevel := InfoLevel(InfoObsolete);;
-gap> SetInfoLevel(InfoObsolete,1);
+gap> SetInfoLevel(InfoObsolete,2);
 gap> bar();
 #I  'bar' is obsolete.
 #I  It may be removed in a future release of GAP.

--- a/tst/testinstall/obsolete.tst
+++ b/tst/testinstall/obsolete.tst
@@ -1,0 +1,57 @@
+gap> START_TEST("obsolete.tst");
+gap> newfunc:=function() return 42; end;
+function(  ) ... end
+gap> DeclareObsoleteSynonym("obsoletetestfunc","newfunc",1);
+gap> DeclareObsoleteSynonym("obsoletetestfunc2","newfunc",2);
+gap> DeclareObsoleteSynonym("obsoletetestfunc3","newfunc",2);
+gap> oldLevel := InfoLevel(InfoObsolete);;
+gap> SetInfoLevel(InfoObsolete,1);
+gap> obsoletetestfunc();
+#I  'obsoletetestfunc' is obsolete.
+#I  It may be removed in a future release of GAP.
+#I  Use newfunc instead.
+42
+gap> obsoletetestfunc();
+42
+gap> obsoletetestfunc2();
+42
+gap> obsoletetestfunc2();
+42
+gap> SetInfoLevel(InfoObsolete, 2);
+gap> obsoletetestfunc2();
+#I  'obsoletetestfunc2' is obsolete.
+#I  It may be removed in a future release of GAP.
+#I  Use newfunc instead.
+42
+gap> obsoletetestfunc2();
+42
+gap> obsoletetestfunc3();
+#I  'obsoletetestfunc3' is obsolete.
+#I  It may be removed in a future release of GAP.
+#I  Use newfunc instead.
+42
+gap> obsoletetestfunc3();
+42
+gap> DeclareObsoleteSynonymAttr("obsoleteattr", "IsEmpty");
+gap> obsoleteattr([1,2,3]);
+#I  'obsoleteattr' is obsolete.
+#I  It may be removed in a future release of GAP.
+#I  Use IsEmpty instead.
+false
+gap> obsoleteattr([1,2,3]);
+false
+gap> obsoleteattr([]);
+true
+gap> Hasobsoleteattr([]);
+#I  'Hasobsoleteattr' is obsolete.
+#I  It may be removed in a future release of GAP.
+#I  Use HasIsEmpty instead.
+true
+gap> Hasobsoleteattr([]);
+true
+gap> Setobsoleteattr([], true);
+#I  'Setobsoleteattr' is obsolete.
+#I  It may be removed in a future release of GAP.
+#I  Use SetIsEmpty instead.
+gap> SetInfoLevel(InfoObsolete, oldLevel);
+gap> STOP_TEST("obsolete.tst");


### PR DESCRIPTION
One problem with the way we currently handle 'obsolete' is that normal users of GAP will never see an obsolete warning, until we delete the function (as they don't tend to increase InfoObsolete, or run with `-O`).

This extends 'obsolete' into two levels, 1 and 2. Level 1 messages are always printed, level 2 messages have to be explicitly enabled.

The -O option still disables any obsolete functions from being used at all.

My long-term plan is that we would put obsolete messages in a major release at level 1 before removing them, so users would actually see a warning, and have the chance to fix their code.

If changing how InfoObsolete works upsets anyone, we could add a different variable (`InfoObsoleteSoon`?) which displayed messages about things we will delete in the future.