### PR TITLE
set `IsSSortedList` in results of `Positions` etc.

### DIFF
--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -1342,10 +1342,15 @@ InstallGlobalFunction( Filtered,
           res[i]:= elm;
         fi;
       od;
-      return res;
     else
-      return FilteredOp( C, func );
+      res:= FilteredOp( C, func );
     fi;
+
+    if HasIsSSortedList( C ) and IsSSortedList( C ) then
+      SetIsSSortedList( res, true );
+    fi;
+
+    return res;
 end );
 
 

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -689,7 +689,7 @@ DeclareOperation( "Position", [ IsList, IsObject, IS_INT ] );
 ##  <Oper Name="PositionsOp" Arg='list, obj'/>
 ##
 ##  <Description>
-##  returns the positions of <E>all</E> occurrences of <A>obj</A> in
+##  returns the set of positions of <E>all</E> occurrences of <A>obj</A> in
 ##  <A>list</A>.
 ##  <P/>
 ##  <Example><![CDATA[
@@ -958,7 +958,7 @@ DeclareGlobalFunction( "PositionMinimum" );
 ##  <Oper Name="PositionsProperty" Arg='list, func'/>
 ##
 ##  <Description>
-##  returns the list of all those positions in the list <A>list</A>
+##  returns the set of all those positions in the list <A>list</A>
 ##  which are bound and
 ##  for which the property tester function <A>func</A> returns <K>true</K>.
 ##  <P/>
@@ -1007,11 +1007,11 @@ DeclareOperation( "PositionBound", [ IsList ] );
 
 #############################################################################
 ##
-#O  PositionsBound( <list> ) . . . . . . . . . positions of all bound entries
+#F  PositionsBound( <list> ) . . . . . . . . . positions of all bound entries
 ##
 ##  <#GAPDoc Label="PositionsBound">
 ##  <ManSection>
-##  <Oper Name="PositionsBound" Arg='list'/>
+##  <Func Name="PositionsBound" Arg='list'/>
 ##
 ##  <Description>
 ##  returns the set of all bound positions in the list
@@ -1030,7 +1030,6 @@ DeclareOperation( "PositionBound", [ IsList ] );
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction( "PositionsBound", [IsList] );
-
 
 
 #############################################################################

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -1346,10 +1346,13 @@ InstallGlobalFunction( Positions,
           break;
         fi;
       od;
-      return res;
     else
-      return PositionsOp(list,obj);
+      res:= PositionsOp(list,obj);
     fi;
+
+    SetIsSSortedList( res, true );
+
+    return res;
   end );
 # generic method for non-plain lists
 InstallMethod(PositionsOp, [IsList, IsObject], function(list, obj)
@@ -1654,6 +1657,8 @@ InstallMethod( PositionsProperty,
       fi;
     od;
 
+    SetIsSSortedList( result, true );
+
     return result;
     end );
 
@@ -1669,6 +1674,8 @@ InstallMethod( PositionsProperty,
         Add( result, i );
       fi;
     od;
+
+    SetIsSSortedList( result, true );
 
     return result;
     end );
@@ -1709,6 +1716,8 @@ InstallGlobalFunction( PositionsBound, function( list )
             Add( bound, i );
         fi;
     od;
+
+    SetIsSSortedList( bound, true );
 
     return bound;
 end );

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -347,6 +347,15 @@ gap> l := [40, 39 .. 10];;
 gap> RepresentativeSmallest(l);
 10
 
+# Positions
+gap> ll := [ 1, 2, 3, 2, 1, 2 ];;
+gap> Positions( ll, 1 );
+[ 1, 5 ]
+gap> Positions( ll, 4 );
+[  ]
+gap> HasIsSSortedList( Positions( ll, 2 ) );
+true
+
 # PositionsProperty
 gap> ll := [ 1, , "s" ];;
 gap> PositionsProperty( ll, ReturnTrue );
@@ -358,6 +367,8 @@ gap> PositionsProperty( ll, ReturnTrue );
 [ 1, 2, 3 ]
 gap> PositionsProperty( ll, IsInt );
 [ 1, 2, 3 ]
+gap> HasIsSSortedList( PositionsProperty( ll, IsPrimeInt ) );
+true
 
 # PositionProperty
 gap> ll := [ 1, , "s" ];;
@@ -378,6 +389,28 @@ gap> PositionProperty( ll, ReturnTrue, 2);
 3
 gap> PositionProperty( ll, ReturnTrue, 3);
 fail
+
+# PositionBound
+gap> PositionBound( [] );
+fail
+gap> PositionBound( [ 1 .. 3 ] );
+1
+gap> PositionBound( [ 2, 3, 4 ] );
+1
+gap> PositionBound( [ ,, 1 ] );
+3
+
+# PositionsBound
+gap> PositionsBound( [] );
+[  ]
+gap> PositionsBound( [ 1 .. 3 ] );
+[ 1 .. 3 ]
+gap> PositionsBound( [ 1, 2, 3 ] );
+[ 1 .. 3 ]
+gap> PositionsBound( [ 1,, 2 ] );
+[ 1, 3 ]
+gap> HasIsSSortedList( PositionsBound( [ 1,, 2 ] ) );
+true
 
 #
 gap> STOP_TEST("list.tst");

--- a/tst/testinstall/listgen.tst
+++ b/tst/testinstall/listgen.tst
@@ -24,8 +24,14 @@ gap> Reversed( [ 1, 2, 1, 2 ] );
 [ 2, 1, 2, 1 ]
 gap> Print(Reversed( [ 1 .. 10 ] ),"\n");
 [ 10, 9 .. 1 ]
-gap> Filtered( [ 1 .. 10 ], x -> x < 5 );
+gap> filt:= Filtered( [ 1 .. 10 ], x -> x < 5 );
 [ 1, 2, 3, 4 ]
+gap> HasIsSSortedList( filt );
+true
+gap> filt:= Filtered( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ], x -> x < 5 );
+[ 1, 2, 3, 4 ]
+gap> HasIsSSortedList( filt );
+false
 gap> Number( [ 1 .. 10 ], x -> x < 5 );
 4
 gap> Number( [ 1 .. 10 ] );


### PR DESCRIPTION
- The global functions `Positions` and `PositionsBound`
  set the filter `IsSSortedList` for their result.
- The two `PositionsProperty` methods in `lib/list.gi`
  set the filter `IsSSortedList` for their result.
- The documentation of `Positions`and `PositionsProperty`
  now mentions that the result is a set.
- The documentation of `PositionsBound` now states that it is
  a global function not an operation.
- The test file `tst/testinstall/list.tst` now checks
  that `IsSSortedList` is set in these situations.

(It would be easy to set `IsSSortedList` also for the result of
`Filtered` if the given list has `IsSSortedList`.
Would that be reasonable?)