### PR TITLE
re-added the `ViewObj` method for generic fields

### DIFF
--- a/lib/field.gi
+++ b/lib/field.gi
@@ -235,7 +235,23 @@ InstallMethod( ClosureDivisionRing,
 
 #############################################################################
 ##
-#M  ViewString( <F> )  . . . . . . . . . . . . . . . . . . . . . .  view a field
+#M  ViewObj( <F> )  . . . . . . . . . . . . . . . . . . . . . .  view a field
+##
+InstallMethod( ViewObj,
+    "for a field",
+    [ IsField ],
+    function( F )
+    if HasSize( F ) and IsInt( Size( F ) ) then
+      Print( "<field of size ", String(Size( F )), ">" );
+    else
+      Print( "<field in characteristic ", Characteristic( F ), ">" );
+    fi;
+    end );
+
+
+#############################################################################
+##
+#M  ViewString( <F> ) . . . . . . . . . . . . . . . . . . . . .  view a field
 ##
 InstallMethod( ViewString,
     "for a field",

--- a/tst/testbugfix/2012-08-14-t00271.tst
+++ b/tst/testbugfix/2012-08-14-t00271.tst
@@ -1,6 +1,7 @@
 # 2012/08/14 (AK)
 gap> R:=PolynomialRing(GF(5),"mu");;
 gap> mu:=Indeterminate(GF(5));;
-gap> T:=AlgebraicExtension(GF(5),mu^5-mu+1);;
+gap> T:=AlgebraicExtension(GF(5),mu^5-mu+1);
+<field of size 3125>
 gap> A:=PolynomialRing(T,"x");
 <field of size 3125>[x]

--- a/tst/testbugfix/2017-07-06-DoImmutableMatrix.tst
+++ b/tst/testbugfix/2017-07-06-DoImmutableMatrix.tst
@@ -1,6 +1,6 @@
 # handling of finite fields of size q <= 256 but not GF(q)
 gap> f1 := AlgebraicExtension(GF(3), CyclotomicPolynomial(GF(3), 5));
-<algebra-with-one of dimension 4 over GF(3)>
+<field of size 81>
 gap> a := RootOfDefiningPolynomial(f1);
 a
 gap> mat := [[a]];


### PR DESCRIPTION
This method had been lost in 2012 (see Commit v4.6.0)
when a `ViewString` method had replaced it.
Note that other `ViewObj` methods for the objects in question are
applicable that have a higher rank than the delegation to `ViewString`.
The same happens for many objects, but for the moment I want to fix
the behavior for fields.

(This could have been noticed in `tst/testbugfix/2012-08-14-t00271.tst`.)