### PR TITLE
Improve some kernel error messages

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -1372,10 +1372,8 @@ Obj FuncSET_NAME_FUNC(
                       Obj func,
                       Obj name )
 {
-  while (!IsStringConv(name)) {
-    name = ErrorReturnObj("SET_NAME_FUNC( <func>, <name> ): <name> must be a string, not a %s",
-                          (Int)TNAM_OBJ(name), 0, "You can return a new name to continue");
-  }
+    RequireStringRepMayReplace("SET_NAME_FUNC", name);
+
   if (TNUM_OBJ(func) == T_FUNCTION ) {
     SET_NAME_FUNC(func, ImmutableString(name));
     CHANGED_BAG(func);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5543,22 +5543,12 @@ Obj FuncCOMPILE_FUNC (
     magic1 = ELM_LIST( arg, 4 );
     magic2 = ELM_LIST( arg, 5 );
 
-    /* check the arguments                                                 */
-    if ( ! IsStringConv( output ) ) {
-        ErrorQuit("CompileFunc: <output> must be a string",0L,0L);
-    }
-    if ( TNUM_OBJ(func) != T_FUNCTION ) {
-        ErrorQuit("CompileFunc: <func> must be a function",0L,0L);
-    }
-    if ( ! IsStringConv( name ) ) {
-        ErrorQuit("CompileFunc: <name> must be a string",0L,0L);
-    }
-    if ( ! IS_INTOBJ(magic1) ) {
-        ErrorQuit("CompileFunc: <magic1> must be an integer",0L,0L);
-    }
-    if ( ! IsStringConv(magic2) ) {
-        ErrorQuit("CompileFunc: <magic2> must be a string",0L,0L);
-    }
+    // check the arguments
+    RequireStringRep("CompileFunc", output);
+    RequireFunction("CompileFunc", func);
+    RequireStringRep("CompileFunc", name);
+    RequireSmallInt("CompileFunc", magic1, "magic1");
+    RequireStringRep("CompileFunc", magic2);
 
     /* possible optimiser flags                                            */
     CompFastIntArith        = 1;

--- a/src/error.c
+++ b/src/error.c
@@ -586,6 +586,55 @@ void CheckSameLength(const Char * desc, const Char *leftName, const Char *rightN
 
 /****************************************************************************
 **
+*F  RACErrorHelper
+*/
+Obj RACErrorHelper(int          mayReturn,
+                   const char * funcname,
+                   Obj          op,
+                   const char * argname,
+                   const char * msg)
+{
+    char msgbuf[1024] = { 0 };
+    Int  arg1 = 0;
+    Int  arg2 = 0;
+
+    strlcat(msgbuf, funcname, sizeof(msgbuf));
+    strlcat(msgbuf, ": <", sizeof(msgbuf));
+    strlcat(msgbuf, argname, sizeof(msgbuf));
+    strlcat(msgbuf, "> ", sizeof(msgbuf));
+    strlcat(msgbuf, msg, sizeof(msgbuf));
+    if (IS_INTOBJ(op)) {
+        strlcat(msgbuf, " (not the integer %d)", sizeof(msgbuf));
+        arg1 = INT_INTOBJ(op);
+    }
+    else if (op == True)
+        strlcat(msgbuf, " (not the value 'true')", sizeof(msgbuf));
+    else if (op == False)
+        strlcat(msgbuf, " (not the value 'false')", sizeof(msgbuf));
+    else if (op == Fail)
+        strlcat(msgbuf, " (not the value 'fail')", sizeof(msgbuf));
+    else {
+        strlcat(msgbuf, " (not a %s)", sizeof(msgbuf));
+        arg1 = (Int)TNAM_OBJ(op);
+    }
+
+    if (mayReturn) {
+        char extrabuf[1024] = { 0 };
+        strlcat(extrabuf, "you can replace <", sizeof(extrabuf));
+        strlcat(extrabuf, argname, sizeof(extrabuf));
+        strlcat(extrabuf, "> via 'return <", sizeof(extrabuf));
+        strlcat(extrabuf, argname, sizeof(extrabuf));
+        strlcat(extrabuf, ">;'", sizeof(extrabuf));
+        return ErrorReturnObj(msgbuf, arg1, arg2, extrabuf);
+    }
+    else {
+        ErrorMayQuit(msgbuf, arg1, arg2);
+    }
+}
+
+
+/****************************************************************************
+**
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
 static StructGVarFunc GVarFuncs[] = {

--- a/src/error.h
+++ b/src/error.h
@@ -163,6 +163,42 @@ extern Obj RACErrorHelper(int          mayReturn,
 
 /****************************************************************************
 **
+*F  RequireInt
+*/
+#define RequireInt(funcname, op, argname) \
+    RequireArgumentCondition(funcname, op, argname, IS_INT(op), \
+        "must be an integer")
+
+
+/****************************************************************************
+**
+*F  RequireIntMayReplace
+*/
+#define RequireIntMayReplace(funcname, op, argname) \
+    RequireArgumentConditionMayReplace(funcname, op, argname, IS_INT(op), \
+        "must be an integer")
+
+
+/****************************************************************************
+**
+*F  RequireSmallInt
+*/
+#define RequireSmallInt(funcname, op, argname) \
+    RequireArgumentCondition(funcname, op, argname, IS_INTOBJ(op), \
+        "must be a small integer")
+
+
+/****************************************************************************
+**
+*F  RequireSmallIntMayReplace
+*/
+#define RequireSmallIntMayReplace(funcname, op, argname) \
+    RequireArgumentConditionMayReplace(funcname, op, argname, IS_INTOBJ(op), \
+        "must be a small integer")
+
+
+/****************************************************************************
+**
 *F  RequirePositiveSmallInt
 */
 #define RequirePositiveSmallInt(funcname, op, argname) \

--- a/src/error.h
+++ b/src/error.h
@@ -253,6 +253,24 @@ extern Obj RACErrorHelper(int          mayReturn,
 
 /****************************************************************************
 **
+*F  RequireStringRep
+*/
+#define RequireStringRep(funcname, op) \
+    RequireArgumentCondition(funcname, op, #op, IsStringConv(op), \
+        "must be a string")
+
+
+/****************************************************************************
+**
+*F  RequireStringRepMayReplace
+*/
+#define RequireStringRepMayReplace(funcname, op) \
+    RequireArgumentConditionMayReplace(funcname, op, #op, IsStringConv(op), \
+        "must be a string")
+
+
+/****************************************************************************
+**
 *F  CheckIsPossList( <desc>, <poss> ) . . . . . . . . . . check for poss list
 */
 void CheckIsPossList(const Char * desc, Obj poss);

--- a/src/error.h
+++ b/src/error.h
@@ -129,14 +129,23 @@ ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2);
 
 /****************************************************************************
 **
+*F  RACErrorHelper
+*/
+extern Obj RACErrorHelper(int          mayReturn,
+                          const char * funcname,
+                          Obj          op,
+                          const char * argname,
+                          const char * msg);
+
+/****************************************************************************
+**
 *F  RequireArgumentCondition
 */
-#define RequireArgumentCondition(funcname, op, argname, cond, msg) \
-    do { \
-        if (!(cond)) { \
-            ErrorMayQuit(funcname ": <" argname "> " msg " (not a %s)", \
-                (Int)TNAM_OBJ(op), 0); \
-        } \
+#define RequireArgumentCondition(funcname, op, argname, cond, msg)           \
+    do {                                                                     \
+        if (!(cond)) {                                                       \
+            RACErrorHelper(0, funcname, op, argname, msg);                   \
+        }                                                                    \
     } while (0)
 
 
@@ -145,12 +154,10 @@ ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2);
 *F  RequireArgumentConditionMayReplace
 */
 #define RequireArgumentConditionMayReplace(funcname, op, argname, cond, msg) \
-    do { \
-        while (!(cond)) { \
-            op = ErrorReturnObj(funcname ": <" argname "> " msg " (not a %s)", \
-                (Int)TNAM_OBJ(op), 0, \
-                "you can replace <" argname "> via 'return <" argname ">;'"); \
-        } \
+    do {                                                                     \
+        while (!(cond)) {                                                    \
+            op = RACErrorHelper(1, funcname, op, argname, msg);              \
+        }                                                                    \
     } while (0)
 
 

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1086,12 +1086,7 @@ Obj             EvalRangeExpr (
 
     /* evaluate the low value                                              */
     val = EVAL_EXPR(READ_EXPR(expr, 0));
-    while ( ! IS_INTOBJ(val) ) {
-        val = ErrorReturnObj(
-            "Range: <first> must be a small integer (not a %s)",
-            (Int)TNAM_OBJ(val), 0,
-            "you can replace <first> via 'return <first>;'" );
-    }
+    RequireSmallIntMayReplace("Range", val, "first");
     low = INT_INTOBJ( val );
 
     /* evaluate the second value (if present)                              */

--- a/src/gap.c
+++ b/src/gap.c
@@ -892,12 +892,7 @@ Obj FuncGASMAN (
         /* evaluate and check the command                                  */
         Obj cmd = ELM_PLIST( args, i );
 again:
-        while ( ! IsStringConv(cmd) ) {
-           cmd = ErrorReturnObj(
-               "GASMAN: <cmd> must be a string (not a %s)",
-               (Int)TNAM_OBJ(cmd), 0L,
-               "you can replace <cmd> via 'return <cmd>;'" );
-       }
+        RequireStringRepMayReplace("GASMAN", cmd);
 
         // perform full garbage collection
         if ( strcmp( CONST_CSTR_STRING(cmd), "collect" ) == 0 ) {

--- a/src/gap.c
+++ b/src/gap.c
@@ -1195,25 +1195,20 @@ Obj FuncFUNC_BODY_SIZE(Obj self, Obj f)
 
 Obj FuncSleep( Obj self, Obj secs )
 {
-  Int  s;
+    RequireSmallIntMayReplace("Sleep", secs, "secs");
 
-  while( ! IS_INTOBJ(secs) )
-    secs = ErrorReturnObj( "<secs> must be a small integer", 0L, 0L, 
-                           "you can replace <secs> via 'return <secs>;'" );
+    Int s = INT_INTOBJ(secs);
+    if (s > 0)
+        SySleep((UInt)s);
 
-  
-  if ( (s = INT_INTOBJ(secs)) > 0)
-    SySleep((UInt)s);
-  
-  /* either we used up the time, or we were interrupted. */
-  if (HaveInterrupt())
-    {
-      ClearError(); /* The interrupt may still be pending */
-      ErrorReturnVoid("user interrupt in sleep", 0L, 0L,
-                    "you can 'return;' as if the sleep was finished");
+    /* either we used up the time, or we were interrupted. */
+    if (HaveInterrupt()) {
+        ClearError(); /* The interrupt may still be pending */
+        ErrorReturnVoid("user interrupt in sleep", 0L, 0L,
+                        "you can 'return;' as if the sleep was finished");
     }
-  
-  return (Obj) 0;
+
+    return (Obj)0;
 }
 
 
@@ -1225,25 +1220,23 @@ Obj FuncSleep( Obj self, Obj secs )
 
 Obj FuncMicroSleep( Obj self, Obj msecs )
 {
-  Int  s;
+    RequireSmallIntMayReplace("MicroSleep", msecs, "usecs");
 
-  while( ! IS_INTOBJ(msecs) )
-    msecs = ErrorReturnObj( "<usecs> must be a small integer", 0L, 0L, 
-                           "you can replace <usecs> via 'return <usecs>;'" );
+    Int s = INT_INTOBJ(msecs);
 
-  
-  if ( (s = INT_INTOBJ(msecs)) > 0)
-    SyUSleep((UInt)s);
-  
-  /* either we used up the time, or we were interrupted. */
-  if (HaveInterrupt())
-    {
-      ClearError(); /* The interrupt may still be pending */
-      ErrorReturnVoid("user interrupt in microsleep", 0L, 0L,
-                    "you can 'return;' as if the microsleep was finished");
+
+    if (s > 0)
+        SyUSleep((UInt)s);
+
+    /* either we used up the time, or we were interrupted. */
+    if (HaveInterrupt()) {
+        ClearError(); /* The interrupt may still be pending */
+        ErrorReturnVoid(
+            "user interrupt in microsleep", 0L, 0L,
+            "you can 'return;' as if the microsleep was finished");
     }
-  
-  return (Obj) 0;
+
+    return (Obj)0;
 }
 
 

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -901,12 +901,7 @@ Obj             FuncAUTO (
 
     /* get and check the function                                          */
     func = ELM_LIST( args, 1 );
-    while ( TNUM_OBJ(func) != T_FUNCTION ) {
-        func = ErrorReturnObj(
-            "AUTO: <func> must be a function (not a %s)",
-            (Int)TNAM_OBJ(func), 0L,
-            "you can return a function for <func>" );
-    }
+    RequireFunctionMayReplace("AUTO", func);
 
     /* get the argument                                                    */
     arg = ELM_LIST( args, 2 );

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -740,13 +740,8 @@ Obj FuncMakeReadOnlyGVar (
     Obj                 self,
     Obj                 name )
 {       
-    /* check the argument                                                  */
-    while ( ! IsStringConv( name ) ) {
-        name = ErrorReturnObj(
-            "MakeReadOnlyGVar: <name> must be a string (not a %s)",
-            (Int)TNAM_OBJ(name), 0L,
-            "you can return a string for <name>" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("MakeReadOnlyGVar", name);
 
     /* get the variable and make it read only                              */
     MakeReadOnlyGVar(GVarName(CONST_CSTR_STRING(name)));
@@ -768,12 +763,8 @@ Obj FuncMakeReadOnlyGVar (
 */
 Obj FuncMakeConstantGVar(Obj self, Obj name)
 {
-    /* check the argument                                                  */
-    while (!IsStringConv(name)) {
-        name = ErrorReturnObj(
-            "MakeConstantGVar: <name> must be a string (not a %s)",
-            (Int)TNAM_OBJ(name), 0L, "you can return a string for <name>");
-    }
+    // check the argument
+    RequireStringRepMayReplace("MakeConstantGVar", name);
 
     /* get the variable and make it read only                              */
     MakeConstantGVar(GVarName(CONST_CSTR_STRING(name)));
@@ -812,13 +803,8 @@ Obj FuncMakeReadWriteGVar (
     Obj                 self,
     Obj                 name )
 {
-    /* check the argument                                                  */
-    while ( ! IsStringConv( name ) ) {
-        name = ErrorReturnObj(
-            "MakeReadWriteGVar: <name> must be a string (not a %s)",
-            (Int)TNAM_OBJ(name), 0L,
-            "you can return a string for <name>" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("MakeReadWriteGVar", name);
 
     /* get the variable and make it read write                             */
     MakeReadWriteGVar(GVarName(CONST_CSTR_STRING(name)));
@@ -847,13 +833,8 @@ static Obj FuncIsReadOnlyGVar (
     Obj                 self,
     Obj                 name )
 {
-    /* check the argument                                                  */
-    while ( ! IsStringConv( name ) ) {
-        name = ErrorReturnObj(
-            "IsReadOnlyGVar: <name> must be a string (not a %s)",
-            (Int)TNAM_OBJ(name), 0L,
-            "you can return a string for <name>" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("IsReadOnlyGVar", name);
 
     /* get the answer                             */
     return IsReadOnlyGVar(GVarName(CONST_CSTR_STRING(name))) ? True : False;
@@ -877,11 +858,7 @@ Int IsConstantGVar(UInt gvar)
 static Obj FuncIsConstantGVar(Obj self, Obj name)
 {
     // check the argument
-    while (!IsStringConv(name)) {
-        name = ErrorReturnObj(
-            "IsConstantGVar: <name> must be a string (not a %s)",
-            (Int)TNAM_OBJ(name), 0L, "you can return a string for <name>");
-    }
+    RequireStringRepMayReplace("IsConstantGVar", name);
 
     /* get the answer                             */
     return IsConstantGVar(GVarName(CONST_CSTR_STRING(name))) ? True : False;
@@ -943,12 +920,7 @@ Obj             FuncAUTO (
     /* make the global variables automatic                                 */
     for ( i = 3; i <= LEN_LIST(args); i++ ) {
         name = ELM_LIST( args, i );
-        while ( ! IsStringConv(name) ) {
-            name = ErrorReturnObj(
-                "AUTO: <name> must be a string (not a %s)",
-                (Int)TNAM_OBJ(name), 0L,
-                "you can return a string for <name>" );
-        }
+        RequireStringRepMayReplace("AUTO", name);
         gvar = GVarName( CONST_CSTR_STRING(name) );
         SET_ELM_GVAR_LIST( ValGVars, gvar, 0 );
         SET_ELM_GVAR_LIST( ExprGVars, gvar, list );
@@ -1090,13 +1062,8 @@ Obj FuncASS_GVAR (
     Obj                 gvar,
     Obj                 val )
 {
-    /* check the argument                                                  */
-    while ( ! IsStringConv( gvar ) ) {
-        gvar = ErrorReturnObj(
-            "READ: <gvar> must be a string (not a %s)",
-            (Int)TNAM_OBJ(gvar), 0L,
-            "you can return a string for <gvar>" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("READ", gvar);
 
     AssGVar( GVarName( CONST_CSTR_STRING(gvar) ), val );
     return 0L;
@@ -1111,13 +1078,8 @@ Obj FuncISB_GVAR (
     Obj                 self,
     Obj                 gvar )
 {
-    /* check the argument                                                  */
-    while ( ! IsStringConv( gvar ) ) {
-        gvar = ErrorReturnObj(
-            "ISB_GVAR: <gvar> must be a string (not a %s)",
-            (Int)TNAM_OBJ(gvar), 0L,
-            "you can return a string for <gvar>" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("ISB_GVAR", gvar);
 
     UInt gv = GVarName( CONST_CSTR_STRING(gvar) );
     if (VAL_GVAR_INTERN(gv))
@@ -1145,13 +1107,8 @@ Obj FuncVAL_GVAR (
    Obj                 gvar )
 {
   Obj val;
-    /* check the argument                                                  */
-    while ( ! IsStringConv( gvar ) ) {
-        gvar = ErrorReturnObj(
-            "VAL_GVAR: <gvar> must be a string (not a %s)",
-            (Int)TNAM_OBJ(gvar), 0L,
-            "you can return a string for <gvar>" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("VAL_GVAR", gvar);
 
     /* get the value */
     val = ValAutoGVar( GVarName( CONST_CSTR_STRING(gvar) ) );
@@ -1172,13 +1129,8 @@ Obj FuncUNB_GVAR (
     Obj                 self,
     Obj                 gvar )
 {
-    /* check the argument                                                  */
-    while ( ! IsStringConv( gvar ) ) {
-        gvar = ErrorReturnObj(
-            "UNB_GVAR: <gvar> must be a string (not a %s)",
-            (Int)TNAM_OBJ(gvar), 0L,
-            "you can return a string for <gvar>" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("UNB_GVAR", gvar);
 
     /*  */
     AssGVar( GVarName( CONST_CSTR_STRING(gvar) ), (Obj)0 );

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -1118,8 +1118,7 @@ static Obj FuncGET_ATOMIC_RECORD(Obj self, Obj record, Obj field, Obj def)
   Obj result;
   if (TNUM_OBJ(record) != T_AREC)
     ArgumentError("GET_ATOMIC_RECORD: First argument must be an atomic record");
-  if (!IsStringConv(field))
-    ArgumentError("GET_ATOMIC_RECORD: Second argument must be a string");
+  RequireStringRep("GET_ATOMIC_RECORD", field);
   fieldname = RNamName(CONST_CSTR_STRING(field));
   result = GetARecordField(record, fieldname);
   return result ? result : def;
@@ -1131,8 +1130,7 @@ static Obj FuncSET_ATOMIC_RECORD(Obj self, Obj record, Obj field, Obj value)
   Obj result;
   if (TNUM_OBJ(record) != T_AREC)
     ArgumentError("SET_ATOMIC_RECORD: First argument must be an atomic record");
-  if (!IsStringConv(field))
-    ArgumentError("SET_ATOMIC_RECORD: Second argument must be a string");
+  RequireStringRep("SET_ATOMIC_RECORD", field);
   fieldname = RNamName(CONST_CSTR_STRING(field));
   result = SetARecordField(record, fieldname, value);
   if (!result)
@@ -1147,8 +1145,7 @@ static Obj FuncUNBIND_ATOMIC_RECORD(Obj self, Obj record, Obj field)
   Obj exists;
   if (TNUM_OBJ(record) != T_AREC)
     ArgumentError("UNBIND_ATOMIC_RECORD: First argument must be an atomic record");
-  if (!IsStringConv(field))
-    ArgumentError("UNBIND_ATOMIC_RECORD: Second argument must be a string");
+  RequireStringRep("UNBIND_ATOMIC_RECORD", field);
   fieldname = RNamName(CONST_CSTR_STRING(field));
   if (GetARecordUpdatePolicy(record) != AREC_RW)
     ErrorQuit("UNBIND_ATOMIC_RECORD: Record elements cannot be changed",
@@ -1251,8 +1248,7 @@ static Obj FuncSetTLConstructor(Obj self, Obj record, Obj name, Obj function)
     ArgumentError("SetTLConstructor: First argument must be a thread-local record");
   if (!IS_STRING(name) && !IS_INTOBJ(name))
     ArgumentError("SetTLConstructor: Second argument must be a string or integer");
-  if (TNUM_OBJ(function) != T_FUNCTION)
-    ArgumentError("SetTLConstructor: Third argument must be a function");
+  RequireFunction("SetTLConstructor", function);
   SetTLConstructor(record, RNamObj(name), function);
   return (Obj) 0;
 }
@@ -1638,10 +1634,7 @@ Obj BindOncePosObj(Obj obj, Obj index, Obj *new, int eval, const char *currFuncN
   Int n;
   Bag *contents;
   Bag result;
-  if (!IS_POS_INTOBJ(index)) {
-    FuncError("index for positional object must be a positive small integer");
-    return (Obj) 0; /* flow control hint */
-  }
+  RequirePositiveSmallInt(currFuncName, index, "index");
   n = INT_INTOBJ(index);
   ReadGuard(obj);
 #ifndef WARD_ENABLED
@@ -1698,8 +1691,7 @@ Obj BindOnceAPosObj(Obj obj, Obj index, Obj *new, int eval, const char *currFunc
   addr = ADDR_ATOM(obj);
   MEMBAR_READ();
   len = ALIST_LEN(addr[0].atom);
-  if (!IS_INTOBJ(index))
-    FuncError("Second argument must be an integer");
+  RequireSmallInt(currFuncName, index, "index");
   n = INT_INTOBJ(index);
   if (n <= 0 || n > len)
     FuncError("Index out of range");

--- a/src/integer.c
+++ b/src/integer.c
@@ -2647,21 +2647,16 @@ Obj FuncRandomIntegerMT(Obj self, Obj mtstr, Obj nrbits)
   Int i, n, q, r, qoff, len;
   UInt4 *mt;
   UInt4 *pt;
-  while (! IsStringConv(mtstr)) {
-     mtstr = ErrorReturnObj(
-         "<mtstr> must be a string (not a %s)",
-         (Int)TNAM_OBJ(mtstr), 0L,
-         "you can replace <mtstr> via 'return <mtstr>;'" );
-  }
+  RequireStringRepMayReplace("RandomIntegerMT", mtstr);
   while ((! IsStringConv(mtstr)) || GET_LEN_STRING(mtstr) < 2500) {
      mtstr = ErrorReturnObj(
-         "<mtstr> must be a string with at least 2500 characters",
+         "RandomIntegerMT: <mtstr> must be a string with at least 2500 characters",
          0L, 0L,
          "you can replace <mtstr> via 'return <mtstr>;'" );
   }
   while ((! IS_INTOBJ(nrbits)) || INT_INTOBJ(nrbits) < 0) {
      nrbits = ErrorReturnObj(
-         "<nrbits> must be a small non-negative integer (not a %s)",
+         "RandomIntegerMT: <nrbits> must be a small non-negative integer (not a %s)",
          (Int)TNAM_OBJ(nrbits), 0L,
          "you can replace <mtstr> via 'return <mtstr>;'" );
   }

--- a/src/integer.c
+++ b/src/integer.c
@@ -130,11 +130,7 @@ static Obj ObjInt_UIntInv( UInt i );
 
 #define SIZE_INT_OR_INTOBJ(obj) (IS_INTOBJ(obj) ? 1 : SIZE_INT(obj))
 
-#define REQUIRE_INT_ARG(funcname, argname, op) \
-    if ( !IS_INT(op) ) { \
-      ErrorMayQuit( funcname ": <" argname "> must be an integer (not a %s)", \
-                         (Int)TNAM_OBJ(op), 0L ); \
-    }
+#define REQUIRE_INT_ARG(funcname, argname, op) RequireInt(funcname, op, argname)
 
 GAP_STATIC_ASSERT( sizeof(mp_limb_t) == sizeof(UInt), "gmp limb size incompatible with GAP word size");
 

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -92,12 +92,7 @@ Obj FuncInitRandomMT( Obj self, Obj initstr)
   UInt4 *mt, key_length, byte_key_length, i, j, k, N = 624;
 
   /* check the seed, given as string */
-  while (! IsStringConv(initstr)) {
-     initstr = ErrorReturnObj(
-         "<initstr> must be a string (not a %s)",
-         (Int)TNAM_OBJ(initstr), 0L,
-         "you can replace <initstr> via 'return <initstr>;'" );
-  }
+  RequireStringRepMayReplace("InitRandomMT", initstr);
 
   /* store array of 624 UInt4 and one UInt4 as counter "mti" and an
      endianness marker */

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -453,22 +453,12 @@ Obj FuncHASHKEY_BAG(Obj self, Obj obj, Obj opSeed, Obj opOffset, Obj opMaxLen)
   }
 
   /* check the arguments                                                 */
-  while ( !IS_INTOBJ(opSeed) ) {
-      opSeed = ErrorReturnObj(
-	  "HASHKEY_BAG: <seed> must be a small integer (not a %s)",
-	  (Int)TNAM_OBJ(opSeed), 0L,
-	  "you can replace <seed> via 'return <seed>;'" );
-  }
+  RequireSmallIntMayReplace("HASHKEY_BAG", opSeed, "seed");
   
   do {
     offs = -1;
 
-    while ( !IS_INTOBJ(opOffset)  ) {
-      opOffset = ErrorReturnObj(
-       "HASHKEY_BAG: <offset> must be a small integer (not a %s)",
-       (Int)TNAM_OBJ(opOffset), 0L,
-       "you can replace <offset> via 'return <offset>;'" );      
-    }
+    RequireSmallIntMayReplace("HASHKEY_BAG", opOffset, "offset");
     offs = INT_INTOBJ(opOffset);
     if ( offs < 0 || offs > SIZE_OBJ(obj)) {
       opOffset = ErrorReturnObj(
@@ -479,12 +469,7 @@ Obj FuncHASHKEY_BAG(Obj self, Obj obj, Obj opSeed, Obj opOffset, Obj opMaxLen)
     }
   } while (offs < 0);
 
-  while ( !IS_INTOBJ(opMaxLen) ) {
-      opMaxLen = ErrorReturnObj(
-        "HASHKEY_BAG: <maxlen> must be a small integer (not a %s)",
-        (Int)TNAM_OBJ(opMaxLen), 0L,
-        "you can replace <maxlen> via 'return <maxlen>;'" );
-  }
+  RequireSmallIntMayReplace("HASHKEY_BAG", opMaxLen, "maxlen");
 
   n=SIZE_OBJ(obj)-offs;
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2178,21 +2178,13 @@ void            IntrListExprEnd (
 
         /* get the low value                                               */
         val = ELM_LIST( list, 1 );
-        if ( ! IS_INTOBJ(val) ) {
-            ErrorQuit(
-                "Range: <first> must be a small integer (not a %s)",
-                (Int)TNAM_OBJ(val), 0 );
-        }
+        RequireSmallInt("Range", val, "first");
         low = INT_INTOBJ( val );
 
         /* get the increment                                               */
         if ( nr == 3 ) {
             val = ELM_LIST( list, 2 );
-            if ( ! IS_INTOBJ(val) ) {
-                ErrorQuit(
-                    "Range: <second> must be a small integer (not a %s)",
-                    (Int)TNAM_OBJ(val), 0 );
-            }
+            RequireSmallInt("Range", val, "second");
             if ( INT_INTOBJ(val) == low ) {
                 ErrorQuit(
                       "Range: <second> must not be equal to <first> (%d)",
@@ -2206,11 +2198,7 @@ void            IntrListExprEnd (
 
         /* get and check the high value                                    */
         val = ELM_LIST( list, LEN_LIST(list) );
-        if ( ! IS_INTOBJ(val) ) {
-            ErrorQuit(
-                "Range: <last> must be a small integer (not a %s)",
-                (Int)TNAM_OBJ(val), 0 );
-        }
+        RequireSmallInt("Range", val, "last");
         if ( (INT_INTOBJ(val) - low) % inc != 0 ) {
             ErrorQuit(
                 "Range: <last>-<first> (%d) must be divisible by <inc> (%d)",

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -308,12 +308,8 @@ Obj FuncMACFLOAT_INT( Obj self, Obj i )
 
 Obj FuncMACFLOAT_STRING( Obj self, Obj s )
 {
+    RequireStringRepMayReplace("MACFLOAT_STRING", s);
 
-  while (!IsStringConv(s))
-    {
-      s = ErrorReturnObj("MACFLOAT_STRING: object to be converted must be a string not a %s",
-			 (Int)TNAM_OBJ(s),0,"You can return a string to continue" );
-    }
   char * endptr;
   UChar *sp = CHARS_STRING(s);
   Obj res= NEW_MACFLOAT((Double) STRTOD((char *)sp,&endptr));

--- a/src/modules.c
+++ b/src/modules.c
@@ -125,11 +125,7 @@ static void RegisterModuleState(StructInitInfo * info)
 Obj FuncGAP_CRC(Obj self, Obj filename)
 {
     /* check the argument                                                  */
-    while (!IsStringConv(filename)) {
-        filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)", (Int)TNAM_OBJ(filename),
-            0L, "you can replace <filename> via 'return <filename>;'");
-    }
+    RequireStringRepMayReplace("GAP_CRC", filename);
 
     /* compute the crc value                                               */
     return INTOBJ_INT(SyGAPCRC(CONST_CSTR_STRING(filename)));
@@ -217,14 +213,10 @@ Obj FuncLOAD_DYN(Obj self, Obj filename, Obj crc)
     InitInfoFunc     init;
 
     /* check the argument                                                  */
-    while (!IsStringConv(filename)) {
-        filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)", (Int)TNAM_OBJ(filename),
-            0L, "you can replace <filename> via 'return <filename>;'");
-    }
+    RequireStringRepMayReplace("LOAD_DYN", filename);
     while (!IS_INTOBJ(crc) && crc != False) {
         crc = ErrorReturnObj(
-            "<crc> must be a small integer or 'false' (not a %s)",
+            "LOAD_DYN: <crc> must be a small integer or 'false' (not a %s)",
             (Int)TNAM_OBJ(crc), 0L,
             "you can replace <crc> via 'return <crc>;'");
     }
@@ -298,14 +290,10 @@ Obj FuncLOAD_STAT(Obj self, Obj filename, Obj crc)
     Int              k;
 
     /* check the argument                                                  */
-    while (!IsStringConv(filename)) {
-        filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)", (Int)TNAM_OBJ(filename),
-            0L, "you can replace <filename> via 'return <filename>;'");
-    }
+    RequireStringRepMayReplace("LOAD_STAT", filename);
     while (!IS_INTOBJ(crc) && crc != False) {
         crc = ErrorReturnObj(
-            "<crc> must be a small integer or 'false' (not a %s)",
+            "LOAD_STAT: <crc> must be a small integer or 'false' (not a %s)",
             (Int)TNAM_OBJ(crc), 0L,
             "you can replace <crc> via 'return <crc>;'");
     }

--- a/src/opers.c
+++ b/src/opers.c
@@ -3444,19 +3444,13 @@ Obj FuncINSTALL_GLOBAL_FUNCTION (
     Obj                 func )
 {
     /* check the arguments                                                 */
-    if ( ! IS_FUNC(oper) ) {
-        ErrorQuit( "<oper> must be a function (not a %s)",
-                   (Int)TNAM_OBJ(oper), 0L );
-    }
+    RequireFunction("INSTALL_GLOBAL_FUNCTION", oper);
     if ( (REREADING != True) &&
          (HDLR_FUNC(oper,0) != (ObjFunc)DoUninstalledGlobalFunction) ) {
         ErrorQuit( "operation already installed",
                    0L, 0L );
     }
-    if ( ! IS_FUNC(func) ) {
-        ErrorQuit( "<func> must be a function (not a %s)",
-                   (Int)TNAM_OBJ(func), 0L );
-    }
+    RequireFunction("INSTALL_GLOBAL_FUNCTION", func);
     if ( IS_OPERATION(func) ) {
         ErrorQuit( "<func> must not be an operation", 0L, 0L );
     }

--- a/src/range.c
+++ b/src/range.c
@@ -773,17 +773,9 @@ Obj Range2Check (
 {
     Obj                 range;
     Int                 f, l;
-    if ( ! IS_INTOBJ(first) ) {
-        ErrorQuit(
-            "Range: <first> must be a small integer (not a %s)",
-            (Int)TNAM_OBJ(first), 0L );
-    }
+    RequireSmallInt("Range", first, "first");
+    RequireSmallInt("Range", last, "last");
     f = INT_INTOBJ(first);
-    if ( ! IS_INTOBJ(last) ) {
-        ErrorQuit(
-            "Range: <last> must be a small integer (not a %s)",
-            (Int)TNAM_OBJ(last), 0L );
-    }
     l = INT_INTOBJ(last);
     if ( f > l ) {
         range = NEW_PLIST( T_PLIST, 0 );
@@ -814,28 +806,16 @@ Obj Range3Check (
 {
     Obj                 range;
     Int                 f, i, l;
-    if ( ! IS_INTOBJ(first) ) {
-        ErrorQuit(
-            "Range: <first> must be a small integer (not a %s)",
-            (Int)TNAM_OBJ(first), 0L );
-    }
-    f = INT_INTOBJ(first);
-    if ( ! IS_INTOBJ(second) ) {
-        ErrorQuit(
-            "Range: <second> must be a small integer (not a %s)",
-            (Int)TNAM_OBJ(second), 0L );
-    }
+    RequireSmallInt("Range", first, "first");
+    RequireSmallInt("Range", second, "second");
+    RequireSmallInt("Range", last, "last");
     if ( first == second ) {
         ErrorQuit(
             "Range: <second> must not be equal to <first> (%d)",
             (Int)INT_INTOBJ(first), 0L );
     }
+    f = INT_INTOBJ(first);
     i = INT_INTOBJ(second) - f;
-    if ( ! IS_INTOBJ(last) ) {
-        ErrorQuit(
-            "Range: <last> must be a small integer (not a %s)",
-            (Int)TNAM_OBJ(last), 0L );
-    }
     l = INT_INTOBJ(last);
     if ( (l - f) % i != 0 ) {
         ErrorQuit(

--- a/src/stats.c
+++ b/src/stats.c
@@ -512,20 +512,10 @@ static ALWAYS_INLINE UInt ExecForRangeHelper(Stat stat, UInt nr)
     /* evaluate the range                                                  */
     VisitStatIfHooked(READ_STAT(stat, 1));
     elm = EVAL_EXPR(READ_EXPR(READ_STAT(stat, 1), 0));
-    while ( ! IS_INTOBJ(elm) ) {
-        elm = ErrorReturnObj(
-            "Range: <first> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(elm), 0L,
-            "you can replace <first> via 'return <first>;'" );
-    }
+    RequireSmallIntMayReplace("Range", elm, "first");
     first = INT_INTOBJ(elm);
     elm = EVAL_EXPR(READ_EXPR(READ_STAT(stat, 1), 1));
-    while ( ! IS_INTOBJ(elm) ) {
-        elm = ErrorReturnObj(
-            "Range: <last> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(elm), 0L,
-            "you can replace <last> via 'return <last>;'" );
-    }
+    RequireSmallIntMayReplace("Range", elm, "last");
     last  = INT_INTOBJ(elm);
 
     /* get the body                                                        */

--- a/src/streams.c
+++ b/src/streams.c
@@ -561,12 +561,7 @@ Obj FuncLOG_TO (
     Obj                 self,
     Obj                 filename )
 {
-    while ( ! IsStringConv(filename) ) {
-        filename = ErrorReturnObj(
-            "LogTo: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    RequireStringRepMayReplace("LogTo", filename);
     if ( ! OpenLog( CONST_CSTR_STRING(filename) ) ) {
         ErrorReturnVoid( "LogTo: cannot log to %g",
                          (Int)filename, 0L,
@@ -633,12 +628,7 @@ Obj FuncINPUT_LOG_TO (
     Obj                 self,
     Obj                 filename )
 {
-    while ( ! IsStringConv(filename) ) {
-        filename = ErrorReturnObj(
-            "InputLogTo: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    RequireStringRepMayReplace("InputLogTo", filename);
     if ( ! OpenInputLog( CONST_CSTR_STRING(filename) ) ) {
         ErrorReturnVoid( "InputLogTo: cannot log to %g",
                          (Int)filename, 0L,
@@ -705,12 +695,7 @@ Obj FuncOUTPUT_LOG_TO (
     Obj                 self,
     Obj                 filename )
 {
-    while ( ! IsStringConv(filename) ) {
-        filename = ErrorReturnObj(
-            "OutputLogTo: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    RequireStringRepMayReplace("OutputLogTo", filename);
     if ( ! OpenOutputLog( CONST_CSTR_STRING(filename) ) ) {
         ErrorReturnVoid( "OutputLogTo: cannot log to %g",
                          (Int)filename, 0L,
@@ -790,12 +775,7 @@ static Obj PRINT_OR_APPEND_TO(Obj args, int append)
 
     /* first entry is the filename                                         */
     filename = ELM_LIST(args,1);
-    while ( ! IsStringConv(filename) ) {
-        filename = ErrorReturnObj(
-            "%s: <filename> must be a string (not a %s)",
-            (Int)funcname, (Int)TNAM_OBJ(filename),
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    RequireStringRepMayReplace(funcname, filename);
 
     /* try to open the file for output                                     */
     i = append ? OpenAppend( CONST_CSTR_STRING(filename) )
@@ -975,12 +955,7 @@ Obj FuncREAD (
     Obj                 filename )
 {
    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "READ: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    RequireStringRepMayReplace("READ", filename);
 
     /* try to open the file                                                */
     if ( ! OpenInput( CONST_CSTR_STRING(filename) ) ) {
@@ -1104,13 +1079,8 @@ Obj FuncREAD_AS_FUNC (
     Obj                 self,
     Obj                 filename )
 {
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "READ_AS_FUNC: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("READ_AS_FUNC", filename);
 
     /* try to open the file                                                */
     if ( ! OpenInput( CONST_CSTR_STRING(filename) ) ) {
@@ -1154,13 +1124,8 @@ Obj FuncREAD_GAP_ROOT (
 {
     Char filenamecpy[GAP_PATH_MAX];
 
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "READ: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("READ", filename);
 
     /* Copy to avoid garbage collection moving string                      */
     strlcpy(filenamecpy, CONST_CSTR_STRING(filename), GAP_PATH_MAX);
@@ -1213,13 +1178,8 @@ Obj FuncRemoveFile (
     Obj             self,
     Obj             filename )
 {
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("RemoveFile", filename);
     
     /* call the system dependent function                                  */
     return SyRemoveFile( CONST_CSTR_STRING(filename) ) == -1 ? Fail : True;
@@ -1233,13 +1193,8 @@ Obj FuncCreateDir (
     Obj             self,
     Obj             filename )
 {
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "CreateDir: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("CreateDir", filename);
     
     /* call the system dependent function                                  */
     return SyMkdir( CONST_CSTR_STRING(filename) ) == -1 ? Fail : True;
@@ -1253,13 +1208,8 @@ Obj FuncRemoveDir (
     Obj             self,
     Obj             filename )
 {
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "RemoveDir: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("RemoveDir", filename);
     
     /* call the system dependent function                                  */
     return SyRmdir( CONST_CSTR_STRING(filename) ) == -1 ? Fail : True;
@@ -1273,12 +1223,7 @@ Obj FuncIsDir (
     Obj             self,
     Obj             filename )
 {
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "IsDir: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    RequireStringRepMayReplace("IsDir", filename);
 
     /* call the system dependent function                                  */
     return SyIsDir( CONST_CSTR_STRING(filename) );
@@ -1338,13 +1283,8 @@ Obj FuncIsExistingFile (
 {
     Int             res;
 
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "IsExistingFile: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("IsExistingFile", filename);
     
     /* call the system dependent function                                  */
     res = SyIsExistingFile( CONST_CSTR_STRING(filename) );
@@ -1362,13 +1302,8 @@ Obj FuncIsReadableFile (
 {
     Int             res;
 
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "IsReadableFile: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("IsReadableFile", filename);
     
     /* call the system dependent function                                  */
     res = SyIsReadableFile( CONST_CSTR_STRING(filename) );
@@ -1386,13 +1321,8 @@ Obj FuncIsWritableFile (
 {
     Int             res;
 
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "IsWritableFile: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("IsWritableFile", filename);
     
     /* call the system dependent function                                  */
     res = SyIsWritableFile( CONST_CSTR_STRING(filename) );
@@ -1410,13 +1340,8 @@ Obj FuncIsExecutableFile (
 {
     Int             res;
 
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "IsExecutableFile: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("IsExecutableFile", filename);
     
     /* call the system dependent function                                  */
     res = SyIsExecutableFile( CONST_CSTR_STRING(filename) );
@@ -1434,13 +1359,8 @@ Obj FuncIsDirectoryPathString (
 {
     Int             res;
 
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "IsDirectoryPathString: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("IsDirectoryPathString", filename);
     
     /* call the system dependent function                                  */
     res = SyIsDirectoryPath( CONST_CSTR_STRING(filename) );
@@ -1469,13 +1389,8 @@ Obj FuncSTRING_LIST_DIR (
     Obj res;
     Int len, sl;
 
-    /* check the argument                                                  */
-    while ( ! IsStringConv( dirname ) ) {
-        dirname = ErrorReturnObj(
-            "STRING_LIST_DIR: <dirname> must be a string (not a %s)",
-            (Int)TNAM_OBJ(dirname), 0L,
-            "you can replace <dirname> via 'return <dirname>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("STRING_LIST_DIR", dirname);
     
     SyClearErrorNo();
     dir = opendir(CONST_CSTR_STRING(dirname));
@@ -1515,7 +1430,7 @@ Obj FuncCLOSE_FILE (
 {
     Int             ret;
 
-    /* check the argument                                                  */
+    // check the argument
     RequireSmallIntMayReplace("CLOSE_FILE", fid, "fid");
     
     /* call the system dependent function                                  */
@@ -1534,13 +1449,8 @@ Obj FuncINPUT_TEXT_FILE (
 {
     Int             fid;
 
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "INPUT_TEXT_FILE: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("INPUT_TEXT_FILE", filename);
     
     /* call the system dependent function                                  */
     SyClearErrorNo();
@@ -1561,7 +1471,7 @@ Obj FuncIS_END_OF_FILE (
 {
     Int             ret;
 
-    /* check the argument                                                  */
+    // check the argument
     RequireSmallIntMayReplace("IS_END_OF_FILE", fid, "fid");
     
     ret = SyIsEndOfFile( INT_INTOBJ(fid) );
@@ -1580,13 +1490,8 @@ Obj FuncOUTPUT_TEXT_FILE (
 {
     Int             fid;
 
-    /* check the argument                                                  */
-    while ( ! IsStringConv( filename ) ) {
-        filename = ErrorReturnObj(
-            "OUTPUT_TEXT_FILE: <filename> must be a string (not a %s)",
-            (Int)TNAM_OBJ(filename), 0L,
-            "you can replace <filename> via 'return <filename>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("OUTPUT_TEXT_FILE", filename);
     while ( append != True && append != False ) {
         filename = ErrorReturnObj(
             "OUTPUT_TEXT_FILE: <append> must be a boolean (not a %s)",
@@ -1616,7 +1521,7 @@ Obj FuncPOSITION_FILE (
     Obj             self,
     Obj             fid )
 {
-    /* check the argument                                                  */
+    // check the argument
     RequireSmallIntMayReplace("POSITION_FILE", fid, "fid");
 
     Int ifid = INT_INTOBJ(fid);
@@ -1642,7 +1547,7 @@ Obj FuncREAD_BYTE_FILE (
 {
     Int             ret;
 
-    /* check the argument                                                  */
+    // check the argument
     RequireSmallIntMayReplace("READ_BYTE_FILE", fid, "fid");
     
     /* call the system dependent function                                  */
@@ -1668,7 +1573,7 @@ Obj FuncREAD_LINE_FILE (
     UInt            lstr;
     Obj             str;
 
-    /* check the argument                                                  */
+    // check the argument
     RequireSmallIntMayReplace("READ_LINE_FILE", fid, "fid");
     ifid = INT_INTOBJ(fid);
 
@@ -1722,7 +1627,7 @@ Obj FuncREAD_ALL_FILE (
     Int             ilim;
     UInt            csize;
 
-    /* check the argument                                                  */
+    // check the argument
     RequireSmallIntMayReplace("READ_ALL_FILE", fid, "fid");
     ifid = INT_INTOBJ(fid);
 
@@ -1811,7 +1716,7 @@ Obj FuncSEEK_POSITION_FILE (
 {
     Int             ret;
 
-    /* check the argument                                                  */
+    // check the argument
     RequireSmallIntMayReplace("SEEK_POSITION_FILE", fid, "fid");
     RequireSmallIntMayReplace("SEEK_POSITION_FILE", pos, "pos");
     
@@ -1831,7 +1736,7 @@ Obj FuncWRITE_BYTE_FILE (
 {
     Int             ret;
 
-    /* check the argument                                                  */
+    // check the argument
     RequireSmallIntMayReplace("WRITE_BYTE_FILE", fid, "fid");
     RequireSmallIntMayReplace("WRITE_BYTE_FILE", ch, "ch");
     
@@ -1873,7 +1778,7 @@ Obj FuncREAD_STRING_FILE (
     Obj             self,
     Obj             fid )
 {
-    /* check the argument                                                  */
+    // check the argument
     RequireSmallIntMayReplace("READ_STRING_FILE", fid, "fid");
     return SyReadStringFid(INT_INTOBJ(fid));
 }
@@ -2038,19 +1943,9 @@ Obj FuncExecuteProcess (
     Int                 res;
     Int                 i;
 
-    /* check the argument                                                  */
-    while ( ! IsStringConv(dir) ) {
-        dir = ErrorReturnObj(
-            "ExecuteProcess: <dir> must be a string (not a %s)",
-            (Int)TNAM_OBJ(dir), 0L,
-            "you can replace <dir> via 'return <dir>;'" );
-    }
-    while ( ! IsStringConv(prg) ) {
-        prg = ErrorReturnObj(
-            "ExecuteProcess: <prg> must be a string (not a %s)",
-            (Int)TNAM_OBJ(prg), 0L,
-            "you can replace <prg> via 'return <prg>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("ExecuteProcess", dir);
+    RequireStringRepMayReplace("ExecuteProcess", prg);
     RequireSmallIntMayReplace("ExecuteProcess", in, "in");
     RequireSmallIntMayReplace("ExecuteProcess", out, "out");
     RequireSmallListMayReplace("ExecuteProcess", args);
@@ -2060,12 +1955,7 @@ Obj FuncExecuteProcess (
         if ( i == 1023 )
             break;
         tmp = ELM_LIST( args, i );
-        while ( ! IsStringConv(tmp) ) {
-            tmp = ErrorReturnObj(
-                "ExecuteProcess: <tmp> must be a string (not a %s)",
-                (Int)TNAM_OBJ(tmp), 0L,
-                "you can replace <tmp> via 'return <tmp>;'" );
-        }
+        RequireStringRepMayReplace("ExecuteProcess", tmp);
         ExecArgs[i] = tmp;
     }
     ExecCArgs[0]   = CSTR_STRING(prg);

--- a/src/streams.c
+++ b/src/streams.c
@@ -1236,7 +1236,7 @@ Obj FuncCreateDir (
     /* check the argument                                                  */
     while ( ! IsStringConv( filename ) ) {
         filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)",
+            "CreateDir: <filename> must be a string (not a %s)",
             (Int)TNAM_OBJ(filename), 0L,
             "you can replace <filename> via 'return <filename>;'" );
     }
@@ -1256,7 +1256,7 @@ Obj FuncRemoveDir (
     /* check the argument                                                  */
     while ( ! IsStringConv( filename ) ) {
         filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)",
+            "RemoveDir: <filename> must be a string (not a %s)",
             (Int)TNAM_OBJ(filename), 0L,
             "you can replace <filename> via 'return <filename>;'" );
     }
@@ -1275,7 +1275,7 @@ Obj FuncIsDir (
 {
     while ( ! IsStringConv( filename ) ) {
         filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)",
+            "IsDir: <filename> must be a string (not a %s)",
             (Int)TNAM_OBJ(filename), 0L,
             "you can replace <filename> via 'return <filename>;'" );
     }
@@ -1341,7 +1341,7 @@ Obj FuncIsExistingFile (
     /* check the argument                                                  */
     while ( ! IsStringConv( filename ) ) {
         filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)",
+            "IsExistingFile: <filename> must be a string (not a %s)",
             (Int)TNAM_OBJ(filename), 0L,
             "you can replace <filename> via 'return <filename>;'" );
     }
@@ -1365,7 +1365,7 @@ Obj FuncIsReadableFile (
     /* check the argument                                                  */
     while ( ! IsStringConv( filename ) ) {
         filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)",
+            "IsReadableFile: <filename> must be a string (not a %s)",
             (Int)TNAM_OBJ(filename), 0L,
             "you can replace <filename> via 'return <filename>;'" );
     }
@@ -1389,7 +1389,7 @@ Obj FuncIsWritableFile (
     /* check the argument                                                  */
     while ( ! IsStringConv( filename ) ) {
         filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)",
+            "IsWritableFile: <filename> must be a string (not a %s)",
             (Int)TNAM_OBJ(filename), 0L,
             "you can replace <filename> via 'return <filename>;'" );
     }
@@ -1413,7 +1413,7 @@ Obj FuncIsExecutableFile (
     /* check the argument                                                  */
     while ( ! IsStringConv( filename ) ) {
         filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)",
+            "IsExecutableFile: <filename> must be a string (not a %s)",
             (Int)TNAM_OBJ(filename), 0L,
             "you can replace <filename> via 'return <filename>;'" );
     }
@@ -1437,7 +1437,7 @@ Obj FuncIsDirectoryPathString (
     /* check the argument                                                  */
     while ( ! IsStringConv( filename ) ) {
         filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)",
+            "IsDirectoryPathString: <filename> must be a string (not a %s)",
             (Int)TNAM_OBJ(filename), 0L,
             "you can replace <filename> via 'return <filename>;'" );
     }
@@ -1472,7 +1472,7 @@ Obj FuncSTRING_LIST_DIR (
     /* check the argument                                                  */
     while ( ! IsStringConv( dirname ) ) {
         dirname = ErrorReturnObj(
-            "<dirname> must be a string (not a %s)",
+            "STRING_LIST_DIR: <dirname> must be a string (not a %s)",
             (Int)TNAM_OBJ(dirname), 0L,
             "you can replace <dirname> via 'return <dirname>;'" );
     }
@@ -1516,12 +1516,7 @@ Obj FuncCLOSE_FILE (
     Int             ret;
 
     /* check the argument                                                  */
-    while ( ! IS_INTOBJ(fid) ) {
-        fid = ErrorReturnObj(
-            "<fid> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(fid), 0L,
-            "you can replace <fid> via 'return <fid>;'" );
-    }
+    RequireSmallIntMayReplace("CLOSE_FILE", fid, "fid");
     
     /* call the system dependent function                                  */
     ret = SyFclose( INT_INTOBJ(fid) );
@@ -1542,7 +1537,7 @@ Obj FuncINPUT_TEXT_FILE (
     /* check the argument                                                  */
     while ( ! IsStringConv( filename ) ) {
         filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)",
+            "INPUT_TEXT_FILE: <filename> must be a string (not a %s)",
             (Int)TNAM_OBJ(filename), 0L,
             "you can replace <filename> via 'return <filename>;'" );
     }
@@ -1567,12 +1562,7 @@ Obj FuncIS_END_OF_FILE (
     Int             ret;
 
     /* check the argument                                                  */
-    while ( ! IS_INTOBJ(fid) ) {
-        fid = ErrorReturnObj(
-            "<fid> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(fid), 0L,
-            "you can replace <fid> via 'return <fid>;'" );
-    }
+    RequireSmallIntMayReplace("IS_END_OF_FILE", fid, "fid");
     
     ret = SyIsEndOfFile( INT_INTOBJ(fid) );
     return ret == -1 ? Fail : ( ret == 0 ? False : True );
@@ -1593,13 +1583,13 @@ Obj FuncOUTPUT_TEXT_FILE (
     /* check the argument                                                  */
     while ( ! IsStringConv( filename ) ) {
         filename = ErrorReturnObj(
-            "<filename> must be a string (not a %s)",
+            "OUTPUT_TEXT_FILE: <filename> must be a string (not a %s)",
             (Int)TNAM_OBJ(filename), 0L,
             "you can replace <filename> via 'return <filename>;'" );
     }
     while ( append != True && append != False ) {
         filename = ErrorReturnObj(
-            "<append> must be a boolean (not a %s)",
+            "OUTPUT_TEXT_FILE: <append> must be a boolean (not a %s)",
             (Int)TNAM_OBJ(append), 0L,
             "you can replace <append> via 'return <append>;'" );
     }
@@ -1627,12 +1617,7 @@ Obj FuncPOSITION_FILE (
     Obj             fid )
 {
     /* check the argument                                                  */
-    while ( ! IS_INTOBJ(fid) ) {
-        fid = ErrorReturnObj(
-            "<fid> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(fid), 0L,
-            "you can replace <fid> via 'return <fid>;'" );
-    }
+    RequireSmallIntMayReplace("POSITION_FILE", fid, "fid");
 
     Int ifid = INT_INTOBJ(fid);
     Int ret = SyFtell(ifid);
@@ -1658,12 +1643,7 @@ Obj FuncREAD_BYTE_FILE (
     Int             ret;
 
     /* check the argument                                                  */
-    while ( ! IS_INTOBJ(fid) ) {
-        fid = ErrorReturnObj(
-            "<fid> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(fid), 0L,
-            "you can replace <fid> via 'return <fid>;'" );
-    }
+    RequireSmallIntMayReplace("READ_BYTE_FILE", fid, "fid");
     
     /* call the system dependent function                                  */
     ret = SyGetch( INT_INTOBJ(fid) );
@@ -1689,12 +1669,7 @@ Obj FuncREAD_LINE_FILE (
     Obj             str;
 
     /* check the argument                                                  */
-    while ( ! IS_INTOBJ(fid) ) {
-        fid = ErrorReturnObj(
-            "<fid> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(fid), 0L,
-            "you can replace <fid> via 'return <fid>;'" );
-    }
+    RequireSmallIntMayReplace("READ_LINE_FILE", fid, "fid");
     ifid = INT_INTOBJ(fid);
 
     /* read <fid> until we see a newline or eof or we've read at least
@@ -1748,19 +1723,10 @@ Obj FuncREAD_ALL_FILE (
     UInt            csize;
 
     /* check the argument                                                  */
-    while ( ! IS_INTOBJ(fid) ) {
-        fid = ErrorReturnObj(
-            "<fid> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(fid), 0L,
-            "you can replace <fid> via 'return <fid>;'" );
-    }
+    RequireSmallIntMayReplace("READ_ALL_FILE", fid, "fid");
     ifid = INT_INTOBJ(fid);
 
-    while ( ! IS_INTOBJ(limit) ) {
-        limit = ErrorReturnObj("<limit> must be a small integer (not a %s)",
-                               (Int)TNAM_OBJ(limit), 0L,
-                               "you can replace limit via 'return <limit>;'");
-    }
+    RequireSmallIntMayReplace("READ_ALL_FILE", limit, "limit");
     ilim = INT_INTOBJ(limit);
 
     /* read <fid> until we see  eof or we've read at least
@@ -1846,18 +1812,8 @@ Obj FuncSEEK_POSITION_FILE (
     Int             ret;
 
     /* check the argument                                                  */
-    while ( ! IS_INTOBJ(fid) ) {
-        fid = ErrorReturnObj(
-            "<fid> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(fid), 0L,
-            "you can replace <fid> via 'return <fid>;'" );
-    }
-    while ( ! IS_INTOBJ(pos) ) {
-        pos = ErrorReturnObj(
-            "<pos> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(pos), 0L,
-            "you can replace <pos> via 'return <pos>;'" );
-    }
+    RequireSmallIntMayReplace("SEEK_POSITION_FILE", fid, "fid");
+    RequireSmallIntMayReplace("SEEK_POSITION_FILE", pos, "pos");
     
     ret = SyFseek( INT_INTOBJ(fid), INT_INTOBJ(pos) );
     return ret == -1 ? Fail : True;
@@ -1876,18 +1832,8 @@ Obj FuncWRITE_BYTE_FILE (
     Int             ret;
 
     /* check the argument                                                  */
-    while ( ! IS_INTOBJ(fid) ) {
-        fid = ErrorReturnObj(
-            "<fid> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(fid), 0L,
-            "you can replace <fid> via 'return <fid>;'" );
-    }
-    while ( ! IS_INTOBJ(ch) ) {
-        ch = ErrorReturnObj(
-            "<ch> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(ch), 0L,
-            "you can replace <ch> via 'return <ch>;'" );
-    }
+    RequireSmallIntMayReplace("WRITE_BYTE_FILE", fid, "fid");
+    RequireSmallIntMayReplace("WRITE_BYTE_FILE", ch, "ch");
     
     /* call the system dependent function                                  */
     ret = SyEchoch( INT_INTOBJ(ch), INT_INTOBJ(fid) );
@@ -1928,12 +1874,7 @@ Obj FuncREAD_STRING_FILE (
     Obj             fid )
 {
     /* check the argument                                                  */
-    while ( ! IS_INTOBJ(fid) ) {
-        fid = ErrorReturnObj(
-            "<fid> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(fid), 0L,
-            "you can replace <fid> via 'return <fid>;'" );
-    }
+    RequireSmallIntMayReplace("READ_STRING_FILE", fid, "fid");
     return SyReadStringFid(INT_INTOBJ(fid));
 }
 
@@ -1943,26 +1884,17 @@ Obj FuncREAD_STRING_FILE (
 */
 Obj FuncFD_OF_FILE(Obj self,Obj fid)
 {
-  while (fid == (Obj) 0 || !(IS_INTOBJ(fid))) {
-    fid = ErrorReturnObj(
-           "<fid> must be a small integer (not a %s)",
-           (Int)TNAM_OBJ(fid),0L,
-           "you can replace <fid> via 'return <fid>;'" );
-  }
+    RequireSmallIntMayReplace("FD_OF_FILE", fid, "fid");
 
-  Int fd = INT_INTOBJ(fid);
-  Int fdi = SyBufFileno(fd);
-  return INTOBJ_INT(fdi);
+    Int fd = INT_INTOBJ(fid);
+    Int fdi = SyBufFileno(fd);
+    return INTOBJ_INT(fdi);
 }
 
 #ifdef HPCGAP
 Obj FuncRAW_MODE_FILE(Obj self, Obj fid, Obj onoff)
 {
-    while (!IS_INTOBJ(fid)) {
-        fid = ErrorReturnObj("<fid> must be a small integer (not a %s)",
-                             (Int)TNAM_OBJ(fid), 0L,
-                             "you can replace <fid> via 'return <fid>;'");
-    }
+    RequireSmallIntMayReplace("RAW_MODE_FILE", fid, "fid");
 
     Int fd = INT_INTOBJ(fid);
     if (onoff == False || onoff == Fail) {
@@ -1986,17 +1918,17 @@ Obj FuncUNIXSelect(Obj self, Obj inlist, Obj outlist, Obj exclist,
 
   while (inlist == (Obj) 0 || !(IS_PLIST(inlist)))
     inlist = ErrorReturnObj(
-           "<inlist> must be a list of small integers (not a %s)",
+           "UNIXSelect: <inlist> must be a list of small integers (not a %s)",
            (Int)TNAM_OBJ(inlist),0L,
            "you can replace <inlist> via 'return <inlist>;'" );
   while (outlist == (Obj) 0 || !(IS_PLIST(outlist)))
     outlist = ErrorReturnObj(
-           "<outlist> must be a list of small integers (not a %s)",
+           "UNIXSelect: <outlist> must be a list of small integers (not a %s)",
            (Int)TNAM_OBJ(outlist),0L,
            "you can replace <outlist> via 'return <outlist>;'" );
   while (exclist == (Obj) 0 || !(IS_PLIST(exclist)))
     exclist = ErrorReturnObj(
-           "<exclist> must be a list of small integers (not a %s)",
+           "UNIXSelect: <exclist> must be a list of small integers (not a %s)",
            (Int)TNAM_OBJ(exclist),0L,
            "you can replace <exclist> via 'return <exclist>;'" );
 
@@ -2119,18 +2051,8 @@ Obj FuncExecuteProcess (
             (Int)TNAM_OBJ(prg), 0L,
             "you can replace <prg> via 'return <prg>;'" );
     }
-    while ( ! IS_INTOBJ(in) ) {
-        in = ErrorReturnObj(
-            "ExecuteProcess: <in> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(in), 0L,
-            "you can replace <in> via 'return <in>;'" );
-    }
-    while ( ! IS_INTOBJ(out) ) {
-        out = ErrorReturnObj(
-            "ExecuteProcess: <out> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(out), 0L,
-            "you can replace <out> via 'return <out>;'" );
-    }
+    RequireSmallIntMayReplace("ExecuteProcess", in, "in");
+    RequireSmallIntMayReplace("ExecuteProcess", out, "out");
     RequireSmallListMayReplace("ExecuteProcess", args);
 
     /* create an argument array                                            */
@@ -2140,7 +2062,7 @@ Obj FuncExecuteProcess (
         tmp = ELM_LIST( args, i );
         while ( ! IsStringConv(tmp) ) {
             tmp = ErrorReturnObj(
-                "<tmp> must be a string (not a %s)",
+                "ExecuteProcess: <tmp> must be a string (not a %s)",
                 (Int)TNAM_OBJ(tmp), 0L,
                 "you can replace <tmp> via 'return <tmp>;'" );
         }

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -228,12 +228,7 @@ Obj    FuncEmptyString( Obj self, Obj len )
 */
 Obj   FuncShrinkAllocationString( Obj self, Obj str )
 {
-    while (! IsStringConv(str)) {
-       str = ErrorReturnObj(
-           "<str> must be a string, not a %s)",
-           (Int)TNAM_OBJ(str), 0L,
-           "you can replace <str> via 'return <str>;'" );
-    }
+    RequireStringRepMayReplace("ShrinkAllocationString", str);
     SHRINK_STRING(str);
     return (Obj)0;
 }
@@ -1499,20 +1494,10 @@ Obj FuncPOSITION_SUBSTRING(
   const UInt1  *s, *ss;
 
   /* check whether <string> is a string                                  */
-  while ( ! IsStringConv( string ) ) {
-    string = ErrorReturnObj(
-	     "POSITION_SUBSTRING: <string> must be a string (not a %s)",
-	     (Int)TNAM_OBJ(string), 0L,
-	     "you can replace <string> via 'return <string>;'" );
-  }
+  RequireStringRepMayReplace("POSITION_SUBSTRING", string);
   
   /* check whether <substr> is a string                        */
-  while ( ! IsStringConv( substr ) ) {
-    substr = ErrorReturnObj(
-	  "POSITION_SUBSTRING: <substr> must be a string (not a %s)",
-	  (Int)TNAM_OBJ(substr), 0L,
-	  "you can replace <substr> via 'return <substr>;'" );
-  }
+  RequireStringRepMayReplace("POSITION_SUBSTRING", substr);
 
   /* check wether <off> is a non-negative integer  */
   while ( ! IS_INTOBJ(off) || (ipos = INT_INTOBJ(off)) < 0 ) {
@@ -1565,12 +1550,7 @@ Obj FuncNormalizeWhitespace (
   Int i, j, len, white;
 
   /* check whether <string> is a string                                  */
-  while ( ! IsStringConv( string ) ) {
-    string = ErrorReturnObj(
-	     "NormalizeWhitespace: <string> must be a string (not a %s)",
-	     (Int)TNAM_OBJ(string), 0L,
-	     "you can replace <string> via 'return <string>;'" );
-  }
+  RequireStringRepMayReplace("NormalizeWhitespace", string);
   
   len = GET_LEN_STRING(string);
   s = CHARS_STRING(string);
@@ -1620,20 +1600,10 @@ Obj FuncREMOVE_CHARACTERS (
   UInt1 REMCHARLIST[256] = {0};
 
   /* check whether <string> is a string                                  */
-  while ( ! IsStringConv( string ) ) {
-    string = ErrorReturnObj(
-	     "RemoveCharacters: first argument <string> must be a string (not a %s)",
-	     (Int)TNAM_OBJ(string), 0L,
-	     "you can replace <string> via 'return <string>;'" );
-  }
+  RequireStringRepMayReplace("RemoveCharacters", string);
   
   /* check whether <rem> is a string                                  */
-  while ( ! IsStringConv( rem ) ) {
-    rem = ErrorReturnObj(
-	     "RemoveCharacters: second argument <rem> must be a string (not a %s)",
-	     (Int)TNAM_OBJ(rem), 0L,
-	     "you can replace <rem> via 'return <rem>;'" );
-  }
+  RequireStringRepMayReplace("RemoveCharacters", rem);
   
   /* set REMCHARLIST by setting positions of characters in rem to 1 */
   len = GET_LEN_STRING(rem);
@@ -1673,23 +1643,18 @@ Obj FuncTranslateString (
   Int j, len;
 
   /* check whether <string> is a string                                  */
-  while ( ! IsStringConv( string ) ) {
-    string = ErrorReturnObj(
-	     "TranslateString: first argument <string> must be a string (not a %s)",
-	     (Int)TNAM_OBJ(string), 0L,
-	     "you can replace <string> via 'return <string>;'" );
-  }
+  RequireStringRepMayReplace("TranslateString", string);
   
   // check whether <trans> is a string of length at least 256
   while ( ! IsStringConv( trans ) || GET_LEN_STRING( trans ) < 256 ) {
     if ( ! IsStringConv( trans ) ) {
       trans = ErrorReturnObj(
-           "TranslateString: second argument <trans> must be a string (not a %s)",
+           "TranslateString: <trans> must be a string (not a %s)",
            (Int)TNAM_OBJ(trans), 0L,
            "you can replace <trans> via 'return <trans>;'" );
     } else if ( GET_LEN_STRING( trans ) < 256 ) {
       trans = ErrorReturnObj(
-           "TranslateString: second argument <trans> must have length >= 256",
+           "TranslateString: <trans> must have length >= 256",
            0L, 0L,
            "you can replace <trans> via 'return <trans>;'" );
     }
@@ -1728,29 +1693,14 @@ Obj FuncSplitStringInternal (
   UInt1 SPLITSTRINGWSPACE[256] = { 0 };
 
   /* check whether <string> is a string                                  */
-  while ( ! IsStringConv( string ) ) {
-    string = ErrorReturnObj(
-	     "SplitString: first argument <string> must be a string (not a %s)",
-	     (Int)TNAM_OBJ(string), 0L,
-	     "you can replace <string> via 'return <string>;'" );
-  }
-  
+  RequireStringRepMayReplace("SplitString", string);
+
   /* check whether <seps> is a string                                  */
-  while ( ! IsStringConv( seps ) ) {
-    seps = ErrorReturnObj(
-	     "SplitString: second argument <seps> must be a string (not a %s)",
-	     (Int)TNAM_OBJ(seps), 0L,
-	     "you can replace <seps> via 'return <seps>;'" );
-  }
-  
+  RequireStringRepMayReplace("SplitString", seps);
+
   /* check whether <wspace> is a string                                  */
-  while ( ! IsStringConv( wspace ) ) {
-    wspace = ErrorReturnObj(
-	     "SplitString: third argument <wspace> must be a string (not a %s)",
-	     (Int)TNAM_OBJ(wspace), 0L,
-	     "you can replace <wspace> via 'return <wspace>;'" );
-  }
-  
+  RequireStringRepMayReplace("SplitString", wspace);
+
   /* set SPLITSTRINGSEPS by setting positions of characters in rem to 1 */
   len = GET_LEN_STRING(seps);
   s = CONST_CHARS_STRING(seps);

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -250,12 +250,7 @@ Obj FuncCHAR_INT (
 
     /* get and check the integer value                                     */
 again:
-    while ( ! IS_INTOBJ(val) ) {
-        val = ErrorReturnObj(
-            "<val> must be an integer (not a %s)",
-            (Int)TNAM_OBJ(val), 0L,
-            "you can replace <val> via 'return <val>;'" );
-    }
+    RequireSmallIntMayReplace("CHAR_INT", val, "val");
     chr = INT_INTOBJ(val);
     if ( 255 < chr || chr < 0 ) {
         val = ErrorReturnObj(
@@ -301,12 +296,7 @@ Obj FuncCHAR_SINT (
 
   /* get and check the integer value                                     */
 agains:
-  while ( ! IS_INTOBJ(val) ) {
-      val = ErrorReturnObj(
-	  "<val> must be an integer (not a %s)",
-	  (Int)TNAM_OBJ(val), 0L,
-	  "you can replace <val> via 'return <val>;'" );
-  }
+  RequireSmallIntMayReplace("CHAR_SINT", val, "val");
   chr = INT_INTOBJ(val);
   if ( 127 < chr || chr < -128 ) {
       val = ErrorReturnObj(

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -356,13 +356,8 @@ Obj FuncCrcString( Obj self, Obj str ) {
     Int4        ch;
     Int         seen_nl;
 
-    /* check the argument                                                  */
-    while ( ! IsStringConv( str ) ) {
-        str = ErrorReturnObj(
-            "<str> must be a string (not a %s)",
-            (Int)TNAM_OBJ(str), 0L,
-            "you can replace <filename> via 'return <str>;'" );
-    }
+    // check the argument
+    RequireStringRepMayReplace("CrcString", str);
 
     ptr = CONST_CSTR_STRING(str);
     len = GET_LEN_STRING(str);

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1771,10 +1771,7 @@ Obj FuncELM0_GF2VEC (
 {
     UInt                p;
 
-    
-    if (!IS_INTOBJ(pos))
-      ErrorMayQuit("ELM0_GF2VEC: position must be a small integer, not a %s",
-		(Int)TNAM_OBJ(pos),0L);
+    RequireSmallInt("ELM0_GF2VEC", pos, "pos");
     p = INT_INTOBJ(pos);
     if ( LEN_GF2VEC(list) < p ) {
         return Fail;
@@ -1800,9 +1797,7 @@ Obj FuncELM_GF2VEC (
 {
     UInt                p;
 
-    if (!IS_INTOBJ(pos))
-      ErrorMayQuit("ELM_GF2VEC: position must be a small integer, not a %s",
-		(Int)TNAM_OBJ(pos),0L);
+    RequireSmallInt("ELM_GF2VEC", pos, "pos");
     p = INT_INTOBJ(pos);
     if ( LEN_GF2VEC(list) < p ) {
         ErrorReturnVoid(
@@ -1946,9 +1941,7 @@ Obj FuncASS_GF2VEC (
     }
 
     /* get the position                                                    */
-    if (!IS_INTOBJ(pos))
-      ErrorMayQuit("ASS_VEC8BIT: position must be a small integer, not a %s",
-		(Int)TNAM_OBJ(pos),0L);
+    RequireSmallInt("ASS_VEC8BIT", pos, "pos");
     p = INT_INTOBJ(pos);
 
     /* if <elm> is Z(2) or 0*Z(2) and the position is OK, keep rep         */
@@ -2029,9 +2022,7 @@ Obj FuncASS_GF2MAT (
     }
 
     /* get the position                                                    */
-    if (!IS_INTOBJ(pos))
-      ErrorMayQuit("ASS_GF2MAT: position must be a small integer, not a %s",
-		(Int)TNAM_OBJ(pos),0L);
+    RequireSmallInt("ASS_GF2MAT", pos, "pos");
     p = INT_INTOBJ(pos);
 
     /* if <elm> is a GF2 vector and the length is OK, keep the rep         */
@@ -2073,10 +2064,7 @@ Obj FuncASS_GF2MAT (
 */
 Obj FuncELM_GF2MAT( Obj self, Obj mat, Obj row )
 {
-    if (!IS_POS_INTOBJ(row)) {
-        ErrorMayQuit("ELM_GF2MAT: position must be a small integer, not a %s",
-                     (Int)TNAM_OBJ(row), 0L);
-    }
+    RequireSmallInt("ELM_GF2MAT", row, "row");
     UInt r = INT_INTOBJ(row);
     if (LEN_GF2MAT(mat) < r) {
         ErrorMayQuit("row index %d exceeds %d, the number of rows", r, LEN_GF2MAT(mat));
@@ -2119,9 +2107,7 @@ Obj FuncUNB_GF2VEC (
     }
 
     /* get the position                                                    */
-    if (!IS_INTOBJ(pos))
-      ErrorMayQuit("UNB_GF2VEC: position must be a small integer, not a %s",
-		(Int)TNAM_OBJ(pos),0L);
+    RequireSmallInt("UNB_GF2VEC", pos, "pos");
     p = INT_INTOBJ(pos);
 
     /* if we unbind the last position keep the representation              */
@@ -2166,9 +2152,7 @@ Obj FuncUNB_GF2MAT (
     }
 
     /* get the position                                                    */
-    if (!IS_INTOBJ(pos))
-      ErrorMayQuit("UNB_GF2MAT: position must be a small integer, not a %s",
-		(Int)TNAM_OBJ(pos),0L);
+    RequireSmallInt("UNB_GF2MAT", pos, "pos");
     p = INT_INTOBJ(pos);
 
     /* if we unbind the last position keep the representation              */
@@ -3712,7 +3696,7 @@ Obj FuncSHIFT_LEFT_GF2VEC( Obj self, Obj vec, Obj amount)
       return (Obj)0;
     }
   if (!IS_INTOBJ(amount))
-    ErrorMayQuit("SHIFT_LEFT_GF2VEC: the amnount to shift must be a small integer, not a %d",
+    ErrorMayQuit("SHIFT_LEFT_GF2VEC: the amount to shift must be a small integer, not a %d",
 	      (Int)TNAM_OBJ(amount), 0L);
   amount1 = INT_INTOBJ(amount);
   if (amount1 < 0)

--- a/tst/testinstall/callfunc.tst
+++ b/tst/testinstall/callfunc.tst
@@ -2,9 +2,9 @@ gap> START_TEST("callfunc.tst");
 
 #
 gap> CallFuncList(1,2);
-Error, CallFuncList: <list> must be a small list (not a integer)
+Error, CallFuncList: <list> must be a small list (not the integer 2)
 gap> CallFuncListWrap(1,2);
-Error, CallFuncListWrap: <list> must be a small list (not a integer)
+Error, CallFuncListWrap: <list> must be a small list (not the integer 2)
 
 #
 gap> ForAll([0,2..100], x -> [1..x] = CallFuncList(Union, List([1..x], y -> [y]) ) );

--- a/tst/testinstall/coder.tst
+++ b/tst/testinstall/coder.tst
@@ -193,17 +193,17 @@ true
 #
 gap> l := [1,2,3];;
 gap> function() l![fail] := 42; end();
-Error, PosObj Assignment: <position> must be a positive small integer (not a b\
-oolean or fail)
+Error, PosObj Assignment: <position> must be a positive small integer (not the\
+ value 'fail')
 gap> function() return l![fail]; end();
-Error, PosObj Element: <position> must be a positive small integer (not a bool\
-ean or fail)
+Error, PosObj Element: <position> must be a positive small integer (not the va\
+lue 'fail')
 gap> function() return IsBound(l![fail]); end();
-Error, PosObj Element: <position> must be a positive small integer (not a bool\
-ean or fail)
+Error, PosObj Element: <position> must be a positive small integer (not the va\
+lue 'fail')
 gap> function() Unbind(l![fail]); end();
-Error, PosObj Assignment: <position> must be a positive small integer (not a b\
-oolean or fail)
+Error, PosObj Assignment: <position> must be a positive small integer (not the\
+ value 'fail')
 
 #
 # posobj
@@ -235,17 +235,17 @@ false
 
 #
 gap> function() l![fail] := 42; end();
-Error, PosObj Assignment: <position> must be a positive small integer (not a b\
-oolean or fail)
+Error, PosObj Assignment: <position> must be a positive small integer (not the\
+ value 'fail')
 gap> function() return l![fail]; end();
-Error, PosObj Element: <position> must be a positive small integer (not a bool\
-ean or fail)
+Error, PosObj Element: <position> must be a positive small integer (not the va\
+lue 'fail')
 gap> function() return IsBound(l![fail]); end();
-Error, PosObj Element: <position> must be a positive small integer (not a bool\
-ean or fail)
+Error, PosObj Element: <position> must be a positive small integer (not the va\
+lue 'fail')
 gap> function() Unbind(l![fail]); end();
-Error, PosObj Assignment: <position> must be a positive small integer (not a b\
-oolean or fail)
+Error, PosObj Assignment: <position> must be a positive small integer (not the\
+ value 'fail')
 
 #
 # atomic posobj (HPC-GAP)
@@ -277,17 +277,17 @@ false
 
 #
 gap> function() l![fail] := 42; end();
-Error, PosObj Assignment: <position> must be a positive small integer (not a b\
-oolean or fail)
+Error, PosObj Assignment: <position> must be a positive small integer (not the\
+ value 'fail')
 gap> function() return l![fail]; end();
-Error, PosObj Element: <position> must be a positive small integer (not a bool\
-ean or fail)
+Error, PosObj Element: <position> must be a positive small integer (not the va\
+lue 'fail')
 gap> function() return IsBound(l![fail]); end();
-Error, PosObj Element: <position> must be a positive small integer (not a bool\
-ean or fail)
+Error, PosObj Element: <position> must be a positive small integer (not the va\
+lue 'fail')
 gap> function() Unbind(l![fail]); end();
-Error, PosObj Assignment: <position> must be a positive small integer (not a b\
-oolean or fail)
+Error, PosObj Assignment: <position> must be a positive small integer (not the\
+ value 'fail')
 
 #
 gap> STOP_TEST("coder.tst", 1);

--- a/tst/testinstall/combinat.tst
+++ b/tst/testinstall/combinat.tst
@@ -17,7 +17,7 @@ gap> Factorial( 50 );
 gap> Factorial(-1);
 Error, Factorial: <n> must be nonnegative
 gap> Factorial(fail);
-Error, Factorial: <n> must be an integer (not a boolean or fail)
+Error, Factorial: <n> must be an integer (not the value 'fail')
 
 #F  Binomial( <n>, <k> )  . . . . . . . . .  binomial coefficient of integers
 gap> Print(List( [-8..8], k -> Binomial( 0, k ) ),"\n");
@@ -34,9 +34,9 @@ true
 gap> Binomial( 2^100, 2 ) = 2^100 * (2^100 - 1) / 2;
 true
 gap> Binomial(fail, 0);
-Error, Binomial: <n> must be an integer (not a boolean or fail)
+Error, Binomial: <n> must be an integer (not the value 'fail')
 gap> Binomial(0, fail);
-Error, Binomial: <k> must be an integer (not a boolean or fail)
+Error, Binomial: <k> must be an integer (not the value 'fail')
 
 #F  Bell( <n> ) . . . . . . . . . . . . . . . . .  value of the Bell sequence
 gap> Print(List( [0..10], n -> Bell(n) ),"\n");

--- a/tst/testinstall/cyclotom.tst
+++ b/tst/testinstall/cyclotom.tst
@@ -292,7 +292,7 @@ gap> SetCyclotomicsLimit(1000000);
 
 #
 gap> E(0);
-Error, E: <n> must be a positive small integer (not a integer)
+Error, E: <n> must be a positive small integer (not the integer 0)
 
 #
 gap> IS_CYC('a');

--- a/tst/testinstall/intarith.tst
+++ b/tst/testinstall/intarith.tst
@@ -313,9 +313,9 @@ Error, Integer operations: <divisor> must be nonzero
 gap> QuoInt(bigPos, 0);
 Error, Integer operations: <divisor> must be nonzero
 gap> QuoInt(fail,1);
-Error, QuoInt: <left> must be an integer (not a boolean or fail)
+Error, QuoInt: <left> must be an integer (not the value 'fail')
 gap> QuoInt(1,fail);
-Error, QuoInt: <right> must be an integer (not a boolean or fail)
+Error, QuoInt: <right> must be an integer (not the value 'fail')
 
 # corner cases
 gap> QuoInt(-2^28, -1);
@@ -363,9 +363,9 @@ Error, Integer operations: <divisor> must be nonzero
 gap> RemInt(bigPos, 0);
 Error, Integer operations: <divisor> must be nonzero
 gap> RemInt(fail,1);
-Error, RemInt: <left> must be an integer (not a boolean or fail)
+Error, RemInt: <left> must be an integer (not the value 'fail')
 gap> RemInt(1,fail);
-Error, RemInt: <right> must be an integer (not a boolean or fail)
+Error, RemInt: <right> must be an integer (not the value 'fail')
 
 # corner cases
 gap> RemInt(-2^28, 2^28);
@@ -436,9 +436,9 @@ true
 
 #
 gap> GcdInt(fail,1);
-Error, GcdInt: <left> must be an integer (not a boolean or fail)
+Error, GcdInt: <left> must be an integer (not the value 'fail')
 gap> GcdInt(1,fail);
-Error, GcdInt: <right> must be an integer (not a boolean or fail)
+Error, GcdInt: <right> must be an integer (not the value 'fail')
 
 # corner cases
 gap> GcdInt(0, 0);
@@ -483,9 +483,9 @@ true
 
 #
 gap> LcmInt(fail,1);
-Error, LcmInt: <left> must be an integer (not a boolean or fail)
+Error, LcmInt: <left> must be an integer (not the value 'fail')
 gap> LcmInt(1,fail);
-Error, LcmInt: <right> must be an integer (not a boolean or fail)
+Error, LcmInt: <right> must be an integer (not the value 'fail')
 
 # corner cases
 gap> LcmInt(0, 0);
@@ -1372,9 +1372,9 @@ Error, PValuation: <p> must be nonzero
 gap> PVALUATION_INT(0,0);
 Error, PValuation: <p> must be nonzero
 gap> PVALUATION_INT(fail,1);
-Error, PValuation: <n> must be an integer (not a boolean or fail)
+Error, PValuation: <n> must be an integer (not the value 'fail')
 gap> PVALUATION_INT(1,fail);
-Error, PValuation: <p> must be an integer (not a boolean or fail)
+Error, PValuation: <p> must be an integer (not the value 'fail')
 
 #
 # test ROOT_INT
@@ -1413,9 +1413,9 @@ Error, Root: <n> is negative but <k> is even
 gap> RootInt(0, 0);
 Error, Root: <k> must be a positive integer
 gap> RootInt(fail, 1);
-Error, Root: <n> must be an integer (not a boolean or fail)
+Error, Root: <n> must be an integer (not the value 'fail')
 gap> RootInt(1, fail);
-Error, Root: <k> must be an integer (not a boolean or fail)
+Error, Root: <k> must be an integer (not the value 'fail')
 
 #
 # test IS_PROBAB_PRIME_INT
@@ -1427,9 +1427,9 @@ gap> Filtered([-100..100], n -> false <> IS_PROBAB_PRIME_INT(2^255+n, 5));
 gap> Filtered([-100..100], n -> false <> IsProbablyPrimeInt(2^255+n));
 [ -31, -19, 95 ]
 gap> IS_PROBAB_PRIME_INT(fail, 1);
-Error, IsProbablyPrimeInt: <n> must be an integer (not a boolean or fail)
+Error, IsProbablyPrimeInt: <n> must be an integer (not the value 'fail')
 gap> IS_PROBAB_PRIME_INT(1, fail);
-Error, IsProbablyPrimeInt: <reps> must be an integer (not a boolean or fail)
+Error, IsProbablyPrimeInt: <reps> must be an integer (not the value 'fail')
 gap> IS_PROBAB_PRIME_INT(1, 2^100);
 Error, IsProbablyPrimeInt: <reps> must be a small positive integer
 gap> IS_PROBAB_PRIME_INT(1, 0);

--- a/tst/testinstall/intarith.tst
+++ b/tst/testinstall/intarith.tst
@@ -948,11 +948,12 @@ gap> Random(mysource, 1, 2^40);
 gap> Random(mysource, 1, 2^80);
 1071135285340982180054653
 gap> RandomIntegerMT(fail, 1);
-Error, <mtstr> must be a string (not a boolean or fail)
+Error, RandomIntegerMT: <mtstr> must be a string (not the value 'fail')
 gap> RandomIntegerMT("abc", 1);
-Error, <mtstr> must be a string with at least 2500 characters
+Error, RandomIntegerMT: <mtstr> must be a string with at least 2500 characters
 gap> RandomIntegerMT(mysource!.state, fail);
-Error, <nrbits> must be a small non-negative integer (not a boolean or fail)
+Error, RandomIntegerMT: <nrbits> must be a small non-negative integer (not a b\
+oolean or fail)
 
 #
 # PrintInt

--- a/tst/testinstall/interpreter.tst
+++ b/tst/testinstall/interpreter.tst
@@ -160,17 +160,17 @@ gap> l;
 
 #
 gap> l![fail] := 42;
-Error, PosObj Assignment: <position> must be a positive small integer (not a b\
-oolean or fail)
+Error, PosObj Assignment: <position> must be a positive small integer (not the\
+ value 'fail')
 gap> l![fail];
-Error, PosObj Element: <position> must be a positive small integer (not a bool\
-ean or fail)
+Error, PosObj Element: <position> must be a positive small integer (not the va\
+lue 'fail')
 gap> IsBound(l![fail]);
-Error, PosObj Element: <position> must be a positive small integer (not a bool\
-ean or fail)
+Error, PosObj Element: <position> must be a positive small integer (not the va\
+lue 'fail')
 gap> Unbind(l![fail]);
-Error, PosObj Assignment: <position> must be a positive small integer (not a b\
-oolean or fail)
+Error, PosObj Assignment: <position> must be a positive small integer (not the\
+ value 'fail')
 
 #
 gap> l{[1,3]} := [42, 23];
@@ -206,17 +206,17 @@ false
 
 #
 gap> l![fail] := 42;
-Error, PosObj Assignment: <position> must be a positive small integer (not a b\
-oolean or fail)
+Error, PosObj Assignment: <position> must be a positive small integer (not the\
+ value 'fail')
 gap> l![fail];
-Error, PosObj Element: <position> must be a positive small integer (not a bool\
-ean or fail)
+Error, PosObj Element: <position> must be a positive small integer (not the va\
+lue 'fail')
 gap> IsBound(l![fail]);
-Error, PosObj Element: <position> must be a positive small integer (not a bool\
-ean or fail)
+Error, PosObj Element: <position> must be a positive small integer (not the va\
+lue 'fail')
 gap> Unbind(l![fail]);
-Error, PosObj Assignment: <position> must be a positive small integer (not a b\
-oolean or fail)
+Error, PosObj Assignment: <position> must be a positive small integer (not the\
+ value 'fail')
 
 #
 # atomic posobj (HPC-GAP)
@@ -236,17 +236,17 @@ false
 
 #
 gap> l![fail] := 42;
-Error, PosObj Assignment: <position> must be a positive small integer (not a b\
-oolean or fail)
+Error, PosObj Assignment: <position> must be a positive small integer (not the\
+ value 'fail')
 gap> l![fail];
-Error, PosObj Element: <position> must be a positive small integer (not a bool\
-ean or fail)
+Error, PosObj Element: <position> must be a positive small integer (not the va\
+lue 'fail')
 gap> IsBound(l![fail]);
-Error, PosObj Element: <position> must be a positive small integer (not a bool\
-ean or fail)
+Error, PosObj Element: <position> must be a positive small integer (not the va\
+lue 'fail')
 gap> Unbind(l![fail]);
-Error, PosObj Assignment: <position> must be a positive small integer (not a b\
-oolean or fail)
+Error, PosObj Assignment: <position> must be a positive small integer (not the\
+ value 'fail')
 
 #
 #

--- a/tst/testinstall/kernel/blister.tst
+++ b/tst/testinstall/kernel/blister.tst
@@ -111,17 +111,17 @@ gap> List(l, SizeBlist);
 
 # FuncBLIST_LIST
 gap> BlistList(fail, fail);
-Error, BlistList: <list> must be a small list (not a boolean or fail)
+Error, BlistList: <list> must be a small list (not the value 'fail')
 gap> BlistList([1,2,3], fail);
-Error, BlistList: <sub> must be a small list (not a boolean or fail)
+Error, BlistList: <sub> must be a small list (not the value 'fail')
 gap> BlistList([1,2,3], [1,3]);
 [ true, false, true ]
 
 # FuncLIST_BLIST
 gap> ListBlist(fail, fail);
-Error, ListBlist: <list> must be a small list (not a boolean or fail)
+Error, ListBlist: <list> must be a small list (not the value 'fail')
 gap> ListBlist([1,2,3], fail);
-Error, ListBlist: <blist> must be a boolean list (not a boolean or fail)
+Error, ListBlist: <blist> must be a boolean list (not the value 'fail')
 gap> ListBlist([1,2,3], [true,false]);
 Error, ListBlist: <blist> must have the same length as <list> (3)
 gap> ListBlist([1,2,3], [true,false,true]);
@@ -129,9 +129,9 @@ gap> ListBlist([1,2,3], [true,false,true]);
 
 # FuncIS_SUB_BLIST
 gap> IsSubsetBlist(fail, fail);
-Error, IsSubsetBlist: <blist1> must be a boolean list (not a boolean or fail)
+Error, IsSubsetBlist: <blist1> must be a boolean list (not the value 'fail')
 gap> IsSubsetBlist([true,false], fail);
-Error, IsSubsetBlist: <blist2> must be a boolean list (not a boolean or fail)
+Error, IsSubsetBlist: <blist2> must be a boolean list (not the value 'fail')
 gap> IsSubsetBlist([true,false,true], [true,false]);
 Error, IsSubsetBlist: <blist2> must have the same length as <blist1> (3)
 gap> IsSubsetBlist([true,false,true], [true,false,false]);
@@ -141,9 +141,9 @@ false
 
 # FuncUNITE_BLIST
 gap> UniteBlist(fail, fail);
-Error, UniteBlist: <blist1> must be a boolean list (not a boolean or fail)
+Error, UniteBlist: <blist1> must be a boolean list (not the value 'fail')
 gap> UniteBlist([true,false], fail);
-Error, UniteBlist: <blist2> must be a boolean list (not a boolean or fail)
+Error, UniteBlist: <blist2> must be a boolean list (not the value 'fail')
 gap> UniteBlist([true,false,true], [true,false]);
 Error, UniteBlist: <blist2> must have the same length as <blist1> (3)
 gap> x:= [false,true,true,false];;
@@ -153,13 +153,13 @@ gap> x;
 
 # FuncUNITE_BLIST_LIST
 gap> UniteBlistList(fail, fail, fail);
-Error, UniteBlistList: <list> must be a small list (not a boolean or fail)
+Error, UniteBlistList: <list> must be a small list (not the value 'fail')
 gap> UniteBlistList([1,2], fail, fail);
-Error, UniteBlistList: <blist> must be a boolean list (not a boolean or fail)
+Error, UniteBlistList: <blist> must be a boolean list (not the value 'fail')
 gap> UniteBlistList([1,2], [true], fail);
 Error, UniteBlistList: <blist> must have the same length as <list> (2)
 gap> UniteBlistList([1,2], [true,false], fail);
-Error, UniteBlistList: <sub> must be a small list (not a boolean or fail)
+Error, UniteBlistList: <sub> must be a small list (not the value 'fail')
 gap> x:= [true,true,false];;
 gap> UniteBlistList([1,2,3], x, [2,3]);
 gap> x;
@@ -167,9 +167,9 @@ gap> x;
 
 # FuncINTER_BLIST
 gap> IntersectBlist(fail, fail);
-Error, IntersectBlist: <blist1> must be a boolean list (not a boolean or fail)
+Error, IntersectBlist: <blist1> must be a boolean list (not the value 'fail')
 gap> IntersectBlist([true,false], fail);
-Error, IntersectBlist: <blist2> must be a boolean list (not a boolean or fail)
+Error, IntersectBlist: <blist2> must be a boolean list (not the value 'fail')
 gap> IntersectBlist([true,false,true], [true,false]);
 Error, IntersectBlist: <blist2> must have the same length as <blist1> (3)
 gap> x:= [false,true,true,false];;
@@ -179,9 +179,9 @@ gap> x;
 
 # FuncSUBTR_BLIST
 gap> SubtractBlist(fail, fail);
-Error, SubtractBlist: <blist1> must be a boolean list (not a boolean or fail)
+Error, SubtractBlist: <blist1> must be a boolean list (not the value 'fail')
 gap> SubtractBlist([true,false], fail);
-Error, SubtractBlist: <blist2> must be a boolean list (not a boolean or fail)
+Error, SubtractBlist: <blist2> must be a boolean list (not the value 'fail')
 gap> SubtractBlist([true,false,true], [true,false]);
 Error, SubtractBlist: <blist2> must have the same length as <blist1> (3)
 gap> x:= [false,true,true,false];;
@@ -191,9 +191,9 @@ gap> x;
 
 # FuncMEET_BLIST
 gap> MEET_BLIST(fail, fail);
-Error, MeetBlist: <blist1> must be a boolean list (not a boolean or fail)
+Error, MeetBlist: <blist1> must be a boolean list (not the value 'fail')
 gap> MEET_BLIST([true,false], fail);
-Error, MeetBlist: <blist2> must be a boolean list (not a boolean or fail)
+Error, MeetBlist: <blist2> must be a boolean list (not the value 'fail')
 gap> MEET_BLIST([true,false,true], [true,false]);
 Error, MeetBlist: <blist2> must have the same length as <blist1> (3)
 gap> x:= [false,true,true,false];;

--- a/tst/testinstall/kernel/calls.tst
+++ b/tst/testinstall/kernel/calls.tst
@@ -79,36 +79,36 @@ Error, no 1st choice method found for `PROF_FUNC' on 1 arguments
 gap> PROF_FUNC(x->x);
 [ 0, 0, 0, 0, 0 ]
 gap> CLEAR_PROFILE_FUNC(fail);
-Error, CLEAR_PROFILE_FUNC: <func> must be a function (not a boolean or fail)
+Error, CLEAR_PROFILE_FUNC: <func> must be a function (not the value 'fail')
 gap> PROFILE_FUNC(fail);
-Error, PROFILE_FUNC: <func> must be a function (not a boolean or fail)
+Error, PROFILE_FUNC: <func> must be a function (not the value 'fail')
 gap> IS_PROFILED_FUNC(fail);
-Error, IS_PROFILED_FUNC: <func> must be a function (not a boolean or fail)
+Error, IS_PROFILED_FUNC: <func> must be a function (not the value 'fail')
 gap> IS_PROFILED_FUNC(x->x);
 false
 
 #
 gap> f:=x->x;;
 gap> FILENAME_FUNC(fail);
-Error, FILENAME_FUNC: <func> must be a function (not a boolean or fail)
+Error, FILENAME_FUNC: <func> must be a function (not the value 'fail')
 gap> FILENAME_FUNC(f);
 "stream"
 gap> FILENAME_FUNC(IS_OBJECT);
 fail
 gap> STARTLINE_FUNC(fail);
-Error, STARTLINE_FUNC: <func> must be a function (not a boolean or fail)
+Error, STARTLINE_FUNC: <func> must be a function (not the value 'fail')
 gap> STARTLINE_FUNC(f);
 1
 gap> STARTLINE_FUNC(IS_OBJECT);
 fail
 gap> ENDLINE_FUNC(fail);
-Error, ENDLINE_FUNC: <func> must be a function (not a boolean or fail)
+Error, ENDLINE_FUNC: <func> must be a function (not the value 'fail')
 gap> ENDLINE_FUNC(f);
 1
 gap> ENDLINE_FUNC(IS_OBJECT);
 fail
 gap> LOCATION_FUNC(fail);
-Error, LOCATION_FUNC: <func> must be a function (not a boolean or fail)
+Error, LOCATION_FUNC: <func> must be a function (not the value 'fail')
 gap> LOCATION_FUNC(f);
 fail
 gap> LOCATION_FUNC(IS_OBJECT);
@@ -116,7 +116,7 @@ fail
 
 #
 gap> UNPROFILE_FUNC(fail);
-Error, UNPROFILE_FUNC: <func> must be a function (not a boolean or fail)
+Error, UNPROFILE_FUNC: <func> must be a function (not the value 'fail')
 gap> UNPROFILE_FUNC(x->x);
 
 #

--- a/tst/testinstall/kernel/exprs.tst
+++ b/tst/testinstall/kernel/exprs.tst
@@ -12,8 +12,8 @@ gap> f(2,1);
 gap> f(2,2);
 Error, Permutation: cycles must be disjoint and duplicate-free
 gap> f(2,fail);
-Error, Permutation: <expr> must be a positive small integer (not a boolean or \
-fail)
+Error, Permutation: <expr> must be a positive small integer (not the value 'fa\
+il')
 gap> f:={a,b,c,d} -> (a,b,c,d);;
 gap> f(1,2,3,4);
 (1,2,3,4)

--- a/tst/testinstall/kernel/gap.tst
+++ b/tst/testinstall/kernel/gap.tst
@@ -109,21 +109,23 @@ gap> CALL_WITH_CATCH({x,y,z}->x,[1..3]);
 
 #
 gap> GAP_CRC(fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, GAP_CRC: <filename> must be a string (not the value 'fail')
 gap> GAP_CRC("foobar");
 0
 
 #
 gap> LOAD_DYN(fail, fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, LOAD_DYN: <filename> must be a string (not the value 'fail')
 gap> LOAD_DYN("foobar", fail);
-Error, <crc> must be a small integer or 'false' (not a boolean or fail)
+Error, LOAD_DYN: <crc> must be a small integer or 'false' (not a boolean or fa\
+il)
 
 #
 gap> LOAD_STAT(fail, fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, LOAD_STAT: <filename> must be a string (not the value 'fail')
 gap> LOAD_STAT("foobar", fail);
-Error, <crc> must be a small integer or 'false' (not a boolean or fail)
+Error, LOAD_STAT: <crc> must be a small integer or 'false' (not a boolean or f\
+ail)
 gap> LOAD_STAT("foobar", false);
 false
 
@@ -135,7 +137,7 @@ gap> GASMAN();
 Error, usage: GASMAN( "display"|"displayshort"|"clear"|"collect"|"message"|"pa\
 rtial" )
 gap> GASMAN(fail);
-Error, GASMAN: <cmd> must be a string (not a boolean or fail)
+Error, GASMAN: <cmd> must be a string (not the value 'fail')
 
 #
 gap> SIZE_OBJ(0);

--- a/tst/testinstall/kernel/gap.tst
+++ b/tst/testinstall/kernel/gap.tst
@@ -160,13 +160,13 @@ fail
 
 #
 gap> Sleep(fail);
-Error, <secs> must be a small integer
+Error, Sleep: <secs> must be a small integer (not the value 'fail')
 gap> Sleep(0);
 gap> Sleep(1);
 
 #
 gap>    MicroSleep(fail);
-Error, <usecs> must be a small integer
+Error, MicroSleep: <usecs> must be a small integer (not the value 'fail')
 gap> MicroSleep(0);
 gap> MicroSleep(1);
 

--- a/tst/testinstall/kernel/integer.tst
+++ b/tst/testinstall/kernel/integer.tst
@@ -21,7 +21,7 @@ gap> SIGN_INT(-100000000000);
 
 #
 gap> FACTORIAL_INT(fail);
-Error, Factorial: <n> must be an integer (not a boolean or fail)
+Error, Factorial: <n> must be an integer (not the value 'fail')
 
 #
 #

--- a/tst/testinstall/kernel/intfuncs.tst
+++ b/tst/testinstall/kernel/intfuncs.tst
@@ -5,7 +5,7 @@ gap> START_TEST("kernel/intfuncs.tst");
 
 #
 gap> InitRandomMT(fail);
-Error, <initstr> must be a string (not a boolean or fail)
+Error, InitRandomMT: <initstr> must be a string (not the value 'fail')
 
 #
 gap> HASHKEY_BAG(0, 0, 0, 0);

--- a/tst/testinstall/kernel/intfuncs.tst
+++ b/tst/testinstall/kernel/intfuncs.tst
@@ -13,13 +13,13 @@ gap> HASHKEY_BAG(0, 0, 0, 0);
 gap> HASHKEY_BAG(Z(2), 0, 0, 0);
 Error, HASHKEY_BAG: <obj> must not be an FFE
 gap> HASHKEY_BAG("x", fail, 0, 0);
-Error, HASHKEY_BAG: <seed> must be a small integer (not a boolean or fail)
+Error, HASHKEY_BAG: <seed> must be a small integer (not the value 'fail')
 gap> HASHKEY_BAG("x", 0, fail, 0);
-Error, HASHKEY_BAG: <offset> must be a small integer (not a boolean or fail)
+Error, HASHKEY_BAG: <offset> must be a small integer (not the value 'fail')
 gap> HASHKEY_BAG("x", 0, 1000, 0);
 Error, HashKeyBag: <offset> must be non-negative and less than the bag size
 gap> HASHKEY_BAG("x", 0, 0, fail);
-Error, HASHKEY_BAG: <maxlen> must be a small integer (not a boolean or fail)
+Error, HASHKEY_BAG: <maxlen> must be a small integer (not the value 'fail')
 
 #
 gap> STOP_TEST("kernel/intfuncs.tst", 1);

--- a/tst/testinstall/kernel/listfunc.tst
+++ b/tst/testinstall/kernel/listfunc.tst
@@ -27,16 +27,16 @@ Error, AppendList: <list1> must be a small list (not a record (plain))
 
 #
 gap> POSITION_SORTED_LIST(fail, fail);
-Error, POSITION_SORTED_LIST: <list> must be a small list (not a boolean or fai\
-l)
+Error, POSITION_SORTED_LIST: <list> must be a small list (not the value 'fail'\
+)
 
 #
 gap> POSITION_SORTED_LIST_COMP(fail, fail, fail);
-Error, POSITION_SORTED_LIST_COMP: <list> must be a small list (not a boolean o\
-r fail)
+Error, POSITION_SORTED_LIST_COMP: <list> must be a small list (not the value '\
+fail')
 gap> POSITION_SORTED_LIST_COMP([], 1, fail);
-Error, POSITION_SORTED_LIST_COMP: <func> must be a function (not a boolean or \
-fail)
+Error, POSITION_SORTED_LIST_COMP: <func> must be a function (not the value 'fa\
+il')
 gap> POSITION_SORTED_LIST_COMP([1,2,3], 3, \<);
 3
 gap> POSITION_SORTED_LIST_COMP([1..3], 3, \<);
@@ -48,42 +48,41 @@ gap> POSITION_SORTED_LIST_COMP([1..3], 0, \<);
 
 #
 gap> SORT_LIST(fail);
-Error, SORT_LIST: <list> must be a small list (not a boolean or fail)
+Error, SORT_LIST: <list> must be a small list (not the value 'fail')
 
 #
 gap> STABLE_SORT_LIST(fail);
-Error, STABLE_SORT_LIST: <list> must be a small list (not a boolean or fail)
+Error, STABLE_SORT_LIST: <list> must be a small list (not the value 'fail')
 
 #
 gap> SORT_LIST_COMP(fail, fail);
-Error, SORT_LIST_COMP: <list> must be a small list (not a boolean or fail)
+Error, SORT_LIST_COMP: <list> must be a small list (not the value 'fail')
 gap> SORT_LIST_COMP([], fail);
-Error, SORT_LIST_COMP: <func> must be a function (not a boolean or fail)
+Error, SORT_LIST_COMP: <func> must be a function (not the value 'fail')
 
 #
 gap> STABLE_SORT_LIST_COMP(fail, fail);
-Error, STABLE_SORT_LIST_COMP: <list> must be a small list (not a boolean or fa\
-il)
+Error, STABLE_SORT_LIST_COMP: <list> must be a small list (not the value 'fail\
+')
 gap> STABLE_SORT_LIST_COMP([], fail);
-Error, STABLE_SORT_LIST_COMP: <func> must be a function (not a boolean or fail\
-)
+Error, STABLE_SORT_LIST_COMP: <func> must be a function (not the value 'fail')
 
 #
 gap> SORT_PARA_LIST(fail, fail);
-Error, SORT_PARA_LIST: <list> must be a small list (not a boolean or fail)
+Error, SORT_PARA_LIST: <list> must be a small list (not the value 'fail')
 gap> SORT_PARA_LIST([], fail);
-Error, SORT_PARA_LIST: <shadow> must be a small list (not a boolean or fail)
+Error, SORT_PARA_LIST: <shadow> must be a small list (not the value 'fail')
 gap> SORT_PARA_LIST([], [1]);
 Error, SORT_PARA_LIST: <list> must have the same length as <shadow> (not 0 and\
  1)
 
 #
 gap> STABLE_SORT_PARA_LIST(fail, fail);
-Error, STABLE_SORT_PARA_LIST: <list> must be a small list (not a boolean or fa\
-il)
+Error, STABLE_SORT_PARA_LIST: <list> must be a small list (not the value 'fail\
+')
 gap> STABLE_SORT_PARA_LIST([], fail);
-Error, STABLE_SORT_PARA_LIST: <shadow> must be a small list (not a boolean or \
-fail)
+Error, STABLE_SORT_PARA_LIST: <shadow> must be a small list (not the value 'fa\
+il')
 gap> STABLE_SORT_PARA_LIST([], [1]);
 Error, STABLE_SORT_PARA_LIST: <list> must have the same length as <shadow> (no\
 t 0 and 1)
@@ -94,7 +93,7 @@ Error, OnPairs: <pair> must be a list of length 2 (not a boolean or fail)
 
 #
 gap> OnTuples(fail,fail);
-Error, OnTuples: <tuple> must be a small list (not a boolean or fail)
+Error, OnTuples: <tuple> must be a small list (not the value 'fail')
 
 #
 gap> OnSets(fail,fail);

--- a/tst/testinstall/kernel/macfloat.tst
+++ b/tst/testinstall/kernel/macfloat.tst
@@ -9,8 +9,7 @@ fail
 
 #
 gap> MACFLOAT_STRING(fail);
-Error, MACFLOAT_STRING: object to be converted must be a string not a boolean \
-or fail
+Error, MACFLOAT_STRING: <s> must be a string (not the value 'fail')
 
 #
 gap> pi := 3.1415926535897932384626433;

--- a/tst/testinstall/kernel/opers.tst
+++ b/tst/testinstall/kernel/opers.tst
@@ -197,10 +197,12 @@ Error, usage: NewProperty( <name> )
 gap> NEW_GLOBAL_FUNCTION(fail);
 Error, usage: NewGlobalFunction( <name> )
 gap> INSTALL_GLOBAL_FUNCTION(fail, fail);
-Error, <oper> must be a function (not a boolean or fail)
+Error, INSTALL_GLOBAL_FUNCTION: <oper> must be a function (not the value 'fail\
+')
 gap> func := NEW_GLOBAL_FUNCTION("quux");;
 gap> INSTALL_GLOBAL_FUNCTION(func, fail);
-Error, <func> must be a function (not a boolean or fail)
+Error, INSTALL_GLOBAL_FUNCTION: <func> must be a function (not the value 'fail\
+')
 gap> INSTALL_GLOBAL_FUNCTION(func, Size);
 Error, <func> must not be an operation
 gap> INSTALL_GLOBAL_FUNCTION(func, x -> x);

--- a/tst/testinstall/kernel/set.tst
+++ b/tst/testinstall/kernel/set.tst
@@ -7,15 +7,15 @@ gap> START_TEST("kernel/set.tst");
 gap> IsSet(1);
 false
 gap> LIST_SORTED_LIST(1);
-Error, Set: <list> must be a small list (not a integer)
+Error, Set: <list> must be a small list (not the integer 1)
 
 #
 gap> IS_EQUAL_SET;
 function( list1, list2 ) ... end
 gap> IS_EQUAL_SET(1,1);
-Error, IsEqualSet: <list1> must be a small list (not a integer)
+Error, IsEqualSet: <list1> must be a small list (not the integer 1)
 gap> IS_EQUAL_SET([],1);
-Error, IsEqualSet: <list2> must be a small list (not a integer)
+Error, IsEqualSet: <list2> must be a small list (not the integer 1)
 gap> IS_EQUAL_SET([],[]);
 true
 
@@ -23,9 +23,9 @@ true
 gap> IS_SUBSET_SET;
 function( set1, set2 ) ... end
 gap> IS_SUBSET_SET(1,1);
-Error, IsSubsetSet: <set1> must be a small list (not a integer)
+Error, IsSubsetSet: <set1> must be a small list (not the integer 1)
 gap> IS_SUBSET_SET([],1);
-Error, IsSubsetSet: <set2> must be a small list (not a integer)
+Error, IsSubsetSet: <set2> must be a small list (not the integer 1)
 gap> IS_SUBSET_SET([],[]);
 true
 gap> IS_SUBSET_SET([1,2,3],[1,2]);
@@ -59,7 +59,7 @@ function( set1, set2 ) ... end
 gap> UNITE_SET(1,1);
 Error, UniteSet: <set1> must be a mutable proper set (not a integer)
 gap> UNITE_SET([],1);
-Error, UniteSet: <set2> must be a small list (not a integer)
+Error, UniteSet: <set2> must be a small list (not the integer 1)
 gap> UNITE_SET([],[]);
 
 #
@@ -68,7 +68,7 @@ function( set1, set2 ) ... end
 gap> INTER_SET(1,1);
 Error, IntersectSet: <set1> must be a mutable proper set (not a integer)
 gap> INTER_SET([],1);
-Error, IntersectSet: <set2> must be a small list (not a integer)
+Error, IntersectSet: <set2> must be a small list (not the integer 1)
 gap> INTER_SET([],[]);
 
 #
@@ -77,7 +77,7 @@ function( set1, set2 ) ... end
 gap> SUBTR_SET(1,1);
 Error, SubtractSet: <set1> must be a mutable proper set (not a integer)
 gap> SUBTR_SET([],1);
-Error, SubtractSet: <set2> must be a small list (not a integer)
+Error, SubtractSet: <set2> must be a small list (not the integer 1)
 gap> SUBTR_SET([],[]);
 
 #

--- a/tst/testinstall/kernel/stats.tst
+++ b/tst/testinstall/kernel/stats.tst
@@ -6,10 +6,10 @@ gap> START_TEST("kernel/stats.tst");
 # test checks in ExecForRangeHelper
 gap> f := function(a) local x; for x in [a..1] do od; end;;
 gap> f('x');
-Error, Range: <first> must be an integer (not a character)
+Error, Range: <first> must be a small integer (not a character)
 gap> f := function(a) local x; for x in [1..a] do od; end;;
 gap> f('x');
-Error, Range: <last> must be an integer (not a character)
+Error, Range: <last> must be a small integer (not a character)
 
 # test Assert with two arguments
 gap> function() Assert(0, 0); end();

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -135,7 +135,7 @@ Error, ExecuteProcess: <in> must be an integer (not a boolean or fail)
 gap> ExecuteProcess("","",0,fail,fail);
 Error, ExecuteProcess: <out> must be an integer (not a boolean or fail)
 gap> ExecuteProcess("","",0,0,fail);
-Error, ExecuteProcess: <args> must be a small list (not a boolean or fail)
+Error, ExecuteProcess: <args> must be a small list (not the value 'fail')
 gap> ExecuteProcess("","",0,0,[1]);
 Error, <tmp> must be a string (not a integer)
 

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -7,39 +7,39 @@ gap> START_TEST("kernel/streams.tst");
 gap> CLOSE_LOG_TO();
 Error, LogTo: can not close the logfile
 gap> LOG_TO(fail);
-Error, LogTo: <filename> must be a string (not a boolean or fail)
+Error, LogTo: <filename> must be a string (not the value 'fail')
 
 #
 gap> CLOSE_INPUT_LOG_TO();
 Error, InputLogTo: can not close the logfile
 gap> INPUT_LOG_TO(fail);
-Error, InputLogTo: <filename> must be a string (not a boolean or fail)
+Error, InputLogTo: <filename> must be a string (not the value 'fail')
 
 #
 gap> CLOSE_OUTPUT_LOG_TO();
 Error, OutputLogTo: can not close the logfile
 gap> OUTPUT_LOG_TO(fail);
-Error, OutputLogTo: <filename> must be a string (not a boolean or fail)
+Error, OutputLogTo: <filename> must be a string (not the value 'fail')
 
 #
 gap> READ(fail);
-Error, READ: <filename> must be a string (not a boolean or fail)
+Error, READ: <filename> must be a string (not the value 'fail')
 gap> READ_NORECOVERY(fail);
 fail
 gap> READ_AS_FUNC(fail);
-Error, READ_AS_FUNC: <filename> must be a string (not a boolean or fail)
+Error, READ_AS_FUNC: <filename> must be a string (not the value 'fail')
 gap> READ_GAP_ROOT(fail);
-Error, READ: <filename> must be a string (not a boolean or fail)
+Error, READ: <filename> must be a string (not the value 'fail')
 
 #
 gap> RemoveFile(fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, RemoveFile: <filename> must be a string (not the value 'fail')
 gap> CreateDir(fail);
-Error, CreateDir: <filename> must be a string (not a boolean or fail)
+Error, CreateDir: <filename> must be a string (not the value 'fail')
 gap> RemoveDir(fail);
-Error, RemoveDir: <filename> must be a string (not a boolean or fail)
+Error, RemoveDir: <filename> must be a string (not the value 'fail')
 gap> IsDir(fail);
-Error, IsDir: <filename> must be a string (not a boolean or fail)
+Error, IsDir: <filename> must be a string (not the value 'fail')
 
 #
 gap> LastSystemError();; LastSystemError();
@@ -47,24 +47,24 @@ rec( message := "no error", number := 0 )
 
 #
 gap> IsExistingFile(fail);
-Error, IsExistingFile: <filename> must be a string (not a boolean or fail)
+Error, IsExistingFile: <filename> must be a string (not the value 'fail')
 gap> IsReadableFile(fail);
-Error, IsReadableFile: <filename> must be a string (not a boolean or fail)
+Error, IsReadableFile: <filename> must be a string (not the value 'fail')
 gap> IsWritableFile(fail);
-Error, IsWritableFile: <filename> must be a string (not a boolean or fail)
+Error, IsWritableFile: <filename> must be a string (not the value 'fail')
 gap> IsExecutableFile(fail);
-Error, IsExecutableFile: <filename> must be a string (not a boolean or fail)
+Error, IsExecutableFile: <filename> must be a string (not the value 'fail')
 gap> IsDirectoryPathString(fail);
-Error, IsDirectoryPathString: <filename> must be a string (not a boolean or fa\
-il)
+Error, IsDirectoryPathString: <filename> must be a string (not the value 'fail\
+')
 gap> STRING_LIST_DIR(fail);
-Error, STRING_LIST_DIR: <dirname> must be a string (not a boolean or fail)
+Error, STRING_LIST_DIR: <dirname> must be a string (not the value 'fail')
 
 #
 gap> CLOSE_FILE(fail);
 Error, CLOSE_FILE: <fid> must be a small integer (not the value 'fail')
 gap> INPUT_TEXT_FILE(fail);
-Error, INPUT_TEXT_FILE: <filename> must be a string (not a boolean or fail)
+Error, INPUT_TEXT_FILE: <filename> must be a string (not the value 'fail')
 gap> IS_END_OF_FILE(fail);
 Error, IS_END_OF_FILE: <fid> must be a small integer (not the value 'fail')
 gap> IS_END_OF_FILE(-1);
@@ -74,7 +74,7 @@ false
 gap> IS_END_OF_FILE(254);
 fail
 gap> OUTPUT_TEXT_FILE(fail, fail);
-Error, OUTPUT_TEXT_FILE: <filename> must be a string (not a boolean or fail)
+Error, OUTPUT_TEXT_FILE: <filename> must be a string (not the value 'fail')
 gap> OUTPUT_TEXT_FILE("test", fail);
 Error, OUTPUT_TEXT_FILE: <append> must be a boolean (not a boolean or fail)
 
@@ -130,9 +130,9 @@ Error, FD_OF_FILE: <fid> must be a small integer (not the value 'fail')
 
 #
 gap> ExecuteProcess(fail,fail,fail,fail,fail);
-Error, ExecuteProcess: <dir> must be a string (not a boolean or fail)
+Error, ExecuteProcess: <dir> must be a string (not the value 'fail')
 gap> ExecuteProcess("",fail,fail,fail,fail);
-Error, ExecuteProcess: <prg> must be a string (not a boolean or fail)
+Error, ExecuteProcess: <prg> must be a string (not the value 'fail')
 gap> ExecuteProcess("","",fail,fail,fail);
 Error, ExecuteProcess: <in> must be a small integer (not the value 'fail')
 gap> ExecuteProcess("","",0,fail,fail);
@@ -140,7 +140,7 @@ Error, ExecuteProcess: <out> must be a small integer (not the value 'fail')
 gap> ExecuteProcess("","",0,0,fail);
 Error, ExecuteProcess: <args> must be a small list (not the value 'fail')
 gap> ExecuteProcess("","",0,0,[1]);
-Error, ExecuteProcess: <tmp> must be a string (not a integer)
+Error, ExecuteProcess: <tmp> must be a string (not the integer 1)
 
 #
 gap> STOP_TEST("kernel/streams.tst", 1);

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -35,11 +35,11 @@ Error, READ: <filename> must be a string (not a boolean or fail)
 gap> RemoveFile(fail);
 Error, <filename> must be a string (not a boolean or fail)
 gap> CreateDir(fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, CreateDir: <filename> must be a string (not a boolean or fail)
 gap> RemoveDir(fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, RemoveDir: <filename> must be a string (not a boolean or fail)
 gap> IsDir(fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, IsDir: <filename> must be a string (not a boolean or fail)
 
 #
 gap> LastSystemError();; LastSystemError();
@@ -47,25 +47,26 @@ rec( message := "no error", number := 0 )
 
 #
 gap> IsExistingFile(fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, IsExistingFile: <filename> must be a string (not a boolean or fail)
 gap> IsReadableFile(fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, IsReadableFile: <filename> must be a string (not a boolean or fail)
 gap> IsWritableFile(fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, IsWritableFile: <filename> must be a string (not a boolean or fail)
 gap> IsExecutableFile(fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, IsExecutableFile: <filename> must be a string (not a boolean or fail)
 gap> IsDirectoryPathString(fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, IsDirectoryPathString: <filename> must be a string (not a boolean or fa\
+il)
 gap> STRING_LIST_DIR(fail);
-Error, <dirname> must be a string (not a boolean or fail)
+Error, STRING_LIST_DIR: <dirname> must be a string (not a boolean or fail)
 
 #
 gap> CLOSE_FILE(fail);
-Error, <fid> must be an integer (not a boolean or fail)
+Error, CLOSE_FILE: <fid> must be a small integer (not the value 'fail')
 gap> INPUT_TEXT_FILE(fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, INPUT_TEXT_FILE: <filename> must be a string (not a boolean or fail)
 gap> IS_END_OF_FILE(fail);
-Error, <fid> must be an integer (not a boolean or fail)
+Error, IS_END_OF_FILE: <fid> must be a small integer (not the value 'fail')
 gap> IS_END_OF_FILE(-1);
 fail
 gap> IS_END_OF_FILE(0);
@@ -73,13 +74,13 @@ false
 gap> IS_END_OF_FILE(254);
 fail
 gap> OUTPUT_TEXT_FILE(fail, fail);
-Error, <filename> must be a string (not a boolean or fail)
+Error, OUTPUT_TEXT_FILE: <filename> must be a string (not a boolean or fail)
 gap> OUTPUT_TEXT_FILE("test", fail);
-Error, <append> must be a boolean (not a boolean or fail)
+Error, OUTPUT_TEXT_FILE: <append> must be a boolean (not a boolean or fail)
 
 #
 gap> POSITION_FILE(fail);
-Error, <fid> must be an integer (not a boolean or fail)
+Error, POSITION_FILE: <fid> must be a small integer (not the value 'fail')
 gap> POSITION_FILE(-1);
 fail
 gap> IsInt(POSITION_FILE(4));
@@ -89,27 +90,29 @@ fail
 
 #
 gap> READ_BYTE_FILE(fail);
-Error, <fid> must be an integer (not a boolean or fail)
+Error, READ_BYTE_FILE: <fid> must be a small integer (not the value 'fail')
 gap> READ_BYTE_FILE(-1);
 fail
 
 #
 gap> READ_LINE_FILE(fail);
-Error, <fid> must be an integer (not a boolean or fail)
+Error, READ_LINE_FILE: <fid> must be a small integer (not the value 'fail')
 gap> READ_ALL_FILE(fail,fail);
-Error, <fid> must be an integer (not a boolean or fail)
+Error, READ_ALL_FILE: <fid> must be a small integer (not the value 'fail')
 gap> READ_ALL_FILE(1,fail);
-Error, <limit> must be a small integer (not a boolean or fail)
+Error, READ_ALL_FILE: <limit> must be a small integer (not the value 'fail')
 gap> SEEK_POSITION_FILE(fail,fail);
-Error, <fid> must be an integer (not a boolean or fail)
+Error, SEEK_POSITION_FILE: <fid> must be a small integer (not the value 'fail'\
+)
 gap> SEEK_POSITION_FILE(1,fail);
-Error, <pos> must be an integer (not a boolean or fail)
+Error, SEEK_POSITION_FILE: <pos> must be a small integer (not the value 'fail'\
+)
 
 #
 gap> WRITE_BYTE_FILE(fail,fail);
-Error, <fid> must be an integer (not a boolean or fail)
+Error, WRITE_BYTE_FILE: <fid> must be a small integer (not the value 'fail')
 gap> WRITE_BYTE_FILE(1,fail);
-Error, <ch> must be an integer (not a boolean or fail)
+Error, WRITE_BYTE_FILE: <ch> must be a small integer (not the value 'fail')
 gap> WRITE_BYTE_FILE(-1,65);
 fail
 gap> WRITE_BYTE_FILE(0,65);
@@ -119,11 +122,11 @@ fail
 
 #
 gap> READ_STRING_FILE(fail);
-Error, <fid> must be an integer (not a boolean or fail)
+Error, READ_STRING_FILE: <fid> must be a small integer (not the value 'fail')
 
 #
 gap> FD_OF_FILE(fail);
-Error, <fid> must be a small integer (not a boolean or fail)
+Error, FD_OF_FILE: <fid> must be a small integer (not the value 'fail')
 
 #
 gap> ExecuteProcess(fail,fail,fail,fail,fail);
@@ -131,13 +134,13 @@ Error, ExecuteProcess: <dir> must be a string (not a boolean or fail)
 gap> ExecuteProcess("",fail,fail,fail,fail);
 Error, ExecuteProcess: <prg> must be a string (not a boolean or fail)
 gap> ExecuteProcess("","",fail,fail,fail);
-Error, ExecuteProcess: <in> must be an integer (not a boolean or fail)
+Error, ExecuteProcess: <in> must be a small integer (not the value 'fail')
 gap> ExecuteProcess("","",0,fail,fail);
-Error, ExecuteProcess: <out> must be an integer (not a boolean or fail)
+Error, ExecuteProcess: <out> must be a small integer (not the value 'fail')
 gap> ExecuteProcess("","",0,0,fail);
 Error, ExecuteProcess: <args> must be a small list (not the value 'fail')
 gap> ExecuteProcess("","",0,0,[1]);
-Error, <tmp> must be a string (not a integer)
+Error, ExecuteProcess: <tmp> must be a string (not a integer)
 
 #
 gap> STOP_TEST("kernel/streams.tst", 1);

--- a/tst/testinstall/kernel/stringobj.tst
+++ b/tst/testinstall/kernel/stringobj.tst
@@ -16,7 +16,7 @@ Error, <str> must be a string, not a integer)
 
 #
 gap> CHAR_INT(fail);
-Error, <val> must be an integer (not a boolean or fail)
+Error, CHAR_INT: <val> must be a small integer (not the value 'fail')
 gap> CHAR_INT(-1);
 Error, <val> must be an integer between 0 and 255
 gap> CHAR_INT(65);
@@ -30,7 +30,7 @@ gap> INT_CHAR('A');
 
 #
 gap> CHAR_SINT(fail);
-Error, <val> must be an integer (not a boolean or fail)
+Error, CHAR_SINT: <val> must be a small integer (not the value 'fail')
 gap> CHAR_SINT(255);
 Error, <val> must be an integer between -128 and 127
 gap> CHAR_SINT(65);

--- a/tst/testinstall/kernel/stringobj.tst
+++ b/tst/testinstall/kernel/stringobj.tst
@@ -12,7 +12,7 @@ Error, <len> must be an non-negative integer (not a integer)
 #
 gap> ShrinkAllocationString(s);
 gap> ShrinkAllocationString(1);
-Error, <str> must be a string, not a integer)
+Error, ShrinkAllocationString: <str> must be a string (not the integer 1)
 
 #
 gap> CHAR_INT(fail);
@@ -87,9 +87,9 @@ gap> POSITION_SUBSTRING("abc","b",0);
 gap> POSITION_SUBSTRING("abc","b",3);
 fail
 gap> POSITION_SUBSTRING(1,2,3);
-Error, POSITION_SUBSTRING: <string> must be a string (not a integer)
+Error, POSITION_SUBSTRING: <string> must be a string (not the integer 1)
 gap> POSITION_SUBSTRING("abc",2,3);
-Error, POSITION_SUBSTRING: <substr> must be a string (not a integer)
+Error, POSITION_SUBSTRING: <substr> must be a string (not the integer 2)
 gap> POSITION_SUBSTRING("abc","b",-1);
 Error, POSITION_SUBSTRING: <off> must be a non-negative integer (not a integer\
 )
@@ -98,29 +98,25 @@ Error, POSITION_SUBSTRING: <off> must be a non-negative integer (not a integer\
 gap> s:="  abc\n  xyz\n";; NormalizeWhitespace(s); s;
 "abc xyz"
 gap> NormalizeWhitespace(1);
-Error, NormalizeWhitespace: <string> must be a string (not a integer)
+Error, NormalizeWhitespace: <string> must be a string (not the integer 1)
 
 #
 gap> s:="abcdabcd";; REMOVE_CHARACTERS(s, "db"); s;
 "acac"
 gap> REMOVE_CHARACTERS(1,1);
-Error, RemoveCharacters: first argument <string> must be a string (not a integ\
-er)
+Error, RemoveCharacters: <string> must be a string (not the integer 1)
 gap> REMOVE_CHARACTERS(s,1);
-Error, RemoveCharacters: second argument <rem> must be a string (not a integer\
-)
+Error, RemoveCharacters: <rem> must be a string (not the integer 1)
 
 #
 gap> s:="abc";; TranslateString(s,UPPERCASETRANSTABLE); s;
 "ABC"
 gap> TranslateString(1,1);
-Error, TranslateString: first argument <string> must be a string (not a intege\
-r)
+Error, TranslateString: <string> must be a string (not the integer 1)
 gap> TranslateString("abc",1);
-Error, TranslateString: second argument <trans> must be a string (not a intege\
-r)
+Error, TranslateString: <trans> must be a string (not a integer)
 gap> TranslateString("abc","def");
-Error, TranslateString: second argument <trans> must have length >= 256
+Error, TranslateString: <trans> must have length >= 256
 
 #
 gap> STOP_TEST("kernel/strinobj.tst", 1);

--- a/tst/testinstall/numtheor.tst
+++ b/tst/testinstall/numtheor.tst
@@ -74,9 +74,9 @@ gap> JACOBI_INT_GAP := function ( n, m )
 gap> ForAll([-100 .. 100], a-> ForAll([1 .. 100], b -> JACOBI_INT_GAP(a,b)=JACOBI_INT(a,b)));
 true
 gap> JACOBI_INT(fail, 1);
-Error, Jacobi: <n> must be an integer (not a boolean or fail)
+Error, Jacobi: <n> must be an integer (not the value 'fail')
 gap> JACOBI_INT(1, fail);
-Error, Jacobi: <m> must be an integer (not a boolean or fail)
+Error, Jacobi: <m> must be an integer (not the value 'fail')
 
 #
 gap> STOP_TEST( "numtheor.tst", 1);

--- a/tst/testinstall/perm.tst
+++ b/tst/testinstall/perm.tst
@@ -19,7 +19,8 @@ true
 
 # test error handling parsing of permutations
 gap> (1,2,0);
-Error, Permutation: <expr> must be a positive small integer (not a integer)
+Error, Permutation: <expr> must be a positive small integer (not the integer 0\
+)
 gap> (1,2)(1,2);
 Error, Permutation: cycles must be disjoint and duplicate-free
 gap> (1,2,3,2);

--- a/tst/testinstall/trans.tst
+++ b/tst/testinstall/trans.tst
@@ -468,11 +468,11 @@ true
 
 # Test PREIMAGES_TRANS_INT
 gap> PREIMAGES_TRANS_INT(IdentityTransformation, 0);
-Error, PREIMAGES_TRANS_INT: <pt> must be a positive small integer (not a integ\
-er)
+Error, PREIMAGES_TRANS_INT: <pt> must be a positive small integer (not the int\
+eger 0)
 gap> PREIMAGES_TRANS_INT(IdentityTransformation, -1);
-Error, PREIMAGES_TRANS_INT: <pt> must be a positive small integer (not a integ\
-er)
+Error, PREIMAGES_TRANS_INT: <pt> must be a positive small integer (not the int\
+eger -1)
 gap> PREIMAGES_TRANS_INT(IdentityTransformation, "a");
 Error, PREIMAGES_TRANS_INT: <pt> must be a positive small integer (not a list \
 (string))
@@ -1469,8 +1469,8 @@ gap> COMPONENT_TRANS_INT(Transformation([3, 8, 1, 9, 9, 4, 10, 5, 10, 6, 12,
 gap> COMPONENT_TRANS_INT(IdentityTransformation, 10);
 [ 10 ]
 gap> COMPONENT_TRANS_INT(IdentityTransformation, 0);
-Error, COMPONENT_TRANS_INT: <pt> must be a positive small integer (not a integ\
-er)
+Error, COMPONENT_TRANS_INT: <pt> must be a positive small integer (not the int\
+eger 0)
 gap> COMPONENT_TRANS_INT(IdentityTransformation, "a");
 Error, COMPONENT_TRANS_INT: <pt> must be a positive small integer (not a list \
 (string))
@@ -1566,7 +1566,8 @@ gap> CYCLE_TRANS_INT(Transformation([3, 8, 1, 9, 9, 4, 10, 5, 10, 6, 12,
 gap> CYCLE_TRANS_INT(IdentityTransformation, 10);
 [ 10 ]
 gap> CYCLE_TRANS_INT(IdentityTransformation, 0);
-Error, CYCLE_TRANS_INT: <pt> must be a positive small integer (not a integer)
+Error, CYCLE_TRANS_INT: <pt> must be a positive small integer (not the integer\
+ 0)
 gap> CYCLE_TRANS_INT(IdentityTransformation, "a");
 Error, CYCLE_TRANS_INT: <pt> must be a positive small integer (not a list (str\
 ing))
@@ -2587,8 +2588,8 @@ gap> 10 ^ Transformation([1, 1]);
 gap> (2 ^ 60) ^ Transformation([1, 1]);
 1152921504606846976
 gap> (-1) ^ Transformation([1, 1]);
-Error, Tran. Operations: <point> must be a positive small integer (not a integ\
-er)
+Error, Tran. Operations: <point> must be a positive small integer (not the int\
+eger -1)
 gap> 65535 ^ Transformation([65535], [65537]);
 65537
 gap> 1 ^ Transformation([65535], [65537]);
@@ -2598,8 +2599,8 @@ gap> 65538 ^ Transformation([65535], [65537]);
 gap> (2 ^ 60) ^ Transformation([65535], [65537]);
 1152921504606846976
 gap> (-1) ^ Transformation([65535], [65537]);
-Error, Tran. Operations: <point> must be a positive small integer (not a integ\
-er)
+Error, Tran. Operations: <point> must be a positive small integer (not the int\
+eger -1)
 
 # OnSetsTrans: for a transformation
 gap> OnSets([], Transformation([1, 1]));
@@ -2611,8 +2612,8 @@ gap> OnSets([1, 2, 10], Transformation([1, 1]));
 gap> OnSets([1, 2, 10, (2 ^ 60)], Transformation([1, 1]));
 [ 1, 10, 1152921504606846976 ]
 gap> OnSets([-1, 1, 2], Transformation([1, 1]));
-Error, Tran. Operations: <point> must be a positive small integer (not a integ\
-er)
+Error, Tran. Operations: <point> must be a positive small integer (not the int\
+eger -1)
 gap> OnSets([65535, 65536, 65537], Transformation([65535], [65537]));
 [ 65536, 65537 ]
 gap> OnSets([1, 2, 10], Transformation([65535], [65537]));
@@ -2622,8 +2623,8 @@ gap> OnSets([1, 65535, 65538], Transformation([65535], [65537]));
 gap> OnSets([1, 2, 10, 65537, (2 ^ 60)], Transformation([65537], [1]));
 [ 1, 2, 10, 1152921504606846976 ]
 gap> OnSets([-1, 1, 2], Transformation([65535], [65537]));
-Error, Tran. Operations: <point> must be a positive small integer (not a integ\
-er)
+Error, Tran. Operations: <point> must be a positive small integer (not the int\
+eger -1)
 gap> OnSets([1, 2, 10, 65535, (2 ^ 60)], Transformation([65535], [5]));
 [ 1, 2, 5, 10, 1152921504606846976 ]
 gap> OnSets([1 .. 20], Transformation([10, 7, 10, 8, 8, 7, 5, 9, 1, 9]));
@@ -2649,8 +2650,8 @@ gap> OnTuples([1, 2, 10], Transformation([1, 1]));
 gap> OnTuples([1, 2, 10, (2 ^ 60)], Transformation([1, 1]));
 [ 1, 1, 10, 1152921504606846976 ]
 gap> OnTuples([-1, 1, 2], Transformation([1, 1]));
-Error, Tran. Operations: <point> must be a positive small integer (not a integ\
-er)
+Error, Tran. Operations: <point> must be a positive small integer (not the int\
+eger -1)
 gap> OnTuples([65535, 65536, 65537], Transformation([65535], [65537]));
 [ 65537, 65536, 65537 ]
 gap> OnTuples([1, 2, 10], Transformation([65535], [65537]));
@@ -2660,8 +2661,8 @@ gap> OnTuples([1, 65535, 65538], Transformation([65535], [65537]));
 gap> OnTuples([1, 2, 10, 65537, (2 ^ 60)], Transformation([65537], [1]));
 [ 1, 2, 10, 1, 1152921504606846976 ]
 gap> OnTuples([-1, 1, 2], Transformation([65535], [65537]));
-Error, Tran. Operations: <point> must be a positive small integer (not a integ\
-er)
+Error, Tran. Operations: <point> must be a positive small integer (not the int\
+eger -1)
 gap> OnTuples([1, 2, 10, 65535, (2 ^ 60)], Transformation([65535], [5]));
 [ 1, 2, 10, 5, 1152921504606846976 ]
 gap> OnTuples([1 .. 20], Transformation([10, 7, 10, 8, 8, 7, 5, 9, 1, 9]));

--- a/tst/testinstall/weakptr-badargs.tst
+++ b/tst/testinstall/weakptr-badargs.tst
@@ -4,7 +4,7 @@ gap> w := WeakPointerObject([1,,3,4]);
 Error, Variable: 'WeakPointerObject' must have a value
 gap> w := WeakPointerObj([1,,3,4]);;
 gap> SetElmWPObj(w, 0, 0);
-Error, SetElmWPObj: <pos> must be a positive small integer (not a integer)
+Error, SetElmWPObj: <pos> must be a positive small integer (not the integer 0)
 gap> SetElmWPObj(w, [1,2], 0);
 Error, SetElmWPObj: <pos> must be a positive small integer (not a list (plain,\
 cyc))
@@ -15,7 +15,8 @@ gap> SetElmWPObj((), 1, 1);
 Error, SetElmWPObj: <wp> must be a weak pointer object (not a permutation (sma\
 ll))
 gap> UnbindElmWPObj(w, 0);
-Error, UnbindElmWPObj: <pos> must be a positive small integer (not a integer)
+Error, UnbindElmWPObj: <pos> must be a positive small integer (not the integer\
+ 0)
 gap> UnbindElmWPObj(w, []);
 Error, UnbindElmWPObj: <pos> must be a positive small integer (not a list (pla\
 in,empty))
@@ -23,7 +24,7 @@ gap> UnbindElmWPObj([], 2);
 Error, UnbindElmWPObj: <wp> must be a weak pointer object (not a list (plain,e\
 mpty))
 gap> ElmWPObj(w, 0);
-Error, ElmWPObj: <pos> must be a positive small integer (not a integer)
+Error, ElmWPObj: <pos> must be a positive small integer (not the integer 0)
 gap> ElmWPObj(w, []);
 Error, ElmWPObj: <pos> must be a positive small integer (not a list (plain,emp\
 ty))
@@ -32,7 +33,8 @@ Error, ElmWPObj: <wp> must be a weak pointer object (not a list (plain,empty))
 gap> IsBoundWPObj(w, 0);
 Error, Variable: 'IsBoundWPObj' must have a value
 gap> IsBoundElmWPObj(w, 0);
-Error, IsBoundElmWPObj: <pos> must be a positive small integer (not a integer)
+Error, IsBoundElmWPObj: <pos> must be a positive small integer (not the intege\
+r 0)
 gap> IsBoundElmWPObj(w, []);
 Error, IsBoundElmWPObj: <pos> must be a positive small integer (not a list (pl\
 ain,empty))
@@ -43,5 +45,5 @@ gap> LengthWPObj([]);
 Error, LengthWPObj: <wp> must be a weak pointer object (not a list (plain,empt\
 y))
 gap> LengthWPObj(0);
-Error, LengthWPObj: <wp> must be a weak pointer object (not a integer)
+Error, LengthWPObj: <wp> must be a weak pointer object (not the integer 0)
 gap> STOP_TEST( "weakptr-badargs.tst", 1);


### PR DESCRIPTION
This continues the work begun in PR #2947 and implements the change I promised there: Instead of "(not a integer)" we now say for example "(not the integer 5)".

Also adds and uses `RequireStringRep`, `RequireInt`, `RequireSmallInt`