### PR TITLE
remove broken shifting of gasman stats for package mode

### DIFF
--- a/src/sysmem.c
+++ b/src/sysmem.c
@@ -142,9 +142,6 @@ void SyMsgsBags (
     }
     /* package (window) mode full garbage collection messages              */
     if ( phase != 0 ) {
-      shifted =   3 <= phase && nr >= (1 << 21);
-      if (shifted)
-        nr *= 1024;
       cmd[0] = '@';
       cmd[1] = ( full ? '0' : ' ' ) + phase;
       cmd[2] = '\0';
@@ -153,8 +150,6 @@ void SyMsgsBags (
         str[i++] = '0' + (nr % 10);
       str[i++] = '+';
       str[i++] = '\0';
-      if (shifted)
-        str[i++] = 'k';
       syWinPut( 1, cmd, str );
     }
 }


### PR DESCRIPTION
Gasman supplies information automatically to xgap.  The logic that is currently there appears to be trying to express the numbers in mb rather than kb if larger than 2048mb.  However, it actually gets it backwards and expresses them in bytes.  It also tries to append a 'k' after the closing null character.

This patch removes the shifting altogether.  I'd also be happy to edit to match the shifting done elsewhere more closely (and include the units correctly) if anyone would prefer.