### PR TITLE
Revision of ApplicableMethod

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -850,15 +850,22 @@ found in the <F>tst</F> directory of the &GAP; distribution.
 
 <#Include Label="[1]{testinstall.g}">
 
+You will get a large number of lines with output about the progress of 
+the tests, for example:
 <Log><![CDATA[
-test file         time(msec)
--------------------------------------------
-testing: ................/gap4r5/tst/zlattice.tst
-zlattice.tst               0
-testing: ................/gap4r5/tst/gaussian.tst
-gaussian.tst              10
-[ further lines deleted ]
+You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g -K 2g'.
+
+Architecture: x86_64-apple-darwin15.6.0-gcc-6-default64
+
+testing: /Users/alexk/GITREPS/gap/tst/testinstall/alghom.tst
+     140 msec for alghom.tst        
+testing: /Users/alexk/GITREPS/gap/tst/testinstall/algmat.tst
+    1309 msec for algmat.tst        
+testing: /Users/alexk/GITREPS/gap/tst/testinstall/algsc.tst
+     500 msec for algsc.tst         
+... further lines deleted ...
 ]]></Log>
+<P/>
 
 <#Include Label="[1]{teststandard.g}">
 <P/>

--- a/doc/ref/libform.xml
+++ b/doc/ref/libform.xml
@@ -79,7 +79,7 @@ This does not work for arbitrary functions,
 see Section <Ref Func="FilenameFunc"/> for the restrictions.
 <P/>
 If you are interested in getting the function which implements a method
-for specific arguments, you can use <Ref Sect="ApplicableMethod"/>.
+for specific arguments, you can use <Ref Func="ApplicableMethod"/>.
 If <Ref Func="FilenameFunc"/> does not work for this method then
 setting the print level of <Ref Sect="ApplicableMethod"/> higher will give
 you the installation string for this method, which can be used for searching

--- a/lib/function.g
+++ b/lib/function.g
@@ -266,9 +266,9 @@ DeclareOperationKernel( "NamesLocalVariablesFunction", [IS_OBJECT], NAMS_FUNC );
 ##  fail
 ##  gap> FilenameFunc( x -> x^2 );  # an interactively entered function
 ##  "*stdin*"
-##  gap> meth:= ApplicableMethod( Size, [ Group( () ) ] );;
+##  gap> meth:= ApplicableMethod( Size, [ Group( () ) ], 0, 2 );;
 ##  gap> FilenameFunc( meth );
-##  "... some path .../grpperm.gi"
+##  "... some path .../lib/grpperm.gi"
 ##  ]]></Log>
 ##  </Description>
 ##  </ManSection>
@@ -296,9 +296,9 @@ BIND_GLOBAL( "FilenameFunc", FILENAME_FUNC );
 ##  in this file where the definition of <A>func</A> ends.
 ##  <P/>
 ##  <Log><![CDATA[
-##  gap> meth:= ApplicableMethod( Size, [ Group( () ) ] );;
+##  gap> meth:= ApplicableMethod( Size, [ Group( () ) ], 0, 2 );;
 ##  gap> FilenameFunc( meth );
-##  "... some path ... gap4r5/lib/grpperm.gi"
+##  "... some path ... /lib/grpperm.gi"
 ##  gap> StartlineFunc( meth );
 ##  487
 ##  gap> EndlineFunc( meth );
@@ -325,7 +325,7 @@ BIND_GLOBAL( "EndlineFunc", ENDLINE_FUNC );
 ##  <P/>
 ##  <Log><![CDATA[
 ##  gap> LocationFunc( Intersection );
-##  "... some path ... gap/lib/coll.gi:2467"
+##  "... some path ... /lib/coll.gi:2373"
 ##  # String is an attribute, so no information is stored
 ##  gap> LocationFunc( String );
 ##  ""

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -350,6 +350,12 @@ local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
         Print(" at ",LocationFunc(oper));
       fi;
       Print("\n");
+      ## not sure what this test is for
+      if not ( fams=fail or CallFuncList(m.famPred,fams) ) then 
+        if verbos>2 then 
+          Print("#I   - bad family relations\n"); 
+        fi;
+      fi;
     elif verbos>1 then
       Print("#I  Method ",i); 
       Print(", value: ");  

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -170,7 +170,7 @@ end);
 ##  #I  ``SplitString: for a string and two characters''
 ##  #I   at GAPROOT/lib/string.gi:545
 ##  #I   - 2nd argument needs [ "IsChar" ]
-##  [ function( string, d1, d2 ) ... end ]
+##  [ function( string, seps, d ) ... end ]
 ##  ]]></Log>
 ##  When a method returned by <Ref Func="ApplicableMethod"/> is called 
 ##  it returns either the desired result or the string
@@ -280,6 +280,12 @@ local oper,narg,args,verbos,fams,flags,i,j,methods,flag,flag2,
       fi;
       flag := flag and flag2;
     od;
+    if not ( fams=fail or CallFuncList(m.famPred,fams) ) then 
+      flag := false; 
+      if verbos>2 then 
+        Print("#I   - bad family relations\n"); 
+      fi;
+    fi;
     if flag then 
       valid[i] := true; 
       Add( applic, i );;
@@ -357,12 +363,6 @@ local oper,narg,args,verbos,fams,flags,i,j,methods,flag,flag2,
         Print(" at ",LocationFunc(oper));
       fi;
       Print("\n");
-      ## not sure what this test is for
-      if not ( fams=fail or CallFuncList(m.famPred,fams) ) then 
-        if verbos>2 then 
-          Print("#I   - bad family relations\n"); 
-        fi;
-      fi;
     elif verbos>1 then
       Print("#I  Method ",i); 
       Print(", value: ");  

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -95,7 +95,7 @@ end);
 ##  Since <C>ApplicableMethod</C> returns a function, <C>Print(last);</C> 
 ##  may be used to view the code. 
 ##  <P/>
-##  If the first argument is a function, rather than an operation, 
+##  If the first argument is a function, but not an operation, 
 ##  then the function is returned. 
 ##  <P/>
 ##  The first example shows that there are 50 methods for <C>Size</C> 
@@ -105,12 +105,12 @@ end);
 ##  gap> ApplicableMethod( Size, [s4], 1, "all" );
 ##  #I  Searching Method for Size with 1 arguments:
 ##  #I  Total: 50 entries, of which 3 are applicable:
-##  #I  Method 6, valid operation number 1, value: 103
-##  #I  ``Size'' at ... some path .../lib/coll.gi:176
-##  #I  Method 10, valid operation number 2, value: 59
-##  #I  ``Size: for a permutation group'' at ... some path .../lib/grpperm.gi:483
-##  #I  Method 50, valid operation number 3, value: 2
-##  #I  ``Size: for a collection'' at ... some path .../lib/coll.gi:189
+##  #I  Method 6, applicable method number 1, value: 103
+##  #I  ``Size'' at GAPROOT/lib/coll.gi:176
+##  #I  Method 10, applicable method number 2, value: 59
+##  #I  ``Size: for a permutation group'' at GAPROOT/lib/grpperm.gi:483
+##  #I  Method 50, applicable method number 3, value: 2
+##  #I  ``Size: for a collection'' at GAPROOT/lib/coll.gi:189
 ##  [ function( C ) ... end, function( G ) ... end, function( C ) ... end ]
 ##  gap> Print( last[1], "\n" );                  
 ##  function ( C )
@@ -122,30 +122,30 @@ end);
 
 ##  ]]></Log>
 ##  The second example shows that for <C>DirectProduct</C>, 
-##  which is a function the location may be displayed and the code returned. 
-##  For <C>DirectProductOp</C> with verbosity <M>2</M> and <M>nr=2</M> 
+##  which is a function, the location may be displayed and the code returned. 
+##  For <C>DirectProductOp</C>, with verbosity <M>2</M> and <M>nr=2</M>, 
 ##  methods <M>1</M> and <M>5</M> are applicable, and all methods numbered 
 ##  <M>[2..5]</M> are displayed. 
 ##  <Log><![CDATA[
 ##  gap> ApplicableMethod( DirectProduct, [s4,s4], 1, 1 );    
 ##  #I  DirectProduct is a function, not an operation, located at:
-##  #I  ... some path .../lib/gprd.gi:17
+##  #I  GAPROOT/lib/gprd.gi:17
 ##  function( arg... ) ... end
 ##  gap> ApplicableMethod( DirectProductOp, [[s4,s4],s4], 2, 2 );
 ##  #I  Searching Method for DirectProductOp with 2 arguments:
 ##  #I  Total: 5 entries, of which 2 are applicable:
 ##  #I  Method 2, value: 66
 ##  #I  ``DirectProductOp: for a list (of pc groups), and a pc group''
-##  #I   at ... some path .../lib/gprdpc.gi:15
+##  #I   at GAPROOT/lib/gprdpc.gi:15
 ##  #I  Method 3, value: 47
 ##  #I  ``DirectProductOp: matrix groups''
-##  #I   at ... some path .../lib/gprdmat.gi:70
+##  #I   at GAPROOT/lib/gprdmat.gi:70
 ##  #I  Method 4, value: 40
 ##  #I  ``DirectProductOp: for a list of fp groups, and a fp group''
-##  #I   at ... some path .../lib/grpfp.gi:5495
-##  #I  Method 5, valid operation number 2, value: 37
+##  #I   at GAPROOT/lib/grpfp.gi:5495
+##  #I  Method 5, applicable method number 2, value: 37
 ##  #I  ``DirectProductOp: for a list (of groups), and a group''
-##  #I   at ... some path .../lib/gprd.gi:50
+##  #I   at GAPROOT/lib/gprd.gi:50
 ##  function( list, gp ) ... end
 ##  ]]></Log>
 ##  The third example shows the sort of output that can be obtained 
@@ -157,23 +157,23 @@ end);
 ##  #I  Total: 4 entries, of which 1 is applicable:
 ##  #I  Method 1, value: 15
 ##  #I  ``SplitString: for three strings''
-##  #I   at ... some path .../lib/string.gi:539
+##  #I   at GAPROOT/lib/string.gi:539
 ##  #I   - 3rd argument needs [ "IsString" ]
 ##  #I  Method 2, value: 11
 ##  #I  ``SplitString: for a string, a character and a string''
-##  #I   at ... some path .../lib/string.gi:561
+##  #I   at GAPROOT/lib/string.gi:561
 ##  #I   - 2nd argument needs [ "IsChar" ]
 ##  #I   - 3rd argument needs [ "IsString" ]
-##  #I  Method 3, valid operation number 1, value: 11
+##  #I  Method 3, applicable method number 1, value: 11
 ##  #I  ``SplitString: for two strings and a character''
-##  #I   at ... some path .../lib/string.gi:553
+##  #I   at GAPROOT/lib/string.gi:553
 ##  #I  Method 4, value: 7
 ##  #I  ``SplitString: for a string and two characters''
-##  #I   at ... some path .../lib/string.gi:545
+##  #I   at GAPROOT/lib/string.gi:545
 ##  #I   - 2nd argument needs [ "IsChar" ]
 ##  [ function( string, d1, d2 ) ... end ]
 ##  ]]></Log>
-##  When a method returned by <Ref Func="ApplicableMethod"/> is called then
+##  When a method returned by <Ref Func="ApplicableMethod"/> is called 
 ##  it returns either the desired result or the string
 ##  <C>"TRY_NEXT_METHOD"</C>, which corresponds to a call to
 ##  <Ref Func="TryNextMethod"/> in the method and means that
@@ -197,7 +197,7 @@ end);
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL("ApplicableMethodTypes",function(arg)
-local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
+local oper,narg,args,verbos,fams,flags,i,j,methods,flag,flag2,
       m,nam,val,has,need,isconstructor,
       nummeth,valid,applic,numapplic,nr,first,last;
   if Length(arg)<2 or not IsList(arg[2]) or not IsFunction(arg[1]) then
@@ -206,8 +206,8 @@ local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
   ## process the arguments 
   oper:=arg[1];
   isconstructor:=IS_CONSTRUCTOR(oper);
-    opargs:=arg[2];
-  nopargs:=Length(opargs);
+    args:=arg[2];
+  narg:=Length(args);
   verbos:=0;
   if Length(arg)>2 and IsPosInt(arg[3]) then
     verbos:=Minimum(arg[3],4);
@@ -220,8 +220,8 @@ local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
       nr:=0;
     fi;
   fi;
-  ## accept the name of a function 
-  if not oper in OPERATIONS then 
+  ## if not an operation, just return the function 
+  if not IsOperation(oper) then 
     nam:=FilenameFunc(oper); 
     if nam=fail then 
       Print("#I  ",oper," is not recognised as the name of an operation\n"); 
@@ -238,7 +238,7 @@ local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
   # get families and filters
   flags:=[];
   fams:=[];
-  for i in opargs do
+  for i in args do
     if IsFilter(i) then
       Add(flags,FLAGS_FILTER(i));
       Add(fams,fail);
@@ -254,7 +254,7 @@ local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
     Info(InfoWarning,1,"Family predicate cannot be tested");
   fi;
   ## find all the methods 
-  methods:=MethodsOperation(oper,nopargs);
+  methods:=MethodsOperation(oper,narg);
   nummeth:=Length(methods);
   if nummeth=0 then 
     Print("#I  no method found for this operation with these arguments\n"); 
@@ -265,7 +265,7 @@ local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
   for i in [1..nummeth] do 
     flag := true; 
     m := methods[i];
-    for j in [1..nopargs] do 
+    for j in [1..narg] do 
       if isconstructor then
         flag2:=IS_SUBSET_FLAGS(m.argFilt[j],flags[j]);
       else
@@ -288,7 +288,7 @@ local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
   fi;
   ## output basic information
   Print("#I  Searching Method for ",NameFunction(oper)," with ", 
-        nopargs," arguments:\n");
+        narg," arguments:\n");
   Print("#I  Total: ",nummeth," entries, of which ",numapplic); 
   if numapplic=1 then 
     Print(" is applicable:\n");
@@ -297,12 +297,12 @@ local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
   fi;
   if nr>numapplic then 
     if (numapplic=0) then 
-      Print("#I  there are no valid methods with these parameters\n"); 
+      Print("#I  there are no applicable methods with these parameters\n"); 
     else
       if numapplic=1 then 
-        Print("#I  there is only 1 valid method\n"); 
+        Print("#I  there is only 1 applicable method\n"); 
       else
-        Print("#I  there are only ",numapplic," valid methods\n"); 
+        Print("#I  there are only ",numapplic," applicable methods\n"); 
       fi;
     fi;
   fi;
@@ -340,7 +340,7 @@ local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
     oper:=m.func;
     if i in applic then 
       Print("#I  Method ",i); 
-      Print(", valid operation number ",Position(applic,i)); 
+      Print(", applicable method number ",Position(applic,i)); 
       Print(", value: ");  
       Print_Value_SFF(val);
       Print("\n#I  ``",nam,"''\n");
@@ -369,7 +369,7 @@ local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
       Print("\n");
       flag:=true;
       j:=1;
-      while j<=nopargs and (flag or verbos>3) do
+      while j<=narg and (flag or verbos>3) do
         if j=1 and isconstructor then
           flag2:=IS_SUBSET_FLAGS(m.argFilt[j],flags[j]);
         else

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -407,23 +407,23 @@ local oper,narg,args,verbos,fams,flags,i,j,methods,flag,flag2,
 end);
 
 BIND_GLOBAL("ApplicableMethod",function(arg)
-local i,l,ok,errstr;
+local i,l,ok;
   ok:=false;
-  errstr:="#I  usage: ApplicableMethod(<opr>,<arglist>[,<verbosity>[,<nr>]])\n";
   if Length(arg)<2 then 
     Print("#I  ApplicableMethod requires at least two arguments\n"); 
-  elif not IsList(arg[2]) then 
-    Print("#I  argument 2 must be a list of arguments for the operation\n" ); 
   elif not IsFunction(arg[1]) then 
-    Print("#I  argument 1 must be the name of an operation\n" );
+    Print("#I  argument 1 must be the name of a function\n");
   else 
     ok := true;
   fi;
   if not ok then 
-    Print(errstr);
-    return fail;
+    Error("usage: ApplicableMethod(<opr>,<arglist>[,<verbosity>[,<nr>]])\n");
   fi;
   l:=ShallowCopy(arg[2]);
+  if not IsList(l) then 
+    Print("#I  replacing second argument arg2 by the list [arg2]\n");
+    l:=[l];
+  fi;
   for i in [1..Length(l)] do
     if i=1 and IS_CONSTRUCTOR(arg[1]) then
       l[i]:=l[i];

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -100,7 +100,7 @@ end);
 ##  <P/>
 ##  The first example shows that there are 50 methods for <C>Size</C> 
 ##  currently available, or which 3 are applicable to <C>s4</C>. 
-##  <Example><![CDATA[
+##  <Log><![CDATA[
 ##  gap> s4 := Group( (1,2,3,4), (3,4) );; 
 ##  gap> ApplicableMethod( Size, [s4], 1, "all" );
 ##  #I  Searching Method for Size with 1 arguments:
@@ -120,13 +120,13 @@ end);
 ##      return infinity;
 ##  end
 
-##  ]]></Example>
+##  ]]></Log>
 ##  The second example shows that for <C>DirectProduct</C>, 
 ##  which is a function the location may be displayed and the code returned. 
 ##  For <C>DirectProductOp</C> with verbosity <M>2</M> and <M>nr=2</M> 
 ##  methods <M>1</M> and <M>5</M> are applicable, and all methods numbered 
 ##  <M>[2..5]</M> are displayed. 
-##  <Example><![CDATA[
+##  <Log><![CDATA[
 ##  gap> ApplicableMethod( DirectProduct, [s4,s4], 1, 1 );    
 ##  #I  DirectProduct is a function, not an operation, located at:
 ##  #I  ... some path .../lib/gprd.gi:17
@@ -147,10 +147,10 @@ end);
 ##  #I  ``DirectProductOp: for a list (of groups), and a group''
 ##  #I   at ... some path .../lib/gprd.gi:50
 ##  function( list, gp ) ... end
-##  ]]></Example>
+##  ]]></Log>
 ##  The third example shows the sort of output that can be obtained 
 ##  with verbosity <M>4</M>.  
-##  <Example><![CDATA[
+##  <Log><![CDATA[
 ##  gap> s := "hello! hello! hello!";;                           
 ##  gap> ApplicableMethod(SplitString,[s,"!",' '],4,"all");
 ##  #I  Searching Method for SplitString with 3 arguments:
@@ -172,7 +172,7 @@ end);
 ##  #I   at ... some path .../lib/string.gi:545
 ##  #I   - 2nd argument needs [ "IsChar" ]
 ##  [ function( string, d1, d2 ) ... end ]
-##  ]]></Example>
+##  ]]></Log>
 ##  When a method returned by <Ref Func="ApplicableMethod"/> is called then
 ##  it returns either the desired result or the string
 ##  <C>"TRY_NEXT_METHOD"</C>, which corresponds to a call to

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -384,7 +384,6 @@ local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
       od;
     fi;
   od;
-Print([nr,numapplic],"\n");
   if nr>numapplic then 
     return fail;
   elif nr=0 then 

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -223,22 +223,24 @@ local oper,narg,args,verbos,fams,flags,i,j,methods,flag,flag2,
   if not IsOperation(oper) then 
     nam:=FilenameFunc(oper); 
     if nam=fail then 
-      Print("#I  ",oper," is not recognised as the name of an operation\n"); 
+      Info(InfoWarning, 1, oper, 
+        " is not recognised as the name of an operation"); 
       return fail;
     fi;
     if verbos>0 then 
-      Print("#I  ",NameFunction(oper)," is a function, not an operation\n"); 
+      Info(InfoWarning, 1, NameFunction(oper), 
+        " is a function, not an operation"); 
     fi;
     naf:=NumberArgumentsFunction(oper);
     if naf>0 and naf<>narg then 
-      Print("#I  and requires ",naf," arguments\n");
+      Info(InfoWarning, 1, "and requires ",naf," arguments");
       return fail; 
     elif -naf>narg then 
-      Print("#I  and requires at least ",-naf," arguments\n");
+      Info(InfoWarning, 1, "and requires at least ",-naf," arguments");
       return fail; 
     fi;
     if verbos>0 then 
-      Print("#I  and is located at: ",LocationFunc(oper),"\n"); 
+      Info(InfoWarning, 1, "and is located at: ",LocationFunc(oper)); 
     fi;
     return oper;
   fi; 
@@ -264,7 +266,8 @@ local oper,narg,args,verbos,fams,flags,i,j,methods,flag,flag2,
   methods:=MethodsOperation(oper,narg);
   nummeth:=Length(methods);
   if nummeth=0 then 
-    Print("#I  no method found for this operation with these arguments\n"); 
+    Info(InfoWarning, 1, 
+        "no method found for this operation with this number of arguments"); 
     return fail;
   fi;
   applic := [ ];
@@ -410,9 +413,9 @@ BIND_GLOBAL("ApplicableMethod",function(arg)
 local i,l,ok;
   ok:=false;
   if Length(arg)<2 then 
-    Print("#I  ApplicableMethod requires at least two arguments\n"); 
+    Info(InfoWarning, 1,"ApplicableMethod requires at least two arguments"); 
   elif not IsFunction(arg[1]) then 
-    Print("#I  argument 1 must be the name of a function\n");
+    Info(InfoWarning, 1,"argument 1 must be the name of a function");
   else 
     ok := true;
   fi;
@@ -421,7 +424,7 @@ local i,l,ok;
   fi;
   l:=ShallowCopy(arg[2]);
   if not IsList(l) then 
-    Print("#I  replacing second argument arg2 by the list [arg2]\n");
+    Info(InfoWarning, 1,"replacing second argument arg2 by the list [arg2]");
     l:=[l];
   fi;
   for i in [1..Length(l)] do

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -111,11 +111,15 @@ end);
 ##  #I  ``Size: for a permutation group'' at ... some path .../lib/grpperm.gi:483
 ##  #I  Method 50, valid operation number 3, value: 2
 ##  #I  ``Size: for a collection'' at ... some path .../lib/coll.gi:189
-##  function( C ) ... end
-##  gap> Print( last );
+##  [ function( C ) ... end, function( G ) ... end, function( C ) ... end ]
+##  gap> Print( last[1], "\n" );                  
 ##  function ( C )
-##      return Length( Enumerator( C ) );
+##      if IsFinite( C ) then
+##          TryNextMethod();
+##      fi;
+##      return infinity;
 ##  end
+
 ##  ]]></Example>
 ##  The second example shows that for <C>DirectProduct</C>, 
 ##  which is a function the location may be displayed and the code returned. 
@@ -167,7 +171,7 @@ end);
 ##  #I  ``SplitString: for a string and two characters''
 ##  #I   at ... some path .../lib/string.gi:545
 ##  #I   - 2nd argument needs [ "IsChar" ]
-##  function( string, d1, d2 ) ... end
+##  [ function( string, d1, d2 ) ... end ]
 ##  ]]></Example>
 ##  When a method returned by <Ref Func="ApplicableMethod"/> is called then
 ##  it returns either the desired result or the string
@@ -380,8 +384,11 @@ local oper,opargs,nopargs,verbos,fams,flags,i,j,methods,flag,flag2,
       od;
     fi;
   od;
+Print([nr,numapplic],"\n");
   if nr>numapplic then 
     return fail;
+  elif nr=0 then 
+    return List(applic, i->methods[i].func);
   else 
     return oper;
   fi;

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -128,8 +128,7 @@ end);
 ##  <M>[2..5]</M> are displayed. 
 ##  <Log><![CDATA[
 ##  gap> ApplicableMethod( DirectProduct, [s4,s4], 1, 1 );    
-##  #I  DirectProduct is a function, not an operation, located at:
-##  #I  GAPROOT/lib/gprd.gi:17
+##  #I  and is located at: /GAPROOT/lib/gprd.gi:17
 ##  function( arg... ) ... end
 ##  gap> ApplicableMethod( DirectProductOp, [[s4,s4],s4], 2, 2 );
 ##  #I  Searching Method for DirectProductOp with 2 arguments:
@@ -199,14 +198,14 @@ end);
 BIND_GLOBAL("ApplicableMethodTypes",function(arg)
 local oper,narg,args,verbos,fams,flags,i,j,methods,flag,flag2,
       m,nam,val,has,need,isconstructor,
-      nummeth,valid,applic,numapplic,nr,first,last;
+      naf,nummeth,valid,applic,numapplic,nr,first,last;
   if Length(arg)<2 or not IsList(arg[2]) or not IsFunction(arg[1]) then
     Error("usage: ApplicableMethodTypes(<opr>,<arglist>[,<verbosity>[,<nr>]])");
   fi;
   ## process the arguments 
   oper:=arg[1];
   isconstructor:=IS_CONSTRUCTOR(oper);
-    args:=arg[2];
+  args:=arg[2];
   narg:=Length(args);
   verbos:=0;
   if Length(arg)>2 and IsPosInt(arg[3]) then
@@ -226,14 +225,22 @@ local oper,narg,args,verbos,fams,flags,i,j,methods,flag,flag2,
     if nam=fail then 
       Print("#I  ",oper," is not recognised as the name of an operation\n"); 
       return fail;
-    else
-      if verbos>0 then 
-        Print("#I  ",NameFunction(oper),
-              " is a function, not an operation, located at:\n"); 
-        Print("#I  ",LocationFunc(oper),"\n"); 
-      fi;
-      return oper;
-    fi; 
+    fi;
+    if verbos>0 then 
+      Print("#I  ",NameFunction(oper)," is a function, not an operation\n"); 
+    fi;
+    naf:=NumberArgumentsFunction(oper);
+    if naf>0 and naf<>narg then 
+      Print("#I  and requires ",naf," arguments\n");
+      return fail; 
+    elif -naf>narg then 
+      Print("#I  and requires at least ",-naf," arguments\n");
+      return fail; 
+    fi;
+    if verbos>0 then 
+      Print("#I  and is located at: ",LocationFunc(oper),"\n"); 
+    fi;
+    return oper;
   fi; 
   # get families and filters
   flags:=[];

--- a/tst/testbugfix/2005-08-10-t00086.tst
+++ b/tst/testbugfix/2005-08-10-t00086.tst
@@ -6,5 +6,9 @@
 # <span class="code">Conductor</span> and thus was much slower.
 # Now the special method has been ranked up by changing the requirements
 # in the method installation.
-gap> ApplicableMethod( \in, [ 1, Rationals ] );
-function( x, Rationals ) ... end
+gap> ApplicableMethod( \in, [ 1, Rationals ], 0, 1 );
+function( arg... ) ... end
+gap> Display( ApplicableMethod( \in, [ 1, Rationals ], 0, 2 ) );
+function ( x, Rationals )
+    return IsRat( x );
+end

--- a/tst/testbugfix/2005-08-10-t00086.tst
+++ b/tst/testbugfix/2005-08-10-t00086.tst
@@ -6,9 +6,5 @@
 # <span class="code">Conductor</span> and thus was much slower.
 # Now the special method has been ranked up by changing the requirements
 # in the method installation.
-gap> ApplicableMethod( \in, [ 1, Rationals ], 0, 1 );
-function( arg... ) ... end
-gap> Display( ApplicableMethod( \in, [ 1, Rationals ], 0, 2 ) );
-function ( x, Rationals )
-    return IsRat( x );
-end
+gap> ApplicableMethod( \in, [ 1, Rationals ] );
+function( x, Rationals ) ... end

--- a/tst/testinstall/methwhy.tst
+++ b/tst/testinstall/methwhy.tst
@@ -72,7 +72,7 @@ gap> ApplicableMethod(foobar, [ ['a'] ], 1, "all");
 #I  Method 4, valid operation number 3, value: 0
 #I  ``foobar''
 #I   at stream:1
-function( x ) ... end
+[ function( x ) ... end, <Attribute "Length">, function( x ) ... end ]
 
 #
 gap> Display(ApplicableMethod(foobar, [fail], 1));

--- a/tst/testinstall/methwhy.tst
+++ b/tst/testinstall/methwhy.tst
@@ -3,8 +3,8 @@ gap> START_TEST("methwhy.tst");
 #
 gap> ApplicableMethod();
 #I  ApplicableMethod requires at least two arguments
-#I  usage: ApplicableMethod(<opr>,<arglist>[,<verbosity>[,<nr>]])
-fail
+Error, usage: ApplicableMethod(<opr>,<arglist>[,<verbosity>[,<nr>]])
+
 
 #
 gap> foobar := NewOperation("foobar", [IsObject]);
@@ -44,10 +44,13 @@ gap> Display(ApplicableMethod(foobar, [ ['a'] ], 1));
 function ( x )
     return StartsWith( x, "foo" );
 end
-gap> ApplicableMethod(foobar, 'a', 1);   
-#I  argument 2 must be a list of arguments for the operation
-#I  usage: ApplicableMethod(<opr>,<arglist>[,<verbosity>[,<nr>]])
-fail
+gap> ApplicableMethod(foobar, [ ['a'] ], 1, 2);
+#I  Searching Method for foobar with 1 arguments:
+#I  Total: 4 entries, of which 3 are applicable:
+#I  Method 2, applicable method number 2, value: 42
+#I  ``foobar: for a list''
+#I   at stream:1
+<Attribute "Length">
 gap> ApplicableMethod(foobar, [ ['a'] ], 1, 3);
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 3 are applicable:
@@ -84,7 +87,7 @@ gap> Display(ApplicableMethod(foobar, [fail], 1));
 function ( x )
     return fail;
 end
-gap> ApplicableMethod(foobar, [fail], 4);
+gap> Display(ApplicableMethod(foobar, [fail], 4));
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 1 is applicable:
 #I  Method 1, value: 2*SUM_FLAGS+1
@@ -102,7 +105,9 @@ gap> ApplicableMethod(foobar, [fail], 4);
 #I  Method 4, applicable method number 1, value: 0
 #I  ``foobar''
 #I   at stream:1
-function( x ) ... end
+function ( x )
+    return fail;
+end
 gap> ApplicableMethod(foobar, [fail], 6);; 
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 1 is applicable:
@@ -203,18 +208,33 @@ gap> ApplicableMethod(foobar, [1, []], 2);
 #I  ``foobar: for 2 integers''
 #I   at stream:2
 fail
+gap> ApplicableMethod(foobar, [1, []], 4);
+#I  Searching Method for foobar with 2 arguments:
+#I  Total: 2 entries, of which 0 are applicable:
+#I  there are no applicable methods with these parameters
+#I  Method 1, value: 17
+#I  ``foobar: for two lists''
+#I   at stream:1
+#I   - 1st argument needs [ "IsList" ]
+#I  Method 2, value: 0
+#I  ``foobar: for 2 integers''
+#I   at stream:2
+#I   - 2nd argument needs [ "IsInt" ]
+fail
 
 #
 # check 0-6 arguments
 #
-gap> ApplicableMethod(foobar, [], 4);
+gap> Display(ApplicableMethod(foobar, [], 4));
 #I  Searching Method for foobar with 0 arguments:
 #I  Total: 1 entries, of which 1 is applicable:
 #I  Method 1, applicable method number 1, value: 0
 #I  ``foobar: for no argument''
 #I   at stream:1
-function(  ) ... end
-gap> ApplicableMethod(foobar, [1], 4, 1);
+function (  )
+    return 1;
+end
+gap> Display(ApplicableMethod(foobar, [1], 4, 1));
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 2 are applicable:
 #I  Method 1, value: 2*SUM_FLAGS+1
@@ -228,7 +248,9 @@ gap> ApplicableMethod(foobar, [1], 4, 1);
 #I  Method 3, applicable method number 1, value: 1
 #I  ``foobar: for an integer''
 #I   at stream:1
-function( x ) ... end
+function ( x )
+    return 1;
+end
 gap> ApplicableMethod(foobar, [1], 4, 2);
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 2 are applicable:
@@ -298,6 +320,20 @@ gap> ApplicableMethod( foobar, [9], 1, 1 );
 #I  foobar is a function, not an operation
 #I  and requires at least 2 arguments
 fail
+
+#
+# now not returning 'fail' when the second argument fails to be a list, 
+# but replacing arg2 by [arg2] and then carrying on:
+#
+gap> g := Group(());;
+gap> Display(ApplicableMethod(Size,g));
+#I  replacing second argument arg2 by the list [arg2]
+function ( C )
+    if IsFinite( C ) then
+        TryNextMethod();
+    fi;
+    return infinity;
+end
 
 #
 gap> STOP_TEST("methwhy.tst");

--- a/tst/testinstall/methwhy.tst
+++ b/tst/testinstall/methwhy.tst
@@ -298,6 +298,9 @@ gap> ApplicableMethod(foobar, [1..6], 1);
 #I  ``foobar: for 6 integers''
 #I   at stream:6
 function( x, y... ) ... end
+gap> ApplicableMethod(foobar, [1..7], 1);
+#I  no method found for this operation with this number of arguments
+fail
 
 #
 # check ApplicableMethod when applied to a function 

--- a/tst/testinstall/methwhy.tst
+++ b/tst/testinstall/methwhy.tst
@@ -38,7 +38,7 @@ end
 gap> Display(ApplicableMethod(foobar, [ ['a'] ], 1));
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 3 are applicable:
-#I  Method 1, valid operation number 1, value: 2*SUM_FLAGS+1
+#I  Method 1, applicable operation number 1, value: 2*SUM_FLAGS+1
 #I  ``foobar: for a string''
 #I   at stream:1
 function ( x )
@@ -51,25 +51,25 @@ fail
 gap> ApplicableMethod(foobar, [ ['a'] ], 1, 3);
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 3 are applicable:
-#I  Method 4, valid operation number 3, value: 0
+#I  Method 4, applicable operation number 3, value: 0
 #I  ``foobar''
 #I   at stream:1
 function( x ) ... end
 gap> ApplicableMethod(foobar, [ ['a'] ], 1, 4);
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 3 are applicable:
-#I  there are only 3 valid methods
+#I  there are only 3 applicable methods
 fail
 gap> ApplicableMethod(foobar, [ ['a'] ], 1, "all");
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 3 are applicable:
-#I  Method 1, valid operation number 1, value: 2*SUM_FLAGS+1
+#I  Method 1, applicable operation number 1, value: 2*SUM_FLAGS+1
 #I  ``foobar: for a string''
 #I   at stream:1
-#I  Method 2, valid operation number 2, value: 42
+#I  Method 2, applicable operation number 2, value: 42
 #I  ``foobar: for a list''
 #I   at stream:1
-#I  Method 4, valid operation number 3, value: 0
+#I  Method 4, applicable operation number 3, value: 0
 #I  ``foobar''
 #I   at stream:1
 [ function( x ) ... end, <Attribute "Length">, function( x ) ... end ]
@@ -78,7 +78,7 @@ gap> ApplicableMethod(foobar, [ ['a'] ], 1, "all");
 gap> Display(ApplicableMethod(foobar, [fail], 1));
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 1 is applicable:
-#I  Method 4, valid operation number 1, value: 0
+#I  Method 4, applicable operation number 1, value: 0
 #I  ``foobar''
 #I   at stream:1
 function ( x )
@@ -99,7 +99,7 @@ gap> ApplicableMethod(foobar, [fail], 4);
 #I  ``foobar: for an integer''
 #I   at stream:1
 #I   - 1st argument needs [ "IsInt" ]
-#I  Method 4, valid operation number 1, value: 0
+#I  Method 4, applicable operation number 1, value: 0
 #I  ``foobar''
 #I   at stream:1
 function( x ) ... end
@@ -118,7 +118,7 @@ gap> ApplicableMethod(foobar, [fail], 6);;
 #I  ``foobar: for an integer''
 #I   at stream:1
 #I   - 1st argument needs [ "IsInt" ]
-#I  Method 4, valid operation number 1, value: 0
+#I  Method 4, applicable operation number 1, value: 0
 #I  ``foobar''
 #I   at stream:1
 
@@ -132,7 +132,7 @@ end
 gap> Display(ApplicableMethod(foobar, [1, 2], 1));
 #I  Searching Method for foobar with 2 arguments:
 #I  Total: 2 entries, of which 1 is applicable:
-#I  Method 2, valid operation number 1, value: 0
+#I  Method 2, applicable operation number 1, value: 0
 #I  ``foobar: for 2 integers''
 #I   at stream:2
 function ( x, y... )
@@ -144,7 +144,7 @@ gap> Display(ApplicableMethod(foobar, [1, 2], 2));
 #I  Method 1, value: 17
 #I  ``foobar: for two lists''
 #I   at stream:1
-#I  Method 2, valid operation number 1, value: 0
+#I  Method 2, applicable operation number 1, value: 0
 #I  ``foobar: for 2 integers''
 #I   at stream:2
 function ( x, y... )
@@ -157,7 +157,7 @@ gap> Display(ApplicableMethod(foobar, [1, 2], 3));
 #I  ``foobar: for two lists''
 #I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
-#I  Method 2, valid operation number 1, value: 0
+#I  Method 2, applicable operation number 1, value: 0
 #I  ``foobar: for 2 integers''
 #I   at stream:2
 function ( x, y... )
@@ -171,7 +171,7 @@ gap> Display(ApplicableMethod(foobar, [1, 2], 4));
 #I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
 #I   - 2nd argument needs [ "IsList" ]
-#I  Method 2, valid operation number 1, value: 0
+#I  Method 2, applicable operation number 1, value: 0
 #I  ``foobar: for 2 integers''
 #I   at stream:2
 function ( x, y... )
@@ -182,7 +182,7 @@ end
 gap> ApplicableMethod(foobar, [[1], []], 5);;
 #I  Searching Method for foobar with 2 arguments:
 #I  Total: 2 entries, of which 1 is applicable:
-#I  Method 1, valid operation number 1, value: 17
+#I  Method 1, applicable operation number 1, value: 17
 #I  ``foobar: for two lists''
 #I   at stream:1
 
@@ -190,12 +190,12 @@ gap> ApplicableMethod(foobar, [[1], []], 5);;
 gap> ApplicableMethod(foobar, [1, []], 1);   
 #I  Searching Method for foobar with 2 arguments:
 #I  Total: 2 entries, of which 0 are applicable:
-#I  there are no valid methods with these parameters
+#I  there are no applicable methods with these parameters
 fail
 gap> ApplicableMethod(foobar, [1, []], 2);
 #I  Searching Method for foobar with 2 arguments:
 #I  Total: 2 entries, of which 0 are applicable:
-#I  there are no valid methods with these parameters
+#I  there are no applicable methods with these parameters
 #I  Method 1, value: 17
 #I  ``foobar: for two lists''
 #I   at stream:1
@@ -210,7 +210,7 @@ fail
 gap> ApplicableMethod(foobar, [], 4);
 #I  Searching Method for foobar with 0 arguments:
 #I  Total: 1 entries, of which 1 is applicable:
-#I  Method 1, valid operation number 1, value: 0
+#I  Method 1, applicable operation number 1, value: 0
 #I  ``foobar: for no argument''
 #I   at stream:1
 function(  ) ... end
@@ -225,14 +225,14 @@ gap> ApplicableMethod(foobar, [1], 4, 1);
 #I  ``foobar: for a list''
 #I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
-#I  Method 3, valid operation number 1, value: 1
+#I  Method 3, applicable operation number 1, value: 1
 #I  ``foobar: for an integer''
 #I   at stream:1
 function( x ) ... end
 gap> ApplicableMethod(foobar, [1], 4, 2);
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 2 are applicable:
-#I  Method 4, valid operation number 2, value: 0
+#I  Method 4, applicable operation number 2, value: 0
 #I  ``foobar''
 #I   at stream:1
 function( x ) ... end
@@ -244,35 +244,35 @@ gap> ApplicableMethod(foobar, [1,2], 4);
 #I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
 #I   - 2nd argument needs [ "IsList" ]
-#I  Method 2, valid operation number 1, value: 0
+#I  Method 2, applicable operation number 1, value: 0
 #I  ``foobar: for 2 integers''
 #I   at stream:2
 function( x, y... ) ... end
 gap> ApplicableMethod(foobar, [1..3], 4);
 #I  Searching Method for foobar with 3 arguments:
 #I  Total: 1 entries, of which 1 is applicable:
-#I  Method 1, valid operation number 1, value: 0
+#I  Method 1, applicable operation number 1, value: 0
 #I  ``foobar: for 3 integers''
 #I   at stream:3
 function( x, y... ) ... end
 gap> ApplicableMethod(foobar, [1..4], 4);
 #I  Searching Method for foobar with 4 arguments:
 #I  Total: 1 entries, of which 1 is applicable:
-#I  Method 1, valid operation number 1, value: 0
+#I  Method 1, applicable operation number 1, value: 0
 #I  ``foobar: for 4 integers''
 #I   at stream:4
 function( x, y... ) ... end
 gap> ApplicableMethod(foobar, [1..5], 2);
 #I  Searching Method for foobar with 5 arguments:
 #I  Total: 1 entries, of which 1 is applicable:
-#I  Method 1, valid operation number 1, value: 0
+#I  Method 1, applicable operation number 1, value: 0
 #I  ``foobar: for 5 integers''
 #I   at stream:5
 function( x, y... ) ... end
 gap> ApplicableMethod(foobar, [1..6], 1);
 #I  Searching Method for foobar with 6 arguments:
 #I  Total: 1 entries, of which 1 is applicable:
-#I  Method 1, valid operation number 1, value: 0
+#I  Method 1, applicable operation number 1, value: 0
 #I  ``foobar: for 6 integers''
 #I   at stream:6
 function( x, y... ) ... end

--- a/tst/testinstall/methwhy.tst
+++ b/tst/testinstall/methwhy.tst
@@ -278,4 +278,26 @@ gap> ApplicableMethod(foobar, [1..6], 1);
 function( x, y... ) ... end
 
 #
+# check ApplicableMethod when applied to a function 
+#
+gap> foobar := function(a,b,c) return 1; end;; 
+gap> ApplicableMethod( foobar, [4,5,6], 1, 1 );       
+#I  foobar is a function, not an operation
+#I  and is located at: stream:1
+function( a, b, c ) ... end
+gap> ApplicableMethod( foobar, [7,8], 1, 1 );  
+#I  foobar is a function, not an operation
+#I  and requires 3 arguments
+fail
+gap> foobar := function(x,arg...) return x*arg[1]; end;;
+gap> ApplicableMethod( foobar, [7,8], 1, 1 );           
+#I  foobar is a function, not an operation
+#I  and is located at: stream:1
+function( x, arg... ) ... end
+gap> ApplicableMethod( foobar, [9], 1, 1 );  
+#I  foobar is a function, not an operation
+#I  and requires at least 2 arguments
+fail
+
+#
 gap> STOP_TEST("methwhy.tst");

--- a/tst/testinstall/methwhy.tst
+++ b/tst/testinstall/methwhy.tst
@@ -1,8 +1,10 @@
-gap> START_TEST("methwy.tst");
+gap> START_TEST("methwhy.tst");
 
 #
 gap> ApplicableMethod();
-Error, usage: ApplicableMethod(<opr>,<arglist>[,<verbosity>[,<nr>]])
+#I  ApplicableMethod requires at least two arguments
+#I  usage: ApplicableMethod(<opr>,<arglist>[,<verbosity>[,<nr>]])
+fail
 
 #
 gap> foobar := NewOperation("foobar", [IsObject]);
@@ -35,52 +37,90 @@ function ( x )
 end
 gap> Display(ApplicableMethod(foobar, [ ['a'] ], 1));
 #I  Searching Method for foobar with 1 arguments:
-#I  Total: 4 entries
-#I  Method 1: ``foobar: for a string'' at stream:1 , value: 2*SUM_FLAGS+1
+#I  Total: 4 entries, of which 3 are applicable:
+#I  Method 1, valid operation number 1, value: 2*SUM_FLAGS+1
+#I  ``foobar: for a string''
+#I   at stream:1
 function ( x )
     return StartsWith( x, "foo" );
 end
-gap> Display(ApplicableMethod(foobar, [ ['a'] ], 1, 2));
+gap> ApplicableMethod(foobar, 'a', 1);   
+#I  argument 2 must be a list of arguments for the operation
+#I  usage: ApplicableMethod(<opr>,<arglist>[,<verbosity>[,<nr>]])
+fail
+gap> ApplicableMethod(foobar, [ ['a'] ], 1, 3);
 #I  Searching Method for foobar with 1 arguments:
-#I  Total: 4 entries
-#I  Method 1: ``foobar: for a string'' at stream:1 , value: 2*SUM_FLAGS+1
-#I  Skipped:
-#I  Method 2: ``foobar: for a list'' at stream:1 , value: 42
-<Attribute "Length">
+#I  Total: 4 entries, of which 3 are applicable:
+#I  Method 4, valid operation number 3, value: 0
+#I  ``foobar''
+#I   at stream:1
+function( x ) ... end
+gap> ApplicableMethod(foobar, [ ['a'] ], 1, 4);
+#I  Searching Method for foobar with 1 arguments:
+#I  Total: 4 entries, of which 3 are applicable:
+#I  there are only 3 valid methods
+fail
+gap> ApplicableMethod(foobar, [ ['a'] ], 1, "all");
+#I  Searching Method for foobar with 1 arguments:
+#I  Total: 4 entries, of which 3 are applicable:
+#I  Method 1, valid operation number 1, value: 2*SUM_FLAGS+1
+#I  ``foobar: for a string''
+#I   at stream:1
+#I  Method 2, valid operation number 2, value: 42
+#I  ``foobar: for a list''
+#I   at stream:1
+#I  Method 4, valid operation number 3, value: 0
+#I  ``foobar''
+#I   at stream:1
+function( x ) ... end
+
+#
 gap> Display(ApplicableMethod(foobar, [fail], 1));
 #I  Searching Method for foobar with 1 arguments:
-#I  Total: 4 entries
-#I  Method 4: ``foobar'' at stream:1 , value: 0
+#I  Total: 4 entries, of which 1 is applicable:
+#I  Method 4, valid operation number 1, value: 0
+#I  ``foobar''
+#I   at stream:1
 function ( x )
     return fail;
 end
-gap> Display(ApplicableMethod(foobar, [fail], 4));
+gap> ApplicableMethod(foobar, [fail], 4);
 #I  Searching Method for foobar with 1 arguments:
-#I  Total: 4 entries
-#I  Method 1: ``foobar: for a string'' at stream:1, value: 2*SUM_FLAGS+1
+#I  Total: 4 entries, of which 1 is applicable:
+#I  Method 1, value: 2*SUM_FLAGS+1
+#I  ``foobar: for a string''
+#I   at stream:1
 #I   - 1st argument needs [ "IsString" ]
-#I  Method 2: ``foobar: for a list'' at stream:1, value: 42
+#I  Method 2, value: 42
+#I  ``foobar: for a list''
+#I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
-#I  Method 3: ``foobar: for an integer'' at stream:1, value: 1
+#I  Method 3, value: 1
+#I  ``foobar: for an integer''
+#I   at stream:1
 #I   - 1st argument needs [ "IsInt" ]
-#I  Method 4: ``foobar'' at stream:1, value: 0
-function ( x )
-    return fail;
-end
-gap> ApplicableMethod(foobar, [fail], 6);; Print("\n");
+#I  Method 4, valid operation number 1, value: 0
+#I  ``foobar''
+#I   at stream:1
+function( x ) ... end
+gap> ApplicableMethod(foobar, [fail], 6);; 
 #I  Searching Method for foobar with 1 arguments:
-#I  Total: 4 entries
-#I  Method 1: ``foobar: for a string'' at stream:1, value: 2*SUM_FLAGS+1
+#I  Total: 4 entries, of which 1 is applicable:
+#I  Method 1, value: 2*SUM_FLAGS+1
+#I  ``foobar: for a string''
+#I   at stream:1
 #I   - 1st argument needs [ "IsString" ]
-#I  Method 2: ``foobar: for a list'' at stream:1, value: 42
+#I  Method 2, value: 42
+#I  ``foobar: for a list''
+#I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
-#I  Method 3: ``foobar: for an integer'' at stream:1, value: 1
+#I  Method 3, value: 1
+#I  ``foobar: for an integer''
+#I   at stream:1
 #I   - 1st argument needs [ "IsInt" ]
-#I  Method 4: ``foobar'' at stream:1, value: 0
-#I  Function Body:
-function ( x )
-    return fail;
-end
+#I  Method 4, valid operation number 1, value: 0
+#I  ``foobar''
+#I   at stream:1
 
 #
 # Test other methods with two args
@@ -91,45 +131,49 @@ function ( x, y... )
 end
 gap> Display(ApplicableMethod(foobar, [1, 2], 1));
 #I  Searching Method for foobar with 2 arguments:
-#I  Total: 2 entries
-#I  Method 2: ``foobar: for 2 integers'' at stream:2 , value: 0
+#I  Total: 2 entries, of which 1 is applicable:
+#I  Method 2, valid operation number 1, value: 0
+#I  ``foobar: for 2 integers''
+#I   at stream:2
 function ( x, y... )
     return 1;
 end
 gap> Display(ApplicableMethod(foobar, [1, 2], 2));
 #I  Searching Method for foobar with 2 arguments:
-#I  Total: 2 entries
-#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
-#I  Method 2: ``foobar: for 2 integers'' at stream:2, value: 0
+#I  Total: 2 entries, of which 1 is applicable:
+#I  Method 1, value: 17
+#I  ``foobar: for two lists''
+#I   at stream:1
+#I  Method 2, valid operation number 1, value: 0
+#I  ``foobar: for 2 integers''
+#I   at stream:2
 function ( x, y... )
     return 1;
 end
 gap> Display(ApplicableMethod(foobar, [1, 2], 3));
 #I  Searching Method for foobar with 2 arguments:
-#I  Total: 2 entries
-#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
+#I  Total: 2 entries, of which 1 is applicable:
+#I  Method 1, value: 17
+#I  ``foobar: for two lists''
+#I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
-#I  Method 2: ``foobar: for 2 integers'' at stream:2, value: 0
+#I  Method 2, valid operation number 1, value: 0
+#I  ``foobar: for 2 integers''
+#I   at stream:2
 function ( x, y... )
     return 1;
 end
 gap> Display(ApplicableMethod(foobar, [1, 2], 4));
 #I  Searching Method for foobar with 2 arguments:
-#I  Total: 2 entries
-#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
+#I  Total: 2 entries, of which 1 is applicable:
+#I  Method 1, value: 17
+#I  ``foobar: for two lists''
+#I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
 #I   - 2nd argument needs [ "IsList" ]
-#I  Method 2: ``foobar: for 2 integers'' at stream:2, value: 0
-function ( x, y... )
-    return 1;
-end
-gap> Display(ApplicableMethod(foobar, [1, 2], 5));
-#I  Searching Method for foobar with 2 arguments:
-#I  Total: 2 entries
-#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
-#I   - 1st argument needs [ "IsList" ]
-#I   - 2nd argument needs [ "IsList" ]
-#I  Method 2: ``foobar: for 2 integers'' at stream:2, value: 0
+#I  Method 2, valid operation number 1, value: 0
+#I  ``foobar: for 2 integers''
+#I   at stream:2
 function ( x, y... )
     return 1;
 end
@@ -137,78 +181,101 @@ end
 # check the method for two lists
 gap> ApplicableMethod(foobar, [[1], []], 5);;
 #I  Searching Method for foobar with 2 arguments:
-#I  Total: 2 entries
-#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
+#I  Total: 2 entries, of which 1 is applicable:
+#I  Method 1, valid operation number 1, value: 17
+#I  ``foobar: for two lists''
+#I   at stream:1
 
 # no method found
-gap> ApplicableMethod(foobar, [1, []], 5);
+gap> ApplicableMethod(foobar, [1, []], 1);   
 #I  Searching Method for foobar with 2 arguments:
-#I  Total: 2 entries
-#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
-#I   - 1st argument needs [ "IsList" ]
-#I  Method 2: ``foobar: for 2 integers'' at stream:2, value: 0
-#I   - 2nd argument needs [ "IsInt" ]
+#I  Total: 2 entries, of which 0 are applicable:
+#I  there are no valid methods with these parameters
+fail
+gap> ApplicableMethod(foobar, [1, []], 2);
+#I  Searching Method for foobar with 2 arguments:
+#I  Total: 2 entries, of which 0 are applicable:
+#I  there are no valid methods with these parameters
+#I  Method 1, value: 17
+#I  ``foobar: for two lists''
+#I   at stream:1
+#I  Method 2, value: 0
+#I  ``foobar: for 2 integers''
+#I   at stream:2
 fail
 
 #
 # check 0-6 arguments
 #
-gap> Display(ApplicableMethod(foobar, [], 5));
+gap> ApplicableMethod(foobar, [], 4);
 #I  Searching Method for foobar with 0 arguments:
-#I  Total: 1 entries
-#I  Method 1: ``foobar: for no argument'' at stream:1, value: 0
-function (  )
-    return 1;
-end
-gap> Display(ApplicableMethod(foobar, [1], 5));
+#I  Total: 1 entries, of which 1 is applicable:
+#I  Method 1, valid operation number 1, value: 0
+#I  ``foobar: for no argument''
+#I   at stream:1
+function(  ) ... end
+gap> ApplicableMethod(foobar, [1], 4, 1);
 #I  Searching Method for foobar with 1 arguments:
-#I  Total: 4 entries
-#I  Method 1: ``foobar: for a string'' at stream:1, value: 2*SUM_FLAGS+1
+#I  Total: 4 entries, of which 2 are applicable:
+#I  Method 1, value: 2*SUM_FLAGS+1
+#I  ``foobar: for a string''
+#I   at stream:1
 #I   - 1st argument needs [ "IsString" ]
-#I  Method 2: ``foobar: for a list'' at stream:1, value: 42
+#I  Method 2, value: 42
+#I  ``foobar: for a list''
+#I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
-#I  Method 3: ``foobar: for an integer'' at stream:1, value: 1
-function ( x )
-    return 1;
-end
-gap> Display(ApplicableMethod(foobar, [1,2], 5));
+#I  Method 3, valid operation number 1, value: 1
+#I  ``foobar: for an integer''
+#I   at stream:1
+function( x ) ... end
+gap> ApplicableMethod(foobar, [1], 4, 2);
+#I  Searching Method for foobar with 1 arguments:
+#I  Total: 4 entries, of which 2 are applicable:
+#I  Method 4, valid operation number 2, value: 0
+#I  ``foobar''
+#I   at stream:1
+function( x ) ... end
+gap> ApplicableMethod(foobar, [1,2], 4);   
 #I  Searching Method for foobar with 2 arguments:
-#I  Total: 2 entries
-#I  Method 1: ``foobar: for two lists'' at stream:1, value: 17
+#I  Total: 2 entries, of which 1 is applicable:
+#I  Method 1, value: 17
+#I  ``foobar: for two lists''
+#I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
 #I   - 2nd argument needs [ "IsList" ]
-#I  Method 2: ``foobar: for 2 integers'' at stream:2, value: 0
-function ( x, y... )
-    return 1;
-end
-gap> Display(ApplicableMethod(foobar, [1..3], 5));
+#I  Method 2, valid operation number 1, value: 0
+#I  ``foobar: for 2 integers''
+#I   at stream:2
+function( x, y... ) ... end
+gap> ApplicableMethod(foobar, [1..3], 4);
 #I  Searching Method for foobar with 3 arguments:
-#I  Total: 1 entries
-#I  Method 1: ``foobar: for 3 integers'' at stream:3, value: 0
-function ( x, y... )
-    return 1;
-end
-gap> Display(ApplicableMethod(foobar, [1..4], 5));
+#I  Total: 1 entries, of which 1 is applicable:
+#I  Method 1, valid operation number 1, value: 0
+#I  ``foobar: for 3 integers''
+#I   at stream:3
+function( x, y... ) ... end
+gap> ApplicableMethod(foobar, [1..4], 4);
 #I  Searching Method for foobar with 4 arguments:
-#I  Total: 1 entries
-#I  Method 1: ``foobar: for 4 integers'' at stream:4, value: 0
-function ( x, y... )
-    return 1;
-end
-gap> Display(ApplicableMethod(foobar, [1..5], 5));
+#I  Total: 1 entries, of which 1 is applicable:
+#I  Method 1, valid operation number 1, value: 0
+#I  ``foobar: for 4 integers''
+#I   at stream:4
+function( x, y... ) ... end
+gap> ApplicableMethod(foobar, [1..5], 2);
 #I  Searching Method for foobar with 5 arguments:
-#I  Total: 1 entries
-#I  Method 1: ``foobar: for 5 integers'' at stream:5, value: 0
-function ( x, y... )
-    return 1;
-end
-gap> Display(ApplicableMethod(foobar, [1..6], 5));
+#I  Total: 1 entries, of which 1 is applicable:
+#I  Method 1, valid operation number 1, value: 0
+#I  ``foobar: for 5 integers''
+#I   at stream:5
+function( x, y... ) ... end
+gap> ApplicableMethod(foobar, [1..6], 1);
 #I  Searching Method for foobar with 6 arguments:
-#I  Total: 1 entries
-#I  Method 1: ``foobar: for 6 integers'' at stream:6, value: 0
-function ( x, y... )
-    return 1;
-end
+#I  Total: 1 entries, of which 1 is applicable:
+#I  Method 1, valid operation number 1, value: 0
+#I  ``foobar: for 6 integers''
+#I   at stream:6
+function( x, y... ) ... end
 
 #
-gap> STOP_TEST("methwy.tst");
+gap> STOP_TEST("methwhy.tst");

--- a/tst/testinstall/methwhy.tst
+++ b/tst/testinstall/methwhy.tst
@@ -38,7 +38,7 @@ end
 gap> Display(ApplicableMethod(foobar, [ ['a'] ], 1));
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 3 are applicable:
-#I  Method 1, applicable operation number 1, value: 2*SUM_FLAGS+1
+#I  Method 1, applicable method number 1, value: 2*SUM_FLAGS+1
 #I  ``foobar: for a string''
 #I   at stream:1
 function ( x )
@@ -51,7 +51,7 @@ fail
 gap> ApplicableMethod(foobar, [ ['a'] ], 1, 3);
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 3 are applicable:
-#I  Method 4, applicable operation number 3, value: 0
+#I  Method 4, applicable method number 3, value: 0
 #I  ``foobar''
 #I   at stream:1
 function( x ) ... end
@@ -63,13 +63,13 @@ fail
 gap> ApplicableMethod(foobar, [ ['a'] ], 1, "all");
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 3 are applicable:
-#I  Method 1, applicable operation number 1, value: 2*SUM_FLAGS+1
+#I  Method 1, applicable method number 1, value: 2*SUM_FLAGS+1
 #I  ``foobar: for a string''
 #I   at stream:1
-#I  Method 2, applicable operation number 2, value: 42
+#I  Method 2, applicable method number 2, value: 42
 #I  ``foobar: for a list''
 #I   at stream:1
-#I  Method 4, applicable operation number 3, value: 0
+#I  Method 4, applicable method number 3, value: 0
 #I  ``foobar''
 #I   at stream:1
 [ function( x ) ... end, <Attribute "Length">, function( x ) ... end ]
@@ -78,7 +78,7 @@ gap> ApplicableMethod(foobar, [ ['a'] ], 1, "all");
 gap> Display(ApplicableMethod(foobar, [fail], 1));
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 1 is applicable:
-#I  Method 4, applicable operation number 1, value: 0
+#I  Method 4, applicable method number 1, value: 0
 #I  ``foobar''
 #I   at stream:1
 function ( x )
@@ -99,7 +99,7 @@ gap> ApplicableMethod(foobar, [fail], 4);
 #I  ``foobar: for an integer''
 #I   at stream:1
 #I   - 1st argument needs [ "IsInt" ]
-#I  Method 4, applicable operation number 1, value: 0
+#I  Method 4, applicable method number 1, value: 0
 #I  ``foobar''
 #I   at stream:1
 function( x ) ... end
@@ -118,7 +118,7 @@ gap> ApplicableMethod(foobar, [fail], 6);;
 #I  ``foobar: for an integer''
 #I   at stream:1
 #I   - 1st argument needs [ "IsInt" ]
-#I  Method 4, applicable operation number 1, value: 0
+#I  Method 4, applicable method number 1, value: 0
 #I  ``foobar''
 #I   at stream:1
 
@@ -132,7 +132,7 @@ end
 gap> Display(ApplicableMethod(foobar, [1, 2], 1));
 #I  Searching Method for foobar with 2 arguments:
 #I  Total: 2 entries, of which 1 is applicable:
-#I  Method 2, applicable operation number 1, value: 0
+#I  Method 2, applicable method number 1, value: 0
 #I  ``foobar: for 2 integers''
 #I   at stream:2
 function ( x, y... )
@@ -144,7 +144,7 @@ gap> Display(ApplicableMethod(foobar, [1, 2], 2));
 #I  Method 1, value: 17
 #I  ``foobar: for two lists''
 #I   at stream:1
-#I  Method 2, applicable operation number 1, value: 0
+#I  Method 2, applicable method number 1, value: 0
 #I  ``foobar: for 2 integers''
 #I   at stream:2
 function ( x, y... )
@@ -157,7 +157,7 @@ gap> Display(ApplicableMethod(foobar, [1, 2], 3));
 #I  ``foobar: for two lists''
 #I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
-#I  Method 2, applicable operation number 1, value: 0
+#I  Method 2, applicable method number 1, value: 0
 #I  ``foobar: for 2 integers''
 #I   at stream:2
 function ( x, y... )
@@ -171,7 +171,7 @@ gap> Display(ApplicableMethod(foobar, [1, 2], 4));
 #I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
 #I   - 2nd argument needs [ "IsList" ]
-#I  Method 2, applicable operation number 1, value: 0
+#I  Method 2, applicable method number 1, value: 0
 #I  ``foobar: for 2 integers''
 #I   at stream:2
 function ( x, y... )
@@ -182,7 +182,7 @@ end
 gap> ApplicableMethod(foobar, [[1], []], 5);;
 #I  Searching Method for foobar with 2 arguments:
 #I  Total: 2 entries, of which 1 is applicable:
-#I  Method 1, applicable operation number 1, value: 17
+#I  Method 1, applicable method number 1, value: 17
 #I  ``foobar: for two lists''
 #I   at stream:1
 
@@ -210,7 +210,7 @@ fail
 gap> ApplicableMethod(foobar, [], 4);
 #I  Searching Method for foobar with 0 arguments:
 #I  Total: 1 entries, of which 1 is applicable:
-#I  Method 1, applicable operation number 1, value: 0
+#I  Method 1, applicable method number 1, value: 0
 #I  ``foobar: for no argument''
 #I   at stream:1
 function(  ) ... end
@@ -225,14 +225,14 @@ gap> ApplicableMethod(foobar, [1], 4, 1);
 #I  ``foobar: for a list''
 #I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
-#I  Method 3, applicable operation number 1, value: 1
+#I  Method 3, applicable method number 1, value: 1
 #I  ``foobar: for an integer''
 #I   at stream:1
 function( x ) ... end
 gap> ApplicableMethod(foobar, [1], 4, 2);
 #I  Searching Method for foobar with 1 arguments:
 #I  Total: 4 entries, of which 2 are applicable:
-#I  Method 4, applicable operation number 2, value: 0
+#I  Method 4, applicable method number 2, value: 0
 #I  ``foobar''
 #I   at stream:1
 function( x ) ... end
@@ -244,35 +244,35 @@ gap> ApplicableMethod(foobar, [1,2], 4);
 #I   at stream:1
 #I   - 1st argument needs [ "IsList" ]
 #I   - 2nd argument needs [ "IsList" ]
-#I  Method 2, applicable operation number 1, value: 0
+#I  Method 2, applicable method number 1, value: 0
 #I  ``foobar: for 2 integers''
 #I   at stream:2
 function( x, y... ) ... end
 gap> ApplicableMethod(foobar, [1..3], 4);
 #I  Searching Method for foobar with 3 arguments:
 #I  Total: 1 entries, of which 1 is applicable:
-#I  Method 1, applicable operation number 1, value: 0
+#I  Method 1, applicable method number 1, value: 0
 #I  ``foobar: for 3 integers''
 #I   at stream:3
 function( x, y... ) ... end
 gap> ApplicableMethod(foobar, [1..4], 4);
 #I  Searching Method for foobar with 4 arguments:
 #I  Total: 1 entries, of which 1 is applicable:
-#I  Method 1, applicable operation number 1, value: 0
+#I  Method 1, applicable method number 1, value: 0
 #I  ``foobar: for 4 integers''
 #I   at stream:4
 function( x, y... ) ... end
 gap> ApplicableMethod(foobar, [1..5], 2);
 #I  Searching Method for foobar with 5 arguments:
 #I  Total: 1 entries, of which 1 is applicable:
-#I  Method 1, applicable operation number 1, value: 0
+#I  Method 1, applicable method number 1, value: 0
 #I  ``foobar: for 5 integers''
 #I   at stream:5
 function( x, y... ) ... end
 gap> ApplicableMethod(foobar, [1..6], 1);
 #I  Searching Method for foobar with 6 arguments:
 #I  Total: 1 entries, of which 1 is applicable:
-#I  Method 1, applicable operation number 1, value: 0
+#I  Method 1, applicable method number 1, value: 0
 #I  ``foobar: for 6 integers''
 #I   at stream:6
 function( x, y... ) ... end


### PR DESCRIPTION
This PR attempts to address issue #2871. 
The following aims have been addressed (in no particular order):  
 - stick to the existing 'magic constants' (except verbosity 6) rather than introduce 'options'; 
 - when a function, rather than an operation, is given, do not raise an error - return the function; 
 - improve the layout of the #I messages; 
 - this is a function which may well be used by non-expert users, so the Reference Manual needs a selection of examples; 
 - the file tst/testinstall/methwhy.tst required extensive revision.
Undoubtedly more testing is required!