### PR TITLE
Unify kernel error checking

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -1195,12 +1195,7 @@ Obj FuncPositionNthTrueBlist (
             (Int)TNAM_OBJ(blist), 0L,
             "you can replace <blist> via 'return <blist>;'" );
     }
-    while ( ! IS_POS_INTOBJ(Nth) ) {
-        Nth = ErrorReturnObj(
-            "Position: <nth> must be a positive small integer (not a %s)",
-            (Int)TNAM_OBJ(Nth), 0L,
-            "you can replace <nth> via 'return <nth>;'" );
-    }
+    RequirePositiveSmallIntMayReplace("Position", Nth, "nth");
     
     nrb = NUMBER_BLOCKS_BLIST(blist);
     if ( ! nrb )  return Fail;

--- a/src/blister.c
+++ b/src/blister.c
@@ -1077,18 +1077,8 @@ Obj FuncBLIST_LIST (
     Obj                 sub )
 {
     /* get and check the arguments                                         */
-    while ( ! IS_SMALL_LIST(list) ) {
-        list = ErrorReturnObj(
-            "BlistList: <list> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(list), 0L,
-            "you can replace <list> via 'return <list>;'" );
-    }
-    while ( ! IS_SMALL_LIST(sub) ) {
-        sub = ErrorReturnObj(
-            "BlistList: <sub> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(sub), 0L,
-            "you can replace <sub> via 'return <sub>;'" );
-    }
+    RequireSmallListMayReplace("BlistList", list);
+    RequireSmallListMayReplace("BlistList", sub);
 
     Int lenList = LEN_LIST( list );
     Obj blist = NewBag( T_BLIST, SIZE_PLEN_BLIST( lenList ) );
@@ -1127,12 +1117,7 @@ Obj FuncLIST_BLIST (
     UInt                i;              /* loop variable                   */
 
     /* get and check the first argument                                    */
-    while ( ! IS_SMALL_LIST( list ) ) {
-        list = ErrorReturnObj(
-            "ListBlist: <list> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(list), 0L,
-            "you can replace <list> via 'return <list>;'" );
-    }
+    RequireSmallListMayReplace("ListBlist", list);
     /* get and check the second argument                                   */
     while ( ! IsBlistConv( blist ) ) {
         blist = ErrorReturnObj(
@@ -1358,12 +1343,7 @@ Obj FuncUNITE_BLIST_LIST (
     long                s, t;           /* elements of a range             */
 
     /* get and check the arguments                                         */
-    while ( ! IS_SMALL_LIST(list) ) {
-        list = ErrorReturnObj(
-            "UniteBlistList: <list> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(list), 0L,
-            "you can replace <list> via 'return <list>;'" );
-    }
+    RequireSmallListMayReplace("UniteBlistList", list);
 
     lenList  = LEN_LIST( list );
 
@@ -1380,12 +1360,7 @@ Obj FuncUNITE_BLIST_LIST (
             "you can replace <blist> via 'return <blist>;'" );
     }
 
-    while ( ! IS_SMALL_LIST(sub) ) {
-        sub = ErrorReturnObj(
-            "UniteBlistList: <sub> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(sub), 0L,
-            "you can replace <sub> via 'return <sub>;'" );
-    }
+    RequireSmallListMayReplace("UniteBlistList", sub);
 
     lenSub   = LEN_LIST( sub );
 

--- a/src/blister.c
+++ b/src/blister.c
@@ -85,6 +85,10 @@
 #include "set.h"
 
 
+#define RequireBlistMayReplace(funcname, op, argname) \
+    RequireArgumentConditionMayReplace(funcname, op, argname, IsBlistConv(op), \
+        "must be a boolean list")
+
 /****************************************************************************
 **
 *F  TypeBlist( <list> )  . . . . . . . . . . . . . . . type of a boolean list
@@ -1039,14 +1043,7 @@ Obj FuncSIZE_BLIST (
     Obj                 self,
     Obj                 blist )
 {
-    /* get and check the argument                                          */
-    while ( ! IsBlistConv(blist) ) {
-        blist = ErrorReturnObj(
-            "SizeBlist: <blist> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(blist), 0L,
-            "you can replace <blist> via 'return <blist>;'" );
-    }
-  
+    RequireBlistMayReplace("SizeBlist", blist, "blist");
     return INTOBJ_INT(SizeBlist(blist));
 }
 
@@ -1119,12 +1116,7 @@ Obj FuncLIST_BLIST (
     /* get and check the first argument                                    */
     RequireSmallListMayReplace("ListBlist", list);
     /* get and check the second argument                                   */
-    while ( ! IsBlistConv( blist ) ) {
-        blist = ErrorReturnObj(
-            "ListBlist: <blist> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(blist), 0L,
-            "you can replace <blist> via 'return <blist>;'" );
-    }
+    RequireBlistMayReplace("ListBlist", blist, "blist");
     while ( LEN_LIST( list ) != LEN_BLIST( blist ) ) {
         blist = ErrorReturnObj(
             "ListBlist: <blist> must have the same length as <list> (%d)",
@@ -1174,12 +1166,7 @@ Obj FuncPositionNthTrueBlist (
     const UInt *        ptr;
 
     /* Check the arguments. */    
-    while ( ! IsBlistConv( blist ) ) {
-        blist = ErrorReturnObj(
-            "ListBlist: <blist> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(blist), 0L,
-            "you can replace <blist> via 'return <blist>;'" );
-    }
+    RequireBlistMayReplace("ListBlist", blist, "blist");
     RequirePositiveSmallIntMayReplace("Position", Nth, "nth");
     
     nrb = NUMBER_BLOCKS_BLIST(blist);
@@ -1229,18 +1216,8 @@ Obj FuncIS_SUB_BLIST (
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    while ( ! IsBlistConv( list1 ) ) {
-        list1 = ErrorReturnObj(
-            "IsSubsetBlist: <blist1> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(list1), 0L,
-            "you can replace <blist1> via 'return <blist1>;'" );
-    }
-    while ( ! IsBlistConv( list2 ) ) {
-        list2 = ErrorReturnObj(
-            "IsSubsetBlist: <blist2> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(list2), 0L,
-            "you can replace <blist2> via 'return <blist2>;'" );
-    }
+    RequireBlistMayReplace("IsSubsetBlist", list1, "blist1");
+    RequireBlistMayReplace("IsSubsetBlist", list2, "blist2");
     while ( LEN_BLIST(list1) != LEN_BLIST(list2) ) {
         list2 = ErrorReturnObj(
         "IsSubsetBlist: <blist2> must have the same length as <blist1> (%d)",
@@ -1285,18 +1262,8 @@ Obj FuncUNITE_BLIST (
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    while ( ! IsBlistConv( list1 ) ) {
-        list1 = ErrorReturnObj(
-            "UniteBlist: <blist1> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(list1), 0L,
-            "you can replace <blist1> via 'return <blist1>;'" );
-    }
-    while ( ! IsBlistConv( list2 ) ) {
-        list2 = ErrorReturnObj(
-            "UniteBlist: <blist2> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(list2), 0L,
-            "you can replace <blist2> via 'return <blist2>;'" );
-    }
+    RequireBlistMayReplace("UniteBlist", list1, "blist1");
+    RequireBlistMayReplace("UniteBlist", list2, "blist2");
     while ( LEN_BLIST(list1) != LEN_BLIST(list2) ) {
         list2 = ErrorReturnObj(
            "UniteBlist: <blist2> must have the same length as <blist1> (%d)",
@@ -1347,12 +1314,7 @@ Obj FuncUNITE_BLIST_LIST (
 
     lenList  = LEN_LIST( list );
 
-    while ( ! IsBlistConv( blist ) ) {
-        blist = ErrorReturnObj(
-            "UniteBlistList: <blist> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(blist), 0L,
-            "you can replace <blist> via 'return <blist>;'" );
-    }
+    RequireBlistMayReplace("UniteBlistList", blist, "blist");
     while ( LEN_BLIST(blist) != lenList ) {
         blist = ErrorReturnObj(
           "UniteBlistList: <blist> must have the same length as <list> (%d)",
@@ -1567,18 +1529,8 @@ Obj FuncINTER_BLIST (
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    while ( ! IsBlistConv( list1 ) ) {
-        list1 = ErrorReturnObj(
-            "IntersectBlist: <blist1> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(list1), 0L,
-            "you can replace <blist1> via 'return <blist1>;'" );
-    }
-    while ( ! IsBlistConv( list2 ) ) {
-        list2 = ErrorReturnObj(
-            "IntersectBlist: <blist2> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(list2), 0L,
-            "you can replace <blist2> via 'return <blist2>;'" );
-    }
+    RequireBlistMayReplace("IntersectBlist", list1, "blist1");
+    RequireBlistMayReplace("IntersectBlist", list2, "blist2");
     while ( LEN_BLIST(list1) != LEN_BLIST(list2) ) {
         list2 = ErrorReturnObj(
        "IntersectBlist: <blist2> must have the same length as <blist1> (%d)",
@@ -1620,18 +1572,8 @@ Obj FuncSUBTR_BLIST (
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    while ( ! IsBlistConv( list1 ) ) {
-        list1 = ErrorReturnObj(
-            "SubtractBlist: <blist1> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(list1), 0L,
-            "you can replace <blist1> via 'return <blist1>;'" );
-    }
-    while ( ! IsBlistConv( list2 ) ) {
-        list2 = ErrorReturnObj(
-            "SubtractBlist: <blist2> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(list2), 0L,
-            "you can replace <blist2> via 'return <blist2>;'" );
-    }
+    RequireBlistMayReplace("SubtractBlist", list1, "blist1");
+    RequireBlistMayReplace("SubtractBlist", list2, "blist2");
     while ( LEN_BLIST(list1) != LEN_BLIST(list2) ) {
         list2 = ErrorReturnObj(
         "SubtractBlist: <blist2> must have the same length as <blist1> (%d)",
@@ -1675,18 +1617,8 @@ Obj FuncMEET_BLIST (
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    while ( ! IsBlistConv( list1 ) ) {
-        list1 = ErrorReturnObj(
-            "MeetBlist: <blist1> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(list1), 0L,
-            "you can replace <blist1> via 'return <blist1>;'" );
-    }
-    while ( ! IsBlistConv( list2 ) ) {
-        list2 = ErrorReturnObj(
-            "MeetBlist: <blist2> must be a boolean list (not a %s)",
-            (Int)TNAM_OBJ(list2), 0L,
-            "you can replace <blist2> via 'return <blist2>;'" );
-    }
+    RequireBlistMayReplace("MeetBlist", list1, "blist1");
+    RequireBlistMayReplace("MeetBlist", list2, "blist2");
     while ( LEN_BLIST(list1) != LEN_BLIST(list2) ) {
         list2 = ErrorReturnObj(
         "MeetBlist: <blist2> must have the same length as <blist1> (%d)",

--- a/src/calls.c
+++ b/src/calls.c
@@ -1307,9 +1307,7 @@ Obj FuncCALL_FUNC_LIST (
     Obj                 list )
 {
     /* check that the second argument is a list                            */
-    if ( ! IS_SMALL_LIST( list ) ) {
-       ErrorMayQuit("CallFuncList: <list> must be a small list", 0L, 0L);
-    }
+    RequireSmallList("CallFuncList", list);
     return CallFuncList(func, list);
 }
 
@@ -1320,9 +1318,7 @@ Obj FuncCALL_FUNC_LIST_WRAP (
 {
     Obj retval, retlist;
     /* check that the second argument is a list                            */
-    if ( ! IS_SMALL_LIST( list ) ) {
-       ErrorMayQuit("CallFuncListWrap: <list> must be a small list", 0L, 0L);
-    }
+    RequireSmallList("CallFuncListWrap", list);
     retval = CallFuncList(func, list);
 
     if (retval == 0)

--- a/src/calls.c
+++ b/src/calls.c
@@ -1487,11 +1487,7 @@ Obj FuncCLEAR_PROFILE_FUNC(
 {
     Obj                 prof;
 
-    /* check the argument                                                  */
-    if ( TNUM_OBJ(func) != T_FUNCTION ) {
-        ErrorQuit( "<func> must be a function", 0L, 0L );
-        return 0;
-    }
+    RequireFunction("CLEAR_PROFILE_FUNC", func);
 
     /* clear profile info                                                  */
     prof = PROF_FUNC(func);
@@ -1527,11 +1523,8 @@ Obj FuncPROFILE_FUNC(
     Obj                 prof;
     Obj                 copy;
 
-    /* check the argument                                                  */
-    if ( TNUM_OBJ(func) != T_FUNCTION ) {
-        ErrorQuit( "<func> must be a function", 0L, 0L );
-        return 0;
-    }
+    RequireFunction("PROFILE_FUNC", func);
+
     /* uninstall trace handler                                             */
     ChangeDoOperations( func, 0 );
 
@@ -1578,21 +1571,13 @@ Obj FuncIS_PROFILED_FUNC(
     Obj                 self,
     Obj                 func )
 {
-    /* check the argument                                                  */
-    if ( TNUM_OBJ(func) != T_FUNCTION ) {
-        ErrorQuit( "<func> must be a function", 0L, 0L );
-        return 0;
-    }
+    RequireFunction("IS_PROFILED_FUNC", func);
     return ( TNUM_OBJ(PROF_FUNC(func)) != T_FUNCTION ) ? False : True;
 }
 
-Obj FuncFILENAME_FUNC(Obj self, Obj func) {
-
-    /* check the argument                                                  */
-    if ( TNUM_OBJ(func) != T_FUNCTION ) {
-        ErrorQuit( "<func> must be a function", 0L, 0L );
-        return 0;
-    }
+Obj FuncFILENAME_FUNC(Obj self, Obj func)
+{
+    RequireFunction("FILENAME_FUNC", func);
 
     if (BODY_FUNC(func)) {
         Obj fn =  GET_FILENAME_BODY(BODY_FUNC(func));
@@ -1602,12 +1587,9 @@ Obj FuncFILENAME_FUNC(Obj self, Obj func) {
     return Fail;
 }
 
-Obj FuncSTARTLINE_FUNC(Obj self, Obj func) {
-    /* check the argument                                                  */
-    if ( TNUM_OBJ(func) != T_FUNCTION ) {
-        ErrorQuit( "<func> must be a function", 0L, 0L );
-        return 0;
-    }
+Obj FuncSTARTLINE_FUNC(Obj self, Obj func)
+{
+    RequireFunction("STARTLINE_FUNC", func);
 
     if (BODY_FUNC(func)) {
         UInt sl = GET_STARTLINE_BODY(BODY_FUNC(func));
@@ -1617,12 +1599,9 @@ Obj FuncSTARTLINE_FUNC(Obj self, Obj func) {
     return Fail;
 }
 
-Obj FuncENDLINE_FUNC(Obj self, Obj func) {
-    /* check the argument                                                  */
-    if ( TNUM_OBJ(func) != T_FUNCTION ) {
-        ErrorQuit( "<func> must be a function", 0L, 0L );
-        return 0;
-    }
+Obj FuncENDLINE_FUNC(Obj self, Obj func)
+{
+    RequireFunction("ENDLINE_FUNC", func);
 
     if (BODY_FUNC(func)) {
         UInt el = GET_ENDLINE_BODY(BODY_FUNC(func));
@@ -1632,12 +1611,9 @@ Obj FuncENDLINE_FUNC(Obj self, Obj func) {
     return Fail;
 }
 
-Obj FuncLOCATION_FUNC(Obj self, Obj func) {
-    /* check the argument                                                  */
-    if ( TNUM_OBJ(func) != T_FUNCTION ) {
-        ErrorQuit( "<func> must be a function", 0L, 0L );
-        return 0;
-    }
+Obj FuncLOCATION_FUNC(Obj self, Obj func)
+{
+    RequireFunction("LOCATION_FUNC", func);
 
     if (BODY_FUNC(func)) {
         Obj sl = GET_LOCATION_BODY(BODY_FUNC(func));
@@ -1657,11 +1633,7 @@ Obj FuncUNPROFILE_FUNC(
 {
     Obj                 prof;
 
-    /* check the argument                                                  */
-    if ( TNUM_OBJ(func) != T_FUNCTION ) {
-        ErrorQuit( "<func> must be a function", 0L, 0L );
-        return 0;
-    }
+    RequireFunction("UNPROFILE_FUNC", func);
 
     /* uninstall trace handler                                             */
     ChangeDoOperations( func, 0 );

--- a/src/collectors.cc
+++ b/src/collectors.cc
@@ -1686,12 +1686,8 @@ Obj FuncFinPowConjCol_ReducedQuotient ( Obj self, Obj sc, Obj w, Obj u )
 */
 Obj FuncSET_SCOBJ_MAX_STACK_SIZE ( Obj self, Obj size )
 {
-    if (IS_INTOBJ(size) && INT_INTOBJ(size) > 0)
-        CollectorsState()->SC_MAX_STACK_SIZE = INT_INTOBJ(size);
-    else
-        ErrorQuit( "collect vector must be a positive small integer not a %s",
-                   (Int)TNAM_OBJ(size), 0L );
-
+    RequirePositiveSmallInt("SET_SCOBJ_MAX_STACK_SIZE", size, "size");
+    CollectorsState()->SC_MAX_STACK_SIZE = INT_INTOBJ(size);
     return 0;
 }
 

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -1544,12 +1544,7 @@ Obj FuncE (
     }
 
     /* get and check the argument                                          */
-    while (!IS_POS_INTOBJ(n)) {
-        n = ErrorReturnObj(
-            "E: <n> must be a positive small integer (not a %s)",
-            (Int)TNAM_OBJ(n), 0L,
-            "you can replace <n> via 'return <n>;'" );
-    }
+    RequirePositiveSmallIntMayReplace("E", n, "n");
 
     /* for $e_1$ return 1 and for $e_2$ return -1                          */
     if ( n == INTOBJ_INT(1) )

--- a/src/error.h
+++ b/src/error.h
@@ -192,6 +192,24 @@ ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2);
 
 /****************************************************************************
 **
+*F  RequireFunction
+*/
+#define RequireFunction(funcname, op) \
+    RequireArgumentCondition(funcname, op, #op, IS_FUNC(op), \
+        "must be a function")
+
+
+/****************************************************************************
+**
+*F  RequireFunctionMayReplace
+*/
+#define RequireFunctionMayReplace(funcname, op) \
+    RequireArgumentConditionMayReplace(funcname, op, #op, IS_FUNC(op), \
+        "must be a function")
+
+
+/****************************************************************************
+**
 *F  CheckIsPossList( <desc>, <poss> ) . . . . . . . . . . check for poss list
 */
 void CheckIsPossList(const Char * desc, Obj poss);

--- a/src/error.h
+++ b/src/error.h
@@ -174,6 +174,24 @@ ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2);
 
 /****************************************************************************
 **
+*F  RequireSmallList
+*/
+#define RequireSmallList(funcname, op) \
+    RequireArgumentCondition(funcname, op, #op, IS_SMALL_LIST(op), \
+        "must be a small list")
+
+
+/****************************************************************************
+**
+*F  RequireSmallListMayReplace
+*/
+#define RequireSmallListMayReplace(funcname, op) \
+    RequireArgumentConditionMayReplace(funcname, op, #op, IS_SMALL_LIST(op), \
+        "must be a small list")
+
+
+/****************************************************************************
+**
 *F  CheckIsPossList( <desc>, <poss> ) . . . . . . . . . . check for poss list
 */
 void CheckIsPossList(const Char * desc, Obj poss);

--- a/src/error.h
+++ b/src/error.h
@@ -129,6 +129,51 @@ ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2);
 
 /****************************************************************************
 **
+*F  RequireArgumentCondition
+*/
+#define RequireArgumentCondition(funcname, op, argname, cond, msg) \
+    do { \
+        if (!(cond)) { \
+            ErrorMayQuit(funcname ": <" argname "> " msg " (not a %s)", \
+                (Int)TNAM_OBJ(op), 0); \
+        } \
+    } while (0)
+
+
+/****************************************************************************
+**
+*F  RequireArgumentConditionMayReplace
+*/
+#define RequireArgumentConditionMayReplace(funcname, op, argname, cond, msg) \
+    do { \
+        while (!(cond)) { \
+            op = ErrorReturnObj(funcname ": <" argname "> " msg " (not a %s)", \
+                (Int)TNAM_OBJ(op), 0, \
+                "you can replace <" argname "> via 'return <" argname ">;'"); \
+        } \
+    } while (0)
+
+
+/****************************************************************************
+**
+*F  RequirePositiveSmallInt
+*/
+#define RequirePositiveSmallInt(funcname, op, argname) \
+    RequireArgumentCondition(funcname, op, argname, IS_POS_INTOBJ(op), \
+        "must be a positive small integer")
+
+
+/****************************************************************************
+**
+*F  RequirePositiveSmallIntMayReplace
+*/
+#define RequirePositiveSmallIntMayReplace(funcname, op, argname) \
+    RequireArgumentConditionMayReplace(funcname, op, argname, IS_POS_INTOBJ(op), \
+        "must be a positive small integer")
+
+
+/****************************************************************************
+**
 *F  CheckIsPossList( <desc>, <poss> ) . . . . . . . . . . check for poss list
 */
 void CheckIsPossList(const Char * desc, Obj poss);

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -833,12 +833,7 @@ Obj             EvalPermExpr (
 
             /* get and check current entry for the cycle                   */
             val = EVAL_EXPR(READ_EXPR(cycle, j - 1));
-            while ( ! IS_POS_INTOBJ(val) ) {
-                val = ErrorReturnObj(
-              "Permutation: <expr> must be a positive small integer (not a %s)",
-                    (Int)TNAM_OBJ(val), 0L,
-                    "you can replace <expr> via 'return <expr>;'" );
-            }
+            RequirePositiveSmallIntMayReplace("Permutation", val, "expr");
             c = INT_INTOBJ(val);
             if (c > MAX_DEG_PERM4)
               ErrorMayQuit( "Permutation literal exceeds maximum permutation degree",

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1971,11 +1971,7 @@ void            IntrPermCycle (
 
         /* get and check current entry for the cycle                       */
         val = PopObj();
-        if (!IS_POS_INTOBJ(val)) {
-            ErrorQuit(
-                "Permutation: <expr> must be a positive small integer (not a %s)",
-                (Int)TNAM_OBJ(val), 0L );
-        }
+        RequirePositiveSmallInt("Permutation", val, "expr");
         c = INT_INTOBJ(val);
         if (c > MAX_DEG_PERM4)
           ErrorQuit( "Permutation literal exceeds maximum permutation degree",
@@ -3199,11 +3195,7 @@ void            IntrElmListLevel ( Int narg,
       
     /* /\* get and check the position                                          *\/ */
     /* pos = PopObj(); */
-    /* if ( TNUM_OBJ(pos) != T_INTPOS && (! IS_POS_INTOBJ(pos) )) { */
-    /*     ErrorQuit( */
-    /*         "List Element: <position> must be a positive integer (not a %s)", */
-    /*         (Int)TNAM_OBJ(pos), 0L ); */
-    /* } */
+    /* RequirePositiveSmallInt("List Element", pos, "position"); */
 
     /* get lists (if this works, then <lists> is nested <level> deep,      */
     /* checking it is nested <level>+1 deep is done by 'ElmListLevel')     */
@@ -3510,11 +3502,7 @@ void            IntrAssPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_POS_INTOBJ(pos) ) {
-        ErrorQuit(
-         "PosObj Assignment: <position> must be a positive small integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
-    }
+    RequirePositiveSmallInt("PosObj Assignment", pos, "position");
     p = INT_INTOBJ(pos);
 
     /* get the list (checking is done by 'ASS_LIST')                       */
@@ -3541,11 +3529,7 @@ void            IntrUnbPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_POS_INTOBJ(pos) ) {
-        ErrorQuit(
-         "PosObj Assignment: <position> must be a positive small integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
-    }
+    RequirePositiveSmallInt("PosObj Assignment", pos, "position");
     p = INT_INTOBJ(pos);
 
     /* get the list (checking is done by 'UNB_LIST')                       */
@@ -3578,11 +3562,7 @@ void            IntrElmPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_POS_INTOBJ(pos) ) {
-        ErrorQuit(
-            "PosObj Element: <position> must be a positive small integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
-    }
+    RequirePositiveSmallInt("PosObj Element", pos, "position");
     p = INT_INTOBJ( pos );
 
     /* get the list (checking is done by 'ELM_LIST')                       */
@@ -3610,11 +3590,7 @@ void            IntrIsbPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    if ( ! IS_POS_INTOBJ(pos) ) {
-        ErrorQuit(
-            "PosObj Element: <position> must be a positive small integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L );
-    }
+    RequirePositiveSmallInt("PosObj Element", pos, "position");
     p = INT_INTOBJ( pos );
 
     /* get the list (checking is done by 'ISB_LIST')                       */

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -293,12 +293,7 @@ Obj             FuncAPPEND_LIST_INTR (
 
     /* check the type of the first argument                                */
     if ( TNUM_OBJ( list1 ) != T_PLIST ) {
-        while ( ! IS_SMALL_LIST( list1 ) ) {
-            list1 = ErrorReturnObj(
-                "AppendList: <list1> must be a small list (not a %s)",
-                (Int)TNAM_OBJ(list1), 0L,
-                "you can replace <list1> via 'return <list1>;'" );
-        }
+        RequireSmallListMayReplace("AppendList", list1);
         if ( ! IS_PLIST( list1 ) ) {
             PLAIN_LIST( list1 );
         }
@@ -308,12 +303,7 @@ Obj             FuncAPPEND_LIST_INTR (
 
     /* check the type of the second argument                               */
     if ( ! IS_PLIST( list2 ) ) {
-        while ( ! IS_SMALL_LIST( list2 ) ) {
-            list2 = ErrorReturnObj(
-                "AppendList: <list2> must be a small list (not a %s)",
-                (Int)TNAM_OBJ(list2), 0L,
-                "you can replace <list2> via 'return <list2>;'"  );
-        }
+        RequireSmallListMayReplace("AppendList", list2);
         len2 = LEN_LIST( list2 );
     }
     else {
@@ -433,13 +423,7 @@ Obj             FuncPOSITION_SORTED_LIST (
     UInt                h;              /* position, result                */
 
     /* check the first argument                                            */
-    while ( ! IS_SMALL_LIST(list) ) {
-        list = ErrorReturnObj(
-            "POSITION_SORTED_LIST: <list> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(list), 0L,
-            "you can replace <list> via 'return <list>;'" );
-    }
-
+    RequireSmallListMayReplace("POSITION_SORTED_LIST", list);
     /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) ) {
         h = PositionSortedDensePlist( list, obj );
@@ -524,12 +508,7 @@ Obj             FuncPOSITION_SORTED_LIST_COMP (
     UInt                h;              /* position, result                */
 
     /* check the first argument                                            */
-    while ( ! IS_SMALL_LIST(list) ) {
-        list = ErrorReturnObj(
-            "POSITION_SORTED_LIST_COMP: <list> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(list), 0L,
-            "you can replace <list> via 'return <list>;'" );
-    }
+    RequireSmallListMayReplace("POSITION_SORTED_LIST_COMP", list);
 
     /* check the third argument                                            */
     while ( TNUM_OBJ( func ) != T_FUNCTION ) {
@@ -891,14 +870,6 @@ UInt            RemoveDupsDensePlist (
 **  Some common checks.
 */
 
-static void CheckIsSmallList( Obj list, const Char * caller)
-{
-  if ( ! IS_SMALL_LIST(list) ) {
-    ErrorMayQuit("%s: <list> must be a small list (not a %s)",
-                 (Int)caller, (Int)TNAM_OBJ(list));
-  }
-}
-
 static void CheckIsFunction(Obj func, const Char * caller)
 {
   if ( TNUM_OBJ( func ) != T_FUNCTION ) {
@@ -916,7 +887,7 @@ Obj FuncSORT_LIST (
     Obj                 list )
 {
     /* check the first argument                                            */
-    CheckIsSmallList(list, "SORT_LIST");
+    RequireSmallList("SORT_LIST", list);
 
     /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) ) {
@@ -936,7 +907,7 @@ Obj FuncSTABLE_SORT_LIST (
     Obj                 list )
 {
     /* check the first argument                                            */
-    CheckIsSmallList(list, "STABLE_SORT_LIST");
+    RequireSmallList("STABLE_SORT_LIST", list);
 
     /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) ) {
@@ -963,7 +934,7 @@ Obj FuncSORT_LIST_COMP (
     Obj                 func )
 {
     /* check the first argument                                            */
-    CheckIsSmallList(list, "SORT_LIST_COMP");
+    RequireSmallList("SORT_LIST_COMP", list);
 
     /* check the third argument                                            */
     CheckIsFunction(func, "SORT_LIST_COMP");
@@ -986,7 +957,7 @@ Obj FuncSTABLE_SORT_LIST_COMP (
     Obj                 func )
 {
     /* check the first argument                                            */
-    CheckIsSmallList(list, "STABLE_SORT_LIST_COMP");
+    RequireSmallList("STABLE_SORT_LIST_COMP", list);
 
     /* check the third argument                                            */
     CheckIsFunction(func, "STABLE_SORT_LIST_COMP");
@@ -1014,8 +985,8 @@ Obj FuncSORT_PARA_LIST (
     Obj               shadow )
 {
     /* check the first two arguments                                       */
-    CheckIsSmallList(list, "SORT_PARA_LIST");
-    CheckIsSmallList(shadow, "SORT_PARA_LIST");
+    RequireSmallList("SORT_PARA_LIST", list);
+    RequireSmallList("SORT_PARA_LIST", shadow);
     CheckSameLength("SORT_PARA_LIST", "list", "shadow", list, shadow);
 
     /* dispatch                                                            */
@@ -1037,8 +1008,8 @@ Obj FuncSTABLE_SORT_PARA_LIST (
     Obj               shadow )
 {
     /* check the first two arguments                                       */
-    CheckIsSmallList(list, "STABLE_SORT_PARA_LIST");
-    CheckIsSmallList(shadow, "STABLE_SORT_PARA_LIST");
+    RequireSmallList("STABLE_SORT_PARA_LIST", list);
+    RequireSmallList("STABLE_SORT_PARA_LIST", shadow);
     CheckSameLength("STABLE_SORT_PARA_LIST", "list", "shadow", list, shadow);
 
     /* dispatch                                                            */
@@ -1066,8 +1037,8 @@ Obj FuncSORT_PARA_LIST_COMP (
     Obj                 func )
 {
     /* check the first two arguments                                       */
-    CheckIsSmallList(list, "SORT_PARA_LIST_COMP");
-    CheckIsSmallList(shadow, "SORT_PARA_LIST_COMP");
+    RequireSmallList("SORT_PARA_LIST_COMP", list);
+    RequireSmallList("SORT_PARA_LIST_COMP", shadow);
     CheckSameLength("SORT_PARA_LIST_COMP", "list", "shadow", list, shadow);
 
     /* check the third argument                                            */
@@ -1092,8 +1063,8 @@ Obj FuncSTABLE_SORT_PARA_LIST_COMP (
     Obj                 func )
 {
     /* check the first two arguments                                       */
-    CheckIsSmallList(list, "SORT_PARA_LIST_COMP");
-    CheckIsSmallList(shadow, "SORT_PARA_LIST_COMP");
+    RequireSmallList("SORT_PARA_LIST_COMP", list);
+    RequireSmallList("SORT_PARA_LIST_COMP", shadow);
     CheckSameLength("SORT_PARA_LIST_COMP", "list", "shadow", list, shadow);
 
     /* check the third argument                                            */
@@ -1199,12 +1170,7 @@ Obj             FuncOnTuples (
     UInt                i;              /* loop variable                   */
 
     /* check the type of the first argument                                */
-    while ( ! IS_SMALL_LIST( tuple ) ) {
-        tuple = ErrorReturnObj(
-            "OnTuples: <tuple> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(tuple), 0L,
-            "you can replace <tuple> via 'return <tuple>;'" );
-    }
+    RequireSmallListMayReplace("OnTuples", tuple);
 
     /* special case for the empty list */
     if (LEN_LIST(tuple) == 0) {

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -87,7 +87,7 @@ void            AddPlist3 (
         list = ErrorReturnObj(
                 "List Assignment: <list> must be a mutable list",
                 0L, 0L,
-                "you may replace <list> via 'return <list>;'" );
+                "you can replace <list> via 'return <list>;'" );
         FuncADD_LIST( 0, list, obj );
         return;
     }
@@ -182,7 +182,7 @@ Obj            RemList (
         list = ErrorReturnObj(
                 "Remove: <list> must not be empty",
                 0L, 0L,
-                "you may replace <list> via 'return <list>;'" );
+                "you can replace <list> via 'return <list>;'" );
         return RemList(list);
     }
     result = ELM_LIST(list, pos);
@@ -203,7 +203,7 @@ static Obj RemPlist(Obj list)
         list = ErrorReturnObj(
                 "Remove: <list> must be a mutable list",
                 0L, 0L,
-                "you may replace <list> via 'return <list>;'" );
+                "you can replace <list> via 'return <list>;'" );
         return FuncREM_LIST( 0, list);
     }
     pos = LEN_PLIST( list );
@@ -211,7 +211,7 @@ static Obj RemPlist(Obj list)
         list = ErrorReturnObj(
                 "Remove: <list> must not be empty",
                 0L, 0L,
-                "you may replace <list> via 'return <list>;'" );
+                "you can replace <list> via 'return <list>;'" );
         return FuncREM_LIST( 0, list);
     }
     removed = ELM_PLIST(list, pos);

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -511,12 +511,7 @@ Obj             FuncPOSITION_SORTED_LIST_COMP (
     RequireSmallListMayReplace("POSITION_SORTED_LIST_COMP", list);
 
     /* check the third argument                                            */
-    while ( TNUM_OBJ( func ) != T_FUNCTION ) {
-        func = ErrorReturnObj(
-            "POSITION_SORTED_LIST_COMP: <func> must be a function (not a %s)",
-            (Int)TNAM_OBJ(func), 0L,
-            "you can replace <func> via 'return <func>;'" );
-    }
+    RequireFunctionMayReplace("POSITION_SORTED_LIST_COMP", func);
 
     /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) ) {
@@ -867,19 +862,6 @@ UInt            RemoveDupsDensePlist (
 
 /****************************************************************************
 **
-**  Some common checks.
-*/
-
-static void CheckIsFunction(Obj func, const Char * caller)
-{
-  if ( TNUM_OBJ( func ) != T_FUNCTION ) {
-    ErrorMayQuit("%s: <func> must be a function (not a %s)",
-          (Int)caller, (Int)TNAM_OBJ(func));
-  }
-}
-
-/****************************************************************************
-**
 *F  FuncSORT_LIST( <self>, <list> ) . . . . . . . . . . . . . . . sort a list
 */
 Obj FuncSORT_LIST (
@@ -937,7 +919,7 @@ Obj FuncSORT_LIST_COMP (
     RequireSmallList("SORT_LIST_COMP", list);
 
     /* check the third argument                                            */
-    CheckIsFunction(func, "SORT_LIST_COMP");
+    RequireFunction("SORT_LIST_COMP", func);
 
     /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) ) {
@@ -960,7 +942,7 @@ Obj FuncSTABLE_SORT_LIST_COMP (
     RequireSmallList("STABLE_SORT_LIST_COMP", list);
 
     /* check the third argument                                            */
-    CheckIsFunction(func, "STABLE_SORT_LIST_COMP");
+    RequireFunction("STABLE_SORT_LIST_COMP", func);
 
     /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) ) {
@@ -1042,7 +1024,7 @@ Obj FuncSORT_PARA_LIST_COMP (
     CheckSameLength("SORT_PARA_LIST_COMP", "list", "shadow", list, shadow);
 
     /* check the third argument                                            */
-    CheckIsFunction(func, "SORT_PARA_LIST_COMP");
+    RequireFunction("SORT_PARA_LIST_COMP", func);
     
     /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) && IS_DENSE_PLIST(shadow) ) {
@@ -1068,7 +1050,7 @@ Obj FuncSTABLE_SORT_PARA_LIST_COMP (
     CheckSameLength("SORT_PARA_LIST_COMP", "list", "shadow", list, shadow);
 
     /* check the third argument                                            */
-    CheckIsFunction(func, "SORT_PARA_LIST_COMP");
+    RequireFunction("SORT_PARA_LIST_COMP", func);
     
     /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) && IS_DENSE_PLIST(shadow) ) {

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -2363,12 +2363,7 @@ Obj Array2Perm (
     /* loop over the cycles                                                */
     for ( i = 1; i <= LEN_LIST(array); i++ ) {
         cycle = ELM_LIST( array, i );
-        while ( ! IS_SMALL_LIST(cycle) ) {
-            cycle = ErrorReturnObj(
-                "Array2Perm: <cycle> must be a small list (not a %s)",
-                (Int)TNAM_OBJ(cycle), 0L,
-                "you can replace <cycle> via 'return <cycle>;'" );
-        }
+        RequireSmallListMayReplace("Array2Perm", cycle);
 
         /* loop over the entries of the cycle                              */
         c = p = l = 0;

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -1331,12 +1331,7 @@ Obj             FuncCYCLE_PERM_INT (
             (Int)TNAM_OBJ(perm), 0L,
             "you can replace <perm> via 'return <perm>;'" );
     }
-    while (!IS_POS_INTOBJ(point)) {
-        point = ErrorReturnObj(
-            "CyclePermInt: <point> must be a positive small integer (not a %s)",
-            (Int)TNAM_OBJ(point), 0L,
-            "you can replace <point> via 'return <point>;'" );
-    }
+    RequirePositiveSmallInt("CyclePermInt", point, "point");
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
         return CYCLE_PERM_INT<UInt2>(perm, point);
@@ -2381,12 +2376,7 @@ Obj Array2Perm (
 
             /* get and check current entry for the cycle                   */
             val = ELM_LIST( cycle, j );
-            while (!IS_POS_INTOBJ(val)) {
-                val = ErrorReturnObj(
-              "Permutation: <expr> must be a positive small integer (not a %s)",
-                    (Int)TNAM_OBJ(val), 0L,
-                    "you can replace <expr> via 'return <expr>;'" );
-            }
+            RequirePositiveSmallIntMayReplace("Permutation", val, "expr");
             c = INT_INTOBJ(val);
             if (c > MAX_DEG_PERM4)
               ErrorMayQuit( "Permutation literal exceeds maximum permutation degree",

--- a/src/plist.c
+++ b/src/plist.c
@@ -2556,12 +2556,7 @@ Obj FuncASS_PLIST_DEFAULT (
     Int                 p;
 
     /* check the arguments                                                 */
-    while ( ! IS_POS_INTOBJ(pos) ) {
-        pos = ErrorReturnObj(
-            "<pos> must be a positive small integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0,
-            "you can replace <pos> via 'return <pos>;'" );
-    }
+    RequirePositiveSmallIntMayReplace("List Assignment", pos, "pos");
     p = INT_INTOBJ(pos);
     while ( ! IS_PLIST(plist) || ! IS_PLIST_MUTABLE(plist) ) {
         plist = ErrorReturnObj(

--- a/src/set.c
+++ b/src/set.c
@@ -199,12 +199,7 @@ Obj FuncLIST_SORTED_LIST (
     Obj                 set;            /* result                          */
 
     /* check the argument                                                  */
-    while ( ! IS_SMALL_LIST( list ) ) {
-        list = ErrorReturnObj(
-            "Set: <list> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(list), 0L,
-            "you can replace <list> via 'return <list>;'" );
-    }
+    RequireSmallListMayReplace("Set", list);
 
     /* if the list is empty create a new empty list                        */
     if ( LEN_LIST(list) == 0 ) {
@@ -275,19 +270,9 @@ Obj             FuncIS_EQUAL_SET (
     Obj                 list2 )
 {
     /* check the arguments, convert to sets if necessary                   */
-    while ( ! IS_SMALL_LIST(list1) ) {
-        list1 = ErrorReturnObj(
-            "IsEqualSet: <list1> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(list1), 0L,
-            "you can replace <list1> via 'return <list1>;'" );
-    }
+    RequireSmallListMayReplace("IsEqualSet", list1);
     if ( ! IsSet( list1 ) )  list1 = SetList( list1 );
-    while ( ! IS_SMALL_LIST(list2) ) {
-        list2 = ErrorReturnObj(
-            "IsEqualSet: <list2> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(list2), 0L,
-            "you can replace <list2> via 'return <list2>;'" );
-    }
+    RequireSmallListMayReplace("IsEqualSet", list2);
     if ( ! IsSet( list2 ) )  list2 = SetList( list2 );
 
     /* and now compare them                                                */
@@ -322,18 +307,8 @@ Obj             FuncIS_SUBSET_SET (
     UInt                pos;            /* position                        */
 
     /* check the arguments, convert to sets if necessary                   */
-    while ( ! IS_SMALL_LIST(set1) ) {
-        set1 = ErrorReturnObj(
-            "IsSubsetSet: <set1> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(set1), 0L,
-            "you can replace <set1> via 'return <set1>;'" );
-    }
-    while ( ! IS_SMALL_LIST(set2) ) {
-        set2 = ErrorReturnObj(
-            "IsSubsetSet: <set2> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(set2), 0L,
-            "you can replace <set2> via 'return <set2>;'" );
-    }
+    RequireSmallListMayReplace("IsSubsetSet", set1);
+    RequireSmallListMayReplace("IsSubsetSet", set2);
     if ( ! IsSet( set1 ) )  set1 = SetList( set1 );
     if ( ! IsSet( set2 ) )  set2 = SetList( set2 );
 
@@ -631,12 +606,7 @@ Obj FuncUNITE_SET (
             (Int)TNAM_OBJ(set1), 0L,
             "you can replace <set1> via 'return <set1>;'" );
     }
-    while ( ! IS_SMALL_LIST(set2) ) {
-        set2 = ErrorReturnObj(
-            "UniteSet: <set2> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(set2), 0L,
-            "you can replace <set2> via 'return <set2>;'" );
-    }
+    RequireSmallListMayReplace("UniteSet", set2);
     if ( ! IsSet(set2) )  set2 = SetList(set2);
 
     /* get the logical lengths and the pointer                             */
@@ -809,12 +779,7 @@ Obj FuncINTER_SET (
             (Int)TNAM_OBJ(set1), 0L,
             "you can replace <set1> via 'return <set1>;'" );
     }
-    while ( ! IS_SMALL_LIST(set2) ) {
-        set2 = ErrorReturnObj(
-            "IntersectSet: <set2> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(set2), 0L,
-            "you can replace <set2> via 'return <set2>;'" );
-    }
+    RequireSmallListMayReplace("IntersectSet", set2);
     if ( ! IsSet(set2) )  set2 = SetList(set2);
 
     /* get the logical lengths and the pointer                             */
@@ -987,12 +952,7 @@ Obj FuncSUBTR_SET (
             (Int)TNAM_OBJ(set1), 0L,
             "you can replace <set1> via 'return <set1>;'" );
     }
-    while ( ! IS_SMALL_LIST(set2) ) {
-        set2 = ErrorReturnObj(
-            "SubtractSet: <set2> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(set2), 0L,
-            "you can replace <set2> via 'return <set2>;'" );
-    }
+    RequireSmallListMayReplace("SubtractSet", set2);
     if ( ! IsSet(set2) )  set2 = SetList(set2);
 
     /* get the logical lengths and the pointer                             */

--- a/src/streams.c
+++ b/src/streams.c
@@ -2131,12 +2131,7 @@ Obj FuncExecuteProcess (
             (Int)TNAM_OBJ(out), 0L,
             "you can replace <out> via 'return <out>;'" );
     }
-    while ( ! IS_SMALL_LIST(args) ) {
-        args = ErrorReturnObj(
-            "<args> must be a small list (not a %s)",
-            (Int)TNAM_OBJ(args), 0L,
-            "you can replace <args> via 'return <args>;'" );
-    }
+    RequireSmallListMayReplace("ExecuteProcess", args);
 
     /* create an argument array                                            */
     for ( i = 1;  i <= LEN_LIST(args);  i++ ) {

--- a/src/streams.c
+++ b/src/streams.c
@@ -2109,25 +2109,25 @@ Obj FuncExecuteProcess (
     /* check the argument                                                  */
     while ( ! IsStringConv(dir) ) {
         dir = ErrorReturnObj(
-            "<dir> must be a string (not a %s)",
+            "ExecuteProcess: <dir> must be a string (not a %s)",
             (Int)TNAM_OBJ(dir), 0L,
             "you can replace <dir> via 'return <dir>;'" );
     }
     while ( ! IsStringConv(prg) ) {
         prg = ErrorReturnObj(
-            "<prg> must be a string (not a %s)",
+            "ExecuteProcess: <prg> must be a string (not a %s)",
             (Int)TNAM_OBJ(prg), 0L,
             "you can replace <prg> via 'return <prg>;'" );
     }
     while ( ! IS_INTOBJ(in) ) {
         in = ErrorReturnObj(
-            "<in> must be an integer (not a %s)",
+            "ExecuteProcess: <in> must be an integer (not a %s)",
             (Int)TNAM_OBJ(in), 0L,
             "you can replace <in> via 'return <in>;'" );
     }
     while ( ! IS_INTOBJ(out) ) {
         out = ErrorReturnObj(
-            "<out> must be an integer (not a %s)",
+            "ExecuteProcess: <out> must be an integer (not a %s)",
             (Int)TNAM_OBJ(out), 0L,
             "you can replace <out> via 'return <out>;'" );
     }

--- a/src/trans.c
+++ b/src/trans.c
@@ -3237,7 +3237,7 @@ Obj FuncCYCLES_TRANS_LIST(Obj self, Obj f, Obj list)
         ptf2 = CONST_ADDR_TRANS2(f);
         for (i = 1; i <= (UInt)LEN_LIST(list); i++) {
             list_i = ELM_LIST(list, i);
-            if (!IS_INTOBJ(list_i) || INT_INTOBJ(list_i) < 1) {
+            if (!IS_POS_INTOBJ(list_i)) {
                 ErrorQuit("CYCLES_TRANS_LIST: the second argument must be a "
                           "list of positive integer (not a %s)",
                           (Int)TNAM_OBJ(list_i), 0L);
@@ -3284,9 +3284,9 @@ Obj FuncCYCLES_TRANS_LIST(Obj self, Obj f, Obj list)
         ptf4 = CONST_ADDR_TRANS4(f);
         for (i = 1; i <= (UInt)LEN_LIST(list); i++) {
             list_i = ELM_LIST(list, i);
-            if (!IS_INTOBJ(list_i) || INT_INTOBJ(list_i) < 1) {
+            if (!IS_POS_INTOBJ(list_i)) {
                 ErrorQuit("CYCLES_TRANS_LIST: the second argument must be a "
-                          "positive integer (not a %s)",
+                          "list of positive integers (not a %s)",
                           (Int)TNAM_OBJ(list_i), 0L);
             }
             j = INT_INTOBJ(list_i) - 1;

--- a/src/trans.c
+++ b/src/trans.c
@@ -1054,12 +1054,8 @@ Obj FuncPREIMAGES_TRANS_INT(Obj self, Obj f, Obj pt)
     UInt deg, nr, i, j;
     Obj  out;
 
-    if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
-        ErrorQuit("PREIMAGES_TRANS_INT: the second argument must be a "
-                  "positive integer",
-                  0L, 0L);
-    }
-    else if (!IS_TRANS(f)) {
+    RequirePositiveSmallInt("PREIMAGES_TRANS_INT", pt, "pt");
+    if (!IS_TRANS(f)) {
         ErrorQuit("PREIMAGES_TRANS_INT: the first argument must be a "
                   "transformation (not a %s)",
                   (Int)TNAM_OBJ(f), 0L);
@@ -2999,11 +2995,7 @@ Obj FuncCOMPONENT_TRANS_INT(Obj self, Obj f, Obj pt)
                   "transformation (not a %s)",
                   (Int)TNAM_OBJ(f), 0L);
     }
-    else if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
-        ErrorQuit("COMPONENT_TRANS_INT: the second argument must be a "
-                  "positive integer (not a %s)",
-                  (Int)TNAM_OBJ(pt), 0L);
-    }
+    RequirePositiveSmallInt("COMPONENT_TRANS_INT", pt, "pt");
 
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
     cpt = INT_INTOBJ(pt) - 1;
@@ -3062,11 +3054,7 @@ Obj FuncCYCLE_TRANS_INT(Obj self, Obj f, Obj pt)
                   "transformation (not a %s)",
                   (Int)TNAM_OBJ(f), 0L);
     }
-    else if (!IS_INTOBJ(pt) || INT_INTOBJ(pt) < 1) {
-        ErrorQuit("CYCLE_TRANS_INT: the second argument must be a "
-                  "positive integer (not a %s)",
-                  (Int)TNAM_OBJ(pt), 0L);
-    }
+    RequirePositiveSmallInt("CYCLE_TRANS_INT", pt, "pt");
 
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
     cpt = INT_INTOBJ(pt) - 1;
@@ -5173,13 +5161,9 @@ Obj PowIntTrans2(Obj i, Obj f)
         return i;
     }
 
-    img = INT_INTOBJ(i);
+    RequirePositiveSmallInt("Tran. Operations", i, "point");
 
-    if (img <= 0) {
-        ErrorQuit("Tran. Operations: <point> must be a positive integer "
-                  "(not %d)",
-                  (Int)img, 0L);
-    }
+    img = INT_INTOBJ(i);
 
     if ((UInt)img <= DEG_TRANS2(f)) {
         img = (CONST_ADDR_TRANS2(f))[img - 1] + 1;
@@ -5196,13 +5180,9 @@ Obj PowIntTrans4(Obj i, Obj f)
         return i;
     }
 
-    img = INT_INTOBJ(i);
+    RequirePositiveSmallInt("Tran. Operations", i, "point");
 
-    if (img <= 0) {
-        ErrorQuit(
-            "Tran. Operations: <point> must be a positive integer (not %d)",
-            (Int)img, 0L);
-    }
+    img = INT_INTOBJ(i);
 
     if ((UInt)img <= DEG_TRANS4(f)) {
         img = (CONST_ADDR_TRANS4(f))[img - 1] + 1;

--- a/src/vars.c
+++ b/src/vars.c
@@ -1549,12 +1549,7 @@ UInt            ExecAssPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_STAT(stat, 1));
-    while ( ! IS_POS_INTOBJ(pos) ) {
-        pos = ErrorReturnObj(
-         "PosObj Assignment: <position> must be a positive small integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L,
-            "you can replace <position> via 'return <position>;'" );
-    }
+    RequirePositiveSmallIntMayReplace("PosObj Assignment", pos, "position");
     p = INT_INTOBJ(pos);
 
     /* evaluate the right hand side                                        */
@@ -1587,12 +1582,7 @@ UInt            ExecUnbPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_STAT(stat, 1));
-    while ( ! IS_POS_INTOBJ(pos) ) {
-        pos = ErrorReturnObj(
-         "PosObj Assignment: <position> must be a positive small integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L,
-            "you can replace <position> via 'return <position>;'" );
-    }
+    RequirePositiveSmallIntMayReplace("PosObj Assignment", pos, "position");
     p = INT_INTOBJ(pos);
 
     /* unbind the element                                                  */
@@ -1623,12 +1613,7 @@ Obj             EvalElmPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
-    while ( ! IS_POS_INTOBJ(pos) ) {
-        pos = ErrorReturnObj(
-            "PosObj Element: <position> must be a positive small integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L,
-            "you can replace <position> via 'return <position>;'" );
-    }
+    RequirePositiveSmallIntMayReplace("PosObj Element", pos, "position");
     p = INT_INTOBJ( pos );
 
     /* special case for plain lists (use generic code to signal errors)    */
@@ -1659,12 +1644,7 @@ Obj             EvalIsbPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
-    while ( ! IS_POS_INTOBJ(pos) ) {
-        pos = ErrorReturnObj(
-            "PosObj Element: <position> must be a positive small integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L,
-            "you can replace <position> via 'return <position>;'" );
-    }
+    RequirePositiveSmallIntMayReplace("PosObj Element", pos, "position");
     p = INT_INTOBJ( pos );
 
     /* get the result                                                      */

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -812,14 +812,8 @@ Obj FuncCONV_VEC8BIT (
     Obj                 list,
     Obj                 q)
 {
-    if (!IS_INTOBJ(q)) {
-        ErrorMayQuit("CONV_VEC8BIT: q must be a small integer (3--256) not a %s",
-        (Int)TNAM_OBJ(q), 0);
-    }
-
+    RequirePositiveSmallInt("CONV_VEC8BIT", q, "q");
     ConvVec8Bit(list, INT_INTOBJ(q));
-
-    /* return nothing                                                      */
     return 0;
 }
 
@@ -952,15 +946,8 @@ Obj FuncCOPY_VEC8BIT (
     Obj                 list,
     Obj                 q)
 {
-  if (!IS_INTOBJ(q))
-    {
-      ErrorMayQuit("CONV_VEC8BIT: q must be a small integer (3--256) not a %s",
-		   (Int)TNAM_OBJ(q), 0);
-    }
-    
-  list = NewVec8Bit(list, INT_INTOBJ(q));
-  
-  return list;
+    RequirePositiveSmallInt("COPY_VEC8BIT", q, "q");
+    return NewVec8Bit(list, INT_INTOBJ(q));
 }
 
 /****************************************************************************
@@ -2732,9 +2719,7 @@ Obj FuncELM0_VEC8BIT (
     Obj     info;
     UInt elts;
 
-    if (!IS_INTOBJ(pos))
-        ErrorQuit("ELM0_VEC8BIT: position must be a small integer, not a %s",
-                  (Int)TNAM_OBJ(pos), 0L);
+    RequirePositiveSmallInt("ELM0_VEC8BIT", pos, "position");
     p = INT_INTOBJ(pos);
     if (LEN_VEC8BIT(list) < p) {
         return Fail;
@@ -2765,9 +2750,7 @@ Obj FuncELM_VEC8BIT (
     Obj     info;
     UInt elts;
 
-    if (!IS_INTOBJ(pos))
-        ErrorQuit("ELM0_VEC8BIT: position must be a small integer, not a %s",
-                  (Int)TNAM_OBJ(pos), 0L);
+    RequirePositiveSmallInt("ELM_VEC8BIT", pos, "position");
     p = INT_INTOBJ(pos);
     if (LEN_VEC8BIT(list) < p) {
         ErrorReturnVoid(
@@ -2984,12 +2967,8 @@ Obj FuncASS_VEC8BIT (
     }
 
     /* get the position                                                    */
-    if (!IS_INTOBJ(pos))
-        ErrorQuit("ASS_VEC8BIT: position should be a small integer, not a %s",
-                  (Int)TNAM_OBJ(pos), 0L);
+    RequirePositiveSmallInt("ASS_VEC8BIT", pos, "position");
     p = INT_INTOBJ(pos);
-    if (p <= 0)
-        ErrorQuit("ASS_VEC8BIT: position must be positive", 0L, 0L);
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     chr = P_FIELDINFO_8BIT(info);
@@ -3099,12 +3078,8 @@ Obj FuncUNB_VEC8BIT (
     }
 
     /* get the position                                                    */
-    if (!IS_INTOBJ(pos))
-        ErrorQuit("UNB_VEC8BIT: position should be a small integer, not a %s",
-        (Int)TNAM_OBJ(pos), 0L);
+    RequirePositiveSmallInt("UNB_VEC8BIT", pos, "position");
     p = INT_INTOBJ(pos);
-    if (p <= 0)
-        ErrorQuit("UNB_VEC8BIT: position must be positive", 0L, 0L);
 
     /* if we unbind the last position keep the representation              */
     if (LEN_VEC8BIT(list) < p) {
@@ -3402,9 +3377,7 @@ Obj FuncCONV_MAT8BIT( Obj self, Obj list, Obj q )
     Obj tmp;
     Obj type;
 
-    if (!IS_INTOBJ(q))
-        ErrorQuit("CONV_MAT8BIT: q must be a small integer, not a %s",
-        (Int)TNAM_OBJ(q), (Int)0L);
+    RequirePositiveSmallInt("CONV_MAT8BIT", q, "q");
     PLAIN_LIST(list);
     len = LEN_PLIST(list);
     mut = IS_MUTABLE_OBJ(list);
@@ -3898,12 +3871,8 @@ Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj p, Obj obj)
     UInt pos;
     Obj type;
 
-    if (!IS_INTOBJ(p))
-        ErrorQuit("ASS_MAT8BIT: position should be a small integer, not a %s",
-                  (Int)TNAM_OBJ(p), 0L);
+    RequirePositiveSmallInt("ASS_MAT8BIT", p, "position");
     pos = INT_INTOBJ(p);
-    if (pos <= 0)
-        ErrorQuit("ASS_MAT8BIT: position must be positive", 0L, 0L);
 
     len = LEN_MAT8BIT(mat);
     if (!IS_VEC8BIT_REP(obj) && !IS_GF2VEC_REP(obj))
@@ -3991,10 +3960,7 @@ cantdo:
 */
 Obj FuncELM_MAT8BIT( Obj self, Obj mat, Obj row )
 {
-    if (!IS_POS_INTOBJ(row)) {
-        ErrorMayQuit("ELM_MAT8BIT: position must be a small integer, not a %s",
-                     (Int)TNAM_OBJ(row), 0L);
-    }
+    RequirePositiveSmallInt("ELM_MAT8BIT", row, "position");
     UInt r = INT_INTOBJ(row);
     if (LEN_MAT8BIT(mat) < r) {
         ErrorMayQuit("row index %d exceeds %d, the number of rows", r, LEN_MAT8BIT(mat));
@@ -5837,7 +5803,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(AINV_VEC8BIT_IMMUTABLE, 1, "gfqvec"),
     GVAR_FUNC(AINV_VEC8BIT_SAME_MUTABILITY, 1, "gfqvec"),
     GVAR_FUNC(ZERO_VEC8BIT, 1, "gfqvec"),
-    GVAR_FUNC(ZERO_VEC8BIT_2, 2, "q,len"),
+    GVAR_FUNC(ZERO_VEC8BIT_2, 2, "q, len"),
     GVAR_FUNC(EQ_VEC8BIT_VEC8BIT, 2, "gfqvecl, gfqvecr"),
     GVAR_FUNC(LT_VEC8BIT_VEC8BIT, 2, "gfqvecl, gfqvecr"),
     GVAR_FUNC(PROD_VEC8BIT_VEC8BIT, 2, "gfqvecl, gfqvecr"),

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -44,6 +44,11 @@
 #include "julia.h"
 #endif
 
+#define RequireWPObj(funcname, op) \
+    RequireArgumentCondition(funcname, op, #op, TNUM_OBJ(op) == T_WPOBJ, \
+        "must be a weak pointer object")
+
+
 /****************************************************************************
 **
 *F
@@ -301,12 +306,8 @@ Int LengthWPObj(Obj wp)
 
 Obj FuncLengthWPObj(Obj self, Obj wp)
 {
-  if (TNUM_OBJ(wp) != T_WPOBJ)
-    {
-      ErrorMayQuit("LengthWPObj: argument must be a weak pointer object, not a %s",
-                   (Int)TNAM_OBJ(wp), 0);
-    }
-  return INTOBJ_INT(LengthWPObj(wp));
+    RequireWPObj("LengthWPObj", wp);
+    return INTOBJ_INT(LengthWPObj(wp));
 }
 
 
@@ -320,19 +321,9 @@ Obj FuncLengthWPObj(Obj self, Obj wp)
 
 Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 {
-  if (TNUM_OBJ(wp) != T_WPOBJ)
-    {
-      ErrorMayQuit("SetElmWPObj: First argument must be a weak pointer object, not a %s",
-                   (Int)TNAM_OBJ(wp), 0);
-    }
-
-  if (!IS_POS_INTOBJ(pos))
-    {
-      ErrorMayQuit("SetElmWPObj: Position must be a positive small integer, not a %s",
-                (Int)TNAM_OBJ(pos),0L);
-    }
-
-  UInt ipos = INT_INTOBJ(pos);
+    RequireWPObj("SetElmWPObj", wp);
+    RequirePositiveSmallInt("SetElmWPObj", pos, "pos");
+    UInt ipos = INT_INTOBJ(pos);
 
 #ifdef USE_BOEHM_GC
   /* Ensure reference remains visible to GC in case val is
@@ -375,19 +366,9 @@ Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 
 Int IsBoundElmWPObj( Obj wp, Obj pos)
 {
-  if (TNUM_OBJ(wp) != T_WPOBJ)
-    {
-      ErrorMayQuit("IsBoundElmWPObj: First argument must be a weak pointer object, not a %s",
-                   (Int)TNAM_OBJ(wp), 0);
-    }
-
-  if (!IS_POS_INTOBJ(pos))
-    {
-      ErrorMayQuit("IsBoundElmWPObj: Position must be a positive small integer, not a %s",
-                (Int)TNAM_OBJ(pos),0L);
-    }
-
-  UInt ipos = INT_INTOBJ(pos);
+    RequireWPObj("IsBoundElmWPObj", wp);
+    RequirePositiveSmallInt("IsBoundElmWPObj", pos, "pos");
+    UInt ipos = INT_INTOBJ(pos);
 
 #ifdef HPCGAP
   volatile
@@ -431,19 +412,9 @@ Obj FuncIsBoundElmWPObj( Obj self, Obj wp, Obj pos)
 
 Obj FuncUnbindElmWPObj( Obj self, Obj wp, Obj pos)
 {
-  if (TNUM_OBJ(wp) != T_WPOBJ)
-    {
-      ErrorMayQuit("UnbindElmWPObj: First argument must be a weak pointer object, not a %s",
-                   (Int)TNAM_OBJ(wp), 0);
-    }
-
-  if (!IS_POS_INTOBJ(pos))
-    {
-      ErrorMayQuit("UnbindElmWPObj: Position must be a positive small integer, not a %s",
-                (Int)TNAM_OBJ(pos),0L);
-    }
-
-  UInt ipos = INT_INTOBJ(pos);
+    RequireWPObj("UnbindElmWPObj", wp);
+    RequirePositiveSmallInt("UnbindElmWPObj", pos, "pos");
+    UInt ipos = INT_INTOBJ(pos);
 
   Int len = LengthWPObj(wp);
   if ( ipos <= len ) {
@@ -518,17 +489,8 @@ Obj ElmDefWPList(Obj wp, Int ipos, Obj def)
 */
 Obj FuncElmWPObj(Obj self, Obj wp, Obj pos)
 {
-    if (TNUM_OBJ(wp) != T_WPOBJ) {
-        ErrorMayQuit("ElmWPObj: First argument must be a weak pointer "
-                     "object, not a %s",
-                     (Int)TNAM_OBJ(wp), 0);
-    }
-
-    if (!IS_POS_INTOBJ(pos)) {
-        ErrorMayQuit("ElmWPObj: Position must be a positive small integer, not a %s",
-                     (Int)TNAM_OBJ(pos), 0L);
-    }
-
+    RequireWPObj("ElmWPObj", wp);
+    RequirePositiveSmallInt("ElmWPObj", pos, "pos");
     Int ipos = INT_INTOBJ(pos);
 
     return ElmDefWPList(wp, ipos, Fail);

--- a/tst/testinstall/callfunc.tst
+++ b/tst/testinstall/callfunc.tst
@@ -2,9 +2,9 @@ gap> START_TEST("callfunc.tst");
 
 #
 gap> CallFuncList(1,2);
-Error, CallFuncList: <list> must be a small list
+Error, CallFuncList: <list> must be a small list (not a integer)
 gap> CallFuncListWrap(1,2);
-Error, CallFuncListWrap: <list> must be a small list
+Error, CallFuncListWrap: <list> must be a small list (not a integer)
 
 #
 gap> ForAll([0,2..100], x -> [1..x] = CallFuncList(Union, List([1..x], y -> [y]) ) );

--- a/tst/testinstall/kernel/calls.tst
+++ b/tst/testinstall/kernel/calls.tst
@@ -79,36 +79,36 @@ Error, no 1st choice method found for `PROF_FUNC' on 1 arguments
 gap> PROF_FUNC(x->x);
 [ 0, 0, 0, 0, 0 ]
 gap> CLEAR_PROFILE_FUNC(fail);
-Error, <func> must be a function
+Error, CLEAR_PROFILE_FUNC: <func> must be a function (not a boolean or fail)
 gap> PROFILE_FUNC(fail);
-Error, <func> must be a function
+Error, PROFILE_FUNC: <func> must be a function (not a boolean or fail)
 gap> IS_PROFILED_FUNC(fail);
-Error, <func> must be a function
+Error, IS_PROFILED_FUNC: <func> must be a function (not a boolean or fail)
 gap> IS_PROFILED_FUNC(x->x);
 false
 
 #
 gap> f:=x->x;;
 gap> FILENAME_FUNC(fail);
-Error, <func> must be a function
+Error, FILENAME_FUNC: <func> must be a function (not a boolean or fail)
 gap> FILENAME_FUNC(f);
 "stream"
 gap> FILENAME_FUNC(IS_OBJECT);
 fail
 gap> STARTLINE_FUNC(fail);
-Error, <func> must be a function
+Error, STARTLINE_FUNC: <func> must be a function (not a boolean or fail)
 gap> STARTLINE_FUNC(f);
 1
 gap> STARTLINE_FUNC(IS_OBJECT);
 fail
 gap> ENDLINE_FUNC(fail);
-Error, <func> must be a function
+Error, ENDLINE_FUNC: <func> must be a function (not a boolean or fail)
 gap> ENDLINE_FUNC(f);
 1
 gap> ENDLINE_FUNC(IS_OBJECT);
 fail
 gap> LOCATION_FUNC(fail);
-Error, <func> must be a function
+Error, LOCATION_FUNC: <func> must be a function (not a boolean or fail)
 gap> LOCATION_FUNC(f);
 fail
 gap> LOCATION_FUNC(IS_OBJECT);
@@ -116,7 +116,7 @@ fail
 
 #
 gap> UNPROFILE_FUNC(fail);
-Error, <func> must be a function
+Error, UNPROFILE_FUNC: <func> must be a function (not a boolean or fail)
 gap> UNPROFILE_FUNC(x->x);
 
 #

--- a/tst/testinstall/kernel/listfunc.tst
+++ b/tst/testinstall/kernel/listfunc.tst
@@ -72,7 +72,7 @@ Error, STABLE_SORT_LIST_COMP: <func> must be a function (not a boolean or fail\
 gap> SORT_PARA_LIST(fail, fail);
 Error, SORT_PARA_LIST: <list> must be a small list (not a boolean or fail)
 gap> SORT_PARA_LIST([], fail);
-Error, SORT_PARA_LIST: <list> must be a small list (not a boolean or fail)
+Error, SORT_PARA_LIST: <shadow> must be a small list (not a boolean or fail)
 gap> SORT_PARA_LIST([], [1]);
 Error, SORT_PARA_LIST: <list> must have the same length as <shadow> (not 0 and\
  1)
@@ -82,8 +82,8 @@ gap> STABLE_SORT_PARA_LIST(fail, fail);
 Error, STABLE_SORT_PARA_LIST: <list> must be a small list (not a boolean or fa\
 il)
 gap> STABLE_SORT_PARA_LIST([], fail);
-Error, STABLE_SORT_PARA_LIST: <list> must be a small list (not a boolean or fa\
-il)
+Error, STABLE_SORT_PARA_LIST: <shadow> must be a small list (not a boolean or \
+fail)
 gap> STABLE_SORT_PARA_LIST([], [1]);
 Error, STABLE_SORT_PARA_LIST: <list> must have the same length as <shadow> (no\
 t 0 and 1)

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -135,7 +135,7 @@ Error, <in> must be an integer (not a boolean or fail)
 gap> ExecuteProcess("","",0,fail,fail);
 Error, <out> must be an integer (not a boolean or fail)
 gap> ExecuteProcess("","",0,0,fail);
-Error, <args> must be a small list (not a boolean or fail)
+Error, ExecuteProcess: <args> must be a small list (not a boolean or fail)
 gap> ExecuteProcess("","",0,0,[1]);
 Error, <tmp> must be a string (not a integer)
 

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -127,13 +127,13 @@ Error, <fid> must be a small integer (not a boolean or fail)
 
 #
 gap> ExecuteProcess(fail,fail,fail,fail,fail);
-Error, <dir> must be a string (not a boolean or fail)
+Error, ExecuteProcess: <dir> must be a string (not a boolean or fail)
 gap> ExecuteProcess("",fail,fail,fail,fail);
-Error, <prg> must be a string (not a boolean or fail)
+Error, ExecuteProcess: <prg> must be a string (not a boolean or fail)
 gap> ExecuteProcess("","",fail,fail,fail);
-Error, <in> must be an integer (not a boolean or fail)
+Error, ExecuteProcess: <in> must be an integer (not a boolean or fail)
 gap> ExecuteProcess("","",0,fail,fail);
-Error, <out> must be an integer (not a boolean or fail)
+Error, ExecuteProcess: <out> must be an integer (not a boolean or fail)
 gap> ExecuteProcess("","",0,0,fail);
 Error, ExecuteProcess: <args> must be a small list (not a boolean or fail)
 gap> ExecuteProcess("","",0,0,[1]);

--- a/tst/testinstall/trans.tst
+++ b/tst/testinstall/trans.tst
@@ -468,11 +468,14 @@ true
 
 # Test PREIMAGES_TRANS_INT
 gap> PREIMAGES_TRANS_INT(IdentityTransformation, 0);
-Error, PREIMAGES_TRANS_INT: the second argument must be a positive integer
+Error, PREIMAGES_TRANS_INT: <pt> must be a positive small integer (not a integ\
+er)
 gap> PREIMAGES_TRANS_INT(IdentityTransformation, -1);
-Error, PREIMAGES_TRANS_INT: the second argument must be a positive integer
+Error, PREIMAGES_TRANS_INT: <pt> must be a positive small integer (not a integ\
+er)
 gap> PREIMAGES_TRANS_INT(IdentityTransformation, "a");
-Error, PREIMAGES_TRANS_INT: the second argument must be a positive integer
+Error, PREIMAGES_TRANS_INT: <pt> must be a positive small integer (not a list \
+(string))
 gap> PREIMAGES_TRANS_INT("a", 2);
 Error, PREIMAGES_TRANS_INT: the first argument must be a transformation (not a\
  list (string))
@@ -1466,11 +1469,11 @@ gap> COMPONENT_TRANS_INT(Transformation([3, 8, 1, 9, 9, 4, 10, 5, 10, 6, 12,
 gap> COMPONENT_TRANS_INT(IdentityTransformation, 10);
 [ 10 ]
 gap> COMPONENT_TRANS_INT(IdentityTransformation, 0);
-Error, COMPONENT_TRANS_INT: the second argument must be a positive integer (no\
-t a integer)
+Error, COMPONENT_TRANS_INT: <pt> must be a positive small integer (not a integ\
+er)
 gap> COMPONENT_TRANS_INT(IdentityTransformation, "a");
-Error, COMPONENT_TRANS_INT: the second argument must be a positive integer (no\
-t a list (string))
+Error, COMPONENT_TRANS_INT: <pt> must be a positive small integer (not a list \
+(string))
 gap> COMPONENT_TRANS_INT((), 1);
 Error, COMPONENT_TRANS_INT: the first argument must be a transformation (not a\
  permutation (small))
@@ -1563,11 +1566,10 @@ gap> CYCLE_TRANS_INT(Transformation([3, 8, 1, 9, 9, 4, 10, 5, 10, 6, 12,
 gap> CYCLE_TRANS_INT(IdentityTransformation, 10);
 [ 10 ]
 gap> CYCLE_TRANS_INT(IdentityTransformation, 0);
-Error, CYCLE_TRANS_INT: the second argument must be a positive integer (not a \
-integer)
+Error, CYCLE_TRANS_INT: <pt> must be a positive small integer (not a integer)
 gap> CYCLE_TRANS_INT(IdentityTransformation, "a");
-Error, CYCLE_TRANS_INT: the second argument must be a positive integer (not a \
-list (string))
+Error, CYCLE_TRANS_INT: <pt> must be a positive small integer (not a list (str\
+ing))
 gap> CYCLE_TRANS_INT((), 1);
 Error, CYCLE_TRANS_INT: the first argument must be a transformation (not a per\
 mutation (small))
@@ -2585,7 +2587,8 @@ gap> 10 ^ Transformation([1, 1]);
 gap> (2 ^ 60) ^ Transformation([1, 1]);
 1152921504606846976
 gap> (-1) ^ Transformation([1, 1]);
-Error, Tran. Operations: <point> must be a positive integer (not -1)
+Error, Tran. Operations: <point> must be a positive small integer (not a integ\
+er)
 gap> 65535 ^ Transformation([65535], [65537]);
 65537
 gap> 1 ^ Transformation([65535], [65537]);
@@ -2595,7 +2598,8 @@ gap> 65538 ^ Transformation([65535], [65537]);
 gap> (2 ^ 60) ^ Transformation([65535], [65537]);
 1152921504606846976
 gap> (-1) ^ Transformation([65535], [65537]);
-Error, Tran. Operations: <point> must be a positive integer (not -1)
+Error, Tran. Operations: <point> must be a positive small integer (not a integ\
+er)
 
 # OnSetsTrans: for a transformation
 gap> OnSets([], Transformation([1, 1]));
@@ -2607,7 +2611,8 @@ gap> OnSets([1, 2, 10], Transformation([1, 1]));
 gap> OnSets([1, 2, 10, (2 ^ 60)], Transformation([1, 1]));
 [ 1, 10, 1152921504606846976 ]
 gap> OnSets([-1, 1, 2], Transformation([1, 1]));
-Error, Tran. Operations: <point> must be a positive integer (not -1)
+Error, Tran. Operations: <point> must be a positive small integer (not a integ\
+er)
 gap> OnSets([65535, 65536, 65537], Transformation([65535], [65537]));
 [ 65536, 65537 ]
 gap> OnSets([1, 2, 10], Transformation([65535], [65537]));
@@ -2617,7 +2622,8 @@ gap> OnSets([1, 65535, 65538], Transformation([65535], [65537]));
 gap> OnSets([1, 2, 10, 65537, (2 ^ 60)], Transformation([65537], [1]));
 [ 1, 2, 10, 1152921504606846976 ]
 gap> OnSets([-1, 1, 2], Transformation([65535], [65537]));
-Error, Tran. Operations: <point> must be a positive integer (not -1)
+Error, Tran. Operations: <point> must be a positive small integer (not a integ\
+er)
 gap> OnSets([1, 2, 10, 65535, (2 ^ 60)], Transformation([65535], [5]));
 [ 1, 2, 5, 10, 1152921504606846976 ]
 gap> OnSets([1 .. 20], Transformation([10, 7, 10, 8, 8, 7, 5, 9, 1, 9]));
@@ -2643,7 +2649,8 @@ gap> OnTuples([1, 2, 10], Transformation([1, 1]));
 gap> OnTuples([1, 2, 10, (2 ^ 60)], Transformation([1, 1]));
 [ 1, 1, 10, 1152921504606846976 ]
 gap> OnTuples([-1, 1, 2], Transformation([1, 1]));
-Error, Tran. Operations: <point> must be a positive integer (not -1)
+Error, Tran. Operations: <point> must be a positive small integer (not a integ\
+er)
 gap> OnTuples([65535, 65536, 65537], Transformation([65535], [65537]));
 [ 65537, 65536, 65537 ]
 gap> OnTuples([1, 2, 10], Transformation([65535], [65537]));
@@ -2653,7 +2660,8 @@ gap> OnTuples([1, 65535, 65538], Transformation([65535], [65537]));
 gap> OnTuples([1, 2, 10, 65537, (2 ^ 60)], Transformation([65537], [1]));
 [ 1, 2, 10, 1, 1152921504606846976 ]
 gap> OnTuples([-1, 1, 2], Transformation([65535], [65537]));
-Error, Tran. Operations: <point> must be a positive integer (not -1)
+Error, Tran. Operations: <point> must be a positive small integer (not a integ\
+er)
 gap> OnTuples([1, 2, 10, 65535, (2 ^ 60)], Transformation([65535], [5]));
 [ 1, 2, 10, 5, 1152921504606846976 ]
 gap> OnTuples([1 .. 20], Transformation([10, 7, 10, 8, 8, 7, 5, 9, 1, 9]));

--- a/tst/testinstall/trans.tst
+++ b/tst/testinstall/trans.tst
@@ -1712,8 +1712,8 @@ gap> CYCLES_TRANS_LIST(f, [65535 .. 70001]);
 gap> CYCLES_TRANS_LIST(f, [1, , 3]);
 Error, List Element: <list>[2] must have an assigned value
 gap> CYCLES_TRANS_LIST(f, [-1]);
-Error, CYCLES_TRANS_LIST: the second argument must be a positive integer (not \
-a integer)
+Error, CYCLES_TRANS_LIST: the second argument must be a list of positive integ\
+ers (not a integer)
 gap> CYCLES_TRANS_LIST(0, [1 .. 10]);
 Error, CYCLES_TRANS_LIST: the first argument must be a transformation (not a i\
 nteger)

--- a/tst/testinstall/weakptr-badargs.tst
+++ b/tst/testinstall/weakptr-badargs.tst
@@ -4,47 +4,44 @@ gap> w := WeakPointerObject([1,,3,4]);
 Error, Variable: 'WeakPointerObject' must have a value
 gap> w := WeakPointerObj([1,,3,4]);;
 gap> SetElmWPObj(w, 0, 0);
-Error, SetElmWPObj: Position must be a positive small integer, not a integer
+Error, SetElmWPObj: <pos> must be a positive small integer (not a integer)
 gap> SetElmWPObj(w, [1,2], 0);
-Error, SetElmWPObj: Position must be a positive small integer, not a list (pla\
-in,cyc)
+Error, SetElmWPObj: <pos> must be a positive small integer (not a list (plain,\
+cyc))
 gap> SetElmWPObj(w, (), 0);
-Error, SetElmWPObj: Position must be a positive small integer, not a permutati\
-on (small)
+Error, SetElmWPObj: <pos> must be a positive small integer (not a permutation \
+(small))
 gap> SetElmWPObj((), 1, 1);
-Error, SetElmWPObj: First argument must be a weak pointer object, not a permut\
-ation (small)
+Error, SetElmWPObj: <wp> must be a weak pointer object (not a permutation (sma\
+ll))
 gap> UnbindElmWPObj(w, 0);
-Error, UnbindElmWPObj: Position must be a positive small integer, not a intege\
-r
+Error, UnbindElmWPObj: <pos> must be a positive small integer (not a integer)
 gap> UnbindElmWPObj(w, []);
-Error, UnbindElmWPObj: Position must be a positive small integer, not a list (\
-plain,empty)
+Error, UnbindElmWPObj: <pos> must be a positive small integer (not a list (pla\
+in,empty))
 gap> UnbindElmWPObj([], 2);
-Error, UnbindElmWPObj: First argument must be a weak pointer object, not a lis\
-t (plain,empty)
+Error, UnbindElmWPObj: <wp> must be a weak pointer object (not a list (plain,e\
+mpty))
 gap> ElmWPObj(w, 0);
-Error, ElmWPObj: Position must be a positive small integer, not a integer
+Error, ElmWPObj: <pos> must be a positive small integer (not a integer)
 gap> ElmWPObj(w, []);
-Error, ElmWPObj: Position must be a positive small integer, not a list (plain,\
-empty)
+Error, ElmWPObj: <pos> must be a positive small integer (not a list (plain,emp\
+ty))
 gap> ElmWPObj([], 1);
-Error, ElmWPObj: First argument must be a weak pointer object, not a list (pla\
-in,empty)
+Error, ElmWPObj: <wp> must be a weak pointer object (not a list (plain,empty))
 gap> IsBoundWPObj(w, 0);
 Error, Variable: 'IsBoundWPObj' must have a value
 gap> IsBoundElmWPObj(w, 0);
-Error, IsBoundElmWPObj: Position must be a positive small integer, not a integ\
-er
+Error, IsBoundElmWPObj: <pos> must be a positive small integer (not a integer)
 gap> IsBoundElmWPObj(w, []);
-Error, IsBoundElmWPObj: Position must be a positive small integer, not a list \
-(plain,empty)
+Error, IsBoundElmWPObj: <pos> must be a positive small integer (not a list (pl\
+ain,empty))
 gap> IsBoundElmWPObj([], 1);
-Error, IsBoundElmWPObj: First argument must be a weak pointer object, not a li\
-st (plain,empty)
+Error, IsBoundElmWPObj: <wp> must be a weak pointer object (not a list (plain,\
+empty))
 gap> LengthWPObj([]);
-Error, LengthWPObj: argument must be a weak pointer object, not a list (plain,\
-empty)
+Error, LengthWPObj: <wp> must be a weak pointer object (not a list (plain,empt\
+y))
 gap> LengthWPObj(0);
-Error, LengthWPObj: argument must be a weak pointer object, not a integer
+Error, LengthWPObj: <wp> must be a weak pointer object (not a integer)
 gap> STOP_TEST( "weakptr-badargs.tst", 1);


### PR DESCRIPTION
This contains PR #2946 (mainly for historical reasons: when I started writing this a couple months ago, I first only wanted to clean up some error messages, and then it kept growing... and now untangling it would have been just too much effort for no clear gain).

Some notes: `RequireArgumentCondition` and `RequireArgumentConditionMayReplace` are implemented as macros because that was super convenient when I started out. Part of them will likely stay so, because it makes it super easy to test for arbitrary conditions (as C has no lambda functions)... But I am now considering to reimplement at least the part which generates the error message as a separate function. One reason for that is that I am contemplating to replace the `(not a %s)` part of those errors by something slightly better:
* if the "bad" object is an integer, instead of `(not a integer)` (sic) let's show `(not the integer 123)`; this improves awkward messages like "most be a positive integer (not a integer)".
* if the "bad" object is a boolean, replace `(not a boolean or fail)` by one of
  * `(not the boolean true)` or `(not true)` (preferences, anybody)
  *  `(not the boolean false)` or `(not false)`,
  *  `(not fail)`
* ... anything else? well, it'll be trivial to add

Finally, note that `RequirePositiveSmallInt` takes three arguments, while e.g. `RequireSmallList` only takes two. Here's an example for the former:
```C
  RequirePositiveSmallInt("SET_SCOBJ_MAX_STACK_SIZE", size, "size");
```
For `RequireSmallList`, the second and third argument were merged. For `RequirePositiveSmallInt` this was not always possible:
```C
  RequirePositiveSmallInt("PosObj Element", pos, "position");
```
On the long run, I'd consider changing the code to use the same name for the argument as for the C variable, and then drop the 3rd argument to `RequirePositiveSmallInt` (which would be derivable from the 2nd). But I did not want to introduce even more variation to the the code than this PR already does.