### PR TITLE
Remove option to return values from break loop in many places

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -85,8 +85,8 @@
 #include "set.h"
 
 
-#define RequireBlistMayReplace(funcname, op, argname) \
-    RequireArgumentConditionMayReplace(funcname, op, argname, IsBlistConv(op), \
+#define RequireBlist(funcname, op, argname) \
+    RequireArgumentCondition(funcname, op, argname, IsBlistConv(op), \
         "must be a boolean list")
 
 /****************************************************************************
@@ -1043,7 +1043,7 @@ Obj FuncSIZE_BLIST (
     Obj                 self,
     Obj                 blist )
 {
-    RequireBlistMayReplace("SizeBlist", blist, "blist");
+    RequireBlist("SizeBlist", blist, "blist");
     return INTOBJ_INT(SizeBlist(blist));
 }
 
@@ -1074,8 +1074,8 @@ Obj FuncBLIST_LIST (
     Obj                 sub )
 {
     /* get and check the arguments                                         */
-    RequireSmallListMayReplace("BlistList", list);
-    RequireSmallListMayReplace("BlistList", sub);
+    RequireSmallList("BlistList", list);
+    RequireSmallList("BlistList", sub);
 
     Int lenList = LEN_LIST( list );
     Obj blist = NewBag( T_BLIST, SIZE_PLEN_BLIST( lenList ) );
@@ -1114,9 +1114,9 @@ Obj FuncLIST_BLIST (
     UInt                i;              /* loop variable                   */
 
     /* get and check the first argument                                    */
-    RequireSmallListMayReplace("ListBlist", list);
+    RequireSmallList("ListBlist", list);
     /* get and check the second argument                                   */
-    RequireBlistMayReplace("ListBlist", blist, "blist");
+    RequireBlist("ListBlist", blist, "blist");
     while ( LEN_LIST( list ) != LEN_BLIST( blist ) ) {
         blist = ErrorReturnObj(
             "ListBlist: <blist> must have the same length as <list> (%d)",
@@ -1166,8 +1166,8 @@ Obj FuncPositionNthTrueBlist (
     const UInt *        ptr;
 
     /* Check the arguments. */    
-    RequireBlistMayReplace("ListBlist", blist, "blist");
-    RequirePositiveSmallIntMayReplace("Position", Nth, "nth");
+    RequireBlist("ListBlist", blist, "blist");
+    RequirePositiveSmallInt("Position", Nth, "nth");
     
     nrb = NUMBER_BLOCKS_BLIST(blist);
     if ( ! nrb )  return Fail;
@@ -1216,8 +1216,8 @@ Obj FuncIS_SUB_BLIST (
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlistMayReplace("IsSubsetBlist", list1, "blist1");
-    RequireBlistMayReplace("IsSubsetBlist", list2, "blist2");
+    RequireBlist("IsSubsetBlist", list1, "blist1");
+    RequireBlist("IsSubsetBlist", list2, "blist2");
     while ( LEN_BLIST(list1) != LEN_BLIST(list2) ) {
         list2 = ErrorReturnObj(
         "IsSubsetBlist: <blist2> must have the same length as <blist1> (%d)",
@@ -1262,8 +1262,8 @@ Obj FuncUNITE_BLIST (
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlistMayReplace("UniteBlist", list1, "blist1");
-    RequireBlistMayReplace("UniteBlist", list2, "blist2");
+    RequireBlist("UniteBlist", list1, "blist1");
+    RequireBlist("UniteBlist", list2, "blist2");
     while ( LEN_BLIST(list1) != LEN_BLIST(list2) ) {
         list2 = ErrorReturnObj(
            "UniteBlist: <blist2> must have the same length as <blist1> (%d)",
@@ -1310,11 +1310,11 @@ Obj FuncUNITE_BLIST_LIST (
     long                s, t;           /* elements of a range             */
 
     /* get and check the arguments                                         */
-    RequireSmallListMayReplace("UniteBlistList", list);
+    RequireSmallList("UniteBlistList", list);
 
     lenList  = LEN_LIST( list );
 
-    RequireBlistMayReplace("UniteBlistList", blist, "blist");
+    RequireBlist("UniteBlistList", blist, "blist");
     while ( LEN_BLIST(blist) != lenList ) {
         blist = ErrorReturnObj(
           "UniteBlistList: <blist> must have the same length as <list> (%d)",
@@ -1322,7 +1322,7 @@ Obj FuncUNITE_BLIST_LIST (
             "you can replace <blist> via 'return <blist>;'" );
     }
 
-    RequireSmallListMayReplace("UniteBlistList", sub);
+    RequireSmallList("UniteBlistList", sub);
 
     lenSub   = LEN_LIST( sub );
 
@@ -1529,8 +1529,8 @@ Obj FuncINTER_BLIST (
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlistMayReplace("IntersectBlist", list1, "blist1");
-    RequireBlistMayReplace("IntersectBlist", list2, "blist2");
+    RequireBlist("IntersectBlist", list1, "blist1");
+    RequireBlist("IntersectBlist", list2, "blist2");
     while ( LEN_BLIST(list1) != LEN_BLIST(list2) ) {
         list2 = ErrorReturnObj(
        "IntersectBlist: <blist2> must have the same length as <blist1> (%d)",
@@ -1572,8 +1572,8 @@ Obj FuncSUBTR_BLIST (
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlistMayReplace("SubtractBlist", list1, "blist1");
-    RequireBlistMayReplace("SubtractBlist", list2, "blist2");
+    RequireBlist("SubtractBlist", list1, "blist1");
+    RequireBlist("SubtractBlist", list2, "blist2");
     while ( LEN_BLIST(list1) != LEN_BLIST(list2) ) {
         list2 = ErrorReturnObj(
         "SubtractBlist: <blist2> must have the same length as <blist1> (%d)",
@@ -1617,8 +1617,8 @@ Obj FuncMEET_BLIST (
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlistMayReplace("MeetBlist", list1, "blist1");
-    RequireBlistMayReplace("MeetBlist", list2, "blist2");
+    RequireBlist("MeetBlist", list1, "blist1");
+    RequireBlist("MeetBlist", list2, "blist2");
     while ( LEN_BLIST(list1) != LEN_BLIST(list2) ) {
         list2 = ErrorReturnObj(
         "MeetBlist: <blist2> must have the same length as <blist1> (%d)",

--- a/src/calls.c
+++ b/src/calls.c
@@ -1372,7 +1372,7 @@ Obj FuncSET_NAME_FUNC(
                       Obj func,
                       Obj name )
 {
-    RequireStringRepMayReplace("SET_NAME_FUNC", name);
+    RequireStringRep("SET_NAME_FUNC", name);
 
   if (TNUM_OBJ(func) == T_FUNCTION ) {
     SET_NAME_FUNC(func, ImmutableString(name));

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -1544,7 +1544,7 @@ Obj FuncE (
     }
 
     /* get and check the argument                                          */
-    RequirePositiveSmallIntMayReplace("E", n, "n");
+    RequirePositiveSmallInt("E", n, "n");
 
     /* for $e_1$ return 1 and for $e_2$ return -1                          */
     if ( n == INTOBJ_INT(1) )

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -833,7 +833,7 @@ Obj             EvalPermExpr (
 
             /* get and check current entry for the cycle                   */
             val = EVAL_EXPR(READ_EXPR(cycle, j - 1));
-            RequirePositiveSmallIntMayReplace("Permutation", val, "expr");
+            RequirePositiveSmallInt("Permutation", val, "expr");
             c = INT_INTOBJ(val);
             if (c > MAX_DEG_PERM4)
               ErrorMayQuit( "Permutation literal exceeds maximum permutation degree",
@@ -1086,7 +1086,7 @@ Obj             EvalRangeExpr (
 
     /* evaluate the low value                                              */
     val = EVAL_EXPR(READ_EXPR(expr, 0));
-    RequireSmallIntMayReplace("Range", val, "first");
+    RequireSmallInt("Range", val, "first");
     low = INT_INTOBJ( val );
 
     /* evaluate the second value (if present)                              */

--- a/src/gap.c
+++ b/src/gap.c
@@ -892,7 +892,7 @@ Obj FuncGASMAN (
         /* evaluate and check the command                                  */
         Obj cmd = ELM_PLIST( args, i );
 again:
-        RequireStringRepMayReplace("GASMAN", cmd);
+        RequireStringRep("GASMAN", cmd);
 
         // perform full garbage collection
         if ( strcmp( CONST_CSTR_STRING(cmd), "collect" ) == 0 ) {
@@ -1190,7 +1190,7 @@ Obj FuncFUNC_BODY_SIZE(Obj self, Obj f)
 
 Obj FuncSleep( Obj self, Obj secs )
 {
-    RequireSmallIntMayReplace("Sleep", secs, "secs");
+    RequireSmallInt("Sleep", secs, "secs");
 
     Int s = INT_INTOBJ(secs);
     if (s > 0)
@@ -1215,7 +1215,7 @@ Obj FuncSleep( Obj self, Obj secs )
 
 Obj FuncMicroSleep( Obj self, Obj msecs )
 {
-    RequireSmallIntMayReplace("MicroSleep", msecs, "usecs");
+    RequireSmallInt("MicroSleep", msecs, "usecs");
 
     Int s = INT_INTOBJ(msecs);
 

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -741,7 +741,7 @@ Obj FuncMakeReadOnlyGVar (
     Obj                 name )
 {       
     // check the argument
-    RequireStringRepMayReplace("MakeReadOnlyGVar", name);
+    RequireStringRep("MakeReadOnlyGVar", name);
 
     /* get the variable and make it read only                              */
     MakeReadOnlyGVar(GVarName(CONST_CSTR_STRING(name)));
@@ -764,7 +764,7 @@ Obj FuncMakeReadOnlyGVar (
 Obj FuncMakeConstantGVar(Obj self, Obj name)
 {
     // check the argument
-    RequireStringRepMayReplace("MakeConstantGVar", name);
+    RequireStringRep("MakeConstantGVar", name);
 
     /* get the variable and make it read only                              */
     MakeConstantGVar(GVarName(CONST_CSTR_STRING(name)));
@@ -804,7 +804,7 @@ Obj FuncMakeReadWriteGVar (
     Obj                 name )
 {
     // check the argument
-    RequireStringRepMayReplace("MakeReadWriteGVar", name);
+    RequireStringRep("MakeReadWriteGVar", name);
 
     /* get the variable and make it read write                             */
     MakeReadWriteGVar(GVarName(CONST_CSTR_STRING(name)));
@@ -834,7 +834,7 @@ static Obj FuncIsReadOnlyGVar (
     Obj                 name )
 {
     // check the argument
-    RequireStringRepMayReplace("IsReadOnlyGVar", name);
+    RequireStringRep("IsReadOnlyGVar", name);
 
     /* get the answer                             */
     return IsReadOnlyGVar(GVarName(CONST_CSTR_STRING(name))) ? True : False;
@@ -858,7 +858,7 @@ Int IsConstantGVar(UInt gvar)
 static Obj FuncIsConstantGVar(Obj self, Obj name)
 {
     // check the argument
-    RequireStringRepMayReplace("IsConstantGVar", name);
+    RequireStringRep("IsConstantGVar", name);
 
     /* get the answer                             */
     return IsConstantGVar(GVarName(CONST_CSTR_STRING(name))) ? True : False;
@@ -901,7 +901,7 @@ Obj             FuncAUTO (
 
     /* get and check the function                                          */
     func = ELM_LIST( args, 1 );
-    RequireFunctionMayReplace("AUTO", func);
+    RequireFunction("AUTO", func);
 
     /* get the argument                                                    */
     arg = ELM_LIST( args, 2 );
@@ -915,7 +915,7 @@ Obj             FuncAUTO (
     /* make the global variables automatic                                 */
     for ( i = 3; i <= LEN_LIST(args); i++ ) {
         name = ELM_LIST( args, i );
-        RequireStringRepMayReplace("AUTO", name);
+        RequireStringRep("AUTO", name);
         gvar = GVarName( CONST_CSTR_STRING(name) );
         SET_ELM_GVAR_LIST( ValGVars, gvar, 0 );
         SET_ELM_GVAR_LIST( ExprGVars, gvar, list );
@@ -1058,7 +1058,7 @@ Obj FuncASS_GVAR (
     Obj                 val )
 {
     // check the argument
-    RequireStringRepMayReplace("READ", gvar);
+    RequireStringRep("READ", gvar);
 
     AssGVar( GVarName( CONST_CSTR_STRING(gvar) ), val );
     return 0L;
@@ -1074,7 +1074,7 @@ Obj FuncISB_GVAR (
     Obj                 gvar )
 {
     // check the argument
-    RequireStringRepMayReplace("ISB_GVAR", gvar);
+    RequireStringRep("ISB_GVAR", gvar);
 
     UInt gv = GVarName( CONST_CSTR_STRING(gvar) );
     if (VAL_GVAR_INTERN(gv))
@@ -1103,7 +1103,7 @@ Obj FuncVAL_GVAR (
 {
   Obj val;
     // check the argument
-    RequireStringRepMayReplace("VAL_GVAR", gvar);
+    RequireStringRep("VAL_GVAR", gvar);
 
     /* get the value */
     val = ValAutoGVar( GVarName( CONST_CSTR_STRING(gvar) ) );
@@ -1125,7 +1125,7 @@ Obj FuncUNB_GVAR (
     Obj                 gvar )
 {
     // check the argument
-    RequireStringRepMayReplace("UNB_GVAR", gvar);
+    RequireStringRep("UNB_GVAR", gvar);
 
     /*  */
     AssGVar( GVarName( CONST_CSTR_STRING(gvar) ), (Obj)0 );

--- a/src/integer.c
+++ b/src/integer.c
@@ -2647,7 +2647,7 @@ Obj FuncRandomIntegerMT(Obj self, Obj mtstr, Obj nrbits)
   Int i, n, q, r, qoff, len;
   UInt4 *mt;
   UInt4 *pt;
-  RequireStringRepMayReplace("RandomIntegerMT", mtstr);
+  RequireStringRep("RandomIntegerMT", mtstr);
   while ((! IsStringConv(mtstr)) || GET_LEN_STRING(mtstr) < 2500) {
      mtstr = ErrorReturnObj(
          "RandomIntegerMT: <mtstr> must be a string with at least 2500 characters",

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -92,7 +92,7 @@ Obj FuncInitRandomMT( Obj self, Obj initstr)
   UInt4 *mt, key_length, byte_key_length, i, j, k, N = 624;
 
   /* check the seed, given as string */
-  RequireStringRepMayReplace("InitRandomMT", initstr);
+  RequireStringRep("InitRandomMT", initstr);
 
   /* store array of 624 UInt4 and one UInt4 as counter "mti" and an
      endianness marker */
@@ -448,12 +448,12 @@ Obj FuncHASHKEY_BAG(Obj self, Obj obj, Obj opSeed, Obj opOffset, Obj opMaxLen)
   }
 
   /* check the arguments                                                 */
-  RequireSmallIntMayReplace("HASHKEY_BAG", opSeed, "seed");
+  RequireSmallInt("HASHKEY_BAG", opSeed, "seed");
   
   do {
     offs = -1;
 
-    RequireSmallIntMayReplace("HASHKEY_BAG", opOffset, "offset");
+    RequireSmallInt("HASHKEY_BAG", opOffset, "offset");
     offs = INT_INTOBJ(opOffset);
     if ( offs < 0 || offs > SIZE_OBJ(obj)) {
       opOffset = ErrorReturnObj(
@@ -464,7 +464,7 @@ Obj FuncHASHKEY_BAG(Obj self, Obj obj, Obj opSeed, Obj opOffset, Obj opMaxLen)
     }
   } while (offs < 0);
 
-  RequireSmallIntMayReplace("HASHKEY_BAG", opMaxLen, "maxlen");
+  RequireSmallInt("HASHKEY_BAG", opMaxLen, "maxlen");
 
   n=SIZE_OBJ(obj)-offs;
 

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -293,7 +293,7 @@ Obj             FuncAPPEND_LIST_INTR (
 
     /* check the type of the first argument                                */
     if ( TNUM_OBJ( list1 ) != T_PLIST ) {
-        RequireSmallListMayReplace("AppendList", list1);
+        RequireSmallList("AppendList", list1);
         if ( ! IS_PLIST( list1 ) ) {
             PLAIN_LIST( list1 );
         }
@@ -303,7 +303,7 @@ Obj             FuncAPPEND_LIST_INTR (
 
     /* check the type of the second argument                               */
     if ( ! IS_PLIST( list2 ) ) {
-        RequireSmallListMayReplace("AppendList", list2);
+        RequireSmallList("AppendList", list2);
         len2 = LEN_LIST( list2 );
     }
     else {
@@ -423,7 +423,7 @@ Obj             FuncPOSITION_SORTED_LIST (
     UInt                h;              /* position, result                */
 
     /* check the first argument                                            */
-    RequireSmallListMayReplace("POSITION_SORTED_LIST", list);
+    RequireSmallList("POSITION_SORTED_LIST", list);
     /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) ) {
         h = PositionSortedDensePlist( list, obj );
@@ -508,10 +508,10 @@ Obj             FuncPOSITION_SORTED_LIST_COMP (
     UInt                h;              /* position, result                */
 
     /* check the first argument                                            */
-    RequireSmallListMayReplace("POSITION_SORTED_LIST_COMP", list);
+    RequireSmallList("POSITION_SORTED_LIST_COMP", list);
 
     /* check the third argument                                            */
-    RequireFunctionMayReplace("POSITION_SORTED_LIST_COMP", func);
+    RequireFunction("POSITION_SORTED_LIST_COMP", func);
 
     /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) ) {
@@ -1152,7 +1152,7 @@ Obj             FuncOnTuples (
     UInt                i;              /* loop variable                   */
 
     /* check the type of the first argument                                */
-    RequireSmallListMayReplace("OnTuples", tuple);
+    RequireSmallList("OnTuples", tuple);
 
     /* special case for the empty list */
     if (LEN_LIST(tuple) == 0) {

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -308,7 +308,7 @@ Obj FuncMACFLOAT_INT( Obj self, Obj i )
 
 Obj FuncMACFLOAT_STRING( Obj self, Obj s )
 {
-    RequireStringRepMayReplace("MACFLOAT_STRING", s);
+    RequireStringRep("MACFLOAT_STRING", s);
 
   char * endptr;
   UChar *sp = CHARS_STRING(s);

--- a/src/modules.c
+++ b/src/modules.c
@@ -125,7 +125,7 @@ static void RegisterModuleState(StructInitInfo * info)
 Obj FuncGAP_CRC(Obj self, Obj filename)
 {
     /* check the argument                                                  */
-    RequireStringRepMayReplace("GAP_CRC", filename);
+    RequireStringRep("GAP_CRC", filename);
 
     /* compute the crc value                                               */
     return INTOBJ_INT(SyGAPCRC(CONST_CSTR_STRING(filename)));
@@ -213,7 +213,7 @@ Obj FuncLOAD_DYN(Obj self, Obj filename, Obj crc)
     InitInfoFunc     init;
 
     /* check the argument                                                  */
-    RequireStringRepMayReplace("LOAD_DYN", filename);
+    RequireStringRep("LOAD_DYN", filename);
     while (!IS_INTOBJ(crc) && crc != False) {
         crc = ErrorReturnObj(
             "LOAD_DYN: <crc> must be a small integer or 'false' (not a %s)",
@@ -290,7 +290,7 @@ Obj FuncLOAD_STAT(Obj self, Obj filename, Obj crc)
     Int              k;
 
     /* check the argument                                                  */
-    RequireStringRepMayReplace("LOAD_STAT", filename);
+    RequireStringRep("LOAD_STAT", filename);
     while (!IS_INTOBJ(crc) && crc != False) {
         crc = ErrorReturnObj(
             "LOAD_STAT: <crc> must be a small integer or 'false' (not a %s)",

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -2364,7 +2364,7 @@ Obj Array2Perm (
     /* loop over the cycles                                                */
     for ( i = 1; i <= LEN_LIST(array); i++ ) {
         cycle = ELM_LIST( array, i );
-        RequireSmallListMayReplace("Array2Perm", cycle);
+        RequireSmallList("Array2Perm", cycle);
 
         /* loop over the entries of the cycle                              */
         c = p = l = 0;
@@ -2372,7 +2372,7 @@ Obj Array2Perm (
 
             /* get and check current entry for the cycle                   */
             val = ELM_LIST( cycle, j );
-            RequirePositiveSmallIntMayReplace("Permutation", val, "expr");
+            RequirePositiveSmallInt("Permutation", val, "expr");
             c = INT_INTOBJ(val);
             if (c > MAX_DEG_PERM4)
               ErrorMayQuit( "Permutation literal exceeds maximum permutation degree",

--- a/src/plist.c
+++ b/src/plist.c
@@ -2556,7 +2556,7 @@ Obj FuncASS_PLIST_DEFAULT (
     Int                 p;
 
     /* check the arguments                                                 */
-    RequirePositiveSmallIntMayReplace("List Assignment", pos, "pos");
+    RequirePositiveSmallInt("List Assignment", pos, "pos");
     p = INT_INTOBJ(pos);
     while ( ! IS_PLIST(plist) || ! IS_PLIST_MUTABLE(plist) ) {
         plist = ErrorReturnObj(

--- a/src/set.c
+++ b/src/set.c
@@ -199,7 +199,7 @@ Obj FuncLIST_SORTED_LIST (
     Obj                 set;            /* result                          */
 
     /* check the argument                                                  */
-    RequireSmallListMayReplace("Set", list);
+    RequireSmallList("Set", list);
 
     /* if the list is empty create a new empty list                        */
     if ( LEN_LIST(list) == 0 ) {
@@ -270,9 +270,9 @@ Obj             FuncIS_EQUAL_SET (
     Obj                 list2 )
 {
     /* check the arguments, convert to sets if necessary                   */
-    RequireSmallListMayReplace("IsEqualSet", list1);
+    RequireSmallList("IsEqualSet", list1);
     if ( ! IsSet( list1 ) )  list1 = SetList( list1 );
-    RequireSmallListMayReplace("IsEqualSet", list2);
+    RequireSmallList("IsEqualSet", list2);
     if ( ! IsSet( list2 ) )  list2 = SetList( list2 );
 
     /* and now compare them                                                */
@@ -307,8 +307,8 @@ Obj             FuncIS_SUBSET_SET (
     UInt                pos;            /* position                        */
 
     /* check the arguments, convert to sets if necessary                   */
-    RequireSmallListMayReplace("IsSubsetSet", set1);
-    RequireSmallListMayReplace("IsSubsetSet", set2);
+    RequireSmallList("IsSubsetSet", set1);
+    RequireSmallList("IsSubsetSet", set2);
     if ( ! IsSet( set1 ) )  set1 = SetList( set1 );
     if ( ! IsSet( set2 ) )  set2 = SetList( set2 );
 
@@ -606,7 +606,7 @@ Obj FuncUNITE_SET (
             (Int)TNAM_OBJ(set1), 0L,
             "you can replace <set1> via 'return <set1>;'" );
     }
-    RequireSmallListMayReplace("UniteSet", set2);
+    RequireSmallList("UniteSet", set2);
     if ( ! IsSet(set2) )  set2 = SetList(set2);
 
     /* get the logical lengths and the pointer                             */
@@ -779,7 +779,7 @@ Obj FuncINTER_SET (
             (Int)TNAM_OBJ(set1), 0L,
             "you can replace <set1> via 'return <set1>;'" );
     }
-    RequireSmallListMayReplace("IntersectSet", set2);
+    RequireSmallList("IntersectSet", set2);
     if ( ! IsSet(set2) )  set2 = SetList(set2);
 
     /* get the logical lengths and the pointer                             */
@@ -952,7 +952,7 @@ Obj FuncSUBTR_SET (
             (Int)TNAM_OBJ(set1), 0L,
             "you can replace <set1> via 'return <set1>;'" );
     }
-    RequireSmallListMayReplace("SubtractSet", set2);
+    RequireSmallList("SubtractSet", set2);
     if ( ! IsSet(set2) )  set2 = SetList(set2);
 
     /* get the logical lengths and the pointer                             */

--- a/src/stats.c
+++ b/src/stats.c
@@ -512,10 +512,10 @@ static ALWAYS_INLINE UInt ExecForRangeHelper(Stat stat, UInt nr)
     /* evaluate the range                                                  */
     VisitStatIfHooked(READ_STAT(stat, 1));
     elm = EVAL_EXPR(READ_EXPR(READ_STAT(stat, 1), 0));
-    RequireSmallIntMayReplace("Range", elm, "first");
+    RequireSmallInt("Range", elm, "first");
     first = INT_INTOBJ(elm);
     elm = EVAL_EXPR(READ_EXPR(READ_STAT(stat, 1), 1));
-    RequireSmallIntMayReplace("Range", elm, "last");
+    RequireSmallInt("Range", elm, "last");
     last  = INT_INTOBJ(elm);
 
     /* get the body                                                        */

--- a/src/streams.c
+++ b/src/streams.c
@@ -561,7 +561,7 @@ Obj FuncLOG_TO (
     Obj                 self,
     Obj                 filename )
 {
-    RequireStringRepMayReplace("LogTo", filename);
+    RequireStringRep("LogTo", filename);
     if ( ! OpenLog( CONST_CSTR_STRING(filename) ) ) {
         ErrorReturnVoid( "LogTo: cannot log to %g",
                          (Int)filename, 0L,
@@ -628,7 +628,7 @@ Obj FuncINPUT_LOG_TO (
     Obj                 self,
     Obj                 filename )
 {
-    RequireStringRepMayReplace("InputLogTo", filename);
+    RequireStringRep("InputLogTo", filename);
     if ( ! OpenInputLog( CONST_CSTR_STRING(filename) ) ) {
         ErrorReturnVoid( "InputLogTo: cannot log to %g",
                          (Int)filename, 0L,
@@ -695,7 +695,7 @@ Obj FuncOUTPUT_LOG_TO (
     Obj                 self,
     Obj                 filename )
 {
-    RequireStringRepMayReplace("OutputLogTo", filename);
+    RequireStringRep("OutputLogTo", filename);
     if ( ! OpenOutputLog( CONST_CSTR_STRING(filename) ) ) {
         ErrorReturnVoid( "OutputLogTo: cannot log to %g",
                          (Int)filename, 0L,
@@ -775,7 +775,7 @@ static Obj PRINT_OR_APPEND_TO(Obj args, int append)
 
     /* first entry is the filename                                         */
     filename = ELM_LIST(args,1);
-    RequireStringRepMayReplace(funcname, filename);
+    RequireStringRep(funcname, filename);
 
     /* try to open the file for output                                     */
     i = append ? OpenAppend( CONST_CSTR_STRING(filename) )
@@ -955,7 +955,7 @@ Obj FuncREAD (
     Obj                 filename )
 {
    /* check the argument                                                  */
-    RequireStringRepMayReplace("READ", filename);
+    RequireStringRep("READ", filename);
 
     /* try to open the file                                                */
     if ( ! OpenInput( CONST_CSTR_STRING(filename) ) ) {
@@ -1080,7 +1080,7 @@ Obj FuncREAD_AS_FUNC (
     Obj                 filename )
 {
     // check the argument
-    RequireStringRepMayReplace("READ_AS_FUNC", filename);
+    RequireStringRep("READ_AS_FUNC", filename);
 
     /* try to open the file                                                */
     if ( ! OpenInput( CONST_CSTR_STRING(filename) ) ) {
@@ -1125,7 +1125,7 @@ Obj FuncREAD_GAP_ROOT (
     Char filenamecpy[GAP_PATH_MAX];
 
     // check the argument
-    RequireStringRepMayReplace("READ", filename);
+    RequireStringRep("READ", filename);
 
     /* Copy to avoid garbage collection moving string                      */
     strlcpy(filenamecpy, CONST_CSTR_STRING(filename), GAP_PATH_MAX);
@@ -1179,7 +1179,7 @@ Obj FuncRemoveFile (
     Obj             filename )
 {
     // check the argument
-    RequireStringRepMayReplace("RemoveFile", filename);
+    RequireStringRep("RemoveFile", filename);
     
     /* call the system dependent function                                  */
     return SyRemoveFile( CONST_CSTR_STRING(filename) ) == -1 ? Fail : True;
@@ -1194,7 +1194,7 @@ Obj FuncCreateDir (
     Obj             filename )
 {
     // check the argument
-    RequireStringRepMayReplace("CreateDir", filename);
+    RequireStringRep("CreateDir", filename);
     
     /* call the system dependent function                                  */
     return SyMkdir( CONST_CSTR_STRING(filename) ) == -1 ? Fail : True;
@@ -1209,7 +1209,7 @@ Obj FuncRemoveDir (
     Obj             filename )
 {
     // check the argument
-    RequireStringRepMayReplace("RemoveDir", filename);
+    RequireStringRep("RemoveDir", filename);
     
     /* call the system dependent function                                  */
     return SyRmdir( CONST_CSTR_STRING(filename) ) == -1 ? Fail : True;
@@ -1223,7 +1223,7 @@ Obj FuncIsDir (
     Obj             self,
     Obj             filename )
 {
-    RequireStringRepMayReplace("IsDir", filename);
+    RequireStringRep("IsDir", filename);
 
     /* call the system dependent function                                  */
     return SyIsDir( CONST_CSTR_STRING(filename) );
@@ -1284,7 +1284,7 @@ Obj FuncIsExistingFile (
     Int             res;
 
     // check the argument
-    RequireStringRepMayReplace("IsExistingFile", filename);
+    RequireStringRep("IsExistingFile", filename);
     
     /* call the system dependent function                                  */
     res = SyIsExistingFile( CONST_CSTR_STRING(filename) );
@@ -1303,7 +1303,7 @@ Obj FuncIsReadableFile (
     Int             res;
 
     // check the argument
-    RequireStringRepMayReplace("IsReadableFile", filename);
+    RequireStringRep("IsReadableFile", filename);
     
     /* call the system dependent function                                  */
     res = SyIsReadableFile( CONST_CSTR_STRING(filename) );
@@ -1322,7 +1322,7 @@ Obj FuncIsWritableFile (
     Int             res;
 
     // check the argument
-    RequireStringRepMayReplace("IsWritableFile", filename);
+    RequireStringRep("IsWritableFile", filename);
     
     /* call the system dependent function                                  */
     res = SyIsWritableFile( CONST_CSTR_STRING(filename) );
@@ -1341,7 +1341,7 @@ Obj FuncIsExecutableFile (
     Int             res;
 
     // check the argument
-    RequireStringRepMayReplace("IsExecutableFile", filename);
+    RequireStringRep("IsExecutableFile", filename);
     
     /* call the system dependent function                                  */
     res = SyIsExecutableFile( CONST_CSTR_STRING(filename) );
@@ -1360,7 +1360,7 @@ Obj FuncIsDirectoryPathString (
     Int             res;
 
     // check the argument
-    RequireStringRepMayReplace("IsDirectoryPathString", filename);
+    RequireStringRep("IsDirectoryPathString", filename);
     
     /* call the system dependent function                                  */
     res = SyIsDirectoryPath( CONST_CSTR_STRING(filename) );
@@ -1390,7 +1390,7 @@ Obj FuncSTRING_LIST_DIR (
     Int len, sl;
 
     // check the argument
-    RequireStringRepMayReplace("STRING_LIST_DIR", dirname);
+    RequireStringRep("STRING_LIST_DIR", dirname);
     
     SyClearErrorNo();
     dir = opendir(CONST_CSTR_STRING(dirname));
@@ -1431,7 +1431,7 @@ Obj FuncCLOSE_FILE (
     Int             ret;
 
     // check the argument
-    RequireSmallIntMayReplace("CLOSE_FILE", fid, "fid");
+    RequireSmallInt("CLOSE_FILE", fid, "fid");
     
     /* call the system dependent function                                  */
     ret = SyFclose( INT_INTOBJ(fid) );
@@ -1450,7 +1450,7 @@ Obj FuncINPUT_TEXT_FILE (
     Int             fid;
 
     // check the argument
-    RequireStringRepMayReplace("INPUT_TEXT_FILE", filename);
+    RequireStringRep("INPUT_TEXT_FILE", filename);
     
     /* call the system dependent function                                  */
     SyClearErrorNo();
@@ -1472,7 +1472,7 @@ Obj FuncIS_END_OF_FILE (
     Int             ret;
 
     // check the argument
-    RequireSmallIntMayReplace("IS_END_OF_FILE", fid, "fid");
+    RequireSmallInt("IS_END_OF_FILE", fid, "fid");
     
     ret = SyIsEndOfFile( INT_INTOBJ(fid) );
     return ret == -1 ? Fail : ( ret == 0 ? False : True );
@@ -1491,7 +1491,7 @@ Obj FuncOUTPUT_TEXT_FILE (
     Int             fid;
 
     // check the argument
-    RequireStringRepMayReplace("OUTPUT_TEXT_FILE", filename);
+    RequireStringRep("OUTPUT_TEXT_FILE", filename);
     while ( append != True && append != False ) {
         filename = ErrorReturnObj(
             "OUTPUT_TEXT_FILE: <append> must be a boolean (not a %s)",
@@ -1522,7 +1522,7 @@ Obj FuncPOSITION_FILE (
     Obj             fid )
 {
     // check the argument
-    RequireSmallIntMayReplace("POSITION_FILE", fid, "fid");
+    RequireSmallInt("POSITION_FILE", fid, "fid");
 
     Int ifid = INT_INTOBJ(fid);
     Int ret = SyFtell(ifid);
@@ -1548,7 +1548,7 @@ Obj FuncREAD_BYTE_FILE (
     Int             ret;
 
     // check the argument
-    RequireSmallIntMayReplace("READ_BYTE_FILE", fid, "fid");
+    RequireSmallInt("READ_BYTE_FILE", fid, "fid");
     
     /* call the system dependent function                                  */
     ret = SyGetch( INT_INTOBJ(fid) );
@@ -1574,7 +1574,7 @@ Obj FuncREAD_LINE_FILE (
     Obj             str;
 
     // check the argument
-    RequireSmallIntMayReplace("READ_LINE_FILE", fid, "fid");
+    RequireSmallInt("READ_LINE_FILE", fid, "fid");
     ifid = INT_INTOBJ(fid);
 
     /* read <fid> until we see a newline or eof or we've read at least
@@ -1628,10 +1628,10 @@ Obj FuncREAD_ALL_FILE (
     UInt            csize;
 
     // check the argument
-    RequireSmallIntMayReplace("READ_ALL_FILE", fid, "fid");
+    RequireSmallInt("READ_ALL_FILE", fid, "fid");
     ifid = INT_INTOBJ(fid);
 
-    RequireSmallIntMayReplace("READ_ALL_FILE", limit, "limit");
+    RequireSmallInt("READ_ALL_FILE", limit, "limit");
     ilim = INT_INTOBJ(limit);
 
     /* read <fid> until we see  eof or we've read at least
@@ -1717,8 +1717,8 @@ Obj FuncSEEK_POSITION_FILE (
     Int             ret;
 
     // check the argument
-    RequireSmallIntMayReplace("SEEK_POSITION_FILE", fid, "fid");
-    RequireSmallIntMayReplace("SEEK_POSITION_FILE", pos, "pos");
+    RequireSmallInt("SEEK_POSITION_FILE", fid, "fid");
+    RequireSmallInt("SEEK_POSITION_FILE", pos, "pos");
     
     ret = SyFseek( INT_INTOBJ(fid), INT_INTOBJ(pos) );
     return ret == -1 ? Fail : True;
@@ -1737,8 +1737,8 @@ Obj FuncWRITE_BYTE_FILE (
     Int             ret;
 
     // check the argument
-    RequireSmallIntMayReplace("WRITE_BYTE_FILE", fid, "fid");
-    RequireSmallIntMayReplace("WRITE_BYTE_FILE", ch, "ch");
+    RequireSmallInt("WRITE_BYTE_FILE", fid, "fid");
+    RequireSmallInt("WRITE_BYTE_FILE", ch, "ch");
     
     /* call the system dependent function                                  */
     ret = SyEchoch( INT_INTOBJ(ch), INT_INTOBJ(fid) );
@@ -1779,7 +1779,7 @@ Obj FuncREAD_STRING_FILE (
     Obj             fid )
 {
     // check the argument
-    RequireSmallIntMayReplace("READ_STRING_FILE", fid, "fid");
+    RequireSmallInt("READ_STRING_FILE", fid, "fid");
     return SyReadStringFid(INT_INTOBJ(fid));
 }
 
@@ -1789,7 +1789,7 @@ Obj FuncREAD_STRING_FILE (
 */
 Obj FuncFD_OF_FILE(Obj self,Obj fid)
 {
-    RequireSmallIntMayReplace("FD_OF_FILE", fid, "fid");
+    RequireSmallInt("FD_OF_FILE", fid, "fid");
 
     Int fd = INT_INTOBJ(fid);
     Int fdi = SyBufFileno(fd);
@@ -1799,7 +1799,7 @@ Obj FuncFD_OF_FILE(Obj self,Obj fid)
 #ifdef HPCGAP
 Obj FuncRAW_MODE_FILE(Obj self, Obj fid, Obj onoff)
 {
-    RequireSmallIntMayReplace("RAW_MODE_FILE", fid, "fid");
+    RequireSmallInt("RAW_MODE_FILE", fid, "fid");
 
     Int fd = INT_INTOBJ(fid);
     if (onoff == False || onoff == Fail) {
@@ -1944,18 +1944,18 @@ Obj FuncExecuteProcess (
     Int                 i;
 
     // check the argument
-    RequireStringRepMayReplace("ExecuteProcess", dir);
-    RequireStringRepMayReplace("ExecuteProcess", prg);
-    RequireSmallIntMayReplace("ExecuteProcess", in, "in");
-    RequireSmallIntMayReplace("ExecuteProcess", out, "out");
-    RequireSmallListMayReplace("ExecuteProcess", args);
+    RequireStringRep("ExecuteProcess", dir);
+    RequireStringRep("ExecuteProcess", prg);
+    RequireSmallInt("ExecuteProcess", in, "in");
+    RequireSmallInt("ExecuteProcess", out, "out");
+    RequireSmallList("ExecuteProcess", args);
 
     /* create an argument array                                            */
     for ( i = 1;  i <= LEN_LIST(args);  i++ ) {
         if ( i == 1023 )
             break;
         tmp = ELM_LIST( args, i );
-        RequireStringRepMayReplace("ExecuteProcess", tmp);
+        RequireStringRep("ExecuteProcess", tmp);
         ExecArgs[i] = tmp;
     }
     ExecCArgs[0]   = CSTR_STRING(prg);

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -228,7 +228,7 @@ Obj    FuncEmptyString( Obj self, Obj len )
 */
 Obj   FuncShrinkAllocationString( Obj self, Obj str )
 {
-    RequireStringRepMayReplace("ShrinkAllocationString", str);
+    RequireStringRep("ShrinkAllocationString", str);
     SHRINK_STRING(str);
     return (Obj)0;
 }
@@ -245,7 +245,7 @@ Obj FuncCHAR_INT (
 
     /* get and check the integer value                                     */
 again:
-    RequireSmallIntMayReplace("CHAR_INT", val, "val");
+    RequireSmallInt("CHAR_INT", val, "val");
     chr = INT_INTOBJ(val);
     if ( 255 < chr || chr < 0 ) {
         val = ErrorReturnObj(
@@ -291,7 +291,7 @@ Obj FuncCHAR_SINT (
 
   /* get and check the integer value                                     */
 agains:
-  RequireSmallIntMayReplace("CHAR_SINT", val, "val");
+  RequireSmallInt("CHAR_SINT", val, "val");
   chr = INT_INTOBJ(val);
   if ( 127 < chr || chr < -128 ) {
       val = ErrorReturnObj(
@@ -1494,10 +1494,10 @@ Obj FuncPOSITION_SUBSTRING(
   const UInt1  *s, *ss;
 
   /* check whether <string> is a string                                  */
-  RequireStringRepMayReplace("POSITION_SUBSTRING", string);
+  RequireStringRep("POSITION_SUBSTRING", string);
   
   /* check whether <substr> is a string                        */
-  RequireStringRepMayReplace("POSITION_SUBSTRING", substr);
+  RequireStringRep("POSITION_SUBSTRING", substr);
 
   /* check wether <off> is a non-negative integer  */
   while ( ! IS_INTOBJ(off) || (ipos = INT_INTOBJ(off)) < 0 ) {
@@ -1550,7 +1550,7 @@ Obj FuncNormalizeWhitespace (
   Int i, j, len, white;
 
   /* check whether <string> is a string                                  */
-  RequireStringRepMayReplace("NormalizeWhitespace", string);
+  RequireStringRep("NormalizeWhitespace", string);
   
   len = GET_LEN_STRING(string);
   s = CHARS_STRING(string);
@@ -1600,10 +1600,10 @@ Obj FuncREMOVE_CHARACTERS (
   UInt1 REMCHARLIST[256] = {0};
 
   /* check whether <string> is a string                                  */
-  RequireStringRepMayReplace("RemoveCharacters", string);
+  RequireStringRep("RemoveCharacters", string);
   
   /* check whether <rem> is a string                                  */
-  RequireStringRepMayReplace("RemoveCharacters", rem);
+  RequireStringRep("RemoveCharacters", rem);
   
   /* set REMCHARLIST by setting positions of characters in rem to 1 */
   len = GET_LEN_STRING(rem);
@@ -1643,7 +1643,7 @@ Obj FuncTranslateString (
   Int j, len;
 
   /* check whether <string> is a string                                  */
-  RequireStringRepMayReplace("TranslateString", string);
+  RequireStringRep("TranslateString", string);
   
   // check whether <trans> is a string of length at least 256
   while ( ! IsStringConv( trans ) || GET_LEN_STRING( trans ) < 256 ) {
@@ -1693,13 +1693,13 @@ Obj FuncSplitStringInternal (
   UInt1 SPLITSTRINGWSPACE[256] = { 0 };
 
   /* check whether <string> is a string                                  */
-  RequireStringRepMayReplace("SplitString", string);
+  RequireStringRep("SplitString", string);
 
   /* check whether <seps> is a string                                  */
-  RequireStringRepMayReplace("SplitString", seps);
+  RequireStringRep("SplitString", seps);
 
   /* check whether <wspace> is a string                                  */
-  RequireStringRepMayReplace("SplitString", wspace);
+  RequireStringRep("SplitString", wspace);
 
   /* set SPLITSTRINGSEPS by setting positions of characters in rem to 1 */
   len = GET_LEN_STRING(seps);

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -357,7 +357,7 @@ Obj FuncCrcString( Obj self, Obj str ) {
     Int         seen_nl;
 
     // check the argument
-    RequireStringRepMayReplace("CrcString", str);
+    RequireStringRep("CrcString", str);
 
     ptr = CONST_CSTR_STRING(str);
     len = GET_LEN_STRING(str);

--- a/src/vars.c
+++ b/src/vars.c
@@ -1549,7 +1549,7 @@ UInt            ExecAssPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_STAT(stat, 1));
-    RequirePositiveSmallIntMayReplace("PosObj Assignment", pos, "position");
+    RequirePositiveSmallInt("PosObj Assignment", pos, "position");
     p = INT_INTOBJ(pos);
 
     /* evaluate the right hand side                                        */
@@ -1582,7 +1582,7 @@ UInt            ExecUnbPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_STAT(stat, 1));
-    RequirePositiveSmallIntMayReplace("PosObj Assignment", pos, "position");
+    RequirePositiveSmallInt("PosObj Assignment", pos, "position");
     p = INT_INTOBJ(pos);
 
     /* unbind the element                                                  */
@@ -1613,7 +1613,7 @@ Obj             EvalElmPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
-    RequirePositiveSmallIntMayReplace("PosObj Element", pos, "position");
+    RequirePositiveSmallInt("PosObj Element", pos, "position");
     p = INT_INTOBJ( pos );
 
     /* special case for plain lists (use generic code to signal errors)    */
@@ -1644,7 +1644,7 @@ Obj             EvalIsbPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
-    RequirePositiveSmallIntMayReplace("PosObj Element", pos, "position");
+    RequirePositiveSmallInt("PosObj Element", pos, "position");
     p = INT_INTOBJ( pos );
 
     /* get the result                                                      */


### PR DESCRIPTION
This removes the option to return a value from the break loop in many places (in particular, places Max just cleaned up).

This isn't all places, but I thought I'd make this simple pass first, then work through the other cases in further PRs.