### PR TITLE
Use robust rank for generic SemidirectProduct method; function fields are fields; tweak a LocationFunc test

### DIFF
--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -1080,7 +1080,7 @@ end);
 InstallMethod( SemidirectProduct,"different representations",true, 
     [ IsGroup and IsFinite, IsGroupHomomorphism, IsGroup and IsFinite], 
     # don't be higher than specific perm/pc methods
-    -20,
+    {} -> 2*(RankFilter(IsGroup) - RankFilter(IsGroup and IsFinite)),
 function( G, aut, N )
 local giso,niso,P,gens,a,Go,No,i;
   Go:=G;

--- a/lib/ringpoly.gd
+++ b/lib/ringpoly.gd
@@ -42,7 +42,7 @@ DeclareCategory( "IsPolynomialRing", IsRing );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareCategory("IsFunctionField",IsRing);
+DeclareCategory("IsFunctionField",IsField);
 
 #############################################################################
 ##

--- a/lib/ringpoly.gi
+++ b/lib/ringpoly.gi
@@ -667,11 +667,6 @@ function(r,n)
   type := IsFunctionField and IsAttributeStoringRep and IsLeftModule 
           and IsAlgebraWithOne;
 
-  # If the coefficients form an integral ring, then the function field is also a field
-  if HasIsIntegralRing(r) and IsIntegralRing(r) then
-    type:= type and IsField;
-  fi;
-
   fcfl := Objectify(NewType(CollectionsFamily(rfun),type),rec());;
 
   # The function field is commutative if and only if the coefficient ring is.

--- a/tst/testinstall/opers/LocationFunc.tst
+++ b/tst/testinstall/opers/LocationFunc.tst
@@ -6,8 +6,8 @@ gap> LocationFunc(f);
 "stream:1"
 
 # Library function
-gap> LocationFunc(OnQuit);
-"GAPROOT/lib/error.g:32"
+gap> LocationFunc(Where);
+"GAPROOT/lib/error.g:79"
 
 # GAP function which was compiled to C code by gac
 gap> LocationFunc(INSTALL_METHOD_FLAGS);


### PR DESCRIPTION
This fixes an infinite recursion if the rank of `IsGroup and IsFinite`
becomes very large (e.g. due to many packages are loaded which add
implications from that).

Resolves part of #2818