### PR TITLE
clang-format: set AlwaysBreakTemplateDeclarations: true

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,3 +24,5 @@ PointerBindsToType: Middle
 SpacesBeforeTrailingComments: 4
 UseTab: Never
 SortIncludes: false
+
+AlwaysBreakTemplateDeclarations: true

--- a/src/collectors.cc
+++ b/src/collectors.cc
@@ -145,8 +145,8 @@ typedef struct {
 **
 *F  WordVectorAndClear( <type>, <vv>, <num> )
 */
-template<typename UIntN>
-Obj WordVectorAndClear ( Obj type, Obj vv, Int num )
+template <typename UIntN>
+Obj WordVectorAndClear(Obj type, Obj vv, Int num)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* unsigned exponent mask                  */
@@ -190,8 +190,8 @@ Obj WordVectorAndClear ( Obj type, Obj vv, Int num )
 **
 **  WARNING: This function assumes that <vv> is cleared!
 */
-template<typename UIntN>
-Int VectorWord ( Obj vv, Obj v, Int num )
+template <typename UIntN>
+Int VectorWord(Obj vv, Obj v, Int num)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* unsigned exponent mask                  */
@@ -256,10 +256,16 @@ Int VectorWord ( Obj vv, Obj v, Int num )
 **  global exponent because the beginning of  the word might not commute with
 **  the rest.
 **/
-template<typename UIntN>
-static Int SAddWordIntoExpVec( Int *v, const UIntN *w, Int e,
-                           Int ebits, UInt expm,
-                           const Obj *ro, const Obj *pow, Int lpow ) {
+template <typename UIntN>
+static Int SAddWordIntoExpVec(Int *         v,
+                              const UIntN * w,
+                              Int           e,
+                              Int           ebits,
+                              UInt          expm,
+                              const Obj *   ro,
+                              const Obj *   pow,
+                              Int           lpow)
+{
 
     const UIntN * wend = w + (INT_INTOBJ((((const Obj*)(w))[-1])) - 1);
     Int        i;
@@ -283,10 +289,16 @@ static Int SAddWordIntoExpVec( Int *v, const UIntN *w, Int e,
     return start;
 }
 
-template<typename UIntN>
-static Int SAddPartIntoExpVec( Int *v, const UIntN *w, const UIntN *wend,
-                           Int ebits, UInt expm,
-                           const Obj* ro, const Obj *pow, Int lpow ) {
+template <typename UIntN>
+static Int SAddPartIntoExpVec(Int *         v,
+                              const UIntN * w,
+                              const UIntN * wend,
+                              Int           ebits,
+                              UInt          expm,
+                              const Obj *   ro,
+                              const Obj *   pow,
+                              Int           lpow)
+{
 
     Int        i;
     Int        ex;
@@ -316,8 +328,8 @@ static Int SAddPartIntoExpVec( Int *v, const UIntN *w, const UIntN *wend,
 **
 **  If a stack overflow occurs, we simply stop and return false.
 */
-template<typename UIntN>
-Int SingleCollectWord ( Obj sc, Obj vv, Obj w )
+template <typename UIntN>
+Int SingleCollectWord(Obj sc, Obj vv, Obj w)
 {
     Int         ebits;      /* number of bits in the exponent              */
     UInt        expm;       /* unsigned exponent mask                      */
@@ -594,12 +606,8 @@ Int SingleCollectWord ( Obj sc, Obj vv, Obj w )
 **
 *F  Solution( <sc>, <ww>, <uu>, <func> )
 */
-template<typename UIntN>
-Int Solution(
-    Obj         sc,
-    Obj         ww,
-    Obj         uu,
-    FuncIOOO    func )
+template <typename UIntN>
+Int Solution(Obj sc, Obj ww, Obj uu, FuncIOOO func)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* unsigned exponent mask                  */
@@ -732,10 +740,16 @@ FinPowConjCol C32Bits_SingleCollector = {
 **  global exponent because the beginning of  the word might not commute with
 **  the rest.
 **/
-template<typename UIntN>
-static void AddWordIntoExpVec( Int *v, const UIntN *w, Int e,
-                           Int ebits, UInt expm,
-                           Int p, const Obj *pow, Int lpow ) {
+template <typename UIntN>
+static void AddWordIntoExpVec(Int *         v,
+                              const UIntN * w,
+                              Int           e,
+                              Int           ebits,
+                              UInt          expm,
+                              Int           p,
+                              const Obj *   pow,
+                              Int           lpow)
+{
 
     const UIntN * wend = w + (INT_INTOBJ((((const Obj*)(w))[-1])) - 1);
     Int        i;
@@ -756,10 +770,16 @@ static void AddWordIntoExpVec( Int *v, const UIntN *w, Int e,
     }
 }
 
-template<typename UIntN>
-static void AddCommIntoExpVec( Int *v, const UIntN *w, Int e,
-                           Int ebits, UInt expm,
-                           Int p, const Obj *pow, Int lpow ) {
+template <typename UIntN>
+static void AddCommIntoExpVec(Int *         v,
+                              const UIntN * w,
+                              Int           e,
+                              Int           ebits,
+                              UInt          expm,
+                              Int           p,
+                              const Obj *   pow,
+                              Int           lpow)
+{
 
     const UIntN * wend = w + (INT_INTOBJ((((const Obj*)(w))[-1])) - 1);
     Int        i;
@@ -782,10 +802,16 @@ static void AddCommIntoExpVec( Int *v, const UIntN *w, Int e,
     }
 }
 
-template<typename UIntN>
-static void AddPartIntoExpVec( Int *v, const UIntN *w, const UIntN *wend,
-                           Int ebits, UInt expm,
-                           Int p, const Obj *pow, Int lpow ) {
+template <typename UIntN>
+static void AddPartIntoExpVec(Int *         v,
+                              const UIntN * w,
+                              const UIntN * wend,
+                              Int           ebits,
+                              UInt          expm,
+                              Int           p,
+                              const Obj *   pow,
+                              Int           lpow)
+{
 
     Int        i;
     Int        ex;
@@ -811,8 +837,8 @@ static void AddPartIntoExpVec( Int *v, const UIntN *w, const UIntN *wend,
 **
 **  If a stack overflow occurs, we simply stop and return false.
 */
-template<typename UIntN>
-Int CombiCollectWord ( Obj sc, Obj vv, Obj w )
+template <typename UIntN>
+Int CombiCollectWord(Obj sc, Obj vv, Obj w)
 {
     Int         ebits;      /* number of bits in the exponent              */
     UInt        expm;       /* unsigned exponent mask                      */

--- a/src/objfgelm.cc
+++ b/src/objfgelm.cc
@@ -90,10 +90,21 @@ extern "C" {
 // OverflowType<UIntN> is a type which is larger enough to detect
 // overflow of multiplication of two IntN values. For 8 and 16 bit
 // inputs, we use `Int`, for 32 bit inputs we use Int8.
-template<typename T> struct OverflowType { };
-template<> struct OverflowType<UInt1> { typedef Int type; };
-template<> struct OverflowType<UInt2> { typedef Int type; };
-template<> struct OverflowType<UInt4> { typedef Int8 type; };
+template <typename T>
+struct OverflowType {
+};
+template <>
+struct OverflowType<UInt1> {
+    typedef Int type;
+};
+template <>
+struct OverflowType<UInt2> {
+    typedef Int type;
+};
+template <>
+struct OverflowType<UInt4> {
+    typedef Int8 type;
+};
 
 
 extern Obj NewWord(Obj type, UInt npairs)
@@ -120,11 +131,8 @@ extern Obj NewWord(Obj type, UInt npairs)
 #define Func8Bits_Equal FuncNBits_Equal<UInt1>
 #define Func16Bits_Equal FuncNBits_Equal<UInt2>
 #define Func32Bits_Equal FuncNBits_Equal<UInt4>
-template<typename UIntN>
-Obj FuncNBits_Equal (
-    Obj         self,
-    Obj         l,
-    Obj         r )
+template <typename UIntN>
+Obj FuncNBits_Equal(Obj self, Obj l, Obj r)
 {
     Int         nl;             /* number of pairs to consider in <l>      */
     Int         nr;             /* number of pairs in <r>                  */
@@ -157,12 +165,8 @@ Obj FuncNBits_Equal (
 #define Func8Bits_ExponentSums3 FuncNBits_ExponentSums3<UInt1>
 #define Func16Bits_ExponentSums3 FuncNBits_ExponentSums3<UInt2>
 #define Func32Bits_ExponentSums3 FuncNBits_ExponentSums3<UInt4>
-template<typename UIntN>
-Obj FuncNBits_ExponentSums3 (
-    Obj         self,
-    Obj         obj,
-    Obj         vstart,
-    Obj         vend )
+template <typename UIntN>
+Obj FuncNBits_ExponentSums3(Obj self, Obj obj, Obj vstart, Obj vend)
 {
     Int         start;          /* the lowest generator number             */
     Int         end;            /* the highest generator number            */
@@ -245,10 +249,8 @@ Obj FuncNBits_ExponentSums3 (
 #define Func8Bits_ExponentSums1 FuncNBits_ExponentSums1<UInt1>
 #define Func16Bits_ExponentSums1 FuncNBits_ExponentSums1<UInt2>
 #define Func32Bits_ExponentSums1 FuncNBits_ExponentSums1<UInt4>
-template<typename UIntN>
-Obj FuncNBits_ExponentSums1 (
-    Obj         self,
-    Obj         obj )
+template <typename UIntN>
+Obj FuncNBits_ExponentSums1(Obj self, Obj obj)
 {
     return FuncNBits_ExponentSums3<UIntN>( self, obj,
         INTOBJ_INT(1), INTOBJ_INT(RANK_WORD(obj)) );
@@ -262,11 +264,8 @@ Obj FuncNBits_ExponentSums1 (
 #define Func8Bits_ExponentSyllable FuncNBits_ExponentSyllable<UInt1>
 #define Func16Bits_ExponentSyllable FuncNBits_ExponentSyllable<UInt2>
 #define Func32Bits_ExponentSyllable FuncNBits_ExponentSyllable<UInt4>
-template<typename UIntN>
-Obj FuncNBits_ExponentSyllable (
-    Obj         self,
-    Obj         w,
-    Obj         vi )
+template <typename UIntN>
+Obj FuncNBits_ExponentSyllable(Obj self, Obj w, Obj vi)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* signed exponent mask                    */
@@ -305,10 +304,8 @@ Obj FuncNBits_ExponentSyllable (
 #define Func8Bits_ExtRepOfObj FuncNBits_ExtRepOfObj<UInt1>
 #define Func16Bits_ExtRepOfObj FuncNBits_ExtRepOfObj<UInt2>
 #define Func32Bits_ExtRepOfObj FuncNBits_ExtRepOfObj<UInt4>
-template<typename UIntN>
-Obj FuncNBits_ExtRepOfObj (
-    Obj         self,
-    Obj         obj )
+template <typename UIntN>
+Obj FuncNBits_ExtRepOfObj(Obj self, Obj obj)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* signed exponent mask                    */
@@ -362,11 +359,8 @@ Obj FuncNBits_ExtRepOfObj (
 #define Func8Bits_GeneratorSyllable FuncNBits_GeneratorSyllable<UInt1>
 #define Func16Bits_GeneratorSyllable FuncNBits_GeneratorSyllable<UInt2>
 #define Func32Bits_GeneratorSyllable FuncNBits_GeneratorSyllable<UInt4>
-template<typename UIntN>
-Obj FuncNBits_GeneratorSyllable (
-    Obj         self,
-    Obj         w,
-    Obj         vi )
+template <typename UIntN>
+Obj FuncNBits_GeneratorSyllable(Obj self, Obj w, Obj vi)
 {
     Int         ebits;          /* number of bits in the exponent          */
     Int         num;            /* number of gen/exp pairs in <data>       */
@@ -396,11 +390,8 @@ Obj FuncNBits_GeneratorSyllable (
 #define Func8Bits_HeadByNumber FuncNBits_HeadByNumber<UInt1>
 #define Func16Bits_HeadByNumber FuncNBits_HeadByNumber<UInt2>
 #define Func32Bits_HeadByNumber FuncNBits_HeadByNumber<UInt4>
-template<typename UIntN>
-Obj FuncNBits_HeadByNumber (
-    Obj         self,
-    Obj         l,
-    Obj         r )
+template <typename UIntN>
+Obj FuncNBits_HeadByNumber(Obj self, Obj l, Obj r)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        genm;           /* generator mask                          */
@@ -477,11 +468,8 @@ Obj FuncNBits_HeadByNumber (
 #define Func8Bits_Less FuncNBits_Less<UInt1>
 #define Func16Bits_Less FuncNBits_Less<UInt2>
 #define Func32Bits_Less FuncNBits_Less<UInt4>
-template<typename UIntN>
-Obj FuncNBits_Less (
-    Obj         self,
-    Obj         l,
-    Obj         r )
+template <typename UIntN>
+Obj FuncNBits_Less(Obj self, Obj l, Obj r)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* signed exponent mask                    */
@@ -580,11 +568,8 @@ Obj FuncNBits_Less (
 #define Func8Bits_AssocWord FuncNBits_AssocWord<UInt1>
 #define Func16Bits_AssocWord FuncNBits_AssocWord<UInt2>
 #define Func32Bits_AssocWord FuncNBits_AssocWord<UInt4>
-template<typename UIntN>
-Obj FuncNBits_AssocWord (
-    Obj         self,
-    Obj         type,
-    Obj         data )
+template <typename UIntN>
+Obj FuncNBits_AssocWord(Obj self, Obj type, Obj data)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* unsigned exponent mask                  */
@@ -636,11 +621,8 @@ Obj FuncNBits_AssocWord (
 #define Func8Bits_ObjByVector FuncNBits_ObjByVector<UInt1>
 #define Func16Bits_ObjByVector FuncNBits_ObjByVector<UInt2>
 #define Func32Bits_ObjByVector FuncNBits_ObjByVector<UInt4>
-template<typename UIntN>
-Obj FuncNBits_ObjByVector (
-    Obj         self,
-    Obj         type,
-    Obj         data )
+template <typename UIntN>
+Obj FuncNBits_ObjByVector(Obj self, Obj type, Obj data)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* unsigned exponent mask                  */
@@ -700,11 +682,8 @@ Obj FuncNBits_ObjByVector (
 #define Func8Bits_Power FuncNBits_Power<UInt1>
 #define Func16Bits_Power FuncNBits_Power<UInt2>
 #define Func32Bits_Power FuncNBits_Power<UInt4>
-template<typename UIntN>
-Obj FuncNBits_Power (
-    Obj         self,
-    Obj         l,
-    Obj         r )
+template <typename UIntN>
+Obj FuncNBits_Power(Obj self, Obj l, Obj r)
 {
     typedef typename OverflowType<UIntN>::type OInt;
 
@@ -936,11 +915,8 @@ Obj FuncNBits_Power (
 #define Func8Bits_Product FuncNBits_Product<UInt1>
 #define Func16Bits_Product FuncNBits_Product<UInt2>
 #define Func32Bits_Product FuncNBits_Product<UInt4>
-template<typename UIntN>
-Obj FuncNBits_Product (
-    Obj         self,
-    Obj         l,
-    Obj         r )
+template <typename UIntN>
+Obj FuncNBits_Product(Obj self, Obj l, Obj r)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* signed exponent mask                    */
@@ -1024,11 +1000,8 @@ Obj FuncNBits_Product (
 #define Func8Bits_Quotient FuncNBits_Quotient<UInt1>
 #define Func16Bits_Quotient FuncNBits_Quotient<UInt2>
 #define Func32Bits_Quotient FuncNBits_Quotient<UInt4>
-template<typename UIntN>
-Obj FuncNBits_Quotient (
-    Obj         self,
-    Obj         l,
-    Obj         r )
+template <typename UIntN>
+Obj FuncNBits_Quotient(Obj self, Obj l, Obj r)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* signed exponent mask                    */
@@ -1113,10 +1086,8 @@ Obj FuncNBits_Quotient (
 #define Func8Bits_LengthWord FuncNBits_LengthWord<UInt1>
 #define Func16Bits_LengthWord FuncNBits_LengthWord<UInt2>
 #define Func32Bits_LengthWord FuncNBits_LengthWord<UInt4>
-template<typename UIntN>
-Obj FuncNBits_LengthWord (
-    Obj         self,
-    Obj         w )
+template <typename UIntN>
+Obj FuncNBits_LengthWord(Obj self, Obj w)
 {
   UInt npairs,i,ebits,exps,expm;
   Obj len, uexp;

--- a/src/objpcgel.cc
+++ b/src/objpcgel.cc
@@ -104,8 +104,8 @@ Obj FuncNBitsPcWord_Quotient ( Obj self, Obj left, Obj right )
 **
 *F  DepthOfPcElement( <self>, <pcgs>, <w> )
 */
-template<typename UIntN>
-Obj DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
+template <typename UIntN>
+Obj DepthOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     Int         ebits;          /* number of bits in the exponent          */
 
@@ -125,8 +125,8 @@ Obj DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  ExponentOfPcElement( <self>, <pcgs>, <w>, <pos> )
 */
-template<typename UIntN>
-Obj ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
+template <typename UIntN>
+Obj ExponentOfPcElement(Obj self, Obj pcgs, Obj w, Obj pos)
 {
     UInt        expm;           /* signed exponent mask                    */
     UInt        exps;           /* sign exponent mask                      */
@@ -169,8 +169,8 @@ Obj ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
 **
 *F  LeadingExponentOfPcElement( <self>, <pcgs>, <w> )
 */
-template<typename UIntN>
-Obj LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
+template <typename UIntN>
+Obj LeadingExponentOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     UInt        expm;           /* signed exponent mask                    */
     UInt        exps;           /* sign exponent mask                      */
@@ -196,8 +196,8 @@ Obj LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  ExponentsOfPcElement( <self>, <pcgs>, <w> )
 */
-template<typename UIntN>
-Obj ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
+template <typename UIntN>
+Obj ExponentsOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     UInt	len;		/* length of pcgs */
     Obj		el;		/* exponents list */

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -73,42 +73,50 @@ extern "C" {
 
 
 #ifdef GAP_KERNEL_DEBUG
-template <typename T> static bool CHECK_PERM_TYPE(Obj perm);
+template <typename T>
+static bool CHECK_PERM_TYPE(Obj perm);
 
-template <> inline bool CHECK_PERM_TYPE<UInt2>(Obj perm)
+template <>
+inline bool CHECK_PERM_TYPE<UInt2>(Obj perm)
 {
     return TNUM_OBJ(perm) == T_PERM2;
 }
 
-template <> inline bool CHECK_PERM_TYPE<UInt4>(Obj perm)
+template <>
+inline bool CHECK_PERM_TYPE<UInt4>(Obj perm)
 {
     return TNUM_OBJ(perm) == T_PERM4;
 }
 #endif
 
-template<typename T> static inline UInt SIZEBAG_PERM(UInt deg)
+template <typename T>
+static inline UInt SIZEBAG_PERM(UInt deg)
 {
     return sizeof(Obj) + deg * sizeof(T);
 }
 
-template<typename T> static inline Obj NEW_PERM(UInt deg)
+template <typename T>
+static inline Obj NEW_PERM(UInt deg)
 {
     return NewBag(sizeof(T) == 2 ? T_PERM2 : T_PERM4, SIZEBAG_PERM<T>(deg));
 }
 
-template<typename T> static inline UInt DEG_PERM(Obj perm)
+template <typename T>
+static inline UInt DEG_PERM(Obj perm)
 {
     GAP_ASSERT(CHECK_PERM_TYPE<T>(perm));
     return (SIZE_OBJ(perm) - sizeof(Obj)) / sizeof(T);
 }
 
-template<typename T> static inline T * ADDR_PERM(Obj perm)
+template <typename T>
+static inline T * ADDR_PERM(Obj perm)
 {
     GAP_ASSERT(CHECK_PERM_TYPE<T>(perm));
     return (T *)(ADDR_OBJ(perm) + 1);
 }
 
-template<typename T> static inline const T * CONST_ADDR_PERM(Obj perm)
+template <typename T>
+static inline const T * CONST_ADDR_PERM(Obj perm)
 {
     GAP_ASSERT(CHECK_PERM_TYPE<T>(perm));
     return (const T *)(CONST_ADDR_OBJ(perm) + 1);
@@ -117,12 +125,18 @@ template<typename T> static inline const T * CONST_ADDR_PERM(Obj perm)
 //
 // The 'ResultType' template is used by functions which take two permutations
 // as argument to select the type of the output they produce: by default, a
-// T_PERM4, whose entries are stored as UInt4. But if both inputs are T_PERM2,
-// then as a special case the output is also a T_PERM2, whose entries are
-// stored as UInt2.
+// T_PERM4, whose entries are stored as UInt4. But if both inputs are
+// T_PERM2, then as a special case the output is also a T_PERM2, whose
+// entries are stored as UInt2.
 //
-template<typename TL, typename TR> struct ResultType { typedef UInt4 type; };
-template<> struct ResultType<UInt2, UInt2> { typedef UInt2 type; };
+template <typename TL, typename TR>
+struct ResultType {
+    typedef UInt4 type;
+};
+template <>
+struct ResultType<UInt2, UInt2> {
+    typedef UInt2 type;
+};
 
 /****************************************************************************
 **
@@ -182,7 +196,8 @@ static UInt1 * UseTmpPerm(UInt size)
     return (UInt1 *)(ADDR_OBJ(TmpPerm) + 1);
 }
 
-template<typename T> static inline T * ADDR_TMP_PERM()
+template <typename T>
+static inline T * ADDR_TMP_PERM()
 {
     // no GAP_ASSERT here on purpose
     return (T *)(ADDR_OBJ(TmpPerm) + 1);
@@ -227,8 +242,8 @@ Obj             TypePerm4 (
 **  This may in the worst case, for (1,2,..,n), take n^2/2 steps, but is fast
 **  enough to keep a terminal at 9600 baud busy for all but the extrem cases.
 */
-template<typename T> void            PrintPerm(
-    Obj                 perm )
+template <typename T>
+void PrintPerm(Obj perm)
 {
     UInt                degPerm;        /* degree of the permutation       */
     const T *           ptPerm;         /* pointer to the permutation      */
@@ -286,10 +301,8 @@ template<typename T> void            PrintPerm(
 **  same length, if  the  larger  permutation  fixes  the  exceeding  points.
 **
 */
-template<typename TL, typename TR>
-Int             EqPerm (
-    Obj                 opL,
-    Obj                 opR )
+template <typename TL, typename TR>
+Int EqPerm(Obj opL, Obj opR)
 {
     UInt                degL;           /* degree of the left operand      */
     const TL *          ptL;            /* pointer to the left operand     */
@@ -336,10 +349,8 @@ Int             EqPerm (
 **  the permutation  <opR>.  Permutations are  ordered lexicographically with
 **  respect to the images of 1,2,.., etc.
 */
-template<typename TL, typename TR>
-Int             LtPerm (
-    Obj                 opL,
-    Obj                 opR )
+template <typename TL, typename TR>
+Int LtPerm(Obj opL, Obj opR)
 {
     UInt                degL;           /* degree of the left operand      */
     const TL *          ptL;            /* pointer to the left operand     */
@@ -391,10 +402,8 @@ Int             LtPerm (
 **
 **  This is a little bit tuned but should be sufficiently easy to understand.
 */
-template<typename TL, typename TR>
-Obj             ProdPerm (
-    Obj                 opL,
-    Obj                 opR )
+template <typename TL, typename TR>
+Obj ProdPerm(Obj opL, Obj opR)
 {
     typedef typename ResultType<TL,TR>::type Res;
 
@@ -462,10 +471,8 @@ Obj QuoPerm(Obj opL, Obj opR)
 **
 **  This can be done as fast as a single multiplication or inversion.
 */
-template<typename TL, typename TR>
-Obj             LQuoPerm (
-    Obj                 opL,
-    Obj                 opR )
+template <typename TL, typename TR>
+Obj LQuoPerm(Obj opL, Obj opR)
 {
     typedef typename ResultType<TL,TR>::type Res;
 
@@ -514,9 +521,8 @@ Obj             LQuoPerm (
 **
 *F  InvPerm( <perm> ) . . . . . . . . . . . . . . .  inverse of a permutation
 */
-template<typename T>
-Obj InvPerm (
-    Obj             perm )
+template <typename T>
+Obj InvPerm(Obj perm)
 {
     Obj                 inv;            /* handle of the inverse (result)  */
     T *                 ptInv;          /* pointer to the inverse          */
@@ -555,10 +561,8 @@ Obj InvPerm (
 **  This repeatedly applies the permutation <opR> to all points  which  seems
 **  to be faster than binary powering, and does not need  temporary  storage.
 */
-template<typename T>
-Obj             PowPermInt (
-    Obj                 opL,
-    Obj                 opR )
+template <typename T>
+Obj PowPermInt(Obj opL, Obj opR)
 {
     Obj                 pow;            /* handle of the power (result)    */
     T *                 ptP;            /* pointer to the power            */
@@ -812,10 +816,8 @@ Obj             PowPermInt (
 **  permutation <opR>.  If <opL>  is larger than the  degree of <opR> it is a
 **  fixpoint of the permutation and thus simply returned.
 */
-template<typename T>
-Obj             PowIntPerm (
-    Obj                 opL,
-    Obj                 opR )
+template <typename T>
+Obj PowIntPerm(Obj opL, Obj opR)
 {
     Int                 img;            /* image (result)                  */
 
@@ -859,10 +861,8 @@ Obj             PowIntPerm (
 */
 static Obj PERM_INVERSE_THRESHOLD;
 
-template<typename T>
-Obj             QuoIntPerm (
-    Obj                 opL,
-    Obj                 opR )
+template <typename T>
+Obj QuoIntPerm(Obj opL, Obj opR)
 {
     T                   pre;            /* preimage (result)               */
     Int                 img;            /* image (left operand)            */
@@ -915,10 +915,8 @@ Obj             QuoIntPerm (
 **  <opR>, that s  defined as the  following product '<opR>\^-1 \*\ <opL> \*\
 **  <opR>'.
 */
-template<typename TL, typename TR>
-Obj             PowPerm (
-    Obj                 opL,
-    Obj                 opR )
+template <typename TL, typename TR>
+Obj PowPerm(Obj opL, Obj opR)
 {
     typedef typename ResultType<TL,TR>::type Res;
 
@@ -966,10 +964,8 @@ Obj             PowPerm (
 **  'CommPerm' returns the  commutator  of  the  two permutations  <opL>  and
 **  <opR>, that is defined as '<hd>\^-1 \*\ <opR>\^-1 \*\ <opL> \*\ <opR>'.
 */
-template<typename TL, typename TR>
-Obj             CommPerm (
-    Obj                 opL,
-    Obj                 opR )
+template <typename TL, typename TR>
+Obj CommPerm(Obj opL, Obj opR)
 {
     typedef typename ResultType<TL,TR>::type Res;
 
@@ -1066,7 +1062,8 @@ Obj IsPermHandler (
 **  'FuncPermList' simply copies the list pointwise into  a  permutation  bag.
 **  It also does some checks to make sure that the  list  is  a  permutation.
 */
-template <typename T> static inline Obj PermList(Obj list)
+template <typename T>
+static inline Obj PermList(Obj list)
 {
     Obj                 perm;           /* handle of the permutation       */
     T *                 ptPerm;         /* pointer to the permutation      */
@@ -1155,7 +1152,8 @@ Obj             FuncPermList (
 **
 **  This is easy, except that permutations may  contain  trailing  fixpoints.
 */
-template <typename T> static inline UInt LargestMovedPointPerm_(Obj perm)
+template <typename T>
+static inline UInt LargestMovedPointPerm_(Obj perm)
 {
     UInt      sup;
     const T * ptPerm;
@@ -1353,7 +1351,8 @@ Obj             FuncCYCLE_PERM_INT (
 **  'CycleStructPerm' returns a list of the form as described under
 **  `CycleStructure'.
 */
-template <typename T> static inline Obj CYCLE_STRUCT_PERM(Obj perm)
+template <typename T>
+static inline Obj CYCLE_STRUCT_PERM(Obj perm)
 {
     Obj                 list;           /* handle of the list (result)     */
     Obj *               ptList;         /* pointer to the list             */
@@ -1484,7 +1483,8 @@ Obj FuncCYCLE_STRUCT_PERM(Obj self, Obj perm)
 **  Since the largest element in S(65536) has oder greater than  10^382  this
 **  computation may easily overflow.  So we have to use  arbitrary precision.
 */
-template <typename T> static inline Obj ORDER_PERM(Obj perm)
+template <typename T>
+static inline Obj ORDER_PERM(Obj perm)
 {
     const T *           ptPerm;         /* pointer to the permutation      */
     Obj                 ord;            /* order (result), may be huge     */
@@ -1567,7 +1567,8 @@ Obj             FuncORDER_PERM (
 **  is a homomorphism from the symmetric group onto the multiplicative  group
 **  $\{ +1, -1 \}$, the kernel of which is the alternating group.
 */
-template <typename T> static inline Obj SIGN_PERM(Obj perm)
+template <typename T>
+static inline Obj SIGN_PERM(Obj perm)
 {
     const T *           ptPerm;         /* pointer to the permutation      */
     Int                 sign;           /* sign (result)                   */
@@ -1650,7 +1651,8 @@ Obj             FuncSIGN_PERM (
 **  respect  to the lexicographical order  defined  by '\<' the smallest such
 **  permutation.
 */
-template <typename T> static inline Obj SMALLEST_GENERATOR_PERM(Obj perm)
+template <typename T>
+static inline Obj SMALLEST_GENERATOR_PERM(Obj perm)
 {
     Obj                 small;          /* handle of the smallest gen      */
     T *                 ptSmall;        /* pointer to the smallest gen     */
@@ -1769,9 +1771,8 @@ Obj             FuncSMALLEST_GENERATOR_PERM (
 **  is set to `true' is is verified that <dom> is the union of cycles of
 **  <perm>.
 */
-template <typename T> static inline Obj RESTRICTED_PERM(Obj perm,
-    Obj                 dom,
-    Obj 		test)
+template <typename T>
+static inline Obj RESTRICTED_PERM(Obj perm, Obj dom, Obj test)
 {
     Obj rest;
     T *                ptRest;
@@ -1943,12 +1944,9 @@ Obj             FuncTRIM_PERM (
 **  many are moved).
 **  Ppoints and Qnum must be plain lists of small integers.
 */
-template <typename T> static inline Obj SPLIT_PARTITION(
-    Obj Ppoints,
-    Obj Qnum,
-    Obj jval,
-    Obj g,
-    Obj lst)
+template <typename T>
+static inline Obj
+SPLIT_PARTITION(Obj Ppoints, Obj Qnum, Obj jval, Obj g, Obj lst)
 {
   Int a;
   Int b;
@@ -2073,7 +2071,8 @@ Obj FuncDISTANCE_PERMS(Obj self, Obj opL, Obj opR)
 **  `SmallestImgTuplePerm' returns the smallest image of the  tuple  <tup>
 **  under  the permutation <perm>.
 */
-template <typename T> static inline Obj SMALLEST_IMG_TUP_PERM(Obj tup, Obj perm)
+template <typename T>
+static inline Obj SMALLEST_IMG_TUP_PERM(Obj tup, Obj perm)
 {
     UInt                res;            /* handle of the image, result     */
     const Obj *         ptTup;          /* pointer to the tuple            */
@@ -2127,7 +2126,8 @@ Obj             FuncSMALLEST_IMG_TUP_PERM (
 **  The input <tup> must be a non-empty and dense plain list. This is is not
 **  verified.
 */
-template <typename T> static inline Obj OnTuplesPerm_(Obj tup, Obj perm)
+template <typename T>
+static inline Obj OnTuplesPerm_(Obj tup, Obj perm)
 {
     Obj                 res;            /* handle of the image, result     */
     Obj *               ptRes;          /* pointer to the result           */
@@ -2203,7 +2203,8 @@ Obj             OnTuplesPerm (
 **  The input <set> must be a non-empty set, i.e., plain, dense and strictly
 **  sorted. This is is not verified.
 */
-template <typename T> static inline Obj OnSetsPerm_(Obj set, Obj perm)
+template <typename T>
+static inline Obj OnSetsPerm_(Obj set, Obj perm)
 {
     Obj                 res;            /* handle of the image, result     */
     Obj *               ptRes;          /* pointer to the result           */


### PR DESCRIPTION
This specifies how to format C++ templates.

Also reformat some of our code accordingly.