### PR TITLE
Remove confusing error message

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -4529,13 +4529,8 @@ InstallMethod( IsGeneratorsOfMagmaWithInverses,
 #F  Group( <gens>, <id> )
 ##
 InstallGlobalFunction( Group, function( arg )
-
-    if Length( arg ) = 1 and IsDomain( arg[1] ) then
-      Error( "no longer supported ..." );
-#T this was possible in GAP-3 ...
-
-    # special case for matrices, because they may look like lists
-    elif Length( arg ) = 1 and IsMatrix( arg[1] )
+    #  special case for matrices, because they may look like lists
+    if Length( arg ) = 1 and IsMatrix( arg[1] )
                            and IsGeneratorsOfMagmaWithInverses( arg ) then
       return GroupByGenerators( arg );
 

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -16,6 +16,12 @@ gap> TrivialGroup(IsPermGroup);
 Group(())
 
 #
+# Creating groups over domains is not supported in GAP4
+#
+gap> Group(Group(()));
+Error, usage: Group(<gen>,...), Group(<gens>), Group(<gens>,<id>)
+
+#
 gap> TrivialGroup(1);
 Error, usage: TrivialGroup( [<filter>] )
 gap> TrivialGroup(IsRing);


### PR DESCRIPTION
When calling `Group()` with a domain as argument, GAP raised the error
"no longer supported ...", which was not helpful (what is no longer supported?).

We just remove this error condition which will lead to a usage message for the
function `Group()` to be printed.