### PR TITLE
kernel: when using julia_gc, call jl_atexit_hook in SyExit

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -366,8 +366,7 @@ void InformProfilingThatThisIsAForkedGAP(void)
         // Allow 20 chracters to allow space for .%d.gz
         const int SUPPORTED_PATH_LEN = GAP_PATH_MAX - 20;
         if(strlen(profileState.filename) > SUPPORTED_PATH_LEN) {
-           Pr("Filename can be at most %d character when forking", SUPPORTED_PATH_LEN, 0L);
-           SyExit(1);
+           Panic("Filename can be at most %d character when forking", SUPPORTED_PATH_LEN);
         }
         if (endsWithgz(profileState.filename)) {
             snprintf(filenamecpy, sizeof(filenamecpy), "%.*s.%d.gz",
@@ -599,17 +598,14 @@ struct InterpreterHooks profileHooks = { visitStat,
 void enableAtStartup(char * filename, Int repeats, TickMethod tickMethod)
 {
     if(profileState_Active) {
-        fprintf(stderr, "-P or -C can only be passed once\n");
-        exit(1);
+        Panic("-P or -C can only be passed once\n");
     }
     
     profileState.OutputRepeats = repeats;
 
     fopenMaybeCompressed(filename, &profileState);
     if(!profileState.Stream) {
-        fprintf(stderr, "Failed to open '%s' for profiling output.\n", filename);
-        fprintf(stderr, "Abandoning starting GAP.\n");
-        exit(1);
+        Panic("Failed to open '%s' for profiling output.\n", filename);
     }
 
     strlcpy(profileState.filename, filename, GAP_PATH_MAX);

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -372,11 +372,8 @@ static void LoadBagData ( void )
   flags = LoadUInt1();
   size = LoadUInt();
 
-    if (TNAM_TNUM(type) == NULL)
-      {
-        Pr("Bad type %d, size %d\n",type,size);
-        exit(1);
-      }
+  if (TNAM_TNUM(type) == NULL)
+    Panic("Bad type %d, size %d\n", (int)type, (int)size);
 
   /* Get GASMAN to set up the bag for me */
   bag = NextBagRestoring( type, flags, size );

--- a/src/system.c
+++ b/src/system.c
@@ -33,6 +33,10 @@
 #include "hpc/misc.h"
 #endif
 
+#ifdef USE_JULIA_GC
+#include "julia.h"
+#endif
+
 #include <assert.h>
 #include <fcntl.h>
 #include <stdarg.h>
@@ -547,7 +551,10 @@ void SyUSleep ( UInt msecs )
 void SyExit (
     UInt                ret )
 {
-        exit( (int)ret );
+#ifdef USE_JULIA_GC
+    jl_atexit_hook(ret);
+#endif
+    exit( (int)ret );
 }
 
 

--- a/src/system.c
+++ b/src/system.c
@@ -563,7 +563,7 @@ void Panic_(const char * file, int line, const char * fmt, ...)
     vfprintf(stderr, fmt, args);
     va_end (args);
     fputs("\n", stderr);
-    exit(1);
+    SyExit(1);
 }
 
 


### PR DESCRIPTION
... as recommended by https://docs.julialang.org/en/v1/manual/embedding/index.html

This makes it possible to collect coverage data in Julia code (as that is written to disk via that atexit hook).