### PR TITLE
Adjust bin/BuildPackages.sh for new simpcomp version

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -214,9 +214,11 @@ build_one_package() {
     ;;
 
     simpcomp*)
-      chmod a+x configure depcomp install-sh missing && \
-      echo_run ./configure && \
-      echo_run "$MAKE" && \
+      # Old versions of simpcomp were not setting the executable
+      # bit for some files; they also were not copying the bistellar
+      # executable to the right place
+      (chmod a+x configure depcomp install-sh missing || :) && \
+      run_configure_and_make && \
       mkdir -p bin && test -x bin/bistellar || mv bistellar bin
     ;;
 


### PR DESCRIPTION
With this tweak, one can build the currently shipping version of simpcomp;
future (fixed) releases; and also the simpcomp git repository.