### PR TITLE
buildsys: add libgap.la to all: target

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -13,7 +13,7 @@
 ########################################################################
 # Default rule: build gap
 ########################################################################
-all: gap$(EXEEXT) gac
+all: gap$(EXEEXT) gac libgap.la
 .PHONY: all
 
 # Backwards compatibility: add "default" target as alias for "all"


### PR DESCRIPTION
When using projects using libgap.la, I constantly forget to type
`make libgap.la`, and only do `make`, resulting in all kinds of
annoying issues.