### PR TITLE
Warning fix

### DIFF
--- a/cnf/m4/ax_compiler_flags_cflags.m4
+++ b/cnf/m4/ax_compiler_flags_cflags.m4
@@ -113,6 +113,7 @@ AC_DEFUN([AX_COMPILER_WARNING_FLAGS],[
             -Wrestrict dnl
             dnl -Wnull-dereference dnl
             -Wdouble-promotion dnl
+            -Wno-cast-function-type dnl
         ],ax_warn_cflags_variable,[$ax_compiler_flags_test])
         # HACK: use the warning flags determined so far also for the C++ compiler.
         # This assumes that the C and C++ compiler are "related" and thus will

--- a/src/system.h
+++ b/src/system.h
@@ -82,8 +82,8 @@ GAP_STATIC_ASSERT(sizeof(void *) == SIZEOF_VOID_P, "sizeof(void *) is wrong");
 **  at least GAP won't be the only program to run into problems.
 */
 enum {
-#ifdef PATH_MAX
-    GAP_PATH_MAX = 4096 > PATH_MAX ? 4096 : PATH_MAX,
+#if defined(PATH_MAX) && PATH_MAX > 4096
+    GAP_PATH_MAX = PATH_MAX,
 #else
     GAP_PATH_MAX = 4096,
 #endif


### PR DESCRIPTION
This fixes two new warnings I see compiling GAP in gcc 8.2.

One of them `-Wno-cast-function-type` I am sure we should just disable, because GAP casts quite a lot of functions in strange ways, and there doesn't seem to be an easy way to hide it.

The other warning, `-Widentical-branches` (which checks if both sides of an if, or `?:` operator, are the same), I actually like. There is one place where it appears and it is hard to fix (checking `PATH_MAX`), so I add a slightly horrible hack (with comment) to handle the case where `PATH_MAX == 4096`.