### PR TITLE
Make INT_INTOBJ always check its argument

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -433,6 +433,12 @@ void ErrorQuitIntSmall(Obj obj)
               0L);
 }
 
+void ErrorMayQuitIntSmall(Obj obj)
+{
+    ErrorMayQuit("<obj> must be a small integer (not a %s)", (Int)TNAM_OBJ(obj),
+                 0L);
+}
+
 
 /****************************************************************************
 **

--- a/src/error.h
+++ b/src/error.h
@@ -61,8 +61,10 @@ extern void ErrorQuitFuncResult(void) NORETURN;
 /****************************************************************************
 **
 *F  ErrorQuitIntSmall( <obj> )  . . . . . . . . . . . . . not a small integer
+*F  ErrorMayQuitIntSmall( <obj> )  . . . . . . . . . . .  not a small integer
 */
 extern void ErrorQuitIntSmall(Obj obj) NORETURN;
+extern void ErrorMayQuitIntSmall(Obj obj) NORETURN;
 
 
 /****************************************************************************

--- a/src/intobj.h
+++ b/src/intobj.h
@@ -33,6 +33,7 @@ a
 #define GAP_INTOBJ_H
 
 #include "system.h"
+#include "error.h"
 
 #ifdef SYS_IS_64_BIT
 #define NR_SMALL_INT_BITS  (64 - 4)
@@ -111,12 +112,18 @@ static inline Int ARE_INTOBJS(Obj o1, Obj o2)
  * chooses to do a logical right shift. */
 static inline Int INT_INTOBJ(Obj o)
 {
-    GAP_ASSERT(IS_INTOBJ(o));
+    if(__builtin_expect(IS_INTOBJ(o),1))
+    {
 #ifdef HAVE_ARITHRIGHTSHIFT
-    return (Int)o >> 2;
+        return (Int)o >> 2;
 #else
-    return ((Int)o - 1) / 4;
+        return ((Int)o - 1) / 4;
 #endif
+    }
+    else
+    {
+        ErrorQuitIntSmall(o);
+    }
 }
 
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -45,6 +45,7 @@
 #include "finfield.h"
 #include "funcs.h"
 #include "gaputils.h"
+#include "integer.h"
 #include "io.h"
 #include "lists.h"
 #include "modules.h"
@@ -3417,12 +3418,24 @@ static StructGVarFilt GVarFilts [] = {
 
 };
 
+static Obj FuncTEST_SUM_LIST(Obj self, Obj list)
+{
+    UInt sum = 0;
+    Int len = LEN_PLIST(list);
+    for(Int j = 1; j < 200; ++j) {
+        for(Int k = 1; k <= len; ++k) {
+            sum += INT_INTOBJ(ELM_PLIST(list, k)) * j;
+        }
+    }
+    return ObjInt_UInt(sum);
+}
 
 /****************************************************************************
 **
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
 static StructGVarFunc GVarFuncs [] = {
+    GVAR_FUNC(TEST_SUM_LIST, 1, "list"),
 
     GVAR_FUNC(ASS_PLIST_DEFAULT, 3, "list, pos, val"),
     GVAR_FUNC(IsRectangularTablePlist, 1, "plist"),


### PR DESCRIPTION
This commit makes INT_INTOBJ always check it is given an INTOBJ, and produce an error if not. At the moment we assert in this case in debug mode, and produce nonsense in normal execution.

This might seem like an inefficiency, as this is a really high-use function. However, I'm having trouble measuring any measurable slowdown on any GAP code I can write. I have in this PR a special test which hits what I imagine is the very worst case (just reading loads of integers, one after the other).

```
x := List([1..10000000], y -> (y mod 100));;
TEST_SUM_LIST(x);
time;
```

This has a 7% slowdown (and as I say, this is code which does absolutely no useful work).

This will fix some bugs I found today (including `x := [1,,,3]; y := x{[2^2000]};`), and also in general deal with what has been a continuous source of difficult to track down crashes and bugs going back over the whole time I've worked on GAP. This will allow a bunch of tests to be deleted (I'm happy to go through and remove them, if we will merge this).

The `__builtin_unlikely`, if you haven't seen it before, it a piece of code built into gcc and clang which tells the compiler that this value will (in this case) probably be true, and the optimiser uses this accordingly. We could add some configure magic if anyone is worried about a compiler that doesn't support this (but gcc and clang both do).