### PR TITLE
kernel: add MakeObjInt helper

### DIFF
--- a/src/integer.c
+++ b/src/integer.c
@@ -563,7 +563,7 @@ Obj ObjInt_UInt8( UInt8 i )
 #endif
 }
 
-/**************************************************************************
+/****************************************************************************
 **
 ** Convert GAP Integers to various C types -- see header file
 */
@@ -684,7 +684,7 @@ Obj MakeObjInt(const UInt * limbs, int size)
     else if (size == -1)
         obj = ObjInt_UIntInv(limbs[0]);
     else {
-        UInt tnum = (size > 0 : T_INTPOS : T_INTNEG);
+        UInt tnum = (size > 0 ? T_INTPOS : T_INTNEG);
         if (size < 0) size = -size;
         obj = NewBag(tnum, size * sizeof(mp_limb_t));
         memcpy(ADDR_INT(obj), limbs, size * sizeof(mp_limb_t));

--- a/src/integer.c
+++ b/src/integer.c
@@ -15,7 +15,7 @@
 **  Each integer has a unique representation, e.g., an integer that can be
 **  represented as 'T_INT' is never represented as 'T_INTPOS' or 'T_INTNEG'.
 **
-**  In the following, let 'N' be the number of bits in an mp_limb_t (so 32 or
+**  In the following, let 'N' be the number of bits in an UInt (so 32 or
 **  64, depending on the system). 'T_INT' is the type of those integers small
 **  enough to fit into N-3 bits. Therefore the value range of this small
 **  integers is $-2^{N-4}...2^{N-4}-1$. Only these small integers can be used
@@ -46,7 +46,8 @@
 **
 **  These large integers values are represented as low-level GMP integer
 **  objects, that is, in base 2^N. That means that the bag of a large integer
-**  has the following form:
+**  has the following form, where the "digits" are also more commonly referred
+**  to as "limbs".:
 **
 **      +-------+-------+-------+-------+- - - -+-------+-------+-------+
 **      | digit | digit | digit | digit |       | digit | digit | digit |
@@ -56,7 +57,7 @@
 **  The value of this is: $d0 + d1 2^N + d2 (2^N)^2 + ... + d_n (2^N)^n$,
 **  respectively the negative of this if the object type is 'T_INTNEG'.
 **
-**  Each digit is of course stored as a N bit wide unsigned integer.
+**  Each digit resp. limb is stored as a N bit wide unsigned integer.
 **
 **  Note that we require that all large integers be normalized (that is, they
 **  must not contain leading zero limbs) and reduced (they do not fit into a
@@ -98,6 +99,8 @@
  #endif
 #endif
 
+GAP_STATIC_ASSERT(sizeof(mp_limb_t) == sizeof(UInt),
+                  "sizeof(mp_limb_t) != sizeof(UInt)");
 
 static Obj ObjInt_UIntInv( UInt i );
 
@@ -343,26 +346,7 @@ static Obj GMPorINTOBJ_FAKEMPZ( fake_mpz_t fake )
 */
 static Obj GMPorINTOBJ_MPZ( mpz_t v )
 {
-  Int size = v->_mp_size;
-  Obj obj;
-  if ( size == 0 )
-    obj = INTOBJ_INT(0);
-  else if ( size == 1 )
-    obj = ObjInt_UInt( v->_mp_d[0] );
-  else if ( size == -1 )
-    obj = ObjInt_UIntInv( v->_mp_d[0] );
-  else {
-    Int sign = size > 0 ? 1 : -1;
-    if (size < 0)
-      size = -size;
-    obj = NewBag(sign == 1 ? T_INTPOS : T_INTNEG, size * sizeof(mp_limb_t));
-    memcpy(ADDR_INT(obj), v->_mp_d, size * sizeof(mp_limb_t));
-
-    // FIXME: necessary to normalize and reduce???
-    obj = GMP_NORMALIZE( obj );
-    obj = GMP_REDUCE( obj );
-  }
-  return obj;
+    return MakeObjInt((const UInt *)v->_mp_d, v->_mp_size);
 }
 
 
@@ -683,6 +667,34 @@ UInt8 UInt8_ObjInt(Obj i)
     return (UInt8)vall + ((UInt8)valh << 32);
 #endif
 }
+
+
+/****************************************************************************
+**
+*F  MakeObjInt(<limbs>, <size>) . . . . . . . . . create a new integer object
+**
+*/
+Obj MakeObjInt(const UInt * limbs, int size)
+{
+    Obj obj;
+    if (size == 0)
+        obj = INTOBJ_INT(0);
+    else if (size == 1)
+        obj = ObjInt_UInt(limbs[0]);
+    else if (size == -1)
+        obj = ObjInt_UIntInv(limbs[0]);
+    else {
+        UInt tnum = (size > 0 : T_INTPOS : T_INTNEG);
+        if (size < 0) size = -size;
+        obj = NewBag(tnum, size * sizeof(mp_limb_t));
+        memcpy(ADDR_INT(obj), limbs, size * sizeof(mp_limb_t));
+
+        obj = GMP_NORMALIZE(obj);
+        obj = GMP_REDUCE(obj);
+    }
+    return obj;
+}
+
 
 // This function returns an immediate integer, or
 // an integer object with exactly one limb, and returns

--- a/src/integer.h
+++ b/src/integer.h
@@ -146,7 +146,23 @@ extern UInt UInt_ObjInt(Obj i);
 extern Int8 Int8_ObjInt(Obj i);    
 extern UInt8 UInt8_ObjInt(Obj i);    
 
-    
+
+/****************************************************************************
+**
+*F  MakeObjInt(<limbs>, <size>) . . . . . . . . . create a new integer object
+**
+**  Construct an integer object from the limbs at which <limbs> points. The
+**  absolute value of <size> determines the number of limbs. If <size> is
+**  zero, then `INTOBJ_INT(0)` is returned. Otherwise, the sign of the
+**  returned integer object is determined by the sign of <size>.
+**
+**  Note that GAP automatically reduces and normalized the integer object,
+**  i.e., it will discard any leading zeros; and if the integer fits into a
+**  small integer, it will be returned as such.
+*/
+extern Obj MakeObjInt(const UInt * limbs, int size);
+
+
 /****************************************************************************
 **
 **  Reduce and normalize the given large integer object if necessary.

--- a/src/integer.h
+++ b/src/integer.h
@@ -1,8 +1,8 @@
 /****************************************************************************
 **
 *W  integer.h                   GAP source                     John McDermott
-**                                                           
-**                                                           
+**
+**
 **
 **
 *Y  Copyright (C)  1996,  Lehrstuhl D für Mathematik,  RWTH Aachen,  Germany
@@ -25,7 +25,7 @@
 #endif
 
 
-/**************************************************************************
+/****************************************************************************
 **
 **  'IS_LARGEINT' returns 1 if 'obj' is large positive or negative integer
 **  object, and 0 for all other kinds of objects.
@@ -37,7 +37,7 @@ static inline Int IS_LARGEINT(Obj obj)
 }
 
 
-/**************************************************************************
+/****************************************************************************
 **
 **  'IS_INT' returns 1 if 'obj' is either a large or an immediate integer
 **  object, and 0 for all other kinds of objects.
@@ -48,7 +48,7 @@ static inline Int IS_INT(Obj obj)
 }
 
 
-/**************************************************************************
+/****************************************************************************
 **
 **  'ADDR_INT' returns a pointer to the limbs of the large integer 'obj'.
 **  'CONST_ADDR_INT' does the same, but returns a const pointer.
@@ -66,7 +66,7 @@ static inline const UInt * CONST_ADDR_INT(Obj obj)
 }
 
 
-/**************************************************************************
+/****************************************************************************
 **
 **  'SIZE_INT' returns the number of limbs in a large integer object.
 */
@@ -77,7 +77,7 @@ static inline UInt SIZE_INT(Obj obj)
 }
 
 
-/**************************************************************************
+/****************************************************************************
 **
 **  'IS_NEG_INT' returns 1 if 'obj' is a negative large or immediate
 **  integer object, and 0 for all other kinds of objects.
@@ -89,7 +89,7 @@ static inline Int IS_NEG_INT(Obj obj)
     return TNUM_OBJ(obj) == T_INTNEG;
 }
 
-/**************************************************************************
+/****************************************************************************
 **
 **  'IS_POS_INT' returns 1 if 'obj' is a positive large or immediate
 **  integer object, and 0 for all other kinds of objects.
@@ -101,7 +101,7 @@ static inline Int IS_POS_INT(Obj obj)
     return TNUM_OBJ(obj) == T_INTPOS;
 }
 
-/**************************************************************************
+/****************************************************************************
 **
 **  'IS_ODD_INT' returns 1 if 'obj' is an odd large or immediate integer
 **  object, and 0 for all other kinds of objects.
@@ -114,7 +114,7 @@ static inline Int IS_ODD_INT(Obj obj)
 }
 
 
-/**************************************************************************
+/****************************************************************************
 **
 **  'IS_EVEN_INT' returns 1 if 'obj' is an even large or immediate integer
 **  object, and 0 for all other kinds of objects.
@@ -125,10 +125,10 @@ static inline Int IS_EVEN_INT(Obj obj)
 }
 
 
-/**************************************************************************
+/****************************************************************************
 **
 **  The following functions convert Int, UInt or Int8 respectively into
-**  a GAP integer, either an immediate, small integer if possible or 
+**  a GAP integer, either an immediate, small integer if possible or
 **  otherwise a new GAP bag with TNUM T_INTPOS or T_INTNEG.
 */
 extern Obj ObjInt_Int(Int i);
@@ -136,15 +136,16 @@ extern Obj ObjInt_UInt(UInt i);
 extern Obj ObjInt_Int8(Int8 i);
 extern Obj ObjInt_UInt8(UInt8 i);
 
-/**************************************************************************
+
+/****************************************************************************
 **
 **  The following functions convert a GAP integer into an Int, UInt,
 **  Int8 or UInt8 if it is in range. Otherwise it gives an error.
 */
-extern Int Int_ObjInt(Obj i);    
-extern UInt UInt_ObjInt(Obj i);    
-extern Int8 Int8_ObjInt(Obj i);    
-extern UInt8 UInt8_ObjInt(Obj i);    
+extern Int   Int_ObjInt(Obj i);
+extern UInt  UInt_ObjInt(Obj i);
+extern Int8  Int8_ObjInt(Obj i);
+extern UInt8 UInt8_ObjInt(Obj i);
 
 
 /****************************************************************************
@@ -198,7 +199,7 @@ Obj IntStringInternal(Obj string, const Char *str);
 **
 *F  EqInt( <opL>, <opR> ) . . . . . test if two integers are equal
 **
-**  'EqInt' returns 1  if  the two GMP integer arguments <opL> and  
+**  'EqInt' returns 1  if  the two GMP integer arguments <opL> and
 **  <opR> are equal and 0 otherwise.
 */
 extern Int EqInt( Obj opL, Obj opR );
@@ -208,7 +209,7 @@ extern Int EqInt( Obj opL, Obj opR );
 **
 *F  LtInt( <opL>, <opR> )  test if an integer is less than another
 **
-**  'LtInt' returns 1 if the integer <opL> is strictly less than the 
+**  'LtInt' returns 1 if the integer <opL> is strictly less than the
 **  integer <opR> and 0 otherwise.
 */
 extern Int LtInt( Obj opL, Obj opR );
@@ -345,14 +346,19 @@ extern Obj InverseModInt(Obj base, Obj mod);
 */
 extern Int CLog2Int( Int intnum );
 
-// Compute the binomial coefficient of n and k
+
+/****************************************************************************
+**
+*F  BinomialInt(<n>, <k>) . . . .  return the binomial coefficient of n and k
+**
+*/
 extern Obj BinomialInt(Obj n, Obj k);
+
 
 /****************************************************************************
 **
 *F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
 */
-
 
 /****************************************************************************
 **


### PR DESCRIPTION
This is highly useful for kernel extensions that interface GAP with other systems using bigints (typically GMP `mpz_t`), such as NormalizInterface, SingularInterface, GAPJulia and more.
